### PR TITLE
Add board support for nrf52840_mdk_m2_module

### DIFF
--- a/boards/arm/nrf52840_mdk_m2_module/Kconfig
+++ b/boards/arm/nrf52840_mdk_m2_module/Kconfig
@@ -1,0 +1,22 @@
+# nRF52840 MDK M.2 Module board configuration
+
+# Copyright (c) 2022 Matt Anderson
+# Copyright (c) 2022 Nikola Trifunovic
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF52840_MDK_M2_MODULE
+
+config BOARD_ENABLE_DCDC
+	bool "DCDC mode"
+	select SOC_DCDC_NRF52X
+	default y
+
+config BOARD_HAS_NRF5_BOOTLOADER
+	bool "Board has nRF5 bootloader"
+	default y
+	help
+	  If selected, applications are linked so that they can be loaded by Nordic
+	  nRF5 bootloader.
+
+endif # BOARD_NRF52840_MDK_M2_MODULE

--- a/boards/arm/nrf52840_mdk_m2_module/Kconfig.board
+++ b/boards/arm/nrf52840_mdk_m2_module/Kconfig.board
@@ -1,0 +1,10 @@
+# nRF52840 MDK M2 Module board configuration
+
+# Copyright (c) 2022 Matt Anderson
+# Copyright (c) 2022 Nikola Trifunovic
+# Copyright (c) 2018 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_NRF52840_MDK_M2_MODULE
+	bool "nRF52840 MDK M2 MODULE"
+	depends on SOC_NRF52840_QIAA

--- a/boards/arm/nrf52840_mdk_m2_module/Kconfig.defconfig
+++ b/boards/arm/nrf52840_mdk_m2_module/Kconfig.defconfig
@@ -28,13 +28,9 @@ config FLASH_LOAD_OFFSET
 	default 0x1000
 	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
 
-if USB_DEVICE_STACK
-
 # Enable UART driver, needed for CDC ACM
 config SERIAL
-	default y
-
-endif # USB_DEVICE_STACK
+	default y if USB_DEVICE_STACK
 
 config BT_CTLR
 	default BT

--- a/boards/arm/nrf52840_mdk_m2_module/Kconfig.defconfig
+++ b/boards/arm/nrf52840_mdk_m2_module/Kconfig.defconfig
@@ -1,0 +1,42 @@
+# nRF52840 MDK USB Dongle board configuration
+#
+# Copyright (c) 2018 Nordic Semiconductor ASA
+#
+# Copyright (c) 2022 Nikola Trifunovic
+#
+# Copyright (c) 2022 Matt Anderson
+#
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_NRF52840_MDK_M2_MODULE
+
+config BOARD
+	default "nrf52840_mdk_m2_module"
+
+# To let the nRF5 bootloader load an application, the application
+# must be linked after Nordic MBR, that is factory-programmed on the board.
+
+# Nordic nRF5 booatloader exists outside of the partitions specified in the
+# DTS file, so we manually override FLASH_LOAD_OFFEST to link the application
+# correctly, after Nordic MBR.
+
+# When building MCUBoot, MCUBoot itself will select USE_DT_CODE_PARTITION
+# which will make it link into the correct partition specified in DTS file,
+# so no override is necessary.
+
+config FLASH_LOAD_OFFSET
+	default 0x1000
+	depends on BOARD_HAS_NRF5_BOOTLOADER && !USE_DT_CODE_PARTITION
+
+if USB_DEVICE_STACK
+
+# Enable UART driver, needed for CDC ACM
+config SERIAL
+	default y
+
+endif # USB_DEVICE_STACK
+
+config BT_CTLR
+	default BT
+
+endif # BOARD_NRF52840_MDK_M2_MODULE

--- a/boards/arm/nrf52840_mdk_m2_module/board.cmake
+++ b/boards/arm/nrf52840_mdk_m2_module/board.cmake
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
+include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52840_mdk_m2_module/doc/index.rst
+++ b/boards/arm/nrf52840_mdk_m2_module/doc/index.rst
@@ -1,0 +1,38 @@
+.. _nrf52840_mdk_m2_module:
+
+nRF52840 MDK M.2 Module
+#######################
+
+Overview
+********
+
+nRF52840 M.2 Module is a removable module designed and built to meet the
+multiprotocol connectivity, security and ease-of-use requirements of your next
+embedded design. Based on the nRF52840 SoC, it has protocol support for
+Bluetooth 5, Bluetooth mesh, Thread, Zigbee, 802.15.4, ANT and 2.4 GHz
+proprietary stacks.
+
+The module comes with an M.2 (also known as NGFF - Next Generation Form Factor)
+Key-E form factor, that will simplify and minimize the development cycle and
+deployment of your end-product helping to accelerate its time-to-market.
+
+
+.. figure:: nrf52840-mdk-m2-module-pinout.png
+     :width: 442px
+     :align: center
+     :alt: nRF52840 MDK M.2 Module
+
+     nRF52840 MDK M.2 Module
+
+See `nrf52840-mdk-m2-module website`_ for more information about the development
+board and `nRF52840 website`_ for the official reference on the IC itself.
+
+
+References
+**********
+.. target-notes::
+
+.. _nRF52840 website:
+   https://www.nordicsemi.com/Products/Low-power-short-range-wireless/nRF52840
+.. _nrf52840-mdk-m2-module website:
+   https://wiki.makerdiary.com/nrf52840-m2/

