### PR TITLE
scripts: gen_kobject_list: linker section for _thread_idx_map

### DIFF
--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -466,7 +466,7 @@ def analyze_die_array(die):
 def analyze_typedef(die):
     type_offset = die_get_type_offset(die)
 
-    if type_offset not in type_env.keys():
+    if type_offset not in type_env:
         return
 
     type_env[die.offset] = type_env[type_offset]

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -868,6 +868,7 @@ def write_gperf_table(fp, syms, objs, little_endian, static_begin, static_end):
 
     # Generate the array of already mapped thread indexes
     fp.write('\n')
+    fp.write('Z_GENERIC_DOT_SECTION(data)\n')
     fp.write('uint8_t _thread_idx_map[%d] = {' % (thread_max_bytes))
 
     for i in range(0, thread_max_bytes):


### PR DESCRIPTION
In some circumstances, _thread_idx_map[] is all zero and the linker
decides to put it into BSS instead of DATA section. This results in
kernel objects being pushed away so the hash table is no longer
valid. This forces _thread_idx_map to be in the data section inside
the intermediate object file so it will be placed in the data
section in final binary.

Fixes #43618

Signed-off-by: Daniel Leung <daniel.leung@intel.com>