### PR TITLE
boards: arm: nucleo_f207zg: Add PWM LEDs to board DTS

### DIFF
--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -36,6 +36,23 @@
 		};
 	};
 
+	pwmleds {
+		compatible = "pwm-leds";
+
+		green_pwm_led: led_pwm_1 {
+			pwms = <&pwm3 3 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "Green PWM LED";
+		};
+		blue_pwm_led: led_pwm_2 {
+			pwms = <&pwm4 2 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "Blue PWM LED";
+		};
+		red_pwm_led: led_pwm_0 {
+			pwms = <&pwm12 1 PWM_MSEC(20) PWM_POLARITY_NORMAL>;
+			label = "Red PWM LED";
+		};
+	};
+
 	gpio_keys {
 		compatible = "gpio-keys";
 		user_button: button {
@@ -48,6 +65,12 @@
 		led0 = &green_led_1;
 		led1 = &blue_led_1;
 		led2 = &red_led_1;
+		pwm-led0 = &green_pwm_led;
+		pwm-led1 = &blue_pwm_led;
+		pwm-led2 = &red_pwm_led;
+		green-pwm-led = &green_pwm_led;
+		blue-pwm-led = &blue_pwm_led;
+		red-pwm-led = &red_pwm_led;
 		sw0 = &user_button;
 	};
 };
@@ -177,6 +200,39 @@ zephyr_udc0: &usbotg_fs {
 	pwm1: pwm {
 		status = "okay";
 		pinctrl-0 = <&tim1_ch1_pe9>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers3 {
+	status = "okay";
+	st,prescaler = <10000>;
+
+	pwm3: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim3_ch3_pb0>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers4 {
+	status = "okay";
+	st,prescaler = <10000>;
+
+	pwm4: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim4_ch2_pb7>;
+		pinctrl-names = "default";
+	};
+};
+
+&timers12 {
+	status = "okay";
+	st,prescaler = <10000>;
+
+	pwm12: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim12_ch1_pb14>;
 		pinctrl-names = "default";
 	};
 };


### PR DESCRIPTION
This commit adds PWM LEDs to the boards DTS. This was
verified by running the pwm_leds example.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>