### PR TITLE
cmake: modules: boards: Add board revision variable

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -846,6 +846,12 @@ config BOARD
 	  if not found we look for the linker file in
 	  soc/<arch>/<family>/<series>
 
+config BOARD_REVISION
+	string
+	help
+	  This option holds the revision of the board (if a board revision was
+	  used)
+
 config TOOLCHAIN_HAS_BUILTIN_FFS
 	bool
 	default y if !(64BIT && RISCV)

--- a/cmake/modules/boards.cmake
+++ b/cmake/modules/boards.cmake
@@ -128,6 +128,9 @@ if(DEFINED BOARD_REVISION)
     set(BOARD_REVISION ${ACTIVE_BOARD_REVISION})
   endif()
 
+  # Add board revision to build variables
+  add_definitions(-DCONFIG_BOARD_REVISION="${BOARD_REVISION}")
+
   string(REPLACE "." "_" BOARD_REVISION_STRING ${BOARD_REVISION})
 endif()
 


### PR DESCRIPTION
Not sure this is the right way to go about this but don't know enough about the internals of the zephyr build system to know where this would go. Use case is for application code to be able to know the board revision that it was compiled for.

    This variable can be accessed by applications to know what board
    revision is being used.
