### PR TITLE
debug: Revert ASSERT options dependency

### DIFF
--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -33,7 +33,10 @@ zephyr_sources_ifdef(CONFIG_JSON_LIBRARY json.c)
 
 zephyr_sources_ifdef(CONFIG_RING_BUFFER ring_buffer.c)
 
-zephyr_sources_ifdef(CONFIG_ASSERT assert.c)
+if (CONFIG_ASSERT OR CONFIG_ASSERT_VERBOSE)
+zephyr_sources(assert.c)
+endif()
+
 
 zephyr_sources_ifdef(CONFIG_USERSPACE mutex.c user_work.c)
 

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -206,14 +206,6 @@ config ASSERT
 	  Disabling this option will cause assertions to compile to nothing,
 	  improving performance and system footprint.
 
-config FORCE_NO_ASSERT
-	bool "Force-disable no assertions"
-	help
-	  This boolean option disables Zephyr assertion testing even
-	  in circumstances (twister) where it is enabled via
-	  CFLAGS and not Kconfig.  Added solely to be able to work
-	  around compiler bugs for specific tests.
-
 if ASSERT
 
 config ASSERT_LEVEL
@@ -237,6 +229,16 @@ config SPIN_VALIDATE
 	  There's a spinlock validation framework available when asserts are
 	  enabled. It adds a relatively hefty overhead (about 3k or so) to
 	  kernel code size, don't use on platforms known to be small.
+
+endif # ASSERT
+
+config FORCE_NO_ASSERT
+	bool "Force-disable no assertions"
+	help
+	  This boolean option disables Zephyr assertion testing even
+	  in circumstances (twister) where it is enabled via
+	  CFLAGS and not Kconfig.  Added solely to be able to work
+	  around compiler bugs for specific tests.
 
 config ASSERT_VERBOSE
 	bool "Verbose assertions"
@@ -271,8 +273,6 @@ config ASSERT_NO_MSG_INFO
 	  necessary for tiny targets. It is recommended to disable message
 	  before disabling file info since the message can be found in the
 	  source using file info.
-
-endif # ASSERT
 
 config OVERRIDE_FRAME_POINTER_DEFAULT
 	bool "Override compiler defaults for -fomit-frame-pointer"


### PR DESCRIPTION
f4df23c9 added dependency on ASSERT to some options prefixed
with ASSERT_ assuming that they are no used elsewhere. Turned
out that there are subsystem specific assert macros (e.g. BT_ASSERT)
which relies on those options. Removing the dependency.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>