### PR TITLE
boards: arm: mimxrt1024_evk: enable USB1

### DIFF
--- a/boards/arm/mimxrt1024_evk/doc/index.rst
+++ b/boards/arm/mimxrt1024_evk/doc/index.rst
@@ -101,6 +101,8 @@ features:
 +-----------+------------+-------------------------------------+
 | GPT       | on-chip    | gpt                                 |
 +-----------+------------+-------------------------------------+
+| USB       | on-chip    | USB                                 |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1024_evk/mimxrt1024_evk_defconfig``

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -134,3 +134,7 @@
 &gpt_hw_timer {
 	status = "okay";
 };
+
+zephyr_udc0: &usb1 {
+	status = "okay";
+};

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.yaml
@@ -22,3 +22,4 @@ supported:
   - watchdog
   - spi
   - adc
+  - usb_device


### PR DESCRIPTION
Enable USB device controller on the NXP i.MX RT1024 Evaluation Kit.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>