### PR TITLE
tests/mgmt/mcumgr/smp_reassembly: Remove dependency on TINYCBOR

### DIFF
--- a/tests/subsys/mgmt/smp_reassembly/prj.conf
+++ b/tests/subsys/mgmt/smp_reassembly/prj.conf
@@ -4,7 +4,5 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 CONFIG_ZTEST=y
-# THis is annoying
-CONFIG_TINYCBOR=y
 CONFIG_MCUMGR=y
 CONFIG_MCUMGR_BUF_COUNT=1


### PR DESCRIPTION
Removed dependency from prj.conf.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>