### PR TITLE
Bluetooth: Controller: Fix spurious transmit after mic failure

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -249,6 +249,15 @@ void lll_conn_isr_rx(void *param)
 		err = isr_rx_pdu(lll, pdu_data_rx, &is_rx_enqueue, &tx_release,
 				 &is_done);
 		if (err) {
+			/* Disable radio trx switch on MIC failure for both
+			 * central and peripheral, and close the radio event.
+			 */
+			radio_isr_set(isr_done, param);
+			radio_disable();
+
+			/* assert if radio started tx before being disabled */
+			LL_ASSERT(!radio_is_ready());
+
 			goto lll_conn_isr_rx_exit;
 		}
 


### PR DESCRIPTION
Fix spurious transmit of corrupt PDU after reception of PDU
with MIC failure.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>