### PR TITLE
soc: it8xxx2: enable extensions by configuration options

### DIFF
--- a/soc/riscv/riscv-ite/CMakeLists.txt
+++ b/soc/riscv/riscv-ite/CMakeLists.txt
@@ -1,3 +1,2 @@
 add_subdirectory(common)
 add_subdirectory(${SOC_SERIES})
-zephyr_compile_options(-march=rv32imac)

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
@@ -5,6 +5,9 @@ config SOC_SERIES_RISCV32_IT8XXX2
 	bool "ITE IT8XXX2 implementation"
 	#depends on RISCV
 	select COMPRESSED_ISA
+	select CPU_HAS_FPU
+	select RISCV_ATOMICS_ISA
+	select RISCV_MUL_ISA
 	select SOC_FAMILY_RISCV_ITE
 	help
 	    Enable support for ITE IT8XXX2


### PR DESCRIPTION
CONFIG_RISCV_ATOMICS_ISA enables A extension.
CONFIG_RISCV_MUL_ISA enables M extension.
CONFIG_FLOAT_HARD enables F extension. (FPU)

added compile options "-march=rv32imac"

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>