### PR TITLE
Bluetooth: Controller: Fix assert on LL BIG terminate

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -186,8 +186,6 @@ uint8_t ll_big_sync_terminate(uint8_t big_handle, void **rx)
 		}
 		sync->iso.sync_iso = NULL;
 
-		ull_sync_iso_stream_release(sync_iso);
-
 		node_rx = (void *)sync->iso.node_rx_estab;
 		link_sync_estab = node_rx->hdr.link;
 		link_sync_lost = sync_iso->node_rx_lost.hdr.link;


### PR DESCRIPTION
Fix assert on LL BIG terminate call before BIG sync is
established. Assert was caused due to duplicate calls to
release stream contexts, once in LL BIG terminate function
then when releasing the HCI BIG sync failed to be
established node rx was being released.

Use iso_broadcast and iso_receive samples, power cycle the
iso_broadcast device when iso_receive sample is waiting for
BIG sync to be established, iso_receive sample will perform
a BIG sync terminate that leads to the assert.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>