### PR TITLE
net: lwm2m: Allow initializing opaque and string data to zero length

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -44,6 +44,8 @@ Deprecated in this release
 ==========================
 
 * :c:func:`nvs_init` is deprecated in favor of utilizing :c:func:`nvs_mount`.
+* :c:func:`lwm2m_engine_set_res_data` is deprecated in favor of :c:func:`lwm2m_engine_set_res_buf`
+* :c:func:`lwm2m_engine_get_res_data` is deprecated in favor of :c:func:`lwm2m_engine_get_res_buf`
 * The TinyCBOR module has been deprecated in favor of the new zcbor CBOR
   library, included with Zephyr in this release.
 

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1008,14 +1008,47 @@ int lwm2m_engine_register_delete_callback(uint16_t obj_id,
  * resource.
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
+ * @param[in] buffer_ptr Data buffer pointer
+ * @param[in] buffer_len Length of buffer
+ * @param[in] data_len Length of existing data in the buffer
+ * @param[in] data_flags Data buffer flags (such as read-only, etc)
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_set_res_buf(const char *pathstr, void *buffer_ptr, uint16_t buffer_len,
+			     uint16_t data_len, uint8_t data_flags);
+
+/**
+ * @brief Set data buffer for a resource
+ *
+ * Use this function to set the data buffer and flags for the specified LwM2M
+ * resource.
+ *
+ * @deprecated Use lwm2m_engine_set_res_buf() instead, so you can define buffer size and data size
+ *             separately.
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
  * @param[in] data_ptr Data buffer pointer
  * @param[in] data_len Length of buffer
  * @param[in] data_flags Data buffer flags (such as read-only, etc)
  *
  * @return 0 for success or negative in case of error.
  */
+__deprecated
 int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data_len,
 			      uint8_t data_flags);
+
+/**
+ * @brief Update data size for a resource
+ *
+ * Use this function to set the new size of data in the buffer if you write
+ * to a buffer received by lwm2m_engine_get_res_buf().
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
+ * @param[in] data_len Length of data
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_set_res_data_len(const char *pathstr, uint16_t data_len);
 
 /**
  * @brief Get data buffer for a resource
@@ -1023,15 +1056,40 @@ int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data
  * Use this function to get the data buffer information for the specified LwM2M
  * resource.
  *
+ * If you directly write into the buffer, you must use lwm2m_engine_set_res_data_len()
+ * function to update the new size of the written data.
+ *
+ * All parameters except pathstr can NULL if you don't want to read those values.
+ *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
- * @param[out] data_ptr Data buffer pointer
- * @param[out] data_len Length of buffer
+ * @param[out] buffer_ptr Data buffer pointer
+ * @param[out] buffer_len Length of buffer
+ * @param[out] data_len Length of existing data in the buffer
  * @param[out] data_flags Data buffer flags (such as read-only, etc)
  *
  * @return 0 for success or negative in case of error.
  */
-int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr,
-			      uint16_t *data_len, uint8_t *data_flags);
+int lwm2m_engine_get_res_buf(const char *pathstr, void **buffer_ptr, uint16_t *buffer_len,
+			     uint16_t *data_len, uint8_t *data_flags);
+
+/**
+ * @brief Get data buffer for a resource
+ *
+ * Use this function to get the data buffer information for the specified LwM2M
+ * resource.
+ *
+ * @deprecated Use lwm2m_engine_get_res_buf() as it can tell you the size of the buffer as well.
+ *
+ * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"
+ * @param[out] data_ptr Data buffer pointer
+ * @param[out] data_len Length of existing data in the buffer
+ * @param[out] data_flags Data buffer flags (such as read-only, etc)
+ *
+ * @return 0 for success or negative in case of error.
+ */
+__deprecated
+int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *data_len,
+			      uint8_t *data_flags);
 
 /**
  * @brief Create a resource instance

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -282,26 +282,24 @@ static int lwm2m_setup(void)
 	int ret;
 	char *server_url;
 	uint16_t server_url_len;
-	uint8_t server_url_flags;
 
 	/* setup SECURITY object */
 
 	/* Server URL */
-	ret = lwm2m_engine_get_res_data("0/0/0",
-					(void **)&server_url, &server_url_len,
-					&server_url_flags);
+	ret = lwm2m_engine_get_res_buf("0/0/0", (void **)&server_url, &server_url_len, NULL, NULL);
 	if (ret < 0) {
 		return ret;
 	}
 
