### PR TITLE
soc: esp32: add snippets into linker script

### DIFF
--- a/soc/riscv/esp32c3/linker.ld
+++ b/soc/riscv/esp32c3/linker.ld
@@ -184,6 +184,9 @@ SECTIONS
     __esp_shell_root_cmds_end = .;
 
     . = ALIGN(4);
+    #include <snippets-rodata.ld>
+
+    . = ALIGN(4);
     *(EXCLUDE_FILE (*libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.*) .rodata)
     *(EXCLUDE_FILE (*libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.*) .rodata.*)
 
@@ -354,6 +357,8 @@ SECTIONS
     . = ALIGN(4);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+  #include <snippets-sections.ld>
+
   .dram0.data :
   {
     . = ALIGN(4);
@@ -398,7 +403,10 @@ SECTIONS
   #include <linker/common-rom.ld>
   #pragma pop_macro("GROUP_ROM_LINK_IN")
   #pragma pop_macro("ITERABLE_SECTION_ROM")
+
+  #include <snippets-data-sections.ld>
   #include <linker/common-ram.ld>
+  #include <snippets-ram-sections.ld>
 
   __shell_root_cmds_start = __esp_shell_root_cmds_start;
   __shell_root_cmds_end = __esp_shell_root_cmds_end;
@@ -406,6 +414,7 @@ SECTIONS
   .dummy.dram.data :
   {
     . = ALIGN(4);
+    #include <snippets-rwdata.ld>
     _data_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -204,6 +204,9 @@ SECTIONS
     __esp_shell_root_cmds_end = .;
 
     . = ALIGN(4);
+    #include <snippets-rodata.ld>
+
+    . = ALIGN(4);
     *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.*) .rodata)
     *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.*) .rodata.*)
 
@@ -239,6 +242,8 @@ SECTIONS
   _image_dram_start = LOADADDR(".dram0.data");
   _image_dram_size = LOADADDR(".dummy.dram.data") + SIZEOF(".dummy.dram.data") - _image_dram_start;
   _image_dram_vaddr = ADDR(".dram0.data");
+
+  #include <snippets-sections.ld>
 
   .dram0.data :
   {
@@ -288,13 +293,18 @@ SECTIONS
   #include <linker/common-rom.ld>
   #pragma pop_macro("GROUP_ROM_LINK_IN")
   #pragma pop_macro("ITERABLE_SECTION_ROM")
+
+  #include <snippets-data-sections.ld>
   #include <linker/common-ram.ld>
+  #include <snippets-ram-sections.ld>
 
   __shell_root_cmds_start = __esp_shell_root_cmds_start;
   __shell_root_cmds_end = __esp_shell_root_cmds_end;
 
   .dummy.dram.data :
   {
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
     . = ALIGN(4);
     _data_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/soc/xtensa/esp32s2/linker.ld
+++ b/soc/xtensa/esp32s2/linker.ld
@@ -196,6 +196,9 @@ SECTIONS
     __esp_shell_root_cmds_end = .;
 
     . = ALIGN(4);
+    #include <snippets-rodata.ld>
+
+    . = ALIGN(4);
     *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.*) .rodata)
     *(EXCLUDE_FILE (*libarch__xtensa__core.a:* *libkernel.a:fatal.* *libkernel.a:init.* *libzephyr.a:cbprintf_complete* *libzephyr.a:log_core.* *libzephyr.a:log_backend_uart.* *libzephyr.a:log_output.* *libzephyr.a:loader.* *libdrivers__flash.a:flash_esp32.* *libdrivers__serial.a:uart_esp32.*) .rodata.*)
 
@@ -376,6 +379,8 @@ SECTIONS
     . = ALIGN(8);
   } GROUP_LINK_IN(RAMABLE_REGION)
 
+#include <snippets-sections.ld>
+
   .dram0.data :
   {
     _data_start = ABSOLUTE(.);
@@ -417,13 +422,18 @@ SECTIONS
   #include <linker/common-rom.ld>
   #pragma pop_macro("GROUP_ROM_LINK_IN")
   #pragma pop_macro("ITERABLE_SECTION_ROM")
+
+  #include <snippets-data-sections.ld>
   #include <linker/common-ram.ld>
+  #include <snippets-ram-sections.ld>
 
   __shell_root_cmds_start = __esp_shell_root_cmds_start;
   __shell_root_cmds_end = __esp_shell_root_cmds_end;
 
   .dummy.dram.data :
   {
+    . = ALIGN(4);
+    #include <snippets-rwdata.ld>
     . = ALIGN(4);
     _data_end = ABSOLUTE(.);
   } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)


### PR DESCRIPTION
Add linker script snippets includes.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>