### PR TITLE
Bluetooth: tests: Add shell build tests for hearing access service

### DIFF
--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -201,3 +201,15 @@ tests:
     platform_allow: native_posix
     extra_configs:
       - CONFIG_BT_AUDIO_BROADCAST_SINK=n
+  bluetooth.audio_shell.no_has:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_BT_HAS=n
+  bluetooth.audio_shell.no_has_client:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_BT_HAS_CLIENT=n


### PR DESCRIPTION
Add entries for HAS builds to testcase list.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>