### PR TITLE
smp: remove CONFIG_SMP_BOOT_DELAY dependency on CONFIG_SMP

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -850,7 +850,6 @@ config SMP
 
 config SMP_BOOT_DELAY
 	bool "Delay booting secondary cores"
-	depends on SMP
 	help
 	  By default Zephyr will boot all available CPUs during start up.
 	  Select this option to skip this and allow architecture code boot


### PR DESCRIPTION
Currently CONFIG_SMP_BOOT_DELAY defaults to yes for SOF builds, but that generates warnings if SMP isn't enabled. The simplest way to fix this is to remove the dependency. If SMP is disabled this option will have no effect anyway.
