### PR TITLE
cmake: Fix dependencies so builds are sparse again

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1370,7 +1370,7 @@ set(post_build_byproducts "")
 list(APPEND
   post_build_commands
   COMMAND
-  ${CMAKE_COMMAND} -E rename ${logical_target_for_zephyr_elf}.map ${KERNEL_MAP_NAME}
+  ${CMAKE_COMMAND} -E copy ${logical_target_for_zephyr_elf}.map ${KERNEL_MAP_NAME}
 )
 list(APPEND post_build_byproducts ${KERNEL_MAP_NAME})
 

--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -30,7 +30,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   endif()
 
   zephyr_get_include_directories_for_lang(C current_includes)
-  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
 # the command to generate linker file from template
@@ -46,7 +45,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -x c
     ${NOSYSDEF_CFLAG}
     -Hnocopyr
-    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+    -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
     -imacros ${AUTOCONF_H}

--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -29,7 +29,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   endif()
 
   zephyr_get_include_directories_for_lang(C current_includes)
-  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
   add_custom_command(
@@ -42,7 +41,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     COMMAND ${CMAKE_C_COMPILER}
     -x assembler-with-cpp
     ${NOSYSDEF_CFLAG}
-    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+    -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
     ${current_includes}


### PR DESCRIPTION
Rebuilding unchanged Zephyr applications using GNU ld, has the last 4 months performed linking again.
I.e. running cmake && ninja over an unchanged application has cost linking time.
This PR fixes that, i.e. makes the build sparse again so linker is not invoked again needlessly.
ld/target.cmake had drifted behind other linkers, lacking ${base_name}.

GCC can build dependency files which ninja picks up.
GCC is told to generate a dep file that depends on a target that is
never created: The file is created but under the basename zephyr folder.
Thus the dependency check always failed.

This also realigns ld with lld and arcmwdt:

```
$ rg -tcmake base_name
cmake/linker/arcmwdt/target.cmake
33:  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
49:    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}

cmake/linker/ld/target.cmake
67:    get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
81:      -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}

cmake/linker/lld/target.cmake
32:  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
45:    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
```

Finally, use copy rather than rename as renaming can break dependencies. Copying is more idempotent.