### PR TITLE
samples: Bluetooth: df: fix wrong GPIO assignment for ant switching

### DIFF
--- a/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_central/boards/nrf52833dk_nrf52820.overlay
@@ -19,8 +19,8 @@
 	 * Radio peripheral. The pins will be acquired by Radio to
 	 * drive antenna switching when AoD is enabled.
 	 */
-	dfegpio0-gpios = <&gpio0 1 0>;
-	dfegpio1-gpios = <&gpio0 2 0>;
-	dfegpio2-gpios = <&gpio0 3 0>;
-	dfegpio3-gpios = <&gpio0 4 0>;
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
 };

--- a/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_central/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,9 +12,9 @@
   */
 &gpio_fwd {
 	dfe-gpio-if {
-		gpios = <&gpio0 0 0>,
-			<&gpio0 1 0>,
-			<&gpio0 2 0>,
-			<&gpio0 3 0>;
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
 		};
 };

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52820.overlay
@@ -19,8 +19,8 @@
 	 * Radio peripheral. The pins will be acquired by Radio to
 	 * drive antenna switching when AoD is enabled.
 	 */
-	dfegpio0-gpios = <&gpio0 1 0>;
-	dfegpio1-gpios = <&gpio0 2 0>;
-	dfegpio2-gpios = <&gpio0 3 0>;
-	dfegpio3-gpios = <&gpio0 4 0>;
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
 };

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf52833dk_nrf52833.overlay
@@ -19,8 +19,8 @@
 	 * Radio peripheral. The pins will be acquired by Radio to
 	 * drive antenna switching when AoD is enabled.
 	 */
-	dfegpio0-gpios = <&gpio0 1 0>;
-	dfegpio1-gpios = <&gpio0 2 0>;
-	dfegpio2-gpios = <&gpio0 3 0>;
-	dfegpio3-gpios = <&gpio0 4 0>;
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
 };

--- a/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_rx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,9 +12,9 @@
   */
 &gpio_fwd {
 	dfe-gpio-if {
-		gpios = <&gpio0 0 0>,
-			<&gpio0 1 0>,
-			<&gpio0 2 0>,
-			<&gpio0 3 0>;
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
 		};
 };

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52820.overlay
@@ -19,8 +19,8 @@
 	 * Radio peripheral. The pins will be acquired by Radio to
 	 * drive antenna switching when AoD is enabled.
 	 */
-	dfegpio0-gpios = <&gpio0 1 0>;
-	dfegpio1-gpios = <&gpio0 2 0>;
-	dfegpio2-gpios = <&gpio0 3 0>;
-	dfegpio3-gpios = <&gpio0 4 0>;
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
 };

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf52833dk_nrf52833.overlay
@@ -19,8 +19,8 @@
 	 * Radio peripheral. The pins will be acquired by Radio to
 	 * drive antenna switching when AoD is enabled.
 	 */
-	dfegpio0-gpios = <&gpio0 1 0>;
-	dfegpio1-gpios = <&gpio0 2 0>;
-	dfegpio2-gpios = <&gpio0 3 0>;
-	dfegpio3-gpios = <&gpio0 4 0>;
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
 };

--- a/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_connectionless_tx/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,9 +12,9 @@
   */
 &gpio_fwd {
 	dfe-gpio-if {
-		gpios = <&gpio0 0 0>,
-			<&gpio0 1 0>,
-			<&gpio0 2 0>,
-			<&gpio0 3 0>;
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
 		};
 };

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf52833dk_nrf52820.overlay
@@ -19,8 +19,8 @@
 	 * Radio peripheral. The pins will be acquired by Radio to
 	 * drive antenna switching when AoD is enabled.
 	 */
-	dfegpio0-gpios = <&gpio0 1 0>;
-	dfegpio1-gpios = <&gpio0 2 0>;
-	dfegpio2-gpios = <&gpio0 3 0>;
-	dfegpio3-gpios = <&gpio0 4 0>;
+	dfegpio0-gpios = <&gpio0 3 0>;
+	dfegpio1-gpios = <&gpio0 4 0>;
+	dfegpio2-gpios = <&gpio0 28 0>;
+	dfegpio3-gpios = <&gpio0 29 0>;
 };

--- a/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/bluetooth/direction_finding_peripheral/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -12,9 +12,9 @@
   */
 &gpio_fwd {
 	dfe-gpio-if {
-		gpios = <&gpio0 0 0>,
-			<&gpio0 1 0>,
-			<&gpio0 2 0>,
-			<&gpio0 3 0>;
+		gpios = <&gpio0 4 0>,
+			<&gpio0 5 0>,
+			<&gpio0 6 0>,
+			<&gpio0 7 0>;
 		};
 };


### PR DESCRIPTION
There were wrong GPIOs assigned for antenna switches.
Used pins were assigned to other peripehrals so that
there were no outpus printed.

The samples should use GPIOs that are not assigned to any
peripheral.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>