### PR TITLE
Fix CONFIG_IMG_MGMT_VERBOSE_ERR

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -38,6 +38,16 @@ config MGMT_CBORATTR_FLOAT_SUPPORT
 	  the option needs to be enabled.
 	  Disabling the option slightly reduces code footprint.
 
+config MGMT_VERBOSE_ERR_RESPONSE
+	bool "Support verbose error response"
+	help
+	  Support for encoding "rc" code explanation in form of "rsn"
+	  text string.  This is useful, when returning MGMT_ERR_EUNKNOWN,
+	  to add additional information on the source of an error.
+	  Note that the "rsn" is string additional to "rc" code,
+	  so MCUMGR_BUF_SIZE should be large enough to be able to encode
+	  both.
+
 menu "Command Handlers"
 menuconfig MCUMGR_CMD_FS_MGMT
 	bool "Mcumgr handlers for file management (insecure)"

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -188,6 +188,7 @@ config IMG_MGMT_UPDATABLE_IMAGE_NUMBER
 
 config IMG_MGMT_VERBOSE_ERR
 	bool "Verbose logging when uploading a new image"
+	select MGMT_VERBOSE_ERR_RESPONSE
 	help
 	  Enable verbose logging during a firmware upgrade.
 

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -100,6 +100,10 @@ struct img_mgmt_upload_action {
 	bool proceed;
 	/** Whether to erase the destination flash area. */
 	bool erase;
+#ifdef CONFIG_IMG_MGMT_VERBOSE_ERR
+	/** "rsn" string to be sent as explanation for "rc" code */
+	const char *rc_rsn;
+#endif
 };
 
 /**
@@ -238,7 +242,9 @@ void img_mgmt_dfu_started(void);
 void img_mgmt_dfu_pending(void);
 void img_mgmt_dfu_confirmed(void);
 
-#if CONFIG_IMG_MGMT_VERBOSE_ERR
+#ifdef CONFIG_IMG_MGMT_VERBOSE_ERR
+#define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn) ((action)->rc_rsn = (rsn))
+#define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) ((action)->rc_rsn)
 int img_mgmt_error_rsp(struct mgmt_ctxt *ctxt, int rc, const char *rsn);
 extern const char *img_mgmt_err_str_app_reject;
 extern const char *img_mgmt_err_str_hdr_malformed;
@@ -250,16 +256,8 @@ extern const char *img_mgmt_err_str_flash_write_failed;
 extern const char *img_mgmt_err_str_downgrade;
 extern const char *img_mgmt_err_str_image_bad_flash_addr;
 #else
-#define img_mgmt_error_rsp(ctxt, rc, rsn)	(rc)
-#define img_mgmt_err_str_app_reject		NULL
-#define img_mgmt_err_str_hdr_malformed		NULL
-#define img_mgmt_err_str_magic_mismatch		NULL
-#define img_mgmt_err_str_no_slot		NULL
-#define img_mgmt_err_str_flash_open_failed	NULL
-#define img_mgmt_err_str_flash_erase_failed	NULL
-#define img_mgmt_err_str_flash_write_failed	NULL
-#define img_mgmt_err_str_downgrade		NULL
-#define img_mgmt_err_str_image_bad_flash_addr	NULL
+#define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn)
+#define IMG_MGMT_UPLOAD_ACTION_RC_RSN(action) NULL
 #endif
 
 #ifdef __cplusplus

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -131,7 +131,7 @@ int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len);
  * @return 0 if processing should occur;A MGMT_ERR code if an error response should be sent instead.
  */
 int img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
-				 struct img_mgmt_upload_action *action, const char **errstr);
+				 struct img_mgmt_upload_action *action);
 
 #define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
 int img_mgmt_impl_erased_val(int slot, uint8_t *erased_val);

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -522,7 +522,7 @@ img_mgmt_impl_swap_type(int slot)
  */
 int
 img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
-				 struct img_mgmt_upload_action *action, const char **errstr)
+				 struct img_mgmt_upload_action *action)
 {
 	const struct image_header *hdr;
 	struct image_version cur_ver;
@@ -533,7 +533,7 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 
 	if (req->off == -1) {
 		/* Request did not include an `off` field. */
-		*errstr = img_mgmt_err_str_hdr_malformed;
+		IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_hdr_malformed);
 		return MGMT_ERR_EINVAL;
 	}
 
