### PR TITLE
soc: arm: cc13xx_cc26xx: pinctrl: minor fix for typedef typo

### DIFF
--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/pinctrl_soc.h
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/pinctrl_soc.h
@@ -30,7 +30,7 @@
 #define IOC_IOPULL_UP           0x00004000
 #define IOC_IOPULL_DOWN         0x00002000
 
-typedef struct pinctrl_soc_pin_t {
+typedef struct pinctrl_soc_pin {
 	uint32_t pin;
 	uint32_t iofunc;
 	uint32_t iomode;


### PR DESCRIPTION
Drop `_t` from struct name in typedef.

cc @vaishnavachath