### PR TITLE
dts: pwm: gd,gd32-pwm: add period to PWM cells

### DIFF
--- a/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
+++ b/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
@@ -60,7 +60,7 @@
 
 		/* NOTE: bridge TIMER0_CH0 (PA8) and LED1 (PC0) */
 		pwm_led: pwm_led {
-			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
+++ b/boards/arm/gd32f403z_eval/gd32f403z_eval.dts
@@ -64,7 +64,7 @@
 
 		/* NOTE: bridge TIMER0_CH0 (PA8) and LED2 (PF0) */
 		pwm_led: pwm_led {
-			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
@@ -56,7 +56,7 @@
 
 		/* NOTE: bridge TIMER1_CH2 (PB10) and LED1 (PE2) */
 		pwm_led: pwm_led {
-			pwms = <&pwm1 2 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm1 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
+++ b/boards/riscv/gd32vf103c_starter/gd32vf103c_starter.dts
@@ -41,7 +41,7 @@
 		/* NOTE: pwm_led and led1 are share same pin (PA7). */
 		/* When CONFIG_PWM=y it can only be controlled using the PWM API. */
 		pwm_led: pwm_led {
-			pwms = <&pwm2 1 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
@@ -68,7 +68,7 @@
 
 		/* NOTE: bridge TIMER0_CH0 (PA8) and LED1 (PC0) */
 		pwm_led: pwm_led {
-			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -41,12 +41,12 @@
 
 		/* NOTE: bridge TIMER1_CH1 and LED_GREEN (PA1) */
 		pwm_led_green: pwm_led_green {
-			pwms = <&pwm1 1 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm1 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "PWM_LED_G";
 		};
 		/* NOTE: bridge TIMER1_CH2 and LED_BLUE (PA2) */
 		pwm_led_blue: pwm_led_blue {
-			pwms = <&pwm1 2 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm1 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "PWM_LED_B";
 		};
 	};

--- a/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
+++ b/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
@@ -222,7 +222,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_0";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -241,7 +241,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_1";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -260,7 +260,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_2";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -279,7 +279,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_3";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -298,7 +298,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_4";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -342,7 +342,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_7";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -361,7 +361,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_8";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -380,7 +380,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_9";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -399,7 +399,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_10";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -418,7 +418,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_11";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -437,7 +437,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_12";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -456,7 +456,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_13";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -246,7 +246,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_0";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -265,7 +265,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_2";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -284,7 +284,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_3";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -328,7 +328,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_7";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -347,7 +347,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_8";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -366,7 +366,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_9";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -385,7 +385,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_10";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -404,7 +404,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_11";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -423,7 +423,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_12";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -442,7 +442,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_13";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 	};

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -340,7 +340,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_0";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -360,7 +360,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_1";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -379,7 +379,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_2";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -398,7 +398,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_3";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -418,7 +418,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_4";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -462,7 +462,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_7";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -481,7 +481,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_8";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -500,7 +500,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_9";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -519,7 +519,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_10";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -538,7 +538,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_11";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -557,7 +557,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_12";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -576,7 +576,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_13";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 	};

--- a/dts/bindings/pwm/gd,gd32-pwm.yaml
+++ b/dts/bindings/pwm/gd,gd32-pwm.yaml
@@ -15,8 +15,9 @@ properties:
     required: true
 
   "#pwm-cells":
-    const: 2
+    const: 3
 
 pwm-cells:
   - channel
+  - period
   - flags

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -234,7 +234,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_0";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -254,7 +254,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_1";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -274,7 +274,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_2";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -294,7 +294,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_3";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 
@@ -314,7 +314,7 @@
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
 				label = "PWM_4";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 


### PR DESCRIPTION
Add the period cell to GD32 PWM compatible and update all boards
accordingly. A period of 20 ms (50 Hz) has been set for all PWM LEDs.

Prep-work for https://github.com/zephyrproject-rtos/zephyr/pull/44523