### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 2.7

### DIFF
--- a/arch/x86/core/intel64/fatal.c
+++ b/arch/x86/core/intel64/fatal.c
@@ -15,6 +15,8 @@ LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
  */
 __weak bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 {
+	ARG_UNUSED(esf);
+
 	return false;
 }
 

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -34,6 +34,8 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 
 #if CONFIG_X86_STACK_PROTECTION
 	z_x86_set_stack_guard(stack);
+#else
+	ARG_UNUSED(stack);
 #endif
 #ifdef CONFIG_USERSPACE
 	switch_entry = z_x86_userspace_prepare_thread(thread);
@@ -65,11 +67,16 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 int arch_float_disable(struct k_thread *thread)
 {
 	/* x86-64 always has FP/SSE enabled so cannot be disabled */
+	ARG_UNUSED(thread);
+
 	return -ENOTSUP;
 }
 
 int arch_float_enable(struct k_thread *thread, unsigned int options)
 {
 	/* x86-64 always has FP/SSE enabled so nothing to do here */
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
+
 	return 0;
 }

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -189,6 +189,8 @@ uint32_t pcie_msi_map(unsigned int irq,
 	ARG_UNUSED(irq);
 #if defined(CONFIG_INTEL_VTD_ICTL)
 #if !defined(CONFIG_PCIE_MSI_X)
+	ARG_UNUSED(vector);
+
 	if (vector != NULL) {
 		map = vtd_remap_msi(vtd, vector);
 	} else
@@ -197,6 +199,8 @@ uint32_t pcie_msi_map(unsigned int irq,
 		map = vtd_remap_msi(vtd, vector);
 	} else
 #endif
+#else
+	ARG_UNUSED(vector);
 #endif
 	{
 		map = 0xFEE00000U; /* standard delivery to BSP local APIC */

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -449,6 +449,8 @@ static inline void assert_addr_aligned(uintptr_t addr)
 #if __ASSERT_ON
 	__ASSERT((addr & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
 		 "unaligned address 0x%" PRIxPTR, addr);
+#else
+	ARG_UNUSED(addr);
 #endif
 }
 
@@ -465,6 +467,8 @@ static inline void assert_region_page_aligned(void *addr, size_t size)
 #if __ASSERT_ON
 	__ASSERT((size & (CONFIG_MMU_PAGE_SIZE - 1)) == 0U,
 		 "unaligned size %zu", size);
+#else
+	ARG_UNUSED(size);
 #endif
 }
 
@@ -788,6 +792,9 @@ static inline pentry_t pte_finalize_value(pentry_t val, bool user_table,
 	    get_entry_phys(val, level) != shared_phys_addr) {
 		val = ~val;
 	}
+#else
+	ARG_UNUSED(user_table);
+	ARG_UNUSED(level);
 #endif
 	return val;
 }

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -217,6 +217,8 @@ static inline pentry_t *z_x86_thread_page_tables_get(struct k_thread *thread)
 		 */
 		return z_mem_virt_addr(thread->arch.ptables);
 	}
+#else
+	ARG_UNUSED(thread);
 #endif
 	return z_x86_kernel_ptables;
 }

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -68,6 +68,8 @@ static void disable_hpet(void)
  */
 uintptr_t __abi efi_entry(void *img_handle, struct efi_system_table *sys_tab)
 {
+	(void)img_handle;
+
 	efi = sys_tab;
 	z_putchar = efi_putchar;
 	printf("*** Zephyr EFI Loader ***\n");

--- a/include/debug/coredump.h
+++ b/include/debug/coredump.h
@@ -139,23 +139,36 @@ int coredump_cmd(enum coredump_cmd_id cmd_id, void *arg);
 void coredump(unsigned int reason, const z_arch_esf_t *esf,
 	      struct k_thread *thread)
 {
+	ARG_UNUSED(reason);
+	ARG_UNUSED(esf);
+	ARG_UNUSED(thread);
 }
 
 void coredump_memory_dump(uintptr_t start_addr, uintptr_t end_addr)
 {
+	ARG_UNUSED(start_addr);
+	ARG_UNUSED(end_addr);
 }
 
 void coredump_buffer_output(uint8_t *buf, size_t buflen)
 {
+	ARG_UNUSED(buf);
+	ARG_UNUSED(buflen);
 }
 
 int coredump_query(enum coredump_query_id query_id, void *arg)
 {
+	ARG_UNUSED(query_id);
+	ARG_UNUSED(arg);
+
 	return -ENOTSUP;
 }
 
 int coredump_cmd(enum coredump_cmd_id query_id, void *arg)
 {
+	ARG_UNUSED(query_id);
+	ARG_UNUSED(arg);
+
 	return -ENOTSUP;
 }
 

--- a/include/debug/stack.h
+++ b/include/debug/stack.h
@@ -35,6 +35,8 @@ static inline void log_stack_usage(const struct k_thread *thread)
 			thread, log_strdup(tname), unused, size - unused, size,
 			pcnt);
 	}
+#else
+	ARG_UNUSED(thread);
 #endif
 }
 #endif /* ZEPHYR_INCLUDE_DEBUG_STACK_H_ */

