### PR TITLE
Bluetooth: Increase supported maximum simultaneous connection to 250

### DIFF
--- a/samples/bluetooth/central_multilink/src/central_multilink.c
+++ b/samples/bluetooth/central_multilink/src/central_multilink.c
@@ -20,11 +20,11 @@
 #include <bluetooth/gatt.h>
 #include <sys/byteorder.h>
 
-#define SCAN_INTERVAL 0x0140 /* 200 ms */
+#define SCAN_INTERVAL 0x0640 /* 1000 ms */
 #define SCAN_WINDOW   0x0030 /* 30 ms */
 #define INIT_INTERVAL 0x0010 /* 10 ms */
 #define INIT_WINDOW   0x0010 /* 10 ms */
-#define CONN_INTERVAL 0x00A0 /* 200 ms */
+#define CONN_INTERVAL 0x0320 /* 1000 ms */
 #define CONN_LATENCY  0
 #define CONN_TIMEOUT  MIN(MAX((CONN_INTERVAL * 125 * \
 			       MAX(CONFIG_BT_MAX_CONN, 6) / 1000), 10), 3200)
@@ -74,6 +74,7 @@ static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 	}
 
 	if (bt_le_scan_stop()) {
+		printk("Scanning successfully stopped\n");
 		return;
 	}
 
