### PR TITLE
ipc_service: static_vrings: Set WQ default type to PRIO_COOP

### DIFF
--- a/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
@@ -42,4 +42,5 @@ properties:
       or for K_PRIO_PREEMPT(2)
         priority = <2 PRIO_PREEMPT>;
 
-      When this property is missing a default priority of 0 is assumed.
+      When this property is missing a default priority of <0 PRIO_COOP> is
+      assumed.

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -610,7 +610,7 @@ static int backend_init(const struct device *instance)
 			   (0)),							\
 		.wq_prio_type = COND_CODE_1(DT_INST_NODE_HAS_PROP(i, zephyr_priority),	\
 			   (DT_INST_PROP_BY_IDX(i, zephyr_priority, 1)),		\
-			   (PRIO_PREEMPT)),						\
+			   (PRIO_COOP)),						\
 		.id = i,								\
 	};										\
 											\


### PR DESCRIPTION
In 92d8329d5b6 a new DT property was introduced to set the WQ priority
of the instance. The fallback value when the property was not present
was arbitrarily set to <0 PRIO_PREEMPT>.

The problem is that this value is actually changing the behaviour for
the code that is not explicitly setting the DT property, breaking in
some cases the existing code.

Move the default value to <0 PRIO_COOP> to give the old code a
consistent behaviour before and after the 92d8329d5b6 commit.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>