### PR TITLE
arch/xtensa: adsp:  Rename module_init section

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/cavs-link.ld
+++ b/soc/xtensa/intel_adsp/common/include/cavs-link.ld
@@ -307,7 +307,7 @@ SECTIONS {
 
   .module_init : {
     _module_init_start = .;
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = .;
   } >ram
 

--- a/soc/xtensa/nxp_adsp/imx8/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8/linker.ld
@@ -339,7 +339,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sdram0 :sdram0_phdr
 

--- a/soc/xtensa/nxp_adsp/imx8m/linker.ld
+++ b/soc/xtensa/nxp_adsp/imx8m/linker.ld
@@ -339,7 +339,7 @@ SECTIONS
   .module_init : ALIGN(4)
   {
    _module_init_start = ABSOLUTE(.);
-    *(*.module_init)
+    *(*.initcall)
     _module_init_end = ABSOLUTE(.);
   } >sdram0 :sdram0_phdr
 


### PR DESCRIPTION
.module_init sections is used to keep all components constructor
functions.

Zephyr uses -ffunction-sections option which will create a section for
each function. Unfortunately, this creates a section named .module_init
for the function module_init() used to initialize the processing module
generic layer.

Thus, places module_init() in the constructor area named .module_init
which is wrong.

To avoid this we rename .module_init section for constructors to
.initcall.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>