### PR TITLE
drivers: can: add missing static keywords

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -63,7 +63,7 @@ static inline int check_filter_match(const struct zcan_frame *frame,
 		(frame->id & filter->id_mask));
 }
 
-void tx_thread(void *arg1, void *arg2, void *arg3)
+static void tx_thread(void *arg1, void *arg2, void *arg3)
 {
 	const struct device *dev = arg1;
 	struct can_loopback_data *data = dev->data;
@@ -95,10 +95,10 @@ void tx_thread(void *arg1, void *arg2, void *arg3)
 	}
 }
 
-int can_loopback_send(const struct device *dev,
-		      const struct zcan_frame *frame,
-		      k_timeout_t timeout, can_tx_callback_t callback,
-		      void *user_data)
+static int can_loopback_send(const struct device *dev,
+			     const struct zcan_frame *frame,
+			     k_timeout_t timeout, can_tx_callback_t callback,
+			     void *user_data)
 {
 	struct can_loopback_data *data = dev->data;
 	int ret;
@@ -150,8 +150,8 @@ static inline int get_free_filter(struct can_loopback_filter *filters)
 	return -ENOSPC;
 }
 
-int can_loopback_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
-			       void *cb_arg, const struct zcan_filter *filter)
+static int can_loopback_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
+				      void *cb_arg, const struct zcan_filter *filter)
 {
 	struct can_loopback_data *data = dev->data;
 	struct can_loopback_filter *loopback_filter;
@@ -187,7 +187,7 @@ int can_loopback_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 	return filter_id;
 }
 
-void can_loopback_remove_rx_filter(const struct device *dev, int filter_id)
+static void can_loopback_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct can_loopback_data *data = dev->data;
 
@@ -197,7 +197,7 @@ void can_loopback_remove_rx_filter(const struct device *dev, int filter_id)
 	k_mutex_unlock(&data->mtx);
 }
 
-int can_loopback_set_mode(const struct device *dev, enum can_mode mode)
+static int can_loopback_set_mode(const struct device *dev, enum can_mode mode)
 {
 	struct can_loopback_data *data = dev->data;
 
@@ -205,9 +205,9 @@ int can_loopback_set_mode(const struct device *dev, enum can_mode mode)
 	return 0;
 }
 
-int can_loopback_set_timing(const struct device *dev,
-			 const struct can_timing *timing,
-			 const struct can_timing *timing_data)
+static int can_loopback_set_timing(const struct device *dev,
+				   const struct can_timing *timing,
+				   const struct can_timing *timing_data)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(timing);
@@ -233,7 +233,7 @@ static int can_loopback_get_state(const struct device *dev, enum can_state *stat
 }
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
-int can_loopback_recover(const struct device *dev, k_timeout_t timeout)
+static int can_loopback_recover(const struct device *dev, k_timeout_t timeout)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(timeout);
@@ -251,14 +251,14 @@ static void can_loopback_set_state_change_callback(const struct device *dev,
 	ARG_UNUSED(user_data);
 }
 
-int can_loopback_get_core_clock(const struct device *dev, uint32_t *rate)
+static int can_loopback_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	/* Return 16MHz as an realistic value for the testcases */
 	*rate = 16000000;
 	return 0;
 }
 
-int can_loopback_get_max_filters(const struct device *dev, enum can_ide id_type)
+static int can_loopback_get_max_filters(const struct device *dev, enum can_ide id_type)
 {
 	ARG_UNUSED(id_type);
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -328,14 +328,14 @@ static int mcp2515_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-int mcp2515_get_max_filters(const struct device *dev, enum can_ide id_type)
+static int mcp2515_get_max_filters(const struct device *dev, enum can_ide id_type)
 {
 	ARG_UNUSED(id_type);
 
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-int mcp2515_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int mcp2515_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct mcp2515_config *dev_cfg = dev->config;
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -135,14 +135,14 @@ static int mcux_flexcan_get_core_clock(const struct device *dev, uint32_t *rate)
 	return clock_control_get_rate(config->clock_dev, config->clock_subsys, rate);
 }
 
-int mcux_flexcan_get_max_filters(const struct device *dev, enum can_ide id_type)
+static int mcux_flexcan_get_max_filters(const struct device *dev, enum can_ide id_type)
 {
 	ARG_UNUSED(id_type);
 
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-int mcux_flexcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int mcux_flexcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct mcux_flexcan_config *config = dev->config;
 
@@ -450,7 +450,7 @@ static void mcux_flexcan_set_state_change_callback(const struct device *dev,
 }
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
-int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
+static int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 {
 	const struct mcux_flexcan_config *config = dev->config;
 	enum can_state state;

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -99,7 +99,7 @@ static int mcux_mcan_get_core_clock(const struct device *dev, uint32_t *rate)
 				      rate);
 }
 
-int mcux_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int mcux_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct mcux_mcan_config *config = dev->config;
 

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -566,7 +566,7 @@ static int can_rcar_enter_operation_mode(const struct can_rcar_cfg *config)
 	return 0;
 }
 
