### PR TITLE
drivers: i2s: Refactor drivers to use shared init priority

### DIFF
--- a/drivers/i2s/Kconfig
+++ b/drivers/i2s/Kconfig
@@ -15,7 +15,7 @@ if I2S
 
 config I2S_INIT_PRIORITY
 	int "Init priority"
-	default 70
+	default KERNEL_INIT_PRIORITY_DEVICE
 	help
 	  Device driver initialization priority.
 

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -908,7 +908,7 @@ static int i2s_mcux_init(const struct device *dev)
 			    &i2s_mcux_data_##id,			\
 			    &i2s_mcux_config_##id,			\
 			    POST_KERNEL,				\
-			    CONFIG_KERNEL_INIT_PRIORITY_DEVICE,		\
+			    CONFIG_I2S_INIT_PRIORITY,			\
 			    &i2s_mcux_driver_api);			\
 	static void i2s_mcux_config_func_##id(const struct device *dev)	\
 	{								\


### PR DESCRIPTION
Refactors the remaining I2S drivers to use the shared driver class
initialization priority configuration, CONFIG_I2S_INIT_PRIORITY, to
allow configuring I2S drivers separately from other devices. This is
similar to other driver classes.

The default is set to CONFIG_KERNEL_INIT_PRIORITY_DEVICE to be
consistent with other driver classes.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>