### PR TITLE
ci: backport: Update backport action to v1.1.1-3

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,7 @@ jobs:
     name: Backport
     steps:
       - name: Backport
-        uses: zephyrproject-rtos/action-backport@v1.1.1-1
+        uses: zephyrproject-rtos/action-backport@v1.1.1-3
         with:
           github_token: ${{ secrets.ZB_GITHUB_TOKEN }}
           issue_labels: backport


### PR DESCRIPTION
This commit updates the backport workflow to use the backport action
v1.1.1-3, which introduces the following enhancements:

1. Cherry-pick backport commits with the `-x` option to improve
   traceability.

2. Disable incorrect warning when "rebase merge" method is enabled.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Tracked in https://github.com/zephyrproject-rtos/infrastructure-private/issues/17
Tested in https://github.com/zephyrproject-rtos/zephyr-testing/pull/170/commits