### PR TITLE
LE Audio: Use array of stream pointers instead of array of streams

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1551,14 +1551,14 @@ int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf);
  *  unicast client. Streams in a unicast group shall share the same interval,
  *  framing and latency (see @ref bt_codec_qos).
  *
- *  @param[in]  streams        Array of stream objects being used for the
- *                             group.
+ *  @param[in]  streams        Array of stream object pointers being used for
+ *                             the group.
  *  @param[in]  num_stream     Number of streams in @p streams.
  *  @param[out] unicast_group  Pointer to the unicast group created
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
+int bt_audio_unicast_group_create(struct bt_audio_stream *streams[],
 				  size_t num_stream,
 				  struct bt_audio_unicast_group **unicast_group);
 
@@ -1573,13 +1573,14 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
  *  (see bt_audio_stream_ops.stopped()).
  *
  *  @param unicast_group  Pointer to the unicast group
- *  @param streams        Array of stream objects being added to the group.
+ *  @param streams        Array of stream object pointers being added to the
+ *                        group.
  *  @param num_stream     Number of streams in @p streams.
  *
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_group,
-				       struct bt_audio_stream *streams,
+				       struct bt_audio_stream *streams[],
 				       size_t num_stream);
 
 /** @brief Remove streams from a unicast group as a unicast client
@@ -1592,13 +1593,14 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
  *  (see bt_audio_stream_ops.stopped()).
  *
  *  @param unicast_group  Pointer to the unicast group
- *  @param streams        Array of stream objects removed from the group.
+ *  @param streams        Array of stream object pointers removed from the
+ *                        group.
  *  @param num_stream     Number of streams in @p streams.
  *
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast_group,
-					  struct bt_audio_stream *streams,
+					  struct bt_audio_stream *streams[],
 					  size_t num_stream);
 
 /** @brief Delete audio unicast group.

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1737,9 +1737,9 @@ int bt_audio_broadcast_sink_scan_stop(void);
  *  @param indexes_bitfield   Bitfield of the BIS index to sync to. To sync to
  *                            e.g. BIS index 1 and 2, this should have the value
  *                            of BIT(1) | BIT(2).
- *  @param streams            Stream objects to be used for the receiver. If
- *                            multiple BIS indexes shall be synchronized,
- *                            multiple streams shall be provided.
+ *  @param streams            Stream object pointerss to be used for the
+ *                            receiver. If multiple BIS indexes shall be
+ *                            synchronized, multiple streams shall be provided.
  *  @param codec              Codec configuration.
  *  @param broadcast_code     The 16-octet broadcast code. Shall be supplied if
  *                            the broadcast is encrypted (see the syncable
@@ -1749,7 +1749,7 @@ int bt_audio_broadcast_sink_scan_stop(void);
  */
 int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 				 uint32_t indexes_bitfield,
-				 struct bt_audio_stream *streams,
+				 struct bt_audio_stream *streams[],
 				 struct bt_codec *codec,
 				 const uint8_t broadcast_code[16]);
 

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1634,7 +1634,7 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group);
  *  called and no audio information (BIGInfo) will be visible to scanners
  *  (see bt_le_per_adv_sync_cb).
  *
- *  @param[in]  streams     Array of stream objects being used for the
+ *  @param[in]  streams     Array of stream object pointers being used for the
  *                          broadcaster. This array shall remain valid for the
  *                          duration of the broadcast source.
  *  @param[in]  num_stream  Number of streams in @p streams.
@@ -1644,7 +1644,7 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group);
  *
  *  @return Zero on success or (negative) error code otherwise.
  */
