### PR TITLE
boards: arm: nucleo_f030r8: Add support for MB1136 C-01 board version

### DIFF
--- a/boards/arm/nucleo_f030r8/doc/index.rst
+++ b/boards/arm/nucleo_f030r8/doc/index.rst
@@ -139,6 +139,8 @@ Applications for the ``nucleo_f030r8`` board configuration can be built and
 flashed in the usual way (see :ref:`build_an_application` and
 :ref:`application_run` for more details).
 
+.. _nucleo-f030r8-flashing:
+
 Flashing
 ========
 
@@ -157,6 +159,13 @@ Here is an example for the :ref:`blinky-sample` application.
 
 You will see the LED blinking every second.
 
+If using the C-01 board, select revision '1' that supports the board.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f030r8@1
+   :goals: build flash
+
 Debugging
 =========
 
@@ -168,6 +177,28 @@ You can debug an application in the usual way.  Here is an example for the
    :board: nucleo_f030r8
    :maybe-skip-config:
    :goals: debug
+
+Again you have to use the adapted command for C-01.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/basic/blinky
+   :board: nucleo_f030r8@1
+   :maybe-skip-config:
+   :goals: debug
+
+Board Revisions
+***************
+
+Nucleo F030R8 has some version of board variants.
+`STM32 Nucleo-64 board User Manual`_ mentions to Nucleo board variants.
+
+   | *The board version MB1136 C-01 or MB1136 C-02 is mentioned on the sticker, placed on the bottom side of the PCB.*
+   | *The board marking MB1136 C-01 corresponds to a board, configured as HSE not used.*
+   | *The board marking MB1136 C-02 (or higher) corresponds to a board, configured to use ST-LINK MCO as the clock input.*
+
+Using revision **2** adapted for C-02(or higher) as default when not explicitly selecting revisions.
+If using the C-01 board, select revision **1**.
+Please see :ref:`Flashing <nucleo-f030r8-flashing>` section.
 
 References
 **********

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8_1.conf
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8_1.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8_1.overlay
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8_1.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&clk_hse {
+	status = "disabled";
+};
+
+&clk_hsi {
+	status = "okay";
+};
+
+&pll {
+	prediv = <2>;
+	mul = <12>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8_2.conf
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8_2.conf
@@ -1,0 +1,2 @@
+# Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+# SPDX-License-Identifier: Apache-2.0

--- a/boards/arm/nucleo_f030r8/revision.cmake
+++ b/boards/arm/nucleo_f030r8/revision.cmake
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+board_check_revision(FORMAT NUMBER
+		     DEFAULT_REVISION 2)


### PR DESCRIPTION
nucleo_f030r8 configuration is not supporting the C-01 board version.
Adding nucleo_f030r8_ver_c01 configuration to support the board variant.

Nucleo F030R8 (and some Nucleo boards) has some version of board variants.
This document mentions to Nucleo board variants.
https://www.st.com/resource/en/user_manual/um1724-stm32-nucleo64-boards-mb1136-stmicroelectronics.pdf

```
The board marking MB1136 C-01 corresponds to a board, configured as HSE not used.
The board marking MB1136 C-02 (or higher) corresponds to a board, configured to use ST-LINK MCO as the clock input.
```

This patch verified with my Nucleo F030R8 (C-01) board.
(samples/basic/blinky work correctly.)

- - -

By the way, Many Nucleo series are using same board.
Some Nucleo boards potentially have the same problem, I think.

Please let me know your opinions.