### PR TITLE
device: useful injected devices

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -580,6 +580,52 @@ device_required_handles_get(const struct device *dev,
 }
 
 /**
+ * @brief Get the device handles for injected dependencies of this device.
+ *
+ * This function returns a pointer to an array of device handles. The
+ * length of the array is stored in the @p count parameter.
+ *
+ * The array contains a handle for each device that @p dev manually injected
+ * as a dependency, via providing extra arguments to Z_DEVICE_DEFINE. This does
+ * not include transitive dependencies; you must recursively determine those.
+ *
+ * @param dev the device for which injected dependencies are desired.
+ *
+ * @param count pointer to where this function should store the length
+ * of the returned array. No value is stored if the call returns a
+ * null pointer. The value may be set to zero if the device has no
+ * devicetree dependencies.
+ *
+ * @return a pointer to a sequence of @p *count device handles, or a null
+ * pointer if @p dev does not have any dependency data.
+ */
+static inline const device_handle_t *
+device_injected_handles_get(const struct device *dev,
+			    size_t *count)
+{
+	const device_handle_t *rv = dev->handles;
+	size_t region = 0;
+	size_t i = 0;
+
+	if (rv != NULL) {
+		/* Fast forward to injected devices */
+		while (region != 1) {
+			if (*rv == DEVICE_HANDLE_SEP) {
+				region++;
+			}
+			rv++;
+		}
+		while ((rv[i] != DEVICE_HANDLE_ENDS)
+		       && (rv[i] != DEVICE_HANDLE_SEP)) {
+			++i;
+		}
+		*count = i;
+	}
+
+	return rv;
+}
+
+/**
  * @brief Get the set of handles that this device supports.
  *
  * This function returns a pointer to an array of device handles. The

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -858,7 +858,7 @@ __deprecated static inline int device_usable_check(const struct device *dev)
  * {
  *     List of existing devicetree dependency handles (if any),
  *     DEVICE_HANDLE_SEP,
- *     List of injected dependency ordinals (if any),
+ *     List of injected devicetree dependency handles (if any),
  *     DEVICE_HANDLE_SEP,
  *     List of existing devicetree support handles (if any),
  *     DEVICE_HANDLE_NULL

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -245,7 +245,7 @@ def main():
         hv = handle.handles
         hvi = 1
         handle.dev_deps = []
-        handle.ext_deps = []
+        handle.dev_injected = []
         handle.dev_sups = []
         hdls = handle.dev_deps
         while hvi < len(hv):
@@ -254,7 +254,7 @@ def main():
                 break
             if h == DEVICE_HANDLE_SEP:
                 if hdls == handle.dev_deps:
-                    hdls = handle.ext_deps
+                    hdls = handle.dev_injected
                 else:
                     hdls = handle.dev_sups
             else:
@@ -307,7 +307,7 @@ def main():
             hs = dev.handle
             assert hs, "no hs for %s" % (dev.sym.name,)
             dep_paths = []
-            ext_paths = []
+            inj_paths = []
             sup_paths = []
             hdls = []
 
@@ -321,10 +321,13 @@ def main():
                         dep_paths.append('(%s)' % dn.path)
             # Force separator to signal start of injected dependencies
             hdls.append(DEVICE_HANDLE_SEP)
-            if len(hs.ext_deps) > 0:
-                # TODO: map these to something smaller?
-                ext_paths.extend(map(str, hs.ext_deps))
-                hdls.extend(hs.ext_deps)
+            for inj in hs.dev_injected:
+                if inj not in edt.dep_ord2node:
+                    continue
+                expected = edt.dep_ord2node[inj]
+                if expected in used_nodes:
+                    inj_paths.append(expected.path)
+                    hdls.append(expected.__device.dev_handle)
 
             # Force separator to signal start of supported devices
             hdls.append(DEVICE_HANDLE_SEP)
@@ -347,9 +350,9 @@ def main():
             if len(dep_paths) > 0:
                 lines.append(' * Direct Dependencies:')
                 lines.append(' *   - %s' % ('\n *   - '.join(dep_paths)))
-            if len(ext_paths) > 0:
+            if len(inj_paths) > 0:
                 lines.append(' * Injected Dependencies:')
-                lines.append(' *   - %s' % ('\n *   - '.join(ext_paths)))
+                lines.append(' *   - %s' % ('\n *   - '.join(inj_paths)))
             if len(sup_paths) > 0:
                 lines.append(' * Supported:')
                 lines.append(' *   - %s' % ('\n *   - '.join(sup_paths)))

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -324,7 +324,6 @@ def main():
             if len(hs.ext_deps) > 0:
                 # TODO: map these to something smaller?
                 ext_paths.extend(map(str, hs.ext_deps))
-                hdls.append(DEVICE_HANDLE_SEP)
                 hdls.extend(hs.ext_deps)
 
             # Force separator to signal start of supported devices

--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -61,7 +61,7 @@
 			test_dev_c: test-i2c-dev@13 {
 				compatible = "vnd,i2c-device";
 				label = "TEST_SPI_DEV_0";
-				reg = <13>;
+				reg = <0x13>;
 				status = "disabled";
 
 				partitions {
@@ -79,6 +79,15 @@
 					};
 				};
 			};
+		};
+
+		test_gpio_injected: gpio@1000 {
+			gpio-controller;
+			#gpio-cells = <0x2>;
+			compatible = "vnd,gpio-device";
+			status = "okay";
+			reg = <0x1000 0x1000>;
+			label = "TEST_GPIO_INJECTED";
 		};
 	};
 };

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -16,6 +16,7 @@
 #define TEST_DEVB DT_NODELABEL(test_dev_b)
 #define TEST_DEVC DT_NODELABEL(test_dev_c)
 #define TEST_PARTITION DT_NODELABEL(test_p0)
+#define TEST_GPIO_INJECTED DT_NODELABEL(test_gpio_injected)
 
 static const struct device *devlist;
 static const struct device *devlist_end;
@@ -47,6 +48,9 @@ DEVICE_DT_DEFINE(TEST_DEVC, dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 50, NULL);
 DEVICE_DT_DEFINE(TEST_PARTITION, dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 60, NULL);
+/* Device with both an existing and missing injected dependency */
+DEVICE_DT_DEFINE(TEST_GPIO_INJECTED, dev_init, NULL,
+		 NULL, NULL, POST_KERNEL, 70, NULL, DT_DEP_ORD(TEST_DEVB), 999);
 
 #define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
 
