### PR TITLE
net: http: Allow a content_len of 4GB

### DIFF
--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(net_http, CONFIG_NET_HTTP_LOG_LEVEL);
 
 #include "net_private.h"
 
-#define HTTP_CONTENT_LEN_SIZE 6
+#define HTTP_CONTENT_LEN_SIZE 11
 #define MAX_SEND_BUF_LEN 192
 
 static ssize_t sendall(int sock, const void *buf, size_t len)


### PR DESCRIPTION
Instead of maximally 99999 bytes allow a content_len of 4GB.

Signed-off-by: Sjors Hettinga <s.a.hettinga@gmail.com>