### PR TITLE
net: add ability to check that interface initialisation passed

### DIFF
--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -35,7 +35,7 @@ struct socket_can_context {
 	struct k_thread rx_thread_data;
 };
 
-static inline void socket_can_iface_init(struct net_if *iface)
+static inline int socket_can_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct socket_can_context *socket_context = dev->data;
@@ -43,6 +43,8 @@ static inline void socket_can_iface_init(struct net_if *iface)
 	socket_context->iface = iface;
 
 	LOG_DBG("Init CAN interface %p dev %p", iface, dev);
+
+	return 0;
 }
 
 static inline void tx_irq_callback(int error, void *arg)

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -954,7 +954,7 @@ static struct net_if *dsa_ksz8xxx_get_iface(struct net_if *iface,
 }
 #endif
 
-static void dsa_iface_init(struct net_if *iface)
+static int dsa_iface_init(struct net_if *iface)
 {
 	struct dsa_slave_config *cfg = (struct dsa_slave_config *)
 		net_if_get_device(iface)->config;
@@ -971,7 +971,7 @@ static void dsa_iface_init(struct net_if *iface)
 		context->iface_master = net_if_lookup_by_dev(dm);
 		if (context->iface_master == NULL) {
 			LOG_ERR("DSA: Master iface NOT found!");
-			return;
+			return -EINVAL;
 		}
 
 		/*
@@ -1009,6 +1009,7 @@ static void dsa_iface_init(struct net_if *iface)
 		k_work_init_delayable(&context->dsa_work, dsa_delayed_work);
 		k_work_reschedule(&context->dsa_work, DSA_STATUS_PERIOD_MS);
 	}
+	return 0;
 }
 
 static enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -508,7 +508,7 @@ static int dwmac_set_config(const struct device *dev,
 	return ret;
 }
 
-static void dwmac_iface_init(struct net_if *iface)
+static int dwmac_iface_init(struct net_if *iface)
 {
 	struct dwmac_priv *p = net_if_get_device(iface)->data;
 	uint32_t reg_val;
@@ -558,6 +558,7 @@ static void dwmac_iface_init(struct net_if *iface)
 		  DMA_CHn_IRQ_ENABLE_AIE);
 
 	LOG_DBG("done");
+	return 0;
 }
 
 int dwmac_probe(const struct device *dev)

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -285,7 +285,7 @@ int e1000_probe(const struct device *ddev)
 	return 0;
 }
 
-static void e1000_iface_init(struct net_if *iface)
+static int e1000_iface_init(struct net_if *iface)
 {
 	struct e1000_dev *dev = net_if_get_device(iface)->data;
 
@@ -313,6 +313,7 @@ static void e1000_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	LOG_DBG("done");
+	return 0;
 }
 
 static struct e1000_dev e1000_dev;

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -701,7 +701,7 @@ static enum ethernet_hw_caps eth_enc28j60_get_capabilities(const struct device *
 		;
 }
 
-static void eth_enc28j60_iface_init(struct net_if *iface)
+static int eth_enc28j60_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_enc28j60_runtime *context = dev->data;
@@ -719,6 +719,7 @@ static void eth_enc28j60_iface_init(struct net_if *iface)
 	}
 
 	ethernet_init(iface);
+	return 0;
 }
 
 static const struct ethernet_api api_funcs = {

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -552,7 +552,7 @@ static enum ethernet_hw_caps enc424j600_get_capabilities(const struct device *de
 	return ETHERNET_LINK_10BASE_T | ETHERNET_LINK_100BASE_T;
 }
 
-static void enc424j600_iface_init(struct net_if *iface)
+static int enc424j600_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct enc424j600_runtime *context = dev->data;
@@ -565,6 +565,7 @@ static void enc424j600_iface_init(struct net_if *iface)
 
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	context->iface_initialized = true;
+	return 0;
 }
 
 static int enc424j600_start_device(const struct device *dev)

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -500,7 +500,7 @@ static void generate_mac(uint8_t mac_addr[6])
 #endif
 }
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_gecko_dev_data *const dev_data = dev->data;
@@ -607,7 +607,7 @@ static void eth_iface_init(struct net_if *iface)
 	result = phy_gecko_init(&cfg->phy);
 	if (result < 0) {
 		LOG_ERR("ETH PHY Initialization Error");
-		return;
+		return result;
 	}
 
 	/* Initialise TX/RX semaphores */
@@ -620,6 +620,7 @@ static void eth_iface_init(struct net_if *iface)
 			rx_thread, (void *) dev, NULL, NULL,
 			K_PRIO_COOP(CONFIG_ETH_GECKO_RX_THREAD_PRIO),
 			0, K_NO_WAIT);
+	return 0;
 }
 
 static enum ethernet_hw_caps eth_gecko_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -196,7 +196,7 @@ static const struct eth_liteeth_config eth_config = {
 	.config_func = eth_irq_config,
 };
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *port = net_if_get_device(iface);
 	struct eth_liteeth_dev_data *context = port->data;
@@ -204,7 +204,7 @@ static void eth_iface_init(struct net_if *iface)
 
 	/* initialize only once */
 	if (init_done) {
-		return;
+		return 0;
 	}
 
 	/* set interface */
@@ -222,7 +222,7 @@ static void eth_iface_init(struct net_if *iface)
 	if (net_if_set_link_addr(iface, context->mac_addr, sizeof(context->mac_addr),
 			     NET_LINK_ETHERNET) < 0) {
 		LOG_ERR("setting mac failed");
-		return;
+		return -EIO;
 	}
 
 	/* clear pending events */
@@ -240,6 +240,8 @@ static void eth_iface_init(struct net_if *iface)
 	context->rx_buf[1] = (uint8_t *)LITEETH_SLOT_RX1;
 
 	init_done = true;
