### PR TITLE
net: lib: lwm2m: Use defines for update state and result pathstrs

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -97,7 +97,7 @@ uint8_t lwm2m_firmware_get_update_state(void)
 void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 {
 	bool error = false;
-	char path[sizeof("5/65535/3")];
+	char path[LWM2M_MAX_PATH_STR_LEN];
 
 	/* Check LWM2M SPEC appendix E.6.1 */
 	switch (state) {
@@ -129,7 +129,8 @@ void lwm2m_firmware_set_update_state_inst(uint16_t obj_inst_id, uint8_t state)
 			update_state[obj_inst_id], state);
 	}
 
-	snprintk(path, sizeof(path), "5/%" PRIu16 "/3", obj_inst_id);
+	snprintk(path, sizeof(path), "%" PRIu16 "/%" PRIu16 "/%" PRIu16,
+		 LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id, FIRMWARE_STATE_ID);
 
 	lwm2m_engine_set_u8(path, state);
 
@@ -155,7 +156,7 @@ void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result)
 {
 	uint8_t state;
 	bool error = false;
-	char path[sizeof("5/65535/5")];
+	char path[LWM2M_MAX_PATH_STR_LEN];
 
 	/* Check LWM2M SPEC appendix E.6.1 */
 	switch (result) {
@@ -211,7 +212,8 @@ void lwm2m_firmware_set_update_result_inst(uint16_t obj_inst_id, uint8_t result)
 			result, state);
 	}
 
-	snprintk(path, sizeof(path), "5/%" PRIu16 "/5", obj_inst_id);
+	snprintk(path, sizeof(path), "%" PRIu16 "/%" PRIu16 "/%" PRIu16,
+		 LWM2M_OBJECT_FIRMWARE_ID, obj_inst_id, FIRMWARE_UPDATE_RESULT_ID);
 
 	lwm2m_engine_set_u8(path, result);
 


### PR DESCRIPTION
Use defines instead of hardcoded strings to avoid future errors if the
values would change.

I found this when I noticed the bug introduced with 9782f86450f20920a0043c3375710df078f8512f which was corrected in c2550d56c8163fc230334cefcaa7b8f0c4565936.