### PR TITLE
util: convert wait_for macro to uppercase

### DIFF
--- a/include/sys/util.h
+++ b/include/sys/util.h
@@ -471,7 +471,7 @@ char *utf8_lcpy(char *dst, const char *src, size_t n);
  *
  * @retval expr As a boolean return, if false then it has timed out.
  */
-#define wait_for(expr, timeout, delay_stmt)                                                        \
+#define WAIT_FOR(expr, timeout, delay_stmt)                                                        \
 	({                                                                                         \
 		uint32_t cycle_count = (sys_clock_hw_cycles_per_sec() / USEC_PER_SEC) * (timeout); \
 		uint32_t start = k_cycle_get_32();                                                 \

--- a/soc/xtensa/intel_adsp/common/include/cavstool.h
+++ b/soc/xtensa/intel_adsp/common/include/cavstool.h
@@ -5,19 +5,6 @@
 #ifndef ZEPHYR_INCLUDE_CAVS_TEST_H
 #define ZEPHYR_INCLUDE_CAVS_TEST_H
 
-/* Helper to escape from infinite polling loops with a test failure
- * instead of a hang.  Spins with a relaxation loop so that it works
- * in interrupt context and doesn't stress shared resources like SRAM
- */
-#define WAIT_FOR(expr) do {						\
-		int i;							\
-		for (i = 0; !(expr) && i < 10000; i++) {		\
-			for (volatile int j = 0; j < 1000; j++) {	\
-			}						\
-		}							\
-		zassert_true(i < 10000, "timeout waiting for %s", #expr); \
-	} while (0)
-
 /* The cavstool.py script that launched us listens for a very simple
  * set of IPC commands to help test.  Pass one of the following values
  * as the "data" argument to cavs_ipc_send_message(CAVS_HOST_DEV, ...):

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/bass_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/bass_client_test.c
@@ -308,7 +308,7 @@ static struct bt_le_per_adv_sync_cb sync_callbacks = {
 
 static void test_exchange_mtu(void)
 {
-	WAIT_FOR(g_mtu_exchanged);
+	WAIT_FOR_COND(g_mtu_exchanged);
 	printk("MTU exchanged\n");
 }
 
@@ -323,7 +323,7 @@ static void test_bass_discover(void)
 		return;
 	}
 
-	WAIT_FOR(g_discovery_complete);
+	WAIT_FOR_COND(g_discovery_complete);
 	printk("Discovery complete\n");
 }
 
@@ -339,7 +339,7 @@ static void test_bass_scan_start(void)
 		return;
 	}
 
-	WAIT_FOR(g_write_complete && g_broadcaster_found);
+	WAIT_FOR_COND(g_write_complete && g_broadcaster_found);
 	printk("Scan started\n");
 }
 
@@ -355,7 +355,7 @@ static void test_bass_scan_stop(void)
 		return;
 	}
 
-	WAIT_FOR(g_write_complete);
+	WAIT_FOR_COND(g_write_complete);
 	printk("Scan stopped\n");
 }
 
@@ -374,7 +374,7 @@ static void test_bass_create_pa_sync(void)
 		return;
 	}
 
-	WAIT_FOR(g_pa_synced);
+	WAIT_FOR_COND(g_pa_synced);
 	printk("PA synced\n");
 }
 
@@ -401,7 +401,7 @@ static void test_bass_add_source(void)
 		return;
 	}
 
-	WAIT_FOR(g_cb && g_write_complete);
+	WAIT_FOR_COND(g_cb && g_write_complete);
 	printk("Source added\n");
 }
 
@@ -426,9 +426,9 @@ static void test_bass_mod_source(void)
 		return;
 	}
 
-	WAIT_FOR(g_cb && g_write_complete);
+	WAIT_FOR_COND(g_cb && g_write_complete);
 	printk("Source added, waiting for server to PA sync\n");
-	WAIT_FOR(g_state_synced)
+	WAIT_FOR_COND(g_state_synced)
 	printk("Server PA synced\n");
 }
 
@@ -450,7 +450,7 @@ static void test_bass_broadcast_code(void)
 		return;
 	}
 
-	WAIT_FOR(g_write_complete);
+	WAIT_FOR_COND(g_write_complete);
 	printk("Broadcast code added\n");
 }
 
@@ -465,7 +465,7 @@ static void test_bass_remove_source(void)
 		FAIL("Could not remove source (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_cb && g_write_complete);
+	WAIT_FOR_COND(g_cb && g_write_complete);
 	printk("Source removed\n");
 }
 
@@ -494,7 +494,7 @@ static void test_main(void)
 
 	printk("Scanning successfully started\n");
 
-	WAIT_FOR(g_is_connected);
+	WAIT_FOR_COND(g_is_connected);
 
 	test_exchange_mtu();
 	test_bass_discover();

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/bass_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/bass_test.c
@@ -86,9 +86,9 @@ static void test_main(void)
 
 	printk("Advertising successfully started\n");
 
-	WAIT_FOR(g_connected);
+	WAIT_FOR_COND(g_connected);
 
-	WAIT_FOR(g_pa_synced);
+	WAIT_FOR_COND(g_pa_synced);
 
 	PASS("BASS passed\n");
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
@@ -32,7 +32,7 @@
 #define WAIT_SECONDS 30                         /* seconds */
 #define WAIT_TIME (WAIT_SECONDS * USEC_PER_SEC) /* microseconds*/
 
-#define WAIT_FOR(cond) while (!(cond)) { k_sleep(K_MSEC(1)); }
+#define WAIT_FOR_COND(cond) while (!(cond)) { k_sleep(K_MSEC(1)); }
 
 #define CREATE_FLAG(flag) static atomic_t flag = (atomic_t)false
 #define SET_FLAG(flag) (void)atomic_set(&flag, (atomic_t)true)

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/csis_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/csis_client_test.c
@@ -206,9 +206,9 @@ static void read_set_lock_state(const struct bt_csis_client_set_member **members
 	}
 
 	if (expect_locked) {
-		WAIT_FOR(set_read_locked);
+		WAIT_FOR_COND(set_read_locked);
 	} else {
-		WAIT_FOR(set_read_unlocked);
+		WAIT_FOR_COND(set_read_unlocked);
 	}
 }
 
@@ -241,7 +241,7 @@ static void test_main(void)
 
 	printk("Scanning successfully started\n");
 
-	WAIT_FOR(members_found == 1);
+	WAIT_FOR_COND(members_found == 1);
 
 	printk("Stopping scan\n");
 	err = bt_le_scan_stop();
@@ -259,7 +259,7 @@ static void test_main(void)
 	}
 	printk("Connecting to %s\n", addr);
 
