### PR TITLE
Unicast server stream control

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1958,8 +1958,8 @@ int bt_audio_stream_stop(struct bt_audio_stream *stream);
 
 /** @brief Release Audio Stream
  *
- *  This procedure is used by a client to release a unicast or broadcast
- *  source stream.
+ *  This procedure is used by a unicast client or unicast server to release a
+ *  unicast stream.
  *
  *  Broadcast sink streams cannot be released, but can be deleted by
  *  bt_audio_broadcast_sink_delete().

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1917,7 +1917,8 @@ int bt_audio_stream_metadata(struct bt_audio_stream *stream,
 
 /** @brief Disable Audio Stream
  *
- *  This procedure is used by a client to disable a stream.
+ *  This procedure is used by a unicast client or unicast server to disable a
+ *  stream.
  *
  *  This shall only be called for unicast streams, as broadcast streams will
  *  always be enabled once created.

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1903,7 +1903,8 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
 
 /** @brief Change Audio Stream Metadata
  *
- *  This procedure is used by a client to change the metadata of a stream.
+ *  This procedure is used by a unicast client or unicast server to change the
+ *  metadata of a stream.
  *
  *  @param stream Stream object
  *  @param meta_count Number of metadata entries

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1279,7 +1279,7 @@ struct bt_audio_stream {
 	/** Endpoint reference */
 	struct bt_audio_ep *ep;
 	/** Codec Configuration */
-	struct bt_codec *codec;
+	const struct bt_codec *codec;
 	/** QoS Configuration */
 	struct bt_codec_qos *qos;
 	/** ISO channel reference */
@@ -1856,8 +1856,8 @@ int bt_audio_stream_config(struct bt_conn *conn,
 
 /** @brief Reconfigure Audio Stream
  *
- *  This procedure is used by a client to reconfigure a stream using the
- *  a different local capability and/or codec configuration.
+ *  This procedure is used by a unicast client or unicast server to reconfigure
+ *  a stream to use a different local codec configuration.
  *
  *  This can only be done for unicast streams.
  *
@@ -1867,7 +1867,7 @@ int bt_audio_stream_config(struct bt_conn *conn,
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_stream_reconfig(struct bt_audio_stream *stream,
-			     struct bt_codec *codec);
+			     const struct bt_codec *codec);
 
 /** @brief Configure Audio Stream QoS
  *

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1932,7 +1932,8 @@ int bt_audio_stream_disable(struct bt_audio_stream *stream);
 
 /** @brief Start Audio Stream
  *
- *  This procedure is used by a client to make a stream start streaming.
+ *  This procedure is used by a unicast client or unicast server to make a
+ *  stream start streaming.
  *
  *  This shall only be called for unicast streams.
  *  Broadcast sinks will always be started once synchronized, and broadcast

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1648,9 +1648,9 @@ static int ascs_verify_metadata(const struct net_buf_simple *buf,
 	return 0;
 }
 
-static int ascs_ep_set_metadata(struct bt_audio_ep *ep,
-				struct net_buf_simple *buf, uint8_t len,
-				struct bt_codec *codec)
+int ascs_ep_set_metadata(struct bt_audio_ep *ep,
+			 struct net_buf_simple *buf, uint8_t len,
+			 struct bt_codec *codec)
 {
 	struct net_buf_simple meta_ltv;
 	int err;

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -361,3 +361,6 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 }
 
 void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state);
+int ascs_ep_set_metadata(struct bt_audio_ep *ep,
+			 struct net_buf_simple *buf, uint8_t len,
+			 struct bt_codec *codec);

--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -359,3 +359,5 @@ static inline const char *bt_ascs_reason_str(uint8_t reason)
 
 	return "Unknown";
 }
+
+void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state);

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -722,45 +722,6 @@ int bt_audio_stream_metadata(struct bt_audio_stream *stream,
 	return 0;
 }
 
-int bt_audio_stream_disable(struct bt_audio_stream *stream)
-{
-	uint8_t role;
-	int err;
-
-	BT_DBG("stream %p", stream);
-
-	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
-		BT_DBG("Invalid stream");
-		return -EINVAL;
-	}
-
-	role = stream->conn->role;
-	if (role != BT_HCI_ROLE_CENTRAL) {
-		BT_DBG("Invalid conn role: %u, shall be central", role);
-		return -EINVAL;
-	}
-
-	switch (stream->ep->status.state) {
-	/* Valid only if ASE_State field = 0x03 (Enabling) */
-	case BT_AUDIO_EP_STATE_ENABLING:
-	 /* or 0x04 (Streaming) */
-	case BT_AUDIO_EP_STATE_STREAMING:
-		break;
-	default:
-		BT_ERR("Invalid state: %s",
-		       bt_audio_ep_state_str(stream->ep->status.state));
-		return -EBADMSG;
-	}
-
-	err = bt_unicast_client_disable(stream);
-	if (err != 0) {
-		BT_DBG("Disabling stream failed: %d", err);
-		return err;
-	}
-
-	return 0;
-}
-
 int bt_audio_stream_start(struct bt_audio_stream *stream)
 {
 	uint8_t role;
@@ -1139,6 +1100,50 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group)
 }
 
 #endif /* CONFIG_BT_AUDIO_UNICAST_CLIENT */
