### PR TITLE
ci: twister: Trigger on release branches

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v*-branch
   pull_request_target:
     branches:
       - main
+      - v*-branch
   schedule:
     # Run at 00:00 on Wednesday and Saturday
     - cron: '0 0 * * 3,6'


### PR DESCRIPTION
This commit updates the Twister workflow to trigger on all pushes and
pull requests to the release branches.

Note that this change in itself does not make the Twister workflow run
on the existing release branches -- what this does is to prepare for
the future release branches to run the Twister workflow in them.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>