### PR TITLE
Bluetooth: Host: Bitwise-or CCC values

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -52,6 +52,8 @@ Bluetooth
   * The enum bt_l2cap_chan_state values BT_L2CAP_CONNECT and BT_L2CAP_DISCONNECT
     has been renamed to BT_L2CAP_CONNECTING and BT_L2CAP_DISCONNECTING.
 
+  * :c:member:`_bt_gatt_ccc.value` is now a bitwise-or reduction of the
+    individual CCC values of connected clients instead of the maximum.
 
 New APIs in this release
 ========================

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -703,7 +703,7 @@ struct _bt_gatt_ccc {
 	/** Configuration for each connection */
 	struct bt_gatt_ccc_cfg cfg[BT_GATT_CCC_MAX];
 
-	/** Highest value of all connected peer's subscriptions */
+	/** Bitwise-or of all connected peer's CCC values */
 	uint16_t value;
 
 	/** @brief CCC attribute changed callback

--- a/include/bluetooth/gatt.h
+++ b/include/bluetooth/gatt.h
@@ -706,10 +706,20 @@ struct _bt_gatt_ccc {
 	/** Bitwise-or of all connected peer's CCC values */
 	uint16_t value;
 
-	/** @brief CCC attribute changed callback
+	/** @brief React to changes to the @c value field of this struct
 	 *
-	 *  @param attr   The attribute that's changed value
-	 *  @param value  New value
+	 *  Use this event to optimize when to broadcast using bt_gatt_indicate()
+	 *  and bt_gatt_notify().
+	 *
+	 *  This event will not trigger if only the @c cfg field changes but the
+	 *  @c value field remains the same. Combine the use of this event and
+	 *  @c cfg_write to catch all changes to the @c cfg field.
+	 *
+	 *  Note: This event may come before the connection event when CCC values
+	 *  are restored from bond information.
+	 *
+	 *  @param attr   The attribute this CCC refers to
+	 *  @param value  New value of the @c value field
 	 */
 	void (*cfg_changed)(const struct bt_gatt_attr *attr, uint16_t value);
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1890,8 +1890,18 @@ static void gatt_ccc_changed(const struct bt_gatt_attr *attr,
 	uint16_t value = 0x0000;
 
 	for (i = 0; i < ARRAY_SIZE(ccc->cfg); i++) {
-		if (ccc->cfg[i].value > value) {
-			value = ccc->cfg[i].value;
+		/* `ccc->value` shall be a summary of connected peers' CCC values, but
+		 * `ccc->cfg` can contain entries for bonded but not connected peers.
+		 */
+		struct bt_conn *conn = bt_conn_lookup_addr_le(ccc->cfg[i].id, &ccc->cfg[i].peer);
+
+		if (conn) {
+			if (ccc->cfg[i].value > value) {
+				value = ccc->cfg[i].value;
+			}
+
+			bt_conn_unref(conn);
+			conn = NULL;
 		}
 	}
 

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -1896,9 +1896,7 @@ static void gatt_ccc_changed(const struct bt_gatt_attr *attr,
 		struct bt_conn *conn = bt_conn_lookup_addr_le(ccc->cfg[i].id, &ccc->cfg[i].peer);
 
 		if (conn) {
-			if (ccc->cfg[i].value > value) {
-				value = ccc->cfg[i].value;
-			}
+			value |= ccc->cfg[i].value;
 
 			bt_conn_unref(conn);
 			conn = NULL;


### PR DESCRIPTION
This PR fixes several issues:
  - Only consider connected peers when summing CCC values instead of
    connected or bonded.
  - Aggregate the value of the CCC using bitwise-or instead of max.
  - Document the `cfg_changed` event.