### PR TITLE
Bluetooth: Controller: Fixing #44296 to set sample_offset properly

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -282,6 +282,7 @@ static inline void radio_df_ctrl_set(uint8_t cte_len,
 		} else {
 			sample_offset = 0;
 		}
+		break;
 	case PHY_2M:
 		if (switch_spacing == RADIO_DFECTRL1_TSWITCHSPACING_2us) {
 			sample_offset = CONFIG_BT_CTLR_DF_SAMPLE_OFFSET_PHY_2M_SAMPLING_1US;


### PR DESCRIPTION
When PHY is set to 1M, due to missed "break" statement of switch/case
the sample_offset will be set to the corresponding values of 2M
which causes improper function of sampling CTE signals.
By adding "break" statement the problem has solved.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/44296

Signed-off-by: Saleh Mehdikhani <saleh.mehdikhani@unikie.com>