### PR TITLE
net: l2: ppp: config: fix for max terminate-req transmissions

### DIFF
--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -191,7 +191,7 @@ static void terminate(struct ppp_fsm *fsm, enum ppp_state next_state)
 		fsm_down(fsm);
 	}
 
-	fsm->retransmits = MAX_CONFIGURE_REQ;
+	fsm->retransmits = MAX_TERMINATE_REQ;
 	fsm->req_id = ++fsm->id;
 
 	(void)ppp_send_pkt(fsm, NULL, PPP_TERMINATE_REQ, fsm->req_id,


### PR DESCRIPTION
It was found that CONFIG_NET_L2_PPP_MAX_TERMINATE_REQ_RETRANSMITS was not having any impact and CONFIG_NET_L2_PPP_MAX_CONFIGURE_REQ_RETRANSMITS was used incorrectly instead for terminate().
