### PR TITLE
cmake: remove base_name for dep file

### DIFF
--- a/cmake/linker/arcmwdt/target.cmake
+++ b/cmake/linker/arcmwdt/target.cmake
@@ -30,7 +30,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   endif()
 
   zephyr_get_include_directories_for_lang(C current_includes)
-  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
 # the command to generate linker file from template
@@ -46,7 +45,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -x c
     ${NOSYSDEF_CFLAG}
     -Hnocopyr
-    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+    -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
     -imacros ${AUTOCONF_H}

--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -29,7 +29,6 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
   endif()
 
   zephyr_get_include_directories_for_lang(C current_includes)
-  get_filename_component(base_name ${CMAKE_CURRENT_BINARY_DIR} NAME)
   get_property(current_defines GLOBAL PROPERTY PROPERTY_LINKER_SCRIPT_DEFINES)
 
   add_custom_command(
@@ -42,7 +41,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     COMMAND ${CMAKE_C_COMPILER}
     -x assembler-with-cpp
     ${NOSYSDEF_CFLAG}
-    -MD -MF ${linker_script_gen}.dep -MT ${base_name}/${linker_script_gen}
+    -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
     ${current_includes}


### PR DESCRIPTION
With CMake 3.20 relative path inside DEPFILEs are treated relative to
CMAKE_CURRENT_BINARY_DIR and are transformed by CMake in its internal
dep file.

Therefore Zephyr build system must no longer add `base_name` to the
`-MT` argument for the preprocessor.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>