### PR TITLE
MAINTAINER file terminology change: remove orphaned usage

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -69,7 +69,7 @@ jobs:
         # debug
         ls -la
         git log  --pretty=oneline | head -n 10
-        ./scripts/ci/check_compliance.py -m Codeowners -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}..
+        ./scripts/ci/check_compliance.py -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@master
@@ -84,7 +84,7 @@ jobs:
           exit 1;
         fi
 
-        for file in Nits.txt checkpatch.txt Identity.txt Gitlint.txt pylint.txt Devicetree.txt Kconfig.txt Codeowners.txt; do
+        for file in Nits.txt checkpatch.txt Identity.txt Gitlint.txt pylint.txt Devicetree.txt Kconfig.txt; do
           if [[ -s $file ]]; then
             errors=$(cat $file)
             errors="${errors//'%'/'%25'}"

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -13,9 +13,8 @@
 #             The area has a Maintainer (approved by the TSC) who
 #             looks after the area.
 #
-#         * orphaned:
-#             No current maintainer (but maybe you could take the role as you
-#             write your new code).
+#         * odd fixes:
+#            The ares gets odd fixes and has collaborators.
 #
 #         * obsolete:
 #             Old code. Something being marked obsolete generally means it has
@@ -299,7 +298,7 @@ C library:
          - "area: C Library"
 
 CMSIS API layer:
-    status: orphaned
+    status: odd fixes
     collaborators:
          - nashif
     files:
@@ -323,8 +322,8 @@ CMSIS-DSP integration:
     labels:
         - "area: CMSIS-DSP"
 
-Common arch:
-    status: orphaned
+Common Architecture Interface:
+    status: odd fixes
     collaborators:
         - dcpleung
         - nashif
@@ -417,7 +416,7 @@ Disk:
         - "area: Disk Access"
 
 Display drivers:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - jfischer-no
         - gmarull
@@ -525,7 +524,7 @@ Documentation:
         - "area: Clock control"
 
 "Drivers: Console":
-    status: orphaned
+    status: odd fixes
     collaborators:
         - pfalcon
     files:
@@ -704,7 +703,7 @@ Documentation:
         - "area: IEEE 802.15.4"
 
 "Drivers: Interrupt controllers":
-    status: orphaned
+    status: odd fixes
     files:
         - drivers/interrupt_controller/
         - dts/bindings/interrupt-controller/
@@ -789,7 +788,7 @@ Documentation:
         - "area: Modem"
 
 "Drivers: Neural Networks":
-    status: orphaned
+    status: odd fixes
     collaborators:
         - nashif
     files:
@@ -940,8 +939,8 @@ Documentation:
     labels:
         - "area: Timer"
 
-"Drivers: video":
-    status: orphaned
+"Drivers: Video":
+    status: odd fixes
     collaborators:
         - loicpoulain
     files:
@@ -952,7 +951,7 @@ Documentation:
         - "area: Video"
 
 "Drivers: Watchdog":
-    status: orphaned
+    status: odd fixes
     collaborators:
         - katsuster
         - martinjaeger
@@ -979,7 +978,7 @@ Documentation:
         - "area: Wifi"
 
 "Drivers: WiFi es-WiFi":
-    status: orphaned
+    status: odd fixes
     collaborators:
         - loicpoulain
     files:
@@ -1034,7 +1033,7 @@ IPC:
         - "area: IPC"
 
 JSON Web Token:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - mrfuchs
         - sir-branch
@@ -1046,7 +1045,7 @@ JSON Web Token:
         - "area: JSON"
 
 Kconfig:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - tejlmand
         - nashif
@@ -1097,7 +1096,7 @@ Base OS:
         - "area: Base OS"
 
 Little FS:
-    status: orphaned
+    status: odd fixes
     files:
         - subsys/fs/Kconfig.littlefs
         - subsys/fs/littlefs_fs.c
@@ -1161,7 +1160,7 @@ MCU Manager:
         - "area: mcumgr"
 
 OSDP:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - sidcha
     files:
@@ -1172,7 +1171,7 @@ OSDP:
         - "area: OSDP"
 
 hawkBit:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - ycsin
     files:
