### PR TITLE
kconfig: remove Enable from boolean prompts

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -221,7 +221,7 @@ config SRAM_OFFSET
 menu "Linker Sections"
 
 config LINKER_USE_BOOT_SECTION
-	bool "Usage of Boot Linker Section"
+	bool "Use Boot Linker Section"
 	help
 	  If enabled, the symbols which are needed for the boot process
 	  will be put into another linker section reserved for these
@@ -231,7 +231,7 @@ config LINKER_USE_BOOT_SECTION
 	  board or custom linker script.
 
 config LINKER_USE_PINNED_SECTION
-	bool "Usage of Pinned Linker Section"
+	bool "Use Pinned Linker Section"
 	help
 	  If enabled, the symbols which need to be pinned in memory
 	  will be put into another linker section reserved for pinned

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -221,7 +221,7 @@ config SRAM_OFFSET
 menu "Linker Sections"
 
 config LINKER_USE_BOOT_SECTION
-	bool "Enable Usage of Boot Linker Section"
+	bool "Usage of Boot Linker Section"
 	help
 	  If enabled, the symbols which are needed for the boot process
 	  will be put into another linker section reserved for these
@@ -231,7 +231,7 @@ config LINKER_USE_BOOT_SECTION
 	  board or custom linker script.
 
 config LINKER_USE_PINNED_SECTION
-	bool "Enable Usage of Pinned Linker Section"
+	bool "Usage of Pinned Linker Section"
 	help
 	  If enabled, the symbols which need to be pinned in memory
 	  will be put into another linker section reserved for pinned
@@ -309,7 +309,7 @@ config NO_OPTIMIZATIONS
 endchoice
 
 config COMPILER_COLOR_DIAGNOSTICS
-	bool "Enable colored diagnostics"
+	bool "Colored diagnostics"
 	default y
 	help
 	  Compiler diagnostic messages are colorized.
@@ -349,7 +349,7 @@ config NO_RUNTIME_CHECKS
 	  Do not do any runtime checks or asserts when using the CHECK macro.
 
 config RUNTIME_ERROR_CHECKS
-	bool "Enable runtime error checks"
+	bool "Runtime error checks"
 	help
 	  Always perform runtime checks covered with the CHECK macro. This
 	  option is the default and the only option used during testing.

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -378,7 +378,7 @@ config NOCACHE_MEMORY
 menu "Interrupt Configuration"
 
 config DYNAMIC_INTERRUPTS
-	bool "Enable installation of IRQs at runtime"
+	bool "Installation of IRQs at runtime"
 	help
 	  Enable installation of interrupts at runtime, which will move some
 	  interrupt-related data structures to RAM instead of ROM, and
@@ -436,7 +436,7 @@ config GEN_IRQ_START_VECTOR
 	  left alone.
 
 config IRQ_OFFLOAD
-	bool "Enable IRQ offload"
+	bool "IRQ offload"
 	depends on TEST
 	help
 	  Enable irq_offload() API which allows functions to be synchronously
@@ -618,7 +618,7 @@ config ARCH_MAPS_ALL_RAM
 	  as reserved) and Z_PAGE_FRAME_MAPPED will not be set.
 
 menuconfig MPU
-	bool "Enable MPU features"
+	bool "MPU features"
 	depends on CPU_HAS_MPU
 	help
 	  This option, when enabled, indicates to the core kernel that an MPU
@@ -699,7 +699,7 @@ config SRAM_REGION_PERMISSIONS
 menu "Floating Point Options"
 
 config FPU
-	bool "Enable floating point unit (FPU)"
+	bool "Floating point unit (FPU)"
 	depends on CPU_HAS_FPU
 	help
 	  This option enables the hardware Floating Point Unit (FPU), in order to
@@ -740,7 +740,7 @@ endmenu
 menu "Cache Options"
 
 config CACHE_MANAGEMENT
-	bool "Enable cache management features"
+	bool "Cache management features"
 	help
 	  This links in the cache management functions (for d-cache and i-cache
 	  where possible).

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -168,7 +168,7 @@ config ARC_FIRQ
 	  from the performance point of view.
 
 config ARC_FIRQ_STACK
-	bool "Enable separate firq stack"
+	bool "Separate firq stack"
 	depends on ARC_FIRQ && RGF_NUM_BANKS > 1
 	help
 	  Use separate stack for FIRQ handing. When the fast irq is also a direct
@@ -220,7 +220,7 @@ config ARC_STACK_PROTECTION
 	  prioritized over the MPU-based stack guard.
 
 config ARC_USE_UNALIGNED_MEM_ACCESS
-	bool "Enable unaligned access in HW"
+	bool "Unaligned access in HW"
 	default y if CPU_ARCHS
 	depends on (CPU_ARCEM && !ARC_HAS_SECURE) || CPU_ARCHS
 	help
@@ -325,7 +325,7 @@ menu "ARC MPU Options"
 depends on CPU_HAS_MPU
 
 config ARC_MPU_ENABLE
-	bool "Enable MPU"
+	bool "MPU"
 	select ARC_MPU
 	help
 	  Enable MPU

--- a/arch/arc/Kconfig
+++ b/arch/arc/Kconfig
@@ -325,7 +325,7 @@ menu "ARC MPU Options"
 depends on CPU_HAS_MPU
 
 config ARC_MPU_ENABLE
-	bool "MPU"
+	bool "Memory Protection Unit (MPU)"
 	select ARC_MPU
 	help
 	  Enable MPU

--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -143,7 +143,7 @@ config RUNTIME_NMI
 	  needed, enable this option and attach it via _NmiHandlerSet().
 
 config PLATFORM_SPECIFIC_INIT
-	bool "Enable platform (SOC) specific startup hook"
+	bool "Platform (SOC) specific startup hook"
 	help
 	  The platform specific initialization code (z_arm_platform_init) is
 	  executed at the beginning of the startup code (__start).

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -280,7 +280,7 @@ config GEN_ISR_TABLES
 	default y
 
 config ZERO_LATENCY_IRQS
-	bool "Enable zero-latency interrupts"
+	bool "Zero-latency interrupts"
 	depends on CPU_CORTEX_M_HAS_BASEPRI
 	help
 	  The kernel may reserve some of the highest interrupts priorities in
@@ -296,7 +296,7 @@ config ZERO_LATENCY_IRQS
 	  kernel functionality.
 
 config DYNAMIC_DIRECT_INTERRUPTS
-	bool "Enable support for dynamic direct interrupts"
+	bool "Support for dynamic direct interrupts"
 	depends on DYNAMIC_INTERRUPTS
 	help
 	  Direct interrupts are designed for performance-critical interrupt
@@ -307,7 +307,7 @@ config DYNAMIC_DIRECT_INTERRUPTS
 	  kernel.
 
 config SW_VECTOR_RELAY
-	bool "Enable Software Vector Relay"
+	bool "Software Vector Relay"
 	help
 	  When building a bootloader firmware this option adds a
 	  vector table relay handler and a vector relay table, to
@@ -316,7 +316,7 @@ config SW_VECTOR_RELAY
 	  with no hardware vector table relocation mechanisms (e.g. VTOR).
 
 config SW_VECTOR_RELAY_CLIENT
-	bool "Enable Software Vector Relay (client)"
+	bool "Software Vector Relay (client)"
 	default y if BOOTLOADER_MCUBOOT && !CPU_CORTEX_M0_HAS_VECTOR_TABLE_REMAP
 	depends on !CPU_CORTEX_M_HAS_VTOR
 	help
@@ -326,7 +326,7 @@ config SW_VECTOR_RELAY_CLIENT
 	  initialization.
 
 config CORTEX_M_DWT
-	bool "Enable and use the DWT"
+	bool "And use the DWT"
 	depends on CPU_CORTEX_M_HAS_DWT
 	default y if TIMING_FUNCTIONS
 	help
@@ -345,7 +345,7 @@ endmenu
 # Trace Unit and the Debug Monitor Exception, or the Memory Protection Unit.
 
 choice NULL_POINTER_EXCEPTION_DETECTION
-	bool "Enable and use null-pointer exception"
+	bool "And use null-pointer exception"
 	# Disable this until https://github.com/zephyrproject-rtos/zephyr/issues/32984 is fixed
 	# default NULL_POINTER_EXCEPTION_DETECTION_DWT if TEST_ARM_CORTEX_M && !ARM_NONSECURE_FIRMWARE && CPU_CORTEX_M_HAS_DWT
 	default NULL_POINTER_EXCEPTION_DETECTION_MPU if TEST_ARM_CORTEX_M && !ARM_NONSECURE_FIRMWARE && ARM_MPU && !CPU_CORTEX_M_HAS_DWT

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -326,7 +326,7 @@ config SW_VECTOR_RELAY_CLIENT
 	  initialization.
 
 config CORTEX_M_DWT
-	bool "And use the DWT"
+	bool "Data Watchpoint and Trace (DWT)"
 	depends on CPU_CORTEX_M_HAS_DWT
 	default y if TIMING_FUNCTIONS
 	help
@@ -345,7 +345,7 @@ endmenu
 # Trace Unit and the Debug Monitor Exception, or the Memory Protection Unit.
 
 choice NULL_POINTER_EXCEPTION_DETECTION
-	bool "And use null-pointer exception"
+	bool "Null-pointer exception"
 	# Disable this until https://github.com/zephyrproject-rtos/zephyr/issues/32984 is fixed
 	# default NULL_POINTER_EXCEPTION_DETECTION_DWT if TEST_ARM_CORTEX_M && !ARM_NONSECURE_FIRMWARE && CPU_CORTEX_M_HAS_DWT
 	default NULL_POINTER_EXCEPTION_DETECTION_MPU if TEST_ARM_CORTEX_M && !ARM_NONSECURE_FIRMWARE && ARM_MPU && !CPU_CORTEX_M_HAS_DWT
@@ -358,7 +358,7 @@ choice NULL_POINTER_EXCEPTION_DETECTION
 	  is enabled and the DWT-based solution is preferred.
 
 config NULL_POINTER_EXCEPTION_DETECTION_NONE
-	bool "Do not enable null pointer exception detection"
+	bool "No null pointer exception detection"
 	help
 	  Null pointer exception detection feature is not
 	  enabled.

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -14,14 +14,14 @@ config COMPRESSED_ISA
 	default y if 64BIT
 
 config FLOAT_HARD
-	bool "Enable hard-float calling convention"
+	bool "Hard-float calling convention"
 	default y
 	depends on FPU
 	help
 	  This option enables the hard-float calling convention.
 
 config RISCV_GP
-	bool "Enable RISC-V global pointer relative addressing"
+	bool "RISC-V global pointer relative addressing"
 	default n
 	help
 	  Use global pointer relative addressing for small globals declared
@@ -50,7 +50,7 @@ config INCLUDE_RESET_VECTOR
 	  prepares for running C code.
 
 config RISCV_SOC_CONTEXT_SAVE
-	bool "Enable SOC-based context saving in IRQ handlers"
+	bool "SOC-based context saving in IRQ handlers"
 	select RISCV_SOC_OFFSETS
 	help
 	  Enable low-level SOC-specific context management, for SOCs
@@ -85,7 +85,7 @@ config RISCV_SOC_CONTEXT_SAVE
 	  pointer address is in a0, and ra contains the return address.
 
 config RISCV_SOC_OFFSETS
-	bool "Enable SOC-based offsets"
+	bool "SOC-based offsets"
 	help
 	  Enabling this option requires that the SoC provide a soc_offsets.h
 	  header which defines the following macros:
@@ -97,7 +97,7 @@ config RISCV_SOC_OFFSETS
 	    See gen_offset.h for more details.
 
 config RISCV_SOC_INTERRUPT_INIT
-	bool "Enable SOC-based interrupt initialization"
+	bool "SOC-based interrupt initialization"
 	help
 	  Enable SOC-based interrupt initialization
 	  (call soc_interrupt_init, within _IntLibInit when enabled)

--- a/arch/riscv/core/pmp/Kconfig
+++ b/arch/riscv/core/pmp/Kconfig
@@ -11,7 +11,7 @@ config PMP_SLOT
 	  than the Hardware allow you.
 
 config PMP_POWER_OF_TWO_ALIGNMENT
-	bool "Enable power of two alignment"
+	bool "Power of two alignment"
 	default n
 	select MPU_REQUIRES_POWER_OF_TWO_ALIGNMENT
 	select GEN_PRIV_STACKS

--- a/arch/x86/Kconfig
+++ b/arch/x86/Kconfig
@@ -101,56 +101,56 @@ config X86_CPU_HAS_SSE4A
 if FPU || X86_64
 
 config X86_MMX
-	bool "Enable MMX Support"
+	bool "MMX Support"
 	depends on X86_CPU_HAS_MMX
 	help
 	  This option enables MMX support, and the use of MMX registers
 	  by threads.
 
 config X86_SSE
-	bool "Enable SSE Support"
+	bool "SSE Support"
 	depends on X86_CPU_HAS_SSE
 	help
 	  This option enables SSE support, and the use of SSE registers
 	  by threads.
 
 config X86_SSE2
-	bool "Enable SSE2 Support"
+	bool "SSE2 Support"
 	depends on X86_CPU_HAS_SSE2
 	select X86_SSE
 	help
 	  This option enables SSE2 support.
 
 config X86_SSE3
-	bool "Enable SSE3 Support"
+	bool "SSE3 Support"
 	depends on X86_CPU_HAS_SSE3
 	select X86_SSE
 	help
 	  This option enables SSE3 support.
 
 config X86_SSSE3
-	bool "Enable SSSE3 (Supplemental SSE3) Support"
+	bool "SSSE3 (Supplemental SSE3) Support"
 	depends on X86_CPU_HAS_SSSE3
 	select X86_SSE
 	help
 	  This option enables Supplemental SSE3 support.
 
 config X86_SSE41
-	bool "Enable SSE4.1 Support"
+	bool "SSE4.1 Support"
 	depends on X86_CPU_HAS_SSE41
 	select X86_SSE
 	help
 	  This option enables SSE4.1 support.
 
 config X86_SSE42
-	bool "Enable SSE4.2 Support"
+	bool "SSE4.2 Support"
 	depends on X86_CPU_HAS_SSE42
 	select X86_SSE
 	help
 	  This option enables SSE4.2 support.
 
 config X86_SSE4A
-	bool "Enable SSE4A Support"
+	bool "SSE4A Support"
 	depends on X86_CPU_HAS_SSE4A
 	select X86_SSE
 	help
@@ -336,7 +336,7 @@ config X86_VERY_EARLY_CONSOLE
 	  tree. This mini-driver assumes I/O to the UART is done via ports.
 
 config X86_MMU
-	bool "Enable Memory Management Unit"
+	bool "Memory Management Unit"
 	select MMU
 	help
 	  This options enables the memory management unit present in x86
@@ -450,7 +450,7 @@ config DISABLE_SSBD
 	  require this feature.
 
 config ENABLE_EXTENDED_IBRS
-	bool "Enable Extended IBRS"
+	bool "Extended IBRS"
 	depends on USERSPACE
 	default y if !X86_NO_SPECTRE_V2
 	help
@@ -469,7 +469,7 @@ config X86_BOUNDS_CHECK_BYPASS_MITIGATION
 	  to be immune to it.
 
 config X86_KPTI
-	bool "Enable kernel page table isolation"
+	bool "Kernel page table isolation"
 	default y
 	depends on USERSPACE
 	depends on !X86_NO_MELTDOWN

--- a/arch/x86/core/Kconfig.ia32
+++ b/arch/x86/core/Kconfig.ia32
@@ -6,7 +6,7 @@
 if !X86_64
 
 config NESTED_INTERRUPTS
-	bool "Enable nested interrupts"
+	bool "Nested interrupts"
 	default y
 	help
 	  This option enables support for nested interrupts.

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -44,7 +44,7 @@ config XTENSA_USE_CORE_CRT1
 	  to false.
 
 config XTENSA_ENABLE_BACKTRACE
-	bool "Enable backtrace on panic exception"
+	bool "Backtrace on panic exception"
 	default y
 	depends on SOC_ESP32
 	help
@@ -56,14 +56,14 @@ config XTENSA_CPU_IDLE_SPIN
 	  Use a spin loop instead of WAITI for the CPU idle state.
 
 config XTENSA_WAITI_BUG
-	bool "Enable workaround sequence for WAITI bug on LX6"
+	bool "Workaround sequence for WAITI bug on LX6"
 	help
 	  SOF traditionally contains this workaround on its ADSP
 	  platforms which prefixes a WAITI entry with 128 NOP
 	  instructions followed by an ISYNC and EXTW.
 
 config XTENSA_SMALL_VECTOR_TABLE_ENTRY
-	bool "Enable workaround for small vector table entries"
+	bool "Workaround for small vector table entries"
 	help
 	  This option enables a small indirection to bypass the size
 	  constraint of the vector table entry and moved the default

--- a/boards/arm/adafruit_feather_nrf52840/Kconfig
+++ b/boards/arm/adafruit_feather_nrf52840/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_ADAFRUIT_FEATHER_NRF52840

--- a/boards/arm/bl5340_dvk/Kconfig
+++ b/boards/arm/bl5340_dvk/Kconfig
@@ -46,17 +46,17 @@ endif # RPMSG_SERVICE_DUAL_IPM_SUPPORT
 if BOARD_BL5340_DVK_CPUAPP || BOARD_BL5340_DVK_CPUAPP_NS
 
 config BOARD_ENABLE_DCDC_APP
-	bool "Enable Application MCU DCDC converter"
+	bool "Application MCU DCDC converter"
 	select SOC_DCDC_NRF53X_APP
 	default y
 
 config BOARD_ENABLE_DCDC_NET
-	bool "Enable Network MCU DCDC converter"
+	bool "Network MCU DCDC converter"
 	select SOC_DCDC_NRF53X_NET
 	default y
 
 config BOARD_ENABLE_DCDC_HV
-	bool "Enable High Voltage DCDC converter"
+	bool "High Voltage DCDC converter"
 	select SOC_DCDC_NRF53X_HV
 	default y
 
@@ -71,7 +71,7 @@ config BT_HCI_VS
 	default y if BT
 
 config BOARD_ENABLE_CPUNET
-	bool "Enable nRF53 Network MCU"
+	bool "NRF53 Network MCU"
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/boards/arm/bl652_dvk/Kconfig
+++ b/boards/arm/bl652_dvk/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BL652_DVK

--- a/boards/arm/bl653_dvk/Kconfig
+++ b/boards/arm/bl653_dvk/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BL653_DVK

--- a/boards/arm/bl654_dvk/Kconfig
+++ b/boards/arm/bl654_dvk/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BL654_DVK

--- a/boards/arm/bl654_sensor_board/Kconfig
+++ b/boards/arm/bl654_sensor_board/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BL654_SENSOR_BOARD

--- a/boards/arm/bl654_usb/Kconfig
+++ b/boards/arm/bl654_usb/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BL654_USB

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/Kconfig
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BLUECLOVER_PLT_DEMO_V2_NRF52832

--- a/boards/arm/bt510/Kconfig
+++ b/boards/arm/bt510/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BT510

--- a/boards/arm/bt610/Kconfig
+++ b/boards/arm/bt610/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_BT610

--- a/boards/arm/contextualelectronics_abc/Kconfig
+++ b/boards/arm/contextualelectronics_abc/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_CONTEXTELEC_ABC

--- a/boards/arm/decawave_dwm1001_dev/Kconfig
+++ b/boards/arm/decawave_dwm1001_dev/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_DECAWAVE_DWM1001_DEV

--- a/boards/arm/degu_evk/Kconfig
+++ b/boards/arm/degu_evk/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_DEGU_EVK

--- a/boards/arm/hexiwear_k64/Kconfig
+++ b/boards/arm/hexiwear_k64/Kconfig
@@ -4,5 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BATTERY_SENSE
-	bool "Enable the battery sense circuit"
+	bool "The battery sense circuit"
 	depends on BOARD_HEXIWEAR_K64

--- a/boards/arm/nrf21540dk_nrf52840/Kconfig
+++ b/boards/arm/nrf21540dk_nrf52840/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF21540DK_NRF52840

--- a/boards/arm/nrf52832_mdk/Kconfig
+++ b/boards/arm/nrf52832_mdk/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52832_MDK

--- a/boards/arm/nrf52833dk_nrf52820/Kconfig
+++ b/boards/arm/nrf52833dk_nrf52820/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52833DK_NRF52820

--- a/boards/arm/nrf52833dk_nrf52833/Kconfig
+++ b/boards/arm/nrf52833dk_nrf52833/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52833DK_NRF52833

--- a/boards/arm/nrf52840_blip/Kconfig
+++ b/boards/arm/nrf52840_blip/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52840_BLIP

--- a/boards/arm/nrf52840_mdk/Kconfig
+++ b/boards/arm/nrf52840_mdk/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52840_MDK

--- a/boards/arm/nrf52840_papyr/Kconfig
+++ b/boards/arm/nrf52840_papyr/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52840_PAPYR

--- a/boards/arm/nrf52840dk_nrf52811/Kconfig
+++ b/boards/arm/nrf52840dk_nrf52811/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52840DK_NRF52811

--- a/boards/arm/nrf52840dk_nrf52840/Kconfig
+++ b/boards/arm/nrf52840dk_nrf52840/Kconfig
@@ -6,12 +6,12 @@
 if BOARD_NRF52840DK_NRF52840
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 
 config BOARD_ENABLE_DCDC_HV
-	bool "Enable High Voltage DCDC converter"
+	bool "High Voltage DCDC converter"
 	select SOC_DCDC_NRF52X_HV
 	default y
 

--- a/boards/arm/nrf52840dongle_nrf52840/Kconfig
+++ b/boards/arm/nrf52840dongle_nrf52840/Kconfig
@@ -6,12 +6,12 @@
 if BOARD_NRF52840DONGLE_NRF52840
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 
 config BOARD_ENABLE_DCDC_HV
-	bool "Enable High Voltage DCDC converter"
+	bool "High Voltage DCDC converter"
 	select SOC_DCDC_NRF52X_HV
 	default y
 

--- a/boards/arm/nrf52_adafruit_feather/Kconfig
+++ b/boards/arm/nrf52_adafruit_feather/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52_ADAFRUIT_FEATHER

--- a/boards/arm/nrf52dk_nrf52805/Kconfig
+++ b/boards/arm/nrf52dk_nrf52805/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52DK_NRF52805

--- a/boards/arm/nrf52dk_nrf52810/Kconfig
+++ b/boards/arm/nrf52dk_nrf52810/Kconfig
@@ -6,7 +6,7 @@
 if BOARD_NRF52DK_NRF52810
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 

--- a/boards/arm/nrf52dk_nrf52832/Kconfig
+++ b/boards/arm/nrf52dk_nrf52832/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_NRF52DK_NRF52832

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig
@@ -45,17 +45,17 @@ endif # RPMSG_SERVICE_DUAL_IPM_SUPPORT
 if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
 config BOARD_ENABLE_DCDC_APP
-	bool "Enable Application MCU DCDC converter"
+	bool "Application MCU DCDC converter"
 	select SOC_DCDC_NRF53X_APP
 	default y
 
 config BOARD_ENABLE_DCDC_NET
-	bool "Enable Network MCU DCDC converter"
+	bool "Network MCU DCDC converter"
 	select SOC_DCDC_NRF53X_NET
 	default y
 
 config BOARD_ENABLE_DCDC_HV
-	bool "Enable High Voltage DCDC converter"
+	bool "High Voltage DCDC converter"
 	select SOC_DCDC_NRF53X_HV
 	default y
 
@@ -70,7 +70,7 @@ config BT_HCI_VS
 	default y if BT
 
 config BOARD_ENABLE_CPUNET
-	bool "Enable nRF53 Network MCU"
+	bool "NRF53 Network MCU"
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/boards/arm/nrf9160dk_nrf52840/Kconfig
+++ b/boards/arm/nrf9160dk_nrf52840/Kconfig
@@ -6,7 +6,7 @@
 if BOARD_NRF9160DK_NRF52840
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 

--- a/boards/arm/particle_argon/Kconfig
+++ b/boards/arm/particle_argon/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_PARTICLE_ARGON

--- a/boards/arm/particle_boron/Kconfig
+++ b/boards/arm/particle_boron/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_PARTICLE_BORON

--- a/boards/arm/particle_xenon/Kconfig
+++ b/boards/arm/particle_xenon/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_PARTICLE_XENON

--- a/boards/arm/pinnacle_100_dvk/Kconfig
+++ b/boards/arm/pinnacle_100_dvk/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_PINNACLE_100_DVK

--- a/boards/arm/reel_board/Kconfig
+++ b/boards/arm/reel_board/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_REEL_BOARD || BOARD_REEL_BOARD_V2

--- a/boards/arm/ruuvi_ruuvitag/Kconfig
+++ b/boards/arm/ruuvi_ruuvitag/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_RUUVI_RUUVITAG

--- a/boards/arm/thingy53_nrf5340/Kconfig
+++ b/boards/arm/thingy53_nrf5340/Kconfig
@@ -51,22 +51,22 @@ endif # RPMSG_SERVICE_DUAL_IPM_SUPPORT
 if BOARD_THINGY53_NRF5340_CPUAPP || BOARD_THINGY53_NRF5340_CPUAPP_NS
 
 config BOARD_ENABLE_DCDC_APP
-	bool "Enable Application MCU DCDC converter"
+	bool "Application MCU DCDC converter"
 	select SOC_DCDC_NRF53X_APP
 	default y
 
 config BOARD_ENABLE_DCDC_NET
-	bool "Enable Network MCU DCDC converter"
+	bool "Network MCU DCDC converter"
 	select SOC_DCDC_NRF53X_NET
 	default y
 
 config BOARD_ENABLE_DCDC_HV
-	bool "Enable High Voltage DCDC converter"
+	bool "High Voltage DCDC converter"
 	select SOC_DCDC_NRF53X_HV
 	default y
 
 config BOARD_ENABLE_CPUNET
-	bool "Enable nRF53 Network MCU"
+	bool "NRF53 Network MCU"
 	help
 	  This option enables releasing the Network 'force off' signal, which
 	  as a consequence will power up the Network MCU during system boot.

--- a/boards/arm/twr_ke18f/Kconfig
+++ b/boards/arm/twr_ke18f/Kconfig
@@ -6,7 +6,7 @@
 if BOARD_TWR_KE18F
 
 config BOARD_TWR_KE18F_FLEXIO_CLKOUT
-	bool "Enable CLKOUT signal on FlexIO header"
+	bool "CLKOUT signal on FlexIO header"
 	help
 	  Enable the CLKOUT signal on FlexIO header pin 7 (PTE10).
 

--- a/boards/arm/ubx_bmd300eval_nrf52832/Kconfig
+++ b/boards/arm/ubx_bmd300eval_nrf52832/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_BMD300EVAL_NRF52832

--- a/boards/arm/ubx_bmd330eval_nrf52810/Kconfig
+++ b/boards/arm/ubx_bmd330eval_nrf52810/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_BMD330EVAL_NRF52810

--- a/boards/arm/ubx_bmd340eval_nrf52840/Kconfig
+++ b/boards/arm/ubx_bmd340eval_nrf52840/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_BMD340EVAL_NRF52840

--- a/boards/arm/ubx_bmd360eval_nrf52811/Kconfig
+++ b/boards/arm/ubx_bmd360eval_nrf52811/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_BMD360EVAL_NRF52811

--- a/boards/arm/ubx_bmd380eval_nrf52840/Kconfig
+++ b/boards/arm/ubx_bmd380eval_nrf52840/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-bool "Enable DCDC mode"
+bool "DCDC mode"
 select SOC_DCDC_NRF52X
 default y
 depends on BOARD_UBX_BMD380EVAL_NRF52840

--- a/boards/arm/ubx_evkannab1_nrf52832/Kconfig
+++ b/boards/arm/ubx_evkannab1_nrf52832/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_EVKANNAB1_NRF52832

--- a/boards/arm/ubx_evkninab1_nrf52832/Kconfig
+++ b/boards/arm/ubx_evkninab1_nrf52832/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_EVKNINAB1_NRF52832

--- a/boards/arm/ubx_evkninab3_nrf52840/Kconfig
+++ b/boards/arm/ubx_evkninab3_nrf52840/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_EVKNINAB3_NRF52840

--- a/boards/arm/ubx_evkninab4_nrf52833/Kconfig
+++ b/boards/arm/ubx_evkninab4_nrf52833/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD_ENABLE_DCDC
-	bool "Enable DCDC mode"
+	bool "DCDC mode"
 	select SOC_DCDC_NRF52X
 	default y
 	depends on BOARD_UBX_EVKNINAB4_NRF52833

--- a/drivers/adc/Kconfig
+++ b/drivers/adc/Kconfig
@@ -16,7 +16,7 @@ menuconfig ADC
 if ADC
 
 config ADC_SHELL
-	bool "Enable ADC Shell"
+	bool "ADC Shell"
 	default y
 	depends on SHELL
 	help
@@ -29,7 +29,7 @@ config ADC_CONFIGURABLE_INPUTS
 	bool
 
 config ADC_ASYNC
-	bool "Enable asynchronous call support"
+	bool "Asynchronous call support"
 	select POLL
 	help
 	  This option enables the asynchronous API calls.

--- a/drivers/adc/Kconfig.lmp90xxx
+++ b/drivers/adc/Kconfig.lmp90xxx
@@ -36,7 +36,7 @@ config ADC_LMP90XXX_CRC
 	  the data read from the LMP90xxx.
 
 config ADC_LMP90XXX_GPIO
-	bool "Enable GPIO support"
+	bool "GPIO support"
 	depends on GPIO
 	select GPIO_LMP90XXX
 	help

--- a/drivers/adc/Kconfig.mcux
+++ b/drivers/adc/Kconfig.mcux
@@ -60,7 +60,7 @@ config ADC_MCUX_ADC16_VREF_ALTERNATE
 endchoice
 
 config ADC_MCUX_ADC16_ENABLE_EDMA
-	bool "Enable EDMA for adc driver"
+	bool "EDMA for adc driver"
 	depends on HAS_MCUX_ADC16 && HAS_MCUX_EDMA
 	help
 	  Enable the MCUX ADC16 driver.

--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -94,13 +94,13 @@ config BT_SPI_INIT_PRIORITY
 	default 75
 
 config BT_BLUENRG_ACI
-	bool "Enable ACI message with with BlueNRG-based devices"
+	bool "ACI message with with BlueNRG-based devices"
 	help
 	  Enable support for devices compatible with the BlueNRG Bluetooth
 	  Stack. Current driver supports: ST BLUENRG-MS.
 
 config BT_SPI_BLUENRG
-	bool "Enable compatibility with BlueNRG-based devices"
+	bool "Compatibility with BlueNRG-based devices"
 	help
 	  Enable support for devices compatible with the BlueNRG Bluetooth
 	  Stack. Current driver supports: ST BLUENRG-MS.

--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -24,7 +24,7 @@ config CAN_INIT_PRIORITY
 	  CAN driver device initialization priority.
 
 config CAN_SHELL
-	bool "Enable CAN Shell"
+	bool "CAN Shell"
 	default y
 	depends on SHELL
 	select POLL
@@ -32,7 +32,7 @@ config CAN_SHELL
 	  Enable CAN Shell for testing.
 
 config CAN_STATS
-	bool "Enable CAN controller device statistics"
+	bool "CAN controller device statistics"
 	depends on STATS
 	help
 	  Enable CAN controller device statistics.
@@ -76,7 +76,7 @@ config CAN_INIT_PRIORITY
 	  so that it can start before the networking sub-system.
 
 config CAN_RX_TIMESTAMP
-	bool "Enable receiving timestamps"
+	bool "Receiving timestamps"
 	depends on CAN_HAS_RX_TIMESTAMP
 	help
 	  This option enables a timestamp value of the CAN free running timer.
@@ -84,7 +84,7 @@ config CAN_RX_TIMESTAMP
 	  is initialized.
 
 config CAN_AUTO_BUS_OFF_RECOVERY
-	bool "Enable automatic recovery from bus-off"
+	bool "Automatic recovery from bus-off"
 	default y
 	help
 	  This option enables the automatic bus-off recovery according to

--- a/drivers/can/Kconfig.mcan
+++ b/drivers/can/Kconfig.mcan
@@ -16,7 +16,7 @@ config CAN_MCAN
 if CAN_MCAN
 
 config CAN_DELAY_COMP
-	bool "Enable transceiver delay compensation"
+	bool "Transceiver delay compensation"
 	default y
 	help
 	  Enable the automatic transceiver delay compensation.

--- a/drivers/can/Kconfig.net
+++ b/drivers/can/Kconfig.net
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config CAN_NET
-	bool "Enable 6loCAN network interface [EXPERIMENTAL]"
+	bool "6loCAN network interface [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Enable IPv6 Networking over can (6loCAN)

--- a/drivers/clock_control/Kconfig.beetle
+++ b/drivers/clock_control/Kconfig.beetle
@@ -21,7 +21,7 @@ config ARM_CLOCK_CONTROL_DEV_NAME
 	  Configure Clock Config Device name
 
 config CLOCK_CONTROL_BEETLE_ENABLE_PLL
-	bool "Enable PLL on Beetle"
+	bool "PLL on Beetle"
 	depends on SOC_SERIES_BEETLE
 	help
 	  Enable PLL on Beetle.

--- a/drivers/clock_control/Kconfig.lpc11u6x
+++ b/drivers/clock_control/Kconfig.lpc11u6x
@@ -13,12 +13,12 @@ menuconfig CLOCK_CONTROL_LPC11U6X
 if CLOCK_CONTROL_LPC11U6X
 
 config CLOCK_CONTROL_LPC11U6X_ENABLE_SRAM1
-	bool "Enable SRAM1"
+	bool "SRAM1"
 	help
 	  Enable SRAM1
 
 config CLOCK_CONTROL_LPC11U6X_ENABLE_USB_RAM
-	bool "Enable USB RAM"
+	bool "USB RAM"
 	help
 	  Enable USB RAM
 

--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -55,7 +55,7 @@ config CLOCK_CONTROL_NRF_K32SRC_EXT_FULL_SWING
 endchoice
 
 config CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
-	bool "Enable LF clock calibration"
+	bool "LF clock calibration"
 	depends on !SOC_SERIES_NRF91X && CLOCK_CONTROL_NRF_K32SRC_RC
 	default y
 	help

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -25,7 +25,7 @@ config CONSOLE_HAS_DRIVER
 	  that some kind of console exists.
 
 config CONSOLE_HANDLER
-	bool "Enable console input handler"
+	bool "Console input handler"
 	depends on UART_CONSOLE && SERIAL_SUPPORT_INTERRUPT
 	select UART_INTERRUPT_DRIVEN
 	help
@@ -58,7 +58,7 @@ config UART_CONSOLE_DEBUG_SERVER_HOOKS
 	  code handle them if they are of no special significance to it.
 
 config UART_CONSOLE_MCUMGR
-	bool "Enable UART console mcumgr passthrough"
+	bool "UART console mcumgr passthrough"
 	depends on UART_CONSOLE
 	help
 	  Enables the UART console to receive mcumgr frames for image upgrade
@@ -67,7 +67,7 @@ config UART_CONSOLE_MCUMGR
 	  (e.g., the shell).  If unset, incoming mcumgr frames are dropped.
 
 config UART_CONSOLE_INPUT_EXPIRED
-	bool "Enable support for UART console input expired mechanism"
+	bool "Support for UART console input expired mechanism"
 	default y
 	depends on UART_CONSOLE && PM
 	help
@@ -190,7 +190,7 @@ config IPM_CONSOLE_LINE_BUF_LEN
 	  where characters are stored before sending the whole line.
 
 config UART_PIPE
-	bool "Enable pipe UART driver"
+	bool "Pipe UART driver"
 	select UART_INTERRUPT_DRIVEN
 	help
 	  Enable pipe UART driver. This driver allows application to communicate
@@ -211,7 +211,7 @@ config UART_PIPE_ON_DEV_NAME
 	  for pipe UART.
 
 config UART_MCUMGR
-	bool "Enable mcumgr UART driver"
+	bool "Mcumgr UART driver"
 	select UART_INTERRUPT_DRIVEN
 	help
 	  Enable the mcumgr UART driver. This driver allows the application to
@@ -307,7 +307,7 @@ source "subsys/logging/Kconfig.template.log_config"
 source "drivers/console/Kconfig.gsm_mux"
 
 config UART_MUX
-	bool "Enable UART muxing (GSM 07.10) support [EXPERIMENTAL]"
+	bool "UART muxing (GSM 07.10) support [EXPERIMENTAL]"
 	depends on SERIAL_SUPPORT_INTERRUPT && GSM_MUX
 	select UART_INTERRUPT_DRIVEN
 	select EXPERIMENTAL

--- a/drivers/console/Kconfig.gsm_mux
+++ b/drivers/console/Kconfig.gsm_mux
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config GSM_MUX
-	bool "Enable GSM 07.10 muxing protocol"
+	bool "GSM 07.10 muxing protocol"
 	help
 	  Enable GSM 07.10 muxing protocol defined in
 	  https://www.etsi.org/deliver/etsi_ts/101300_101399/101369/07.01.00_60/ts_101369v070100p.pdf

