### PR TITLE
tests: spi: spi_loopback: remove usage of deprecated fields

### DIFF
--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -24,8 +24,10 @@ LOG_MODULE_REGISTER(main);
 #if defined(CONFIG_SPI_LOOPBACK_CS_GPIO)
 #define CS_CTRL_GPIO_DRV_NAME CONFIG_SPI_LOOPBACK_CS_CTRL_GPIO_DRV_NAME
 struct spi_cs_control spi_cs = {
-	.gpio_pin = CONFIG_SPI_LOOPBACK_CS_CTRL_GPIO_PIN,
-	.gpio_dt_flags = GPIO_ACTIVE_LOW,
+	.gpio = {
+		.pin = CONFIG_SPI_LOOPBACK_CS_CTRL_GPIO_PIN,
+		.dt_flags = GPIO_ACTIVE_LOW
+	},
 	.delay = 0,
 };
 #define SPI_CS (&spi_cs)
@@ -102,10 +104,10 @@ struct spi_config spi_cfg_fast = {
 #if defined(CONFIG_SPI_LOOPBACK_CS_GPIO)
 static int cs_ctrl_gpio_config(void)
 {
-	spi_cs.gpio_dev = device_get_binding(CS_CTRL_GPIO_DRV_NAME);
-	if (!spi_cs.gpio_dev) {
+	spi_cs.gpio.port = device_get_binding(CS_CTRL_GPIO_DRV_NAME);
+	if (!spi_cs.gpio.port) {
 		LOG_ERR("Cannot find %s!", CS_CTRL_GPIO_DRV_NAME);
-		zassert_not_null(spi_cs.gpio_dev, "Invalid gpio device");
+		zassert_not_null(spi_cs.gpio.port, "Invalid gpio device");
 		return -1;
 	}
 

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -42,15 +42,11 @@ struct spi_cs_control spi_cs = {
 
 #if CONFIG_NOCACHE_MEMORY
 static const char tx_data[] = "0123456789abcdef\0";
-static __aligned(32) char buffer_tx[BUF_SIZE] __used
-	__attribute__((__section__(".nocache")));
-static __aligned(32) char buffer_rx[BUF_SIZE] __used
-	__attribute__((__section__(".nocache")));
+static __aligned(32) char buffer_tx[BUF_SIZE] __used __attribute__((__section__(".nocache")));
+static __aligned(32) char buffer_rx[BUF_SIZE] __used __attribute__((__section__(".nocache")));
 static const char tx2_data[] = "Thequickbrownfoxjumpsoverthelazydog\0";
-static __aligned(32) char buffer2_tx[BUF2_SIZE] __used
-	__attribute__((__section__(".nocache")));
-static __aligned(32) char buffer2_rx[BUF2_SIZE] __used
-	__attribute__((__section__(".nocache")));
+static __aligned(32) char buffer2_tx[BUF2_SIZE] __used __attribute__((__section__(".nocache")));
+static __aligned(32) char buffer2_rx[BUF2_SIZE] __used __attribute__((__section__(".nocache")));
 #else
 /* this src memory shall be in RAM to support using as a DMA source pointer.*/
 uint8_t buffer_tx[] = "0123456789abcdef\0";
@@ -126,6 +122,7 @@ static int spi_complete_multiple(const struct device *dev,
 		.buffers = tx_bufs,
 		.count = ARRAY_SIZE(tx_bufs)
 	};
+
 	tx_bufs[0].buf = buffer_tx;
 	tx_bufs[0].len = BUF_SIZE;
 
@@ -159,10 +156,8 @@ static int spi_complete_multiple(const struct device *dev,
 	if (memcmp(buffer_tx, buffer_rx, BUF_SIZE)) {
 		to_display_format(buffer_tx, BUF_SIZE, buffer_print_tx);
 		to_display_format(buffer_rx, BUF_SIZE, buffer_print_rx);
-		LOG_ERR("Buffer contents are different: %s",
-			    buffer_print_tx);
-		LOG_ERR("                           vs: %s",
-			    buffer_print_rx);
+		LOG_ERR("Buffer contents are different: %s", buffer_print_tx);
+		LOG_ERR("                           vs: %s", buffer_print_rx);
 		zassert_false(1, "Buffer contents are different");
 		return -1;
 	}
@@ -170,11 +165,9 @@ static int spi_complete_multiple(const struct device *dev,
 	if (memcmp(buffer2_tx, buffer2_rx, BUF2_SIZE)) {
 		to_display_format(buffer2_tx, BUF2_SIZE, buffer_print_tx2);
 		to_display_format(buffer2_rx, BUF2_SIZE, buffer_print_rx2);
-		LOG_ERR("Buffer 2 contents are different: %s",
-			    buffer_print_tx2);
-		LOG_ERR("                           vs: %s",
-			    buffer_print_rx2);
-		zassert_false(1, "Buffer contents are different");
+		LOG_ERR("Buffer 2 contents are different: %s", buffer_print_tx2);
+		LOG_ERR("                             vs: %s", buffer_print_rx2);
+		zassert_false(1, "Buffer 2 contents are different");
 		return -1;
 	}
 
@@ -221,10 +214,8 @@ static int spi_complete_loop(const struct device *dev,
 	if (memcmp(buffer_tx, buffer_rx, BUF_SIZE)) {
 		to_display_format(buffer_tx, BUF_SIZE, buffer_print_tx);
 		to_display_format(buffer_rx, BUF_SIZE, buffer_print_rx);
-		LOG_ERR("Buffer contents are different: %s",
-			    buffer_print_tx);
-		LOG_ERR("                           vs: %s",
-			    buffer_print_rx);
+		LOG_ERR("Buffer contents are different: %s", buffer_print_tx);
+		LOG_ERR("                           vs: %s", buffer_print_rx);
 		zassert_false(1, "Buffer contents are different");
 		return -1;
 	}
@@ -238,14 +229,14 @@ static int spi_null_tx_buf(const struct device *dev,
 			   struct spi_config *spi_conf)
 {
 	static const uint8_t EXPECTED_NOP_RETURN_BUF[BUF_SIZE] = { 0 };
+
 	(void)memset(buffer_rx, 0x77, BUF_SIZE);
 
 	const struct spi_buf tx_bufs[] = {
+		/* According to documentation, when sending NULL tx buf -
+		 *  NOP frames should be sent on MOSI line
+		 */
 		{
-	       /*
-		* According to documentation, when sending NULL tx buf -
-		*  NOP frames should be sent on MOSI line
-		*/
 			.buf = NULL,
 			.len = BUF_SIZE,
 		},
@@ -329,10 +320,8 @@ static int spi_rx_half_start(const struct device *dev,
 	if (memcmp(buffer_tx, buffer_rx, 8)) {
 		to_display_format(buffer_tx, 8, buffer_print_tx);
 		to_display_format(buffer_rx, 8, buffer_print_rx);
-		LOG_ERR("Buffer contents are different: %s",
-			    buffer_print_tx);
-		LOG_ERR("                           vs: %s",
-			    buffer_print_rx);
+		LOG_ERR("Buffer contents are different: %s", buffer_print_tx);
+		LOG_ERR("                           vs: %s", buffer_print_rx);
 		zassert_false(1, "Buffer contents are different");
 		return -1;
 	}
@@ -387,13 +376,11 @@ static int spi_rx_half_end(const struct device *dev,
 		return -1;
 	}
 
-	if (memcmp(buffer_tx+8, buffer_rx, 8)) {
+	if (memcmp(buffer_tx + 8, buffer_rx, 8)) {
 		to_display_format(buffer_tx + 8, 8, buffer_print_tx);
 		to_display_format(buffer_rx, 8, buffer_print_rx);
-		LOG_ERR("Buffer contents are different: %s",
-			    buffer_print_tx);
-		LOG_ERR("                           vs: %s",
-			    buffer_print_rx);
+		LOG_ERR("Buffer contents are different: %s", buffer_print_tx);
+		LOG_ERR("                           vs: %s", buffer_print_rx);
 		zassert_false(1, "Buffer contents are different");
 		return -1;
 	}
@@ -464,19 +451,15 @@ static int spi_rx_every_4(const struct device *dev,
 	if (memcmp(buffer_tx + 4, buffer_rx, 4)) {
 		to_display_format(buffer_tx + 4, 4, buffer_print_tx);
 		to_display_format(buffer_rx, 4, buffer_print_rx);
-		LOG_ERR("Buffer contents are different: %s",
-			    buffer_print_tx);
-		LOG_ERR("                           vs: %s",
-			    buffer_print_rx);
+		LOG_ERR("Buffer contents are different: %s", buffer_print_tx);
+		LOG_ERR("                           vs: %s", buffer_print_rx);
 		zassert_false(1, "Buffer contents are different");
 		return -1;
 	} else if (memcmp(buffer_tx + 12, buffer_rx + 4, 4)) {
 		to_display_format(buffer_tx + 12, 4, buffer_print_tx);
 		to_display_format(buffer_rx + 4, 4, buffer_print_rx);
-		LOG_ERR("Buffer contents are different: %s",
-			    buffer_print_tx);
-		LOG_ERR("                           vs: %s",
-			    buffer_print_rx);
+		LOG_ERR("Buffer contents are different: %s", buffer_print_tx);
+		LOG_ERR("                           vs: %s", buffer_print_rx);
 		zassert_false(1, "Buffer contents are different");
 		return -1;
 	}
@@ -558,7 +541,7 @@ static int spi_async_call(const struct device *dev,
 
 	k_sem_take(&caller, K_FOREVER);
 
-	if (result)  {
+	if (result) {
 		LOG_ERR("Call code %d", ret);
 		zassert_false(result, "SPI transceive failed");
 		return -1;


### PR DESCRIPTION
Remove the usage of deprecated struct fields from the test.