### PR TITLE
random: rand32_ctr_drbg: fix bug preventing initialization

### DIFF
--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -28,7 +28,11 @@
 
 static K_SEM_DEFINE(state_sem, 1, 1);
 
-static const struct device *entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+/*
+ * entropy_dev is initialized at runtime to allow first time initialization
+ * of the ctr_drbg engine.
+ */
+static const struct device *entropy_dev;
 static const unsigned char drbg_seed[] = CONFIG_CS_CTR_DRBG_PERSONALIZATION;
 
 #if defined(CONFIG_MBEDTLS)
@@ -50,6 +54,8 @@ static TCCtrPrng_t ctr_ctx;
 static int ctr_drbg_initialize(void)
 {
 	int ret;
+
+	entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 	if (!device_is_ready(entropy_dev)) {
 		__ASSERT(0, "Entropy device %s not ready", entropy_dev->name);


### PR DESCRIPTION
Bug introduced that prevented the logic from initializing the
context structure. Without this initialization, the application
will crash on repeated request for ctr_drbg random data.

Fixes: #44092
Fixes: #43792
Fixes: #43841
Fixes: #43842

Signed-off-by: David Leach <david.leach@nxp.com>