### PR TITLE
cmake: reuse interface lib for compile options if it already exists

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -500,13 +500,11 @@ function(zephyr_library_compile_options item)
   string(MD5 uniqueness ${item})
   set(lib_name options_interface_lib_${uniqueness})
 
-  if (TARGET ${lib_name})
-    # ${item} already added, ignoring duplicate just like CMake does
-    return()
+  if (NOT TARGET ${lib_name})
+    # Create the unique target only if it doesn't exist.
+    add_library(           ${lib_name} INTERFACE)
+    target_compile_options(${lib_name} INTERFACE ${item} ${ARGN})
   endif()
-
-  add_library(           ${lib_name} INTERFACE)
-  target_compile_options(${lib_name} INTERFACE ${item} ${ARGN})
 
   target_link_libraries(${ZEPHYR_CURRENT_LIBRARY} PRIVATE ${lib_name})
 endfunction()


### PR DESCRIPTION
Fixes: #43835

In zephyr_library_compile_options() the existence of the compile
options interface library is checked and function returns if it already
exists. This results in #43835 meaning two libraries cannot add the
same option.

This commit fixes this by re-using the already created unique interface
library and link this to the Zephyr library.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>