### PR TITLE
drivers: can: add struct device argument to callback functions

### DIFF
--- a/doc/reference/canbus/controller.rst
+++ b/doc/reference/canbus/controller.rst
@@ -175,9 +175,9 @@ occurred. It does not block until the message is sent like the example above.
 
 .. code-block:: C
 
-  void tx_irq_callback(int error, void *arg)
+  void tx_callback(const struct device *dev, int error, void *user_data)
   {
-          char *sender = (char *)arg;
+          char *sender = (char *)user_data;
 
           if (error != 0) {
                   LOG_ERR("Sendig failed [%d]\nSender: %s\n", error, sender);
@@ -211,7 +211,7 @@ added.
 
 .. code-block:: C
 
-  void rx_callback_function(struct zcan_frame *frame, void *user_data)
+  void rx_callback_function(const struct device *dev, struct zcan_frame *frame, void *user_data)
   {
           ... do something with the frame ...
   }

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -14,16 +14,18 @@ LOG_MODULE_REGISTER(can_common, CONFIG_CAN_LOG_LEVEL);
 /* CAN sync segment is always one time quantum */
 #define CAN_SYNC_SEG 1
 
-static void can_msgq_put(struct zcan_frame *frame, void *arg)
+static void can_msgq_put(const struct device *dev, struct zcan_frame *frame, void *user_data)
 {
-	struct k_msgq *msgq = (struct k_msgq *)arg;
+	struct k_msgq *msgq = (struct k_msgq *)user_data;
 	int ret;
+
+	ARG_UNUSED(dev);
 
 	__ASSERT_NO_MSG(msgq);
 
 	ret = k_msgq_put(msgq, frame, K_NO_WAIT);
 	if (ret) {
-		LOG_ERR("Msgq %p overflowed. Frame ID: 0x%x", arg, frame->id);
+		LOG_ERR("Msgq %p overflowed. Frame ID: 0x%x", msgq, frame->id);
 	}
 }
 

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -166,6 +166,7 @@ struct can_mcan_msg_sram {
 } __packed __aligned(4);
 
 struct can_mcan_data {
+	const struct device *dev;
 	struct k_mutex inst_mutex;
 	struct k_sem tx_sem;
 	struct k_mutex tx_mtx;

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -635,7 +635,7 @@ static void mcp2515_rx_filter(const struct device *dev,
 		/*Make a temporary copy in case the user modifies the message*/
 		tmp_frame = *frame;
 
-		callback(&tmp_frame, dev_data->cb_arg[filter_id]);
+		callback(dev, &tmp_frame, dev_data->cb_arg[filter_id]);
 	}
 
 	k_mutex_unlock(&dev_data->mutex);
@@ -665,7 +665,7 @@ static void mcp2515_tx_done(const struct device *dev, uint8_t tx_idx)
 	if (dev_data->tx_cb[tx_idx].cb == NULL) {
 		k_sem_give(&dev_data->tx_cb[tx_idx].sem);
 	} else {
-		dev_data->tx_cb[tx_idx].cb(0, dev_data->tx_cb[tx_idx].cb_arg);
+		dev_data->tx_cb[tx_idx].cb(dev, 0, dev_data->tx_cb[tx_idx].cb_arg);
 	}
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
@@ -731,7 +731,7 @@ static void mcp2515_handle_errors(const struct device *dev)
 
 	if (state_change_cb && dev_data->old_state != state) {
 		dev_data->old_state = state;
-		state_change_cb(state, err_cnt, state_change_cb_data);
+		state_change_cb(dev, state, err_cnt, state_change_cb_data);
 	}
 }
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -547,7 +547,7 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 		data->state = state;
 
 		if (cb != NULL) {
-			cb(state, err_cnt, cb_data);
+			cb(dev, state, err_cnt, cb_data);
 		}
 	}
 
@@ -562,7 +562,7 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 				FLEXCAN_TransferAbortSend(config->base, &data->handle,
 							  ALLOC_IDX_TO_TXMB_IDX(alloc));
 				if (function != NULL) {
-					function(-ENETDOWN, arg);
+					function(dev, -ENETDOWN, arg);
 				} else {
 					data->tx_cbs[alloc].status = -ENETDOWN;
 					k_sem_give(&data->tx_cbs[alloc].done);
@@ -590,7 +590,7 @@ static inline void mcux_flexcan_transfer_tx_idle(const struct device *dev,
 
 	if (atomic_test_and_clear_bit(data->tx_allocs, alloc)) {
 		if (function != NULL) {
-			function(0, arg);
+			function(dev, 0, arg);
 		} else {
 			data->tx_cbs[alloc].status = 0;
 			k_sem_give(&data->tx_cbs[alloc].done);
@@ -618,7 +618,7 @@ static inline void mcux_flexcan_transfer_rx_idle(const struct device *dev,
 	if (atomic_test_bit(data->rx_allocs, alloc)) {
 		mcux_flexcan_copy_frame_to_zframe(&data->rx_cbs[alloc].frame,
 						  &frame);
-		function(&frame, arg);
+		function(dev, &frame, arg);
 
 		/* Setup RX message buffer to receive next message */
 		FLEXCAN_SetRxMbConfig(config->base, mb,

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -233,7 +233,7 @@ static void can_rcar_tx_done(const struct device *dev)
 
 	data->tx_unsent--;
 	if (tx_cb->cb != NULL) {
-		tx_cb->cb(0, tx_cb->cb_arg);
+		tx_cb->cb(dev, 0, tx_cb->cb_arg);
 	} else {
 		k_sem_give(&tx_cb->sem);
 	}
@@ -267,7 +267,7 @@ static void can_rcar_state_change(const struct device *dev, uint32_t newstate)
 		return;
 	}
 	can_rcar_get_error_count(config, &err_cnt);
-	cb(newstate, err_cnt, state_change_cb_data);
+	cb(dev, newstate, err_cnt, state_change_cb_data);
 }
 
 static void can_rcar_error(const struct device *dev)
@@ -366,7 +366,8 @@ static void can_rcar_error(const struct device *dev)
 	}
 }
 
-static void can_rcar_rx_filter_isr(struct can_rcar_data *data,
+static void can_rcar_rx_filter_isr(const struct device *dev,
+				   struct can_rcar_data *data,
 				   const struct zcan_frame *frame)
 {
 	struct zcan_frame tmp_frame;
@@ -385,7 +386,7 @@ static void can_rcar_rx_filter_isr(struct can_rcar_data *data,
 		 * modifies the message.
 		 */
 		tmp_frame = *frame;
-		data->rx_callback[i](&tmp_frame, data->rx_callback_arg[i]);
+		data->rx_callback[i](dev, &tmp_frame, data->rx_callback_arg[i]);
 	}
 }
 
@@ -437,7 +438,7 @@ static void can_rcar_rx_isr(const struct device *dev)
 	/* Increment CPU side pointer */
 	sys_write8(0xff, config->reg_addr + RCAR_CAN_RFPCR);
 
-	can_rcar_rx_filter_isr(data, &frame);
+	can_rcar_rx_filter_isr(dev, data, &frame);
 }
 
 static void can_rcar_isr(const struct device *dev)

--- a/drivers/can/socket_can_generic.h
+++ b/drivers/can/socket_can_generic.h
@@ -45,9 +45,12 @@ static inline void socket_can_iface_init(struct net_if *iface)
 	LOG_DBG("Init CAN interface %p dev %p", iface, dev);
 }
 
-static inline void tx_irq_callback(int error, void *arg)
+static inline void tx_irq_callback(const struct device *dev, int error, void *arg)
 {
 	char *caller_str = (char *)arg;
+
+	ARG_UNUSED(dev);
+
 	if (error != 0) {
 		LOG_DBG("TX error from %s! error-code: %d",
 			caller_str, error);

--- a/include/drivers/can.h
+++ b/include/drivers/can.h
@@ -257,30 +257,35 @@ struct can_timing {
  * @typedef can_tx_callback_t
  * @brief Defines the application callback handler function signature
  *
+ * @param dev       Pointer to the device structure for the driver instance.
  * @param error     Status of the performed send operation. See the list of
  *                  return values for @a can_send() for value descriptions.
  * @param user_data User data provided when the frame was sent.
  */
-typedef void (*can_tx_callback_t)(int error, void *user_data);
+typedef void (*can_tx_callback_t)(const struct device *dev, int error, void *user_data);
 
 /**
  * @typedef can_rx_callback_t
  * @brief Defines the application callback handler function signature for receiving.
  *
+ * @param dev       Pointer to the device structure for the driver instance.
  * @param frame     Received frame.
  * @param user_data User data provided when the filter was added.
  */
-typedef void (*can_rx_callback_t)(struct zcan_frame *frame, void *user_data);
+typedef void (*can_rx_callback_t)(const struct device *dev, struct zcan_frame *frame,
+				  void *user_data);
 
 /**
  * @typedef can_state_change_callback_t
  * @brief Defines the state change callback handler function signature
  *
+ * @param dev       Pointer to the device structure for the driver instance.
  * @param state     State of the CAN controller.
  * @param err_cnt   CAN controller error counter values.
  * @param user_data User data provided the callback was set.
  */
-typedef void (*can_state_change_callback_t)(enum can_state state,
+typedef void (*can_state_change_callback_t)(const struct device *dev,
+					    enum can_state state,
 					    struct can_bus_err_cnt err_cnt,
 					    void *user_data);
 

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -78,10 +78,12 @@ static void canopen_detach_all_rx_filters(CO_CANmodule_t *CANmodule)
 	}
 }
 
-static void canopen_rx_callback(struct zcan_frame *msg, void *arg)
+static void canopen_rx_callback(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	CO_CANrx_t *buffer = (CO_CANrx_t *)arg;
 	CO_CANrxMsg_t rxMsg;
+
+	ARG_UNUSED(dev);
 
 	if (!buffer || !buffer->pFunct) {
 		LOG_ERR("failed to process CAN rx callback");
@@ -94,9 +96,11 @@ static void canopen_rx_callback(struct zcan_frame *msg, void *arg)
 	buffer->pFunct(buffer->object, &rxMsg);
 }
 
-static void canopen_tx_callback(int error, void *arg)
+static void canopen_tx_callback(const struct device *dev, int error, void *arg)
 {
 	CO_CANmodule_t *CANmodule = arg;
+
+	ARG_UNUSED(dev);
 
 	if (!CANmodule) {
 		LOG_ERR("failed to process CAN tx callback");

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -44,9 +44,11 @@ static struct k_poll_event change_led_events[1] = {
 					&change_led_msgq, 0)
 };
 
-void tx_irq_callback(int error, void *arg)
+void tx_irq_callback(const struct device *dev, int error, void *arg)
 {
 	char *sender = (char *)arg;
+
+	ARG_UNUSED(dev);
 
 	if (error != 0) {
 		printk("Callback! error-code: %d\nSender: %s\n",
@@ -174,9 +176,12 @@ void state_change_work_handler(struct k_work *work)
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 }
 
-void state_change_callback(enum can_state state, struct can_bus_err_cnt err_cnt, void *user_data)
+void state_change_callback(const struct device *dev, enum can_state state,
+			   struct can_bus_err_cnt err_cnt, void *user_data)
 {
 	struct k_work *work = (struct k_work *)user_data;
+
+	ARG_UNUSED(dev);
 
 	current_state = state;
 	current_err_cnt = err_cnt;

--- a/subsys/canbus/isotp/isotp.c
+++ b/subsys/canbus/isotp/isotp.c
@@ -76,9 +76,11 @@ static inline void receive_report_error(struct isotp_recv_ctx *ctx, int err)
 	ctx->error_nr = err;
 }
 
-static void receive_can_tx(int error, void *arg)
+static void receive_can_tx(const struct device *dev, int error, void *arg)
 {
 	struct isotp_recv_ctx *ctx = (struct isotp_recv_ctx *)arg;
+
+	ARG_UNUSED(dev);
 
 	if (error != 0) {
 		LOG_ERR("Error sending FC frame (%d)", error);
@@ -525,9 +527,11 @@ static void process_cf(struct isotp_recv_ctx *ctx, struct zcan_frame *frame)
 	}
 }
 
-static void receive_can_rx(struct zcan_frame *frame, void *arg)
+static void receive_can_rx(const struct device *dev, struct zcan_frame *frame, void *arg)
 {
 	struct isotp_recv_ctx *ctx = (struct isotp_recv_ctx *)arg;
+
+	ARG_UNUSED(dev);
 
 	switch (ctx->state) {
 	case ISOTP_RX_STATE_WAIT_FF_SF:
@@ -723,9 +727,11 @@ static inline void send_report_error(struct isotp_send_ctx *ctx, uint32_t err)
 	ctx->error_nr = err;
 }
 
-static void send_can_tx_cb(int error, void *arg)
+static void send_can_tx_cb(const struct device *dev, int error, void *arg)
 {
 	struct isotp_send_ctx *ctx = (struct isotp_send_ctx *)arg;
+
+	ARG_UNUSED(dev);
 
 	ctx->tx_backlog--;
 	k_sem_give(&ctx->tx_sem);
@@ -816,9 +822,11 @@ static void send_process_fc(struct isotp_send_ctx *ctx,
 	}
 }
 
-static void send_can_rx_cb(struct zcan_frame *frame, void *arg)
+static void send_can_rx_cb(const struct device *dev, struct zcan_frame *frame, void *arg)
 {
 	struct isotp_send_ctx *ctx = (struct isotp_send_ctx *)arg;
+
+	ARG_UNUSED(dev);
 
 	if (ctx->state == ISOTP_TX_WAIT_FC) {
 		z_abort_timeout(&ctx->timeout);

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -174,94 +174,106 @@ static inline void check_msg(const struct zcan_frame *msg1,
 	zassert_equal(cmp_res, 0, "Received data differ");
 }
 
-static void tx_std_isr_1(int error, void *arg)
+static void tx_std_isr_1(const struct device *dev, int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
 	k_sem_give(&tx_cb_sem);
 
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal(msg->id, TEST_CAN_STD_ID_1, "Arg does not match");
 }
 
-static void tx_std_isr_2(int error, void *arg)
+static void tx_std_isr_2(const struct device *dev, int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
 	k_sem_give(&tx_cb_sem);
 
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal(msg->id, TEST_CAN_STD_ID_2, "Arg does not match");
 }
 
-static void tx_ext_isr_1(int error, void *arg)
+static void tx_ext_isr_1(const struct device *dev, int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
 	k_sem_give(&tx_cb_sem);
 
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal(msg->id, TEST_CAN_EXT_ID_1, "Arg does not match");
 }
 
-static void tx_ext_isr_2(int error, void *arg)
+static void tx_ext_isr_2(const struct device *dev, int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
 	k_sem_give(&tx_cb_sem);
 
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal(msg->id, TEST_CAN_EXT_ID_2, "Arg does not match");
 }
 
-static void rx_std_isr_1(struct zcan_frame *msg, void *arg)
+static void rx_std_isr_1(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_1, 0);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_filter_1, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_std_isr_2(struct zcan_frame *msg, void *arg)
+static void rx_std_isr_2(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_2, 0);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_filter_2, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_std_mask_isr_1(struct zcan_frame *msg, void *arg)
+static void rx_std_mask_isr_1(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_1, 0x0F);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_masked_filter_1, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_std_mask_isr_2(struct zcan_frame *msg, void *arg)
+static void rx_std_mask_isr_2(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_2, 0x0F);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_masked_filter_2, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_ext_isr_1(struct zcan_frame *msg, void *arg)
+static void rx_ext_isr_1(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg_1, 0);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_ext_filter_1, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_ext_isr_2(struct zcan_frame *msg, void *arg)
+static void rx_ext_isr_2(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg_2, 0);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_ext_filter_2, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_ext_mask_isr_1(struct zcan_frame *msg, void *arg)
+static void rx_ext_mask_isr_1(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg_1, 0x0F);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_ext_masked_filter_1, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_ext_mask_isr_2(struct zcan_frame *msg, void *arg)
+static void rx_ext_mask_isr_2(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_ext_msg_2, 0x0F);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_ext_masked_filter_2, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -112,48 +112,54 @@ static inline void check_msg(const struct zcan_frame *msg1,
 	zassert_equal(cmp_res, 0, "Received data differ");
 }
 
-static void tx_std_isr_1(int error, void *arg)
+static void tx_std_isr_1(const struct device *dev, int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
 	k_sem_give(&tx_cb_sem);
 
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal(msg->id, TEST_CAN_STD_ID_1, "Arg does not match");
 }
 
-static void tx_std_isr_2(int error, void *arg)
+static void tx_std_isr_2(const struct device *dev, int error, void *arg)
 {
 	const struct zcan_frame *msg = (const struct zcan_frame *)arg;
 
 	k_sem_give(&tx_cb_sem);
 
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal(msg->id, TEST_CAN_STD_ID_2, "Arg does not match");
 }
 
-static void rx_std_isr_1(struct zcan_frame *msg, void *arg)
+static void rx_std_isr_1(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_1);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_filter_1, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_std_isr_2(struct zcan_frame *msg, void *arg)
+static void rx_std_isr_2(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_2);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_filter_2, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_std_isr_fd_1(struct zcan_frame *msg, void *arg)
+static void rx_std_isr_fd_1(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_fd_1);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_filter_1, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }
 
-static void rx_std_isr_fd_2(struct zcan_frame *msg, void *arg)
+static void rx_std_isr_fd_2(const struct device *dev, struct zcan_frame *msg, void *arg)
 {
 	check_msg(msg, &test_std_msg_fd_2);
+	zassert_equal(dev, can_dev, "CAN device does not match");
 	zassert_equal_ptr(arg, &test_std_filter_2, "arg does not match");
 	k_sem_give(&rx_isr_sem);
 }


### PR DESCRIPTION
Include a pointer to the CAN controller device for the CAN transmit, receive, and state change callback functions.

This is recommended by the [Zephyr API design guidelines](https://docs.zephyrproject.org/latest/reference/api/design_guidelines.html#using-callbacks).

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>