### PR TITLE
drivers: ieee802154_nrf5: fix delayed operation accuracy

### DIFF
--- a/drivers/ieee802154/Kconfig
+++ b/drivers/ieee802154/Kconfig
@@ -137,13 +137,6 @@ config IEEE802154_2015
 	help
 	  Enable radio driver support for IEEE 802.15.4-2015 frames, including security handling of frames and ACKs.
 
-config IEEE802154_DELAY_TRX_ACC
-	int "Clock accuracy for delayed operations"
-	default 20
-	help
-	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
-	  or delayed reception), in ppm.
-
 config IEEE802154_CSL_ENDPOINT
 	bool "Support for CSL Endpoint"
 	help

--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -75,4 +75,11 @@ config IEEE802154_NRF5_FCS_IN_LENGTH
 	  the overall packet length while others not. Allow to configure this
 	  behavior, based on the selected upper layer.
 
+config IEEE802154_NRF5_DELAY_TRX_ACC
+	int "Clock accuracy for delayed operations"
+	default CLOCK_CONTROL_NRF_ACCURACY
+	help
+	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
+	  or delayed reception), in ppm.
+
 endif

--- a/drivers/ieee802154/ieee802154_nrf5.c
+++ b/drivers/ieee802154/ieee802154_nrf5.c
@@ -594,7 +594,7 @@ static uint8_t nrf5_get_acc(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	return CONFIG_IEEE802154_DELAY_TRX_ACC;
+	return CONFIG_IEEE802154_NRF5_DELAY_TRX_ACC;
 }
 
 static int nrf5_start(const struct device *dev)


### PR DESCRIPTION
Align clock accuracy used in CSL calculations to the value in platform.
This is recomended setting for devices working in wide range
temperature. Nevertheless it can be profiled in end product to decrease
CSL window duration and finally the power consumption.
