### PR TITLE
dt: pwm: add support for specifying frequency in Hz and kHz

### DIFF
--- a/include/zephyr/dt-bindings/pwm/pwm.h
+++ b/include/zephyr/dt-bindings/pwm/pwm.h
@@ -21,6 +21,10 @@
 #define PWM_MSEC(x)	(PWM_USEC(x) * 1000UL)
 /** Specify PWM period in seconds */
 #define PWM_SEC(x)	(PWM_MSEC(x) * 1000UL)
+/** Specify PWM frequency in hertz */
+#define PWM_HZ(x)	(PWM_SEC(1UL) / (x))
+/** Specify PWM frequency in kilohertz */
+#define PWM_KHZ(x)	(PWM_HZ((x) * 1000UL))
 
 /** @} */
 


### PR DESCRIPTION
Hi, adding a couple macros in the PWM dt includes to specify the period as frequency in hertz or kilohertz. I think it may be easier to use in some situation (like if connected to a device with a spec expressed in frequency rather than period).

-- 8< --

Add a pair of dt macros for specifying the pwm frequency in hertz or
kilohertz: PWM_HZ and PWM_KHZ. This is then converted in period
nanoseconds so it works as expected with the other definitions.