### PR TITLE
drivers: ctimer: Add set_top_value support

### DIFF
--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -522,7 +522,10 @@ void test_multiple_alarms_instance(const char *dev_name)
 	}
 	dev = device_get_binding(dev_name);
 	ticks = counter_us_to_ticks(dev, counter_period_us);
-	top_cfg.ticks = ticks;
+
+	err = counter_get_value(dev, &(top_cfg.ticks));
+	zassert_equal(0, err, "%s: Counter get value failed", dev_name);
+	top_cfg.ticks += ticks;
 
 	alarm_cfg.flags = COUNTER_ALARM_CFG_ABSOLUTE;
 	alarm_cfg.ticks = counter_us_to_ticks(dev, 2000);
@@ -558,11 +561,7 @@ void test_multiple_alarms_instance(const char *dev_name)
 	err = counter_set_channel_alarm(dev, 1, &alarm_cfg2);
 	zassert_equal(0, err, "%s: Counter set alarm failed", dev_name);
 
-#ifdef CONFIG_COUNTER_MCUX_CTIMER
-	k_busy_wait((uint32_t)counter_ticks_to_us(dev, 0xFFFFFFFF));
-#else
 	k_busy_wait(1.2 * counter_ticks_to_us(dev, ticks * 2U));
-#endif
 
 	cnt = IS_ENABLED(CONFIG_ZERO_LATENCY_IRQS) ?
 		alarm_cnt : k_sem_count_get(&alarm_cnt_sem);


### PR DESCRIPTION
Implement the set_top_value. This reserves one of the Match channels to set the top value and to reset the counter. Therefore the number of channels available to the user is reduced by 1.

Also update `test_multiple_alarms` test inside `counter_basic_api/src/test_counter.c` to set the top value relative to the current time. This is so that we avoid the case of setting the top value that is prior to the current counter value.

Fixes Issue #44672
