### PR TITLE
Bluetooth: Controller: Use remainder for auxiliary PDU scheduling

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -196,7 +196,7 @@ config BT_CTLR_ADV_PDU_LINK
 
 config BT_CTLR_ADV_PDU_BACK2BACK
 	bool "Back-to-back transmission of extended advertising trains"
-	depends on BT_CTLR_ADV_EXT && BT_BROADCASTER
+	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
 	select BT_CTLR_ADV_PDU_LINK
 	help
 	  Enables transmission of AUX_CHAIN_IND in extended advertising train by
@@ -689,6 +689,14 @@ config BT_TICKER_LOW_LAT
 	  ticker node timeouts and thereby prevents ticker interrupts during
 	  radio RX/TX. Enabling this option disables the ticker priority- and
 	  'must expire' features.
+
+config BT_TICKER_REMAINDER_GET
+	bool "Ticker Next Slot Get with Remainder"
+	default y if BT_BROADCASTER && BT_CTLR_ADV_EXT
+	help
+	  This option enables ticker interface to iterate through active
+	  ticker nodes, returning tick to expire and remainder from a reference
+	  tick.
 
 config BT_TICKER_LAZY_GET
 	bool "Ticker Next Slot Get with Lazy"

--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -129,10 +129,11 @@ struct lll_adv_aux {
 	 */
 	uint16_t data_chan_counter;
 
-	/* Temporary stored use by primary channel PDU event to fill the
+	/* Store use by primary channel PDU event to fill the
 	 * auxiliary offset to this auxiliary PDU event.
 	 */
 	uint32_t ticks_offset;
+	uint32_t us_offset;
 
 	struct lll_adv_pdu data;
 #if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)

--- a/subsys/bluetooth/controller/ll_sw/lll_adv_aux.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv_aux.h
@@ -10,6 +10,5 @@ void lll_adv_aux_prepare(void *param);
 
 extern uint8_t ull_adv_aux_lll_handle_get(struct lll_adv_aux *lll);
 extern struct pdu_adv_aux_ptr *
-	ull_adv_aux_lll_offset_fill(struct pdu_adv *pdu,
-				    uint32_t ticks_offset,
-				    uint32_t start_us);
+	ull_adv_aux_lll_offset_fill(struct pdu_adv *pdu, uint32_t ticks_offset,
+				    uint32_t remainder_us, uint32_t start_us);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1302,6 +1302,7 @@ static void isr_done(void *param)
 		if (lll_aux) {
 			(void)ull_adv_aux_lll_offset_fill(pdu,
 							  lll_aux->ticks_offset,
+							  lll_aux->us_offset,
 							  start_us);
 		}
 #else /* !CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -960,7 +960,7 @@ static void mfy_iso_offset_get(void *param)
 		ret = ticker_next_slot_get_ext(TICKER_INSTANCE_ID_CTLR,
 					       TICKER_USER_ID_ULL_LOW,
 					       &id, &ticks_current,
-					       &ticks_to_expire, &lazy,
+					       &ticks_to_expire, NULL, &lazy,
 					       NULL, NULL,
 					       ticker_op_cb, (void *)&ret_cb);
 		if (ret == TICKER_STATUS_BUSY) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1657,7 +1657,7 @@ static void mfy_sync_offset_get(void *param)
 		ret = ticker_next_slot_get_ext(TICKER_INSTANCE_ID_CTLR,
 					       TICKER_USER_ID_ULL_LOW,
 					       &id, &ticks_current,
-					       &ticks_to_expire, &lazy,
+					       &ticks_to_expire, NULL, &lazy,
 					       NULL, NULL,
 					       ticker_op_cb, (void *)&ret_cb);
 		if (ret == TICKER_STATUS_BUSY) {

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -181,6 +181,9 @@ struct ticker_user_op_slot_get {
 	uint8_t  *ticker_id;
 	uint32_t *ticks_current;
 	uint32_t *ticks_to_expire;
+#if defined(CONFIG_BT_TICKER_REMAINDER_GET)
+	uint32_t *remainder;
+#endif /* CONFIG_BT_TICKER_REMAINDER_GET */
 #if defined(CONFIG_BT_TICKER_LAZY_GET)
 	uint16_t *lazy;
 #endif /* CONFIG_BT_TICKER_LAZY_GET */
@@ -385,10 +388,11 @@ static uint8_t ticker_by_slot_get(struct ticker_node *node, uint8_t ticker_id_he
  * @internal
  */
 static void ticker_by_next_slot_get(struct ticker_instance *instance,
-				    uint8_t *ticker_id_head, uint32_t *ticks_current,
+				    uint8_t *ticker_id_head,
+				    uint32_t *ticks_current,
 				    uint32_t *ticks_to_expire,
 				    ticker_op_match_func fp_match_op_func,
-				    void *match_op_context,
+				    void *match_op_context, uint32_t *remainder,
 				    uint16_t *lazy)
 {
 	struct ticker_node *ticker;
@@ -453,6 +457,13 @@ static void ticker_by_next_slot_get(struct ticker_instance *instance,
 	if (_ticker_id_head != TICKER_NULL) {
 		/* Add ticks for found ticker */
 		_ticks_to_expire += ticker->ticks_to_expire;
+
+#if defined(CONFIG_BT_TICKER_REMAINDER_GET)
+		if (remainder) {
+			*remainder = ticker->remainder_current;
+		}
+#endif /* CONFIG_BT_TICKER_REMAINDER_GET */
+
 #if defined(CONFIG_BT_TICKER_LAZY_GET)
 		if (lazy) {
 			*lazy = ticker->lazy_current;
@@ -2232,6 +2243,11 @@ static inline void ticker_job_op_inquire(struct ticker_instance *instance,
 #else
 					NULL, NULL,
 #endif
+#if defined(CONFIG_BT_TICKER_REMAINDER_GET)
+					uop->params.slot_get.remainder,
+#else /* !CONFIG_BT_TICKER_REMAINDER_GET */
+					NULL,
+#endif /* !CONFIG_BT_TICKER_REMAINDER_GET */
 #if defined(CONFIG_BT_TICKER_LAZY_GET)
 					uop->params.slot_get.lazy);
 #else /* !CONFIG_BT_TICKER_LAZY_GET */
@@ -3027,21 +3043,26 @@ uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id,
 			      ticker_op_func fp_op_func, void *op_context)
 {
 #if defined(CONFIG_BT_TICKER_LAZY_GET) || \
+	defined(CONFIG_BT_TICKER_REMAINDER_GET) || \
 	defined(CONFIG_BT_TICKER_NEXT_SLOT_GET_MATCH)
 	return ticker_next_slot_get_ext(instance_index, user_id, ticker_id,
 					ticks_current, ticks_to_expire, NULL,
-					NULL, NULL,
-					fp_op_func, op_context);
+					NULL, NULL, NULL, fp_op_func,
+					op_context);
 }
 
 uint32_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
 				  uint8_t *ticker_id, uint32_t *ticks_current,
-				  uint32_t *ticks_to_expire, uint16_t *lazy,
+				  uint32_t *ticks_to_expire,
+				  uint32_t *remainder, uint16_t *lazy,
 				  ticker_op_match_func fp_match_op_func,
 				  void *match_op_context,
 				  ticker_op_func fp_op_func, void *op_context)
 {
-#endif /* CONFIG_BT_TICKER_LAZY_GET || CONFIG_BT_TICKER_NEXT_SLOT_GET_MATCH */
+#endif /* CONFIG_BT_TICKER_LAZY_GET ||
+	* CONFIG_BT_TICKER_REMAINDER_GET ||
+	* CONFIG_BT_TICKER_NEXT_SLOT_GET_MATCH
+	*/
 	struct ticker_instance *instance = &_instance[instance_index];
 	struct ticker_user_op *user_op;
 	struct ticker_user *user;
@@ -3064,6 +3085,9 @@ uint32_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
 	user_op->params.slot_get.ticker_id = ticker_id;
 	user_op->params.slot_get.ticks_current = ticks_current;
 	user_op->params.slot_get.ticks_to_expire = ticks_to_expire;
+#if defined(CONFIG_BT_TICKER_REMAINDER_GET)
+	user_op->params.slot_get.remainder = remainder;
+#endif /* CONFIG_BT_TICKER_REMAINDER_GET */
 #if defined(CONFIG_BT_TICKER_LAZY_GET)
 	user_op->params.slot_get.lazy = lazy;
 #endif /* CONFIG_BT_TICKER_LAZY_GET */

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -157,7 +157,8 @@ uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id,
 			      ticker_op_func fp_op_func, void *op_context);
 uint32_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
 				  uint8_t *ticker_id, uint32_t *ticks_current,
-				  uint32_t *ticks_to_expire, uint16_t *lazy,
+				  uint32_t *ticks_to_expire,
+				  uint32_t *remainder, uint16_t *lazy,
 				  ticker_op_match_func fp_op_match_func,
 				  void *match_op_context,
 				  ticker_op_func fp_op_func, void *op_context);


### PR DESCRIPTION
Use remainder value in scheduling the periodic auxiliary
PDUs and use the ticker next slot get interface with
remainder value to fill the auxiliary offsets with
microsecond precision in the primary channel PDUs.

Updated ticker implementation to return remainder value for
a ticker when enumerating active tickers with time
reservations.

This is required to find offsets and to use the remainder
value to correctly calculate auxiliary offsets to the
microsecond resolution.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>