### PR TITLE
devicetree: child index accessors

### DIFF
--- a/doc/guides/dts/macros.bnf
+++ b/doc/guides/dts/macros.bnf
@@ -67,6 +67,8 @@ node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_VARGS"
 ; over each child node with status "okay".
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_VARGS"
+; The node's zero-based index in the list of it's parent's child nodes.
+node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX"
 ; The node's status macro; dt-name in this case is something like "okay"
 ; or "disabled".
 node-macro =/ %s"DT_N" path-id %s"_STATUS_" dt-name

--- a/include/devicetree.h
+++ b/include/devicetree.h
@@ -475,6 +475,30 @@
 #define DT_NODE_FULL_NAME(node_id) DT_CAT(node_id, _FULL_NAME)
 
 /**
+ * @brief Get a devicetree node's index into its parent's list of children
+ *
+ * Indexes are zero-based.
+ *
+ * It is an error to use this macro with the root node.
+ *
+ * Example devicetree fragment:
+ *
+ *     parent {
+ *             c1: child-1 {};
+ *             c2: child-2 {};
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_NODE_CHILD_IDX(DT_NODELABEL(c1)) // 0
+ *     DT_NODE_CHILD_IDX(DT_NODELABEL(c2)) // 1
+ *
+ * @param node_id node identifier
+ * @return the node's index in its parent node's list of children
+ */
+#define DT_NODE_CHILD_IDX(node_id) DT_CAT(node_id, _CHILD_IDX)
+
+/**
  * @brief Do node_id1 and node_id2 refer to the same node?
  *
  * Both "node_id1" and "node_id2" must be node identifiers for nodes

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -132,8 +132,7 @@ def main():
                 out_dt_define(f"{node.z_path_id}_PARENT",
                               f"DT_{node.parent.z_path_id}")
 
-            write_child_functions(node)
-            write_child_functions_status_okay(node)
+            write_children(node)
             write_dep_info(node)
             write_idents_and_existence(node)
             write_bus(node)
@@ -531,9 +530,8 @@ def write_compatibles(node):
             f"{node.z_path_id}_COMPAT_MATCHES_{str2ident(compat)}", 1)
 
 
-def write_child_functions(node):
-    # Writes macro that are helpers that will call a macro/function
-    # for each child node.
+def write_children(node):
+    # Writes helper macros for dealing with node's children.
 
     out_dt_define(f"{node.z_path_id}_FOREACH_CHILD(fn)",
             " ".join(f"fn(DT_{child.z_path_id})" for child in
@@ -542,10 +540,6 @@ def write_child_functions(node):
     out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_VARGS(fn, ...)",
             " ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)" for child in
                 node.children.values()))
-
-def write_child_functions_status_okay(node):
-    # Writes macros that are helpers that will call a macro/function
-    # for each child node with status "okay".
 
     functions = ''
     functions_args = ''

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -132,6 +132,10 @@ def main():
                 out_dt_define(f"{node.z_path_id}_PARENT",
                               f"DT_{node.parent.z_path_id}")
 
+                out_comment(f"Node's index in its parent's list of children:")
+                out_dt_define(f"{node.z_path_id}_CHILD_IDX",
+                              node.parent.child_index(node))
+
             write_children(node)
             write_dep_info(node)
             write_idents_and_existence(node)

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -724,6 +724,21 @@ class Node:
         return OrderedDict((name, self.edt._node2enode[node])
                            for name, node in self._node.nodes.items())
 
+    def child_index(self, node):
+        """Get the index of *node* in self.children.
+        Raises KeyError if the argument is not a child of this node.
+        """
+        if not hasattr(self, '_child2index'):
+            # Defer initialization of this lookup table until this
+            # method is callable to handle parents needing to be
+            # initialized before their chidlren. By the time we
+            # return from __init__, 'self.children' is callable.
+            self._child2index = OrderedDict()
+            for index, child in enumerate(self.children.values()):
+                self._child2index[child] = index
+
+        return self._child2index[node]
+
     @property
     def required_by(self):
         "See the class docstring"

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -310,7 +310,7 @@
 	};
 
 	//
-	// For testing Node.parent and Node.children
+	// For testing hierarchy.
 	//
 
 	parent {

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -158,6 +158,20 @@ def test_hierarchy():
 
     assert edt.get_node("/parent/child-1").children == {}
 
+def test_child_index():
+    '''Test Node.child_index.'''
+    with from_here():
+        edt = edtlib.EDT("test.dts", ["test-bindings"])
+
+    parent, child_1, child_2 = [edt.get_node(path) for path in
+                                ("/parent",
+                                 "/parent/child-1",
+                                 "/parent/child-2")]
+    assert parent.child_index(child_1) == 0
+    assert parent.child_index(child_2) == 1
+    with pytest.raises(KeyError):
+        parent.child_index(parent)
+
 def test_include():
     '''Test 'include:' and the legacy 'inherits: !include ...' in bindings'''
     with from_here():

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1996,6 +1996,13 @@ static void test_node_name(void)
 			     "reg-holder"), "");
 }
 
+static void test_node_child_idx(void)
+{
+	zassert_equal(DT_NODE_CHILD_IDX(DT_NODELABEL(test_child_a)), 0, "");
+	zassert_equal(DT_NODE_CHILD_IDX(DT_NODELABEL(test_child_b)), 1, "");
+	zassert_equal(DT_NODE_CHILD_IDX(DT_NODELABEL(test_child_c)), 2, "");
+}
+
 static void test_same_node(void)
 {
 	zassert_true(DT_SAME_NODE(TEST_DEADBEEF, TEST_DEADBEEF), "");
@@ -2369,6 +2376,7 @@ void test_main(void)
 			 ztest_unit_test(test_dep_ord),
 			 ztest_unit_test(test_path),
 			 ztest_unit_test(test_node_name),
+			 ztest_unit_test(test_node_child_idx),
 			 ztest_unit_test(test_same_node),
 			 ztest_unit_test(test_pinctrl),
 			 ztest_unit_test(test_mbox),


### PR DESCRIPTION
The main point of this PR is to add the following macro:

```
+/**
+ * @brief Get a devicetree node's index into its parent's list of children
+ *
+ * Indexes are zero-based.
+ *
+ * It is an error to use this macro with the root node.
+ *
+ * Example devicetree fragment:
+ *
+ *     parent {
+ *             c1: child-1 {};
+ *             c2: child-2 {};
+ *     };
+ *
+ * Example usage:
+ *
+ *     DT_NODE_CHILD_IDX(DT_NODELABEL(c1)) // 0
+ *     DT_NODE_CHILD_IDX(DT_NODELABEL(c2)) // 1
+ *
+ * @param node_id node identifier
+ * @return the node's index in its parent node's list of children
+ */
+#define DT_NODE_CHILD_IDX(node_id) [...]
```

Everything else is just prep work and bookkeeping.

Fixes:  #43988