### PR TITLE
Bluetooth: controller: df: Fix check for saturated IQ samples.

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -75,8 +75,8 @@ struct lll_df_adv_cfg {
  * To mitigate the limited accuracy and losing information about saturated IQ samples a 0x80 value
  * is selected to serve the purpose.
  */
-#define IQ_SAMPLE_STATURATED_16_BIT 0x8000
-#define IQ_SAMPLE_STATURATED_8_BIT 0x80
+#define IQ_SAMPLE_STATURATED_16_BIT ((int16_t)0x8000)
+#define IQ_SAMPLE_STATURATED_8_BIT ((int8_t)0x80)
 
 #define IQ_SHIFT_12_TO_8_BIT(x) ((int8_t)((x) >> 4))
 #define IQ_CONVERT_12_TO_8_BIT(x)                                                                  \


### PR DESCRIPTION
When an int16_t I or Q value is input to IQ_CONVERT_12_TO_8_BIT the compiler would
not make the correct comparison with IQ_SAMPLE_STATURATED_16_BIT causing saturated
IQ samples never being found.

This macro is not doing what is expected: https://github.com/zephyrproject-rtos/zephyr/blob/a8ffd192813a5e8ac1f5bf89123d3009f5d6539e/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h#L82

In the end it boils down to:
```
(-32768 == 0x8000) => false
(-32768 == (int16_t)0x8000) => true (this is what we want)
``` 
Hence this fix.