### PR TITLE
Bluetooth: Controller: radio: Fix num of antennas returned by controller

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -207,6 +207,9 @@ void radio_df_ant_switching_gpios_cfg(void)
  *
  * The number of antennas is hardware defined. It is provided via devicetree.
  *
+ * If antenna switching is not enabled then there must be a single antenna
+ * responsible for PDU reception and transmission.
+ *
  * @return	Number of available antennas.
  */
 uint8_t radio_df_ant_num_get(void)
@@ -215,7 +218,7 @@ uint8_t radio_df_ant_num_get(void)
 	defined(CONFIG_BT_CTLR_DF_ANT_SWITCH_RX)
 	return ant_cfg.ant_num;
 #else
-	return 0;
+	return 1U;
 #endif
 }
 


### PR DESCRIPTION
The antenna number returned by controller if antenna switching is not
enabled was zero. That is not compliant with  BT 5.3. Core Spec Vol 4.
Part E section 7.8.87. In this situation returned value should be 1.

There is always single antenna available that is responsible for PDU
reception and transmission.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>