### PR TITLE
Bluetooth: Controller: Enqueue missing ISO PDUs with invalid status

### DIFF
--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -221,8 +221,9 @@ static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *in
 	}
 
 	str_len = bin2hex(buf->data, buf->len, data_str, sizeof(data_str));
-	printk("Incoming data channel %p len %u: %s (counter value %u)\n",
-	       chan, buf->len, data_str, count);
+	printk("Incoming data channel %p flags 0x%x sn %u ts %u len %u: %s "
+	       "(counter value %u)\n", chan, info->flags, info->sn, info->ts,
+	       buf->len, data_str, count);
 }
 
 static void iso_connected(struct bt_iso_chan *chan)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -44,6 +44,10 @@ static int prepare_cb(struct lll_prepare_param *p);
 static int prepare_cb_common(struct lll_prepare_param *p);
 static void isr_rx_estab(void *param);
 static void isr_rx(void *param);
+static void isr_rx_iso_data_valid(struct lll_sync_iso *lll, uint8_t bis_idx,
+				  struct node_rx_pdu *node_rx);
+static void isr_rx_iso_data_invalid(struct lll_sync_iso *lll, uint8_t bis_idx,
+				    uint8_t bn, struct node_rx_pdu *node_rx);
 static void isr_rx_ctrl_recv(struct lll_sync_iso *lll, struct pdu_bis *pdu);
 
 /* FIXME: Optimize by moving to a common place, as similar variable is used for
@@ -450,7 +454,12 @@ static void isr_rx(void *param)
 
 			isr_rx_ctrl_recv(lll, pdu);
 		} else {
-			node_rx = ull_iso_pdu_rx_alloc_peek(3U);
+			/* check if there are 2 free rx buffers, one will be
+			 * consumed to receive the current PDU, and the other
+			 * is to ensure a PDU can be setup for the radio DMA to
+			 * receive in the next sub_interval/iso_interval.
+			 */
+			node_rx = ull_iso_pdu_rx_alloc_peek(2U);
 			if (!node_rx) {
 				goto isr_rx_done;
 			}
@@ -470,27 +479,11 @@ static void isr_rx(void *param)
 			payload_index -= lll->payload_count_max;
 		}
 
-		if (!lll->payload[bis_idx][payload_index] &&
+		if (pdu->len && !lll->payload[bis_idx][payload_index] &&
 		    ((payload_index >= lll->payload_tail) ||
 		     (payload_index < lll->payload_head))) {
-			struct node_rx_iso_meta *iso_meta;
-
 			ull_iso_pdu_rx_alloc();
-
-			node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
-			node_rx->hdr.handle = lll->stream_handle[bis_idx];
-
-			iso_meta = &node_rx->hdr.rx_iso_meta;
-			iso_meta->payload_number = lll->payload_count +
-						   (lll->bn_curr - 1U) +
-						   (lll->ptc_curr * lll->pto) -
-						   lll->bn;
-			iso_meta->timestamp =
-				HAL_TICKER_TICKS_TO_US(radio_tmr_start_get()) +
-				radio_tmr_aa_restore() - addr_us_get(lll->phy) +
-				(ceiling_fraction(lll->ptc_curr, lll->bn) *
-				 lll->iso_interval * PERIODIC_INT_UNIT_US);
-			iso_meta->status = 0U;
+			isr_rx_iso_data_valid(lll, bis_idx, node_rx);
 
 			lll->payload[bis_idx][payload_index] = node_rx;
 		}
@@ -597,6 +590,21 @@ isr_rx_find_subevent:
 				lll->payload[bis_idx][payload_tail] = NULL;
 
 				iso_rx_put(node_rx->hdr.link, node_rx);
+			} else {
+				/* check if there are 2 free rx buffers, one
+				 * will be consumed to generate PDU with invalid
+				 * status, and the other is to ensure a PDU can
+				 * be setup for the radio DMA to receive in the
+				 * next sub_interval/iso_interval.
+				 */
+				node_rx = ull_iso_pdu_rx_alloc_peek(2U);
+				if (node_rx) {
+					ull_iso_pdu_rx_alloc();
+					isr_rx_iso_data_invalid(lll, bis_idx,
+								bn, node_rx);
+
+					iso_rx_put(node_rx->hdr.link, node_rx);
+				}
 			}
 
 			payload_index = payload_tail + 1U;
