### PR TITLE
gitignore: add .clangd to the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ hide-defaults-note
 venv
 .venv
 .DS_Store
+.clangd
 
 # CI output
 compliance.xml


### PR DESCRIPTION
This adds .clangd to .gitignore for when you need to provide
local configurations to clang's language server.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>