### PR TITLE
Bluetooth: Controller: Fix aux context release before aux done event

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -51,6 +51,7 @@ static inline struct ll_sync_set *sync_create_get(struct ll_scan_set *scan);
 static inline struct ll_sync_iso_set *
 	sync_iso_create_get(struct ll_sync_set *sync);
 static void done_disabled_cb(void *param);
+static void flush_safe(void *param);
 static void flush(void *param);
 static void rx_release_put(struct node_rx_hdr *rx);
 static void aux_sync_incomplete(void *param);
@@ -697,9 +698,6 @@ ull_scan_aux_rx_flush:
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC */
 
 	if (aux) {
-		struct ull_hdr *hdr;
-		uint8_t ref;
-
 		/* Enqueue last rx in aux context if possible, otherwise send
 		 * immediately since we are in sync context.
 		 */
@@ -720,30 +718,7 @@ ull_scan_aux_rx_flush:
 			return;
 		}
 
-		/* ref == 0
-		 * All PDUs were scheduled from LLL and there is no pending done
-		 * event, we can flush here.
-		 *
-		 * ref == 1
-		 * There is pending done event so we need to flush from disabled
-		 * callback. Flushing here would release aux context and thus
-		 * ull_hdr before done event was processed.
-		 */
-		hdr = &aux->ull;
-		ref = ull_ref_get(hdr);
-		if (ref == 0) {
-			flush(aux);
-		} else {
-			/* A specific single shot scheduled aux context cannot
-			 * overlap, i.e. ULL reference count shall be less than
-			 * 2.
-			 */
-			LL_ASSERT(ref < 2);
-
-			LL_ASSERT(!hdr->disabled_cb);
-			hdr->disabled_param = aux;
-			hdr->disabled_cb = done_disabled_cb;
-		}
+		flush_safe(aux);
 
 		return;
 	}
@@ -902,7 +877,6 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 		struct ll_scan_aux_set *aux;
 		struct ll_scan_set *scan;
 		struct lll_scan *lll;
-		struct ull_hdr *hdr;
 		uint8_t is_stop;
 
 		aux = HDR_LLL2ULL(lll_aux);
@@ -923,26 +897,7 @@ void ull_scan_aux_release(memq_link_t *link, struct node_rx_hdr *rx)
 		}
 
 		if (!is_stop) {
-			uint8_t ref;
-
-			/* Flush from here or from done event, if one is
-			 * pending.
-			 */
-			hdr = &aux->ull;
-			ref = ull_ref_get(hdr);
-			if (ref == 0) {
-				flush(aux);
-			} else {
-				/* A specific single shot scheduled aux context
-				 * cannot overlap, i.e. ULL reference count
-				 * shall be less than 2.
-				 */
-				LL_ASSERT(ref < 2);
-
-				LL_ASSERT(!hdr->disabled_cb);
-				hdr->disabled_param = aux;
-				hdr->disabled_cb = done_disabled_cb;
-			}
+			flush_safe(aux);
 
 		} else if (!scan) {
 			/* Sync terminate requested, enqueue node rx so that it
@@ -1080,6 +1035,39 @@ static inline struct ll_sync_iso_set *
 static void done_disabled_cb(void *param)
 {
 	flush(param);
+}
+
+static void flush_safe(void *param)
+{
+	struct ll_scan_aux_set *aux;
+	struct ull_hdr *hdr;
+	uint8_t ref;
+
+	/* ref == 0
+	 * All PDUs were scheduled from LLL and there is no pending done
+	 * event, we can flush here.
+	 *
+	 * ref == 1
+	 * There is pending done event so we need to flush from disabled
+	 * callback. Flushing here would release aux context and thus
+	 * ull_hdr before done event was processed.
+	 */
+	aux = param;
+	hdr = &aux->ull;
+	ref = ull_ref_get(hdr);
+	if (ref == 0U) {
+		flush(aux);
+	} else {
+		/* A specific single shot scheduled aux context
+		 * cannot overlap, i.e. ULL reference count
+		 * shall be less than 2.
+		 */
+		LL_ASSERT(ref < 2U);
+
+		LL_ASSERT(!hdr->disabled_cb);
+		hdr->disabled_param = aux;
+		hdr->disabled_cb = done_disabled_cb;
+	}
 }
 
 static void flush(void *param)
@@ -1268,7 +1256,7 @@ static void ticker_op_cb(uint32_t status, void *param)
 		if (IS_ENABLED(CONFIG_BT_CTLR_SYNC_PERIODIC) && sync) {
 			mfy.fp = aux_sync_incomplete;
 		} else {
-			mfy.fp = flush;
+			mfy.fp = flush_safe;
 		}
 	}
 


### PR DESCRIPTION
Fix scan aux context release when (ULL) ticker scheduling
fails due to overlapping events (example a new scan window)
and aux context being released before scan aux done event is
processed, caused assertion when processing the done event
with corrupt ULL reference count.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>