### PR TITLE
dts: arm: silabs: add period cell to PWM

### DIFF
--- a/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
@@ -16,7 +16,7 @@
 		compatible = "pwm-leds";
 		status = "okay";
 		pwm_led0: pwm_led0 {
-			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -59,7 +59,7 @@
 		compatible = "pwm-leds";
 		status = "okay";
 		pwm_led0: pwm_led0 {
-			pwms = <&pwm0 0 PWM_POLARITY_NORMAL>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 		};
 	};
 };

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -184,7 +184,7 @@
 				compatible = "silabs,gecko-pwm";
 				status = "disabled";
 				label = "PWM_0";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -245,7 +245,7 @@
 				compatible = "silabs,gecko-pwm";
 				status = "disabled";
 				label = "PWM_0";
-				#pwm-cells = <2>;
+				#pwm-cells = <3>;
 			};
 		};
 

--- a/dts/bindings/pwm/silabs,gecko-pwm.yaml
+++ b/dts/bindings/pwm/silabs,gecko-pwm.yaml
@@ -29,8 +29,9 @@ properties:
         - 1024
 
     "#pwm-cells":
-      const: 2
+      const: 3
 
 pwm-cells:
   - channel
+  - period
   - flags


### PR DESCRIPTION
The PWM period cell will soon be required by the pwm_dt_spec facilities,
this patch adds support for it and updates all boards.

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523