### PR TITLE
mgmt/mcumgr/lib: Remove mgmt_streamer_reset_buf

### DIFF
--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -168,7 +168,6 @@ typedef void (*mgmt_free_buf_fn)(void *buf, void *arg);
 struct mgmt_streamer_cfg {
 	mgmt_alloc_rsp_fn alloc_rsp;
 	mgmt_trim_front_fn trim_front;
-	mgmt_reset_buf_fn reset_buf;
 	mgmt_write_hdr_fn write_hdr;
 	mgmt_free_buf_fn free_buf;
 };
@@ -261,16 +260,6 @@ void *mgmt_streamer_alloc_rsp(struct mgmt_streamer *streamer, const void *src_bu
  * @param len		The number of bytes to remove.
  */
 void mgmt_streamer_trim_front(struct mgmt_streamer *streamer, void *buf, size_t len);
-
-/**
- * @brief Uses the specified streamer to reset a buffer to a length of 0.
- *
- * The buffer's user data remains, but its payload is cleared.
- *
- * @param streamer	The streamer providing the callback.
- * @param buf		The buffer to reset.
- */
-void mgmt_streamer_reset_buf(struct mgmt_streamer *streamer, void *buf);
 
 /**
  * @brief Uses the specified streamer to write header to buffer.

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -28,12 +28,6 @@ mgmt_streamer_trim_front(struct mgmt_streamer *streamer, void *buf, size_t len)
 	streamer->cfg->trim_front(buf, len, streamer->cb_arg);
 }
 
-void
-mgmt_streamer_reset_buf(struct mgmt_streamer *streamer, void *buf)
-{
-	streamer->cfg->reset_buf(buf, streamer->cb_arg);
-}
-
 int
 mgmt_streamer_write_hdr(struct mgmt_streamer *streamer, const struct mgmt_hdr *hdr)
 {

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -128,12 +128,6 @@ zephyr_smp_split_frag(struct net_buf **nb, void *arg, uint16_t mtu)
 	return frag;
 }
 
-static void
-zephyr_smp_reset_buf(void *buf, void *arg)
-{
-	net_buf_reset(buf);
-}
-
 static int
 zephyr_smp_write_hdr(struct cbor_nb_writer *cnw, const struct mgmt_hdr *hdr)
 {
@@ -239,7 +233,6 @@ zephyr_smp_handle_reqs(struct k_work *work)
 static const struct mgmt_streamer_cfg zephyr_smp_cbor_cfg = {
 	.alloc_rsp = zephyr_smp_alloc_rsp,
 	.trim_front = zephyr_smp_trim_front,
-	.reset_buf = zephyr_smp_reset_buf,
 	.write_hdr = zephyr_smp_write_hdr,
 	.free_buf = zephyr_smp_free_buf,
 };


### PR DESCRIPTION
Commit removes mgmt_streamer_reset_buf from mcumgr lib,
and supporting Zephyr function zephyr_smp_reset_buf.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>