### PR TITLE
devicetree: instance macros for `STRING_TOKEN`

### DIFF
--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -471,9 +471,9 @@ static struct spi_driver_api spi_b91_api = {
 									  \
 	static struct spi_b91_cfg spi_b91_cfg_##inst = {		  \
 		.peripheral_id = DT_INST_ENUM_IDX(inst, peripheral_id),	  \
-		.cs_pin[0] = DT_STRING_TOKEN(DT_DRV_INST(inst), cs0_pin), \
-		.cs_pin[1] = DT_STRING_TOKEN(DT_DRV_INST(inst), cs1_pin), \
-		.cs_pin[2] = DT_STRING_TOKEN(DT_DRV_INST(inst), cs2_pin), \
+		.cs_pin[0] = DT_INST_STRING_TOKEN(inst, cs0_pin),	  \
+		.cs_pin[1] = DT_INST_STRING_TOKEN(inst, cs1_pin),	  \
+		.cs_pin[2] = DT_INST_STRING_TOKEN(inst, cs2_pin),	  \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		  \
 	};								  \
 									  \

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -892,6 +892,25 @@
 #define DT_STRING_UPPER_TOKEN(node_id, prop) \
 	DT_CAT4(node_id, _P_, prop, _STRING_UPPER_TOKEN)
 
+/**
+ * @brief Like DT_STRING_UPPER_TOKEN(), but with a fallback to default_value
+ *
+ * If the value exists, this expands to DT_STRING_UPPER_TOKEN(node_id, prop).
+ * The default_value parameter is not expanded in this case.
+ *
+ * Otherwise, this expands to default_value.
+ *
+ * @param node_id node identifier
+ * @param prop lowercase-and-underscores property name
+ * @param default_value a fallback value to expand to
+ * @return if @p prop exists, its value as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores.
+ *         Othewise @p default_value
+ */
+#define DT_STRING_UPPER_TOKEN_OR(node_id, prop, default_value) \
+	COND_CODE_1(DT_NODE_HAS_PROP(node_id, prop), \
+		(DT_STRING_UPPER_TOKEN(node_id, prop)), (default_value))
+
 /*
  * phandle properties
  *
@@ -2496,6 +2515,26 @@
 #define DT_INST_LABEL(inst) DT_INST_PROP(inst, label)
 
 /**
+ * @brief Get a string property's value as a token.
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property string name
+ * @return the value of @p prop as a token, i.e. without any quotes
+ *         and with special characters converted to underscores
+ */
+#define DT_INST_STRING_TOKEN(inst, prop) \
+	DT_STRING_TOKEN(DT_DRV_INST(inst), prop)
+
+/**
+ * @brief Like DT_INST_STRING_TOKEN(), but uppercased.
+ * @param inst instance number
+ * @param prop lowercase-and-underscores property string name
+ * @return the value of @p prop as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores
+ */
+#define DT_INST_STRING_UPPER_TOKEN(inst, prop) \
+	DT_STRING_UPPER_TOKEN(DT_DRV_INST(inst), prop)
+
+/**
  * @brief Get a DT_DRV_COMPAT instance's property value from a phandle's node
  * @param inst instance number
  * @param ph lowercase-and-underscores property of "inst"
@@ -2738,15 +2777,28 @@
 #define DT_INST_ON_BUS(inst, bus) DT_ON_BUS(DT_DRV_INST(inst), bus)
 
 /**
- * @brief Tests if DT_DRV_COMPAT's has string property, returns string token if
- *        found, otherwise returns default_value.
+ * @brief Like DT_INST_STRING_TOKEN(), but with a fallback to default_value
  * @param inst instance number
  * @param name lowercase-and-underscores property name
  * @param default_value a fallback value to expand to
- * @return the property's value or default_value
+ * @return if @p prop exists, its value as a token, i.e. without any quotes and
+ *         with special characters converted to underscores. Othewise
+ *         @p default_value
  */
 #define DT_INST_STRING_TOKEN_OR(inst, name, default_value) \
 	DT_STRING_TOKEN_OR(DT_DRV_INST(inst), name, default_value)
