### PR TITLE
os: lib: bin2hex: fix memory overwrite

### DIFF
--- a/lib/os/hex.c
+++ b/lib/os/hex.c
@@ -39,7 +39,7 @@ int hex2char(uint8_t x, char *c)
 
 size_t bin2hex(const uint8_t *buf, size_t buflen, char *hex, size_t hexlen)
 {
-	if ((hexlen + 1) < buflen * 2) {
+	if (hexlen < (buflen * 2 + 1)) {
 		return 0;
 	}
 


### PR DESCRIPTION
Destination buffer size could be too small by one,
but null termination is still written. 

Signed-off-by: Rico Ganahl <rico.ganahl@bytesatwork.ch>