### PR TITLE
kernel: Remove idle thread cpu index on single-core devices

### DIFF
--- a/doc/guides/debug_tools/thread-analyzer.rst
+++ b/doc/guides/debug_tools/thread-analyzer.rst
@@ -31,7 +31,7 @@ information from Thread Analyzer::
 	 thread_b            : STACK: unused 740 usage 284 / 1024 (27 %); CPU: 0 %
 	 thread_analyzer     : STACK: unused 8 usage 504 / 512 (98 %); CPU: 0 %
 	 thread_a            : STACK: unused 648 usage 376 / 1024 (36 %); CPU: 98 %
-	 idle 00             : STACK: unused 204 usage 116 / 320 (36 %); CPU: 0 %
+	 idle                : STACK: unused 204 usage 116 / 320 (36 %); CPU: 0 %
 	thread_b: Hello World from cpu 0 on qemu_x86!
 	thread_a: Hello World from cpu 0 on qemu_x86!
 	thread_b: Hello World from cpu 0 on qemu_x86!
@@ -44,7 +44,7 @@ information from Thread Analyzer::
 	 thread_b            : STACK: unused 648 usage 376 / 1024 (36 %); CPU: 7 %
 	 thread_analyzer     : STACK: unused 8 usage 504 / 512 (98 %); CPU: 0 %
 	 thread_a            : STACK: unused 648 usage 376 / 1024 (36 %); CPU: 9 %
-	 idle 00             : STACK: unused 204 usage 116 / 320 (36 %); CPU: 82 %
+	 idle                : STACK: unused 204 usage 116 / 320 (36 %); CPU: 82 %
 	thread_b: Hello World from cpu 0 on qemu_x86!
 	thread_a: Hello World from cpu 0 on qemu_x86!
 	thread_b: Hello World from cpu 0 on qemu_x86!
@@ -57,7 +57,7 @@ information from Thread Analyzer::
 	 thread_b            : STACK: unused 648 usage 376 / 1024 (36 %); CPU: 7 %
 	 thread_analyzer     : STACK: unused 8 usage 504 / 512 (98 %); CPU: 0 %
 	 thread_a            : STACK: unused 648 usage 376 / 1024 (36 %); CPU: 8 %
-	 idle 00             : STACK: unused 204 usage 116 / 320 (36 %); CPU: 83 %
+	 idle                : STACK: unused 204 usage 116 / 320 (36 %); CPU: 83 %
 	thread_b: Hello World from cpu 0 on qemu_x86!
 	thread_a: Hello World from cpu 0 on qemu_x86!
 	thread_b: Hello World from cpu 0 on qemu_x86!

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -262,9 +262,14 @@ static void init_idle_thread(int i)
 	k_thread_stack_t *stack = z_idle_stacks[i];
 
 #ifdef CONFIG_THREAD_NAME
-	char tname[8];
 
+#if CONFIG_MP_NUM_CPUS > 1
+	char tname[8];
 	snprintk(tname, 8, "idle %02d", i);
+#else
+	char *tname = "idle";
+#endif
+
 #else
 	char *tname = NULL;
 #endif /* CONFIG_THREAD_NAME */

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -265,7 +265,7 @@ static void ztress_thread(void *data, void *prio, void *unused)
 static void thread_cb(const struct k_thread *cthread, void *user_data)
 {
 #define GET_IDLE_TID(i, tid) do {\
-	if (strcmp(tname, "idle 0" STRINGIFY(i)) == 0) { \
+	if (strcmp(tname, (CONFIG_MP_NUM_CPUS == 1) ? "idle" : "idle 0" STRINGIFY(i)) == 0) { \
 		idle_tid[i] = tid; \
 	} \
 } while (0)


### PR DESCRIPTION
The idle thread got an index suffix in #23536 to make it easier to
identify different idle threads on different cores. This looks out of
place on single-core devices when the idle thread is listed next to
other kernel threads, such as main.

Remove the idle thread index on single-core platforms, and replace all
references to this format in tests and documentation.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>