### PR TITLE
xtensa: cavs: support running test by west flash and twister with remote host

### DIFF
--- a/boards/common/intel_adsp.board.cmake
+++ b/boards/common/intel_adsp.board.cmake
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(intel_adsp "--default-key=${RIMAGE_SIGN_KEY}")
+
+board_finalize_runner_args(intel_adsp)

--- a/boards/xtensa/intel_adsp_cavs15/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs15/board.cmake
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(intel_adsp)
+
+set(RIMAGE_SIGN_KEY otc_private_key.pem)
 
 board_set_rimage_target(apl)
+
+include(${ZEPHYR_BASE}/boards/common/intel_adsp.board.cmake)

--- a/boards/xtensa/intel_adsp_cavs15/doc/index.rst
+++ b/boards/xtensa/intel_adsp_cavs15/doc/index.rst
@@ -72,55 +72,75 @@ Loading image to Audio DSP
 `SOF Diagnostic Driver`_ provide interface for firmware loading. Python tools
 in the board support directory use the interface to load firmware to ``ADSP``.
 
-Note that the ``/dev/hda`` device file created by the diagnostic
-driver must be readable and writable by the process.  This can be
-accomplished via a simple chmod, via a udev handler that associates
-the device with a particular user or group, or simply by running the
+Assume that the up_squared board's host name is ``cavs15`` (It also can be an
+ip address), and the user account is ``user``. Then copy the python tool to the
+``up_squared`` board from your build environment::
+
+   $ scp boards/xtensa/intel_adsp/tools/cavstool_server.py user@cavs15:
+
+
+Note that the ``/dev/hda`` device file created by the diagnostic driver must
+be readable and writable by the process.  So we simply by running the
 loader script as root:
 
 .. code-block:: console
 
-   $ sudo chmod 777 /dev/hda
-   $ boards/xtensa/intel_adsp_cavs15/tools/fw_loader.py -f <path to zephyr.ri>
+   cavs15$ sudo ./cavstool_server.py
 
-Debugging
-=========
+Cavstool_server.py is a daemon which accepts a firmware image from a remote host
+and loads it into the ADSP. After successful firmware download, the daemon also
+sends any log messages or output back to the client.
 
-The only way to debug application is using logging. Logging and ADSP logging
-backend needs to be enabled in the application configuration.
+Running and Debugging
+=====================
 
-ADSP logging backend writes logs to the ring buffer in the shared memory.
-
-As above, the ``adsplog`` tool requires appropriate permissions, in
-this case to the sysfs "resource4" device on the appropriate PCI
-device.  This can likewise be managed via any filesystem, setuid or
-udev trick the operator prefers.
+While the python script is running on ``up_squared`` board, you can start load
+image and run the application by:
 
 .. code-block:: console
 
-   $ boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
-   ERROR: Cannot open /sys/bus/pci/devices/0000:00:0e.0/resource4 for reading
+   west flash --remote-host cavs15
 
-   $ sudo chmod 666 /sys/bus/pci/devices/0000:00:0e.0/resource4
-   $ boards/xtensa/intel_adsp_cavs15/tools/adsplog.py
+or
+
+.. code-block:: console
+
+   west flash --remote-host 192.168.x.x
+
+Then you can see the log message immediately:
+
+.. code-block:: console
+
    Hello World! intel_adsp_cavs15
+
 
 Integration Testing With Twister
 ================================
 
 The ADSP hardware also has integration for testing using the twister
-tool.  The ``adsplog`` script can be used as the
+tool.  The ``cavstool_client.py`` script can be used as the
 ``--device-serial-pty`` handler, and the west flash script should take
-a path to the same key file used above.  Remember to pass the
-``--no-history`` argument to ``adsplog.py``, because by default it
-will dump the current log buffer, which may contain output from a
-previous test run.
+a path to the same key file used above.
 
 .. code-block:: console
 
