### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 8.6

### DIFF
--- a/include/app_memory/mem_domain.h
+++ b/include/app_memory/mem_domain.h
@@ -106,6 +106,7 @@ struct k_mem_domain;
 struct k_mem_partition;
 #endif /* CONFIG_USERSPACE */
 
+#ifdef CONFIG_USERSPACE
 /**
  * @brief Initialize a memory domain.
  *
@@ -174,6 +175,7 @@ extern void k_mem_domain_remove_partition(struct k_mem_domain *domain,
  */
 extern void k_mem_domain_add_thread(struct k_mem_domain *domain,
 				    k_tid_t thread);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/arch/x86/memmap.h
+++ b/include/arch/x86/memmap.h
@@ -21,7 +21,9 @@ enum x86_memmap_source {
 	X86_MEMMAP_SOURCE_MANUAL
 };
 
+#ifdef CONFIG_X86_MEMMAP
 extern enum x86_memmap_source x86_memmap_source;
+#endif
 
 /*
  * For simplicity, we maintain a fixed-sized array of memory regions.
@@ -53,7 +55,9 @@ struct x86_memmap_entry {
 	enum x86_memmap_entry_type type;
 };
 
+#ifdef CONFIG_X86_MEMMAP
 extern struct x86_memmap_entry x86_memmap[];
+#endif
 
 /*
  * We keep track of kernel memory areas (text, data, etc.) in a table for
@@ -67,8 +71,10 @@ struct x86_memmap_exclusion {
 	void *end;		/* one byte past end of exclusion */
 };
 
+#ifdef CONFIG_X86_MEMMAP
 extern struct x86_memmap_exclusion x86_memmap_exclusions[];
 extern int x86_nr_memmap_exclusions;
+#endif
 
 #endif /* _ASMLANGUAGE */
 

--- a/include/arch/x86/multiboot.h
+++ b/include/arch/x86/multiboot.h
@@ -34,9 +34,11 @@ struct multiboot_info {
 	uint8_t  fb_color_info[6];
 };
 
+#ifdef CONFIG_MULTIBOOT_INFO
 extern struct multiboot_info multiboot_info;
 
 extern void z_multiboot_init(struct multiboot_info *info_pa);
+#endif
 
 /*
  * the mmap_addr field points to a series of entries of the following form.

--- a/include/drivers/console/uart_console.h
+++ b/include/drivers/console/uart_console.h
@@ -15,6 +15,7 @@
 extern "C" {
 #endif
 
+#ifdef CONFIG_CONSOLE_HANDLER
 /** @brief Register uart input processing
  *
  *  Input processing is started when string is typed in the console.
@@ -31,6 +32,7 @@ extern "C" {
  */
 void uart_register_input(struct k_fifo *avail, struct k_fifo *lines,
 			 uint8_t (*completion)(char *str, uint8_t len));
+#endif
 
 /*
  * Allows having debug hooks in the console driver for handling incoming

--- a/include/drivers/timer/system_timer.h
+++ b/include/drivers/timer/system_timer.h
@@ -38,6 +38,7 @@ extern "C" {
  */
 extern int sys_clock_driver_init(const struct device *dev);
 
+#if 0
 /**
  * @brief Initialize system clock driver
  *
@@ -48,6 +49,7 @@ extern int sys_clock_driver_init(const struct device *dev);
  */
 extern int clock_device_ctrl(const struct device *dev,
 			     enum pm_device_state state);
+#endif
 
 /**
  * @brief Set system clock timeout

--- a/include/fs/fs.h
+++ b/include/fs/fs.h
@@ -231,6 +231,7 @@ static inline void fs_dir_t_init(struct fs_dir_t *zdp)
 	*zdp = (struct fs_dir_t){ 0 };
 }
 
+#ifdef CONFIG_POSIX_FS
 /**
  * @brief Open or create file
  *
@@ -591,6 +592,7 @@ int fs_register(int type, const struct fs_file_system_t *fs);
  * @retval <0 negative errno code on error.
  */
 int fs_unregister(int type, const struct fs_file_system_t *fs);
