### PR TITLE
lib: os: assert: Decouple header from printk.h

### DIFF
--- a/include/sys/__assert.h
+++ b/include/sys/__assert.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_SYS___ASSERT_H_
 
 #include <stdbool.h>
-#include <sys/printk.h>
+#include <toolchain.h>
 
 #ifdef CONFIG_ASSERT
 #ifndef __ASSERT_ON
@@ -21,8 +21,19 @@
 #define __ASSERT_ON 0
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Wrapper around printk to avoid including printk.h in assert.h */
+void assert_print(const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
+
 #if defined(CONFIG_ASSERT_VERBOSE)
-#define __ASSERT_PRINT(fmt, ...) printk(fmt, ##__VA_ARGS__)
+#define __ASSERT_PRINT(fmt, ...) assert_print(fmt, ##__VA_ARGS__)
 #else /* CONFIG_ASSERT_VERBOSE */
 #define __ASSERT_PRINT(fmt, ...)
 #endif /* CONFIG_ASSERT_VERBOSE */
@@ -63,8 +74,6 @@
 #endif
 
 #if __ASSERT_ON
-
-#include <sys/printk.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/sys/cbprintf_internal.h
+++ b/include/sys/cbprintf_internal.h
@@ -359,6 +359,7 @@ union z_cbprintf_hdr {
  * multiple times. VLA is not always available.
  */
 #define Z_CBPRINTF_ON_STACK_ALLOC(_name, _len) \
+	__ASSERT(_len <= 32, "Too many string arguments."); \
 	uint8_t _name##_buf4[4]; \
 	uint8_t _name##_buf8[8]; \
 	uint8_t _name##_buf12[12]; \

--- a/lib/os/assert.c
+++ b/lib/os/assert.c
@@ -5,6 +5,7 @@
  */
 
 #include <sys/__assert.h>
+#include <sys/printk.h>
 #include <zephyr.h>
 
 
@@ -40,4 +41,15 @@ __weak void assert_post_action(const char *file, unsigned int line)
 #endif
 
 	k_panic();
+}
+
+void assert_print(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+
+	vprintk(fmt, ap);
+
+	va_end(ap);
 }

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -206,11 +206,20 @@ config ASSERT
 	  Disabling this option will cause assertions to compile to nothing,
 	  improving performance and system footprint.
 
+config FORCE_NO_ASSERT
+	bool "Force-disable no assertions"
+	help
+	  This boolean option disables Zephyr assertion testing even
+	  in circumstances (twister) where it is enabled via
+	  CFLAGS and not Kconfig.  Added solely to be able to work
+	  around compiler bugs for specific tests.
+
+if ASSERT
+
 config ASSERT_LEVEL
 	int "__ASSERT() level"
 	default 2
 	range 0 2
-	depends on ASSERT
 	help
 	  This option specifies the assertion level used by the __ASSERT()
 	  macro. It can be set to one of three possible values:
@@ -221,7 +230,6 @@ config ASSERT_LEVEL
 
 config SPIN_VALIDATE
 	bool "Spinlock validation"
-	depends on ASSERT
 	depends on MULTITHREADING
 	depends on MP_NUM_CPUS <= 4
 	default y if !FLASH || FLASH_SIZE > 32
@@ -229,14 +237,6 @@ config SPIN_VALIDATE
 	  There's a spinlock validation framework available when asserts are
 	  enabled. It adds a relatively hefty overhead (about 3k or so) to
 	  kernel code size, don't use on platforms known to be small.
-
-config FORCE_NO_ASSERT
-	bool "Force-disable no assertions"
-	help
-	  This boolean option disables Zephyr assertion testing even
-	  in circumstances (twister) where it is enabled via
-	  CFLAGS and not Kconfig.  Added solely to be able to work
-	  around compiler bugs for specific tests.
 
 config ASSERT_VERBOSE
 	bool "Verbose assertions"
@@ -271,6 +271,8 @@ config ASSERT_NO_MSG_INFO
 	  necessary for tiny targets. It is recommended to disable message
 	  before disabling file info since the message can be found in the
 	  source using file info.
+
+endif # ASSERT
 
 config OVERRIDE_FRAME_POINTER_DEFAULT
 	bool "Override compiler defaults for -fomit-frame-pointer"


### PR DESCRIPTION
Based on #43759

Remove `printk.h` include from `__assert.h`. 

Add assert to `Z_CBPRINTF_ON_STACK_ALLOC` macro.