### PR TITLE
add more stm32 boards to pass Test wdt 

### DIFF
--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -166,6 +166,10 @@
 	status = "okay";
 };
 
+&iwdg {
+	status = "okay";
+};
+
 &subghzspi {
 	status = "okay";
 	lora: radio@0 {

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
@@ -19,3 +19,4 @@ supported:
   - dac
   - pwm
   - dma
+  - watchdog

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nucleo_f429zi.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nucleo_f429zi.overlay
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&wwdg {
+	status = "okay";
+};
+
+&iwdg {
+	status = "disabled";
+};


### PR DESCRIPTION
This PR complete the testcases to be executed on the stm32 boards

- enable the IDWG on the stm32wl55 
- test on the nucleo_f429zi

It completes the https://github.com/zephyrproject-rtos/zephyr/pull/44682

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)