### PR TITLE
Bluetooth: Controller: Fix -40 tx power kconfig for nrf53

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -305,7 +305,7 @@ config BT_CTLR_TX_PWR_MINUS_30
 
 config BT_CTLR_TX_PWR_MINUS_40
 	bool "-40 dBm"
-	depends on SOC_COMPATIBLE_NRF52X
+	depends on SOC_COMPATIBLE_NRF52X || SOC_SERIES_NRF53X
 
 endchoice
 


### PR DESCRIPTION
Fix -40 dbm kconfig tx power option not working for nrf53 boards.

Signed-off-by: Timothy Keys <timothy.keys@nordicsemi.no>