### PR TITLE
west.yaml: hal_stm32: STM32Cube packages update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: f1cae48438a1ababa5e27b261f9e2d172afe6cf7
+      revision: 13964e0af173f19fafad3692869e8486f3c2043d
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
- update stm32l4 to cube version V1.17.1
- update stm32wb to cube version V1.13.2 (including hci lib)
- update stm32f4 to cube version V1.27.0
- update stm32u5 to cube version V1.1.0
- update stm32g4 to cube version V1.5.0
- update stm32h7 to cube version V1.10.0
- update stm32f7 to cube version V1.16.2

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>