### PR TITLE
ITE drivers/timer: fix timer

### DIFF
--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -15,6 +15,9 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(timer, LOG_LEVEL_ERR);
 
+BUILD_ASSERT(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 32768,
+	     "ITE RTOS timer HW frequency is fixed at 32768Hz");
+
 /* Event timer configurations */
 #define EVENT_TIMER		EXT_TIMER_3
 #define EVENT_TIMER_IRQ		DT_INST_IRQ_BY_IDX(0, 0, irq)

--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -289,7 +289,7 @@ uint32_t sys_clock_elapsed(void)
 uint32_t sys_clock_cycle_get_32(void)
 {
 	/*
-	 * Get free run observer count and transform unit to system tick
+	 * Get free run observer count
 	 *
 	 * NOTE: Timer is counting down from 0xffffffff. In not combined
 	 *       mode, the observer count value is the same as count, so after
@@ -297,8 +297,7 @@ uint32_t sys_clock_cycle_get_32(void)
 	 *       combined mode, the observer count value is the same as NOT
 	 *       count operation.
 	 */
-	uint32_t dticks = (~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER)))
-				/ HW_CNT_PER_SYS_TICK;
+	uint32_t dticks = ~(IT8XXX2_EXT_CNTOX(FREE_RUN_TIMER));
 
 	return dticks;
 }

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -26,7 +26,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 32768
+	default 8192
 
 config UART_NS16550
 	default y


### PR DESCRIPTION
1.We don't need to convert the free run clock count,
that will be converted by the kernel
(base on CONFIG_SYS_CLOCK_TICKS_PER_SEC),
so we should return the HW register count value directly.

2.ITE RTOS timer HW frequency is fixed at 32768Hz, because this
clock source is always active in any EC mode (running/doze/deep doze).

3.When run the test_mutex_lock_timeout(), we need more time (>300us) for the testing 
thread to finish the job, or we will get a fail (we didn't run the test before). 

Because our event timer doesn't handle the float part, and 32768 is divisible by 8192 which
 is closest to kernel tick default 10000, I add CONFIG_SYS_CLOCK_TICKS_PER_SEC = 8192 
for it8xxx2_evb.

If the CONFIG_SYS_CLOCK_TICKS_PER_SEC = 32768, the 10 tick of timeout = 300us.
If the CONFIG_SYS_CLOCK_TICKS_PER_SEC = 8192, the 10 tick of timeout = 1200us. 
So we can get more time to finish the job.

fixes https://github.com/zephyrproject-rtos/zephyr/issues/43513
fixes https://github.com/zephyrproject-rtos/zephyr/issues/42847

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>