### PR TITLE
drivers: wifi: Fix four Coverity issues in esp_at/esp.c

### DIFF
--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -299,6 +299,7 @@ MODEM_CMD_DEFINE(on_cmd_cwlap)
 
 static void esp_dns_work(struct k_work *work)
 {
+#if defined(ESP_MAX_DNS)
 	struct esp_data *data = CONTAINER_OF(work, struct esp_data, dns_work);
 	struct dns_resolve_context *dnsctx;
 	struct sockaddr_in *addrs = data->dns_addresses;
@@ -320,11 +321,13 @@ static void esp_dns_work(struct k_work *work)
 	}
 
 	LOG_DBG("DNS resolver reconfigured");
+#endif
 }
 
 /* +CIPDNS:enable[,"DNS IP1"[,"DNS IP2"[,"DNS IP3"]]] */
 MODEM_CMD_DEFINE(on_cmd_cipdns)
 {
+#if defined(ESP_MAX_DNS)
 	struct esp_data *dev = CONTAINER_OF(data, struct esp_data,
 					    cmd_handler_data);
 	struct sockaddr_in *addrs = dev->dns_addresses;
@@ -360,6 +363,7 @@ MODEM_CMD_DEFINE(on_cmd_cipdns)
 	if (valid_servers) {
 		k_work_submit(&dev->dns_work);
 	}
+#endif
 
 	return 0;
 }

--- a/drivers/wifi/esp_at/esp.h
+++ b/drivers/wifi/esp_at/esp.h
@@ -81,8 +81,6 @@ extern "C" {
 
 #if defined(CONFIG_WIFI_ESP_AT_DNS_USE)
 #define ESP_MAX_DNS	MIN(3, CONFIG_DNS_RESOLVER_MAX_SERVERS)
-#else
-#define ESP_MAX_DNS	0
 #endif
 
 #define ESP_MAX_SOCKETS 5
@@ -227,7 +225,9 @@ struct esp_data {
 	struct in_addr gw;
 	struct in_addr nm;
 	uint8_t mac_addr[6];
+#if defined(ESP_MAX_DNS)
 	struct sockaddr_in dns_addresses[ESP_MAX_DNS];
+#endif
 
 	/* modem context */
 	struct modem_context mctx;


### PR DESCRIPTION
Fix following Coverity issues:

    Coverity-CID: 219490
    Coverity-CID: 219524
    Coverity-CID: 219520
    Coverity-CID: 219513

They deal with logical expressions always evaluated to false, and unreachable code. They all originate from a single file, drivers/wifi/esp_at/esp.c. Related header drivers/wifi/esp_at/esp.h turns out to be involved as well.

If the preprocessor constant ESP_MAX_DNS is equal to 0, Coverity reports a condition that can never be true, and some dead code as well. This also violates MISRA rules on dead code.

This is caused by this segment in drivers/wifi/esp_at/esp.h:

```
 #if defined(CONFIG_WIFI_ESP_AT_DNS_USE)
 #define ESP_MAX_DNS	MIN(3, CONFIG_DNS_RESOLVER_MAX_SERVERS)
 #else
 #define ESP_MAX_DNS	0
 #endif
```
The problematic part is the case of defining ESP_MAX_DNS as 0, and for that case all Coverity issues arise.

Fix this by never setting ESP_MAX_DNS to 0, as is the currently case. Define ESP_MAX_DNS only if it is configured through CONFIG_WIFI_ESP_AT_DNS_USE and CONFIG_DNS_RESOLVER_MAX_SERVERS:

```
 #if defined(CONFIG_WIFI_ESP_AT_DNS_USE)
 #define ESP_MAX_DNS	MIN(3, CONFIG_DNS_RESOLVER_MAX_SERVERS)
 #endif
```

Since CONFIG_DNS_RESOLVER_MAX_SERVERS is 1 or greater, ESP_MAX_DNS will always be greater than 0.

If, on the other hand, ESP_MAX_DNS is not defined, relevant functions will be reduced to empty stubs, since in that case they do not make sense.

There could be a cleaner solution to this, but this one is the least intrusive (involves less code changes).