### PR TITLE
pm: device: helper to query power state

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -555,6 +555,16 @@ int pm_device_power_domain_add(const struct device *dev,
  */
 int pm_device_power_domain_remove(const struct device *dev,
 				  const struct device *domain);
+
+/**
+ * @brief Check if the device is currently powered.
+ *
+ * @param dev Device instance.
+ *
+ * @retval true If device is currently powered
+ * @retval false If device is not currently powered
+ */
+bool pm_device_is_powered(const struct device *dev);
 #else
 static inline void pm_device_init_suspended(const struct device *dev)
 {
@@ -626,6 +636,11 @@ static inline int pm_device_power_domain_remove(const struct device *dev,
 	return -ENOSYS;
 }
 
+static inline bool pm_device_is_powered(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+	return true;
+}
 #endif /* CONFIG_PM_DEVICE */
 
 /** @} */

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -372,3 +372,19 @@ bool pm_device_on_power_domain(const struct device *dev)
 	return false;
 #endif
 }
+
+bool pm_device_is_powered(const struct device *dev)
+{
+#ifdef CONFIG_PM_DEVICE_POWER_DOMAIN
+	struct pm_device *pm = dev->pm;
+
+	/* If a device doesn't support PM or is not under a PM domain,
+	 * assume it is always powered on.
+	 */
+	return (pm == NULL) ||
+	       (pm->domain == NULL) ||
+	       (pm->domain->pm->state == PM_DEVICE_STATE_ACTIVE);
+#else
+	return true;
+#endif
+}

--- a/tests/subsys/pm/device_power_domains/src/main.c
+++ b/tests/subsys/pm/device_power_domains/src/main.c
@@ -15,25 +15,41 @@ static void test_demo(void)
 	const struct device *reg_1 = DEVICE_DT_GET(DT_NODELABEL(test_reg_1));
 	const struct device *reg_chained = DEVICE_DT_GET(DT_NODELABEL(test_reg_chained));
 
+	/* Initial power state */
+	zassert_true(pm_device_is_powered(reg_0), "");
+	zassert_true(pm_device_is_powered(reg_1), "");
+	zassert_false(pm_device_is_powered(reg_chained), "");
+
 	TC_PRINT("Enabling runtime power management on regulators\n");
 
 	pm_device_runtime_enable(reg_0);
 	pm_device_runtime_enable(reg_1);
 	pm_device_runtime_enable(reg_chained);
 
+	/* State shouldn't have changed */
+	zassert_true(pm_device_is_powered(reg_0), "");
+	zassert_true(pm_device_is_powered(reg_1), "");
+	zassert_false(pm_device_is_powered(reg_chained), "");
+
 	TC_PRINT("Cycling: %s\n", reg_0->name);
 
+	/* reg_chained is powered off reg_0, so it's power state should change */
 	pm_device_runtime_get(reg_0);
+	zassert_true(pm_device_is_powered(reg_chained), "");
 	pm_device_runtime_put(reg_0);
+	zassert_false(pm_device_is_powered(reg_chained), "");
 
 	TC_PRINT("Cycling: %s\n", reg_1->name);
 
 	pm_device_runtime_get(reg_1);
+	zassert_false(pm_device_is_powered(reg_chained), "");
 	pm_device_runtime_put(reg_1);
 
 	TC_PRINT("Cycling: %s\n", reg_chained->name);
 
+	/* reg_chained should be powered after being requested */
 	pm_device_runtime_get(reg_chained);
+	zassert_true(pm_device_is_powered(reg_chained), "");
 	pm_device_runtime_put(reg_chained);
 
 	TC_PRINT("DONE\n");


### PR DESCRIPTION
Adds a helper function to query whether a device is currently powered.
This can be used to determine if the chip can be initialised now, or if
it needs to be deferred.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>