### PR TITLE
board/arm/nucleo_l073rz : add entropy RNG support

### DIFF
--- a/boards/arm/nucleo_l073rz/doc/index.rst
+++ b/boards/arm/nucleo_l073rz/doc/index.rst
@@ -100,6 +100,8 @@ The Zephyr nucleo_l073rz board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
 +-----------+------------+-------------------------------------+
+| RNG       | on-chip    | Random Number Generator             |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -18,6 +18,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,entropy = &rng;
 	};
 
 	leds {
@@ -125,4 +126,8 @@
 		pinctrl-0 = <&tim2_ch1_pa5>;
 		pinctrl-names = "default";
 	};
+};
+
+&rng {
+	status = "okay";
 };

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.yaml
@@ -19,3 +19,4 @@ supported:
   - adc
   - dac
   - pwm
+  - rng


### PR DESCRIPTION
stm32l073 add entropy RNG testcase running on nucleo target

