### PR TITLE
tests: drivers: spi: don't use deprecated spi_cs_control struct members

### DIFF
--- a/tests/drivers/spi/dt_spec/src/main.c
+++ b/tests/drivers/spi/dt_spec/src/main.c
@@ -18,12 +18,12 @@ static void test_dt_spec(void)
 		SPI_DT_SPEC_GET(DT_NODELABEL(test_spi_dev_cs), 0, 0);
 
 	LOG_DBG("spi_cs.bus = %p", spi_cs.bus);
-	LOG_DBG("spi_cs.config.cs->gpio_dev = %p", spi_cs.config.cs->gpio_dev);
 	LOG_DBG("spi_cs.config.cs->gpio.port = %p", spi_cs.config.cs->gpio.port);
+	LOG_DBG("spi_cs.config.cs->gpio.pin = %u", spi_cs.config.cs->gpio.pin);
 
 	zassert_equal(spi_cs.bus, DEVICE_DT_GET(DT_NODELABEL(test_spi_cs)), "");
-	zassert_equal(spi_cs.config.cs->gpio_dev, DEVICE_DT_GET(DT_NODELABEL(test_gpio)), "");
 	zassert_equal(spi_cs.config.cs->gpio.port, DEVICE_DT_GET(DT_NODELABEL(test_gpio)), "");
+	zassert_equal(spi_cs.config.cs->gpio.pin, 0x10, "");
 
 	const struct spi_dt_spec spi_no_cs =
 		SPI_DT_SPEC_GET(DT_NODELABEL(test_spi_dev_no_cs), 0, 0);


### PR DESCRIPTION
`gpio_dev` is being deprecated in favor of `gpio_dt_spec` gpio member so let's use it instead of that one.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>