### PR TITLE
Bluetooth: Controller: Fix null pointer dereference

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -6247,7 +6247,7 @@ static void le_ext_adv_report(struct pdu_data *pdu_data,
 			ptr += sizeof(*adi);
 
 			BT_DBG("    AdvDataInfo DID = 0x%x, SID = 0x%x",
-			       adi->did, adi->sid);
+			       adi_curr->did, adi_curr->sid);
 		}
 
 		if (h->aux_ptr) {


### PR DESCRIPTION
Fix null pointer dereference in Controller when receiving an extended
advertisement and CONFIG_BT_LOG_LEVEL_DBG is enabled.

Signed-off-by: Pieterjan Camerlynck <pieterjan.camerlynck@gmail.com>