### PR TITLE
drivers: can: mcan: fix compiler warning

### DIFF
--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -108,12 +108,14 @@ static int mcux_mcan_get_max_bitrate(const struct device *dev, uint32_t *max_bit
 	return 0;
 }
 
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 static int mcux_mcan_recover(const struct device *dev, k_timeout_t timeout)
 {
 	const struct mcux_mcan_config *config = dev->config;
 
 	return can_mcan_recover(&config->mcan, timeout);
 }
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 
 static void mcux_mcan_line_0_isr(const struct device *dev)
 {

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -145,12 +145,14 @@ static int can_sam_get_max_bitrate(const struct device *dev, uint32_t *max_bitra
 	return 0;
 }
 
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 static int can_sam_recover(const struct device *dev, k_timeout_t timeout)
 {
 	const struct can_sam_config *cfg = dev->config;
 
 	return can_mcan_recover(&cfg->mcan_cfg, timeout);
 }
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 
 static void can_sam_line_0_isr(const struct device *dev)
 {

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -154,12 +154,14 @@ static int can_stm32fd_get_max_bitrate(const struct device *dev, uint32_t *max_b
 	return 0;
 }
 
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 static int can_stm32fd_recover(const struct device *dev, k_timeout_t timeout)
 {
 	const struct can_stm32fd_config *cfg = dev->config;
 
 	return can_mcan_recover(&cfg->mcan_cfg, timeout);
 }
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 
 static void can_stm32fd_line_0_isr(const struct device *dev)
 {

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -176,12 +176,14 @@ static int can_stm32h7_get_max_bitrate(const struct device *dev, uint32_t *max_b
 	return 0;
 }
 
+#ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 static int can_stm32h7_recover(const struct device *dev, k_timeout_t timeout)
 {
 	const struct can_stm32h7_config *cfg = dev->config;
 
 	return can_mcan_recover(&cfg->mcan_cfg, timeout);
 }
+#endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 
 static void can_stm32h7_line_0_isr(const struct device *dev)
 {


### PR DESCRIPTION
Fix compiler warning with CONFIG_CAN_AUTO_BUS_OFF_RECOVERY=y.

Fixes: 4e41d89c7bf8dad6699365f0a150995d4e02a737

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>