### PR TITLE
x86: Remove Jailhouse references in this arch

### DIFF
--- a/doc/_scripts/redirects.py
+++ b/doc/_scripts/redirects.py
@@ -136,7 +136,6 @@ REDIRECTS = [
     ('boards/x86/qemu_x86/doc/board', 'boards/x86/qemu_x86/doc/index'),
     ('boards/x86/tinytile/doc/board', 'boards/x86/tinytile/doc/index'),
     ('boards/x86/up_squared/doc/up_squared', 'boards/x86/up_squared/doc/index'),
-    ('boards/x86/x86_jailhouse/doc/board', 'boards/x86/x86_jailhouse/doc/index'),
     ('boards/xtensa/esp32/doc/esp32', 'boards/xtensa/esp32/doc/index'),
     ('boards/xtensa/intel_s1000_crb/doc/intel_s1000', 'boards/xtensa/intel_s1000_crb/doc/index'),
     ('boards/xtensa/qemu_xtensa/doc/board', 'boards/xtensa/qemu_xtensa/doc/index'),

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -143,9 +143,6 @@ void z_loapic_enable(unsigned char cpu_number)
 
 	/* program Local Vector Table for the Virtual Wire Mode */
 
-	/* skip LINT0/LINT1 for Jailhouse guest case, because we won't
-	 * ever be waiting for interrupts on those
-	 */
 	/* set LINT0: extInt, high-polarity, edge-trigger, not-masked */
 
 	x86_write_loapic(LOAPIC_LINT0, (x86_read_loapic(LOAPIC_LINT0) &


### PR DESCRIPTION
Jailhouse support in X86 was removed long time ago. Just removing some
leftovers.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>