### PR TITLE
west.yml: stm32f4: Use Legacy Ethernet HAL

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 13964e0af173f19fafad3692869e8486f3c2043d
+      revision: 5945d50882a5133e6cab918d1214c3be373b2c6a
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
A new HAL API was delivered in latest STM32F4 package.
Default to legacy eth API until Zephyr STM32 ethernet
driver is updated to support this new API.

Fixes #44486 

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>