### PR TITLE
drivers: pwm: check if pulse > period and other cleanups

### DIFF
--- a/drivers/pwm/pwm_gd32.c
+++ b/drivers/pwm/pwm_gd32.c
@@ -142,10 +142,6 @@ static int pwm_gd32_pin_set(const struct device *dev, uint32_t pwm,
 		return -EINVAL;
 	}
 
-	if (pulse_cycles > period_cycles) {
-		return -EINVAL;
-	}
-
 	/* 16-bit timers can count up to UINT16_MAX */
 	if (!config->is_32bit && (period_cycles > UINT16_MAX)) {
 		return -ENOTSUP;

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -60,7 +60,7 @@ static int imx_pwm_pin_set(const struct device *dev, uint32_t pwm,
 	uint32_t cr, sr;
 
 
-	if ((period_cycles == 0U) || (pulse_cycles > period_cycles)) {
+	if (period_cycles == 0U) {
 		LOG_ERR("Invalid combination: period_cycles=%d, "
 			    "pulse_cycles=%d", period_cycles, pulse_cycles);
 		return -EINVAL;

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -61,9 +61,8 @@ static int imx_pwm_pin_set(const struct device *dev, uint32_t pwm,
 
 
 	if (period_cycles == 0U) {
-		LOG_ERR("Invalid combination: period_cycles=%d, "
-			    "pulse_cycles=%d", period_cycles, pulse_cycles);
-		return -EINVAL;
+		LOG_ERR("Channel can not be set to inactive level");
+		return -ENOTSUP;
 	}
 
 	if (flags) {

--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -109,9 +109,6 @@ static int pwm_it8xxx2_pin_set(const struct device *dev,
 
 	ARG_UNUSED(pwm);
 
-	if (pulse_cycles > period_cycles)
-		return -EINVAL;
-
 	/* PWM channel clock source gating before configuring */
 	pwm_enable(dev, 0);
 

--- a/drivers/pwm/pwm_litex.c
+++ b/drivers/pwm/pwm_litex.c
@@ -25,9 +25,6 @@ struct pwm_litex_cfg {
 	volatile uint32_t *reg_period;
 };
 
-#define GET_PWM_CFG(dev)				       \
-	((const struct pwm_litex_cfg *) dev->config)
-
 static void litex_set_reg(volatile uint32_t *reg, uint32_t reg_size, uint32_t val)
 {
 	uint32_t shifted_data;
@@ -42,7 +39,7 @@ static void litex_set_reg(volatile uint32_t *reg, uint32_t reg_size, uint32_t va
 
 int pwm_litex_init(const struct device *dev)
 {
-	const struct pwm_litex_cfg *cfg = GET_PWM_CFG(dev);
+	const struct pwm_litex_cfg *cfg = dev->config;
 
 	litex_set_reg(cfg->reg_en, cfg->reg_en_size, REG_EN_ENABLE);
 	return 0;
@@ -52,7 +49,7 @@ int pwm_litex_pin_set(const struct device *dev, uint32_t pwm,
 		      uint32_t period_cycles,
 		      uint32_t pulse_cycles, pwm_flags_t flags)
 {
-	const struct pwm_litex_cfg *cfg = GET_PWM_CFG(dev);
+	const struct pwm_litex_cfg *cfg = dev->config;
 
 	if (pwm >= NUMBER_OF_CHANNELS) {
 		return -EINVAL;

--- a/drivers/pwm/pwm_mchp_xec.c
+++ b/drivers/pwm/pwm_mchp_xec.c
@@ -326,10 +326,6 @@ static int pwm_xec_pin_set(const struct device *dev, uint32_t pwm,
 		return -EIO;
 	}
 
-	if (pulse_cycles > period_cycles) {
-		return -EINVAL;
-	}
-
 	if (flags) {
 		/* PWM polarity not supported (yet?) */
 		return -ENOTSUP;

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -53,9 +53,8 @@ static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
 	}
 
 	if (period_cycles == 0) {
-		LOG_ERR("Invalid combination: period_cycles=%u, "
-			"pulse_cycles=%u", period_cycles, pulse_cycles);
-		return -EINVAL;
+		LOG_ERR("Channel can not be set to inactive level");
+		return -ENOTSUP;
 	}
 
 	if (period_cycles > UINT16_MAX) {

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -52,7 +52,7 @@ static int mcux_pwm_pin_set(const struct device *dev, uint32_t pwm,
 		return -ENOTSUP;
 	}
 
-	if ((period_cycles == 0) || (pulse_cycles > period_cycles)) {
+	if (period_cycles == 0) {
 		LOG_ERR("Invalid combination: period_cycles=%u, "
 			"pulse_cycles=%u", period_cycles, pulse_cycles);
 		return -EINVAL;

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -71,9 +71,8 @@ static int mcux_ftm_pin_set(const struct device *dev, uint32_t pwm,
 #endif /* CONFIG_PWM_CAPTURE */
 
 	if (period_cycles == 0U) {
-		LOG_ERR("Invalid combination: period_cycles=%d, "
-			    "pulse_cycles=%d", period_cycles, pulse_cycles);
-		return -EINVAL;
+		LOG_ERR("Channel can not be set to inactive level");
+		return -ENOTSUP;
 	}
 
 	if (pwm >= config->channel_count) {

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -70,7 +70,7 @@ static int mcux_ftm_pin_set(const struct device *dev, uint32_t pwm,
 	uint32_t irqs;
 #endif /* CONFIG_PWM_CAPTURE */
 
-	if ((period_cycles == 0U) || (pulse_cycles > period_cycles)) {
+	if (period_cycles == 0U) {
 		LOG_ERR("Invalid combination: period_cycles=%d, "
 			    "pulse_cycles=%d", period_cycles, pulse_cycles);
 		return -EINVAL;

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -42,7 +42,7 @@ static int mcux_sctimer_pwm_pin_set(const struct device *dev, uint32_t pwm,
 		return -EINVAL;
 	}
 
-	if ((period_cycles == 0) || (pulse_cycles > period_cycles)) {
+	if (period_cycles == 0) {
 		LOG_ERR("Invalid combination: period_cycles=%u, "
 			"pulse_cycles=%u", period_cycles, pulse_cycles);
 		return -EINVAL;

--- a/drivers/pwm/pwm_mcux_sctimer.c
+++ b/drivers/pwm/pwm_mcux_sctimer.c
@@ -43,9 +43,8 @@ static int mcux_sctimer_pwm_pin_set(const struct device *dev, uint32_t pwm,
 	}
 
 	if (period_cycles == 0) {
-		LOG_ERR("Invalid combination: period_cycles=%u, "
-			"pulse_cycles=%u", period_cycles, pulse_cycles);
-		return -EINVAL;
+		LOG_ERR("Channel can not be set to inactive level");
+		return -ENOTSUP;
 	}
 
 	if ((flags & PWM_POLARITY_INVERTED) == 0) {

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -49,7 +49,7 @@ static int mcux_tpm_pin_set(const struct device *dev, uint32_t pwm,
 	struct mcux_tpm_data *data = dev->data;
 	uint8_t duty_cycle;
 
-	if ((period_cycles == 0U) || (pulse_cycles > period_cycles)) {
+	if (period_cycles == 0U) {
 		LOG_ERR("Invalid combination: period_cycles=%d, "
 			    "pulse_cycles=%d", period_cycles, pulse_cycles);
 		return -EINVAL;

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -50,9 +50,8 @@ static int mcux_tpm_pin_set(const struct device *dev, uint32_t pwm,
 	uint8_t duty_cycle;
 
 	if (period_cycles == 0U) {
-		LOG_ERR("Invalid combination: period_cycles=%d, "
-			    "pulse_cycles=%d", period_cycles, pulse_cycles);
-		return -EINVAL;
+		LOG_ERR("Channel can not be set to inactive level");
+		return -ENOTSUP;
 	}
 
 	if (pwm >= config->channel_count) {

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -102,10 +102,6 @@ static int pwm_npcx_pin_set(const struct device *dev, uint32_t pwm,
 	uint32_t dcr;
 	uint32_t prsc;
 
-	if (pulse_cycles > period_cycles) {
-		return -EINVAL;
-	}
-
 	ctl = inst->PWMCTL | BIT(NPCX_PWMCTL_PWR);
 
 	/* Select PWM inverted polarity (ie. active-low pulse). */

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -189,12 +189,6 @@ static int pwm_nrfx_pin_set(const struct device *dev, uint32_t pwm,
 		}
 	}
 
-	/* Limit pulse cycles to period cycles (meaning 100% duty), bigger
-	 * values might not fit after prescaling into the 15-bit field that
-	 * is filled below.
-	 */
-	pulse_cycles = MIN(pulse_cycles, period_cycles);
-
 	/* Store new pulse value bit[14:0], and polarity bit[15] for channel. */
 	data->current[channel] = (
 		(data->current[channel] & PWM_NRFX_CH_POLARITY_MASK)

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -46,7 +46,7 @@ static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t pwm,
 	struct rv32m1_tpm_data *data = dev->data;
 	uint8_t duty_cycle;
 
-	if ((period_cycles == 0U) || (pulse_cycles > period_cycles)) {
+	if (period_cycles == 0U) {
 		LOG_ERR("Invalid combination: period_cycles=%d, "
 			    "pulse_cycles=%d", period_cycles, pulse_cycles);
 		return -EINVAL;

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -47,9 +47,8 @@ static int rv32m1_tpm_pin_set(const struct device *dev, uint32_t pwm,
 	uint8_t duty_cycle;
 
 	if (period_cycles == 0U) {
-		LOG_ERR("Invalid combination: period_cycles=%d, "
-			    "pulse_cycles=%d", period_cycles, pulse_cycles);
-		return -EINVAL;
+		LOG_ERR("Channel can not be set to inactive level");
+		return -ENOTSUP;
 	}
 
 	if (pwm >= config->channel_count) {

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -54,7 +54,7 @@ static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
 		return -ENOTSUP;
 	}
 
-	if (period_cycles == 0U || pulse_cycles > period_cycles) {
+	if (period_cycles == 0U) {
 		return -EINVAL;
 	}
 

--- a/drivers/pwm/pwm_sam.c
+++ b/drivers/pwm/pwm_sam.c
@@ -55,7 +55,7 @@ static int sam_pwm_pin_set(const struct device *dev, uint32_t ch,
 	}
 
 	if (period_cycles == 0U) {
-		return -EINVAL;
+		return -ENOTSUP;
 	}
 
 	if (period_cycles > 0xffff) {

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -171,12 +171,6 @@ static int pwm_sifive_pin_set(const struct device *dev,
 		return -EIO;
 	}
 
-	if (pulse_cycles > period_cycles) {
-		LOG_ERR("Requested pulse %d is longer than period %d\n",
-			pulse_cycles, period_cycles);
-		return -EIO;
-	}
-
 	/* Set the pwmscale field */
 	sys_set_mask(PWM_REG(config, REG_PWMCFG),
 		     SF_PWMSCALEMASK,

--- a/drivers/pwm/pwm_sifive.c
+++ b/drivers/pwm/pwm_sifive.c
@@ -112,25 +112,14 @@ static int pwm_sifive_pin_set(const struct device *dev,
 			      uint32_t pulse_cycles,
 			      pwm_flags_t flags)
 {
-	const struct pwm_sifive_cfg *config = NULL;
+	const struct pwm_sifive_cfg *config = dev->config;
 	uint32_t count_max = 0U;
 	uint32_t max_cmp_val = 0U;
 	uint32_t pwmscale = 0U;
 
-	if (dev == NULL) {
-		LOG_ERR("The device instance pointer was NULL\n");
-		return -EFAULT;
-	}
-
 	if (flags) {
 		/* PWM polarity not supported (yet?) */
 		return -ENOTSUP;
-	}
-
-	config = dev->config;
-	if (config == NULL) {
-		LOG_ERR("The device configuration is NULL\n");
-		return -EFAULT;
 	}
 
 	if (pwm >= SF_NUMCHANNELS) {
@@ -139,7 +128,7 @@ static int pwm_sifive_pin_set(const struct device *dev,
 	}
 
 	/* Channel 0 sets the period, we can't output PWM with it */
-	if ((pwm == 0U)) {
+	if (pwm == 0U) {
 		LOG_ERR("PWM channel 0 cannot be configured\n");
 		return -ENOTSUP;
 	}

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -235,11 +235,6 @@ static int pwm_stm32_pin_set(const struct device *dev, uint32_t pwm,
 		return -EINVAL;
 	}
 
-	if (pulse_cycles > period_cycles) {
-		LOG_ERR("Invalid combination of pulse and period cycles");
-		return -EINVAL;
-	}
-
 	/*
 	 * Non 32-bit timers count from 0 up to the value in the ARR register
 	 * (16-bit). Thus period_cycles cannot be greater than UINT16_MAX + 1.

--- a/drivers/pwm/pwm_xlnx_axi_timer.c
+++ b/drivers/pwm/pwm_xlnx_axi_timer.c
@@ -74,11 +74,6 @@ static int xlnx_axi_timer_pin_set(const struct device *dev, uint32_t pwm,
 		return -ENOTSUP;
 	}
 
-	if (pulse_cycles > period_cycles) {
-		LOG_ERR("pulse cycles must be less than or equal to period");
-		return -EINVAL;
-	}
-
 	LOG_DBG("period = 0x%08x, pulse = 0x%08x", period_cycles, pulse_cycles);
 
 	if (pulse_cycles == 0) {

--- a/include/drivers/pwm.h
+++ b/include/drivers/pwm.h
@@ -179,6 +179,7 @@ __subsystem struct pwm_driver_api {
  * @param flags Flags for pin configuration.
  *
  * @retval 0 If successful.
+ * @retval -EINVAL If pulse > period.
  * @retval -errno Negative errno code on failure.
  */
 __syscall int pwm_pin_set_cycles(const struct device *dev, uint32_t pwm,
@@ -192,6 +193,10 @@ static inline int z_impl_pwm_pin_set_cycles(const struct device *dev,
 {
 	const struct pwm_driver_api *api =
 		(const struct pwm_driver_api *)dev->api;
+
+	if (pulse > period) {
+		return -EINVAL;
+	}
 
 	return api->pin_set(dev, pwm, period, pulse, flags);
 }


### PR DESCRIPTION
Calling pwm_pin_set_cycles with a pulse > period doesn't make sense. By
definition, pulse ranges from 0 up to the period value.

Also:
- The API spec states that calling pin_set() with period set to 0 is
equivalent to set the PWM channel to an inactive level. Some drivers
treat this input as invalid (-EINVAL), however, it's an unsupported
feature. Maybe it's due to copy&paste effect? This changes error message
to be clear, and changes return value to -ENOTSUP for this case.
- Other minor fixes I found while doing this work (please check commit messages)