### PR TITLE
net: lwm2m: handle socket fault as network error

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -229,6 +229,8 @@ static void sm_handle_failure_state(enum sm_engine_state sm_state)
 		event = LWM2M_RD_CLIENT_EVENT_REG_UPDATE_FAILURE;
 	} else if (client.engine_state == ENGINE_DEREGISTER_SENT) {
 		event = LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE;
+	} else {
+		event = LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR;
 	}
 
 	set_sm_state(sm_state);
@@ -243,15 +245,9 @@ static void socket_fault_cb(int error)
 {
 	LOG_ERR("RD Client socket error: %d", error);
 
-	lwm2m_engine_context_close(client.ctx);
-
 	client.ctx->sec_obj_inst = -1;
 
-	/* Jump directly to the registration phase. In case there is no valid
-	 * security object for the LWM2M server, it will fall back to the
-	 * bootstrap procedure.
-	 */
-	set_sm_state(ENGINE_DO_REGISTRATION);
+	sm_handle_failure_state(ENGINE_DO_REGISTRATION);
 }
 
 /* force re-update with remote peer */


### PR DESCRIPTION
Socket fault callback is called if socket operations fails by
lwm2m engine. Instead of switching state directly, handle
socket fault as network error.

Signed-off-by: Marin Jurjević <marin.jurjevic@hotmail.com>