### PR TITLE
tests/kernel/sched/schedule_api: don't break the test if not divisible

### DIFF
--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_reset.c
@@ -143,8 +143,13 @@ void test_slice_reset(void)
 	uint32_t slice_ticks = k_ms_to_ticks_ceil32(SLICE_SIZE);
 	uint32_t half_slice_cyc = k_ticks_to_cyc_ceil32(slice_ticks / 2);
 
-	__ASSERT(slice_ticks % 2 == 0,
-		 "timeslice in ticks much be divisible by two");
+	if (slice_ticks % 2 != 0) {
+		uint32_t deviation = k_ticks_to_cyc_ceil32(1);
+		/* slice_ticks can't be divisible by two, so we add the
+		 * (slice_ticks / 2) floating part back to half_slice_cyc.
+		 */
+		half_slice_cyc = half_slice_cyc + (deviation / 2);
+	}
 
 	for (int j = 0; j < 2; j++) {
 		k_sem_reset(&sema);


### PR DESCRIPTION
When test tests/kernel/sched/schedule_api, it shows "ASSERTION FAIL:
timeslice in ticks much be divisible by two", then break and fail
the test.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/44887.

On board it8xxx2_evb, it can pass schedule_api test without
the assertion, so I add the floating part back to half_slice_cyc
when the timeslice in ticks can't be divisible by two.
After change, the time slice will be:
1.slice_ticks = (200x8192+999)/1000 = 1639 (not changed)
2.before add the deviation (not handle the floating part):
half_slice_cyc = (1639/2) * (32768/8192) = (819) * (32768/8192) = 3276,
after add the deviation:
half_slice_cyc = 3276 + (32768/8192/2) = 3278,
and it's equal (1639/2) * (32768/8192) = 3278.

Verified by test pattern:
west build -p always -b it8xxx2_evb tests/kernel/sched/schedule_api

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>