### PR TITLE
samples: subsys: mgmt: smp_svr: Fix dupicate fs mgmt registration

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -90,9 +90,6 @@ void main(void)
 #ifdef CONFIG_MCUMGR_CMD_SHELL_MGMT
 	shell_mgmt_register_group();
 #endif
-#ifdef CONFIG_MCUMGR_CMD_FS_MGMT
-	fs_mgmt_register_group();
-#endif
 #ifdef CONFIG_MCUMGR_SMP_BT
 	start_smp_bluetooth();
 #endif


### PR DESCRIPTION
This fixes an issue with the filesystem mcumgr being registered twice
in the sample application which resolves an issue with an endless loop
if a mcumgr handler is used which is not registered.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/43858