### PR TITLE
drivers: CAN: Fix unused parameter warnings when compiling with -Wextra

### DIFF
--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1109,6 +1109,8 @@ static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeo
 /* This implementation prevents inking errors for auto recovery */
 static inline int z_impl_can_recover(const struct device *dev, k_timeout_t timeout)
 {
+	ARG_UNUSED(dev);
+	ARG_UNUSED(timeout);
 	return 0;
 }
 #endif /* !CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */


### PR DESCRIPTION
Since the CAN header file is included directly by application code,
an application developer including this file and only applying
-Wextra to the application source files will see many warnings.

Signed-off-by: Pete Dietl <petedietl@gmail.com>