### PR TITLE
drivers: ethernet: stm32: avoid segfault if cannot get RX buffer

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -563,6 +563,10 @@ release_desc:
 	}
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
+	if (!pkt) {
+		goto out;
+	}
+
 #if defined(CONFIG_NET_VLAN)
 	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
 
@@ -595,6 +599,7 @@ release_desc:
 	}
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
+out:
 	if (!pkt) {
 		eth_stats_update_errors_rx(get_iface(dev_data, *vlan_tag));
 	}


### PR DESCRIPTION
Avoids segfault in situations when we can't acquire an RX buffer, and VLAN or
PTP code is enabled which tries to inspect packets by adding a pkt check.

Signed-off-by: Alex Sergeev <asergeev@carbonrobotics.com>