### PR TITLE
Bluetooth: Audio: Fix bad string format for ARRAY_SIZE

### DIFF
--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -465,7 +465,7 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	sink->subgroup_count = net_buf_simple_pull_u8(&net_buf);
 
 	if (sink->subgroup_count > ARRAY_SIZE(base.subgroups)) {
-		BT_DBG("Cannot decode BASE with %u subgroups (max supported is %ld)",
+		BT_DBG("Cannot decode BASE with %u subgroups (max supported is %zu)",
 		       sink->subgroup_count, ARRAY_SIZE(base.subgroups));
 
 		return false;


### PR DESCRIPTION
ARRAY_SIZE was recently changed to a size_t instead of
a long. Update the log statement to use correct
string format.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>