### PR TITLE
drivers: espi: Correct default eSPI to UART mapping

### DIFF
--- a/drivers/espi/Kconfig.xec
+++ b/drivers/espi/Kconfig.xec
@@ -31,7 +31,8 @@ config ESPI_PERIPHERAL_UART
 
 config ESPI_PERIPHERAL_UART_SOC_MAPPING
 	int "SoC port exposed as logical eSPI UART"
-	default 2
+	default 2 if SOC_SERIES_MEC1501X
+	default 1 if SOC_SERIES_MEC172X
 	depends on ESPI_PERIPHERAL_UART
 	help
 	  This tells the driver to which SoC UART to direct the UART traffic


### PR DESCRIPTION
Correct default mapping for eSPI UART virtual port to SoC UART
for MEC172x.

Signed-off-by: Meza Arellano, Jose A <jose.a.meza.arellano@intel.com>