### PR TITLE
BT510 fixups

### DIFF
--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -36,7 +36,7 @@
 
 	buttons {
 		compatible = "gpio-keys";
-		button1: button_1 {
+		button0: button_0 {
 			gpios = <&gpio1 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 1 (SW1)";
 		};
@@ -79,7 +79,7 @@
 	aliases {
 		led0 = &led1a;
 		led1 = &led1b;
-		sw0 = &button1;
+		sw0 = &button0;
 	};
 };
 

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -119,6 +119,7 @@
 		irq-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>,
 				<&gpio1 12 GPIO_ACTIVE_HIGH>;
 		label = "LIS2DH12";
+		disconnect-sdo-sa0-pull-up;
 	};
 
 	si7055@40 {

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -37,7 +37,7 @@
 	buttons {
 		compatible = "gpio-keys";
 		button1: button_1 {
-			gpios = <&gpio1 10 GPIO_PULL_UP>;
+			gpios = <&gpio1 10 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Push button switch 1 (SW1)";
 		};
 	};
@@ -45,15 +45,15 @@
 	ids {
 		compatible = "gpio-keys";
 		id0: id_0 {
-			gpios = <&gpio1 2 GPIO_PULL_UP>;
+			gpios = <&gpio1 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "ID 0";
 		};
 		id1: id_1 {
-			gpios = <&gpio1 1 GPIO_PULL_UP>;
+			gpios = <&gpio1 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "ID 1";
 		};
 		id2: id_2 {
-			gpios = <&gpio0 25 GPIO_PULL_UP>;
+			gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "ID 2";
 		};
 	};
@@ -61,7 +61,7 @@
 	tm {
 		compatible = "gpio-keys";
 		tm0: tm_0 {
-			gpios = <&gpio0 3 GPIO_PULL_UP>;
+			gpios = <&gpio0 3 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 			label = "Test mode (TM)";
 		};
 	};

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -100,7 +100,7 @@
 };
 
 &uart0 {
-	compatible = "nordic,nrf-uart";
+	compatible = "nordic,nrf-uarte";
 	current-speed = <115200>;
 	status = "okay";
 	tx-pin = <6>;
@@ -108,7 +108,7 @@
 };
 
 &i2c0 {
-	compatible = "nordic,nrf-twi";
+	compatible = "nordic,nrf-twim";
 	status = "okay";
 	sda-pin = <26>;
 	scl-pin = <27>;

--- a/boards/arm/bt510/bt510_defconfig
+++ b/boards/arm/bt510/bt510_defconfig
@@ -7,30 +7,15 @@ CONFIG_BOARD_BT510=y
 # Enable MPU
 CONFIG_ARM_MPU=y
 
-# Enable RTT
-CONFIG_USE_SEGGER_RTT=y
-
 # Enable GPIO
 CONFIG_GPIO=y
 
 # Enable uart driver
 CONFIG_SERIAL=y
 
-# Enable accelerometer & temperature sensor
-CONFIG_I2C=y
-CONFIG_SENSOR=y
-CONFIG_LIS2DH=y
-CONFIG_LIS2DH_TRIGGER_GLOBAL_THREAD=y
-CONFIG_LIS2DH_OPER_MODE_LOW_POWER=y
-CONFIG_SI7055=y
-
-# Enable magnetoresistive driver
-CONFIG_SM351LT=y
-
 # Enable console
 CONFIG_CONSOLE=y
 CONFIG_UART_CONSOLE=y
-CONFIG_RTT_CONSOLE=y
 
 # Additional board options
 CONFIG_GPIO_AS_PINRESET=y


### PR DESCRIPTION
Various updates to fix issues in the BT510 board file, resolves https://github.com/zephyrproject-rtos/zephyr/issues/43742
 * Disables SAO pull-up resistor inside lis2dh sensor
 * Add active low flags to GPIO inputs
 * Switch from UART and TWI to UARTE and TWIM
 * Disable peripherals being enabled by default in the defconfig file