### PR TITLE
Bluetooth: controller: Fix build error in ISO-AL for iso_broadcast

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -226,8 +226,8 @@ config BT_CTLR_ISO_TX_BUFFER_SIZE
 	  Read Buffer Size V2 command response.
 
 config BT_CTLR_ISOAL_SOURCES
-	int "Number of Isochronous Adaptation Layer sinks"
-	depends on BT_CTLR_ADV_ISO || BT_CTLR_CONN_ISO
+	int "Number of Isochronous Adaptation Layer sources"
+	depends on BT_CTLR_ISO
 	range 1 64
 	default 1
 	help
@@ -236,7 +236,7 @@ config BT_CTLR_ISOAL_SOURCES
 
 config BT_CTLR_ISOAL_SINKS
 	int "Number of Isochronous Adaptation Layer sinks"
-	depends on BT_CTLR_SYNC_ISO || BT_CTLR_CONN_ISO
+	depends on BT_CTLR_ISO
 	range 1 64
 	default 1
 	help


### PR DESCRIPTION
CONFIG_BT_CTLR_ISOAL_SINKS and CONFIG_BT_CTLR_ISOAL_SOURCES were not
defined when building samples/bluetooth/iso_broadcast the Kconfig
dependencies were not fulfilled. These should be defined if the ISO-AL
is built. So changed the dependency to match the ISO-AL source
inclusion conditions.

Signed-off-by: Nirosharn Amarasinghe <niag@demant.com>