### PR TITLE
it8xxx2: re-factor idle routine

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -179,6 +179,11 @@ uint8_t ite_intc_get_irq_num(void)
 	return intc_irq;
 }
 
+bool ite_intc_no_irq(void)
+{
+	return (IVECT == IVECT_OFFSET_WITH_IRQ);
+}
+
 uint8_t get_irq(void *arg)
 {
 	ARG_UNUSED(arg);
@@ -197,8 +202,6 @@ uint8_t get_irq(void *arg)
 	intc_irq -= IVECT_OFFSET_WITH_IRQ;
 	/* clear interrupt status */
 	ite_intc_isr_clear(intc_irq);
-	/* Clear flag on each interrupt. */
-	wait_interrupt_fired = 0;
 	/* return interrupt number */
 	return intc_irq;
 }

--- a/drivers/interrupt_controller/intc_ite_it8xxx2.h
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.h
@@ -9,7 +9,4 @@
 #include <dt-bindings/interrupt-controller/ite-intc.h>
 #include <soc.h>
 
-/* use data type int here not bool to get better instruction number. */
-volatile int wait_interrupt_fired;
-
 #endif /* ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_INTC_ITE_IT8XXX2_H_ */

--- a/soc/riscv/riscv-ite/common/soc_common.h
+++ b/soc/riscv/riscv-ite/common/soc_common.h
@@ -46,6 +46,7 @@ extern int ite_intc_irq_is_enable(unsigned int irq);
 extern void ite_intc_irq_polarity_set(unsigned int irq, unsigned int flags);
 extern void ite_intc_isr_clear(unsigned int irq);
 void ite_intc_init(void);
+bool ite_intc_no_irq(void);
 #endif /* CONFIG_ITE_IT8XXX2_INTC */
 
 #ifdef CONFIG_SOC_IT8XXX2_PLL_FLASH_48M


### PR DESCRIPTION
Don't leave idle state if soc isn't waked-up by an interrupt.
(We change to check interrupt controller register)

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>