### PR TITLE
boards: arm: arduino_nano_33_ble: Add missing leds to DTS

### DIFF
--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
@@ -30,9 +30,40 @@
 			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 			label = "Blue LED";
 		};
+		led3: led_3 {
+			/* Cannot be used together with spi2. */
+			gpios = <&gpio0 13 GPIO_ACTIVE_HIGH>;
+			label = "Yellow LED";
+		};
 		led4: led_4 {
 			gpios = <&gpio1 9 GPIO_ACTIVE_HIGH>;
 			label = "User LED";
+		};
+	};
+
+	pwmleds {
+		compatible = "pwm-leds";
+
+		red_pwm_led: led_pwm_0 {
+			pwms = <&pwm0 24>;
+			label = "Red PWM LED";
+		};
+		green_pwm_led: led_pwm_1 {
+			pwms = <&pwm0 16>;
+			label = "Green PWM LED";
+		};
+		blue_pwm_led: led_pwm_2 {
+			pwms = <&pwm0 6>;
+			label = "Blue PWM LED";
+		};
+		yellow_pwm_led: led_pwm_3 {
+			/* Cannot be used together with spi2. */
+			pwms = <&pwm0 13>;
+			label = "Yellow PWM LED";
+		};
+		user_pwm_led: led_pwm_4 {
+			pwms = <&pwm1 41>;
+			label = "User PWM LED";
 		};
 	};
 
@@ -55,7 +86,16 @@
 		led0 = &led0;
 		led1 = &led1;
 		led2 = &led2;
+		led3 = &led3;
 		led4 = &led4;
+		pwm-led0 = &red_pwm_led;
+		pwm-led1 = &green_pwm_led;
+		pwm-led2 = &blue_pwm_led;
+		pwm-led3 = &yellow_pwm_led;
+		pwm-led4 = &user_pwm_led;
+		red-pwm-led = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
 		spi = &spi2;
 	};
 };
@@ -136,6 +176,20 @@ arduino_spi: &spi2 {
 
 &gpio1 {
 	status = "okay";
+};
+
+&pwm0 {
+	status = "okay";
+	pinctrl-0 = <&pwm0_default>;
+	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm1 {
+	status = "okay";
+	pinctrl-0 = <&pwm1_default>;
+	pinctrl-1 = <&pwm1_sleep>;
+	pinctrl-names = "default", "sleep";
 };
 
 zephyr_udc0: &usbd {

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
@@ -65,4 +65,38 @@
 			low-power-enable;
 		};
 	};
+
+	pwm0_default: pwm0_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 24)>,
+					<NRF_PSEL(PWM_OUT1, 0, 16)>,
+					<NRF_PSEL(PWM_OUT2, 0, 6)>,
+					<NRF_PSEL(PWM_OUT3, 0, 13)>;
+			nordic,invert;
+		};
+	};
+
+	pwm0_sleep: pwm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 24)>,
+					<NRF_PSEL(PWM_OUT1, 0, 16)>,
+					<NRF_PSEL(PWM_OUT2, 0, 6)>,
+					<NRF_PSEL(PWM_OUT3, 0, 13)>;
+			low-power-enable;
+		};
+	};
+
+	pwm1_default: pwm1_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 9)>;
+			nordic,invert;
+		};
+	};
+
+	pwm1_sleep: pwm1_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 1, 9)>;
+			low-power-enable;
+		};
+	};
 };


### PR DESCRIPTION
This commit adds missing yellow led and missing PWM leds.

This was verified with samples blinky, blinky_pwm,
fade_led and rgb_led.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>