### PR TITLE
bluetooth: host: Check for duplicate device before adding to resolving list

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -309,6 +309,26 @@ void bt_keys_clear(struct bt_keys *keys)
 	(void)memset(keys, 0, sizeof(*keys));
 }
 
+bool bt_keys_match(struct bt_keys *keys)
+{
+	int i;
+	int n_found = 0;
+
+	for (i = 0; i < ARRAY_SIZE(key_pool); i++) {
+		if (key_pool[i].id == keys->id) {
+			if (!memcmp(&key_pool[i].irk.val, &keys->irk.val, 16)) {
+				if (!bt_addr_cmp(&key_pool[i].addr.a, &keys->addr.a)) {
+					n_found++;
+					if (n_found > 1) {
+						return true;
+					}
+				}
+			}
+		}
+	}
+	return false;
+}
+
 #if defined(CONFIG_BT_SETTINGS)
 int bt_keys_store(struct bt_keys *keys)
 {

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -84,6 +84,7 @@ struct bt_keys *bt_keys_find_addr(uint8_t id, const bt_addr_le_t *addr);
 
 void bt_keys_add_type(struct bt_keys *keys, int type);
 void bt_keys_clear(struct bt_keys *keys);
+bool bt_keys_match(struct bt_keys *keys);
 
 #if defined(CONFIG_BT_SETTINGS)
 int bt_keys_store(struct bt_keys *keys);


### PR DESCRIPTION
In Core spec v5.3, controller has the option to accept or reject when the same device is added to resolving list.
This check ensures duplicate device will not be sent to the controller.

Signed-off-by: Azizah Ibrahim <azizah.ibrahim@nordicsemi.no>