### PR TITLE
Add support to relocate open-amp resource table

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -421,6 +421,9 @@ device.
      - Used by the OpenThread to specify UART device for Spinel protocol
    * - zephyr,pcie-controller
      - The node corresponding to the PCIe Controller
+   * - zephyr,rsc_table
+     - The resource table is copied to the "reserved memory" area specified
+       by the ``zephyr,rsc_table`` node
    * - zephyr,settings-partition
      - Fixed partition node. If defined this selects the partition used
        by the NVS and FCB settings backends.


### PR DESCRIPTION
There are some remote processing scenarios where the resource table needs
to be moved to another location. This can be either because there is no
way to exchange the location of the resource table between the two
processors and they have to agree on a fixed predefined location, or
because the memory segment where the current resource table resides is not
is accessible/writable by the remote processor.
A real example of such a case can be found in the Linux rproc driver for
i.MX SoCs. A memory area containing the resource table can be specified
there in the device tree. Since this feature is application dependent, it
can optionally be configured in the device tree along with the other
open-amp related nodes.

This device tree snippet is intended to illustrate a possible use case:
```
chosen {
    zephyr,ipc_shm = &ipc_shm;
    zephyr,rsc_table = &rsc_table;
    zephyr,ipc = &mailbox0;
};

reserved-memory {
    #address-cells = <1>;
    #size-cells = <1>;
    ranges;

    ipc_shm: memory@55000000 {
        reg = <0x55000000 0x500000>;
    };

    rsc_table: rsc-table@550ff000 {
        reg = <0x550ff000 0x1000>;
    };
};
```