### PR TITLE
Bluetooth: controller: implement connection termination on invalid pdus

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -186,6 +186,21 @@ static void lp_chmu_execute_fsm(struct ll_conn *conn, struct proc_ctx *ctx, uint
 	}
 }
 
+void llcp_lp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx)
+{
+	struct pdu_data *pdu = (struct pdu_data *)rx->pdu;
+
+	switch (pdu->llctrl.opcode) {
+	default:
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_lr_complete(conn);
+		ctx->state = LP_CHMU_STATE_IDLE;
+		break;
+	}
+}
+
 void llcp_lp_chmu_init_proc(struct proc_ctx *ctx)
 {
 	ctx->state = LP_CHMU_STATE_IDLE;
@@ -195,6 +210,7 @@ void llcp_lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param)
 {
 	lp_chmu_execute_fsm(conn, ctx, LP_CHMU_EVT_RUN, param);
 }
+
 #endif /* CONFIG_BT_CENTRAL */
 
 #if defined(CONFIG_BT_PERIPHERAL)
@@ -285,8 +301,12 @@ void llcp_rp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_
 		rp_chmu_execute_fsm(conn, ctx, RP_CHMU_EVT_RX_CHAN_MAP_IND, pdu);
 		break;
 	default:
-		/* Unknown opcode */
-		LL_ASSERT(0);
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_rr_complete(conn);
+		ctx->state = RP_CHMU_STATE_IDLE;
+		break;
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -170,18 +170,11 @@ static void lp_comm_ntf_feature_exchange(struct ll_conn *conn, struct proc_ctx *
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
 		llcp_ntf_encode_feature_rsp(conn, pdu);
 		break;
-	case PDU_DATA_LLCTRL_TYPE_PER_INIT_FEAT_XCHG:
-	case PDU_DATA_LLCTRL_TYPE_FEATURE_REQ:
-		/*
-		 * No notification on feature-request or periph-feature request
-		 * TODO: probably handle as an unexpected call
-		 */
-		break;
 	case PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP:
 		llcp_ntf_encode_unknown_rsp(ctx, pdu);
 		break;
 	default:
-		/* TODO: define behaviour for unexpected PDU */
+		/* Unexpected PDU, should not get through, so ASSERT */
 		LL_ASSERT(0);
 	}
 }
@@ -194,7 +187,7 @@ static void lp_comm_ntf_version_ind(struct ll_conn *conn, struct proc_ctx *ctx,
 		llcp_ntf_encode_version_ind(conn, pdu);
 		break;
 	default:
-		/* TODO: define behaviour for unexpected PDU */
+		/* Unexpected PDU, should not get through, so ASSERT */
 		LL_ASSERT(0);
 	}
 }
@@ -238,7 +231,7 @@ static void lp_comm_ntf_cte_req(struct ll_conn *conn, struct proc_ctx *ctx, stru
 		llcp_ntf_encode_reject_ext_ind(ctx, pdu);
 		break;
 	default:
-		/* TODO (ppryga): Update when behavior for unexpected PDU is defined */
+		/* Unexpected PDU, should not get through, so ASSERT */
 		LL_ASSERT(0);
 	}
 }
@@ -284,6 +277,15 @@ static void lp_comm_ntf(struct ll_conn *conn, struct proc_ctx *ctx)
 	ll_rx_sched();
 }
 
