### PR TITLE
dts: bindings: pwm: nxp,imx-pwm: add PWM period cell

### DIFF
--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -52,7 +52,7 @@
 		compatible = "pwm-leds";
 
 		green_pwm_led: green_pwm_led {
-			pwms = <&flexpwm2_pwm3 0>;
+			pwms = <&flexpwm2_pwm3 0 PWM_MSEC(20)>;
 		};
 	};
 

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -32,7 +32,7 @@
 		compatible = "pwm-leds";
 
 		green_pwm_led: green_pwm_led {
-			pwms = <&flexpwm1_pwm2 0>;
+			pwms = <&flexpwm1_pwm2 0 PWM_MSEC(20)>;
 		};
 	};
 };

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -32,7 +32,7 @@
 		compatible = "pwm-leds";
 
 		green_pwm_led: green_pwm_led {
-			pwms = <&flexpwm1_pwm2 0>;
+			pwms = <&flexpwm1_pwm2 0 PWM_MSEC(20)>;
 		};
 	};
 };

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -450,7 +450,7 @@
 				index = <0>;
 				label = "FLEXPWM1_PWM0";
 				interrupts = <102 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -460,7 +460,7 @@
 				index = <1>;
 				label = "FLEXPWM1_PWM1";
 				interrupts = <103 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -470,7 +470,7 @@
 				index = <2>;
 				label = "FLEXPWM1_PWM2";
 				interrupts = <104 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -480,7 +480,7 @@
 				index = <3>;
 				label = "FLEXPWM1_PWM3";
 				interrupts = <105 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -496,7 +496,7 @@
 				index = <0>;
 				label = "FLEXPWM2_PWM0";
 				interrupts = <137 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -506,7 +506,7 @@
 				index = <1>;
 				label = "FLEXPWM2_PWM1";
 				interrupts = <138 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -516,7 +516,7 @@
 				index = <2>;
 				label = "FLEXPWM2_PWM2";
 				interrupts = <139 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -526,7 +526,7 @@
 				index = <3>;
 				label = "FLEXPWM2_PWM3";
 				interrupts = <140 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -542,7 +542,7 @@
 				index = <0>;
 				label = "FLEXPWM3_PWM0";
 				interrupts = <142 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -552,7 +552,7 @@
 				index = <1>;
 				label = "FLEXPWM3_PWM1";
 				interrupts = <143 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -562,7 +562,7 @@
 				index = <2>;
 				label = "FLEXPWM3_PWM2";
 				interrupts = <144 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -572,7 +572,7 @@
 				index = <3>;
 				label = "FLEXPWM3_PWM3";
 				interrupts = <145 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -588,7 +588,7 @@
 				index = <0>;
 				label = "FLEXPWM4_PWM0";
 				interrupts = <147 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -598,7 +598,7 @@
 				index = <1>;
 				label = "FLEXPWM4_PWM1";
 				interrupts = <148 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -608,7 +608,7 @@
 				index = <2>;
 				label = "FLEXPWM4_PWM2";
 				interrupts = <149 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -618,7 +618,7 @@
 				index = <3>;
 				label = "FLEXPWM4_PWM3";
 				interrupts = <150 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -9,6 +9,7 @@
 #include <dt-bindings/clock/imx_ccm.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -9,6 +9,7 @@
 #include <dt-bindings/clock/imx_ccm_rev2.h>
 #include <dt-bindings/gpio/gpio.h>
 #include <dt-bindings/i2c/i2c.h>
+#include <dt-bindings/pwm/pwm.h>
 #include <dt-bindings/pm/imx_spc.h>
 
 / {

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -560,7 +560,7 @@
 				index = <0>;
 				label = "FLEXPWM1_PWM0";
 				interrupts = <125 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -570,7 +570,7 @@
 				index = <1>;
 				label = "FLEXPWM1_PWM1";
 				interrupts = <126 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -580,7 +580,7 @@
 				index = <2>;
 				label = "FLEXPWM1_PWM2";
 				interrupts = <127 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -590,7 +590,7 @@
 				index = <3>;
 				label = "FLEXPWM1_PWM3";
 				interrupts = <128 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -606,7 +606,7 @@
 				index = <0>;
 				label = "FLEXPWM2_PWM0";
 				interrupts = <177 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -616,7 +616,7 @@
 				index = <1>;
 				label = "FLEXPWM2_PWM1";
 				interrupts = <178 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -626,7 +626,7 @@
 				index = <2>;
 				label = "FLEXPWM2_PWM2";
 				interrupts = <179 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -636,7 +636,7 @@
 				index = <3>;
 				label = "FLEXPWM2_PWM3";
 				interrupts = <180 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -652,7 +652,7 @@
 				index = <0>;
 				label = "FLEXPWM3_PWM0";
 				interrupts = <182 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -662,7 +662,7 @@
 				index = <1>;
 				label = "FLEXPWM3_PWM1";
 				interrupts = <183 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -672,7 +672,7 @@
 				index = <2>;
 				label = "FLEXPWM3_PWM2";
 				interrupts = <184 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -682,7 +682,7 @@
 				index = <3>;
 				label = "FLEXPWM3_PWM3";
 				interrupts = <185 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -698,7 +698,7 @@
 				index = <0>;
 				label = "FLEXPWM4_PWM0";
 				interrupts = <187 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -708,7 +708,7 @@
 				index = <1>;
 				label = "FLEXPWM4_PWM1";
 				interrupts = <188 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -718,7 +718,7 @@
 				index = <2>;
 				label = "FLEXPWM4_PWM2";
 				interrupts = <189 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};
@@ -728,7 +728,7 @@
 				index = <3>;
 				label = "FLEXPWM4_PWM3";
 				interrupts = <190 0>;
-				#pwm-cells = <1>;
+				#pwm-cells = <2>;
 				clocks = <&ccm IMX_CCM_PWM_CLK 0 0>;
 				status = "disabled";
 			};

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -20,7 +20,8 @@ properties:
       required: true
 
     "#pwm-cells":
-      const: 1
+      const: 2
 
 pwm-cells:
   - channel
+  - period


### PR DESCRIPTION
The PWM period cell will soon be required by the pwm_dt_spec facilities,
this patch adds support for it.

Prep work for https://github.com/zephyrproject-rtos/zephyr/pull/44523