@@ -541,20 +541,20 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 		/* First upload chunk. */
 		if (req->data_len < sizeof(struct image_header)) {
 			/*  Image header is the first thing in the image */
-			*errstr = img_mgmt_err_str_hdr_malformed;
+			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_hdr_malformed);
 			return MGMT_ERR_EINVAL;
 		}
 
 		if (req->size == -1) {
 			/* Request did not include a `len` field. */
-			*errstr = img_mgmt_err_str_hdr_malformed;
+			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_hdr_malformed);
 			return MGMT_ERR_EINVAL;
 		}
 		action->size = req->size;
 
 		hdr = (struct image_header *)req->img_data;
 		if (hdr->ih_magic != IMAGE_MAGIC) {
-			*errstr = img_mgmt_err_str_magic_mismatch;
+			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_magic_mismatch);
 			return MGMT_ERR_EINVAL;
 		}
 
@@ -578,7 +578,7 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 		action->area_id = img_mgmt_get_unused_slot_area_id(req->image);
 		if (action->area_id < 0) {
 			/* No slot where to upload! */
-			*errstr = img_mgmt_err_str_no_slot;
+			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_no_slot);
 			return MGMT_ERR_ENOENT;
 		}
 
@@ -586,12 +586,14 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 		if (hdr->ih_flags & IMAGE_F_ROM_FIXED_ADDR) {
 			rc = flash_area_open(action->area_id, &fa);
 			if (rc) {
-				*errstr = img_mgmt_err_str_flash_open_failed;
+				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action,
+					img_mgmt_err_str_flash_open_failed);
 				return MGMT_ERR_EUNKNOWN;
 			}
 
 			if (fa->fa_off != hdr->ih_load_addr) {
-				*errstr = img_mgmt_err_str_image_bad_flash_addr;
+				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(aciton,
+					img_mgmt_err_str_image_bad_flash_addr);
 				flash_area_close(fa);
 				return MGMT_ERR_EINVAL;
 			}
@@ -611,7 +613,8 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 			}
 
 			if (img_mgmt_vercmp(&cur_ver, &hdr->ih_ver) >= 0) {
-				*errstr = img_mgmt_err_str_downgrade;
+				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action,
+					img_mgmt_err_str_downgrade);
 				return MGMT_ERR_EBADSTATE;
 			}
 		}
@@ -642,6 +645,7 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 
 	action->write_bytes = req->data_len;
 	action->proceed = true;
+	IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, NULL);
 
 	return 0;
 }

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -219,7 +219,18 @@ struct mgmt_ctxt {
 	struct CborEncoder encoder;
 	struct CborParser parser;
 	struct CborValue it;
+#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
+	const char *rc_rsn;
+#endif
 };
