### PR TITLE
logging: fix LOG_TAG_MAX_LEN min warning

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -1271,10 +1271,7 @@ const char *z_log_get_tag(void)
 
 int log_set_tag(const char *str)
 {
-	if (CONFIG_LOG_TAG_MAX_LEN == 0) {
-		return -ENOTSUP;
-	}
-
+#if CONFIG_LOG_TAG_MAX_LEN > 0
 	if (str == NULL) {
 		return -EINVAL;
 	}
@@ -1291,6 +1288,9 @@ int log_set_tag(const char *str)
 	}
 
 	return 0;
+#else
+	return -ENOTSUP;
+#endif
 }
 
 int log_mem_get_usage(uint32_t *buf_size, uint32_t *usage)


### PR DESCRIPTION
if CONFIG_LOG_TAG_MAX_LEN is 0, then a warning would be generated
on the MIN macro always being false, but as
CONFIG_LOG_TAG_MAX_LEN is a constant, then it is better to just
compile out the function if it's 0.

Signed-off-by: Ryan McClelland <ryanmcclelland@fb.com>