### PR TITLE
Bluetooth: Audio: Media - pass structs by reference instead of by value

### DIFF
--- a/include/zephyr/bluetooth/audio/mcc.h
+++ b/include/zephyr/bluetooth/audio/mcc.h
@@ -313,7 +313,7 @@ typedef void (*bt_mcc_read_media_state_cb)(struct bt_conn *conn, int err, uint8_
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param cmd           The command sent
  */
-typedef void (*bt_mcc_send_cmd_cb)(struct bt_conn *conn, int err, struct mpl_cmd cmd);
+typedef void (*bt_mcc_send_cmd_cb)(struct bt_conn *conn, int err, const struct mpl_cmd *cmd);
 
 /**
  * @brief Callback function for command notifications
@@ -328,7 +328,7 @@ typedef void (*bt_mcc_send_cmd_cb)(struct bt_conn *conn, int err, struct mpl_cmd
  * @param err           Error value. 0 on success, GATT error or errno on fail
  * @param ntf           The command notification
  */
-typedef void (*bt_mcc_cmd_ntf_cb)(struct bt_conn *conn, int err, struct mpl_cmd_ntf ntf);
+typedef void (*bt_mcc_cmd_ntf_cb)(struct bt_conn *conn, int err, const struct mpl_cmd_ntf *ntf);
 
 /**
  * @brief Callback function for bt_mcc_read_opcodes_supported()
@@ -353,7 +353,7 @@ typedef void (*bt_mcc_read_opcodes_supported_cb)(struct bt_conn *conn, int err,
  * @param search        The search set (or attempted to set)
  */
 typedef void (*bt_mcc_send_search_cb)(struct bt_conn *conn, int err,
-				      struct mpl_search search);
+				      const struct mpl_search *search);
 
 /**
  * @brief Callback function for search notifications
@@ -815,7 +815,7 @@ int bt_mcc_read_media_state(struct bt_conn *conn);
  *
  * @return 0 if success, errno on failure.
  */
-int bt_mcc_send_cmd(struct bt_conn *conn, struct mpl_cmd cmd);
+int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd);
 
 /**
  * @brief Read Opcodes Supported
@@ -837,7 +837,7 @@ int bt_mcc_read_opcodes_supported(struct bt_conn *conn);
  *
  * @return 0 if success, errno on failure.
  */
-int bt_mcc_send_search(struct bt_conn *conn, struct mpl_search search);
+int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search);
 
 /**
  * @brief Search Results Group Object ID

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -593,7 +593,7 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param cmd      The command sent
 	 */
-	void (*command_send)(struct media_player *player, int err, struct mpl_cmd cmd);
+	void (*command_send)(struct media_player *player, int err, const struct mpl_cmd *cmd);
 
 	/**
 	 * @brief Command result receive callback
@@ -606,7 +606,8 @@ struct media_proxy_ctrl_cbs {
 	 *                 or errno on negative value.
 	 * @param result   The result received
 	 */
-	void (*command_recv)(struct media_player *player, int err, struct mpl_cmd_ntf result);
+	void (*command_recv)(struct media_player *player, int err,
+			     const struct mpl_cmd_ntf *result);
 
 	/**
 	 * @brief Commands supported receive callback
@@ -632,7 +633,7 @@ struct media_proxy_ctrl_cbs {
 	 *                      or errno on negative value.
 	 * @param search        The search sent
 	 */
-	void (*search_send)(struct media_player *player, int err, struct mpl_search search);
+	void (*search_send)(struct media_player *player, int err, const struct mpl_search *search);
 
 	/**
 	 * @brief Search result code receive callback
@@ -1035,7 +1036,7 @@ int media_proxy_ctrl_get_media_state(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_send_command(struct media_player *player, struct mpl_cmd command);
+int media_proxy_ctrl_send_command(struct media_player *player, const struct mpl_cmd *command);
 
 /**
  * @brief Read Commands Supported
@@ -1068,7 +1069,7 @@ int media_proxy_ctrl_get_commands_supported(struct media_player *player);
  *
  * @return 0 if success, errno on failure.
  */
-int media_proxy_ctrl_send_search(struct media_player *player, struct mpl_search search);
+int media_proxy_ctrl_send_search(struct media_player *player, const struct mpl_search *search);
 
 /**
  * @brief Read Search Results Object ID
@@ -1376,7 +1377,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param command	The command to send
 	 */
-	void (*send_command)(struct mpl_cmd command);
+	void (*send_command)(const struct mpl_cmd *command);
 
 	/**
 	 * @brief Read Commands Supported
@@ -1399,7 +1400,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * @param search	The search to write
 	 */
-	void (*send_search)(struct mpl_search search);
+	void (*send_search)(const struct mpl_search *search);
 
 	/**
 	 * @brief Read Search Results Object ID
@@ -1578,7 +1579,7 @@ void media_proxy_pl_media_state_cb(uint8_t state);
  *
  * @param cmd_ntf	The result of the command
  */
-void media_proxy_pl_command_cb(struct mpl_cmd_ntf cmd_ntf);
+void media_proxy_pl_command_cb(const struct mpl_cmd_ntf *cmd_ntf);
 
 /**
  * @brief Commands supported callback

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -200,7 +200,7 @@ static uint8_t mcc_read_player_name_cb(struct bt_conn *conn, uint8_t err,
 			length = sizeof(name) - 1;
 		}
 
-		memcpy(&name, data, length);
+		(void)memcpy(&name, data, length);
 		name[length] = '\0';
 		BT_DBG("Player name: %s", log_strdup(name));
 	}
@@ -259,7 +259,7 @@ static uint8_t mcc_read_icon_url_cb(struct bt_conn *conn, uint8_t err,
 		cb_err = BT_ATT_ERR_INSUFFICIENT_RESOURCES;
 	} else {
 		BT_HEXDUMP_DBG(data, length, "Icon URL");
-		memcpy(&url, data, length);
+		(void)memcpy(&url, data, length);
 		url[length] = '\0';
 		BT_DBG("Icon URL: %s", log_strdup(url));
 	}
@@ -289,7 +289,7 @@ static uint8_t mcc_read_track_title_cb(struct bt_conn *conn, uint8_t err,
 			/* If the description is too long; clip it. */
 			length = sizeof(title) - 1;
 		}
-		memcpy(&title, data, length);
+		(void)memcpy(&title, data, length);
 		title[length] = '\0';
 		BT_DBG("Track title: %s", log_strdup(title));
 	}
