### PR TITLE
drivers: can: mcux: flexcan: fail init if clock device is not ready

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -701,6 +701,11 @@ static int mcux_flexcan_init(const struct device *dev)
 		}
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock device not ready");
+		return -ENODEV;
+	}
+
 	k_mutex_init(&data->rx_mutex);
 	k_sem_init(&data->tx_allocs_sem, MCUX_FLEXCAN_MAX_TX,
 		   MCUX_FLEXCAN_MAX_TX);


### PR DESCRIPTION
Fail the NXP MCUX FlexCAN driver initialization of the clock controller device is not ready.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>