### PR TITLE
soc/it8xxx2: enable FPU support

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
@@ -5,6 +5,7 @@ config SOC_SERIES_RISCV32_IT8XXX2
 	bool "ITE IT8XXX2 implementation"
 	#depends on RISCV
 	select COMPRESSED_ISA
+	select CPU_HAS_FPU
 	select SOC_FAMILY_RISCV_ITE
 	help
 	    Enable support for ITE IT8XXX2


### PR DESCRIPTION
IT8xxx2 supports the standard 'F' extension for single-precision
floating point: select the relevant Kconfig option for the SoC so
users can build floating-point code.

Signed-off-by: Peter Marheine <pmarheine@chromium.org>