### PR TITLE
Cortex-M fix MPU livelock when stack overflowing on hardware-stacked registers for an SVC

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -338,6 +338,17 @@ static uint32_t mem_manage_fault(z_arch_esf_t *esf, int from_hard_fault,
 #endif /* CONFIG_MPU_STACK_GUARD || CONFIG_USERSPACE */
 	}
 
+	/* When we were handling this fault, we may have triggered a fp
+	 * lazy stacking Memory Manage fault. At the time of writing, this
+	 * can happen when printing.  If that's true, we should clear the
+	 * pending flag in addition to the clearing the reason for the fault
+	 */
+#if defined(CONFIG_ARMV7_M_ARMV8_M_FP)
+	if ((SCB->CFSR & SCB_CFSR_MLSPERR_Msk) != 0) {
+		SCB->SHCSR &= ~SCB_SHCSR_MEMFAULTPENDED_Msk;
+	}
+#endif /* CONFIG_ARMV7_M_ARMV8_M_FP */
+
 	/* clear MMFSR sticky bits */
 	SCB->CFSR |= SCB_CFSR_MEMFAULTSR_Msk;
 

--- a/arch/arm/core/aarch32/cortex_m/thread_abort.c
+++ b/arch/arm/core/aarch32/cortex_m/thread_abort.c
@@ -40,6 +40,12 @@ void z_impl_k_thread_abort(k_tid_t thread)
 			 * is not an implicit scheduler invocation.
 			 */
 			SCB->ICSR |= SCB_ICSR_PENDSVSET_Msk;
+			/* Clear any system calls that may be pending
+			 * as they have a higher priority than the PendSV
+			 * handler and will check the stack of the thread
+			 * being aborted.
+			 */
+			SCB->SHCSR &= ~SCB_SHCSR_SVCALLPENDED_Msk;
 		}
 	}
 


### PR DESCRIPTION
I had fun debugging this one, see #42496 for details.

That's a long thread, so I'll try to summarize here as best I can.

As the titles says, when you cause a the hardware to trigger a stack overflow during a svc, you can end up in a livelock situation. In particular, this livelock is caused by implementing `k_sys_fatal_error_handler()` to do something sensible: kill the thread that caused the stack overflow. On stack overflows, we reset the stack pointer to it's "stack full" value. This means that when tail chaining the svc, we have arbitrary, probably nonsense, values in the saved exception state. In some circumstances, this will cause the svc to cause a hard fault, which again invokes `k_sys_fatal_error_handler` which tries to kill the thread, again. Since the thread was already dead this does not change the state of the system, and the svc -> hardfault -> svc cycle repeats, livelocking the system.

The first commit resolves this issue by clearing the pending svc when killing the current thread.
The second commit resolves a subsequent spurious mpu fault that occurs because the mpu fault pushes fpu registers and they could also cause an mpu fault. This does not propagate further, as once the the second fault is triggered, it clears the lazy stacking enabled flag.

Resolves #42496