### PR TITLE
Bluetooth: Controller: fix wrong use of LE Features in CTE REQ llcp

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -1213,11 +1213,7 @@ uint8_t ll_df_set_conn_cte_req_enable(uint16_t handle, uint8_t enable,
 		 * whether required features are enabled.
 		 */
 		if (conn->llcp.fex.valid &&
-		    (!(conn->llcp.fex.features_peer & BIT64(BT_LE_FEAT_BIT_CONN_CTE_RESP)) ||
-		     ((requested_cte_type == BT_HCI_LE_AOD_CTE_1US ||
-		       requested_cte_type == BT_HCI_LE_AOD_CTE_2US) &&
-		      !(conn->llcp.fex.features_peer &
-			BIT64(BT_LE_FEAT_BIT_ANT_SWITCH_TX_AOD))))) {
+		    (!(conn->llcp.fex.features_peer & BIT64(BT_LE_FEAT_BIT_CONN_CTE_RESP)))) {
 			return BT_HCI_ERR_UNSUPP_REMOTE_FEATURE;
 		}
 


### PR DESCRIPTION
When Host calls HCI_LE_Connection_CTE_Request_Enable with cte type
set to AoD with 1us slots or AoD with  2 us slots, the Controller
verifies if peer device supports Antenna Switching During CTE
Transmission (AoD) feature.

That is wrong because the feature is marked as optional when send
to peer, so it shall be igonerd by remote device.

There are no means to check if peer device supports particular
CTE type, hence the check has to be removed.

The check causes enable CTE REQ procedure to fail after feature
exchange has happened.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>