+
+int bt_audio_stream_disable(struct bt_audio_stream *stream)
+{
+	uint8_t state;
+	uint8_t role;
+	int err;
+
+	BT_DBG("stream %p", stream);
+
+	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+		BT_DBG("Invalid stream");
+		return -EINVAL;
+	}
+
+	state = stream->ep->status.state;
+	switch (state) {
+	/* Valid only if ASE_State field = 0x03 (Enabling) */
+	case BT_AUDIO_EP_STATE_ENABLING:
+	 /* or 0x04 (Streaming) */
+	case BT_AUDIO_EP_STATE_STREAMING:
+		break;
+	default:
+		BT_ERR("Invalid state: %s", bt_audio_ep_state_str(state));
+		return -EBADMSG;
+	}
+
+	role = stream->conn->role;
+	if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_CLIENT) &&
+	    role == BT_HCI_ROLE_CENTRAL) {
+		err = bt_unicast_client_disable(stream);
+	} else if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_SERVER) &&
+		   role == BT_HCI_ROLE_PERIPHERAL) {
+		err = bt_unicast_server_disable(stream);
+	} else {
+		err = -EOPNOTSUPP;
+	}
+
+	if (err != 0) {
+		BT_DBG("Disabling stream failed: %d", err);
+		return err;
+	}
+
+	return 0;
+}
 
 int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache)
 {

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -681,47 +681,6 @@ int bt_audio_stream_enable(struct bt_audio_stream *stream,
 	return 0;
 }
 
-int bt_audio_stream_metadata(struct bt_audio_stream *stream,
-			     struct bt_codec_data *meta,
-			     size_t meta_count)
-{
-	uint8_t role;
-	int err;
-
-	BT_DBG("stream %p metadata count %u", stream, meta_count);
-
-	if (stream == NULL || stream->ep == NULL || stream->conn == NULL) {
-		BT_DBG("Invalid stream");
-		return -EINVAL;
-	}
-
-	role = stream->conn->role;
-	if (role != BT_HCI_ROLE_CENTRAL) {
-		BT_DBG("Invalid conn role: %u, shall be central", role);
-		return -EINVAL;
-	}
-
-	switch (stream->ep->status.state) {
-	/* Valid for an ASE only if ASE_State field = 0x03 (Enabling) */
-	case BT_AUDIO_EP_STATE_ENABLING:
-	/* or 0x04 (Streaming) */
-	case BT_AUDIO_EP_STATE_STREAMING:
-		break;
-	default:
-		BT_ERR("Invalid state: %s",
-		       bt_audio_ep_state_str(stream->ep->status.state));
-		return -EBADMSG;
-	}
-
-	err = bt_unicast_client_metadata(stream, meta, meta_count);
-	if (err != 0) {
-		BT_DBG("Updating metadata failed: %d", err);
-		return err;
-	}
-
-	return 0;
-}
-
 int bt_audio_stream_start(struct bt_audio_stream *stream)
 {
 	uint8_t role;
@@ -1100,6 +1059,58 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group)
 }
 
 #endif /* CONFIG_BT_AUDIO_UNICAST_CLIENT */
