### PR TITLE
modules: tinycbor: Deprecate the module

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -40,6 +40,8 @@ Deprecated in this release
 ==========================
 
 * :c:func:`nvs_init` is deprecated in favor of utilizing :c:func:`nvs_mount`.
+* The TinyCBOR module has been deprecated in favor of the new zcbor CBOR
+  library, included with Zephyr in this release.
 
 Stable API changes in this release
 ==================================

--- a/modules/Kconfig.tinycbor
+++ b/modules/Kconfig.tinycbor
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config TINYCBOR
-	bool "tinyCBOR Support"
+	bool "DEPRECATED: tinyCBOR Support"
 	help
 	  This option enables the tinyCBOR library.
+	  Note: This module is deprecated, please use ZCBOR instead.
 
 if TINYCBOR
 

--- a/west.yml
+++ b/west.yml
@@ -213,7 +213,7 @@ manifest:
       path: modules/lib/tflite-micro
       repo-path: tflite-micro
     - name: tinycbor
-      revision: 40daca97b478989884bffb5226e9ab73ca54b8c4
+      revision: 9e1f34bc08123aaad7666d3652aaa839e8178b3b
       path: modules/lib/tinycbor
     - name: tinycrypt
       revision: 3e9a49d2672ec01435ffbf0d788db6d95ef28de0


### PR DESCRIPTION
See #40591 for details, TinyCBOR (or rather the fork of TinyCBOR that we
had) is being replaced by zcbor.

Closes #40591.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>