### PR TITLE
debug: generate call graph profile data using gprof

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -24,6 +24,10 @@ zephyr_compile_options($<TARGET_PROPERTY:compiler,hosted>)
 
 zephyr_include_directories(${BOARD_DIR})
 
+if (CONFIG_GPROF)
+  zephyr_compile_options($<TARGET_PROPERTY:compiler,gprof>)
+  zephyr_link_libraries($<TARGET_PROPERTY:linker,gprof>)
+endif()
 if (CONFIG_ASAN)
   zephyr_compile_options($<TARGET_PROPERTY:compiler,sanitize_address>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,sanitize_address>)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -177,6 +177,8 @@ set_compiler_property(PROPERTY imacros -imacros)
 # GCC compiler flags for sanitizing.
 set_compiler_property(PROPERTY sanitize_address -fsanitize=address)
 
+set_compiler_property(PROPERTY gprof -pg)
+
 set_compiler_property(PROPERTY sanitize_undefined -fsanitize=undefined)
 
 # GCC compiler flag for turning off thread-safe initialization of local statics

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -10,5 +10,6 @@ endif()
 # ld/gcc linker flags for sanitizing.
 check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -lasan)
 check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -fsanitize=address)
-
 check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_undefined -fsanitize=undefined)
+
+check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -99,6 +99,13 @@ config DEBUG
 	  only disables optimization, more debugging variants can be selected
 	  from here to allow more debugging.
 
+config GPROF
+	bool "Generate profiling information"
+	depends on ARCH_POSIX
+	help
+	  Generate call graph profile data for the application that can be
+	  analyzed with gprof
+
 config ASAN
 	bool "Build with address sanitizer"
 	depends on ARCH_POSIX


### PR DESCRIPTION
This will generate profile data that can be analyzed using gprof. When
you build the application (currently for native_posix only), after
running the application you will get a file "gmon.out" with the call
graph which can be processed with gprof:

  gprof build/zephyr/zephyr.exe gmon.out > analysis.txt

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
