### PR TITLE
Bluetooth: Controller: Kconfig: Cleanup direction finding configs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -8,7 +8,7 @@
 # individually.
 config BT_CTLR_DF_SUPPORT
 	bool
-	depends on !BT_CTLR_TIFS_HW
+	depends on BT_LL_SW_SPLIT && !BT_CTLR_TIFS_HW
 	select BT_CTLR_DF_CTE_TX_SUPPORT
 	select BT_CTLR_DF_ANT_SWITCH_2US_SUPPORT
 	select BT_CTLR_DF_ANT_SWITCH_1US_SUPPORT
@@ -115,7 +115,7 @@ config BT_CTLR_DF_CONN_CTE_RSP
 config BT_CTLR_DF_ADV_CTE_TX
 	bool "Connectionless CTE Transmitter feature"
 	depends on BT_CTLR_DF_CTE_TX && BT_CTLR_ADV_PERIODIC
-	select BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY
+	select BT_CTLR_ADV_EXT_PDU_EXTRA_DATA_MEMORY if BT_LL_SW_SPLIT
 	default y
 	help
 	  Enable support for Bluetooth v5.1 Connectionless CTE Transmitter

--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -3,6 +3,9 @@
 # Copyright (c) 2020 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
+# BT_CTLR_DF_SUPPORT is a wrapper for all DF features.
+# If only certain DF features are supported, those should be selected
+# individually.
 config BT_CTLR_DF_SUPPORT
 	bool
 	depends on !BT_CTLR_TIFS_HW

--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -145,6 +145,8 @@ config BT_CTLR_DF_CONN_CTE_RX
 	  Enable reception and sampling of Constant Tone Extension in direction
 	  finding connected mode.
 
+if BT_LL_SW_SPLIT
+
 config BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC
 	bool "Sampling of CTE for PDUs with bad CRC"
 	depends on BT_CTLR_DF_SCAN_CTE_RX
@@ -268,5 +270,7 @@ config BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE
 	  CTEINLINECTRLEN is enabled and received PDU does not have CTEInfo field. The option
 	  enables workaround for the delay to maintain inter frame spacing (IFS) for connection
 	  events.
+
+endif # BT_LL_SW_SPLIT
 
 endif # BT_CTLR_DF

--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -35,7 +35,7 @@ config BT_CTLR_CTEINLINE_SUPPORT
 
 menuconfig BT_CTLR_DF
 	bool "LE Direction Finding [EXPERIMENTAL]"
-	depends on BT_CTLR_DF_SUPPORT
+	depends on BT_CTLR_DF_CTE_TX_SUPPORT || BT_CTLR_DF_CTE_RX_SUPPORT
 	select EXPERIMENTAL
 	help
 	  Enable support for Bluetooth 5.1 Direction Finding


### PR DESCRIPTION
- Makes it possible to support transmitting or receiving constant tone extensions only
- Removes dependencies to BT_LL_SW_SPLIT for common configurations
- Marks some configurations to be specific to BT_LL_SW_SPLIT
- Makes it possible to make BT_CTLR_DF non-experimental for out of tree controllers