### PR TITLE
Fix usage fault in flash shell sample for RT1064 EVK

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -51,11 +51,15 @@ enum {
 };
 
 struct flash_flexspi_nor_config {
-	const struct device *controller;
 	flexspi_port_t port;
 	flexspi_device_config_t config;
 	struct flash_pages_layout layout;
 	struct flash_parameters flash_parameters;
+};
+
+/* Device variables used in critical sections should be in this structure */
+struct flash_flexspi_nor_data {
+	const struct device *controller;
 };
 
 static const uint32_t flash_flexspi_nor_lut[][4] = {
@@ -128,6 +132,7 @@ static int flash_flexspi_nor_get_vendor_id(const struct device *dev,
 		uint8_t *vendor_id)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 	uint32_t buffer = 0;
 	int ret;
 
@@ -143,7 +148,7 @@ static int flash_flexspi_nor_get_vendor_id(const struct device *dev,
 
 	LOG_DBG("Reading id");
 
-	ret = memc_flexspi_transfer(config->controller, &transfer);
+	ret = memc_flexspi_transfer(data->controller, &transfer);
 	*vendor_id = buffer;
 
 	return ret;
@@ -153,6 +158,7 @@ static int flash_flexspi_nor_read_status(const struct device *dev,
 		uint32_t *status)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
@@ -166,13 +172,14 @@ static int flash_flexspi_nor_read_status(const struct device *dev,
 
 	LOG_DBG("Reading status register");
 
-	return memc_flexspi_transfer(config->controller, &transfer);
+	return memc_flexspi_transfer(data->controller, &transfer);
 }
 
 static int flash_flexspi_nor_write_status(const struct device *dev,
 		uint32_t *status)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
@@ -186,13 +193,14 @@ static int flash_flexspi_nor_write_status(const struct device *dev,
 
 	LOG_DBG("Writing status register");
 
-	return memc_flexspi_transfer(config->controller, &transfer);
+	return memc_flexspi_transfer(data->controller, &transfer);
 }
 
 static int flash_flexspi_nor_write_enable(const struct device *dev,
 		bool enableOctal)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 	flexspi_transfer_t transfer;
 
 	transfer.deviceAddress = 0;
@@ -209,13 +217,14 @@ static int flash_flexspi_nor_write_enable(const struct device *dev,
 
 	LOG_DBG("Enabling write");
 
-	return memc_flexspi_transfer(config->controller, &transfer);
+	return memc_flexspi_transfer(data->controller, &transfer);
 }
 
 static int flash_flexspi_nor_erase_sector(const struct device *dev,
 		off_t offset)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
@@ -229,12 +238,13 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 
 	LOG_DBG("Erasing sector at 0x%08zx", (ssize_t) offset);
 
-	return memc_flexspi_transfer(config->controller, &transfer);
+	return memc_flexspi_transfer(data->controller, &transfer);
 }
 
 static int flash_flexspi_nor_erase_chip(const struct device *dev)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
@@ -248,13 +258,14 @@ static int flash_flexspi_nor_erase_chip(const struct device *dev)
 
 	LOG_DBG("Erasing chip");
 
-	return memc_flexspi_transfer(config->controller, &transfer);
+	return memc_flexspi_transfer(data->controller, &transfer);
 }
 
 static int flash_flexspi_nor_page_program(const struct device *dev,
 		off_t offset, const void *buffer, size_t len)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
@@ -268,7 +279,7 @@ static int flash_flexspi_nor_page_program(const struct device *dev,
 
 	LOG_DBG("Page programming %d bytes to 0x%08zx", len, (ssize_t) offset);
 
-	return memc_flexspi_transfer(config->controller, &transfer);
+	return memc_flexspi_transfer(data->controller, &transfer);
 }
 
 static int flash_flexspi_nor_wait_bus_busy(const struct device *dev)
@@ -290,14 +301,14 @@ static int flash_flexspi_nor_wait_bus_busy(const struct device *dev)
 
 static int flash_flexspi_enable_octal_mode(const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 	/* FLASH_ENABLE_OCTAL_CMD: (01 = STR OPI Enable) */
 	uint32_t status = 0x01;
 
 	flash_flexspi_nor_write_enable(dev, false);
 	flash_flexspi_nor_write_status(dev, &status);
 	flash_flexspi_nor_wait_bus_busy(dev);
-	memc_flexspi_reset(config->controller);
+	memc_flexspi_reset(data->controller);
 
 	return 0;
 }
