### PR TITLE
bluetooth: ots: remove bt_ots_obj_id_to_str

### DIFF
--- a/include/bluetooth/services/ots.h
+++ b/include/bluetooth/services/ots.h
@@ -1011,27 +1011,6 @@ typedef int (*bt_ots_client_dirlisting_cb)(struct bt_ots_obj_metadata *meta);
 int bt_ots_client_decode_dirlisting(uint8_t *data, uint16_t length,
 				    bt_ots_client_dirlisting_cb cb);
 
-/** @brief Converts binary OTS Object ID to string.
- *
- *  @param obj_id Object ID.
- *  @param str    Address of user buffer with enough room to store
- *                formatted string containing binary Object ID.
- *  @param len    Length of data to be copied to user string buffer.
- *                Refer to BT_OTS_OBJ_ID_STR_LEN about
- *                recommended value.
- *
- *  @return Number of successfully formatted bytes from binary ID.
- */
-static inline int bt_ots_obj_id_to_str(uint64_t obj_id, char *str, size_t len)
-{
-	uint8_t id[6];
-
-	sys_put_le48(obj_id, id);
-
-	return snprintk(str, len, "0x%02X%02X%02X%02X%02X%02X",
-			id[5], id[4], id[3], id[2], id[1], id[0]);
-}
-
 /** @brief Displays one or more object metadata as text with BT_INFO.
  *
  * @param metadata Pointer to the first (or only) metadata in an array.

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -69,20 +69,16 @@ static int ots_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id
 			   const struct bt_ots_obj_add_param *add_param,
 			   struct bt_ots_obj_created_desc *created_desc)
 {
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	uint64_t index;
-
-	bt_ots_obj_id_to_str(id, id_str, sizeof(id_str));
 
 	if (obj_cnt >= ARRAY_SIZE(objects)) {
 		printk("No item from Object pool is available for Object "
-		       "with %s ID\n", id_str);
+		       "with 0x%llx ID\n", id);
 		return -ENOMEM;
 	}
 
 	if (add_param->size > OBJ_MAX_SIZE) {
-		printk("Object pool item is too small for Object with %s ID\n",
-		       id_str);
+		printk("Object pool item is too small for Object with 0x%llx ID\n", id);
 		return -ENOMEM;
 	}
 
@@ -102,7 +98,7 @@ static int ots_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id
 		BT_OTS_OBJ_SET_PROP_DELETE(created_desc->props);
 	}
 
-	printk("Object with %s ID has been created\n", id_str);
+	printk("Object with 0x%llx ID has been created\n", id);
 	obj_cnt++;
 
 	return 0;
@@ -111,11 +107,7 @@ static int ots_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id
 static int ots_obj_deleted(struct bt_ots *ots, struct bt_conn *conn,
 			    uint64_t id)
 {
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
-
-	bt_ots_obj_id_to_str(id, id_str, sizeof(id_str));
-
-	printk("Object with %s ID has been deleted\n", id_str);
+	printk("Object with 0x%llx ID has been deleted\n", id);
 
 	obj_cnt--;
 
@@ -125,25 +117,17 @@ static int ots_obj_deleted(struct bt_ots *ots, struct bt_conn *conn,
 static void ots_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 			     uint64_t id)
 {
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
-
-	bt_ots_obj_id_to_str(id, id_str, sizeof(id_str));
-
-	printk("Object with %s ID has been selected\n", id_str);
+	printk("Object with 0x%llx ID has been selected\n", id);
 }
 
 static ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
 			   uint64_t id, void **data, size_t len,
 			   off_t offset)
 {
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	uint32_t obj_index = (id % ARRAY_SIZE(objects));
 
-	bt_ots_obj_id_to_str(id, id_str, sizeof(id_str));
-
 	if (!data) {
-		printk("Object with %s ID has been successfully read\n",
-		       id_str);
+		printk("Object with 0x%llx ID has been successfully read\n", id);
 
 		return 0;
 	}
@@ -157,9 +141,8 @@ static ssize_t ots_obj_read(struct bt_ots *ots, struct bt_conn *conn,
 		len = (len < 20) ? len : 20;
 	}
 
-	printk("Object with %s ID is being read\n"
-		"Offset = %lu, Length = %zu\n",
-		id_str, (long)offset, len);
+	printk("Object with 0x%llx ID is being read\n"
+		"Offset = %lu, Length = %zu\n", id, (long)offset, len);
 
 	return len;
 }
@@ -168,14 +151,11 @@ static ssize_t ots_obj_write(struct bt_ots *ots, struct bt_conn *conn,
 			     uint64_t id, const void *data, size_t len,
 			     off_t offset, size_t rem)
 {
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	uint32_t obj_index = (id % ARRAY_SIZE(objects));
 
-	bt_ots_obj_id_to_str(id, id_str, sizeof(id_str));
-
-	printk("Object with %s ID is being written\n"
+	printk("Object with 0x%llx ID is being written\n"
 		"Offset = %lu, Length = %zu, Remaining= %zu\n",
-		id_str, (long)offset, len, rem);
+		id, (long)offset, len, rem);
 
 	(void)memcpy(&objects[obj_index].data[offset], data, len);
 
@@ -184,11 +164,7 @@ static ssize_t ots_obj_write(struct bt_ots *ots, struct bt_conn *conn,
 
 void ots_obj_name_written(struct bt_ots *ots, struct bt_conn *conn, uint64_t id, const char *name)
 {
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
-
-	bt_ots_obj_id_to_str(id, id_str, sizeof(id_str));
-
-	printk("Name for object with %s ID has been written\n", id_str);
+	printk("Name for object with 0x%llx ID has been written\n", id);
 }
 
 static struct bt_ots_cb ots_callbacks = {

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -23,19 +23,6 @@
 #include <bluetooth/services/ots.h>
 #include "../services/ots/ots_client_internal.h"
 
-/* TODO: Temporarily copied here from media_proxy_internal.h - clean up */
-/* Debug output of 48 bit Object ID value */
-/* (Zephyr does not yet support debug output of more than 32 bit values.) */
-/* Takes a text and a 64-bit integer as input */
-#define BT_DBG_OBJ_ID(text, id64) \
-	do { \
-		if (IS_ENABLED(CONFIG_BT_DEBUG_MCS)) { \
-			char t[BT_OTS_OBJ_ID_STR_LEN]; \
-			(void)bt_ots_obj_id_to_str(id64, t, sizeof(t)); \
-			BT_DBG(text "0x%s", log_strdup(t)); \
-		} \
-	} while (0)
-
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_MCC)
 #define LOG_MODULE_NAME bt_mcc
