### PR TITLE
boards: bl654_usb: Fix non-mcuboot builds not limiting size

### DIFF
--- a/boards/arm/bl654_usb/Kconfig.defconfig
+++ b/boards/arm/bl654_usb/Kconfig.defconfig
@@ -1,6 +1,6 @@
 # BL654 USB adapter board configuration
 
-# Copyright (c) 2021 Laird Connectivity
+# Copyright (c) 2021-2022 Laird Connectivity
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_BL654_USB
@@ -13,14 +13,19 @@ config BOARD
 
 # Nordic nRF5 bootloader exists outside of the partitions specified in the
 # DTS file, so we manually override FLASH_LOAD_OFFSET to link the application
-# correctly, after Nordic MBR.
+# correctly, after Nordic MBR, and limit the maximum size to not protude into
+# the bootloader at the end of flash.
 
 # When building MCUBoot, MCUBoot itself will select USE_DT_CODE_PARTITION
 # which will make it link into the correct partition specified in DTS file,
-# so no override is necessary.
+# so no override or limit is necessary.
 
 config FLASH_LOAD_OFFSET
 	default 0x1000
+	depends on !USE_DT_CODE_PARTITION
+
+config FLASH_LOAD_SIZE
+	default 0xdf000
 	depends on !USE_DT_CODE_PARTITION
 
 config USB_CDC_ACM


### PR DESCRIPTION
    This limits non-mcuboot builds to have a maximum size of 892KB to
    prevent code being placed over the top of the bootloader's flash area.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44531