### PR TITLE
drivers: ieee802154_nrf5: limit IEEE802154_NRF5_DELAY_TRX_ACC

### DIFF
--- a/drivers/ieee802154/Kconfig.nrf5
+++ b/drivers/ieee802154/Kconfig.nrf5
@@ -77,7 +77,8 @@ config IEEE802154_NRF5_FCS_IN_LENGTH
 
 config IEEE802154_NRF5_DELAY_TRX_ACC
 	int "Clock accuracy for delayed operations"
-	default CLOCK_CONTROL_NRF_ACCURACY
+	default CLOCK_CONTROL_NRF_ACCURACY if CLOCK_CONTROL_NRF_ACCURACY < 255
+	default 255
 	help
 	  Accuracy of the clock used for scheduling radio delayed operations (delayed transmission
 	  or delayed reception), in ppm.


### PR DESCRIPTION
Currently IEEE802154_NRF5_DELAY_TRX_ACC can exceed the max possible value. Add upper bound to limit this.

This PR addresses https://github.com/zephyrproject-rtos/zephyr/pull/44287#discussion_r839511196