### PR TITLE
Bluetooth: Controller: Increase event done max count for Coded PHY

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -334,10 +334,17 @@ static MFIFO_DEFINE(prep, sizeof(struct lll_event), EVENT_PIPELINE_MAX);
  *
  * If Extended Scanning is supported, then an additional auxiliary scan event's
  * prepare could be enqueued in the pipeline during the preemption duration.
+ *
+ * If Extended Scanning with Coded PHY is supported, then an additional 1 resume
+ * prepare could be enqueued in the pipeline during the preemption duration.
  */
 #if !defined(VENDOR_EVENT_DONE_MAX)
 #if defined(CONFIG_BT_CTLR_ADV_EXT) && defined(CONFIG_BT_OBSERVER)
+#if defined(CONFIG_BT_CTLR_PHY_CODED)
+#define EVENT_DONE_MAX 6
+#else /* !CONFIG_BT_CTLR_PHY_CODED */
 #define EVENT_DONE_MAX 5
+#endif /* !CONFIG_BT_CTLR_PHY_CODED */
 #else /* !CONFIG_BT_CTLR_ADV_EXT || !CONFIG_BT_OBSERVER */
 #define EVENT_DONE_MAX 4
 #endif /* !CONFIG_BT_CTLR_ADV_EXT || !CONFIG_BT_OBSERVER */


### PR DESCRIPTION
Increase the event done max count when supporting Extended
Scanning with Coded PHY support, wherein prepare queue will
hold an extra resume prepare when both 1M and Coded PHY
are enabled in continuous scanning.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>