### PR TITLE
coding guidelines: partially comply with MISRA C:2012 Rule 7.4

### DIFF
--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -149,9 +149,10 @@ extern "C" {
 #ifdef __cplusplus
 #define Z_CBPRINTF_ARG_SIZE(v) z_cbprintf_cxx_arg_size(v)
 #else
+#define Z_CONSTIFY(v) (_Generic((v), char * : (const char *)(uintptr_t)(v), default : (v)))
 #define Z_PROMOTE(v) ((__typeof__((v) + 0))(v))
 #define Z_CBPRINTF_ARG_SIZE(v) ({\
-	__auto_type _v = Z_PROMOTE(v); \
+	__auto_type _v = Z_PROMOTE(Z_CONSTIFY(v)); \
 	size_t _arg_size = _Generic((v), \
 		float : sizeof(double), \
 		default : \
@@ -171,7 +172,7 @@ extern "C" {
 #define Z_CBPRINTF_STORE_ARG(buf, arg) z_cbprintf_cxx_store_arg(buf, arg)
 #else
 #define Z_CBPRINTF_STORE_ARG(buf, arg) do { \
-	__auto_type _v = Z_PROMOTE(arg); \
+	__auto_type _v = Z_PROMOTE(Z_CONSTIFY(arg)); \
 	if (Z_CBPRINTF_VA_STACK_LL_DBL_MEMCPY) { \
 		/* If required, copy arguments by word to avoid unaligned access.*/ \
 		double _d = _Generic(_v, \


### PR DESCRIPTION
In particual:

- avoided to assign string literals to non-const char *

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>