### PR TITLE
[RFC] drivers: pwm: API naming changes and pwm_dt_spec

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -48,6 +48,15 @@ Deprecated in this release
   * Deprecated the `gpio_dev`, `gpio_pin` and `gpio_dt_flags` members from
     spi_cs_control struct in favor of `gpio_dt_spec` gpio.
 
+* PWM
+
+  * The ``pin`` prefix has been removed from all PWM API calls. So for example,
+    ``pwm_pin_set_cycles`` is now ``pwm_set_cycles``. The old API calls are
+    still provided but marked as deprecated.
+  * The PWM period is now always set in nanoseconds, so the ``_nsec`` and
+    ``_usec`` set functions have been deprecated. Other units can be specified
+    using, e.g. ``PWM_USEC()`` macros, which convert down to nanoseconds.
+
 Stable API changes in this release
 ==================================
 
@@ -167,6 +176,11 @@ Drivers and Sensors
 * Pin control
 
 * PWM
+
+  * Added :c:struct:`pwm_dt_spec` and associated helpers, e.g.
+    :c:macro:`PWM_DT_SPEC_GET` or :c:func:`pwm_set_dt`. This addition makes it
+    easier to use the PWM API when the PWM channel, period and flags are taken
+    from a Devicetree PWM cell.
 
 * Sensor
 

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -49,7 +49,7 @@ static int led_pwm_blink(const struct device *dev, uint32_t led,
 
 	dt_led = &config->led[led];
 
-	return pwm_set_usec_dt(dt_led, period_usec, pulse_usec);
+	return pwm_set_dt(dt_led, PWM_USEC(period_usec), PWM_USEC(pulse_usec));
 }
 
 static int led_pwm_set_brightness(const struct device *dev,
@@ -64,8 +64,8 @@ static int led_pwm_set_brightness(const struct device *dev,
 
 	dt_led = &config->led[led];
 
-	return pwm_set_nsec_pulse_dt(&config->led[led],
-				     dt_led->period * value / 100);
+	return pwm_set_pulse_dt(&config->led[led],
+				dt_led->period * value / 100);
 }
 
 static int led_pwm_on(const struct device *dev, uint32_t led)

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -56,8 +56,8 @@ static int led_pwm_blink(const struct device *dev, uint32_t led,
 
 	led_pwm = &config->led[led];
 
-	return pwm_pin_set_usec(led_pwm->dev, led_pwm->channel,
-				period_usec, pulse_usec, led_pwm->flags);
+	return pwm_set_usec(led_pwm->dev, led_pwm->channel, period_usec,
+			    pulse_usec, led_pwm->flags);
 }
 
 static int led_pwm_set_brightness(const struct device *dev,
@@ -75,8 +75,8 @@ static int led_pwm_set_brightness(const struct device *dev,
 
 	pulse = led_pwm->period * value / 100;
 
-	return pwm_pin_set_nsec(led_pwm->dev, led_pwm->channel,
-				led_pwm->period, pulse, led_pwm->flags);
+	return pwm_set_nsec(led_pwm->dev, led_pwm->channel, led_pwm->period,
+			    pulse, led_pwm->flags);
 }
 
 static int led_pwm_on(const struct device *dev, uint32_t led)

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -21,23 +21,16 @@
 #include <logging/log.h>
 LOG_MODULE_REGISTER(led_pwm, CONFIG_LED_LOG_LEVEL);
 
-struct led_pwm {
-	const struct device *dev;
-	uint32_t channel;
-	uint32_t period;
-	pwm_flags_t flags;
-};
-
 struct led_pwm_config {
 	int num_leds;
-	const struct led_pwm *led;
+	const struct pwm_dt_spec *led;
 };
 
 static int led_pwm_blink(const struct device *dev, uint32_t led,
 			 uint32_t delay_on, uint32_t delay_off)
 {
 	const struct led_pwm_config *config = dev->config;
-	const struct led_pwm *led_pwm;
+	const struct pwm_dt_spec *dt_led;
 	uint32_t period_usec, pulse_usec;
 
 	if (led >= config->num_leds) {
@@ -54,29 +47,25 @@ static int led_pwm_blink(const struct device *dev, uint32_t led,
 		return -EINVAL;
 	}
 
-	led_pwm = &config->led[led];
+	dt_led = &config->led[led];
 
-	return pwm_set_usec(led_pwm->dev, led_pwm->channel, period_usec,
-			    pulse_usec, led_pwm->flags);
+	return pwm_set_usec_dt(dt_led, period_usec, pulse_usec);
 }
 
 static int led_pwm_set_brightness(const struct device *dev,
 				  uint32_t led, uint8_t value)
 {
 	const struct led_pwm_config *config = dev->config;
-	const struct led_pwm *led_pwm;
-	uint32_t pulse;
+	const struct pwm_dt_spec *dt_led;
 
 	if (led >= config->num_leds || value > 100) {
 		return -EINVAL;
 	}
 
-	led_pwm = &config->led[led];
+	dt_led = &config->led[led];
 
-	pulse = led_pwm->period * value / 100;
-
-	return pwm_set_nsec(led_pwm->dev, led_pwm->channel, led_pwm->period,
-			    pulse, led_pwm->flags);
+	return pwm_set_nsec_pulse_dt(&config->led[led],
+				     dt_led->period * value / 100);
 }
 
 static int led_pwm_on(const struct device *dev, uint32_t led)
@@ -101,10 +90,10 @@ static int led_pwm_init(const struct device *dev)
 	}
 
 	for (i = 0; i < config->num_leds; i++) {
-		const struct led_pwm *led = &config->led[i];
+		const struct pwm_dt_spec *led = &config->led[i];
 
 		if (!device_is_ready(led->dev)) {
-			LOG_ERR("%s: pwm device not ready", dev->name);
+			LOG_ERR("%s: pwm device not ready", led->dev->name);
 			return -ENODEV;
 		}
 	}
@@ -121,14 +110,13 @@ static int led_pwm_pm_action(const struct device *dev,
 	/* switch all underlying PWM devices to the new state */
 	for (size_t i = 0; i < config->num_leds; i++) {
 		int err;
-		const struct led_pwm *led_pwm = &config->led[i];
+		const struct pwm_dt_spec *led = &config->led[i];
 
-		LOG_DBG("PWM %p running pm action %" PRIu32, led_pwm->dev,
-				action);
+		LOG_DBG("PWM %p running pm action %" PRIu32, led->dev, action);
 
-		err = pm_device_action_run(led_pwm->dev, action);
+		err = pm_device_action_run(led->dev, action);
 		if (err && (err != -EALREADY)) {
-			LOG_ERR("Cannot switch PWM %p power state", led_pwm->dev);
+			LOG_ERR("Cannot switch PWM %p power state", led->dev);
 		}
 	}
 
@@ -143,19 +131,12 @@ static const struct led_driver_api led_pwm_api = {
 	.set_brightness	= led_pwm_set_brightness,
 };
 
-#define LED_PWM(led_node_id)						\
-{									\
-	.dev		= DEVICE_DT_GET(DT_PWMS_CTLR(led_node_id)),	\
-	.channel	= DT_PWMS_CHANNEL(led_node_id),			\
-	.period		= DT_PHA_OR(led_node_id, pwms, period, 100000),	\
-	.flags		= DT_PHA_OR(led_node_id, pwms, flags,		\
-				    PWM_POLARITY_NORMAL),		\
-},
+#define PWM_DT_SPEC_GET_AND_COMMA(node_id) PWM_DT_SPEC_GET(node_id)),
 
 #define LED_PWM_DEVICE(id)					\
 								\
-static const struct led_pwm led_pwm_##id[] = {			\
-	DT_INST_FOREACH_CHILD(id, LED_PWM)			\
+static const struct pwm_dt_spec led_pwm_##id[] = {		\
+	DT_INST_FOREACH_CHILD(id, PWM_DT_SPEC_GET_AND_COMMA)	\
 };								\
 								\
 static const struct led_pwm_config led_pwm_config_##id = {	\

--- a/drivers/pwm/pwm_b91.c
+++ b/drivers/pwm/pwm_b91.c
@@ -55,10 +55,10 @@ static int pwm_b91_init(const struct device *dev)
 	return 0;
 }
 
-/* API implementation: pin_set */
-static int pwm_b91_pin_set(const struct device *dev, uint32_t channel,
-			   uint32_t period_cycles, uint32_t pulse_cycles,
-			   pwm_flags_t flags)
+/* API implementation: set_cycles */
+static int pwm_b91_set_cycles(const struct device *dev, uint32_t channel,
+			      uint32_t period_cycles, uint32_t pulse_cycles,
+			      pwm_flags_t flags)
 {
 	ARG_UNUSED(dev);
 
@@ -119,7 +119,7 @@ static int pwm_b91_get_cycles_per_sec(const struct device *dev,
 
 /* PWM driver APIs structure */
 static const struct pwm_driver_api pwm_b91_driver_api = {
-	.pin_set = pwm_b91_pin_set,
+	.set_cycles = pwm_b91_set_cycles,
 	.get_cycles_per_sec = pwm_b91_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_b91.c
+++ b/drivers/pwm/pwm_b91.c
@@ -56,14 +56,14 @@ static int pwm_b91_init(const struct device *dev)
 }
 
 /* API implementation: pin_set */
-static int pwm_b91_pin_set(const struct device *dev, uint32_t pwm,
+static int pwm_b91_pin_set(const struct device *dev, uint32_t channel,
 			   uint32_t period_cycles, uint32_t pulse_cycles,
 			   pwm_flags_t flags)
 {
 	ARG_UNUSED(dev);
 
 	/* check pwm channel */
-	if (pwm >= NUM_OF_CHANNELS) {
+	if (channel >= NUM_OF_CHANNELS) {
 		return -EINVAL;
 	}
 
@@ -75,39 +75,39 @@ static int pwm_b91_pin_set(const struct device *dev, uint32_t pwm,
 
 	/* set polarity */
 	if (flags & PWM_POLARITY_INVERTED) {
-		pwm_invert_en(pwm);
+		pwm_invert_en(channel);
 	} else {
-		pwm_invert_dis(pwm);
+		pwm_invert_dis(channel);
 	}
 
 	/* set pulse and period */
-	pwm_set_tcmp(pwm, pulse_cycles);
-	pwm_set_tmax(pwm, period_cycles);
+	pwm_set_tcmp(channel, pulse_cycles);
+	pwm_set_tmax(channel, period_cycles);
 
 	/* start pwm */
-	pwm_start(pwm);
+	pwm_start(channel);
 
 	return 0;
 }
 
 /* API implementation: get_cycles_per_sec */
-static int pwm_b91_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				      uint64_t *cycles)
+static int pwm_b91_get_cycles_per_sec(const struct device *dev,
+				      uint32_t channel, uint64_t *cycles)
 {
 	ARG_UNUSED(dev);
 
 	/* check pwm channel */
-	if (pwm >= NUM_OF_CHANNELS) {
+	if (channel >= NUM_OF_CHANNELS) {
 		return -EINVAL;
 	}
 
 	if (
-		((pwm == 0u) && DT_INST_PROP(0, clk32k_ch0_enable)) ||
-		((pwm == 1u) && DT_INST_PROP(0, clk32k_ch1_enable)) ||
-		((pwm == 2u) && DT_INST_PROP(0, clk32k_ch2_enable)) ||
-		((pwm == 3u) && DT_INST_PROP(0, clk32k_ch3_enable)) ||
-		((pwm == 4u) && DT_INST_PROP(0, clk32k_ch4_enable)) ||
-		((pwm == 5u) && DT_INST_PROP(0, clk32k_ch5_enable))
+		((channel == 0u) && DT_INST_PROP(0, clk32k_ch0_enable)) ||
+		((channel == 1u) && DT_INST_PROP(0, clk32k_ch1_enable)) ||
+		((channel == 2u) && DT_INST_PROP(0, clk32k_ch2_enable)) ||
+		((channel == 3u) && DT_INST_PROP(0, clk32k_ch3_enable)) ||
+		((channel == 4u) && DT_INST_PROP(0, clk32k_ch4_enable)) ||
+		((channel == 5u) && DT_INST_PROP(0, clk32k_ch5_enable))
 		) {
 		*cycles = 32000u;
 	} else {

--- a/drivers/pwm/pwm_capture.c
+++ b/drivers/pwm/pwm_capture.c
@@ -19,7 +19,7 @@ struct z_pwm_pin_capture_cb_data {
 };
 
 static void z_pwm_pin_capture_cycles_callback(const struct device *dev,
-					      uint32_t pwm,
+					      uint32_t channel,
 					      uint32_t period_cycles,
 					      uint32_t pulse_cycles,
 					      int status,
@@ -34,7 +34,7 @@ static void z_pwm_pin_capture_cycles_callback(const struct device *dev,
 	k_sem_give(&data->sem);
 }
 
-int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
+int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t channel,
 				  pwm_flags_t flags, uint32_t *period,
 				  uint32_t *pulse, k_timeout_t timeout)
 {
@@ -49,7 +49,7 @@ int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
 	flags |= PWM_CAPTURE_MODE_SINGLE;
 	k_sem_init(&data.sem, 0, 1);
 
-	err = pwm_pin_configure_capture(dev, pwm, flags,
+	err = pwm_pin_configure_capture(dev, channel, flags,
 					z_pwm_pin_capture_cycles_callback,
 					&data);
 	if (err) {
@@ -57,7 +57,7 @@ int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
 		return err;
 	}
 
-	err = pwm_pin_enable_capture(dev, pwm);
+	err = pwm_pin_enable_capture(dev, channel);
 	if (err) {
 		LOG_ERR("failed to enable pwm capture");
 		return err;
@@ -65,8 +65,8 @@ int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t pwm,
 
 	err = k_sem_take(&data.sem, timeout);
 	if (err == -EAGAIN) {
-		(void)pwm_pin_disable_capture(dev, pwm);
-		(void)pwm_pin_configure_capture(dev, pwm, flags, NULL, NULL);
+		(void)pwm_pin_disable_capture(dev, channel);
+		(void)pwm_pin_configure_capture(dev, channel, flags, NULL, NULL);
 		LOG_WRN("pwm capture timed out");
 		return err;
 	}

--- a/drivers/pwm/pwm_capture.c
+++ b/drivers/pwm/pwm_capture.c
@@ -11,21 +11,20 @@
 
 LOG_MODULE_REGISTER(pwm_capture, CONFIG_PWM_LOG_LEVEL);
 
-struct z_pwm_pin_capture_cb_data {
+struct z_pwm_capture_cb_data {
 	uint32_t period;
 	uint32_t pulse;
 	struct k_sem sem;
 	int status;
 };
 
-static void z_pwm_pin_capture_cycles_callback(const struct device *dev,
-					      uint32_t channel,
-					      uint32_t period_cycles,
-					      uint32_t pulse_cycles,
-					      int status,
-					      void *user_data)
+static void z_pwm_capture_cycles_callback(const struct device *dev,
+					  uint32_t channel,
+					  uint32_t period_cycles,
+					  uint32_t pulse_cycles, int status,
+					  void *user_data)
 {
-	struct z_pwm_pin_capture_cb_data *data = user_data;
+	struct z_pwm_capture_cb_data *data = user_data;
 
 	data->period = period_cycles;
 	data->pulse = pulse_cycles;
@@ -34,11 +33,11 @@ static void z_pwm_pin_capture_cycles_callback(const struct device *dev,
 	k_sem_give(&data->sem);
 }
 
-int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t channel,
-				  pwm_flags_t flags, uint32_t *period,
-				  uint32_t *pulse, k_timeout_t timeout)
+int z_impl_pwm_capture_cycles(const struct device *dev, uint32_t channel,
+			      pwm_flags_t flags, uint32_t *period,
+			      uint32_t *pulse, k_timeout_t timeout)
 {
-	struct z_pwm_pin_capture_cb_data data;
+	struct z_pwm_capture_cb_data data;
 	int err;
 
 	if ((flags & PWM_CAPTURE_MODE_MASK) == PWM_CAPTURE_MODE_CONTINUOUS) {
@@ -49,15 +48,14 @@ int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t channel,
 	flags |= PWM_CAPTURE_MODE_SINGLE;
 	k_sem_init(&data.sem, 0, 1);
 
-	err = pwm_pin_configure_capture(dev, channel, flags,
-					z_pwm_pin_capture_cycles_callback,
-					&data);
+	err = pwm_configure_capture(dev, channel, flags,
+				    z_pwm_capture_cycles_callback, &data);
 	if (err) {
 		LOG_ERR("failed to configure pwm capture");
 		return err;
 	}
 
-	err = pwm_pin_enable_capture(dev, channel);
+	err = pwm_enable_capture(dev, channel);
 	if (err) {
 		LOG_ERR("failed to enable pwm capture");
 		return err;
@@ -65,8 +63,8 @@ int z_impl_pwm_pin_capture_cycles(const struct device *dev, uint32_t channel,
 
 	err = k_sem_take(&data.sem, timeout);
 	if (err == -EAGAIN) {
-		(void)pwm_pin_disable_capture(dev, channel);
-		(void)pwm_pin_configure_capture(dev, channel, flags, NULL, NULL);
+		(void)pwm_disable_capture(dev, channel);
+		(void)pwm_configure_capture(dev, channel, flags, NULL, NULL);
 		LOG_WRN("pwm capture timed out");
 		return err;
 	}

--- a/drivers/pwm/pwm_gd32.c
+++ b/drivers/pwm/pwm_gd32.c
@@ -132,9 +132,9 @@ static uint32_t pwm_gd32_get_tim_clk(const struct device *dev)
 #endif /* RCU_CFG1_TIMERSEL */
 }
 
-static int pwm_gd32_pin_set(const struct device *dev, uint32_t channel,
-			    uint32_t period_cycles, uint32_t pulse_cycles,
-			    pwm_flags_t flags)
+static int pwm_gd32_set_cycles(const struct device *dev, uint32_t channel,
+			      uint32_t period_cycles, uint32_t pulse_cycles,
+			      pwm_flags_t flags)
 {
 	const struct pwm_gd32_config *config = dev->config;
 
@@ -219,7 +219,7 @@ static int pwm_gd32_get_cycles_per_sec(const struct device *dev,
 }
 
 static const struct pwm_driver_api pwm_gd32_driver_api = {
-	.pin_set = pwm_gd32_pin_set,
+	.set_cycles = pwm_gd32_set_cycles,
 	.get_cycles_per_sec = pwm_gd32_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_gecko.c
+++ b/drivers/pwm/pwm_gecko.c
@@ -37,7 +37,7 @@ static int pwm_gecko_pin_set(const struct device *dev, uint32_t pwm,
 		BUS_RegMaskedWrite(&cfg->timer->ROUTE,
 			_TIMER_ROUTE_LOCATION_MASK,
 			cfg->location << _TIMER_ROUTE_LOCATION_SHIFT);
-		BUS_RegMaskedSet(&pwm->timer->ROUTE, 1 << pwm);
+		BUS_RegMaskedSet(&cfg->timer->ROUTE, 1 << pwm);
 #elif defined(_TIMER_ROUTELOC0_MASK)
 		BUS_RegMaskedWrite(&cfg->timer->ROUTELOC0,
 			_TIMER_ROUTELOC0_CC0LOC_MASK << (pwm * _TIMER_ROUTELOC0_CC1LOC_SHIFT),

--- a/drivers/pwm/pwm_gecko.c
+++ b/drivers/pwm/pwm_gecko.c
@@ -23,9 +23,9 @@ struct pwm_gecko_config {
 	uint8_t pin;
 };
 
-static int pwm_gecko_pin_set(const struct device *dev, uint32_t channel,
-			     uint32_t period_cycles, uint32_t pulse_cycles,
-			     pwm_flags_t flags)
+static int pwm_gecko_set_cycles(const struct device *dev, uint32_t channel,
+				uint32_t period_cycles, uint32_t pulse_cycles,
+				pwm_flags_t flags)
 {
 	TIMER_InitCC_TypeDef compare_config = TIMER_INITCC_DEFAULT;
 	const struct pwm_gecko_config *cfg = dev->config;
@@ -73,7 +73,7 @@ static int pwm_gecko_get_cycles_per_sec(const struct device *dev,
 }
 
 static const struct pwm_driver_api pwm_gecko_driver_api = {
-	.pin_set = pwm_gecko_pin_set,
+	.set_cycles = pwm_gecko_set_cycles,
 	.get_cycles_per_sec = pwm_gecko_get_cycles_per_sec
 };
 

--- a/drivers/pwm/pwm_handlers.c
+++ b/drivers/pwm/pwm_handlers.c
@@ -8,15 +8,15 @@
 #include <syscall_handler.h>
 #include <drivers/pwm.h>
 
-static inline int z_vrfy_pwm_pin_set_cycles(const struct device *dev,
-					    uint32_t channel, uint32_t period,
-					    uint32_t pulse, pwm_flags_t flags)
+static inline int z_vrfy_pwm_set_cycles(const struct device *dev,
+					uint32_t channel, uint32_t period,
+					uint32_t pulse, pwm_flags_t flags)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_set));
-	return z_impl_pwm_pin_set_cycles((const struct device *)dev, channel,
+	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, set_cycles));
+	return z_impl_pwm_set_cycles((const struct device *)dev, channel,
 					 period, pulse, flags);
 }
-#include <syscalls/pwm_pin_set_cycles_mrsh.c>
+#include <syscalls/pwm_set_cycles_mrsh.c>
 
 static inline int z_vrfy_pwm_get_cycles_per_sec(const struct device *dev,
 						uint32_t channel,
@@ -31,41 +31,38 @@ static inline int z_vrfy_pwm_get_cycles_per_sec(const struct device *dev,
 
 #ifdef CONFIG_PWM_CAPTURE
 
-static inline int z_vrfy_pwm_pin_enable_capture(const struct device *dev,
-						uint32_t channel)
+static inline int z_vrfy_pwm_enable_capture(const struct device *dev,
+					    uint32_t channel)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_enable_capture));
-	return z_impl_pwm_pin_enable_capture((const struct device *)dev,
-					     channel);
+	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, enable_capture));
+	return z_impl_pwm_enable_capture((const struct device *)dev, channel);
 }
-#include <syscalls/pwm_pin_enable_capture_mrsh.c>
+#include <syscalls/pwm_enable_capture_mrsh.c>
 
-static inline int z_vrfy_pwm_pin_disable_capture(const struct device *dev,
-						 uint32_t channel)
+static inline int z_vrfy_pwm_disable_capture(const struct device *dev,
+					     uint32_t channel)
 {
-	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_disable_capture));
-	return z_impl_pwm_pin_disable_capture((const struct device *)dev,
-					      channel);
+	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, disable_capture));
+	return z_impl_pwm_disable_capture((const struct device *)dev, channel);
 }
-#include <syscalls/pwm_pin_disable_capture_mrsh.c>
+#include <syscalls/pwm_disable_capture_mrsh.c>
 
-static inline int z_vrfy_pwm_pin_capture_cycles(const struct device *dev,
-						uint32_t channel,
-						pwm_flags_t flags,
-						uint32_t *period_cycles,
-						uint32_t *pulse_cycles,
-						k_timeout_t timeout)
+static inline int z_vrfy_pwm_capture_cycles(const struct device *dev,
+					    uint32_t channel, pwm_flags_t flags,
+					    uint32_t *period_cycles,
+					    uint32_t *pulse_cycles,
+					    k_timeout_t timeout)
 {
 	uint32_t period;
 	uint32_t pulse;
 	int err;
 
-	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_configure_capture));
-	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_enable_capture));
-	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_disable_capture));
+	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, configure_capture));
+	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, enable_capture));
+	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, disable_capture));
 