+static void lp_comm_terminate_invalid_pdu(struct ll_conn *conn, struct proc_ctx *ctx)
+{
+	/* Invalid behaviour */
+	/* Invalid PDU received so terminate connection */
+	conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+	llcp_lr_complete(conn);
+	ctx->state = LP_COMMON_STATE_IDLE;
+}
+
 static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t evt, void *param)
 {
 	switch (ctx->proc) {
@@ -295,17 +297,23 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 			ctx->state = LP_COMMON_STATE_IDLE;
 		} else {
 			/* Illegal response opcode */
-			LL_ASSERT(0);
+			lp_comm_terminate_invalid_pdu(conn, ctx);
 		}
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PROC_FEATURE_EXCHANGE:
-		if (!llcp_ntf_alloc_is_available()) {
-			ctx->state = LP_COMMON_STATE_WAIT_NTF;
+		if (ctx->response_opcode == PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP ||
+		    ctx->response_opcode == PDU_DATA_LLCTRL_TYPE_FEATURE_RSP) {
+			if (!llcp_ntf_alloc_is_available()) {
+				ctx->state = LP_COMMON_STATE_WAIT_NTF;
+			} else {
+				lp_comm_ntf(conn, ctx);
+				llcp_lr_complete(conn);
+				ctx->state = LP_COMMON_STATE_IDLE;
+			}
 		} else {
-			lp_comm_ntf(conn, ctx);
-			llcp_lr_complete(conn);
-			ctx->state = LP_COMMON_STATE_IDLE;
+			/* Illegal response opcode */
+			lp_comm_terminate_invalid_pdu(conn, ctx);
 		}
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN) && defined(CONFIG_BT_PERIPHERAL)
@@ -315,12 +323,17 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		break;
 #endif /* CONFIG_BT_CTLR_MIN_USED_CHAN && CONFIG_BT_PERIPHERAL */
 	case PROC_VERSION_EXCHANGE:
-		if (!llcp_ntf_alloc_is_available()) {
-			ctx->state = LP_COMMON_STATE_WAIT_NTF;
+		if (ctx->response_opcode == PDU_DATA_LLCTRL_TYPE_VERSION_IND) {
+			if (!llcp_ntf_alloc_is_available()) {
+				ctx->state = LP_COMMON_STATE_WAIT_NTF;
+			} else {
+				lp_comm_ntf(conn, ctx);
+				llcp_lr_complete(conn);
+				ctx->state = LP_COMMON_STATE_IDLE;
+			}
 		} else {
-			lp_comm_ntf(conn, ctx);
-			llcp_lr_complete(conn);
-			ctx->state = LP_COMMON_STATE_IDLE;
+			/* Illegal response opcode */
+			lp_comm_terminate_invalid_pdu(conn, ctx);
 		}
 		break;
 	case PROC_TERMINATE:
@@ -333,7 +346,7 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		break;
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
-		if (ctx->response_opcode != PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP) {
+		if (ctx->response_opcode == PDU_DATA_LLCTRL_TYPE_LENGTH_RSP) {
 			/* Apply changes in data lengths/times */
 			uint8_t dle_changed = ull_dle_update_eff(conn);
 
@@ -347,12 +360,16 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 				llcp_lr_complete(conn);
 				ctx->state = LP_COMMON_STATE_IDLE;
 			}
-		} else {
+		} else if (ctx->response_opcode == PDU_DATA_LLCTRL_TYPE_UNKNOWN_RSP) {
 			/* Peer does not accept DLU, so disable on current connection */
 			feature_unmask_features(conn, LL_FEAT_BIT_DLE);
 
 			llcp_lr_complete(conn);
 			ctx->state = LP_COMMON_STATE_IDLE;
+		} else {
+			/* Illegal response opcode */
+			lp_comm_terminate_invalid_pdu(conn, ctx);
+			break;
 		}
 
 		if (!ull_cp_remote_dle_pending(conn)) {
@@ -396,6 +413,9 @@ static void lp_comm_complete(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 			 */
 			ull_cp_cte_req_set_disable(conn);
 			ctx->state = LP_COMMON_STATE_IDLE;
+		} else {
+			/* Illegal response opcode */
+			lp_comm_terminate_invalid_pdu(conn, ctx);
 		}
 
 		if (ctx->state == LP_COMMON_STATE_IDLE) {
@@ -620,6 +640,9 @@ static void lp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_REQ */
 	case PDU_DATA_LLCTRL_TYPE_REJECT_EXT_IND:
 		llcp_pdu_decode_reject_ext_ind(ctx, pdu);
+		break;
+	case PDU_DATA_LLCTRL_TYPE_REJECT_IND:
+		/* Empty on purpose, as we don't care about the PDU content, we'll disconnect */
 		break;
 	default:
 		/* Unknown opcode */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -212,6 +212,7 @@ static void lp_cu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 		break;
 #endif /* CONFIG_BT_CENTRAL */
 	default:
+		/* Unknown opcode */
 		LL_ASSERT(0);
 		break;
 	}
@@ -586,8 +587,11 @@ void llcp_lp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		lp_cu_execute_fsm(conn, ctx, LP_CU_EVT_REJECT, pdu);
 		break;
 	default:
-		/* Unknown opcode */
-		LL_ASSERT(0);
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_lr_complete(conn);
+		ctx->state = LP_CU_STATE_IDLE;
 		break;
 	}
 }
@@ -637,6 +641,7 @@ static void rp_cu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 		llcp_pdu_encode_unknown_rsp(ctx, pdu);
 		break;
 	default:
+		/* Unknown opcode */
 		LL_ASSERT(0);
 		break;
 	}
