### PR TITLE
LE Audio: PAC type rename and type cleanup

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -921,7 +921,7 @@ struct bt_audio_unicast_server_cb {
 	 *
 	 *  @param[in]  conn    Connection object.
 	 *  @param[in]  ep      Local Audio Endpoint being configured.
-	 *  @param[in]  type    Type of the endpoint.
+	 *  @param[in]  dir     Direction of the endpoint.
 	 *  @param[in]  codec   Codec configuration.
 	 *  @param[out] stream  Pointer to stream that will be configured for
 	 *                      the endpoint.
@@ -933,7 +933,7 @@ struct bt_audio_unicast_server_cb {
 	 */
 	int (*config)(struct bt_conn *conn,
 		      const struct bt_audio_ep *ep,
-		      enum bt_audio_dir type,
+		      enum bt_audio_dir dir,
 		      const struct bt_codec *codec,
 		      struct bt_audio_stream **stream,
 		      struct bt_codec_qos_pref *const pref);
@@ -944,7 +944,7 @@ struct bt_audio_unicast_server_cb {
 	 *  reconfigured with different codec configuration.
 	 *
 	 *  @param[in]  stream  Stream object being reconfigured.
-	 *  @param[in]  type    Type of the endpoint.
+	 *  @param[in]  dir     Direction of the endpoint.
 	 *  @param[in]  codec   Codec configuration.
 	 *  @param[out] pref    Pointer to a QoS preference object that shall
 	 *                      be populated with values. Invalid values will
@@ -953,7 +953,7 @@ struct bt_audio_unicast_server_cb {
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
 	int (*reconfig)(struct bt_audio_stream *stream,
-			uint8_t type,
+			enum bt_audio_dir dir,
 			const struct bt_codec *codec,
 			struct bt_codec_qos_pref *const pref);
 
@@ -1082,13 +1082,13 @@ struct bt_audio_unicast_server_cb {
 	 *                        for sending a notification, as a result of
 	 *                        calling
 	 *                        bt_audio_unicast_server_location_changed().
-	 *  @param[in]  type      Type of the endpoint.
+	 *  @param[in]  dir       Direction of the endpoint.
 	 *  @param[out] location  Pointer to the location that needs to be set.
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
 	int (*publish_location)(struct bt_conn *conn,
-				enum bt_audio_dir type,
+				enum bt_audio_dir dir,
 				enum bt_audio_location *location);
 
 #if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE) || defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
@@ -1098,12 +1098,12 @@ struct bt_audio_unicast_server_cb {
 	 *  requests to write the Published Audio Capabilities (PAC) location.
 	 *
 	 *  @param conn      The connection that requests the write.
-	 *  @param type      Type of the endpoint.
+	 *  @param dir       Direction of the endpoint.
 	 *  @param location  The location being written.
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*write_location)(struct bt_conn *conn, enum bt_audio_dir type,
+	int (*write_location)(struct bt_conn *conn, enum bt_audio_dir dir,
 			      enum bt_audio_location location);
 #endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE || CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
 #endif /* CONFIG_BT_PAC_SNK_LOC || CONFIG_BT_PAC_SRC_LOC */
@@ -1340,9 +1340,11 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
  *
  * Notify connected clients that the location has changed
  *
+ * @param dir       Direction of the endpoint.
+ *
  * @return 0 in case of success or negative value in case of error.
  */
-int bt_audio_unicast_server_location_changed(enum bt_audio_dir type);
+int bt_audio_unicast_server_location_changed(enum bt_audio_dir dir);
 
 /** @} */ /* End of group bt_audio_server */
 
@@ -1366,7 +1368,7 @@ typedef void (*bt_audio_discover_func_t)(struct bt_conn *conn,
 
 struct bt_audio_discover_params {
 	/** Capabilities type */
-	uint8_t  type;
+	enum bt_audio_dir dir;
 	/** Callback function */
 	bt_audio_discover_func_t func;
 	/** Number of capabilities found */

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -306,7 +306,7 @@ struct bt_audio_base {
 };
 
 /** @brief Audio Capability type */
-enum bt_audio_pac_type {
+enum bt_audio_dir {
 	BT_AUDIO_SINK = 0x01,
 	BT_AUDIO_SOURCE = 0x02,
 };
@@ -933,7 +933,7 @@ struct bt_audio_unicast_server_cb {
 	 */
 	int (*config)(struct bt_conn *conn,
 		      const struct bt_audio_ep *ep,
-		      enum bt_audio_pac_type type,
+		      enum bt_audio_dir type,
 		      const struct bt_codec *codec,
 		      struct bt_audio_stream **stream,
 		      struct bt_codec_qos_pref *const pref);
@@ -1088,7 +1088,7 @@ struct bt_audio_unicast_server_cb {
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
 	int (*publish_location)(struct bt_conn *conn,
-				enum bt_audio_pac_type type,
+				enum bt_audio_dir type,
 				enum bt_audio_location *location);
 
 #if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE) || defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
@@ -1103,7 +1103,7 @@ struct bt_audio_unicast_server_cb {
 	 *
 	 *  @return 0 in case of success or negative value in case of error.
 	 */
-	int (*write_location)(struct bt_conn *conn, enum bt_audio_pac_type type,
+	int (*write_location)(struct bt_conn *conn, enum bt_audio_dir type,
 			      enum bt_audio_location location);
 #endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE || CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
 #endif /* CONFIG_BT_PAC_SNK_LOC || CONFIG_BT_PAC_SRC_LOC */
@@ -1342,7 +1342,7 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
  *
  * @return 0 in case of success or negative value in case of error.
  */
-int bt_audio_unicast_server_location_changed(enum bt_audio_pac_type type);
+int bt_audio_unicast_server_location_changed(enum bt_audio_dir type);
 
 /** @} */ /* End of group bt_audio_server */
 

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -307,8 +307,8 @@ struct bt_audio_base {
 
 /** @brief Audio Capability type */
 enum bt_audio_dir {
-	BT_AUDIO_SINK = 0x01,
-	BT_AUDIO_SOURCE = 0x02,
+	BT_AUDIO_DIR_SINK = 0x01,
+	BT_AUDIO_DIR_SOURCE = 0x02,
 };
 
 /** @def BT_CODEC_QOS

--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -17,7 +17,7 @@ extern "C" {
 #endif
 
 /* Get list of capabilities by type */
-sys_slist_t *bt_audio_capability_get(uint8_t type);
+sys_slist_t *bt_audio_capability_get(enum bt_audio_dir dir);
 
 
 /** @brief Audio Capability type */
@@ -107,7 +107,7 @@ struct bt_audio_capability_ops {
 	 *
 	 *  @param conn Connection object
 	 *  @param ep Remote Audio Endpoint being configured
-	 *  @param type Type of the endpoint.
+	 *  @param dir Direction of the endpoint.
 	 *  @param cap Local Audio Capability being configured
 	 *  @param codec Codec configuration
 	 *
@@ -115,7 +115,7 @@ struct bt_audio_capability_ops {
 	 */
 	struct bt_audio_stream *(*config)(struct bt_conn *conn,
 					  struct bt_audio_ep *ep,
-					  enum bt_audio_dir type,
+					  enum bt_audio_dir dir,
 					  struct bt_audio_capability *cap,
 					  struct bt_codec *codec);
 
@@ -228,8 +228,8 @@ struct bt_audio_capability_ops {
  *
  */
 struct bt_audio_capability {
-	/** Capability type */
-	uint8_t  type;
+	/** Capability direction */
+	enum bt_audio_dir dir;
 	/** Supported Audio Contexts */
 	uint16_t context;
 	/** Capability codec reference */
@@ -263,11 +263,11 @@ int bt_audio_capability_unregister(struct bt_audio_capability *cap);
 
 /** @brief Set the location for an endpoint type
  *
- * @param type     Type of the endpoint.
+ * @param dir      Direction of the endpoints to change location for.
  * @param location The location to be set.
  *
  */
-int bt_audio_capability_set_location(enum bt_audio_dir type,
+int bt_audio_capability_set_location(enum bt_audio_dir dir,
 				     enum bt_audio_location location);
 
 #ifdef __cplusplus

--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -115,7 +115,7 @@ struct bt_audio_capability_ops {
 	 */
 	struct bt_audio_stream *(*config)(struct bt_conn *conn,
 					  struct bt_audio_ep *ep,
-					  enum bt_audio_pac_type type,
+					  enum bt_audio_dir type,
 					  struct bt_audio_capability *cap,
 					  struct bt_codec *codec);
 
@@ -267,7 +267,7 @@ int bt_audio_capability_unregister(struct bt_audio_capability *cap);
  * @param location The location to be set.
  *
  */
-int bt_audio_capability_set_location(enum bt_audio_pac_type type,
+int bt_audio_capability_set_location(enum bt_audio_dir type,
 				     enum bt_audio_location location);
 
 #ifdef __cplusplus

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -465,13 +465,14 @@ static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)
 }
 
 static void add_remote_codec(struct bt_codec *codec_capabilities, int index,
-				  uint8_t type)
+			     enum bt_audio_dir dir)
 {
-	printk("#%u: codec %p type 0x%02x\n", index, codec_capabilities, type);
+	printk("#%u: codec_capabilities %p dir 0x%02x\n",
+	       index, codec_capabilities, dir);
 
 	print_codec_capabilities(codec_capabilities);
 
-	if (type != BT_AUDIO_SINK && type != BT_AUDIO_SOURCE) {
+	if (dir != BT_AUDIO_SINK && dir != BT_AUDIO_SOURCE) {
 		return;
 	}
 
@@ -491,15 +492,15 @@ static void discover_sink_cb(struct bt_conn *conn,
 	}
 
 	if (codec != NULL) {
-		add_remote_codec(codec, params->num_caps, params->type);
+		add_remote_codec(codec, params->num_caps, params->dir);
 		return;
 	}
 
 	if (ep != NULL) {
-		if (params->type == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_SINK) {
 			add_remote_sink(ep, params->num_eps);
 		} else {
-			printk("Invalid param type: %u\n", params->type);
+			printk("Invalid param dir: %u\n", params->dir);
 		}
 
 		return;
@@ -601,7 +602,7 @@ static int discover_sink(void)
 	int err;
 
 	params.func = discover_sink_cb;
-	params.type = BT_AUDIO_SINK;
+	params.dir = BT_AUDIO_SINK;
 
 	err = bt_audio_discover(default_conn, &params);
 	if (err != 0) {

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -472,7 +472,7 @@ static void add_remote_codec(struct bt_codec *codec_capabilities, int index,
 
 	print_codec_capabilities(codec_capabilities);
 
-	if (dir != BT_AUDIO_SINK && dir != BT_AUDIO_SOURCE) {
+	if (dir != BT_AUDIO_DIR_SINK && dir != BT_AUDIO_DIR_SOURCE) {
 		return;
 	}
 
@@ -497,7 +497,7 @@ static void discover_sink_cb(struct bt_conn *conn,
 	}
 
 	if (ep != NULL) {
-		if (params->dir == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_DIR_SINK) {
 			add_remote_sink(ep, params->num_eps);
 		} else {
 			printk("Invalid param dir: %u\n", params->dir);
@@ -602,7 +602,7 @@ static int discover_sink(void)
 	int err;
 
 	params.func = discover_sink_cb;
-	params.dir = BT_AUDIO_SINK;
+	params.dir = BT_AUDIO_DIR_SINK;
 
 	err = bt_audio_discover(default_conn, &params);
 	if (err != 0) {

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -133,7 +133,7 @@ static void print_qos(struct bt_codec_qos *qos)
 
 static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 					  struct bt_audio_ep *ep,
-					  enum bt_audio_pac_type type,
+					  enum bt_audio_dir type,
 					  struct bt_audio_capability *cap,
 					  struct bt_codec *codec)
 {

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -380,7 +380,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 static struct bt_audio_capability caps[] = {
 	{
-		.dir = BT_AUDIO_SINK,
+		.dir = BT_AUDIO_DIR_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000,

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -133,12 +133,12 @@ static void print_qos(struct bt_codec_qos *qos)
 
 static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 					  struct bt_audio_ep *ep,
-					  enum bt_audio_dir type,
+					  enum bt_audio_dir dir,
 					  struct bt_audio_capability *cap,
 					  struct bt_codec *codec)
 {
-	printk("ASE Codec Config: conn %p ep %p type %u, cap %p\n",
-	       conn, ep, type, cap);
+	printk("ASE Codec Config: conn %p ep %p dir %u, cap %p\n",
+	       conn, ep, dir, cap);
 
 	print_codec(codec);
 
@@ -380,7 +380,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 
 static struct bt_audio_capability caps[] = {
 	{
-		.type = BT_AUDIO_SINK,
+		.dir = BT_AUDIO_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000,

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -312,7 +312,7 @@ static void ascs_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = CONTAINER_OF(chan, struct bt_audio_ep, iso);
 
-	BT_DBG("stream %p ep %p type %u", chan, ep, ep != NULL ? ep->type : 0);
+	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
@@ -786,7 +786,6 @@ void ascs_ep_init(struct bt_audio_ep *ep, uint8_t id)
 	BT_DBG("ep %p id 0x%02x", ep, id);
 
 	memset(ep, 0, sizeof(*ep));
-	ep->type = BT_AUDIO_EP_LOCAL;
 	ep->status.id = id;
 	ep->iso.ops = &ascs_iso_ops;
 	ep->iso.qos = &ep->iso_qos;

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -35,7 +35,7 @@
 
 #define ASE_ID(_ase) ase->ep.status.id
 #define ASE_DIR(_id) \
-	(_id > CONFIG_BT_ASCS_ASE_SNK_COUNT ? BT_AUDIO_SOURCE : BT_AUDIO_SINK)
+	(_id > CONFIG_BT_ASCS_ASE_SNK_COUNT ? BT_AUDIO_DIR_SOURCE : BT_AUDIO_DIR_SINK)
 #define ASE_UUID(_id) \
 	(_id > CONFIG_BT_ASCS_ASE_SNK_COUNT ? BT_UUID_ASCS_ASE_SRC : BT_UUID_ASCS_ASE_SNK)
 #define ASE_COUNT (CONFIG_BT_ASCS_ASE_SNK_COUNT + CONFIG_BT_ASCS_ASE_SRC_COUNT)
@@ -345,7 +345,7 @@ static void ascs_iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 		/* The ASE state machine goes into different states from this operation
 		 * based on whether it is a source or a sink ASE.
 		 */
-		if (ep->dir == BT_AUDIO_SOURCE) {
+		if (ep->dir == BT_AUDIO_DIR_SOURCE) {
 			ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_DISABLING);
 		} else {
 			ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
@@ -584,7 +584,7 @@ static void ase_disable(struct bt_ascs_ase *ase)
 	/* The ASE state machine goes into different states from this operation
 	 * based on whether it is a source or a sink ASE.
 	 */
-	if (ep->dir == BT_AUDIO_SOURCE) {
+	if (ep->dir == BT_AUDIO_DIR_SOURCE) {
 		ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_DISABLING);
 	} else {
 		ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
@@ -1506,7 +1506,7 @@ static int ase_enable(struct bt_ascs_ase *ase, struct bt_ascs_metadata *meta,
 	ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_ENABLING);
 
 
-	if (ep->dir == BT_AUDIO_SINK) {
+	if (ep->dir == BT_AUDIO_DIR_SINK) {
 		/* SINK ASEs can autonomously go into the streaming state if
 		 * the CIS is connected
 		 */
@@ -1593,7 +1593,7 @@ static void ase_start(struct bt_ascs_ase *ase)
 	 * characteristic to the client, and the server shall set the
 	 * Response_Code value for that ASE to 0x05 (Invalid ASE direction).
 	 */
-	if (ep->dir == BT_AUDIO_SINK) {
+	if (ep->dir == BT_AUDIO_DIR_SINK) {
 		BT_ERR("Start failed: invalid operation for Sink");
 		ascs_cp_rsp_add(ASE_ID(ase), BT_ASCS_START_OP,
 				BT_ASCS_RSP_INVALID_DIR, BT_ASCS_REASON_NONE);
@@ -1717,7 +1717,7 @@ static void ase_stop(struct bt_ascs_ase *ase)
 	 * characteristic to the client, and the server shall set the
 	 * Response_Code value for that ASE to 0x05 (Invalid ASE direction).
 	 */
-	if (ase->ep.dir == BT_AUDIO_SINK) {
+	if (ase->ep.dir == BT_AUDIO_DIR_SINK) {
 		BT_ERR("Stop failed: invalid operation for Sink");
 		ascs_cp_rsp_add(ASE_ID(ase), BT_ASCS_STOP_OP,
 				BT_ASCS_RSP_INVALID_DIR, BT_ASCS_REASON_NONE);

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -781,7 +781,7 @@ static void broadcast_sink_ep_init(struct bt_audio_ep *ep)
 	ep->iso.qos = &ep->iso_qos;
 	ep->iso.qos->rx = &ep->iso_rx;
 	ep->iso.qos->tx = &ep->iso_tx;
-	ep->dir = BT_AUDIO_SINK;
+	ep->dir = BT_AUDIO_DIR_SINK;
 }
 
 static struct bt_audio_ep *broadcast_sink_new_ep(uint8_t index)

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -186,7 +186,7 @@ static void broadcast_source_ep_init(struct bt_audio_ep *ep)
 	ep->iso.qos = &ep->iso_qos;
 	ep->iso.qos->rx = &ep->iso_rx;
 	ep->iso.qos->tx = &ep->iso_tx;
-	ep->dir = BT_AUDIO_SOURCE;
+	ep->dir = BT_AUDIO_DIR_SOURCE;
 }
 
 static struct bt_audio_ep *broadcast_source_new_ep(uint8_t index)

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -43,9 +43,9 @@ static int unicast_server_config_cb(struct bt_conn *conn,
 	struct bt_audio_capability *cap;
 	sys_slist_t *lst;
 
-	if (dir == BT_AUDIO_SINK) {
+	if (dir == BT_AUDIO_DIR_SINK) {
 		lst = &snks;
-	} else if (dir == BT_AUDIO_SOURCE) {
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		lst = &srcs;
 	} else {
 		BT_ERR("Invalid endpoint dir: %u", dir);
@@ -97,9 +97,9 @@ static int unicast_server_reconfig_cb(struct bt_audio_stream *stream,
 	struct bt_audio_capability *cap;
 	sys_slist_t *lst;
 
-	if (dir == BT_AUDIO_SINK) {
+	if (dir == BT_AUDIO_DIR_SINK) {
 		lst = &snks;
-	} else if (dir == BT_AUDIO_SOURCE) {
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		lst = &srcs;
 	} else {
 		BT_ERR("Invalid endpoint dir: %u", dir);
@@ -234,9 +234,9 @@ static int publish_capability_cb(struct bt_conn *conn, uint8_t dir,
 	sys_slist_t *lst;
 	uint8_t i;
 
-	if (dir == BT_AUDIO_SINK) {
+	if (dir == BT_AUDIO_DIR_SINK) {
 		lst = &snks;
-	} else if (dir == BT_AUDIO_SOURCE) {
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		lst = &srcs;
 	} else {
 		BT_ERR("Invalid endpoint dir: %u", dir);
@@ -273,11 +273,11 @@ static int publish_location_cb(struct bt_conn *conn,
 {
 	if (0) {
 #if defined(CONFIG_BT_PAC_SNK_LOC)
-	} else if (dir == BT_AUDIO_SINK) {
+	} else if (dir == BT_AUDIO_DIR_SINK) {
 		*location = sink_location;
 #endif /* CONFIG_BT_PAC_SNK_LOC */
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-	} else if (dir == BT_AUDIO_SOURCE) {
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		*location = source_location;
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 	} else {
@@ -321,9 +321,9 @@ static struct bt_audio_unicast_server_cb unicast_server_cb = {
 sys_slist_t *bt_audio_capability_get(enum bt_audio_dir dir)
 {
 	switch (dir) {
-	case BT_AUDIO_SINK:
+	case BT_AUDIO_DIR_SINK:
 		return &snks;
-	case BT_AUDIO_SOURCE:
+	case BT_AUDIO_DIR_SOURCE:
 		return &srcs;
 	}
 
@@ -430,11 +430,11 @@ int bt_audio_capability_set_location(enum bt_audio_dir dir,
 
 	if (0) {
 #if defined(CONFIG_BT_PAC_SNK_LOC)
-	} else if (dir == BT_AUDIO_SINK) {
+	} else if (dir == BT_AUDIO_DIR_SINK) {
 		sink_location = location;
 #endif /* CONFIG_BT_PAC_SNK_LOC */
 #if defined(CONFIG_BT_PAC_SRC_LOC)
-	} else if (dir == BT_AUDIO_SOURCE) {
+	} else if (dir == BT_AUDIO_DIR_SOURCE) {
 		source_location = location;
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 	} else {

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -35,7 +35,7 @@ static sys_slist_t srcs;
  */
 static int unicast_server_config_cb(struct bt_conn *conn,
 				    const struct bt_audio_ep *ep,
-				    enum bt_audio_pac_type type,
+				    enum bt_audio_dir type,
 				    const struct bt_codec *codec,
 				    struct bt_audio_stream **stream,
 				    struct bt_codec_qos_pref *const pref)
@@ -268,7 +268,7 @@ static enum bt_audio_location source_location;
 #endif /* CONFIG_BT_PAC_SRC_LOC */
 
 static int publish_location_cb(struct bt_conn *conn,
-			       enum bt_audio_pac_type type,
+			       enum bt_audio_dir type,
 			       enum bt_audio_location *location)
 {
 	if (0) {
@@ -290,7 +290,7 @@ static int publish_location_cb(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE) || defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
-static int write_location_cb(struct bt_conn *conn, enum bt_audio_pac_type type,
+static int write_location_cb(struct bt_conn *conn, enum bt_audio_dir type,
 			     enum bt_audio_location location)
 {
 	return bt_audio_capability_set_location(type, location);
@@ -423,7 +423,7 @@ int bt_audio_capability_unregister(struct bt_audio_capability *cap)
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-int bt_audio_capability_set_location(enum bt_audio_pac_type type,
+int bt_audio_capability_set_location(enum bt_audio_dir type,
 				     enum bt_audio_location location)
 {
 	int err;

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -23,16 +23,12 @@
 #define BROADCAST_STREAM_CNT 0
 #endif /* CONFIG_BT_AUDIO_BROADCAST_SOURCE */
 
-#define BT_AUDIO_EP_LOCAL	0x00
-#define BT_AUDIO_EP_REMOTE	0x01
-
 /* Temp struct declarations to handle circular dependencies */
 struct bt_audio_unicast_group;
 struct bt_audio_broadcast_source;
 struct bt_audio_broadcast_sink;
 
 struct bt_audio_ep {
-	uint8_t  type;
 	uint8_t  dir;
 	uint16_t handle;
 	uint16_t cp_handle;

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -605,14 +605,14 @@ static int has_init(const struct device *dev)
 			 * Front Left and the Front Right bits to a value of 0b1
 			 * in the Sink Audio Locations characteristic value.
 			 */
-			bt_audio_capability_set_location(BT_AUDIO_SINK,
+			bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
 							 (BT_AUDIO_LOCATION_FRONT_LEFT |
 								BT_AUDIO_LOCATION_FRONT_RIGHT));
 		} else if (IS_ENABLED(CONFIG_BT_HAS_HEARING_AID_LEFT)) {
-			bt_audio_capability_set_location(BT_AUDIO_SINK,
+			bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
 							 BT_AUDIO_LOCATION_FRONT_LEFT);
 		} else {
-			bt_audio_capability_set_location(BT_AUDIO_SINK,
+			bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
 							 BT_AUDIO_LOCATION_FRONT_RIGHT);
 		}
 	}

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -50,7 +50,7 @@ static void pac_data_add(struct net_buf_simple *buf, uint8_t num,
 	}
 }
 
-static void get_pac_records(struct bt_conn *conn, uint8_t type,
+static void get_pac_records(struct bt_conn *conn, enum bt_audio_dir dir,
 			    struct net_buf_simple *buf)
 {
 	struct bt_pacs_read_rsp *rsp;
@@ -72,7 +72,7 @@ static void get_pac_records(struct bt_conn *conn, uint8_t type,
 		struct bt_pac *pac;
 		int err;
 
-		err = unicast_server_cb->publish_capability(conn, type,
+		err = unicast_server_cb->publish_capability(conn, dir,
 							    rsp->num_pac,
 							    &codec);
 		if (err != 0) {
@@ -110,15 +110,15 @@ static void get_pac_records(struct bt_conn *conn, uint8_t type,
 static ssize_t pac_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			void *buf, uint16_t len, uint16_t offset)
 {
-	uint8_t type;
+	enum bt_audio_dir dir;
 
 	if (!bt_uuid_cmp(attr->uuid, BT_UUID_PACS_SNK)) {
-		type = BT_AUDIO_SINK;
+		dir = BT_AUDIO_SINK;
 	} else {
-		type = BT_AUDIO_SOURCE;
+		dir = BT_AUDIO_SOURCE;
 	}
 
-	get_pac_records(conn, type, &read_buf);
+	get_pac_records(conn, dir, &read_buf);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, read_buf.data,
 				 read_buf.len);
@@ -173,7 +173,7 @@ static ssize_t supported_context_read(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-static int get_pac_loc(struct bt_conn *conn, enum bt_audio_dir type,
+static int get_pac_loc(struct bt_conn *conn, enum bt_audio_dir dir,
 		       enum bt_audio_location *location)
 {
 	int err;
@@ -184,7 +184,7 @@ static int get_pac_loc(struct bt_conn *conn, enum bt_audio_dir type,
 		return -ENODATA;
 	}
 
-	err = unicast_server_cb->publish_location(conn, type, location);
+	err = unicast_server_cb->publish_location(conn, dir, location);
 	if (err != 0 || *location == 0) {
 		BT_DBG("err (%d) or invalid location value (%u)",
 		       err, *location);
@@ -454,9 +454,9 @@ BT_GATT_SERVICE_DEFINE(pacs_svc,
 );
 #endif /* CONFIG_BT_PAC_SNK || CONFIG_BT_PAC_SRC */
 
-static struct k_work_delayable *bt_pacs_get_work(uint8_t type)
+static struct k_work_delayable *bt_pacs_get_work(enum bt_audio_dir dir)
 {
-	switch (type) {
+	switch (dir) {
 #if defined(CONFIG_BT_PAC_SNK)
 	case BT_AUDIO_SINK:
 		return &snks_work;
@@ -465,15 +465,15 @@ static struct k_work_delayable *bt_pacs_get_work(uint8_t type)
 	case BT_AUDIO_SOURCE:
 		return &srcs_work;
 #endif /* CONFIG_BT_PAC_SNK */
+	default:
+		return NULL;
 	}
-
-	return NULL;
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-static struct k_work_delayable *bt_pacs_get_loc_work(uint8_t type)
+static struct k_work_delayable *bt_pacs_get_loc_work(enum bt_audio_dir dir)
 {
-	switch (type) {
+	switch (dir) {
 #if defined(CONFIG_BT_PAC_SNK)
 	case BT_AUDIO_SINK:
 		return &snks_loc_work;
@@ -482,9 +482,9 @@ static struct k_work_delayable *bt_pacs_get_loc_work(uint8_t type)
 	case BT_AUDIO_SOURCE:
 		return &srcs_loc_work;
 #endif /* CONFIG_BT_PAC_SNK */
+	default:
+		return NULL;
 	}
-
-	return NULL;
 }
 
 static void pac_notify_loc(struct k_work *work)
@@ -492,25 +492,25 @@ static void pac_notify_loc(struct k_work *work)
 #if defined(CONFIG_BT_PAC_SNK) || defined(CONFIG_BT_PAC_SRC)
 	uint32_t location;
 	struct bt_uuid *uuid;
-	enum bt_audio_dir type;
+	enum bt_audio_dir dir;
 	int err;
 
 #if defined(CONFIG_BT_PAC_SNK)
 	if (work == &snks_loc_work.work) {
-		type = BT_AUDIO_SINK;
+		dir = BT_AUDIO_SINK;
 		uuid = BT_UUID_PACS_SNK_LOC;
 	}
 #endif /* CONFIG_BT_PAC_SNK */
 
 #if defined(CONFIG_BT_PAC_SRC)
 	if (work == &srcs_loc_work.work) {
-		type = BT_AUDIO_SOURCE;
+		dir = BT_AUDIO_SOURCE;
 		uuid = BT_UUID_PACS_SRC_LOC;
 	}
 #endif /* CONFIG_BT_PAC_SRC */
 
 	/* TODO: We can skip this if we are not connected to any devices */
-	err = get_pac_loc(NULL, type, &location);
+	err = get_pac_loc(NULL, dir, &location);
 	if (err != 0) {
 		BT_DBG("get_pac_loc returned %d, won't notify", err);
 		return;
@@ -530,25 +530,25 @@ static void pac_notify(struct k_work *work)
 {
 #if defined(CONFIG_BT_PAC_SNK) || defined(CONFIG_BT_PAC_SRC)
 	struct bt_uuid *uuid;
-	uint8_t type;
+	enum bt_audio_dir dir;
 	int err;
 
 #if defined(CONFIG_BT_PAC_SNK)
 	if (work == &snks_work.work) {
-		type = BT_AUDIO_SINK;
+		dir = BT_AUDIO_SINK;
 		uuid = BT_UUID_PACS_SNK;
 	}
 #endif /* CONFIG_BT_PAC_SNK */
 
 #if defined(CONFIG_BT_PAC_SRC)
 	if (work == &srcs_work.work) {
-		type = BT_AUDIO_SOURCE;
+		dir = BT_AUDIO_SOURCE;
 		uuid = BT_UUID_PACS_SRC;
 	}
 #endif /* CONFIG_BT_PAC_SRC */
 
 	/* TODO: We can skip this if we are not connected to any devices */
-	get_pac_records(NULL, type, &read_buf);
+	get_pac_records(NULL, dir, &read_buf);
 
 	err = bt_gatt_notify_uuid(NULL, uuid, pacs_svc.attrs, read_buf.data,
 				  read_buf.len);
@@ -558,11 +558,11 @@ static void pac_notify(struct k_work *work)
 #endif /* CONFIG_BT_PAC_SNK || CONFIG_BT_PAC_SRC */
 }
 
-void bt_pacs_add_capability(uint8_t type)
+void bt_pacs_add_capability(enum bt_audio_dir dir)
 {
 	struct k_work_delayable *work;
 
-	work = bt_pacs_get_work(type);
+	work = bt_pacs_get_work(dir);
 	if (!work) {
 		return;
 	}
@@ -575,11 +575,11 @@ void bt_pacs_add_capability(uint8_t type)
 	k_work_reschedule(work, PAC_NOTIFY_TIMEOUT);
 }
 
-void bt_pacs_remove_capability(uint8_t type)
+void bt_pacs_remove_capability(enum bt_audio_dir dir)
 {
 	struct k_work_delayable *work;
 
-	work = bt_pacs_get_work(type);
+	work = bt_pacs_get_work(dir);
 	if (!work) {
 		return;
 	}
@@ -588,11 +588,11 @@ void bt_pacs_remove_capability(uint8_t type)
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-int bt_pacs_location_changed(enum bt_audio_dir type)
+int bt_pacs_location_changed(enum bt_audio_dir dir)
 {
 	struct k_work_delayable *work;
 
-	work = bt_pacs_get_loc_work(type);
+	work = bt_pacs_get_loc_work(dir);
 	if (!work) {
 		return -EINVAL;
 	}

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -173,7 +173,7 @@ static ssize_t supported_context_read(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-static int get_pac_loc(struct bt_conn *conn, enum bt_audio_pac_type type,
+static int get_pac_loc(struct bt_conn *conn, enum bt_audio_dir type,
 		       enum bt_audio_location *location)
 {
 	int err;
@@ -492,7 +492,7 @@ static void pac_notify_loc(struct k_work *work)
 #if defined(CONFIG_BT_PAC_SNK) || defined(CONFIG_BT_PAC_SRC)
 	uint32_t location;
 	struct bt_uuid *uuid;
-	enum bt_audio_pac_type type;
+	enum bt_audio_dir type;
 	int err;
 
 #if defined(CONFIG_BT_PAC_SNK)
@@ -588,7 +588,7 @@ void bt_pacs_remove_capability(uint8_t type)
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-int bt_pacs_location_changed(enum bt_audio_pac_type type)
+int bt_pacs_location_changed(enum bt_audio_dir type)
 {
 	struct k_work_delayable *work;
 

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -113,9 +113,9 @@ static ssize_t pac_read(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 	enum bt_audio_dir dir;
 
 	if (!bt_uuid_cmp(attr->uuid, BT_UUID_PACS_SNK)) {
-		dir = BT_AUDIO_SINK;
+		dir = BT_AUDIO_DIR_SINK;
 	} else {
-		dir = BT_AUDIO_SOURCE;
+		dir = BT_AUDIO_DIR_SOURCE;
 	}
 
 	get_pac_records(conn, dir, &read_buf);
@@ -228,7 +228,7 @@ static ssize_t snk_loc_read(struct bt_conn *conn,
 	BT_DBG("conn %p attr %p buf %p len %u offset %u", conn, attr, buf, len,
 	       offset);
 
-	err = get_pac_loc(NULL, BT_AUDIO_SINK, &location);
+	err = get_pac_loc(NULL, BT_AUDIO_DIR_SINK, &location);
 	if (err != 0) {
 		BT_DBG("get_pac_loc returned %d", err);
 		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
@@ -274,7 +274,8 @@ static ssize_t snk_loc_write(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
 	}
 
-	err = unicast_server_cb->write_location(conn, BT_AUDIO_SINK, location);
+	err = unicast_server_cb->write_location(conn, BT_AUDIO_DIR_SINK,
+						location);
 	if (err != 0) {
 		BT_DBG("write_location returned %d", err);
 		return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
@@ -324,7 +325,7 @@ static ssize_t src_loc_read(struct bt_conn *conn,
 	BT_DBG("conn %p attr %p buf %p len %u offset %u", conn, attr, buf, len,
 	       offset);
 
-	err = get_pac_loc(NULL, BT_AUDIO_SOURCE, &location);
+	err = get_pac_loc(NULL, BT_AUDIO_DIR_SOURCE, &location);
 	if (err != 0) {
 		BT_DBG("get_pac_loc returned %d", err);
 		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
@@ -370,7 +371,7 @@ static ssize_t src_loc_write(struct bt_conn *conn,
 		return BT_GATT_ERR(BT_ATT_ERR_VALUE_NOT_ALLOWED);
 	}
 
-	err = unicast_server_cb->write_location(conn, BT_AUDIO_SOURCE,
+	err = unicast_server_cb->write_location(conn, BT_AUDIO_DIR_SOURCE,
 						location);
 	if (err != 0) {
 		BT_DBG("write_location returned %d", err);
@@ -458,11 +459,11 @@ static struct k_work_delayable *bt_pacs_get_work(enum bt_audio_dir dir)
 {
 	switch (dir) {
 #if defined(CONFIG_BT_PAC_SNK)
-	case BT_AUDIO_SINK:
+	case BT_AUDIO_DIR_SINK:
 		return &snks_work;
 #endif /* CONFIG_BT_PAC_SNK */
 #if defined(CONFIG_BT_PAC_SRC)
-	case BT_AUDIO_SOURCE:
+	case BT_AUDIO_DIR_SOURCE:
 		return &srcs_work;
 #endif /* CONFIG_BT_PAC_SNK */
 	default:
@@ -475,11 +476,11 @@ static struct k_work_delayable *bt_pacs_get_loc_work(enum bt_audio_dir dir)
 {
 	switch (dir) {
 #if defined(CONFIG_BT_PAC_SNK)
-	case BT_AUDIO_SINK:
+	case BT_AUDIO_DIR_SINK:
 		return &snks_loc_work;
 #endif /* CONFIG_BT_PAC_SNK */
 #if defined(CONFIG_BT_PAC_SRC)
-	case BT_AUDIO_SOURCE:
+	case BT_AUDIO_DIR_SOURCE:
 		return &srcs_loc_work;
 #endif /* CONFIG_BT_PAC_SNK */
 	default:
@@ -497,14 +498,14 @@ static void pac_notify_loc(struct k_work *work)
 
 #if defined(CONFIG_BT_PAC_SNK)
 	if (work == &snks_loc_work.work) {
-		dir = BT_AUDIO_SINK;
+		dir = BT_AUDIO_DIR_SINK;
 		uuid = BT_UUID_PACS_SNK_LOC;
 	}
 #endif /* CONFIG_BT_PAC_SNK */
 
 #if defined(CONFIG_BT_PAC_SRC)
 	if (work == &srcs_loc_work.work) {
-		dir = BT_AUDIO_SOURCE;
+		dir = BT_AUDIO_DIR_SOURCE;
 		uuid = BT_UUID_PACS_SRC_LOC;
 	}
 #endif /* CONFIG_BT_PAC_SRC */
@@ -535,14 +536,14 @@ static void pac_notify(struct k_work *work)
 
 #if defined(CONFIG_BT_PAC_SNK)
 	if (work == &snks_work.work) {
-		dir = BT_AUDIO_SINK;
+		dir = BT_AUDIO_DIR_SINK;
 		uuid = BT_UUID_PACS_SNK;
 	}
 #endif /* CONFIG_BT_PAC_SNK */
 
 #if defined(CONFIG_BT_PAC_SRC)
 	if (work == &srcs_work.work) {
-		dir = BT_AUDIO_SOURCE;
+		dir = BT_AUDIO_DIR_SOURCE;
 		uuid = BT_UUID_PACS_SRC;
 	}
 #endif /* CONFIG_BT_PAC_SRC */

--- a/subsys/bluetooth/audio/pacs_internal.h
+++ b/subsys/bluetooth/audio/pacs_internal.h
@@ -50,6 +50,6 @@ struct bt_pacs_context {
 	uint16_t  src;
 } __packed;
 
-void bt_pacs_add_capability(uint8_t type);
-void bt_pacs_remove_capability(uint8_t type);
-int bt_pacs_location_changed(enum bt_audio_dir type);
+void bt_pacs_add_capability(enum bt_audio_dir dir);
+void bt_pacs_remove_capability(enum bt_audio_dir dir);
+int bt_pacs_location_changed(enum bt_audio_dir dir);

--- a/subsys/bluetooth/audio/pacs_internal.h
+++ b/subsys/bluetooth/audio/pacs_internal.h
@@ -52,4 +52,4 @@ struct bt_pacs_context {
 
 void bt_pacs_add_capability(uint8_t type);
 void bt_pacs_remove_capability(uint8_t type);
-int bt_pacs_location_changed(enum bt_audio_pac_type type);
+int bt_pacs_location_changed(enum bt_audio_dir type);

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -283,6 +283,7 @@ int bt_audio_stream_config(struct bt_conn *conn,
 			   struct bt_codec *codec)
 {
 	uint8_t role;
+	int err;
 
 	BT_DBG("conn %p stream %p, ep %p codec %p codec id 0x%02x "
 	       "codec cid 0x%04x codec vid 0x%04x", conn, stream, ep,
@@ -316,16 +317,10 @@ int bt_audio_stream_config(struct bt_conn *conn,
 
 	bt_audio_stream_attach(conn, stream, ep, codec);
 
-	if (ep->type == BT_AUDIO_EP_LOCAL) {
-		bt_unicast_client_ep_set_state(ep, BT_AUDIO_EP_STATE_CODEC_CONFIGURED);
-	} else {
-		int err;
-
-		err = bt_unicast_client_config(stream, codec);
-		if (err != 0) {
-			BT_DBG("Failed to configure stream: %d", err);
-			return err;
-		}
+	err = bt_unicast_client_config(stream, codec);
+	if (err != 0) {
+		BT_DBG("Failed to configure stream: %d", err);
+		return err;
 	}
 
 	return 0;
@@ -336,6 +331,7 @@ int bt_audio_stream_reconfig(struct bt_audio_stream *stream,
 {
 	struct bt_audio_ep *ep;
 	uint8_t role;
+	int err;
 
 	BT_DBG("stream %p codec %p", stream, codec);
 
@@ -373,18 +369,12 @@ int bt_audio_stream_reconfig(struct bt_audio_stream *stream,
 
 	bt_audio_stream_attach(stream->conn, stream, ep, codec);
 
-	if (ep->type == BT_AUDIO_EP_LOCAL) {
-		bt_unicast_client_ep_set_state(ep, BT_AUDIO_EP_STATE_CODEC_CONFIGURED);
-	} else {
-		int err;
-
-		err = bt_unicast_client_config(stream, codec);
-		if (err) {
-			return err;
-		}
-
-		stream->codec = codec;
+	err = bt_unicast_client_config(stream, codec);
+	if (err) {
+		return err;
 	}
+
+	stream->codec = codec;
 
 	return 0;
 }
@@ -641,19 +631,6 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 	return 0;
 }
 
-static bool bt_audio_stream_enabling(struct bt_audio_stream *stream)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(enabling); i++) {
-		if (enabling[i] == stream) {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 int bt_audio_stream_enable(struct bt_audio_stream *stream,
 			   struct bt_codec_data *meta,
 			   size_t meta_count)
@@ -687,27 +664,7 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
 		return err;
 	}
 
-	if (stream->ep->type != BT_AUDIO_EP_LOCAL) {
-		return 0;
-	}
-
-	bt_unicast_client_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_ENABLING);
-
-	if (bt_audio_stream_enabling(stream)) {
-		return 0;
-	}
-
-	if (stream->ep->dir == BT_AUDIO_SOURCE) {
-		return 0;
-	}
-
-	/* After an ASE has been enabled, the Unicast Server acting as an Audio
-	 * Sink for that ASE shall autonomously initiate the Handshake
-	 * operation to transition the ASE to the Streaming state when the
-	 * Unicast Server is ready to consume audio data transmitted by the
-	 * Unicast Client.
-	 */
-	return bt_audio_stream_start(stream);
+	return 0;
 }
 
 int bt_audio_stream_metadata(struct bt_audio_stream *stream,
@@ -748,13 +705,6 @@ int bt_audio_stream_metadata(struct bt_audio_stream *stream,
 		return err;
 	}
 
-	if (stream->ep->type != BT_AUDIO_EP_LOCAL) {
-		return 0;
-	}
-
-	/* Set the state to the same state to trigger the notifications */
-	bt_unicast_client_ep_set_state(stream->ep, stream->ep->status.state);
-
 	return 0;
 }
 
@@ -794,25 +744,7 @@ int bt_audio_stream_disable(struct bt_audio_stream *stream)
 		return err;
 	}
 
-	if (stream->ep->type != BT_AUDIO_EP_LOCAL) {
-		return 0;
-	}
-
-	bt_unicast_client_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_DISABLING);
-
-	if (stream->ep->dir == BT_AUDIO_SOURCE) {
-		return 0;
-	}
-
-	/* If an ASE is in the Disabling state, and if the Unicast Server is in
-	 * the Audio Sink role, the Unicast Server shall autonomously initiate
-	 * the Receiver Stop Ready operation when the Unicast Server is ready
-	 * to stop consuming audio data transmitted for that ASE by the Unicast
-	 * Client. The Unicast Client in the Audio Source role should not stop
-	 * transmitting audio data until the Unicast Server transitions the ASE
-	 * to the QoS Configured state.
-	 */
-	return bt_audio_stream_stop(stream);
+	return 0;
 }
 
 int bt_audio_stream_start(struct bt_audio_stream *stream)
@@ -849,11 +781,7 @@ int bt_audio_stream_start(struct bt_audio_stream *stream)
 		return err;
 	}
 
-	if (stream->ep->type == BT_AUDIO_EP_LOCAL) {
-		bt_unicast_client_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_STREAMING);
-	}
-
-	return err;
+	return 0;
 }
 
 int bt_audio_stream_stop(struct bt_audio_stream *stream)
@@ -891,23 +819,7 @@ int bt_audio_stream_stop(struct bt_audio_stream *stream)
 		return err;
 	}
 
-	if (ep->type != BT_AUDIO_EP_LOCAL) {
-		return err;
-	}
-
-	/* If the Receiver Stop Ready operation has completed successfully the
-	 * Unicast Client or the Unicast Server may terminate a CIS established
-	 * for that ASE by following the Connected Isochronous Stream Terminate
-	 * procedure defined in Volume 3, Part C, Section 9.3.15.
-	 */
-	if (!bt_audio_stream_disconnect(stream)) {
-		return err;
-	}
-
-	bt_unicast_client_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
-	bt_audio_stream_iso_listen(stream);
-
-	return err;
+	return 0;
 }
 
 int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache)
@@ -952,21 +864,7 @@ int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache)
 		return err;
 	}
 
-	if (stream->ep->type != BT_AUDIO_EP_LOCAL) {
-		return err;
-	}
-
-	/* Any previously applied codec configuration may be cached by the
-	 * server.
-	 */
-	if (!cache) {
-		bt_unicast_client_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_RELEASING);
-	} else {
-		bt_unicast_client_ep_set_state(stream->ep,
-				      BT_AUDIO_EP_STATE_CODEC_CONFIGURED);
-	}
-
-	return err;
+	return 0;
 }
 
 int bt_audio_cig_terminate(struct bt_audio_unicast_group *group)

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -544,13 +544,13 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 		}
 
 		iso_qos = stream->iso->qos;
-		if (stream->ep->dir == BT_AUDIO_SINK) {
+		if (stream->ep->dir == BT_AUDIO_DIR_SINK) {
 			/* If the endpoint is a sink, then we need to
 			 * configure our TX parameters
 			 */
 			io = iso_qos->tx;
 			iso_qos->rx = NULL;
-		} else if (stream->ep->dir == BT_AUDIO_SOURCE) {
+		} else if (stream->ep->dir == BT_AUDIO_DIR_SOURCE) {
 			/* If the endpoint is a source, then we need to
 			 * configure our RX parameters
 			 */

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -139,13 +139,13 @@ static struct bt_iso_chan_ops unicast_client_iso_ops = {
 };
 
 static void unicast_client_ep_init(struct bt_audio_ep *ep, uint16_t handle,
-				   uint8_t id, uint8_t dir)
+				   uint8_t dir)
 {
-	BT_DBG("ep %p dir 0x%02x handle 0x%04x id 0x%02x", ep, dir, handle, id);
+	BT_DBG("ep %p dir 0x%02x handle 0x%04x", ep, dir, handle);
 
 	(void)memset(ep, 0, sizeof(*ep));
 	ep->handle = handle;
-	ep->status.id = id;
+	ep->status.id = 0U;
 	ep->iso.ops = &unicast_client_iso_ops;
 	ep->iso.qos = &ep->iso_qos;
 	ep->iso.qos->rx = &ep->iso_rx;
@@ -208,7 +208,7 @@ static struct bt_audio_ep *unicast_client_ep_new(struct bt_conn *conn,
 		struct bt_audio_ep *ep = &cache[i];
 
 		if (!ep->handle) {
-			unicast_client_ep_init(ep, handle, 0x00, dir);
+			unicast_client_ep_init(ep, handle, dir);
 			return ep;
 		}
 	}

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -30,7 +30,7 @@
 
 #if defined(CONFIG_BT_AUDIO_UNICAST_CLIENT)
 
-#define PAC_DIR_UNUSED(dir) ((dir) != BT_AUDIO_SINK && (dir) != BT_AUDIO_SOURCE)
+#define PAC_DIR_UNUSED(dir) ((dir) != BT_AUDIO_DIR_SINK && (dir) != BT_AUDIO_DIR_SOURCE)
 
 #define EP_ISO(_iso) CONTAINER_OF(_iso, struct bt_audio_ep, iso)
 
@@ -193,11 +193,11 @@ static struct bt_audio_ep *unicast_client_ep_new(struct bt_conn *conn,
 	index = bt_conn_index(conn);
 
 	switch (dir) {
-	case BT_AUDIO_SINK:
+	case BT_AUDIO_DIR_SINK:
 		cache = snks[index];
 		size = ARRAY_SIZE(snks[index]);
 		break;
-	case BT_AUDIO_SOURCE:
+	case BT_AUDIO_DIR_SOURCE:
 		cache = srcs[index];
 		size = ARRAY_SIZE(srcs[index]);
 		break;
@@ -1420,7 +1420,7 @@ int bt_unicast_client_start(struct bt_audio_stream *stream)
 	/* When initiated by the client, valid only if Direction field
 	 * parameter value = 0x02 (Server is Audio Source)
 	 */
-	if (ep->dir == BT_AUDIO_SOURCE) {
+	if (ep->dir == BT_AUDIO_DIR_SOURCE) {
 		err = unicast_client_ep_start(ep, buf);
 		if (err) {
 			return err;
@@ -1472,7 +1472,7 @@ int bt_unicast_client_stop(struct bt_audio_stream *stream)
 	/* When initiated by the client, valid only if Direction field
 	 * parameter value = 0x02 (Server is Audio Source)
 	 */
-	if (ep->dir == BT_AUDIO_SOURCE) {
+	if (ep->dir == BT_AUDIO_DIR_SOURCE) {
 		err = unicast_client_ep_stop(ep, buf);
 		if (err) {
 			return err;
@@ -1649,9 +1649,9 @@ static int unicast_client_ase_discover(struct bt_conn *conn,
 	params->read.func = unicast_client_ase_read_func;
 	params->read.handle_count = 0u;
 
-	if (params->dir == BT_AUDIO_SINK) {
+	if (params->dir == BT_AUDIO_DIR_SINK) {
 		params->read.by_uuid.uuid = ase_snk_uuid;
-	} else if (params->dir == BT_AUDIO_SOURCE) {
+	} else if (params->dir == BT_AUDIO_DIR_SOURCE) {
 		params->read.by_uuid.uuid = ase_src_uuid;
 	} else {
 		return -EINVAL;
@@ -1695,10 +1695,10 @@ static uint8_t unicast_client_pacs_context_read_func(struct bt_conn *conn,
 		}
 
 		switch (pac->dir) {
-		case BT_AUDIO_SINK:
+		case BT_AUDIO_DIR_SINK:
 			pac->context = sys_le16_to_cpu(context->snk);
 			break;
-		case BT_AUDIO_SOURCE:
+		case BT_AUDIO_DIR_SOURCE:
 			pac->context = sys_le16_to_cpu(context->src);
 			break;
 		default:
@@ -1909,9 +1909,9 @@ int bt_audio_discover(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	if (params->dir == BT_AUDIO_SINK) {
+	if (params->dir == BT_AUDIO_DIR_SINK) {
 		params->read.by_uuid.uuid = snk_uuid;
-	} else if (params->dir == BT_AUDIO_SOURCE) {
+	} else if (params->dir == BT_AUDIO_DIR_SOURCE) {
 		params->read.by_uuid.uuid = src_uuid;
 	} else {
 		return -EINVAL;

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -96,7 +96,7 @@ static void unicast_client_ep_iso_connected(struct bt_iso_chan *chan)
 {
 	struct bt_audio_ep *ep = EP_ISO(chan);
 
-	BT_DBG("stream %p ep %p type %u", chan, ep, ep != NULL ? ep->type : 0);
+	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
@@ -123,10 +123,6 @@ static void unicast_client_ep_iso_disconnected(struct bt_iso_chan *chan,
 		BT_WARN("No callback for stopped set");
 	}
 
-	if (ep->type != BT_AUDIO_EP_LOCAL) {
-		return;
-	}
-
 	bt_unicast_client_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
 
 	err = bt_audio_stream_iso_listen(stream);
@@ -142,14 +138,12 @@ static struct bt_iso_chan_ops unicast_client_iso_ops = {
 	.disconnected	= unicast_client_ep_iso_disconnected,
 };
 
-static void unicast_client_ep_init(struct bt_audio_ep *ep, uint8_t type,
-				   uint16_t handle, uint8_t id, uint8_t dir)
+static void unicast_client_ep_init(struct bt_audio_ep *ep, uint16_t handle,
+				   uint8_t id, uint8_t dir)
 {
-	BT_DBG("ep %p type 0x%02x handle 0x%04x id 0x%02x", ep, type, handle,
-	       id);
+	BT_DBG("ep %p dir 0x%02x handle 0x%04x id 0x%02x", ep, dir, handle, id);
 
 	(void)memset(ep, 0, sizeof(*ep));
-	ep->type = type;
 	ep->handle = handle;
 	ep->status.id = id;
 	ep->iso.ops = &unicast_client_iso_ops;
@@ -214,8 +208,7 @@ static struct bt_audio_ep *unicast_client_ep_new(struct bt_conn *conn,
 		struct bt_audio_ep *ep = &cache[i];
 
 		if (!ep->handle) {
-			unicast_client_ep_init(ep, BT_AUDIO_EP_REMOTE, handle,
-					       0x00, dir);
+			unicast_client_ep_init(ep, handle, 0x00, dir);
 			return ep;
 		}
 	}

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -30,12 +30,12 @@
 
 #if defined(CONFIG_BT_AUDIO_UNICAST_CLIENT)
 
-#define PAC_TYPE_UNUSED 0
+#define PAC_DIR_UNUSED(dir) ((dir) != BT_AUDIO_SINK && (dir) != BT_AUDIO_SOURCE)
 
 #define EP_ISO(_iso) CONTAINER_OF(_iso, struct bt_audio_ep, iso)
 
 static struct unicast_client_pac {
-	enum bt_audio_dir dir; /* type == PAC_TYPE_UNUSED means unused */
+	enum bt_audio_dir dir;
 	uint16_t context;
 	struct bt_codec codec;
 } cache[CONFIG_BT_MAX_CONN][CONFIG_BT_AUDIO_UNICAST_CLIENT_PAC_COUNT];
@@ -1690,7 +1690,7 @@ static uint8_t unicast_client_pacs_context_read_func(struct bt_conn *conn,
 	for (i = 0; i < CONFIG_BT_AUDIO_UNICAST_CLIENT_PAC_COUNT; i++) {
 		struct unicast_client_pac *pac = &cache[index][i];
 
-		if (pac->dir == PAC_TYPE_UNUSED) {
+		if (PAC_DIR_UNUSED(pac->dir)) {
 			continue;
 		}
 
@@ -1744,7 +1744,7 @@ static struct unicast_client_pac *unicast_client_pac_alloc(struct bt_conn *conn,
 	for (i = 0; i < CONFIG_BT_AUDIO_UNICAST_CLIENT_PAC_COUNT; i++) {
 		struct unicast_client_pac *pac = &cache[index][i];
 
-		if (pac->dir == PAC_TYPE_UNUSED) {
+		if (PAC_DIR_UNUSED(pac->dir)) {
 			pac->dir = dir;
 			return pac;
 		}
@@ -1875,7 +1875,7 @@ static void unicast_client_pac_reset(struct bt_conn *conn)
 	for (i = 0; i < CONFIG_BT_AUDIO_UNICAST_CLIENT_PAC_COUNT; i++) {
 		struct unicast_client_pac *pac = &cache[index][i];
 
-		if (pac->dir != PAC_TYPE_UNUSED) {
+		if (!PAC_DIR_UNUSED(pac->dir)) {
 			(void)memset(pac, 0, sizeof(*pac));
 		}
 	}

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -53,7 +53,7 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-int bt_audio_unicast_server_location_changed(enum bt_audio_pac_type type)
+int bt_audio_unicast_server_location_changed(enum bt_audio_dir type)
 {
 	return bt_pacs_location_changed(type);
 }

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -53,8 +53,8 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 }
 
 #if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
-int bt_audio_unicast_server_location_changed(enum bt_audio_dir type)
+int bt_audio_unicast_server_location_changed(enum bt_audio_dir dir)
 {
-	return bt_pacs_location_changed(type);
+	return bt_pacs_location_changed(dir);
 }
 #endif /* CONFIG_BT_PAC_SNK_LOC || CONFIG_BT_PAC_SRC_LOC */

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -269,7 +269,7 @@ static int cmd_select_unicast(const struct shell *sh, size_t argc, char *argv[])
 
 static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 					struct bt_audio_ep *ep,
-					enum bt_audio_pac_type type,
+					enum bt_audio_dir type,
 					struct bt_audio_capability *cap,
 					struct bt_codec *codec)
 {

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -437,7 +437,7 @@ static struct bt_audio_capability_ops lc3_ops = {
 
 static struct bt_audio_capability caps[MAX_PAC] = {
 	{
-		.dir = BT_AUDIO_SOURCE,
+		.dir = BT_AUDIO_DIR_SOURCE,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u,
@@ -446,7 +446,7 @@ static struct bt_audio_capability caps[MAX_PAC] = {
 		.ops = &lc3_ops,
 	},
 	{
-		.dir = BT_AUDIO_SINK,
+		.dir = BT_AUDIO_DIR_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u,
@@ -462,13 +462,13 @@ static uint8_t stream_dir(const struct bt_audio_stream *stream)
 {
 	for (size_t i = 0; i < ARRAY_SIZE(snks); i++) {
 		if (snks[i] != NULL && stream->ep == snks[i]) {
-			return BT_AUDIO_SINK;
+			return BT_AUDIO_DIR_SINK;
 		}
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(srcs); i++) {
 		if (srcs[i] != NULL && stream->ep == srcs[i]) {
-			return BT_AUDIO_SOURCE;
+			return BT_AUDIO_DIR_SOURCE;
 		}
 	}
 
@@ -482,7 +482,7 @@ static void add_codec(struct bt_codec *codec, uint8_t index, enum bt_audio_dir d
 
 	print_codec(codec);
 
-	if (dir != BT_AUDIO_SINK && dir != BT_AUDIO_SOURCE) {
+	if (dir != BT_AUDIO_DIR_SINK && dir != BT_AUDIO_DIR_SOURCE) {
 		return;
 	}
 
@@ -515,9 +515,9 @@ static void discover_cb(struct bt_conn *conn, struct bt_codec *codec,
 	}
 
 	if (ep) {
-		if (params->dir == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_DIR_SINK) {
 			add_sink(ep, params->num_eps);
-		} else if (params->dir == BT_AUDIO_SOURCE) {
+		} else if (params->dir == BT_AUDIO_DIR_SOURCE) {
 			add_source(ep, params->num_eps);
 		}
 
@@ -539,9 +539,9 @@ static void discover_all(struct bt_conn *conn, struct bt_codec *codec,
 	}
 
 	if (ep) {
-		if (params->dir == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_DIR_SINK) {
 			add_sink(ep, params->num_eps);
-		} else if (params->dir == BT_AUDIO_SOURCE) {
+		} else if (params->dir == BT_AUDIO_DIR_SOURCE) {
 			add_source(ep, params->num_eps);
 		}
 
@@ -549,11 +549,11 @@ static void discover_all(struct bt_conn *conn, struct bt_codec *codec,
 	}
 
 	/* Sinks discovery complete, now discover sources */
-	if (params->dir == BT_AUDIO_SINK) {
+	if (params->dir == BT_AUDIO_DIR_SINK) {
 		int err;
 
 		params->func = discover_cb;
-		params->dir = BT_AUDIO_SOURCE;
+		params->dir = BT_AUDIO_DIR_SOURCE;
 
 		err = bt_audio_discover(default_conn, params);
 		if (err) {
@@ -578,14 +578,14 @@ static int cmd_discover(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	params.func = discover_all;
-	params.dir = BT_AUDIO_SINK;
+	params.dir = BT_AUDIO_DIR_SINK;
 
 	if (argc > 1) {
 		if (!strcmp(argv[1], "sink")) {
 			params.func = discover_cb;
 		} else if (!strcmp(argv[1], "source")) {
 			params.func = discover_cb;
-			params.dir = BT_AUDIO_SOURCE;
+			params.dir = BT_AUDIO_DIR_SOURCE;
 		} else {
 			shell_error(sh, "Unsupported dir: %s", argv[1]);
 			return -ENOEXEC;
@@ -636,10 +636,10 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	if (!strcmp(argv[1], "sink")) {
-		dir = BT_AUDIO_SINK;
+		dir = BT_AUDIO_DIR_SINK;
 		ep = snks[index];
 	} else if (!strcmp(argv[1], "source")) {
-		dir = BT_AUDIO_SOURCE;
+		dir = BT_AUDIO_DIR_SOURCE;
 		ep = srcs[index];
 	} else {
 		shell_error(sh, "Unsupported dir: %s", argv[1]);

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -269,14 +269,14 @@ static int cmd_select_unicast(const struct shell *sh, size_t argc, char *argv[])
 
 static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 					struct bt_audio_ep *ep,
-					enum bt_audio_dir type,
+					enum bt_audio_dir dir,
 					struct bt_audio_capability *cap,
 					struct bt_codec *codec)
 {
 	int i;
 
-	shell_print(ctx_shell, "ASE Codec Config: conn %p ep %p type %u, cap %p",
-		    conn, ep, type, cap);
+	shell_print(ctx_shell, "ASE Codec Config: conn %p ep %p dir %u, cap %p",
+		    conn, ep, dir, cap);
 
 	print_codec(codec);
 
@@ -437,7 +437,7 @@ static struct bt_audio_capability_ops lc3_ops = {
 
 static struct bt_audio_capability caps[MAX_PAC] = {
 	{
-		.type = BT_AUDIO_SOURCE,
+		.dir = BT_AUDIO_SOURCE,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u,
@@ -446,7 +446,7 @@ static struct bt_audio_capability caps[MAX_PAC] = {
 		.ops = &lc3_ops,
 	},
 	{
-		.type = BT_AUDIO_SINK,
+		.dir = BT_AUDIO_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0u, 60u, 20000u, 40000u,
@@ -476,18 +476,18 @@ static uint8_t stream_dir(const struct bt_audio_stream *stream)
 	return 0;
 }
 
-static void add_codec(struct bt_codec *codec, uint8_t index, uint8_t type)
+static void add_codec(struct bt_codec *codec, uint8_t index, enum bt_audio_dir dir)
 {
-	shell_print(ctx_shell, "#%u: codec %p type 0x%02x", index, codec, type);
+	shell_print(ctx_shell, "#%u: codec %p dir 0x%02x", index, codec, dir);
 
 	print_codec(codec);
 
-	if (type != BT_AUDIO_SINK && type != BT_AUDIO_SOURCE) {
+	if (dir != BT_AUDIO_SINK && dir != BT_AUDIO_SOURCE) {
 		return;
 	}
 
 	if (index < CONFIG_BT_AUDIO_UNICAST_CLIENT_PAC_COUNT) {
-		rcodecs[type - 1][index] = codec;
+		rcodecs[dir - 1][index] = codec;
 	}
 }
 
@@ -510,14 +510,14 @@ static void discover_cb(struct bt_conn *conn, struct bt_codec *codec,
 			struct bt_audio_discover_params *params)
 {
 	if (codec != NULL) {
-		add_codec(codec, params->num_caps, params->type);
+		add_codec(codec, params->num_caps, params->dir);
 		return;
 	}
 
 	if (ep) {
-		if (params->type == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_SINK) {
 			add_sink(ep, params->num_eps);
-		} else if (params->type == BT_AUDIO_SOURCE) {
+		} else if (params->dir == BT_AUDIO_SOURCE) {
 			add_source(ep, params->num_eps);
 		}
 
@@ -534,14 +534,14 @@ static void discover_all(struct bt_conn *conn, struct bt_codec *codec,
 			struct bt_audio_discover_params *params)
 {
 	if (codec != NULL) {
-		add_codec(codec, params->num_caps, params->type);
+		add_codec(codec, params->num_caps, params->dir);
 		return;
 	}
 
 	if (ep) {
-		if (params->type == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_SINK) {
 			add_sink(ep, params->num_eps);
-		} else if (params->type == BT_AUDIO_SOURCE) {
+		} else if (params->dir == BT_AUDIO_SOURCE) {
 			add_source(ep, params->num_eps);
 		}
 
@@ -549,11 +549,11 @@ static void discover_all(struct bt_conn *conn, struct bt_codec *codec,
 	}
 
 	/* Sinks discovery complete, now discover sources */
-	if (params->type == BT_AUDIO_SINK) {
+	if (params->dir == BT_AUDIO_SINK) {
 		int err;
 
 		params->func = discover_cb;
-		params->type = BT_AUDIO_SOURCE;
+		params->dir = BT_AUDIO_SOURCE;
 
 		err = bt_audio_discover(default_conn, params);
 		if (err) {
@@ -578,16 +578,16 @@ static int cmd_discover(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	params.func = discover_all;
-	params.type = BT_AUDIO_SINK;
+	params.dir = BT_AUDIO_SINK;
 
 	if (argc > 1) {
 		if (!strcmp(argv[1], "sink")) {
 			params.func = discover_cb;
 		} else if (!strcmp(argv[1], "source")) {
 			params.func = discover_cb;
-			params.type = BT_AUDIO_SOURCE;
+			params.dir = BT_AUDIO_SOURCE;
 		} else {
-			shell_error(sh, "Unsupported type: %s", argv[1]);
+			shell_error(sh, "Unsupported dir: %s", argv[1]);
 			return -ENOEXEC;
 		}
 	}
@@ -642,7 +642,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char *argv[])
 		dir = BT_AUDIO_SOURCE;
 		ep = srcs[index];
 	} else {
-		shell_error(sh, "Unsupported type: %s", argv[1]);
+		shell_error(sh, "Unsupported dir: %s", argv[1]);
 		return -ENOEXEC;
 	}
 
@@ -1421,7 +1421,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(audio_cmds,
 		      cmd_term_broadcast_sink, 1, 0),
 #endif /* CONFIG_BT_AUDIO_BROADCAST_SINK */
 #if defined(CONFIG_BT_AUDIO_UNICAST_CLIENT)
-	SHELL_CMD_ARG(discover, NULL, "[type: sink, source]",
+	SHELL_CMD_ARG(discover, NULL, "[dir: sink, source]",
 		      cmd_discover, 1, 1),
 	SHELL_CMD_ARG(preset, NULL, "[preset]", cmd_preset, 1, 1),
 	SHELL_CMD_ARG(config, NULL,

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -104,7 +104,7 @@ static void add_remote_codec(struct bt_codec *codec, int index,
 
 	print_codec(codec);
 
-	if (dir != BT_AUDIO_SINK && dir != BT_AUDIO_SOURCE) {
+	if (dir != BT_AUDIO_DIR_SINK && dir != BT_AUDIO_DIR_SOURCE) {
 		return;
 	}
 
@@ -133,7 +133,7 @@ static void discover_sink_cb(struct bt_conn *conn,
 	}
 
 	if (ep != NULL) {
-		if (params->dir == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_DIR_SINK) {
 			add_remote_sink(ep, params->num_eps);
 			endpoint_found = true;
 		} else {
@@ -229,7 +229,7 @@ static void discover_sink(void)
 	int err;
 
 	params.func = discover_sink_cb;
-	params.dir = BT_AUDIO_SINK;
+	params.dir = BT_AUDIO_DIR_SINK;
 
 	err = bt_audio_discover(default_conn, &params);
 	if (err != 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -97,13 +97,14 @@ static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)
 	g_sinks[index] = ep;
 }
 
-static void add_remote_codec(struct bt_codec *codec, int index, uint8_t type)
+static void add_remote_codec(struct bt_codec *codec, int index,
+			     enum bt_audio_dir dir)
 {
-	printk("#%u: codec %p type 0x%02x\n", index, codec, type);
+	printk("#%u: codec %p dir 0x%02x\n", index, codec, dir);
 
 	print_codec(codec);
 
-	if (type != BT_AUDIO_SINK && type != BT_AUDIO_SOURCE) {
+	if (dir != BT_AUDIO_SINK && dir != BT_AUDIO_SOURCE) {
 		return;
 	}
 
@@ -126,17 +127,17 @@ static void discover_sink_cb(struct bt_conn *conn,
 	}
 
 	if (codec != NULL) {
-		add_remote_codec(codec, params->num_caps, params->type);
+		add_remote_codec(codec, params->num_caps, params->dir);
 		codec_found = true;
 		return;
 	}
 
 	if (ep != NULL) {
-		if (params->type == BT_AUDIO_SINK) {
+		if (params->dir == BT_AUDIO_SINK) {
 			add_remote_sink(ep, params->num_eps);
 			endpoint_found = true;
 		} else {
-			FAIL("Invalid param type: %u\n", params->type);
+			FAIL("Invalid param dir: %u\n", params->dir);
 		}
 
 		return;
@@ -228,7 +229,7 @@ static void discover_sink(void)
 	int err;
 
 	params.func = discover_sink_cb;
-	params.type = BT_AUDIO_SINK;
+	params.dir = BT_AUDIO_SINK;
 
 	err = bt_audio_discover(default_conn, &params);
 	if (err != 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -169,7 +169,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 static void init(void)
 {
 	static struct bt_audio_capability caps = {
-		.dir = BT_AUDIO_SINK,
+		.dir = BT_AUDIO_DIR_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000, 40000, 40000),
@@ -210,7 +210,7 @@ static void set_location(void)
 	int err;
 
 	if (IS_ENABLED(CONFIG_BT_PAC_SNK_LOC)) {
-		err = bt_audio_capability_set_location(BT_AUDIO_SINK,
+		err = bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
 						       BT_AUDIO_LOCATION_FRONT_CENTER);
 		if (err != 0) {
 			FAIL("Failed to set sink location (err %d)\n", err);
@@ -219,7 +219,7 @@ static void set_location(void)
 	}
 
 	if (IS_ENABLED(CONFIG_BT_PAC_SRC_LOC)) {
-		err = bt_audio_capability_set_location(BT_AUDIO_SINK,
+		err = bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
 						       (BT_AUDIO_LOCATION_FRONT_LEFT |
 							BT_AUDIO_LOCATION_FRONT_RIGHT));
 		if (err != 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -34,12 +34,12 @@ CREATE_FLAG(flag_stream_configured);
 
 static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 					struct bt_audio_ep *ep,
-					enum bt_audio_dir type,
+					enum bt_audio_dir dir,
 					struct bt_audio_capability *cap,
 					struct bt_codec *codec)
 {
-	printk("ASE Codec Config: conn %p ep %p type %u, cap %p\n",
-	       conn, ep, type, cap);
+	printk("ASE Codec Config: conn %p ep %p dir %u, cap %p\n",
+	       conn, ep, dir, cap);
 
 	print_codec(codec);
 
@@ -169,7 +169,7 @@ BT_CONN_CB_DEFINE(conn_callbacks) = {
 static void init(void)
 {
 	static struct bt_audio_capability caps = {
-		.type = BT_AUDIO_SINK,
+		.dir = BT_AUDIO_SINK,
 		.pref = BT_AUDIO_CAPABILITY_PREF(
 				BT_AUDIO_CAPABILITY_UNFRAMED_SUPPORTED,
 				BT_GAP_LE_PHY_2M, 0x02, 10, 40000, 40000, 40000, 40000),

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -34,7 +34,7 @@ CREATE_FLAG(flag_stream_configured);
 
 static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 					struct bt_audio_ep *ep,
-					enum bt_audio_pac_type type,
+					enum bt_audio_dir type,
 					struct bt_audio_capability *cap,
 					struct bt_codec *codec)
 {


### PR DESCRIPTION
The goal of this PR was to rename the `enum bt_audio_pac_type`. To do this properly, some cleanup had to be done to avoid confusion with the (unused) endpoint type. Furthermore, the implementation used the term `type` and `dir` interchangeably, so the code was also updated to be more consistent.  

fixes https://github.com/zephyrproject-rtos/zephyr/issues/43693