### PR TITLE
Bluetooth: Controller: Fix CTE_REQ disable lock if there is no CTE_RSP 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1645,12 +1645,18 @@ void ull_conn_done(struct node_rx_event_done *done)
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ)
-	if (conn->llcp.cte_req.req_expire != 0U) {
+	/* Check if the CTE_REQ procedure is periodic and counter has been started.
+	 * req_expire is set when: new CTE_REQ is started, after completion of last periodic run.
+	 */
+	if (conn->llcp.cte_req.req_interval != 0U && conn->llcp.cte_req.req_expire != 0U) {
 		if (conn->llcp.cte_req.req_expire > elapsed_event) {
 			conn->llcp.cte_req.req_expire -= elapsed_event;
 		} else {
 			uint8_t err;
 
+			/* Set req_expire to zero to mark that new periodic CTE_REQ was started.
+			 * The counter is re-started after completion of this run.
+			 */
 			conn->llcp.cte_req.req_expire = 0U;
 
 			err = ull_cp_cte_req(conn, conn->llcp.cte_req.min_cte_len,

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1665,13 +1665,8 @@ void ull_conn_done(struct node_rx_event_done *done)
 			if (err == BT_HCI_ERR_CMD_DISALLOWED) {
 				/* Conditions has changed e.g. PHY was changed to CODED.
 				 * New CTE REQ is not possible. Disable the periodic requests.
-				 *
-				 * If the CTE REQ is in active state, let it complete and disable
-				 * in regular control procedure way.
 				 */
-				if (!conn->llcp.cte_req.is_active) {
-					ull_cp_cte_req_set_disable(conn);
-				}
+				ull_cp_cte_req_set_disable(conn);
 			}
 		}
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -429,15 +429,12 @@ struct llcp_struct {
 		/* Procedure may be active periodically, active state must be stored.
 		 * If procedure is active, request parameters update may not be issued.
 		 */
-		uint8_t is_enabled:1;
-		uint8_t is_active:1;
+		volatile uint8_t is_enabled;
 		uint8_t cte_type;
 		/* Minimum requested CTE length in 8us units */
 		uint8_t min_cte_len;
 		uint16_t req_interval;
 		uint16_t req_expire;
-		void *disable_param;
-		void (*disable_cb)(void *param);
 	} cte_req;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_REQ */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -1123,12 +1123,12 @@ uint8_t ll_df_set_conn_cte_rx_params(uint16_t handle, uint8_t sampling_enable,
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 
-#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ) || defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
 static void df_conn_cte_req_disable(void *param)
 {
 	k_sem_give(param);
 }
-#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_REQ || CONFIG_BT_CTLR_DF_CONN_CTE_RSP */
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RSP */
 
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ)
 /* @brief Function enables or disables CTE request control procedure for a connection.
@@ -1164,18 +1164,6 @@ uint8_t ll_df_set_conn_cte_req_enable(uint16_t handle, uint8_t enable,
 
 	if (!enable) {
 		ull_cp_cte_req_set_disable(conn);
-
-		if (conn->llcp.cte_req.is_active) {
-			struct k_sem sem;
-
-			k_sem_init(&sem, 0U, 1U);
-			conn->llcp.cte_req.disable_param = &sem;
-			conn->llcp.cte_req.disable_cb = df_conn_cte_req_disable;
-
-			if (!conn->llcp.cte_req.is_active) {
-				k_sem_take(&sem, K_FOREVER);
-			}
-		}
 
 		return BT_HCI_ERR_SUCCESS;
 	} else {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -485,9 +485,6 @@ void ull_llcp_init(struct ll_conn *conn)
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_REQ)
 	conn->llcp.cte_req.is_enabled = 0U;
 	conn->llcp.cte_req.req_expire = 0U;
-	conn->llcp.cte_req.is_active = 0U;
-	conn->llcp.cte_req.disable_param = NULL;
-	conn->llcp.cte_req.disable_cb = NULL;
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_REQ */
 #if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RSP)
 	conn->llcp.cte_rsp.is_enabled = 0U;
@@ -980,8 +977,6 @@ uint8_t ull_cp_cte_req(struct ll_conn *conn, uint8_t min_cte_len, uint8_t cte_ty
 
 		ctx->data.cte_req.min_len = min_cte_len;
 		ctx->data.cte_req.type = cte_type;
-
-		conn->llcp.cte_req.is_active = 1U;
 
 		llcp_lr_enqueue(conn, ctx);
 

--- a/tests/bluetooth/controller/ctrl_cte_req/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cte_req/src/main.c
@@ -84,7 +84,10 @@ void test_cte_req_central_local(void)
 	/* Connect */
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
+
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -261,6 +264,8 @@ void test_cte_req_peripheral_local(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -475,6 +480,8 @@ void test_cte_req_rejected_inv_ll_param_central_local(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -549,6 +556,8 @@ void test_cte_req_rejected_inv_ll_param_peripheral_local(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -1124,6 +1133,8 @@ static void test_local_cte_req_wait_for_phy_update_complete_and_disable(uint8_t 
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -1189,6 +1200,8 @@ static void test_local_cte_req_wait_for_phy_update_complete(uint8_t role)
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -1235,6 +1248,8 @@ static void test_local_phy_update_wait_for_cte_req_complete(uint8_t role)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -1385,6 +1400,8 @@ static void test_cte_req_wait_for_remote_phy_update_complete_and_disable(uint8_t
 	event_done(&conn);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
@@ -1439,6 +1456,8 @@ static void test_cte_req_wait_for_remote_phy_update_complete(uint8_t role)
 	event_done(&conn);
 
 	/* Initiate an CTE Request Procedure */
+	conn.llcp.cte_req.is_enabled = 1U;
+
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 

--- a/tests/bluetooth/controller/ctrl_cte_req/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cte_req/src/main.c
@@ -41,6 +41,9 @@ struct ll_conn conn;
 static void setup(void)
 {
 	test_setup(&conn);
+
+	/* Set CTE request enable as if it was called by Host */
+	conn.llcp.cte_req.is_enabled = 1U;
 }
 
 /* Tests of successful execution of CTE Request Procedure */
@@ -792,6 +795,8 @@ static uint16_t pu_event_counter(struct ll_conn *conn)
 static void phy_update_setup(void)
 {
 	test_setup(&conn);
+	/* Set CTE request enable as if it was called by Host */
+	conn.llcp.cte_req.is_enabled = 1U;
 
 	/* Emulate initial conn state */
 	conn.phy_pref_rx = PHY_PREFER_ANY;


### PR DESCRIPTION
First item:

There is an error in the condition that checks if new CTE_REQ should
be started after end of connection event. The condition verifies if
counter req_expire is set to zero. Then new CTE_REQ is started
irrespectively to CTE_REQ being disabled.

req_interval is used to store information if the CTE_REQ is:
- periodic, then value doesn't equal zero,
- single shot or disabled, then value equals zero.

The condition should verify if the req_interval is not zero and
req_expire is not zero. The second part of the if condition is
required to avoid starting next CTE_REQ until last one has been
completed.

Second item:
The periodic CTE_REQ disable command, requested by Host, may be locked
until connection is dropped due to missing CTE_RSP from peer device.
That is caused by implementation of CTE_REQ disable and CTE_REQ
control procedure handling.

The procedure is marked as active when CTE request was send to peer
device. It is marked as inactive after completion of the procedure.
That caused locking of CTE disable on a semaphore.

The BT 5.3 Core Spec, Vol 4, Part E, section 7.8.85 says the HCI_LE_-
Connection_CTE_Request_Enable should be considered active on a conne-
ction from when Host successfully issues the command with Enable=0x1
until a command is issued with Enable=0x0 or single LLCP CTE request
has finished (CTE_Request_Interval=0x0). Also there is a clarification
from BT SIG that the command with Enable=0x0 does not affect any
initiated LLCP CTE request. That means Controller is allowed to finish
already started procedure and it is not allowed to start new LLCP CTE
request procedure after completion of the command with Enable=0x0.

Taking that into account, there is no need to synchronize ULL and LLL
in regard of disable the LLCP CTE request while the procedure is
pending. Controller is free to complete the procedure or terminate it.

The change removes all code related with cte_req.is_active, disable
callback and waiting of ULL for LLL to finish the LLCP CTE request.

The ULL will complete the HCI_LE_Connection_Request_Enable with
Enable=0x0 immediately. In case the procedure is disabled in before
the response arrives, then further processing of the response is
dropped and the procedure context released.

The context is not released by the code responsible for disable
handling, to have single place where it is done.