### PR TITLE
tests: drivers: flash on stm32 target boards

### DIFF
--- a/tests/drivers/flash/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/flash/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 8KB of storage at the end of 2MB flash */
+		storage_partition: partition@1fe000 {
+			label = "storage";
+			reg = <0x01fe000 0x00002000>;
+		};
+	};
+};

--- a/tests/drivers/flash/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/flash/boards/disco_l475_iot1.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 4KB of storage at the end of 1MB flash */
+		storage_partition: partition@ff000 {
+			label = "storage";
+			reg = <0x00ff000 0x00001000>;
+		};
+	};
+};

--- a/tests/drivers/flash/boards/nucleo_f746zg.overlay
+++ b/tests/drivers/flash/boards/nucleo_f746zg.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 64KB of storage at the end of 1MB flash */
+		storage_partition: partition@2f0000 {
+			label = "storage";
+			reg = <0x002f0000 0x00010000>;
+		};
+	};
+};

--- a/tests/drivers/flash/boards/nucleo_l073rz.overlay
+++ b/tests/drivers/flash/boards/nucleo_l073rz.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Set 2KB of storage at the end of 192KB flash */
+		storage_partition: partition@2f800 {
+			label = "storage";
+			reg = <0x0002f800 0x00000800>;
+		};
+	};
+};
+


### PR DESCRIPTION
Configure nucleo_l073, nucleo_f746zg, disco_l475, disco b_u585i
boards with overlay for a flash partition
to execute the tests/drivers/flash

Signed-off-by: Francois Ramu <francois.ramu@st.com>