### PR TITLE
shell: Add new API for adding subcommands

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -26,6 +26,20 @@
 		__shell_root_cmds_end = .;
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
+	SECTION_DATA_PROLOGUE(shell_subcmds_sections,,)
+	{
+		__shell_subcmds_start = .;
+		KEEP(*(SORT(.shell_subcmd_*)));
+		__shell_subcmds_end = .;
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
+	SECTION_DATA_PROLOGUE(shell_dynamic_subcmds_sections,,)
+	{
+		__shell_dynamic_subcmds_start = .;
+		KEEP(*(SORT(.shell_dynamic_subcmd_*)));
+		__shell_dynamic_subcmds_end = .;
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
 	SECTION_DATA_PROLOGUE(font_entry_sections,,)
 	{
 		__font_entry_start = .;

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -394,6 +394,32 @@ SHELL_COND_CMD_ARG_REGISTER(CONFIG_SHELL_START_OBSCURED, login, NULL,
 SHELL_COND_CMD_REGISTER(CONFIG_SHELL_START_OBSCURED, logout, NULL,
 			"Log out.", cmd_logout);
 
+
+/* Create a set of commands. Commands to this set are added using @ref SHELL_SUBCMD_ADD
+ * and @ref SHELL_SUBCMD_COND_ADD.
+ */
+SHELL_SUBCMD_SET_CREATE(sub_section_cmd, (section_cmd));
+
+static int cmd1_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "cmd1 executed");
+
+	return 0;
+}
+
+/* Create a set of subcommands for "section_cmd cm1". */
+SHELL_SUBCMD_SET_CREATE(sub_section_cmd1, (section_cmd, cmd1));
+
+/* Add command to the set. Subcommand set is identify by parent shell command. */
+SHELL_SUBCMD_ADD((section_cmd), cmd1, &sub_section_cmd1, "help for cmd1", cmd1_handler, 1, 0);
+
+SHELL_CMD_REGISTER(section_cmd, &sub_section_cmd,
+		   "Demo command using section for subcommand registration", NULL);
+
 void main(void)
 {
 	if (IS_ENABLED(CONFIG_SHELL_START_OBSCURED)) {

--- a/samples/subsys/shell/shell_module/src/test_module.c
+++ b/samples/subsys/shell/shell_module/src/test_module.c
@@ -5,6 +5,7 @@
  */
 
 #include <logging/log.h>
+#include <shell/shell.h>
 LOG_MODULE_REGISTER(app_test);
 
 void foo(void)
@@ -13,3 +14,33 @@ void foo(void)
 	LOG_WRN("warning message");
 	LOG_ERR("err message");
 }
+
+/* Commands below are added using memory section approach which allows to build
+ * a set of subcommands from multiple files.
+ */
+static int cmd2_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "cmd2 executed");
+
+	return 0;
+}
+
+SHELL_SUBCMD_ADD((section_cmd), cmd2, NULL, "help for cmd2", cmd2_handler, 1, 0);
+
+static int sub_cmd1_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	shell_print(sh, "sub cmd1 executed");
+
+	return 0;
+}
+
+SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL, "help for cmd2",
+			sub_cmd1_handler, 1, 0);

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -9,12 +9,47 @@
 #include "shell_utils.h"
 #include "shell_wildcard.h"
 
-extern const struct shell_cmd_entry __shell_root_cmds_start[];
-extern const struct shell_cmd_entry __shell_root_cmds_end[];
+extern const union shell_cmd_entry __shell_root_cmds_start[];
+extern const union shell_cmd_entry __shell_root_cmds_end[];
 
-static inline const struct shell_cmd_entry *shell_root_cmd_get(uint32_t id)
+extern const union shell_cmd_entry __shell_dynamic_subcmds_start[];
+extern const union shell_cmd_entry __shell_dynamic_subcmds_end[];
+
+extern const union shell_cmd_entry __shell_subcmds_start[];
+extern const union shell_cmd_entry __shell_subcmds_end[];
+
+/* Macro creates empty entry at the bottom of the memory section with subcommands
+ * it is used to detect end of subcommand set that is located before this marker.
+ */
+#define Z_SHELL_SUBCMD_END_MARKER_CREATE()				\
+	static const struct shell_static_entry z_shell_subcmd_end_marker\
+	__attribute__ ((section("."					\
+			STRINGIFY(Z_SHELL_SUBCMD_NAME(999)))))		\
+	__attribute__((used))
+
+Z_SHELL_SUBCMD_END_MARKER_CREATE();
+
+static inline const union shell_cmd_entry *shell_root_cmd_get(uint32_t id)
 {
 	return &__shell_root_cmds_start[id];
+}
+
+/* Determine if entry is a dynamic command by checking if address is within
+ * dynamic commands memory section.
+ */
+static inline bool is_dynamic_cmd(const union shell_cmd_entry *entry)
+{
+	return (entry >= __shell_dynamic_subcmds_start) &&
+		(entry < __shell_dynamic_subcmds_end);
+}
+
+/* Determine if entry is a section command by checking if address is within
+ * subcommands memory section.
+ */
+static inline bool is_section_cmd(const union shell_cmd_entry *entry)
+{
+	return (entry >= __shell_subcmds_start) &&
+		(entry < __shell_subcmds_end);
 }
 
 /* Calculates relative line number of given position in buffer */
