### PR TITLE
pwm: atmel: add period cell

### DIFF
--- a/boards/arm/adafruit_itsybitsy_m4_express/adafruit_itsybitsy_m4_express.dts
+++ b/boards/arm/adafruit_itsybitsy_m4_express/adafruit_itsybitsy_m4_express.dts
@@ -38,7 +38,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&tcc0 2>;
+			pwms = <&tcc0 2 PWM_MSEC(20)>;
 		};
 	};
 };
@@ -75,7 +75,7 @@
 	status = "okay";
 	compatible = "atmel,sam0-tcc-pwm";
 	prescaler = <8>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm0_default>;
 	pinctrl-names = "default";

--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -38,7 +38,7 @@
 		compatible = "pwm-leds";
 
 		pwm_led0: pwm_led_0 {
-			pwms = <&tcc0 2>;
+			pwms = <&tcc0 2 PWM_MSEC(20)>;
 		};
 	};
 };
@@ -94,7 +94,7 @@
 	compatible = "atmel,sam0-tcc-pwm";
 	/* Gives a maximum period of 1.4 s */
 	prescaler = <4>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";

--- a/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
@@ -33,7 +33,7 @@
 		compatible = "pwm-leds";
 
 		pwm_led0: pwm_led_0 {
-			pwms = <&tcc2 1>;
+			pwms = <&tcc2 1 PWM_MSEC(20)>;
 		};
 	};
 
@@ -139,7 +139,7 @@
 	status = "okay";
 	compatible = "atmel,sam0-tcc-pwm";
 	prescaler = <1024>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";

--- a/boards/arm/arduino_zero/arduino_zero.dts
+++ b/boards/arm/arduino_zero/arduino_zero.dts
@@ -47,7 +47,7 @@
 		compatible = "pwm-leds";
 
 		pwm_led0: pwm_led_0 {
-			pwms = <&tcc2 1>;
+			pwms = <&tcc2 1 PWM_MSEC(20)>;
 		};
 	};
 };
@@ -95,7 +95,7 @@
 	compatible = "atmel,sam0-tcc-pwm";
 	/* Gives a maximum period of 1.4 s */
 	prescaler = <1024>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";

--- a/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
+++ b/boards/arm/atsamd21_xpro/atsamd21_xpro.dts
@@ -38,7 +38,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&tcc0 0>;
+			pwms = <&tcc0 0 PWM_MSEC(20)>;
 		};
 	};
 
@@ -60,7 +60,7 @@
 	compatible = "atmel,sam0-tcc-pwm";
 	/* Gives a maximum period of 1.4s */
 	prescaler = <4>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -38,7 +38,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&tcc0 2>;
+			pwms = <&tcc0 2 PWM_MSEC(20)>;
 		};
 	};
 
@@ -56,7 +56,7 @@
 	compatible = "atmel,sam0-tcc-pwm";
 	/* Gives a maximum period of 1.1s for 120MHz main clock */
 	prescaler = <8>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -38,7 +38,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&tcc0 3>;
+			pwms = <&tcc0 3 PWM_MSEC(20)>;
 		};
 	};
 
@@ -105,7 +105,7 @@
 	status = "okay";
 	compatible = "atmel,sam0-tcc-pwm";
 	prescaler = <4>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -45,7 +45,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		pwm_led0: pwm_led_0 {
-			pwms = <&pwm0 0 1000000>;
+			pwms = <&pwm0 0 PWM_MSEC(20)>;
 		};
 	};
 

--- a/boards/arm/serpente/serpente.dts
+++ b/boards/arm/serpente/serpente.dts
@@ -55,15 +55,15 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: pwm_led_0 {
-			pwms = <&tcc0 0>;
+			pwms = <&tcc0 0 PWM_MSEC(20)>;
 			label = "Red PWM LED";
 		};
 		green_pwm_led: pwm_led_1 {
-			pwms = <&tcc0 3>;
+			pwms = <&tcc0 3 PWM_MSEC(20)>;
 			label = "Green PWM LED";
 		};
 		blue_pwm_led: pwm_led_2 {
-			pwms = <&tcc0 1>;
+			pwms = <&tcc0 1 PWM_MSEC(20)>;
 			label = "Blue PWM LED";
 		};
 	};
@@ -111,7 +111,7 @@ zephyr_udc0: &usb0 {
 	status = "okay";
 	compatible = "atmel,sam0-tcc-pwm";
 	prescaler = <4>;
-	#pwm-cells = <1>;
+	#pwm-cells = <2>;
 
 	pinctrl-0 = <&pwm_default>;
 	pinctrl-names = "default";

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv6-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -7,6 +7,7 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -8,6 +8,7 @@
 #include <arm/armv7-m.dtsi>
 #include <dt-bindings/i2c/i2c.h>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
@@ -59,7 +59,8 @@ properties:
       - 1024
 
   "#pwm-cells":
-    const: 1
+    const: 2
 
 pwm-cells:
   - channel
+  - period


### PR DESCRIPTION
The period cell will soon be required by the pwm_dt_spec facilities,
this patch adds it to the Atmel platform and updates all boards accordingly. Note that flags have not been added as they are
optional and not supported anyway.

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523