### PR TITLE
Mgmt mcumgr zephyr grp fixes

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -30,23 +30,7 @@ menu "Command Handlers"
 
 rsource "lib/cmd/Kconfig"
 
-menuconfig MCUMGR_GRP_ZEPHYR_BASIC
-	bool "Zephyr specific basic group of commands"
-	help
-	  Enables mcumgr to processing of Zephyr specific groups.
-
-if MCUMGR_GRP_ZEPHYR_BASIC
-config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
-	bool "Storage erase command"
-	help
-	  Enables command that allows to erase storage partition.
-
-module=MGMT_SETTINGS
-module-dep=LOG
-module-str=SETTINGS
-source "subsys/logging/Kconfig.template.log_config"
-
-endif
+rsource "zephyr_grp/Kconfig"
 
 endmenu
 

--- a/subsys/mgmt/mcumgr/zephyr_grp/Kconfig
+++ b/subsys/mgmt/mcumgr/zephyr_grp/Kconfig
@@ -12,9 +12,9 @@ config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
 	help
 	  Enables command that allows to erase storage partition.
 
-module=MGMT_SETTINGS
+module=MCUMGR_ZEPHYR_GRP
 module-dep=LOG
-module-str=SETTINGS
+module-str=mcumgr_zephyr_grp
 source "subsys/logging/Kconfig.template.log_config"
 
 endif

--- a/subsys/mgmt/mcumgr/zephyr_grp/Kconfig
+++ b/subsys/mgmt/mcumgr/zephyr_grp/Kconfig
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+menuconfig MCUMGR_GRP_ZEPHYR_BASIC
+	bool "Zephyr specific basic group of commands"
+	help
+	  Enables mcumgr to processing of Zephyr specific groups.
+
+if MCUMGR_GRP_ZEPHYR_BASIC
+config MCUMGR_GRP_BASIC_CMD_STORAGE_ERASE
+	bool "Storage erase command"
+	help
+	  Enables command that allows to erase storage partition.
+
+module=MGMT_SETTINGS
+module-dep=LOG
+module-str=SETTINGS
+source "subsys/logging/Kconfig.template.log_config"
+
+endif

--- a/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
+++ b/subsys/mgmt/mcumgr/zephyr_grp/basic_mgmt.c
@@ -11,7 +11,7 @@
 #include <mgmt/mcumgr/zephyr_groups.h>
 #include <storage/flash_map.h>
 
-LOG_MODULE_REGISTER(mgmt_zephyr_basic, CONFIG_MGMT_SETTINGS_LOG_LEVEL);
+LOG_MODULE_REGISTER(mcumgr_zephyr_grp);
 
 static int storage_erase(void)
 {


### PR DESCRIPTION
Two commits:
 1) moving zephyr_grp Kconfig options under zephyr_grp source dir;
 2) correcting logging module name which was different for Kconfig and source files.

Also fixes: https://github.com/zephyrproject-rtos/zephyr/issues/43700