### PR TITLE
dts: bindings: nxp,sctimer-pwm: add PWM period cell

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -58,7 +58,7 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		red_pwm_led: red_pwm_led {
-			pwms = <&sc_timer 0 PWM_POLARITY_NORMAL>;
+			pwms = <&sc_timer 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Red PWM LED";
 			status = "okay";
 		};

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -70,17 +70,17 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		green_pwm_led: green_pwm_led {
-			pwms = <&sc_timer 0 PWM_POLARITY_NORMAL>;
+			pwms = <&sc_timer 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Green PWM LED";
 			status = "okay";
 		};
 		blue_pwm_led: blue_pwm_led {
-			pwms = <&sc_timer 6 PWM_POLARITY_NORMAL>;
+			pwms = <&sc_timer 6 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Blue PWM LED";
 			status = "okay";
 		};
 		red_pwm_led: red_pwm_led {
-			pwms = <&sc_timer 6 PWM_POLARITY_NORMAL>;
+			pwms = <&sc_timer 6 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "Red PWM LED";
 			status = "disabled";
 		};

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -390,7 +390,7 @@
 		status = "disabled";
 		prescaler = <2>;
 		label = "SC_TIMER";
-		#pwm-cells = <2>;
+		#pwm-cells = <3>;
 	};
 };
 

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -347,7 +347,7 @@
 		status = "disabled";
 		prescaler = <8>;
 		label = "SC_TIMER";
-		#pwm-cells = <2>;
+		#pwm-cells = <3>;
 	};
 
 	wwdt0: watchdog@e000 {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -299,7 +299,7 @@
 		status = "disabled";
 		prescaler = <8>;
 		label = "SC_TIMER";
-		#pwm-cells = <2>;
+		#pwm-cells = <3>;
 	};
 
 	wwdt0: watchdog@e000 {

--- a/dts/bindings/pwm/nxp,sctimer-pwm.yaml
+++ b/dts/bindings/pwm/nxp,sctimer-pwm.yaml
@@ -24,8 +24,9 @@ properties:
         - 128
 
     "#pwm-cells":
-      const: 2
+      const: 3
 
 pwm-cells:
   - channel
+  - period
   - flags


### PR DESCRIPTION
The period cell will soon be required by the pwm_dt_spec facilities,
this patch adds support for it and updates boards accordingly.

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523