### PR TITLE
soc: riscv: sifive-freedom: Fix whitespace mistake.

### DIFF
--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -23,7 +23,7 @@
 #define SIFIVE_PINMUX_PINS            32
 
 /* Clock controller. */
-#define PRCI_BASE_ADDR           0x10008000
+#define PRCI_BASE_ADDR               0x10008000
 
 /* Always ON Domain */
 #define SIFIVE_PMUIE		     0x10000140


### PR DESCRIPTION
Revert the deleted spaces from PR#42280 / c74526919.

Signed-off-by: Shawn Nematbakhsh <shawn@rivosinc.com>