### PR TITLE
Bluetooth: Controller: Fix Periodic Sync CTE time reservations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -14,6 +14,7 @@
 #include "util/dbuf.h"
 
 #include "hal/cpu.h"
+#include "hal/ccm.h"
 #include "hal/radio_df.h"
 
 #include "pdu.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -466,7 +466,7 @@ uint8_t ll_df_set_cl_iq_sampling_enable(uint16_t handle,
 		 * (-ENOENT) gracefully.
 		 * Periodic sync lost event also disables the CTE sampling.
 		 */
-		err = ull_sync_slot_update(sync, 0, CTE_LEN_MAX_US);
+		err = ull_sync_slot_update(sync, slot_plus_us, slot_minus_us);
 		LL_ASSERT(err == 0 || err == -ENOENT);
 	}
 

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -1080,8 +1080,8 @@ void ull_sync_chm_update(uint8_t sync_handle, uint8_t *acad, uint8_t acad_len)
 int ull_sync_slot_update(struct ll_sync_set *sync, uint32_t slot_plus_us,
 			 uint32_t slot_minus_us)
 {
+	uint32_t volatile ret_cb;
 	uint32_t ret;
-	uint32_t ret_cb;
 
 	ret_cb = TICKER_STATUS_BUSY;
 	ret = ticker_update(TICKER_INSTANCE_ID_CTLR,
@@ -1089,8 +1089,8 @@ int ull_sync_slot_update(struct ll_sync_set *sync, uint32_t slot_plus_us,
 			    (TICKER_ID_SCAN_SYNC_BASE +
 			    ull_sync_handle_get(sync)),
 			    0, 0,
-			    slot_plus_us,
-			    slot_minus_us,
+			    HAL_TICKER_US_TO_TICKS(slot_plus_us),
+			    HAL_TICKER_US_TO_TICKS(slot_minus_us),
 			    0, 0,
 			    ticker_update_op_status_give,
 			    (void *)&ret_cb);


### PR DESCRIPTION
Fix Periodic Advertising Synchronization time reservation
updated when enabling/disabling direction finding IQ
sampling.

Fixes #42518.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>