--- a/include/drivers/uart.h
+++ b/include/drivers/uart.h
@@ -473,6 +473,10 @@ static inline int uart_callback_set(const struct device *dev,
 
 	return api->callback_set(dev, callback, user_data);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(callback);
+	ARG_UNUSED(user_data);
+
 	return -ENOTSUP;
 #endif
 }
@@ -507,6 +511,11 @@ static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf,
 
 	return api->tx(dev, buf, len, timeout);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+
 	return -ENOTSUP;
 #endif
 }
@@ -533,6 +542,8 @@ static inline int z_impl_uart_tx_abort(const struct device *dev)
 
 	return api->tx_abort(dev);
 #else
+	ARG_UNUSED(dev);
+
 	return -ENOTSUP;
 #endif
 }
@@ -572,6 +583,11 @@ static inline int z_impl_uart_rx_enable(const struct device *dev,
 
 	return api->rx_enable(dev, buf, len, timeout);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
+
 	return -ENOTSUP;
 #endif
 }
@@ -606,6 +622,10 @@ static inline int uart_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 
 	return api->rx_buf_rsp(dev, buf, len);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+
 	return -ENOTSUP;
 #endif
 }
@@ -635,6 +655,8 @@ static inline int z_impl_uart_rx_disable(const struct device *dev)
 
 	return api->rx_disable(dev);
 #else
+	ARG_UNUSED(dev);
+
 	return -ENOTSUP;
 #endif
 }
@@ -804,9 +826,13 @@ static inline int uart_fifo_fill(const struct device *dev,
 	}
 
 	return api->fifo_fill(dev, tx_data, size);
-#endif
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(tx_data);
+	ARG_UNUSED(size);
 
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -845,9 +871,14 @@ static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data,
 	}
 
 	return api->fifo_read(dev, rx_data, size);
-#endif
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(rx_data);
+	ARG_UNUSED(size);
 
 	return -ENOTSUP;
+#endif
+
 }
 
 /**
@@ -868,6 +899,8 @@ static inline void z_impl_uart_irq_tx_enable(const struct device *dev)
 	if (api->irq_tx_enable != NULL) {
 		api->irq_tx_enable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 /**
@@ -888,6 +921,8 @@ static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
 	if (api->irq_tx_disable != NULL) {
 		api->irq_tx_disable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -919,9 +954,11 @@ static inline int uart_irq_tx_ready(const struct device *dev)
 	}
 
 	return api->irq_tx_ready(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
 
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -942,6 +979,8 @@ static inline void z_impl_uart_irq_rx_enable(const struct device *dev)
 	if (api->irq_rx_enable != NULL) {
 		api->irq_rx_enable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -963,6 +1002,8 @@ static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
 	if (api->irq_rx_disable != NULL) {
 		api->irq_rx_disable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -995,8 +1036,11 @@ static inline int uart_irq_tx_complete(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_tx_complete(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
+
 	return -ENOTSUP;
+#endif
 
 }
 
@@ -1031,9 +1075,11 @@ static inline int uart_irq_rx_ready(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_rx_ready(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
 
 	return -ENOTSUP;
+#endif
 }
 /**
  * @brief Enable error interrupt.
@@ -1053,6 +1099,8 @@ static inline void z_impl_uart_irq_err_enable(const struct device *dev)
 	if (api->irq_err_enable) {
 		api->irq_err_enable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -1075,6 +1123,8 @@ static inline void z_impl_uart_irq_err_disable(const struct device *dev)
 	if (api->irq_err_disable) {
 		api->irq_err_disable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -1100,8 +1150,11 @@ static inline int z_impl_uart_irq_is_pending(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_is_pending(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
+
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1141,8 +1194,11 @@ static inline int z_impl_uart_irq_update(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_update(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
+
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1169,6 +1225,10 @@ static inline void uart_irq_callback_user_data_set(const struct device *dev,
 	if ((api != NULL) && (api->irq_callback_set != NULL)) {
 		api->irq_callback_set(dev, cb, user_data);
 	}
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
 #endif
 }
 
@@ -1216,9 +1276,13 @@ static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
 		return -ENOSYS;
 	}
 	return api->line_ctrl_set(dev, ctrl, val);
-#endif
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
 
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1247,9 +1311,13 @@ static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
 		return -ENOSYS;
 	}
 	return api->line_ctrl_get(dev, ctrl, val);
-#endif
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
 
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1280,9 +1348,13 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 		return -ENOSYS;
 	}
 	return api->drv_cmd(dev, cmd, p);
-#endif
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(p);
 
 	return -ENOTSUP;
+#endif
 }
 
 #ifdef __cplusplus

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -223,10 +223,27 @@ bool pm_device_is_any_busy(void);
  */
 bool pm_device_is_busy(const struct device *dev);
 #else
