### PR TITLE
net: context: log on net_pkt alloc fail

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1638,6 +1638,7 @@ static int context_sendto(struct net_context *context,
 
 	pkt = context_alloc_pkt(context, len, PKT_WAIT_TIME);
 	if (!pkt) {
+		NET_ERR("Failed to allocate net_pkt");
 		return -ENOBUFS;
 	}
 


### PR DESCRIPTION
Log an error when allocating a network packet for transmission fails.
This is a problem which can be solved by increasing
`CONFIG_NET_PKT_TX_COUNT`, but is currently hard to diagnose.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>