### PR TITLE
dts: arm: atmel: Enable user-nrst by default

### DIFF
--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -216,6 +216,7 @@
 			reg = <0x400e1400 0x10>;
 			peripheral-id = <1>;
 			label = "RSTC";
+			user-nrst;
 		};
 	};
 };

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -498,6 +498,7 @@
 			reg = <0x400e1800 0x10>;
 			peripheral-id = <1>;
 			label = "RSTC";
+			user-nrst;
 		};
 	};
 };


### PR DESCRIPTION
The datasheet for both sam4s/same70 specifies that the NRST pin
is an input after reset, used as a user reset.

Add the user-nrst property to match the default.

Fixes #43306