--- a/boards/arm/nrf52840_mdk_m2_module/fstab-debugger.dts
+++ b/boards/arm/nrf52840_mdk_m2_module/fstab-debugger.dts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table without support for Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* The size of this partition ensures that MCUBoot can be built
+		 * with an RTT console, CDC ACM support, and w/o optimizations.
+		 */
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x000000000 0x00012000>;
+		};
+
+		slot0_partition: partition@12000 {
+			label = "image-0";
+			reg = <0x00012000 0x000069000>;
+		};
+		slot1_partition: partition@7b000 {
+			label = "image-1";
+			reg = <0x0007b000 0x000069000>;
+		};
+		scratch_partition: partition@e4000 {
+			label = "image-scratch";
+			reg = <0x000e4000 0x00018000>;
+		};
+		storage_partition: partition@fc000 {
+			label = "storage";
+			reg = <0x000fc000 0x00004000>;
+		};
+	};
+};

--- a/boards/arm/nrf52840_mdk_m2_module/fstab-stock.dts
+++ b/boards/arm/nrf52840_mdk_m2_module/fstab-stock.dts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Flash partition table compatible with Nordic nRF5 bootloader */
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* MCUboot placed after Nordic MBR.
+		 * The size of this partition ensures that MCUBoot
+		 * can be built with CDC ACM support and w/o optimizations.
+		 */
+		boot_partition: partition@1000 {
+			label = "mcuboot";
+			reg = <0x00001000 0x000f000>;
+		};
+
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x00010000 0x00005e000>;
+		};
+		slot1_partition: partition@6e000 {
+			label = "image-1";
+			reg = <0x006e000 0x00005e000>;
+		};
+		storage_partition: partition@cc000 {
+			label = "storage";
+			reg = <0x000cc000 0x00004000>;
+		};
+		scratch_partition: partition@d0000 {
+			label = "image-scratch";
+			reg = <0x000d0000 0x00010000>;
+		};
+
+		/* Nordic nRF5 bootloader <0xe0000 0x1c000>
+		 *
+		 * In addition, the last and second last flash pages
+		 * are used by the nRF5 bootloader and MBR to store settings.
+		 */
+	};
+};

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module-pinctrl.dtsi
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module-pinctrl.dtsi
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	uart0_default: uart0_default {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 16)>,
+			        <NRF_PSEL(UART_RX, 0, 15)>;
+		};
+	};
+
+	uart0_sleep: uart0_sleep {
+		group1 {
+			psels = <NRF_PSEL(UART_TX, 0, 16)>,
+			        <NRF_PSEL(UART_RX, 0, 15)>;
+			low-power-enable;
+		};
+	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 29)>,
+			        <NRF_PSEL(PWM_OUT1, 0, 30)>,
+			        <NRF_PSEL(PWM_OUT2, 0, 31)>;
+			nordic,invert;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 29)>,
+			        <NRF_PSEL(PWM_OUT1, 0, 30)>,
+			        <NRF_PSEL(PWM_OUT2, 0, 31)>;
+			low-power-enable;
+		};
+	};
+
+	qspi_default: qspi_default {
+		group1 {
+			psels = <NRF_PSEL(QSPI_SCK, 1, 11)>,
+			        <NRF_PSEL(QSPI_IO0, 1, 10)>,
+			        <NRF_PSEL(QSPI_IO1, 1, 14)>,
+			        <NRF_PSEL(QSPI_IO2, 1, 15)>,
+			        <NRF_PSEL(QSPI_IO3, 1, 12)>,
+			        <NRF_PSEL(QSPI_CSN, 1, 13)>;
+		};
+	};
+
+	qspi_sleep: qspi_sleep {
+		group1 {
+			psels = <NRF_PSEL(QSPI_SCK, 1, 11)>,
+			        <NRF_PSEL(QSPI_IO0, 1, 10)>,
+			        <NRF_PSEL(QSPI_IO1, 1, 14)>,
+			        <NRF_PSEL(QSPI_IO2, 1, 15)>,
+			        <NRF_PSEL(QSPI_IO3, 1, 12)>,
+			        <NRF_PSEL(QSPI_CSN, 1, 13)>;
+			low-power-enable;
+		};
+	};
+};

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
@@ -54,8 +54,8 @@
 		};
 	};
 
