### PR TITLE
hal: nxp: Centralize handling of SDK custom sections

### DIFF
--- a/soc/arm/nxp_imx/rt5xx/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt5xx/CMakeLists.txt
@@ -19,7 +19,4 @@ zephyr_library_include_directories(
 zephyr_linker_sources_ifdef(CONFIG_NXP_IMX_RT5XX_BOOT_HEADER
   ROM_START SORT_KEY 0 boot_header.ld)
 
-zephyr_linker_sources(
-  RWDATA quick_access.ld)
-
 zephyr_code_relocate(flash_clock_setup.c SRAM)

--- a/soc/arm/nxp_imx/rt5xx/quick_access.ld
+++ b/soc/arm/nxp_imx/rt5xx/quick_access.ld
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2022 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-. = ALIGN(4);
-KEEP(*(CodeQuickAccess))
-KEEP(*(DataQuickAccess))

--- a/soc/arm/nxp_imx/rt6xx/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt6xx/CMakeLists.txt
@@ -20,8 +20,5 @@ zephyr_library_include_directories(
 zephyr_linker_sources_ifdef(CONFIG_NXP_IMX_RT6XX_BOOT_HEADER
   ROM_START SORT_KEY 0 boot_header.ld)
 
-zephyr_linker_sources(
-  RWDATA quick_access.ld)
-
 zephyr_linker_sources_ifdef(CONFIG_USB_DEVICE_DRIVER
   SECTIONS usb.ld)

--- a/soc/arm/nxp_imx/rt6xx/quick_access.ld
+++ b/soc/arm/nxp_imx/rt6xx/quick_access.ld
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2020 NXP
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-. = ALIGN(4);
-KEEP(*(CodeQuickAccess))
-KEEP(*(DataQuickAccess))

--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: a3d46260cc3544777c5ca2105f9c2b84c182c04c
+      revision: ca1610119ca147b2cd1b875238881e4abb805297
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
The NXP SDK defines CodeQuickAccess and DataQuickAccess sections
for locating critical items that need faster access. Centralize
the handling of these sections instead of doing it per SOC.

Fixes #44453

Signed-off-by: David Leach <david.leach@nxp.com>