+
+#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
+#define MGMT_CTXT_SET_RC_RSN(mc, rsn) ((mc->rc_rsn) = (rsn))
+#define MGMT_CTXT_RC_RSN(mc) ((mc)->rc_rsn)
+#else
+#define MGMT_CTXT_SET_RC_RSN(mc, rsn)
+#define MGMT_CTXT_RC_RSN(mc) NULL
+#endif
 
 /** @typedef mgmt_handler_fn
  * @brief Processes a request and writes the corresponding response.

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -154,6 +154,20 @@ mgmt_write_rsp_status(struct mgmt_ctxt *ctxt, int errcode)
 		return rc;
 	}
 
+#ifdef CONFIG_MGMT_VERBOSE_ERR_RESPONSE
+	if (MGMT_CTXT_RC_RSN(ctxt) != NULL) {
+		rc = cbor_encode_text_stringz(&ctxt->encoder, "rsn");
+		if (rc != 0) {
+			return rc;
+		}
+
+		rc = cbor_encode_text_stringz(&ctxt->encoder, MGMT_CTXT_RC_RSN(ctxt));
+		if (rc != 0) {
+			return rc;
+		}
+	}
+#endif
+
 	return 0;
 }
 

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -65,9 +65,8 @@ smp_write_hdr(struct smp_streamer *streamer, const struct mgmt_hdr *src_hdr)
 }
 
 static int
-smp_build_err_rsp(struct smp_streamer *streamer,
-				  const struct mgmt_hdr *req_hdr,
-				  int status)
+smp_build_err_rsp(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr, int status,
+		  const char *rc_rsn)
 {
 	struct CborEncoder map;
 	struct mgmt_ctxt cbuf;
@@ -162,6 +161,7 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct mgmt_hdr *req_hdr
 		*handler_found = true;
 		mgmt_evt(MGMT_EVT_OP_CMD_RECV, req_hdr->nh_group, req_hdr->nh_id, NULL);
 
+		MGMT_CTXT_SET_RC_RSN(cbuf, NULL);
 		rc = handler_fn(cbuf);
 	} else {
 		rc = MGMT_ERR_ENOTSUP;
@@ -189,7 +189,7 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct mgmt_hdr *req_hdr
  */
 static int
 smp_handle_single_req(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
-		      bool *handler_found)
+		      bool *handler_found, const char **rsn)
 {
 	struct mgmt_ctxt cbuf;
 	struct mgmt_hdr rsp_hdr;
@@ -212,6 +212,7 @@ smp_handle_single_req(struct smp_streamer *streamer, const struct mgmt_hdr *req_
 	/* Process the request and write the response payload. */
 	rc = smp_handle_single_payload(&cbuf, req_hdr, handler_found);
 	if (rc != 0) {
+		*rsn = MGMT_CTXT_RC_RSN(&cbuf);
 		return rc;
 	}
 
@@ -235,10 +236,12 @@ smp_handle_single_req(struct smp_streamer *streamer, const struct mgmt_hdr *req_
  * @param req		The buffer holding the request.
  * @param rsp		The buffer holding the response, or NULL if none was allocated.
  * @param status	The status to indicate in the error response.
+ * @param rsn		The text explanation to @status encoded as "rsn" into CBOR
+ *			response.
  */
 static void
 smp_on_err(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
-		   void *req, void *rsp, int status)
+		   void *req, void *rsp, int status, const char *rsn)
 {
 	int rc;
 
@@ -255,7 +258,7 @@ smp_on_err(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	mgmt_streamer_init_writer(&streamer->mgmt_stmr, rsp);
 
 	/* Build and transmit the error response. */
-	rc = smp_build_err_rsp(streamer, req_hdr, status);
+	rc = smp_build_err_rsp(streamer, req_hdr, status, rsn);
 	if (rc == 0) {
 		streamer->tx_rsp_cb(streamer, rsp, streamer->mgmt_stmr.cb_arg);
 		rsp = NULL;
@@ -288,6 +291,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *req)
 	void *rsp;
 	bool valid_hdr, handler_found;
 	int rc = 0;
+	const char *rsn = NULL;
 
 	rsp = NULL;
 
@@ -324,7 +328,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *req)
 		mgmt_streamer_init_writer(&streamer->mgmt_stmr, rsp);
 
 		/* Process the request payload and build the response. */
-		rc = smp_handle_single_req(streamer, &req_hdr, &handler_found);
+		rc = smp_handle_single_req(streamer, &req_hdr, &handler_found, &rsn);
 		if (rc != 0) {
 			break;
 		}
@@ -346,7 +350,7 @@ smp_process_request_packet(struct smp_streamer *streamer, void *req)
 	}
 
 	if (rc != 0 && valid_hdr) {
-		smp_on_err(streamer, &req_hdr, req, rsp, rc);
+		smp_on_err(streamer, &req_hdr, req, rsp, rc, rsn);
 
 		if (handler_found) {
 			cmd_done_arg.err = rc;


### PR DESCRIPTION
The PR fixes #32545:  even though `CONFIG_IMG_MGMT_VERBOSE_ERR` and `"rsn"` would be set by image management, the final response would remove the `"rsn"` string before sending error SMP response.

The PR contains two commits:
1) adding `CONFIG_MGMT_VERBOSE_ERR_RESPONSE` Kconfig option that enables general support for `"rsn"` in error SMP responses;
2) fixes `CONFIG_IMG_MGMT_VERBOSE_ERR` using newly provided support for `"rsn"` strings.

Fixes #32545