### PR TITLE
soc/intel_adsp: set default cavs kconfig to cavs platforms only

### DIFF
--- a/soc/xtensa/intel_adsp/Kconfig.defconfig
+++ b/soc/xtensa/intel_adsp/Kconfig.defconfig
@@ -13,7 +13,7 @@ config XTENSA_CACHED_REGION
 config XTENSA_UNCACHED_REGION
 	default 4
 
-if SOC_FAMILY_INTEL_ADSP
+if INTEL_ADSP_CAVS
 
 config DMA_CAVS_GPDMA
 	default y
@@ -27,4 +27,4 @@ config I2S_CAVS
 	default y
 	depends on I2S
 
-endif # SOC_FAMILY_INTEL_ADSP
+endif # INTEL_ADSP_CAVS


### PR DESCRIPTION
This will set intel cavs kconfig to cavs platforms only