### PR TITLE
tests: drivers: can: api: test send/receive in userspace

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -139,7 +139,7 @@ static inline void z_vrfy_can_remove_rx_filter(const struct device *dev, int fil
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, remove_rx_filter));
 
-	z_impl_can_remove_rx_filter((const struct device *)dev, (int)filter_id);
+	z_impl_can_remove_rx_filter(dev, filter_id);
 }
 #include <syscalls/can_remove_rx_filter_mrsh.c>
 

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -115,20 +115,11 @@ static inline int z_vrfy_can_send(const struct device *dev,
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, send));
 
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((const struct zcan_frame *)frame,
-				      sizeof(struct zcan_frame)));
-	Z_OOPS(Z_SYSCALL_MEMORY_READ(((struct zcan_frame *)frame)->data,
-				     sizeof((struct zcan_frame *)frame)->data));
-	Z_OOPS(Z_SYSCALL_VERIFY_MSG(callback == 0,
-				    "callbacks may not be set from user mode"));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(frame, sizeof(*frame)));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(frame->data, sizeof(frame->data)));
+	Z_OOPS(Z_SYSCALL_VERIFY_MSG(callback == NULL, "callbacks may not be set from user mode"));
 
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((void *)user_data, sizeof(void *)));
-
-	return z_impl_can_send((const struct device *)dev,
-			       (const struct zcan_frame *)frame,
-			       (k_timeout_t)timeout,
-			       (can_tx_callback_t) callback,
-			       (void *)user_data);
+	return z_impl_can_send(dev, frame, timeout, callback, user_data);
 }
 #include <syscalls/can_send_mrsh.c>
 

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -127,15 +127,11 @@ static inline int z_vrfy_can_add_rx_filter_msgq(const struct device *dev,
 						struct k_msgq *msgq,
 						const struct zcan_filter *filter)
 {
-	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
-
-	Z_OOPS(Z_SYSCALL_MEMORY_READ((struct zcan_filter *)filter,
-				     sizeof(struct zcan_filter)));
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, add_rx_filter));
 	Z_OOPS(Z_SYSCALL_OBJ(msgq, K_OBJ_MSGQ));
+	Z_OOPS(Z_SYSCALL_MEMORY_READ(filter, sizeof(*filter)));
 
-	return z_impl_can_add_rx_filter_msgq((const struct device *)dev,
-					     (struct k_msgq *)msgq,
-					     (const struct zcan_filter *)filter);
+	return z_impl_can_add_rx_filter_msgq(dev, msgq, filter);
 }
 #include <syscalls/can_add_rx_filter_msgq_mrsh.c>
 

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -767,7 +767,7 @@ static void test_send_invalid_dlc(void)
 
 	frame.dlc = CAN_MAX_DLC + 1;
 
-	err = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, tx_std_callback_1, NULL);
+	err = can_send(can_dev, &frame, TEST_SEND_TIMEOUT, NULL, NULL);
 	zassert_equal(err, -EINVAL, "sent a frame with an invalid DLC");
 }
 
@@ -791,21 +791,22 @@ void test_main(void)
 
 	zassert_true(device_is_ready(can_dev), "CAN device not ready");
 
+	k_object_access_grant(&can_msgq, k_current_get());
 	k_object_access_grant(can_dev, k_current_get());
 
 	/* Tests without callbacks can run in userspace */
 	ztest_test_suite(can_api_tests,
 			 ztest_unit_test(test_set_loopback),
-			 ztest_unit_test(test_send_and_forget),
+			 ztest_user_unit_test(test_send_and_forget),
 			 ztest_unit_test(test_add_filter),
-			 ztest_unit_test(test_receive_timeout),
+			 ztest_user_unit_test(test_receive_timeout),
 			 ztest_unit_test(test_send_callback),
 			 ztest_unit_test(test_send_receive_std_id),
 			 ztest_unit_test(test_send_receive_ext_id),
 			 ztest_unit_test(test_send_receive_std_id_masked),
 			 ztest_unit_test(test_send_receive_ext_id_masked),
-			 ztest_unit_test(test_send_receive_msgq),
-			 ztest_unit_test(test_send_invalid_dlc),
+			 ztest_user_unit_test(test_send_receive_msgq),
+			 ztest_user_unit_test(test_send_invalid_dlc),
 			 ztest_unit_test(test_send_receive_wrong_id),
 			 ztest_user_unit_test(test_recover));
 	ztest_run_test_suite(can_api_tests);


### PR DESCRIPTION
- Remove unnecessary typecasts from from CAN send/receive handlers.
- Verify the `add_rx_filter` API call in `z_vrfy_can_add_rx_filter_msgq()`.
- Do not attempt to verify that the current thread has access to the `void *user_data` argument to `z_vrfy_can_send()`.
- Run CAN send/receive API tests without callbacks in userspace.