### PR TITLE
Initial support for STM32 FMC NOR/PSRAM 

### DIFF
--- a/drivers/memc/CMakeLists.txt
+++ b/drivers/memc/CMakeLists.txt
@@ -5,6 +5,7 @@ zephyr_library()
 zephyr_library_sources_ifdef(CONFIG_MEMC_STM32 memc_stm32.c)
 zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_SDRAM memc_stm32_sdram.c)
 zephyr_linker_sources_ifdef(CONFIG_MEMC_STM32_SDRAM SECTIONS memc_stm32_sdram.ld)
+zephyr_library_sources_ifdef(CONFIG_MEMC_STM32_NOR_PSRAM memc_stm32_nor_psram.c)
 
 zephyr_library_sources_ifdef(CONFIG_MEMC_MCUX_FLEXSPI memc_mcux_flexspi.c)
 zephyr_library_sources_ifdef(CONFIG_MEMC_MCUX_FLEXSPI_HYPERRAM memc_mcux_flexspi_hyperram.c)

--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -19,3 +19,15 @@ config MEMC_STM32_SDRAM
 	select USE_STM32_HAL_SDRAM
 	help
 	  Enable STM32 FMC SDRAM controller.
+
+DT_COMPAT_ST_STM32_FMC_NOR_PSRAM := st,stm32-fmc-nor-psram
+
+config MEMC_STM32_NOR_PSRAM
+	bool "STM32 FMC NOR/PSRAM controller"
+	depends on MEMC_STM32
+	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_FMC_NOR_PSRAM))
+	select USE_STM32_LL_FMC
+	select USE_STM32_HAL_NOR
+	select USE_STM32_HAL_SRAM
+	help
+	  Enable STM32 FMC NOR/PSRAM controller.