-	WAIT_FOR(is_connected);
+	WAIT_FOR_COND(is_connected);
 	connected_member_count++;
 
 	err = bt_csis_client_discover(&set_members[0]);
@@ -269,7 +269,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR(discovered);
+	WAIT_FOR_COND(discovered);
 
 	err = bt_le_scan_start(BT_LE_SCAN_ACTIVE, NULL);
 	if (err != 0) {
@@ -284,7 +284,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR(members_found == inst->info.set_size);
+	WAIT_FOR_COND(members_found == inst->info.set_size);
 
 	(void)k_work_cancel_delayable(&discover_members_timer);
 	err = bt_le_scan_stop();
@@ -308,7 +308,7 @@ static void test_main(void)
 		}
 
 		printk("Connected to %s\n", addr);
-		WAIT_FOR(is_connected);
+		WAIT_FOR_COND(is_connected);
 		connected_member_count++;
 
 		discovered = false;
@@ -320,7 +320,7 @@ static void test_main(void)
 			return;
 		}
 
-		WAIT_FOR(discovered);
+		WAIT_FOR_COND(discovered);
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(locked_members); i++) {
@@ -337,7 +337,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR(set_locked);
+	WAIT_FOR_COND(set_locked);
 
 	read_set_lock_state(locked_members, connected_member_count, true);
 
@@ -351,7 +351,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR(set_unlocked);
+	WAIT_FOR_COND(set_unlocked);
 
 	read_set_lock_state(locked_members, connected_member_count, false);
 
@@ -367,7 +367,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR(set_locked);
+	WAIT_FOR_COND(set_locked);
 
 	k_sleep(K_MSEC(1000)); /* Simulate doing stuff */
 
@@ -379,7 +379,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR(set_unlocked);
+	WAIT_FOR_COND(set_unlocked);
 
 	for (uint8_t i = 0; i < members_found; i++) {
 		printk("Disconnecting member[%u] (%s)", i, addr);

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/csis_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/csis_test.c
@@ -128,7 +128,7 @@ static void test_force_release(void)
 
 	bt_conn_cb_register(&conn_callbacks);
 
-	WAIT_FOR(g_locked);
+	WAIT_FOR_COND(g_locked);
 	printk("Force releasing set\n");
 	bt_csis_lock(csis, false, true);
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_client_test.c
@@ -242,7 +242,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS state get\n");
 
 	printk("Getting AICS gain setting\n");
@@ -252,7 +252,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS gain setting get\n");
 
 	printk("Getting AICS input type\n");
@@ -264,7 +264,7 @@ static int test_aics(void)
 		return err;
 	}
 	/* Expect and wait for input_type from init */
-	WAIT_FOR(g_cb && expected_input_type == g_aics_input_type);
+	WAIT_FOR_COND(g_cb && expected_input_type == g_aics_input_type);
 	printk("AICS input type get\n");
 
 	printk("Getting AICS status\n");
@@ -274,7 +274,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS status get\n");
 
 	printk("Getting AICS description\n");
@@ -284,7 +284,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS description get\n");
 
 	printk("Setting AICS mute\n");
@@ -295,7 +295,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_input_mute == expected_input_mute &&
+	WAIT_FOR_COND(g_aics_input_mute == expected_input_mute &&
 		 g_cb && g_write_complete);
 	printk("AICS mute set\n");
 
@@ -307,7 +307,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_input_mute == expected_input_mute &&
+	WAIT_FOR_COND(g_aics_input_mute == expected_input_mute &&
 		 g_cb && g_write_complete);
 	printk("AICS unmute set\n");
 
@@ -319,7 +319,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_mode == expected_mode && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_aics_mode == expected_mode && g_cb && g_write_complete);
 	printk("AICS auto mode set\n");
 
 	printk("Setting AICS manual mode\n");
@@ -330,7 +330,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_mode == expected_mode && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_aics_mode == expected_mode && g_cb && g_write_complete);
 	printk("AICS manual mode set\n");
 
 	printk("Setting AICS gain\n");
@@ -341,7 +341,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_gain == expected_gain && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_aics_gain == expected_gain && g_cb && g_write_complete);
 	printk("AICS gain set\n");
 
 	printk("Setting AICS Description\n");
@@ -355,7 +355,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS Description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb &&
+	WAIT_FOR_COND(g_cb &&
 		 strncmp(expected_aics_desc, g_aics_desc, sizeof(expected_aics_desc) == 0));
 	printk("AICS Description set\n");
 
@@ -378,7 +378,7 @@ static void test_main(void)
 
 	bt_mics_client_cb_register(&mics_cbs);
 
