### PR TITLE
Bluetooth: Controller: df: Fix missing disable CTE req LLCP after compl

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -216,6 +216,13 @@ static void lp_comm_complete_cte_req_finalize(struct ll_conn *conn)
 
 	conn->llcp.cte_req.is_active = 0U;
 
+	/* Disable the CTE request procedure when it is completed in case it was executed as
+	 * non-periodic.
+	 */
+	if (conn->llcp.cte_req.req_interval == 0U) {
+		conn->llcp.cte_req.is_enabled = 0U;
+	}
+
 	/* If disable_cb is not NULL then there is waiting CTE REQ disable request
 	 * from host. Execute the callback to notify waiting thread that the
 	 * procedure is inactive.


### PR DESCRIPTION
The CTE request procedure can be run in periodic and non-periodic mode.
In periodic mode it stays enabled until Host call HCI_LE_Connection_CTE-
_Request_Enable(Enable=0x0).
In non-periodic mode the command is disabled after completion,
LL_CTE_RSP is successfully received.

There is missing disable of the procedure in the current code,
so Host is not able to run the command HCI_LE_Connection_CTE_Request_-
Enable(Enable=0x1) again without explicit call to HCI_LE_Connection_-
CTE_Request_Enable(Enable=0x0).

The commit adds missing code responsible for disable of the procedure.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>