### PR TITLE
Microchip: MEC172x fix dtsi errors

### DIFF
--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -920,8 +920,8 @@
 				reg = <0x400f0c00 0x400>;
 				interrupts = <47 3>, <48 3>;
 				interrupt-names = "acpi_ibf", "acpi_obe";
-				girqs = < MCHP_XEC_ECIA(15, 7, 7, 58)
-					  MCHP_XEC_ECIA(15, 8, 7, 58) >;
+				girqs = < MCHP_XEC_ECIA(15, 7, 7, 47)
+					  MCHP_XEC_ECIA(15, 8, 7, 48) >;
 				ldn = <3>;
 				label = "ACPI_EC_1";
 				status = "disabled";
@@ -931,8 +931,8 @@
 				reg = <0x400f1000 0x400>;
 				interrupts = <49 3>, <50 3>;
 				interrupt-names = "acpi_ibf", "acpi_obe";
-				girqs = < MCHP_XEC_ECIA(15, 9, 7, 58)
-					  MCHP_XEC_ECIA(15, 10, 7, 58) >;
+				girqs = < MCHP_XEC_ECIA(15, 9, 7, 49)
+					  MCHP_XEC_ECIA(15, 10, 7, 50) >;
 				ldn = <4>;
 				label = "ACPI_EC_2";
 				status = "disabled";
@@ -942,8 +942,8 @@
 				reg = <0x400f1400 0x400>;
 				interrupts = <51 3>, <52 3>;
 				interrupt-names = "acpi_ibf", "acpi_obe";
-				girqs = < MCHP_XEC_ECIA(15, 11, 7, 58)
-					  MCHP_XEC_ECIA(15, 12, 7, 58) >;
+				girqs = < MCHP_XEC_ECIA(15, 11, 7, 51)
+					  MCHP_XEC_ECIA(15, 12, 7, 52) >;
 				ldn = <5>;
 				label = "ACPI_EC_3";
 				status = "disabled";
@@ -953,8 +953,8 @@
 				reg = <0x400f1800 0x400>;
 				interrupts = <53 3>, <54 3>;
 				interrupt-names = "acpi_ibf", "acpi_obe";
-				girqs = < MCHP_XEC_ECIA(15, 13, 7, 58)
-					  MCHP_XEC_ECIA(15, 14, 7, 58) >;
+				girqs = < MCHP_XEC_ECIA(15, 13, 7, 53)
+					  MCHP_XEC_ECIA(15, 14, 7, 54) >;
 				ldn = <6>;
 				label = "ACPI_EC_4";
 				status = "disabled";
@@ -964,9 +964,9 @@
 				reg = <0x400f1c00 0x400>;
 				interrupts = <55 3>, <56 3>, <57 3>;
 				interrupt-names = "pm1_ctl", "pm1_en", "pm1_sts";
-				girqs = < MCHP_XEC_ECIA(15, 15, 7, 58)
-					  MCHP_XEC_ECIA(15, 16, 7, 58)
-					  MCHP_XEC_ECIA(15, 17, 7, 58) >;
+				girqs = < MCHP_XEC_ECIA(15, 15, 7, 55)
+					  MCHP_XEC_ECIA(15, 16, 7, 56)
+					  MCHP_XEC_ECIA(15, 17, 7, 57) >;
 				ldn = <7>;
 				label = "ACPI_PM1";
 				status = "disabled";

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -899,7 +899,7 @@
 				interrupts = <58 3>, <59 3>;
 				interrupt-names = "kbc_obe", "kbc_ibf";
 				girqs = < MCHP_XEC_ECIA(15, 18, 7, 58)
-					  MCHP_XEC_ECIA(15, 19, 7, 58) >;
+					  MCHP_XEC_ECIA(15, 19, 7, 59) >;
 				ldn = <1>;
 				label = "KBC_0";
 				status = "disabled";

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -1045,7 +1045,7 @@
 				compatible = "microchip,xec-espi-host-dev";
 				reg = <0x400f8000 0x400>;
 				interrupts = <62 0>;
-				girqs = < MCHP_XEC_ECIA(15, 22, 7, 58) >;
+				girqs = < MCHP_XEC_ECIA(15, 22, 7, 62) >;
 				pcrs = <2 25>;
 				ldn = <32>;
 				label = "P80BD_0";


### PR DESCRIPTION
Fixed 8042 IBF direct NVIC input number.

Signed-off-by: Jeff Daly <jeffd@silicom-usa.com>