### PR TITLE
MAINTAINERS: add JordanYates to lora collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -768,6 +768,7 @@ Documentation:
         - Mani-Sadhasivam
     collaborators:
         - mniestroj
+        - JordanYates
     files:
         - drivers/lora/
         - include/drivers/lora.h


### PR DESCRIPTION
Add JordanYates to the list of lora collaborators.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>