### PR TITLE
Bluetooth: GATT client subscription security validation

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1668,6 +1668,13 @@ struct bt_gatt_subscribe_params {
 #endif /* CONFIG_BT_GATT_AUTO_DISCOVER_CCC */
 	/** Subscribe value */
 	uint16_t value;
+#if defined(CONFIG_BT_SMP)
+	/** Minimum required security for received notification. Notifications
+	 * and indications received over a connection with a lower security
+	 * level are silently discarded.
+	 */
+	bt_security_t min_security;
+#endif
 	/** Subscription flags */
 	ATOMIC_DEFINE(flags, BT_GATT_SUBSCRIBE_NUM_FLAGS);
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3008,6 +3008,15 @@ static struct gatt_sub *gatt_sub_add_by_addr(uint8_t id,
 	return sub;
 }
 
+static bool check_subscribe_security_level(struct bt_conn *conn,
+					   const struct bt_gatt_subscribe_params *params)
+{
+#if defined(CONFIG_BT_SMP)
+	return conn->sec_level >= params->min_security;
+#endif
+	return true;
+}
+
 void bt_gatt_notification(struct bt_conn *conn, uint16_t handle,
 			  const void *data, uint16_t length)
 {
@@ -3026,9 +3035,11 @@ void bt_gatt_notification(struct bt_conn *conn, uint16_t handle,
 			continue;
 		}
 
-		if (params->notify(conn, params, data, length) ==
-		    BT_GATT_ITER_STOP) {
-			bt_gatt_unsubscribe(conn, params);
+		if (check_subscribe_security_level(conn, params)) {
+			if (params->notify(conn, params, data, length) ==
+			    BT_GATT_ITER_STOP) {
+				bt_gatt_unsubscribe(conn, params);
+			}
 		}
 	}
 }
@@ -3072,9 +3083,11 @@ void bt_gatt_mult_notification(struct bt_conn *conn, const void *data,
 				continue;
 			}
 
-			if (params->notify(conn, params, nfy->value, len) ==
-			    BT_GATT_ITER_STOP) {
-				bt_gatt_unsubscribe(conn, params);
+			if (check_subscribe_security_level(conn, params)) {
+				if (params->notify(conn, params, nfy->value, len) ==
+					BT_GATT_ITER_STOP) {
+					bt_gatt_unsubscribe(conn, params);
+				}
 			}
 		}
 

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -1791,6 +1791,9 @@ static int enable_subscription(struct bt_conn *conn, uint16_t ccc_handle,
 	subscription->value = value;
 	subscription->notify = notify_func;
 
+	/* require security level from time of subscription */
+	subscription->min_security = bt_conn_get_security(conn);
+
 	return bt_gatt_discover(conn, &discover_params);
 }
 


### PR DESCRIPTION
Fixes following qualification tests:
GAP/SEC/SEM/BV-56-C
GAP/SEC/SEM/BV-57-C
GAP/SEC/SEM/BV-58-C
GAP/SEC/SEM/BV-59-C
GAP/SEC/SEM/BV-60-C
GAP/SEC/SEM/BV-61-C

see https://github.com/zephyrproject-rtos/zephyr/pull/42726 for reference