### PR TITLE
Bluetooth: Controller: Use the received coding scheme for Extended Advertising and Periodic Sync

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -381,7 +381,7 @@ static int common_prepare_cb(struct lll_prepare_param *p, bool is_resume)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 	/* TODO: if coded we use S8? */
-	radio_phy_set(lll->phy, 1);
+	radio_phy_set(lll->phy, PHY_FLAGS_S8);
 	radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT, PDU_AC_LEG_PAYLOAD_SIZE_MAX,
 			    RADIO_PKT_CONF_PHY(lll->phy));
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -204,7 +204,7 @@ uint8_t lll_scan_aux_setup(struct pdu_adv *pdu, uint8_t pdu_phy,
 		overhead_us += cte_info->time << 3;
 	}
 #endif
-	overhead_us += lll_radio_rx_ready_delay_get(phy, 1);
+	overhead_us += lll_radio_rx_ready_delay_get(phy, PHY_FLAGS_S8);
 	overhead_us += window_widening_us;
 	overhead_us += EVENT_JITTER_US;
 
@@ -341,7 +341,7 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	hcto += window_size_us;
 	hcto += window_widening_us;
 	hcto += EVENT_JITTER_US;
-	hcto += radio_rx_chain_delay_get(phy_aux, 1);
+	hcto += radio_rx_chain_delay_get(phy_aux, PHY_FLAGS_S8);
 	hcto += addr_us_get(phy_aux);
 	radio_tmr_hcto_configure(hcto);
 
