### PR TITLE
mgmt/mcumgr/lib: Fix incorrect ssize used for unsigned values

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -106,8 +106,8 @@ os_mgmt_taskstat_encode_stack_info(struct CborEncoder *thread_map,
 				   const struct k_thread *thread)
 {
 #ifdef CONFIG_OS_MGMT_TASKSTAT_STACK_INFO
-	ssize_t stack_size = 0;
-	ssize_t stack_used = 0;
+	size_t stack_size = 0;
+	size_t stack_used = 0;
 	int err = 0;
 
 #ifdef CONFIG_THREAD_STACK_INFO


### PR DESCRIPTION
The commit fixes OS mgmt taskstat command using ssize_t for
stack parameters that are unsigned, and then encoding them
with CBOR encoder functions dedicated to unsigned integers.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>