### PR TITLE
samples: tflite-micro: fix hello_world README

### DIFF
--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -61,16 +61,15 @@ Sample Output
 
     ...
 
-The modified sample prints 50 generated-x-and-predicted-y pairs.
+The modified sample prints 10 generated-x-and-predicted-y pairs. To see
+the full period of the sine curve, increase the number of loops in :file:`main.c`.
 
 Modifying Sample for Your Own Project
 *************************************
 
 It is recommended that you copy and modify one of the two TensorFlow
 samples when creating your own TensorFlow project. To build with
-TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`.
-
-:file:`prj.conf`:
+TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`:
 
 .. code-block:: console
 


### PR DESCRIPTION
Corrects number of loops mentioned in README of sample
to match NUM_LOOPS in main.c. NUM_LOOPS was lowered in
PR #41123 to reduce the noise the sample produced in CI,
but the PR missed changing the README.

Cleans up one line.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>