### PR TITLE
drivers: can: allow calling can_set_bitrate() from userspace

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -207,7 +207,7 @@ uint16_t sample_point_for_bitrate(uint32_t bitrate)
 	return sample_pnt;
 }
 
-int can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t bitrate_data)
+int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t bitrate_data)
 {
 	struct can_timing timing;
 #ifdef CONFIG_CAN_FD_MODE

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -123,6 +123,15 @@ static inline int z_vrfy_can_set_mode(const struct device *dev, enum can_mode mo
 }
 #include <syscalls/can_set_mode_mrsh.c>
 
+static inline int z_vrfy_can_set_bitrate(const struct device *dev, uint32_t bitrate,
+					 uint32_t bitrate_data)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_timing));
+
+	return z_impl_can_set_bitrate(dev, bitrate, bitrate_data);
+}
+#include <syscalls/can_set_bitrate_mrsh.c>
+
 static inline int z_vrfy_can_send(const struct device *dev,
 				  const struct zcan_frame *frame,
 				  k_timeout_t timeout,

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -867,7 +867,7 @@ static inline int z_impl_can_set_mode(const struct device *dev, enum can_mode mo
  * @retval -EINVAL bitrate/sample point cannot be met.
  * @retval -EIO General input/output error, failed to set bitrate.
  */
-int can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t bitrate_data);
+__syscall int can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t bitrate_data);
 
 /** @} */
 

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -16,6 +16,11 @@
  */
 
 /**
+ * Test bitrate in bits/second.
+ */
+#define TEST_BITRATE 125000
+
+/**
  * @brief Test timeouts.
  */
 #define TEST_SEND_TIMEOUT    K_MSEC(100)
@@ -635,6 +640,17 @@ static void test_set_bitrate_too_high(void)
 }
 
 /**
+ * @brief Test setting bitrate.
+ */
+static void test_set_bitrate(void)
+{
+	int err;
+
+	err = can_set_bitrate(can_dev, TEST_BITRATE, 0);
+	zassert_equal(err, 0, "failed to set bitrate");
+}
+
+/**
  * @brief Test configuring the CAN controller for loopback mode.
  *
  * This test case must be run before sending/receiving test cases as it allows
@@ -903,6 +919,7 @@ void test_main(void)
 			 ztest_user_unit_test(test_get_core_clock),
 			 ztest_unit_test(test_set_state_change_callback),
 			 ztest_user_unit_test(test_set_bitrate_too_high),
+			 ztest_user_unit_test(test_set_bitrate),
 			 ztest_user_unit_test(test_set_loopback),
 			 ztest_user_unit_test(test_send_and_forget),
 			 ztest_unit_test(test_add_filter),


### PR DESCRIPTION
- Add syscall to allow calling can_set_bitrate() from userspace.
- Add test for can_set_bitrate() syscall.