### PR TITLE
drivers: sensor: mhz19b: fix all channels fetch

### DIFF
--- a/drivers/sensor/mhz19b/mhz19b.c
+++ b/drivers/sensor/mhz19b/mhz19b.c
@@ -240,11 +240,11 @@ static int mhz19b_attr_get(const struct device *dev, enum sensor_channel chan,
 
 static int mhz19b_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
-	if (chan != SENSOR_CHAN_CO2) {
-		return -ENOTSUP;
+	if (chan == SENSOR_CHAN_CO2 || chan == SENSOR_CHAN_ALL) {
+		return mhz19b_poll_data(dev, MHZ19B_CMD_IDX_GET_CO2);
 	}
 
-	return mhz19b_poll_data(dev, MHZ19B_CMD_IDX_GET_CO2);
+	return -ENOTSUP;
 }
 
 static const struct sensor_driver_api mhz19b_api_funcs = {


### PR DESCRIPTION
`mhz19b_sample_fetch()` from `mhz19b` sensor driver didn't support `SENSOR_CHAN_ALL` `chan` parameter value, so `sensor_sample_fetch()` didn't work, always returning `-ENOTSUP` (`sensor_sample_fetch_chan()` worked, if called with `SENSOR_CHAN_CO2`).

This change enables `mhz19b` sensor to work both with `sensor_sample_fetch()` and with `sensor_sample_fetch_chan()` with `SENSOR_CHAN_CO2`.