### PR TITLE
mgmt: mcumgr: lib: os: Add reset callback

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -208,6 +208,9 @@ Libraries / Subsystems
       * When hash/checksum query to mcumgr does not specify a type, then the order
         of preference (most priority) is CRC32 followed by SHA256.
 
+  * Added mcumgr os hook to allow an application to accept or decline a reset
+    request; :kconfig:option:`CONFIG_OS_MGMT_RESET_HOOK` enables the callback.
+
 HALs
 ****
 

--- a/doc/services/device_mgmt/smp_groups/smp_group_0.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_0.rst
@@ -408,8 +408,14 @@ where:
 System reset
 ************
 
-Performs reset of system. The device should issue response before resetting so that
-the SMP client could receive information that the command has been accepted.
+Performs reset of system. The device should issue response before resetting so
+that the SMP client could receive information that the command has been
+accepted. By default, this command is accepted in all conditions, however if the
+:kconfig:option:`CONFIG_OS_MGMT_RESET_HOOK` is enabled and an application
+registers a callback, the callback will be called when this command is issued
+and can be used to perform any necessary tidy operations prior to the module
+rebooting, or to reject the reset request outright altogether with an error
+response.
 
 System reset request
 ====================

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
@@ -17,6 +17,17 @@ config OS_MGMT_RESET_MS
 	  before performing the reset.  This delay allows time for the mcumgr
 	  response to be delivered.
 
+config OS_MGMT_RESET_HOOK
+	bool "Reset hook"
+	help
+	  Allows applications to control and get notifications of when a reset
+	  command has been issued via an mcumgr command. With this option
+	  disabled, modules will reboot when the command is received without
+	  notification, when this is enabled and a handler is registered, the
+	  application will be notified that a reset command has been received
+	  and will allow the application to perform any required operations
+	  before accepting or declining the reset request.
+
 config OS_MGMT_TASKSTAT
 	bool "Support for taskstat command"
 	depends on THREAD_MONITOR

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Laird Connectivity
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,10 +23,31 @@ extern "C" {
 #define OS_MGMT_ID_RESET		5
 #define OS_MGMT_ID_MCUMGR_PARAMS	6
 
+#ifdef CONFIG_OS_MGMT_RESET_HOOK
+/** @typedef os_mgmt_on_reset_evt_cb
+ * @brief Function to be called on os mgmt reset event.
+ *
+ * This callback function is used to notify the application about a pending
+ * reset request and to authorise or deny it.
+ *
+ * @return 0 to allow reset, MGMT_ERR_[...] code to disallow reset.
+ */
+typedef int (*os_mgmt_on_reset_evt_cb)(void);
+#endif
+
 /**
  * @brief Registers the OS management command handler group.
  */
 void os_mgmt_register_group(void);
+
+#ifdef CONFIG_OS_MGMT_RESET_HOOK
+/**
+ * @brief Register os reset event callback function.
+ *
+ * @param cb Callback function or NULL to disable.
+ */
+void os_mgmt_register_reset_evt_cb(os_mgmt_on_reset_evt_cb cb);
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This adds an optional Kconfig option that, when enabled, allows applications to receive mcumgr os reset commands and decide if they should be accepted or declined, and allows them to tidy operations prior to the module rebooting.

    doc: release-notes: Add mcumgr os reset request hook details
    
    Adds the os reset request hook that applications can use to allow
    or decline requests to reboot the module to the release notes.
    
    doc: guides: device_mgmt: smp: os: Add os reset hook details
    
    Adds details about the os reset request hook that applications can use
    to allow or decline the request or tidy up.
    
    mgmt: mcumgr: lib: os: Add reset callback
    
    This allows an application to inspect a mcumgr os reset command and
    either allow it or deny it with a result code.