### PR TITLE
drivers: pinctrl: stm32: fix F1 SWJ_CFG application

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -22,6 +22,16 @@ Changes in this release
 Removed APIs in this release
 ============================
 
+* STM32F1 Serial wire JTAG configuration (SWJ CFG) configuration choice
+  was moved from Kconfig to :ref:`devicetree <dt-guide>`.
+  See the :dtcompatible:`st,stm32f1-pinctrl` devicetree binding for more information.
+  As a consequence, the following Kconfig symbols were removed:
+
+  * ``CONFIG_GPIO_STM32_SWJ_ENABLE``
+  * ``CONFIG_GPIO_STM32_SWJ_NONJTRST``
+  * ``CONFIG_GPIO_STM32_SWJ_NOJTAG``
+  * ``CONFIG_GPIO_STM32_SWJ_DISABLE``
+
 Deprecated in this release
 ==========================
 

--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -3,30 +3,8 @@
 # Copyright (c) 2016 Open-RnD Sp. z o.o.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig GPIO_STM32
+config GPIO_STM32
 	bool "GPIO Driver for STM32 family of MCUs"
 	depends on SOC_FAMILY_STM32
 	help
 	  Enable GPIO driver for STM32 line of MCUs
-
-if GPIO_STM32
-
-choice GPIO_STM32_SWJ
-	prompt "Serial wire JTAG configuration"
-	depends on SOC_SERIES_STM32F1X
-
-config GPIO_STM32_SWJ_ENABLE
-	bool "Full SWJ (JTAG-DP + SW-DP): Reset State"
-
-config GPIO_STM32_SWJ_NONJTRST
-	bool "Full SWJ (JTAG-DP + SW-DP) but without NJTRST"
-
-config GPIO_STM32_SWJ_NOJTAG
-	bool "JTAG-DP Disabled and SW-DP Enabled"
-
-config GPIO_STM32_SWJ_DISABLE
-	bool "JTAG-DP Disabled and SW-DP Disabled"
-
-endchoice
-
-endif # GPIO_STM32

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -703,33 +703,3 @@ GPIO_DEVICE_INIT_STM32(j, J);
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpiok), okay)
 GPIO_DEVICE_INIT_STM32(k, K);
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(gpiok), okay) */
-
-
-#if defined(CONFIG_SOC_SERIES_STM32F1X) && \
-	!defined(CONFIG_GPIO_STM32_SWJ_ENABLE)
-
-static int gpio_stm32_afio_init(const struct device *dev)
-{
-	UNUSED(dev);
-
-	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
-
-#if defined(CONFIG_GPIO_STM32_SWJ_NONJTRST)
-	/* released PB4 */
-	__HAL_AFIO_REMAP_SWJ_NONJTRST();
-#elif defined(CONFIG_GPIO_STM32_SWJ_NOJTAG)
-	/* released PB4 PB3 PA15 */
-	__HAL_AFIO_REMAP_SWJ_NOJTAG();
-#elif defined(CONFIG_GPIO_STM32_SWJ_DISABLE)
-	/* released PB4 PB3 PA13 PA14 PA15 */
-	__HAL_AFIO_REMAP_SWJ_DISABLE();
-#endif
-
-	LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_AFIO);
-
-	return 0;
-}
-
-SYS_INIT(gpio_stm32_afio_init, PRE_KERNEL_1, 0);
-
-#endif /* CONFIG_SOC_SERIES_STM32F1X && !CONFIG_GPIO_STM32_SWJ_ENABLE */

