### PR TITLE
Bluetooth: ISO: Add seq_num and ts to bt_iso_chan_send

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -47,9 +47,9 @@ extern "C" {
 #define BT_ISO_DATA_PATH_HCI        0x00
 
 /** Minimum interval value in microseconds */
-#define BT_ISO_INTERVAL_MIN         0x0000FF
+#define BT_ISO_SDU_INTERVAL_MIN     0x0000FFU
 /** Maximum interval value in microseconds */
-#define BT_ISO_INTERVAL_MAX         0x0FFFFF
+#define BT_ISO_SDU_INTERVAL_MAX     0x0FFFFFU
 /** Minimum latency value in milliseconds */
 #define BT_ISO_LATENCY_MIN          0x0005
 /** Maximum latency value in milliseconds */
@@ -251,7 +251,7 @@ struct bt_iso_cig_param {
 
 	/** @brief Channel interval in us.
 	 *
-	 *  Value range BT_ISO_INTERVAL_MIN - BT_ISO_INTERVAL_MAX.
+	 *  Value range BT_ISO_SDU_INTERVAL_MIN - BT_ISO_SDU_INTERVAL_MAX.
 	 */
 	uint32_t interval;
 
@@ -308,7 +308,7 @@ struct bt_iso_big_create_param {
 
 	/** @brief Channel interval in us.
 	 *
-	 *  Value range BT_ISO_INTERVAL_MIN - BT_ISO_INTERVAL_MAX.
+	 *  Value range BT_ISO_SDU_INTERVAL_MIN - BT_ISO_SDU_INTERVAL_MAX.
 	 */
 	uint32_t interval;
 

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -86,6 +86,12 @@ extern "C" {
 #define BT_ISO_BIS_INDEX_MIN        0x01
 /** Highest BIS index */
 #define BT_ISO_BIS_INDEX_MAX        0x1F
+/** Omit time stamp when sending to controller
+ *
+ * Using this value will enqueue the ISO SDU in a FIFO manner, instead of
+ * transmitting it at a specified timestamp.
+ */
+#define BT_ISO_TIMESTAMP_NONE 0U
 
 /** @brief Life-span states of ISO channel. Used only by internal APIs
  *  dealing with setting channel to proper state depending on operational
@@ -629,10 +635,19 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  *
  *  @param chan Channel object.
  *  @param buf Buffer containing data to be sent.
+ *  @param sn  Packet Sequence number. This value shall be incremented for each
+ *             call to this function and at least once per SDU
+ *             interval for a specific channel.
+ *  @param ts  Timestamp of the SDU in microseconds (us).
+ *             This value can be used to transmit multiple
+ *             SDUs in the same SDU interval in a CIG or BIG. Can be omitted
+ *             by using @ref BT_ISO_TIMESTAMP_NONE which will simply enqueue
+ *             the ISO SDU in a FIFO manner.
  *
  *  @return Bytes sent in case of success or negative value in case of error.
  */
-int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf);
+int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
+		     uint32_t sn, uint32_t ts);
 
 struct bt_iso_unicast_tx_info {
 	/** The transport latency in us */

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -228,7 +228,7 @@ struct bt_iso_recv_info {
 	uint32_t ts;
 
 	/** ISO packet sequence number of the first fragment in the SDU */
-	uint16_t sn;
+	uint16_t seq_num;
 
 	/** ISO packet flags bitfield (BT_ISO_FLAGS_*) */
 	uint8_t flags;
@@ -633,21 +633,21 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  *  @note Buffer ownership is transferred to the stack in case of success, in
  *  case of an error the caller retains the ownership of the buffer.
  *
- *  @param chan Channel object.
- *  @param buf Buffer containing data to be sent.
- *  @param sn  Packet Sequence number. This value shall be incremented for each
- *             call to this function and at least once per SDU
- *             interval for a specific channel.
- *  @param ts  Timestamp of the SDU in microseconds (us).
- *             This value can be used to transmit multiple
- *             SDUs in the same SDU interval in a CIG or BIG. Can be omitted
- *             by using @ref BT_ISO_TIMESTAMP_NONE which will simply enqueue
- *             the ISO SDU in a FIFO manner.
+ *  @param chan     Channel object.
+ *  @param buf      Buffer containing data to be sent.
+ *  @param seq_num  Packet Sequence number. This value shall be incremented for
+ *                  each call to this function and at least once per SDU
+ *                  interval for a specific channel.
+ *  @param ts       Timestamp of the SDU in microseconds (us).
+ *                  This value can be used to transmit multiple
+ *                  SDUs in the same SDU interval in a CIG or BIG. Can be
+ *                  omitted by using @ref BT_ISO_TIMESTAMP_NONE which will
+ *                  simply enqueue the ISO SDU in a FIFO manner.
  *
  *  @return Bytes sent in case of success or negative value in case of error.
  */
 int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
-		     uint32_t sn, uint32_t ts);
+		     uint32_t seq_num, uint32_t ts);
 
 struct bt_iso_unicast_tx_info {
 	/** The transport latency in us */

--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -23,7 +23,7 @@ static void start_scan(void);
 static struct bt_conn *default_conn;
 static struct k_work_delayable iso_send_work;
 static struct bt_iso_chan iso_chan;
-static uint32_t sn;
+static uint32_t seq_num;
 static uint32_t interval_us = 10U * USEC_PER_MSEC; /* 10 ms */
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8,
 			  NULL);
@@ -62,7 +62,7 @@ static void iso_timer_timeout(struct k_work *work)
 
 	net_buf_add_mem(buf, buf_data, len_to_send);
 
-	ret = bt_iso_chan_send(&iso_chan, buf, sn++, BT_ISO_TIMESTAMP_NONE);
+	ret = bt_iso_chan_send(&iso_chan, buf, seq_num++, BT_ISO_TIMESTAMP_NONE);
 
 	if (ret < 0) {
 		printk("Failed to send ISO data (%d)\n", ret);
@@ -130,7 +130,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 {
 	printk("ISO Channel %p connected\n", chan);
 
-	sn = 0U;
+	seq_num = 0U;
 
 	/* Start send timer */
 	k_work_schedule(&iso_send_work, K_MSEC(0));

--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -23,6 +23,8 @@ static void start_scan(void);
 static struct bt_conn *default_conn;
 static struct k_work_delayable iso_send_work;
 static struct bt_iso_chan iso_chan;
+static uint32_t sn;
+static uint32_t interval_us = 10U * USEC_PER_MSEC; /* 10 ms */
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8,
 			  NULL);
 
@@ -60,13 +62,13 @@ static void iso_timer_timeout(struct k_work *work)
 
 	net_buf_add_mem(buf, buf_data, len_to_send);
 
-	ret = bt_iso_chan_send(&iso_chan, buf);
+	ret = bt_iso_chan_send(&iso_chan, buf, sn++, BT_ISO_TIMESTAMP_NONE);
 
 	if (ret < 0) {
 		printk("Failed to send ISO data (%d)\n", ret);
 	}
 
-	k_work_schedule(&iso_send_work, K_MSEC(1000));
+	k_work_schedule(&iso_send_work, K_USEC(interval_us));
 
 	len_to_send++;
 	if (len_to_send > ARRAY_SIZE(buf_data)) {
@@ -127,6 +129,8 @@ static void start_scan(void)
 static void iso_connected(struct bt_iso_chan *chan)
 {
 	printk("ISO Channel %p connected\n", chan);
+
+	sn = 0U;
 
 	/* Start send timer */
 	k_work_schedule(&iso_send_work, K_MSEC(0));
@@ -238,7 +242,7 @@ void main(void)
 	param.packing = 0;
 	param.framing = 0;
 	param.latency = 10; /* ms */
-	param.interval = 10 * USEC_PER_MSEC; /* us */
+	param.interval = interval_us; /* us */
 
 	err = bt_iso_cig_create(&param, &cig);
 

--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -17,13 +17,13 @@ NET_BUF_POOL_FIXED_DEFINE(bis_tx_pool, BIS_ISO_CHAN_COUNT,
 static K_SEM_DEFINE(sem_big_cmplt, 0, 1);
 static K_SEM_DEFINE(sem_big_term, 0, 1);
 
-static uint32_t sn;
+static uint32_t seq_num;
 
 static void iso_connected(struct bt_iso_chan *chan)
 {
 	printk("ISO Channel %p connected\n", chan);
 
-	sn = 0U;
+	seq_num = 0U;
 
 	k_sem_give(&sem_big_cmplt);
 }
@@ -138,7 +138,7 @@ void main(void)
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 		sys_put_le32(++iso_send_count, iso_data);
 		net_buf_add_mem(buf, iso_data, sizeof(iso_data));
-		ret = bt_iso_chan_send(&bis_iso_chan, buf, sn++,
+		ret = bt_iso_chan_send(&bis_iso_chan, buf, seq_num++,
 				       BT_ISO_TIMESTAMP_NONE);
 		if (ret < 0) {
 			printk("Unable to broadcast data: %d", ret);

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -140,7 +140,7 @@ static int parse_interval_arg(void)
 	}
 
 	interval = strtoul(buffer, NULL, 0);
-	if (interval < BT_ISO_INTERVAL_MIN || interval > BT_ISO_INTERVAL_MAX) {
+	if (interval < BT_ISO_SDU_INTERVAL_MIN || interval > BT_ISO_SDU_INTERVAL_MAX) {
 		printk("Invalid interval %llu", interval);
 		return -EINVAL;
 	}

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -35,6 +35,8 @@ static uint8_t connected_bis;
 
 static struct bt_iso_chan bis_iso_chans[CONFIG_BT_ISO_MAX_CHAN];
 static struct bt_iso_chan *bis[CONFIG_BT_ISO_MAX_CHAN];
+/* We use a single SN for all the BIS as they share the same SDU interval */
+static uint32_t sn;
 static struct bt_iso_big_create_param big_create_param = {
 	.num_bis = DEFAULT_BIS_COUNT,
 	.bis_channels = bis,
@@ -50,6 +52,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 
 	connected_bis++;
 	if (connected_bis == big_create_param.num_bis) {
+		sn = 0U;
 		k_sem_give(&sem_big_complete);
 	}
 }
@@ -375,7 +378,8 @@ static void iso_timer_timeout(struct k_work *work)
 
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 		net_buf_add_mem(buf, iso_data, iso_tx_qos.sdu);
-		ret = bt_iso_chan_send(&bis_iso_chans[i], buf);
+		ret = bt_iso_chan_send(&bis_iso_chans[i], buf, sn,
+				       BT_ISO_TIMESTAMP_NONE);
 		if (ret < 0) {
 			LOG_ERR("Unable to broadcast data: %d", ret);
 			net_buf_unref(buf);
@@ -387,6 +391,8 @@ static void iso_timer_timeout(struct k_work *work)
 			LOG_INF("Sent %u packets", iso_send_count);
 		}
 	}
+
+	sn++;
 }
 
 static int create_big(struct bt_le_ext_adv **adv, struct bt_iso_big **big)

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -35,8 +35,8 @@ static uint8_t connected_bis;
 
 static struct bt_iso_chan bis_iso_chans[CONFIG_BT_ISO_MAX_CHAN];
 static struct bt_iso_chan *bis[CONFIG_BT_ISO_MAX_CHAN];
-/* We use a single SN for all the BIS as they share the same SDU interval */
-static uint32_t sn;
+/* We use a single seq_num for all the BIS as they share the same SDU interval */
+static uint32_t seq_num;
 static struct bt_iso_big_create_param big_create_param = {
 	.num_bis = DEFAULT_BIS_COUNT,
 	.bis_channels = bis,
@@ -52,7 +52,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 
 	connected_bis++;
 	if (connected_bis == big_create_param.num_bis) {
-		sn = 0U;
+		seq_num = 0U;
 		k_sem_give(&sem_big_complete);
 	}
 }
@@ -378,7 +378,7 @@ static void iso_timer_timeout(struct k_work *work)
 
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 		net_buf_add_mem(buf, iso_data, iso_tx_qos.sdu);
-		ret = bt_iso_chan_send(&bis_iso_chans[i], buf, sn,
+		ret = bt_iso_chan_send(&bis_iso_chans[i], buf, seq_num,
 				       BT_ISO_TIMESTAMP_NONE);
 		if (ret < 0) {
 			LOG_ERR("Unable to broadcast data: %d", ret);
@@ -392,7 +392,7 @@ static void iso_timer_timeout(struct k_work *work)
 		}
 	}
 
-	sn++;
+	seq_num++;
 }
 
 static int create_big(struct bt_le_ext_adv **adv, struct bt_iso_big **big)

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -52,7 +52,7 @@ struct iso_chan_work {
 	struct bt_iso_chan chan;
 	struct k_work_delayable send_work;
 	struct bt_iso_info info;
-	uint32_t sn;
+	uint32_t seq_num;
 } iso_chans[CONFIG_BT_ISO_MAX_CHAN];
 
 static enum benchmark_role role;
@@ -172,7 +172,7 @@ static void iso_send(struct bt_iso_chan *chan)
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, iso_data, iso_tx_qos.sdu);
 
-	ret = bt_iso_chan_send(chan, buf, chan_work->sn++,
+	ret = bt_iso_chan_send(chan, buf, chan_work->seq_num++,
 			       BT_ISO_TIMESTAMP_NONE);
 	if (ret < 0) {
 		LOG_ERR("Unable to send data: %d", ret);
@@ -279,7 +279,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 	iso_conn_start_time = k_uptime_get();
 
 	chan_work = CONTAINER_OF(chan, struct iso_chan_work, chan);
-	chan_work->sn = 0U;
+	chan_work->seq_num = 0U;
 
 	k_sem_give(&sem_iso_connected);
 }

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -527,7 +527,7 @@ static int parse_interval_arg(void)
 
 	interval = strtoul(buffer, NULL, 0);
 	/* TODO: Replace literal ints with a #define once it has been created */
-	if (interval < BT_ISO_INTERVAL_MIN || interval > BT_ISO_INTERVAL_MAX) {
+	if (interval < BT_ISO_SDU_INTERVAL_MIN || interval > BT_ISO_SDU_INTERVAL_MAX) {
 		printk("Invalid interval %llu", interval);
 		return -EINVAL;
 	}

--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -221,9 +221,9 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 	}
 
 	str_len = bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
-	printk("Incoming data channel %p flags 0x%x sn %u ts %u len %u: %s "
-	       "(counter value %u)\n", chan, info->flags, info->sn, info->ts,
-	       buf->len, data_str, count);
+	printk("Incoming data channel %p flags 0x%x seq_num %u ts %u len %u: "
+	       "%s (counter value %u)\n", chan, info->flags, info->seq_num,
+	       info->ts, buf->len, data_str, count);
 }
 
 static void iso_connected(struct bt_iso_chan *chan)

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -371,7 +371,7 @@ static void ascs_iso_connected(struct bt_iso_chan *chan)
 
 	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
-	ep->sn = 0U;
+	ep->seq_num = 0U;
 
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -371,6 +371,8 @@ static void ascs_iso_connected(struct bt_iso_chan *chan)
 
 	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
+	ep->sn = 0U;
+
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
 		       bt_audio_ep_state_str(ep->status.state));

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -146,7 +146,7 @@ static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 	BT_DBG("stream %p ep %p", chan, ep);
 
 	broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_STREAMING);
-	ep->sn = 0U;
+	ep->seq_num = 0U;
 
 	if (ops != NULL && ops->started != NULL) {
 		ops->started(ep->stream);

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -146,6 +146,7 @@ static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 	BT_DBG("stream %p ep %p", chan, ep);
 
 	broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_STREAMING);
+	ep->sn = 0U;
 
 	if (ops != NULL && ops->started != NULL) {
 		ops->started(ep->stream);

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -43,7 +43,7 @@ struct bt_audio_ep {
 	uint8_t  cig_id;
 	uint8_t  cis_id;
 	/* ISO sequence number */
-	uint32_t sn;
+	uint32_t seq_num;
 	struct bt_ascs_ase_status status;
 	struct bt_audio_stream *stream;
 	struct bt_codec codec;

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -42,6 +42,8 @@ struct bt_audio_ep {
 	uint16_t cp_handle;
 	uint8_t  cig_id;
 	uint8_t  cis_id;
+	/* ISO sequence number */
+	uint32_t sn;
 	struct bt_ascs_ase_status status;
 	struct bt_audio_stream *stream;
 	struct bt_codec codec;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -59,19 +59,25 @@ void bt_audio_stream_attach(struct bt_conn *conn,
 #if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SOURCE)
 int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf)
 {
+	struct bt_audio_ep *ep;
+
 	if (stream == NULL || stream->ep == NULL) {
 		return -EINVAL;
 	}
 
-	if (stream->ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
+	ep = stream->ep;
+
+	if (ep->status.state != BT_AUDIO_EP_STATE_STREAMING) {
 		BT_DBG("Channel %p not ready for streaming (state: %s)",
-		       stream, bt_audio_ep_state_str(stream->ep->status.state));
+		       stream, bt_audio_ep_state_str(ep->status.state));
 		return -EBADMSG;
 	}
 
 	/* TODO: Add checks for broadcast sink */
 
-	return bt_iso_chan_send(stream->iso, buf);
+	/* TODO: Ensure that the sequence number is incremented per SDU interval */
+	return bt_iso_chan_send(stream->iso, buf, ep->sn++,
+				BT_ISO_TIMESTAMP_NONE);
 }
 #endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SOURCE */
 

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -161,10 +161,10 @@ done:
 
 bool bt_audio_valid_qos(const struct bt_codec_qos *qos)
 {
-	if (qos->interval < BT_ISO_INTERVAL_MIN ||
-	    qos->interval > BT_ISO_INTERVAL_MAX) {
+	if (qos->interval < BT_ISO_SDU_INTERVAL_MIN ||
+	    qos->interval > BT_ISO_SDU_INTERVAL_MAX) {
 		BT_DBG("Interval not within allowed range: %u (%u-%u)",
-		       qos->interval, BT_ISO_INTERVAL_MIN, BT_ISO_INTERVAL_MAX);
+		       qos->interval, BT_ISO_SDU_INTERVAL_MIN, BT_ISO_SDU_INTERVAL_MAX);
 		return false;
 	}
 

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -76,7 +76,7 @@ int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf)
 	/* TODO: Add checks for broadcast sink */
 
 	/* TODO: Ensure that the sequence number is incremented per SDU interval */
-	return bt_iso_chan_send(stream->iso, buf, ep->sn++,
+	return bt_iso_chan_send(stream->iso, buf, ep->seq_num++,
 				BT_ISO_TIMESTAMP_NONE);
 }
 #endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SOURCE */

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -122,6 +122,8 @@ static void unicast_client_ep_iso_connected(struct bt_iso_chan *chan)
 
 	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
+	ep->sn = 0U;
+
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
 		       bt_audio_ep_state_str(ep->status.state));

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -122,7 +122,7 @@ static void unicast_client_ep_iso_connected(struct bt_iso_chan *chan)
 
 	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
-	ep->sn = 0U;
+	ep->seq_num = 0U;
 
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -126,8 +126,13 @@ struct bt_conn_iso {
 	};
 
 #if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_BROADCASTER)
-	/** 16-bit sequence number that shall be incremented per SDU interval */
-	uint16_t seq_num;
+	/** @brief 16-bit sequence number that shall be incremented per SDU interval
+	 *
+	 *  Stored as 32-bit to handle wrapping: Only once the value has
+	 *  become greater than 0xFFFF will values less than the
+	 *  current are allowed again.
+	 */
+	uint32_t seq_num;
 #endif /* CONFIG_BT_ISO_UNICAST) || CONFIG_BT_ISO_BROADCASTER */
 
 	/** Stored information about the ISO stream */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -701,9 +701,9 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 #endif /* CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_SYNC_RECEIVER */
 
 #if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_BROADCASTER)
-int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf)
+int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
+		     uint32_t sn, uint32_t ts)
 {
-	struct bt_hci_iso_data_hdr *hdr;
 	struct bt_conn *iso_conn;
 
 	CHECKIF(!chan || !buf) {
@@ -724,13 +724,39 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf)
 		return -EINVAL;
 	}
 
-	hdr = net_buf_push(buf, sizeof(*hdr));
-	hdr->sn = sys_cpu_to_le16(iso_conn->iso.seq_num);
-	hdr->slen = sys_cpu_to_le16(bt_iso_pkt_len_pack(net_buf_frags_len(buf)
-							- sizeof(*hdr),
-							BT_ISO_DATA_VALID));
+	/* Once the stored seq_num reaches the maximum value sendable to the
+	 * controller (BT_ISO_MAX_SEQ_NUM) we will allow the application to wrap
+	 * it. This ensures that up to 2^32-1 SDUs can be sent without wrapping
+	 * the sequence number which should provide ample room to handle
+	 * applications that does not send an SDU every interval.
+	 */
+	if (sn <= iso_conn->iso.seq_num &&
+	    iso_conn->iso.seq_num < BT_ISO_MAX_SEQ_NUM) {
+		BT_DBG("Invalid sn %u - Shall be > than %u",
+		       sn, iso_conn->iso.seq_num);
+		return -EINVAL;
+	}
 
-	iso_conn->iso.seq_num++;
+	iso_conn->iso.seq_num = sn;
+
+	if (ts == BT_ISO_TIMESTAMP_NONE) {
+		struct bt_hci_iso_data_hdr *hdr;
+
+		hdr = net_buf_push(buf, sizeof(*hdr));
+		hdr->sn = sys_cpu_to_le16((uint16_t)sn);
+		hdr->slen = sys_cpu_to_le16(bt_iso_pkt_len_pack(net_buf_frags_len(buf)
+								- sizeof(*hdr),
+								BT_ISO_DATA_VALID));
+	} else {
+		struct bt_hci_iso_ts_data_hdr *hdr;
+
+		hdr = net_buf_push(buf, sizeof(*hdr));
+		hdr->ts = ts;
+		hdr->data.sn = sys_cpu_to_le16((uint16_t)sn);
+		hdr->data.slen = sys_cpu_to_le16(bt_iso_pkt_len_pack(net_buf_frags_len(buf)
+								     - sizeof(*hdr),
+								     BT_ISO_DATA_VALID));
+	}
 
 	return bt_conn_send_cb(iso_conn, buf, bt_iso_send_cb, NULL);
 }
@@ -849,7 +875,7 @@ void hci_le_cis_established(struct net_buf *buf)
 		__ASSERT(chan != NULL && chan->qos != NULL, "Invalid ISO chan");
 
 		/* Reset sequence number */
-		iso->iso.seq_num = 0;
+		iso->iso.seq_num = BT_ISO_MAX_SEQ_NUM;
 
 		tx = chan->qos->tx;
 		rx = chan->qos->rx;
@@ -2283,7 +2309,8 @@ void hci_le_big_complete(struct net_buf *buf)
 		const uint16_t handle = evt->handle[i++];
 		struct bt_conn *iso_conn = bis->iso;
 
-		iso_conn->iso.seq_num = 0;
+		/* Reset sequence number */
+		iso_conn->iso.seq_num = BT_ISO_MAX_SEQ_NUM;
 		iso_conn->handle = sys_le16_to_cpu(handle);
 		store_bis_broadcaster_info(evt, &iso_conn->iso.info);
 		bt_conn_set_state(iso_conn, BT_CONN_CONNECTED);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1483,8 +1483,8 @@ static bool valid_cig_param(const struct bt_iso_cig_param *param)
 		return false;
 	}
 
