### PR TITLE
doc: arch: semihost: fix broken link

### DIFF
--- a/doc/hardware/arch/semihost.rst
+++ b/doc/hardware/arch/semihost.rst
@@ -14,7 +14,7 @@ More complete documentation on the available functionality is available at the
 `ARM Github documentation`_.
 
 The RISC-V functionality borrows from the ARM definitions, as described at the
-`RISC-V Github documentation`.
+`RISC-V Github documentation`_.
 
 File Operations
 ***************


### PR DESCRIPTION
Fix a broken link in the documentation added in #44358.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>