### PR TITLE
kernel: workq: add k_work_user_queue_thread_get()

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4104,6 +4104,21 @@ extern void k_work_user_queue_start(struct k_work_user_q *work_q,
 				    size_t stack_size, int prio,
 				    const char *name);
 
+/**
+ * @brief Access the user mode thread that animates a work queue.
+ *
+ * This is necessary to grant a user mode work queue thread access to things
+ * the work items it will process are expected to use.
+ *
+ * @param work_q pointer to the user mode queue structure.
+ *
+ * @return the user mode thread associated with the work queue.
+ */
+static inline k_tid_t k_work_user_queue_thread_get(struct k_work_user_q *work_q)
+{
+	return &work_q->thread;
+}
+
 /** @} */
 
 /**


### PR DESCRIPTION
This adds a simple function to get the thread pointer to the user
mode thread of the user work queue. This is useful for granting
that user mode thread additional access to kernel objects.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>