### PR TITLE
kernel: mutex: remove unnecessary schedule locking

### DIFF
--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -222,8 +222,6 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 	 */
 	__ASSERT_NO_MSG(mutex->lock_count > 0U);
 
-	z_sched_lock();
-
 	LOG_DBG("mutex %p lock_count: %d", mutex, mutex->lock_count);
 
 	/*
@@ -265,8 +263,6 @@ int z_impl_k_mutex_unlock(struct k_mutex *mutex)
 
 k_mutex_unlock_return:
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_mutex, unlock, mutex, 0);
-
-	k_sched_unlock();
 
 	return 0;
 }


### PR DESCRIPTION
Removes an unnecessary schedule lock/unlock pair from k_mutex_unlock().

Rationale: Given that only the current thread (which would also be the
mutex owner) will be able to modify the mutex object AND that a
recursive unlock ought never trigger any reschedule (as it does not
touch the pend queue), then performing a schedule lock is not needed
prior to testing for a recursive unlock.

Furthermore, even if it is not a recursive unlock, then a schedule lock
is superfluous as the existing spinlock provides sufficient protection.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>