### PR TITLE
samples: misc fixes to docs

### DIFF
--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -71,7 +71,7 @@ It is recommended that you copy and modify one of the two TensorFlow
 samples when creating your own TensorFlow project. To build with
 TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`:
 
-.. code-block:: console
+.. code-block:: kconfig
 
     CONFIG_CPLUSPLUS=y
     CONFIG_NEWLIB_LIBC=y

--- a/samples/modules/tflite-micro/magic_wand/README.rst
+++ b/samples/modules/tflite-micro/magic_wand/README.rst
@@ -40,7 +40,7 @@ start the emulator:
 
 .. code-block:: console
 
-    renode -e "set zephyr_elf @./build/zephyr/zephyr.elf; s @./renode/litex-vexriscv-tflite.resc"
+    renode -e "set zephyr_elf @./build/zephyr/zephyr.elf; s @./samples/modules/tflite-micro/magic_wand/renode/litex-vexriscv-tflite.resc"
 
 .. _download and install Renode 1.12 or higher as a package:
     https://github.com/renode/renode/releases/
@@ -102,11 +102,9 @@ Modifying Sample for Your Own Project
 
 It is recommended that you copy and modify one of the two TensorFlow
 samples when creating your own TensorFlow project. To build with
-TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`.
+TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`:
 
-:file:`prj.conf`:
-
-.. code-block:: console
+.. code-block:: kconfig
 
     CONFIG_CPLUSPLUS=y
     CONFIG_NEWLIB_LIBC=y

--- a/samples/net/cloud/google_iot_mqtt/README.rst
+++ b/samples/net/cloud/google_iot_mqtt/README.rst
@@ -53,7 +53,7 @@ from the Google Cloud Platform itself:
 From these values, the config values can be set using the following
 template:
 
-.. code-block: kconfig
+.. code-block:: kconfig
 
    CLOUD_CLIENT_ID="projects/PROJECT_ID/locations/REGION/registries/REGISTRY_ID/devices/DEVICE_ID"
    CLOUD_AUDIENCE="PROJECT_ID"

--- a/samples/net/mqtt_publisher/README.rst
+++ b/samples/net/mqtt_publisher/README.rst
@@ -160,7 +160,7 @@ same host as the MQTT broker.
 To start a proxy server, ``ssh`` can be used.
 Use the following command to run it on your host with the default port:
 
-.. code-block: console
+.. code-block:: console
 
 	$ ssh -N -D 0.0.0.0:1080 localhost
 

--- a/samples/net/sockets/echo_client/README.rst
+++ b/samples/net/sockets/echo_client/README.rst
@@ -124,13 +124,13 @@ with the default port:
 
 For IPv4 proxy server:
 
-.. code-block: console
+.. code-block:: console
 
         $ ssh -N -D 0.0.0.0:1080 localhost
 
 For IPv6 proxy server:
 
-.. code-block: console
+.. code-block:: console
 
         $ ssh -N -D [::]:1080 localhost
 


### PR DESCRIPTION
Changes console blocks in hello_world and magic_wand tflite-micro samples to Kconfig blocks to match content. Fixes typos in some networking samples so that code blocks display instead of being hidden. Fixes path to litex-vexriscv-tflite.resc.

(Noticed while reviewing #44517)