### PR TITLE
[v2.7] X86: direct MSI message to proper processor

### DIFF
--- a/arch/x86/core/CMakeLists.txt
+++ b/arch/x86/core/CMakeLists.txt
@@ -6,6 +6,7 @@ zephyr_library()
 zephyr_library_sources(cpuhalt.c)
 zephyr_library_sources(prep_c.c)
 zephyr_library_sources(fatal.c)
+zephyr_library_sources(cpuid.c)
 zephyr_library_sources(spec_ctrl.c)
 
 zephyr_library_sources_ifdef(CONFIG_X86_MEMMAP memmap.c)

--- a/arch/x86/core/cpuid.c
+++ b/arch/x86/core/cpuid.c
@@ -21,3 +21,31 @@ uint32_t z_x86_cpuid_extended_features(void)
 
 	return edx;
 }
+
+#define INITIAL_APIC_ID_SHIFT (24)
+#define INITIAL_APIC_ID_MASK (0xFF)
+
+uint8_t z_x86_cpuid_get_current_physical_apic_id(void)
+{
+	uint32_t eax, ebx, ecx, edx;
+
+	if (IS_ENABLED(CONFIG_X2APIC)) {
+		/* leaf 0x1F should be used first prior to using 0x0B */
+		if (__get_cpuid(CPUID_EXTENDED_TOPOLOGY_ENUMERATION_V2,
+				&eax, &ebx, &ecx, &edx) == 0) {
+			if (__get_cpuid(CPUID_EXTENDED_TOPOLOGY_ENUMERATION,
+					&eax, &ebx, &ecx, &edx) == 0) {
+				return 0;
+			}
+		}
+	} else {
+		if (__get_cpuid(CPUID_BASIC_INFO_1,
+				&eax, &ebx, &ecx, &edx) == 0) {
+			return 0;
+		}
+
+		edx = (ebx >> INITIAL_APIC_ID_SHIFT);
+	}
+
+	return (uint8_t)(edx & INITIAL_APIC_ID_MASK);
+}

--- a/arch/x86/core/cpuid.c
+++ b/arch/x86/core/cpuid.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <cpuid.h> /* Header provided by the toolchain. */
+
+#include <kernel_structs.h>
+#include <arch/x86/cpuid.h>
+#include <kernel.h>
+
+uint32_t z_x86_cpuid_extended_features(void)
+{
+	uint32_t eax, ebx, ecx = 0U, edx;
+
+	if (__get_cpuid(CPUID_EXTENDED_FEATURES_LVL,
+			&eax, &ebx, &ecx, &edx) == 0) {
+		return 0;
+	}
+
+	return edx;
+}

--- a/arch/x86/core/spec_ctrl.c
+++ b/arch/x86/core/spec_ctrl.c
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <cpuid.h> /* Header provided by the toolchain. */
-
 #include <init.h>
 #include <kernel_structs.h>
 #include <kernel_arch_data.h>
 #include <kernel_arch_func.h>
 #include <arch/x86/msr.h>
+#include <arch/x86/cpuid.h>
 #include <kernel.h>
 
 /*
@@ -18,31 +17,13 @@
  * https://software.intel.com/security-software-guidance/api-app/sites/default/files/336996-Speculative-Execution-Side-Channel-Mitigations.pdf
  */
 
-#define CPUID_EXTENDED_FEATURES_LVL 7
-
-/* Bits to check in CPUID extended features */
-#define CPUID_SPEC_CTRL_SSBD	BIT(31)
-#define CPUID_SPEC_CTRL_IBRS	BIT(26)
-
 #if defined(CONFIG_DISABLE_SSBD) || defined(CONFIG_ENABLE_EXTENDED_IBRS)
-static uint32_t cpuid_extended_features(void)
-{
-	uint32_t eax, ebx, ecx = 0U, edx;
-
-	if (__get_cpuid(CPUID_EXTENDED_FEATURES_LVL,
-			&eax, &ebx, &ecx, &edx) == 0) {
-		return 0;
-	}
-
-	return edx;
-}
-
 static int spec_ctrl_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
 	uint32_t enable_bits = 0U;
-	uint32_t cpuid7 = cpuid_extended_features();
+	uint32_t cpuid7 = z_x86_cpuid_extended_features();
 
 #ifdef CONFIG_DISABLE_SSBD
 	if ((cpuid7 & CPUID_SPEC_CTRL_SSBD) != 0U) {

--- a/include/arch/x86/cpuid.h
+++ b/include/arch/x86/cpuid.h
@@ -11,13 +11,18 @@
 extern "C" {
 #endif
 
-#define CPUID_EXTENDED_FEATURES_LVL 7
+#define CPUID_BASIC_INFO_1			0x01
+#define CPUID_EXTENDED_FEATURES_LVL		0x07
+#define CPUID_EXTENDED_TOPOLOGY_ENUMERATION	0x0B
+#define CPUID_EXTENDED_TOPOLOGY_ENUMERATION_V2	0x1F
 
 /* Bits to check in CPUID extended features */
 #define CPUID_SPEC_CTRL_SSBD	BIT(31)
 #define CPUID_SPEC_CTRL_IBRS	BIT(26)
 
 uint32_t z_x86_cpuid_extended_features(void);
+
+uint8_t z_x86_cpuid_get_current_physical_apic_id(void);
 
 #ifdef __cplusplus
 }

--- a/include/arch/x86/cpuid.h
+++ b/include/arch/x86/cpuid.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022 Intel Corp.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_X86_CPUID_H_
+#define ZEPHYR_INCLUDE_ARCH_X86_CPUID_H_
+
+#ifndef _ASMLANGUAGE
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CPUID_EXTENDED_FEATURES_LVL 7
+
+/* Bits to check in CPUID extended features */
+#define CPUID_SPEC_CTRL_SSBD	BIT(31)
+#define CPUID_SPEC_CTRL_IBRS	BIT(26)
+
+uint32_t z_x86_cpuid_extended_features(void);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* _ASMLANGUAGE */
+
+#endif /* ZEPHYR_INCLUDE_ARCH_X86_CPUID_H_ */


### PR DESCRIPTION
Backport of #42480 to 2.7. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/43853