### PR TITLE
net: lwm2m: update client tx timestamp before sending message

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1025,6 +1025,12 @@ cleanup:
 int lwm2m_send_message_async(struct lwm2m_message *msg)
 {
 	sys_slist_append(&msg->ctx->pending_sends, &msg->node);
+
+	if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT) &&
+	    IS_ENABLED(CONFIG_LWM2M_QUEUE_MODE_ENABLED)) {
+		engine_update_tx_time();
+	}
+
 	return 0;
 }
 
@@ -1054,11 +1060,6 @@ static int lwm2m_send_message(struct lwm2m_message *msg)
 
 	if (msg->type != COAP_TYPE_CON) {
 		lwm2m_reset_message(msg, true);
-	}
-
-	if (IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT) &&
-	    IS_ENABLED(CONFIG_LWM2M_QUEUE_MODE_ENABLED)) {
-		engine_update_tx_time();
 	}
 
 	return 0;


### PR DESCRIPTION
TX timestamp tracking mechanisms predates async socket io introduction.
Timestamp tracking is needed for notifying client when RX can be
shut down. Since the check is performed inside registration done
state, TX timestamp is invalid so we update it directly.

Signed-off-by: Marin Jurjević <marin.jurjevic@hotmail.com>