### PR TITLE
Self-remove alwa-nordic from CODEOWNERS for Bluetooth audio and mesh

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -709,7 +709,7 @@ scripts/gen_image_info.py                 @tejlmand
 /subsys/bluetooth/                        @alwa-nordic @jhedberg @Vudentz
 /subsys/bluetooth/audio/                  @jhedberg @Vudentz @Thalley @asbjornsabo
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
-/subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @alwa-nordic @Vudentz @LingaoM
+/subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @Vudentz @LingaoM
 /subsys/canbus/                           @alexanderwachter @henrikbrixandersen
 /subsys/debug/                            @nashif
 /subsys/debug/coredump/                   @dcpleung

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -707,7 +707,7 @@ scripts/gen_image_info.py                 @tejlmand
 /share/zephyr-package/                    @tejlmand
 /share/zephyrunittest-package/            @tejlmand
 /subsys/bluetooth/                        @alwa-nordic @jhedberg @Vudentz
-/subsys/bluetooth/audio/                  @alwa-nordic @jhedberg @Vudentz @Thalley @asbjornsabo
+/subsys/bluetooth/audio/                  @jhedberg @Vudentz @Thalley @asbjornsabo
 /subsys/bluetooth/controller/             @carlescufi @cvinayak @thoh-ot @kruithofa
 /subsys/bluetooth/mesh/                   @jhedberg @trond-snekvik @alwa-nordic @Vudentz @LingaoM
 /subsys/canbus/                           @alexanderwachter @henrikbrixandersen


### PR DESCRIPTION
I would like to step down as code owner for Bluetooth audio and mesh because I don't have the necessary familiarity with these subsystems and because I want to focus on Bluetooth host.