### PR TITLE
Fix echo

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cborattr/src/cborattr.c
+++ b/subsys/mgmt/mcumgr/lib/cborattr/src/cborattr.c
@@ -291,7 +291,7 @@ cbor_internal_read_object(CborValue *root_value,
 				err |= CborErrorIllegalType;
 			}
 		}
-		err = cbor_value_advance(&cur_value);
+		err |= cbor_value_advance(&cur_value);
 	}
 	if (!err) {
 		/* that should be it for this container */

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -46,7 +46,7 @@ os_mgmt_echo(struct mgmt_ctxt *ctxt)
 
 	err = cbor_read_object(&ctxt->it, attrs);
 	if (err != 0) {
-		return MGMT_ERR_EINVAL;
+		return mgmt_err_from_cbor(err);
 	}
 
 	echo_buf[sizeof(echo_buf) - 1] = '\0';


### PR DESCRIPTION
The PR consists of two patches:
 - 1) to cborattr where err code of cbor parsing loop could get reset to 0, causing the loop to continue even if it has failed to process some data;
 - 2) to OS group echo command callback that has been returning cbor error value instead of expected MGMT error value.

Fixes #43382

```
$$ sudo ~/go/bin/mcumgr -t 1200 --loglevel=debug --conntype ble --connstring ctlr_name=hci0,peer_name='Zephyr' echo 01234567890
DEBU[2022-03-10 14:07:04.513] Using connection profile: name=unnamed type=ble connstring=ctlr_name=hci0,peer_name=Zephyr
DEBU[2022-03-10 14:07:05.005] Connecting to peer
DEBU[2022-03-10 14:07:05.623] Exchanging MTU
DEBU[2022-03-10 14:07:05.645] Exchanged MTU; ATT MTU = 252
DEBU[2022-03-10 14:07:05.645] Discovering profile
DEBU[2022-03-10 14:07:05.779] Subscribing to NMP response characteristic
DEBU[2022-03-10 14:07:05.794] {add-nmp-listener} [bll_sesn.go:392] seq=66
DEBU[2022-03-10 14:07:05.794] Encoded &{NmpBase:{hdr:{Op:2 Flags:0 Len:0 Group:0 Seq:66 Id:0}} Payload:01234567890} to:
00000000  a1 61 64 6b 30 31 32 33  34 35 36 37 38 39 30     |.adk01234567890|
DEBU[2022-03-10 14:07:05.794] Encoded:
00000000  02 00 00 0f 00 00 42 00  a1 61 64 6b 30 31 32 33  |......B..adk0123|
00000010  34 35 36 37 38 39 30                              |4567890|
DEBU[2022-03-10 14:07:05.794] Tx NMP request: 00000000  02 00 00 0f 00 00 42 00  a1 61 64 6b 30 31 32 33  |......B..adk0123|
00000010  34 35 36 37 38 39 30                              |4567890|
DEBU[2022-03-10 14:07:05.809] rx nmp response: 00000000  03 00 00 06 00 00 42 00  bf 62 72 63 02 ff        |......B..brc..|
DEBU[2022-03-10 14:07:05.809] Received nmp rsp: &{NmpBase:{hdr:{Op:3 Flags:0 Len:6 Group:0 Seq:66 Id:0}} Payload: Rc:2}
DEBU[2022-03-10 14:07:05.809] {remove-nmp-listener} [bll_sesn.go:392] seq=66
```
It is seen that now `rc=2`, which is `MGMT_ERR_ENOMEM`.