### PR TITLE
usb: cdc_acm: fix bug on transmission

### DIFF
--- a/subsys/usb/device/class/cdc_acm.c
+++ b/subsys/usb/device/class/cdc_acm.c
@@ -243,6 +243,8 @@ static void tx_work_handler(struct k_work *work)
 		return;
 	}
 
+	dev_data->tx_ready = false;
+
 	/*
 	 * Transfer less data to avoid zero-length packet. The application
 	 * running on the host may conclude that there is no more data to be


### PR DESCRIPTION
The bug could be triggered in this situation, where an user wants to send some data
```
 User thread                   USB worker                USB interrupt
1) User enable tx
2) cdc_acm_irq_tx_enable
    -> submit cb_work
                     3) cdc_acm_irq_callback_work_handler
                             -> call uart callback
                     4) User uart callback
                        tx_ready is ready so the user use
                        fifo_fill to send data
                     5) cdc_acm_fifo_fill
                        - tx_ready is set to false
                        - Data are put in ring buffer
                        - work tx_work is submit
                     6) tx_work_handler is executed
                        - ringbuffer data are claimed
                        - start usb transfer
                        - ringbuffer data are finished
                                                7) cdc_acm_write_cb
                                                    - tx_ready is set to true
                                                    - User callback is called
                                                    - Nothing to send,
						      the user disable tx
                                                    - ringbuffer not empty
                                                       work tx_work is submit
                     9) tx_work_handler is executed
                        - ringbuffer data are claimed
                        - start usb transfer
                        - ringbuffer data are finished
                          Now, we are in a dangerous situation
                          because tx_ready is on true state and data
                          released in ringbuffer are being transmitted
10) User enable tx
11) cdc_acm_irq_tx_enable
     -> submit cb_work

                      12) cdc_acm_irq_callback_work_handler
                          -> call uart callback
                      13) User uart callback
                          tx_ready is ready so the user could used
                          fifo_fill to send data.
                      14) cdc_acm_fifo_fill
                          Some ringbuffer data are being tranferred to USB.
                          The call to ring_buf_put could rewrite this data
```
Signed-off-by: Julien D'Ascenzio <julien.dascenzio@paratronic.fr>