### PR TITLE
drivers: fpga: change retval description in fpga_get_status

### DIFF
--- a/include/drivers/fpga.h
+++ b/include/drivers/fpga.h
@@ -48,8 +48,8 @@ __subsystem struct fpga_driver_api {
  *
  * @param dev FPGA device structure.
  *
- * @retval 0 if the FPGA is in ACTIVE state.
- * @retval 1 if the FPGA is in INACTIVE state.
+ * @retval 0 if the FPGA is in INACTIVE state.
+ * @retval 1 if the FPGA is in ACTIVE state.
  */
 static inline enum FPGA_status fpga_get_status(const struct device *dev)
 {


### PR DESCRIPTION
This PR fixes the description of values returned by the `fpga_get_status()` function in the fpga controller subsystem. 

The values were swapped in the initial contribution. After this change the values match the description in the `FPGA_status` enum.