### PR TITLE
MAINTAINERS: remove inactive CAN driver collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -488,9 +488,7 @@ Documentation:
     collaborators:
         - alexanderwachter
         - karstenkoenig
-        - nixward
         - martinjaeger
-        - legoabram
     files:
         - doc/hardware/peripherals/canbus/
         - drivers/can/


### PR DESCRIPTION
Remove a couple of inactive CAN driver collaborators.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>