### PR TITLE
gh: actions: Triggger the do not merge after manifest runs

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+  workflow_run:
+    workflows: [Manifest]
+    types:
+      - completed
+
+
 jobs:
   do-not-merge:
     if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}


### PR DESCRIPTION
For some reason when the manifest action runs and removes the DNM label,
the Do Not Merge workflow doesn't run automatically. Force it running
whenever the Manifest workflow completes to fix this.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>