@@ -357,7 +357,8 @@ void lll_scan_aux_isr_aux_setup(void *param)
 	radio_gpio_lna_setup();
 
 	radio_gpio_pa_lna_enable(aux_start_us +
-				 radio_rx_ready_delay_get(phy_aux, 1) -
+				 radio_rx_ready_delay_get(phy_aux,
+							  PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
 }
@@ -531,9 +532,9 @@ sync_aux_prepare_done:
 	remainder_us = radio_tmr_start(0, ticks_at_start, remainder);
 
 	hcto = remainder_us + lll_aux->window_size_us;
-	hcto += radio_rx_ready_delay_get(lll_aux->phy, 1);
+	hcto += radio_rx_ready_delay_get(lll_aux->phy, PHY_FLAGS_S8);
 	hcto += addr_us_get(lll_aux->phy);
-	hcto += radio_rx_chain_delay_get(lll_aux->phy, 1);
+	hcto += radio_rx_chain_delay_get(lll_aux->phy, PHY_FLAGS_S8);
 	radio_tmr_hcto_configure(hcto);
 
 	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
@@ -548,7 +549,8 @@ sync_aux_prepare_done:
 	radio_gpio_lna_setup();
 
 	radio_gpio_pa_lna_enable(remainder_us +
-				 radio_rx_ready_delay_get(lll_aux->phy, 1) -
+				 radio_rx_ready_delay_get(lll_aux->phy,
+							  PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
 
@@ -1310,11 +1312,11 @@ static void isr_tx(struct lll_scan_aux *lll_aux, void *pdu_rx,
 #endif /* CONFIG_BT_CTLR_PRIVACY */
 
 	/* +/- 2us active clock jitter, +1 us hcto compensation */
-	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US + 4 +
-		RANGE_DELAY_US + 1;
-	hcto += radio_rx_chain_delay_get(lll_aux->phy, 1);
+	hcto = radio_tmr_tifs_base_get() + EVENT_IFS_US +
+	       (EVENT_CLOCK_JITTER_US << 1U) + RANGE_DELAY_US + 1U;
+	hcto += radio_rx_chain_delay_get(lll_aux->phy, PHY_FLAGS_S8);
 	hcto += addr_us_get(lll_aux->phy);
-	hcto -= radio_tx_chain_delay_get(lll_aux->phy, 1);
+	hcto -= radio_tx_chain_delay_get(lll_aux->phy, PHY_FLAGS_S8);
 	radio_tmr_hcto_configure(hcto);
 
 	/* capture end of Rx-ed PDU, extended scan to schedule auxiliary
@@ -1334,8 +1336,10 @@ static void isr_tx(struct lll_scan_aux *lll_aux, void *pdu_rx,
 	}
 
 	radio_gpio_lna_setup();
-	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US - 4 -
-				 radio_tx_chain_delay_get(lll_aux->phy, 1) -
+	radio_gpio_pa_lna_enable(radio_tmr_tifs_base_get() + EVENT_IFS_US -
+				 (EVENT_CLOCK_JITTER_US << 1U) -
+				 radio_tx_chain_delay_get(lll_aux->phy,
+							  PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -147,7 +147,7 @@ void lll_sync_aux_prepare_cb(struct lll_sync *lll,
 	/* Start setting up Radio h/w */
 	radio_reset();
 
-	radio_phy_set(lll_aux->phy, 1);
+	radio_phy_set(lll_aux->phy, PHY_FLAGS_S8);
 	radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT, LL_EXT_OCTETS_RX_MAX,
 			    RADIO_PKT_CONF_PHY(lll_aux->phy));
 
@@ -387,7 +387,7 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	/* Start setting up Radio h/w */
 	radio_reset();
 
-	radio_phy_set(lll->phy, 1);
+	radio_phy_set(lll->phy, PHY_FLAGS_S8);
 	radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT, LL_EXT_OCTETS_RX_MAX,
 			    RADIO_PKT_CONF_PHY(lll->phy));
 	radio_aa_set(lll->access_addr);
@@ -417,9 +417,9 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	       ((EVENT_JITTER_US + EVENT_TICKER_RES_MARGIN_US + lll->window_widening_event_us)
 		<< 1) +
 	       lll->window_size_event_us;
-	hcto += radio_rx_ready_delay_get(lll->phy, 1);
+	hcto += radio_rx_ready_delay_get(lll->phy, PHY_FLAGS_S8);
 	hcto += addr_us_get(lll->phy);
-	hcto += radio_rx_chain_delay_get(lll->phy, 1);
+	hcto += radio_rx_chain_delay_get(lll->phy, PHY_FLAGS_S8);
 	radio_tmr_hcto_configure(hcto);
 
 	radio_tmr_end_capture();
@@ -428,7 +428,8 @@ static int prepare_cb_common(struct lll_prepare_param *p, uint8_t chan_idx)
 	radio_gpio_lna_setup();
 
 	radio_gpio_pa_lna_enable(remainder_us +
-				 radio_rx_ready_delay_get(lll->phy, 1) -
+				 radio_rx_ready_delay_get(lll->phy,
+							  PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
 
@@ -553,7 +554,7 @@ static void isr_aux_setup(void *param)
 	}
 
 	/* Setup radio for auxiliary PDU scan */
-	radio_phy_set(phy_aux, 1);
+	radio_phy_set(phy_aux, PHY_FLAGS_S8);
 	radio_pkt_configure(RADIO_PKT_CONF_LENGTH_8BIT, LL_EXT_OCTETS_RX_MAX,
 			    RADIO_PKT_CONF_PHY(phy_aux));
 
@@ -579,7 +580,7 @@ static void isr_aux_setup(void *param)
 	 * PDU start time in this case.
 	 */
 	aux_start_us = ftr->radio_end_us + aux_offset_us;
-	aux_start_us -= lll_radio_rx_ready_delay_get(phy_aux, 1);
+	aux_start_us -= lll_radio_rx_ready_delay_get(phy_aux, PHY_FLAGS_S8);
 	aux_start_us -= window_widening_us;
 	aux_start_us -= EVENT_JITTER_US;
 	radio_tmr_start_us(0, aux_start_us);
@@ -589,7 +590,7 @@ static void isr_aux_setup(void *param)
 	hcto += window_size_us;
 	hcto += window_widening_us;
 	hcto += EVENT_JITTER_US;
-	hcto += radio_rx_chain_delay_get(phy_aux, 1);
+	hcto += radio_rx_chain_delay_get(phy_aux, PHY_FLAGS_S8);
 	hcto += addr_us_get(phy_aux);
 	radio_tmr_hcto_configure(hcto);
 
@@ -605,7 +606,8 @@ static void isr_aux_setup(void *param)
 	radio_gpio_lna_setup();
 
 	radio_gpio_pa_lna_enable(aux_start_us +
-				 radio_rx_ready_delay_get(phy_aux, 1) -
+				 radio_rx_ready_delay_get(phy_aux,
+							  PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -620,7 +620,8 @@ void ull_scan_aux_setup(memq_link_t *link, struct node_rx_hdr *rx)
 	lll_aux->window_size_us += (EVENT_TICKER_RES_MARGIN_US +
 				    ((EVENT_JITTER_US + window_widening_us) << 1));
 
-	ready_delay_us = lll_radio_rx_ready_delay_get(lll_aux->phy, 1);
+	ready_delay_us = lll_radio_rx_ready_delay_get(lll_aux->phy,
+						      PHY_FLAGS_S8);
 
 	/* Calculate the aux offset from start of the scan window */
 	aux_offset_us += ftr->radio_end_us;


### PR DESCRIPTION
Use the received coding scheme when receiving Extended
and Periodic Advertising PDUs for correctly calculating
the receive chain delay and on-air PDU time.

Relates to commit https://github.com/zephyrproject-rtos/zephyr/commit/6911e7e1d88845d31df03b4a30dc55afca29ba5a ("Bluetooth: Controller: Use
the received coding scheme when scanning").

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>