### PR TITLE
Bluetooth: Audio: Align BabbleSim simulation lengths with other tests

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/bass.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/bass.sh
@@ -35,7 +35,8 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=2 -testid=bass_broadcaster -rs=69
 
-Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 -sim_length=20e6 $@
+# Simulation time should be larger than the WAIT_TIME in common.h
+Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -D=3 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/broadcast_audio.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/broadcast_audio.sh
@@ -33,8 +33,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=broadcast_sink -rs=27
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"
@@ -50,8 +51,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 \
   -testid=broadcast_sink_disconnect -rs=27
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/tbs.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/tbs.sh
@@ -31,8 +31,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=tbs_client -rs=6
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/unicast_audio.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/test_scripts/unicast_audio.sh
@@ -33,8 +33,9 @@ Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
 Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_audio_prj_conf \
   -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} -d=1 -testid=unicast_server -rs=27
 
+# Simulation time should be larger than the WAIT_TIME in common.h
 Execute ./bs_2G4_phy_v1 -v=${VERBOSITY_LEVEL} -s=${SIMULATION_ID} \
-  -D=2 -sim_length=20e6 $@
+  -D=2 -sim_length=60e6 $@
 
 for PROCESS_ID in $PROCESS_IDS; do
   wait $PROCESS_ID || let "EXIT_CODE=$?"


### PR DESCRIPTION
Use same simulation length for TBS, bass, broadcas and unicast as for
the other tests.  Simulation length must be larger than time-out
value, to give the test a chance to time out.

The time-out value have previosly been aligned for the other tests.
TBS was not done at that time, as it was still being upstreamed.
(Unsure about why bass, unicast and broadcast were not done at the
same time - they may have been in PRs).

See commits f7cd6afb79c6d013726909db15b988f98930f5b8 and
73f5ffcf4e207381df0bd40202839b8aa4c6a861

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>