### PR TITLE
boards: nrf: Fix jlink invocation strings

### DIFF
--- a/boards/arm/actinius_icarus/board.cmake
+++ b/boards/arm/actinius_icarus/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/actinius_icarus_bee/board.cmake
+++ b/boards/arm/actinius_icarus_bee/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/actinius_icarus_som/board.cmake
+++ b/boards/arm/actinius_icarus_som/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/adafruit_feather_nrf52840/board.cmake
+++ b/boards/arm/adafruit_feather_nrf52840/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(blackmagicprobe "--gdb-serial=/dev/ttyBmpGdb")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bbc_microbit/board.cmake
+++ b/boards/arm/bbc_microbit/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf51")
-board_runner_args(jlink "--device=nrf51" "--speed=4000")
+board_runner_args(jlink "--device=nRF51822_xxAA" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/bbc_microbit_v2/board.cmake
+++ b/boards/arm/bbc_microbit_v2/board.cmake
@@ -2,7 +2,7 @@
 
 board_runner_args(pyocd "--target=nrf52")
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/bl652_dvk/board.cmake
+++ b/boards/arm/bl652_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bl653_dvk/board.cmake
+++ b/boards/arm/bl653_dvk/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bl654_dvk/board.cmake
+++ b/boards/arm/bl654_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bl654_sensor_board/board.cmake
+++ b/boards/arm/bl654_sensor_board/board.cmake
@@ -2,7 +2,7 @@
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/board.cmake
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/board.cmake
@@ -2,7 +2,7 @@
 
 set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bt510/board.cmake
+++ b/boards/arm/bt510/board.cmake
@@ -2,7 +2,7 @@
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/bt610/board.cmake
+++ b/boards/arm/bt610/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/circuitdojo_feather_nrf9160/board.cmake
+++ b/boards/arm/circuitdojo_feather_nrf9160/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/contextualelectronics_abc/board.cmake
+++ b/boards/arm/contextualelectronics_abc/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 set (OPENOCD_NRF5_SUBFAMILY "nrf52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/decawave_dwm1001_dev/board.cmake
+++ b/boards/arm/decawave_dwm1001_dev/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52")
 set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/degu_evk/board.cmake
+++ b/boards/arm/degu_evk/board.cmake
@@ -1,6 +1,6 @@
 # Copyright (c) 2019 Atmark Techno, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/holyiot_yj16019/board.cmake
+++ b/boards/arm/holyiot_yj16019/board.cmake
@@ -1,4 +1,4 @@
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf21540dk_nrf52840/board.cmake
+++ b/boards/arm/nrf21540dk_nrf52840/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf51_ble400/board.cmake
+++ b/boards/arm/nrf51_ble400/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf51" "--speed=4000")
+board_runner_args(jlink "--device=nRF51822_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf51dk_nrf51422/board.cmake
+++ b/boards/arm/nrf51dk_nrf51422/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf51" "--speed=4000")
+board_runner_args(jlink "--device=nRF51822_xxAC" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/nrf51dongle_nrf51422/board.cmake
+++ b/boards/arm/nrf51dongle_nrf51422/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf51" "--speed=4000")
+board_runner_args(jlink "--device=nRF51822_xxAC" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52833dk_nrf52820/board.cmake
+++ b/boards/arm/nrf52833dk_nrf52820/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52820" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52833dk_nrf52833/board.cmake
+++ b/boards/arm/nrf52833dk_nrf52833/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52840_mdk_usb_dongle/board.cmake
+++ b/boards/arm/nrf52840_mdk_usb_dongle/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52840dk_nrf52811/board.cmake
+++ b/boards/arm/nrf52840dk_nrf52811/board.cmake
@@ -2,7 +2,7 @@
 
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/nrf52840dk_nrf52840/board.cmake
+++ b/boards/arm/nrf52840dk_nrf52840/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52840dongle_nrf52840/board.cmake
+++ b/boards/arm/nrf52840dongle_nrf52840/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52_adafruit_feather/board.cmake
+++ b/boards/arm/nrf52_adafruit_feather/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf52dk_nrf52805/board.cmake
+++ b/boards/arm/nrf52dk_nrf52805/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/nrf52dk_nrf52810/board.cmake
+++ b/boards/arm/nrf52dk_nrf52810/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/nrf52dk_nrf52832/board.cmake
+++ b/boards/arm/nrf52dk_nrf52832/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160_innblue21/board.cmake
+++ b/boards/arm/nrf9160_innblue21/board.cmake
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 InnBlue
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160_innblue22/board.cmake
+++ b/boards/arm/nrf9160_innblue22/board.cmake
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 InnBlue
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nrf9160dk_nrf52840/board.cmake
+++ b/boards/arm/nrf9160dk_nrf52840/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/particle_argon/board.cmake
+++ b/boards/arm/particle_argon/board.cmake
@@ -5,7 +5,7 @@
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/particle_boron/board.cmake
+++ b/boards/arm/particle_boron/board.cmake
@@ -5,7 +5,7 @@
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/particle_xenon/board.cmake
+++ b/boards/arm/particle_xenon/board.cmake
@@ -6,7 +6,7 @@
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/pinnacle_100_dvk/board.cmake
+++ b/boards/arm/pinnacle_100_dvk/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/rak4631_nrf52840/board.cmake
+++ b/boards/arm/rak4631_nrf52840/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Guillaume Paquet <guillaume.paquet@smile.fr>
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/rak5010_nrf52840/board.cmake
+++ b/boards/arm/rak5010_nrf52840/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Guillaume Paquet <guillaume.paquet@smile.fr>
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/reel_board/board.cmake
+++ b/boards/arm/reel_board/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/rm1xx_dvk/board.cmake
+++ b/boards/arm/rm1xx_dvk/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF51")
-board_runner_args(jlink "--device=nrf51" "--speed=4000")
+board_runner_args(jlink "--device=nRF51822_xxAC" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ruuvi_ruuvitag/board.cmake
+++ b/boards/arm/ruuvi_ruuvitag/board.cmake
@@ -1,6 +1,6 @@
 # Copyright (c) 2020 Ruuvi Innovations Ltd (Oy)
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/sparkfun_thing_plus_nrf9160/board.cmake
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF91")
-board_runner_args(jlink "--device=cortex-m33" "--speed=4000")
+board_runner_args(jlink "--device=nRF9160_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/thingy52_nrf52832/board.cmake
+++ b/boards/arm/thingy52_nrf52832/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--softreset")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/ubx_bmd300eval_nrf52832/board.cmake
+++ b/boards/arm/ubx_bmd300eval_nrf52832/board.cmake
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 u-blox AG
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ubx_bmd330eval_nrf52810/board.cmake
+++ b/boards/arm/ubx_bmd330eval_nrf52810/board.cmake
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 u-blox AG
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52810_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/ubx_bmd340eval_nrf52840/board.cmake
+++ b/boards/arm/ubx_bmd340eval_nrf52840/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ubx_bmd345eval_nrf52840/board.cmake
+++ b/boards/arm/ubx_bmd345eval_nrf52840/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ubx_bmd360eval_nrf52811/board.cmake
+++ b/boards/arm/ubx_bmd360eval_nrf52811/board.cmake
@@ -3,7 +3,7 @@
 # Copyright (c) 2021 u-blox AG
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52811_xxAA" "--speed=4000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd-nrf5.board.cmake)

--- a/boards/arm/ubx_bmd380eval_nrf52840/board.cmake
+++ b/boards/arm/ubx_bmd380eval_nrf52840/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ubx_evkannab1_nrf52832/board.cmake
+++ b/boards/arm/ubx_evkannab1_nrf52832/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ubx_evkninab1_nrf52832/board.cmake
+++ b/boards/arm/ubx_evkninab1_nrf52832/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ubx_evkninab3_nrf52840/board.cmake
+++ b/boards/arm/ubx_evkninab3_nrf52840/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/ubx_evkninab4_nrf52833/board.cmake
+++ b/boards/arm/ubx_evkninab4_nrf52833/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52833" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/we_proteus2ev_nrf52832/board.cmake
+++ b/boards/arm/we_proteus2ev_nrf52832/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)

--- a/boards/arm/we_proteus3ev_nrf52840/board.cmake
+++ b/boards/arm/we_proteus3ev_nrf52840/board.cmake
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(jlink "--device=nrf52" "--speed=4000")
+board_runner_args(jlink "--device=nRF52840_xxAA" "--speed=4000")
 board_runner_args(pyocd "--target=nrf52840" "--frequency=4000000")
 
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)


### PR DESCRIPTION
The jlink executable expects a fully qualified IC name, and not just the
family.

Fixes #37294

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>