### PR TITLE
twister: harness: configure to have tests running after that pass.

### DIFF
--- a/scripts/pylib/twister/harness.py
+++ b/scripts/pylib/twister/harness.py
@@ -32,7 +32,6 @@ class Harness:
         self.fieldnames = []
         self.ztest = False
         self.is_pytest = False
-        self.detected_suite_names = []
 
     def configure(self, instance):
         config = instance.testcase.harness_config
@@ -220,14 +219,8 @@ class Pytest(Harness):
 class Test(Harness):
     RUN_PASSED = "PROJECT EXECUTION SUCCESSFUL"
     RUN_FAILED = "PROJECT EXECUTION FAILED"
-    test_suite_start_pattern = r"Running test suite (?P<suite_name>.*)"
 
     def handle(self, line):
-        test_suite_match = re.search(self.test_suite_start_pattern, line)
-        if test_suite_match:
-            suite_name = test_suite_match.group("suite_name")
-            self.detected_suite_names.append(suite_name)
-
         match = result_re.match(line)
         if match and match.group(2):
             name = "{}.{}".format(self.id, match.group(3))

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1928,8 +1928,7 @@ Tests should reference the category and subsystem with a dot as a separator.
         has_test_main = False
         ztest_suite_names = []
 
-        src_dir_path = self._find_src_dir_path(path)
-        for filename in glob.glob(os.path.join(src_dir_path, "*.c*")):
+        for filename in glob.glob(os.path.join(path, "src", "*.c*")):
             try:
                 result: ScanPathResult = self.scan_file(filename)
                 if result.warnings:
@@ -1982,21 +1981,6 @@ Tests should reference the category and subsystem with a dot as a separator.
             self.cases.append(self.id)
 
         self.ztest_suite_names = ztest_suite_names
-
-    @staticmethod
-    def _find_src_dir_path(test_dir_path):
-        """
-        Try to find src directory with test source code. Sometimes due to the
-        optimization reasons it is placed in upper directory.
-        """
-        src_dir_name = "src"
-        src_dir_path = os.path.join(test_dir_path, src_dir_name)
-        if os.path.isdir(src_dir_path):
-            return src_dir_path
-        src_dir_path = os.path.join(test_dir_path, "..", src_dir_name)
-        if os.path.isdir(src_dir_path):
-            return src_dir_path
-        return ""
 
     def __str__(self):
         return self.name

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1793,8 +1793,9 @@ Tests should reference the category and subsystem with a dot as a separator.
                     )
         return unique
 
