### PR TITLE
twister: change serial option existence verification

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -698,7 +698,7 @@ class DeviceHandler(Handler):
         for d in self.suite.duts:
             if fixture and fixture not in d.fixtures:
                 continue
-            if d.platform != device or not (d.serial or d.serial_pty):
+            if d.platform != device or (d.serial is None and d.serial_pty is None):
                 continue
             d.lock.acquire()
             avail = False


### PR DESCRIPTION
Modify `serial` and `serial_pty` **option** availability verification in `device_is_available` method could help to avoid situation when empty string passed as serial in hardware_map.yaml cause hang up Twister in this place.

So, when hypothetically empty string is passed in hardware map like there:
```
- connected: true
  id: 0006
  platform: nrf52840dk_nrf52840
  product: J-Link
  runner: nrfjprog
  serial: ""
```
Then after run Twister with such defined hardware map, the program will **not** stuck in `device_is_available` method and will be able to go forward, and during trying to create `Serial` object, program will rise suitable error, like that:
```
ERROR   - Serial device error: [Errno 2] could not open port : [Errno 2] No such file or directory: ''
```

I think that this solution is just the simplest, rather than write another verification code of loaded data from hardware map yaml file. Simultaneously this change do not impact on current workflow of `device_is_available` method.

Fixes: #41169

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>