### PR TITLE
west: spdx: Exclude files not present after build

### DIFF
--- a/scripts/west_commands/zspdx/scanner.py
+++ b/scripts/west_commands/zspdx/scanner.py
@@ -190,7 +190,7 @@ def scanDocument(cfg, doc):
             # get hashes for file
             hashes = getHashes(f.abspath)
             if not hashes:
-                log.wrn("unable to get hashes for file {f.abspath}; skipping")
+                log.wrn(f"unable to get hashes for file {f.abspath}; skipping")
                 continue
             hSHA1, hSHA256, hMD5 = hashes
             f.sha1 = hSHA1

--- a/scripts/west_commands/zspdx/walker.py
+++ b/scripts/west_commands/zspdx/walker.py
@@ -266,8 +266,9 @@ class Walker:
                 # add its build file
                 bf = self.addBuildFile(cfgTarget, pkg)
 
-                # get its source files
-                self.collectPendingSourceFiles(cfgTarget, pkg, bf)
+                # get its source files if build file is found
+                if bf:
+                    self.collectPendingSourceFiles(cfgTarget, pkg, bf)
             else:
                 log.dbg(f"  - target {cfgTarget.name} has no build artifacts")
 
@@ -302,6 +303,11 @@ class Walker:
         log.dbg(f"  - adding File {artifactPath}")
         log.dbg(f"    - relativeBaseDir: {pkg.cfg.relativeBaseDir}")
         log.dbg(f"    - artifacts[0]: {cfgTarget.target.artifacts[0]}")
+
+        # don't create build File if artifact path points to nonexistent file
+        if not os.path.exists(artifactPath):
+            log.dbg(f"  - target {cfgTarget.name} lists build artifact {artifactPath} but file not found after build; skipping")
+            return None
 
         # create build File
         bf = File(self.docBuild, pkg)


### PR DESCRIPTION
The list of files which are included in the `build.spdx` SPDX SBOM document
is based on the files recorded as build artifacts based on the CMake
file-based API metadata response.

In some situations, such as the case indicated in #42072, a build artifact
may be reported by CMake but no such file is present on the system
following the build. This results in the `build.spdx` SPDX SBOM being
invalid, as a result of trying to provide metadata for a non-existent
file (and specifically being unable to provide its checksum).

This commit fixes this bug by omitting files from `build.spdx` if they
do not exist on disk after the build is complete, even if the CMake
metadata claims that they should. The resulting SPDX document should
then be valid.

Fixes #42072

Signed-off-by: Steve Winslow <steve@swinslow.net>