### PR TITLE
drivers: counter: Fix dt_node_bool_prop calls in Kconfig.nrfx

### DIFF
--- a/drivers/counter/Kconfig.nrfx
+++ b/drivers/counter/Kconfig.nrfx
@@ -97,14 +97,14 @@ config COUNTER_RTC2_ZLI
 
 # Internal flag which detects if PPI wrap feature is enabled for any instance
 config COUNTER_RTC_WITH_PPI_WRAP
-	def_bool ($(dt_node_bool_prop,rtc-0,ppi-wrap) && COUNTER_RTC0) || \
-		 ($(dt_node_bool_prop,rtc-1,ppi-wrap) && COUNTER_RTC1) || \
-		 ($(dt_node_bool_prop,rtc-2,ppi-wrap) && COUNTER_RTC2)
+	def_bool ($(dt_nodelabel_bool_prop,rtc0,ppi-wrap) && COUNTER_RTC0) || \
+		 ($(dt_nodelabel_bool_prop,rtc1,ppi-wrap) && COUNTER_RTC1) || \
+		 ($(dt_nodelabel_bool_prop,rtc2,ppi-wrap) && COUNTER_RTC2)
 	select NRFX_PPI if HAS_HW_NRF_PPI
 	select NRFX_DPPI if HAS_HW_NRF_DPPIC
 
 # Internal flag which detects if fixed top feature is enabled for any instance
 config COUNTER_RTC_CUSTOM_TOP_SUPPORT
-	def_bool (!$(dt_node_bool_prop,rtc-0,fixed-top) && COUNTER_RTC0) || \
-		 (!$(dt_node_bool_prop,rtc-1,fixed-top) && COUNTER_RTC1) || \
-		 (!$(dt_node_bool_prop,rtc-2,fixed-top) && COUNTER_RTC2)
+	def_bool (!$(dt_nodelabel_bool_prop,rtc0,fixed-top) && COUNTER_RTC0) || \
+		 (!$(dt_nodelabel_bool_prop,rtc1,fixed-top) && COUNTER_RTC1) || \
+		 (!$(dt_nodelabel_bool_prop,rtc2,fixed-top) && COUNTER_RTC2)

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -322,6 +322,9 @@ def _dt_node_bool_prop_generic(node_search_function, search_arg, prop):
     except edtlib.EDTError:
         return "n"
 
+    if node is None:
+        return "n"
+
     if prop not in node.props:
         return "n"
 


### PR DESCRIPTION
This is a follow up to commit a1ab8da86243d6ebcd5116a22ed3ddf4270a9260.

*scripts: kconfig: Add missing check in _dt_node_bool_prop_generic*

Handle the case when a node with the specified label does not exist.
Unlike edt.get_node(), edt.label2node.get() retuns None then, it does
not raise edtlib.EDTError.

*drivers: counter: Fix dt_node_bool_prop calls in Kconfig.nrfx*

Several calls to the dt_node_bool_prop function in Kconfig.nrfx for
the counter drivers are done with wrong parameters. The function
expects a full node path, but it is provided with only the node name
component.
Fix those by using dt_nodelabel_bool_prop instead, as such function is
available now and it is more suitable for such cases.