-	err = z_impl_pwm_pin_capture_cycles((const struct device *)dev, channel,
-					    flags, &period, &pulse, timeout);
+	err = z_impl_pwm_capture_cycles((const struct device *)dev, channel,
+					flags, &period, &pulse, timeout);
 	if (period_cycles != NULL) {
 		Z_OOPS(z_user_to_copy(period_cycles, &period,
 				      sizeof(*period_cycles)));
@@ -78,6 +75,6 @@ static inline int z_vrfy_pwm_pin_capture_cycles(const struct device *dev,
 
 	return err;
 }
-#include <syscalls/pwm_pin_capture_cycles_mrsh.c>
+#include <syscalls/pwm_capture_cycles_mrsh.c>
 
 #endif /* CONFIG_PWM_CAPTURE */

--- a/drivers/pwm/pwm_handlers.c
+++ b/drivers/pwm/pwm_handlers.c
@@ -9,48 +9,49 @@
 #include <drivers/pwm.h>
 
 static inline int z_vrfy_pwm_pin_set_cycles(const struct device *dev,
-					    uint32_t pwm,
-					    uint32_t period, uint32_t pulse,
-					    pwm_flags_t flags)
+					    uint32_t channel, uint32_t period,
+					    uint32_t pulse, pwm_flags_t flags)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_set));
-	return z_impl_pwm_pin_set_cycles((const struct device *)dev, pwm,
-					 period,
-					 pulse, flags);
+	return z_impl_pwm_pin_set_cycles((const struct device *)dev, channel,
+					 period, pulse, flags);
 }
 #include <syscalls/pwm_pin_set_cycles_mrsh.c>
 
 static inline int z_vrfy_pwm_get_cycles_per_sec(const struct device *dev,
-						uint32_t pwm,
+						uint32_t channel,
 						uint64_t *cycles)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, get_cycles_per_sec));
 	Z_OOPS(Z_SYSCALL_MEMORY_WRITE(cycles, sizeof(uint64_t)));
 	return z_impl_pwm_get_cycles_per_sec((const struct device *)dev,
-					     pwm, (uint64_t *)cycles);
+					     channel, (uint64_t *)cycles);
 }
 #include <syscalls/pwm_get_cycles_per_sec_mrsh.c>
 
 #ifdef CONFIG_PWM_CAPTURE
 
 static inline int z_vrfy_pwm_pin_enable_capture(const struct device *dev,
-						uint32_t pwm)
+						uint32_t channel)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_enable_capture));
-	return z_impl_pwm_pin_enable_capture((const struct device *)dev, pwm);
+	return z_impl_pwm_pin_enable_capture((const struct device *)dev,
+					     channel);
 }
 #include <syscalls/pwm_pin_enable_capture_mrsh.c>
 
 static inline int z_vrfy_pwm_pin_disable_capture(const struct device *dev,
-						 uint32_t pwm)
+						 uint32_t channel)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_disable_capture));
-	return z_impl_pwm_pin_disable_capture((const struct device *)dev, pwm);
+	return z_impl_pwm_pin_disable_capture((const struct device *)dev,
+					      channel);
 }
 #include <syscalls/pwm_pin_disable_capture_mrsh.c>
 
 static inline int z_vrfy_pwm_pin_capture_cycles(const struct device *dev,
-						uint32_t pwm, pwm_flags_t flags,
+						uint32_t channel,
+						pwm_flags_t flags,
 						uint32_t *period_cycles,
 						uint32_t *pulse_cycles,
 						k_timeout_t timeout)
@@ -63,7 +64,7 @@ static inline int z_vrfy_pwm_pin_capture_cycles(const struct device *dev,
 	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_enable_capture));
 	Z_OOPS(Z_SYSCALL_DRIVER_PWM(dev, pin_disable_capture));
 
