### PR TITLE
boards: arm: frdm_kw41z: fix PWM LEDs period

### DIFF
--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -49,15 +49,15 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		blue_pwm_led: pwm_led_0 {
-			pwms = <&tpm2 0 PWM_MSEC(20) 0>;
+			pwms = <&tpm2 0 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "User PWM LD1";
 		};
 		green_pwm_led: pwm_led_1 {
-			pwms = <&tpm2 1 PWM_MSEC(20) 0>;
+			pwms = <&tpm2 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "User PWM LD2";
 		};
 		red_pwm_led: pwm_led_2 {
-			pwms = <&tpm0 2 PWM_MSEC(20) 0>;
+			pwms = <&tpm0 2 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 			label = "User PWM LD3";
 		};
 	};

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -49,15 +49,15 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		blue_pwm_led: pwm_led_0 {
-			pwms = <&tpm2 0 0 0>;
+			pwms = <&tpm2 0 PWM_MSEC(20) 0>;
 			label = "User PWM LD1";
 		};
 		green_pwm_led: pwm_led_1 {
-			pwms = <&tpm2 1 0 0>;
+			pwms = <&tpm2 1 PWM_MSEC(20) 0>;
 			label = "User PWM LD2";
 		};
 		red_pwm_led: pwm_led_2 {
-			pwms = <&tpm0 2 0 0>;
+			pwms = <&tpm0 2 PWM_MSEC(20) 0>;
 			label = "User PWM LD3";
 		};
 	};

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -6,6 +6,7 @@
 #include <dt-bindings/clock/kinetis_mcg.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -10,6 +10,7 @@
 #include <dt-bindings/clock/kinetis_mcg.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {


### PR DESCRIPTION
The period was set to 0, a value not meaningful to drive an LED. A value
of 20 msec has been chosen as most other boards do.

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523