### PR TITLE
ipc_service: Extend API with nocopy functions

### DIFF
--- a/include/ipc/ipc_service_backend.h
+++ b/include/ipc/ipc_service_backend.h
@@ -27,7 +27,7 @@ extern "C" {
 struct ipc_service_backend {
 	/** @brief Pointer to the function that will be used to open an instance
 	 *
-	 *  @param instance Instance pointer.
+	 *  @param[in] instance Instance pointer.
 	 *
 	 *  @retval -EALREADY when the instance is already opened.
 	 *
@@ -39,10 +39,10 @@ struct ipc_service_backend {
 
 	/** @brief Pointer to the function that will be used to send data to the endpoint.
 	 *
-	 *  @param instance Instance pointer.
-	 *  @param token Backend-specific token.
-	 *  @param data Pointer to the buffer to send.
-	 *  @param len Number of bytes to send.
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *  @param[in] data Pointer to the buffer to send.
+	 *  @param[in] len Number of bytes to send.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
 	 *  @retval -EBADMSG when the message is invalid.
@@ -57,9 +57,9 @@ struct ipc_service_backend {
 
 	/** @brief Pointer to the function that will be used to register endpoints.
 	 *
-	 *  @param instance Instance to register the endpoint onto.
-	 *  @param token Backend-specific token.
-	 *  @param cfg Endpoint configuration.
+	 *  @param[in] instance Instance to register the endpoint onto.
+	 *  @param[out] token Backend-specific token.
+	 *  @param[in] cfg Endpoint configuration.
 	 *
 	 *  @retval -EINVAL when the endpoint configuration or instance is invalid.
 	 *  @retval -EBUSY when the instance is busy or not ready.

--- a/include/ipc/ipc_service_backend.h
+++ b/include/ipc/ipc_service_backend.h
@@ -48,7 +48,7 @@ struct ipc_service_backend {
 	 *  @retval -EBADMSG when the message is invalid.
 	 *  @retval -EBUSY when the instance is busy or not ready.
 	 *
-	 *  @retval 0 on success
+	 *  @retval bytes number of bytes sent.
 	 *  @retval other errno codes depending on the implementation of the
 	 *	    backend.
 	 */
@@ -71,6 +71,114 @@ struct ipc_service_backend {
 	int (*register_endpoint)(const struct device *instance,
 				 void **token,
 				 const struct ipc_ept_cfg *cfg);
+
+	/** @brief Pointer to the function that will return the TX buffer size
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *
+	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOTSUP when the operation is not supported.
+	 *
+	 *  @retval size TX buffer size on success.
+	 *  @retval other errno codes depending on the implementation of the
+	 *	    backend.
+	 */
+	int (*get_tx_buffer_size)(const struct device *instance, void *token);
+
+	/** @brief Pointer to the function that will return an empty TX buffer.
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *  @param[out] data Pointer to the empty TX buffer.
+	 *  @param[in,out] len Pointer to store the TX buffer size.
+	 *  @param[in] wait Timeout waiting for an available TX buffer.
+	 *
+	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOTSUP when the operation or the timeout is not supported.
+	 *  @retval -ENOBUFS when there are no TX buffers available.
+	 *  @retval -EALREADY when a buffer was already claimed and not yet released.
+	 *  @retval -ENOMEM when the requested size is too big (and the size parameter
+	 *		    contains the maximum allowed size).
+	 *
+	 *  @retval 0 on success
+	 *  @retval other errno codes depending on the implementation of the
+	 *	    backend.
+	 */
+	int (*get_tx_buffer)(const struct device *instance, void *token,
+			     void **data, uint32_t *len, k_timeout_t wait);
+
+	/** @brief Pointer to the function that will drop a TX buffer.
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *  @param[in] data Pointer to the TX buffer.
+	 *
+	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOTSUP when this function is not supported.
+	 *  @retval -EALREADY when the buffer was already dropped.
+	 *
+	 *  @retval 0 on success
+	 *  @retval other errno codes depending on the implementation of the
+	 *	    backend.
+	 */
+	int (*drop_tx_buffer)(const struct device *instance, void *token,
+			      const void *data);
+
+	/** @brief Pointer to the function that will be used to send data to
+	 *	   the endpoint when the TX buffer has been obtained using @ref
+	 *	   ipc_service_get_tx_buffer
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *  @param[in] data Pointer to the buffer to send.
+	 *  @param[in] len Number of bytes to send.
+	 *
+	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -EBADMSG when the data is invalid (i.e. invalid data format,
+	 *		     invalid length, ...)
+	 *  @retval -EBUSY when the instance is busy or not ready.
+	 *
+	 *  @retval bytes number of bytes sent.
+	 *  @retval other errno codes depending on the implementation of the
+	 *	    backend.
+	 */
+	int (*send_nocopy)(const struct device *instance, void *token,
+			   const void *data, size_t len);
+
+	/** @brief Pointer to the function that will hold the RX buffer
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *  @param[in] data Pointer to the RX buffer to hold.
+	 *
+	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -EALREADY when the buffer data has been already hold.
+	 *  @retval -ENOTSUP when this function is not supported.
+	 *
+	 *  @retval 0 on success
+	 *  @retval other errno codes depending on the implementation of the
+	 *	    backend.
+	 */
+	int (*hold_rx_buffer)(const struct device *instance, void *token,
+			      void *data);
+
+	/** @brief Pointer to the function that will release the RX buffer.
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *  @param[in] token Backend-specific token.
+	 *  @param[in] data Pointer to the RX buffer to release.
+	 *
+	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -EALREADY when the buffer data has been already released.
+	 *  @retval -ENOTSUP when this function is not supported.
+	 *
+	 *  @retval 0 on success
+	 *  @retval other errno codes depending on the implementation of the
+	 *	    backend.
+	 */
+	int (*release_rx_buffer)(const struct device *instance, void *token,
+				 void *data);
 };
 
 /**

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
@@ -181,7 +181,12 @@ K_THREAD_DEFINE(ipc0B_thread_id, STACKSIZE, ipc0B_entry, NULL, NULL, NULL, PRIOR
 
 /*
  * ==> THREAD 1 (IPC instance 1) <==
+ *
+ * NOTE: This instance is using the NOCOPY copability of the backend.
  */
+
+static struct ipc_ept ipc1_ept;
+static void *recv_data;
 
 static void ipc1_ept_bound(void *priv)
 {
@@ -190,7 +195,18 @@ static void ipc1_ept_bound(void *priv)
 
 static void ipc1_ept_recv(const void *data, size_t len, void *priv)
 {
-	ipc1_received_data = *((uint8_t *) data);
+	int ret;
+
+	ret = ipc_service_hold_rx_buffer(&ipc1_ept, (void *) data);
+	if (ret < 0) {
+		printk("ipc_service_hold_rx_buffer failed with ret %d\n", ret);
+	}
+
+	/*
+	 * This will only support a synchronous request-answer mechanism. For
+	 * asynchronous cases a chain list should be implemented.
+	 */
+	recv_data = (void *) data;
 
 	k_sem_give(&ipc1_data_sem);
 }
@@ -211,7 +227,6 @@ static void ipc1_entry(void *dummy0, void *dummy1, void *dummy2)
 
 	const struct device *ipc1_instance;
 	unsigned char message = 0;
-	struct ipc_ept ipc1_ept;
 	int ret;
 
 	printk("IPC-service REMOTE [INST 1] demo started\n");
@@ -232,19 +247,35 @@ static void ipc1_entry(void *dummy0, void *dummy1, void *dummy2)
 
 	k_sem_take(&ipc1_bound_sem, K_FOREVER);
 
-	while (message < 99) {
+	while (message < 50) {
+		uint32_t len = sizeof(message);
+		void *data;
+
 		k_sem_take(&ipc1_data_sem, K_FOREVER);
-		message = ipc1_received_data;
 
-		printk("REMOTE [1]: %d\n", message);
+		printk("REMOTE [1]: %d\n", *((unsigned char *) recv_data));
 
-		message++;
+		ret = ipc_service_get_tx_buffer(&ipc1_ept, &data, &len, K_FOREVER);
+		if (ret < 0) {
+			printk("ipc_service_get_tx_buffer failed with ret %d\n", ret);
+			break;
+		}
 
-		ret = ipc_service_send(&ipc1_ept, &message, sizeof(message));
+		*((unsigned char *) data) = *((unsigned char *) recv_data) + 1;
+
+		ret = ipc_service_release_rx_buffer(&ipc1_ept, recv_data);
+		if (ret < 0) {
+			printk("ipc_service_release_rx_buffer failed with ret %d\n", ret);
+			break;
+		}
+
+		ret = ipc_service_send_nocopy(&ipc1_ept, data, sizeof(unsigned char));
 		if (ret < 0) {
 			printk("send_message(%d) failed with ret %d\n", message, ret);
 			break;
 		}
+
+		message++;
 	}
 
 	printk("IPC-service REMOTE [INST 1] demo ended.\n");

--- a/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
@@ -179,7 +179,12 @@ K_THREAD_DEFINE(ipc0B_thread_id, STACKSIZE, ipc0B_entry, NULL, NULL, NULL, PRIOR
 
 /*
  * ==> THREAD 1 (IPC instance 1) <==
+ *
+ * NOTE: This instance is using the NOCOPY copability of the backend.
  */
+
+static struct ipc_ept ipc1_ept;
+static void *recv_data;
 
 static void ipc1_ept_bound(void *priv)
 {
@@ -188,7 +193,18 @@ static void ipc1_ept_bound(void *priv)
 
 static void ipc1_ept_recv(const void *data, size_t len, void *priv)
 {
-	ipc1_received_data = *((uint8_t *) data);
+	int ret;
+
+	ret = ipc_service_hold_rx_buffer(&ipc1_ept, (void *) data);
+	if (ret < 0) {
+		printk("ipc_service_hold_rx_buffer failed with ret %d\n", ret);
+	}
+
+	/*
+	 * This will only support a synchronous request-answer mechanism. For
+	 * asynchronous cases a chain list should be implemented.
+	 */
+	recv_data = (void *) data;
 
 	k_sem_give(&ipc1_data_sem);
 }
@@ -209,7 +225,6 @@ static void ipc1_entry(void *dummy0, void *dummy1, void *dummy2)
 
 	const struct device *ipc1_instance;
 	unsigned char message = 0;
-	struct ipc_ept ipc1_ept;
 	int ret;
 
 	printk("IPC-service HOST [INST 1] demo started\n");
@@ -230,17 +245,38 @@ static void ipc1_entry(void *dummy0, void *dummy1, void *dummy2)
 
 	k_sem_take(&ipc1_bound_sem, K_FOREVER);
 
-	while (message < 100) {
-		ret = ipc_service_send(&ipc1_ept, &message, sizeof(message));
+	while (message < 50) {
+		uint32_t len = 0;
+		void *data;
+
+		ret = ipc_service_get_tx_buffer(&ipc1_ept, &data, &len, K_FOREVER);
+		if (ret < 0) {
+			printk("ipc_service_get_tx_buffer failed with ret %d\n", ret);
+			break;
+		}
+
+		if (message != 0) {
+			*((unsigned char *) data) = *((unsigned char *) recv_data) + 1;
+
+			ret = ipc_service_release_rx_buffer(&ipc1_ept, recv_data);
+			if (ret < 0) {
+				printk("ipc_service_release_rx_buffer failed with ret %d\n", ret);
+				break;
+			}
+		} else {
+			*((unsigned char *) data) = 0;
+		}
+
+		ret = ipc_service_send_nocopy(&ipc1_ept, data, sizeof(unsigned char));
 		if (ret < 0) {
 			printk("send_message(%d) failed with ret %d\n", message, ret);
 			break;
 		}
 
 		k_sem_take(&ipc1_data_sem, K_FOREVER);
-		message = ipc1_received_data;
 
-		printk("HOST [1]: %d\n", message);
+		printk("HOST [1]: %d\n", *((unsigned char *) recv_data));
+
 		message++;
 	}
 

--- a/subsys/ipc/ipc_service/ipc_service.c
+++ b/subsys/ipc/ipc_service/ipc_service.c
@@ -81,3 +81,148 @@ int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len)
 
 	return backend->send(ept->instance, ept->token, data, len);
 }
+
+int ipc_service_get_tx_buffer_size(struct ipc_ept *ept)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!ept) {
+		LOG_ERR("Invalid endpoint");
+		return -EINVAL;
+	}
+
+	backend = ept->instance->api;
+
+	if (!backend) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	if (!backend->get_tx_buffer_size) {
+		LOG_ERR("No-copy feature not available");
+		return -EIO;
+	}
+
+	return backend->get_tx_buffer_size(ept->instance, ept->token);
+}
+
+int ipc_service_get_tx_buffer(struct ipc_ept *ept, void **data, uint32_t *len, k_timeout_t wait)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!ept || !data || !len) {
+		LOG_ERR("Invalid endpoint, data or len pointer");
+		return -EINVAL;
+	}
+
+	backend = ept->instance->api;
+
+	if (!backend) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	if (!backend->send_nocopy || !backend->get_tx_buffer) {
+		LOG_ERR("No-copy feature not available");
+		return -EIO;
+	}
+
+	return backend->get_tx_buffer(ept->instance, ept->token, data, len, wait);
+}
+
+int ipc_service_drop_tx_buffer(struct ipc_ept *ept, const void *data)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!ept || !data) {
+		LOG_ERR("Invalid endpoint or data pointer");
+		return -EINVAL;
+	}
+
+	backend = ept->instance->api;
+
+	if (!backend) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	if (!backend->drop_tx_buffer) {
+		LOG_ERR("No-copy feature not available");
+		return -EIO;
+	}
+
+	return backend->drop_tx_buffer(ept->instance, ept->token, data);
+}
+
+int ipc_service_send_nocopy(struct ipc_ept *ept, const void *data, size_t len)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!ept) {
+		LOG_ERR("Invalid endpoint");
+		return -EINVAL;
+	}
+
+	backend = ept->instance->api;
+
+	if (!backend) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	if (!backend->get_tx_buffer || !backend->send_nocopy) {
+		LOG_ERR("No-copy feature not available");
+		return -EIO;
+	}
+
+	return backend->send_nocopy(ept->instance, ept->token, data, len);
+}
+
+int ipc_service_hold_rx_buffer(struct ipc_ept *ept, void *data)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!ept) {
+		LOG_ERR("Invalid endpoint");
+		return -EINVAL;
+	}
+
+	backend = ept->instance->api;
+
+	if (!backend) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	/* We also need the release function */
+	if (!backend->release_rx_buffer || !backend->hold_rx_buffer) {
+		LOG_ERR("No-copy feature not available");
+		return -EIO;
+	}
+
+	return backend->hold_rx_buffer(ept->instance, ept->token, data);
+}
+int ipc_service_release_rx_buffer(struct ipc_ept *ept, void *data)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!ept) {
+		LOG_ERR("Invalid endpoint");
+		return -EINVAL;
+	}
+
+	backend = ept->instance->api;
+
+	if (!backend) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	/* We also need the hold function */
+	if (!backend->hold_rx_buffer || !backend->release_rx_buffer) {
+		LOG_ERR("No-copy feature not available");
+		return -EIO;
+	}
+
+	return backend->release_rx_buffer(ept->instance, ept->token, data);
+}


### PR DESCRIPTION
This PR follows the discussion at #43924. The idea is that we want to extend the IPC service API to expose several new functions that can be used by backends with nocopy capabilities.

In this PR we also adapt the static vrings backend and the related sample.