### PR TITLE
drivers: console: adds hardware CDC as option for console and shell for esp32c3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -230,6 +230,7 @@
 /drivers/clock_control/*rcar*             @aaillet
 /drivers/counter/                         @nordic-krch
 /drivers/console/ipm_console.c            @finikorg
+/drivers/console/esp32_hw_cdc_console.c   @uLipe
 /drivers/console/semihost_console.c       @luozhongyao
 /drivers/console/jailhouse_debug_console.c @MrVan
 /drivers/counter/counter_cmos.c           @dcpleung

--- a/drivers/console/CMakeLists.txt
+++ b/drivers/console/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 zephyr_library()
+zephyr_library_sources_ifdef(CONFIG_ESP32_CDC_CONSOLE esp32_hw_cdc_console.c)
 zephyr_library_sources_ifdef(CONFIG_GSM_MUX gsm_mux.c)
 zephyr_library_sources_ifdef(CONFIG_IPM_CONSOLE_RECEIVER ipm_console_receiver.c)
 zephyr_library_sources_ifdef(CONFIG_IPM_CONSOLE_SENDER ipm_console_sender.c)

--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -40,6 +40,15 @@ config CONSOLE_INIT_PRIORITY
 	help
 	  Console driver device initialization priority.
 
+config ESP32_CDC_CONSOLE
+	bool "Use ESP32 Hardware CDC for console"
+	depends on SOC_ESP32C3
+	default n
+	select CONSOLE_HAS_DRIVER
+	help
+	  Enable this option to esp32 enabled chips to use their
+	  hardware CDC as console output.
+
 config UART_CONSOLE
 	bool "Use UART for console"
 	depends on SERIAL && SERIAL_HAS_DRIVER

--- a/drivers/console/esp32_hw_cdc_console.c
+++ b/drivers/console/esp32_hw_cdc_console.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <kernel.h>
+#include <sys/printk.h>
+#include <device.h>
+#include <init.h>
+#include <soc.h>
+
+extern void __stdout_hook_install(int (*hook)(int));
+extern void __printk_hook_install(int (*fn)(int));
+
+static int esp32_hw_console_out(int character)
+{
+	/* console over cdc on esp32 uses the same uart rom
+	 * functions
+	 */
+	esp_rom_usb_uart_tx_one_char(character);
+	return 0;
+}
+
+static int esp32_hw_console_init(const struct device *d)
+{
+	ARG_UNUSED(d);
+
+	__stdout_hook_install(esp32_hw_console_out);
+	__printk_hook_install(esp32_hw_console_out);
+
+	return 0;
+}
+
+SYS_INIT(esp32_hw_console_init, PRE_KERNEL_1, CONFIG_CONSOLE_INIT_PRIORITY);

--- a/soc/riscv/esp32c3/soc.h
+++ b/soc/riscv/esp32c3/soc.h
@@ -42,6 +42,8 @@ extern void esp_rom_uart_attach(void);
 extern void esp_rom_uart_tx_wait_idle(uint8_t uart_no);
 extern STATUS esp_rom_uart_tx_one_char(uint8_t chr);
 extern STATUS esp_rom_uart_rx_one_char(uint8_t *chr);
+extern int esp_rom_usb_uart_tx_one_char(uint8_t chr);
+extern int esp_rom_usb_uart_rx_one_char(uint8_t *chr);
 extern int esp_rom_gpio_matrix_in(uint32_t gpio, uint32_t signal_index, bool inverted);
 extern int esp_rom_gpio_matrix_out(uint32_t gpio, uint32_t signal_index,
 				bool out_invrted, bool out_enabled_inverted);
