### PR TITLE
Revert "Bluetooth: gatt: ccc changed cb after connection cb"

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2738,6 +2738,8 @@ static void bt_att_connected(struct bt_l2cap_chan *chan)
 	att_chan_mtu_updated(att_chan);
 
 	k_work_init_delayable(&att_chan->timeout_work, att_timeout);
+
+	bt_gatt_connected(ch->chan.conn);
 }
 
 static void bt_att_disconnected(struct bt_l2cap_chan *chan)

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -37,7 +37,6 @@
 #include "smp.h"
 #include "ssp.h"
 #include "att_internal.h"
-#include "gatt_internal.h"
 #include "iso_internal.h"
 #include "direction_internal.h"
 
@@ -1298,10 +1297,6 @@ static void notify_connected(struct bt_conn *conn)
 		if (cb->connected) {
 			cb->connected(conn, conn->err);
 		}
-	}
-
-	if (!conn->err) {
-		bt_gatt_connected(conn);
 	}
 }
 


### PR DESCRIPTION
This reverts commit 6bb75a53d12d3c7afd9dad628dfab40a2d79a089.
This fixes GATT that was uninitalized when application received
bt_conn_cb->connected callback. As the result, the bt_gatt_is_subscribed
was not working as expected when called from bt_conn_cb->connected.

The _bt_gatt_ccc->cfg_changed callback does not carry information about
the device that subscribed for notifications but rather is says the
app when it should start/stop broadcasting notifications.

This leads to the conclusion that the bt_gatt_ccc->cfg_changed can be
called before bt_conn_cb->connected callback.

Fixes: #42829
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>