### PR TITLE
boards: thingy52_nrf52832: additional led aliases

### DIFF
--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -26,6 +26,8 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		led1 = &led1;
+		led2 = &led2;
 		sw0 = &button0;
 	};
 


### PR DESCRIPTION
This PR updates the `thingy52_nrf52832` dts to add two additional
aliases for leds 1 & 2.

Why: 
In a university course, alot of students use this board with Zephyr
and have wondered why many boards provide dts aliases for additional leds (ex [1][2]), yet,
this only has an alias for the single led. The PR adds required led
aliases to make working with the leds on this board a little bit
quicker/easier.

Testing:
- 	 `./scripts/twister -p thingy52_nrf52832`
- 	 Hardware verification using the gpio_api to toggle all leds.

[1] https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/arm/particle_boron/dts/mesh_feather.dtsi
[2] https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble.dts

Signed-off-by: Wilfred Mallawa <thulith.mallawa@uqconnect.edu.au>