### PR TITLE
twister: add option to disable Ztest suite name check

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -429,6 +429,7 @@ class Handler:
         self.set_state("running", self.duration)
         self.generator = None
         self.generator_cmd = None
+        self.suite_name_check = True
 
         self.args = []
         self.terminated = False
@@ -525,8 +526,9 @@ class Handler:
     def _final_handle_actions(self, harness, handler_time):
         self._set_skip_reason(harness.state)
 
+        # only for Ztest tests:
         harness_class_name = type(harness).__name__
-        if harness_class_name == "Test":  # only for ZTest tests
+        if self.suite_name_check and harness_class_name == "Test":
             self._verify_ztest_suite_name(harness.state, harness.detected_suite_names, handler_time)
 
         self.record(harness)
@@ -2523,6 +2525,7 @@ class ProjectBuilder(FilterBuilder):
         self.verbose = kwargs.get('verbose', None)
         self.warnings_as_errors = kwargs.get('warnings_as_errors', True)
         self.overflow_as_errors = kwargs.get('overflow_as_errors', False)
+        self.suite_name_check = kwargs.get('suite_name_check', True)
 
     @staticmethod
     def log_info(filename, inline_logs):
@@ -2614,6 +2617,7 @@ class ProjectBuilder(FilterBuilder):
             instance.handler.args = args
             instance.handler.generator_cmd = self.generator_cmd
             instance.handler.generator = self.generator
+            instance.handler.suite_name_check = self.suite_name_check
 
     def process(self, pipeline, done, message, lock, results):
         op = message.get('op')
@@ -2987,6 +2991,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         self.overflow_as_errors = False
         self.quarantine_verify = False
         self.retry_build_errors = False
+        self.suite_name_check = True
 
         # Keep track of which test cases we've filtered out and why
         self.testcases = {}
@@ -3699,7 +3704,8 @@ class TestSuite(DisablePyTestCollectionMixin):
                                     generator_cmd=self.generator_cmd,
                                     verbose=self.verbose,
                                     warnings_as_errors=self.warnings_as_errors,
-                                    overflow_as_errors=self.overflow_as_errors
+                                    overflow_as_errors=self.overflow_as_errors,
+                                    suite_name_check=self.suite_name_check
                                     )
                 pb.process(pipeline, done_queue, task, lock, results)
 

--- a/scripts/twister
+++ b/scripts/twister
@@ -475,6 +475,12 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         default=False,
         help="Skip the 'unrecognized section' test.")
 
+    parser.add_argument(
+        "--disable-suite-name-check", action="store_true", default=False,
+        help="Disable extended test suite name verification at the beginning "
+             "of Ztest test. This option could be useful for tests or "
+             "platforms, which from some reasons cannot print early logs.")
+
     parser.add_argument("-e", "--exclude-tag", action="append",
                         help="Specify tags of tests that should not run. "
                              "Default is to run all tests with all tags.")
@@ -945,6 +951,7 @@ def main():
     suite.warnings_as_errors = not options.disable_warnings_as_errors
     suite.integration = options.integration
     suite.overflow_as_errors = options.overflow_as_errors
+    suite.suite_name_check = not options.disable_suite_name_check
 
     if options.ninja:
         suite.generator_cmd = "ninja"


### PR DESCRIPTION
If from some reasons, test or platform are not able to provide full logs (especially those from the beginning), then test suite name verification could be removed from Twister test runner by add argument to Twister's call:
```
./scripts/twister -v --device-testing --device-serial /dev/ttyACM0 -p nrf52840dk_nrf52840 -T tests/arch/arm --disable-suite-name-check
```

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>