### PR TITLE
boards: arduino_nano_33_ble: Correct certain PWM LED settings

### DIFF
--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
@@ -56,14 +56,20 @@
 			pwms = <&pwm0 6>;
 			label = "Blue PWM LED";
 		};
-		yellow_pwm_led: led_pwm_3 {
-			/* Cannot be used together with spi2. */
-			pwms = <&pwm0 13>;
-			label = "Yellow PWM LED";
-		};
 		user_pwm_led: led_pwm_4 {
 			pwms = <&pwm1 41>;
 			label = "User PWM LED";
+		};
+	};
+
+	pwmleds2 {
+		compatible = "pwm-leds";
+		/* Cannot be used together with spi2. */
+		status = "disabled";
+
+		yellow_pwm_led: led_pwm_3 {
+			pwms = <&pwm2 13>;
+			label = "Yellow PWM LED";
 		};
 	};
 
@@ -189,6 +195,14 @@ arduino_spi: &spi2 {
 	status = "okay";
 	pinctrl-0 = <&pwm1_default>;
 	pinctrl-1 = <&pwm1_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+&pwm2 {
+	/* Cannot be used together with spi2 because of conflict on P0.13. */
+	status = "disabled";
+	pinctrl-0 = <&pwm2_default>;
+	pinctrl-1 = <&pwm2_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
@@ -89,7 +89,6 @@
 	pwm1_default: pwm1_default {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 1, 9)>;
-			nordic,invert;
 		};
 	};
 

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
@@ -69,9 +69,8 @@
 	pwm0_default: pwm0_default {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 24)>,
-					<NRF_PSEL(PWM_OUT1, 0, 16)>,
-					<NRF_PSEL(PWM_OUT2, 0, 6)>,
-					<NRF_PSEL(PWM_OUT3, 0, 13)>;
+				<NRF_PSEL(PWM_OUT1, 0, 16)>,
+				<NRF_PSEL(PWM_OUT2, 0, 6)>;
 			nordic,invert;
 		};
 	};
@@ -79,9 +78,8 @@
 	pwm0_sleep: pwm0_sleep {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 24)>,
-					<NRF_PSEL(PWM_OUT1, 0, 16)>,
-					<NRF_PSEL(PWM_OUT2, 0, 6)>,
-					<NRF_PSEL(PWM_OUT3, 0, 13)>;
+				<NRF_PSEL(PWM_OUT1, 0, 16)>,
+				<NRF_PSEL(PWM_OUT2, 0, 6)>;
 			low-power-enable;
 		};
 	};
@@ -95,6 +93,19 @@
 	pwm1_sleep: pwm1_sleep {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 1, 9)>;
+			low-power-enable;
+		};
+	};
+
+	pwm2_default: pwm2_default {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>;
+		};
+	};
+
+	pwm2_sleep: pwm2_sleep {
+		group1 {
+			psels = <NRF_PSEL(PWM_OUT0, 0, 13)>;
 			low-power-enable;
 		};
 	};


### PR DESCRIPTION
This is a follow-up to commit f4a0ddd8afa1c2b99a30dcd940f34304ce678c93.

According to the schematic, the LED connected to the P1.09 pin is
active high. Therefore, the PWM1 instance that is configured to drive
the LED should not use the "nordic,invert" property.

Since the yellow LED and the SCK line of spi2 use the same pin
(P0.13), they cannot be used together. Consequently, the pin
should not be assigned to the same PWM instance as other pins
that drive LEDs, as the limitation of usage would apply to the
whole PWM instance (it acquires all the pins assigned to it on
initialization of the PWM driver, regardless of whether the PWM
signal is eventually generated on particular outputs or not).

Use a separate PWM instance (disabled by default) for driving
the yellow LED.