### PR TITLE
drivers: i2c: Fix unused parameter warnings when compiling with -Wextra

### DIFF
--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -474,6 +474,9 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs,
 				  uint8_t num_msgs)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(msgs);
+	ARG_UNUSED(num_msgs);
 }
 
 #define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\


### PR DESCRIPTION
Since the i2c header file is included directly by application code,
an application developer including this file and only applying
-Wextra to the application source files will see this warning.

Signed-off-by: Pete Dietl <petedietl@gmail.com>