### PR TITLE
arm64: refer to the link register as "lr" rather than "x30"

### DIFF
--- a/arch/arm64/core/cpu_idle.S
+++ b/arch/arm64/core/cpu_idle.S
@@ -17,9 +17,9 @@ _ASM_FILE_PROLOGUE
 GTEXT(arch_cpu_idle)
 SECTION_FUNC(TEXT, arch_cpu_idle)
 #ifdef CONFIG_TRACING
-	stp	xzr, x30, [sp, #-16]!
+	str	lr, [sp, #-16]!
 	bl	sys_trace_idle
-	ldp	xzr, x30, [sp], #16
+	ldr	lr, [sp], #16
 #endif
 	dsb	sy
 	wfi
@@ -29,9 +29,9 @@ SECTION_FUNC(TEXT, arch_cpu_idle)
 GTEXT(arch_cpu_atomic_idle)
 SECTION_FUNC(TEXT, arch_cpu_atomic_idle)
 #ifdef CONFIG_TRACING
-	stp	x0, x30, [sp, #-16]!
+	stp	x0, lr, [sp, #-16]!
 	bl	sys_trace_idle
-	ldp	x0, x30, [sp], #16
+	ldp	x0, lr, [sp], #16
 #endif
 	msr	daifset, #(DAIFSET_IRQ_BIT)
 	isb

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -167,7 +167,7 @@ static void esf_dump(const z_arch_esf_t *esf)
 	LOG_ERR("x12: 0x%016llx  x13: 0x%016llx", esf->x12, esf->x13);
 	LOG_ERR("x14: 0x%016llx  x15: 0x%016llx", esf->x14, esf->x15);
 	LOG_ERR("x16: 0x%016llx  x17: 0x%016llx", esf->x16, esf->x17);
-	LOG_ERR("x18: 0x%016llx  x30: 0x%016llx", esf->x18, esf->x30);
+	LOG_ERR("x18: 0x%016llx  lr:  0x%016llx", esf->x18, esf->lr);
 }
 #endif /* CONFIG_EXCEPTION_DEBUG */
 

--- a/arch/arm64/core/offsets/offsets.c
+++ b/arch/arm64/core/offsets/offsets.c
@@ -43,7 +43,7 @@ GEN_NAMED_OFFSET_SYM(_callee_saved_t, sp_elx, sp_elx_lr);
 GEN_ABSOLUTE_SYM(___callee_saved_t_SIZEOF, sizeof(struct _callee_saved));
 
 GEN_NAMED_OFFSET_SYM(_esf_t, spsr, spsr_elr);
-GEN_NAMED_OFFSET_SYM(_esf_t, x18, x18_x30);
+GEN_NAMED_OFFSET_SYM(_esf_t, x18, x18_lr);
 GEN_NAMED_OFFSET_SYM(_esf_t, x16, x16_x17);
 GEN_NAMED_OFFSET_SYM(_esf_t, x14, x14_x15);
 GEN_NAMED_OFFSET_SYM(_esf_t, x12, x12_x13);

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -38,7 +38,7 @@ SECTION_FUNC(TEXT,z_arm64_el1_plat_prep_c)
 GTEXT(__reset_prep_c)
 SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset_prep_c)
 	/* return address: x23 */
-	mov	x23, x30
+	mov	x23, lr
 
 	switch_el x0, 3f, 2f, 1f
 3:

--- a/arch/arm64/core/switch.S
+++ b/arch/arm64/core/switch.S
@@ -99,15 +99,15 @@ SECTION_FUNC(TEXT, z_arm64_context_switch)
 	mov	sp, x4
 
 #ifdef CONFIG_USERSPACE
-	stp     xzr, x30, [sp, #-16]!
+	str     lr, [sp, #-16]!
 	bl      z_arm64_swap_mem_domains
-	ldp     xzr, x30, [sp], #16
+	ldr     lr, [sp], #16
 #endif
 
 #ifdef CONFIG_INSTRUMENT_THREAD_SWITCHING
-	stp	xzr, x30, [sp, #-16]!
+	str	lr, [sp, #-16]!
 	bl	z_thread_mark_switched_in
-	ldp	xzr, x30, [sp], #16
+	ldr	lr, [sp], #16
 #endif
 
 	/* Return to arch_switch() or _isr_wrapper() */

--- a/arch/arm64/core/vector_table.S
+++ b/arch/arm64/core/vector_table.S
@@ -17,9 +17,9 @@
 _ASM_FILE_PROLOGUE
 
 /*
- * Save volatile registers, x30, SPSR_EL1 and ELR_EL1
+ * Save volatile registers, LR, SPSR_EL1 and ELR_EL1
  *
- * Save the volatile registers and x30 on the process stack. This is
+ * Save the volatile registers and LR on the process stack. This is
  * needed if the thread is switched out because they can be clobbered by the
  * ISR and/or context switch.
  */
@@ -45,7 +45,7 @@ _ASM_FILE_PROLOGUE
 	stp	x12, x13, [sp, ___esf_t_x12_x13_OFFSET]
 	stp	x14, x15, [sp, ___esf_t_x14_x15_OFFSET]
 	stp	x16, x17, [sp, ___esf_t_x16_x17_OFFSET]
-	stp	x18, x30, [sp, ___esf_t_x18_x30_OFFSET]
+	stp	x18, lr, [sp, ___esf_t_x18_lr_OFFSET]
 
 	mrs	\xreg0, spsr_el1
 	mrs	\xreg1, elr_el1
@@ -205,7 +205,7 @@ SECTION_FUNC(TEXT, z_arm64_serror)
 	b	z_arm64_exit_exc
 
 /*
- * Restore volatile registers, x30, SPSR_EL1 and ELR_EL1
+ * Restore volatile registers, LR, SPSR_EL1 and ELR_EL1
  *
  * This is the common exit point for z_arm64_sync_exc() and _isr_wrapper().
  */
@@ -242,7 +242,7 @@ SECTION_FUNC(TEXT, z_arm64_exit_exc)
 	ldp	x12, x13, [sp, ___esf_t_x12_x13_OFFSET]
 	ldp	x14, x15, [sp, ___esf_t_x14_x15_OFFSET]
 	ldp	x16, x17, [sp, ___esf_t_x16_x17_OFFSET]
-	ldp	x18, x30, [sp, ___esf_t_x18_x30_OFFSET]
+	ldp	x18, lr, [sp, ___esf_t_x18_lr_OFFSET]
 
 	add	sp, sp, ___esf_t_SIZEOF
 

--- a/include/arch/arm64/exc.h
+++ b/include/arch/arm64/exc.h
@@ -44,7 +44,7 @@ struct __esf {
 	uint64_t x16;
 	uint64_t x17;
 	uint64_t x18;
-	uint64_t x30;
+	uint64_t lr;
 	uint64_t spsr;
 	uint64_t elr;
 } __aligned(16);


### PR DESCRIPTION
In ARM parlance, the subroutine call return address is stored in the
"link register" or simply lr. Refer to it as lr which is clearer than
the anonymous x30 designation.

Signed-off-by: Nicolas Pitre <npitre@baylibre.com>
