### PR TITLE
Bluetooth: Controller: Fix jitter between primary and auxiliary PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -1080,7 +1080,7 @@ uint32_t ull_adv_aux_start(struct ll_adv_aux_set *aux, uint32_t ticks_anchor,
 			   (TICKER_ID_ADV_AUX_BASE + aux_handle),
 			   ticks_anchor, 0,
 			   HAL_TICKER_US_TO_TICKS(interval_us),
-			   HAL_TICKER_REMAINDER(interval_us), TICKER_NULL_LAZY,
+			   TICKER_NULL_REMAINDER, TICKER_NULL_LAZY,
 			   (aux->ull.ticks_slot + ticks_slot_overhead),
 			   ticker_cb, aux,
 			   ull_ticker_status_give, (void *)&ret_cb);


### PR DESCRIPTION
As Extended Advertising primary PDUs do not use ticker
remainder value for fine scheduling of radio events, do not
use the remainder value for auxiliary PDUs. This fixes the
jitter in the aux_offset value that caused the auxiliary PDU
being observed to be late compared to the aux_offset value
filled in the primary PDUs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>