### PR TITLE
board: frdm_k64f: Switch MCUboot to swap-move

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -24,6 +24,13 @@ config TEMP_KINETIS
 	default y if "$(dt_nodelabel_enabled,adc1)"
 	depends on SENSOR && ADC
 
+if MCUBOOT
+
+config BOOT_SWAP_USING_MOVE
+	default y
+
+endif # MCUBOOT
+
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -222,17 +222,19 @@ zephyr_udc0: &usbotg {
 			reg = <0x0001e000 0x00002000>;
 		};
 
+		/*
+		 * For "swap-move" in MCUboot, slot 0 must be 1 page
+		 * larger than the maximum image size.  With even
+		 * pages, it isn't helpful to make the sizes
+		 * different, and we are limited by 1 less than the
+		 * size of slot 1. */
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00060000>;
+			reg = <0x00020000 0x00070000>;
 		};
-		slot1_partition: partition@80000 {
+		slot1_partition: partition@90000 {
 			label = "image-1";
-			reg = <0x00080000 0x00060000>;
-		};
-		scratch_partition: partition@e0000 {
-			label = "image-scratch";
-			reg = <0x000e0000 0x00020000>;
+			reg = <0x00090000 0x00070000>;
 		};
 	};
 };


### PR DESCRIPTION
Change the MCUboot configuration to use the "swap move" algorithm
instead of "swap scratch".  Instead of needing a scratch area, which
incurs higher wear than the other image areas, this algorithm uses a
single additional sector in slot0.  Because there are an even number of
sectors available, set the size of both slots to be the same, with a
total image size available (image + status/trailer) of the size of slot
0, minus one page, or 0x6f0000 (454656) bytes.

Signed-off-by: David Brown <david.brown@linaro.org>