### PR TITLE
drivers: watchdog: stm32 iwdg starts with timeout install

### DIFF
--- a/drivers/watchdog/wdt_iwdg_stm32.c
+++ b/drivers/watchdog/wdt_iwdg_stm32.c
@@ -77,7 +77,7 @@ static void iwdg_stm32_convert_timeout(uint32_t timeout,
 
 static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 {
-	IWDG_TypeDef *iwdg = IWDG_STM32_STRUCT(dev);
+	ARG_UNUSED(dev);
 
 	/* Deactivate running when debugger is attached. */
 	if (options & WDT_OPT_PAUSE_HALTED_BY_DBG) {
@@ -99,7 +99,7 @@ static int iwdg_stm32_setup(const struct device *dev, uint8_t options)
 		return -ENOTSUP;
 	}
 
-	LL_IWDG_Enable(iwdg);
+	/* Enable the IWDG only when the timeout is installed */
 	return 0;
 }
 
@@ -134,6 +134,7 @@ static int iwdg_stm32_install_timeout(const struct device *dev,
 
 	tickstart = k_uptime_get_32();
 
+	LL_IWDG_Enable(iwdg);
 	LL_IWDG_EnableWriteAccess(iwdg);
 
 	LL_IWDG_SetPrescaler(iwdg, prescaler);
@@ -172,12 +173,10 @@ static const struct wdt_driver_api iwdg_stm32_api = {
 static int iwdg_stm32_init(const struct device *dev)
 {
 #ifndef CONFIG_WDT_DISABLE_AT_BOOT
-	IWDG_TypeDef *iwdg = IWDG_STM32_STRUCT(dev);
 	struct wdt_timeout_cfg config = {
 		.window.max = CONFIG_IWDG_STM32_INITIAL_TIMEOUT
 	};
 
-	LL_IWDG_Enable(iwdg);
 	iwdg_stm32_install_timeout(dev, &config);
 #endif
 


### PR DESCRIPTION
It Follows the sequence to configure and launch the IWDG watchdog
for the stm32 mcus
The IWDG is started (LL_IWDG_Enable) just before the timeout is installed (_iwdg_stm32_install_timeout_)

It applies the recommendation of the ref man (example given for the stm32wb55):
```
When the window option it is not used, the IWDG can be configured as follows:
1. Enable the IWDG by writing 0x0000 CCCC in the IWDG key register (IWDG_KR).
2. Enable register access by writing 0x0000 5555 in the IWDG key register (IWDG_KR).
3. Write the prescaler by programming the IWDG prescaler register (IWDG_PR) from 0 to 7.
4. Write the IWDG reload register (IWDG_RLR).
5. Wait for the registers to be updated (IWDG_SR = 0x0000 0000).
6. Refresh the counter value with IWDG_RLR (IWDG_KR = 0x0000 AAAA).
```

Signed-off-by: Francois Ramu <francois.ramu@st.com>