### PR TITLE
[backport v2.7-branch]  drivers: spi: stm32 spi with dma must enable cs after periph

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -718,10 +718,10 @@ static int transceive_dma(const struct device *dev,
 	/* Set buffers info */
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
+	LL_SPI_Enable(spi);
+
 	/* This is turned off in spi_stm32_complete(). */
 	spi_stm32_cs_control(dev, true);
-
-	LL_SPI_Enable(spi);
 
 	while (data->ctx.rx_len > 0 || data->ctx.tx_len > 0) {
 		size_t dma_len;


### PR DESCRIPTION
When using DMA to transfer over the spi, the spi_stm32_cs_control
is done after enabling the SPI. The same sequence applies
in the transceive_dma function as in transceive function

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/43694

Signed-off-by: Francois Ramu <francois.ramu@st.com>