### PR TITLE
audio: codec: Extend codec API to support recording

### DIFF
--- a/include/zephyr/audio/codec.h
+++ b/include/zephyr/audio/codec.h
@@ -66,6 +66,8 @@ typedef enum {
 typedef enum {
 	AUDIO_PROPERTY_OUTPUT_VOLUME,
 	AUDIO_PROPERTY_OUTPUT_MUTE,
+	AUDIO_PROPERTY_INPUT_GAIN,
+	AUDIO_PROPERTY_INPUT_MUTE,
 } audio_property_t;
 
 /**
@@ -120,6 +122,8 @@ struct audio_codec_api {
 			 struct audio_codec_cfg *cfg);
 	void (*start_output)(const struct device *dev);
 	void (*stop_output)(const struct device *dev);
+	void (*start_input)(const struct device *dev);
+	void (*stop_input)(const struct device *dev);
 	int (*set_property)(const struct device *dev,
 			    audio_property_t property,
 			    audio_channel_t channel,
@@ -178,6 +182,40 @@ static inline void audio_codec_stop_output(const struct device *dev)
 		(const struct audio_codec_api *)dev->api;
 
 	api->stop_output(dev);
+}
+
+/**
+ * @brief Set codec to start input audio recording
+ *
+ * Setup the audio codec device to start the audio recording
+ *
+ * @param dev Pointer to the device structure for codec driver instance.
+ *
+ * @return none
+ */
+static inline void audio_codec_start_input(const struct device *dev)
+{
+	const struct audio_codec_api *api =
+		(const struct audio_codec_api *)dev->api;
+
+	api->start_input(dev);
+}
+
+/**
+ * @brief Set codec to stop input audio recording
+ *
+ * Setup the audio codec device to stop the audio recording
+ *
+ * @param dev Pointer to the device structure for codec driver instance.
+ *
+ * @return none
+ */
+static inline void audio_codec_stop_input(const struct device *dev)
+{
+	const struct audio_codec_api *api =
+		(const struct audio_codec_api *)dev->api;
+
+	api->stop_input(dev);
 }
 
 /**


### PR DESCRIPTION
Add start_input and stop_input to the audio codec API.

Signed-off-by: Bogdan Togorean <bogdan.togorean@analog.com>