### PR TITLE
dts: arm: st: f1: remove AFIOEN bit from IO clocks

### DIFF
--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -113,7 +113,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40010800 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000005>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000004>;
 				label = "GPIOA";
 			};
 
@@ -122,7 +122,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40010c00 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000009>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000008>;
 				label = "GPIOB";
 			};
 
@@ -131,7 +131,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000011>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000010>;
 				label = "GPIOC";
 			};
 
@@ -140,7 +140,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011400 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000021>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000020>;
 				label = "GPIOD";
 			};
 
@@ -149,7 +149,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011800 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000041>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000040>;
 				label = "GPIOE";
 			};
 		};

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -100,7 +100,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40011c00 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000081>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000080>;
 				label = "GPIOF";
 			};
 
@@ -109,7 +109,7 @@
 				gpio-controller;
 				#gpio-cells = <2>;
 				reg = <0x40012000 0x400>;
-				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000101>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000100>;
 				label = "GPIOG";
 			};
 		};


### PR DESCRIPTION
Don't set AFIOEN when enabling IO port clock.
The bit is set upon requirement within pinctrl
or pinmux

Signed-off-by: Georgij Cernysiov <geo.cgv@gmail.com>