### PR TITLE
test: portability.posix.common.newlib: exclude lpcxpresso55s06

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -10,7 +10,7 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=n
   portability.posix.common.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb lpcxpresso55s06
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
@@ -26,7 +26,7 @@ tests:
       - CONFIG_THREAD_LOCAL_STORAGE=y
       - CONFIG_MAIN_STACK_SIZE=1152
   portability.posix.common.tls.newlib:
-    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb
+    platform_exclude: nsim_sem_mpu_stack_guard ehl_crb lpcxpresso55s06
     filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_ARCH_HAS_THREAD_LOCAL_STORAGE and CONFIG_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
exclude newlib for posix testing as the MAX_HEAP_SIZE will be
too small if enabled NEWLIBC

Fixes #43873

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>