### PR TITLE
arduino_nano_33_ble: enable the adafruit 2.8 TFT display

### DIFF
--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts
@@ -94,7 +94,7 @@
 	tx-pin = <35>; //P1.03
 	rx-pin = <42>; //P1.10
 };
-&i2c0 {
+arduino_i2c: &i2c0 {
 	compatible = "nordic,nrf-twim";
 	status = "okay";
 	sda-pin = <31>; //P0.31
@@ -107,7 +107,7 @@
 	scl-pin = <15>; //P0.15
 };
 // we use SPI2 because SPI1/0 shares conflicts with I2C1/0
-&spi2 {
+arduino_spi: &spi2 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 	sck-pin = <13>; //P0.13

--- a/boards/shields/adafruit_2_8_tft_touch_v2/boards/arduino_nano_33_ble.overlay
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/boards/arduino_nano_33_ble.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2022 Huawei Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	/*
+	 * Arduino Nano form factor doesn't really have a Rev3 Arduino header
+	 * so this is just a "virtual" mapping for the pins used by the
+	 * Adafruit display.
+	 */
+	arduino_header: connector {
+		compatible = "arduino-header-r3";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <10 0 &gpio1 15 0>, // D4
+			   <15 0 &gpio1 2 0>,  // D10
+			   <16 0 &gpio0 27 0>; // D9
+	};
+};


### PR DESCRIPTION
The following device-tree changes make it possible to connect the adafruit 2.8 TFT display with patch wires or a hand-made adapter to the Arduino Nano 33 BLE and make the display and touchscreen work.

The following command builds an lvgl Hello World image: `west build  -b arduino_nano_33_ble ./samples/subsys/display/lvgl/ -- -DSHIELD=adafruit_2_8_tft_touch_v2`.

Normally the display is connected using the Rev3 Arduino header but the nano form factor doesn't have one. This doesn't mean the display can't be used however as it only needs SPI and I2C (and two GPIOs) hence the PR.