### PR TITLE
boards/arm: Add MCUbootr's button and led aliases to Nordic's boards

### DIFF
--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -74,6 +74,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		bootloader-led0 = &green_pwm_led;
+		mcuboot-button0 = &button0;
 	};
 
 	vbatt {

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -75,6 +75,7 @@
 		sw0 = &button0;
 		bootloader-led0 = &green_pwm_led;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &green_pwm_led;
 	};
 
 	vbatt {

--- a/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
+++ b/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
@@ -74,6 +74,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		bootloader-led0 = &green_pwm_led;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
+++ b/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
@@ -75,6 +75,7 @@
 		sw0 = &button0;
 		bootloader-led0 = &green_pwm_led;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &green_pwm_led;
 	};
 };
 

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -85,6 +85,7 @@
 		sw2 = &button3;
 		sw3 = &button4;
 		mcuboot-button0 = &button1;
+		mcuboot-led0 = &led1;
 	};
 };
 

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -84,6 +84,7 @@
 		sw1 = &button2;
 		sw2 = &button3;
 		sw3 = &button4;
+		mcuboot-button0 = &button1;
 	};
 };
 

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -54,6 +54,7 @@
 		sw0 = &button1;
 		sw1 = &button2;
 		mcuboot-button0 = &button1;
+		mcuboot-led0 = &led1;
 	};
 };
 

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -53,6 +53,7 @@
 		led1 = &led2;
 		sw0 = &button1;
 		sw1 = &button2;
+		mcuboot-button0 = &button1;
 	};
 };
 

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -73,6 +73,7 @@
 		sw1 = &button2;
 		sw2 = &button3;
 		sw3 = &button4;
+		mcuboot-button0 = &button1;
 	};
 };
 

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -74,6 +74,7 @@
 		sw2 = &button3;
 		sw3 = &button4;
 		mcuboot-button0 = &button1;
+		mcuboot-led0 = &led1;
 	};
 };
 

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -73,6 +73,7 @@
 		sw1 = &button2;
 		sw2 = &button3;
 		sw3 = &button4;
+		mcuboot-button0 = &button1;
 	};
 };
 

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -74,6 +74,7 @@
 		sw2 = &button3;
 		sw3 = &button4;
 		mcuboot-button0 = &button1;
+		mcuboot-led0 = &led1;
 	};
 };
 

--- a/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
+++ b/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
@@ -43,6 +43,7 @@
 	aliases {
 		led0 = &led1;
 		sw0 = &button1;
+		mcuboot-button0 = &button1;
 	};
 };
 

--- a/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
+++ b/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
@@ -44,6 +44,7 @@
 		led0 = &led1;
 		sw0 = &button1;
 		mcuboot-button0 = &button1;
+		mcuboot-led0 = &led1;
 	};
 };
 

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -81,6 +81,7 @@
 		led0 = &led1a;
 		led1 = &led1b;
 		sw0 = &button0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -82,6 +82,7 @@
 		led1 = &led1b;
 		sw0 = &button0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led1a;
 	};
 };
 

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -194,6 +194,7 @@
 		sw1 = &button2;
 		sw2 = &mag1;
 		mcuboot-button0 = &button1;
+		mcuboot-led0 = &led1;
 	};
 };
 

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -193,6 +193,7 @@
 		sw0 = &button1;
 		sw1 = &button2;
 		sw2 = &mag1;
+		mcuboot-button0 = &button1;
 	};
 };
 

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -46,6 +46,7 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &blue_led;
 	};
 
 	/* Used for accessing other pins */

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -45,6 +45,7 @@
 		bootloader-led0 = &blue_led;
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
+		mcuboot-button0 = &button0;
 	};
 
 	/* Used for accessing other pins */

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -133,6 +133,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -134,6 +134,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -82,6 +82,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -83,6 +83,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -82,6 +82,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -81,6 +81,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -112,6 +112,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -111,6 +111,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -82,6 +82,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -83,6 +83,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -122,6 +122,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -123,6 +123,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -82,6 +82,7 @@
 		red-pwm-led = &red_pwm_led;
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -83,6 +83,7 @@
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0_green;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -75,6 +75,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -74,6 +74,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -77,6 +77,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -76,6 +76,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -123,6 +123,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -124,6 +124,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -122,6 +122,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -123,6 +123,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -104,6 +104,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -103,6 +103,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -147,6 +147,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -148,6 +148,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -72,6 +72,7 @@
 		sw1 = &button2;
 		sw2 = &button3;
 		sw3 = &button4;
+		mcuboot-button0 = &button1;
 	};
 };
 

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -73,6 +73,7 @@
 		sw2 = &button3;
 		sw3 = &button4;
 		mcuboot-button0 = &button1;
+		mcuboot-led0 = &led1;
 	};
 };
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
@@ -46,6 +46,7 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &blue_led;
 	};
 
 	/* Used for accessing other pins */

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
@@ -45,6 +45,7 @@
 		bootloader-led0 = &blue_led;
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
+		mcuboot-button0 = &button0;
 	};
 
 	/* Used for accessing other pins */

--- a/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
+++ b/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
@@ -127,6 +127,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
+++ b/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
@@ -126,6 +126,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
+++ b/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
@@ -127,6 +127,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
+++ b/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
@@ -126,6 +126,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -136,6 +136,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -137,6 +137,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
+++ b/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
@@ -127,6 +127,7 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
+++ b/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
@@ -126,6 +126,7 @@
 		sw2 = &button2;
 		sw3 = &button3;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 

--- a/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
+++ b/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
@@ -50,6 +50,7 @@
 		sw0 = &button0;
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
+		mcuboot-led0 = &led0;
 	};
 };
 

--- a/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
+++ b/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
@@ -49,6 +49,7 @@
 		led1 = &led1;
 		sw0 = &button0;
 		bootloader-led0 = &led0;
+		mcuboot-button0 = &button0;
 	};
 };
 


### PR DESCRIPTION
Added alias for the button's gpio pin which might be used by MCUboot.
So far pin assignments for MCUboot was configured by the Kconfig. New
alias will help to switch configuration to more native DTS based
description.

MCUboot will start to use the alias thanks to: https://github.com/mcu-tools/mcuboot/pull/1344