### PR TITLE
drivers: can: add missing can_set_mode() syscall handler + test case

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -108,6 +108,14 @@ static inline const struct can_timing *z_vrfy_can_get_timing_max_data(const stru
 
 #endif /* CONFIG_CAN_FD_MODE */
 
+static inline int z_vrfy_can_set_mode(const struct device *dev, enum can_mode mode)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_mode));
+
+	return z_impl_can_set_mode(dev, mode);
+}
+#include <syscalls/can_set_mode_mrsh.c>
+
 static inline int z_vrfy_can_send(const struct device *dev,
 				  const struct zcan_frame *frame,
 				  k_timeout_t timeout,

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -850,7 +850,7 @@ void test_main(void)
 	ztest_test_suite(can_api_tests,
 			 ztest_user_unit_test(test_get_core_clock),
 			 ztest_user_unit_test(test_set_bitrate_too_high),
-			 ztest_unit_test(test_set_loopback),
+			 ztest_user_unit_test(test_set_loopback),
 			 ztest_user_unit_test(test_send_and_forget),
 			 ztest_unit_test(test_add_filter),
 			 ztest_user_unit_test(test_receive_timeout),


### PR DESCRIPTION
- Add missing syscall verification handler for `can_set_mode()`.
- Run the test case for `can_set_mode()` in userspace to validate the syscall handler.

Fixes: #44361