### PR TITLE
Bluetooth: bap: Remove EATT dependency

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.baps
+++ b/subsys/bluetooth/audio/Kconfig.baps
@@ -10,10 +10,7 @@ config BT_AUDIO_UNICAST
 	bool
 	depends on BT_CONN
 	select BT_SMP
-	select BT_L2CAP_DYNAMIC_CHANNEL
 	select BT_ISO_UNICAST
-	select BT_L2CAP_ECRED
-	select BT_EATT
 
 config BT_AUDIO_UNICAST_SERVER
 	bool "Bluetooth Unicast Audio Server Support [EXPERIMENTAL]"

--- a/subsys/bluetooth/host/Kconfig.l2cap
+++ b/subsys/bluetooth/host/Kconfig.l2cap
@@ -32,6 +32,7 @@ config BT_L2CAP_TX_MTU
 	default 253 if BT_BREDR
 	default 69 if BT_MESH_GATT
 	default 65 if BT_SMP
+	default 64 if BT_AUDIO_UNICAST_SERVER || BT_AUDIO_UNICAST_CLIENT || BT_AUDIO_BROADCAST_SINK || BT_BASS || BT_BASS_CLIENT
 	default 23
 	range 65 2000 if BT_SMP
 	range 23 2000


### PR DESCRIPTION
The EATT support is optional for BAP. The specification mandates the
minimum MTU supported to be 64 bytes.

As per BAP_v1.0
"The Unicast Server shall support a minimum ATT_MTU of 64 octets for
one Unenhanced ATT bearer, or for at least one Enhanced ATT bearer
if the Unicast Server supports Enhanced ATT bearers."

The same applies for other BAP roles.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>