### PR TITLE
wifi: esp_at: log message on async close

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -509,6 +509,8 @@ MODEM_CMD_DEFINE(on_cmd_closed)
 
 	link_id = data->match_buf[0] - '0';
 
+	LOG_DBG("Link %d closed", link_id);
+
 	dev = CONTAINER_OF(data, struct esp_data, cmd_handler_data);
 	sock = esp_socket_ref_from_link_id(dev, link_id);
 	if (!sock) {


### PR DESCRIPTION
Log a warning when the modem asynchronously closes a link. This is
useful information to the user as it can explain the root cause of later
failures.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>