### PR TITLE
stm32: Fix adc implementation for G4  series

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -804,14 +804,32 @@ static void adc_stm32_setup_speed(const struct device *dev, uint8_t id,
 static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_id)
 {
 	const struct adc_stm32_cfg *config = dev->config;
+#ifdef CONFIG_SOC_SERIES_STM32G4X
+	ADC_TypeDef *adc = config->base;
 
+	if (config->has_temp_channel) {
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay)
+		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC1) == channel_id)
+		    && (adc == ADC1)) {
+			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
+		}
+#endif
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(adc5), okay)
+		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC5) == channel_id)
+		   && (adc == ADC5)) {
+			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
+		}
+#endif
+	}
+#else
 	if (config->has_temp_channel &&
-		__LL_ADC_CHANNEL_TO_DECIMAL_NB(ADC_CHANNEL_TEMPSENSOR) == channel_id) {
+		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR) == channel_id) {
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 	}
+#endif /* CONFIG_SOC_SERIES_STM32G4X */
 
 	if (config->has_vref_channel &&
-		__LL_ADC_CHANNEL_TO_DECIMAL_NB(ADC_CHANNEL_VREFINT) == channel_id) {
+		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_VREFINT) == channel_id) {
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_VREFINT);
 	}
 }

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -81,6 +81,8 @@
 			status = "disabled";
 			label = "ADC_1";
 			#io-channel-cells = <1>;
+			has-vref-channel;
+			has-temp-channel;
 		};
 
 		adc2: adc@50000100 {

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -67,6 +67,7 @@
 			status = "disabled";
 			label = "ADC_3";
 			#io-channel-cells = <1>;
+			has-vref-channel;
 		};
 
 		adc4: adc@50000500 {
@@ -87,6 +88,7 @@
 			status = "disabled";
 			label = "ADC_5";
 			#io-channel-cells = <1>;
+			has-temp-channel;
 		};
 	};
 };

--- a/dts/arm/st/g4/stm32g474.dtsi
+++ b/dts/arm/st/g4/stm32g474.dtsi
@@ -139,6 +139,7 @@
 			status = "disabled";
 			label = "ADC_3";
 			#io-channel-cells = <1>;
+			has-vref-channel;
 		};
 
 		adc4: adc@50000500 {
@@ -159,6 +160,7 @@
 			status = "disabled";
 			label = "ADC_5";
 			#io-channel-cells = <1>;
+			has-temp-channel;
 		};
 	};
 };

--- a/dts/arm/st/g4/stm32g483.dtsi
+++ b/dts/arm/st/g4/stm32g483.dtsi
@@ -67,6 +67,7 @@
 			status = "disabled";
 			label = "ADC_3";
 			#io-channel-cells = <1>;
+			has-vref-channel;
 		};
 
 		adc4: adc@50000500 {
@@ -87,6 +88,7 @@
 			status = "disabled";
 			label = "ADC_5";
 			#io-channel-cells = <1>;
+			has-temp-channel;
 		};
 	};
 };

--- a/dts/arm/st/g4/stm32g484.dtsi
+++ b/dts/arm/st/g4/stm32g484.dtsi
@@ -67,6 +67,7 @@
 			status = "disabled";
 			label = "ADC_3";
 			#io-channel-cells = <1>;
+			has-vref-channel;
 		};
 
 		adc4: adc@50000500 {
@@ -87,6 +88,7 @@
 			status = "disabled";
 			label = "ADC_5";
 			#io-channel-cells = <1>;
+			has-temp-channel;
 		};
 	};
 };

--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -49,6 +49,7 @@
 			status = "disabled";
 			label = "ADC_3";
 			#io-channel-cells = <1>;
+			has-vref-channel;
 		};
 	};
 };

--- a/dts/arm/st/g4/stm32g4a1.dtsi
+++ b/dts/arm/st/g4/stm32g4a1.dtsi
@@ -49,6 +49,7 @@
 			status = "disabled";
 			label = "ADC_3";
 			#io-channel-cells = <1>;
+			has-vref-channel;
 		};
 	};
 };


### PR DESCRIPTION
Following https://github.com/zephyrproject-rtos/zephyr/pull/42567, https://github.com/zephyrproject-rtos/zephyr/pull/43752 and https://github.com/zephyrproject-rtos/zephyr/pull/43805, fix G4 implementation in adc_stm32 driver.

Fixes #43888

~~Based on https://github.com/zephyrproject-rtos/zephyr/pull/43936 to avoid a checkpatch false positive.~~ Merged