### PR TITLE
drivers: can: mcp2515: do not soft-reset device when changing timing

### DIFF
--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -358,7 +358,7 @@ static int mcp2515_set_timing(const struct device *dev,
 
 	/* CNF3, CNF2, CNF1, CANINTE */
 	uint8_t config_buf[4];
-	uint8_t reset_mode;
+	uint8_t mode;
 
 	/* CNF1; SJW<7:6> | BRP<5:0> */
 	__ASSERT(timing->prescaler > 0, "Prescaler should be bigger than zero");
@@ -412,28 +412,15 @@ static int mcp2515_set_timing(const struct device *dev,
 
 	k_mutex_lock(&dev_data->mutex, K_FOREVER);
 
-	k_usleep(MCP2515_OSC_STARTUP_US);
-
-	/* will enter configuration mode automatically */
-	ret = mcp2515_cmd_soft_reset(dev);
+	ret = mcp2515_get_mode(dev, &mode);
 	if (ret < 0) {
-		LOG_ERR("Failed to reset the device [%d]", ret);
+		LOG_ERR("Failed to read device mode [%d]", ret);
 		goto done;
 	}
 
-	k_usleep(MCP2515_OSC_STARTUP_US);
-
-	ret = mcp2515_get_mode(dev, &reset_mode);
+	ret = mcp2515_set_mode_int(dev, MCP2515_MODE_CONFIGURATION);
 	if (ret < 0) {
-		LOG_ERR("Failed to read device mode [%d]",
-			ret);
-		goto done;
-	}
-
-	if (reset_mode != MCP2515_MODE_CONFIGURATION) {
-		LOG_ERR("Device did not reset into configuration mode [%d]",
-			reset_mode);
-		ret = -EIO;
+		LOG_ERR("Failed to enter configuration mode [%d]", ret);
 		goto done;
 	}
 
@@ -441,18 +428,28 @@ static int mcp2515_set_timing(const struct device *dev,
 				    sizeof(config_buf));
 	if (ret < 0) {
 		LOG_ERR("Failed to write the configuration [%d]", ret);
+		goto done;
 	}
 
 	ret = mcp2515_cmd_bit_modify(dev, MCP2515_ADDR_RXB0CTRL, rx0_ctrl,
 				     rx0_ctrl);
 	if (ret < 0) {
 		LOG_ERR("Failed to write RXB0CTRL [%d]", ret);
+		goto done;
 	}
 
 	ret = mcp2515_cmd_bit_modify(dev, MCP2515_ADDR_RXB1CTRL, rx1_ctrl,
 				     rx1_ctrl);
 	if (ret < 0) {
 		LOG_ERR("Failed to write RXB1CTRL [%d]", ret);
+		goto done;
+	}
+
+	/* Restore previous mode */
+	ret = mcp2515_set_mode_int(dev, mode);
+	if (ret < 0) {
+		LOG_ERR("Failed to restore mode [%d]", ret);
+		goto done;
 	}
 
 done:

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -16,9 +16,10 @@
  */
 
 /**
- * Test bitrate in bits/second.
+ * Test bitrates in bits/second.
  */
-#define TEST_BITRATE 125000
+#define TEST_BITRATE_1 125000
+#define TEST_BITRATE_2 250000
 
 /**
  * @brief Test timeouts.
@@ -646,7 +647,7 @@ static void test_set_bitrate(void)
 {
 	int err;
 
-	err = can_set_bitrate(can_dev, TEST_BITRATE, 0);
+	err = can_set_bitrate(can_dev, TEST_BITRATE_1, 0);
 	zassert_equal(err, 0, "failed to set bitrate");
 }
 
@@ -904,6 +905,34 @@ static void test_filters_preserved_through_mode_change(void)
 	can_remove_rx_filter(can_dev, filter_id);
 }
 
+static void test_filters_preserved_through_bitrate_change(void)
+{
+	struct zcan_frame frame;
+	int filter_id;
+	int err;
+
+	filter_id = add_rx_msgq(can_dev, &test_std_filter_1);
+	send_test_frame(can_dev, &test_std_frame_1);
+
+	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
+	zassert_equal(err, 0, "receive timeout");
+	assert_frame_equal(&frame, &test_std_frame_1, 0);
+
+	err = can_set_bitrate(can_dev, TEST_BITRATE_2, 0);
+	zassert_equal(err, 0, "failed to set bitrate");
+
+	err = can_set_bitrate(can_dev, TEST_BITRATE_1, 0);
+	zassert_equal(err, 0, "failed to set bitrate");
+
+	send_test_frame(can_dev, &test_std_frame_1);
+
+	err = k_msgq_get(&can_msgq, &frame, TEST_RECEIVE_TIMEOUT);
+	zassert_equal(err, 0, "receive timeout");
+	assert_frame_equal(&frame, &test_std_frame_1, 0);
+
+	can_remove_rx_filter(can_dev, filter_id);
+}
+
 void test_main(void)
 {
 	k_sem_init(&rx_callback_sem, 0, 2);
@@ -934,6 +963,7 @@ void test_main(void)
 			 ztest_unit_test(test_send_receive_wrong_id),
 			 ztest_user_unit_test(test_recover),
 			 ztest_user_unit_test(test_get_state),
-			 ztest_user_unit_test(test_filters_preserved_through_mode_change));
+			 ztest_user_unit_test(test_filters_preserved_through_mode_change),
+			 ztest_user_unit_test(test_filters_preserved_through_bitrate_change));
 	ztest_run_test_suite(can_api_tests);
 }


### PR DESCRIPTION
Do not soft-reset device when changing timing parameters as the soft-reset will discard the configured CAN controller mode.

Add test to verify that mode and added rx filters are preserved through bitrate changes.
    
Fixes: #44837