### PR TITLE
ISO TX data path including ISOAL

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -31,6 +31,9 @@
 
 #include "hal/ecb.h"
 #include "hal/ccm.h"
+#include "hal/ticker.h"
+
+#include "ticker/ticker.h"
 
 #include "ll_sw/pdu.h"
 
@@ -58,6 +61,7 @@
 #include "ll_sw/ull_conn_types.h"
 #include "ll_sw/ull_iso_types.h"
 #include "ll_sw/ull_conn_iso_types.h"
+#include "ll_sw/ull_conn_iso_internal.h"
 #include "ll_sw/ull_df_types.h"
 
 #include "ll_sw/ull_adv_internal.h"
@@ -5125,15 +5129,21 @@ int hci_acl_handle(struct net_buf *buf, struct net_buf **evt)
 int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 {
 	struct bt_hci_iso_data_hdr *iso_data_hdr;
+	struct isoal_sdu_tx sdu_frag_tx;
 	struct bt_hci_iso_hdr *iso_hdr;
-	uint16_t stream_handle;
-	struct node_tx_iso *tx;
+	struct ll_iso_datapath *dp_in;
+	struct ll_iso_stream_hdr *hdr;
+	uint32_t *time_stamp;
 	uint16_t handle;
+	uint8_t pb_flag;
+	uint8_t ts_flag;
 	uint8_t flags;
-	uint16_t slen;
 	uint16_t len;
 
-	*evt = NULL;
+	iso_data_hdr = NULL;
+	*evt  = NULL;
+	hdr   = NULL;
+	dp_in = NULL;
 
 	if (buf->len < sizeof(*iso_hdr)) {
 		BT_ERR("No HCI ISO header");
@@ -5149,113 +5159,201 @@ int hci_iso_handle(struct net_buf *buf, struct net_buf **evt)
 		return -EINVAL;
 	}
 
-	/* assigning flags first because handle will be overwritten */
+	/* Assigning flags first because handle will be overwritten */
 	flags = bt_iso_flags(handle);
-	if (bt_iso_flags_ts(flags)) {
-		struct bt_hci_iso_ts_data_hdr *iso_ts_data_hdr;
-
-		iso_ts_data_hdr = net_buf_pull_mem(buf,
-						   sizeof(*iso_ts_data_hdr));
-	}
-
-	iso_data_hdr = net_buf_pull_mem(buf, sizeof(*iso_data_hdr));
-	slen = iso_data_hdr->slen;
-
-#if defined(CONFIG_BT_CTLR_ADV_ISO)
-	/* Check invalid BIS PDU length */
-	if (slen > LL_BIS_OCTETS_TX_MAX) {
-		BT_ERR("Invalid HCI ISO Data length");
-		return -EINVAL;
-	}
-
-	/* Get BIS stream handle and stream context */
+	pb_flag = bt_iso_flags_pb(flags);
+	ts_flag = bt_iso_flags_ts(flags);
 	handle = bt_iso_handle(handle);
-	if (handle < BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE) {
-		return -EINVAL;
-	}
-	stream_handle = handle - BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE;
 
-	struct lll_adv_iso_stream *stream;
-
-	stream = ull_adv_iso_stream_get(stream_handle);
-	if (!stream) {
-		BT_ERR("Invalid BIS stream");
-		return -EINVAL;
-	}
-
-	struct ll_adv_iso_set *adv_iso;
-
-	adv_iso = ull_adv_iso_by_stream_get(stream_handle);
-	if (!adv_iso) {
-		BT_ERR("No BIG associated with stream handle");
-		return -EINVAL;
-	}
-
-	/* Get free node tx */
-	tx = ll_iso_tx_mem_acquire();
-	if (!tx) {
-		BT_ERR("ISO Tx Buffer Overflow");
-		data_buf_overflow(evt, BT_OVERFLOW_LINK_ISO);
-		return -ENOBUFS;
-	}
-
-	struct pdu_bis *pdu = (void *)tx->pdu;
-
-	/* FIXME: Update to use correct LLID for BIS and CIS */
-	switch (bt_iso_flags_pb(flags)) {
-	case BT_ISO_SINGLE:
-		pdu->ll_id = PDU_BIS_LLID_COMPLETE_END;
-		break;
-	default:
-		ll_iso_tx_mem_release(tx);
-		return -EINVAL;
-	}
-
-	pdu->len = slen;
-	memcpy(pdu->payload, buf->data, slen);
-
-	struct lll_adv_iso *lll_iso;
-
-	lll_iso = &adv_iso->lll;
-
-	uint64_t pkt_seq_num;
-
-	pkt_seq_num = lll_iso->payload_count / lll_iso->bn;
-	if (((pkt_seq_num - stream->pkt_seq_num) & BIT64_MASK(39)) <=
-	    BIT64_MASK(38)) {
-		stream->pkt_seq_num = pkt_seq_num;
-	} else {
-		pkt_seq_num = stream->pkt_seq_num;
-	}
-
-	tx->payload_count = pkt_seq_num * lll_iso->bn;
-
-	stream->pkt_seq_num++;
-
-#else /* CONFIG_BT_CTLR_CONN_ISO */
-	/* FIXME: Add Connected ISO implementation */
-	stream_handle = 0U;
-
-	/* NOTE: Keeping the code below to pass compilation until Connected ISO
-	 *       integration.
+	/* Extract time stamp */
+	/* Set default to current time
+	 * BT Core V5.3 : Vol 6 Low Energy Controller : Part G IS0-AL:
+	 * 3.1 Time_Offset in framed PDUs :
+	 * The Controller transmitting a SDU may use any of the following
+	 * methods to determine the value of the SDU reference time:
+	 * -- A captured time stamp of the SDU
+	 * -- A time stamp provided by the higher layer
+	 * -- A computed time stamp based on a sequence counter provided by the
+	 *    higher layer (Not implemented)
+	 * -- Any other method of determining Time_Offset (Not implemented)
 	 */
-	/* Get free node tx */
-	tx = ll_iso_tx_mem_acquire();
-	if (!tx) {
-		BT_ERR("ISO Tx Buffer Overflow");
-		data_buf_overflow(evt, BT_OVERFLOW_LINK_ISO);
-		return -ENOBUFS;
+	if (ts_flag) {
+		/* Overwrite time stamp with HCI provided time stamp */
+		time_stamp = net_buf_pull_mem(buf, sizeof(*time_stamp));
+		len -= sizeof(*time_stamp);
+		sdu_frag_tx.time_stamp = *time_stamp;
+	} else {
+		sdu_frag_tx.time_stamp =
+			HAL_TICKER_TICKS_TO_US(ticker_ticks_now_get());
 	}
 
+	/* Extract ISO data header if included (PB_Flag 0b00 or 0b10) */
+	if ((pb_flag & 0x01) == 0) {
+		iso_data_hdr = net_buf_pull_mem(buf, sizeof(*iso_data_hdr));
+		len -= sizeof(*iso_data_hdr);
+		sdu_frag_tx.packet_sn = iso_data_hdr->sn;
+		sdu_frag_tx.iso_sdu_length = iso_data_hdr->slen;
+	} else {
+		sdu_frag_tx.packet_sn = 0;
+		sdu_frag_tx.iso_sdu_length = 0;
+	}
+
+	/* Packet boudary flags should be bitwise identical to the SDU state
+	 * 0b00 BT_ISO_START
+	 * 0b01 BT_ISO_CONT
+	 * 0b10 BT_ISO_SINGLE
+	 * 0b11 BT_ISO_END
+	 */
+	sdu_frag_tx.sdu_state = pb_flag;
+	/* Fill in SDU buffer fields */
+	sdu_frag_tx.dbuf = buf->data;
+	sdu_frag_tx.size = len;
+
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+	/* Extract source handle from CIS or BIS handle by way of header and
+	 * data path
+	 */
+	if (IS_CIS_HANDLE(handle)) {
+		struct ll_conn_iso_stream *cis =
+			ll_iso_stream_connected_get(handle);
+		if (!cis) {
+			return -EINVAL;
+		}
+
+		struct ll_conn_iso_group *cig = cis->group;
+
+		hdr = &(cis->hdr);
+
+		/* Set target event as the current event. This might cause some
+		 * misalignment between SDU interval and ISO interval in the
+		 * case of a burst from the application or late release. However
+		 * according to the specifications:
+		 * BT Core V5.3 : Vol 6 Low Energy Controller : Part B LL Spec:
+		 * 4.5.13.3 Connected Isochronous Data:
+		 * This burst is associated with the corresponding CIS event but
+		 * the payloads may be transmitted in later events as well.
+		 * If flush timeout is greater than one, use the current event,
+		 * otherwise postpone to the next.
+		 *
+		 * TODO: Calculate the best possible target event based on CIS
+		 * reference, FT and event_count.
+		 */
+		sdu_frag_tx.target_event = cis->lll.event_count +
+			(cis->lll.tx.flush_timeout > 1 ? 0 : 1);
+
+		sdu_frag_tx.cig_ref_point = cig->cig_ref_point;
+
+		/* Get controller's input data path for CIS */
+		dp_in = hdr->datapath_in;
+		if (!dp_in || dp_in->path_id != BT_HCI_DATAPATH_ID_HCI) {
+			BT_ERR("Input data path not set for HCI");
+			return -EINVAL;
+		}
+
+		/* Get input data path's source handle */
+		isoal_source_handle_t source = dp_in->source_hdl;
+
+		/* Start Fragmentation */
+		if (isoal_tx_sdu_fragment(source, &sdu_frag_tx)) {
+			return -EINVAL;
+		}
+
+		/* TODO: Assign *evt if an immediate response is required */
+		return 0;
+	}
 #endif /* CONFIG_BT_CTLR_CONN_ISO */
 
-	if (ll_iso_tx_mem_enqueue(stream_handle, tx)) {
-		BT_ERR("Invalid ISO Tx Enqueue");
-		ll_iso_tx_mem_release(tx);
-		return -EINVAL;
-	}
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
+	if (IS_ADV_ISO_HANDLE(handle)) {
+		/* FIXME: Use ISOAL */
+		struct node_tx_iso *tx;
+		uint16_t stream_handle;
+		uint16_t slen;
 
-	return 0;
+		/* FIXME: Code only expects header present */
+		slen = iso_data_hdr ? iso_data_hdr->slen : 0;
+
+		/* Check invalid BIS PDU length */
+		if (slen > LL_BIS_OCTETS_TX_MAX) {
+			BT_ERR("Invalid HCI ISO Data length");
+			return -EINVAL;
+		}
+
+		/* Get BIS stream handle and stream context */
+		handle = bt_iso_handle(handle);
+		if (handle < BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE) {
+			return -EINVAL;
+		}
+		stream_handle = handle - BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE;
+
+		struct lll_adv_iso_stream *stream;
+
+		stream = ull_adv_iso_stream_get(stream_handle);
+		if (!stream) {
+			BT_ERR("Invalid BIS stream");
+			return -EINVAL;
+		}
+
+		struct ll_adv_iso_set *adv_iso;
+
+		adv_iso = ull_adv_iso_by_stream_get(stream_handle);
+		if (!adv_iso) {
+			BT_ERR("No BIG associated with stream handle");
+			return -EINVAL;
+		}
+
+		/* Get free node tx */
+		tx = ll_iso_tx_mem_acquire();
+		if (!tx) {
+			BT_ERR("ISO Tx Buffer Overflow");
+			data_buf_overflow(evt, BT_OVERFLOW_LINK_ISO);
+			return -ENOBUFS;
+		}
+
+		struct pdu_bis *pdu = (void *)tx->pdu;
+
+		/* FIXME: Update to use correct LLID for BIS and CIS */
+		switch (bt_iso_flags_pb(flags)) {
+		case BT_ISO_SINGLE:
+			pdu->ll_id = PDU_BIS_LLID_COMPLETE_END;
+			break;
+		default:
+			ll_iso_tx_mem_release(tx);
+			return -EINVAL;
+		}
+
+		pdu->len = slen;
+		memcpy(pdu->payload, buf->data, slen);
+
+		struct lll_adv_iso *lll_iso;
+
+		lll_iso = &adv_iso->lll;
+
+		uint64_t pkt_seq_num;
+
+		pkt_seq_num = lll_iso->payload_count / lll_iso->bn;
+		if (((pkt_seq_num - stream->pkt_seq_num) & BIT64_MASK(39)) <=
+		BIT64_MASK(38)) {
+			stream->pkt_seq_num = pkt_seq_num;
+		} else {
+			pkt_seq_num = stream->pkt_seq_num;
+		}
+
+		tx->payload_count = pkt_seq_num * lll_iso->bn;
+
+		stream->pkt_seq_num++;
+
+		if (ll_iso_tx_mem_enqueue(stream_handle, tx, NULL)) {
+			BT_ERR("Invalid ISO Tx Enqueue");
+			ll_iso_tx_mem_release(tx);
+			return -EINVAL;
+		}
+
+		return 0;
+	}
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
+
+	return -EINVAL;
 }
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 

--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -321,7 +321,8 @@ void ll_iso_rx_mem_release(void **node_rx);
 /* Downstream - ISO Data */
 void *ll_iso_tx_mem_acquire(void);
 void ll_iso_tx_mem_release(void *tx);
-int ll_iso_tx_mem_enqueue(uint16_t handle, void *tx);
+int ll_iso_tx_mem_enqueue(uint16_t handle, void *tx, void *link);
+void ll_iso_link_tx_release(void *link);
 
 /* External co-operation */
 void ll_timeslice_ticker_id_get(uint8_t * const instance_index,

--- a/subsys/bluetooth/controller/ll_sw/isoal.h
+++ b/subsys/bluetooth/controller/ll_sw/isoal.h
@@ -171,6 +171,18 @@ struct isoal_sdu_tx {
 	 *  can be directly assigned to the SDU state
 	 */
 	uint8_t sdu_state;
+	/** Packet sequence number from HCI ISO Data Header (ISO Data Load
+	 *  Field)
+	 */
+	uint16_t packet_sn;
+	/** ISO SDU length from HCI ISO Data Header (ISO Data Load Field) */
+	uint16_t iso_sdu_length;
+	/** Time stamp from HCI or vendor specific path (us) */
+	uint32_t time_stamp;
+	/** CIG Reference of target event (us, compensated for drift) */
+	uint32_t cig_ref_point;
+	/** Target Event of SDU */
+	uint64_t target_event:39;
 };
 
 
@@ -236,6 +248,7 @@ struct isoal_sink_session {
 	isoal_sdu_cnt_t          seqn;
 	uint16_t                 handle;
 	uint8_t                  pdus_per_sdu;
+	uint8_t                  framed;
 	uint32_t                 latency_unframed;
 	uint32_t                 latency_framed;
 };
@@ -247,6 +260,9 @@ struct isoal_sdu_production {
 	struct isoal_sdu_produced  sdu;
 	/* Bookkeeping */
 	isoal_pdu_cnt_t  prev_pdu_id : 39;
+	/* Assumes that isoal_pdu_cnt_t is a uint64_t bit field */
+	uint64_t prev_pdu_is_end:1;
+	uint64_t prev_pdu_is_padding:1;
 	enum {
 		ISOAL_START,
 		ISOAL_CONTINUE,
@@ -341,6 +357,9 @@ struct isoal_source_session {
 	struct isoal_source_config param;
 	isoal_sdu_cnt_t            seqn;
 	uint16_t                   handle;
+	uint16_t                   iso_interval;
+	uint8_t                    framed;
+	uint8_t                    burst_number;
 	uint8_t                    pdus_per_sdu;
 	uint8_t                    max_pdu_size;
 	uint32_t                   latency_unframed;
@@ -350,12 +369,19 @@ struct isoal_source_session {
 struct isoal_pdu_production {
 	/* Permit atomic enable/disable of PDU production */
 	volatile isoal_production_mode_t  mode;
-	/* We are constructing an PDU from {<1 or =1 or >1} SDUs */
+	/* We are constructing a PDU from {<1 or =1 or >1} SDUs */
 	struct isoal_pdu_produced pdu;
+	uint8_t                   pdu_state;
 	/* PDUs produced for current SDU */
 	uint8_t                   pdu_cnt;
+	uint64_t                  payload_number:39;
+	uint64_t                  seg_hdr_sc:1;
+	uint64_t                  seg_hdr_length:8;
+	uint64_t                  sdu_fragments:8;
 	isoal_pdu_len_t           pdu_written;
 	isoal_pdu_len_t           pdu_available;
+	/* Location (byte index) of last segmentation header */
+	isoal_pdu_len_t           last_seg_hdr_loc;
 };
 
 struct isoal_source {
@@ -372,6 +398,7 @@ isoal_status_t isoal_reset(void);
 
 isoal_status_t isoal_sink_create(uint16_t handle,
 				 uint8_t  role,
+				 uint8_t  framed,
 				 uint8_t  burst_number,
 				 uint8_t  flush_timeout,
 				 uint32_t sdu_interval,
@@ -406,6 +433,7 @@ isoal_status_t sink_sdu_write_hci(void *dbuf,
 
 isoal_status_t isoal_source_create(uint16_t handle,
 				   uint8_t  role,
+				   uint8_t  framed,
 				   uint8_t  burst_number,
 				   uint8_t  flush_timeout,
 				   uint8_t  max_octets,
@@ -428,7 +456,7 @@ void isoal_source_disable(isoal_source_handle_t hdl);
 void isoal_source_destroy(isoal_source_handle_t hdl);
 
 isoal_status_t isoal_tx_sdu_fragment(isoal_source_handle_t source_hdl,
-				      const struct isoal_sdu_tx *tx_sdu);
+				     struct isoal_sdu_tx *tx_sdu);
 
 void isoal_tx_pdu_release(isoal_source_handle_t source_hdl,
 			  struct node_tx_iso *node_tx);

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -376,9 +376,9 @@ struct node_rx_ftr {
 
 /* Meta-information for isochronous PDUs in node_rx_hdr */
 struct node_rx_iso_meta {
-	uint64_t payload_number : 39; /* cisPayloadNumber */
-	uint32_t timestamp;           /* Time of reception */
-	uint8_t  status;              /* Status of reception (OK/not OK) */
+	uint64_t payload_number:39; /* cisPayloadNumber */
+	uint64_t status:8;          /* Status of reception (OK/not OK) */
+	uint32_t timestamp;         /* Time of reception */
 };
 
 /* Define invalid/unassigned Controller state/role instance handle */
@@ -532,6 +532,8 @@ static inline void lll_hdr_init(void *lll, void *parent)
 #define iso_rx_sched() ll_rx_sched()
 #endif /* CONFIG_BT_CTLR_ISO_VENDOR_DATA_PATH */
 
+struct node_tx_iso;
+
 void lll_done_score(void *param, uint8_t result);
 
 int lll_init(void);
@@ -570,6 +572,8 @@ void ull_rx_sched(void);
 void ull_rx_sched_done(void);
 void ull_iso_rx_put(memq_link_t *link, void *rx);
 void ull_iso_rx_sched(void);
+void *ull_iso_tx_ack_dequeue(void);
+void ull_iso_lll_ack_enqueue(uint16_t handle, struct node_tx_iso *tx);
 struct event_done_extra *ull_event_done_extra_get(void);
 struct event_done_extra *ull_done_extra_type_set(uint8_t type);
 void *ull_event_done(void *param);

--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -5,10 +5,11 @@
  */
 
 struct lll_conn_iso_stream_rxtx {
-	uint8_t phy;            /* PHY */
-	uint8_t burst_number;   /* Burst number (BN) */
-	uint8_t flush_timeout;  /* Flush timeout (FT) */
-	uint8_t max_octets;     /* Maximum PDU size */
+	uint64_t payload_number:39; /* cisPayloadNumber */
+	uint8_t  phy;               /* PHY */
+	uint8_t  burst_number;      /* Burst number (BN) */
+	uint8_t  flush_timeout;     /* Flush timeout (FT) */
+	uint8_t  max_octets;        /* Maximum PDU size */
 };
 
 struct lll_conn_iso_stream {
@@ -27,12 +28,13 @@ struct lll_conn_iso_stream {
 
 	/* Event and payload counters */
 	uint64_t event_count : 39;       /* cisEventCount */
-	uint64_t rx_payload_number : 39; /* cisPayloadNumber */
 
 	/* Acknowledgment and flow control */
 	uint8_t sn:1;               /* Sequence number */
 	uint8_t nesn:1;             /* Next expected sequence number */
 	uint8_t cie:1;              /* Close isochronous event */
+	uint8_t flushed:1;          /* 1 if CIS LLL has been flushed */
+	uint8_t datapath_ready_rx:1;/* 1 if datapath for RX is ready */
 
 	/* Resumption information */
 	uint8_t next_subevent;      /* Next subevent to schedule */

--- a/subsys/bluetooth/controller/ll_sw/lll_iso_tx.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_iso_tx.h
@@ -12,5 +12,6 @@ struct node_tx_iso {
 	};
 
 	uint64_t payload_count:39; /* bisPayloadCounter/cisPayloadCounter */
+	uint64_t sdu_fragments : 8;
 	uint8_t  pdu[];
 };

--- a/subsys/bluetooth/controller/ll_sw/pdu.h
+++ b/subsys/bluetooth/controller/ll_sw/pdu.h
@@ -688,25 +688,23 @@ struct pdu_data_llctrl_cte_rsp {
 } __packed;
 
 struct pdu_data_llctrl_cis_req {
-	uint8_t cig_id;
-	uint8_t cis_id;
-	uint8_t c_phy;
-	uint8_t p_phy;
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	uint16_t c_max_sdu:12;
-	uint16_t rfu0:3;
-	uint16_t framed:1;
-	uint16_t p_max_sdu:12;
-	uint16_t rfu1:4;
-#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-	uint16_t framed:1;
-	uint16_t rfu0:3;
-	uint16_t c_max_sdu:12;
-	uint16_t rfu1:4;
-	uint16_t p_max_sdu:12;
-#else
-#error "Unsupported endianness"
-#endif
+	uint8_t  cig_id;
+	uint8_t  cis_id;
+	uint8_t  c_phy;
+	uint8_t  p_phy;
+	/* c_max_sdu:12
+	 * rfu:3
+	 * framed:1
+	 * NOTE: This layout as bitfields is not portable for BE using
+	 * endianness conversion macros.
+	 */
+	uint8_t  c_max_sdu_packed[2];
+	/* p_max_sdu:12
+	 * rfu:4
+	 * NOTE: This layout as bitfields is not portable for BE using
+	 * endianness conversion macros.
+	 */
+	uint8_t  p_max_sdu[2];
 	uint8_t  c_sdu_interval[3];
 	uint8_t  p_sdu_interval[3];
 	uint16_t c_max_pdu;
@@ -903,6 +901,15 @@ struct pdu_iso_sdu_sh {
 #error "Unsupported endianness"
 #endif /* __BYTE_ORDER__ */
 } __packed;
+
+enum pdu_cis_llid {
+	/** Unframed complete or end fragment */
+	PDU_CIS_LLID_COMPLETE_END = 0x00,
+	/** Unframed start or continuation fragment */
+	PDU_CIS_LLID_START_CONTINUE = 0x01,
+	/** Framed; one or more segments of a SDU */
+	PDU_CIS_LLID_FRAMED = 0x02
+};
 
 struct pdu_cis {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -473,20 +473,22 @@ static MFIFO_DEFINE(ll_pdu_rx_free, sizeof(void *), LL_PDU_RX_CNT);
 static void *mark_update;
 #endif /* CONFIG_BT_CONN */
 
-#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_CONN_ISO)
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 #if defined(CONFIG_BT_CONN)
 #define BT_BUF_ACL_TX_COUNT CONFIG_BT_BUF_ACL_TX_COUNT
 #else
 #define BT_BUF_ACL_TX_COUNT 0
 #endif /* CONFIG_BT_CONN */
-#if defined(CONFIG_BT_CTLR_CONN_ISO)
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
 #define BT_CTLR_ISO_TX_BUFFERS CONFIG_BT_CTLR_ISO_TX_BUFFERS
 #else
 #define BT_CTLR_ISO_TX_BUFFERS 0
-#endif /* CONFIG_BT_CTLR_CONN_ISO */
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
 static MFIFO_DEFINE(tx_ack, sizeof(struct lll_tx),
 		    BT_BUF_ACL_TX_COUNT + BT_CTLR_ISO_TX_BUFFERS);
-#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_CONN_ISO */
+#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 
 static void *mark_disable;
 
@@ -511,12 +513,12 @@ static void rx_demux(void *param);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
 static void rx_demux_yield(void);
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 static uint8_t tx_cmplt_get(uint16_t *handle, uint8_t *first, uint8_t last);
 static inline void rx_demux_conn_tx_ack(uint8_t ack_last, uint16_t handle,
 					memq_link_t *link,
 					struct node_tx *node_tx);
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 static inline int rx_demux_rx(memq_link_t *link, struct node_rx_hdr *rx);
 static inline void rx_demux_event_done(memq_link_t *link,
 				       struct node_rx_hdr *rx);
@@ -866,18 +868,20 @@ uint8_t ll_rx_get(void **node_rx, uint16_t *handle)
 
 #if defined(CONFIG_BT_CONN) || \
 	(defined(CONFIG_BT_OBSERVER) && defined(CONFIG_BT_CTLR_ADV_EXT)) || \
-	defined(CONFIG_BT_CTLR_ADV_PERIODIC)
+	defined(CONFIG_BT_CTLR_ADV_PERIODIC) || \
+	defined(CONFIG_BT_CTLR_ADV_ISO)
 ll_rx_get_again:
 #endif /* CONFIG_BT_CONN ||
 	* (CONFIG_BT_OBSERVER && CONFIG_BT_CTLR_ADV_EXT) ||
-	* CONFIG_BT_CTLR_ADV_PERIODIC
+	* CONFIG_BT_CTLR_ADV_PERIODIC ||
+	* CONFIG_BT_CTLR_ADV_ISO
 	*/
 
 	*node_rx = NULL;
 
 	link = memq_peek(memq_ll_rx.head, memq_ll_rx.tail, (void **)&rx);
 	if (link) {
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 		cmplt = tx_cmplt_get(handle, &mfifo_tx_ack.f, rx->ack_last);
 		if (!cmplt) {
 			uint8_t f, cmplt_prev, cmplt_curr;
@@ -891,7 +895,7 @@ ll_rx_get_again:
 							  mfifo_tx_ack.l);
 			} while ((cmplt_prev != 0U) ||
 				 (cmplt_prev != cmplt_curr));
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 
 			if (0) {
 #if defined(CONFIG_BT_CONN) || \
@@ -939,11 +943,11 @@ ll_rx_get_again:
 
 			*node_rx = rx;
 
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 		}
 	} else {
 		cmplt = tx_cmplt_get(handle, &mfifo_tx_ack.f, mfifo_tx_ack.l);
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 	}
 
 	return cmplt;
@@ -1654,7 +1658,9 @@ void *ll_pdu_rx_alloc(void)
 {
 	return MFIFO_DEQUEUE(ll_pdu_rx_free);
 }
+#endif /* CONFIG_BT_CONN */
 
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 void ll_tx_ack_put(uint16_t handle, struct node_tx *node_tx)
 {
 	struct lll_tx *tx;
@@ -1668,7 +1674,7 @@ void ll_tx_ack_put(uint16_t handle, struct node_tx *node_tx)
 
 	MFIFO_ENQUEUE(tx_ack, idx);
 }
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 
 void ll_timeslice_ticker_id_get(uint8_t * const instance_index,
 				uint8_t * const ticker_id)
@@ -2383,7 +2389,7 @@ static void rx_demux_yield(void)
 }
 #endif /* CONFIG_BT_CTLR_LOW_LAT_ULL */
 
-#if defined(CONFIG_BT_CONN)
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_CTLR_ADV_ISO)
 static uint8_t tx_cmplt_get(uint16_t *handle, uint8_t *first, uint8_t last)
 {
 	struct lll_tx *tx;
@@ -2399,14 +2405,13 @@ static uint8_t tx_cmplt_get(uint16_t *handle, uint8_t *first, uint8_t last)
 	*handle = tx->handle;
 	cmplt = 0U;
 	do {
-		struct pdu_data *p;
-		struct node_tx *tx_node;
-
-#if defined(CONFIG_BT_CTLR_BROADCAST_ISO) || \
+		if (false) {
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || \
 	defined(CONFIG_BT_CTLR_CONN_ISO)
-		if (IS_CIS_HANDLE(tx->handle) ||
-		    IS_ADV_ISO_HANDLE(tx->handle)) {
+		} else if (IS_CIS_HANDLE(tx->handle) ||
+			   IS_ADV_ISO_HANDLE(tx->handle)) {
 			struct node_tx_iso *tx_node_iso;
+			struct pdu_data *p;
 			uint8_t fragments;
 
 			tx_node_iso = tx->node;
@@ -2426,34 +2431,43 @@ static uint8_t tx_cmplt_get(uint16_t *handle, uint8_t *first, uint8_t last)
 				}
 				cmplt += fragments;
 			}
+
 			ll_iso_link_tx_release(tx_node_iso->link);
 			ll_iso_tx_mem_release(tx_node_iso);
+
 			goto next_ack;
-		}
-#endif /* CONFIG_BT_CTLR_BROADCAST_ISO || CONFIG_BT_CTLR_CONN_ISO */
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
-		tx_node = tx->node;
-		p = (void *)tx_node->pdu;
-		if (!tx_node || (tx_node == (void *)1) ||
-		    (((uint32_t)tx_node & ~3) &&
-		     (p->ll_id == PDU_DATA_LLID_DATA_START ||
-		      p->ll_id == PDU_DATA_LLID_DATA_CONTINUE))) {
-			/* data packet, hence count num cmplt */
-			tx->node = (void *)1;
-			cmplt++;
+#if defined(CONFIG_BT_CONN)
 		} else {
-			/* ctrl packet or flushed, hence dont count num cmplt */
-			tx->node = (void *)2;
+			struct node_tx *tx_node;
+			struct pdu_data *p;
+
+			tx_node = tx->node;
+			p = (void *)tx_node->pdu;
+			if (!tx_node || (tx_node == (void *)1) ||
+			    (((uint32_t)tx_node & ~3) &&
+			     (p->ll_id == PDU_DATA_LLID_DATA_START ||
+			      p->ll_id == PDU_DATA_LLID_DATA_CONTINUE))) {
+				/* data packet, hence count num cmplt */
+				tx->node = (void *)1;
+				cmplt++;
+			} else {
+				/* ctrl packet or flushed, hence dont count num cmplt */
+				tx->node = (void *)2;
+			}
+
+			if (((uint32_t)tx_node & ~3)) {
+				ll_tx_mem_release(tx_node);
+			}
+#endif /* CONFIG_BT_CONN */
+
 		}
 
-		if (((uint32_t)tx_node & ~3)) {
-			ll_tx_mem_release(tx_node);
-		}
-
-#if defined(CONFIG_BT_CTLR_BROADCAST_ISO) || \
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || \
 	defined(CONFIG_BT_CTLR_CONN_ISO)
 next_ack:
-#endif /* CONFIG_BT_CTLR_BROADCAST_ISO || CONFIG_BT_CTLR_CONN_ISO */
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 		tx = mfifo_dequeue_iter_get(mfifo_tx_ack.m, mfifo_tx_ack.s,
 					    mfifo_tx_ack.n, mfifo_tx_ack.f,
@@ -2493,7 +2507,7 @@ static inline void rx_demux_conn_tx_ack(uint8_t ack_last, uint16_t handle,
 			ll_rx_sched();
 		}
 }
-#endif /* CONFIG_BT_CONN */
+#endif /* CONFIG_BT_CONN || CONFIG_BT_CTLR_ADV_ISO */
 
 #if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
 static void ull_done(void *param)

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso.c
@@ -6,6 +6,7 @@
 
 #include <zephyr.h>
 #include <sys/byteorder.h>
+#include <bluetooth/bluetooth.h>
 
 #include "util/mem.h"
 #include "util/memq.h"
@@ -27,10 +28,22 @@
 #include "ull_internal.h"
 #include "lll/lll_vendor.h"
 
+#include "ll.h"
+
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_conn_iso
 #include "common/log.h"
 #include "hal/debug.h"
+
+/* Used by LISTIFY */
+#define _INIT_MAYFLY_ARRAY(_i, _l, _fp) \
+	{ ._link = &_l[_i], .fp = _fp },
+
+/* Declare static initialized array of mayflies with associated link element */
+#define DECLARE_MAYFLY_ARRAY(_name, _fp, _cnt) \
+	static memq_link_t _links[_cnt]; \
+	static struct mayfly _name[_cnt] = \
+		{ LISTIFY(_cnt, _INIT_MAYFLY_ARRAY, (), _links, _fp) }
 
 
 static int init_reset(void);
@@ -43,6 +56,8 @@ static void cis_disabled_cb(void *param);
 static void ticker_stop_op_cb(uint32_t status, void *param);
 static void cig_disable(void *param);
 static void cig_disabled_cb(void *param);
+static void disable(uint16_t handle);
+static void cis_tx_lll_flush(void *param);
 
 static struct ll_conn_iso_stream cis_pool[CONFIG_BT_CTLR_CONN_ISO_STREAMS];
 static void *cis_free;
@@ -88,8 +103,11 @@ struct ll_conn_iso_stream *ll_conn_iso_stream_acquire(void)
 {
 	struct ll_conn_iso_stream *cis = mem_acquire(&cis_free);
 
-	cis->hdr.datapath_in = NULL;
-	cis->hdr.datapath_out = NULL;
+	if (cis) {
+		cis->hdr.datapath_in = NULL;
+		cis->hdr.datapath_out = NULL;
+	}
+
 	return cis;
 }
 
@@ -124,7 +142,8 @@ struct ll_conn_iso_stream *ll_iso_stream_connected_get(uint16_t handle)
 	}
 
 	cis = ll_conn_iso_stream_get(handle);
-	if (cis->lll.handle != handle) {
+	if ((cis->group == NULL) || (cis->lll.handle != handle)) {
+		/* CIS does not belong to a group or has inconsistent handle */
 		return NULL;
 	}
 
@@ -217,7 +236,7 @@ void ull_conn_iso_cis_established(struct ll_conn_iso_stream *cis)
 
 	est = (void *)node_rx->pdu;
 	est->status = 0;
-	est->cis_handle = sys_le16_to_cpu(cis->lll.handle);
+	est->cis_handle = cis->lll.handle;
 
 	ll_rx_put(node_rx->hdr.link, node_rx);
 	ll_rx_sched();
@@ -279,7 +298,7 @@ void ull_conn_iso_done(struct node_rx_event_done *done)
  * has completed and the stream is released and callback is provided, the
  * cis_released_cb callback is invoked.
  *
- * @param cis		  Pointer to connected ISO stream to stop
+ * @param cis             Pointer to connected ISO stream to stop
  * @param cis_released_cb Callback to invoke when the CIS has been released.
  *                        NULL to ignore.
  * @param reason          Termination reason
@@ -352,6 +371,11 @@ void ull_conn_iso_resume_ticker_start(struct lll_event *resume_event,
 	cig = resume_event->prepare_param.param;
 	ticker_id = TICKER_ID_CONN_ISO_RESUME_BASE + cig->handle;
 
+	if (cig->resume_cis != LLL_HANDLE_INVALID) {
+		/* Restarting resume ticker - must be stopped first */
+		(void)ticker_stop(TICKER_INSTANCE_ID_CTLR, TICKER_USER_ID_LLL,
+				  ticker_id, NULL, NULL);
+	}
 	cig->resume_cis = cis_handle;
 
 	if (0) {
@@ -407,7 +431,15 @@ int ull_conn_iso_reset(void)
 
 static int init_reset(void)
 {
+	struct ll_conn_iso_stream *cis;
+	struct ll_conn_iso_group *cig;
+	uint16_t handle;
 	int err;
+
+	/* Disable all active CIGs (uses blocking ull_ticker_stop_with_mark) */
+	for (handle = 0U; handle < CONFIG_BT_CTLR_CONN_ISO_GROUPS; handle++) {
+		disable(handle);
+	}
 
 	/* Initialize CIS pool */
 	mem_init(cis_pool, sizeof(struct ll_conn_iso_stream),
@@ -419,8 +451,17 @@ static int init_reset(void)
 		 sizeof(cig_pool) / sizeof(struct ll_conn_iso_group),
 		 &cig_free);
 
-	for (int h = 0; h < CONFIG_BT_CTLR_CONN_ISO_GROUPS; h++) {
-		ll_conn_iso_group_get(h)->cig_id = 0xFF;
+	for (handle = 0; handle < CONFIG_BT_CTLR_CONN_ISO_GROUPS; handle++) {
+		cig = ll_conn_iso_group_get(handle);
+		cig->cig_id  = 0xFF;
+		cig->started = 0;
+		cig->lll.num_cis = 0;
+	}
+
+	for (handle = LL_CIS_HANDLE_BASE; handle <= LAST_VALID_CIS_HANDLE; handle++) {
+		cis = ll_conn_iso_stream_get(handle);
+		cis->cis_id = 0;
+		cis->group  = NULL;
 	}
 
 	/* Initialize LLL */
@@ -456,6 +497,7 @@ static void ticker_resume_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 {
 	static memq_link_t link;
 	static struct mayfly mfy = {0, 0, &link, NULL, lll_resume};
+	struct lll_conn_iso_group *cig;
 	struct lll_event *resume_event;
 	uint32_t ret;
 
@@ -470,6 +512,10 @@ static void ticker_resume_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	resume_event->prepare_param.lazy = 0;
 	resume_event->prepare_param.force = force;
 	mfy.param = resume_event;
+
+	/* Mark resume as done */
+	cig = resume_event->prepare_param.param;
+	cig->resume_cis = LLL_HANDLE_INVALID;
 
 	/* Kick LLL resume */
 	ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH, TICKER_USER_ID_LLL,
@@ -496,15 +542,38 @@ static void cis_disabled_cb(void *param)
 		cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
 		LL_ASSERT(cis);
 
-		if (cis->teardown) {
+		if (cis->lll.flushed) {
 			ll_iso_stream_released_cb_t cis_released_cb;
-			struct node_rx_pdu *node_terminate;
 			struct ll_conn *conn;
 
 			conn = ll_conn_get(cis->lll.acl_handle);
 			cis_released_cb = cis->released_cb;
 
-			/* Create and enqueue termination node */
+			/* Remove data path and ISOAL sink/source associated with this CIS
+			 * for both directions.
+			 */
+			ll_remove_iso_path(cis->lll.handle, BT_HCI_DATAPATH_DIR_CTLR_TO_HOST);
+			ll_remove_iso_path(cis->lll.handle, BT_HCI_DATAPATH_DIR_HOST_TO_CTLR);
+
+			ll_conn_iso_stream_release(cis);
+			cig->lll.num_cis--;
+
+			/* Check if removed CIS has an ACL disassociation callback. Invoke
+			 * the callback to allow cleanup.
+			 */
+			if (cis_released_cb) {
+				/* CIS removed - notify caller */
+				cis_released_cb(conn);
+			}
+		} else if (cis->teardown) {
+			DECLARE_MAYFLY_ARRAY(mfys, cis_tx_lll_flush,
+				CONFIG_BT_CTLR_CONN_ISO_GROUPS);
+			struct node_rx_pdu *node_terminate;
+			uint32_t ret;
+
+			/* Create and enqueue termination node. This shall prevent
+			 * further enqueuing of TX nodes for terminating CIS.
+			 */
 			node_terminate = ull_pdu_rx_alloc();
 			LL_ASSERT(node_terminate);
 			node_terminate->hdr.handle = cis->lll.handle;
@@ -514,16 +583,27 @@ static void cis_disabled_cb(void *param)
 			ll_rx_put(node_terminate->hdr.link, node_terminate);
 			ll_rx_sched();
 
-			ll_conn_iso_stream_release(cis);
-			cig->lll.num_cis--;
+			if (cig->lll.resume_cis == cis->lll.handle) {
+				/* Resume pending for terminating CIS - stop ticker */
+				(void)ticker_stop(TICKER_INSTANCE_ID_CTLR,
+						  TICKER_USER_ID_ULL_HIGH,
+						  TICKER_ID_CONN_ISO_RESUME_BASE +
+						  ll_conn_iso_group_handle_get(cig),
+						  NULL, NULL);
 
-			/* Check if removed CIS had an ACL disassociation callback. Invoke
-			 * the callback to allow cleanup.
-			 */
-			if (cis_released_cb) {
-				/* CIS removed - notify caller */
-				cis_released_cb(conn);
+				cig->lll.resume_cis = LLL_HANDLE_INVALID;
 			}
+
+			/* We need to flush TX nodes in LLL before releasing the stream.
+			 * More than one CIG may be terminating at the same time, so
+			 * enqueue a mayfly instance for this CIG.
+			 */
+			mfys[cig->lll.handle].param = &cis->lll;
+			ret = mayfly_enqueue(TICKER_USER_ID_ULL_HIGH,
+					     TICKER_USER_ID_LLL, 1, &mfys[cig->lll.handle]);
+			LL_ASSERT(!ret);
+
+			return;
 		}
 	}
 
@@ -541,6 +621,44 @@ static void cis_disabled_cb(void *param)
 		LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 			  (ticker_status == TICKER_STATUS_BUSY));
 	}
+}
+
+static void cis_tx_lll_flush(void *param)
+{
+	DECLARE_MAYFLY_ARRAY(mfys, cis_disabled_cb, CONFIG_BT_CTLR_CONN_ISO_GROUPS);
+
+	struct lll_conn_iso_stream *lll;
+	struct ll_conn_iso_stream *cis;
+	struct ll_conn_iso_group *cig;
+	struct node_tx *tx;
+	memq_link_t *link;
+	uint32_t ret;
+
+	lll = param;
+	lll->flushed = 1;
+
+	cis = ll_conn_iso_stream_get(lll->handle);
+	cig = cis->group;
+
+	/* Flush in LLL - may return TX nodes to ack queue */
+	lll_conn_iso_flush(lll->handle, lll);
+
+	link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head, (void **)&tx);
+	while (link) {
+		/* Create instant NACK */
+		ll_tx_ack_put(lll->handle, tx);
+		link->next = tx->next;
+		tx->next = link;
+
+		link = memq_dequeue(lll->memq_tx.tail, &lll->memq_tx.head,
+				    (void **)&tx);
+	}
+
+	/* Resume CIS teardown in ULL_HIGH context */
+	mfys[cig->lll.handle].param = &cig->lll;
+	ret = mayfly_enqueue(TICKER_USER_ID_LLL,
+			     TICKER_USER_ID_ULL_HIGH, 1, &mfys[cig->lll.handle]);
+	LL_ASSERT(!ret);
 }
 
 static void ticker_stop_op_cb(uint32_t status, void *param)
@@ -596,8 +714,27 @@ static void cig_disabled_cb(void *param)
 	struct ll_conn_iso_group *cig;
 
 	cig = HDR_LLL2ULL(param);
+	cig->cig_id  = 0xFF;
+	cig->started = 0;
 
 	ll_conn_iso_group_release(cig);
+}
 
-	/* TODO: Flush pending TX in LLL */
+static void disable(uint16_t handle)
+{
+	struct ll_conn_iso_group *cig;
+	int err;
+
+	cig = ll_conn_iso_group_get(handle);
+
+	(void)ull_ticker_stop_with_mark(TICKER_ID_CONN_ISO_RESUME_BASE + handle,
+					cig, &cig->lll);
+
+	err = ull_ticker_stop_with_mark(TICKER_ID_CONN_ISO_BASE + handle,
+					cig, &cig->lll);
+
+	LL_ASSERT(err == 0 || err == -EALREADY);
+
+	cig->lll.handle = LLL_HANDLE_INVALID;
+	cig->lll.resume_cis = LLL_HANDLE_INVALID;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_iso_types.h
@@ -18,11 +18,12 @@ struct ll_conn_iso_stream {
 	uint8_t  terminate_reason;
 	uint32_t offset;          /* Offset of CIS from ACL event in us */
 	ll_iso_stream_released_cb_t released_cb; /* CIS release callback */
-	uint8_t  established : 1; /* 0 if CIS has not yet been established.
+	uint8_t  framed:1;
+	uint8_t  established:1;   /* 0 if CIS has not yet been established.
 				   * 1 if CIS has been established and host
 				   * notified.
 				   */
-	uint8_t teardown : 1;     /* 1 if CIS teardown has been initiated */
+	uint8_t teardown:1;       /* 1 if CIS teardown has been initiated */
 };
 
 struct ll_conn_iso_group {
@@ -40,8 +41,12 @@ struct ll_conn_iso_group {
 				 */
 	uint32_t c_sdu_interval;
 	uint32_t p_sdu_interval;
+	uint32_t cig_ref_point;	/* CIG reference point timestamp (us) based on
+				 * controller's clock.
+				 */
 	uint16_t iso_interval;
 	uint8_t  cig_id;
+	uint8_t  started:1;     /* 1 if CIG started and ticker is running */
 };
 
 struct node_rx_conn_iso_req {

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_types.h
@@ -335,7 +335,6 @@ struct ll_conn {
 		uint8_t  cis_id;
 		uint32_t c_max_sdu:12;
 		uint32_t p_max_sdu:12;
-		uint32_t framed:1;
 		uint32_t cis_offset_min;
 		uint32_t cis_offset_max;
 		uint16_t conn_event_count;

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -17,6 +17,7 @@
 #include "util/mayfly.h"
 
 #include "pdu.h"
+#include "hal/ticker.h"
 
 #include "lll.h"
 #include "lll/lll_adv_types.h"
@@ -109,21 +110,20 @@ static void iso_rx_demux(void *param);
 #endif /* CONFIG_BT_CTLR_SYNC_ISO) || CONFIG_BT_CTLR_CONN_ISO */
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
-#define ISO_TX_BUF_SIZE MROUND(offsetof(struct node_tx_iso, pdu) + \
-			       offsetof(struct pdu_iso, payload) + \
-			       CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE)
+#define NODE_TX_BUFFER_SIZE MROUND(offsetof(struct node_tx_iso, pdu) + \
+				   offsetof(struct pdu_iso, payload) + \
+				   CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE)
+
 static struct {
 	void *free;
-	uint8_t pool[ISO_TX_BUF_SIZE * CONFIG_BT_CTLR_ISO_TX_BUFFERS];
+	uint8_t pool[NODE_TX_BUFFER_SIZE * CONFIG_BT_CTLR_ISO_TX_BUFFERS];
 } mem_iso_tx;
 
 static struct {
 	void *free;
 	uint8_t pool[sizeof(memq_link_t) * CONFIG_BT_CTLR_ISO_TX_BUFFERS];
-} mem_link_tx;
+} mem_link_iso_tx;
 
-static MFIFO_DEFINE(iso_ack, sizeof(struct lll_tx),
-		    CONFIG_BT_CTLR_ISO_TX_BUFFERS);
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 /* Must be implemented by vendor */
@@ -177,12 +177,14 @@ __weak bool ll_data_path_sink_create(struct ll_iso_datapath *datapath,
 }
 
 /* Could be implemented by vendor */
-__weak bool ll_data_path_source_create(struct ll_iso_datapath *datapath,
+__weak bool ll_data_path_source_create(uint16_t handle,
+				       struct ll_iso_datapath *datapath,
 				       isoal_source_pdu_alloc_cb *pdu_alloc,
 				       isoal_source_pdu_write_cb *pdu_write,
 				       isoal_source_pdu_emit_cb *pdu_emit,
 				       isoal_source_pdu_release_cb *pdu_release)
 {
+	ARG_UNUSED(handle);
 	ARG_UNUSED(datapath);
 	ARG_UNUSED(pdu_alloc);
 	ARG_UNUSED(pdu_write);
@@ -234,6 +236,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	uint32_t sdu_interval;
 	uint8_t  burst_number;
 	isoal_status_t err;
+	uint8_t framed;
 	uint8_t role;
 
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
@@ -244,7 +247,30 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	struct ll_conn_iso_group *cig = NULL;
 
 	if (IS_CIS_HANDLE(handle)) {
+		struct ll_conn *conn;
+
 		cis = ll_conn_iso_stream_get(handle);
+		if (!cis->group) {
+			/* CIS does not belong to a CIG */
+			return BT_HCI_ERR_UNKNOWN_CONN_ID;
+		}
+
+		conn = ll_connected_get(cis->lll.acl_handle);
+		if (conn) {
+			/* If we're still waiting for accept/response from
+			 * host, path setup is premature and we must return
+			 * disallowed status.
+			 */
+#if defined(CONFIG_BT_CTLR_PERIPHERAL_ISO)
+			const uint8_t cis_waiting = (conn->llcp_cis.state ==
+						     LLCP_CIS_STATE_RSP_WAIT);
+
+			if (cis_waiting) {
+				return BT_HCI_ERR_CMD_DISALLOWED;
+			}
+#endif /* CONFIG_BT_CTLR_PERIPHERAL_ISO */
+		}
+
 		cig = cis->group;
 		dp_in = cis->hdr.datapath_in;
 		dp_out = cis->hdr.datapath_out;
@@ -316,6 +342,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	iso_interval = cig->iso_interval;
 	stream_sync_delay = cis->sync_delay;
 	group_sync_delay = cig->sync_delay;
+	framed = cis->framed;
 
 	if (path_dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
 		/* Create sink for RX data path */
@@ -335,7 +362,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 
 		if (path_id == BT_HCI_DATAPATH_ID_HCI) {
 			/* Not vendor specific, thus alloc and emit functions known */
-			err = isoal_sink_create(handle, role,
+			err = isoal_sink_create(handle, role, framed,
 						burst_number, flush_timeout,
 						sdu_interval, iso_interval,
 						stream_sync_delay, group_sync_delay,
@@ -349,7 +376,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 
 			/* Request vendor sink callbacks for path */
 			if (ll_data_path_sink_create(dp, &sdu_alloc, &sdu_emit, &sdu_write)) {
-				err = isoal_sink_create(handle, role,
+				err = isoal_sink_create(handle, role, framed,
 							burst_number, flush_timeout,
 							sdu_interval, iso_interval,
 							stream_sync_delay, group_sync_delay,
@@ -397,13 +424,14 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 		pdu_release = ll_iso_pdu_release;
 
 		if (path_is_vendor_specific(path_id)) {
-			if (!ll_data_path_source_create(dp, &pdu_alloc, &pdu_write,
+			if (!ll_data_path_source_create(handle, dp,
+							&pdu_alloc, &pdu_write,
 							&pdu_emit, &pdu_release)) {
 				return BT_HCI_ERR_CMD_DISALLOWED;
 			}
 		}
 
-		err = isoal_source_create(handle, role,
+		err = isoal_source_create(handle, role, framed,
 					  burst_number, flush_timeout, max_octets,
 					  sdu_interval, iso_interval,
 					  stream_sync_delay, group_sync_delay,
@@ -427,13 +455,14 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 	lll_iso = &sync_iso->lll;
 
 	role = 1U; /* FIXME: Set role from LLL struct */
+	framed = 0;
 	burst_number = lll_iso->bn;
 	sdu_interval = lll_iso->sdu_interval;
 	iso_interval = lll_iso->iso_interval;
 
 	if (path_id == BT_HCI_DATAPATH_ID_HCI) {
 		/* Not vendor specific, thus alloc and emit functions known */
-		err = isoal_sink_create(handle, role,
+		err = isoal_sink_create(handle, role, framed,
 					burst_number, flush_timeout,
 					sdu_interval, iso_interval,
 					stream_sync_delay, group_sync_delay,
@@ -447,7 +476,7 @@ uint8_t ll_setup_iso_path(uint16_t handle, uint8_t path_dir, uint8_t path_id,
 
 		/* Request vendor sink callbacks for path */
 		if (ll_data_path_sink_create(dp, &sdu_alloc, &sdu_emit, &sdu_write)) {
-			err = isoal_sink_create(handle, role,
+			err = isoal_sink_create(handle, role, framed,
 						burst_number, flush_timeout,
 						sdu_interval, iso_interval,
 						stream_sync_delay, group_sync_delay,
@@ -500,12 +529,16 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 	if (path_dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR) {
 		dp = hdr->datapath_in;
 		if (dp) {
+			isoal_source_destroy(dp->source_hdl);
+
 			hdr->datapath_in = NULL;
 			ull_iso_datapath_release(dp);
 		}
 	} else if (path_dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST) {
 		dp = hdr->datapath_out;
 		if (dp) {
+			isoal_sink_destroy(dp->sink_hdl);
+
 			hdr->datapath_out = NULL;
 			ull_iso_datapath_release(dp);
 		}
@@ -535,6 +568,8 @@ uint8_t ll_remove_iso_path(uint16_t handle, uint8_t path_dir)
 
 	dp = stream->dp;
 	if (dp) {
+		isoal_sink_destroy(dp->sink_hdl);
+
 		stream->dp = NULL;
 		isoal_sink_destroy(dp->sink_hdl);
 		ull_iso_datapath_release(dp);
@@ -627,29 +662,31 @@ void ll_iso_tx_mem_release(void *node_tx)
 	mem_release(node_tx, &mem_iso_tx.free);
 }
 
-int ll_iso_tx_mem_enqueue(uint16_t handle, void *node_tx)
+int ll_iso_tx_mem_enqueue(uint16_t handle, void *node_tx, void *link)
 {
-	struct lll_adv_iso_stream *stream;
-	memq_link_t *link;
+	if (IS_ENABLED(CONFIG_BT_CTLR_CONN_ISO) &&
+	    IS_CIS_HANDLE(handle)) {
+		struct ll_conn_iso_stream *cis;
 
-	/* FIXME: Translate to CIS or BIS handle
-	 */
+		cis = ll_conn_iso_stream_get(handle);
+		memq_enqueue(link, node_tx, &cis->lll.memq_tx.tail);
 
-	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ISO)) {
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ISO) &&
+		   IS_ADV_ISO_HANDLE(handle)) {
+		struct lll_adv_iso_stream *stream;
+
+		/* FIXME: When hci_iso_handle uses ISOAL, link is provided and
+		 * this code should be removed.
+		 */
+		link = mem_acquire(&mem_link_iso_tx.free);
+		LL_ASSERT(link);
+
 		stream = ull_adv_iso_stream_get(handle);
-	} else {
-		/* FIXME: Get connected ISO stream instance */
-		stream = NULL;
-	}
+		memq_enqueue(link, node_tx, &stream->memq_tx.tail);
 
-	if (!stream) {
+	} else {
 		return -EINVAL;
 	}
-
-	link = mem_acquire(&mem_link_tx.free);
-	LL_ASSERT(link);
-
-	memq_enqueue(link, node_tx, &stream->memq_tx.tail);
 
 	return 0;
 }
@@ -671,11 +708,6 @@ int ull_iso_reset(void)
 {
 	int err;
 
-#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
-	/* Re-initialize the Tx Ack mfifo */
-	MFIFO_INIT(iso_ack);
-#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
-
 	err = init_reset();
 	if (err) {
 		return err;
@@ -687,46 +719,24 @@ int ull_iso_reset(void)
 #if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
 void ull_iso_lll_ack_enqueue(uint16_t handle, struct node_tx_iso *node_tx)
 {
-	struct lll_tx *tx;
-	uint8_t idx;
+	struct ll_iso_datapath *dp = NULL;
 
-	idx = MFIFO_ENQUEUE_GET(iso_ack, (void **)&tx);
-	LL_ASSERT(tx);
+	if (IS_ENABLED(CONFIG_BT_CTLR_CONN_ISO) && IS_CIS_HANDLE(handle)) {
+		struct ll_conn_iso_stream *cis;
 
-	tx->handle = handle;
-	tx->node = node_tx;
+		cis = ll_conn_iso_stream_get(handle);
+		dp  = cis->hdr.datapath_in;
 
-	MFIFO_ENQUEUE(iso_ack, idx);
-
-	ll_rx_sched();
-}
-
-uint8_t ull_iso_tx_ack_get(uint16_t *handle)
-{
-	struct lll_tx *tx;
-	uint8_t cmplt = 0U;
-
-	tx = MFIFO_DEQUEUE_GET(iso_ack);
-	if (tx) {
-		*handle = tx->handle;
-
-		do {
-			struct node_tx_iso *node_tx;
-
-			cmplt++;
-
-			node_tx = tx->node;
-
-			MFIFO_DEQUEUE(iso_ack);
-
-			mem_release(node_tx->link, &mem_link_tx.free);
-			mem_release(node_tx, &mem_iso_tx.free);
-
-			tx = MFIFO_DEQUEUE_GET(iso_ack);
-		} while (tx && (tx->handle == *handle));
+		if (dp) {
+			isoal_tx_pdu_release(dp->source_hdl, node_tx);
+		}
+	} else if (IS_ENABLED(CONFIG_BT_CTLR_ADV_ISO) && IS_ADV_ISO_HANDLE(handle)) {
+		/* Process as TX ack. TODO: Can be unified with CIS and use
+		 * ISOAL.
+		 */
+		ll_tx_ack_put(handle, (void *)node_tx);
+		ll_rx_sched();
 	}
-
-	return cmplt;
 }
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
@@ -761,12 +771,50 @@ void ull_iso_rx_sched(void)
 	mayfly_enqueue(TICKER_USER_ID_LLL, TICKER_USER_ID_ULL_HIGH, 1, &mfy);
 }
 
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+static void iso_rx_cig_ref_point_update(struct ll_conn_iso_group *cig,
+					const struct ll_conn_iso_stream *cis,
+					const struct node_rx_iso_meta  *meta)
+{
+	uint32_t cig_sync_delay;
+	uint32_t cis_sync_delay;
+	uint64_t event_count;
+	uint8_t burst_number;
+	uint8_t role;
+
+	role = cig->lll.role;
+	cig_sync_delay = cig->sync_delay;
+	cis_sync_delay = cis->sync_delay;
+	burst_number = cis->lll.rx.burst_number;
+	event_count = cis->lll.event_count;
+
+	if (role) {
+		/* Peripheral */
+
+		/* Check if this is the first payload received for this cis in
+		 * this event
+		 */
+		if (meta->payload_number == (burst_number * event_count)) {
+			/* Update the CIG reference point based on the CIS
+			 * anchor point
+			 */
+			/* TODO: It is not clear that the timestamp is in ticks.
+			 * Upstream expectations might be different and this
+			 * might have to be updated.
+			 */
+			cig->cig_ref_point = HAL_TICKER_TICKS_TO_US(meta->timestamp) +
+						cis_sync_delay - cig_sync_delay;
+		}
+	}
+}
+#endif /* CONFIG_BT_CTLR_CONN_ISO */
+
 static void iso_rx_demux(void *param)
 {
 	struct ll_conn_iso_stream *cis;
+	struct ll_conn_iso_group *cig;
 	struct ll_iso_datapath *dp;
 	struct node_rx_pdu *rx_pdu;
-	isoal_sink_handle_t sink;
 	struct node_rx_hdr *rx;
 	memq_link_t *link;
 
@@ -791,10 +839,12 @@ static void iso_rx_demux(void *param)
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
 				rx_pdu = (struct node_rx_pdu *)rx;
 				cis = ll_conn_iso_stream_get(rx_pdu->hdr.handle);
-				dp = cis->hdr.datapath_out;
-				sink = dp->sink_hdl;
+				cig = cis->group;
+				dp  = cis->hdr.datapath_out;
 
-				if (dp->path_id != BT_HCI_DATAPATH_ID_HCI) {
+				iso_rx_cig_ref_point_update(cig, cis, &rx_pdu->hdr.rx_iso_meta);
+
+				if (dp && dp->path_id != BT_HCI_DATAPATH_ID_HCI) {
 					/* If vendor specific datapath pass to ISO AL here,
 					 * in case of HCI destination it will be passed in
 					 * HCI context.
@@ -806,7 +856,7 @@ static void iso_rx_demux(void *param)
 
 					/* Pass the ISO PDU through ISO-AL */
 					const isoal_status_t err =
-						isoal_rx_pdu_recombine(sink, &pckt_meta);
+						isoal_rx_pdu_recombine(dp->sink_hdl, &pckt_meta);
 
 					LL_ASSERT(err == ISOAL_STATUS_OK); /* TODO handle err */
 				}
@@ -895,7 +945,9 @@ void ll_iso_rx_mem_release(void **node_rx)
 			mem_release(rx_free, &mem_iso_rx.free);
 			break;
 		default:
-			LL_ASSERT(0);
+			/* Ignore other types as node may have been initialized due to
+			 * race with HCI reset.
+			 */
 			break;
 		}
 	}
@@ -911,6 +963,13 @@ void ull_iso_datapath_release(struct ll_iso_datapath *dp)
 	mem_release(dp, &datapath_free);
 }
 
+#if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
+void ll_iso_link_tx_release(void *link)
+{
+	mem_release(link, &mem_link_iso_tx.free);
+}
+#endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
+
 #if defined(CONFIG_BT_CTLR_CONN_ISO)
 /**
  * Allocate a PDU from the LL and store the details in the given buffer. Allocation
@@ -921,11 +980,27 @@ void ull_iso_datapath_release(struct ll_iso_datapath *dp)
  */
 static isoal_status_t ll_iso_pdu_alloc(struct isoal_pdu_buffer *pdu_buffer)
 {
-	ARG_UNUSED(pdu_buffer);
+	struct node_tx_iso *node_tx;
 
-	/* TODO: Function will be populated along with the data-path
-	 * implementation
+	node_tx = ll_iso_tx_mem_acquire();
+	if (!node_tx) {
+		BT_ERR("Tx Buffer Overflow");
+		/* TODO: Report overflow to HCI and remove assert
+		 * data_buf_overflow(evt, BT_OVERFLOW_LINK_ISO)
+		 */
+		LL_ASSERT(0);
+		return ISOAL_STATUS_ERR_PDU_ALLOC;
+	}
+
+	/* node_tx handle will be required to emit the PDU later */
+	pdu_buffer->handle = (void *)node_tx;
+	pdu_buffer->pdu    = (void *)node_tx->pdu;
+
+	/* Use TX buffer size as the limit here. Actual size will be decided in
+	 * the ISOAL based on the minimum of the buffer size and the respective
+	 * Max_PDU_C_To_P or Max_PDU_P_To_C.
 	 */
+	pdu_buffer->size = CONFIG_BT_CTLR_ISO_TX_BUFFER_SIZE;
 
 	return ISOAL_STATUS_OK;
 }
@@ -950,9 +1025,13 @@ static isoal_status_t ll_iso_pdu_write(struct isoal_pdu_buffer *pdu_buffer,
 	LL_ASSERT(pdu_buffer->pdu);
 	LL_ASSERT(sdu_payload);
 
-	/* TODO: Function will be populated along with the data-path
-	 * implementation
-	 */
+	if ((pdu_offset + consume_len) > pdu_buffer->size) {
+		/* Exceeded PDU buffer */
+		return ISOAL_STATUS_ERR_UNSPECIFIED;
+	}
+
+	/* Copy source to destination at given offset */
+	memcpy(&pdu_buffer->pdu->payload[pdu_offset], sdu_payload, consume_len);
 
 	return ISOAL_STATUS_OK;
 }
@@ -966,12 +1045,14 @@ static isoal_status_t ll_iso_pdu_write(struct isoal_pdu_buffer *pdu_buffer,
 static isoal_status_t ll_iso_pdu_emit(struct node_tx_iso *node_tx,
 				      const uint16_t handle)
 {
-	ARG_UNUSED(node_tx);
-	ARG_UNUSED(handle);
+	memq_link_t *link;
 
-	/* TODO: Function will be populated along with the data-path
-	 * implementation
-	 */
+	link = mem_acquire(&mem_link_iso_tx.free);
+	LL_ASSERT(link);
+
+	if (ll_iso_tx_mem_enqueue(handle, node_tx, link)) {
+		return ISOAL_STATUS_ERR_PDU_EMIT;
+	}
 
 	return ISOAL_STATUS_OK;
 }
@@ -987,13 +1068,14 @@ static isoal_status_t ll_iso_pdu_release(struct node_tx_iso *node_tx,
 					 const uint16_t handle,
 					 const isoal_status_t status)
 {
-	ARG_UNUSED(node_tx);
-	ARG_UNUSED(handle);
-	ARG_UNUSED(status);
-
-	/* TODO: Function will be populated along with the data-path
-	 * implementation
-	 */
+	if (status == ISOAL_STATUS_OK) {
+		/* Process as TX ack */
+		ll_tx_ack_put(handle, (void *)node_tx);
+		ll_rx_sched();
+	} else {
+		/* Release back to memory pool */
+		ll_iso_tx_mem_release(node_tx);
+	}
 
 	return ISOAL_STATUS_OK;
 }
@@ -1027,12 +1109,13 @@ static int init_reset(void)
 
 #if defined(CONFIG_BT_CTLR_ADV_ISO) || defined(CONFIG_BT_CTLR_CONN_ISO)
 	/* Initialize tx pool. */
-	mem_init(mem_iso_tx.pool, ISO_TX_BUF_SIZE,
+	mem_init(mem_iso_tx.pool, NODE_TX_BUFFER_SIZE,
 		 CONFIG_BT_CTLR_ISO_TX_BUFFERS, &mem_iso_tx.free);
 
 	/* Initialize tx link pool. */
-	mem_init(mem_link_tx.pool, sizeof(memq_link_t),
-		 CONFIG_BT_CTLR_ISO_TX_BUFFERS, &mem_link_tx.free);
+	mem_init(mem_link_iso_tx.pool, sizeof(memq_link_t),
+		 CONFIG_BT_CTLR_ISO_TX_BUFFERS,
+		 &mem_link_iso_tx.free);
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */
 
 #if BT_CTLR_ISO_STREAMS
@@ -1040,6 +1123,9 @@ static int init_reset(void)
 	mem_init(datapath_pool, sizeof(struct ll_iso_datapath),
 		 sizeof(datapath_pool) / sizeof(struct ll_iso_datapath), &datapath_free);
 #endif /* BT_CTLR_ISO_STREAMS */
+
+	/* Initialize ISO Adaptation Layer */
+	isoal_init();
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -736,6 +736,8 @@ void ull_iso_lll_ack_enqueue(uint16_t handle, struct node_tx_iso *node_tx)
 		 */
 		ll_tx_ack_put(handle, (void *)node_tx);
 		ll_rx_sched();
+	} else {
+		LL_ASSERT(0);
 	}
 }
 #endif /* CONFIG_BT_CTLR_ADV_ISO || CONFIG_BT_CTLR_CONN_ISO */

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_internal.h
@@ -7,7 +7,6 @@
 int ull_iso_init(void);
 int ull_iso_reset(void);
 void ull_iso_datapath_release(struct ll_iso_datapath *dp);
-uint8_t ull_iso_tx_ack_get(uint16_t *handle);
 void ll_iso_rx_put(memq_link_t *link, void *rx);
 void *ll_iso_rx_get(void);
 void ll_iso_rx_dequeue(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso_types.h
@@ -25,6 +25,15 @@
 #define IS_CIS_HANDLE(_handle) 0
 #endif /* CONFIG_BT_CTLR_CONN_ISO */
 
+
+#if defined(CONFIG_BT_CTLR_ADV_ISO)
+#define IS_ADV_ISO_HANDLE(_handle) \
+	(((_handle) >= BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE) && \
+	((_handle) <= (BT_CTLR_ADV_ISO_STREAM_HANDLE_BASE + BT_CTLR_ADV_ISO_STREAM_MAX - 1)))
+#else
+#define IS_ADV_ISO_HANDLE(_handle) 0
+#endif /* CONFIG_BT_CTLR_ADV_ISO */
+
 /* Common members for ll_conn_iso_stream and ll_broadcast_iso_stream */
 struct ll_iso_stream_hdr {
 	struct ll_iso_datapath *datapath_in;

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -92,6 +92,7 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 {
 	struct ll_conn_iso_group *cig;
 	struct ll_conn_iso_stream *cis;
+	uint16_t handle;
 
 	/* Get CIG by id */
 	cig = ll_conn_iso_group_get_by_id(req->cig_id);
@@ -106,8 +107,9 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 		memset(&cig->lll, 0, sizeof(cig->lll));
 
 		cig->cig_id = req->cig_id;
-		cig->lll.handle = 0xFFFF;
+		cig->lll.handle = LLL_HANDLE_INVALID;
 		cig->lll.role = acl->lll.role;
+		cig->lll.resume_cis = LLL_HANDLE_INVALID;
 
 		ull_hdr_init(&cig->ull);
 		lll_hdr_init(&cig->lll, cig);
@@ -118,6 +120,14 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 		return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 	}
 
+	for (handle = LL_CIS_HANDLE_BASE; handle <= LAST_VALID_CIS_HANDLE; handle++) {
+		cis = ll_iso_stream_connected_get(handle);
+		if (cis && cis->cis_id == req->cis_id) {
+			/* CIS ID already in use */
+			return BT_HCI_ERR_INVALID_LL_PARAM;
+		}
+	}
+
 	/* Acquire new CIS */
 	cis = ll_conn_iso_stream_acquire();
 	if (cis == NULL) {
@@ -125,11 +135,13 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 		return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 	}
 
-	cig->iso_interval   = sys_le16_to_cpu(req->iso_interval);
-	cig->c_sdu_interval = sys_get_le24(req->c_sdu_interval);
-	cig->p_sdu_interval = sys_get_le24(req->p_sdu_interval);
+	cig->iso_interval = sys_le16_to_cpu(req->iso_interval);
+	/* Read 20-bit SDU intervals (mask away RFU bits) */
+	cig->c_sdu_interval = sys_get_le24(req->c_sdu_interval) & 0x0FFFFF;
+	cig->p_sdu_interval = sys_get_le24(req->p_sdu_interval) & 0x0FFFFF;
 
 	cis->cis_id = req->cis_id;
+	cis->framed = (req->c_max_sdu_packed[1] & BIT(7)) >> 7;
 	cis->established = 0;
 	cis->group = cig;
 	cis->teardown = 0;
@@ -143,16 +155,28 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 	cis->lll.sn = 0;
 	cis->lll.nesn = 0;
 	cis->lll.cie = 0;
+	cis->lll.flushed = 0;
+	cis->lll.datapath_ready_rx = 0;
 
 	cis->lll.rx.phy = req->c_phy;
 	cis->lll.rx.burst_number = req->c_bn;
 	cis->lll.rx.flush_timeout = req->c_ft;
 	cis->lll.rx.max_octets = sys_le16_to_cpu(req->c_max_pdu);
+	cis->lll.rx.payload_number = 0;
 
 	cis->lll.tx.phy = req->p_phy;
 	cis->lll.tx.burst_number = req->p_bn;
 	cis->lll.tx.flush_timeout = req->p_ft;
 	cis->lll.tx.max_octets = sys_le16_to_cpu(req->p_max_pdu);
+	cis->lll.tx.payload_number = 0;
+
+	if (!cis->lll.link_tx_free) {
+		cis->lll.link_tx_free = &cis->lll.link_tx;
+	}
+
+	memq_init(cis->lll.link_tx_free, &cis->lll.memq_tx.head,
+		  &cis->lll.memq_tx.tail);
+	cis->lll.link_tx_free = NULL;
 
 	*cis_handle = ll_conn_iso_stream_handle_get(cis);
 	cig->lll.num_cis++;
@@ -198,11 +222,13 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	static struct lll_prepare_param p;
 	struct ll_conn_iso_group *cig;
 	struct ll_conn_iso_stream *cis;
+	uint64_t leading_event_count;
 	uint16_t handle_iter;
 	uint32_t err;
 	uint8_t ref;
 
 	cig = param;
+	leading_event_count = 0;
 
 	/* Check if stopping ticker (on disconnection, race with ticker expiry)
 	 */
@@ -225,7 +251,25 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 		 */
 		if (cis->lll.handle != 0xFFFF) {
 			cis->lll.event_count++;
+
+
+			leading_event_count = MAX(leading_event_count,
+						cis->lll.event_count);
 		}
+
+		/* Latch datapath validity entering event */
+		cis->lll.datapath_ready_rx = cis->hdr.datapath_out != NULL;
+	}
+
+	/* Update the CIG reference point for this event. Event 0 for the
+	 * leading CIS in the CIG would have had it's reference point set in
+	 * ull_peripheral_iso_start(). The reference point should only be
+	 * updated from event 1 onwards. Although the cig reference point set
+	 * this way is not accurate, it is the best possible until the anchor
+	 * point for the leading CIS is available for this event.
+	 */
+	if (leading_event_count > 0) {
+		cig->cig_ref_point += (cig->iso_interval * CONN_INT_UNIT_US);
 	}
 
 	/* Increment prepare reference count */
@@ -252,7 +296,8 @@ static void ticker_op_cb(uint32_t status, void *param)
 	LL_ASSERT(status == TICKER_STATUS_SUCCESS);
 }
 
-void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
+void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire,
+			      uint16_t cis_handle)
 {
 	struct ll_conn_iso_group *cig;
 	struct ll_conn_iso_stream *cis;
@@ -262,17 +307,12 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
 	uint32_t ticks_interval;
 	uint32_t ticker_status;
 	int32_t cig_offset_us;
-	uint16_t handle_iter;
-	uint16_t cis_handle;
 	uint8_t ticker_id;
 
-	cis_handle = acl->llcp_cis.cis_handle;
-
-	cig = ll_conn_iso_group_get_by_id(acl->llcp_cis.cig_id);
 	cis = ll_conn_iso_stream_get(cis_handle);
+	cig = cis->group;
 
 	cis_offs_to_cig_ref = cig->sync_delay - cis->sync_delay;
-	handle_iter = UINT16_MAX;
 
 	cis->lll.offset = cis_offs_to_cig_ref;
 	cis->lll.handle = cis_handle;
@@ -281,17 +321,7 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
 	 * running. If so, we just return with updated offset and
 	 * validated handle.
 	 */
-	for (int i = 0; i < cig->lll.num_cis; i++) {
-		struct ll_conn_iso_stream *other_cis;
-
-		other_cis = ll_conn_iso_stream_get_by_group(cig, &handle_iter);
-		LL_ASSERT(other_cis);
-
-		if (other_cis == cis || other_cis->lll.handle == 0xFFFF) {
-			/* Same CIS or not valid - skip */
-			continue;
-		}
-
+	if (cig->started) {
 		/* We're done */
 		return;
 	}
@@ -312,7 +342,9 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
 	ready_delay_us = lll_radio_rx_ready_delay_get(0, 0);
 #endif
 
+	/* Calculate initial ticker offset - we're one ACL interval early */
 	cig_offset_us  = acl_to_cig_ref_point;
+	cig_offset_us += (acl->lll.interval * CONN_INT_UNIT_US);
 	cig_offset_us -= EVENT_OVERHEAD_START_US;
 	cig_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	cig_offset_us -= EVENT_JITTER_US;
@@ -322,6 +354,14 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
 	 * by skipping <n> interval(s) and incrementing event_count.
 	 */
 	LL_ASSERT(cig_offset_us > 0);
+
+	/* Calculate the CIG reference point of first CIG event. This
+	 * calculation is inaccurate. However it is the best estimate available
+	 * until the first anchor point for the leading CIS is available.
+	 */
+	cig->cig_ref_point = HAL_TICKER_TICKS_TO_US(ticks_at_expire);
+	cig->cig_ref_point += acl_to_cig_ref_point;
+	cig->cig_ref_point += (acl->lll.interval * CONN_INT_UNIT_US);
 
 	/* Start CIS peripheral CIG ticker */
 	ticker_status = ticker_start(TICKER_INSTANCE_ID_CTLR,
@@ -338,4 +378,6 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire)
 
 	LL_ASSERT((ticker_status == TICKER_STATUS_SUCCESS) ||
 		  (ticker_status == TICKER_STATUS_BUSY));
+
+	cig->started = 1;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso_internal.h
@@ -14,4 +14,5 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 uint8_t ull_peripheral_iso_setup(struct pdu_data_llctrl_cis_ind *ind,
 				 uint8_t cig_id,
 				 uint16_t cis_handle);
-void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire);
+void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire,
+			      uint16_t cis_handle);

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -1046,6 +1046,7 @@ void hci_le_cis_req(struct net_buf *buf)
 		return;
 	}
 
+	iso->iso.info.type = BT_ISO_CHAN_TYPE_CONNECTED;
 	iso->iso.cig_id = evt->cig_id;
 	iso->iso.cis_id = evt->cis_id;
 


### PR DESCRIPTION
Bluetooth: controller: ISO TX data path including ISOAL
- ISO TX data path for HCI and support for vendor path
- ISO-AL segmentation of framed PDUs
- Insertion of segment headers
- Reconstruction and storing of CIG reference point in ULL
- Calculation and insertion of of Time-Offset
- Exit error spooling in ISO-AL on detecting start
- ISO-AL TX unframed fragmentation

tests: bluetooth: Updates for ISOAL unittest
Minor adjustments due to implementation changes.

Bluetooth: host: Set ISO type for CIS at request
Set BT_ISO_CHAN_TYPE_CONNECTED as type for connected ISO at CIS_REQ.