--- a/drivers/counter/Kconfig.native_posix
+++ b/drivers/counter/Kconfig.native_posix
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config COUNTER_NATIVE_POSIX
-    bool "Counter on COUNTER_0"
-    default y
-    depends on BOARD_NATIVE_POSIX
+	bool "Counter on COUNTER_0"
+	default y
+	depends on BOARD_NATIVE_POSIX
 
 config COUNTER_NATIVE_POSIX_FREQUENCY
-    int "native_posix counter frequency in Hz"
-    default 1000
-    depends on COUNTER_NATIVE_POSIX
+	int "native_posix counter frequency in Hz"
+	default 1000
+	depends on COUNTER_NATIVE_POSIX

--- a/drivers/counter/Kconfig.native_posix
+++ b/drivers/counter/Kconfig.native_posix
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config COUNTER_NATIVE_POSIX
-    bool "Enable counter on COUNTER_0"
+    bool "Counter on COUNTER_0"
     default y
     depends on BOARD_NATIVE_POSIX
 

--- a/drivers/counter/Kconfig.nrfx
+++ b/drivers/counter/Kconfig.nrfx
@@ -8,7 +8,7 @@ config COUNTER_NRF_RTC
 	bool
 
 config COUNTER_TIMER0
-	bool "Enable Counter on TIMER0"
+	bool "Counter on TIMER0"
 	depends on HAS_HW_NRF_TIMER0
 	depends on !NRF_HW_TIMER0_RESERVED
 	select COUNTER_NRF_TIMER
@@ -19,7 +19,7 @@ config COUNTER_TIMER0_ZLI
 	depends on ZERO_LATENCY_IRQS
 
 config COUNTER_TIMER1
-	bool "Enable Counter on TIMER1"
+	bool "Counter on TIMER1"
 	depends on HAS_HW_NRF_TIMER1
 	depends on !NRF_HW_TIMER1_RESERVED
 	select COUNTER_NRF_TIMER
@@ -30,7 +30,7 @@ config COUNTER_TIMER1_ZLI
 	depends on ZERO_LATENCY_IRQS
 
 config COUNTER_TIMER2
-	bool "Enable Counter on TIMER2"
+	bool "Counter on TIMER2"
 	depends on HAS_HW_NRF_TIMER2
 	depends on !NRF_HW_TIMER2_RESERVED
 	select COUNTER_NRF_TIMER
@@ -41,7 +41,7 @@ config COUNTER_TIMER2_ZLI
 	depends on ZERO_LATENCY_IRQS
 
 config COUNTER_TIMER3
-	bool "Enable Counter on TIMER3"
+	bool "Counter on TIMER3"
 	depends on HAS_HW_NRF_TIMER3
 	depends on !NRF_HW_TIMER3_RESERVED
 	select COUNTER_NRF_TIMER
@@ -52,7 +52,7 @@ config COUNTER_TIMER3_ZLI
 	depends on ZERO_LATENCY_IRQS
 
 config COUNTER_TIMER4
-	bool "Enable Counter on TIMER4"
+	bool "Counter on TIMER4"
 	depends on HAS_HW_NRF_TIMER4
 	depends on !NRF_HW_TIMER4_RESERVED
 	select COUNTER_NRF_TIMER
@@ -63,7 +63,7 @@ config COUNTER_TIMER4_ZLI
 	depends on ZERO_LATENCY_IRQS
 
 config COUNTER_RTC0
-	bool "Enable Counter on RTC0"
+	bool "Counter on RTC0"
 	depends on HAS_HW_NRF_RTC0
 	depends on !NRF_HW_RTC0_RESERVED
 	select COUNTER_NRF_RTC
@@ -74,7 +74,7 @@ config COUNTER_RTC0_ZLI
 	depends on ZERO_LATENCY_IRQS
 
 config COUNTER_RTC1
-	bool "Enable Counter on RTC1"
+	bool "Counter on RTC1"
 	depends on HAS_HW_NRF_RTC1
 	depends on !NRF_HW_RTC1_RESERVED
 	select COUNTER_NRF_RTC
@@ -85,7 +85,7 @@ config COUNTER_RTC1_ZLI
 	depends on ZERO_LATENCY_IRQS
 
 config COUNTER_RTC2
-	bool "Enable Counter on RTC2"
+	bool "Counter on RTC2"
 	depends on HAS_HW_NRF_RTC2
 	depends on !NRF_HW_RTC2_RESERVED
 	select COUNTER_NRF_RTC

--- a/drivers/crypto/Kconfig
+++ b/drivers/crypto/Kconfig
@@ -22,7 +22,7 @@ module-str = CRYPTO
 source "subsys/logging/Kconfig.template.log_config"
 
 config CRYPTO_TINYCRYPT_SHIM
-	bool "Enable TinyCrypt shim driver [EXPERIMENTAL]"
+	bool "TinyCrypt shim driver [EXPERIMENTAL]"
 	select TINYCRYPT
 	select TINYCRYPT_AES
 	select TINYCRYPT_AES_CBC
@@ -49,7 +49,7 @@ config CRYPTO_TINYCRYPT_SHIM_DRV_NAME
 	  Device name for TinyCrypt Pseudo device.
 
 config CRYPTO_MBEDTLS_SHIM
-	bool "Enable mbedTLS shim driver [EXPERIMENTAL]"
+	bool "MbedTLS shim driver [EXPERIMENTAL]"
 	select MBEDTLS
 	select MBEDTLS_ENABLE_HEAP
 	select EXPERIMENTAL

--- a/drivers/dac/Kconfig
+++ b/drivers/dac/Kconfig
@@ -18,7 +18,7 @@ module-str = DAC
 source "subsys/logging/Kconfig.template.log_config"
 
 config DAC_SHELL
-	bool "Enable DAC shell"
+	bool "DAC shell"
 	default y
 	depends on SHELL
 	help

--- a/drivers/dac/Kconfig.mcux
+++ b/drivers/dac/Kconfig.mcux
@@ -17,7 +17,7 @@ config DAC_MCUX_DAC32
 	  Enable the driver for the NXP Kinetis MCUX DAC32.
 
 config DAC_MCUX_DAC32_TESTOUT
-	bool "Enable DAC test output"
+	bool "DAC test output"
 	depends on DAC_MCUX_DAC32
 	help
 	  Enable the DAC test output.

--- a/drivers/debug/Kconfig.rtt
+++ b/drivers/debug/Kconfig.rtt
@@ -7,7 +7,7 @@ config HAS_SEGGER_RTT
 	  Indicates that the platform supports SEGGER J-Link RTT.
 
 config USE_SEGGER_RTT
-	bool "Enable SEGGER RTT libraries."
+	bool "SEGGER RTT libraries."
 	depends on HAS_SEGGER_RTT
 	help
 	  Enable Segger J-Link RTT libraries for platforms that support it.
@@ -17,7 +17,7 @@ config USE_SEGGER_RTT
 if USE_SEGGER_RTT
 
 config SEGGER_RTT_CUSTOM_LOCKING
-	bool "Enable custom locking"
+	bool "Custom locking"
 	help
 	  Enable custom locking using a mutex.
 

--- a/drivers/display/Kconfig.ssd1306
+++ b/drivers/display/Kconfig.ssd1306
@@ -28,7 +28,7 @@ config SSD1306_DEFAULT
 	bool "Default SSD1306 controller"
 
 config SSD1306_SH1106_COMPATIBLE
-	bool "Enable SH1106 compatible mode"
+	bool "SH1106 compatible mode"
 
 endchoice
 

--- a/drivers/dma/Kconfig.cavs_gpdma
+++ b/drivers/dma/Kconfig.cavs_gpdma
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DMA_CAVS_GPDMA
-	bool "Enable cAVS GPDMA DMA driver"
+	bool "CAVS GPDMA DMA driver"
 	help
 	  Intel cAVS GPDMA DMA driver.

--- a/drivers/dma/Kconfig.dw
+++ b/drivers/dma/Kconfig.dw
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DMA_DW
-	bool "Enable DesignWare DMA driver"
+	bool "DesignWare DMA driver"
 	help
 	  DesignWare DMA driver.

--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DMA_MCUX_EDMA
-	bool "Enable MCUX DMA driver"
+	bool "MCUX DMA driver"
 	depends on HAS_MCUX_EDMA
 	imply NOCACHE_MEMORY if HAS_MCUX_CACHE
 	help

--- a/drivers/dma/Kconfig.mcux_lpc
+++ b/drivers/dma/Kconfig.mcux_lpc
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config DMA_MCUX_LPC
-	bool "Enable MCUX LPC DMAC driver"
+	bool "MCUX LPC DMAC driver"
 	depends on HAS_MCUX_LPC_DMA
 	help
 	  DMA driver for MCUX LPC MCUs.

--- a/drivers/dma/Kconfig.stm32
+++ b/drivers/dma/Kconfig.stm32
@@ -10,7 +10,7 @@ DT_COMPAT_ST_STM32_DMA_V2BIS := st,stm32-dma-v2bis
 DT_COMPAT_ST_STM32_DMAMUX := st,stm32-dmamux
 
 config DMA_STM32
-	bool "Enable STM32 DMA driver"
+	bool "STM32 DMA driver"
 	select USE_STM32_LL_DMA
 	depends on SOC_FAMILY_STM32
 	help

--- a/drivers/edac/Kconfig
+++ b/drivers/edac/Kconfig
@@ -11,13 +11,13 @@ menuconfig EDAC
 if EDAC
 
 config EDAC_ERROR_INJECT
-	bool "Enable EDAC Error Injection mechanism"
+	bool "EDAC Error Injection mechanism"
 	help
 	  Enable Error injection capability for test error checking
 	  and reporting. Should not be enabled in production system.
 
 config EDAC_SHELL
-	bool "Enable EDAC Shell"
+	bool "EDAC Shell"
 	depends on SHELL
 	default y if SHELL
 	help

--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -21,7 +21,7 @@ config EEPROM_INIT_PRIORITY
 	  EEPROM driver device initialization priority.
 
 config EEPROM_SHELL
-	bool "Enable EEPROM shell"
+	bool "EEPROM shell"
 	default y
 	depends on SHELL
 	help
@@ -68,7 +68,7 @@ config EEPROM_SIMULATOR
 	  Enable Simulated EEPROM driver.
 
 config EEPROM_SIMULATOR_SIMULATE_TIMING
-	bool "Enable hardware timing simulation"
+	bool "Hardware timing simulation"
 	depends on EEPROM_SIMULATOR
 	help
 	  Enable Simulated hardware timing.

--- a/drivers/entropy/Kconfig.nrf5
+++ b/drivers/entropy/Kconfig.nrf5
@@ -25,7 +25,7 @@ menuconfig ENTROPY_NRF5_RNG
 if ENTROPY_NRF5_RNG
 
 config ENTROPY_NRF5_BIAS_CORRECTION
-	bool "Enable bias correction (uniform distribution)"
+	bool "Bias correction (uniform distribution)"
 	help
 	  This option enables the RNG bias correction, which guarantees a
 	  uniform distribution of 0 and 1. When this option is enabled, the time

--- a/drivers/ethernet/Kconfig.dsa
+++ b/drivers/ethernet/Kconfig.dsa
@@ -17,25 +17,25 @@ config DSA_KSZ8XXX
 	bool
 
 config DSA_KSZ8794
-	bool "Enable support for KSZ8794"
+	bool "Support for KSZ8794"
 	select DSA_KSZ8XXX
 	help
 	  Add support for KSZ8794 DSA device driver.
 
 config DSA_KSZ8863
-	bool "Enable support for KSZ8863"
+	bool "Support for KSZ8863"
 	select DSA_KSZ8XXX
 	help
 	  Add support for KSZ8863 DSA device driver.
 
 config DSA_KSZ_TAIL_TAGGING
-	bool "Enable support for tail tagging"
+	bool "Support for tail tagging"
 	depends on DSA_KSZ8794 || DSA_KSZ8863
 	help
 	  Add support for tail tagging on DSA device.
 
 config DSA_SPI
-	bool "Enable support for PHY SPI interface"
+	bool "Support for PHY SPI interface"
 	depends on SPI && (DSA_KSZ8794 || DSA_KSZ8863)
 	help
 	  Use SPI bus to communicate with PHY

--- a/drivers/ethernet/Kconfig.e1000
+++ b/drivers/ethernet/Kconfig.e1000
@@ -19,13 +19,13 @@ config ETH_NIC_MODEL
 	  a parameter to -nic qemu command line option.
 
 config ETH_E1000_VERBOSE_DEBUG
-	bool "Enable hexdump of the received and sent frames"
+	bool "Hexdump of the received and sent frames"
 	help
 	  Enabling this will turn on the hexdump of the received and sent
 	  frames. Do not leave on for production.
 
 config ETH_E1000_PTP_CLOCK
-	bool "Enable PTP clock driver support [EXPERIMENTAL]"
+	bool "PTP clock driver support [EXPERIMENTAL]"
 	depends on PTP_CLOCK
 	select EXPERIMENTAL
 	default y

--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -17,13 +17,13 @@ menuconfig ETH_MCUX
 if ETH_MCUX
 
 config ETH_MCUX_PROMISCUOUS_MODE
-	bool "Enable promiscuous mode"
+	bool "Promiscuous mode"
 	help
 	  Place the Ethernet receiver in promiscuous mode. This may be useful
 	  for debugging and not needed for normal work.
 
 config ETH_MCUX_RMII_EXT_CLK
-	bool "Enable RMII clock from external sources"
+	bool "RMII clock from external sources"
 	help
 	  Setting this option will configure MCUX clock block to feed RMII
 	  reference clock from external source (ENET_1588_CLKIN)
@@ -43,7 +43,7 @@ config ETH_MCUX_PHY_TICK_MS
 	  Set the PHY status polling period.
 
 config ETH_MCUX_PHY_EXTRA_DEBUG
-	bool "Enable additional detailed PHY debug"
+	bool "Additional detailed PHY debug"
 	help
 	  Enable additional PHY related debug information related to
 	  PHY status polling.
@@ -63,7 +63,7 @@ config ETH_MCUX_TX_BUFFERS
 	  Set the number of TX buffers provided to the MCUX driver.
 
 config ETH_MCUX_HW_ACCELERATION
-	bool "Enable hardware acceleration"
+	bool "Hardware acceleration"
 	help
 	  Enable hardware acceleration for the following:
 	  - IPv4, UDP and TCP checksum (both Rx and Tx)

--- a/drivers/ethernet/Kconfig.stellaris
+++ b/drivers/ethernet/Kconfig.stellaris
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig ETH_STELLARIS
-	bool "Enable TI Stellaris MCU family ethernet driver."
+	bool "TI Stellaris MCU family ethernet driver."
 	help
 	  Stellaris on-board Ethernet Controller
 

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -89,7 +89,7 @@ config ETH_STM32_CARRIER_CHECK_RX_IDLE_TIMEOUT_MS
 	  PHY's carrier status is re-evaluated.
 
 config ETH_STM32_AUTO_NEGOTIATION_ENABLE
-	bool "Enable autonegotiation mode"
+	bool "Autonegotiation mode"
 	default y
 	help
 	  Enable this if using autonegotiation
@@ -97,14 +97,14 @@ config ETH_STM32_AUTO_NEGOTIATION_ENABLE
 if !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
 config ETH_STM32_SPEED_10M
-	bool "Enable this if using 10 Mbps for speed when autonegotiation is diabled"
+	bool "This if using 10 Mbps for speed when autonegotiation is diabled"
 	default n
 	help
 	  Set this if using 10 Mbps and when autonegotiation is disabled, otherwise speed
 	  is 100 Mbps
 
 config ETH_STM32_MODE_HALFDUPLEX
-	bool "Enable this if using half duplex"
+	bool "This if using half duplex"
 	default n
 	help
 	  Set this if using half duplex when autonegotiation is disabled otherwise

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -97,14 +97,14 @@ config ETH_STM32_AUTO_NEGOTIATION_ENABLE
 if !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
 config ETH_STM32_SPEED_10M
-	bool "This if using 10 Mbps for speed when autonegotiation is diabled"
+	bool "Set speed to 10 Mbps when autonegotiation is diabled"
 	default n
 	help
 	  Set this if using 10 Mbps and when autonegotiation is disabled, otherwise speed
 	  is 100 Mbps
 
 config ETH_STM32_MODE_HALFDUPLEX
-	bool "This if using half duplex"
+	bool "Half duplex mode"
 	default n
 	help
 	  Set this if using half duplex when autonegotiation is disabled otherwise

--- a/drivers/flash/Kconfig
+++ b/drivers/flash/Kconfig
@@ -44,7 +44,7 @@ module-str = flash
 source "subsys/logging/Kconfig.template.log_config"
 
 config FLASH_SHELL
-	bool "Enable Flash shell"
+	bool "Flash shell"
 	depends on SHELL && FLASH_PAGE_LAYOUT
 	default y
 	help

--- a/drivers/flash/Kconfig.simulator
+++ b/drivers/flash/Kconfig.simulator
@@ -27,7 +27,7 @@ config FLASH_SIMULATOR_DOUBLE_WRITES
 	 Keep in mind that write operations can only pull bits to zero, regardless.
 
 config FLASH_SIMULATOR_SIMULATE_TIMING
-	bool "Enable hardware timing simulation"
+	bool "Hardware timing simulation"
 
 if FLASH_SIMULATOR_SIMULATE_TIMING
 

--- a/drivers/fpga/Kconfig
+++ b/drivers/fpga/Kconfig
@@ -15,7 +15,7 @@ module-str = fpga
 source "subsys/logging/Kconfig.template.log_config"
 
 config FPGA_SHELL
-	bool "Enable FPGA Shell"
+	bool "FPGA Shell"
 	depends on SHELL && FPGA
 	help
 	  Enable FPGA Shell support.

--- a/drivers/gpio/Kconfig
+++ b/drivers/gpio/Kconfig
@@ -16,7 +16,7 @@ module-str = gpio
 source "subsys/logging/Kconfig.template.log_config"
 
 config GPIO_SHELL
-	bool "Enable GPIO Shell"
+	bool "GPIO Shell"
 	depends on SHELL
 	help
 	  Enable GPIO Shell for testing.

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -14,7 +14,7 @@ config GPIO_DW_SHARED_IRQ
 	bool
 
 config GPIO_DW_CLOCK_GATE
-	bool "Enable clock gating"
+	bool "Clock gating"
 	select CLOCK_CONTROL
 
 config GPIO_DW_CLOCK_GATE_DRV_NAME

--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -15,7 +15,7 @@ module-str = HWINFO
 source "subsys/logging/Kconfig.template.log_config"
 
 config HWINFO_SHELL
-	bool "Enable HWINFO Shell"
+	bool "HWINFO Shell"
 	default y
 	depends on SHELL
 	help

--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -14,7 +14,7 @@ menuconfig I2C
 if I2C
 
 config I2C_SHELL
-	bool "Enable I2C Shell"
+	bool "I2C Shell"
 	default y
 	depends on SHELL
 	help
@@ -23,7 +23,7 @@ config I2C_SHELL
 	  The I2C shell currently support scanning and bus recovery.
 
 config I2C_STATS
-	bool "Enable I2C device Stats"
+	bool "I2C device Stats"
 	depends on STATS
 	help
 	  Enable I2C Stats.

--- a/drivers/i2c/Kconfig.sam0
+++ b/drivers/i2c/Kconfig.sam0
@@ -9,7 +9,7 @@ menuconfig I2C_SAM0
 	  Enable the SAM0 series SERCOM I2C driver.
 
 config I2C_SAM0_DMA_DRIVEN
-	bool "Enable DMA support for SAM0 I2C devices"
+	bool "DMA support for SAM0 I2C devices"
 	depends on I2C_SAM0
 	select DMA
 	help

--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -22,7 +22,7 @@ config I2S_STM32_TX_BLOCK_COUNT
 	default 4
 
 config I2S_STM32_USE_PLLI2S_ENABLE
-	bool "Enable usage of PLL"
+	bool "Usage of PLL"
 	help
 	  Enable it if I2S clock should be provided by the PLLI2S.
 	  If not enabled the clock will be provided by HSI/HSE.

--- a/drivers/i2s/Kconfig.stm32
+++ b/drivers/i2s/Kconfig.stm32
@@ -22,7 +22,7 @@ config I2S_STM32_TX_BLOCK_COUNT
 	default 4
 
 config I2S_STM32_USE_PLLI2S_ENABLE
-	bool "Usage of PLL"
+	bool "Use PLL"
 	help
 	  Enable it if I2S clock should be provided by the PLLI2S.
 	  If not enabled the clock will be provided by HSI/HSE.

--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -40,7 +40,7 @@ config IEEE802154_RDEV
 	  PHY is a ranging-capable device (RDEV)
 
 config IEEE802154_VENDOR_OUI_ENABLE
-	bool "Enables setting Vendor Organizationally Unique Identifier"
+	bool "Setting Vendor Organizationally Unique Identifier"
 	help
 	  This option enables setting custom vendor
 	  OUI using IEEE802154_VENDOR_OUI. After enabling,
@@ -133,7 +133,7 @@ endif # IEEE802154_UPIPE_RANDOM_MAC
 endif # IEEE802154_UPIPE
 
 config IEEE802154_2015
-	bool "Enable support for IEEE 802.15.4-2015 frames"
+	bool "Support for IEEE 802.15.4-2015 frames"
 	help
 	  Enable radio driver support for IEEE 802.15.4-2015 frames, including security handling of frames and ACKs.
 
@@ -145,7 +145,7 @@ config IEEE802154_DELAY_TRX_ACC
 	  or delayed reception), in ppm.
 
 config IEEE802154_CSL_ENDPOINT
-	bool "Enable support for CSL Endpoint"
+	bool "Support for CSL Endpoint"
 	help
 	  Enable support for CSL Endpoint with delayed reception handling and CSL IE injection.
 

--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -13,7 +13,7 @@ menuconfig IEEE802154
 if IEEE802154
 
 config IEEE802154_NET_IF_NO_AUTO_START
-	bool "Disable 802.15.4 interface auto-start"
+	bool "IEEE 802.15.4 interface without auto-start"
 	help
 	  This option allows user to set any configuration and/or filter before
 	  the radio becomes operational. For instance, the EUI-64 value can be
@@ -26,7 +26,7 @@ config IEEE802154_NET_IF_NO_AUTO_START
 	  have any doubt about this option leave it as default value.
 
 config IEEE802154_RAW_MODE
-	bool "Use IEEE 802.15.4 driver without the MAC stack"
+	bool "IEEE 802.15.4 driver without the MAC stack"
 	select NET_RAW_MODE
 	help
 	  This option enables using the drivers in a so-called "raw" mode,
@@ -40,7 +40,7 @@ config IEEE802154_RDEV
 	  PHY is a ranging-capable device (RDEV)
 
 config IEEE802154_VENDOR_OUI_ENABLE
-	bool "Setting Vendor Organizationally Unique Identifier"
+	bool "Support setting Vendor Organizationally Unique Identifier"
 	help
 	  This option enables setting custom vendor
 	  OUI using IEEE802154_VENDOR_OUI. After enabling,

--- a/drivers/ieee802154/Kconfig.cc2520
+++ b/drivers/ieee802154/Kconfig.cc2520
@@ -71,7 +71,7 @@ config IEEE802154_CC2520_MAC7
 endif # IEEE802154_CC2520_RANDOM_MAC
 
 config IEEE802154_CC2520_CRYPTO
-	bool "Enable hardware crypto helper on cc2520"
+	bool "Hardware crypto helper on cc2520"
 	depends on NET_L2_IEEE802154_SECURITY
 	help
 	  This option will expose the hardware AES encryption from CC2520.

--- a/drivers/ieee802154/Kconfig.kw41z
+++ b/drivers/ieee802154/Kconfig.kw41z
@@ -25,7 +25,7 @@ config IEEE802154_KW41Z_INIT_PRIO
 	  you know what you are doing. It has to start before the net stack.
 
 config KW41_DBG_TRACE
-	bool "Enabled simplified debug tracing of events"
+	bool "Simplified debug tracing of events"
 	help
 	  The value depends on your debugging needs. This generates an encoded
 	  trace of events without going to debug logging to avoid timing impact

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -44,7 +44,7 @@ config IEEE802154_NRF5_EXT_IRQ_MGMT
 	  a radio arbiter used in dynamic multiprotocol applications.
 
 config IEEE802154_NRF5_UICR_EUI64_ENABLE
-	bool "Using EUI64 value stored in UICR registers"
+	bool "Support usage of EUI64 value stored in UICR registers"
 	depends on !IEEE802154_VENDOR_OUI_ENABLE
 	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF53X
 	help

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -44,7 +44,7 @@ config IEEE802154_NRF5_EXT_IRQ_MGMT
 	  a radio arbiter used in dynamic multiprotocol applications.
 
 config IEEE802154_NRF5_UICR_EUI64_ENABLE
-	bool "Enables using EUI64 value stored in UICR registers"
+	bool "Using EUI64 value stored in UICR registers"
 	depends on !IEEE802154_VENDOR_OUI_ENABLE
 	depends on SOC_SERIES_NRF52X || SOC_SERIES_NRF53X
 	help

--- a/drivers/interrupt_controller/Kconfig.esp32
+++ b/drivers/interrupt_controller/Kconfig.esp32
@@ -11,7 +11,7 @@ config INTC_ESP32
 	  architecture.
 
 config INTC_ESP32_DECISIONS_LOG
-	bool "Enables Espressif's interrupt allocator logging"
+	bool "Espressif's interrupt allocator logging"
 	depends on INTC_ESP32
 	select LOG
 	help

--- a/drivers/interrupt_controller/Kconfig.esp32c3
+++ b/drivers/interrupt_controller/Kconfig.esp32c3
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config INTC_ESP32C3
-	bool "Enables ESP32C3 interrupt controller driver"
+	bool "ESP32C3 interrupt controller driver"
 	depends on SOC_ESP32C3
 	default y
 	help
@@ -10,7 +10,7 @@ config INTC_ESP32C3
 	  management at SoC level.
 
 config INTC_ESP32C3_DECISIONS_LOG
-	bool "Enables Espressif's interrupt allocator logging"
+	bool "Espressif's interrupt allocator logging"
 	depends on INTC_ESP32C3
 	select LOG
 	help

--- a/drivers/ipm/Kconfig.nrfx_ipc_channel
+++ b/drivers/ipm/Kconfig.nrfx_ipc_channel
@@ -6,7 +6,7 @@
 menu "IPM Message Channel [$(nrfx_ipc_num)] configuration"
 
 config IPM_MSG_CH_$(nrfx_ipc_num)_ENABLE
-	bool "Enable IPM Message Channel $(nrfx_ipc_num)"
+	bool "IPM Message Channel $(nrfx_ipc_num)"
 
 config IPM_MSG_CH_$(nrfx_ipc_num)_RX
 	bool "IPM Message RX Channel"

--- a/drivers/kscan/Kconfig.cst816s
+++ b/drivers/kscan/Kconfig.cst816s
@@ -20,7 +20,7 @@ config KSCAN_CST816S_PERIOD
 	  Sample period in milliseconds when in polling mode.
 
 config KSCAN_CST816S_INTERRUPT
-	bool "Enable interrupt support"
+	bool "Interrupt support"
 	default y
 	depends on GPIO
 	help

--- a/drivers/kscan/Kconfig.ft5336
+++ b/drivers/kscan/Kconfig.ft5336
@@ -20,7 +20,7 @@ config KSCAN_FT5336_PERIOD
 	  Sample period in milliseconds when in polling mode.
 
 config KSCAN_FT5336_INTERRUPT
-	bool "Enable interrupt"
+	bool "Interrupt"
 	help
 	  Enable interrupt support (requires GPIO).
 

--- a/drivers/led/Kconfig.ht16k33
+++ b/drivers/led/Kconfig.ht16k33
@@ -12,7 +12,7 @@ menuconfig HT16K33
 	  (up to 16 rows and 8 commons).
 
 config HT16K33_KEYSCAN
-	bool "Enable keyscan support"
+	bool "Keyscan support"
 	depends on (HT16K33 && KSCAN)
 	select KSCAN_HT16K33
 	help

--- a/drivers/led_strip/Kconfig.lpd880x
+++ b/drivers/led_strip/Kconfig.lpd880x
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config LPD880X_STRIP
-	bool "Enable LPD880x SPI LED strip driver"
+	bool "LPD880x SPI LED strip driver"
 	depends on SPI
 	help
 	  Enable LED strip driver for daisy chains of LPD880x

--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -20,14 +20,14 @@ choice WS2812_STRIP_DRIVER
 	depends on WS2812_STRIP
 
 config WS2812_STRIP_SPI
-	bool "The SPI driver"
+	bool "SPI driver"
 	depends on SPI
 	help
 	  The SPI driver is portable, but requires significantly more
 	  memory (1 byte of overhead per bit of pixel data).
 
 config WS2812_STRIP_GPIO
-	bool "The GPIO driver"
+	bool "GPIO driver"
 	# Only an Cortex-M0 inline assembly implementation for the nRF51
 	# is supported currently.
 	depends on SOC_SERIES_NRF51X

--- a/drivers/led_strip/Kconfig.ws2812
+++ b/drivers/led_strip/Kconfig.ws2812
@@ -8,7 +8,7 @@
 # https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
 
 menuconfig WS2812_STRIP
-	bool "Enable WS2812 (and compatible) LED strip driver"
+	bool "WS2812 (and compatible) LED strip driver"
 	select LED_STRIP_RGB_SCRATCH
 	help
 	  Enable LED strip driver for daisy chains of WS2812-ish (or WS2812B,
@@ -20,14 +20,14 @@ choice WS2812_STRIP_DRIVER
 	depends on WS2812_STRIP
 
 config WS2812_STRIP_SPI
-	bool "Enable the SPI driver"
+	bool "The SPI driver"
 	depends on SPI
 	help
 	  The SPI driver is portable, but requires significantly more
 	  memory (1 byte of overhead per bit of pixel data).
 
 config WS2812_STRIP_GPIO
-	bool "Enable the GPIO driver"
+	bool "The GPIO driver"
 	# Only an Cortex-M0 inline assembly implementation for the nRF51
 	# is supported currently.
 	depends on SOC_SERIES_NRF51X

--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -21,7 +21,7 @@ module-str = lora
 source "subsys/logging/Kconfig.template.log_config"
 
 config LORA_SHELL
-	bool "Enable LoRa Shell"
+	bool "LoRa Shell"
 	default y
 	depends on SHELL
 	help

--- a/drivers/mdio/Kconfig
+++ b/drivers/mdio/Kconfig
@@ -14,7 +14,7 @@ menuconfig MDIO
 if MDIO
 
 config MDIO_SHELL
-	bool "Enable MDIO Shell"
+	bool "MDIO Shell"
 	default y
 	depends on SHELL
 	help

--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -4,7 +4,7 @@
 DT_COMPAT_ST_STM32_FMC := st,stm32-fmc
 
 config MEMC_STM32
-	bool "Enable STM32 Flexible Memory Controller (FMC)"
+	bool "STM32 Flexible Memory Controller (FMC)"
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_FMC))
 	help
 	  Enable STM32 Flexible Memory Controller.
@@ -12,7 +12,7 @@ config MEMC_STM32
 DT_COMPAT_ST_STM32_FMC_SDRAM := st,stm32-fmc-sdram
 
 config MEMC_STM32_SDRAM
-	bool "Enable STM32 FMC SDRAM controller"
+	bool "STM32 FMC SDRAM controller"
 	depends on MEMC_STM32
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_FMC_SDRAM))
 	select USE_STM32_LL_FMC

--- a/drivers/misc/grove_lcd_rgb/Kconfig
+++ b/drivers/misc/grove_lcd_rgb/Kconfig
@@ -6,7 +6,7 @@ module-str = grove_lcd_rgb
 source "subsys/logging/Kconfig.template.log_config"
 
 config GROVE_LCD_RGB
-	bool "The Seeed Grove LCD RGB Backlight"
+	bool "Seeed Grove LCD RGB Backlight"
 	help
 	  Setting this value will enable driver support for the Groove-LCD RGB
 	  Backlight.

--- a/drivers/misc/grove_lcd_rgb/Kconfig
+++ b/drivers/misc/grove_lcd_rgb/Kconfig
@@ -6,7 +6,7 @@ module-str = grove_lcd_rgb
 source "subsys/logging/Kconfig.template.log_config"
 
 config GROVE_LCD_RGB
-	bool "Enable the Seeed Grove LCD RGB Backlight"
+	bool "The Seeed Grove LCD RGB Backlight"
 	help
 	  Setting this value will enable driver support for the Groove-LCD RGB
 	  Backlight.

--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -15,7 +15,7 @@ module-str = modem
 source "subsys/logging/Kconfig.template.log_config"
 
 config MODEM_RECEIVER
-	bool "Enable modem receiver helper driver"
+	bool "Modem receiver helper driver"
 	depends on SERIAL_SUPPORT_INTERRUPT
 	select UART_INTERRUPT_DRIVEN
 	select RING_BUFFER
@@ -119,14 +119,14 @@ config MODEM_SOCKET_PACKET_COUNT
 endif # MODEM_CONTEXT
 
 config MODEM_SHELL
-	bool "Enable modem shell utilities"
+	bool "Modem shell utilities"
 	select SHELL
 	help
 	  Activate shell module that provides modem utilities like
 	  sending a command to the modem UART.
 
 config MODEM_SIM_NUMBERS
-	bool "Enable querying the SIM for IMSI and ICCID"
+	bool "Querying the SIM for IMSI and ICCID"
 	depends on MODEM_SHELL
 	default y
 	help
@@ -134,7 +134,7 @@ config MODEM_SIM_NUMBERS
 	  can be disabled if the application does not use a SIM.
 
 config MODEM_CELL_INFO
-	bool "Enable querying for operator and cell info"
+	bool "Querying for operator and cell info"
 	depends on MODEM_SHELL
 	help
 	  Query for numerical operator id, location area code and cell id.

--- a/drivers/modem/Kconfig
+++ b/drivers/modem/Kconfig
@@ -126,7 +126,7 @@ config MODEM_SHELL
 	  sending a command to the modem UART.
 
 config MODEM_SIM_NUMBERS
-	bool "Querying the SIM for IMSI and ICCID"
+	bool "Query the SIM for IMSI and ICCID"
 	depends on MODEM_SHELL
 	default y
 	help
@@ -134,7 +134,7 @@ config MODEM_SIM_NUMBERS
 	  can be disabled if the application does not use a SIM.
 
 config MODEM_CELL_INFO
-	bool "Querying for operator and cell info"
+	bool "Query for operator and cell info"
 	depends on MODEM_SHELL
 	help
 	  Query for numerical operator id, location area code and cell id.

--- a/drivers/modem/Kconfig.gsm
+++ b/drivers/modem/Kconfig.gsm
@@ -96,7 +96,7 @@ config MODEM_GSM_RSSI_POLLING_PERIOD
 	  This settings is used to configure the period of RSSI polling
 
 config MODEM_GSM_ENABLE_CESQ_RSSI
-	bool "Enable +CESQ RSSI measurement"
+	bool "+CESQ RSSI measurement"
 	help
 	   If this is enabled, RSRP, RSCP and RXREL values are read from the
 	   modem with +CESQ. Otherwise only RSSI value is read with +CSQ

--- a/drivers/modem/Kconfig.hl7800
+++ b/drivers/modem/Kconfig.hl7800
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MODEM_HL7800
-	bool "Enable Sierra Wireless HL7800 modem driver"
+	bool "Sierra Wireless HL7800 modem driver"
 	select MODEM_RECEIVER
 	select NET_OFFLOAD
 	imply GPIO
@@ -15,7 +15,7 @@ menuconfig MODEM_HL7800
 if MODEM_HL7800
 
 config MODEM_HL7800_FW_UPDATE
-	bool "Enable firmware update"
+	bool "Firmware update"
 	select FILE_SYSTEM
 	help
 	  Enable the ability to update the HL7800 via XMODEM
@@ -76,119 +76,119 @@ menuconfig MODEM_HL7800_CONFIGURE_BANDS
 if MODEM_HL7800_CONFIGURE_BANDS
 
 config MODEM_HL7800_BAND_1
-	bool "Enable Band 1  (2000MHz)"
+	bool "Band 1  (2000MHz)"
 	default "y"
 	help
 	  Enable Band 1 (2000MHz)
 
 config MODEM_HL7800_BAND_2
-	bool "Enable Band 2  (1900MHz)"
+	bool "Band 2  (1900MHz)"
 	default "y"
 	help
 	  Enable Band 2 (1900MHz)
 
 config MODEM_HL7800_BAND_3
-	bool "Enable Band 3  (1800MHz)"
+	bool "Band 3  (1800MHz)"
 	default "y"
 	help
 	  Enable Band 3 (1800MHz)
 
 config MODEM_HL7800_BAND_4
-	bool "Enable Band 4  (1700MHz)"
+	bool "Band 4  (1700MHz)"
 	default "y"
 	help
 	  Enable Band 4 (1700MHz)
 
 config MODEM_HL7800_BAND_5
