### PR TITLE
tests/subsys/mgmt/mcumgr: Add unit tests for zcbor_bulk

### DIFF
--- a/tests/subsys/mgmt/zcbor_bulk/CMakeLists.txt
+++ b/tests/subsys/mgmt/zcbor_bulk/CMakeLists.txt
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(zcbor_bulk)
+
+FILE(GLOB app_sources
+	src/*.c
+	${ZEPHYR_BASE}/subsys/mgmt/mcumgr/lib/util/src/zcbor_bulk.c
+)
+zephyr_include_directories(
+	${ZEPHYR_BASE}/subsys/mgmt/mcumgr/lib/util/include/
+)
+
+target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/mgmt/zcbor_bulk/prj.conf
+++ b/tests/subsys/mgmt/zcbor_bulk/prj.conf
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+CONFIG_ZTEST=y
+CONFIG_ZCBOR=y

--- a/tests/subsys/mgmt/zcbor_bulk/src/main.c
+++ b/tests/subsys/mgmt/zcbor_bulk/src/main.c
@@ -1,0 +1,305 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ztest.h>
+#include <sys/byteorder.h>
+#include <zcbor_common.h>
+#include <zcbor_decode.h>
+#include <zcbor_encode.h>
+#include <zcbor_bulk/zcbor_bulk_priv.h>
+
+#define zcbor_true_put(zse) zcbor_bool_put(zse, true)
+
+void test_correct(void)
+{
+	uint8_t buffer[512];
+	struct zcbor_string world;
+	uint32_t one = 0;
+	bool bool_val = false;
+	zcbor_state_t zsd[4] = { 0 };
+	size_t decoded = 0;
+	bool ok;
+	struct zcbor_map_decode_key_val dm[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+	};
+
+	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
+
+	/* { "hello":"world", "one":1, "bool_val":true } */
+	ok = zcbor_map_start_encode(zsd, 10) &&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
+	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
+	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_map_end_encode(zsd, 10);
+
+	zassert_true(ok, "Expected to be successful in encoding test pattern");
+
+	zassert_true(zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1),
+		"Failed to init");
+
+	int rc = zcbor_map_decode_bulk(zsd, dm, ARRAY_SIZE(dm), &decoded);
+
+	zassert_ok(rc, "Expected 0, got %d", rc);
+	zassert_equal(decoded, ARRAY_SIZE(dm), "Expected %d got %d",
+		ARRAY_SIZE(dm), decoded);
+	zassert_equal(one, 1, "Expected 1");
+	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
+		sizeof("world") - 1);
+	zassert_equal(0, memcmp(world.value, "world", world.len),
+		"Expected \"world\", got %.*s", world.len, world.value);
+	zassert_true(bool_val, "Expected bool_val == true");
+}
+
+void test_correct_out_of_order(void)
+{
+	uint8_t buffer[512];
+	struct zcbor_string world;
+	uint32_t one = 0;
+	bool bool_val = false;
+	zcbor_state_t zsd[4] = { 0 };
+	size_t decoded = 0;
+	bool ok;
+	struct zcbor_map_decode_key_val dm[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+	};
+
+	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
+
+	/* { "hello":"world", "one":1, "bool_val":true } */
+	ok = zcbor_map_start_encode(zsd, 10) &&
+	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
+	     zcbor_map_end_encode(zsd, 10);
+
+	zassert_true(ok, "Expected to be successful in encoding test pattern");
+
+	zassert_true(zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1),
+		"Failed to init");
+
+	int rc = zcbor_map_decode_bulk(zsd, dm, ARRAY_SIZE(dm), &decoded);
+
+	zassert_ok(rc, "Expected 0, got %d", rc);
+	zassert_equal(decoded, ARRAY_SIZE(dm), "Expected %d got %d",
+		ARRAY_SIZE(dm), decoded);
+	zassert_equal(one, 1, "Expected 1");
+	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
+		sizeof("world") - 1);
+	zassert_equal(0, memcmp(world.value, "world", world.len),
+		"Expected \"world\", got %.*s", world.len, world.value);
+	zassert_true(bool_val, "Expected bool_val == true");
+}
+
+void test_not_map(void)
+{
+	uint8_t buffer[512];
+	struct zcbor_string world;
+	uint32_t one = 0;
+	bool bool_val = false;
+	zcbor_state_t zsd[4] = { 0 };
+	size_t decoded = 1111;
+	bool ok;
+	struct zcbor_map_decode_key_val dm[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+	};
+
+	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
+
+	/* List "hello", "world" */
+	ok = zcbor_list_start_encode(zsd, 10) &&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
+	     zcbor_list_end_encode(zsd, 10);
+
+	zassert_true(ok, "Expected to be successful in encoding test pattern");
+
+	zassert_true(zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1),
+		"Failed to init");
+
+	int rc = zcbor_map_decode_bulk(zsd, dm, ARRAY_SIZE(dm), &decoded);
+
+	zassert_equal(rc, -EBADMSG, "Expected -EBADMSG(%d), got %d", -EBADMSG, rc);
+	zassert_equal(decoded, 1111, "Expected decoded value to be unmodified");
+}
+
+void test_bad_type(void)
+{
+	uint8_t buffer[512];
+	struct zcbor_string world = { 0 };
+	uint32_t one = 0;
+	bool bool_val = false;
+	zcbor_state_t zsd[4] = { 0 };
+	size_t decoded = 0;
+	bool ok;
+	struct zcbor_map_decode_key_val dm[] = {
+		/* First entry has bad decoder given instead of tstr */
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_uint32_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+	};
+
+	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
+
+	/* { "hello":"world", "one":1, "bool_val":true } */
+	ok = zcbor_map_start_encode(zsd, 10) &&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
+	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
+	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_map_end_encode(zsd, 10);
+
+	zassert_true(ok, "Expected to be successful in encoding test pattern");
+
+	zassert_true(zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1),
+		"Failed to init");
+
+	int rc = zcbor_map_decode_bulk(zsd, dm, ARRAY_SIZE(dm), &decoded);
+
+	zassert_equal(rc, -ENOMSG, "Expected -ENOMSG, got %d", rc);
+	zassert_equal(decoded, 0, "Expected 0 got %d", decoded);
+	zassert_equal(one, 0, "Expected 0");
+	zassert_equal(0, world.len, "Expected to be unmodified");
+	zassert_false(bool_val, "Expected bool_val == false");
+}
+
+void test_bad_type_2(void)
+{
+	uint8_t buffer[512];
+	struct zcbor_string world = { 0 };
+	uint32_t one = 0;
+	bool bool_val = false;
+	zcbor_state_t zsd[4] = { 0 };
+	size_t decoded = 0;
+	bool ok;
+	struct zcbor_map_decode_key_val dm[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		/* This is bad decoder for type bool */
+		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_tstr_decode, &bool_val)
+	};
+
+	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
+
+	/* { "hello":"world", "one":1, "bool_val":true } */
+	ok = zcbor_map_start_encode(zsd, 10) &&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
+	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
+	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_map_end_encode(zsd, 10);
+
+	zassert_true(zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1),
+		"Failed to init");
+
+	int rc = zcbor_map_decode_bulk(zsd, dm, ARRAY_SIZE(dm), &decoded);
+
+	zassert_equal(rc, -ENOMSG, "Expected -ENOMSG, got %d", rc);
+	zassert_equal(decoded, ARRAY_SIZE(dm) - 1, "Expected %d got %d",
+		ARRAY_SIZE(dm) - 1, decoded);
+	zassert_equal(one, 1, "Expected 1");
+	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
+		sizeof("world") - 1);
+	zassert_equal(0, memcmp(world.value, "world", world.len),
+		"Expected \"world\", got %.*s", world.len, world.value);
+	zassert_false(bool_val, "Expected bool_val unmodified");
+}
+
+void test_bad_type_encoded(void)
+{
+	uint8_t buffer[512];
+	struct zcbor_string world = { 0 };
+	uint32_t one = 0;
+	bool bool_val = false;
+	zcbor_state_t zsd[4] = { 0 };
+	size_t decoded = 0;
+	bool ok;
+	struct zcbor_map_decode_key_val dm[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+	};
+
+	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
+
+	/* { "hello":"world", "one":1, "bool_val":true } */
+	ok = zcbor_map_start_encode(zsd, 10) &&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_uint32_put(zsd, 10)		&&
+	     zcbor_tstr_put_lit(zsd, "one") && zcbor_uint32_put(zsd, 1)			&&
+	     zcbor_tstr_put_lit(zsd, "bool_val") && zcbor_true_put(zsd)			&&
+	     zcbor_map_end_encode(zsd, 10);
+
+	zassert_true(ok, "Expected to be successful in encoding test pattern");
+
+	zassert_true(zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1),
+		"Failed to init");
+
+	int rc = zcbor_map_decode_bulk(zsd, dm, ARRAY_SIZE(dm), &decoded);
+
+	zassert_equal(rc, -ENOMSG, "Expected -ENOMSG, got %d", rc);
+	zassert_equal(decoded, 0, "Expected 0 got %d", decoded);
+	zassert_equal(one, 0, "Expected 0");
+	zassert_equal(0, world.len, "Expected to be unmodified");
+	zassert_false(bool_val, "Expected bool_val == false");
+}
+
+void test_duplicate(void)
+{
+	/* Duplicate key is error and should never happen */
+	uint8_t buffer[512];
+	struct zcbor_string world = { 0 };
+	uint32_t one = 0;
+	bool bool_val = false;
+	zcbor_state_t zsd[4] = { 0 };
+	size_t decoded = 0;
+	bool ok;
+	struct zcbor_map_decode_key_val dm[] = {
+		ZCBOR_MAP_DECODE_KEY_VAL(hello, zcbor_tstr_decode, &world),
+		ZCBOR_MAP_DECODE_KEY_VAL(one, zcbor_uint32_decode, &one),
+		ZCBOR_MAP_DECODE_KEY_VAL(bool_val, zcbor_bool_decode, &bool_val)
+	};
+
+	zcbor_new_encode_state(zsd, 2, buffer, ARRAY_SIZE(buffer), 0);
+
+	/* { "hello":"world", "hello":"world" } */
+	ok = zcbor_map_start_encode(zsd, 10) &&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
+	     zcbor_tstr_put_lit(zsd, "hello") && zcbor_tstr_put_lit(zsd, "world")	&&
+	     zcbor_map_end_encode(zsd, 10);
+
+	zassert_true(zcbor_new_decode_state(zsd, 4, buffer, ARRAY_SIZE(buffer), 1),
+		"Failed to init");
+
+	int rc = zcbor_map_decode_bulk(zsd, dm, ARRAY_SIZE(dm), &decoded);
+
+	zassert_equal(rc, -EADDRINUSE, "Expected -EADDRINUSE, got %d", rc);
+	zassert_equal(decoded, 1, "Expected %d got %d",
+		ARRAY_SIZE(dm) - 1, decoded);
+	zassert_equal(one, 0, "Expected unmodified");
+	zassert_equal(sizeof("world") - 1, world.len, "Expected length %d",
+		sizeof("world") - 1);
+	zassert_equal(0, memcmp(world.value, "world", world.len),
+		"Expected \"world\", got %.*s", world.len, world.value);
+	zassert_false(bool_val, "Expected bool_val unmodified");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(
+		zcbor_bulk,
+		ztest_unit_test(test_correct),
+		ztest_unit_test(test_correct_out_of_order),
+		ztest_unit_test(test_not_map),
+		ztest_unit_test(test_bad_type),
+		ztest_unit_test(test_bad_type_2),
+		ztest_unit_test(test_bad_type_encoded),
+		ztest_unit_test(test_duplicate)
+		);
+
+	ztest_run_test_suite(zcbor_bulk);
+}

--- a/tests/subsys/mgmt/zcbor_bulk/testcase.yaml
+++ b/tests/subsys/mgmt/zcbor_bulk/testcase.yaml
@@ -1,0 +1,9 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+tests:
+  zcbor.bulk:
+    platform_allow: native_posix
+    tags: zcbor_bulk


### PR DESCRIPTION
The commit adds unit tests for zcbor_bulk utility function,
which has been provided to internally support zcbor in decoding
maps with command parameters.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>