### PR TITLE
twister: ignore serial device SerialException.

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -747,9 +747,10 @@ class DeviceHandler(Handler):
                 serial_line = ser.readline()
             except TypeError:
                 pass
+            # ignore SerialException which may happen during the serial device
+            # power off/on process.
             except serial.SerialException:
-                ser.close()
-                break
+                pass
 
             # Just because ser_fileno has data doesn't mean an entire line
             # is available yet.


### PR DESCRIPTION
twister: ignore serial device SerialException.

For some boards, like up_squared and ehl_crb, they need do a
power off/on operation and use bios to load and execute zephyr
test binary, **during the power off, it may meet this SerialException,
but the serial object still works well after power on, we can continue
to get all results from serial, so we don't need to close it,
it's ok to ignore this exception.**
BTW, even if we ignore this exception here, it doesn't influence twister
function, because if it was really caused by disconnection, the test would
still be judged as failed due to timeout and serial would be closed later
in main thread, it doesn't impact results.
On the contrary, close serial directly in the monitor serial thread, it
will cause later tests failed due to mismatch errors.

fixes #45009 

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>