### PR TITLE
Fix lwm2m client sample dtls

### DIFF
--- a/include/net/lwm2m.h
+++ b/include/net/lwm2m.h
@@ -137,6 +137,7 @@ struct lwm2m_ctx {
 	 */
 	char *desthostname;
 	uint16_t desthostnamelen;
+	bool hostname_verify;
 
 	/** Client can set load_credentials function as a way of overriding
 	 *  the default behavior of load_tls_credential() in lwm2m_engine.c

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -5641,7 +5641,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 			return -errno;
 		}
 
-		if (client_ctx->desthostname != NULL) {
+		if (client_ctx->hostname_verify && (client_ctx->desthostname != NULL)) {
 			/** store character at len position */
 			tmp = client_ctx->desthostname[client_ctx->desthostnamelen];
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -5656,6 +5656,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 			client_ctx->desthostname[client_ctx->desthostnamelen] = tmp;
 			if (ret < 0) {
 				LOG_ERR("Failed to set TLS_HOSTNAME option: %d", errno);
+				lwm2m_engine_context_close(client_ctx);
 				return -errno;
 			}
 		}


### PR DESCRIPTION
LWM2M client sample with dtls fails with the following error:
```
<err> net_lwm2m_engine: Failed to set TLS_HOSTNAME option: 109
<err> net_lwm2m_rd_client: Cannot init LWM2M engine (-109)
```
TLS_HOSTNAME can only be set if MBEDTLS_X509_CRT_PARSE_C is enabled which is not the case if using PSK.  
As this code was added in #40100 with the mention of a use case when CONFIG_MBEDTLS_SERVER_NAME_INDICATION is enabled, I suggest to only set the hostname if this option is enabled. Better options are welcome.

During the debugging i found out, that there is ```lwm2m_engine_context_close``` missing

Signed-off-by: Benjamin Bigler <benjamin.bigler@securiton.ch>