### PR TITLE
cmake: Add support to add symbols to ramfunc section

### DIFF
--- a/arch/common/ramfunc.ld
+++ b/arch/common/ramfunc.ld
@@ -13,6 +13,9 @@ SECTION_DATA_PROLOGUE(.ramfunc,,)
 	__ramfunc_start = .;
 	*(.ramfunc)
 	*(".ramfunc.*")
+
+#include <snippets-ramfunc-section.ld>
+
 	MPU_ALIGN(__ramfunc_size);
 	__ramfunc_end = .;
 } GROUP_DATA_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1145,6 +1145,7 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #                  Note: On RISC-V the rom_start section will be after vector section.
 #    RAM_SECTIONS  Inside the RAMABLE_REGION GROUP, not initialized.
 #    DATA_SECTIONS Inside the RAMABLE_REGION GROUP, initialized.
+#    RAMFUNC_SECTION Inside the RAMFUNC RAMABLE_REGION GROUP, not initialized.
 #    SECTIONS      Near the end of the file. Don't use this when linking into
 #                  RAMABLE_REGION, use RAM_SECTIONS instead.
 # <sort_key> is an optional key to sort by inside of each location. The key must
@@ -1153,9 +1154,9 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #
 # Use NOINIT, RWDATA, and RODATA unless they don't work for your use case.
 #
-# When placing into NOINIT, RWDATA, RODATA, ROM_START, the contents of the files
-# will be placed inside an output section, so assume the section definition is
-# already present, e.g.:
+# When placing into NOINIT, RWDATA, RODATA, ROM_START, RAMFUNC_SECTION the
+# contents of the files will be placed inside an output section, so assume
+# the section definition is already present, e.g.:
 #    _mysection_start = .;
 #    KEEP(*(.mysection));
 #    _mysection_end = .;
@@ -1188,6 +1189,7 @@ function(zephyr_linker_sources location)
   set(noinit_path        "${snippet_base}/snippets-noinit.ld")
   set(rwdata_path        "${snippet_base}/snippets-rwdata.ld")
   set(rodata_path        "${snippet_base}/snippets-rodata.ld")
+  set(ramfunc_path       "${snippet_base}/snippets-ramfunc-section.ld")
 
   # Clear destination files if this is the first time the function is called.
   get_property(cleared GLOBAL PROPERTY snippet_files_cleared)
@@ -1199,6 +1201,7 @@ function(zephyr_linker_sources location)
     file(WRITE ${noinit_path} "")
     file(WRITE ${rwdata_path} "")
     file(WRITE ${rodata_path} "")
+    file(WRITE ${ramfunc_path} "")
     set_property(GLOBAL PROPERTY snippet_files_cleared true)
   endif()
 
@@ -1217,6 +1220,8 @@ function(zephyr_linker_sources location)
     set(snippet_path "${rwdata_path}")
   elseif("${location}" STREQUAL "RODATA")
     set(snippet_path "${rodata_path}")
+  elseif("${location}" STREQUAL "RAMFUNC_SECTION")
+    set(snippet_path "${ramfunc_path}")
   else()
     message(fatal_error "Must choose valid location for linker snippet.")
   endif()


### PR DESCRIPTION
This PR allows the user to add symbols to the ramfunc section. The use for this could be as follows:

```
zephyr_linker_sources_ifdef(CONFIG_ARCH_HAS_RAMFUNC_SUPPORT
  RAMFUNC_SECTION
  quick_access_code.ld
)
```

`quick_access_code.ld` (as shown below) can define additional symbols to  go into the ramfunc section

```
. = ALIGN(4);
KEEP(*(CodeQuickAccess))
```