@@ -778,9 +778,9 @@ static void mcs_write_cp_cb(struct bt_conn *conn, uint8_t err,
 		BT_DBG("length: %d, data: %p", params->length, params->data);
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
-		memcpy(&cmd.opcode, params->data, sizeof(cmd.opcode));
+		(void)memcpy(&cmd.opcode, params->data, sizeof(cmd.opcode));
 		if (params->length == sizeof(cmd.opcode) + sizeof(cmd.param)) {
-			memcpy(&cmd.param,
+			(void)memcpy(&cmd.param,
 			       (char *)(params->data) + sizeof(cmd.opcode),
 			       sizeof(cmd.param));
 			cmd.use_param = true;
@@ -838,7 +838,7 @@ static void mcs_write_scp_cb(struct bt_conn *conn, uint8_t err,
 		cb_err = BT_GATT_ERR(BT_ATT_ERR_INVALID_ATTRIBUTE_LEN);
 	} else {
 		search.len = params->length;
-		memcpy(search.search, params->data, params->length);
+		(void)memcpy(search.search, params->data, params->length);
 		BT_DBG("Length of returned value in callback: %d", search.len);
 	}
 
@@ -1485,7 +1485,7 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 	subscribe_all = subscribe;
 	memset(&discover_params, 0, sizeof(discover_params));
 	memset(&mcs_inst, 0, sizeof(mcs_inst));
-	memcpy(&uuid, BT_UUID_GMCS, sizeof(uuid));
+	(void)memcpy(&uuid, BT_UUID_GMCS, sizeof(uuid));
 
 	discover_params.func = discover_primary_func;
 	discover_params.uuid = &uuid.uuid;
@@ -1678,7 +1678,7 @@ int bt_mcc_set_track_position(struct bt_conn *conn, int32_t pos)
 		return -EBUSY;
 	}
 
-	memcpy(cur_mcs_inst->write_buf, &pos, sizeof(pos));
+	(void)memcpy(cur_mcs_inst->write_buf, &pos, sizeof(pos));
 
 	cur_mcs_inst->write_params.offset = 0;
 	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
@@ -1738,7 +1738,7 @@ int bt_mcc_set_playback_speed(struct bt_conn *conn, int8_t speed)
 		return -EBUSY;
 	}
 
-	memcpy(cur_mcs_inst->write_buf, &speed, sizeof(speed));
+	(void)memcpy(cur_mcs_inst->write_buf, &speed, sizeof(speed));
 
 	cur_mcs_inst->write_params.offset = 0;
 	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
@@ -2070,7 +2070,7 @@ int bt_mcc_set_playing_order(struct bt_conn *conn, uint8_t order)
 		return -EBUSY;
 	}
 
-	memcpy(cur_mcs_inst->write_buf, &order, sizeof(order));
+	(void)memcpy(cur_mcs_inst->write_buf, &order, sizeof(order));
 
 	cur_mcs_inst->write_params.offset = 0;
 	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
@@ -2158,10 +2158,10 @@ int bt_mcc_send_cmd(struct bt_conn *conn, const struct mpl_cmd *cmd)
 		return -EBUSY;
 	}
 
-	memcpy(cur_mcs_inst->write_buf, &cmd->opcode, length);
+	(void)memcpy(cur_mcs_inst->write_buf, &cmd->opcode, length);
 	if (cmd->use_param) {
 		length += sizeof(cmd->param);
-		memcpy(&cur_mcs_inst->write_buf[sizeof(cmd->opcode)], &cmd->param,
+		(void)memcpy(&cur_mcs_inst->write_buf[sizeof(cmd->opcode)], &cmd->param,
 		       sizeof(cmd->param));
 	}
 
@@ -2224,7 +2224,7 @@ int bt_mcc_send_search(struct bt_conn *conn, const struct mpl_search *search)
 		return -EBUSY;
 	}
 
-	memcpy(cur_mcs_inst->write_buf, &search->search, search->len);
+	(void)memcpy(cur_mcs_inst->write_buf, &search->search, search->len);
 
 	cur_mcs_inst->write_params.offset = 0;
 	cur_mcs_inst->write_params.data = cur_mcs_inst->write_buf;
@@ -2394,7 +2394,7 @@ static void decode_track_segments(struct net_buf_simple *buff,
 				seg->name_len =
 					CONFIG_BT_MCC_SEGMENT_NAME_MAX - 1;
 			}
-			memcpy(seg->name, name, seg->name_len);
+			(void)memcpy(seg->name, name, seg->name_len);
 		}
 		seg->name[seg->name_len] = '\0';
 

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -511,7 +511,7 @@ static ssize_t write_control_point(struct bt_conn *conn,
 		BT_DBG("Parameter: %d", command.param);
 	}
 
-	media_proxy_sctrl_send_command(command);
+	media_proxy_sctrl_send_command(&command);
 
 	return len;
 }
@@ -561,7 +561,7 @@ static ssize_t write_search_control_point(struct bt_conn *conn,
 	BT_DBG("Search length: %d", len);
 	BT_HEXDUMP_DBG(&search.search, search.len, "Search content");
 
-	media_proxy_sctrl_send_search(search);
+	media_proxy_sctrl_send_search(&search);
 
 	return len;
 }
@@ -919,11 +919,11 @@ void media_proxy_sctrl_media_state_cb(uint8_t state)
 	notify(BT_UUID_MCS_MEDIA_STATE, &state, sizeof(state));
 }
 
-void media_proxy_sctrl_command_cb(struct mpl_cmd_ntf cmd_ntf)
+void media_proxy_sctrl_command_cb(const struct mpl_cmd_ntf *cmd_ntf)
 {
 	BT_DBG("Notifying control point command - opcode: %d, result: %d",
-	       cmd_ntf.requested_opcode, cmd_ntf.result_code);
-	notify(BT_UUID_MCS_MEDIA_CONTROL_POINT, &cmd_ntf, sizeof(cmd_ntf));
+	       cmd_ntf->requested_opcode, cmd_ntf->result_code);
+	notify(BT_UUID_MCS_MEDIA_CONTROL_POINT, cmd_ntf, sizeof(*cmd_ntf));
 }
 
 void media_proxy_sctrl_commands_supported_cb(uint32_t opcodes)

--- a/subsys/bluetooth/audio/media_proxy.c
+++ b/subsys/bluetooth/audio/media_proxy.c
@@ -522,30 +522,30 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 	}
 }
 
-static void mcc_send_cmd_cb(struct bt_conn *conn, int err, struct mpl_cmd cmd)
+static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
 		BT_ERR("Command send failed (%d) - opcode: %d, param: %d",
-		       err, cmd.opcode, cmd.param);
+		       err, cmd->opcode, cmd->param);
 	}
 
 	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->command_send) {
-		mprx.ctrlr.cbs->command_send(&mprx.remote_player, err, cmd);
+		mprx.ctrlr.cbs->command_send(&mprx.remote_player, err, *cmd);
 	} else {
 		BT_DBG("No callback");
 	}
 }
 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
-			   struct mpl_cmd_ntf ntf)
+			   const struct mpl_cmd_ntf *ntf)
 {
 	if (err) {
 		BT_ERR("Command notification error (%d) - command opcode: %d, result: %d",
-		       err, ntf.requested_opcode, ntf.result_code);
+		       err, ntf->requested_opcode, ntf->result_code);
 	}
 
 	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->command_recv) {
-		mprx.ctrlr.cbs->command_recv(&mprx.remote_player, err, ntf);
+		mprx.ctrlr.cbs->command_recv(&mprx.remote_player, err, *ntf);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -565,14 +565,14 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err, uint32_
 }
 
 #ifdef CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS
