### PR TITLE
Bluetooth: ISO: Add TS flag to ISO recv

### DIFF
--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -184,19 +184,29 @@ struct bt_iso_chan_path {
 enum {
 	/** The ISO packet is valid. */
 	BT_ISO_FLAGS_VALID = BIT(0),
+
 	/** @brief The ISO packet may possibly contain errors.
 	 *
 	 * May be caused by a failed CRC check or if missing a part of the SDU.
 	 */
 	BT_ISO_FLAGS_ERROR = BIT(1),
+
 	/** The ISO packet was lost. */
-	BT_ISO_FLAGS_LOST = BIT(2)
+	BT_ISO_FLAGS_LOST = BIT(2),
+
+	/** Timestamp is valid
+	 *
+	 * If not set, then the bt_iso_recv_info.ts value is not valid, and
+	 * should not be used.
+	 */
+	BT_ISO_FLAGS_TS = BIT(3)
 };
 
 /** @brief ISO Meta Data structure for received ISO packets. */
 struct bt_iso_recv_info {
-	/** ISO timestamp - valid only if the Bluetooth controller includes it
-	 *  If time stamp is not present this value will be 0 on all iso packets
+	/** ISO timestamp
+	 *
+	 * Only valid if @p flags has the BT_ISO_FLAGS_TS bit set.
 	 */
 	uint32_t ts;
 

--- a/include/bluetooth/iso.h
+++ b/include/bluetooth/iso.h
@@ -180,17 +180,17 @@ struct bt_iso_chan_path {
 	uint8_t				cc[0];
 };
 
-/** ISO packet status flags */
+/** ISO packet status flag bits */
 enum {
 	/** The ISO packet is valid. */
-	BT_ISO_FLAGS_VALID,
+	BT_ISO_FLAGS_VALID = BIT(0),
 	/** @brief The ISO packet may possibly contain errors.
 	 *
 	 * May be caused by a failed CRC check or if missing a part of the SDU.
 	 */
-	BT_ISO_FLAGS_ERROR,
+	BT_ISO_FLAGS_ERROR = BIT(1),
 	/** The ISO packet was lost. */
-	BT_ISO_FLAGS_LOST
+	BT_ISO_FLAGS_LOST = BIT(2)
 };
 
 /** @brief ISO Meta Data structure for received ISO packets. */
@@ -203,7 +203,7 @@ struct bt_iso_recv_info {
 	/** ISO packet sequence number of the first fragment in the SDU */
 	uint16_t sn;
 
-	/** ISO packet flags (BT_ISO_FLAGS_*) */
+	/** ISO packet flags bitfield (BT_ISO_FLAGS_*) */
 	uint8_t flags;
 };
 

--- a/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
@@ -181,7 +181,7 @@ static void iso_recv(struct bt_iso_chan *chan,
 
 	/* NOTE: The packets received may be on different BISes */
 
-	if (info->flags == BT_ISO_FLAGS_VALID) {
+	if (info->flags & BT_ISO_FLAGS_VALID) {
 		stats_current_sync.iso_recv_count++;
 		stats_overall.iso_recv_count++;
 		stats_latest_arr[stats_latest_arr_pos++] = true;

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -216,7 +216,7 @@ static void iso_recv(struct bt_iso_chan *chan,
 
 	/* NOTE: The packets received may be on different CISes */
 
-	if (info->flags == BT_ISO_FLAGS_VALID) {
+	if (info->flags & BT_ISO_FLAGS_VALID) {
 		stats_current_conn.iso_recv_count++;
 		stats_overall.iso_recv_count++;
 		stats_latest_arr[stats_latest_arr_pos++] = true;

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -620,6 +620,8 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 	switch (pb) {
 	case BT_ISO_START:
 	case BT_ISO_SINGLE:
+		iso_info(buf)->flags = 0;
+
 		/* The ISO_Data_Load field contains either the first fragment
 		 * of an SDU or a complete SDU.
 		 */
@@ -630,6 +632,7 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 			iso_info(buf)->ts = sys_le32_to_cpu(ts_hdr->ts);
 
 			hdr = &ts_hdr->data;
+			iso_info(buf)->flags |= BT_ISO_FLAGS_TS;
 		} else {
 			hdr = net_buf_pull_mem(buf, sizeof(*hdr));
 			/* TODO: Generate a timestamp? */
@@ -641,8 +644,6 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		len = bt_iso_pkt_len(len);
 		pkt_seq_no = sys_le16_to_cpu(hdr->sn);
 		iso_info(buf)->sn = pkt_seq_no;
-
-		iso_info(buf)->flags = 0;
 		if (flags == BT_ISO_DATA_VALID) {
 			iso_info(buf)->flags |= BT_ISO_FLAGS_VALID;
 		} else if (flags == BT_ISO_DATA_INVALID) {

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -642,12 +642,13 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 		pkt_seq_no = sys_le16_to_cpu(hdr->sn);
 		iso_info(buf)->sn = pkt_seq_no;
 
+		iso_info(buf)->flags = 0;
 		if (flags == BT_ISO_DATA_VALID) {
-			iso_info(buf)->flags = BT_ISO_FLAGS_VALID;
+			iso_info(buf)->flags |= BT_ISO_FLAGS_VALID;
 		} else if (flags == BT_ISO_DATA_INVALID) {
-			iso_info(buf)->flags = BT_ISO_FLAGS_ERROR;
+			iso_info(buf)->flags |= BT_ISO_FLAGS_ERROR;
 		} else if (flags == BT_ISO_DATA_NOP) {
-			iso_info(buf)->flags = BT_ISO_FLAGS_LOST;
+			iso_info(buf)->flags |= BT_ISO_FLAGS_LOST;
 		} else {
 			BT_WARN("Invalid ISO packet status flag: %u", flags);
 			iso_info(buf)->flags = 0;


### PR DESCRIPTION
Add a flag to tell the application that the timestamp value is valid. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/44283