### PR TITLE
Bluetooth: Mesh: Update defaults - proxy filter, msg cache

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -203,12 +203,15 @@ config BT_MESH_PROXY_USE_DEVICE_NAME
 
 config BT_MESH_PROXY_FILTER_SIZE
 	int "Maximum number of filter entries per Proxy Client"
-	default 3
+	default 16
 	range 1 32767
 	depends on BT_MESH_GATT_PROXY
 	help
 	  This option specifies how many Proxy Filter entries the local
-	  node supports.
+	  node supports. This helps in reducing unwanted traffic getting sent to
+	  the proxy client. This value is application specific and should be large
+	  enough so that proxy client can communicate with several devices through
+	  this proxy server node using the default accept list filter type.
 
 endif # BT_CONN
 
@@ -288,13 +291,17 @@ config BT_MESH_CRPL
 
 config BT_MESH_MSG_CACHE_SIZE
 	int "Network message cache size"
-	default 10
+	default 32
 	range 2 65535
 	help
-	  Number of messages that are cached for the network. This helps
-	  prevent unnecessary decryption operations and unnecessary
-	  relays. This option is similar to the replay protection list,
-	  but has a different purpose.
+	  Number of messages that are cached by the node to avoid acting on the
+	  recently seen duplicate messages. This option is similar to
+	  the replay protection list, but has a different purpose. Network message
+	  cache helps prevent unnecessary decryption operations. This also prevents
+	  unnecessary relaying and helps in getting rid of relay loops. Setting
+	  this value to a very low number can cause unnecessary network traffic.
+	  Setting this value to a very large number can impact the processing time
+	  for each received network PDU and increases RAM footprint proportionately.
 
 config BT_MESH_ADV_BUF_COUNT
 	int "Number of advertising buffers"


### PR DESCRIPTION
This updates the default proxy filter size to 16. Previous value of 3
is too less for the most practical uses and demos. The default proxy
filter type is accept list type and in this mode proxy server rejects
incoming messages from source addresses not in the accept list. The
addresses are added to the accept list when proxy client sends
messages to unicast addresses or manually adds certain addresses to
the accept list. Once this list is full more addresses cannot be added.

This also updates the default network message cache size to 32. The
network message cache helps in preventing duplicate messages getting
repeatedly relayed and helps in reducing unnecessary network traffic.
Previous value of 10 is quite less for most usecases and makes the
node appear to generate much more traffic in mixed network. The
updated value should suffice for most use cases.

Additional explannation is added in Kconfig to help users understand
the significance of this setting.

These two changes result in 176 bytes of additional RAM usage in mesh
samples.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>