### PR TITLE
Support H7 FMC NOR/PSRAM and SDRAM banks remap or swap

### DIFF
--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -4,15 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT st_stm32_fmc
-
 #include <device.h>
+#include <soc.h>
 
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/pinctrl.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(memc_stm32, CONFIG_MEMC_LOG_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_fmc)
+#define DT_DRV_COMPAT st_stm32_fmc
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_fmc)
+#define DT_DRV_COMPAT st_stm32h7_fmc
+#else
+#error "No compatible FMC devicetree node found"
+#endif
 
 struct memc_stm32_config {
 	uint32_t fmc;
@@ -42,6 +49,16 @@ static int memc_stm32_init(const struct device *dev)
 		LOG_ERR("Could not initialize FMC clock (%d)", r);
 		return r;
 	}
+
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_fmc)
+#if (DT_ENUM_IDX(DT_DRV_INST(0), st_mem_swap) == 1)
+	/* sdram-sram */
+	MODIFY_REG(FMC_Bank1_R->BTCR[0], FMC_BCR1_BMAP, FMC_BCR1_BMAP_0);
+#elif (DT_ENUM_IDX(DT_DRV_INST(0), st_mem_swap) == 2)
+	/* sdramb2 */
+	MODIFY_REG(FMC_Bank1_R->BTCR[0], FMC_BCR1_BMAP, FMC_BCR1_BMAP_1);
+#endif
+#endif
 
 	return 0;
 }

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -857,7 +857,7 @@
 		};
 
 		fmc: memory-controller@52004000 {
-			compatible = "st,stm32-fmc";
+			compatible = "st,stm32h7-fmc";
 			reg = <0x52004000 0x400>;
 			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00001000>;
 			label = "STM32_FMC";

--- a/dts/bindings/memory-controllers/st,stm32h7-fmc.yaml
+++ b/dts/bindings/memory-controllers/st,stm32h7-fmc.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2022 Georgij Cernysiov
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 Flexible Memory Controller (FMC).
+
+  The FMC allows to interface with static-memory mapped external devices such as
+  SRAM, NOR Flash, NAND Flash, SDRAM...
+
+  All external memories share the addresses, data and control signals with the
+  controller. Each external device is accessed by means of a unique chip select.
+  The FMC performs only one access at a time to an external device.
+
+  The flexible memory controller includes three memory controllers:
+
+    - NOR/PSRAM memory controller
+    - NAND memory controller (some devices also support PC Card)
+    - Synchronous DRAM (SDRAM/Mobile LPSDR SDRAM) controller
+
+  Each memory controller is defined below the FMC DeviceTree node and is managed
+  by a separate Zephyr device. However, because signals are shared the FMC
+  device handles the signals and the peripheral clocks. FMC can be enabled
+  in your board DeviceTree file like this:
+
+  &fmc {
+      status = "okay";
+      pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1 &fmc_nbl2_pi4...>;
+  };
+
+compatible: "st,stm32h7-fmc"
+
+include: ["st,stm32-fmc.yaml"]
+
+properties:
+    st,mem-swap:
+      type: string
+      required: false
+      default: "disable" # reset state
+      enum:
+        - "disable"
+        - "sdram-sram"
+        - "sdramb2"
+      description: |
+        The FMC bank mapping configuration (BMAP bits of FMC_BCR1).
+
+        * disable    - Default mapping.
+        * sdram-sram - Swap the NOR/PSRAM bank with SDRAM.
+        * sdramb2    - Remaps the SDRAM bank2.
+
+        If absent, then default mapping (disable) is used (reset state).


### PR DESCRIPTION
Adds support for FMC NOR/PSRAM and SDRAM banks remap or swap.

The following values are supported:

* `disabled` - default mapping (reset state).
* `sdram-sram` - swaps the NOR/PSRAM and SDRAM banks.
* `sdramb2` - remaps SDRAM bank 2.

Available only on the H7 series.