### PR TITLE
boards: arm: arduino_nano_33_ble_sense: Add dmic device to DTS

### DIFF
--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-pinctrl.dtsi
@@ -96,6 +96,20 @@
 	pwm1_sleep: pwm1_sleep {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 1, 9)>;
+		};
+	};
+
+	pdm0_default: pdm0_default {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 0, 26)>,
+				<NRF_PSEL(PDM_DIN, 0, 25)>;
+		};
+	};
+
+	pdm0_sleep: pdm0_sleep {
+		group1 {
+			psels = <NRF_PSEL(PDM_CLK, 0, 26)>,
+				<NRF_PSEL(PDM_DIN, 0, 25)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble_sense.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble_sense.dts
@@ -12,6 +12,14 @@
 / {
 	model = "Arduino Nano 33 BLE Sense";
 	compatible = "arduino,arduino_nano_33_ble_sense";
+
+	mic_pwr: mic_pwr {
+		compatible = "regulator-fixed-sync", "regulator-fixed";
+		label = "mic_pwr";
+		regulator-name = "mic_pwr";
+		enable-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+		regulator-boot-on;
+	};
 };
 
 &i2c1 {
@@ -36,4 +44,12 @@
 		label = "APDS9960";
 		int-gpios = <&gpio0 19 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
+};
+
+dmic_dev: &pdm0 {
+	status = "okay";
+	pinctrl-0 = <&pdm0_default>;
+	pinctrl-1 = <&pdm0_sleep>;
+	pinctrl-names = "default", "sleep";
+	clock-source = "PCLK32M_HFXO";
 };


### PR DESCRIPTION
This commit adds audio dmic to the boards dts and a regulator
to enable the microphone VDD and L/R pin.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>