### PR TITLE
Libs: mem_blocks library extensions

### DIFF
--- a/include/sys/bitarray.h
+++ b/include/sys/bitarray.h
@@ -228,6 +228,31 @@ int sys_bitarray_set_region(sys_bitarray_t *bitarray, size_t num_bits,
 			    size_t offset);
 
 /**
+ * Test if all bits in a region are cleared/set and set/clear them
+ * in a single atomic operation
+ *
+ * This checks if all the bits (@p num_bits) in region starting
+ * from @p offset are in required state. If even one bit is not,
+ * -EEXIST is returned.  If the whole region is set/cleared
+ * it is set to opposite state. The check and set is performed as a single
+ * atomic operation.
+ *
+ * @param bitarray Bitarray struct
+ * @param num_bits Number of bits to test and set
+ * @param offset   Starting bit position to test and set
+ * @param to_set   if true the region will be set if all bits are cleared
+ *		   if false the region will be cleard if all bits are set
+ *
+ * @retval 0	   Operation successful
+ * @retval -EINVAL Invalid argument (e.g. bit to set exceeds
+ *		   the number of bits in bit array, etc.)
+ * @retval -EEXIST at least one bit in the region is set/cleared,
+ *		   operation cancelled
+ */
+int sys_bitarray_test_and_set_region(sys_bitarray_t *bitarray, size_t num_bits,
+				     size_t offset, bool to_set);
+
+/**
  * Clear all bits in a region.
  *
  * This clears the number of bits (@p num_bits) in region starting

--- a/include/sys/mem_blocks.h
+++ b/include/sys/mem_blocks.h
@@ -218,6 +218,22 @@ struct sys_multi_mem_blocks {
 int sys_mem_blocks_alloc(sys_mem_blocks_t *mem_block, size_t count,
 			 void **out_blocks);
 
+/**
+ * @brief Allocate a contiguous set of memory blocks
+ *
+ * Allocate multiple memory blocks, and place their pointers into
+ * the output array.
+ *
+ * @param[in]  mem_block Pointer to memory block object.
+ * @param[in]  count     Number of blocks to allocate.
+ * @param[out] out_block Output pointer to the start of the allocated block set
+ *
+ * @retval 0       Successful
+ * @retval -EINVAL Invalid argument supplied.
+ * @retval -ENOMEM Not enough contiguous blocks for allocation.
+ */
+int sys_mem_blocks_alloc_contiguous(sys_mem_blocks_t *mem_block, size_t count,
+				   void **out_block);
 
 /**
  * @brief Force allocation of a specified blocks in a memory block object
@@ -253,6 +269,21 @@ int sys_mem_blocks_get(sys_mem_blocks_t *mem_block, void *in_block, size_t count
  */
 int sys_mem_blocks_free(sys_mem_blocks_t *mem_block, size_t count,
 			void **in_blocks);
