### PR TITLE
soc: arm: microchip: mec172x: Fix PWM dependency

### DIFF
--- a/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.defconfig.mec172xnsz
@@ -23,6 +23,10 @@ config PINMUX_XEC
 	default y
 	depends on PINMUX
 
+config PWM_XEC
+	default y
+	depends on PWM
+
 config ADC_XEC_V2
 	default y
 	depends on ADC


### PR DESCRIPTION
Enable PWM_XEC whenever CONFIG_PWM is selected
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44239

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>