@@ -1053,8 +1058,11 @@ void llcp_rp_cu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		rp_cu_execute_fsm(conn, ctx, RP_CU_EVT_CONN_UPDATE_IND, pdu);
 		break;
 	default:
-		/* Unknown opcode */
-		LL_ASSERT(0);
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_rr_complete(conn);
+		ctx->state = RP_CU_STATE_IDLE;
 		break;
 	}
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_internal.h
@@ -405,6 +405,7 @@ void llcp_lp_cu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 /*
  * LLCP Local Channel Map Update
  */
+void llcp_lp_chmu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *rx);
 void llcp_lp_chmu_init_proc(struct proc_ctx *ctx);
 void llcp_lp_chmu_run(struct ll_conn *conn, struct proc_ctx *ctx, void *param);
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -164,6 +164,11 @@ void llcp_lr_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pdu *
 	case PROC_TERMINATE:
 		llcp_lp_comm_rx(conn, ctx, rx);
 		break;
+#if defined(CONFIG_BT_CENTRAL)
+	case PROC_CHAN_MAP_UPDATE:
+		llcp_lp_chmu_rx(conn, ctx, rx);
+		break;
+#endif /* CONFIG_BT_CENTRAL */
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 	case PROC_DATA_LENGTH_UPDATE:
 		llcp_lp_comm_rx(conn, ctx, rx);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -749,8 +749,12 @@ void llcp_lp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		lp_pu_execute_fsm(conn, ctx, LP_PU_EVT_REJECT, pdu);
 		break;
 	default:
-		/* Unknown opcode */
-		LL_ASSERT(0);
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_lr_complete(conn);
+		ctx->state = LP_PU_STATE_IDLE;
+		break;
 	}
 }
 
@@ -1121,8 +1125,12 @@ void llcp_rp_pu_rx(struct ll_conn *conn, struct proc_ctx *ctx, struct node_rx_pd
 		break;
 #endif /* CONFIG_BT_PERIPHERAL */
 	default:
-		/* Unknown opcode */
-		LL_ASSERT(0);
+		/* Invalid behaviour */
+		/* Invalid PDU received so terminate connection */
+		conn->llcp_terminate.reason_final = BT_HCI_ERR_LMP_PDU_NOT_ALLOWED;
+		llcp_rr_complete(conn);
+		ctx->state = RP_PU_STATE_IDLE;
+		break;
 	}
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -548,10 +548,10 @@ static void rr_st_idle(struct ll_conn *conn, uint8_t evt, void *param)
 		break;
 	}
 }
+
 static void rr_st_reject(struct ll_conn *conn, uint8_t evt, void *param)
 {
-	/* TODO */
-	LL_ASSERT(0);
+	rr_act_reject(conn);
 }
 
 static void rr_st_unsupported(struct ll_conn *conn, uint8_t evt, void *param)

--- a/tests/bluetooth/controller/ctrl_chmu/src/main.c
+++ b/tests/bluetooth/controller/ctrl_chmu/src/main.c
@@ -132,6 +132,77 @@ void test_channel_map_update_central_loc(void)
 				  "Free CTX buffers %d", ctx_buffers_free());
 }
 
