### PR TITLE
driver: clock: npcx: remove the guard for npcx_clock_get_sleep_ticks

### DIFF
--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -295,12 +295,10 @@ void npcx_clock_compensate_system_timer(void)
 			sys_clock_hw_cycles_per_sec()) / EVT_CYCLES_PER_SEC;
 }
 
-#if defined(CONFIG_NPCX_PM_TRACE)
 uint64_t npcx_clock_get_sleep_ticks(void)
 {
 	return  cyc_sys_compensated / SYS_CYCLES_PER_TICK;
 }
-#endif /* CONFIG_NPCX_PM_TRACE */
 #endif /* CONFIG_PM */
 
 static int sys_clock_driver_init(const struct device *dev)


### PR DESCRIPTION
The function npcx_clock_get_sleep_ticks is currently guarded by
CONFIG_PM && CONFIG_NPCX_PM_TRACE. The other codes guarded by
CONFIG_NPCX_PM_TRACE is used to trace and will print a lot of messages.
The user who wants to use npcx_clock_get_sleep_ticks has to enable this
flag and get a lot of console spam. This commit removes the guard
CONFIG_NPCX_PM_TRACE and makes this function is available when
CONFIG_PM is defined.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>