### PR TITLE
mgmt: mcumgr: lib: img: Add image header to callback

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -249,6 +249,11 @@ Libraries / Subsystems
   * Added mcumgr fs hook to allow an application to accept or decline a file
     read/write request; :kconfig:option:`CONFIG_FS_MGMT_FILE_ACCESS_HOOK`
     enables the feature which then needs to be registered by the application.
+  * Added supplied image header to mcumgr img upload callback parameter list
+    which allows the application to inspect it to determine if it should be
+    allowed or declined.
+  * Made the img mgmt ``img_mgmt_vercmp`` function public to allow application-
+    level comparison of image versions.
 
 * SD Subsystem
 

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -9,6 +9,7 @@
 
 #include <inttypes.h>
 #include "img_mgmt_config.h"
+#include "image.h"
 #include "mgmt/mgmt.h"
 #include <zcbor_common.h>
 
@@ -213,15 +214,14 @@ struct img_mgmt_dfu_callbacks_t {
  * proceeds.  If the callback returns nonzero, the request is rejected with a
  * response containing an `rc` value equal to the return code.
  *
- * @param offset	The offset specified by the incoming request.
- * @param size		The total size of the image being uploaded.
- * @param arg		Optional argument specified when the callback
- *			was configured.
+ * @param req		Image upload request structure
+ * @param action	Image upload action structure
  *
- * @return 0 if the upload request should be accepted; nonzero to reject the request with the
- *	   specified status.
+ * @return	0 if the upload request should be accepted; nonzero to reject
+ *		the request with the specified status.
  */
-typedef int (*img_mgmt_upload_fn)(uint32_t offset, uint32_t size, void *arg);
+typedef int (*img_mgmt_upload_fn)(const struct img_mgmt_upload_req req,
+				  const struct img_mgmt_upload_action action);
 
 /**
  * @brief Configures a callback that gets called whenever a valid image upload
@@ -233,14 +233,25 @@ typedef int (*img_mgmt_upload_fn)(uint32_t offset, uint32_t size, void *arg);
  * response containing an `rc` value equal to the return code.
  *
  * @param cb	The callback to execute on rx of an upload request.
- * @param arg	Optional argument that gets passed to the callback.
  */
-void img_mgmt_set_upload_cb(img_mgmt_upload_fn cb, void *arg);
+void img_mgmt_set_upload_cb(img_mgmt_upload_fn cb);
 void img_mgmt_register_callbacks(const struct img_mgmt_dfu_callbacks_t *cb_struct);
 void img_mgmt_dfu_stopped(void);
 void img_mgmt_dfu_started(void);
 void img_mgmt_dfu_pending(void);
 void img_mgmt_dfu_confirmed(void);
+
+/**
+ * Compares two image version numbers in a semver-compatible way.
+ *
+ * @param a	The first version to compare.
+ * @param b	The second version to compare.
+ *
+ * @return	-1 if a < b
+ * @return	0 if a = b
+ * @return	1 if a > b
+ */
+int img_mgmt_vercmp(const struct image_version *a, const struct image_version *b);
 
 #ifdef CONFIG_IMG_MGMT_VERBOSE_ERR
 #define IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, rsn) ((action)->rc_rsn = (rsn))

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -22,7 +22,6 @@
 #include "img_mgmt_priv.h"
 #include "img_mgmt/img_mgmt_config.h"
 
-static void *img_mgmt_upload_arg;
 static img_mgmt_upload_fn img_mgmt_upload_cb;
 
 const struct img_mgmt_dfu_callbacks_t *img_mgmt_dfu_callbacks_fn;
@@ -385,7 +384,8 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 	 * request.
 	 */
 	if (img_mgmt_upload_cb != NULL) {
-		rc = img_mgmt_upload_cb(req.off, action.size, img_mgmt_upload_arg);
+		rc = img_mgmt_upload_cb(req, action);
+
 		if (rc != 0) {
 			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(&action, img_mgmt_err_str_app_reject);
 			goto end;
@@ -515,10 +515,9 @@ img_mgmt_dfu_confirmed(void)
 }
 
 void
-img_mgmt_set_upload_cb(img_mgmt_upload_fn cb, void *arg)
+img_mgmt_set_upload_cb(img_mgmt_upload_fn cb)
 {
 	img_mgmt_upload_cb = cb;
-	img_mgmt_upload_arg = arg;
 }
 
 void

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -225,17 +225,7 @@ img_mgmt_get_unused_slot_area_id(int image)
 #error "Unsupported number of images"
 #endif
 
-/**
- * Compares two image version numbers in a semver-compatible way.
- *
- * @param a	The first version to compare.
- * @param b	The second version to compare.
- *
- * @return	-1 if a < b
- * @return	0 if a = b
- * @return	1 if a > b
- */
-static int
+int
 img_mgmt_vercmp(const struct image_version *a, const struct image_version *b)
 {
 	if (a->iv_major < b->iv_major) {


### PR DESCRIPTION
This adds support for passing the new image header back via the mcumgr img upload callback function so that an application can inspect the contents and make a decision if the image upload should be allowed or disallowed based upon the contents of the new image header. Additionally the image version command is no longer static, to allow the application to call it and perform version comparisons.

    doc: release-notes: Add mcumgr image header callback addition details
    
    Adds information on adding the image header details to the img mgmt
    callback for application-level determination of what to allow or
    decline.

    mgmt: mcumgr: lib: img: Add image header to callback
    
    This allows an application to inspect a mcumgr img upload command to
    provide additional information for acceptance or rejection of it, and
    makes the previous private version compare function public so that
    application code can call it.