### PR TITLE
MAINTAINERS: add @jciupis to IEEE 802.15.4 drivers collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -698,6 +698,7 @@ Documentation:
         - tbursztyka
     collaborators:
         - rlubos
+        - jciupis
     files:
         - drivers/ieee802154/
     labels:


### PR DESCRIPTION
Adds @jciupis as collaborator of IEEE 802.15.4 drivers.

Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>