### PR TITLE
semihosting: fix inline assembly output dependency

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/semihost.c
+++ b/arch/arm/core/aarch32/cortex_a_r/semihost.c
@@ -19,9 +19,11 @@ long semihost_exec(enum semihost_instr instr, void *args)
 	register long ret __asm__ ("r0");
 
 	if (IS_ENABLED(CONFIG_ISA_THUMB2)) {
-		__asm__ __volatile__ ("svc 0xab" : : "r" (r0), "r" (r1) : "memory");
+		__asm__ __volatile__ ("svc 0xab"
+				      : "=r" (ret) : "r" (r0), "r" (r1) : "memory");
 	} else {
-		__asm__ __volatile__ ("svc 0x123456" : : "r" (r0), "r" (r1) : "memory");
+		__asm__ __volatile__ ("svc 0x123456"
+				      : "=r" (ret) : "r" (r0), "r" (r1) : "memory");
 	}
 	return ret;
 }

--- a/arch/arm/core/aarch32/cortex_m/semihost.c
+++ b/arch/arm/core/aarch32/cortex_m/semihost.c
@@ -13,6 +13,7 @@ long semihost_exec(enum semihost_instr instr, void *args)
 	register void *r1 __asm__ ("r1") = args;
 	register int ret __asm__ ("r0");
 
-	__asm__ __volatile__ ("bkpt 0xab" : : "r" (r0), "r" (r1) : "memory");
+	__asm__ __volatile__ ("bkpt 0xab"
+			      : "=r" (ret) : "r" (r0), "r" (r1) : "memory");
 	return ret;
 }

--- a/arch/arm64/core/semihost.c
+++ b/arch/arm64/core/semihost.c
@@ -13,6 +13,7 @@ long semihost_exec(enum semihost_instr instr, void *args)
 	register void *x1 __asm__ ("x1") = args;
 	register long ret __asm__ ("x0");
 
-	__asm__ volatile ("hlt 0xf000" : : "r" (w0), "r" (x1) : "memory");
+	__asm__ volatile ("hlt 0xf000"
+			  : "=r" (ret) : "r" (w0), "r" (x1) : "memory");
 	return ret;
 }

--- a/arch/riscv/core/semihost.c
+++ b/arch/riscv/core/semihost.c
@@ -20,7 +20,7 @@ long semihost_exec(enum semihost_instr instr, void *args)
 		"ebreak\n\t"
 		"srai zero, zero, 0x7\n\t"
 		".option pop"
-		: : "r" (a0), "r" (a1) : "memory");
+		: "=r" (ret) : "r" (a0), "r" (a1) : "memory");
 
 	return ret;
 }


### PR DESCRIPTION
Commit d8f186aa4a18 ("arch: common: semihost: add semihosting
operations") encapsulated semihosting invocation in a per-arch
semihost_exec() function. There is a fixed register variable declaration
for the return value but this variable is not listed as an output
operand to respective inline assembly segments which is an error.
This is not reported as such by gcc and the generated code is still OK
in those particular instances but this is not guaranteed, and clang
does complain about such cases.