@@ -226,19 +261,19 @@ static inline uint32_t shell_root_cmd_count(void)
 {
 	return ((uint8_t *)__shell_root_cmds_end -
 			(uint8_t *)__shell_root_cmds_start)/
-				sizeof(struct shell_cmd_entry);
+				sizeof(union shell_cmd_entry);
 }
 
 /* Function returning pointer to parent command matching requested syntax. */
 const struct shell_static_entry *root_cmd_find(const char *syntax)
 {
 	const size_t cmd_count = shell_root_cmd_count();
-	const struct shell_cmd_entry *cmd;
+	const union shell_cmd_entry *cmd;
 
 	for (size_t cmd_idx = 0; cmd_idx < cmd_count; ++cmd_idx) {
 		cmd = shell_root_cmd_get(cmd_idx);
-		if (strcmp(syntax, cmd->u.entry->syntax) == 0) {
-			return cmd->u.entry;
+		if (strcmp(syntax, cmd->entry->syntax) == 0) {
+			return cmd->entry;
 		}
 	}
 
@@ -254,20 +289,32 @@ const struct shell_static_entry *z_shell_cmd_get(
 
 	if (parent == NULL) {
 		return  (idx < shell_root_cmd_count()) ?
-				shell_root_cmd_get(idx)->u.entry : NULL;
+				shell_root_cmd_get(idx)->entry : NULL;
 	}
 
 	__ASSERT_NO_MSG(dloc != NULL);
 
 	if (parent->subcmd) {
-		if (parent->subcmd->is_dynamic) {
-			parent->subcmd->u.dynamic_get(idx, dloc);
+		if (is_dynamic_cmd(parent->subcmd)) {
+			parent->subcmd->dynamic_get(idx, dloc);
 			if (dloc->syntax != NULL) {
 				res = dloc;
 			}
 		} else {
-			if (parent->subcmd->u.entry[idx].syntax != NULL) {
-				res = &parent->subcmd->u.entry[idx];
+			const struct shell_static_entry *entry_list;
+
+			if (is_section_cmd(parent->subcmd)) {
+				/* First element is null */
+				entry_list =
+					(const struct shell_static_entry *)parent->subcmd;
+				idx++;
+			} else {
+				entry_list = parent->subcmd->entry;
+			}
+
+
+			if (entry_list[idx].syntax != NULL) {
+				res = &entry_list[idx];
 			}
 		}
 	}

--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -419,6 +419,35 @@ static void test_cmd_dict(void)
 	test_shell_execute_cmd("dict2 two", 4);
 }
 
+SHELL_SUBCMD_SET_CREATE(sub_section_cmd, (section_cmd));
+
+static int cmd1_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return 10;
+}
+
+/* Create a set of subcommands for "section_cmd cm1". */
+SHELL_SUBCMD_SET_CREATE(sub_section_cmd1, (section_cmd, cmd1));
+
+/* Add command to the set. Subcommand set is identify by parent shell command. */
+SHELL_SUBCMD_ADD((section_cmd), cmd1, &sub_section_cmd1, "help for cmd1", cmd1_handler, 1, 0);
+
+SHELL_CMD_REGISTER(section_cmd, &sub_section_cmd,
+		   "Demo command using section for subcommand registration", NULL);
+
+static void test_section_cmd(void)
+{
+	test_shell_execute_cmd("section_cmd", SHELL_CMD_HELP_PRINTED);
+	test_shell_execute_cmd("section_cmd cmd1", 10);
+	test_shell_execute_cmd("section_cmd cmd2", 20);
+	test_shell_execute_cmd("section_cmd cmd1 sub_cmd1", 11);
+	test_shell_execute_cmd("section_cmd cmd1 sub_cmd2", -EINVAL);
+}
+
 void test_main(void)
 {
 	ztest_test_suite(shell_test_suite,
@@ -435,7 +464,8 @@ void test_main(void)
 			ztest_unit_test(test_set_root_cmd),
 			ztest_unit_test(test_raw_arg),
 			ztest_unit_test(test_max_argc),
-			ztest_unit_test(test_cmd_dict)
+			ztest_unit_test(test_cmd_dict),
+			ztest_unit_test(test_section_cmd)
 			);
 
 	/* Let the shell backend initialize. */

--- a/tests/subsys/shell/shell/src/test_module.c
+++ b/tests/subsys/shell/shell/src/test_module.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <shell/shell.h>
+
+static int cmd2_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return 20;
+}
+
+SHELL_SUBCMD_ADD((section_cmd), cmd2, NULL, "help for cmd2", cmd2_handler, 1, 0);
+
+static int sub_cmd1_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return 11;
+}
+
+SHELL_SUBCMD_COND_ADD(1, (section_cmd, cmd1), sub_cmd1, NULL,
+		      "help for sub cmd1", sub_cmd1_handler, 1, 0);
+
+static int sub_cmd2_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return 12;
+}
+
+/* Flag set to 0, command will not be compiled. Add to validate that setting
+ * flag to 0 does not add command and does not generate any warnings.
+ */
+SHELL_SUBCMD_COND_ADD(0, (section_cmd, cmd1), sub_cmd2, NULL,
+		      "help for sub cmd2", sub_cmd2_handler, 1, 0);


### PR DESCRIPTION
Added macro `SHELL_SUBCMD_SET_CREATE` which creates a set of subcommands.
`SHELL_SUBCMD_ADD` and `SHELL_SUBCMD_COND_ADD` can be used from any file to
add command to the set. This approach allows to have subcommands added
from multiple files.

Solution is using sorted memory section to which subcommands are added. When set is created an empty command is added and because of sorting all commands in the section follows the empty command. Shell is creating an empty entry which is always at the end of the section so that every set of commands is terminated by empty entry of the new command or this global terminator.

Additionally, added dedicated memory section for dynamic subcommands. This allow to change how dynamic commands are distinguished from static one. It is now done based on the address check. Previously it was done by using additional flag.

Added test and extended sample.