### PR TITLE
doc: Improve the layout of four tables

### DIFF
--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -375,6 +375,7 @@ device.
 
 .. list-table:: Zephyr-specific chosen properties
    :header-rows: 1
+   :widths: 25 75
 
    * - Property
      - Purpose

--- a/doc/connectivity/networking/api/net_config.rst
+++ b/doc/connectivity/networking/api/net_config.rst
@@ -19,7 +19,7 @@ setup the system:
 
 .. csv-table:: Kconfig options for network configuration library
    :header: "Option name", "Description"
-   :widths: auto
+   :widths: 45 55
 
    ":kconfig:option:`CONFIG_NET_CONFIG_SETTINGS`", "This option controls whether the
    network system is configured or initialized at all. If not set, then the

--- a/doc/connectivity/networking/api/net_shell.rst
+++ b/doc/connectivity/networking/api/net_shell.rst
@@ -13,7 +13,7 @@ The following net-shell commands are implemented:
 
 .. csv-table:: net-shell commands
    :header: "Command", "Description"
-   :widths: auto
+   :widths: 15 85
 
    "net allocs", "Print network memory allocations. Only available if
    :kconfig:option:`CONFIG_NET_DEBUG_NET_PKT_ALLOC` is set."

--- a/doc/contribute/coding_guidelines/index.rst
+++ b/doc/contribute/coding_guidelines/index.rst
@@ -52,6 +52,7 @@ severity and the equivalent rules from other standards for reference.
 
 .. list-table:: Main rules
     :header-rows: 1
+    :widths: 17 14 43 12 14
 
     * -  MISRA C 2012
       -  Severity


### PR DESCRIPTION
This PR aims to improve table layout for four tables in Zephyr documentation. In all four cases, this is achieved by defining more appropriate column widths, so that they can accommodate their content more efficiently.

This will, for example, make very large MISRA-C rules table occupy only 9 pages, instead of current 18 pages, without sacrificing readability. In fact, its readability will be greatly improved.

Further example is the network Kconfig options table that will not exhibit text overlap between columns after this PR.

Similar effects will be present for remaining two tables.