+void test_channel_map_update_central_invalid(void)
+{
+	uint8_t chm[5] = { 0x00, 0x04, 0x05, 0x06, 0x00 };
+	uint8_t err;
+	struct node_tx *tx;
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = PDU_DATA_LLCTRL_TYPE_CHAN_MAP_IND
+	};
+	struct pdu_data_llctrl_chan_map_ind chmu_ind = {
+		.instant = 6,
+		.chm = { 0x00, 0x04, 0x05, 0x06, 0x00 },
+	};
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	err = ull_cp_chan_map_update(&conn, chm);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_CHAN_MAP_UPDATE_IND, &conn, &tx, &chmu_ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Done */
+	event_done(&conn);
+
+	/* There should NOT be a host notification */
+	ut_rx_q_is_empty();
+
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Inject invalid 'RSP' */
+	lt_tx(LL_UNKNOWN_RSP, &conn, &unknown_rsp);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+				  "Free CTX buffers %d", ctx_buffers_free());
+}
+
 void test_channel_map_update_periph_rem(void)
 {
 	uint8_t chm[5] = { 0x00, 0x04, 0x05, 0x06, 0x00 };
@@ -203,6 +274,65 @@ void test_channel_map_update_periph_rem(void)
 				  "Free CTX buffers %d", ctx_buffers_free());
 }
 
+void test_channel_map_update_periph_invalid(void)
+{
+	struct pdu_data_llctrl_chan_map_ind chmu_ind = {
+		.instant = 6,
+		.chm = { 0x00, 0x04, 0x05, 0x06, 0x00 },
+	};
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = PDU_DATA_LLCTRL_TYPE_UNUSED
+	};
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* RX */
+	lt_tx(LL_CHAN_MAP_UPDATE_IND, &conn, &chmu_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	/* Prepare */
+	event_prepare(&conn);
+	/* Done */
+	event_done(&conn);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Inject invalid 'RSP' */
+	lt_tx(LL_UNKNOWN_RSP, &conn, &unknown_rsp);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+				  "Free CTX buffers %d", ctx_buffers_free());
+}
+
 void test_channel_map_update_periph_loc(void)
 {
 	uint8_t err;
@@ -226,8 +356,12 @@ void test_main(void)
 	ztest_test_suite(chmu,
 			 ztest_unit_test_setup_teardown(test_channel_map_update_central_loc, setup,
 							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_channel_map_update_central_invalid,
+							setup, unit_test_noop),
 			 ztest_unit_test_setup_teardown(test_channel_map_update_periph_rem, setup,
 							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_channel_map_update_periph_invalid,
+							setup, unit_test_noop),
 			 ztest_unit_test_setup_teardown(test_channel_map_update_periph_loc, setup,
 							unit_test_noop));
 

--- a/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
@@ -36,6 +36,7 @@
 #include "ull_llcp.h"
 #include "ull_conn_internal.h"
 #include "ull_llcp_internal.h"
+#include "ull_llcp_features.h"
 
 #include "helper_pdu.h"
 #include "helper_util.h"
@@ -48,7 +49,7 @@ static void setup(void)
 	test_setup(&conn);
 }
 
