### PR TITLE
drivers: pwm: nrf: Update handling of `pwm` parameter and definitions of `pwm-cells`, add support for `PWM_POLARITY_INVERTED` flag

### DIFF
--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -38,17 +38,17 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: led_pwm_0 {
-			pwms = <&pwm0 10>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Red PWM LED";
 		};
 
 		green_pwm_led: led_pwm_1 {
-			pwms = <&pwm0 11>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Green PWM LED";
 		};
 
 		blue_pwm_led: led_pwm_2 {
-			pwms = <&pwm0 12>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Blue PWM LED";
 		};
 	};

--- a/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
+++ b/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
@@ -38,17 +38,17 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: led_pwm_0 {
-			pwms = <&pwm0 21>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Red PWM LED";
 		};
 
 		green_pwm_led: led_pwm_1 {
-			pwms = <&pwm0 22>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Green PWM LED";
 		};
 
 		blue_pwm_led: led_pwm_2 {
-			pwms = <&pwm0 25>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Blue PWM LED";
 		};
 	};

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
@@ -45,19 +45,19 @@
 		compatible = "pwm-leds";
 
 		red_pwm_led: led_pwm_0 {
-			pwms = <&pwm0 24>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Red PWM LED";
 		};
 		green_pwm_led: led_pwm_1 {
-			pwms = <&pwm0 16>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Green PWM LED";
 		};
 		blue_pwm_led: led_pwm_2 {
-			pwms = <&pwm0 6>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Blue PWM LED";
 		};
 		user_pwm_led: led_pwm_4 {
-			pwms = <&pwm1 41>;
+			pwms = <&pwm1 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "User PWM LED";
 		};
 	};
@@ -68,7 +68,7 @@
 		status = "disabled";
 
 		yellow_pwm_led: led_pwm_3 {
-			pwms = <&pwm2 13>;
+			pwms = <&pwm2 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Yellow PWM LED";
 		};
 	};

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -69,6 +69,33 @@
 		timer = <&timer2>;
 		pixel-group-size = <3>;
 	};
+
+	edge_connector: connector {
+		compatible = "microbit,edge-connector";
+		#gpio-cells = <2>;
+		gpio-map-mask = <0xffffffff 0xffffffc0>;
+		gpio-map-pass-thru = <0 0x3f>;
+		gpio-map = <0 0 &gpio0 3 0>,	/* P0, Analog in */
+			   <1 0 &gpio0 2 0>,	/* P1, Analog in */
+			   <2 0 &gpio0 1 0>,	/* P2, Analog in */
+			   <3 0 &gpio0 4 0>,	/* P3, Analog in, LED Col 1 */
+			   <4 0 &gpio0 5 0>,	/* P4, Analog in, LED Col 2 */
+			   <5 0 &gpio0 17 0>,	/* P5, Button A */
+			   <6 0 &gpio0 12 0>,	/* P6, LED Col 9 */
+			   <7 0 &gpio0 11 0>,	/* P7, LED Col 8 */
+			   <8 0 &gpio0 18 0>,	/* P8 */
+			   <9 0 &gpio0 10 0>,	/* P9, LED Col 7 */
+			   <10 0 &gpio0 6 0>,	/* P10, Analog in, LED Col 3 */
+			   <11 0 &gpio0 26 0>,	/* P11, Button B */
+			   <12 0 &gpio0 20 0>,	/* P12 */
+			   <13 0 &gpio0 23 0>,	/* P13, SPI1 SCK */
+			   <14 0 &gpio0 22 0>,	/* P14, SPI1 MISO */
+			   <15 0 &gpio0 21 0>,	/* P15, SPI1 MOSI */
+			   <16 0 &gpio0 16 0>,	/* P16 */
+			   /* 17 and 18 are just 3.3V pins */
+			   <19 0 &gpio0 0 0>,	/* P19, I2C1 SCL */
+			   <20 0 &gpio0 30 0>;	/* P20, I2C1 SDA */
+	};
 };
 
 &gpiote {
@@ -82,10 +109,6 @@
 	 * are needed for the LED matrix and the SW PWM.
 	 */
 	sense-edge-mask = <0xffffffff>;
-};
-
-&sw_pwm {
-	channel-count = <1>;
 };
 
 &uart0 {

--- a/boards/arm/bl654_usb/bl654_usb.dts
+++ b/boards/arm/bl654_usb/bl654_usb.dts
@@ -32,7 +32,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		led1bluepwm: led_pwm_1 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "PWM LED 1 Blue";
 		};
 

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -39,12 +39,12 @@
 		compatible = "pwm-leds";
 
 		led1pwm: led_1_pwm {
-			pwms = <&pwm0 39>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Red PWM LED 1";
 		};
 
 		led2pwm: led_2_pwm {
-			pwms = <&pwm1 35>;
+			pwms = <&pwm1 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Green PWM LED 2";
 		};
 	};

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -27,7 +27,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 3>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0_red: pwm_led_0 {
-			pwms = <&pwm0 22>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Red PWM LED";
 		};
 	};

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -47,7 +47,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&sw_pwm 21>;
+			pwms = <&sw_pwm 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 
@@ -83,6 +83,12 @@
 		sw3 = &button3;
 		bootloader-led0 = &led0;
 	};