-    $ZEPHYR_BASE/scripts/twister --device-testing -p intel_adsp_cavs15 \
-      --device-serial-pty $ZEPHYR_BASE/boards/xtensa/intel_adsp_cavs15/tools/adsplog.py,--no-history \
-      --west-flash $ZEPHYR_BASE/boards/xtensa/intel_adsp_cavs15/tools/flash.sh,$PATH_TO_KEYFILE.pem
+    ./scripts/twister --device-testing -p intel_adsp_cavs15 \
+      --device-serial-pty $ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,cavs15,-l \
+      --west-flash "--remote-host=cavs15,--pty"
+
+And if you install the SOF software stack in rather than the default path,
+you also can specify the location of the rimage tool, signing key and the
+toml config, for example:
+
+.. code-block:: console
+
+    ./scripts/twister --device-testing -p intel_adsp_cavs15 \
+      --device-serial-pty $ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,cavs15,-l \
+      --west-flash "--remote-host=cavs15,--pty\
+      --rimage-tool=/path/to/rimage_tool,\
+      --key=/path/to/otc_private_key.pem,\
+      --config-dir=/path/to/config_dir"
+
 
 .. target-notes::
 

--- a/boards/xtensa/intel_adsp_cavs18/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs18/board.cmake
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(intel_adsp)
+
+set(RIMAGE_SIGN_KEY otc_private_key.pem)
 
 board_set_rimage_target(cnl)
+
+include(${ZEPHYR_BASE}/boards/common/intel_adsp.board.cmake)

--- a/boards/xtensa/intel_adsp_cavs18/doc/generic_intel_adsp.rst
+++ b/boards/xtensa/intel_adsp_cavs18/doc/generic_intel_adsp.rst
@@ -1,0 +1,161 @@
+.. _Intel_Adsp_Generic_Running_Guide:
+
+Intel Adsp Generic Running Guide
+################################
+
+This documentation describes how to run the intel_adsp_cavs boards. Including:
+
+- intel_adsp_cavs15
+
+- intel_adsp_cavs18
+
+- intel_adsp_cavs20
+
+- intel_adsp_cavs25
+
+
+Set up the environment
+**********************
+
+1. Copy soc/xtensa/intel_adsp/tools/cavstool_server.py to the target
+   host machine (DUT).
+
+2. In your build machine, install the rimage tool, the signed key and
+   the toml config file. Please refer to please refer:
+
+
+     https://github.com/thesofproject/rimage.
+
+
+Build and run the tests
+***********************
+
+1. In the remote target machine, starting the service by:
+
+.. code-block:: console
+
+   sudo ./cavstool_server.py
+
+2. Build the application. Take semaphore as an example:
+
+.. code-block:: console
+
+   west build -b intel_adsp_cavs15 samples/hello_world
+
+3. Run the test by:
+
+.. code-block:: console
+
+   west flash --remote-host [remote hostname or ip addr]
+
+Now you can see the outout log in your terminal.
+
+
+If you don't want to use the default location of rimage tools, you can
+also specify the rimage tool, config and key by:
+
+.. code-block:: console
+
+   west flash --remote-host [remote hostname or ip addr] \
+              --rimage-tool [path to the rimage tool] \
+              --config-dir [path to dir of .toml config file] \
+              --key [path to signing key]
+
+Run by twister
+**************
+
+Assume the remote ADSP host's ip address is 192.168.1.2, you can run the
+twister by following command:
+
+.. code-block:: console
+
+   twister -p intel_adsp_cavs15 --device-testing \
+     --device-serial-pty="$ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.2,-l" \
+     --west-flash="--remote-host=192.168.1.2,--pty"
+
+
+Like we run test by west, if you don't want to use the default location of
+SOF tools, you can also specify the rimage tool, config and key by:
+
+.. code-block:: console
+
+   twister -p intel_adsp_cavs15 --device-testing \
+     --device-serial-pty="$ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.2,-l" \
+     --west-flash="--remote-host=192.168.1.2,--pty,\
+     --rimage-tool=$HOME/sof/rimage/rimage,\
+     --config-dir=$HOME/sof/rimage/config/,\
+     --key=$HOME/sof/keys/otc_private_key.pem" \
+     -T tests/kernel/semaphore/semaphore/ -vv
+
+
+Note that there should be no space between the arguments in --west-flash,
+it use comma to separate the parameters.
+
+
+Run multiple boards
+*******************
+
+In the above example, there are many parameters need to be key in when
+running it. There is a more easy way to make you to key in less, and
+it also support running multiple boards at the same time.
+
+Ex.
+  twister --hardware-map cavs.map --device-testing -T tests/ -v
+
+
+Run it this way we have to make a hardware map file first. Edit a
+hardware map file like below example, you can run one/multiple tests
+on one/multiple ADSP boards parallelly.
+
+And if you don't want to run it in certain platform, just make
+the "connected" field from "true" to "false", it will be skip.
+
+Here is a example of the hardware map file:
+
+.. code-block:: console
+
+   - connected: true
+     id: None
+     platform: intel_adsp_cavs15
+     product: None
+     runner: intel_adsp
+     serial_pty: "/home/user/zephyrproject/zephyr/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.2,-l"
+     runner_params:
+       - --remote-host=192.168.1.2
+
+   - connected: true
+     id: None
+     platform: intel_adsp_cavs18
+     product: None
+     runner: intel_adsp
+     serial_pty: "/home/user/zephyrproject/zephyr/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.3,-l"
+     runner_params:
+       - --remote-host=192.168.1.3
+
+   - connected: true
+     id: None
+     platform: intel_adsp_cavs25
+     product: None
+     runner: intel_adsp
+     serial_pty: "/home/user/zephyrproject/zephyr/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.4,-l"
+     runner_params:
+       - --remote-host=192.168.1.4
+
+
+By the way, if you don't use the default location of the SOF tools, you
+can remove the --rimage-tool, --config-dir and --key in the extra_params
+field. For example:
+
+.. code-block:: console
+
+   - connected: true
+     id: None
+     platform: intel_adsp_cavs25
+     product: None
+     runner: intel_adsp
+     serial_pty: "/home/user/zephyrproject/zephyr/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.4,-l"
+     runner_params:
+       - --remote-host=192.168.1.4
+       - --rimage-tool=/home/user/sof/rimage/rimage
+       - --config-dir=/home/user/sof/rimage/config/
+       - --key=/home/user/sof/keys/otc_private_key_3k.pem