@@ -63,7 +65,6 @@ extern int esp_rom_gpio_matrix_in(uint32_t gpio, uint32_t signal_index,
 extern int esp_rom_gpio_matrix_out(uint32_t gpio, uint32_t signal_index,
 				     bool out_inverted,
 				     bool out_enabled_inverted);
-
 #endif /* _ASMLANGUAGE */
 
 #endif /* __SOC_H__ */

--- a/subsys/shell/backends/CMakeLists.txt
+++ b/subsys/shell/backends/CMakeLists.txt
@@ -11,6 +11,11 @@ zephyr_sources_ifdef(
 )
 
 zephyr_sources_ifdef(
+  CONFIG_SHELL_BACKEND_ESP32_HW_CDC
+  shell_esp32_hw_cdc.c
+)
+
+zephyr_sources_ifdef(
   CONFIG_SHELL_BACKEND_RTT
   shell_rtt.c
 )

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -119,6 +119,24 @@ config SHELL_BACKEND_SERIAL_LOG_LEVEL
 
 endif # SHELL_BACKEND_SERIAL
 
+config SHELL_BACKEND_ESP32_HW_CDC
+	bool "Enable ESP32 HW CDC backend"
+	select CONSOLE
+	select ESP32_CDC_CONSOLE
+	depends on SOC_ESP32C3
+	help
+	  Enable shell backend over ESP32 hardware CDC.
+
+if SHELL_BACKEND_ESP32_HW_CDC
+
+config SHELL_PROMPT_ESP32_HW_CDC
+	string "Displayed prompt name"
+	default "~$ "
+	help
+	  Displayed prompt name for ESP32 HW CDC backend.
+
+endif
+
 config SHELL_BACKEND_RTT
 	bool "RTT backend"
 	select CONSOLE

--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -120,12 +120,12 @@ config SHELL_BACKEND_SERIAL_LOG_LEVEL
 endif # SHELL_BACKEND_SERIAL
 
 config SHELL_BACKEND_ESP32_HW_CDC
-	bool "Enable ESP32 HW CDC backend"
+	bool "ESP32 HW CDC backend"
 	select CONSOLE
 	select ESP32_CDC_CONSOLE
 	depends on SOC_ESP32C3
 	help
-	  Enable shell backend over ESP32 hardware CDC.
+		Enables shell backend over ESP32 hardware CDC.
 
 if SHELL_BACKEND_ESP32_HW_CDC
 

--- a/subsys/shell/backends/shell_esp32_hw_cdc.c
+++ b/subsys/shell/backends/shell_esp32_hw_cdc.c
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <shell/shell.h>
+#include <init.h>
+#include <logging/log.h>
+#include <soc.h>
+
+static struct shell_transport shell_transport_esp32_hw_cdc;
+
+SHELL_DEFINE(shell_esp32_hw_cdc, CONFIG_SHELL_PROMPT_ESP32_HW_CDC, &shell_transport_esp32_hw_cdc,
+	     1, 0, SHELL_FLAG_OLF_CRLF);
+
+static int init(const struct shell_transport *transport,
+		const void *config,
+		shell_transport_handler_t evt_handler,
+		void *context)
+{
+	return 0;
+}
+
+static int uninit(const struct shell_transport *transport)
+{
+	return 0;
+}
+
+static int enable(const struct shell_transport *transport, bool blocking)
+{
+	return 0;
+}
+
+static int write(const struct shell_transport *transport,
+		 const void *data, size_t length, size_t *cnt)
+{
+
+	*cnt = length;
+	uint8_t *ptr = (uint8_t *)data;
+
+	while (length--) {
+		esp_rom_usb_uart_tx_one_char(*ptr++);
+	}
+
+	return 0;
+}
+
+static int read(const struct shell_transport *transport,
+		void *data, size_t length, size_t *cnt)
+{
+	int result = esp_rom_usb_uart_rx_one_char((uint8_t *)data);
+
+	if (result) {
+		*cnt = 0;
+	} else {
+		*cnt = 1;
+	}
+
+	return 0;
+}
+
+const struct shell_transport_api shell_transport_esp32_hw_cdc_api = {
+	.init = init,
+	.uninit = uninit,
+	.enable = enable,
+	.write = write,
+	.read = read
+};
+
+static int enable_shell_esp32_hw_cdc(const struct device *arg)
+{
+	ARG_UNUSED(arg);
+
+	shell_transport_esp32_hw_cdc.api = &shell_transport_esp32_hw_cdc_api;
+
+	static const struct shell_backend_config_flags cfg_flags =
+					SHELL_DEFAULT_BACKEND_CONFIG_FLAGS;
+	shell_init(&shell_esp32_hw_cdc, NULL, cfg_flags, true, LOG_LEVEL_INF);
+	return 0;
+}
+SYS_INIT(enable_shell_esp32_hw_cdc, POST_KERNEL, 0);


### PR DESCRIPTION
This PR adds the hardware CDC of esp32c3 as an option for console and shell backend. 