### PR TITLE
Media control cleanups

### DIFF
--- a/include/bluetooth/audio/media_proxy.h
+++ b/include/bluetooth/audio/media_proxy.h
@@ -257,6 +257,7 @@ struct media_proxy_ctrl_cbs {
 	 */
 	void (*local_player_instance)(struct media_player *player, int err);
 
+#ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL
 	/**
 	 * @brief Discover Player Instance callback
 	 *
@@ -269,6 +270,7 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 */
 	void (*discover_player)(struct media_player *player, int err);
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
 	/**
 	 * @brief Media Player Name receive callback

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -726,7 +726,7 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL	*/
 
 
-#if defined(CONFIG_MCTL_LOCAL_PLAYER_CONTROL)
+#if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL) || defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
 int media_proxy_ctrl_get_player_name(struct media_player *player)
 {
 	CHECKIF(player == NULL) {
@@ -1692,7 +1692,7 @@ uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player)
 
 	return -EOPNOTSUPP;
 }
-#endif /* CONFIG_MCTL_LOCAL_PLAYER_CONTROL */
+#endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL || CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
 
 

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -723,7 +723,7 @@ int media_proxy_ctrl_discover_player(struct bt_conn *conn)
 
 	return 0;
 }
-#endif /* CONIG_MCTL_REMOTE_PLAYER_CONTROL	*/
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL	*/
 
 
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_CONTROL)

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -775,7 +775,7 @@ int media_proxy_ctrl_get_icon_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_icon_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_id_recv) {
-				uint64_t id = mprx.local_player.calls->get_icon_id();
+				const uint64_t id = mprx.local_player.calls->get_icon_id();
 
 				mprx.ctrlr.cbs->icon_id_recv(&mprx.local_player, 0, id);
 			} else {
@@ -880,7 +880,8 @@ int media_proxy_ctrl_get_track_duration(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_track_duration) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration_recv) {
-				int32_t duration = mprx.local_player.calls->get_track_duration();
+				const int32_t duration =
+					mprx.local_player.calls->get_track_duration();
 
 				mprx.ctrlr.cbs->track_duration_recv(player, 0, duration);
 			} else {
@@ -915,7 +916,8 @@ int media_proxy_ctrl_get_track_position(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_track_position) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
-				int32_t position = mprx.local_player.calls->get_track_position();
+				const int32_t position =
+					mprx.local_player.calls->get_track_position();
 
 				mprx.ctrlr.cbs->track_position_recv(player, 0, position);
 			} else {
@@ -985,7 +987,7 @@ int media_proxy_ctrl_get_playback_speed(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_playback_speed) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
-				int8_t speed = mprx.local_player.calls->get_playback_speed();
+				const int8_t speed = mprx.local_player.calls->get_playback_speed();
 
 				mprx.ctrlr.cbs->playback_speed_recv(player, 0, speed);
 			} else {
@@ -1055,7 +1057,7 @@ int media_proxy_ctrl_get_seeking_speed(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_seeking_speed) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed_recv) {
-				int8_t speed = mprx.local_player.calls->get_seeking_speed();
+				const int8_t speed = mprx.local_player.calls->get_seeking_speed();
 
 				mprx.ctrlr.cbs->seeking_speed_recv(player, 0, speed);
 			} else {
@@ -1090,7 +1092,8 @@ int media_proxy_ctrl_get_track_segments_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_track_segments_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_segments_id_recv) {
-				uint64_t id = mprx.local_player.calls->get_track_segments_id();
+				const uint64_t id =
+					mprx.local_player.calls->get_track_segments_id();
 
 				mprx.ctrlr.cbs->track_segments_id_recv(player, 0, id);
 			} else {
@@ -1125,7 +1128,7 @@ int media_proxy_ctrl_get_current_track_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_current_track_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_recv) {
-				uint64_t id = mprx.local_player.calls->get_current_track_id();
+				const uint64_t id = mprx.local_player.calls->get_current_track_id();
 
 				mprx.ctrlr.cbs->current_track_id_recv(player, 0, id);
 			} else {
@@ -1201,7 +1204,7 @@ int media_proxy_ctrl_get_next_track_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_next_track_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_recv) {
-				uint64_t id = mprx.local_player.calls->get_next_track_id();
+				const uint64_t id = mprx.local_player.calls->get_next_track_id();
 
 				mprx.ctrlr.cbs->next_track_id_recv(player, 0, id);
 			} else {
@@ -1277,7 +1280,7 @@ int media_proxy_ctrl_get_parent_group_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_parent_group_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id_recv) {
-				uint64_t id = mprx.local_player.calls->get_parent_group_id();
+				const uint64_t id = mprx.local_player.calls->get_parent_group_id();
 
 				mprx.ctrlr.cbs->parent_group_id_recv(player, 0, id);
 			} else {
@@ -1312,7 +1315,7 @@ int media_proxy_ctrl_get_current_group_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_current_group_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_recv) {
-				uint64_t id = mprx.local_player.calls->get_current_group_id();
+				const uint64_t id = mprx.local_player.calls->get_current_group_id();
 
 				mprx.ctrlr.cbs->current_group_id_recv(player, 0, id);
 			} else {
@@ -1388,7 +1391,7 @@ int media_proxy_ctrl_get_playing_order(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_playing_order) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
-				uint8_t order = mprx.local_player.calls->get_playing_order();
+				const uint8_t order = mprx.local_player.calls->get_playing_order();
 
 				mprx.ctrlr.cbs->playing_order_recv(player, 0, order);
 			} else {
@@ -1459,7 +1462,7 @@ int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_playing_orders_supported) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_orders_supported_recv) {
-				uint16_t orders =
+				const uint16_t orders =
 					mprx.local_player.calls->get_playing_orders_supported();
 
 				mprx.ctrlr.cbs->playing_orders_supported_recv(player, 0, orders);
@@ -1495,7 +1498,7 @@ int media_proxy_ctrl_get_media_state(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_media_state) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state_recv) {
-				uint8_t state = mprx.local_player.calls->get_media_state();
+				const uint8_t state = mprx.local_player.calls->get_media_state();
 
 				mprx.ctrlr.cbs->media_state_recv(player, 0, state);
 			} else {
@@ -1565,7 +1568,7 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_commands_supported) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported_recv) {
-				uint32_t opcodes =
+				const uint32_t opcodes =
 					mprx.local_player.calls->get_commands_supported();
 
 				mprx.ctrlr.cbs->commands_supported_recv(player, 0, opcodes);
@@ -1636,7 +1639,8 @@ int media_proxy_ctrl_get_search_results_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_search_results_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id_recv) {
-				uint64_t id = mprx.local_player.calls->get_search_results_id();
+				const uint64_t id =
+					mprx.local_player.calls->get_search_results_id();
 
 				mprx.ctrlr.cbs->search_results_id_recv(player, 0, id);
 			} else {
@@ -1671,7 +1675,7 @@ uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_content_ctrl_id) {
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->content_ctrl_id_recv) {
-				uint8_t ccid = mprx.local_player.calls->get_content_ctrl_id();
+				const uint8_t ccid = mprx.local_player.calls->get_content_ctrl_id();
 
 				mprx.ctrlr.cbs->content_ctrl_id_recv(player, 0, ccid);
 			} else {

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -738,9 +738,9 @@ int media_proxy_ctrl_get_player_name(struct media_player *player)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		BT_DBG("Local player");
 		if (mprx.local_player.calls->get_player_name) {
-			const char *name = mprx.local_player.calls->get_player_name();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->player_name_recv) {
+				const char *name = mprx.local_player.calls->get_player_name();
+
 				mprx.ctrlr.cbs->player_name_recv(&mprx.local_player, 0, name);
 			} else {
 				BT_DBG("No callback");
@@ -774,9 +774,9 @@ int media_proxy_ctrl_get_icon_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_icon_id) {
-			uint64_t id = mprx.local_player.calls->get_icon_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_id_recv) {
+				uint64_t id = mprx.local_player.calls->get_icon_id();
+
 				mprx.ctrlr.cbs->icon_id_recv(&mprx.local_player, 0, id);
 			} else {
 				BT_DBG("No callback");
@@ -809,9 +809,9 @@ int media_proxy_ctrl_get_icon_url(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_icon_url) {
-			const char *url = mprx.local_player.calls->get_icon_url();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->icon_url_recv) {
+				const char *url = mprx.local_player.calls->get_icon_url();
+
 				mprx.ctrlr.cbs->icon_url_recv(player, 0, url);
 			} else {
 				BT_DBG("No callback");
@@ -844,9 +844,9 @@ int media_proxy_ctrl_get_track_title(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_track_title) {
-			const char *title = mprx.local_player.calls->get_track_title();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_title_recv) {
+
+				const char *title = mprx.local_player.calls->get_track_title();
 				mprx.ctrlr.cbs->track_title_recv(player, 0, title);
 			} else {
 				BT_DBG("No callback");
@@ -879,9 +879,9 @@ int media_proxy_ctrl_get_track_duration(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_track_duration) {
-			int32_t duration = mprx.local_player.calls->get_track_duration();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_duration_recv) {
+				int32_t duration = mprx.local_player.calls->get_track_duration();
+
 				mprx.ctrlr.cbs->track_duration_recv(player, 0, duration);
 			} else {
 				BT_DBG("No callback");
@@ -914,9 +914,9 @@ int media_proxy_ctrl_get_track_position(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_track_position) {
-			int32_t position = mprx.local_player.calls->get_track_position();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_position_recv) {
+				int32_t position = mprx.local_player.calls->get_track_position();
+
 				mprx.ctrlr.cbs->track_position_recv(player, 0, position);
 			} else {
 				BT_DBG("No callback");
@@ -984,9 +984,9 @@ int media_proxy_ctrl_get_playback_speed(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_playback_speed) {
-			int8_t speed = mprx.local_player.calls->get_playback_speed();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playback_speed_recv) {
+				int8_t speed = mprx.local_player.calls->get_playback_speed();
+
 				mprx.ctrlr.cbs->playback_speed_recv(player, 0, speed);
 			} else {
 				BT_DBG("No callback");
@@ -1054,9 +1054,9 @@ int media_proxy_ctrl_get_seeking_speed(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_seeking_speed) {
-			int8_t speed = mprx.local_player.calls->get_seeking_speed();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->seeking_speed_recv) {
+				int8_t speed = mprx.local_player.calls->get_seeking_speed();
+
 				mprx.ctrlr.cbs->seeking_speed_recv(player, 0, speed);
 			} else {
 				BT_DBG("No callback");
@@ -1089,9 +1089,9 @@ int media_proxy_ctrl_get_track_segments_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_track_segments_id) {
-			uint64_t id = mprx.local_player.calls->get_track_segments_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->track_segments_id_recv) {
+				uint64_t id = mprx.local_player.calls->get_track_segments_id();
+
 				mprx.ctrlr.cbs->track_segments_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
@@ -1124,9 +1124,9 @@ int media_proxy_ctrl_get_current_track_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_current_track_id) {
-			uint64_t id = mprx.local_player.calls->get_current_track_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_track_id_recv) {
+				uint64_t id = mprx.local_player.calls->get_current_track_id();
+
 				mprx.ctrlr.cbs->current_track_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
@@ -1200,9 +1200,9 @@ int media_proxy_ctrl_get_next_track_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_next_track_id) {
-			uint64_t id = mprx.local_player.calls->get_next_track_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->next_track_id_recv) {
+				uint64_t id = mprx.local_player.calls->get_next_track_id();
+
 				mprx.ctrlr.cbs->next_track_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
@@ -1276,9 +1276,9 @@ int media_proxy_ctrl_get_parent_group_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_parent_group_id) {
-			uint64_t id = mprx.local_player.calls->get_parent_group_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->parent_group_id_recv) {
+				uint64_t id = mprx.local_player.calls->get_parent_group_id();
+
 				mprx.ctrlr.cbs->parent_group_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
@@ -1311,9 +1311,9 @@ int media_proxy_ctrl_get_current_group_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_current_group_id) {
-			uint64_t id = mprx.local_player.calls->get_current_group_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->current_group_id_recv) {
+				uint64_t id = mprx.local_player.calls->get_current_group_id();
+
 				mprx.ctrlr.cbs->current_group_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
@@ -1387,9 +1387,9 @@ int media_proxy_ctrl_get_playing_order(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_playing_order) {
-			uint8_t order = mprx.local_player.calls->get_playing_order();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_order_recv) {
+				uint8_t order = mprx.local_player.calls->get_playing_order();
+
 				mprx.ctrlr.cbs->playing_order_recv(player, 0, order);
 			} else {
 				BT_DBG("No callback");
@@ -1458,9 +1458,10 @@ int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_playing_orders_supported) {
-			uint16_t orders = mprx.local_player.calls->get_playing_orders_supported();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->playing_orders_supported_recv) {
+				uint16_t orders =
+					mprx.local_player.calls->get_playing_orders_supported();
+
 				mprx.ctrlr.cbs->playing_orders_supported_recv(player, 0, orders);
 			} else {
 				BT_DBG("No callback");
@@ -1493,9 +1494,9 @@ int media_proxy_ctrl_get_media_state(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_media_state) {
-			uint8_t state = mprx.local_player.calls->get_media_state();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->media_state_recv) {
+				uint8_t state = mprx.local_player.calls->get_media_state();
+
 				mprx.ctrlr.cbs->media_state_recv(player, 0, state);
 			} else {
 				BT_DBG("No callback");
@@ -1563,9 +1564,10 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_commands_supported) {
-			uint32_t opcodes = mprx.local_player.calls->get_commands_supported();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->commands_supported_recv) {
+				uint32_t opcodes =
+					mprx.local_player.calls->get_commands_supported();
+
 				mprx.ctrlr.cbs->commands_supported_recv(player, 0, opcodes);
 			} else {
 				BT_DBG("No callback");
@@ -1633,9 +1635,9 @@ int media_proxy_ctrl_get_search_results_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_search_results_id) {
-			uint64_t id = mprx.local_player.calls->get_search_results_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_results_id_recv) {
+				uint64_t id = mprx.local_player.calls->get_search_results_id();
+
 				mprx.ctrlr.cbs->search_results_id_recv(player, 0, id);
 			} else {
 				BT_DBG("No callback");
@@ -1668,9 +1670,9 @@ uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player)
 #if defined(CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL)
 	if (mprx.local_player.registered && player == &mprx.local_player) {
 		if (mprx.local_player.calls->get_content_ctrl_id) {
-			uint8_t ccid = mprx.local_player.calls->get_content_ctrl_id();
-
 			if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->content_ctrl_id_recv) {
+				uint8_t ccid = mprx.local_player.calls->get_content_ctrl_id();
+
 				mprx.ctrlr.cbs->content_ctrl_id_recv(player, 0, ccid);
 			} else {
 				BT_DBG("No callback");

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -761,7 +761,7 @@ int media_proxy_ctrl_get_player_name(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_icon_id(struct media_player *player)
@@ -796,7 +796,7 @@ int media_proxy_ctrl_get_icon_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_icon_url(struct media_player *player)
@@ -831,7 +831,7 @@ int media_proxy_ctrl_get_icon_url(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_track_title(struct media_player *player)
@@ -866,7 +866,7 @@ int media_proxy_ctrl_get_track_title(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_track_duration(struct media_player *player)
@@ -901,7 +901,7 @@ int media_proxy_ctrl_get_track_duration(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_track_position(struct media_player *player)
@@ -936,7 +936,7 @@ int media_proxy_ctrl_get_track_position(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t position)
@@ -971,7 +971,7 @@ int media_proxy_ctrl_set_track_position(struct media_player *player, int32_t pos
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_playback_speed(struct media_player *player)
@@ -1006,7 +1006,7 @@ int media_proxy_ctrl_get_playback_speed(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t speed)
@@ -1041,7 +1041,7 @@ int media_proxy_ctrl_set_playback_speed(struct media_player *player, int8_t spee
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_seeking_speed(struct media_player *player)
@@ -1076,7 +1076,7 @@ int media_proxy_ctrl_get_seeking_speed(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_track_segments_id(struct media_player *player)
@@ -1111,7 +1111,7 @@ int media_proxy_ctrl_get_track_segments_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_current_track_id(struct media_player *player)
@@ -1146,7 +1146,7 @@ int media_proxy_ctrl_get_current_track_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t id)
@@ -1187,7 +1187,7 @@ int media_proxy_ctrl_set_current_track_id(struct media_player *player, uint64_t 
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_next_track_id(struct media_player *player)
@@ -1222,7 +1222,7 @@ int media_proxy_ctrl_get_next_track_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id)
@@ -1263,7 +1263,7 @@ int media_proxy_ctrl_set_next_track_id(struct media_player *player, uint64_t id)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_parent_group_id(struct media_player *player)
@@ -1298,7 +1298,7 @@ int media_proxy_ctrl_get_parent_group_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_current_group_id(struct media_player *player)
@@ -1333,7 +1333,7 @@ int media_proxy_ctrl_get_current_group_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t id)
@@ -1374,7 +1374,7 @@ int media_proxy_ctrl_set_current_group_id(struct media_player *player, uint64_t 
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_playing_order(struct media_player *player)
@@ -1410,7 +1410,7 @@ int media_proxy_ctrl_get_playing_order(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t order)
@@ -1445,7 +1445,7 @@ int media_proxy_ctrl_set_playing_order(struct media_player *player, uint8_t orde
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player)
@@ -1480,7 +1480,7 @@ int media_proxy_ctrl_get_playing_orders_supported(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_media_state(struct media_player *player)
@@ -1515,7 +1515,7 @@ int media_proxy_ctrl_get_media_state(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_send_command(struct media_player *player, struct mpl_cmd cmd)
@@ -1550,7 +1550,7 @@ int media_proxy_ctrl_send_command(struct media_player *player, struct mpl_cmd cm
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_commands_supported(struct media_player *player)
@@ -1585,7 +1585,7 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_send_search(struct media_player *player, struct mpl_search search)
@@ -1620,7 +1620,7 @@ int media_proxy_ctrl_send_search(struct media_player *player, struct mpl_search 
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 int media_proxy_ctrl_get_search_results_id(struct media_player *player)
@@ -1655,7 +1655,7 @@ int media_proxy_ctrl_get_search_results_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 
 uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player)
@@ -1690,7 +1690,7 @@ uint8_t media_proxy_ctrl_get_content_ctrl_id(struct media_player *player)
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
-	return -EOPNOTSUPP;
+	return -EINVAL;
 }
 #endif /* CONFIG_MCTL_LOCAL_PLAYER_LOCAL_CONTROL || CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -50,6 +50,7 @@ static void local_player_instance_cb(struct media_player *plr, int err)
 	}
 }
 
+#ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL
 static void discover_player_cb(struct media_player *plr, int err)
 {
 	if (err) {
@@ -63,6 +64,7 @@ static void discover_player_cb(struct media_player *plr, int err)
 	/* Assuming that since discovery was called, the remote player is wanted */
 	current_player = remote_player;
 }
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
 static void player_name_cb(struct media_player *plr, int err, const char *name)
 {
@@ -386,7 +388,9 @@ int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	/* Set up the callback structure */
+#ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL
 	cbs.discover_player               = discover_player_cb;
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 	cbs.local_player_instance         = local_player_instance_cb;
 	cbs.player_name_recv              = player_name_cb;
 	cbs.icon_id_recv                  = icon_id_cb;
@@ -478,7 +482,7 @@ static int cmd_media_show_players(const struct shell *sh, size_t argc, char *arg
 	return 0;
 }
 
-#ifdef CONFIG_BT_MCC
+#ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL
 static int cmd_media_discover_player(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err = media_proxy_ctrl_discover_player(default_conn);
@@ -489,7 +493,7 @@ static int cmd_media_discover_player(const struct shell *sh, size_t argc, char *
 
 	return err;
 }
-#endif /* CONFIG_BT_MCC */
+#endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
 static int cmd_media_read_player_name(const struct shell *sh, size_t argc, char *argv[])
 {


### PR DESCRIPTION
This PR fixes various comments postponed from an earlier PR.
- return -EINVAL instead of -EOPNOTSUPP in calls to player
- guard a callback in the struct in the header file, to not spend memory unecessarily
- move variables to innermost scope

In addition, there is a fix for guarding, and a spelling correction.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/41200