### PR TITLE
drivers: modem: Fix Coverity issue in ublox-sara-r4.c

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -368,6 +368,11 @@ static ssize_t send_socket_data(void *obj,
 		}
 
 		ret = modem_context_get_addr_port(dst_addr, &dst_port);
+		if (ret != 0) {
+			LOG_ERR("Error getting port from IP address %d", ret);
+			goto exit;
+		}
+
 		snprintk(send_buf, sizeof(send_buf),
 			 "AT+USOST=%d,\"%s\",%u,%zu", sock->id,
 			 ip_str,


### PR DESCRIPTION
Coverity reported unused value for a variable "ret" in the function
send_socket_data(). Indeed there were two subsequent assignments
to "ret", meaning that the first one was unused.

The root cause of the problem is not checking the value of "ret"
after correctly invoking a function within send_socket_data(). Fix
this by adding appropriate checks.

Coverity-CID: 215249

Signed-off-by: Aleksandar Markovic <aleksandar.markovic.sa@gmail.com>