### PR TITLE
Bluetooth: Controller: lll: Add missing CTEInfo copy if conn encrypted

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -268,6 +268,20 @@ void lll_conn_isr_rx(void *param)
 		is_done = (crc_expire == 0U);
 	}
 
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX) && defined(CONFIG_BT_CTLR_LE_ENC)
+		if (lll->enc_rx) {
+			struct pdu_data *pdu_scratch;
+
+			pdu_scratch = (struct pdu_data *)radio_pkt_scratch_get();
+
+			if (pdu_scratch->cp) {
+				(void)memcpy((void *)&pdu_data_rx->cte_info,
+					     (void *)&pdu_scratch->cte_info,
+					     sizeof(pdu_data_rx->cte_info));
+			}
+		}
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX && defined(CONFIG_BT_CTLR_LE_ENC) */
+
 	/* prepare tx packet */
 	is_empty_pdu_tx_retry = lll->empty;
 	lll_conn_pdu_tx_prep(lll, &pdu_data_tx);
@@ -397,7 +411,6 @@ lll_conn_isr_rx_exit:
 #elif !defined(HAL_RADIO_PDU_LEN_MAX)
 #error "Undefined HAL_RADIO_PDU_LEN_MAX."
 #endif
-
 		ull_pdu_rx_alloc();
 
 		node_rx->hdr.type = NODE_RX_TYPE_DC_PDU;


### PR DESCRIPTION
In case a connection is encrypted received PDU is decrypted by CCM.
CCM does not encrypt/decrypt S1 byte that stores CTEInfo.
In case of reception of a PDU by encrypted connection there is missing
CTEInfo in a memory where CCM stores decrypted PDU.
The CTEInfo data must be copied from scratch packet.

The commit adds code responsible for copying of the CTEInfo into
target PDU memory.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>