### PR TITLE
[DNM] manifest: hal_nxp: update NXP hal to use new pin control headers

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: dcfcee4242d7a8ffa1cae3b22d9bb1d68fb38083
+      revision: a3d46260cc3544777c5ca2105f9c2b84c182c04c
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
### Note: this PR was merged before #43826, which means it effectively updated the NXP HAL to use v2.11 of MCUX SDK.


Pin control DTSI files need /omit-if-no-ref/ property to reduce
generated devicetree size and improve build times.

Fixes #44262

Dependent on #43826, due to the ordering of commits in NXP's HAL
Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>