### PR TITLE
ci: Update to Zephyr SDK 0.14.0

### DIFF
--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -23,11 +23,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: bluetooth-test-prep
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
       options: '--entrypoint /bin/bash'
     env:
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       BSIM_OUT_PATH: /opt/bsim/
       BSIM_COMPONENTS_PATH: /opt/bsim/components

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: zephyr_runner
     needs: clang-build-prep
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject
@@ -23,7 +23,7 @@ jobs:
       matrix:
         platform: ["native_posix"]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -18,14 +18,14 @@ jobs:
     runs-on: zephyr_runner
     needs: codecov-prep
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
       matrix:
         platform: ["native_posix", "qemu_x86", "unit_testing"]
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
     steps:
       - name: Update PATH for west

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -10,9 +10,9 @@ jobs:
   check-errno:
     runs-on: ubuntu-latest
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
 
     steps:
       - name: checkout

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -27,12 +27,12 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-tracking-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -16,12 +16,12 @@ jobs:
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       ZEPHYR_TOOLCHAIN_VARIANT: zephyr
     steps:

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: zephyr_runner
     needs: twister-build-cleanup
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject
@@ -37,7 +37,7 @@ jobs:
       MATRIX_SIZE: 10
       PUSH_MATRIX_SIZE: 15
       DAILY_MATRIX_SIZE: 80
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TESTS_PER_BUILDER: 700
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
@@ -110,7 +110,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: zephyrprojectrtos/ci:v0.21.0
+      image: zephyrprojectrtos/ci:v0.22.0
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject
@@ -119,7 +119,7 @@ jobs:
       matrix:
         subset: ${{fromJSON(needs.twister-build-prep.outputs.subset)}}
     env:
-      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.13.2
+      ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.0
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TWISTER_COMMON: ' --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all --no-skipped-report'


### PR DESCRIPTION
Pull in the CI docker image v0.22.0, which contains the Zephyr SDK
0.14.0 release, and use the Zephyr SDK 0.14.0 for building and testing
Zephyr in the CI.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Tested in https://github.com/zephyrproject-rtos/zephyr-testing/actions/runs/1991610068
Documentation updates to be reviewed/merged as part of #43008