### PR TITLE
edac: ibecc: Add support for EHL SKU13, SKU14, SKU15

### DIFF
--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -307,6 +307,12 @@ static int edac_ibecc_init(const struct device *dev)
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU11):
 		__fallthrough;
 	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU12):
+		__fallthrough;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU13):
+		__fallthrough;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU14):
+		__fallthrough;
+	case PCIE_ID(PCI_VENDOR_ID_INTEL, PCI_DEVICE_ID_SKU15):
 		break;
 	default:
 		LOG_ERR("PCI Probe failed"); /* LCOV_EXCL_BR_LINE */

--- a/drivers/edac/ibecc.h
+++ b/drivers/edac/ibecc.h
@@ -21,6 +21,9 @@
 #define PCI_DEVICE_ID_SKU10	0x452e
 #define PCI_DEVICE_ID_SKU11	0x4532
 #define PCI_DEVICE_ID_SKU12	0x4518
+#define PCI_DEVICE_ID_SKU13	0x451a
+#define PCI_DEVICE_ID_SKU14	0x4534
+#define PCI_DEVICE_ID_SKU15	0x4536
 
 /* TODO: Move to correct place NMI registers */
 


### PR DESCRIPTION
Add support for missing EHL SKUs. The information about SKUs is
already public and available in Linux kernel:

https://github.com/torvalds/linux/blob/38f80f42147ff658aff218edb0a88c37e58bf44f/drivers/edac/igen6_edac.c#L197-L208