### PR TITLE
net: openthread: name Kconfig version choice

### DIFF
--- a/subsys/net/l2/openthread/Kconfig.features
+++ b/subsys/net/l2/openthread/Kconfig.features
@@ -3,8 +3,9 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-choice
+choice OPENTHREAD_STACK_VERSION
 	prompt "OpenThread stack version"
+	default OPENTHREAD_THREAD_VERSION_1_1
 	help
 	  This option selects version of Thread stack
 


### PR DESCRIPTION
Name OpenThread version selection option to `OPENTHREAD_STACK_VERSION`
to be able to superseed it somewhere else.

Signed-off-by: Eduardo Montoya <eduardo.montoya@nordicsemi.no>