### PR TITLE
Bluetooth: Host: Add `const` to `bt_conn_index`

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -56,6 +56,9 @@ Bluetooth
     :c:func:`bond_delete` from the `struct bt_auth_cb` to a newly created
     informational-only callback `struct bt_auth_info_cb`.
 
+  * The :c:macro:bt_conn_index function now takes a `const struct bt_conn`.
+
+
 New APIs in this release
 ========================
 

--- a/include/bluetooth/conn.h
+++ b/include/bluetooth/conn.h
@@ -256,7 +256,7 @@ const bt_addr_le_t *bt_conn_get_dst(const struct bt_conn *conn);
  *  @return Index of the connection object.
  *          The range of the returned value is 0..CONFIG_BT_MAX_CONN-1
  */
-uint8_t bt_conn_index(struct bt_conn *conn);
+uint8_t bt_conn_index(const struct bt_conn *conn);
 
 /** Connection Type */
 enum {

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1108,7 +1108,7 @@ void bt_conn_unref(struct bt_conn *conn)
 	}
 }
 
-uint8_t bt_conn_index(struct bt_conn *conn)
+uint8_t bt_conn_index(const struct bt_conn *conn)
 {
 	ptrdiff_t index = 0;
 


### PR DESCRIPTION
The `bt_conn_index` simply returns the index
of a `bt_conn` struct. There is no reason why
such a function should not use `const`.

Not using `const` will make other lookup/index
functions that perhaps relies on the bt_conn index
unable to use `const` as well.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>