### PR TITLE
lib: posix: support for pthread_attr_setstacksize()

### DIFF
--- a/include/zephyr/posix/pthread.h
+++ b/include/zephyr/posix/pthread.h
@@ -64,6 +64,9 @@ struct posix_thread {
 /* Passed to pthread_once */
 #define PTHREAD_ONCE_INIT 1
 
+/* The minimum allowable stack size */
+#define PTHREAD_STACK_MIN Z_KERNEL_STACK_SIZE_ADJUST(0)
+
 /**
  * @brief Declare a pthread condition variable
  *
@@ -483,6 +486,7 @@ static inline int pthread_rwlockattr_init(pthread_rwlockattr_t *attr)
 }
 
 int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize);
+int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize);
 int pthread_attr_setschedpolicy(pthread_attr_t *attr, int policy);
 int pthread_attr_getschedpolicy(const pthread_attr_t *attr, int *policy);
 int pthread_attr_setdetachstate(pthread_attr_t *attr, int detachstate);

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -553,6 +553,25 @@ int pthread_attr_getstacksize(const pthread_attr_t *attr, size_t *stacksize)
 }
 
 /**
+ * @brief Set stack size attribute in thread attributes object.
+ *
+ * See IEEE 1003.1
+ */
+int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize)
+{
+	if ((attr == NULL) || (attr->initialized == 0U)) {
+		return EINVAL;
+	}
+
+	if (stacksize < PTHREAD_STACK_MIN) {
+		return EINVAL;
+	}
+
+	attr->stacksize = stacksize;
+	return 0;
+}
+
+/**
  * @brief Get stack attributes in thread attributes object.
  *
  * See IEEE 1003.1

--- a/tests/posix/common/src/main.c
+++ b/tests/posix/common/src/main.c
@@ -21,6 +21,7 @@ extern void test_posix_pthread_create_negative(void);
 extern void test_posix_pthread_termination(void);
 extern void test_posix_multiple_threads_single_key(void);
 extern void test_posix_single_thread_multiple_keys(void);
+extern void test_posix_thread_attr_stacksize(void);
 extern void test_nanosleep_NULL_NULL(void);
 extern void test_nanosleep_NULL_notNULL(void);
 extern void test_nanosleep_notNULL_NULL(void);
@@ -45,6 +46,7 @@ void test_main(void)
 			ztest_unit_test(test_posix_pthread_termination),
 			ztest_unit_test(test_posix_multiple_threads_single_key),
 			ztest_unit_test(test_posix_single_thread_multiple_keys),
+			ztest_unit_test(test_posix_thread_attr_stacksize),
 			ztest_unit_test(test_posix_clock),
 			ztest_unit_test(test_posix_semaphore),
 			ztest_unit_test(test_posix_normal_mutex),

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -531,6 +531,28 @@ void test_posix_pthread_termination(void)
 	zassert_equal(ret, ESRCH, "got attr from terminated thread!");
 }
 
+void test_posix_thread_attr_stacksize(void)
+{
+	size_t act_size;
+	pthread_attr_t attr;
+	const size_t exp_size = 0xB105F00D;
+
+	/* TESTPOINT: specify a custom stack size via pthread_attr_t */
+	zassert_equal(0, pthread_attr_init(&attr), "pthread_attr_init() failed");
+
+	if (PTHREAD_STACK_MIN > 0) {
+		zassert_equal(EINVAL, pthread_attr_setstacksize(&attr, 0),
+			      "pthread_attr_setstacksize() did not fail");
+	}
+
+	zassert_equal(0, pthread_attr_setstacksize(&attr, exp_size),
+		      "pthread_attr_setstacksize() failed");
+	zassert_equal(0, pthread_attr_getstacksize(&attr, &act_size),
+		      "pthread_attr_getstacksize() failed");
+	zassert_equal(exp_size, act_size, "wrong size: act: %zu exp: %zu",
+		exp_size, act_size);
+}
+
 static void *create_thread1(void *p1)
 {
 	/* do nothing */


### PR DESCRIPTION
We already support `pthread_attr_getstacksize()`. It would also make sense to support `pthread_attr_setstacksize()`. 

Fixes #44722

(Compliance check is a false positive)