-	snprintk(server_url, server_url_len, "coap%s//%s%s%s",
-		 IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) ? "s:" : ":",
-		 strchr(SERVER_ADDR, ':') ? "[" : "", SERVER_ADDR,
-		 strchr(SERVER_ADDR, ':') ? "]" : "");
+	server_url_len = snprintk(server_url, server_url_len, "coap%s//%s%s%s",
+				  IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) ? "s:" : ":",
+				  strchr(SERVER_ADDR, ':') ? "[" : "", SERVER_ADDR,
+				  strchr(SERVER_ADDR, ':') ? "]" : "");
+
+	lwm2m_engine_set_res_data_len("0/0/0", server_url_len + 1);
 
 	/* Security Mode */
-	lwm2m_engine_set_u8("0/0/2",
-			    IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) ? 0 : 3);
+	lwm2m_engine_set_u8("0/0/2", IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) ? 0 : 3);
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
 	lwm2m_engine_set_string("0/0/3", (char *)client_psk_id);
 	lwm2m_engine_set_opaque("0/0/5",
@@ -326,45 +324,60 @@ static int lwm2m_setup(void)
 
 	/* setup DEVICE object */
 
-	lwm2m_engine_set_res_data("3/0/0", CLIENT_MANUFACTURER,
-				  sizeof(CLIENT_MANUFACTURER),
-				  LWM2M_RES_DATA_FLAG_RO);
-	lwm2m_engine_set_res_data("3/0/1", CLIENT_MODEL_NUMBER,
-				  sizeof(CLIENT_MODEL_NUMBER),
-				  LWM2M_RES_DATA_FLAG_RO);
-	lwm2m_engine_set_res_data("3/0/2", CLIENT_SERIAL_NUMBER,
-				  sizeof(CLIENT_SERIAL_NUMBER),
-				  LWM2M_RES_DATA_FLAG_RO);
-	lwm2m_engine_set_res_data("3/0/3", CLIENT_FIRMWARE_VER,
-				  sizeof(CLIENT_FIRMWARE_VER),
-				  LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_engine_set_res_buf("3/0/0", CLIENT_MANUFACTURER,
+				 sizeof(CLIENT_MANUFACTURER),
+				 sizeof(CLIENT_MANUFACTURER),
+				 LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_engine_set_res_buf("3/0/1", CLIENT_MODEL_NUMBER,
+				 sizeof(CLIENT_MODEL_NUMBER),
+				 sizeof(CLIENT_MODEL_NUMBER),
+				 LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_engine_set_res_buf("3/0/2", CLIENT_SERIAL_NUMBER,
+				 sizeof(CLIENT_SERIAL_NUMBER),
+				 sizeof(CLIENT_SERIAL_NUMBER),
+				 LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_engine_set_res_buf("3/0/3", CLIENT_FIRMWARE_VER,
+				 sizeof(CLIENT_FIRMWARE_VER),
+				 sizeof(CLIENT_FIRMWARE_VER),
+				 LWM2M_RES_DATA_FLAG_RO);
 	lwm2m_engine_register_exec_callback("3/0/4", device_reboot_cb);
 	lwm2m_engine_register_exec_callback("3/0/5", device_factory_default_cb);
-	lwm2m_engine_set_res_data("3/0/9", &bat_level, sizeof(bat_level), 0);
-	lwm2m_engine_set_res_data("3/0/10", &mem_free, sizeof(mem_free), 0);
-	lwm2m_engine_set_res_data("3/0/17", CLIENT_DEVICE_TYPE,
-				  sizeof(CLIENT_DEVICE_TYPE),
-				  LWM2M_RES_DATA_FLAG_RO);
-	lwm2m_engine_set_res_data("3/0/18", CLIENT_HW_VER,
-				  sizeof(CLIENT_HW_VER),
-				  LWM2M_RES_DATA_FLAG_RO);
-	lwm2m_engine_set_res_data("3/0/20", &bat_status, sizeof(bat_status), 0);
-	lwm2m_engine_set_res_data("3/0/21", &mem_total, sizeof(mem_total), 0);
+	lwm2m_engine_set_res_buf("3/0/9", &bat_level, sizeof(bat_level),
+				 sizeof(bat_level), 0);
+	lwm2m_engine_set_res_buf("3/0/10", &mem_free, sizeof(mem_free),
+				 sizeof(mem_free), 0);
+	lwm2m_engine_set_res_buf("3/0/17", CLIENT_DEVICE_TYPE,
+				 sizeof(CLIENT_DEVICE_TYPE),
+				 sizeof(CLIENT_DEVICE_TYPE),
+				 LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_engine_set_res_buf("3/0/18", CLIENT_HW_VER,
+				 sizeof(CLIENT_HW_VER), sizeof(CLIENT_HW_VER),
+				 LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_engine_set_res_buf("3/0/20", &bat_status, sizeof(bat_status),
+				 sizeof(bat_status), 0);
+	lwm2m_engine_set_res_buf("3/0/21", &mem_total, sizeof(mem_total),
+				 sizeof(mem_total), 0);
 
 	/* add power source resource instances */
 	lwm2m_engine_create_res_inst("3/0/6/0");
-	lwm2m_engine_set_res_data("3/0/6/0", &bat_idx, sizeof(bat_idx), 0);
+	lwm2m_engine_set_res_buf("3/0/6/0", &bat_idx, sizeof(bat_idx),
+				 sizeof(bat_idx), 0);
 
 	lwm2m_engine_create_res_inst("3/0/7/0");
-	lwm2m_engine_set_res_data("3/0/7/0", &bat_mv, sizeof(bat_mv), 0);
+	lwm2m_engine_set_res_buf("3/0/7/0", &bat_mv, sizeof(bat_mv),
+				 sizeof(bat_mv), 0);
 	lwm2m_engine_create_res_inst("3/0/8/0");
-	lwm2m_engine_set_res_data("3/0/8/0", &bat_ma, sizeof(bat_ma), 0);
+	lwm2m_engine_set_res_buf("3/0/8/0", &bat_ma, sizeof(bat_ma),
+				 sizeof(bat_ma), 0);
 	lwm2m_engine_create_res_inst("3/0/6/1");
-	lwm2m_engine_set_res_data("3/0/6/1", &usb_idx, sizeof(usb_idx), 0);
+	lwm2m_engine_set_res_buf("3/0/6/1", &usb_idx, sizeof(usb_idx),
+				 sizeof(usb_idx), 0);
 	lwm2m_engine_create_res_inst("3/0/7/1");
-	lwm2m_engine_set_res_data("3/0/7/1", &usb_mv, sizeof(usb_mv), 0);
+	lwm2m_engine_set_res_buf("3/0/7/1", &usb_mv, sizeof(usb_mv),
+				 sizeof(usb_mv), 0);
 	lwm2m_engine_create_res_inst("3/0/8/1");
-	lwm2m_engine_set_res_data("3/0/8/1", &usb_ma, sizeof(usb_ma), 0);
+	lwm2m_engine_set_res_buf("3/0/8/1", &usb_ma, sizeof(usb_ma),
+				 sizeof(usb_ma), 0);
 
 	/* setup FIRMWARE object */
 
@@ -375,8 +388,9 @@ static int lwm2m_setup(void)
 #endif
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT)
 	lwm2m_engine_create_res_inst("5/0/8/0");
-	lwm2m_engine_set_res_data("5/0/8/0", &supported_protocol[0],
-				  sizeof(supported_protocol[0]), 0);
+	lwm2m_engine_set_res_buf("5/0/8/0", &supported_protocol[0],
+				 sizeof(supported_protocol[0]),
+				 sizeof(supported_protocol[0]), 0);
 
 	lwm2m_firmware_set_update_cb(firmware_update_cb);
 #endif
@@ -390,9 +404,10 @@ static int lwm2m_setup(void)
 		lwm2m_engine_create_obj_inst("3311/0");
 		lwm2m_engine_register_post_write_callback("3311/0/5850",
 				led_on_off_cb);
-		lwm2m_engine_set_res_data("3311/0/5750",
-					  LIGHT_NAME, sizeof(LIGHT_NAME),
-					  LWM2M_RES_DATA_FLAG_RO);
+		lwm2m_engine_set_res_buf("3311/0/5750", LIGHT_NAME,
+					 sizeof(LIGHT_NAME),
+					 sizeof(LIGHT_NAME),
+					 LWM2M_RES_DATA_FLAG_RO);
 	}
 
 	/* IPSO: Timer object */
@@ -401,8 +416,9 @@ static int lwm2m_setup(void)
 			timer_on_off_validate_cb);
 	lwm2m_engine_register_post_write_callback("3340/0/5543",
 			timer_digital_state_cb);
-	lwm2m_engine_set_res_data("3340/0/5750", TIMER_NAME, sizeof(TIMER_NAME),
-				  LWM2M_RES_DATA_FLAG_RO);
+	lwm2m_engine_set_res_buf("3340/0/5750", TIMER_NAME,
+				 sizeof(TIMER_NAME), sizeof(TIMER_NAME),
+				 LWM2M_RES_DATA_FLAG_RO);
 
 	return 0;
 }

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1924,9 +1924,8 @@ int lwm2m_engine_delete_obj_inst(const char *pathstr)
 	return 0;
 }
 
-
-int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data_len,
-			      uint8_t data_flags)
+int lwm2m_engine_set_res_buf(const char *pathstr, void *buffer_ptr,
+				  uint16_t buffer_len, uint16_t data_len, uint8_t data_flags)
 {
 	struct lwm2m_obj_path path;
 	struct lwm2m_engine_res_inst *res_inst = NULL;
@@ -1955,12 +1954,18 @@ int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data
 	}
 
 	/* assign data elements */
-	res_inst->data_ptr = data_ptr;
+	res_inst->data_ptr = buffer_ptr;
 	res_inst->data_len = data_len;
-	res_inst->max_data_len = data_len;
+	res_inst->max_data_len = buffer_len;
 	res_inst->data_flags = data_flags;
 
 	return ret;
+}
+
+int lwm2m_engine_set_res_data(const char *pathstr, void *data_ptr, uint16_t data_len,
+			      uint8_t data_flags)
+{
+	return lwm2m_engine_set_res_buf(pathstr, data_ptr, data_len, data_len, data_flags);
 }
 
 static int lwm2m_engine_set(const char *pathstr, void *value, uint16_t len)
