### PR TITLE
MAINTAINERS: remove myself from the riscv collaborator group

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1346,7 +1346,6 @@ RISCV arch:
         - fkokosinski
         - mgielda
         - katsuster
-        - henrikbrixandersen
         - edersondisouza
     files:
         - arch/riscv/


### PR DESCRIPTION
Remove myself from the RISC-V collaborator group due to lack of time.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>