### PR TITLE
Fix Zephyr H7 build when FMC is used but MPU is off

### DIFF
--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -7,6 +7,7 @@
 #define DT_DRV_COMPAT st_stm32_fmc
 
 #include <device.h>
+#include <soc.h>
 
 #include <drivers/clock_control/stm32_clock_control.h>
 #include <drivers/pinctrl.h>


### PR DESCRIPTION
The Zephyr build fails on H7 with enabled FMC (`CONFIG_MEMC=y`) and disabled MPU (`CONFIG_ARM_MPU=n`.)

<details>
  <summary>Click to expand the output.</summary>

```
<redacted>\zephyr\drivers\memc\memc_stm32.c: In function 'memc_stm32_init':
In file included from <redacted>\zephyr\include\sys\util_macro.h:34,
                 from <redacted>\zephyr\include\sys\atomic.h:16,
                 from <redacted>\zephyr\include\kernel_includes.h:21,
                 from <redacted>\zephyr\include\kernel.h:17,
                 from <redacted>\zephyr\include\init.h:11,
                 from <redacted>\zephyr\include\device.h:29,
                 from <redacted>\zephyr\drivers\memc\memc_stm32.c:9:
<redacted>\zephyr\drivers\memc\memc_stm32.c: At top level:
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:66:5: error: 'STM32_NO_PULL' undeclared here (not in a function)
   66 |  (((STM32_NO_PULL * DT_PROP(node_id, bias_disable)) << STM32_PUPDR_SHIFT) | \
      |     ^~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:67:26: note: in definition of macro '__DEBRACKET'
   67 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:59:2: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   59 |  __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |  ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:54:2: note: in expansion of macro '__COND_CODE'
   54 |  __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_macro.h:157:2: note: in expansion of macro 'Z_COND_CODE_1'
  157 |  Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:142:2: note: in expansion of macro 'COND_CODE_1'
  142 |  COND_CODE_1(Z_PINCTRL_SKIP_STATE(state_idx, node_id), (),        \
      |  ^~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:84:14: note: in expansion of macro 'Z_PINCTRL_STM32_PINCFG_INIT'
   84 |    .pincfg = Z_PINCTRL_STM32_PINCFG_INIT(          \
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\display-app\build\zephyr\include\generated\devicetree_unfixed.h:14165:83: note: in expansion of macro 'Z_PINCTRL_STATE_PIN_INIT'
14165 | #define DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM(fn) fn(DT_N_S_soc_S_memory_controller_52004000, pinctrl_0, 0) \
      |                                                                                   ^~
<redacted>\zephyr\include\devicetree.h:2901:33: note: in expansion of macro 'DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM'
 2901 | #define DT_CAT4(a1, a2, a3, a4) a1 ## a2 ## a3 ## a4
      |                                 ^~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:94:3: note: in expansion of macro 'DT_FOREACH_PROP_ELEM'
   94 |  {DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
      |   ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:145:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_INIT'
  145 |  Z_PINCTRL_STATE_PINS_INIT(node_id, pinctrl_ ## state_idx);))
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_loops.h:1086:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_DEFINE'
 1086 |  F(0, __VA_ARGS__)
      |  ^
<redacted>\zephyr\include\sys\util_internal.h:99:36: note: in expansion of macro 'Z_UTIL_LISTIFY_1'
   99 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
<redacted>\zephyr\include\drivers\pinctrl.h:238:2: note: in expansion of macro 'UTIL_LISTIFY'
  238 |  UTIL_LISTIFY(DT_NUM_PINCTRL_STATES(node_id),          \
      |  ^~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:252:38: note: in expansion of macro 'PINCTRL_DT_DEFINE'
  252 | #define PINCTRL_DT_INST_DEFINE(inst) PINCTRL_DT_DEFINE(DT_DRV_INST(inst))
      |                                      ^~~~~~~~~~~~~~~~~
<redacted>\zephyr\drivers\memc\memc_stm32.c:61:1: note: in expansion of macro 'PINCTRL_DT_INST_DEFINE'
   61 | PINCTRL_DT_INST_DEFINE(0);
      | ^~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:67:5: error: 'STM32_PULL_UP' undeclared here (not in a function)
   67 |   ((STM32_PULL_UP * DT_PROP(node_id, bias_pull_up)) << STM32_PUPDR_SHIFT) | \
      |     ^~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:64:53: note: in expansion of macro '__DEBRACKET'
   64 | #define __GET_ARG2_DEBRACKET(ignore_this, val, ...) __DEBRACKET val
      |                                                     ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:59:2: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   59 |  __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |  ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:54:2: note: in expansion of macro '__COND_CODE'
   54 |  __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_macro.h:157:2: note: in expansion of macro 'Z_COND_CODE_1'
  157 |  Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:142:2: note: in expansion of macro 'COND_CODE_1'
  142 |  COND_CODE_1(Z_PINCTRL_SKIP_STATE(state_idx, node_id), (),        \
      |  ^~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:84:14: note: in expansion of macro 'Z_PINCTRL_STM32_PINCFG_INIT'
   84 |    .pincfg = Z_PINCTRL_STM32_PINCFG_INIT(          \
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\display-app\build\zephyr\include\generated\devicetree_unfixed.h:14165:83: note: in expansion of macro 'Z_PINCTRL_STATE_PIN_INIT'
14165 | #define DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM(fn) fn(DT_N_S_soc_S_memory_controller_52004000, pinctrl_0, 0) \
      |                                                                                   ^~
<redacted>\zephyr\include\devicetree.h:2901:33: note: in expansion of macro 'DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM'
 2901 | #define DT_CAT4(a1, a2, a3, a4) a1 ## a2 ## a3 ## a4
      |                                 ^~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:94:3: note: in expansion of macro 'DT_FOREACH_PROP_ELEM'
   94 |  {DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
      |   ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:145:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_INIT'
  145 |  Z_PINCTRL_STATE_PINS_INIT(node_id, pinctrl_ ## state_idx);))
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_loops.h:1086:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_DEFINE'
 1086 |  F(0, __VA_ARGS__)
      |  ^
<redacted>\zephyr\include\sys\util_internal.h:99:36: note: in expansion of macro 'Z_UTIL_LISTIFY_1'
   99 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
<redacted>\zephyr\include\drivers\pinctrl.h:238:2: note: in expansion of macro 'UTIL_LISTIFY'
  238 |  UTIL_LISTIFY(DT_NUM_PINCTRL_STATES(node_id),          \
      |  ^~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:252:38: note: in expansion of macro 'PINCTRL_DT_DEFINE'
  252 | #define PINCTRL_DT_INST_DEFINE(inst) PINCTRL_DT_DEFINE(DT_DRV_INST(inst))
      |                                      ^~~~~~~~~~~~~~~~~
<redacted>\zephyr\drivers\memc\memc_stm32.c:61:1: note: in expansion of macro 'PINCTRL_DT_INST_DEFINE'
   61 | PINCTRL_DT_INST_DEFINE(0);
      | ^~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:68:5: error: 'STM32_PULL_DOWN' undeclared here
(not in a function); did you mean 'STM32_PUPDR_PULL_DOWN'?
   68 |   ((STM32_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << STM32_PUPDR_SHIFT) | \
      |     ^~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:67:26: note: in definition of macro '__DEBRACKET'
   67 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:59:2: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   59 |  __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |  ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:54:2: note: in expansion of macro '__COND_CODE'
   54 |  __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_macro.h:157:2: note: in expansion of macro 'Z_COND_CODE_1'
  157 |  Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:142:2: note: in expansion of macro 'COND_CODE_1'
  142 |  COND_CODE_1(Z_PINCTRL_SKIP_STATE(state_idx, node_id), (),        \
      |  ^~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:84:14: note: in expansion of macro 'Z_PINCTRL_STM32_PINCFG_INIT'
   84 |    .pincfg = Z_PINCTRL_STM32_PINCFG_INIT(          \
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\display-app\build\zephyr\include\generated\devicetree_unfixed.h:14165:83: note: in expansion of macro 'Z_PINCTRL_STATE_PIN_INIT'
14165 | #define DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM(fn) fn(DT_N_S_soc_S_memory_controller_52004000, pinctrl_0, 0) \
      |                                                                                   ^~
<redacted>\zephyr\include\devicetree.h:2901:33: note: in expansion of macro 'DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM'
 2901 | #define DT_CAT4(a1, a2, a3, a4) a1 ## a2 ## a3 ## a4
      |                                 ^~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:94:3: note: in expansion of macro 'DT_FOREACH_PROP_ELEM'
   94 |  {DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
      |   ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:145:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_INIT'
  145 |  Z_PINCTRL_STATE_PINS_INIT(node_id, pinctrl_ ## state_idx);))
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_loops.h:1086:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_DEFINE'
 1086 |  F(0, __VA_ARGS__)
      |  ^
<redacted>\zephyr\include\sys\util_internal.h:99:36: note: in expansion of macro 'Z_UTIL_LISTIFY_1'
   99 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
<redacted>\zephyr\include\drivers\pinctrl.h:238:2: note: in expansion of macro 'UTIL_LISTIFY'
  238 |  UTIL_LISTIFY(DT_NUM_PINCTRL_STATES(node_id),          \
      |  ^~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:252:38: note: in expansion of macro 'PINCTRL_DT_DEFINE'
  252 | #define PINCTRL_DT_INST_DEFINE(inst) PINCTRL_DT_DEFINE(DT_DRV_INST(inst))
      |                                      ^~~~~~~~~~~~~~~~~
<redacted>\zephyr\drivers\memc\memc_stm32.c:61:1: note: in expansion of macro 'PINCTRL_DT_INST_DEFINE'
   61 | PINCTRL_DT_INST_DEFINE(0);
      | ^~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:69:5: error: 'STM32_PUSH_PULL' undeclared here
(not in a function); did you mean 'STM32_PUPDR_PULL_UP'?
   69 |   ((STM32_PUSH_PULL * DT_PROP(node_id, drive_push_pull)) << STM32_OTYPER_SHIFT) | \
      |     ^~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:67:26: note: in definition of macro '__DEBRACKET'
   67 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:59:2: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   59 |  __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |  ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:54:2: note: in expansion of macro '__COND_CODE'
   54 |  __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_macro.h:157:2: note: in expansion of macro 'Z_COND_CODE_1'
  157 |  Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:142:2: note: in expansion of macro 'COND_CODE_1'
  142 |  COND_CODE_1(Z_PINCTRL_SKIP_STATE(state_idx, node_id), (),        \
      |  ^~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:84:14: note: in expansion of macro 'Z_PINCTRL_STM32_PINCFG_INIT'
   84 |    .pincfg = Z_PINCTRL_STM32_PINCFG_INIT(          \
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\display-app\build\zephyr\include\generated\devicetree_unfixed.h:14165:83: note: in expansion of macro 'Z_PINCTRL_STATE_PIN_INIT'
14165 | #define DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM(fn) fn(DT_N_S_soc_S_memory_controller_52004000, pinctrl_0, 0) \
      |                                                                                   ^~
<redacted>\zephyr\include\devicetree.h:2901:33: note: in expansion of macro 'DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM'
 2901 | #define DT_CAT4(a1, a2, a3, a4) a1 ## a2 ## a3 ## a4
      |                                 ^~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:94:3: note: in expansion of macro 'DT_FOREACH_PROP_ELEM'
   94 |  {DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
      |   ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:145:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_INIT'
  145 |  Z_PINCTRL_STATE_PINS_INIT(node_id, pinctrl_ ## state_idx);))
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_loops.h:1086:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_DEFINE'
 1086 |  F(0, __VA_ARGS__)
      |  ^
<redacted>\zephyr\include\sys\util_internal.h:99:36: note: in expansion of macro 'Z_UTIL_LISTIFY_1'
   99 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
<redacted>\zephyr\include\drivers\pinctrl.h:238:2: note: in expansion of macro 'UTIL_LISTIFY'
  238 |  UTIL_LISTIFY(DT_NUM_PINCTRL_STATES(node_id),          \
      |  ^~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:252:38: note: in expansion of macro 'PINCTRL_DT_DEFINE'
  252 | #define PINCTRL_DT_INST_DEFINE(inst) PINCTRL_DT_DEFINE(DT_DRV_INST(inst))
      |                                      ^~~~~~~~~~~~~~~~~
<redacted>\zephyr\drivers\memc\memc_stm32.c:61:1: note: in expansion of macro 'PINCTRL_DT_INST_DEFINE'
   61 | PINCTRL_DT_INST_DEFINE(0);
      | ^~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:70:5: error: 'STM32_OPEN_DRAIN' undeclared here (not in a function)
   70 |   ((STM32_OPEN_DRAIN * DT_PROP(node_id, drive_open_drain)) << STM32_OTYPER_SHIFT) | \
      |     ^~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:67:26: note: in definition of macro '__DEBRACKET'
   67 | #define __DEBRACKET(...) __VA_ARGS__
      |                          ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:59:2: note: in expansion of macro '__GET_ARG2_DEBRACKET'
   59 |  __GET_ARG2_DEBRACKET(one_or_two_args _if_code, _else_code)
      |  ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_internal.h:54:2: note: in expansion of macro '__COND_CODE'
   54 |  __COND_CODE(_XXXX##_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~
<redacted>\zephyr\include\sys\util_macro.h:157:2: note: in expansion of macro 'Z_COND_CODE_1'
  157 |  Z_COND_CODE_1(_flag, _if_1_code, _else_code)
      |  ^~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:142:2: note: in expansion of macro 'COND_CODE_1'
  142 |  COND_CODE_1(Z_PINCTRL_SKIP_STATE(state_idx, node_id), (),        \
      |  ^~~~~~~~~~~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:84:14: note: in expansion of macro 'Z_PINCTRL_STM32_PINCFG_INIT'
   84 |    .pincfg = Z_PINCTRL_STM32_PINCFG_INIT(          \
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\display-app\build\zephyr\include\generated\devicetree_unfixed.h:14165:83: note: in expansion of macro 'Z_PINCTRL_STATE_PIN_INIT'
14165 | #define DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM(fn) fn(DT_N_S_soc_S_memory_controller_52004000, pinctrl_0, 0) \
      |                                                                                   ^~
<redacted>\zephyr\include\devicetree.h:2901:33: note: in expansion of macro 'DT_N_S_soc_S_memory_controller_52004000_P_pinctrl_0_FOREACH_PROP_ELEM'
 2901 | #define DT_CAT4(a1, a2, a3, a4) a1 ## a2 ## a3 ## a4
      |                                 ^~
<redacted>\zephyr\soc\arm\st_stm32\common\pinctrl_soc.h:94:3: note: in expansion of macro 'DT_FOREACH_PROP_ELEM'
   94 |  {DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
      |   ^~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:145:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_INIT'
  145 |  Z_PINCTRL_STATE_PINS_INIT(node_id, pinctrl_ ## state_idx);))
      |  ^~~~~~~~~~~~~~~~~~~~~~~~~
<redacted>\zephyr\include\sys\util_loops.h:1086:2: note: in expansion of macro 'Z_PINCTRL_STATE_PINS_DEFINE'
 1086 |  F(0, __VA_ARGS__)
      |  ^
<redacted>\zephyr\include\sys\util_internal.h:99:36: note: in expansion of macro 'Z_UTIL_LISTIFY_1'
   99 | #define UTIL_PRIMITIVE_CAT(a, ...) a##__VA_ARGS__
      |                                    ^
<redacted>\zephyr\include\drivers\pinctrl.h:238:2: note: in expansion of macro 'UTIL_LISTIFY'
  238 |  UTIL_LISTIFY(DT_NUM_PINCTRL_STATES(node_id),          \
      |  ^~~~~~~~~~~~
<redacted>\zephyr\include\drivers\pinctrl.h:252:38: note: in expansion of macro 'PINCTRL_DT_DEFINE'
  252 | #define PINCTRL_DT_INST_DEFINE(inst) PINCTRL_DT_DEFINE(DT_DRV_INST(inst))
      |                                      ^~~~~~~~~~~~~~~~~
<redacted>\zephyr\drivers\memc\memc_stm32.c:61:1: note: in expansion of macro 'PINCTRL_DT_INST_DEFINE'
   61 | PINCTRL_DT_INST_DEFINE(0);
      | ^~~~~~~~~~~~~~~~~~~~~~
```
</details>

Including `soc.h`  in `memc_stm32.c` fixes the build.