### PR TITLE
mgmt/mcumgr/lib: Add OS group command for obtaining mcumgr parameters

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -185,6 +185,12 @@ Build and Infrastructure
 Libraries / Subsystems
 **********************
 
+* Management
+
+  * Added support for MCUMGR Parameters command, which can be used to obtain
+    MCUMGR parameters; :kconfig:option:`CONFIG_OS_MGMT_MCUMGR_PARAMS` enables
+    the command.
+
 HALs
 ****
 

--- a/doc/services/device_mgmt/smp_groups/smp_group_0.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_0.rst
@@ -24,6 +24,8 @@ OS management group defines following commands:
     +-------------------+-----------------------------------------------+
     | ``5``             | System reset                                  |
     +-------------------+-----------------------------------------------+
+    | ``6``             | MCUMGR parameters                             |
+    +-------------------+-----------------------------------------------+
 
 Echo command
 ************
@@ -452,6 +454,66 @@ where:
 .. table::
     :align: center
 
+    +-----------------------+---------------------------------------------------+
+    | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
+    |                       | may not appear if 0                               |
+    +-----------------------+---------------------------------------------------+
+
+MCUMGR Parameters
+*****************
+
+Used to obtain parameters of mcumgr library.
+
+MCUMGR Parameters Request
+=========================
+
+MCUMGR parameters request header fields:
+
+.. table::
+    :align: center
+
+    +--------+--------------+----------------+
+    | ``OP`` | ``Group ID`` | ``Command ID`` |
+    +========+==============+================+
+    | ``0``  | ``0``        |  ``6``         |
+    +--------+--------------+----------------+
+
+The command sends empty CBOR map as data.
+
+MCUMGR Parameters Response
+==========================
+
+MCUMGR parameters response header fields
+
+.. table::
+    :align: center
+
+    +--------+--------------+----------------+
+    | ``OP`` | ``Group ID`` | ``Command ID`` |
+    +========+==============+================+
+    | ``2``  | ``0``        |  ``6``         |
+    +--------+--------------+----------------+
+
+CBOR data of response:
+
+.. code-block:: none
+
+    {
+        (str)"buf_size"     : (uint)
+        (str)"buf_count"    : (uint)
+        (opt,str)"rc"       : (int)
+    }
+
+where:
+
+.. table::
+    :align: center
+
+    +-----------------------+---------------------------------------------------+
+    | "buf_size"            | Single SMP buffer size, this includes SMP header  |
+    |                       | and CBOR payload                                  |
+    +-----------------------+---------------------------------------------------+
+    | "buf_count"           | Number of SMP buffers supported                   |
     +-----------------------+---------------------------------------------------+
     | "rc"                  | :ref:`mcumgr_smp_protocol_status_codes`;          |
     |                       | may not appear if 0                               |

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/Kconfig
@@ -118,4 +118,7 @@ config OS_MGMT_ECHO_LENGTH
 
 endif
 
+config OS_MGMT_MCUMGR_PARAMS
+	bool "MCUMGR Parameters retrieval command"
+
 endif

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/include/os_mgmt/os_mgmt.h
@@ -20,6 +20,7 @@ extern "C" {
 #define OS_MGMT_ID_MPSTAT		3
 #define OS_MGMT_ID_DATETIME_STR		4
 #define OS_MGMT_ID_RESET		5
+#define OS_MGMT_ID_MCUMGR_PARAMS	6
 
 /**
  * @brief Registers the OS management command handler group.

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -235,6 +235,22 @@ os_mgmt_reset(struct mgmt_ctxt *ctxt)
 	return os_mgmt_impl_reset(CONFIG_OS_MGMT_RESET_MS);
 }
 
+#if CONFIG_OS_MGMT_MCUMGR_PARAMS
+static int
+os_mgmt_mcumgr_params(struct mgmt_ctxt *ctxt)
+{
+	zcbor_state_t *zse = ctxt->cnbe->zs;
+	bool ok;
+
+	ok = zcbor_tstr_put_lit(zse, "buf_size")		&&
+	     zcbor_uint32_put(zse, CONFIG_MCUMGR_BUF_SIZE)	&&
+	     zcbor_tstr_put_lit(zse, "buf_count")		&&
+	     zcbor_uint32_put(zse, CONFIG_MCUMGR_BUF_COUNT);
+
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+}
+#endif
+
 static const struct mgmt_handler os_mgmt_group_handlers[] = {
 #if CONFIG_OS_MGMT_ECHO
 	[OS_MGMT_ID_ECHO] = {
@@ -249,6 +265,11 @@ static const struct mgmt_handler os_mgmt_group_handlers[] = {
 	[OS_MGMT_ID_RESET] = {
 		NULL, os_mgmt_reset
 	},
+#if CONFIG_OS_MGMT_MCUMGR_PARAMS
+	[OS_MGMT_ID_MCUMGR_PARAMS] = {
+		os_mgmt_mcumgr_params, NULL
+	},
+#endif
 };
 
 #define OS_MGMT_GROUP_SZ ARRAY_SIZE(os_mgmt_group_handlers)


### PR DESCRIPTION
The PR adds two commits that:
 1) add documentation for new OS management command that allows to obtain MCUMGR parameters;
 2) add implementation for that commit together with Kconfig options.

Due to lack of better suggestions to https://github.com/zephyrproject-rtos/zephyr/issues/42325 this is the best thing we can have now.