### PR TITLE
Batch/defer scheduler IPIs until schedule points

### DIFF
--- a/include/zephyr/kernel_structs.h
+++ b/include/zephyr/kernel_structs.h
@@ -183,6 +183,11 @@ struct z_kernel {
 #if defined(CONFIG_THREAD_MONITOR)
 	struct k_thread *threads; /* singly linked list of ALL threads */
 #endif
+
+#if defined(CONFIG_SMP) && defined(CONFIG_SCHED_IPI_SUPPORTED)
+	/* Need to signal an IPI at the next scheduling point */
+	bool pending_ipi;
+#endif
 };
 
 typedef struct z_kernel _kernel_t;

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -368,13 +368,13 @@ int k_work_submit_to_queue(struct k_work_q *queue,
 
 	k_spin_unlock(&lock, key);
 
-	/* If we changed the queue contents (as indicated by a positive ret)
-	 * the queue thread may now be ready, but we missed the reschedule
-	 * point because the lock was held.  If this is being invoked by a
-	 * preemptible thread then yield.
+	/* submit_to_queue_locked() won't reschedule on its own
+	 * (really it should, otherwise this process will result in
+	 * spurious calls to z_swap() due to the race), so do it here
+	 * if the queue state changed.
 	 */
-	if ((ret > 0) && (k_is_preempt_thread() != 0)) {
-		k_yield();
+	if (ret > 0) {
+		z_reschedule_unlocked();
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_work, submit_to_queue, queue, work, ret);


### PR DESCRIPTION
The original design intent with arch_sched_ipi() was that interprocessor interrupts were fast and easily sent, so to reduce latency the scheduler should notify other CPUs synchronously when scheduler state changes.

This tends to result in "storms" of IPIs in some use cases, though. For example, SOF will enumerate over all cores doing a k_sem_give() to notify a worker thread pinned to each, each call causing a separate IPI.  Add to that the fact that unlike x86's IO-APIC, the intel_adsp architecture has targeted/non-broadcast IPIs that need to be repeated for each core, and suddenly we have an O(N^2) scaling problem in the number of CPUs.

Instead, batch the "pending" IPIs and send them only at known scheduling points (end-of-interrupt and swap).  This semantically matches the locations where application code will "expect" to see other threads run, so arguably is a better choice anyway.