### PR TITLE
sensor: bme280: fix pressure conversion to hPa

### DIFF
--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -240,9 +240,9 @@ static int bme280_channel_get(const struct device *dev,
 		 * fractional.  Output value of 24674867 represents
 		 * 24674867/256 = 96386.2 Pa = 963.862 hPa
 		 */
-		val->val1 = (data->comp_press >> 8) / 1000U;
-		val->val2 = (data->comp_press >> 8) % 1000 * 1000U +
-			(((data->comp_press & 0xff) * 1000U) >> 8);
+		val->val1 = (data->comp_press >> 8) / 100U;
+		val->val2 = (data->comp_press >> 8) % 100 * 10000U +
+			(((data->comp_press & 0xff) * 10000U) >> 8);
 		break;
 	case SENSOR_CHAN_HUMIDITY:
 		/*


### PR DESCRIPTION
The [BME280 datasheet](https://www.bosch-sensortec.com/media/boschsensortec/downloads/datasheets/bst-bme280-ds002.pdf) specifies an operating range for the pressure reading between 300 hPa and 1100 hPa. Currently this driver outputs a value that is an order of magnitude off from hPa (e.g. 97.696777 instead of 976.967770).

![image](https://user-images.githubusercontent.com/367685/159719821-4de5d13c-e756-4db5-beed-b7a010aa8e9a.png)

## Issue:

We can print out the raw data to see how the driver currently performs by adding one statement to [the sensor driver file](https://github.com/zephyrproject-rtos/zephyr/blob/646499c36e84d4d05dc4f0b9938af5e6110f0665/drivers/sensor/bme280/bme280.c#L237-L246):

```
	case SENSOR_CHAN_PRESS:
		/*
		 * data->comp_press has 24 integer bits and 8
		 * fractional.  Output value of 24674867 represents
		 * 24674867/256 = 96386.2 Pa = 963.862 hPa
		 */
		printk("data->comp_press: %u\n", data->comp_press);	/* Added to show the problem */
		val->val1 = (data->comp_press >> 8) / 1000U;
		val->val2 = (data->comp_press >> 8) % 1000 * 1000U +
			(((data->comp_press & 0xff) * 1000U) >> 8);
		break;
```

Output

```			
data->comp_press: 25010375
temp: 24.090000; press: 97.696777; humidity: 37.388671
```

The lower 8 bits are the decimal values of that reading, so 25010375/256 = 97696.7773 P = 976.9678 hPa

## Corrected by this PR:

This PR fixes the conversion, outputting the expected valued in the 300..1100 range, and preserves more precision.

```
data->comp_press: 25006314
temp: 24.560000; press: 976.809140; humidity: 36.538085
```

25006314/256 = 97680.9140625 P = 976.80914065 hPa