@@ -231,7 +218,7 @@ static uint8_t mcc_read_icon_obj_id_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		BT_HEXDUMP_DBG(pid, length, "Icon Object ID");
 		id = sys_get_le48(pid);
-		BT_DBG_OBJ_ID("Icon Object ID: ", id);
+		BT_DBG("Icon Object ID: 0x%llx", id);
 	}
 
 	if (mcc_cb && mcc_cb->read_icon_obj_id) {
@@ -470,7 +457,7 @@ static uint8_t mcc_read_segments_obj_id_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		BT_HEXDUMP_DBG(pid, length, "Segments Object ID");
 		id = sys_get_le48(pid);
-		BT_DBG_OBJ_ID("Segments Object ID: ", id);
+		BT_DBG("Segments Object ID: 0x%llx", id);
 		cb_err = 0;
 	}
 
@@ -499,7 +486,7 @@ static uint8_t mcc_read_current_track_obj_id_cb(struct bt_conn *conn, uint8_t er
 	} else {
 		BT_HEXDUMP_DBG(pid, length, "Current Track Object ID");
 		id = sys_get_le48(pid);
-		BT_DBG_OBJ_ID("Current Track Object ID: ", id);
+		BT_DBG("Current Track Object ID: 0x%llx", id);
 		cb_err = 0;
 	}
 
@@ -524,7 +511,7 @@ static void mcs_write_current_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
 		obj_id = sys_get_le48((const uint8_t *)params->data);
