### PR TITLE
drivers/disk: sdmmc: stm32: DMA header requested on F4 serie

### DIFF
--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -51,7 +51,7 @@ config SDMMC_STM32
 	select USE_STM32_HAL_SD
 	select USE_STM32_HAL_SD_EX if SOC_SERIES_STM32L4X
 	select USE_STM32_LL_SDMMC
-	select USE_STM32_HAL_DMA if (SOC_SERIES_STM32L4X || SOC_SERIES_STM32F7X)
+	select USE_STM32_HAL_DMA if (SOC_SERIES_STM32L4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32F4X)
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_SDMMC))
 	help
 	  File system on sdmmc accessed through stm32 sdmmc.

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -514,6 +514,15 @@
 			status = "disabled";
 			label = "DMA_2";
 		};
+
+		sdmmc1: sdmmc@40012c00 {
+			compatible = "st,stm32-sdmmc";
+			reg = <0x40012c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000800>;
+			interrupts = <49 0>;
+			status = "disabled";
+			label = "SDMMC_1";
+		};
 	};
 
 	otgfs_phy: otgfs_phy {


### PR DESCRIPTION
Even if not used DMA HAL is required in F4 SD HAL driver. Just
as for L4/F7 series that have been added before.
Add it for this specific serie.

Signed-off-by: John Kjellberg <kjellberg.john@gmail.com>