### PR TITLE
soc: nxp: Do not select CODE_DATA_RELOCATION_SRAM

### DIFF
--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
@@ -14,9 +14,6 @@ config ROM_START_OFFSET
 config NUM_IRQS
 	default 60
 
-config PM
-	select CODE_DATA_RELOCATION_SRAM
-
 config ZTEST_NO_YIELD
 	default y if (ZTEST && PM)
 

--- a/west.yml
+++ b/west.yml
@@ -101,7 +101,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 46be8173d2453b16c617b555f96c59d62920a290
+      revision: 9ac27f746517a483c01df2721957c822b5bda954
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
We no longer need to relocate the SDK power management source file to SRAM. Instead specfic functions from the SDK file are relocated to the ramfunc section.

Fixes #44670
