### PR TITLE
Bluetooth: Audio: Include documentation in doxygen

### DIFF
--- a/doc/reference/bluetooth/audio.rst
+++ b/doc/reference/bluetooth/audio.rst
@@ -1,0 +1,10 @@
+.. _bluetooth_audio:
+
+Bluetooth Audio
+####################
+
+
+API Reference
+*************
+
+.. doxygengroup:: bt_audio

--- a/doc/reference/bluetooth/index.rst
+++ b/doc/reference/bluetooth/index.rst
@@ -6,6 +6,7 @@ Bluetooth
 .. toctree::
    :maxdepth: 1
 
+   audio.rst
    connection_mgmt.rst
    controller.rst
    crypto.rst

--- a/include/bluetooth/audio/audio.h
+++ b/include/bluetooth/audio/audio.h
@@ -1316,8 +1316,8 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 int bt_audio_unicast_server_location_changed(enum bt_audio_pac_type type);
 
 /**
- * @defgroup bt_audio_client Audio Client APIs
- * @ingroup bt_audio
+ * @name Audio Client APIs
+ * @anchor bt_audio_client
  * @{
  */
 
@@ -1581,6 +1581,13 @@ int bt_audio_unicast_group_remove_streams(struct bt_audio_unicast_group *unicast
  */
 int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group);
 
+/** @} */ /* End of group bt_audio_client */
+/**
+ * @name Audio Broadcast APIs
+ * @anchor bt_audio_broadcast
+ * @{
+ */
+
 /** @brief Create audio broadcast source.
  *
  *  Create a new audio broadcast source with one or more audio streams.
@@ -1736,14 +1743,13 @@ int bt_audio_broadcast_sink_stop(struct bt_audio_broadcast_sink *sink);
  */
 int bt_audio_broadcast_sink_delete(struct bt_audio_broadcast_sink *sink);
 
-/** @} */
+/** @} */ /* End of group bt_audio_broadcast */
 
 #ifdef __cplusplus
 }
 #endif
 
-/**
- * @}
- */
+/** @} */ /* end of bt_audio */
+
 
 #endif /* ZEPHYR_INCLUDE_BLUETOOTH_AUDIO_H_ */


### PR DESCRIPTION
A reference to the documentaation in audio.h was missing.
This change adds that reference and removes the use of sub-sections
which do not seem supported.

Signed-off-by: Casper Bonde <casper_bonde@bose.com>