### PR TITLE
Bluetooth: Controller: Offset Coded PHY scan window

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -57,6 +57,8 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 static uint8_t disable(uint8_t handle);
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
+#define IS_PHY_ENABLED(scan_ctx, scan_phy) ((scan_ctx)->lll.phy & (scan_phy))
+
 static uint8_t is_scan_update(uint8_t handle, uint16_t duration,
 			      uint16_t period, struct ll_scan_set **scan,
 			      struct node_rx_pdu **node_rx_scan_term);
@@ -114,6 +116,9 @@ uint8_t ll_scan_params_set(uint8_t type, uint16_t interval, uint16_t window,
 		return 0;
 	}
 
+	/* If phy assigned is PHY_1M or PHY_CODED, then scanning on that
+	 * PHY is enabled.
+	 */
 	lll->phy = phy;
 
 #else /* !CONFIG_BT_CTLR_ADV_EXT */
@@ -196,7 +201,7 @@ uint8_t ll_scan_enable(uint8_t enable)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	if (!is_coded_phy || (scan->lll.phy & PHY_1M))
+	if (!is_coded_phy || IS_PHY_ENABLED(scan, PHY_1M))
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	{
 		err = duration_period_setup(scan, duration, period,
@@ -244,7 +249,7 @@ uint8_t ll_scan_enable(uint8_t enable)
 
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	if (!is_coded_phy || (scan->lll.phy & PHY_1M))
+	if (!is_coded_phy || IS_PHY_ENABLED(scan, PHY_1M))
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	{
 		err = duration_period_update(scan, is_update_1m);
@@ -266,7 +271,7 @@ uint8_t ll_scan_enable(uint8_t enable)
 	}
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-	if (!is_coded_phy || (scan->lll.phy & PHY_1M))
+	if (!is_coded_phy || IS_PHY_ENABLED(scan, PHY_1M))
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 	{
@@ -446,7 +451,7 @@ uint8_t ull_scan_enable(struct ll_scan_set *scan)
 		const struct ll_scan_set *scan_1m;
 
 		scan_1m = ull_scan_set_get(SCAN_HANDLE_1M);
-		if (scan_1m->lll.phy & PHY_1M) {
+		if (IS_PHY_ENABLED(scan_1m, PHY_1M)) {
 			ticks_offset = scan_1m->lll.ticks_window +
 				       (EVENT_TICKER_RES_MARGIN_US << 1);
 		} else {
@@ -597,7 +602,7 @@ void ull_scan_term_dequeue(uint8_t handle)
 		struct ll_scan_set *scan_coded;
 
 		scan_coded = ull_scan_set_get(SCAN_HANDLE_PHY_CODED);
-		if (scan_coded->lll.phy & PHY_CODED) {
+		if (IS_PHY_ENABLED(scan_coded, PHY_CODED)) {
 			uint8_t err;
 
 			err = disable(SCAN_HANDLE_PHY_CODED);
@@ -607,7 +612,7 @@ void ull_scan_term_dequeue(uint8_t handle)
 		struct ll_scan_set *scan_1m;
 
 		scan_1m = ull_scan_set_get(SCAN_HANDLE_1M);
-		if (scan_1m->lll.phy & PHY_1M) {
+		if (IS_PHY_ENABLED(scan_1m, PHY_1M)) {
 			uint8_t err;
 
 			err = disable(SCAN_HANDLE_1M);


### PR DESCRIPTION
Offset the Coded PHY scan window by 1M PHY scan window
duration so that when 1M PHY scan window is less than
scan interval then Coded PHY scan window can utilize the
radio thereafter for its scan window duration. For
example, with 20 ms interval and 10 ms window there can
be 10 ms 1M PHY followed by 10 ms of Coded PHY scanning.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>