### PR TITLE
drivers: remove redundant DEV_NAME helpers

### DIFF
--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -39,8 +39,6 @@ struct counter_gecko_data {
 	void *top_user_data;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 #ifdef CONFIG_SOC_GECKO_HAS_ERRATA_RTCC_E201
 #define ERRATA_RTCC_E201_MESSAGE \
 	"Errata RTCC_E201: In case RTCC prescaler != 1 the module does not " \
@@ -302,7 +300,7 @@ static int counter_gecko_init(const struct device *dev)
 	/* Configure & enable module interrupts */
 	dev_cfg->irq_config();
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -70,8 +70,6 @@ struct counter_sam_dev_data {
 	struct counter_sam_alarm_data alarm[MAX_ALARMS_PER_TC_CHANNEL];
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static const uint32_t sam_tc_input_freq_table[] = {
 #if defined(CONFIG_SOC_SERIES_SAME70) || defined(CONFIG_SOC_SERIES_SAMV71)
 	USEC_PER_SEC,
@@ -332,7 +330,7 @@ static int counter_sam_initialize(const struct device *dev)
 #endif
 	dev_cfg->irq_config_func(dev);
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -46,8 +46,6 @@ struct dac_sam_dev_data {
 	struct dac_channel dac_channels[DAC_CHANNEL_NO];
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static void dac_sam_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;
@@ -140,7 +138,7 @@ static int dac_sam_init(const struct device *dev)
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -21,8 +21,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(dma_dw);
 
-#define DEV_NAME(dev) ((dev)->name)
-
 /* Device constant configuration parameters */
 struct dw_dma_cfg {
 	struct dw_dma_dev_cfg dw_cfg;
@@ -39,7 +37,7 @@ static int dw_dma_init(const struct device *dev)
 	/* Configure interrupts */
 	dev_cfg->irq_config();
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -24,8 +24,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(dma_iproc_pax);
 
-#define PAX_DMA_DEV_NAME(dev) ((dev)->name)
-
 /* Driver runtime data for PAX DMA and RM */
 static struct dma_iproc_pax_data pax_dma_data;
 
@@ -678,10 +676,9 @@ static int dma_iproc_pax_init(const struct device *dev)
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 #else
-	LOG_INF("%s PAX DMA rings in poll mode!\n", PAX_DMA_DEV_NAME(dev));
+	LOG_INF("%s PAX DMA rings in poll mode!\n", dev->name);
 #endif
-	LOG_INF("%s RM setup %d rings\n", PAX_DMA_DEV_NAME(dev),
-		pd->used_rings);
+	LOG_INF("%s RM setup %d rings\n", dev->name, pd->used_rings);
 
 	return 0;
 }

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -24,8 +24,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(dma_iproc_pax_v2);
 
-#define PAX_DMA_DEV_NAME(dev)	((dev)->name)
-
 /* Driver runtime data for PAX DMA and RM */
 static struct dma_iproc_pax_data pax_dma_data;
 
@@ -756,10 +754,9 @@ static int dma_iproc_pax_init(const struct device *dev)
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 #else
-	LOG_INF("%s PAX DMA rings in poll mode!\n", PAX_DMA_DEV_NAME(dev));
+	LOG_INF("%s PAX DMA rings in poll mode!\n", dev->name);
 #endif
-	LOG_INF("%s RM setup %d rings\n", PAX_DMA_DEV_NAME(dev),
-		pd->used_rings);
+	LOG_INF("%s RM setup %d rings\n", dev->name, pd->used_rings);
 
 	return 0;
 }

--- a/drivers/dma/dma_nios2_msgdma.c
+++ b/drivers/dma/dma_nios2_msgdma.c
@@ -31,8 +31,6 @@ struct nios2_msgdma_dev_data {
 	dma_callback_t dma_callback;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static void nios2_msgdma_isr(void *arg)
 {
 	const struct device *dev = (const struct device *)arg;

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -17,8 +17,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(dma_pl330);
 
-#define DEV_NAME(dev) ((dev)->name)
-
 #define BYTE_WIDTH(burst_size) (1 << (burst_size))
 
 static int dma_pl330_submit(const struct device *dev, uint64_t dst,
@@ -563,7 +561,7 @@ static int dma_pl330_initialize(const struct device *dev)
 		k_mutex_init(&channel_cfg->ch_mutex);
 	}
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 	return 0;
 }
 

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -46,8 +46,6 @@ struct sam_xdmac_dev_data {
 	struct sam_xdmac_channel_cfg dma_channels[DMA_CHANNELS_NO];
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static void sam_xdmac_isr(const struct device *dev)
 {
 	const struct sam_xdmac_dev_cfg *const dev_cfg = dev->config;
@@ -353,7 +351,7 @@ static int sam_xdmac_initialize(const struct device *dev)
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/eeprom/eeprom_simulator.c
+++ b/drivers/eeprom/eeprom_simulator.c
@@ -35,8 +35,6 @@ struct eeprom_sim_config {
 	bool readonly;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 #define EEPROM(addr) (mock_eeprom + (addr))
 
 #if defined(CONFIG_MULTITHREADING)

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -481,7 +481,7 @@ static int eth_init(const struct device *dev)
 	/* Connect and enable IRQ */
 	cfg->config_func();
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/ethernet/eth_gecko_priv.h
+++ b/drivers/ethernet/eth_gecko_priv.h
@@ -94,8 +94,6 @@ struct eth_gecko_dev_data {
 	bool link_up;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 /* PHY Management pins */
 #define PIN_PHY_MDC {DT_INST_PROP_BY_IDX(0, location_phy_mdc, 1), \
 	DT_INST_PROP_BY_IDX(0, location_phy_mdc, 2), gpioModePushPull,\

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -34,8 +34,6 @@ struct phy_mii_dev_data {
 	struct k_sem sem;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static int phy_mii_get_link_state(const struct device *dev,
 				  struct phy_link_state *state);
 

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -30,8 +30,6 @@ static const struct flash_parameters flash_gecko_parameters = {
 	.erase_value = 0xff,
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static bool write_range_is_valid(off_t offset, uint32_t size);
 static bool read_range_is_valid(off_t offset, uint32_t size);
 static int erase_flash_block(off_t offset, size_t size);
@@ -204,7 +202,7 @@ static int flash_gecko_init(const struct device *dev)
 	/* Lock the MSC module. */
 	MSC->LOCK = 0;
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -105,8 +105,6 @@ struct flash_stm32_qspi_data {
 	bool flag_quad_io_en: 1;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static inline void qspi_lock_thread(const struct device *dev)
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
@@ -1110,7 +1108,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	}
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/i2s/i2s_cavs.c
+++ b/drivers/i2s/i2s_cavs.c
@@ -85,8 +85,6 @@ struct i2s_cavs_dev_data {
 	struct stream rx;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static void i2s_dma_tx_callback(const struct device *, void *, uint32_t, int);
 static void i2s_tx_stream_disable(struct i2s_cavs_dev_data *,
 		volatile struct i2s_cavs_ssp *const, const struct device *);
@@ -791,7 +789,7 @@ static int i2s_cavs_initialize(const struct device *dev)
 	dev_data->tx.state = I2S_STATE_NOT_READY;
 	dev_data->rx.state = I2S_STATE_NOT_READY;
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -98,8 +98,6 @@ struct i2s_sam_dev_data {
 	struct stream tx;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 #define MODULO_INC(val, max) { val = (++val < max) ? val : 0; }
 
 static const struct device *get_dev_from_dma_channel(uint32_t dma_channel);
@@ -980,7 +978,7 @@ static int i2s_sam_initialize(const struct device *dev)
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -31,8 +31,6 @@ struct mdio_sam_dev_config {
 	int protocol;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static int mdio_transfer(const struct device *dev, uint8_t prtad, uint8_t devad,
 			 uint8_t rw, uint16_t data_in, uint16_t *data_out)
 {
@@ -65,7 +63,7 @@ static int mdio_transfer(const struct device *dev, uint8_t prtad, uint8_t devad,
 	/* Wait until done */
 	while (!(cfg->regs->GMAC_NSR & GMAC_NSR_IDLE)) {
 		if (timeout-- == 0U) {
-			LOG_ERR("transfer timedout %s", DEV_NAME(dev));
+			LOG_ERR("transfer timedout %s", dev->name);
 			k_sem_give(&data->sem);
 
 			return -ETIMEDOUT;

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -27,8 +27,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(neural_net);
 
-#define DEV_NAME(dev) ((dev)->name)
-
 #if LOG_LEVEL >= LOG_LEVEL_DBG
 static void intel_gna_regs_dump(const struct device *dev);
 static void intel_gna_config_desc_dump(const struct device *dev);
@@ -188,25 +186,25 @@ static int intel_gna_initialize(const struct device *dev)
 			GNA_PG_DIR_ENTRY(&gna_page_table[page]) : (uint32_t)-1;
 		gna_config_desc.pagedir[page] = page_dir_entry;
 		LOG_DBG("%s: page %u pagetable %08x",
-			DEV_NAME(dev), page, gna_config_desc.pagedir[page]);
+			dev->name, page, gna_config_desc.pagedir[page]);
 	}
 	gna_config_desc.vamaxaddr = GNA_ADDRESSABLE_MEM_SIZE;
 	LOG_DBG("%s: max virtual address %08x",
-			DEV_NAME(dev), gna_config_desc.vamaxaddr);
+			dev->name, gna_config_desc.vamaxaddr);
 
 	/* flush cache */
 	SOC_DCACHE_FLUSH((void *)&gna_config_desc, sizeof(gna_config_desc));
 
 	LOG_INF("%s: initialized (max %u models & max %u pending requests)",
-			DEV_NAME(dev), GNA_MAX_NUM_MODELS,
+			dev->name, GNA_MAX_NUM_MODELS,
 			GNA_REQUEST_QUEUE_LEN);
 	LOG_INF("%s: max addressable memory %u MB",
-			DEV_NAME(dev), GNA_ADDRESSABLE_MEM_SIZE >> 20);
+			dev->name, GNA_ADDRESSABLE_MEM_SIZE >> 20);
 	LOG_INF("%s: %u page table(s) at %p and %u bytes",
-			DEV_NAME(dev), (uint32_t)GNA_NUM_PG_TABLES_NEEDED,
+			dev->name, (uint32_t)GNA_NUM_PG_TABLES_NEEDED,
 			gna_page_table, sizeof(gna_page_table));
 	LOG_INF("%s: configuration descriptor at %p",
-			DEV_NAME(dev), &gna_config_desc);
+			dev->name, &gna_config_desc);
 
 	/* register interrupt handler */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
@@ -266,7 +264,7 @@ static int intel_gna_configure(const struct device *dev,
 	INTEL_GNA_CONFIG_DESC_DUMP(dev);
 
 	LOG_INF("Device %s (version %u.%u) configured with power mode %u",
-			DEV_NAME(dev), regs->gnaversion >> 1,
+			dev->name, regs->gnaversion >> 1,
 			(uint32_t)(regs->gnaversion & BIT(0)),
 			CONFIG_INTEL_GNA_POWER_MODE);
 

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -34,8 +34,6 @@ struct qdec_sam_dev_data {
 	uint16_t position;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static int qdec_sam_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	const struct qdec_sam_dev_cfg *const dev_cfg = dev->config;
@@ -108,7 +106,7 @@ static int qdec_sam_initialize(const struct device *dev)
 
 	qdec_sam_configure(dev);
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -40,8 +40,6 @@ struct wdt_gecko_data {
 	bool timeout_installed;
 };
 
-#define DEV_NAME(dev) ((dev)->name)
-
 static uint32_t wdt_gecko_get_timeout_from_persel(int perSel)
 {
 	return (8 << perSel) + 1;
@@ -264,7 +262,7 @@ static int wdt_gecko_init(const struct device *dev)
 	/* Enable IRQs */
 	config->irq_cfg_func();
 
-	LOG_INF("Device %s initialized", DEV_NAME(dev));
+	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }


### PR DESCRIPTION
Just use dev->name. This change follow same principles applied when
DEV_CFG and DEV_DATA macros were removed.