### PR TITLE
boards: arm: pinetime: Enable SPI_NOR flash driver

### DIFF
--- a/boards/arm/pinetime_devkit0/Kconfig.defconfig
+++ b/boards/arm/pinetime_devkit0/Kconfig.defconfig
@@ -21,6 +21,16 @@ config ST7789V
 
 endif # DISPLAY
 
+if FLASH
+
+config SPI
+	default y
+
+config SPI_NOR
+	default y
+
+endif # FLASH
+
 config I2C
 	default y if KSCAN
 


### PR DESCRIPTION
When the application requests `CONFIG_FLASH`, then automatically
enable the flash driver using `CONFIG_SPI_NOR`.

Signed-off-by: Casper Meijn <casper@meijn.net>