### PR TITLE
scripts: twister: valgrind improvements

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -558,7 +558,8 @@ class BinaryHandler(Handler):
             command = ["valgrind", "--error-exitcode=2",
                        "--leak-check=full",
                        "--suppressions=" + ZEPHYR_BASE + "/scripts/valgrind.supp",
-                       "--log-file=" + self.build_dir + "/valgrind.log"
+                       "--log-file=" + self.build_dir + "/valgrind.log",
+                       "--track-origins=yes",
                        ] + command
             run_valgrind = True
 

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -609,13 +609,14 @@ class BinaryHandler(Handler):
         self.instance.results = harness.tests
 
         if not self.terminated and self.returncode != 0:
-            # When a process is killed, the default handler returns 128 + SIGTERM
-            # so in that case the return code itself is not meaningful
-            self.set_state("failed", handler_time)
-            self.instance.reason = "Failed"
-        elif run_valgrind and self.returncode == 2:
-            self.set_state("failed", handler_time)
-            self.instance.reason = "Valgrind error"
+            if run_valgrind and self.returncode == 2:
+                self.set_state("failed", handler_time)
+                self.instance.reason = "Valgrind error"
+            else:
+                # When a process is killed, the default handler returns 128 + SIGTERM
+                # so in that case the return code itself is not meaningful
+                self.set_state("failed", handler_time)
+                self.instance.reason = "Failed"
         elif harness.state:
             self.set_state(harness.state, handler_time)
             if harness.state == "failed":

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -554,7 +554,7 @@ class BinaryHandler(Handler):
             command = [self.binary]
 
         run_valgrind = False
-        if self.valgrind and shutil.which("valgrind"):
+        if self.valgrind:
             command = ["valgrind", "--error-exitcode=2",
                        "--leak-check=full",
                        "--suppressions=" + ZEPHYR_BASE + "/scripts/valgrind.supp",

--- a/scripts/twister
+++ b/scripts/twister
@@ -878,6 +878,10 @@ def main():
         logger.error("west-flash requires device-testing to be enabled")
         sys.exit(1)
 
+    if options.enable_valgrind and not shutil.which("valgrind"):
+        logger.error("valgrind enabled but valgrind executable not found")
+        sys.exit(1)
+
     if options.coverage:
         options.enable_coverage = True
 


### PR DESCRIPTION
A few improvements to twister's valgrind integration:

* warn if no valgrind executable is found
* log path to valgrind.log on failures during valgrind step
* add `--track-origins=yes` to valgrind options

Adding `--track-origins=yes` will make valgrind execution a bit slower but will provide much more valuable information on failures.