### PR TITLE
[backport v2.7-branch] stm32 adc define the internal voltage reference

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -36,6 +36,9 @@ LOG_MODULE_REGISTER(adc_stm32);
 #endif
 #endif
 
+/* reference voltage for the ADC */
+#define STM32_ADC_VREF_MV DT_INST_PROP(0, vref_mv)
+
 #if !defined(CONFIG_SOC_SERIES_STM32F0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32G0X) && \
 	!defined(CONFIG_SOC_SERIES_STM32L0X) && \
@@ -980,6 +983,7 @@ static const struct adc_driver_api api_stm32_driver_api = {
 #ifdef CONFIG_ADC_ASYNC
 	.read_async = adc_stm32_read_async,
 #endif
+	.ref_internal = STM32_ADC_VREF_MV, /* VREF is usually connected to VDD */
 };
 
 #define STM32_ADC_INIT(index)						\

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -29,5 +29,11 @@ properties:
     "#io-channel-cells":
       const: 1
 
+    vref_mv:
+      type: int
+      required: false
+      default: 3300
+      description: Indicates the reference voltage of the ADC in mV.
+
 io-channel-cells:
     - input


### PR DESCRIPTION
the backport of https://github.com/zephyrproject-rtos/zephyr/pull/43861 to v2.7-branch failed.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44049