### PR TITLE
MAINTAINAERS: introduce formatted output and fix path matching for BT

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -192,6 +192,9 @@ Bluetooth:
         - subsys/bluetooth/audio/
         - include/bluetooth/audio/
         - tests/bluetooth/bsim_bt/bsim_test_audio/
+        - tests/bluetooth/controller/
+        - tests/bluetooth/mesh_*/
+        - tests/bluetooth/mesh/
     labels:
         - "area: Bluetooth"
 
@@ -209,6 +212,7 @@ Bluetooth controller:
         - erbr-ot
     files:
         - subsys/bluetooth/controller/
+        - tests/bluetooth/controller/
     labels:
         - "area: Bluetooth Controller"
         - "area: Bluetooth"
@@ -999,6 +1003,19 @@ Filesystems:
     labels:
         - "area: File System"
 
+Formatted Output:
+    status: maintained
+    maintainers:
+      - nordic-krch
+    files:
+      - include/sys/cbprintf*
+      - tests/unit/cbprintf/
+      - tests/lib/cbprintf_*/
+      - lib/os/cbprintf*
+      - lib/os/Kconfig.cbprintf
+    labels:
+      - "area: Formatting Output"
+
 IPC:
     status: maintained
     maintainers:
@@ -1067,6 +1084,12 @@ Base OS:
     files:
         - include/sys/
         - lib/os/
+    files-exclude:
+      - include/sys/cbprintf*
+      - tests/unit/cbprintf/
+      - tests/lib/cbprintf_*/
+      - lib/os/cbprintf*
+      - lib/os/Kconfig.cbprintf
     labels:
         - "area: Base OS"
 


### PR DESCRIPTION
Introduce formatted ouptut area and fix BT controller paths for tests.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