+
+	return 0;
 }
 
 static enum ethernet_hw_caps eth_caps(const struct device *dev)

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1165,7 +1165,7 @@ static void net_if_mcast_cb(struct net_if *iface,
 }
 #endif /* CONFIG_NET_IPV6 */
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
@@ -1195,6 +1195,7 @@ static void eth_iface_init(struct net_if *iface)
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 
 	context->config_func();
+	return 0;
 }
 
 static enum ethernet_hw_caps eth_mcux_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -414,7 +414,7 @@ static void create_rx_handler(struct eth_context *ctx)
 	}
 }
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	struct eth_context *ctx = net_if_get_device(iface)->data;
 	struct net_linkaddr *ll_addr = eth_get_mac(ctx);
@@ -429,7 +429,7 @@ static void eth_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 
 	if (ctx->init_done) {
-		return;
+		return 0;
 	}
 
 	net_lldp_set_lldpdu(iface);
@@ -489,6 +489,7 @@ static void eth_iface_init(struct net_if *iface)
 
 		eth_start_script(ctx->if_name);
 	}
+	return 0;
 }
 
 static

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1849,7 +1849,7 @@ static void phy_link_state_changed(const struct device *pdev,
 	}
 }
 
-static void eth0_iface_init(struct net_if *iface)
+static int eth0_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_sam_dev_data *const dev_data = dev->data;
@@ -1871,7 +1871,7 @@ static void eth0_iface_init(struct net_if *iface)
 
 	/* The rest of initialization should only be done once */
 	if (init_done) {
-		return;
+		return 0;
 	}
 
 	/* Check the status of data caches */
@@ -1887,7 +1887,7 @@ static void eth0_iface_init(struct net_if *iface)
 	result = gmac_init(cfg->regs, gmac_ncfgr_val);
 	if (result < 0) {
 		LOG_ERR("Unable to initialize ETH driver");
-		return;
+		return result;
 	}
 
 	generate_mac(dev_data->mac_addr);
@@ -1910,7 +1910,7 @@ static void eth0_iface_init(struct net_if *iface)
 		result = queue_init(cfg->regs, &dev_data->queue_list[i]);
 		if (result < 0) {
 			LOG_ERR("Unable to initialize ETH queue%d", i);
-			return;
+			return result;
 		}
 	}
 
@@ -1966,6 +1966,8 @@ static void eth0_iface_init(struct net_if *iface)
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 
 	init_done = true;
+
+	return 0;
 }
 
 static enum ethernet_hw_caps eth_sam_gmac_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -427,7 +427,7 @@ static struct net_stats_eth *get_stats(const struct device *dev)
 }
 #endif
 
-static void eth_initialize(struct net_if *iface)
+static int eth_initialize(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
@@ -444,6 +444,8 @@ static void eth_initialize(struct net_if *iface)
 	context->iface = iface;
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int smsc_write_tx_fifo(const uint8_t *buf, uint32_t len, bool is_last)

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -267,7 +267,7 @@ static void eth_stellaris_isr(const struct device *dev)
 	irq_unlock(lock);
 }
 
-static void eth_stellaris_init(struct net_if *iface)
+static int eth_stellaris_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	const struct eth_stellaris_config *dev_conf = dev->config;
@@ -286,6 +286,7 @@ static void eth_stellaris_init(struct net_if *iface)
 
 	/* Initialize Interrupts. */
 	dev_conf->config_func(dev);
+	return 0;
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -916,7 +916,7 @@ static int eth_initialize(const struct device *dev)
 	return 0;
 }
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev;
 	struct eth_stm32_hal_dev_data *dev_data;
@@ -954,6 +954,8 @@ static void eth_iface_init(struct net_if *iface)
 		__ASSERT_NO_MSG(cfg->config_func != NULL);
 		cfg->config_func();
 	}
+
+	return 0;
 }
 
 static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -311,7 +311,7 @@ done:
 	}
 }
 
-static void w5500_iface_init(struct net_if *iface)
+static int w5500_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct w5500_runtime *ctx = dev->data;
@@ -325,6 +325,8 @@ static void w5500_iface_init(struct net_if *iface)
 	}
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static enum ethernet_hw_caps w5500_get_capabilities(const struct device *dev)

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -38,7 +38,7 @@
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 static int  eth_xlnx_gem_dev_init(const struct device *dev);
-static void eth_xlnx_gem_iface_init(struct net_if *iface);
+static int eth_xlnx_gem_iface_init(struct net_if *iface);
 static void eth_xlnx_gem_isr(const struct device *dev);
 static int  eth_xlnx_gem_send(const struct device *dev, struct net_pkt *pkt);
 static int  eth_xlnx_gem_start_device(const struct device *dev);
@@ -216,7 +216,7 @@ static int eth_xlnx_gem_dev_init(const struct device *dev)
  *
  * @param iface Pointer to the associated interface data struct
  */
-static void eth_xlnx_gem_iface_init(struct net_if *iface)
+static int eth_xlnx_gem_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	const struct eth_xlnx_gem_dev_cfg *dev_conf = dev->config;
@@ -252,6 +252,7 @@ static void eth_xlnx_gem_iface_init(struct net_if *iface)
 
 	/* Submit initial PHY status polling delayed work */
 	k_work_reschedule(&dev_data->phy_poll_delayed_work, K_NO_WAIT);
+	return 0;
 }
 
 /**

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -384,7 +384,7 @@ static int b91_init(const struct device *dev)
 }
 
 /* API implementation: iface_init */
-static void b91_iface_init(struct net_if *iface)
+static int b91_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct b91_data *b91 = dev->data;
@@ -395,6 +395,8 @@ static void b91_iface_init(struct net_if *iface)
 	b91->iface = iface;
 
 	ieee802154_init(iface);
+
+	return 0;
 }
 
 /* API implementation: get_capabilities */

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -766,7 +766,7 @@ static int cc1200_init(const struct device *dev)
 	return 0;
 }
 
-static void cc1200_iface_init(struct net_if *iface)
+static int cc1200_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct cc1200_context *cc1200 = dev->data;
@@ -779,6 +779,8 @@ static void cc1200_iface_init(struct net_if *iface)
 	cc1200->iface = iface;
 
 	ieee802154_init(iface);
