### PR TITLE
manifest: update mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -173,7 +173,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 7b9e4eecaa2547ba34cd40a13530f10dd70c92ca
+      revision: e86f575f68fdac2cab1898e0a893c8c6d8fd0fa1
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Synch up to upstream
https://github.com/mcu-tools/mcuboot/commit/aa041a282d

- Added workflow verifying integration with the Zephyr
- removed deprecated DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
- Fixed usage of CONFIG_LOG_IMMEDIATE

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>