### PR TITLE
nxp: imx: rename IMX_CCM_UART_CLK

### DIFF
--- a/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
@@ -80,7 +80,7 @@
 		interrupts = <GIC_SPI 27 IRQ_TYPE_LEVEL 0>;
 		interrupt-names = "irq_0";
 		interrupt-parent = <&gic>;
-		clocks = <&ccm IMX_CCM_UART_CLK 0x6c 24>;
+		clocks = <&ccm IMX_CCM_UART2_CLK 0x6c 24>;
 		label = "UART_2";
 		status = "disabled";
 	};
@@ -91,7 +91,7 @@
 		interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL 0>;
 		interrupt-names = "irq_0";
 		interrupt-parent = <&gic>;
-		clocks = <&ccm IMX_CCM_UART_CLK 0x6c 24>;
+		clocks = <&ccm IMX_CCM_UART4_CLK 0x6c 24>;
 		label = "UART_4";
 		status = "disabled";
 	};


### PR DESCRIPTION
rename IMX_CCM_UART_CLK to IMX_CCM_UART4_CLK and
IMX_CCM_UART2_CLK a53 dtsi.

This was missed in a previsous patch set.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
