### PR TITLE
ztest: fix `before` function ordering

### DIFF
--- a/subsys/testsuite/ztest/include/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/ztest_test_new.h
@@ -278,6 +278,12 @@ struct ztest_test_rule {
  * provides a mechanism for tests to perform custom operations depending on the specific test or
  * the data (for example logging may use the test's name).
  *
+ * Ordering:
+ * - Test rule's `before` function will run before the suite's `before` function. This is done to
+ * allow the test suite's customization to take precedence over the rule which is applied to all
+ * suites.
+ * - Test rule's `after` function is not guaranteed to run in any particular order.
+ *
  * @param name The name for the test rule (must be unique within the compilation unit)
  * @param before_each_fn The callback function to call before each test (may be NULL)
  * @param after_each_fn The callback function to call after each test (may be NULL)

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -400,10 +400,10 @@ static void test_cb(void *a, void *b, void *c)
 	struct ztest_unit_test *test = b;
 
 	test_result = 1;
+	run_test_rules(/*is_before=*/true, test, /*data=*/c);
 	if (suite->before) {
 		suite->before(/*data=*/c);
 	}
-	run_test_rules(/*is_before=*/true, test, /*data=*/c);
 	run_test_functions(suite, test, c);
 	test_result = 0;
 }
@@ -430,10 +430,10 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 		k_thread_join(&ztest_thread, K_FOREVER);
 	} else {
 		test_result = 1;
+		run_test_rules(/*is_before=*/true, test, data);
 		if (suite->before) {
 			suite->before(data);
 		}
-		run_test_rules(/*is_before=*/true, test, data);
 		run_test_functions(suite, test, data);
 	}
 


### PR DESCRIPTION
Make sure that the test rules' `before` function runs before the
suite's. This allows the suite to override any defaults set by the
rule.

Signed-off-by: Yuval Peress <peress@google.com>