### PR TITLE
Bluetooth: Controller: LLCP: Fix handling of invalid DLE parameters

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -81,6 +81,11 @@
 #define PDU_DC_PAYLOAD_TIME_MIN 328
 #define PDU_DC_PAYLOAD_TIME_MIN_CODED 2704
 
+/* Data channel maximum payload size and time */
+#define PDU_DC_PAYLOAD_SIZE_MAX 251
+#define PDU_DC_PAYLOAD_TIME_MAX 2120
+#define PDU_DC_PAYLOAD_TIME_MAX_CODED 17040
+
 /* Link Layer header size of Data PDU. Assumes pdu_data is packed */
 #define PDU_DC_LL_HEADER_SIZE  (offsetof(struct pdu_data, lldata))
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -193,6 +193,12 @@ struct proc_ctx {
 		} pu;
 #endif /* CONFIG_BT_CTLR_PHY */
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+		struct {
+			uint8_t invalid:1;
+		} dle;
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+
 		/* TODO(tosk): leave out some params below if !CONFIG_BT_CTLR_CONN_PARAM_REQ */
 		/* Connection Update & Connection Parameter Request */
 		struct {
@@ -597,8 +603,8 @@ void llcp_rp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
  */
 void llcp_pdu_encode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
 void llcp_pdu_encode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
-void llcp_pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
-void llcp_pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
+bool llcp_pdu_decode_length_req(struct ll_conn *conn, struct pdu_data *pdu);
+bool llcp_pdu_decode_length_rsp(struct ll_conn *conn, struct pdu_data *pdu);
 void llcp_ntf_encode_length_change(struct ll_conn *conn,
 					struct pdu_data *pdu);
 


### PR DESCRIPTION
If peer is sending invalid DLE parameters in either request or response
just reject it instead of trying to fix those when calculating
effective parameters. This make it clear on what parameters are to be
used by both sides.

This was affecting following qualification test cases:
LL/CON/PER/BI-10-C
LL/CON/PER/BI-11-C
LL/CON/PER/BI-12-C
LL/CON/CEN/BI-07-C
LL/CON/CEN/BI-08-C
LL/CON/CEN/BI-09-C

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>