### PR TITLE
lib: os: cbprintf: Tweak Z_CBPRINTF_PCHAR_COUNT macro for vscode

### DIFF
--- a/include/zephyr/logging/log_msg2.h
+++ b/include/zephyr/logging/log_msg2.h
@@ -353,7 +353,7 @@ do { \
 	Z_LOG_MSG2_STR_VAR(_fmt, ##__VA_ARGS__); \
 	bool has_rw_str = CBPRINTF_MUST_RUNTIME_PACKAGE( \
 					Z_LOG_MSG2_CBPRINTF_FLAGS(_cstr_cnt), \
-					__VA_ARGS__); \
+					Z_LOG_FMT_ARGS(_fmt, ##__VA_ARGS__)); \
 	if (IS_ENABLED(CONFIG_LOG_SPEED) && _try_0cpy && ((_dlen) == 0) && !has_rw_str) {\
 		LOG_MSG2_DBG("create zero-copy message\n");\
 		Z_LOG_MSG2_SIMPLE_CREATE(_cstr_cnt, _domain_id, _source, \

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -110,24 +110,20 @@ extern "C" {
  * @retval 0 otherwise.
  */
 #define Z_CBPRINTF_IS_X_PCHAR(idx, x, flags) \
-	  (idx < Z_CBPRINTF_PACKAGE_FIRST_RO_STR_CNT_GET(flags) ? \
+	  (idx < (Z_CBPRINTF_PACKAGE_FIRST_RO_STR_CNT_GET(flags) + 1) ? \
 		0 : Z_CBPRINTF_IS_PCHAR(x, flags))
 
-/** @brief Calculate number of char * or wchar_t * arguments in the arguments.
+/* @brief Count number of char pointer arguments.
  *
- * @param fmt string.
+ * @param flags Option flags. If @ref CBPRINTF_PACKAGE_CONST_CHAR_RO is used then
+ * pointers to constants are not included in the count.
  *
- * @param ... string arguments.
+ * @param ... Format string with argument.
  *
- * @return number of arguments which are char * or wchar_t *.
+ * @return Number of counted char pointer arguments.
  */
-#define Z_CBPRINTF_HAS_PCHAR_ARGS(flags, fmt, ...) \
-	(FOR_EACH_IDX_FIXED_ARG(Z_CBPRINTF_IS_X_PCHAR, (+), flags, __VA_ARGS__))
-
 #define Z_CBPRINTF_PCHAR_COUNT(flags, ...) \
-	COND_CODE_0(NUM_VA_ARGS_LESS_1(__VA_ARGS__), \
-		    (0), \
-		    (Z_CBPRINTF_HAS_PCHAR_ARGS(flags, __VA_ARGS__)))
+	FOR_EACH_IDX_FIXED_ARG(Z_CBPRINTF_IS_X_PCHAR, (+), flags, (const char *)__VA_ARGS__)
 
 /**
  * @brief Check if formatted string must be packaged in runtime.


### PR DESCRIPTION
VSCode macro parser was notifying errors in logging macros. The reason
was char pointer counting macro that VSCode seen as being called with
no enough parameters. There was no issue in the macro so change is
rather to cover for VSCode annoyance.

Issue reported:github.com/microsoft/vscode-cpptools/issues/9187

Additionally, minor change added to log as CBPRINTF_MUST_RUNTIME_PACKAGE
is no longer accepting empty arguments.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>