### PR TITLE
drivers: mpu9250: magnetometer data read fix

### DIFF
--- a/drivers/sensor/mpu9250/mpu9250.c
+++ b/drivers/sensor/mpu9250/mpu9250.c
@@ -210,9 +210,9 @@ static int mpu9250_sample_fetch(const struct device *dev,
 	drv_data->gyro_y = sys_be16_to_cpu(buf[5]);
 	drv_data->gyro_z = sys_be16_to_cpu(buf[6]);
 #ifdef CONFIG_MPU9250_MAGN_EN
-	drv_data->magn_x = sys_be16_to_cpu(buf[7]);
-	drv_data->magn_y = sys_be16_to_cpu(buf[8]);
-	drv_data->magn_z = sys_be16_to_cpu(buf[9]);
+	drv_data->magn_x = sys_le16_to_cpu(buf[7]);
+	drv_data->magn_y = sys_le16_to_cpu(buf[8]);
+	drv_data->magn_z = sys_le16_to_cpu(buf[9]);
 	drv_data->magn_st2 = ((uint8_t *)buf)[20];
 	LOG_DBG("magn_st2: %u", drv_data->magn_st2);
 #endif


### PR DESCRIPTION
The magnetometer data read from AK9863 is assumed to be big endian 
(like the accelerometer & gyroscope data).
However it is in little endian, which means the appropriate byteorder
function is sys_le16_to_cpu().
See the MPU925 register map: https://3cfeqx1hf82y3xcoull08ihx-wpengine.netdna-ssl.com/wp-content/uploads/2017/11/RM-MPU-9250A-00-v1.6.pdf
At 5.6 HXL to HZH: Measurement Data

Signed-off-by: Loris Schmit loris.schmit@inovex.de