### PR TITLE
coredump: Add callee registers to arm arch block

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/coredump.c
+++ b/arch/arm/core/aarch32/cortex_m/coredump.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <debug/coredump.h>
 
-#define ARCH_HDR_VER			1
+#define ARCH_HDR_VER			2
 
 uint32_t z_arm_coredump_fault_sp;
 
@@ -22,6 +22,16 @@ struct arm_arch_block {
 		uint32_t	pc;
 		uint32_t	xpsr;
 		uint32_t	sp;
+
+		/* callee registers - optionally collected in V2 */
+		uint32_t	r4;
+		uint32_t	r5;
+		uint32_t	r6;
+		uint32_t	r7;
+		uint32_t	r8;
+		uint32_t	r9;
+		uint32_t	r10;
+		uint32_t	r11;
 	} r;
 } __packed;
 
@@ -63,6 +73,19 @@ void arch_coredump_info_dump(const z_arch_esf_t *esf)
 	arch_blk.r.xpsr = esf->basic.xpsr;
 
 	arch_blk.r.sp = z_arm_coredump_fault_sp;
+
+#if defined(CONFIG_EXTRA_EXCEPTION_INFO)
+	if (esf->extra_info.callee) {
+		arch_blk.r.r4  = esf->extra_info.callee->v1;
+		arch_blk.r.r5  = esf->extra_info.callee->v2;
+		arch_blk.r.r6  = esf->extra_info.callee->v3;
+		arch_blk.r.r7  = esf->extra_info.callee->v4;
+		arch_blk.r.r8  = esf->extra_info.callee->v5;
+		arch_blk.r.r9  = esf->extra_info.callee->v6;
+		arch_blk.r.r10 = esf->extra_info.callee->v7;
+		arch_blk.r.r11 = esf->extra_info.callee->v8;
+	}
+#endif
 
 	/* Send for output */
 	coredump_buffer_output((uint8_t *)&hdr, sizeof(hdr));

--- a/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
+++ b/scripts/coredump/gdbstubs/arch/arm_cortex_m.py
@@ -35,7 +35,8 @@ class RegNum():
 
 
 class GdbStub_ARM_CortexM(GdbStub):
-    ARCH_DATA_BLK_STRUCT = "<IIIIIIIII"
+    ARCH_DATA_BLK_STRUCT    = "<IIIIIIIII"
+    ARCH_DATA_BLK_STRUCT_V2 = "<IIIIIIIIIIIIIIIII"
 
     GDB_SIGNAL_DEFAULT = 7
 
@@ -50,7 +51,12 @@ class GdbStub_ARM_CortexM(GdbStub):
 
     def parse_arch_data_block(self):
         arch_data_blk = self.logfile.get_arch_data()['data']
-        tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT, arch_data_blk)
+        arch_data_ver = self.logfile.get_arch_data()['hdr_ver']
+
+        if arch_data_ver == 1:
+            tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT, arch_data_blk)
+        elif arch_data_ver == 2:
+            tu = struct.unpack(self.ARCH_DATA_BLK_STRUCT_V2, arch_data_blk)
 
         self.registers = dict()
 
@@ -63,6 +69,16 @@ class GdbStub_ARM_CortexM(GdbStub):
         self.registers[RegNum.PC] = tu[6]
         self.registers[RegNum.XPSR] = tu[7]
         self.registers[RegNum.SP] = tu[8]
+
+        if arch_data_ver > 1:
+            self.registers[RegNum.R4]  = tu[9]
+            self.registers[RegNum.R5]  = tu[10]
+            self.registers[RegNum.R6]  = tu[11]
+            self.registers[RegNum.R7]  = tu[12]
+            self.registers[RegNum.R8]  = tu[13]
+            self.registers[RegNum.R9]  = tu[14]
+            self.registers[RegNum.R10] = tu[15]
+            self.registers[RegNum.R11] = tu[16]
 
     def handle_register_group_read_packet(self):
         reg_fmt = "<I"


### PR DESCRIPTION
Add version 2 to coredump arm_arch_block
which includes callee registers

Signed-off-by: Mark Holden <mholden@fb.com>