@@ -306,7 +317,8 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 		void *buffer, size_t len)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
-	uint8_t *src = memc_flexspi_get_ahb_address(config->controller,
+	struct flash_flexspi_nor_data *data = dev->data;
+	uint8_t *src = memc_flexspi_get_ahb_address(data->controller,
 						    config->port,
 						    offset);
 
@@ -319,16 +331,22 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		const void *buffer, size_t len)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 	size_t size = len;
 	uint8_t *src = (uint8_t *) buffer;
 	int i;
 	unsigned int key = 0;
 
-	uint8_t *dst = memc_flexspi_get_ahb_address(config->controller,
+	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
 						    config->port,
 						    offset);
 
-	if (memc_flexspi_is_running_xip(config->controller)) {
+	if (memc_flexspi_is_running_xip(data->controller)) {
+		/*
+		 * ==== ENTER CRITICAL SECTION ====
+		 * No flash access should be performed in critical section. All
+		 * code and data accessed must reside in ram.
+		 */
 		key = irq_lock();
 	}
 
@@ -348,13 +366,14 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		flash_flexspi_nor_page_program(dev, offset, src, i);
 #endif
 		flash_flexspi_nor_wait_bus_busy(dev);
-		memc_flexspi_reset(config->controller);
+		memc_flexspi_reset(data->controller);
 		src += i;
 		offset += i;
 		len -= i;
 	}
 
-	if (memc_flexspi_is_running_xip(config->controller)) {
+	if (memc_flexspi_is_running_xip(data->controller)) {
+		/* ==== EXIT CRITICAL SECTION ==== */
 		irq_unlock(key);
 	}
 
@@ -369,11 +388,12 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		size_t size)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 	int num_sectors = size / SPI_NOR_SECTOR_SIZE;
 	int i;
 	unsigned int key = 0;
 
-	uint8_t *dst = memc_flexspi_get_ahb_address(config->controller,
+	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
 						    config->port,
 						    offset);
 
@@ -387,7 +407,12 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		return -EINVAL;
 	}
 
-	if (memc_flexspi_is_running_xip(config->controller)) {
+	if (memc_flexspi_is_running_xip(data->controller)) {
+		/*
+		 * ==== ENTER CRITICAL SECTION ====
+		 * No flash access should be performed in critical section. All
+		 * code and data accessed must reside in ram.
+		 */
 		key = irq_lock();
 	}
 
@@ -395,18 +420,19 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		flash_flexspi_nor_write_enable(dev, true);
 		flash_flexspi_nor_erase_chip(dev);
 		flash_flexspi_nor_wait_bus_busy(dev);
-		memc_flexspi_reset(config->controller);
+		memc_flexspi_reset(data->controller);
 	} else {
 		for (i = 0; i < num_sectors; i++) {
 			flash_flexspi_nor_write_enable(dev, true);
 			flash_flexspi_nor_erase_sector(dev, offset);
 			flash_flexspi_nor_wait_bus_busy(dev);
-			memc_flexspi_reset(config->controller);
+			memc_flexspi_reset(data->controller);
 			offset += SPI_NOR_SECTOR_SIZE;
 		}
 	}
 
