### PR TITLE
Bluetooth: audio: Fix compliation error

### DIFF
--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -465,7 +465,7 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	sink->subgroup_count = net_buf_simple_pull_u8(&net_buf);
 
 	if (sink->subgroup_count > ARRAY_SIZE(base.subgroups)) {
-		BT_DBG("Cannot decode BASE with %u subgroups (max supported is %ld)",
+		BT_DBG("Cannot decode BASE with %u subgroups (max supported is %zu)",
 		       sink->subgroup_count, ARRAY_SIZE(base.subgroups));
 
 		return false;


### PR DESCRIPTION
This fixes compliation error caused by invalid format specifier.
The ARRAY_SIZE return type has been changed by commit
ae55dae45454dab03aedcab51da4e7de557e7def

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>