--- a/drivers/pinmux/pinmux_stm32.c
+++ b/drivers/pinmux/pinmux_stm32.c
@@ -184,6 +184,40 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 }
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32f1_pinctrl)
+
+/* ignore swj-cfg reset state (default value) */
+#if ((DT_NODE_HAS_PROP(DT_NODELABEL(pinctrl), swj_cfg)) && \
+	(DT_ENUM_IDX(DT_NODELABEL(pinctrl), swj_cfg) != 0))
+
+static int stm32f1_swj_cfg_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
+
+	/* reset state is '000' (Full SWJ, (JTAG-DP + SW-DP)) */
+	/* only one of the 3 bits can be set */
+#if (DT_ENUM_IDX(DT_NODELABEL(pinctrl), swj_cfg) == 1)
+	/* 001: Full SWJ (JTAG-DP + SW-DP) but without NJTRST */
+	/* releases: PB4 */
+	LL_GPIO_AF_Remap_SWJ_NONJTRST();
+#elif (DT_ENUM_IDX(DT_NODELABEL(pinctrl), swj_cfg) == 2)
+	/* 010: JTAG-DP Disabled and SW-DP Enabled */
+	/* releases: PB4 PB3 PA15 */
+	LL_GPIO_AF_Remap_SWJ_NOJTAG();
+#elif (DT_ENUM_IDX(DT_NODELABEL(pinctrl), swj_cfg) == 3)
+	/* 100: JTAG-DP Disabled and SW-DP Disabled */
+	/* releases: PB4 PB3 PA13 PA14 PA15 */
+	LL_GPIO_AF_DisableRemap_SWJ();
+#endif
+
+	return 0;
+}
+
+SYS_INIT(stm32f1_swj_cfg_init, PRE_KERNEL_1, 0);
+
+#endif /* DT_NODE_HAS_PROP(DT_NODELABEL(pinctrl), swj_cfg) */
+
 /**
  * @brief Helper function to check and apply provided pinctrl remap
  *        configuration
@@ -199,9 +233,7 @@ int stm32_dt_pinctrl_configure(const struct soc_gpio_pinctrl *pinctrl,
 int stm32_dt_pinctrl_remap(const struct soc_gpio_pinctrl *pinctrl,
 			   size_t list_size)
 {
-	uint8_t pos;
 	uint32_t reg_val;
-	volatile uint32_t *reg;
 	uint16_t remap;
 
 	remap = (uint16_t)STM32_DT_PINMUX_REMAP(pinctrl[0].pinmux);
@@ -222,17 +254,17 @@ int stm32_dt_pinctrl_remap(const struct soc_gpio_pinctrl *pinctrl,
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_AFIO);
 
 	if (STM32_REMAP_REG_GET(remap) == 0U) {
-		reg = &AFIO->MAPR;
+		/* read initial value, ignore write-only SWJ_CFG */
+		reg_val = AFIO->MAPR & ~AFIO_MAPR_SWJ_CFG;
+		reg_val |= STM32_REMAP_VAL_GET(remap) << STM32_REMAP_SHIFT_GET(remap);
+		/* apply undocumented '111' (AFIO_MAPR_SWJ_CFG) to affirm SWJ_CFG */
+		/* the pins are not remapped without that (when SWJ_CFG is not default) */
+		AFIO->MAPR = reg_val | AFIO_MAPR_SWJ_CFG;
 	} else {
-		reg = &AFIO->MAPR2;
+		reg_val = AFIO->MAPR2;
+		reg_val |= STM32_REMAP_VAL_GET(remap) << STM32_REMAP_SHIFT_GET(remap);
+		AFIO->MAPR2 = reg_val;
 	}
-
-	pos = STM32_REMAP_SHIFT_GET(remap);
-
-	reg_val = *reg;
-	reg_val &= ~(STM32_REMAP_MASK_GET(remap) << pos);
-	reg_val |= STM32_REMAP_VAL_GET(remap) << pos;
-	*reg = reg_val;
 
 	return 0;
 }

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -11,6 +11,28 @@ properties:
     reg:
       required: true
 
+    swj-cfg:
+        type: string
+        required: false
+        default: "full" # reset state
+        enum:
+          - "full"
+          - "no-njtrst"
+          - "jtag-disable"
+          - "disable"
+        description: |
+          Configures number of pins assigned to the SWJ debug port.
+
+          * full         - Full SWJ (JTAG-DP + SW-DP).
+          * no-njtrst    - Full SWJ (JTAG-DP + SW-DP) but without NJTRST.
+                           Releases: PB4.
+          * jtag-disable - JTAG-DP Disabled and SW-DP Enabled.
+                           Releases: PA15 PB3 PB4.
+          * disable      - JTAG-DP Disabled and SW-DP Disabled.
+                           Releases: PA13 PA14 PA15 PB3 PB4.
+
+          If absent, then Full SWJ (JTAG-DP + SW-DP) is used (reset state).
+
 child-binding:
     description: |
         This binding gives a base representation of the STM32F1 pins


### PR DESCRIPTION
Based on `LL` and `HAL` libraries the value of `AFIO_MAPR_SWJ_CFG`  has to be applied to the `MAPR`  upon enabling of a remap. That solved the issue of a not working SPI 1 remap on F103VC and allowed it to be debuggable when the `CONFIG_GPIO_STM32_SWJ_NOJTAG` option is enabled.

The SWJ CFG initialization into `pinctrl` /`pinmux` (*deprecated*) modules.
Kconfig SWJ options were moved into F1 `pinctrl` /`pinmux` DTS.

Fixes #43452
Fixes #43640 

Signed-off-by: Georgij Cernysiov <geo.cgv@gmail.com>