### PR TITLE
tracing: misc fixes to test format and backend choices

### DIFF
--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -160,6 +160,7 @@ config TRACING_BACKEND_RAM
 	  Use a ram buffer to output tracing data which can
 	  be dumped to a file at runtime with a debugger.
 	  See gdb dump binary memory documentation for example.
+endchoice
 
 config RAM_TRACING_BUFFER_SIZE
 	int "Ram Tracing buffer size"
@@ -169,7 +170,6 @@ config RAM_TRACING_BUFFER_SIZE
 	  Size of the RAM trace buffer. Trace will be discarded if the
 	  length is exceeded.
 
-endchoice
 
 config TRACING_BACKEND_UART_NAME
 	string "Device Name of UART Device for UART backend"

--- a/subsys/tracing/test/tracing_string_format_test.c
+++ b/subsys/tracing/test/tracing_string_format_test.c
@@ -512,3 +512,13 @@ void sys_trace_syscall_exit(uint32_t syscall_id, const char *syscall_name)
 {
 	TRACING_STRING("%s: %s (%u) exit\n", __func__, syscall_name, syscall_id);
 }
+
+void sys_trace_k_thread_foreach_unlocked_enter(k_thread_user_cb_t user_cb, void *data)
+{
+	TRACING_STRING("%s: %p (%p) enter\n", __func__, user_cb, data);
+}
+
+void sys_trace_k_thread_foreach_unlocked_exit(k_thread_user_cb_t user_cb, void *data)
+{
+	TRACING_STRING("%s: %p (%p) exit\n", __func__, user_cb, data);
+}


### PR DESCRIPTION
- tracing: add missing macros needed for k_thread_foreach
- tracing: kconfig: move RAM_TRACING_BUFFER_SIZE out of choice
