### PR TITLE
net: mqtt: remove custom logging macros

### DIFF
--- a/subsys/net/lib/mqtt/mqtt.c
+++ b/subsys/net/lib/mqtt/mqtt.c
@@ -53,7 +53,7 @@ static void client_disconnect(struct mqtt_client *client, int result,
 
 	err_code = mqtt_transport_disconnect(client);
 	if (err_code < 0) {
-		MQTT_ERR("Failed to disconnect transport!");
+		NET_ERR("Failed to disconnect transport!");
 	}
 
 	/* Reset internal state. */
@@ -100,7 +100,7 @@ static int client_connect(struct mqtt_client *client)
 	/* Reset the unanswered ping count for a new connection */
 	client->unacked_ping = 0;
 
-	MQTT_TRC("Connect completed");
+	NET_INFO("Connect completed");
 
 	return 0;
 
@@ -130,17 +130,17 @@ static int client_write(struct mqtt_client *client, const uint8_t *data,
 {
 	int err_code;
 
-	MQTT_TRC("[%p]: Transport writing %d bytes.", client, datalen);
+	NET_DBG("[%p]: Transport writing %d bytes.", client, datalen);
 
 	err_code = mqtt_transport_write(client, data, datalen);
 	if (err_code < 0) {
-		MQTT_TRC("Transport write failed, err_code = %d, "
+		NET_ERR("Transport write failed, err_code = %d, "
 			 "closing connection", err_code);
 		client_disconnect(client, err_code, true);
 		return err_code;
 	}
 
-	MQTT_TRC("[%p]: Transport write complete.", client);
+	NET_DBG("[%p]: Transport write complete.", client);
 	client->internal.last_activity = mqtt_sys_tick_in_ms_get();
 
 	return 0;
@@ -151,17 +151,17 @@ static int client_write_msg(struct mqtt_client *client,
 {
 	int err_code;
 
-	MQTT_TRC("[%p]: Transport writing message.", client);
+	NET_DBG("[%p]: Transport writing message.", client);
 
 	err_code = mqtt_transport_write_msg(client, message);
 	if (err_code < 0) {
-		MQTT_TRC("Transport write failed, err_code = %d, "
+		NET_ERR("Transport write failed, err_code = %d, "
 			 "closing connection", err_code);
 		client_disconnect(client, err_code, true);
 		return err_code;
 	}
 
-	MQTT_TRC("[%p]: Transport write complete.", client);
+	NET_DBG("[%p]: Transport write complete.", client);
 	client->internal.last_activity = mqtt_sys_tick_in_ms_get();
 
 	return 0;
@@ -247,7 +247,7 @@ int mqtt_publish(struct mqtt_client *client,
 	NULL_PARAM_CHECK(client);
 	NULL_PARAM_CHECK(param);
 
-	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Topic size 0x%08x, "
+	NET_DBG("[CID %p]:[State 0x%02x]: >> Topic size 0x%08x, "
 		 "Data size 0x%08x", client, client->internal.state,
 		 param->message.topic.topic.size,
 		 param->message.payload.len);
@@ -279,7 +279,7 @@ int mqtt_publish(struct mqtt_client *client,
 	err_code = client_write_msg(client, &msg);
 
 error:
-	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+	NET_DBG("[CID %p]:[State 0x%02x]: << result 0x%08x",
 			 client, client->internal.state, err_code);
 
 	mqtt_mutex_unlock(client);
@@ -296,7 +296,7 @@ int mqtt_publish_qos1_ack(struct mqtt_client *client,
 	NULL_PARAM_CHECK(client);
 	NULL_PARAM_CHECK(param);
 
-	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+	NET_DBG("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
 		 client, client->internal.state, param->message_id);
 
 	mqtt_mutex_lock(client);
@@ -316,7 +316,7 @@ int mqtt_publish_qos1_ack(struct mqtt_client *client,
 	err_code = client_write(client, packet.cur, packet.end - packet.cur);
 
 error:
-	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+	NET_DBG("[CID %p]:[State 0x%02x]: << result 0x%08x",
 		 client, client->internal.state, err_code);
 
 	mqtt_mutex_unlock(client);
@@ -333,7 +333,7 @@ int mqtt_publish_qos2_receive(struct mqtt_client *client,
 	NULL_PARAM_CHECK(client);
 	NULL_PARAM_CHECK(param);
 
-	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+	NET_DBG("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
 		 client, client->internal.state, param->message_id);
 
 	mqtt_mutex_lock(client);
@@ -353,7 +353,7 @@ int mqtt_publish_qos2_receive(struct mqtt_client *client,
 	err_code = client_write(client, packet.cur, packet.end - packet.cur);
 
 error:
-	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+	NET_DBG("[CID %p]:[State 0x%02x]: << result 0x%08x",
 		 client, client->internal.state, err_code);
 
 	mqtt_mutex_unlock(client);
@@ -370,7 +370,7 @@ int mqtt_publish_qos2_release(struct mqtt_client *client,
 	NULL_PARAM_CHECK(client);
 	NULL_PARAM_CHECK(param);
 
-	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+	NET_DBG("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
 		 client, client->internal.state, param->message_id);
 
 	mqtt_mutex_lock(client);
@@ -390,7 +390,7 @@ int mqtt_publish_qos2_release(struct mqtt_client *client,
 	err_code = client_write(client, packet.cur, packet.end - packet.cur);
 
 error:
-	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+	NET_DBG("[CID %p]:[State 0x%02x]: << result 0x%08x",
 		 client, client->internal.state, err_code);
 
 	mqtt_mutex_unlock(client);
@@ -407,7 +407,7 @@ int mqtt_publish_qos2_complete(struct mqtt_client *client,
 	NULL_PARAM_CHECK(client);
 	NULL_PARAM_CHECK(param);
 
-	MQTT_TRC("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
+	NET_DBG("[CID %p]:[State 0x%02x]: >> Message id 0x%04x",
 		 client, client->internal.state, param->message_id);
 
 	mqtt_mutex_lock(client);
@@ -430,7 +430,7 @@ int mqtt_publish_qos2_complete(struct mqtt_client *client,
 	}
 
 error:
-	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+	NET_DBG("[CID %p]:[State 0x%02x]: << result 0x%08x",
 		 client, client->internal.state, err_code);
 
 	mqtt_mutex_unlock(client);
@@ -481,7 +481,7 @@ int mqtt_subscribe(struct mqtt_client *client,
 	NULL_PARAM_CHECK(client);
 	NULL_PARAM_CHECK(param);
 
-	MQTT_TRC("[CID %p]:[State 0x%02x]: >> message id 0x%04x "
+	NET_DBG("[CID %p]:[State 0x%02x]: >> message id 0x%04x "
 		 "topic count 0x%04x", client, client->internal.state,
 		 param->message_id, param->list_count);
 
@@ -502,7 +502,7 @@ int mqtt_subscribe(struct mqtt_client *client,
 	err_code = client_write(client, packet.cur, packet.end - packet.cur);
 
 error:
-	MQTT_TRC("[CID %p]:[State 0x%02x]: << result 0x%08x",
+	NET_DBG("[CID %p]:[State 0x%02x]: << result 0x%08x",
 		 client, client->internal.state, err_code);
 
 	mqtt_mutex_unlock(client);
@@ -565,7 +565,7 @@ int mqtt_ping(struct mqtt_client *client)
 	err_code = client_write(client, packet.cur, packet.end - packet.cur);
 
 	if (client->unacked_ping >= INT8_MAX) {
-		MQTT_TRC("PING count overflow!");
+		NET_WARN("PING count overflow!");
 	} else {
 		client->unacked_ping++;
 	}
@@ -644,7 +644,7 @@ int mqtt_input(struct mqtt_client *client)
 
 	mqtt_mutex_lock(client);
 
-	MQTT_TRC("state:0x%08x", client->internal.state);
+	NET_DBG("state:0x%08x", client->internal.state);
 
 	if (MQTT_HAS_STATE(client, MQTT_STATE_TCP_CONNECTED)) {
 		err_code = client_read(client);

--- a/subsys/net/lib/mqtt/mqtt_decoder.c
+++ b/subsys/net/lib/mqtt/mqtt_decoder.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(net_mqtt_dec, CONFIG_MQTT_LOG_LEVEL);
  */
 static int unpack_uint8(struct buf_ctx *buf, uint8_t *val)
 {
-	MQTT_TRC(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
 
 	if ((buf->end - buf->cur) < sizeof(uint8_t)) {
 		return -EINVAL;
@@ -37,7 +37,7 @@ static int unpack_uint8(struct buf_ctx *buf, uint8_t *val)
 
 	*val = *(buf->cur++);
 
-	MQTT_TRC("<< val:%02x", *val);
+	NET_DBG("<< val:%02x", *val);
 
 	return 0;
 }
@@ -55,7 +55,7 @@ static int unpack_uint8(struct buf_ctx *buf, uint8_t *val)
  */
 static int unpack_uint16(struct buf_ctx *buf, uint16_t *val)
 {
-	MQTT_TRC(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
 
 	if ((buf->end - buf->cur) < sizeof(uint16_t)) {
 		return -EINVAL;
@@ -64,7 +64,7 @@ static int unpack_uint16(struct buf_ctx *buf, uint16_t *val)
 	*val = *(buf->cur++) << 8; /* MSB */
 	*val |= *(buf->cur++); /* LSB */
 
-	MQTT_TRC("<< val:%04x", *val);
+	NET_DBG("<< val:%04x", *val);
 
 	return 0;
 }
@@ -85,7 +85,7 @@ static int unpack_utf8_str(struct buf_ctx *buf, struct mqtt_utf8 *str)
 	uint16_t utf8_strlen;
 	int err_code;
 
-	MQTT_TRC(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
 
 	err_code = unpack_uint16(buf, &utf8_strlen);
 	if (err_code != 0) {
@@ -106,7 +106,7 @@ static int unpack_utf8_str(struct buf_ctx *buf, struct mqtt_utf8 *str)
 		str->utf8 = NULL;
 	}
 
-	MQTT_TRC("<< str_size:%08x", (uint32_t)GET_UT8STR_BUFFER_SIZE(str));
+	NET_DBG("<< str_size:%08x", (uint32_t)GET_UT8STR_BUFFER_SIZE(str));
 
 	return 0;
 }
@@ -126,7 +126,7 @@ static int unpack_utf8_str(struct buf_ctx *buf, struct mqtt_utf8 *str)
 static int unpack_data(uint32_t length, struct buf_ctx *buf,
 		       struct mqtt_binstr *str)
 {
-	MQTT_TRC(">> cur:%p, end:%p", buf->cur, buf->end);
+	NET_DBG(">> cur:%p, end:%p", buf->cur, buf->end);
 
 	if ((buf->end - buf->cur) < length) {
 		return -EINVAL;
@@ -142,7 +142,7 @@ static int unpack_data(uint32_t length, struct buf_ctx *buf,
 		str->data = NULL;
 	}
 
-	MQTT_TRC("<< bin len:%08x", GET_BINSTR_BUFFER_SIZE(str));
+	NET_DBG("<< bin len:%08x", GET_BINSTR_BUFFER_SIZE(str));
 
 	return 0;
 }
@@ -183,7 +183,7 @@ static int packet_length_decode(struct buf_ctx *buf, uint32_t *length)
 		return -EINVAL;
 	}
 
-	MQTT_TRC("length:0x%08x", *length);
+	NET_DBG("length:0x%08x", *length);
 
 	return 0;
 }
@@ -221,7 +221,7 @@ int connect_ack_decode(const struct mqtt_client *client, struct buf_ctx *buf,
 		param->session_present_flag =
 			flags & MQTT_CONNACK_FLAG_SESSION_PRESENT;
 
-		MQTT_TRC("[CID %p]: session_present_flag: %d", client,
+		NET_DBG("[CID %p]: session_present_flag: %d", client,
 			 param->session_present_flag);
 	}
 
@@ -257,7 +257,7 @@ int publish_decode(uint8_t flags, uint32_t var_length, struct buf_ctx *buf,
 	}
 
 	if (var_length < var_header_length) {
-		MQTT_ERR("Corrupted PUBLISH message, header length (%u) larger "
+		NET_ERR("Corrupted PUBLISH message, header length (%u) larger "
 			 "than total length (%u)", var_header_length,
 			 var_length);
 		return -EINVAL;

--- a/subsys/net/lib/mqtt/mqtt_encoder.c
+++ b/subsys/net/lib/mqtt/mqtt_encoder.c
@@ -49,7 +49,7 @@ static int pack_uint8(uint8_t val, struct buf_ctx *buf)
 		return -ENOMEM;
 	}
 
-	MQTT_TRC(">> val:%02x cur:%p, end:%p", val, buf->cur, buf->end);
+	NET_DBG(">> val:%02x cur:%p, end:%p", val, buf->cur, buf->end);
 
 	/* Pack value. */
 	*(buf->cur++) = val;
@@ -73,7 +73,7 @@ static int pack_uint16(uint16_t val, struct buf_ctx *buf)
 		return -ENOMEM;
 	}
 
-	MQTT_TRC(">> val:%04x cur:%p, end:%p", val, buf->cur, buf->end);
+	NET_DBG(">> val:%04x cur:%p, end:%p", val, buf->cur, buf->end);
 
 	/* Pack value. */
 	*(buf->cur++) = (val >> 8) & 0xFF;
@@ -98,7 +98,7 @@ static int pack_utf8_str(const struct mqtt_utf8 *str, struct buf_ctx *buf)
 		return -ENOMEM;
 	}
 
-	MQTT_TRC(">> str_size:%08x cur:%p, end:%p",
+	NET_DBG(">> str_size:%08x cur:%p, end:%p",
 		 (uint32_t)GET_UT8STR_BUFFER_SIZE(str), buf->cur, buf->end);
 
 	/* Pack length followed by string. */
@@ -139,7 +139,7 @@ static uint8_t packet_length_encode(uint32_t length, struct buf_ctx *buf)
 {
 	uint8_t encoded_bytes = 0U;
 
-	MQTT_TRC(">> length:0x%08x cur:%p, end:%p", length,
+	NET_DBG(">> length:0x%08x cur:%p, end:%p", length,
 		 (buf == NULL) ? 0 : buf->cur, (buf == NULL) ? 0 : buf->end);
 
 	do {
@@ -193,12 +193,12 @@ static uint32_t mqtt_encode_fixed_header(uint8_t message_type, uint8_t *start,
 		return -EMSGSIZE;
 	}
 
-	MQTT_TRC("<< msg type:0x%02x length:0x%08x", message_type, length);
+	NET_DBG("<< msg type:0x%02x length:0x%08x", message_type, length);
 
 	fixed_header_length = packet_length_encode(length, NULL);
 	fixed_header_length += sizeof(uint8_t);
 
-	MQTT_TRC("Fixed header length = %02x", fixed_header_length);
+	NET_DBG("Fixed header length = %02x", fixed_header_length);
 
 	/* Set the pointer at the start of the frame before encoding. */
 	buf->cur = start - fixed_header_length;
@@ -287,7 +287,7 @@ int connect_request_encode(const struct mqtt_client *client,
 	buf->cur += MQTT_FIXED_HEADER_MAX_SIZE;
 	start = buf->cur;
 
-	MQTT_HEXDUMP_TRC(mqtt_proto_desc->utf8, mqtt_proto_desc->size,
+	NET_HEXDUMP_DBG(mqtt_proto_desc->utf8, mqtt_proto_desc->size,
 			 "Encoding Protocol Description.");
 
 	err_code = pack_utf8_str(mqtt_proto_desc, buf);
@@ -295,7 +295,7 @@ int connect_request_encode(const struct mqtt_client *client,
 		return err_code;
 	}
 
-	MQTT_TRC("Encoding Protocol Version %02x.", client->protocol_version);
+	NET_DBG("Encoding Protocol Version %02x.", client->protocol_version);
 	err_code = pack_uint8(client->protocol_version, buf);
 	if (err_code != 0) {
 		return err_code;
@@ -311,13 +311,13 @@ int connect_request_encode(const struct mqtt_client *client,
 		return err_code;
 	}
 
-	MQTT_TRC("Encoding Keep Alive Time %04x.", client->keepalive);
+	NET_DBG("Encoding Keep Alive Time %04x.", client->keepalive);
 	err_code = pack_uint16(client->keepalive, buf);
 	if (err_code != 0) {
 		return err_code;
 	}
 
-	MQTT_HEXDUMP_TRC(client->client_id.utf8, client->client_id.size,
+	NET_HEXDUMP_DBG(client->client_id.utf8, client->client_id.size,
 			 "Encoding Client Id.");
 	err_code = pack_utf8_str(&client->client_id, buf);
 	if (err_code != 0) {
@@ -331,7 +331,7 @@ int connect_request_encode(const struct mqtt_client *client,
 		connect_flags |= ((client->will_topic->qos & 0x03) << 3);
 		connect_flags |= client->will_retain << 5;
 
-		MQTT_HEXDUMP_TRC(client->will_topic->topic.utf8,
+		NET_HEXDUMP_DBG(client->will_topic->topic.utf8,
 				 client->will_topic->topic.size,
 				 "Encoding Will Topic.");
 		err_code = pack_utf8_str(&client->will_topic->topic, buf);
@@ -340,7 +340,7 @@ int connect_request_encode(const struct mqtt_client *client,
 		}
 
 		if (client->will_message != NULL) {
-			MQTT_HEXDUMP_TRC(client->will_message->utf8,
+			NET_HEXDUMP_DBG(client->will_message->utf8,
 					 client->will_message->size,
 					 "Encoding Will Message.");
 			err_code = pack_utf8_str(client->will_message, buf);
@@ -348,7 +348,7 @@ int connect_request_encode(const struct mqtt_client *client,
 				return err_code;
 			}
 		} else {
-			MQTT_TRC("Encoding Zero Length Will Message.");
+			NET_DBG("Encoding Zero Length Will Message.");
 			err_code = zero_len_str_encode(buf);
 			if (err_code != 0) {
 				return err_code;
@@ -360,7 +360,7 @@ int connect_request_encode(const struct mqtt_client *client,
 	if (client->user_name != NULL) {
 		connect_flags |= MQTT_CONNECT_FLAG_USERNAME;
 
-		MQTT_HEXDUMP_TRC(client->user_name->utf8,
+		NET_HEXDUMP_DBG(client->user_name->utf8,
 				 client->user_name->size,
 				 "Encoding Username.");
 		err_code = pack_utf8_str(client->user_name, buf);
@@ -373,7 +373,7 @@ int connect_request_encode(const struct mqtt_client *client,
 	if (client->password != NULL) {
 		connect_flags |= MQTT_CONNECT_FLAG_PASSWORD;
 
-		MQTT_HEXDUMP_TRC(client->password->utf8,
+		NET_HEXDUMP_DBG(client->password->utf8,
 				 client->password->size,
 				 "Encoding Password.");
 		err_code = pack_utf8_str(client->password, buf);

--- a/subsys/net/lib/mqtt/mqtt_os.h
+++ b/subsys/net/lib/mqtt/mqtt_os.h
@@ -30,24 +30,6 @@
 extern "C" {
 #endif
 
-/**@brief Method to get trace logs from the module. */
-#define MQTT_TRC(...) NET_DBG(__VA_ARGS__)
-
-/**@brief Method to error logs from the module. */
-#define MQTT_ERR(...) NET_ERR(__VA_ARGS__)
-
-/**@brief Method to hexdump trace logs from the module. */
-#define MQTT_HEXDUMP_TRC(_data, _length, _str) NET_HEXDUMP_DBG(_data, _length, _str)
-
-/**@brief Method to hexdump error logs from the module. */
-#define MQTT_HEXDUMP_ERR(_data, _length, _str) NET_HEXDUMP_ERR(_data, _length, _str)
-
-/**@brief Method to hexdump warning logs from the module. */
-#define MQTT_HEXDUMP_WARN(_data, _length, _str) NET_HEXDUMP_WARN(_data, _length, _str)
-
-/**@brief Method to hexdump info logs from the module. */
-#define MQTT_HEXDUMP_INFO(_data, _length, _str) NETHEXDUMP_INFO(_data, _length, _str)
-
 /**@brief Initialize the mutex for the module, if any.
  *
  * @details This method is called during module initialization @ref mqtt_init.

--- a/subsys/net/lib/mqtt/mqtt_rx.c
+++ b/subsys/net/lib/mqtt/mqtt_rx.c
@@ -30,12 +30,12 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 
 	switch (type_and_flags & 0xF0) {
 	case MQTT_PKT_TYPE_CONNACK:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_CONNACK!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_CONNACK!", client);
 
 		evt.type = MQTT_EVT_CONNACK;
 		err_code = connect_ack_decode(client, buf, &evt.param.connack);
 		if (err_code == 0) {
-			MQTT_TRC("[CID %p]: return_code: %d", client,
+			NET_DBG("[CID %p]: return_code: %d", client,
 				 evt.param.connack.return_code);
 
 			if (evt.param.connack.return_code ==
@@ -54,7 +54,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_PUBLISH:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBLISH", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_PUBLISH", client);
 
 		evt.type = MQTT_EVT_PUBLISH;
 		err_code = publish_decode(type_and_flags, var_length, buf,
@@ -64,7 +64,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		client->internal.remaining_payload =
 					evt.param.publish.message.payload.len;
 
-		MQTT_TRC("PUB QoS:%02x, message len %08x, topic len %08x",
+		NET_DBG("PUB QoS:%02x, message len %08x, topic len %08x",
 			 evt.param.publish.message.topic.qos,
 			 evt.param.publish.message.payload.len,
 			 evt.param.publish.message.topic.topic.size);
@@ -72,7 +72,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_PUBACK:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBACK!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_PUBACK!", client);
 
 		evt.type = MQTT_EVT_PUBACK;
 		err_code = publish_ack_decode(buf, &evt.param.puback);
@@ -80,7 +80,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_PUBREC:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBREC!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_PUBREC!", client);
 
 		evt.type = MQTT_EVT_PUBREC;
 		err_code = publish_receive_decode(buf, &evt.param.pubrec);
@@ -88,7 +88,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_PUBREL:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBREL!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_PUBREL!", client);
 
 		evt.type = MQTT_EVT_PUBREL;
 		err_code = publish_release_decode(buf, &evt.param.pubrel);
@@ -96,7 +96,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_PUBCOMP:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PUBCOMP!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_PUBCOMP!", client);
 
 		evt.type = MQTT_EVT_PUBCOMP;
 		err_code = publish_complete_decode(buf, &evt.param.pubcomp);
@@ -104,7 +104,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_SUBACK:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_SUBACK!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_SUBACK!", client);
 
 		evt.type = MQTT_EVT_SUBACK;
 		err_code = subscribe_ack_decode(buf, &evt.param.suback);
@@ -112,7 +112,7 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_UNSUBACK:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_UNSUBACK!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_UNSUBACK!", client);
 
 		evt.type = MQTT_EVT_UNSUBACK;
 		err_code = unsubscribe_ack_decode(buf, &evt.param.unsuback);
@@ -120,10 +120,10 @@ static int mqtt_handle_packet(struct mqtt_client *client,
 		break;
 
 	case MQTT_PKT_TYPE_PINGRSP:
-		MQTT_TRC("[CID %p]: Received MQTT_PKT_TYPE_PINGRSP!", client);
+		NET_DBG("[CID %p]: Received MQTT_PKT_TYPE_PINGRSP!", client);
 
 		if (client->unacked_ping <= 0) {
-			MQTT_TRC("Unexpected PINGRSP");
+			NET_WARN("Unexpected PINGRSP");
 			client->unacked_ping = 0;
 		} else {
 			client->unacked_ping--;
@@ -164,19 +164,21 @@ static int mqtt_read_message_chunk(struct mqtt_client *client,
 	/* Check if read does not exceed the buffer. */
 	if ((buf->end + remaining > client->rx_buf + client->rx_buf_size) ||
 	    (buf->end + remaining < client->rx_buf)) {
-		MQTT_ERR("[CID %p]: Read would exceed RX buffer bounds.",
+		NET_ERR("[CID %p]: Read would exceed RX buffer bounds.",
 			 client);
 		return -ENOMEM;
 	}
 
 	len = mqtt_transport_read(client, buf->end, remaining, false);
 	if (len < 0) {
-		MQTT_TRC("[CID %p]: Transport read error: %d", client, len);
+		if (len != -EAGAIN) {
+			NET_ERR("[CID %p]: Transport read error: %d", client, len);
+		}
 		return len;
 	}
 
 	if (len == 0) {
-		MQTT_TRC("[CID %p]: Connection closed.", client);
+		NET_ERR("[CID %p]: Connection closed.", client);
 		return -ENOTCONN;
 	}
 
@@ -184,7 +186,7 @@ static int mqtt_read_message_chunk(struct mqtt_client *client,
 	buf->end += len;
 
 	if (len < remaining) {
-		MQTT_TRC("[CID %p]: Message partially received.", client);
+		NET_ERR("[CID %p]: Message partially received.", client);
 		return -EAGAIN;
 	}
 

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tcp.c
@@ -41,7 +41,7 @@ int mqtt_client_tcp_connect(struct mqtt_client *client)
 	}
 #endif
 
-	MQTT_TRC("Created socket %d", client->transport.tcp.sock);
+	NET_DBG("Created socket %d", client->transport.tcp.sock);
 
 	size_t peer_addr_size = sizeof(struct sockaddr_in6);
 
@@ -55,7 +55,7 @@ int mqtt_client_tcp_connect(struct mqtt_client *client)
 		goto error;
 	}
 
-	MQTT_TRC("Connect completed");
+	NET_DBG("Connect completed");
 	return 0;
 
 error:
@@ -144,7 +144,7 @@ int mqtt_client_tcp_disconnect(struct mqtt_client *client)
 {
 	int ret;
 
-	MQTT_TRC("Closing socket %d", client->transport.tcp.sock);
+	NET_INFO("Closing socket %d", client->transport.tcp.sock);
 
 	ret = zsock_close(client->transport.tcp.sock);
 	if (ret < 0) {

--- a/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_socket_tls.c
@@ -30,7 +30,7 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 		return -errno;
 	}
 
-	MQTT_TRC("Created socket %d", client->transport.tls.sock);
+	NET_DBG("Created socket %d", client->transport.tls.sock);
 
 #if defined(CONFIG_SOCKS)
 	if (client->transport.proxy.addrlen != 0) {
@@ -99,7 +99,7 @@ int mqtt_client_tls_connect(struct mqtt_client *client)
 		goto error;
 	}
 
-	MQTT_TRC("Connect completed");
+	NET_DBG("Connect completed");
 	return 0;
 
 error:
@@ -187,7 +187,7 @@ int mqtt_client_tls_disconnect(struct mqtt_client *client)
 {
 	int ret;
 
-	MQTT_TRC("Closing socket %d", client->transport.tls.sock);
+	NET_INFO("Closing socket %d", client->transport.tls.sock);
 	ret = zsock_close(client->transport.tls.sock);
 	if (ret < 0) {
 		return -errno;

--- a/subsys/net/lib/mqtt/mqtt_transport_websocket.c
+++ b/subsys/net/lib/mqtt/mqtt_transport_websocket.c
@@ -74,14 +74,14 @@ int mqtt_client_websocket_connect(struct mqtt_client *client)
 			client->transport.websocket.timeout,
 			NULL);
 	if (client->transport.websocket.sock < 0) {
-		MQTT_TRC("Websocket connect failed (%d)",
+		NET_ERR("Websocket connect failed (%d)",
 			 client->transport.websocket.sock);
 
 		(void)close(transport_sock);
 		return client->transport.websocket.sock;
 	}
 
-	MQTT_TRC("Connect completed");
+	NET_DBG("Connect completed");
 
 	return 0;
 }
@@ -165,7 +165,7 @@ int mqtt_client_websocket_read(struct mqtt_client *client, uint8_t *data,
 
 int mqtt_client_websocket_disconnect(struct mqtt_client *client)
 {
-	MQTT_TRC("Closing socket %d", client->transport.websocket.sock);
+	NET_INFO("Closing socket %d", client->transport.websocket.sock);
 
 	return websocket_disconnect(client->transport.websocket.sock);
 }


### PR DESCRIPTION
Remove the custom MQTT logging macros and just use the NET macros
directly. The custom macros provide no additional functionality and the
non-standard naming can cause confusion.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>