### PR TITLE
tests: drivers: can: api: add build-only test for MCP2515

### DIFF
--- a/boards/shields/mcp2515/Kconfig.defconfig
+++ b/boards/shields/mcp2515/Kconfig.defconfig
@@ -5,6 +5,9 @@ if SHIELD_DFROBOT_CAN_BUS_V2_0 || SHIELD_KEYESTUDIO_CAN_BUS_KS0411
 
 if CAN
 
+config GPIO
+	default y
+
 config SPI
 	default y
 

--- a/samples/drivers/can/sample.yaml
+++ b/samples/drivers/can/sample.yaml
@@ -10,6 +10,3 @@ tests:
       type: one_line
       regex:
         - "Counter received: (.*)"
-  sample.drivers.can.dfrobot_can_bus_v2_0:
-    platform_allow: nrf52840dk_nrf52840
-    extra_args: SHIELD=dfrobot_can_bus_v2_0

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -128,18 +128,6 @@ test_spi_ms5607: ms5607@e {
 	spi-max-frequency = <0>;
 };
 
-test_spi_mcp2515: mcp2515@12 {
-	compatible = "microchip,mcp2515";
-	label = "MCP2515";
-	reg = <0x12>;
-	spi-max-frequency = <0>;
-	osc-freq = <0>;
-	int-gpios = <&test_gpio 0 0>;
-	bus-speed = <0>;
-	sjw = <0>;
-	sample-point = <875>;
-};
-
 test_spi_mcr20a: mcr20a@13 {
 	compatible = "nxp,mcr20a";
 	label = "MCR20A";

--- a/tests/drivers/can/api/testcase.yaml
+++ b/tests/drivers/can/api/testcase.yaml
@@ -3,3 +3,8 @@ tests:
     tags: drivers can
     depends_on: can
     filter: dt_chosen_enabled("zephyr,canbus")
+  drivers.can.api.mcp2515:
+    tags: drivers can
+    depends_on: arduino_spi arduino_gpio
+    extra_args: SHIELD=dfrobot_can_bus_v2_0
+    build_only: true


### PR DESCRIPTION
- Add a build-only API test for the Microchip MCP2515 SPI CAN controller driver since no in-tree boards have this chip.
- Remove the MCP2515 build-only configuration from the CAN driver sample application since the newly added API test provides better coverage.
- Remove the MCP2515 CAN controller from the build_all sensor drivers test.