### PR TITLE
tests: Increase timeout for some tests

### DIFF
--- a/tests/kernel/mem_slab/mslab_concept/testcase.yaml
+++ b/tests/kernel/mem_slab/mslab_concept/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.memory_slabs.concept:
     tags: kernel
+    timeout: 70
   kernel.memory_slabs.concept.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator

--- a/tests/kernel/workq/work/testcase.yaml
+++ b/tests/kernel/workq/work/testcase.yaml
@@ -5,6 +5,7 @@ tests:
     # this patform fails to run due to #40376, all
     # the related CI checks got blocked, so exclude it.
     platform_exclude: hifive1
+    timeout: 70
   kernel.work.api.linker_generator:
     platform_allow: qemu_cortex_m3
     min_flash: 34


### PR DESCRIPTION
There are tests failing sometimes due timeouts in simulators, slightly
increase the default timeout for these cases.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>