### PR TITLE
Bluetooth: Mesh: Config Client timeout setting

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -769,10 +769,34 @@ config BT_MESH_CFG_CLI
 	help
 	  Enable support for the configuration client model.
 
+if BT_MESH_CFG_CLI
+
+config BT_MESH_CFG_CLI_TIMEOUT
+	int "Config Client model timeout in milliseconds"
+	default 5000
+	help
+	  This timeout controls how long config client waits for a response
+	  message to arrive. This value can be changed at runtime using
+	  @ref bt_mesh_cfg_cli_timeout_set.
+
+endif # BT_MESH_CFG_CLI
+
 config BT_MESH_HEALTH_CLI
 	bool "Support for Health Client Model"
 	help
 	  Enable support for the health client model.
+
+if BT_MESH_HEALTH_CLI
+
+config BT_MESH_HEALTH_CLI_TIMEOUT
+	int "Health Client model timeout in milliseconds"
+	default 2000
+	help
+	  This timeout controls how long health client waits for a response
+	  message to arrive. This value can be changed at runtime using
+	  @ref bt_mesh_health_cli_timeout_set.
+
+endif # BT_MESH_HEALTH_CLI
 
 config BT_MESH_SHELL
 	bool "Bluetooth mesh shell"

--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -895,7 +895,7 @@ static int cfg_cli_init(struct bt_mesh_model *model)
 
 	cli = model->user_data;
 	cli->model = model;
-	msg_timeout = 2 * MSEC_PER_SEC;
+	msg_timeout = CONFIG_BT_MESH_CFG_CLI_TIMEOUT;
 
 	/*
 	 * Configuration Model security is device-key based and both the local

--- a/subsys/bluetooth/mesh/health_cli.c
+++ b/subsys/bluetooth/mesh/health_cli.c
@@ -601,7 +601,7 @@ int bt_mesh_health_cli_set(struct bt_mesh_model *model)
 	}
 
 	health_cli = model->user_data;
-	msg_timeout = 2 * MSEC_PER_SEC;
+	msg_timeout = CONFIG_BT_MESH_HEALTH_CLI_TIMEOUT;
 
 	return 0;
 }


### PR DESCRIPTION
Adds a Kconfig option for setting the Config Client timeout and
updates the default to allow reception of full sized message
from a similar peer device at zero hops.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>