### PR TITLE
boards: fix ADC compilation error

### DIFF
--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -81,8 +81,6 @@
 			status = "disabled";
 			label = "ADC_1";
 			#io-channel-cells = <1>;
-			has-temp-channel;
-			has-vref-channel;
 		};
 
 		adc2: adc@50000100 {


### PR DESCRIPTION
ADC check fails for STM32g4

Signed-off-by: Matthias Hauser <Matthias.Hauser@we-online.de>