### PR TITLE
scripts: kconfig: add dt_chosen_has_compat

### DIFF
--- a/doc/build/kconfig/preprocessor-functions.rst
+++ b/doc/build/kconfig/preprocessor-functions.rst
@@ -34,6 +34,7 @@ while the ``*_hex`` version returns a hexadecimal value starting with ``0x``.
    $(dt_chosen_label,<property in /chosen>)
    $(dt_chosen_enabled,<property in /chosen>)
    $(dt_chosen_path,<property in /chosen>)
+   $(dt_chosen_has_compat,<property in /chosen>)
    $(dt_path_enabled,<node path>)
    $(dt_alias_enabled,<node alias>)
    $(dt_nodelabel_enabled,<node label>)

--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -88,6 +88,23 @@ def dt_chosen_path(kconf, _, chosen):
 
     return node.path if node else ""
 
+def dt_chosen_has_compat(kconf, _, chosen, compat):
+    """
+    This function takes a /chosen node property and returns 'y' if the
+    chosen node has the provided compatible string 'compat'
+    """
+    if doc_mode or edt is None:
+        return "n"
+
+    node = edt.chosen_node(chosen)
+
+    if node is None:
+        return "n"
+
+    if compat in node.compats:
+        return "y"
+
+    return "n"
 
 def dt_node_enabled(kconf, name, node):
     """
@@ -574,6 +591,7 @@ functions = {
         "dt_chosen_label": (dt_chosen_label, 1, 1),
         "dt_chosen_enabled": (dt_chosen_enabled, 1, 1),
         "dt_chosen_path": (dt_chosen_path, 1, 1),
+        "dt_chosen_has_compat": (dt_chosen_has_compat, 2, 2),
         "dt_path_enabled": (dt_node_enabled, 1, 1),
         "dt_alias_enabled": (dt_node_enabled, 1, 1),
         "dt_nodelabel_enabled": (dt_nodelabel_enabled, 1, 1),


### PR DESCRIPTION
Add `dt_chosen_has_compat` kconfig helper function. This function checks
if a given `chosen` node has a provided compatible string in its
compatible list. Returns "y" if compatible string is present, and "n"
otherwise.