### PR TITLE
maintainers: set henrikbrixandersen as canbus maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -485,9 +485,9 @@ Documentation:
 "Drivers: CAN":
     status: maintained
     maintainers:
-        - alexanderwachter
-    collaborators:
         - henrikbrixandersen
+    collaborators:
+        - alexanderwachter
         - karstenkoenig
         - nixward
         - martinjaeger


### PR DESCRIPTION
Set henrikbrixandersen as the new maintainer of canbus

Signed-off-by: Alexander Wachter <alexander@wachter.cloud>