+
+int bt_audio_stream_metadata(struct bt_audio_stream *stream,
+			     struct bt_codec_data *meta,
+			     size_t meta_count)
+{
+	uint8_t state;
+	uint8_t role;
+	int err;
+
+	BT_DBG("stream %p metadata count %u", stream, meta_count);
+
+	CHECKIF(stream == NULL || stream->ep == NULL || stream->conn == NULL) {
+		BT_DBG("Invalid stream");
+		return -EINVAL;
+	}
+
+	CHECKIF((meta == NULL && meta_count != 0U) ||
+		(meta != NULL && meta_count == 0U)) {
+		BT_DBG("Invalid meta (%p) or count (%zu)", meta, meta_count);
+		return -EINVAL;
+	}
+
+	state = stream->ep->status.state;
+	switch (state) {
+	/* Valid for an ASE only if ASE_State field = 0x03 (Enabling) */
+	case BT_AUDIO_EP_STATE_ENABLING:
+	/* or 0x04 (Streaming) */
+	case BT_AUDIO_EP_STATE_STREAMING:
+		break;
+	default:
+		BT_ERR("Invalid state: %s", bt_audio_ep_state_str(state));
+		return -EBADMSG;
+	}
+
+	role = stream->conn->role;
+	if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_CLIENT) &&
+	    role == BT_HCI_ROLE_CENTRAL) {
+		err = bt_unicast_client_metadata(stream, meta, meta_count);
+	} else if (IS_ENABLED(CONFIG_BT_AUDIO_UNICAST_SERVER) &&
+		   role == BT_HCI_ROLE_PERIPHERAL) {
+		err = bt_unicast_server_metadata(stream, meta, meta_count);
+	} else {
+		err = -EOPNOTSUPP;
+	}
+
+	if (err != 0) {
+		BT_DBG("Updating metadata failed: %d", err);
+		return err;
+	}
+
+	return 0;
+}
 
 int bt_audio_stream_disable(struct bt_audio_stream *stream)
 {

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -830,10 +830,10 @@ static void unicast_client_ep_set_status(struct bt_audio_ep *ep,
 static void unicast_client_codec_data_add(struct net_buf_simple *buf,
 					  const char *prefix,
 					  size_t num,
-					  struct bt_codec_data *data)
+					  const struct bt_codec_data *data)
 {
 	for (size_t i = 0; i < num; i++) {
-		struct bt_data *d = &data[i].data;
+		const struct bt_data *d = &data[i].data;
 		struct bt_ascs_codec_config *cc;
 
 		BT_DBG("#%u: %s type 0x%02x len %u", i, prefix, d->type,
@@ -1198,7 +1198,7 @@ struct net_buf_simple *bt_unicast_client_ep_create_pdu(uint8_t op)
 
 static int unicast_client_ep_config(struct bt_audio_ep *ep,
 				    struct net_buf_simple *buf,
-				    struct bt_codec *codec)
+				    const struct bt_codec *codec)
 {
 	struct bt_ascs_config *req;
 	uint8_t cc_len;
@@ -1547,7 +1547,7 @@ void bt_unicast_client_ep_detach(struct bt_audio_ep *ep,
 }
 
 int bt_unicast_client_config(struct bt_audio_stream *stream,
-			     struct bt_codec *codec)
+			     const struct bt_codec *codec)
 {
 	struct bt_audio_ep *ep = stream->ep;
 	struct bt_ascs_config_op *op;

--- a/subsys/bluetooth/audio/unicast_client_internal.h
+++ b/subsys/bluetooth/audio/unicast_client_internal.h
@@ -7,7 +7,7 @@
  */
 
 int bt_unicast_client_config(struct bt_audio_stream *stream,
-		  struct bt_codec *codec);
+			     const struct bt_codec *codec);
 
 int bt_unicast_client_enable(struct bt_audio_stream *stream,
 			     struct bt_codec_data *meta,

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -53,6 +53,25 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 	return 0;
 }
 
+int bt_unicast_server_start(struct bt_audio_stream *stream)
+{
+	int err;
+
+	if (unicast_server_cb != NULL && unicast_server_cb->start != NULL) {
+		err = unicast_server_cb->start(stream);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	if (err != 0) {
+		return err;
+	}
+
+	ascs_ep_set_state(stream->ep, BT_AUDIO_EP_STATE_STREAMING);
+
+	return 0;
+}
+
 int bt_unicast_server_metadata(struct bt_audio_stream *stream,
 			       struct bt_codec_data meta[],
 			       size_t meta_count)

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -11,8 +11,7 @@
 #include <zephyr/bluetooth/audio/audio.h>
 
 #include "pacs_internal.h"
-#include "stream.h"
-#include "ascs_internal.h"
+#include "endpoint.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_UNICAST_SERVER)
 #define LOG_MODULE_NAME bt_unicast_server
@@ -50,6 +49,35 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 	}
 
 	unicast_server_cb = NULL;
+
+	return 0;
+}
+
+int bt_unicast_server_disable(struct bt_audio_stream *stream)
+{
+	struct bt_audio_ep *ep;
+	int err;
+
+	if (unicast_server_cb != NULL && unicast_server_cb->disable != NULL) {
+		err = unicast_server_cb->disable(stream);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	if (err != 0) {
+		return err;
+	}
+
+	ep = stream->ep;
+
+	/* The ASE state machine goes into different states from this operation
+	 * based on whether it is a source or a sink ASE.
+	 */
+	if (ep->dir == BT_AUDIO_DIR_SOURCE) {
+		ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_DISABLING);
+	} else {
+		ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_QOS_CONFIGURED);
+	}
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -53,6 +53,36 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 	return 0;
 }
 
+int bt_unicast_server_metadata(struct bt_audio_stream *stream,
+			       struct bt_codec_data meta[],
+			       size_t meta_count)
+{
+	struct bt_audio_ep *ep;
+	int err;
+
+
+	if (unicast_server_cb != NULL && unicast_server_cb->metadata != NULL) {
+		err = unicast_server_cb->metadata(stream, meta, meta_count);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	ep = stream->ep;
+	for (size_t i = 0U; i < meta_count; i++) {
+		(void)memcpy(&ep->codec.meta[i], &meta[i],
+			     sizeof(ep->codec.meta[i]));
+	}
+
+	if (err) {
+		return err;
+	}
+
+	/* Set the state to the same state to trigger the notifications */
+	ascs_ep_set_state(ep, ep->status.state);
+
+	return 0;
+}
+
 int bt_unicast_server_disable(struct bt_audio_stream *stream)
 {
 	struct bt_audio_ep *ep;

--- a/subsys/bluetooth/audio/unicast_server.c
+++ b/subsys/bluetooth/audio/unicast_server.c
@@ -53,6 +53,33 @@ int bt_audio_unicast_server_unregister_cb(const struct bt_audio_unicast_server_c
 	return 0;
 }
 
+int bt_unicast_server_reconfig(struct bt_audio_stream *stream,
+			       const struct bt_codec *codec)
+{
+	struct bt_audio_ep *ep;
+	int err;
+
+	ep = stream->ep;
+
+	if (unicast_server_cb != NULL &&
+		unicast_server_cb->reconfig != NULL) {
+		err = unicast_server_cb->reconfig(stream, ep->dir, codec,
+						  &ep->qos_pref);
+	} else {
+		err = -ENOTSUP;
+	}
+
+	if (err != 0) {
+		return err;
+	}
+
+	(void)memcpy(&ep->codec, &codec, sizeof(codec));
+
+	ascs_ep_set_state(ep, BT_AUDIO_EP_STATE_CODEC_CONFIGURED);
+
+	return 0;
+}
+
 int bt_unicast_server_start(struct bt_audio_stream *stream)
 {
 	int err;

--- a/subsys/bluetooth/audio/unicast_server.h
+++ b/subsys/bluetooth/audio/unicast_server.h
@@ -10,5 +10,8 @@
 
 extern const struct bt_audio_unicast_server_cb *unicast_server_cb;
 
+int bt_unicast_server_metadata(struct bt_audio_stream *stream,
+			       struct bt_codec_data meta[],
+			       size_t meta_count);
 int bt_unicast_server_disable(struct bt_audio_stream *stream);
 int bt_unicast_server_release(struct bt_audio_stream *stream, bool cache);

--- a/subsys/bluetooth/audio/unicast_server.h
+++ b/subsys/bluetooth/audio/unicast_server.h
@@ -10,6 +10,7 @@
 
 extern const struct bt_audio_unicast_server_cb *unicast_server_cb;
 
+int bt_unicast_server_start(struct bt_audio_stream *stream);
 int bt_unicast_server_metadata(struct bt_audio_stream *stream,
 			       struct bt_codec_data meta[],
 			       size_t meta_count);

--- a/subsys/bluetooth/audio/unicast_server.h
+++ b/subsys/bluetooth/audio/unicast_server.h
@@ -9,3 +9,5 @@
 #include <zephyr/bluetooth/audio/audio.h>
 
 extern const struct bt_audio_unicast_server_cb *unicast_server_cb;
+
+int bt_unicast_server_release(struct bt_audio_stream *stream, bool cache);

--- a/subsys/bluetooth/audio/unicast_server.h
+++ b/subsys/bluetooth/audio/unicast_server.h
@@ -10,6 +10,8 @@
 
 extern const struct bt_audio_unicast_server_cb *unicast_server_cb;
 
+int bt_unicast_server_reconfig(struct bt_audio_stream *stream,
+			       const struct bt_codec *codec);
 int bt_unicast_server_start(struct bt_audio_stream *stream);
 int bt_unicast_server_metadata(struct bt_audio_stream *stream,
 			       struct bt_codec_data meta[],

--- a/subsys/bluetooth/audio/unicast_server.h
+++ b/subsys/bluetooth/audio/unicast_server.h
@@ -10,4 +10,5 @@
 
 extern const struct bt_audio_unicast_server_cb *unicast_server_cb;
 
+int bt_unicast_server_disable(struct bt_audio_stream *stream);
 int bt_unicast_server_release(struct bt_audio_stream *stream, bool cache);


### PR DESCRIPTION
Add support for some of the stream control procedures for the unicast server. 

This should add support for all server procedures except for configuring the ASE first time around (i.e. the server can only reconfigure an endpoint). This is a limitation of the current stream control API. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/44400