### PR TITLE
Bluetooth: Controller: Fix sync reports post terminate and rx disable

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6527,6 +6527,7 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	struct pdu_adv_aux_ptr *aux_ptr = NULL;
 	const struct pdu_adv_adi *adi = NULL;
 	uint8_t cte_type = BT_HCI_LE_NO_CTE;
+	const struct ll_sync_set *sync;
 	struct pdu_adv_com_ext_adv *p;
 	struct pdu_adv_ext_hdr *h;
 	uint16_t data_len_total;
@@ -6545,6 +6546,22 @@ static void le_per_adv_sync_report(struct pdu_data *pdu_data,
 	if (!(event_mask & BT_EVT_MASK_LE_META_EVENT) ||
 	    (!(le_event_mask & BT_EVT_MASK_LE_PER_ADVERTISING_REPORT) &&
 	     !(le_event_mask & BT_EVT_MASK_LE_BIGINFO_ADV_REPORT))) {
+		return;
+	}
+
+	/* NOTE: The timeout_reload field in the sync context is checked under
+	 *       race condition between HCI Tx and Rx thread wherein a sync
+	 *       terminate was performed which resets the timeout_reload field
+	 *       before releasing the sync context back into its memory pool.
+	 *       It is important that timeout_reload field is at safe offset
+	 *       inside the sync context such that it is not corrupt while being
+	 *       in the memory pool.
+	 *
+	 *       This check ensures reports are not sent out after sync
+	 *       terminate.
+	 */
+	sync = HDR_LLL2ULL(ftr->param);
+	if (unlikely(!sync->timeout_reload)) {
 		return;
 	}
 
@@ -6671,14 +6688,13 @@ no_ext_hdr:
 	defined(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT)
 	} else if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC_ADI_SUPPORT) &&
 		   adi) {
-		const struct ll_sync_set *sync = HDR_LLL2ULL(ftr->param);
 		uint8_t data_status;
 
 		data_status = (aux_ptr) ?
 			      BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_PARTIAL :
 			      BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE;
 
-		accept = ftr->sync_rx_enabled &&
+		accept = sync->rx_enable && ftr->sync_rx_enabled &&
 			 (!sync->nodups ||
 			  !dup_found(PDU_ADV_TYPE_EXT_IND,
 				     sync->peer_id_addr_type,
@@ -6690,7 +6706,7 @@ no_ext_hdr:
 	*/
 
 	} else {
-		accept = ftr->sync_rx_enabled;
+		accept = sync->rx_enable && ftr->sync_rx_enabled;
 	}
 
 	data_len_max = CONFIG_BT_BUF_EVT_RX_SIZE -

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -1184,6 +1184,7 @@ static void aux_sync_incomplete(void *param)
 		/* prepare sync report with failure */
 		rx->type = NODE_RX_TYPE_SYNC_REPORT;
 		rx->handle = ull_sync_handle_get(sync);
+		rx->rx_ftr.param = lll;
 
 		/* flag chain reception failure */
 		rx->rx_ftr.aux_failed = 1U;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -52,6 +52,14 @@
 #include <soc.h>
 #include "hal/debug.h"
 
+/* Check that timeout_reload member is at safe offset when ll_sync_set is
+ * allocated using mem interface. timeout_reload being non-zero is used to
+ * indicate that a sync is established. And is used to check for sync being
+ * terminated under race conditions between HCI Tx and Rx thread when
+ * Periodic Advertising Reports are generated.
+ */
+MEM_FREE_MEMBER_ACCESS_BUILD_ASSERT(struct ll_sync_set, timeout_reload);
+
 static int init_reset(void);
 static inline struct ll_sync_set *sync_acquire(void);
 static void sync_ticker_cleanup(struct ll_sync_set *sync, ticker_op_func stop_op_cb);

--- a/subsys/bluetooth/controller/util/mem.h
+++ b/subsys/bluetooth/controller/util/mem.h
@@ -37,6 +37,22 @@
 #define MROUND(x) (((uint32_t)(x)+3) & (~((uint32_t)3)))
 #endif
 
+/* When memory is free in the mem_pool, first few bytes are reserved for
+ * maintaining the next pointer and free count.
+ */
+#define MEM_FREE_MEMBER_NEXT_SIZE  (sizeof(void *))
+#define MEM_FREE_MEMBER_COUNT_SIZE (sizeof(uint16_t))
+#define MEM_FREE_RESERVED_SIZE     ((MEM_FREE_MEMBER_NEXT_SIZE) + \
+				    (MEM_FREE_MEMBER_COUNT_SIZE))
+
+/* Define to check if a structure member is safe to be accessed when the memory
+ * is in the mem_pool free list. I.e. whether a structure member be safely
+ * accessed after the mem being freed.
+ */
+#define MEM_FREE_MEMBER_ACCESS_BUILD_ASSERT(type, member) \
+	BUILD_ASSERT(offsetof(type, member) >= MEM_FREE_RESERVED_SIZE, \
+		     "Possible unsafe member access inside free mem pool")
+
 void mem_init(void *mem_pool, uint16_t mem_size, uint16_t mem_count, void **mem_head);
 void *mem_acquire(void **mem_head);
 void mem_release(void *mem, void **mem_head);


### PR DESCRIPTION
Fix generating periodic advertising reports post sync
terminate under race condition when disabling reporting or
terminating the sync or while performing HCI reset.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>