-/*C
+/*
  * Locally triggered Data Length Update procedure
  *
  * +-----+                     +-------+                       +-----+
@@ -126,6 +127,189 @@ void test_data_length_update_central_loc(void)
 	ut_rx_q_is_empty();
 	zassert_equal(conn.lll.event_counter, 2, "Wrong event-count %d\n",
 				  conn.lll.event_counter);
+}
+
+/*
+ * Locally triggered Data Length Update procedure
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    | Start                      |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |--------------------------->|                              |
+ *    |                            |  (251,2120,211,1800)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |----------------------------->|
+ *    |                            |                              |
+ *    |                            |         LL_UNKNOWN_RSP       |
+ *    |                            |<-----------------------------|
+ *    |                            |                              |
+ *  ~~~~~~~~~~~~~~~~~~~~~~~  Unmask DLE support ~~~~~~~~~~~~~~~~~~~~
+ *    |                            |                              |
+ *    |                            |                              |
+ */
+void test_data_length_update_central_loc_unknown_rsp(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = PDU_DATA_LLCTRL_TYPE_LENGTH_REQ
+	};
+	struct pdu_data_llctrl_length_req local_length_req = { 251, 2120, 211, 1800 };
+
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(251);
+	ull_conn_default_tx_time_set(2120);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Confirm DLE is indicated as supported */
+	zassert_equal(feature_dle(&conn), true, "DLE Feature masked out");
+
+	/* Initiate a Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 211, 1800);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_UNKNOWN_RSP, &conn, &unknown_rsp);
+
+	event_done(&conn);
+
+	/* Release tx node */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Confirm DLE is no longer indicated as supported */
+	zassert_equal(feature_dle(&conn), false, "DLE Feature not masked out");
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+}
+
+/*
+ * Locally triggered Data Length Update procedure
+ *
+ * +-----+                     +-------+                       +-----+
+ * | UT  |                     | LL_A  |                       | LT  |
+ * +-----+                     +-------+                       +-----+
+ *    |                            |                              |
+ *    | Start                      |                              |
+ *    | Data Length Update Proc.   |                              |
+ *    |--------------------------->|                              |
+ *    |                            |  (251,2120,211,1800)         |
+ *    |                            | LL_DATA_LENGTH_UPDATE_REQ    |
+ *    |                            |----------------------------->|
+ *    |                            |                              |
+ *    |                            |         LL_<INVALID>_RSP     |
+ *    |                            |<-----------------------------|
+ *    |                            |                              |
+ *   ~~~~~~~~~~~~~~~~~~~~  TERMINATE CONNECTION  ~~~~~~~~~~~~~~~~~~~
+ *    |                            |                              |
+ *    |                            |                              |
+ */
+void test_data_length_update_central_loc_invalid_rsp(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct pdu_data_llctrl_reject_ind reject_ind = {
+		.error_code = BT_HCI_ERR_LL_PROC_COLLISION
+	};
+	struct pdu_data_llctrl_reject_ext_ind reject_ext_ind = {
+		.reject_opcode = PDU_DATA_LLCTRL_TYPE_LENGTH_REQ,
+		.error_code = BT_HCI_ERR_LL_PROC_COLLISION
+	};
+
+	struct pdu_data_llctrl_length_req local_length_req = { 251, 2120, 211, 1800 };
+
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(251);
+	ull_conn_default_tx_time_set(2120);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Initiate a Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 211, 1800);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_REJECT_IND, &conn, &reject_ind);
+
+	event_done(&conn);
+
+	/* Release tx node */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+
+	/* Init DLE data */
+	ull_conn_default_tx_octets_set(251);
+	ull_conn_default_tx_time_set(2120);
+	ull_dle_init(&conn, PHY_1M);
+
+	/* Initiate another Data Length Update Procedure */
+	err = ull_cp_data_length_update(&conn, 211, 1800);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	event_prepare(&conn);
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LENGTH_REQ, &conn, &tx, &local_length_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Rx */
+	lt_tx(LL_REJECT_EXT_IND, &conn, &reject_ext_ind);
+
+	event_done(&conn);
+
+	/* Release tx node */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
 }
 
 /*
@@ -648,6 +832,10 @@ void test_main(void)
 		data_length_update_central,
 		ztest_unit_test_setup_teardown(test_data_length_update_central_loc, setup,
 					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_data_length_update_central_loc_unknown_rsp,
+					       setup, unit_test_noop),
+		ztest_unit_test_setup_teardown(test_data_length_update_central_loc_invalid_rsp,
+					       setup, unit_test_noop),
 		ztest_unit_test_setup_teardown(test_data_length_update_central_loc_no_eff_change,
 					       setup, unit_test_noop),
 		ztest_unit_test_setup_teardown(test_data_length_update_central_loc_no_eff_change2,

--- a/tests/bluetooth/controller/ctrl_le_ping/src/main.c
+++ b/tests/bluetooth/controller/ctrl_le_ping/src/main.c
@@ -57,6 +57,15 @@ static void setup(void)
  *    |                            |    LL_LE_PING_RSP |
  *    |                            |<------------------|
  *    |                            |                   |
+ *    | Start                      |                   |
+ *    | LE Ping Proc.              |                   |
+ *    |--------------------------->|                   |
+ *    |                            |                   |
+ *    |                            | LL_LE_PING_REQ    |
+ *    |                            |------------------>|
+ *    |                            |                   |
+ *    |                            |    LL_UNKNOWN_RSP |
+ *    |                            |<------------------|
  *    |                            |                   |
  */
 void test_ping_central_loc(void)
