### PR TITLE
mgmt/mcumgr: Fix possible buffer overflow in BT tranport

### DIFF
--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -231,8 +231,17 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 
 	nb = mcumgr_buf_alloc();
 	if (!nb) {
+		LOG_DBG("failed net_buf alloc for SMP packet");
 		return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
 	}
+
+	if (net_buf_tailroom(nb) < len) {
+		LOG_DBG("SMP packet len (%zu) > net_buf len (%zu)",
+			len, net_buf_tailroom(nb));
+		mcumgr_buf_free(nb);
+		return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);
+	}
+
 	net_buf_add_mem(nb, buf, len);
 
 	ud = net_buf_user_data(nb);


### PR DESCRIPTION
The commit add checks whether frame received from BT transport
will really fit into allocated net_buf form mcumgr.

Fixes: #44271

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>