### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 17.7

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -1317,7 +1317,7 @@ int arch_buffer_validate(const void *addr, size_t size, bool write)
 	int ret = 0;
 
 	/* addr/size arbitrary, fix this up into an aligned region */
-	k_mem_region_align((uintptr_t *)&virt, &aligned_size,
+	(void)k_mem_region_align((uintptr_t *)&virt, &aligned_size,
 			   (uintptr_t)addr, size, CONFIG_MMU_PAGE_SIZE);
 
 	for (size_t offset = 0; offset < aligned_size;

--- a/include/spinlock.h
+++ b/include/spinlock.h
@@ -180,7 +180,7 @@ static ALWAYS_INLINE void k_spin_unlock(struct k_spinlock *l,
 	 * a memory barrier when used like this, and we don't have a
 	 * Zephyr framework for that.
 	 */
-	atomic_clear(&l->locked);
+	(void)atomic_clear(&l->locked);
 #endif
 	arch_irq_unlock(key.key);
 }
@@ -195,7 +195,7 @@ static ALWAYS_INLINE void k_spin_release(struct k_spinlock *l)
 	__ASSERT(z_spin_unlock_valid(l), "Not my spinlock %p", l);
 #endif
 #ifdef CONFIG_SMP
-	atomic_clear(&l->locked);
+	(void)atomic_clear(&l->locked);
 #endif
 }
 

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -33,7 +33,7 @@ void z_smp_global_unlock(unsigned int key)
 		_current->base.global_lock_count--;
 
 		if (_current->base.global_lock_count == 0) {
-			atomic_clear(&global_lock);
+			(void)atomic_clear(&global_lock);
 		}
 	}
 
@@ -44,7 +44,7 @@ void z_smp_global_unlock(unsigned int key)
 void z_smp_release_global_lock(struct k_thread *thread)
 {
 	if (thread->base.global_lock_count == 0) {
-		atomic_clear(&global_lock);
+		(void)atomic_clear(&global_lock);
 	}
 }
 

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -52,7 +52,7 @@ int sys_sem_init(struct sys_sem *sem, unsigned int initial_count,
 		return -EINVAL;
 	}
 
-	atomic_set(&sem->futex.val, (int)initial_count);
+	(void)atomic_set(&sem->futex.val, (int)initial_count);
 	sem->limit = (int)limit;
 
 	return 0;

--- a/scripts/gen_syscalls.py
+++ b/scripts/gen_syscalls.py
@@ -210,7 +210,7 @@ def wrapper_defs(func_name, func_type, args):
         wrap += "\t\t" + "(void)%s;\n" % invoke
         wrap += "\t\t" + "return (%s)ret64;\n" % func_type
     elif func_type == "void":
-        wrap += "\t\t" + "%s;\n" % invoke
+        wrap += "\t\t" + "(void)%s;\n" % invoke
         wrap += "\t\t" + "return;\n"
     elif func_type == "bool":
         wrap += "\t\t" + "return %s != 0U;\n" % (invoke)


### PR DESCRIPTION
- added explicit cast to void when returned value is expectedly ignored

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>