@@ -2188,10 +2193,25 @@ int lwm2m_engine_set_objlnk(const char *pathstr, struct lwm2m_objlnk *value)
 	return lwm2m_engine_set(pathstr, value, sizeof(struct lwm2m_objlnk));
 }
 
+int lwm2m_engine_set_res_data_len(const char *pathstr, uint16_t data_len)
+{
+	int ret;
+	void *buffer_ptr;
+	uint16_t buffer_len;
+	uint16_t old_len;
+	uint8_t data_flags;
+
+	ret = lwm2m_engine_get_res_buf(pathstr, &buffer_ptr, &buffer_len, &old_len, &data_flags);
+	if (ret) {
+		return ret;
+	}
+	return lwm2m_engine_set_res_buf(pathstr, buffer_ptr, buffer_len, data_len, data_flags);
+}
+
 /* user data getter functions */
 
-int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *data_len,
-			      uint8_t *data_flags)
+int lwm2m_engine_get_res_buf(const char *pathstr, void **buffer_ptr, uint16_t *buffer_len,
+				  uint16_t *data_len, uint8_t *data_flags)
 {
 	struct lwm2m_obj_path path;
 	struct lwm2m_engine_res_inst *res_inst = NULL;
@@ -2219,12 +2239,28 @@ int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *da
 		return -ENOENT;
 	}
 