+
+/**
+ * @brief Like DT_INST_STRING_UPPER_TOKEN(), but with a fallback to default_value
+ * @param inst instance number
+ * @param name lowercase-and-underscores property name
+ * @param default_value a fallback value to expand to
+ * @return if @p prop exists, its value as an uppercased token, i.e. without
+ *         any quotes and with special characters converted to underscores.
+ *         Othewise @p default_value
+ */
+#define DT_INST_STRING_UPPER_TOKEN_OR(inst, name, default_value) \
+	DT_STRING_UPPER_TOKEN_OR(DT_DRV_INST(inst), name, default_value)
 
 /**
  * @brief Test if any DT_DRV_COMPAT node is on a bus of a given type

--- a/subsys/testsuite/ztest/include/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/ztest_assert.h
@@ -211,6 +211,20 @@ static inline bool z_zassert(bool cond,
 		msg, ##__VA_ARGS__)
 
 /**
+ * @brief Assert that @a a is greater than or equal to @a l and less
+ *        than or equal to @a u
+ *
+ * @param a Value to compare
+ * @param l Lower limit
+ * @param u Upper limit
+ * @param msg Optional message to print if the assertion fails
+ */
+#define zassert_between_inclusive(a, l, u, msg, ...)		     \
+	zassert(((a) >= (l)) && ((a) <= (u)),			     \
+		#a " not between " #l " and " #u " inclusive",	     \
+		msg, ##__VA_ARGS__)
+
+/**
  * @brief Assert that 2 memory buffers have the same contents
  *
  * This macro calls the final memory comparison assertion macro.

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2220,40 +2220,98 @@ static void test_string_token(void)
 		token_zero,
 		token_one,
 		token_two,
-		token_max,
 		token_no_inst,
+	};
+	enum {
+		TOKEN_ZERO = token_no_inst + 1,
+		TOKEN_ONE,
+		TOKEN_TWO,
+		TOKEN_NO_INST,
 	};
 	int i;
 
-	/* Test DT_INST_STRING_TOKEN_OR when property is found */
+	/* Test DT_INST_STRING_TOKEN */
+#define STRING_TOKEN_TEST_INST_EXPANSION(inst) \
+	DT_INST_STRING_TOKEN(inst, val),
 	int array_inst[] = {
-#define STRING_TOKEN_TEST_INST_EXPANSION(inst)                                \
-	DT_INST_STRING_TOKEN_OR(inst, val, token_no_inst),
-	DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_TEST_INST_EXPANSION)
+		DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_TEST_INST_EXPANSION)
 	};
 
 	for (i = 0; i < ARRAY_SIZE(array_inst); i++) {
-		zassert_true(array_inst[i] != token_no_inst, "");
+		zassert_between_inclusive(array_inst[i], token_zero, token_two, "");
+	}
+
+	/* Test DT_INST_STRING_UPPER_TOKEN */
+#define STRING_UPPER_TOKEN_TEST_INST_EXPANSION(inst) \
+	DT_INST_STRING_UPPER_TOKEN(inst, val),
+	int array_inst_upper[] = {
+		DT_INST_FOREACH_STATUS_OKAY(STRING_UPPER_TOKEN_TEST_INST_EXPANSION)
+	};
+
+	for (i = 0; i < ARRAY_SIZE(array_inst_upper); i++) {
+		zassert_between_inclusive(array_inst_upper[i], TOKEN_ZERO, TOKEN_TWO, "");
+	}
+
+	/* Test DT_INST_STRING_TOKEN_OR when property is found */
+#define STRING_TOKEN_OR_TEST_INST_EXPANSION(inst) \
+	DT_INST_STRING_TOKEN_OR(inst, val, token_no_inst),
+	int array_inst_or[] = {
+		DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_OR_TEST_INST_EXPANSION)
+	};
+
+	for (i = 0; i < ARRAY_SIZE(array_inst_or); i++) {
+		zassert_between_inclusive(array_inst_or[i], token_zero, token_two, "");
+	}
+
+	/* Test DT_INST_STRING_UPPER_TOKEN_OR when property is found */
+#define STRING_UPPER_TOKEN_OR_TEST_INST_EXPANSION(inst)	\
+	DT_INST_STRING_UPPER_TOKEN_OR(inst, val, TOKEN_NO_INST),
+	int array_inst_upper_or[] = {
+		DT_INST_FOREACH_STATUS_OKAY(STRING_UPPER_TOKEN_OR_TEST_INST_EXPANSION)
+	};
+
+	for (i = 0; i < ARRAY_SIZE(array_inst_upper_or); i++) {
+		zassert_between_inclusive(array_inst_upper_or[i], TOKEN_ZERO, TOKEN_TWO, "");
 	}
 
 	/* Test DT_STRING_TOKEN_OR when property is found */
 	zassert_equal(DT_STRING_TOKEN_OR(DT_NODELABEL(test_string_token_0),
-		val, token_one), token_zero, "");
+					 val, token_one), token_zero, "");
 	zassert_equal(DT_STRING_TOKEN_OR(DT_NODELABEL(test_string_token_1),
-		val, token_two), token_one, "");
+					 val, token_two), token_one, "");
 
 	/* Test DT_STRING_TOKEN_OR is not found */
 	zassert_equal(DT_STRING_TOKEN_OR(DT_NODELABEL(test_string_token_1),
-		no_inst, token_zero), token_zero, "");
+					 no_inst, token_zero), token_zero, "");
+
+	/* Test DT_STRING_UPPER_TOKEN_OR when property is found */
+	zassert_equal(DT_STRING_UPPER_TOKEN_OR(DT_NODELABEL(test_string_token_0),
+					       val, TOKEN_ONE), TOKEN_ZERO, "");
+	zassert_equal(DT_STRING_UPPER_TOKEN_OR(DT_NODELABEL(test_string_token_1),
+					       val, TOKEN_TWO), TOKEN_ONE, "");
+
+	/* Test DT_STRING_UPPER_TOKEN_OR is not found */
+	zassert_equal(DT_STRING_UPPER_TOKEN_OR(DT_NODELABEL(test_string_token_1),
+					       no_inst, TOKEN_ZERO), TOKEN_ZERO, "");
 
 	/* Test DT_INST_STRING_TOKEN_OR when property is not found */
