### PR TITLE
drivers: fpga: connect eos_s3 dts with driver

### DIFF
--- a/boards/arm/quick_feather/quick_feather.dts
+++ b/boards/arm/quick_feather/quick_feather.dts
@@ -51,7 +51,7 @@
 		};
 	};
 
-	fpga {
+	fpga0: fpga {
 		status = "okay";
 	};
 };

--- a/drivers/fpga/fpga_eos_s3.c
+++ b/drivers/fpga/fpga_eos_s3.c
@@ -142,5 +142,5 @@ static const struct fpga_driver_api eos_s3_api = {
 	.get_info = eos_s3_fpga_get_info
 };
 
-DEVICE_DEFINE(fpga, "FPGA", &eos_s3_fpga_init, NULL, &fpga_data, NULL, APPLICATION,
+DEVICE_DT_DEFINE(DT_NODELABEL(fpga0), &eos_s3_fpga_init, NULL, &fpga_data, NULL, APPLICATION,
 	      CONFIG_KERNEL_INIT_PRIORITY_DEVICE, &eos_s3_api);


### PR DESCRIPTION
This PR connects the fpga node in `eos_s3` dts to the driver so that it is now used and relevant.