### PR TITLE
drivers: spi_handlers: switch to gpio_dt_spec member

### DIFF
--- a/drivers/spi/spi_handlers.c
+++ b/drivers/spi/spi_handlers.c
@@ -108,8 +108,8 @@ static inline int z_vrfy_spi_transceive(const struct device *dev,
 		const struct spi_cs_control *cs = config_copy.cs;
 
 		Z_OOPS(Z_SYSCALL_MEMORY_READ(cs, sizeof(*cs)));
-		if (cs->gpio_dev) {
-			Z_OOPS(Z_SYSCALL_OBJ(cs->gpio_dev, K_OBJ_DRIVER_GPIO));
+		if (cs->gpio.port) {
+			Z_OOPS(Z_SYSCALL_OBJ(cs->gpio.port, K_OBJ_DRIVER_GPIO));
 		}
 	}
 


### PR DESCRIPTION
Don't use the old gpio_dev spi_cs_control's member since it's been deprecated in favor of gpio_dt_spec.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>