+
+	return 0;
 }
 
 static const struct cc1200_config cc1200_config = {

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -508,7 +508,7 @@ static void ieee802154_cc13xx_cc26xx_data_init(const struct device *dev)
 	k_mutex_init(&drv_data->tx_mutex);
 }
 
-static void ieee802154_cc13xx_cc26xx_iface_init(struct net_if *iface)
+static int ieee802154_cc13xx_cc26xx_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
@@ -519,6 +519,8 @@ static void ieee802154_cc13xx_cc26xx_iface_init(struct net_if *iface)
 	drv_data->iface = iface;
 
 	ieee802154_init(iface);
+
+	return 0;
 }
 
 static struct ieee802154_radio_api ieee802154_cc13xx_cc26xx_radio_api = {

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -595,7 +595,7 @@ static void ieee802154_cc13xx_cc26xx_subg_data_init(
 	k_mutex_init(&drv_data->tx_mutex);
 }
 
-static void ieee802154_cc13xx_cc26xx_subg_iface_init(struct net_if *iface)
+static int ieee802154_cc13xx_cc26xx_subg_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
@@ -606,6 +606,8 @@ static void ieee802154_cc13xx_cc26xx_subg_iface_init(struct net_if *iface)
 	drv_data->iface = iface;
 
 	ieee802154_init(iface);
+
+	return 0;
 }
 
 static struct ieee802154_radio_api

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -1012,7 +1012,7 @@ static int cc2520_init(const struct device *dev)
 	return 0;
 }
 
-static void cc2520_iface_init(struct net_if *iface)
+static int cc2520_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct cc2520_context *cc2520 = dev->data;
@@ -1023,6 +1023,8 @@ static void cc2520_iface_init(struct net_if *iface)
 	cc2520->iface = iface;
 
 	ieee802154_init(iface);
+
+	return 0;
 }
 
 static const struct cc2520_config cc2520_config = {

--- a/drivers/ieee802154/ieee802154_dw1000.c
+++ b/drivers/ieee802154/ieee802154_dw1000.c
@@ -1605,7 +1605,7 @@ static inline uint8_t *get_mac(const struct device *dev)
 	return dw1000->mac_addr;
 }
 
-static void dwt_iface_api_init(struct net_if *iface)
+static int dwt_iface_api_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct dwt_context *dw1000 = dev->data;
@@ -1618,6 +1618,7 @@ static void dwt_iface_api_init(struct net_if *iface)
 	ieee802154_init(iface);
 
 	LOG_INF("Iface initialized");
+	return 0;
 }
 
 static struct ieee802154_radio_api dwt_radio_api = {

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -1061,7 +1061,7 @@ static int kw41z_init(const struct device *dev)
 	return 0;
 }
 
-static void kw41z_iface_init(struct net_if *iface)
+static int kw41z_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct kw41z_context *kw41z = dev->data;
@@ -1074,6 +1074,7 @@ static void kw41z_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
 	kw41z->iface = iface;
 	ieee802154_init(iface);
+	return 0;
 }
 
 static int kw41z_configure(const struct device *dev,

--- a/drivers/ieee802154/ieee802154_mcr20a.c
+++ b/drivers/ieee802154/ieee802154_mcr20a.c
@@ -1402,7 +1402,7 @@ static int mcr20a_init(const struct device *dev)
 	return 0;
 }
 
-static void mcr20a_iface_init(struct net_if *iface)
+static int mcr20a_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct mcr20a_context *mcr20a = dev->data;
@@ -1415,6 +1415,7 @@ static void mcr20a_iface_init(struct net_if *iface)
 	ieee802154_init(iface);
 
 	LOG_DBG("done");
+	return 0;
 }
 
 static const struct mcr20a_config mcr20a_config = {

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -684,7 +684,7 @@ static int nrf5_init(const struct device *dev)
 	return 0;
 }
 
-static void nrf5_iface_init(struct net_if *iface)
+static int nrf5_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct nrf5_802154_data *nrf5_radio = NRF5_802154_DATA(dev);
@@ -696,6 +696,8 @@ static void nrf5_iface_init(struct net_if *iface)
 	nrf5_radio->iface = iface;
 
 	ieee802154_init(iface);
+
+	return 0;
 }
 
 #if defined(CONFIG_IEEE802154_2015)

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -887,7 +887,7 @@ static int rf2xx_init(const struct device *dev)
 	return 0;
 }
 
-static void rf2xx_iface_init(struct net_if *iface)
+static int rf2xx_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct rf2xx_context *ctx = dev->data;
@@ -898,6 +898,7 @@ static void rf2xx_iface_init(struct net_if *iface)
 	ctx->iface = iface;
 
 	ieee802154_init(iface);
+	return 0;
 }
 
 static struct ieee802154_radio_api rf2xx_radio_api = {

--- a/drivers/ieee802154/ieee802154_uart_pipe.c
+++ b/drivers/ieee802154/ieee802154_uart_pipe.c
@@ -362,7 +362,7 @@ static inline uint8_t *get_mac(const struct device *dev)
 	return upipe->mac_addr;
 }
 
-static void upipe_iface_init(struct net_if *iface)
+static int upipe_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct upipe_context *upipe = dev->data;
@@ -374,6 +374,7 @@ static void upipe_iface_init(struct net_if *iface)
 	upipe->iface = iface;
 
 	ieee802154_init(iface);
+	return 0;
 }
 
 static struct upipe_context upipe_context_data;

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -6188,7 +6188,7 @@ static int hl7800_init(const struct device *dev)
 	return ret;
 }
 
-static void offload_iface_init(struct net_if *iface)
+static int offload_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct hl7800_iface_ctx *ctx = dev->data;
@@ -6202,6 +6202,7 @@ static void offload_iface_init(struct net_if *iface)
 				     NET_LINK_ETHERNET);
 		ictx.initialized = true;
 	}
