### PR TITLE
dma/cavs_hda: Support channel filtering

### DIFF
--- a/drivers/dma/dma_cavs_hda.c
+++ b/drivers/dma/dma_cavs_hda.c
@@ -130,6 +130,23 @@ int cavs_hda_dma_status(const struct device *dev, uint32_t channel,
 	return 0;
 }
 
+bool cavs_hda_dma_chan_filter(const struct device *dev, int channel, void *filter_param)
+{
+	uint32_t requested_channel;
+
+	if (!filter_param) {
+		return true;
+	}
+
+	requested_channel = *(uint32_t *)filter_param;
+
+	if (channel == requested_channel) {
+		return true;
+	}
+
+	return false;
+}
+
 int cavs_hda_dma_start(const struct device *dev, uint32_t channel)
 {
 	const struct cavs_hda_dma_cfg *const cfg = dev->config;

--- a/drivers/dma/dma_cavs_hda.h
+++ b/drivers/dma/dma_cavs_hda.h
@@ -37,6 +37,9 @@ int cavs_hda_dma_host_reload(const struct device *dev, uint32_t channel,
 int cavs_hda_dma_status(const struct device *dev, uint32_t channel,
 			struct dma_status *stat);
 
+bool cavs_hda_dma_chan_filter(const struct device *dev, int channel,
+			      void *filter_param);
+
 int cavs_hda_dma_start(const struct device *dev, uint32_t channel);
 
 int cavs_hda_dma_stop(const struct device *dev, uint32_t channel);

--- a/drivers/dma/dma_cavs_hda_host_in.c
+++ b/drivers/dma/dma_cavs_hda_host_in.c
@@ -19,6 +19,7 @@ static const struct dma_driver_api cavs_hda_dma_host_in_api = {
 	.start = cavs_hda_dma_start,
 	.stop = cavs_hda_dma_stop,
 	.get_status = cavs_hda_dma_status,
+	.chan_filter = cavs_hda_dma_chan_filter,
 };
 
 #define CAVS_HDA_DMA_HOST_IN_INIT(inst)                                                            \

--- a/drivers/dma/dma_cavs_hda_host_out.c
+++ b/drivers/dma/dma_cavs_hda_host_out.c
@@ -19,6 +19,7 @@ static const struct dma_driver_api cavs_hda_dma_host_out_api = {
 	.start = cavs_hda_dma_start,
 	.stop = cavs_hda_dma_stop,
 	.get_status = cavs_hda_dma_status,
+	.chan_filter = cavs_hda_dma_chan_filter,
 };
 
 #define CAVS_HDA_DMA_HOST_OUT_INIT(inst)                                                           \


### PR DESCRIPTION
Support channel filtering to find the requested channel
if filter_param provided

This is in addition to PR #42938 and will allow to
support cases where it is necessary to use a specific channel