### PR TITLE
drivers: uart_stm32: Add support for tx/rx swap

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -473,6 +473,12 @@ static int uart_stm32_configure(const struct device *dev,
 		data->baud_rate = cfg->baudrate;
 	}
 
+#ifdef LL_USART_TXRX_SWAPPED
+	if (config->tx_rx_swap) {
+		LL_USART_SetTXRXSwap(config->usart, LL_USART_TXRX_SWAPPED);
+	}
+#endif
+
 	LL_USART_Enable(config->usart);
 	return 0;
 };
@@ -1715,6 +1721,7 @@ static const struct uart_stm32_config uart_stm32_cfg_##index = {	\
 	.parity = DT_INST_ENUM_IDX_OR(index, parity, UART_CFG_PARITY_NONE),	\
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(index),			\
 	.single_wire = DT_INST_PROP_OR(index, single_wire, false), \
+	.tx_rx_swap = DT_INST_PROP_OR(index, tx_rx_swap, false),	\
 	STM32_UART_IRQ_HANDLER_FUNC(index)				\
 };									\
 									\

--- a/drivers/serial/uart_stm32.h
+++ b/drivers/serial/uart_stm32.h
@@ -28,6 +28,8 @@ struct uart_stm32_config {
 	int  parity;
 	/* switch to enable single wire / half duplex feature */
 	bool single_wire;
+	/* enable tx/rx pin swap */
+	bool tx_rx_swap;
 	const struct pinctrl_dev_config *pcfg;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API) || \
 	defined(CONFIG_PM)

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -20,6 +20,12 @@ properties:
         only TX pin is used afterwards and should be configured.
         RX/TX conflicts must be handled on user side.
 
+    tx-rx-swap:
+      type: boolean
+      required: false
+      description: |
+        Swap the TX and RX pins. Used in case of a cross-wired connection.
+
     pinctrl-0:
       required: true
 


### PR DESCRIPTION
Add a new boolean devicetree property `tx-rx-swap` to the
st,stm32-usart binding, used to control TX/RX swap during
device initialization.

Signed-off-by: Alexander Mihajlovic <a@abxy.se>