### PR TITLE
dts: stm32wb55Xg: fix sram size

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -6,7 +6,7 @@ toolchain:
   - zephyr
   - gnuarmemb
   - xtools
-ram: 96
+ram: 192
 flash: 1024
 supported:
   - gpio

--- a/dts/arm/st/wb/stm32wb55Xg.dtsi
+++ b/dts/arm/st/wb/stm32wb55Xg.dtsi
@@ -8,7 +8,7 @@
 
 / {
 	sram0: memory@20000000 {
-		reg = <0x20000000 DT_SIZE_K(96)>;
+		reg = <0x20000000 DT_SIZE_K(192)>;
 	};
 
 	soc {


### PR DESCRIPTION
STM32WB55xG MCUs include 256 KiB of SRAM split into three blocks. The size of the main block is 192 KiB, and not 96 KiB as it was specified in the device tree. This PR:
* Fixes the issue.
* Updates the definition of the NUCLEO-WB55 board, based on a STM32WB55RG MCU.

SRAM size is specified in the datasheet [DS19929](https://www.st.com/resource/en/datasheet/stm32wb55rg.pdf), p. 14.