### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 8.8

### DIFF
--- a/include/sys/kobject.h
+++ b/include/sys/kobject.h
@@ -134,6 +134,38 @@ struct z_object_assignment {
  * @param obj Address of the kernel object
  */
 void z_object_init(const void *obj);
+
+/**
+ * Revoke a thread's access to a kernel object
+ *
+ * The thread will lose access to the object if the caller is from
+ * supervisor mode, or the caller is from user mode AND has permissions
+ * on both the object and the thread whose access is being revoked.
+ *
+ * @param object Address of kernel object
+ * @param thread Thread to remove access to the object
+ */
+void k_object_access_revoke(const void *object, struct k_thread *thread);
+
+/**
+ * Grant all present and future threads access to an object
+ *
+ * If the caller is from supervisor mode, or the caller is from user mode and
+ * have sufficient permissions on the object, then that object will have
+ * permissions granted to it for *all* current and future threads running in
+ * the system, effectively becoming a public kernel object.
+ *
+ * Use of this API should be avoided on systems that are running untrusted code
+ * as it is possible for such code to derive the addresses of kernel objects
+ * and perform unwanted operations on them.
+ *
+ * It is not possible to revoke permissions on public objects; once public,
+ * any thread may use it.
+ *
+ * @param object Address of kernel object
+ */
+void k_object_access_all_grant(const void *object);
+
 #else
 /* LCOV_EXCL_START */
 #define K_THREAD_ACCESS_GRANT(thread, ...)
@@ -195,18 +227,6 @@ __syscall void k_object_access_grant(const void *object,
 				     struct k_thread *thread);
 
 /**
- * Revoke a thread's access to a kernel object
- *
- * The thread will lose access to the object if the caller is from
- * supervisor mode, or the caller is from user mode AND has permissions
- * on both the object and the thread whose access is being revoked.
- *
- * @param object Address of kernel object
- * @param thread Thread to remove access to the object
- */
-void k_object_access_revoke(const void *object, struct k_thread *thread);
-
-/**
  * @brief Release an object
  *
  * Allows user threads to drop their own permission on an object
@@ -216,25 +236,6 @@ void k_object_access_revoke(const void *object, struct k_thread *thread);
  *
  */
 __syscall void k_object_release(const void *object);
-
-/**
- * Grant all present and future threads access to an object
- *
- * If the caller is from supervisor mode, or the caller is from user mode and
- * have sufficient permissions on the object, then that object will have
- * permissions granted to it for *all* current and future threads running in
- * the system, effectively becoming a public kernel object.
- *
- * Use of this API should be avoided on systems that are running untrusted code
- * as it is possible for such code to derive the addresses of kernel objects
- * and perform unwanted operations on them.
- *
- * It is not possible to revoke permissions on public objects; once public,
- * any thread may use it.
- *
- * @param object Address of kernel object
- */
-void k_object_access_all_grant(const void *object);
 
 /**
  * Allocate a kernel object of a designated type


### PR DESCRIPTION
In particular:

- moved declarations so to not conflict with static inline stubs