### PR TITLE
samples: ipc: openamp_rsc_table: add option to configure mailbox channel

### DIFF
--- a/samples/subsys/ipc/openamp_rsc_table/Kconfig
+++ b/samples/subsys/ipc/openamp_rsc_table/Kconfig
@@ -12,4 +12,8 @@ config OPENAMP_IPC_DEV_NAME
 	help
 	  This option specifies the device name for the IPC device to be used
 
+config OPENAMP_IPC_NOTIFY_CHAN
+	int "Mailbox channel to use to notify the host"
+	default 0
+
 source "Kconfig.zephyr"

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -136,7 +136,7 @@ int mailbox_notify(void *priv, uint32_t id)
 	ARG_UNUSED(priv);
 
 	LOG_DBG("%s: msg received\n", __func__);
-	ipm_send(ipm_handle, 0, id, NULL, 0);
+	ipm_send(ipm_handle, 0, CONFIG_OPENAMP_IPC_NOTIFY_CHAN, NULL, 0);
 
 	return 0;
 }


### PR DESCRIPTION
This is an RFC to address the rpmsg notification ID issues discussed in PR #43113.

If a platform requires an ID other than the currently used 0, this can be specified in the board-specific .conf with such an entry:
`CONFIG_OPENAMP_IPC_NOTIFY_CHAN=1 `
