### PR TITLE
Bluetooth: controller: llcp: remove extra initialisation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -498,9 +498,6 @@ void ull_llcp_init(struct ll_conn *conn)
 #endif /* LLCP_TX_CTRL_BUF_QUEUE_ENABLE */
 
 	conn->lll.event_counter = 0;
-
-	llcp_lr_init(conn);
-	llcp_rr_init(conn);
 }
 
 void ull_cp_release_tx(struct ll_conn *conn, struct node_tx *tx)


### PR DESCRIPTION
There was an extra call to llcp_lr_init and llcp_rr_init, which is
removed in this commit
The initialisation is done at the start of the function
[ull_llcp_init](https://github.com/kruithofa/zephyr/blob/2ebae6b10310b4fb3ef09aaf2c94e4c0fb8b8dc8/subsys/bluetooth/controller/ll_sw/ull_llcp.c#L450)

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>