### PR TITLE
tests: cmsis_dsp: Disable FP16 tests for POSIX arch 

### DIFF
--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -80,12 +80,11 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_Q31=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.unary_f16:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained
       - mps2_an521
-      - native_posix
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 64
@@ -93,7 +92,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_UNARY_F16=y
   libraries.cmsis_dsp.matrix.unary_f16.fpu:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
     tags: cmsis_dsp fpu
@@ -230,12 +229,11 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_Q31=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.matrix.binary_f16:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained
       - mps2_an521
-      - native_posix
     tags: cmsis_dsp
     min_flash: 128
     min_ram: 144
@@ -243,7 +241,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_MATRIX_BINARY_F16=y
   libraries.cmsis_dsp.matrix.binary_f16.fpu:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
     tags: cmsis_dsp fpu

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -104,12 +104,11 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RQ31=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.cf16:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained
       - mps2_an521
-      - native_posix
     tags: cmsis_dsp
     min_flash: 512
     min_ram: 64
@@ -117,7 +116,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF16=y
   libraries.cmsis_dsp.transform.cf16.fpu:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
     tags: cmsis_dsp fpu
@@ -128,12 +127,11 @@ tests:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_CF16=y
       - CONFIG_FPU=y
   libraries.cmsis_dsp.transform.rf16:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained
       - mps2_an521
-      - native_posix
     tags: cmsis_dsp
     min_flash: 512
     min_ram: 64
@@ -141,7 +139,7 @@ tests:
     extra_configs:
       - CONFIG_CMSIS_DSP_TEST_TRANSFORM_RF16=y
   libraries.cmsis_dsp.transform.rf16.fpu:
-    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
+    filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
     tags: cmsis_dsp fpu


### PR DESCRIPTION
This commit disables the half-precision floating-point (FP16) tests for
the POSIX arch, because the `__fp16` type is not supported on the x86
host, which is the most common host type for the POSIX arch.

Note that the FP16 tests can technically run on the POSIX arch if the
host type is AArch64; but, since we do not have a proper configuration
scheme to resolve the host type for the POSIX arch at this time, we
simply disable these tests completely for the POSIX arch.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #43816 