### PR TITLE
maintainers: Add random subsystem

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1876,3 +1876,13 @@ ZTest:
         - tests/unit/util/
     labels:
         - "area: Testsuite"
+
+Random:
+    status: orphaned
+    collaborators:
+         - ceolin
+    files:
+        - subsys/random/
+        - include/random/
+    labels:
+        - "area: Random"


### PR DESCRIPTION
The random subsystem was not included in the maintainers file. Just add
a new entry for it and add myself (Flavio) as collaborator.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>