### PR TITLE
drivers: eth: stellaris: Fix build error

### DIFF
--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -293,7 +293,7 @@ static struct net_stats_eth *eth_stellaris_stats(const struct device *dev)
 {
 	struct eth_stellaris_runtime *dev_data = dev->data;
 
-	return &data->stats;
+	return &dev_data->stats;
 }
 #endif
 


### PR DESCRIPTION
Use the correct variable name in eth_stellaris, which fixes
the build error.

Signed-off-by: MohanKumar Kumar <mohankm@fb.com>