### PR TITLE
doc: fix figure style CSS selector

### DIFF
--- a/doc/_static/css/custom.css
+++ b/doc/_static/css/custom.css
@@ -864,7 +864,7 @@ kbd, .kbd {
     column-width: 18em;
 }
 
-.figure {
+.rst-content div.figure, .rst-content figure {
     text-align: center;
 }
 


### PR DESCRIPTION
The CSS classes used by figures in docutils has changed in recent
versions. Adjust CSS so that figures are centered again by default.