### PR TITLE
drivers: pinctrl: update lpc pin control implementation

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69-pinctrl.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69-pinctrl.dtsi
@@ -66,8 +66,8 @@
 
 	pinmux_sctimer_default: pinmux_sctimer_default {
 		group0 {
-			pinmux = <SCT02_PIO0_15>,
-				<SCT00_PIO1_4>;
+			pinmux = <SCT0_OUT2_PIO0_15>,
+				<SCT0_OUT0_PIO1_4>;
 			slew-rate = "standard";
 		};
 	};

--- a/drivers/pinctrl/pinctrl_lpc_iocon.c
+++ b/drivers/pinctrl/pinctrl_lpc_iocon.c
@@ -7,25 +7,24 @@
 #include <drivers/pinctrl.h>
 #include <fsl_clock.h>
 
-#define PORT(mux) (((mux) & 0xC0000000) >> 30)
-#define PIN(mux) (((mux) & 0x3F000000) >> 24)
-#define TYPE(mux) (((mux) & 0xC00000) >> 22)
+#define OFFSET(mux) (((mux) & 0xFFF00000) >> 20)
+#define TYPE(mux) (((mux) & 0xC0000) >> 18)
 
 #define IOCON_TYPE_D 0x0
 #define IOCON_TYPE_I 0x1
 #define IOCON_TYPE_A 0x2
 
-static IOCON_Type *iocon = (IOCON_Type *)DT_REG_ADDR(DT_NODELABEL(iocon));
+static volatile uint32_t *iocon =
+	(volatile uint32_t *)DT_REG_ADDR(DT_NODELABEL(iocon));
 
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			   uintptr_t reg)
 {
 	for (uint8_t i = 0; i < pin_cnt; i++) {
-		/* Check if this is an analog or i2c type pin */
 		uint32_t pin_mux = pins[i];
-		uint32_t port = PORT(pin_mux);
-		uint32_t pin = PIN(pin_mux);
+		uint32_t offset = OFFSET(pin_mux);
 
+		/* Check if this is an analog or i2c type pin */
 		switch (TYPE(pin_mux)) {
 		case IOCON_TYPE_D:
 			pin_mux &= Z_PINCTRL_IOCON_D_PIN_MASK;
@@ -41,7 +40,7 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			assert(TYPE(pin_mux <= IOCON_TYPE_A));
 		}
 		/* Set pinmux */
-		iocon->PIO[port][pin] = pin_mux;
+		*(iocon + offset) = pin_mux;
 	}
 	return 0;
 }

--- a/soc/arm/nxp_lpc/CMakeLists.txt
+++ b/soc/arm/nxp_lpc/CMakeLists.txt
@@ -5,6 +5,3 @@
 #
 
 add_subdirectory(${SOC_SERIES})
-
-# This is for access to pinctrl macros
-zephyr_include_directories(common)

--- a/soc/arm/nxp_lpc/lpc55xxx/pinctrl_soc.h
+++ b/soc/arm/nxp_lpc/lpc55xxx/pinctrl_soc.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#ifndef ZEPHYR_SOC_ARM_NXP_LPC_COMMON_PINCTRL_SOC_H_
-#define ZEPHYR_SOC_ARM_NXP_LPC_COMMON_PINCTRL_SOC_H_
+#ifndef ZEPHYR_SOC_ARM_NXP_LPC_55xxx_PINCTRL_SOC_H_
+#define ZEPHYR_SOC_ARM_NXP_LPC_55xxx_PINCTRL_SOC_H_
 
 #include <devicetree.h>
 #include <zephyr/types.h>
@@ -65,4 +65,4 @@ typedef uint32_t pinctrl_soc_pin_t;
 }
 #endif
 
-#endif /* ZEPHYR_SOC_ARM_NXP_LPC_COMMON_PINCTRL_SOC_H_ */
+#endif /* ZEPHYR_SOC_ARM_NXP_LPC_55xxx_PINCTRL_SOC_H_ */

--- a/west.yml
+++ b/west.yml
@@ -98,7 +98,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: ca1610119ca147b2cd1b875238881e4abb805297
+      revision: 46be8173d2453b16c617b555f96c59d62920a290
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
update LPC pin control implementation to use offsets for pin registers
instead of pin/port combination, to permit additional flexibility for
lpc devices with non contiguous register layouts. Update LPC55s69 pin
control names to align with newly generated pin control header.

Move pin control header to LPC55xxx directory, since the IOCON peripheral on LPC55xxx parts is specific to that family.

This change also requires an update to the NXP HAL to use the new pin
control headers with offsets.