### PR TITLE
Revert "soc/it8xxx2: enable FPU support"

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
@@ -5,7 +5,6 @@ config SOC_SERIES_RISCV32_IT8XXX2
 	bool "ITE IT8XXX2 implementation"
 	#depends on RISCV
 	select COMPRESSED_ISA
-	select CPU_HAS_FPU
 	select SOC_FAMILY_RISCV_ITE
 	help
 	    Enable support for ITE IT8XXX2


### PR DESCRIPTION
This reverts commit b1ad97bc264c98236ba25a0997e7296babc387c9 since it
causes the following build failure:

  cc1: error: requested ABI requires '-march' to subsume the 'F'
  extension

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Reverts #44493