--- a/boards/xtensa/intel_adsp_cavs20/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs20/board.cmake
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(intel_adsp)
+
+set(RIMAGE_SIGN_KEY otc_private_key.pem)
 
 if(CONFIG_BOARD_INTEL_ADSP_CAVS20)
 board_set_rimage_target(icl)
@@ -10,3 +11,5 @@ endif()
 if(CONFIG_BOARD_INTEL_ADSP_CAVS20_JSL)
 board_set_rimage_target(jsl)
 endif()
+
+include(${ZEPHYR_BASE}/boards/common/intel_adsp.board.cmake)

--- a/boards/xtensa/intel_adsp_cavs25/board.cmake
+++ b/boards/xtensa/intel_adsp_cavs25/board.cmake
@@ -1,7 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_set_flasher_ifnset(misc-flasher)
-board_finalize_runner_args(misc-flasher)
+board_set_flasher_ifnset(intel_adsp)
+
+set(RIMAGE_SIGN_KEY otc_private_key_3k.pem)
 
 if(CONFIG_BOARD_INTEL_ADSP_CAVS25)
 board_set_rimage_target(tgl)
@@ -10,3 +11,5 @@ endif()
 if(CONFIG_BOARD_INTEL_ADSP_CAVS25_TGPH)
 board_set_rimage_target(tgl-h)
 endif()
+
+include(${ZEPHYR_BASE}/boards/common/intel_adsp.board.cmake)

--- a/boards/xtensa/intel_adsp_cavs25/doc/index.rst
+++ b/boards/xtensa/intel_adsp_cavs25/doc/index.rst
@@ -359,13 +359,19 @@ but anywhere is acceptable):
 Copy Integration Scripting to Chromebook
 ========================================
 
-There are two python scripts needed on the device, to be run inside
+There is a python scripts needed on the device, to be run inside
 the Crouton environment installed above.  Copy them:
 
 .. code-block:: console
 
