### PR TITLE
 mgmt/mcumgr/lib: Add missing inclusion of toolchain.h 

### DIFF
--- a/subsys/mgmt/mcumgr/lib/util/include/zcbor_bulk/zcbor_bulk_priv.h
+++ b/subsys/mgmt/mcumgr/lib/util/include/zcbor_bulk/zcbor_bulk_priv.h
@@ -10,6 +10,8 @@
 extern "C" {
 #endif
 
+#include <toolchain.h>
+
 /** @cond INTERNAL_HIDDEN */
 
 struct zcbor_map_decode_key_val {


### PR DESCRIPTION
The zcbor_bulk_priv.h uses STRINGIFY for some of definitions
and, due to lack of inclusion of the toolchain.h, that was causing
compilation errors when NEWLIB would be selected.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44811.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>