### PR TITLE
ci: do not fail if ccache setup fails

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -180,6 +180,7 @@ jobs:
       - name: use cache
         id: cache-ccache
         uses: nashif/action-s3-cache@master
+        continue-on-error: true
         with:
           key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-${{github.event_name}}-${{ matrix.subset }}-ccache
           path: /github/home/.ccache


### PR DESCRIPTION
Continue without cache of something fails with ccache setup.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
