### PR TITLE
Bluetooth: Audio: Add parent service requirement if CSIS cnt > 1

### DIFF
--- a/include/zephyr/bluetooth/audio/csis.h
+++ b/include/zephyr/bluetooth/audio/csis.h
@@ -131,6 +131,19 @@ struct bt_csis_register_param {
 
 	/** Pointer to the callback structure. */
 	struct bt_csis_cb *cb;
+
+#if CONFIG_BT_CSIS_MAX_INSTANCE_COUNT > 1
+	/**
+	 * @brief Parent service pointer
+	 *
+	 * Mandatory parent service pointer if this CSIS instance is included
+	 * by another service. All CSIS instances when
+	 * @kconfig{CONFIG_BT_CSIS_MAX_INSTANCE_COUNT} is above 1 shall
+	 * be included by another service, as per the
+	 * Coordinated Set Identification Profile (CSIP).
+	 */
+	const struct bt_gatt_service *parent;
+#endif /* CONFIG_BT_CSIS_MAX_INSTANCE_COUNT > 1 */
 };
 
 /**

--- a/subsys/bluetooth/audio/csis.c
+++ b/subsys/bluetooth/audio/csis.c
@@ -856,6 +856,13 @@ static bool valid_register_param(const struct bt_csis_register_param *param)
 		return false;
 	}
 
+#if CONFIG_BT_CSIS_MAX_INSTANCE_COUNT > 1
+	if (param->parent == NULL) {
+		BT_DBG("Parent service not provided");
+		return false;
+	}
+#endif /* CONFIG_BT_CSIS_MAX_INSTANCE_COUNT > 1 */
+
 	return true;
 }
 


### PR DESCRIPTION
If the number of CSIS instances on a device is
above 1, then each shall be included by another
service.

This creates a bit of a chicken and egg issue,
as we can't really register the "parant" service
before the CSIS instance has been registered,
and we thus can't verify if the parent service
pointer is actually another primary service on this
device. The best we can do is add the proper
type and a NULL check.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>