+};
+
+&sw_pwm {
+	status ="okay";
+	channel-gpios = <&gpio0 21 0>;
+	clock-prescaler = <8>;
 };
 
 &gpiote {

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -42,7 +42,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&sw_pwm 21>;
+			pwms = <&sw_pwm 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 
@@ -53,6 +53,12 @@
 		led2 = &led0_blue;
 		pwm-led0 = &pwm_led0;
 	};
+};
+
+&sw_pwm {
+	status ="okay";
+	channel-gpios = <&gpio0 21 0>;
+	clock-prescaler = <8>;
 };
 
 &gpiote {

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -43,15 +43,15 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0_green: pwm_led_0 {
-			pwms = <&pwm0 22>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Green PWM LED 0";
 		};
 		pwm_led1_red: pwm_led_1 {
-			pwms = <&pwm0 23>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Red PWM LED 1";
 		};
 		pwm_led2_blue: pwm_led_2 {
-			pwms = <&pwm0 24>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Blue PWM LED 1";
 		};
 	};

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&sw_pwm 13>;
+			pwms = <&sw_pwm 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -42,15 +42,15 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0_green: pwm_led_0 {
-			pwms = <&pwm0 22>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Green PWM LED 0";
 		};
 		pwm_led1_red: pwm_led_1 {
-			pwms = <&pwm0 23>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Red PWM LED 1";
 		};
 		pwm_led2_blue: pwm_led_2 {
-			pwms = <&pwm0 24>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Blue PWM LED 2";
 		};
 	};