-	if (param->interval < BT_ISO_INTERVAL_MIN ||
-	    param->interval > BT_ISO_INTERVAL_MAX) {
+	if (param->interval < BT_ISO_SDU_INTERVAL_MIN ||
+	    param->interval > BT_ISO_SDU_INTERVAL_MAX) {
 		BT_DBG("Invalid interval: %u", param->interval);
 		return false;
 	}
@@ -2211,8 +2211,8 @@ int bt_iso_big_create(struct bt_le_ext_adv *padv, struct bt_iso_big_create_param
 		return -EINVAL;
 	}
 
-	CHECKIF(param->interval < BT_ISO_INTERVAL_MIN ||
-		param->interval > BT_ISO_INTERVAL_MAX) {
+	CHECKIF(param->interval < BT_ISO_SDU_INTERVAL_MIN ||
+		param->interval > BT_ISO_SDU_INTERVAL_MAX) {
 		BT_DBG("Invalid interval: %u", param->interval);
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/host/iso_internal.h
+++ b/subsys/bluetooth/host/iso_internal.h
@@ -4,12 +4,14 @@
 
 /*
  * Copyright (c) 2020 Intel Corporation
- * Copyright (c) 2021 Nordic Semiconductor ASA
+ * Copyright (c) 2021-2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
 #include <zephyr/bluetooth/iso.h>
+
+#define BT_ISO_MAX_SEQ_NUM 0xFFFF
 
 struct iso_data {
 	/** BT_BUF_ISO_IN */

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -304,7 +304,7 @@ static int iso_accept(const struct bt_iso_accept_info *info,
 	 * the PSN may be incremented, and it is thus OK for us to increment
 	 * it faster than the SDU interval.
 	 */
-	cis_sdu_interval_us = BT_ISO_INTERVAL_MIN;
+	cis_sdu_interval_us = BT_ISO_SDU_INTERVAL_MIN;
 
 	return 0;
 }

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -64,7 +64,7 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 		struct net_buf *buf)
 {
 	shell_print(ctx_shell, "Incoming data channel %p len %u, seq: %d, ts: %d",
-		    chan, buf->len, info->sn, info->ts);
+		    chan, buf->len, info->seq_num, info->ts);
 }
 
 static void iso_connected(struct bt_iso_chan *chan)

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -86,7 +86,7 @@ static struct bt_iso_chan bis_iso_chan = {
 
 #define BIS_ISO_CHAN_COUNT 1
 static struct bt_iso_chan *bis_channels[BIS_ISO_CHAN_COUNT] = { &bis_iso_chan };
-static uint32_t sn;
+static uint32_t seq_num;
 
 NET_BUF_POOL_FIXED_DEFINE(bis_tx_pool, BIS_ISO_CHAN_COUNT,
 			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8, NULL);
@@ -109,7 +109,7 @@ static isoal_status_t test_sink_sdu_alloc(const struct isoal_sink    *sink_ctx,
 static isoal_status_t test_sink_sdu_emit(const struct isoal_sink         *sink_ctx,
 					 const struct isoal_sdu_produced *valid_sdu)
 {
-	printk("Vendor sink SDU len %u, sn %u, ts %u\n",
+	printk("Vendor sink SDU len %u, seq_num %u, ts %u\n",
 		sink_ctx->sdu_production.sdu_written, valid_sdu->seqn,
 		valid_sdu->timestamp);
 	is_iso_vs_emitted = true;
@@ -257,7 +257,7 @@ static void test_iso_main(void)
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	sys_put_le32(++iso_send_count, iso_data);
 	net_buf_add_mem(buf, iso_data, sizeof(iso_data));
-	err = bt_iso_chan_send(&bis_iso_chan, buf, sn++, BT_ISO_TIMESTAMP_NONE);
+	err = bt_iso_chan_send(&bis_iso_chan, buf, seq_num++, BT_ISO_TIMESTAMP_NONE);
 	if (err < 0) {
 		net_buf_unref(buf);
 		FAIL("Unable to broadcast data (%d)", err);
@@ -346,15 +346,15 @@ static const char *phy2str(uint8_t phy)
 static void iso_recv(struct bt_iso_chan *chan,
 		     const struct bt_iso_recv_info *info, struct net_buf *buf)
 {
-	printk("Incoming data channel %p len %u, flags %u, sn %u, ts %u\n",
-		chan, buf->len, info->flags, info->sn, info->ts);
+	printk("Incoming data channel %p len %u, flags %u, seq_num %u, ts %u\n",
+		chan, buf->len, info->flags, info->seq_num, info->ts);
 }
 
 static void iso_connected(struct bt_iso_chan *chan)
 {
 	printk("ISO Channel %p connected\n", chan);
 
-	sn = 0U;
+	seq_num = 0U;
 	is_iso_connected = true;
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_iso/src/main.c
@@ -86,6 +86,7 @@ static struct bt_iso_chan bis_iso_chan = {
 
 #define BIS_ISO_CHAN_COUNT 1
 static struct bt_iso_chan *bis_channels[BIS_ISO_CHAN_COUNT] = { &bis_iso_chan };
+static uint32_t sn;
 
 NET_BUF_POOL_FIXED_DEFINE(bis_tx_pool, BIS_ISO_CHAN_COUNT,
 			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8, NULL);
@@ -256,7 +257,7 @@ static void test_iso_main(void)
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	sys_put_le32(++iso_send_count, iso_data);
 	net_buf_add_mem(buf, iso_data, sizeof(iso_data));
-	err = bt_iso_chan_send(&bis_iso_chan, buf);
+	err = bt_iso_chan_send(&bis_iso_chan, buf, sn++, BT_ISO_TIMESTAMP_NONE);
 	if (err < 0) {
 		net_buf_unref(buf);
 		FAIL("Unable to broadcast data (%d)", err);
@@ -353,6 +354,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 {
 	printk("ISO Channel %p connected\n", chan);
 
+	sn = 0U;
 	is_iso_connected = true;
 }
 


### PR DESCRIPTION
Add two new parameters to bt_iso_chan_send:
sn: The packet sequence number which shall be incremeted per SDU interval.
ts: An optional timestamp value used to synchronize SDUs.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/43859