### PR TITLE
drivers: clock_control: nrf: Fix missing dependency to mt

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -68,6 +68,7 @@ if CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
 config CLOCK_CONTROL_NRF_DRIVER_CALIBRATION
 	bool
 	depends on !CLOCK_CONTROL_NRF_FORCE_ALT
+	depends on MULTITHREADING
 	default y
 	help
 	  Enabling indicates that calibration is perfomed by the clock control driver.


### PR DESCRIPTION
The temperature sensor used in the clock_control driver requires
multithreading, but this is not compatible with mcuboot builds with
multithreading disabled.

Fixes #41597.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>