### PR TITLE
Revert "scripts: check_compliance: check for commit message errors"

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -202,10 +202,15 @@ class CheckPatch(ComplianceTest):
         if not os.path.exists(checkpatch):
             self.skip(checkpatch + " not found")
 
+        # git diff's output doesn't depend on the current (sub)directory
+        diff = subprocess.Popen(('git', 'diff', COMMIT_RANGE),
+                                stdout=subprocess.PIPE)
         try:
-            subprocess.check_output((checkpatch, '--no-tree', '-g', COMMIT_RANGE),
+            subprocess.check_output((checkpatch, '--mailback', '--no-tree', '-'),
+                                    stdin=diff.stdout,
                                     stderr=subprocess.STDOUT,
-                                    cwd=GIT_TOP)
+                                    shell=True, cwd=GIT_TOP)
+
         except subprocess.CalledProcessError as ex:
             output = ex.output.decode("utf-8")
             self.add_failure(output)


### PR DESCRIPTION
This reverts commit e61c534e520816f7d0f1948781a7095640ed24cb, which
enabled commit message checking via the checkpatch script.

The checkpatch commit message checking is currently causing more
problems that it fixes, for example:

1. the rules that are supposed to be specific to the "header" (commit
   message) are being applied to the diffs.

2. there are some rules that do not fully make sense for the Zephyr
   and the way we have been doing things.

Note that we currently have the 'gitlint' checking the commit messages,
so reverting this feature does not completely take away the commit
message checking in the CI.

If we are to ever re-introduce this feature, all of the aforementioned
issues need to be addressed, and the effects and ramifications of
enabling this feature must be thoroughly analysed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Reverts #44118