### PR TITLE
Bluetooth: Mesh: Various small fixes in mesh shell module

### DIFF
--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -166,23 +166,20 @@ static void health_fault_status(struct bt_mesh_health_cli *cli, uint16_t addr,
 				uint8_t test_id, uint16_t cid, uint8_t *faults,
 				size_t fault_count)
 {
-	shell_print(ctx_shell, "Health Fault Status from 0x%04x", addr);
+	shell_print_ctx("Health Fault Status from 0x%04x", addr);
 	show_faults(test_id, cid, faults, fault_count);
 }
 
 static void health_attention_status(struct bt_mesh_health_cli *cli,
 				    uint16_t addr, uint8_t attention)
 {
-	shell_print(ctx_shell, "Health Attention Status from 0x%04x: %u", addr,
-		    attention);
+	shell_print_ctx("Health Attention Status from 0x%04x: %u", addr, attention);
 }
 
 static void health_period_status(struct bt_mesh_health_cli *cli, uint16_t addr,
 				 uint8_t period)
 {
-	shell_print(ctx_shell,
-		    "Health Fast Period Divisor Status from 0x%04x: %u", addr,
-		    period);
+	shell_print_ctx("Health Fast Period Divisor Status from 0x%04x: %u", addr, period);
 }
 
 struct bt_mesh_health_cli bt_mesh_shell_health_cli = {

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -244,10 +244,6 @@ static int cmd_input_num(const struct shell *shell, size_t argc, char *argv[])
 	int err = 0;
 	uint32_t val;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	if (input_act != BT_MESH_ENTER_NUMBER) {
 		shell_print(shell, "A number hasn't been requested!");
 		return 0;
@@ -278,10 +274,6 @@ static int cmd_input_num(const struct shell *shell, size_t argc, char *argv[])
 static int cmd_input_str(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
-
-	if (argc < 2) {
-		return -EINVAL;
-	}
 
 	if (input_act != BT_MESH_ENTER_STRING) {
 		shell_print(shell, "A string hasn't been requested!");
@@ -402,10 +394,6 @@ static int cmd_uuid(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t uuid[16];
 	size_t len;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	len = hex2bin(argv[1], strlen(argv[1]), uuid, sizeof(uuid));
 	if (len < 1) {
 		return -EINVAL;
@@ -432,9 +420,6 @@ static int cmd_reset(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err = 0;
 	uint16_t addr;
-	if (argc < 2) {
-		return -EINVAL;
-	}
 
 	addr = shell_strtoul(argv[1], 0, &err);
 	if (err) {
@@ -721,10 +706,6 @@ static int cmd_net_send(const struct shell *shell, size_t argc, char *argv[])
 	size_t len;
 	int err;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	len = hex2bin(argv[1], strlen(argv[1]),
 		      msg.data, net_buf_simple_tailroom(&msg) - 4);
 	net_buf_simple_add(&msg, len);
@@ -757,10 +738,6 @@ static int cmd_iv_update_test(const struct shell *shell, size_t argc,
 {
 	int err = 0;
 	bool enable;
-
-	if (argc < 2) {
-		return -EINVAL;
-	}
 
 	enable = shell_strtobool(argv[1], 0, &err);
 	if (err) {
@@ -1157,10 +1134,6 @@ static int cmd_net_key_add(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t status;
 	int err = 0;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	key_net_idx = shell_strtoul(argv[1], 0, &err);
 	if (err) {
 		shell_warn(shell, "Unable to parse input string argument");
@@ -1323,10 +1296,6 @@ static int cmd_app_key_add(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t status;
 	int err = 0;
 
-	if (argc < 3) {
-		return -EINVAL;
-	}
-
 	key_net_idx = shell_strtoul(argv[1], 0, &err);
 	key_app_idx = shell_strtoul(argv[2], 0, &err);
 	if (err) {
@@ -1397,10 +1366,6 @@ static int cmd_app_key_upd(const struct shell *sh, size_t argc, char *argv[])
 	bool has_key_val = (argc > 3);
 	uint8_t status;
 	int err = 0;
-
-	if (argc < 3) {
-		return -EINVAL;
-	}
 
 	key_net_idx = shell_strtoul(argv[1], 0, &err);
 	key_app_idx = shell_strtoul(argv[2], 0, &err);
@@ -1531,10 +1496,6 @@ static int cmd_app_key_del(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t status;
 	int err = 0;
 
-	if (argc < 3) {
-		return -EINVAL;
-	}
-
 	key_net_idx = shell_strtoul(argv[1], 0, &err);
 	key_app_idx = shell_strtoul(argv[2], 0, &err);
 	if (err) {
@@ -1566,10 +1527,6 @@ static int cmd_mod_app_bind(const struct shell *shell, size_t argc,
 	uint16_t elem_addr, mod_app_idx, mod_id, cid;
 	uint8_t status;
 	int err = 0;
-
-	if (argc < 4) {
-		return -EINVAL;
-	}
 
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 	mod_app_idx = shell_strtoul(argv[2], 0, &err);
@@ -1617,10 +1574,6 @@ static int cmd_mod_app_unbind(const struct shell *shell, size_t argc,
 	uint16_t elem_addr, mod_app_idx, mod_id, cid;
 	uint8_t status;
 	int err = 0;
-
-	if (argc < 4) {
-		return -EINVAL;
-	}
 
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 	mod_app_idx = shell_strtoul(argv[2], 0, &err);
@@ -1727,10 +1680,6 @@ static int cmd_mod_sub_add(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t status;
 	int err = 0;
 
-	if (argc < 4) {
-		return -EINVAL;
-	}
-
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 	sub_addr = shell_strtoul(argv[2], 0, &err);
 	mod_id = shell_strtoul(argv[3], 0, &err);
@@ -1775,10 +1724,6 @@ static int cmd_mod_sub_del(const struct shell *shell, size_t argc, char *argv[])
 	uint16_t elem_addr, sub_addr, mod_id, cid;
 	uint8_t status;
 	int err = 0;
-
-	if (argc < 4) {
-		return -EINVAL;
-	}
 
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 	sub_addr = shell_strtoul(argv[2], 0, &err);
@@ -1827,10 +1772,6 @@ static int cmd_mod_sub_add_va(const struct shell *shell, size_t argc,
 	uint8_t status;
 	size_t len;
 	int err = 0;
-
-	if (argc < 4) {
-		return -EINVAL;
-	}
 
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 
@@ -1885,10 +1826,6 @@ static int cmd_mod_sub_del_va(const struct shell *shell, size_t argc,
 	size_t len;
 	int err = 0;
 
-	if (argc < 4) {
-		return -EINVAL;
-	}
-
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 
 	len = hex2bin(argv[2], strlen(argv[2]), label, sizeof(label));
@@ -1939,10 +1876,6 @@ static int cmd_mod_sub_ow(const struct shell *sh, size_t argc, char *argv[])
 	uint8_t status;
 	int err = 0;
 
-	if (argc < 4) {
-		return -EINVAL;
-	}
-
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 	sub_addr = shell_strtoul(argv[2], 0, &err);
 	mod_id = shell_strtoul(argv[3], 0, &err);
@@ -1990,10 +1923,6 @@ static int cmd_mod_sub_ow_va(const struct shell *sh, size_t argc,
 	uint8_t status;
 	size_t len;
 	int err = 0;
-
-	if (argc < 4) {
-		return -EINVAL;
-	}
 
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 
@@ -2044,10 +1973,6 @@ static int cmd_mod_sub_del_all(const struct shell *sh, size_t argc, char *argv[]
 	uint16_t elem_addr, mod_id, cid;
 	uint8_t status;
 	int err = 0;
-
-	if (argc < 3) {
-		return -EINVAL;
-	}
 
 	elem_addr = shell_strtoul(argv[1], 0, &err);
 	mod_id = shell_strtoul(argv[2], 0, &err);
@@ -2299,10 +2224,6 @@ static int cmd_mod_pub(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err = 0;
 	uint16_t addr, mod_id, cid;
-
-	if (argc < 3) {
-		return -EINVAL;
-	}
 
 	addr = shell_strtoul(argv[1], 0, &err);
 	mod_id = shell_strtoul(argv[2], 0, &err);
@@ -2605,10 +2526,6 @@ static int cmd_provision(const struct shell *shell, size_t argc, char *argv[])
 	uint32_t iv_index;
 	int err = 0;
 
-	if (argc < 3) {
-		return -EINVAL;
-	}
-
 	net_idx = shell_strtoul(argv[1], 0, &err);
 	addr = shell_strtoul(argv[2], 0, &err);
 
@@ -2718,10 +2635,6 @@ static int cmd_fault_clear(const struct shell *shell, size_t argc,
 	uint16_t cid;
 	int err = 0;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	cid = shell_strtoul(argv[1], 0, &err);
 	if (err) {
 		shell_warn(shell, "Unable to parse input string argument");
@@ -2748,10 +2661,6 @@ static int cmd_fault_clear_unack(const struct shell *shell, size_t argc,
 	uint16_t cid;
 	int err = 0;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	cid = shell_strtoul(argv[1], 0, &err);
 	if (err) {
 		shell_warn(shell, "Unable to parse input string argument");
@@ -2774,10 +2683,6 @@ static int cmd_fault_test(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t test_id;
 	uint16_t cid;
 	int err = 0;
-
-	if (argc < 3) {
-		return -EINVAL;
-	}
 
 	fault_count = sizeof(faults);
 	cid = shell_strtoul(argv[1], 0, &err);
@@ -2805,10 +2710,6 @@ static int cmd_fault_test_unack(const struct shell *shell, size_t argc,
 	uint16_t cid;
 	uint8_t test_id;
 	int err = 0;
-
-	if (argc < 3) {
-		return -EINVAL;
-	}
 
 	cid = shell_strtoul(argv[1], 0, &err);
 	test_id = shell_strtoul(argv[2], 0, &err);
@@ -2847,10 +2748,6 @@ static int cmd_period_set(const struct shell *shell, size_t argc, char *argv[])
 	uint8_t divisor, updated_divisor;
 	int err = 0;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	divisor = shell_strtoul(argv[1], 0, &err);
 	if (err) {
 		shell_warn(shell, "Unable to parse input string argument");
@@ -2875,10 +2772,6 @@ static int cmd_period_set_unack(const struct shell *shell, size_t argc,
 {
 	uint8_t divisor;
 	int err = 0;
-
-	if (argc < 2) {
-		return -EINVAL;
-	}
 
 	divisor = shell_strtoul(argv[1], 0, &err);
 	if (err) {
@@ -2919,10 +2812,6 @@ static int cmd_attention_set(const struct shell *shell, size_t argc,
 	uint8_t attention, updated_attention;
 	int err = 0;
 
-	if (argc < 2) {
-		return -EINVAL;
-	}
-
 	attention = shell_strtoul(argv[1], 0, &err);
 	if (err) {
 		shell_warn(shell, "Unable to parse input string argument");
@@ -2947,10 +2836,6 @@ static int cmd_attention_set_unack(const struct shell *shell, size_t argc,
 {
 	uint8_t attention;
 	int err = 0;
-
-	if (argc < 2) {
-		return -EINVAL;
-	}
 
 	attention = shell_strtoul(argv[1], 0, &err);
 	if (err) {
@@ -2989,10 +2874,6 @@ static int cmd_add_fault(const struct shell *shell, size_t argc, char *argv[])
 	elem = primary_element();
 	if (elem == NULL) {
 		shell_print(shell, "Element not found!");
-		return -EINVAL;
-	}
-
-	if (argc < 2) {
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Various small fixes in mesh shell:
- Use shell_print_ctx macro when printing to shall from callbacks. ctx_shell may not be initialized when callback is called.

- Remove argc check in mesh shell commands. The shell submodule already checks number of arguments.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>