### PR TITLE
Mgmt mcumgr remove zephyr_smp_trim_front  and mgmt_streamer_trim_front 

### DIFF
--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -119,18 +119,6 @@ typedef void (*mgmt_on_evt_cb)(uint8_t opcode, uint16_t group, uint8_t id, void 
  */
 typedef void *(*mgmt_alloc_rsp_fn)(const void *src_buf, void *arg);
 
-/** @typedef mgmt_trim_front_fn
- * @brief Trims data from the front of a buffer.
- *
- * If the amount to trim exceeds the size of the buffer, the buffer is
- * truncated to a length of 0.
- *
- * @param buf	The buffer to trim.
- * @param len	The number of bytes to remove.
- * @param arg	Optional streamer argument.
- */
-typedef void (*mgmt_trim_front_fn)(void *buf, size_t len, void *arg);
-
 /** @typedef mgmt_reset_buf_fn
  * @brief Resets a buffer to a length of 0.
  *
@@ -167,7 +155,6 @@ typedef void (*mgmt_free_buf_fn)(void *buf, void *arg);
  */
 struct mgmt_streamer_cfg {
 	mgmt_alloc_rsp_fn alloc_rsp;
-	mgmt_trim_front_fn trim_front;
 	mgmt_write_hdr_fn write_hdr;
 	mgmt_free_buf_fn free_buf;
 };

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -22,12 +22,6 @@ mgmt_streamer_alloc_rsp(struct mgmt_streamer *streamer, const void *req)
 	return streamer->cfg->alloc_rsp(req, streamer->cb_arg);
 }
 
-void
-mgmt_streamer_trim_front(struct mgmt_streamer *streamer, void *buf, size_t len)
-{
-	streamer->cfg->trim_front(buf, len, streamer->cb_arg);
-}
-
 int
 mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hdr *hdr)
 {

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -54,19 +54,6 @@ zephyr_smp_alloc_rsp(const void *req, void *arg)
 	return rsp_nb;
 }
 
-static void
-zephyr_smp_trim_front(void *buf, size_t len, void *arg)
-{
-	struct net_buf *nb;
-
-	nb = buf;
-	if (len > nb->len) {
-		len = nb->len;
-	}
-
-	net_buf_pull(nb, len);
-}
-
 /**
  * Splits an appropriately-sized fragment from the front of a net_buf, as
  * needed.  If the length of the net_buf is greater than specified maximum
@@ -122,7 +109,7 @@ zephyr_smp_split_frag(struct net_buf **nb, void *arg, uint16_t mtu)
 		net_buf_add_mem(frag, src->data, mtu);
 
 		/* Remove fragment from total response. */
-		zephyr_smp_trim_front(src, mtu, NULL);
+		net_buf_pull(src, mtu);
 	}
 
 	return frag;
@@ -232,7 +219,6 @@ zephyr_smp_handle_reqs(struct k_work *work)
 
 static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg = {
 	.alloc_rsp = zephyr_smp_alloc_rsp,
-	.trim_front = zephyr_smp_trim_front,
 	.write_hdr = zephyr_smp_write_hdr,
 	.free_buf = zephyr_smp_free_buf,
 };


### PR DESCRIPTION
The PR consists of two commits:
 1) replacing usage of zephyr_smp_trim_front with net_buf_pull as additional logic is not longer needed;
 2) removing mgmt_streamer_trim_front and callback pointer mgmt_streamer_cfg.trim_front;