@@ -311,10 +312,10 @@ int init_central(uint8_t iterations)
 
 	while (true) {
 		while (conn_count < CONFIG_BT_MAX_CONN) {
-			k_sleep(K_SECONDS(1));
+			k_sleep(K_MSEC(10));
 		}
 
-		k_sleep(K_SECONDS(10));
+		k_sleep(K_SECONDS(60));
 
 		if (!iterations) {
 			break;
@@ -327,8 +328,9 @@ int init_central(uint8_t iterations)
 		bt_conn_foreach(BT_CONN_TYPE_LE, disconnect, NULL);
 
 		while (is_disconnecting) {
-			k_sleep(K_SECONDS(1));
+			k_sleep(K_MSEC(10));
 		}
+		printk("All disconnected.\n");
 	}
 
 	return 0;

--- a/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
+++ b/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
@@ -99,6 +99,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	printk("Disconnected %s (reason 0x%02x)\n", addr, reason);
 
 	if ((conn_count == 1U) && is_disconnecting) {
+		is_disconnecting = false;
 		k_work_submit(&work_adv_start);
 	}
 	conn_count--;
@@ -256,7 +257,7 @@ int init_peripheral(uint8_t iterations)
 
 	/* wait for connection attempts on all identities */
 	do {
-		k_sleep(K_MSEC(100));
+		k_sleep(K_MSEC(10));
 
 		id_count = 0xFF;
 		bt_id_get(NULL, &id_count);
@@ -279,10 +280,9 @@ int init_peripheral(uint8_t iterations)
 
 			printk("Wait for disconnections...\n");
 			is_disconnecting = true;
-			while (conn_count != 0) {
+			while (is_disconnecting) {
 				k_sleep(K_MSEC(10));
 			}
-			is_disconnecting = false;
 			printk("All disconnected.\n");
 
 			continue;
@@ -296,11 +296,11 @@ int init_peripheral(uint8_t iterations)
 
 			continue;
 		} else {
-			uint16_t wait = 1200U;
+			uint16_t wait = 6200U;
 
-			/* Maximum duration without connection count change, central
-			 * waiting before disconnecting all its connections plus few
-			 * seconds of margin.
+			/* Maximum duration without connection count change,
+			 * central waiting before disconnecting all its
+			 * connections plus few seconds of margin.
 			 */
 			while ((prev_count == conn_count) && wait) {
 				wait--;

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -115,7 +115,7 @@ config BT_CONN
 config BT_MAX_CONN
 	int "Maximum number of simultaneous connections"
 	depends on BT_CONN
-	range 1 64
+	range 1 250
 	default 2 if BT_MESH_GATT_CLIENT
 	default 1
 	help

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -454,7 +454,7 @@ static struct {
 	  (BT_CTLR_SCAN_SYNC_ISO_SET * 2) +                                    \
 	  (IQ_REPORT_CNT)))
 static struct {
-	uint8_t quota_pdu; /* Number of un-utilized buffers */
+	uint16_t quota_pdu; /* Number of un-utilized buffers */
 
 	void *free;
 	uint8_t pool[LINK_RX_POOL_SIZE];

--- a/subsys/bluetooth/controller/util/mem.c
+++ b/subsys/bluetooth/controller/util/mem.c
@@ -104,7 +104,7 @@ void *mem_get(void *mem_pool, uint16_t mem_size, uint16_t index)
 
 uint16_t mem_index_get(void *mem, void *mem_pool, uint16_t mem_size)
 {
-	return ((uint16_t)((uint8_t *)mem - (uint8_t *)mem_pool) / mem_size);
+	return ((uint8_t *)mem - (uint8_t *)mem_pool) / mem_size;
 }
 
 /**

--- a/subsys/bluetooth/controller/util/mfifo.h
+++ b/subsys/bluetooth/controller/util/mfifo.h
@@ -45,11 +45,11 @@
 		struct {                                                    \
 			/* TODO: const, optimise RAM use */                 \
 			/* TODO: Separate s,n,f,l out into common struct */ \
-			uint8_t const s;         /* Stride between elements */ \
-			uint8_t const n;         /* Number of buffers */       \
-			uint8_t f;               /* First. Read index */       \
-			uint8_t l;               /* Last. Write index */       \
-			uint8_t MALIGN(4) m[MROUND(sz) * ((cnt) + 1)];         \
+			uint16_t const s;     /* Stride between elements */ \
+			uint16_t const n;     /* Number of buffers */       \
+			uint8_t f;            /* First. Read index */       \
+			uint8_t l;            /* Last. Write index */       \
+			uint8_t MALIGN(4) m[MROUND(sz) * ((cnt) + 1)];      \
 		} mfifo_##name = {                                          \
 			.n = ((cnt) + 1),                                   \
 			.s = MROUND(sz),                                    \

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -583,7 +583,7 @@ config BT_DEVICE_APPEARANCE
 
 config BT_ID_MAX
 	int "Maximum number of local identities"
-	range 1 64
+	range 1 250
 	default 1
 	help
 	  Maximum number of supported local identity addresses. For most

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/prj.conf
@@ -10,8 +10,8 @@ CONFIG_BT_AUTO_PHY_UPDATE=y
 CONFIG_BT_USER_DATA_LEN_UPDATE=y
 CONFIG_BT_AUTO_DATA_LEN_UPDATE=y
 
-CONFIG_BT_MAX_CONN=62
-CONFIG_BT_ID_MAX=62
+CONFIG_BT_MAX_CONN=250
+CONFIG_BT_ID_MAX=250
 
 # L2CAP, ATT and SMP usage cause data transmission deadlock due to shortage
 # of buffers when transactions crossover amongst the connections in the same
@@ -22,7 +22,7 @@ CONFIG_BT_GAP_AUTO_UPDATE_CONN_PARAMS=n
 # CONFIG_BT_GATT_CLIENT=y
 
 # CONFIG_BT_SMP=y
-# CONFIG_BT_MAX_PAIRED=62
+# CONFIG_BT_MAX_PAIRED=250
 
 CONFIG_BT_BUF_CMD_TX_SIZE=255
 CONFIG_BT_BUF_EVT_RX_SIZE=255
@@ -35,3 +35,11 @@ CONFIG_BT_CTLR_DATA_LENGTH_MAX=251
 # Each PHY update can pause connections for 6 interval hence to let other
 # parallel connection establishment to succeed increase Rx buffer count.
 CONFIG_BT_CTLR_RX_BUFFERS=6
+
+# Provide enough spacing between connections so that multiple peripheral roles
+# when connected to a single peer device (peripheral_identity sample) have
+# room for window widening and do not overlap with each other in that single
+# peer device. This can be tuned based on connection interval and clock
+# accuracy, current value here is sufficient for 500ppm at 1 second interval.
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+CONFIG_BT_CTLR_SCHED_ADVANCED_CENTRAL_CONN_SPACING=1000

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/src/main.c
@@ -81,7 +81,7 @@ exit:
 
 static void test_multiple_init(void)
 {
-	bst_ticker_set_next_tick_absolute(600e6);
+	bst_ticker_set_next_tick_absolute(4500e6);
 	bst_result = In_progress;
 }
 

--- a/tests/bluetooth/bsim_bt/bsim_test_multiple/tests_scripts/multiple.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_multiple/tests_scripts/multiple.sh
@@ -13,7 +13,7 @@ function Execute(){
  compile it?)\e[39m"
     exit 1
   fi
-  timeout 300 $@ & process_ids="$process_ids $!"
+  timeout 900 $@ & process_ids="$process_ids $!"
 }
 
 : "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
@@ -30,7 +30,7 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_multiple_prj_conf\
   -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral
 
 Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
-  -D=2 -sim_length=600e6 $@
+  -D=2 -sim_length=4500e6 $@
 
 for process_id in $process_ids; do
   wait $process_id || let "exit_code=$?"


### PR DESCRIPTION
Update Controller to use uint16_t instead of uint8_t to
allow buffer counts to exceed beyond 255. Also fix pointer
arithmetic from being restricted to uint16_t that prevented
calculating the memory index for large offsets. This will
now allow support for 250 simultaneous connections, limited
by ticker_id type being uint8_t.

Increase the supported maximum simultaneous connection to
250, tested under BabbleSim simulations.

Increase to 250 simultaneous connections in the BabbleSim
test. Update connection interval to accommodate 250
non-overlapping connections and a scan window.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>