### PR TITLE
it8xxx2: intc: ensure IER disabling to become effective

### DIFF
--- a/drivers/interrupt_controller/intc_ite_it8xxx2.c
+++ b/drivers/interrupt_controller/intc_ite_it8xxx2.c
@@ -122,6 +122,7 @@ void ite_intc_irq_disable(unsigned int irq)
 {
 	uint32_t g, i;
 	volatile uint8_t *en;
+	volatile uint8_t _ier __unused;
 
 	if (irq > CONFIG_NUM_IRQS) {
 		return;
@@ -133,6 +134,11 @@ void ite_intc_irq_disable(unsigned int irq)
 	/* critical section due to run a bit-wise OR operation */
 	unsigned int key = irq_lock();
 	CLEAR_MASK(*en, BIT(i));
+	/*
+	 * This load operation will guarantee the above modification of
+	 * SOC's register can be seen by any following instructions.
+	 */
+	_ier = *en;
 	irq_unlock(key);
 }
 


### PR DESCRIPTION
We put disabling SOC interrupt enable register (IER) sequence in
between disable and enable core's global interrupt to prevent race
condition.
After core interrupt enable instruction has been executed, the new
configuration of IER has not yet been fully processed due to
asynchronization between core and SOC's source clock.

If SOC interrupt is fired under the above condition, we will get
IRQ number 0 in ISR due to IER disabling taken effect.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>