### PR TITLE
ITE: drviers/adc: Adjust the wait time for acquiring a semaphore

### DIFF
--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -246,11 +246,8 @@ static void adc_enable_measurement(uint32_t ch)
 	} else {
 		/* Enable adc interrupt */
 		irq_enable(DT_INST_IRQN(0));
-		/* Wait for an interrupt to read data valid. */
-		if (k_sem_take(&data->sem, K_MSEC(1))) {
-			LOG_ERR("ADC interrupt is not fired.");
-			return;
-		}
+		/* Wait for an interrupt to read valid data. */
+		k_sem_take(&data->sem, K_FOREVER);
 	}
 }
 


### PR DESCRIPTION
After the ADC interrupt is enabled, the interrupt will be triggered
and the ADC channel valid data will be read, so there is no time
limit here.
Refer to the timeout is also set to K_FOREVER in the function of
adc_context_wait_for_completion().

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>