@@ -61,6 +65,12 @@ static void test_init_order(void)
 	zassert_equal(init_order[3], DEV_HDL(TEST_DEVB),
 		      NULL);
 	zassert_equal(init_order[4], DEV_HDL(TEST_GPIOX),
+		      NULL);
+	zassert_equal(init_order[5], DEV_HDL(TEST_DEVC),
+		      NULL);
+	zassert_equal(init_order[6], DEV_HDL(TEST_PARTITION),
+		      NULL);
+	zassert_equal(init_order[7], DEV_HDL(TEST_GPIO_INJECTED),
 		      NULL);
 }
 
@@ -118,6 +128,14 @@ static void test_requires(void)
 	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 
+	/* TEST_GPIO_INJECTED: no req */
+	dev = device_get_binding(DT_LABEL(TEST_GPIO_INJECTED));
+	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
+	hdls = device_required_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
+		      NULL);
+
 	/* TEST_I2C: no req */
 	dev = device_get_binding(DT_LABEL(TEST_I2C));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C), NULL);
@@ -148,11 +166,11 @@ static void test_requires(void)
 	zassert_equal(2, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_I2C)))
-		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_I2C))),
-		      NULL);
+		     || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_I2C))),
+		     NULL);
 	zassert_true((ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_GPIO)))
-		      || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_GPIO))),
-		      NULL);
+		     || (ctx.rdevs[1] == device_from_handle(DEV_HDL(TEST_GPIO))),
+		     NULL);
 
 	/* TEST_GPIOX: TEST_I2C */
 	dev = device_get_binding(DT_LABEL(TEST_GPIOX));
@@ -175,6 +193,35 @@ static void test_requires(void)
 	zassert_equal(nhdls, 2, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
+
+	/* TEST_GPIO_INJECTED: NONE */
+	dev = device_get_binding(DT_LABEL(TEST_GPIO_INJECTED));
+	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
+	hdls = device_required_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+}
+
+static void test_injected(void)
+{
+	size_t nhdls = 0;
+	const device_handle_t *hdls;
+	const struct device *dev;
+
+	/* TEST_GPIO: NONE */
+	dev = device_get_binding(DT_LABEL(TEST_GPIO));
+	hdls = device_injected_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+
+	/* TEST_DEVB: NONE */
+	dev = device_get_binding(DT_LABEL(TEST_DEVB));
+	hdls = device_injected_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+
+	/* TEST_GPIO_INJECTED: TEST_DEVB */
+	dev = device_get_binding(DT_LABEL(TEST_GPIO_INJECTED));
+	hdls = device_injected_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 1, NULL);
+	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);
 }
 
 static void test_get_or_null(void)
@@ -197,6 +244,11 @@ static void test_supports(void)
 
 	/* TEST_DEVB: None */
 	dev = DEVICE_DT_GET(TEST_DEVB);
+	hdls = device_supported_handles_get(dev, &nhdls);
+	zassert_equal(nhdls, 0, NULL);
+
+	/* TEST_GPIO_INJECTED: None */
+	dev = DEVICE_DT_GET(TEST_GPIO_INJECTED);
 	hdls = device_supported_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
 
@@ -247,6 +299,7 @@ void test_main(void)
 	ztest_test_suite(devicetree_driver,
 			 ztest_unit_test(test_init_order),
 			 ztest_unit_test(test_requires),
+			 ztest_unit_test(test_injected),
 			 ztest_unit_test(test_get_or_null),
 			 ztest_unit_test(test_supports)
 			 );


### PR DESCRIPTION
This PR updates the injected device API to be marginally useful.

Ordinals provided as injected dependencies to devices are now converted to device handles, as no useful operations can be done on device ordinals at runtime beyond printing them.

This aligns with the definition of the array:
https://github.com/zephyrproject-rtos/zephyr/blob/13f382287ad050d9600362bffca8bc03b93bbbe4/include/zephyr/device.h#L461-L468

Future work will enable `SYS_INIT` macros to be provided as injected dependencies, allowing progress towards #22545 for software constructs. Using `device_handles_t` for this information was previously envisioned: https://github.com/zephyrproject-rtos/zephyr/blob/13f382287ad050d9600362bffca8bc03b93bbbe4/include/zephyr/device.h#L46-L48