+#endif
 
 /**
  * @}

--- a/include/irq_offload.h
+++ b/include/irq_offload.h
@@ -17,6 +17,7 @@ extern "C" {
 
 typedef void (*irq_offload_routine_t)(const void *parameter);
 
+#ifdef CONFIG_IRQ_OFFLOAD
 /**
  * @brief Run a function in interrupt context
  *
@@ -30,6 +31,7 @@ typedef void (*irq_offload_routine_t)(const void *parameter);
  * interrupt
  */
 void irq_offload(irq_offload_routine_t routine, const void *parameter);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/kernel.h
+++ b/include/kernel.h
@@ -981,6 +981,7 @@ extern void k_sched_lock(void);
  */
 extern void k_sched_unlock(void);
 
+#ifdef CONFIG_THREAD_CUSTOM_DATA
 /**
  * @brief Set current thread's custom data.
  *
@@ -1005,6 +1006,7 @@ __syscall void k_thread_custom_data_set(void *value);
  * @return Current custom data value.
  */
 __syscall void *k_thread_custom_data_get(void);
+#endif
 
 /**
  * @brief Set current thread name
@@ -3953,6 +3955,7 @@ static inline int k_work_user_submit_to_queue(struct k_work_user_q *work_q,
 	return ret;
 }
 
+#ifdef CONFIG_USERSPACE
 /**
  * @brief Start a workqueue in user mode
  *
@@ -3978,6 +3981,7 @@ extern void k_work_user_queue_start(struct k_work_user_q *work_q,
 				    k_thread_stack_t *stack,
 				    size_t stack_size, int prio,
 				    const char *name);
+#endif
 
 /** @} */
 
@@ -4033,6 +4037,7 @@ struct k_work_poll {
 #define K_DELAYED_WORK_DEFINE(work, work_handler) __DEPRECATED_MACRO \
 	struct k_delayed_work work = Z_DELAYED_WORK_INITIALIZER(work_handler)
 
+#ifdef CONFIG_POLL
 /**
  * @brief Initialize a triggered work item.
  *
@@ -4138,6 +4143,7 @@ extern int k_work_poll_submit(struct k_work_poll *work,
  * @retval -EINVAL Work item is being processed or has completed its work.
  */
 extern int k_work_poll_cancel(struct k_work_poll *work);
+#endif
 
 /** @} */
 
@@ -5347,6 +5353,7 @@ struct k_poll_event {
 	}, \
 	}
 
+#ifdef CONFIG_POOL
 /**
  * @brief Initialize one struct k_poll_event instance
  *
@@ -5367,6 +5374,13 @@ struct k_poll_event {
 extern void k_poll_event_init(struct k_poll_event *event, uint32_t type,
 			      int mode, void *obj);
 
+/**
+ * @internal
+ */
+extern void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
+#endif
+
+#ifdef CONFIG_POLL
 /**
  * @brief Wait for one or many of multiple poll events to occur
  *
@@ -5470,11 +5484,7 @@ __syscall void k_poll_signal_check(struct k_poll_signal *sig,
  */
 
 __syscall int k_poll_signal_raise(struct k_poll_signal *sig, int result);
-
-/**
- * @internal
- */
-extern void z_handle_obj_poll_events(sys_dlist_t *events, uint32_t state);
+#endif
 
 /** @} */
 
@@ -5607,7 +5617,7 @@ extern void z_init_static_threads(void);
  */
 extern bool z_is_thread_essential(void);
 
-#ifdef CONFIG_SMP
+#if CONFIG_MP_NUM_CPUS > 1
 void z_smp_thread_init(void *arg, struct k_thread *thread);
 void z_smp_thread_swap(void);
 #endif

--- a/include/logging/log_core.h
+++ b/include/logging/log_core.h
@@ -558,11 +558,13 @@ static inline uint16_t log_dynamic_source_id(struct log_source_dynamic_data *dat
 			sizeof(struct log_source_dynamic_data));
 }
 
+#if !defined(CONFIG_LOG_MINIMAL)
 /* Initialize runtime filters */
 void z_log_runtime_filters_init(void);
 
 /* Notify log_core that a backend was enabled. */
 void z_log_notify_backend_enabled(void);
+#endif
 
 /** @brief Dummy function to trigger log messages arguments type checking. */
 static inline __printf_like(1, 2)
