### PR TITLE
Bluetooth: Mesh: Add warning about RPL persistence

### DIFF
--- a/doc/reference/bluetooth/mesh/core.rst
+++ b/doc/reference/bluetooth/mesh/core.rst
@@ -52,6 +52,14 @@ Finding the right balance between @ref CONFIG_BT_MESH_RPL_STORE_TIMEOUT and
 calling @ref bt_mesh_rpl_pending_store may reduce a risk of security
 volnurability and flash wear out.
 
+.. warning:
+
+   Failing to enable :kconfig:option:`CONFIG_BT_SETTINGS`, or setting
+   :kconfig:option:`CONFIG_BT_MESH_RPL_STORE_TIMEOUT` to -1 and not storing
+   the RPL between reboots, will make the device vulnerable to replay attacks
+   and not perform the replay protection required by the spec.
+
+
 API reference
 **************
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -833,6 +833,9 @@ config BT_MESH_RPL_STORE_TIMEOUT
 	  stored by @ref BT_MESH_STORE_TIMEOUT. Finding the right balance
 	  between this timeout and calling @ref bt_mesh_rpl_pending_store
 	  may reduce a risk of security vulnerability and flash wear out.
+	  Failure to store the RPL and becoming vulnerable after reboot
+	  will cause the device to not perform the replay protection
+	  required by the spec.
 
 endif # BT_SETTINGS
 


### PR DESCRIPTION
With BT_SETTINGS disabled, or when using an indefinite
RPL_STORE_TIMEOUT and not storing the RPL, the device will not be able
to follow the replay protection required by the spec. This adds a
warning about this.

Signed-off-by: Ludvig Samuelsen Jordet <ludvig.jordet@nordicsemi.no>