### PR TITLE
Do not relocate vector table on ARMv8-R aarch32

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/reset.S
+++ b/arch/arm/core/aarch32/cortex_a_r/reset.S
@@ -61,11 +61,7 @@ SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start)
     ldr r0, =HACTLR_INIT
     mcr p15, 4, r0, c1, c0, 1
 
-    /* Change EL1 exception base address */
-    ldr r0,=_vector_table
-    mcr p15, 0, r0, c12, c0, 0 /* Write to VBAR */
-
-    /* Go to SVC mode */
+   /* Go to SVC mode */
     mrs r0, cpsr
     bic r0, #MODE_MASK
     orr r0, #MODE_SVC

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -53,8 +53,17 @@ static inline void relocate_vector_table(void)
 	__ISB();
 }
 
-#else
+#elif defined(CONFIG_AARCH32_ARMV8_R)
 
+#define VECTOR_ADDRESS ((uintptr_t)_vector_start)
+
+static inline void relocate_vector_table(void)
+{
+	write_vbar(VECTOR_ADDRESS & VBAR_MASK);
+	__ISB();
+}
+
+#else
 #define VECTOR_ADDRESS 0
 
 void __weak relocate_vector_table(void)

--- a/include/arch/arm/aarch32/cortex_a_r/cpu.h
+++ b/include/arch/arm/aarch32/cortex_a_r/cpu.h
@@ -48,6 +48,7 @@
 #define DFSR_AXI_SLAVE_MASK	(1 << 12)
 
 /* Armv8-R AArch32 architecture profile */
+#define VBAR_MASK		(0xFFFFFFE0U)
 #define SCTLR_M_BIT		BIT(0)
 #define SCTLR_A_BIT		BIT(1)
 #define SCTLR_C_BIT		BIT(2)

--- a/include/arch/arm/aarch32/cortex_a_r/lib_helpers.h
+++ b/include/arch/arm/aarch32/cortex_a_r/lib_helpers.h
@@ -68,6 +68,7 @@ MAKE_REG_HELPER(sctlr,	     0, 1, 0, 0);
 MAKE_REG_HELPER(prselr,	     0, 6, 2, 1);
 MAKE_REG_HELPER(prbar,	     0, 6, 3, 0);
 MAKE_REG_HELPER(prlar,	     0, 6, 3, 1);
+MAKE_REG_HELPER(vbar,        0, 12, 0, 0);
 MAKE_REG_HELPER(cntv_ctl,    0, 14,  3, 1);
 MAKE_REG64_HELPER(ICC_SGI1R, 0, 12);
 MAKE_REG64_HELPER(cntvct,    1, 14);


### PR DESCRIPTION
ARMv8-R allows to set the vector table address using VBAR
register, so there is no need to relocate it.

Move away vector_table setting from reset.S and move it to
relocate vector table function as it's done for Cortex-M
CPU.

Signed-off-by: Julien Massot <julien.massot@iot.bzh>