### PR TITLE
Bluetooth: Controller: df: Fix CTE req send wrong ntf in single shot run

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -366,9 +366,11 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ)
 	case PROC_CTE_REQ:
 		if (ctx->response_opcode == PDU_DATA_LLCTRL_TYPE_CTE_RSP) {
-			if (ctx->data.cte_remote_rsp.has_cte &&
-			    conn->llcp.cte_req.req_interval != 0U) {
-				conn->llcp.cte_req.req_expire = conn->llcp.cte_req.req_interval;
+			if (ctx->data.cte_remote_rsp.has_cte) {
+				if (conn->llcp.cte_req.req_interval != 0U) {
+					conn->llcp.cte_req.req_expire =
+						conn->llcp.cte_req.req_interval;
+				}
 				ctx->state = LP_COMMON_STATE_IDLE;
 			} else if (llcp_ntf_alloc_is_available()) {
 				lp_comm_ntf(conn, ctx);


### PR DESCRIPTION
In case the CTE request was executed as a single shot and Controller
successfully received LL_CTE_RSP PDU there was an assertion.
The assertion was caused by not completely prepared notification PDU.
The notification PDU was send towards Host by CTE request handling code
due to an error in lp_comm_complete function. If the CTE request was
single shot it went into wrong if-else statement, despite that the
LL_CTE_RSP was correctly received.

A check if-clause if the procedure is periodic should not affect the
procedure completion. It should affect whether req_expire counter has
to be restored.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>