### PR TITLE
drivers: interrupt_controller: Refactor drivers to use shared init prio

### DIFF
--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -45,6 +45,12 @@ config LEON_IRQMP
 	help
 	  GRLIB IRQMP and IRQAMP
 
+config INTC_INIT_PRIORITY
+	int "Interrupt controller init priority"
+	default KERNEL_INIT_PRIORITY_DEFAULT
+	help
+	  Interrupt controller device initialization priority.
+
 source "drivers/interrupt_controller/Kconfig.multilevel"
 
 source "drivers/interrupt_controller/Kconfig.loapic"

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -423,7 +423,7 @@ static struct stm32_exti_data exti_data;
 DEVICE_DT_DEFINE(EXTI_NODE, &stm32_exti_init,
 		 NULL,
 		 &exti_data, NULL,
-		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,
+		 PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,
 		 NULL);
 
 /**

--- a/drivers/interrupt_controller/intc_gd32_exti.c
+++ b/drivers/interrupt_controller/intc_gd32_exti.c
@@ -191,4 +191,4 @@ static int gd32_exti_init(const struct device *dev)
 static struct gd32_exti_data data;
 
 DEVICE_DT_INST_DEFINE(0, gd32_exti_init, NULL, &data, NULL, PRE_KERNEL_1,
-		      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
+		      CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -239,7 +239,7 @@ int arm_gic_init(const struct device *unused)
 	return 0;
 }
 
-SYS_INIT(arm_gic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(arm_gic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
 
 #ifdef CONFIG_SMP
 void arm_gic_secondary_init(void)

--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -487,7 +487,7 @@ int arm_gic_init(const struct device *unused)
 
 	return 0;
 }
-SYS_INIT(arm_gic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(arm_gic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);
 
 #ifdef CONFIG_SMP
 void arm_gic_secondary_init(void)

--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -667,7 +667,7 @@ struct its_driver_api gicv3_its_api = {
 			      &gicv3_its_data##n,			       \
 			      &gicv3_its_config##n,			       \
 			      POST_KERNEL,				       \
-			      CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	       \
+			      CONFIG_INTC_INIT_PRIORITY,		       \
 			      &gicv3_its_api);
 
 DT_INST_FOREACH_STATUS_OKAY(GICV3_ITS_INIT)

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -545,4 +545,4 @@ static void IoApicRedUpdateLo(unsigned int irq,
 PM_DEVICE_DEFINE(ioapic, ioapic_pm_action);
 
 DEVICE_DEFINE(ioapic, "ioapic", ioapic_init, PM_DEVICE_GET(ioapic), NULL, NULL,
-	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+	      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);

--- a/drivers/interrupt_controller/intc_irqmp.c
+++ b/drivers/interrupt_controller/intc_irqmp.c
@@ -122,4 +122,4 @@ static int irqmp_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(irqmp_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(irqmp_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -422,7 +422,7 @@ static int loapic_pm_action(const struct device *dev,
 PM_DEVICE_DEFINE(loapic, loapic_pm_action);
 
 DEVICE_DEFINE(loapic, "loapic", loapic_init, PM_DEVICE_GET(loapic), NULL, NULL,
-	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT, NULL);
+	      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY, NULL);
 
 #if CONFIG_LOAPIC_SPURIOUS_VECTOR
 extern void z_loapic_spurious_handler(void);

--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -568,7 +568,7 @@ static int xec_ecia_init(const struct device *dev)
 									\
 	DEVICE_DT_DEFINE(n, xec_girq_init_##n,				\
 		 NULL, &xec_data_girq_##n, &xec_config_girq_##n,	\
-		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,	\
+		 PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,		\
 		 NULL);							\
 									\
 	static int xec_girq_init_##n(const struct device *dev)		\
@@ -606,7 +606,7 @@ static const struct xec_ecia_config xec_config_ecia = {
 
 DEVICE_DT_DEFINE(DT_NODELABEL(ecia), xec_ecia_init,
 		 NULL, NULL, &xec_config_ecia,
-		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		 PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,
 		 NULL);
 
 /* look up GIRQ node handle from ECIA configuration */

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -382,7 +382,7 @@ int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 			    NULL,					       \
 			    NULL, &miwu_config_##inst,                         \
 			    PRE_KERNEL_1,                                      \
-			    CONFIG_KERNEL_INIT_PRIORITY_OBJECTS, NULL);        \
+			    CONFIG_INTC_INIT_PRIORITY, NULL);                  \
 									       \
 	NPCX_MIWU_ISR_FUNC_IMPL(inst)                                          \
 									       \

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -181,4 +181,4 @@ static int nuclei_eclic_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(nuclei_eclic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(nuclei_eclic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -208,4 +208,4 @@ static int plic_init(const struct device *dev)
 	return 0;
 }
 
-SYS_INIT(plic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(plic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -409,5 +409,5 @@ static int sam0_eic_init(const struct device *dev)
 static struct sam0_eic_data eic_data;
 DEVICE_DT_INST_DEFINE(0, sam0_eic_init,
 	      NULL, &eic_data, NULL,
-	      PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+	      PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY,
 	      NULL);

--- a/drivers/interrupt_controller/intc_swerv_pic.c
+++ b/drivers/interrupt_controller/intc_swerv_pic.c
@@ -235,4 +235,4 @@ int arch_irq_is_enabled(unsigned int irq)
 	return !!(mie & (1 << irq));
 }
 
-SYS_INIT(swerv_pic_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(swerv_pic_init, PRE_KERNEL_1, CONFIG_INTC_INIT_PRIORITY);

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -135,4 +135,4 @@ static int vexriscv_litex_irq_init(const struct device *dev)
 }
 
 SYS_INIT(vexriscv_litex_irq_init, PRE_KERNEL_2,
-		CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+		CONFIG_INTC_INIT_PRIORITY);


### PR DESCRIPTION
Refactors interrupt controller drivers to use the shared driver class
initialization priority configuration, CONFIG_INTC_INIT_PRIORITY, to
allow configuring interrupt controller drivers separately from other
devices. This is similar to other driver classes.

The default is set to CONFIG_KERNEL_INIT_PRIORITY_DEFAULT to preserve
the existing default initialization priority for most drivers.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>