### PR TITLE
drivers: display: st7735r: Add rgb-is-inverted property

### DIFF
--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -51,6 +51,7 @@ struct st7735r_config {
 	uint8_t gamctrp1[16];
 	uint8_t gamctrn1[16];
 	bool inversion_on;
+	bool rgb_is_inverted;
 };
 
 struct st7735r_data {
@@ -269,7 +270,16 @@ static void st7735r_get_capabilities(const struct device *dev,
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->width;
 	capabilities->y_resolution = config->height;
-	if (config->madctl & ST7735R_MADCTL_BGR) {
+
+	/*
+	 * Invert the pixel format if rgb_is_inverted is enabled.
+	 * Report pixel format as the same format set in the MADCTL
+	 * if disabling the rgb_is_inverted option.
+	 * Or not so, reporting pixel format as RGB if MADCTL setting
+	 * is BGR. And also vice versa.
+	 * It is a workaround for supporting buggy modules that display RGB as BGR.
+	 */
+	if (!(config->madctl & ST7735R_MADCTL_BGR) != !config->rgb_is_inverted) {
 		capabilities->supported_pixel_formats = PIXEL_FORMAT_BGR_565;
 		capabilities->current_pixel_format = PIXEL_FORMAT_BGR_565;
 	} else {
@@ -551,6 +561,7 @@ static const struct display_driver_api st7735r_api = {
 		.gamctrp1 = DT_INST_PROP(inst, gamctrp1),			\
 		.gamctrn1 = DT_INST_PROP(inst, gamctrn1),			\
 		.inversion_on = DT_INST_PROP(inst, inversion_on),		\
+		.rgb_is_inverted = DT_INST_PROP(inst, rgb_is_inverted),		\
 	};									\
 										\
 	static struct st7735r_data st7735r_data_ ## inst = {			\

--- a/dts/bindings/display/sitronix,st7735r.yaml
+++ b/dts/bindings/display/sitronix,st7735r.yaml
@@ -123,3 +123,12 @@ properties:
       description: |
         Enable Display Inversion
         Make a drawing with the inverted color of the frame memory.
+
+    rgb-is-inverted:
+      type: boolean
+      description: |
+        Inverting color format order (RGB->BGR or BGR->RGB)
+        In the case of enabling this option, API reports pixel-format in capabilities
+        as the inverted value of the RGB pixel-format specified in MADCTL.
+        This option is convenient for supporting displays with bugs
+        where the actual color is different from the pixel format of MADCTL.


### PR DESCRIPTION
Purpose
----------------------------------

This patch intends to support Longan Nano's built-in LCD module that uses ST7735S. (Adding workaround for  Longan Nano built-in LCD module's bug.)
(#44796 is PR to support Longan Nano's built-in LCD module, the PR is depends to this) 

Problem
---------------

Longan-Nano LCD module has an ST7735S controller that can drive with the ST7735R driver.
This LED module seems to be inverted pixel format between the MADCTL setting and the actual displaying color.

If pixel-format setting as RGB in MADCTL settings,
This driver 0xF100 displays as RED, 0x01F displays as GREEN in the usual case.
But this module is not so.
0xF100 displays as GREEN, 0x01F displays as RED.


I created a pattern for color confirmation with such a code and confirmed the actual display of Longan Nano. 

```
        for(int xx=0; xx<16; xx++) {
                uint16_t* buf16 = (uint16_t*)buf;
                for(int j=0; j<capabilities.x_resolution/16*capabilities.y_resolution; j++) {
                        uint16_t col = (1U << xx);
                        *buf16++ = (col&0xFF) << 8 | (col&0xFF00)>>8;
                }
                display_write(display_dev, (capabilities.x_resolution/16)*(15-xx), 0, &buf_desc, buf);
        }
```
We can see the bit and the corresponding color in this pattern.

MADCTL is 112 (order is RGB)

![IMG-3592](https://user-images.githubusercontent.com/458281/163408800-01af29bd-ea99-4855-8d2e-78ac8ca77fbc.jpg)

the pixel format is 🟦🟦🟦🟦🟦🟩🟩🟩🟩🟩🟩🟥🟥🟥🟥🟥

(white square indicate (0,0))

MADCTL is 120 (order is BGR)

![IMG-3591](https://user-images.githubusercontent.com/458281/163408835-31933848-6c34-42c0-8aef-83abd30722fa.jpg)

the pixel format is 🟥🟥🟥🟥🟥🟩🟩🟩🟩🟩🟩🟦🟦🟦🟦🟦

The pixel format settings of the controller and the actual display are mismatched.


This behavior was observed in some samples from the module vendor.

In https://github.com/sipeed/Longan_GD32VF_examples case,

https://github.com/sipeed/Longan_GD32VF_examples/blob/7fe21406e73dbe49e9aa3c5a9cd24a44af3b5f41/gd32v_lcd/src/lcd/lcd.c#L330-L334
```
	LCD_WR_REG(0x36);
	if(USE_HORIZONTAL==0)LCD_WR_DATA8(0x08);
	else if(USE_HORIZONTAL==1)LCD_WR_DATA8(0xC8);
	else if(USE_HORIZONTAL==2)LCD_WR_DATA8(0x78);
	else LCD_WR_DATA8(0xA8);
```

Set 0x8(BGR) to MADCTL,

https://github.com/sipeed/Longan_GD32VF_examples/blob/7fe21406e73dbe49e9aa3c5a9cd24a44af3b5f41/gd32v_lcd/include/lcd/lcd.h#L117
```
#define RED           	 0xF800
```
But RED is define in RGB in format.



(I'm guessing there's a problem connecting the st7735 controller to the LCD panel.)

Of course, the MADCTL setting can swap RGB/BGR setting,
But that cannot solve all problem.

display_get_capabilities() API can retreive Display's pixel format.

ST7735R driver reports pixel-format of itself from MADCTL(36h) register.

Pixel-format that retrieve from display_get_capabilities() is same as MADCTL setting. That is different from the actual display pixel format in the Longan Nano LCD module's case.

As a result, correctly implemented applications that use display_get_capabilities() API will not display the correct color.
(such as samples/drivers/display.)


Workaround
------------------------

The problem is "Mismatching between reported pixel-format from display_get_capabilities() API and actual pixel-format for displaying."

Inverting pixel-format (swap RGB/BGR setting from MADCTL's register)  reported from display_get_capabilities() API can solve this mismatching.
(The primary problem is on the module side. But no way to fix MADCTL set pixel format and actual display color. It may be possible even if disassembling and rewiring the module.)

Typical LCD module behavior using ST7735R:

|Color data   | Reported pixel-format from display_get_capabilities()      | pixel-format set in MADCTL register        | Displayed color |
|-------------|----------------------|---------------|---------------------|
|0xF800       | PIXEL_FORMAT_RGB_565 | RGB           | RED                 | 
|0x07E0       | PIXEL_FORMAT_RGB_565 | RGB           | GREEN               | 
|0x001F       | PIXEL_FORMAT_RGB_565 | RGB           | BLUE                | 
|0xF800       | PIXEL_FORMAT_BGR_565 | BGR           | BLUE                | 
|0x07E0       | PIXEL_FORMAT_BGR_565 | BGR           | GREEN               | 
|0x001F       | PIXEL_FORMAT_BGR_565 | BGR           | RED                 | 


Longan Nano built-in LCD behavior:

|Color data   | Reported pixel-format from display_get_capabilities()      | pixel-format set in MADCTL register        | Displayed color |
|-------------|----------------------|---------------|---------------------|
|0xF800       | PIXEL_FORMAT_RGB_565 | RGB           | BLUE               | 
|0x07E0       | PIXEL_FORMAT_RGB_565 | RGB           | GREEN              | 
|0x001F       | PIXEL_FORMAT_RGB_565 | RGB           | RED                | 
|0xF800       | PIXEL_FORMAT_BGR_565 | BGR           | RED                | 
|0x07E0       | PIXEL_FORMAT_BGR_565 | BGR           | GREEN              | 
|0x001F       | PIXEL_FORMAT_BGR_565 | BGR           | BLUE               | 


workaround (Swap the RGB/BGR of the MADCTL registers and report them as capabilities):

|Color data   | Reported pixel-format from display_get_capabilities()      | pixel-format set in MADCTL register        | Displayed color |
|-------------|----------------------|---------------|---------------------|
|0xF800       | PIXEL_FORMAT_BGR_565 | RGB           | BLUE               | 
|0x07E0       | PIXEL_FORMAT_BGR_565 | RGB           | GREEN              | 
|0x001F       | PIXEL_FORMAT_BGR_565 | RGB           | RED                | 
|0xF800       | PIXEL_FORMAT_RGB_565 | BGR           | RED                | 
|0x07E0       | PIXEL_FORMAT_RGB_565 | BGR           | GREEN              | 
|0x001F       | PIXEL_FORMAT_RGB_565 | BGR           | BLUE               | 

