### PR TITLE
OpenAMP prerequisites for NXP iMX8M Mini EVK

### DIFF
--- a/boards/arm/mimx8mm_evk/mimx8mm_evk.dts
+++ b/boards/arm/mimx8mm_evk/mimx8mm_evk.dts
@@ -28,3 +28,7 @@
 	status = "okay";
 	current-speed = <115200>;
 };
+
+&mailbox0 {
+	status = "okay";
+};

--- a/dts/arm/nxp/nxp_imx8m_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx8m_m4.dtsi
@@ -173,6 +173,18 @@
 			label = "UART_4";
 			status = "disabled";
 		};
+
+		mailbox0: mailbox@30ab0000 {
+			compatible = "nxp,imx-mu";
+			reg = <0x30ab0000 DT_SIZE_K(64)>;
+			interrupts = <97 0>;
+			label = "MAILBOX_0";
+			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW)|\
+			       RDC_DOMAIN_PERM(M4_DOMAIN_ID,\
+					       RDC_DOMAIN_PERM_RW))>;
+			status = "disabled";
+		};
 	};
 };
 

--- a/soc/arm/nxp_imx/mimx8mm6_m4/CMakeLists.txt
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/CMakeLists.txt
@@ -7,3 +7,8 @@
 zephyr_sources(
   soc.c
   )
+
+if(CONFIG_OPENAMP_RSC_TABLE)
+  zephyr_linker_section(NAME .resource_table GROUP ROM_REGION NOINPUT)
+  zephyr_linker_section_configure(SECTION .resource_table KEEP INPUT ".resource_table*")
+endif()

--- a/soc/arm/nxp_imx/mimx8mm6_m4/Kconfig.defconfig.mimx8mm6_m4
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/Kconfig.defconfig.mimx8mm6_m4
@@ -41,4 +41,8 @@ config GPIO_MCUX_IGPIO
 
 endif # GPIO
 
+config IPM_IMX_REV2
+	default y
+	depends on IPM
+
 endif # SOC_MIMX8MM6

--- a/soc/arm/nxp_imx/mimx8mm6_m4/linker.ld
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/linker.ld
@@ -5,3 +5,13 @@
  */
 
 #include <arch/arm/aarch32/cortex_m/scripts/linker.ld>
+
+SECTIONS
+     {
+#ifdef CONFIG_OPENAMP_RSC_TABLE
+        SECTION_PROLOGUE(.resource_table,, SUBALIGN(4))
+        {
+            KEEP(*(.resource_table*))
+        } GROUP_LINK_IN(ROMABLE_REGION)
+#endif
+     }


### PR DESCRIPTION
- Add a resource table section to the i.MX8MM linker scripts required to include the open-amp resource table in the build output.
- Add a mailbox device tree entry for i.MX8MM and enable the driver by default.
- Activate mailbox unit for NXP i.MX8M Mini EVK.