### PR TITLE
logging: syst: embed log message source IDs in Sys-T messages

### DIFF
--- a/scripts/logging/dictionary/dictionary_parser/log_database.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_database.py
@@ -14,6 +14,7 @@ import json
 
 from .mipi_syst import gen_syst_xml_file
 from .utils import extract_one_string_in_section
+from .utils import find_string_in_mappings
 
 
 ARCHS = {
@@ -190,17 +191,7 @@ class LogDatabase():
         Find string pointed by string_ptr in the string mapping
         list. Return None if not found.
         """
-        if string_ptr in self.database['string_mappings']:
-            return self.database['string_mappings'][string_ptr]
-
-        # No direct match on pointer value.
-        # This may be a combined string. So check for that.
-        for ptr, string in self.database['string_mappings'].items():
-            if ptr <= string_ptr < (ptr + len(string)):
-                whole_str = self.database['string_mappings'][ptr]
-                return whole_str[string_ptr - ptr:]
-
-        return None
+        return find_string_in_mappings(self.database['string_mappings'], string_ptr)
 
 
     def __find_string_in_sections(self, string_ptr):

--- a/scripts/logging/dictionary/dictionary_parser/mipi_syst.py
+++ b/scripts/logging/dictionary/dictionary_parser/mipi_syst.py
@@ -18,7 +18,7 @@ XML_HEADER = """
     xsi:schemaLocation="http://www.mipi.org/1.0/sys-t
                         https://www.mipi.org/schema/sys-t/sys-t_1-0.xsd">
 
-  <syst:Client>
+  <syst:Client Name="Zephyr">
 """
 
 XML_FOOTER = """
@@ -59,7 +59,8 @@ XML_CATALOG64_FOOTER = """
 
 XML_GUIDS = """
     <syst:Guids>
-      <syst:Guid ID="{00000000-0000-0000-0000-000000000000}"><![CDATA[Zephyr]]></syst:Guid>
+      <syst:Guid   ID="{00000000-0000-0000-0000-000000000000}"
+                 Mask="{00000000-0000-0000-FF00-000000000000}"><![CDATA[Zephyr]]></syst:Guid>
     </syst:Guids>
 """
 

--- a/scripts/logging/dictionary/dictionary_parser/utils.py
+++ b/scripts/logging/dictionary/dictionary_parser/utils.py
@@ -41,3 +41,27 @@ def extract_one_string_in_section(section, str_ptr):
         offset += 1
 
     return ret_str
+
+
+def find_string_in_mappings(string_mappings, str_ptr):
+    """
+    Find string pointed by string_ptr in the string mapping
+    list. Return None if not found.
+    """
+    if string_mappings is None:
+        return None
+
+    if len(string_mappings) == 0:
+        return None
+
+    if str_ptr in string_mappings:
+        return string_mappings[str_ptr]
+
+    # No direct match on pointer value.
+    # This may be a combined string. So check for that.
+    for ptr, string in string_mappings.items():
+        if ptr <= str_ptr < (ptr + len(string)):
+            whole_str = string_mappings[ptr]
+            return whole_str[str_ptr - ptr:]
+
+    return None

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -21,15 +21,17 @@ config LOG_FUNC_NAME_PREFIX_DBG
 
 endmenu
 
-config LOG_MIPI_SYST_ENABLE
+menuconfig LOG_MIPI_SYST_ENABLE
 	bool "MIPI SyS-T format output"
 	select MIPI_SYST_LIB
 	help
 	  Enable MIPI SyS-T format output for the logger system.
 
+if LOG_MIPI_SYST_ENABLE
+
 config LOG_MIPI_SYST_USE_CATALOG
 	bool "Use MIPI Sys-T Catalog for logging"
-	depends on LOG2 && LOG_MIPI_SYST_ENABLE
+	depends on LOG2
 	select LOG2_FMT_SECTION
 	select LOG2_MSG_PKG_ALWAYS_ADD_RO_STRING_IDXS
 	help
@@ -43,6 +45,40 @@ config LOG_MIPI_SYST_CATALOG_ARGS_BUFFER_SIZE
 	  The size (in bytes) of the temporary buffer to store the expanded
 	  argument list needed for the MIPI Sys-T library for processing
 	  catalog messages.
+
+config LOG_MIPI_SYST_OUTPUT_LOG_MSG_SRC_ID
+	bool "Output Log Message Source ID as Module ID"
+	default y if LOG_MIPI_SYST_USE_CATALOG
+	help
+	  Enable this option to output the log message source ID
+	  as the Sys-T message module ID (as in origin unit in Sys-T
+	  message header).
+
+config LOG_MIPI_SYST_MSG_DEFAULT_MODULE_ID
+	int "Default module ID in Sys-T message"
+	range 0 127
+	default 127 if LOG_MIPI_SYST_OUTPUT_LOG_MSG_SRC_ID
+	default 0
+	help
+	  The default module ID embedded in the origin unit in
+	  Sys-T message header.
+
+	  If CONFIG_LOG_MIPI_SYST_OUTPUT_LOG_MSG_SRC_ID is disabled,
+	  this will be used for all Sys-T messages.
+
+	  If CONFIG_LOG_MIPI_SYST_OUTPUT_LOG_MSG_SRC_ID is enabled,
+	  this will be used for log messages without source IDs,
+	  for example, printk() if CONFIG_LOG_PRINTK is enabled.
+
+config LOG_MIPI_SYST_MSG_DEFAULT_UNIT_ID
+	int "Default unit ID in Sys-T message"
+	range 0 15
+	default 0
+	help
+	  The default unit ID embedded in the origin unit in
+	  Sys-T message header.
+
+endif # LOG_MIPI_SYST_ENABLE
 
 config LOG_DICTIONARY_SUPPORT
 	bool

--- a/subsys/logging/log_output.c
+++ b/subsys/logging/log_output.c
@@ -63,11 +63,13 @@ extern void log_output_msg2_syst_process(const struct log_output *output,
 				struct log_msg2 *msg, uint32_t flag);
 extern void log_output_string_syst_process(const struct log_output *output,
 				struct log_msg_ids src_level,
-				const char *fmt, va_list ap, uint32_t flag);
+				const char *fmt, va_list ap, uint32_t flag,
+				int16_t source_id);
 extern void log_output_hexdump_syst_process(const struct log_output *output,
 				struct log_msg_ids src_level,
 				const char *metadata,
-				const uint8_t *data, uint32_t length, uint32_t flag);
+				const uint8_t *data, uint32_t length,
+				uint32_t flag, int16_t source_id);
 
 /* The RFC 5424 allows very flexible mapping and suggest the value 0 being the
  * highest severity and 7 to be the lowest (debugging level) severity.
@@ -731,8 +733,8 @@ void log_output_string(const struct log_output *output,
 
 	if (IS_ENABLED(CONFIG_LOG_MIPI_SYST_ENABLE) &&
 	    flags & LOG_OUTPUT_FLAG_FORMAT_SYST) {
-		log_output_string_syst_process(output,
-				src_level, fmt, ap, flags);
+		log_output_string_syst_process(output, src_level, fmt, ap,
+					       flags, source_id);
 		return;
 	}
 
@@ -769,9 +771,9 @@ void log_output_hexdump(const struct log_output *output,
 
 	if (IS_ENABLED(CONFIG_LOG_MIPI_SYST_ENABLE) &&
 	    flags & LOG_OUTPUT_FLAG_FORMAT_SYST) {
-		log_output_hexdump_syst_process(output,
-				src_level, metadata,
-				data, length, flags);
+		log_output_hexdump_syst_process(output, src_level, metadata,
+						data, length, flags,
+						source_id);
 		return;
 	}
 


### PR DESCRIPTION
This embeds the log message source IDs inside the origin unit
as module IDs in Sys-T messages. This allows Sys-T message
parsers to see where the log messages are coming from.

This is enabled by default if using Sys-T catalog messages as
the collateral XML file contains the information to interpret
the module ID.