### PR TITLE
doc: getting_started: linux: fixup dnf usage

### DIFF
--- a/doc/getting_started/installation_linux.rst
+++ b/doc/getting_started/installation_linux.rst
@@ -86,7 +86,7 @@ need one.
       .. code-block:: console
 
          sudo dnf group install "Development Tools" "C Development Tools and Libraries"
-         dnf install git cmake ninja-build gperf ccache dfu-util dtc wget \
+         sudo dnf install git cmake ninja-build gperf ccache dfu-util dtc wget \
            python3-pip python3-tkinter xz file glibc-devel.i686 libstdc++-devel.i686 python38 \
            SDL2-devel
 


### PR DESCRIPTION
Fixup a command where dnf should be invoked with sudo.
If this command is ran without sudo, dnf will return:

`Error: This command has to be run with superuser
privileges (under the root user on most systems).`

Signed-off-by: Wilfred Mallawa <thulith.mallawa@uqconnect.edu.au>