### PR TITLE
soc: stm32: Fix DBGMCU register write for SWO configuration

### DIFF
--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -26,11 +26,13 @@
 static int st_stm32_common_config(const struct device *dev)
 {
 #ifdef CONFIG_LOG_BACKEND_SWO
-	/* TRACE pin assignment for asynchronous mode */
-	DBGMCU->CR &= ~DBGMCU_CR_TRACE_MODE_Msk;
-	/* Enable the SWO pin */
-	DBGMCU->CR |= DBGMCU_CR_TRACE_IOEN;
+	/* Enable SWO trace asynchronous mode */
+#if defined(CONFIG_SOC_SERIES_STM32WBX)
+	LL_DBGMCU_EnableTraceClock();
+#else
+	LL_DBGMCU_SetTracePinAssignment(LL_DBGMCU_TRACE_ASYNCH);
 #endif
+#endif /* CONFIG_LOG_BACKEND_SWO */
 
 #if defined(CONFIG_USE_SEGGER_RTT)
 	/* On some STM32 boards, for unclear reason,


### PR DESCRIPTION
DBGMCU register, which is used for SWO pin configuration,
may not have TRACE_MODE bits in some STM32 MCUs.
Remove unnecessary clear for these MCUs.

Fixes #44584

Signed-off-by: Alexander Vasiliev <alex.m.vasil@gmail.com>