### PR TITLE
drivers: watchdog: iwdg_stm32: fix wdg install timeout

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -140,7 +140,7 @@ static int iwdg_stm32_install_timeout(const struct device *dev,
 	LL_IWDG_SetReloadCounter(iwdg, reload);
 
 	/* Wait for the update operation completed */
-	while (LL_IWDG_IsReady(iwdg) != 0) {
+	while (LL_IWDG_IsReady(iwdg) == 0) {
 		if ((k_uptime_get_32() - tickstart) > IWDG_SR_UPDATE_TIMEOUT) {
 			return -ENODEV;
 		}


### PR DESCRIPTION
In the function iwdg_stm32_install_timeout, the test on watchdog ready
was inverted. So, if 2 successive calls were made to this function, the
value of the prescaler or counter reload was not taken into account.

Signed-off-by: Julien D'Ascenzio <julien.dascenzio@paratronic.fr>