### PR TITLE
boards: arm: legend: fix PWM LEDs period

### DIFF
--- a/boards/arm/legend/legend_25hdd.overlay
+++ b/boards/arm/legend/legend_25hdd.overlay
@@ -19,7 +19,7 @@
 
 		pwm_led0: pwm_led_0 {
 			label = "Activity LED";
-			pwms = <&pwm3 3 255 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm3 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 };

--- a/boards/arm/legend/legend_35.overlay
+++ b/boards/arm/legend/legend_35.overlay
@@ -19,7 +19,7 @@
 
 		pwm_led0: pwm_led_0 {
 			label = "Activity LED";
-			pwms = <&pwm3 3 255 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm3 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 };


### PR DESCRIPTION
The period was 255 nsec, a value that doesn't make much sense when
driving an LED. Since the period cell is rarely used nowadays, the
value was probably copy&pasted or a random value was added since it is
required. A period of 20 msec has been chosen as most other boards do
for PWM LEDs.