### PR TITLE
Stm32f429i disc1 LTDC & Display

### DIFF
--- a/boards/arm/stm32f429i_disc1/Kconfig.defconfig
+++ b/boards/arm/stm32f429i_disc1/Kconfig.defconfig
@@ -8,5 +8,14 @@ if BOARD_STM32F429I_DISC1
 config BOARD
 	default "stm32f429i_disc1"
 
+config SPI
+	default y if DISPLAY
+
+config MEMC
+	default y if DISPLAY
+
+config LV_Z_DISPLAY_DEV_NAME
+	depends on LVGL
+	default "LTDC" if STM32_LTDC
 
 endif # BOARD_STM32F429I_DISC1

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/f4/stm32f429Xi.dtsi>
 #include <st/f4/stm32f429zitx-pinctrl.dtsi>
+#include <dt-bindings/display/ili9xxx.h>
 
 / {
 	model = "STMicroelectronics STM32F429I_DISC1 board";
@@ -18,7 +19,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,ccm = &ccm0;
-		zephyr,display = &ili9340;
+		zephyr,display = &ili9341;
 	};
 
 	sdram2: sdram@d0000000 {
@@ -114,14 +115,34 @@
 	pinctrl-names = "default";
 	status = "okay";
 	cs-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
-	ili9340: ili9340@0 {
-		compatible = "ilitek,ili9340";
-		label = "DISPLAY";
-		spi-max-frequency = <15151515>;
+	ili9341: ili9341@0 {
+		compatible = "ilitek,ili9341";
+		label = "ILI9341";
+		spi-max-frequency = <5625000>;
 		reg = <0>;
 		cmd-data-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>;
 		width = <240>;
 		height = <320>;
+		rotation = <180>;
+		pixel-format = <ILI9XXX_PIXEL_FORMAT_RGB565>;
+		pwctrla = [39 2c 00 34 02];
+		pwctrlb = [00 c1 30];
+		timctrla = [85 00 78];
+		timctrlb = [00 00];
+		pwseqctrl = [64 03 12 81];
+		pumpratioctrl = [20];
+		disctrl = [08 82 27];
+		vmctrl1 = [45 15];
+		vmctrl2 = [90];
+		enable3g = [00];
+		ifctl = [01 00 06];
+		ifmode = [c2];
+		gamset = [01];
+		frmctr1 = [00 1b];
+		pwctrl1 = [10];
+		pwctrl2 = [10];
+		pgamctrl = [0F 29 24 0c 0e 09 4e 78 3c 09 13 05 17 11 00];
+		ngamctrl = [00 16 1b 04 11 07 31 33 42 05 0c 0a 28 2f 0f];
 	};
 };
 

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 #include <st/f4/stm32f429Xi.dtsi>
 #include <st/f4/stm32f429zitx-pinctrl.dtsi>
+#include <dt-bindings/display/stm32_ltdc.h>
 #include <dt-bindings/display/ili9xxx.h>
 
 / {
@@ -183,4 +184,32 @@
 			st,sdram-timing = <2 7 4 7 2 2 2>;
 		};
 	};
+};
+
+&ltdc {
+	pinctrl-0 = <&ltdc_r2_pc10 &ltdc_r3_pb0 &ltdc_r4_pa11 &ltdc_r5_pa12
+		     &ltdc_r6_pb1 &ltdc_r7_pg6 &ltdc_g2_pa6 &ltdc_g3_pg10
+		     &ltdc_g4_pb10 &ltdc_g5_pb11 &ltdc_g6_pc7 &ltdc_g7_pd3
+		     &ltdc_b2_pd6 &ltdc_b3_pg11 &ltdc_b4_pg12 &ltdc_b5_pa3
+		     &ltdc_b6_pb8 &ltdc_b7_pb9 &ltdc_de_pf10 &ltdc_clk_pg7
+		     &ltdc_hsync_pc6 &ltdc_vsync_pa4>;
+	pinctrl-names = "default";
+	ext-sdram = <&sdram2>;
+	status = "okay";
+
+	width = <240>;
+	height = <320>;
+	hsync-pol = <STM32_LTDC_HSPOL_ACTIVE_LOW>;
+	vsync-pol = <STM32_LTDC_VSPOL_ACTIVE_LOW>;
+	de-pol = <STM32_LTDC_DEPOL_ACTIVE_LOW>;
+	pclk-pol = <STM32_LTDC_PCPOL_ACTIVE_LOW>;
+	hsync-duration = <10>;
+	vsync-duration = <2>;
+	hbp-duration = <20>;
+	vbp-duration = <2>;
+	hfp-duration = <10>;
+	vfp-duration = <4>;
+	def-back-color-red = <0xFF>;
+	def-back-color-green = <0xFF>;
+	def-back-color-blue = <0xFF>;
 };

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.yaml
@@ -12,3 +12,4 @@ supported:
   - counter
   - i2c
   - spi
+  - display

