### PR TITLE
arch: drivers: soc: remove unnecessary "EOF" comment lines from my sources

### DIFF
--- a/arch/arm/core/aarch32/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch32/mmu/arm_mmu.c
@@ -1090,5 +1090,3 @@ int arch_page_phys_get(void *virt, uintptr_t *phys)
 	}
 	return rc;
 }
-
-/* EOF */

--- a/arch/arm/core/aarch32/mmu/arm_mmu_priv.h
+++ b/arch/arm/core/aarch32/mmu/arm_mmu_priv.h
@@ -201,5 +201,3 @@ struct arm_mmu_perms_attrs {
 };
 
 #endif /* ZEPHYR_ARCH_AARCH32_ARM_MMU_PRIV_H_ */
-
-/* EOF */

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -1634,5 +1634,3 @@ static void eth_xlnx_gem_handle_tx_done(const struct device *dev)
 	/* Indicate completion to a blocking eth_xlnx_gem_send() call */
 	k_sem_give(&dev_data->tx_done_sem);
 }
-
-/* EOF */

--- a/drivers/ethernet/eth_xlnx_gem_priv.h
+++ b/drivers/ethernet/eth_xlnx_gem_priv.h
@@ -774,5 +774,3 @@ struct eth_xlnx_gem_dev_data {
 };
 
 #endif /* _ZEPHYR_DRIVERS_ETHERNET_ETH_XLNX_GEM_PRIV_H_ */
-
-/* EOF */

--- a/drivers/ethernet/phy_xlnx_gem.c
+++ b/drivers/ethernet/phy_xlnx_gem.c
@@ -974,5 +974,3 @@ int phy_xlnx_gem_detect(const struct device *dev)
 	LOG_ERR("%s PHY detection failed", dev->name);
 	return -EIO;
 }
-
-/* EOF */

--- a/drivers/ethernet/phy_xlnx_gem.h
+++ b/drivers/ethernet/phy_xlnx_gem.h
@@ -153,5 +153,3 @@ struct phy_xlnx_gem_supported_dev {
 int phy_xlnx_gem_detect(const struct device *dev);
 
 #endif /* _ZEPHYR_DRIVERS_ETHERNET_PHY_XLNX_GEM_H_ */
-
-/* EOF */

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -91,5 +91,3 @@ static int soc_xlnx_zynq7000_init(const struct device *arg)
 
 SYS_INIT(soc_xlnx_zynq7000_init, PRE_KERNEL_1,
 	CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-
-/* EOF */

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -91,5 +91,3 @@ static int soc_xlnx_zynq7000s_init(const struct device *arg)
 
 SYS_INIT(soc_xlnx_zynq7000s_init, PRE_KERNEL_1,
 	CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
-
-/* EOF */


### PR DESCRIPTION
Remove the unnecessary "EOF" comment lines at the end of each source file, as such markers aren't common in the Zephyr sources.