### PR TITLE
MAINTAINERS: add samples/net/sockets/can/ to CAN files

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -503,6 +503,7 @@ Documentation:
         - modules/canopennode/
         - samples/drivers/can/
         - samples/modules/canopennode/
+        - samples/net/sockets/can/
         - samples/subsys/canbus/
         - subsys/canbus/
         - subsys/net/l2/canbus/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -493,21 +493,21 @@ Documentation:
         - martinjaeger
         - legoabram
     files:
+        - doc/reference/canbus/
         - drivers/can/
-        - include/canbus/
-        - subsys/canbus/
-        - subsys/net/l2/canbus/
-        - tests/subsys/canbus/
         - dts/bindings/can/
+        - include/canbus/
         - include/devicetree/can.h
         - include/drivers/can.h
         - include/drivers/can/
-        - samples/drivers/can/
-        - tests/drivers/can/
-        - samples/subsys/canbus/
-        - doc/reference/canbus/
         - modules/canopennode/
+        - samples/drivers/can/
         - samples/modules/canopennode/
+        - samples/subsys/canbus/
+        - subsys/canbus/
+        - subsys/net/l2/canbus/
+        - tests/drivers/can/
+        - tests/subsys/canbus/
     labels:
         - "area: CAN"
 


### PR DESCRIPTION
Sort the entries in the CAN drivers files section and add samples/net/sockets/can/ to the CAN area.
