### PR TITLE
doc: boards: s/device_get_binding/DEVICE_DT_GET

### DIFF
--- a/boards/arm/bl653_dvk/doc/bl653_dvk.rst
+++ b/boards/arm/bl653_dvk/doc/bl653_dvk.rst
@@ -191,7 +191,7 @@ more than one UART for connecting peripheral devices:
 
    In the overlay file above, pin P0.16 is used for RX and P0.14 is used for TX
 
-2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 See :ref:`set-devicetree-overlays` for further details.
 

--- a/boards/arm/nrf21540dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf21540dk_nrf52840/doc/index.rst
@@ -197,7 +197,7 @@ more than one UART for connecting peripheral devices:
 
    In the overlay file above, pin P0.16 is used for RX and P0.14 is used for TX
 
-2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 See :ref:`set-devicetree-overlays` for further details.
 

--- a/boards/arm/nrf52833dk_nrf52833/doc/index.rst
+++ b/boards/arm/nrf52833dk_nrf52833/doc/index.rst
@@ -178,7 +178,7 @@ more than one UART for connecting peripheral devices:
 
    In the overlay file above, pin P0.16 is used for RX and P0.14 is used for TX
 
-2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 See :ref:`set-devicetree-overlays` for further details.
 

--- a/boards/arm/nrf52840dk_nrf52840/doc/index.rst
+++ b/boards/arm/nrf52840dk_nrf52840/doc/index.rst
@@ -186,7 +186,7 @@ more than one UART for connecting peripheral devices:
 
    In the overlay file above, pin P0.16 is used for RX and P0.14 is used for TX
 
-2. Use the UART1 as ``device_get_binding(DT_LABEL(DT_NODELABEL(uart1)))``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 See :ref:`set-devicetree-overlays` for further details.
 

--- a/boards/arm/ubx_bmd340eval_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_bmd340eval_nrf52840/doc/index.rst
@@ -475,7 +475,7 @@ more than one UART for connecting peripheral devices:
    In the overlay file above, pin P0.16 is used for RX and P0.14 is
    used for TX
 
-2. Use the UART1 as ``device_get_binding("UART_1")``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 Overlay file naming
 ===================

--- a/boards/arm/ubx_bmd345eval_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_bmd345eval_nrf52840/doc/index.rst
@@ -487,7 +487,7 @@ more than one UART for connecting peripheral devices:
    In the overlay file above, pin P0.16 is used for RX and P0.14 is
    used for TX
 
-2. Use the UART1 as ``device_get_binding("UART_1")``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 Overlay file naming
 ===================

--- a/boards/arm/ubx_bmd380eval_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_bmd380eval_nrf52840/doc/index.rst
@@ -473,7 +473,7 @@ more than one UART for connecting peripheral devices:
    In the overlay file above, pin P0.16 is used for RX and P0.14 is
    used for TX
 
-2. Use the UART1 as ``device_get_binding("UART_1")``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 Overlay file naming
 ===================


### PR DESCRIPTION
Change to DEVICE_DT_GET when the documented device can be obtained at
compile time.