### PR TITLE
x86: qemu: add a newline after "Booting from ROM.."

### DIFF
--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -52,6 +52,18 @@ if (IS_ENABLED(CONFIG_MULTIBOOT_INFO) &&
 
 #ifdef CONFIG_X86_VERY_EARLY_CONSOLE
 	z_x86_early_serial_init();
+
+#if defined(CONFIG_BOARD_QEMU_X86) || defined(CONFIG_BOARD_QEMU_X86_64)
+	/*
+	 * Under QEMU and SeaBIOS, everything gets to be printed
+	 * immediately after "Booting from ROM.." as there is no newline.
+	 * This prevents parsing QEMU console output for the very first
+	 * line where it needs to match from the beginning of the line.
+	 * So add a dummy newline here so the next output is at
+	 * the beginning of a line.
+	 */
+	arch_printk_char_out('\n');
+#endif
 #endif
 
 #if CONFIG_X86_STACK_PROTECTION


### PR DESCRIPTION
Under QEMU and SeaBIOS, everything gets to be printed
immediately after "Booting from ROM.." as there is no newline.
This prevents parsing QEMU console output for the very first
line where it needs to match from the beginning of the line.
So add a dummy newline here so the next output is at
the beginning of a line.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>