### PR TITLE
soc: arm: nxp_imx: Select MCUX_IGPIO driver for mimx8mm6

### DIFF
--- a/soc/arm/nxp_imx/mimx8mm6_m4/Kconfig.defconfig.mimx8mm6_m4
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/Kconfig.defconfig.mimx8mm6_m4
@@ -34,4 +34,11 @@ config UART_MCUX_IUART
 
 endif # SERIAL
 
+if GPIO
+
+config GPIO_MCUX_IGPIO
+	default y
+
+endif # GPIO
+
 endif # SOC_MIMX8MM6


### PR DESCRIPTION
This automatically enables the gpio_mcux_igpio driver when gpio is
enabled on this platform.

I was adding ``CONFIG_GPIO_MCUX_IGPIO`` manually in a board overlay when a colleague told me that it was not necessary. This was missing after https://github.com/zephyrproject-rtos/zephyr/pull/42345