### PR TITLE
Bluetooth: host: Fix crash in bt_l2cap_chan_recv_complete

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -2246,7 +2246,6 @@ int bt_l2cap_chan_recv_complete(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
 	struct bt_l2cap_le_chan *le_chan = BT_L2CAP_LE_CHAN(chan);
 	struct bt_conn *conn = chan->conn;
-	uint16_t credits;
 
 	__ASSERT_NO_MSG(chan);
 	__ASSERT_NO_MSG(buf);
@@ -2261,10 +2260,14 @@ int bt_l2cap_chan_recv_complete(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 	BT_DBG("chan %p buf %p", chan, buf);
 
-	/* Restore credits used by packet */
-	memcpy(&credits, net_buf_user_data(buf), sizeof(credits));
+	if (bt_l2cap_chan_get_state(&le_chan->chan) == BT_L2CAP_CONNECTED) {
+		uint16_t credits;
 
-	l2cap_chan_send_credits(le_chan, buf, credits);
+		/* Restore credits used by packet */
+		memcpy(&credits, net_buf_user_data(buf), sizeof(credits));
+
+		l2cap_chan_send_credits(le_chan, buf, credits);
+	}
 
 	net_buf_unref(buf);
 


### PR DESCRIPTION
It is possible that LE CoC channel is in disconnecting state (eg due
to peer sending too many packets) but application is not yet aware
of this (ie disconnected callback was not called) and thus may call
bt_l2cap_chan_recv_complete() to return credits. In this case it
leads to assert in l2cap_chan_send_credits.

It looks like PTS 8.2.1 is able to trigger this scenario when
executing L2CAP/ECFC/BI-02-C test.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>