### PR TITLE
mgmt/mcumgr: Kconfig: Gather transport options under own menus

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -50,14 +50,46 @@ endif
 
 endmenu
 
-config MCUMGR_SMP_REASSEMBLY_BT
-	bool "Reassemble packets in Bluetooth SMP transport"
-	select MCUMGR_SMP_REASSEMBLY
-	help
-	  When enabled, the SMP BT transport will buffer and reassemble received
-	  packet fragments before passing it for further processing.
+menu "Transports and Transport Related Configuration Options"
 
-config MCUMGR_SMP_BT
+config MCUMGR_SMP_REASSEMBLY
+	bool
+	help
+	  Enable structures and functions needed for packet reassembly by SMP backend.
+
+config MCUMGR_BUF_COUNT
+	int "Number of mcumgr buffers"
+	default 2 if MCUMGR_SMP_UDP
+	default 4
+	help
+	  The number of net_bufs to allocate for mcumgr.  These buffers are
+	  used for both requests and responses.
+
+config MCUMGR_BUF_SIZE
+	int "Size of each mcumgr buffer"
+	default 2048 if MCUMGR_SMP_UDP
+	default 384
+	help
+	  The size, in bytes, of each mcumgr buffer.  This value must satisfy
+	  the following relation:
+	  MCUMGR_BUF_SIZE >= transport-specific-MTU + transport-overhead
+	  In case when MCUMGR_SMP_SHELL is enabled this value should be set to
+	  at least SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
+
+config MCUMGR_BUF_USER_DATA_SIZE
+	int "Size of mcumgr buffer user data"
+	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
+	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
+	default 4
+	help
+	  The size, in bytes, of user data to allocate for each mcumgr buffer.
+
+	  Different mcumgr transports impose different requirements for this
+	  setting. A value of 4 is sufficient for UART, shell, and bluetooth.
+	  For UDP, the userdata must be large enough to hold a IPv4/IPv6 address.
+
+
+menuconfig MCUMGR_SMP_BT
 	bool "Bluetooth mcumgr SMP transport"
 	select BT
 	select BT_PERIPHERAL
@@ -66,6 +98,14 @@ config MCUMGR_SMP_BT
 	  Enables handling of SMP commands received over Bluetooth.
 
 if MCUMGR_SMP_BT
+
+config MCUMGR_SMP_REASSEMBLY_BT
+	bool "Reassemble packets in Bluetooth SMP transport"
+	select MCUMGR_SMP_REASSEMBLY
+	help
+	  When enabled, the SMP BT transport will buffer and reassemble received
+	  packet fragments before passing it for further processing.
+
 
 config MCUMGR_SMP_BT_AUTHEN
 	bool "Authenticated requirement for Bluetooth mcumgr SMP transport"
@@ -136,7 +176,7 @@ endif # MCUMGR_SMP_BT_CONN_PARAM_CONTROL
 
 endif # MCUMGR_SMP_BT
 
-config MCUMGR_SMP_SHELL
+menuconfig MCUMGR_SMP_SHELL
 	bool "Shell mcumgr SMP transport"
 	select SHELL
 	select SHELL_BACKEND_SERIAL
@@ -163,7 +203,7 @@ config MCUMGR_SMP_SHELL_RX_BUF_COUNT
 
 endif # MCUMGR_SMP_SHELL
 
-config MCUMGR_SMP_UART
+menuconfig MCUMGR_SMP_UART
 	bool "UART mcumgr SMP transport"
 	select UART_MCUMGR
 	select BASE64
@@ -210,7 +250,7 @@ config MCUMGR_SMP_UART_MTU
 	  MCUMGR_SMP_UART_MTU <= MCUMGR_BUF_SIZE + 2
 
 
-config MCUMGR_SMP_UDP
+menuconfig MCUMGR_SMP_UDP
 	bool "UDP mcumgr SMP transport"
 	select NETWORKING
 	select NET_UDP
@@ -265,41 +305,7 @@ config MCUMGR_SMP_UDP_MTU
 
 endif # MCUMGR_SMP_UDP
 
-config MCUMGR_SMP_REASSEMBLY
-	bool
-	help
-	  Enable structures and functions needed for packet reassembly by SMP backend.
-
-config MCUMGR_BUF_COUNT
-	int "Number of mcumgr buffers"
-	default 2 if MCUMGR_SMP_UDP
-	default 4
-	help
-	  The number of net_bufs to allocate for mcumgr.  These buffers are
-	  used for both requests and responses.
-
-config MCUMGR_BUF_SIZE
-	int "Size of each mcumgr buffer"
-	default 2048 if MCUMGR_SMP_UDP
-	default 384
-	help
-	  The size, in bytes, of each mcumgr buffer.  This value must satisfy
-	  the following relation:
-	  MCUMGR_BUF_SIZE >= transport-specific-MTU + transport-overhead
-	  In case when MCUMGR_SMP_SHELL is enabled this value should be set to
-	  at least SHELL_BACKEND_DUMMY_BUF_SIZE + 32.
-
-config MCUMGR_BUF_USER_DATA_SIZE
-	int "Size of mcumgr buffer user data"
-	default 24 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV6
-	default 8 if MCUMGR_SMP_UDP && MCUMGR_SMP_UDP_IPV4
-	default 4
-	help
-	  The size, in bytes, of user data to allocate for each mcumgr buffer.
-
-	  Different mcumgr transports impose different requirements for this
-	  setting. A value of 4 is sufficient for UART, shell, and bluetooth.
-	  For UDP, the userdata must be large enough to hold a IPv4/IPv6 address.
+endmenu
 
 module = MCUMGR_SMP
 module-str = mcumgr_smp


### PR DESCRIPTION
The commit adds transport dedicated menu and gathers all transport
options under that menu; each transport gets its own menu, witch
gathers options specific for that transport

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>