### PR TITLE
soc: rt11xx: enable AHB clock during CM7 sleep

### DIFF
--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -455,7 +455,7 @@ static ALWAYS_INLINE void clock_init(void)
 	GPC_CM_EnableCpuSleepHold(GPC_CPU_MODE_CTRL_0, false);
 	GPC_CM_EnableCpuSleepHold(GPC_CPU_MODE_CTRL_1, false);
 
-#ifdef CONFIG_SEGGER_RTT_SECTION_DTCM
+#if !defined(CONFIG_PM)
 	/* Enable the AHB clock while the CM7 is sleeping to allow debug access
 	 * to TCM
 	 */


### PR DESCRIPTION
Zephyr kernel will always execute WFI in k_cpu_idle(), so access to TCM
will be gated. This can cause memory corruption, particularly in the case of DMA. 
Keep the AHB clock enabled in sleep unless CONFIG_PM is
selected, to avoid this error.