### PR TITLE
scripts: check_compliance: check for commit message errors

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -202,15 +202,10 @@ class CheckPatch(ComplianceTest):
         if not os.path.exists(checkpatch):
             self.skip(checkpatch + " not found")
 
-        # git diff's output doesn't depend on the current (sub)directory
-        diff = subprocess.Popen(('git', 'diff', COMMIT_RANGE),
-                                stdout=subprocess.PIPE)
         try:
-            subprocess.check_output((checkpatch, '--mailback', '--no-tree', '-'),
-                                    stdin=diff.stdout,
+            subprocess.check_output((checkpatch, '--no-tree', '-g', COMMIT_RANGE),
                                     stderr=subprocess.STDOUT,
-                                    shell=True, cwd=GIT_TOP)
-
+                                    cwd=GIT_TOP)
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
             self.add_failure(output)


### PR DESCRIPTION
Hi, noticed that the compliance script is not catching checkpatch.pl errors like leftover Gerrit tags. That is because it's setup to only work on the diff. Turns out checkpatch can work on commits directly, this should fix it. If some checks turns out to be too restrictive (like the 75 columns limit forcing people to cut backtraces and URLs) we may turn those off selectively... let me know what you think.