### PR TITLE
boards: arm: pinetime: Fix minimal sample build

### DIFF
--- a/boards/arm/pinetime_devkit0/CMakeLists.txt
+++ b/boards/arm/pinetime_devkit0/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Copyright (c) 2021 Casper Meijn <casper@meijn.net
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library()
-zephyr_library_sources(key_out.c)
+if(CONFIG_GPIO)
+  zephyr_library()
+  zephyr_library_sources(key_out.c)
+endif()


### PR DESCRIPTION
The board specific driver for `pinetime_devkit0` has a requirement for
`CONFIG_GPIO` that was not documented. With this fix the minimal sample
build successful.

Signed-off-by: Casper Meijn <casper@meijn.net>