### PR TITLE
code_relocation: Move NOCOPY flag to avoid OS drive colon

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1273,7 +1273,7 @@ function(zephyr_code_relocate file location)
   endif()
   set_property(TARGET code_data_relocation_target
     APPEND PROPERTY COMPILE_DEFINITIONS
-    "${location}:${file}:${copy_flag}")
+    "${location}:${copy_flag}:${file}")
 endfunction()
 
 # Usage:

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -418,7 +418,7 @@ def create_dict_wrt_mem():
         if ':' not in line:
             continue
 
-        mem_region, file_name, copy_flag = line.split(':', 2)
+        mem_region, copy_flag, file_name = line.split(':', 2)
 
         file_name_list = glob.glob(file_name)
         if not file_name_list:


### PR DESCRIPTION
COPY/NOCOPY flag was added to the end of the string with ':'
as separators. The python script then split the line on ':'
which breaks on Windows build because the string was

[MEM]:[FILE]:[COPY]

In windows you will have 'c:\' in the file path so the
line.split() in script will split on the 'c:'.

Move the COPY/NOCOPY to:

[MEM]:[COPY/NOCOPY]:[FILE]

Note that the comments at top of gen_relocate_app.py also
indicates this format.

Fixes #43950

Signed-off-by: David Leach <david.leach@nxp.com>