### PR TITLE
Tls fixes

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -33,7 +33,7 @@ config ARM
 	# FIXME: current state of the code for all ARM requires this, but
 	# is really only necessary for Cortex-M with ARM MPU!
 	select GEN_PRIV_STACKS
-	select ARCH_HAS_THREAD_LOCAL_STORAGE if CPU_AARCH32_CORTEX_R || CPU_CORTEX_M
+	select ARCH_HAS_THREAD_LOCAL_STORAGE if CPU_AARCH32_CORTEX_R || CPU_CORTEX_M || CPU_AARCH32_CORTEX_A
 	help
 	  ARM architecture
 

--- a/arch/arm/core/aarch32/cortex_a_r/CMakeLists.txt
+++ b/arch/arm/core/aarch32/cortex_a_r/CMakeLists.txt
@@ -16,3 +16,4 @@ zephyr_library_sources(
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE thread.c)
 zephyr_library_sources_ifdef(CONFIG_SEMIHOST semihost.c)
+zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE __aeabi_read_tp.S)

--- a/arch/arm/core/aarch32/cortex_a_r/__aeabi_read_tp.S
+++ b/arch/arm/core/aarch32/cortex_a_r/__aeabi_read_tp.S
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2020 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <toolchain.h>
+
+_ASM_FILE_PROLOGUE
+
+GTEXT(__aeabi_read_tp)
+
+SECTION_FUNC(text, __aeabi_read_tp)
+	mrc 15, 0, r0, c13, c0, 3
+	bx lr

--- a/arch/arm/core/aarch32/swap_helper.S
+++ b/arch/arm/core/aarch32/swap_helper.S
@@ -186,7 +186,7 @@ out_fp_endif:
     adds r4, r2, r4
     ldr r0, [r4]
 
-#if defined(CONFIG_CPU_AARCH32_CORTEX_R)
+#if defined(CONFIG_CPU_AARCH32_CORTEX_R) || defined(CONFIG_CPU_AARCH32_CORTEX_A)
     /* Store TLS pointer in the "Process ID" register.
      * This register is used as a base pointer to all
      * thread variables with offsets added by toolchain.

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -42,6 +42,7 @@ FUNC_NORETURN void z_riscv_fatal_error(unsigned int reason,
 #ifdef CONFIG_USERSPACE
 		LOG_ERR("     sp: " PR_REG, esf->sp);
 #endif
+		LOG_ERR("     tp: " PR_REG, esf->tp);
 		LOG_ERR("     ra: " PR_REG, esf->ra);
 		LOG_ERR("   mepc: " PR_REG, esf->mepc);
 		LOG_ERR("mstatus: " PR_REG, esf->mstatus);

--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -59,6 +59,7 @@
 	op a5, __z_arch_esf_t_a5_OFFSET(sp)		;\
 	op a6, __z_arch_esf_t_a6_OFFSET(sp)		;\
 	op a7, __z_arch_esf_t_a7_OFFSET(sp)		;\
+	op tp, __z_arch_esf_t_tp_OFFSET(sp)             ;\
 	op ra, __z_arch_esf_t_ra_OFFSET(sp)
 
 #ifdef CONFIG_SMP

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -81,6 +81,8 @@ GEN_OFFSET_SYM(z_arch_esf_t, mstatus);
 
 GEN_OFFSET_SYM(z_arch_esf_t, s0);
 
+GEN_OFFSET_SYM(z_arch_esf_t, tp);
+
 #ifdef CONFIG_USERSPACE
 GEN_OFFSET_SYM(z_arch_esf_t, sp);
 #endif

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -41,6 +41,9 @@ void z_riscv_secondary_cpu_init(int cpu_num)
 #ifdef CONFIG_SMP
 	irq_enable(RISCV_MACHINE_SOFT_IRQ);
 #endif
+#ifdef CONFIG_THREAD_LOCAL_STORAGE
+	__asm__("mv tp, %0" : : "r" (z_idle_threads[cpu_num].tls));
+#endif
 	riscv_cpu_init[cpu_num].fn(riscv_cpu_init[cpu_num].arg);
 }
 

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -94,6 +94,11 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	stack_init->sp = (ulong_t)(stack_init + 1);
 #endif /* CONFIG_USERSPACE */
 