-static inline void pm_device_busy_set(const struct device *dev) {}
-static inline void pm_device_busy_clear(const struct device *dev) {}
-static inline bool pm_device_is_any_busy(void) { return false; }
-static inline bool pm_device_is_busy(const struct device *dev) { return false; }
+static inline void pm_device_busy_set(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
+static inline void pm_device_busy_clear(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+}
+
+static inline bool pm_device_is_any_busy(void)
+{
+	return false;
+}
+
+static inline bool pm_device_is_busy(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return false;
+}
 #endif
 
 __deprecated static inline void device_busy_set(const struct device *dev)

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -193,6 +193,11 @@ static inline struct z_page_frame *z_phys_to_page_frame(uintptr_t phys)
 
 static inline void z_mem_assert_virtual_region(uint8_t *addr, size_t size)
 {
+#ifndef __ASSERT_ON
+	ARG_UNUSED(addr);
+	ARG_UNUSED(size);
+#endif
+
 	__ASSERT((uintptr_t)addr % CONFIG_MMU_PAGE_SIZE == 0U,
 		 "unaligned addr %p", addr);
 	__ASSERT(size % CONFIG_MMU_PAGE_SIZE == 0U,

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -88,6 +88,9 @@ static inline void handle_poll_events(struct k_queue *queue, uint32_t state)
 {
 #ifdef CONFIG_POLL
 	z_handle_obj_poll_events(&queue->poll_events, state);
+#else
+	ARG_UNUSED(queue);
+	ARG_UNUSED(state);
 #endif
 }
 

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -68,6 +68,8 @@ static inline bool is_metairq(struct k_thread *thread)
 	return (thread->base.prio - K_HIGHEST_THREAD_PRIO)
 		< CONFIG_NUM_METAIRQ_PRIORITIES;
 #else
+	ARG_UNUSED(thread);
+
 	return false;
 #endif
 }
@@ -437,6 +439,8 @@ static void update_metairq_preempt(struct k_thread *thread)
 		/* Returning from existing preemption */
 		_current_cpu->metairq_preempted = NULL;
 	}
+#else
+	ARG_UNUSED(thread);
 #endif
 }
 

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -71,6 +71,9 @@ void k_thread_foreach(k_thread_user_cb_t user_cb, void *user_data)
 	SYS_PORT_TRACING_FUNC_EXIT(k_thread, foreach);
 
 	k_spin_unlock(&z_thread_monitor_lock, key);
+#else
+	ARG_UNUSED(user_cb);
+	ARG_UNUSED(user_data);
 #endif
 }
 
@@ -95,6 +98,9 @@ void k_thread_foreach_unlocked(k_thread_user_cb_t user_cb, void *user_data)
 	SYS_PORT_TRACING_FUNC_EXIT(k_thread, foreach_unlocked);
 
 	k_spin_unlock(&z_thread_monitor_lock, key);
+#else
+	ARG_UNUSED(user_cb);
+	ARG_UNUSED(user_data);
 #endif
 }
 
@@ -860,6 +866,8 @@ int z_impl_k_float_disable(struct k_thread *thread)
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	return arch_float_disable(thread);
 #else
+	ARG_UNUSED(thread);
+
 	return -ENOTSUP;
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 }
@@ -869,6 +877,9 @@ int z_impl_k_float_enable(struct k_thread *thread, unsigned int options)
 #if defined(CONFIG_FPU) && defined(CONFIG_FPU_SHARING)
 	return arch_float_enable(thread, options);
 #else
+	ARG_UNUSED(thread);
+	ARG_UNUSED(options);
+
 	return -ENOTSUP;
 #endif /* CONFIG_FPU && CONFIG_FPU_SHARING */
 }

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -906,6 +906,12 @@ static uintptr_t handler_bad_syscall(uintptr_t bad_id, uintptr_t arg2,
 				     uintptr_t arg5, uintptr_t arg6,
 				     void *ssf)
 {
+	ARG_UNUSED(bad_id);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+	ARG_UNUSED(arg4);
+	ARG_UNUSED(arg5);
+
 	LOG_ERR("Bad system call id %" PRIuPTR " invoked", bad_id);
 	arch_syscall_oops(ssf);
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */
@@ -915,6 +921,13 @@ static uintptr_t handler_no_syscall(uintptr_t arg1, uintptr_t arg2,
 				    uintptr_t arg3, uintptr_t arg4,
 				    uintptr_t arg5, uintptr_t arg6, void *ssf)
 {
+	ARG_UNUSED(arg1);
+	ARG_UNUSED(arg2);
+	ARG_UNUSED(arg3);
+	ARG_UNUSED(arg4);
+	ARG_UNUSED(arg5);
+	ARG_UNUSED(arg6);
+
 	LOG_ERR("Unimplemented system call");
 	arch_syscall_oops(ssf);
 	CODE_UNREACHABLE; /* LCOV_EXCL_LINE */

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -579,6 +579,9 @@ bool k_work_cancel_sync(struct k_work *work,
  */
 static void work_queue_main(void *workq_ptr, void *p2, void *p3)
 {
+	ARG_UNUSED(p2);
+	ARG_UNUSED(p3);
+
 	struct k_work_q *queue = (struct k_work_q *)workq_ptr;
 
 	while (true) {


### PR DESCRIPTION
In particular:

- added missing ARG_UNUSED

- added void to cast where ARG_UNUSED macro is not available