### PR TITLE
Lwm2m queue mode DTLS resume

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -117,6 +117,9 @@ struct lwm2m_ctx {
 	struct coap_pending pendings[CONFIG_LWM2M_ENGINE_MAX_PENDING];
 	struct coap_reply replies[CONFIG_LWM2M_ENGINE_MAX_REPLIES];
 	sys_slist_t pending_sends;
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+	sys_slist_t queued_messages;
+#endif
 	sys_slist_t observer;
 
 	/** A pointer to currently processed request, for internal LwM2M engine
@@ -151,6 +154,19 @@ struct lwm2m_ctx {
 	 */
 	bool use_dtls;
 
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+	/**
+	 * Flag to indicate that the socket connection is suspended.
+	 * With queue mode, this will tell if there is a need to reconnect.
+	 */
+	bool connection_suspended;
+
+	/**
+	 * Flag to indicate that the client is buffering Notifications and Send messages.
+	 * True value buffer Notifications and Send messages.
+	 */
+	bool buffer_client_messages;
+#endif
 	/** Current index of Security Object used for server credentials */
 	int sec_obj_inst;
 

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1147,7 +1147,7 @@ struct coap_pending *coap_pending_next_unused(
 	size_t i;
 
 	for (i = 0, p = pendings; i < len; i++, p++) {
-		if (p->timeout == 0) {
+		if (p->data == 0) {
 			return p;
 		}
 	}

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -192,6 +192,11 @@ config LWM2M_QUEUE_MODE_UPTIME
 	  defaults to 93 seconds, see RFC 7252), it does not forbid other
 	  values though.
 
+config LWM2M_TLS_SESSION_CACHING
+	bool "TLS session caching"
+	help
+	  Enabling this only when feature is supported in TLS library.
+
 config LWM2M_RD_CLIENT_SUPPORT
 	bool "support for LWM2M client bootstrap/registration state machine"
 	default y

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -123,6 +123,8 @@ struct lwm2m_message *lwm2m_get_message(struct lwm2m_ctx *client_ctx);
 void lwm2m_reset_message(struct lwm2m_message *msg, bool release);
 int lwm2m_init_message(struct lwm2m_message *msg);
 int lwm2m_send_message_async(struct lwm2m_message *msg);
+/* Notification and Send operation */
+int lwm2m_information_interface_send(struct lwm2m_message *msg);
 int lwm2m_send_empty_ack(struct lwm2m_ctx *client_ctx, uint16_t mid);
 
 int lwm2m_register_payload_handler(struct lwm2m_message *msg);
@@ -192,6 +194,11 @@ const char *lwm2m_engine_get_attr_name(const struct lwm2m_attr *attr);
 int  lwm2m_socket_add(struct lwm2m_ctx *ctx);
 void lwm2m_socket_del(struct lwm2m_ctx *ctx);
 int  lwm2m_socket_start(struct lwm2m_ctx *client_ctx);
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+int lwm2m_engine_close_socket_connection(struct lwm2m_ctx *client_ctx);
+int lwm2m_engine_connection_resume(struct lwm2m_ctx *client_ctx);
+int lwm2m_push_queued_buffers(struct lwm2m_ctx *client_ctx);
+#endif
 int  lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmware_uri);
 
 #endif /* LWM2M_ENGINE_H */

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -43,7 +43,9 @@ int engine_trigger_bootstrap(void);
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 void engine_bootstrap_finish(void);
 #endif
-
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+int lwm2m_rd_client_connection_resume(struct lwm2m_ctx *client_ctx);
+#endif
 void engine_update_tx_time(void);
 
 #endif /* LWM2M_RD_CLIENT_H */


### PR DESCRIPTION
- Enabled DTLS session cache for support session resume.
- Fixed LwM2M queue mode for close connection and reconnect automatically.
- Re-connect will do Registration update before it send queued data.
- Coap Confirmation pending class allocation fix.
- Registration update failure trig full Registration. This will handle session resume failure.