### PR TITLE
include: dt-bindings: fix overlap between SYSCON clock constants

### DIFF
--- a/include/dt-bindings/clock/mcux_lpc_syscon_clock.h
+++ b/include/dt-bindings/clock/mcux_lpc_syscon_clock.h
@@ -35,8 +35,8 @@
 #define MCUX_CTIMER3_CLK		3
 #define MCUX_CTIMER4_CLK		4
 
-#define MCUX_MCAN_CLK			23
+#define MCUX_MCAN_CLK			27
 
-#define MCUX_BUS_CLK			24
+#define MCUX_BUS_CLK			28
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_MCUX_LPC_SYSCON_H_ */


### PR DESCRIPTION
Fix all syscon dt bindings clock constants to avoid any overlap, to
prevent case statement in mcux syscon clock driver from failing to
build.

Fixes #44216

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>