### PR TITLE
Bluetooth: Host: Fix assert in L2CAP ECRED connection response

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1564,6 +1564,13 @@ static void le_ecred_conn_rsp(struct bt_l2cap *l2cap, uint8_t ident,
 			/* Cancel RTX work */
 			k_work_cancel_delayable(&chan->rtx_work);
 
+			if (buf->len < sizeof(dcid)) {
+				BT_ERR("Fewer dcid values than expected");
+				bt_l2cap_chan_remove(conn, &chan->chan);
+				bt_l2cap_chan_del(&chan->chan);
+				continue;
+			}
+
 			dcid = net_buf_pull_le16(buf);
 			attempted++;
 


### PR DESCRIPTION
In the case that the peer responds with fewer dcid values than the
number of scid values in the connection request, we would assert or read
past the end of the buffer.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>
