### PR TITLE
libc: newlib: Fix declare a type conflict

### DIFF
--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -89,7 +89,7 @@
 	/* End of the malloc arena is the end of physical memory */
 	#if defined(CONFIG_XTENSA)
 		/* TODO: Why is xtensa a special case? */
-		extern void *_heap_sentry;
+		extern char _heap_sentry[];
 		#define MAX_HEAP_SIZE	(POINTER_TO_UINT(&_heap_sentry) - \
 					 HEAP_BASE)
 	#else


### PR DESCRIPTION
Fix a variable declaration type conflict:

libc-hooks.c:92:16: error: conflicting types for '_heap_sentry'
   92 |   extern void *_heap_sentry;
soc.h:78:13: note: previous declaration of '_heap_sentry' was here

Fixes #44926

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>