### PR TITLE
Bluetooth: Controller: Back-to-Back Radio Rx interface

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -96,6 +96,8 @@ void radio_switch_complete_with_delay_compensation_and_tx(
 	enum radio_end_evt_delay_state end_evt_delay_en);
 void radio_switch_complete_and_b2b_tx(uint8_t phy_curr, uint8_t flags_curr,
 				      uint8_t phy_next, uint8_t flags_next);
+void radio_switch_complete_and_b2b_rx(uint8_t phy_curr, uint8_t flags_curr,
+				      uint8_t phy_next, uint8_t flags_next);
 void radio_switch_complete_and_disable(void);
 
 uint8_t radio_phy_flags_rx_get(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -492,6 +492,20 @@ static inline void hal_radio_rxen_on_sw_switch(uint8_t ppi)
 	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, ppi);
 }
 
+static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t ppi)
+{
+	/* NOTE: Calling radio_tmr_start/radio_tmr_start_us/radio_tmr_start_now
+	 *       after the radio_switch_complete_and_b2b_rx() call would have
+	 *       changed the PPI channel to HAL_RADIO_ENABLE_ON_TICK_PPI as we
+	 *       cannot double buffer the subscribe buffer. Hence, lets have
+	 *       both DPPI channel enabled (other one was enabled by the DPPI
+	 *       group when the Radio End occurred) so that when both timer
+	 *       trigger one of the DPPI is correct in the radio rx
+	 *       subscription.
+	 */
+	nrf_radio_subscribe_set(NRF_RADIO, NRF_RADIO_TASK_RXEN, ppi);
+	nrf_dppi_channels_enable(NRF_DPPIC, BIT(ppi));
+}
 
 static inline void hal_radio_sw_switch_disable(void)
 {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -417,6 +417,16 @@ static inline void hal_radio_rxen_on_sw_switch(uint8_t ppi)
 		HAL_SW_SWITCH_RADIO_ENABLE_PPI_TASK_RX);
 }
 
+static inline void hal_radio_b2b_rxen_on_sw_switch(uint8_t ppi)
+{
+	/* NOTE: As independent PPI are used to trigger the Radio Rx task,
+	 *       double buffers implementation works for sw_switch using PPIs,
+	 *       simply reuse the hal_radio_rxen_on_sw_switch() functon to set
+	 *	 the next PPIs task to be Radio Rx enable.
+	 */
+	hal_radio_rxen_on_sw_switch(ppi);
+}
+
 static inline void hal_radio_sw_switch_disable(void)
 {
 	/* Disable the following PPI channels that implement SW Switch:

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -261,10 +261,11 @@ static void isr_rx(void *param)
 	LL_ASSERT(node_rx);
 
 	radio_df_iq_data_packet_set(node_rx->pdu, IQ_SAMPLE_TOTAL_CNT);
+#endif /* CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT */
 
 	/* Setup next Rx */
-	radio_switch_complete_and_rx(test_phy);
-#endif /* CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT */
+	radio_tmr_tifs_set(EVENT_IFS_US);
+	radio_switch_complete_and_b2b_rx(test_phy, test_phy_flags, test_phy, test_phy_flags);
 
 	/* Count Rx-ed packets */
 	if (crc_ok) {
@@ -517,7 +518,7 @@ static uint8_t init(uint8_t chan, uint8_t phy, int8_t tx_power,
 	/* Setup Radio in Tx/Rx */
 	/* NOTE: No whitening in test mode. */
 	radio_phy_set(test_phy, test_phy_flags);
-	radio_tmr_tifs_set(150);
+	radio_tmr_tifs_set(EVENT_IFS_US);
 
 	ret = tx_power_set(tx_power);
 
@@ -695,7 +696,7 @@ uint8_t ll_test_rx(uint8_t chan, uint8_t phy, uint8_t mod_idx, uint8_t expected_
 #endif /* CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT */
 
 	radio_pkt_rx_set(radio_pkt_scratch_get());
-	radio_switch_complete_and_rx(test_phy);
+	radio_switch_complete_and_b2b_rx(test_phy, test_phy_flags, test_phy, test_phy_flags);
 	radio_tmr_start(0, cntr_cnt_get() + CNTR_MIN_DELTA, 0);
 
 #if defined(HAL_RADIO_GPIO_HAVE_LNA_PIN)


### PR DESCRIPTION
This PR introduces Back-to-Back Radio Rx interface and aligns the Direct Test Mode to use it.
This solves the issue on the nRF53 when it was able to receive only one radio Rx packet and it didn't switch to next Rx again.
This changes were tested on nRF53 and nRF52 with the Anritsu tester.