+#if defined(CONFIG_THREAD_LOCAL_STORAGE)
+	stack_init->tp = thread->tls;
+	thread->callee_saved.tp = thread->tls;
+#endif
+
 	/* Assign thread entry point and mstatus.MPRV mode. */
 	if (IS_ENABLED(CONFIG_USERSPACE)
 	    && (thread->base.user_options & K_USER)) {

--- a/boards/riscv/qemu_riscv32/Kconfig.defconfig
+++ b/boards/riscv/qemu_riscv32/Kconfig.defconfig
@@ -10,3 +10,8 @@ config BOARD
 
 config COMPRESSED_ISA
 	default y
+
+# Use thread local storage by default so that
+# this feature gets more CI coverage.
+config THREAD_LOCAL_STORAGE
+	default y

--- a/cmake/linker/ld/ld_script.cmake
+++ b/cmake/linker/ld/ld_script.cmake
@@ -311,6 +311,7 @@ function(section_to_string)
 
   if(NOT nosymbols)
     set(TEMP "${TEMP}\n__${name_clean}_size = __${name_clean}_end - __${name_clean}_start;")
+    set(TEMP "${TEMP}\nPROVIDE(__${name_clean}_align = ALIGNOF(${name}));")
     set(TEMP "${TEMP}\n__${name_clean}_load_start = LOADADDR(${name});")
   endif()
 

--- a/cmake/linker_script/common/thread-local-storage.cmake
+++ b/cmake/linker_script/common/thread-local-storage.cmake
@@ -2,10 +2,14 @@
 
 if(CONFIG_THREAD_LOCAL_STORAGE)
   zephyr_linker_section(NAME .tdata LMA FLASH NOINPUT)
+  zephyr_linker_section_configure(SECTION .tdata INPUT ".tdata")
+  zephyr_linker_section_configure(SECTION .tdata INPUT ".tdata.*")
   zephyr_linker_section_configure(SECTION .tdata INPUT ".gnu.linkonce.td.*")
   # GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 
   zephyr_linker_section(NAME .tbss LMA FLASH NOINPUT)
+  zephyr_linker_section_configure(SECTION .tbss INPUT ".tbss")
+  zephyr_linker_section_configure(SECTION .tbss INPUT ".tbss.*")
   zephyr_linker_section_configure(SECTION .tbss INPUT ".gnu.linkonce.tb.*")
   zephyr_linker_section_configure(SECTION .tbss INPUT ".tcommon")
   # GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)

--- a/include/zephyr/arch/riscv/exp.h
+++ b/include/zephyr/arch/riscv/exp.h
@@ -74,6 +74,7 @@ struct __esf {
 
 	ulong_t s0;		/* callee-saved s0 */
 
+	ulong_t tp;		/* thread pointer */
 #ifdef CONFIG_USERSPACE
 	ulong_t sp;		/* preserved (user or kernel) stack pointer */
 #endif

--- a/samples/userspace/shared_mem/sample.yaml
+++ b/samples/userspace/shared_mem/sample.yaml
@@ -15,3 +15,5 @@ tests:
   sample.kernel.memory_protection.shared_mem:
     filter: CONFIG_ARCH_HAS_USERSPACE
     platform_exclude: twr_ke18f
+    extra_configs:
+      - CONFIG_TEST_HW_STACK_PROTECTION=n

--- a/subsys/logging/Kconfig.processing
+++ b/subsys/logging/Kconfig.processing
@@ -94,6 +94,7 @@ config LOG_PROCESS_THREAD_STACK_SIZE
 	default 1152 if LOG_BACKEND_NET
 	default 4096 if NO_OPTIMIZATIONS
 	default 1024 if XTENSA
+	default 2048 if ASSERT || SPIN_VALIDATE
 	default 768
 	help
 	  Set the internal stack size for log processing thread.

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -22,7 +22,8 @@ void sys_trace_k_thread_switched_in(void)
 	int key = irq_lock();
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
-	sys_trace_thread_switched_in_user(k_current_get());
+	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
+	sys_trace_thread_switched_in_user(z_current_get());
 
 	irq_unlock(key);
 }
@@ -32,7 +33,8 @@ void sys_trace_k_thread_switched_out(void)
 	int key = irq_lock();
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
-	sys_trace_thread_switched_out_user(k_current_get());
+	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
+	sys_trace_thread_switched_out_user(z_current_get());
 
 	irq_unlock(key);
 }

--- a/tests/benchmarks/footprints/src/main.c
+++ b/tests/benchmarks/footprints/src/main.c
@@ -13,7 +13,7 @@
 #include <kernel.h>
 #include <zephyr.h>
 #include <ksched.h>
-
+#include <sys/libc-hooks.h>
 #include "footprint.h"
 
 #ifdef CONFIG_USERSPACE
