### PR TITLE
kconfig: Remove unneeded ${ZEPHYR_BASE} from template import 

### DIFF
--- a/subsys/bluetooth/services/Kconfig.bas
+++ b/subsys/bluetooth/services/Kconfig.bas
@@ -11,6 +11,6 @@ if BT_BAS
 
 module = BT_BAS
 module-str = BAS
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # BT_BAS

--- a/subsys/bluetooth/services/Kconfig.hrs
+++ b/subsys/bluetooth/services/Kconfig.hrs
@@ -29,6 +29,6 @@ endchoice
 
 module = BT_HRS
 module-str = HRS
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # BT_HRS

--- a/subsys/bluetooth/services/Kconfig.tps
+++ b/subsys/bluetooth/services/Kconfig.tps
@@ -10,6 +10,6 @@ if BT_TPS
 
 module = BT_TPS
 module-str = TPS
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # BT_TPS

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -21,7 +21,7 @@ menuconfig THREAD_ANALYZER
 if THREAD_ANALYZER
 module = THREAD_ANALYZER
 module-str = thread analyzer
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 choice
 	prompt "Thread analysis print mode"

--- a/subsys/ipc/ipc_service/Kconfig
+++ b/subsys/ipc/ipc_service/Kconfig
@@ -15,6 +15,6 @@ rsource "backends/Kconfig"
 
 module = IPC_SERVICE
 module-str = IPC service and backend
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # IPC_SERVICE

--- a/subsys/ipc/rpmsg_service/Kconfig
+++ b/subsys/ipc/rpmsg_service/Kconfig
@@ -121,6 +121,6 @@ config RPMSG_SERVICE_EP_REG_PRIORITY
 
 module = RPMSG_SERVICE
 module-str = RPMsg service and backend
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif # RPMSG_SERVICE

--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -357,7 +357,7 @@ config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
 module=MGMT_SETTINGS
 module-dep=LOG
 module-str=SETTINGS
-source "${ZEPHYR_BASE}/subsys/logging/Kconfig.template.log_config"
+source "subsys/logging/Kconfig.template.log_config"
 
 endif
 


### PR DESCRIPTION
The commit removes, from various Kconfigs, ${ZEPHYR_BASE} in
sourcing of logging template.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>