### PR TITLE
samples: logging/syst: build for C++ too

### DIFF
--- a/samples/subsys/logging/syst/CMakeLists.txt
+++ b/samples/subsys/logging/syst/CMakeLists.txt
@@ -5,3 +5,8 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(syst)
 
 target_sources(app PRIVATE src/main.c)
+
+if(CONFIG_CPLUSPLUS)
+  # When building for C++, force C++ compilation
+  set_source_files_properties(src/main.c PROPERTIES LANGUAGE CXX)
+endif()

--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -58,3 +58,65 @@ tests:
         - "SYS-T RAW DATA: "
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
+
+  sample.logger.syst.v1.deferred_cpp:
+    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    platform_allow: mps2_an385 qemu_x86 qemu_x86_64 sam_e70_xplained qemu_cortex_a53
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_LOG1=y
+      - CONFIG_CPLUSPLUS=y
+  sample.logger.syst.v1.immediate_cpp:
+    platform_allow: mps2_an385 qemu_x86 qemu_x86_64 sam_e70_xplained qemu_cortex_a53
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_LOG1=y
+      - CONFIG_CPLUSPLUS=y
+  sample.logger.syst.v2.deferred_cpp:
+    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    platform_allow: mps2_an385 qemu_x86 qemu_x86_64 sam_e70_xplained qemu_cortex_a53
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_CPLUSPLUS=y
+  sample.logger.syst.v2.immediate_cpp:
+    platform_allow: mps2_an385 qemu_x86 qemu_x86_64 sam_e70_xplained qemu_cortex_a53
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_CPLUSPLUS=y
+  sample.logger.syst.catalog.v2.deferred_cpp:
+    extra_args: OVERLAY_CONFIG=overlay_deferred.conf
+    platform_allow: mps2_an385 qemu_x86
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
+      - CONFIG_CPLUSPLUS=y
+  sample.logger.syst.catalog.v2.immediate_cpp:
+    platform_allow: mps2_an385 qemu_x86
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
+      - CONFIG_CPLUSPLUS=y

--- a/samples/subsys/logging/syst/src/main.c
+++ b/samples/subsys/logging/syst/src/main.c
@@ -39,14 +39,14 @@ void log_msgs(void)
 #ifndef CONFIG_LOG2
 	struct log_msg_ids src_level = {
 		.level = LOG_LEVEL_INTERNAL_RAW_STRING,
-		.source_id = 0, /* not used as level indicates raw string. */
 		.domain_id = 0, /* not used as level indicates raw string. */
+		.source_id = 0, /* not used as level indicates raw string. */
 	};
 #endif
 
 	char c = '!';
-	char *s = "static str";
-	char *s1 = "c str";
+	const char *s = "static str";
+	const char *s1 = "c str";
 	char vs0[32];
 	char vs1[32];
 


### PR DESCRIPTION
This extends the samples to build for C++ using the same code.
This shows MIPI Sys-T can work C++ too.

The change to main.c regarding to the struct log_msg_ids is
simply that the compiler errored out complaining the members
must be initialized the same order as the declaration.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>