-	bool "Enable Band 5  (850MHz)"
+	bool "Band 5  (850MHz)"
 	default "y"
 	help
 	  Enable Band 5 (850MHz)
 
 config MODEM_HL7800_BAND_8
-	bool "Enable Band 8  (900MHz)"
+	bool "Band 8  (900MHz)"
 	default "y"
 	help
 	  Enable Band 8 (900MHz)
 
 config MODEM_HL7800_BAND_9
-	bool "Enable Band 9  (1900MHz)"
+	bool "Band 9  (1900MHz)"
 	help
 	  Enable Band 9 (1900MHz)
 
 config MODEM_HL7800_BAND_10
-	bool "Enable Band 10 (2100MHz)"
+	bool "Band 10 (2100MHz)"
 	help
 	  Enable Band 10 (2100MHz)
 
 config MODEM_HL7800_BAND_12
-	bool "Enable Band 12 (700MHz)"
+	bool "Band 12 (700MHz)"
 	default "y"
 	help
 	  Enable Band 12 (700MHz)
 
 config MODEM_HL7800_BAND_13
-	bool "Enable Band 13 (700MHz)"
+	bool "Band 13 (700MHz)"
 	default "y"
 	help
 	  Enable Band 13 (700MHz)
 
 config MODEM_HL7800_BAND_14
-	bool "Enable Band 14 (700MHz)"
+	bool "Band 14 (700MHz)"
 	help
 	  Enable Band 14 (700MHz)
 
 config MODEM_HL7800_BAND_17
-	bool "Enable Band 17 (700MHz)"
+	bool "Band 17 (700MHz)"
 	help
 	  Enable Band 17 (700MHz)
 
 config MODEM_HL7800_BAND_18
-	bool "Enable Band 18 (800MHz)"
+	bool "Band 18 (800MHz)"
 	help
 	  Enable Band 18 (800MHz)
 
 config MODEM_HL7800_BAND_19
-	bool "Enable Band 19 (800MHz)"
+	bool "Band 19 (800MHz)"
 	help
 	  Enable Band 19 (800MHz)
 
 config MODEM_HL7800_BAND_20
-	bool "Enable Band 20 (800MHz)"
+	bool "Band 20 (800MHz)"
 	default "y"
 	help
 	  Enable Band 20 (800MHz)
 
 config MODEM_HL7800_BAND_25
-	bool "Enable Band 25 (1900MHz)"
+	bool "Band 25 (1900MHz)"
 	help
 	  Enable Band 25 (1900MHz)
 
 config MODEM_HL7800_BAND_26
-	bool "Enable Band 26 (800MHz)"
+	bool "Band 26 (800MHz)"
 	help
 	  Enable Band 26 (800MHz)
 
 config MODEM_HL7800_BAND_27
-	bool "Enable Band 27 (800MHz)"
+	bool "Band 27 (800MHz)"
 	help
 	  Enable Band 27 (800MHz)
 
 config MODEM_HL7800_BAND_28
-	bool "Enable Band 28 (700MHz)"
+	bool "Band 28 (700MHz)"
 	default "y"
 	help
 	  Enable Band 28 (700MHz)
 
 config MODEM_HL7800_BAND_66
-	bool "Enable Band 66 (1800MHz)"
+	bool "Band 66 (1800MHz)"
 	help
 	  Enable Band 66 (1800MHz)
 
 endif # MODEM_HL7800_CONFIGURE_BAND
 
 menuconfig MODEM_HL7800_LOW_POWER_MODE
-	bool "Enable low power modes"
+	bool "Low power modes"
 	help
 	  Choose this setting to enable a low power mode for the HL7800 modem
 
@@ -327,14 +327,14 @@ config MODEM_HL7800_BOOT_IN_AIRPLANE_MODE
 endchoice
 
 config MODEM_HL7800_GPS
-	bool "Enable GPS command and handlers"
+	bool "GPS command and handlers"
 
 config MODEM_HL7800_USE_GLONASS
 	bool "Use GLONASS in addition to GPS"
 	depends on MODEM_HL7800_GPS
 
 config MODEM_HL7800_POLTE
-	bool "Enable PoLTE commands and handlers"
+	bool "PoLTE commands and handlers"
 
 choice
 	prompt "IP Address family"

--- a/drivers/modem/Kconfig.quectel-bg9x
+++ b/drivers/modem/Kconfig.quectel-bg9x
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config MODEM_QUECTEL_BG9X
-	bool "Enable quectel modem driver"
+	bool "Quectel modem driver"
 	select MODEM_CONTEXT
 	select MODEM_CMD_HANDLER
 	select MODEM_IFACE_UART

--- a/drivers/modem/Kconfig.ublox-sara-r4
+++ b/drivers/modem/Kconfig.ublox-sara-r4
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config MODEM_UBLOX_SARA
-	bool "Enable u-blox SARA modem driver"
+	bool "U-blox SARA modem driver"
 	select MODEM_CONTEXT
 	select MODEM_CMD_HANDLER
 	select MODEM_IFACE_UART
@@ -91,7 +91,7 @@ config MODEM_UBLOX_SARA_R4_INIT_PRIORITY
 	  so that it can start before the networking sub-system.
 
 config MODEM_UBLOX_SARA_R4_NET_STATUS
-	bool "Enable support for network status indication"
+	bool "Support for network status indication"
 	help
 	  Choose this setting to use a modem GPIO pin as network indication.
 
@@ -108,7 +108,7 @@ config MODEM_UBLOX_SARA_R4_NET_STATUS_PIN
 endif # MODEM_UBLOX_SARA_R4_NET_STATUS
 
 config MODEM_UBLOX_SARA_RSSI_WORK
-	bool "Enable RSSI polling work"
+	bool "RSSI polling work"
 	default y
 	help
 	  u-blox SARA-R4 device is configured to poll for RSSI

--- a/drivers/modem/Kconfig.wncm14a2a
+++ b/drivers/modem/Kconfig.wncm14a2a
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig MODEM_WNCM14A2A
-	bool "Enable Wistron LTE-M modem driver"
+	bool "Wistron LTE-M modem driver"
 	select MODEM_RECEIVER
 	select NET_OFFLOAD
 	imply GPIO

--- a/drivers/pcie/endpoint/Kconfig
+++ b/drivers/pcie/endpoint/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PCIE_ENDPOINT
-	bool "Enable PCIe Endpoint support"
+	bool "PCIe Endpoint support"
 	help
 	  This option enables PCIe Endpoint support.
 

--- a/drivers/pcie/host/Kconfig
+++ b/drivers/pcie/host/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PCIE
-	bool "Enable new PCI/PCIe Root Complex support"
+	bool "New PCI/PCIe Root Complex support"
 	help
 	  This option enables support for new PCI(e) drivers.
 
@@ -15,7 +15,7 @@ module-str = pcie
 source "subsys/logging/Kconfig.template.log_config"
 
 config PCIE_CONTROLLER
-	bool "Enable PCIe Controller management"
+	bool "PCIe Controller management"
 	help
 	  Add support for PCIe Controller management when not handled by a
 	  system firmware like on x86 platforms.
@@ -23,7 +23,7 @@ config PCIE_CONTROLLER
 if PCIE_CONTROLLER
 
 config PCIE_ECAM
-	bool "Enable support for PCIe ECAM Controllers"
+	bool "Support for PCIe ECAM Controllers"
 	help
 	  Add support for Enhanced Configuration Address Mapping configured
 	  PCIe Controllers allowing all outgoing I/O and MEM TLPs to be mapped
@@ -32,7 +32,7 @@ config PCIE_ECAM
 endif # PCIE_CONTROLLER
 
 config PCIE_MSI
