### PR TITLE
hwinfo: Add dependency handling for HWINFO_NRF in nonsecure

### DIFF
--- a/drivers/hwinfo/Kconfig
+++ b/drivers/hwinfo/Kconfig
@@ -32,6 +32,7 @@ config HWINFO_NRF
 	bool "NRF device ID"
 	default y
 	depends on SOC_FAMILY_NRF
+	depends on NRF_SOC_SECURE_SUPPORTED
 	help
 	  Enable Nordic NRF hwinfo driver.
 

--- a/soc/arm/nordic_nrf/Kconfig
+++ b/soc/arm/nordic_nrf/Kconfig
@@ -16,6 +16,14 @@ config SOC_FAMILY
 source "soc/arm/nordic_nrf/Kconfig.peripherals"
 source "soc/arm/nordic_nrf/*/Kconfig.soc"
 
+config NRF_SOC_SECURE_SUPPORTED
+	def_bool !TRUSTED_EXECUTION_NONSECURE || BUILD_WITH_TFM
+	help
+	  Hidden function to indicate that that the soc_secure functions are
+	  available.
+	  The functions are always available when not in non-secure.
+	  For non-secure the functions must redirect to secure services exposed
+	  by the secure firmware.
 
 config NRF_MPU_FLASH_REGION_SIZE
 	hex

--- a/soc/arm/nordic_nrf/common/soc_secure.h
+++ b/soc/arm/nordic_nrf/common/soc_secure.h
@@ -41,6 +41,13 @@ static inline void soc_secure_read_deviceid(uint32_t deviceid[2])
 }
 
 #else /* defined(CONFIG_TRUSTED_EXECUTION_NONSECURE) */
+
+static inline int soc_secure_mem_read(void *dst, void *src, size_t len)
+{
+	(void)memcpy(dst, src, len);
+	return 0;
+}
+
 #if defined(GPIO_PIN_CNF_MCUSEL_Msk)
 static inline void soc_secure_gpio_pin_mcu_select(uint32_t pin_number,
 						  nrf_gpio_pin_mcusel_t mcu)


### PR DESCRIPTION
The limitation on HWINFO_NRF depending on not nonsecure was removed in
https://github.com/zephyrproject-rtos/zephyr/commit/52be3030aac9ad6523baeb3d83a473ffe05d62a1.
This caused problems when TF-M was not enabled.

This happens on the thingy53_nrf5340_cpuapp_ns board since this board
is not supported by TF-M.

Introduce proper dependency handling for the soc secure functions
to make HWINFO_NRF unavailable when no secure services exist in
nonsecure.

Add soc_secure_mem_read implementation for secure.
This simplifies users code so that ifdefs are not required.
