### PR TITLE
boards: nrf: pyocd: Fix pyocd invocation strings

### DIFF
--- a/boards/arm/96b_nitrogen/board.cmake
+++ b/boards/arm/96b_nitrogen/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52832")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/arduino_nicla_sense_me/board.cmake
+++ b/boards/arm/arduino_nicla_sense_me/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52" "--frequency=400000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=400000")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/bbc_microbit/board.cmake
+++ b/boards/arm/bbc_microbit/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf51")
+board_runner_args(pyocd "--target=nrf51822")
 board_runner_args(jlink "--device=nRF51822_xxAA" "--speed=4000")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/bbc_microbit_v2/board.cmake
+++ b/boards/arm/bbc_microbit_v2/board.cmake
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52833")
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52833_xxAA" "--speed=4000")
 

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/board.cmake
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/board.cmake
@@ -3,7 +3,7 @@
 set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/decawave_dwm1001_dev/board.cmake
+++ b/boards/arm/decawave_dwm1001_dev/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52832")
 set(OPENOCD_NRF5_SUBFAMILY "nrf52")
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf51_blenano/board.cmake
+++ b/boards/arm/nrf51_blenano/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf51")
+board_runner_args(pyocd "--target=nrf51822")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf51_vbluno51/board.cmake
+++ b/boards/arm/nrf51_vbluno51/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf51")
+board_runner_args(pyocd "--target=nrf51822")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52832_mdk/board.cmake
+++ b/boards/arm/nrf52832_mdk/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52832")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52_adafruit_feather/board.cmake
+++ b/boards/arm/nrf52_adafruit_feather/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52_blenano2/board.cmake
+++ b/boards/arm/nrf52_blenano2/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52832")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52_sparkfun/board.cmake
+++ b/boards/arm/nrf52_sparkfun/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52832")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52_vbluno52/board.cmake
+++ b/boards/arm/nrf52_vbluno52/board.cmake
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52832")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/nrf52dk_nrf52832/board.cmake
+++ b/boards/arm/nrf52dk_nrf52832/board.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/pinetime_devkit0/board.cmake
+++ b/boards/arm/pinetime_devkit0/board.cmake
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 
-board_runner_args(pyocd "--target=nrf52")
+board_runner_args(pyocd "--target=nrf52832")
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/blackmagicprobe.board.cmake)

--- a/boards/arm/ubx_bmd300eval_nrf52832/board.cmake
+++ b/boards/arm/ubx_bmd300eval_nrf52832/board.cmake
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/ubx_evkannab1_nrf52832/board.cmake
+++ b/boards/arm/ubx_evkannab1_nrf52832/board.cmake
@@ -5,7 +5,7 @@
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)

--- a/boards/arm/ubx_evkninab1_nrf52832/board.cmake
+++ b/boards/arm/ubx_evkninab1_nrf52832/board.cmake
@@ -5,7 +5,7 @@
 
 board_runner_args(nrfjprog "--nrf-family=NRF52")
 board_runner_args(jlink "--device=nRF52832_xxAA" "--speed=4000")
-board_runner_args(pyocd "--target=nrf52" "--frequency=4000000")
+board_runner_args(pyocd "--target=nrf52832" "--frequency=4000000")
 include(${ZEPHYR_BASE}/boards/common/nrfjprog.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
A follow-up to #44181, this time fixing the pyocd target parameters to
match the actual hardware on the board.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>