### PR TITLE
log: Fix possible undefined reference

### DIFF
--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -263,9 +263,34 @@ extern "C" {
 /*****************************************************************************/
 /****************** Definitions used by minimal logging *********************/
 /*****************************************************************************/
+#ifdef CONFIG_LOG_MODE_MINIMAL
+
 void z_log_minimal_hexdump_print(int level, const void *data, size_t size);
 void z_log_minimal_vprintk(const char *fmt, va_list ap);
 void z_log_minimal_printk(const char *fmt, ...);
+
+#else
+
+static inline void z_log_minimal_hexdump_print(int level, const void *data, size_t size)
+{
+	ARG_UNUSED(level);
+	ARG_UNUSED(data);
+	ARG_UNUSED(size);
+}
+
+static inline void z_log_minimal_vprintk(const char *fmt, va_list ap)
+{
+	ARG_UNUSED(fmt);
+	ARG_UNUSED(ap);
+}
+
+static inline void z_log_minimal_printk(const char *fmt, ...)
+{
+	ARG_UNUSED(fmt);
+}
+
+#endif /* CONFIG_LOG_MODE_MINIMAL */
+
 
 #define Z_LOG_TO_PRINTK(_level, fmt, ...) do { \
 	z_log_minimal_printk("%c: " fmt "\n", \


### PR DESCRIPTION
Depending on compilation options the linker may not garbage collect
references to some "log minimal" functions even if not used. Just
declaring them as static inline in this situation to avoid:

zephyr/kernel/mutex.c:85: undefined reference to `z_log_minimal_printk'
zephyr/kernel/libkernel.a(mutex.c.obj): In function
`z_impl_k_mutex_lock':
zephyr/kernel/mutex.c:150: undefined reference to `z_log_minimal_printk'

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>