### PR TITLE
samples/boards/nrf/system_off: Fix configuration of the wake up button

### DIFF
--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -10,6 +10,7 @@
 #include <init.h>
 #include <pm/pm.h>
 #include <pm/device.h>
+#include <soc.h>
 #include "retained.h"
 #include <hal/nrf_gpio.h>
 
@@ -58,9 +59,9 @@ void main(void)
 	}
 
 	/* Configure to generate PORT event (wakeup) on button 1 press. */
-	nrf_gpio_cfg_input(DT_GPIO_PIN(DT_NODELABEL(button0), gpios),
+	nrf_gpio_cfg_input(NRF_DT_GPIOS_TO_PSEL(DT_ALIAS(sw0), gpios),
 			   NRF_GPIO_PIN_PULLUP);
-	nrf_gpio_cfg_sense_set(DT_GPIO_PIN(DT_NODELABEL(button0), gpios),
+	nrf_gpio_cfg_sense_set(NRF_DT_GPIOS_TO_PSEL(DT_ALIAS(sw0), gpios),
 			       NRF_GPIO_PIN_SENSE_LOW);
 
 	printk("Busy-wait %u s\n", BUSY_WAIT_S);


### PR DESCRIPTION
Use NRF_DT_GPIOS_TO_PSEL() in calls to nRF GPIO HAL functions as they
need a psel value, a pin number combined with the corresponding GPIO
port number, not only the pin number as provided by DT_GPIO_PIN().
This way buttons connected to pins in the P1 port can also be handled
properly.
Replace also DT_NODELABEL(button0) with DT_ALIAS(sw0) for consistency
with other samples that use the standard button.

Fixes #43400.