### PR TITLE
net: lwm2m: fix potential invalid pointer dereference in reset message

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1333,7 +1333,9 @@ void lwm2m_reset_message(struct lwm2m_message *msg, bool release)
 		coap_reply_clear(msg->reply);
 	}
 
-	sys_slist_find_and_remove(&msg->ctx->pending_sends, &msg->node);
+	if (msg->ctx) {
+		sys_slist_find_and_remove(&msg->ctx->pending_sends, &msg->node);
+	}
 
 	if (release) {
 		(void)memset(msg, 0, sizeof(*msg));


### PR DESCRIPTION
Sometimes message is being reset from multiple locations in code.
If message has already been reset, pointer to context is invalid.

Signed-off-by: Marin Jurjević <marin.jurjevic@hotmail.com>