-		BT_DBG_OBJ_ID("Object ID: ", obj_id);
+		BT_DBG("Object ID: 0x%llx", obj_id);
 	}
 
 	if (mcc_cb && mcc_cb->set_current_track_obj_id) {
@@ -551,7 +538,7 @@ static uint8_t mcc_read_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 	} else {
 		BT_HEXDUMP_DBG(pid, length, "Next Track Object ID");
 		id = sys_get_le48(pid);
-		BT_DBG_OBJ_ID("Next Track Object ID: ", id);
+		BT_DBG("Next Track Object ID: 0x%llx", id);
 	}
 
 	if (mcc_cb && mcc_cb->read_next_track_obj_id) {
@@ -575,7 +562,7 @@ static void mcs_write_next_track_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
 		obj_id = sys_get_le48((const uint8_t *)params->data);
-		BT_DBG_OBJ_ID("Object ID: ", obj_id);
+		BT_DBG("Object ID: 0x%llx", obj_id);
 	}
 
 	if (mcc_cb && mcc_cb->set_next_track_obj_id) {
@@ -600,7 +587,7 @@ static uint8_t mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, uint8_t err
 	} else {
 		BT_HEXDUMP_DBG(pid, length, "Parent Group Object ID");
 		id = sys_get_le48(pid);
-		BT_DBG_OBJ_ID("Parent Group Object ID: ", id);
+		BT_DBG("Parent Group Object ID: 0x%llx", id);
 	}
 
 	if (mcc_cb && mcc_cb->read_parent_group_obj_id) {
@@ -627,7 +614,7 @@ static uint8_t mcc_read_current_group_obj_id_cb(struct bt_conn *conn, uint8_t er
 	} else {
 		BT_HEXDUMP_DBG(pid, length, "Current Group Object ID");
 		id = sys_get_le48(pid);
-		BT_DBG_OBJ_ID("Current Group Object ID: ", id);
+		BT_DBG("Current Group Object ID: 0x%llx", id);
 	}
 
 	if (mcc_cb && mcc_cb->read_current_group_obj_id) {
@@ -651,7 +638,7 @@ static void mcs_write_current_group_obj_id_cb(struct bt_conn *conn, uint8_t err,
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
 		obj_id = sys_get_le48((const uint8_t *)params->data);
-		BT_DBG_OBJ_ID("Object ID: ", obj_id);
+		BT_DBG("Object ID: 0x%llx", obj_id);
 	}
 
 	if (mcc_cb && mcc_cb->set_current_group_obj_id) {
@@ -867,7 +854,7 @@ static uint8_t mcc_read_search_results_obj_id_cb(struct bt_conn *conn, uint8_t e
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
 		id = sys_get_le48(pid);
-		BT_DBG_OBJ_ID("Search Results Object ID: ", id);
+		BT_DBG("Search Results Object ID: 0x%llx", id);
 	}
 
 	if (mcc_cb && mcc_cb->read_search_results_obj_id) {
@@ -2565,12 +2552,8 @@ int on_parent_group_content(struct bt_ots_client *otc_inst,
 
 		decode_group(&otc_obj_buf, &group);
 		for (int i = 0; i < group.cnt; i++) {
-			char t[BT_OTS_OBJ_ID_STR_LEN];
-
-			(void)bt_ots_obj_id_to_str(group.ids[i].id, t,
-						   BT_OTS_OBJ_ID_STR_LEN);
-			BT_DBG("Object type: %d, object  ID: %s",
-			       group.ids[i].type, log_strdup(t));
+			BT_DBG("Object type: %d, object  ID: 0x%llx",
+			       group.ids[i].type, group.ids[i].id);
 		}
 #endif /* CONFIG_BT_DEBUG_MCC */
 
@@ -2611,12 +2594,8 @@ int on_current_group_content(struct bt_ots_client *otc_inst,
 
 		decode_group(&otc_obj_buf, &group);
 		for (int i = 0; i < group.cnt; i++) {
-			char t[BT_OTS_OBJ_ID_STR_LEN];
-
-			(void)bt_ots_obj_id_to_str(group.ids[i].id, t,
-						   BT_OTS_OBJ_ID_STR_LEN);
-			BT_DBG("Object type: %d, object  ID: %s",
-			       group.ids[i].type, log_strdup(t));
+			BT_DBG("Object type: %d, object  ID: 0x%llx",
+			       group.ids[i].type, group.ids[i].id);
 		}
 #endif /* CONFIG_BT_DEBUG_MCC */
 

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -69,7 +69,7 @@ static ssize_t read_icon_id(struct bt_conn *conn,
 {
 	uint64_t icon_id = media_proxy_sctrl_get_icon_id();
 
-	BT_DBG_OBJ_ID("Icon object read: ", icon_id);
+	BT_DBG("Icon object read: 0x%llx", icon_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &icon_id,
 				 BT_OTS_OBJ_ID_SIZE);
 }
@@ -237,7 +237,7 @@ static ssize_t read_track_segments_id(struct bt_conn *conn,
 {
 	uint64_t track_segments_id = media_proxy_sctrl_get_track_segments_id();
 
-	BT_DBG_OBJ_ID("Track segments ID read: ", track_segments_id);
+	BT_DBG("Track segments ID read: 0x%llx", track_segments_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
 				 &track_segments_id, BT_OTS_OBJ_ID_SIZE);
 }
@@ -248,7 +248,7 @@ static ssize_t read_current_track_id(struct bt_conn *conn,
 {
 	uint64_t track_id = media_proxy_sctrl_get_current_track_id();
 
-	BT_DBG_OBJ_ID("Current track ID read: ", track_id);
+	BT_DBG("Current track ID read: 0x%llx", track_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &track_id,
 				 BT_OTS_OBJ_ID_SIZE);
 }
@@ -273,10 +273,8 @@ static ssize_t write_current_track_id(struct bt_conn *conn,
 	id = sys_get_le48((uint8_t *)buf);
 
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MCS)) {
-		char str[BT_OTS_OBJ_ID_STR_LEN];
-		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		BT_DBG("Current track write: offset: %d, len: %d, track ID: %s",
-		       offset, len, log_strdup(str));
+		BT_DBG("Current track write: offset: %d, len: %d, track ID: 0x%llx",
+		       offset, len, id);
 	}
 
 	media_proxy_sctrl_set_current_track_id(id);
@@ -303,7 +301,7 @@ static ssize_t read_next_track_id(struct bt_conn *conn,
 		return bt_gatt_attr_read(conn, attr, buf, len, offset, NULL, 0);
 	}
 
-	BT_DBG_OBJ_ID("Next track read: ", track_id);
+	BT_DBG("Next track read: 0x%llx", track_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
 				 &track_id, BT_OTS_OBJ_ID_SIZE);
 }
@@ -328,10 +326,8 @@ static ssize_t write_next_track_id(struct bt_conn *conn,
 	id = sys_get_le48((uint8_t *)buf);
 
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MCS)) {
-		char str[BT_OTS_OBJ_ID_STR_LEN];
-		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		BT_DBG("Next  track write: offset: %d, len: %d, track ID: %s",
-		       offset, len, log_strdup(str));
+		BT_DBG("Next  track write: offset: %d, len: %d, track ID: 0x%llx",
+		       offset, len, id);
 	}
 
 	media_proxy_sctrl_set_next_track_id(id);
@@ -351,7 +347,7 @@ static ssize_t read_parent_group_id(struct bt_conn *conn,
 {
 	uint64_t group_id = media_proxy_sctrl_get_parent_group_id();
 
-	BT_DBG_OBJ_ID("Parent group read: ", group_id);
+	BT_DBG("Parent group read: 0x%llx", group_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &group_id,
 				 BT_OTS_OBJ_ID_SIZE);
 }
@@ -368,7 +364,7 @@ static ssize_t read_current_group_id(struct bt_conn *conn,
 {
 	uint64_t group_id = media_proxy_sctrl_get_current_group_id();
 
-	BT_DBG_OBJ_ID("Current group read: ", group_id);
+	BT_DBG("Current group read: 0x%llx", group_id);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &group_id,
 				 BT_OTS_OBJ_ID_SIZE);
 }
@@ -393,10 +389,8 @@ static ssize_t write_current_group_id(struct bt_conn *conn,
 	id = sys_get_le48((uint8_t *)buf);
 
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MCS)) {
-		char str[BT_OTS_OBJ_ID_STR_LEN];
-		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		BT_DBG("Current group ID write: offset: %d, len: %d, track ID: %s",
-		       offset, len, log_strdup(str));
+		BT_DBG("Current group ID write: offset: %d, len: %d, track ID: 0x%llx",
+		       offset, len, id);
 	}
 
 	media_proxy_sctrl_set_current_group_id(id);
@@ -578,7 +572,7 @@ static ssize_t read_search_results_id(struct bt_conn *conn,
 {
 	uint64_t search_id = media_proxy_sctrl_get_search_results_id();
 
-	BT_DBG_OBJ_ID("Search results id read: ", search_id);
+	BT_DBG("Search results id read: 0x%llx", search_id);
 
 	/* TODO: The permanent solution here should be that the call to */
 	/* mpl should fill the UUID in a pointed-to value, and return a */
@@ -878,7 +872,7 @@ void media_proxy_sctrl_seeking_speed_cb(int8_t speed)
 
 void media_proxy_sctrl_current_track_id_cb(uint64_t id)
 {
-	BT_DBG_OBJ_ID("Notifying current track ID: ", id);
+	BT_DBG("Notifying current track ID: 0x%llx", id);
 	notify(BT_UUID_MCS_CURRENT_TRACK_OBJ_ID, &id, BT_OTS_OBJ_ID_SIZE);
 }
 
@@ -887,23 +881,23 @@ void media_proxy_sctrl_next_track_id_cb(uint64_t id)
 	if (id == MPL_NO_TRACK_ID) {
 		/* "If the media player has no next track, the length of the */
 		/* characteristic shall be zero." */
-		BT_DBG_OBJ_ID("Notifying EMPTY next track ID: ", id);
+		BT_DBG("Notifying EMPTY next track ID: 0x%llx", id);
 		notify(BT_UUID_MCS_NEXT_TRACK_OBJ_ID, NULL, 0);
 	} else {
-		BT_DBG_OBJ_ID("Notifying next track ID: ", id);
+		BT_DBG("Notifying next track ID: 0x%llx", id);
 		notify(BT_UUID_MCS_NEXT_TRACK_OBJ_ID, &id, BT_OTS_OBJ_ID_SIZE);
 	}
 }
 
 void media_proxy_sctrl_parent_group_id_cb(uint64_t id)
 {
-	BT_DBG_OBJ_ID("Notifying parent group ID: ", id);
+	BT_DBG("Notifying parent group ID: 0x%llx", id);
 	notify(BT_UUID_MCS_PARENT_GROUP_OBJ_ID, &id, BT_OTS_OBJ_ID_SIZE);
 }
 
 void media_proxy_sctrl_current_group_id_cb(uint64_t id)
 {
-	BT_DBG_OBJ_ID("Notifying current group ID: ", id);
+	BT_DBG("Notifying current group ID: 0x%llx", id);
 	notify(BT_UUID_MCS_CURRENT_GROUP_OBJ_ID, &id, BT_OTS_OBJ_ID_SIZE);
 }
 
@@ -943,7 +937,7 @@ void media_proxy_sctrl_search_cb(uint8_t result_code)
 
 void media_proxy_sctrl_search_results_id_cb(uint64_t id)
 {
-	BT_DBG_OBJ_ID("Notifying search results ID: ", id);
+	BT_DBG("Notifying search results ID: 0x%llx", id);
 	notify(BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID, &id, BT_OTS_OBJ_ID_SIZE);
 }
 

--- a/subsys/bluetooth/audio/media_proxy_internal.h
+++ b/subsys/bluetooth/audio/media_proxy_internal.h
@@ -13,19 +13,6 @@
 
 #define MPL_NO_TRACK_ID 0
 
-/* Debug output of 48 bit Object ID value */
-/* (Zephyr does not yet support debug output of more than 32 bit values.) */
-/* Takes a text and a 64-bit integer as input */
-#define BT_DBG_OBJ_ID(text, id64) \
-	do { \
-		if (IS_ENABLED(CONFIG_BT_DEBUG_MCS)) { \
-			char t[BT_OTS_OBJ_ID_STR_LEN]; \
-			(void)bt_ots_obj_id_to_str(id64, t, sizeof(t)); \
-			BT_DBG(text "0x%s", log_strdup(t)); \
-		} \
-	} while (0)
-
-
 /* SYNCHRONOUS (CALL/RETURN) API FOR CONTROLLERS */
 
 /** @brief Callbacks to a controller, from the media proxy */

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -691,7 +691,7 @@ static int add_group_and_track_objects(struct mpl_mediaplayer *pl)
 static int on_obj_deleted(struct bt_ots *ots, struct bt_conn *conn,
 			   uint64_t id)
 {
-	BT_DBG_OBJ_ID("Object Id deleted: ", id);
+	BT_DBG("Object Id deleted: 0x%llx", id);
 
 	return 0;
 }
@@ -707,7 +707,7 @@ static void on_obj_selected(struct bt_ots *ots, struct bt_conn *conn,
 	}
 	obj.busy = true;
 
-	BT_DBG_OBJ_ID("Object Id selected: ", id);
+	BT_DBG("Object Id selected: 0x%llx", id);
 
 	if (id == pl.icon_id) {
 		BT_DBG("Icon Object ID");
@@ -746,7 +746,7 @@ static int on_obj_created(struct bt_ots *ots, struct bt_conn *conn, uint64_t id,
 			  const struct bt_ots_obj_add_param *add_param,
 			  struct bt_ots_obj_created_desc *created_desc)
 {
-	BT_DBG_OBJ_ID("Object Id created: ", id);
+	BT_DBG("Object Id created: 0x%llx", id);
 
 	*created_desc = *obj.desc;
 
@@ -820,9 +820,7 @@ static ssize_t on_object_send(struct bt_ots *ots, struct bt_conn *conn,
 	obj.busy = true;
 
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MPL)) {
-		char t[BT_OTS_OBJ_ID_STR_LEN];
-		(void)bt_ots_obj_id_to_str(id, t, sizeof(t));
-		BT_DBG("Object Id %s, offset %lu, length %zu", log_strdup(t),
+		BT_DBG("Object Id 0x%llx, offset %lu, length %zu", id,
 		       (long)offset, len);
 	}
 
@@ -967,7 +965,7 @@ static bool do_prev_track(struct mpl_mediaplayer *pl)
 	bool track_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID before: ", pl->group->track->id);
+	BT_DBG("Track ID before: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->track->prev != NULL) {
@@ -976,7 +974,7 @@ static bool do_prev_track(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID after: ", pl->group->track->id);
+	BT_DBG("Track ID after: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return track_changed;
@@ -988,7 +986,7 @@ static bool do_next_track_normal_order(struct mpl_mediaplayer *pl)
 	bool track_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID before: ", pl->group->track->id);
+	BT_DBG("Track ID before: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->track->next != NULL) {
@@ -997,7 +995,7 @@ static bool do_next_track_normal_order(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID after: ", pl->group->track->id);
+	BT_DBG("Track ID after: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return track_changed;
@@ -1033,7 +1031,7 @@ static bool do_first_track(struct mpl_mediaplayer *pl)
 	bool track_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID before: ", pl->group->track->id);
+	BT_DBG("Track ID before: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->track->prev != NULL) {
@@ -1045,7 +1043,7 @@ static bool do_first_track(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID after: ", pl->group->track->id);
+	BT_DBG("Track ID after: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return track_changed;
@@ -1056,7 +1054,7 @@ static bool do_last_track(struct mpl_mediaplayer *pl)
 	bool track_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID before: ", pl->group->track->id);
+	BT_DBG("Track ID before: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->track->next != NULL) {
@@ -1068,7 +1066,7 @@ static bool do_last_track(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID after: ", pl->group->track->id);
+	BT_DBG("Track ID after: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return track_changed;
@@ -1080,7 +1078,7 @@ static bool do_goto_track(struct mpl_mediaplayer *pl, int32_t tracknum)
 	int32_t k;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID before: ", pl->group->track->id);
+	BT_DBG("Track ID before: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (tracknum > 0) {
@@ -1114,7 +1112,7 @@ static bool do_goto_track(struct mpl_mediaplayer *pl, int32_t tracknum)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Track ID after: ", pl->group->track->id);
+	BT_DBG("Track ID after: 0x%llx", pl->group->track->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	/* The track has changed if we have moved more in one direction */
@@ -1128,7 +1126,7 @@ static bool do_prev_group(struct mpl_mediaplayer *pl)
 	bool group_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID before: ", pl->group->id);
+	BT_DBG("Group ID before: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->prev != NULL) {
@@ -1137,7 +1135,7 @@ static bool do_prev_group(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID after: ", pl->group->id);
+	BT_DBG("Group ID after: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return group_changed;
@@ -1148,7 +1146,7 @@ static bool do_next_group(struct mpl_mediaplayer *pl)
 	bool group_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID before: ", pl->group->id);
+	BT_DBG("Group ID before: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->next != NULL) {
@@ -1157,7 +1155,7 @@ static bool do_next_group(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID after: ", pl->group->id);
+	BT_DBG("Group ID after: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return group_changed;
@@ -1168,7 +1166,7 @@ static bool do_first_group(struct mpl_mediaplayer *pl)
 	bool group_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID before: ", pl->group->id);
+	BT_DBG("Group ID before: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->prev != NULL) {
@@ -1180,7 +1178,7 @@ static bool do_first_group(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID after: ", pl->group->id);
+	BT_DBG("Group ID after: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return group_changed;
@@ -1191,7 +1189,7 @@ static bool do_last_group(struct mpl_mediaplayer *pl)
 	bool group_changed = false;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID before: ", pl->group->id);
+	BT_DBG("Group ID before: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (pl->group->next != NULL) {
@@ -1203,7 +1201,7 @@ static bool do_last_group(struct mpl_mediaplayer *pl)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID after: ", pl->group->id);
+	BT_DBG("Group ID after: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	return group_changed;
@@ -1215,7 +1213,7 @@ static bool  do_goto_group(struct mpl_mediaplayer *pl, int32_t groupnum)
 	int32_t k;
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID before: ", pl->group->id);
+	BT_DBG("Group ID before: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	if (groupnum > 0) {
@@ -1249,7 +1247,7 @@ static bool  do_goto_group(struct mpl_mediaplayer *pl, int32_t groupnum)
 	}
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-	BT_DBG_OBJ_ID("Group ID after: ", pl->group->id);
+	BT_DBG("Group ID after: 0x%llx", pl->group->id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	/* The group has changed if we have moved more in one direction */
@@ -2459,7 +2457,7 @@ void set_current_track_id(uint64_t id)
 	struct mpl_group *group;
 	struct mpl_track *track;
 
-	BT_DBG_OBJ_ID("Track ID to set: ", id);
+	BT_DBG("Track ID to set: 0x%llx", id);
 
 	if (find_track_by_id(&pl, id, &group, &track)) {
 
@@ -2506,7 +2504,7 @@ void set_next_track_id(uint64_t id)
 	struct mpl_group *group;
 	struct mpl_track *track;
 
-	BT_DBG_OBJ_ID("Next Track ID to set: ", id);
+	BT_DBG("Next Track ID to set: 0x%llx", id);
 
 	if (find_track_by_id(&pl, id, &group, &track)) {
 
@@ -2535,7 +2533,7 @@ void set_current_group_id(uint64_t id)
 	struct mpl_group *group;
 	bool track_change;
 
-	BT_DBG_OBJ_ID("Group ID to set: ", id);
+	BT_DBG("Group ID to set: 0x%llx", id);
 
 	if (find_group_by_id(&pl, id, &group)) {
 
@@ -2792,7 +2790,6 @@ int media_proxy_pl_init(void)
 void mpl_debug_dump_state(void)
 {
 #if CONFIG_BT_MPL_OBJECTS
-	char t[BT_OTS_OBJ_ID_STR_LEN];
 	struct mpl_group *group;
 	struct mpl_track *track;
 #endif /* CONFIG_BT_MPL_OBJECTS */
@@ -2800,8 +2797,7 @@ void mpl_debug_dump_state(void)
 	BT_DBG("Mediaplayer name: %s", log_strdup(pl.name));
 
 #if CONFIG_BT_MPL_OBJECTS
-	(void)bt_ots_obj_id_to_str(pl.icon_id, t, sizeof(t));
-	BT_DBG("Icon ID: %s", log_strdup(t));
+	BT_DBG("Icon ID: 0x%llx", pl.icon_id);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
 	BT_DBG("Icon URL: %s", log_strdup(pl.icon_url));
@@ -2815,29 +2811,21 @@ void mpl_debug_dump_state(void)
 	BT_DBG("Content control ID: %d", pl.content_ctrl_id);
 
 #if CONFIG_BT_MPL_OBJECTS
-	(void)bt_ots_obj_id_to_str(pl.group->parent->id, t, sizeof(t));
-	BT_DBG("Current group's parent: %s", log_strdup(t));
+	BT_DBG("Current group's parent: 0x%llx", pl.group->parent->id);
+	BT_DBG("Current group: 0x%llx", pl.group->id);
 
-	(void)bt_ots_obj_id_to_str(pl.group->id, t, sizeof(t));
-	BT_DBG("Current group: %s", log_strdup(t));
-
-	(void)bt_ots_obj_id_to_str(pl.group->track->id, t, sizeof(t));
-	BT_DBG("Current track: %s", log_strdup(t));
+	BT_DBG("Current track: 0x%llx", pl.group->track->id);
 
 	if (pl.next_track_set) {
-		(void)bt_ots_obj_id_to_str(pl.next.track->id, t, sizeof(t));
-		BT_DBG("Next track: %s", log_strdup(t));
+		BT_DBG("Next track: 0x%llx", pl.next.track->id);
 	} else if (pl.group->track->next) {
-		(void)bt_ots_obj_id_to_str(pl.group->track->next->id, t,
-					   sizeof(t));
-		BT_DBG("Next track: %s", log_strdup(t));
+		BT_DBG("Next track: 0x%llx", pl.group->track->next->id);
 	} else {
 		BT_DBG("No next track");
 	}
 
 	if (pl.search_results_id) {
-		(void)bt_ots_obj_id_to_str(pl.search_results_id, t, sizeof(t));
-		BT_DBG("Search results: %s", log_strdup(t));
+		BT_DBG("Search results: 0x%llx", pl.search_results_id);
 	} else {
 		BT_DBG("No search results");
 	}
@@ -2850,12 +2838,10 @@ void mpl_debug_dump_state(void)
 	}
 
 	while (group) {
-		(void)bt_ots_obj_id_to_str(group->id, t, sizeof(t));
-		BT_DBG("Group: %s, %s", log_strdup(t),
+		BT_DBG("Group: 0x%llx, %s", group->id,
 		       log_strdup(group->title));
 
-		(void)bt_ots_obj_id_to_str(group->parent->id, t, sizeof(t));
-		BT_DBG("\tParent: %s, %s", log_strdup(t),
+		BT_DBG("\tParent: 0x%llx, %s", group->parent->id,
 		       log_strdup(group->parent->title));
 
 		track = group->track;
@@ -2864,8 +2850,7 @@ void mpl_debug_dump_state(void)
 		}
 
 		while (track) {
-			(void)bt_ots_obj_id_to_str(track->id, t, sizeof(t));
-			BT_DBG("\tTrack: %s, %s, duration: %d", log_strdup(t),
+			BT_DBG("\tTrack: 0x%llx, %s, duration: %d", track->id,
 			       log_strdup(track->title), track->duration);
 			track = track->next;
 		}

--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -798,21 +798,16 @@ static uint8_t read_obj_id_cb(struct bt_conn *conn, uint8_t err,
 	} else if (data) {
 		if (length == BT_OTS_OBJ_ID_SIZE) {
 			uint64_t obj_id = net_buf_simple_pull_le48(&net_buf);
-			char t[BT_OTS_OBJ_ID_STR_LEN];
 			struct bt_ots_obj_metadata *cur_object =
 				&inst->otc_inst->cur_object;
 
-			(void)bt_ots_obj_id_to_str(obj_id, t, sizeof(t));
-			BT_DBG("Object Id : %s", log_strdup(t));
+			BT_DBG("Object Id : 0x%llx", obj_id);
 
 			if (cur_object->id != OTS_CLIENT_UNKNOWN_ID &&
 			    cur_object->id != obj_id) {
-				char str[BT_OTS_OBJ_ID_STR_LEN];
 
-				(void)bt_ots_obj_id_to_str(cur_object->id, str,
-							   sizeof(str));
-				BT_INFO("Read Obj Id %s not selected obj Id %s",
-					log_strdup(t), log_strdup(str));
+				BT_INFO("Read Obj Id 0x%llx not selected obj Id 0x%llx",
+					obj_id, cur_object->id);
 			} else {
 				BT_INFO("Read Obj Id confirmed correct Obj Id");
 				cur_object->id = obj_id;
@@ -1294,10 +1289,7 @@ static int decode_record(struct net_buf_simple *buf,
 	rec->metadata.id = net_buf_simple_pull_le48(buf);
 
 	if (IS_ENABLED(CONFIG_BT_DEBUG_OTS_CLIENT)) {
-		char t[BT_OTS_OBJ_ID_STR_LEN];
-
-		(void)bt_ots_obj_id_to_str(rec->metadata.id, t, sizeof(t));
-		BT_DBG("Object ID 0x%s", log_strdup(t));
+		BT_DBG("Object ID 0x%llx", rec->metadata.id);
 	}
 
 	if ((start_len - buf->len) + sizeof(uint8_t) > rec->len) {
@@ -1480,10 +1472,7 @@ void bt_ots_metadata_display(struct bt_ots_obj_metadata *metadata,
 	BT_INFO("--- Displaying %u metadata records ---", count);
 
 	for (int i = 0; i < count; i++) {
-		char t[BT_OTS_OBJ_ID_STR_LEN];
-
-		(void)bt_ots_obj_id_to_str(metadata->id, t, sizeof(t));
-		BT_INFO("Object ID: 0x%s", log_strdup(t));
+		BT_INFO("Object ID: 0x%llx", metadata->id);
 		BT_INFO("Object name: %s", log_strdup(metadata->name_c));
 		BT_INFO("Object Current Size: %u", metadata->size.cur);
 		BT_INFO("Object Allocate Size: %u", metadata->size.alloc);

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -133,13 +133,11 @@ static int bt_ots_dir_list_search_forward(struct bt_ots_dir_list *dir_list, void
 					  off_t offset)
 {
 	int err;
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	struct bt_gatt_ots_object *obj = dir_list->anchor_object;
 	size_t rec_len = dir_list_object_record_size(obj);
 
-	bt_ots_obj_id_to_str(obj->id, id_str, sizeof(id_str));
-	LOG_DBG("Searching forward for offset %ld starting at %ld with object ID %s",
-		(long)offset, (long)dir_list->anchor_offset, log_strdup(id_str));
+	LOG_DBG("Searching forward for offset %ld starting at %ld with object ID 0x%llx",
+		(long)offset, (long)dir_list->anchor_offset, obj->id);
 
 	while (dir_list->anchor_offset + rec_len <= offset) {
 
@@ -161,12 +159,10 @@ static int bt_ots_dir_list_search_backward(struct bt_ots_dir_list *dir_list, voi
 					   off_t offset)
 {
 	int err;
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 	struct bt_gatt_ots_object *obj = dir_list->anchor_object;
 
-	bt_ots_obj_id_to_str(obj->id, id_str, sizeof(id_str));
-	LOG_DBG("Searching backward for offset %ld starting at %ld with object ID %s",
-		(long)offset, (long)dir_list->anchor_offset, log_strdup(id_str));
+	LOG_DBG("Searching backward for offset %ld starting at %ld with object ID 0x%llx",
+		(long)offset, (long)dir_list->anchor_offset, obj->id);
 
 	while (dir_list->anchor_offset > offset) {
 
@@ -185,7 +181,6 @@ static int bt_ots_dir_list_search_backward(struct bt_ots_dir_list *dir_list, voi
 static int bt_ots_dir_list_search(struct bt_ots_dir_list *dir_list, void *obj_manager, off_t offset)
 {
 	int err = 0;
-	char id_str[BT_OTS_OBJ_ID_STR_LEN];
 
 	/* decide start location and direction of movement based on offset, we can only choose
 	 * current anchor point, beginning, or end as those are the only places where we know
@@ -224,9 +219,8 @@ static int bt_ots_dir_list_search(struct bt_ots_dir_list *dir_list, void *obj_ma
 		return err;
 	}
 
-	bt_ots_obj_id_to_str(dir_list->anchor_object->id, id_str, sizeof(id_str));
-	LOG_DBG("Found offset %ld starting at %ld in object with ID %s",
-		(long)offset, (long)dir_list->anchor_offset, log_strdup(id_str));
+	LOG_DBG("Found offset %ld starting at %ld in object with ID 0x%llx",
+		(long)offset, (long)dir_list->anchor_offset, dir_list->anchor_object->id);
 
 	return 0;
 }

--- a/subsys/bluetooth/services/ots/ots_olcp.c
+++ b/subsys/bluetooth/services/ots/ots_olcp.c
@@ -257,12 +257,8 @@ ssize_t bt_gatt_ots_olcp_write(struct bt_conn *conn,
 		if (olcp_status != BT_GATT_OTS_OLCP_RES_SUCCESS) {
 			LOG_WRN("OLCP Write error status: 0x%02X", olcp_status);
 		} else if (old_obj != ots->cur_obj) {
-			char id[BT_OTS_OBJ_ID_STR_LEN];
-
-			bt_ots_obj_id_to_str(ots->cur_obj->id, id,
-						sizeof(id));
-			LOG_DBG("Selecting a new Current Object with id: %s",
-				log_strdup(id));
+			LOG_DBG("Selecting a new Current Object with id: 0x%llx",
+				ots->cur_obj->id);
 
 			if (IS_ENABLED(CONFIG_BT_OTS_DIR_LIST_OBJ)) {
 				bt_ots_dir_list_selected(ots->dir_list, ots->obj_manager,

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -64,15 +64,12 @@ static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *n
 #ifdef CONFIG_BT_MCC_OTS
 static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Icon Object ID read failed (%d)", err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Icon object ID: %s", str);
+	shell_print(ctx_shell, "Icon object ID: 0x%llx", id);
 
 	obj_ids.icon_obj_id = id;
 }
@@ -175,16 +172,13 @@ static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 					uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell,
 			    "Track Segments Object ID read failed (%d)", err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Track Segments Object ID: %s", str);
+	shell_print(ctx_shell, "Track Segments Object ID: 0x%llx", id);
 
 	obj_ids.track_segments_obj_id = id;
 }
@@ -193,16 +187,13 @@ static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Current Track Object ID read failed (%d)",
 			    err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Track Object ID: %s", str);
+	shell_print(ctx_shell, "Current Track Object ID: 0x%llx", id);
 
 	obj_ids.current_track_obj_id = id;
 }
@@ -211,22 +202,18 @@ static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Current Track Object ID set failed (%d)", err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Track Object ID written: %s", str);
+	shell_print(ctx_shell, "Current Track Object ID written: 0x%llx", id);
 }
 
 
 static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					  uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
 		shell_error(ctx_shell, "Next Track Object ID read failed (%d)",
@@ -237,8 +224,7 @@ static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 	if (id == MPL_NO_TRACK_ID) {
 		shell_print(ctx_shell, "Next Track Object ID is empty");
 	} else {
-		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Next Track Object ID: %s", str);
+		shell_print(ctx_shell, "Next Track Object ID: 0x%llx", id);
 	}
 
 	obj_ids.next_track_obj_id = id;
@@ -248,22 +234,18 @@ static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Next Track Object ID set failed (%d)", err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Next Track Object ID written: %s", str);
+	shell_print(ctx_shell, "Next Track Object ID written: 0x%llx", id);
 }
 
 
 static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
 		shell_error(ctx_shell,
@@ -271,8 +253,7 @@ static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Parent Group Object ID: %s", str);
+	shell_print(ctx_shell, "Parent Group Object ID: 0x%llx", id);
 
 	obj_ids.parent_group_obj_id = id;
 }
@@ -281,7 +262,6 @@ static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					     uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
 		shell_error(ctx_shell,
@@ -289,8 +269,7 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Group Object ID: %s", str);
+	shell_print(ctx_shell, "Current Group Object ID: 0x%llx", id);
 
 	obj_ids.current_group_obj_id = id;
 }
@@ -298,15 +277,12 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 					    uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Current Group Object ID set failed (%d)", err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Group Object ID written: %s", str);
+	shell_print(ctx_shell, "Current Group Object ID written: 0x%llx", id);
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
@@ -420,8 +396,6 @@ static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code
 static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 					      uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell,
 			    "Search Results Object ID read failed (%d)", err);
@@ -431,8 +405,7 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 	if (id == 0) {
 		shell_print(ctx_shell, "Search Results Object ID: 0x000000000000");
 	} else {
-		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Search Results Object ID: %s", str);
+		shell_print(ctx_shell, "Search Results Object ID: 0x%llx", id);
 	}
 
 	obj_ids.search_results_obj_id = id;

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -78,15 +78,12 @@ static void player_name_cb(struct media_player *plr, int err, const char *name)
 
 static void icon_id_cb(struct media_player *plr, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Icon ID failed (%d)", plr, err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Icon Object ID: %s", plr, str);
+	shell_print(ctx_shell, "Player: %p, Icon Object ID: 0x%llx", plr, id);
 }
 
 static void icon_url_cb(struct media_player *plr, int err, const char *url)
@@ -182,34 +179,26 @@ static void seeking_speed_cb(struct media_player *plr, int err, int8_t speed)
 #ifdef CONFIG_BT_OTS
 static void track_segments_id_cb(struct media_player *plr, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Track segments ID failed (%d)", plr, err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Track Segments Object ID: %s", plr, str);
+	shell_print(ctx_shell, "Player: %p, Track Segments Object ID: 0x%llx", plr, id);
 }
 
 static void current_track_id_cb(struct media_player *plr, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Current track ID failed (%d)", plr, err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Current Track Object ID: %s", plr, str);
+	shell_print(ctx_shell, "Player: %p, Current Track Object ID: 0x%llx", plr, id);
 }
 
 static void next_track_id_cb(struct media_player *plr, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Next track ID failed (%d)", plr, err);
 		return;
@@ -218,35 +207,28 @@ static void next_track_id_cb(struct media_player *plr, int err, uint64_t id)
 	if (id == MPL_NO_TRACK_ID) {
 		shell_print(ctx_shell, "Player: %p, Next Track Object ID is empty", plr);
 	} else {
-		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Player: %p, Next Track Object ID: %s", plr, str);
+		shell_print(ctx_shell, "Player: %p, Next Track Object ID: 0x%llx", plr, id);
 	}
 }
 
 static void current_group_id_cb(struct media_player *plr, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Current group ID failed (%d)", plr, err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Current Group Object ID: %s", plr, str);
+	shell_print(ctx_shell, "Player: %p, Current Group Object ID: 0x%llx", plr, id);
 }
 
 static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Parent group ID failed (%d)", plr, err);
 		return;
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Parent Group Object ID: %s", plr, str);
+	shell_print(ctx_shell, "Player: %p, Parent Group Object ID: 0x%llx", plr, id);
 }
 #endif /* CONFIG_BT_OTS */
 
@@ -348,8 +330,6 @@ static void search_recv_cb(struct media_player *plr, int err, uint8_t result_cod
 
 static void search_results_id_cb(struct media_player *plr, int err, uint64_t id)
 {
-	char str[BT_OTS_OBJ_ID_STR_LEN];
-
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Search results ID failed (%d)", plr, err);
 		return;
@@ -359,8 +339,7 @@ static void search_results_id_cb(struct media_player *plr, int err, uint64_t id)
 		shell_print(ctx_shell, "Player: %p, Search result not avilable", plr);
 	}
 
-	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Search Results Object ID: %s", plr, str);
+	shell_print(ctx_shell, "Player: %p, Search Results Object ID: 0x%llx", plr, id);
 }
 #endif /* CONFIG_BT_OTS */
 


### PR DESCRIPTION
The new v2 logging module is capable of handling 64-bit numbers. As a
result of this new capability, we no longer need the
bt_ots_obj_id_to_str function.

Signed-off-by: Abe Kohandel <abe.kohandel@gmail.com>