### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 11.6

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1071,8 +1071,8 @@ __pinned_func
 static void range_map(void *virt, uintptr_t phys, size_t size,
 		      pentry_t entry_flags, pentry_t mask, uint32_t options)
 {
-	LOG_DBG("%s: %p -> %p (%zu) flags " PRI_ENTRY " mask "
-		PRI_ENTRY " opt 0x%x", __func__, (void *)phys, virt, size,
+	LOG_DBG("%s: 0x%" PRIxPTR " -> %p (%zu) flags " PRI_ENTRY " mask "
+		PRI_ENTRY " opt 0x%x", __func__, phys, virt, size,
 		entry_flags, mask, options);
 
 #ifdef CONFIG_X86_64
@@ -1646,8 +1646,8 @@ static inline void apply_region(pentry_t *ptables, void *start,
 __pinned_func
 static void set_stack_perms(struct k_thread *thread, pentry_t *ptables)
 {
-	LOG_DBG("update stack for thread %p's ptables at %p: %p (size %zu)",
-		thread, ptables, (void *)thread->stack_info.start,
+	LOG_DBG("update stack for thread %p's ptables at %p: 0x%" PRIxPTR " (size %zu)",
+		thread, ptables, thread->stack_info.start,
 		thread->stack_info.size);
 	apply_region(ptables, (void *)thread->stack_info.start,
 		     thread->stack_info.size,
@@ -1791,8 +1791,8 @@ void arch_mem_domain_thread_add(struct k_thread *thread)
 	}
 
 	thread->arch.ptables = z_mem_phys_addr(domain->arch.ptables);
-	LOG_DBG("set thread %p page tables to %p", thread,
-		(void *)thread->arch.ptables);
+	LOG_DBG("set thread %p page tables to 0x%" PRIxPTR, thread,
+		thread->arch.ptables);
 
 	/* Check if we're doing a migration from a different memory domain
 	 * and have to remove permissions from its old domain.


### PR DESCRIPTION
In particular:

- avoided unneeded conversions from integer to pointer

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>