### PR TITLE
net: lwm2m: Makes OMA TLV content fmt conditional

### DIFF
--- a/subsys/net/lib/lwm2m/CMakeLists.txt
+++ b/subsys/net/lib/lwm2m/CMakeLists.txt
@@ -11,7 +11,6 @@ zephyr_library_sources(
     lwm2m_obj_device.c
     lwm2m_rw_link_format.c
     lwm2m_rw_plain_text.c
-    lwm2m_rw_oma_tlv.c
     lwm2m_util.c
     )
 
@@ -44,6 +43,10 @@ zephyr_library_sources_ifdef(CONFIG_LWM2M_PORTFOLIO_OBJ_SUPPORT
     lwm2m_obj_portfolio.c
     )
 
+# TLV Support
+zephyr_library_sources_ifdef(CONFIG_LWM2M_RW_OMA_TLV_SUPPORT
+    lwm2m_rw_oma_tlv.c
+    )
 # JSON Support
 zephyr_library_sources_ifdef(CONFIG_LWM2M_RW_JSON_SUPPORT
     lwm2m_rw_json.c

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -25,6 +25,7 @@ choice
 
 config LWM2M_VERSION_1_0
 	bool "LwM2M version 1.0"
+	imply LWM2M_RW_OMA_TLV_SUPPORT
 
 config LWM2M_VERSION_1_1
 	bool "LwM2M version 1.1 [EXPERIMENTAL]"
@@ -401,6 +402,11 @@ config LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR
 	depends on LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT
 	help
 	  Network address of the CoAP proxy server.
+
+config LWM2M_RW_OMA_TLV_SUPPORT
+	bool "TLV data format"
+	help
+	  Include support for write / parse TLV data
 
 config LWM2M_RW_JSON_SUPPORT
 	bool "support for JSON writer"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -1582,10 +1582,12 @@ static int select_writer(struct lwm2m_output_context *out, uint16_t accept)
 		out->writer = &plain_text_writer;
 		break;
 
+#ifdef CONFIG_LWM2M_RW_OMA_TLV_SUPPORT
 	case LWM2M_FORMAT_OMA_TLV:
 	case LWM2M_FORMAT_OMA_OLD_TLV:
 		out->writer = &oma_tlv_writer;
 		break;
+#endif
 
 #ifdef CONFIG_LWM2M_RW_JSON_SUPPORT
 	case LWM2M_FORMAT_OMA_JSON:
@@ -1619,10 +1621,12 @@ static int select_reader(struct lwm2m_input_context *in, uint16_t format)
 		in->reader = &plain_text_reader;
 		break;
 
+#ifdef CONFIG_LWM2M_RW_OMA_TLV_SUPPORT
 	case LWM2M_FORMAT_OMA_TLV:
 	case LWM2M_FORMAT_OMA_OLD_TLV:
 		in->reader = &oma_tlv_reader;
 		break;
+#endif
 
 #ifdef CONFIG_LWM2M_RW_JSON_SUPPORT
 	case LWM2M_FORMAT_OMA_JSON:
@@ -3684,9 +3688,11 @@ static int do_read_op(struct lwm2m_message *msg, uint16_t content_format)
 	case LWM2M_FORMAT_OMA_PLAIN_TEXT:
 		return do_read_op_plain_text(msg, content_format);
 
+#if defined(CONFIG_LWM2M_RW_OMA_TLV_SUPPORT)
 	case LWM2M_FORMAT_OMA_TLV:
 	case LWM2M_FORMAT_OMA_OLD_TLV:
 		return do_read_op_tlv(msg, content_format);
+#endif
 
 #if defined(CONFIG_LWM2M_RW_JSON_SUPPORT)
 	case LWM2M_FORMAT_OMA_JSON:
@@ -4228,9 +4234,11 @@ static int do_write_op(struct lwm2m_message *msg,
 	case LWM2M_FORMAT_OMA_PLAIN_TEXT:
 		return do_write_op_plain_text(msg);
 
+#ifdef CONFIG_LWM2M_RW_OMA_TLV_SUPPORT
 	case LWM2M_FORMAT_OMA_TLV:
 	case LWM2M_FORMAT_OMA_OLD_TLV:
 		return do_write_op_tlv(msg);
+#endif
 
 #ifdef CONFIG_LWM2M_RW_JSON_SUPPORT
 	case LWM2M_FORMAT_OMA_JSON:
@@ -4423,10 +4431,14 @@ static int lwm2m_engine_default_content_format(uint16_t *accept_format)
 			LOG_ERR("SenML CBOR or JSON is not supported");
 			return -ENOTSUP;
 		}
-	} else {
+	} else if (IS_ENABLED(CONFIG_LWM2M_RW_OMA_TLV_SUPPORT)) {
 		LOG_DBG("No accept option given. Assume OMA TLV.");
 		*accept_format = LWM2M_FORMAT_OMA_TLV;
+	} else {
+		LOG_ERR("No default content format is set");
+		return -ENOTSUP;
 	}
+
 	return 0;
 }
 


### PR DESCRIPTION
With LwM2M v1.1 usage of the OMA TLV content format is discouraged.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>