### PR TITLE
logging: Fix CONFIG_LOG_OVERRIDE_LEVEL feature

### DIFF
--- a/subsys/logging/log_mgmt.c
+++ b/subsys/logging/log_mgmt.c
@@ -37,6 +37,7 @@ void z_log_runtime_filters_init(void)
 		uint32_t *filters = z_log_dynamic_filters_get(i);
 		uint8_t level = log_compiled_level_get(i);
 
+		level = MAX(level, CONFIG_LOG_OVERRIDE_LEVEL);
 		LOG_FILTER_SLOT_SET(filters,
 				    LOG_FILTER_AGGR_SLOT_IDX,
 				    level);
@@ -109,7 +110,7 @@ uint32_t z_impl_log_filter_set(struct log_backend const *const backend,
 			uint32_t max = log_filter_get(backend, domain_id,
 						      source_id, false);
 
-			level = MIN(level, max);
+			level = MIN(level, MAX(max, CONFIG_LOG_OVERRIDE_LEVEL));
 
 			LOG_FILTER_SLOT_SET(filters,
 					    log_backend_id_get(backend),

--- a/tests/subsys/logging/log_api/CMakeLists.txt
+++ b/tests/subsys/logging/log_api/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(log_api)
 
 target_sources(app PRIVATE src/main.c src/mock_frontend.c
-               src/mock_backend.c src/test_module.c)
+               src/mock_backend.c src/test_module.c src/test_module2.c)
 
 if(CONFIG_CPLUSPLUS)
   # When testing for C++ force test file C++ compilation

--- a/tests/subsys/logging/log_api/CMakeLists.txt
+++ b/tests/subsys/logging/log_api/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(log_core)
+project(log_api)
 
 target_sources(app PRIVATE src/main.c src/mock_frontend.c
                src/mock_backend.c src/test_module.c)

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -19,9 +19,6 @@
 #define NO_BACKENDS 0
 #endif
 
-#define MODULE_NAME test
-#define CXX_MODULE_NAME test_cxx
-
 LOG_MODULE_REGISTER(test, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
 
 #define LOG2_SIMPLE_MSG_LEN \
@@ -44,7 +41,7 @@ MOCK_LOG_BACKEND_DEFINE(backend2, false);
 static log_timestamp_t stamp;
 static bool in_panic;
 static int16_t test_source_id;
-static int16_t test_cxx_source_id;
+static int16_t test2_source_id;
 
 static log_timestamp_t timestamp_get(void)
 {
@@ -103,8 +100,8 @@ static void log_setup(bool backend2_enable)
 
 	mock_log_frontend_reset();
 
-	test_source_id = log_source_id_get(STRINGIFY(MODULE_NAME));
-	test_cxx_source_id = log_source_id_get(STRINGIFY(CXX_MODULE_NAME));
+	test_source_id = log_source_id_get(STRINGIFY(test));
+	test2_source_id = log_source_id_get(STRINGIFY(test2));
 
 	if (NO_BACKENDS) {
 		return;
@@ -798,6 +795,41 @@ ZTEST(test_log_api, test_log_arg_evaluation)
 #undef TEST_MSG_0_PREFIX
 }
 
+ZTEST(test_log_api, test_log_override_level)
+{
+	log_timestamp_t exp_timestamp = TIMESTAMP_INIT_VAL;
+
+	log_setup(false);
+
+	if (CONFIG_LOG_OVERRIDE_LEVEL == 4) {
+		char str[128];
+
+		/* If prefix is enabled, add function name prefix */
+		if (IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) {
+			snprintk(str, sizeof(str),
+				 "%s: " TEST_DBG_MSG, "test_func");
+		} else {
+			snprintk(str, sizeof(str), TEST_DBG_MSG);
+		}
+
+		mock_log_frontend_record(test2_source_id, LOG_LEVEL_DBG, str);
+		mock_log_backend_record(&backend1, test2_source_id,
+					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_DBG,
+					exp_timestamp++, str);
+
+		mock_log_frontend_record(test2_source_id, LOG_LEVEL_ERR, TEST_ERR_MSG);
+		mock_log_backend_record(&backend1, test2_source_id,
+					CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_ERR,
+					exp_timestamp++, TEST_ERR_MSG);
+	} else if (CONFIG_LOG_OVERRIDE_LEVEL != 0) {
+		zassert_true(false, "Unexpected configuration.");
+	}
+
+	test_func2();
+
+	process_and_validate(false, false);
+}
+
 /* Disable backends because same suite may be executed again but compiled by C++ */
 static void log_api_suite_teardown(void *data)
 {
@@ -847,6 +879,9 @@ static void log_api_suite_before(void *data)
 	/* Flush logs and enable test backends. */
 	flush_log();
 
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
+		mock_log_frontend_check_enable();
+	}
 	mock_log_backend_check_enable(&backend1);
 	mock_log_backend_check_enable(&backend2);
 }
@@ -867,6 +902,9 @@ static void log_api_suite_after(void *data)
 	/* Disable testing backends after the test. Otherwise test may fail due
 	 * to unexpected log message.
 	 */
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
+		mock_log_frontend_check_disable();
+	}
 	mock_log_backend_check_disable(&backend1);
 	mock_log_backend_check_disable(&backend2);
 }

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -149,6 +149,11 @@ static void process_and_validate(bool backend2_enable, bool panic)
 	}
 }
 
