### PR TITLE
doc: Use :kconfig:option: domain role

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -652,8 +652,9 @@ Networking
   * Added a parameter to forcefully close the LwM2M session to
     :c:func:`lwm2m_rd_client_stop` function.
   * Replaced custom ``float32_value_t`` type with double.
-  * Added :kconfig:`LWM2M_FIRMWARE_PORT_NONSECURE`/:kconfig:`LWM2M_FIRMWARE_PORT_SECURE`
-    options, which allow to specify a custom port or firmware update.
+  * Added :kconfig:option:`LWM2M_FIRMWARE_PORT_NONSECURE`/
+    :kconfig:option:`LWM2M_FIRMWARE_PORT_SECURE` options, which allow to
+    specify a custom port or firmware update.
   * Added :c:func:`lwm2m_update_device_service_period` API function.
   * Added observe callback for observe and notification events.
   * Added support for multiple LwM2M Firmware Update object instances.


### PR DESCRIPTION
Multiple usages of the :kconfig: role, which is now obsolete, was
merged in the PR #43053; update these to use the :kconfig:option:
domain role.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>