### PR TITLE
doc: extensions: kconfig: add support for selected/implied by and menu path

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -264,6 +264,23 @@ def kconfig_build_resources(app: Sphinx) -> None:
                         fmt += f" if {kconfiglib.expr_str(cond, sc_fmt)}"
                     alt_defaults.append([fmt, node.filename])
 
+            # build list of symbols that select/imply the current one
+            # note: all reverse dependencies are ORed together, and conditionals
+            # (e.g. select/imply A if B) turns into A && B. So we first split
+            # by OR to include all entries, and we split each one by AND to just
+            # take the first entry.
+            selected_by = list()
+            if isinstance(sc, kconfiglib.Symbol) and sc.rev_dep != sc.kconfig.n:
+                for select in kconfiglib.split_expr(sc.rev_dep, kconfiglib.OR):
+                    sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
+                    selected_by.append(f"CONFIG_{sym.name}")
+
+            implied_by = list()
+            if isinstance(sc, kconfiglib.Symbol) and sc.weak_rev_dep != sc.kconfig.n:
+                for select in kconfiglib.split_expr(sc.weak_rev_dep, kconfiglib.OR):
+                    sym = kconfiglib.split_expr(select, kconfiglib.AND)[0]
+                    implied_by.append(f"CONFIG_{sym.name}")
+
             # only process nodes with prompt or help
             nodes = [node for node in sc.nodes if node.prompt or node.help]
 
@@ -332,7 +349,9 @@ def kconfig_build_resources(app: Sphinx) -> None:
                         "defaults": defaults,
                         "alt_defaults": alt_defaults,
                         "selects": selects,
+                        "selected_by": selected_by,
                         "implies": implies,
+                        "implied_by": implied_by,
                         "ranges": ranges,
                         "choices": choices,
                         "filename": filename,

--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -333,6 +333,14 @@ def kconfig_build_resources(app: Sphinx) -> None:
                     for sym in sc.syms:
                         choices.append(kconfiglib.expr_str(sym, sc_fmt))
 
+                menupath = ""
+                iternode = node
+                while iternode.parent is not iternode.kconfig.top_node:
+                    iternode = iternode.parent
+                    menupath = f" > {iternode.prompt[0]}" + menupath
+
+                menupath = "(Top)" + menupath
+
                 filename = node.filename
                 for name, path in module_paths.items():
                     if node.filename.startswith(path):
@@ -356,6 +364,7 @@ def kconfig_build_resources(app: Sphinx) -> None:
                         "choices": choices,
                         "filename": filename,
                         "linenr": node.linenr,
+                        "menupath": menupath,
                     }
                 )
 

--- a/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
@@ -88,9 +88,10 @@ function renderKconfigPropLiteral(parent, title, content) {
  * @param {Element} parent Parent element.
  * @param {String} title Title.
  * @param {list} elements List of elements.
- * @returns
+ * @param {boolean} linkElements Whether to link elements (treat each element
+ *                  as an unformatted option)
  */
-function renderKconfigPropList(parent, title, elements) {
+function renderKconfigPropList(parent, title, elements, linkElements) {
     if (elements.length === 0) {
         return;
     }
@@ -112,8 +113,17 @@ function renderKconfigPropList(parent, title, elements) {
         const listItem = document.createElement('li');
         list.appendChild(listItem);
 
-        /* using HTML since element content may be pre-formatted */
-        listItem.innerHTML = element;
+        if (linkElements) {
+            const link = document.createElement('a');
+            link.href = '#' + element;
+            listItem.appendChild(link);
+
+            const linkText = document.createTextNode(element);
+            link.appendChild(linkText);
+        } else {
+            /* using HTML since element content is pre-formatted */
+            listItem.innerHTML = element;
+        }
     });
 }
 
@@ -250,10 +260,12 @@ function renderKconfigEntry(entry) {
         renderKconfigPropList(props, 'Dependencies', [entry.dependencies]);
     }
     renderKconfigDefaults(props, entry.defaults, entry.alt_defaults);
-    renderKconfigPropList(props, 'Selects', entry.selects);
-    renderKconfigPropList(props, 'Implies', entry.implies);
-    renderKconfigPropList(props, 'Ranges', entry.ranges);
-    renderKconfigPropList(props, 'Choices', entry.choices);
+    renderKconfigPropList(props, 'Selects', entry.selects, false);
+    renderKconfigPropList(props, 'Selected by', entry.selected_by, true);
+    renderKconfigPropList(props, 'Implies', entry.implies, false);
+    renderKconfigPropList(props, 'Implied by', entry.implied_by, true);
+    renderKconfigPropList(props, 'Ranges', entry.ranges, false);
+    renderKconfigPropList(props, 'Choices', entry.choices, false);
     renderKconfigPropLiteral(props, 'Location', `${entry.filename}:${entry.linenr}`);
 
     return container;

--- a/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
@@ -267,6 +267,7 @@ function renderKconfigEntry(entry) {
     renderKconfigPropList(props, 'Ranges', entry.ranges, false);
     renderKconfigPropList(props, 'Choices', entry.choices, false);
     renderKconfigPropLiteral(props, 'Location', `${entry.filename}:${entry.linenr}`);
+    renderKconfigPropLiteral(props, 'Menu path', entry.menupath);
 
     return container;
 }


### PR DESCRIPTION
- Adds support for displaying the "selected by" and "implied by" entries in the Kconfig search extension, ie, reverse dependencies.
- Render the menu path where an option can be found. For example, CONFIG_SPI: (Top) > Device Drivers.

Note: this change increases DB size in ~1.5-2Mb, so we should probably look into gzipping the JSON and decompressing it at client side.