### PR TITLE
arch/xtensa: Enable backtrace on panic on Intel ADSP platforms

### DIFF
--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -46,7 +46,7 @@ config XTENSA_USE_CORE_CRT1
 config XTENSA_ENABLE_BACKTRACE
 	bool "Backtrace on panic exception"
 	default y
-	depends on SOC_ESP32
+	depends on SOC_ESP32 || SOC_FAMILY_INTEL_ADSP
 	help
 	  Enable this config option to print backtrace on panic exception
 

--- a/arch/xtensa/core/xtensa_backtrace.c
+++ b/arch/xtensa/core/xtensa_backtrace.c
@@ -9,6 +9,8 @@
 #include "sys/printk.h"
 #if defined(CONFIG_SOC_ESP32)
 #include "soc/soc_memory_layout.h"
+#elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
+#include "soc.h"
 #endif
 static int mask, cause;
 
@@ -34,6 +36,8 @@ static inline bool z_xtensa_stack_ptr_is_sane(uint32_t sp)
 {
 #if defined(CONFIG_SOC_ESP32)
 	return esp_stack_ptr_is_sane(sp);
+#elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
+	return intel_adsp_ptr_is_sane(sp);
 #else
 #warning "z_xtensa_stack_ptr_is_sane is not defined for this platform"
 #endif
@@ -43,6 +47,8 @@ static inline bool z_xtensa_ptr_executable(const void *p)
 {
 #if defined(CONFIG_SOC_ESP32)
 	return esp_ptr_executable(p);
+#elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
+	return intel_adsp_ptr_executable(p);
 #else
 #warning "z_xtensa_ptr_executable is not defined for this platform"
 #endif

--- a/soc/xtensa/intel_adsp/common/include/cavs-link.ld
+++ b/soc/xtensa/intel_adsp/common/include/cavs-link.ld
@@ -143,9 +143,11 @@ SECTIONS {
 
   /* Boot loader code in IMR memory */
   .imr : {
+    _imr_start = .;
     /* Entry point MUST be here per external configuration */
     KEEP (*(.boot_entry.text))
     *(.imr .imr.*)
+    _imr_end = .;
   } >imr
 
   /* Boot loader data.  Note that rimage seems to want this
@@ -256,6 +258,7 @@ SECTIONS {
 
   .text : {
     _text_start = .;
+    *(.iram1 .iram1.*)
     *(.entry.text)
     *(.init.literal)
     *(.iram0.text)
@@ -372,7 +375,9 @@ SECTIONS {
   * thread stacks, but applications can put symbols here too.
   */
   .cached SEGSTART_CACHED : {
+    _cached_start = .;
     *(.cached .cached.*)
+    _cached_end = .;
   } >ram
 
   /* Rimage requires 4k alignment between "DATA" and "BSS", can't do

--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -70,6 +70,15 @@
 #define __imr __in_section_unique(imr)
 #define __imrdata __in_section_unique(imrdata)
 
+extern char _text_start[];
+extern char _text_end[];
+extern char _imr_start[];
+extern char _imr_end[];
+extern char _end[];
+extern char _heap_sentry[];
+extern char _cached_start[];
+extern char _cached_end[];
+
 extern void soc_trace_init(void);
 extern void z_soc_irq_init(void);
 extern void z_soc_irq_enable(uint32_t irq);
@@ -111,5 +120,19 @@ extern bool soc_cpus_active[CONFIG_MP_NUM_CPUS];
  * @return 0 on success, -EINVAL on error
  */
 int soc_adsp_halt_cpu(int id);
+
+static inline bool intel_adsp_ptr_executable(const void *p)
+{
+	return (p >= (void *)_text_start && p <= (void *)_text_end) ||
+		(p >= (void *)_imr_start && p <= (void *)_imr_end);
+}
+
+static inline bool intel_adsp_ptr_is_sane(uint32_t sp)
+{
+	return ((char *)sp >= _end && (char *)sp <= _heap_sentry) ||
+		((char *)sp >= _cached_start && (char *)sp <= _cached_end) ||
+		(sp >= (CONFIG_IMR_MANIFEST_ADDR - CONFIG_ISR_STACK_SIZE)
+		 && sp <= CONFIG_IMR_MANIFEST_ADDR);
+}
 
 #endif /* __INC_SOC_H */

--- a/west.yml
+++ b/west.yml
@@ -206,7 +206,7 @@ manifest:
       groups:
         - debug
     - name: sof
-      revision: ab715d8e347fcbbc253ec5cae1c5295043821727
+      revision: aef3a147ec296d0e70066942b7eaf36530c90f9a
       path: modules/audio/sof
     - name: tflite-micro
       revision: 9156d050927012da87079064db59d07f03b8baf6


### PR DESCRIPTION
Platform specific functions necessary to enable this feature were
implemented (z_xtensa_ptr_executable() and
z_xtensa_stack_ptr_is_sane() for Intel ADSP platforms.

Current implementation just ensures stack pointer and program counter
are within relevant areas defined in the linker scripts, without going
too fine grained.

Finally, `.iram1` section, used by the backtrace code, also added to
Intel ADSP linker script.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>