### PR TITLE
timer/cavs: Ignore timer isr when dticks are 0

### DIFF
--- a/drivers/timer/cavs_timer.c
+++ b/drivers/timer/cavs_timer.c
@@ -88,6 +88,11 @@ static void compare_isr(const void *arg)
 	curr = count();
 	dticks = (uint32_t)((curr - last_count) / CYC_PER_TICK);
 
+	if (dticks == 0) {
+		k_spin_unlock(&lock, key);
+		return;
+	}
+
 	/* Clear the triggered bit */
 	*WCTCS |= DSP_WCT_CS_TT(COMPARATOR_IDX);
 


### PR DESCRIPTION
With SMP the last_count is being updated by the last core
to run the timer compare ISR. last_count is used to relatively
set the timer compare for the next interrupt.
    
The issue is that the last core to run the ISR is later
than the expected timeout. This can cause time skew to
occur.
    
To fix this the first core to get the timer compare interrupt
should be the only one that should service it and set the compare.
    
By comparing the difference in dticks (should never be 0!) the ISR
is skipped on any subsequent ISR calls on different cores and the
timer compare is left as it was.


Signed-off-by: Tom Burdick <thomas.burdick@intel.com>