### PR TITLE
Bluetooth: Host: Call `att_mtu_updated` callback when channel is reconfigured

### DIFF
--- a/include/zephyr/bluetooth/att.h
+++ b/include/zephyr/bluetooth/att.h
@@ -60,6 +60,9 @@ extern "C" {
 
 int bt_eatt_disconnect_one(struct bt_conn *conn);
 
+/* Reconfigure all EATT channels on connection */
+int bt_eatt_reconfigure(struct bt_conn *conn, uint16_t mtu);
+
 #endif /* CONFIG_BT_TESTING */
 
 /** @brief Connect Enhanced ATT channels

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2930,6 +2930,17 @@ static void bt_att_released(struct bt_l2cap_chan *ch)
 	k_mem_slab_free(&chan_slab, (void **)&chan);
 }
 
+#if defined(CONFIG_BT_EATT)
+static void bt_att_reconfigured(struct bt_l2cap_chan *l2cap_chan)
+{
+	struct bt_att_chan *att_chan = ATT_CHAN(l2cap_chan);
+
+	BT_DBG("chan %p", att_chan);
+
+	att_chan_mtu_updated(att_chan);
+}
+#endif /* CONFIG_BT_EATT */
+
 static struct bt_att_chan *att_chan_new(struct bt_att *att, atomic_val_t flags)
 {
 	int quota = 0;
@@ -2943,6 +2954,9 @@ static struct bt_att_chan *att_chan_new(struct bt_att *att, atomic_val_t flags)
 		.encrypt_change = bt_att_encrypt_change,
 	#endif /* CONFIG_BT_SMP */
 		.released = bt_att_released,
+	#if defined(CONFIG_BT_EATT)
+		.reconfigured = bt_att_reconfigured,
+	#endif /* CONFIG_BT_EATT */
 	};
 	struct bt_att_chan *chan;
 

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3231,6 +3231,37 @@ int bt_eatt_disconnect_one(struct bt_conn *conn)
 
 	return err;
 }
+
+int bt_eatt_reconfigure(struct bt_conn *conn, uint16_t mtu)
+{
+	struct bt_att_chan *att_chan = att_get_fixed_chan(conn);
+	struct bt_att *att = att_chan->att;
+	struct bt_l2cap_chan *chans[CONFIG_BT_EATT_MAX + 1] = {};
+	size_t offset = 0;
+	size_t i = 0;
+	int err;
+
+	SYS_SLIST_FOR_EACH_CONTAINER(&att->chans, att_chan, node) {
+		if (atomic_test_bit(att_chan->flags, ATT_ENHANCED)) {
+			chans[i] = &att_chan->chan.chan;
+			i++;
+		}
+	}
+
+	while (offset < i) {
+		/* bt_l2cap_ecred_chan_reconfigure() uses the first L2CAP_ECRED_CHAN_MAX_PER_REQ
+		 * elements of the array or until a null-terminator is reached.
+		 */
+		err = bt_l2cap_ecred_chan_reconfigure(&chans[offset], mtu);
+		if (err < 0) {
+			return err;
+		}
+
+		offset += L2CAP_ECRED_CHAN_MAX_PER_REQ;
+	}
+
+	return 0;
+}
 #endif /* CONFIG_BT_TESTING */
 #endif /* CONFIG_BT_EATT */
 

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/CMakeLists.txt
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(app PRIVATE
   src/common.c
   src/main_collision.c
   src/main_autoconnect.c
+  src/main_reconfigure.c
   src/main.c
 )
 

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.h
@@ -23,6 +23,13 @@
 
 extern enum bst_result_t bst_result;
 
