### PR TITLE
manifest: update hal_microchip

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       groups:
         - hal
     - name: hal_microchip
-      revision: 870d05e6a64ea9548da6b907058b03c8c9420826
+      revision: 5d079f1683a00b801373bbbbf5d181d4e33b30d5
       path: modules/hal/microchip
       groups:
         - hal


### PR DESCRIPTION
update hal_microchip revision, which includes mpfs_hal for Microchip's PolarFire SoC Icicle Kit.
which is up for review in PR #44208

Signed-off-by: Conor Paxton <conor.paxton@microchip.com>