### PR TITLE
net: lwm2m: SenML Json Base compare fix

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_json.c
@@ -330,7 +330,7 @@ static int put_begin_oi(struct lwm2m_output_context *out, struct lwm2m_obj_path 
 
 	if (update_base_name) {
 		fd->base_name.level = LWM2M_PATH_LEVEL_OBJECT_INST;
-		fd->base_name.obj_inst_id = path->obj_id;
+		fd->base_name.obj_id = path->obj_id;
 		fd->base_name.obj_inst_id = path->obj_inst_id;
 	}
 


### PR DESCRIPTION
Fixed wrong initialized base name objed id.
Base name was added to every object instance.
Fix will save message size.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>