### PR TITLE
ADC: STM32: Add device tree config for clock source with prescaler

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -259,6 +259,7 @@ struct adc_stm32_cfg {
 	void (*irq_cfg_func)(void);
 	struct stm32_pclken pclken;
 	const struct pinctrl_dev_config *pcfg;
+	uint32_t clock_prescaler;
 	bool has_temp_channel;
 	bool has_vref_channel;
 	bool has_vbat_channel;
@@ -994,6 +995,8 @@ static int adc_stm32_init(const struct device *dev)
 		return -EIO;
 	}
 
+	LOG_DBG("ADC clock prescaler (%d)", config->clock_prescaler);
+
 	/* Configure dt provided device signals when available */
 	err = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (err < 0) {
@@ -1039,20 +1042,18 @@ static int adc_stm32_init(const struct device *dev)
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
-	LL_ADC_SetClock(adc, LL_ADC_CLOCK_SYNC_PCLK_DIV4);
+	LL_ADC_SetClock(adc, config->clock_prescaler);
 #elif defined(STM32F3X_ADC_V1_1) || \
 	defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L5X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \
 	defined(CONFIG_SOC_SERIES_STM32G4X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X)
-	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),
-			      LL_ADC_CLOCK_SYNC_PCLK_DIV4);
-#elif defined(CONFIG_SOC_SERIES_STM32L1X) || \
+	defined(CONFIG_SOC_SERIES_STM32H7X) || \
+	defined(CONFIG_SOC_SERIES_STM32L1X) || \
 	defined(CONFIG_SOC_SERIES_STM32U5X)
 	LL_ADC_SetCommonClock(__LL_ADC_COMMON_INSTANCE(adc),
-			LL_ADC_CLOCK_ASYNC_DIV4);
+			      config->clock_prescaler);
 #endif
 
 #if !defined(CONFIG_SOC_SERIES_STM32F2X) && \
@@ -1169,6 +1170,27 @@ static const struct adc_driver_api api_stm32_driver_api = {
 	.ref_internal = STM32_ADC_VREF_MV, /* VREF is usually connected to VDD */
 };
 
+/*
+ * define a prefix to be LL_ADC_CLOCK_ASYNC_DIVn or LL_ADC_CLOCK_SYNC_PCLK_DIVn
+ * for the ADC clock prescaler, depending on the serie (stm32F1 has none)
+ */
+#if defined(CONFIG_SOC_SERIES_STM32L1X) || \
+	defined(CONFIG_SOC_SERIES_STM32U5X)
+#define prescaler_pre LL_ADC_CLOCK_ASYNC_DIV
+#elif !defined(CONFIG_SOC_SERIES_STM32F1X)
+#define prescaler_pre LL_ADC_CLOCK_SYNC_PCLK_DIV
+#endif
+
+#ifdef prescaler_pre
+/* LL_ADC_CLOCK_x value from the existing st,prescaler property (default is _DIV4) */
+#define DT_PRESC_PROP_OR(inst, prefix)							\
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, st_prescaler),				\
+		    (_CONCAT(prefix, DT_STRING_TOKEN(DT_DRV_INST(inst), st_prescaler))),\
+		    (_CONCAT(prefix, 4)))
+#else
+#define DT_PRESC_PROP_OR(inst, prefix) 0
+#endif /* prescaler_pre */
+
 #ifdef CONFIG_ADC_STM32_SHARED_IRQS
 
 bool adc_stm32_is_irq_active(ADC_TypeDef *adc)
@@ -1213,6 +1235,7 @@ static const struct adc_stm32_cfg adc_stm32_cfg_##index = {		\
 		.bus = DT_INST_CLOCKS_CELL(index, bus),			\
 	},								\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
+	.clock_prescaler = DT_PRESC_PROP_OR(index, prescaler_pre),	\
 	.has_temp_channel = DT_INST_PROP(index, has_temp_channel),	\
 	.has_vref_channel = DT_INST_PROP(index, has_vref_channel),	\
 	.has_vbat_channel = DT_INST_PROP(index, has_vbat_channel),	\
@@ -1235,6 +1258,7 @@ static const struct adc_stm32_cfg adc_stm32_cfg_##index = {		\
 		.bus = DT_INST_CLOCKS_CELL(index, bus),			\
 	},								\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
+	.clock_prescaler = DT_PRESC_PROP_OR(index, prescaler_pre),	\
 	.has_temp_channel = DT_INST_PROP(index, has_temp_channel),	\
 	.has_vref_channel = DT_INST_PROP(index, has_vref_channel),	\
 	.has_vbat_channel = DT_INST_PROP(index, has_vbat_channel),	\
@@ -1257,6 +1281,6 @@ DEVICE_DT_INST_DEFINE(index,						\
 		    &adc_stm32_init, NULL,				\
 		    &adc_stm32_data_##index, &adc_stm32_cfg_##index,	\
 		    POST_KERNEL, CONFIG_ADC_INIT_PRIORITY,		\
-		    &api_stm32_driver_api);
+		    &api_stm32_driver_api);				\
 
 DT_INST_FOREACH_STATUS_OKAY(STM32_ADC_INIT)

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -27,6 +27,27 @@ properties:
     pinctrl-names:
       required: true
 
+    st,prescaler:
+      type: string
+      required: no
+      enum:
+        - "1" # not divided
+        - "2"
+        - "4"
+        - "6"
+        - "8"
+        - "10"
+        - "12"
+        - "16"
+        - "32"
+        - "64"
+        - "128"
+        - "256"
+      description: |
+        Clock prescaler at the input of the adc:
+        can be LL_ADC_CLOCK_SYNC_PCLK_DIVx or LL_ADC_CLOCK_ASYNC_DIVx
+        depending on the stm32 serie. Refer to the RefMan
+
     vref-mv:
       type: int
       required: false


### PR DESCRIPTION
This PR adds a clock prescaler to the ADC of the stm32 mcus

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/40955

Signed-off-by: Francois Ramu <francois.ramu@st.com>