### PR TITLE
driver: adc: fix build error for adc_dma

### DIFF
--- a/drivers/adc/adc_mcux_adc16.c
+++ b/drivers/adc/adc_mcux_adc16.c
@@ -11,7 +11,6 @@
 #include <drivers/pinctrl.h>
 #ifdef CONFIG_ADC_MCUX_ADC16_ENABLE_EDMA
 #include <drivers/dma.h>
-#include <fsl_sim.h>
 #endif
 
 #include <fsl_adc16.h>

--- a/tests/drivers/adc/adc_dma/testcase.yaml
+++ b/tests/drivers/adc/adc_dma/testcase.yaml
@@ -2,5 +2,5 @@ common:
   tags: adc dma trigger
 tests:
   drivers.adc-dma:
-    depends_on: adc dma pit
+    depends_on: adc dma
     platform_allow: frdm_k82f frdm_k64f


### PR DESCRIPTION
fsl_sim.h is not required as SDK upgrade

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>