-static void mcc_send_search_cb(struct bt_conn *conn, int err, struct mpl_search search)
+static void mcc_send_search_cb(struct bt_conn *conn, int err, const struct mpl_search *search)
 {
 	if (err) {
 		BT_ERR("Search send failed (%d)", err);
 	}
 
 	if (mprx.ctrlr.cbs && mprx.ctrlr.cbs->search_send) {
-		mprx.ctrlr.cbs->search_send(&mprx.remote_player, err, search);
+		mprx.ctrlr.cbs->search_send(&mprx.remote_player, err, *search);
 	} else {
 		BT_DBG("No callback");
 	}
@@ -1551,7 +1551,7 @@ int media_proxy_ctrl_send_command(struct media_player *player, struct mpl_cmd cm
 
 #if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
-		return bt_mcc_send_cmd(mprx.remote_player.conn, cmd);
+		return bt_mcc_send_cmd(mprx.remote_player.conn, &cmd);
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL */
 
@@ -1622,7 +1622,7 @@ int media_proxy_ctrl_send_search(struct media_player *player, struct mpl_search 
 
 #if defined(CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS)
 	if (mprx.remote_player.registered && player == &mprx.remote_player) {
-		return bt_mcc_send_search(mprx.remote_player.conn, search);
+		return bt_mcc_send_search(mprx.remote_player.conn, &search);
 	}
 #endif /* CONFIG_MCTL_REMOTE_PLAYER_CONTROL_OBJECTS */
 

--- a/subsys/bluetooth/audio/media_proxy_internal.h
+++ b/subsys/bluetooth/audio/media_proxy_internal.h
@@ -56,7 +56,7 @@ struct media_proxy_sctrl_cbs {
 
 	void (*media_state)(uint8_t state);
 
-	void (*command)(struct mpl_cmd_ntf cmd_ntf);
+	void (*command)(const struct mpl_cmd_ntf *cmd_ntf);
 
 	void (*commands_supported)(uint32_t opcodes);
 
@@ -114,12 +114,12 @@ uint16_t media_proxy_sctrl_get_playing_orders_supported(void);
 
 uint8_t media_proxy_sctrl_get_media_state(void);
 
-void media_proxy_sctrl_send_command(struct mpl_cmd command);
+void media_proxy_sctrl_send_command(const struct mpl_cmd *command);
 
 uint32_t media_proxy_sctrl_get_commands_supported(void);
 
 #ifdef CONFIG_BT_OTS
-void media_proxy_sctrl_send_search(struct mpl_search search);
+void media_proxy_sctrl_send_search(const struct mpl_search *search);
 
 uint64_t media_proxy_sctrl_get_search_results_id(void);
 #endif /* CONFIG_BT_OTS */

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -2614,35 +2614,36 @@ static void parse_search(struct mpl_search search)
 	bool search_failed = false;
 
 	if (search.len > SEARCH_LEN_MAX) {
-		BT_WARN("Search too long (%d) - truncating", search.len);
-		search.len = SEARCH_LEN_MAX;
-	}
-	BT_DBG("Parsing %d octets search", search.len);
+		BT_WARN("Search too long (%d) - aborting", search.len);
+		search_failed = true;
+	} else {
+		BT_DBG("Parsing %d octets search", search.len);
 
-	while (search.len - index > 0) {
-		sci.len = (uint8_t)search.search[index++];
-		if (sci.len < SEARCH_SCI_LEN_MIN) {
-			BT_WARN("Invalid length field - too small");
-			search_failed = true;
-			break;
-		}
-		if (sci.len > (search.len - index)) {
-			BT_WARN("Incomplete search control item");
-			search_failed = true;
-			break;
-		}
-		sci.type = (uint8_t)search.search[index++];
-		if (sci.type <  BT_MCS_SEARCH_TYPE_TRACK_NAME ||
-		    sci.type > BT_MCS_SEARCH_TYPE_ONLY_GROUPS) {
-			search_failed = true;
-			break;
-		}
-		memcpy(&sci.param, &search.search[index], sci.len - 1);
-		index += sci.len - 1;
+		while (search.len - index > 0) {
+			sci.len = (uint8_t)search.search[index++];
+			if (sci.len < SEARCH_SCI_LEN_MIN) {
+				BT_WARN("Invalid length field - too small");
+				search_failed = true;
+				break;
+			}
+			if (sci.len > (search.len - index)) {
+				BT_WARN("Incomplete search control item");
+				search_failed = true;
+				break;
+			}
+			sci.type = (uint8_t)search.search[index++];
+			if (sci.type <  BT_MCS_SEARCH_TYPE_TRACK_NAME ||
+			    sci.type > BT_MCS_SEARCH_TYPE_ONLY_GROUPS) {
+				search_failed = true;
+				break;
+			}
+			memcpy(&sci.param, &search.search[index], sci.len - 1);
+			index += sci.len - 1;
 
-		BT_DBG("SCI # %d: type: %d", sci_num, sci.type);
-		BT_HEXDUMP_DBG(sci.param, sci.len-1, "param:");
-		sci_num++;
+			BT_DBG("SCI # %d: type: %d", sci_num, sci.type);
+			BT_HEXDUMP_DBG(sci.param, sci.len-1, "param:");
+			sci_num++;
+		}
 	}
 
 	/* TODO: Add real search functionality. */

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -2589,7 +2589,6 @@ void send_command(struct mpl_cmd command)
 	if (command.use_param) {
 		BT_DBG("opcode: %d, param: %d", command.opcode, command.param);
 	} else {
-		command.param = 0; /* ensure that is set to 0 if not used */
 		BT_DBG("opcode: %d", command.opcode);
 	}
 

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -1397,16 +1397,16 @@ void do_full_goto_group(struct mpl_mediaplayer *pl, int32_t groupnum)
 }
 
 /* Command handlers (state machines) */
-void inactive_state_command_handler(struct mpl_cmd command,
-				    struct mpl_cmd_ntf ntf)
+void inactive_state_command_handler(const struct mpl_cmd *command,
+				    struct mpl_cmd_ntf *ntf)
 {
-	BT_DBG("Command opcode: %d", command.opcode);
+	BT_DBG("Command opcode: %d", command->opcode);
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MPL)) {
-		if (command.use_param) {
-			BT_DBG("Command parameter: %d", command.param);
+		if (command->use_param) {
+			BT_DBG("Command parameter: %d", command->param);
 		}
 	}
-	switch (command.opcode) {
+	switch (command->opcode) {
 	case BT_MCS_OPC_PLAY: /* Fall-through - handle several cases identically */
 	case BT_MCS_OPC_PAUSE:
 	case BT_MCS_OPC_FAST_REWIND:
@@ -1418,7 +1418,7 @@ void inactive_state_command_handler(struct mpl_cmd command,
 	case BT_MCS_OPC_FIRST_SEGMENT:
 	case BT_MCS_OPC_LAST_SEGMENT:
 	case BT_MCS_OPC_GOTO_SEGMENT:
-		ntf.result_code = BT_MCS_OPC_NTF_PLAYER_INACTIVE;
+		ntf->result_code = BT_MCS_OPC_NTF_PLAYER_INACTIVE;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_PREV_TRACK:
@@ -1434,7 +1434,7 @@ void inactive_state_command_handler(struct mpl_cmd command,
 		}
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_TRACK:
@@ -1457,7 +1457,7 @@ void inactive_state_command_handler(struct mpl_cmd command,
 		/* does not change */
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_TRACK:
@@ -1472,7 +1472,7 @@ void inactive_state_command_handler(struct mpl_cmd command,
 		}
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_TRACK:
@@ -1487,12 +1487,12 @@ void inactive_state_command_handler(struct mpl_cmd command,
 		}
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_TRACK:
-		if (command.use_param) {
-			if (do_goto_track(&pl, command.param)) {
+		if (command->use_param) {
+			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
 				do_track_change_notifications(&pl);
 			} else {
@@ -1504,9 +1504,9 @@ void inactive_state_command_handler(struct mpl_cmd command,
 			}
 			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -1514,68 +1514,68 @@ void inactive_state_command_handler(struct mpl_cmd command,
 		do_full_prev_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_GROUP:
 		do_full_next_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_GROUP:
 		do_full_first_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_GROUP:
 		do_full_last_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_GROUP:
-		if (command.use_param) {
-			do_full_goto_group(&pl, command.param);
+		if (command->use_param) {
+			do_full_goto_group(&pl, command->param);
 			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
-		BT_DBG("Invalid command: %d", command.opcode);
-		ntf.result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		BT_DBG("Invalid command: %d", command->opcode);
+		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
 }
 
-void playing_state_command_handler(struct mpl_cmd command,
-				   struct mpl_cmd_ntf ntf)
+void playing_state_command_handler(const struct mpl_cmd *command,
+				   struct mpl_cmd_ntf *ntf)
 {
-	BT_DBG("Command opcode: %d", command.opcode);
+	BT_DBG("Command opcode: %d", command->opcode);
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MPL)) {
-		if (command.use_param) {
-			BT_DBG("Command parameter: %d", command.param);
+		if (command->use_param) {
+			BT_DBG("Command parameter: %d", command->param);
 		}
 	}
-	switch (command.opcode) {
+	switch (command->opcode) {
 	case BT_MCS_OPC_PLAY:
 		/* Continue playing - i.e. do nothing */
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_PAUSE:
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FAST_REWIND:
@@ -1584,7 +1584,7 @@ void playing_state_command_handler(struct mpl_cmd command,
 		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FAST_FORWARD:
@@ -1593,7 +1593,7 @@ void playing_state_command_handler(struct mpl_cmd command,
 		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_STOP:
@@ -1601,23 +1601,23 @@ void playing_state_command_handler(struct mpl_cmd command,
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_MOVE_RELATIVE:
-		if (command.use_param) {
+		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
-			if (command.param >
+			if (command->param >
 			    pl.group->track->duration - pl.track_pos) {
 				pl.track_pos = pl.group->track->duration;
-			} else if (command.param < -pl.track_pos) {
+			} else if (command->param < -pl.track_pos) {
 				pl.track_pos = 0;
 			} else {
-				pl.track_pos += command.param;
+				pl.track_pos += command->param;
 			}
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_track_position_cb(pl.track_pos);
 		media_proxy_pl_command_cb(ntf);
@@ -1631,43 +1631,43 @@ void playing_state_command_handler(struct mpl_cmd command,
 		}
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_SEGMENT:
 		do_next_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_SEGMENT:
 		do_first_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_SEGMENT:
 		do_last_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_SEGMENT:
-		if (command.use_param) {
-			if (command.param != 0) {
-				do_goto_segment(&pl, command.param);
+		if (command->use_param) {
+			if (command->param != 0) {
+				do_goto_segment(&pl, command->param);
 				pl.track_pos = pl.group->track->segment->pos;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
 			/* track position shall not change. */
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -1682,7 +1682,7 @@ void playing_state_command_handler(struct mpl_cmd command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_TRACK:
@@ -1699,7 +1699,7 @@ void playing_state_command_handler(struct mpl_cmd command,
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_TRACK:
@@ -1712,7 +1712,7 @@ void playing_state_command_handler(struct mpl_cmd command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_TRACK:
@@ -1725,12 +1725,12 @@ void playing_state_command_handler(struct mpl_cmd command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_TRACK:
-		if (command.use_param) {
-			if (do_goto_track(&pl, command.param)) {
+		if (command->use_param) {
+			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
 				do_track_change_notifications(&pl);
 			} else {
@@ -1740,68 +1740,68 @@ void playing_state_command_handler(struct mpl_cmd command,
 				pl.track_pos = 0;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_PREV_GROUP:
 		do_full_prev_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_GROUP:
 		do_full_next_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_GROUP:
 		do_full_first_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_GROUP:
 		do_full_last_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_GROUP:
-		if (command.use_param) {
-			do_full_goto_group(&pl, command.param);
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		if (command->use_param) {
+			do_full_goto_group(&pl, command->param);
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
-		BT_DBG("Invalid command: %d", command.opcode);
-		ntf.result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		BT_DBG("Invalid command: %d", command->opcode);
+		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
 }
 
-void paused_state_command_handler(struct mpl_cmd command,
-				  struct mpl_cmd_ntf ntf)
+void paused_state_command_handler(const struct mpl_cmd *command,
+				  struct mpl_cmd_ntf *ntf)
 {
-	BT_DBG("Command opcode: %d", command.opcode);
+	BT_DBG("Command opcode: %d", command->opcode);
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MPL)) {
-		if (command.use_param) {
-			BT_DBG("Command parameter: %d", command.param);
+		if (command->use_param) {
+			BT_DBG("Command parameter: %d", command->param);
 		}
 	}
-	switch (command.opcode) {
+	switch (command->opcode) {
 	case BT_MCS_OPC_PLAY:
 		pl.state = BT_MCS_MEDIA_STATE_PLAYING;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_PAUSE:
 		/* No change */
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FAST_REWIND:
@@ -1810,7 +1810,7 @@ void paused_state_command_handler(struct mpl_cmd command,
 		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FAST_FORWARD:
@@ -1819,7 +1819,7 @@ void paused_state_command_handler(struct mpl_cmd command,
 		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_STOP:
@@ -1827,23 +1827,23 @@ void paused_state_command_handler(struct mpl_cmd command,
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_MOVE_RELATIVE:
-		if (command.use_param) {
+		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
-			if (command.param >
+			if (command->param >
 			    pl.group->track->duration - pl.track_pos) {
 				pl.track_pos = pl.group->track->duration;
-			} else if (command.param < -pl.track_pos) {
+			} else if (command->param < -pl.track_pos) {
 				pl.track_pos = 0;
 			} else {
-				pl.track_pos += command.param;
+				pl.track_pos += command->param;
 			}
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_track_position_cb(pl.track_pos);
 		media_proxy_pl_command_cb(ntf);
@@ -1857,43 +1857,43 @@ void paused_state_command_handler(struct mpl_cmd command,
 		}
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_SEGMENT:
 		do_next_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_SEGMENT:
 		do_first_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_SEGMENT:
 		do_last_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_SEGMENT:
-		if (command.use_param) {
-			if (command.param != 0) {
-				do_goto_segment(&pl, command.param);
+		if (command->use_param) {
+			if (command->param != 0) {
+				do_goto_segment(&pl, command->param);
 				pl.track_pos = pl.group->track->segment->pos;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
 			/* track position shall not change. */
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -1908,7 +1908,7 @@ void paused_state_command_handler(struct mpl_cmd command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_TRACK:
@@ -1925,7 +1925,7 @@ void paused_state_command_handler(struct mpl_cmd command,
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_TRACK:
@@ -1938,7 +1938,7 @@ void paused_state_command_handler(struct mpl_cmd command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_TRACK:
@@ -1951,12 +1951,12 @@ void paused_state_command_handler(struct mpl_cmd command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_TRACK:
-		if (command.use_param) {
-			if (do_goto_track(&pl, command.param)) {
+		if (command->use_param) {
+			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
 				do_track_change_notifications(&pl);
 			} else {
@@ -1966,65 +1966,65 @@ void paused_state_command_handler(struct mpl_cmd command,
 				pl.track_pos = 0;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_PREV_GROUP:
 		do_full_prev_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_GROUP:
 		do_full_next_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_GROUP:
 		do_full_first_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_GROUP:
 		do_full_last_group(&pl);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_GROUP:
-		if (command.use_param) {
-			do_full_goto_group(&pl, command.param);
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		if (command->use_param) {
+			do_full_goto_group(&pl, command->param);
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
-		BT_DBG("Invalid command: %d", command.opcode);
-		ntf.result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		BT_DBG("Invalid command: %d", command->opcode);
+		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
 }
 
-void seeking_state_command_handler(struct mpl_cmd command,
-				   struct mpl_cmd_ntf ntf)
+void seeking_state_command_handler(const struct mpl_cmd *command,
+				   struct mpl_cmd_ntf *ntf)
 {
-	BT_DBG("Command opcode: %d", command.opcode);
+	BT_DBG("Command opcode: %d", command->opcode);
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MPL)) {
-		if (command.use_param) {
-			BT_DBG("Command parameter: %d", command.param);
+		if (command->use_param) {
+			BT_DBG("Command parameter: %d", command->param);
 		}
 	}
-	switch (command.opcode) {
+	switch (command->opcode) {
 	case BT_MCS_OPC_PLAY:
 		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
 		pl.state = BT_MCS_MEDIA_STATE_PLAYING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_PAUSE:
@@ -2033,7 +2033,7 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FAST_REWIND:
@@ -2048,7 +2048,7 @@ void seeking_state_command_handler(struct mpl_cmd command,
 			pl.seeking_speed_factor -= MPL_SEEKING_SPEED_FACTOR_STEP;
 			media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FAST_FORWARD:
@@ -2058,7 +2058,7 @@ void seeking_state_command_handler(struct mpl_cmd command,
 			pl.seeking_speed_factor += MPL_SEEKING_SPEED_FACTOR_STEP;
 			media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
 		}
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_STOP:
@@ -2068,23 +2068,23 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_MOVE_RELATIVE:
-		if (command.use_param) {
+		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
-			if (command.param >
+			if (command->param >
 			    pl.group->track->duration - pl.track_pos) {
 				pl.track_pos = pl.group->track->duration;
-			} else if (command.param < -pl.track_pos) {
+			} else if (command->param < -pl.track_pos) {
 				pl.track_pos = 0;
 			} else {
-				pl.track_pos += command.param;
+				pl.track_pos += command->param;
 			}
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_track_position_cb(pl.track_pos);
 		media_proxy_pl_command_cb(ntf);
@@ -2098,43 +2098,43 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		}
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_SEGMENT:
 		do_next_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_SEGMENT:
 		do_first_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_SEGMENT:
 		do_last_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_SEGMENT:
-		if (command.use_param) {
-			if (command.param != 0) {
-				do_goto_segment(&pl, command.param);
+		if (command->use_param) {
+			if (command->param != 0) {
+				do_goto_segment(&pl, command->param);
 				pl.track_pos = pl.group->track->segment->pos;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
 			/* track position shall not change. */
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -2152,7 +2152,7 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_TRACK:
@@ -2172,7 +2172,7 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_TRACK:
@@ -2188,7 +2188,7 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_TRACK:
@@ -2204,12 +2204,12 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_TRACK:
-		if (command.use_param) {
-			if (do_goto_track(&pl, command.param)) {
+		if (command->use_param) {
+			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
 				do_track_change_notifications(&pl);
 			} else {
@@ -2222,9 +2222,9 @@ void seeking_state_command_handler(struct mpl_cmd command,
 			pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
 			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
@@ -2232,51 +2232,51 @@ void seeking_state_command_handler(struct mpl_cmd command,
 		do_full_prev_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_NEXT_GROUP:
 		do_full_next_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_FIRST_GROUP:
 		do_full_first_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_LAST_GROUP:
 		do_full_last_group(&pl);
 		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	case BT_MCS_OPC_GOTO_GROUP:
-		if (command.use_param) {
-			do_full_goto_group(&pl, command.param);
+		if (command->use_param) {
+			do_full_goto_group(&pl, command->param);
 			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf.result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
 		} else {
-			ntf.result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
-		BT_DBG("Invalid command: %d", command.opcode);
-		ntf.result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		BT_DBG("Invalid command: %d", command->opcode);
+		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
 }
 
-void (*command_handlers[BT_MCS_MEDIA_STATE_LAST])(struct mpl_cmd command,
-						  struct mpl_cmd_ntf ntf) = {
+void (*command_handlers[BT_MCS_MEDIA_STATE_LAST])(const struct mpl_cmd *command,
+						  struct mpl_cmd_ntf *ntf) = {
 	inactive_state_command_handler,
 	playing_state_command_handler,
 	paused_state_command_handler,
@@ -2582,19 +2582,19 @@ uint8_t get_media_state(void)
 	return pl.state;
 }
 
-void send_command(struct mpl_cmd command)
+void send_command(const struct mpl_cmd *command)
 {
 	struct mpl_cmd_ntf ntf;
 
-	if (command.use_param) {
-		BT_DBG("opcode: %d, param: %d", command.opcode, command.param);
+	if (command->use_param) {
+		BT_DBG("opcode: %d, param: %d", command->opcode, command->param);
 	} else {
-		BT_DBG("opcode: %d", command.opcode);
+		BT_DBG("opcode: %d", command->opcode);
 	}
 
 	if (pl.state < BT_MCS_MEDIA_STATE_LAST) {
-		ntf.requested_opcode = command.opcode;
-		command_handlers[pl.state](command, ntf);
+		ntf.requested_opcode = command->opcode;
+		command_handlers[pl.state](command, &ntf);
 	} else {
 		BT_DBG("INVALID STATE");
 	}
@@ -2606,38 +2606,38 @@ uint32_t get_commands_supported(void)
 }
 
 #ifdef CONFIG_BT_MPL_OBJECTS
-static void parse_search(struct mpl_search search)
+static void parse_search(const struct mpl_search *search)
 {
 	uint8_t index = 0;
 	struct mpl_sci sci;
 	uint8_t sci_num = 0;
 	bool search_failed = false;
 
-	if (search.len > SEARCH_LEN_MAX) {
-		BT_WARN("Search too long (%d) - aborting", search.len);
+	if (search->len > SEARCH_LEN_MAX) {
+		BT_WARN("Search too long (%d) - aborting", search->len);
 		search_failed = true;
 	} else {
-		BT_DBG("Parsing %d octets search", search.len);
+		BT_DBG("Parsing %d octets search", search->len);
 
-		while (search.len - index > 0) {
-			sci.len = (uint8_t)search.search[index++];
+		while (search->len - index > 0) {
+			sci.len = (uint8_t)search->search[index++];
 			if (sci.len < SEARCH_SCI_LEN_MIN) {
 				BT_WARN("Invalid length field - too small");
 				search_failed = true;
 				break;
 			}
-			if (sci.len > (search.len - index)) {
+			if (sci.len > (search->len - index)) {
 				BT_WARN("Incomplete search control item");
 				search_failed = true;
 				break;
 			}
-			sci.type = (uint8_t)search.search[index++];
+			sci.type = (uint8_t)search->search[index++];
 			if (sci.type <  BT_MCS_SEARCH_TYPE_TRACK_NAME ||
 			    sci.type > BT_MCS_SEARCH_TYPE_ONLY_GROUPS) {
 				search_failed = true;
 				break;
 			}
-			memcpy(&sci.param, &search.search[index], sci.len - 1);
+			memcpy(&sci.param, &search->search[index], sci.len - 1);
 			index += sci.len - 1;
 
 			BT_DBG("SCI # %d: type: %d", sci_num, sci.type);
@@ -2661,13 +2661,13 @@ static void parse_search(struct mpl_search search)
 	media_proxy_pl_search_results_id_cb(pl.search_results_id);
 }
 
-void send_search(struct mpl_search search)
+void send_search(const struct mpl_search *search)
 {
-	if (search.len > SEARCH_LEN_MAX) {
-		BT_WARN("Search too long: %d", search.len);
+	if (search->len > SEARCH_LEN_MAX) {
+		BT_WARN("Search too long: %d", search->len);
 	}
 
-	BT_HEXDUMP_DBG(search.search, search.len, "Search");
+	BT_HEXDUMP_DBG(search->search, search->len, "Search");
 
 	parse_search(search);
 }

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -2637,7 +2637,7 @@ static void parse_search(const struct mpl_search *search)
 				search_failed = true;
 				break;
 			}
-			memcpy(&sci.param, &search->search[index], sci.len - 1);
+			(void)memcpy(&sci.param, &search->search[index], sci.len - 1);
 			index += sci.len - 1;
 
 			BT_DBG("SCI # %d: type: %d", sci_num, sci.type);

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -353,30 +353,30 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 	shell_print(ctx_shell, "Media State: %d", state);
 }
 
-static void mcc_send_cmd_cb(struct bt_conn *conn, int err, struct mpl_cmd cmd)
+static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
 		shell_error(ctx_shell,
 			    "Command send failed (%d) - opcode: %d, param: %d",
-			    err, cmd.opcode, cmd.param);
+			    err, cmd->opcode, cmd->param);
 		return;
 	}
 
-	shell_print(ctx_shell, "Command opcode: %d, param: %d", cmd.opcode, cmd.param);
+	shell_print(ctx_shell, "Command opcode: %d, param: %d", cmd->opcode, cmd->param);
 }
 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
-			   struct mpl_cmd_ntf ntf)
+			   const struct mpl_cmd_ntf *ntf)
 {
 	if (err) {
 		shell_error(ctx_shell,
 			    "Command notification error (%d) - opcode: %d, result: %d",
-			    err, ntf.requested_opcode, ntf.result_code);
+			    err, ntf->requested_opcode, ntf->result_code);
 		return;
 	}
 
 	shell_print(ctx_shell, "Command opcode: %d, result: %d",
-		    ntf.requested_opcode, ntf.result_code);
+		    ntf->requested_opcode, ntf->result_code);
 }
 
 static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
@@ -393,7 +393,7 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 
 #ifdef CONFIG_BT_MCC_OTS
 static void mcc_send_search_cb(struct bt_conn *conn, int err,
-			       struct mpl_search search)
+			       const struct mpl_search *search)
 {
 	if (err) {
 		shell_error(ctx_shell,
@@ -948,7 +948,7 @@ int cmd_mcc_set_cp(const struct shell *sh, size_t argc, char *argv[])
 		cmd.param = 0;
 	}
 
-	result = bt_mcc_send_cmd(default_conn, cmd);
+	result = bt_mcc_send_cmd(default_conn, &cmd);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -977,7 +977,7 @@ int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc, char *argv[])
 	memcpy(search.search, argv[1], search.len);
 	BT_DBG("Search string: %s", log_strdup(argv[1]));
 
-	result = bt_mcc_send_search(default_conn, search);
+	result = bt_mcc_send_search(default_conn, &search);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -1075,7 +1075,7 @@ int cmd_mcc_send_search_ioptest(const struct shell *sh, size_t argc,
 	shell_print(sh, "Search string: ");
 	shell_hexdump(sh, (uint8_t *)&search.search, search.len);
 
-	result = bt_mcc_send_search(default_conn, search);
+	result = bt_mcc_send_search(default_conn, &search);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -1098,7 +1098,7 @@ int cmd_mcc_test_send_search_iop_invalid_type(const struct shell *sh,
 	shell_print(sh, "Search string: ");
 	shell_hexdump(sh, (uint8_t *)&search.search, search.len);
 
-	result = bt_mcc_send_search(default_conn, search);
+	result = bt_mcc_send_search(default_conn, &search);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}
@@ -1123,7 +1123,7 @@ int cmd_mcc_test_send_search_invalid_sci_len(const struct shell *sh,
 	shell_print(sh, "Search string: ");
 	shell_hexdump(sh, (uint8_t *)&search.search, search.len);
 
-	result = bt_mcc_send_search(default_conn, search);
+	result = bt_mcc_send_search(default_conn, &search);
 	if (result) {
 		shell_print(sh, "Fail: %d", result);
 	}

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -293,17 +293,17 @@ static void media_state_cb(struct media_player *plr, int err, uint8_t state)
 	/* TODO: Parse state and output state name (e.g. "Playing") */
 }
 
-static void command_send_cb(struct media_player *plr, int err, struct mpl_cmd cmd)
+static void command_send_cb(struct media_player *plr, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Command send failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Command opcode sent: %u", plr, cmd.opcode);
+	shell_print(ctx_shell, "Player: %p, Command opcode sent: %u", plr, cmd->opcode);
 }
 
-static void command_recv_cb(struct media_player *plr, int err, struct mpl_cmd_ntf cmd_ntf)
+static void command_recv_cb(struct media_player *plr, int err, const struct mpl_cmd_ntf *cmd_ntf)
 {
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Command failed (%d)", plr, err);
@@ -311,7 +311,7 @@ static void command_recv_cb(struct media_player *plr, int err, struct mpl_cmd_nt
 	}
 
 	shell_print(ctx_shell, "Player: %p, Command opcode: %u, result: %u",
-		    plr, cmd_ntf.requested_opcode, cmd_ntf.result_code);
+		    plr, cmd_ntf->requested_opcode, cmd_ntf->result_code);
 }
 
 static void commands_supported_cb(struct media_player *plr, int err, uint32_t opcodes)
@@ -326,14 +326,14 @@ static void commands_supported_cb(struct media_player *plr, int err, uint32_t op
 }
 
 #ifdef CONFIG_BT_OTS
-static void search_send_cb(struct media_player *plr, int err, struct mpl_search search)
+static void search_send_cb(struct media_player *plr, int err, const struct mpl_search *search)
 {
 	if (err) {
 		shell_error(ctx_shell, "Player: %p, Search send failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Search sent with len %u", plr, search.len);
+	shell_print(ctx_shell, "Player: %p, Search sent with len %u", plr, search->len);
 }
 
 static void search_recv_cb(struct media_player *plr, int err, uint8_t result_code)
@@ -735,7 +735,7 @@ static int cmd_media_send_command(const struct shell *sh, size_t argc, char *arg
 		cmd.param = 0;
 	}
 
-	err = media_proxy_ctrl_send_command(current_player, cmd);
+	err = media_proxy_ctrl_send_command(current_player, &cmd);
 
 	if (err) {
 		shell_error(ctx_shell, "Command send failed (%d)", err);
@@ -769,7 +769,7 @@ int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
 	memcpy(search.search, argv[1], search.len);
 	BT_DBG("Search string: %s", log_strdup(argv[1]));
 
-	err = media_proxy_ctrl_send_search(current_player, search);
+	err = media_proxy_ctrl_send_search(current_player, &search);
 	if (err) {
 		shell_error(ctx_shell, "Search send failed (%d)", err);
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mcc_test.c
@@ -350,31 +350,31 @@ static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state
 	SET_FLAG(media_state_read);
 }
 
-static void mcc_send_command_cb(struct bt_conn *conn, int err, struct mpl_cmd cmd)
+static void mcc_send_command_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
 		FAIL("Command send failed (%d) - opcode: %u, param: %d",
-		     err, cmd.opcode, cmd.param);
+		     err, cmd->opcode, cmd->param);
 		return;
 	}
 
 	SET_FLAG(command_sent);
 }
 
-static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err, struct mpl_cmd_ntf ntf)
+static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err, const struct mpl_cmd_ntf *ntf)
 {
 	if (err) {
 		FAIL("Command notification error (%d) - opcode: %u, result: %u",
-		     err, ntf.requested_opcode, ntf.result_code);
+		     err, ntf->requested_opcode, ntf->result_code);
 		return;
 	}
 
-	g_command_result = ntf.result_code;
+	g_command_result = ntf->result_code;
 	SET_FLAG(command_notified);
 }
 
 static void mcc_send_search_cb(struct bt_conn *conn, int err,
-			       struct mpl_search search)
+			       const struct mpl_search *search)
 {
 	if (err) {
 		FAIL("Search send failed (%d)", err);
@@ -647,7 +647,7 @@ static bool test_verify_media_state_wait_flags(uint8_t expected_state)
  * Will FAIL on error to send the command.
  * Will WAIT for the required flags before returning.
  */
-static void test_send_cmd_wait_flags(struct mpl_cmd cmd)
+static void test_send_cmd_wait_flags(struct mpl_cmd *cmd)
 {
 	int err;
 
@@ -661,7 +661,7 @@ static void test_send_cmd_wait_flags(struct mpl_cmd cmd)
 	err = bt_mcc_send_cmd(default_conn, cmd);
 	if (err) {
 		FAIL("Failed to send command: %d, opcode: %u",
-		     err, cmd.opcode);
+		     err, cmd->opcode);
 		return;
 	}
 
@@ -676,7 +676,7 @@ static void test_cp_play(void)
 	cmd.opcode = BT_MCS_OPC_PLAY;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("PLAY command failed\n");
@@ -695,7 +695,7 @@ static void test_cp_pause(void)
 	cmd.opcode = BT_MCS_OPC_PAUSE;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("PAUSE command failed\n");
@@ -714,7 +714,7 @@ static void test_cp_fast_rewind(void)
 	cmd.opcode = BT_MCS_OPC_FAST_REWIND;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("FAST REWIND command failed\n");
@@ -733,7 +733,7 @@ static void test_cp_fast_forward(void)
 	cmd.opcode = BT_MCS_OPC_FAST_FORWARD;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("FAST FORWARD command failed\n");
@@ -752,7 +752,7 @@ static void test_cp_stop(void)
 	cmd.opcode = BT_MCS_OPC_STOP;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("STOP command failed\n");
@@ -789,7 +789,7 @@ static void test_cp_move_relative(void)
 	cmd.use_param = true;
 	cmd.param = 1000;  /* Position change, measured in 1/100 of a second */
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("MOVE RELATIVE command failed\n");
@@ -833,7 +833,7 @@ static void test_cp_prev_segment(void)
 	cmd.opcode = BT_MCS_OPC_PREV_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("PREV SEGMENT command failed\n");
@@ -850,7 +850,7 @@ static void test_cp_next_segment(void)
 	cmd.opcode = BT_MCS_OPC_NEXT_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("NEXT SEGMENT command failed\n");
@@ -867,7 +867,7 @@ static void test_cp_first_segment(void)
 	cmd.opcode = BT_MCS_OPC_FIRST_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("FIRST SEGMENT command failed\n");
@@ -884,7 +884,7 @@ static void test_cp_last_segment(void)
 	cmd.opcode = BT_MCS_OPC_LAST_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("LAST SEGMENT command failed\n");
@@ -902,7 +902,7 @@ static void test_cp_goto_segment(void)
 	cmd.use_param = true;
 	cmd.param = 2;    /* Second segment - not the first, maybe not last */
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("GOTO SEGMENT command failed\n");
@@ -949,7 +949,7 @@ static void test_cp_prev_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("PREV TRACK command failed\n");
@@ -981,7 +981,7 @@ static void test_cp_next_track_and_track_changed(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("NEXT TRACK command failed\n");
@@ -1012,7 +1012,7 @@ static void test_cp_first_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("FIRST TRACK command failed\n");
@@ -1040,7 +1040,7 @@ static void test_cp_last_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("LAST TRACK command failed\n");
@@ -1069,7 +1069,7 @@ static void test_cp_goto_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("GOTO TRACK command failed\n");
@@ -1123,7 +1123,7 @@ static void test_cp_prev_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("PREV GROUP command failed\n");
@@ -1152,7 +1152,7 @@ static void test_cp_next_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("NEXT GROUP command failed\n");
@@ -1180,7 +1180,7 @@ static void test_cp_first_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("FIRST GROUP command failed\n");
@@ -1208,7 +1208,7 @@ static void test_cp_last_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("LAST GROUP command failed\n");
@@ -1237,7 +1237,7 @@ static void test_cp_goto_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != BT_MCS_OPC_NTF_SUCCESS) {
 		FAIL("GOTO GROUP command failed\n");
@@ -1306,7 +1306,7 @@ static void test_search(void)
 	UNSET_FLAG(search_notified);
 	UNSET_FLAG(search_results_object_id_read);
 
-	err = bt_mcc_send_search(default_conn, search);
+	err = bt_mcc_send_search(default_conn, &search);
 	if (err) {
 		FAIL("Failed to write to search control point\n");
 		return;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/media_controller_test.c
@@ -398,7 +398,7 @@ static void media_state_cb(struct media_player *plr, int err, uint8_t state)
 	SET_FLAG(media_state_read);
 }
 
-static void command_send_cb(struct media_player *plr, int err, struct mpl_cmd cmd)
+static void command_send_cb(struct media_player *plr, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
 		FAIL("Command send failed (%d)", err);
@@ -413,7 +413,7 @@ static void command_send_cb(struct media_player *plr, int err, struct mpl_cmd cm
 	SET_FLAG(command_sent_flag);
 }
 
-static void command_recv_cb(struct media_player *plr, int err, struct mpl_cmd_ntf cmd_ntf)
+static void command_recv_cb(struct media_player *plr, int err, const struct mpl_cmd_ntf *cmd_ntf)
 {
 	if (err) {
 		FAIL("Command failed (%d)", err);
@@ -425,7 +425,7 @@ static void command_recv_cb(struct media_player *plr, int err, struct mpl_cmd_nt
 		return;
 	}
 
-	g_command_result = cmd_ntf.result_code;
+	g_command_result = cmd_ntf->result_code;
 	SET_FLAG(command_results_flag);
 }
 
@@ -447,7 +447,7 @@ static void commands_supported_cb(struct media_player *plr, int err, uint32_t op
 
 
 
-static void search_send_cb(struct media_player *plr, int err, struct mpl_search search)
+static void search_send_cb(struct media_player *plr, int err, const struct mpl_search *search)
 {
 	if (err) {
 		FAIL("Search failed (%d)", err);
@@ -623,7 +623,7 @@ static bool test_verify_media_state_wait_flags(uint8_t expected_state)
  * Will FAIL on error to send the command.
  * Will WAIT for the required flags before returning.
  */
-static void test_send_cmd_wait_flags(struct mpl_cmd cmd)
+static void test_send_cmd_wait_flags(struct mpl_cmd *cmd)
 {
 	int err;
 
@@ -632,7 +632,7 @@ static void test_send_cmd_wait_flags(struct mpl_cmd cmd)
 	err = media_proxy_ctrl_send_command(current_player, cmd);
 	if (err) {
 		FAIL("Failed to send command: %d, opcode: %u",
-		     err, cmd.opcode);
+		     err, cmd->opcode);
 		return;
 	}
 
@@ -647,7 +647,7 @@ static void test_cp_play(void)
 	cmd.opcode = MEDIA_PROXY_OP_PLAY;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("PLAY command failed\n");
@@ -666,7 +666,7 @@ static void test_cp_pause(void)
 	cmd.opcode = MEDIA_PROXY_OP_PAUSE;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("PAUSE command failed\n");
@@ -685,7 +685,7 @@ static void test_cp_fast_rewind(void)
 	cmd.opcode = MEDIA_PROXY_OP_FAST_REWIND;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("FAST REWIND command failed\n");
@@ -704,7 +704,7 @@ static void test_cp_fast_forward(void)
 	cmd.opcode = MEDIA_PROXY_OP_FAST_FORWARD;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("FAST FORWARD command failed\n");
@@ -723,7 +723,7 @@ static void test_cp_stop(void)
 	cmd.opcode = MEDIA_PROXY_OP_STOP;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("STOP command failed\n");
@@ -760,7 +760,7 @@ static void test_cp_move_relative(void)
 	cmd.use_param = true;
 	cmd.param = 1000;  /* Position change, measured in 1/100 of a second */
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("MOVE RELATIVE command failed\n");
@@ -804,7 +804,7 @@ static void test_cp_prev_segment(void)
 	cmd.opcode = MEDIA_PROXY_OP_PREV_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("PREV SEGMENT command failed\n");
@@ -821,7 +821,7 @@ static void test_cp_next_segment(void)
 	cmd.opcode = MEDIA_PROXY_OP_NEXT_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("NEXT SEGMENT command failed\n");
@@ -838,7 +838,7 @@ static void test_cp_first_segment(void)
 	cmd.opcode = MEDIA_PROXY_OP_FIRST_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("FIRST SEGMENT command failed\n");
@@ -855,7 +855,7 @@ static void test_cp_last_segment(void)
 	cmd.opcode = MEDIA_PROXY_OP_LAST_SEGMENT;
 	cmd.use_param = false;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("LAST SEGMENT command failed\n");
@@ -873,7 +873,7 @@ static void test_cp_goto_segment(void)
 	cmd.use_param = true;
 	cmd.param = 2;    /* Second segment - not the first, maybe not last */
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("GOTO SEGMENT command failed\n");
@@ -920,7 +920,7 @@ static void test_cp_prev_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("PREV TRACK command failed\n");
@@ -949,7 +949,7 @@ static void test_cp_next_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("NEXT TRACK command failed\n");
@@ -977,7 +977,7 @@ static void test_cp_first_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("FIRST TRACK command failed\n");
@@ -1005,7 +1005,7 @@ static void test_cp_last_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("LAST TRACK command failed\n");
@@ -1034,7 +1034,7 @@ static void test_cp_goto_track(void)
 	test_read_current_track_object_id_wait_flags();
 	object_id = g_current_track_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("GOTO TRACK command failed\n");
@@ -1088,7 +1088,7 @@ static void test_cp_prev_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("PREV GROUP command failed\n");
@@ -1117,7 +1117,7 @@ static void test_cp_next_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("NEXT GROUP command failed\n");
@@ -1145,7 +1145,7 @@ static void test_cp_first_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("FIRST GROUP command failed\n");
@@ -1173,7 +1173,7 @@ static void test_cp_last_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("LAST GROUP command failed\n");
@@ -1202,7 +1202,7 @@ static void test_cp_goto_group(void)
 	test_read_current_group_object_id_wait_flags();
 	object_id = g_current_group_object_id;
 
-	test_send_cmd_wait_flags(cmd);
+	test_send_cmd_wait_flags(&cmd);
 
 	if (g_command_result != MEDIA_PROXY_CMD_SUCCESS) {
 		FAIL("GOTO GROUP command failed\n");
@@ -1271,7 +1271,7 @@ static void test_scp(void)
 	UNSET_FLAG(search_result_code_flag);
 	UNSET_FLAG(search_results_object_id_read);
 
-	err = media_proxy_ctrl_send_search(current_player, search);
+	err = media_proxy_ctrl_send_search(current_player, &search);
 	if (err) {
 		FAIL("Failed to write to search control point\n");
 		return;


### PR DESCRIPTION
Change the MCC (media control client) and media proxy APIs to pass structs by reference instead of by value.
- optimization - less to pass around
- consistency - this is how structs are usually passed in comparable files

Note that these APIs are marked as experimental, so API changes should be OK.

Also changes internal functions in the media player, the media client test, and the media controller test to pass structs by reference instead of by value.

closes https://github.com/zephyrproject-rtos/zephyr/issues/42096