### PR TITLE
Bluetooth: Audio: Add missing null check for ep idle state

### DIFF
--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -240,11 +240,16 @@ static void unicast_client_ep_idle_state(struct bt_audio_ep *ep,
 					 struct net_buf_simple *buf)
 {
 	struct bt_audio_stream *stream = ep->stream;
+	const struct bt_audio_stream_ops *ops;
+
+	if (stream == NULL) {
+		return;
+	}
 
 	/* Notify upper layer */
-	if (stream != NULL && stream->ops != NULL &&
-	    stream->ops->released != NULL) {
-		stream->ops->released(stream);
+	ops = stream->ops;
+	if (ops != NULL && ops->released != NULL) {
+		ops->released(stream);
 	} else {
 		BT_WARN("No callback for released set");
 	}


### PR DESCRIPTION
The endpoint will likely be in the idle state when
we first read the ASE state. In that case we have
not yet attached a stream to the endpoint, and
thus should not request the stream to be released when it
is NULL.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>