+
+/**
+ * @brief Free contiguous multiple memory blocks
+ *
+ * Free contiguous multiple memory blocks
+ *
+ * @param[in] mem_block Pointer to memory block object.
+ * @param[in] block     Pointer to the first memory block
+ * @param[in] count     Number of blocks to free.
+ *
+ * @retval 0       Successful
+ * @retval -EINVAL Invalid argument supplied.
+ * @retval -EFAULT Invalid pointer supplied.
+ */
+int sys_mem_blocks_free_contiguous(sys_mem_blocks_t *mem_block, void *block, size_t count);
 
 /**
  * @brief Initialize multi memory blocks allocator group

--- a/include/sys/mem_blocks.h
+++ b/include/sys/mem_blocks.h
@@ -218,6 +218,25 @@ struct sys_multi_mem_blocks {
 int sys_mem_blocks_alloc(sys_mem_blocks_t *mem_block, size_t count,
 			 void **out_blocks);
 
+
+/**
+ * @brief Force allocation of a specified blocks in a memory block object
+ *
+ * Allocate a specified blocks in a memory block object.
+ * Note: use caution when mixing sys_mem_blocks_get and sys_mem_blocks_alloc,
+ * allocation may take any of the free memory space
+ *
+ *
+ * @param[in]  mem_block  Pointer to memory block object.
+ * @param[in]  in_block   Address of the first required block to allocate
+ * @param[in]  count      Number of blocks to allocate.
+ *
+ * @retval 0       Successful
+ * @retval -EINVAL Invalid argument supplied.
+ * @retval -ENOMEM Some of blocks are taken and cannot be allocated
+ */
+int sys_mem_blocks_get(sys_mem_blocks_t *mem_block, void *in_block, size_t count);
+
 /**
  * @brief Free multiple memory blocks
  *

--- a/lib/os/bitarray.c
+++ b/lib/os/bitarray.c
@@ -218,6 +218,7 @@ int sys_bitarray_set_bit(sys_bitarray_t *bitarray, size_t bit)
 
 	key = k_spin_lock(&bitarray->lock);
 
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
 
 	if (bit >= bitarray->num_bits) {
@@ -243,9 +244,10 @@ int sys_bitarray_clear_bit(sys_bitarray_t *bitarray, size_t bit)
 	int ret;
 	size_t idx, off;
 
-	key = k_spin_lock(&bitarray->lock);
-
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
+	key = k_spin_lock(&bitarray->lock);
 
 	if (bit >= bitarray->num_bits) {
 		ret = -EINVAL;
@@ -270,9 +272,10 @@ int sys_bitarray_test_bit(sys_bitarray_t *bitarray, size_t bit, int *val)
 	int ret;
 	size_t idx, off;
 
-	key = k_spin_lock(&bitarray->lock);
-
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
+	key = k_spin_lock(&bitarray->lock);
 
 	CHECKIF(val == NULL) {
 		ret = -EINVAL;
@@ -306,9 +309,10 @@ int sys_bitarray_test_and_set_bit(sys_bitarray_t *bitarray, size_t bit, int *pre
 	int ret;
 	size_t idx, off;
 
-	key = k_spin_lock(&bitarray->lock);
-
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
+	key = k_spin_lock(&bitarray->lock);
 
 	CHECKIF(prev_val == NULL) {
 		ret = -EINVAL;
@@ -344,9 +348,10 @@ int sys_bitarray_test_and_clear_bit(sys_bitarray_t *bitarray, size_t bit, int *p
 	int ret;
 	size_t idx, off;
 
-	key = k_spin_lock(&bitarray->lock);
-
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
+	key = k_spin_lock(&bitarray->lock);
 
 	CHECKIF(prev_val == NULL) {
 		ret = -EINVAL;
@@ -386,9 +391,10 @@ int sys_bitarray_alloc(sys_bitarray_t *bitarray, size_t num_bits,
 	size_t off_start, off_end;
 	size_t mismatch;
 
-	key = k_spin_lock(&bitarray->lock);
-
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
+	key = k_spin_lock(&bitarray->lock);
 
 	CHECKIF(offset == NULL) {
 		ret = -EINVAL;
@@ -457,9 +463,10 @@ int sys_bitarray_free(sys_bitarray_t *bitarray, size_t num_bits,
 	size_t off_end = offset + num_bits - 1;
 	struct bundle_data bd;
 
-	key = k_spin_lock(&bitarray->lock);
-
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
+	key = k_spin_lock(&bitarray->lock);
 
 	if ((num_bits == 0)
 	    || (num_bits > bitarray->num_bits)
@@ -493,6 +500,7 @@ static bool is_region_set_clear(sys_bitarray_t *bitarray, size_t num_bits,
 	size_t off_end = offset + num_bits - 1;
 	k_spinlock_key_t key = k_spin_lock(&bitarray->lock);
 
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
 
 	if ((num_bits == 0)
@@ -529,6 +537,7 @@ static int set_clear_region(sys_bitarray_t *bitarray, size_t num_bits,
 	size_t off_end = offset + num_bits - 1;
 	k_spinlock_key_t key = k_spin_lock(&bitarray->lock);
 
+	__ASSERT_NO_MSG(bitarray != NULL);
 	__ASSERT_NO_MSG(bitarray->num_bits > 0);
 
 	if ((num_bits == 0)
@@ -554,10 +563,12 @@ int sys_bitarray_test_and_set_region(sys_bitarray_t *bitarray, size_t num_bits,
 	bool region_clear;
 	struct bundle_data bd;
 
+	__ASSERT_NO_MSG(bitarray != NULL);
+	__ASSERT_NO_MSG(bitarray->num_bits > 0);
+
 	size_t off_end = offset + num_bits - 1;
 	k_spinlock_key_t key = k_spin_lock(&bitarray->lock);
 
-	__ASSERT_NO_MSG(bitarray->num_bits > 0);
 
 	if ((num_bits == 0)
 	    || (num_bits > bitarray->num_bits)

--- a/lib/os/mem_blocks.c
+++ b/lib/os/mem_blocks.c
@@ -11,7 +11,7 @@
 #include <sys/mem_blocks.h>
 #include <sys/util.h>
 
-static void *alloc_one(sys_mem_blocks_t *mem_block)
+static void *alloc_blocks(sys_mem_blocks_t *mem_block, size_t num_blocks)
 {
 	size_t offset;
 	int r;
@@ -19,7 +19,7 @@ static void *alloc_one(sys_mem_blocks_t *mem_block)
 	void *ret = NULL;
 
 	/* Find an unallocated block */
