### PR TITLE
MAINTAINERS: fix 'odd fixes' description

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -14,7 +14,7 @@
 #             looks after the area.
 #
 #         * odd fixes:
-#            The ares gets odd fixes and has collaborators.
+#            The area gets odd fixes and may have collaborators.
 #
 #         * obsolete:
 #             Old code. Something being marked obsolete generally means it has


### PR DESCRIPTION
There is a typo (s/ares/area/).

More importantly, there are examples of areas with this status that do
not have any collaborators:

- Drivers: Interrupt controllers
- Little FS

Fix the text to reflect reality.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>