### PR TITLE
power_domain: gpio: respect timing parameters

### DIFF
--- a/doc/services/pm/device.rst
+++ b/doc/services/pm/device.rst
@@ -73,6 +73,12 @@ in transition between power states:
 * Gate/Un-gate power.
 * Mask/Un-mask interrupts.
 
+.. note::
+
+   When using :ref:`pm-system`, device transitions can be run from the idle thread.
+   As functions in this context cannot block, transitions that intend to use blocking
+   API's **must** check whether they can do so with :c:func:`k_can_yield`.
+
 Device Model with Power Management Support
 ******************************************
 

--- a/doc/services/pm/system.rst
+++ b/doc/services/pm/system.rst
@@ -1,3 +1,5 @@
+.. _pm-system:
+
 System Power Management
 #######################
 

--- a/drivers/power_domain/Kconfig
+++ b/drivers/power_domain/Kconfig
@@ -11,5 +11,6 @@ if POWER_DOMAIN
 config POWER_DOMAIN_GPIO
 	bool "GPIO controlled power domain"
 	depends on GPIO
+	depends on TIMEOUT_64BIT
 
 endif

--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -7,12 +7,12 @@
 
 #define DT_DRV_COMPAT power_domain_gpio
 
-#include <kernel.h>
-#include <drivers/gpio.h>
-#include <pm/device.h>
-#include <pm/device_runtime.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(power_domain_gpio, LOG_LEVEL_INF);
 
 struct pd_gpio_config {

--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -22,20 +22,32 @@ struct pd_gpio_config {
 };
 
 struct pd_gpio_data {
-	k_timeout_t last_boot;
+	k_timeout_t next_boot;
 };
 
 static int pd_gpio_pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {
 	const struct pd_gpio_config *cfg = dev->config;
+	struct pd_gpio_data *data = dev->data;
+	int64_t next_boot_ticks;
 	int rc = 0;
+
+	/* Validate that blocking API's can be used */
+	if (!k_can_yield()) {
+		LOG_ERR("Blocking actions cannot run in this context");
+		return -ENOTSUP;
+	}
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
+		/* Wait until we can boot again */
+		k_sleep(data->next_boot);
 		/* Switch power on */
 		gpio_pin_set_dt(&cfg->enable, 1);
 		LOG_DBG("%s is now ON", dev->name);
+		/* Wait for domain to come up */
+		k_sleep(K_USEC(cfg->startup_delay_us));
 		/* Notify supported devices they are now powered */
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_ON, NULL);
 		break;
@@ -45,6 +57,9 @@ static int pd_gpio_pm_action(const struct device *dev,
 		/* Switch power off */
 		gpio_pin_set_dt(&cfg->enable, 0);
 		LOG_DBG("%s is now OFF and powered", dev->name);
+		/* Store next time we can boot */
+		next_boot_ticks = k_uptime_ticks() + k_us_to_ticks_ceil32(cfg->off_on_delay_us);
+		data->next_boot = K_TIMEOUT_ABS_TICKS(next_boot_ticks);
 		break;
 	case PM_DEVICE_ACTION_TURN_ON:
 		/* Actively control the enable pin now that the device is powered */
@@ -66,12 +81,15 @@ static int pd_gpio_pm_action(const struct device *dev,
 static int pd_gpio_init(const struct device *dev)
 {
 	const struct pd_gpio_config *cfg = dev->config;
+	struct pd_gpio_data *data = dev->data;
 	int rc;
 
 	if (!device_is_ready(cfg->enable.port)) {
 		LOG_ERR("GPIO port %s is not ready", cfg->enable.port->name);
 		return -ENODEV;
 	}
+	/* We can't know how long the domain has been off for before boot */
+	data->next_boot = K_TIMEOUT_ABS_US(cfg->off_on_delay_us);
 
 	if (pm_device_on_power_domain(dev)) {
 		/* Device is unpowered */

--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -25,14 +25,6 @@ struct pd_gpio_data {
 	k_timeout_t last_boot;
 };
 
-const char *actions[] = {
-	[PM_DEVICE_ACTION_RESUME] = "RESUME",
-	[PM_DEVICE_ACTION_SUSPEND] = "SUSPEND",
-	[PM_DEVICE_ACTION_TURN_ON] = "TURN ON",
-	[PM_DEVICE_ACTION_TURN_OFF] = "TURN OFF"
-};
-
-
 static int pd_gpio_pm_action(const struct device *dev,
 			     enum pm_device_action action)
 {

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -465,6 +465,19 @@ __syscall int32_t k_usleep(int32_t us);
 __syscall void k_busy_wait(uint32_t usec_to_wait);
 
 /**
+ * @brief Check whether it is possible to yield in the current context.
+ *
+ * This routine checks whether the kernel is in a state where it is possible to
+ * yield or call blocking API's. It should be used by code that needs to yield
+ * to perform correctly, but can feasibly be called from contexts where that
+ * is not possible. For example in the PRE_KERNEL initialization step, or when
+ * being run from the idle thread.
+ *
+ * @return True if it is possible to yield in the current context, false otherwise.
+ */
+bool k_can_yield(void);
+
+/**
  * @brief Yield the current thread.
  *
  * This routine causes the current thread to yield execution to another

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1325,6 +1325,12 @@ static inline void z_vrfy_k_thread_deadline_set(k_tid_t tid, int deadline)
 #endif
 #endif
 
+bool k_can_yield(void)
+{
+	return !(k_is_pre_kernel() || k_is_in_isr() ||
+		 z_is_idle_thread_object(_current));
+}
+
 void z_impl_k_yield(void)
 {
 	__ASSERT(!arch_is_in_isr(), "");

--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -42,6 +42,7 @@
 #define EXEC_CTX_TYPE_CMD  1
 
 #define UNKNOWN_COMMAND    -1
+#define INVALID_BEHAVIOUR  -2
 
 /*
  * Get the timer type dependent IRQ number. If timer type
@@ -226,6 +227,10 @@ static void test_kernel_cpu_idle_atomic(void);
 static void isr_handler(const void *data)
 {
 	ARG_UNUSED(data);
+
+	if (k_can_yield()) {
+		isr_info.error = INVALID_BEHAVIOUR;
+	}
 
 	switch (isr_info.command) {
 	case THREAD_SELF_CMD:
@@ -816,6 +821,11 @@ static void k_yield_entry(void *arg0, void *arg1, void *arg2)
 
 	zassert_equal(thread_evidence, 0,
 		      "Helper created at higher priority ran prematurely.");
+
+	/*
+	 * Validate the thread is allowed to yield
+	 */
+	zassert_true(k_can_yield(), "Thread incorrectly detected it could not yield");
 
 	/*
 	 * Test that the thread will yield to the higher priority helper.

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -135,6 +135,7 @@ static struct init_record {
 	bool pre_kernel;
 	bool is_in_isr;
 	bool is_pre_kernel;
+	bool could_yield;
 } init_records[4];
 
 __pinned_data
@@ -146,6 +147,7 @@ static int add_init_record(bool pre_kernel)
 	rp->pre_kernel = pre_kernel;
 	rp->is_pre_kernel = k_is_pre_kernel();
 	rp->is_in_isr = k_is_in_isr();
+	rp->could_yield = k_can_yield();
 	++rp;
 	return 0;
 }
@@ -205,6 +207,8 @@ void test_pre_kernel_detection(void)
 			      "rec %zu isr", rp - init_records);
 		zassert_equal(rp->is_pre_kernel, true,
 			      "rec %zu pre-kernel", rp - init_records);
+		zassert_equal(rp->could_yield, false,
+			      "rec %zu could-yield", rp - init_records);
 		++rp;
 	}
 	zassert_equal(rp - init_records, 2U,
@@ -215,6 +219,8 @@ void test_pre_kernel_detection(void)
 			      "rec %zu isr", rp - init_records);
 		zassert_equal(rp->is_pre_kernel, false,
 			      "rec %zu post-kernel", rp - init_records);
+		zassert_equal(rp->could_yield, true,
+			      "rec %zu could-yield", rp - init_records);
 		++rp;
 	}
 }

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -213,6 +213,7 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 	/* make sure this is idle thread */
 	zassert_true(z_is_idle_thread_object(_current), NULL);
 	zassert_true(ticks == _kernel.idle, NULL);
+	zassert_false(k_can_yield(), NULL);
 	idle_entered = true;
 
 	if (enter_low_power) {


### PR DESCRIPTION
Update the GPIO power domain to respect the on-off and startup times specified in devicetree.