### PR TITLE
mgmt/mcumgr/lib: Remove Kconfig for never declared log module

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -11,11 +11,6 @@ menuconfig MCUMGR
 
 if MCUMGR
 
-module = MCUMGR
-module-str = mcumgr
-source "subsys/logging/Kconfig.template.log_config"
-
-
 config APP_LINK_WITH_MCUMGR
 	bool "Link 'app' with MCUMGR"
 	default y


### PR DESCRIPTION
The mcumgr log module has never been registered nor declared.
The mcumgr_smp is used instead.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>