### PR TITLE
dt: pwm: add period set helpers

### DIFF
--- a/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
+++ b/boards/arm/nucleo_f031k6/nucleo_f031k6.dts
@@ -30,7 +30,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm2 2 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm2 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
+++ b/boards/arm/nucleo_f303k8/nucleo_f303k8.dts
@@ -30,7 +30,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm2 2 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm2 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -33,7 +33,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm2 1 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -32,7 +32,7 @@
 		compatible = "pwm-leds";
 
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -33,7 +33,7 @@
 		compatible = "pwm-leds";
 
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
+++ b/boards/arm/nucleo_h723zg/nucleo_h723zg.dts
@@ -41,7 +41,7 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm12 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm12 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "User LD3 - PWM12";
 		};
 	};

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -39,7 +39,7 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm12 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm12 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
+++ b/boards/arm/nucleo_h745zi_q/nucleo_h745zi_q_m7.dts
@@ -33,7 +33,7 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm12 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm12 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "User LD3 - PWM12";
 		};
 	};

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -39,7 +39,7 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm12 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm12 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -37,7 +37,7 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm12 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm12 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -40,7 +40,7 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm15 1 4 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm15 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -42,16 +42,16 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm4 1 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm4 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 		orange_pwm_led: orange_pwm_led {
-			pwms = <&pwm4 2 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm4 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm4 3 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm4 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&pwm4 4 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm4 4 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/include/dt-bindings/pwm/pwm.h
+++ b/include/dt-bindings/pwm/pwm.h
@@ -7,6 +7,24 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PWM_PWM_H_
 
 /**
+ * @name PWM period set helpers
+ * The period cell in the PWM specifier needs to be provided in nanoseconds.
+ * However, in some applications it is more convenient to use another scale.
+ * @{
+ */
+
+/** Specify PWM period in nanoseconds */
+#define PWM_NSEC(x)	(x)
+/** Specify PWM period in microseconds */
+#define PWM_USEC(x)	(PWM_NSEC(x) * 1000UL)
+/** Specify PWM period in milliseconds */
+#define PWM_MSEC(x)	(PWM_USEC(x) * 1000UL)
+/** Specify PWM period in seconds */
+#define PWM_SEC(x)	(PWM_MSEC(x) * 1000UL)
+
+/** @} */
+
+/**
  * @name PWM polarity flags
  * The `PWM_POLARITY_*` flags are used with pwm_pin_set_cycles(),
  * pwm_pin_set_usec(), pwm_pin_set_nsec() or pwm_pin_configure_capture() to


### PR DESCRIPTION
The period cell in the PWM specifier needs to be provided in nanoseconds.
However, in some applications it is more convenient to use another scale
such as milliseconds. This patch introduces 3 helpers to allow using
seconds, milliseconds and microseconds scales.

Prep-work for #44523 