### PR TITLE
drivers: can: guard against bitrate of zero

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -83,7 +83,7 @@ static int can_calc_timing_int(uint32_t core_clock, struct can_timing *res,
 	int sp_err;
 	struct can_timing tmp_res;
 
-	if (sp >= 1000 ||
+	if (bitrate == 0 || sp >= 1000 ||
 	    (!IS_ENABLED(CONFIG_CAN_FD_MODE) && bitrate > 1000000) ||
 	     (IS_ENABLED(CONFIG_CAN_FD_MODE) && bitrate > 8000000)) {
 		return -EINVAL;


### PR DESCRIPTION
Guard against attempts to set a bitrate of zero as this will lead to division-by-zero.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>