-int can_rcar_set_mode(const struct device *dev, enum can_mode mode)
+static int can_rcar_set_mode(const struct device *dev, enum can_mode mode)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
@@ -647,9 +647,9 @@ static void can_rcar_set_bittiming(const struct can_rcar_cfg *config,
 		    config->reg_addr + RCAR_CAN_BCR);
 }
 
-int can_rcar_set_timing(const struct device *dev,
-			const struct can_timing *timing,
-			const struct can_timing *timing_data)
+static int can_rcar_set_timing(const struct device *dev,
+			       const struct can_timing *timing,
+			       const struct can_timing *timing_data)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
@@ -703,7 +703,7 @@ static int can_rcar_get_state(const struct device *dev, enum can_state *state,
 }
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
-int can_rcar_recover(const struct device *dev, k_timeout_t timeout)
+static int can_rcar_recover(const struct device *dev, k_timeout_t timeout)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
@@ -738,9 +738,9 @@ done:
 }
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 
-int can_rcar_send(const struct device *dev, const struct zcan_frame *frame,
-		  k_timeout_t timeout, can_tx_callback_t callback,
-		  void *user_data)
+static int can_rcar_send(const struct device *dev, const struct zcan_frame *frame,
+			 k_timeout_t timeout, can_tx_callback_t callback,
+			 void *user_data)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
@@ -839,8 +839,8 @@ static inline int can_rcar_add_rx_filter_unlocked(const struct device *dev,
 	return -ENOSPC;
 }
 
-int can_rcar_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
-			   void *cb_arg, const struct zcan_filter *filter)
+static int can_rcar_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
+				  void *cb_arg, const struct zcan_filter *filter)
 {
 	struct can_rcar_data *data = dev->data;
 	int filter_id;
@@ -851,7 +851,7 @@ int can_rcar_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 	return filter_id;
 }
 
-void can_rcar_remove_rx_filter(const struct device *dev, int filter_id)
+static void can_rcar_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	struct can_rcar_data *data = dev->data;
 
@@ -1021,14 +1021,14 @@ static int can_rcar_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-int can_rcar_get_max_filters(const struct device *dev, enum can_ide id_type)
+static int can_rcar_get_max_filters(const struct device *dev, enum can_ide id_type)
 {
 	ARG_UNUSED(id_type);
 
 	return CONFIG_CAN_RCAR_MAX_FILTER;
 }
 
-int can_rcar_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int can_rcar_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct can_rcar_cfg *config = dev->config;
 

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -136,7 +136,7 @@ static int can_sam_set_timing(const struct device *dev, const struct can_timing 
 	return can_mcan_set_timing(mcan_cfg, timing, timing_data);
 }
 
-int can_sam_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int can_sam_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct can_sam_config *cfg = dev->config;
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -84,8 +84,7 @@ static void can_stm32_get_msg_fifo(CAN_FIFOMailBox_TypeDef *mbox,
 #endif
 }
 
-static inline
-void can_stm32_rx_isr_handler(const struct device *dev)
+static inline void can_stm32_rx_isr_handler(const struct device *dev)
 {
 	struct can_stm32_data *data = dev->data;
 	const struct can_stm32_config *cfg = dev->config;
@@ -200,8 +199,7 @@ static inline void can_stm32_bus_state_change_isr(const struct device *dev)
 	}
 }
 
