### PR TITLE
templates: nomination: Fix 'TSC Project Roles' link

### DIFF
--- a/.github/ISSUE_TEMPLATE/nomination.md
+++ b/.github/ISSUE_TEMPLATE/nomination.md
@@ -37,5 +37,5 @@ reviewed by the GitHub user that demonstrate the user's dedication to the
 Zephyr project.
 
 
-[TSC Project Roles]: <https://docs.zephyrproject.org/latest/development_process/project_roles.html#tsc-project-roles>
+[TSC Project Roles]: <https://docs.zephyrproject.org/latest/project/project_roles.html>
 [GitHub Permission Level]: <https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization>


### PR DESCRIPTION
This commit fixes the broken 'TSC Project Roles' link URL, which has
been recently changed with the documentation structure overhaul.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>