### PR TITLE
console: semihosting: add RISC-V support

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -298,14 +298,15 @@ config NATIVE_POSIX_CONSOLE_INIT_PRIORITY
 config SEMIHOST_CONSOLE
 	bool "Use semihosting for console"
 	select CONSOLE_HAS_DRIVER
-	depends on CPU_CORTEX_M || ARM64
+	depends on CPU_CORTEX_M || ARM64 || RISCV
 	help
 	  Enable this option to use semihosting for console.
-	  Semihosting is a mechanism that enables code running on an ARM target
-	  to communicate and use the Input/Output facilities on a host computer
-	  that is running a debugger.
+	  Semihosting is a mechanism that enables code running on an ARM or
+	  RISC-V target to communicate and use the Input/Output facilities
+	  on a host computer that is running a debugger.
 	  Additional information can be found in:
 	  https://developer.arm.com/docs/dui0471/k/what-is-semihosting/what-is-semihosting
+	  https://github.com/riscv/riscv-semihosting-spec/blob/main/riscv-semihosting-spec.adoc
 	  This option is compatible with hardware and with QEMU, through the
 	  (automatic) use of the -semihosting-config switch when invoking it.
 

--- a/drivers/console/semihost_console.c
+++ b/drivers/console/semihost_console.c
@@ -29,6 +29,20 @@ int arch_printk_char_out(int _c)
 
 	__asm__ volatile ("hlt 0xf000" : : "r" (x0), "r" (x1) : "memory");
 
+#elif defined(CONFIG_RISCV)
+
+	register unsigned long a0 __asm__("a0") = SYS_WRITEC;
+	register void *a1 __asm__("a1") = &c;
+
+	__asm__ volatile (
+	".option push\n\t"
+	".option norvc\n\t"
+	"slli zero, zero, 0x1f\n\t"
+	"ebreak\n\t"
+	"srai zero, zero, 0x7\n\t"
+	".option pop"
+	: : "r" (a0), "r" (a1) : "memory");
+
 #else
 #error "unsupported CPU type"
 #endif


### PR DESCRIPTION
The RISC-V version is supported by qemu and openocd.
Tested on qemu only.
