### PR TITLE
ci: manifest: Use 'zephyrbot' token to run manifest action

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -4,12 +4,6 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
-  workflow_run:
-    workflows: [Manifest]
-    types:
-      - completed
-
-
 jobs:
   do-not-merge:
     if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}

--- a/.github/workflows/manifest.yml
+++ b/.github/workflows/manifest.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Manifest
         uses: zephyrproject-rtos/action-manifest@2f1ad2908599d4fe747f886f9d733dd7eebae4ef
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          github-token: ${{ secrets.ZB_GITHUB_TOKEN }}
           manifest-path: 'west.yml'
           checkout-path: 'zephyrproject/zephyr'
           label-prefix: 'manifest-'


### PR DESCRIPTION
This commit updates the CI manifest workflow to run the manifest action
as the 'zephyrbot' user instead of the 'github-actions' user.

The 'github-actions' user does not have the permissions required to
trigger another workflow and fails to trigger the "Do Not Merge"
workflow when it (un)labels a pull request with the "DNM" label.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>