### PR TITLE
boards: arm: nucleo_h743zi runner openocd requires reset halt

### DIFF
--- a/boards/arm/nucleo_h743zi/board.cmake
+++ b/boards/arm/nucleo_h743zi/board.cmake
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
+board_runner_args(openocd --cmd-post-verify "reset halt")
 board_runner_args(jlink "--device=STM32H743ZI" "--speed=4000")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 


### PR DESCRIPTION
Add the command to the openocd runner so that a board reset happens
after flash and verify

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/42351

Signed-off-by: Francois Ramu <francois.ramu@st.com>