### PR TITLE
net: openthread: add Time Sync support

### DIFF
--- a/subsys/net/lib/openthread/platform/alarm.c
+++ b/subsys/net/lib/openthread/platform/alarm.c
@@ -126,3 +126,8 @@ uint32_t otPlatAlarmMicroGetNow(void)
 {
 	return (uint32_t)(k_ticks_to_us_floor64(k_uptime_ticks()) - time_offset_us);
 }
+
+uint16_t otPlatTimeGetXtalAccuracy(void)
+{
+	return otPlatRadioGetCslAccuracy(NULL);
+}


### PR DESCRIPTION
Implement `otPlatTimeGetXtalAccuracy` which is missing when Time Sync is enabled.

Even if they are not exactly the same for OpenThread I'm leveraging `otPlatRadioGetCslAccuracy` here not to add too much complication in the KConfig. I believe some simplification should be done in OpenThread regarding both functions.