### PR TITLE
doc: reference: canbus: use DEVICE_DT_GET for the samples

### DIFF
--- a/doc/reference/canbus/controller.rst
+++ b/doc/reference/canbus/controller.rst
@@ -158,10 +158,8 @@ a mailbox. When a transmitting mailbox is assigned, sending cannot be canceled.
           .dlc = 8,
           .data = {1,2,3,4,5,6,7,8}
   };
-  const struct device *can_dev;
+  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
   int ret;
-
-  can_dev = device_get_binding("CAN_0");
 
   ret = can_send(can_dev, &frame, K_MSEC(100), NULL, NULL);
   if (ret != 0) {
@@ -236,9 +234,7 @@ The filter for this example is configured to match the identifier 0x123 exactly.
           .id_mask = CAN_STD_ID_MASK
   };
   int filter_id;
-  const struct device *can_dev;
-
-  can_dev = device_get_binding("CAN_0");
+  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
   filter_id = can_add_rx_filter(can_dev, rx_callback_function, callback_arg, &my_filter);
   if (filter_id < 0) {
@@ -265,9 +261,7 @@ The filter for this example is configured to match the extended identifier
   CAN_MSGQ_DEFINE(my_can_msgq, 2);
   struct zcan_frame rx_frame;
   int filter_id;
-  const struct device *can_dev;
-
-  can_dev = device_get_binding("CAN_0");
+  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
   filter_id = can_add_rx_filter_msgq(can_dev, &my_can_msgq, &my_filter);
   if (filter_id < 0) {
@@ -302,10 +296,8 @@ The following example sets the bitrate to 250k baud with the sampling point at
 .. code-block:: C
 
   struct can_timing timing;
-  const struct device *can_dev;
+  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
   int ret;
-
-  can_dev = device_get_binding("CAN_0");
 
   ret = can_calc_timing(can_dev, &timing, 250000, 875);
   if (ret > 0) {


### PR DESCRIPTION
Use DEVICE_DT_GET instead of device_get_binding on the samples. Also,
use the zephyr,canbus chosen device. Note that check for readiness has
not been added as previous code did not check for NULL either.