@@ -571,6 +573,7 @@ void z_log_printf_arg_checker(const char *fmt, ...)
 	ARG_UNUSED(fmt);
 }
 
+#if !defined(CONFIG_LOG_MINIMAL)
 /** @brief Standard log with no arguments.
  *
  * @param str           String.
@@ -798,6 +801,7 @@ void log_hexdump_from_user(struct log_msg_ids src_level, const char *metadata,
 __syscall void z_log_hexdump_from_user(uint32_t src_level_val,
 				       const char *metadata,
 				       const uint8_t *data, uint32_t len);
+#endif
 
 /******************************************************************************/
 /********** Mocros _VA operate on var-args parameters.          ***************/

--- a/include/logging/log_core2.h
+++ b/include/logging/log_core2.h
@@ -12,6 +12,7 @@
 extern "C" {
 #endif
 
+#if !defined(CONFIG_LOG_MINIMAL)
 /** @brief Initialize module for handling logging message. */
 void z_log_msg2_init(void);
 
@@ -49,6 +50,7 @@ void z_log_msg2_free(union log_msg2_generic *msg);
  * @retval false if no message is pending.
  */
 bool z_log_msg2_pending(void);
+#endif
 
 #ifdef __cplusplus
 }

--- a/include/logging/log_ctrl.h
+++ b/include/logging/log_ctrl.h
@@ -31,6 +31,7 @@ extern "C" {
 
 typedef log_timestamp_t (*log_timestamp_get_t)(void);
 
+#if !defined(CONFIG_LOG_MINIMAL)
 /** @brief Function system initialization of the logger.
  *
  * Function is called during start up to allow logging before user can
@@ -65,6 +66,7 @@ void log_thread_set(k_tid_t process_tid);
  */
 int log_set_timestamp_func(log_timestamp_get_t timestamp_getter,
 			   uint32_t freq);
+#endif
 
 /**
  * @brief Switch the logger subsystem to the panic mode.
@@ -95,6 +97,7 @@ __syscall bool log_process(bool bypass);
  */
 __syscall uint32_t log_buffered_cnt(void);
 
+#if !defined(CONFIG_LOG_MINIMAL)
 /** @brief Get number of independent logger sources (modules and instances)
  *
  * @param domain_id Domain ID.
@@ -168,6 +171,7 @@ void log_backend_enable(struct log_backend const *const backend,
  * @param backend	Backend instance.
  */
 void log_backend_disable(struct log_backend const *const backend);
+#endif
 
 #if defined(CONFIG_LOG) && !defined(CONFIG_LOG_MINIMAL)
 #define LOG_CORE_INIT() log_core_init()

--- a/include/logging/log_msg.h
+++ b/include/logging/log_msg.h
@@ -161,6 +161,7 @@ union log_msg_chunk {
 	struct log_msg_cont cont;
 };
 
+#if !defined(CONFIG_LOG_MINIMAL)
 /** @brief Function for initialization of the log message pool. */
 void log_msg_pool_init(void);
 
@@ -188,6 +189,8 @@ void log_msg_put(struct log_msg *msg);
  *
  * @return Domain ID.
  */
+#endif
+
 static inline uint32_t log_msg_domain_id_get(struct log_msg *msg)
 {
 	return msg->hdr.ids.domain_id;
@@ -238,6 +241,7 @@ static inline bool log_msg_is_std(struct log_msg *msg)
 	return  (msg->hdr.params.generic.type == LOG_MSG_TYPE_STD);
 }
 
+#if !defined(CONFIG_LOG_MINIMAL)
 /** @brief Returns number of arguments in standard log message.
  *
  * @param msg Standard log message.
@@ -463,6 +467,7 @@ static inline struct log_msg *log_msg_create_3(const char *str,
  *
  *  @return Pointer to allocated head of the message or NULL.
  */
+
 struct log_msg *log_msg_create_n(const char *str,
 				 log_arg_t *args,
 				 uint32_t nargs);
@@ -481,6 +486,7 @@ uint32_t log_msg_mem_get_used(void);
  * @brief Get max used blocks from the log mem pool
  */
 uint32_t log_msg_mem_get_max_used(void);
+#endif
 
 
 /**

--- a/include/logging/log_msg2.h
+++ b/include/logging/log_msg2.h
@@ -403,6 +403,7 @@ do { \
 			   _domain_id, _source, _level, _data, _dlen, \
 			   Z_LOG_STR(_level, __VA_ARGS__))
 
+#ifdef CONFIG_LOG2
 /** @brief Finalize message.
  *
  * Finalization includes setting source, copying data and timestamp in the
@@ -429,6 +430,7 @@ void z_log_msg2_finalize(struct log_msg2 *msg, const void *source,
  *
  * @oaram data Data.
  */
+
 __syscall void z_log_msg2_static_create(const void *source,
 					const struct log_msg2_desc desc,
 					uint8_t *package, const void *data);
@@ -488,6 +490,7 @@ static inline void z_log_msg2_runtime_create(uint8_t domain_id,
 				   data, dlen, fmt, ap);
 	va_end(ap);
 }
