### PR TITLE
Bluetooth: has: Improve grouping of settings

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.has
+++ b/subsys/bluetooth/audio/Kconfig.has
@@ -4,7 +4,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-config BT_HAS
+menuconfig BT_HAS
 	bool "Hearing Access Service support [EXPERIMENTAL]"
 	select EXPERIMENTAL
 	help


### PR DESCRIPTION
Use menuconfig in order to give a better grouping of HAS related
settings with separate subpage.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>