### PR TITLE
drivers: remove superfluous default n for boolean types in Kconfig 

### DIFF
--- a/drivers/dac/Kconfig.sam0
+++ b/drivers/dac/Kconfig.sam0
@@ -3,7 +3,6 @@
 
 config DAC_SAM0
 	bool "Atmel SAM0 series DAC Driver"
-	default n
 	depends on SOC_SERIES_SAMD20 || SOC_SERIES_SAMD21
 	help
 	  Enables the Atmel SAM0 MCU Family Digital-to-Analog (DAC) driver.

--- a/drivers/dma/Kconfig.mcux_edma
+++ b/drivers/dma/Kconfig.mcux_edma
@@ -28,7 +28,6 @@ config DMA_MCUX_TEST_SLOT_START
 
 config DMA_MCUX_USE_DTCM_FOR_DMA_DESCRIPTORS
 	bool "Use DTCM for DMA descriptors"
-	default n
 	help
 	  When this option is activated, the descriptors for DMA transfer are
 	  located in the DTCM (Data Tightly Coupled Memory).

--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -57,7 +57,6 @@ config ESPI_FLASH_BUFFER_SIZE
 config ESPI_SAF
 	bool "XEC Microchip ESPI SAF driver"
 	depends on ESPI_FLASH_CHANNEL
-	default n
 	help
 	  Enable Slave Attached Flash eSPI driver. SAF depends upon ESPI XEC driver
 	  and flash channel.

--- a/drivers/espi/Kconfig.xec_v2
+++ b/drivers/espi/Kconfig.xec_v2
@@ -133,7 +133,6 @@ config ESPI_FLASH_BUFFER_SIZE
 config ESPI_SAF
 	bool "XEC Microchip ESPI SAF driver"
 	depends on ESPI_FLASH_CHANNEL
-	default n
 	help
 	  Enable Slave Attached Flash eSPI driver. SAF depends upon ESPI XEC driver
 	  and flash channel.

--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -98,14 +98,12 @@ if !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
 config ETH_STM32_SPEED_10M
 	bool "Set speed to 10 Mbps when autonegotiation is disabled"
-	default n
 	help
 	  Set this if using 10 Mbps and when autonegotiation is disabled, otherwise speed
 	  is 100 Mbps
 
 config ETH_STM32_MODE_HALFDUPLEX
 	bool "Half duplex mode"
-	default n
 	help
 	  Set this if using half duplex when autonegotiation is disabled otherwise
 	  duplex mode is full duplex

--- a/drivers/gpio/Kconfig.pca95xx
+++ b/drivers/gpio/Kconfig.pca95xx
@@ -18,7 +18,6 @@ config GPIO_PCA95XX_INIT_PRIORITY
 
 config GPIO_PCA95XX_INTERRUPT
 	bool "Interrupt enable"
-	default n
 	depends on GPIO_PCA95XX
 	help
 	  Enable interrupt support in PCA95XX driver.

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -23,7 +23,6 @@ config GPIO_SX1509B_INIT_PRIORITY
 
 config GPIO_SX1509B_INTERRUPT
 	bool "Interrupt enable"
-	default n
 	help
 	  Enable support for interrupts on GPIO pins.
 

--- a/drivers/i2s/Kconfig.litex
+++ b/drivers/i2s/Kconfig.litex
@@ -22,10 +22,8 @@ config I2S_LITEX_TX_BLOCK_COUNT
 
 config I2S_LITEX_CHANNELS_CONCATENATED
 	bool "Channels placed without padding in fifo"
-	default n
 
 config I2S_LITEX_DATA_BIG_ENDIAN
 	bool "Received data will be stored as big endian"
-	default n
 
 endif

--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -28,7 +28,6 @@ config PLIC
 
 config SWERV_PIC
 	bool "SweRV EH1 Programmable Interrupt Controller (PIC)"
-	default n
 	help
 	  Programmable Interrupt Controller for the SweRV EH1 RISC-V CPU;
 

--- a/drivers/pcie/endpoint/Kconfig.iproc
+++ b/drivers/pcie/endpoint/Kconfig.iproc
@@ -5,7 +5,6 @@
 
 menuconfig PCIE_EP_IPROC
 	bool "Broadcom iProc PCIe EP driver"
-	default n
 	help
 	  This option enables Broadcom iProc PCIe EP driver.
 
@@ -13,10 +12,8 @@ if PCIE_EP_IPROC
 
 config PCIE_EP_IPROC_INIT_CFG
 	bool "Re-initialize PCIe MSI/MSIX configurations"
-	default n
 
 config PCIE_EP_IPROC_V2
 	bool "Version-2 of iProc PCIe EP controller"
-	default n
 
 endif # PCIE_EP_IPROC

--- a/drivers/sensor/qdec_sam/Kconfig
+++ b/drivers/sensor/qdec_sam/Kconfig
@@ -7,6 +7,5 @@
 config QDEC_SAM
 	bool "Atmel SAM QDEC driver"
 	depends on SOC_FAMILY_SAM
-	default n
 	help
 	  Atmel SAM MCU family Quadrature Decoder (TC) driver.

--- a/drivers/serial/Kconfig.xen
+++ b/drivers/serial/Kconfig.xen
@@ -37,7 +37,6 @@ config XEN_EARLY_CONSOLEIO
 	bool "Early printk/stdout through console_io Xen interface"
 	depends on BOARD_XENVM
 	depends on UART_XEN_HVC
-	default n
 	help
 	  Enable setting of console_io symbol hook for stdout and printk.
 	  Log output will become available on PRE_KERNEL_1 stage. Requires

--- a/drivers/watchdog/Kconfig.it8xxx2
+++ b/drivers/watchdog/Kconfig.it8xxx2
@@ -21,7 +21,6 @@ config WDT_ITE_WARNING_LEADING_TIME_MS
 config WDT_ITE_REDUCE_WARNING_LEADING_TIME
 	bool "Reduce warning leading time"
 	depends on SOC_IT8XXX2
-	default n
 	help
 	  Once warning timer triggered, if watchdog timer isn't reloaded,
 	  then we will reduce interval of warning timer to 30ms to print


### PR DESCRIPTION
bool symbols implicitly default to n so there is no need to redundant those values.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>