### PR TITLE
tests: cpp: cxx: include top-level driver headers

### DIFF
--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -479,7 +479,7 @@ static inline int z_impl_dma_request_channel(const struct device *dev,
 	const struct dma_driver_api *api =
 		(const struct dma_driver_api *)dev->api;
 	/* dma_context shall be the first one in dev data */
-	struct dma_context *dma_ctx = dev->data;
+	struct dma_context *dma_ctx = (struct dma_context *)dev->data;
 
 	if (dma_ctx->magic != DMA_MAGIC) {
 		return channel;
@@ -515,13 +515,13 @@ __syscall void dma_release_channel(const struct device *dev,
 static inline void z_impl_dma_release_channel(const struct device *dev,
 					      uint32_t channel)
 {
-	struct dma_context *dma_ctx = dev->data;
+	struct dma_context *dma_ctx = (struct dma_context *)dev->data;
 
 	if (dma_ctx->magic != DMA_MAGIC) {
 		return;
 	}
 
-	if (channel < dma_ctx->dma_channels) {
+	if ((int)channel < dma_ctx->dma_channels) {
 		atomic_clear_bit(dma_ctx->atomic, channel);
 	}
 

--- a/include/zephyr/drivers/edac.h
+++ b/include/zephyr/drivers/edac.h
@@ -377,7 +377,7 @@ static inline int edac_errors_uc_get(const struct device *dev)
 static inline int edac_notify_callback_set(const struct device *dev,
 					   edac_notify_callback_f cb)
 {
-	const struct edac_driver_api *api = dev->api;
+	const struct edac_driver_api *api = (const struct edac_driver_api *)dev->api;
 
 	if (api->notify_cb_set == NULL) {
 		return -ENOSYS;

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -15,6 +15,7 @@
 
 #include <zephyr/types.h>
 #include <device.h>
+#include <drivers/espi.h>
 #include <drivers/emul.h>
 
 /**

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -161,9 +161,9 @@ __syscall int reset_status(const struct device *dev, uint32_t id, uint8_t *statu
 
 static inline int z_impl_reset_status(const struct device *dev, uint32_t id, uint8_t *status)
 {
-	const struct reset_driver_api *api = dev->api;
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
 
-	if (!api->status) {
+	if (api->status == NULL) {
 		return -ENOSYS;
 	}
 
@@ -204,9 +204,9 @@ __syscall int reset_assert(const struct device *dev, uint32_t id);
 
 static inline int z_impl_reset_assert(const struct device *dev, uint32_t id)
 {
-	const struct reset_driver_api *api = dev->api;
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
 
-	if (!api->assert) {
+	if (api->assert == NULL) {
 		return -ENOSYS;
 	}
 
@@ -246,9 +246,9 @@ __syscall int reset_deassert(const struct device *dev, uint32_t id);
 
 static inline int z_impl_reset_deassert(const struct device *dev, uint32_t id)
 {
-	const struct reset_driver_api *api = dev->api;
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
 
-	if (!api->deassert) {
+	if (api->deassert == NULL) {
 		return -ENOSYS;
 	}
 
@@ -287,9 +287,9 @@ __syscall int reset_toggle(const struct device *dev, uint32_t id);
 
 static inline int z_impl_reset_toggle(const struct device *dev, uint32_t id)
 {
-	const struct reset_driver_api *api = dev->api;
+	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
 
-	if (!api->toggle) {
+	if (api->toggle == NULL) {
 		return -ENOSYS;
 	}
 

--- a/tests/subsys/cpp/cxx/src/main.cpp
+++ b/tests/subsys/cpp/cxx/src/main.cpp
@@ -17,16 +17,62 @@
 #include <device.h>
 #include <kernel.h>
 #include <net/buf.h>
-#include <sys/byteorder.h>
+/* #include <sys/byteorder.h> conflicts with __bswapXX on native_posix */
 #include <sys/crc.h>
 #include <sys/crc.h>
 
+#include <drivers/adc.h>
+#include <drivers/bbram.h>
+#include <drivers/cache.h>
+#include <drivers/can.h>
+#include <drivers/can/transceiver.h>
+#include <drivers/clock_control.h>
+#include <drivers/counter.h>
+#include <drivers/dac.h>
+#include <drivers/disk.h>
+#include <drivers/display.h>
+#include <drivers/dma.h>
+#include <drivers/ec_host_cmd_periph.h>
+#include <drivers/edac.h>
+#include <drivers/eeprom.h>
+#include <drivers/emul.h>
+#include <drivers/entropy.h>
+#include <drivers/espi_emul.h>
+#include <drivers/espi.h>
+/* drivers/espi_saf.h requires SoC specific header */
+#include <drivers/flash.h>
+#include <drivers/fpga.h>
+#include <drivers/gna.h>
 #include <drivers/gpio.h>
+#include <drivers/hwinfo.h>
+#include <drivers/i2c_emul.h>
+#include <drivers/i2c.h>
+#include <drivers/i2s.h>
+#include <drivers/ipm.h>
+#include <drivers/kscan.h>
+#include <drivers/led.h>
 #include <drivers/led_strip.h>
+#include <drivers/lora.h>
+#include <drivers/mbox.h>
+#include <drivers/mdio.h>
+#include <drivers/peci.h>
+/* drivers/pinctrl.h requires SoC specific header */
+#include <drivers/pinmux.h>
+#include <drivers/pm_cpu_ops.h>
+#include <drivers/ps2.h>
+#include <drivers/ptp_clock.h>
+#include <drivers/pwm.h>
+#include <drivers/regulator.h>
+/* drivers/reset.h conflicts with assert() for certain platforms */
+#include <drivers/sensor.h>
+#include <drivers/spi_emul.h>
 #include <drivers/spi.h>
+#include <drivers/syscon.h>
 #include <drivers/uart.h>
 #include <usb/usb_device.h>
 #include <usb/class/usb_hid.h>
+#include <drivers/video-controls.h>
+#include <drivers/video.h>
 #include <drivers/watchdog.h>
 
 #include <ztest.h>


### PR DESCRIPTION
Include (almost) all top-level driver header files to ensure error-free C++ compilation. This revealed a few issues, which are fixed by this PR as well.