### PR TITLE
doc: mcumgr: Update instruction for go version 1.18+

### DIFF
--- a/doc/services/device_mgmt/mcumgr.rst
+++ b/doc/services/device_mgmt/mcumgr.rst
@@ -43,9 +43,21 @@ Command-line Tool
 MCUmgr provides a command-line tool, :file:`mcumgr`, for managing remote devices.
 The tool is written in the Go programming language.
 
-To install the tool::
+To install the tool:
 
-  go get github.com/apache/mynewt-mcumgr-cli/mcumgr
+.. tabs::
+
+   .. group-tab:: go version < 1.18
+
+      .. code-block:: console
+
+         go get github.com/apache/mynewt-mcumgr-cli/mcumgr
+
+   .. group-tab:: go version >= 1.18
+
+      .. code-block:: console
+
+         go install github.com/apache/mynewt-mcumgr-cli/mcumgr@latest
 
 Configuring the transport
 *************************


### PR DESCRIPTION
go get is deprecated starting from go tool version 1.18:
https://go.dev/doc/go-get-install-deprecation

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>