### PR TITLE
[nrf fromlist] bluetooth: host: Check for duplicate device

### DIFF
--- a/subsys/bluetooth/host/id.c
+++ b/subsys/bluetooth/host/id.c
@@ -773,12 +773,25 @@ void bt_id_add(struct bt_keys *keys)
 		goto done;
 	}
 
+	/*
+	 * Core Spec 5.3, p 2424
+	 * Controller can accept or reject when the same device is added to
+	 * resolving list.  This check ensures duplicate device will not be
+	 * sent to the controller.
+	 */
+	if (bt_dev.le.rl_entries) {
+		if (bt_keys_match(keys)) {
+			goto entry_added;
+		}
+	}
+
 	err = hci_id_add(keys->id, &keys->addr, keys->irk.val);
 	if (err) {
 		BT_ERR("Failed to add IRK to controller");
 		goto done;
 	}
 
+entry_added:
 	bt_dev.le.rl_entries++;
 	keys->state |= BT_KEYS_ID_ADDED;
 

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -309,6 +309,21 @@ void bt_keys_clear(struct bt_keys *keys)
 	(void)memset(keys, 0, sizeof(*keys));
 }
 
+bool bt_keys_match(struct bt_keys *keys)
+{
+	int i;
+	for (i = 0; i < ARRAY_SIZE(key_pool); i++) {
+		if (key_pool[i].id == keys->id) {
+			if (!memcmp(&key_pool[i].irk.val, &keys->irk.val, 16)) {
+				if (!bt_addr_cmp(&key_pool[i].addr.a, &keys->addr.a)) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+
 #if defined(CONFIG_BT_SETTINGS)
 int bt_keys_store(struct bt_keys *keys)
 {

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -84,6 +84,7 @@ struct bt_keys *bt_keys_find_addr(uint8_t id, const bt_addr_le_t *addr);
 
 void bt_keys_add_type(struct bt_keys *keys, int type);
 void bt_keys_clear(struct bt_keys *keys);
+bool bt_keys_match(struct bt_keys *keys);
 
 #if defined(CONFIG_BT_SETTINGS)
 int bt_keys_store(struct bt_keys *keys);


### PR DESCRIPTION
In Core spec v5.3, controller has the option to accept or reject when the same device is added to resolving list.
This check ensures duplicate device will not be sent to the controller.

Signed-off-by: Azizah Ibrahim <azizah.ibrahim@nordicsemi.no>