### PR TITLE
Bluetooth: Kconfig: Increase TX stack size for BT_CTLR && BT_LL_SW_SPLIT

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -22,7 +22,7 @@ config BT_HCI_TX_STACK_SIZE
 	default 416 if BT_SPI
 	default 940 if BT_CTLR && BT_LL_SW_SPLIT && NO_OPTIMIZATIONS
 	default 1024 if BT_CTLR && BT_LL_SW_SPLIT && BT_CENTRAL
-	default 640 if BT_CTLR && BT_LL_SW_SPLIT
+	default 768 if BT_CTLR && BT_LL_SW_SPLIT
 	default 512 if BT_USERCHAN
 	default 640 if BT_STM32_IPM
 	# Even if no driver is selected the following default is still


### PR DESCRIPTION
Increase the default TX stack size for BT_CTLR && BT_LL_SW_SPLIT,
as we have seen applications/samples nearing and even reaching
the stack size, causing stack overflows. This is especially
true if CONFIG_FPU=y which takes 96 bytes of the TX stack.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/44931