### PR TITLE
Bluetooth: controller: LLCP PRT rewrite

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -1039,7 +1039,9 @@ uint8_t ll_adv_enable(uint8_t enable)
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_TX */
 		conn->connect_expire = 6;
 		conn->supervision_expire = 0;
+#if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 		conn->procedure_expire = 0;
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 		conn->apto_expire = 0U;

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -285,9 +285,11 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 	conn->supervision_reload = RADIO_CONN_EVENTS(timeout * 10000U,
 							 conn_interval_us);
 
+#if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 	conn->procedure_expire = 0U;
 	conn->procedure_reload = RADIO_CONN_EVENTS(40000000,
 						       conn_interval_us);
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	conn->apto_expire = 0U;
@@ -360,6 +362,9 @@ uint8_t ll_create_connection(uint16_t scan_interval, uint16_t scan_window,
 #else /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 	/* Re-initialize the control procedure data structures */
 	ull_llcp_init(conn);
+
+	/* Setup the PRT reload */
+	ull_cp_prt_reload_set(conn, conn_interval_us);
 
 	conn->central.terminate_ack = 0U;
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1594,6 +1594,7 @@ void ull_conn_done(struct node_rx_event_done *done)
 	}
 
 	/* check procedure timeout */
+#if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 	if (conn->procedure_expire != 0U) {
 		if (conn->procedure_expire > elapsed_event) {
 			conn->procedure_expire -= elapsed_event;
@@ -1603,6 +1604,13 @@ void ull_conn_done(struct node_rx_event_done *done)
 			return;
 		}
 	}
+#else /* CONFIG_BT_LL_SW_LLCP_LEGACY */
+	if (-ETIMEDOUT == ull_cp_prt_elapse(conn, elapsed_event)) {
+		conn_cleanup(conn, BT_HCI_ERR_LL_RESP_TIMEOUT);
+
+		return;
+	}
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	/* check apto */
@@ -7601,21 +7609,6 @@ void ull_conn_resume_rx_data(struct ll_conn *conn)
 }
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
-/**
- * @brief Restart procedure timeout 'timer'
- */
-void ull_conn_prt_reload(struct ll_conn *conn, uint16_t procedure_reload)
-{
-	conn->procedure_expire = procedure_reload;
-}
-
-/**
- * @brief Clear procedure timeout 'timer'
- */
-void ull_conn_prt_clear(struct ll_conn *conn)
-{
-	conn->procedure_expire = 0U;
-}
 uint16_t ull_conn_event_counter(struct ll_conn *conn)
 {
 	struct lll_conn *lll;
@@ -7656,12 +7649,6 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 
 	instant_latency = (event_counter - instant) & 0xFFFF;
 
-#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-	if (!is_cu_proc) {
-		/* Stop procedure timeout */
-		conn->procedure_expire = 0U;
-	}
-#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 
 	ticks_at_expire = conn->llcp.prep.ticks_at_expire;
 
