### PR TITLE
doc: contribute: coding guidelines: add links to CAN inclusive language

### DIFF
--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -910,6 +910,12 @@ Related GitHub Issues and Pull Requests are tagged with the `Inclusive Language 
      - See `Bluetooth Appropriate Language Mapping Tables`_
      -
 
+   * - CAN
+     - This `CAN in Automation Inclusive Language news post`_ has a list of general
+       recommendations. See `CAN in Automation Inclusive Language`_ for terms to
+       be used in specification document updates.
+     -
+
    * - eSPI
      - * ``master / slave`` => TBD
      -
@@ -951,6 +957,8 @@ Related GitHub Issues and Pull Requests are tagged with the `Inclusive Language 
 .. _I2C Specification: https://www.nxp.com/docs/en/user-guide/UM10204.pdf
 .. _Bluetooth Appropriate Language Mapping Tables: https://btprodspecificationrefs.blob.core.windows.net/language-mapping/Appropriate_Language_Mapping_Table.pdf
 .. _OSHWA Resolution to Redefine SPI Signal Names: https://www.oshwa.org/a-resolution-to-redefine-spi-signal-names/
+.. _CAN in Automation Inclusive Language news post: https://www.can-cia.org/news/archive/view/?tx_news_pi1%5Bnews%5D=699&tx_news_pi1%5Bday%5D=6&tx_news_pi1%5Bmonth%5D=12&tx_news_pi1%5Byear%5D=2020&cHash=784e79eb438141179386cf7c29ed9438
+.. _CAN in Automation Inclusive Language: https://can-newsletter.org/canopen/categories/
 
 Parasoft Codescan Tool
 **********************


### PR DESCRIPTION
Add links for the CAN in Automation recommendations for using inclusive language terms in CAN.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>