### PR TITLE
soc: arm: stm32 adjust wdt task fallback due to LSI oscillator characteristics

### DIFF
--- a/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f0/Kconfig.defconfig.series
@@ -15,4 +15,9 @@ config SOC_SERIES
 config SRAM_VECTOR_TABLE
 	default y
 
+# adjust the fallback because of the LSI oscaillator characteristics
+config TASK_WDT_HW_FALLBACK_DELAY
+	depends on TASK_WDT_HW_FALLBACK
+	default 100
+
 endif # SOC_SERIES_STM32F0X

--- a/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f1/Kconfig.defconfig.series
@@ -12,4 +12,9 @@ source "soc/arm/st_stm32/stm32f1/Kconfig.defconfig.stm32f1*"
 config SOC_SERIES
 	default "stm32f1"
 
+# adjust the fallback because of the LSI oscaillator characteristics
+config TASK_WDT_HW_FALLBACK_DELAY
+	depends on TASK_WDT_HW_FALLBACK
+	default 200
+
 endif # SOC_SERIES_STM32F1X

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.series
@@ -12,4 +12,9 @@ source "soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f4*"
 config SOC_SERIES
 	default "stm32f4"
 
+# adjust the fallback because of the LSI oscaillator characteristics
+config TASK_WDT_HW_FALLBACK_DELAY
+	depends on TASK_WDT_HW_FALLBACK
+	default 200
+
 endif # SOC_SERIES_STM32F4X

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -15,4 +15,9 @@ config SOC_SERIES
 config STM32_LPTIM_TIMER
 	default y if PM
 
+# adjust the fallback because of the LSI oscaillator characteristics
+config TASK_WDT_HW_FALLBACK_DELAY
+	depends on TASK_WDT_HW_FALLBACK
+	default 200
+
 endif # SOC_SERIES_STM32L0X

--- a/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l1/Kconfig.defconfig.series
@@ -10,4 +10,9 @@ source "soc/arm/st_stm32/stm32l1/Kconfig.defconfig.stm32l1*"
 config SOC_SERIES
 	default "stm32l1"
 
+# adjust the fallback because of the LSI oscaillator characteristics
+config TASK_WDT_HW_FALLBACK_DELAY
+	depends on TASK_WDT_HW_FALLBACK
+	default 200
+
 endif # SOC_SERIES_STM32L1X


### PR DESCRIPTION
Due to a wide range of variation in the LSI RC oscillator
characteristics given by the datasheet of the soc,
It is necessary to add a delay for hardware watchdog.
This is done by the CONFIG_TASK_WDT_HW_FALLBACK_DELAY

The TASK_WDT_MIN_TIMEOUT is 1..10000 (in ms) for the stm32 mcus where the LSI clock varies in a large range from typical to max, the CONFIG_TASK_WDT_HW_FALLBACK_DELAY can be given by :

upper value of TASK_WDT_MIN_TIMEOUT * LSI_CLOCK typical freq / USEC_PER_SEC - upper value of TASK_WDT_MIN_TIMEOUT * LSI_CLOCK max freq / USEC_PER_SEC

Depending on and only for the following soc:
stm32F0x : CONFIG_TASK_WDT_HW_FALLBACK_DELAY=100
stm32F1x : CONFIG_TASK_WDT_HW_FALLBACK_DELAY=200
stm32F4x : CONFIG_TASK_WDT_HW_FALLBACK_DELAY=200
stm32L0x : CONFIG_TASK_WDT_HW_FALLBACK_DELAY=200
stm32L1x : CONFIG_TASK_WDT_HW_FALLBACK_DELAY=200


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/43024

Signed-off-by: Francois Ramu <francois.ramu@st.com>