+	return 0;
 }
 
 static struct net_if_api api_funcs = {

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -1067,7 +1067,7 @@ static const struct socket_op_vtable offload_socket_fd_op_vtable = {
 };
 
 /* Setup the Modem NET Interface. */
-static void modem_net_iface_init(struct net_if *iface)
+static int modem_net_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct modem_data *data	 = dev->data;
@@ -1077,6 +1077,7 @@ static void modem_net_iface_init(struct net_if *iface)
 			     sizeof(data->mac_addr),
 			     NET_LINK_ETHERNET);
 	data->net_iface = iface;
+	return 0;
 }
 
 static struct net_if_api api_funcs = {

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -63,7 +63,7 @@ static inline uint8_t *modem_get_mac(const struct device *dev)
 }
 
 /* Setup the Modem NET Interface. */
-static void modem_net_iface_init(struct net_if *iface)
+static int modem_net_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct sim7080_data *data = dev->data;
@@ -73,6 +73,8 @@ static void modem_net_iface_init(struct net_if *iface)
 	data->netif = iface;
 
 	socket_offload_dns_register(&offload_dns_ops);
+
+	return 0;
 }
 
 /**

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -2087,7 +2087,7 @@ static inline uint8_t *modem_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void modem_net_iface_init(struct net_if *iface)
+static int modem_net_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct modem_data *data = dev->data;
@@ -2101,6 +2101,7 @@ static void modem_net_iface_init(struct net_if *iface)
 #ifdef CONFIG_DNS_RESOLVER
 	socket_offload_dns_register(&offload_dns_ops);
 #endif
+	return 0;
 }
 
 static struct net_if_api api_funcs = {

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1832,7 +1832,7 @@ static inline uint8_t *wncm14a2a_get_mac(const struct device *dev)
 	return ctx->mac_addr;
 }
 
-static void offload_iface_init(struct net_if *iface)
+static int offload_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct wncm14a2a_iface_ctx *ctx = dev->data;
@@ -1842,6 +1842,7 @@ static void offload_iface_init(struct net_if *iface)
 			     sizeof(ctx->mac_addr),
 			     NET_LINK_ETHERNET);
 	ctx->iface = iface;
+	return 0;
 }
 
 static struct net_if_api api_funcs = {

--- a/drivers/net/loopback.c
+++ b/drivers/net/loopback.c
@@ -31,7 +31,7 @@ int loopback_dev_init(const struct device *dev)
 	return 0;
 }
 
-static void loopback_init(struct net_if *iface)
+static int loopback_init(struct net_if *iface)
 {
 	struct net_if_addr *ifaddr;
 
@@ -58,6 +58,7 @@ static void loopback_init(struct net_if *iface)
 			LOG_ERR("Failed to register IPv6 loopback address");
 		}
 	}
+	return 0;
 }
 
 static int loopback_send(const struct device *dev, struct net_pkt *pkt)

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -912,7 +912,7 @@ static inline struct net_linkaddr *ppp_get_mac(struct ppp_driver_context *ppp)
 	return &ppp->ll_addr;
 }
 
-static void ppp_iface_init(struct net_if *iface)
+static int ppp_iface_init(struct net_if *iface)
 {
 	struct ppp_driver_context *ppp = net_if_get_device(iface)->data;
 	struct net_linkaddr *ll_addr;
@@ -922,7 +922,7 @@ static void ppp_iface_init(struct net_if *iface)
 	net_ppp_init(iface);
 
 	if (ppp->init_done) {
-		return;
+		return 0;
 	}
 
 	ppp->init_done = true;
@@ -962,6 +962,7 @@ use_random_mac:
 	    IS_ENABLED(CONFIG_PPP_NET_IF_NO_AUTO_START)) {
 		net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	}
+	return 0;
 }
 
 #if defined(CONFIG_NET_STATISTICS_PPP)

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -390,7 +390,7 @@ static inline struct net_linkaddr *slip_get_mac(struct slip_context *slip)
 	return &slip->ll_addr;
 }
 
-static void slip_iface_init(struct net_if *iface)
+static int slip_iface_init(struct net_if *iface)
 {
 	struct slip_context *slip = net_if_get_device(iface)->data;
 	struct net_linkaddr *ll_addr;
@@ -404,7 +404,7 @@ static void slip_iface_init(struct net_if *iface)
 #endif
 
 	if (slip->init_done) {
-		return;
+		return 0;
 	}
 
 	ll_addr = slip_get_mac(slip);
@@ -429,6 +429,8 @@ use_random_mac:
 	}
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
 			     NET_LINK_ETHERNET);
+
+	return 0;
 }
 
 static struct slip_context slip_context_data;

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -152,7 +152,7 @@ static void esp_wifi_event_task(void)
 	}
 }
 
-static void eth_esp32_init(struct net_if *iface)
+static int eth_esp32_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct esp32_wifi_runtime *dev_data = dev->data;
@@ -171,6 +171,7 @@ static void eth_esp32_init(struct net_if *iface)
 	ethernet_init(iface);
 
 	esp_wifi_internal_reg_rxcb(ESP_IF_WIFI_STA, eth_esp32_rx);
+	return 0;
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -1026,7 +1026,7 @@ static void esp_init_work(struct k_work *work)
 	net_if_up(dev->net_iface);
 }
 
-static void esp_reset(struct esp_data *dev)
+static int esp_reset(struct esp_data *dev)
 {
 	if (net_if_is_up(dev->net_iface)) {
 		net_if_down(dev->net_iface);
@@ -1055,12 +1055,13 @@ static void esp_reset(struct esp_data *dev)
 
 	if (ret < 0) {
 		LOG_ERR("Failed to reset device: %d", ret);
-		return;
+		return -EAGAIN;
 	}
 #endif
+	return 0;
 }
 
-static void esp_iface_init(struct net_if *iface)
+static int esp_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct esp_data *data = dev->data;
@@ -1068,7 +1069,7 @@ static void esp_iface_init(struct net_if *iface)
 	net_if_flag_set(iface, NET_IF_NO_AUTO_START);
 	data->net_iface = iface;
 	esp_offload_init(iface);
-	esp_reset(data);
+	return esp_reset(data);
 }
 
 static const struct net_wifi_mgmt_offload esp_api = {

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -378,23 +378,26 @@ static int eswifi_get_mac_addr(struct eswifi_dev *eswifi, uint8_t addr[6])
 	return 0;
 }
 
-static void eswifi_iface_init(struct net_if *iface)
+static int eswifi_iface_init(struct net_if *iface)
 {
 	struct eswifi_dev *eswifi = &eswifi0;
 	uint8_t mac[6];
+	int result;
 
 	LOG_DBG("");
 
 	eswifi_lock(eswifi);
 
-	if (eswifi_reset(eswifi) < 0) {
+	result = eswifi_reset(eswifi);
+	if (result < 0) {
 		LOG_ERR("Unable to reset device");
-		return;
+		return result;
 	}
 
-	if (eswifi_get_mac_addr(eswifi, mac) < 0) {
+	result = eswifi_get_mac_addr(eswifi, mac);
+	if (result < 0) {
 		LOG_ERR("Unable to read MAC address");
-		return;
+		return result;
 	}
 
 	LOG_DBG("MAC Address %02X:%02X:%02X:%02X:%02X:%02X",
@@ -412,7 +415,7 @@ static void eswifi_iface_init(struct net_if *iface)
 #if defined(CONFIG_NET_SOCKETS_OFFLOAD)
 	eswifi_socket_offload_init(eswifi);
 #endif
-
+	return 0;
 }
 
 static int eswifi_mgmt_scan(const struct device *dev, scan_result_cb_t cb)

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -212,7 +212,7 @@ static struct net_offload simplelink_offload = {
 	.put	       = NULL,
 };
 
-static void simplelink_iface_init(struct net_if *iface)
+static int simplelink_iface_init(struct net_if *iface)
 {
 	int ret;
 
@@ -231,7 +231,7 @@ static void simplelink_iface_init(struct net_if *iface)
 	ret = z_simplelink_init(simplelink_wifi_cb);
 	if (ret) {
 		LOG_ERR("z_simplelink_init failed!");
-		return;
+		return ret;
 	}
 
 	ret = k_sem_take(&ip_acquired, FC_TIMEOUT);
@@ -259,7 +259,7 @@ static void simplelink_iface_init(struct net_if *iface)
 	socket_offload_dns_register(&simplelink_dns_ops);
 	simplelink_sockets_init();
 #endif
-
+	return 0;
 }
 
 static const struct net_wifi_mgmt_offload simplelink_api = {

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -1085,7 +1085,7 @@ static int winc1500_mgmt_ap_disable(const struct device *dev)
 	return 0;
 }
 
-static void winc1500_iface_init(struct net_if *iface)
+static int winc1500_iface_init(struct net_if *iface)
 {
 	LOG_DBG("eth_init:net_if_set_link_addr:"
 		"MAC Address %02X:%02X:%02X:%02X:%02X:%02X",
@@ -1098,6 +1098,8 @@ static void winc1500_iface_init(struct net_if *iface)
 	iface->if_dev->offload = &winc1500_offload;
 
 	w1500_data.iface = iface;
+
+	return 0;
 }
 
 static const struct net_wifi_mgmt_offload winc1500_api = {

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -181,6 +181,9 @@ enum net_if_flag {
 	/** Power management specific: interface is being suspended */
 	NET_IF_SUSPENDED,
 
