### PR TITLE
devicetree_regions: Remove path fallback and sanitize name

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -3442,10 +3442,7 @@ function(zephyr_linker_dts_memory)
   dt_reg_addr(addr PATH ${DTS_MEMORY_PATH})
   dt_reg_size(size PATH ${DTS_MEMORY_PATH})
   dt_prop(name PATH ${DTS_MEMORY_PATH} PROPERTY "zephyr,memory-region")
-  if (NOT DEFINED name)
-    # Fallback to the node path
-    set(name ${DTS_MEMORY_PATH})
-  endif()
+  zephyr_string(SANITIZE name ${name})
 
   zephyr_linker_memory(
     NAME  ${name}

--- a/include/linker/devicetree_regions.h
+++ b/include/linker/devicetree_regions.h
@@ -10,8 +10,8 @@
 /**
  * @brief Get the linker memory-region name
  *
- * This attempts to use the zephyr,memory-region property, falling back
- * to the node path if it doesn't exist.
+ * This attempts to use the zephyr,memory-region property (with
+ * non-alphanumeric characters replaced with underscores).
  *
  * Example devicetree fragment:
  *
@@ -20,27 +20,28 @@
  *                     sram1: memory@2000000 {
  *                         zephyr,memory-region = "MY_NAME";
  *                     };
- *                     sram2: memory@2001000 { ... };
+ *                     sram2: memory@2001000 {
+ *                         zephyr,memory-region = "MY@OTHER@NAME";
+ *                     };
  *             };
  *     };
  *
  * Example usage:
  *
  *    LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram1)) // "MY_NAME"
- *    LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram2)) // "/soc/memory@2001000"
+ *    LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(sram2)) // "MY_OTHER_NAME"
  *
  * @param node_id node identifier
  * @return the name of the memory memory region the node will generate
  */
 #define LINKER_DT_NODE_REGION_NAME(node_id) \
-	DT_PROP_OR(node_id, zephyr_memory_region, DT_NODE_PATH(node_id))
+	DT_STRING_TOKEN(node_id, zephyr_memory_region)
 
 /** @cond INTERNAL_HIDDEN */
 
 #define _DT_COMPATIBLE	zephyr_memory_region
 
-#define _DT_SECTION_NAME(node_id)	DT_STRING_TOKEN(node_id, zephyr_memory_region)
-#define _DT_SECTION_PREFIX(node_id)	UTIL_CAT(__, _DT_SECTION_NAME(node_id))
+#define _DT_SECTION_PREFIX(node_id)	UTIL_CAT(__, LINKER_DT_NODE_REGION_NAME(node_id))
 #define _DT_SECTION_START(node_id)	UTIL_CAT(_DT_SECTION_PREFIX(node_id), _start)
 #define _DT_SECTION_END(node_id)	UTIL_CAT(_DT_SECTION_PREFIX(node_id), _end)
 #define _DT_SECTION_SIZE(node_id)	UTIL_CAT(_DT_SECTION_PREFIX(node_id), _size)
@@ -64,15 +65,15 @@
  * @param node_id devicetree node identifier
  */
 #define _SECTION_DECLARE(node_id)								\
-	_DT_SECTION_NAME(node_id) DT_REG_ADDR(node_id) (NOLOAD) :				\
+	LINKER_DT_NODE_REGION_NAME(node_id) DT_REG_ADDR(node_id) (NOLOAD) :			\
 	{											\
 		_DT_SECTION_START(node_id) = .;							\
-		KEEP(*(_DT_SECTION_NAME(node_id)))						\
-		KEEP(*(_DT_SECTION_NAME(node_id).*))						\
+		KEEP(*(LINKER_DT_NODE_REGION_NAME(node_id)))					\
+		KEEP(*(LINKER_DT_NODE_REGION_NAME(node_id).*))					\
 		_DT_SECTION_END(node_id) = .;							\
-	} > _DT_SECTION_NAME(node_id)								\
+	} > LINKER_DT_NODE_REGION_NAME(node_id)							\
 	_DT_SECTION_SIZE(node_id) = _DT_SECTION_END(node_id) - _DT_SECTION_START(node_id);	\
-	_DT_SECTION_LOAD(node_id) = LOADADDR(_DT_SECTION_NAME(node_id));
+	_DT_SECTION_LOAD(node_id) = LOADADDR(LINKER_DT_NODE_REGION_NAME(node_id));
 
 /** @endcond */
 

--- a/tests/lib/devicetree/api_ext/app.overlay
+++ b/tests/lib/devicetree/api_ext/app.overlay
@@ -22,8 +22,9 @@
 			zephyr,memory-region = "SRAM_REGION";
 		};
 		test_sram2: sram@20001000 {
-			compatible = "mmio-sram";
+			compatible = "zephyr,memory-region", "mmio-sram";
 			reg = < 0x20001000 0x1000 >;
+			zephyr,memory-region = "SRAM@REGION#2";
 		};
 	};
 };

--- a/tests/lib/devicetree/api_ext/src/main.c
+++ b/tests/lib/devicetree/api_ext/src/main.c
@@ -17,8 +17,10 @@
 
 static void test_linker_regions(void)
 {
-	zassert_true(!strcmp(LINKER_DT_NODE_REGION_NAME(TEST_SRAM1), "SRAM_REGION"), "");
-	zassert_true(!strcmp(LINKER_DT_NODE_REGION_NAME(TEST_SRAM2), "/test/sram@20001000"), "");
+	zassert_true(!strcmp(STRINGIFY(LINKER_DT_NODE_REGION_NAME(TEST_SRAM1)),
+		     "SRAM_REGION"), "");
+	zassert_true(!strcmp(STRINGIFY(LINKER_DT_NODE_REGION_NAME(TEST_SRAM2)),
+		     "SRAM_REGION_2"), "");
 }
 
 void test_main(void)


### PR DESCRIPTION
This patch is doing two things:

- it is removing the fallback on the path for `LINKER_DT_NODE_REGION_NAME`. This is not possible anymore since the DT binding file is now actually requiring the `zephyr,memory-region` property to be present from which the region name is obtained.

- it is sanitizing the name when `CONFIG_CMAKE_LINKER_GENERATOR` is used or not.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>