### PR TITLE
Bluetooth: Host: Fix bt_recv_thread_id assignment

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -117,6 +117,20 @@ K_MEM_SLAB_DEFINE(chan_slab, sizeof(struct bt_att_chan),
 		  __alignof__(struct bt_att_chan));
 static struct bt_att_req cancel;
 
+/** The thread ATT response handlers likely run on.
+ *
+ *  Blocking this thread while waiting for an ATT request to resolve can cause a
+ *  deadlock.
+ *
+ *  This can happen if the application queues ATT requests in the context of a
+ *  callback from the Bluetooth stack. This is because queuing an ATT request
+ *  will block until a request-resource is available, and the callbacks run on
+ *  the same thread as the ATT response handler that frees request-resources.
+ *
+ *  The intended use of this value is to detect the above situation.
+ */
+static k_tid_t att_handle_rsp_thread;
+
 typedef void (*bt_att_chan_sent_t)(struct bt_att_chan *chan);
 
 static bt_att_chan_sent_t chan_cb(struct net_buf *buf);
@@ -2974,6 +2988,8 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **ch)
 		return -ENOMEM;
 	}
 
+	att_handle_rsp_thread = k_current_get();
+
 	(void)memset(att, 0, sizeof(*att));
 	att->conn = conn;
 	sys_slist_init(&att->reqs);
@@ -3234,7 +3250,7 @@ struct bt_att_req *bt_att_req_alloc(k_timeout_t timeout)
 {
 	struct bt_att_req *req = NULL;
 
-	if (k_current_get() == bt_recv_thread_id) {
+	if (k_current_get() == att_handle_rsp_thread) {
 		/* No req will be fulfilled while blocking on the bt_recv thread.
 		 * Blocking would cause deadlock.
 		 */

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3376,14 +3376,8 @@ void hci_event_prio(struct net_buf *buf)
 	}
 }
 
-k_tid_t bt_recv_thread_id;
-
 int bt_recv(struct net_buf *buf)
 {
-	if (bt_recv_thread_id == NULL) {
-		bt_recv_thread_id = k_current_get();
-	}
-
 	bt_monitor_send(bt_monitor_opcode(buf), buf->data, buf->len);
 
 	BT_DBG("buf %p len %u", buf, buf->len);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -475,8 +475,3 @@ void bt_hci_synchronous_conn_complete(struct net_buf *buf);
 
 void bt_hci_le_df_connection_iq_report(struct net_buf *buf);
 void bt_hci_le_df_cte_req_failed(struct net_buf *buf);
-
-/** First thread that called bt_recv. NULL if not yet called.
- *  Updated non-atomically; may be used only to compare to current thread id.
- */
-extern k_tid_t bt_recv_thread_id;


### PR DESCRIPTION
The above mentioned fix attempts to detect the situation when
bt_att_req_alloc() is invoked on the same thread that runs
att_handle_rsp. It attempts to do so by noting the thread that
first ran bt_recv, assuming the same thread will house all calls
to bt_att_req_free. This turns out not to be correct. It is
evident from the call stack provided below that bt_att_req_free
can be called from other threads than the one that runs bt_recv.

Fixes: #43448

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>