### PR TITLE
drivers: pwm: header cleanup

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -2275,7 +2275,6 @@ PREDEFINED             = __DOXYGEN__ \
                          CONFIG_NET_MGMT_EVENT \
                          CONFIG_NET_TCP \
                          CONFIG_NET_UDP \
-                         CONFIG_PWM_CAPTURE \
                          CONFIG_SCHED_CPU_MASK \
                          CONFIG_SCHED_DEADLINE \
                          CONFIG_SCHED_DEADLINE \

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -84,7 +84,7 @@ typedef uint16_t pwm_flags_t;
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected to enable PWM capture
  * support.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param period_cycles Captured PWM period width (in clock cycles). HW
  *                      specific.
@@ -172,7 +172,7 @@ __subsystem struct pwm_driver_api {
  * Passing a non-zero @p pulse equal to @p period will cause the pin
  * to be driven to a constant active level.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param period Period (in clock cycles) set to the PWM. HW specific.
  * @param pulse Pulse width (in clock cycles) set to the PWM. HW specific.
@@ -199,10 +199,10 @@ static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
 /**
  * @brief Get the clock rate (cycles per second) for a single PWM output.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
- * @param cycles Pointer to the memory to store clock rate (cycles per sec).
- *		 HW specific.
+ * @param[out] cycles Pointer to the memory to store clock rate (cycles per
+ *                    sec). HW specific.
  *
  * @retval 0 If successful.
  * @retval -errno Negative errno code on failure.
@@ -224,7 +224,7 @@ static inline int z_impl_pwm_get_cycles_per_sec(const struct device *dev,
  * @brief Set the period and pulse width in microseconds for a single PWM
  *        output.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param period Period (in microseconds) set to the PWM.
  * @param pulse Pulse width (in microseconds) set to the PWM.
@@ -265,7 +265,7 @@ static inline int pwm_pin_set_usec(const struct device *dev, uint32_t pwm,
 /**
  * @brief Set the period and pulse width in nanoseconds for a single PWM output.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param period Period (in nanoseconds) set to the PWM.
  * @param pulse Pulse width (in nanoseconds) set to the PWM.
@@ -306,10 +306,10 @@ static inline int pwm_pin_set_nsec(const struct device *dev, uint32_t pwm,
 /**
  * @brief Convert from PWM cycles to microseconds.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param cycles Cycles to be converted.
- * @param usec Pointer to the memory to store calculated usec.
+ * @param[out] usec Pointer to the memory to store calculated usec.
  *
  * @retval 0 If successful.
  * @retval -ERANGE If result is too large.
@@ -339,10 +339,10 @@ static inline int pwm_pin_cycles_to_usec(const struct device *dev, uint32_t pwm,
 /**
  * @brief Convert from PWM cycles to nanoseconds.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param cycles Cycles to be converted.
- * @param nsec Pointer to the memory to store the calculated nsec.
+ * @param[out] nsec Pointer to the memory to store the calculated nsec.
  *
  * @retval 0 If successful.
  * @retval -ERANGE If result is too large.
@@ -385,12 +385,12 @@ static inline int pwm_pin_cycles_to_nsec(const struct device *dev, uint32_t pwm,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags
- * @param cb Application callback handler function to be called upon capture
- * @param user_data User data to pass to the application callback handler
- *                  function
+ * @param[in] cb Application callback handler function to be called upon capture
+ * @param[in] user_data User data to pass to the application callback handler
+ *                      function
  *
  * @retval -EINVAL if invalid function parameters were given
  * @retval -ENOSYS if PWM capture is not supported or the given flags are not
@@ -423,7 +423,7 @@ static inline int pwm_pin_configure_capture(const struct device *dev,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  *
  * @retval 0 If successful.
@@ -455,7 +455,7 @@ static inline int z_impl_pwm_pin_enable_capture(const struct device *dev,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  *
  * @retval 0 If successful.
@@ -492,13 +492,13 @@ static inline int z_impl_pwm_pin_disable_capture(const struct device *dev,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags.
- * @param period Pointer to the memory to store the captured PWM period width
- *               (in clock cycles). HW specific.
- * @param pulse Pointer to the memory to store the captured PWM pulse width (in
- *              clock cycles). HW specific.
+ * @param[out] period Pointer to the memory to store the captured PWM period
+ *                    width (in clock cycles). HW specific.
+ * @param[out] pulse Pointer to the memory to store the captured PWM pulse width
+ *                   (in clock cycles). HW specific.
  * @param timeout Waiting period for the capture to complete.
  *
  * @retval 0 If successful.
@@ -523,13 +523,13 @@ __syscall int pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags.
- * @param period Pointer to the memory to store the captured PWM period width
- *               (in usec).
- * @param pulse Pointer to the memory to store the captured PWM pulse width (in
- *              usec).
+ * @param[out] period Pointer to the memory to store the captured PWM period
+ *                    width (in usec).
+ * @param[out] pulse Pointer to the memory to store the captured PWM pulse width
+ *                   (in usec).
  * @param timeout Waiting period for the capture to complete.
  *
  * @retval 0 If successful.
@@ -578,13 +578,13 @@ static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev PWM device instance.
+ * @param[in] dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags.
- * @param period Pointer to the memory to store the captured PWM period width
- *               (in nsec).
- * @param pulse Pointer to the memory to store the captured PWM pulse width (in
- *              nsec).
+ * @param[out] period Pointer to the memory to store the captured PWM period
+ *                    width (in nsec).
+ * @param[out] pulse Pointer to the memory to store the captured PWM pulse width
+ *                   (in nsec).
  * @param timeout Waiting period for the capture to complete.
  *
  * @retval 0 If successful.

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -84,9 +84,8 @@ typedef uint16_t pwm_flags_t;
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected to enable PWM capture
  * support.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
-
  * @param period_cycles Captured PWM period width (in clock cycles). HW
  *                      specific.
  * @param pulse_cycles Captured PWM pulse width (in clock cycles). HW specific.
@@ -103,7 +102,7 @@ typedef void (*pwm_capture_callback_handler_t)(const struct device *dev,
 
 /** @cond INTERNAL_HIDDEN */
 /**
- * @brief Callback API upon setting the pin
+ * @brief PWM driver API call to configure PWM pin period and pulse width.
  * @see pwm_pin_set_cycles() for argument description.
  */
 typedef int (*pwm_pin_set_t)(const struct device *dev, uint32_t pwm,
@@ -111,7 +110,7 @@ typedef int (*pwm_pin_set_t)(const struct device *dev, uint32_t pwm,
 			     pwm_flags_t flags);
 
 /**
- * @brief Callback API upon getting cycles per second
+ * @brief PWM driver API call to obtain the PWM cycles per second (frequency).
  * @see pwm_get_cycles_per_sec() for argument description
  */
 typedef int (*pwm_get_cycles_per_sec_t)(const struct device *dev,
@@ -119,7 +118,7 @@ typedef int (*pwm_get_cycles_per_sec_t)(const struct device *dev,
 
 #ifdef CONFIG_PWM_CAPTURE
 /**
- * @brief Callback API upon configuring PWM pin capture
+ * @brief PWM driver API call to configure PWM capture.
  * @see pwm_pin_configure_capture() for argument description.
  */
 typedef int (*pwm_pin_configure_capture_t)(const struct device *dev,
@@ -127,14 +126,14 @@ typedef int (*pwm_pin_configure_capture_t)(const struct device *dev,
 					   pwm_capture_callback_handler_t cb,
 					   void *user_data);
 /**
- * @brief Callback API upon enabling PWM pin capture
+ * @brief PWM driver API call to enable PWM capture.
  * @see pwm_pin_enable_capture() for argument description.
  */
 typedef int (*pwm_pin_enable_capture_t)(const struct device *dev,
 					uint32_t pwm);
 
 /**
- * @brief Callback API upon disabling PWM pin capture
+ * @brief PWM driver API call to disable PWM capture.
  * @see pwm_pin_disable_capture() for argument description
  */
 typedef int (*pwm_pin_disable_capture_t)(const struct device *dev,
@@ -173,11 +172,11 @@ __subsystem struct pwm_driver_api {
  * Passing a non-zero @p pulse equal to @p period will cause the pin
  * to be driven to a constant active level.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
- * @param period Period (in clock cycle) set to the PWM. HW specific.
- * @param pulse Pulse width (in clock cycle) set to the PWM. HW specific.
- * @param flags Flags for pin configuration (polarity).
+ * @param period Period (in clock cycles) set to the PWM. HW specific.
+ * @param pulse Pulse width (in clock cycles) set to the PWM. HW specific.
+ * @param flags Flags for pin configuration.
  *
  * @retval 0 If successful.
  * @retval -errno Negative errno code on failure.
@@ -200,7 +199,7 @@ static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
 /**
  * @brief Get the clock rate (cycles per second) for a single PWM output.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param cycles Pointer to the memory to store clock rate (cycles per sec).
  *		 HW specific.
@@ -222,9 +221,10 @@ static inline int z_impl_pwm_get_cycles_per_sec(const struct device *dev,
 }
 
 /**
- * @brief Set the period and pulse width for a single PWM output.
+ * @brief Set the period and pulse width in microseconds for a single PWM
+ *        output.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param period Period (in microseconds) set to the PWM.
  * @param pulse Pulse width (in microseconds) set to the PWM.
@@ -263,9 +263,9 @@ static inline int pwm_pin_set_usec(const struct device *dev, uint32_t pwm,
 }
 
 /**
- * @brief Set the period and pulse width for a single PWM output.
+ * @brief Set the period and pulse width in nanoseconds for a single PWM output.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param period Period (in nanoseconds) set to the PWM.
  * @param pulse Pulse width (in nanoseconds) set to the PWM.
@@ -306,7 +306,7 @@ static inline int pwm_pin_set_nsec(const struct device *dev, uint32_t pwm,
 /**
  * @brief Convert from PWM cycles to microseconds.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param cycles Cycles to be converted.
  * @param usec Pointer to the memory to store calculated usec.
@@ -339,7 +339,7 @@ static inline int pwm_pin_cycles_to_usec(const struct device *dev, uint32_t pwm,
 /**
  * @brief Convert from PWM cycles to nanoseconds.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param cycles Cycles to be converted.
  * @param nsec Pointer to the memory to store the calculated nsec.
@@ -385,7 +385,7 @@ static inline int pwm_pin_cycles_to_nsec(const struct device *dev, uint32_t pwm,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags
  * @param cb Application callback handler function to be called upon capture
@@ -423,7 +423,7 @@ static inline int pwm_pin_configure_capture(const struct device *dev,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  *
  * @retval 0 If successful.
@@ -455,7 +455,7 @@ static inline int z_impl_pwm_pin_enable_capture(const struct device *dev,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  *
  * @retval 0 If successful.
@@ -492,7 +492,7 @@ static inline int z_impl_pwm_pin_disable_capture(const struct device *dev,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags.
  * @param period Pointer to the memory to store the captured PWM period width
@@ -523,7 +523,7 @@ __syscall int pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags.
  * @param period Pointer to the memory to store the captured PWM period width
@@ -578,7 +578,7 @@ static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
- * @param dev Pointer to the device structure for the driver instance.
+ * @param dev PWM device instance.
  * @param pwm PWM pin.
  * @param flags PWM capture flags.
  * @param period Pointer to the memory to store the captured PWM period width

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -191,9 +191,9 @@ static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
 					    uint32_t period, uint32_t pulse,
 					    pwm_flags_t flags)
 {
-	struct pwm_driver_api *api;
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
 
-	api = (struct pwm_driver_api *)dev->api;
 	return api->pin_set(dev, pwm, period, pulse, flags);
 }
 
@@ -232,7 +232,8 @@ static inline int pwm_pin_configure_capture(const struct device *dev,
 					    pwm_capture_callback_handler_t cb,
 					    void *user_data)
 {
-	const struct pwm_driver_api *api = (struct pwm_driver_api *)dev->api;
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
 
 	if (api->pin_configure_capture == NULL) {
 		return -ENOSYS;
@@ -266,7 +267,8 @@ __syscall int pwm_pin_enable_capture(const struct device *dev, uint32_t pwm);
 static inline int z_impl_pwm_pin_enable_capture(const struct device *dev,
 						uint32_t pwm)
 {
-	const struct pwm_driver_api *api = (struct pwm_driver_api *)dev->api;
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
 
 	if (api->pin_enable_capture == NULL) {
 		return -ENOSYS;
@@ -296,7 +298,8 @@ __syscall int pwm_pin_disable_capture(const struct device *dev, uint32_t pwm);
 static inline int z_impl_pwm_pin_disable_capture(const struct device *dev,
 						 uint32_t pwm)
 {
-	const struct pwm_driver_api *api = (struct pwm_driver_api *)dev->api;
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
 
 	if (api->pin_disable_capture == NULL) {
 		return -ENOSYS;
@@ -357,9 +360,9 @@ static inline int z_impl_pwm_get_cycles_per_sec(const struct device *dev,
 						uint32_t pwm,
 						uint64_t *cycles)
 {
-	struct pwm_driver_api *api;
+	const struct pwm_driver_api *api =
+		(const struct pwm_driver_api *)dev->api;
 
-	api = (struct pwm_driver_api *)dev->api;
 	return api->get_cycles_per_sec(dev, pwm, cycles);
 }
 

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -181,7 +181,7 @@ __subsystem struct pwm_driver_api {
  * @param flags Flags for pin configuration (polarity).
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code on failure.
  */
 __syscall int pwm_pin_set_cycles(const struct device *dev, uint32_t pwm,
 				 uint32_t period, uint32_t pulse, pwm_flags_t flags);
@@ -351,7 +351,7 @@ __syscall int pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
  *		 HW specific.
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -errno Negative errno code on failure.
  */
 __syscall int pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 				     uint64_t *cycles);
@@ -376,16 +376,19 @@ static inline int z_impl_pwm_get_cycles_per_sec(const struct device *dev,
  * @param flags Flags for pin configuration (polarity).
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -ENOTSUP If requested period or pulse cycles are not supported.
+ * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_set_usec(const struct device *dev, uint32_t pwm,
 				   uint32_t period, uint32_t pulse,
 				   pwm_flags_t flags)
 {
+	int err;
 	uint64_t period_cycles, pulse_cycles, cycles_per_sec;
 
-	if (pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec) != 0) {
-		return -EIO;
+	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
+	if (err < 0) {
+		return err;
 	}
 
 	period_cycles = (period * cycles_per_sec) / USEC_PER_SEC;
@@ -412,16 +415,19 @@ static inline int pwm_pin_set_usec(const struct device *dev, uint32_t pwm,
  * @param flags Flags for pin configuration (polarity).
  *
  * @retval 0 If successful.
- * @retval Negative errno code if failure.
+ * @retval -ENOTSUP If requested period or pulse cycles are not supported.
+ * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_set_nsec(const struct device *dev, uint32_t pwm,
 				   uint32_t period, uint32_t pulse,
 				   pwm_flags_t flags)
 {
+	int err;
 	uint64_t period_cycles, pulse_cycles, cycles_per_sec;
 
-	if (pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec) != 0) {
-		return -EIO;
+	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
+	if (err < 0) {
+		return err;
 	}
 
 	period_cycles = (period * cycles_per_sec) / NSEC_PER_SEC;
@@ -447,17 +453,19 @@ static inline int pwm_pin_set_nsec(const struct device *dev, uint32_t pwm,
  * @param usec Pointer to the memory to store calculated usec.
  *
  * @retval 0 If successful.
- * @retval -EIO If cycles per second cannot be determined.
  * @retval -ERANGE If result is too large.
+ * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_cycles_to_usec(const struct device *dev, uint32_t pwm,
 					 uint32_t cycles, uint64_t *usec)
 {
+	int err;
 	uint64_t cycles_per_sec;
 	uint64_t temp;
 
-	if (pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec) != 0) {
-		return -EIO;
+	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
+	if (err < 0) {
+		return err;
 	}
 
 	if (u64_mul_overflow(cycles, (uint64_t)USEC_PER_SEC, &temp)) {
@@ -478,17 +486,19 @@ static inline int pwm_pin_cycles_to_usec(const struct device *dev, uint32_t pwm,
  * @param nsec Pointer to the memory to store the calculated nsec.
  *
  * @retval 0 If successful.
- * @retval -EIO If cycles per second cannot be determined.
  * @retval -ERANGE If result is too large.
+ * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_cycles_to_nsec(const struct device *dev, uint32_t pwm,
 					 uint32_t cycles, uint64_t *nsec)
 {
+	int err;
 	uint64_t cycles_per_sec;
 	uint64_t temp;
 
-	if (pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec) != 0) {
-		return -EIO;
+	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
+	if (err < 0) {
+		return err;
 	}
 
 	if (u64_mul_overflow(cycles, (uint64_t)NSEC_PER_SEC, &temp)) {
@@ -526,6 +536,7 @@ static inline int pwm_pin_cycles_to_nsec(const struct device *dev, uint32_t pwm,
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EIO IO error while capturing.
  * @retval -ERANGE If result is too large.
+ * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
 				       pwm_flags_t flags,
@@ -582,6 +593,7 @@ static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
  * @retval -EAGAIN Waiting period timed out.
  * @retval -EIO IO error while capturing.
  * @retval -ERANGE If result is too large.
+ * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_capture_nsec(const struct device *dev, uint32_t pwm,
 				       pwm_flags_t flags,

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -75,14 +75,6 @@ extern "C" {
 typedef uint16_t pwm_flags_t;
 
 /**
- * @brief Callback API upon setting the pin
- * @see pwm_pin_set_cycles() for argument description.
- */
-typedef int (*pwm_pin_set_t)(const struct device *dev, uint32_t pwm,
-			     uint32_t period_cycles, uint32_t pulse_cycles,
-			     pwm_flags_t flags);
-
-/**
  * @brief PWM capture callback handler function signature
  *
  * @note The callback handler will be called in interrupt context.
@@ -108,6 +100,16 @@ typedef void (*pwm_capture_callback_handler_t)(const struct device *dev,
 					       int status,
 					       void *user_data);
 
+/** @cond INTERNAL_HIDDEN */
+/**
+ * @brief Callback API upon setting the pin
+ * @see pwm_pin_set_cycles() for argument description.
+ */
+typedef int (*pwm_pin_set_t)(const struct device *dev, uint32_t pwm,
+			     uint32_t period_cycles, uint32_t pulse_cycles,
+			     pwm_flags_t flags);
+
+#ifdef CONFIG_PWM_CAPTURE
 /**
  * @brief Callback API upon configuring PWM pin capture
  * @see pwm_pin_configure_capture() for argument description.
@@ -130,6 +132,7 @@ typedef int (*pwm_pin_enable_capture_t)(const struct device *dev,
  */
 typedef int (*pwm_pin_disable_capture_t)(const struct device *dev,
 					 uint32_t pwm);
+#endif /* CONFIG_PWM_CAPTURE */
 
 /**
  * @brief Callback API upon getting cycles per second
@@ -149,6 +152,7 @@ __subsystem struct pwm_driver_api {
 #endif /* CONFIG_PWM_CAPTURE */
 	pwm_get_cycles_per_sec_t get_cycles_per_sec;
 };
+/** @endcond */
 
 /**
  * @brief Set the period and pulse width for a single PWM output.

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -21,10 +21,12 @@
  */
 
 #include <errno.h>
-#include <zephyr/types.h>
-#include <stddef.h>
-#include <sys/math_extras.h>
+#include <stdint.h>
+
 #include <device.h>
+#include <sys/math_extras.h>
+#include <toolchain.h>
+
 #include <dt-bindings/pwm/pwm.h>
 
 #ifdef __cplusplus

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -249,12 +249,12 @@ static inline int pwm_pin_set_usec(const struct device *dev, uint32_t pwm,
 	}
 
 	period_cycles = (period * cycles_per_sec) / USEC_PER_SEC;
-	if (period_cycles >= ((uint64_t)1 << 32)) {
+	if (period_cycles > UINT32_MAX) {
 		return -ENOTSUP;
 	}
 
 	pulse_cycles = (pulse * cycles_per_sec) / USEC_PER_SEC;
-	if (pulse_cycles >= ((uint64_t)1 << 32)) {
+	if (pulse_cycles > UINT32_MAX) {
 		return -ENOTSUP;
 	}
 
@@ -290,12 +290,12 @@ static inline int pwm_pin_set_nsec(const struct device *dev, uint32_t pwm,
 	}
 
 	period_cycles = (period * cycles_per_sec) / NSEC_PER_SEC;
-	if (period_cycles >= ((uint64_t)1 << 32)) {
+	if (period_cycles > UINT32_MAX) {
 		return -ENOTSUP;
 	}
 
 	pulse_cycles = (pulse * cycles_per_sec) / NSEC_PER_SEC;
-	if (pulse_cycles >= ((uint64_t)1 << 32)) {
+	if (pulse_cycles > UINT32_MAX) {
 		return -ENOTSUP;
 	}
 

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -97,8 +97,7 @@ typedef void (*pwm_capture_callback_handler_t)(const struct device *dev,
 					       uint32_t pwm,
 					       uint32_t period_cycles,
 					       uint32_t pulse_cycles,
-					       int status,
-					       void *user_data);
+					       int status, void *user_data);
 
 /** @cond INTERNAL_HIDDEN */
 /**
@@ -114,8 +113,7 @@ typedef int (*pwm_pin_set_t)(const struct device *dev, uint32_t pwm,
  * @see pwm_get_cycles_per_sec() for argument description
  */
 typedef int (*pwm_get_cycles_per_sec_t)(const struct device *dev,
-					uint32_t pwm,
-					uint64_t *cycles);
+					uint32_t pwm, uint64_t *cycles);
 
 #ifdef CONFIG_PWM_CAPTURE
 /**
@@ -123,8 +121,7 @@ typedef int (*pwm_get_cycles_per_sec_t)(const struct device *dev,
  * @see pwm_pin_configure_capture() for argument description.
  */
 typedef int (*pwm_pin_configure_capture_t)(const struct device *dev,
-					   uint32_t pwm,
-					   pwm_flags_t flags,
+					   uint32_t pwm, pwm_flags_t flags,
 					   pwm_capture_callback_handler_t cb,
 					   void *user_data);
 /**
@@ -184,7 +181,8 @@ __subsystem struct pwm_driver_api {
  * @retval -errno Negative errno code on failure.
  */
 __syscall int pwm_pin_set_cycles(const struct device *dev, uint32_t pwm,
-				 uint32_t period, uint32_t pulse, pwm_flags_t flags);
+				 uint32_t period, uint32_t pulse,
+				 pwm_flags_t flags);
 
 static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
 					    uint32_t pwm,
@@ -239,7 +237,9 @@ static inline int pwm_pin_set_usec(const struct device *dev, uint32_t pwm,
 				   pwm_flags_t flags)
 {
 	int err;
-	uint64_t period_cycles, pulse_cycles, cycles_per_sec;
+	uint64_t pulse_cycles;
+	uint64_t period_cycles;
+	uint64_t cycles_per_sec;
 
 	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
 	if (err < 0) {
@@ -278,7 +278,9 @@ static inline int pwm_pin_set_nsec(const struct device *dev, uint32_t pwm,
 				   pwm_flags_t flags)
 {
 	int err;
-	uint64_t period_cycles, pulse_cycles, cycles_per_sec;
+	uint64_t pulse_cycles;
+	uint64_t period_cycles;
+	uint64_t cycles_per_sec;
 
 	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
 	if (err < 0) {
@@ -315,8 +317,8 @@ static inline int pwm_pin_cycles_to_usec(const struct device *dev, uint32_t pwm,
 					 uint32_t cycles, uint64_t *usec)
 {
 	int err;
-	uint64_t cycles_per_sec;
 	uint64_t temp;
+	uint64_t cycles_per_sec;
 
 	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
 	if (err < 0) {
@@ -348,8 +350,8 @@ static inline int pwm_pin_cycles_to_nsec(const struct device *dev, uint32_t pwm,
 					 uint32_t cycles, uint64_t *nsec)
 {
 	int err;
-	uint64_t cycles_per_sec;
 	uint64_t temp;
+	uint64_t cycles_per_sec;
 
 	err = pwm_get_cycles_per_sec(dev, pwm, &cycles_per_sec);
 	if (err < 0) {
@@ -395,8 +397,7 @@ static inline int pwm_pin_cycles_to_nsec(const struct device *dev, uint32_t pwm,
  * @retval -EBUSY if PWM capture is already in progress
  */
 static inline int pwm_pin_configure_capture(const struct device *dev,
-					    uint32_t pwm,
-					    pwm_flags_t flags,
+					    uint32_t pwm, pwm_flags_t flags,
 					    pwm_capture_callback_handler_t cb,
 					    void *user_data)
 {
@@ -505,10 +506,8 @@ static inline int z_impl_pwm_pin_disable_capture(const struct device *dev,
  * @retval -ERANGE If result is too large.
  */
 __syscall int pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
-				     pwm_flags_t flags,
-				     uint32_t *period,
-				     uint32_t *pulse,
-				     k_timeout_t timeout);
+				     pwm_flags_t flags, uint32_t *period,
+				     uint32_t *pulse, k_timeout_t timeout);
 
 /**
  * @brief Capture a single PWM period/pulse width in microseconds for a single
@@ -539,14 +538,12 @@ __syscall int pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
  * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
-				       pwm_flags_t flags,
-				       uint64_t *period,
-				       uint64_t *pulse,
-				       k_timeout_t timeout)
+				       pwm_flags_t flags, uint64_t *period,
+				       uint64_t *pulse, k_timeout_t timeout)
 {
-	uint32_t period_cycles;
-	uint32_t pulse_cycles;
 	int err;
+	uint32_t pulse_cycles;
+	uint32_t period_cycles;
 
 	err = pwm_pin_capture_cycles(dev, pwm, flags, &period_cycles,
 				     &pulse_cycles, timeout);
@@ -596,14 +593,12 @@ static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
  * @retval -errno Other negative errno code on failure.
  */
 static inline int pwm_pin_capture_nsec(const struct device *dev, uint32_t pwm,
-				       pwm_flags_t flags,
-				       uint64_t *period,
-				       uint64_t *pulse,
-				       k_timeout_t timeout)
+				       pwm_flags_t flags, uint64_t *period,
+				       uint64_t *pulse, k_timeout_t timeout)
 {
-	uint32_t period_cycles;
-	uint32_t pulse_cycles;
 	int err;
+	uint32_t pulse_cycles;
+	uint32_t period_cycles;
 
 	err = pwm_pin_capture_cycles(dev, pwm, flags, &period_cycles,
 				     &pulse_cycles, timeout);

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -33,6 +33,7 @@ extern "C" {
 
 /**
  * @name PWM capture configuration flags
+ * @anchor PWM_CAPTURE_FLAGS
  * @{
  */
 
@@ -67,21 +68,21 @@ extern "C" {
  *
  * The lower 8 bits are used for standard flags.
  * The upper 8 bits are reserved for SoC specific flags.
+ *
+ * @see @ref PWM_CAPTURE_FLAGS.
  */
 
 typedef uint16_t pwm_flags_t;
 
 /**
- * @typedef pwm_pin_set_t
  * @brief Callback API upon setting the pin
- * See @a pwm_pin_set_cycles() for argument description
+ * @see pwm_pin_set_cycles() for argument description.
  */
 typedef int (*pwm_pin_set_t)(const struct device *dev, uint32_t pwm,
 			     uint32_t period_cycles, uint32_t pulse_cycles,
 			     pwm_flags_t flags);
 
 /**
- * @typedef pwm_capture_callback_handler_t
  * @brief PWM capture callback handler function signature
  *
  * @note The callback handler will be called in interrupt context.
@@ -96,9 +97,9 @@ typedef int (*pwm_pin_set_t)(const struct device *dev, uint32_t pwm,
  *                      specific.
  * @param pulse_cycles Captured PWM pulse width (in clock cycles). HW specific.
  * @param status Status for the PWM capture (0 if no error, negative errno
- *               otherwise. See @a pwm_pin_capture_cycles() return value
+ *               otherwise. See pwm_pin_capture_cycles() return value
  *               descriptions for details).
- * @param user_data User data passed to @a pwm_pin_configure_capture()
+ * @param user_data User data passed to pwm_pin_configure_capture()
  */
 typedef void (*pwm_capture_callback_handler_t)(const struct device *dev,
 					       uint32_t pwm,
@@ -108,9 +109,8 @@ typedef void (*pwm_capture_callback_handler_t)(const struct device *dev,
 					       void *user_data);
 
 /**
- * @typedef pwm_pin_configure_capture_t
  * @brief Callback API upon configuring PWM pin capture
- * See @a pwm_pin_configure_capture() for argument description
+ * @see pwm_pin_configure_capture() for argument description.
  */
 typedef int (*pwm_pin_configure_capture_t)(const struct device *dev,
 					   uint32_t pwm,
@@ -118,25 +118,22 @@ typedef int (*pwm_pin_configure_capture_t)(const struct device *dev,
 					   pwm_capture_callback_handler_t cb,
 					   void *user_data);
 /**
- * @typedef pwm_pin_enable_capture_t
  * @brief Callback API upon enabling PWM pin capture
- * See @a pwm_pin_enable_capture() for argument description
+ * @see pwm_pin_enable_capture() for argument description.
  */
 typedef int (*pwm_pin_enable_capture_t)(const struct device *dev,
 					uint32_t pwm);
 
 /**
- * @typedef pwm_pin_disable_capture_t
  * @brief Callback API upon disabling PWM pin capture
- * See @a pwm_pin_disable_capture() for argument description
+ * @see pwm_pin_disable_capture() for argument description
  */
 typedef int (*pwm_pin_disable_capture_t)(const struct device *dev,
 					 uint32_t pwm);
 
 /**
- * @typedef pwm_get_cycles_per_sec_t
  * @brief Callback API upon getting cycles per second
- * See @a pwm_get_cycles_per_sec() for argument description
+ * @see pwm_get_cycles_per_sec() for argument description
  */
 typedef int (*pwm_get_cycles_per_sec_t)(const struct device *dev,
 					uint32_t pwm,
@@ -196,16 +193,17 @@ static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
 	return api->pin_set(dev, pwm, period, pulse, flags);
 }
 
+#if defined(CONFIG_PWM_CAPTURE) || defined(__DOXYGEN__)
 /**
  * @brief Configure PWM period/pulse width capture for a single PWM input.
  *
  * After configuring PWM capture using this function, the capture can be
- * enabled/disabled using @a pwm_pin_enable_capture() and @a
+ * enabled/disabled using pwm_pin_enable_capture() and
  * pwm_pin_disable_capture().
  *
  * @note This API function cannot be invoked from user space due to the use of a
- * function callback. In user space, one of the simpler API functions (@a
- * pwm_pin_capture_cycles(), @a pwm_pin_capture_usec(), or @a
+ * function callback. In user space, one of the simpler API functions
+ * (pwm_pin_capture_cycles(), pwm_pin_capture_usec(), or
  * pwm_pin_capture_nsec()) can be used instead.
  *
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
@@ -224,7 +222,6 @@ static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
  * @retval -EIO if IO error occurred while configuring
  * @retval -EBUSY if PWM capture is already in progress
  */
-#ifdef CONFIG_PWM_CAPTURE
 static inline int pwm_pin_configure_capture(const struct device *dev,
 					    uint32_t pwm,
 					    pwm_flags_t flags,
@@ -244,7 +241,7 @@ static inline int pwm_pin_configure_capture(const struct device *dev,
 /**
  * @brief Enable PWM period/pulse width capture for a single PWM input.
  *
- * The PWM pin must be configured using @a pwm_pin_configure_capture() prior to
+ * The PWM pin must be configured using pwm_pin_configure_capture() prior to
  * calling this function.
  *
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
@@ -278,7 +275,6 @@ static inline int z_impl_pwm_pin_enable_capture(const struct device *dev,
 /**
  * @brief Disable PWM period/pulse width capture for a single PWM input.
  *
- *
  * @note @kconfig{CONFIG_PWM_CAPTURE} must be selected for this function to be
  * available.
  *
@@ -310,8 +306,8 @@ static inline int z_impl_pwm_pin_disable_capture(const struct device *dev,
  * @brief Capture a single PWM period/pulse width in clock cycles for a single
  *        PWM input.
  *
- * This API function wraps calls to @a pwm_pin_configure_capture(), @a
- * pwm_pin_enable_capture(), and @a pwm_pin_disable_capture() and passes the
+ * This API function wraps calls to pwm_pin_configure_capture(),
+ * pwm_pin_enable_capture(), and pwm_pin_disable_capture() and passes the
  * capture result to the caller. The function is blocking until either the PWM
  * capture is completed or a timeout occurs.
  *
@@ -501,7 +497,7 @@ static inline int pwm_pin_cycles_to_nsec(const struct device *dev, uint32_t pwm,
  * @brief Capture a single PWM period/pulse width in microseconds for a single
  *        PWM input.
  *
- * This API function wraps calls to @a pwm_pin_capture_cycles() and @a
+ * This API function wraps calls to pwm_pin_capture_cycles() and
  * pwm_pin_cycles_to_usec() and passes the capture result to the caller. The
  * function is blocking until either the PWM capture is completed or a timeout
  * occurs.
@@ -557,7 +553,7 @@ static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
  * @brief Capture a single PWM period/pulse width in nanoseconds for a single
  *        PWM input.
  *
- * This API function wraps calls to @a pwm_pin_capture_cycles() and @a
+ * This API function wraps calls to pwm_pin_capture_cycles() and
  * pwm_pin_cycles_to_nsec() and passes the capture result to the caller. The
  * function is blocking until either the PWM capture is completed or a timeout
  * occurs.

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -550,17 +550,17 @@ static inline int pwm_pin_capture_usec(const struct device *dev, uint32_t pwm,
 
 	err = pwm_pin_capture_cycles(dev, pwm, flags, &period_cycles,
 				     &pulse_cycles, timeout);
-	if (err) {
+	if (err < 0) {
 		return err;
 	}
 
 	err = pwm_pin_cycles_to_usec(dev, pwm, period_cycles, period);
-	if (err) {
+	if (err < 0) {
 		return err;
 	}
 
 	err = pwm_pin_cycles_to_usec(dev, pwm, pulse_cycles, pulse);
-	if (err) {
+	if (err < 0) {
 		return err;
 	}
 
@@ -607,17 +607,17 @@ static inline int pwm_pin_capture_nsec(const struct device *dev, uint32_t pwm,
 
 	err = pwm_pin_capture_cycles(dev, pwm, flags, &period_cycles,
 				     &pulse_cycles, timeout);
-	if (err) {
+	if (err < 0) {
 		return err;
 	}
 
 	err = pwm_pin_cycles_to_nsec(dev, pwm, period_cycles, period);
-	if (err) {
+	if (err < 0) {
 		return err;
 	}
 
 	err = pwm_pin_cycles_to_nsec(dev, pwm, pulse_cycles, pulse);
-	if (err) {
+	if (err < 0) {
 		return err;
 	}
 


### PR DESCRIPTION
This PR includes some prep-work before introducing `pwm_dt_spec` facilities, as some other APIs do. It mainly contains:

- Doxygen cleanup/improvements
- Code formatting
- Minor code improvements (error handling, includes...)