### PR TITLE
dts: nordic: nrf9160: Add IPC node

### DIFF
--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -79,6 +79,14 @@ egu5: egu@20000 {
 	status = "okay";
 };
 
+ipc: ipc@2a000 {
+	compatible = "nordic,nrf-ipc";
+	reg = <0x2a000 0x1000>;
+	interrupts = <42 NRF_DEFAULT_IRQ_PRIORITY>;
+	status = "okay";
+	label = "IPC";
+};
+
 i2s0: i2s@28000 {
 	compatible = "nordic,nrf-i2s";
 	#address-cells = <1>;


### PR DESCRIPTION
Add devicetree node for IPC driver so that the IPC interrupt properties
can be accessed with device tree interrupt property macros and
configured using devicetree overlays.

Signed-off-by: Eivind Jølsgard <eivind.jolsgard@nordicsemi.no>