-    /* The button is not present on the module, though reset is typically
-     * connected on the baseboard to reset the module. */
+	/* The button is not present on the module, though reset is typically
+	 * connected on the baseboard to reset the module. */
 	buttons {
 		compatible = "gpio-keys";
 		reset_button: button_0 {
@@ -69,9 +69,9 @@
 		led0 = &led0_red;
 		led1 = &led0_green;
 		led2 = &led0_blue;
-		led0-red   = &led0_red;
+		led0-red = &led0_red;
 		led0-green = &led0_green;
-		led0-blue  = &led0_blue;
+		led0-blue = &led0_blue;
 		pwm-led0 = &red_pwm_led;
 		pwm-led1 = &green_pwm_led;
 		pwm-led2 = &blue_pwm_led;
@@ -94,9 +94,9 @@
 };
 
 &uart0 {
-    /* Line drivers are not present on the module, P0.16(RX) / P0.15(TX)
-     * are defined here for compatibility with the DAPLink/LPC11U35 on
-     * the M.2 Developer Kit */
+	/* Line drivers are not present on the module, P0.16(RX) / P0.15(TX)
+	 * are defined here for compatibility with the DAPLink/LPC11U35 on
+	 * the M.2 Developer Kit */
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
@@ -9,6 +9,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
+#include "nrf52840_mdk_m2_module-pinctrl.dtsi"
 
 / {
 	model = "nRF52840 MDK M2 Module";
@@ -100,25 +101,23 @@
 	compatible = "nordic,nrf-uarte";
 	status = "okay";
 	current-speed = <115200>;
-	tx-pin = <16>;
-	rx-pin = <15>;
+	pinctrl-0 = <&uart0_default>;
+	pinctrl-1 = <&uart0_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &pwm0 {
 	status = "okay";
-	ch0-pin = <29>;
-	ch0-inverted;
-	ch1-pin = <30>;
-	ch1-inverted;
-	ch2-pin = <31>;
-	ch2-inverted;
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 &qspi {
 	status = "okay";
-	sck-pin = <43>;
-	io-pins = <42>, <46>, <47>, <44>;
-	csn-pins = <45>;
+	pinctrl-0 = <&qspi_default>;
+	pinctrl-1 = <&qspi_sleep>;
+	pinctrl-names = "default", "sleep";
 	mx25r64: mx25r6435f@0 {
 		compatible = "nordic,qspi-nor";
 		reg = <0>;

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
@@ -30,15 +30,15 @@
 		compatible = "gpio-leds";
 		led0_red: led_0 {
 			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
-			label = "Red LED 0";
+			label = "Red LED 1";
 		};
 		led0_green: led_1 {
 			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
-			label = "Green LED 0";
+			label = "Green LED 2";
 		};
 		led0_blue: led_2 {
 			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
-			label = "Blue LED 0";
+			label = "Blue LED 3";
 		};
 	};
 

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.dts
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2022 Matt Anderson
+ * Copyright (c) 2022 Nikola Trifunovic
+ * Copyright (c) 2018 Nordic Semiconductor ASA
+ * Copyright (c) 2017 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <nordic/nrf52840_qiaa.dtsi>
+
+/ {
+	model = "nRF52840 MDK M2 Module";
+	compatible = "nrf52840_mdk_m2_module";
+
+	chosen {
+		zephyr,console = &uart0;
+		zephyr,shell-uart = &uart0;
+		zephyr,uart-mcumgr = &uart0;
+		zephyr,bt-mon-uart = &uart0;
+		zephyr,bt-c2h-uart = &uart0;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0_red: led_0 {
+			gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
+			label = "Red LED 0";
+		};
+		led0_green: led_1 {
+			gpios = <&gpio0 29 GPIO_ACTIVE_LOW>;
+			label = "Green LED 0";
+		};
+		led0_blue: led_2 {
+			gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
+			label = "Blue LED 0";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+		red_pwm_led: pwm_led_0 {
+			pwms = <&pwm0 30>;
+		};
+		green_pwm_led: pwm_led_1 {
+			pwms = <&pwm0 29>;
+		};
+		blue_pwm_led: pwm_led_2 {
+			pwms = <&pwm0 31>;
+		};
+	};
+
+    /* The button is not present on the module, though reset is typically
+     * connected on the baseboard to reset the module. */
+	buttons {
+		compatible = "gpio-keys";
+		reset_button: button_0 {
+			gpios = <&gpio0 18 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
+			label = "reset button";
+		};
+	};
+
+	/* These aliases are provided for compatibility with samples */
+	aliases {
+		led0 = &led0_red;
+		led1 = &led0_green;
+		led2 = &led0_blue;
+		led0-red   = &led0_red;
+		led0-green = &led0_green;
+		led0-blue  = &led0_blue;
+		pwm-led0 = &red_pwm_led;
+		pwm-led1 = &green_pwm_led;
+		pwm-led2 = &blue_pwm_led;
+		red-pwm-led = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
+	};
+};
+
+&gpiote {
+	status = "okay";
+};
+
+&gpio0 {
+	status = "okay";
+};
+
+&gpio1 {
+	status = "okay";
+};
+
+&uart0 {
+    /* Line drivers are not present on the module, P0.16(RX) / P0.15(TX)
+     * are defined here for compatibility with the DAPLink/LPC11U35 on
+     * the M.2 Developer Kit */
+	compatible = "nordic,nrf-uarte";
+	status = "okay";
+	current-speed = <115200>;
+	tx-pin = <16>;
+	rx-pin = <15>;
+};
+
+&pwm0 {
+	status = "okay";
+	ch0-pin = <29>;
+	ch0-inverted;
+	ch1-pin = <30>;
+	ch1-inverted;
+	ch2-pin = <31>;
+	ch2-inverted;
+};
+
+&qspi {
+	status = "okay";
+	sck-pin = <43>;
+	io-pins = <42>, <46>, <47>, <44>;
+	csn-pins = <45>;
+	mx25r64: mx25r6435f@0 {
+		compatible = "nordic,qspi-nor";
+		reg = <0>;
+		writeoc = "pp4io";
+		readoc = "read4io";
+		sck-frequency = <8000000>;
+		label = "MX25R64";
+		jedec-id = [c2 28 17];
+		sfdp-bfp = [
+			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb
+			ee ff ff ff  ff ff 00 ff  ff ff 00 ff  0c 20 0f 52
+			10 d8 00 ff  23 72 f5 00  82 ed 04 cc  44 83 68 44
+			30 b0 30 b0  f7 c4 d5 5c  00 be 29 ff  f0 d0 ff ff
+		];
+		size = <67108864>;
+		has-dpd;
+		t-enter-dpd = <10000>;
+		t-exit-dpd = <35000>;
+	};
+};
+
+/* Include flash partition table.
+ * Two partition tables are available:
+ * fstab-stock		-compatible with Nordic nRF5 bootloader, default
+ * fstab-debugger	-to use an external debugger, w/o the nRF5 bootloader
+ */
+#include "fstab-stock.dts"
+
+zephyr_udc0: &usbd {
+	compatible = "nordic,nrf-usbd";
+	status = "okay";
+};

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.yaml
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module.yaml
@@ -1,0 +1,18 @@
+identifier: nrf52840_mdk_m2_module
+name: nRF52840-MDK-M2-Module
+type: mcu
+arch: arm
+ram: 256
+flash: 1024
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+supported:
+  - usb_device
+  - usb_cdc
+  - ble
+  - ieee802154
+  - pwm
+  - watchdog
+  - counter

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module_defconfig
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module_defconfig
@@ -15,3 +15,5 @@ CONFIG_GPIO=y
 
 # additional board options
 CONFIG_GPIO_AS_PINRESET=y
+
+CONFIG_PINCTRL=y

--- a/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module_defconfig
+++ b/boards/arm/nrf52840_mdk_m2_module/nrf52840_mdk_m2_module_defconfig
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_NRF52X=y
+CONFIG_SOC_NRF52840_QIAA=y
+CONFIG_BOARD_NRF52840_MDK_M2_MODULE=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable hardware stack protection
+CONFIG_HW_STACK_PROTECTION=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# additional board options
+CONFIG_GPIO_AS_PINRESET=y


### PR DESCRIPTION
Origin: Original

Source code from board/arm/nrf52840_mdk_usb_dongle was adapted for the nrf52840_mdk_m2_module.

Modifications:
 - LED's are on different pins
 - Add QSPI
 - Remove CONFIG_NFCT_PINS_AS_GPIO=y as these pins are connected to a u.FL for NFC antenna