--- a/boards/arm/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
+++ b/boards/arm/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
@@ -44,13 +44,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: pwm_led_0 {
-			pwms = <&pwm0 23>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: pwm_led_1 {
-			pwms = <&pwm0 22>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: pwm_led_2 {
-			pwms = <&pwm0 24>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -41,15 +41,15 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Green PWM LED 0";
 		};
 		pwm_led1: pwm_led_1 {
-			pwms = <&pwm0 15>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Blue PWM LED 1";
 		};
 		pwm_led2: pwm_led_2 {
-			pwms = <&pwm0 14>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "Red PWM LED 2";
 		};
 	};

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -47,13 +47,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: pwm_led_0 {
-			pwms = <&pwm0 8>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: pwm_led_1 {
-			pwms = <&pwm0 41>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: pwm_led_2 {
-			pwms = <&pwm0 12>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather-pinctrl.dtsi
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather-pinctrl.dtsi
@@ -36,14 +36,15 @@
 
 	pwm0_default: pwm0_default {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 17)>;
-			nordic,invert;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 17)>,
+				<NRF_PSEL(PWM_OUT1, 0, 19)>;
 		};
 	};
 
 	pwm0_sleep: pwm0_sleep {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT0, 0, 17)>;
+			psels = <NRF_PSEL(PWM_OUT0, 0, 17)>,
+				<NRF_PSEL(PWM_OUT1, 0, 19)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -51,10 +51,10 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: pwm_led_0 {
-			pwms = <&pwm0 17>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 		blue_pwm_led: pwm_led_1 {
-			pwms = <&pwm0 19>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -47,7 +47,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 17>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -38,7 +38,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 28>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -38,7 +38,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 2>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -26,13 +26,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: pwm_led_0 {
-			pwms = <&pwm0 11>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: pwm_led_1 {
-			pwms = <&pwm0 12>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: pwm_led_2 {
-			pwms = <&pwm0 41>;
+			pwms = <&pwm0 3 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -37,7 +37,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		back_pwm_led: pwm_led_3 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common-pinctrl.dtsi
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common-pinctrl.dtsi
@@ -67,6 +67,7 @@
 	pwm0_default: pwm0_default {
 		group1 {
 			psels = <NRF_PSEL(PWM_OUT0, 0, 3)>;
+			nordic,invert;
 		};
 	};
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
@@ -27,7 +27,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 3>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -45,17 +45,17 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_led_pwm: led_pwm_0 {
-			pwms = <&pwm0 40>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Red PWM LED";
 		};
 
 		green_led_pwm: led_pwm_1 {
-			pwms = <&pwm0 38>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Green PWM LED";
 		};
 
 		blue_led_pwm: led_pwm_2 {
-			pwms = <&pwm0 39>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Blue PWM LED";
 		};
 	};

--- a/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
+++ b/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 17>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
+++ b/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 17>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -47,7 +47,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -48,7 +48,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
+++ b/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
@@ -46,7 +46,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 17>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -48,7 +48,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/ubx_evkannab1_nrf52832/ubx_evkannab1_nrf52832.dts
+++ b/boards/arm/ubx_evkannab1_nrf52832/ubx_evkannab1_nrf52832.dts
@@ -45,13 +45,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm0 27>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm0 25>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&pwm0 26>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 
@@ -167,8 +167,6 @@ arduino_i2c: &i2c0 {
 };
 
 &pwm0 {
-	status = "okay";
-	status = "okay";
 	status = "okay";
 	pinctrl-0 = <&pwm0_default>;
 	pinctrl-1 = <&pwm0_sleep>;

--- a/boards/arm/ubx_evkninab1_nrf52832/ubx_evkninab1_nrf52832.dts
+++ b/boards/arm/ubx_evkninab1_nrf52832/ubx_evkninab1_nrf52832.dts
@@ -45,13 +45,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm0 8>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm0 16>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&pwm0 18>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 
@@ -167,8 +167,6 @@ arduino_i2c: &i2c0 {
 };
 
 &pwm0 {
-	status = "okay";
-	status = "okay";
 	status = "okay";
 	pinctrl-0 = <&pwm0_default>;
 	pinctrl-1 = <&pwm0_sleep>;

--- a/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
+++ b/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
@@ -42,13 +42,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm0 25>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&pwm0 32>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 

--- a/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
+++ b/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
@@ -45,13 +45,13 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: red_pwm_led {
-			pwms = <&pwm0 13>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		green_pwm_led: green_pwm_led {
-			pwms = <&pwm0 33>;
+			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&pwm0 32>;
+			pwms = <&pwm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
 	};
 
@@ -185,8 +185,6 @@ arduino_spi: &spi2 {
 };
 
 &pwm0 {
-	status = "okay";
-	status = "okay";
 	status = "okay";
 	pinctrl-0 = <&pwm0_default>;
 	pinctrl-1 = <&pwm0_sleep>;

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -327,7 +327,7 @@
 		label = "SW_PWM";
 		generator = <&timer1>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -323,10 +323,9 @@
 
 	sw_pwm: sw-pwm {
 		compatible = "nordic,nrf-sw-pwm";
-		status = "okay";
+		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer1>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -315,7 +315,7 @@
 		label = "SW_PWM";
 		generator = <&timer2>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -314,7 +314,6 @@
 		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer2>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -335,7 +335,6 @@
 		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer2>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -284,7 +284,7 @@
 			interrupts = <28 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_0";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pdm0: pdm@4001d000 {
@@ -336,7 +336,7 @@
 		label = "SW_PWM";
 		generator = <&timer2>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -310,7 +310,7 @@
 			interrupts = <28 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_0";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pdm0: pdm@4001d000 {
@@ -365,7 +365,7 @@
 		label = "SW_PWM";
 		generator = <&timer2>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -364,7 +364,6 @@
 		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer2>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -377,7 +377,6 @@
 		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer2>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -378,7 +378,7 @@
 		label = "SW_PWM";
 		generator = <&timer2>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -465,7 +465,6 @@
 		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer2>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -353,7 +353,7 @@
 			interrupts = <28 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_0";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pdm0: pdm@4001d000 {
@@ -399,7 +399,7 @@
 			interrupts = <33 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_1";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@40022000 {
@@ -408,7 +408,7 @@
 			interrupts = <34 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_2";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		spi2: spi@40023000 {
@@ -466,7 +466,7 @@
 		label = "SW_PWM";
 		generator = <&timer2>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -527,7 +527,6 @@
 		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer2>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -355,7 +355,7 @@
 			interrupts = <28 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_0";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pdm0: pdm@4001d000 {
@@ -408,7 +408,7 @@
 			interrupts = <33 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_1";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@40022000 {
@@ -417,7 +417,7 @@
 			interrupts = <34 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_2";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		spi2: spi@40023000 {
@@ -485,7 +485,7 @@
 			interrupts = <45 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_3";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		spi3: spi@4002f000 {
@@ -528,7 +528,7 @@
 		label = "SW_PWM";
 		generator = <&timer2>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -548,7 +548,6 @@
 		status = "disabled";
 		label = "SW_PWM";
 		generator = <&timer2>;
-		channel-count = <3>;
 		clock-prescaler = <0>;
 		#pwm-cells = <1>;
 	};

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -350,7 +350,7 @@
 			interrupts = <28 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_0";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pdm0: pdm@4001d000 {
@@ -403,7 +403,7 @@
 			interrupts = <33 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_1";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		pwm2: pwm@40022000 {
@@ -412,7 +412,7 @@
 			interrupts = <34 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_2";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		spi2: spi@40023000 {
@@ -491,7 +491,7 @@
 			interrupts = <45 NRF_DEFAULT_IRQ_PRIORITY>;
 			status = "disabled";
 			label = "PWM_3";
-			#pwm-cells = <1>;
+			#pwm-cells = <3>;
 		};
 
 		spi3: spi@4002f000 {
@@ -549,7 +549,7 @@
 		label = "SW_PWM";
 		generator = <&timer2>;
 		clock-prescaler = <0>;
-		#pwm-cells = <1>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -368,7 +368,7 @@ pwm0: pwm@21000 {
 	interrupts = <33 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_0";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 pwm1: pwm@22000 {
@@ -377,7 +377,7 @@ pwm1: pwm@22000 {
 	interrupts = <34 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_1";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 pwm2: pwm@23000 {
@@ -386,7 +386,7 @@ pwm2: pwm@23000 {
 	interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_2";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 pwm3: pwm@24000 {
@@ -395,7 +395,7 @@ pwm3: pwm@24000 {
 	interrupts = <36 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_3";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 pdm0: pdm@26000 {

--- a/dts/arm/nordic/nrf9160_common.dtsi
+++ b/dts/arm/nordic/nrf9160_common.dtsi
@@ -287,7 +287,7 @@ pwm0: pwm@21000 {
 	interrupts = <33 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_0";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 pwm1: pwm@22000 {
@@ -296,7 +296,7 @@ pwm1: pwm@22000 {
 	interrupts = <34 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_1";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 pwm2: pwm@23000 {
@@ -305,7 +305,7 @@ pwm2: pwm@23000 {
 	interrupts = <35 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_2";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 pwm3: pwm@24000 {
@@ -314,7 +314,7 @@ pwm3: pwm@24000 {
 	interrupts = <36 NRF_DEFAULT_IRQ_PRIORITY>;
 	status = "disabled";
 	label = "PWM_3";
-	#pwm-cells = <1>;
+	#pwm-cells = <3>;
 };
 
 gpio0: gpio@842500 {

--- a/dts/arm/nordic/nrf_common.dtsi
+++ b/dts/arm/nordic/nrf_common.dtsi
@@ -7,6 +7,7 @@
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/pinctrl/nrf-pinctrl.h>
+#include <dt-bindings/pwm/pwm.h>
 
 #include <arm/nordic/override.dtsi>
 /*

--- a/dts/bindings/gpio/microbit,edge-connector.yaml
+++ b/dts/bindings/gpio/microbit,edge-connector.yaml
@@ -20,6 +20,9 @@ description: |
     Only the pins on the front are connected to signals. The back rings are
     connected to the front rings, but the back small strips are unconnected.
 
+    Pin assignments can be found at:
+    https://tech.microbit.org/hardware/edgeconnector/#edge-connector-pins
+
 compatible: "microbit,edge-connector"
 
 include: [gpio-nexus.yaml, base.yaml]

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -107,7 +107,9 @@ properties:
         Set this to invert channel 3.
 
     "#pwm-cells":
-      const: 1
+      const: 3
 
 pwm-cells:
   - channel
+  - period
+  - flags

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -54,7 +54,9 @@ properties:
         in the request, i.e. PWM_POLARITY_INVERTED or PWM_POLARITY_NORMAL.
 
     "#pwm-cells":
-      const: 1
+      const: 3
 
 pwm-cells:
   - channel
+  - period
+  - flags

--- a/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-sw-pwm.yaml
@@ -7,19 +7,13 @@ include: [pwm-controller.yaml, base.yaml]
 properties:
     generator:
       type: phandle
+      required: true
       description: |
         Reference to TIMER or RTC instance for generating PWM output signals
-      required: true
-
-    channel-count:
-      type: int
-      description: |
-        Number of PWM channels. Limited by RTC/TIMER instance compare registers
-        minus 1.
-      required: true
 
     clock-prescaler:
       type: int
+      required: true
       description: |
         Clock prescaler for RTC or TIMER used for generating PWM output signals.
 
@@ -27,7 +21,37 @@ properties:
         generation.
 
         TIMER: 16 MHz / 2^prescaler base clock is used for PWM generation.
+
+    channel-gpios:
+      type: phandle-array
       required: true
+      description: |
+        An array of GPIOs assigned as outputs for the PWM channels. The number
+        of items in this array determines the number of channels that this PWM
+        will provide. This value is limited by the number of compare registers
+        in the used RTC/TIMER instance minus 1.
+
+        Example:
+
+          sw_pwm: sw-pwm {
+            compatible = "nordic,nrf-sw-pwm";
+            ...
+            channel-gpios = <&gpio0 20 GPIO_ACTIVE_HIGH>,
+                            <&gpio1 12 GPIO_ACTIVE_HIGH>;
+            ...
+          };
+
+        The above will assign P0.20 as the output for channel 0 and P1.12 as
+        the output for channel 1. Both outputs will be initially configured as
+        active high.
+
+        Please note that in the flags cell (the last component of each item
+        of the array) only the GPIO flags that specify the active level are
+        taken into account (any others are ignored), and they are used only
+        when the initial (inactive) state of the outputs is set.
+        After any PWM signal generation is requested for a given channel,
+        the polarity of its output is determined by the flag specified
+        in the request, i.e. PWM_POLARITY_INVERTED or PWM_POLARITY_NORMAL.
 
     "#pwm-cells":
       const: 1

--- a/samples/basic/servo_motor/README.rst
+++ b/samples/basic/servo_motor/README.rst
@@ -51,7 +51,7 @@ BBC micro:bit
 =============
 
 You will need to connect the motor's red wire to external 5V, the black wire to
-ground and the white wire to the SCL pin, i.e. pin 21 on the edge connector.
+ground and the white wire to the SCL pin, i.e. pin P19 on the edge connector.
 
 Building and Running
 ********************

--- a/samples/basic/servo_motor/boards/bbc_microbit.overlay
+++ b/samples/basic/servo_motor/boards/bbc_microbit.overlay
@@ -6,5 +6,7 @@
 };
 
 &sw_pwm {
+	status = "okay";
 	clock-prescaler = <3>;
+	channel-gpios = <&edge_connector 19 GPIO_ACTIVE_HIGH>;
 };

--- a/samples/bluetooth/mesh_demo/CMakeLists.txt
+++ b/samples/bluetooth/mesh_demo/CMakeLists.txt
@@ -8,8 +8,6 @@ project(mesh_demo)
 
 target_sources(app PRIVATE src/main.c)
 target_sources_ifdef(CONFIG_BOARD_BBC_MICROBIT app PRIVATE src/microbit.c)
-zephyr_include_directories_ifdef(CONFIG_BOARD_BBC_MICROBIT
-				 ${ZEPHYR_BASE}/boards/arm/bbc_microbit)
 
 if(NODE_ADDR)
   zephyr_compile_definitions(NODE_ADDR=${NODE_ADDR})

--- a/samples/bluetooth/mesh_demo/boards/bbc_microbit.overlay
+++ b/samples/bluetooth/mesh_demo/boards/bbc_microbit.overlay
@@ -1,0 +1,4 @@
+&sw_pwm {
+	status = "okay";
+	channel-gpios = <&edge_connector 0 GPIO_ACTIVE_HIGH>;
+};

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -7,7 +7,6 @@
  */
 
 #include <drivers/gpio.h>
-#include <board.h>
 #include <soc.h>
 #include <sys/printk.h>
 #include <ctype.h>
@@ -22,7 +21,7 @@
 
 #define SCROLL_SPEED   300
 
-#define BUZZER_PIN     EXT_P0_GPIO_PIN
+#define BUZZER_PWM_CHANNEL 0
 #define BEEP_DURATION  K_MSEC(60)
 
 #define SEQ_PER_BIT  976
@@ -130,14 +129,14 @@ void board_play_tune(const char *str)
 		}
 
 		if (period) {
-			pwm_pin_set_usec(pwm, BUZZER_PIN, period, period / 2U,
-					 0);
+			pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL,
+					 period, period / 2U, 0);
 		}
 
 		k_sleep(K_MSEC(duration));
 
 		/* Disable the PWM */
-		pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0, 0);
+		pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
 	}
 }
 

--- a/samples/boards/bbc_microbit/pong/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/pong/CMakeLists.txt
@@ -7,4 +7,3 @@ project(pong)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(${ZEPHYR_BASE}/boards/arm/bbc_microbit)

--- a/samples/boards/bbc_microbit/pong/boards/bbc_microbit.overlay
+++ b/samples/boards/bbc_microbit/pong/boards/bbc_microbit.overlay
@@ -1,0 +1,4 @@
+&sw_pwm {
+	status = "okay";
+	channel-gpios = <&edge_connector 0 GPIO_ACTIVE_HIGH>;
+};

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -6,7 +6,6 @@
 
 #include <zephyr.h>
 #include <sys/printk.h>
-#include <board.h>
 #include <drivers/gpio.h>
 #include <device.h>
 #include <string.h>
@@ -107,7 +106,7 @@ static struct x_y ball_vel = { 0, 0 };
 static int64_t a_timestamp;
 static int64_t b_timestamp;
 
-#define SOUND_PIN            EXT_P0_GPIO_PIN
+#define SOUND_PWM_CHANNEL    0
 #define SOUND_PERIOD_PADDLE  200
 #define SOUND_PERIOD_WALL    1000
 
@@ -121,7 +120,7 @@ static enum sound_state {
 
 static inline void beep(int period)
 {
-	pwm_pin_set_usec(pwm, SOUND_PIN, period, period / 2, 0);
+	pwm_pin_set_usec(pwm, SOUND_PWM_CHANNEL, period, period / 2, 0);
 }
 
 static void sound_set(enum sound_state state)

--- a/samples/boards/bbc_microbit/sound/CMakeLists.txt
+++ b/samples/boards/bbc_microbit/sound/CMakeLists.txt
@@ -7,4 +7,3 @@ project(sound)
 
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})
-zephyr_include_directories(${ZEPHYR_BASE}/boards/arm/bbc_microbit)

--- a/samples/boards/bbc_microbit/sound/boards/bbc_microbit.overlay
+++ b/samples/boards/bbc_microbit/sound/boards/bbc_microbit.overlay
@@ -1,0 +1,4 @@
+&sw_pwm {
+	status = "okay";
+	channel-gpios = <&edge_connector 0 GPIO_ACTIVE_HIGH>;
+};

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -6,14 +6,13 @@
 
 #include <zephyr.h>
 #include <sys/printk.h>
-#include <board.h>
 #include <drivers/gpio.h>
 #include <drivers/pwm.h>
 #include <device.h>
 
 #include <display/mb_display.h>
 
-#define BUZZER_PIN     EXT_P0_GPIO_PIN
+#define BUZZER_PWM_CHANNEL 0
 
 #define PERIOD_MIN     50
 #define PERIOD_MAX     3900
@@ -34,11 +33,11 @@ static void beep(struct k_work *work)
 	/* The "period / 2" pulse duration gives 50% duty cycle, which
 	 * should result in the maximum sound volume.
 	 */
-	pwm_pin_set_usec(pwm, BUZZER_PIN, period, period / 2U, 0);
+	pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL, period, period / 2U, 0);
 	k_sleep(BEEP_DURATION);
 
 	/* Disable the PWM */
-	pwm_pin_set_usec(pwm, BUZZER_PIN, 0, 0, 0);
+	pwm_pin_set_usec(pwm, BUZZER_PWM_CHANNEL, 0, 0, 0);
 
 	/* Ensure there's a clear silent period between two tones */
 	k_sleep(K_MSEC(50));


### PR DESCRIPTION
This PR is a preparation for #44523.

The two nRF PWM drivers (pwm_nrfx and pwm_nrf5_sw) are aligned with other in-tree PWM drivers in the way that the `pwm` parameter of the `pwm_pin_set_cycles` function is handled. The parameter is now interpreted as a PWM channel, not an SoC pin.

Definitions of `pwm_cells` in bindings related to both the drivers are extended with `period` and `flags` cells, and support for the `PWM_POLARITY_INVERTED` flag is added in the drivers.

All affected board definitions and samples are updated accordingly.

For further details, please see the particular commit messages.