### PR TITLE
Bluetooth: Audio: Unicast client missing unref on ACL disconnected

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -264,9 +264,11 @@ void bt_audio_stream_reset(struct bt_audio_stream *stream)
 
 	BT_DBG("stream %p", stream);
 
-	if (stream == NULL || stream->conn == NULL) {
+	if (stream == NULL) {
 		return;
 	}
+
+	bt_audio_stream_detach(stream);
 
 	err = bt_audio_cig_terminate(stream);
 	if (err != 0) {


### PR DESCRIPTION
The unicast client takes a reference to the ACL, but did
not return the reference when the ACL disconnected, but
rather just reset everything.

Modified to detach the stream, ensuring
a bt_conn_unref on ACL disconnect.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>