-    def scan_file(self, inf_name):
-        regular_suite_regex = re.compile(
+    @staticmethod
+    def scan_file(inf_name):
+        suite_regex = re.compile(
             # do not match until end-of-line, otherwise we won't allow
             # stc_regex below to catch the ones that are declared in the same
             # line--as we only search starting the end of this match
@@ -1803,9 +1804,6 @@ Tests should reference the category and subsystem with a dot as a separator.
         registered_suite_regex = re.compile(
             br"^\s*ztest_register_test_suite"
             br"\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,",
-            re.MULTILINE)
-        new_suite_regex = re.compile(
-            br"^\s*ZTEST_SUITE\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,",
             re.MULTILINE)
         # Checks if the file contains a definition of "void test_main(void)"
         # Since ztest provides a plain test_main implementation it is OK to:
@@ -1816,11 +1814,35 @@ Tests should reference the category and subsystem with a dot as a separator.
         test_main_regex = re.compile(
             br"^\s*void\s+test_main\(void\)",
             re.MULTILINE)
+        stc_regex = re.compile(
+            br"""^\s*  # empty space at the beginning is ok
+            # catch the case where it is declared in the same sentence, e.g:
+            #
+            # ztest_test_suite(mutex_complex, ztest_user_unit_test(TESTNAME));
+            # ztest_register_test_suite(n, p, ztest_user_unit_test(TESTNAME),
+            (?:ztest_
+              (?:test_suite\(|register_test_suite\([a-zA-Z0-9_]+\s*,\s*)
+              [a-zA-Z0-9_]+\s*,\s*
+            )?
+            # Catch ztest[_user]_unit_test-[_setup_teardown](TESTNAME)
+            ztest_(?:1cpu_)?(?:user_)?unit_test(?:_setup_teardown)?
+            # Consume the argument that becomes the extra testcase
+            \(\s*(?P<stc_name>[a-zA-Z0-9_]+)
+            # _setup_teardown() variant has two extra arguments that we ignore
+            (?:\s*,\s*[a-zA-Z0-9_]+\s*,\s*[a-zA-Z0-9_]+)?
+            \s*\)""",
+            # We don't check how it finishes; we don't care
+            re.MULTILINE | re.VERBOSE)
+        suite_run_regex = re.compile(
+            br"^\s*ztest_run_test_suite\((?P<suite_name>[a-zA-Z0-9_]+)\)",
+            re.MULTILINE)
         registered_suite_run_regex = re.compile(
             br"^\s*ztest_run_registered_test_suites\("
             br"(\*+|&)?(?P<state_identifier>[a-zA-Z0-9_]+)\)",
             re.MULTILINE)
-
+        achtung_regex = re.compile(
+            br"(#ifdef|#endif)",
+            re.MULTILINE)
         warnings = None
         has_registered_test_suites = False
         has_run_registered_test_suites = False
@@ -1834,12 +1856,10 @@ Tests should reference the category and subsystem with a dot as a separator.
                              'offset': 0}
 
             with contextlib.closing(mmap.mmap(**mmap_args)) as main_c:
-                regular_suite_regex_matches = \
-                    [m for m in regular_suite_regex.finditer(main_c)]
+                suite_regex_matches = \
+                    [m for m in suite_regex.finditer(main_c)]
                 registered_suite_regex_matches = \
                     [m for m in registered_suite_regex.finditer(main_c)]
-                new_suite_regex_matches = \
-                    [m for m in new_suite_regex.finditer(main_c)]
 
                 if registered_suite_regex_matches:
                     has_registered_test_suites = True
@@ -1848,140 +1868,58 @@ Tests should reference the category and subsystem with a dot as a separator.
                 if test_main_regex.search(main_c):
                     has_test_main = True
 
-                if regular_suite_regex_matches:
-                    ztest_suite_names = \
-                        self._extract_ztest_suite_names(regular_suite_regex_matches)
-                    testcase_names, warnings = \
-                        self._find_regular_ztest_testcases(main_c, regular_suite_regex_matches, has_registered_test_suites)
-                elif registered_suite_regex_matches:
-                    ztest_suite_names = \
-                        self._extract_ztest_suite_names(registered_suite_regex_matches)
-                    testcase_names, warnings = \
-                        self._find_regular_ztest_testcases(main_c, registered_suite_regex_matches, has_registered_test_suites)
-                elif new_suite_regex_matches:
-                    ztest_suite_names = \
-                        self._extract_ztest_suite_names(new_suite_regex_matches)
-                    testcase_names, warnings = \
-                        self._find_new_ztest_testcases(main_c)
-                else:
+                if not suite_regex_matches and not has_registered_test_suites:
                     # can't find ztest_test_suite, maybe a client, because
                     # it includes ztest.h
-                    ztest_suite_names = []
-                    testcase_names, warnings = None, None
+                    return ScanPathResult(
+                        matches=None,
+                        warnings=None,
+                        has_registered_test_suites=has_registered_test_suites,
+                        has_run_registered_test_suites=has_run_registered_test_suites,
+                        has_test_main=has_test_main,
+                        ztest_suite_names=[])
 
+                suite_run_match = suite_run_regex.search(main_c)
+                if suite_regex_matches and not suite_run_match:
+                    raise ValueError("can't find ztest_run_test_suite")
+
+                if suite_regex_matches:
+                    search_start = suite_regex_matches[0].end()
+                    ztest_suite_names = \
+                        [m.group("suite_name") for m in suite_regex_matches]
+                else:
+                    search_start = registered_suite_regex_matches[0].end()
+                    ztest_suite_names = \
+                        [m.group("suite_name") for m in registered_suite_regex_matches]
+                ztest_suite_names = \
+                    [name.decode("UTF-8") for name in ztest_suite_names]
+
+                if suite_run_match:
+                    search_end = suite_run_match.start()
+                else:
+                    search_end = re.compile(br"\);", re.MULTILINE) \
+                        .search(main_c, search_start) \
+                        .end()
+                achtung_matches = re.findall(
+                    achtung_regex,
+                    main_c[search_start:search_end])
+                if achtung_matches:
+                    warnings = "found invalid %s in ztest_test_suite()" \
+                               % ", ".join(sorted({match.decode() for match in achtung_matches},reverse = True))
+                _matches = re.findall(
+                    stc_regex,
+                    main_c[search_start:search_end])
+                for match in _matches:
+                    if not match.decode().startswith("test_"):
+                        warnings = "Found a test that does not start with test_"
+                matches = [match.decode().replace("test_", "", 1) for match in _matches]
                 return ScanPathResult(
-                    matches=testcase_names,
+                    matches=matches,
                     warnings=warnings,
                     has_registered_test_suites=has_registered_test_suites,
                     has_run_registered_test_suites=has_run_registered_test_suites,
                     has_test_main=has_test_main,
                     ztest_suite_names=ztest_suite_names)
-
-    @staticmethod
-    def _extract_ztest_suite_names(suite_regex_matches):
-        ztest_suite_names = \
-            [m.group("suite_name") for m in suite_regex_matches]
-        ztest_suite_names = \
-            [name.decode("UTF-8") for name in ztest_suite_names]
-        return ztest_suite_names
-
-    def _find_regular_ztest_testcases(self, search_area, suite_regex_matches, is_registered_test_suite):
-        """
-        Find regular ztest testcases like "ztest_unit_test" or similar. Return
-        testcases' names and eventually found warnings.
-        """
-        testcase_regex = re.compile(
-            br"""^\s*  # empty space at the beginning is ok
-            # catch the case where it is declared in the same sentence, e.g:
-            #
-            # ztest_test_suite(mutex_complex, ztest_user_unit_test(TESTNAME));
-            # ztest_register_test_suite(n, p, ztest_user_unit_test(TESTNAME),
-            (?:ztest_
-              (?:test_suite\(|register_test_suite\([a-zA-Z0-9_]+\s*,\s*)
-              [a-zA-Z0-9_]+\s*,\s*
-            )?
-            # Catch ztest[_user]_unit_test-[_setup_teardown](TESTNAME)
-            ztest_(?:1cpu_)?(?:user_)?unit_test(?:_setup_teardown)?
-            # Consume the argument that becomes the extra testcase
-            \(\s*(?P<testcase_name>[a-zA-Z0-9_]+)
-            # _setup_teardown() variant has two extra arguments that we ignore
-            (?:\s*,\s*[a-zA-Z0-9_]+\s*,\s*[a-zA-Z0-9_]+)?
-            \s*\)""",
-            # We don't check how it finishes; we don't care
-            re.MULTILINE | re.VERBOSE)
-        achtung_regex = re.compile(
-            br"(#ifdef|#endif)",
-            re.MULTILINE)
-
-        search_start, search_end = \
-            self._get_search_area_boundary(search_area, suite_regex_matches, is_registered_test_suite)
-        limited_search_area = search_area[search_start:search_end]
-        testcase_names, warnings = \
-            self._find_ztest_testcases(limited_search_area, testcase_regex)
-
-        achtung_matches = re.findall(achtung_regex, limited_search_area)
-        if achtung_matches and warnings is None:
-            achtung = ", ".join(sorted({match.decode() for match in achtung_matches},reverse = True))
-            warnings = f"found invalid {achtung} in ztest_test_suite()"
-
-        return testcase_names, warnings
-
-    @staticmethod
-    def _get_search_area_boundary(search_area, suite_regex_matches, is_registered_test_suite):
-        """
-        Get search area boundary based on "ztest_test_suite(...)",
-        "ztest_register_test_suite(...)" or "ztest_run_test_suite(...)"
-        functions occurrence.
-        """
-        suite_run_regex = re.compile(
-            br"^\s*ztest_run_test_suite\((?P<suite_name>[a-zA-Z0-9_]+)\)",
-            re.MULTILINE)
-
-        search_start = suite_regex_matches[0].end()
-
-        suite_run_match = suite_run_regex.search(search_area)
-        if suite_run_match:
-            search_end = suite_run_match.start()
-        elif not suite_run_match and not is_registered_test_suite:
-            raise ValueError("can't find ztest_run_test_suite")
-        else:
-            search_end = re.compile(br"\);", re.MULTILINE) \
-                .search(search_area, search_start) \
-                .end()
-
-        return search_start, search_end
-
-    def _find_new_ztest_testcases(self, search_area):
-        """
-        Find regular ztest testcases like "ZTEST" or "ZTEST_F". Return
-        testcases' names and eventually found warnings.
-        """
-        testcase_regex = re.compile(
-            br"^\s*(?:ZTEST|ZTEST_F)\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,"
-            br"\s*(?P<testcase_name>[a-zA-Z0-9_]+)\s*",
-            re.MULTILINE)
-
-        return self._find_ztest_testcases(search_area, testcase_regex)
-
-    @staticmethod
-    def _find_ztest_testcases(search_area, testcase_regex):
-        """
-        Parse search area and try to find testcases defined in testcase_regex
-        argument. Return testcase names and eventually found warnings.
-        """
-        testcase_regex_matches = \
-            [m for m in testcase_regex.finditer(search_area)]
-        testcase_names = \
-            [m.group("testcase_name") for m in testcase_regex_matches]
-        testcase_names = [name.decode("UTF-8") for name in testcase_names]
-        warnings = None
-        for testcase_name in testcase_names:
-            if not testcase_name.startswith("test_"):
-                warnings = "Found a test that does not start with test_"
-        testcase_names = \
-            [tc_name.replace("test_", "", 1) for tc_name in testcase_names]
-
-        return testcase_names, warnings
 
     def scan_path(self, path):
         subcases = []

--- a/scripts/tests/twister/test_testinstance.py
+++ b/scripts/tests/twister/test_testinstance.py
@@ -124,31 +124,27 @@ TESTDATA_5 = [
                   'user', 'last'],
          has_registered_test_suites=False,
          has_run_registered_test_suites=False,
-         has_test_main=False,
-         ztest_suite_names = ["test_api"])),
+         has_test_main=False)),
     ("testcases/tests/test_a/test_ztest_error.c",
      ScanPathResult(
          warnings="Found a test that does not start with test_",
          matches=['1a', '1c', '2a', '2b'],
          has_registered_test_suites=False,
          has_run_registered_test_suites=False,
-         has_test_main=True,
-         ztest_suite_names = ["feature1", "feature2"])),
+         has_test_main=True)),
     ("testcases/tests/test_a/test_ztest_error_1.c",
      ScanPathResult(
          warnings="found invalid #ifdef, #endif in ztest_test_suite()",
          matches=['unit_1a', 'unit_1b', 'Unit_1c'],
          has_registered_test_suites=False,
          has_run_registered_test_suites=False,
-         has_test_main=False,
-         ztest_suite_names = ["feature3"])),
+         has_test_main=False)),
     ("testcases/tests/test_d/test_ztest_error_register_test_suite.c",
      ScanPathResult(
          warnings=None, matches=['unit_1a', 'unit_1b'],
          has_registered_test_suites=True,
          has_run_registered_test_suites=False,
-         has_test_main=False,
-         ztest_suite_names = ["feature4"])),
+         has_test_main=False)),
 ]
 
 @pytest.mark.parametrize("test_file, expected", TESTDATA_5)
