### PR TITLE
devicetree: deprecate DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL 

### DIFF
--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -6,6 +6,7 @@
  */
 
 #include <zephyr.h>
+#include <devicetree.h>
 
 #include <shell/shell.h>
 #include <sys/util.h>
@@ -18,11 +19,8 @@
 #define BUF_ARRAY_CNT 16
 #define TEST_ARR_SIZE 0x1000
 
-#ifdef DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
-#define FLASH_DEV_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
-#else
-#define FLASH_DEV_NAME ""
-#endif
+static const struct device *zephyr_flash_controller =
+	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_flash_controller));
 
 static uint8_t __aligned(4) test_arr[TEST_ARR_SIZE];
 
@@ -33,12 +31,27 @@ static int parse_helper(const struct shell *shell, size_t *argc,
 	char *endptr;
 
 	*addr = strtoul((*argv)[1], &endptr, 16);
-	*flash_dev = device_get_binding((*endptr != '\0') ? (*argv)[1] :
-			FLASH_DEV_NAME);
-	if (!*flash_dev) {
-		shell_error(shell, "Flash driver was not found!");
+
+	if (*endptr != '\0') {
+		/* flash controller from user input */
+		*flash_dev = device_get_binding((*argv)[1]);
+		if (!*flash_dev) {
+			shell_error(shell, "Given flash device was not found");
+			return -ENODEV;
+		}
+	} else if (zephyr_flash_controller != NULL) {
+		/* default to zephyr,flash-controller */
+		if (!device_is_ready(zephyr_flash_controller)) {
+			shell_error(shell, "Default flash driver not ready");
+			return -ENODEV;
+		}
+		*flash_dev = zephyr_flash_controller;
+	} else {
+		/* no flash controller given, no default available */
+		shell_error(shell, "No flash device specified (required)");
 		return -ENODEV;
 	}
+
 	if (*endptr == '\0') {
 		return 0;
 	}

--- a/include/devicetree/zephyr.h
+++ b/include/devicetree/zephyr.h
@@ -46,6 +46,10 @@
 /**
  * @def DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
  *
+ * @deprecated Use @c DT_LABEL(DT_CHOSEN(zephyr_flash_controller)) instead. If
+ * used to to obtain a device instance with device_get_binding(), consider using
+ * @c DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller)).
+ *
  * @brief If there is a chosen node zephyr,flash-controller property which has
  *        a label property, that property's value. Undefined otherwise.
  */
@@ -60,7 +64,7 @@
 
 #if DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_flash_controller), label)
 #define DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL \
-	DT_LABEL(DT_CHOSEN(zephyr_flash_controller))
+	__DEPRECATED_MACRO DT_LABEL(DT_CHOSEN(zephyr_flash_controller))
 #endif
 
 /**

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -7,6 +7,7 @@
 
 #include <zephyr.h>
 #include <device.h>
+#include <devicetree.h>
 #include <drivers/gpio.h>
 #include <display/cfb.h>
 #include <sys/printk.h>
@@ -577,9 +578,12 @@ static int configure_leds(void)
 
 static int erase_storage(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 
-	dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
+	if (!device_is_ready(dev)) {
+		printk("Flash device not ready\n");
+		return -ENODEV;
+	}
 
 	return flash_erase(dev, FLASH_AREA_OFFSET(storage),
 			   FLASH_AREA_SIZE(storage));

--- a/samples/drivers/soc_flash_nrf/src/main.c
+++ b/samples/drivers/soc_flash_nrf/src/main.c
@@ -9,6 +9,7 @@
 #include <drivers/flash.h>
 #include <storage/flash_map.h>
 #include <device.h>
+#include <devicetree.h>
 #include <stdio.h>
 
 
@@ -44,11 +45,9 @@ void main(void)
 	printf("\nNordic nRF5 Flash Testing\n");
 	printf("=========================\n");
 
-	flash_dev =
-		device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-
-	if (!flash_dev) {
-		printf("Nordic nRF5 flash driver was not found!\n");
+	flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+	if (!device_is_ready(flash_dev)) {
+		printf("Flash device not ready\n");
 		return;
 	}
 

--- a/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
+++ b/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
@@ -25,11 +25,7 @@
 #define STACKSIZE 1024
 #define PRIORITY 7
 
-#ifndef DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
-#define DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL ""
-#endif
-
-static const struct device *flash_dev;
+static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static struct flash_pages_info page_info;
 static int *mem;
 uint8_t flash_fill_buff[FLASH_READBACK_LEN];
@@ -245,9 +241,8 @@ void flash_test(void)
 
 void flash_init(void)
 {
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	if (!flash_dev) {
-		TC_ERROR("flash controller initialization failed\n");
+	if (!device_is_ready(flash_dev)) {
+		TC_ERROR("flash controller not ready\n");
 	}
 	flash_test();
 }

--- a/tests/drivers/flash/src/main.c
+++ b/tests/drivers/flash/src/main.c
@@ -12,7 +12,7 @@
 
 #if (CONFIG_NORDIC_QSPI_NOR - 0)
 #define NORDIC_QSPI_NOR_NODE DT_INST(0, nordic_qspi_nor)
-#define FLASH_DEVICE DT_LABEL(NORDIC_QSPI_NOR_NODE)
+#define FLASH_NODEID NORDIC_QSPI_NOR_NODE
 #define FLASH_TEST_REGION_OFFSET 0xff000
 
 #if DT_NODE_HAS_PROP(NORDIC_QSPI_NOR_NODE, size_in_bytes)
@@ -23,18 +23,18 @@
 
 #elif defined(CONFIG_FLASH_MCUX_FLEXSPI_NOR)
 
-#define FLASH_DEVICE DT_LABEL(DT_INST(0, nxp_imx_flexspi_nor))
+#define FLASH_NODEID DT_INST(0, nxp_imx_flexspi_nor)
 #define FLASH_TEST_REGION_OFFSET FLASH_AREA_OFFSET(storage)
 #define TEST_AREA_MAX ((FLASH_AREA_SIZE(storage)) + (FLASH_TEST_REGION_OFFSET))
 #elif defined(CONFIG_FLASH_MCUX_FLEXSPI_MX25UM51345G)
 
-#define FLASH_DEVICE DT_LABEL(DT_INST(0, nxp_imx_flexspi_mx25um51345g))
+#define FLASH_NODEID DT_INST(0, nxp_imx_flexspi_mx25um51345g)
 #define FLASH_TEST_REGION_OFFSET FLASH_AREA_OFFSET(storage)
 #define TEST_AREA_MAX ((FLASH_AREA_SIZE(storage)) + (FLASH_TEST_REGION_OFFSET))
 #else
 
 /* SoC embedded NVM */
-#define FLASH_DEVICE DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
+#define FLASH_NODEID DT_CHOSEN(zephyr_flash_controller)
 
 #ifdef CONFIG_TRUSTED_EXECUTION_NONSECURE
 #define FLASH_TEST_REGION_OFFSET FLASH_AREA_OFFSET(image_1_nonsecure)
@@ -50,7 +50,7 @@
 #define EXPECTED_SIZE	256
 #define CANARY		0xff
 
-static const struct device *flash_dev;
+static const struct device *flash_dev = DEVICE_DT_GET(FLASH_NODEID);
 static struct flash_pages_info page_info;
 static uint8_t __aligned(4) expected[EXPECTED_SIZE];
 
@@ -58,7 +58,8 @@ static void test_setup(void)
 {
 	int rc;
 
-	flash_dev = device_get_binding(FLASH_DEVICE);
+	zassert_true(device_is_ready(flash_dev), NULL);
+
 	const struct flash_parameters *flash_params =
 			flash_get_parameters(flash_dev);
 

--- a/tests/drivers/flash_simulator/src/main.c
+++ b/tests/drivers/flash_simulator/src/main.c
@@ -32,7 +32,7 @@
 		(((((((0xff & pat) << 8) | (0xff & pat)) << 8) | \
 		   (0xff & pat)) << 8) | (0xff & pat))
 
-static const struct device *flash_dev;
+static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static uint8_t test_read_buf[TEST_SIM_FLASH_SIZE];
 
 static uint32_t p32_inc;
@@ -76,10 +76,8 @@ static void test_init(void)
 {
 	int rc;
 
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-
-	zassert_true(flash_dev != NULL,
-		     "Simulated flash driver was not found!");
+	zassert_true(device_is_ready(flash_dev),
+		     "Simulated flash device not ready");
 
 	rc = flash_erase(flash_dev, FLASH_SIMULATOR_BASE_OFFSET,
 			 FLASH_SIMULATOR_FLASH_SIZE);

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -30,6 +30,7 @@
 #define TEST_DATA_ID			1
 #define TEST_SECTOR_COUNT		5U
 
+static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static struct nvs_fs fs;
 struct stats_hdr *sim_stats;
 struct stats_hdr *sim_thresholds;
@@ -608,13 +609,9 @@ void test_delete(void)
 void test_nvs_gc_corrupt_close_ate(void)
 {
 	struct nvs_ate ate, close_ate;
-	const struct device *flash_dev;
 	uint32_t data;
 	ssize_t len;
 	int err;
-
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(flash_dev != NULL,  "device_get_binding failure");
 
 	close_ate.id = 0xffff;
 	close_ate.offset = fs.sector_size - sizeof(struct nvs_ate) * 5;
@@ -667,11 +664,7 @@ void test_nvs_gc_corrupt_close_ate(void)
 void test_nvs_gc_corrupt_ate(void)
 {
 	struct nvs_ate corrupt_ate, close_ate;
-	const struct device *flash_dev;
 	int err;
-
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
-	zassert_true(flash_dev != NULL,  "device_get_binding failure");
 
 	close_ate.id = 0xffff;
 	close_ate.offset = fs.sector_size / 2;
@@ -709,6 +702,8 @@ void test_nvs_gc_corrupt_ate(void)
 
 void test_main(void)
 {
+	__ASSERT_NO_MSG(device_is_ready(flash_dev));
+
 	ztest_test_suite(test_nvs,
 			 ztest_unit_test_setup_teardown(test_nvs_mount, setup,
 				 teardown),

--- a/tests/subsys/shell/shell_flash/src/shell_flash_test.c
+++ b/tests/subsys/shell/shell_flash/src/shell_flash_test.c
@@ -35,7 +35,7 @@ static void test_flash_read(void)
 		"00000020: 61 62 63                                         |abc              |",
 	};
 	const struct shell *shell = shell_backend_dummy_get_ptr();
-	static const struct device *flash_dev;
+	const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	const char *buf;
 	const int test_base = FLASH_SIMULATOR_BASE_OFFSET;
 	const int test_size = 0x24;  /* 32-alignment required */
@@ -47,10 +47,9 @@ static void test_flash_read(void)
 	for (i = 0; i < test_size; i++) {
 		data[i] = 'A' + i;
 	}
-	flash_dev = device_get_binding(DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL);
 
-	zassert_true(flash_dev != NULL,
-		     "Simulated flash driver was not found!");
+	zassert_true(device_is_ready(flash_dev),
+		     "Simulated flash driver not ready");
 
 	ret = flash_write(flash_dev, test_base, data, test_size);
 	zassert_equal(0, ret, "flash_write() failed: %d", ret);

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -19,13 +19,12 @@
 #define TESTBUF_SIZE (MAX_PAGE_SIZE * MAX_NUM_PAGES)
 #define SOC_NV_FLASH_NODE DT_INST(0, soc_nv_flash)
 #define FLASH_SIZE DT_REG_SIZE(SOC_NV_FLASH_NODE)
-#define FLASH_NAME DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
 
 /* so that we don't overwrite the application when running on hw */
 #define FLASH_BASE (128*1024)
 #define FLASH_AVAILABLE (FLASH_SIZE-FLASH_BASE)
 
-static const struct device *fdev;
+static const struct device *fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static const struct flash_driver_api *api;
 static const struct flash_pages_layout *layout;
 static size_t layout_size;
@@ -646,7 +645,8 @@ static void test_stream_flash_progress_clear(void)
 
 void test_main(void)
 {
-	fdev = device_get_binding(FLASH_NAME);
+	__ASSERT_NO_MSG(device_is_ready(fdev));
+
 	api = fdev->api;
 	api->page_layout(fdev, &layout, &layout_size);
 


### PR DESCRIPTION
DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL was the last macro to be
deprecated from the DT_CHOSEN_()_LABEL series. All its usages have been
replaced with DT_CHOSEN(zephyr_flash_controller), usually combined with
DEVICE_DT_GET to obtain references at compile time.

Resolves https://github.com/zephyrproject-rtos/zephyr/issues/44128