### PR TITLE
Bluetooth: gatt: Add support for automatic ATT MTU Exchange

### DIFF
--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1231,6 +1231,7 @@ struct bt_gatt_exchange_params {
  *  Allow a pending request to resolve before retrying, or call this function
  *  outside the BT RX thread to get blocking behavior. Queue size is controlled
  *  by @kconfig{CONFIG_BT_L2CAP_TX_BUF_COUNT}.
+ *  @retval -EALREADY The MTU exchange request has been already sent.
  */
 int bt_gatt_exchange_mtu(struct bt_conn *conn,
 			 struct bt_gatt_exchange_params *params);

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -1231,7 +1231,8 @@ struct bt_gatt_exchange_params {
  *  Allow a pending request to resolve before retrying, or call this function
  *  outside the BT RX thread to get blocking behavior. Queue size is controlled
  *  by @kconfig{CONFIG_BT_L2CAP_TX_BUF_COUNT}.
- *  @retval -EALREADY The MTU exchange request has been already sent.
+ *
+ *  @retval -EALREADY The MTU exchange procedure has been already performed.
  */
 int bt_gatt_exchange_mtu(struct bt_conn *conn,
 			 struct bt_gatt_exchange_params *params);

--- a/subsys/bluetooth/audio/Kconfig.baps
+++ b/subsys/bluetooth/audio/Kconfig.baps
@@ -32,6 +32,7 @@ config BT_AUDIO_UNICAST_CLIENT
 	select BT_CENTRAL
 	select BT_GATT_CLIENT
 	select BT_GATT_AUTO_DISCOVER_CCC
+	select BT_GATT_AUTO_UPDATE_MTU
 	help
 	  This option enables support for Bluetooth Unicast Audio Client
 	  using Isochronous channels.

--- a/subsys/bluetooth/audio/Kconfig.bass
+++ b/subsys/bluetooth/audio/Kconfig.bass
@@ -65,6 +65,7 @@ config BT_BASS_CLIENT
 	select BT_ISO_SYNC_RECEIVER
 	select BT_GATT_CLIENT
 	select BT_GATT_AUTO_DISCOVER_CCC
+	select BT_GATT_AUTO_UPDATE_MTU
 	help
 	  This option enables support for the Broadcast Audio Scan Service
 	  client.

--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -141,6 +141,13 @@ config BT_GATT_AUTO_DISCOVER_CCC
 	  This option enables support for GATT to initiate discovery for CCC
 	  handles if the CCC handle is unknown by the application.
 
+config BT_GATT_AUTO_UPDATE_MTU
+	bool "Automatically send ATT MTU exchange request on connect"
+	depends on BT_GATT_CLIENT
+	help
+	  This option if enabled allows automatically sending request for ATT
+	  MTU exchange.
+
 config BT_GAP_AUTO_UPDATE_CONN_PARAMS
 	bool "Automatic Update of Connection Parameters"
 	default y

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -563,6 +563,16 @@ static uint8_t att_mtu_req(struct bt_att_chan *chan, struct net_buf *buf)
 
 	BT_DBG("Negotiated MTU %u", chan->chan.rx.mtu);
 
+#if defined(CONFIG_BT_GATT_CLIENT)
+	/* Mark the MTU Exchange as complete.
+	 * This will skip sending ATT Exchange MTU from our side.
+	 *
+	 * Core 5.3 | Vol 3, Part F 3.4.2.2:
+	 * If MTU is exchanged in one direction, that is sufficient for both directions.
+	 */
+	atomic_set_bit(conn->flags, BT_CONN_ATT_MTU_EXCHANGED);
+#endif /* CONFIG_BT_GATT_CLIENT */
+
 	att_chan_mtu_updated(chan);
 
 	return 0;

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -36,6 +36,9 @@ enum {
 	BT_CONN_PERIPHERAL_PARAM_SET,	/* If periph param were set from app */
 	BT_CONN_PERIPHERAL_PARAM_L2CAP,	/* If should force L2CAP for CPUP */
 	BT_CONN_FORCE_PAIR,             /* Pairing even with existing keys. */
+#if defined(CONFIG_BT_GATT_CLIENT)
+	BT_CONN_ATT_MTU_EXCHANGED,	/* If ATT MTU has been exchanged. */
+#endif /* CONFIG_BT_GATT_CLIENT */
 
 	BT_CONN_AUTO_FEATURE_EXCH,	/* Auto-initiated LE Feat done */
 	BT_CONN_AUTO_VERSION_INFO,      /* Auto-initiated LE version done */

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4908,6 +4908,20 @@ static void add_subscriptions(struct bt_conn *conn)
 		}
 	}
 }
+
+#if defined(CONFIG_BT_GATT_AUTO_UPDATE_MTU)
+static void gatt_exchange_mtu_func(struct bt_conn *conn, uint8_t err,
+				   struct bt_gatt_exchange_params *params)
+{
+	if (err) {
+		BT_WARN("conn %p err 0x%02x", conn, err);
+	}
+}
+
+static struct bt_gatt_exchange_params gatt_exchange_params = {
+	.func = gatt_exchange_mtu_func,
+};
+#endif /* CONFIG_BT_GATT_AUTO_UPDATE_MTU */
 #endif /* CONFIG_BT_GATT_CLIENT */
 
 #define CCC_STORE_MAX 48
