### PR TITLE
drivers: can: stm32h7: fix compilation

### DIFF
--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -179,11 +179,11 @@ static int can_stm32h7_set_timing(const struct device *dev,
 	return can_mcan_set_timing(&cfg->mcan_cfg, timing, timing_data);
 }
 
-int mcux_stm32h7_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+int can_stm32h7_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
-	const struct mcux_stm32h7_config *cfg = dev->config;
+	const struct can_stm32h7_config *cfg = dev->config;
 
-	*max_bitrate = cfg->mcan.max_bitrate;
+	*max_bitrate = cfg->mcan_cfg.max_bitrate;
 
 	return 0;
 }


### PR DESCRIPTION
Fix compilation of the STM32H7 CAN-FD driver front-end.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>