-    dev$ scp boards/xtensa/intel_adsp_cavs15/tools/cavs-fw-v25.py root@crouton:
-    dev$ scp boards/xtensa/intel_adsp_cavs15/tools/adsplog.py root@crouton:
+    dev$ scp boards/xtensa/intel_adsp_cavs15/tools/cavstool_server.py user@crouton:
+
+Then start the service in the Crouton environment:
+
+.. code-block:: console
+
+    crouton$ sudo ./cavstool_server.py user@crouton:
+
 
 Build and Sign Zephyr App
 =========================
@@ -381,7 +387,6 @@ a "zephyr.ri" file to be copied to the device.
     dev$ west build -b intel_adsp_cavs25 samples/hello_world
     dev$ west sign --tool-data=~/rimage/config -t ~/rimage/rimage -- \
                 -k $ZEPHYR_BASE/../modules/audio/sof/keys/otc_private_key_3k.pem
-    dev$ scp build/zephyr/zephyr.ri root@crouton:
 
 Run it!
 =======
@@ -393,8 +398,7 @@ the logging script.
 
 .. code-block:: console
 
-    crouton# ./cavs-fw-v25.py zephyr.ri
-    crouton# ./adsplog.py
+    dev$ west flash --remote-host crouton
     Hello World! intel_adsp_cavs25
 
 Misc References

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -846,6 +846,8 @@ class DeviceHandler(Handler):
                         command.append("--tool-opt=-SelectEmuBySN  %s" % (board_id))
                     elif runner == "stm32cubeprogrammer":
                         command.append("--tool-opt=sn=%s" % (board_id))
+                    elif runner == "intel_adsp":
+                        command.append("--pty")
 
                     # Receive parameters from an runner_params field
                     # of the specified hardware map file.