-	WAIT_FOR(g_bt_init);
+	WAIT_FOR_COND(g_bt_init);
 
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);
 	if (err != 0) {
@@ -386,13 +386,13 @@ static void test_main(void)
 		return;
 	}
 	printk("Scanning successfully started\n");
-	WAIT_FOR(g_is_connected);
+	WAIT_FOR_COND(g_is_connected);
 
 	err = bt_mics_discover(default_conn, &mics);
 	if (err != 0) {
 		FAIL("Failed to discover MICS %d", err);
 	}
-	WAIT_FOR(g_discovery_complete);
+	WAIT_FOR_COND(g_discovery_complete);
 
 	err = bt_mics_included_get(mics, &mics_included);
 	if (err != 0) {
@@ -418,7 +418,7 @@ static void test_main(void)
 		FAIL("Could not get MICS mute state (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("MICS mute state received\n");
 
 	printk("Muting MICS\n");
@@ -429,7 +429,7 @@ static void test_main(void)
 		FAIL("Could not mute MICS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_mute == expected_mute && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
 	printk("MICS muted\n");
 
 	printk("Unmuting MICS\n");
@@ -440,7 +440,7 @@ static void test_main(void)
 		FAIL("Could not unmute MICS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_mute == expected_mute && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
 	printk("MICS unmuted\n");
 
 	if (CONFIG_BT_MICS_CLIENT_MAX_AICS_INST > 0 && g_aics_count > 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
@@ -158,7 +158,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not deactivate AICS (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_aics_active == g_aics_active);
+	WAIT_FOR_COND(expected_aics_active == g_aics_active);
 	printk("AICS deactivated\n");
 
 	printk("Activating AICS\n");
@@ -168,7 +168,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not activate AICS (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_aics_active == g_aics_active);
+	WAIT_FOR_COND(expected_aics_active == g_aics_active);
 	printk("AICS activated\n");
 
 	printk("Getting AICS state\n");
@@ -178,7 +178,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS state get\n");
 
 	printk("Getting AICS gain setting\n");
@@ -188,7 +188,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS gain setting get\n");
 
 	printk("Getting AICS input type\n");
@@ -200,7 +200,7 @@ static int test_aics_server_only(void)
 		return err;
 	}
 	/* Expect and wait for input_type from init */
-	WAIT_FOR(g_cb && expected_input_type == g_aics_input_type);
+	WAIT_FOR_COND(g_cb && expected_input_type == g_aics_input_type);
 	printk("AICS input type get\n");
 
 	printk("Getting AICS status\n");
@@ -210,7 +210,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS status get\n");
 
 	printk("Getting AICS description\n");
@@ -220,7 +220,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS description get\n");
 
 	printk("Setting AICS mute\n");
@@ -231,7 +231,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && expected_input_mute == g_aics_input_mute);
+	WAIT_FOR_COND(g_cb && expected_input_mute == g_aics_input_mute);
 	printk("AICS mute set\n");
 
 	printk("Setting AICS unmute\n");
@@ -242,7 +242,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && expected_input_mute == g_aics_input_mute);
+	WAIT_FOR_COND(g_cb && expected_input_mute == g_aics_input_mute);
 	printk("AICS unmute set\n");
 
 	printk("Setting AICS auto mode\n");
@@ -253,7 +253,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && expected_mode == g_aics_mode);
+	WAIT_FOR_COND(g_cb && expected_mode == g_aics_mode);
 	printk("AICS auto mode set\n");
 
 	printk("Setting AICS manual mode\n");
@@ -264,7 +264,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && expected_mode == g_aics_mode);
+	WAIT_FOR_COND(g_cb && expected_mode == g_aics_mode);
 	printk("AICS manual mode set\n");
 
 	printk("Setting AICS gain\n");
@@ -275,7 +275,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && expected_gain == g_aics_gain);
+	WAIT_FOR_COND(g_cb && expected_gain == g_aics_gain);
 	printk("AICS gain set\n");
 
 	printk("Setting AICS Description\n");
