### PR TITLE
zephyr:ztest: Add Z_TEST_SKIP_IFDEF macro

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -138,6 +138,19 @@ it needs to report either a pass or fail.  For example::
 		ztest_run_test_suite(common);
 	}
 
+Use the following macro at the start of your test to skip it with a KConfig
+option.
+
+#define Z_TEST_SKIP_IFDEF(config)
+
+For example::
+
+	void test_test1(void)
+	{
+		Z_TEST_SKIP_IFDEF(CONFIG_BUGxxxxx);
+		zassert_equal(1, 0, NULL);
+	}
+
 Quick start - Unit testing
 **************************
 

--- a/subsys/testsuite/ztest/include/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/ztest_test_new.h
@@ -211,6 +211,16 @@ static inline void unit_test_noop(void)
 #define Z_ZTEST_F(suite, fn, t_options) Z_TEST(suite, fn, t_options, 1)
 
 /**
+ * @brief Skips the test if config is enabled
+ *
+ * Use this macro at the start of your test case, to skip it when
+ * config is enabled.  Useful when your test is still under development.
+ *
+ * @param config The Kconfig option used to skip the test.
+ */
+#define Z_TEST_SKIP_IFDEF(config) COND_CODE_1(config, (ztest_test_skip()), ())
+
+/**
  * @brief Create and register a new unit test.
  *
  * Calling this macro will create a new unit test and attach it to the declared `suite`. The `suite`

--- a/tests/ztest/base/Kconfig
+++ b/tests/ztest/base/Kconfig
@@ -1,0 +1,9 @@
+# Copyright 2022 Google LLC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config BUGxxxxx
+	bool
+	default y
+
+source "Kconfig.zephyr"

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -35,6 +35,12 @@ ZTEST(framework_tests, test_assert_mem_equal)
 	zassert_mem_equal(actual, expected, sizeof(expected), NULL);
 }
 
+ZTEST(framework_tests, test_skip_config)
+{
+	Z_TEST_SKIP_IFDEF(CONFIG_BUGxxxxx);
+	zassert_true(false, NULL);
+}
+
 /***************************************************************************************************
  * Sample fixture tests
  **************************************************************************************************/


### PR DESCRIPTION
Defined Z_TEST_SKIP_IFDEF macro to skip tests when specified
config is enabled.

Signed-off-by: Al Semjonovs <asemjonovs@google.com>