### PR TITLE
Bluetooth: Controller: Workaround nRF52840 Revision 3 Errata 191

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -52,6 +52,7 @@
 #elif defined(CONFIG_SOC_NRF52833)
 #include "radio_nrf52833.h"
 #elif defined(CONFIG_SOC_NRF52840)
+#include <nrf52_erratas.h>
 #include "radio_nrf52840.h"
 #elif defined(CONFIG_SOC_NRF5340_CPUNET)
 #include "radio_nrf5340.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
@@ -413,8 +413,10 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 		mode = RADIO_MODE_MODE_Ble_1Mbit;
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-		/* Workaround: nRF52840 Engineering A Errata ID 164 */
-		*(volatile uint32_t *)0x4000173c &= ~0x80000000;
+		/* Workaround: nRF52840 Revision 3 Errata 191 */
+		if (nrf52_errata_191()) {
+			*(volatile uint32_t *)0x40001740 &= ~0x80000000;
+		}
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 
 		break;
@@ -423,8 +425,10 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 		mode = RADIO_MODE_MODE_Ble_2Mbit;
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
-		/* Workaround: nRF52840 Engineering A Errata ID 164 */
-		*(volatile uint32_t *)0x4000173c &= ~0x80000000;
+		/* Workaround: nRF52840 Revision 3 Errata 191 */
+		if (nrf52_errata_191()) {
+			*(volatile uint32_t *)0x40001740 &= ~0x80000000;
+		}
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 
 		break;
@@ -437,11 +441,12 @@ static inline uint32_t hal_radio_phy_mode_get(uint8_t phy, uint8_t flags)
 			mode = RADIO_MODE_MODE_Ble_LR500Kbit;
 		}
 
-		/* Workaround: nRF52840 Engineering A Errata ID 164 */
-		*(volatile uint32_t *)0x4000173c |= 0x80000000;
-		*(volatile uint32_t *)0x4000173c =
-				((*(volatile uint32_t *)0x4000173c) & 0xFFFFFF00) |
-				0x5C;
+		/* Workaround: nRF52840 Revision 3 Errata 191 */
+		if (nrf52_errata_191()) {
+			*(volatile uint32_t *)0x40001740 =
+				((*(volatile uint32_t *)0x40001740) & 0x7FFF00FF) |
+				0x80000000 | ((uint32_t)(196U) << 8U);
+		}
 		break;
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
 	}


### PR DESCRIPTION
Add workaround for nRF52840 Revision 3 Errata 191. Removed
workaround for fixed nRF52840 Engineering Revision A Errata
164.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>