+	/** Interface initialised successfully */
+	NET_IF_INITIALISED,
+
 	/** Flag defines if received multicasts of other interface are
 	 * forwarded on this interface. This activates multicast
 	 * routing / forwarding for this interface.

--- a/include/net/net_if.h
+++ b/include/net/net_if.h
@@ -2195,7 +2195,7 @@ bool net_if_is_suspended(struct net_if *iface);
 
 /** @cond INTERNAL_HIDDEN */
 struct net_if_api {
-	void (*init)(struct net_if *iface);
+	int (*init)(struct net_if *iface);
 };
 
 #if defined(CONFIG_NET_DHCPV4) && defined(CONFIG_NET_NATIVE_IPV4)

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -41,14 +41,14 @@ struct virtual_test_context {
 	bool init_done;
 };
 
-static void virtual_test_iface_init(struct net_if *iface)
+static int virtual_test_iface_init(struct net_if *iface)
 {
 	struct virtual_test_context *ctx = net_if_get_device(iface)->data;
 	char name[16];
 	static int count;
 
 	if (ctx->init_done) {
-		return;
+		return 0;
 	}
 
 	ctx->iface = iface;
@@ -60,6 +60,7 @@ static void virtual_test_iface_init(struct net_if *iface)
 	(void)net_virtual_set_flags(iface, NET_L2_POINT_TO_POINT);
 
 	ctx->init_done = true;
+	return 0;
 }
 
 static struct virtual_test_context virtual_test_context_data1 = {

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -428,7 +428,9 @@ static inline void init_iface(struct net_if *iface)
 	z_object_init(iface);
 #endif
 
-	api->init(iface);
+	if (api->init(iface) == 0) {
+		net_if_flag_set(iface, NET_IF_INITIALISED);
+	}
 }
 
 enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -277,7 +277,7 @@ static struct bt_context bt_context_data = {
 	}
 };
 
-static void bt_iface_init(struct net_if *iface)
+static int bt_iface_init(struct net_if *iface)
 {
 	struct bt_context *ctxt = net_if_get_device(iface)->data;
 	struct bt_if_conn *conn = NULL;
@@ -296,7 +296,7 @@ static void bt_iface_init(struct net_if *iface)
 
 	if (!conn) {
 		NET_ERR("Unable to allocate iface");
-		return;
+		return -EINVAL;
 	}
 
 	conn->iface = iface;
@@ -309,6 +309,7 @@ static void bt_iface_init(struct net_if *iface)
 	 */
 	net_if_flag_set(iface, NET_IF_POINTOPOINT);
 #endif
+	return 0;
 }
 
 static struct net_if_api bt_if_api = {

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -56,12 +56,12 @@ static int ipip_init(const struct device *dev)
 	return 0;
 }
 