-	err = z_impl_pwm_pin_capture_cycles((const struct device *)dev, pwm,
+	err = z_impl_pwm_pin_capture_cycles((const struct device *)dev, channel,
 					    flags, &period, &pulse, timeout);
 	if (period_cycles != NULL) {
 		Z_OOPS(z_user_to_copy(period_cycles, &period,

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -37,7 +37,7 @@ static bool imx_pwm_is_enabled(PWM_Type *base)
 }
 
 static int imx_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				       uint64_t *cycles)
+				      uint64_t *cycles)
 {
 	PWM_Type *base = DEV_BASE(dev);
 	const struct imx_pwm_config *config = dev->config;
@@ -47,9 +47,9 @@ static int imx_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-static int imx_pwm_pin_set(const struct device *dev, uint32_t channel,
-			   uint32_t period_cycles, uint32_t pulse_cycles,
-			   pwm_flags_t flags)
+static int imx_pwm_set_cycles(const struct device *dev, uint32_t channel,
+			      uint32_t period_cycles, uint32_t pulse_cycles,
+			      pwm_flags_t flags)
 {
 	PWM_Type *base = DEV_BASE(dev);
 	const struct imx_pwm_config *config = dev->config;
@@ -149,7 +149,7 @@ static int imx_pwm_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api imx_pwm_driver_api = {
-	.pin_set = imx_pwm_pin_set,
+	.set_cycles = imx_pwm_set_cycles,
 	.get_cycles_per_sec = imx_pwm_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -47,7 +47,7 @@ static int imx_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-static int imx_pwm_pin_set(const struct device *dev, uint32_t pwm,
+static int imx_pwm_pin_set(const struct device *dev, uint32_t channel,
 			   uint32_t period_cycles, uint32_t pulse_cycles,
 			   pwm_flags_t flags)
 {

--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -68,9 +68,9 @@ static void pwm_enable(const struct device *dev, int enabled)
 }
 
 static int pwm_it8xxx2_get_cycles_per_sec(const struct device *dev,
-					     uint32_t pwm, uint64_t *cycles)
+					  uint32_t channel, uint64_t *cycles)
 {
-	ARG_UNUSED(pwm);
+	ARG_UNUSED(channel);
 
 	/*
 	 * There are three ways to call pwm_it8xxx2_pin_set() from pwm api:
@@ -95,9 +95,9 @@ static int pwm_it8xxx2_get_cycles_per_sec(const struct device *dev,
 	return 0;
 }
 
-static int pwm_it8xxx2_pin_set(const struct device *dev,
-				uint32_t pwm, uint32_t period_cycles,
-				uint32_t pulse_cycles, pwm_flags_t flags)
+static int pwm_it8xxx2_pin_set(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	const struct pwm_it8xxx2_cfg *config = dev->config;
 	struct pwm_it8xxx2_regs *const inst = config->base;
@@ -125,7 +125,7 @@ static int pwm_it8xxx2_pin_set(const struct device *dev,
 		return 0;
 	}
 
-	pwm_it8xxx2_get_cycles_per_sec(dev, pwm, &pwm_clk_src);
+	pwm_it8xxx2_get_cycles_per_sec(dev, channel, &pwm_clk_src);
 	target_freq = ((uint32_t) pwm_clk_src) / period_cycles;
 
 	/*

--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -73,16 +73,16 @@ static int pwm_it8xxx2_get_cycles_per_sec(const struct device *dev,
 	ARG_UNUSED(channel);
 
 	/*
-	 * There are three ways to call pwm_it8xxx2_pin_set() from pwm api:
-	 * 1) pwm_pin_set_usec() -> pwm_pin_set_cycles() -> pwm_it8xxx2_pin_set()
+	 * There are three ways to call pwm_it8xxx2_set_cycles() from pwm api:
+	 * 1) pwm_set_cycles_usec() -> pwm_set_cycles_cycles() -> pwm_it8xxx2_set_cycles()
 	 *    target_freq = pwm_clk_src / period_cycles
 	 *                = cycles / (period * cycles / USEC_PER_SEC)
 	 *                = USEC_PER_SEC / period
-	 * 2) pwm_pin_set_nsec() -> pwm_pin_set_cycles() -> pwm_it8xxx2_pin_set()
+	 * 2) pwm_set_cycles_nsec() -> pwm_set_cycles_cycles() -> pwm_it8xxx2_set_cycles()
 	 *    target_freq = pwm_clk_src / period_cycles
 	 *                = cycles / (period * cycles / NSEC_PER_SEC)
 	 *                = NSEC_PER_SEC / period
-	 * 3) pwm_pin_set_cycles() -> pwm_it8xxx2_pin_set()
+	 * 3) pwm_set_cycles_cycles() -> pwm_it8xxx2_set_cycles()
 	 *    target_freq = pwm_clk_src / period_cycles
 	 *                = cycles / period
 	 *
@@ -95,9 +95,9 @@ static int pwm_it8xxx2_get_cycles_per_sec(const struct device *dev,
 	return 0;
 }
 
-static int pwm_it8xxx2_pin_set(const struct device *dev, uint32_t channel,
-			       uint32_t period_cycles, uint32_t pulse_cycles,
-			       pwm_flags_t flags)
+static int pwm_it8xxx2_set_cycles(const struct device *dev,
+				  uint32_t channel, uint32_t period_cycles,
+				  uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_it8xxx2_cfg *config = dev->config;
 	struct pwm_it8xxx2_regs *const inst = config->base;
@@ -251,7 +251,7 @@ static int pwm_it8xxx2_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api pwm_it8xxx2_api = {
-	.pin_set = pwm_it8xxx2_pin_set,
+	.set_cycles = pwm_it8xxx2_set_cycles,
 	.get_cycles_per_sec = pwm_it8xxx2_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -58,12 +58,13 @@ static void pwm_enable(const struct device *dev, int enabled)
 	volatile uint8_t *reg_pcsgr = (uint8_t *)config->reg_pcsgr;
 	int ch = config->channel;
 
-	if (enabled)
+	if (enabled) {
 		/* PWM channel clock source not gating */
 		*reg_pcsgr &= ~BIT(ch);
-	else
+	} else {
 		/* PWM channel clock source gating */
 		*reg_pcsgr |= BIT(ch);
+	}
 }
 
 static int pwm_it8xxx2_get_cycles_per_sec(const struct device *dev,
@@ -113,10 +114,11 @@ static int pwm_it8xxx2_pin_set(const struct device *dev,
 	pwm_enable(dev, 0);
 
 	/* Select PWM inverted polarity (ex. active-low pulse) */
-	if (flags & PWM_POLARITY_INVERTED)
+	if (flags & PWM_POLARITY_INVERTED) {
 		*reg_pwmpol |= BIT(ch);
-	else
+	} else {
 		*reg_pwmpol &= ~BIT(ch);
+	}
 
 	/* If pulse cycles is 0, set duty cycle 0 and enable pwm channel */
 	if (pulse_cycles == 0) {

--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -108,8 +108,6 @@ static int pwm_it8xxx2_pin_set(const struct device *dev,
 	uint32_t actual_freq = 0xffffffff, target_freq, deviation, cxcprs, ctr;
 	uint64_t pwm_clk_src;
 
-	ARG_UNUSED(pwm);
-
 	/* PWM channel clock source gating before configuring */
 	pwm_enable(dev, 0);
 

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -295,8 +295,10 @@ static int pwm_led_esp32_timer_set(int speed_mode, int timer,
 
 /* period_cycles is not used, set frequency on menuconfig instead. */
 static int pwm_led_esp32_pin_set_cycles(const struct device *dev,
-					uint32_t pwm, uint32_t period_cycles,
-					uint32_t pulse_cycles, pwm_flags_t flags)
+					uint32_t channel,
+					uint32_t period_cycles,
+					uint32_t pulse_cycles,
+					pwm_flags_t flags)
 {
 	int speed_mode;
 	int channel;
@@ -312,7 +314,7 @@ static int pwm_led_esp32_pin_set_cycles(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	channel = pwm_led_esp32_get_gpio_config(pwm, config->ch_cfg);
+	channel = pwm_led_esp32_get_gpio_config(channel, config->ch_cfg);
 	if (channel < 0) {
 		return -EINVAL;
 	}
@@ -338,7 +340,7 @@ static int pwm_led_esp32_pin_set_cycles(const struct device *dev,
 	}
 
 	/* Set channel */
-	ret = pwm_led_esp32_channel_set(pwm, speed_mode, channel, 0, timer);
+	ret = pwm_led_esp32_channel_set(channel, speed_mode, channel, 0, timer);
 	if (ret < 0) {
 		return ret;
 	}
@@ -349,8 +351,7 @@ static int pwm_led_esp32_pin_set_cycles(const struct device *dev,
 }
 
 static int pwm_led_esp32_get_cycles_per_sec(const struct device *dev,
-					    uint32_t pwm,
-					    uint64_t *cycles)
+					    uint32_t channel, uint64_t *cycles)
 {
 	const struct pwm_led_esp32_config *config;
 	int channel;
@@ -359,7 +360,7 @@ static int pwm_led_esp32_get_cycles_per_sec(const struct device *dev,
 
 	config = (const struct pwm_led_esp32_config *) dev->config;
 
-	channel = pwm_led_esp32_get_gpio_config(pwm, config->ch_cfg);
+	channel = pwm_led_esp32_get_gpio_config(channel, config->ch_cfg);
 	if (channel < 0) {
 		return -EINVAL;
 	}

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -294,11 +294,9 @@ static int pwm_led_esp32_timer_set(int speed_mode, int timer,
 }
 
 /* period_cycles is not used, set frequency on menuconfig instead. */
-static int pwm_led_esp32_pin_set_cycles(const struct device *dev,
-					uint32_t channel,
-					uint32_t period_cycles,
-					uint32_t pulse_cycles,
-					pwm_flags_t flags)
+static int pwm_led_esp32_set_cycles(const struct device *dev, uint32_t channel,
+				    uint32_t period_cycles,
+				    uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	int speed_mode;
 	int channel;
@@ -375,7 +373,7 @@ static int pwm_led_esp32_get_cycles_per_sec(const struct device *dev,
 }
 
 static const struct pwm_driver_api pwm_led_esp32_api = {
-	.pin_set = pwm_led_esp32_pin_set_cycles,
+	.set_cycles = pwm_led_esp32_set_cycles,
 	.get_cycles_per_sec = pwm_led_esp32_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -45,9 +45,9 @@ int pwm_litex_init(const struct device *dev)
 	return 0;
 }
 
-int pwm_litex_pin_set(const struct device *dev, uint32_t channel,
-		      uint32_t period_cycles,
-		      uint32_t pulse_cycles, pwm_flags_t flags)
+int pwm_litex_set_cycles(const struct device *dev, uint32_t channel,
+			 uint32_t period_cycles,
+			 uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_litex_cfg *cfg = dev->config;
 
@@ -75,8 +75,8 @@ int pwm_litex_get_cycles_per_sec(const struct device *dev, uint32_t channel,
 }
 
 static const struct pwm_driver_api pwm_litex_driver_api = {
-	.pin_set             = pwm_litex_pin_set,
-	.get_cycles_per_sec  = pwm_litex_get_cycles_per_sec,
+	.set_cycles = pwm_litex_set_cycles,
+	.get_cycles_per_sec = pwm_litex_get_cycles_per_sec,
 };
 
 /* Device Instantiation */

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -45,13 +45,13 @@ int pwm_litex_init(const struct device *dev)
 	return 0;
 }
 
-int pwm_litex_pin_set(const struct device *dev, uint32_t pwm,
+int pwm_litex_pin_set(const struct device *dev, uint32_t channel,
 		      uint32_t period_cycles,
 		      uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_litex_cfg *cfg = dev->config;
 
-	if (pwm >= NUMBER_OF_CHANNELS) {
+	if (channel >= NUMBER_OF_CHANNELS) {
 		return -EINVAL;
 	}
 
@@ -63,10 +63,10 @@ int pwm_litex_pin_set(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-int pwm_litex_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
+int pwm_litex_get_cycles_per_sec(const struct device *dev, uint32_t channel,
 				 uint64_t *cycles)
 {
-	if (pwm >= NUMBER_OF_CHANNELS) {
+	if (channel >= NUMBER_OF_CHANNELS) {
 		return -EINVAL;
 	}
 

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -313,9 +313,9 @@ done:
 	regs->CONFIG = cfgval;
 }
 
-static int pwm_xec_pin_set(const struct device *dev, uint32_t channel,
-			   uint32_t period_cycles, uint32_t pulse_cycles,
-			   pwm_flags_t flags)
+static int pwm_xec_set_cycles(const struct device *dev, uint32_t channel,
+			      uint32_t period_cycles, uint32_t pulse_cycles,
+			      pwm_flags_t flags)
 {
 	const struct pwm_xec_config * const cfg = dev->config;
 	struct pwm_regs * const regs = cfg->regs;
@@ -375,7 +375,7 @@ static int pwm_xec_get_cycles_per_sec(const struct device *dev,
 }
 
 static const struct pwm_driver_api pwm_xec_driver_api = {
-	.pin_set = pwm_xec_pin_set,
+	.set_cycles = pwm_xec_set_cycles,
 	.get_cycles_per_sec = pwm_xec_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -313,7 +313,7 @@ done:
 	regs->CONFIG = cfgval;
 }
 
-static int pwm_xec_pin_set(const struct device *dev, uint32_t pwm,
+static int pwm_xec_pin_set(const struct device *dev, uint32_t channel,
 			   uint32_t period_cycles, uint32_t pulse_cycles,
 			   pwm_flags_t flags)
 {
@@ -322,7 +322,7 @@ static int pwm_xec_pin_set(const struct device *dev, uint32_t pwm,
 	uint32_t target_freq;
 	uint32_t on, off;
 
-	if (pwm > 0) {
+	if (channel > 0) {
 		return -EIO;
 	}
 
@@ -355,12 +355,12 @@ static int pwm_xec_pin_set(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-static int pwm_xec_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				      uint64_t *cycles)
+static int pwm_xec_get_cycles_per_sec(const struct device *dev,
+				      uint32_t channel, uint64_t *cycles)
 {
 	ARG_UNUSED(dev);
 
-	if (pwm > 0) {
+	if (channel > 0) {
 		return -EIO;
 	}
 

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -34,9 +34,9 @@ struct pwm_mcux_data {
 	pwm_signal_param_t channel[CHANNEL_COUNT];
 };
 
-static int mcux_pwm_pin_set(const struct device *dev, uint32_t channel,
-			    uint32_t period_cycles, uint32_t pulse_cycles,
-			    pwm_flags_t flags)
+static int mcux_pwm_set_cycles(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	const struct pwm_mcux_config *config = dev->config;
 	struct pwm_mcux_data *data = dev->data;
@@ -167,7 +167,7 @@ static int pwm_mcux_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api pwm_mcux_driver_api = {
-	.pin_set = mcux_pwm_pin_set,
+	.set_cycles = mcux_pwm_set_cycles,
 	.get_cycles_per_sec = mcux_pwm_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -34,7 +34,7 @@ struct pwm_mcux_data {
 	pwm_signal_param_t channel[CHANNEL_COUNT];
 };
 
-static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
+static int mcux_pwm_pin_set(const struct device *dev, uint32_t channel,
 			    uint32_t period_cycles, uint32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
@@ -42,7 +42,7 @@ static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
 	struct pwm_mcux_data *data = dev->data;
 	uint8_t duty_cycle;
 
-	if (pwm >= CHANNEL_COUNT) {
+	if (channel >= CHANNEL_COUNT) {
 		LOG_ERR("Invalid channel");
 		return -EINVAL;
 	}
@@ -68,12 +68,12 @@ static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
 	duty_cycle = 100 * pulse_cycles / period_cycles;
 
 	/* FIXME: Force re-setup even for duty-cycle update */
-	if (period_cycles != data->period_cycles[pwm]) {
+	if (period_cycles != data->period_cycles[channel]) {
 		uint32_t clock_freq;
 		uint32_t pwm_freq;
 		status_t status;
 
-		data->period_cycles[pwm] = period_cycles;
+		data->period_cycles[channel] = period_cycles;
 
 		LOG_DBG("SETUP dutycycle to %u\n", duty_cycle);
 
@@ -91,7 +91,7 @@ static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
 
 		PWM_StopTimer(config->base, 1U << config->index);
 
-		data->channel[pwm].dutyCyclePercent = duty_cycle;
+		data->channel[channel].dutyCyclePercent = duty_cycle;
 
 		status = PWM_SetupPwm(config->base, config->index,
 				      &data->channel[0], CHANNEL_COUNT,
@@ -106,7 +106,7 @@ static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
 		PWM_StartTimer(config->base, 1U << config->index);
 	} else {
 		PWM_UpdatePwmDutycycle(config->base, config->index,
-				       (pwm == 0) ? kPWM_PwmA : kPWM_PwmB,
+				       (channel == 0) ? kPWM_PwmA : kPWM_PwmB,
 				       config->mode, duty_cycle);
 		PWM_SetPwmLdok(config->base, 1U << config->index, true);
 	}
@@ -114,8 +114,8 @@ static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-static int mcux_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				       uint64_t *cycles)
+static int mcux_pwm_get_cycles_per_sec(const struct device *dev,
+				       uint32_t channel, uint64_t *cycles)
 {
 	const struct pwm_mcux_config *config = dev->config;
 	uint32_t clock_freq;

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -58,9 +58,9 @@ struct mcux_ftm_data {
 #endif /* CONFIG_PWM_CAPTURE */
 };
 
-static int mcux_ftm_pin_set(const struct device *dev, uint32_t channel,
-			    uint32_t period_cycles, uint32_t pulse_cycles,
-			    pwm_flags_t flags)
+static int mcux_ftm_set_cycles(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
@@ -136,10 +136,10 @@ static int mcux_ftm_pin_set(const struct device *dev, uint32_t channel,
 }
 
 #ifdef CONFIG_PWM_CAPTURE
-static int mcux_ftm_pin_configure_capture(const struct device *dev,
-					  uint32_t channel, pwm_flags_t flags,
-					  pwm_capture_callback_handler_t cb,
-					  void *user_data)
+static int mcux_ftm_configure_capture(const struct device *dev,
+				      uint32_t channel, pwm_flags_t flags,
+				      pwm_capture_callback_handler_t cb,
+				      void *user_data)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
@@ -206,8 +206,7 @@ static int mcux_ftm_pin_configure_capture(const struct device *dev,
 	return 0;
 }
 
-static int mcux_ftm_pin_enable_capture(const struct device *dev,
-				       uint32_t channel)
+static int mcux_ftm_enable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
@@ -245,8 +244,7 @@ static int mcux_ftm_pin_enable_capture(const struct device *dev,
 	return 0;
 }
 
-static int mcux_ftm_pin_disable_capture(const struct device *dev,
-					uint32_t channel)
+static int mcux_ftm_disable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
@@ -440,12 +438,12 @@ static int mcux_ftm_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api mcux_ftm_driver_api = {
-	.pin_set = mcux_ftm_pin_set,
+	.set_cycles = mcux_ftm_set_cycles,
 	.get_cycles_per_sec = mcux_ftm_get_cycles_per_sec,
 #ifdef CONFIG_PWM_CAPTURE
-	.pin_configure_capture = mcux_ftm_pin_configure_capture,
-	.pin_enable_capture = mcux_ftm_pin_enable_capture,
-	.pin_disable_capture = mcux_ftm_pin_disable_capture,
+	.configure_capture = mcux_ftm_configure_capture,
+	.enable_capture = mcux_ftm_enable_capture,
+	.disable_capture = mcux_ftm_disable_capture,
 #endif /* CONFIG_PWM_CAPTURE */
 };
 

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -58,7 +58,7 @@ struct mcux_ftm_data {
 #endif /* CONFIG_PWM_CAPTURE */
 };
 
-static int mcux_ftm_pin_set(const struct device *dev, uint32_t pwm,
+static int mcux_ftm_pin_set(const struct device *dev, uint32_t channel,
 			    uint32_t period_cycles, uint32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
@@ -66,7 +66,7 @@ static int mcux_ftm_pin_set(const struct device *dev, uint32_t pwm,
 	struct mcux_ftm_data *data = dev->data;
 	status_t status;
 #ifdef CONFIG_PWM_CAPTURE
-	uint32_t pair = pwm / 2U;
+	uint32_t pair = channel / 2U;
 	uint32_t irqs;
 #endif /* CONFIG_PWM_CAPTURE */
 
@@ -75,7 +75,7 @@ static int mcux_ftm_pin_set(const struct device *dev, uint32_t pwm,
 		return -ENOTSUP;
 	}
 
-	if (pwm >= config->channel_count) {
+	if (channel >= config->channel_count) {
 		LOG_ERR("Invalid channel");
 		return -ENOTSUP;
 	}
@@ -88,12 +88,12 @@ static int mcux_ftm_pin_set(const struct device *dev, uint32_t pwm,
 	}
 #endif /* CONFIG_PWM_CAPTURE */
 
-	data->channel[pwm].dutyValue = pulse_cycles;
+	data->channel[channel].dutyValue = pulse_cycles;
 
 	if ((flags & PWM_POLARITY_INVERTED) == 0) {
-		data->channel[pwm].level = kFTM_HighTrue;
+		data->channel[channel].level = kFTM_HighTrue;
 	} else {
-		data->channel[pwm].level = kFTM_LowTrue;
+		data->channel[channel].level = kFTM_LowTrue;
 	}
 
 	LOG_DBG("pulse_cycles=%d, period_cycles=%d, flags=%d",
@@ -137,17 +137,16 @@ static int mcux_ftm_pin_set(const struct device *dev, uint32_t pwm,
 
 #ifdef CONFIG_PWM_CAPTURE
 static int mcux_ftm_pin_configure_capture(const struct device *dev,
-					  uint32_t pwm,
-					  pwm_flags_t flags,
+					  uint32_t channel, pwm_flags_t flags,
 					  pwm_capture_callback_handler_t cb,
 					  void *user_data)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
 	ftm_dual_edge_capture_param_t *param;
-	uint32_t pair = pwm / 2U;
+	uint32_t pair = channel / 2U;
 
-	if (pwm & 0x1U) {
+	if (channel & 0x1U) {
 		LOG_ERR("PWM capture only supported on even channels");
 		return -ENOTSUP;
 	}
@@ -207,13 +206,14 @@ static int mcux_ftm_pin_configure_capture(const struct device *dev,
 	return 0;
 }
 
-static int mcux_ftm_pin_enable_capture(const struct device *dev, uint32_t pwm)
+static int mcux_ftm_pin_enable_capture(const struct device *dev,
+				       uint32_t channel)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
-	uint32_t pair = pwm / 2U;
+	uint32_t pair = channel / 2U;
 
-	if (pwm & 0x1U) {
+	if (channel & 0x1U) {
 		LOG_ERR("PWM capture only supported on even channels");
 		return -ENOTSUP;
 	}
@@ -245,13 +245,14 @@ static int mcux_ftm_pin_enable_capture(const struct device *dev, uint32_t pwm)
 	return 0;
 }
 
-static int mcux_ftm_pin_disable_capture(const struct device *dev, uint32_t pwm)
+static int mcux_ftm_pin_disable_capture(const struct device *dev,
+					uint32_t channel)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
-	uint32_t pair = pwm / 2U;
+	uint32_t pair = channel / 2U;
 
-	if (pwm & 0x1U) {
+	if (channel & 0x1U) {
 		LOG_ERR("PWM capture only supported on even channels");
 		return -ENOTSUP;
 	}
@@ -271,12 +272,13 @@ static int mcux_ftm_pin_disable_capture(const struct device *dev, uint32_t pwm)
 	return 0;
 }
 
-static void mcux_ftm_capture_first_edge(const struct device *dev, uint32_t pwm)
+static void mcux_ftm_capture_first_edge(const struct device *dev,
+					uint32_t channel)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
 	struct mcux_ftm_capture_data *capture;
-	uint32_t pair = pwm / 2U;
+	uint32_t pair = channel / 2U;
 
 	__ASSERT_NO_MSG(pair < ARRAY_SIZE(data->capture));
 	capture = &data->capture[pair];
@@ -285,13 +287,14 @@ static void mcux_ftm_capture_first_edge(const struct device *dev, uint32_t pwm)
 	capture->first_edge_overflows = data->overflows;
 }
 
-static void mcux_ftm_capture_second_edge(const struct device *dev, uint32_t pwm)
+static void mcux_ftm_capture_second_edge(const struct device *dev,
+					 uint32_t channel)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;
 	uint32_t second_edge_overflows = data->overflows;
 	struct mcux_ftm_capture_data *capture;
-	uint32_t pair = pwm / 2U;
+	uint32_t pair = channel / 2U;
 	uint32_t overflows;
 	uint32_t first_cnv;
 	uint32_t second_cnv;
@@ -373,8 +376,8 @@ static void mcux_ftm_isr(const struct device *dev)
 }
 #endif /* CONFIG_PWM_CAPTURE */
 
-static int mcux_ftm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				       uint64_t *cycles)
+static int mcux_ftm_get_cycles_per_sec(const struct device *dev,
+				       uint32_t channel, uint64_t *cycles)
 {
 	const struct mcux_ftm_config *config = dev->config;
 	struct mcux_ftm_data *data = dev->data;

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -50,12 +50,12 @@ static inline bool mcux_pwt_is_active(const struct device *dev)
 	return !!(config->base->CS & PWT_CS_PWTEN_MASK);
 }
 
-static int mcux_pwt_pin_set(const struct device *dev, uint32_t pwm,
+static int mcux_pwt_pin_set(const struct device *dev, uint32_t channel,
 			    uint32_t period_cycles, uint32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
 	ARG_UNUSED(dev);
-	ARG_UNUSED(pwm);
+	ARG_UNUSED(channel);
 	ARG_UNUSED(period_cycles);
 	ARG_UNUSED(pulse_cycles);
 	ARG_UNUSED(flags);
@@ -66,16 +66,15 @@ static int mcux_pwt_pin_set(const struct device *dev, uint32_t pwm,
 }
 
 static int mcux_pwt_pin_configure_capture(const struct device *dev,
-					  uint32_t pwm,
-					  pwm_flags_t flags,
+					  uint32_t channel, pwm_flags_t flags,
 					  pwm_capture_callback_handler_t cb,
 					  void *user_data)
 {
 	const struct mcux_pwt_config *config = dev->config;
 	struct mcux_pwt_data *data = dev->data;
 
-	if (pwm >= PWT_INPUTS) {
-		LOG_ERR("invalid channel %d", pwm);
+	if (channel >= PWT_INPUTS) {
+		LOG_ERR("invalid channel %d", channel);
 		return -EINVAL;
 	}
 
@@ -87,7 +86,7 @@ static int mcux_pwt_pin_configure_capture(const struct device *dev,
 	data->callback = cb;
 	data->user_data = user_data;
 
-	data->pwt_config.inputSelect = pwm;
+	data->pwt_config.inputSelect = channel;
 
 	data->continuous =
 		(flags & PWM_CAPTURE_MODE_MASK) == PWM_CAPTURE_MODE_CONTINUOUS;
@@ -102,13 +101,14 @@ static int mcux_pwt_pin_configure_capture(const struct device *dev,
 	return 0;
 }
 
-static int mcux_pwt_pin_enable_capture(const struct device *dev, uint32_t pwm)
+static int mcux_pwt_pin_enable_capture(const struct device *dev,
+				       uint32_t channel)
 {
 	const struct mcux_pwt_config *config = dev->config;
 	struct mcux_pwt_data *data = dev->data;
 
-	if (pwm >= PWT_INPUTS) {
-		LOG_ERR("invalid channel %d", pwm);
+	if (channel >= PWT_INPUTS) {
+		LOG_ERR("invalid channel %d", channel);
 		return -EINVAL;
 	}
 
@@ -130,12 +130,13 @@ static int mcux_pwt_pin_enable_capture(const struct device *dev, uint32_t pwm)
 	return 0;
 }
 
-static int mcux_pwt_pin_disable_capture(const struct device *dev, uint32_t pwm)
+static int mcux_pwt_pin_disable_capture(const struct device *dev,
+					uint32_t channel)
 {
 	const struct mcux_pwt_config *config = dev->config;
 
-	if (pwm >= PWT_INPUTS) {
-		LOG_ERR("invalid channel %d", pwm);
+	if (channel >= PWT_INPUTS) {
+		LOG_ERR("invalid channel %d", channel);
 		return -EINVAL;
 	}
 
@@ -263,13 +264,13 @@ static void mcux_pwt_isr(const struct device *dev)
 	}
 }
 
-static int mcux_pwt_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				       uint64_t *cycles)
+static int mcux_pwt_get_cycles_per_sec(const struct device *dev,
+				       uint32_t channel, uint64_t *cycles)
 {
 	const struct mcux_pwt_config *config = dev->config;
 	struct mcux_pwt_data *data = dev->data;
 
-	ARG_UNUSED(pwm);
+	ARG_UNUSED(channel);
 
 	*cycles = data->clock_freq >> config->prescale;
 

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -50,9 +50,9 @@ static inline bool mcux_pwt_is_active(const struct device *dev)
 	return !!(config->base->CS & PWT_CS_PWTEN_MASK);
 }
 
-static int mcux_pwt_pin_set(const struct device *dev, uint32_t channel,
-			    uint32_t period_cycles, uint32_t pulse_cycles,
-			    pwm_flags_t flags)
+static int mcux_pwt_set_cycles(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(channel);
@@ -65,10 +65,10 @@ static int mcux_pwt_pin_set(const struct device *dev, uint32_t channel,
 	return -ENOTSUP;
 }
 
-static int mcux_pwt_pin_configure_capture(const struct device *dev,
-					  uint32_t channel, pwm_flags_t flags,
-					  pwm_capture_callback_handler_t cb,
-					  void *user_data)
+static int mcux_pwt_configure_capture(const struct device *dev,
+				      uint32_t channel, pwm_flags_t flags,
+				      pwm_capture_callback_handler_t cb,
+				      void *user_data)
 {
 	const struct mcux_pwt_config *config = dev->config;
 	struct mcux_pwt_data *data = dev->data;
@@ -101,8 +101,7 @@ static int mcux_pwt_pin_configure_capture(const struct device *dev,
 	return 0;
 }
 
-static int mcux_pwt_pin_enable_capture(const struct device *dev,
-				       uint32_t channel)
+static int mcux_pwt_enable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct mcux_pwt_config *config = dev->config;
 	struct mcux_pwt_data *data = dev->data;
@@ -130,8 +129,7 @@ static int mcux_pwt_pin_enable_capture(const struct device *dev,
 	return 0;
 }
 
-static int mcux_pwt_pin_disable_capture(const struct device *dev,
-					uint32_t channel)
+static int mcux_pwt_disable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct mcux_pwt_config *config = dev->config;
 
@@ -307,11 +305,11 @@ static int mcux_pwt_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api mcux_pwt_driver_api = {
-	.pin_set = mcux_pwt_pin_set,
+	.set_cycles = mcux_pwt_set_cycles,
 	.get_cycles_per_sec = mcux_pwt_get_cycles_per_sec,
-	.pin_configure_capture = mcux_pwt_pin_configure_capture,
-	.pin_enable_capture = mcux_pwt_pin_enable_capture,
-	.pin_disable_capture = mcux_pwt_pin_disable_capture,
+	.configure_capture = mcux_pwt_configure_capture,
+	.enable_capture = mcux_pwt_enable_capture,
+	.disable_capture = mcux_pwt_disable_capture,
 };
 
 #define TO_PWT_PRESCALE_DIVIDE(val) _DO_CONCAT(kPWT_Prescale_Divide_, val)

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -35,9 +35,9 @@ struct pwm_mcux_sctimer_data {
 	sctimer_pwm_signal_param_t channel[CHANNEL_COUNT];
 };
 
-static int mcux_sctimer_pwm_pin_set(const struct device *dev, uint32_t channel,
-			    uint32_t period_cycles, uint32_t pulse_cycles,
-			    pwm_flags_t flags)
+static int mcux_sctimer_pwm_set_cycles(const struct device *dev,
+				       uint32_t channel, uint32_t period_cycles,
+				       uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct pwm_mcux_sctimer_config *config = dev->config;
 	struct pwm_mcux_sctimer_data *data = dev->data;
@@ -167,7 +167,7 @@ static int mcux_sctimer_pwm_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api pwm_mcux_sctimer_driver_api = {
-	.pin_set = mcux_sctimer_pwm_pin_set,
+	.set_cycles = mcux_sctimer_pwm_set_cycles,
 	.get_cycles_per_sec = mcux_sctimer_pwm_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -41,7 +41,7 @@ struct mcux_tpm_data {
 	tpm_chnl_pwm_signal_param_t channel[MAX_CHANNELS];
 };
 
-static int mcux_tpm_pin_set(const struct device *dev, uint32_t pwm,
+static int mcux_tpm_pin_set(const struct device *dev, uint32_t channel,
 			      uint32_t period_cycles, uint32_t pulse_cycles,
 			      pwm_flags_t flags)
 {
@@ -54,18 +54,18 @@ static int mcux_tpm_pin_set(const struct device *dev, uint32_t pwm,
 		return -ENOTSUP;
 	}
 
-	if (pwm >= config->channel_count) {
+	if (channel >= config->channel_count) {
 		LOG_ERR("Invalid channel");
 		return -ENOTSUP;
 	}
 
 	duty_cycle = pulse_cycles * 100U / period_cycles;
-	data->channel[pwm].dutyCyclePercent = duty_cycle;
+	data->channel[channel].dutyCyclePercent = duty_cycle;
 
 	if ((flags & PWM_POLARITY_INVERTED) == 0) {
-		data->channel[pwm].level = kTPM_HighTrue;
+		data->channel[channel].level = kTPM_HighTrue;
 	} else {
-		data->channel[pwm].level = kTPM_LowTrue;
+		data->channel[channel].level = kTPM_LowTrue;
 	}
 
 	LOG_DBG("pulse_cycles=%d, period_cycles=%d, duty_cycle=%d, flags=%d",
@@ -108,17 +108,17 @@ static int mcux_tpm_pin_set(const struct device *dev, uint32_t pwm,
 		}
 		TPM_StartTimer(config->base, config->tpm_clock_source);
 	} else {
-		TPM_UpdateChnlEdgeLevelSelect(config->base, pwm,
-					      data->channel[pwm].level);
-		TPM_UpdatePwmDutycycle(config->base, pwm, config->mode,
+		TPM_UpdateChnlEdgeLevelSelect(config->base, channel,
+					      data->channel[channel].level);
+		TPM_UpdatePwmDutycycle(config->base, channel, config->mode,
 				       duty_cycle);
 	}
 
 	return 0;
 }
 
-static int mcux_tpm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-					 uint64_t *cycles)
+static int mcux_tpm_get_cycles_per_sec(const struct device *dev,
+				       uint32_t channel, uint64_t *cycles)
 {
 	const struct mcux_tpm_config *config = dev->config;
 	struct mcux_tpm_data *data = dev->data;

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -41,9 +41,9 @@ struct mcux_tpm_data {
 	tpm_chnl_pwm_signal_param_t channel[MAX_CHANNELS];
 };
 
-static int mcux_tpm_pin_set(const struct device *dev, uint32_t channel,
-			      uint32_t period_cycles, uint32_t pulse_cycles,
-			      pwm_flags_t flags)
+static int mcux_tpm_set_cycles(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	const struct mcux_tpm_config *config = dev->config;
 	struct mcux_tpm_data *data = dev->data;
@@ -175,7 +175,7 @@ static int mcux_tpm_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api mcux_tpm_driver_api = {
-	.pin_set = mcux_tpm_pin_set,
+	.set_cycles = mcux_tpm_set_cycles,
 	.get_cycles_per_sec = mcux_tpm_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -88,9 +88,9 @@ static void pwm_npcx_configure(const struct device *dev, int clk_bus)
 }
 
 /* PWM api functions */
-static int pwm_npcx_pin_set(const struct device *dev, uint32_t channel,
-			   uint32_t period_cycles, uint32_t pulse_cycles,
-			   pwm_flags_t flags)
+static int pwm_npcx_set_cycles(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	/* Single channel for each pwm device */
 	ARG_UNUSED(channel);
@@ -173,7 +173,7 @@ static int pwm_npcx_get_cycles_per_sec(const struct device *dev,
 
 /* PWM driver registration */
 static const struct pwm_driver_api pwm_npcx_driver_api = {
-	.pin_set = pwm_npcx_pin_set,
+	.set_cycles = pwm_npcx_set_cycles,
 	.get_cycles_per_sec = pwm_npcx_get_cycles_per_sec
 };
 

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -88,12 +88,12 @@ static void pwm_npcx_configure(const struct device *dev, int clk_bus)
 }
 
 /* PWM api functions */
-static int pwm_npcx_pin_set(const struct device *dev, uint32_t pwm,
+static int pwm_npcx_pin_set(const struct device *dev, uint32_t channel,
 			   uint32_t period_cycles, uint32_t pulse_cycles,
 			   pwm_flags_t flags)
 {
 	/* Single channel for each pwm device */
-	ARG_UNUSED(pwm);
+	ARG_UNUSED(channel);
 	struct pwm_npcx_data *const data = dev->data;
 	struct pwm_reg *const inst = HAL_INSTANCE(dev);
 	int prescaler;
@@ -160,11 +160,11 @@ static int pwm_npcx_pin_set(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-static int pwm_npcx_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				      uint64_t *cycles)
+static int pwm_npcx_get_cycles_per_sec(const struct device *dev,
+				       uint32_t channel, uint64_t *cycles)
 {
 	/* Single channel for each pwm device */
-	ARG_UNUSED(pwm);
+	ARG_UNUSED(channel);
 	struct pwm_npcx_data *const data = dev->data;
 
 	*cycles = data->cycles_per_sec;

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -107,7 +107,7 @@ static uint32_t pwm_period_check(struct pwm_data *data, uint8_t map_size,
 	return 0;
 }
 
-static int pwm_nrf5_sw_pin_set(const struct device *dev, uint32_t pwm,
+static int pwm_nrf5_sw_pin_set(const struct device *dev, uint32_t channel,
 			       uint32_t period_cycles, uint32_t pulse_cycles,
 			       pwm_flags_t flags)
 {
@@ -116,7 +116,6 @@ static int pwm_nrf5_sw_pin_set(const struct device *dev, uint32_t pwm,
 	NRF_RTC_Type *rtc = pwm_config_rtc(config);
 	struct pwm_data *data = dev->data;
 	uint32_t ppi_mask;
-	uint8_t channel = pwm;
 	uint8_t active_level;
 	uint8_t psel_ch;
 	uint8_t gpiote_ch;
@@ -277,8 +276,7 @@ static int pwm_nrf5_sw_pin_set(const struct device *dev, uint32_t pwm,
 }
 
 static int pwm_nrf5_sw_get_cycles_per_sec(const struct device *dev,
-					  uint32_t pwm,
-					  uint64_t *cycles)
+					  uint32_t channel, uint64_t *cycles)
 {
 	const struct pwm_config *config = dev->config;
 

--- a/drivers/pwm/pwm_nrf5_sw.c
+++ b/drivers/pwm/pwm_nrf5_sw.c
@@ -107,9 +107,9 @@ static uint32_t pwm_period_check(struct pwm_data *data, uint8_t map_size,
 	return 0;
 }
 
-static int pwm_nrf5_sw_pin_set(const struct device *dev, uint32_t channel,
-			       uint32_t period_cycles, uint32_t pulse_cycles,
-			       pwm_flags_t flags)
+static int pwm_nrf5_sw_set_cycles(const struct device *dev, uint32_t channel,
+				  uint32_t period_cycles, uint32_t pulse_cycles,
+				  pwm_flags_t flags)
 {
 	const struct pwm_config *config = dev->config;
 	NRF_TIMER_Type *timer = pwm_config_timer(config);
@@ -298,7 +298,7 @@ static int pwm_nrf5_sw_get_cycles_per_sec(const struct device *dev,
 }
 
 static const struct pwm_driver_api pwm_nrf5_sw_drv_api_funcs = {
-	.pin_set = pwm_nrf5_sw_pin_set,
+	.set_cycles = pwm_nrf5_sw_set_cycles,
 	.get_cycles_per_sec = pwm_nrf5_sw_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -121,9 +121,9 @@ static bool channel_psel_get(uint32_t channel, uint32_t *psel,
 		== PWM_PSEL_OUT_CONNECT_Connected);
 }
 
-static int pwm_nrfx_pin_set(const struct device *dev, uint32_t channel,
-			    uint32_t period_cycles, uint32_t pulse_cycles,
-			    pwm_flags_t flags)
+static int pwm_nrfx_set_cycles(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	/* We assume here that period_cycles will always be 16MHz
 	 * peripheral clock. Since pwm_nrfx_get_cycles_per_sec() function might
@@ -141,9 +141,9 @@ static int pwm_nrfx_pin_set(const struct device *dev, uint32_t channel,
 	}
 
 	/* Check if nrfx_pwm_stop function was called in previous
-	 * pwm_nrfx_pin_set call. Relying only on state returned by
-	 * nrfx_pwm_is_stopped may cause race condition if the pwm_nrfx_pin_set
-	 * is called multiple times in quick succession.
+	 * pwm_nrfx_set_cycles call. Relying only on state returned by
+	 * nrfx_pwm_is_stopped may cause race condition if the
+	 * pwm_nrfx_set_cycles is called multiple times in quick succession.
 	 */
 	was_stopped = !pwm_channel_is_active(channel, data) &&
 		      !any_other_channel_is_active(channel, data);
@@ -239,7 +239,7 @@ static int pwm_nrfx_get_cycles_per_sec(const struct device *dev, uint32_t channe
 }
 
 static const struct pwm_driver_api pwm_nrfx_drv_api_funcs = {
-	.pin_set = pwm_nrfx_pin_set,
+	.set_cycles = pwm_nrfx_set_cycles,
 	.get_cycles_per_sec = pwm_nrfx_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -121,7 +121,7 @@ static bool channel_psel_get(uint32_t channel, uint32_t *psel,
 		== PWM_PSEL_OUT_CONNECT_Connected);
 }
 
-static int pwm_nrfx_pin_set(const struct device *dev, uint32_t pwm,
+static int pwm_nrfx_pin_set(const struct device *dev, uint32_t channel,
 			    uint32_t period_cycles, uint32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
@@ -132,7 +132,6 @@ static int pwm_nrfx_pin_set(const struct device *dev, uint32_t pwm,
 	 */
 	const struct pwm_nrfx_config *config = dev->config;
 	struct pwm_nrfx_data *data = dev->data;
-	uint8_t channel = pwm;
 	bool inverted = (flags & PWM_POLARITY_INVERTED);
 	bool was_stopped;
 
@@ -227,7 +226,7 @@ static int pwm_nrfx_pin_set(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-static int pwm_nrfx_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
+static int pwm_nrfx_get_cycles_per_sec(const struct device *dev, uint32_t channel,
 				       uint64_t *cycles)
 {
 	/* TODO: Since this function might be removed, we will always return

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -38,9 +38,9 @@ struct rv32m1_tpm_data {
 	tpm_chnl_pwm_signal_param_t channel[MAX_CHANNELS];
 };
 
-static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t channel,
-			      uint32_t period_cycles, uint32_t pulse_cycles,
-			      pwm_flags_t flags)
+static int rv32m1_tpm_set_cycles(const struct device *dev, uint32_t channel,
+				 uint32_t period_cycles, uint32_t pulse_cycles,
+				 pwm_flags_t flags)
 {
 	const struct rv32m1_tpm_config *config = dev->config;
 	struct rv32m1_tpm_data *data = dev->data;
@@ -166,7 +166,7 @@ static int rv32m1_tpm_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api rv32m1_tpm_driver_api = {
-	.pin_set = rv32m1_tpm_pin_set,
+	.set_cycles = rv32m1_tpm_set_cycles,
 	.get_cycles_per_sec = rv32m1_tpm_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -38,7 +38,7 @@ struct rv32m1_tpm_data {
 	tpm_chnl_pwm_signal_param_t channel[MAX_CHANNELS];
 };
 
-static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t pwm,
+static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t channel,
 			      uint32_t period_cycles, uint32_t pulse_cycles,
 			      pwm_flags_t flags)
 {
@@ -51,18 +51,18 @@ static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t pwm,
 		return -ENOTSUP;
 	}
 
-	if (pwm >= config->channel_count) {
+	if (channel >= config->channel_count) {
 		LOG_ERR("Invalid channel");
 		return -ENOTSUP;
 	}
 
 	duty_cycle = pulse_cycles * 100U / period_cycles;
-	data->channel[pwm].dutyCyclePercent = duty_cycle;
+	data->channel[channel].dutyCyclePercent = duty_cycle;
 
 	if ((flags & PWM_POLARITY_INVERTED) == 0) {
-		data->channel[pwm].level = kTPM_HighTrue;
+		data->channel[channel].level = kTPM_HighTrue;
 	} else {
-		data->channel[pwm].level = kTPM_LowTrue;
+		data->channel[channel].level = kTPM_LowTrue;
 	}
 
 	LOG_DBG("pulse_cycles=%d, period_cycles=%d, duty_cycle=%d, flags=%d",
@@ -105,9 +105,9 @@ static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t pwm,
 		}
 		TPM_StartTimer(config->base, config->tpm_clock_source);
 	} else {
-		TPM_UpdateChnlEdgeLevelSelect(config->base, pwm,
-					      data->channel[pwm].level);
-		TPM_UpdatePwmDutycycle(config->base, pwm, config->mode,
+		TPM_UpdateChnlEdgeLevelSelect(config->base, channel,
+					      data->channel[channel].level);
+		TPM_UpdatePwmDutycycle(config->base, channel, config->mode,
 				       duty_cycle);
 	}
 
@@ -115,8 +115,7 @@ static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t pwm,
 }
 
 static int rv32m1_tpm_get_cycles_per_sec(const struct device *dev,
-					 uint32_t pwm,
-					 uint64_t *cycles)
+					 uint32_t channel, uint64_t *cycles)
 {
 	const struct rv32m1_tpm_config *config = dev->config;
 	struct rv32m1_tpm_data *data = dev->data;

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -37,9 +37,9 @@ static int sam_pwm_get_cycles_per_sec(const struct device *dev,
 	return 0;
 }
 
-static int sam_pwm_pin_set(const struct device *dev, uint32_t channel,
-			   uint32_t period_cycles, uint32_t pulse_cycles,
-			   pwm_flags_t flags)
+static int sam_pwm_set_cycles(const struct device *dev, uint32_t channel,
+			      uint32_t period_cycles, uint32_t pulse_cycles,
+			      pwm_flags_t flags)
 {
 	const struct sam_pwm_config *config = dev->config;
 
@@ -104,7 +104,7 @@ static int sam_pwm_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api sam_pwm_driver_api = {
-	.pin_set = sam_pwm_pin_set,
+	.set_cycles = sam_pwm_set_cycles,
 	.get_cycles_per_sec = sam_pwm_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -24,8 +24,8 @@ struct sam_pwm_config {
 	uint8_t divider;
 };
 
-static int sam_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
-				      uint64_t *cycles)
+static int sam_pwm_get_cycles_per_sec(const struct device *dev,
+				      uint32_t channel, uint64_t *cycles)
 {
 	const struct sam_pwm_config *config = dev->config;
 	uint8_t prescaler = config->prescaler;
@@ -37,7 +37,7 @@ static int sam_pwm_get_cycles_per_sec(const struct device *dev, uint32_t pwm,
 	return 0;
 }
 
-static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
+static int sam_pwm_pin_set(const struct device *dev, uint32_t channel,
 			   uint32_t period_cycles, uint32_t pulse_cycles,
 			   pwm_flags_t flags)
 {
@@ -45,7 +45,7 @@ static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
 
 	Pwm * const pwm = config->regs;
 
-	if (ch >= PWMCHNUM_NUMBER) {
+	if (channel >= PWMCHNUM_NUMBER) {
 		return -EINVAL;
 	}
 
@@ -63,16 +63,16 @@ static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
 	}
 
 	/* Select clock A */
-	pwm->PWM_CH_NUM[ch].PWM_CMR = PWM_CMR_CPRE_CLKA_Val;
+	pwm->PWM_CH_NUM[channel].PWM_CMR = PWM_CMR_CPRE_CLKA_Val;
 
 	/* Update period and pulse using the update registers, so that the
 	 * change is triggered at the next PWM period.
 	 */
-	pwm->PWM_CH_NUM[ch].PWM_CPRDUPD = period_cycles;
-	pwm->PWM_CH_NUM[ch].PWM_CDTYUPD = pulse_cycles;
+	pwm->PWM_CH_NUM[channel].PWM_CPRDUPD = period_cycles;
+	pwm->PWM_CH_NUM[channel].PWM_CDTYUPD = pulse_cycles;
 
 	/* Enable the output */
-	pwm->PWM_ENA = 1 << ch;
+	pwm->PWM_ENA = 1 << channel;
 
 	return 0;
 }

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -56,9 +56,9 @@ static int pwm_sam0_get_cycles_per_sec(const struct device *dev,
 	return 0;
 }
 
-static int pwm_sam0_pin_set(const struct device *dev, uint32_t channel,
-			    uint32_t period_cycles, uint32_t pulse_cycles,
-			    pwm_flags_t flags)
+static int pwm_sam0_set_cycles(const struct device *dev, uint32_t channel,
+			       uint32_t period_cycles, uint32_t pulse_cycles,
+			       pwm_flags_t flags)
 {
 	const struct pwm_sam0_config *const cfg = dev->config;
 	Tcc *regs = cfg->regs;
@@ -136,7 +136,7 @@ static int pwm_sam0_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api pwm_sam0_driver_api = {
-	.pin_set = pwm_sam0_pin_set,
+	.set_cycles = pwm_sam0_set_cycles,
 	.get_cycles_per_sec = pwm_sam0_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_sam0_tcc.c
+++ b/drivers/pwm/pwm_sam0_tcc.c
@@ -43,12 +43,12 @@ static void wait_synchronization(Tcc *regs)
 	}
 }
 
-static int pwm_sam0_get_cycles_per_sec(const struct device *dev, uint32_t ch,
-				       uint64_t *cycles)
+static int pwm_sam0_get_cycles_per_sec(const struct device *dev,
+				       uint32_t channel, uint64_t *cycles)
 {
 	const struct pwm_sam0_config *const cfg = dev->config;
 
-	if (ch >= cfg->channels) {
+	if (channel >= cfg->channels) {
 		return -EINVAL;
 	}
 	*cycles = cfg->freq;
@@ -56,18 +56,18 @@ static int pwm_sam0_get_cycles_per_sec(const struct device *dev, uint32_t ch,
 	return 0;
 }
 
-static int pwm_sam0_pin_set(const struct device *dev, uint32_t ch,
+static int pwm_sam0_pin_set(const struct device *dev, uint32_t channel,
 			    uint32_t period_cycles, uint32_t pulse_cycles,
 			    pwm_flags_t flags)
 {
 	const struct pwm_sam0_config *const cfg = dev->config;
 	Tcc *regs = cfg->regs;
 	uint32_t top = 1 << cfg->counter_size;
-	uint32_t invert_mask = 1 << ch;
+	uint32_t invert_mask = 1 << channel;
 	bool invert = ((flags & PWM_POLARITY_INVERTED) != 0);
 	bool inverted = ((regs->DRVCTRL.vec.INVEN & invert_mask) != 0);
 
-	if (ch >= cfg->channels) {
+	if (channel >= cfg->channels) {
 		return -EINVAL;
 	}
 	if (period_cycles >= top || pulse_cycles >= top) {
@@ -80,11 +80,11 @@ static int pwm_sam0_pin_set(const struct device *dev, uint32_t ch,
 	 */
 #ifdef TCC_PERBUF_PERBUF
 	/* SAME51 naming */
-	regs->CCBUF[ch].reg = TCC_CCBUF_CCBUF(pulse_cycles);
+	regs->CCBUF[channel].reg = TCC_CCBUF_CCBUF(pulse_cycles);
 	regs->PERBUF.reg = TCC_PERBUF_PERBUF(period_cycles);
 #else
 	/* SAMD21 naming */
-	regs->CCB[ch].reg = TCC_CCB_CCB(pulse_cycles);
+	regs->CCB[channel].reg = TCC_CCB_CCB(pulse_cycles);
 	regs->PERB.reg = TCC_PERB_PERB(period_cycles);
 #endif
 

--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -23,7 +23,7 @@ struct args_index {
 
 static const struct args_index args_indx = {
 	.device = 1,
-	.pwm = 2,
+	.channel = 2,
 	.period = 3,
 	.pulse = 4,
 	.flags = 5,
@@ -35,7 +35,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 	const struct device *dev;
 	uint32_t period;
 	uint32_t pulse;
-	uint32_t pwm;
+	uint32_t channel;
 	int err;
 
 	dev = device_get_binding(argv[args_indx.device]);
@@ -44,7 +44,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	pwm = strtoul(argv[args_indx.pwm], NULL, 0);
+	channel = strtoul(argv[args_indx.channel], NULL, 0);
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
@@ -52,7 +52,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_pin_set_cycles(dev, pwm, period, pulse, flags);
+	err = pwm_pin_set_cycles(dev, channel, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)",
 			    err);
@@ -68,7 +68,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 	const struct device *dev;
 	uint32_t period;
 	uint32_t pulse;
-	uint32_t pwm;
+	uint32_t channel;
 	int err;
 
 	dev = device_get_binding(argv[args_indx.device]);
@@ -77,7 +77,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	pwm = strtoul(argv[args_indx.pwm], NULL, 0);
+	channel = strtoul(argv[args_indx.channel], NULL, 0);
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
@@ -85,7 +85,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_pin_set_usec(dev, pwm, period, pulse, flags);
+	err = pwm_pin_set_usec(dev, channel, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;
@@ -100,7 +100,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 	const struct device *dev;
 	uint32_t period;
 	uint32_t pulse;
-	uint32_t pwm;
+	uint32_t channel;
 	int err;
 
 	dev = device_get_binding(argv[args_indx.device]);
@@ -109,7 +109,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	pwm = strtoul(argv[args_indx.pwm], NULL, 0);
+	channel = strtoul(argv[args_indx.channel], NULL, 0);
 	period = strtoul(argv[args_indx.period], NULL, 0);
 	pulse = strtoul(argv[args_indx.pulse], NULL, 0);
 
@@ -117,7 +117,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_pin_set_nsec(dev, pwm, period, pulse, flags);
+	err = pwm_pin_set_nsec(dev, channel, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;
@@ -127,11 +127,11 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 }
 
 SHELL_STATIC_SUBCMD_SET_CREATE(pwm_cmds,
-	SHELL_CMD_ARG(cycles, NULL, "<device> <pwm> <period in cycles> "
+	SHELL_CMD_ARG(cycles, NULL, "<device> <channel> <period in cycles> "
 		      "<pulse width in cycles> [flags]", cmd_cycles, 5, 1),
-	SHELL_CMD_ARG(usec, NULL, "<device> <pwm> <period in usec> "
+	SHELL_CMD_ARG(usec, NULL, "<device> <channel> <period in usec> "
 		      "<pulse width in usec> [flags]", cmd_usec, 5, 1),
-	SHELL_CMD_ARG(nsec, NULL, "<device> <pwm> <period in nsec> "
+	SHELL_CMD_ARG(nsec, NULL, "<device> <channel> <period in nsec> "
 		      "<pulse width in nsec> [flags]", cmd_nsec, 5, 1),
 	SHELL_SUBCMD_SET_END
 );

--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -52,7 +52,7 @@ static int cmd_cycles(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_pin_set_cycles(dev, channel, period, pulse, flags);
+	err = pwm_set_cycles(dev, channel, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)",
 			    err);
@@ -85,7 +85,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_pin_set_usec(dev, channel, period, pulse, flags);
+	err = pwm_set_cycles_usec(dev, channel, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;
@@ -117,7 +117,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_pin_set_nsec(dev, channel, period, pulse, flags);
+	err = pwm_set_cycles_nsec(dev, channel, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -106,9 +106,9 @@ static int pwm_sifive_init(const struct device *dev)
 	return 0;
 }
 
-static int pwm_sifive_pin_set(const struct device *dev, uint32_t channel,
-			      uint32_t period_cycles, uint32_t pulse_cycles,
-			      pwm_flags_t flags)
+static int pwm_sifive_set_cycles(const struct device *dev, uint32_t channel,
+				 uint32_t period_cycles, uint32_t pulse_cycles,
+				 pwm_flags_t flags)
 {
 	const struct pwm_sifive_cfg *config = dev->config;
 	uint32_t count_max = 0U;
@@ -209,7 +209,7 @@ static int pwm_sifive_get_cycles_per_sec(const struct device *dev,
 /* Device Instantiation */
 
 static const struct pwm_driver_api pwm_sifive_api = {
-	.pin_set = pwm_sifive_pin_set,
+	.set_cycles = pwm_sifive_set_cycles,
 	.get_cycles_per_sec = pwm_sifive_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -231,9 +231,9 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 	return 0;
 }
 
-static int pwm_stm32_pin_set(const struct device *dev, uint32_t channel,
-			     uint32_t period_cycles, uint32_t pulse_cycles,
-			     pwm_flags_t flags)
+static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
+				uint32_t period_cycles, uint32_t pulse_cycles,
+				pwm_flags_t flags)
 {
 	const struct pwm_stm32_config *cfg = dev->config;
 
@@ -395,9 +395,10 @@ static int init_capture_channel(const struct device *dev, uint32_t channel,
 	return 0;
 }
 
-static int pwm_stm32_pin_configure_capture(
-	const struct device *dev, uint32_t channel, pwm_flags_t flags,
-	pwm_capture_callback_handler_t cb, void *user_data)
+static int pwm_stm32_configure_capture(const struct device *dev,
+				       uint32_t channel, pwm_flags_t flags,
+				       pwm_capture_callback_handler_t cb,
+				       void *user_data)
 {
 
 	/*
@@ -470,8 +471,7 @@ static int pwm_stm32_pin_configure_capture(
 	return 0;
 }
 
-static int pwm_stm32_pin_enable_capture(const struct device *dev,
-					uint32_t channel)
+static int pwm_stm32_enable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct pwm_stm32_config *cfg = dev->config;
 	struct pwm_stm32_data *data = dev->data;
@@ -511,8 +511,7 @@ static int pwm_stm32_pin_enable_capture(const struct device *dev,
 	return 0;
 }
 
-static int pwm_stm32_pin_disable_capture(const struct device *dev,
-					 uint32_t channel)
+static int pwm_stm32_disable_capture(const struct device *dev, uint32_t channel)
 {
 	const struct pwm_stm32_config *cfg = dev->config;
 
@@ -576,7 +575,7 @@ static void pwm_stm32_isr(const struct device *dev)
 			}
 
 			if (!cpt->continuous) {
-				pwm_stm32_pin_disable_capture(dev, in_ch);
+				pwm_stm32_disable_capture(dev, in_ch);
 			} else {
 				cpt->overflows = 0u;
 			}
@@ -615,12 +614,12 @@ static int pwm_stm32_get_cycles_per_sec(const struct device *dev,
 }
 
 static const struct pwm_driver_api pwm_stm32_driver_api = {
-	.pin_set = pwm_stm32_pin_set,
+	.set_cycles = pwm_stm32_set_cycles,
 	.get_cycles_per_sec = pwm_stm32_get_cycles_per_sec,
 #ifdef CONFIG_PWM_CAPTURE
-	.pin_configure_capture = pwm_stm32_pin_configure_capture,
-	.pin_enable_capture = pwm_stm32_pin_enable_capture,
-	.pin_disable_capture = pwm_stm32_pin_disable_capture,
+	.configure_capture = pwm_stm32_configure_capture,
+	.enable_capture = pwm_stm32_enable_capture,
+	.disable_capture = pwm_stm32_disable_capture,
 #endif /* CONFIG_PWM_CAPTURE */
 };
 

--- a/drivers/pwm/pwm_test.c
+++ b/drivers/pwm/pwm_test.c
@@ -15,30 +15,28 @@
 
 #define DT_DRV_COMPAT vnd_pwm
 
-static int vnd_pwm_pin_set(const struct device *dev, uint32_t channel,
-			   uint32_t period_cycles, uint32_t pulse_cycles,
-			   pwm_flags_t flags)
+static int vnd_pwm_set_cycles(const struct device *dev, uint32_t channel,
+			      uint32_t period_cycles, uint32_t pulse_cycles,
+			      pwm_flags_t flags)
 {
 	return -ENOTSUP;
 }
 
 #ifdef CONFIG_PWM_CAPTURE
-static int vnd_pwm_pin_configure_capture(const struct device *dev,
-					 uint32_t channel, pwm_flags_t flags,
-					 pwm_capture_callback_handler_t cb,
-					 void *user_data)
+static int vnd_pwm_configure_capture(const struct device *dev, uint32_t channel,
+				     pwm_flags_t flags,
+				     pwm_capture_callback_handler_t cb,
+				     void *user_data)
 {
 	return -ENOTSUP;
 }
 
-static int vnd_pwm_pin_enable_capture(const struct device *dev,
-				      uint32_t channel)
+static int vnd_pwm_enable_capture(const struct device *dev, uint32_t channel)
 {
 	return -ENOTSUP;
 }
 
-static int vnd_pwm_pin_disable_capture(const struct device *dev,
-				       uint32_t channel)
+static int vnd_pwm_disable_capture(const struct device *dev, uint32_t channel)
 {
 	return -ENOTSUP;
 }
@@ -51,11 +49,11 @@ static int vnd_pwm_get_cycles_per_sec(const struct device *dev,
 }
 
 static const struct pwm_driver_api vnd_pwm_api = {
-	.pin_set = vnd_pwm_pin_set,
+	.set_cycles = vnd_pwm_set_cycles,
 #ifdef CONFIG_PWM_CAPTURE
-	.pin_configure_capture = vnd_pwm_pin_configure_capture,
-	.pin_enable_capture = vnd_pwm_pin_enable_capture,
-	.pin_disable_capture = vnd_pwm_pin_disable_capture,
+	.configure_capture = vnd_pwm_configure_capture,
+	.enable_capture = vnd_pwm_enable_capture,
+	.disable_capture = vnd_pwm_disable_capture,
 #endif /* CONFIG_PWM_CAPTURE */
 	.get_cycles_per_sec = vnd_pwm_get_cycles_per_sec,
 };

--- a/drivers/pwm/pwm_test.c
+++ b/drivers/pwm/pwm_test.c
@@ -15,7 +15,7 @@
 
 #define DT_DRV_COMPAT vnd_pwm
 
-static int vnd_pwm_pin_set(const struct device *dev, uint32_t pwm,
+static int vnd_pwm_pin_set(const struct device *dev, uint32_t channel,
 			   uint32_t period_cycles, uint32_t pulse_cycles,
 			   pwm_flags_t flags)
 {
@@ -24,8 +24,7 @@ static int vnd_pwm_pin_set(const struct device *dev, uint32_t pwm,
 
 #ifdef CONFIG_PWM_CAPTURE
 static int vnd_pwm_pin_configure_capture(const struct device *dev,
-					 uint32_t pwm,
-					 pwm_flags_t flags,
+					 uint32_t channel, pwm_flags_t flags,
 					 pwm_capture_callback_handler_t cb,
 					 void *user_data)
 {
@@ -33,21 +32,20 @@ static int vnd_pwm_pin_configure_capture(const struct device *dev,
 }
 
 static int vnd_pwm_pin_enable_capture(const struct device *dev,
-				      uint32_t pwm)
+				      uint32_t channel)
 {
 	return -ENOTSUP;
 }
 
 static int vnd_pwm_pin_disable_capture(const struct device *dev,
-				       uint32_t pwm)
+				       uint32_t channel)
 {
 	return -ENOTSUP;
 }
 #endif /* CONFIG_PWM_CAPTURE */
 
 static int vnd_pwm_get_cycles_per_sec(const struct device *dev,
-				      uint32_t pwm,
-				      uint64_t *cycles)
+				      uint32_t channel, uint64_t *cycles)
 {
 	return -ENOTSUP;
 }

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -60,9 +60,9 @@ static inline void xlnx_axi_timer_write32(const struct device *dev,
 	sys_write32(value, config->base + offset);
 }
 
-static int xlnx_axi_timer_pin_set(const struct device *dev, uint32_t channel,
-				  uint32_t period_cycles, uint32_t pulse_cycles,
-				  pwm_flags_t flags)
+static int xlnx_axi_timer_set_cycles(const struct device *dev, uint32_t channel,
+				     uint32_t period_cycles,
+				     uint32_t pulse_cycles, pwm_flags_t flags)
 {
 	const struct xlnx_axi_timer_config *config = dev->config;
 	uint32_t tcsr0 = TCSR_PWM;
@@ -176,7 +176,7 @@ static int xlnx_axi_timer_init(const struct device *dev)
 }
 
 static const struct pwm_driver_api xlnx_axi_timer_driver_api = {
-	.pin_set = xlnx_axi_timer_pin_set,
+	.set_cycles = xlnx_axi_timer_set_cycles,
 	.get_cycles_per_sec = xlnx_axi_timer_get_cycles_per_sec,
 };
 

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -60,7 +60,7 @@ static inline void xlnx_axi_timer_write32(const struct device *dev,
 	sys_write32(value, config->base + offset);
 }
 
-static int xlnx_axi_timer_pin_set(const struct device *dev, uint32_t pwm,
+static int xlnx_axi_timer_pin_set(const struct device *dev, uint32_t channel,
 				  uint32_t period_cycles, uint32_t pulse_cycles,
 				  pwm_flags_t flags)
 {
@@ -70,7 +70,7 @@ static int xlnx_axi_timer_pin_set(const struct device *dev, uint32_t pwm,
 	uint32_t tlr0;
 	uint32_t tlr1;
 
-	if (pwm != 0) {
+	if (channel != 0) {
 		return -ENOTSUP;
 	}
 
@@ -159,11 +159,11 @@ static int xlnx_axi_timer_pin_set(const struct device *dev, uint32_t pwm,
 }
 
 static int xlnx_axi_timer_get_cycles_per_sec(const struct device *dev,
-					     uint32_t pwm, uint64_t *cycles)
+					     uint32_t channel, uint64_t *cycles)
 {
 	const struct xlnx_axi_timer_config *config = dev->config;
 
-	ARG_UNUSED(pwm);
+	ARG_UNUSED(channel);
 
 	*cycles = config->freq;
 

--- a/include/zephyr/dt-bindings/pwm/pwm.h
+++ b/include/zephyr/dt-bindings/pwm/pwm.h
@@ -26,9 +26,8 @@
 
 /**
  * @name PWM polarity flags
- * The `PWM_POLARITY_*` flags are used with pwm_set_cycles(), pwm_set_usec(),
- * pwm_set_nsec() or pwm_configure_capture() to specify the polarity of a PWM
- * channel.
+ * The `PWM_POLARITY_*` flags are used with pwm_set_cycles(), pwm_set()
+ * or pwm_configure_capture() to specify the polarity of a PWM channel.
  *
  * The flags are on the lower 8bits of the pwm_flags_t
  * @{

--- a/include/zephyr/dt-bindings/pwm/pwm.h
+++ b/include/zephyr/dt-bindings/pwm/pwm.h
@@ -26,9 +26,10 @@
 
 /**
  * @name PWM polarity flags
- * The `PWM_POLARITY_*` flags are used with pwm_pin_set_cycles(),
- * pwm_pin_set_usec(), pwm_pin_set_nsec() or pwm_pin_configure_capture() to
- * specify the polarity of a PWM pin.
+ * The `PWM_POLARITY_*` flags are used with pwm_set_cycles(), pwm_set_usec(),
+ * pwm_set_nsec() or pwm_configure_capture() to specify the polarity of a PWM
+ * channel.
+ *
  * The flags are on the lower 8bits of the pwm_flags_t
  * @{
  */

--- a/samples/basic/blinky_pwm/README.rst
+++ b/samples/basic/blinky_pwm/README.rst
@@ -28,13 +28,6 @@ controlling this LED must be configured using the ``pwm_led0`` :ref:`devicetree
 <dt-guide>` alias, usually in the :ref:`BOARD.dts file
 <devicetree-in-out-files>`.
 
-You will see this error if you try to build this sample for an unsupported
-board:
-
-.. code-block:: none
-
-   Unsupported board: pwm_led0 devicetree alias is not defined
-
 Wiring
 ******
 

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -14,25 +14,13 @@
 #include <device.h>
 #include <drivers/pwm.h>
 
-#define PWM_LED0_NODE	DT_ALIAS(pwm_led0)
+static const struct pwm_dt_spec pwm_led0 = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
 
-#if DT_NODE_HAS_STATUS(PWM_LED0_NODE, okay)
-#define PWM_CTLR	DT_PWMS_CTLR(PWM_LED0_NODE)
-#define PWM_CHANNEL	DT_PWMS_CHANNEL(PWM_LED0_NODE)
-#define PWM_FLAGS	DT_PWMS_FLAGS(PWM_LED0_NODE)
-#else
-#error "Unsupported board: pwm-led0 devicetree alias is not defined"
-#define PWM_CTLR	DT_INVALID_NODE
-#define PWM_CHANNEL	0
-#define PWM_FLAGS	0
-#endif
-
-#define MIN_PERIOD_USEC	(USEC_PER_SEC / 128U)
-#define MAX_PERIOD_USEC	USEC_PER_SEC
+#define MIN_PERIOD PWM_SEC(1U) / 128U
+#define MAX_PERIOD PWM_SEC(1U)
 
 void main(void)
 {
-	const struct device *pwm;
 	uint32_t max_period;
 	uint32_t period;
 	uint8_t dir = 0U;
@@ -40,39 +28,37 @@ void main(void)
 
 	printk("PWM-based blinky\n");
 
-	pwm = DEVICE_DT_GET(PWM_CTLR);
-	if (!device_is_ready(pwm)) {
-		printk("Error: PWM device %s is not ready\n", pwm->name);
+	if (!device_is_ready(pwm_led0.dev)) {
+		printk("Error: PWM device %s is not ready\n",
+		       pwm_led0.dev->name);
 		return;
 	}
 
 	/*
-	 * In case the default MAX_PERIOD_USEC value cannot be set for
+	 * In case the default MAX_PERIOD value cannot be set for
 	 * some PWM hardware, decrease its value until it can.
 	 *
-	 * Keep its value at least MIN_PERIOD_USEC * 4 to make sure
+	 * Keep its value at least MIN_PERIOD * 4 to make sure
 	 * the sample changes frequency at least once.
 	 */
-	printk("Calibrating for channel %d...\n", PWM_CHANNEL);
-	max_period = MAX_PERIOD_USEC;
-	while (pwm_set_usec(pwm, PWM_CHANNEL, max_period, max_period / 2U,
-			    PWM_FLAGS)) {
+	printk("Calibrating for channel %d...\n", pwm_led0.channel);
+	max_period = MAX_PERIOD;
+	while (pwm_set_nsec_dt(&pwm_led0, max_period, max_period / 2U)) {
 		max_period /= 2U;
-		if (max_period < (4U * MIN_PERIOD_USEC)) {
+		if (max_period < (4U * MIN_PERIOD)) {
 			printk("Error: PWM device "
-			       "does not support a period at least %u\n",
-			       4U * MIN_PERIOD_USEC);
+			       "does not support a period at least %lu\n",
+			       4U * MIN_PERIOD);
 			return;
 		}
 	}
 
-	printk("Done calibrating; maximum/minimum periods %u/%u usec\n",
-	       max_period, MIN_PERIOD_USEC);
+	printk("Done calibrating; maximum/minimum periods %u/%lu usec\n",
+	       max_period, MIN_PERIOD);
 
 	period = max_period;
 	while (1) {
-		ret = pwm_set_usec(pwm, PWM_CHANNEL, period, period / 2U,
-				   PWM_FLAGS);
+		ret = pwm_set_nsec_dt(&pwm_led0, period, period / 2U);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;
@@ -82,8 +68,8 @@ void main(void)
 		if (period > max_period) {
 			period = max_period / 2U;
 			dir = 0U;
-		} else if (period < MIN_PERIOD_USEC) {
-			period = MIN_PERIOD_USEC * 2U;
+		} else if (period < MIN_PERIOD) {
+			period = MIN_PERIOD * 2U;
 			dir = 1U;
 		}
 

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -55,8 +55,8 @@ void main(void)
 	 */
 	printk("Calibrating for channel %d...\n", PWM_CHANNEL);
 	max_period = MAX_PERIOD_USEC;
-	while (pwm_pin_set_usec(pwm, PWM_CHANNEL,
-				max_period, max_period / 2U, PWM_FLAGS)) {
+	while (pwm_set_usec(pwm, PWM_CHANNEL, max_period, max_period / 2U,
+			    PWM_FLAGS)) {
 		max_period /= 2U;
 		if (max_period < (4U * MIN_PERIOD_USEC)) {
 			printk("Error: PWM device "
@@ -71,8 +71,8 @@ void main(void)
 
 	period = max_period;
 	while (1) {
-		ret = pwm_pin_set_usec(pwm, PWM_CHANNEL,
-				       period, period / 2U, PWM_FLAGS);
+		ret = pwm_set_usec(pwm, PWM_CHANNEL, period, period / 2U,
+				   PWM_FLAGS);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -43,7 +43,7 @@ void main(void)
 	 */
 	printk("Calibrating for channel %d...\n", pwm_led0.channel);
 	max_period = MAX_PERIOD;
-	while (pwm_set_nsec_dt(&pwm_led0, max_period, max_period / 2U)) {
+	while (pwm_set_dt(&pwm_led0, max_period, max_period / 2U)) {
 		max_period /= 2U;
 		if (max_period < (4U * MIN_PERIOD)) {
 			printk("Error: PWM device "
@@ -58,7 +58,7 @@ void main(void)
 
 	period = max_period;
 	while (1) {
-		ret = pwm_set_nsec_dt(&pwm_led0, period, period / 2U);
+		ret = pwm_set_dt(&pwm_led0, period, period / 2U);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;

--- a/samples/basic/fade_led/README.rst
+++ b/samples/basic/fade_led/README.rst
@@ -10,7 +10,9 @@ This application "fades" a LED using the :ref:`PWM API <pwm_api>`.
 
 The LED starts off increases its brightness until it is fully or nearly fully
 on. The brightness then decreases until the LED is off, completing on fade
-cycle. Each cycle takes 2.5 seconds, and the cycles repeat forever.
+cycle. Each cycle takes 2.5 seconds, and the cycles repeat forever. The PWM
+period is taken from Devicetree. It should be fast enough to be above the
+flicker fusion threshold.
 
 Requirements and Wiring
 ***********************

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -35,7 +35,7 @@ void main(void)
 	}
 
 	while (1) {
-		ret = pwm_set_nsec_pulse_dt(&pwm_led0, pulse_width);
+		ret = pwm_set_pulse_dt(&pwm_led0, pulse_width);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -53,8 +53,8 @@ void main(void)
 	}
 
 	while (1) {
-		ret = pwm_pin_set_usec(pwm, PWM_CHANNEL, PERIOD_USEC,
-				       pulse_width, PWM_FLAGS);
+		ret = pwm_set_usec(pwm, PWM_CHANNEL, PERIOD_USEC, pulse_width,
+				   PWM_FLAGS);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -14,63 +14,44 @@
 #include <device.h>
 #include <drivers/pwm.h>
 
-#define PWM_LED0_NODE	DT_ALIAS(pwm_led0)
+static const struct pwm_dt_spec pwm_led0 = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
 
-#if DT_NODE_HAS_STATUS(PWM_LED0_NODE, okay)
-#define PWM_CTLR	DT_PWMS_CTLR(PWM_LED0_NODE)
-#define PWM_CHANNEL	DT_PWMS_CHANNEL(PWM_LED0_NODE)
-#define PWM_FLAGS	DT_PWMS_FLAGS(PWM_LED0_NODE)
-#else
-#error "Unsupported board: pwm-led0 devicetree alias is not defined"
-#define PWM_CTLR	DT_INVALID_NODE
-#define PWM_CHANNEL	0
-#define PWM_FLAGS	0
-#endif
-
-/*
- * This period should be fast enough to be above the flicker fusion
- * threshold. The steps should also be small enough, and happen
- * quickly enough, to make the output fade change appear continuous.
- */
-#define PERIOD_USEC	20000U
 #define NUM_STEPS	50U
-#define STEP_USEC	(PERIOD_USEC / NUM_STEPS)
 #define SLEEP_MSEC	25U
 
 void main(void)
 {
-	const struct device *pwm;
 	uint32_t pulse_width = 0U;
+	uint32_t step = pwm_led0.period / NUM_STEPS;
 	uint8_t dir = 1U;
 	int ret;
 
 	printk("PWM-based LED fade\n");
 
-	pwm = DEVICE_DT_GET(PWM_CTLR);
-	if (!device_is_ready(pwm)) {
-		printk("Error: PWM device %s is not ready\n", pwm->name);
+	if (!device_is_ready(pwm_led0.dev)) {
+		printk("Error: PWM device %s is not ready\n",
+		       pwm_led0.dev->name);
 		return;
 	}
 
 	while (1) {
-		ret = pwm_set_usec(pwm, PWM_CHANNEL, PERIOD_USEC, pulse_width,
-				   PWM_FLAGS);
+		ret = pwm_set_nsec_pulse_dt(&pwm_led0, pulse_width);
 		if (ret) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;
 		}
 
 		if (dir) {
-			pulse_width += STEP_USEC;
-			if (pulse_width >= PERIOD_USEC) {
-				pulse_width = PERIOD_USEC - STEP_USEC;
+			pulse_width += step;
+			if (pulse_width >= pwm_led0.period) {
+				pulse_width = pwm_led0.period - step;
 				dir = 0U;
 			}
 		} else {
-			if (pulse_width >= STEP_USEC) {
-				pulse_width -= STEP_USEC;
+			if (pulse_width >= step) {
+				pulse_width -= step;
 			} else {
-				pulse_width = STEP_USEC;
+				pulse_width = step;
 				dir = 1U;
 			}
 		}

--- a/samples/basic/rgb_led/README.rst
+++ b/samples/basic/rgb_led/README.rst
@@ -9,11 +9,12 @@ Overview
 This is a sample app which drives an RGB LED using PWM.
 
 There are three single-color component LEDs in an RGB LED. Each component LED
-is driven by a PWM port where the pulse width is changed from zero to a fusion
-flicker threshold (the minimum flicker rate where the LED is perceived as being
-steady), causing each component LED to step from dark to max brightness. Three
-**for** loops (one for each component LED) generate a gradual range of color
-changes from the RGB LED, and the sample repeats forever.
+is driven by a PWM port where the pulse width is changed from zero to the period
+indicated in Devicetree. Such period should be fast enough to be above the
+flicker fusion threshold (the minimum flicker rate where the LED is perceived as
+being steady). The sample causes each LED component to step from dark to max
+brightness. Three **for** loops (one for each component LED) generate a gradual
+range of color changes from the RGB LED, and the sample repeats forever.
 
 Requirements
 ************

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -39,7 +39,7 @@ void main(void)
 	while (1) {
 		for (pulse_red = 0U; pulse_red <= red_pwm_led.period;
 		     pulse_red += STEP_SIZE) {
-			ret = pwm_set_nsec_pulse_dt(&red_pwm_led, pulse_red);
+			ret = pwm_set_pulse_dt(&red_pwm_led, pulse_red);
 			if (ret != 0) {
 				printk("Error %d: red write failed\n", ret);
 				return;
@@ -48,8 +48,8 @@ void main(void)
 			for (pulse_green = 0U;
 			     pulse_green <= green_pwm_led.period;
 			     pulse_green += STEP_SIZE) {
-				ret = pwm_set_nsec_pulse_dt(&green_pwm_led,
-							    pulse_green);
+				ret = pwm_set_pulse_dt(&green_pwm_led,
+						       pulse_green);
 				if (ret != 0) {
 					printk("Error %d: green write failed\n",
 					       ret);
@@ -59,8 +59,8 @@ void main(void)
 				for (pulse_blue = 0U;
 				     pulse_blue <= blue_pwm_led.period;
 				     pulse_blue += STEP_SIZE) {
-					ret = pwm_set_nsec_pulse_dt(
-						&blue_pwm_led, pulse_blue);
+					ret = pwm_set_pulse_dt(&blue_pwm_led,
+							       pulse_blue);
 					if (ret != 0) {
 						printk("Error %d: "
 						       "blue write failed\n",

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -64,8 +64,7 @@
 static int pwm_set(const struct device *pwm_dev, uint32_t pwm_pin,
 		     uint32_t pulse_width, pwm_flags_t flags)
 {
-	return pwm_pin_set_usec(pwm_dev, pwm_pin, PERIOD_USEC,
-				pulse_width, flags);
+	return pwm_set_usec(pwm_dev, pwm_pin, PERIOD_USEC, pulse_width, flags);
 }
 
 enum { RED, GREEN, BLUE };

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -13,118 +13,54 @@
 #include <device.h>
 #include <drivers/pwm.h>
 
-/*
- * Extract devicetree configuration.
- */
+static const struct pwm_dt_spec red_pwm_led =
+	PWM_DT_SPEC_GET(DT_ALIAS(red_pwm_led));
+static const struct pwm_dt_spec green_pwm_led =
+	PWM_DT_SPEC_GET(DT_ALIAS(green_pwm_led));
+static const struct pwm_dt_spec blue_pwm_led =
+	PWM_DT_SPEC_GET(DT_ALIAS(blue_pwm_led));
 
-#define RED_NODE DT_ALIAS(red_pwm_led)
-#define GREEN_NODE DT_ALIAS(green_pwm_led)
-#define BLUE_NODE DT_ALIAS(blue_pwm_led)
-
-#if DT_NODE_HAS_STATUS(RED_NODE, okay)
-#define RED_CTLR_NODE	DT_PWMS_CTLR(RED_NODE)
-#define RED_CHANNEL	DT_PWMS_CHANNEL(RED_NODE)
-#define RED_FLAGS	DT_PWMS_FLAGS(RED_NODE)
-#else
-#error "Unsupported board: red-pwm-led devicetree alias is not defined"
-#define RED_CTLR_NODE	DT_INVALID_NODE
-#define RED_CHANNEL	0
-#define RED_FLAGS	0
-#endif
-
-#if DT_NODE_HAS_STATUS(GREEN_NODE, okay)
-#define GREEN_CTLR_NODE	DT_PWMS_CTLR(GREEN_NODE)
-#define GREEN_CHANNEL	DT_PWMS_CHANNEL(GREEN_NODE)
-#define GREEN_FLAGS	DT_PWMS_FLAGS(GREEN_NODE)
-#else
-#error "Unsupported board: green-pwm-led devicetree alias is not defined"
-#define GREEN_CTLR_NODE	DT_INVALID_NODE
-#define GREEN_CHANNEL	0
-#define GREEN_FLAGS	0
-#endif
-
-#if DT_NODE_HAS_STATUS(BLUE_NODE, okay)
-#define BLUE_CTLR_NODE	DT_PWMS_CTLR(BLUE_NODE)
-#define BLUE_CHANNEL	DT_PWMS_CHANNEL(BLUE_NODE)
-#define BLUE_FLAGS	DT_PWMS_FLAGS(BLUE_NODE)
-#else
-#error "Unsupported board: blue-pwm-led devicetree alias is not defined"
-#define BLUE_CTLR_NODE	DT_INVALID_NODE
-#define BLUE_CHANNEL	0
-#define BLUE_FLAGS	0
-#endif
-
-/*
- * 50 is flicker fusion threshold. Modulated light will be perceived
- * as steady by our eyes when blinking rate is at least 50.
- */
-#define PERIOD_USEC	(USEC_PER_SEC / 50U)
-#define STEPSIZE_USEC	2000
-
-static int pwm_set(const struct device *pwm_dev, uint32_t pwm_pin,
-		     uint32_t pulse_width, pwm_flags_t flags)
-{
-	return pwm_set_usec(pwm_dev, pwm_pin, PERIOD_USEC, pulse_width, flags);
-}
-
-enum { RED, GREEN, BLUE };
+#define STEP_SIZE PWM_USEC(2000)
 
 void main(void)
 {
-	const struct device *pwm_dev[3];
 	uint32_t pulse_red, pulse_green, pulse_blue; /* pulse widths */
 	int ret;
 
 	printk("PWM-based RGB LED control\n");
 
-	pwm_dev[RED] = DEVICE_DT_GET(RED_CTLR_NODE);
-	pwm_dev[GREEN] = DEVICE_DT_GET(GREEN_CTLR_NODE);
-	pwm_dev[BLUE] = DEVICE_DT_GET(BLUE_CTLR_NODE);
-
-	if (!device_is_ready(pwm_dev[RED])) {
-		printk("Error: red PWM device %s is not ready\n", pwm_dev[RED]->name);
-		return;
-	}
-
-	if (!device_is_ready(pwm_dev[GREEN])) {
-		printk("Error: green PWM device %s is not ready\n", pwm_dev[GREEN]->name);
-		return;
-	}
-
-	if (!device_is_ready(pwm_dev[BLUE])) {
-		printk("Error: blue PWM device %s is not ready\n", pwm_dev[BLUE]->name);
+	if (!device_is_ready(red_pwm_led.dev) ||
+	    !device_is_ready(green_pwm_led.dev) ||
+	    !device_is_ready(blue_pwm_led.dev)) {
+		printk("Error: one or more PWM devices not ready\n");
 		return;
 	}
 
 	while (1) {
-		for (pulse_red = 0U; pulse_red <= PERIOD_USEC;
-		     pulse_red += STEPSIZE_USEC) {
-			ret = pwm_set(pwm_dev[RED], RED_CHANNEL,
-				      pulse_red, RED_FLAGS);
+		for (pulse_red = 0U; pulse_red <= red_pwm_led.period;
+		     pulse_red += STEP_SIZE) {
+			ret = pwm_set_nsec_pulse_dt(&red_pwm_led, pulse_red);
 			if (ret != 0) {
-				printk("Error %d: "
-				       "red write failed\n",
-				       ret);
+				printk("Error %d: red write failed\n", ret);
 				return;
 			}
 
-			for (pulse_green = 0U; pulse_green <= PERIOD_USEC;
-			     pulse_green += STEPSIZE_USEC) {
-				ret = pwm_set(pwm_dev[GREEN], GREEN_CHANNEL,
-					      pulse_green, GREEN_FLAGS);
+			for (pulse_green = 0U;
+			     pulse_green <= green_pwm_led.period;
+			     pulse_green += STEP_SIZE) {
+				ret = pwm_set_nsec_pulse_dt(&green_pwm_led,
+							    pulse_green);
 				if (ret != 0) {
-					printk("Error %d: "
-					       "green write failed\n",
+					printk("Error %d: green write failed\n",
 					       ret);
 					return;
 				}
 
-				for (pulse_blue = 0U; pulse_blue <= PERIOD_USEC;
-				     pulse_blue += STEPSIZE_USEC) {
-					ret = pwm_set(pwm_dev[BLUE],
-						      BLUE_CHANNEL,
-						      pulse_blue,
-						      BLUE_FLAGS);
+				for (pulse_blue = 0U;
+				     pulse_blue <= blue_pwm_led.period;
+				     pulse_blue += STEP_SIZE) {
+					ret = pwm_set_nsec_pulse_dt(
+						&blue_pwm_led, pulse_blue);
 					if (ret != 0) {
 						printk("Error %d: "
 						       "blue write failed\n",

--- a/samples/basic/servo_motor/README.rst
+++ b/samples/basic/servo_motor/README.rst
@@ -19,29 +19,24 @@ to modify the source code if you are using a different servomotor.
 Requirements
 ************
 
-You will see this error if you try to build this sample for an unsupported
-board:
+The sample requires a servomotor whose signal pin is connected to a pin driven
+by PWM. The servo must be defined in Devicetree using the ``pwm-servo``
+compatible (part of the sample) and setting its node label to ``servo``. You
+will need to do something like this:
 
-.. code-block:: none
-
-   Unsupported board: pwm-servo devicetree alias is not defined
-
-The sample requires a servomotor whose signal pin is connected to a PWM
-device's channel 0. The PWM device must be configured using the ``pwm-servo``
-:ref:`devicetree <dt-guide>` alias. Usually you will need to set this up via a
-:ref:`devicetree overlay <set-devicetree-overlays>` like so:
-
-.. code-block:: DTS
+.. code-block:: devicetree
 
    / {
-   	aliases {
-   		pwm-servo = &some_pwm_node;
-   	};
+       servo: servo {
+           compatible = "pwm-servo";
+           pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+           min-pulse = <PWM_USEC(700)>;
+           max-pulse = <PWM_USEC(2500)>;
+       };
    };
 
-Where ``some_pwm_node`` is the node label of a PWM device in your system.
-
-See :zephyr_file:`samples/basic/servo_motor/boards/bbc_microbit.overlay` for an
+Note that a commonly used period value is 20 ms. See
+:zephyr_file:`samples/basic/servo_motor/boards/bbc_microbit.overlay` for an
 example.
 
 Wiring

--- a/samples/basic/servo_motor/boards/bbc_microbit.overlay
+++ b/samples/basic/servo_motor/boards/bbc_microbit.overlay
@@ -1,7 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 / {
-	aliases {
-		pwm-servo = &sw_pwm;
+	servo: servo {
+		compatible = "pwm-servo";
+		pwms = <&sw_pwm 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+		min-pulse = <PWM_USEC(700)>;
+		max-pulse = <PWM_USEC(2500)>;
 	};
 };
 

--- a/samples/basic/servo_motor/dts/bindings/pwm-servo.yaml
+++ b/samples/basic/servo_motor/dts/bindings/pwm-servo.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: PWM-driven servo motor.
+
+compatible: "pwm-servo"
+
+include: base.yaml
+
+properties:
+    pwms:
+      required: true
+      type: phandle-array
+      description: PWM specifier driving the servo motor.
+
+    min-pulse:
+      required: true
+      type: int
+      description: Minimum pulse width (nanoseconds).
+
+    max-pulse:
+      required: true
+      type: int
+      description: Maximum pulse width (nanoseconds).

--- a/samples/basic/servo_motor/sample.yaml
+++ b/samples/basic/servo_motor/sample.yaml
@@ -5,4 +5,4 @@ tests:
     tags: drivers pwm
     depends_on: pwm
     harness: motor
-    platform_allow: bbc_microbit
+    filter: dt_compat_enabled("pwm-servo")

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -13,20 +13,11 @@
 #include <device.h>
 #include <drivers/pwm.h>
 
-#define PWM_NODE DT_ALIAS(pwm_servo)
+static const struct pwm_dt_spec servo = PWM_DT_SPEC_GET(DT_NODELABEL(servo));
+static const uint32_t min_pulse = DT_PROP(DT_NODELABEL(servo), min_pulse);
+static const uint32_t max_pulse = DT_PROP(DT_NODELABEL(servo), max_pulse);
 
-#if !DT_NODE_HAS_STATUS(PWM_NODE, okay)
-#error "Unsupported board: pwm-servo devicetree alias is not defined or enabled"
-#endif
-
-/*
- * Unlike pulse width, the PWM period is not a critical parameter for
- * motor control. 20 ms is commonly used.
- */
-#define PERIOD_USEC	(20U * USEC_PER_MSEC)
-#define STEP_USEC	100
-#define MIN_PULSE_USEC	700
-#define MAX_PULSE_USEC	2300
+#define STEP PWM_USEC(100)
 
 enum direction {
 	DOWN,
@@ -35,39 +26,37 @@ enum direction {
 
 void main(void)
 {
-	const struct device *pwm;
-	uint32_t pulse_width = MIN_PULSE_USEC;
+	uint32_t pulse_width = min_pulse;
 	enum direction dir = UP;
 	int ret;
 
 	printk("Servomotor control\n");
 
-	pwm = DEVICE_DT_GET(PWM_NODE);
-	if (!device_is_ready(pwm)) {
-		printk("Error: PWM device %s is not ready\n", pwm->name);
+	if (!device_is_ready(servo.dev)) {
+		printk("Error: PWM device %s is not ready\n", servo.dev->name);
 		return;
 	}
 
 	while (1) {
-		ret = pwm_set_usec(pwm, 0, PERIOD_USEC, pulse_width, 0);
+		ret = pwm_set_nsec_pulse_dt(&servo, pulse_width);
 		if (ret < 0) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;
 		}
 
 		if (dir == DOWN) {
-			if (pulse_width <= MIN_PULSE_USEC) {
+			if (pulse_width <= min_pulse) {
 				dir = UP;
-				pulse_width = MIN_PULSE_USEC;
+				pulse_width = min_pulse;
 			} else {
-				pulse_width -= STEP_USEC;
+				pulse_width -= STEP;
 			}
 		} else {
-			pulse_width += STEP_USEC;
+			pulse_width += STEP;
 
-			if (pulse_width >= MAX_PULSE_USEC) {
+			if (pulse_width >= max_pulse) {
 				dir = DOWN;
-				pulse_width = MAX_PULSE_USEC;
+				pulse_width = max_pulse;
 			}
 		}
 

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -38,7 +38,7 @@ void main(void)
 	}
 
 	while (1) {
-		ret = pwm_set_nsec_pulse_dt(&servo, pulse_width);
+		ret = pwm_set_pulse_dt(&servo, pulse_width);
 		if (ret < 0) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -49,7 +49,7 @@ void main(void)
 	}
 
 	while (1) {
-		ret = pwm_pin_set_usec(pwm, 0, PERIOD_USEC, pulse_width, 0);
+		ret = pwm_set_usec(pwm, 0, PERIOD_USEC, pulse_width, 0);
 		if (ret < 0) {
 			printk("Error %d: failed to set pulse width\n", ret);
 			return;

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -129,14 +129,13 @@ void board_play_tune(const char *str)
 		}
 
 		if (period) {
-			pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL,
-					 period, period / 2U, 0);
+			pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, period, period / 2U, 0);
 		}
 
 		k_sleep(K_MSEC(duration));
 
 		/* Disable the PWM */
-		pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
+		pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
 	}
 }
 

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -129,13 +129,14 @@ void board_play_tune(const char *str)
 		}
 
 		if (period) {
-			pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, period, period / 2U, 0);
+			pwm_set(pwm, BUZZER_PWM_CHANNEL, PWM_USEC(period),
+				PWM_USEC(period) / 2U, 0);
 		}
 
 		k_sleep(K_MSEC(duration));
 
 		/* Disable the PWM */
-		pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
+		pwm_set(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
 	}
 }
 

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -120,7 +120,7 @@ static enum sound_state {
 
 static inline void beep(int period)
 {
-	pwm_set_usec(pwm, SOUND_PWM_CHANNEL, period, period / 2, 0);
+	pwm_set(pwm, SOUND_PWM_CHANNEL, PWM_USEC(period), PWM_USEC(period) / 2, 0);
 }
 
 static void sound_set(enum sound_state state)

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -120,7 +120,7 @@ static enum sound_state {
 
 static inline void beep(int period)
 {
-	pwm_pin_set_usec(pwm, SOUND_PWM_CHANNEL, period, period / 2, 0);
+	pwm_set_usec(pwm, SOUND_PWM_CHANNEL, period, period / 2, 0);
 }
 
 static void sound_set(enum sound_state state)

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -33,11 +33,11 @@ static void beep(struct k_work *work)
 	/* The "period / 2" pulse duration gives 50% duty cycle, which
 	 * should result in the maximum sound volume.
 	 */
-	pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, period, period / 2U, 0);
+	pwm_set(pwm, BUZZER_PWM_CHANNEL, PWM_USEC(period), PWM_USEC(period) / 2U, 0);
 	k_sleep(BEEP_DURATION);
 
 	/* Disable the PWM */
-	pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
+	pwm_set(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
 
 	/* Ensure there's a clear silent period between two tones */
 	k_sleep(K_MSEC(50));

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -33,11 +33,11 @@ static void beep(struct k_work *work)
 	/* The "period / 2" pulse duration gives 50% duty cycle, which
 	 * should result in the maximum sound volume.
 	 */
-	pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL, period, period / 2U, 0);
+	pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, period, period / 2U, 0);
 	k_sleep(BEEP_DURATION);
 
 	/* Disable the PWM */
-	pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
+	pwm_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
 
 	/* Ensure there's a clear silent period between two tones */
 	k_sleep(K_MSEC(50));

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -12,8 +12,7 @@
  * @details
  * - Test Steps
  *   -# Bind PWM_0 port 0.
- *   -# Set PWM period and pulse using pwm_set_cycles(),
- *	pwm_set_usec(), or pwm_set_nsec().
+ *   -# Set PWM period and pulse using pwm_set_cycles() or pwm_set().
  *   -# Use multimeter or other instruments to measure the output
  *	from PWM_OUT_0.
  * - Expected Results
@@ -121,15 +120,9 @@ static int test_task(uint32_t port, uint32_t period, uint32_t pulse, uint8_t uni
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}
-	} else if (unit == UNIT_USECS) {
-		/* Verify pwm_set_usec() */
-		if (pwm_set_usec(pwm_dev, port, period, pulse, 0)) {
-			TC_PRINT("Fail to set the period and pulse width\n");
-			return TC_FAIL;
-		}
 	} else { /* unit == UNIT_NSECS */
-		/* Verify pwm_set_nsec() */
-		if (pwm_set_nsec(pwm_dev, port, period, pulse, 0)) {
+		/* Verify pwm_set() */
+		if (pwm_set(pwm_dev, port, period, pulse, 0)) {
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -12,8 +12,8 @@
  * @details
  * - Test Steps
  *   -# Bind PWM_0 port 0.
- *   -# Set PWM period and pulse using pwm_pin_set_cycles(),
- *	pwm_pin_set_usec(), or pwm_pin_set_nsec().
+ *   -# Set PWM period and pulse using pwm_set_cycles(),
+ *	pwm_set_usec(), or pwm_set_nsec().
  *   -# Use multimeter or other instruments to measure the output
  *	from PWM_OUT_0.
  * - Expected Results
@@ -116,20 +116,20 @@ static int test_task(uint32_t port, uint32_t period, uint32_t pulse, uint8_t uni
 	}
 
 	if (unit == UNIT_CYCLES) {
-		/* Verify pwm_pin_set_cycles() */
-		if (pwm_pin_set_cycles(pwm_dev, port, period, pulse, 0)) {
+		/* Verify pwm_set_cycles() */
+		if (pwm_set_cycles(pwm_dev, port, period, pulse, 0)) {
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}
 	} else if (unit == UNIT_USECS) {
-		/* Verify pwm_pin_set_usec() */
-		if (pwm_pin_set_usec(pwm_dev, port, period, pulse, 0)) {
+		/* Verify pwm_set_usec() */
+		if (pwm_set_usec(pwm_dev, port, period, pulse, 0)) {
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}
 	} else { /* unit == UNIT_NSECS */
-		/* Verify pwm_pin_set_nsec() */
-		if (pwm_pin_set_nsec(pwm_dev, port, period, pulse, 0)) {
+		/* Verify pwm_set_nsec() */
+		if (pwm_set_nsec(pwm_dev, port, period, pulse, 0)) {
 			TC_PRINT("Fail to set the period and pulse width\n");
 			return TC_FAIL;
 		}

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -50,17 +50,17 @@ void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit unit,
 	case TEST_PWM_UNIT_NSEC:
 		TC_PRINT("Testing PWM capture @ %u/%u nsec\n",
 			 pulse, period);
-		err = pwm_pin_set_nsec(out.dev, out.pwm, period,
-				       pulse, out.flags ^=
-				       (flags & PWM_POLARITY_MASK));
+		err = pwm_set_nsec(out.dev, out.pwm, period,
+				   pulse, out.flags ^=
+				   (flags & PWM_POLARITY_MASK));
 		break;
 
 	case TEST_PWM_UNIT_USEC:
 		TC_PRINT("Testing PWM capture @ %u/%u usec\n",
 			 pulse, period);
-		err = pwm_pin_set_usec(out.dev, out.pwm, period,
-				       pulse, out.flags ^=
-				       (flags & PWM_POLARITY_MASK));
+		err = pwm_set_usec(out.dev, out.pwm, period,
+				   pulse, out.flags ^=
+				   (flags & PWM_POLARITY_MASK));
 		break;
 
 	default:
@@ -72,15 +72,13 @@ void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit unit,
 
 	switch (unit) {
 	case TEST_PWM_UNIT_NSEC:
-		err = pwm_pin_capture_nsec(in.dev, in.pwm, flags,
-					   &period_capture, &pulse_capture,
-					   K_NSEC(period * 10));
+		err = pwm_capture_nsec(in.dev, in.pwm, flags, &period_capture,
+				       &pulse_capture, K_NSEC(period * 10));
 		break;
 
 	case TEST_PWM_UNIT_USEC:
-		err = pwm_pin_capture_usec(in.dev, in.pwm, flags,
-					   &period_capture, &pulse_capture,
-					   K_USEC(period * 10));
+		err = pwm_capture_usec(in.dev, in.pwm, flags, &period_capture,
+				       &pulse_capture, K_USEC(period * 10));
 		break;
 
 	default:
@@ -166,18 +164,17 @@ void test_capture_timeout(void)
 
 	get_test_pwms(&out, &in);
 
-	err = pwm_pin_set_cycles(out.dev, out.pwm, 100, 0, out.flags);
+	err = pwm_set_cycles(out.dev, out.pwm, 100, 0, out.flags);
 	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
 
-	err = pwm_pin_capture_cycles(in.dev, in.pwm,
-				     PWM_CAPTURE_TYPE_PULSE,
-				     &period, &pulse, K_MSEC(1000));
+	err = pwm_capture_cycles(in.dev, in.pwm, PWM_CAPTURE_TYPE_PULSE,
+				 &period, &pulse, K_MSEC(1000));
 	if (err == -ENOTSUP) {
 		TC_PRINT("Pulse capture not supported, "
 			 "trying period capture\n");
-		err = pwm_pin_capture_cycles(in.dev, in.pwm,
-					     PWM_CAPTURE_TYPE_PERIOD,
-					     &period, &pulse, K_MSEC(1000));
+		err = pwm_capture_cycles(in.dev, in.pwm,
+					 PWM_CAPTURE_TYPE_PERIOD, &period,
+					 &pulse, K_MSEC(1000));
 	}
 
 	zassert_equal(err, -EAGAIN, "pwm capture did not timeout (err %d)",
@@ -238,42 +235,40 @@ void test_continuous_capture(void)
 	memset(buffer, 0, sizeof(buffer));
 	k_sem_init(&data.sem, 0, 1);
 
-	err = pwm_pin_set_usec(out.dev, out.pwm, period_usec, pulse_usec,
+	err = pwm_set_usec(out.dev, out.pwm, period_usec, pulse_usec,
 			       out.flags);
 	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
 
-	err = pwm_pin_configure_capture(in.dev, in.pwm,
-					in.flags |
-					PWM_CAPTURE_MODE_CONTINUOUS |
-					PWM_CAPTURE_TYPE_PULSE,
-					continuous_capture_callback,
-					&data);
+	err = pwm_configure_capture(in.dev, in.pwm,
+				    in.flags |
+				    PWM_CAPTURE_MODE_CONTINUOUS |
+				    PWM_CAPTURE_TYPE_PULSE,
+				    continuous_capture_callback, &data);
 	if (err == -ENOTSUP) {
 		TC_PRINT("Pulse capture not supported, "
 			 "trying period capture\n");
-		err = pwm_pin_configure_capture(in.dev, in.pwm,
-						in.flags |
-						PWM_CAPTURE_MODE_CONTINUOUS |
-						PWM_CAPTURE_TYPE_PERIOD,
-						continuous_capture_callback,
-						&data);
+		err = pwm_configure_capture(in.dev, in.pwm,
+					    in.flags |
+					    PWM_CAPTURE_MODE_CONTINUOUS |
+					    PWM_CAPTURE_TYPE_PERIOD,
+					    continuous_capture_callback, &data);
 		zassert_equal(err, 0, "failed to configure pwm input (err %d)",
 			      err);
 		data.pulse_capture = false;
 	}
 
-	err = pwm_pin_enable_capture(in.dev, in.pwm);
+	err = pwm_enable_capture(in.dev, in.pwm);
 	zassert_equal(err, 0, "failed to enable pwm capture (err %d)", err);
 
 	err = k_sem_take(&data.sem, K_USEC(period_usec * data.buffer_len * 10));
 	zassert_equal(err, 0, "pwm capture timed out (err %d)", err);
 	zassert_equal(data.status, 0, "pwm capture failed (err %d)", err);
 
-	err = pwm_pin_disable_capture(in.dev, in.pwm);
+	err = pwm_disable_capture(in.dev, in.pwm);
 	zassert_equal(err, 0, "failed to disable pwm capture (err %d)", err);
 
 	for (i = 0; i < data.buffer_len; i++) {
-		err = pwm_pin_cycles_to_usec(in.dev, in.pwm, buffer[i], &usec);
+		err = pwm_cycles_to_usec(in.dev, in.pwm, buffer[i], &usec);
 		zassert_equal(err, 0, "failed to calculate usec (err %d)", err);
 
 		if (data.pulse_capture) {
@@ -306,38 +301,32 @@ void test_capture_busy(void)
 	memset(buffer, 0, sizeof(buffer));
 	k_sem_init(&data.sem, 0, 1);
 
-	err = pwm_pin_set_cycles(out.dev, out.pwm, 100, 0, out.flags);
+	err = pwm_set_cycles(out.dev, out.pwm, 100, 0, out.flags);
 	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
 
-	err = pwm_pin_configure_capture(in.dev, in.pwm,
-					in.flags | flags,
-					continuous_capture_callback,
-					&data);
+	err = pwm_configure_capture(in.dev, in.pwm, in.flags | flags,
+				    continuous_capture_callback, &data);
 	if (err == -ENOTSUP) {
 		TC_PRINT("Pulse capture not supported, "
 			 "trying period capture\n");
 		flags = PWM_CAPTURE_MODE_SINGLE | PWM_CAPTURE_TYPE_PERIOD;
-		err = pwm_pin_configure_capture(in.dev, in.pwm,
-						in.flags | flags,
-						continuous_capture_callback,
-						&data);
+		err = pwm_configure_capture(in.dev, in.pwm, in.flags | flags,
+					    continuous_capture_callback, &data);
 		zassert_equal(err, 0, "failed to configure pwm input (err %d)",
 			      err);
 		data.pulse_capture = false;
 	}
 
-	err = pwm_pin_enable_capture(in.dev, in.pwm);
+	err = pwm_enable_capture(in.dev, in.pwm);
 	zassert_equal(err, 0, "failed to enable pwm capture (err %d)", err);
 
-	err = pwm_pin_configure_capture(in.dev, in.pwm,
-					in.flags | flags,
-					continuous_capture_callback,
-					&data);
+	err = pwm_configure_capture(in.dev, in.pwm, in.flags | flags,
+				    continuous_capture_callback, &data);
 	zassert_equal(err, -EBUSY, "pwm capture not busy (err %d)", err);
 
-	err = pwm_pin_enable_capture(in.dev, in.pwm);
+	err = pwm_enable_capture(in.dev, in.pwm);
 	zassert_equal(err, -EBUSY, "pwm capture not busy (err %d)", err);
 
-	err = pwm_pin_disable_capture(in.dev, in.pwm);
+	err = pwm_disable_capture(in.dev, in.pwm);
 	zassert_equal(err, 0, "failed to disable pwm capture (err %d)", err);
 }

--- a/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
+++ b/tests/drivers/pwm/pwm_loopback/src/test_pwm_loopback.c
@@ -50,17 +50,16 @@ void test_capture(uint32_t period, uint32_t pulse, enum test_pwm_unit unit,
 	case TEST_PWM_UNIT_NSEC:
 		TC_PRINT("Testing PWM capture @ %u/%u nsec\n",
 			 pulse, period);
-		err = pwm_set_nsec(out.dev, out.pwm, period,
-				   pulse, out.flags ^=
-				   (flags & PWM_POLARITY_MASK));
+		err = pwm_set(out.dev, out.pwm, period, pulse, out.flags ^=
+			      (flags & PWM_POLARITY_MASK));
 		break;
 
 	case TEST_PWM_UNIT_USEC:
 		TC_PRINT("Testing PWM capture @ %u/%u usec\n",
 			 pulse, period);
-		err = pwm_set_usec(out.dev, out.pwm, period,
-				   pulse, out.flags ^=
-				   (flags & PWM_POLARITY_MASK));
+		err = pwm_set(out.dev, out.pwm, PWM_USEC(period),
+			      PWM_USEC(pulse), out.flags ^=
+			      (flags & PWM_POLARITY_MASK));
 		break;
 
 	default:
@@ -235,8 +234,8 @@ void test_continuous_capture(void)
 	memset(buffer, 0, sizeof(buffer));
 	k_sem_init(&data.sem, 0, 1);
 
-	err = pwm_set_usec(out.dev, out.pwm, period_usec, pulse_usec,
-			       out.flags);
+	err = pwm_set(out.dev, out.pwm, PWM_USEC(period_usec),
+		      PWM_USEC(pulse_usec), out.flags);
 	zassert_equal(err, 0, "failed to set pwm output (err %d)", err);
 
 	err = pwm_configure_capture(in.dev, in.pwm,


### PR DESCRIPTION
This RFC attempts to improve the PWM API in multiple aspects, mainly:

1. All PWM API functions take a `pwm` parameter that indicates the selected PWM channel. The variable name (pwm) and its documentation “PWM pin” is misleading. This patch changes it to “channel” in line with the terminology used in Devicetree (see `DT_PWMS_CHANNEL...` family of macros). Most drivers refer to `pwm` as “channels”, suggesting the new name makes sense.
2. The PWM API operates on “channels”, not “pins”. While the API calls could have been changed by `_channel`, this PR takes the approach of just dropping `_pin`, e.g., `pwm_pin_set_cycles()` -> `pwm_set_cycles()`. The main reason for this choice is that all API calls operate by definition on a channel basis.
3. Similar to other APIs, this patch introduces the `pwm_dt_spec` structure and associated helpers, e.g., `PWM_DT_SPEC_GET()` or `pwm_set_cycles_dt()`. The `pwm_dt_spec` reduces the boilerplate code needed when using Devicetree. For example, if we have:

```
    led: led {
        ...
        pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
        ...
    };
```
One can do now in the application:

```c
    struct pwm_dt_spec led = PWM_DT_SPEC_GET(DT_NODELABEL(led));
    pwm_set_pulse_dt(&led, PWM_MSEC(10));
```
4. Some samples/drivers have been updated to show usage of `pwm_dt_spec`.
5. PWM `set` API operates in nanoseconds, other units/scales can be specified using e.g. `PWM_MSEC()` macros that convert down to nanoseconds.