### PR TITLE
Fixed microbit v2 lsm303agr irq pin

### DIFF
--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -132,7 +132,7 @@
 		status = "okay";
 		reg = <0x1e>;
 		label = "LSM303AGR-MAGN";
-		irq-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;	/* A3 */
+		irq-gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 
 	lsm303agr-accel@19 {
@@ -140,7 +140,7 @@
 		status = "okay";
 		reg = <0x19>;
 		label = "LSM303AGR-ACCEL";
-		irq-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+		irq-gpios = <&gpio0 25 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };
 


### PR DESCRIPTION
As you can see here, the NOR gate on the Motion Sensor is active low [https://github.com/microbit-foundation/microbit-v2-hardware/blob/main/V2/MicroBit_V2.0.0_S_schematic.PDF].

Fixes: #44622