### PR TITLE
tests: drivers: can: timing: test that calculated timings can be set

### DIFF
--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -27,11 +27,18 @@ static inline int z_vrfy_can_set_timing(const struct device *dev,
 					const struct can_timing *timing,
 					const struct can_timing *timing_data)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_timing));
+	struct can_timing timing_copy;
+	struct can_timing timing_data_copy;
 
-	return z_impl_can_set_timing((const struct device *)dev,
-				     (const struct can_timing *)timing,
-				     (const struct can_timing *)timing_data);
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_timing));
+	Z_OOPS(z_user_from_copy(&timing_copy, timing, sizeof(timing_copy)));
+
+	if (timing_data != NULL) {
+		Z_OOPS(z_user_from_copy(&timing_data_copy, timing_data, sizeof(timing_data_copy)));
+		return z_impl_can_set_timing(dev, &timing_copy, &timing_data_copy);
+	}
+
+	return z_impl_can_set_timing(dev, &timing_copy, NULL);
 }
 #include <syscalls/can_set_timing_mrsh.c>
 

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -160,7 +160,7 @@ void can_mcan_configure_timing(struct can_mcan_reg  *can,
 				timing_data->phase_seg1 > 0);
 		__ASSERT_NO_MSG(timing_data->phase_seg2 <= 0x10 &&
 				timing_data->phase_seg2 > 0);
-		__ASSERT_NO_MSG(timing_data->prescaler <= 20 &&
+		__ASSERT_NO_MSG(timing_data->prescaler <= 0x20 &&
 				timing_data->prescaler > 0);
 		__ASSERT_NO_MSG(timing_data->sjw == CAN_SJW_NO_CHANGE ||
 				(timing_data->sjw <= 0x80 && timing_data->sjw > 0));

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -133,7 +133,8 @@ void can_mcan_configure_timing(struct can_mcan_reg  *can,
 				timing->phase_seg2 > 0);
 		__ASSERT_NO_MSG(timing->prescaler <= 0x200 &&
 				timing->prescaler > 0);
-		__ASSERT_NO_MSG(timing->sjw <= 0x80 && timing->sjw > 0);
+		__ASSERT_NO_MSG(timing->sjw == CAN_SJW_NO_CHANGE ||
+				(timing->sjw <= 0x80 && timing->sjw > 0));
 
 		can->nbtp = (((uint32_t)timing->phase_seg1 - 1UL) & 0xFF) <<
 				CAN_MCAN_NBTP_NTSEG1_POS |
@@ -161,8 +162,8 @@ void can_mcan_configure_timing(struct can_mcan_reg  *can,
 				timing_data->phase_seg2 > 0);
 		__ASSERT_NO_MSG(timing_data->prescaler <= 20 &&
 				timing_data->prescaler > 0);
-		__ASSERT_NO_MSG(timing_data->sjw <= 0x80 &&
-				timing_data->sjw > 0);
+		__ASSERT_NO_MSG(timing_data->sjw == CAN_SJW_NO_CHANGE ||
+				(timing_data->sjw <= 0x80 && timing_data->sjw > 0));
 
 		can->dbtp = (((uint32_t)timing_data->phase_seg1 - 1UL) & 0x1F) <<
 				CAN_MCAN_DBTP_DTSEG1_POS |

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -849,7 +849,7 @@ static const struct can_driver_api can_api_funcs = {
 		.sjw = 0x1,
 		.prop_seg = 0x01,
 		.phase_seg1 = 0x01,
-		.phase_seg2 = 0x01,
+		.phase_seg2 = 0x02,
 		.prescaler = 0x01
 	},
 	.timing_max = {
@@ -857,7 +857,7 @@ static const struct can_driver_api can_api_funcs = {
 		.prop_seg = 0x08,
 		.phase_seg1 = 0x08,
 		.phase_seg2 = 0x08,
-		.prescaler = 0x20
+		.prescaler = 0x40
 	}
 };
 

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -241,6 +241,38 @@ void test_timing_data(void)
 }
 #endif /* CONFIG_CAN_FD_MODE */
 