@@ -288,7 +288,7 @@ static int test_aics_server_only(void)
 		FAIL("Could not set AICS Description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && !strncmp(expected_aics_desc, g_aics_desc,
+	WAIT_FOR_COND(g_cb && !strncmp(expected_aics_desc, g_aics_desc,
 				  sizeof(expected_aics_desc)));
 	printk("AICS Description set\n");
 
@@ -347,7 +347,7 @@ static void test_server_only(void)
 		FAIL("Could not get MICS mute (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("MICS mute get\n");
 
 	printk("Setting MICS mute\n");
@@ -357,7 +357,7 @@ static void test_server_only(void)
 		FAIL("MICS mute failed (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_mute == g_mute);
+	WAIT_FOR_COND(expected_mute == g_mute);
 	printk("MICS mute set\n");
 
 	printk("Setting MICS unmute\n");
@@ -367,7 +367,7 @@ static void test_server_only(void)
 		FAIL("MICS unmute failed (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_mute == g_mute);
+	WAIT_FOR_COND(expected_mute == g_mute);
 	printk("MICS unmute set\n");
 
 	printk("Setting MICS disable\n");
@@ -377,7 +377,7 @@ static void test_server_only(void)
 		FAIL("MICS disable failed (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_mute == g_mute);
+	WAIT_FOR_COND(expected_mute == g_mute);
 	printk("MICS disable set\n");
 
 	if (CONFIG_BT_MICS_AICS_INSTANCE_COUNT > 0) {
@@ -442,7 +442,7 @@ static void test_main(void)
 
 	printk("Advertising successfully started\n");
 
-	WAIT_FOR(g_is_connected);
+	WAIT_FOR_COND(g_is_connected);
 
 	PASS("MICS passed\n");
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/tbs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/tbs_client_test.c
@@ -139,7 +139,7 @@ static void test_main(void)
 	bt_conn_cb_register(&conn_callbacks);
 	bt_tbs_client_register_cb(&tbs_client_cbs);
 
-	WAIT_FOR(bt_init);
+	WAIT_FOR_COND(bt_init);
 
 	printk("Audio Server: Bluetooth discovered\n");
 
@@ -151,14 +151,14 @@ static void test_main(void)
 
 	printk("Advertising successfully started\n");
 
-	WAIT_FOR(is_connected);
+	WAIT_FOR_COND(is_connected);
 
 	tbs_client_err = bt_tbs_client_discover(default_conn, true);
 	if (tbs_client_err) {
 		FAIL("Failed to discover TBS_CLIENT for connection %d", tbs_client_err);
 	}
 
-	WAIT_FOR(discovery_complete);
+	WAIT_FOR_COND(discovery_complete);
 
 	printk("GTBS %sfound\n", is_gtbs_found ? "" : "not ");
 
@@ -175,7 +175,7 @@ static void test_main(void)
 	 * 4) Remotely Held
 	 */
 	printk("Waiting for remotely held\n");
-	WAIT_FOR(call_state == BT_TBS_CALL_STATE_REMOTELY_HELD);
+	WAIT_FOR_COND(call_state == BT_TBS_CALL_STATE_REMOTELY_HELD);
 
 	printk("Holding call\n");
 	err = bt_tbs_client_hold_call(default_conn, index, call_index);
@@ -187,7 +187,7 @@ static void test_main(void)
 	 * 1) Locally and remotely held
 	 * 2) Locally held
 	 */
-	WAIT_FOR(call_state == BT_TBS_CALL_STATE_LOCALLY_HELD);
+	WAIT_FOR_COND(call_state == BT_TBS_CALL_STATE_LOCALLY_HELD);
 
 	printk("Retrieving call\n");
 	err = bt_tbs_client_retrieve_call(default_conn, index, call_index);
@@ -195,7 +195,7 @@ static void test_main(void)
 		FAIL("Retrieve call failed (%d)\n", err);
 	}
 
-	WAIT_FOR(call_state == BT_TBS_CALL_STATE_ACTIVE);
+	WAIT_FOR_COND(call_state == BT_TBS_CALL_STATE_ACTIVE);
 
 	printk("Reading bearer provider name\n");
 	err = bt_tbs_client_read_bearer_provider_name(default_conn, index);
@@ -203,7 +203,7 @@ static void test_main(void)
 		FAIL("Read bearer provider name failed (%d)\n", err);
 	}
 
-	WAIT_FOR(read_complete);
+	WAIT_FOR_COND(read_complete);
 	PASS("TBS_CLIENT Passed\n");
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/tbs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/tbs_test.c
@@ -92,9 +92,9 @@ static void test_main(void)
 
 	printk("Scanning successfully started\n");
 
-	WAIT_FOR(is_connected);
+	WAIT_FOR_COND(is_connected);
 
-	WAIT_FOR(call_placed);
+	WAIT_FOR_COND(call_placed);
 
 	err = bt_tbs_remote_answer(call_id);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {
@@ -109,7 +109,7 @@ static void test_main(void)
 	}
 	printk("Remote held %u\n", call_id);
 
-	WAIT_FOR(call_held);
+	WAIT_FOR_COND(call_held);
 
 	err = bt_tbs_remote_retrieve(call_id);
 	if (err != BT_TBS_RESULT_CODE_SUCCESS) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_client_test.c
@@ -315,7 +315,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS state get\n");
 
 	printk("Getting AICS gain setting\n");
@@ -325,7 +325,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS gain setting get\n");
 
 	printk("Getting AICS input type\n");
@@ -337,7 +337,7 @@ static int test_aics(void)
 		return err;
 	}
 	/* Expect and wait for input_type from init */
-	WAIT_FOR(g_cb && expected_input_type == g_aics_input_type);
+	WAIT_FOR_COND(g_cb && expected_input_type == g_aics_input_type);
 	printk("AICS input type get\n");
 
 	printk("Getting AICS status\n");
@@ -347,7 +347,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS status get\n");
 
 	printk("Getting AICS description\n");
@@ -357,7 +357,7 @@ static int test_aics(void)
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS description get\n");
 
 	printk("Setting AICS mute\n");
@@ -368,7 +368,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_input_mute == expected_input_mute &&
+	WAIT_FOR_COND(g_aics_input_mute == expected_input_mute &&
 		 g_cb && g_write_complete);
 	printk("AICS mute set\n");
 
@@ -380,7 +380,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_input_mute == expected_input_mute &&
+	WAIT_FOR_COND(g_aics_input_mute == expected_input_mute &&
 		 g_cb && g_write_complete);
 	printk("AICS unmute set\n");
 
@@ -392,7 +392,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_mode == expected_mode && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_aics_mode == expected_mode && g_cb && g_write_complete);
 	printk("AICS auto mode set\n");
 
 	printk("Setting AICS manual mode\n");
@@ -403,7 +403,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_mode == expected_mode && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_aics_mode == expected_mode && g_cb && g_write_complete);
 	printk("AICS manual mode set\n");
 
 	printk("Setting AICS gain\n");
@@ -414,7 +414,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_aics_gain == expected_gain && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_aics_gain == expected_gain && g_cb && g_write_complete);
 	printk("AICS gain set\n");
 
 	printk("Setting AICS Description\n");
