### PR TITLE
Bluetooth: Controller: Force MD feature not supported in LOW LAT ULL

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -589,6 +589,7 @@ config BT_CTLR_THROUGHPUT
 
 config BT_CTLR_FORCE_MD_COUNT
 	int "Forced MD bit count" if !BT_CTLR_FORCE_MD_AUTO
+	depends on !BT_CTLR_LOW_LAT_ULL
 	range 0 255
 	default 1 if BT_CTLR_FORCE_MD_AUTO
 	default 0
@@ -602,6 +603,7 @@ config BT_CTLR_FORCE_MD_COUNT
 
 config BT_CTLR_FORCE_MD_AUTO
 	bool "Forced MD bit automatic calculation"
+	depends on !BT_CTLR_LOW_LAT_ULL
 	select BT_CTLR_THROUGHPUT
 	default y if BT_HCI_RAW
 	help


### PR DESCRIPTION
Add Kconfig dependency to disable use of Force MD feature
when using LOW LAT ULL variant of the Controller.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>