@@ -163,26 +159,17 @@ def test_scan_file(test_data, test_file, expected: ScanPathResult):
 
 
 TESTDATA_6 = [
-    (
-        "testcases/tests",
-        ['a', 'c', 'unit_a', 'newline', 'test_test_aa', 'user', 'last'],
-        ["test_api"]
-    ),
-    (
-        "testcases/tests/test_a",
-        ['unit_1a', 'unit_1b', 'Unit_1c', '1a', '1c', '2a', '2b'],
-        ["feature3", "feature1", "feature2"]
-    ),
+    ("testcases/tests", ['a', 'c', 'unit_a', 'newline', 'test_test_aa', 'user', 'last']),
+    ("testcases/tests/test_a", ['unit_1a', 'unit_1b', 'Unit_1c', '1a', '1c', '2a', '2b']),
 ]
 
-@pytest.mark.parametrize("test_path, expected_subcases, expected_ztest_suite_names", TESTDATA_6)
-def test_subcases(test_data, test_path, expected_subcases, expected_ztest_suite_names):
+@pytest.mark.parametrize("test_path, expected_subcases", TESTDATA_6)
+def test_subcases(test_data, test_path, expected_subcases):
     '''Testing scan path and parse subcases methods for expected subcases'''
     testcase = TestCase("/scripts/tests/twister/test_data/testcases/tests", ".", "test_a.check_1")
 
-    subcases, ztest_suite_names = testcase.scan_path(os.path.join(test_data, test_path))
+    subcases = testcase.scan_path(os.path.join(test_data, test_path))
     assert sorted(subcases) == sorted(expected_subcases)
-    assert sorted(ztest_suite_names) == sorted(expected_ztest_suite_names)
 
     testcase.id = "test_id"
     testcase.parse_subcases(test_data + test_path)


### PR DESCRIPTION
To fix the ci: twister test failure "Testsuite mismatch"

Fix https://github.com/zephyrproject-rtos/zephyr/issues/44539

Signed-off-by: Francois Ramu <francois.ramu@st.com>