### PR TITLE
shell: fix missing "update" for the last RXRDY signal

### DIFF
--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1330,15 +1330,15 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 
 		k_mutex_lock(&shell->ctx->wr_mtx, K_FOREVER);
 
-		if (shell->iface->api->update) {
-			shell->iface->api->update(shell->iface);
-		}
-
 		shell_signal_handle(shell, SHELL_SIGNAL_KILL, kill_handler);
 		shell_signal_handle(shell, SHELL_SIGNAL_RXRDY, shell_process);
 		if (IS_ENABLED(CONFIG_SHELL_LOG_BACKEND)) {
 			shell_signal_handle(shell, SHELL_SIGNAL_LOG_MSG,
 					    shell_log_process);
+		}
+
+		if (shell->iface->api->update) {
+			shell->iface->api->update(shell->iface);
 		}
 
 		k_mutex_unlock(&shell->ctx->wr_mtx);


### PR DESCRIPTION
COMMIT MESSAGE:

Fixed the issue when sometimes "update" is not called for the
last RXRDY signal. First, need to reset the signal and only
after that need to call the "update" function.

Signed-off-by: Yuriy Vynnychek <yura.vynnychek@telink-semi.com>

ISSUE DESCRIPTION:

Sometimes the "update" function is not called for the last RXRDY signal.

ISSUE ROOTCAUSE:

If between the "update" and "k_poll_signal_reset" ("shell_signal_handle" function) there is new RXRDY interrupt/signal. This new signal is reset during "shell_signal_handle" call and the new "update" is not called for this new signal.

SOLUTION:

First need to reset the signal (call "shell_signal_handle" function), and only after that need to call the "update" function.


