### PR TITLE
modules: zcbor: kconfig: Disallow ZCBOR_VERBOSE with MINIMAL_LIBC

### DIFF
--- a/modules/zcbor/Kconfig
+++ b/modules/zcbor/Kconfig
@@ -26,6 +26,9 @@ config ZCBOR_STOP_ON_ERROR
 config ZCBOR_VERBOSE
 	bool "Make zcbor code print messages"
 
+	# TODO: FIXME: Remove when Minimal LIBC has been fixed.
+	depends on !MINIMAL_LIBC # Because Minimal LIBC doesn't have PRIuFAST32 and PRIxFAST32.
+
 config ZCBOR_ASSERT
 	def_bool ASSERT
 


### PR DESCRIPTION
Because Minimal LIBC doesn't have PRIuFAST32 and PRIxFAST32 which is
needed when printing traces in zcbor.

Signed-off-by: Øyvind Rønningstad <oyvind.ronningstad@nordicsemi.no>

Fixes #44997 