### PR TITLE
drivers: uart: Fix unused parameter warnings when compiling with -Wextra

### DIFF
--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -547,6 +547,8 @@ static inline int z_impl_uart_poll_in_u16(const struct device *dev,
 
 	return api->poll_in_u16(dev, p_u16);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(p_u16);
 	return -ENOTSUP;
 #endif
 }
@@ -599,6 +601,9 @@ static inline void z_impl_uart_poll_out_u16(const struct device *dev,
 		(const struct uart_driver_api *)dev->api;
 
 	api->poll_out_u16(dev, out_u16);
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(out_u16);
 #endif
 }
 
@@ -701,9 +706,12 @@ static inline int uart_fifo_fill(const struct device *dev,
 	}
 
 	return api->fifo_fill(dev, tx_data, size);
-#endif
-
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(tx_data);
+	ARG_UNUSED(size);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -740,6 +748,9 @@ static inline int uart_fifo_fill_u16(const struct device *dev,
 
 	return api->fifo_fill_u16(dev, tx_data, size);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(tx_data);
+	ARG_UNUSED(size);
 	return -ENOTSUP;
 #endif
 }
@@ -780,9 +791,12 @@ static inline int uart_fifo_read(const struct device *dev, uint8_t *rx_data,
 	}
 
 	return api->fifo_read(dev, rx_data, size);
-#endif
-
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(rx_data);
+	ARG_UNUSED(size);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -822,9 +836,12 @@ static inline int uart_fifo_read_u16(const struct device *dev,
 	}
 
 	return api->fifo_read_u16(dev, rx_data, size);
-#endif
-
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(rx_data);
+	ARG_UNUSED(size);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -843,6 +860,8 @@ static inline void z_impl_uart_irq_tx_enable(const struct device *dev)
 	if (api->irq_tx_enable != NULL) {
 		api->irq_tx_enable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -862,6 +881,8 @@ static inline void z_impl_uart_irq_tx_disable(const struct device *dev)
 	if (api->irq_tx_disable != NULL) {
 		api->irq_tx_disable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -894,9 +915,10 @@ static inline int uart_irq_tx_ready(const struct device *dev)
 	}
 
 	return api->irq_tx_ready(dev);
-#endif
-
+#else
+	ARG_UNUSED(dev);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -915,6 +937,8 @@ static inline void z_impl_uart_irq_rx_enable(const struct device *dev)
 	if (api->irq_rx_enable != NULL) {
 		api->irq_rx_enable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -934,6 +958,8 @@ static inline void z_impl_uart_irq_rx_disable(const struct device *dev)
 	if (api->irq_rx_disable != NULL) {
 		api->irq_rx_disable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -966,9 +992,10 @@ static inline int uart_irq_tx_complete(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_tx_complete(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
 	return -ENOTSUP;
-
+#endif
 }
 
 /**
@@ -1001,9 +1028,10 @@ static inline int uart_irq_rx_ready(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_rx_ready(dev);
-#endif
-
+#else
+	ARG_UNUSED(dev);
 	return -ENOTSUP;
+#endif
 }
 /**
  * @brief Enable error interrupt.
@@ -1021,6 +1049,8 @@ static inline void z_impl_uart_irq_err_enable(const struct device *dev)
 	if (api->irq_err_enable) {
 		api->irq_err_enable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -1040,6 +1070,8 @@ static inline void z_impl_uart_irq_err_disable(const struct device *dev)
 	if (api->irq_err_disable) {
 		api->irq_err_disable(dev);
 	}
+#else
+	ARG_UNUSED(dev);
 #endif
 }
 
@@ -1065,8 +1097,10 @@ static inline int z_impl_uart_irq_is_pending(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_is_pending(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1106,8 +1140,10 @@ static inline int z_impl_uart_irq_update(const struct device *dev)
 		return -ENOSYS;
 	}
 	return api->irq_update(dev);
-#endif
+#else
+	ARG_UNUSED(dev);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1132,6 +1168,10 @@ static inline void uart_irq_callback_user_data_set(const struct device *dev,
 	if ((api != NULL) && (api->irq_callback_set != NULL)) {
 		api->irq_callback_set(dev, cb, user_data);
 	}
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(user_data);
 #endif
 }
 
@@ -1188,6 +1228,9 @@ static inline int uart_callback_set(const struct device *dev,
 
 	return api->callback_set(dev, callback, user_data);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(callback);
+	ARG_UNUSED(user_data);
 	return -ENOTSUP;
 #endif
 }
@@ -1223,6 +1266,10 @@ static inline int z_impl_uart_tx(const struct device *dev, const uint8_t *buf,
 
 	return api->tx(dev, buf, len, timeout);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
 	return -ENOTSUP;
 #endif
 }
@@ -1258,6 +1305,10 @@ static inline int z_impl_uart_tx_u16(const struct device *dev,
 
 	return api->tx_u16(dev, buf, len, timeout);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
 	return -ENOTSUP;
 #endif
 }
@@ -1285,6 +1336,7 @@ static inline int z_impl_uart_tx_abort(const struct device *dev)
 
 	return api->tx_abort(dev);
 #else
+	ARG_UNUSED(dev);
 	return -ENOTSUP;
 #endif
 }
@@ -1325,6 +1377,10 @@ static inline int z_impl_uart_rx_enable(const struct device *dev,
 
 	return api->rx_enable(dev, buf, len, timeout);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
 	return -ENOTSUP;
 #endif
 }
@@ -1364,6 +1420,10 @@ static inline int z_impl_uart_rx_enable_u16(const struct device *dev,
 
 	return api->rx_enable_u16(dev, buf, len, timeout);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
+	ARG_UNUSED(timeout);
 	return -ENOTSUP;
 #endif
 }
@@ -1398,6 +1458,9 @@ static inline int uart_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 
 	return api->rx_buf_rsp(dev, buf, len);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
 	return -ENOTSUP;
 #endif
 }
@@ -1432,6 +1495,9 @@ static inline int uart_rx_buf_rsp_u16(const struct device *dev, uint16_t *buf,
 
 	return api->rx_buf_rsp_u16(dev, buf, len);
 #else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(buf);
+	ARG_UNUSED(len);
 	return -ENOTSUP;
 #endif
 }
@@ -1462,6 +1528,7 @@ static inline int z_impl_uart_rx_disable(const struct device *dev)
 
 	return api->rx_disable(dev);
 #else
+	ARG_UNUSED(dev);
 	return -ENOTSUP;
 #endif
 }
@@ -1496,9 +1563,12 @@ static inline int z_impl_uart_line_ctrl_set(const struct device *dev,
 		return -ENOSYS;
 	}
 	return api->line_ctrl_set(dev, ctrl, val);
-#endif
-
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1527,9 +1597,12 @@ static inline int z_impl_uart_line_ctrl_get(const struct device *dev,
 		return -ENOSYS;
 	}
 	return api->line_ctrl_get(dev, ctrl, val);
-#endif
-
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(ctrl);
+	ARG_UNUSED(val);
 	return -ENOTSUP;
+#endif
 }
 
 /**
@@ -1560,9 +1633,12 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 		return -ENOSYS;
 	}
 	return api->drv_cmd(dev, cmd, p);
-#endif
-
+#else
+	ARG_UNUSED(dev);
+	ARG_UNUSED(cmd);
+	ARG_UNUSED(p);
 	return -ENOTSUP;
+#endif
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Since the UART header file is included directly by application code,
an application developer including this file and only applying
-Wextra to the application source files will see many warnings.

Signed-off-by: Pete Dietl <petedietl@gmail.com>