### PR TITLE
drivers: can: add missing can_get_max_filters() syscall handler

### DIFF
--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -15,7 +15,7 @@ config CAN_MAX_FILTER
 	depends on CAN_MCUX_FLEXCAN
 	default 5
 	range 1 15 if SOC_SERIES_KINETIS_KE1XF || SOC_SERIES_KINETIS_K6X
-	range 1 64 if SOC_SERIES_IMX_RT
+	range 1 63 if SOC_SERIES_IMX_RT
 	help
 	  Defines maximum number of concurrent active RX filters
 

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -115,6 +115,15 @@ static inline const struct can_timing *z_vrfy_can_get_timing_max_data(const stru
 
 #endif /* CONFIG_CAN_FD_MODE */
 
+static inline int z_vrfy_can_get_max_filters(const struct device *dev, enum can_ide id_type)
+{
+	/* Optional API function */
+	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
+
+	return z_impl_can_get_max_filters(dev, id_type);
+}
+#include <syscalls/can_get_max_filters_mrsh.c>
+
 static inline int z_vrfy_can_set_mode(const struct device *dev, enum can_mode mode)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_mode));

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -865,7 +865,7 @@ int can_mcan_add_rx_filter_std(struct can_mcan_data *data,
 	filter_id = can_mcan_get_free_std(msg_ram->std_filt);
 
 	if (filter_id == -ENOSPC) {
-		LOG_INF("No free standard id filter left");
+		LOG_WRN("No free standard id filter left");
 		return -ENOSPC;
 	}
 
@@ -927,7 +927,7 @@ static int can_mcan_add_rx_filter_ext(struct can_mcan_data *data,
 	filter_id = can_mcan_get_free_ext(msg_ram->ext_filt);
 
 	if (filter_id == -ENOSPC) {
-		LOG_INF("No free extended id filter left");
+		LOG_WRN("No free extended id filter left");
 		return -ENOSPC;
 	}
 
@@ -979,11 +979,9 @@ int can_mcan_add_rx_filter(struct can_mcan_data *data,
 	} else {
 		filter_id = can_mcan_add_rx_filter_ext(data, msg_ram, callback,
 						       user_data, filter);
-		filter_id += NUM_STD_FILTER_DATA;
-	}
-
-	if (filter_id == -ENOSPC) {
-		LOG_INF("No free filter left");
+		if (filter_id >= 0) {
+			filter_id += NUM_STD_FILTER_DATA;
+		}
 	}
 
 	return filter_id;
@@ -995,7 +993,7 @@ void can_mcan_remove_rx_filter(struct can_mcan_data *data,
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	if (filter_id >= NUM_STD_FILTER_DATA) {
 		filter_id -= NUM_STD_FILTER_DATA;
-		if (filter_id >= NUM_STD_FILTER_DATA) {
+		if (filter_id >= NUM_EXT_FILTER_DATA) {
 			LOG_ERR("Wrong filter id");
 			return;
 		}

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -51,7 +51,7 @@ LOG_MODULE_REGISTER(can_mcux_flexcan, CONFIG_CAN_LOG_LEVEL);
  * RX message buffers (filters) will take up the first N message
  * buffers. The rest are available for TX use.
  */
-#define MCUX_FLEXCAN_MAX_RX CONFIG_CAN_MAX_FILTER
+#define MCUX_FLEXCAN_MAX_RX (CONFIG_CAN_MAX_FILTER + RX_START_IDX)
 #define MCUX_FLEXCAN_MAX_TX \
 	(FSL_FEATURE_FLEXCAN_HAS_MESSAGE_BUFFER_MAX_NUMBERn(0) \
 	- MCUX_FLEXCAN_MAX_RX)

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -460,13 +460,6 @@ static int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-static int can_stm32_get_max_filters(const struct device *dev, enum can_ide id_type)
-{
-	ARG_UNUSED(id_type);
-
-	return CONFIG_CAN_MAX_FILTER;
-}
-
 static int can_stm32_get_max_bitrate(const struct device *dev, uint32_t *max_bitrate)
 {
 	const struct can_stm32_config *config = dev->config;
@@ -1156,7 +1149,6 @@ static const struct can_driver_api can_api_funcs = {
 #endif
 	.set_state_change_callback = can_stm32_set_state_change_callback,
 	.get_core_clock = can_stm32_get_core_clock,
-	.get_max_filters = can_stm32_get_max_filters,
 	.get_max_bitrate = can_stm32_get_max_bitrate,
 	.timing_min = {
 		.sjw = 0x1,

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -184,18 +184,20 @@ CO_ReturnError_t CO_CANmodule_init(CO_CANmodule_t *CANmodule,
 	}
 
 	max_filters = can_get_max_filters(ctx->dev, CAN_STANDARD_IDENTIFIER);
-	if (max_filters < 0) {
-		LOG_ERR("unable to determine number of CAN RX filters");
-		return CO_ERROR_SYSCALL;
-	}
+	if (max_filters != -ENOSYS) {
+		if (max_filters < 0) {
+			LOG_ERR("unable to determine number of CAN RX filters");
+			return CO_ERROR_SYSCALL;
+		}
 
-	if (rxSize > max_filters) {
-		LOG_ERR("insufficient number of concurrent CAN RX filters"
-			" (needs %d, %d available)", rxSize, max_filters);
-		return CO_ERROR_OUT_OF_MEMORY;
-	} else if (rxSize < max_filters) {
-		LOG_DBG("excessive number of concurrent CAN RX filters enabled"
-			" (needs %d, %d available)", rxSize, max_filters);
+		if (rxSize > max_filters) {
+			LOG_ERR("insufficient number of concurrent CAN RX filters"
+				" (needs %d, %d available)", rxSize, max_filters);
+			return CO_ERROR_OUT_OF_MEMORY;
+		} else if (rxSize < max_filters) {
+			LOG_DBG("excessive number of concurrent CAN RX filters enabled"
+				" (needs %d, %d available)", rxSize, max_filters);
+		}
 	}
 
 	canopen_detach_all_rx_filters(CANmodule);

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -688,6 +688,69 @@ static void test_add_filter(void)
 }
 
 /**
+ * @brief Test adding up to and above the maximum number of RX filters.
+ *
+ * @param id_type CAN frame identifier type
+ * @param id_mask filter
+ */
+static void add_remove_max_filters(enum can_ide id_type)
+{
+	uint32_t id_mask = id_type == CAN_STANDARD_IDENTIFIER ? CAN_STD_ID_MASK : CAN_EXT_ID_MASK;
+	struct zcan_filter filter = {
+		.id_type = id_type,
+		.rtr = CAN_DATAFRAME,
+		.id = 0,
+		.rtr_mask = 1,
+		.id_mask = id_mask,
+	};
+	int filter_id;
+	int max;
+	int i;
+
+	max = can_get_max_filters(can_dev, id_type);
+	if (max == -ENOSYS || max == 0) {
+		/*
+		 * Skip test if max is not known or no filters of the given type
+		 * is supported.
+		 */
+		ztest_test_skip();
+	}
+
+	zassert_true(max > 0, "failed to get max filters (err %d)", max);
+
+	int filter_ids[max];
+
+	for (i = 0; i < max; i++) {
+		filter.id++;
+		filter_ids[i] = add_rx_msgq(can_dev, &filter);
+	}
+
+	filter.id++;
+	filter_id = can_add_rx_filter_msgq(can_dev, &can_msgq, &filter);
+	zassert_equal(filter_id, -ENOSPC, "added more than max filters");
+
+	for (i = 0; i < max; i++) {
+		can_remove_rx_filter(can_dev, filter_ids[i]);
+	}
+}
+
+/**
+ * @brief Test max standard (11-bit) CAN RX filters.
+ */
+static void test_max_std_filters(void)
+{
+	add_remove_max_filters(CAN_STANDARD_IDENTIFIER);
+}
+
+/**
+ * @brief Test max extended (29-bit) CAN RX filters.
+ */
+static void test_max_ext_filters(void)
+{
+	add_remove_max_filters(CAN_EXTENDED_IDENTIFIER);
+}
+
+/**
  * @brief Test that no message is received when nothing was sent.
  */
 static void test_receive_timeout(void)
@@ -876,6 +939,8 @@ void test_main(void)
 			 ztest_user_unit_test(test_set_loopback),
 			 ztest_user_unit_test(test_send_and_forget),
 			 ztest_unit_test(test_add_filter),
+			 ztest_user_unit_test(test_max_std_filters),
+			 ztest_user_unit_test(test_max_ext_filters),
 			 ztest_user_unit_test(test_receive_timeout),
 			 ztest_unit_test(test_send_callback),
 			 ztest_unit_test(test_send_receive_std_id),


### PR DESCRIPTION
- Add missing syscall verification handler for `can_get_max_filters()` (fixes #44687).
- Add test for the `can_get_max_filters()` optional API function.

Implementing this test revealed a few issues, which are also fixed by this PR in order for the added test to pass:
- CANopenNode needs not depend on the optional `can_get_max_filters()` API function.
- #44721
- #44724

Implementing the test for the `can_get_max_filters()` syscall also revealed an issue in the STM32 bxCAN driver, which is not addressed by this PR (except for removing support for `can_get_max_filters()` from that driver for now). I have opened #44725 for dealing with that. 