-static void iface_init(struct net_if *iface)
+static int iface_init(struct net_if *iface)
 {
 	struct ipip_context *ctx = net_if_get_device(iface)->data;
 
 	if (ctx->init_done) {
-		return;
+		return 0;
 	}
 
 	ctx->iface = iface;
@@ -71,6 +71,7 @@ static void iface_init(struct net_if *iface)
 	(void)net_virtual_set_flags(iface, NET_L2_POINT_TO_POINT);
 
 	ctx->init_done = true;
+	return 0;
 }
 
 static enum virtual_interface_caps get_capabilities(struct net_if *iface)

--- a/subsys/usb/class/netusb/netusb.c
+++ b/subsys/usb/class/netusb/netusb.c
@@ -122,7 +122,7 @@ bool netusb_enabled(void)
 	return !!netusb.func;
 }
 
-static void netusb_init(struct net_if *iface)
+static int netusb_init(struct net_if *iface)
 {
 	static uint8_t mac[6] = { 0x00, 0x00, 0x5E, 0x00, 0x53, 0x00 };
 
@@ -136,6 +136,7 @@ static void netusb_init(struct net_if *iface)
 	net_if_set_link_addr(iface, mac, sizeof(mac), NET_LINK_ETHERNET);
 
 	LOG_INF("netusb initialized");
+	return 0;
 }
 
 static const struct ethernet_api netusb_api_funcs = {

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -254,9 +254,9 @@ int net_6lo_dev_init(const struct device *dev)
 	return 0;
 }
 
