### PR TITLE
Bluetooth: Controller: Fix auxiliary context leak on stop

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -503,6 +503,8 @@ uint8_t ull_scan_disable(uint8_t handle, struct ll_scan_set *scan)
 			if (err && (err != -EALREADY)) {
 				return BT_HCI_ERR_CMD_DISALLOWED;
 			}
+
+			LL_ASSERT(!aux->parent);
 		}
 	}
 #endif /* CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -929,10 +929,10 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 				hdr->disabled_param = aux;
 				hdr->disabled_cb = done_disabled_cb;
 			}
-		} else {
-			/* Sync terminate requested, enqueue node rx that will
-			 * be flushed by the disabled_cb setup by the
-			 * terminate.
+
+		} else if (!scan) {
+			/* Sync terminate requested, enqueue node rx so that it
+			 * be flushed by ull_scan_aux_stop().
 			 */
 			rx->link = link;
 			if (aux->rx_last) {

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -969,7 +969,7 @@ int ull_scan_aux_stop(struct ll_scan_aux_set *aux)
 	/* Abort LLL event if ULL scheduling not used or already in prepare */
 	if (err == -EALREADY) {
 		err = ull_disable(&aux->lll);
-		if (err) {
+		if (err && (err != -EALREADY)) {
 			return err;
 		}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -365,6 +365,8 @@ uint8_t ll_sync_terminate(uint16_t handle)
 		if (err) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
 		}
+
+		LL_ASSERT(!aux->parent);
 	}
 
 	link_sync_lost = sync->node_rx_lost.hdr.link;


### PR DESCRIPTION
Fix auxiliary context leak on stop, under race condition
where ULL High execution context does not release the
auxiliary context as stop has been requested, and done
has decremented the auxiliary context's reference count.

Do not enqueue NODE_RX_TYPE_RELEASE into Auxiliary context
when stopping scanner, as this type is not to be passed to
HCI processing, which would lead to assertion.

Fix auxiliary context from being flushed when scanner or
periodic synchronization is stopped, to avoid using the
disable_cb by both. Fixes an assertion when this race
condition happens.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>