### PR TITLE
net: sockets: tls: use cipherlist set by user

### DIFF
--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -1076,6 +1076,13 @@ static int tls_mbedtls_init(struct tls_context *context, bool is_server)
 		return ret;
 	}
 
+	if (context->options.ciphersuites[0] != 0) {
+		/* Specific ciphersuites configured, so use them */
+		NET_DBG("Using user-specified ciphersuites");
+		mbedtls_ssl_conf_ciphersuites(&context->config,
+					      context->options.ciphersuites);
+	}
+
 #if defined(CONFIG_MBEDTLS_SSL_ALPN)
 	if (ALPN_MAX_PROTOCOLS && context->options.alpn_list[0] != NULL) {
 		ret = mbedtls_ssl_conf_alpn_protocols(&context->config,
@@ -1198,6 +1205,8 @@ static int tls_opt_ciphersuite_list_set(struct tls_context *context,
 	memcpy(context->options.ciphersuites, optval, optlen);
 	context->options.ciphersuites[cipher_cnt] = 0;
 
+	mbedtls_ssl_conf_ciphersuites(&context->config,
+				      context->options.ciphersuites);
 	return 0;
 }
 


### PR DESCRIPTION
The function setsockopt() option TLS_CIPHERSUITE_LIST
allows the user to set a specific list of ciphersuites
when using the Zephyr native + Mbed TLS stack.  However, the
list provided was not actually being used later for
handshaking.

This adds the missing calls to mbedtls_ssl_conf_ciphersuites()
to use the list provided.  If none was provided, fall back
to the default list as determined by Mbed TLS from Kconfig
values.

Signed-off-by: Pete Skeggs <peter.skeggs@nordicsemi.no>