### PR TITLE
Bluetooth: Host: Fix unable cleanup conn

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -890,7 +890,9 @@ void bt_conn_set_state(struct bt_conn *conn, bt_conn_state_t state)
 			tx_notify(conn);
 
 			/* Cancel Connection Update if it is pending */
-			if (conn->type == BT_CONN_TYPE_LE) {
+			if ((conn->type == BT_CONN_TYPE_LE) &&
+			    (k_work_delayable_busy_get(&conn->deferred_work) &
+			     (K_WORK_QUEUED | K_WORK_DELAYED))) {
 				k_work_cancel_delayable(&conn->deferred_work);
 			}
 


### PR DESCRIPTION
The peripheral is configured to update the connection
parameters for 5 seconds by default.

There is an abnormal situation with a very low probability.

The central actively disconnects or abnormally disconnects the
Bluetooth connection at the same time.

At this time, the connection disconnection event will be
handled by `BT RX`.

At this time, `sysworkq` has sent a parameter update request and
will receive a reply with `status = 0x02`, because the handle is
invalid at this time.

We can not just cancel work, because `work->flag` may be
in `K_WORK_RUNNING`, so `work->flag` is set to `K_WORK_CANCELING`
 and subsequent `conn_cleanup` will unable call `k_work_rescheduler`
successfully.

According `submit_to_queue_locked` will return `ret = -EBUSY`.

``` C
	if (flag_test(&work->flags, K_WORK_CANCELING_BIT)) {
		/* Disallowed */
		ret = -EBUSY;
```

As a result, the connection cannot be cleanup correctly.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>