### PR TITLE
arm64: mmu: provide more memory mapping types for z_phys_map()

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -870,15 +870,27 @@ static int __arch_mem_map(void *virt, uintptr_t phys, size_t size, uint32_t flag
 	/* Translate flags argument into HW-recognized entry flags. */
 	switch (flags & K_MEM_CACHE_MASK) {
 	/*
-	 * K_MEM_CACHE_NONE => MT_DEVICE_nGnRnE
+	 * K_MEM_CACHE_NONE, K_MEM_ARM_DEVICE_nGnRnE => MT_DEVICE_nGnRnE
 	 *			(Device memory nGnRnE)
+	 * K_MEM_ARM_DEVICE_nGnRE => MT_DEVICE_nGnRE
+	 *			(Device memory nGnRE)
+	 * K_MEM_ARM_DEVICE_GRE => MT_DEVICE_GRE
+	 *			(Device memory GRE)
 	 * K_MEM_CACHE_WB   => MT_NORMAL
 	 *			(Normal memory Outer WB + Inner WB)
 	 * K_MEM_CACHE_WT   => MT_NORMAL_WT
 	 *			(Normal memory Outer WT + Inner WT)
 	 */
 	case K_MEM_CACHE_NONE:
+	/* K_MEM_CACHE_NONE equal to K_MEM_ARM_DEVICE_nGnRnE */
+	/* case K_MEM_ARM_DEVICE_nGnRnE: */
 		entry_flags |= MT_DEVICE_nGnRnE;
+		break;
+	case K_MEM_ARM_DEVICE_nGnRE:
+		entry_flags |= MT_DEVICE_nGnRE;
+		break;
+	case K_MEM_ARM_DEVICE_GRE:
+		entry_flags |= MT_DEVICE_GRE;
 		break;
 	case K_MEM_CACHE_WT:
 		entry_flags |= MT_NORMAL_WT;

--- a/include/arch/arm64/arm_mem.h
+++ b/include/arch/arm64/arm_mem.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_INCLUDE_ARCH_ARM64_ARM_MEM_H_
+#define ZEPHYR_INCLUDE_ARCH_ARM64_ARM_MEM_H_
+
+/*
+ * Define ARM specific memory flags used by z_phys_map()
+ * followed public definitions in include/sys/mem_manage.h.
+ */
+/* For ARM64, K_MEM_CACHE_NONE is nGnRnE. */
+#define K_MEM_ARM_DEVICE_nGnRnE	K_MEM_CACHE_NONE
+
+/** ARM64 Specific flags: device memory with nGnRE */
+#define K_MEM_ARM_DEVICE_nGnRE	3
+
+/** ARM64 Specific flags: device memory with GRE */
+#define K_MEM_ARM_DEVICE_GRE	4
+
+#endif /* ZEPHYR_INCLUDE_ARCH_ARM64_ARM_MEM_H_ */

--- a/include/sys/mem_manage.h
+++ b/include/sys/mem_manage.h
@@ -9,6 +9,9 @@
 
 #include <sys/util.h>
 #include <toolchain.h>
+#if defined(CONFIG_ARM_MMU) && defined(CONFIG_ARM64)
+#include <arch/arm64/arm_mem.h>
+#endif
 
 /*
  * Caching mode definitions. These are mutually exclusive.
@@ -22,6 +25,11 @@
 
 /** Full write-back caching. Any RAM mapped wants this. */
 #define K_MEM_CACHE_WB		0
+
+/*
+ * ARM64 Specific flags are defined in arch/arm64/arm_mem.h,
+ * pay attention to be not conflicted when updating these flags.
+ */
 
 /** Reserved bits for cache modes in k_map() flags argument */
 #define K_MEM_CACHE_MASK	(BIT(3) - 1)


### PR DESCRIPTION
ARM64 supports more memory mapping types for device memory (nGnRnE,
nGnRE, GRE), add these mapping support for os common mapping API
function z_phys_map().

Signed-off-by: Jiafei Pan <Jiafei.Pan@nxp.com>