@@ -5170,7 +5184,14 @@ void bt_gatt_connected(struct bt_conn *conn)
 
 #if defined(CONFIG_BT_GATT_CLIENT)
 	add_subscriptions(conn);
+#if defined(CONFIG_BT_GATT_AUTO_UPDATE_MTU)
+	int err;
 
+	err = bt_gatt_exchange_mtu(conn, &gatt_exchange_params);
+	if (err) {
+		BT_WARN("MTU Exchange failed (err %d)", err);
+	}
+#endif /* CONFIG_BT_GATT_AUTO_UPDATE_MTU */
 #endif /* CONFIG_BT_GATT_CLIENT */
 }
 

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -86,7 +86,9 @@ static void exchange_func(struct bt_conn *conn, uint8_t err,
 	(void)memset(params, 0, sizeof(*params));
 }
 
-static struct bt_gatt_exchange_params exchange_params;
+static struct bt_gatt_exchange_params exchange_params = {
+	.func = exchange_func,
+};
 
 static int cmd_exchange_mtu(const struct shell *sh,
 			     size_t argc, char *argv[])
@@ -98,15 +100,10 @@ static int cmd_exchange_mtu(const struct shell *sh,
 		return -ENOEXEC;
 	}
 
-	if (exchange_params.func) {
-		shell_print(sh, "MTU Exchange ongoing");
-		return -ENOEXEC;
-	}
-
-	exchange_params.func = exchange_func;
-
 	err = bt_gatt_exchange_mtu(default_conn, &exchange_params);
-	if (err) {
+	if (err == -EALREADY) {
+		shell_print(sh, "Already exchanged");
+	} else if (err) {
 		shell_print(sh, "Exchange failed (err %d)", err);
 	} else {
 		shell_print(sh, "Exchange pending");

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -21,7 +21,6 @@ static struct bt_mics *mics;
 static struct bt_mics_included mics_included;
 static volatile bool g_bt_init;
 static volatile bool g_is_connected;
-static volatile bool g_mtu_exchanged;
 static volatile bool g_discovery_complete;
 static volatile bool g_write_complete;
 
@@ -182,17 +181,6 @@ static struct bt_mics_cb mics_cbs = {
 		.set_auto_mode = aics_write_cb,
 	}
 };
-
-static void mtu_cb(struct bt_conn *conn, uint8_t err,
-		   struct bt_gatt_exchange_params *params)
-{
-	if (err != 0) {
-		FAIL("Failed to exchange MTU (%u)\n", err);
-		return;
-	}
-
-	g_mtu_exchanged = true;
-}
 
 static void connected(struct bt_conn *conn, uint8_t err)
 {
@@ -379,7 +367,6 @@ static void test_main(void)
 {
 	int err;
 	uint8_t expected_mute;
-	static struct bt_gatt_exchange_params mtu_params = { .func = mtu_cb };
 	struct bt_conn *cached_conn;
 
 	err = bt_enable(bt_ready);
@@ -400,12 +387,6 @@ static void test_main(void)
 	}
 	printk("Scanning successfully started\n");
 	WAIT_FOR(g_is_connected);
-
-	err = bt_gatt_exchange_mtu(default_conn, &mtu_params);
-	if (err != 0) {
-		FAIL("Failed to exchange MTU %d", err);
-	}
-	WAIT_FOR(g_mtu_exchanged);
 
 	err = bt_mics_discover(default_conn, &mics);
 	if (err != 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -21,7 +21,6 @@ static struct bt_vcs *vcs;
 static struct bt_vcs_included vcs_included;
 static volatile bool g_bt_init;
 static volatile bool g_is_connected;
-static volatile bool g_mtu_exchanged;
 static volatile bool g_discovery_complete;
 static volatile bool g_write_complete;
 
@@ -256,17 +255,6 @@ static struct bt_vcs_cb vcs_cbs = {
 		.set_auto_mode = aics_write_cb,
 	}
 };
-
-static void mtu_cb(struct bt_conn *conn, uint8_t err,
-		   struct bt_gatt_exchange_params *params)
-{
-	if (err) {
-		FAIL("Failed to exchange MTU (%u)\n", err);
-		return;
-	}
-
-	g_mtu_exchanged = true;
-}
 
 static void connected(struct bt_conn *conn, uint8_t err)
 {
@@ -547,9 +535,6 @@ static void test_main(void)
 	uint8_t expected_volume;
 	uint8_t previous_volume;
 	uint8_t expected_mute;
-	static struct bt_gatt_exchange_params mtu_params =  {
-		.func = mtu_cb,
-	};
 	struct bt_conn *cached_conn;
 
 	err = bt_enable(bt_ready);
@@ -576,13 +561,6 @@ static void test_main(void)
 	printk("Scanning successfully started\n");
 
 	WAIT_FOR(g_is_connected);
-
-	err = bt_gatt_exchange_mtu(default_conn, &mtu_params);
-	if (err) {
-		FAIL("Failed to exchange MTU %d", err);
-	}
-
-	WAIT_FOR(g_mtu_exchanged);
 
 	err = bt_vcs_discover(default_conn, &vcs);
 	if (err) {


### PR DESCRIPTION
This adds support for automatic ATT MTU Exchange that will be done right after the connection has been established.
This ensures the ATT MTU Exchange request will not be sent more than once. As the improvement the code follows Core 5.3 recommendation to skip MTU Exchange procedure if already performed by peer.

Fixes: #43946