-	bool "Enable support for PCI(e) MSI"
+	bool "Support for PCI(e) MSI"
 	help
 	  Use Message-Signaled Interrupts where possible. With this option
 	  enabled, PCI(e) devices which support MSI will be configured (at
@@ -42,7 +42,7 @@ config PCIE_MSI
 if PCIE_MSI
 
 config PCIE_MSI_MULTI_VECTOR
-	bool "Enable MSI multi-vector support"
+	bool "MSI multi-vector support"
 	help
 	  MSI can support up to 32 different messages. This will enable the
 	  support of such capability so each message can get a vector
@@ -52,7 +52,7 @@ config PCIE_MSI_MULTI_VECTOR
 	  peripheral require this.
 
 config PCIE_MSI_X
-	bool "Enable MSI-X support"
+	bool "MSI-X support"
 	help
 	  If one or more device support MSI-X, you'll need to enable this.
 	  If a device exposes support for both MSI-X and MSI, MSI-X will be
@@ -62,13 +62,13 @@ config PCIE_MSI_X
 endif # PCIE_MSI
 
 config PCIE_PTM
-	bool "Enable support for PCI(e) Precision Time Management (PTM)"
+	bool "Support for PCI(e) Precision Time Management (PTM)"
 	help
 	  This will enable support both PTM root and PTM requester features.
 	  Up to the PCIe device driver to enable its PTM requester capability.
 
 config PCIE_SHELL
-	bool "Enable PCIe/new PCI Shell"
+	bool "PCIe/new PCI Shell"
 	default y
 	depends on SHELL
 	help

--- a/drivers/pinctrl/Kconfig
+++ b/drivers/pinctrl/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig PINCTRL
-	bool "Enable pin controller drivers"
+	bool "Pin controller drivers"
 
 if PINCTRL
 
@@ -22,7 +22,7 @@ config PINCTRL_NON_STATIC
 	  dynamic pin control is enabled or in testing environments.
 
 config PINCTRL_DYNAMIC
-	bool "Enable dynamic configuration of pins"
+	bool "Dynamic configuration of pins"
 	select PINCTRL_NON_STATIC
 	help
 	  When this option is enabled pin control configuration can be changed at

--- a/drivers/pinmux/Kconfig
+++ b/drivers/pinmux/Kconfig
@@ -7,7 +7,7 @@
 # PinMux options
 #
 menuconfig PINMUX
-	bool "Enable board pinmux driver"
+	bool "Board pinmux driver"
 
 if PINMUX
 

--- a/drivers/pwm/Kconfig
+++ b/drivers/pwm/Kconfig
@@ -15,7 +15,7 @@ module-str = pwm
 source "subsys/logging/Kconfig.template.log_config"
 
 config PWM_SHELL
-	bool "Enable PWM shell"
+	bool "PWM shell"
 	default y
 	depends on SHELL
 	help

--- a/drivers/pwm/Kconfig.esp32
+++ b/drivers/pwm/Kconfig.esp32
@@ -24,7 +24,7 @@ menuconfig PWM_LED_ESP32_HS_CH
 if PWM_LED_ESP32_HS_CH
 
 menuconfig PWM_LED_ESP32_HS_CH0
-	bool "Enable channel 0"
+	bool "Channel 0"
 	default y
 
 if PWM_LED_ESP32_HS_CH0
@@ -46,7 +46,7 @@ config PWM_LED_ESP32_HS_CH0_TIMER
 endif # PWM_LED_ESP32_HS_CH0
 
 menuconfig PWM_LED_ESP32_HS_CH1
-	bool "Enable channel 1"
+	bool "Channel 1"
 	default y
 
 if PWM_LED_ESP32_HS_CH1
@@ -68,7 +68,7 @@ config PWM_LED_ESP32_HS_CH1_TIMER
 endif # PWM_LED_ESP32_HS_CH1
 
 menuconfig PWM_LED_ESP32_HS_CH2
-	bool "Enable channel 2"
+	bool "Channel 2"
 	default y
 
 if PWM_LED_ESP32_HS_CH2
@@ -90,7 +90,7 @@ config PWM_LED_ESP32_HS_CH2_TIMER
 endif # PWM_LED_ESP32_HS_CH2
 
 menuconfig PWM_LED_ESP32_HS_CH3
-	bool "Enable channel 3"
+	bool "Channel 3"
 	default y
 
 if PWM_LED_ESP32_HS_CH3
@@ -112,7 +112,7 @@ config PWM_LED_ESP32_HS_CH3_TIMER
 endif # PWM_LED_ESP32_HS_CH3
 
 menuconfig PWM_LED_ESP32_HS_CH4
-	bool "Enable channel 4"
+	bool "Channel 4"
 	default y
 
 if PWM_LED_ESP32_HS_CH4
@@ -134,7 +134,7 @@ config PWM_LED_ESP32_HS_CH4_TIMER
 endif # PWM_LED_ESP32_HS_CH4
 
 menuconfig PWM_LED_ESP32_HS_CH5
-	bool "Enable channel 5"
+	bool "Channel 5"
 	default y
 
 if PWM_LED_ESP32_HS_CH5
@@ -156,7 +156,7 @@ config PWM_LED_ESP32_HS_CH5_TIMER
 endif # PWM_LED_ESP32_HS_CH5
 
 menuconfig PWM_LED_ESP32_HS_CH6
-	bool "Enable channel 6"
+	bool "Channel 6"
 	default y
 
 if PWM_LED_ESP32_HS_CH6
@@ -178,7 +178,7 @@ config PWM_LED_ESP32_HS_CH6_TIMER
 endif # PWM_LED_ESP32_HS_CH6
 
 menuconfig PWM_LED_ESP32_HS_CH7
-	bool "Enable channel 7"
+	bool "Channel 7"
 	default y
 
 if PWM_LED_ESP32_HS_CH7
@@ -208,7 +208,7 @@ menuconfig PWM_LED_ESP32_LS_CH
 if PWM_LED_ESP32_LS_CH
 
 menuconfig PWM_LED_ESP32_LS_CH0
-	bool "Enable channel 0"
+	bool "Channel 0"
 	default y
 
 if PWM_LED_ESP32_LS_CH0
@@ -230,7 +230,7 @@ config PWM_LED_ESP32_LS_CH0_TIMER
 endif # PWM_LED_ESP32_LS_CH0
 
 menuconfig PWM_LED_ESP32_LS_CH1
-	bool "Enable channel 1"
+	bool "Channel 1"
 	default y
 
 if PWM_LED_ESP32_LS_CH1
@@ -252,7 +252,7 @@ config PWM_LED_ESP32_LS_CH1_TIMER
 endif # PWM_LED_ESP32_LS_CH1
 
 menuconfig PWM_LED_ESP32_LS_CH2
-	bool "Enable channel 2"
+	bool "Channel 2"
 	default y
 
 if PWM_LED_ESP32_LS_CH2
@@ -274,7 +274,7 @@ config PWM_LED_ESP32_LS_CH2_TIMER
 endif # PWM_LED_ESP32_LS_CH2
 
 menuconfig PWM_LED_ESP32_LS_CH3
-	bool "Enable channel 3"
+	bool "Channel 3"
 	default y
 
 if PWM_LED_ESP32_LS_CH3
@@ -296,7 +296,7 @@ config PWM_LED_ESP32_LS_CH3_TIMER
 endif # PWM_LED_ESP32_LS_CH3
 
 menuconfig PWM_LED_ESP32_LS_CH4
-	bool "Enable channel 4"
+	bool "Channel 4"
 	default y
 
 if PWM_LED_ESP32_LS_CH4
@@ -318,7 +318,7 @@ config PWM_LED_ESP32_LS_CH4_TIMER
 endif # PWM_LED_ESP32_LS_CH4
 
 menuconfig PWM_LED_ESP32_LS_CH5
-	bool "Enable channel 5"
+	bool "Channel 5"
 	default y
 
 if PWM_LED_ESP32_LS_CH5
@@ -340,7 +340,7 @@ config PWM_LED_ESP32_LS_CH5_TIMER
 endif # PWM_LED_ESP32_LS_CH5
 
 menuconfig PWM_LED_ESP32_LS_CH6
-	bool "Enable channel 6"
+	bool "Channel 6"
 	default y
 
 if PWM_LED_ESP32_LS_CH6
@@ -362,7 +362,7 @@ config PWM_LED_ESP32_LS_CH6_TIMER
 endif # PWM_LED_ESP32_LS_CH6
 
 menuconfig PWM_LED_ESP32_LS_CH7
-	bool "Enable channel 7"
+	bool "Channel 7"
 	default y
 
 if PWM_LED_ESP32_LS_CH7

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -21,7 +21,7 @@ config SENSOR_INIT_PRIORITY
 	  Sensor initialization priority.
 
 config SENSOR_SHELL
-	bool "Enable sensor shell"
+	bool "Sensor shell"
 	depends on SHELL
 	select CBPRINTF_FP_SUPPORT
 	default y if !SHELL_MINIMAL
@@ -29,7 +29,7 @@ config SENSOR_SHELL
 	  This shell provides access to basic sensor data.
 
 config SENSOR_SHELL_BATTERY
-	bool "Enable sensor shell 'battery' command"
+	bool "Sensor shell 'battery' command"
 	depends on SHELL
 	help
 	  This enables the 'battery' command which reports charging information

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -30,7 +30,7 @@ config APDS9960_TRIGGER
 	bool
 
 config APDS9960_ENABLE_ALS
-	bool "Enable Ambient Light Sense"
+	bool "Ambient Light Sense"
 	default y
 	help
 	  Enable Ambient Light Sense (ALS).

--- a/drivers/sensor/bmc150_magn/Kconfig
+++ b/drivers/sensor/bmc150_magn/Kconfig
@@ -35,24 +35,24 @@ config BMC150_MAGN_PRESET_HIGH_ACCURACY
 endchoice
 
 config BMC150_MAGN_SAMPLING_RATE_RUNTIME
-	bool "Enable dynamic sampling rate"
+	bool "Dynamic sampling rate"
 	help
 	  Enable alteration of sampling rate attribute at runtime.
 
 config BMC150_MAGN_SAMPLING_REP_XY
-	bool "Enable dynamic XY oversampling"
+	bool "Dynamic XY oversampling"
 	help
 	  Enable alteration of XY oversampling at runtime.
 
 config BMC150_MAGN_SAMPLING_REP_Z
-	bool "Enable dynamic Z oversampling"
+	bool "Dynamic Z oversampling"
 	help
 	  Enable alteration of Z oversampling at runtime.
 
 endmenu
 
 config BMC150_MAGN_TRIGGER
-	bool "Enable triggers"
+	bool "Triggers"
 	depends on GPIO
 	help
 	  Enable triggers for BMC150 magnetometer
@@ -65,7 +65,7 @@ config BMC150_MAGN_TRIGGER_THREAD_STACK
 	  Specify the internal thread stack size.
 
 config BMC150_MAGN_TRIGGER_DRDY
-	bool "Enable data ready trigger"
+	bool "Data ready trigger"
 	depends on BMC150_MAGN_TRIGGER
 	help
 	  Enable data ready interrupt for BMC150 magnetometer

--- a/drivers/sensor/bmm150/Kconfig
+++ b/drivers/sensor/bmm150/Kconfig
@@ -32,17 +32,17 @@ config BMM150_PRESET_HIGH_ACCURACY
 endchoice
 
 config BMM150_SAMPLING_RATE_RUNTIME
-	bool "Enable dynamic sampling rate"
+	bool "Dynamic sampling rate"
 	help
 	  Enable alteration of sampling rate attribute at runtime.
 
 config BMM150_SAMPLING_REP_XY
-	bool "Enable dynamic XY oversampling"
+	bool "Dynamic XY oversampling"
 	help
 	  Enable alteration of XY oversampling at runtime.
 
 config BMM150_SAMPLING_REP_Z
-	bool "Enable dynamic Z oversampling"
+	bool "Dynamic Z oversampling"
 	help
 	  Enable alteration of Z oversampling at runtime.
 

--- a/drivers/sensor/ens210/Kconfig
+++ b/drivers/sensor/ens210/Kconfig
@@ -18,9 +18,9 @@ choice
 config ENS210_TEMPERATURE_OFF
 	bool "Disable temperature measurements"
 config ENS210_TEMPERATURE_SINGLE
-	bool "Enable temperature measurements in single shot mode"
+	bool "Temperature measurements in single shot mode"
 config ENS210_TEMPERATURE_CONTINUOUS
-	bool "Enable temperature measurements in continuous mode"
+	bool "Temperature measurements in continuous mode"
 endchoice
 
 choice
@@ -31,13 +31,13 @@ choice
 config ENS210_HUMIDITY_OFF
 	bool "Disable relative humidity measurements"
 config ENS210_HUMIDITY_SINGLE
-	bool "Enable relative humidity measurements in single shot mode"
+	bool "Relative humidity measurements in single shot mode"
 config ENS210_HUMIDITY_CONTINUOUS
-	bool "Enable relative humidity measurements in continuous mode"
+	bool "Relative humidity measurements in continuous mode"
 endchoice
 
 config ENS210_CRC_CHECK
-	bool "Enable CRC Check"
+	bool "CRC Check"
 	default y
 	help
 	  Check the crc value after data reading.

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -30,7 +30,7 @@ config FXOS8700_MODE_HYBRID
 endchoice
 
 config FXOS8700_TEMP
-	bool "Enable temperature"
+	bool "Temperature"
 	depends on FXOS8700_MODE_MAGN || FXOS8700_MODE_HYBRID
 	help
 	  Enable the temperature sensor. Note that the temperature sensor is

--- a/drivers/sensor/grove/Kconfig
+++ b/drivers/sensor/grove/Kconfig
@@ -11,14 +11,14 @@ config GROVE_SENSORS
 if GROVE_SENSORS
 
 config GROVE_LIGHT_SENSOR
-	bool "Enable the Seeed Grove Light Sensor"
+	bool "The Seeed Grove Light Sensor"
 	depends on ADC && !MINIMAL_LIBC
 	help
 	  Setting this value will enable driver support for the Grove Light
 	  Sensor.
 
 config GROVE_TEMPERATURE_SENSOR
-	bool "Enable the Seeed Grove Temperature Sensor"
+	bool "The Seeed Grove Temperature Sensor"
 	depends on ADC && !MINIMAL_LIBC
 	help
 	  Setting this value will enable driver support for the Grove

--- a/drivers/sensor/iis2iclx/Kconfig
+++ b/drivers/sensor/iis2iclx/Kconfig
@@ -56,12 +56,12 @@ config IIS2ICLX_THREAD_STACK_SIZE
 endif # IIS2ICLX_TRIGGER
 
 config IIS2ICLX_ENABLE_TEMP
-	bool "Enable temperature"
+	bool "Temperature"
 	help
 	  Enable/disable temperature
 
 config IIS2ICLX_SENSORHUB
-	bool "Enable I2C sensorhub feature"
+	bool "I2C sensorhub feature"
 	help
 	  Enable/disable internal sensorhub. You can enable
 	  a maximum of two external sensors (if more than two are enabled
@@ -70,19 +70,19 @@ config IIS2ICLX_SENSORHUB
 if IIS2ICLX_SENSORHUB
 
 config IIS2ICLX_EXT_LIS2MDL
-	bool "Enable LIS2MDL as external sensor"
+	bool "LIS2MDL as external sensor"
 
 config IIS2ICLX_EXT_IIS2MDC
-	bool "Enable IIS2MDC as external sensor"
+	bool "IIS2MDC as external sensor"
 
 config IIS2ICLX_EXT_LPS22HH
-	bool "Enable LPS22HH as external sensor"
+	bool "LPS22HH as external sensor"
 
 config IIS2ICLX_EXT_HTS221
-	bool "Enable HTS221 as external sensor"
+	bool "HTS221 as external sensor"
 
 config IIS2ICLX_EXT_LPS22HB
-	bool "Enable LPS22HB as external sensor"
+	bool "LPS22HB as external sensor"
 
 endif # IIS2ICLX_SENSORHUB
 

--- a/drivers/sensor/iis3dhhc/Kconfig
+++ b/drivers/sensor/iis3dhhc/Kconfig
@@ -54,7 +54,7 @@ config IIS3DHHC_THREAD_STACK_SIZE
 menu "Attributes"
 
 config IIS3DHHC_NORM_MODE
-	bool "Enable Sensor at 1KHz"
+	bool "Sensor at 1KHz"
 	default y
 
 config IIS3DHHC_DRDY_INT1

--- a/drivers/sensor/ism330dhcx/Kconfig
+++ b/drivers/sensor/ism330dhcx/Kconfig
@@ -56,12 +56,12 @@ config ISM330DHCX_THREAD_STACK_SIZE
 endif # ISM330DHCX_TRIGGER
 
 config ISM330DHCX_ENABLE_TEMP
-	bool "Enable temperature"
+	bool "Temperature"
 	help
 	  Enable/disable temperature
 
 config ISM330DHCX_SENSORHUB
-	bool "Enable I2C sensorhub feature"
+	bool "I2C sensorhub feature"
 	help
 	  Enable/disable internal sensorhub. You can enable
 	  a maximum of two external sensors (if more than two are enabled
@@ -70,19 +70,19 @@ config ISM330DHCX_SENSORHUB
 if ISM330DHCX_SENSORHUB
 
 config ISM330DHCX_EXT_LIS2MDL
-	bool "Enable LIS2MDL as external sensor"
+	bool "LIS2MDL as external sensor"
 
 config ISM330DHCX_EXT_IIS2MDC
-	bool "Enable IIS2MDC as external sensor"
+	bool "IIS2MDC as external sensor"
 
 config ISM330DHCX_EXT_LPS22HH
-	bool "Enable LPS22HH as external sensor"
+	bool "LPS22HH as external sensor"
 
 config ISM330DHCX_EXT_HTS221
-	bool "Enable HTS221 as external sensor"
+	bool "HTS221 as external sensor"
 
 config ISM330DHCX_EXT_LPS22HB
-	bool "Enable LPS22HB as external sensor"
+	bool "LPS22HB as external sensor"
 
 endif # ISM330DHCX_SENSORHUB
 

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -142,7 +142,7 @@ config LIS2DH_BLOCK_DATA_UPDATE
 	bool "Output registers not updated until MSB and LSB read"
 
 config LIS2DH_MEASURE_TEMPERATURE
-	bool "Enable temperature measurements"
+	bool "Temperature measurements"
 	select LIS2DH_BLOCK_DATA_UPDATE
 	help
 	  The temperature sensor is most suitable for measuring

--- a/drivers/sensor/lis2ds12/Kconfig
+++ b/drivers/sensor/lis2ds12/Kconfig
@@ -51,7 +51,7 @@ config LIS2DS12_THREAD_STACK_SIZE
 	  Stack size of thread used by the driver to handle interrupts.
 
 config LIS2DS12_ENABLE_TEMP
-	bool "Enable temperature"
+	bool "Temperature"
 	help
 	  Enable/disable temperature
 

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -14,49 +14,49 @@ menuconfig LSM6DS0
 if LSM6DS0
 
 config LSM6DS0_ACCEL_ENABLE_X_AXIS
-	bool "Enable accelerometer X axis"
+	bool "Accelerometer X axis"
 	default y
 	help
 	  Enable/disable accelerometer X axis totally by stripping everything
 	  related in driver.
 
 config LSM6DS0_ACCEL_ENABLE_Y_AXIS
-	bool "Enable accelerometer Y axis"
+	bool "Accelerometer Y axis"
 	default y
 	help
 	  Enable/disable accelerometer Y axis totally by stripping everything
 	  related in driver.
 
 config LSM6DS0_ACCEL_ENABLE_Z_AXIS
-	bool "Enable accelerometer Z axis"
+	bool "Accelerometer Z axis"
 	default y
 	help
 	  Enable/disable accelerometer Z axis totally by stripping everything
 	  related in driver.
 
 config LSM6DS0_GYRO_ENABLE_X_AXIS
-	bool "Enable gyroscope X axis"
+	bool "Gyroscope X axis"
 	default y
 	help
 	  Enable/disable gyroscope X axis totally by stripping everything
 	  related in driver.
 
 config LSM6DS0_GYRO_ENABLE_Y_AXIS
-	bool "Enable gyroscope Y axis"
+	bool "Gyroscope Y axis"
 	default y
 	help
 	  Enable/disable gyroscope Y axis totally by stripping everything
 	  related in driver.
 
 config LSM6DS0_GYRO_ENABLE_Z_AXIS
-	bool "Enable gyroscope Z axis"
+	bool "Gyroscope Z axis"
 	default y
 	help
 	  Enable/disable gyroscope Z axis totally by stripping everything
 	  related in driver.
 
 config LSM6DS0_ENABLE_TEMP
-	bool "Enable temperature"
+	bool "Temperature"
 	help
 	  Enable/disable temperature totally by stripping everything related in
 	  driver.

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -51,12 +51,12 @@ config LSM6DSL_THREAD_STACK_SIZE
 	  Stack size of thread used by the driver to handle interrupts.
 
 config LSM6DSL_ENABLE_TEMP
-	bool "Enable temperature"
+	bool "Temperature"
 	help
 	  Enable/disable temperature
 
 config LSM6DSL_SENSORHUB
-	bool "Enable I2C sensorhub feature"
+	bool "I2C sensorhub feature"
 	help
 	  Enable/disable internal sensorhub
 

--- a/drivers/sensor/lsm6dso/Kconfig
+++ b/drivers/sensor/lsm6dso/Kconfig
@@ -56,12 +56,12 @@ config LSM6DSO_THREAD_STACK_SIZE
 endif # LSM6DSO_TRIGGER
 
 config LSM6DSO_ENABLE_TEMP
-	bool "Enable temperature"
+	bool "Temperature"
 	help
 	  Enable/disable temperature
 
 config LSM6DSO_SENSORHUB
-	bool "Enable I2C sensorhub feature"
+	bool "I2C sensorhub feature"
 	help
 	  Enable/disable internal sensorhub. You can enable
 	  a maximum of two external sensors (if more than two are enabled
@@ -70,18 +70,18 @@ config LSM6DSO_SENSORHUB
 if LSM6DSO_SENSORHUB
 
 config LSM6DSO_EXT_LIS2MDL
-	bool "Enable LIS2MDL as external sensor"
+	bool "LIS2MDL as external sensor"
 	default y
 
 config LSM6DSO_EXT_LPS22HH
-	bool "Enable LPS22HH as external sensor"
+	bool "LPS22HH as external sensor"
 	default y
 
 config LSM6DSO_EXT_HTS221
-	bool "Enable HTS221 as external sensor"
+	bool "HTS221 as external sensor"
 
 config LSM6DSO_EXT_LPS22HB
-	bool "Enable LPS22HB as external sensor"
+	bool "LPS22HB as external sensor"
 
 endif # LSM6DSO_SENSORHUB
 

--- a/drivers/sensor/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/lsm9ds0_gyro/Kconfig
@@ -31,7 +31,7 @@ config LSM9DS0_GYRO_FULLSCALE_2000
 endchoice
 
 config LSM9DS0_GYRO_FULLSCALE_RUNTIME
-	bool "Enable dynamic full-scale"
+	bool "Dynamic full-scale"
 	help
 	  Enable alteration of full-scale attribute at runtime.
 
@@ -56,14 +56,14 @@ config LSM9DS0_GYRO_SAMPLING_RATE_760
 endchoice
 
 config LSM9DS0_GYRO_SAMPLING_RATE_RUNTIME
-	bool "Enable dynamic sampling rate"
+	bool "Dynamic sampling rate"
 	help
 	  Enable alteration of sampling rate frequency at runtime.
 
 endmenu
 
 config LSM9DS0_GYRO_TRIGGERS
-	bool "Enable triggers"
+	bool "Triggers"
 	depends on GPIO
 
 config LSM9DS0_GYRO_THREAD_STACK_SIZE
@@ -74,7 +74,7 @@ config LSM9DS0_GYRO_THREAD_STACK_SIZE
 	  Specify the internal thread stack size.
 
 config LSM9DS0_GYRO_TRIGGER_DRDY
-	bool "Enable data ready trigger"
+	bool "Data ready trigger"
 	depends on LSM9DS0_GYRO_TRIGGERS
 
 endif # LSM9DS0_GYRO

--- a/drivers/sensor/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/lsm9ds0_mfd/Kconfig
@@ -12,21 +12,21 @@ menuconfig LSM9DS0_MFD
 if LSM9DS0_MFD
 
 config LSM9DS0_MFD_ACCEL_ENABLE
-	bool "Enable accelerometer"
+	bool "Accelerometer"
 	default y
 	help
 	  Enable/disable accelerometer totally by stripping everything related
 	  in driver.
 
 config LSM9DS0_MFD_MAGN_ENABLE
-	bool "Enable magnetometer"
+	bool "Magnetometer"
 	default y
 	help
 	  Enable/disable magnetometer totally by stripping everything related in
 	  driver.
 
 config LSM9DS0_MFD_TEMP_ENABLE
-	bool "Enable temperature sensor"
+	bool "Temperature sensor"
 	help
 	  Enable/disable temperature sensor totally by stripping everything
 	  related in driver.
@@ -76,7 +76,7 @@ config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_1600
 endchoice
 
 config LSM9DS0_MFD_ACCEL_SAMPLING_RATE_RUNTIME
-	bool "Enable dynamic sampling rate for accelerometer"
+	bool "Dynamic sampling rate for accelerometer"
 	depends on LSM9DS0_MFD_ACCEL_ENABLE
 	help
 	  Enable alteration of accelerometer sampling rate attribute at
@@ -107,24 +107,24 @@ config LSM9DS0_MFD_ACCEL_FULL_SCALE_16
 endchoice
 
 config LSM9DS0_MFD_ACCEL_FULL_SCALE_RUNTIME
-	bool "Enable dynamic full-scale for accelerometer"
+	bool "Dynamic full-scale for accelerometer"
 	depends on LSM9DS0_MFD_ACCEL_ENABLE
 	help
 	  Enable alteration of accelerometer full-scale attribute at
 	  runtime.
 
 config LSM9DS0_MFD_ACCEL_ENABLE_X
-	bool "Enable accelerometer X axis"
+	bool "Accelerometer X axis"
 	depends on LSM9DS0_MFD_ACCEL_ENABLE
 	default y
 
 config LSM9DS0_MFD_ACCEL_ENABLE_Y
-	bool "Enable accelerometer Y axis"
+	bool "Accelerometer Y axis"
 	depends on LSM9DS0_MFD_ACCEL_ENABLE
 	default y
 
 config LSM9DS0_MFD_ACCEL_ENABLE_Z
-	bool "Enable accelerometer Z axis"
+	bool "Accelerometer Z axis"
 	depends on LSM9DS0_MFD_ACCEL_ENABLE
 	default y
 
@@ -156,7 +156,7 @@ config LSM9DS0_MFD_MAGN_SAMPLING_RATE_100
 endchoice
 
 config LSM9DS0_MFD_MAGN_SAMPLING_RATE_RUNTIME
-	bool "Enable dynamic sampling rate for magnetometer"
+	bool "Dynamic sampling rate for magnetometer"
 	depends on LSM9DS0_MFD_MAGN_ENABLE
 	help
 	  Enable alteration of magnetometer sampling rate attribute at
@@ -184,7 +184,7 @@ config LSM9DS0_MFD_MAGN_FULL_SCALE_12
 endchoice
 
 config LSM9DS0_MFD_MAGN_FULL_SCALE_RUNTIME
-	bool "Enable dynamic full-scale for magnetometer"
+	bool "Dynamic full-scale for magnetometer"
 	depends on LSM9DS0_MFD_MAGN_ENABLE
 	help
 	  Enable alteration of magnetometer full-scale attribute at

--- a/drivers/sensor/nxp_kinetis_temp/Kconfig
+++ b/drivers/sensor/nxp_kinetis_temp/Kconfig
@@ -29,7 +29,7 @@ config TEMP_KINETIS_OVERSAMPLING
 	  more stable readings.
 
 config TEMP_KINETIS_FILTER
-	bool "Enable digital filtering of ADC readings"
+	bool "Digital filtering of ADC readings"
 	help
 	  Enable weighted average digital filtering of the ADC
 	  readings as per NXP AN3031.

--- a/drivers/sensor/vcnl4040/Kconfig
+++ b/drivers/sensor/vcnl4040/Kconfig
@@ -12,7 +12,7 @@ menuconfig VCNL4040
 if VCNL4040
 
 config VCNL4040_ENABLE_ALS
-	bool "Enable ambient light sensor"
+	bool "Ambient light sensor"
 	help
 	  Enable Ambient Light Sense (ALS).
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -45,7 +45,7 @@ config SERIAL_SUPPORT_WIDE_DATA
 	  than 8-bit.
 
 config UART_USE_RUNTIME_CONFIGURE
-	bool "Enable runtime configuration for UART controllers"
+	bool "Runtime configuration for UART controllers"
 	default y
 	help
 	  Enable runtime configuration of UART controllers.
@@ -60,20 +60,20 @@ config UART_USE_RUNTIME_CONFIGURE
 	  applications that do not require runtime UART configuration.
 
 config UART_ASYNC_API
-	bool "Enable asynchronous UART API"
+	bool "Asynchronous UART API"
 	depends on SERIAL_SUPPORT_ASYNC
 	help
 	  This option enables asynchronous UART API.
 
 config UART_INTERRUPT_DRIVEN
-	bool "Enable UART Interrupt support"
+	bool "UART Interrupt support"
 	depends on SERIAL_SUPPORT_INTERRUPT
 	help
 	  This option enables interrupt support for UART allowing console
 	  input and other UART based drivers.
 
 config UART_LINE_CTRL
-	bool "Enable Serial Line Control API"
+	bool "Serial Line Control API"
 	help
 	  This enables the API for apps to control the serial line,
 	  such as baud rate, CTS and RTS.
@@ -83,7 +83,7 @@ config UART_LINE_CTRL
 	  Says no if not sure.
 
 config UART_DRV_CMD
-	bool "Enable driver commands API"
+	bool "Driver commands API"
 	help
 	  This enables the API to send extra commands to drivers.
 	  This allows drivers to expose hardware specific functions.
@@ -91,7 +91,7 @@ config UART_DRV_CMD
 	  Says no if not sure.
 
 config UART_WIDE_DATA
-	bool "Enable API to support data longer than 8-bit"
+	bool "API to support data longer than 8-bit"
 	help
 	  This enables the API to process data longer than 8-bit.
 	  This is up to the driver to implement the necessary functions

--- a/drivers/serial/Kconfig.native_posix
+++ b/drivers/serial/Kconfig.native_posix
@@ -50,7 +50,7 @@ config UART_NATIVE_WAIT_PTS_READY_ENABLE
 	  Otherwise writes are sent irrespectively.
 
 config UART_NATIVE_POSIX_PORT_1_ENABLE
-	bool "Enable second UART port"
+	bool "Second UART port"
 	help
 	  Useful if you need to have another serial connection to host.
 	  This is used for example in PPP (Point-to-Point Protocol)

--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -55,21 +55,21 @@ config UART_0_ENHANCED_POLL_OUT
 	  Feature uses a PPI channel.
 
 config UART_0_INTERRUPT_DRIVEN
-	bool "Enable interrupt support on port 0"
+	bool "Interrupt support on port 0"
 	depends on UART_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART interrupt support on port 0.
 
 config UART_0_ASYNC
-	bool "Enable Asynchronous API support on port 0"
+	bool "Asynchronous API support on port 0"
 	depends on UART_ASYNC_API && !UART_0_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART Asynchronous API support on port 0.
 
 config UART_0_NRF_PARITY_BIT
-	bool "Enable parity bit"
+	bool "Parity bit"
 	help
 	  Enable parity bit.
 
@@ -107,7 +107,7 @@ config UART_0_NRF_HW_ASYNC_TIMER
 	depends on UART_0_NRF_HW_ASYNC
 
 config UART_0_GPIO_MANAGEMENT
-	bool "Enable GPIO management on port 0"
+	bool "GPIO management on port 0"
 	depends on PM_DEVICE
 	default y
 	help
@@ -127,14 +127,14 @@ config UART_1_NRF_UARTE
 if UART_1_NRF_UARTE
 
 config UART_1_INTERRUPT_DRIVEN
-	bool "Enable interrupt support on port 1"
+	bool "Interrupt support on port 1"
 	depends on UART_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART interrupt support on port 1.
 
 config UART_1_ASYNC
-	bool "Enable Asynchronous API support on port 1"
+	bool "Asynchronous API support on port 1"
 	depends on UART_ASYNC_API && !UART_1_INTERRUPT_DRIVEN
 	default y
 	help
@@ -148,7 +148,7 @@ config UART_1_ENHANCED_POLL_OUT
 	  Feature uses a PPI channel.
 
 config UART_1_NRF_PARITY_BIT
-	bool "Enable parity bit"
+	bool "Parity bit"
 	help
 	  Enable parity bit.
 
@@ -184,7 +184,7 @@ config UART_1_NRF_HW_ASYNC_TIMER
 	depends on UART_1_NRF_HW_ASYNC
 
 config UART_1_GPIO_MANAGEMENT
-	bool "Enable GPIO management on port 1"
+	bool "GPIO management on port 1"
 	depends on PM_DEVICE
 	default y
 	help
@@ -204,14 +204,14 @@ config UART_2_NRF_UARTE
 if UART_2_NRF_UARTE
 
 config UART_2_INTERRUPT_DRIVEN
-	bool "Enable interrupt support on port 2"
+	bool "Interrupt support on port 2"
 	depends on UART_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART interrupt support on port 2.
 
 config UART_2_ASYNC
-	bool "Enable Asynchronous API support on port 2"
+	bool "Asynchronous API support on port 2"
 	depends on UART_ASYNC_API && !UART_2_INTERRUPT_DRIVEN
 	default y
 	help
@@ -225,7 +225,7 @@ config UART_2_ENHANCED_POLL_OUT
 	  Feature uses a PPI channel.
 
 config UART_2_NRF_PARITY_BIT
-	bool "Enable parity bit"
+	bool "Parity bit"
 	help
 	  Enable parity bit.
 
@@ -260,7 +260,7 @@ config UART_2_NRF_HW_ASYNC_TIMER
 	depends on UART_2_NRF_HW_ASYNC
 
 config UART_2_GPIO_MANAGEMENT
-	bool "Enable GPIO management on port 2"
+	bool "GPIO management on port 2"
 	depends on PM_DEVICE
 	default y
 	help
@@ -280,14 +280,14 @@ config UART_3_NRF_UARTE
 if UART_3_NRF_UARTE
 
 config UART_3_INTERRUPT_DRIVEN
-	bool "Enable interrupt support on port 3"
+	bool "Interrupt support on port 3"
 	depends on UART_INTERRUPT_DRIVEN
 	default y
 	help
 	  This option enables UART interrupt support on port 3.
 
 config UART_3_ASYNC
-	bool "Enable Asynchronous API support on port 3"
+	bool "Asynchronous API support on port 3"
 	depends on UART_ASYNC_API && !UART_3_INTERRUPT_DRIVEN
 	default y
 	help
@@ -301,7 +301,7 @@ config UART_3_ENHANCED_POLL_OUT
 	  Feature uses a PPI channel.
 
 config UART_3_NRF_PARITY_BIT
-	bool "Enable parity bit"
+	bool "Parity bit"
 	help
 	  Enable parity bit.
 
@@ -336,7 +336,7 @@ config UART_3_NRF_HW_ASYNC_TIMER
 	depends on UART_3_NRF_HW_ASYNC
 
 config UART_3_GPIO_MANAGEMENT
-	bool "Enable GPIO management on port 3"
+	bool "GPIO management on port 3"
 	depends on PM_DEVICE
 	default y
 	help

--- a/drivers/serial/Kconfig.ns16550
+++ b/drivers/serial/Kconfig.ns16550
@@ -12,7 +12,7 @@ menuconfig UART_NS16550
 if UART_NS16550
 
 config UART_NS16550_LINE_CTRL
-	bool "Enable Serial Line Control for Apps"
+	bool "Serial Line Control for Apps"
 	depends on UART_LINE_CTRL
 	help
 	  This enables the API for apps to control the serial line,
@@ -21,7 +21,7 @@ config UART_NS16550_LINE_CTRL
 	  Says n if not sure.
 
 config UART_NS16550_DRV_CMD
-	bool "Enable Driver Commands"
+	bool "Driver Commands"
 	depends on UART_DRV_CMD
 	help
 	  This enables the API for apps to send commands to driver.
@@ -29,7 +29,7 @@ config UART_NS16550_DRV_CMD
 	  Says n if not sure.
 
 config UART_NS16750
-	bool "Enable UART 16750 (64-bytes FIFO and auto flow control)"
+	bool "UART 16750 (64-bytes FIFO and auto flow control)"
 	help
 	  This enables support for 64-bytes FIFO and automatic hardware
 	  flow control if UART controller is 16750.

--- a/drivers/serial/Kconfig.pl011
+++ b/drivers/serial/Kconfig.pl011
@@ -11,17 +11,17 @@ menuconfig UART_PL011
 if UART_PL011
 
 config UART_PL011_PORT0
-	bool "Enable driver for UART 0"
+	bool "Driver for UART 0"
 	help
 	  Build the driver to utilize UART controller Port 0.
 
 config UART_PL011_PORT1
-	bool "Enable driver for UART 1"
+	bool "Driver for UART 1"
 	help
 	  Build the driver to utilize UART controller Port 1.
 
 config UART_PL011_SBSA
-	bool "Enable SBSA UART"
+	bool "SBSA UART"
 	help
 	  Enable SBSA mode for PL011 driver. SBSA stands for
 	  Server Based System Architecture. This specification

--- a/drivers/serial/Kconfig.rtt
+++ b/drivers/serial/Kconfig.rtt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig UART_RTT
-	bool "Enable UART RTT driver"
+	bool "UART RTT driver"
 	depends on USE_SEGGER_RTT
 	select SEGGER_RTT_CUSTOM_LOCKING
 	help

--- a/drivers/serial/Kconfig.sifive
+++ b/drivers/serial/Kconfig.sifive
@@ -14,7 +14,7 @@ menuconfig UART_SIFIVE
 # ---------- Port 0 ----------
 
 menuconfig UART_SIFIVE_PORT_0
-	bool "Enable SIFIVE Port 0"
+	bool "SIFIVE Port 0"
 	depends on UART_SIFIVE
 	help
 	  This tells the driver to configure the UART port at boot, depending on
@@ -37,7 +37,7 @@ config UART_SIFIVE_PORT_0_TXCNT_IRQ
 # ---------- Port 1 ----------
 
 menuconfig UART_SIFIVE_PORT_1
-	bool "Enable SIFIVE Port 1"
+	bool "SIFIVE Port 1"
 	depends on UART_SIFIVE
 	help
 	  This tells the driver to configure the UART port at boot, depending on

--- a/drivers/serial/Kconfig.stellaris
+++ b/drivers/serial/Kconfig.stellaris
@@ -15,7 +15,7 @@ if UART_STELLARIS
 # ---------- Port 0 ----------
 
 config UART_STELLARIS_PORT_0
-	bool "Enable Stellaris UART Port 0"
+	bool "Stellaris UART Port 0"
 	help
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.
@@ -23,7 +23,7 @@ config UART_STELLARIS_PORT_0
 # ---------- Port 1 ----------
 
 config UART_STELLARIS_PORT_1
-	bool "Enable Stellaris UART Port 1"
+	bool "Stellaris UART Port 1"
 	help
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.
@@ -31,7 +31,7 @@ config UART_STELLARIS_PORT_1
 # ---------- Port 2 ----------
 
 config UART_STELLARIS_PORT_2
-	bool "Enable Stellaris UART Port 2"
+	bool "Stellaris UART Port 2"
 	help
 	  This tells the driver to configure the UART port at boot, depending on
 	  the additional configure options below.

--- a/drivers/serial/Kconfig.xec
+++ b/drivers/serial/Kconfig.xec
@@ -14,7 +14,7 @@ config UART_XEC
 if UART_XEC
 
 config UART_XEC_LINE_CTRL
-	bool "Enable Serial Line Control for Apps"
+	bool "Serial Line Control for Apps"
 	depends on UART_LINE_CTRL
 	help
 	  This enables the API for apps to control the serial line,

--- a/drivers/spi/Kconfig
+++ b/drivers/spi/Kconfig
@@ -14,20 +14,20 @@ menuconfig SPI
 if SPI
 
 config SPI_ASYNC
-	bool "Enable Asynchronous call support"
+	bool "Asynchronous call support"
 	select POLL
 	help
 	  This option enables the asynchronous API calls.
 
 config SPI_SLAVE
-	bool "Enable Slave support [EXPERIMENTAL]"
+	bool "Slave support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Enables Driver SPI slave operations. Slave support depends
 	  on the driver and the hardware it runs on.
 
 config SPI_EXTENDED_MODES
-	bool "Enable extended modes [EXPERIMENTAL]"
+	bool "Extended modes [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Enables extended operations in the SPI API. Currently, this

--- a/drivers/usb/device/Kconfig
+++ b/drivers/usb/device/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig USB_DEVICE_DRIVER
-	bool "Enable USB device controller drivers"
+	bool "USB device controller drivers"
 	help
 	  Enable USB device controller drivers.
 
@@ -16,7 +16,7 @@ config USB_DC_HAS_HS_SUPPORT
 	  USB device controller supports high speed.
 
 config USB_DEVICE_REMOTE_WAKEUP
-	bool "Enable remote wakeup support"
+	bool "Remote wakeup support"
 	help
 	  USB device controller supports remote wakeup feature.
 

--- a/drivers/virtualization/Kconfig
+++ b/drivers/virtualization/Kconfig
@@ -55,7 +55,7 @@ config IVSHMEM_INT_PRIORITY
 	  Interrupt priority used for the MSI-X generated interrupts.
 
 config IVSHMEM_SHELL
-	bool "Enable IVshmem shell module"
+	bool "IVshmem shell module"
 	depends on SHELL
 	help
 	  This is mostly a module to help getting info the ivshmem and/or

--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -25,7 +25,7 @@ config HAS_WDT_MULTISTAGE
 	bool
 
 config WDT_MULTISTAGE
-	bool "Enable multistage timeouts"
+	bool "Multistage timeouts"
 	depends on HAS_WDT_MULTISTAGE
 	help
 	  Enable multistage operation of watchdog timeouts.

--- a/drivers/watchdog/Kconfig.nrfx
+++ b/drivers/watchdog/Kconfig.nrfx
@@ -12,14 +12,14 @@ config WDT_NRFX
 	  Enable support for nrfx WDT driver for nRF MCU series.
 
 config NRFX_WDT0
-	bool "Enable WDT0 instance"
+	bool "WDT0 instance"
 	depends on HAS_HW_NRF_WDT || HAS_HW_NRF_WDT0
 	default y
 	help
 	  Enable support for nrfx WDT instance 0.
 
 config NRFX_WDT1
-	bool "Enable WDT1 instance"
+	bool "WDT1 instance"
 	depends on HAS_HW_NRF_WDT1
 	help
 	  Enable support for nrfx WDT instance 1.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -110,7 +110,7 @@ config NUM_METAIRQ_PRIORITIES
 	  from application code.
 
 config SCHED_DEADLINE
-	bool "Enable earliest-deadline-first scheduling"
+	bool "Earliest-deadline-first scheduling"
 	help
 	  This enables a simple "earliest deadline first" scheduling
 	  mode where threads can set "deadline" deltas measured in
@@ -119,7 +119,7 @@ config SCHED_DEADLINE
 	  not simply the least recently added thread.
 
 config SCHED_CPU_MASK
-	bool "Enable CPU mask affinity/pinning API"
+	bool "CPU mask affinity/pinning API"
 	depends on SCHED_DUMB
 	help
 	  When true, the application will have access to the
@@ -203,7 +203,7 @@ config THREAD_USERSPACE_LOCAL_DATA
 	default y if ERRNO && !ERRNO_IN_TLS
 
 config ERRNO
-	bool "Enable errno support"
+	bool "Errno support"
 	default y
 	help
 	  Enable per-thread errno in the kernel. Application and library code must
@@ -513,7 +513,7 @@ endmenu
 menu "Other Kernel Object Options"
 
 config MEM_SLAB_TRACE_MAX_UTILIZATION
-	bool "Enable getting maximum slab utilization"
+	bool "Getting maximum slab utilization"
 	help
 	  This adds variable to the k_mem_slab structure to hold
 	  maximum utilization of the slab.
@@ -530,7 +530,7 @@ config NUM_MBOX_ASYNC_MSGS
 	  mailbox messages.
 
 config EVENTS
-	bool "Enable event objects"
+	bool "Event objects"
 	help
 	  This option enables event objects. Threads may wait on event
 	  objects for specific events, but both threads and ISRs may deliver
@@ -718,7 +718,7 @@ config STACK_CANARIES
 	  will occur at build time.
 
 config EXECUTE_XOR_WRITE
-	bool "Enable W^X for memory partitions"
+	bool "W^X for memory partitions"
 	depends on USERSPACE
 	depends on ARCH_HAS_EXECUTABLE_PAGE_BIT
 	default y
@@ -752,7 +752,7 @@ config STACK_POINTER_RANDOM
 	  grow towards lower memory addresses.
 
 config BOUNDS_CHECK_BYPASS_MITIGATION
-	bool "Enable bounds check bypass mitigations for speculative execution"
+	bool "Bounds check bypass mitigations for speculative execution"
 	depends on USERSPACE
 	help
 	  Untrusted parameters from user mode may be used in system calls to
@@ -834,7 +834,7 @@ config USE_SWITCH_SUPPORTED
 	  platforms that implement it.
 
 config SMP
-	bool "Enable symmetric multithreading support"
+	bool "Symmetric multithreading support"
 	depends on USE_SWITCH
 	help
 	  When true, kernel will be built with SMP support, allowing
@@ -868,7 +868,7 @@ config SCHED_IPI_SUPPORTED
 	  future).
 
 config TRACE_SCHED_IPI
-	bool "Enable Test IPI"
+	bool "Test IPI"
 	help
 	  When true, it will add a hook into z_sched_ipi(), in order
 	  to check if schedule IPI has called or not, for testing

--- a/kernel/Kconfig.vm
+++ b/kernel/Kconfig.vm
@@ -83,7 +83,7 @@ config KERNEL_VM_SIZE
 endif # KERNEL_VM_SUPPORT
 
 menuconfig MMU
-	bool "Enable MMU features"
+	bool "MMU features"
 	depends on CPU_HAS_MMU
 	select KERNEL_VM_SUPPORT
 	help
@@ -99,7 +99,7 @@ config MMU_PAGE_SIZE
 	  support multiple page sizes, put the smallest one here.
 
 menuconfig DEMAND_PAGING
-	bool "Enable demand paging [EXPERIMENTAL]"
+	bool "Demand paging [EXPERIMENTAL]"
 	depends on ARCH_HAS_DEMAND_PAGING
 	help
 	  Enable demand paging. Requires architecture support in how the kernel

--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -122,7 +122,7 @@ endif # NEWLIB_LIBC
 if MINIMAL_LIBC
 
 config MINIMAL_LIBC_MALLOC
-	bool "Enable minimal libc malloc implementation"
+	bool "Minimal libc malloc implementation"
 	default y
 	help
 	  Enable the minimal libc's implementation of malloc, free, and realloc.
@@ -137,14 +137,14 @@ config MINIMAL_LIBC_MALLOC_ARENA_SIZE
 	  minimal libc's malloc() implementation.
 
 config MINIMAL_LIBC_CALLOC
-	bool "Enable minimal libc trivial calloc implementation"
+	bool "Minimal libc trivial calloc implementation"
 	default y
 	help
 	  Enable the minimal libc's trivial implementation of calloc, which
 	  forwards to malloc and memset.
 
 config MINIMAL_LIBC_REALLOCARRAY
-	bool "Enable minimal libc trivial reallocarray implementation"
+	bool "Minimal libc trivial reallocarray implementation"
 	default y
 	help
 	  Enable the minimal libc's trivial implementation of reallocarray, which
@@ -165,7 +165,7 @@ config MINIMAL_LIBC_OPTIMIZE_STRING_FOR_SIZE
 	  memset. On the Cortex-M0+ this reduces the total code size by 120 bytes.
 
 config MINIMAL_LIBC_RAND
-	bool "Enables rand and srand functions"
+	bool "Rand and srand functions"
 	select NEED_LIBC_MEM_PARTITION
 	help
 	  Enable rand() and srand() for the minimal libc. The

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -10,14 +10,14 @@ config JSON_LIBRARY
 	  applications such as the NATS client.
 
 config RING_BUFFER
-	bool "Enable ring buffers"
+	bool "Ring buffers"
 	help
 	  Enable usage of ring buffers. This is similar to kernel FIFOs but ring
 	  buffers manage their own buffer memory and can store arbitrary data.
 	  For optimal performance, use buffer sizes that are a power of 2.
 
 config BASE64
-	bool "Enable base64 encoding and decoding"
+	bool "Base64 encoding and decoding"
 	help
 	  Enable base64 encoding and decoding functionality
 

--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -61,7 +61,7 @@ endchoice
 
 # 02: 82% / 1530 B (02 / 00)
 config CBPRINTF_FP_SUPPORT
-	bool "Enable floating point formatting in cbprintf"
+	bool "Floating point formatting in cbprintf"
 	default y if FPU
 	depends on CBPRINTF_COMPLETE
 	help
@@ -71,7 +71,7 @@ config CBPRINTF_FP_SUPPORT
 
 # 04: 13% / 456 B (07 / 03)
 config CBPRINTF_FP_A_SUPPORT
-	bool "Enable floating point %a conversions"
+	bool "Floating point %a conversions"
 	depends on CBPRINTF_FULL_INTEGRAL
 	select CBPRINTF_FP_SUPPORT
 	help

--- a/lib/os/Kconfig.heap
+++ b/lib/os/Kconfig.heap
@@ -5,7 +5,7 @@
 menu "Heap and Memory Allocation"
 
 config SYS_HEAP_VALIDATE
-	bool "Enable internal heap validity checking"
+	bool "Internal heap validity checking"
 	help
 	  The sys_heap implementation is instrumented for extensive
 	  internal validation.  Leave this off by default, unless
@@ -35,7 +35,7 @@ config SYS_HEAP_RUNTIME_STATS
 	  Gather system heap runtime statistics.
 
 config SYS_HEAP_LISTENER
-	bool "Enable sys_heap event notifications"
+	bool "Sys_heap event notifications"
 	select HEAP_LISTENER
 	help
 	  This allows application to listen for sys_heap events,
@@ -118,7 +118,7 @@ config SYS_MEM_BLOCKS
 	     powered down to conserve energy.
 
 config SYS_MEM_BLOCKS_LISTENER
-	bool "Enable Memory Blocks Allocator event notifications"
+	bool "Memory Blocks Allocator event notifications"
 	depends on SYS_MEM_BLOCKS
 	select HEAP_LISTENER
 	help

--- a/lib/os/Kconfig.heap
+++ b/lib/os/Kconfig.heap
@@ -35,7 +35,7 @@ config SYS_HEAP_RUNTIME_STATS
 	  Gather system heap runtime statistics.
 
 config SYS_HEAP_LISTENER
-	bool "Sys_heap event notifications"
+	bool "sys_heap event notifications"
 	select HEAP_LISTENER
 	help
 	  This allows application to listen for sys_heap events,

--- a/lib/posix/Kconfig
+++ b/lib/posix/Kconfig
@@ -58,7 +58,7 @@ config MAX_TIMER_COUNT
 	  Mention maximum number of timers in POSIX compliant application.
 
 config POSIX_MQUEUE
-	bool "Enable POSIX message queue"
+	bool "POSIX message queue"
 	default y if POSIX_API
 	help
 	  This enabled POSIX message queue related APIs.
@@ -87,7 +87,7 @@ config MQUEUE_NAMELEN_MAX
 endif
 
 config POSIX_FS
-	bool "Enable POSIX file system API support"
+	bool "POSIX file system API support"
 	default y if POSIX_API
 	depends on FILE_SYSTEM
 	help
@@ -111,7 +111,7 @@ config APP_LINK_WITH_POSIX_SUBSYS
 	  Add POSIX subsystem header files to the 'app' include path.
 
 config EVENTFD
-	bool "Enable support for eventfd"
+	bool "Support for eventfd"
 	depends on !ARCH_POSIX
 	help
 	  Enable support for event file descriptors, eventfd. An eventfd can

--- a/lib/smf/Kconfig
+++ b/lib/smf/Kconfig
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config SMF
-	bool "Enable Hierarchical State Machine"
+	bool "Hierarchical State Machine"
 	help
 	  This option enables the Hierarchical State Machine library
 
 if SMF
 
 config SMF_ANCESTOR_SUPPORT
-	bool "Enable states to have 1 or more ancestors"
+	bool "States to have 1 or more ancestors"
 	help
 	   If y, then the state machine framework includes ancestor state support
 

--- a/modules/Kconfig.mcuboot_bootutil
+++ b/modules/Kconfig.mcuboot_bootutil
@@ -22,7 +22,7 @@ source "subsys/logging/Kconfig.template.log_config"
 endif
 
 config BOOT_IMAGE_ACCESS_HOOKS
-	bool "Enable hooks for overriding MCUboot's bootutil native routines"
+	bool "Hooks for overriding MCUboot's bootutil native routines"
 	help
 	  Allow to provide procedures for override or extend native
 	  MCUboot's routines required for access the image data.

--- a/modules/hal_nordic/Kconfig
+++ b/modules/hal_nordic/Kconfig
@@ -19,7 +19,7 @@ config NRF_802154_SOURCE_HAL_NORDIC
 endchoice
 
 menuconfig NRF_802154_RADIO_DRIVER
-	bool "Enable nRF IEEE 802.15.4 radio driver"
+	bool "NRF IEEE 802.15.4 radio driver"
 	depends on HAS_HW_NRF_RADIO_IEEE802154
 	select DYNAMIC_INTERRUPTS
 	select ENTROPY_GENERATOR

--- a/modules/hal_nordic/nrfx/Kconfig
+++ b/modules/hal_nordic/nrfx/Kconfig
@@ -8,62 +8,62 @@ menu "nrfx drivers"
 	depends on HAS_NRFX
 
 config NRFX_ADC
-	bool "Enable ADC driver"
+	bool "ADC driver"
 	depends on HAS_HW_NRF_ADC
 
 config NRFX_CLOCK
-	bool "Enable CLOCK driver"
+	bool "CLOCK driver"
 	depends on HAS_HW_NRF_CLOCK
 
 config NRFX_CLOCK_LFXO_TWO_STAGE_ENABLED
-	bool "Enable two stage start sequence of the low frequency clock"
+	bool "Two stage start sequence of the low frequency clock"
 	depends on NRFX_CLOCK
 
 config NRFX_COMP
-	bool "Enable COMP driver"
+	bool "COMP driver"
 	depends on HAS_HW_NRF_COMP
 
 config NRFX_DPPI
-	bool "Enable DPPI allocator"
+	bool "DPPI allocator"
 	depends on HAS_HW_NRF_DPPIC
 
 config NRFX_EGU
-	bool "Enable EGU driver"
+	bool "EGU driver"
 	depends on HAS_HW_NRF_EGU0 || HAS_HW_NRF_EGU1 || HAS_HW_NRF_EGU2 || \
 		   HAS_HW_NRF_EGU3 || HAS_HW_NRF_EGU4 || HAS_HW_NRF_EGU5
 
 config NRFX_EGU0
-	bool "Enable EGU0 instance"
+	bool "EGU0 instance"
 	depends on HAS_HW_NRF_EGU0
 	select NRFX_EGU
 
 config NRFX_EGU1
-	bool "Enable EGU1 instance"
+	bool "EGU1 instance"
 	depends on HAS_HW_NRF_EGU1
 	select NRFX_EGU
 
 config NRFX_EGU2
-	bool "Enable EGU2 instance"
+	bool "EGU2 instance"
 	depends on HAS_HW_NRF_EGU2
 	select NRFX_EGU
 
 config NRFX_EGU3
-	bool "Enable EGU3 instance"
+	bool "EGU3 instance"
 	depends on HAS_HW_NRF_EGU3
 	select NRFX_EGU
 
 config NRFX_EGU4
-	bool "Enable EGU4 instance"
+	bool "EGU4 instance"
 	depends on HAS_HW_NRF_EGU4
 	select NRFX_EGU
 
 config NRFX_EGU5
-	bool "Enable EGU5 instance"
+	bool "EGU5 instance"
 	depends on HAS_HW_NRF_EGU5
 	select NRFX_EGU
 
 config NRFX_GPIOTE
-	bool "Enable GPIOTE driver"
+	bool "GPIOTE driver"
 	depends on HAS_HW_NRF_GPIOTE
 
 config NRFX_GPIOTE_NUM_OF_EVT_HANDLERS
@@ -75,356 +75,356 @@ config NRFX_GPIOTE_NUM_OF_EVT_HANDLERS
 	  by the user.
 
 config NRFX_I2S
-	bool "Enable I2S driver"
+	bool "I2S driver"
 	depends on HAS_HW_NRF_I2S
 
 config NRFX_IPC
-	bool "Enable IPC driver"
+	bool "IPC driver"
 	depends on HAS_HW_NRF_IPC
 
 config NRFX_LPCOMP
-	bool "Enable LPCOMP driver"
+	bool "LPCOMP driver"
 	depends on HAS_HW_NRF_LPCOMP
 
 config NRFX_NFCT
-	bool "Enable NFCT driver"
+	bool "NFCT driver"
 	depends on HAS_HW_NRF_NFCT
 	select NRFX_TIMER4 if SOC_SERIES_NRF52X
 	select NRFX_TIMER2 if SOC_SERIES_NRF53X
 
 config NRFX_NVMC
-	bool "Enable NVMC driver"
+	bool "NVMC driver"
 
 config NRFX_PDM
-	bool "Enable PDM driver"
+	bool "PDM driver"
 	depends on HAS_HW_NRF_PDM
 
 config NRFX_POWER
-	bool "Enable POWER driver"
+	bool "POWER driver"
 	depends on HAS_HW_NRF_POWER
 	# On SoCs featuring the USBREG peripheral, the POWER driver uses
 	# internally the USBREG driver.
 	select NRFX_USBREG if HAS_HW_NRF_USBREG
 
 config NRFX_PPI
-	bool "Enable PPI allocator"
+	bool "PPI allocator"
 	depends on HAS_HW_NRF_PPI
 
 config NRFX_PWM
-	bool "Enable PWM driver"
+	bool "PWM driver"
 	depends on HAS_HW_NRF_PWM0 || HAS_HW_NRF_PWM1 || \
 		   HAS_HW_NRF_PWM2 || HAS_HW_NRF_PWM3
 
 config NRFX_PWM0
-	bool "Enable PWM0 instance"
+	bool "PWM0 instance"
 	depends on HAS_HW_NRF_PWM0
 	select NRFX_PWM
 
 config NRFX_PWM1
-	bool "Enable PWM1 instance"
+	bool "PWM1 instance"
 	depends on HAS_HW_NRF_PWM1
 	select NRFX_PWM
 
 config NRFX_PWM2
-	bool "Enable PWM2 instance"
+	bool "PWM2 instance"
 	depends on HAS_HW_NRF_PWM2
 	select NRFX_PWM
 
 config NRFX_PWM3
-	bool "Enable PWM3 instance"
+	bool "PWM3 instance"
 	depends on HAS_HW_NRF_PWM3
 	select NRFX_PWM
 
 config NRFX_QDEC
-	bool "Enable QDEC driver"
+	bool "QDEC driver"
 	depends on HAS_HW_NRF_QDEC || HAS_HW_NRF_QDEC0
 
 config NRFX_QSPI
-	bool "Enable QSPI driver"
+	bool "QSPI driver"
 	depends on HAS_HW_NRF_QSPI
 
 config NRFX_RNG
-	bool "Enable RNG driver"
+	bool "RNG driver"
 	depends on HAS_HW_NRF_RNG
 
 config NRFX_RTC
-	bool "Enable RTC driver"
+	bool "RTC driver"
 	depends on HAS_HW_NRF_RTC0 || HAS_HW_NRF_RTC1 || HAS_HW_NRF_RTC2
 
 config NRFX_RTC0
-	bool "Enable RTC0 instance"
+	bool "RTC0 instance"
 	depends on HAS_HW_NRF_RTC0
 	select NRFX_RTC
 
 config NRFX_RTC1
-	bool "Enable RTC1 instance"
+	bool "RTC1 instance"
 	depends on HAS_HW_NRF_RTC1
 	select NRFX_RTC
 
 config NRFX_RTC2
-	bool "Enable RTC2 instance"
+	bool "RTC2 instance"
 	depends on HAS_HW_NRF_RTC2
 	select NRFX_RTC
 
 config NRFX_SAADC
-	bool "Enable SAADC driver"
+	bool "SAADC driver"
 	depends on HAS_HW_NRF_SAADC
 
 config NRFX_SPI
-	bool "Enable SPI driver"
+	bool "SPI driver"
 	depends on HAS_HW_NRF_SPI0 || HAS_HW_NRF_SPI1 || HAS_HW_NRF_SPI2
 
 config NRFX_SPI0
-	bool "Enable SPI0 instance"
+	bool "SPI0 instance"
 	depends on HAS_HW_NRF_SPI0
 	select NRFX_SPI
 
 config NRFX_SPI1
-	bool "Enable SPI1 instance"
+	bool "SPI1 instance"
 	depends on HAS_HW_NRF_SPI1
 	select NRFX_SPI
 
 config NRFX_SPI2
-	bool "Enable SPI2 instance"
+	bool "SPI2 instance"
 	depends on HAS_HW_NRF_SPI2
 	select NRFX_SPI
 
 config NRFX_SPIM
-	bool "Enable SPIM driver"
+	bool "SPIM driver"
 	depends on HAS_HW_NRF_SPIM0 || HAS_HW_NRF_SPIM1 || \
 		   HAS_HW_NRF_SPIM2 || HAS_HW_NRF_SPIM3 || HAS_HW_NRF_SPIM4
 
 config NRFX_SPIM0
-	bool "Enable SPIM0 instance"
+	bool "SPIM0 instance"
 	depends on HAS_HW_NRF_SPIM0
 	select NRFX_SPIM
 
 config NRFX_SPIM1
-	bool "Enable SPIM1 instance"
+	bool "SPIM1 instance"
 	depends on HAS_HW_NRF_SPIM1
 	select NRFX_SPIM
 
 config NRFX_SPIM2
-	bool "Enable SPIM2 instance"
+	bool "SPIM2 instance"
 	depends on HAS_HW_NRF_SPIM2
 	select NRFX_SPIM
 
 config NRFX_SPIM3
-	bool "Enable SPIM3 instance"
+	bool "SPIM3 instance"
 	depends on HAS_HW_NRF_SPIM3
 	select NRFX_SPIM
 
 config NRFX_SPIM4
-	bool "Enable SPIM4 instance"
+	bool "SPIM4 instance"
 	depends on HAS_HW_NRF_SPIM4
 	select NRFX_SPIM
 
 config NRFX_SPIS
-	bool "Enable SPIS driver"
+	bool "SPIS driver"
 	depends on HAS_HW_NRF_SPIS0 || HAS_HW_NRF_SPIS1 || \
 		   HAS_HW_NRF_SPIS2 || HAS_HW_NRF_SPIS3
 
 config NRFX_SPIS0
-	bool "Enable SPIS0 instance"
+	bool "SPIS0 instance"
 	depends on HAS_HW_NRF_SPIS0
 	select NRFX_SPIS
 
 config NRFX_SPIS1
-	bool "Enable SPIS1 instance"
+	bool "SPIS1 instance"
 	depends on HAS_HW_NRF_SPIS1
 	select NRFX_SPIS
 
 config NRFX_SPIS2
-	bool "Enable SPIS2 instance"
+	bool "SPIS2 instance"
 	depends on HAS_HW_NRF_SPIS2
 	select NRFX_SPIS
 
 config NRFX_SPIS3
-	bool "Enable SPIS3 instance"
+	bool "SPIS3 instance"
 	depends on HAS_HW_NRF_SPIS3
 	select NRFX_SPIS
 
 config NRFX_SYSTICK
-	bool "Enable SYSTICK driver"
+	bool "SYSTICK driver"
 	depends on CPU_CORTEX_M_HAS_SYSTICK
 
 config NRFX_TEMP
-	bool "Enable TEMP driver"
+	bool "TEMP driver"
 	depends on HAS_HW_NRF_TEMP
 
 config NRFX_TIMER
-	bool "Enable TIMER driver"
+	bool "TIMER driver"
 	depends on HAS_HW_NRF_TIMER0 || HAS_HW_NRF_TIMER1 || \
 		   HAS_HW_NRF_TIMER2 || HAS_HW_NRF_TIMER3 || \
 		   HAS_HW_NRF_TIMER4
 
 config NRFX_TIMER0
-	bool "Enable TIMER0 instance"
+	bool "TIMER0 instance"
 	depends on HAS_HW_NRF_TIMER0
 	select NRFX_TIMER
 
 config NRFX_TIMER1
-	bool "Enable TIMER1 instance"
+	bool "TIMER1 instance"
 	depends on HAS_HW_NRF_TIMER1
 	select NRFX_TIMER
 
 config NRFX_TIMER2
-	bool "Enable TIMER2 instance"
+	bool "TIMER2 instance"
 	depends on HAS_HW_NRF_TIMER2
 	select NRFX_TIMER
 
 config NRFX_TIMER3
-	bool "Enable TIMER3 instance"
+	bool "TIMER3 instance"
 	depends on HAS_HW_NRF_TIMER3
 	select NRFX_TIMER
 
 config NRFX_TIMER4
-	bool "Enable TIMER4 instance"
+	bool "TIMER4 instance"
 	depends on HAS_HW_NRF_TIMER4
 	select NRFX_TIMER
 
 config NRFX_TWI
-	bool "Enable TWI driver"
+	bool "TWI driver"
 	depends on HAS_HW_NRF_TWI0 || HAS_HW_NRF_TWI1
 
 config NRFX_TWI0
-	bool "Enable TWI0 instance"
+	bool "TWI0 instance"
 	depends on HAS_HW_NRF_TWI0
 	select NRFX_TWI
 
 config NRFX_TWI1
-	bool "Enable TWI1 instance"
+	bool "TWI1 instance"
 	depends on HAS_HW_NRF_TWI1
 	select NRFX_TWI
 
 config NRFX_TWIM
-	bool "Enable TWIM driver"
+	bool "TWIM driver"
 	depends on HAS_HW_NRF_TWIM0 || HAS_HW_NRF_TWIM1 || \
 		   HAS_HW_NRF_TWIM2 || HAS_HW_NRF_TWIM3
 
 config NRFX_TWIM0
-	bool "Enable TWIM0 instance"
+	bool "TWIM0 instance"
 	depends on HAS_HW_NRF_TWIM0
 	select NRFX_TWIM
 
 config NRFX_TWIM1
-	bool "Enable TWIM1 instance"
+	bool "TWIM1 instance"
 	depends on HAS_HW_NRF_TWIM1
 	select NRFX_TWIM
 
 config NRFX_TWIM2
-	bool "Enable TWIM2 instance"
+	bool "TWIM2 instance"
 	depends on HAS_HW_NRF_TWIM2
 	select NRFX_TWIM
 
 config NRFX_TWIM3
-	bool "Enable TWIM3 instance"
+	bool "TWIM3 instance"
 	depends on HAS_HW_NRF_TWIM3
 	select NRFX_TWIM
 
 config NRFX_TWIS
-	bool "Enable TWIS driver"
+	bool "TWIS driver"
 	depends on HAS_HW_NRF_TWIS0 || HAS_HW_NRF_TWIS1 || \
 		   HAS_HW_NRF_TWIS2 || HAS_HW_NRF_TWIS3
 
 config NRFX_TWIS0
-	bool "Enable TWIS0 instance"
+	bool "TWIS0 instance"
 	depends on HAS_HW_NRF_TWIS0
 	select NRFX_TWIS
 
 config NRFX_TWIS1
-	bool "Enable TWIS1 instance"
+	bool "TWIS1 instance"
 	depends on HAS_HW_NRF_TWIS1
 	select NRFX_TWIS
 
 config NRFX_TWIS2
-	bool "Enable TWIS2 instance"
+	bool "TWIS2 instance"
 	depends on HAS_HW_NRF_TWIS2
 	select NRFX_TWIS
 
 config NRFX_TWIS3
-	bool "Enable TWIS3 instance"
+	bool "TWIS3 instance"
 	depends on HAS_HW_NRF_TWIS3
 	select NRFX_TWIS
 
 config NRFX_UART
-	bool "Enable UART driver"
+	bool "UART driver"
 	depends on HAS_HW_NRF_UART0
 
 config NRFX_UART0
-	bool "Enable UART0 instance"
+	bool "UART0 instance"
 	depends on HAS_HW_NRF_UART0
 	select NRFX_UART
 
 config NRFX_UARTE
-	bool "Enable UARTE driver"
+	bool "UARTE driver"
 	depends on HAS_HW_NRF_UARTE0 || HAS_HW_NRF_UARTE1 || \
 		   HAS_HW_NRF_UARTE2 || HAS_HW_NRF_UARTE3
 
 config NRFX_UARTE0
-	bool "Enable UARTE0 instance"
+	bool "UARTE0 instance"
 	depends on HAS_HW_NRF_UARTE0
 	select NRFX_UARTE
 
 config NRFX_UARTE1
-	bool "Enable UARTE1 instance"
+	bool "UARTE1 instance"
 	depends on HAS_HW_NRF_UARTE1
 	select NRFX_UARTE
 
 config NRFX_UARTE2
-	bool "Enable UARTE2 instance"
+	bool "UARTE2 instance"
 	depends on HAS_HW_NRF_UARTE2
 	select NRFX_UARTE
 
 config NRFX_UARTE3
-	bool "Enable UARTE3 instance"
+	bool "UARTE3 instance"
 	depends on HAS_HW_NRF_UARTE3
 	select NRFX_UARTE
 
 config NRFX_USBD
-	bool "Enable USBD driver"
+	bool "USBD driver"
 	depends on HAS_HW_NRF_USBD
 	select NRFX_SYSTICK
 
 config NRFX_USBREG
-	bool "Enable USBREG driver"
+	bool "USBREG driver"
 	depends on HAS_HW_NRF_USBREG
 
 config NRFX_WDT
-	bool "Enable WDT driver"
+	bool "WDT driver"
 	depends on HAS_HW_NRF_WDT || HAS_HW_NRF_WDT0 || HAS_HW_NRF_WDT1
 
 config NRFX_WDT0
-	bool "Enable WDT0 instance"
+	bool "WDT0 instance"
 	depends on HAS_HW_NRF_WDT || HAS_HW_NRF_WDT0
 	select NRFX_WDT
 
 config NRFX_WDT1
-	bool "Enable WDT1 instance"
+	bool "WDT1 instance"
 	depends on HAS_HW_NRF_WDT1
 	select NRFX_WDT
 
 config NRFX_PRS
-	bool "Enable Peripheral Resource Sharing module"
+	bool "Peripheral Resource Sharing module"
 
 config NRFX_PRS_BOX_0
-	bool "Enable PRS box 0"
+	bool "PRS box 0"
 	select NRFX_PRS
 
 config NRFX_PRS_BOX_1
-	bool "Enable PRS box 1"
+	bool "PRS box 1"
 	select NRFX_PRS
 
 config NRFX_PRS_BOX_2
-	bool "Enable PRS box 2"
+	bool "PRS box 2"
 	select NRFX_PRS
 
 config NRFX_PRS_BOX_3
-	bool "Enable PRS box 3"
+	bool "PRS box 3"
 	select NRFX_PRS
 
 config NRFX_PRS_BOX_4
-	bool "Enable PRS box 4"
+	bool "PRS box 4"
 	select NRFX_PRS
 
 endmenu

--- a/modules/lz4/Kconfig
+++ b/modules/lz4/Kconfig
@@ -5,7 +5,7 @@ config ZEPHYR_LZ4_MODULE
 	bool
 
 config LZ4
-	bool "Enable lz4 data compression and decompression"
+	bool "Lz4 data compression and decompression"
 	help
 	  This option enables lz4 compression & decompression library
 	  support.

--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -127,7 +127,7 @@ config MBEDTLS_INSTALL_PATH
 	  is enabled otherwise the build will fail.
 
 config MBEDTLS_ENABLE_HEAP
-	bool "Enable global heap for mbed TLS"
+	bool "Global heap for mbed TLS"
 	help
 	  This option enables the mbedtls to use the heap. This setting must
 	  be global so that various applications and libraries in Zephyr do not

--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -10,35 +10,35 @@ menu "TLS configuration"
 menu "Supported TLS version"
 
 config MBEDTLS_TLS_VERSION_1_0
-	bool "Enable support for TLS 1.0"
+	bool "Support for TLS 1.0"
 	select MBEDTLS_CIPHER
 	select MBEDTLS_MAC_MD5_ENABLED
 	select MBEDTLS_MAC_SHA1_ENABLED
 	select MBEDTLS_MD
 
 config MBEDTLS_TLS_VERSION_1_1
-	bool "Enable support for TLS 1.1 (DTLS 1.0)"
+	bool "Support for TLS 1.1 (DTLS 1.0)"
 	select MBEDTLS_CIPHER
 	select MBEDTLS_MAC_MD5_ENABLED
 	select MBEDTLS_MAC_SHA1_ENABLED
 	select MBEDTLS_MD
 
 config MBEDTLS_TLS_VERSION_1_2
-	bool "Enable support for TLS 1.2 (DTLS 1.2)"
+	bool "Support for TLS 1.2 (DTLS 1.2)"
 	default y if !NET_L2_OPENTHREAD
 	select MBEDTLS_CIPHER
 	select MBEDTLS_MD
 
 config MBEDTLS_DTLS
-	bool "Enable support for DTLS"
+	bool "Support for DTLS"
 	depends on MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
 config MBEDTLS_SSL_EXPORT_KEYS
-	bool "Enable support for exporting SSL key block and master secret"
+	bool "Support for exporting SSL key block and master secret"
 	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
 config MBEDTLS_SSL_ALPN
-	bool "Enable support for setting the supported Application Layer Protocols"
+	bool "Support for setting the supported Application Layer Protocols"
 	depends on MBEDTLS_TLS_VERSION_1_0 || MBEDTLS_TLS_VERSION_1_1 || MBEDTLS_TLS_VERSION_1_2
 
 endmenu
@@ -48,7 +48,7 @@ menu "Ciphersuite configuration"
 comment "Supported key exchange modes"
 
 config MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
-	bool "Enable all available ciphersuite modes"
+	bool "All available ciphersuite modes"
 	select MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 	select MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
 	select MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
@@ -62,16 +62,16 @@ config MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
 	select MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
 config MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
-	bool "Enable the PSK based ciphersuite modes"
+	bool "The PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
-	bool "Enable the DHE-PSK based ciphersuite modes"
+	bool "The DHE-PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
-	bool "Enable the ECDHE-PSK based ciphersuite modes"
+	bool "The ECDHE-PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-	bool "Enable the RSA-PSK based ciphersuite modes"
+	bool "The RSA-PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED
 	bool
@@ -88,29 +88,29 @@ config MBEDTLS_PSK_MAX_LEN
 	  Max size of TLS pre-shared keys, in bytes.
 
 config MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-	bool "Enable the RSA-only based ciphersuite modes"
+	bool "The RSA-only based ciphersuite modes"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
-	bool "Enable the DHE-RSA based ciphersuite modes"
+	bool "The DHE-RSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
-	bool "Enable the ECDHE-RSA based ciphersuite modes"
+	bool "The ECDHE-RSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-	bool "Enable the ECDHE-ECDSA based ciphersuite modes"
+	bool "The ECDHE-ECDSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
-	bool "Enable the ECDH-ECDSA based ciphersuite modes"
+	bool "The ECDH-ECDSA based ciphersuite modes"
 
 config MBEDTLS_ECDSA_DETERMINISTIC
-	bool "Enable deterministic ECDSA (RFC 6979)"
+	bool "Deterministic ECDSA (RFC 6979)"
 
 config MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-	bool "Enable the ECDH-RSA based ciphersuite modes"
+	bool "The ECDH-RSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-	bool "Enable the ECJPAKE based ciphersuite modes"
+	bool "The ECJPAKE based ciphersuite modes"
 
 if MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED || \
 	MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED || \
@@ -122,7 +122,7 @@ if MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED || \
 comment "Supported elliptic curves"
 
 config MBEDTLS_ECP_ALL_ENABLED
-	bool "Enable all available elliptic curves"
+	bool "All available elliptic curves"
 	select MBEDTLS_ECP_DP_SECP192R1_ENABLED
 	select MBEDTLS_ECP_DP_SECP192R1_ENABLED
 	select MBEDTLS_ECP_DP_SECP224R1_ENABLED
@@ -140,68 +140,68 @@ config MBEDTLS_ECP_ALL_ENABLED
 	select MBEDTLS_ECP_NIST_OPTIM
 
 config MBEDTLS_ECP_DP_SECP192R1_ENABLED
-	bool "Enable SECP192R1 elliptic curve"
+	bool "SECP192R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_SECP224R1_ENABLED
-	bool "Enable SECP224R1 elliptic curve"
+	bool "SECP224R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_SECP256R1_ENABLED
-	bool "Enable SECP256R1 elliptic curve"
+	bool "SECP256R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_SECP384R1_ENABLED
-	bool "Enable SECP384R1 elliptic curve"
+	bool "SECP384R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_SECP521R1_ENABLED
-	bool "Enable SECP521R1 elliptic curve"
+	bool "SECP521R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_SECP192K1_ENABLED
-	bool "Enable SECP192K1 elliptic curve"
+	bool "SECP192K1 elliptic curve"
 
 config MBEDTLS_ECP_DP_SECP224K1_ENABLED
-	bool "Enable SECP224K1 elliptic curve"
+	bool "SECP224K1 elliptic curve"
 
 config MBEDTLS_ECP_DP_SECP256K1_ENABLED
-	bool "Enable SECP256K1 elliptic curve"
+	bool "SECP256K1 elliptic curve"
 
 config MBEDTLS_ECP_DP_BP256R1_ENABLED
-	bool "Enable BP256R1 elliptic curve"
+	bool "BP256R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_BP384R1_ENABLED
-	bool "Enable BP384R1 elliptic curve"
+	bool "BP384R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_BP512R1_ENABLED
-	bool "Enable BP512R1 elliptic curve"
+	bool "BP512R1 elliptic curve"
 
 config MBEDTLS_ECP_DP_CURVE25519_ENABLED
-	bool "Enable CURVE25519 elliptic curve"
+	bool "CURVE25519 elliptic curve"
 
 config MBEDTLS_ECP_DP_CURVE448_ENABLED
-	bool "Enable CURVE448 elliptic curve"
+	bool "CURVE448 elliptic curve"
 
 config MBEDTLS_ECP_NIST_OPTIM
-	bool "Enable NSIT curves optimization"
+	bool "NSIT curves optimization"
 
 endif
 
 comment "Supported hash"
 
 config MBEDTLS_HASH_ALL_ENABLED
-	bool "Enable all available hashes"
+	bool "All available hashes"
 	select MBEDTLS_HASH_SHA256_ENABLED
 	select MBEDTLS_HASH_SHA512_ENABLED
 
 config MBEDTLS_HASH_SHA256_ENABLED
-	bool "Enable SHA256 hash"
+	bool "SHA256 hash"
 	default y
 
 config MBEDTLS_HASH_SHA512_ENABLED
-	bool "Enable SHA512 hash"
+	bool "SHA512 hash"
 	default y
 
 comment "Supported cipher modes"
 
 config MBEDTLS_CIPHER_ALL_ENABLED
-	bool "Enable all available ciphers"
+	bool "All available ciphers"
 	select MBEDTLS_CIPHER_AES_ENABLED
 	select MBEDTLS_CIPHER_CAMELLIA_ENABLED
 	select MBEDTLS_CIPHER_DES_ENABLED
@@ -216,7 +216,7 @@ config MBEDTLS_CIPHER_ALL_ENABLED
 	select MBEDTLS_CHACHAPOLY_AEAD_ENABLED
 
 config MBEDTLS_CIPHER_AES_ENABLED
-	bool "Enable the AES block cipher"
+	bool "The AES block cipher"
 	default y
 
 config MBEDTLS_AES_ROM_TABLES
@@ -225,48 +225,48 @@ config MBEDTLS_AES_ROM_TABLES
 	default y
 
 config MBEDTLS_CIPHER_CAMELLIA_ENABLED
-	bool "Enable the Camellia block cipher"
+	bool "The Camellia block cipher"
 
 config MBEDTLS_CIPHER_DES_ENABLED
-	bool "Enable the DES block cipher"
+	bool "The DES block cipher"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_CIPHER_ARC4_ENABLED
-	bool "Enable the ARC4 stream cipher"
+	bool "The ARC4 stream cipher"
 
 config MBEDTLS_CIPHER_CHACHA20_ENABLED
-	bool "Enable the ChaCha20 stream cipher"
+	bool "The ChaCha20 stream cipher"
 
 config MBEDTLS_CIPHER_BLOWFISH_ENABLED
-	bool "Enable the Blowfish block cipher"
+	bool "The Blowfish block cipher"
 
 config MBEDTLS_CIPHER_CCM_ENABLED
-	bool "Enable the Counter with CBC-MAC (CCM) mode for 128-bit block cipher"
+	bool "The Counter with CBC-MAC (CCM) mode for 128-bit block cipher"
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_CAMELLIA_ENABLED
 
 config MBEDTLS_CIPHER_GCM_ENABLED
-	bool "Enable the Galois/Counter Mode (GCM) for AES"
+	bool "The Galois/Counter Mode (GCM) for AES"
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_CAMELLIA_ENABLED
 
 config MBEDTLS_CIPHER_MODE_XTS_ENABLED
-	bool "Enable Xor-encrypt-xor with ciphertext stealing mode (XTS) for AES"
+	bool "Xor-encrypt-xor with ciphertext stealing mode (XTS) for AES"
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_CAMELLIA_ENABLED
 
 config MBEDTLS_CIPHER_MODE_CBC_ENABLED
-	bool "Enable Cipher Block Chaining mode (CBC) for symmetric ciphers"
+	bool "Cipher Block Chaining mode (CBC) for symmetric ciphers"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_CIPHER_MODE_CTR_ENABLED
-	bool "Enable Counter Block Cipher mode (CTR) for symmetric ciphers."
+	bool "Counter Block Cipher mode (CTR) for symmetric ciphers."
 
 config MBEDTLS_CHACHAPOLY_AEAD_ENABLED
-	bool "Enable the ChaCha20-Poly1305 AEAD algorithm"
+	bool "The ChaCha20-Poly1305 AEAD algorithm"
 	depends on MBEDTLS_CIPHER_CHACHA20_ENABLED || MBEDTLS_MAC_POLY1305_ENABLED
 
 comment "Supported message authentication methods"
 
 config MBEDTLS_MAC_ALL_ENABLED
-	bool "Enable all available MAC methods"
+	bool "All available MAC methods"
 	select MBEDTLS_MAC_MD4_ENABLED
 	select MBEDTLS_MAC_MD5_ENABLED
 	select MBEDTLS_MAC_SHA1_ENABLED
@@ -276,22 +276,22 @@ config MBEDTLS_MAC_ALL_ENABLED
 	select MBEDTLS_MAC_CMAC_ENABLED
 
 config MBEDTLS_MAC_MD4_ENABLED
-	bool "Enable the MD4 hash algorithm"
+	bool "The MD4 hash algorithm"
 
 config MBEDTLS_MAC_MD5_ENABLED
-	bool "Enable the MD5 hash algorithm"
+	bool "The MD5 hash algorithm"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_MAC_SHA1_ENABLED
-	bool "Enable the SHA1 hash algorithm"
+	bool "The SHA1 hash algorithm"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_MAC_SHA256_ENABLED
-	bool "Enable the SHA-224 and SHA-256 hash algorithms"
+	bool "The SHA-224 and SHA-256 hash algorithms"
 	default y
 
 config MBEDTLS_SHA256_SMALLER
-	bool "Enable smaller SHA-256 implementation"
+	bool "Smaller SHA-256 implementation"
 	depends on MBEDTLS_MAC_SHA256_ENABLED
 	default y
 	help
@@ -299,13 +299,13 @@ config MBEDTLS_SHA256_SMALLER
 	  lower performance
 
 config MBEDTLS_MAC_SHA512_ENABLED
-	bool "Enable the SHA-384 and SHA-512 hash algorithms"
+	bool "The SHA-384 and SHA-512 hash algorithms"
 
 config MBEDTLS_MAC_POLY1305_ENABLED
-	bool "Enable the Poly1305 MAC algorithm"
+	bool "The Poly1305 MAC algorithm"
 
 config MBEDTLS_MAC_CMAC_ENABLED
-	bool "Enable the CMAC (Cipher-based Message Authentication Code) mode for block ciphers."
+	bool "The CMAC (Cipher-based Message Authentication Code) mode for block ciphers."
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_DES_ENABLED
 
 endmenu
@@ -313,33 +313,33 @@ endmenu
 comment "Random number generators"
 
 config MBEDTLS_CTR_DRBG_ENABLED
-	bool "Enable the CTR_DRBG AES-256-based random generator"
+	bool "The CTR_DRBG AES-256-based random generator"
 	depends on MBEDTLS_CIPHER_AES_ENABLED
 	default y
 
 config MBEDTLS_HMAC_DRBG_ENABLED
-	bool "Enable the HMAC_DRBG random generator"
+	bool "The HMAC_DRBG random generator"
 	select MBEDTLS_MD
 
 comment "Other configurations"
 
 config MBEDTLS_CIPHER
-	bool "Enable the generic cipher layer."
+	bool "The generic cipher layer."
 
 config MBEDTLS_MD
-	bool "Enable the generic message digest layer."
+	bool "The generic message digest layer."
 
 config MBEDTLS_GENPRIME_ENABLED
-	bool "Enable the prime-number generation code."
+	bool "The prime-number generation code."
 
 config MBEDTLS_PEM_CERTIFICATE_FORMAT
-	bool "Enable support for PEM certificate format"
+	bool "Support for PEM certificate format"
 	help
 	  By default only DER (binary) format of certificates is supported. Enable
 	  this option to enable support for PEM format.
 
 config MBEDTLS_HAVE_ASM
-	bool "Enable use of assembly code"
+	bool "Use of assembly code"
 	default y if !ARM
 	help
 	  Enable use of assembly code in mbedTLS. This improves the performances
@@ -347,11 +347,11 @@ config MBEDTLS_HAVE_ASM
 	  code size.
 
 config MBEDTLS_ENTROPY_ENABLED
-	bool "Enable mbedTLS generic entropy pool"
+	bool "MbedTLS generic entropy pool"
 	depends on MBEDTLS_MAC_SHA256_ENABLED || MBEDTLS_MAC_SHA512_ENABLED
 
 config MBEDTLS_OPENTHREAD_OPTIMIZATIONS_ENABLED
-	bool "Enable mbedTLS optimizations for OpenThread"
+	bool "MbedTLS optimizations for OpenThread"
 	depends on NET_L2_OPENTHREAD
 	default y if !NET_SOCKETS_SOCKOPT_TLS
 	help
@@ -361,7 +361,7 @@ config MBEDTLS_OPENTHREAD_OPTIMIZATIONS_ENABLED
 	  sockets), it's advised to disable this option.
 
 config MBEDTLS_USER_CONFIG_ENABLE
-	bool "Enable user mbedTLS config file"
+	bool "User mbedTLS config file"
 	help
 	  Enable user mbedTLS config file that will be included at the end of
 	  the generic config file.
@@ -373,25 +373,25 @@ config MBEDTLS_USER_CONFIG_FILE
 	  covered by the generic config file.
 
 config MBEDTLS_SERVER_NAME_INDICATION
-	bool "Enable support for RFC 6066 server name indication (SNI) in SSL"
+	bool "Support for RFC 6066 server name indication (SNI) in SSL"
 	help
 	  Enable this to support RFC 6066 server name indication (SNI) in SSL.
 	  This requires that MBEDTLS_X509_CRT_PARSE_C is also set.
 
 config MBEDTLS_PK_WRITE_C
-	bool "Enable the generic public (asymetric) key writer"
+	bool "The generic public (asymetric) key writer"
 	help
 	  Enable generic public key write functions.
 
 config MBEDTLS_HAVE_TIME_DATE
-	bool "Enable date/time validation in mbed TLS"
+	bool "Date/time validation in mbed TLS"
 	help
 	  System has time.h, time(), and an implementation for gmtime_r().
 	  There also need to be a valid time source in the system, as mbedTLS
 	  expects a valid date/time for certificate validation."
 
 config MBEDTLS_PKCS5_C
-	bool "Enable password-based encryption functions"
+	bool "Password-based encryption functions"
 	select MBEDTLS_MD
 	help
 	  Enable PKCS5 functions

--- a/modules/mbedtls/Kconfig.tls-generic
+++ b/modules/mbedtls/Kconfig.tls-generic
@@ -62,16 +62,16 @@ config MBEDTLS_KEY_EXCHANGE_ALL_ENABLED
 	select MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
 
 config MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
-	bool "The PSK based ciphersuite modes"
+	bool "PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_DHE_PSK_ENABLED
-	bool "The DHE-PSK based ciphersuite modes"
+	bool "DHE-PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED
-	bool "The ECDHE-PSK based ciphersuite modes"
+	bool "ECDHE-PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_RSA_PSK_ENABLED
-	bool "The RSA-PSK based ciphersuite modes"
+	bool "RSA-PSK based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_SOME_PSK_ENABLED
 	bool
@@ -88,29 +88,29 @@ config MBEDTLS_PSK_MAX_LEN
 	  Max size of TLS pre-shared keys, in bytes.
 
 config MBEDTLS_KEY_EXCHANGE_RSA_ENABLED
-	bool "The RSA-only based ciphersuite modes"
+	bool "RSA-only based ciphersuite modes"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED
-	bool "The DHE-RSA based ciphersuite modes"
+	bool "DHE-RSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED
-	bool "The ECDHE-RSA based ciphersuite modes"
+	bool "ECDHE-RSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
-	bool "The ECDHE-ECDSA based ciphersuite modes"
+	bool "ECDHE-ECDSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECDH_ECDSA_ENABLED
-	bool "The ECDH-ECDSA based ciphersuite modes"
+	bool "ECDH-ECDSA based ciphersuite modes"
 
 config MBEDTLS_ECDSA_DETERMINISTIC
 	bool "Deterministic ECDSA (RFC 6979)"
 
 config MBEDTLS_KEY_EXCHANGE_ECDH_RSA_ENABLED
-	bool "The ECDH-RSA based ciphersuite modes"
+	bool "ECDH-RSA based ciphersuite modes"
 
 config MBEDTLS_KEY_EXCHANGE_ECJPAKE_ENABLED
-	bool "The ECJPAKE based ciphersuite modes"
+	bool "ECJPAKE based ciphersuite modes"
 
 if MBEDTLS_KEY_EXCHANGE_ECDHE_PSK_ENABLED || \
 	MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED || \
@@ -216,7 +216,7 @@ config MBEDTLS_CIPHER_ALL_ENABLED
 	select MBEDTLS_CHACHAPOLY_AEAD_ENABLED
 
 config MBEDTLS_CIPHER_AES_ENABLED
-	bool "The AES block cipher"
+	bool "AES block cipher"
 	default y
 
 config MBEDTLS_AES_ROM_TABLES
@@ -225,27 +225,27 @@ config MBEDTLS_AES_ROM_TABLES
 	default y
 
 config MBEDTLS_CIPHER_CAMELLIA_ENABLED
-	bool "The Camellia block cipher"
+	bool "Camellia block cipher"
 
 config MBEDTLS_CIPHER_DES_ENABLED
-	bool "The DES block cipher"
+	bool "DES block cipher"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_CIPHER_ARC4_ENABLED
-	bool "The ARC4 stream cipher"
+	bool "ARC4 stream cipher"
 
 config MBEDTLS_CIPHER_CHACHA20_ENABLED
-	bool "The ChaCha20 stream cipher"
+	bool "ChaCha20 stream cipher"
 
 config MBEDTLS_CIPHER_BLOWFISH_ENABLED
-	bool "The Blowfish block cipher"
+	bool "Blowfish block cipher"
 
 config MBEDTLS_CIPHER_CCM_ENABLED
-	bool "The Counter with CBC-MAC (CCM) mode for 128-bit block cipher"
+	bool "Counter with CBC-MAC (CCM) mode for 128-bit block cipher"
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_CAMELLIA_ENABLED
 
 config MBEDTLS_CIPHER_GCM_ENABLED
-	bool "The Galois/Counter Mode (GCM) for AES"
+	bool "Galois/Counter Mode (GCM) for AES"
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_CAMELLIA_ENABLED
 
 config MBEDTLS_CIPHER_MODE_XTS_ENABLED
@@ -260,7 +260,7 @@ config MBEDTLS_CIPHER_MODE_CTR_ENABLED
 	bool "Counter Block Cipher mode (CTR) for symmetric ciphers."
 
 config MBEDTLS_CHACHAPOLY_AEAD_ENABLED
-	bool "The ChaCha20-Poly1305 AEAD algorithm"
+	bool "ChaCha20-Poly1305 AEAD algorithm"
 	depends on MBEDTLS_CIPHER_CHACHA20_ENABLED || MBEDTLS_MAC_POLY1305_ENABLED
 
 comment "Supported message authentication methods"
@@ -276,18 +276,18 @@ config MBEDTLS_MAC_ALL_ENABLED
 	select MBEDTLS_MAC_CMAC_ENABLED
 
 config MBEDTLS_MAC_MD4_ENABLED
-	bool "The MD4 hash algorithm"
+	bool "MD4 hash algorithm"
 
 config MBEDTLS_MAC_MD5_ENABLED
-	bool "The MD5 hash algorithm"
+	bool "MD5 hash algorithm"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_MAC_SHA1_ENABLED
-	bool "The SHA1 hash algorithm"
+	bool "SHA1 hash algorithm"
 	default y if !NET_L2_OPENTHREAD
 
 config MBEDTLS_MAC_SHA256_ENABLED
-	bool "The SHA-224 and SHA-256 hash algorithms"
+	bool "SHA-224 and SHA-256 hash algorithms"
 	default y
 
 config MBEDTLS_SHA256_SMALLER
@@ -299,13 +299,13 @@ config MBEDTLS_SHA256_SMALLER
 	  lower performance
 
 config MBEDTLS_MAC_SHA512_ENABLED
-	bool "The SHA-384 and SHA-512 hash algorithms"
+	bool "SHA-384 and SHA-512 hash algorithms"
 
 config MBEDTLS_MAC_POLY1305_ENABLED
-	bool "The Poly1305 MAC algorithm"
+	bool "Poly1305 MAC algorithm"
 
 config MBEDTLS_MAC_CMAC_ENABLED
-	bool "The CMAC (Cipher-based Message Authentication Code) mode for block ciphers."
+	bool "CMAC (Cipher-based Message Authentication Code) mode for block ciphers."
 	depends on MBEDTLS_CIPHER_AES_ENABLED || MBEDTLS_CIPHER_DES_ENABLED
 
 endmenu
@@ -313,24 +313,24 @@ endmenu
 comment "Random number generators"
 
 config MBEDTLS_CTR_DRBG_ENABLED
-	bool "The CTR_DRBG AES-256-based random generator"
+	bool "CTR_DRBG AES-256-based random generator"
 	depends on MBEDTLS_CIPHER_AES_ENABLED
 	default y
 
 config MBEDTLS_HMAC_DRBG_ENABLED
-	bool "The HMAC_DRBG random generator"
+	bool "HMAC_DRBG random generator"
 	select MBEDTLS_MD
 
 comment "Other configurations"
 
 config MBEDTLS_CIPHER
-	bool "The generic cipher layer."
+	bool "generic cipher layer."
 
 config MBEDTLS_MD
-	bool "The generic message digest layer."
+	bool "generic message digest layer."
 
 config MBEDTLS_GENPRIME_ENABLED
-	bool "The prime-number generation code."
+	bool "prime-number generation code."
 
 config MBEDTLS_PEM_CERTIFICATE_FORMAT
 	bool "Support for PEM certificate format"

--- a/modules/nanopb/Kconfig
+++ b/modules/nanopb/Kconfig
@@ -12,7 +12,7 @@ menuconfig NANOPB
 if NANOPB
 
 config NANOPB_ENABLE_MALLOC
-	bool "Enable malloc usage"
+	bool "Malloc usage"
 	help
 	  This option enables dynamic allocation support in the decoder.
 

--- a/modules/trusted-firmware-m/Kconfig.tfm.partitions
+++ b/modules/trusted-firmware-m/Kconfig.tfm.partitions
@@ -6,7 +6,7 @@
 if BUILD_WITH_TFM
 
 config TFM_PARTITION_PROTECTED_STORAGE
-	bool "Enable secure partition 'Protected Storage'"
+	bool "Secure partition 'Protected Storage'"
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_PROTECTED_STORAGE'
@@ -17,7 +17,7 @@ config TFM_PARTITION_PROTECTED_STORAGE
 	  repository.
 
 config TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
-	bool "Enable secure partition 'Internal Trusted Storage'"
+	bool "Secure partition 'Internal Trusted Storage'"
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_INTERNAL_TRUSTED_STORAGE'
@@ -28,7 +28,7 @@ config TFM_PARTITION_INTERNAL_TRUSTED_STORAGE
 	  repository.
 
 config TFM_PARTITION_CRYPTO
-	bool "Enable secure partition 'Crypto'"
+	bool "Secure partition 'Crypto'"
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_CRYPTO'
@@ -39,7 +39,7 @@ config TFM_PARTITION_CRYPTO
 	  repository.
 
 config TFM_PARTITION_INITIAL_ATTESTATION
-	bool "Enable secure partition 'Initial Attestation'"
+	bool "Secure partition 'Initial Attestation'"
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_INITIAL_ATTESTATION'
@@ -50,7 +50,7 @@ config TFM_PARTITION_INITIAL_ATTESTATION
 	  repository.
 
 config TFM_PARTITION_PLATFORM
-	bool "Enable secure partition 'Platform'"
+	bool "Secure partition 'Platform'"
 	default y
 	help
 	  Setting this option will cause '-DTFM_PARTITION_PLATFORM'
@@ -61,7 +61,7 @@ config TFM_PARTITION_PLATFORM
 	  repository.
 
 config TFM_PARTITION_AUDIT_LOG
-	bool "Enable secure partition 'Audit Log'" if !TFM_IPC
+	bool "Secure partition 'Audit Log'" if !TFM_IPC
 	depends on !TFM_IPC
 	default y
 	help

--- a/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/Kconfig
+++ b/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/Kconfig
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config HELLO_WORLD_DRIVER
-	bool "Enable support for the demonstration out of tree driver"
+	bool "Support for the demonstration out of tree driver"

--- a/samples/boards/nrf/system_off/Kconfig
+++ b/samples/boards/nrf/system_off/Kconfig
@@ -4,7 +4,7 @@
 mainmenu "Nordic SYSTEM_OFF demo"
 
 config APP_RETENTION
-	bool "Enable state retention in system off"
+	bool "State retention in system off"
 	depends on SOC_COMPATIBLE_NRF52X
 	help
 	  On some Nordic chips this application supports retaining

--- a/samples/sensor/tmp108/Kconfig
+++ b/samples/sensor/tmp108/Kconfig
@@ -11,7 +11,7 @@ config APP_REPORT_TEMP_ALERTS
 	default n
 
 config APP_ENABLE_ONE_SHOT
-	bool "Enable one shot low power mode"
+	bool "One shot low power mode"
 	default n
 	help
 		One shot requires a callback to be invoked after the tmp108 has

--- a/samples/tfm_integration/psa_crypto/Kconfig
+++ b/samples/tfm_integration/psa_crypto/Kconfig
@@ -14,13 +14,13 @@ source "subsys/logging/Kconfig.template.log_config"
 endmenu
 
 config PSA_SHELL
-	bool "Enable the 'psa' shell command"
+	bool "The 'psa' shell command"
 	depends on SHELL
 	help
 	  Enabling this option will make the 'psa' shell command available.
 
 config PSA_IMPORT_KEY
-	bool "Enable support for importing private key data"
+	bool "Support for importing private key data"
 	help
 	  Enable support for importing a pre-generated or randomly generated
 	  private key using PSA APIs and PRIVATE_KEY_STATIC or

--- a/soc/arm/atmel_sam0/common/Kconfig.samd2x
+++ b/soc/arm/atmel_sam0/common/Kconfig.samd2x
@@ -3,14 +3,14 @@
 if SOC_SERIES_SAMD20 || SOC_SERIES_SAMD21 || SOC_SERIES_SAMR21
 
 config SOC_ATMEL_SAMD_XOSC32K
-	bool "Enable the external 32 kHz crystal oscillator"
+	bool "The external 32 kHz crystal oscillator"
 	help
 	  Say y to enable the external 32 kHZ crystal oscillator at
 	  startup.  This can then be selected as the main clock source
 	  for the SOC.
 
 config SOC_ATMEL_SAMD_XOSC
-	bool "Enable the external crystal oscillator"
+	bool "The external crystal oscillator"
 	help
 	  Say y to enable the external crystal oscillator at startup.
 

--- a/soc/arm/atmel_sam0/common/Kconfig.samd2x
+++ b/soc/arm/atmel_sam0/common/Kconfig.samd2x
@@ -3,14 +3,14 @@
 if SOC_SERIES_SAMD20 || SOC_SERIES_SAMD21 || SOC_SERIES_SAMR21
 
 config SOC_ATMEL_SAMD_XOSC32K
-	bool "The external 32 kHz crystal oscillator"
+	bool "External 32 kHz crystal oscillator"
 	help
 	  Say y to enable the external 32 kHZ crystal oscillator at
 	  startup.  This can then be selected as the main clock source
 	  for the SOC.
 
 config SOC_ATMEL_SAMD_XOSC
-	bool "The external crystal oscillator"
+	bool "External crystal oscillator"
 	help
 	  Say y to enable the external crystal oscillator at startup.
 

--- a/soc/arm/atmel_sam0/common/Kconfig.samd5x
+++ b/soc/arm/atmel_sam0/common/Kconfig.samd5x
@@ -4,7 +4,7 @@
 if SOC_SERIES_SAMD51 || SOC_SERIES_SAME51 || SOC_SERIES_SAME53 || SOC_SERIES_SAME54
 
 config SOC_ATMEL_SAMD5X_XOSC32K
-	bool "Enable the external 32 kHz crystal oscillator"
+	bool "The external 32 kHz crystal oscillator"
 	help
 	  Say y to enable the external 32 kHZ crystal oscillator at
 	  startup.  This can then be selected as the main clock source

--- a/soc/arm/cypress/Kconfig
+++ b/soc/arm/cypress/Kconfig
@@ -22,7 +22,7 @@ config SOC_PSOC6_M4
 endchoice
 
 config SOC_PSOC6_M0_ENABLES_M4
-	bool "Enable dual-core support [activate Cortex-M4]"
+	bool "Dual-core support [activate Cortex-M4]"
 	depends on SOC_PSOC6_M0
 	help
 	  Cortex-M0 CPU should boot Cortex-M4

--- a/soc/arm/microchip_mec/mec1501/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.soc
@@ -75,7 +75,7 @@ config SOC_MEC1501_VCI_PINS_AS_GPIOS
 	  design.
 
 config SOC_MEC1501_TEST_CLK_OUT
-	bool "Enable test clock out pin"
+	bool "Test clock out pin"
 	help
 	  Enables a test clock out pin
 

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -120,7 +120,7 @@ config NRF_SECURE_APPROTECT_USER_HANDLING
 endchoice
 
 config NRF_TRACE_PORT
-	bool "NRF TPIU"
+	bool "nRF TPIU"
 	depends on !SOC_SERIES_NRF51X
 	help
 	  Enable this option to initialize the TPIU (Trace Port Interface

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -120,7 +120,7 @@ config NRF_SECURE_APPROTECT_USER_HANDLING
 endchoice
 
 config NRF_TRACE_PORT
-	bool "Enable nRF TPIU"
+	bool "NRF TPIU"
 	depends on !SOC_SERIES_NRF51X
 	help
 	  Enable this option to initialize the TPIU (Trace Port Interface

--- a/soc/arm/nordic_nrf/nrf52/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf52/Kconfig.soc
@@ -471,7 +471,7 @@ config GPIO_AS_PINRESET
 	default y
 
 config NRF_ENABLE_ICACHE
-	bool "Enable the instruction cache (I-Cache)"
+	bool "The instruction cache (I-Cache)"
 	depends on SOC_NRF52832 || SOC_NRF52833 || SOC_NRF52840
 	default y
 

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -147,7 +147,7 @@ config SOC_DCDC_NRF53X_HV
 if !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
 
 config SOC_ENABLE_LFXO
-	bool "Enable LFXO"
+	bool "LFXO"
 	default y
 	help
 	  Enable the low-frequency oscillator (LFXO) functionality on XL1 and
@@ -212,7 +212,7 @@ endif # SOC_NRF5340_CPUAPP
 
 
 config NRF_ENABLE_CACHE
-	bool "Enable cache"
+	bool "Cache"
 	depends on (SOC_NRF5340_CPUAPP && (!TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM)) \
 			|| SOC_NRF5340_CPUNET
 	default y
@@ -228,7 +228,7 @@ config BUILD_WITH_TFM
 	select NRF_ENABLE_CACHE if SOC_NRF5340_CPUAPP
 
 config NRF53_SYNC_RTC
-	bool "Enable RTC clock synchronization"
+	bool "RTC clock synchronization"
 	default y if LOG && !LOG_MODE_MINIMAL
 	depends on NRF_RTC_TIMER
 	select NRFX_DPPI

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -69,6 +69,6 @@ config SOC_NRF9160_SICA
 endchoice
 
 config NRF_ENABLE_ICACHE
-	bool "Enable the instruction cache (I-Cache)"
+	bool "The instruction cache (I-Cache)"
 	depends on SOC_NRF9160
 	default y

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -69,6 +69,6 @@ config SOC_NRF9160_SICA
 endchoice
 
 config NRF_ENABLE_ICACHE
-	bool "The instruction cache (I-Cache)"
+	bool "Instruction cache (I-Cache)"
 	depends on SOC_NRF9160
 	default y

--- a/soc/arm/nuvoton_npcx/Kconfig
+++ b/soc/arm/nuvoton_npcx/Kconfig
@@ -12,7 +12,7 @@ config SOC_FAMILY
 	default "nuvoton_npcx"
 
 menuconfig NPCX_HEADER
-	bool "Enable the output binary with NPCX binary header"
+	bool "The output binary with NPCX binary header"
 	help
 	  On NPCX series chip, the NPCX ROM code loads firmware image from flash
 	  to RAM by the firmware binary header setting. Enable this to invoke
@@ -125,13 +125,13 @@ config NPCX_HEADER_CORE_CLOCK_SPI_CLOCK_RATIO
 	default 2 if NPCX_HEADER_CORE_CLOCK_SPI_CLOCK_RATIO_2
 
 config NPCX_HEADER_ENABLE_HEADER_CRC
-	bool "Enable header crc check"
+	bool "Header crc check"
 	help
 	  When enabled, the header will be verified at boot using a crc
 	  checksum.
 
 config NPCX_HEADER_ENABLE_FIRMWARE_CRC
-	bool "Enable firmware image crc check"
+	bool "Firmware image crc check"
 	help
 	  When enabled, the firmware image will be verified at boot using a
 	  crc checksum.

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -621,7 +621,7 @@ config PM_MCUX_PMU
 	bool "MCUX power management unit driver"
 
 menuconfig NXP_IMX_RT_BOOT_HEADER
-	bool "Enable the boot header"
+	bool "The boot header"
 	depends on !BOOTLOADER_MCUBOOT
 	help
 	  Enable data structures required by the boot ROM to boot the
@@ -666,7 +666,7 @@ config IMAGE_VECTOR_TABLE_OFFSET
 	  ROM requires a fixed IVT offset for each type of boot device.
 
 config DEVICE_CONFIGURATION_DATA
-	bool "Enable device configuration data"
+	bool "Device configuration data"
 	default y if HAS_MCUX_SEMC
 	help
 	  Device configuration data (DCD) provides a sequence of commands to

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -621,7 +621,7 @@ config PM_MCUX_PMU
 	bool "MCUX power management unit driver"
 
 menuconfig NXP_IMX_RT_BOOT_HEADER
-	bool "The boot header"
+	bool "Boot header"
 	depends on !BOOTLOADER_MCUBOOT
 	help
 	  Enable data structures required by the boot ROM to boot the

--- a/soc/arm/nxp_imx/rt5xx/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt5xx/Kconfig.soc
@@ -69,7 +69,7 @@ config SOC_PART_NUMBER_IMX_RT5XX
 	  choice defines the default value for this string.
 
 menuconfig NXP_IMX_RT5XX_BOOT_HEADER
-	bool "Enable the boot header"
+	bool "The boot header"
 	depends on !BOOTLOADER_MCUBOOT
 	help
 	  Enable data structures required by the boot ROM to boot the

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.soc
@@ -78,7 +78,7 @@ config SYSOSC_SETTLING_US
 	  board's defconfig.
 
 menuconfig NXP_IMX_RT6XX_BOOT_HEADER
-	bool "Enable the boot header"
+	bool "The boot header"
 	depends on !BOOTLOADER_MCUBOOT
 	help
 	  Enable data structures required by the boot ROM to boot the

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.soc
@@ -78,7 +78,7 @@ config SYSOSC_SETTLING_US
 	  board's defconfig.
 
 menuconfig NXP_IMX_RT6XX_BOOT_HEADER
-	bool "The boot header"
+	bool "Boot header"
 	depends on !BOOTLOADER_MCUBOOT
 	help
 	  Enable data structures required by the boot ROM to boot the

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
@@ -98,7 +98,7 @@ config WDOG_INITIAL_TIMEOUT
 	  milliseconds.
 
 config KINETIS_KE1XF_ENABLE_CODE_CACHE
-	bool "Enable the code cache"
+	bool "The code cache"
 	default y
 
 endif # SOC_SERIES_KINETIS_KE1XF

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.soc
@@ -98,7 +98,7 @@ config WDOG_INITIAL_TIMEOUT
 	  milliseconds.
 
 config KINETIS_KE1XF_ENABLE_CODE_CACHE
-	bool "The code cache"
+	bool "Code cache"
 	default y
 
 endif # SOC_SERIES_KINETIS_KE1XF

--- a/soc/arm/nxp_lpc/lpc54xxx/Kconfig.soc
+++ b/soc/arm/nxp_lpc/lpc54xxx/Kconfig.soc
@@ -39,7 +39,7 @@ config SOC_PART_NUMBER_LPC54XXX
 	  choice defines the default value for this string.
 
 config SECOND_CORE_MCUX
-	bool "Enable LPC54114 Cortex-M0 second core"
+	bool "LPC54114 Cortex-M0 second core"
 	depends on HAS_MCUX
 	help
 	  Driver for second core startup

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.soc
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.soc
@@ -83,7 +83,7 @@ config INIT_PLL0
 	bool "Initialize PLL0"
 
 config SECOND_CORE_MCUX
-	bool "Enable LPC55xxx's second core"
+	bool "LPC55xxx's second core"
 	depends on HAS_MCUX
 	help
 	  Driver for second core startup

--- a/soc/arm/silabs_exx32/Kconfig
+++ b/soc/arm/silabs_exx32/Kconfig
@@ -110,7 +110,7 @@ config SOC_GECKO_TRNG
 	  Set if the SoC has a True Random Number Generator (TRNG) module.
 
 config SOC_GECKO_EMU_DCDC
-	bool "Enable SoC DC/DC regulator"
+	bool "SoC DC/DC regulator"
 	select SOC_GECKO_EMU
 	help
 	  Enable the on chip DC/DC regulator

--- a/soc/arm/st_stm32/common/Kconfig.soc
+++ b/soc/arm/st_stm32/common/Kconfig.soc
@@ -10,7 +10,7 @@ config STM32_CCM
 	def_bool $(dt_chosen_enabled,$(DT_CHOSEN_Z_CCM))
 
 config STM32_BACKUP_SRAM
-	bool "Enable STM32 Backup SRAM"
+	bool "STM32 Backup SRAM"
 	depends on SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || \
 		   SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
 	help

--- a/soc/arm/st_stm32/stm32h7/Kconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.series
@@ -18,5 +18,5 @@ config SOC_SERIES_STM32H7X
 	  Enable support for STM32H7 MCU series
 
 config STM32H7_DUAL_CORE
-	bool "Enable Dual Core"
+	bool "Dual Core"
 	depends on SOC_SERIES_STM32H7X

--- a/soc/riscv/riscv-privilege/andes_v5/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/andes_v5/Kconfig.soc
@@ -45,16 +45,16 @@ config DOUBLE_PRECISION_FPU
 endchoice
 
 config CACHE_ENABLE
-	bool "Enable cache"
+	bool "Cache"
 	default n
 
 config SOC_ANDES_V5_L2_CACHE
-	bool "Enable Andes V5 L2 cache controller"
+	bool "Andes V5 L2 cache controller"
 	depends on CACHE_ENABLE
 	default y
 
 config SOC_ANDES_V5_HWDSP
-	bool "Enable AndeStar V5 DSP ISA"
+	bool "AndeStar V5 DSP ISA"
 	select RISCV_SOC_CONTEXT_SAVE
 	depends on !RISCV_GENERIC_TOOLCHAIN
 	help
@@ -62,7 +62,7 @@ config SOC_ANDES_V5_HWDSP
 		support using the DSP instructions.
 
 config SOC_ANDES_V5_PFT
-	bool "Enable Andes V5 PowerBrake extension"
+	bool "Andes V5 PowerBrake extension"
 	default y
 	select RISCV_SOC_CONTEXT_SAVE
 	help
@@ -70,7 +70,7 @@ config SOC_ANDES_V5_PFT
 		executing rate.
 
 config SOC_ANDES_V5_PMA
-	bool "Enable Andes V5 Physical Memory Attribute (PMA)"
+	bool "Andes V5 Physical Memory Attribute (PMA)"
 	select ARCH_HAS_NOCACHE_MEMORY_SUPPORT
 	help
 		This option enables the Andes V5 PMA, in order to support SW to

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -155,7 +155,7 @@ config BT_HCI_ACL_FLOW_CONTROL
 	  not run out of incoming ACL buffers.
 
 config BT_REMOTE_VERSION
-	bool "Fetching of remote version"
+	bool "Allow fetching of remote version"
 	# Enable if building a Controller-only build
 	default y if BT_HCI_RAW
 	help

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -155,7 +155,7 @@ config BT_HCI_ACL_FLOW_CONTROL
 	  not run out of incoming ACL buffers.
 
 config BT_REMOTE_VERSION
-	bool "Enable fetching of remote version"
+	bool "Fetching of remote version"
 	# Enable if building a Controller-only build
 	default y if BT_HCI_RAW
 	help

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -113,7 +113,7 @@ endchoice
 comment "BLE Controller configuration"
 
 config BT_CTLR_CRYPTO
-	bool "Enable crypto functions in Controller"
+	bool "Crypto functions in Controller"
 	default y
 	select ENTROPY_GENERATOR
 	help
@@ -132,7 +132,7 @@ config BT_CTLR_HCI_VS_BUILD_INFO
 	  already included information.
 
 config BT_CTLR_AD_DATA_BACKUP
-	bool "Enable Legacy AD Data backup"
+	bool "Legacy AD Data backup"
 	depends on BT_PERIPHERAL || BT_CTLR_ADV_EXT
 	default y
 	help
@@ -143,7 +143,7 @@ config BT_CTLR_AD_DATA_BACKUP
 	  Advertising or switch between Legacy and Extended Advertising.
 
 config BT_CTLR_HCI_ADV_HANDLE_MAPPING
-	bool "Enable advertising set handle mapping between HCI and LL"
+	bool "Advertising set handle mapping between HCI and LL"
 	depends on BT_CTLR_ADV_EXT
 	default y if BT_HCI_RAW
 	help
@@ -231,7 +231,7 @@ config BT_CTLR_ISO_TX_BUFFER_SIZE
 	  Read Buffer Size V2 command response.
 
 config BT_CTLR_ISO_VENDOR_DATA_PATH
-	bool "Enable vendor-specific ISO data path"
+	bool "Vendor-specific ISO data path"
 	depends on BT_CTLR_SYNC_ISO || BT_CTLR_CONN_ISO
 
 choice BT_CTLR_TX_PWR

--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -43,7 +43,7 @@ if BT_CTLR_DF
 # Bluetooth v5.1 Direction Finding
 
 config BT_CTLR_DF_CTE_TX
-	bool "Enable transmission of Constant Tone Extension"
+	bool "Transmission of Constant Tone Extension"
 	depends on BT_CTLR_DF_CTE_TX_SUPPORT
 	default y
 	help
@@ -51,7 +51,7 @@ config BT_CTLR_DF_CTE_TX
 	  controller.
 
 config BT_CTLR_DF_CTE_RX_SAMPLE_1US
-	bool "Enable reception of CTE with 1us sampling slots"
+	bool "Reception of CTE with 1us sampling slots"
 	depends on BT_CTLR_DF_CTE_RX_SAMPLE_1US_SUPPORT
 	default y
 	help
@@ -61,7 +61,7 @@ config BT_CTLR_DF_CTE_RX_SAMPLE_1US
 	  Bluetooth v5.1.
 
 config BT_CTLR_DF_ANT_SWITCH_1US
-	bool "Enable support for 1us antenna switch slots"
+	bool "Support for 1us antenna switch slots"
 	depends on BT_CTLR_DF_ANT_SWITCH_1US_SUPPORT
 	default y
 	help
@@ -72,7 +72,7 @@ config BT_CTLR_DF_ANT_SWITCH_1US
 # BT Core spec 5.1, Vol 6, Part B, sec. 4.6 Feature Support
 
 config BT_CTLR_DF_ANT_SWITCH_TX
-	bool "Enable antenna switching during CTE transmission (AoD) feature"
+	bool "Antenna switching during CTE transmission (AoD) feature"
 	depends on BT_CTLR_DF_CTE_TX && BT_CTLR_DF_ANT_SWITCH_2US_SUPPORT
 	default y
 	help
@@ -80,7 +80,7 @@ config BT_CTLR_DF_ANT_SWITCH_TX
 	  Also known as Angle of Departure mode.
 
 config BT_CTLR_DF_ANT_SWITCH_RX
-	bool "Enable antenna switching during CTE reception (AoA) feature"
+	bool "Antenna switching during CTE reception (AoA) feature"
 	depends on BT_CTLR_DF_CTE_RX && BT_CTLR_DF_ANT_SWITCH_2US_SUPPORT
 	default y
 	help
@@ -88,7 +88,7 @@ config BT_CTLR_DF_ANT_SWITCH_RX
 	  Also known as Angle of Arrival mode.
 
 config BT_CTLR_DF_CTE_RX
-	bool "Enable reception of Constant Tone Extension feature"
+	bool "Reception of Constant Tone Extension feature"
 	depends on BT_CTLR_DF_CTE_RX_SUPPORT
 	select BT_CTLR_CONN_RSSI if BT_CONN
 	default y
@@ -96,21 +96,21 @@ config BT_CTLR_DF_CTE_RX
 	  Enable support for reception of Constant Tone Extension in controller.
 
 config BT_CTLR_DF_CONN_CTE_REQ
-	bool "Enable Connection CTE Request feature"
+	bool "Connection CTE Request feature"
 	depends on BT_CTLR_DF_CONN_CTE_RX
 	help
 	  Enable support for Bluetooth v5.1 Connection CTE Request feature
 	  in controller.
 
 config BT_CTLR_DF_CONN_CTE_RSP
-	bool "Enable Connection CTE Response feature"
+	bool "Connection CTE Response feature"
 	depends on BT_CTLR_DF_CONN_CTE_TX
 	help
 	  Enable support for Bluetooth v5.1 Connection CTE Response feature
 	  in controller.
 
 config BT_CTLR_DF_ADV_CTE_TX
-	bool "Enable Connectionless CTE Transmitter feature"
+	bool "Connectionless CTE Transmitter feature"
 	depends on BT_CTLR_DF_CTE_TX && BT_CTLR_ADV_PERIODIC
 	select BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY
 	default y
@@ -119,7 +119,7 @@ config BT_CTLR_DF_ADV_CTE_TX
 	  feature in controller.
 
 config BT_CTLR_DF_SCAN_CTE_RX
-	bool "Enable Connectionless CTE Receiver"
+	bool "Connectionless CTE Receiver"
 	depends on BT_CTLR_DF_CTE_RX && BT_CTLR_SYNC_PERIODIC
 	default y
 	help
@@ -127,7 +127,7 @@ config BT_CTLR_DF_SCAN_CTE_RX
 	  in controller.
 
 config BT_CTLR_DF_CONN_CTE_TX
-	bool "Enable Connection based CTE Transmitter"
+	bool "Connection based CTE Transmitter"
 	depends on BT_CTLR_DF_CTE_TX && BT_CONN
 	default y
 	help
@@ -135,7 +135,7 @@ config BT_CTLR_DF_CONN_CTE_TX
 	  direction finding connected mode.
 
 config BT_CTLR_DF_CONN_CTE_RX
-	bool "Enable Connection based CTE Receiver"
+	bool "Connection based CTE Receiver"
 	depends on BT_CTLR_DF_CTE_RX && BT_CONN
 	default y
 	help
@@ -143,7 +143,7 @@ config BT_CTLR_DF_CONN_CTE_RX
 	  finding connected mode.
 
 config BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC
-	bool "Enable sampling of CTE for PDUs with bad CRC"
+	bool "Sampling of CTE for PDUs with bad CRC"
 	depends on BT_CTLR_DF_SCAN_CTE_RX
 	default y
 	help
@@ -164,7 +164,7 @@ config BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN
 	  to be within range 2 up to 75.
 
 config BT_CTLR_DF_INIT_ANT_SEL_GPIOS
-	bool "Enable initialization of GPIOs responsible for antenna switching"
+	bool "Initialization of GPIOs responsible for antenna switching"
 	depends on BT_CTLR_DF_ANT_SWITCH_TX || BT_CTLR_DF_ANT_SWITCH_RX
 	default y
 	help

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -191,14 +191,14 @@ config BT_CTLR_ADV_SYNC_SET
 	  Maximum supported periodic advertising sets.
 
 config BT_CTLR_ADV_PDU_LINK
-	bool "Enable linking of advertising PDU trains"
+	bool "Linking of advertising PDU trains"
 	help
 	  Enables extra space in each advertising PDU to allow linking PDUs. This
 	  is required to enable advertising data trains (i.e. transmission of
 	  AUX_CHAIN_IND).
 
 config BT_CTLR_ADV_PDU_BACK2BACK
-	bool "Enable back-to-back transmission of extended advertising trains"
+	bool "Back-to-back transmission of extended advertising trains"
 	depends on BT_CTLR_ADV_EXT && BT_BROADCASTER
 	select BT_CTLR_ADV_PDU_LINK
 	help
@@ -214,7 +214,7 @@ config BT_CTLR_ADV_PDU_BACK2BACK_AFS
 	  extended advertising trains. Time specified in microseconds.
 
 config BT_CTLR_ADV_SYNC_PDU_BACK2BACK
-	bool "Enable back-to-back transmission of periodic advertising trains"
+	bool "Back-to-back transmission of periodic advertising trains"
 	depends on BT_CTLR_ADV_PERIODIC
 	select BT_CTLR_ADV_PDU_LINK
 	help
@@ -431,14 +431,14 @@ config BT_CTLR_LOW_LAT_ULL_DONE
 	  Done events be processed and dequeued in ULL context.
 
 config BT_CTLR_CONN_META
-	prompt "Enable connection meta data extension"
+	prompt "Connection meta data extension"
 	bool
 	help
 	  Enables vendor specific per-connection meta data as part of the
 	  LLL connection object.
 
 config BT_CTLR_RX_PDU_META
-	prompt "Enable RX pdu meta data"
+	prompt "RX pdu meta data"
 	bool
 
 config BT_CTLR_RADIO_ENABLE_FAST
@@ -472,7 +472,7 @@ config BT_CTLR_SW_SWITCH_SINGLE_TIMER
 	  less left for other uses
 
 config BT_CTLR_PARAM_CHECK
-	bool "Enable HCI Command Parameter checking"
+	bool "HCI Command Parameter checking"
 	default y if BT_HCI_RAW
 	help
 	  Enable code checking HCI Command Parameters. This is not needed in
@@ -599,7 +599,7 @@ config BT_CTLR_FORCE_MD_AUTO
 	  data throughput.
 
 config BT_CTLR_CONN_RANDOM_FORCE
-	bool "Enable random forced scheduling for peripheral on missed anchor point"
+	bool "Random forced scheduling for peripheral on missed anchor point"
 	depends on BT_PERIPHERAL
 	default y
 	help
@@ -725,7 +725,7 @@ config BT_CTLR_JIT_SCHEDULING
 	  the link layer.
 
 config BT_CTLR_USER_EXT
-	prompt "Enable proprietary extensions in Controller"
+	prompt "Proprietary extensions in Controller"
 	bool
 	help
 	  Catch-all for enabling proprietary event types in Controller behavior.
@@ -759,7 +759,7 @@ config BT_RX_USER_PDU_LEN
 	  PDUs are assumed to not go across HCI.
 
 config BT_CTLR_USER_CPR_INTERVAL_MIN
-	bool "Enable proprietary Connection Parameter Request minimum interval"
+	bool "Proprietary Connection Parameter Request minimum interval"
 	depends on BT_CTLR_USER_EXT
 	help
 	  When enabled, controller will accept Connection Parameter Request

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -176,7 +176,7 @@ config BT_WHITELIST
 	select BT_FILTER_ACCEPT_LIST
 
 config BT_FILTER_ACCEPT_LIST
-	bool "Enable filter accept list support"
+	bool "Filter accept list support"
 	help
 	  This option enables the filter accep list API. This takes advantage of the
 	  filtering feature of a BLE controller.
@@ -245,7 +245,7 @@ config BT_AUTO_DATA_LEN_UPDATE
 	  procedure at its discretion or want to initiate manually.
 
 config BT_REMOTE_INFO
-	bool "Enable application access to remote information"
+	bool "Application access to remote information"
 	help
 	  Enable application access to the remote information available in the
 	  stack. The remote information is retrieved once a connection has been
@@ -360,7 +360,7 @@ config BT_FIXED_PASSKEY
 	  pairing_confim() callback will be called for all incoming pairings.
 
 config BT_USE_DEBUG_KEYS
-	bool "Enable Security Manager Debug Mode"
+	bool "Security Manager Debug Mode"
 	help
 	  This option places Security Manager in a Debug Mode. In this mode
 	  predefined Diffie-Hellman private/public key pair is used as described
@@ -562,7 +562,7 @@ config BT_ID_MAX
 	  products this is safe to leave as the default value (1).
 
 config BT_DF
-	bool "Enable Direction Finding support [EXPERIMENTAL]"
+	bool "Direction Finding support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Enable support for Bluetooth 5.1 Direction Finding.
@@ -572,45 +572,45 @@ config BT_DF
 if BT_DF
 
 config BT_DF_CONNECTIONLESS_CTE_RX
-	bool "Enable support for receive of CTE in connectionless mode"
+	bool "Support for receive of CTE in connectionless mode"
 	help
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connectionless mode.
 
 config BT_DF_CONNECTIONLESS_CTE_TX
-	bool "Enable support for transmission of CTE in connectionless mode"
+	bool "Support for transmission of CTE in connectionless mode"
 	help
 	  Enable support for transmission of Constant Tone Extension in
 	  connectionless mode.
 
 config BT_DF_CONNECTION_CTE_RX
-	bool "Enable support for receive of CTE in connection mode"
+	bool "Support for receive of CTE in connection mode"
 	help
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connection mode.
 
 config BT_DF_CONNECTION_CTE_TX
-	bool "Enable support for transmission of CTE in connection mode"
+	bool "Support for transmission of CTE in connection mode"
 	help
 	  Enable support for transmission of Constant Tone Extension in
 	  connection mode.
 
 config BT_DF_CONNECTION_CTE_REQ
-	bool "Enable support for CTE request procedure in connection mode"
+	bool "Support for CTE request procedure in connection mode"
 	depends on BT_DF_CONNECTION_CTE_RX
 	help
 	  Enable support for request of Constant Tone Extension in connection
 	  mode.
 
 config BT_DF_CONNECTION_CTE_RSP
-	bool "Enable support for CTE request procedure in connection mode"
+	bool "Support for CTE request procedure in connection mode"
 	depends on BT_DF_CONNECTION_CTE_TX
 	help
 	  Enable support for request of Constant Tone Extension in connection
 	  mode.
 
 config BT_DF_CTE_RX_AOA
-	bool "Enable antenna switching during CTE reception (AoA) feature"
+	bool "Antenna switching during CTE reception (AoA) feature"
 	depends on BT_DF_CONNECTIONLESS_CTE_RX || BT_DF_CONNECTION_CTE_RX
 	default y
 	help
@@ -618,7 +618,7 @@ config BT_DF_CTE_RX_AOA
 	  Also known as Angle of Arrival mode.
 
 config BT_DF_CTE_TX_AOD
-	bool "Enable antenna switching during CTE transmission (AoD) feature"
+	bool "Antenna switching during CTE transmission (AoD) feature"
 	depends on BT_DF_CONNECTIONLESS_CTE_TX || BT_DF_CONNECTION_CTE_TX
 	default y
 	help
@@ -634,7 +634,7 @@ endif # BT_DF
 endif # BT_HCI_HOST
 
 config BT_ECC
-	bool "Enable ECDH key generation support"
+	bool "ECDH key generation support"
 	default y if BT_MESH_PROV || (BT_SMP && !BT_SMP_OOB_LEGACY_PAIR_ONLY)
 	help
 	  This option adds support for ECDH HCI commands.
@@ -658,7 +658,7 @@ config BT_TINYCRYPT_ECC
 	  does not have any special ECC support itself (at least not currently).
 
 config BT_HOST_CCM
-	bool "Enable host side AES-CCM module"
+	bool "Host side AES-CCM module"
 	help
 	  Enables the software based AES-CCM engine in the host. Will use the
 	  controller's AES encryption functions if available, or BT_HOST_CRYPTO

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -213,7 +213,7 @@ config BT_MESH_PROXY_FILTER_SIZE
 endif # BT_CONN
 
 config BT_MESH_ACCESS_LAYER_MSG
-	bool "Enable direct Bluetooth message access layer messages"
+	bool "Direct Bluetooth message access layer messages"
 	help
 	  This option allows the applicaiton to directly access
 	  Bluetooth access layer messages without the need to
@@ -775,7 +775,7 @@ config BT_MESH_HEALTH_CLI
 	  Enable support for the health client model.
 
 config BT_MESH_SHELL
-	bool "Enable Bluetooth mesh shell"
+	bool "Bluetooth mesh shell"
 	select SHELL
 	help
 	  Activate shell module that provides Bluetooth mesh commands to
@@ -837,7 +837,7 @@ config BT_MESH_RPL_STORE_TIMEOUT
 endif # BT_SETTINGS
 
 config BT_MESH_DEBUG
-	bool "Enable debug logs"
+	bool "Debug logs"
 	depends on BT_DEBUG
 	help
 	  Use this option to enable debug logs for the Bluetooth

--- a/subsys/bluetooth/services/Kconfig.bas
+++ b/subsys/bluetooth/services/Kconfig.bas
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_BAS
-	bool "Enable GATT Battery service"
+	bool "GATT Battery service"
 	select SENSOR
 
 if BT_BAS

--- a/subsys/bluetooth/services/Kconfig.dis
+++ b/subsys/bluetooth/services/Kconfig.dis
@@ -4,12 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_DIS
-	bool "Enable GATT Device Information service"
+	bool "GATT Device Information service"
 
 if BT_DIS
 
 config BT_DIS_SETTINGS
-	bool "Enable Settings usage in Device Information Service"
+	bool "Settings usage in Device Information Service"
 	select SETTINGS
 	help
 	  Enable Settings usage in Device Information Service.
@@ -36,7 +36,7 @@ config BT_DIS_MANUF
 	  The device manufacturer inside Device Information Service.
 
 config BT_DIS_PNP
-	bool "Enable PnP_ID characteristic"
+	bool "PnP_ID characteristic"
 	default y
 	help
 	  Enable PnP_ID characteristic in Device Information Service.
@@ -99,7 +99,7 @@ config BT_DIS_PNP_VER
 endif # BT_DIS_PNP
 
 config BT_DIS_SERIAL_NUMBER
-	bool "Enable DIS Serial number characteristic"
+	bool "DIS Serial number characteristic"
 	help
 	  Enable Serial Number characteristic in Device Information Service.
 
@@ -110,7 +110,7 @@ config BT_DIS_SERIAL_NUMBER_STR
 	  Enable Serial Number characteristic in Device Information Service.
 
 config BT_DIS_FW_REV
-	bool "Enable DIS Firmware Revision characteristic"
+	bool "DIS Firmware Revision characteristic"
 	help
 	  Enable Firmware Revision characteristic in Device Information Service.
 
@@ -121,7 +121,7 @@ config BT_DIS_FW_REV_STR
 	  Enable firmware revision characteristic in Device Information Service.
 
 config BT_DIS_HW_REV
-	bool "Enable DIS Hardware Revision characteristic"
+	bool "DIS Hardware Revision characteristic"
 	help
 	  Enable Hardware Revision characteristic in Device Information Service.
 
@@ -132,7 +132,7 @@ config BT_DIS_HW_REV_STR
 	  Enable hardware revision characteristic in Device Information Service.
 
 config BT_DIS_SW_REV
-	bool "Enable DIS Software Revision characteristic"
+	bool "DIS Software Revision characteristic"
 	help
 	  Enable Software Revision characteristic in Device Information Service.
 

--- a/subsys/bluetooth/services/Kconfig.hrs
+++ b/subsys/bluetooth/services/Kconfig.hrs
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_HRS
-	bool "Enable GATT Heart Rate service"
+	bool "GATT Heart Rate service"
 
 if BT_HRS
 

--- a/subsys/bluetooth/services/Kconfig.tps
+++ b/subsys/bluetooth/services/Kconfig.tps
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig BT_TPS
-	bool "Enable GATT TX Power service"
+	bool "GATT TX Power service"
 
 if BT_TPS
 

--- a/subsys/bluetooth/services/ots/Kconfig
+++ b/subsys/bluetooth/services/ots/Kconfig
@@ -15,7 +15,7 @@ config BT_OTS
 if BT_OTS
 
 config BT_OTS_DIR_LIST_OBJ
-	bool "Enables the Directory Listing Object"
+	bool "The Directory Listing Object"
 	help
 	  Enables the Directory Listing Object, which is an object that contains all the metadata
 	  from all other objects, for easy exposure to a client. Enabling this will use one of the

--- a/subsys/bluetooth/shell/Kconfig
+++ b/subsys/bluetooth/shell/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BT_SHELL
-	bool "Enable Bluetooth shell"
+	bool "Bluetooth shell"
 	select SHELL
 	help
 	  Activate shell module that provides Bluetooth commands to the

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -59,7 +59,7 @@ config ISOTP_REQUIRE_RX_PADDING
 	  By default, received CAN frames with or without padding are accepted.
 
 config ISOTP_ENABLE_TX_PADDING
-	bool "Enable padding for transmitted messages"
+	bool "Padding for transmitted messages"
 	help
 	  Add padding bytes 0xCC (as recommended by Bosch) if the PDU payload
 	  does not fit exactly into the CAN frame.
@@ -116,7 +116,7 @@ config ISOTP_BUF_TX_DATA_POOL_SIZE
 endif # ISOTP_USE_TX_BUF
 
 config ISOTP_ENABLE_CONTEXT_BUFFERS
-	bool "Enable buffered tx contexts"
+	bool "Buffered tx contexts"
 	default y
 	help
 	  This option enables buffered sending contexts. This makes send and

--- a/subsys/cpp/Kconfig
+++ b/subsys/cpp/Kconfig
@@ -63,13 +63,13 @@ config LIB_CPLUSPLUS
 if LIB_CPLUSPLUS
 
 config EXCEPTIONS
-	bool "Enable C++ exceptions support"
+	bool "C++ exceptions support"
 	depends on !NEWLIB_LIBC_NANO
 	help
 	  This option enables support of C++ exceptions.
 
 config RTTI
-	bool "Enable C++ RTTI support"
+	bool "C++ RTTI support"
 	help
 	  This option enables support of C++ RTTI.
 

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -7,7 +7,7 @@
 menu "System Monitoring Options"
 
 menuconfig THREAD_ANALYZER
-	bool "Enable Thread analyzer"
+	bool "Thread analyzer"
 	select INIT_STACKS
 	select THREAD_MONITOR
 	select THREAD_STACK_INFO
@@ -142,7 +142,7 @@ config STACK_USAGE
 	  on a per-function basis.
 
 config STACK_SENTINEL
-	bool "Enable stack sentinel"
+	bool "Stack sentinel"
 	select THREAD_STACK_INFO
 	depends on MULTITHREADING
 	depends on !USERSPACE
@@ -195,7 +195,7 @@ config EARLY_CONSOLE
 	  sent through the console at the earliest stage possible.
 
 config ASSERT
-	bool "Enable __ASSERT() macro"
+	bool "__ASSERT() macro"
 	default y if TEST
 	help
 	  This enables the __ASSERT() macro in the kernel code. If an assertion
@@ -220,7 +220,7 @@ config ASSERT_LEVEL
 	  Level 2: on + no warning
 
 config SPIN_VALIDATE
-	bool "Enable spinlock validation"
+	bool "Spinlock validation"
 	depends on ASSERT
 	depends on MULTITHREADING
 	depends on MP_NUM_CPUS <= 4
@@ -239,7 +239,7 @@ config FORCE_NO_ASSERT
 	  around compiler bugs for specific tests.
 
 config ASSERT_VERBOSE
-	bool "Enable verbose assertions"
+	bool "Verbose assertions"
 	default y
 	help
 	  This option enables printing an assert message with information about
@@ -307,7 +307,7 @@ config OMIT_FRAME_POINTER
 # Generic Debugging Options
 #
 config DEBUG_INFO
-	bool "Enable system debugging information"
+	bool "System debugging information"
 	help
 	  This option enables the addition of various information that can be
 	  used by debuggers in debugging the system, or enable additional

--- a/subsys/debug/coredump/Kconfig
+++ b/subsys/debug/coredump/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig DEBUG_COREDUMP
-	bool "Enable Core Dump"
+	bool "Core Dump"
 	depends on ARCH_SUPPORTS_COREDUMP
 	help
 	  Enable core dump so it can be used for offline debugging.
@@ -62,7 +62,7 @@ config DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM
 endchoice
 
 config DEBUG_COREDUMP_SHELL
-	bool "Enable Coredump shell"
+	bool "Coredump shell"
 	default y
 	depends on SHELL
 	help

--- a/subsys/dfu/Kconfig
+++ b/subsys/dfu/Kconfig
@@ -71,7 +71,7 @@ config IMG_ERASE_PROGRESSIVELY
 	  times at the beginning of the DFU process.
 
 config IMG_ENABLE_IMAGE_CHECK
-	bool "Enable image check functions"
+	bool "Image check functions"
 	depends on MCUBOOT_IMG_MANAGER
 	select FLASH_AREA_CHECK_INTEGRITY
 	help

--- a/subsys/fs/Kconfig
+++ b/subsys/fs/Kconfig
@@ -44,7 +44,7 @@ config FILE_SYSTEM_MAX_FILE_NAME
          violations.
 
 config FILE_SYSTEM_SHELL
-	bool "Enable file system shell"
+	bool "File system shell"
 	depends on SHELL
 	depends on HEAP_MEM_POOL_SIZE > 0
 	help
@@ -52,7 +52,7 @@ config FILE_SYSTEM_SHELL
 	  file system.
 
 config FUSE_FS_ACCESS
-	bool "Enable FUSE based access to file system partitions"
+	bool "FUSE based access to file system partitions"
 	depends on ARCH_POSIX
 	help
 	  Expose file system partitions to the host system through FUSE.

--- a/subsys/fs/Kconfig.fatfs
+++ b/subsys/fs/Kconfig.fatfs
@@ -57,7 +57,7 @@ config FS_FATFS_MAX_ROOT_ENTRIES
 endif # FS_FATFS_MOUNT_MKFS
 
 config FS_FATFS_EXFAT
-	bool "Enable exFAT support"
+	bool "ExFAT support"
 	select FS_FATFS_LFN
 	help
 	  Enable the exFAT format support for FatFs.
@@ -71,7 +71,7 @@ config FS_FATFS_NUM_DIRS
 	default 4
 
 config FS_FATFS_LFN
-	bool "Enable long filenames (LFN)"
+	bool "Long filenames (LFN)"
 	help
 	  Without long filenames enabled, file names are limited to 8.3 format.
 	  This option increases working buffer size.

--- a/subsys/fs/Kconfig.littlefs
+++ b/subsys/fs/Kconfig.littlefs
@@ -106,7 +106,7 @@ config FS_LITTLEFS_HEAP_PER_ALLOC_OVERHEAD_SIZE
 endif # FS_LITTLEFS_FC_HEAP_SIZE <= 0
 
 config FS_LITTLEFS_BLK_DEV
-	bool "Enable support for littlefs on block devices"
+	bool "Support for littlefs on block devices"
 	help
 	  Enable this option to provide support for littlefs on the block
 	  devices (like for example SD card).

--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -4,7 +4,7 @@
 menu "Backends"
 
 config LOG_BACKEND_UART
-	bool "Enable UART backend"
+	bool "UART backend"
 	depends on UART_CONSOLE
 	default y if !SHELL_BACKEND_SERIAL
 	help
@@ -44,7 +44,7 @@ endif # LOG_BACKEND_UART_OUTPUT_DICTIONARY
 endif # LOG_BACKEND_UART
 
 config LOG_BACKEND_SWO
-	bool "Enable Serial Wire Output (SWO) backend"
+	bool "Serial Wire Output (SWO) backend"
 	depends on HAS_SWO
 	help
 	  When enabled, backend will use SWO for logging.
@@ -73,7 +73,7 @@ source "subsys/logging/Kconfig.template.log_format_config"
 endif # LOG_BACKEND_SWO
 
 config LOG_BACKEND_RTT
-	bool "Enable Segger J-Link RTT backend"
+	bool "Segger J-Link RTT backend"
 	depends on USE_SEGGER_RTT
 	default y if !SHELL_BACKEND_RTT
 	select SEGGER_RTT_CUSTOM_LOCKING
@@ -178,7 +178,7 @@ config LOG_BACKEND_RTT_FORCE_PRINTK
 endif # LOG_BACKEND_RTT
 
 config LOG_BACKEND_SPINEL
-	bool "Enable OpenThread dedicated Spinel protocol backend"
+	bool "OpenThread dedicated Spinel protocol backend"
 	depends on !LOG_BACKEND_UART
 	depends on NET_L2_OPENTHREAD
 	help
@@ -202,7 +202,7 @@ source "subsys/logging/Kconfig.template.log_format_config"
 endif # LOG_BACKEND_SPINEL
 
 config LOG_BACKEND_NATIVE_POSIX
-	bool "Enable native backend"
+	bool "Native backend"
 	depends on ARCH_POSIX
 	help
 	  Enable backend in native_posix
@@ -216,7 +216,7 @@ source "subsys/logging/Kconfig.template.log_format_config"
 endif # LOG_BACKEND_NATIVE_POSIX
 
 config LOG_BACKEND_XTENSA_SIM
-	bool "Enable xtensa simulator backend"
+	bool "Xtensa simulator backend"
 	depends on SOC_XTENSA_SAMPLE_CONTROLLER || SOC_FAMILY_INTEL_ADSP
 	help
 	  Enable backend in xtensa simulator
@@ -240,7 +240,7 @@ endif # LOG_BACKEND_XTENSA_SIM
 # Immediate mode cannot be used with network backend as it would cause the sent
 # rsyslog message to be malformed.
 config LOG_BACKEND_NET
-	bool "Enable networking backend"
+	bool "Networking backend"
 	depends on NETWORKING && NET_UDP && !LOG_MODE_IMMEDIATE
 	select NET_CONTEXT_NET_PKT_POOL
 	help
@@ -301,7 +301,7 @@ source "subsys/logging/Kconfig.template.log_format_config"
 endif # LOG_BACKEND_NET
 
 config LOG_BACKEND_ADSP
-	bool "Enable Intel ADSP buffer backend"
+	bool "Intel ADSP buffer backend"
 	depends on SOC_FAMILY_INTEL_ADSP
 	help
 	  Enable backend for the host trace protocol of the Intel ADSP
@@ -316,7 +316,7 @@ source "subsys/logging/Kconfig.template.log_format_config"
 endif # LOG_BACKEND_ADSP
 
 config LOG_BACKEND_FS
-	bool "Enable file system backend"
+	bool "File system backend"
 	depends on FILE_SYSTEM
 	help
 	  When enabled, backend is using the configured file system to output logs.
@@ -331,7 +331,7 @@ backend-str = fs
 source "subsys/logging/Kconfig.template.log_format_config"
 
 config LOG_BACKEND_FS_OVERWRITE
-	bool "Enable old log files overwrite"
+	bool "Old log files overwrite"
 	default y
 	help
 	  When enabled backend overwrites oldest log files.

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -22,7 +22,7 @@ config LOG_FUNC_NAME_PREFIX_DBG
 endmenu
 
 config LOG_MIPI_SYST_ENABLE
-	bool "Enable MIPI SyS-T format output"
+	bool "MIPI SyS-T format output"
 	select MIPI_SYST_LIB
 	help
 	  Enable MIPI SyS-T format output for the logger system.
@@ -51,7 +51,7 @@ config LOG_IMMEDIATE_CLEAN_OUTPUT
 	  time (up to multiple milliseconds).
 
 config LOG_BACKEND_SHOW_COLOR
-	bool "Enable colors in the backend"
+	bool "Colors in the backend"
 	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
 	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM
 	default y
@@ -81,7 +81,7 @@ config LOG_TAG_DEFAULT
 	  Initial tag.
 
 config LOG_BACKEND_FORMAT_TIMESTAMP
-	bool "Enable timestamp formatting in the backend"
+	bool "Timestamp formatting in the backend"
 	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
 	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM || LOG_BACKEND_FS
 	default y

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -12,7 +12,7 @@ config LOG_DOMAIN_ID
 	  In multicore system each application/core must have unique domain ID.
 
 config LOG_CMDS
-	bool "Enable shell commands"
+	bool "Shell commands"
 	depends on SHELL
 	depends on !LOG_FRONTEND && !LOG_MODE_MINIMAL
 	default y if SHELL
@@ -57,7 +57,7 @@ config LOG2_FMT_SECTION
 	  logging.
 
 config LOG_MEM_UTILIZATION
-	bool "Enable tracking maximum memory utilization"
+	bool "Tracking maximum memory utilization"
 	depends on LOG_MODE_DEFERRED
 	default y if LOG_CMDS
 	select MEM_SLAB_TRACE_MAX_UTILIZATION if LOG1

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -142,7 +142,7 @@ config LOG_STRDUP_BUF_COUNT
 	  some additional fixed overhead.
 
 config LOG_STRDUP_POOL_PROFILING
-	bool "Enable profiling of pool used for log_strdup()"
+	bool "Profiling of pool used for log_strdup()"
 	help
 	  When enabled, maximal utilization of the pool is tracked. It can
 	  be read out using shell command.

--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -35,7 +35,7 @@ config HAWKBIT_POLL_INTERVAL
 	  This time interval is zero and 43200 minutes(30 days).
 
 config HAWKBIT_SHELL
-	bool "Enable Hawkbit shell utilities"
+	bool "Hawkbit shell utilities"
 	depends on SHELL
 	help
 	  Activate shell module that provides Hawkbit commands.

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -31,7 +31,7 @@ config MGMT_CBORATTR_MAX_SIZE
           The maximum size of a CBOR attribute during decoding
 
 config MGMT_CBORATTR_FLOAT_SUPPORT
-	bool "Enable support for float"
+	bool "Support for float"
 	help
 	  The option enables float processing within CBOR attributes.
 	  If your code requires processing of float numbers by CBOR,
@@ -40,7 +40,7 @@ config MGMT_CBORATTR_FLOAT_SUPPORT
 
 menu "Command Handlers"
 menuconfig MCUMGR_CMD_FS_MGMT
-	bool "Enable mcumgr handlers for file management (insecure)"
+	bool "Mcumgr handlers for file management (insecure)"
 	depends on FILE_SYSTEM
 	help
 	  Enables mcumgr handlers for file management
@@ -96,7 +96,7 @@ config FS_MGMT_UL_CHUNK_SIZE
 	  this size gets allocated on the stack during handling of a file upload command.
 
 config FS_MGMT_DL_CHUNK_SIZE_LIMIT
-	bool "Enable setting custom size of download file chunk"
+	bool "Setting custom size of download file chunk"
 	help
 	  By default file chunk, that will be read off storage and fit into
 	  mcumgr frame, is automatically calculated to fit into buffer
@@ -132,7 +132,7 @@ config FS_MGMT_PATH_SIZE
 endif
 
 config MCUMGR_CMD_SHELL_MGMT
-	bool "Enable mcumgr handlers for shell management"
+	bool "Mcumgr handlers for shell management"
 	depends on SHELL
 	select SHELL_BACKEND_DUMMY
 	help
@@ -147,7 +147,7 @@ config MCUMGR_CMD_SHELL_MGMT
 	  increase the value. Remember to set MCUMGR_BUF_SIZE accordingly.
 
 menuconfig MCUMGR_CMD_IMG_MGMT
-	bool "Enable mcumgr handlers for image management"
+	bool "Mcumgr handlers for image management"
 	select FLASH
 	select MPU_ALLOW_FLASH_WRITE if ARM_MPU
 	select IMG_MANAGER
@@ -221,7 +221,7 @@ endif
 
 
 menuconfig MCUMGR_CMD_OS_MGMT
-	bool "Enable mcumgr handlers for OS management"
+	bool "Mcumgr handlers for OS management"
 	select REBOOT
 	help
 	  Enables mcumgr handlers for OS management
@@ -287,7 +287,7 @@ config OS_MGMT_TASKSTAT_THREAD_NAME_LEN
 	  sign.
 
 config OS_MGMT_TASKSTAT_SIGNED_PRIORITY
-	bool "Enable signed priorities"
+	bool "Signed priorities"
 	help
 	  Zephyr uses int8_t as thread priorities, but in taskstat response it encodes
 	  them as unsigned.  Enabling this option will use signed int for priorities in
@@ -327,7 +327,7 @@ endif
 
 
 menuconfig MCUMGR_CMD_STAT_MGMT
-	bool "Enable mcumgr handlers for statistics management"
+	bool "Mcumgr handlers for statistics management"
 	depends on STATS
 	help
 	  Enables mcumgr handlers for statistics management.
@@ -344,13 +344,13 @@ config STAT_MGMT_MAX_NAME_LEN
 
 
 menuconfig MCUMGR_GRP_ZEPHYR_BASIC
-	bool "Enable Zephyr specific basic group of commands"
+	bool "Zephyr specific basic group of commands"
 	help
 	  Enables mcumgr to processing of Zephyr specific groups.
 
 if MCUMGR_GRP_ZEPHYR_BASIC
 config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
-	bool "Enables storage erase command"
+	bool "Storage erase command"
 	help
 	  Enables command that allows to erase storage partition.
 

--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -69,7 +69,7 @@ config OSDP_PACKET_TRACE
 	  LOG_HEXDUMP_DBG() is used to achieve this and can be very verbose.
 
 config OSDP_SC_ENABLED
-	bool "Enable OSDP Secure Channel"
+	bool "OSDP Secure Channel"
 	depends on CSPRING_ENABLED
 	default y
 	select CRYPTO

--- a/subsys/mgmt/updatehub/Kconfig
+++ b/subsys/mgmt/updatehub/Kconfig
@@ -65,7 +65,7 @@ config UPDATEHUB_SERVER
 	  other address, must be set on the UpdateHub shell
 
 config UPDATEHUB_SHELL
-	bool "Enable UpdateHub shell utilities"
+	bool "UpdateHub shell utilities"
 	depends on SHELL
 	select KERNEL_SHELL
 	help

--- a/subsys/modbus/Kconfig
+++ b/subsys/modbus/Kconfig
@@ -72,7 +72,7 @@ config MODBUS_FP_EXTENSIONS
 	  Enable Floating-Point extensions
 
 config MODBUS_FC08_DIAGNOSTIC
-	bool "Enable FC08 Diagnostic support"
+	bool "FC08 Diagnostic support"
 	depends on MODBUS_SERVER
 	default y
 	help

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -7,7 +7,7 @@
 menu "IP stack"
 
 config NET_NATIVE
-	bool "Enable native IP stack"
+	bool "Native IP stack"
 	default y
 	help
 	  Enables Zephyr native IP stack. If you disable this, then
@@ -117,14 +117,14 @@ source "subsys/net/ip/Kconfig.ipv6"
 source "subsys/net/ip/Kconfig.ipv4"
 
 config NET_SHELL
-	bool "Enable network shell utilities"
+	bool "Network shell utilities"
 	select SHELL
 	help
 	  Activate shell module that provides network commands like
 	  ping to the console.
 
 config NET_SHELL_DYN_CMD_COMPLETION
-	bool "Enable network shell dynamic command completion"
+	bool "Network shell dynamic command completion"
 	depends on NET_SHELL
 	default y
 	help
@@ -320,7 +320,7 @@ config NET_MAX_NEXTHOPS
 	  This determines how many entries can be stored in nexthop table.
 
 config NET_ROUTE_MCAST
-	bool "Enable Multicast Routing / Forwarding"
+	bool "Multicast Routing / Forwarding"
 	depends on NET_ROUTE
 	help
 	  Activates multicast routing/forwarding
@@ -334,7 +334,7 @@ config NET_MAX_MCAST_ROUTES
 	  routing table.
 
 config NET_TCP
-	bool "Enable TCP"
+	bool "TCP"
 	help
 	  The value depends on your network needs.
 
@@ -480,12 +480,12 @@ config NET_TCP_ISN_RFC6528
 	  If this is not set, then sys_rand32_get() is used for ISN value.
 
 config NET_TEST_PROTOCOL
-	bool "Enable JSON based test protocol (UDP)"
+	bool "JSON based test protocol (UDP)"
 	help
 	  Enable JSON based test protocol (UDP).
 
 config NET_UDP
-	bool "Enable UDP"
+	bool "UDP"
 	default y
 	help
 	  The value depends on your network needs.
@@ -533,7 +533,7 @@ config NET_MAX_CONTEXTS
 	  similar as one could call a network socket in some other systems.
 
 config NET_CONTEXT_NET_PKT_POOL
-	bool "Enable net_buf TX pool / context"
+	bool "Net_buf TX pool / context"
 	default y if NET_TCP && NET_6LO
 	help
 	  If enabled, then it is possible to fine-tune network packet pool
@@ -609,7 +609,7 @@ config NET_SLIP_TAP
 	  https://github.com/zephyrproject-rtos/net-tools for more details.
 
 config NET_TRICKLE
-	bool "Enable Trickle library"
+	bool "Trickle library"
 	help
 	  Normally this is enabled automatically if needed,
 	  so say 'n' if unsure.
@@ -752,7 +752,7 @@ config NET_DEFAULT_IF_PPP
 endchoice
 
 config NET_PKT_TIMESTAMP
-	bool "Enable network packet timestamp support"
+	bool "Network packet timestamp support"
 	help
 	  Enable network packet timestamp support. This is needed for
 	  example in gPTP which needs to know how long it takes to send
@@ -779,14 +779,14 @@ config NET_PKT_TIMESTAMP_STACK_SIZE
 	  callbacks.
 
 config NET_PKT_TXTIME
-	bool "Enable network packet TX time support"
+	bool "Network packet TX time support"
 	help
 	  Enable network packet TX time support. This is needed for
 	  when the application wants to set the exact time when the network
 	  packet should be sent.
 
 config NET_PKT_RXTIME_STATS
-	bool "Enable network packet RX time statistics"
+	bool "Network packet RX time statistics"
 	select NET_PKT_TIMESTAMP
 	select NET_STATISTICS
 	depends on (NET_UDP || NET_TCP || NET_SOCKETS_PACKET) && NET_NATIVE
@@ -809,7 +809,7 @@ config NET_PKT_RXTIME_STATS_DETAIL
 	  command.
 
 config NET_PKT_TXTIME_STATS
-	bool "Enable network packet TX time statistics"
+	bool "Network packet TX time statistics"
 	select NET_PKT_TIMESTAMP
 	select NET_STATISTICS
 	depends on (NET_UDP || NET_TCP || NET_SOCKETS_PACKET) && NET_NATIVE
@@ -834,7 +834,7 @@ config NET_PKT_TXTIME_STATS_DETAIL
 	  command.
 
 config NET_PROMISCUOUS_MODE
-	bool "Enable promiscuous mode support"
+	bool "Promiscuous mode support"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	select NET_L2_ETHERNET_MGMT if NET_L2_ETHERNET

--- a/subsys/net/ip/Kconfig.debug
+++ b/subsys/net/ip/Kconfig.debug
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_LOG
-	bool "Enable network stack logging and debugging"
+	bool "Network stack logging and debugging"
 	select LOG
 	help
 	  Enable logging in various parts of the network stack.

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -58,7 +58,7 @@ config NET_IPV4_IGMP
 	  See RFC 2236 for details.
 
 config NET_DHCPV4
-	bool "Enable DHCPv4 client"
+	bool "DHCPv4 client"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	depends on NET_UDP
@@ -73,14 +73,14 @@ config NET_DHCPV4_INITIAL_DELAY_MAX
 	  1 and 10 seconds before sending the initial discover.
 
 config NET_IPV4_AUTO
-	bool "Enable IPv4 autoconfiguration [EXPERIMENTAL]"
+	bool "IPv4 autoconfiguration [EXPERIMENTAL]"
 	depends on NET_ARP
 	select EXPERIMENTAL
 	help
 	  Enables IPv4 auto IP address configuration (see RFC 3927)
 
 config NET_IPV4_HDR_OPTIONS
-	bool "Enable IPv4 Header options support"
+	bool "IPv4 Header options support"
 	help
 	  Enables IPv4 header options support. Current support for only
 	  ICMPv4 Echo request. Only RecordRoute and Timestamp are handled.

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -137,14 +137,14 @@ config NET_IPV6_RA_RDNSS
 	  See RFC 6106 for details. The value depends on your network needs.
 
 config NET_6LO
-	bool "Enable 6lowpan IPv6 Compression library"
+	bool "6lowpan IPv6 Compression library"
 	default y if NET_L2_IEEE802154
 	help
 	  6lowpan compression and fragmentation. It is enabled by default
 	  if 802.15.4 is present, since using IPv6 on it requires it.
 
 config NET_6LO_CONTEXT
-	bool "Enable 6lowpan context based compression"
+	bool "6lowpan context based compression"
 	depends on NET_6LO
 	help
 	  Enables 6lowpan context based compression based on information

--- a/subsys/net/ip/Kconfig.mgmt
+++ b/subsys/net/ip/Kconfig.mgmt
@@ -39,7 +39,7 @@ config NET_MGMT_EVENT_QUEUE_SIZE
 	  on the load of the system, planned for the usage.
 
 config NET_MGMT_EVENT_INFO
-	bool "Enable passing information along with an event"
+	bool "Passing information along with an event"
 	help
 	  Event notifier will be able to provide information to an event,
 	  and listeners will then be able to get it. Such information depends
@@ -70,7 +70,7 @@ module-help = Enable debug messages output for network management events.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_DEBUG_MGMT_EVENT_STACK
-	bool "Enable stack analysis output on Net MGMT event core"
+	bool "Stack analysis output on Net MGMT event core"
 	select INIT_STACKS
 	help
 	  Add debug messages output on how much Net MGMT event stack is used.

--- a/subsys/net/l2/Kconfig
+++ b/subsys/net/l2/Kconfig
@@ -4,14 +4,14 @@
 menu "Link layer options"
 
 config NET_L2_DUMMY
-	bool "Enable dummy l2 layer"
+	bool "Dummy l2 layer"
 	default y if !NET_L2_ETHERNET && NET_TEST
 	help
 	  Add a dummy L2 layer driver. This is usually only needed when
 	  simulating a network interface when running network stack inside QEMU.
 
 config NET_L2_BT
-	bool "Enable Bluetooth support"
+	bool "Bluetooth support"
 	depends on NET_IPV6
 	depends on BT
 	depends on BT_PERIPHERAL
@@ -53,13 +53,13 @@ source "subsys/net/Kconfig.template.log_config.net"
 endif
 
 config NET_L2_BT_MGMT
-	bool "Enable Bluetooth Network Management support"
+	bool "Bluetooth Network Management support"
 	depends on NET_L2_BT
 	select NET_MGMT
 	select NET_MGMT_EVENT
 
 config NET_L2_BT_SHELL
-	bool "Enable Bluetooth shell module"
+	bool "Bluetooth shell module"
 	select SHELL
 	select NET_L2_BT_MGMT
 	help
@@ -82,7 +82,7 @@ source "subsys/net/l2/ieee802154/Kconfig"
 source "subsys/net/l2/openthread/Kconfig"
 
 config NET_L2_CUSTOM_IEEE802154
-	bool "Enable custom IEEE802154 L2"
+	bool "Custom IEEE802154 L2"
 	select NET_L2_PHY_IEEE802154
 	help
 	  Enable custom IEEE802154 based L2. Zephyr does not provide
@@ -97,7 +97,7 @@ config NET_L2_CUSTOM_IEEE802154_MTU
 source "subsys/net/l2/canbus/Kconfig"
 
 config NET_L2_WIFI_MGMT
-	bool "Enable Wi-Fi Management support"
+	bool "Wi-Fi Management support"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
@@ -113,14 +113,14 @@ source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_L2_WIFI_MGMT
 
 config NET_L2_WIFI_SHELL
-	bool "Enable Wi-Fi shell module"
+	bool "Wi-Fi shell module"
 	select NET_L2_WIFI_MGMT
 	help
 	  This can be used for controlling Wi-Fi through the console via
 	  exposing a shell module named "wifi".
 
 config NET_L2_PTP
-	bool "Enable PTP L2 support"
+	bool "PTP L2 support"
 	select NET_PKT_TIMESTAMP
 	select PTP_CLOCK
 	help

--- a/subsys/net/l2/canbus/Kconfig
+++ b/subsys/net/l2/canbus/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config NET_L2_CANBUS
-	bool "Enable CANBUS L2 layer [EXPERIMENTAL]"
+	bool "CANBUS L2 layer [EXPERIMENTAL]"
 	depends on CAN_NET
 	select NET_6LO
 	select EXPERIMENTAL
@@ -54,7 +54,7 @@ config NET_L2_CANBUS_BS
 	  See also: ISO 15765-2:2016
 
 config NET_L2_CANBUS_ETH_TRANSLATOR
-	bool "Enable 6LoCAN to Ethernet translator"
+	bool "6LoCAN to Ethernet translator"
 	depends on NET_L2_ETHERNET
 	help
 	  Enable a 6LoCAN Ethernet translator. With this translator it is
@@ -72,6 +72,6 @@ source "subsys/net/Kconfig.template.log_config.net"
 endif # NET_L2_CANBUS
 
 config NET_L2_CANBUS_RAW
-	bool "Enable CANBUS RAW l2 layer"
+	bool "CANBUS RAW l2 layer"
 	help
 	  Add a CANBUS L2 layer driver. This is the layer for SOCKET CAN.

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_L2_ETHERNET
-	bool "Enable Ethernet support"
+	bool "Ethernet support"
 	help
 	  Add support for Ethernet, enabling selecting relevant hardware drivers.
 	  If NET_SLIP_TAP is selected, NET_L2_ETHERNET will enable to fully
@@ -17,7 +17,7 @@ module-help = Enables Ethernet L2 to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_L2_ETHERNET_MGMT
-	bool "Enable Ethernet network management interface"
+	bool "Ethernet network management interface"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	help
@@ -25,7 +25,7 @@ config NET_L2_ETHERNET_MGMT
 	  configure at run-time Ethernet drivers and L2 settings.
 
 config NET_VLAN
-	bool "Enable virtual lan support"
+	bool "Virtual lan support"
 	help
 	  Enables virtual lan (VLAN) support for Ethernet.
 
@@ -38,7 +38,7 @@ config NET_VLAN_COUNT
 	  How many VLAN tags can be configured.
 
 config NET_ARP
-	bool "Enable ARP"
+	bool "ARP"
 	default y
 	depends on NET_IPV4
 	help

--- a/subsys/net/l2/ethernet/gptp/Kconfig
+++ b/subsys/net/l2/ethernet/gptp/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_GPTP
-	bool "Enable IEEE 802.1AS (gPTP) support [EXPERIMENTAL]"
+	bool "IEEE 802.1AS (gPTP) support [EXPERIMENTAL]"
 	select NET_L2_PTP
 	select EXPERIMENTAL
 	help
@@ -18,7 +18,7 @@ module-help = Enable logs for the gPTP stack.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_GPTP_GM_CAPABLE
-	bool "Enable IEEE 802.1AS GrandMaster Capability"
+	bool "IEEE 802.1AS GrandMaster Capability"
 	help
 	  Enable to mark the whole system as Grand Master Capable.
 

--- a/subsys/net/l2/ethernet/lldp/Kconfig
+++ b/subsys/net/l2/ethernet/lldp/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_LLDP
-	bool "Enable Link Layer Discovery Protocol (LLDP)"
+	bool "Link Layer Discovery Protocol (LLDP)"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	help
@@ -43,7 +43,7 @@ config NET_LLDP_TX_HOLD
 # End of LLDPDU TLV CONFIG
 #
 config NET_LLDP_END_LLDPDU_TLV_ENABLED
-	bool "Enable End of LLDPDU TLV"
+	bool "End of LLDPDU TLV"
 	default y
 	help
 	  Tells whether LLDPDU packet will have marker at the end of the packet.

--- a/subsys/net/l2/ieee802154/Kconfig
+++ b/subsys/net/l2/ieee802154/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_L2_IEEE802154
-	bool "Enable IEEE 802.15.4 Radio"
+	bool "IEEE 802.15.4 Radio"
 	select NET_L2_PHY_IEEE802154
 	help
 	  Add support for low rate WPAN IEEE 802.15.4 technology.
@@ -28,7 +28,7 @@ module-help = Enables IEEE 802.15.4 code to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET
-	bool "Enable IEEE 802.15.4 packet display"
+	bool "IEEE 802.15.4 packet display"
 	depends on NET_LOG
 	help
 	  Enable printing out in/out 802.15.4 packets. This is extremely
@@ -57,7 +57,7 @@ config NET_DEBUG_L2_IEEE802154_DISPLAY_PACKET_TX
 endchoice
 
 config NET_L2_IEEE802154_ACK_REPLY
-	bool "Enable IEEE 802.15.4 ACK reply logic"
+	bool "IEEE 802.15.4 ACK reply logic"
 	help
 	  Enable inner stack's logic on handling ACK request. Note that
 	  if the hw driver has an AUTOACK feature, this is then unnecessary.
@@ -81,7 +81,7 @@ config NET_L2_IEEE802154_RFD
 endchoice
 
 config NET_L2_IEEE802154_SHELL
-	bool "Enable IEEE 802.15.4 shell module"
+	bool "IEEE 802.15.4 shell module"
 	select SHELL
 	depends on NET_L2_IEEE802154_RFD
 	help
@@ -89,7 +89,7 @@ config NET_L2_IEEE802154_SHELL
 	  a shell module named "ieee15_4".
 
 config NET_L2_IEEE802154_FRAGMENT
-	bool "Enable 802.15.4 fragmentation support"
+	bool "802.15.4 fragmentation support"
 	default y
 	depends on NET_6LO
 	help
@@ -115,7 +115,7 @@ config NET_L2_IEEE802154_REASSEMBLY_TIMEOUT
 	  Otherwise all accumulated fragments are dropped.
 
 config NET_L2_IEEE802154_SECURITY
-	bool "Enable IEEE 802.15.4 security [EXPERIMENTAL]"
+	bool "IEEE 802.15.4 security [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Enable 802.15.4 frame security handling, in order to bring data

--- a/subsys/net/l2/openthread/Kconfig
+++ b/subsys/net/l2/openthread/Kconfig
@@ -156,7 +156,7 @@ config OPENTHREAD_RADIO_WORKQUEUE_STACK_SIZE
 endmenu # "Zephyr optimizations"
 
 config OPENTHREAD_SHELL
-	bool "Enable OpenThread shell"
+	bool "OpenThread shell"
 	depends on SHELL
 	default y
 
@@ -284,32 +284,32 @@ config OPENTHREAD_TMF_ADDRESS_CACHE_ENTRIES
 	  The number of EID-to-RLOC cache entries.
 
 config OPENTHREAD_LOG_PREPEND_LEVEL_ENABLE
-	bool "Enable prepending the log level to all OpenThread log messages"
+	bool "Prepending the log level to all OpenThread log messages"
 	help
 	  When enabled the OpenThread logs will be prepended with the appropriate
 	  log level prefix i.e. [CRIT], [WARN], [NOTE], [INFO], [DEBG].
 
 config OPENTHREAD_MAC_SOFTWARE_ACK_TIMEOUT_ENABLE
-	bool "Enable software ACK timeout logic"
+	bool "Software ACK timeout logic"
 	default y
 	help
 	  Set y if the radio supports AckTime event
 
 config OPENTHREAD_MAC_SOFTWARE_RETRANSMIT_ENABLE
-	bool "Enable software retransmission logic"
+	bool "Software retransmission logic"
 	default y
 	help
 	  Set y if the radio supports tx retry logic with collision avoidance (CSMA)
 
 config OPENTHREAD_MAC_SOFTWARE_CSMA_BACKOFF_ENABLE
-	bool "Enable software CSMA backoff logic"
+	bool "Software CSMA backoff logic"
 	default y
 	help
 	  Set y to enable software CSMA backoff. The option can be disabled if
 	  the radio has hardware support for this feature (IEEE802154_HW_CSMA).
 
 config OPENTHREAD_CRYPTO_PSA
-	bool "Enable ARM PSA crypto API"
+	bool "ARM PSA crypto API"
 	depends on BUILD_WITH_TFM
 	select OPENTHREAD_PLATFORM_KEY_REFERENCES_ENABLE
 	help
@@ -317,7 +317,7 @@ config OPENTHREAD_CRYPTO_PSA
 	  API instead of the default, using mbedTLS.
 
 config OPENTHREAD_PLATFORM_KEY_REFERENCES_ENABLE
-	bool "Enable cryptographic key reference support"
+	bool "Cryptographic key reference support"
 	help
 	  Enable usage of cryptographic key references instead of literal keys
 	  This requires a crypto backend library that supports key references.

--- a/subsys/net/l2/openthread/Kconfig.features
+++ b/subsys/net/l2/openthread/Kconfig.features
@@ -21,34 +21,34 @@ config OPENTHREAD_THREAD_VERSION
 	default "unknown"
 
 config OPENTHREAD_BACKBONE_ROUTER
-	bool "Enable Backbone Router functionality"
+	bool "Backbone Router functionality"
 
 config OPENTHREAD_BORDER_AGENT
-	bool "Enable Border Agent support"
+	bool "Border Agent support"
 
 config OPENTHREAD_BORDER_ROUTER
-	bool "Enable Border Router support"
+	bool "Border Router support"
 
 config OPENTHREAD_BORDER_ROUTING_NAT64
-	bool "Enable border routing NAT64 support"
+	bool "Border routing NAT64 support"
 
 config OPENTHREAD_COAP
-	bool "Enable OpenThread CoAP support"
+	bool "OpenThread CoAP support"
 	help
 	  Enable CoAP API for the application with use of OpenThread stack
 
 config OPENTHREAD_COAPS
-	bool "Enable Secure CoAP API support"
+	bool "Secure CoAP API support"
 	depends on OPENTHREAD_COAP
 
 config OPENTHREAD_COAP_BLOCK
-	bool "Enable CoAP Block-wise option support"
+	bool "CoAP Block-wise option support"
 
 config OPENTHREAD_COAP_OBSERVE
-	bool "Enable CoAP Observe option support"
+	bool "CoAP Observe option support"
 
 config OPENTHREAD_COMMISSIONER
-	bool "Enable Commissioner functions support"
+	bool "Commissioner functions support"
 	help
 	  Enable commissioner capability in OpenThread stack. Note, that DTLS
 	  handshake used in the commissioning procedure requires a larger
@@ -56,65 +56,65 @@ config OPENTHREAD_COMMISSIONER
 	  CONFIG_MBEDTLS_HEAP_SIZE for the commissioning is 10KB.
 
 config OPENTHREAD_CHANNEL_MANAGER
-	bool "Enable channel manager support"
+	bool "Channel manager support"
 	depends on OPENTHREAD_CHANNEL_MONITOR
 
 config OPENTHREAD_CHANNEL_MONITOR
-	bool "Enable channel monitor support"
+	bool "Channel monitor support"
 
 config OPENTHREAD_CHILD_SUPERVISION
-	bool "Enable child supervision support"
+	bool "Child supervision support"
 
 config OPENTHREAD_CSL_RECEIVER
-	bool "Enable CSL Receiver support"
+	bool "CSL Receiver support"
 	help
 	  Enable CSL Receiver support for Thread 1.2
 
 config OPENTHREAD_DHCP6_CLIENT
-	bool "Enable DHCPv6 client support"
+	bool "DHCPv6 client support"
 
 config OPENTHREAD_DHCP6_SERVER
-	bool "Enable DHCPv6 server support"
+	bool "DHCPv6 server support"
 
 config OPENTHREAD_DIAG
-	bool "Enable Diagnostic functions support"
+	bool "Diagnostic functions support"
 	help
 	  Enable OpenThread CLI diagnostic commands
 
 config OPENTHREAD_DNS_CLIENT
-	bool "Enable DNS client support"
+	bool "DNS client support"
 
 config OPENTHREAD_DNS_DSO
-	bool "Enable DNS Stateful Operations (DSO) support"
+	bool "DNS Stateful Operations (DSO) support"
 
 config OPENTHREAD_DNSSD_SERVER
-	bool "Enable DNS-SD server support"
+	bool "DNS-SD server support"
 
 config OPENTHREAD_DUA
-	bool "Enable Domain Unicast Address support"
+	bool "Domain Unicast Address support"
 	help
 	  Enable Domain Unicast Address feature for Thread 1.2
 
 config OPENTHREAD_LOG_LEVEL_DYNAMIC
-	bool "Enable dynamic log level control"
+	bool "Dynamic log level control"
 
 config OPENTHREAD_ECDSA
-	bool "Enable ECDSA support"
+	bool "ECDSA support"
 
 config OPENTHREAD_EXCLUDE_TCPLP_LIB
 	bool "Exclude TCPlp library from build"
 
 config OPENTHREAD_EXTERNAL_HEAP
-	bool "Enable external heap support"
+	bool "External heap support"
 
 config OPENTHREAD_IP6_FRAGM
-	bool "Enable IPv6 fragmentation support"
+	bool "IPv6 fragmentation support"
 
 config OPENTHREAD_JAM_DETECTION
-	bool "Enable Jam detection support"
+	bool "Jam detection support"
 
 config OPENTHREAD_JOINER
-	bool "Enable Joiner functions support"
+	bool "Joiner functions support"
 	help
 	  Enable joiner capability in OpenThread stack. Note, that DTLS
 	  handshake used in the commissioning procedure requires a larger
@@ -122,98 +122,98 @@ config OPENTHREAD_JOINER
 	  CONFIG_MBEDTLS_HEAP_SIZE for the commissioning is 10KB.
 
 config OPENTHREAD_LEGACY
-	bool "Enable legacy network support"
+	bool "Legacy network support"
 
 config OPENTHREAD_RAW
-	bool "Enable raw Link support"
+	bool "Raw Link support"
 
 config OPENTHREAD_MAC_FILTER
-	bool "Enable MAC filter support"
+	bool "MAC filter support"
 
 config OPENTHREAD_MLE_LONG_ROUTES
-	bool "Enable MLE long routes extension (experimental)"
+	bool "MLE long routes extension (experimental)"
 	help
 	  Enable MLE long routes extension (experimental, breaks Thread conformance)
 
 config OPENTHREAD_MLR
-	bool "Enable Multicast Listener Registration support"
+	bool "Multicast Listener Registration support"
 	help
 	  Enable Multicast Listener Registration support for Thread 1.2
 
 config OPENTHREAD_MTD_NETDIAG
-	bool "Enable TMF network diagnostics on MTDs"
+	bool "TMF network diagnostics on MTDs"
 
 config OPENTHREAD_MULTIPLE_INSTANCE
-	bool "Enable OpenThread multiple instances"
+	bool "OpenThread multiple instances"
 
 config OPENTHREAD_NEIGHBOR_DISCOVERY_AGENT
-	bool "Enable neighbor discovery agent support"
+	bool "Neighbor discovery agent support"
 
 config OPENTHREAD_NETDATA_PUBLISHER
-	bool "Enable Thread Network Data publisher"
+	bool "Thread Network Data publisher"
 
 config OPENTHREAD_PING_SENDER
-	bool "Enable ping sender support"
+	bool "Ping sender support"
 
 config OPENTHREAD_PLATFORM_UDP
-	bool "Enable platform UDP support"
+	bool "Platform UDP support"
 
 config OPENTHREAD_PLATFORM_NETIF
-	bool "Enable platform netif support"
+	bool "Platform netif support"
 
 config OPENTHREAD_REFERENCE_DEVICE
-	bool "Enable Reference Device support"
+	bool "Reference Device support"
 	help
 	  Enable Thread Certification reference device support in OpenThread stack
 
 config OPENTHREAD_ENABLE_SERVICE
-	bool "Enable Service support"
+	bool "Service support"
 	help
 	  Enable Thread Services capability in OpenThread stack
 
 config OPENTHREAD_SLAAC
-	bool "Enable SLAAC support"
+	bool "SLAAC support"
 
 config OPENTHREAD_SNTP_CLIENT
-	bool "Enable SNTP Client support"
+	bool "SNTP Client support"
 
 config OPENTHREAD_TIME_SYNC
-	bool "Enable the time synchronization service feature"
+	bool "The time synchronization service feature"
 
 config OPENTHREAD_TREL
-	bool "Enable TREL radio link for Thread over Infrastructure feature"
+	bool "TREL radio link for Thread over Infrastructure feature"
 
 config OPENTHREAD_UDP_FORWARD
-	bool "Enable UDP forward support"
+	bool "UDP forward support"
 
 config OPENTHREAD_SETTINGS_RAM
-	bool "Enable volatile-only storage of settings"
+	bool "Volatile-only storage of settings"
 
 config OPENTHREAD_OTNS
-	bool "Enable OTNS support"
+	bool "OTNS support"
 
 config OPENTHREAD_FULL_LOGS
-	bool "Enable OpenThread full logs"
+	bool "OpenThread full logs"
 
 config OPENTHREAD_LINK_METRICS_INITIATOR
-	bool "Enable Link Metrics initiator"
+	bool "Link Metrics initiator"
 
 config OPENTHREAD_LINK_METRICS_SUBJECT
-	bool "Enable Link Metrics subject"
+	bool "Link Metrics subject"
 
 config OPENTHREAD_SRP_CLIENT
-	bool "Enable SRP Client support"
+	bool "SRP Client support"
 	select OPENTHREAD_ECDSA
 
 config OPENTHREAD_SRP_SERVER
-	bool "Enable SRP Server support"
+	bool "SRP Server support"
 	select OPENTHREAD_ECDSA
 
 config OPENTHREAD_CSL_DEBUG
-	bool "Enable CSL debugging"
+	bool "CSL debugging"
 
 config OPENTHREAD_DATSET_UPDATER
-	bool "Enable dataset updater"
+	bool "Dataset updater"
 
 config OPENTHREAD_UPTIME
-	bool "Enable openthread uptime counter"
+	bool "Openthread uptime counter"

--- a/subsys/net/l2/openthread/Kconfig.thread
+++ b/subsys/net/l2/openthread/Kconfig.thread
@@ -31,7 +31,7 @@ config OPENTHREAD_NETWORKKEY
 	  "00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd:ee:ff"
 
 config OPENTHREAD_JOINER_AUTOSTART
-	bool "Enable automatic joiner start"
+	bool "Automatic joiner start"
 	depends on OPENTHREAD_JOINER
 
 config OPENTHREAD_JOINER_PSKD
@@ -76,14 +76,14 @@ config OPENTHREAD_CONFIG_PLATFORM_INFO
 	default "Zephyr"
 
 config OPENTHREAD_RADIO_LINK_IEEE_802_15_4_ENABLE
-	bool "Enable support for IEEE802.15.4 radio link"
+	bool "Support for IEEE802.15.4 radio link"
 	default y
 
 config OPENTHREAD_RADIO_LINK_TREL_ENABLE
 	bool "Thread Radio Encapsulation Link (TREL)"
 
 config OPENTHREAD_CSL_AUTO_SYNC
-	bool "Enable CSL autosync"
+	bool "CSL autosync"
 	default y if OPENTHREAD_CSL_RECEIVER
 
 config OPENTHREAD_CSL_RECEIVE_TIME_AHEAD
@@ -103,7 +103,7 @@ config OPENTHREAD_PLATFORM_CSL_UNCERT
 	  The Uncertainty of the scheduling CSL of transmission by the parent, in ±10 us units.
 
 config OPENTHREAD_MAC_SOFTWARE_TX_SECURITY_ENABLE
-	bool "Enable software transmission security logic"
+	bool "Software transmission security logic"
 	default y if OPENTHREAD_THREAD_VERSION_1_2
 
 config OPENTHREAD_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
@@ -115,7 +115,7 @@ config OPENTHREAD_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
 	  router, enable the Inform Previous Parent on Reattach feature.
 
 config OPENTHREAD_PARENT_SEARCH
-	bool "Enable periodic parent search support"
+	bool "Periodic parent search support"
 	help
 	  To allow end devices (EDs) in a Thread network to switch to a
 	  better parent router than their current one—while still attached
@@ -152,12 +152,12 @@ config OPENTHREAD_IP6_MAX_EXT_MCAST_ADDRS
 	default 2
 
 config OPENTHREAD_TCP_ENABLE
-	bool "Enable TCP"
+	bool "TCP"
 
 config OPENTHREAD_CLI_TCP_ENABLE
-	bool "Enable TCP in the CLI tool"
+	bool "TCP in the CLI tool"
 	default y if SHELL
 	depends on OPENTHREAD_TCP_ENABLE
 
 config OPENTHREAD_HISTORY_TRACKER
-	bool "Enable history tracker support"
+	bool "History tracker support"

--- a/subsys/net/l2/ppp/Kconfig
+++ b/subsys/net/l2/ppp/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_L2_PPP
-	bool "Enable point-to-point (PPP) support [EXPERIMENTAL]"
+	bool "Point-to-point (PPP) support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help
 	  Add support for PPP.
@@ -86,7 +86,7 @@ module-help = Enables ppp L2 to output debug messages.
 source "subsys/net/Kconfig.template.log_config.net"
 
 config NET_L2_PPP_MGMT
-	bool "Enable ppp network management interface"
+	bool "Ppp network management interface"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	help

--- a/subsys/net/l2/virtual/Kconfig
+++ b/subsys/net/l2/virtual/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_L2_VIRTUAL
-	bool "Enable virtual L2 support"
+	bool "Virtual L2 support"
 	help
 	  Add a virtual L2 layer driver. This is needed if you have a L2
 	  layer that depends on other L2 layer. Like running VPN on top of
@@ -11,7 +11,7 @@ menuconfig NET_L2_VIRTUAL
 if NET_L2_VIRTUAL
 
 config NET_L2_VIRTUAL_MGMT
-	bool "Enable virtual interface network management interface"
+	bool "Virtual interface network management interface"
 	select NET_MGMT
 	select NET_MGMT_EVENT
 	help

--- a/subsys/net/l2/virtual/ipip/Kconfig
+++ b/subsys/net/l2/virtual/ipip/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_L2_IPIP
-	bool "Enable IP-to-IP tunneling support"
+	bool "IP-to-IP tunneling support"
 	depends on NET_L2_VIRTUAL
 	help
 	  Add a IP-to-IP tunnel driver. If this is enabled, then a network

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -13,7 +13,7 @@ if COAP
 
 # This setting is only used by unit test. Do not enable it in applications
 config COAP_TEST_API_ENABLE
-	bool "Enable test API for CoAP unit tests"
+	bool "Test API for CoAP unit tests"
 	help
 	  Do not enable this for normal use.
 
@@ -70,14 +70,14 @@ config COAP_RANDOMIZE_ACK_TIMEOUT
 	  will be fixed to the value of COAP_INIT_ACK_TIMEOUT_MS option.
 
 config COAP_URI_WILDCARD
-	bool "Enable wildcards in CoAP resource path"
+	bool "Wildcards in CoAP resource path"
 	default y
 	help
 	  This option enables MQTT-style wildcards in path. Disable it if
 	  resource path may contain plus or hash symbol.
 
 config COAP_KEEP_USER_DATA
-	bool "Enable keeping user data in the CoAP packet"
+	bool "Keeping user data in the CoAP packet"
 	help
 	  This option enables keeping application-specific user data
 

--- a/subsys/net/lib/config/Kconfig
+++ b/subsys/net/lib/config/Kconfig
@@ -178,7 +178,7 @@ config NET_CONFIG_IEEE802154_SECURITY_LEVEL
 endif # NET_L2_IEEE802154 || IEEE802154_RAW_MODE
 
 config NET_CONFIG_BT_NODE
-	bool "Enable Bluetooth node support"
+	bool "Bluetooth node support"
 	depends on NET_L2_BT
 	select NET_L2_BT_MGMT
 	help

--- a/subsys/net/lib/conn_mgr/Kconfig
+++ b/subsys/net/lib/conn_mgr/Kconfig
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig NET_CONNECTION_MANAGER
-	bool "Enable network connection manager [EXPERIMENTAL]"
+	bool "Network connection manager [EXPERIMENTAL]"
 	depends on NET_IPV6 || NET_IPV4
 	select NET_MGMT
 	select NET_MGMT_EVENT

--- a/subsys/net/lib/dns/Kconfig
+++ b/subsys/net/lib/dns/Kconfig
@@ -10,13 +10,13 @@ config DNS_RESOLVER
 if DNS_RESOLVER
 
 config MDNS_RESOLVER
-	bool "Enable mDNS support"
+	bool "MDNS support"
 	help
 	  This option enables multicast DNS client side support.
 	  See RFC 6762 for details.
 
 config LLMNR_RESOLVER
-	bool "Enable LLMNR support"
+	bool "LLMNR support"
 	help
 	  This option enables link local multicast name resolution client side
 	  support. See RFC 4795 for details. LLMNR is typically used by Windows
@@ -153,7 +153,7 @@ config MDNS_RESPONDER_INIT_PRIO
 	  should be bigger than its value.
 
 config MDNS_RESPONDER_DNS_SD
-	bool "Enable DNS Service Discovery via mDNS"
+	bool "DNS Service Discovery via mDNS"
 	default y
 	depends on DNS_SD
 	help
@@ -164,7 +164,7 @@ config MDNS_RESPONDER_DNS_SD
 
 if MDNS_RESPONDER_DNS_SD
 config MDNS_RESPONDER_DNS_SD_SERVICE_TYPE_ENUMERATION
-	bool "Enable DNS SD Service Type Enumeration"
+	bool "DNS SD Service Type Enumeration"
 	default y
 	help
 	  Selecting this option ensures that the MDNS Responder
@@ -236,7 +236,7 @@ config LLMNR_RESOLVER_ADDITIONAL_BUF_CTR
 endif # LLMNR_RESPONDER
 
 config DNS_SD
-	bool "Enable DNS Service Discovery"
+	bool "DNS Service Discovery"
 	help
 	  This option enables DNS Service Discovery for Zephyr. It can
 	  be enabled for virtually any network service with only a few

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -33,7 +33,7 @@ config LWM2M_VERSION_1_1
 endchoice
 
 config LWM2M_DTLS_SUPPORT
-	bool "Enable DTLS support in the LwM2M client"
+	bool "DTLS support in the LwM2M client"
 	select TLS_CREDENTIALS
 	select NET_SOCKETS_SOCKOPT_TLS
 	select NET_SOCKETS_ENABLE_DTLS
@@ -71,7 +71,7 @@ config LWM2M_SERVER_OBJECT_VERSION_1_1
 endchoice
 
 config LWM2M_DNS_SUPPORT
-	bool "Enable DNS support in the LWM2M client"
+	bool "DNS support in the LWM2M client"
 	default y if DNS_RESOLVER
 
 config LWM2M_ENGINE_STACK_SIZE
@@ -168,7 +168,7 @@ config LWM2M_SECONDS_TO_UPDATE_EARLY
 	  higher, in order to allow the response to arrive before timeout.
 
 config LWM2M_QUEUE_MODE_ENABLED
-	bool "Enable Queue Mode UDP binding"
+	bool "Queue Mode UDP binding"
 	help
 	  Set the transport binding to UDP with Queue Mode (UQ).
 
@@ -190,7 +190,7 @@ config LWM2M_RD_CLIENT_SUPPORT
 	  LWM2M servers (including bootstrap server support)
 
 config LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP
-	bool "Enable bootstrap support"
+	bool "Bootstrap support"
 	help
 	  Enabling this setting allows the RD client to support bootstrap mode.
 
@@ -459,7 +459,7 @@ config LWM2M_LOCATION_OBJ_SUPPORT
 	  Include support for LWM2M Location Object (ID 6)
 
 config LWM2M_GATEWAY_OBJ_SUPPORT
-	bool "Enable LwM2M Gateway Object (25) [EXPERIMENTAL]"
+	bool "LwM2M Gateway Object (25) [EXPERIMENTAL]"
 
 if LWM2M_GATEWAY_OBJ_SUPPORT
 

--- a/subsys/net/lib/sockets/Kconfig
+++ b/subsys/net/lib/sockets/Kconfig
@@ -65,7 +65,7 @@ config NET_SOCKETS_DNS_TIMEOUT
 	  maximum timeout is 5 min.
 
 config NET_SOCKETS_SOCKOPT_TLS
-	bool "Enable TCP TLS socket option support [EXPERIMENTAL]"
+	bool "TCP TLS socket option support [EXPERIMENTAL]"
 	imply TLS_CREDENTIALS
 	select MBEDTLS if NET_NATIVE
 	select EXPERIMENTAL
@@ -97,7 +97,7 @@ config NET_SOCKETS_TLS_SET_MAX_FRAGMENT_LENGTH
 	  the maximum supported receive record length.
 
 config NET_SOCKETS_ENABLE_DTLS
-	bool "Enable DTLS socket support [EXPERIMENTAL]"
+	bool "DTLS socket support [EXPERIMENTAL]"
 	depends on NET_SOCKETS_SOCKOPT_TLS
 	select MBEDTLS_DTLS if NET_NATIVE
 	select EXPERIMENTAL
@@ -176,7 +176,7 @@ config NET_SOCKETS_OFFLOAD_TLS
 	  will be used, and only TCP/UDP socket calls will be offloaded.
 
 config NET_SOCKETS_PACKET
-	bool "Enable packet socket support"
+	bool "Packet socket support"
 	help
 	  This is an initial version of packet socket support (special type
 	  raw socket). Packets are passed to and from the device driver
@@ -186,7 +186,7 @@ config NET_SOCKETS_PACKET
 	  will be feed to sockets as it as from the driver.
 
 config NET_SOCKETS_PACKET_DGRAM
-	bool "Enable packet socket SOCK_DGRAM support"
+	bool "Packet socket SOCK_DGRAM support"
 	depends on NET_SOCKETS_PACKET
 	default y
 	help
@@ -197,7 +197,7 @@ config NET_SOCKETS_PACKET_DGRAM
 	  they are queued.
 
 config NET_SOCKETS_CAN
-	bool "Enable socket CAN support [EXPERIMENTAL]"
+	bool "Socket CAN support [EXPERIMENTAL]"
 	select NET_L2_CANBUS_RAW
 	select EXPERIMENTAL
 	help
@@ -228,7 +228,7 @@ config NET_SOCKETPAIR_BUFFER_SIZE
 	  Buffer size for socketpair(2)
 
 config NET_SOCKETS_NET_MGMT
-	bool "Enable network management socket support [EXPERIMENTAL]"
+	bool "Network management socket support [EXPERIMENTAL]"
 	depends on NET_MGMT_EVENT
 	select NET_MGMT_EVENT_INFO
 	select EXPERIMENTAL

--- a/subsys/net/pkt_filter/Kconfig
+++ b/subsys/net/pkt_filter/Kconfig
@@ -5,7 +5,7 @@
 menu "Network Packet Filtering"
 
 config NET_PKT_FILTER
-	bool "Enable network packet filtering"
+	bool "Network packet filtering"
 	help
 	  The Network Packet Filtering facility provides the infrastructure
 	  to construct custom rules for accepting and/or denying packet

--- a/subsys/pm/Kconfig
+++ b/subsys/pm/Kconfig
@@ -55,7 +55,7 @@ module-str = Device Power Management
 source "subsys/logging/Kconfig.template.log_config"
 
 config PM_DEVICE_POWER_DOMAIN
-	bool "Enable power domain"
+	bool "Power domain"
 	depends on PM_DEVICE
 	default y
 	help

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -126,7 +126,7 @@ config SETTINGS_NVS_SECTOR_COUNT
 	  Number of sectors used for the NVS settings area
 
 config SETTINGS_SHELL
-	bool "Enable Settings shell"
+	bool "Settings shell"
 	depends on SETTINGS && SHELL
 	help
 	  Enable shell commands for listing and reading the settings. Note that

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -89,7 +89,7 @@ config SHELL_ARGC_MAX
 	  Maximum number of arguments that can build a command.
 
 config SHELL_TAB
-	bool "Enable the Tab button support in shell"
+	bool "The Tab button support in shell"
 	default y if !SHELL_MINIMAL
 	help
 	  Enable using the Tab button in the shell. The button
@@ -97,7 +97,7 @@ config SHELL_TAB
 	  This feature has high impact on flash usage.
 
 config SHELL_TAB_AUTOCOMPLETION
-	bool "Enable commands autocompletion with the Tab button"
+	bool "Commands autocompletion with the Tab button"
 	depends on SHELL_TAB
 	default y if !SHELL_MINIMAL
 	help
@@ -105,14 +105,14 @@ config SHELL_TAB_AUTOCOMPLETION
 	  key. This function can be deactivated to save some flash.
 
 config SHELL_WILDCARD
-	bool "Enable wildcard support in shell"
+	bool "Wildcard support in shell"
 	select FNMATCH
 	default y if !SHELL_MINIMAL
 	help
 	  Enables using wildcards: * and ? in the shell.
 
 config SHELL_ECHO_STATUS
-	bool "Enable echo on shell"
+	bool "Echo on shell"
 	default y
 	help
 	  If enabled shell prints back every input byte.
@@ -125,20 +125,20 @@ config SHELL_START_OBSCURED
 	  This is used for login prompts.
 
 config SHELL_VT100_COMMANDS
-	bool "Enable VT100 commands in shell"
+	bool "VT100 commands in shell"
 	default y
 	help
 	  Enables VT100 commands in shell (e.g. cursor position, clear screen etc.).
 
 config SHELL_VT100_COLORS
-	bool "Enable colors in shell"
+	bool "Colors in shell"
 	depends on SHELL_VT100_COMMANDS
 	default y if !SHELL_MINIMAL
 	help
 	  If enabled VT100 colors are used in shell (e.g. print errors in red).
 
 config SHELL_GETOPT
-	bool "Enable threadsafe getopt support in shell"
+	bool "Threadsafe getopt support in shell"
 	select GETOPT
 	help
 	  This config creates a separate getopt_state for the shell instance.
@@ -147,7 +147,7 @@ config SHELL_GETOPT
 	  get getopt state of the shell thread.
 
 config SHELL_METAKEYS
-	bool "Enable metakeys"
+	bool "Metakeys"
 	default y if !SHELL_MINIMAL
 	help
 	  Enables shell meta keys: Ctrl+a, Ctrl+b, Ctrl+c, Ctrl+d, Ctrl+e,
@@ -155,7 +155,7 @@ config SHELL_METAKEYS
 	  Meta keys will not be active when shell echo is set to off.
 
 config SHELL_HELP
-	bool "Enable help message"
+	bool "Help message"
 	default y if !SHELL_MINIMAL
 	help
 	  Enables shell functions for printing formatted help message.
@@ -171,12 +171,12 @@ config SHELL_HELP_OPT_PARSE
 	  for a command.
 
 config SHELL_HELP_ON_WRONG_ARGUMENT_COUNT
-	bool "Enable printing help on wrong argument count"
+	bool "Printing help on wrong argument count"
 	depends on SHELL_HELP
 	default y if !SHELL_MINIMAL
 
 config SHELL_HISTORY
-	bool "Enable history in shell"
+	bool "History in shell"
 	default y if !SHELL_MINIMAL
 	select RING_BUFFER
 	help
@@ -192,17 +192,17 @@ config SHELL_HISTORY_BUFFER
 	  Number of bytes dedicated for storing executed commands.
 
 config SHELL_STATS
-	bool "Enable shell statistics"
+	bool "Shell statistics"
 	default y if !SHELL_MINIMAL
 
 config SHELL_CMDS
-	bool "Enable built-in commands"
+	bool "Built-in commands"
 	default y if !SHELL_MINIMAL
 	help
 	  Enable built-in commands like 'clear', 'history', etc.
 
 config SHELL_CMDS_RESIZE
-	bool "Enable resize command"
+	bool "Resize command"
 	depends on SHELL_CMDS
 	depends on SHELL_VT100_COMMANDS
 	default y if !SHELL_MINIMAL
@@ -213,7 +213,7 @@ config SHELL_CMDS_RESIZE
 	  The resize command can be turned off to save code memory (~0,5k).
 
 config SHELL_CMDS_SELECT
-	bool "Enable select command"
+	bool "Select command"
 	depends on SHELL_CMDS
 	help
 	  This option enables select command. It can be used to set new root
@@ -226,7 +226,7 @@ config SHELL_CMD_ROOT
 	  and when exiting to main command tree with alt+r.
 
 config SHELL_LOG_BACKEND
-	bool "Enable shell log backend"
+	bool "Shell log backend"
 	depends on LOG && !LOG_MODE_MINIMAL
 	default y if LOG
 	help

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 menuconfig SHELL_BACKENDS
-	bool "Enable shell backends"
+	bool "Shell backends"
 	default y
 	help
 	  Enable shell backends.
@@ -15,7 +15,7 @@ if SHELL_BACKENDS
 DT_CHOSEN_Z_SHELL_UART := zephyr,shell-uart
 
 config SHELL_BACKEND_SERIAL
-	bool "Enable serial backend"
+	bool "Serial backend"
 	default "$(dt_chosen_enabled,$(DT_CHOSEN_Z_SHELL_UART))" if HAS_DTS
 	default y if !HAS_DTS
 	select SERIAL
@@ -120,7 +120,7 @@ config SHELL_BACKEND_SERIAL_LOG_LEVEL
 endif # SHELL_BACKEND_SERIAL
 
 config SHELL_BACKEND_RTT
-	bool "Enable RTT backend"
+	bool "RTT backend"
 	select CONSOLE
 	select RTT_CONSOLE
 	depends on USE_SEGGER_RTT
@@ -188,7 +188,7 @@ source "subsys/logging/Kconfig.template.log_config"
 endif # SHELL_BACKEND_RTT
 
 config SHELL_BACKEND_TELNET
-	bool "Enable TELNET backend."
+	bool "TELNET backend."
 	depends on NET_TCP
 	depends on NET_IPV4 || NET_IPV6
 	help
@@ -283,7 +283,7 @@ source "subsys/logging/Kconfig.template.log_config"
 endif # SHELL_TELNET_BACKEND
 
 config SHELL_BACKEND_DUMMY
-	bool "Enable dummy backend."
+	bool "Dummy backend."
 	help
 	  Enable dummy backend which can be used to execute commands with no
 	  need for physical transport interface.

--- a/subsys/shell/modules/Kconfig
+++ b/subsys/shell/modules/Kconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config KERNEL_SHELL
-	bool "Enable kernel shell"
+	bool "Kernel shell"
 	default y if !SHELL_MINIMAL
 	imply INIT_STACKS
 	imply THREAD_MONITOR
@@ -27,20 +27,20 @@ config KERNEL_SHELL_REBOOT_DELAY
 	  device.
 
 config DEVICE_SHELL
-	bool "Enable device shell"
+	bool "Device shell"
 	default y if !SHELL_MINIMAL
 	help
 	  This shell provides access to basic device data.
 
 config DATE_SHELL
-	bool "Enable date shell"
+	bool "Date shell"
 	depends on POSIX_CLOCK
 	default y if !SHELL_MINIMAL
 	help
 	  This shell provides access to date and time based on Unix time.
 
 config DEVMEM_SHELL
-	bool "Enable devmem shell"
+	bool "Devmem shell"
 	default y if !SHELL_MINIMAL
 	help
 	  This shell command provides read/write access to physical memory.

--- a/subsys/storage/flash_map/Kconfig
+++ b/subsys/storage/flash_map/Kconfig
@@ -16,7 +16,7 @@ menuconfig FLASH_MAP
 if FLASH_MAP
 
 config FLASH_MAP_SHELL
-	bool "Enable flash map shell interface"
+	bool "Flash map shell interface"
 	depends on SHELL
 	help
 	  This enables shell commands to list and test flash maps.
@@ -29,7 +29,7 @@ config FLASH_MAP_CUSTOM
 	  if had enabled this option.
 
 config FLASH_AREA_CHECK_INTEGRITY
-	bool "Enable flash check functions"
+	bool "Flash check functions"
 	help
 	  If enabled, there will be available the backend to check flash
 	  integrity using SHA-256 verification algorithm.

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -76,7 +76,7 @@ config TEST_USERSPACE
 	  testcase.yaml.
 
 config TEST_LOGGING_DEFAULTS
-	bool "Enable test case logging defaults"
+	bool "Test case logging defaults"
 	depends on TEST
 	select LOG
 	select LOG_DEFAULT_MINIMAL
@@ -116,7 +116,7 @@ config TEST_USERSPACE_WITHOUT_HW_STACK_PROTECTION
 	  related tests without enabling HW stack protection.
 
 config TEST_HW_STACK_PROTECTION
-	bool "Enable hardware-based stack overflow detection if available"
+	bool "Hardware-based stack overflow detection if available"
 	depends on ARCH_HAS_STACK_PROTECTION
 	depends on TEST
 	select HW_STACK_PROTECTION
@@ -151,7 +151,7 @@ config TEST_ARM_CORTEX_M
 	  set, these exceptions are set to target the Non-Secure state.
 
 config TEST_BUSY_SIM
-	bool "Enable busy simulator"
+	bool "Busy simulator"
 	depends on TEST
 	select ENTROPY_GENERATOR
 	select RING_BUFFER if !XOSHIRO_RANDOM_GENERATOR

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -69,7 +69,7 @@ endchoice
 
 
 config TRACING_CTF_TIMESTAMP
-	bool "Enable CTF internal timestamp"
+	bool "CTF internal timestamp"
 	default y
 	depends on TRACING_CTF
 	help
@@ -134,28 +134,28 @@ choice
 	default TRACING_BACKEND_UART
 
 config TRACING_BACKEND_UART
-	bool "Enable UART backend"
+	bool "UART backend"
 	depends on UART_CONSOLE
 
 	help
 	  Use UART to output tracing data.
 
 config TRACING_BACKEND_USB
-	bool "Enable USB backend"
+	bool "USB backend"
 	depends on USB_DEVICE_STACK
 	depends on TRACING_ASYNC
 	help
 	  Use USB to output tracing data.
 
 config TRACING_BACKEND_POSIX
-	bool "Enable posix architecture (native) backend"
+	bool "Posix architecture (native) backend"
 	depends on TRACING_SYNC
 	depends on ARCH_POSIX
 	help
 	  Use posix architecture to output tracing data to file system.
 
 config TRACING_BACKEND_RAM
-	bool "Enable RAM backend"
+	bool "RAM backend"
 	help
 	  Use a ram buffer to output tracing data which can
 	  be dumped to a file at runtime with a debugger.
@@ -188,7 +188,7 @@ config TRACING_USB_MPS
 	  USB tracing backend max packet size(endpoint MPS).
 
 config TRACING_HANDLE_HOST_CMD
-	bool "Enable host command handle"
+	bool "Host command handle"
 	select UART_INTERRUPT_DRIVEN if TRACING_BACKEND_UART
 	help
 	  When enabled tracing will handle cmd from host to dynamically
@@ -203,7 +203,7 @@ config TRACING_CMD_BUFFER_SIZE
 	  Size of tracing command buffer.
 
 config TRACING_OBJECT_TRACKING
-	bool "Enable object tracking"
+	bool "Object tracking"
 	default n
 	help
 	  Keep lists to track kernel objects.
@@ -211,110 +211,110 @@ config TRACING_OBJECT_TRACKING
 menu "Tracing Configuration"
 
 config TRACING_SYSCALL
-	bool "Enable tracing Syscalls"
+	bool "Tracing Syscalls"
 	default y
 	help
 	  Enable tracing Syscalls.
 
 config TRACING_THREAD
-	bool "Enable tracing Threads"
+	bool "Tracing Threads"
 	default y
 	help
 	  Enable tracing Threads.
 
 config TRACING_WORK
-	bool "Enable tracing Work"
+	bool "Tracing Work"
 	default y
 	help
 	  Enable tracing Work and Work queue events
 
 config TRACING_ISR
-	bool "Enable tracing ISRs"
+	bool "Tracing ISRs"
 	default y
 	help
 	  Enable tracing ISRs. This requires the backend to be
 	  very low-latency.
 
 config TRACING_SEMAPHORE
-	bool "Enable tracing Semaphores"
+	bool "Tracing Semaphores"
 	default y
 	help
 	  Enable tracing Semaphores.
 
 config TRACING_MUTEX
-	bool "Enable tracing Mutexes"
+	bool "Tracing Mutexes"
 	default y
 	help
 	  Enable tracing Mutexes.
 
 config TRACING_CONDVAR
-	bool "Enable tracing Condition Variables"
+	bool "Tracing Condition Variables"
 	default y
 	help
 	  Enable tracing Condition Variables
 
 config TRACING_QUEUE
-	bool "Enable tracing Queues"
+	bool "Tracing Queues"
 	default y
 	help
 	  Enable tracing Queues.
 
 config TRACING_FIFO
-	bool "Enable tracing FIFO queues"
+	bool "Tracing FIFO queues"
 	default y
 	help
 	  Enable tracing FIFO queues.
 
 config TRACING_LIFO
-	bool "Enable tracing LIFO queues"
+	bool "Tracing LIFO queues"
 	default y
 	help
 	  Enable tracing LIFO queues.
 
 config TRACING_STACK
-	bool "Enable tracing Memory Stacks"
+	bool "Tracing Memory Stacks"
 	default y
 	help
 	  Enable tracing Memory Stacks.
 
 config TRACING_MESSAGE_QUEUE
-	bool "Enable tracing Message Queues"
+	bool "Tracing Message Queues"
 	default y
 	help
 	  Enable tracing Message Queues.
 
 config TRACING_MAILBOX
-	bool "Enable tracing Mailboxes"
+	bool "Tracing Mailboxes"
 	default y
 	help
 	  Enable tracing Mailboxes.
 
 config TRACING_PIPE
-	bool "Enable tracing Pipes"
+	bool "Tracing Pipes"
 	default y
 	help
 	  Enable tracing Pipes.
 
 config TRACING_HEAP
-	bool "Enable tracing Memory Heaps"
+	bool "Tracing Memory Heaps"
 	default y
 	help
 	  Enable tracing Memory Heaps.
 
 config TRACING_MEMORY_SLAB
-	bool "Enable tracing Memory Slabs"
+	bool "Tracing Memory Slabs"
 	default y
 	help
 	  Enable tracing Memory Slabs.
 
 config TRACING_TIMER
-	bool "Enable tracing Timers"
+	bool "Tracing Timers"
 	default y
 	help
 	  Enable tracing Timers.
 
 config TRACING_EVENT
-	bool "Enable tracing Events"
+	bool "Tracing Events"
 	default y
 	help
 	  Enable tracing Events.

--- a/subsys/tracing/sysview/Kconfig
+++ b/subsys/tracing/sysview/Kconfig
@@ -13,7 +13,7 @@ config SEGGER_SYSVIEW_RTT_BUFFER_SIZE
 	default 4096
 
 config SEGGER_SYSVIEW_POST_MORTEM_MODE
-	bool "Enable post-mortem mode for SystemView"
+	bool "Post-mortem mode for SystemView"
 	depends on SEGGER_SYSTEMVIEW
 
 choice SEGGER_SYSVIEW_SECTION

--- a/subsys/usb/Kconfig
+++ b/subsys/usb/Kconfig
@@ -51,7 +51,7 @@ config USB_DEVICE_SN
 	  Hardware Information Driver (HWINFO).
 
 config USB_COMPOSITE_DEVICE
-	bool "Enable composite device driver"
+	bool "Composite device driver"
 	help
 	  Enable composite USB device driver.
 
@@ -96,14 +96,14 @@ config USB_NUMOF_EP_WRITE_RETRIES
 	  Number of endpoint write retries.
 
 config USB_DEVICE_SOF
-	bool "Enable Start of Frame processing in events"
+	bool "Start of Frame processing in events"
 	default y if (USB_DEVICE_AUDIO && NRFX_USBD)
 
 config USB_DEVICE_BOS
-	bool "Enable USB Binary Device Object Store (BOS)"
+	bool "USB Binary Device Object Store (BOS)"
 
 config USB_DEVICE_OS_DESC
-	bool "Enable MS OS Descriptors support"
+	bool "MS OS Descriptors support"
 
 config USB_SELF_POWERED
 	bool "Set Self-powered characteristic"

--- a/subsys/usb/class/Kconfig.bt
+++ b/subsys/usb/class/Kconfig.bt
@@ -9,7 +9,7 @@ menuconfig USB_DEVICE_BLUETOOTH
 	  USB Bluetooth device class support
 
 config USB_DEVICE_BLUETOOTH_VS_H4
-	bool "Enable USB Bluetooth H4 vendor command"
+	bool "USB Bluetooth H4 vendor command"
 	depends on USB_DEVICE_BLUETOOTH
 	select BT_HCI_RAW_H4
 	select BT_HCI_RAW_CMD_EXT

--- a/subsys/usb/class/dfu/Kconfig
+++ b/subsys/usb/class/dfu/Kconfig
@@ -30,7 +30,7 @@ config USB_DFU_DEFAULT_POLLTIMEOUT
 	  Default value for bwPollTimeout (in ms)
 
 config USB_DFU_ENABLE_UPLOAD
-	bool "Enable firmware uploading to the host"
+	bool "Firmware uploading to the host"
 	help
 	  Enabling this option allows to upload firmware image to the host.
 	  Be aware that upload capability can be a security risk because

--- a/subsys/usb/class/hid/Kconfig
+++ b/subsys/usb/class/hid/Kconfig
@@ -27,7 +27,7 @@ module-str = usb hid
 source "subsys/logging/Kconfig.template.log_config"
 
 config ENABLE_HID_INT_OUT_EP
-	bool "Enable USB HID Device Interrupt OUT Endpoint"
+	bool "USB HID Device Interrupt OUT Endpoint"
 	help
 	  Enable USB HID Device Interrupt OUT Endpoint.
 
@@ -58,7 +58,7 @@ config USB_HID_REPORTS
 	  idle rate must be supported.
 
 config USB_HID_BOOT_PROTOCOL
-	bool "Enable USB HID Boot Protocol handling"
+	bool "USB HID Boot Protocol handling"
 	help
 	  Sets bInterfaceSubClass to 1 and enables Set_Protocol and Get_Protocol
 	  requests handling.

--- a/tests/drivers/i2c/i2c_slave_api/common/Kconfig
+++ b/tests/drivers/i2c/i2c_slave_api/common/Kconfig
@@ -16,4 +16,4 @@ config I2C_VIRTUAL_NAME
 	depends on I2C_VIRTUAL
 
 config APP_DUAL_ROLE_I2C
-	bool "Enable test with combined master/slave behavior"
+	bool "Test with combined master/slave behavior"

--- a/tests/drivers/pinctrl/gd32/Kconfig
+++ b/tests/drivers/pinctrl/gd32/Kconfig
@@ -6,7 +6,7 @@ mainmenu "pinctrl GD32 DT Test"
 source "Kconfig.zephyr"
 
 config PINCTRL_TEST_NON_STATIC
-	bool "Enable access to pin control configuration"
+	bool "Access to pin control configuration"
 	select PINCTRL_NON_STATIC
 	help
 	  This option should be selected by unit tests that need to access the pin

--- a/tests/drivers/pinctrl/nrf/Kconfig
+++ b/tests/drivers/pinctrl/nrf/Kconfig
@@ -6,7 +6,7 @@ mainmenu "pinctrl nRF DT Test"
 source "Kconfig.zephyr"
 
 config PINCTRL_TEST_NON_STATIC
-	bool "Enable access to pin control configuration"
+	bool "Access to pin control configuration"
 	select PINCTRL_NON_STATIC
 	help
 	  This option should be selected by unit tests that need to access the pin


### PR DESCRIPTION
According to Kconfig guidelines, boolean prompts must not start with
"Enable...". This PR removes all usages of `bool "Enable..."` and introduces a CI check to prevent new cases in the future. Note that due to these changes, certain prompts may need some tweaks (check 2nd commit for some I've already adjusted).

Note that Kconfig symbols in modules (e.g. LVGL) are ignored since we have no control on them.