### PR TITLE
logging: backend_uart: configurable buffer size

### DIFF
--- a/subsys/logging/Kconfig.backends
+++ b/subsys/logging/Kconfig.backends
@@ -17,6 +17,14 @@ config LOG_BACKEND_UART_ASYNC
 	depends on UART_ASYNC_API
 	depends on !LOG_BACKEND_UART_OUTPUT_DICTIONARY_HEX
 
+config LOG_BACKEND_UART_BUFFER_SIZE
+	int "Number of bytes to buffer in RAM before flushing"
+	default 32 if LOG_BACKEND_UART_ASYNC
+	default 1
+	help
+	  Sets the number of bytes which can be buffered in RAM before log_output_flush
+	  is automatically called on the backend.
+
 backend = UART
 backend-str = uart
 source "subsys/logging/Kconfig.template.log_format_config"

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -87,7 +87,7 @@ static int char_out(uint8_t *data, size_t length, void *ctx)
 	return length;
 }
 
-static uint8_t uart_output_buf[IS_ENABLED(CONFIG_LOG_BACKEND_UART_ASYNC) ? 32 : 1];
+static uint8_t uart_output_buf[CONFIG_LOG_BACKEND_UART_BUFFER_SIZE];
 LOG_OUTPUT_DEFINE(log_output_uart, char_out, uart_output_buf, sizeof(uart_output_buf));
 
 static void put(const struct log_backend *const backend,


### PR DESCRIPTION
Update the UART RAM buffer size to be user configurable from Kconfig.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>