### PR TITLE
Bluetooth: Host: change adv_new_legacy to adv_get_legacy and return the adv instance if it already isnt NULL.

### DIFF
--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -269,11 +269,11 @@ void bt_le_ext_adv_foreach(void (*func)(struct bt_le_ext_adv *adv, void *data),
 #endif /* defined(CONFIG_BT_EXT_ADV) */
 }
 
-static struct bt_le_ext_adv *adv_new_legacy(void)
+static struct bt_le_ext_adv *adv_get_legacy(void)
 {
 #if defined(CONFIG_BT_EXT_ADV)
 	if (bt_dev.adv) {
-		return NULL;
+		return bt_dev.adv;
 	}
 
 	bt_dev.adv = adv_new();
@@ -1336,7 +1336,7 @@ int bt_le_adv_start(const struct bt_le_adv_param *param,
 		    const struct bt_data *ad, size_t ad_len,
 		    const struct bt_data *sd, size_t sd_len)
 {
-	struct bt_le_ext_adv *adv = adv_new_legacy();
+	struct bt_le_ext_adv *adv = adv_get_legacy();
 	int err;
 
 	if (!adv) {


### PR DESCRIPTION
if the device is advertising, and one starts the advertiser again the returned error code is -EALREADY.
if CONFIG_BT_EXT_ADV is enabled, the function behaves differently and suddenly returns another error code in the same situation(-ENOMEM).
this is a little bit confusing and therefore the -ENOMEM should be changed to -EALREADY, so that the error codes match.