### PR TITLE
boards: Remove superfluous comments in boards.dts

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpunet.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpunet.dts
@@ -57,10 +57,6 @@
 };
 
 &flash1 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -135,10 +135,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/bl654_usb/bl654_usb.dts
+++ b/boards/arm/bl654_usb/bl654_usb.dts
@@ -61,10 +61,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
@@ -104,10 +104,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -133,10 +133,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -299,10 +299,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -110,10 +110,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4180a.dts
@@ -97,15 +97,6 @@
 };
 
 &flash0 {
-	/*
-	 * If the chosen node has no zephyr,code-partition property, the
-	 * application image link uses the entire flash device. If a
-	 * zephyr,code-partition property is defined, the application link
-	 * will be restricted to that partition.
-	 *
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -191,10 +191,6 @@ zephyr_udc0: &usbotg {
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -126,10 +126,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -115,10 +115,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -164,10 +164,6 @@ zephyr_udc0: &usbotg_fs {
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -142,10 +142,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
+++ b/boards/arm/nucleo_l452re/nucleo_l452re_common.dtsi
@@ -105,10 +105,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -189,10 +189,6 @@ zephyr_udc0: &usb {
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * https://docs.zephyrproject.org/latest/reference/devicetree/index.html#fixed-flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -178,10 +178,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -175,10 +175,6 @@
 };
 
 &flash0 {
-	/*
-	 * For more information, see:
-	 * http://docs.zephyrproject.org/latest/guides/dts/index.html#flash-partitions
-	 */
 	partitions {
 		compatible = "fixed-partitions";
 		#address-cells = <1>;


### PR DESCRIPTION
If more information is required on anything, one should look at
documentation, no point to add a specific comment about it.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>