### PR TITLE
mgmt/mcumgr/lib: Remove unneeded rc fields in stat respones

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
@@ -61,9 +61,6 @@ stat_mgmt_show(struct mgmt_ctxt *ctxt)
 		return MGMT_ERR_EINVAL;
 	}
 
-	err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
-	err |= cbor_encode_int(&ctxt->encoder, MGMT_ERR_EOK);
-
 	err |= cbor_encode_text_stringz(&ctxt->encoder, "name");
 	err |= cbor_encode_text_stringz(&ctxt->encoder, stat_name);
 
@@ -94,8 +91,7 @@ stat_mgmt_list(struct mgmt_ctxt *ctxt)
 	int i;
 
 	err = CborNoError;
-	err |= cbor_encode_text_stringz(&ctxt->encoder, "rc");
-	err |= cbor_encode_int(&ctxt->encoder, MGMT_ERR_EOK);
+
 	err |= cbor_encode_text_stringz(&ctxt->encoder, "stat_list");
 	err |= cbor_encoder_create_array(&ctxt->encoder, &arr_enc, CborIndefiniteLength);
 


### PR DESCRIPTION
In responses to stat group commands there have been added rc = 0
pairs that are not needed in successful responses; they have been
added as first items of returned CBOR map, and are not needed
because in case of failure the entire CBOR map will be rewritten
with new error response.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>