### PR TITLE
mgmt: mcumgr: lib: fs: Add file read/write access callback

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -210,6 +210,9 @@ Libraries / Subsystems
 
   * Added mcumgr os hook to allow an application to accept or decline a reset
     request; :kconfig:option:`CONFIG_OS_MGMT_RESET_HOOK` enables the callback.
+  * Added mcumgr fs hook to allow an application to accept or decline a file
+    read/write request; :kconfig:option:`CONFIG_FS_MGMT_FILE_ACCESS_HOOK`
+    enables the feature which then needs to be registered by the application.
 
 HALs
 ****

--- a/doc/services/device_mgmt/smp_groups/smp_group_8.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_8.rst
@@ -37,6 +37,14 @@ belonging to specified download session. This means that the file is not
 locked in any way or exclusively owned by mcumgr, for the time of download
 session, and may change between requests or even be removed.
 
+.. note::
+    By default, all file upload requests are unconditionally allowed. However,
+    if the Kconfig option :kconfig:option:`FS_MGMT_FILE_ACCESS_HOOK` is enabled,
+    then an application can register a callback handler for ``fs_mgmt_on_evt_cb``
+    by calling ``fs_mgmt_register_evt_cb()`` with the handler supplied. This can
+    be used to allow or decline access to reading from or writing to a
+    particular file, or for rewriting the path supplied by the client.
+
 File download request
 =====================
 
@@ -143,6 +151,14 @@ session, and may change between requests or even be removed.
     single upload context, holding information on ongoing upload, that consists
     of bool flag indicating in-progress upload, last successfully uploaded offset
     and total length only.
+
+.. note::
+    By default, all file upload requests are unconditionally allowed. However,
+    if the Kconfig option :kconfig:option:`FS_MGMT_FILE_ACCESS_HOOK` is enabled,
+    then an application can register a callback handler for ``fs_mgmt_on_evt_cb``
+    by calling ``fs_mgmt_register_evt_cb()`` with the handler supplied. This can
+    be used to allow or decline access to reading from or writing to a
+    particular file, or for rewriting the path supplied by the client.
 
 File upload request
 ===================

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/Kconfig
@@ -136,4 +136,14 @@ config FS_MGMT_PATH_SIZE
 	  of this size gets allocated on the stack during handling of file upload
 	  and download commands.
 
+config FS_MGMT_FILE_ACCESS_HOOK
+	bool "File read/write access hook"
+	help
+	  Allows applications to control file read and write access by
+	  registering for a callback which is then triggered whenever a file
+	  read or write attempt is made. This also, optionally, allows
+	  re-writing or changing of supplied file paths.
+	  Note that this will be called multiple times for each file read and
+	  write due to mcumgr's method of stateless operation.
+
 endif

--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/include/fs_mgmt/fs_mgmt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2022 mcumgr authors
+ * Copyright (c) 2022 Laird Connectivity
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,10 +19,37 @@ extern "C" {
 #define FS_MGMT_ID_STAT			 1
 #define FS_MGMT_ID_HASH_CHECKSUM	 2
 
+#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
+/** @typedef fs_mgmt_on_evt_cb
+ * @brief Function to be called on fs mgmt event.
+ *
+ * This callback function is used to notify the application about a pending file
+ * read/write request and to authorise or deny it.
+ *
+ * @param write		True if write access is requested, false for read access
+ * @param path		The path of the file to query.
+ *
+ * @note That the path can potentially be changed by the application code so
+ *	 long as it does not exceed the maximum path string size.
+ *
+ * @return 0 to allow read/write, MGMT_ERR_[...] code to disallow read/write.
+ */
+typedef int (*fs_mgmt_on_evt_cb)(bool write, char *path);
+#endif
+
 /**
  * @brief Registers the file system management command handler group.
  */
 void fs_mgmt_register_group(void);
+
+#ifdef CONFIG_FS_MGMT_FILE_ACCESS_HOOK
+/**
+ * @brief Register file read/write access event callback function.
+ *
+ * @param cb Callback function or NULL to disable.
+ */
+void fs_mgmt_register_evt_cb(fs_mgmt_on_evt_cb cb);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Adds a hook that applications can register for and then use to receive callbacks that can grant or deny access requests to files via the fs mcumgr system.

    doc: release-notes: Add mcumgr file read/write request hook details
    
    Adds the file read/write request hook that applications can use to allow
    or decline requests to files to the release notes.
    
    doc: guides: device_mgmt: smp: fs: Add fs hook details
    
    Adds details about the file read/write request hook that applications
    can use to allow or decline requests to files.
    
    mgmt: mcumgr: lib: fs: Add file read/write access callback
    
    This allows an application to inspect a mcumgr file access command and
    either allow it or deny it with a result code.