-	if (memc_flexspi_is_running_xip(config->controller)) {
+	if (memc_flexspi_is_running_xip(data->controller)) {
+		/* ==== EXIT CRITICAL SECTION ==== */
 		irq_unlock(key);
 	}
 
@@ -439,28 +465,29 @@ static void flash_flexspi_nor_pages_layout(const struct device *dev,
 static int flash_flexspi_nor_init(const struct device *dev)
 {
 	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 	uint8_t vendor_id;
 
-	if (!device_is_ready(config->controller)) {
+	if (!device_is_ready(data->controller)) {
 		LOG_ERR("Controller device not ready");
 		return -ENODEV;
 	}
 
-	if (!memc_flexspi_is_running_xip(config->controller) &&
-	    memc_flexspi_set_device_config(config->controller, &config->config,
+	if (!memc_flexspi_is_running_xip(data->controller) &&
+	    memc_flexspi_set_device_config(data->controller, &config->config,
 					   config->port)) {
 		LOG_ERR("Could not set device configuration");
 		return -EINVAL;
 	}
 
-	if (memc_flexspi_update_lut(config->controller, 0,
+	if (memc_flexspi_update_lut(data->controller, 0,
 				   (const uint32_t *) flash_flexspi_nor_lut,
 				   sizeof(flash_flexspi_nor_lut) / 4)) {
 		LOG_ERR("Could not update lut");
 		return -EINVAL;
 	}
 
-	memc_flexspi_reset(config->controller);
+	memc_flexspi_reset(data->controller);
 
 	if (flash_flexspi_enable_octal_mode(dev)) {
 		LOG_ERR("Could not enable octal mode");
@@ -521,7 +548,6 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 #define FLASH_FLEXSPI_NOR(n)						\
 	static const struct flash_flexspi_nor_config			\
 		flash_flexspi_nor_config_##n = {			\
-		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
 		.port = DT_INST_REG_ADDR(n),				\
 		.config = FLASH_FLEXSPI_DEVICE_CONFIG(n),		\
 		.layout = {						\
@@ -535,10 +561,15 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 		},							\
 	};								\
 									\
+	static struct flash_flexspi_nor_data				\
+		flash_flexspi_nor_data_##n = {				\
+		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
+	};								\
+									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      flash_flexspi_nor_init,			\
 			      NULL,					\
-			      NULL,					\
+			      &flash_flexspi_nor_data_##n,		\
 			      &flash_flexspi_nor_config_##n,		\
 			      POST_KERNEL,				\
 			      CONFIG_FLASH_INIT_PRIORITY,		\

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -25,7 +25,8 @@
 
 LOG_MODULE_REGISTER(memc_flexspi, CONFIG_MEMC_LOG_LEVEL);
 
-struct memc_flexspi_config {
+/* flexspi device data should be stored in RAM to avoid read-while-write hazards */
+struct memc_flexspi_data {
 	FLEXSPI_Type *base;
 	uint8_t *ahb_base;
 	bool xip;
@@ -36,33 +37,30 @@ struct memc_flexspi_config {
 	bool combination_mode;
 	bool sck_differential_clock;
 	flexspi_read_sample_clock_t rx_sample_clock;
-};
-
-struct memc_flexspi_data {
 	size_t size[kFLEXSPI_PortCount];
 };
 
 void memc_flexspi_wait_bus_idle(const struct device *dev)
 {
-	const struct memc_flexspi_config *config = dev->config;
+	struct memc_flexspi_data *data = dev->data;
 
-	while (false == FLEXSPI_GetBusIdleStatus(config->base)) {
+	while (false == FLEXSPI_GetBusIdleStatus(data->base)) {
 	}
 }
 
 bool memc_flexspi_is_running_xip(const struct device *dev)
 {
-	const struct memc_flexspi_config *config = dev->config;
+	struct memc_flexspi_data *data = dev->data;
 
-	return config->xip;
+	return data->xip;
 }
 
 int memc_flexspi_update_lut(const struct device *dev, uint32_t index,
 		const uint32_t *cmd, uint32_t count)
 {
-	const struct memc_flexspi_config *config = dev->config;
+	struct memc_flexspi_data *data = dev->data;
 
-	FLEXSPI_UpdateLUT(config->base, index, cmd, count);
+	FLEXSPI_UpdateLUT(data->base, index, cmd, count);
 
 	return 0;
 }
@@ -71,7 +69,6 @@ int memc_flexspi_set_device_config(const struct device *dev,
 		const flexspi_device_config_t *device_config,
 		flexspi_port_t port)
 {
-	const struct memc_flexspi_config *config = dev->config;
 	struct memc_flexspi_data *data = dev->data;
 
 	if (port >= kFLEXSPI_PortCount) {
@@ -81,7 +78,7 @@ int memc_flexspi_set_device_config(const struct device *dev,
 
 	data->size[port] = device_config->flashSize * KB(1);
 
-	FLEXSPI_SetFlashConfig(config->base,
+	FLEXSPI_SetFlashConfig(data->base,
 			       (flexspi_device_config_t *) device_config,
 			       port);
 
@@ -90,9 +87,9 @@ int memc_flexspi_set_device_config(const struct device *dev,
 
 int memc_flexspi_reset(const struct device *dev)
 {
-	const struct memc_flexspi_config *config = dev->config;
+	struct memc_flexspi_data *data = dev->data;
 
-	FLEXSPI_SoftwareReset(config->base);
+	FLEXSPI_SoftwareReset(data->base);
 
 	return 0;
 }
@@ -100,8 +97,8 @@ int memc_flexspi_reset(const struct device *dev)
 int memc_flexspi_transfer(const struct device *dev,
 		flexspi_transfer_t *transfer)
 {
-	const struct memc_flexspi_config *config = dev->config;
-	status_t status = FLEXSPI_TransferBlocking(config->base, transfer);
+	struct memc_flexspi_data *data = dev->data;
+	status_t status = FLEXSPI_TransferBlocking(data->base, transfer);
 
 	if (status != kStatus_Success) {
 		LOG_ERR("Transfer error: %d", status);
@@ -114,7 +111,6 @@ int memc_flexspi_transfer(const struct device *dev,
 void *memc_flexspi_get_ahb_address(const struct device *dev,
 		flexspi_port_t port, off_t offset)
 {
-	const struct memc_flexspi_config *config = dev->config;
 	struct memc_flexspi_data *data = dev->data;
 	int i;
 
@@ -127,12 +123,12 @@ void *memc_flexspi_get_ahb_address(const struct device *dev,
 		offset += data->size[port];
 	}
 
-	return config->ahb_base + offset;
+	return data->ahb_base + offset;
 }
 
 static int memc_flexspi_init(const struct device *dev)
 {
-	const struct memc_flexspi_config *config = dev->config;
+	struct memc_flexspi_data *data = dev->data;
 	flexspi_config_t flexspi_config;
 
 	/* we should not configure the device we are running on */
@@ -143,18 +139,18 @@ static int memc_flexspi_init(const struct device *dev)
 
 	FLEXSPI_GetDefaultConfig(&flexspi_config);
 
-	flexspi_config.ahbConfig.enableAHBBufferable = config->ahb_bufferable;
-	flexspi_config.ahbConfig.enableAHBCachable = config->ahb_cacheable;
-	flexspi_config.ahbConfig.enableAHBPrefetch = config->ahb_prefetch;
-	flexspi_config.ahbConfig.enableReadAddressOpt = config->ahb_read_addr_opt;
+	flexspi_config.ahbConfig.enableAHBBufferable = data->ahb_bufferable;
+	flexspi_config.ahbConfig.enableAHBCachable = data->ahb_cacheable;
+	flexspi_config.ahbConfig.enableAHBPrefetch = data->ahb_prefetch;
+	flexspi_config.ahbConfig.enableReadAddressOpt = data->ahb_read_addr_opt;
 #if !(defined(FSL_FEATURE_FLEXSPI_HAS_NO_MCR0_COMBINATIONEN) && \
 	FSL_FEATURE_FLEXSPI_HAS_NO_MCR0_COMBINATIONEN)
-	flexspi_config.enableCombination = config->combination_mode;
+	flexspi_config.enableCombination = data->combination_mode;
 #endif
-	flexspi_config.enableSckBDiffOpt = config->sck_differential_clock;
-	flexspi_config.rxSampleClock = config->rx_sample_clock;
+	flexspi_config.enableSckBDiffOpt = data->sck_differential_clock;
+	flexspi_config.rxSampleClock = data->rx_sample_clock;
 
-	FLEXSPI_Init(config->base, &flexspi_config);
+	FLEXSPI_Init(data->base, &flexspi_config);
 
 	return 0;
 }
@@ -170,8 +166,8 @@ static int memc_flexspi_init(const struct device *dev)
 #endif
 
 #define MEMC_FLEXSPI(n)							\
-	static const struct memc_flexspi_config				\
-		memc_flexspi_config_##n = {				\
+	static struct memc_flexspi_data					\
+		memc_flexspi_data_##n = {				\
 		.base = (FLEXSPI_Type *) DT_INST_REG_ADDR(n),		\
 		.xip = MEMC_FLEXSPI_CFG_XIP(DT_DRV_INST(n)),		\
 		.ahb_base = (uint8_t *) DT_INST_REG_ADDR_BY_IDX(n, 1),	\
@@ -184,13 +180,11 @@ static int memc_flexspi_init(const struct device *dev)
 		.rx_sample_clock = DT_INST_PROP(n, rx_clock_source),	\
 	};								\
 									\
-	static struct memc_flexspi_data memc_flexspi_data_##n;		\
-									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      memc_flexspi_init,			\
 			      NULL,					\
 			      &memc_flexspi_data_##n,			\
-			      &memc_flexspi_config_##n,			\
+			      NULL,					\
 			      POST_KERNEL,				\
 			      CONFIG_KERNEL_INIT_PRIORITY_DEVICE,	\
 			      NULL);


### PR DESCRIPTION
Fix usage fault in flash shell sample for RT1064 EVK. This fault is cause by a read-while-write hazard, the FlexSPI driver cannot access flash memory while it is actively writing data to the flash device. This PR reverts the changes introduced in #42230, which moved device objects from RAM into flash, triggered a RWW bug, and additionally moves the memc driver data into ram to prevent future RWW hazards. Comments have also been added around critical sections to warn developers that flash access at these times will cause RWW bugs.

Fixes #44043