### PR TITLE
Fix aarch32 misc issues

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
+++ b/arch/arm/core/aarch32/cortex_a_r/exc_exit.S
@@ -86,6 +86,10 @@ system_thread_exit\@:
  */
 SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
 
+#ifdef CONFIG_STACK_SENTINEL
+	bl z_check_stack_sentinel
+#endif /* CONFIG_STACK_SENTINEL */
+
 #ifdef CONFIG_PREEMPT_ENABLED
 	/* Do not context switch if exiting a nested interrupt */
 	ldr r3, =_kernel
@@ -99,10 +103,6 @@ SECTION_SUBSEC_FUNC(TEXT, _HandlerModeExit, z_arm_int_exit)
 	blne z_arm_pendsv
 __EXIT_INT:
 #endif /* CONFIG_PREEMPT_ENABLED */
-
-#ifdef CONFIG_STACK_SENTINEL
-	bl z_check_stack_sentinel
-#endif /* CONFIG_STACK_SENTINEL */
 
 	/* Disable nested interrupts while exiting */
 	cpsid i

--- a/include/arch/arm/aarch32/cortex_a_r/lib_helpers.h
+++ b/include/arch/arm/aarch32/cortex_a_r/lib_helpers.h
@@ -30,7 +30,7 @@
 
 #define read_sysreg64(op1, CRm)						\
 ({									\
-	uint32_t val;							\
+	uint64_t val;							\
 	__asm__ volatile ("mrrc p15, " #op1 ", %Q0, %R0, c"		\
 			  #CRm : "=r" (val) :: "memory");		\
 	val;								\


### PR DESCRIPTION
This PR fixes:
1. Fix the incorrect type in `read_sysreg64`. The temp val should be `uint64_t` in `read_sysreg64 `instead of `uint32_t`. The incorrect type `uint32_t `will cause an issue: mrrc instruction needs 2 registers when reading from a 64-bit system register. The type `uint32_t `tells GCC only to save/restore one register, so after the mrrc is executed, the other would clash.
2. Fix `tests/kernel/fatal/exception/kernel.common.stack_sentinel` by swaping the stack sentinel checking and context switch checking. The incorrect sequence will cause the thread cannot be aborted in the ISR context. The stack sentinel detects the stack overflow as normal during a timer ISR exit. Note that, currently, the stack overflow detection is behind the context switch checking, and then the detection will call svc to raise a fatal error resulting in increasing the nested counter(+1). At this point, it needs a context switch to finally abort the thread. However, after the fatal error handling, the program cannot do a context switch either during the svc exit[1], or during the timer ISR exit[2].
[1] is because the svc context is in an interrupt nested state (the nested counter is 2).
[2] is because the current point (after svc context pop out) is right behind the switch checking.
