### PR TITLE
Bluetooth Audio: Add codec parsing functions

### DIFF
--- a/doc/reference/bluetooth/audio.rst
+++ b/doc/reference/bluetooth/audio.rst
@@ -8,3 +8,7 @@ API Reference
 *************
 
 .. doxygengroup:: bt_audio
+.. doxygengroup:: bt_audio_client
+.. doxygengroup:: bt_audio_server
+.. doxygengroup:: bt_audio_broadcast
+.. doxygengroup:: bt_audio_codec_cfg

--- a/include/bluetooth/audio/lc3.h
+++ b/include/bluetooth/audio/lc3.h
@@ -27,13 +27,42 @@ extern "C" {
  */
 #define BT_CODEC_LC3_ID                  0x06
 
-/* TODO: Remove base once LTV types are defined */
-#define BT_CODEC_LC3_CAP_BASE            0x01
-
-/** @def BT_CODEC_LC3_FREQ
- *  @brief LC3 sample frequency capability type
+/**
+ * @brief Codec capability type id's
+ *
+ * Used to build and parse codec capabilities as specified in the PAC specification.
+ * Source is assigned numbers for Generic Audio, bluetooth.com.
+ *
+ * Even though they are in-fixed with LC3 they can be used for other codec types as well.
  */
-#define BT_CODEC_LC3_FREQ                (BT_CODEC_LC3_CAP_BASE)
+enum bt_codec_capability_type {
+
+	/** @def BT_CODEC_LC3_FREQ
+	 *  @brief LC3 sample frequency capability type
+	 */
+	BT_CODEC_LC3_FREQ                = 0x01,
+
+	/** @def BT_CODEC_LC3_DURATION
+	 *  @brief LC3 frame duration capability type
+	 */
+	BT_CODEC_LC3_DURATION            = 0x02,
+
+	/** @def BT_CODEC_LC3_CHAN_COUNT
+	 *  @brief LC3 channel count capability type
+	 */
+	BT_CODEC_LC3_CHAN_COUNT          = 0x03,
+
+	/** @def BT_CODEC_LC3_FRAME_LEN
+	 *  @brief LC3 frame length capability type
+	 */
+	BT_CODEC_LC3_FRAME_LEN           = 0x04,
+
+	/** @def BT_CODEC_LC3_FRAME_COUNT
+	 *  @brief Max codec frame count per SDU capability type
+	 */
+	BT_CODEC_LC3_FRAME_COUNT         = 0x05,
+};
+
 /** @def BT_CODEC_LC3_FREQ_8KHZ
  *  @brief LC3 8 Khz frequency capability
  */
@@ -76,10 +105,6 @@ extern "C" {
 					  BT_CODEC_LC3_FREQ_44KHZ | \
 					  BT_CODEC_LC3_FREQ_48KHZ)
 
-/** @def BT_CODEC_LC3_DURATION
- *  @brief LC3 frame duration capability type
- */
-#define BT_CODEC_LC3_DURATION            (BT_CODEC_LC3_CAP_BASE + 1)
 /** @def BT_CODEC_LC3_DURATION_7_5
  *  @brief LC3 7.5 msec frame duration capability
  */
@@ -103,74 +128,101 @@ extern "C" {
 #define BT_CODEC_LC3_DURATION_PREFER_10  BIT(5)
 
 
-/** @def BT_CODEC_LC3_CHAN_COUNT
- *  @brief LC3 channel count capability type
- */
-#define BT_CODEC_LC3_CHAN_COUNT          (BT_CODEC_LC3_CAP_BASE + 2)
 /** @def BT_CODEC_LC3_CHAN_COUNT_SUPPORT
  *  @brief LC3 channel count support capability
+ *  OR multiple supported counts together from 1 to 8
+ *  Example to support 1 and 3 channels:
+ *  BT_CODEC_LC3_CHAN_COUNT_SUPPORT(1) | BT_CODEC_LC3_CHAN_COUNT_SUPPORT(3)
  */
-#define BT_CODEC_LC3_CHAN_COUNT_SUPPORT  BIT(0)
+#define BT_CODEC_LC3_CHAN_COUNT_SUPPORT(_count)  ((uint8_t)BIT((_count) - 1))
 
-/** @def BT_CODEC_LC3_FRAME_LEN
- *  @brief LC3 frame length capability type
- */
-#define BT_CODEC_LC3_FRAME_LEN           (BT_CODEC_LC3_CAP_BASE + 3)
 
-/** @def BT_CODEC_LC3_FRAME_COUNT
- *  @brief LC3 frame count capability type
- */
-#define BT_CODEC_LC3_FRAME_COUNT         (BT_CODEC_LC3_CAP_BASE + 4)
-
-/* TODO: Remove base once LTV types are defined */
-#define BT_CODEC_LC3_CONFIG_BASE         0x01
 
 struct bt_codec_lc3_frame_len {
 	uint16_t min;
 	uint16_t max;
 };
 
-/** @def BT_CODEC_CONFIG_LC3_FREQ
- *  @brief LC3 Sample Frequency configuration type
+
+/**
+ * @brief Codec configuration type IDs
+ *
+ * Used to build and parse codec configurations as specified in the ASCS and BAP specifications.
+ * Source is assigned numbers for Generic Audio, bluetooth.com.
+ *
+ * Even though they are in-fixed with LC3 they can be used for other codec types as well.
  */
-#define BT_CODEC_CONFIG_LC3_FREQ         (BT_CODEC_LC3_CONFIG_BASE)
+enum bt_codec_config_type {
+
+	/** @brief LC3 Sample Frequency configuration type. */
+	BT_CODEC_CONFIG_LC3_FREQ                 = 0x01,
+
+	/** @brief LC3 Frame Duration configuration type. */
+	BT_CODEC_CONFIG_LC3_DURATION             = 0x02,
+
+	/** @brief LC3 channel Allocation configuration type. */
+	BT_CODEC_CONFIG_LC3_CHAN_ALLOC           = 0x03,
+
+	/** @brief LC3 Frame Length configuration type. */
+	BT_CODEC_CONFIG_LC3_FRAME_LEN            = 0x04,
+
+	/** @brief Codec frames = blocks, per SDU configuration type. */
+	BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU   = 0x05,
+};
+
 /** @def BT_CODEC_CONFIG_LC3_FREQ_8KHZ
- *  @brief LC3 8 Khz Sample Frequency configuration
+ *  @brief 8 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_8KHZ    0x01
 /** @def BT_CODEC_CONFIG_LC3_FREQ_11KHZ
- *  @brief LC3 11.025 Khz Sample Frequency configuration
+ *  @brief 11.025 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_11KHZ   0x02
 /** @def BT_CODEC_CONFIG_LC3_FREQ_16KHZ
- *  @brief LC3 16 Khz Sample Frequency configuration
+ *  @brief 16 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_16KHZ   0x03
 /** @def BT_CODEC_CONFIG_LC3_FREQ_22KHZ
- *  @brief LC3 22.05 Khz Sample Frequency configuration
+ *  @brief 22.05 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_22KHZ   0x04
 /** @def BT_CODEC_CONFIG_LC3_FREQ_24KHZ
- *  @brief LC3 24 Khz Sample Frequency configuration
+ *  @brief 24 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_24KHZ   0x05
 /** @def BT_CODEC_CONFIG_LC3_FREQ_32KHZ
- *  @brief LC3 32 Khz Sample Frequency configuration
+ *  @brief 32 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_32KHZ   0x06
 /** @def BT_CODEC_CONFIG_LC3_FREQ_44KHZ
- *  @brief LC3 44.1 Khz Sample Frequency configuration
+ *  @brief 44.1 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_44KHZ   0x07
 /** @def BT_CODEC_CONFIG_LC3_FREQ_48KHZ
- *  @brief LC3 48 Khz Sample Frequency configuration
+ *  @brief 48 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_48KHZ   0x08
-
-/** @def BT_CODEC_CONFIG_LC3_DURATION
- *  @brief LC3 Frame Duration configuration type
+/** @def BT_CODEC_CONFIG_LC3_FREQ_88KHZ
+ *  @brief 88.2 Khz codec Sample Frequency configuration
  */
-#define BT_CODEC_CONFIG_LC3_DURATION     (BT_CODEC_LC3_CONFIG_BASE + 1)
+#define BT_CODEC_CONFIG_LC3_FREQ_88KHZ   0x09
+/** @def BT_CODEC_CONFIG_LC3_FREQ_96KHZ
+ *  @brief 96 Khz codec Sample Frequency configuration
+ */
+#define BT_CODEC_CONFIG_LC3_FREQ_96KHZ   0x0a
+/** @def BT_CODEC_CONFIG_LC3_FREQ_176KHZ
+ *  @brief 176.4 Khz codec Sample Frequency configuration
+ */
+#define BT_CODEC_CONFIG_LC3_FREQ_176KHZ   0x0b
+/** @def BT_CODEC_CONFIG_LC3_FREQ_192KHZ
+ *  @brief 192 Khz codec Sample Frequency configuration
+ */
+#define BT_CODEC_CONFIG_LC3_FREQ_192KHZ   0x0c
+/** @def BT_CODEC_CONFIG_LC3_FREQ_384KHZ
+ *  @brief 384 Khz codec Sample Frequency configuration
+ */
+#define BT_CODEC_CONFIG_LC3_FREQ_384KHZ   0x0d
+
 /** @def BT_CODEC_CONFIG_LC3_DURATION_7_5
  *  @brief LC3 7.5 msec Frame Duration configuration
  */
@@ -180,15 +232,7 @@ struct bt_codec_lc3_frame_len {
  */
 #define BT_CODEC_CONFIG_LC3_DURATION_10  0x01
 
-/** @def BT_CODEC_CONFIG_LC3_CHAN_ALLOC
- *  @brief LC3 channel Allocation configuration type
- */
-#define BT_CODEC_CONFIG_LC3_CHAN_ALLOC   (BT_CODEC_LC3_CONFIG_BASE + 2)
 
-/** @def BT_CODEC_CONFIG_LC3_FRAME_LEN
- *  @brief LC3 Frame Length configuration type
- */
-#define BT_CODEC_CONFIG_LC3_FRAME_LEN    (BT_CODEC_LC3_CONFIG_BASE + 3)
 
 /** @def BT_CODEC_LC3_DATA
  *  @brief Helper to declare LC3 codec capability
@@ -391,6 +435,9 @@ struct bt_codec_lc3_frame_len {
  */
 #define BT_CODEC_LC3_QOS_10_UNFRAMED(_sdu, _rtn, _latency, _pd) \
 	BT_CODEC_QOS_UNFRAMED(10000u, _sdu, _rtn, _latency, _pd)
+
+
+
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/audio/CMakeLists.txt
+++ b/subsys/bluetooth/audio/CMakeLists.txt
@@ -46,7 +46,7 @@ zephyr_library_sources_ifdef(CONFIG_MCTL media_proxy.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_ASCS ascs.c)
 zephyr_library_sources_ifdef(CONFIG_BT_PACS pacs.c)
-zephyr_library_sources_ifdef(CONFIG_BT_AUDIO_STREAM stream.c)
+zephyr_library_sources_ifdef(CONFIG_BT_AUDIO_STREAM stream.c codec.c)
 zephyr_library_sources_ifdef(CONFIG_BT_AUDIO_UNICAST_SERVER unicast_server.c)
 zephyr_library_sources_ifdef(CONFIG_BT_AUDIO_CAPABILITY capabilities.c)
 zephyr_library_sources_ifdef(CONFIG_BT_AUDIO_UNICAST_CLIENT unicast_client.c)

--- a/subsys/bluetooth/audio/codec.c
+++ b/subsys/bluetooth/audio/codec.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2022 Bose Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/** @file
+ *  @brief Bluetooth LE-Audio codec LTV parsing
+ *
+ *  Helper functions to parse codec config data as specified in the Bluetooth assigned numbers for
+ *  Generic Audio.
+ */
+
+#include <bluetooth/audio/audio.h>
+#include <sys/byteorder.h>
+#include <sys/check.h>
+
+#define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_AUDIO)
+#define LOG_MODULE_NAME bt_audio
+#include "common/log.h"
+
+bool bt_codec_get_val(const struct bt_codec *codec,
+		      uint8_t type,
+		      const struct bt_codec_data **data)
+{
+	CHECKIF(codec == NULL) {
+		BT_DBG("codec is NULL");
+		return false;
+	}
+
+	for (size_t i = 0; i < codec->data_count; i++) {
+		if (codec->data[i].data.type == type) {
+			*data = &codec->data[i];
+
+			return true;
+		}
+	}
+
+	return false;
+}
+
+int bt_codec_cfg_get_freq(const struct bt_codec *codec)
+{
+	const struct bt_codec_data *element;
+
+	CHECKIF(codec == NULL) {
+		BT_DBG("codec is NULL");
+		return BT_AUDIO_CODEC_PARSE_ERR_INVALID_PARAM;
+	}
+
+	if (bt_codec_get_val(codec, BT_CODEC_CONFIG_LC3_FREQ, &element)) {
+
+		switch (element->data.data[0]) {
+		case BT_CODEC_CONFIG_LC3_FREQ_8KHZ:
+			return 8000;
+		case BT_CODEC_CONFIG_LC3_FREQ_11KHZ:
+			return 11025;
+		case BT_CODEC_CONFIG_LC3_FREQ_16KHZ:
+			return 16000;
+		case BT_CODEC_CONFIG_LC3_FREQ_22KHZ:
+			return 22050;
+		case BT_CODEC_CONFIG_LC3_FREQ_24KHZ:
+			return 24000;
+		case BT_CODEC_CONFIG_LC3_FREQ_32KHZ:
+			return 32000;
+		case BT_CODEC_CONFIG_LC3_FREQ_44KHZ:
+			return 44100;
+		case BT_CODEC_CONFIG_LC3_FREQ_48KHZ:
+			return 48000;
+		case BT_CODEC_CONFIG_LC3_FREQ_88KHZ:
+			return 88200;
+		case BT_CODEC_CONFIG_LC3_FREQ_96KHZ:
+			return 96000;
+		case BT_CODEC_CONFIG_LC3_FREQ_176KHZ:
+			return 176400;
+		case BT_CODEC_CONFIG_LC3_FREQ_192KHZ:
+			return 192000;
+		case BT_CODEC_CONFIG_LC3_FREQ_384KHZ:
+			return 384000;
+		default:
+			return BT_AUDIO_CODEC_PARSE_ERR_INVALID_VALUE_FOUND;
+		}
+	}
+
+	return BT_AUDIO_CODEC_PARSE_ERR_TYPE_NOT_FOUND;
+}
+
+int bt_codec_cfg_get_frame_duration_us(const struct bt_codec *codec)
+{
+	const struct bt_codec_data *element;
+
+	CHECKIF(codec == NULL) {
+		BT_DBG("codec is NULL");
+		return BT_AUDIO_CODEC_PARSE_ERR_INVALID_PARAM;
+	}
+
+	if (bt_codec_get_val(codec, BT_CODEC_CONFIG_LC3_DURATION, &element)) {
+		switch (element->data.data[0]) {
+		case BT_CODEC_CONFIG_LC3_DURATION_7_5:
+			return 7500;
+		case BT_CODEC_CONFIG_LC3_DURATION_10:
+			return 10000;
+		default:
+			return BT_AUDIO_CODEC_PARSE_ERR_INVALID_VALUE_FOUND;
+		}
+	}
+
+	return BT_AUDIO_CODEC_PARSE_ERR_TYPE_NOT_FOUND;
+}
+
+int bt_codec_cfg_get_chan_allocation_val(const struct bt_codec *codec,
+					 enum bt_audio_location *chan_allocation)
+{
+	const struct bt_codec_data *element;
+
+	CHECKIF(codec == NULL) {
+		BT_DBG("codec is NULL");
+		return BT_AUDIO_CODEC_PARSE_ERR_INVALID_PARAM;
+	}
+
+	CHECKIF(chan_allocation == NULL) {
+		return BT_AUDIO_CODEC_PARSE_ERR_INVALID_PARAM;
+	}
+
+	*chan_allocation = 0;
+	if (bt_codec_get_val(codec, BT_CODEC_CONFIG_LC3_CHAN_ALLOC, &element)) {
+
+		*chan_allocation = sys_le32_to_cpu(*((uint32_t *)&element->data.data[0]));
+
+		return BT_AUDIO_CODEC_PARSE_ERR_SUCCESS;
+	}
+
+	return BT_AUDIO_CODEC_PARSE_ERR_TYPE_NOT_FOUND;
+}
+
+int bt_codec_cfg_get_octets_per_frame(const struct bt_codec *codec)
+{
+	const struct bt_codec_data *element;
+
+	CHECKIF(codec == NULL) {
+		BT_DBG("codec is NULL");
+		return BT_AUDIO_CODEC_PARSE_ERR_INVALID_PARAM;
+	}
+
+	if (bt_codec_get_val(codec, BT_CODEC_CONFIG_LC3_FRAME_LEN, &element)) {
+
+		return sys_le16_to_cpu(*((uint16_t *)&element->data.data[0]));
+	}
+
+	return BT_AUDIO_CODEC_PARSE_ERR_TYPE_NOT_FOUND;
+}
+
+int bt_codec_cfg_get_frame_blocks_per_sdu(const struct bt_codec *codec, bool fallback_to_default)
+{
+	const struct bt_codec_data *element;
+
+	CHECKIF(codec == NULL) {
+		BT_DBG("codec is NULL");
+		return BT_AUDIO_CODEC_PARSE_ERR_INVALID_PARAM;
+	}
+
+	if (bt_codec_get_val(codec, BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU, &element)) {
+
+		return element->data.data[0];
+	}
+
+	if (fallback_to_default) {
+
+		return 1;
+	}
+
+	return BT_AUDIO_CODEC_PARSE_ERR_TYPE_NOT_FOUND;
+}


### PR DESCRIPTION
Fixes #42960.
Introduce functions to parse codec configuration and use them for LC3 configuration for BAP unicast applications.