### PR TITLE
ITE drivers/timer: customize busy wait timer

### DIFF
--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -15,12 +15,27 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(timer, LOG_LEVEL_ERR);
 
+/* RAM code section */
+#define __timer_ram_code __attribute__((section(".__ram_code")))
+
 /* Event timer configurations */
 #define EVENT_TIMER		EXT_TIMER_3
 #define EVENT_TIMER_IRQ		DT_INST_IRQ_BY_IDX(0, 0, irq)
 #define EVENT_TIMER_FLAG	DT_INST_IRQ_BY_IDX(0, 0, flags)
 /* Event timer max count is 512 sec (base on clock source 32768Hz) */
 #define EVENT_TIMER_MAX_CNT	0x00FFFFFFUL
+
+/* Busy wait low timer configurations */
+#define BUSY_WAIT_L_TIMER	EXT_TIMER_5
+#define BUSY_WAIT_L_TIMER_IRQ	DT_INST_IRQ_BY_IDX(0, 2, irq)
+#define BUSY_WAIT_L_TIMER_FLAG	DT_INST_IRQ_BY_IDX(0, 2, flags)
+
+/* Busy wait high timer configurations */
+#define BUSY_WAIT_H_TIMER	EXT_TIMER_6
+#define BUSY_WAIT_H_TIMER_IRQ	DT_INST_IRQ_BY_IDX(0, 3, irq)
+#define BUSY_WAIT_H_TIMER_FLAG	DT_INST_IRQ_BY_IDX(0, 3, flags)
+/* Busy wait high timer max count is 71.58min (base on clock source 1MHz) */
+#define BUSY_WAIT_TIMER_H_MAX_CNT 0xFFFFFFFFUL
 
 #ifdef CONFIG_SOC_IT8XXX2_PLL_FLASH_48M
 /*
@@ -121,6 +136,32 @@ void timer_5ms_one_shot(void)
 	irq_enable(ONE_SHOT_TIMER_IRQ);
 }
 #endif /* CONFIG_SOC_IT8XXX2_PLL_FLASH_48M */
