### PR TITLE
Add pwm-0 alias to mec172xevb dts file

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -26,6 +26,7 @@
 		i2c-0 = &i2c_smb_0;
 		i2c1 = &i2c_smb_1;
 		i2c7 = &i2c_smb_2;
+		pwm-0 = &pwm0;
 	};
 
 	leds {

--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.yaml
@@ -18,3 +18,4 @@ supported:
   - pinmux
   - i2c
   - adc
+  - pwm

--- a/drivers/pwm/Kconfig.xec
+++ b/drivers/pwm/Kconfig.xec
@@ -3,9 +3,11 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
+DT_COMPAT_PWM_XEC := microchip,xec-pwm
+
 config PWM_XEC
 	bool "Microchip XEC PWM"
 	depends on SOC_FAMILY_MEC
-	default $(dt_compat_enabled,${DT_COMPAT_ST_PWM_XEC})
+	default $(dt_compat_enabled,${DT_COMPAT_PWM_XEC})
 	help
 	  Enable driver to utilize PWM on the Microchip XEC IP block.


### PR DESCRIPTION
Without this the test case of tests/drivers/pwm/pwm_api will fail
"west build -p always -b mec172xevb_assy6906 tests/drivers/pwm/pwm_api"

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>