### PR TITLE
drivers: watchdog: it8xxx2: Prevent Kconfig option being wrongly shown

### DIFF
--- a/drivers/watchdog/Kconfig.it8xxx2
+++ b/drivers/watchdog/Kconfig.it8xxx2
@@ -12,6 +12,7 @@ config WDT_ITE_IT8XXX2
 
 config WDT_ITE_WARNING_LEADING_TIME_MS
 	int "Number of ms before generating watchdog event/signal"
+	depends on WDT_ITE_IT8XXX2
 	default 500
 	help
 	  This option defines the window in which a watchdog event must be
@@ -20,7 +21,7 @@ config WDT_ITE_WARNING_LEADING_TIME_MS
 
 config WDT_ITE_REDUCE_WARNING_LEADING_TIME
 	bool "Reduce warning leading time"
-	depends on SOC_IT8XXX2
+	depends on WDT_ITE_IT8XXX2
 	help
 	  Once warning timer triggered, if watchdog timer isn't reloaded,
 	  then we will reduce interval of warning timer to 30ms to print


### PR DESCRIPTION
    The it8xxx2 watchdog Kconfig options are always shown, for every type
    of device, they should only be shown when an it8xxx2 device is being
    targeted.