### PR TITLE
drivers: net: offload: implement missing 'is_supported' socket offload cbs

### DIFF
--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -1085,6 +1085,19 @@ static struct net_if_api api_funcs = {
 
 static bool offload_is_supported(int family, int type, int proto)
 {
+	if (family != AF_INET &&
+	    family != AF_INET6) {
+		return false;
+	}
+
+	if (type != SOCK_STREAM) {
+		return false;
+	}
+
+	if (proto != IPPROTO_TCP) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -746,6 +746,21 @@ static struct net_if_api api_funcs = {
 
 static bool offload_is_supported(int family, int type, int proto)
 {
+	if (family != AF_INET &&
+	    family != AF_INET6) {
+		return false;
+	}
+
+	if (type != SOCK_DGRAM &&
+	    type != SOCK_STREAM) {
+		return false;
+	}
+
+	if (proto != IPPROTO_TCP &&
+	    proto != IPPROTO_UDP) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -1947,7 +1947,22 @@ static const struct socket_op_vtable offload_socket_fd_op_vtable = {
 
 static bool offload_is_supported(int family, int type, int proto)
 {
-	/* TODO offloading always enabled for now. */
+	if (family != AF_INET &&
+	    family != AF_INET6) {
+		return false;
+	}
+
+	if (type != SOCK_DGRAM &&
+	    type != SOCK_STREAM) {
+		return false;
+	}
+
+	if (proto != IPPROTO_TCP &&
+	    proto != IPPROTO_UDP &&
+	    proto != IPPROTO_TLS_1_2) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -131,6 +131,8 @@ int eswifi_at_cmd_rsp(struct eswifi_dev *eswifi, char *cmd, char **rsp);
 void eswifi_async_msg(struct eswifi_dev *eswifi, char *msg, size_t len);
 void eswifi_offload_async_msg(struct eswifi_dev *eswifi, char *msg, size_t len);
 
+int eswifi_socket_type_from_zephyr(int proto, enum eswifi_transport_type *type);
+
 int __eswifi_socket_free(struct eswifi_dev *eswifi,
 			 struct eswifi_off_socket *socket);
 int __eswifi_socket_new(struct eswifi_dev *eswifi, int family, int type,

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -18,6 +18,22 @@ LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 #include "eswifi.h"
 #include <net/net_pkt.h>
 
+int eswifi_socket_type_from_zephyr(int proto, enum eswifi_transport_type *type)
+{
+	if (IS_ENABLED(CONFIG_NET_SOCKETS_SOCKOPT_TLS) &&
+	    proto >= IPPROTO_TLS_1_0 && proto <= IPPROTO_TLS_1_2) {
+		*type = ESWIFI_TRANSPORT_TCP_SSL;
+	} else if (proto == IPPROTO_TCP) {
+		*type = ESWIFI_TRANSPORT_TCP;
+	} else if (proto == IPPROTO_UDP) {
+		*type = ESWIFI_TRANSPORT_UDP;
+	} else {
+		return -EPFNOSUPPORT;
+	}
+
+	return 0;
+}
+
 static int __stop_socket(struct eswifi_dev *eswifi,
 			 struct eswifi_off_socket *socket)
 {
@@ -274,16 +290,10 @@ int __eswifi_socket_new(struct eswifi_dev *eswifi, int family, int type,
 		return -ENOMEM;
 	}
 
-	if (IS_ENABLED(CONFIG_NET_SOCKETS_SOCKOPT_TLS) &&
-	    proto >= IPPROTO_TLS_1_0 && proto <= IPPROTO_TLS_1_2) {
-		socket->type = ESWIFI_TRANSPORT_TCP_SSL;
-	} else if (proto == IPPROTO_TCP) {
-		socket->type = ESWIFI_TRANSPORT_TCP;
-	} else if (proto == IPPROTO_UDP) {
-		socket->type = ESWIFI_TRANSPORT_UDP;
-	} else {
+	err = eswifi_socket_type_from_zephyr(proto, &socket->type);
+	if (err) {
 		LOG_ERR("Only TCP & UDP is supported");
-		return -EPFNOSUPPORT;
+		return err;
 	}
 
 	err = __select_socket(eswifi, socket->index);

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -492,6 +492,23 @@ static int eswifi_socket_bind(void *obj, const struct sockaddr *addr,
 
 static bool eswifi_socket_is_supported(int family, int type, int proto)
 {
+	enum eswifi_transport_type eswifi_socket_type;
+	int err;
+
+	if (family != AF_INET) {
+		return false;
+	}
+
+	if (type != SOCK_DGRAM &&
+	    type != SOCK_STREAM) {
+		return false;
+	}
+
+	err = eswifi_socket_type_from_zephyr(proto, &eswifi_socket_type);
+	if (err) {
+		return false;
+	}
+
 	return true;
 }
 

--- a/drivers/wifi/simplelink/simplelink_sockets.c
+++ b/drivers/wifi/simplelink/simplelink_sockets.c
@@ -186,64 +186,94 @@ static int getErrno(_i32 error)
 	return error;
 }
 
+static int simplelink_socket_family_from_posix(int family, int *family_sl)
+{
+	switch (family) {
+	case AF_INET:
+		*family_sl = SL_AF_INET;
+		break;
+	case AF_INET6:
+		*family_sl = SL_AF_INET6;
+		break;
+	default:
+		return -EAFNOSUPPORT;
+	}
+
+	return 0;
+}
+
+static int simplelink_socket_type_from_posix(int type, int *type_sl)
+{
+	switch (type) {
+	case SOCK_STREAM:
+		*type_sl = SL_SOCK_STREAM;
+		break;
+	case SOCK_DGRAM:
+		*type_sl = SL_SOCK_DGRAM;
+		break;
+	case SOCK_RAW:
+		*type_sl = SL_SOCK_RAW;
+		break;
+	default:
+		return -ESOCKTNOSUPPORT;
+	}
+
+	return 0;
+}
+
+static int simplelink_socket_proto_from_zephyr(int proto, int *proto_sl)
+{
+	if (proto >= IPPROTO_TLS_1_0 && proto <= IPPROTO_TLS_1_2) {
+		*proto_sl = SL_SEC_SOCKET;
+	} else if (proto >= IPPROTO_DTLS_1_0 && proto <= IPPROTO_DTLS_1_2) {
+		/* SimpleLink doesn't handle DTLS yet! */
+		return -EPROTONOSUPPORT;
+	} else {
+		switch (proto) {
+		case IPPROTO_TCP:
+			*proto_sl = SL_IPPROTO_TCP;
+			break;
+		case IPPROTO_UDP:
+			*proto_sl = SL_IPPROTO_UDP;
+			break;
+		default:
+			return -EPROTONOSUPPORT;
+		}
+	}
+
+	return 0;
+}
+
 static int simplelink_socket(int family, int type, int proto)
 {
 	uint8_t sec_method = SL_SO_SEC_METHOD_SSLv3_TLSV1_2;
 	int sd;
 	int retval = 0;
 	int sl_proto = proto;
+	int err;
 
 	/* Map Zephyr socket.h family to SimpleLink's: */
-	switch (family) {
-	case AF_INET:
-		family = SL_AF_INET;
-		break;
-	case AF_INET6:
-		family = SL_AF_INET6;
-		break;
-	default:
+	err = simplelink_socket_family_from_posix(family, &family);
+	if (err) {
 		LOG_ERR("unsupported family: %d", family);
-		retval = slcb_SetErrno(EAFNOSUPPORT);
+		retval = slcb_SetErrno(-err);
 		goto exit;
 	}
 
 	/* Map Zephyr socket.h type to SimpleLink's: */
-	switch (type) {
-	case SOCK_STREAM:
-		type = SL_SOCK_STREAM;
-		break;
-	case SOCK_DGRAM:
-		type = SL_SOCK_DGRAM;
-		break;
-	case SOCK_RAW:
-		type = SL_SOCK_RAW;
-		break;
-	default:
-		LOG_ERR("unrecognized type: %d", type);
-		retval = slcb_SetErrno(ESOCKTNOSUPPORT);
+	err = simplelink_socket_type_from_posix(type, &type);
+	if (err) {
+		LOG_ERR("unsupported type: %d", type);
+		retval = slcb_SetErrno(-err);
 		goto exit;
 	}
 
 	/* Map Zephyr protocols to TI's values: */
-	if (proto >= IPPROTO_TLS_1_0 && proto <= IPPROTO_TLS_1_2) {
-		sl_proto = SL_SEC_SOCKET;
-	} else if (proto >= IPPROTO_DTLS_1_0 && proto <= IPPROTO_DTLS_1_2) {
-		/* SimpleLink doesn't handle DTLS yet! */
-		retval = slcb_SetErrno(EPROTONOSUPPORT);
+	err = simplelink_socket_proto_from_zephyr(proto, &sl_proto);
+	if (err) {
+		LOG_ERR("unsupported proto: %d", proto);
+		retval = slcb_SetErrno(-err);
 		goto exit;
-	} else {
-		switch (proto) {
-		case IPPROTO_TCP:
-			sl_proto = SL_IPPROTO_TCP;
-			break;
-		case IPPROTO_UDP:
-			sl_proto = SL_IPPROTO_UDP;
-			break;
-		default:
-			LOG_ERR("unrecognized proto: %d", sl_proto);
-			retval = slcb_SetErrno(EPROTONOSUPPORT);
-			goto exit;
-		}
 	}
 
 	sd = sl_Socket(family, type, sl_proto);
@@ -1207,7 +1237,24 @@ static const struct socket_op_vtable simplelink_socket_fd_op_vtable = {
 
 static bool simplelink_is_supported(int family, int type, int proto)
 {
-	/* TODO offloading always enabled for now. */
+	int dummy;
+	int err;
+
+	err = simplelink_socket_family_from_posix(family, &dummy);
+	if (err) {
+		return false;
+	}
+
+	err = simplelink_socket_type_from_posix(type, &dummy);
+	if (err) {
+		return false;
+	}
+
+	err = simplelink_socket_proto_from_zephyr(proto, &dummy);
+	if (err) {
+		return false;
+	}
+
 	return true;
 }
 


### PR DESCRIPTION
Check if requested socket family, type and protocol are all supported by
the driver, instead of blindly acknowledging every possible variant.

Implemented checks are done based on current state of each driver.

Related PR: #44513