+
+#ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
+__timer_ram_code void arch_busy_wait(uint32_t usec_to_wait)
+{
+	if (!usec_to_wait) {
+		return;
+	}
+
+	/* Decrease 1us here to calibrate our access registers latency */
+	usec_to_wait--;
+
+	/*
+	 * We want to set the bit(1) re-start busy wait timer as soon
+	 * as possible, so we directly write 0xb instead of | bit(1).
+	 */
+	IT8XXX2_EXT_CTRLX(BUSY_WAIT_L_TIMER) = IT8XXX2_EXT_ETX_COMB_RST_EN;
+
+	for (;;) {
+		uint32_t curr = IT8XXX2_EXT_CNTOX(BUSY_WAIT_H_TIMER);
+
+		if (curr >= usec_to_wait) {
+			break;
+		}
+	}
+}
+#endif
 
 static void evt_timer_enable(void)
 {
@@ -371,6 +412,38 @@ static int sys_clock_driver_init(const struct device *dev)
 	if (ret < 0) {
 		LOG_ERR("Init event timer failed");
 		return ret;
+	}
+
+	if (IS_ENABLED(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)) {
+		/* Set timer5 and timer6 combinational mode for busy wait */
+		IT8XXX2_EXT_CTRLX(BUSY_WAIT_L_TIMER) |= IT8XXX2_EXT_ETXCOMB;
+
+		/* Set 32-bit timer6 to count-- every 1us */
+		ret = timer_init(BUSY_WAIT_H_TIMER, EXT_PSR_8M, EXT_RAW_CNT,
+				 BUSY_WAIT_TIMER_H_MAX_CNT, EXT_FIRST_TIME_ENABLE,
+				 BUSY_WAIT_H_TIMER_IRQ, BUSY_WAIT_H_TIMER_FLAG,
+				 EXT_WITHOUT_TIMER_INT, EXT_START_TIMER);
+		if (ret < 0) {
+			LOG_ERR("Init busy wait high timer failed");
+			return ret;
+		}
+
+		/*
+		 * Set 24-bit timer5 to overflow every 1us
+		 * NOTE: When the timer5 count down to overflow in combinational
+		 *       mode, timer6 counter will automatically decrease one count
+		 *       and timer5 will automatically re-start counting down
+		 *       from 0x7. Timer5 clock source is 8MHz (=0.125ns), so the
+		 *       time period from 0x7 to overflow is 0.125ns * 8 = 1us.
+		 */
+		ret = timer_init(BUSY_WAIT_L_TIMER, EXT_PSR_8M, EXT_RAW_CNT,
+				 0x7, EXT_FIRST_TIME_ENABLE,
+				 BUSY_WAIT_L_TIMER_IRQ, BUSY_WAIT_L_TIMER_FLAG,
+				 EXT_WITHOUT_TIMER_INT, EXT_START_TIMER);
+		if (ret < 0) {
+			LOG_ERR("Init busy wait low timer failed");
+			return ret;
+		}
 	}
 
 	return 0;

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -314,8 +314,8 @@
 			label = "TIMER";
 			interrupts = <IT8XXX2_IRQ_TIMER3 IRQ_TYPE_EDGE_RISING   /* Event timer */
 				      IT8XXX2_IRQ_TIMER4 IRQ_TYPE_EDGE_RISING   /* Free run timer */
-				      IT8XXX2_IRQ_TIMER5 IRQ_TYPE_EDGE_RISING
-				      IT8XXX2_IRQ_TIMER6 IRQ_TYPE_EDGE_RISING
+				      IT8XXX2_IRQ_TIMER5 IRQ_TYPE_EDGE_RISING   /* Busy wait low */
+				      IT8XXX2_IRQ_TIMER6 IRQ_TYPE_EDGE_RISING   /* Busy wait high */
 				      IT8XXX2_IRQ_TIMER7 IRQ_TYPE_EDGE_RISING
 				      IT8XXX2_IRQ_TIMER8 IRQ_TYPE_EDGE_RISING>;
 			interrupt-parent = <&intc>;

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2020 ITE Corporation. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -863,6 +863,10 @@ struct wdt_it8xxx2_regs {
 
 /* External Timer register fields */
 /* External Timer 3~8 control */
+#define IT8XXX2_EXT_ETX_COMB_RST_EN	(IT8XXX2_EXT_ETXCOMB | \
+					 IT8XXX2_EXT_ETXRST | \
+					 IT8XXX2_EXT_ETXEN)
+#define IT8XXX2_EXT_ETXCOMB		BIT(3)
 #define IT8XXX2_EXT_ETXRST		BIT(1)
 #define IT8XXX2_EXT_ETXEN		BIT(0)
 
@@ -897,8 +901,8 @@ enum ext_clk_src_sel {
 enum ext_timer_idx {
 	EXT_TIMER_3 = 0,	/* Event timer */
 	EXT_TIMER_4,		/* Free run timer */
-	EXT_TIMER_5,
-	EXT_TIMER_6,
+	EXT_TIMER_5,		/* Busy wait low timer */
+	EXT_TIMER_6,		/* Busy wait high timer */
 	EXT_TIMER_7,
 	EXT_TIMER_8,
 };

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -19,6 +19,9 @@ config RISCV_GP
 config ITE_IT8XXX2_TIMER
 	default y
 
+config ARCH_HAS_CUSTOM_BUSY_WAIT
+	default y
+
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768
 


### PR DESCRIPTION
Customize busy wait timer for micro-seconds accuracy.

Verified by follow test pattern:
west build -p auto -b it8xxx2_evb tests/kernel/timer/timer_api
west build -p auto -b it8xxx2_evb tests/kernel/timer/timer_error_case
west build -p auto -b it8xxx2_evb tests/kernel/timer/timer_monotonic
west build -p auto -b it8xxx2_evb tests/kernel/timer/starve
west build -p auto -b it8xxx2_evb tests/kernel/context
west build -p auto -b it8xxx2_evb tests/drivers/adc/adc_api

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>