### PR TITLE
wifi: fix build error on wifi_winc1500_nm_bsp_internal.h

### DIFF
--- a/drivers/wifi/winc1500/CMakeLists.txt
+++ b/drivers/wifi/winc1500/CMakeLists.txt
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_WIFI_WINC1500)
-  zephyr_library_include_directories(./)
+  zephyr_include_directories(./)
 
   zephyr_library_sources(
     wifi_winc1500_nm_bsp.c


### PR DESCRIPTION
Previous commit 579ca90e25271a693044667418acef69669f353e to
build wifi drivers as a library changed the include path for
the WINC1500 driver, which results in the include path being
local to the library. However, the Atmel HAL requires
wifi_winc1500_nm_bsp_internal.h to in the search path. So
change the include path to be global.

Fixes #43456

Signed-off-by: Daniel Leung <daniel.leung@intel.com>