### PR TITLE
net: openthread: fix check for unsuccessful wipe

### DIFF
--- a/subsys/net/lib/openthread/platform/settings.c
+++ b/subsys/net/lib/openthread/platform/settings.c
@@ -60,6 +60,7 @@ static int ot_setting_delete_cb(const char *key, size_t len,
 	if (ret != 0) {
 		LOG_ERR("Failed to remove setting %s, ret %d", log_strdup(path),
 			ret);
+		__ASSERT_NO_MSG(false);
 	}
 
 	ctx->status = 0;
@@ -98,6 +99,7 @@ static int ot_setting_delete_subtree(int key, int index)
 	if (ret != 0) {
 		LOG_ERR("Failed to delete OT subtree %s, index %d, ret %d",
 			subtree, index, ret);
+		__ASSERT_NO_MSG(false);
 	}
 
 	return delete_ctx.status;
@@ -306,15 +308,9 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 
 void otPlatSettingsWipe(otInstance *aInstance)
 {
-	int ret;
-
 	ARG_UNUSED(aInstance);
 
-	ret = ot_setting_delete_subtree(-1, -1);
-	if (ret != 0) {
-		LOG_ERR("Failed to delete OT subtree");
-		__ASSERT_NO_MSG(false);
-	}
+	(void)ot_setting_delete_subtree(-1, -1);
 }
 
 void otPlatSettingsDeinit(otInstance *aInstance)


### PR DESCRIPTION
ot_setting_delete_subtree returns the information if the subtree
had been found in the persistent storage or not before removing.
This has matter for otPlatSettingsGet. In other uses cases
the return value shoud be ignored.
The right place for the check if deletion succeded is in
settings_load_subtree_direct and its callback.
Currently "ot factoryreset" causes an assert if there is no
OpenThread dataset stored in the persistent memory.
This PR fixes it.

Signed-off-by: Lukasz Maciejonczyk <lukasz.maciejonczyk@nordicsemi.no>