### PR TITLE
ITE drivers/timer: fix tests/drivers/flash build error

### DIFF
--- a/drivers/timer/ite_it8xxx2_timer.c
+++ b/drivers/timer/ite_it8xxx2_timer.c
@@ -15,9 +15,6 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(timer, LOG_LEVEL_ERR);
 
-/* RAM code section */
-#define __timer_ram_code __attribute__((section(".__ram_code")))
-
 /* Event timer configurations */
 #define EVENT_TIMER		EXT_TIMER_3
 #define EVENT_TIMER_IRQ		DT_INST_IRQ_BY_IDX(0, 0, irq)
@@ -138,7 +135,7 @@ void timer_5ms_one_shot(void)
 #endif /* CONFIG_SOC_IT8XXX2_PLL_FLASH_48M */
 
 #ifdef CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT
-__timer_ram_code void arch_busy_wait(uint32_t usec_to_wait)
+void arch_busy_wait(uint32_t usec_to_wait)
 {
 	if (!usec_to_wait) {
 		return;


### PR DESCRIPTION
There wasn't the build error in PR#44060,
but now tool chain isn't happy about putting the arch_busy_wait()
to __ram_code section, then it shows a build error:
https://github.com/zephyrproject-rtos/zephyr/runs/5755633537?check_suite_focus=true#step:10:933

So I remove __ram_code of arch_busy_wait(), and this will need
extra fetch code time when arch_busy_wait() code isn't in the
dynamic cache.

Verified by follow test pattern:
west build -p auto -b it8xxx2_evb tests/drivers/flash

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>