### PR TITLE
west.yml: hal_espressif update and sync

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -67,7 +67,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: bcd7565ffa390d5774dc2fbe71a002faa9a7d082
+      revision: 3373bdddba3857d34c22c0d493da25bdb8630071
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
This updates hal_espressif so that a few changes and
features are available in main repository.

- Removed unused stubs
- Updated esptool version
- Fix macro redefinitions
- Changes to support Zephyr SDK toolchain
- pinctrl base files
- Fix BLE nested locking handling

Closes #43258

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>