### PR TITLE
twister: harness: fix ztest detection

### DIFF
--- a/scripts/pylib/twister/harness.py
+++ b/scripts/pylib/twister/harness.py
@@ -227,7 +227,6 @@ class Test(Harness):
         if test_suite_match:
             suite_name = test_suite_match.group("suite_name")
             self.detected_suite_names.append(suite_name)
-            self.ztest = True
 
         match = result_re.match(line)
         if match and match.group(2):


### PR DESCRIPTION
Decision about whether test should be considered as ztest should be made
after detection ztest testcase - not after detection ztest test suite.

Due to the fact that ztest provides possibility to overwrite some ztest macros by enable this option: `CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE`, then  user can change how ztest output looks like. When he/she do this, then Twister is not able to properly detect testcases. So, final decision about whole test and each testcases results should base in this case only on final communicate `PROJECT EXECUTION SUCCESSFUL` or `PROJECT EXECUTION FAILED`. Removing marking `harness.ztest` attribute after detection test suite enable to handle tests with `CONFIG_ZTEST_TC_UTIL_USER_OVERRIDE` option enable, just like sample.

Fixes: #44397

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>