### PR TITLE
boards: arm: nucleo_g474re: increase size of storage partition

### DIFF
--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -147,10 +147,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 
-		/* Set 2Kb of storage at the end of the 128Kb of flash */
-		storage_partition: partition@1f800 {
+		/* Set 4Kb of storage at the end of the 128Kb of flash */
+		storage_partition: partition@1f000 {
 			label = "storage";
-			reg = <0x0001f800 0x00000800>;
+			reg = <0x0001f000 DT_SIZE_K(4)>;
 		};
 	};
 };


### PR DESCRIPTION
Increase the size of the flash storage partition from 2KB (one page) to 4KB (two pages) in order to support NVS.

Fixes: #44977

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>