### PR TITLE
drivers: i2c: Refactor drivers to use shared init priority

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -54,7 +54,7 @@ source "drivers/i2c/Kconfig.gd32"
 
 config I2C_INIT_PRIORITY
 	int "Init priority"
-	default 60
+	default KERNEL_INIT_PRIORITY_DEVICE
 	help
 	  I2C device driver initialization priority.
 

--- a/drivers/i2c/i2c_b91.c
+++ b/drivers/i2c/i2c_b91.c
@@ -172,7 +172,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
 				  &i2c_b91_data_##inst,		      \
 				  &i2c_b91_cfg_##inst,		      \
 				  POST_KERNEL,			      \
-				  CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+				  CONFIG_I2C_INIT_PRIORITY,	      \
 				  &i2c_b91_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_B91_INIT)

--- a/drivers/i2c/i2c_cc32xx.c
+++ b/drivers/i2c/i2c_cc32xx.c
@@ -380,7 +380,7 @@ static struct i2c_cc32xx_data i2c_cc32xx_data;
 
 I2C_DEVICE_DT_INST_DEFINE(0, i2c_cc32xx_init, NULL,
 		    &i2c_cc32xx_data, &i2c_cc32xx_config,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_cc32xx_driver_api);
 
 static void configure_i2c_irq(const struct i2c_cc32xx_config *config)

--- a/drivers/i2c/i2c_gecko.c
+++ b/drivers/i2c/i2c_gecko.c
@@ -225,7 +225,7 @@ static struct i2c_gecko_data i2c_gecko_data_##idx; \
 I2C_DEVICE_DT_INST_DEFINE(idx, i2c_gecko_init, \
 		 NULL, \
 		 &i2c_gecko_data_##idx, &i2c_gecko_config_##idx, \
-		 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+		 POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, \
 		 &i2c_gecko_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_INIT)

--- a/drivers/i2c/i2c_imx.c
+++ b/drivers/i2c/i2c_imx.c
@@ -372,7 +372,7 @@ static const struct i2c_driver_api i2c_imx_driver_api = {
 				NULL,					\
 				&i2c_imx_data_##n, &i2c_imx_config_##n,	\
 				POST_KERNEL,				\
-				CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+				CONFIG_I2C_INIT_PRIORITY,		\
 				&i2c_imx_driver_api);			\
 									\
 	static void i2c_imx_config_func_##n(const struct device *dev)	\

--- a/drivers/i2c/i2c_ite_it8xxx2.c
+++ b/drivers/i2c/i2c_ite_it8xxx2.c
@@ -1088,7 +1088,7 @@ static const struct i2c_driver_api i2c_it8xxx2_driver_api = {
 			i2c_it8xxx2_init, NULL,				       \
 			&i2c_it8xxx2_data_##idx,	                       \
 			&i2c_it8xxx2_cfg_##idx, POST_KERNEL,		       \
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,                    \
+			CONFIG_I2C_INIT_PRIORITY,			       \
 			&i2c_it8xxx2_driver_api);                              \
 	\
 	static void i2c_it8xxx2_config_func_##idx(void)                        \

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -346,7 +346,7 @@ static struct i2c_stm32_data i2c_stm32_dev_data_##name;			\
 I2C_DEVICE_DT_DEFINE(DT_NODELABEL(name), i2c_stm32_init,		\
 		    NULL, &i2c_stm32_dev_data_##name,			\
 		    &i2c_stm32_cfg_##name,				\
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,		\
 		    &api_funcs);					\
 									\
 STM32_I2C_IRQ_HANDLER(name)

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -404,7 +404,7 @@ I2C_DEVICE_DT_INST_DEFINE(idx,						      \
 		    lpc11u6x_i2c_init,					      \
 		    NULL,						      \
 		    &i2c_data_##idx, &i2c_cfg_##idx,			      \
-		    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS,	      \
+		    PRE_KERNEL_1, CONFIG_I2C_INIT_PRIORITY,		      \
 		    &i2c_api);						      \
 									      \
 static void lpc11u6x_i2c_isr_config_##idx(const struct device *dev)		      \

