### PR TITLE
include: remove unnecessary autoconf.h includes

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86_tiny.ld
+++ b/boards/x86/qemu_x86/qemu_x86_tiny.ld
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 #include <devicetree.h>
 #include <offsets.h>
 #include <linker/linker-defs.h>

--- a/cmake/linker/lld/target.cmake
+++ b/cmake/linker/lld/target.cmake
@@ -44,6 +44,7 @@ macro(configure_linker_script linker_script_gen linker_pass_define)
     -MD -MF ${linker_script_gen}.dep -MT ${linker_script_gen}
     -D_LINKER
     -D_ASMLANGUAGE
+    -imacros ${AUTOCONF_H}
     ${current_includes}
     ${current_defines}
     ${template_script_defines}

--- a/doc/guides/build/index.rst
+++ b/doc/guides/build/index.rst
@@ -130,7 +130,9 @@ Kconfig
 
    The output from Kconfig is an :file:`autoconf.h` header with preprocessor
    assignments, and a :file:`.config` file that acts both as a saved
-   configuration and as configuration output (used by CMake).
+   configuration and as configuration output (used by CMake). The definitions in
+   :file:`autoconf.h` are automatically exposed at compile time, so there is no
+   need to include this header.
 
    Information from devicetree is available to Kconfig, through the functions
    defined in :zephyr_file:`kconfigfunctions.py

--- a/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -11,7 +11,6 @@
  * Linker script for the Cortex-A and Cortex-R platforms.
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 

--- a/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -11,7 +11,6 @@
  * Linker script for the Cortex-M platforms.
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 

--- a/include/arch/arm64/scripts/linker.ld
+++ b/include/arch/arm64/scripts/linker.ld
@@ -11,7 +11,6 @@
  * Linker script for the Cortex-A platforms.
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 

--- a/include/arch/mips/linker.ld
+++ b/include/arch/mips/linker.ld
@@ -11,7 +11,6 @@
  * @brief Linker command/script file for the MIPS platform
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>

--- a/include/arch/nios2/linker.ld
+++ b/include/arch/nios2/linker.ld
@@ -11,7 +11,6 @@
  * Linker script for the Nios II platform
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #include <linker/linker-defs.h>

--- a/include/arch/posix/linker.ld
+++ b/include/arch/posix/linker.ld
@@ -12,7 +12,6 @@
  * Linker script for the POSIX (native) platform
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #include <linker/linker-defs.h>

--- a/include/arch/riscv/common/linker.ld
+++ b/include/arch/riscv/common/linker.ld
@@ -14,7 +14,6 @@
 #include <soc.h>
 #include <devicetree.h>
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <linker/devicetree_regions.h>
 

--- a/include/arch/sparc/linker.ld
+++ b/include/arch/sparc/linker.ld
@@ -11,7 +11,6 @@
 
 #include <soc.h>
 
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #include <linker/linker-defs.h>

--- a/include/arch/x86/memory.ld
+++ b/include/arch/x86/memory.ld
@@ -27,7 +27,6 @@
 #ifndef ARCH_X86_MEMORY_LD
 #define ARCH_X86_MEMORY_LD
 
-#include <autoconf.h>
 #include <devicetree.h>
 #include <sys/mem_manage.h>
 

--- a/include/shared_irq.h
+++ b/include/shared_irq.h
@@ -9,7 +9,6 @@
 #ifndef ZEPHYR_INCLUDE_SHARED_IRQ_H_
 #define ZEPHYR_INCLUDE_SHARED_IRQ_H_
 
-#include <autoconf.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/application_development/code_relocation/linker_arm_sram2.ld
+++ b/samples/application_development/code_relocation/linker_arm_sram2.ld
@@ -11,7 +11,6 @@
  * Linker script for the Cortex-M platforms.
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 

--- a/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
+++ b/samples/application_development/code_relocation_nocopy/linker_arm_nocopy.ld
@@ -11,7 +11,6 @@
  * Linker script for the Cortex-M platforms.
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 

--- a/samples/boards/qemu_cortex_a53/reserved_memory/linker_arm64_reserved.ld
+++ b/samples/boards/qemu_cortex_a53/reserved_memory/linker_arm64_reserved.ld
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 

--- a/soc/arc/snps_arc_hsdk/linker.ld
+++ b/soc/arc/snps_arc_hsdk/linker.ld
@@ -9,7 +9,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 
 /*
  * SRAM base address and size

--- a/soc/arc/snps_arc_iot/linker.ld
+++ b/soc/arc/snps_arc_iot/linker.ld
@@ -9,7 +9,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 
 /*
  * SRAM base address and size

--- a/soc/arc/snps_emsdp/linker.ld
+++ b/soc/arc/snps_emsdp/linker.ld
@@ -9,7 +9,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 
 /*
  * SRAM base address and size

--- a/soc/arc/snps_emsk/linker.ld
+++ b/soc/arc/snps_emsk/linker.ld
@@ -9,7 +9,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 
 /*
  * DRAM base address and size

--- a/soc/arc/snps_nsim/linker.ld
+++ b/soc/arc/snps_nsim/linker.ld
@@ -9,7 +9,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 
 /* Instruction Closely Coupled Memory (ICCM) base address and size */
 #if DT_NODE_HAS_PROP(DT_INST(0, arc_iccm), reg) && \

--- a/soc/arc/snps_qemu/linker.ld
+++ b/soc/arc/snps_qemu/linker.ld
@@ -5,7 +5,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 
 /*
  * SRAM base address and size

--- a/soc/arm/bcm_vk/valkyrie/linker.ld
+++ b/soc/arm/bcm_vk/valkyrie/linker.ld
@@ -3,6 +3,5 @@
  * Copyright 2019 Broadcom.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/bcm_vk/viper/linker.ld
+++ b/soc/arm/bcm_vk/viper/linker.ld
@@ -4,6 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 
 #include <linker_m7.ld>

--- a/soc/arm/cypress/psoc6/linker.ld
+++ b/soc/arm/cypress/psoc6/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_imx/mcimx6x_m4/linker.ld
+++ b/soc/arm/nxp_imx/mcimx6x_m4/linker.ld
@@ -4,5 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_imx/mimx8ml8_m7/linker.ld
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/linker.ld
@@ -5,7 +5,6 @@
  */
 
 
-#include <autoconf.h>
 #include <devicetree.h>
 
 MEMORY

--- a/soc/arm/nxp_imx/rt/linker.ld
+++ b/soc/arm/nxp_imx/rt/linker.ld
@@ -4,8 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
- #include <autoconf.h>
- #include <devicetree.h>
+  #include <devicetree.h>
 
 #define IS_CHOSEN_SRAM(x) (DT_DEP_ORD(DT_NODELABEL(x)) == DT_DEP_ORD(DT_CHOSEN(zephyr_sram)))
 

--- a/soc/arm/nxp_imx/rt6xx/linker.ld
+++ b/soc/arm/nxp_imx/rt6xx/linker.ld
@@ -10,6 +10,5 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_lpc/lpc11u6x/linker.ld
+++ b/soc/arm/nxp_lpc/lpc11u6x/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_lpc/lpc54xxx/linker.ld
+++ b/soc/arm/nxp_lpc/lpc54xxx/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/nxp_lpc/lpc55xxx/linker.ld
+++ b/soc/arm/nxp_lpc/lpc55xxx/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images and XIP images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/rpi_pico/rp2/soc.h
+++ b/soc/arm/rpi_pico/rp2/soc.h
@@ -12,7 +12,6 @@
 #ifndef _RPI_PICO_RP2040_SOC_H_
 #define _RPI_PICO_RP2040_SOC_H_
 
-#include <autoconf.h>
 
 #define __VTOR_PRESENT CONFIG_CPU_CORTEX_M_HAS_VTOR
 #define __MPU_PRESENT CONFIG_CPU_HAS_ARM_MPU

--- a/soc/arm/silabs_exx32/efm32gg11b/linker.ld
+++ b/soc/arm/silabs_exx32/efm32gg11b/linker.ld
@@ -12,6 +12,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efm32hg/linker.ld
+++ b/soc/arm/silabs_exx32/efm32hg/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efm32jg12b/linker.ld
+++ b/soc/arm/silabs_exx32/efm32jg12b/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efm32pg12b/linker.ld
+++ b/soc/arm/silabs_exx32/efm32pg12b/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efm32pg1b/linker.ld
+++ b/soc/arm/silabs_exx32/efm32pg1b/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efm32wg/linker.ld
+++ b/soc/arm/silabs_exx32/efm32wg/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efr32bg13p/linker.ld
+++ b/soc/arm/silabs_exx32/efr32bg13p/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efr32fg13p/linker.ld
+++ b/soc/arm/silabs_exx32/efr32fg13p/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efr32fg1p/linker.ld
+++ b/soc/arm/silabs_exx32/efr32fg1p/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efr32mg12p/linker.ld
+++ b/soc/arm/silabs_exx32/efr32mg12p/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/silabs_exx32/efr32mg21/linker.ld
+++ b/soc/arm/silabs_exx32/efr32mg21/linker.ld
@@ -11,6 +11,5 @@
  * This is the linker script for both standard images.
  */
 
-#include <autoconf.h>
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/xilinx_zynqmp/linker.ld
+++ b/soc/arm/xilinx_zynqmp/linker.ld
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 
 #if defined(CONFIG_SOC_XILINX_ZYNQMP_RPU)
 #include <arch/arm/aarch32/cortex_a_r/scripts/linker.ld>

--- a/soc/arm64/bcm_vk/viper/linker.ld
+++ b/soc/arm64/bcm_vk/viper/linker.ld
@@ -4,6 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 
 #include <linker_a72.ld>

--- a/soc/arm64/nxp_imx/imx8m/linker.ld
+++ b/soc/arm64/nxp_imx/imx8m/linker.ld
@@ -4,6 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 
 #include <arch/arm64/scripts/linker.ld>

--- a/soc/arm64/nxp_layerscape/ls1046a/linker.ld
+++ b/soc/arm64/nxp_layerscape/ls1046a/linker.ld
@@ -4,6 +4,5 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 
 #include <arch/arm64/scripts/linker.ld>

--- a/soc/arm64/xenvm/linker.ld
+++ b/soc/arm64/xenvm/linker.ld
@@ -4,5 +4,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 #include <arch/arm64/scripts/linker.ld>

--- a/soc/riscv/esp32c3/linker.ld
+++ b/soc/riscv/esp32c3/linker.ld
@@ -11,7 +11,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>

--- a/soc/riscv/openisa_rv32m1/linker.ld
+++ b/soc/riscv/openisa_rv32m1/linker.ld
@@ -13,7 +13,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 
 #include <linker/sections.h>
 #include <linker/linker-defs.h>

--- a/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
+++ b/soc/riscv/riscv-privilege/andes_v5/ae350/linker.ld
@@ -15,7 +15,6 @@
 #include <soc.h>
 #include <devicetree.h>
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <linker/devicetree_regions.h>
 

--- a/soc/riscv/riscv-privilege/andes_v5/linker.ld
+++ b/soc/riscv/riscv-privilege/andes_v5/linker.ld
@@ -11,7 +11,6 @@
  * linker script for andes_v5 SoC Series
  */
 
-#include <autoconf.h>
 
 #if defined(CONFIG_SOC_RISCV_ANDES_AE350)
 # include <ae350/linker.ld>

--- a/soc/riscv/riscv-privilege/telink_b91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/linker.ld
@@ -8,7 +8,6 @@
  * @brief Linker script for the Telink B91 SoC
  */
 
-#include <autoconf.h>
 #include <devicetree.h>
 #include <linker/linker-tool.h>
 

--- a/soc/sparc/leon3/linker.ld
+++ b/soc/sparc/leon3/linker.ld
@@ -11,7 +11,6 @@
  * Linker script for LEON3
  */
 
-#include <autoconf.h>
 #include <devicetree.h>
 
 MEMORY

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -13,7 +13,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>

--- a/soc/xtensa/esp32s2/linker.ld
+++ b/soc/xtensa/esp32s2/linker.ld
@@ -11,7 +11,6 @@
  */
 
 #include <devicetree.h>
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>

--- a/soc/xtensa/intel_adsp/common/include/cavs-link.ld
+++ b/soc/xtensa/intel_adsp/common/include/cavs-link.ld
@@ -15,7 +15,6 @@ OUTPUT_ARCH(xtensa)
 
 #include <devicetree.h>
 #include <xtensa/config/core-isa.h>
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <cavs-vectors.h>
 #include <cavs-mem.h>

--- a/soc/xtensa/intel_s1000/linker.ld
+++ b/soc/xtensa/intel_s1000/linker.ld
@@ -15,7 +15,6 @@ OUTPUT_ARCH(xtensa)
 
 #include <devicetree.h>
 #include "memory.h"
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #include <linker/linker-defs.h>

--- a/soc/xtensa/intel_s1000/memory.h
+++ b/soc/xtensa/intel_s1000/memory.h
@@ -6,7 +6,6 @@
 #ifndef __INC_MEMORY_H
 #define __INC_MEMORY_H
 
-#include <autoconf.h>
 
 /* L2 HP SRAM */
 #define L2_VECTOR_SIZE				0x1000

--- a/soc/xtensa/nxp_adsp/imx8/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8/linker.ld
@@ -16,7 +16,6 @@ OUTPUT_ARCH(xtensa)
 #include <devicetree.h>
 #include <xtensa/config/core-isa.h>
 #include <soc/memory.h>
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #include <linker/linker-defs.h>

--- a/soc/xtensa/nxp_adsp/imx8m/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8m/linker.ld
@@ -16,7 +16,6 @@ OUTPUT_ARCH(xtensa)
 #include <devicetree.h>
 #include <xtensa/config/core-isa.h>
 #include <soc/memory.h>
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #include <linker/linker-defs.h>

--- a/soc/xtensa/sample_controller/linker.ld
+++ b/soc/xtensa/sample_controller/linker.ld
@@ -10,7 +10,6 @@
  * Linker script for the Xtensa platform.
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 
 #include <devicetree.h>

--- a/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
+++ b/subsys/net/lib/openthread/platform/openthread-core-zephyr-config.h
@@ -13,7 +13,6 @@
 #ifndef OPENTHREAD_CORE_ZEPHYR_CONFIG_H_
 #define OPENTHREAD_CORE_ZEPHYR_CONFIG_H_
 
-#include <autoconf.h>
 #include <devicetree.h>
 #include <toolchain.h>
 

--- a/subsys/pm/pm_stats.c
+++ b/subsys/pm/pm_stats.c
@@ -7,7 +7,6 @@
 
 #include "pm_stats.h"
 
-#include <autoconf.h>
 #include <init.h>
 #include <kernel_structs.h>
 #include <stats/stats.h>

--- a/tests/drivers/syscon/linker_arm64_reserved.ld
+++ b/tests/drivers/syscon/linker_arm64_reserved.ld
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 

--- a/tests/kernel/mem_heap/shared_multi_heap/linker_arm64_shared_pool.ld
+++ b/tests/kernel/mem_heap/shared_multi_heap/linker_arm64_shared_pool.ld
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <autoconf.h>
 #include <linker/sections.h>
 #include <devicetree.h>
 


### PR DESCRIPTION
The autoconf.h header is not required because the definitions present in
the file are exposed using the compiler `-imacros` flag.