### PR TITLE
doc: Fix spelling errors in .rst files

### DIFF
--- a/boards/arm/lora_e5_dev_board/doc/lora_e5_dev_board.rst
+++ b/boards/arm/lora_e5_dev_board/doc/lora_e5_dev_board.rst
@@ -247,7 +247,7 @@ Then build and flash an application. Here is an example for the
 
 Run a serial host program to connect with your board:
 Per default the console on ``usart1`` is available on the USB Type C connector
-via the build-in USB to UART converter.
+via the built-in USB to UART converter.
 
 .. code-block:: console
 

--- a/boards/arm/mec15xxevb_assy6853/doc/index.rst
+++ b/boards/arm/mec15xxevb_assy6853/doc/index.rst
@@ -401,7 +401,7 @@ Flashing
          :alt: SPI DONGLE ASSY 6791 Connected
 
 
-   .. note:: If you dont't want to press Reset button every time, you can disconnect
+   .. note:: If you don't want to press Reset button every time, you can disconnect
     SPI Dongle ASSY 6791 from the EVB during the west flash programming.
     Then connect it back to the ``J44`` header and apply power to the EVB.
     Result will be the same.

--- a/boards/arm/mec172xevb_assy6906/doc/index.rst
+++ b/boards/arm/mec172xevb_assy6906/doc/index.rst
@@ -405,7 +405,7 @@ Flashing
         :align: center
         :alt: Reset Button
 
-   .. note:: If you dont't want to press Reset button every time, you can disconnect
+   .. note:: If you don't want to press Reset button every time, you can disconnect
     SPI Dongle ASSY 6791 from the EVB during the west flash programming.
     Then connect it back to the ``J34`` header and apply power to the EVB.
     Result will be the same.

--- a/boards/arm/nuvoton_pfm_m487/doc/index.rst
+++ b/boards/arm/nuvoton_pfm_m487/doc/index.rst
@@ -18,7 +18,7 @@ Ethernet series MCU with ARM® -Cortex®-M4F core.
 Features:
 =========
 - 32-bit Arm Cortex®-M4 M487JIDAE MCU
-- Core clock upto 192 MHz
+- Core clock up to 192 MHz
 - 512 KB embedded Dual Bank Flash and 160 KB SRAM
 - Audio codec (NAU88L25) with Microphone In and Headphone Out
 - Ethernet (IP101GR) for network application

--- a/boards/arm/reel_board/doc/index.rst
+++ b/boards/arm/reel_board/doc/index.rst
@@ -328,7 +328,7 @@ Power supply testpoint
 | TP13  | testpoint             | testpoint boost converter input voltage   |
 +-------+-----------------------+-------------------------------------------+
 
-Build-in Debug Adapter
+Built-in Debug Adapter
 ======================
 
 The debug adapter is based on the DAPLink interface firmware and

--- a/boards/arm/sensortile_box/doc/index.rst
+++ b/boards/arm/sensortile_box/doc/index.rst
@@ -44,7 +44,7 @@ SensorTile.box provides the following hardware components:
   - 1 x USB OTG FS (SoC) with micro-B connector
     (USB device role only)
 
-- Internal Busses
+- Internal Buses
 
   - 3 x SPI bus
   - 3 x I2C bus
@@ -104,7 +104,7 @@ SensorTile.box System Clock could be driven by internal or external
 oscillator, as well as main PLL clock. By default, the System clock is
 driven by the PLL clock at 80MHz, driven by the 16MHz external oscillator.
 The system clock can be boosted to 120MHz.
-The internal AHB/APB1/APB2 AMBA busses are all clocked at 80MHz.
+The internal AHB/APB1/APB2 AMBA buses are all clocked at 80MHz.
 
 Serial Port
 ===========

--- a/boards/shields/x_nucleo_iks01a2/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a2/doc/index.rst
@@ -59,7 +59,7 @@ Mode 1: Standard Mode
 =====================
 
 In standard I2C mode the two buses are connected together. As a consequence, all devices on the shield
-reside on the same I2C bus and are accessible from the main board thru I2C bus.
+reside on the same I2C bus and are accessible from the main board through I2C bus.
 
 The jumper configuration to activate this mode is:
 
@@ -71,7 +71,7 @@ Mode 2: SensorHub Mode
 ======================
 
 In SensorHub mode LSM6DSL is connected to I2C2 and is accessible from the main board.
-All the other devices are connected to LSM6DSL master thru I2C1.
+All the other devices are connected to LSM6DSL master through I2C1.
 
 The jumper configuration to activate this mode is:
 

