### PR TITLE
sys: heap: support maximum allocated bytes statistic

### DIFF
--- a/include/zephyr/sys/sys_heap.h
+++ b/include/zephyr/sys/sys_heap.h
@@ -70,6 +70,7 @@ struct z_heap_stress_result {
 struct sys_heap_runtime_stats {
 	size_t free_bytes;
 	size_t allocated_bytes;
+	size_t max_allocated_bytes;
 };
 
 /**
@@ -81,6 +82,17 @@ struct sys_heap_runtime_stats {
  */
 int sys_heap_runtime_stats_get(struct sys_heap *heap,
 		struct sys_heap_runtime_stats *stats);
+
+/**
+ * @brief Reset the maximum heap usage.
+ *
+ * Set the statistic measuring the maximum number of allocated bytes to the
+ * current number of allocated bytes.
+ *
+ * @param heap Pointer to sys_heap
+ * @return -EINVAL if null pointer was passed, otherwise 0
+ */
+int sys_heap_runtime_stats_reset_max(struct sys_heap *heap);
 
 #endif
 

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -422,6 +422,18 @@ int sys_heap_runtime_stats_get(struct sys_heap *heap,
 
 	stats->free_bytes = heap->heap->free_bytes;
 	stats->allocated_bytes = heap->heap->allocated_bytes;
+	stats->max_allocated_bytes = heap->heap->max_allocated_bytes;
+
+	return 0;
+}
+
+int sys_heap_runtime_stats_reset_max(struct sys_heap *heap)
+{
+	if (heap == NULL) {
+		return -EINVAL;
+	}
+
+	heap->heap->max_allocated_bytes = heap->heap->allocated_bytes;
 
 	return 0;
 }

--- a/lib/os/heap.h
+++ b/lib/os/heap.h
@@ -72,6 +72,7 @@ struct z_heap {
 #ifdef CONFIG_SYS_HEAP_RUNTIME_STATS
 	size_t free_bytes;
 	size_t allocated_bytes;
+	size_t max_allocated_bytes;
 #endif
 	struct z_heap_bucket buckets[0];
 };


### PR DESCRIPTION
Besides the current allocated/free bytes, keep track of the maximum allocated bytes to help determine the heap size requirements. Also, provide a function to reset the statistic.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>