### PR TITLE
scripts: gitlint: block Change-Id tags in commit message

### DIFF
--- a/scripts/gitlint/zephyr_commit_rules.py
+++ b/scripts/gitlint/zephyr_commit_rules.py
@@ -117,3 +117,16 @@ class MaxLineLengthExceptions(LineRule):
 
         if len(line) > max_length:
             return [RuleViolation(self.id, self.violation_message.format(len(line), max_length), line)]
+
+class BodyContainsBlockedTags(LineRule):
+    name = "body-contains-blocked-tags"
+    id = "UC7"
+    target = CommitMessageBody
+    tags = ["Change-Id"]
+
+    def validate(self, line, _commit):
+        flags = re.IGNORECASE
+        for tag in self.tags:
+            if re.search(rf"^\s*{tag}:", line, flags=flags):
+                return [RuleViolation(self.id, f"Body contains a blocked tag: {tag}")]
+        return


### PR DESCRIPTION
Hey, second try to add compliancy check on unwanted commit tags. Using checkpatch.pl did not work out and got reverted in #44984, this implements only the tag check using gitlint, only blocks change-id but can be extended.

-- 8< --

Add a new gitlint user rule to block unwanted commit tags, and set it up
to block Gerrit Change-Id tags.