### PR TITLE
soc: arm: nxp_lpc: fix typos

### DIFF
--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -165,7 +165,7 @@ int _slave_init(const struct device *arg)
 	 * and then detects its identity (Cortex-M0, slave) and checks
 	 * registers CPBOOT and CPSTACK and use them to continue the
 	 * boot process.
-	 * Make sure the startup code for current core (Cortex-M4) is
+	 * Make sure the startup code for the current core (Cortex-M4) is
 	 * appropriate and shareable with the Cortex-M0 core!
 	 */
 	SYSCON->CPBOOT = SYSCON_CPBOOT_BOOTADDR(

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -142,7 +142,7 @@ static ALWAYS_INLINE void clock_init(void)
 	/* Put PHY powerdown under software control */
 	*((uint32_t *)(USBHSH_BASE + 0x50)) = USBHSH_PORTMODE_SW_PDCOM_MASK;
 	/*
-	 * According to reference mannual, device mode setting has to be set by
+	 * According to reference manual, device mode setting has to be set by
 	 * access usb host register
 	 */
 	*((uint32_t *)(USBHSH_BASE + 0x50)) |= USBHSH_PORTMODE_DEV_ENABLE_MASK;
@@ -248,7 +248,7 @@ int _second_core_init(const struct device *arg)
 	 * The second core first boots from flash (address 0x00000000)
 	 * and then detects its identity (Core no. 1, second) and checks
 	 * registers CPBOOT and use them to continue the boot process.
-	 * Make sure the startup code for first core is
+	 * Make sure the startup code for the first core is
 	 * appropriate and shareable with the second core!
 	 */
 	SYSCON->CPUCFG |= SYSCON_CPUCFG_CPU1ENABLE_MASK;


### PR DESCRIPTION
Typos were found with codespell utility.

Signed-off-by: Yegor Yefremov <yegorslists@googlemail.com>