--- a/drivers/i2c/i2c_mcux.c
+++ b/drivers/i2c/i2c_mcux.c
@@ -230,7 +230,7 @@ static const struct i2c_driver_api i2c_mcux_driver_api = {
 			i2c_mcux_init, NULL,				\
 			&i2c_mcux_data_ ## n,				\
 			&i2c_mcux_config_ ## n, POST_KERNEL,		\
-			CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			CONFIG_I2C_INIT_PRIORITY,			\
 			&i2c_mcux_driver_api);				\
 									\
 	static void i2c_mcux_config_func_ ## n(const struct device *dev) \

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -231,7 +231,7 @@ static const struct i2c_driver_api mcux_flexcomm_driver_api = {
 			    &mcux_flexcomm_data_##id,			\
 			    &mcux_flexcomm_config_##id,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_I2C_INIT_PRIORITY,			\
 			    &mcux_flexcomm_driver_api);			\
 	static void mcux_flexcomm_config_func_##id(const struct device *dev) \
 	{								\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -263,7 +263,7 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 	I2C_DEVICE_DT_INST_DEFINE(n, mcux_lpi2c_init, NULL,		\
 			    &mcux_lpi2c_data_##n,			\
 			    &mcux_lpi2c_config_##n, POST_KERNEL,	\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_I2C_INIT_PRIORITY,			\
 			    &mcux_lpi2c_driver_api);			\
 									\
 	static void mcux_lpi2c_config_func_##n(const struct device *dev) \

--- a/drivers/i2c/i2c_nios2.c
+++ b/drivers/i2c/i2c_nios2.c
@@ -191,5 +191,5 @@ static int i2c_nios2_init(const struct device *dev)
 
 I2C_DEVICE_DT_INST_DEFINE(0, i2c_nios2_init, NULL,
 		    &i2c_nios2_dev_data, NULL,
-		    POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		    POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,
 		    &i2c_nios2_driver_api);

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -967,7 +967,7 @@ static int i2c_ctrl_init(const struct device *dev)
 			    NPCX_I2C_CTRL_INIT_FUNC(inst),                     \
 			    NULL,                                              \
 			    &i2c_ctrl_data_##inst, &i2c_ctrl_cfg_##inst,       \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
+			    PRE_KERNEL_1, CONFIG_I2C_INIT_PRIORITY,            \
 			    NULL);                                             \
 									       \
 	NPCX_I2C_CTRL_INIT_FUNC_IMPL(inst)

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -166,7 +166,7 @@ static const struct i2c_driver_api i2c_port_npcx_driver_api = {
 			    i2c_npcx_port_init,                                \
 			    NULL, NULL,                                        \
 			    &i2c_npcx_port_cfg_##inst,                         \
-			    PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,  \
+			    PRE_KERNEL_1, CONFIG_I2C_INIT_PRIORITY,            \
 			    &i2c_port_npcx_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(NPCX_I2C_PORT_INIT)

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -366,7 +366,7 @@ static const struct i2c_driver_api i2c_rcar_driver_api = {
 			      NULL,					       \
 			      &i2c_rcar_data_##n,			       \
 			      &i2c_rcar_cfg_##n,			       \
-			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
+			      POST_KERNEL, CONFIG_I2C_INIT_PRIORITY,	       \
 			      &i2c_rcar_driver_api			       \
 			      );					       \
 	static void i2c_rcar_##n##_init(const struct device *dev)	       \

--- a/drivers/i2c/i2c_test.c
+++ b/drivers/i2c/i2c_test.c
@@ -40,7 +40,7 @@ static int vnd_i2c_init(const struct device *dev)
 #define VND_I2C_INIT(n)						\
 	I2C_DEVICE_DT_INST_DEFINE(n, vnd_i2c_init, NULL,			\
 			      NULL, NULL, POST_KERNEL,			\
-			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
+			      CONFIG_I2C_INIT_PRIORITY,	\
 			      &vnd_i2c_api);
 
 DT_INST_FOREACH_STATUS_OKAY(VND_I2C_INIT)


### PR DESCRIPTION
Refactors the remaining I2C drivers to use the shared driver class
initialization priority configuration, CONFIG_I2C_INIT_PRIORITY, to
allow configuring I2C drivers separately from other devices. This is
similar to other driver classes.

The default is set to CONFIG_KERNEL_INIT_PRIORITY_DEVICE to preserve the
existing default initialization priority for most drivers.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>