### PR TITLE
modules: zcbor: Add Kconfig options to match the zcbor ones

### DIFF
--- a/modules/zcbor/CMakeLists.txt
+++ b/modules/zcbor/CMakeLists.txt
@@ -9,4 +9,10 @@ if(CONFIG_ZCBOR)
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_decode.c
     ${ZEPHYR_ZCBOR_MODULE_DIR}/src/zcbor_encode.c
   )
+
+  zephyr_compile_definitions_ifdef(CONFIG_ZCBOR_CANONICAL ZCBOR_CANONICAL)
+  zephyr_compile_definitions_ifdef(CONFIG_ZCBOR_STOP_ON_ERROR ZCBOR_STOP_ON_ERROR)
+  zephyr_compile_definitions_ifdef(CONFIG_ZCBOR_VERBOSE ZCBOR_VERBOSE)
+  zephyr_compile_definitions_ifdef(CONFIG_ZCBOR_ASSERT ZCBOR_ASSERT)
+  zephyr_compile_definitions_ifdef(CONFIG_ZCBOR_BIG_ENDIAN ZCBOR_BIG_ENDIAN)
 endif()

--- a/modules/zcbor/Kconfig
+++ b/modules/zcbor/Kconfig
@@ -5,6 +5,31 @@ config ZEPHYR_ZCBOR_MODULE
 	bool
 
 config ZCBOR
-	bool "zcbor library"
+	bool "zcbor CBOR library"
 	help
-	  Enable zcbor CBOR encoder/decoder library
+	  zcbor CBOR encoder/decoder library
+
+if ZCBOR
+
+config ZCBOR_CANONICAL
+	bool "Produce canonical CBOR"
+	help
+	  Enabling this will prevent zcbor from creating lists and maps with
+	  indefinite-length arrays (it will still decode them properly).
+
+config ZCBOR_STOP_ON_ERROR
+	bool "Stop on error when processing"
+	help
+	  This makes all functions abort their execution if called when an error
+	  has already happened.
+
+config ZCBOR_VERBOSE
+	bool "Make zcbor code print messages"
+
+config ZCBOR_ASSERT
+	def_bool ASSERT
+
+config ZCBOR_BIG_ENDIAN
+	def_bool BIG_ENDIAN
+
+endif # ZCBOR


### PR DESCRIPTION
Add Kconfig options to enable/disable features that are exposed in zcbor
via ZCBOR_ macros that are typically set via -D statements to the
toolchain.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>