### PR TITLE
scripts/checkpatch: typdefsfile: Derogate on STM32Cube CMSIS *_TypeDef

### DIFF
--- a/scripts/checkpatch/typedefsfile
+++ b/scripts/checkpatch/typedefsfile
@@ -4,3 +4,4 @@ mbedtls_pk_context
 z_arch_esf_t
 pinctrl_soc_pin_t
 io_rw_32
+\b[a-zA-Z_][a-zA-Z0-9_]*TypeDef


### PR DESCRIPTION
Derogate on all FOO_TypeDef
Avoid false positive as reported in https://github.com/zephyrproject-rtos/zephyr/pull/43857:

```
-:10: ERROR:SPACING: need consistent spacing around '*' (ctx:WxV)
#10: FILE: drivers/adc/adc_stm32.c:806:
+	ADC_TypeDef *adc = config->base;
```