@@ -428,7 +428,7 @@ static int test_aics(void)
 		FAIL("Could not set AICS Description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(!strncmp(expected_aics_desc, g_aics_desc,
+	WAIT_FOR_COND(!strncmp(expected_aics_desc, g_aics_desc,
 			  sizeof(expected_aics_desc)) &&
 		g_cb);
 	printk("AICS Description set\n");
@@ -463,7 +463,7 @@ static int test_vocs(void)
 		FAIL("Could not get VOCS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VOCS state get\n");
 
 	printk("Getting VOCS location\n");
@@ -473,7 +473,7 @@ static int test_vocs(void)
 		FAIL("Could not get VOCS location (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VOCS location get\n");
 
 	printk("Getting VOCS description\n");
@@ -483,7 +483,7 @@ static int test_vocs(void)
 		FAIL("Could not get VOCS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VOCS description get\n");
 
 	printk("Setting VOCS location\n");
@@ -495,7 +495,7 @@ static int test_vocs(void)
 		FAIL("Could not set VOCS location (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_vocs_location == expected_location && g_cb);
+	WAIT_FOR_COND(g_vocs_location == expected_location && g_cb);
 	printk("VOCS location set\n");
 
 	printk("Setting VOCS state\n");
@@ -506,7 +506,7 @@ static int test_vocs(void)
 		FAIL("Could not set VOCS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_vocs_offset == expected_offset && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_vocs_offset == expected_offset && g_cb && g_write_complete);
 	printk("VOCS state set\n");
 
 	printk("Setting VOCS description\n");
@@ -520,7 +520,7 @@ static int test_vocs(void)
 		FAIL("Could not set VOCS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(!strncmp(expected_description, g_vocs_desc,
+	WAIT_FOR_COND(!strncmp(expected_description, g_vocs_desc,
 			  sizeof(expected_description)) &&
 		 g_cb);
 	printk("VOCS description set\n");
@@ -550,7 +550,7 @@ static void test_main(void)
 		return;
 	}
 
-	WAIT_FOR(g_bt_init);
+	WAIT_FOR_COND(g_bt_init);
 
 	err = bt_le_scan_start(BT_LE_SCAN_PASSIVE, device_found);
 	if (err) {
@@ -560,14 +560,14 @@ static void test_main(void)
 
 	printk("Scanning successfully started\n");
 
-	WAIT_FOR(g_is_connected);
+	WAIT_FOR_COND(g_is_connected);
 
 	err = bt_vcs_discover(default_conn, &vcs);
 	if (err) {
 		FAIL("Failed to discover VCS %d", err);
 	}
 
-	WAIT_FOR(g_discovery_complete);
+	WAIT_FOR_COND(g_discovery_complete);
 
 	err = bt_vcs_included_get(vcs, &vcs_included);
 	if (err) {
@@ -593,7 +593,7 @@ static void test_main(void)
 		FAIL("Could not get VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VCS volume get\n");
 
 	printk("Getting VCS flags\n");
@@ -603,7 +603,7 @@ static void test_main(void)
 		FAIL("Could not get VCS flags (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VCS flags get\n");
 
 	expected_volume = g_volume != 100 ? 100 : 101; /* ensure change */
@@ -613,7 +613,7 @@ static void test_main(void)
 		FAIL("Could not set VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_volume == expected_volume && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_volume == expected_volume && g_cb && g_write_complete);
 	printk("VCS volume set\n");
 
 	printk("Downing VCS volume\n");
@@ -624,7 +624,7 @@ static void test_main(void)
 		FAIL("Could not get down VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_volume < previous_volume && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_volume < previous_volume && g_cb && g_write_complete);
 	printk("VCS volume downed\n");
 
 	printk("Upping VCS volume\n");
@@ -635,7 +635,7 @@ static void test_main(void)
 		FAIL("Could not up VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_volume > previous_volume && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_volume > previous_volume && g_cb && g_write_complete);
 	printk("VCS volume upped\n");
 
 	printk("Muting VCS\n");
@@ -646,7 +646,7 @@ static void test_main(void)
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_mute == expected_mute && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
 	printk("VCS muted\n");
 
 	printk("Downing and unmuting VCS\n");
@@ -658,7 +658,7 @@ static void test_main(void)
 		FAIL("Could not down and unmute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_volume < previous_volume && expected_mute == g_mute &&
+	WAIT_FOR_COND(g_volume < previous_volume && expected_mute == g_mute &&
 		 g_cb && g_write_complete);
 	printk("VCS volume downed and unmuted\n");
 
@@ -670,7 +670,7 @@ static void test_main(void)
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_mute == expected_mute && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
 	printk("VCS muted\n");
 
 	printk("Upping and unmuting VCS\n");
@@ -682,7 +682,7 @@ static void test_main(void)
 		FAIL("Could not up and unmute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_volume > previous_volume && g_mute == expected_mute &&
+	WAIT_FOR_COND(g_volume > previous_volume && g_mute == expected_mute &&
 		 g_cb && g_write_complete);
 	printk("VCS volume upped and unmuted\n");
 
@@ -694,7 +694,7 @@ static void test_main(void)
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_mute == expected_mute && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
 	printk("VCS muted\n");
 
 	printk("Unmuting VCS\n");
@@ -705,7 +705,7 @@ static void test_main(void)
 		FAIL("Could not unmute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_mute == expected_mute && g_cb && g_write_complete);
+	WAIT_FOR_COND(g_mute == expected_mute && g_cb && g_write_complete);
 	printk("VCS volume unmuted\n");
 
 	if (CONFIG_BT_VCS_CLIENT_VOCS > 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -222,7 +222,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not deactivate AICS (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_aics_active == g_aics_active);
+	WAIT_FOR_COND(expected_aics_active == g_aics_active);
 	printk("AICS deactivated\n");
 
 	printk("Activating AICS\n");
@@ -232,7 +232,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not activate AICS (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_aics_active == g_aics_active);
+	WAIT_FOR_COND(expected_aics_active == g_aics_active);
 	printk("AICS activated\n");
 
 	printk("Getting AICS state\n");
@@ -242,7 +242,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not get AICS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS state get\n");
 
 	printk("Getting AICS gain setting\n");
@@ -252,7 +252,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not get AICS gain setting (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS gain setting get\n");
 
 	printk("Getting AICS input type\n");
@@ -263,7 +263,7 @@ static int test_aics_standalone(void)
 		return err;
 	}
 	/* Expect and wait for input_type from init */
-	WAIT_FOR(expected_input_type == g_aics_input_type);
+	WAIT_FOR_COND(expected_input_type == g_aics_input_type);
 	printk("AICS input type get\n");
 
 	printk("Getting AICS status\n");
@@ -273,7 +273,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not get AICS status (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS status get\n");
 
 	printk("Getting AICS description\n");
@@ -283,7 +283,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not get AICS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("AICS description get\n");
 
 	printk("Setting AICS mute\n");
@@ -293,7 +293,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not set AICS mute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_input_mute == g_aics_input_mute);
+	WAIT_FOR_COND(expected_input_mute == g_aics_input_mute);
 	printk("AICS mute set\n");
 
 	printk("Setting AICS unmute\n");
@@ -303,7 +303,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not set AICS unmute (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_input_mute == g_aics_input_mute);
+	WAIT_FOR_COND(expected_input_mute == g_aics_input_mute);
 	printk("AICS unmute set\n");
 
 	printk("Setting AICS auto mode\n");
@@ -313,7 +313,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not set AICS auto mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_mode == g_aics_mode);
+	WAIT_FOR_COND(expected_mode == g_aics_mode);
 	printk("AICS auto mode set\n");
 
 	printk("Setting AICS manual mode\n");
@@ -323,7 +323,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not set AICS manual mode (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_mode == g_aics_mode);
+	WAIT_FOR_COND(expected_mode == g_aics_mode);
 	printk("AICS manual mode set\n");
 
 	printk("Setting AICS gain\n");
@@ -333,7 +333,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not set AICS gain (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_gain == g_aics_gain);
+	WAIT_FOR_COND(expected_gain == g_aics_gain);
 	printk("AICS gain set\n");
 
 	printk("Setting AICS Description\n");
@@ -347,7 +347,7 @@ static int test_aics_standalone(void)
 		FAIL("Could not set AICS Description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && !strncmp(expected_aics_desc, g_aics_desc,
+	WAIT_FOR_COND(g_cb && !strncmp(expected_aics_desc, g_aics_desc,
 				  sizeof(expected_aics_desc)));
 	printk("AICS Description set\n");
 
@@ -368,7 +368,7 @@ static int test_vocs_standalone(void)
 		FAIL("Could not get VOCS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VOCS state get\n");
 
 	printk("Getting VOCS location\n");
@@ -378,7 +378,7 @@ static int test_vocs_standalone(void)
 		FAIL("Could not get VOCS location (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VOCS location get\n");
 
 	printk("Getting VOCS description\n");
@@ -388,7 +388,7 @@ static int test_vocs_standalone(void)
 		FAIL("Could not get VOCS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VOCS description get\n");
 
 	printk("Setting VOCS location\n");
@@ -399,7 +399,7 @@ static int test_vocs_standalone(void)
 		FAIL("Could not set VOCS location (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_location == g_vocs_location);
+	WAIT_FOR_COND(expected_location == g_vocs_location);
 	printk("VOCS location set\n");
 
 	printk("Setting VOCS state\n");
@@ -409,7 +409,7 @@ static int test_vocs_standalone(void)
 		FAIL("Could not set VOCS state (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(expected_offset == g_vocs_offset);
+	WAIT_FOR_COND(expected_offset == g_vocs_offset);
 	printk("VOCS state set\n");
 
 	printk("Setting VOCS description\n");
@@ -423,7 +423,7 @@ static int test_vocs_standalone(void)
 		FAIL("Could not set VOCS description (err %d)\n", err);
 		return err;
 	}
-	WAIT_FOR(g_cb && !strncmp(expected_description, g_vocs_desc,
+	WAIT_FOR_COND(g_cb && !strncmp(expected_description, g_vocs_desc,
 				  sizeof(expected_description)));
 	printk("VOCS description set\n");
 
@@ -508,7 +508,7 @@ static void test_standalone(void)
 		FAIL("Could not get VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VCS volume get\n");
 
 	printk("Getting VCS flags\n");
@@ -518,7 +518,7 @@ static void test_standalone(void)
 		FAIL("Could not get VCS flags (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(g_cb);
+	WAIT_FOR_COND(g_cb);
 	printk("VCS flags get\n");
 
 	printk("Downing VCS volume\n");
@@ -528,7 +528,7 @@ static void test_standalone(void)
 		FAIL("Could not get down VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_volume == g_volume || g_volume == 0);
+	WAIT_FOR_COND(expected_volume == g_volume || g_volume == 0);
 	printk("VCS volume downed\n");
 
 	printk("Upping VCS volume\n");
@@ -538,7 +538,7 @@ static void test_standalone(void)
 		FAIL("Could not up VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_volume == g_volume || g_volume == UINT8_MAX);
+	WAIT_FOR_COND(expected_volume == g_volume || g_volume == UINT8_MAX);
 	printk("VCS volume upped\n");
 
 	printk("Muting VCS\n");
@@ -548,7 +548,7 @@ static void test_standalone(void)
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_mute == g_mute);
+	WAIT_FOR_COND(expected_mute == g_mute);
 	printk("VCS muted\n");
 
 	printk("Downing and unmuting VCS\n");
@@ -559,7 +559,7 @@ static void test_standalone(void)
 		FAIL("Could not down and unmute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR((expected_volume == g_volume || g_volume == 0) &&
+	WAIT_FOR_COND((expected_volume == g_volume || g_volume == 0) &&
 		 expected_mute == g_mute);
 	printk("VCS volume downed and unmuted\n");
 
@@ -570,7 +570,7 @@ static void test_standalone(void)
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_mute == g_mute);
+	WAIT_FOR_COND(expected_mute == g_mute);
 	printk("VCS muted\n");
 
 	printk("Upping and unmuting VCS\n");
@@ -581,7 +581,7 @@ static void test_standalone(void)
 		FAIL("Could not up and unmute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR((expected_volume == g_volume  || g_volume == UINT8_MAX) &&
+	WAIT_FOR_COND((expected_volume == g_volume  || g_volume == UINT8_MAX) &&
 		 expected_mute == g_mute);
 	printk("VCS volume upped and unmuted\n");
 
@@ -592,7 +592,7 @@ static void test_standalone(void)
 		FAIL("Could not mute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_mute == g_mute);
+	WAIT_FOR_COND(expected_mute == g_mute);
 	printk("VCS volume upped\n");
 
 	printk("Unmuting VCS\n");
@@ -602,7 +602,7 @@ static void test_standalone(void)
 		FAIL("Could not unmute VCS (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_mute == g_mute);
+	WAIT_FOR_COND(expected_mute == g_mute);
 	printk("VCS volume unmuted\n");
 
 	expected_volume = g_volume - 5;
@@ -611,7 +611,7 @@ static void test_standalone(void)
 		FAIL("Could not set VCS volume (err %d)\n", err);
 		return;
 	}
-	WAIT_FOR(expected_volume == g_volume);
+	WAIT_FOR_COND(expected_volume == g_volume);
 	printk("VCS volume set\n");
 
 	if (CONFIG_BT_VCS_VOCS_INSTANCE_COUNT > 0) {
@@ -696,7 +696,7 @@ static void test_main(void)
 
 	printk("Advertising successfully started\n");
 
-	WAIT_FOR(g_is_connected);
+	WAIT_FOR_COND(g_is_connected);
 
 	PASS("VCS passed\n");
 }

--- a/tests/boards/intel_adsp/hda/src/dma.c
+++ b/tests/boards/intel_adsp/hda/src/dma.c
@@ -129,7 +129,7 @@ void test_hda_host_in_dma(void)
 		hda_ipc_msg(CAVS_HOST_DEV, IPCCMD_HDA_VALIDATE, channel,
 			    IPC_TIMEOUT);
 
-		WAIT_FOR(msg_cnt > last_msg_cnt);
+		WAIT_FOR(msg_cnt > last_msg_cnt, 10000, k_msleep(1));
 		zassert_true(msg_res == 1,
 			     "Expected data validation to be true from Host");
 	}
@@ -208,7 +208,7 @@ void test_hda_host_out_dma(void)
 		cavs_hda_dbg("host_out", HDA_HOST_OUT_BASE, channel);
 
 		/* TODO add a dma_poll() style call for xfer ready/complete maybe? */
-		WAIT_FOR(cavs_hda_buf_full(HDA_HOST_OUT_BASE, channel));
+		WAIT_FOR(cavs_hda_buf_full(HDA_HOST_OUT_BASE, channel), 10000, k_msleep(1));
 		printk("dsp wait for full: ");
 		cavs_hda_dbg("host_out", HDA_HOST_OUT_BASE, channel);
 

--- a/tests/boards/intel_adsp/hda/src/smoke.c
+++ b/tests/boards/intel_adsp/hda/src/smoke.c
@@ -93,14 +93,14 @@ void test_hda_host_in_smoke(void)
 		cavs_hda_commit(HDA_HOST_IN_BASE, STREAM_ID, HDA_BUF_SIZE);
 		printk("dsp inc_pos: "); cavs_hda_dbg("host_in", HDA_HOST_IN_BASE, STREAM_ID);
 
-		WAIT_FOR(cavs_hda_wp_rp_eq(HDA_HOST_IN_BASE, STREAM_ID));
+		WAIT_FOR(cavs_hda_wp_rp_eq(HDA_HOST_IN_BASE, STREAM_ID), 10000, k_msleep(1));
 		printk("dsp wp_rp_eq: "); cavs_hda_dbg("host_in", HDA_HOST_IN_BASE, STREAM_ID);
 
 		last_msg_cnt = msg_cnt;
 		hda_ipc_msg(CAVS_HOST_DEV, IPCCMD_HDA_VALIDATE, STREAM_ID,
 			    IPC_TIMEOUT);
 
-		WAIT_FOR(msg_cnt > last_msg_cnt);
+		WAIT_FOR(msg_cnt > last_msg_cnt, 10000, k_msleep(1));
 		zassert_true(msg_res == 1,
 			     "Expected data validation to be true from Host");
 	}
@@ -163,7 +163,7 @@ void test_hda_host_out_smoke(void)
 		cavs_hda_dbg("host_out", HDA_HOST_OUT_BASE, STREAM_ID);
 
 
-		WAIT_FOR(cavs_hda_buf_full(HDA_HOST_OUT_BASE, STREAM_ID));
+		WAIT_FOR(cavs_hda_buf_full(HDA_HOST_OUT_BASE, STREAM_ID), 10000, k_msleep(1));
 		printk("dsp wait for full: ");
 		cavs_hda_dbg("host_out", HDA_HOST_OUT_BASE, STREAM_ID);
 

--- a/tests/boards/intel_adsp/smoke/src/cpus.c
+++ b/tests/boards/intel_adsp/smoke/src/cpus.c
@@ -182,7 +182,7 @@ void halt_and_restart(int cpu)
 	/* Startup can be slow */
 	k_msleep(50);
 
-	WAIT_FOR(alive_flag == true);
+	zassert_true(WAIT_FOR(alive_flag == true, 10000, k_msleep(1)), NULL);
 
 	k_thread_abort(&run_on_threads[cpu]);
 }

--- a/tests/boards/intel_adsp/smoke/src/hostipc.c
+++ b/tests/boards/intel_adsp/smoke/src/hostipc.c
@@ -41,8 +41,8 @@ void test_host_ipc(void)
 	done_flag = false;
 	ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_SIGNAL_DONE, 0);
 	zassert_true(ret, "send failed");
-	WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV));
-	WAIT_FOR(done_flag);
+	zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)), NULL);
+	zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
 
 	/* Request the host to return a message which we will complete
 	 * immediately.
@@ -53,9 +53,9 @@ void test_host_ipc(void)
 	ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_RETURN_MSG,
 				    RETURN_MSG_SYNC_VAL);
 	zassert_true(ret, "send failed");
-	WAIT_FOR(done_flag);
-	WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV));
-	WAIT_FOR(msg_flag);
+	zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
+	zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)), NULL);
+	zassert_true(WAIT_FOR(msg_flag, 10000, k_msleep(1)), NULL);
 
 	/* Do exactly the same thing again to check for state bugs
 	 * (e.g. failing to signal done on one side or the other)
@@ -66,9 +66,9 @@ void test_host_ipc(void)
 	ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_RETURN_MSG,
 				    RETURN_MSG_SYNC_VAL);
 	zassert_true(ret, "send failed");
-	WAIT_FOR(done_flag);
-	WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV));
-	WAIT_FOR(msg_flag);
+	zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
+	zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)), NULL);
+	zassert_true(WAIT_FOR(msg_flag, 10000, k_msleep(1)), NULL);
 
 	/* Same, but we'll complete it asynchronously (1.8+ only) */
 	if (!IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V15)) {
@@ -78,9 +78,10 @@ void test_host_ipc(void)
 		ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_RETURN_MSG,
 					    RETURN_MSG_ASYNC_VAL);
 		zassert_true(ret, "send failed");
-		WAIT_FOR(done_flag);
-		WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV));
-		WAIT_FOR(msg_flag);
+		zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
+		zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)),
+			     NULL);
+		zassert_true(WAIT_FOR(msg_flag, 10000, k_msleep(1)), NULL);
 		cavs_ipc_complete(CAVS_HOST_DEV);
 	}
 

--- a/tests/boards/intel_adsp/smoke/src/main.c
+++ b/tests/boards/intel_adsp/smoke/src/main.c
@@ -31,7 +31,7 @@ void test_clock_calibrate(void)
 	/* Now do it again, but with a handler to catch the result */
 	cyc1 = k_cycle_get_32();
 	cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_TIMESTAMP, 0);
-	WAIT_FOR(host_dt != 0);
+	zassert_true(WAIT_FOR(host_dt != 0, 10000, k_msleep(1)), NULL);
 	cavs_ipc_set_message_handler(CAVS_HOST_DEV, NULL, NULL);
 
 	hz = 1000000ULL * (cyc1 - cyc0) / host_dt;

--- a/tests/lib/sys_util/src/wait_for.c
+++ b/tests/lib/sys_util/src/wait_for.c
@@ -16,23 +16,23 @@
 /**
  * @brief Test wait_for works as expected with typical use cases
  *
- * @see wait_for()
+ * @see WAIT_FOR()
  */
 void test_wait_for(void)
 {
 	uint32_t start, end, expected;
 
-	zassert_true(wait_for(true, 0, NULL), "true, no wait, NULL");
-	zassert_true(wait_for(true, 0, k_yield()), "true, no wait, yield");
-	zassert_false(wait_for(false, 0, k_yield()), "false, no wait, yield");
-	zassert_true(wait_for(true, 1, k_yield()), "true, 1usec, yield");
-	zassert_false(wait_for(false, 1, k_yield()), "false, 1usec, yield");
-	zassert_true(wait_for(true, 1000, k_yield()), "true, 1msec, yield");
+	zassert_true(WAIT_FOR(true, 0, NULL), "true, no wait, NULL");
+	zassert_true(WAIT_FOR(true, 0, k_yield()), "true, no wait, yield");
+	zassert_false(WAIT_FOR(false, 0, k_yield()), "false, no wait, yield");
+	zassert_true(WAIT_FOR(true, 1, k_yield()), "true, 1usec, yield");
+	zassert_false(WAIT_FOR(false, 1, k_yield()), "false, 1usec, yield");
+	zassert_true(WAIT_FOR(true, 1000, k_yield()), "true, 1msec, yield");
 
 
 	expected = 1000*(sys_clock_hw_cycles_per_sec()/USEC_PER_SEC);
 	start = k_cycle_get_32();
-	zassert_false(wait_for(false, 1000, k_yield()), "true, 1msec, yield");
+	zassert_false(WAIT_FOR(false, 1000, k_yield()), "true, 1msec, yield");
 	end = k_cycle_get_32();
 	zassert_true(end-start >= expected, "wait for 1ms");
 }


### PR DESCRIPTION
This macro conflicts with C++'s std::condition_variable::wait_for
and makes it very difficult to use Zephyr with C++. Replace it with
an all uppercase name which fits the naming standard better.

Signed-off-by: Yuval Peress <peress@google.com>