### PR TITLE
subsys/mgmt/hawkbit: Convert `hawkbit_get_device_identity` to `__weak`

### DIFF
--- a/subsys/mgmt/hawkbit/Kconfig
+++ b/subsys/mgmt/hawkbit/Kconfig
@@ -40,6 +40,12 @@ config HAWKBIT_SHELL
 	help
 	  Activate shell module that provides Hawkbit commands.
 
+config HAWKBIT_DEVID_BIN_MAX_SIZE
+	int "Maximum length of device identity in binary"
+	default 16
+	help
+	  Define the maximum length of device identity in binary.
+
 config HAWKBIT_SERVER
 	string "User address for the hawkbit server"
 	default ""

--- a/subsys/mgmt/hawkbit/hawkbit_device.c
+++ b/subsys/mgmt/hawkbit/hawkbit_device.c
@@ -6,12 +6,12 @@
 #include "hawkbit_device.h"
 #include <string.h>
 
-bool hawkbit_get_device_identity(char *id, int id_max_len)
+bool __weak hawkbit_get_device_identity(char *id, int id_max_len)
 {
-	uint8_t hwinfo_id[DEVICE_ID_BIN_MAX_SIZE];
+	uint8_t hwinfo_id[CONFIG_HAWKBIT_DEVID_BIN_MAX_SIZE];
 	ssize_t length;
 
-	length = hwinfo_get_device_id(hwinfo_id, DEVICE_ID_BIN_MAX_SIZE);
+	length = hwinfo_get_device_id(hwinfo_id, CONFIG_HAWKBIT_DEVID_BIN_MAX_SIZE);
 	if (length <= 0) {
 		return false;
 	}

--- a/subsys/mgmt/hawkbit/hawkbit_device.h
+++ b/subsys/mgmt/hawkbit/hawkbit_device.h
@@ -10,9 +10,20 @@
 #include <zephyr.h>
 #include <drivers/hwinfo.h>
 
-#define DEVICE_ID_BIN_MAX_SIZE	16
-#define DEVICE_ID_HEX_MAX_SIZE	((DEVICE_ID_BIN_MAX_SIZE * 2) + 1)
+#define DEVICE_ID_HEX_MAX_SIZE ((CONFIG_HAWKBIT_DEVID_BIN_MAX_SIZE * 2) + 1)
 
+/**
+ * @brief Function to define the device identity for which the hawkbit uses
+ * when it connects to the server.
+ *
+ * @note This is a weak-linked function, and can be overridden if desired.
+ *
+ * @param id Pointer to the devid buffer
+ * @param id_max_len Maximum size of the devid buffer defined as
+ * ((CONFIG_HAWKBIT_DEVID_BIN_MAX_SIZE * 2) + 1)
+ *
+ * @return true if length of devid > 0
+ */
 bool hawkbit_get_device_identity(char *id, int id_max_len);
 
 #endif /* __HAWKBIT_DEVICE_H__ */


### PR DESCRIPTION
Convert the hawkbit_get_device_identity function to be _weak linked so that it can be overridden in application. The existing implementation has the limitation of always encoding into hex form.