+static bool dbg_enabled(void)
+{
+	return IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG) || (CONFIG_LOG_OVERRIDE_LEVEL == 4);
+}
+
 ZTEST(test_log_api, test_log_various_messages)
 {
 	char str[128];
@@ -166,7 +171,7 @@ ZTEST(test_log_api, test_log_various_messages)
 #define TEST_MSG_0_PREFIX "%s: %lld %llu %hhd"
 #define TEST_MSG_1 "%f %d %f"
 
-	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+	if (dbg_enabled()) {
 		/* If prefix is enabled, add function name prefix */
 		if (IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) {
 			snprintk(str, sizeof(str),
@@ -201,7 +206,7 @@ ZTEST(test_log_api, test_log_various_messages)
 #define TEST_MSG_0 "%hhd"
 #define TEST_MSG_0_PREFIX "%s: %hhd"
 #define TEST_MSG_1 "%p"
-	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+	if (dbg_enabled()) {
 		/* If prefix is enabled, add function name prefix */
 		if (IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) {
 			snprintk(str, sizeof(str),
@@ -263,7 +268,7 @@ ZTEST(test_log_api, test_log_backend_runtime_filtering)
 
 	log_setup(true);
 
-	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+	if (dbg_enabled()) {
 		char str[128];
 
 		/* If prefix is enabled, add function name prefix */
@@ -546,7 +551,7 @@ ZTEST(test_log_api, test_log_from_declared_module)
 	log_setup(false);
 
 	/* See test module for log message content. */
-	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+	if (dbg_enabled()) {
 		char str[128];
 
 		/* If prefix is enabled, add function name prefix */
@@ -570,7 +575,7 @@ ZTEST(test_log_api, test_log_from_declared_module)
 
 	test_func();
 
-	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+	if (dbg_enabled()) {
 		char str[128];
 
 		/* If prefix is enabled, add function name prefix */
@@ -754,7 +759,7 @@ ZTEST(test_log_api, test_log_arg_evaluation)
 
 	log_setup(false);
 
-	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+	if (dbg_enabled()) {
 		/* Debug message arguments are only evaluated when this level
 		 * is enabled.
 		 */
@@ -766,7 +771,7 @@ ZTEST(test_log_api, test_log_arg_evaluation)
 	mock_log_backend_record(&backend1, LOG_CURRENT_MODULE_ID(),
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_INF,
 				exp_timestamp++, "0 0");
-	if (IS_ENABLED(CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG)) {
+	if (dbg_enabled()) {
 		/* If prefix is enabled, add function name prefix */
 		if (IS_ENABLED(CONFIG_LOG_FUNC_NAME_PREFIX_DBG)) {
 			snprintk(str, sizeof(str),

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -308,8 +308,8 @@ static void process(const struct log_backend *const backend,
 		    log_const_source_id((const struct log_source_const_data *)source);
 	}
 
-	zassert_equal(source_id, exp->source_id, "sourc_id:%p (exp: %d)",
-		      msg->log.hdr.source, exp->source_id);
+	zassert_equal(source_id, exp->source_id, "source_id:%p (exp: %d)",
+		      source_id, exp->source_id);
 
 	size_t len;
 	uint8_t *data;

--- a/tests/subsys/logging/log_api/src/mock_frontend.c
+++ b/tests/subsys/logging/log_api/src/mock_frontend.c
@@ -30,6 +30,16 @@ void mock_log_frontend_dummy_record(int cnt)
 	mock_log_backend_dummy_record(&backend, cnt);
 }
 
+void mock_log_frontend_check_enable(void)
+{
+	mock.do_check = true;
+}
+
+void mock_log_frontend_check_disable(void)
+{
+	mock.do_check = false;
+}
+
 void mock_log_frontend_generic_record(uint16_t source_id,
 				      uint16_t domain_id,
 				      uint8_t level,
@@ -79,6 +89,10 @@ static void log_frontend_n(struct log_msg_ids src_level, const char *fmt, ...)
 	char str[128];
 	va_list ap;
 
+	if (mock.do_check == false) {
+		return;
+	}
+
 	mock.msg_proc_idx++;
 
 	if (!exp_msg->check) {
@@ -105,6 +119,10 @@ void log_frontend_hexdump(const char *str,
 {
 	struct mock_log_backend_msg *exp_msg = &mock.exp_msgs[mock.msg_proc_idx];
 
+	if (mock.do_check == false) {
+		return;
+	}
+
 	zassert_equal(exp_msg->data_len, length, NULL);
 	if (exp_msg->data_len <= sizeof(exp_msg->data)) {
 		zassert_equal(memcmp(data, exp_msg->data, length), 0, NULL);
@@ -115,6 +133,10 @@ void log_frontend_hexdump(const char *str,
 
 void log_frontend_0(const char *str, struct log_msg_ids src_level)
 {
+	if (mock.do_check == false) {
+		return;
+	}
+
 	log_frontend_n(src_level, str);
 }
 
@@ -125,6 +147,10 @@ void log_frontend_1(const char *str, log_arg_t arg0, struct log_msg_ids src_leve
 
 void log_frontend_2(const char *str, log_arg_t arg0, log_arg_t arg1, struct log_msg_ids src_level)
 {
+	if (mock.do_check == false) {
+		return;
+	}
+
 	log_frontend_n(src_level, str, arg0, arg1);
 }
 
@@ -133,6 +159,10 @@ void log_frontend_msg(const void *source,
 		      uint8_t *package, const void *data)
 {
 	struct mock_log_backend_msg *exp_msg = &mock.exp_msgs[mock.msg_proc_idx];
+
+	if (mock.do_check == false) {
+		return;
+	}
 
 	mock.msg_proc_idx++;
 
@@ -147,7 +177,8 @@ void log_frontend_msg(const void *source,
 		log_dynamic_source_id((struct log_source_dynamic_data *)source) :
 		log_const_source_id((const struct log_source_const_data *)source);
 
-	zassert_equal(source_id, exp_msg->source_id, NULL);
+	zassert_equal(source_id, exp_msg->source_id, "got: %d, exp: %d",
+			source_id, exp_msg->source_id);
 
 	zassert_equal(exp_msg->data_len, desc.data_len, NULL);
 	if (exp_msg->data_len <= sizeof(exp_msg->data)) {

--- a/tests/subsys/logging/log_api/src/mock_frontend.h
+++ b/tests/subsys/logging/log_api/src/mock_frontend.h
@@ -27,7 +27,8 @@ static inline void mock_log_frontend_record(uint16_t source_id, uint8_t level, c
 }
 
 void mock_log_frontend_validate(bool panic);
-
+void mock_log_frontend_check_enable(void);
+void mock_log_frontend_check_disable(void);
 #ifdef __cplusplus
 }
 #endif

--- a/tests/subsys/logging/log_api/src/test_module.c
+++ b/tests/subsys/logging/log_api/src/test_module.c
@@ -10,12 +10,13 @@
  *
  */
 
+#include "test_module.h"
 #include <logging/log.h>
 
 LOG_MODULE_DECLARE(test, CONFIG_SAMPLE_MODULE_LOG_LEVEL);
 
 void test_func(void)
 {
-	LOG_DBG("debug");
-	LOG_ERR("test");
+	LOG_DBG(TEST_DBG_MSG);
+	LOG_ERR(TEST_ERR_MSG);
 }

--- a/tests/subsys/logging/log_api/src/test_module.h
+++ b/tests/subsys/logging/log_api/src/test_module.h
@@ -14,6 +14,7 @@ extern "C" {
 #endif
 
 void test_func(void);
+void test_func2(void);
 
 #ifdef __cplusplus
 }

--- a/tests/subsys/logging/log_api/src/test_module2.c
+++ b/tests/subsys/logging/log_api/src/test_module2.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Test module for log api test
+ *
+ */
+
+#include "test_module.h"
+#include <logging/log.h>
+
+/* Module disabled by default, will emit logs only when CONFIG_LOG_OVERRIDE_LEVEL. */
+LOG_MODULE_REGISTER(test2, 0);
+
+void test_func2(void)
+{
+	LOG_DBG(TEST_DBG_MSG);
+	LOG_ERR(TEST_ERR_MSG);
+}

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -127,6 +127,23 @@ tests:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
 
+  logging.log2_api_deferred_override_level:
+    # Testing on selected platforms as it enables all logs in the application
+    # and it cannot be handled on many platforms.
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    extra_configs:
+      - CONFIG_LOG_MODE_DEFERRED=y
+      - CONFIG_LOG_OVERRIDE_LEVEL=4
+
+  logging.log2_api_deferred_override_level_rt_filtering:
+    # Testing on selected platforms as it enables all logs in the application
+    # and it cannot be handled on many platforms.
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    extra_configs:
+      - CONFIG_LOG_MODE_DEFERRED=y
+      - CONFIG_LOG_RUNTIME_FILTERING=y
+      - CONFIG_LOG_OVERRIDE_LEVEL=4
+
   logging.log2_api_immediate:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
@@ -182,6 +199,24 @@ tests:
     extra_configs:
       - CONFIG_LOG_FRONTEND=y
       - CONFIG_LOG_MODE_IMMEDIATE=y
+
+  logging.log_api_frontend_immediate_override_level:
+    # Testing on selected platforms as it enables all logs in the application
+    # and it cannot be handled on many platforms.
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    extra_configs:
+      - CONFIG_LOG_FRONTEND=y
+      - CONFIG_LOG_MODE_IMMEDIATE=y
+      - CONFIG_LOG_OVERRIDE_LEVEL=4
+
+  logging.log2_api_deferred_override_level_rt_filtering:
+    # Testing on selected platforms as it enables all logs in the application
+    # and it cannot be handled on many platforms.
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    extra_configs:
+      - CONFIG_LOG_MODE_DEFERRED=y
+      - CONFIG_LOG_RUNTIME_FILTERING=y
+      - CONFIG_LOG_OVERRIDE_LEVEL=4
 
   logging.log_api_frontend_only:
     # FIXME: qemu_arc_hs6x excluded, see #38041


### PR DESCRIPTION
Feature was not performing as described. Fixed and added to `log_api` test suite.
Note that it enables all logs in the system which breaks the test on some platforms thus test for that option is limited to selected platforms.

Fixes #44029.

~~`DNM` since it is based on #43791.~~