@@ -774,6 +782,39 @@ isr_rx_next_subevent:
 							  PHY_FLAGS_S8) -
 				 HAL_RADIO_GPIO_LNA_OFFSET);
 #endif /* HAL_RADIO_GPIO_HAVE_LNA_PIN */
+}
+
+static void isr_rx_iso_data_valid(struct lll_sync_iso *lll, uint8_t bis_idx,
+				  struct node_rx_pdu *node_rx)
+{
+	struct node_rx_iso_meta *iso_meta;
+
+	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
+	node_rx->hdr.handle = lll->stream_handle[bis_idx];
+
+	iso_meta = &node_rx->hdr.rx_iso_meta;
+	iso_meta->payload_number = lll->payload_count + (lll->bn_curr - 1U) +
+				   (lll->ptc_curr * lll->pto) - lll->bn;
+	iso_meta->timestamp = HAL_TICKER_TICKS_TO_US(radio_tmr_start_get()) +
+			      radio_tmr_aa_restore() - addr_us_get(lll->phy) +
+			      (ceiling_fraction(lll->ptc_curr, lll->bn) *
+			       lll->iso_interval * PERIODIC_INT_UNIT_US);
+	iso_meta->status = 0U;
+}
+
+static void isr_rx_iso_data_invalid(struct lll_sync_iso *lll, uint8_t bis_idx,
+				    uint8_t bn, struct node_rx_pdu *node_rx)
+{
+	struct node_rx_iso_meta *iso_meta;
+
+	node_rx->hdr.type = NODE_RX_TYPE_ISO_PDU;
+	node_rx->hdr.handle = lll->stream_handle[bis_idx];
+
+	iso_meta = &node_rx->hdr.rx_iso_meta;
+	iso_meta->payload_number = lll->payload_count - bn - 1U;
+	iso_meta->timestamp = HAL_TICKER_TICKS_TO_US(radio_tmr_start_get()) +
+			      radio_tmr_aa_restore() - addr_us_get(lll->phy);
+	iso_meta->status = 1U;
 }
 
 static void isr_rx_ctrl_recv(struct lll_sync_iso *lll, struct pdu_bis *pdu)

--- a/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_iso.c
@@ -453,7 +453,12 @@ void ull_sync_iso_setup(struct ll_sync_iso_set *sync_iso,
 			   HAL_TICKER_US_TO_TICKS(sync_iso_offset_us),
 			   HAL_TICKER_US_TO_TICKS(interval_us),
 			   HAL_TICKER_REMAINDER(interval_us),
+#if !defined(CONFIG_BT_TICKER_LOW_LAT) && \
+	!defined(CONFIG_BT_CTLR_LOW_LAT)
+			   TICKER_LAZY_MUST_EXPIRE,
+#else
 			   TICKER_NULL_LAZY,
+#endif /* !CONFIG_BT_TICKER_LOW_LAT && !CONFIG_BT_CTLR_LOW_LAT */
 			   (sync_iso->ull.ticks_slot + ticks_slot_overhead),
 			   ticker_cb, sync_iso,
 			   ticker_start_op_cb, (void *)__LINE__);
@@ -680,6 +685,15 @@ static void ticker_cb(uint32_t ticks_at_expire, uint32_t ticks_drift,
 	uint8_t ref;
 
 	DEBUG_RADIO_PREPARE_O(1);
+
+	if (!IS_ENABLED(CONFIG_BT_TICKER_LOW_LAT) &&
+	    !IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) &&
+	    (lazy == TICKER_LAZY_MUST_EXPIRE)) {
+		/* FIXME: generate ISO PDU with status set to invalid */
+
+		DEBUG_RADIO_PREPARE_O(0);
+		return;
+	}
 
 	sync_iso = param;
 	lll = &sync_iso->lll;


### PR DESCRIPTION
Add implementation to generate node rx for missing ISO PDUs
and set the status as invalid. This is required for ISOAL to
correctly track the sequence numbers for every SDU interval.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>