### PR TITLE
tests: mbedtls: Fix GCC warning about `test_snprintf`

### DIFF
--- a/tests/crypto/mbedtls/src/mbedtls.c
+++ b/tests/crypto/mbedtls/src/mbedtls.c
@@ -71,7 +71,7 @@
 #include "mbedtls/memory_buffer_alloc.h"
 #endif
 
-static int test_snprintf(size_t n, const char ref_buf[10], int ref_ret)
+static int test_snprintf(size_t n, const char *ref_buf, int ref_ret)
 {
 	int ret;
 	char buf[10] = "xxxxxxxxx";


### PR DESCRIPTION
Fix errors like:

inlined from ‘test_mbedtls’ at
zephyrproject/zephyr/tests/crypto/mbedtls/src/mbedtls.c:172:6:
zephyrproject/zephyr/tests/crypto/mbedtls/src/mbedtls.c:96:17: error:
‘test_snprintf’ reading 10 bytes from a region of size 1
[-Werror=stringop-overread]
   96 |                 test_snprintf(1, "", -1) != 0 ||
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~

In GCC >= 11 because `ret_buf` in some calls are shorter literals

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>