### PR TITLE
drivers: Add support for pinctrl in remaining nRF drivers

### DIFF
--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -6,6 +6,8 @@
 
 #include <audio/dmic.h>
 #include <drivers/clock_control/nrf_clock_control.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 #include <nrfx_pdm.h>
 
 #include <logging/log.h>
@@ -26,6 +28,9 @@ struct dmic_nrfx_pdm_drv_data {
 struct dmic_nrfx_pdm_drv_cfg {
 	nrfx_pdm_event_handler_t event_handler;
 	nrfx_pdm_config_t nrfx_def_cfg;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 	enum clock_source {
 		PCLK32M,
 		PCLK32M_HFXO,
@@ -532,15 +537,26 @@ static const struct _dmic_ops dmic_ops = {
 };
 
 #define PDM(idx) DT_NODELABEL(pdm##idx)
+#define PDM_PIN(idx, name) DT_PROP_OR(PDM(idx), name##_pin, 0)
 #define PDM_CLK_SRC(idx) DT_STRING_TOKEN(PDM(idx), clock_source)
 
 #define PDM_NRFX_DEVICE(idx)						     \
+	NRF_DT_ENSURE_PINS_ASSIGNED(PDM(idx), clk_pin);			     \
 	static void *rx_msgs##idx[DT_PROP(PDM(idx), queue_size)];	     \
 	static struct dmic_nrfx_pdm_drv_data dmic_nrfx_pdm_data##idx;	     \
 	static int pdm_nrfx_init##idx(const struct device *dev)		     \
 	{								     \
 		IRQ_CONNECT(DT_IRQN(PDM(idx)), DT_IRQ(PDM(idx), priority),   \
 			    nrfx_isr, nrfx_pdm_irq_handler, 0);		     \
+		IF_ENABLED(CONFIG_PINCTRL, (				     \
+			const struct dmic_nrfx_pdm_drv_cfg *drv_cfg =	     \
+				dev->config;				     \
+			int err = pinctrl_apply_state(drv_cfg->pcfg,	     \
+						      PINCTRL_STATE_DEFAULT);\
+			if (err < 0) {					     \
+				return err;				     \
+			}						     \
+		))							     \
 		k_msgq_init(&dmic_nrfx_pdm_data##idx.rx_queue,		     \
 			    (char *)rx_msgs##idx, sizeof(void *),	     \
 			    ARRAY_SIZE(rx_msgs##idx));			     \
@@ -551,11 +567,15 @@ static const struct _dmic_ops dmic_ops = {
 	{								     \
 		event_handler(DEVICE_DT_GET(PDM(idx)), evt);		     \
 	}								     \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(PDM(idx))));	     \
 	static const struct dmic_nrfx_pdm_drv_cfg dmic_nrfx_pdm_cfg##idx = { \
 		.event_handler = event_handler##idx,			     \
-		.nrfx_def_cfg =	NRFX_PDM_DEFAULT_CONFIG(		     \
-					DT_PROP(PDM(idx), clk_pin),	     \
-					DT_PROP(PDM(idx), din_pin)),	     \
+		.nrfx_def_cfg =	NRFX_PDM_DEFAULT_CONFIG(PDM_PIN(idx, clk),   \
+							PDM_PIN(idx, din)),  \
+		IF_ENABLED(CONFIG_PINCTRL,				     \
+			(.nrfx_def_cfg.skip_gpio_cfg = true,		     \
+			 .nrfx_def_cfg.skip_psel_cfg = true,		     \
+			 .pcfg = PINCTRL_DT_DEV_CONFIG_GET(PDM(idx)),))      \
 		.clk_src = PDM_CLK_SRC(idx),				     \
 	};								     \
 	BUILD_ASSERT(PDM_CLK_SRC(idx) != ACLK || NRF_PDM_HAS_MCLKCONFIG,     \

--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -10,6 +10,8 @@
 #include <drivers/flash.h>
 #include <init.h>
 #include <pm/device.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 #include <string.h>
 #include <logging/log.h>
 LOG_MODULE_REGISTER(qspi_nor, CONFIG_FLASH_LOG_LEVEL);
@@ -51,6 +53,10 @@ struct qspi_nor_config {
 
 	/* JEDEC id from devicetree */
 	uint8_t id[SPI_NOR_MAX_ID_LEN];
+
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 /* Status register bits */
@@ -379,8 +385,10 @@ static void anomaly_122_uninit(const struct device *dev)
 			}
 		}
 
+#ifndef CONFIG_PINCTRL
 		nrf_gpio_cfg_output(QSPI_PROP_AT(csn_pins, 0));
 		nrf_gpio_pin_set(QSPI_PROP_AT(csn_pins, 0));
+#endif
 
 		nrfx_qspi_uninit();
 		qspi_initialized = false;
@@ -1053,6 +1061,15 @@ static int qspi_nor_init(const struct device *dev)
 	nrf_clock_hfclk192m_div_set(NRF_CLOCK, NRF_CLOCK_HFCLK_DIV_4);
 #endif
 
+#ifdef CONFIG_PINCTRL
+	const struct qspi_nor_config *dev_config = dev->config;
+	int ret = pinctrl_apply_state(dev_config->pcfg, PINCTRL_STATE_DEFAULT);
+
+	if (ret < 0) {
+		return ret;
+	}
+#endif
+
 	IRQ_CONNECT(DT_IRQN(QSPI_NODE), DT_IRQ(QSPI_NODE, priority),
 		    nrfx_isr, nrfx_qspi_irq_handler, 0);
 	return qspi_nor_configure(dev);
@@ -1187,9 +1204,23 @@ static int qspi_nor_pm_action(const struct device *dev,
 		}
 
 		nrfx_qspi_uninit();
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(dev_config->pcfg,
+					  PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		break;
 
 	case PM_DEVICE_ACTION_RESUME:
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(dev_config->pcfg,
+					  PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		err = nrfx_qspi_init(&dev_config->nrfx_cfg,
 				     qspi_handler,
 				     dev_data);
@@ -1258,7 +1289,16 @@ static struct qspi_nor_data qspi_nor_dev_data = {
 #endif /* CONFIG_MULTITHREADING */
 };
 
+NRF_DT_ENSURE_PINS_ASSIGNED(QSPI_NODE, sck_pin);
+
+IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(QSPI_NODE)));
+
 static const struct qspi_nor_config qspi_nor_dev_config = {
+#ifdef CONFIG_PINCTRL
+	.nrfx_cfg.skip_gpio_cfg = true,
+	.nrfx_cfg.skip_psel_cfg = true,
+	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(QSPI_NODE),
+#else
 	.nrfx_cfg.pins = {
 		.sck_pin = DT_PROP(QSPI_NODE, sck_pin),
 		.csn_pin = QSPI_PROP_AT(csn_pins, 0),
@@ -1272,6 +1312,7 @@ static const struct qspi_nor_config qspi_nor_dev_config = {
 		.io3_pin = NRF_QSPI_PIN_NOT_CONNECTED,
 #endif
 	},
+#endif /* CONFIG_PINCTRL */
 	.nrfx_cfg.prot_if = {
 		.readoc = COND_CODE_1(DT_INST_NODE_HAS_PROP(0, readoc),
 			(_CONCAT(NRF_QSPI_READOC_,

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -7,6 +7,8 @@
 #include <stdlib.h>
 #include <drivers/i2s.h>
 #include <drivers/clock_control/nrf_clock_control.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 #include <nrfx_i2s.h>
 
 #include <logging/log.h>
@@ -38,6 +40,9 @@ struct i2s_nrfx_drv_data {
 struct i2s_nrfx_drv_cfg {
 	nrfx_i2s_data_handler_t data_handler;
 	nrfx_i2s_config_t nrfx_def_cfg;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 	enum clock_source {
 		PCLK32M,
 		PCLK32M_HFXO,
@@ -873,14 +878,12 @@ static const struct i2s_driver_api i2s_nrf_drv_api = {
 };
 
 #define I2S(idx) DT_NODELABEL(i2s##idx)
-
-#define I2S_PIN(idx, name)					\
-	COND_CODE_1(DT_NODE_HAS_PROP(I2S(idx), name##_pin),	\
-		    (DT_PROP(I2S(idx), name##_pin)),		\
-		    (NRFX_I2S_PIN_NOT_USED))
-#define I2S_CLK_SRC(idx)  DT_STRING_TOKEN(I2S(idx), clock_source)
+#define I2S_PIN(idx, name) DT_PROP_OR(I2S(idx), name##_pin, \
+				      NRFX_I2S_PIN_NOT_USED)
+#define I2S_CLK_SRC(idx) DT_STRING_TOKEN(I2S(idx), clock_source)
 
 #define I2S_NRFX_DEVICE(idx)						     \
+	NRF_DT_ENSURE_PINS_ASSIGNED(I2S(idx), sck_pin);			     \
 	static void *tx_msgs##idx[CONFIG_I2S_NRFX_TX_BLOCK_COUNT];	     \
 	static void *rx_msgs##idx[CONFIG_I2S_NRFX_RX_BLOCK_COUNT];	     \
 	static struct i2s_nrfx_drv_data i2s_nrfx_data##idx = {		     \
@@ -890,6 +893,14 @@ static const struct i2s_driver_api i2s_nrf_drv_api = {
 	{								     \
 		IRQ_CONNECT(DT_IRQN(I2S(idx)), DT_IRQ(I2S(idx), priority),   \
 			    nrfx_isr, nrfx_i2s_irq_handler, 0);		     \
+		IF_ENABLED(CONFIG_PINCTRL, (				     \
+			const struct i2s_nrfx_drv_cfg *drv_cfg = dev->config;\
+			int err = pinctrl_apply_state(drv_cfg->pcfg,	     \
+						      PINCTRL_STATE_DEFAULT);\
+			if (err < 0) {					     \
+				return err;				     \
+			}						     \
+		))							     \
 		k_msgq_init(&i2s_nrfx_data##idx.tx_queue,		     \
 			    (char *)tx_msgs##idx, sizeof(void *),	     \
 			    ARRAY_SIZE(tx_msgs##idx));			     \
@@ -904,6 +915,7 @@ static const struct i2s_driver_api i2s_nrf_drv_api = {
 	{								     \
 		data_handler(DEVICE_DT_GET(I2S(idx)), p_released, status);   \
 	}								     \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(I2S(idx))));	     \
 	static const struct i2s_nrfx_drv_cfg i2s_nrfx_cfg##idx = {	     \
 		.data_handler = data_handler##idx,			     \
 		.nrfx_def_cfg = NRFX_I2S_DEFAULT_CONFIG(I2S_PIN(idx, sck),   \
@@ -911,6 +923,10 @@ static const struct i2s_driver_api i2s_nrf_drv_api = {
 							I2S_PIN(idx, mck),   \
 							I2S_PIN(idx, sdout), \
 							I2S_PIN(idx, sdin)), \
+		IF_ENABLED(CONFIG_PINCTRL,				     \
+			(.nrfx_def_cfg.skip_gpio_cfg = true,		     \
+			 .nrfx_def_cfg.skip_psel_cfg = true,		     \
+			 .pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2S(idx)),))      \
 		.clk_src = I2S_CLK_SRC(idx),				     \
 	};								     \
 	BUILD_ASSERT(I2S_CLK_SRC(idx) != ACLK || NRF_I2S_HAS_CLKCONFIG,	     \

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -61,6 +61,18 @@ BUILD_ASSERT(((NRF_DRIVE_S0S1 == NRF_GPIO_PIN_S0S1) &&
 #define NRF_PSEL_PDM(reg, line) ((NRF_PDM_Type *)reg)->PSEL.line
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_pwm)
+#define NRF_PSEL_PWM(reg, line) ((NRF_PWM_Type *)reg)->PSEL.line
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_qdec)
+#define NRF_PSEL_QDEC(reg, line) ((NRF_QDEC_Type *)reg)->PSEL.line
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_qspi)
+#define NRF_PSEL_QSPI(reg, line) ((NRF_QSPI_Type *)reg)->PSEL.line
+#endif
+
 /**
  * @brief Configure pin settings.
  *
@@ -218,6 +230,81 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 					  NRF_GPIO_PIN_INPUT_CONNECT);
 			break;
 #endif /* defined(NRF_PSEL_PDM) */
+#if defined(NRF_PSEL_PWM)
+		case NRF_FUN_PWM_OUT0:
+			NRF_PSEL_PWM(reg, OUT[0]) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
+					   NRF_GET_INVERT(pins[i]));
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_PWM_OUT1:
+			NRF_PSEL_PWM(reg, OUT[1]) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
+					   NRF_GET_INVERT(pins[i]));
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_PWM_OUT2:
+			NRF_PSEL_PWM(reg, OUT[2]) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
+					   NRF_GET_INVERT(pins[i]));
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_PWM_OUT3:
+			NRF_PSEL_PWM(reg, OUT[3]) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
+					   NRF_GET_INVERT(pins[i]));
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+#endif /* defined(NRF_PSEL_PWM) */
+#if defined(NRF_PSEL_QDEC)
+		case NRF_FUN_QDEC_A:
+			NRF_PSEL_QDEC(reg, A) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_QDEC_B:
+			NRF_PSEL_QDEC(reg, B) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+		case NRF_FUN_QDEC_LED:
+			NRF_PSEL_QDEC(reg, LED) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+#endif /* defined(NRF_PSEL_QDEC) */
+#if defined(NRF_PSEL_QSPI)
+		case NRF_FUN_QSPI_SCK:
+			NRF_PSEL_QSPI(reg, SCK) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_QSPI_CSN:
+			NRF_PSEL_QSPI(reg, CSN) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_QSPI_IO0:
+			NRF_PSEL_QSPI(reg, IO0) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+		case NRF_FUN_QSPI_IO1:
+			NRF_PSEL_QSPI(reg, IO1) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+		case NRF_FUN_QSPI_IO2:
+			NRF_PSEL_QSPI(reg, IO2) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+		case NRF_FUN_QSPI_IO3:
+			NRF_PSEL_QSPI(reg, IO3) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+#endif /* defined(NRF_PSEL_QSPI) */
 		default:
 			return -ENOTSUP;
 		}

--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -53,6 +53,14 @@ BUILD_ASSERT(((NRF_DRIVE_S0S1 == NRF_GPIO_PIN_S0S1) &&
 #define NRF_PSEL_TWIM(reg, line) ((NRF_TWIM_Type *)reg)->PSEL.line
 #endif
 
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_i2s)
+#define NRF_PSEL_I2S(reg, line) ((NRF_I2S_Type *)reg)->PSEL.line
+#endif
+
+#if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_pdm)
+#define NRF_PSEL_PDM(reg, line) ((NRF_PDM_Type *)reg)->PSEL.line
+#endif
+
 /**
  * @brief Configure pin settings.
  *
@@ -156,6 +164,60 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 					  NRF_GPIO_PIN_INPUT_CONNECT);
 			break;
 #endif /* defined(NRF_PSEL_TWIM) */
+#if defined(NRF_PSEL_I2S)
+		case NRF_FUN_I2S_SCK_M:
+			NRF_PSEL_I2S(reg, SCK) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_I2S_SCK_S:
+			NRF_PSEL_I2S(reg, SCK) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_I2S_LRCK_M:
+			NRF_PSEL_I2S(reg, LRCK) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_I2S_LRCK_S:
+			NRF_PSEL_I2S(reg, LRCK) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_I2S_SDIN:
+			NRF_PSEL_I2S(reg, SDIN) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+		case NRF_FUN_I2S_SDOUT:
+			NRF_PSEL_I2S(reg, SDOUT) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_I2S_MCK:
+			NRF_PSEL_I2S(reg, MCK) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+#endif /* defined(NRF_PSEL_I2S) */
+#if defined(NRF_PSEL_PDM)
+		case NRF_FUN_PDM_CLK:
+			NRF_PSEL_PDM(reg, CLK) = NRF_GET_PIN(pins[i]);
+			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
+					  NRF_GPIO_PIN_INPUT_DISCONNECT);
+			break;
+		case NRF_FUN_PDM_DIN:
+			NRF_PSEL_PDM(reg, DIN) = NRF_GET_PIN(pins[i]);
+			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
+					  NRF_GPIO_PIN_INPUT_CONNECT);
+			break;
+#endif /* defined(NRF_PSEL_PDM) */
 		default:
 			return -ENOTSUP;
 		}

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -6,6 +6,8 @@
 #include <nrfx_pwm.h>
 #include <drivers/pwm.h>
 #include <pm/device.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 #include <hal/nrf_gpio.h>
 #include <stdbool.h>
 
@@ -13,16 +15,18 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(pwm_nrfx);
 
-#define PWM_NRFX_CH_POLARITY_MASK       BIT(15)
-#define PWM_NRFX_CH_PULSE_CYCLES_MASK   BIT_MASK(15)
-#define PWM_NRFX_CH_VALUE_NORMAL        PWM_NRFX_CH_POLARITY_MASK
-#define PWM_NRFX_CH_VALUE_INVERTED      (0)
-#define PWM_NRFX_CH_PIN_MASK            ~NRFX_PWM_PIN_INVERTED
+#define PWM_NRFX_CH_POLARITY_MASK          BIT(15)
+#define PWM_NRFX_CH_PULSE_CYCLES_MASK      BIT_MASK(15)
+#define PWM_NRFX_CH_VALUE(value, inverted) \
+	(value | (inverted ? 0 : PWM_NRFX_CH_POLARITY_MASK))
 
 struct pwm_nrfx_config {
 	nrfx_pwm_t pwm;
 	nrfx_pwm_config_t initial_config;
 	nrf_pwm_sequence_t seq;
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pcfg;
+#endif
 };
 
 struct pwm_nrfx_data {
@@ -30,6 +34,7 @@ struct pwm_nrfx_data {
 	uint16_t current[NRF_PWM_CHANNEL_COUNT];
 	uint16_t countertop;
 	uint8_t  prescaler;
+	uint8_t  inverted_channels;
 };
 
 
@@ -84,14 +89,14 @@ static int pwm_period_check_and_set(const struct pwm_nrfx_config *config,
 	return -EINVAL;
 }
 
-static uint8_t pwm_channel_map(const uint8_t *output_pins, uint32_t pwm)
+static uint8_t pwm_channel_map(const struct pwm_nrfx_config *config,
+			       uint32_t pwm)
 {
 	uint8_t i;
 
 	/* Find pin, return channel number */
 	for (i = 0U; i < NRF_PWM_CHANNEL_COUNT; i++) {
-		if (output_pins[i] != NRFX_PWM_PIN_NOT_USED
-		    && (pwm == (output_pins[i] & PWM_NRFX_CH_PIN_MASK))) {
+		if (nrf_pwm_pin_get(config->pwm.p_registers, i) == pwm) {
 			return i;
 		}
 	}
@@ -142,11 +147,11 @@ static int pwm_nrfx_pin_set(const struct device *dev, uint32_t pwm,
 		return -ENOTSUP;
 	}
 
-	/* Check if PWM pin is one of the predefiend DTS config pins.
+	/* Check if PWM pin is one of the predefined DTS config pins.
 	 * Return its array index (channel number),
 	 * or NRF_PWM_CHANNEL_COUNT if not initialized through DTS.
 	 */
-	channel = pwm_channel_map(config->initial_config.output_pins, pwm);
+	channel = pwm_channel_map(config, pwm);
 	if (channel == NRF_PWM_CHANNEL_COUNT) {
 		LOG_ERR("PWM pin %d not enabled through DTS configuration.",
 			pwm);
@@ -211,8 +216,7 @@ static int pwm_nrfx_pin_set(const struct device *dev, uint32_t pwm,
 		 * If pulse 100% and pin not inverted, set HIGH.
 		 */
 		bool channel_inverted_state =
-			config->initial_config.output_pins[channel]
-			& NRFX_PWM_PIN_INVERTED;
+			data->inverted_channels & BIT(channel);
 
 		bool pulse_0_and_not_inverted =
 			(pulse_cycles == 0U)
@@ -274,12 +278,33 @@ static int pwm_nrfx_init(const struct device *dev)
 	const struct pwm_nrfx_config *config = dev->config;
 	struct pwm_nrfx_data *data = dev->data;
 
-	for (size_t i = 0; i < ARRAY_SIZE(data->current); i++) {
-		bool inverted = config->initial_config.output_pins[i] & NRFX_PWM_PIN_INVERTED;
-		uint16_t value = (inverted)?(PWM_NRFX_CH_VALUE_INVERTED):(PWM_NRFX_CH_VALUE_NORMAL);
+#ifdef CONFIG_PINCTRL
+	int ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 
-		data->current[i] = value;
-	};
+	if (ret < 0) {
+		return ret;
+	}
+
+	data->inverted_channels = 0;
+	for (size_t i = 0; i < ARRAY_SIZE(data->current); i++) {
+		uint32_t psel = nrf_pwm_pin_get(config->pwm.p_registers, i);
+		/* Mark channels as inverted according to what initial state
+		 * of their outputs has been set by pinctrl (high idle state
+		 * means that the channel is inverted).
+		 */
+		if (((psel & PWM_PSEL_OUT_CONNECT_Msk) >> PWM_PSEL_OUT_CONNECT_Pos)
+		    == PWM_PSEL_OUT_CONNECT_Connected) {
+			data->inverted_channels |=
+				nrf_gpio_pin_out_read(psel) ? BIT(i) : 0;
+		}
+	}
+#endif
+
+	for (size_t i = 0; i < ARRAY_SIZE(data->current); i++) {
+		bool inverted = data->inverted_channels & BIT(i);
+
+		data->current[i] = PWM_NRFX_CH_VALUE(0, inverted);
+	}
 
 	nrfx_err_t result = nrfx_pwm_init(&config->pwm,
 					  &config->initial_config,
@@ -306,20 +331,38 @@ static void pwm_nrfx_uninit(const struct device *dev)
 static int pwm_nrfx_pm_action(const struct device *dev,
 			      enum pm_device_action action)
 {
-	int err = 0;
+#ifdef CONFIG_PINCTRL
+	const struct pwm_nrfx_config *config = dev->config;
+#endif
+	int ret = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		err = pwm_nrfx_init(dev);
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
+		ret = pwm_nrfx_init(dev);
 		break;
+
 	case PM_DEVICE_ACTION_SUSPEND:
 		pwm_nrfx_uninit(dev);
+
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		break;
+
 	default:
 		return -ENOTSUP;
 	}
 
-	return err;
+	return ret;
 }
 #else
 
@@ -330,49 +373,60 @@ static int pwm_nrfx_pm_action(const struct device *dev,
 #define PWM(dev_idx) DT_NODELABEL(pwm##dev_idx)
 #define PWM_PROP(dev_idx, prop) DT_PROP(PWM(dev_idx), prop)
 
-#define PWM_NRFX_IS_INVERTED(dev_idx, ch_idx) \
+#define PWM_CH_INVERTED(dev_idx, ch_idx) \
 	PWM_PROP(dev_idx, ch##ch_idx##_inverted)
 
-#define PWM_NRFX_CH_PIN(dev_idx, ch_idx)				      \
-	COND_CODE_1(DT_NODE_HAS_PROP(PWM(dev_idx), ch##ch_idx##_pin),	      \
-		    (PWM_PROP(dev_idx, ch##ch_idx##_pin)),		      \
-		    (NRFX_PWM_PIN_NOT_USED))
-
-#define PWM_NRFX_OUTPUT_PIN(dev_idx, ch_idx)				      \
-	(PWM_NRFX_CH_PIN(dev_idx, ch_idx) |				      \
-	 (PWM_NRFX_IS_INVERTED(dev_idx, ch_idx) ? NRFX_PWM_PIN_INVERTED : 0))
-
-#define PWM_NRFX_COUNT_MODE(dev_idx)                                          \
-	(PWM_PROP(dev_idx, center_aligned) ?				      \
-	 NRF_PWM_MODE_UP_AND_DOWN : NRF_PWM_MODE_UP)
+#define PWM_OUTPUT_PIN(dev_idx, ch_idx)					\
+	COND_CODE_1(DT_NODE_HAS_PROP(PWM(dev_idx), ch##ch_idx##_pin),	\
+		(PWM_PROP(dev_idx, ch##ch_idx##_pin) |			\
+			(PWM_CH_INVERTED(dev_idx, ch_idx)		\
+			 ? NRFX_PWM_PIN_INVERTED : 0)),			\
+		(NRFX_PWM_PIN_NOT_USED))
 
 #define PWM_NRFX_DEVICE(idx)						      \
-	static struct pwm_nrfx_data pwm_nrfx_##idx##_data;		      \
+	NRF_DT_ENSURE_PINS_ASSIGNED(PWM(idx),				      \
+				    ch0_pin, ch1_pin, ch2_pin, ch3_pin);      \
+	static struct pwm_nrfx_data pwm_nrfx_##idx##_data = {		      \
+		COND_CODE_1(CONFIG_PINCTRL, (),				      \
+			(.inverted_channels =				      \
+				(PWM_CH_INVERTED(idx, 0) ? BIT(0) : 0) |      \
+				(PWM_CH_INVERTED(idx, 1) ? BIT(1) : 0) |      \
+				(PWM_CH_INVERTED(idx, 2) ? BIT(2) : 0) |      \
+				(PWM_CH_INVERTED(idx, 3) ? BIT(3) : 0),))     \
+	};								      \
+	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(PWM(idx))));	      \
 	static const struct pwm_nrfx_config pwm_nrfx_##idx##config = {	      \
 		.pwm = NRFX_PWM_INSTANCE(idx),				      \
 		.initial_config = {					      \
-			.output_pins = {				      \
-				PWM_NRFX_OUTPUT_PIN(idx, 0),		      \
-				PWM_NRFX_OUTPUT_PIN(idx, 1),		      \
-				PWM_NRFX_OUTPUT_PIN(idx, 2),		      \
-				PWM_NRFX_OUTPUT_PIN(idx, 3),		      \
-			},						      \
+			COND_CODE_1(CONFIG_PINCTRL,			      \
+				(.skip_gpio_cfg = true,			      \
+				 .skip_psel_cfg = true,),		      \
+				(.output_pins = {			      \
+					PWM_OUTPUT_PIN(idx, 0),		      \
+					PWM_OUTPUT_PIN(idx, 1),		      \
+					PWM_OUTPUT_PIN(idx, 2),		      \
+					PWM_OUTPUT_PIN(idx, 3),		      \
+				 },))					      \
 			.base_clock = NRF_PWM_CLK_1MHz,			      \
-			.count_mode = PWM_NRFX_COUNT_MODE(idx),		      \
+			.count_mode = (PWM_PROP(idx, center_aligned)	      \
+				       ? NRF_PWM_MODE_UP_AND_DOWN	      \
+				       : NRF_PWM_MODE_UP),		      \
 			.top_value = 1000,				      \
 			.load_mode = NRF_PWM_LOAD_INDIVIDUAL,		      \
 			.step_mode = NRF_PWM_STEP_TRIGGERED,		      \
 		},							      \
 		.seq.values.p_raw = pwm_nrfx_##idx##_data.current,	      \
-		.seq.length = NRF_PWM_CHANNEL_COUNT			      \
+		.seq.length = NRF_PWM_CHANNEL_COUNT,			      \
+		IF_ENABLED(CONFIG_PINCTRL,				      \
+			(.pcfg = PINCTRL_DT_DEV_CONFIG_GET(PWM(idx)),))	      \
 	};								      \
 	PM_DEVICE_DT_DEFINE(PWM(idx), pwm_nrfx_pm_action);		      \
 	DEVICE_DT_DEFINE(PWM(idx),					      \
-		      pwm_nrfx_init, PM_DEVICE_DT_GET(PWM(idx)),	      \
-		      &pwm_nrfx_##idx##_data,				      \
-		      &pwm_nrfx_##idx##config,				      \
-		      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	      \
-		      &pwm_nrfx_drv_api_funcs)
+			 pwm_nrfx_init, PM_DEVICE_DT_GET(PWM(idx)),	      \
+			 &pwm_nrfx_##idx##_data,			      \
+			 &pwm_nrfx_##idx##config,			      \
+			 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,     \
+			 &pwm_nrfx_drv_api_funcs)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pwm0), okay)
 PWM_NRFX_DEVICE(0);

--- a/drivers/sensor/qdec_nrfx/qdec_nrfx.c
+++ b/drivers/sensor/qdec_nrfx/qdec_nrfx.c
@@ -6,6 +6,8 @@
 
 #include <drivers/sensor.h>
 #include <pm/device.h>
+#include <drivers/pinctrl.h>
+#include <soc.h>
 
 #include <nrfx_qdec.h>
 #include <hal/nrf_gpio.h>
@@ -27,8 +29,13 @@ struct qdec_nrfx_data {
 	sensor_trigger_handler_t data_ready_handler;
 };
 
-
 static struct qdec_nrfx_data qdec_nrfx_data;
+
+#ifdef CONFIG_PINCTRL
+PINCTRL_DT_DEFINE(DT_DRV_INST(0));
+static const struct pinctrl_dev_config *qdec_nrfx_pcfg =
+	PINCTRL_DT_DEV_CONFIG_GET(DT_DRV_INST(0));
+#endif
 
 static void accumulate(struct qdec_nrfx_data *data, int16_t acc)
 {
@@ -166,23 +173,24 @@ static void qdec_nrfx_gpio_ctrl(bool enable)
 #endif
 }
 
+NRF_DT_ENSURE_PINS_ASSIGNED(DT_DRV_INST(0), a_pin);
+
 static int qdec_nrfx_init(const struct device *dev)
 {
 	static const nrfx_qdec_config_t config = {
-		.reportper          = NRF_QDEC_REPORTPER_40,
-		.sampleper          = NRF_QDEC_SAMPLEPER_2048us,
-		.psela              = DT_INST_PROP(0, a_pin),
-		.pselb              = DT_INST_PROP(0, b_pin),
-#if DT_INST_NODE_HAS_PROP(0, led_pin)
-		.pselled            = DT_INST_PROP(0, led_pin),
+		.reportper = NRF_QDEC_REPORTPER_40,
+		.sampleper = NRF_QDEC_SAMPLEPER_2048us,
+#ifdef CONFIG_PINCTRL
+		.skip_gpio_cfg = true,
+		.skip_psel_cfg = true,
 #else
-		.pselled            = 0xFFFFFFFF, /* disabled */
+		.psela   = DT_INST_PROP(0, a_pin),
+		.pselb   = DT_INST_PROP(0, b_pin),
+		.pselled = DT_INST_PROP_OR(0, led_pin,
+					   NRF_QDEC_LED_NOT_CONNECTED),
 #endif
-		.ledpre             = DT_INST_PROP(0, led_pre),
-		.ledpol             = NRF_QDEC_LEPOL_ACTIVE_HIGH,
-		.interrupt_priority = NRFX_QDEC_DEFAULT_CONFIG_IRQ_PRIORITY,
-		.dbfen              = 0, /* disabled */
-		.sample_inten       = 0, /* disabled */
+		.ledpre  = DT_INST_PROP(0, led_pre),
+		.ledpol  = NRF_QDEC_LEPOL_ACTIVE_HIGH,
 	};
 
 	nrfx_err_t nerr;
@@ -191,6 +199,14 @@ static int qdec_nrfx_init(const struct device *dev)
 
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
 		    nrfx_isr, nrfx_qdec_irq_handler, 0);
+
+#ifdef CONFIG_PINCTRL
+	int ret = pinctrl_apply_state(qdec_nrfx_pcfg, PINCTRL_STATE_DEFAULT);
+
+	if (ret < 0) {
+		return ret;
+	}
+#endif
 
 	nerr = nrfx_qdec_init(&config, qdec_nrfx_event_handler);
 	if (nerr == NRFX_ERROR_INVALID_STATE) {
@@ -211,27 +227,51 @@ static int qdec_nrfx_init(const struct device *dev)
 static int qdec_nrfx_pm_action(const struct device *dev,
 			       enum pm_device_action action)
 {
+	int ret = 0;
 	ARG_UNUSED(dev);
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(qdec_nrfx_pcfg,
+					  PINCTRL_STATE_DEFAULT);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		qdec_nrfx_gpio_ctrl(true);
 		nrfx_qdec_enable();
 		break;
+
 	case PM_DEVICE_ACTION_TURN_OFF:
 		/* device must be uninitialized */
 		nrfx_qdec_uninit();
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(qdec_nrfx_pcfg,
+					  PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		break;
+
 	case PM_DEVICE_ACTION_SUSPEND:
 		/* device must be suspended */
 		nrfx_qdec_disable();
 		qdec_nrfx_gpio_ctrl(false);
+#ifdef CONFIG_PINCTRL
+		ret = pinctrl_apply_state(qdec_nrfx_pcfg,
+					  PINCTRL_STATE_SLEEP);
+		if (ret < 0) {
+			return ret;
+		}
+#endif
 		break;
 	default:
 		return -ENOTSUP;
 	}
 
-	return 0;
+	return ret;
 }
 #endif /* CONFIG_PM_DEVICE */
 

--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -5,7 +5,7 @@ description: Nordic PDM (Pulse Density Modulation interface)
 
 compatible: "nordic,nrf-pdm"
 
-include: base.yaml
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
     reg:
@@ -16,13 +16,32 @@ properties:
 
     clk-pin:
       type: int
-      required: true
-      description: CLK pin
+      required: false
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The CLK pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for CLK, set:
+
+            clk-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for CLK, set:
+
+            clk-pin = <34>;  /* 32 + 2 */
 
     din-pin:
       type: int
-      required: true
-      description: DIN pin
+      required: false
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The DIN pin to use. The pin numbering scheme is the same as
+        the clk-pin property's.
 
     clock-source:
       type: string

--- a/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
@@ -21,7 +21,7 @@ description: |
 
 compatible: "nordic,nrf-qspi"
 
-include: flash-controller.yaml
+include: [flash-controller.yaml, pinctrl-device.yaml]
 
 bus: qspi
 
@@ -39,8 +39,11 @@ properties:
 
   sck-pin:
     type: int
-    required: true
+    required: false
     description: |
+      IMPORTANT: This option will only be used if the new pin control driver
+      is not enabled. It will be deprecated in the future.
+
       The SCK pin to use.
 
       For pins P0.0 through P0.31, use the pin number. For example,
@@ -54,8 +57,11 @@ properties:
           sck-pin = <34>;  /* 32 + 2 */
   io-pins:
     type: array
-    required: true
+    required: false
     description: |
+      IMPORTANT: This option will only be used if the new pin control driver
+      is not enabled. It will be deprecated in the future.
+
       Pin numbers associated with IO0 through IO3 signals.
 
       Examples:
@@ -69,8 +75,11 @@ properties:
       sck-pin property's.
   csn-pins:
     type: array
-    required: true
+    required: false
     description: |
+      IMPORTANT: This option will only be used if the new pin control driver
+      is not enabled. It will be deprecated in the future.
+
       Chip select signal pin number. Exactly one pin should be
       given. The pin numbering scheme is the same as the
       sck-pin property's.

--- a/dts/bindings/i2s/nordic,nrf-i2s.yaml
+++ b/dts/bindings/i2s/nordic,nrf-i2s.yaml
@@ -5,7 +5,7 @@ description: Nordic I2S (Inter-IC sound interface)
 
 compatible: "nordic,nrf-i2s"
 
-include: i2s-controller.yaml
+include: [i2s-controller.yaml, pinctrl-device.yaml]
 
 properties:
     reg:
@@ -16,28 +16,62 @@ properties:
 
     sck-pin:
       type: int
-      required: true
-      description: SCK pin
+      required: false
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The SCK pin to use.
+
+        For pins P0.0 through P0.31, use the pin number. For example,
+        to use P0.16 for SCK, set:
+
+            sck-pin = <16>;
+
+        For pins P1.0 through P1.31, add 32 to the pin number. For
+        example, to use P1.2 for SCK, set:
+
+            sck-pin = <34>;  /* 32 + 2 */
 
     lrck-pin:
       type: int
-      required: true
-      description: LRCK pin
+      required: false
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The LRCK pin to use. The pin numbering scheme is the same as
+        the sck-pin property's.
 
     sdout-pin:
       type: int
       required: false
-      description: SDOUT pin
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The SDOUT pin to use. The pin numbering scheme is the same as
+        the sck-pin property's.
 
     sdin-pin:
       type: int
       required: false
-      description: SDIN pin
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The SDIN pin to use. The pin numbering scheme is the same as
+        the sck-pin property's.
 
     mck-pin:
       type: int
       required: false
-      description: MCK pin
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
+        The MCK pin to use. The pin numbering scheme is the same as
+        the sck-pin property's.
 
     clock-source:
       type: string

--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -108,3 +108,9 @@ child-binding:
           nrf-pinctrl.h. Note that extra modes may not be available on certain
           devices. Defaults to standard mode for 0 and 1 (NRF_DRIVE_S0S1), the
           SoC default.
+
+      nordic,invert:
+        type: boolean
+        description: |
+          Invert pin polarity (set the active state to low).
+          Only valid for PWM channel output pins.

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -2,7 +2,7 @@ description: nRF PWM
 
 compatible: "nordic,nrf-pwm"
 
-include: [pwm-controller.yaml, base.yaml]
+include: [pwm-controller.yaml, base.yaml, pinctrl-device.yaml]
 
 properties:
     reg:
@@ -17,6 +17,9 @@ properties:
       type: int
       required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The channel 0 pin to use.
 
         For pins P0.0 through P0.31, use the pin number. For example,
@@ -32,43 +35,76 @@ properties:
     ch0-inverted:
       type: boolean
       required: false
-      description: Set this to invert channel 0.
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+        When the pin control driver is enabled, use the "nordic,invert" property
+        in the corresponding pin configuration group instead.
+
+        Set this to invert channel 0.
 
     ch1-pin:
       type: int
       required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The channel 1 pin to use. The pin numbering scheme is the same
         as the ch0-pin property's.
 
     ch1-inverted:
       type: boolean
       required: false
-      description: Set this to invert channel 1.
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+        When the pin control driver is enabled, use the "nordic,invert" property
+        in the corresponding pin configuration group instead.
+
+        Set this to invert channel 1.
 
     ch2-pin:
       type: int
       required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The channel 2 pin to use. The pin numbering scheme is the same
         as the ch0-pin property's.
 
     ch2-inverted:
       type: boolean
       required: false
-      description: Set this to invert channel 2.
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+        When the pin control driver is enabled, use the "nordic,invert" property
+        in the corresponding pin configuration group instead.
+
+        Set this to invert channel 2.
 
     ch3-pin:
       type: int
       required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The channel 3 pin to use. The pin numbering scheme is the same
         as the ch0-pin property's.
 
     ch3-inverted:
       type: boolean
       required: false
-      description: Set this to invert channel 3.
+      description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+        When the pin control driver is enabled, use the "nordic,invert" property
+        in the corresponding pin configuration group instead.
+
+        Set this to invert channel 3.
 
     "#pwm-cells":
       const: 1

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -5,7 +5,7 @@ description: Nordic nRF quadrature decoder (QDEC) node
 
 compatible: "nordic,nrf-qdec"
 
-include: base.yaml
+include: [base.yaml, pinctrl-device.yaml]
 
 properties:
     reg:
@@ -18,6 +18,9 @@ properties:
       type: int
       required: true
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The A pin to use.
 
         For pins P0.0 through P0.31, use the pin number. For example,
@@ -34,6 +37,9 @@ properties:
       type: int
       required: true
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The B pin to use. The pin numbering scheme is the same as
         the a-pin property's.
 
@@ -41,6 +47,9 @@ properties:
       type: int
       required: false
       description: |
+        IMPORTANT: This option will only be used if the new pin control driver
+        is not enabled. It will be deprecated in the future.
+
         The LED pin to use for a light based QDEC device. The pin
         numbering scheme is the same as the a-pin property's.
 

--- a/include/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -77,6 +77,24 @@
 #define NRF_FUN_TWIM_SCL 11U
 /** TWI master SDA */
 #define NRF_FUN_TWIM_SDA 12U
+/** I2S SCK in master mode */
+#define NRF_FUN_I2S_SCK_M 13U
+/** I2S SCK in slave mode */
+#define NRF_FUN_I2S_SCK_S 14U
+/** I2S LRCK in master mode */
+#define NRF_FUN_I2S_LRCK_M 15U
+/** I2S LRCK in slave mode */
+#define NRF_FUN_I2S_LRCK_S 16U
+/** I2S SDIN */
+#define NRF_FUN_I2S_SDIN 17U
+/** I2S SDOUT */
+#define NRF_FUN_I2S_SDOUT 18U
+/** I2S MCK */
+#define NRF_FUN_I2S_MCK 19U
+/** PDM CLK */
+#define NRF_FUN_PDM_CLK 20U
+/** PDM DIN */
+#define NRF_FUN_PDM_DIN 21U
 
 /** @} */
 

--- a/include/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -11,7 +11,8 @@
  * organized as follows:
  *
  * - 31..16: Pin function.
- * - 15..13: Reserved.
+ * - 15..14: Reserved.
+ * - 13:     Pin inversion mode.
  * - 12:     Pin low power mode.
  * - 11..8:  Pin output drive configuration.
  * - 7..6:   Pin pull configuration.
@@ -27,6 +28,10 @@
 #define NRF_FUN_POS 16U
 /** Mask for the function field. */
 #define NRF_FUN_MSK 0xFFFFU
+/** Position of the invert field. */
+#define NRF_INVERT_POS 13U
+/** Mask for the invert field. */
+#define NRF_INVERT_MSK 0x1U
 /** Position of the low power field. */
 #define NRF_LP_POS 12U
 /** Mask for the low power field. */
@@ -95,6 +100,32 @@
 #define NRF_FUN_PDM_CLK 20U
 /** PDM DIN */
 #define NRF_FUN_PDM_DIN 21U
+/** PWM OUT0 */
+#define NRF_FUN_PWM_OUT0 22U
+/** PWM OUT1 */
+#define NRF_FUN_PWM_OUT1 23U
+/** PWM OUT2 */
+#define NRF_FUN_PWM_OUT2 24U
+/** PWM OUT3 */
+#define NRF_FUN_PWM_OUT3 25U
+/** QDEC A */
+#define NRF_FUN_QDEC_A 26U
+/** QDEC B */
+#define NRF_FUN_QDEC_B 27U
+/** QDEC LED */
+#define NRF_FUN_QDEC_LED 28U
+/** QSPI SCK */
+#define NRF_FUN_QSPI_SCK 29U
+/** QSPI CSN */
+#define NRF_FUN_QSPI_CSN 30U
+/** QSPI IO0 */
+#define NRF_FUN_QSPI_IO0 31U
+/** QSPI IO1 */
+#define NRF_FUN_QSPI_IO1 32U
+/** QSPI IO2 */
+#define NRF_FUN_QSPI_IO2 33U
+/** QSPI IO3 */
+#define NRF_FUN_QSPI_IO3 34U
 
 /** @} */
 

--- a/soc/arm/nordic_nrf/common/pinctrl_soc.h
+++ b/soc/arm/nordic_nrf/common/pinctrl_soc.h
@@ -37,7 +37,8 @@ typedef uint32_t pinctrl_soc_pin_t;
 	 ((NRF_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << NRF_PULL_POS) |\
 	 ((NRF_PULL_UP * DT_PROP(node_id, bias_pull_up)) << NRF_PULL_POS) |    \
 	 (DT_PROP(node_id, drive_mode) << NRF_DRIVE_POS) |		       \
-	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS)  \
+	 ((NRF_LP_ENABLE * DT_PROP(node_id, low_power_enable)) << NRF_LP_POS) |\
+	 (DT_PROP(node_id, nordic_invert) << NRF_INVERT_POS)		       \
 	),
 
 /**
@@ -57,6 +58,13 @@ typedef uint32_t pinctrl_soc_pin_t;
  * @param pincfg Pin configuration bit field.
  */
 #define NRF_GET_FUN(pincfg) (((pincfg) >> NRF_FUN_POS) & NRF_FUN_MSK)
+
+/**
+ * @brief Utility macro to obtain pin inversion flag.
+ *
+ * @param pincfg Pin configuration bit field.
+ */
+#define NRF_GET_INVERT(pincfg) (((pincfg) >> NRF_INVERT_POS) & NRF_INVERT_MSK)
 
 /**
  * @brief Utility macro to obtain pin low power flag.


### PR DESCRIPTION
Add support for the pinctrl API to the drivers that handle the following nRF peripherals:
- I2S
- PDM
- PWM
- QDEC
- QSPI