### PR TITLE
ci: twister: Run `west config` after workspace initialisation

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -65,8 +65,8 @@ jobs:
           rm -fr ".git/rebase-apply"
           git rebase origin/${BASE_REF}
           git log  --pretty=oneline | head -n 10
-          west config manifest.group-filter -- +ci
           west init -l . || true
+          west config manifest.group-filter -- +ci
           # no need for west update here
 
       - name: Generate Test Plan with Twister


### PR DESCRIPTION
The twister workflow was invoking `west config`, which requires a west
workspace to be set up, prior to initialising the workspace via
`west init`.

This commit relocates the `west config` to be run after the workspace
initialisation.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>