### PR TITLE
twister: set encoding during open log file

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2277,6 +2277,8 @@ class CMake():
         self.generator = None
         self.generator_cmd = None
 
+        self.default_encoding = sys.getdefaultencoding()
+
     def parse_generated(self):
         self.defconfig = {}
         return {}
@@ -2310,8 +2312,8 @@ class CMake():
             results = {'msg': msg, "returncode": p.returncode, "instance": self.instance}
 
             if out:
-                log_msg = out.decode(sys.getdefaultencoding())
-                with open(os.path.join(self.build_dir, self.log), "a") as log:
+                log_msg = out.decode(self.default_encoding)
+                with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
                     log.write(log_msg)
 
             else:
@@ -2320,8 +2322,8 @@ class CMake():
             # A real error occurred, raise an exception
             log_msg = ""
             if out:
-                log_msg = out.decode(sys.getdefaultencoding())
-                with open(os.path.join(self.build_dir, self.log), "a") as log:
+                log_msg = out.decode(self.default_encoding)
+                with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
                     log.write(log_msg)
 
             if log_msg:
@@ -2401,8 +2403,8 @@ class CMake():
             results = {"returncode": p.returncode}
 
         if out:
-            with open(os.path.join(self.build_dir, self.log), "a") as log:
-                log_msg = out.decode(sys.getdefaultencoding())
+            with open(os.path.join(self.build_dir, self.log), "a", encoding=self.default_encoding) as log:
+                log_msg = out.decode(self.default_encoding)
                 log.write(log_msg)
 
         return results


### PR DESCRIPTION
When file is open in Python by `open()` function on Windows OS, it is opened with `cp1252` encoding by default. This could lead to problem when Twister want to save CMake output with `utf-8` encoding into such file with `cp1252` encoding. Especially when in CMake output are stored some characters, which do not exists in `cp1252` encoding.

This problem was discovered when I run Twister on Windows and Twister tried to save CMake output which contains `￼` (`OBJECT REPLACEMENT CHARACTER U+FFFC`) character came from this place:
https://github.com/zephyrproject-rtos/zephyr/blob/c5b59282d6bcbcc5eedaf29b386c90c77036440b/subsys/logging/CMakeLists.txt#L113


I already made PR with removal those unnecessary characters:
https://github.com/zephyrproject-rtos/zephyr/pull/44880
but for the future Twister should be able to save such characters with no raised errors.

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>