### PR TITLE
ITE drivers/timer: clean up sys_clock_set_timeout()

### DIFF
--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -225,7 +225,15 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	IT8XXX2_EXT_CTRLX(EVENT_TIMER) &= ~IT8XXX2_EXT_ETXEN;
 
 	if (ticks == K_TICKS_FOREVER) {
-		/* Return since no future timer interrupts are required */
+		/*
+		 * If kernel doesn't have a timeout:
+		 * 1.CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = y (no future timer interrupts
+		 *   are expected), kernel pass K_TICKS_FOREVER (0xFFFF FFFF FFFF FFFF),
+		 *   we handle this case in here.
+		 * 2.CONFIG_SYSTEM_CLOCK_SLOPPY_IDLE = n (schedule timeout as far
+		 *   into the future as possible), kernel pass INT_MAX (0x7FFF FFFF),
+		 *   we handle it in later else {}.
+		 */
 		k_spin_unlock(&lock, key);
 		return;
 	} else if (ticks <= 1) {
@@ -237,19 +245,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 		 */
 		hw_cnt = MAX((1 * HW_CNT_PER_SYS_TICK), 1);
 	} else {
-		if (ticks > EVEN_TIMER_MAX_CNT_SYS_TICK)
-			/*
-			 * Set event timer count to EVENT_TIMER_MAX_CNT, after
-			 * interrupt fired the remaining time will be set again
-			 * by sys_clock_announce().
-			 */
-			hw_cnt = EVENT_TIMER_MAX_CNT;
-		else
-			/*
-			 * Set event timer count to system tick or at least
-			 * 1 hw count
-			 */
-			hw_cnt = MAX((ticks * HW_CNT_PER_SYS_TICK), 1);
+		/*
+		 * Set event timer count to EVENT_TIMER_MAX_CNT, after
+		 * interrupt fired the remaining time will be set again
+		 * by sys_clock_announce().
+		 */
+		hw_cnt = MIN((ticks * HW_CNT_PER_SYS_TICK), EVENT_TIMER_MAX_CNT);
 	}
 
 	/* Set event timer 24-bit count */


### PR DESCRIPTION
Setting event timer count at least 1 hw count, it's redundant,
so I clean up this else {} case. And add the comment about
the K_TICKS_FOREVER and INT_MAX case.
    
NOTE:
CONFIG_TIMEOUT_64BIT = y, then k_ticks_t type is int64_t.
K_FOREVER is (k_timeout_t) { .ticks = (K_TICKS_FOREVER) },
and K_TICKS_FOREVER is ((k_ticks_t) -1),
so K_FOREVER is a k_timeout_t type structure, and
the member ticks: type int64_t,
                              value (= K_TICKS_FOREVER) 0xFFFF FFFF FFFF FFFF.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>