### PR TITLE
Bluetooth: Controller: Add +3dBm Tx power support in nRF53 Series

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -275,7 +275,7 @@ config BT_CTLR_TX_PWR_PLUS_4
 
 config BT_CTLR_TX_PWR_PLUS_3
 	bool "+3 dBm"
-	depends on SOC_COMPATIBLE_NRF52X
+	depends on SOC_COMPATIBLE_NRF52X || SOC_SERIES_NRF53X
 
 config BT_CTLR_TX_PWR_PLUS_2
 	bool "+2 dBm"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -229,6 +229,11 @@ void radio_reset(void)
 #endif
 }
 
+void radio_stop(void)
+{
+	hal_radio_stop();
+}
+
 void radio_phy_set(uint8_t phy, uint8_t flags)
 {
 	uint32_t mode;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -55,6 +55,7 @@ void radio_isr_set(radio_isr_cb_t cb, void *param);
 
 void radio_setup(void);
 void radio_reset(void);
+void radio_stop(void);
 void radio_phy_set(uint8_t phy, uint8_t flags);
 void radio_tx_power_set(int8_t power);
 void radio_tx_power_max_set(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -55,6 +55,7 @@
 #include <nrf52_erratas.h>
 #include "radio_nrf52840.h"
 #elif defined(CONFIG_SOC_NRF5340_CPUNET)
+#include <hal/nrf_vreqctrl.h>
 #include "radio_nrf5340.h"
 #elif
 #error "Unsupported SoC."

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf51.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf51.h
@@ -24,6 +24,14 @@
 
 static inline void hal_radio_reset(void)
 {
+	/* TODO: Add any required setup for each radio event
+	 */
+}
+
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52805.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52805.h
@@ -194,6 +194,14 @@
 
 static inline void hal_radio_reset(void)
 {
+	/* TODO: Add any required setup for each radio event
+	 */
+}
+
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52810.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52810.h
@@ -193,6 +193,14 @@
 
 static inline void hal_radio_reset(void)
 {
+	/* TODO: Add any required setup for each radio event
+	 */
+}
+
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52811.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52811.h
@@ -394,6 +394,12 @@ static inline void hal_radio_reset(void)
 					 0xfffffffe) | 0x01000000;
 }
 
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
+}
+
 static inline void hal_radio_ram_prio_setup(void)
 {
 	struct {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52820.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52820.h
@@ -389,7 +389,14 @@
 
 static inline void hal_radio_reset(void)
 {
+	/* TODO: Add any required setup for each radio event
+	 */
+}
 
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52832.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52832.h
@@ -199,6 +199,12 @@ static inline void hal_radio_reset(void)
 					 0xfffffffe) | 0x01000000;
 }
 
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
+}
+
 static inline void hal_radio_ram_prio_setup(void)
 {
 	struct {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52833.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52833.h
@@ -392,6 +392,12 @@ static inline void hal_radio_reset(void)
 
 }
 
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
+}
+
 static inline void hal_radio_ram_prio_setup(void)
 {
 	struct {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf52840.h
@@ -363,6 +363,12 @@ static inline void hal_radio_reset(void)
 					 0xfffffffe) | 0x01000000;
 }
 
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
+}
+
 static inline void hal_radio_ram_prio_setup(void)
 {
 	struct {

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
@@ -389,7 +389,14 @@
 
 static inline void hal_radio_reset(void)
 {
-	/* TODO */
+	/* TODO: Add any required setup for each radio event
+	 */
+}
+
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5340.h
@@ -387,6 +387,15 @@
 #endif /* !CONFIG_BT_CTLR_SW_SWITCH_SINGLE_TIMER */
 #endif /* !CONFIG_BT_CTLR_TIFS_HW */
 
+/* nRF5340 supports +3dBm Tx Power using high voltage request, define +3dBm
+ * value for Controller use.
+ */
+#ifndef RADIO_TXPOWER_TXPOWER_Pos3dBm
+#define RADIO_TXPOWER_TXPOWER_Pos3dBm (0x03UL)
+#endif
+
+static inline void hal_radio_tx_power_high_voltage_clear(void);
+
 static inline void hal_radio_reset(void)
 {
 	/* TODO: Add any required setup for each radio event
@@ -395,6 +404,11 @@ static inline void hal_radio_reset(void)
 
 static inline void hal_radio_stop(void)
 {
+	/* If +3dBm Tx power was used, then turn off high voltage when radio not
+	 * used.
+	 */
+	hal_radio_tx_power_high_voltage_clear();
+
 	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
 	 */
 }
@@ -506,6 +520,18 @@ static inline uint32_t hal_radio_tx_power_floor(int8_t tx_power_lvl)
 
 	/* Note: The -30 dBm power level is deprecated so ignore it! */
 	return RADIO_TXPOWER_TXPOWER_Neg40dBm;
+}
+
+static inline void hal_radio_tx_power_high_voltage_set(int8_t tx_power_lvl)
+{
+	if (tx_power_lvl >= (int8_t)RADIO_TXPOWER_TXPOWER_Pos3dBm) {
+		nrf_vreqctrl_radio_high_voltage_set(NRF_VREQCTRL, true);
+	}
+}
+
+static inline void hal_radio_tx_power_high_voltage_clear(void)
+{
+	nrf_vreqctrl_radio_high_voltage_set(NRF_VREQCTRL, false);
 }
 
 static inline uint32_t hal_radio_tx_ready_delay_us_get(uint8_t phy, uint8_t flags)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
@@ -197,6 +197,14 @@
 
 static inline void hal_radio_reset(void)
 {
+	/* TODO: Add any required setup for each radio event
+	 */
+}
+
+static inline void hal_radio_stop(void)
+{
+	/* TODO: Add any required cleanup of actions taken in hal_radio_reset()
+	 */
 }
 
 static inline void hal_radio_ram_prio_setup(void)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -573,6 +573,7 @@ void lll_isr_cleanup(void *param)
 	}
 
 	radio_tmr_stop();
+	radio_stop();
 
 	err = lll_hfclock_off();
 	LL_ASSERT(err >= 0);


### PR DESCRIPTION
Add implementation in Controller to set radio high voltage
to enable support for +3dBm Tx Power in nRF53 Series SoCs.

Fixes #37191.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>