### PR TITLE
doc: enable sphinx-copybutton extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -82,6 +82,7 @@ extensions = [
     "zephyr.doxyrunner",
     "zephyr.vcs_link",
     "notfound.extension",
+    "sphinx_copybutton",
     "zephyr.external_content",
 ]
 

--- a/scripts/requirements-doc.txt
+++ b/scripts/requirements-doc.txt
@@ -7,6 +7,7 @@ sphinx-tabs
 sphinxcontrib-svg2pdfconverter
 pygments>=2.9
 sphinx-notfound-page
+sphinx-copybutton
 
 # YAML validation. Used by zephyr_module.
 PyYAML>=5.1


### PR DESCRIPTION
The sphinx-copybutton extension adds a button to every code snippet
that, when clicked, copies the code to the clipboard.

![image](https://user-images.githubusercontent.com/25011557/160121230-93890f9e-f61b-4fdb-a0db-00475cd7c2bf.png)

ref. https://sphinx-copybutton.readthedocs.io/en/latest/index.html