### PR TITLE
logging: Fix cbprintf package alignement

### DIFF
--- a/include/zephyr/logging/log_msg2.h
+++ b/include/zephyr/logging/log_msg2.h
@@ -75,16 +75,22 @@ struct log_msg2_hdr {
 	const void *source;
 	log_timestamp_t timestamp;
 #endif
-#if defined(__xtensa__) && !defined(CONFIG_LOG_TIMESTAMP_64BIT)
-	/* xtensa requires that cbprintf package that follows the header is
-	 * aligned to 16 bytes. Adding padding when necessary.
-	 */
-	uint32_t padding;
-#endif
 };
+
+/* Messages are aligned to alignment required by cbprintf package. */
+#define Z_LOG_MSG2_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
+
+#define Z_LOG_MSG2_PADDING \
+	((sizeof(struct log_msg2_hdr) % Z_LOG_MSG2_ALIGNMENT) > 0 ? \
+	(Z_LOG_MSG2_ALIGNMENT - (sizeof(struct log_msg2_hdr) % Z_LOG_MSG2_ALIGNMENT)) : \
+		0)
 
 struct log_msg2 {
 	struct log_msg2_hdr hdr;
+	/* Adding padding to ensure that cbprintf package that follows is
+	 * properly aligned.
+	 */
+	uint8_t padding[Z_LOG_MSG2_PADDING];
 	uint8_t data[];
 };
 
@@ -131,9 +137,6 @@ enum z_log_msg2_mode {
 	.data_len = _dlen, \
 	.reserved = 0, \
 }
-
-/* Messages are aligned to alignment required by cbprintf package. */
-#define Z_LOG_MSG2_ALIGNMENT CBPRINTF_PACKAGE_ALIGNMENT
 
 #define Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt) \
 	(CBPRINTF_PACKAGE_FIRST_RO_STR_CNT(_cstr_cnt) | \
@@ -187,10 +190,10 @@ enum z_log_msg2_mode {
 #endif /* Z_LOG_MSG2_USE_VLA */
 
 #define Z_LOG_MSG2_ALIGN_OFFSET \
-	sizeof(struct log_msg2_hdr)
+	offsetof(struct log_msg2, data)
 
 #define Z_LOG_MSG2_LEN(pkg_len, data_len) \
-	(sizeof(struct log_msg2_hdr) + pkg_len + (data_len))
+	(offsetof(struct log_msg2, data) + pkg_len + (data_len))
 
 #define Z_LOG_MSG2_ALIGNED_WLEN(pkg_len, data_len) \
 	ceiling_fraction(ROUND_UP(Z_LOG_MSG2_LEN(pkg_len, data_len), \

--- a/tests/subsys/logging/log_msg2/src/main.c
+++ b/tests/subsys/logging/log_msg2/src/main.c
@@ -361,7 +361,7 @@ void test_mode_size_plain_string(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) +
+	exp_len = offsetof(struct log_msg2, data) +
 			 /* package */2 * sizeof(const char *);
 
 	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
@@ -392,7 +392,7 @@ void test_mode_size_data_only(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) + sizeof(data);
+	exp_len = offsetof(struct log_msg2, data) + sizeof(data);
 	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
 	get_msg_validate_length(exp_len);
 }
@@ -420,7 +420,7 @@ void test_mode_size_plain_str_data(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) + sizeof(data) +
+	exp_len = offsetof(struct log_msg2, data) + sizeof(data) +
 		  /* package */2 * sizeof(char *);
 	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
 	get_msg_validate_length(exp_len);
@@ -454,7 +454,7 @@ void test_mode_size_str_with_strings(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) +
+	exp_len = offsetof(struct log_msg2, data) +
 			 /* package */3 * sizeof(const char *);
 	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
 
@@ -495,7 +495,7 @@ void test_mode_size_str_with_2strings(void)
 	 *
 	 * Message size is rounded up to the required alignment.
 	 */
-	exp_len = sizeof(struct log_msg2_hdr) +
+	exp_len = offsetof(struct log_msg2, data) +
 			 /* package */4 * sizeof(const char *) + 2 + strlen(sufix);
 
 	exp_len = ROUND_UP(exp_len, Z_LOG_MSG2_ALIGNMENT) / sizeof(int);
@@ -516,7 +516,7 @@ void test_saturate(void)
 	}
 
 	uint32_t exp_len =
-		ROUND_UP(sizeof(struct log_msg2_hdr) + 2 * sizeof(void *),
+		ROUND_UP(offsetof(struct log_msg2, data) + 2 * sizeof(void *),
 			 Z_LOG_MSG2_ALIGNMENT);
 	uint32_t exp_capacity = (CONFIG_LOG_BUFFER_SIZE - 1) / exp_len;
 	int mode;


### PR DESCRIPTION
Fix alignment fo the cbprintf package withing the log message.
Aligning tests to pass.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>