### PR TITLE
boards: arm: stm32f746g_disco: add support for fmc

### DIFF
--- a/boards/arm/stm32f746g_disco/doc/index.rst
+++ b/boards/arm/stm32f746g_disco/doc/index.rst
@@ -116,6 +116,8 @@ The Zephyr stm32f746g_disco board configuration supports the following hardware 
 +-----------+------------+-------------------------------------+
 | QSPI NOR  | on-chip    | off-chip flash                      |
 +-----------+------------+-------------------------------------+
+| FMC       | on-chip    | memc (SDRAM)                        |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 
@@ -147,6 +149,13 @@ configured as follows
 - LD1 : PI1
 - USB DM : PA11
 - USB DP : PA12
+- FMC SDRAM :
+    - D0-D15 : PD14/PD15/PD0/PD1/PE7/PE8/PE9/PE10/PE11/PE12/PE13/PE14/PE15/PD8/PD9/PD10
+    - A0-A11 : PF0/PF1/PF2/PF3/PF4/PF5/PF12/PF13/PF14/PF15/PG0/PG1
+    - A14/A15 : PG4/PG5
+    - SDNRAS/SDNCAS : PF11/PG15
+    - NBL0/NBL1 : PE0/PE1
+    - SDCLK/SDNWE/SDCKE0/SDNE0 : PG8/PH5/PC3/PH3
 
 System Clock
 ============

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -38,6 +38,13 @@
 		};
 	};
 
+	sdram1: sdram@c0000000 {
+		compatible = "zephyr,memory-region", "mmio-sram";
+		device_type = "memory";
+		reg = <0xc0000000 DT_SIZE_M(16)>;
+		zephyr,memory-region = "SDRAM1";
+	};
+
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
@@ -182,6 +189,45 @@ zephyr_udc0: &usbotg_fs {
 				label = "storage";
 				reg = <0x000a0000 DT_SIZE_M(15)>;
 			};
+		};
+	};
+};
+
+&fmc {
+	pinctrl-0 = <&fmc_nbl0_pe0 &fmc_nbl1_pe1
+		&fmc_sdclk_pg8 &fmc_sdnwe_ph5 &fmc_sdcke0_pc3
+		&fmc_sdne0_ph3 &fmc_sdnras_pf11 &fmc_sdncas_pg15
+
+		&fmc_a0_pf0 &fmc_a1_pf1 &fmc_a2_pf2 &fmc_a3_pf3 &fmc_a4_pf4
+		&fmc_a5_pf5 &fmc_a6_pf12 &fmc_a7_pf13 &fmc_a8_pf14
+		&fmc_a9_pf15 &fmc_a10_pg0 &fmc_a11_pg1
+		&fmc_a14_pg4 &fmc_a15_pg5
+
+		&fmc_d0_pd14 &fmc_d1_pd15
+		&fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
+		&fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
+		&fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
+		&fmc_d15_pd10>;
+	pinctrl-names = "default";
+	status = "okay";
+
+	sdram {
+		status = "okay";
+		power-up-delay = <100>;
+		num-auto-refresh = <8>;
+		mode-register = <0x220>;
+		refresh-rate = <0x603>;
+		bank@0 {
+			reg = <0>;
+			st,sdram-control = <STM32_FMC_SDRAM_NC_8
+					STM32_FMC_SDRAM_NR_12
+					STM32_FMC_SDRAM_MWID_16
+					STM32_FMC_SDRAM_NB_4
+					STM32_FMC_SDRAM_CAS_2
+					STM32_FMC_SDRAM_SDCLK_PERIOD_2
+					STM32_FMC_SDRAM_RBURST_ENABLE
+					STM32_FMC_SDRAM_RPIPE_0>;
+			st,sdram-timing = <2 7 4 7 2 2 2>;
 		};
 	};
 };

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.yaml
@@ -19,3 +19,4 @@ supported:
   - sdhc
   - usb_device
   - kscan:touch
+  - memc


### PR DESCRIPTION
Using these PRs as example (https://github.com/zephyrproject-rtos/zephyr/pull/41981, https://github.com/zephyrproject-rtos/zephyr/pull/43965 and https://github.com/zephyrproject-rtos/zephyr/pull/44533)
Adding support for FMC (Flexible Memory Controller) as a prerequisite to add support for LTDC in the future.
An application using LVGL with frame buffer allocated in SDRAM was tested with no problems.