-	r = sys_bitarray_alloc(mem_block->bitmap, 1, &offset);
+	r = sys_bitarray_alloc(mem_block->bitmap, num_blocks, &offset);
 	if (r != 0) {
 		goto out;
 	}
@@ -33,7 +33,7 @@ out:
 	return ret;
 }
 
-static int free_one(sys_mem_blocks_t *mem_block, void *ptr)
+static int free_blocks(sys_mem_blocks_t *mem_block, void *ptr, size_t num_blocks)
 {
 	size_t offset;
 	uint8_t *blk = ptr;
@@ -51,7 +51,7 @@ static int free_one(sys_mem_blocks_t *mem_block, void *ptr)
 		goto out;
 	}
 
-	ret = sys_bitarray_free(mem_block->bitmap, 1, offset);
+	ret = sys_bitarray_free(mem_block->bitmap, num_blocks, offset);
 
 out:
 	return ret;
@@ -85,7 +85,7 @@ int sys_mem_blocks_alloc(sys_mem_blocks_t *mem_block, size_t count,
 	}
 
 	for (i = 0; i < count; i++) {
-		void *ptr = alloc_one(mem_block);
+		void *ptr = alloc_blocks(mem_block, 1);
 
 		if (ptr == NULL) {
 			break;
@@ -138,7 +138,7 @@ int sys_mem_blocks_free(sys_mem_blocks_t *mem_block, size_t count,
 	for (i = 0; i < count; i++) {
 		void *ptr = in_blocks[i];
 
-		int r = free_one(mem_block, ptr);
+		int r = free_blocks(mem_block, ptr, 1);
 
 		if (r != 0) {
 			ret = r;

--- a/lib/os/mem_blocks.c
+++ b/lib/os/mem_blocks.c
@@ -62,10 +62,8 @@ int sys_mem_blocks_alloc_contiguous(sys_mem_blocks_t *mem_block, size_t count,
 {
 	int ret = 0;
 
-	if ((mem_block == NULL) || (out_block == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
+	__ASSERT_NO_MSG(mem_block != NULL);
+	__ASSERT_NO_MSG(out_block != NULL);
 
 	if (count == 0) {
 		/* Nothing to allocate */
@@ -102,15 +100,10 @@ int sys_mem_blocks_alloc(sys_mem_blocks_t *mem_block, size_t count,
 	int ret = 0;
 	int i;
 
-	if ((mem_block == NULL) || (out_blocks == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	CHECKIF((mem_block->bitmap == NULL) || (mem_block->buffer == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
+	__ASSERT_NO_MSG(mem_block != NULL);
+	__ASSERT_NO_MSG(out_blocks != NULL);
+	__ASSERT_NO_MSG(mem_block->bitmap != NULL);
+	__ASSERT_NO_MSG(mem_block->buffer != NULL);
 
 	if (count == 0) {
 		/* Nothing to allocate */
@@ -153,15 +146,9 @@ int sys_mem_blocks_get(sys_mem_blocks_t *mem_block, void *in_block, size_t count
 	int ret = 0;
 	int offset;
 
-	if (mem_block == NULL) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	CHECKIF((mem_block->bitmap == NULL) || (mem_block->buffer == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
+	__ASSERT_NO_MSG(mem_block != NULL);
+	__ASSERT_NO_MSG(mem_block->bitmap != NULL);
+	__ASSERT_NO_MSG(mem_block->buffer != NULL);
 
 	if (count == 0) {
 		/* Nothing to allocate */
@@ -198,15 +185,10 @@ int sys_mem_blocks_free(sys_mem_blocks_t *mem_block, size_t count,
 	int ret = 0;
 	int i;
 
-	if ((mem_block == NULL) || (in_blocks == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	CHECKIF((mem_block->bitmap == NULL) || (mem_block->buffer == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
+	__ASSERT_NO_MSG(mem_block != NULL);
+	__ASSERT_NO_MSG(in_blocks != NULL);
+	__ASSERT_NO_MSG(mem_block->bitmap != NULL);
+	__ASSERT_NO_MSG(mem_block->buffer != NULL);
 
 	if (count == 0) {
 		/* Nothing to be freed. */
@@ -247,15 +229,9 @@ int sys_mem_blocks_free_contiguous(sys_mem_blocks_t *mem_block, void *block, siz
 {
 	int ret = 0;
 
-	if (mem_block == NULL) {
-		ret = -EINVAL;
-		goto out;
-	}
-
-	CHECKIF((mem_block->bitmap == NULL) || (mem_block->buffer == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
+	__ASSERT_NO_MSG(mem_block != NULL);
+	__ASSERT_NO_MSG(mem_block->bitmap != NULL);
+	__ASSERT_NO_MSG(mem_block->buffer != NULL);
 
 	if (count == 0) {
 		/* Nothing to be freed. */
@@ -304,10 +280,8 @@ int sys_multi_mem_blocks_alloc(sys_multi_mem_blocks_t *group,
 	sys_mem_blocks_t *allocator;
 	int ret = 0;
 
-	if ((group == NULL) || (out_blocks == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
+	__ASSERT_NO_MSG(group != NULL);
+	__ASSERT_NO_MSG(out_blocks != NULL);
 
 	if (count == 0) {
 		if (blk_size != NULL) {
@@ -344,10 +318,8 @@ int sys_multi_mem_blocks_free(sys_multi_mem_blocks_t *group,
 	int ret = 0;
 	sys_mem_blocks_t *allocator = NULL;
 
-	if ((group == NULL) || (in_blocks == NULL)) {
-		ret = -EINVAL;
-		goto out;
-	}
+	__ASSERT_NO_MSG(group != NULL);
+	__ASSERT_NO_MSG(in_blocks != NULL);
 
 	if (count == 0) {
 		goto out;

--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -52,9 +52,11 @@ static bool check_buffer_bound(sys_mem_blocks_t *mem_block, void *ptr)
 }
 
 #ifdef CONFIG_SYS_MEM_BLOCKS_LISTENER
-static uintptr_t listener_heap_id[NUM_BLOCKS];
-static void *listener_mem[NUM_BLOCKS];
-static size_t listener_size[NUM_BLOCKS];
+#define HEAP_LISTENER_LOG_SIZE 64
+
+static uintptr_t listener_heap_id[HEAP_LISTENER_LOG_SIZE];
+static void *listener_mem[HEAP_LISTENER_LOG_SIZE];
+static size_t listener_size[HEAP_LISTENER_LOG_SIZE];
 static uint8_t listener_idx;
 
 static void mem_block_alloc_free_cb(uintptr_t heap_id, void *mem, size_t bytes)

--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -12,7 +12,7 @@
 #include <sys/util.h>
 
 #define BLK_SZ     64
-#define NUM_BLOCKS 4
+#define NUM_BLOCKS 8
 
 SYS_MEM_BLOCKS_DEFINE(mem_block_01, BLK_SZ, NUM_BLOCKS, 4);
 

--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -388,6 +388,188 @@ static void test_mem_block_get(void)
 #endif
 }
 
+static void test_mem_block_alloc_free_continuous(void)
+{
+	int i, ret, val;
+	void *block;
+
+#ifdef CONFIG_SYS_MEM_BLOCKS_LISTENER
+	listener_idx = 0;
+	heap_listener_register(&mem_block_01_alloc);
+	heap_listener_register(&mem_block_01_free);
+#endif
+
+	/* allocate all available blocks */
+	ret = sys_mem_blocks_alloc_contiguous(&mem_block_01, NUM_BLOCKS, &block);
+	zassert_equal(ret, 0,
+		      "sys_mem_blocks_alloc_contiguous failed (%d)", ret);
+
+	/* all blocks should be taken */
+	for (i = 0; i < NUM_BLOCKS; i++) {
+		ret = sys_bitarray_test_bit(mem_block_01.bitmap,
+					    i, &val);
+		zassert_equal(val, 1,
+		     "sys_mem_blocks_alloc_contiguous failed, bit %i should be set", i);
+		break;
+
+	}
+
+	/* free first 3 memory blocks, use a pointer provided by previous case */
+	ret = sys_mem_blocks_free_contiguous(&mem_block_01, block, 3);
+	zassert_equal(ret, 0,
+		      "sys_mem_blocks_free_contiguous failed (%d)", ret);
+
+	/* all blocks extept 0,1,2 should be taken */
+	for (i = 0; i < NUM_BLOCKS; i++) {
+		ret = sys_bitarray_test_bit(mem_block_01.bitmap,
+					    i, &val);
+		switch (i) {
+		case 0:
+		case 1:
+		case 2:
+			zassert_equal(val, 0,
+			     "sys_mem_blocks_alloc_contiguous failed, bit %i should be cleared", i);
+			break;
+		default:
+			zassert_equal(val, 1,
+			     "sys_mem_blocks_alloc_contiguous failed, bit %i should be set", i);
+			break;
+		}
+	}
+
+	/* free a memory block, starting from 4, size 4 */
+	ret = sys_mem_blocks_free_contiguous(&mem_block_01, mem_block_01.buffer+BLK_SZ*4, 4);
+	zassert_equal(ret, 0,
+		      "sys_mem_blocks_free_contiguous failed (%d)", ret);
+
+	/* all blocks extept 0,1,2,4,5,6,7 should be taken */
+	for (i = 0; i < NUM_BLOCKS; i++) {
+		ret = sys_bitarray_test_bit(mem_block_01.bitmap,
+					    i, &val);
+		switch (i) {
+		case 0:
+		case 1:
+		case 2:
+		case 4:
+		case 5:
+		case 6:
+		case 7:
+			zassert_equal(val, 0,
+			     "sys_mem_blocks_alloc_contiguous failed, bit %i should be cleared", i);
+			break;
+		default:
+			zassert_equal(val, 1,
+			     "sys_mem_blocks_alloc_contiguous failed, bit %i should be set", i);
+			break;
+		}
+	}
+
+	/* at this point, regardless of the memory size, there are 2 free continuous blocks
+	 * sizes: 3 and 4 slots.
+	 * try to allocate 5 blocks, should fail
+	 */
+	ret = sys_mem_blocks_alloc_contiguous(&mem_block_01, 5, &block);
+	zassert_equal(ret, -ENOMEM,
+		      "sys_mem_blocks_free_contiguous failed (%d)", ret);
+
+
+	/* allocate 3 blocks */
+	ret = sys_mem_blocks_alloc_contiguous(&mem_block_01, 3, &block);
+	zassert_equal(ret, 0,
+		      "sys_mem_blocks_free_contiguous failed (%d)", ret);
+	/* all blocks extept 4,5,6,7 should be taken */
+	for (i = 0; i < NUM_BLOCKS; i++) {
+		ret = sys_bitarray_test_bit(mem_block_01.bitmap,
+					    i, &val);
+		switch (i) {
+		case 4:
+		case 5:
+		case 6:
+		case 7:
+			zassert_equal(val, 0,
+			     "sys_mem_blocks_alloc_contiguous failed, bit %i should be cleared", i);
+			break;
+		default:
+			zassert_equal(val, 1,
+			     "sys_mem_blocks_alloc_contiguous failed, bit %i should be set", i);
+			break;
+		}
+	}
+
+	/* allocate 4 blocks */
+	ret = sys_mem_blocks_alloc_contiguous(&mem_block_01, 4, &block);
+	zassert_equal(ret, 0,
+		      "sys_mem_blocks_free_contiguous failed (%d)", ret);
+	/* all blocks  should be taken */
+	for (i = 0; i < NUM_BLOCKS; i++) {
+		ret = sys_bitarray_test_bit(mem_block_01.bitmap,
+					    i, &val);
+		zassert_equal(val, 1,
+		     "sys_mem_blocks_alloc_contiguous failed, bit %i should be set", i);
+	}
+
+	/* cleanup - free all blocks */
+	ret = sys_mem_blocks_free_contiguous(&mem_block_01, mem_block_01.buffer, NUM_BLOCKS);
+	zassert_equal(ret, 0,
+		      "sys_mem_blocks_alloc_contiguous failed (%d)", ret);
+
+	/* all blocks should be cleared */
+	for (i = 0; i < NUM_BLOCKS; i++) {
+		ret = sys_bitarray_test_bit(mem_block_01.bitmap,
+					    i, &val);
+		zassert_equal(val, 0,
+		     "sys_mem_blocks_alloc_contiguous failed, bit %i should be cleared", i);
+	}
+
+#ifdef CONFIG_SYS_MEM_BLOCKS_LISTENER
+	heap_listener_unregister(&mem_block_01_alloc);
+	heap_listener_unregister(&mem_block_01_free);
+
+	/* verify alloc/free log */
+	zassert_equal(listener_mem[0], mem_block_01.buffer,
+			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
+			listener_mem[0], mem_block_01.buffer);
+	zassert_equal(listener_size[0], BLK_SZ*NUM_BLOCKS,
+			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			listener_size[0], BLK_SZ*NUM_BLOCKS);
+
+	zassert_equal(listener_mem[1], mem_block_01.buffer,
+			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
+			listener_mem[1], mem_block_01.buffer);
+	zassert_equal(listener_size[1], BLK_SZ*3,
+			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			listener_size[1], BLK_SZ*3);
+
+	zassert_equal(listener_mem[2], mem_block_01.buffer+BLK_SZ*4,
+			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
+			listener_mem[2], mem_block_01.buffer+BLK_SZ*4);
+	zassert_equal(listener_size[2], BLK_SZ*4,
+			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			listener_size[2], BLK_SZ*4);
+
+	zassert_equal(listener_mem[3], mem_block_01.buffer,
+			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
+			listener_mem[3], mem_block_01.buffer);
+	zassert_equal(listener_size[3], BLK_SZ*3,
+			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			listener_size[3], BLK_SZ*3);
+
+	zassert_equal(listener_mem[4], mem_block_01.buffer+BLK_SZ*4,
+			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
+			listener_mem[4], mem_block_01.buffer+BLK_SZ*4);
+	zassert_equal(listener_size[4], BLK_SZ*4,
+			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			listener_size[4], BLK_SZ*4);
+
+	zassert_equal(listener_mem[5], mem_block_01.buffer,
+			"sys_mem_blocks_alloc_contiguous failed, %p != %p",
+			listener_mem[5], mem_block_01.buffer);
+	zassert_equal(listener_size[5], BLK_SZ*NUM_BLOCKS,
+			"sys_mem_blocks_alloc_contiguous failed, %u != %u",
+			listener_size[5], BLK_SZ*NUM_BLOCKS);
+#endif
+}
+
 static void test_multi_mem_block_alloc_free(void)
 {
 	int ret;
@@ -559,7 +741,8 @@ void test_main(void)
 			 ztest_unit_test(test_multi_mem_block_alloc_free),
 			 ztest_unit_test(test_mem_block_invalid_params),
 			 ztest_unit_test(test_multi_mem_block_invalid_params),
-			 ztest_unit_test(test_mem_block_get)
+			 ztest_unit_test(test_mem_block_get),
+			 ztest_unit_test(test_mem_block_alloc_free_continuous)
 			 );
 
 	ztest_run_test_suite(lib_mem_block_test);


### PR DESCRIPTION
This is an extension of memory blocks library. 
Three functions were added:

- sys_mem_blocks_alloc_continuous
- sys_mem_blocks_free_continuous
- sys_mem_blocks_get

above changes require also changes in bitarray lib:

-  sys_bitarray_test_and_set_region added