-static inline
-void can_stm32_tx_isr_handler(const struct device *dev)
+static inline void can_stm32_tx_isr_handler(const struct device *dev)
 {
 	struct can_stm32_data *data = dev->data;
 	const struct can_stm32_config *cfg = dev->config;
@@ -343,7 +341,7 @@ static int can_leave_sleep_mode(CAN_TypeDef *can)
 	return 0;
 }
 
-int can_stm32_set_mode(const struct device *dev, enum can_mode mode)
+static int can_stm32_set_mode(const struct device *dev, enum can_mode mode)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
@@ -403,9 +401,9 @@ done:
 	return ret;
 }
 
-int can_stm32_set_timing(const struct device *dev,
-			 const struct can_timing *timing,
-			 const struct can_timing *timing_data)
+static int can_stm32_set_timing(const struct device *dev,
+				const struct can_timing *timing,
+				const struct can_timing *timing_data)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
@@ -443,7 +441,7 @@ done:
 	return ret;
 }
 
-int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
+static int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	const struct device *clock;
@@ -462,14 +460,14 @@ int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-int can_stm32_get_max_filters(const struct device *dev, enum can_ide id_type)
+static int can_stm32_get_max_filters(const struct device *dev, enum can_ide id_type)
 {
 	ARG_UNUSED(id_type);
 
 	return CONFIG_CAN_MAX_FILTER;
 }
 
-int can_stm32_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int can_stm32_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct can_stm32_config *config = dev->config;
 
@@ -612,7 +610,7 @@ static void can_stm32_set_state_change_callback(const struct device *dev,
 }
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
-int can_stm32_recover(const struct device *dev, k_timeout_t timeout)
+static int can_stm32_recover(const struct device *dev, k_timeout_t timeout)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	struct can_stm32_data *data = dev->data;
@@ -653,9 +651,9 @@ done:
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 
 
-int can_stm32_send(const struct device *dev, const struct zcan_frame *frame,
-		   k_timeout_t timeout, can_tx_callback_t callback,
-		   void *user_data)
+static int can_stm32_send(const struct device *dev, const struct zcan_frame *frame,
+			  k_timeout_t timeout, can_tx_callback_t callback,
+			  void *user_data)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	struct can_stm32_data *data = dev->data;
@@ -801,8 +799,8 @@ static int can_stm32_shift_arr(void **arr, int start, int count)
 	return 0;
 }
 
-enum can_filter_type can_stm32_get_filter_type(int bank_nr, uint32_t mode_reg,
-					       uint32_t scale_reg)
+static enum can_filter_type can_stm32_get_filter_type(int bank_nr, uint32_t mode_reg,
+						      uint32_t scale_reg)
 {
 	uint32_t mode_masked  = (mode_reg  >> bank_nr) & 0x01;
 	uint32_t scale_masked = (scale_reg >> bank_nr) & 0x01;
@@ -1082,8 +1080,8 @@ static inline int can_stm32_add_rx_filter_unlocked(const struct device *dev,
 	return filter_id;
 }
 
-int can_stm32_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
-			    void *cb_arg,
+static int can_stm32_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
+				   void *cb_arg,
 			    const struct zcan_filter *filter)
 {
 	struct can_stm32_data *data = dev->data;
@@ -1096,7 +1094,7 @@ int can_stm32_add_rx_filter(const struct device *dev, can_rx_callback_t cb,
 	return filter_id;
 }
 
-void can_stm32_remove_rx_filter(const struct device *dev, int filter_id)
+static void can_stm32_remove_rx_filter(const struct device *dev, int filter_id)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	struct can_stm32_data *data = dev->data;

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -145,7 +145,7 @@ static int can_stm32fd_set_timing(const struct device *dev,
 	return can_mcan_set_timing(mcan_cfg, timing, timing_data);
 }
 
-int can_stm32fd_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int can_stm32fd_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct can_stm32fd_config *cfg = dev->config;
 

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -167,7 +167,7 @@ static int can_stm32h7_set_timing(const struct device *dev,
 	return can_mcan_set_timing(&cfg->mcan_cfg, timing, timing_data);
 }
 
-int can_stm32h7_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
+static int can_stm32h7_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct can_stm32h7_config *cfg = dev->config;
 


### PR DESCRIPTION
Add missing static keywords for functions internal to the drivers.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>