--- a/boards/shields/x_nucleo_iks01a3/doc/index.rst
+++ b/boards/shields/x_nucleo_iks01a3/doc/index.rst
@@ -57,7 +57,7 @@ Mode 1: Standard Mode
 =====================
 
 In standard I2C mode the two buses are connected together. As a consequence, all devices on the shield
-reside on the same I2C bus and are accessible from the main board thru I2C bus.
+reside on the same I2C bus and are accessible from the main board through I2C bus.
 
 The jumper configuration to activate this mode is:
 
@@ -69,7 +69,7 @@ Mode 2: SensorHub Mode
 ======================
 
 In SensorHub mode LSM6DSO and LIS2DW12 are connected to I2C2 and are accessible from the main board.
-All the other devices are connected to LSM6DSO master thru I2C1.
+All the other devices are connected to LSM6DSO master through I2C1.
 
 The jumper configuration to activate this mode is:
 

--- a/boards/shields/x_nucleo_iks02a1/doc/index.rst
+++ b/boards/shields/x_nucleo_iks02a1/doc/index.rst
@@ -69,7 +69,7 @@ Mode 2: SensorHub Mode
 ======================
 
 In SensorHub mode ISM330DHCX and IIS2DLPC are connected to I2C2 and are accessible from the main board mcu.
-Instead, the IIS2MDC device is connected only to ISM330DHCX sensor thru its SCx/SDX (I2Cx) pins.
+Instead, the IIS2MDC device is connected only to ISM330DHCX sensor through its SCx/SDX (I2Cx) pins.
 
 The jumper configuration to activate this mode is:
 

--- a/doc/connectivity/bluetooth/autopts/autopts-linux.rst
+++ b/doc/connectivity/bluetooth/autopts/autopts-linux.rst
@@ -353,7 +353,7 @@ In this case, choose rather VMWare Workstation.
    :width: 650
    :align: center
 
-One or more of the fallowing steps should help:
+One or more of the following steps should help:
 
 - Close all PTS Windows.
 

--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -264,7 +264,7 @@ Create callback functions for LwM2M resource exuctions:
 		LOG_INF("Device rebooting.");
 		LOG_PANIC();
 		sys_reboot(0);
-		return 0; /* wont reach this */
+		return 0; /* won't reach this */
 	}
 
 The LwM2M RD client can send events back to the sample.  To receive those

--- a/doc/develop/west/west-apis.rst
+++ b/doc/develop/west/west-apis.rst
@@ -192,7 +192,7 @@ Deprecated APIs
 
 The following APIs also use :py:class:`west.configuration.ConfigFile`, but they
 operate by default on a global object which stores the current workspace
-configuration. This has proven to be a bad design descision since west's APIs
+configuration. This has proven to be a bad design decision since west's APIs
 can be used from multiple workspaces. They were deprecated in west v0.13.0.
 
 These APIs are preserved for compatibility with older extensions. They should

--- a/doc/hardware/peripherals/sensor.rst
+++ b/doc/hardware/peripherals/sensor.rst
@@ -87,7 +87,7 @@ To configure a trigger, an application needs to supply a
 :c:struct:`sensor_trigger` and a handler function.  The structure contains the
 trigger type and the channel on which the trigger must be configured.
 
-Because most sensors are connected via SPI or I2C busses, it is not possible
+Because most sensors are connected via SPI or I2C buses, it is not possible
 to communicate with them from the interrupt execution context.  The
 execution of the trigger handler is deferred to a thread, so that data
 fetching operations are possible.  A driver can spawn its own thread to fetch

--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -207,7 +207,7 @@ formatted to *hh:mm:ss:mmm,uuu*. Otherwise is printed in raw format.
 
 Backend options:
 
-:kconfig:option:`CONFIG_LOG_BACKEND_UART`: Enabled build-in UART backend.
+:kconfig:option:`CONFIG_LOG_BACKEND_UART`: Enabled built-in UART backend.
 
 .. _log_usage:
 

--- a/doc/services/shell/index.rst
+++ b/doc/services/shell/index.rst
@@ -263,7 +263,7 @@ Commands execution
 Each command or subcommand may have a handler. The shell executes the handler
 that is found deepest in the command tree and further subcommands (without a
 handler) are passed as arguments. Characters within parentheses are treated
-as one argument. If shell wont find a handler it will display an error message.
+as one argument. If shell won't find a handler it will display an error message.
 
 Commands can be also executed from a user application using any active backend
 and a function :c:func:`shell_execute_cmd`, as shown in this example:

--- a/doc/services/tfm/build.rst
+++ b/doc/services/tfm/build.rst
@@ -63,7 +63,7 @@ key, which is stored inside the secure bootloader firmware image.
 
 By default, ``<tfm-dir>/bl2/ext/mcuboot/root-rsa-3072.pem`` is used to sign secure
 images, and ``<tfm-dir>/bl2/ext/mcuboot/root-rsa-3072_1.pem`` is used to sign
-non-secure images. Theses default .pem keys can (and **should**) be overridden
+non-secure images. These default .pem keys can (and **should**) be overridden
 using the :kconfig:option:`CONFIG_TFM_KEY_FILE_S` and
 :kconfig:option:`CONFIG_TFM_KEY_FILE_NS` config flags.
 

--- a/doc/services/tracing/index.rst
+++ b/doc/services/tracing/index.rst
@@ -204,7 +204,7 @@ Using RAM backend
 =================
 
 For devices that do not have available I/O for tracing such as USB or UART but have
-enough RAM to collect trace datas, the ram backend can be enabled with configuration
+enough RAM to collect trace data, the ram backend can be enabled with configuration
 :kconfig:option:`CONFIG_TRACING_BACKEND_RAM`.
 Adjust :kconfig:option:`CONFIG_RAM_TRACING_BUFFER_SIZE` to be able to record enough traces for your needs.
 Then thanks to a runtime debugger such as gdb this buffer can be fetched from the target
@@ -267,7 +267,7 @@ I/O Taxonomy
   Examples:
     - sync  unbuffered
         E.g. PIO via GPIOs having steady stream, no extra FIFO memory needed.
-        Low jitter but may be less efficient (cant amortize the overhead of
+        Low jitter but may be less efficient (can't amortize the overhead of
         writing).
 
     - sync  buffered

--- a/samples/bluetooth/central_multilink/README.rst
+++ b/samples/bluetooth/central_multilink/README.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 Application demonstrating BLE Central role functionality by scanning for other
-BLE devices and establishing connection to upto 62 peripherals with a strong
+BLE devices and establishing connection to up to 62 peripherals with a strong
 enough signal.
 
 Requirements

--- a/samples/boards/96b_argonkey/microphone/README.rst
+++ b/samples/boards/96b_argonkey/microphone/README.rst
@@ -18,7 +18,7 @@ This sample requires the ArgonKey board plus a USB to TTL 1V8 serial
 cable to get the output audio stream. The board can be powered
 in either one of the following two ways:
 
-- mezzanine mode, plugging the ArgonKey to HiKey board thru its 96Board
+- mezzanine mode, plugging the ArgonKey to HiKey board through its 96Board
   low-speed connector
 - standalone mode, supplying 5V directly on P1 connector
 

--- a/samples/boards/96b_argonkey/sensors/README.rst
+++ b/samples/boards/96b_argonkey/sensors/README.rst
@@ -15,7 +15,7 @@ Requirements
 This sample just requires the ArgonKey board. The board can be powered
 in either one of the following two ways:
 
-- mezzanine mode, plugging the ArgonKey to HiKey board thru its 96Board
+- mezzanine mode, plugging the ArgonKey to HiKey board through its 96Board
   low-speed connector
 - standalone mode, supplying 5V directly on P1 connector
 

--- a/samples/subsys/display/cfb_shell/README.rst
+++ b/samples/subsys/display/cfb_shell/README.rst
@@ -93,7 +93,7 @@ Command example (reel_board):
 .. code-block:: console
 
          uart:~$ cfb set_font 0
-         Font idx=0 height=32 widht=20 set
+         Font idx=0 height=32 width=20 set
 
 **invert**: invert the pixel color of the display.
 

--- a/samples/subsys/mgmt/hawkbit/README.rst
+++ b/samples/subsys/mgmt/hawkbit/README.rst
@@ -198,7 +198,7 @@ to support https.
    openssl req -new -key server.key -out server.csr
 
 Once you run the command, it will prompt you to enter your Country,
-State, City, Company name and enter the Comman Name field with
+State, City, Company name and enter the Command Name field with
 ``<your-ip-address>``.
 
 * Generate the self-signed x509 certificate suitable to use on web server.

--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -195,7 +195,7 @@ the image.
     west flash --bin-file build/zephyr/zephyr.signed.bin
 
 We need to explicitly specify the *signed* image file, otherwise the non-signed version
-will be used and the image wont be runnable.
+will be used and the image won't be runnable.
 
 Sample image: hello world!
 ==========================


### PR DESCRIPTION
Fix spelling errors in assorted .rst files. The errors were found using a tool called 'codespell'.