-int bt_audio_broadcast_source_create(struct bt_audio_stream *streams,
+int bt_audio_broadcast_source_create(struct bt_audio_stream *streams[],
 				     size_t num_stream,
 				     struct bt_codec *codec,
 				     struct bt_codec_qos *qos,

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -182,12 +182,17 @@ static void reset(void)
 
 void main(void)
 {
+	struct bt_audio_stream *streams_p[ARRAY_SIZE(streams)];
 	int err;
 
 	err = init();
 	if (err) {
 		printk("Init failed (err %d)\n", err);
 		return;
+	}
+
+	for (size_t i = 0U; i < ARRAY_SIZE(streams_p); i++) {
+		streams_p[i] = &streams[i];
 	}
 
 	while (true) {
@@ -232,7 +237,7 @@ void main(void)
 		printk("Syncing to broadcast\n");
 		err = bt_audio_broadcast_sink_sync(broadcast_sink,
 						   bis_index_bitfield,
-						   streams,
+						   streams_p,
 						   &preset_16_2_1.codec, NULL);
 		if (err != 0) {
 			printk("Unable to sync to broadcast source: %d\n", err);

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -83,6 +83,7 @@ struct bt_audio_stream_ops stream_ops = {
 
 void main(void)
 {
+	struct bt_audio_stream *streams_p[ARRAY_SIZE(streams)];
 	int err;
 
 	err = bt_enable(NULL);
@@ -94,6 +95,7 @@ void main(void)
 
 	for (size_t i = 0U; i < ARRAY_SIZE(streams); i++) {
 		streams[i].ops = &stream_ops;
+		streams_p[i] = &streams[i];
 	}
 
 	for (size_t i = 0U; i < ARRAY_SIZE(mock_data); i++) {
@@ -103,8 +105,8 @@ void main(void)
 
 	while (true) {
 		printk("Creating broadcast source\n");
-		err = bt_audio_broadcast_source_create(streams,
-						       ARRAY_SIZE(streams),
+		err = bt_audio_broadcast_source_create(streams_p,
+						       ARRAY_SIZE(streams_p),
 						       &preset_16_2_1.codec,
 						       &preset_16_2_1.qos,
 						       &broadcast_source);

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -642,7 +642,7 @@ static int create_group(struct bt_audio_stream *stream)
 {
 	int err;
 
-	err = bt_audio_unicast_group_create(stream, 1, &unicast_group);
+	err = bt_audio_unicast_group_create(&stream, 1, &unicast_group);
 	if (err != 0) {
 		printk("Could not create unicast group (err %d)\n", err);
 		return err;

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -100,7 +100,7 @@ struct bt_audio_broadcast_sink {
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_SNK_STREAM_CNT];
 	/* The streams used to create the broadcast sink */
-	struct bt_audio_stream *streams;
+	struct bt_audio_stream **streams;
 };
 
 static inline const char *bt_audio_ep_state_str(uint8_t state)

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -81,7 +81,7 @@ struct bt_audio_broadcast_source {
 	struct bt_iso_chan *bis[BROADCAST_STREAM_CNT];
 	struct bt_codec_qos *qos;
 	/* The streams used to create the broadcast source */
-	struct bt_audio_stream *streams;
+	struct bt_audio_stream **streams;
 };
 
 struct bt_audio_broadcast_sink {

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -1001,7 +1001,7 @@ int bt_audio_stream_connect(struct bt_audio_stream *stream)
 	}
 }
 
-int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
+int bt_audio_unicast_group_create(struct bt_audio_stream *streams[],
 				  size_t num_stream,
 				  struct bt_audio_unicast_group **out_unicast_group)
 {
@@ -1027,6 +1027,18 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 		return -EINVAL;
 	}
 
+	for (size_t i = 0; i < num_stream; i++) {
+		CHECKIF(streams[i] == NULL) {
+			return -EINVAL;
+		}
+
+		if (streams[i]->group != NULL) {
+			BT_DBG("Channel[%u] (%p) already part of group %p",
+			       i, streams[i], streams[i]->group);
+			return -EALREADY;
+		}
+	}
+
 	unicast_group = NULL;
 	for (index = 0; index < ARRAY_SIZE(unicast_groups); index++) {
 		/* Find free entry */
@@ -1045,23 +1057,7 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 		sys_slist_t *group_streams = &unicast_group->streams;
 		struct bt_audio_stream *stream;
 
-		stream = &streams[i];
-
-		if (stream->group != NULL) {
-			BT_DBG("Channel[%u] (%p) already part of group %p",
-			       i, stream, stream->group);
-
-			/* Cleanup */
-			for (size_t j = 0; j < i; j++) {
-				stream = &streams[j];
-
-				(void)sys_slist_find_and_remove(group_streams,
-								&stream->node);
-				stream->unicast_group = NULL;
-			}
-			return -EALREADY;
-		}
-
+		stream = streams[i];
 		stream->unicast_group = unicast_group;
 		sys_slist_append(group_streams, &stream->node);
 	}
@@ -1072,7 +1068,7 @@ int bt_audio_unicast_group_create(struct bt_audio_stream *streams,
 }
 
 int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_group,
-				       struct bt_audio_stream *streams,
+				       struct bt_audio_stream *streams[],
 				       size_t num_stream)
 {
 	struct bt_audio_stream *tmp_stream;
@@ -1094,6 +1090,12 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 		return -EINVAL;
 	}
 
+	for (size_t i = 0; i < num_stream; i++) {
+		CHECKIF(streams[i] == NULL) {
+			return -EINVAL;
+		}
+	}
+
 	total_stream_cnt = num_stream;
 	SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, tmp_stream, node) {
 		total_stream_cnt++;
@@ -1108,9 +1110,9 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 
 	/* Validate input */
 	for (size_t i = 0; i < num_stream; i++) {
-		if (streams[i].group != NULL) {
+		if (streams[i]->group != NULL) {
 			BT_DBG("stream[%zu] is already part of group %p",
-			       i, streams[i].group);
+			       i, streams[i]->group);
 			return -EINVAL;
 		}
 	}
@@ -1126,7 +1128,7 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 
 	for (size_t i = 0; i < num_stream; i++) {
 		sys_slist_t *group_streams = &unicast_group->streams;
-		struct bt_audio_stream *stream = &streams[i];
+		struct bt_audio_stream *stream = streams[i];
 
 		stream->unicast_group = unicast_group;
 		sys_slist_append(group_streams, &stream->node);
@@ -1136,7 +1138,7 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 }
 
 int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast_group,
-					  struct bt_audio_stream *streams,
+					  struct bt_audio_stream *streams[],
 					  size_t num_stream)
 {
 	struct bt_iso_cig *cig;
@@ -1158,9 +1160,13 @@ int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast
 
 	/* Validate input */
 	for (size_t i = 0; i < num_stream; i++) {
-		if (streams[i].group != unicast_group) {
+		CHECKIF(streams[i] == NULL) {
+			return -EINVAL;
+		}
+
+		if (streams[i]->group != unicast_group) {
 			BT_DBG("stream[%zu] group %p is not group %p",
-			       i, streams[i].group, unicast_group);
+			       i, streams[i]->group, unicast_group);
 			return -EINVAL;
 		}
 	}
@@ -1176,11 +1182,11 @@ int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast
 
 	for (size_t i = 0; i < num_stream; i++) {
 		sys_slist_t *group_streams = &unicast_group->streams;
-		struct bt_audio_stream *stream = &streams[i];
+		struct bt_audio_stream *stream = streams[i];
 
 		stream->unicast_group = NULL;
 		(void)sys_slist_find_and_remove(group_streams,
-						&streams->node);
+						&stream->node);
 	}
 
 	return 0;

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -313,7 +313,7 @@ static int lc3_reconfig(struct bt_audio_stream *stream,
 		int err;
 
 		if (default_unicast_group == NULL) {
-			err = bt_audio_unicast_group_create(default_stream, 1,
+			err = bt_audio_unicast_group_create(&default_stream, 1,
 							    &default_unicast_group);
 			if (err != 0) {
 				shell_error(ctx_shell,
@@ -733,7 +733,7 @@ static int cmd_qos(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (default_unicast_group == NULL) {
-		err = bt_audio_unicast_group_create(default_stream, 1, &default_unicast_group);
+		err = bt_audio_unicast_group_create(&default_stream, 1, &default_unicast_group);
 		if (err != 0) {
 			shell_error(sh, "Unable to create default unicast group: %d", err);
 			return -ENOEXEC;

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1260,6 +1260,7 @@ static int cmd_accept_broadcast(const struct shell *sh, size_t argc,
 
 static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 {
+	static struct bt_audio_stream *streams[ARRAY_SIZE(broadcast_sink_streams)];
 	uint32_t bis_bitfield;
 	int err;
 
@@ -1278,8 +1279,13 @@ static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 		return -ENOEXEC;
 	}
 
+	(void)memset(streams, 0, sizeof(streams));
+	for (size_t i = 0; i < ARRAY_SIZE(streams); i++) {
+		streams[i] = &broadcast_sink_streams[i];
+	}
+
 	err = bt_audio_broadcast_sink_sync(default_sink, bis_bitfield,
-					   broadcast_sink_streams,
+					   streams,
 					   &default_preset->preset.codec,
 					   NULL);
 	if (err != 0) {

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1119,6 +1119,7 @@ static int cmd_select_broadcast_source(const struct shell *sh, size_t argc,
 static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 				char *argv[])
 {
+	static struct bt_audio_stream *streams[ARRAY_SIZE(broadcast_source_streams)];
 	struct named_lc3_preset *named_preset;
 	int err;
 
@@ -1138,8 +1139,12 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 		}
 	}
 
-	err = bt_audio_broadcast_source_create(broadcast_source_streams,
-					       ARRAY_SIZE(broadcast_source_streams),
+	(void)memset(streams, 0, sizeof(streams));
+	for (size_t i = 0; i < ARRAY_SIZE(streams); i++) {
+		streams[i] = &broadcast_source_streams[i];
+	}
+
+	err = bt_audio_broadcast_source_create(streams, ARRAY_SIZE(streams),
 					       &named_preset->preset.codec,
 					       &named_preset->preset.qos,
 					       &default_source);
@@ -1152,7 +1157,7 @@ static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 		    named_preset->name);
 
 	if (default_stream == NULL) {
-		default_stream = &broadcast_source_streams[0];
+		default_stream = streams[0];
 	}
 
 	return 0;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -18,6 +18,7 @@ static void test_main(void)
 	struct bt_audio_lc3_preset preset_16_2_1 = BT_AUDIO_LC3_BROADCAST_PRESET_16_2_1;
 	struct bt_audio_lc3_preset preset_16_2_2 = BT_AUDIO_LC3_BROADCAST_PRESET_16_2_2;
 	struct bt_audio_stream broadcast_source_streams[CONFIG_BT_AUDIO_BROADCAST_SRC_STREAM_COUNT];
+	struct bt_audio_stream *streams[ARRAY_SIZE(broadcast_source_streams)];
 	struct bt_audio_broadcast_source *source;
 
 	err = bt_enable(NULL);
@@ -31,9 +32,12 @@ static void test_main(void)
 	(void)memset(broadcast_source_streams, 0,
 		     sizeof(broadcast_source_streams));
 
+	for (size_t i = 0; i < ARRAY_SIZE(streams); i++) {
+		streams[i] = &broadcast_source_streams[i];
+	}
+
 	printk("Creating broadcast source\n");
-	err = bt_audio_broadcast_source_create(broadcast_source_streams,
-					       ARRAY_SIZE(broadcast_source_streams),
+	err = bt_audio_broadcast_source_create(streams, ARRAY_SIZE(streams),
 					       &preset_16_2_1.codec,
 					       &preset_16_2_1.qos,
 					       &source);
@@ -62,8 +66,7 @@ static void test_main(void)
 
 	/* Recreate broadcast source to verify that it's possible */
 	printk("Recreating broadcast source\n");
-	err = bt_audio_broadcast_source_create(broadcast_source_streams,
-					       ARRAY_SIZE(broadcast_source_streams),
+	err = bt_audio_broadcast_source_create(streams, ARRAY_SIZE(streams),
 					       &preset_16_2_1.codec,
 					       &preset_16_2_1.qos,
 					       &source);


### PR DESCRIPTION
This updates some of the LE Audio APIs to use a more flexible approach when it comes to creating and modifying groups. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/42587