### PR TITLE
drivers: intc: intc_cavs: use correct per-core register set for all ops

### DIFF
--- a/drivers/interrupt_controller/intc_cavs.c
+++ b/drivers/interrupt_controller/intc_cavs.c
@@ -60,8 +60,7 @@ static void cavs_ictl_isr(const struct device *port)
 
 	const struct cavs_ictl_config *config = port->config;
 
-	volatile struct cavs_registers * const regs =
-					get_base_address(context);
+	volatile struct cavs_registers * const regs =  get_base_address(context);
 
 	cavs_ictl_dispatch_child_isrs(regs->status_il,
 				      config->isr_table_offset);
@@ -72,8 +71,7 @@ static void cavs_ictl_irq_enable(const struct device *dev,
 {
 	struct cavs_ictl_runtime *context = dev->data;
 
-	volatile struct cavs_registers * const regs =
-			(struct cavs_registers *)context->base_addr;
+	volatile struct cavs_registers * const regs = get_base_address(context);
 
 	regs->enable_il = 1 << irq;
 }
@@ -83,8 +81,7 @@ static void cavs_ictl_irq_disable(const struct device *dev,
 {
 	struct cavs_ictl_runtime *context = dev->data;
 
-	volatile struct cavs_registers * const regs =
-			(struct cavs_registers *)context->base_addr;
+	volatile struct cavs_registers * const regs = get_base_address(context);
 
 	regs->disable_il = 1 << irq;
 }
@@ -93,8 +90,7 @@ static unsigned int cavs_ictl_irq_get_state(const struct device *dev)
 {
 	struct cavs_ictl_runtime *context = dev->data;
 
-	volatile struct cavs_registers * const regs =
-			(struct cavs_registers *)context->base_addr;
+	volatile struct cavs_registers * const regs = get_base_address(context);
 
 	/* When the bits of this register are set, it means the
 	 * corresponding interrupts are disabled. This function
@@ -108,8 +104,7 @@ static int cavs_ictl_irq_get_line_state(const struct device *dev,
 {
 	struct cavs_ictl_runtime *context = dev->data;
 
-	volatile struct cavs_registers * const regs =
-			(struct cavs_registers *)context->base_addr;
+	volatile struct cavs_registers * const regs = get_base_address(context);
 
 	if ((regs->disable_state_il & BIT(irq)) == 0) {
 		return 1;
@@ -130,7 +125,7 @@ static const struct irq_next_level_api cavs_apis = {
 	{								\
 		struct cavs_ictl_runtime *context = port->data;		\
 		volatile struct cavs_registers * const regs =		\
-			(struct cavs_registers *)context->base_addr;	\
+			get_base_address(context);			\
 		regs->disable_il = ~0;					\
 									\
 		return 0;						\


### PR DESCRIPTION
Current code uses per-core register to check interrupt status and
dispatch handlers. However to disable/enable the interrupt, core
zero register is always used.

While the handlers in _sw_isr_table are common for all cores,
the status bits should still be handled separate for each core.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>