### PR TITLE
Bluetooth: GATT: Add function to get UUIDs for adv data

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1828,6 +1828,39 @@ int bt_gatt_unsubscribe(struct bt_conn *conn,
  */
 void bt_gatt_cancel(struct bt_conn *conn, void *params);
 
+/** @brief Encode GATT UUID of current services into a bt_data struct.
+ *
+ * The data will include both primary and secondary service UUIDs.
+ * Mandatory services such as the GATT and GAP services will not be included.
+ *
+ * @param[in] type
+ * Type of the UUIDs. Shall be one of following:
+ *  - BT_DATA_UUID16_SOME:  Encode 16-bit UUIDs until @p data_buf is full.
+ *  - BT_DATA_UUID16_ALL:   Encode all 16-bit UUIDs, and return error if they
+ *                          do not fit in @p data_buf.
+ *  - BT_DATA_UUID32_SOME:  Encode 32-bit UUIDs until @p data_buf is full.
+ *  - BT_DATA_UUID32_ALL:   Encode all 32-bit UUIDs, and return error if they
+ *                          do not fit in @p data_buf.
+ *  - BT_DATA_UUID128_SOME: Encode 128-bit UUIDs until @p data_buf is full.
+ *  - BT_DATA_UUID128_ALL:  Encode all 128-bit UUIDs, and return error if they
+ *                          do not fit in @p data_buf.
+ * @param[out] data           Pointer to the bt_data struct to store the
+ *                            results in.
+ * @param[out] data_buf       Pointer to the buffer where the encoded UUID data
+ *                            is stored.
+ * @param[in] data_buf_size   Size of the @p data_buf
+ *
+ * @retval 0 on success.
+ *
+ * @retval -EINVAL if any of the parameters are invalid (e.g. NULL or 0).
+ *         In this case @p data_buf and @p data will be invalid.
+ *
+ * @retval -ENOMEM if a _ALL type is used and @p data_buf does not fit all the
+ *         data. In this case @p data_buf and @p data will be invalid.
+ */
+int bt_gatt_get_svc_uuid_data(uint8_t type, struct bt_data *data,
+			      uint8_t data_buf[], size_t data_buf_size);
+
 /** @} */
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1833,8 +1833,10 @@ void bt_gatt_cancel(struct bt_conn *conn, void *params);
  * The data will include both primary and secondary service UUIDs.
  * Mandatory services such as the GATT and GAP services will not be included.
  *
- * @param[in] type
- * Type of the UUIDs. Shall be one of following:
+ * @param data
+ * Pointer to the bt_data struct to store the results in.
+ * Must be initialized with a @p data and and a @p type.
+ * The type shall be one of following:
  *  - BT_DATA_UUID16_SOME:  Encode 16-bit UUIDs until @p data_buf is full.
  *  - BT_DATA_UUID16_ALL:   Encode all 16-bit UUIDs, and return error if they
  *                          do not fit in @p data_buf.
@@ -1844,11 +1846,7 @@ void bt_gatt_cancel(struct bt_conn *conn, void *params);
  *  - BT_DATA_UUID128_SOME: Encode 128-bit UUIDs until @p data_buf is full.
  *  - BT_DATA_UUID128_ALL:  Encode all 128-bit UUIDs, and return error if they
  *                          do not fit in @p data_buf.
- * @param[out] data           Pointer to the bt_data struct to store the
- *                            results in.
- * @param[out] data_buf       Pointer to the buffer where the encoded UUID data
- *                            is stored.
- * @param[in] data_buf_size   Size of the @p data_buf
+ * @param data_buf_size   Size of the @p data.data buffer
  *
  * @retval 0 on success.
  *
@@ -1858,8 +1856,7 @@ void bt_gatt_cancel(struct bt_conn *conn, void *params);
  * @retval -ENOMEM if a _ALL type is used and @p data_buf does not fit all the
  *         data. In this case @p data_buf and @p data will be invalid.
  */
-int bt_gatt_get_svc_uuid_data(uint8_t type, struct bt_data *data,
-			      uint8_t data_buf[], size_t data_buf_size);
+int bt_gatt_get_svc_uuid_data(struct bt_data *data, size_t data_buf_size);
 
 /** @} */
 

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -393,6 +393,17 @@ enum {
 /** @typedef bt_gatt_attr_func_t
  *  @brief Attribute iterator callback.
  *
+ * To be able to read the user_data of the @p attr the user_data
+ * must be cast to an appropriate type.
+ *   - @ref bt_uuid when UUID is @ref BT_UUID_GATT_PRIMARY or
+ *     @ref BT_UUID_GATT_SECONDARY.
+ *   - @ref bt_gatt_attr when UUID is @ref BT_UUID_GATT_INCLUDE.
+ *   - @ref bt_gatt_chrc when UUID is @ref BT_UUID_GATT_CHRC.
+ *   - _bt_gatt_ccc when UUID is @ref BT_UUID_GATT_CCC.
+ *   - @ref bt_gatt_cep when UUID is @ref BT_UUID_GATT_CEP.
+ *   - char * when UUID is @ref BT_UUID_GATT_CUD
+ *   - @ref bt_gatt_cpf when UUID is @ref BT_UUID_GATT_CPF
+ *
  *  @param attr Attribute found.
  *  @param handle Attribute handle found.
  *  @param user_data Data given.

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -484,6 +484,7 @@ void main(void)
 {
 	static uint8_t uuid16_buf[5 * BT_UUID_SIZE_16];
 	struct bt_le_ext_adv *adv;
+	struct bt_data *uuid_data;
 	int err;
 
 	err = bt_enable(NULL);
@@ -495,13 +496,16 @@ void main(void)
 	printk("Bluetooth initialized\n");
 
 	/* Update UUID16 advertising data */
-	err = bt_gatt_get_svc_uuid_data(BT_DATA_UUID16_ALL, &ad[2],
-					uuid16_buf, sizeof(uuid16_buf));
+	uuid_data = &ad[2];
+	uuid_data->type = BT_DATA_UUID16_ALL;
+	uuid_data->data = uuid16_buf;
+
+	err = bt_gatt_get_svc_uuid_data(uuid_data, sizeof(uuid16_buf));
 	if (err != 0) {
 		printk("Could not encode all UUID16 data: %d\n", err);
 
-		err = bt_gatt_get_svc_uuid_data(BT_DATA_UUID16_SOME, &ad[2],
-						uuid16_buf, sizeof(uuid16_buf));
+		uuid_data->type = BT_DATA_UUID16_SOME;
+		err = bt_gatt_get_svc_uuid_data(uuid_data, sizeof(uuid16_buf));
 		if (err != 0) {
 			printk("Could not encode UUID16 data: %d\n", err);
 			return;


### PR DESCRIPTION
Add a function that can help an application get get a
partial or complete list of UUIDs for advertisement purposes.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/33777