### PR TITLE
(2.7 backport) doc: Add link to J-Link virtual MSD disable for SMP

### DIFF
--- a/doc/guides/device_mgmt/mcumgr.rst
+++ b/doc/guides/device_mgmt/mcumgr.rst
@@ -209,6 +209,20 @@ on Zephyr. The ones that are supported are described in the following table:
     :kconfig:`CONFIG_THREAD_STACK_INFO` and :kconfig:`CONFIG_INIT_STACKS` options
     must be set.
 
+.. _mcumgr_jlink_ob_virtual_msd:
+
+J-Link Virtual MSD Interaction Note
+***********************************
+
+On boards where a J-Link OB is present which has both CDC and MSC (virtual Mass
+Storage Device, also known as drag-and-drop) support, the MSD functionality can
+prevent mcumgr commands over the CDC UART port from working due to how USB
+endpoints are configured in the J-Link firmware (for example on the Nordic
+``nrf52840dk``) because of limiting the maximum packet size (most likely to occur
+when using image management commands for updating firmware). This issue can be
+resolved by disabling MSD functionality on the J-Link device, follow the
+instructions on :ref:`nordic_segger_msd` to disable MSD support.
+
 .. _image_mgmt:
 
 Image Management

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -246,6 +246,18 @@ send a string to the remote target device and have it echo it back:
    In the following sections, examples will use ``<connection string>`` to represent
    the ``--conntype <type>`` and ``--connstring=<string>`` :file:`mcumgr` parameters.
 
+J-Link Virtual MSD Interaction Note
+***********************************
+
+On boards where a J-Link OB is present which has both CDC and MSC (virtual Mass
+Storage Device, also known as drag-and-drop) support, the MSD functionality can
+prevent mcumgr commands over the CDC UART port from working due to how USB
+endpoints are configured in the J-Link firmware (for example on the Nordic
+``nrf52840dk``) because of limiting the maximum packet size (most likely to occur
+when using image management commands for updating firmware). This issue can be
+resolved by disabling MSD functionality on the J-Link device, follow the
+instructions on :ref:`nordic_segger_msd` to disable MSD support.
+
 Device Firmware Upgrade (DFU)
 *****************************
 


### PR DESCRIPTION
    Virtual MSD J-Link support on some development boards has caused an
    issue with SMP due to limiting the maximum size of UART data via the CDC
    endpoint, add a link to the SMP documentation and smp_svr sample
    application on how to disable MSD functionality and resolve the issue.

Fixes documentation build error in https://github.com/zephyrproject-rtos/zephyr/pull/44628

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44497