### PR TITLE
drivers: flash: Fix regression on nrf52840 anomaly 122 workaround

### DIFF
--- a/drivers/flash/nrf_qspi_nor.c
+++ b/drivers/flash/nrf_qspi_nor.c
@@ -389,12 +389,13 @@ static void anomaly_122_uninit(const struct device *dev)
 			}
 		}
 
+		nrfx_qspi_uninit();
+
 #ifndef CONFIG_PINCTRL
 		nrf_gpio_cfg_output(QSPI_PROP_AT(csn_pins, 0));
 		nrf_gpio_pin_set(QSPI_PROP_AT(csn_pins, 0));
 #endif
 
-		nrfx_qspi_uninit();
 		qspi_initialized = false;
 	}
 


### PR DESCRIPTION
A nordic hal update was made around the same time that anomaly 122 on
nrf52840 was fixed. This update introduced qspi_pins_deconfigure() in
the nrfx_qspi_uninit(). With that, the CS pin from QSPI becomes a
floating pin after anomaly 122 uninit is executed.

Set the CS pin high after the uninit to fix this.

I'm assuming that floating CS pins that are likely to experience EMI
can impact power consumption. That was the case with my custom board.

My custom board with nrf52840 and MX25R3235F running the hello_world
sample was consuming 2.3 mA before this patch, and 30 uA after
applying it.

Signed-off-by: Rodrigo Brochado <git.rodrigobrochado@gmail.com>