### PR TITLE
arch: arm: change dependency on CODE_DATA_RELOCATION

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -36,7 +36,7 @@ config ARM_CUSTOM_INTERRUPT_CONTROLLER
 
 config CODE_DATA_RELOCATION
 	bool "Relocate code/data sections"
-	depends on CPU_CORTEX_M
+	depends on CPU_CORTEX_M || CPU_AARCH32_CORTEX_R
 	help
 	  When selected this will relocate .text, data and .bss sections from
 	  the specified files and places it in the required memory region. The


### PR DESCRIPTION
This PR adds CPU_AARCH32_CORTEX_R to CODE_DATA_RELOCATION dependency as this capability can also work on cores other than CPU_CORTEX_M. 