### PR TITLE
it8xxx2: pinmux: correct i2c3 alt function locate on GPF2/F3

### DIFF
--- a/drivers/pinmux/pinmux_ite_it8xxx2.c
+++ b/drivers/pinmux/pinmux_ite_it8xxx2.c
@@ -158,19 +158,6 @@ static int pinmux_it8xxx2_init(const struct device *dev)
 	IT8XXX2_GPIO_GCR &= ~(BIT(1) | BIT(2));
 
 	/*
-	 * If SMBUS3 swaps from H group to F group, we have to
-	 * set SMB3PSEL = 1 in PMER3 register.
-	 */
-	if (DEVICE_DT_GET(DT_PHANDLE(DT_NODELABEL(i2c3), gpio_dev)) ==
-	    DEVICE_DT_GET(DT_NODELABEL(gpiof))) {
-
-		struct gctrl_it8xxx2_regs *const gctrl_base =
-			(struct gctrl_it8xxx2_regs *)
-				DT_REG_ADDR(DT_NODELABEL(gctrl));
-
-			gctrl_base->GCTRL_PMER3 |= IT8XXX2_GCTRL_SMB3PSEL;
-	}
-	/*
 	 * TODO: If UART2 swaps from bit2:1 to bit6:5 in H group, we
 	 * have to set UART1PSEL = 1 in UART1PMR register.
 	 */

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -146,9 +146,9 @@
 					 NO_FUNC NO_FUNC 0xf016f1 0xf016f1>;
 			func3_en_mask = <0       0       0x02     0x02
 					 0       0       0x10     0x10    >;
-			func4_gcr =     <NO_FUNC NO_FUNC 0xf016f1 0xf016f1
+			func4_gcr =     <NO_FUNC NO_FUNC 0xf02046 0xf02046
 					 NO_FUNC NO_FUNC NO_FUNC  NO_FUNC >;
-			func4_en_mask = <0       0       0x20     0x20
+			func4_en_mask = <0       0       0x40     0x40
 					 0       0       0        0       >;
 			#pinctrl-cells = <2>;
 		};


### PR DESCRIPTION
Enable the alt function with setting both bit5@0xf016f1 and
bit6@0xf02046 bits will cause internal leakage.
Only bit6@0xf02046 bit is required to enable the alt function,
so fix it.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>