### PR TITLE
Add more uses of zephyr/ prefix for include paths

### DIFF
--- a/doc/build/dts/api-usage.rst
+++ b/doc/build/dts/api-usage.rst
@@ -349,7 +349,7 @@ compatible with less typing, like this:
 
 .. code-block:: c
 
-   #include <devicetree.h>
+   #include <zephyr/devicetree.h>
 
    #define DT_DRV_COMPAT my_driver_compat
 

--- a/doc/build/dts/bindings.rst
+++ b/doc/build/dts/bindings.rst
@@ -1132,7 +1132,7 @@ gpio_dt_spec``, then use it like this:
 
 .. code-block:: C
 
-   #include <drivers/gpio.h>
+   #include <zephyr/drivers/gpio.h>
 
    #define ZEPHYR_USER_NODE DT_PATH(zephyr_user)
 

--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -415,7 +415,7 @@ device-specific configuration and data structures and API functions, like this:
 .. code-block:: c
 
    /* my_driver.c */
-   #include <drivers/some_api.h>
+   #include <zephyr/drivers/some_api.h>
 
    /* Define data (RAM) and configuration (ROM) structures: */
    struct my_dev_data {

--- a/doc/connectivity/networking/api/8021Qav.rst
+++ b/doc/connectivity/networking/api/8021Qav.rst
@@ -42,9 +42,9 @@ The application can configure the credit-based shaper like this:
 
 .. code-block:: c
 
-	#include <net/net_if.h>
-	#include <net/ethernet.h>
-	#include <net/ethernet_mgmt.h>
+	#include <zephyr/net/net_if.h>
+	#include <zephyr/net/ethernet.h>
+	#include <zephyr/net/ethernet_mgmt.h>
 
 	static void qav_set_status(struct net_if *iface,
 	                           int queue_id, bool enable)

--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -196,7 +196,7 @@ Here is a generic template for a test showing the expected use of
 
 .. code-block:: C
 
-   #include <ztest.h>
+   #include <zephyr/ztest.h>
 
    extern void test_sometest1(void);
    extern void test_sometest2(void);
@@ -227,7 +227,7 @@ Alternatively, it is possible to split tests across multiple files using
 
 .. code-block:: C
 
-  #include <ztest.h>
+  #include <zephyr/ztest.h>
 
   void test_sometest1(void) {
   	zassert_true(1, "true");
@@ -251,7 +251,7 @@ state and different test suites need to run. This is achieved in the following:
 
 .. code-block:: C
 
-  #include <ztest.h>
+  #include <zephyr/ztest.h>
 
   struct state {
   	bool is_hibernating;

--- a/doc/hardware/pinctrl/index.rst
+++ b/doc/hardware/pinctrl/index.rst
@@ -446,7 +446,7 @@ The example below contains a complete example of a device driver that uses the
     #define DT_DRV_COMPAT mydev
 
     ...
-    #include <drivers/pinctrl.h>
+    #include <zephyr/drivers/pinctrl.h>
     ...
 
     struct mydev_config {

--- a/doc/kernel/data_structures/mpsc_pbuf.rst
+++ b/doc/kernel/data_structures/mpsc_pbuf.rst
@@ -90,7 +90,7 @@ User header structure must start with internal header:
 
 .. code-block:: c
 
-   #include <sys/mpsc_packet.h>
+   #include <zephyr/sys/mpsc_packet.h>
 
    struct foo_header {
            MPSC_PBUF_HDR;

--- a/doc/kernel/drivers/index.rst
+++ b/doc/kernel/drivers/index.rst
@@ -194,7 +194,7 @@ A device-specific API definition typically looks like this:
 
 .. code-block:: C
 
-   #include <drivers/subsystem.h>
+   #include <zephyr/drivers/subsystem.h>
 
    /* When extensions need not be invoked from user mode threads */
    int specific_do_that(const struct device *dev, int foo);
@@ -235,7 +235,7 @@ implementation of both the subsystem API and the specific APIs:
 
    #ifdef CONFIG_USERSPACE
 
-   #include <syscall_handler.h>
+   #include <zephyr/syscall_handler.h>
 
    int z_vrfy_specific_from_user(const struct device *dev, int bar)
    {

--- a/doc/kernel/timing_functions/index.rst
+++ b/doc/kernel/timing_functions/index.rst
@@ -51,7 +51,7 @@ This shows an example on how to use the timing functions:
 
 .. code-block:: c
 
-   #include <timing/timing.h>
+   #include <zephyr/timing/timing.h>
 
    void gather_timing(void)
    {

--- a/doc/kernel/usermode/memory_domain.rst
+++ b/doc/kernel/usermode/memory_domain.rst
@@ -237,7 +237,7 @@ BSS.
 
 .. code-block:: c
 
-    #include <app_memory/app_memdomain.h>
+    #include <zephyr/app_memory/app_memdomain.h>
 
     /* Declare a k_mem_partition "my_partition" that is read-write to
      * user mode. Note that we do not specify a base address or size.

--- a/doc/services/debugging/gdbstub.rst
+++ b/doc/services/debugging/gdbstub.rst
@@ -252,7 +252,7 @@ how GDB stub works.
          test () at <ZEPHYR_BASE>/samples/subsys/debug/gdbstub/src/main.c:13
          13     {
          (gdb) list
-         8      #include <sys/printk.h>
+         8      #include <zephyr/sys/printk.h>
          9
          10     #define STACKSIZE 512
          11

--- a/doc/services/logging/index.rst
+++ b/doc/services/logging/index.rst
@@ -225,7 +225,7 @@ if custom log level is not provided.
 
 .. code-block:: c
 
-   #include <logging/log.h>
+   #include <zephyr/logging/log.h>
    LOG_MODULE_REGISTER(foo, CONFIG_FOO_LOG_LEVEL);
 
 If the module consists of multiple files, then ``LOG_MODULE_REGISTER()`` should
@@ -237,7 +237,7 @@ is used if custom log level is not provided.
 
 .. code-block:: c
 
-   #include <logging/log.h>
+   #include <zephyr/logging/log.h>
    /* In all files comprising the module but one */
    LOG_MODULE_DECLARE(foo, CONFIG_FOO_LOG_LEVEL);
 
@@ -250,7 +250,7 @@ provided.
 
 .. code-block:: c
 
-   #include <logging/log.h>
+   #include <zephyr/logging/log.h>
 
    static inline void foo(void)
    {
@@ -286,7 +286,7 @@ In order to use instance level filtering following steps must be performed:
 
 .. code-block:: c
 
-   #include <logging/log_instance.h>
+   #include <zephyr/logging/log_instance.h>
 
    struct foo_object {
    	LOG_INSTANCE_PTR_DECLARE(log);
@@ -345,7 +345,7 @@ Following snippet shows how logging can be processed in simple forever loop.
 
 .. code-block:: c
 
-   #include <log_ctrl.h>
+   #include <zephyr/log_ctrl.h>
 
    void main(void)
    {
@@ -613,7 +613,7 @@ to the pool. It is up to the backend how message is processed.
 
 .. code-block:: c
 
-   #include <log_backend.h>
+   #include <zephyr/logging/log_backend.h>
 
    void put(const struct log_backend *const backend,
    	    struct log_msg *msg)

--- a/doc/services/settings/index.rst
+++ b/doc/services/settings/index.rst
@@ -225,10 +225,10 @@ up from where it was before restart.
 
 .. code-block:: c
 
-    #include <zephyr.h>
-    #include <sys/reboot.h>
-    #include <settings/settings.h>
-    #include <sys/printk.h>
+    #include <zephyr/zephyr.h>
+    #include <zephyr/sys/reboot.h>
+    #include <zephyr/settings/settings.h>
+    #include <zephyr/sys/printk.h>
     #include <inttypes.h>
 
     #define DEFAULT_FOO_VAL_VALUE 0

--- a/doc/services/smf/index.rst
+++ b/doc/services/smf/index.rst
@@ -122,7 +122,7 @@ the initial state is S0.
 
 Code::
 
-	#include <smf.h>
+	#include <zephyr/smf.h>
 
 	/* Forward declaration of state table */
 	static const struct smf_state demo_states[];
@@ -230,7 +230,7 @@ S0 and S1 share a parent state and S0 is the initial state.
 
 Code::
 
-	#include <smf.h>
+	#include <zephyr/smf.h>
 
 	/* Forward declaration of state table */
 	static const struct smf_state demo_states[];

--- a/include/zephyr/arch/arc/arch.h
+++ b/include/zephyr/arch/arc/arch.h
@@ -16,7 +16,7 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARC_ARCH_H_
 #define ZEPHYR_INCLUDE_ARCH_ARC_ARCH_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <sw_isr_table.h>
 #include <arch/common/ffs.h>
 #include <arch/arc/thread.h>

--- a/include/zephyr/arch/arm/aarch32/arch.h
+++ b/include/zephyr/arch/arm/aarch32/arch.h
@@ -17,7 +17,7 @@
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_ARCH_H_
 
 /* Add include for DTS generated information */
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* ARM GPRs are often designated by two different names */
 #define sys_define_gpr_with_alias(name1, name2) union { uint32_t name1, name2; }

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/scripts/linker.ld
@@ -12,7 +12,7 @@
  */
 
 #include <linker/sections.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #include <linker/devicetree_regions.h>
 #include <linker/linker-defs.h>

--- a/include/zephyr/arch/arm/aarch32/cortex_m/nvic.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/nvic.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_M_NVIC_H_
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_CORTEX_M_NVIC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #if defined(CONFIG_ARMV8_1_M_MAINLINE)
 /* The order here is on purpose since ARMv8.1-M SoCs may define

--- a/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld
@@ -12,7 +12,7 @@
  */
 
 #include <linker/sections.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #include <linker/devicetree_regions.h>
 #include <linker/linker-defs.h>

--- a/include/zephyr/arch/arm/aarch32/exc.h
+++ b/include/zephyr/arch/arm/aarch32/exc.h
@@ -16,7 +16,7 @@
 #define ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_EXC_H_
 
 #if defined(CONFIG_CPU_CORTEX_M)
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #include <arch/arm/aarch32/cortex_m/nvic.h>
 

--- a/include/zephyr/arch/arm64/arch.h
+++ b/include/zephyr/arch/arm64/arch.h
@@ -17,7 +17,7 @@
 #define ZEPHYR_INCLUDE_ARCH_ARM64_ARCH_H_
 
 /* Add include for DTS generated information */
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #include <arch/arm64/thread.h>
 #include <arch/arm64/exc.h>

--- a/include/zephyr/arch/arm64/scripts/linker.ld
+++ b/include/zephyr/arch/arm64/scripts/linker.ld
@@ -12,7 +12,7 @@
  */
 
 #include <linker/sections.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #include <linker/linker-defs.h>
 #include <linker/linker-tool.h>

--- a/include/zephyr/arch/mips/arch.h
+++ b/include/zephyr/arch/mips/arch.h
@@ -17,7 +17,7 @@
 
 #include <irq.h>
 #include <sw_isr_table.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <mips/mipsregs.h>
 
 #define ARCH_STACK_PTR_ALIGN 16

--- a/include/zephyr/arch/nios2/arch.h
+++ b/include/zephyr/arch/nios2/arch.h
@@ -19,7 +19,7 @@
 #include <arch/nios2/thread.h>
 #include <arch/nios2/asm_inline.h>
 #include <arch/common/addr_types.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <arch/nios2/nios2.h>
 #include <arch/common/sys_bitops.h>
 #include <sys/sys_io.h>

--- a/include/zephyr/arch/posix/arch.h
+++ b/include/zephyr/arch/posix/arch.h
@@ -18,7 +18,7 @@
 #define ZEPHYR_INCLUDE_ARCH_POSIX_ARCH_H_
 
 /* Add include for DTS generated information */
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #include <toolchain.h>
 #include <irq.h>

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -26,7 +26,7 @@
 #include <irq.h>
 #include <sw_isr_table.h>
 #include <soc.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <arch/riscv/csr.h>
 
 /* stacks, for RISCV architecture stack should be 16byte-aligned */

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -12,7 +12,7 @@
  */
 
 #include <soc.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #include <linker/sections.h>
 #include <linker/devicetree_regions.h>

--- a/include/zephyr/arch/sparc/arch.h
+++ b/include/zephyr/arch/sparc/arch.h
@@ -23,7 +23,7 @@
 #include <irq.h>
 #include <sw_isr_table.h>
 #include <soc.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* stacks, for SPARC architecture stack shall be 8byte-aligned */
 #define ARCH_STACK_PTR_ALIGN 8

--- a/include/zephyr/arch/x86/arch.h
+++ b/include/zephyr/arch/x86/arch.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_INCLUDE_ARCH_X86_ARCH_H_
 #define ZEPHYR_INCLUDE_ARCH_X86_ARCH_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* Changing this value will require manual changes to exception and IDT setup
  * in locore.S for intel64

--- a/include/zephyr/arch/x86/memory.ld
+++ b/include/zephyr/arch/x86/memory.ld
@@ -27,7 +27,7 @@
 #ifndef ARCH_X86_MEMORY_LD
 #define ARCH_X86_MEMORY_LD
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <sys/mem_manage.h>
 
 /* Bounds of physical RAM from DTS */

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -15,7 +15,7 @@
 
 #include <irq.h>
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #if !defined(_ASMLANGUAGE) && !defined(__ASSEMBLER__)
 #include <zephyr/types.h>
 #include <toolchain.h>

--- a/include/zephyr/audio/dmic.h
+++ b/include/zephyr/audio/dmic.h
@@ -33,7 +33,7 @@
  */
 
 #include <kernel.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/bluetooth/mesh/msg.h
+++ b/include/zephyr/bluetooth/mesh/msg.h
@@ -17,7 +17,7 @@
  * @{
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <net/buf.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/crypto/cipher.h
+++ b/include/zephyr/crypto/cipher.h
@@ -17,7 +17,7 @@
 #ifndef ZEPHYR_INCLUDE_CRYPTO_CIPHER_H_
 #define ZEPHYR_INCLUDE_CRYPTO_CIPHER_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/util.h>
 /**
  * @addtogroup crypto_cipher

--- a/include/zephyr/crypto/crypto.h
+++ b/include/zephyr/crypto/crypto.h
@@ -17,7 +17,7 @@
 #ifndef ZEPHYR_INCLUDE_CRYPTO_H_
 #define ZEPHYR_INCLUDE_CRYPTO_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
 #include <sys/util.h>
 #include <sys/__assert.h>

--- a/include/zephyr/display/cfb.h
+++ b/include/zephyr/display/cfb.h
@@ -12,7 +12,7 @@
 #ifndef __CFB_H__
 #define __CFB_H__
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/display.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -13,7 +13,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <dt-bindings/adc/adc.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/adc/lmp90xxx.h
+++ b/include/zephyr/drivers/adc/lmp90xxx.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ADC_LMP90XXX_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ADC_LMP90XXX_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/gpio.h>
 
 /* LMP90xxx supports GPIO D0..D6 */

--- a/include/zephyr/drivers/bbram.h
+++ b/include/zephyr/drivers/bbram.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_BBRAM_H
 #define ZEPHYR_INCLUDE_DRIVERS_BBRAM_H
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/bluetooth/hci_driver.h
+++ b/include/zephyr/drivers/bluetooth/hci_driver.h
@@ -21,7 +21,7 @@
 #include <net/buf.h>
 #include <bluetooth/buf.h>
 #include <bluetooth/hci_vs.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/cache.h
+++ b/include/zephyr/drivers/cache.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CACHE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CACHE_H_
 
-#include <cache.h>
+#include <zephyr/cache.h>
 
 /**
  * @brief Enable d-cache

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -9,7 +9,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CAN_H_
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <string.h>
 #include <sys/util.h>
 

--- a/include/zephyr/drivers/can/transceiver.h
+++ b/include/zephyr/drivers/can/transceiver.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CAN_TRANSCEIVER_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -23,7 +23,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/__assert.h>
 #include <sys/slist.h>
 

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CLOCK_CONTROL_NRF_CLOCK_CONTROL_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <hal/nrf_clock.h>
 #include <sys/onoff.h>
 #include <drivers/clock_control.h>

--- a/include/zephyr/drivers/console/ipm_console.h
+++ b/include/zephyr/drivers/console/ipm_console.h
@@ -10,7 +10,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_CONSOLE_IPM_CONSOLE_H_
 
 #include <kernel.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/ring_buffer.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/console/uart_mux.h
+++ b/include/zephyr/drivers/console/uart_mux.h
@@ -19,7 +19,7 @@
  * @{
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/uart.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/counter.h
+++ b/include/zephyr/drivers/counter.h
@@ -22,7 +22,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <stdbool.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/dac.h
+++ b/include/zephyr/drivers/dac.h
@@ -12,7 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_DAC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_DAC_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -25,7 +25,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/display.h
+++ b/include/zephyr/drivers/display.h
@@ -19,7 +19,7 @@
  * @{
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <stddef.h>
 #include <zephyr/types.h>
 

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -14,7 +14,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_DMA_H_
 
 #include <kernel.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/ec_host_cmd_periph.h
+++ b/include/zephyr/drivers/ec_host_cmd_periph.h
@@ -14,7 +14,7 @@
 
 #include <sys/__assert.h>
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/eeprom.h
+++ b/include/zephyr/drivers/eeprom.h
@@ -26,7 +26,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/entropy.h
+++ b/include/zephyr/drivers/entropy.h
@@ -21,7 +21,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/espi.h
+++ b/include/zephyr/drivers/espi.h
@@ -14,7 +14,7 @@
 
 #include <sys/__assert.h>
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -14,7 +14,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/espi.h>
 #include <drivers/emul.h>
 

--- a/include/zephyr/drivers/espi_saf.h
+++ b/include/zephyr/drivers/espi_saf.h
@@ -14,7 +14,7 @@
 
 #include <sys/__assert.h>
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/flash.h
+++ b/include/zephyr/drivers/flash.h
@@ -23,7 +23,7 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <sys/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/fpga.h
+++ b/include/zephyr/drivers/fpga.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/types.h>
 #include <sys/util.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -20,7 +20,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <dt-bindings/gpio/gpio.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/gpio/gpio_esp32.h
+++ b/include/zephyr/drivers/gpio/gpio_esp32.h
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_ESP32_H_
 #define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_ESP32_H_

--- a/include/zephyr/drivers/gpio/gpio_mmio32.h
+++ b/include/zephyr/drivers/gpio/gpio_mmio32.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_MMIO32_H_
 #define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_MMIO32_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/gpio.h>
 #include <zephyr/types.h>
 

--- a/include/zephyr/drivers/gpio/gpio_sx1509b.h
+++ b/include/zephyr/drivers/gpio/gpio_sx1509b.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_SX1509B_H_
 #define ZEPHYR_INCLUDE_DRIVERS_GPIO_GPIO_SX1509B_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/gpio.h>
 
 /**

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -20,7 +20,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -21,7 +21,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/emul.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/i2s.h
+++ b/include/zephyr/drivers/i2s.h
@@ -24,7 +24,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/ieee802154/cc1200.h
+++ b/include/zephyr/drivers/ieee802154/cc1200.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_IEEE802154_CC1200_H_
 #define ZEPHYR_INCLUDE_DRIVERS_IEEE802154_CC1200_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 /* RF settings
  *

--- a/include/zephyr/drivers/interrupt_controller/gic.h
+++ b/include/zephyr/drivers/interrupt_controller/gic.h
@@ -266,7 +266,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 /*
  * GIC Driver Interface Functions

--- a/include/zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h
+++ b/include/zephyr/drivers/interrupt_controller/intc_mchp_xec_ecia.h
@@ -17,7 +17,7 @@
 #ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_MCHP_XEC_ECIA_H_
 #define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_MCHP_XEC_ECIA_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <irq.h>
 
 /**

--- a/include/zephyr/drivers/interrupt_controller/wuc_ite_it8xxx2.h
+++ b/include/zephyr/drivers/interrupt_controller/wuc_ite_it8xxx2.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_IT8XXX2_WUC_H_
 #define ZEPHYR_DRIVERS_INTERRUPT_CONTROLLER_IT8XXX2_WUC_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <stdint.h>
 
 /**

--- a/include/zephyr/drivers/ipm.h
+++ b/include/zephyr/drivers/ipm.h
@@ -21,7 +21,7 @@
  */
 
 #include <kernel.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/kscan.h
+++ b/include/zephyr/drivers/kscan.h
@@ -18,7 +18,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/led.h
+++ b/include/zephyr/drivers/led.h
@@ -20,7 +20,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/led_strip.h
+++ b/include/zephyr/drivers/led_strip.h
@@ -23,7 +23,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -16,7 +16,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/mbox.h
+++ b/include/zephyr/drivers/mbox.h
@@ -67,7 +67,7 @@
  */
 
 #include <kernel.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <devicetree/mbox.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/mdio.h
+++ b/include/zephyr/drivers/mdio.h
@@ -19,7 +19,7 @@
  * @{
  */
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/misc/grove_lcd/grove_lcd.h
+++ b/include/zephyr/drivers/misc/grove_lcd/grove_lcd.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/pcie/controller.h
+++ b/include/zephyr/drivers/pcie/controller.h
@@ -13,7 +13,7 @@
 #define ZEPHYR_INCLUDE_DRIVERS_PCIE_CONTROLLERS_H_
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef CONFIG_PCIE_MSI
 #include <drivers/pcie/msi.h>

--- a/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
+++ b/include/zephyr/drivers/pcie/endpoint/pcie_ep.h
@@ -13,7 +13,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PCIE_EP_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PCIE_EP_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <init.h>
 #include <kernel.h>
 #include <stdint.h>

--- a/include/zephyr/drivers/peci.h
+++ b/include/zephyr/drivers/peci.h
@@ -22,7 +22,7 @@
 #include <errno.h>
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <dt-bindings/pwm/pwm.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -18,7 +18,7 @@
  * @{
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <devicetree.h>
 #include <devicetree/pinctrl.h>
 #include <pinctrl_soc.h>

--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -19,7 +19,7 @@
  */
 
 #include <zephyr/device.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <devicetree/pinctrl.h>
 #include <pinctrl_soc.h>
 #include <sys/util.h>

--- a/include/zephyr/drivers/pinctrl/pinctrl_soc_gd32_common.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_soc_gd32_common.h
@@ -12,7 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PINCTRL_PINCTRL_SOC_GD32_COMMON_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PINCTRL_PINCTRL_SOC_GD32_COMMON_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
 #ifdef CONFIG_PINCTRL_GD32_AF

--- a/include/zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h
@@ -12,7 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_PINCTRL_PINCTRL_SOC_SAM_COMMON_H_
 #define ZEPHYR_INCLUDE_DRIVERS_PINCTRL_PINCTRL_SOC_SAM_COMMON_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 #include <dt-bindings/pinctrl/atmel_sam_pinctrl.h>
 

--- a/include/zephyr/drivers/pinmux.h
+++ b/include/zephyr/drivers/pinmux.h
@@ -20,7 +20,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/pm_cpu_ops.h
+++ b/include/zephyr/drivers/pm_cpu_ops.h
@@ -14,7 +14,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/pm_cpu_ops/psci.h
+++ b/include/zephyr/drivers/pm_cpu_ops/psci.h
@@ -10,7 +10,7 @@
 #include <zephyr/types.h>
 #include <arch/arm64/arm-smccc.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/ps2.h
+++ b/include/zephyr/drivers/ps2.h
@@ -16,7 +16,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/ptp_clock.h
+++ b/include/zephyr/drivers/ptp_clock.h
@@ -9,7 +9,7 @@
 
 #include <kernel.h>
 #include <stdint.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/util.h>
 #include <net/ptp_time.h>
 

--- a/include/zephyr/drivers/pwm.h
+++ b/include/zephyr/drivers/pwm.h
@@ -23,7 +23,7 @@
 #include <errno.h>
 #include <stdint.h>
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/math_extras.h>
 #include <toolchain.h>
 

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -20,7 +20,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/rtc/mcux_snvs_rtc.h
+++ b/include/zephyr/drivers/rtc/mcux_snvs_rtc.h
@@ -21,7 +21,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_RTC_MCUX_SNVS_H_
 #define ZEPHYR_INCLUDE_DRIVERS_RTC_MCUX_SNVS_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -20,7 +20,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/drivers/sensor/ccs811.h
+++ b/include/zephyr/drivers/sensor/ccs811.h
@@ -19,7 +19,7 @@
 extern "C" {
 #endif
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/sensor.h>
 
 /* Status register fields */

--- a/include/zephyr/drivers/sensor/tmp116.h
+++ b/include/zephyr/drivers/sensor/tmp116.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP116_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SENSOR_TMP116_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/types.h>
 
 #define EEPROM_TMP116_SIZE (4 * sizeof(uint16_t))

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -21,7 +21,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <dt-bindings/spi/spi.h>
 #include <drivers/gpio.h>
 

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -14,7 +14,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/emul.h>
 
 /**

--- a/include/zephyr/drivers/syscon.h
+++ b/include/zephyr/drivers/syscon.h
@@ -20,7 +20,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -23,7 +23,7 @@
 #include <errno.h>
 #include <stddef.h>
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/uart/cdc_acm.h
+++ b/include/zephyr/drivers/uart/cdc_acm.h
@@ -14,7 +14,7 @@
 
 #include <errno.h>
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/usb/usb_dc.h
+++ b/include/zephyr/drivers/usb/usb_dc.h
@@ -17,7 +17,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_USB_USB_DC_H_
 #define ZEPHYR_INCLUDE_DRIVERS_USB_USB_DC_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 /**
  * USB endpoint direction and number.

--- a/include/zephyr/drivers/usbc/usbc_tcpc.h
+++ b/include/zephyr/drivers/usbc/usbc_tcpc.h
@@ -23,7 +23,7 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #include "usbc_tc.h"
 #include "usbc_pd.h"

--- a/include/zephyr/drivers/video-controls.h
+++ b/include/zephyr/drivers/video-controls.h
@@ -19,7 +19,7 @@
  * @{
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <stddef.h>
 #include <zephyr/zephyr.h>
 

--- a/include/zephyr/drivers/video-controls.h
+++ b/include/zephyr/drivers/video-controls.h
@@ -21,7 +21,7 @@
 
 #include <device.h>
 #include <stddef.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include <zephyr/types.h>
 

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -19,7 +19,7 @@
  * @{
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <stddef.h>
 #include <zephyr/zephyr.h>
 

--- a/include/zephyr/drivers/video.h
+++ b/include/zephyr/drivers/video.h
@@ -21,7 +21,7 @@
 
 #include <device.h>
 #include <stddef.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include <zephyr/types.h>
 

--- a/include/zephyr/drivers/virtualization/ivshmem.h
+++ b/include/zephyr/drivers/virtualization/ivshmem.h
@@ -15,7 +15,7 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/drivers/watchdog.h
+++ b/include/zephyr/drivers/watchdog.h
@@ -22,7 +22,7 @@
 
 #include <zephyr/types.h>
 #include <sys/util.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/fs/nvs.h
+++ b/include/zephyr/fs/nvs.h
@@ -9,7 +9,7 @@
 
 #include <sys/types.h>
 #include <kernel.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <toolchain.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_IPC_IPC_SERVICE_H_
 
 #include <stdio.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/linker/devicetree_reserved.h
+++ b/include/zephyr/linker/devicetree_reserved.h
@@ -6,7 +6,7 @@
  * Generate memory regions and sections from reserved-memory nodes.
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* Reserved memory node */
 #define _NODE_RESERVED DT_INST(0, reserved_memory)

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -34,7 +34,7 @@
 #define DT_NODE_HAS_STATUS(node, status) 0
 #else
 #include <linker/devicetree_reserved.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #endif
 
 #ifdef _LINKER

--- a/include/zephyr/lorawan/lorawan.h
+++ b/include/zephyr/lorawan/lorawan.h
@@ -15,7 +15,7 @@
  * @{
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/slist.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/mgmt/osdp.h
+++ b/include/zephyr/mgmt/osdp.h
@@ -7,7 +7,7 @@
 #ifndef _OSDP_H_
 #define _OSDP_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdint.h>
 
 #include <sys/slist.h>

--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -13,7 +13,7 @@
 #include <stddef.h>
 #include <zephyr/types.h>
 #include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/net/capture.h
+++ b/include/zephyr/net/capture.h
@@ -13,7 +13,7 @@
 #ifndef ZEPHYR_INCLUDE_NET_CAPTURE_H_
 #define ZEPHYR_INCLUDE_NET_CAPTURE_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/net/dsa.h
+++ b/include/zephyr/net/dsa.h
@@ -11,7 +11,7 @@
 #ifndef ZEPHYR_INCLUDE_NET_DSA_H_
 #define ZEPHYR_INCLUDE_NET_DSA_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <net/net_if.h>
 
 /**

--- a/include/zephyr/net/ieee802154_radio.h
+++ b/include/zephyr/net/ieee802154_radio.h
@@ -12,7 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_NET_IEEE802154_RADIO_H_
 #define ZEPHYR_INCLUDE_NET_IEEE802154_RADIO_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <net/net_if.h>
 #include <net/net_pkt.h>
 #include <net/ieee802154.h>

--- a/include/zephyr/net/mqtt.h
+++ b/include/zephyr/net/mqtt.h
@@ -24,7 +24,7 @@
 
 #include <stddef.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <zephyr/types.h>
 #include <net/tls_credentials.h>
 #include <net/net_ip.h>

--- a/include/zephyr/net/net_config.h
+++ b/include/zephyr/net/net_config.h
@@ -12,7 +12,7 @@
 #define ZEPHYR_INCLUDE_NET_NET_CONFIG_H_
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <net/net_if.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -19,7 +19,7 @@
  * @{
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <sys/slist.h>
 
 #include <net/net_core.h>

--- a/include/zephyr/net/net_l2.h
+++ b/include/zephyr/net/net_l2.h
@@ -12,7 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_NET_NET_L2_H_
 #define ZEPHYR_INCLUDE_NET_NET_L2_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <net/buf.h>
 #include <net/capture.h>
 

--- a/include/zephyr/net/phy.h
+++ b/include/zephyr/net/phy.h
@@ -19,7 +19,7 @@
  * @{
  */
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/net/tftp.h
+++ b/include/zephyr/net/tftp.h
@@ -12,7 +12,7 @@
 #ifndef ZEPHYR_INCLUDE_NET_TFTP_H_
 #define ZEPHYR_INCLUDE_NET_TFTP_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <net/socket.h>
 
 #ifdef __cplusplus

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_PM_DEVICE_H_
 #define ZEPHYR_INCLUDE_PM_DEVICE_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <kernel.h>
 #include <sys/atomic.h>
 

--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -8,7 +8,7 @@
 #ifndef ZEPHYR_INCLUDE_PM_DEVICE_RUNTIME_H_
 #define ZEPHYR_INCLUDE_PM_DEVICE_RUNTIME_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/pm/state.h
+++ b/include/zephyr/pm/state.h
@@ -8,7 +8,7 @@
 #define ZEPHYR_INCLUDE_PM_STATE_H_
 
 #include <sys/util.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/sys/eventfd.h
+++ b/include/zephyr/posix/sys/eventfd.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_POSIX_SYS_EVENTFD_H_
 #define ZEPHYR_INCLUDE_POSIX_SYS_EVENTFD_H_
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <sys/fdtable.h>
 #include <sys/types.h>
 

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -7,7 +7,7 @@
 #ifndef SHELL_H__
 #define SHELL_H__
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <shell/shell_types.h>
 #include <shell/shell_history.h>
 #include <shell/shell_fprintf.h>

--- a/include/zephyr/shell/shell_fprintf.h
+++ b/include/zephyr/shell/shell_fprintf.h
@@ -7,7 +7,7 @@
 #ifndef SHELL_FPRINTF_H__
 #define SHELL_FPRINTF_H__
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdbool.h>
 #include <stddef.h>
 

--- a/include/zephyr/shell/shell_history.h
+++ b/include/zephyr/shell/shell_history.h
@@ -7,7 +7,7 @@
 #ifndef SHELL_HISTORY_H__
 #define SHELL_HISTORY_H__
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <sys/util.h>
 #include <sys/dlist.h>
 #include <sys/ring_buffer.h>

--- a/include/zephyr/shell/shell_log_backend.h
+++ b/include/zephyr/shell/shell_log_backend.h
@@ -7,7 +7,7 @@
 #ifndef SHELL_LOG_BACKEND_H__
 #define SHELL_LOG_BACKEND_H__
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <logging/log_backend.h>
 #include <logging/log_output.h>
 #include <sys/mpsc_pbuf.h>

--- a/include/zephyr/shell/shell_mqtt.h
+++ b/include/zephyr/shell/shell_mqtt.h
@@ -7,7 +7,7 @@
 #ifndef SHELL_MQTT_H__
 #define SHELL_MQTT_H__
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <shell/shell.h>
 #include <net/socket.h>
 #include <net/net_mgmt.h>

--- a/include/zephyr/smf.h
+++ b/include/zephyr/smf.h
@@ -56,7 +56,7 @@
 extern "C" {
 #endif
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /**
  * @brief Function pointer that implements a portion of a state

--- a/include/zephyr/task_wdt/task_wdt.h
+++ b/include/zephyr/task_wdt/task_wdt.h
@@ -19,7 +19,7 @@
 
 #include <zephyr/types.h>
 #include <kernel.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 /**
  * @brief Task Watchdog APIs

--- a/include/zephyr/usb/class/usb_audio.h
+++ b/include/zephyr/usb/class/usb_audio.h
@@ -22,7 +22,7 @@
 #define ZEPHYR_INCLUDE_USB_CLASS_AUDIO_H_
 
 #include <usb/usb_ch9.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <net/buf.h>
 #include <sys/util.h>
 

--- a/include/zephyr/xen/console.h
+++ b/include/zephyr/xen/console.h
@@ -7,7 +7,7 @@
 #define __XEN_CONSOLE_H__
 
 #include <init.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <drivers/uart.h>
 #include <sys/device_mmio.h>
 


### PR DESCRIPTION
Add some more uses of zephyr/ include paths in both code and documentation.

Issue #41543