### PR TITLE
LE Audio: Broadcast audio list instead of array

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -2093,8 +2093,7 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group);
  *  (see bt_le_per_adv_sync_cb).
  *
  *  @param[in]  streams     Array of stream object pointers being used for the
- *                          broadcaster. This array shall remain valid for the
- *                          duration of the broadcast source.
+ *                          broadcaster.
  *  @param[in]  num_stream  Number of streams in @p streams.
  *  @param[in]  codec       Codec configuration.
  *  @param[in]  qos         Quality of Service configuration
@@ -2195,7 +2194,7 @@ int bt_audio_broadcast_sink_scan_stop(void);
  *  @param indexes_bitfield   Bitfield of the BIS index to sync to. To sync to
  *                            e.g. BIS index 1 and 2, this should have the value
  *                            of BIT(1) | BIT(2).
- *  @param streams            Stream objects pointers to be used for the
+ *  @param streams            Stream object pointers to be used for the
  *                            receiver. If multiple BIS indexes shall be
  *                            synchronized, multiple streams shall be provided.
  *  @param broadcast_code     The 16-octet broadcast code. Shall be supplied if

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1286,7 +1286,6 @@ struct bt_audio_stream {
 	struct bt_iso_chan *iso;
 	/** Audio stream operations */
 	struct bt_audio_stream_ops *ops;
-	sys_snode_t node;
 
 	union {
 		void *group;
@@ -1297,6 +1296,9 @@ struct bt_audio_stream {
 
 	/** Stream user data */
 	void *user_data;
+
+	/* Internally used list node */
+	sys_snode_t _node;
 };
 
 /** Unicast Server callback structure */
@@ -1606,7 +1608,7 @@ struct bt_audio_broadcast_sink_cb {
 	void (*pa_sync_lost)(struct bt_audio_broadcast_sink *sink);
 
 	/* Internally used list node */
-	sys_snode_t node;
+	sys_snode_t _node;
 };
 
 /** @brief Stream operation. */

--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -238,7 +238,9 @@ struct bt_audio_capability {
 	/** Capability operations reference */
 	struct bt_audio_capability_ops *ops;
 #endif /* CONFIG_BT_AUDIO_UNICAST_SERVER */
-	sys_snode_t node;
+
+	/* Internally used list node */
+	sys_snode_t _node;
 };
 
 /** @brief Register Audio Capability.

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -49,8 +49,6 @@ static void broadcast_sink_cleanup(struct bt_audio_broadcast_sink *sink);
 static void broadcast_sink_clear_big(struct bt_audio_broadcast_sink *sink)
 {
 	sink->big = NULL;
-	sink->stream_count = 0;
-	sink->streams = NULL;
 }
 
 static struct bt_audio_broadcast_sink *broadcast_sink_lookup_iso_chan(

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -401,7 +401,7 @@ static void broadcast_source_cleanup(struct bt_audio_broadcast_source *source)
 {
 	struct bt_audio_stream *stream, *next;
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&source->streams, stream, next, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&source->streams, stream, next, _node) {
 		stream->ep->stream = NULL;
 		stream->ep = NULL;
 		stream->codec = NULL;
@@ -409,7 +409,7 @@ static void broadcast_source_cleanup(struct bt_audio_broadcast_source *source)
 		stream->iso = NULL;
 		stream->group = NULL;
 
-		sys_slist_remove(&source->streams, NULL, &stream->node);
+		sys_slist_remove(&source->streams, NULL, &stream->_node);
 	}
 
 	(void)memset(source, 0, sizeof(*source));
@@ -499,7 +499,7 @@ int bt_audio_broadcast_source_create(struct bt_audio_stream *streams[],
 		}
 
 		source->bis[i] = &stream->ep->iso->iso_chan;
-		sys_slist_append(&source->streams, &stream->node);
+		sys_slist_append(&source->streams, &stream->_node);
 		source->stream_count++;
 	}
 
@@ -606,7 +606,7 @@ int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
 	}
 
 	head_node = sys_slist_peek_head(&source->streams);
-	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, _node);
 
 	/* All streams in a broadcast source is in the same state,
 	 * so we can just check the first stream
@@ -622,7 +622,7 @@ int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
 		return -EBADMSG;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&source->streams, stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&source->streams, stream, _node) {
 		bt_audio_stream_attach(NULL, stream, stream->ep, codec);
 	}
 
@@ -655,7 +655,7 @@ int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source)
 	}
 
 	head_node = sys_slist_peek_head(&source->streams);
-	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, _node);
 
 	if (stream->ep == NULL) {
 		BT_DBG("stream->ep is NULL");
@@ -682,7 +682,7 @@ int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source)
 		return err;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&source->streams, stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&source->streams, stream, _node) {
 		struct bt_audio_ep *ep = stream->ep;
 
 		broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_ENABLING);
@@ -708,7 +708,7 @@ int bt_audio_broadcast_source_stop(struct bt_audio_broadcast_source *source)
 	}
 
 	head_node = sys_slist_peek_head(&source->streams);
-	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, _node);
 
 	/* All streams in a broadcast source is in the same state,
 	 * so we can just check the first stream
@@ -759,7 +759,7 @@ int bt_audio_broadcast_source_delete(struct bt_audio_broadcast_source *source)
 	}
 
 	head_node = sys_slist_peek_head(&source->streams);
-	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, _node);
 
 	if (stream->ep == NULL) {
 		BT_DBG("stream->ep is NULL");

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -399,19 +399,17 @@ static int bt_audio_set_base(const struct bt_audio_broadcast_source *source,
 
 static void broadcast_source_cleanup(struct bt_audio_broadcast_source *source)
 {
-	for (size_t i = 0; i < source->stream_count; i++) {
-		struct bt_audio_stream *stream = source->streams[i];
+	struct bt_audio_stream *stream, *next;
 
-		if (stream == NULL) {
-			continue;
-		}
-
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&source->streams, stream, next, node) {
 		stream->ep->stream = NULL;
 		stream->ep = NULL;
 		stream->codec = NULL;
 		stream->qos = NULL;
 		stream->iso = NULL;
 		stream->group = NULL;
+
+		sys_slist_remove(&source->streams, NULL, &stream->node);
 	}
 
 	(void)memset(source, 0, sizeof(*source));
@@ -489,8 +487,6 @@ int bt_audio_broadcast_source_create(struct bt_audio_stream *streams[],
 		return -ENOMEM;
 	}
 
-	source->streams = streams;
-	source->stream_count = num_stream;
 	for (size_t i = 0; i < num_stream; i++) {
 		struct bt_audio_stream *stream = streams[i];
 
@@ -503,6 +499,8 @@ int bt_audio_broadcast_source_create(struct bt_audio_stream *streams[],
 		}
 
 		source->bis[i] = &stream->ep->iso->iso_chan;
+		sys_slist_append(&source->streams, &stream->node);
+		source->stream_count++;
 	}
 
 	/* Create a non-connectable non-scannable advertising set */
@@ -594,6 +592,7 @@ int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
 				       struct bt_codec_qos *qos)
 {
 	struct bt_audio_stream *stream;
+	sys_snode_t *head_node;
 	int err;
 
 	CHECKIF(source == NULL) {
@@ -601,13 +600,17 @@ int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
 		return -EINVAL;
 	}
 
-	stream = source->streams[0];
-
-	if (stream == NULL) {
-		BT_DBG("stream is NULL");
+	if (sys_slist_is_empty(&source->streams)) {
+		BT_DBG("Source does not have any streams");
 		return -EINVAL;
 	}
 
+	head_node = sys_slist_peek_head(&source->streams);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
+
+	/* All streams in a broadcast source is in the same state,
+	 * so we can just check the first stream
+	 */
 	if (stream->ep == NULL) {
 		BT_DBG("stream->ep is NULL");
 		return -EINVAL;
@@ -619,14 +622,7 @@ int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
 		return -EBADMSG;
 	}
 
-	for (size_t i = 0; i < source->stream_count; i++) {
-		stream = source->streams[i];
-
-		if (stream == NULL) {
-			BT_DBG("streams[i] is NULL");
-			return -EINVAL;
-		}
-
+	SYS_SLIST_FOR_EACH_CONTAINER(&source->streams, stream, node) {
 		bt_audio_stream_attach(NULL, stream, stream->ep, codec);
 	}
 
@@ -645,6 +641,7 @@ int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source)
 {
 	struct bt_iso_big_create_param param = { 0 };
 	struct bt_audio_stream *stream;
+	sys_snode_t *head_node;
 	int err;
 
 	CHECKIF(source == NULL) {
@@ -652,12 +649,13 @@ int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source)
 		return -EINVAL;
 	}
 
-	stream = source->streams[0];
-
-	if (stream == NULL) {
-		BT_DBG("stream is NULL");
+	if (sys_slist_is_empty(&source->streams)) {
+		BT_DBG("Source does not have any streams");
 		return -EINVAL;
 	}
+
+	head_node = sys_slist_peek_head(&source->streams);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
 
 	if (stream->ep == NULL) {
 		BT_DBG("stream->ep is NULL");
@@ -684,8 +682,8 @@ int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source)
 		return err;
 	}
 
-	for (size_t i = 0U; i < source->stream_count; i++) {
-		struct bt_audio_ep *ep = source->streams[i]->ep;
+	SYS_SLIST_FOR_EACH_CONTAINER(&source->streams, stream, node) {
+		struct bt_audio_ep *ep = stream->ep;
 
 		broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_ENABLING);
 	}
@@ -696,6 +694,7 @@ int bt_audio_broadcast_source_start(struct bt_audio_broadcast_source *source)
 int bt_audio_broadcast_source_stop(struct bt_audio_broadcast_source *source)
 {
 	struct bt_audio_stream *stream;
+	sys_snode_t *head_node;
 	int err;
 
 	CHECKIF(source == NULL) {
@@ -703,13 +702,17 @@ int bt_audio_broadcast_source_stop(struct bt_audio_broadcast_source *source)
 		return -EINVAL;
 	}
 
-	stream = source->streams[0];
-
-	if (stream == NULL) {
-		BT_DBG("stream is NULL");
+	if (sys_slist_is_empty(&source->streams)) {
+		BT_DBG("Source does not have any streams");
 		return -EINVAL;
 	}
 
+	head_node = sys_slist_peek_head(&source->streams);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
+
+	/* All streams in a broadcast source is in the same state,
+	 * so we can just check the first stream
+	 */
 	if (stream->ep == NULL) {
 		BT_DBG("stream->ep is NULL");
 		return -EINVAL;
@@ -742,6 +745,7 @@ int bt_audio_broadcast_source_delete(struct bt_audio_broadcast_source *source)
 {
 	struct bt_audio_stream *stream;
 	struct bt_le_ext_adv *adv;
+	sys_snode_t *head_node;
 	int err;
 
 	CHECKIF(source == NULL) {
@@ -749,19 +753,23 @@ int bt_audio_broadcast_source_delete(struct bt_audio_broadcast_source *source)
 		return -EINVAL;
 	}
 
-	stream = source->streams[0];
+	if (sys_slist_is_empty(&source->streams)) {
+		BT_DBG("Source does not have any streams");
+		return -EINVAL;
+	}
 
-	if (stream != NULL) {
-		if (stream->ep == NULL) {
-			BT_DBG("stream->ep is NULL");
-			return -EINVAL;
-		}
+	head_node = sys_slist_peek_head(&source->streams);
+	stream = CONTAINER_OF(head_node, struct bt_audio_stream, node);
 
-		if (stream->ep->status.state != BT_AUDIO_EP_STATE_QOS_CONFIGURED) {
-			BT_DBG("Broadcast source stream %p invalid state: %u",
-			stream, stream->ep->status.state);
-			return -EBADMSG;
-		}
+	if (stream->ep == NULL) {
+		BT_DBG("stream->ep is NULL");
+		return -EINVAL;
+	}
+
+	if (stream->ep->status.state != BT_AUDIO_EP_STATE_QOS_CONFIGURED) {
+		BT_DBG("Broadcast source stream %p invalid state: %u",
+		stream, stream->ep->status.state);
+		return -EBADMSG;
 	}
 
 	adv = source->adv;

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -55,7 +55,7 @@ static int unicast_server_config_cb(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(lst, cap, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(lst, cap, _node) {
 		/* Skip if capabilities don't match */
 		if (codec->id != cap->codec->id) {
 			continue;
@@ -109,7 +109,7 @@ static int unicast_server_reconfig_cb(struct bt_audio_stream *stream,
 		return -EINVAL;
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER(lst, cap, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(lst, cap, _node) {
 		int err;
 
 		if (codec->id != cap->codec->id) {
@@ -260,7 +260,7 @@ static int publish_capability_cb(struct bt_conn *conn, uint8_t dir,
 	}
 
 	i = 0;
-	SYS_SLIST_FOR_EACH_CONTAINER(lst, cap, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(lst, cap, _node) {
 		if (i != index) {
 			i++;
 			continue;
@@ -399,7 +399,7 @@ int bt_audio_capability_register(struct bt_audio_capability *cap)
 	}
 #endif /* CONFIG_BT_AUDIO_UNICAST_SERVER && CONFIG_BT_ASCS */
 
-	sys_slist_append(lst, &cap->node);
+	sys_slist_append(lst, &cap->_node);
 
 #if defined(CONFIG_BT_PACS)
 	bt_pacs_add_capability(cap->dir);
@@ -424,7 +424,7 @@ int bt_audio_capability_unregister(struct bt_audio_capability *cap)
 
 	BT_DBG("cap %p dir 0x%02x", cap, cap->dir);
 
-	if (!sys_slist_find_and_remove(lst, &cap->node)) {
+	if (!sys_slist_find_and_remove(lst, &cap->_node)) {
 		return -ENOENT;
 	}
 

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -81,7 +81,7 @@ struct bt_audio_broadcast_source {
 	struct bt_iso_chan *bis[BROADCAST_STREAM_CNT];
 	struct bt_codec_qos *qos;
 	/* The streams used to create the broadcast source */
-	struct bt_audio_stream **streams;
+	sys_slist_t streams;
 };
 
 struct bt_audio_broadcast_sink {

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -99,7 +99,7 @@ struct bt_audio_broadcast_sink {
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_SNK_STREAM_CNT];
 	/* The streams used to create the broadcast sink */
-	struct bt_audio_stream **streams;
+	sys_slist_t streams;
 };
 
 static inline const char *bt_audio_ep_state_str(uint8_t state)

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -410,7 +410,7 @@ static int bt_audio_cig_create(struct bt_audio_unicast_group *group,
 	BT_DBG("group %p qos %p", group, qos);
 
 	cis_count = 0;
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		if (stream->iso != NULL) {
 			bool already_added = false;
 
@@ -453,7 +453,7 @@ static int bt_audio_cig_reconfigure(struct bt_audio_unicast_group *group,
 	BT_DBG("group %p qos %p", group, qos);
 
 	cis_count = 0U;
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		group->cis[cis_count++] = stream->iso;
 	}
 
@@ -477,7 +477,7 @@ static void audio_stream_qos_cleanup(const struct bt_conn *conn,
 {
 	struct bt_audio_stream *stream;
 
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		if (stream->conn != conn && stream->ep != NULL) {
 			/* Channel not part of this ACL, skip */
 			continue;
@@ -533,13 +533,7 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 	cig_connected = false;
 
 	/* Validate streams before starting the QoS execution */
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
-		if (stream->conn != conn) {
-			/* Channel not part of this ACL, skip */
-			continue;
-		}
-		conn_stream_found = true;
-
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		if (stream->conn != conn) {
 			/* Channel not part of this ACL, skip */
 			continue;
@@ -594,7 +588,7 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 	}
 
 	/* Setup endpoints before starting the QoS execution */
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		struct bt_audio_iso *audio_iso;
 
 		if (stream->conn != conn) {
@@ -615,7 +609,7 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 
 	(void)memset(op, 0, sizeof(*op));
 	ep = NULL; /* Needed to find the control point handle */
-	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, _node) {
 		if (stream->conn != conn) {
 			/* Channel not part of this ACL, skip */
 			continue;
@@ -929,7 +923,7 @@ static void unicast_group_param_cleanup(struct bt_audio_unicast_group *group,
 					size_t num_param)
 {
 	for (size_t i = 0U; i < num_param; i++) {
-		if (!sys_slist_find_and_remove(&group->streams, &params[i].stream->node)) {
+		if (!sys_slist_find_and_remove(&group->streams, &params[i].stream->_node)) {
 			/* We can stop once `sys_slist_find_and_remove` fails as
 			 * that means that the this and the following streams
 			 * were never added to the group
@@ -1043,7 +1037,7 @@ int bt_audio_unicast_group_create(struct bt_audio_unicast_group_param params[],
 		bt_audio_codec_qos_to_iso_qos(io, params[i].qos);
 		stream->unicast_group = unicast_group;
 		stream->qos = params[i].qos;
-		sys_slist_append(group_streams, &stream->node);
+		sys_slist_append(group_streams, &stream->_node);
 
 		BT_DBG("Added stream %p to group %p", stream, unicast_group);
 	}
@@ -1110,7 +1104,7 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 	}
 
 	total_stream_cnt = num_param;
-	SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, tmp_stream, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER(&unicast_group->streams, tmp_stream, _node) {
 		total_stream_cnt++;
 	}
 
@@ -1135,7 +1129,7 @@ int bt_audio_unicast_group_add_streams(struct bt_audio_unicast_group *unicast_gr
 		struct bt_audio_stream *stream = params[i].stream;
 
 		stream->unicast_group = unicast_group;
-		sys_slist_append(group_streams, &stream->node);
+		sys_slist_append(group_streams, &stream->_node);
 
 		BT_DBG("Added stream %p to group %p", stream, unicast_group);
 	}
@@ -1171,9 +1165,9 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group)
 		}
 	}
 
-	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_group->streams, stream, tmp, node) {
+	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&unicast_group->streams, stream, tmp, _node) {
 		stream->unicast_group = NULL;
-		sys_slist_remove(&unicast_group->streams, NULL, &stream->node);
+		sys_slist_remove(&unicast_group->streams, NULL, &stream->_node);
 		bt_unicast_client_stream_unbind_audio_iso(stream);
 	}
 

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1154,7 +1154,7 @@ static int cmd_select_broadcast_source(const struct shell *sh, size_t argc,
 static int cmd_create_broadcast(const struct shell *sh, size_t argc,
 				char *argv[])
 {
-	static struct bt_audio_stream *streams[ARRAY_SIZE(broadcast_source_streams)];
+	struct bt_audio_stream *streams[ARRAY_SIZE(broadcast_source_streams)];
 	struct named_lc3_preset *named_preset;
 	int err;
 

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1295,7 +1295,7 @@ static int cmd_accept_broadcast(const struct shell *sh, size_t argc,
 
 static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 {
-	static struct bt_audio_stream *streams[ARRAY_SIZE(broadcast_sink_streams)];
+	struct bt_audio_stream *streams[ARRAY_SIZE(broadcast_sink_streams)];
 	uint32_t bis_bitfield;
 	int err;
 


### PR DESCRIPTION
Modifies the broadcast source and sink APIs and implementations to use a slist instead of an array of pointers to hold the streams. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/43767