### PR TITLE
mgmt: mcumgr: lib: Fix non-visible struct build warnings

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -9,6 +9,7 @@
 
 #include <inttypes.h>
 #include "img_mgmt_config.h"
+#include "mgmt/mgmt.h"
 #include <zcbor_common.h>
 
 struct image_version;

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -8,6 +8,7 @@
 #define H_MGMT_MGMT_
 
 #include <inttypes.h>
+#include "mgmt/mcumgr/buf.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
    Fixes build warnings relating to visibility of 2 structs in mcumgr

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44678