-static void net_6lo_iface_init(struct net_if *iface)
+static int net_6lo_iface_init(struct net_if *iface)
 {
-	net_if_set_link_addr(iface, src_mac, 8, NET_LINK_IEEE802154);
+	return net_if_set_link_addr(iface, src_mac, 8, NET_LINK_IEEE802154);
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -76,11 +76,11 @@ static uint8_t *net_arp_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_arp_iface_init(struct net_if *iface)
+static int net_arp_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_arp_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -35,7 +35,7 @@ struct eth_fake_context {
 	bool promisc_mode;
 };
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -54,6 +54,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_fake_send(const struct device *dev,

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -94,7 +94,7 @@ struct eth_context {
 static struct eth_context eth_context_offloading_disabled;
 static struct eth_context eth_context_offloading_enabled;
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
@@ -107,6 +107,8 @@ static void eth_iface_init(struct net_if *iface)
 	    net_sprint_ll_addr(context->mac_addr, sizeof(context->mac_addr)));
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static uint16_t get_udp_chksum(struct net_pkt *pkt)

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -879,12 +879,12 @@ static uint8_t *net_context_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_context_iface_init(struct net_if *iface)
+static int net_context_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_context_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/dhcpv4/src/main.c
+++ b/tests/net/dhcpv4/src/main.c
@@ -189,11 +189,11 @@ static uint8_t *net_dhcpv4_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_dhcpv4_iface_init(struct net_if *iface)
+static int net_dhcpv4_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_dhcpv4_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 struct net_pkt *prepare_dhcp_offer(struct net_if *iface, uint32_t xid)

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -76,7 +76,7 @@ struct eth_fake_context {
 
 static struct eth_fake_context eth_fake_data;
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -88,6 +88,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_fake_send(const struct device *dev,

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -87,12 +87,12 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void net_iface_init(struct net_if *iface)
+static int net_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_iface_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int sender_iface(const struct device *dev, struct net_pkt *pkt)
@@ -138,7 +138,7 @@ struct eth_fake_context {
 
 static struct eth_fake_context eth_fake_data;
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -158,6 +158,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_fake_send(const struct device *dev,

--- a/tests/net/icmpv4/src/main.c
+++ b/tests/net/icmpv4/src/main.c
@@ -163,11 +163,11 @@ static uint8_t *net_icmpv4_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_icmpv4_iface_init(struct net_if *iface)
+static int net_icmpv4_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_icmpv4_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 static int verify_echo_reply(struct net_pkt *pkt)

--- a/tests/net/ieee802154/custom_l2/src/main.c
+++ b/tests/net/ieee802154/custom_l2/src/main.c
@@ -50,12 +50,12 @@ static enum net_l2_flags custom_l2_flags(struct net_if *iface)
 NET_L2_INIT(CUSTOM_IEEE802154_L2, custom_l2_recv, custom_l2_send,
 	    custom_l2_enable, custom_l2_flags);
 
-static void dummy_iface_init(struct net_if *iface)
+static int dummy_iface_init(struct net_if *iface)
 {
 	static uint8_t mac[8] = { 0x00, 0x11, 0x22, 0x33,
 				  0x44, 0x55, 0x66, 0x77 };
 
-	net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
+	return net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
 }
 
 static int dummy_init(const struct device *dev)

--- a/tests/net/ieee802154/fragment/src/main.c
+++ b/tests/net/ieee802154/fragment/src/main.c
@@ -164,11 +164,11 @@ int net_fragment_dev_init(const struct device *dev)
 	return 0;
 }
 
-static void net_fragment_iface_init(struct net_if *iface)
+static int net_fragment_iface_init(struct net_if *iface)
 {
 	static uint8_t mac[8] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xaa, 0xbb};
 
-	net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
+	return net_if_set_link_addr(iface, mac, 8, NET_LINK_IEEE802154);
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
+++ b/tests/net/ieee802154/l2/src/ieee802154_fake_driver.c
@@ -92,7 +92,7 @@ static int fake_stop(const struct device *dev)
 	return 0;
 }
 
-static void fake_iface_init(struct net_if *iface)
+static int fake_iface_init(struct net_if *iface)
 {
 	struct ieee802154_context *ctx = net_if_l2_data(iface);
 	static uint8_t mac[8] = { 0x00, 0x12, 0x4b, 0x00,
@@ -107,6 +107,7 @@ static void fake_iface_init(struct net_if *iface)
 	ctx->sequence = 62U;
 
 	NET_INFO("FAKE ieee802154 iface initialized\n");
+	return 0;
 }
 
 static int fake_init(const struct device *dev)

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -100,12 +100,12 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void net_iface_init(struct net_if *iface)
+static int net_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_iface_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int sender_iface(const struct device *dev, struct net_pkt *pkt)
@@ -193,7 +193,7 @@ struct eth_fake_context {
 
 static struct eth_fake_context eth_fake_data;
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -205,6 +205,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_fake_send(const struct device *dev,

--- a/tests/net/igmp/src/main.c
+++ b/tests/net/igmp/src/main.c
@@ -88,12 +88,12 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_test_iface_init(struct net_if *iface)
+static int net_test_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_test_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static struct net_ipv4_igmp_v2_query *get_igmp_hdr(struct net_pkt *pkt)

--- a/tests/net/ip-addr/src/main.c
+++ b/tests/net/ip-addr/src/main.c
@@ -133,11 +133,11 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_test_iface_init(struct net_if *iface)
+static int net_test_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_test_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -169,12 +169,12 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_test_iface_init(struct net_if *iface)
+static int net_test_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_test_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 /**

--- a/tests/net/ipv6_fragment/src/main.c
+++ b/tests/net/ipv6_fragment/src/main.c
@@ -951,12 +951,12 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void net_iface_init(struct net_if *iface)
+static int net_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_iface_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int verify_fragment(struct net_pkt *pkt)

--- a/tests/net/lib/dns_addremove/src/main.c
+++ b/tests/net/lib/dns_addremove/src/main.c
@@ -102,12 +102,12 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void net_iface_init(struct net_if *iface)
+static int net_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_iface_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int sender_iface(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/lib/dns_resolve/src/main.c
+++ b/tests/net/lib/dns_resolve/src/main.c
@@ -103,12 +103,12 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void net_iface_init(struct net_if *iface)
+static int net_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_iface_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static inline int get_slot_by_id(struct dns_resolve_context *ctx,

--- a/tests/net/mgmt/src/mgmt.c
+++ b/tests/net/mgmt/src/mgmt.c
@@ -73,11 +73,11 @@ int fake_dev_init(const struct device *dev)
 	return 0;
 }
 
-static void fake_iface_init(struct net_if *iface)
+static int fake_iface_init(struct net_if *iface)
 {
 	static uint8_t mac[8] = { 0x00, 0x00, 0x00, 0x00, 0x0a, 0x0b, 0x0c, 0x0d};
 
-	net_if_set_link_addr(iface, mac, 8, NET_LINK_DUMMY);
+	return net_if_set_link_addr(iface, mac, 8, NET_LINK_DUMMY);
 }
 
 static int fake_iface_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/mld/src/main.c
+++ b/tests/net/mld/src/main.c
@@ -92,12 +92,12 @@ static uint8_t *net_test_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_test_iface_init(struct net_if *iface)
+static int net_test_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_test_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static struct net_icmp_hdr *get_icmp_hdr(struct net_pkt *pkt)

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -24,7 +24,7 @@ static uint8_t small_buffer[512];
  * FAKE ETHERNET DEVICE *
 \************************/
 
-static void fake_dev_iface_init(struct net_if *iface)
+static int fake_dev_iface_init(struct net_if *iface)
 {
 	if (mac_addr[2] == 0U) {
 		/* 00-00-5E-00-53-xx Documentation RFC 7042 */
@@ -35,10 +35,9 @@ static void fake_dev_iface_init(struct net_if *iface)
 		mac_addr[4] = 0x53;
 		mac_addr[5] = sys_rand32_get();
 	}
-
-	net_if_set_link_addr(iface, mac_addr, 6, NET_LINK_ETHERNET);
-
 	eth_if = iface;
+
+	return net_if_set_link_addr(iface, mac_addr, 6, NET_LINK_ETHERNET);
 }
 
 static int fake_dev_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/pm/src/main.c
+++ b/tests/net/pm/src/main.c
@@ -72,15 +72,15 @@ static uint8_t *fake_dev_get_mac(struct fake_dev_context *ctx)
 	return ctx->mac_addr;
 }
 
-static void fake_dev_iface_init(struct net_if *iface)
+static int fake_dev_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct fake_dev_context *ctx = dev->data;
 	uint8_t *mac = fake_dev_get_mac(ctx);
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
-
 	ctx->iface = iface;
+
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 int fake_dev_init(const struct device *dev)

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -74,7 +74,7 @@ struct eth_fake_context {
 static struct eth_fake_context eth_fake_data1;
 static struct eth_fake_context eth_fake_data2;
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -86,6 +86,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_fake_send(const struct device *dev,

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -86,7 +86,7 @@ static struct eth_context eth_context_1;
 static struct eth_context eth_context_2;
 static struct eth_context eth_context_3;
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
@@ -96,6 +96,8 @@ static void eth_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -122,12 +122,12 @@ static uint8_t *net_route_get_mac(const struct device *dev)
 	return route->mac_addr;
 }
 
-static void net_route_iface_init(struct net_if *iface)
+static int net_route_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_route_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int tester_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/route_mcast/src/main.c
+++ b/tests/net/route_mcast/src/main.c
@@ -188,22 +188,25 @@ static void net_route_mcast_add_addresses(struct net_if *iface,
 	zassert_not_null(maddr, "Cannot add multicast IPv6 address");
 }
 
-static void net_route_mcast_iface_init1(struct net_if *iface)
+static int net_route_mcast_iface_init1(struct net_if *iface)
 {
 	iface_1 = iface;
 	net_route_mcast_add_addresses(iface, &iface_1_addr, &ll_addr_1);
+	return 0;
 }
 
-static void net_route_mcast_iface_init2(struct net_if *iface)
+static int net_route_mcast_iface_init2(struct net_if *iface)
 {
 	iface_2 = iface;
 	net_route_mcast_add_addresses(iface, &iface_2_addr, &ll_addr_2);
+	return 0;
 }
 
-static void net_route_mcast_iface_init3(struct net_if *iface)
+static int net_route_mcast_iface_init3(struct net_if *iface)
 {
 	iface_3 = iface;
 	net_route_mcast_add_addresses(iface, &iface_3_addr, &ll_addr_3);
+	return 0;
 }
 
 static bool check_packet_addresses(struct net_pkt *pkt)

--- a/tests/net/shell/src/main.c
+++ b/tests/net/shell/src/main.c
@@ -84,11 +84,11 @@ static uint8_t *net_udp_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_udp_iface_init(struct net_if *iface)
+static int net_udp_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_udp_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 static int send_status = -EINVAL;

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -57,7 +57,7 @@ static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -67,6 +67,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 	net_if_set_link_addr(iface, ctx->mac_address, 6, NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static struct ethernet_api eth_fake_api_funcs = {

--- a/tests/net/socket/af_packet_ipproto_raw/src/main.c
+++ b/tests/net/socket/af_packet_ipproto_raw/src/main.c
@@ -62,15 +62,15 @@ static uint8_t *fake_dev_get_mac(struct fake_dev_context *ctx)
 	return ctx->mac_addr;
 }
 
-static void fake_dev_iface_init(struct net_if *iface)
+static int fake_dev_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct fake_dev_context *ctx = dev->data;
 	uint8_t *mac = fake_dev_get_mac(ctx);
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
-
 	ctx->iface = iface;
+
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 int fake_dev_init(const struct device *dev)

--- a/tests/net/socket/misc/src/main.c
+++ b/tests/net/socket/misc/src/main.c
@@ -110,7 +110,7 @@ static int dummy_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static void dummy_iface_init(struct net_if *iface)
+static int dummy_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct dummy_context *ctx = dev->data;
@@ -131,6 +131,8 @@ static void dummy_iface_init(struct net_if *iface)
 	if (!ifaddr) {
 		zassert_not_null(ifaddr, "ipv4 addr");
 	}
+
+	return 0;
 }
 
 static struct dummy_api dummy_api_funcs = {

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -53,7 +53,7 @@ struct eth_fake_context {
 
 static struct eth_fake_context eth_fake_data;
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -65,6 +65,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_fake_send(const struct device *dev,

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -966,7 +966,7 @@ static struct net_linkaddr server_link_addr = {
 #define TEST_TXTIME 0xff112233445566ff
 #define WAIT_TIME K_MSEC(250)
 
-static void eth_fake_iface_init(struct net_if *iface)
+static int eth_fake_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_fake_context *ctx = dev->data;
@@ -978,6 +978,8 @@ static void eth_fake_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/tcp/src/main.c
+++ b/tests/net/tcp/src/main.c
@@ -170,11 +170,11 @@ static uint8_t *net_tcp_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_tcp_iface_init(struct net_if *iface)
+static int net_tcp_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_tcp_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 struct net_tcp_context net_tcp_context_data;

--- a/tests/net/traffic_class/src/main.c
+++ b/tests/net/traffic_class/src/main.c
@@ -104,14 +104,14 @@ struct eth_context {
 
 static struct eth_context eth_context;
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
 
-	net_if_set_link_addr(iface, context->mac_addr,
-			     sizeof(context->mac_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, context->mac_addr,
+				    sizeof(context->mac_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static bool check_higher_priority_pkt_sent(int tc, struct net_pkt *pkt)

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -86,7 +86,7 @@ struct eth_context {
 static struct eth_context eth_context;
 static struct eth_context eth_context2;
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
@@ -96,6 +96,8 @@ static void eth_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -86,11 +86,11 @@ static uint8_t *net_udp_get_mac(const struct device *dev)
 	return context->mac_addr;
 }
 
-static void net_udp_iface_init(struct net_if *iface)
+static int net_udp_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_udp_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, 6, NET_LINK_ETHERNET);
 }
 
 static int send_status = -EINVAL;

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -98,7 +98,7 @@ static uint8_t expecting_outer;
 static uint8_t expecting_inner;
 static int header_len;
 
-static void eth_iface_init(struct net_if *iface)
+static int eth_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
@@ -108,6 +108,8 @@ static void eth_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)
@@ -223,12 +225,12 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void net_iface_init(struct net_if *iface)
+static int net_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_iface_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int sender_iface(const struct device *dev, struct net_pkt *pkt)

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -94,7 +94,7 @@ struct eth_context {
 
 static struct eth_context eth_vlan_context;
 
-static void eth_vlan_iface_init(struct net_if *iface)
+static int eth_vlan_iface_init(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
 	struct eth_context *context = dev->data;
@@ -104,6 +104,8 @@ static void eth_vlan_iface_init(struct net_if *iface)
 			     NET_LINK_ETHERNET);
 
 	ethernet_init(iface);
+
+	return 0;
 }
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)
@@ -225,12 +227,12 @@ static uint8_t *net_iface_get_mac(const struct device *dev)
 	return data->mac_addr;
 }
 
-static void net_iface_init(struct net_if *iface)
+static int net_iface_init(struct net_if *iface)
 {
 	uint8_t *mac = net_iface_get_mac(net_if_get_device(iface));
 
-	net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
-			     NET_LINK_ETHERNET);
+	return net_if_set_link_addr(iface, mac, sizeof(struct net_eth_addr),
+				    NET_LINK_ETHERNET);
 }
 
 static int sender_iface(const struct device *dev, struct net_pkt *pkt)


### PR DESCRIPTION
Adds a new network interface flag that is automatically set when interface initialisation passes.

Applications can then query this flag using `net_if_flag_is_set` to determine if the function passed or not, and take appropriate remedial action if desired.

Implements #43891