@@ -67,6 +76,10 @@ void test_ping_central_loc(void)
 	struct pdu_data_llctrl_ping_req local_ping_req = {};
 
 	struct pdu_data_llctrl_ping_rsp remote_ping_rsp = {};
+
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = PDU_DATA_LLCTRL_TYPE_PING_REQ
+	};
 
 	/* Role */
 	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
@@ -99,6 +112,135 @@ void test_ping_central_loc(void)
 
 	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
 		      "Free CTX buffers %d", ctx_buffers_free());
+
+	/* Initiate another LE Ping Procedure */
+	err = ull_cp_le_ping(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LE_PING_REQ, &conn, &tx, &local_ping_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_UNKNOWN_RSP, &conn, &unknown_rsp);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release tx node */
+	ull_cp_release_tx(&conn, tx);
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+
+}
+
+/* +-----+                     +-------+            +-----+
+ * | UT  |                     | LL_A  |            | LT  |
+ * +-----+                     +-------+            +-----+
+ *    |                            |                   |
+ *    | Start                      |                   |
+ *    | LE Ping Proc.              |                   |
+ *    |--------------------------->|                   |
+ *    |                            |                   |
+ *    |                            | LL_LE_PING_REQ    |
+ *    |                            |------------------>|
+ *    |                            |                   |
+ *    |                            | LL_<INVALID>_RSP  |
+ *    |                            |<------------------|
+ *    |                            |                   |
+ *  ~~~~~~~~~~~~~~~~~ TERMINATE CONNECTION ~~~~~~~~~~~~~~
+ *    |                            |                   |
+ */
+void test_ping_central_loc_invalid_rsp(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+
+	struct pdu_data_llctrl_reject_ind reject_ind = {
+		.error_code = BT_HCI_ERR_LL_PROC_COLLISION
+	};
+	struct pdu_data_llctrl_reject_ext_ind reject_ext_ind = {
+		.reject_opcode = PDU_DATA_LLCTRL_TYPE_PING_REQ,
+		.error_code = BT_HCI_ERR_LL_PROC_COLLISION
+	};
+	struct pdu_data_llctrl_ping_req local_ping_req = {};
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate an LE Ping Procedure */
+	err = ull_cp_le_ping(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LE_PING_REQ, &conn, &tx, &local_ping_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_REJECT_EXT_IND, &conn, &reject_ext_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release tx node */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+
+	/* Initiate another LE Ping Procedure */
+	err = ull_cp_le_ping(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_LE_PING_REQ, &conn, &tx, &local_ping_req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_REJECT_IND, &conn, &reject_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release tx node */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* There should not be a host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+
 }
 
 /* +-----+                     +-------+            +-----+
@@ -271,6 +413,8 @@ void test_main(void)
 {
 	ztest_test_suite(ping,
 			 ztest_unit_test_setup_teardown(test_ping_central_loc, setup,
+							unit_test_noop),
+			 ztest_unit_test_setup_teardown(test_ping_central_loc_invalid_rsp, setup,
 							unit_test_noop),
 			 ztest_unit_test_setup_teardown(test_ping_periph_loc, setup,
 							unit_test_noop),

--- a/tests/bluetooth/controller/ctrl_version/src/main.c
+++ b/tests/bluetooth/controller/ctrl_version/src/main.c
@@ -111,6 +111,156 @@ void test_version_exchange_central_loc(void)
 		      "Free CTX buffers %d", ctx_buffers_free());
 }
 
+/* +-----+                     +-------+            +-----+
+ * | UT  |                     | LL_A  |            | LT  |
+ * +-----+                     +-------+            +-----+
+ *    |                            |                   |
+ *    | Start                      |                   |
+ *    | Version Exchange Proc.     |                   |
+ *    |--------------------------->|                   |
+ *    |                            |                   |
+ *    |                            | LL_VERSION_IND    |
+ *    |                            |------------------>|
+ *    |                            |                   |
+ *    |                            |  LL_<INVALID>_RSP |
+ *    |                            |<------------------|
+ *    |                            |                   |
+ *  ~~~~~~~~~~~~~~~~~~~ TERMINATE CONN ~~~~~~~~~~~~~~~~~~
+ *    |                            |                   |
+ */
+void test_version_exchange_central_loc_invalid_rsp(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+
+	struct pdu_data_llctrl_version_ind local_version_ind = {
+		.version_number = LL_VERSION_NUMBER,
+		.company_id = CONFIG_BT_CTLR_COMPANY_ID,
+		.sub_version_number = CONFIG_BT_CTLR_SUBVERSION_NUMBER,
+	};
+
+	struct pdu_data_llctrl_unknown_rsp unknown_rsp = {
+		.type = PDU_DATA_LLCTRL_TYPE_VERSION_IND
+	};
+
+	struct pdu_data_llctrl_reject_ext_ind reject_ext_ind = {
+		.reject_opcode = PDU_DATA_LLCTRL_TYPE_VERSION_IND,
+		.error_code = BT_HCI_ERR_LL_PROC_COLLISION
+	};
+
+	struct pdu_data_llctrl_reject_ind reject_ind = {
+		.error_code = BT_HCI_ERR_LL_PROC_COLLISION
+	};
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate a Version Exchange Procedure */
+	err = ull_cp_version_exchange(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_VERSION_IND, &conn, &tx, &local_version_ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_UNKNOWN_RSP, &conn, &unknown_rsp);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* There should be no host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+
+	/* Cheat, to allow second VEX */
+	conn.llcp.vex.sent = 0;
+
+	/* Initiate another Version Exchange Procedure */
+	err = ull_cp_version_exchange(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_VERSION_IND, &conn, &tx, &local_version_ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_REJECT_EXT_IND, &conn, &reject_ext_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* Clear termination flag for subsequent test cycle */
+	conn.llcp_terminate.reason_final = 0;
+
+	/* There should be no host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+
+	/* Cheat, to allow second VEX */
+	conn.llcp.vex.sent = 0;
+
+	/* Initiate yet another Version Exchange Procedure */
+	err = ull_cp_version_exchange(&conn);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_VERSION_IND, &conn, &tx, &local_version_ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_REJECT_IND, &conn, &reject_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Termination 'triggered' */
+	zassert_equal(conn.llcp_terminate.reason_final, BT_HCI_ERR_LMP_PDU_NOT_ALLOWED,
+		      "Terminate reason %d", conn.llcp_terminate.reason_final);
+
+	/* There should be no host notifications */
+	ut_rx_q_is_empty();
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
+		      "Free CTX buffers %d", ctx_buffers_free());
+}
+
 void test_version_exchange_central_loc_2(void)
 {
 	uint8_t err;
@@ -367,7 +517,10 @@ void test_main(void)
 			 ztest_unit_test_setup_teardown(test_version_exchange_central_rem_2, setup,
 							unit_test_noop),
 			 ztest_unit_test_setup_teardown(test_version_exchange_central_loc_twice,
-							setup, unit_test_noop));
+							setup, unit_test_noop),
+			 ztest_unit_test_setup_teardown(
+					     test_version_exchange_central_loc_invalid_rsp, setup,
+					     unit_test_noop));
 
 	ztest_run_test_suite(version_exchange);
 }


### PR DESCRIPTION
When a running procedure receives a REJECT or UNKNOWN_RSP PDU that is
not an expected part of the procedure flow this leads to termination
of the connection.

This affects procedures:
CU/CPR, CTE, PHY, PING, DLE, FEX, VEX, CHMU

Unit tests are updated to cover the updated behaviour.

Signed-off-by: Erik Brockhoff <erbr@oticon.com>