+/**
+ * @brief Test that the minimum timing values can be set.
+ */
+void test_set_timing_min(void)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	int err;
+
+	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
+		err = can_set_timing(dev, can_get_timing_min(dev), can_get_timing_min_data(dev));
+	} else {
+		err = can_set_timing(dev, can_get_timing_min(dev), NULL);
+	}
+	zassert_equal(err, 0, "failed to set minimum timing parameters (err %d)", err);
+}
+
+/**
+ * @brief Test that the maximum timing values can be set.
+ */
+void test_set_timing_max(void)
+{
+	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	int err;
+
+	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
+		err = can_set_timing(dev, can_get_timing_max(dev), can_get_timing_max_data(dev));
+	} else {
+		err = can_set_timing(dev, can_get_timing_max(dev), NULL);
+	}
+	zassert_equal(err, 0, "failed to set maximum timing parameters (err %d)", err);
+}
+
 void test_main(void)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
@@ -251,6 +283,8 @@ void test_main(void)
 	k_object_access_grant(dev, k_current_get());
 
 	ztest_test_suite(can_timing_tests,
+			 ztest_user_unit_test(test_set_timing_min),
+			 ztest_user_unit_test(test_set_timing_max),
 			 ztest_user_unit_test(test_timing),
 			 ztest_user_unit_test(test_timing_data));
 	ztest_run_test_suite(can_timing_tests);

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -40,7 +40,7 @@ static const struct can_timing_test can_timing_tests[] = {
 	/** Standard bitrates. */
 	{  125000, 875, false },
 	{  500000, 875, false },
-	{ 1000000, 875, false },
+	{ 1000000, 750, false },
 	/** Additional, valid sample points. */
 	{  125000, 900, false },
 	{  125000, 800, false },
@@ -48,10 +48,10 @@ static const struct can_timing_test can_timing_tests[] = {
 	{  125000, 1000, true },
 #ifdef CONFIG_CAN_FD_MODE
 	/** Invalid CAN-FD bitrate, valid sample point. */
-	{ 8000000 + 1, 875, true },
+	{ 8000000 + 1, 750, true },
 #else /* CONFIG_CAN_FD_MODE */
 	/** Invalid classical bitrate, valid sample point. */
-	{ 1000000 + 1, 875, true },
+	{ 1000000 + 1, 750, true },
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
@@ -69,7 +69,7 @@ static const struct can_timing_test can_timing_data_tests[] = {
 	/** Valid bitrate, invalid sample point. */
 	{  500000, 1000, true },
 	/** Invalid CAN-FD bitrate, valid sample point. */
-	{ 8000000 + 1, 875, true },
+	{ 8000000 + 1, 750, true },
 };
 #endif /* CONFIG_CAN_FD_MODE */
 

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -193,6 +193,17 @@ static void test_timing_values(const struct device *dev, const struct can_timing
 		assert_timing_within_bounds(&timing, min, max);
 		assert_sp_within_margin(&timing, test->sp, SAMPLE_POINT_MARGIN);
 
+		if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
+			if (data_phase) {
+				err = can_set_timing(dev, can_get_timing_min(dev), &timing);
+			} else {
+				err = can_set_timing(dev, &timing, can_get_timing_min_data(dev));
+			}
+		} else {
+			err = can_set_timing(dev, &timing, NULL);
+		}
+		zassert_equal(err, 0, "failed to set timing (err %d)", err);
+
 		printk("OK, sample point error %d.%d%%\n", err / 10, err % 10);
 	}
 }


### PR DESCRIPTION
This patch set adds the following CAN timing test cases:
- tests: drivers: can: timing: test that calculated timings can be set
- tests: drivers: can: timing: test min/max timing can be set

The addition of these test cases revealed a few bugs, for which fixes are included:
- drivers: can: mcan: allow sjw == CAN_SJW_NO_CHANGE (Fixes: #44482)
- drivers: can: mcan: fix bounds check for data phase prescaler (Fixes: #44483)
- drivers: can: mcp2515: correct min/max timing values (Fixes: #44484)

Furthermore, the handler for `can_set_timing()` is changes to validate all parameters and copy them before calling the implementation.

The tested sample point locations for bitrates >= 800kbit/s have been modified to match those uses in the Linux kernel CAN layer as these seem to be much more likely to be met with 100% accuracy by a wide range of CAN controllers. I will follow up with a PR for changing the default sample point locations used by `can_set_bitrate()`.
