### PR TITLE
doc: Enhance documentation section on labeling

### DIFF
--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -348,9 +348,10 @@ Labels applicable to both pull requests and issues
 
 * *area: **
 
-Indicates subsystems (e.g., Kernel, I2C, Memory Management), project functions
-(e.g., Debugging, Documentation, Process), or other categories
-(e.g., Coding Style, MISRA-C) affected by the bug or pull request.
+Indicates Zephyr subsystems (e.g, *area: Kernel*, *area: I2C*,
+*area: Memory Management*), project functions (e.g., *area: Debugging*,
+*area: Documentation*, *area: Process*), or other categories (e.g.,
+*area: Coding Style*, *area: MISRA-C*) affected by the bug or the pull request.
 
 An area maintainer should be able to filter by an area label and find all issues
 and PRs which relate to that area.

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -312,8 +312,7 @@ feature requests are handled and become features can be found in
 Labels applicable to pull requests only
 =======================================
 
-The issue or PR describes a change to a stable API. See additional information
-in :ref:`stable_api_changes`.
+The issue or PR describes a change to a stable API.
 
 * *Hotfix*
 

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -322,6 +322,8 @@ Fix for an issue blocking development.
 
 * *Maintainer*
 
+Maintainer review reqiured.
+
 * *Security Review*
 
 Depending on the PR complexity, an indication of how long a merge should be held

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -331,10 +331,6 @@ to ensure proper review. See :ref:`review process <review_time>`.
 This PR should not be merged (Do Not Merge). For work in progress, GitHub
 "draft" PRs are preferred.
 
-* *Stale*
-
-PR which seems abandoned, and requires attention by the author.
-
 * *Needs review*
 
 The PR needs attention from the maintainers.
@@ -392,6 +388,10 @@ address an issue.
 * *Blocked*
 
 Blocked by another PR or issue.
+
+* *Stale*
+
+An issue or a PR which seems abandoned, and requires attention by the author.
 
 * *In progress*
 

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -263,7 +263,7 @@ These are the labels we currently have, grouped by applicability:
 Labels applicable to issues only
 ================================
 
-* *priority:{high|medium|low}*
+* *priority: {high|medium|low}*
 
 To classify the impact and importance of a bug or
 :ref:`feature <feature-tracking>`.
@@ -315,7 +315,7 @@ Labels applicable to pull requests only
 The issue or PR describes a change to a stable API. See additional information
 in :ref:`stable_api_changes`.
 
-* *Hot Fix*
+* *Hotfix*
 
 * *Trivial*
 
@@ -331,7 +331,7 @@ to ensure proper review. See :ref:`review process <review_time>`.
 This PR should not be merged (Do Not Merge). For work in progress, GitHub
 "draft" PRs are preferred.
 
-* *Stale PR*
+* *Stale*
 
 PR which seems abandoned, and requires attention by the author.
 
@@ -350,7 +350,7 @@ The PR has licensing issues which require a licensing expert to review it.
 Labels applicable to both pull requests and issues
 ==================================================
 
-* *Area:**
+* *area: **
 
 Indicates subsystems (e.g., Kernel, I2C, Memory Management), project functions
 (e.g., Debugging, Documentation, Process), or other categories
@@ -359,7 +359,7 @@ Indicates subsystems (e.g., Kernel, I2C, Memory Management), project functions
 An area maintainer should be able to filter by an area label and find all issues
 and PRs which relate to that area.
 
-* *Platform:**
+* *platform: **
 
 An issue or PR which affects only a particular platform.
 

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -360,12 +360,18 @@ and PRs which relate to that area.
 An issue or PR which affects only a particular platform.
 
 * *dev-review*
-* *TSC*
 
-The issue is to be discussed in the following `dev-review/TSC meeting`_ if time
+The issue is to be discussed in the following `dev-review`_ if time
 permits.
 
-.. _`dev-review/TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings
+.. _`dev-review`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#zephyr-dev-meeting
+
+* *TSC*
+
+TSC stands for Technical Steering Committee. The issue is to be discussed in the
+following `TSC meeting`_ if time permits.
+
+.. _`TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings#technical-steering-committee-tsc
 
 * *Stable API Change*
 

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -326,6 +326,8 @@ Maintainer review reqiured.
 
 * *Security Review*
 
+To be reviewed by a security expert.
+
 Depending on the PR complexity, an indication of how long a merge should be held
 to ensure proper review. See :ref:`review process <review_time>`.
 

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -328,9 +328,6 @@ Maintainer review reqiured.
 
 To be reviewed by a security expert.
 
-Depending on the PR complexity, an indication of how long a merge should be held
-to ensure proper review. See :ref:`review process <review_time>`.
-
 * *DNM*
 
 This PR should not be merged (Do Not Merge). For work in progress, GitHub
@@ -347,6 +344,12 @@ The PR is a backport or should be backported.
 * *Licensing*
 
 The PR has licensing issues which require a licensing expert to review it.
