### PR TITLE
Bluetooth: Controller: Fix power amp for transmit of chain scan resp

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -605,6 +605,10 @@ static inline int isr_rx_pdu(struct lll_adv_aux *lll_aux,
 							 lll->phy_flags,
 							 lll->phy_s,
 							 lll->phy_flags);
+#if defined(HAL_RADIO_GPIO_HAVE_PA_PIN)
+			radio_tmr_end_capture();
+#endif /* HAL_RADIO_GPIO_HAVE_PA_PIN */
+
 #endif /* CONFIG_BT_CTLR_ADV_PDU_BACK2BACK */
 
 		} else {


### PR DESCRIPTION
Fix power amp for transmitting of chain scan response
wherein capture of PDU end timestamp was missing causing
power amplifier from not being enabled for first chain PDU.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>