### PR TITLE
soc: mxrt10xx: remove forces enable boot header

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -688,11 +688,11 @@ config CODE_ITCM
 
 config CODE_FLEXSPI
 	bool "Link code into external FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_FLEXSPI2
 	bool "Link code into internal FlexSPI-controlled memory"
-	select NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
+	imply NXP_IMX_RT_BOOT_HEADER if !BOOTLOADER_MCUBOOT
 
 config CODE_SRAM0
 	bool "Link code into RAM_L memory (RAM_L)"


### PR DESCRIPTION
When we use a third-party or custom bootloader, there is also
need to remove the boot header. Change the select to imply,
so that the boot header can be removed by configuration when
MCUBoot is not used.

Signed-off-by: Frank Li <lgl88911@163.com>