### PR TITLE
subsys: remove superfluous default n for boolean types in Kconfig

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.mics
+++ b/subsys/bluetooth/audio/Kconfig.mics
@@ -10,7 +10,6 @@
 
 config BT_MICS
 	bool "Microphone Input Control Service Support [EXPERIMENTAL]"
-	default n
 	select EXPERIMENTAL
 	help
 	  This option enables support for Microphone Input Control Service.

--- a/subsys/bluetooth/audio/Kconfig.vcs
+++ b/subsys/bluetooth/audio/Kconfig.vcs
@@ -10,7 +10,6 @@
 
 config BT_VCS
 	bool "Volume Control Service Support [EXPERIMENTAL]"
-	default n
 	select EXPERIMENTAL
 	help
 	  This option enables support for Volume Control Service.
@@ -63,7 +62,6 @@ config BT_VCS_CLIENT
 	select BT_GATT_CLIENT
 	select BT_GATT_AUTO_DISCOVER_CCC
 	select EXPERIMENTAL
-	default n
 	help
 	  This option enables support for Volume Control Profile.
 

--- a/subsys/canbus/isotp/Kconfig
+++ b/subsys/canbus/isotp/Kconfig
@@ -91,7 +91,6 @@ config ISOTP_RX_SF_FF_BUF_COUNT
 
 config ISOTP_USE_TX_BUF
 	bool "Buffer tx writes"
-	default n
 	help
 	  Copy the outgoing data to a net buffer so that the calling function
 	  can discard the data.

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -108,7 +108,6 @@ config LOG_BACKEND_FORMAT_TIMESTAMP
 
 config LOG_OUTPUT_FORMAT_LINUX_TIMESTAMP
 	bool "Format timestamp in Linux format"
-	default n
 	help
 	  This formatting is something in the middle between the pure raw format
 	  and the hh:mm:ss:ms,us one. It resembles the Linux's kernel format in

--- a/subsys/net/Kconfig
+++ b/subsys/net/Kconfig
@@ -73,7 +73,6 @@ if NETWORKING
 # which supports PM properly.
 config NET_POWER_MANAGEMENT
 	bool
-	default n
 	depends on PM_DEVICE
 
 source "subsys/net/Kconfig.hostname"

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -119,7 +119,6 @@ config SHELL_ECHO_STATUS
 
 config SHELL_START_OBSCURED
 	bool "Display asterisk when echoing"
-	default n
 	help
 	  If enabled, don't echo actual character, but echo * instead.
 	  This is used for login prompts.

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -63,7 +63,6 @@ config ZTEST_RETEST_IF_PASSED
 
 config ZTEST_FATAL_HOOK
 	bool "Using a pre-defined fatal handler and hook function"
-	default n
 	help
 	  Use the pre-defined common fatal error handler and a post hook to
 	  do actions in your test case, this option often enabled when doing
@@ -72,7 +71,6 @@ config ZTEST_FATAL_HOOK
 
 config ZTEST_ASSERT_HOOK
 	bool "Using a pre-defined assert handler and hook function"
-	default n
 	help
 	  Use the pre-defined common assert fail handler and a post hook to
 	  do actions in your test case, this option often enabled when doing

--- a/subsys/tracing/Kconfig
+++ b/subsys/tracing/Kconfig
@@ -204,7 +204,6 @@ config TRACING_CMD_BUFFER_SIZE
 
 config TRACING_OBJECT_TRACKING
 	bool "Object tracking"
-	default n
 	help
 	  Keep lists to track kernel objects.
 


### PR DESCRIPTION
bool symbols implicitly default to n so there is no need to redundant those values.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>