### PR TITLE
Bluetooth: Controller: Increase BT_RX_STACK_SIZE for BT_HCI_RAW enabled

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -83,7 +83,7 @@ config BT_RECV_IS_RX_THREAD
 config BT_RX_STACK_SIZE
 	int "Size of the receiving thread stack"
 	depends on BT_HCI_HOST || BT_RECV_IS_RX_THREAD
-	default 512 if BT_HCI_RAW
+	default 768 if BT_HCI_RAW
 	default 3092 if BT_MESH_GATT_CLIENT
 	default 2048 if BT_MESH
 	default 2048 if BT_AUDIO


### PR DESCRIPTION
Increase BT_RX_STACK_SIZE for BT_HCI_RAW enabled, as HCI
Extended Advertising Report generation requires more program
stack.

Without the update conformance test run failed with hanging
controller with mem manage fault.

Profiled the hci_uart sample using BlueZ by performing
`find -l` in `btmgmt` utility with the sample built
using:

CONFIG_THREAD_ANALYZER=y
CONFIG_THREAD_ANALYZER_AUTO=y
CONFIG_THREAD_ANALYZER_AUTO_INTERVAL=5
CONFIG_THREAD_NAME=y

Thread analyze:
 HCI uart TX         : STACK: unused 496 usage 528 / 1024 (51 %); CPU: 0 %
      : Total CPU cycles used: 146
 BT RX               : STACK: unused 72 usage 696 / 768 (90 %); CPU: 0 %
      : Total CPU cycles used: 3549
 BT RX pri           : STACK: unused 88 usage 168 / 256 (65 %); CPU: 0 %
      : Total CPU cycles used: 1210
 thread_analyzer     : STACK: unused 528 usage 496 / 1024 (48 %); CPU: 0 %
      : Total CPU cycles used: 889
 sysworkq            : STACK: unused 344 usage 168 / 512 (32 %); CPU: 0 %
      : Total CPU cycles used: 0
 logging             : STACK: unused 240 usage 528 / 768 (68 %); CPU: 0 %
      : Total CPU cycles used: 4305
 idle 00             : STACK: unused 228 usage 92 / 320 (28 %); CPU: 99 %
      : Total CPU cycles used: 3101052
 main                : STACK: unused 672 usage 352 / 1024 (34 %); CPU: 0 %
      : Total CPU cycles used: 395
 ISR0                : STACK: unused 1248 usage 800 / 2048 (39 %)

Signed-off-by: Vinayak Kariappa Chettimada <vinayak.kariappa@gmail.com>