+
+.. note::
+   For all labels applicable to PRs: Please note that the label, together with
+   PR complexity, affects how long a merge should be held to ensure proper
+   review. See :ref:`review process <review_time>` for details.
+
 
 Labels applicable to both pull requests and issues
 ==================================================

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -258,138 +258,155 @@ fix it.
 This saves us all time when searching, reduces the chances of the PR or issue
 being forgotten, speeds up reviewing, avoids duplicate issue reports, etc.
 
-These are the labels we currently have, grouped by type:
+These are the labels we currently have, grouped by applicability:
 
-Area
-====
+Labels applicable to issues only
+================================
 
-=============  ===============================================================
-Labels         ``Area:*``
-Applicable to  PRs  and issues
-Description    Indicates subsystems (e.g., Kernel, I2C, Memory Management),
-               project functions (e.g., Debugging, Documentation, Process),
-               or other categories (e.g., Coding Style, MISRA-C)  affected by
-               the bug or pull request.
-=============  ===============================================================
+* *priority:{high|medium|low}*
 
-An area maintainer should be able to filter by an area label and
-find all issues and PRs which relate to that area.
-
-Platform
-========
-
-=============  ===============================================================
-Labels         ``Platform:*``
-Applicable to  PRs  and issues
-Description    An issue or PR which affects only a particular platform
-=============  ===============================================================
-
-To be discussed in a meeting
-============================
-
-=============  ===============================================================
-Labels         ``dev-review``, ``TSC``
-Applicable to  PRs  and issues
-Description    The issue is to be discussed in the following
-               `dev-review/TSC meeting`_ if time permits
-=============  ===============================================================
-
-.. _`dev-review/TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings
-
-Stable API changes
-==================
-
-=============  ===============================================================
-Labels         ``Stable API Change``
-Applicable to  PRs  and issues
-Description    The issue or PR describes a change to a stable API. See
-               additional information in :ref:`stable_api_changes`
-=============  ===============================================================
-
-Minimum PR review time
-======================
-
-=============  ===============================================================
-Labels         ``Hot Fix``, ``Trivial``, ``Maintainer``,
-               ``Security Review``, ``TSC``
-Applicable to  PRs only
-Description    Depending on the PR complexity, an indication of how long a merge
-               should be held to ensure proper review. See
-               :ref:`review process <review_time>`
-=============  ===============================================================
-
-Issue priority labels
-=====================
-
-=============  ===============================================================
-Labels         ``priority:{high|medium|low}``
-Applicable to  Issues only
-Description    To classify the impact and importance of a bug or
-               :ref:`feature <feature-tracking>`
-=============  ===============================================================
+To classify the impact and importance of a bug or
+:ref:`feature <feature-tracking>`.
 
 Note: Issue priorities are generally set or changed during the bug-triage or TSC
 meetings.
 
-Miscellaneous labels
-====================
+* *Regression*
 
-For both PRs and issues
------------------------
+Something, which was working, but does not anymore (bug subtype).
 
-+------------------------+-----------------------------------------------------+
-|``Bug``                 | The issue is a bug, or the PR is fixing a bug       |
-+------------------------+-----------------------------------------------------+
-|``Coverity``            | A Coverity detected issue or its fix                |
-+------------------------+-----------------------------------------------------+
-|``Waiting for response``| The Zephyr developers are waiting for the submitter |
-|                        | to respond to a question, or address an issue.      |
-+------------------------+-----------------------------------------------------+
-|``Blocked``             | Blocked by another PR or issue                      |
-+------------------------+-----------------------------------------------------+
-|``In progress``         | For PRs: is work in progress and should not be      |
-|                        | merged yet. For issues: Is being worked on          |
-+------------------------+-----------------------------------------------------+
-|``RFC``                 | The author would like input from the community. For |
-|                        | a PR it should be considered a draft                |
-+------------------------+-----------------------------------------------------+
-|``LTS``                 | Long term release branch related                    |
-+------------------------+-----------------------------------------------------+
-|``EXT``                 | Related to an external component (in ``ext/``)      |
-+------------------------+-----------------------------------------------------+
+* *Question*
 
-PR only labels
---------------
+This issue is a question to the Zephyr developers.
 
-================ ===============================================================
-``DNM``          This PR should not be merged (Do Not Merge).
-                 For work in progress, GitHub "draft" PRs are preferred
-``Stale PR``     PR which seems abandoned, and requires attention by the author
-``Needs review`` The PR needs attention from the maintainers
-``Backport``     The PR is a backport or should be backported
-``Licensing``    The PR has licensing issues which require a licensing expert to
-                 review it
-================ ===============================================================
+* *Enhancement*
 
-Issue only labels
------------------
+Changes/Updates/Additions to existing :ref:`features <feature-tracking>`.
 
-==================== ===========================================================
-``Regression``       Something, which was working, but does not anymore
-                     (bug subtype)
-``Question``         This issue is a question to the Zephyr developers
-``Enhancement``      Changes/Updates/Additions to existing
-                     :ref:`features <feature-tracking>`
-``Feature request``  A request for a new :ref:`feature <feature-tracking>`
-``Feature``          A :ref:`planned feature<feature-tracking>` with a milestone
-``Duplicate``        This issue is a duplicate of another issue
-                     (please specify)
-``Good first issue`` Good for a first time contributor to take
-``Release Notes``    Issues that need to be mentioned in release notes as known
-                     issues with additional information
-==================== ===========================================================
+* *Feature request*
 
-Any issue must be classified and labeled as either ``Bug``, ``Question``,
-``Enhancement``, ``Feature``, or ``Feature Request``. More information on how
+A request for a new :ref:`feature <feature-tracking>`.
+
+* *Feature*
+
+A :ref:`planned feature<feature-tracking>` with a milestone.
+
+* *Duplicate*
+
+This issue is a duplicate of another issue (please specify).
+
+* *Good first issue*
+
+Good for a first time contributor to take.
+
+* *Release Notes*
+
+Issues that need to be mentioned in release notes as known issues with
+additional information.
+
+Any issue must be classified and labeled as either *Bug*, *Question*,
+*Enhancement*, *Feature*, or *Feature Request*. More information on how
 feature requests are handled and become features can be found in
 :ref:`Feature Tracking<feature-tracking>`.
+
+Labels applicable to pull requests only
+=======================================
+
+The issue or PR describes a change to a stable API. See additional information
+in :ref:`stable_api_changes`.
+
+* *Hot Fix*
+
+* *Trivial*
+
+* *Maintainer*
+
+* *Security Review*
+
+Depending on the PR complexity, an indication of how long a merge should be held
+to ensure proper review. See :ref:`review process <review_time>`.
+
+* *DNM*
+
+This PR should not be merged (Do Not Merge). For work in progress, GitHub
+"draft" PRs are preferred.
+
+* *Stale PR*
+
+PR which seems abandoned, and requires attention by the author.
+
+* *Needs review*
+
+The PR needs attention from the maintainers.
+
+* *Backport*
+
+The PR is a backport or should be backported.
+
+* *Licensing*
+
+The PR has licensing issues which require a licensing expert to review it.
+
+Labels applicable to both pull requests and issues
+==================================================
+
+* *Area:**
+
+Indicates subsystems (e.g., Kernel, I2C, Memory Management), project functions
+(e.g., Debugging, Documentation, Process), or other categories
+(e.g., Coding Style, MISRA-C) affected by the bug or pull request.
+
+An area maintainer should be able to filter by an area label and find all issues
+and PRs which relate to that area.
+
+* *Platform:**
+
+An issue or PR which affects only a particular platform.
+
+* *dev-review*
+* *TSC*
+
+The issue is to be discussed in the following `dev-review/TSC meeting`_ if time
+permits.
+
+.. _`dev-review/TSC meeting`: https://github.com/zephyrproject-rtos/zephyr/wiki/Zephyr-Committee-and-Working-Group-Meetings
+
+* *Stable API Change*
+
+The issue or PR describes a change to a stable API. See additional information
+in :ref:`stable_api_changes`.
+
+* *Bug*
+
+The issue is a bug, or the PR is fixing a bug.
+
+* *Coverity*
+
+A Coverity detected issue or its fix.
+
+* *Waiting for response*
+
+The Zephyr developers are waiting for the submitter to respond to a question, or
+address an issue.
+
+* *Blocked*
+
+Blocked by another PR or issue.
+
+* *In progress*
+
+For PRs: is work in progress and should not be merged yet. For issues: Is being
+worked on.
+
+* *RFC*
+
+The author would like input from the community. For a PR it should be considered
+a draft.
+
+* *LTS*
+
+Long term release branch related.
+
+* *EXT*
+
+Related to an external component (in ``ext/``).

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -316,6 +316,8 @@ The issue or PR describes a change to a stable API.
 
 * *Hotfix*
 
+Fix for an issue blocking development.
+
 * *Trivial*
 
 * *Maintainer*

--- a/doc/project/dev_env_and_tools.rst
+++ b/doc/project/dev_env_and_tools.rst
@@ -409,4 +409,4 @@ Long term release branch related.
 
 * *EXT*
 
-Related to an external component (in ``ext/``).
+Related to an external component.


### PR DESCRIPTION
Mostly due to the limitations of table support in rst file format, the current content of the section "Labeling issues and pull requests in Github" is difficult to navigate and follow, especially for new contributors, and especially in pdf output..

Fix this by rearranging the content of the section and fixing some minor discrepancies between Github and documentation in the section.

Note that this pull request does only minor changes regarding the information contained in the section. It mostly rearranges it and makes it more accessible to the reader. 