### PR TITLE
CODEOWNERS: Remove aescolar from tests/bluetooth/bsim_bt/

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -778,8 +778,8 @@ scripts/gen_image_info.py                 @tejlmand
 /tests/boards/intel_s1000_crb/            @dcpleung @sathishkuttan
 /tests/bluetooth/                         @alwa-nordic @jhedberg @Vudentz
 /tests/bluetooth/controller/              @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc @ppryga
-/tests/bluetooth/bsim_bt/                 @alwa-nordic @jhedberg @Vudentz @aescolar @wopu-ot
-/tests/bluetooth/bsim_bt/bsim_test_audio/ @alwa-nordic @jhedberg @Vudentz @aescolar @wopu-ot @Thalley @asbjornsabo
+/tests/bluetooth/bsim_bt/                 @alwa-nordic @jhedberg @Vudentz @wopu-ot
+/tests/bluetooth/bsim_bt/bsim_test_audio/ @alwa-nordic @jhedberg @Vudentz @wopu-ot @Thalley @asbjornsabo
 /tests/bluetooth/tester/                  @alwa-nordic @jhedberg @Vudentz @sjanc
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin


### PR DESCRIPTION
Practically all changes in the last 2 years in this folder are in actual tests, and not in infrastructure.
There is no need for me to be added as reviewer to them, specially as all involved know how to ping me if needed.

Having me added as reviewer in those is just noise and can create false expectations from others.

=> Remove myself from the CODEOWNERS list for tests/bluetooth/bsim_bt/

You are of course welcome to ping me or add me manually as reviewer if a change in a test or infrastructure would benefit from my attention.