### PR TITLE
modules/hal_st: Align sensor drivers to stmemsc HAL i/f v2.01

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_st
-      revision: 575de9d461aa6f430cf62c58a053675377e700f3
+      revision: 52a522ca4a8a9ec1e9bb5bb514e1ab6f102863fe
       path: modules/hal/st
       groups:
         - hal


### PR DESCRIPTION
Align all sensor drivers that are using stmemsc (STdC) HAL i/f
to new APIs of stmemsc v2.01.

Requires https://github.com/zephyrproject-rtos/hal_st/pull/9

