### PR TITLE
drivers: timer: stm32 LPTIM  input clock with a prescaler

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -435,6 +435,11 @@ static int sys_clock_driver_init(void)
 	/* ARROK bit validates the write operation to ARR register */
 	LL_LPTIM_EnableIT_ARROK(LPTIM);
 	stm32_lptim_wait_ready();
+#ifdef CONFIG_SOC_SERIES_STM32U5X
+	while (LL_LPTIM_IsActiveFlag_DIEROK(LPTIM) == 0) {
+	}
+	LL_LPTIM_ClearFlag_DIEROK(LPTIM);
+#endif
 	LL_LPTIM_ClearFlag_ARROK(LPTIM);
 
 	accumulated_lptim_cnt = 0;

--- a/dts/bindings/timer/st,stm32-lptim.yaml
+++ b/dts/bindings/timer/st,stm32-lptim.yaml
@@ -14,6 +14,32 @@ include:
       - st,countermode
 
 properties:
+  st,prescaler:
+    type: int
+    default: 1
+    description: |
+        Clock divider at the input of the lptimer clock, default reset value is 'not divided'.
+
+        Prescaler allows to achieve higher LPTIM timeout (up to 256s when lptim clocked by LSE)
+        and consequently higher core sleep durations, but impacts the tick precision.
+        To be used with caution.
+        CONFIG_SYS_CLOCK_TICKS_PER_SEC could be used to tune tick duration and gain precision,
+        at kernel timing granularity cost.
+
+        For example, when LPTIM is clocked by the LSE (32768Hz) and st,prescaler = <32>:
+        LPTIM global timeout is 64 seconds with an increment of 0.97 ms.
+        Using CONFIG_SYS_CLOCK_TICKS_PER_SEC = 4096, tick = 0.24 ms, LPTIM precision is 4 ticks.
+        Using CONFIG_SYS_CLOCK_TICKS_PER_SEC = 1024, tick = 0.97 ms, LPTIM precision is 1 ticks.
+    enum:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+      - 64
+      - 128
+
   st,static-prescaler:
     type: boolean
     description: |

--- a/samples/boards/stm32/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
+++ b/samples/boards/stm32/power_mgmt/blinky/boards/nucleo_wb55rg.overlay
@@ -1,0 +1,9 @@
+ /*
+  * give a prescaler to the lptim clock : LSE / 32 = 1024Hz
+  * so that the sleep period is of 64s in the sample application
+  *
+  */
+
+&lptim1 {
+	st,prescaler = <32>;
+};

--- a/tests/subsys/pm/power_mgmt_soc/boards/nucleo_l476rg.overlay
+++ b/tests/subsys/pm/power_mgmt_soc/boards/nucleo_l476rg.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&lptim1 {
+	status = "okay";
+};


### PR DESCRIPTION
This PR adds a prescaler to the LPTIM input clock to increase the max timeout (0xFFFF lptim counter unit).
With this prescaler, the mcu is able to sleep up to 256 sec w/o wakeup.

With the LSE clock as input (32768Hz),
prescaler = 1 (no division)   one lptim count is  of  0.03 ms and max timeout is 2 seconds
prescaler = 2  one lptim count is  of  0.06 ms and max timeout is 4 seconds
prescaler = 4   -->   one lptim count is  of  0.12 ms and max timeout is 8 seconds
prescaler = 8    -->  one lptim count is  of  0.24 ms and max timeout is 16 seconds
prescaler = 16  -->  one lptim count is  of  0.48 ms and max timeout is 32 seconds
prescaler = 32  -->   one lptim count is  of  0.97 ms and max timeout is 64 seconds
prescaler = 64  -->  one lptim count is  of  1.95 ms and max timeout is 128 seconds
prescaler = 128   one lptim count is  of  3.9 ms and max timeout is 256 seconds


Signed-off-by: Francois Ramu <francois.ramu@st.com>