### PR TITLE
samples: Bluetooth: df: Add missing harness=bluetooth to DF sample.yaml

### DIFF
--- a/samples/bluetooth/direction_finding_central/sample.yaml
+++ b/samples/bluetooth/direction_finding_central/sample.yaml
@@ -11,8 +11,8 @@ tests:
       - nrf52833dk_nrf52820
       - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless_rx.aod:
-    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     harness: bluetooth
+    extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:

--- a/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_rx/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf52833dk_nrf52820
       - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless_rx.aod:
+    harness: bluetooth
     extra_args: OVERLAY_CONFIG="overlay-aod.conf"
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     integration_platforms:

--- a/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
+++ b/samples/bluetooth/direction_finding_connectionless_tx/sample.yaml
@@ -10,6 +10,7 @@ tests:
       - nrf52833dk_nrf52820
       - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless.aoa:
+    harness: bluetooth
     extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     integration_platforms:

--- a/samples/bluetooth/direction_finding_peripheral/sample.yaml
+++ b/samples/bluetooth/direction_finding_peripheral/sample.yaml
@@ -11,8 +11,8 @@ tests:
       - nrf52833dk_nrf52820
       - nrf5340dk_nrf5340_cpuapp
   sample.bluetooth.direction_finding_connectionless_rx.aod:
-    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     harness: bluetooth
+    extra_args: OVERLAY_CONFIG="overlay-aoa.conf"
     platform_allow: nrf52833dk_nrf52833 nrf52833dk_nrf52820 nrf5340dk_nrf5340_cpuapp
     tags: bluetooth
     integration_platforms:


### PR DESCRIPTION
Some build configurations in direction finding samples
sample.yaml didn't have harness=bluetooth. That enables
these configurations to be be executed on hardware by
CI. Those runs end causing CI failures.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>