### PR TITLE
can: stm32fd: correct timing min/max for data prop_seg and nominal sjw

### DIFF
--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -191,14 +191,14 @@ static const struct can_driver_api can_api_funcs = {
 	.get_max_filters = can_mcan_get_max_filters,
 	.set_state_change_callback = can_stm32fd_set_state_change_callback,
 	.timing_min = {
-		.sjw = 0x7f,
+		.sjw = 0x01,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x01,
 		.phase_seg2 = 0x01,
 		.prescaler = 0x01
 	},
 	.timing_max = {
-		.sjw = 0x7f,
+		.sjw = 0x80,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x100,
 		.phase_seg2 = 0x80,
@@ -207,7 +207,7 @@ static const struct can_driver_api can_api_funcs = {
 #ifdef CONFIG_CAN_FD_MODE
 	.timing_min_data = {
 		.sjw = 0x01,
-		.prop_seg = 0x01,
+		.prop_seg = 0x00,
 		.phase_seg1 = 0x01,
 		.phase_seg2 = 0x01,
 		.prescaler = 0x01


### PR DESCRIPTION
This commit changes the timing_min_data prop_seg
initialization of the `st,stm32-fdcan` can driver to zero.

Additionally the nominal sync jump width limits
are also adopted to new values 1 and 128.

This was not tested until recently and therefore
was only detected once the can timing test failed
on stm32g4  after PR #44197 got merged.

