### PR TITLE
Bluetooth: Audio: Add recv_info to audio recv callback

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1275,9 +1275,15 @@ struct bt_audio_stream_ops {
 	 *  This callback is only used if the ISO data path is HCI.
 	 *
 	 *  @param stream Stream object.
-	 *  @param buf  Buffer containing incoming audio data.
+	 *  @param info   Pointer to the metadata for the buffer. The lifetime
+	 *                of the pointer is linked to the lifetime of the
+	 *                net_buf. Metadata such as sequence number and
+	 *                timestamp can be provided by the bluetooth controller.
+	 *  @param buf    Buffer containing incoming audio data.
 	 */
-	void (*recv)(struct bt_audio_stream *stream, struct net_buf *buf);
+	void (*recv)(struct bt_audio_stream *stream,
+		     const struct bt_iso_recv_info *info,
+		     struct net_buf *buf);
 #endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SINK */
 
 #if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SOURCE)

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -37,7 +37,9 @@ static void stream_stopped_cb(struct bt_audio_stream *stream)
 	printk("Stream %p stopped\n", stream);
 }
 
-static void stream_recv_cb(struct bt_audio_stream *stream, struct net_buf *buf)
+static void stream_recv_cb(struct bt_audio_stream *stream,
+			   const struct bt_iso_recv_info *info,
+			   struct net_buf *buf)
 {
 	static uint32_t recv_cnt;
 

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -276,23 +276,25 @@ static struct bt_audio_capability_ops lc3_ops = {
 
 #if defined(CONFIG_LIBLC3CODEC)
 
-static void stream_recv_lc3_codec(struct bt_audio_stream *stream, struct net_buf *buf)
+static void stream_recv_lc3_codec(struct bt_audio_stream *stream,
+				  const struct bt_iso_recv_info *info,
+				  struct net_buf *buf)
 {
+	const uint8_t *in_buf;
 	uint8_t err = -1;
-
-	/* TODO: If there is a way to know if the controller supports indicating errors in the
-	 *       payload one could feed that into bad-frame-indicator. The HCI layer allows to
-	 *       include this information, but currently there is no controller support.
-	 *       Here it is assumed that reveiving a zero-length payload means a lost frame -
-	 *       but actually it could just as well indicate a pause in the stream.
-	 */
-	const uint8_t bad_frame_indicator = buf->len == 0 ? 1 : 0;
-	uint8_t *in_buf = (bad_frame_indicator ? NULL : buf->data);
 	const int octets_per_frame = buf->len / frames_per_sdu;
 
 	if (lc3_decoder == NULL) {
 		printk("LC3 decoder not setup, cannot decode data.\n");
 		return;
+	}
+
+	if (info->flags != BT_ISO_FLAGS_VALID) {
+		printk("Bad packet: 0x%02X\n", info->flags);
+
+		in_buf = NULL;
+	} else {
+		in_buf = buf->data;
 	}
 
 	/* This code is to demonstrate the use of the LC3 codec. On an actual implementation
@@ -325,7 +327,9 @@ static void stream_recv_lc3_codec(struct bt_audio_stream *stream, struct net_buf
 
 #else
 
-static void stream_recv(struct bt_audio_stream *stream, struct net_buf *buf)
+static void stream_recv(struct bt_audio_stream *stream,
+			const struct bt_iso_recv_info *info,
+			struct net_buf *buf)
 {
 	printk("Incoming audio on stream %p len %u\n", stream, buf->len);
 }

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -290,7 +290,7 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 	BT_DBG("stream %p ep %p len %zu", chan, ep, net_buf_frags_len(buf));
 
 	if (ops != NULL && ops->recv != NULL) {
-		ops->recv(ep->stream, buf);
+		ops->recv(ep->stream, info, buf);
 	} else {
 		BT_WARN("No callback for recv set");
 	}

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -99,7 +99,7 @@ static void broadcast_sink_iso_recv(struct bt_iso_chan *chan,
 	BT_DBG("stream %p ep %p len %zu", chan, ep, net_buf_frags_len(buf));
 
 	if (ops != NULL && ops->recv != NULL) {
-		ops->recv(ep->stream, buf);
+		ops->recv(ep->stream, info, buf);
 	} else {
 		BT_WARN("No callback for recv set");
 	}

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -74,7 +74,7 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 	BT_DBG("stream %p ep %p len %zu", chan, ep, net_buf_frags_len(buf));
 
 	if (ops != NULL && ops->recv != NULL) {
-		ops->recv(ep->stream, buf);
+		ops->recv(ep->stream, info, buf);
 	} else {
 		BT_WARN("No callback for recv set");
 	}

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1086,7 +1086,9 @@ static struct bt_audio_broadcast_sink_cb sink_cbs = {
 #endif /* CONFIG_BT_AUDIO_BROADCAST_SINK */
 
 #if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SINK)
-static void audio_recv(struct bt_audio_stream *stream, struct net_buf *buf)
+static void audio_recv(struct bt_audio_stream *stream,
+		       const struct bt_iso_recv_info *info,
+		       struct net_buf *buf)
 {
 	shell_print(ctx_shell, "Incoming audio on stream %p len %u\n", stream, buf->len);
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -137,7 +137,9 @@ static struct bt_audio_capability_ops lc3_ops = {
 	.release = lc3_release,
 };
 
-static void stream_recv(struct bt_audio_stream *stream, struct net_buf *buf)
+static void stream_recv(struct bt_audio_stream *stream,
+			const struct bt_iso_recv_info *info,
+			struct net_buf *buf)
 {
 	printk("Incoming audio on stream %p len %u\n", stream, buf->len);
 }


### PR DESCRIPTION
The audio stream receive callback now contains a
recv_info struct, which contain crucial information
such as timestamps and packet validity.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/44284