### PR TITLE
Bluetooth: Controller: Fix missing periodic accept list SID assignment

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -1418,6 +1418,7 @@ static uint32_t pal_add(const bt_addr_le_t *const id_addr, const uint8_t sid)
 
 	pal[i].id_addr_type = id_addr->type & 0x1;
 	bt_addr_copy(&pal[i].id_addr, &id_addr->a);
+	pal[i].sid = sid;
 
 #if defined(CONFIG_BT_CTLR_PRIVACY)
 	/* Get index to Resolving List if applicable */

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/src/main.c
@@ -38,7 +38,7 @@
 #define ADV_PHY_1M      BIT(0)
 #define ADV_PHY_2M      BIT(1)
 #define ADV_PHY_CODED   BIT(2)
-#define ADV_SID         0
+#define ADV_SID         0x0a
 #define SCAN_REQ_NOT    0
 
 #define AD_OP           0x03


### PR DESCRIPTION
Fix missing assignment of SID in the Periodic Advertiser
Accept List. This cause advertisers with SID 0 only to be
accepted when using list.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>