### PR TITLE
doc: reference: api: design guidelines: use const struct device *dev

### DIFF
--- a/doc/reference/api/design_guidelines.rst
+++ b/doc/reference/api/design_guidelines.rst
@@ -16,7 +16,7 @@ specifying the signature of a callback:
 
 * The first parameter should be a pointer to the object most closely
   associated with the callback.  In the case of device drivers this
-  would be ``struct device *dev``.  For library functions it may be a
+  would be ``const struct device *dev``.  For library functions it may be a
   pointer to another object that was referenced when the callback was
   provided.
 


### PR DESCRIPTION
Use "const struct device *dev" for first argument in callback functions.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>