+#endif
 
 static inline bool z_log_item_is_msg(const union log_msg2_generic *msg)
 {

--- a/include/pm/device.h
+++ b/include/pm/device.h
@@ -139,6 +139,7 @@ struct pm_device {
 typedef int (*pm_device_control_callback_t)(const struct device *dev,
 					    enum pm_device_action action);
 
+#ifdef CONFIG_PM_DEVICE
 /**
  * @brief Get name of device PM state
  *
@@ -179,7 +180,6 @@ int pm_device_state_set(const struct device *dev,
 int pm_device_state_get(const struct device *dev,
 			enum pm_device_state *state);
 
-#ifdef CONFIG_PM_DEVICE
 /**
  * @brief Indicate that the device is in the middle of a transaction
  *
@@ -269,6 +269,7 @@ __deprecated static inline int device_busy_check(const struct device *dev)
 /** Alias for legacy use of device_pm_control_nop */
 #define device_pm_control_nop __DEPRECATED_MACRO NULL
 
+#ifdef CONFIG_PM_DEVICE
 /**
  * @brief Enable a power management wakeup source
  *
@@ -304,6 +305,7 @@ bool pm_device_wakeup_is_enabled(const struct device *dev);
  * @retval false if the device is not wake up capable.
  */
 bool pm_device_wakeup_is_capable(const struct device *dev);
+#endif
 
 /** @} */
 

--- a/include/posix/time.h
+++ b/include/posix/time.h
@@ -90,13 +90,17 @@ int clock_gettime(clockid_t clock_id, struct timespec *ts);
 #else
 __syscall int clock_gettime(clockid_t clock_id, struct timespec *ts);
 #endif /* CONFIG_ARCH_POSIX */
+#ifdef CONFIG_POSIX_CLOCK
 int clock_settime(clockid_t clock_id, const struct timespec *ts);
+#endif
 /* Timer APIs */
+#ifdef CONFIG_POSIX_CLOCK
 int timer_create(clockid_t clockId, struct sigevent *evp, timer_t *timerid);
 int timer_delete(timer_t timerid);
 int timer_gettime(timer_t timerid, struct itimerspec *its);
 int timer_settime(timer_t timerid, int flags, const struct itimerspec *value,
 		  struct itimerspec *ovalue);
+#endif
 int nanosleep(const struct timespec *rqtp, struct timespec *rmtp);
 
 #ifdef __cplusplus

--- a/include/sys/arch_interface.h
+++ b/include/sys/arch_interface.h
@@ -217,12 +217,15 @@ typedef FUNC_NORETURN void (*arch_cpustart_t)(void *data);
 void arch_start_cpu(int cpu_num, k_thread_stack_t *stack, int sz,
 		    arch_cpustart_t fn, void *arg);
 
+#if	(defined(CONFIG_SOC_INTEL_S1000) && defined(CONFIG_SMP)) || \
+	defined(CONFIG_SOC_FAMILY_INTEL_ADSP)
 /**
  * @brief Return CPU power status
  *
  * @param cpu_num Integer number of the CPU
  */
 bool arch_cpu_active(int cpu_num);
+#endif
 
 /** @} */
 
@@ -278,12 +281,16 @@ void arch_irq_disable(unsigned int irq);
  */
 void arch_irq_enable(unsigned int irq);
 
+#if 0
+/*? This should be moved to arch specific header files
+    for architectures where this function is present */
 /**
  * Test if an interrupt line is enabled
  *
  * @see irq_is_enabled()
  */
 int arch_irq_is_enabled(unsigned int irq);
+#endif
 
 /**
  * Arch-specific hook to install a dynamic interrupt.
@@ -685,6 +692,7 @@ FUNC_NORETURN void arch_user_mode_enter(k_thread_entry_t user_entry,
  *            architecture specific.
  */
 FUNC_NORETURN void arch_syscall_oops(void *ssf_ptr);
+#endif /* CONFIG_USERSPACE */
 
 /**
  * @brief Safely take the length of a potentially bad string
@@ -699,7 +707,6 @@ FUNC_NORETURN void arch_syscall_oops(void *ssf_ptr);
  * @return Length of the string, not counting NULL byte, up to maxsize
  */
 size_t arch_user_string_nlen(const char *s, size_t maxsize, int *err);
-#endif /* CONFIG_USERSPACE */
 
 /**
  * @brief Detect memory coherence type

--- a/include/sys/mem_manage.h
+++ b/include/sys/mem_manage.h
@@ -375,6 +375,7 @@ size_t k_mem_region_align(uintptr_t *aligned_addr, size_t *aligned_size,
  * @{
  */
 
+#ifdef CONFIG_DEMAND_PAGING
 /**
  * Evict a page-aligned virtual memory region to the backing store
  *
@@ -441,7 +442,9 @@ void k_mem_pin(void *addr, size_t size);
  * @param size Page-aligned data region size
  */
 void k_mem_unpin(void *addr, size_t size);
+#endif
 
+#ifdef CONFIG_DEMAND_PAGING_STATS
 /**
  * Get the paging statistics since system startup
  *
@@ -465,7 +468,9 @@ struct k_thread;
 __syscall
 void k_mem_paging_thread_stats_get(struct k_thread *thread,
 				   struct k_mem_paging_stats_t *stats);
+#endif
 
+#ifdef CONFIG_DEMAND_PAGING_TIMING_HISTOGRAM
 /**
  * Get the eviction timing histogram
  *
@@ -498,6 +503,7 @@ __syscall void k_mem_paging_histogram_backing_store_page_in_get(
  */
 __syscall void k_mem_paging_histogram_backing_store_page_out_get(
 	struct k_mem_paging_histogram_t *hist);
+#endif
 
 #include <syscalls/mem_manage.h>
 
@@ -510,6 +516,7 @@ __syscall void k_mem_paging_histogram_backing_store_page_out_get(
  * @{
  */
 
+#ifdef CONFIG_EVICTION_NRU
 /**
  * Select a page frame for eviction
  *
@@ -534,6 +541,7 @@ struct z_page_frame *k_mem_paging_eviction_select(bool *dirty);
  * called until this has returned, and this will only be called once.
  */
 void k_mem_paging_eviction_init(void);
+#endif
 
 /** @} */
 
@@ -544,6 +552,7 @@ void k_mem_paging_eviction_init(void);
  * @{
  */
 
+#if defined(CONFIG_BACKING_STORE_RAM) || defined(CONFIG_BACKING_STORE_QEMU_X86_TINY_FLASH)
 /**
  * Reserve or fetch a storage location for a data page loaded into a page frame
  *
@@ -658,6 +667,7 @@ void k_mem_paging_backing_store_page_finalize(struct z_page_frame *pf,
  *   associated page frames, and any internal accounting set up appropriately.
  */
 void k_mem_paging_backing_store_init(void);
+#endif
 
 /** @} */
 

--- a/include/sys_clock.h
+++ b/include/sys_clock.h
@@ -115,10 +115,6 @@ typedef struct {
 
 /** @} */
 
-#ifdef CONFIG_TICKLESS_KERNEL
-extern void z_enable_sys_clock(void);
-#endif
-
 #if defined(CONFIG_SYS_CLOCK_EXISTS) && \
 	(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC == 0)
 #error "SYS_CLOCK_HW_CYCLES_PER_SEC must be non-zero!"

--- a/include/timing/timing.h
+++ b/include/timing/timing.h
@@ -10,6 +10,11 @@
 #include <sys/arch_interface.h>
 #include <timing/types.h>
 
+#ifdef CONFIG_TIMING_FUNCTIONS
+#if !defined(CONFIG_ARM) || \
+	(!defined(CONFIG_BOARD_HAS_TIMING_FUNCTIONS) && \
+	defined(CONFIG_TIMING_FUNCTIONS) && \
+	!defined(CONFIG_CORTEX_M_DWT))
 void soc_timing_init(void);
 void soc_timing_start(void);
 void soc_timing_stop(void);
@@ -31,6 +36,8 @@ uint64_t board_timing_freq_get(void);
 uint64_t board_timing_cycles_to_ns(uint64_t cycles);
 uint64_t board_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count);
 uint32_t board_timing_freq_get_mhz(void);
+#endif
+#endif
 
 
 /**

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -23,7 +23,9 @@ extern const struct init_entry __init_SMP_start[];
 extern const struct device __device_start[];
 extern const struct device __device_end[];
 
+#if 0
 extern uint32_t __device_init_status_start[];
+#endif
 
 /**
  * @brief Initialize state for all static devices.

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -576,6 +576,7 @@ static inline void arch_nop(void);
  * @{
  */
 
+#ifdef CONFIG_DEBUG_COREDUMP
 /**
  * @brief Architecture-specific handling during coredump
  *
@@ -589,6 +590,7 @@ void arch_coredump_info_dump(const z_arch_esf_t *esf);
  * @brief Get the target code specified by the architecture.
  */
 uint16_t arch_coredump_tgt_code_get(void);
+#endif
 
 /** @} */
 
@@ -598,6 +600,7 @@ uint16_t arch_coredump_tgt_code_get(void);
  * @{
  */
 
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
 /**
  * @brief Setup Architecture-specific TLS area in stack
  *
@@ -609,6 +612,7 @@ uint16_t arch_coredump_tgt_code_get(void);
  * @return Number of bytes taken by the TLS area
  */
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr);
+#endif
 
 /** @} */
 

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -141,7 +141,9 @@ extern void z_smp_init(void);
 extern void smp_timer_init(void);
 #endif
 
+#if defined(CONFIG_ENTROPY_HAS_DRIVER) || defined(CONFIG_TEST_RANDOM_GENERATOR)
 extern void z_early_boot_rand_get(uint8_t *buf, size_t length);
+#endif
 
 #if defined(CONFIG_STACK_POINTER_RANDOM) && (CONFIG_STACK_POINTER_RANDOM != 0)
 extern int z_stack_adjust_initialized;

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -38,7 +38,9 @@ BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO
 
 void z_sched_init(void);
 void z_move_thread_to_end_of_prio_q(struct k_thread *thread);
+#if 0
 int z_is_thread_time_slicing(struct k_thread *thread);
+#endif
 void z_unpend_thread_no_timeout(struct k_thread *thread);
 struct k_thread *z_unpend1_no_timeout(_wait_q_t *wait_q);
 int z_pend_curr(struct k_spinlock *lock, k_spinlock_key_t key,
@@ -57,7 +59,9 @@ void *z_get_next_switch_handle(void *interrupted);
 void idle(void *unused1, void *unused2, void *unused3);
 void z_time_slice(int ticks);
 void z_reset_time_slice(void);
+#if 0
 void z_sched_abort(struct k_thread *thread);
+#endif
 void z_sched_ipi(void);
 void z_sched_start(struct k_thread *thread);
 void z_ready_thread(struct k_thread *thread);

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -669,6 +669,7 @@ static inline const char *extract_conversion(struct conversion *conv,
 	return sp;
 }
 
+#ifdef CONFIG_CBPRINTF_FP_SUPPORT
 #ifdef CONFIG_64BIT
 
 static void _ldiv5(uint64_t *v)
@@ -761,6 +762,7 @@ static char _get_digit(uint64_t *fr, int *digit_count)
 
 	return rval;
 }
+#endif /* CONFIG_CBPRINTF_FP_SUPPORT */
 
 static inline unsigned int conversion_radix(char specifier)
 {


### PR DESCRIPTION
- add missing #if(def) around declarations whose definition is
  inside #if(def)

- excluded with IF_ENABLED some declarations whose definition is
  inside #ifdef

- add some #if 0 for declarations having no definitions (to be later removed
  if their presence is confirmed to be unwanted)

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>