### PR TITLE
dts: arm: st: stm32f2: Add missing timers to DTS

### DIFF
--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -488,6 +488,28 @@
 			};
 		};
 
+		timers6: timers@40001000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000010>;
+			interrupts = <54 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+			label = "TIMERS_6";
+		};
+
+		timers7: timers@40001400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000020>;
+			interrupts = <55 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+			label = "TIMERS_7";
+		};
+
 		timers8: timers@40010400 {
 			compatible = "st,stm32-timers";
 			reg = <0x40010400 0x400>;
@@ -524,6 +546,42 @@
 			};
 		};
 
+		timers10: timers@40014400 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00020000>;
+			interrupts = <25 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+			label = "TIMERS_10";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				label = "PWM_10";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers11: timers@40014800 {
+			compatible = "st,stm32-timers";
+			reg = <0x40014800 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00040000>;
+			interrupts = <26 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+			label = "TIMERS_11";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				label = "PWM_11";
+				#pwm-cells = <3>;
+			};
+		};
+
 		timers12: timers@40001800 {
 			compatible = "st,stm32-timers";
 			reg = <0x40001800 0x400>;
@@ -538,6 +596,42 @@
 				compatible = "st,stm32-pwm";
 				status = "disabled";
 				label = "PWM_12";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers13: timers@40001C00 {
+			compatible = "st,stm32-timers";
+			reg = <0x40001C00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000080>;
+			interrupts = <44 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+			label = "TIMERS_13";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				label = "PWM_13";
+				#pwm-cells = <3>;
+			};
+		};
+
+		timers14: timers@40002000 {
+			compatible = "st,stm32-timers";
+			reg = <0x40002000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00000100>;
+			interrupts = <45 0>;
+			interrupt-names = "global";
+			st,prescaler = <0>;
+			status = "disabled";
+			label = "TIMERS_14";
+
+			pwm {
+				compatible = "st,stm32-pwm";
+				status = "disabled";
+				label = "PWM_14";
 				#pwm-cells = <3>;
 			};
 		};


### PR DESCRIPTION
This commit adds missing timers to the stm32f2 series.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>