### PR TITLE
mgmt: mcumgr: lib: smp: Fix checking variable before set

### DIFF
--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -263,7 +263,8 @@ smp_process_request_packet(struct smp_streamer *streamer, void *req)
 	struct mgmt_hdr req_hdr;
 	struct mgmt_evt_op_cmd_done_arg cmd_done_arg;
 	void *rsp;
-	bool valid_hdr, handler_found;
+	bool valid_hdr = false;
+	bool handler_found = false;
 	int rc = 0;
 	const char *rsn = NULL;
 


### PR DESCRIPTION
Fixes a twister test issue whereby handler_found and valid_hdr variables
are checked prior to being set.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44072