### PR TITLE
MAINTAINERS: Add stephanosio as CI maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,7 +13,7 @@
 # Do not use wildcard on all source yet
 # *                                        @galak @nashif
 
-/.github/				  @nashif
+/.github/				  @nashif @stephanosio
 /.github/workflows/                       @galak @nashif
 /MAINTAINERS.yml                          @MaureenHelm
 /arch/arc/                                @abrodkin @ruuddw @evgeniy-paltsev

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1882,6 +1882,7 @@ CI:
     maintainers:
         - nashif
         - galak
+        - stephanosio
     files:
         - .github/
         - scripts/ci/


### PR DESCRIPTION
Add @stephanosio as a maintainer of the Continuous Integration area.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>