--- a/drivers/display/display_ili9341.c
+++ b/drivers/display/display_ili9341.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020 Teslabs Engineering S.L.
  * Copyright (c) 2021 Krivorot Oleg <krivorot.oleg@gmail.com>
+ * Copyright (c) 2022 Konstantinos Papadopoulos <kostas.papadopulos@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -111,6 +112,18 @@ int ili9341_regs_init(const struct device *dev)
 
 	LOG_HEXDUMP_DBG(regs->enable3g, ILI9341_ENABLE3G_LEN, "ENABLE3G");
 	r = ili9xxx_transmit(dev, ILI9341_ENABLE3G, regs->enable3g, ILI9341_ENABLE3G_LEN);
+	if (r < 0) {
+		return r;
+	}
+
+	LOG_HEXDUMP_DBG(regs->ifmode, ILI9341_IFMODE_LEN, "IFMODE");
+	r = ili9xxx_transmit(dev, ILI9341_IFMODE, regs->ifmode, ILI9341_IFMODE_LEN);
+	if (r < 0) {
+		return r;
+	}
+
+	LOG_HEXDUMP_DBG(regs->ifctl, ILI9341_IFCTL_LEN, "IFCTL");
+	r = ili9xxx_transmit(dev, ILI9341_IFCTL, regs->ifctl, ILI9341_IFCTL_LEN);
 	if (r < 0) {
 		return r;
 	}

--- a/drivers/display/display_ili9341.h
+++ b/drivers/display/display_ili9341.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2020 Teslabs Engineering S.L.
  * Copyright (c) 2021 Krivorot Oleg <krivorot.oleg@gmail.com>
+ * Copyright (c) 2022 Konstantinos Papadopoulos <kostas.papadopulos@gmail.com>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -11,6 +12,7 @@
 
 /* Commands/registers. */
 #define ILI9341_GAMSET 0x26
+#define ILI9341_IFMODE 0xB0
 #define ILI9341_FRMCTR1 0xB1
 #define ILI9341_DISCTRL 0xB6
 #define ILI9341_ETMOD 0xB7
@@ -26,10 +28,12 @@
 #define ILI9341_TIMCTRLB 0xEA
 #define ILI9341_PWSEQCTRL 0xED
 #define ILI9341_ENABLE3G 0xF2
+#define ILI9341_IFCTL 0xF6
 #define ILI9341_PUMPRATIOCTRL 0xF7
 
 /* Commands/registers length. */
 #define ILI9341_GAMSET_LEN 1U
+#define ILI9341_IFMODE_LEN 1U
 #define ILI9341_FRMCTR1_LEN 2U
 #define ILI9341_DISCTRL_LEN 3U
 #define ILI9341_PWCTRL1_LEN 1U
@@ -45,6 +49,7 @@
 #define ILI9341_TIMCTRLB_LEN 2U
 #define ILI9341_PUMPRATIOCTRL_LEN 1U
 #define ILI9341_ENABLE3G_LEN 1U
+#define ILI9341_IFCTL_LEN 3U
 #define ILI9341_ETMOD_LEN 1U
 
 /** X resolution (pixels). */
@@ -55,6 +60,7 @@
 /** ILI9341 registers to be initialized. */
 struct ili9341_regs {
 	uint8_t gamset[ILI9341_GAMSET_LEN];
+	uint8_t ifmode[ILI9341_IFMODE_LEN];
 	uint8_t frmctr1[ILI9341_FRMCTR1_LEN];
 	uint8_t disctrl[ILI9341_DISCTRL_LEN];
 	uint8_t pwctrl1[ILI9341_PWCTRL1_LEN];
@@ -70,6 +76,7 @@ struct ili9341_regs {
 	uint8_t timctrlb[ILI9341_TIMCTRLB_LEN];
 	uint8_t pumpratioctrl[ILI9341_PUMPRATIOCTRL_LEN];
 	uint8_t enable3g[ILI9341_ENABLE3G_LEN];
+	uint8_t ifctl[ILI9341_IFCTL_LEN];
 	uint8_t etmod[ILI9341_ETMOD_LEN];
 };
 
@@ -77,6 +84,8 @@ struct ili9341_regs {
 #define ILI9341_REGS_INIT(n)                                                                       \
 	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), gamset) == ILI9341_GAMSET_LEN,        \
 		     "ili9341: Error length gamma set (GAMSET) register");                         \
+	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), ifmode) == ILI9341_IFMODE_LEN,        \
+		     "ili9341: Error length frame rate control (IFMODE) register");                \
 	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), frmctr1) == ILI9341_FRMCTR1_LEN,      \
 		     "ili9341: Error length frame rate control (FRMCTR1) register");               \
 	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), disctrl) == ILI9341_DISCTRL_LEN,      \
@@ -108,10 +117,13 @@ struct ili9341_regs {
 		     "ili9341: Error length Pump ratio control (PUMPRATIOCTRL) register");         \
 	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), enable3g) == ILI9341_ENABLE3G_LEN,    \
 		     "ili9341: Error length enable 3G (ENABLE3G) register");                       \
