### PR TITLE
mgmt/mcumgr/lib: Fix LOG_MODULE_NAME for image group

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -217,6 +217,10 @@ config IMG_MGMT_FRUGAL_LIST
 	  a device but requires support in client software, which has to default omitted values.
 	  Works correctly with mcumgr-cli.
 
+module = MCUMGR_IMG_MGMT
+module-str = mcumgr_img_mgmt
+source "subsys/logging/Kconfig.template.log_config"
+
 endif
 
 

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -4,10 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define LOG_MODULE_NAME mcumgr_flash_mgmt
-#define LOG_LEVEL CONFIG_IMG_MANAGER_LOG_LEVEL
 #include <logging/log.h>
-LOG_MODULE_REGISTER(LOG_MODULE_NAME);
+LOG_MODULE_REGISTER(mcumgr_img_mgmt, CONFIG_MCUMGR_IMG_MGMT_LOG_LEVEL);
 
 #include <assert.h>
 #include <drivers/flash.h>


### PR DESCRIPTION
Two commits:
1) fixes log information string;
2) adds missing Kconfig options to actually control the logging for the module.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>