### PR TITLE
Bluetooth: Controller: df: Fix wrong value of event counter in iq report

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2869,7 +2869,7 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 		 * node rx footer field.
 		 */
 		sync_handle = ull_sync_handle_get(sync);
-		per_evt_counter = lll->event_counter;
+		per_evt_counter = iq_report->event_counter;
 	}
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
 
@@ -3015,7 +3015,7 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 	sep->cte_type = iq_report->cte_info.type;
 
 	sep->data_chan_idx = iq_report->chan_idx;
-	sep->conn_evt_counter = sys_cpu_to_le16(lll->event_counter);
+	sep->conn_evt_counter = sys_cpu_to_le16(iq_report->event_counter);
 
 	if (sep->cte_type == BT_HCI_LE_AOA_CTE) {
 		sep->slot_durations = iq_report->local_slot_durations;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -1056,6 +1056,7 @@ static inline bool create_iq_report(struct lll_conn *lll, uint8_t rssi_ready, ui
 		iq_report->rssi_ant_id = ant;
 		iq_report->cte_info = *(struct pdu_cte_info *)&cte_info;
 		iq_report->local_slot_durations = rx_params->slot_durations;
+		iq_report->event_counter = lll->event_counter;
 
 		ftr = &iq_report->hdr.rx_ftr;
 		ftr->param = lll;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -1056,7 +1056,10 @@ static inline bool create_iq_report(struct lll_conn *lll, uint8_t rssi_ready, ui
 		iq_report->rssi_ant_id = ant;
 		iq_report->cte_info = *(struct pdu_cte_info *)&cte_info;
 		iq_report->local_slot_durations = rx_params->slot_durations;
-		iq_report->event_counter = lll->event_counter;
+		/* Event counter is updated to next value during event preparation, hence
+		 * it has to be subtracted to store actual event counter value.
+		 */
+		iq_report->event_counter = lll->event_counter - 1;
 
 		ftr = &iq_report->hdr.rx_ftr;
 		ftr->param = lll;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -97,6 +97,7 @@ struct node_rx_iq_report {
 	uint8_t packet_status;
 	uint8_t rssi_ant_id;
 	uint8_t chan_idx;
+	uint16_t event_counter;
 	union {
 		uint8_t pdu[0] __aligned(4);
 		struct iq_sample sample[0];

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -1062,6 +1062,7 @@ static inline int create_iq_report(struct lll_sync *lll, uint8_t rssi_ready,
 			iq_report->rssi_ant_id = ant;
 			iq_report->cte_info = *(struct pdu_cte_info *)&cte_info;
 			iq_report->local_slot_durations = cfg->slot_durations;
+			iq_report->event_counter = lll->event_counter;
 
 			ftr = &iq_report->hdr.rx_ftr;
 			ftr->param = lll;

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -1062,7 +1062,10 @@ static inline int create_iq_report(struct lll_sync *lll, uint8_t rssi_ready,
 			iq_report->rssi_ant_id = ant;
 			iq_report->cte_info = *(struct pdu_cte_info *)&cte_info;
 			iq_report->local_slot_durations = cfg->slot_durations;
-			iq_report->event_counter = lll->event_counter;
+			/* Event counter is updated to next value during event preparation, hence
+			 * it has to be subtracted to store actual event counter value.
+			 */
+			iq_report->event_counter = lll->event_counter - 1;
 
 			ftr = &iq_report->hdr.rx_ftr;
 			ftr->param = lll;


### PR DESCRIPTION
HCI_LE_Connectionless_IQ_Report and HCI_LE_Connection_IQ_Report
events has fields that store event counter values: Periodic_Event_-
Counter and Event_Counter, respectively.
Values assigned to this HCI events are taken directly from
lower link layer objects. In case of too slow processing of
HCI events values provided by LLL contexts could be changed before
HCI sends events to Host. That can happen e.g. in case of short
periodic advertising interval and slow UART baudrate.
In such situation event counter values will be corrupted.

To prevent that situation, event counter values connected with
IQ sample reports, has to be stored in node_rx_iq_report when
a report instance is filled in LLL.

This commit introduces required changes.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>