### PR TITLE
dts: bindings: pwm: ite,it8xxx2-pwm: add PWM period cell

### DIFF
--- a/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
@@ -60,4 +60,5 @@ properties:
 
 pwm-cells:
   - channel
+  - period
   - flags

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -1034,7 +1034,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm0>; /* GPA0 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		pwm1: pwm@f01803 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1047,7 +1047,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm1>; /* GPA1 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		pwm2: pwm@f01804 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1060,7 +1060,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm2>; /* GPA2 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		pwm3: pwm@f01805 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1073,7 +1073,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm3>; /* GPA3 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		pwm4: pwm@f01806 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1086,7 +1086,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm4>; /* GPA4 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		pwm5: pwm@f01807 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1099,7 +1099,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm5>; /* GPA5 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		pwm6: pwm@f01808 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1112,7 +1112,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm6>; /* GPA6 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		pwm7: pwm@f01809 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1125,7 +1125,7 @@
 			status = "disabled";
 			pwmctrl = <&prs>;
 			pinctrl-0 = <&pinctrl_pwm7>; /* GPA7 */
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 		tach0: tach@f0181e {
 			compatible = "ite,it8xxx2-tach";


### PR DESCRIPTION
The PWM period cell will soon be required by the pwm_dt_spec facilities.
This patch adds support for it.

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523