### PR TITLE
arch: x86: use DEVICE_DT_GET_ONE

### DIFF
--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -34,19 +34,7 @@ const void *x86_irq_args[NR_IRQ_VECTORS];
 #include <device.h>
 #include <drivers/interrupt_controller/intel_vtd.h>
 
-static const struct device *vtd;
-
-static bool get_vtd(void)
-{
-	if (vtd != NULL) {
-		return true;
-	}
-#define DT_DRV_COMPAT intel_vt_d
-	vtd = device_get_binding(DT_INST_LABEL(0));
-#undef DT_DRV_COMPAT
-
-	return vtd == NULL ? false : true;
-}
+static const struct device *vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 
 #endif /* CONFIG_INTEL_VTD_ICTL */
 
@@ -131,7 +119,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 	vector = z_x86_allocate_vector(priority, -1);
 	if (vector >= 0) {
 #if defined(CONFIG_INTEL_VTD_ICTL)
-		if (get_vtd()) {
+		if (device_is_ready(vtd)) {
 			int irte = vtd_allocate_entries(vtd, 1);
 
 			__ASSERT(irte >= 0, "IRTE allocation must succeed");

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -164,19 +164,7 @@ void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
 #include <drivers/interrupt_controller/intel_vtd.h>
 #include <arch/x86/acpi.h>
 
-static const struct device *vtd;
-
-static bool get_vtd(void)
-{
-	if (vtd != NULL) {
-		return true;
-	}
-#define DT_DRV_COMPAT intel_vt_d
-	vtd = device_get_binding(DT_INST_LABEL(0));
-#undef DT_DRV_COMPAT
-
-	return vtd == NULL ? false : true;
-}
+static const struct device *vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 
 #endif /* CONFIG_INTEL_VTD_ICTL */
 
@@ -244,7 +232,7 @@ uint8_t arch_pcie_msi_vectors_allocate(unsigned int priority,
 	{
 		int irte;
 
-		if (!get_vtd()) {
+		if (!device_is_ready(vtd)) {
 			return 0;
 		}
 
@@ -306,7 +294,7 @@ bool arch_pcie_msi_vector_connect(msi_vector_t *vector,
 	if (vector->arch.remap) {
 		union acpi_dmar_id id;
 
-		if (!get_vtd()) {
+		if (!device_is_ready(vtd)) {
 			return false;
 		}
 


### PR DESCRIPTION
Improve code by using DEVICE_DT_GET_ONE instead of device_get_binding,
since the intel_vt_d device instance can be obtained at compile time.