### PR TITLE
Bluetooth: controller: Make sure effective DLE is valid

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -79,6 +79,7 @@
 /* Data channel minimum payload size and time */
 #define PDU_DC_PAYLOAD_SIZE_MIN 27
 #define PDU_DC_PAYLOAD_TIME_MIN 328
+#define PDU_DC_PAYLOAD_TIME_MIN_CODED 2704
 
 /* Link Layer header size of Data PDU. Assumes pdu_data is packed */
 #define PDU_DC_LL_HEADER_SIZE  (offsetof(struct pdu_data, lldata))

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -7877,14 +7877,24 @@ uint8_t ull_dle_update_eff(struct ll_conn *conn)
 	uint8_t dle_changed = 0;
 
 	const uint16_t eff_tx_octets =
-		MIN(conn->lll.dle.local.max_tx_octets, conn->lll.dle.remote.max_rx_octets);
+		MAX(MIN(conn->lll.dle.local.max_tx_octets, conn->lll.dle.remote.max_rx_octets),
+		    PDU_DC_PAYLOAD_SIZE_MIN);
 	const uint16_t eff_rx_octets =
-		MIN(conn->lll.dle.local.max_rx_octets, conn->lll.dle.remote.max_tx_octets);
+		MAX(MIN(conn->lll.dle.local.max_rx_octets, conn->lll.dle.remote.max_tx_octets),
+		    PDU_DC_PAYLOAD_SIZE_MIN);
+
 #if defined(CONFIG_BT_CTLR_PHY)
+	unsigned int min_eff_tx_time = (conn->lll.phy_tx == PHY_CODED) ?
+			PDU_DC_PAYLOAD_TIME_MIN_CODED : PDU_DC_PAYLOAD_TIME_MIN;
+	unsigned int min_eff_rx_time = (conn->lll.phy_rx == PHY_CODED) ?
+			PDU_DC_PAYLOAD_TIME_MIN_CODED : PDU_DC_PAYLOAD_TIME_MIN;
+
 	const uint16_t eff_tx_time =
-		MIN(conn->lll.dle.local.max_tx_time, conn->lll.dle.remote.max_rx_time);
+		MAX(MIN(conn->lll.dle.local.max_tx_time, conn->lll.dle.remote.max_rx_time),
+		    min_eff_tx_time);
 	const uint16_t eff_rx_time =
-		MIN(conn->lll.dle.local.max_rx_time, conn->lll.dle.remote.max_tx_time);
+		MAX(MIN(conn->lll.dle.local.max_rx_time, conn->lll.dle.remote.max_tx_time),
+		    min_eff_rx_time);
 
 	if (eff_tx_time != conn->lll.dle.eff.max_tx_time) {
 		conn->lll.dle.eff.max_tx_time = eff_tx_time;


### PR DESCRIPTION
If peer sends invalid data length in response IUT should fix those
when calculating effective data length.

This was affecting following qualification test cases:
LL/CON/PER/BI-10-C
LL/CON/PER/BI-11-C
LL/CON/PER/BI-12-C
LL/CON/CEN/BI-07-C
LL/CON/CEN/BI-08-C
LL/CON/CEN/BI-09-C

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>