### PR TITLE
pwm: telink_b91: add PWM period cell

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
@@ -49,7 +49,7 @@
 		compatible = "pwm-leds";
 
 		pwm_led_blue: pwm_led_0 {
-			pwms = <&pwm0 0 PWM_MSEC(20) 0>;
+			pwms = <&pwm0 0 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
 			label = "PWM LED Blue";
 		};
 	};

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
@@ -49,7 +49,7 @@
 		compatible = "pwm-leds";
 
 		pwm_led_blue: pwm_led_0 {
-			pwms = <&pwm0 0 0>;
+			pwms = <&pwm0 0 PWM_MSEC(20) 0>;
 			label = "PWM LED Blue";
 		};
 	};

--- a/dts/bindings/pwm/telink,b91-pwm.yaml
+++ b/dts/bindings/pwm/telink,b91-pwm.yaml
@@ -59,8 +59,9 @@ properties:
       required: true
 
     "#pwm-cells":
-      const: 2
+      const: 3
 
 pwm-cells:
   - channel
+  - period
   - flags

--- a/dts/riscv/telink_b91.dtsi
+++ b/dts/riscv/telink_b91.dtsi
@@ -8,6 +8,7 @@
 
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/telink_b91.dtsi
+++ b/dts/riscv/telink_b91.dtsi
@@ -167,7 +167,7 @@
 			channels = <6>;
 			label = "PWM";
 			status = "disabled";
-			#pwm-cells = <2>;
+			#pwm-cells = <3>;
 		};
 
 		hspi: spi@81FFFFC0 {


### PR DESCRIPTION
The PWM period cell will soon be required by the pwm_dt_spec facilities.
This patch adds support for it and updates all boards accordingly.

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523