### PR TITLE
twister: make git describe work without tags present

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2825,7 +2825,7 @@ class TestSuite(DisablePyTestCollectionMixin):
 
     def check_zephyr_version(self):
         try:
-            subproc = subprocess.run(["git", "describe", "--abbrev=12"],
+            subproc = subprocess.run(["git", "describe", "--abbrev=12", "--always"],
                                      stdout=subprocess.PIPE,
                                      universal_newlines=True,
                                      cwd=ZEPHYR_BASE)


### PR DESCRIPTION
Git has a problem in eg. shallow clones that git describe throws a fatal error when there are no tags. This can be fixed by adding the "--always" argument, which has been done to the cmake files, but not to twister.