### PR TITLE
 stm32 adc define the internal voltage reference

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -40,6 +40,9 @@ LOG_MODULE_REGISTER(adc_stm32);
 #endif
 #endif
 
+/* reference voltage for the ADC */
+#define STM32_ADC_VREF_MV DT_INST_PROP(0, vref_mv)
+
 #if !defined(CONFIG_SOC_SERIES_STM32F0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32G0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32L0X) && \
@@ -1079,6 +1082,7 @@ static const struct adc_driver_api api_stm32_driver_api = {
 #ifdef CONFIG_ADC_ASYNC
 	.read_async = adc_stm32_read_async,
 #endif
+	.ref_internal = STM32_ADC_VREF_MV, /* VREF is usually connected to VDD */
 };
 
 #ifdef CONFIG_ADC_STM32_SHARED_IRQS

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -27,6 +27,12 @@ properties:
     pinctrl-names:
       required: true
 
+    vref_mv:
+      type: int
+      required: false
+      default: 3300
+      description: Indicates the reference voltage of the ADC in mV.
+
     has-temp-channel:
       type: boolean
       description: Indicates if the ADC has a dedicated internal temperature sensor channel.


### PR DESCRIPTION
This change is to define the ref_internal as a pvalue of the adc_driver_api
This Analog reference voltage for the ADC is given by the board AVDD to the VREF+ input of the MCU
It is usually connected to the VDD supply line.

Signed-off-by: Francois Ramu <francois.ramu@st.com>