+#define CREATE_FLAG(flag) static atomic_t flag = (atomic_t)false
+#define SET_FLAG(flag) (void)atomic_set(&flag, (atomic_t)true)
+#define WAIT_FOR_FLAG(flag) \
+	while (!(bool)atomic_get(&flag)) { \
+		(void)k_sleep(K_MSEC(1)); \
+	}
+
 #define FAIL(...)                                                                                  \
 	do {                                                                                       \
 		bst_result = Failed;                                                               \

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main.c
@@ -8,10 +8,12 @@
 
 extern struct bst_test_list *test_main_collision_install(struct bst_test_list *tests);
 extern struct bst_test_list *test_main_autoconnect_install(struct bst_test_list *tests);
+extern struct bst_test_list *test_main_reconfigure_install(struct bst_test_list *tests);
 
 bst_test_install_t test_installers[] = {
 	test_main_collision_install,
 	test_main_autoconnect_install,
+	test_main_reconfigure_install,
 	NULL,
 };
 

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main_reconfigure.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main_reconfigure.c
@@ -1,0 +1,89 @@
+/* main_reconfigure.c - Application main entry point */
+
+/*
+ * Copyright (c) 2022 Nordic Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "common.h"
+
+#include <bluetooth/gatt.h>
+
+CREATE_FLAG(flag_reconfigured);
+
+void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
+{
+	printk("MTU Updated: tx %d, rx %d\n", tx, rx);
+	SET_FLAG(flag_reconfigured);
+}
+
+static struct bt_gatt_cb cb = {
+	.att_mtu_updated = att_mtu_updated,
+};
+
+static void test_peripheral_main(void)
+{
+	peripheral_setup_and_connect();
+
+	bt_gatt_cb_register(&cb);
+
+	while (bt_eatt_count(default_conn) < CONFIG_BT_EATT_MAX) {
+		k_sleep(K_MSEC(10));
+	}
+
+	WAIT_FOR_FLAG(flag_reconfigured);
+
+	disconnect();
+
+	PASS("EATT Peripheral tests Passed\n");
+}
+
+#define NEW_MTU 100
+
+static void test_central_main(void)
+{
+	int err;
+
+	central_setup_and_connect();
+
+	bt_gatt_cb_register(&cb);
+
+	while (bt_eatt_count(default_conn) < CONFIG_BT_EATT_MAX) {
+		k_sleep(K_MSEC(10));
+	}
+
+	err = bt_eatt_reconfigure(default_conn, NEW_MTU);
+	if (err < 0) {
+		FAIL("Reconfigure failed (%d)\n", err);
+	}
+
+	WAIT_FOR_FLAG(flag_reconfigured);
+
+	wait_for_disconnect();
+
+	PASS("EATT Central tests Passed\n");
+}
+
+static const struct bst_test_instance test_def[] = {
+	{
+		.test_id = "peripheral_reconfigure",
+		.test_descr = "Peripheral reconfigure",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_peripheral_main,
+	},
+	{
+		.test_id = "central_reconfigure",
+		.test_descr = "Central reconfigure",
+		.test_post_init_f = test_init,
+		.test_tick_f = test_tick,
+		.test_main_f = test_central_main,
+	},
+	BSTEST_END_MARKER,
+};
+
+struct bst_test_list *test_main_reconfigure_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_def);
+}

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/tests_scripts/reconfigure.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/tests_scripts/reconfigure.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright (c) 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+simulation_id="reconfigure"
+verbosity_level=2
+process_ids=""; exit_code=0
+
+function Execute(){
+  if [ ! -f $1 ]; then
+    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
+ compile it?)\e[39m"
+    exit 1
+  fi
+  timeout 120 $@ & process_ids="$process_ids $!"
+}
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+#Give a default value to BOARD if it does not have one yet:
+BOARD="${BOARD:-nrf52_bsim}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_eatt_prj_autoconnect_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=central_reconfigure
+
+Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_eatt_prj_autoconnect_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=peripheral_reconfigure
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=60e6 $@
+
+for process_id in $process_ids; do
+  wait $process_id || let "exit_code=$?"
+done
+exit $exit_code #the last exit code != 0


### PR DESCRIPTION
Previously, the `att_mtu_updated` callback was only called on initial connection of the channel or during the MTU Exchange procedure. There was no way for the application to know that the MTU increased in the case where the peer initiated a reconfiguration.

Adds a test that verifies the callback is called. The function for reconfiguring the EATT channels is hidden behind `CONFIG_BT_TESTING` and is not meant for use by applications.