### PR TITLE
logging: remove obj character

### DIFF
--- a/subsys/logging/CMakeLists.txt
+++ b/subsys/logging/CMakeLists.txt
@@ -110,12 +110,12 @@ endif()
 
 if(CONFIG_LOG2_MODE_IMMEDIATE OR CONFIG_LOG2_MODE_DEFERRED)
   message(WARNING "CONFIG_LOG2_MODE_{IMMEDIATE,DEFERRED} is deprecated. Please \
-￼                  use CONFIG_LOG_MODE_{IMMEDIATE,DEFERRED} which defaults to v2"
-￼         )
+                   use CONFIG_LOG_MODE_{IMMEDIATE,DEFERRED} which defaults to v2"
+          )
 endif()
 
 if(CONFIG_LOG1)
   message(WARNING "Logging v1 has been deprecated. Use v2 instead and adapt \
                    custom backend to the new backend API"
-￼         )
+          )
 endif()


### PR DESCRIPTION
Remove useless OBJECT REPLACEMENT CHARACTER U+FFFC from warning log messages.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>