### PR TITLE
modules: hal_nordic: Update nrfx to version 2.8.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -88,7 +88,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: 1f9145e8c8359f103b4ac5085c6f5d2e66a2557d
+      revision: 4464a6f96b4a6a1b7ac5ca1b8c3caf6a81d25e57
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Update the hal_nordic module revision, to switch to nrfx v2.8.0.

nrfx 2.8.0 includes improvements to SAADC driver that will
allow using nrfx_saadc API directly in the Zephyr ADC shim.

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>