### PR TITLE
drivers: spi: esp32c3: add master init call

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -233,6 +233,8 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 		return -EIO;
 	}
 
+	spi_ll_master_init(hal->hw);
+
 	ctx->config = spi_cfg;
 
 	if (spi_cfg->operation & SPI_HALF_DUPLEX) {


### PR DESCRIPTION
ESP32C3 requires master init call to enable its clock
gate. Without this, SPI interface may not initialize
properly.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>