### PR TITLE
tests: lib: c_lib: add coverage for qsort_r

### DIFF
--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -1207,6 +1207,14 @@ void test_exit(void)
 extern void test_qsort(void);
 
 /**
+ *
+ * @brief Test qsort_r function
+ *
+ * @see qsort_r()
+ */
+extern void test_qsort_r(void);
+
+/**
  * @}
  */
 
@@ -1247,7 +1255,8 @@ void test_main(void)
 			 ztest_unit_test(test_str_operate),
 			 ztest_unit_test(test_tolower_toupper),
 			 ztest_unit_test(test_strtok_r),
-			 ztest_unit_test(test_qsort)
+			 ztest_unit_test(test_qsort),
+			 ztest_unit_test(test_qsort_r)
 			 );
 	ztest_run_test_suite(test_c_lib);
 }

--- a/tests/lib/c_lib/src/test_qsort.c
+++ b/tests/lib/c_lib/src/test_qsort.c
@@ -121,3 +121,27 @@ void test_qsort(void)
 				  "size 93 not sorted");
 	}
 }
+
+static int compare_ints_with_boolp_arg(const void *a, const void *b, void *argp)
+{
+	int aa = *(const int *)a;
+	int bb = *(const int *)b;
+
+	*(bool *)argp = true;
+
+	return (aa > bb) - (aa < bb);
+}
+
+void test_qsort_r(void)
+{
+	bool arg = false;
+
+	const int expect_int[] = { 1, 5, 7 };
+	int actual_int[] = { 1, 7, 5 };
+
+	qsort_r(actual_int, ARRAY_SIZE(actual_int), sizeof(actual_int[0]),
+		compare_ints_with_boolp_arg, &arg);
+
+	zassert_mem_equal(actual_int, expect_int, sizeof(expect_int), "array not sorted");
+	zassert_true(arg, "arg not modified");
+}


### PR DESCRIPTION
A user previously reported that `qsort_r()` did not have test coverage. Prior to 845a200c1be436c6069cf77861cef66eb7e895b9 `qsort()` was actually just calling `qsort_r()` inline.

There is still virtually no difference between the two sorting routines, but it would be good to add coverage to check that the argument is passed through to the callback.

Relates to #44218