### PR TITLE
x86: Initialise FPU regs during thread creation for eager FPU sharing

### DIFF
--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -114,4 +114,18 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	thread->arch.excNestCount = 0;
 #endif /* CONFIG_LAZY_FPU_SHARING */
 	thread->arch.flags = 0;
+
+	/*
+	 * When "eager FPU sharing" mode is enabled, FPU registers must be
+	 * initialised at the time of thread creation because the floating-point
+	 * context is always active and no further FPU initialisation is performed
+	 * later.
+	 */
+#if defined(CONFIG_EAGER_FPU_SHARING)
+	thread->arch.preempFloatReg.floatRegsUnion.fpRegs.fcw = 0x037f;
+	thread->arch.preempFloatReg.floatRegsUnion.fpRegs.ftw = 0xffff;
+#if defined(CONFIG_X86_SSE)
+	thread->arch.preempFloatReg.floatRegsUnion.fpRegsEx.mxcsr = 0x1f80;
+#endif /* CONFIG_X86_SSE */
+#endif /* CONFIG_EAGER_FPU_SHARING */
 }


### PR DESCRIPTION
When "eager FPU sharing" mode is enabled, FPU registers must be
initialised at the time of thread creation because the floating-point
context is always active and no further FPU initialisation is performed
later.

Note that, in case of the "lazy FPU sharing" mode, floating-point
context is inactive by default and the FPU is initialised when the
first floating-point instruction is executed.

Refer to the issue #44902 for more details.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #44902