### PR TITLE
logging: update for enable CONFIG_LOG2_FMT_SECTION

### DIFF
--- a/include/linker/utils.h
+++ b/include/linker/utils.h
@@ -57,4 +57,34 @@ static inline bool linker_is_in_rodata(const void *addr)
 	#undef RO_END
 }
 
+/**
+ * @brief Check if address is in log string section.
+ *
+ * Note that this may return false if the address lies outside
+ * the compiler's __log_strings_section
+ *
+ * @param addr Address.
+ *
+ * @return True if address identified within __log_strings_section section.
+ */
+#if defined(CONFIG_LOG2_FMT_SECTION)
+static inline bool linker_in_log_string_section(const char *addr)
+{
+#if defined(CONFIG_ARC) || defined(CONFIG_ARM) || defined(CONFIG_X86) \
+	|| defined(CONFIG_RISCV) || defined(CONFIG_ARM64) \
+	|| defined(CONFIG_NIOS2)
+	extern char __log_strings_start[];
+	extern char __log_strings_end[];
+#define STRING_START __log_strings_start
+#define STRING_END __log_strings_end
+#else
+#define STRING_START 0
+#define STRING_END 0
+#endif
+
+	return ((addr >= (const char *)STRING_START) &&
+		(addr < (const char *)STRING_END));
+}
+#endif
+
 #endif /* ZEPHYR_INCLUDE_LINKER_UTILS_H_ */

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -34,6 +34,20 @@ static inline bool ptr_in_rodata(const char *addr)
 #endif
 }
 
+#if defined(CONFIG_LOG2_FMT_SECTION)
+static inline bool ptr_in_string_section(const char *addr)
+{
+#if defined(CBPRINTF_VIA_UNIT_TEST)
+	/* Unit test is X86 (or other host) but not using Zephyr
+	 * linker scripts.
+	 */
+	return false;
+#else
+	return linker_in_log_string_section(addr);
+#endif
+}
+#endif
+
 /*
  * va_list creation
  */
@@ -480,8 +494,15 @@ process_string:
 
 			bool is_ro = (fros_cnt-- > 0) ? true : ptr_in_rodata(s);
 			bool do_ro = !!(flags & CBPRINTF_PACKAGE_ADD_RO_STR_POS);
+#if defined(CONFIG_LOG2_FMT_SECTION)
+			bool is_string = ptr_in_string_section(s);
+#endif
 
+#if defined(CONFIG_LOG2_FMT_SECTION)
+			if (is_ro || is_string) && !do_ro) {
+#else
 			if (is_ro && !do_ro) {
+#endif
 				/* nothing to do */
 			} else {
 				uint32_t s_ptr_idx = BUF_OFFSET / sizeof(int);


### PR DESCRIPTION
While CONFIG_LOG2_FMT_SECTION is enabled, all log strings will located
in __log_string_sections. In this case, we see these strings as
read-only contents.
While we enable log dictionary mode, this change will only transfer
offset information to backend, rather than the whole const strings.

Signed-off-by: Kong Li <li.kong@intel.com>