### PR TITLE
Revert "manifest: hal_nxp: update NXP hal to use new pin control headers"

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: a3d46260cc3544777c5ca2105f9c2b84c182c04c
+      revision: dcfcee4242d7a8ffa1cae3b22d9bb1d68fb38083
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION

This reverts commit dcac0ce0aa53ae69657e1ceccf011f772338c108.
I merged this without noticing a DNM tag on it.
