### PR TITLE
dts/bindings: stm32-otg: Set pinctrl-[0/names] properties as required

### DIFF
--- a/dts/bindings/usb/st,stm32-otgfs.yaml
+++ b/dts/bindings/usb/st,stm32-otgfs.yaml
@@ -14,6 +14,12 @@ properties:
     interrupts:
       required: true
 
+    pinctrl-0:
+      required: true
+
+    pinctrl-names:
+      required: true
+
     ram-size:
       type: int
       required: true

--- a/dts/bindings/usb/st,stm32-otghs.yaml
+++ b/dts/bindings/usb/st,stm32-otghs.yaml
@@ -14,6 +14,12 @@ properties:
     interrupts:
       required: true
 
+    pinctrl-0:
+      required: true
+
+    pinctrl-names:
+      required: true
+
     ram-size:
       type: int
       required: true


### PR DESCRIPTION
Follow up on commit 37bf7cb
("dts/bindings: stm32: Set pinctrl-[0/names] properties as required")
Report lack of those fields soon at build to avoid cryptic
DT api build error messages.