### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 11.2

### DIFF
--- a/include/app_memory/app_memdomain.h
+++ b/include/app_memory/app_memdomain.h
@@ -121,16 +121,16 @@ struct z_app_region {
 	extern char Z_APP_START(name)[]; \
 	extern char Z_APP_SIZE(name)[]; \
 	struct k_mem_partition name = { \
-		.start = (uintptr_t) &Z_APP_START(name), \
-		.size = (size_t) &Z_APP_SIZE(name), \
+		.start = (uintptr_t) &Z_APP_START(name)[0], \
+		.size = (size_t) &Z_APP_SIZE(name)[0], \
 		.attr = K_MEM_PARTITION_P_RW_U_RW \
 	}; \
 	extern char Z_APP_BSS_START(name)[]; \
 	extern char Z_APP_BSS_SIZE(name)[]; \
 	Z_GENERIC_SECTION(.app_regions.name) \
 	const struct z_app_region name##_region = { \
-		.bss_start = &Z_APP_BSS_START(name), \
-		.bss_size = (size_t) &Z_APP_BSS_SIZE(name) \
+		.bss_start = &Z_APP_BSS_START(name)[0], \
+		.bss_size = (size_t) &Z_APP_BSS_SIZE(name)[0] \
 	}; \
 	Z_APPMEM_PLACEHOLDER(name)
 #else

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -39,8 +39,8 @@
 #define Z_VIRT_RAM_END		(Z_VIRT_RAM_START + Z_VIRT_RAM_SIZE)
 
 /* Boot-time virtual location of the kernel image. */
-#define Z_KERNEL_VIRT_START	((uint8_t *)(&z_mapped_start))
-#define Z_KERNEL_VIRT_END	((uint8_t *)(&z_mapped_end))
+#define Z_KERNEL_VIRT_START	((uint8_t *)&z_mapped_start[0])
+#define Z_KERNEL_VIRT_END	((uint8_t *)&z_mapped_end[0])
 #define Z_KERNEL_VIRT_SIZE	(Z_KERNEL_VIRT_END - Z_KERNEL_VIRT_START)
 
 #define Z_VM_OFFSET	 ((CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_OFFSET) - \

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -856,8 +856,8 @@ static int app_shmem_bss_zero(const struct device *unused)
 
 	ARG_UNUSED(unused);
 
-	end = (struct z_app_region *)&__app_shmem_regions_end;
-	region = (struct z_app_region *)&__app_shmem_regions_start;
+	end = (struct z_app_region *)&__app_shmem_regions_end[0];
+	region = (struct z_app_region *)&__app_shmem_regions_start[0];
 
 	for ( ; region < end; region++) {
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)


### PR DESCRIPTION
- avoid to convert pointers to incomplete type using the pointer to first item

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>