### PR TITLE
doc: mcumgr: Fix reference formatting

### DIFF
--- a/doc/services/device_mgmt/mcumgr.rst
+++ b/doc/services/device_mgmt/mcumgr.rst
@@ -218,7 +218,7 @@ On boards where a J-Link OB is present which has both CDC and MSC (virtual Mass
 Storage Device, also known as drag-and-drop) support, the MSD functionality can
 prevent mcumgr commands over the CDC UART port from working due to how USB
 endpoints are configured in the J-Link firmware (for example on the Nordic
-`nrf52840dk`) because of limiting the maximum packet size (most likely to occur
+``nrf52840dk``) because of limiting the maximum packet size (most likely to occur
 when using image management commands for updating firmware). This issue can be
 resolved by disabling MSD functionality on the J-Link device, follow the
 instructions on :ref:`nordic_segger_msd` to disable MSD support.

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -253,7 +253,7 @@ On boards where a J-Link OB is present which has both CDC and MSC (virtual Mass
 Storage Device, also known as drag-and-drop) support, the MSD functionality can
 prevent mcumgr commands over the CDC UART port from working due to how USB
 endpoints are configured in the J-Link firmware (for example on the Nordic
-`nrf52840dk`) because of limiting the maximum packet size (most likely to occur
+``nrf52840dk``) because of limiting the maximum packet size (most likely to occur
 when using image management commands for updating firmware). This issue can be
 resolved by disabling MSD functionality on the J-Link device, follow the
 instructions on :ref:`nordic_segger_msd` to disable MSD support.


### PR DESCRIPTION
    Documentation build for 2.7 was failing due to using only a single
    character instead of double for showing a module name.
