### PR TITLE
Bluetooth: Controller: Fix use of uninitialized secondary PHY

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -959,12 +959,16 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn_lll->max_rx_time = PDU_DC_MAX_US(PDU_DC_PAYLOAD_SIZE_MIN,
 						      PHY_1M);
 #if defined(CONFIG_BT_CTLR_ADV_EXT)
-		conn_lll->max_tx_time = MAX(conn_lll->max_tx_time,
-					    PDU_DC_MAX_US(PDU_DC_PAYLOAD_SIZE_MIN,
-							  lll->phy_s));
-		conn_lll->max_rx_time = MAX(conn_lll->max_rx_time,
-					    PDU_DC_MAX_US(PDU_DC_PAYLOAD_SIZE_MIN,
-							  lll->phy_s));
+		if (pdu_adv->type == PDU_ADV_TYPE_EXT_IND) {
+			conn_lll->max_tx_time =
+				MAX(conn_lll->max_tx_time,
+				    PDU_DC_MAX_US(PDU_DC_PAYLOAD_SIZE_MIN,
+						  lll->phy_s));
+			conn_lll->max_rx_time =
+				MAX(conn_lll->max_rx_time,
+				    PDU_DC_MAX_US(PDU_DC_PAYLOAD_SIZE_MIN,
+						  lll->phy_s));
+		}
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif


### PR DESCRIPTION
Fix connectable advertising to not use uninitialized
secondary PHY value to set the max_tx_time and max_rx_time
for a non-extended connectable advertising context.

The symptoms being Data Length Update event being generated
when peer central initiated Data Length Update Procedure
does not change from default 27 byte 328 us values.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>