### PR TITLE
drivers: can: stm32fd: add clock source selection

### DIFF
--- a/drivers/can/Kconfig.stm32fd
+++ b/drivers/can/Kconfig.stm32fd
@@ -52,8 +52,9 @@ config CAN_STM32FD_CLOCK_SOURCE_PCLK1
 
 endchoice
 
-config CAN_STM32_CLOCK_DIVISOR
+config CAN_STM32FD_CLOCK_DIVISOR
 	int "CAN clock divisor"
+	depends on CAN_STM32FD_CLOCK_SOURCE_PCLK1
 	range 1 30
 	default 1
 	help
@@ -62,4 +63,4 @@ config CAN_STM32_CLOCK_DIVISOR
 	  Note that the the divisor affects all CAN controllers.
 	  Allowed values: 1 or 2 * n, where n <= 15.
 
-endif #CAN_STM32FD
+endif # CAN_STM32FD

--- a/drivers/can/Kconfig.stm32fd
+++ b/drivers/can/Kconfig.stm32fd
@@ -29,6 +29,29 @@ config CAN_MAX_EXT_ID_FILTER
 	  Defines the maximum number of filters with extended ID (29-bit)
 	  that can be attached.
 
+choice CAN_STM32FD_CLOCK_SOURCE
+	prompt "CAN clock source"
+	default CAN_STM32FD_CLOCK_SOURCE_HSE
+	help
+	  CAN clock source selection.
+
+config CAN_STM32FD_CLOCK_SOURCE_HSE
+	bool "HSE"
+	help
+	  HSE clock used as FDCAN clock source.
+
+config CAN_STM32FD_CLOCK_SOURCE_PLL
+	bool "PLL"
+	help
+	  PLL "Q" clock used ad FDCAN clock source.
+
+config CAN_STM32FD_CLOCK_SOURCE_PCLK1
+	bool "PCLK1"
+	help
+	  PCLK1 clock used ad FDCAN clock source.
+
+endchoice
+
 config CAN_STM32_CLOCK_DIVISOR
 	int "CAN clock divisor"
 	range 1 30

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -16,6 +16,16 @@
 
 LOG_MODULE_REGISTER(can_stm32fd, CONFIG_CAN_LOG_LEVEL);
 
+#if defined(CONFIG_CAN_STM32FD_CLOCK_SOURCE_HSE)
+#define CAN_STM32FD_CLOCK_SOURCE LL_RCC_FDCAN_CLKSOURCE_HSE
+#elif defined(CONFIG_CAN_STM32FD_CLOCK_SOURCE_PLL)
+#define CAN_STM32FD_CLOCK_SOURCE LL_RCC_FDCAN_CLKSOURCE_PLL
+#elif defined(CONFIG_CAN_STM32FD_CLOCK_SOURCE_PCLK1)
+#define CAN_STM32FD_CLOCK_SOURCE LL_RCC_FDCAN_CLKSOURCE_PCLK1
+#else
+#error "Unsupported FDCAN clock source"
+#endif
+
 #if CONFIG_CAN_STM32_CLOCK_DIVISOR != 1 && CONFIG_CAN_STM32_CLOCK_DIVISOR & 0x01
 #error CAN_STM32_CLOCK_DIVISOR invalid.\
 Allowed values are 1 or 2 * n, where n <= 15
@@ -40,7 +50,7 @@ static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 
 static void can_stm32fd_clock_enable(void)
 {
-	LL_RCC_SetFDCANClockSource(LL_RCC_FDCAN_CLKSOURCE_PCLK1);
+	LL_RCC_SetFDCANClockSource(CAN_STM32FD_CLOCK_SOURCE);
 	__HAL_RCC_FDCAN_CLK_ENABLE();
 
 	FDCAN_CONFIG->CKDIV = CONFIG_CAN_STM32_CLOCK_DIVISOR >> 1;

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -26,10 +26,15 @@ LOG_MODULE_REGISTER(can_stm32fd, CONFIG_CAN_LOG_LEVEL);
 #error "Unsupported FDCAN clock source"
 #endif
 
-#if CONFIG_CAN_STM32_CLOCK_DIVISOR != 1 && CONFIG_CAN_STM32_CLOCK_DIVISOR & 0x01
-#error CAN_STM32_CLOCK_DIVISOR invalid.\
-Allowed values are 1 or 2 * n, where n <= 15
-#endif
+#ifdef CONFIG_CAN_STM32FD_CLOCK_DIVISOR
+#if CONFIG_CAN_STM32FD_CLOCK_DIVISOR != 1 && CONFIG_CAN_STM32FD_CLOCK_DIVISOR & 0x01
+#error CAN_STM32FD_CLOCK_DIVISOR invalid. Allowed values are 1 or 2 * n, where n <= 15.
+#else
+#define CAN_STM32FD_CLOCK_DIVISOR CONFIG_CAN_STM32FD_CLOCK_DIVISOR
+#endif /* CONFIG_CAN_STM32FD_CLOCK_DIVISOR */
+#else
+#define CAN_STM32FD_CLOCK_DIVISOR 1U
+#endif /* CONFIG_CAN_STM32FD_CLOCK_DIVISOR*/
 
 #define DT_DRV_COMPAT st_stm32_fdcan
 
@@ -43,7 +48,7 @@ static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 		return -EIO;
 	}
 
-	*rate = rate_tmp / CONFIG_CAN_STM32_CLOCK_DIVISOR;
+	*rate = rate_tmp / CAN_STM32FD_CLOCK_DIVISOR;
 
 	return 0;
 }
@@ -53,7 +58,7 @@ static void can_stm32fd_clock_enable(void)
 	LL_RCC_SetFDCANClockSource(CAN_STM32FD_CLOCK_SOURCE);
 	__HAL_RCC_FDCAN_CLK_ENABLE();
 
-	FDCAN_CONFIG->CKDIV = CONFIG_CAN_STM32_CLOCK_DIVISOR >> 1;
+	FDCAN_CONFIG->CKDIV = CAN_STM32FD_CLOCK_DIVISOR >> 1;
 }
 
 static void can_stm32fd_set_state_change_callback(const struct device *dev,

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -285,9 +285,15 @@ void test_set_timing_max(void)
 void test_main(void)
 {
 	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	uint32_t core_clock;
+	int err;
 
 	zassert_true(device_is_ready(dev), "CAN device not ready");
-	printk("testing on device %s\n", dev->name);
+
+	err = can_get_core_clock(dev, &core_clock);
+	zassert_equal(err, 0, "failed to get core CAN clock");
+
+	printk("testing on device %s @ %u Hz\n", dev->name, core_clock);
 
 	k_object_access_grant(dev, k_current_get());
 


### PR DESCRIPTION
- Print the CAN core clock frequency along with the device name to aid in debugging CAN timing test case errors.
- Add support for selecting the CAN clock source. Change previously hardcoded value of PCLK1 to HSE.
- Rename `CONFIG_CAN_STM32_CLOCK_DIVISOR` to `CONFIG_CAN_STM32FD_CLOCK_DIVISOR` to match driver Kconfig name.

Fixes: #44985