### PR TITLE
tests: drivers: can: api: add test for can_get_state() API call

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -156,18 +156,17 @@ static inline void z_vrfy_can_remove_rx_filter(const struct device *dev, int fil
 }
 #include <syscalls/can_remove_rx_filter_mrsh.c>
 
-static inline
-int z_vrfy_can_get_state(const struct device *dev, enum can_state *state,
-			 struct can_bus_err_cnt *err_cnt)
+static inline int z_vrfy_can_get_state(const struct device *dev, enum can_state *state,
+				       struct can_bus_err_cnt *err_cnt)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, get_state));
 
 	if (state != NULL) {
-		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(state, sizeof(enum can_state)));
+		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(state, sizeof(*state)));
 	}
 
 	if (err_cnt != NULL) {
-		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(err_cnt, sizeof(struct can_bus_err_cnt)));
+		Z_OOPS(Z_SYSCALL_MEMORY_WRITE(err_cnt, sizeof(*err_cnt)));
 	}
 
 	return z_impl_can_get_state(dev, state, err_cnt);

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -784,6 +784,25 @@ static void test_recover(void)
 	zassert_equal(err, 0, "failed to recover (err %d)", err);
 }
 
+static void test_get_state(void)
+{
+	struct can_bus_err_cnt err_cnt;
+	enum can_state state;
+	int err;
+
+	err = can_get_state(can_dev, NULL, NULL);
+	zassert_equal(err, 0, "failed to get CAN state without destinations (err %d)", err);
+
+	err = can_get_state(can_dev, &state, NULL);
+	zassert_equal(err, 0, "failed to get CAN state (err %d)", err);
+
+	err = can_get_state(can_dev, NULL, &err_cnt);
+	zassert_equal(err, 0, "failed to get CAN error counters (err %d)", err);
+
+	err = can_get_state(can_dev, &state, &err_cnt);
+	zassert_equal(err, 0, "failed to get CAN state + error counters (err %d)", err);
+}
+
 void test_main(void)
 {
 	k_sem_init(&rx_callback_sem, 0, 2);
@@ -807,6 +826,7 @@ void test_main(void)
 			 ztest_unit_test(test_send_receive_msgq),
 			 ztest_unit_test(test_send_invalid_dlc),
 			 ztest_unit_test(test_send_receive_wrong_id),
-			 ztest_user_unit_test(test_recover));
+			 ztest_user_unit_test(test_recover),
+			 ztest_user_unit_test(test_get_state));
 	ztest_run_test_suite(can_api_tests);
 }


### PR DESCRIPTION
Verify the get_state API call in `z_vrfy_can_get_state()` and add a test case for the `can_get_state()` API call.