### PR TITLE
drivers: sensor: lsm6dso: Remove usage of undefined variable

### DIFF
--- a/drivers/sensor/lsm6dso/lsm6dso_trigger.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_trigger.c
@@ -27,7 +27,6 @@ static int lsm6dso_enable_t_int(const struct device *dev, int enable)
 {
 	const struct lsm6dso_config *cfg = dev->config;
 	stmdev_ctx_t *ctx = (stmdev_ctx_t *)&cfg->ctx;
-	struct lsm6dso_data *lsm6dso = dev->data;
 	lsm6dso_int2_ctrl_t int2_ctrl;
 
 	if (enable) {
@@ -42,7 +41,7 @@ static int lsm6dso_enable_t_int(const struct device *dev, int enable)
 		return -EIO;
 
 	lsm6dso_read_reg(ctx, LSM6DSO_INT2_CTRL, (uint8_t *)&int2_ctrl, 1);
-	int2_route.int2_ctrl.int2_drdy_temp = enable;
+	int2_ctrl.int2_drdy_temp = enable;
 	return lsm6dso_write_reg(ctx, LSM6DSO_INT2_CTRL,
 				 (uint8_t *)&int2_ctrl, 1);
 }


### PR DESCRIPTION
Remove usage of undefined variable, and remove unused variable.

Signed-off-by: Andreas Pettersson <andreaspettersson95@gmail.com>

Fixes the same thing as https://github.com/zephyrproject-rtos/zephyr/pull/42589 which for some unknown reason was closed by the author. Fixes the issue https://github.com/zephyrproject-rtos/zephyr/issues/42588 which was closed by the author without a fix.

Fixes #42588 