### PR TITLE
drivers: display: ili9xxx: default based on DT compatible

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/Kconfig.defconfig
@@ -11,9 +11,6 @@ if DISPLAY
 config SPI
 	default y
 
-config ILI9340
-	default y
-
 if KSCAN
 
 config I2C

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/Kconfig.defconfig
@@ -8,9 +8,6 @@ if DISPLAY
 config SPI
 	default y
 
-config ILI9340
-	default y
-
 if KSCAN
 
 config I2C

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/Kconfig.defconfig
@@ -8,9 +8,6 @@ if DISPLAY
 config SPI
 	default y
 
-config ILI9488
-	default y
-
 if KSCAN
 
 config I2C

--- a/drivers/display/Kconfig.ili9xxx
+++ b/drivers/display/Kconfig.ili9xxx
@@ -10,23 +10,32 @@ config ILI9XXX
 	help
 	  Hidden configuration entry for all ILI9XXX drivers.
 
+DT_COMPAT_ILITEK_ILI9340 := ilitek,ili9340
+
 config ILI9340
 	bool "ILI9340 display driver"
 	depends on SPI
 	select ILI9XXX
+	default $(dt_compat_enabled,$(DT_COMPAT_ILITEK_ILI9340))
 	help
 	  Enable driver for ILI9340 display driver.
+
+DT_COMPAT_ILITEK_ILI9341 := ilitek,ili9341
 
 config ILI9341
 	bool "ILI9341 display driver"
 	depends on SPI
 	select ILI9XXX
+	default $(dt_compat_enabled,$(DT_COMPAT_ILITEK_ILI9341))
 	help
 	  Enable driver for ILI9341 display driver.
+
+DT_COMPAT_ILITEK_ILI9488 := ilitek,ili9488
 
 config ILI9488
 	bool "ILI9488 display driver"
 	depends on SPI
 	select ILI9XXX
+	default $(dt_compat_enabled,$(DT_COMPAT_ILITEK_ILI9488))
 	help
 	  Enable driver for ILI9488 display driver.


### PR DESCRIPTION
Enable the ILI9XXX display driver based on DT compatible status.