### PR TITLE
xenvm: evtchn: expand Xen event channel driver functionality

### DIFF
--- a/boards/arm64/xenvm/doc/index.rst
+++ b/boards/arm64/xenvm/doc/index.rst
@@ -92,7 +92,7 @@ Most of Xen-specific features are not supported at the moment. This includes:
 
 Now only following features are supported:
 * Xen Enlighten memory page
-* Xen event channels (currently only pre-defined - PV console, Xenbus)
+* Xen event channels
 * Xen PV console (2 versions: regular ring buffer based for DomU and consoleio for Dom0)
 * Xen early console_io interface (mainly for debug purposes - requires debug version of Xen)
 

--- a/include/zephyr/xen/events.h
+++ b/include/zephyr/xen/events.h
@@ -16,11 +16,54 @@ struct event_channel_handle {
 	evtchn_cb_t cb;
 	void *priv;
 };
-
 typedef struct event_channel_handle evtchn_handle_t;
 
+/*
+ * Following functions just wrap Xen hypercalls, detailed description
+ * of parameters and return values are located in include/xen/public/event_channel.h
+ */
+int evtchn_status(evtchn_status_t *status);
+int evtchn_close(evtchn_port_t port);
+int evtchn_set_priority(evtchn_port_t port, uint32_t priority);
 void notify_evtchn(evtchn_port_t port);
+
+/*
+ * Allocate event-channel between caller and remote domain
+ *
+ * @param remote_dom - remote domain domid
+ * @return - local event channel port on success, negative on error
+ */
+int alloc_unbound_event_channel(domid_t remote_dom);
+
+/*
+ * Allocate local event channel, binded to remote port and attach specified callback
+ * to it
+ *
+ * @param remote_dom - remote domain domid
+ * @param remote_port - remote domain event channel port number
+ * @param cb - callback, attached to locat port
+ * @param data - private data, that will be passed to cb
+ * @return - local event channel port on success, negative on error
+ */
+int bind_interdomain_event_channel(domid_t remote_dom, evtchn_port_t remote_port,
+		evtchn_cb_t cb, void *data);
+
+/*
+ * Bind user-defined handler to specified event-channel
+ *
+ * @param port - event channel number
+ * @param cb - pointer to event channel handler
+ * @param data - private data, that will be passed to handler as parameter
+ * @return - zero on success
+ */
 int bind_event_channel(evtchn_port_t port, evtchn_cb_t cb, void *data);
+
+/*
+ * Unbind handler from event channel, substitute it with empty callback
+ *
+ * @param port - event channel number to unbind
+ * @return - zero on success
+ */
 int unbind_event_channel(evtchn_port_t port);
 
 int xen_events_init(void);


### PR DESCRIPTION
This PR adds new functions, which can be used for Xen event channel
management (allocation, interdomain binding etc.). Such functionality
is needed for Xen PV driver development in Zephyr.
