### PR TITLE
drivers: sensor: bmi160: fix waiting time before reading CHIP_ID

### DIFF
--- a/drivers/sensor/bmi160/bmi160.c
+++ b/drivers/sensor/bmi160/bmi160.c
@@ -898,7 +898,7 @@ int bmi160_init(const struct device *dev)
 		return -EIO;
 	}
 
-	k_busy_wait(100);
+	k_busy_wait(150);
 
 	if (bmi160_byte_read(dev, BMI160_REG_CHIPID, &val) < 0) {
 		LOG_DBG("Failed to read chip id.");


### PR DESCRIPTION
Value changed from 100ms to 150ms. Value was not enough upon softreset.

Fixes #43794

Signed-off-by: Diogo Correia <dcorreia@protonmail.com>