### PR TITLE
Bluetooth: ascs: Fix ASE invalid state transition

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -328,7 +328,6 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
 	struct bt_audio_stream *stream = ep->stream;
 	struct bt_audio_stream_ops *ops = stream->ops;
-	int err;
 
 	BT_DBG("stream %p ep %p reason 0x%02x", chan, ep, reason);
 
@@ -338,11 +337,24 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 		BT_WARN("No callback for stopped set");
 	}
 
-	ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
+	if (ep->status.state == BT_AUDIO_EP_STATE_RELEASING) {
+		ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_CODEC_CONFIGURED);
+	} else {
+		int err;
 
-	err = bt_audio_stream_iso_listen(stream);
-	if (err != 0) {
-		BT_ERR("Could not make stream listen: %d", err);
+		/* The ASE state machine goes into different states from this operation
+		 * based on whether it is a source or a sink ASE.
+		 */
+		if (ep->dir == BT_AUDIO_SOURCE) {
+			ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_DISABLING);
+		} else {
+			ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
+		}
+
+		err = bt_audio_stream_iso_listen(stream);
+		if (err != 0) {
+			BT_ERR("Could not make stream listen: %d", err);
+		}
 	}
 }
 


### PR DESCRIPTION
This fixes issue where, the ASE went directly to QoS Configured state
when in Releasing state and the ISO link has been disconnected.

To not change the current behavior, the transition from Streaming state
has been unchanged, but rather fixed depending on the ASE direction.

Fixes: #44004
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>