### PR TITLE
drivers: can: mcan: add generic support for can_get_max_filters()

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -828,6 +828,17 @@ static int can_mcan_get_free_std(volatile struct can_mcan_std_filter *filters)
 	return -ENOSPC;
 }
 
+int can_mcan_get_max_filters(const struct device *dev, enum can_ide id_type)
+{
+	ARG_UNUSED(dev);
+
+	if (id_type == CAN_STANDARD_IDENTIFIER) {
+		return NUM_STD_FILTER_DATA;
+	} else {
+		return NUM_EXT_FILTER_DATA;
+	}
+}
+
 /* Use masked configuration only for simplicity. If someone needs more than
  * 28 standard filters, dual mode needs to be implemented.
  * Dual mode gets tricky, because we can only activate both filters.

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -232,6 +232,8 @@ int can_mcan_send(const struct can_mcan_config *cfg, struct can_mcan_data *data,
 		  k_timeout_t timeout, can_tx_callback_t callback,
 		  void *user_data);
 
+int can_mcan_get_max_filters(const struct device *dev, enum can_ide id_type);
+
 int can_mcan_add_rx_filter(struct can_mcan_data *data,
 			   struct can_mcan_msg_sram *msg_ram,
 			   can_rx_callback_t callback, void *user_data,

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -159,6 +159,7 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 	.get_state = mcux_mcan_get_state,
 	.set_state_change_callback = mcux_mcan_set_state_change_callback,
 	.get_core_clock = mcux_mcan_get_core_clock,
+	.get_max_filters = can_mcan_get_max_filters,
 	.get_max_bitrate = mcux_mcan_get_max_bitrate,
 	/*
 	 * MCUX MCAN timing limits are specified in the "Nominal bit timing and

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -172,6 +172,7 @@ static const struct can_driver_api can_api_funcs = {
 	.recover = can_mcan_recover,
 #endif
 	.get_core_clock = can_sam_get_core_clock,
+	.get_max_filters = can_mcan_get_max_filters,
 	.get_max_bitrate = can_sam_get_max_bitrate,
 	.set_state_change_callback =  can_sam_set_state_change_callback,
 	.timing_min = {

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -38,15 +38,6 @@ static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-static int can_stm32fd_get_max_filters(const struct device *dev, enum can_ide id_type)
-{
-	if (id_type == CAN_STANDARD_IDENTIFIER) {
-		return NUM_STD_FILTER_DATA;
-	} else {
-		return NUM_EXT_FILTER_DATA;
-	}
-}
-
 static void can_stm32fd_clock_enable(void)
 {
 	LL_RCC_SetFDCANClockSource(LL_RCC_FDCAN_CLKSOURCE_PCLK1);
@@ -197,7 +188,7 @@ static const struct can_driver_api can_api_funcs = {
 #endif
 	.get_core_clock = can_stm32fd_get_core_clock,
 	.get_max_bitrate = can_stm32fd_get_max_bitrate,
-	.get_max_filters = can_stm32fd_get_max_filters,
+	.get_max_filters = can_mcan_get_max_filters,
 	.set_state_change_callback = can_stm32fd_set_state_change_callback,
 	.timing_min = {
 		.sjw = 0x7f,

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -49,18 +49,6 @@ static int can_stm32h7_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-static int can_stm32h7_get_max_filters(const struct device *dev,
-				       enum can_ide id_type)
-{
-	ARG_UNUSED(dev);
-
-	if (id_type == CAN_STANDARD_IDENTIFIER) {
-		return NUM_STD_FILTER_DATA;
-	} else {
-		return NUM_EXT_FILTER_DATA;
-	}
-}
-
 static int can_stm32h7_clock_enable(const struct device *dev)
 {
 	int ret;
@@ -216,7 +204,7 @@ static const struct can_driver_api can_api_funcs = {
 #endif
 	.get_core_clock = can_stm32h7_get_core_clock,
 	.get_max_bitrate = can_stm32h7_get_max_bitrate,
-	.get_max_filters = can_stm32h7_get_max_filters,
+	.get_max_filters = can_mcan_get_max_filters,
 	.set_state_change_callback = can_stm32h7_set_state_change_cb,
 	/* Timing limits are per the STM32H7 Reference Manual (RM0433 Rev 7),
 	 * section 56.5.7, FDCAN nominal bit timing and prescaler register


### PR DESCRIPTION
Add generic support for can_get_max_filters() to the Bosch M_CAN base driver and use it in all driver frontends.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>