### PR TITLE
stm32wl55 configures the PLL with MSI as source

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 300109f80730cb2477bfcc706a6602b9870336b3
+      revision: ab42f7015e16500db4a51ba562eee36460b7473e
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Change the MSI range configuration when the PLL has MSI as source  for stm32wl soc
This is due to an erroneous pll freq calculation in the LL_PLL_ConfigSystemClock_MSI function from stm32Cube driver

Requires hal_stm32 PR https://github.com/zephyrproject-rtos/hal_stm32/pull/133

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/43316

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)