@@ -44,7 +44,10 @@ void main(void)
 #ifdef CONFIG_USERSPACE
 	int ret;
 	struct k_mem_partition *mem_parts[] = {
-	&footprint_mem_partition
+#if Z_LIBC_PARTITION_EXISTS
+		&z_libc_partition,
+#endif
+		&footprint_mem_partition
 	};
 
 	ret = k_mem_domain_init(&footprint_mem_domain,

--- a/tests/kernel/mem_protect/mem_protect/src/inherit.c
+++ b/tests/kernel/mem_protect/mem_protect/src/inherit.c
@@ -6,6 +6,7 @@
 
 #include "mem_protect.h"
 #include <syscall_handler.h>
+#include <sys/libc-hooks.h> /* for z_libc_partition */
 
 /* function prototypes */
 static inline void dummy_start(struct k_timer *timer)
@@ -38,6 +39,9 @@ K_MEM_PARTITION_DEFINE(inherit_memory_partition,
 		       K_MEM_PARTITION_P_RW_U_RW);
 
 struct k_mem_partition *inherit_memory_partition_array[] = {
+#if Z_LIBC_PARTITION_EXISTS
+	&z_libc_partition,
+#endif
 	&inherit_memory_partition,
 	&ztest_mem_partition
 };

--- a/tests/kernel/mem_protect/mem_protect/testcase.yaml
+++ b/tests/kernel/mem_protect/mem_protect/testcase.yaml
@@ -6,6 +6,7 @@ tests:
     # To get clean results we need to disable this test until the bug is fixed and fix
     # gets propagated to new Zephyr-SDK.
     platform_exclude: twr_ke18f qemu_arc_hs qemu_arc_em
+    extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n
     tags: kernel security userspace ignore_faults
   kernel.memory_protection.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -17,6 +17,7 @@
 #include <debug/stack.h>
 #include <syscall_handler.h>
 #include "test_syscall.h"
+#include <sys/libc-hooks.h> /* for z_libc_partition */
 
 #if defined(CONFIG_ARC)
 #include <arch/arc/v2/mpu/arc_core_mpu.h>
@@ -680,7 +681,12 @@ static void drop_user(volatile bool *to_modify)
  */
 static void test_init_and_access_other_memdomain(void)
 {
-	struct k_mem_partition *parts[] = { &ztest_mem_partition, &alt_part };
+	struct k_mem_partition *parts[] = {
+#if Z_LIBC_PARTITION_EXISTS
+		&z_libc_partition,
+#endif
+		&ztest_mem_partition, &alt_part
+	};
 
 	zassert_equal(
 		k_mem_domain_init(&alternate_domain, ARRAY_SIZE(parts), parts),

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -940,6 +940,7 @@ void test_syscall_context(void)
 	check_syscall_context();
 }
 
+#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 static void tls_leakage_user_part(void *p1, void *p2, void *p3)
 {
 	char *tls_area = p1;
@@ -949,9 +950,11 @@ static void tls_leakage_user_part(void *p1, void *p2, void *p3)
 			      "TLS data leakage to user mode");
 	}
 }
+#endif
 
 void test_tls_leakage(void)
 {
+#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 	/* Tests two assertions:
 	 *
 	 * - That a user thread has full access to its TLS area
@@ -964,15 +967,21 @@ void test_tls_leakage(void)
 
 	k_thread_user_mode_enter(tls_leakage_user_part,
 				 _current->userspace_local_data, NULL, NULL);
+#else
+	ztest_test_skip();
+#endif
 }
 
+#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 void tls_entry(void *p1, void *p2, void *p3)
 {
 	printk("tls_entry\n");
 }
+#endif
 
 void test_tls_pointer(void)
 {
+#ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 	k_thread_create(&test_thread, test_stack, STACKSIZE, tls_entry,
 			NULL, NULL, NULL, 1, K_USER, K_FOREVER);
 
@@ -996,6 +1005,9 @@ void test_tls_pointer(void)
 		printk("tls area out of bounds\n");
 		ztest_test_fail();
 	}
+#else
+	ztest_test_skip();
+#endif
 }
 
 

--- a/tests/kernel/mem_protect/userspace/testcase.yaml
+++ b/tests/kernel/mem_protect/userspace/testcase.yaml
@@ -1,6 +1,7 @@
 tests:
   kernel.memory_protection.userspace:
     filter: CONFIG_ARCH_HAS_USERSPACE
+    extra_args: CONFIG_TEST_HW_STACK_PROTECTION=n
     tags: kernel security userspace ignore_faults
   kernel.memory_protection.userspace.gap_filling.arc:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_MPU_REQUIRES_NON_OVERLAPPING_REGIONS


### PR DESCRIPTION
These patches fix issues found by a twister run on arm and riscv when THREAD_LOCAL_STORAGE is enabled by default. The bulk of them ensure that the cpu-specific TLS base pointer value and z_tls_current value are set correctly early in thread execution.