### PR TITLE
manifest: TF-M: Update to include fix for fwu partition build error

### DIFF
--- a/doc/guides/tfm/requirements.rst
+++ b/doc/guides/tfm/requirements.rst
@@ -45,7 +45,7 @@ The following Python modules are required when building TF-M binaries:
 * pyasn1
 * pyyaml
 * cbor>=1.0.0
-* imgtool>=1.6.0
+* imgtool>=1.9.0
 * jinja2
 * click
 
@@ -53,7 +53,7 @@ You can install them via:
 
    .. code-block:: bash
 
-      $ pip3 install --user cryptography pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.6.0 jinja2 click
+      $ pip3 install --user cryptography pyasn1 pyyaml cbor>=1.0.0 imgtool>=1.9.0 jinja2 click
 
 They are used by TF-M's signing utility to prepare firmware images for
 validation by the bootloader.

--- a/west.yml
+++ b/west.yml
@@ -226,7 +226,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: b90420a2ffbf7d1329716508f1d3f9f880bc865b
+      revision: bfbd7803b0ed77680e220e44ce6fb363ef2a4224
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
In particular, the update of mcuboot cause this issue, as mcuboot
changed the type of mcuboot_img_magic which tf-m has fixed upstream.

Signed-off-by: Jimmy Brisson <jimmy.brisson@linaro.org>