--- a/scripts/west_commands/runners/__init__.py
+++ b/scripts/west_commands/runners/__init__.py
@@ -33,6 +33,7 @@ _names = [
     'esp32',
     'gd32isp',
     'hifive1',
+    'intel_adsp',
     'intel_cyclonev',
     'intel_s1000',
     'jlink',

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -1,0 +1,127 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''Runner for flashing with the Intel ADSP CAVS boards.'''
+
+import os
+import sys
+import re
+import hashlib
+import random
+import shutil
+from runners.core import ZephyrBinaryRunner, RunnerCaps
+from zephyr_ext_common import ZEPHYR_BASE
+
+DEFAULT_CAVSTOOL='soc/xtensa/intel_adsp/tools/cavstool_client.py'
+DEFAULT_SOF_MOD_DIR=os.path.join(ZEPHYR_BASE, '../modules/audio/sof')
+DEFAULT_RIMAGE_TOOL=shutil.which('rimage')
+DEFAULT_CONFIG_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'rimage/config')
+DEFAULT_KEY_DIR=os.path.join(DEFAULT_SOF_MOD_DIR, 'keys')
+
+
+class IntelAdspBinaryRunner(ZephyrBinaryRunner):
+    '''Runner front-end for the intel ADSP boards.'''
+
+    def __init__(self,
+                 cfg,
+                 remote_host,
+                 rimage_tool,
+                 config_dir,
+                 default_key,
+                 key,
+                 pty
+                 ):
+        super().__init__(cfg)
+
+        self.remote_host = remote_host
+        self.rimage_tool = rimage_tool
+        self.config_dir = config_dir
+        self.bin_fw = os.path.join(cfg.build_dir, 'zephyr', 'zephyr.ri')
+
+        self.cavstool = os.path.join(ZEPHYR_BASE, DEFAULT_CAVSTOOL)
+        self.platform = os.path.basename(cfg.board_dir)
+        self.pty = pty
+
+        if key:
+            self.key = key
+        else:
+            self.key = os.path.join(DEFAULT_KEY_DIR, default_key)
+
+    @classmethod
+    def name(cls):
+        return 'intel_adsp'
+
+    @classmethod
+    def capabilities(cls):
+        return RunnerCaps(commands={'flash'})
+
+    @classmethod
+    def do_add_parser(cls, parser):
+        parser.add_argument('--remote-host',
+                            help='hostname of the remote targeting ADSP board')
+        parser.add_argument('--rimage-tool', default=DEFAULT_RIMAGE_TOOL,
+                            help='path to the rimage tool')
+        parser.add_argument('--config-dir', default=DEFAULT_CONFIG_DIR,
+                            help='path to the toml config file')
+        parser.add_argument('--default-key',
+                            help='the default basename of the key store in board.cmake')
+        parser.add_argument('--key',
+                            help='specify where the signing key is')
+        parser.add_argument('--pty', action="store_true",
+                            help='the log will not output immediately to STDOUT, you \
+                            can redirect it to a serial PTY')
+
+    @classmethod
+    def do_create(cls, cfg, args):
+        return IntelAdspBinaryRunner(cfg,
+                                    remote_host=args.remote_host,
+                                    rimage_tool=args.rimage_tool,
+                                    config_dir=args.config_dir,
+                                    default_key=args.default_key,
+                                    key=args.key,
+                                    pty=args.pty
+                                    )
+
+    def do_run(self, command, **kwargs):
+        self.logger.info('Starting Intel ADSP runner')
+
+        # If the zephyr.ri is not existing, it will build and sign it.
+        if self.bin_fw is None or not os.path.isfile(self.bin_fw):
+            self.sign(**kwargs)
+
+        if re.search("intel_adsp_cavs", self.platform):
+            self.require(self.cavstool)
+            self.flash(**kwargs)
+        else:
+            self.logger.error("No suitable platform for running")
+            sys.exit(1)
+
+    def sign(self, **kwargs):
+        sign_cmd = ['west', 'sign', '-d', f'{self.cfg.build_dir}', '-t', 'rimage', '-p', f'{self.rimage_tool}',
+                '-D', f'{self.config_dir}', '--', '-k', f'{self.key}']
+
+        self.check_call(sign_cmd)
+
+    def flash(self, **kwargs):
+        # Generate a hash string for appending to the sending ri file
+        hash_object = hashlib.md5(self.bin_fw.encode())
+        random_str = f"{random.getrandbits(64)}".encode()
+        hash_object.update(random_str)
+        send_bin_fw = str(self.bin_fw + "." + hash_object.hexdigest())
+        os.rename(self.bin_fw, send_bin_fw)
+
+        # Copy the zephyr to target remote ADSP host and run
+        self.run_cmd = ([f'{self.cavstool}','-s', f'{self.remote_host}', f'{send_bin_fw}'])
+        self.log_cmd = ([f'{self.cavstool}','-s', f'{self.remote_host}', '-l'])
+
+        self.logger.debug(f"cavstool({self.cavstool}), fw('{send_bin_fw})")
+        self.logger.debug(f"rcmd: {self.run_cmd}")
+
+        self.check_call(self.run_cmd)
+
+        # If the self.pty assigned, the output the log will
+        # not output to stdout directly. That means we can
+        # make the log output to the PTY.
+        if not self.pty:
+            self.check_call(self.log_cmd)

--- a/scripts/west_commands/tests/test_imports.py
+++ b/scripts/west_commands/tests/test_imports.py
@@ -23,6 +23,7 @@ def test_runner_imports():
                     'esp32',
                     'gd32isp',
                     'hifive1',
+                    'intel_adsp',
                     'intel_cyclonev',
                     'intel_s1000',
                     'jlink',

--- a/soc/xtensa/intel_adsp/tools/cavstool_client.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool_client.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+# Copyright(c) 2022 Intel Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import logging
+import time
+import argparse
+import socket
+import signal
+
+HOST = None
+PORT_LOG = 9999
+PORT_REQ = PORT_LOG + 1
+BUF_SIZE = 4096
+
+CMD_LOG_START = "start_log"
+CMD_LOG_STOP = "stop_log"
+CMD_DOWNLOAD = "download"
+
+logging.basicConfig()
+log = logging.getLogger("cavs-client")
+log.setLevel(logging.INFO)
+
+class cavstool_client():
+    def __init__(self, host, port, args):
+        self.host = host
+        self.port = port
+        self.args = args
+        self.sock = None
+        self.cmd = None
+
+    def send_cmd(self, cmd):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+            self.sock = sock
+            self.cmd = cmd
+            self.sock.connect((self.host, self.port))
+            self.sock.sendall(cmd.encode("utf-8"))
+            log.info(f"Sent:     {cmd}")
+            ack = str(self.sock.recv(BUF_SIZE), "utf-8")
+            log.info(f"Receive: {ack}")
+
+            if ack == CMD_LOG_START:
+                self.monitor_log()
+            elif ack == CMD_LOG_STOP:
+                log.info(f"Stop output.")
+            elif ack == CMD_DOWNLOAD:
+                self.run()
+            else:
+                log.error(f"Receive incorrect msg:{ack} expect:{cmd}")
+
+    def download(self, filename):
+        # Send the FW to server
+        with open(filename,'rb') as f:
+            log.info('Sending...')
+            ret = self.sock.sendfile(f)
+            log.info(f"Done Sending ({ret}).")
+
+    def run(self):
+        filename = str(self.args.fw_file)
+        send_fn = os.path.basename(filename)
+        self.sock.sendall(send_fn.encode("utf-8"))
+        log.info(f"Sent fw:     {send_fn}, {filename}")
+
+        self.download(filename)
+
+    def monitor_log(self):
+        log.info(f"Start to monitor log output...")
+        while True:
+            # Receive data from the server and print out
+            receive_log = str(self.sock.recv(BUF_SIZE).strip(), "utf-8")
+            if receive_log:
+                print(f"{receive_log}")
+                time.sleep(0.1)
+
+    def __del__(self):
+        self.sock.close()
+
+def cleanup():
+    client = cavstool_client(HOST, PORT_REQ, args)
+    client.send_cmd(CMD_LOG_STOP)
+
+def main():
+    if args.log_only:
+        log.info("Monitor process")
+        signal.signal(signal.SIGTERM, cleanup)
+
+        try:
+            client = cavstool_client(HOST, PORT_LOG, args)
+            client.send_cmd(CMD_LOG_START)
+        except KeyboardInterrupt:
+            pass
+        finally:
+            cleanup()
+
+    elif args.kill_cmd:
+        log.info("Stop monitor log")
+        cleanup()
+    else:
+        log.info("Download process")
+        client = cavstool_client(HOST, PORT_REQ, args)
+        client.send_cmd(CMD_DOWNLOAD)
+
+ap = argparse.ArgumentParser(description="DSP loader/logger client tool")
+ap.add_argument("-q", "--quiet", action="store_true",
+                help="No loader output, just DSP logging")
+ap.add_argument("-l", "--log-only", action="store_true",
+                help="Don't load firmware, just show log output")
+ap.add_argument("-s", "--server-addr", default="localhost",
+                help="Specify the adsp server address")
+ap.add_argument("-k", "--kill-cmd", action="store_true",
+                help="No current log buffer at start, just new output")
+ap.add_argument("fw_file", nargs="?", help="Firmware file")
+args = ap.parse_args()
+
+if args.quiet:
+    log.setLevel(logging.WARN)
+
+HOST = args.server_addr
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
There are some changes in this PR:
1. Add a dedicate west runner "intel_adsp" for intel_adsp_cavs boards.
2. Add a client-server base firmware loader instead of original SSH-base one.
3. Add a support for running multiple intel_adsp_cavs boards at same time. This feature rely on the hardware map support for serial-pty. I has already split into another PR: https://github.com/zephyrproject-rtos/zephyr/pull/45197) and try to make this PR clean.

Now we can run the test on cavs boards by west flash command, ex:
```
west build -b intel_adsp_cavs25 samples/hello_world
west flash --remote-host [remote hostname or ip addr]
```
And if you want to specify the location of SOF tool instead of the default ones, such as rimage tool, config and the key,
run it by:
```
west flash --remote-host [remote hostname or ip addr]
                 --rimage-path [path to rimage tool] \
                 --config-path [path to .toml config file] \
                 --key [path to signing key]
```

#Run the twister:
```
twister -p intel_adsp_cavs18 --device-testing
--device-serial-pty="$ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.x.x,-l" \
--west-flash="--remote-host=192.168.x.x, --run-twister"
-T samples/hello_world -vv"
```