@@ -7755,7 +7742,7 @@ void ull_conn_update_parameters(struct ll_conn *conn, uint8_t is_cu_proc, uint8_
 	lll->latency = latency;
 
 	conn->supervision_reload = RADIO_CONN_EVENTS((timeout * 10U * 1000U), conn_interval_us);
-	conn->procedure_reload = RADIO_CONN_EVENTS((40U * 1000U * 1000U), conn_interval_us);
+	ull_cp_prt_reload_set(conn, conn_interval_us);
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	/* APTO in no. of connection events */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -87,14 +87,4 @@ void ull_conn_pause_rx_data(struct ll_conn *conn);
  */
 void ull_conn_resume_rx_data(struct ll_conn *conn);
 
-/**
- * @brief Restart procedure timeout timer
- */
-void ull_conn_prt_reload(struct ll_conn *conn, uint16_t procedure_reload);
-
-/**
- * @brief Clear procedure timeout timer
- */
-void ull_conn_prt_clear(struct ll_conn *conn);
-
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -358,6 +358,8 @@ struct llcp_struct {
 	struct {
 		sys_slist_t pend_proc_list;
 		uint8_t state;
+		/* Procedure Response Timeout timer expire value */
+		uint16_t prt_expire;
 		uint8_t pause;
 	} local;
 
@@ -365,6 +367,8 @@ struct llcp_struct {
 	struct {
 		sys_slist_t pend_proc_list;
 		uint8_t state;
+		/* Procedure Response Timeout timer expire value */
+		uint16_t prt_expire;
 		uint8_t pause;
 		uint8_t collision;
 		uint8_t incompat;
@@ -373,6 +377,9 @@ struct llcp_struct {
 		uint8_t paused_cmd;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RSP || CONFIG_BT_CTLR_DF_CONN_CTE_REQ */
 	} remote;
+
+	/* Procedure Response Timeout timer reload value */
+	uint16_t prt_reload;
 
 	/* Prepare parameters */
 	struct {
@@ -526,8 +533,7 @@ struct ll_conn {
 	uint16_t connect_expire;
 	uint16_t supervision_reload;
 	uint16_t supervision_expire;
-	uint16_t procedure_reload;
-	uint16_t procedure_expire;
+
 
 #if defined(CONFIG_BT_CTLR_PHY)
 	uint8_t phy_pref_tx:3;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.h
@@ -36,6 +36,15 @@ void ull_cp_release_tx(struct ll_conn *conn, struct node_tx *tx);
 void ull_cp_release_ntf(struct node_rx_pdu *ntf);
 
 /**
+ * @brief Procedure Response Timeout Check
+ * @param elapsed_event The number of elapsed events.
+ * @return 0 on success, -ETIMEDOUT if timer expired.
+ */
+int ull_cp_prt_elapse(struct ll_conn *conn, uint16_t elapsed_event);
+
+void ull_cp_prt_reload_set(struct ll_conn *conn, uint32_t conn_intv);
+
+/**
  * @brief Run pending LL Control Procedures.
  */
 void ull_cp_run(struct ll_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -158,9 +158,8 @@ static void lp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
 
-	/* Update procedure timeout. For TERMINATE supervision_timeout is used */
-	ull_conn_prt_reload(conn, (ctx->proc != PROC_TERMINATE) ? conn->procedure_reload :
-									conn->supervision_reload);
+	/* Restart procedure response timeout timer */
+	llcp_lr_prt_restart(conn);
 }
 
 static void lp_comm_ntf_feature_exchange(struct ll_conn *conn, struct proc_ctx *ctx,
@@ -851,6 +850,9 @@ static void rp_comm_tx(struct ll_conn *conn, struct proc_ctx *ctx)
 
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
+
+	/* Restart procedure response timeout timer */
+	llcp_rr_prt_restart(conn);
 }
 
 static void rp_comm_st_idle(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -177,6 +177,13 @@ static void lp_cu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
+
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+	if (ctx->proc == PROC_CONN_PARAM_REQ) {
+		/* Restart procedure response timeout timer */
+		llcp_lr_prt_restart(conn);
+	}
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 }
 
 static void lp_cu_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
@@ -408,6 +415,14 @@ static void lp_cu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 		 * new connection event parameters have been applied.
 		 */
 		cu_update_conn_parameters(conn, ctx);
+
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+		if (ctx->proc == PROC_CONN_PARAM_REQ) {
+			/* Stop procedure response timeout timer */
+			llcp_lr_prt_stop(conn);
+		}
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
+
 		notify = cu_should_notify_host(ctx);
 		if (notify) {
 			llcp_rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
@@ -563,6 +578,13 @@ static void rp_cu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
+
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+	if (ctx->proc == PROC_CONN_PARAM_REQ) {
+		/* Restart procedure response timeout timer */
+		llcp_rr_prt_restart(conn);
+	}
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 }
 
 static void rp_cu_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
@@ -841,10 +863,6 @@ static void rp_cu_st_wait_rx_conn_update_ind(struct ll_conn *conn, struct proc_c
 		case BT_HCI_ROLE_PERIPHERAL:
 			llcp_pdu_decode_conn_update_ind(ctx, param);
 			/* TODO(tosk): skip/terminate if instant passed? */
-#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
-			/* conn param req procedure, if any, is complete */
-			ull_conn_prt_clear(conn);
-#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
 			ctx->state = RP_CU_STATE_WAIT_INSTANT;
 			break;
 		default:
@@ -869,6 +887,14 @@ static void rp_cu_check_instant(struct ll_conn *conn, struct proc_ctx *ctx, uint
 		 * new connection event parameters have been applied.
 		 */
 		cu_update_conn_parameters(conn, ctx);
+
+#if defined(CONFIG_BT_CTLR_CONN_PARAM_REQ)
+		if (ctx->proc == PROC_CONN_PARAM_REQ) {
+			/* Stop procedure response timeout timer */
+			llcp_rr_prt_stop(conn);
+		}
+#endif /* CONFIG_BT_CTLR_CONN_PARAM_REQ */
+
 		notify = cu_should_notify_host(ctx);
 		if (notify) {
 			ctx->data.cu.error = BT_HCI_ERR_SUCCESS;

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -175,8 +175,8 @@ static struct node_tx *llcp_lp_enc_tx(struct ll_conn *conn, struct proc_ctx *ctx
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
 
-	/* Update procedure timeout */
-	ull_conn_prt_reload(conn, conn->procedure_reload);
+	/* Restart procedure response timeout timer */
+	llcp_lr_prt_restart(conn);
 
 	return tx;
 }
@@ -666,6 +666,9 @@ static struct node_tx *llcp_rp_enc_tx(struct ll_conn *conn, struct proc_ctx *ctx
 
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
+
+	/* Restart procedure response timeout timer */
+	llcp_rr_prt_restart(conn);
 
 	return tx;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -352,6 +352,14 @@ void llcp_tx_resume_data(struct ll_conn *conn, enum llcp_tx_q_pause_data_mask re
 void llcp_tx_flush(struct ll_conn *conn);
 
 /*
+ * LLCP Procedure Response Timeout
+ */
+void llcp_lr_prt_restart(struct ll_conn *conn);
+void llcp_lr_prt_stop(struct ll_conn *conn);
+void llcp_rr_prt_restart(struct ll_conn *conn);
+void llcp_rr_prt_stop(struct ll_conn *conn);
+
+/*
  * LLCP Local Procedure Common
  */
 void llcp_lp_comm_tx_ack(struct ll_conn *conn, struct proc_ctx *ctx, struct node_tx *tx);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -342,8 +342,8 @@ static void lp_pu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
 
-	/* Update procedure timeout */
-	ull_conn_prt_reload(conn, conn->procedure_reload);
+	/* Restart procedure response timeout timer */
+	llcp_lr_prt_restart(conn);
 }
 
 static void pu_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
@@ -587,8 +587,10 @@ static void lp_pu_st_wait_tx_ack_phy_update_ind(struct ll_conn *conn, struct pro
 				pu_set_timing_restrict(conn, ctx->data.pu.c_to_p_phy);
 			}
 
-			/* Since at least one phy will change we clear procedure response timeout */
-			ull_conn_prt_clear(conn);
+			/* Since at least one phy will change,
+			 * stop the procedure response timeout
+			 */
+			llcp_lr_prt_stop(conn);
 
 			/* Now we should wait for instant */
 			ctx->state = LP_PU_STATE_WAIT_INSTANT;
@@ -623,8 +625,10 @@ static void lp_pu_st_wait_rx_phy_update_ind(struct ll_conn *conn, struct proc_ct
 				pu_set_timing_restrict(conn, ctx->data.pu.p_to_c_phy);
 			}
 
-			/* Since at least one phy will change we clear procedure response timeout */
-			ull_conn_prt_clear(conn);
+			/* Since at least one phy will change,
+			 * stop the procedure response timeout
+			 */
+			llcp_lr_prt_stop(conn);
 
 			ctx->state = LP_PU_STATE_WAIT_INSTANT;
 		} else {
@@ -805,6 +809,9 @@ static void rp_pu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 
 	/* Enqueue LL Control PDU towards LLL */
 	llcp_tx_enqueue(conn, tx);
+
+	/* Restart procedure response timeout timer */
+	llcp_rr_prt_restart(conn);
 }
 
 static void rp_pu_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
@@ -1010,8 +1017,10 @@ static void rp_pu_st_wait_rx_phy_update_ind(struct ll_conn *conn, struct proc_ct
 		const uint8_t end_procedure = pu_check_update_ind(conn, ctx);
 
 		if (!end_procedure) {
-			/* Since at least one phy will change we clear procedure response timeout */
-			ull_conn_prt_clear(conn);
+			/* Since at least one phy will change,
+			 * stop the procedure response timeout
+			 */
+			llcp_rr_prt_stop(conn);
 
 			ctx->state = LP_PU_STATE_WAIT_INSTANT;
 		} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -108,6 +108,7 @@ static void rr_check_done(struct ll_conn *conn, struct proc_ctx *ctx)
 		LL_ASSERT(ctx_header == ctx);
 
 		rr_dequeue(conn);
+
 		llcp_proc_ctx_release(ctx);
 	}
 }
@@ -192,6 +193,15 @@ void llcp_rr_resume(struct ll_conn *conn)
 	conn->llcp.remote.pause = 0U;
 }
 
+void llcp_rr_prt_restart(struct ll_conn *conn)
+{
+	conn->llcp.remote.prt_expire = conn->llcp.prt_reload;
+}
+
+void llcp_rr_prt_stop(struct ll_conn *conn)
+{
+	conn->llcp.remote.prt_expire = 0U;
+}
 
 void llcp_rr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
 {
@@ -416,10 +426,13 @@ static void rr_act_complete(struct ll_conn *conn)
 
 	rr_set_collision(conn, 0U);
 
-	/* Dequeue pending request that just completed */
 	ctx = llcp_rr_peek(conn);
 	LL_ASSERT(ctx != NULL);
 
+	/* Stop procedure response timeout timer */
+	llcp_rr_prt_stop(conn);
+
+	/* Mark the procedure as safe to delete */
 	ctx->done = 1U;
 }
 
@@ -633,6 +646,7 @@ static void rr_execute_fsm(struct ll_conn *conn, uint8_t evt, void *param)
 void llcp_rr_init(struct ll_conn *conn)
 {
 	rr_set_state(conn, RR_STATE_DISCONNECT);
+	conn->llcp.remote.prt_expire = 0U;
 }
 
 void llcp_rr_prepare(struct ll_conn *conn, struct node_rx_pdu *rx)
@@ -795,6 +809,7 @@ static void rr_abort(struct ll_conn *conn)
 		ctx = rr_dequeue(conn);
 	}
 
+	llcp_rr_prt_stop(conn);
 	rr_set_collision(conn, 0U);
 	rr_set_state(conn, RR_STATE_IDLE);
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -204,8 +204,14 @@ void ull_periph_setup(struct node_rx_hdr *rx, struct node_rx_ftr *ftr,
 	timeout = sys_le16_to_cpu(pdu_adv->connect_ind.timeout);
 	conn->supervision_reload =
 		RADIO_CONN_EVENTS((timeout * 10U * 1000U), conn_interval_us);
+
+#if defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
 	conn->procedure_reload =
 		RADIO_CONN_EVENTS((40 * 1000 * 1000), conn_interval_us);
+#else
+	/* Setup the PRT reload */
+	ull_cp_prt_reload_set(conn, conn_interval_us);
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_LE_PING)
 	/* APTO in no. of connection events */


### PR DESCRIPTION
Rewrite the entire Procedure Response Timeout mechanism.

Use two separate timers for local and remote initiated procedures.

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>