### PR TITLE
samples: hello_world: headers cleanup

### DIFF
--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr.h>
-#include <sys/printk.h>
 
 void main(void)
 {


### PR DESCRIPTION
<zephyr.h> ends up pulling <sys/printk.h> via <kernel_includes.h>, so
simplify the sample.

Note: this change assumes `<zephyr.h>` is a "catch-all" header for applications.