### PR TITLE
boards: odroid_go: fix board name

### DIFF
--- a/boards/xtensa/odroid_go/Kconfig.defconfig
+++ b/boards/xtensa/odroid_go/Kconfig.defconfig
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BOARD
-	default "odroid-go"
+	default "odroid_go"
 	depends on BOARD_ODROID_GO
 
 config ENTROPY_ESP32_RNG


### PR DESCRIPTION
Twister won't run as board name isn't correct.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>