### PR TITLE
posix: Fix pthread_once incorrect behavior

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -334,13 +334,13 @@ int pthread_once(pthread_once_t *once, void (*init_func)(void))
 {
 	pthread_mutex_lock(&pthread_key_lock);
 
-	if (*once == PTHREAD_ONCE_INIT) {
+	if (*once != PTHREAD_ONCE_INIT) {
 		pthread_mutex_unlock(&pthread_key_lock);
 		return 0;
 	}
 
 	init_func();
-	*once = PTHREAD_ONCE_INIT;
+	*once = 0;
 
 	pthread_mutex_unlock(&pthread_key_lock);
 

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -410,7 +410,7 @@ void test_posix_pthread_error_condition(void)
 	void *stackaddr;
 	size_t stacksize;
 	int policy, detach;
-	static pthread_once_t key = 1;
+	static pthread_once_t key;
 
 	/* TESTPOINT: invoke pthread APIs with NULL */
 	zassert_equal(pthread_attr_destroy(NULL), EINVAL,

--- a/tests/posix/common/src/pthread_key.c
+++ b/tests/posix/common/src/pthread_key.c
@@ -17,7 +17,8 @@
 K_THREAD_STACK_ARRAY_DEFINE(stackp, N_THR, STACKSZ);
 
 pthread_key_t key, keys[N_KEY];
-static pthread_once_t key_once, keys_once;
+static pthread_once_t key_once = PTHREAD_ONCE_INIT;
+static pthread_once_t keys_once = PTHREAD_ONCE_INIT;
 
 void *thread_top(void *p1)
 {


### PR DESCRIPTION
Fixes #41285.
As described in https://pubs.opengroup.org/onlinepubs/7908799/xsh/pthread_once.html.

> The behavior of pthread_once() is undefined if once_control has automatic storage duration or is not initialized by PTHREAD_ONCE_INIT.

However, in Zephyr, the implementation is incorrect. If the init value is PTHREAD_ONCE_INIT, the program will never run the init_func.
