### PR TITLE
net: gptp: Fix type mismatch calculation error in gptp_mi

### DIFF
--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -778,7 +778,7 @@ static void gptp_update_local_port_clock(void)
 
 	if (second_diff < 0 && nanosecond_diff > 0) {
 		second_diff++;
-		nanosecond_diff = -NSEC_PER_SEC + nanosecond_diff;
+		nanosecond_diff = -(int64_t)NSEC_PER_SEC + nanosecond_diff;
 	}
 
 	ptp_clock_rate_adjust(clk, port_ds->neighbor_rate_ratio);


### PR DESCRIPTION
NSEC_PER_SEC is an unsigned integer macro. Thus, -NSEC_PER_SEC will be
treated as unsigned integer as well which lead to calculation error on
64bits integer variables. Added the correct type casting into the formula
to fix the calculation error.

Signed-off-by: Kweh Hock Leong <hock.leong.kweh@intel.com>