### PR TITLE
boards: arm: rpi_pico: Fix I2C compatible in docs

### DIFF
--- a/boards/arm/rpi_pico/doc/index.rst
+++ b/boards/arm/rpi_pico/doc/index.rst
@@ -59,7 +59,7 @@ hardware features:
      - :dtcompatible:`rpi,pico-gpio`
    * - I2C
      - :kconfig:option:`CONFIG_I2C`
-     - :dtcompatible:`rpi,pico-i2c`
+     - :dtcompatible:`snps,designware-i2c`
    * - HWINFO
      - :kconfig:option:`CONFIG_HWINFO`
      - N/A


### PR DESCRIPTION
The documentation for rpi_pico used the wrong devicetree
compatible for I2C.

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>