### PR TITLE
boards: riscv: rv32m1_vega: fix PWM period and flags

### DIFF
--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -44,15 +44,15 @@
 	pwmleds {
 		compatible = "pwm-leds";
 		blue_pwm_led: pwm_led_0 {
-			pwms = <&tpm2 2 0 0>;
+			pwms = <&tpm2 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "User PWM LD1";
 		};
 		green_pwm_led: pwm_led_1 {
-			pwms = <&tpm2 1 0 0>;
+			pwms = <&tpm2 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "User PWM LD2";
 		};
 		red_pwm_led: pwm_led_2 {
-			pwms = <&tpm2 0 0 0>;
+			pwms = <&tpm2 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "User PWM LD3";
 		};
 	};

--- a/dts/riscv/rv32m1.dtsi
+++ b/dts/riscv/rv32m1.dtsi
@@ -6,6 +6,7 @@
 #include <dt-bindings/interrupt-controller/openisa-intmux.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	#address-cells = <1>;


### PR DESCRIPTION
The PWM driven LEDs had a wrong period: 0 nsec. A value of 20 msec has
been chosen as most other boards do for PWM driven LEDs. The polarity
has been set to normal (LEDs are driven active high).

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523