+	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), ifctl) == ILI9341_IFCTL_LEN,          \
+		     "ili9341: Error length frame rate control (IFCTL) register");                 \
 	BUILD_ASSERT(DT_PROP_LEN(DT_INST(n, ilitek_ili9341), etmod) == ILI9341_ETMOD_LEN,          \
 		     "ili9341: Error length entry Mode Set (ETMOD) register");                     \
 	static const struct ili9341_regs ili9xxx_regs_##n = {                                      \
 		.gamset = DT_PROP(DT_INST(n, ilitek_ili9341), gamset),                             \
+		.ifmode = DT_PROP(DT_INST(n, ilitek_ili9341), ifmode),                             \
 		.frmctr1 = DT_PROP(DT_INST(n, ilitek_ili9341), frmctr1),                           \
 		.disctrl = DT_PROP(DT_INST(n, ilitek_ili9341), disctrl),                           \
 		.pwctrl1 = DT_PROP(DT_INST(n, ilitek_ili9341), pwctrl1),                           \
@@ -127,6 +139,7 @@ struct ili9341_regs {
 		.timctrlb = DT_PROP(DT_INST(n, ilitek_ili9341), timctrlb),                         \
 		.pumpratioctrl = DT_PROP(DT_INST(n, ilitek_ili9341), pumpratioctrl),               \
 		.enable3g = DT_PROP(DT_INST(n, ilitek_ili9341), enable3g),                         \
+		.ifctl = DT_PROP(DT_INST(n, ilitek_ili9341), ifctl),                               \
 		.etmod = DT_PROP(DT_INST(n, ilitek_ili9341), etmod),                               \
 	}
 

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <device.h>
 #include <devicetree.h>
+#include <stm32_ll_rcc.h>
 #include <drivers/display.h>
 #include <drivers/gpio.h>
 #include <drivers/pinctrl.h>
@@ -247,6 +248,32 @@ static int stm32_ltdc_init(const struct device *dev)
 		LOG_ERR("Could not enable LTDC peripheral clock");
 		return err;
 	}
+
+#if defined(CONFIG_SOC_SERIES_STM32F4X)
+	LL_RCC_PLLSAI_Disable();
+	LL_RCC_PLLSAI_ConfigDomain_LTDC(LL_RCC_PLLSOURCE_HSE,
+					LL_RCC_PLLSAIM_DIV_8,
+					192,
+					LL_RCC_PLLSAIR_DIV_4,
+					LL_RCC_PLLSAIDIVR_DIV_8);
+
+	LL_RCC_PLLSAI_Enable();
+	while (LL_RCC_PLLSAI_IsReady() != 1) {
+	}
+#endif
+
+#if defined(CONFIG_SOC_SERIES_STM32F7X)
+	LL_RCC_PLLSAI_Disable();
+	LL_RCC_PLLSAI_ConfigDomain_LTDC(LL_RCC_PLLSOURCE_HSE,
+					LL_RCC_PLLM_DIV_8,
+					192,
+					LL_RCC_PLLSAIR_DIV_4,
+					LL_RCC_PLLSAIDIVR_DIV_8);
+
+	LL_RCC_PLLSAI_Enable();
+	while (LL_RCC_PLLSAI_IsReady() != 1) {
+	}
+#endif
 
 	/* reset LTDC peripheral */
 	__HAL_RCC_LTDC_FORCE_RESET();

--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -22,7 +22,7 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x040000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x004000000>;
 			status = "disabled";
 			label = "LTDC";
 		};

--- a/dts/bindings/display/ilitek,ili9341.yaml
+++ b/dts/bindings/display/ilitek,ili9341.yaml
@@ -1,6 +1,7 @@
 # Copyright (c) 2018, Jan Van Winkel <jan.van_winkel@dxplore.eu>
 # Copyright (c) 2020, Teslabs Engineering S.L.
 # Copyright (c) 2021, Krivorot Oleg <krivorot.oleg@gmail.com>
+# Copyright (c) 2022, Konstantinos Papadopulos <kostas.papadopulos@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 description: ILI9341 320x240 display controller
@@ -10,6 +11,18 @@ compatible: "ilitek,ili9341"
 include: ilitek,ili9xxx-common.yaml
 
 properties:
+    ifmode:
+      type: uint8-array
+      default: [0x40]
+      description:
+        RGB interface signal control (IFMOD) register value.
+
+    ifctl:
+      type: uint8-array
+      default: [0x01, 0x00, 0x00]
+      description:
+        Interface control (IFCTL) register value.
+
     pwctrla:
       type: uint8-array
       default: [0x39, 0x2c, 0x00, 0x34, 0x02]


### PR DESCRIPTION
As LTDC is now working  #43965 , I enabled support for F429.
I'm thinking of creating a 2 separate configuration files, one with graphic stuff enabled, and one without and also create a board/Kconfig file so that the options would be located within menuconfig in Board options section.
Later I'll push the driver for STMPE811 for the touch controller after this is ok.