### PR TITLE
Bluetooth: Audio: Make PACS location optional

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1070,6 +1070,7 @@ struct bt_audio_unicast_server_cb {
 	int (*publish_capability)(struct bt_conn *conn, uint8_t type,
 				  uint8_t index, struct bt_codec *const codec);
 
+#if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
 	/** @brief Publish location callback
 	 *
 	 *  Publish location callback is called whenever a remote client
@@ -1090,6 +1091,7 @@ struct bt_audio_unicast_server_cb {
 				enum bt_audio_pac_type type,
 				enum bt_audio_location *location);
 
+#if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE) || defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
 	/** @brief Write location callback
 	 *
 	 *  Write location callback is called whenever a remote client
@@ -1103,6 +1105,8 @@ struct bt_audio_unicast_server_cb {
 	 */
 	int (*write_location)(struct bt_conn *conn, enum bt_audio_pac_type type,
 			      enum bt_audio_location location);
+#endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE || CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
+#endif /* CONFIG_BT_PAC_SNK_LOC || CONFIG_BT_PAC_SRC_LOC */
 };
 
 /** Broadcast Audio Sink callback structure */

--- a/subsys/bluetooth/audio/Kconfig.pacs
+++ b/subsys/bluetooth/audio/Kconfig.pacs
@@ -37,6 +37,20 @@ config BT_PACS_SNK_CONTEXT
 	  0x0100: Ringtone
 	  0x0200: TV
 
+config BT_PAC_SNK_LOC
+	bool "Sink PAC Location Support"
+	default y
+	help
+	  This option enables support for Sink PAC Location Characteristic.
+
+config BT_PAC_SNK_LOC_WRITEABLE
+	bool "Sink PAC Location Writable Support"
+	default y
+	depends on BT_PAC_SNK_LOC
+	help
+	  This option enables support for clients to write to the Sink PAC
+	  Location Characteristic.
+
 endif # BT_PACS_SNK
 
 config BT_PAC_SRC
@@ -64,6 +78,20 @@ config BT_PACS_SRC_CONTEXT
 	  0x0080: EmergencyAlert
 	  0x0100: Ringtone
 	  0x0200: TV
+
+config BT_PAC_SRC_LOC
+	bool "Source PAC Location Support"
+	default y
+	help
+	  This option enables support for Source PAC Location Characteristic.
+
+config BT_PAC_SRC_LOC_WRITEABLE
+	bool "Source PAC Location Writable Support"
+	default y
+	depends on BT_PAC_SRC_LOC
+	help
+	  This option enables support for clients to write to the Source PAC
+	  Location Characteristic.
 
 endif # BT_PAC_SRC
 endif # BT_PACS

--- a/subsys/bluetooth/audio/has.c
+++ b/subsys/bluetooth/audio/has.c
@@ -138,17 +138,23 @@ static int has_init(const struct device *dev)
 		has.features |= BT_HAS_FEAT_WRITABLE_PRESETS_SUPP;
 	}
 
-	if (IS_ENABLED(CONFIG_BT_HAS_HEARING_AID_BANDED)) {
-		/* HAP_d1.0r00; 3.7 BAP Unicast Server role requirements
-		 * A Banded Hearing Aid in the HA role shall set the Front Left and the Front
-		 * Right bits to a value of 0b1 in the Sink Audio Locations characteristic value.
-		 */
-		bt_audio_capability_set_location(BT_AUDIO_SINK, BT_AUDIO_LOCATION_FRONT_LEFT |
-								BT_AUDIO_LOCATION_FRONT_RIGHT);
-	} else if (IS_ENABLED(CONFIG_BT_HAS_HEARING_AID_LEFT)) {
-		bt_audio_capability_set_location(BT_AUDIO_SINK, BT_AUDIO_LOCATION_FRONT_LEFT);
-	} else {
-		bt_audio_capability_set_location(BT_AUDIO_SINK, BT_AUDIO_LOCATION_FRONT_RIGHT);
+	if (IS_ENABLED(CONFIG_BT_PAC_SNK_LOC)) {
+		if (IS_ENABLED(CONFIG_BT_HAS_HEARING_AID_BANDED)) {
+			/* HAP_d1.0r00; 3.7 BAP Unicast Server role requirements
+			 * A Banded Hearing Aid in the HA role shall set the
+			 * Front Left and the Front Right bits to a value of 0b1
+			 * in the Sink Audio Locations characteristic value.
+			 */
+			bt_audio_capability_set_location(BT_AUDIO_SINK,
+							 (BT_AUDIO_LOCATION_FRONT_LEFT |
+								BT_AUDIO_LOCATION_FRONT_RIGHT));
+		} else if (IS_ENABLED(CONFIG_BT_HAS_HEARING_AID_LEFT)) {
+			bt_audio_capability_set_location(BT_AUDIO_SINK,
+							 BT_AUDIO_LOCATION_FRONT_LEFT);
+		} else {
+			bt_audio_capability_set_location(BT_AUDIO_SINK,
+							 BT_AUDIO_LOCATION_FRONT_RIGHT);
+		}
 	}
 
 	return 0;

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -52,7 +52,9 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 	return 0;
 }
 
+#if defined(CONFIG_BT_PAC_SNK_LOC) || defined(CONFIG_BT_PAC_SRC_LOC)
 int bt_audio_unicast_server_location_changed(enum bt_audio_pac_type type)
 {
 	return bt_pacs_location_changed(type);
 }
+#endif /* CONFIG_BT_PAC_SNK_LOC || CONFIG_BT_PAC_SRC_LOC */

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_server_test.c
@@ -209,7 +209,7 @@ static void set_location(void)
 {
 	int err;
 
-	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
+	if (IS_ENABLED(CONFIG_BT_PAC_SNK_LOC)) {
 		err = bt_audio_capability_set_location(BT_AUDIO_SINK,
 						       BT_AUDIO_LOCATION_FRONT_CENTER);
 		if (err != 0) {
@@ -218,7 +218,7 @@ static void set_location(void)
 		}
 	}
 
-	if (IS_ENABLED(CONFIG_BT_PAC_SRC)) {
+	if (IS_ENABLED(CONFIG_BT_PAC_SRC_LOC)) {
 		err = bt_audio_capability_set_location(BT_AUDIO_SINK,
 						       (BT_AUDIO_LOCATION_FRONT_LEFT |
 							BT_AUDIO_LOCATION_FRONT_RIGHT));


### PR DESCRIPTION
Make the PACS location characteristic optional, and
also optionally writable.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/43851