-	int array_no_inst[] = {
-#define STRING_TOKEN_TEST_NO_INST_EXPANSION(inst)                             \
+#define STRING_TOKEN_TEST_NO_INST_EXPANSION(inst) \
 	DT_INST_STRING_TOKEN_OR(inst, no_inst, token_no_inst),
-	DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_TEST_NO_INST_EXPANSION)
+	int array_no_inst_or[] = {
+		DT_INST_FOREACH_STATUS_OKAY(STRING_TOKEN_TEST_NO_INST_EXPANSION)
 	};
-	for (i = 0; i < ARRAY_SIZE(array_no_inst); i++) {
-		zassert_true(array_no_inst[i] == token_no_inst, "");
+	for (i = 0; i < ARRAY_SIZE(array_no_inst_or); i++) {
+		zassert_equal(array_no_inst_or[i], token_no_inst, "");
+	}
+
+	/* Test DT_INST_STRING_UPPER_TOKEN_OR when property is not found */
+#define STRING_UPPER_TOKEN_TEST_NO_INST_EXPANSION(inst)	\
+	DT_INST_STRING_UPPER_TOKEN_OR(inst, no_inst, TOKEN_NO_INST),
+	int array_no_inst_upper_or[] = {
+		DT_INST_FOREACH_STATUS_OKAY(STRING_UPPER_TOKEN_TEST_NO_INST_EXPANSION)
+	};
+	for (i = 0; i < ARRAY_SIZE(array_no_inst_upper_or); i++) {
+		zassert_equal(array_no_inst_upper_or[i], TOKEN_NO_INST, "");
 	}
 }
 


### PR DESCRIPTION
Adds instance based macros for the `DT_STRING_TOKEN` and `DT_STRING_TOKEN_UPPER` macros.
This can make `DT_INST_FOREACH_STATUS_OKAY` macros a little cleaner.