### PR TITLE
boards: arm: nrf: Add missing ram and flash sizes in a few nRF DKs

### DIFF
--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 ram: 32
+flash: 256
 supported:
   - adc
   - ble

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.yaml
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.yaml
@@ -7,6 +7,7 @@ toolchain:
   - gnuarmemb
   - xtools
 ram: 32
+flash: 256
 supported:
   - ble
   - nvs

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.yaml
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.yaml
@@ -2,6 +2,8 @@ identifier: nrf52833dk_nrf52833
 name: nRF52833-DK-NRF52833
 type: mcu
 arch: arm
+ram: 128
+flash: 512
 toolchain:
   - zephyr
   - gnuarmemb


### PR DESCRIPTION
Definitions of several nRF DK boards are missing flash and ram sizes.
This commit adds those missing entries.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>