### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 13.3

### DIFF
--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -188,6 +188,6 @@ FUNC_NORETURN void z_x86_cpu_init(struct x86_cpuboot *cpuboot)
 #endif
 
 	/* Enter kernel, never return */
-	cpuboot->ready++;
+	cpuboot->ready += 1;
 	cpuboot->fn(cpuboot->arg);
 }

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -59,7 +59,9 @@ int z_x86_allocate_vector(unsigned int priority, int prev_vector)
 		vector = (int)uvector;
 	}
 
-	for (unsigned int i = 0; i < VECTORS_PER_PRIORITY; ++i, ++vector) {
+	const int end_vector = vector + (int) VECTORS_PER_PRIORITY;
+
+	for (; vector < end_vector; ++vector) {
 		if (prev_vector != 1 && vector == prev_vector) {
 			continue;
 		}

--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -46,14 +46,18 @@ static void prdec(struct _pfr *r, long v)
 	char digs[11U * sizeof(long) / 4];
 	size_t i = sizeof(digs) - 1;
 
-	digs[i--] = '\0';
+	digs[i] = '\0';
+	--i;
 	while ((v != 0) || (i == 9)) {
-		digs[i--] = '0' + (v % 10);
+		digs[i] = '0' + (v % 10);
+		--i;
 		v /= 10;
 	}
 
-	while (digs[++i] != '\0') {
+	++i;
+	while (digs[i] != '\0') {
 		pc(r, digs[i]);
+		++i;
 	}
 }
 
@@ -102,8 +106,10 @@ static size_t vpf(struct _pfr *r, const char *f, va_list ap)
 		case 's': {
 			char *s = va_arg(ap, char *);
 
-			while (*s != '\0')
-				pc(r, *s++);
+			while (*s != '\0') {
+				pc(r, *s);
+				++s;
+			}
 			break;
 		}
 		case 'p':

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -33,7 +33,8 @@ static void efi_putchar(int c)
 		efi_putchar((int)'\r');
 	}
 
-	efibuf[n++] = (uint16_t)c;
+	efibuf[n] = (uint16_t)c;
+	++n;
 
 	if (c == (int)'\n' || n == PUTCHAR_BUFSZ) {
 		efibuf[n] = 0U;
@@ -120,7 +121,7 @@ uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 	 * to drain before we start banging on the same UART from the
 	 * OS.
 	 */
-	for (volatile int i = 0; i < 50000000; i++) {
+	for (volatile int i = 0; i < 50000000; i += 1) {
 	}
 
 	__asm__ volatile("cli; jmp *%0" :: "r"(code));

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -273,7 +273,8 @@ do { \
 	} \
 	size_t _arg_size = Z_CBPRINTF_ARG_SIZE(_arg); \
 	if (Z_CBPRINTF_IS_PCHAR(_arg) != 0) { \
-		(_s_buf)[(_s_idx)++] = (uint16_t)((_idx) / sizeof(int)); \
+		(_s_buf)[(_s_idx)] = (uint16_t)((_idx) / sizeof(int)); \
+		++(_s_idx); \
 	} \
 	if ((_buf) != NULL && (_idx) < (_max)) { \
 		Z_CBPRINTF_STORE_ARG(&(_buf)[(_idx)], _arg); \

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -215,7 +215,7 @@ extern size_t z_free_page_count;
 #define Z_PAGE_FRAME_FOREACH(_phys, _pageframe) \
 	for ((_phys) = Z_PHYS_RAM_START, (_pageframe) = z_page_frames; \
 	     (_phys) < Z_PHYS_RAM_END; \
-	     (_phys) += CONFIG_MMU_PAGE_SIZE, (_pageframe)++)
+	     (_phys) += CONFIG_MMU_PAGE_SIZE, (_pageframe) += 1)
 
 #ifdef CONFIG_DEMAND_PAGING
 /* We reserve a virtual page as a scratch area for page-ins/outs at the end

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -33,7 +33,7 @@ static void *z_heap_aligned_alloc(struct k_heap *heap, size_t align, size_t size
 
 	heap_ref = mem;
 	*heap_ref = heap;
-	mem = ++heap_ref;
+	mem = heap_ref + 1;
 	__ASSERT(align == 0 || ((uintptr_t)mem & (align - 1)) == 0,
 		 "misaligned memory at %p (align = %zu)", mem, align);
 
@@ -46,7 +46,8 @@ void k_free(void *ptr)
 
 	if (ptr != NULL) {
 		heap_ref = ptr;
-		ptr = --heap_ref;
+		--heap_ref;
+		ptr = heap_ref;
 
 		SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_heap_sys, k_free, *heap_ref);
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -993,7 +993,8 @@ void z_priq_rb_add(struct _priq_rb *pq, struct k_thread *thread)
 
 	__ASSERT_NO_MSG(!z_is_idle_thread_object(thread));
 
-	thread->base.order_key = pq->next_order_key++;
+	thread->base.order_key = pq->next_order_key;
+	++pq->next_order_key;
 
 	/* Renumber at wraparound.  This is tiny code, and in practice
 	 * will almost never be hit on real systems.  BUT on very
@@ -1003,7 +1004,8 @@ void z_priq_rb_add(struct _priq_rb *pq, struct k_thread *thread)
 	 */
 	if (pq->next_order_key == 0) {
 		RB_FOR_EACH_CONTAINER(&pq->tree, t, base.qnode_rb) {
-			t->base.order_key = pq->next_order_key++;
+			t->base.order_key = pq->next_order_key;
+			++pq->next_order_key;
 		}
 	}
 

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -517,7 +517,8 @@ static inline const char *extract_specifier(struct conversion *conv,
 {
 	bool unsupported = false;
 
-	conv->specifier = *sp++;
+	conv->specifier = *sp;
+	++sp;
 
 	switch (conv->specifier) {
 	case SINT_CONV_CASES:
@@ -654,7 +655,8 @@ static inline const char *extract_conversion(struct conversion *conv,
 	 */
 	++sp;
 	if (*sp == '%') {
-		conv->specifier = *sp++;
+		conv->specifier = *sp;
+		++sp;
 		return sp;
 	}
 
@@ -799,7 +801,8 @@ static char *encode_uint(uint_value_type value,
 	do {
 		unsigned int lsv = (unsigned int)(value % radix);
 
-		*--bp = (lsv <= 9) ? ('0' + lsv)
+		--bp;
+		*bp = (lsv <= 9) ? ('0' + lsv)
 			: upcase ? ('A' + (lsv - 10)) : ('a' + (lsv - 10));
 		value /= radix;
 	} while ((value != 0) && (bps < bp));
@@ -909,23 +912,27 @@ static char *encode_float(double value,
 	if (expo == (int)BIT_MASK(EXPONENT_BITS)) {
 		if (fract == 0) {
 			if (isupper((int)(unsigned char)c)) {
-				*buf++ = 'I';
-				*buf++ = 'N';
-				*buf++ = 'F';
+				buf[0] = 'I';
+				buf[1] = 'N';
+				buf[2] = 'F';
+				buf += 3;
 			} else {
-				*buf++ = 'i';
-				*buf++ = 'n';
-				*buf++ = 'f';
+				buf[0] = 'i';
+				buf[1] = 'n';
+				buf[2] = 'f';
+				buf += 3;
 			}
 		} else {
 			if (isupper((int)(unsigned char)c)) {
-				*buf++ = 'N';
-				*buf++ = 'A';
-				*buf++ = 'N';
+				buf[0] = 'N';
+				buf[1] = 'A';
+				buf[2] = 'N';
+				buf += 3;
 			} else {
-				*buf++ = 'n';
-				*buf++ = 'a';
-				*buf++ = 'n';
+				buf[0] = 'n';
+				buf[1] = 'a';
+				buf[2] = 'n';
+				buf += 3;
 			}
 		}
 
@@ -945,8 +952,9 @@ static char *encode_float(double value,
 	if ((IS_ENABLED(CONFIG_CBPRINTF_FP_A_SUPPORT))
 	    && ((IS_ENABLED(CONFIG_CBPRINTF_FP_ALWAYS_A))
 		|| conv->specifier_a)) {
-		*buf++ = '0';
-		*buf++ = 'x';
+		buf[0] = '0';
+		buf[1] = 'x';
+		buf += 2;
 
 		/* Remove the offset from the exponent, and store the
 		 * non-fractional value.  Subnormals require increasing the
@@ -954,10 +962,12 @@ static char *encode_float(double value,
 		 */
 		expo -= 1023;
 		if (is_subnormal) {
-			*buf++ = '0';
+			*buf = '0';
+			++buf;
 			++expo;
 		} else {
-			*buf++ = '1';
+			*buf = '1';
+			++buf;
 		}
 
 		/* If we didn't get precision from a %a specification then we
@@ -993,7 +1003,8 @@ static char *encode_float(double value,
 		bool require_dp = ((fract != 0) || conv->flag_hash);
 
 		if (require_dp || (precision != 0)) {
-			*buf++ = '.';
+			*buf = '.';
+			++buf;
 		}
 
 		/* Get the fractional value as a hexadecimal string, using x
@@ -1013,12 +1024,15 @@ static char *encode_float(double value,
 		 * point.
 		 */
 		while ((spe - sp) < FRACTION_HEX) {
-			*--sp = '0';
+			--sp;
+			*sp = '0';
 		}
 
 		/* Append the leading sigificant "digits". */
 		while ((sp < spe) && (precision > 0)) {
-			*buf++ = *sp++;
+			*buf = *sp;
+			++buf;
+			++sp;
 			--precision;
 		}
 
@@ -1031,11 +1045,14 @@ static char *encode_float(double value,
 			}
 		}
 
-		*buf++ = 'p';
+		*buf = 'p';
+		++buf;
 		if (expo >= 0) {
-			*buf++ = '+';
+			*buf = '+';
+			++buf;
 		} else {
-			*buf++ = '-';
+			*buf = '-';
+			++buf;
 			expo = -expo;
 		}
 
@@ -1043,7 +1060,9 @@ static char *encode_float(double value,
 		sp = encode_uint((unsigned int)expo, &aconv, buf, spe);
 
 		while (sp < spe) {
-			*buf++ = *sp++;
+			*buf = *sp;
+			++buf;
+			++sp;
 		}
 
 		*bpe = buf;
@@ -1177,7 +1196,8 @@ static char *encode_float(double value,
 		if (decexp > 0) {
 			/* Emit the digits above the decimal point. */
 			while (decexp > 0 && digit_count > 0) {
-				*buf++ = _get_digit(&fract, &digit_count);
+				*buf = _get_digit(&fract, &digit_count);
+				++buf;
 				decexp--;
 			}
 
@@ -1185,14 +1205,16 @@ static char *encode_float(double value,
 
 			decexp = 0;
 		} else {
-			*buf++ = '0';
+			*buf = '0';
+			++buf;
 		}
 
 		/* Emit the decimal point only if required by the alternative
 		 * format, or if more digits are to follow.
 		 */
 		if (conv->flag_hash || (precision > 0)) {
-			*buf++ = '.';
+			*buf = '.';
+			++buf;
 		}
 
 		if (decexp < 0 && precision > 0) {
@@ -1217,12 +1239,14 @@ static char *encode_float(double value,
 		 * format, or if more digits are to follow.
 		 */
 		if (conv->flag_hash || (precision > 0)) {
-			*buf++ = '.';
+			*buf = '.';
+			++buf;
 		}
 	}
 
 	while (precision > 0 && digit_count > 0) {
-		*buf++ = _get_digit(&fract, &digit_count);
+		*buf = _get_digit(&fract, &digit_count);
+		++buf;
 		precision--;
 	}
 
@@ -1230,32 +1254,37 @@ static char *encode_float(double value,
 
 	if (prune_zero) {
 		conv->pad0_pre_exp = 0;
-		while (*--buf == '0') {
-			;
-		}
+		do {
+			--buf;
+		} while (*buf == '0');
 		if (*buf != '.') {
-			buf++;
+			++buf;
 		}
 	}
 
 	/* Emit the explicit exponent, if format requires it. */
 	if ((c == 'e') || (c == 'E')) {
-		*buf++ = c;
+		*buf = c;
+		++buf;
 		if (decexp < 0) {
 			decexp = -decexp;
-			*buf++ = '-';
+			*buf = '-';
+			++buf;
 		} else {
-			*buf++ = '+';
+			*buf = '+';
+			++buf;
 		}
 
 		/* At most 3 digits to the decimal.  Spit them out. */
 		if (decexp >= 100) {
-			*buf++ = (decexp / 100) + '0';
+			*buf = (decexp / 100) + '0';
+			++buf;
 			decexp %= 100;
 		}
 
-		*buf++ = (decexp / 10) + '0';
-		*buf++ = (decexp % 10) + '0';
+		buf[0] = (decexp / 10) + '0';
+		buf[1] = (decexp % 10) + '0';
+		buf += 2;
 	}
 
 	/* Cache whether there's padding required */
@@ -1327,7 +1356,8 @@ static int outs(cbprintf_cb out,
 	int count = 0;
 
 	while ((sp < ep) || ((ep == NULL) && (*sp != '\0'))) {
-		int rc = out((int)*sp++, ctx);
+		int rc = out((int)*sp, ctx);
+		++sp;
 
 		if (rc < 0) {
 			return rc;
@@ -1373,7 +1403,8 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 
 	while (*fp != '\0') {
 		if (*fp != '%') {
-			OUTC(*fp++);
+			OUTC(*fp);
+			++fp;
 			continue;
 		}
 
@@ -1767,11 +1798,13 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 			if (conv->specifier_a) {
 				/* Only padding is pre_exp */
 				while (*cp != 'p') {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 				}
 			} else {
 				while (isdigit((int)(unsigned char)*cp)) {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 				}
 
 				pad_len = conv->pad0_value;
@@ -1782,7 +1815,8 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 				}
 
 				if (*cp == '.') {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 					/* Remaining padding is
 					 * post-dp.
 					 */
@@ -1791,7 +1825,8 @@ int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
 					}
 				}
 				while (isdigit((int)(unsigned char)*cp)) {
-					OUTC(*cp++);
+					OUTC(*cp);
+					++cp;
 				}
 			}
 

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -257,7 +257,8 @@ int cbvprintf_package(void *packaged, size_t len, uint32_t flags,
 	 * reason for the post-decrement on fmt as it will be incremented
 	 * prior to the next (actually first) round of that loop.
 	 */
-	s = fmt--;
+	s = fmt;
+	--fmt;
 	align = VA_STACK_ALIGN(char *);
 	size = sizeof(char *);
 	goto process_string;
@@ -442,8 +443,9 @@ process_string:
 				}
 
 				/* Use same multiple as the arg list size. */
-				str_ptr_pos[s_idx++] = ro_flag |
+				str_ptr_pos[s_idx] = ro_flag |
 					(uint8_t)((size_t)(buf - buf0) / sizeof(int));
+				++s_idx;
 			} else {
 				if (!is_ro) {
 					/*
@@ -533,7 +535,8 @@ process_string:
 				return -ENOSPC;
 			}
 			/* store the pointer position prefix */
-			*buf++ = pos;
+			*buf = pos;
+			++buf;
 		}
 	}
 
@@ -555,7 +558,8 @@ process_string:
 			return -ENOSPC;
 		}
 		/* store the pointer position prefix */
-		*buf++ = str_ptr_pos[i];
+		*buf = str_ptr_pos[i];
+		++buf;
 		/* copy the string with its terminating '\0' */
 		memcpy(buf, s, size);
 		buf += size;
@@ -607,7 +611,8 @@ int cbpprintf(cbprintf_cb out, void *ctx, void *packaged)
 	 */
 	for (uint8_t i = 0; i < s_nbr; i++) {
 		/* Locate pointer location for this string */
-		s_idx = *(uint8_t *)s++;
+		s_idx = *(uint8_t *)s;
+		++s;
 		ps = (char **)(buf + s_idx * sizeof(int));
 		/* update the pointer with current string location */
 		*ps = s;
@@ -679,7 +684,8 @@ int cbprintf_fsc_package(void *in_packaged,
 			if (out_len > len) {
 				return -ENOSPC;
 			}
-			*out++ = s_idx;
+			*out = s_idx;
+			++out;
 			memcpy(out, *ps, slen);
 			out += slen;
 		}

--- a/lib/os/crc16_sw.c
+++ b/lib/os/crc16_sw.c
@@ -40,7 +40,8 @@ uint16_t crc16_ccitt(uint16_t seed, const uint8_t *src, size_t len)
 	for (; len > 0; len--) {
 		uint8_t e, f;
 
-		e = (uint8_t)(seed ^ *src++);
+		e = (uint8_t)(seed ^ *src);
+		++src;
 		f = e ^ (e << 4);
 		seed = (seed >> 8) ^ ((uint16_t)f << 8) ^ ((uint16_t)f << 3) ^ ((uint16_t)f >> 4);
 	}
@@ -52,7 +53,8 @@ uint16_t crc16_itu_t(uint16_t seed, const uint8_t *src, size_t len)
 {
 	for (; len > 0; len--) {
 		seed = (seed >> 8U) | (seed << 8U);
-		seed ^= *src++;
+		seed ^= *src;
+		++src;
 		seed ^= (seed & 0xffU) >> 4U;
 		seed ^= seed << 12U;
 		seed ^= (seed & 0xffU) << 5U;

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -94,12 +94,12 @@ bool sys_heap_validate(struct sys_heap *heap)
 
 		check_nexts(h, b);
 
-		for (c = c0; c != 0 && (n == 0 || c != c0);
-		     n++, c = next_free_chunk(h, c)) {
+		for (c = c0; c != 0 && (n == 0 || c != c0); n++) {
 			if (!valid_chunk(h, c)) {
 				return false;
 			}
 			set_chunk_used(h, c, true);
+			c = next_free_chunk(h, c);
 		}
 
 		bool empty = (h->avail_buckets & ((uint32_t)1 << b)) == 0;
@@ -148,11 +148,12 @@ bool sys_heap_validate(struct sys_heap *heap)
 			continue;
 		}
 
-		for (c = c0; n == 0 || c != c0; n++, c = next_free_chunk(h, c)) {
+		for (c = c0; n == 0 || c != c0; n++) {
 			if (chunk_used(h, c)) {
 				return false;
 			}
 			set_chunk_used(h, c, true);
+			c = next_free_chunk(h, c);
 		}
 	}
 

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -97,7 +97,8 @@ static int buf_char_out(int c, void *ctx_p)
 	struct buf_out_context *ctx = ctx_p;
 
 	ctx->count++;
-	ctx->buf[ctx->buf_count++] = (char)c;
+	ctx->buf[ctx->buf_count] = (char)c;
+	++ctx->buf_count;
 	if (ctx->buf_count == CONFIG_PRINTK_BUFFER_SIZE) {
 		buf_flush(ctx);
 	}
@@ -232,15 +233,16 @@ struct str_context {
 static int str_out(int c, struct str_context *ctx)
 {
 	if (ctx->str == NULL || ctx->count >= ctx->max) {
-		ctx->count++;
+		++ctx->count;
 		return c;
 	}
 
 	if (ctx->count == ctx->max - 1) {
-		ctx->str[ctx->count++] = '\0';
+		ctx->str[ctx->count] = '\0';
 	} else {
-		ctx->str[ctx->count++] = (char)c;
+		ctx->str[ctx->count] = (char)c;
 	}
+	++ctx->count;
 
 	return c;
 }

--- a/lib/os/rb.c
+++ b/lib/os/rb.c
@@ -81,14 +81,16 @@ static unsigned int find_and_stack(struct rbtree *tree, struct rbnode *node,
 {
 	unsigned int sz = 0;
 
-	stack[sz++] = tree->root;
+	stack[sz] = tree->root;
+	++sz;
 
 	while (stack[sz - 1] != node) {
 		uint8_t side = tree->lessthan_fn(node, stack[sz - 1]) ? 0U : 1U;
 		struct rbnode *ch = get_child(stack[sz - 1], side);
 
 		if (ch != NULL) {
-			stack[sz++] = ch;
+			stack[sz] = ch;
+			++sz;
 		} else {
 			break;
 		}
@@ -242,7 +244,8 @@ void rb_insert(struct rbtree *tree, struct rbnode *node)
 	set_child(parent, side, node);
 	set_color(node, RED);
 
-	stack[stacksz++] = node;
+	stack[stacksz] = node;
+	++stacksz;
 	fix_extra_red(stack, stacksz);
 
 	if (stacksz > tree->max_depth) {
@@ -288,7 +291,8 @@ static void fix_missing_black(struct rbnode **stack, unsigned int stacksz,
 			rotate(stack, stacksz);
 			set_color(parent, RED);
 			set_color(sib, BLACK);
-			stack[stacksz++] = n;
+			stack[stacksz] = n;
+			++stacksz;
 
 			parent = stack[stacksz - 2];
 			sib = get_child(parent, (n_side == 0U) ? 1U : 0U);
@@ -334,7 +338,8 @@ static void fix_missing_black(struct rbnode **stack, unsigned int stacksz,
 			inner = get_child(sib, n_side);
 
 			stack[stacksz - 1] = sib;
-			stack[stacksz++] = inner;
+			stack[stacksz] = inner;
+			++stacksz;
 			rotate(stack, stacksz);
 			set_color(sib, RED);
 			set_color(inner, BLACK);
@@ -391,10 +396,12 @@ void rb_remove(struct rbtree *tree, struct rbnode *node)
 		struct rbnode *node2 = get_child(node, 0U);
 
 		hiparent = (stacksz > 1) ? stack[stacksz - 2] : NULL;
-		stack[stacksz++] = node2;
+		stack[stacksz] = node2;
+		++stacksz;
 		while (get_child(node2, 1U) != NULL) {
 			node2 = get_child(node2, 1U);
-			stack[stacksz++] = node2;
+			stack[stacksz] = node2;
+			++stacksz;
 		}
 
 		loparent = stack[stacksz - 2];


### PR DESCRIPTION
In particular:

- avoided ++/-- on volatile

- avoided to have more than one ++/-- in for third clause

- moved ++/-- before or after the value use

- avoided pointless ++/--

- replaced consecutive ++ with a single +=

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>