@@ -1333,7 +1332,7 @@ nRF52 BSIM:
         - "platform: nrf52_bsim"
 
 POSIX API layer:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - pfalcon
         - enjiamai
@@ -1440,7 +1439,7 @@ Shields:
         - "area: Shields"
 
 SPARC arch:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - martin-aberg
     files:
@@ -1527,7 +1526,7 @@ Nuvoton_NPCX Platforms:
         - "platform: Nuvoton_NPCX"
 
 Nuvoton_Numicro Platforms:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - ssekar15
     files:
@@ -1540,7 +1539,7 @@ Nuvoton_Numicro Platforms:
         - "platform: Nuvoton_Numicro"
 
 SiLabs Platforms:
-    status: orphaned
+    status: odd fixes
     collaborators:
         - chrta
     files:
@@ -1877,7 +1876,7 @@ x86 arch:
     labels:
         - "area: X86"
 
-CI:
+Continuous Integration:
     status: maintained
     maintainers:
         - nashif
@@ -1905,7 +1904,7 @@ ZTest:
         - "area: Testsuite"
 
 Random:
-    status: orphaned
+    status: odd fixes
     collaborators:
          - ceolin
     files:

--- a/scripts/get_maintainer.py
+++ b/scripts/get_maintainer.py
@@ -140,9 +140,9 @@ def _parse_args():
         help="Count the number of unique maintainers")
     count_parser.add_argument(
         "-o",
-        "--count-orphaned",
+        "--count-unmaintained",
         action="store_true",
-        help="Count the number of orphaned areas")
+        help="Count the number of unmaintained areas")
     count_parser.set_defaults(cmd_fn=Maintainers._count_cmd)
 
     args = parser.parse_args()
@@ -289,22 +289,22 @@ class Maintainers:
     def _count_cmd(self, args):
         # 'count' subcommand implementation
 
-        if not (args.count_areas or args.count_collaborators or args.count_maintainers or args.count_orphaned):
+        if not (args.count_areas or args.count_collaborators or args.count_maintainers or args.count_unmaintained):
             # if no specific count is provided, print them all
             args.count_areas = True
             args.count_collaborators = True
             args.count_maintainers = True
-            args.count_orphaned = True
+            args.count_unmaintained = True
 
-        orphaned = 0
+        unmaintained = 0
         collaborators = set()
         maintainers = set()
 
         for area in self.areas.values():
             if area.status == 'maintained':
                 maintainers = maintainers.union(set(area.maintainers))
-            elif area.status == 'orphaned':
-                orphaned += 1
+            elif area.status == 'odd fixes':
+                unmaintained += 1
             collaborators = collaborators.union(set(area.collaborators))
 
         if args.count_areas:
@@ -313,8 +313,8 @@ class Maintainers:
             print('{:14}\t{}'.format('maintainers:', len(maintainers)))
         if args.count_collaborators:
             print('{:14}\t{}'.format('collaborators:', len(collaborators)))
-        if args.count_orphaned:
-            print('{:14}\t{}'.format('orphaned:', orphaned))
+        if args.count_unmaintained:
+            print('{:14}\t{}'.format('unmaintained:', unmaintained))
 
     def _list_cmd(self, args):
         # 'list' subcommand implementation
@@ -481,7 +481,7 @@ def _check_maintainers(maints_path, yaml):
                "files-exclude", "files-regex", "files-regex-exclude",
                "labels", "description"}
 
-    ok_status = {"maintained", "odd fixes", "orphaned", "obsolete"}
+    ok_status = {"maintained", "odd fixes", "unmaintained", "obsolete"}
     ok_status_s = ", ".join('"' + s + '"' for s in ok_status)  # For messages
 
     for area_name, area_dict in yaml.items():

--- a/scripts/schemas/twister/platform-schema.yaml
+++ b/scripts/schemas/twister/platform-schema.yaml
@@ -13,6 +13,10 @@ type: map
 mapping:
   "identifier":
     type: str
+  "maintainers":
+    type: seq
+    seq:
+      - type: str
   "name":
     type: str
   "type":


### PR DESCRIPTION
- ci: compliance: skip codeowner checks
- boards: add maintainer to the platform yaml file
- MAINTAINERS: do not use orphaned terminology
