### PR TITLE
soc: nordic_nrf: Add query items for HW peripheral CTRLAP

### DIFF
--- a/soc/arm/nordic_nrf/Kconfig.peripherals
+++ b/soc/arm/nordic_nrf/Kconfig.peripherals
@@ -30,6 +30,9 @@ config HAS_HW_NRF_CLOCK
 config HAS_HW_NRF_COMP
 	bool
 
+config HAS_HW_NRF_CTRLAP
+	bool
+
 config HAS_HW_NRF_DCNF
 	bool
 

--- a/soc/arm/nordic_nrf/nrf53/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf53/Kconfig.soc
@@ -12,6 +12,7 @@ config SOC_NRF5340_CPUAPP
 	select HAS_HW_NRF_CC312
 	select HAS_HW_NRF_COMP
 	select HAS_HW_NRF_CLOCK
+	select HAS_HW_NRF_CTRLAP
 	select HAS_HW_NRF_DCNF
 	select HAS_HW_NRF_DPPIC
 	select HAS_HW_NRF_EGU0

--- a/soc/arm/nordic_nrf/nrf91/Kconfig.soc
+++ b/soc/arm/nordic_nrf/nrf91/Kconfig.soc
@@ -8,6 +8,7 @@ config SOC_NRF9160
 	bool
 	select HAS_HW_NRF_CC310
 	select HAS_HW_NRF_CLOCK
+	select HAS_HW_NRF_CTRLAP
 	select HAS_HW_NRF_DPPIC
 	select HAS_HW_NRF_EGU0
 	select HAS_HW_NRF_EGU1


### PR DESCRIPTION
Add Kconfig items that can be used to query if the current SoC
support the HW peripheral CTRLAP.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>