### PR TITLE
drivers: uart_nrfx_uarte: Fix USE_LOW_POWER macro for PINCTRL case

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2027,7 +2027,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
  * kconfig option is enabled.
  */
 #define USE_LOW_POWER(idx) \
-	((!UARTE_HAS_PROP(idx, disable_rx) &&				       \
+	((!UARTE_PROP(idx, disable_rx) &&				       \
 	COND_CODE_1(CONFIG_UART_##idx##_ASYNC,				       \
 		(!IS_ENABLED(CONFIG_UART_##idx##_NRF_ASYNC_LOW_POWER)),	       \
 		(1))) ? 0 : UARTE_CFG_FLAG_LOW_POWER)


### PR DESCRIPTION
This macro incorrectly uses DT_NODE_HAS_PROP() to check the truth value
of the "disable-rx" boolean property. In consequence, it always assumed
that RX is disabled and the low power mode needs to be used. Fix this
by replacing the check with DT_PROP().

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>