-	*data_ptr = res_inst->data_ptr;
-	*data_len = res_inst->data_len;
-	*data_flags = res_inst->data_flags;
+	if (buffer_ptr) {
+		*buffer_ptr = res_inst->data_ptr;
+	}
+	if (buffer_len) {
+		*buffer_len = res_inst->max_data_len;
+	}
+	if (data_len) {
+		*data_len = res_inst->data_len;
+	}
+	if (data_flags) {
+		*data_flags = res_inst->data_flags;
+	}
 
 	return 0;
 }
+
+int lwm2m_engine_get_res_data(const char *pathstr, void **data_ptr, uint16_t *data_len,
+			      uint8_t *data_flags)
+{
+	return lwm2m_engine_get_res_buf(pathstr, data_ptr, NULL, data_len, data_flags);
+}
+
 
 static int lwm2m_engine_get(const char *pathstr, void *buf, uint16_t buflen)
 {
@@ -5791,11 +5827,16 @@ static int load_tls_credential(struct lwm2m_ctx *client_ctx, uint16_t res_id,
 	snprintk(pathstr, sizeof(pathstr), "0/%d/%u", client_ctx->sec_obj_inst,
 		 res_id);
 
-	ret = lwm2m_engine_get_res_data(pathstr, &cred, &cred_len, &cred_flags);
+	ret = lwm2m_engine_get_res_buf(pathstr, &cred, NULL, &cred_len, &cred_flags);
 	if (ret < 0) {
 		LOG_ERR("Unable to get resource data for '%s'",
 			log_strdup(pathstr));
 		return ret;
+	}
+
+	if (cred_len == 0) {
+		LOG_ERR("Credential data is empty");
+		return -EINVAL;
 	}
 
 	ret = tls_credential_add(client_ctx->tls_tag, type, cred, cred_len);
@@ -6071,7 +6112,7 @@ int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 
 	/* get the server URL */
 	snprintk(pathstr, sizeof(pathstr), "0/%d/0", client_ctx->sec_obj_inst);
-	ret = lwm2m_engine_get_res_data(pathstr, (void **)&url, &url_len,
+	ret = lwm2m_engine_get_res_buf(pathstr, (void **)&url, NULL, &url_len,
 					&url_data_flags);
 	if (ret < 0) {
 		return ret;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -385,8 +385,8 @@ static struct lwm2m_engine_obj_inst *firmware_create(uint16_t obj_inst_id)
 	/* initialize instance resource data */
 	INIT_OBJ_RES_OPT(FIRMWARE_PACKAGE_ID, res[obj_inst_id], i, res_inst[obj_inst_id], j, 1,
 			 false, true, NULL, NULL, NULL, package_write_cb, NULL);
-	INIT_OBJ_RES(FIRMWARE_PACKAGE_URI_ID, res[obj_inst_id], i, res_inst[obj_inst_id], j, 1,
-		     false, true, package_uri[obj_inst_id], PACKAGE_URI_LEN, NULL, NULL, NULL,
+	INIT_OBJ_RES_LEN(FIRMWARE_PACKAGE_URI_ID, res[obj_inst_id], i, res_inst[obj_inst_id], j, 1,
+		     false, true, package_uri[obj_inst_id], PACKAGE_URI_LEN, 0, NULL, NULL, NULL,
 		     package_uri_write_cb, NULL);
 	INIT_OBJ_RES_EXECUTE(FIRMWARE_UPDATE_ID, res[obj_inst_id], i, firmware_update_cb);
 	INIT_OBJ_RES_DATA(FIRMWARE_STATE_ID, res[obj_inst_id], i, res_inst[obj_inst_id], j,

--- a/subsys/net/lib/lwm2m/lwm2m_obj_portfolio.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_portfolio.c
@@ -94,9 +94,9 @@ static struct lwm2m_engine_obj_inst *portfolio_create(uint16_t obj_inst_id)
 	init_res_instance(res_inst[avail], ARRAY_SIZE(res_inst[avail]));
 
 	/* initialize instance resource data */
-	INIT_OBJ_RES_MULTI_DATA(PORTFOLIO_IDENTITY_ID, res[avail], i,
-				res_inst[avail], j, PORTFOLIO_IDENTITY_MAX, false,
-				identity[indentity_buffer_start], DEFAULT_IDENTITY_BUFFER_LENGTH);
+	INIT_OBJ_RES_MULTI_DATA_LEN(PORTFOLIO_IDENTITY_ID, res[avail], i, res_inst[avail], j,
+				    PORTFOLIO_IDENTITY_MAX, false, identity[indentity_buffer_start],
+				    DEFAULT_IDENTITY_BUFFER_LENGTH, 0);
 	INIT_OBJ_RES_EXECUTE(PORTFOLIO_GET_AUTH_DATA_ID, res[avail], i, NULL);
 	INIT_OBJ_RES_MULTI_OPTDATA(PORTFOLIO_AUTH_DATA_ID, res[avail], i, res_inst[avail], j,
 				   PORTFOLIO_AUTH_DATA_MAX, false);

--- a/subsys/net/lib/lwm2m/lwm2m_obj_security.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_security.c
@@ -148,24 +148,24 @@ static struct lwm2m_engine_obj_inst *security_create(uint16_t obj_inst_id)
 	init_res_instance(res_inst[index], ARRAY_SIZE(res_inst[index]));
 
 	/* initialize instance resource data */
-	INIT_OBJ_RES_DATA(SECURITY_SERVER_URI_ID, res[index], i,
+	INIT_OBJ_RES_DATA_LEN(SECURITY_SERVER_URI_ID, res[index], i,
 			  res_inst[index], j,
-			  security_uri[index], SECURITY_URI_LEN);
+			  security_uri[index], SECURITY_URI_LEN, 0);
 	INIT_OBJ_RES_DATA(SECURITY_BOOTSTRAP_FLAG_ID, res[index], i,
 			  res_inst[index], j,
 			  &bootstrap_flag[index], sizeof(*bootstrap_flag));
 	INIT_OBJ_RES_DATA(SECURITY_MODE_ID, res[index], i,
 			  res_inst[index], j,
 			  &security_mode[index], sizeof(*security_mode));
-	INIT_OBJ_RES_DATA(SECURITY_CLIENT_PK_ID, res[index], i,
+	INIT_OBJ_RES_DATA_LEN(SECURITY_CLIENT_PK_ID, res[index], i,
 			  res_inst[index], j,
-			  &client_identity[index], IDENTITY_LEN);
-	INIT_OBJ_RES_DATA(SECURITY_SERVER_PK_ID, res[index], i,
+			  &client_identity[index], IDENTITY_LEN, 0);
+	INIT_OBJ_RES_DATA_LEN(SECURITY_SERVER_PK_ID, res[index], i,
 			  res_inst[index], j,
-			  &server_pk[index], KEY_LEN);
-	INIT_OBJ_RES_DATA(SECURITY_SECRET_KEY_ID, res[index], i,
+			  &server_pk[index], KEY_LEN, 0);
+	INIT_OBJ_RES_DATA_LEN(SECURITY_SECRET_KEY_ID, res[index], i,
 			  res_inst[index], j,
-			  &secret_key[index], KEY_LEN);
+			  &secret_key[index], KEY_LEN, 0);
 	INIT_OBJ_RES_DATA(SECURITY_SHORT_SERVER_ID, res[index], i,
 			  res_inst[index], j,
 			  &short_server_id[index], sizeof(*short_server_id));

--- a/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_swmgmt.c
@@ -688,12 +688,12 @@ static struct lwm2m_engine_obj_inst *swmgmt_create(uint16_t obj_inst_id)
 #endif
 
 	/* initialize instance resource data */
-	INIT_OBJ_RES_DATA(SWMGMT_PACKAGE_NAME_ID, res[index], res_idx, res_inst[index],
-			  res_inst_idx, &instance->package_name, PACKAGE_NAME_LEN);
+	INIT_OBJ_RES_DATA_LEN(SWMGMT_PACKAGE_NAME_ID, res[index], res_idx, res_inst[index],
+			  res_inst_idx, &instance->package_name, PACKAGE_NAME_LEN, 0);
 
-	INIT_OBJ_RES(SWMGMT_PACKAGE_VERSION_ID, res[index], res_idx, res_inst[index], res_inst_idx,
-		     1, true, false, &instance->package_version, PACKAGE_VERSION_LEN,
-		     state_read_pkg_version, NULL, NULL, NULL, NULL);
+	INIT_OBJ_RES_LEN(SWMGMT_PACKAGE_VERSION_ID, res[index], res_idx, res_inst[index],
+			 res_inst_idx, 1, true, false, &instance->package_version,
+			 PACKAGE_VERSION_LEN, 0, state_read_pkg_version, NULL, NULL, NULL, NULL);
 
 	INIT_OBJ_RES_OPT(SWMGMT_PACKAGE_ID, res[index], res_idx, res_inst[index], res_inst_idx, 1,
 			 true, false, NULL, NULL, package_write_cb, NULL, NULL);

--- a/subsys/net/lib/lwm2m/lwm2m_object.h
+++ b/subsys/net/lib/lwm2m/lwm2m_object.h
@@ -239,14 +239,14 @@ struct lwm2m_engine_obj {
 #endif /* CONFIG_LWM2M_ENGINE_VALIDATION_BUFFER_SIZE > 0 */
 
 #define _INIT_OBJ_RES_INST(_ri_ptr, _ri_idx, _ri_count, _ri_create, \
-			   _data_ptr, _data_len) \
+			   _data_ptr, _data_sz, _data_len) \
 	do { \
 		if (_ri_ptr != NULL && _ri_count > 0) { \
 			for (int _i = 0; _i < _ri_count; _i++) { \
 				_ri_ptr[_ri_idx + _i].data_ptr = \
 						(_data_ptr + _i); \
 				_ri_ptr[_ri_idx + _i].max_data_len = \
-						_data_len; \
+						_data_sz; \
 				_ri_ptr[_ri_idx + _i].data_len = \
 						_data_len; \
 				if (_ri_create) { \
@@ -289,10 +289,22 @@ struct lwm2m_engine_obj {
 			      (_ri_ptr + _ri_idx), _ri_count, _multi_ri, \
 			      _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb); \
 		_INIT_OBJ_RES_INST(_ri_ptr, _ri_idx, _ri_count, _ri_create, \
-				   _data_ptr, _data_len); \
+				   _data_ptr, _data_len, _data_len); \
 	++_r_idx; \
 	} while (false)
 
+#define INIT_OBJ_RES_LEN(_id, _r_ptr, _r_idx, \
+		     _ri_ptr, _ri_idx, _ri_count, _multi_ri, _ri_create, \
+		     _data_ptr, _data_sz, _data_len, \
+		     _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb) \
+	do { \
+		_INIT_OBJ_RES(_id, _r_ptr, _r_idx, \
+			      (_ri_ptr + _ri_idx), _ri_count, _multi_ri, \
+			      _r_cb, _pre_w_cb, _val_cb, _post_w_cb, _ex_cb); \
+		_INIT_OBJ_RES_INST(_ri_ptr, _ri_idx, _ri_count, _ri_create, \
+				   _data_ptr, _data_sz, _data_len); \
+	++_r_idx; \
+	} while (false)
 
 #define INIT_OBJ_RES_OPT(_id, _r_ptr, _r_idx, \
 			 _ri_ptr, _ri_idx, _ri_count, _multi_ri, _ri_create, \
@@ -312,16 +324,27 @@ struct lwm2m_engine_obj {
 		     _ri_ptr, _ri_idx, _ri_count, true, _ri_create, \
 		     _data_ptr, _data_len, NULL, NULL, NULL, NULL, NULL)
 
+#define INIT_OBJ_RES_MULTI_DATA_LEN(_id, _r_ptr, _r_idx, \
+				_ri_ptr, _ri_idx, _ri_count, _ri_create, \
+				_data_ptr, _data_sz, _data_len) \
+	INIT_OBJ_RES_LEN(_id, _r_ptr, _r_idx, \
+		     _ri_ptr, _ri_idx, _ri_count, true, _ri_create, \
+		     _data_ptr, _data_sz, _data_len, NULL, NULL, NULL, NULL, NULL)
+
 #define INIT_OBJ_RES_MULTI_OPTDATA(_id, _r_ptr, _r_idx, \
 				   _ri_ptr, _ri_idx, _ri_count, _ri_create) \
 	INIT_OBJ_RES_OPT(_id, _r_ptr, _r_idx, \
 			 _ri_ptr, _ri_idx, _ri_count, true, _ri_create, \
 			 NULL, NULL, NULL, NULL, NULL)
 
-#define INIT_OBJ_RES_DATA(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, \
-			  _data_ptr, _data_len) \
-	INIT_OBJ_RES(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, 1U, false, true, \
-		     _data_ptr, _data_len, NULL, NULL, NULL, NULL, NULL)
+#define INIT_OBJ_RES_DATA_LEN(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, \
+			  _data_ptr, _data_sz, _data_len) \
+	INIT_OBJ_RES_LEN(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, 1U, false, true, \
+		     _data_ptr, _data_sz, _data_len, NULL, NULL, NULL, NULL, NULL)
+
+#define INIT_OBJ_RES_DATA(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, _data_ptr, _data_len)     \
+	INIT_OBJ_RES_DATA_LEN(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, _data_ptr, _data_len, \
+			      _data_len)
 
 #define INIT_OBJ_RES_OPTDATA(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx) \
 	INIT_OBJ_RES_OPT(_id, _r_ptr, _r_idx, _ri_ptr, _ri_idx, 1U, false, \


### PR DESCRIPTION
By default, any string or opaque data that LwM2M engine initializes
sets data lenght to same value as given buffer length for that
resource.

However, on run time, engine keeps track how much data is written
to each resource, so when reading from any resource, should only
return data that has been written there. But uninitialized resources
return the content of the whole buffer.

Fixed the problem by introducing macros INIT_OBJ_RES_LEN(),
INIT_OBJ_RES_MULTI_DATA_LEN() and INIT_OBJ_RES_DATA_LEN() that
allows you to give the amount of data existing in buffer when
the resource is initialized. This sets the data_len and max_data_len
variables correctly.