--- a/drivers/memc/memc_stm32_nor_psram.c
+++ b/drivers/memc/memc_stm32_nor_psram.c
@@ -1,0 +1,178 @@
+/*
+ * Copyright (c) 2022 Georgij Cernysiov
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT st_stm32_fmc_nor_psram
+
+#include <device.h>
+#include <soc.h>
+#include <errno.h>
+
+#include <logging/log.h>
+LOG_MODULE_REGISTER(memc_stm32_nor_psram, CONFIG_MEMC_LOG_LEVEL);
+
+/** SRAM base register offset, see FMC_Bank1_R_BASE */
+#define SRAM_OFFSET 0x0000UL
+/** SRAM extended mode register offset, see FMC_Bank1E_R_BASE */
+#define SRAM_EXT_OFFSET 0x0104UL
+
+/** FMC NOR/PSRAM controller bank configuration fields. */
+struct memc_stm32_nor_psram_bank_config {
+	FMC_NORSRAM_InitTypeDef init;
+	FMC_NORSRAM_TimingTypeDef timing;
+	FMC_NORSRAM_TimingTypeDef timing_ext;
+};
+
+/** FMC NOR/PSRAM controller configuration fields. */
+struct memc_stm32_nor_psram_config {
+	FMC_NORSRAM_TypeDef *nor_psram;
+	FMC_NORSRAM_EXTENDED_TypeDef *extended;
+	const struct memc_stm32_nor_psram_bank_config *banks;
+	size_t banks_len;
+};
+
+static int memc_stm32_nor_init(const struct memc_stm32_nor_psram_config *config,
+			       const struct memc_stm32_nor_psram_bank_config *bank_config)
+{
+	FMC_NORSRAM_TimingTypeDef *ext_timing;
+	NOR_HandleTypeDef hnor = { 0 };
+
+	hnor.Instance = config->nor_psram;
+	hnor.Extended = config->extended;
+
+	memcpy(&hnor.Init, &bank_config->init, sizeof(hnor.Init));
+
+	if (bank_config->init.ExtendedMode == FMC_EXTENDED_MODE_ENABLE) {
+		ext_timing = (FMC_NORSRAM_TimingTypeDef *)&bank_config->timing_ext;
+	} else {
+		ext_timing = NULL;
+	}
+
+	if (HAL_NOR_Init(&hnor,
+			 (FMC_NORSRAM_TimingTypeDef *)&bank_config->timing,
+			 ext_timing) != HAL_OK) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int memc_stm32_psram_init(const struct memc_stm32_nor_psram_config *config,
+				 const struct memc_stm32_nor_psram_bank_config *bank_config)
+{
+	FMC_NORSRAM_TimingTypeDef *ext_timing;
+	SRAM_HandleTypeDef hsram = { 0 };
+
+	hsram.Instance = config->nor_psram;
+	hsram.Extended = config->extended;
+
+	memcpy(&hsram.Init, &bank_config->init, sizeof(hsram.Init));
+
+	if (bank_config->init.ExtendedMode == FMC_EXTENDED_MODE_ENABLE) {
+		ext_timing = (FMC_NORSRAM_TimingTypeDef *)&bank_config->timing_ext;
+	} else {
+		ext_timing = NULL;
+	}
+
+	if (HAL_SRAM_Init(&hsram,
+			  (FMC_NORSRAM_TimingTypeDef *)&bank_config->timing,
+			  ext_timing) != HAL_OK) {
+		return -ENODEV;
+	}
+
+	return 0;
+}
+
+static int memc_stm32_nor_psram_init(const struct device *dev)
+{
+	const struct memc_stm32_nor_psram_config *config = dev->config;
+	uint32_t memory_type;
+	size_t bank_idx;
+	int ret = 0;
+
+	for (bank_idx = 0U; bank_idx < config->banks_len; ++bank_idx) {
+		memory_type = config->banks[bank_idx].init.MemoryType;
+
+		switch (memory_type) {
+		case FMC_MEMORY_TYPE_NOR:
+			ret = memc_stm32_nor_init(config, &config->banks[bank_idx]);
+			break;
+		case FMC_MEMORY_TYPE_PSRAM:
+			__fallthrough;
+		case FMC_MEMORY_TYPE_SRAM:
+			ret = memc_stm32_psram_init(config, &config->banks[bank_idx]);
+			break;
+		default:
+			ret = -ENOTSUP;
+			break;
+		}
+
+		if (ret < 0) {
+			LOG_ERR("Unable to initialize memory type: "
+				"0x%08X, NSBank: %d, err: %d",
+				memory_type, config->banks[bank_idx].init.NSBank, ret);
+			goto end;
+		}
+	}
+
+end:
+	return ret;
+}
+
+/** SDRAM bank/s configuration initialization macro. */
+#define BANK_CONFIG(node_id)                                                    \
+	{ .init = {                                                             \
+	    .NSBank = DT_REG_ADDR(node_id),                                     \
+	    .DataAddressMux = DT_PROP_BY_IDX(node_id, st_control, 0),           \
+	    .MemoryType = DT_PROP_BY_IDX(node_id, st_control, 1),               \
+	    .MemoryDataWidth = DT_PROP_BY_IDX(node_id, st_control, 2),          \
+	    .BurstAccessMode = DT_PROP_BY_IDX(node_id, st_control, 3),          \
+	    .WaitSignalPolarity = DT_PROP_BY_IDX(node_id, st_control, 4),       \
+	    .WaitSignalActive = DT_PROP_BY_IDX(node_id, st_control, 5),         \
+	    .WriteOperation = DT_PROP_BY_IDX(node_id, st_control, 6),           \
+	    .WaitSignal = DT_PROP_BY_IDX(node_id, st_control, 7),               \
+	    .ExtendedMode = DT_PROP_BY_IDX(node_id, st_control, 8),             \
+	    .AsynchronousWait = DT_PROP_BY_IDX(node_id, st_control, 9),         \
+	    .WriteBurst = DT_PROP_BY_IDX(node_id, st_control, 10),              \
+	    .ContinuousClock = DT_PROP_BY_IDX(node_id, st_control, 11),         \
+	    .WriteFifo = DT_PROP_BY_IDX(node_id, st_control, 12),               \
+	    .PageSize = DT_PROP_BY_IDX(node_id, st_control, 13)                 \
+	  },                                                                    \
+	  .timing = {                                                           \
+	    .AddressSetupTime = DT_PROP_BY_IDX(node_id, st_timing, 0),          \
+	    .AddressHoldTime =  DT_PROP_BY_IDX(node_id, st_timing, 1),          \
+	    .DataSetupTime = DT_PROP_BY_IDX(node_id, st_timing, 2),             \
+	    .BusTurnAroundDuration = DT_PROP_BY_IDX(node_id, st_timing, 3),     \
+	    .CLKDivision = DT_PROP_BY_IDX(node_id, st_timing, 4),               \
+	    .DataLatency = DT_PROP_BY_IDX(node_id, st_timing, 5),               \
+	    .AccessMode = DT_PROP_BY_IDX(node_id, st_timing, 6),                \
+	  },                                                                    \
+	  .timing_ext = {                                                       \
+	    .AddressSetupTime = DT_PROP_BY_IDX(node_id, st_timing_ext, 0),      \
+	    .AddressHoldTime =  DT_PROP_BY_IDX(node_id, st_timing_ext, 1),      \
+	    .DataSetupTime = DT_PROP_BY_IDX(node_id, st_timing_ext, 2),         \
+	    .BusTurnAroundDuration = DT_PROP_BY_IDX(node_id, st_timing_ext, 3), \
+	    .AccessMode = DT_PROP_BY_IDX(node_id, st_timing_ext, 4),            \
+	  }                                                                     \
+	},
+
+/** SRAM bank/s configuration. */
+static const struct memc_stm32_nor_psram_bank_config bank_config[] = {
+	DT_INST_FOREACH_CHILD(0, BANK_CONFIG)
+};
+
+/** SRAM configuration. */
+static const struct memc_stm32_nor_psram_config config = {
+	.nor_psram = (FMC_NORSRAM_TypeDef *)(DT_REG_ADDR(DT_INST_PARENT(0)) + SRAM_OFFSET),
+	.extended = (FMC_NORSRAM_EXTENDED_TypeDef *)(DT_REG_ADDR(DT_INST_PARENT(0))
+								 + SRAM_EXT_OFFSET),
+	.banks = bank_config,
+	.banks_len = ARRAY_SIZE(bank_config),
+};
+
+DEVICE_DT_INST_DEFINE(0, memc_stm32_nor_psram_init, NULL,
+		      NULL, &config,
+		      POST_KERNEL, CONFIG_MEMC_INIT_PRIORITY,
+		      NULL);

--- a/dts/bindings/memory-controllers/st,stm32-fmc-nor-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc-nor-psram.yaml
@@ -1,0 +1,201 @@
+# Copyright (c) 2022 Georgij Cernysiov
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 Flexible Memory Controller (NOR Flash/PSRAM/SRAM controller).
+
+  The FMC generates the appropriate signal timings to drive the
+  following types of memories:
+
+  * Asynchronous SRAM and ROM
+    - 8 bits
+    - 16 bits
+    - 32 bits
+  * PSRAM (Cellular RAM)
+    - Asynchronous mode
+    - Burst mode for synchronous accesses with configurable option to split burst
+      access when crossing boundary page for CRAM 1.5.
+    - Multiplexed or non-multiplexed
+  * NOR Flash memory
+    - Asynchronous mode
+    - Burst mode for synchronous accesses
+    - Multiplexed or non-multiplexed
+
+  A unique Chip Select signal (NE) is used per bank. All the other
+  signals (addresses, data and control) are shared. A wide range of
+  devices is supported through programmable timings.
+
+  Refer to the reference manual for more details.
+
+  The FMC NOR/PSRAM controller is defined below the FMC node and banks are
+  defined as child nodes of the FMC NOR/PSRAM controller node.
+
+  You can enable the controller in devicetree as follows:
+
+  &fmc {
+    status = "okay";
+    pinctrl-0 = <&fmc_nwe_pd5 &fmc_noe_pd4 ...>;
+    pinctrl-names = "default";
+
+    sram {
+      status = "okay";
+      compatible = "st,stm32-fmc-nor-psram";
+      label = "STM32_FMC_NOR_PSRAM";
+
+      #address-cells = <1>;
+      #size-cells = <0>;
+
+      sram2@2 {
+        reg = <0x2>;
+        st,control = <STM32_FMC_DATA_ADDRESS_MUX_DISABLE
+                      STM32_FMC_MEMORY_TYPE_SRAM
+                      STM32_FMC_NORSRAM_MEM_BUS_WIDTH_16
+                      STM32_FMC_BURST_ACCESS_MODE_DISABLE
+                      STM32_FMC_WAIT_SIGNAL_POLARITY_LOW
+                      STM32_FMC_WAIT_TIMING_BEFORE_WS
+                      STM32_FMC_WRITE_OPERATION_ENABLE
+                      STM32_FMC_WAIT_SIGNAL_DISABLE
+                      STM32_FMC_EXTENDED_MODE_DISABLE
+                      STM32_FMC_ASYNCHRONOUS_WAIT_DISABLE
+                      STM32_FMC_WRITE_BURST_DISABLE
+                      STM32_FMC_CONTINUOUS_CLOCK_SYNC_ONLY
+                      STM32_FMC_WRITE_FIFO_DISABLE
+                      STM32_FMC_PAGE_SIZE_NONE>;
+        st,timing = <4 2 3 0 16 17 STM32_FMC_ACCESS_MODE_A>;
+      };
+    };
+  };
+
+  Use constants defined in dt-bindings/memory-controller/stm32-fmc-nor-psram.h.
+
+compatible: "st,stm32-fmc-nor-psram"
+
+include: base.yaml
+
+properties:
+  label:
+    required: true
+
+  "#address-cells":
+    required: true
+    const: 1
+
+  "#size-cells":
+    required: true
+    const: 0
+
+child-binding:
+  description: NOR/PSRAM bank.
+
+  properties:
+    reg:
+      type: int
+      required: true
+
+    st,control:
+      type: array
+      required: true
+      description: |
+        SRAM/NOR-Flash control register (FMC_BCRx).
+
+        Contains control information of each memory bank,
+        used for SRAMs, PSRAM and NOR Flash memories.
+
+        Expected fields, in order:
+
+        * MUXEN - Address/data multiplexing enable bit.
+        * MTYP  - Memory type.
+        * MWID  - Memory data bus width.
+        * FACCEN - Flash access enable.
+        * BURSTEN - Burst enable bit.
+        * WAITPOL - Wait signal polarity bit.
+        * WAITCFG - Wait timing configuration.
+        * WREN - Write enable bit.
+        * WAITEN - Wait enable bit.
+        * EXTMOD - Extended mode enable.
+                   If set, then 'st,timing-ext' shall be provided.
+        * ASYNCWAIT -  Wait signal during asynchronous transfers.
+        * CPSIZE - Cellular RAM (CRAM) 1.5 Page Size.
+        * CBURSTRW - Write burst enable.
+        * CCLKEN - Continuous Clock Enable.
+        * WFDIS - Write FIFO Disable.
+        * BMAP - FMC bank mapping.
+
+    st,timing:
+      type: array
+      required: true
+      description: |
+        SRAM/NOR-Flash (read) timing register (FMC_BTRx).
+
+        If the EXTMOD is set (see control register FMC_BCRx), then
+        FMC_BTRx register is partitioned for write and read access.
+        That means, use this property to configure read accesses and
+        'st,timing-ext' to configure write accesses.
+
+        Expected fields, in order:
+
+        * ADDSET  - Address setup phase duration.
+                    Number of HCLK cycles to configure the duration of
+                    the address setup time. This parameter can be a value
+                    between Min_Data = 0 and Max_Data = 15.
+                    Note: Not used with synchronous NOR Flash memories.
+        * ADDHLD  - Address-hold phase duration.
+                    Number of HCLK cycles to configure the duration of
+                    the address hold time. This parameter can be a value
+                    between Min_Data = 1 and Max_Data = 15.
+                    Note: Not used with synchronous NOR Flash memories.
+        * DATAST  - Data-phase duration.
+                    Number of HCLK cycles to configure the duration of
+                    the data setup time. This parameter can be a value
+                    between Min_Data = 1 and Max_Data = 255.
+                    Note: Used for SRAMs, ROMs and asynchronous multiplexed
+                    NOR Flash memories.
+        * BUSTURN - Bus turnaround phase duration.
+                    Number of HCLK cycles to configure the duration of
+                    the bus turnaround. This parameter can be a value
+                    between Min_Data = 0 and Max_Data = 15.
+                    Note: Only used for multiplexed NOR Flash memories.
+        * CLKDIV  - Clock divide ratio (for FMC_CLK signal).
+                    Period of CLK clock output signal, expressed in number of
+                    HCLK cycles. This parameter can be a value
+                    between Min_Data = 2 and Max_Data = 16.
+                    Note: Not used for asynchronous NOR Flash, SRAM or ROM
+                    accesses.
+        * DATLAT  - Data latency for synchronous memory.
+                    Number of memory clock cycles to issue to the memory
+                    before getting the first data.
+                    The value depends on the memory type as shown below:
+                    - It must be set to 0 in case of a CRAM
+                    - It is don't care in asynchronous NOR, SRAM or ROM accesses
+                    - It may assume a value between Min_Data = 2 and Max_Data = 17
+                      in NOR Flash memories with synchronous burst mode enable
+        * ACCMOD  - Access mode.
+                    See access mode defines
+                    in dt-bindings/memory-controller/stm32-fmc-nor-psram.h.
+
+    st,timing-ext:
+      type: array
+      required: false # required when 'EXTMOD' is enabled
+      default: [0xF, 0xF, 0xFF, 0xF, 0x0] # reset state
+      description: |
+        SRAM/NOR-Flash (write) timing register (FMC_BWTRx).
+
+        Expected fields, in order:
+
+        * ADDSET  - Address setup phase duration.
+                    Reset state: 15 (0xF).
+        * ADDHLD  - Address-hold phase duration.
+                    Reset state: 15 (0xF).
+        * DATAST  - Data-phase duration.
+                    Reset state: 255 (0xFF).
+        * BUSTURN - Bus turnaround phase duration.
+                    Reset state: 15 (0xF).
+        * ACCMOD  - Access mode.
+                    Reset state: 0 (0x0).
+
+        Refer to 'st,timing' for detailed field descriptions.
+
+        This property is applied only when EXTMOD is set
+        (see control register FMC_BCRx).
+
+        If absent, then reset state values are used.

--- a/include/zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h
+++ b/include/zephyr/dt-bindings/memory-controller/stm32-fmc-nor-psram.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2022 Georgij Cernysiov
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_MEMORY_CONTROLLER_STM32_FMC_SRAM_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_MEMORY_CONTROLLER_STM32_FMC_SRAM_H_
+
+/* Data Address Bus Multiplexing */
+#define STM32_FMC_DATA_ADDRESS_MUX_DISABLE         0x00000000UL
+#define STM32_FMC_DATA_ADDRESS_MUX_ENABLE          0x00000002UL
+
+/* Memory Type */
+#define STM32_FMC_MEMORY_TYPE_SRAM                 0x00000000UL
+#define STM32_FMC_MEMORY_TYPE_PSRAM                0x00000004UL
+#define STM32_FMC_MEMORY_TYPE_NOR                  0x00000008UL
+
+/* NORSRAM Data Width */
+#define STM32_FMC_NORSRAM_MEM_BUS_WIDTH_8          0x00000000UL
+#define STM32_FMC_NORSRAM_MEM_BUS_WIDTH_16         0x00000010UL
+#define STM32_FMC_NORSRAM_MEM_BUS_WIDTH_32         0x00000020UL
+
+/* Burst Access Mode */
+#define STM32_FMC_BURST_ACCESS_MODE_DISABLE        0x00000000UL
+#define STM32_FMC_BURST_ACCESS_MODE_ENABLE         0x00000100UL
+
+/* Wait Signal Polarity */
+#define STM32_FMC_WAIT_SIGNAL_POLARITY_LOW         0x00000000UL
+#define STM32_FMC_WAIT_SIGNAL_POLARITY_HIGH        0x00000200UL
+
+/* Wait Timing */
+#define STM32_FMC_WAIT_TIMING_BEFORE_WS            0x00000000UL
+#define STM32_FMC_WAIT_TIMING_DURING_WS            0x00000800UL
+
+/* Write Operation */
+#define STM32_FMC_WRITE_OPERATION_DISABLE          0x00000000UL
+#define STM32_FMC_WRITE_OPERATION_ENABLE           0x00001000UL
+
+/* Wait Signal */
+#define STM32_FMC_WAIT_SIGNAL_DISABLE              0x00000000UL
+#define STM32_FMC_WAIT_SIGNAL_ENABLE               0x00002000UL
+
+/* Extended Mode */
+#define STM32_FMC_EXTENDED_MODE_DISABLE            0x00000000UL
+#define STM32_FMC_EXTENDED_MODE_ENABLE             0x00004000UL
+
+/* Asynchronous Wait */
+#define STM32_FMC_ASYNCHRONOUS_WAIT_DISABLE        0x00000000UL
+#define STM32_FMC_ASYNCHRONOUS_WAIT_ENABLE         0x00008000UL
+
+/* Write Burst */
+#define STM32_FMC_WRITE_BURST_DISABLE              0x00000000UL
+#define STM32_FMC_WRITE_BURST_ENABLE               0x00080000UL
+
+/* Continuous Clock */
+#define STM32_FMC_CONTINUOUS_CLOCK_SYNC_ONLY       0x00000000UL
+#define STM32_FMC_CONTINUOUS_CLOCK_SYNC_ASYNC      0x00100000UL
+
+/* Write FIFO */
+/* Not every SoC can disable FIFO, refer to reference manual */
+#define STM32_FMC_WRITE_FIFO_DISABLE               0x00200000UL
+#define STM32_FMC_WRITE_FIFO_ENABLE                0x00000000UL
+
+/* Page Size */
+#define STM32_FMC_PAGE_SIZE_NONE                   0x00000000UL
+#define STM32_FMC_PAGE_SIZE_128                    0x00010000UL
+#define STM32_FMC_PAGE_SIZE_256                    0x00020000UL
+#define STM32_FMC_PAGE_SIZE_512                    0x00030000UL
+#define STM32_FMC_PAGE_SIZE_1024                   0x00040000UL
+
+/* Access Mode */
+#define STM32_FMC_ACCESS_MODE_A                    0x00000000UL
+#define STM32_FMC_ACCESS_MODE_B                    0x10000000UL
+#define STM32_FMC_ACCESS_MODE_C                    0x20000000UL
+#define STM32_FMC_ACCESS_MODE_D                    0x30000000UL
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_MEMORY_CONTROLLER_STM32_FMC_SRAM_H_ */


### PR DESCRIPTION
This PR extends existing #29686 and adds NOR/PSRAM controller.

The goal is to use an external display over the 8080 parallel interface.

The driver was tested using a custom H7 board with a modified #39335 driver.

![WIN_20220331_13_55_00_Pro (2)](https://user-images.githubusercontent.com/5956504/161228913-218c381d-f754-4da6-ac51-9753d7a7a2c8.jpg)

The adapted display driver uses direct memory writes (for example, `*FMC_BANK2_REG = Reg; __DSB();`), where `FMC_BANK2_REG` is a definition of the SRAM bank address.

Everything works but there are some questions:
* Shall there be an API to write/read to/from NOR/PSRAM memory? Or is it okay when drivers expose properties for FMC reg and mem?
* Maybe it is better to combine `dt-bindings` of FMC under one header as it is done in LL?


