### PR TITLE
drivers: sensor: stm32_temp: Fix + add support for STM32G0B1

### DIFF
--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -24,8 +24,7 @@ LOG_MODULE_REGISTER(stm32_temp, CONFIG_SENSOR_LOG_LEVEL);
 
 struct stm32_temp_data {
 	const struct device *adc;
-	uint8_t channel;
-	struct adc_channel_cfg adc_cfg;
+	const struct adc_channel_cfg adc_cfg;
 	struct adc_sequence adc_seq;
 	struct k_mutex mutex;
 	int16_t sample_buffer;
@@ -60,14 +59,21 @@ static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel
 
 	k_mutex_lock(&data->mutex, K_FOREVER);
 
+	rc = adc_channel_setup(data->adc, &data->adc_cfg);
+	if (rc) {
+		LOG_DBG("Setup AIN%u got %d", data->adc_cfg.channel_id, rc);
+		goto unlock;
+	}
+
 	rc = adc_read(data->adc, sp);
 	if (rc == 0) {
 		data->raw = data->sample_buffer;
 	}
 
+unlock:
 	k_mutex_unlock(&data->mutex);
 
-	return 0;
+	return rc;
 }
 
 static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel chan,
@@ -110,9 +116,7 @@ static const struct sensor_driver_api stm32_temp_driver_api = {
 static int stm32_temp_init(const struct device *dev)
 {
 	struct stm32_temp_data *data = dev->data;
-	struct adc_channel_cfg *accp = &data->adc_cfg;
 	struct adc_sequence *asp = &data->adc_seq;
-	int rc;
 
 	k_mutex_init(&data->mutex);
 
@@ -121,19 +125,11 @@ static int stm32_temp_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	*accp = (struct adc_channel_cfg){ .gain = ADC_GAIN_1,
-					  .reference = ADC_REF_INTERNAL,
-					  .acquisition_time = ADC_ACQ_TIME_MAX,
-					  .channel_id = data->channel,
-					  .differential = 0 };
-	rc = adc_channel_setup(data->adc, accp);
-	LOG_DBG("Setup AIN%u got %d", data->channel, rc);
-
 	*asp = (struct adc_sequence){
-		.channels = BIT(data->channel),
+		.channels = BIT(data->adc_cfg.channel_id),
 		.buffer = &data->sample_buffer,
 		.buffer_size = sizeof(data->sample_buffer),
-		.resolution = 12,
+		.resolution = 12U,
 	};
 
 	return 0;
@@ -157,7 +153,13 @@ static const struct stm32_temp_config stm32_temp_dev_config = {
 
 static struct stm32_temp_data stm32_temp_dev_data = {
 	.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(0)),
-	.channel = DT_INST_IO_CHANNELS_INPUT(0),
+	.adc_cfg = {
+		.gain = ADC_GAIN_1,
+		.reference = ADC_REF_INTERNAL,
+		.acquisition_time = ADC_ACQ_TIME_MAX,
+		.channel_id = DT_INST_IO_CHANNELS_INPUT(0),
+		.differential = 0
+	},
 };
 
 DEVICE_DT_INST_DEFINE(0, stm32_temp_init, NULL, &stm32_temp_dev_data, &stm32_temp_dev_config,

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -61,7 +61,6 @@ static int stm32_temp_sample_fetch(const struct device *dev, enum sensor_channel
 	k_mutex_lock(&data->mutex, K_FOREVER);
 
 	rc = adc_read(data->adc, sp);
-	sp->calibrate = false;
 	if (rc == 0) {
 		data->raw = data->sample_buffer;
 	}
@@ -135,7 +134,6 @@ static int stm32_temp_init(const struct device *dev)
 		.buffer = &data->sample_buffer,
 		.buffer_size = sizeof(data->sample_buffer),
 		.resolution = 12,
-		.calibrate = true,
 	};
 
 	return 0;

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -120,6 +120,19 @@
 		};
 	};
 
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF75A8>;
+		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		ts-cal-offset = <30>;
+		io-channels = <&adc1 12>;
+		status = "disabled";
+		label = "DIE_TEMP";
+	};
+
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;


### PR DESCRIPTION
Remove unnecessary calibration, fix for `stm32_temp`, add support for STM32G0B1

STM32G0B1 datasheet:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/1563974/159425444-e711cd11-8b7e-40f0-bd43-cc1c7b6a2275.png">

I think the configurations should be similar across G0 family, but the TS_CAL2 seems to be missing from other series (at least G0B0 & G070), so I decided to leave them out from this PR for now.

G0B0:
<img width="700" alt="image" src="https://user-images.githubusercontent.com/1563974/159427087-63aeb41b-d8a9-4321-b375-b6a4ce7108d7.png">


Log output from g0b1 custom board, integrated the [stm32_temp sample](https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/sensor/stm32_temp_sensor/src/main.c) into my custom application that samples battery voltages:

```
[00:39:32.226,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2563|195] [4128 mV| 314 mV]
[00:39:42.327,000] <inf> component_power: Current temperature: 31.896545 °C
[00:39:42.327,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2563|192] [4128 mV| 308 mV]
[00:39:52.428,000] <inf> component_power: Current temperature: 31.580459 °C
[00:39:52.429,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2563|191] [4128 mV| 306 mV]
[00:40:02.530,000] <inf> component_power: Current temperature: 31.580459 °C
[00:40:02.530,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2562|193] [4128 mV| 310 mV]
[00:40:12.632,000] <inf> component_power: Current temperature: 31.896545 °C
[00:40:12.632,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2562|193] [4128 mV| 310 mV]
[00:40:22.733,000] <inf> component_power: Current temperature: 32.212631 °C
[00:40:22.733,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2561|193] [4126 mV| 310 mV]
[00:40:32.835,000] <inf> component_power: Current temperature: 32.212631 °C
[00:40:32.835,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2562|192] [4128 mV| 308 mV]
[00:40:42.936,000] <inf> component_power: Current temperature: 31.896545 °C
[00:40:42.937,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2562|194] [4128 mV| 312 mV]
[00:40:53.038,000] <inf> component_power: Current temperature: 32.212631 °C
[00:40:53.038,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2563|193] [4128 mV| 310 mV]
[00:41:03.139,000] <inf> component_power: Current temperature: 32.212631 °C
[00:41:03.140,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2561|196] [4126 mV| 314 mV]
[00:41:13.241,000] <inf> component_power: Current temperature: 31.896545 °C
[00:41:13.241,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2563|192] [4128 mV| 308 mV]
[00:41:23.343,000] <inf> component_power: Current temperature: 31.896545 °C
[00:41:23.343,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2563|193] [4128 mV| 310 mV]
[00:41:33.444,000] <inf> component_power: Current temperature: 31.896545 °C
[00:41:33.444,000] <dbg> component_power.power_work_handler: [BATT|MAIN] [2563|192] [4128 mV| 308 mV]
```

Reading is off though, room temperature should be ~ 28°C

Fixes #41742