### PR TITLE
Add workaround to GPIO MCUX driver for non contiguous pins

### DIFF
--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -40,7 +40,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led-1 {
-			gpios = <&gpio1 24 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio1 24 GPIO_ACTIVE_HIGH>;
 			label = "User LD1";
 		};
 	};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -15,7 +15,7 @@
 	leds {
 		compatible = "gpio-leds";
 		green_led: led-1 {
-			gpios = <&gpio9 3 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio9 3 GPIO_ACTIVE_HIGH>;
 			label = "User LED D6";
 		};
 	};


### PR DESCRIPTION
Some iMX RT parts have a non contiguous set of pins available on certain GPIO ports (for example, GPIO0_0-GPIO0_10 are defined, as well as GPIO0_20-GPIO0_31, but GPIO0_11-GPIO0_19 are absent). Add a workaround to the iMX RT gpio driver to correctly select the GPIO pinmux register in these cases.

This PR also fixes the GPIO active flags on the RT1024 and RT1170 EVK LEDs, as these were discovered to be incorrect in testing.

Fixes #44391