### PR TITLE
tests: mbedtls: exclude m2gl025_miv

### DIFF
--- a/tests/crypto/mbedtls/testcase.yaml
+++ b/tests/crypto/mbedtls/testcase.yaml
@@ -6,6 +6,7 @@ common:
 tests:
   crypto.mbedtls:
     arch_exclude: riscv64
+    platform_exclude: m2gl025_miv
   crypto.mbedtls.riscv64:
     arch_allow: riscv64
     extra_configs:


### PR DESCRIPTION
This test just takes forever on this platform. Exclude it.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
