### PR TITLE
sys: util: Change return type of ARRAY_SIZE to size_t

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -106,7 +106,7 @@ extern "C" {
  * In C, passing a pointer as @p array causes a compile error.
  */
 #define ARRAY_SIZE(array) \
-	((long) (IS_ARRAY(array) + (sizeof(array) / sizeof((array)[0]))))
+	((size_t) (IS_ARRAY(array) + (sizeof(array) / sizeof((array)[0]))))
 
 #endif /* __cplusplus */
 

--- a/subsys/bluetooth/host/hfp_hf.c
+++ b/subsys/bluetooth/host/hfp_hf.c
@@ -230,7 +230,7 @@ void ag_indicator_handle_values(struct at_client *hf_at, uint32_t index,
 	BT_DBG("Index :%u, Value :%u", index, value);
 
 	if (index >= ARRAY_SIZE(ag_ind)) {
-		BT_ERR("Max only %lu indicators are supported",
+		BT_ERR("Max only %zu indicators are supported",
 		       ARRAY_SIZE(ag_ind));
 		return;
 	}

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -1826,7 +1826,7 @@ static int cmd_per_adv_sync_delete(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= ARRAY_SIZE(per_adv_syncs)) {
-		shell_error(sh, "Maximum index is %ld but %d was requested",
+		shell_error(sh, "Maximum index is %zu but %d was requested",
 			    ARRAY_SIZE(per_adv_syncs) - 1, index);
 	}
 
@@ -1963,7 +1963,7 @@ static int cmd_per_adv_sync_transfer(const struct shell *sh, size_t argc,
 	}
 
 	if (index >= ARRAY_SIZE(per_adv_syncs)) {
-		shell_error(sh, "Maximum index is %ld but %d was requested",
+		shell_error(sh, "Maximum index is %zu but %d was requested",
 			    ARRAY_SIZE(per_adv_syncs) - 1, index);
 	}
 

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -329,7 +329,7 @@ static int cmd_mread(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if ((argc - 1) >  ARRAY_SIZE(h)) {
-		shell_print(sh, "Enter max %lu handle items to read",
+		shell_print(sh, "Enter max %zu handle items to read",
 			    ARRAY_SIZE(h));
 		return -EINVAL;
 	}

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -2795,7 +2795,7 @@ static void iface_ipv6_init(int if_count)
 	k_work_init_delayable(&prefix_lifetime_timer, prefix_lifetime_timeout);
 
 	if (if_count > ARRAY_SIZE(ipv6_addresses)) {
-		NET_WARN("You have %lu IPv6 net_if addresses but %d "
+		NET_WARN("You have %zu IPv6 net_if addresses but %d "
 			 "network interfaces", ARRAY_SIZE(ipv6_addresses),
 			 if_count);
 		NET_WARN("Consider increasing CONFIG_NET_IF_MAX_IPV6_COUNT "
@@ -3791,7 +3791,7 @@ static void iface_ipv4_init(int if_count)
 	int i;
 
 	if (if_count > ARRAY_SIZE(ipv4_addresses)) {
-		NET_WARN("You have %lu IPv4 net_if addresses but %d "
+		NET_WARN("You have %zu IPv4 net_if addresses but %d "
 			 "network interfaces", ARRAY_SIZE(ipv4_addresses),
 			 if_count);
 		NET_WARN("Consider increasing CONFIG_NET_IF_MAX_IPV4_COUNT "

--- a/subsys/net/lib/sockets/sockets_can.c
+++ b/subsys/net/lib/sockets/sockets_can.c
@@ -542,7 +542,7 @@ static int can_register_receiver(struct net_if *iface, struct net_context *ctx,
 {
 	int i;
 
-	NET_DBG("Max %lu receivers", ARRAY_SIZE(receivers));
+	NET_DBG("Max %zu receivers", ARRAY_SIZE(receivers));
 
 	for (i = 0; i < ARRAY_SIZE(receivers); i++) {
 		if (receivers[i].ctx != NULL) {

--- a/tests/boards/intel_s1000_crb/main/src/dma_test.c
+++ b/tests/boards/intel_s1000_crb/main/src/dma_test.c
@@ -133,7 +133,7 @@ static int test_task(uint32_t chan_id, uint32_t blen, uint32_t block_count)
 	};
 
 	if (block_count > ARRAY_SIZE(transfer_blocks)) {
-		printk("block_count %u is greater than %ld\n", block_count,
+		printk("block_count %u is greater than %zu\n", block_count,
 			ARRAY_SIZE(transfer_blocks));
 		return -1;
 	}

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1922,7 +1922,7 @@ static void test_dep_ord(void)
 	};
 	zassert_equal(ARRAY_SIZE(children_combined_ords),
 		      ARRAY_SIZE(children_combined_ords_expected),
-		      "%u", ARRAY_SIZE(children_combined_ords));
+		      "%zu", ARRAY_SIZE(children_combined_ords));
 	for (i = 0; i < ARRAY_SIZE(children_combined_ords); i++) {
 		zassert_equal(children_combined_ords[i],
 			      children_combined_ords_expected[i],
@@ -1949,7 +1949,7 @@ static void test_dep_ord(void)
 	};
 	zassert_equal(ARRAY_SIZE(child_a_combined_ords),
 		      ARRAY_SIZE(child_a_combined_ords_expected),
-		      "%u", ARRAY_SIZE(child_a_combined_ords));
+		      "%zu", ARRAY_SIZE(child_a_combined_ords));
 	for (i = 0; i < ARRAY_SIZE(child_a_combined_ords); i++) {
 		zassert_equal(child_a_combined_ords[i],
 			      child_a_combined_ords_expected[i],

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -368,17 +368,17 @@ static void test_virtual_setup(void)
 
 	zassert_equal(ud.virtual_if_count, ARRAY_SIZE(virtual_interfaces),
 		      "Invalid number of virtual interfaces, "
-		      "was %d should be %d",
+		      "was %d should be %zu",
 		      ud.virtual_if_count, ARRAY_SIZE(virtual_interfaces));
 
 	zassert_true(ud.eth_if_count <= ARRAY_SIZE(eth_interfaces),
 		      "Invalid number of eth interfaces, "
-		      "was %d should be %d",
+		      "was %d should be %zu",
 		      ud.eth_if_count, ARRAY_SIZE(eth_interfaces));
 
 	zassert_equal(ud.dummy_if_count, ARRAY_SIZE(dummy_interfaces),
 		      "Invalid number of dummy interfaces, "
-		      "was %d should be %d",
+		      "was %d should be %zu",
 		      ud.dummy_if_count, ARRAY_SIZE(dummy_interfaces));
 }
 

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -337,7 +337,7 @@ static void test_FOR_EACH_IDX(void)
 		FOR_EACH_IDX(FOR_EACH_IDX_MACRO_TEST3, (,), 1, 2, 3)
 	};
 
-	zassert_equal(ARRAY_SIZE(a), 3, "Unexpected value:%d", ARRAY_SIZE(a));
+	zassert_equal(ARRAY_SIZE(a), 3, "Unexpected value:%zu", ARRAY_SIZE(a));
 }
 
 static void test_FOR_EACH_IDX_FIXED_ARG(void)


### PR DESCRIPTION
The ARRAY_SIZE macro uses sizeof and thus the return
type should be an unsigned value. size_t is typically
the type used for sizeof and fits well for the
ARRAY_SIZE macro as well.

It was (incorrectly) changed to a signed value in https://github.com/zephyrproject-rtos/zephyr/pull/16561 