### PR TITLE
soc: rpi_pico: Fix enabling i2c on rpi_pico

### DIFF
--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -6,6 +6,7 @@
 
 #include <arm/armv6-m.dtsi>
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 #include "rpi_pico_common.dtsi"

--- a/soc/arm/rpi_pico/rp2/Kconfig.series
+++ b/soc/arm/rpi_pico/rp2/Kconfig.series
@@ -13,6 +13,7 @@ config SOC_SERIES_RP2XXX
 	select CPU_HAS_ARM_MPU
 	select SOC_FAMILY_RPI_PICO
 	select HAS_RPI_PICO
+	select HAS_I2C_DW if I2C
 	select XIP
 	help
 	  Enable support for Raspberry Pi RP2 MCU series


### PR DESCRIPTION
Select HAS_I2C_DW for RP2040 SoC, and include the
i2c dt-bindings header.

Signed-off-by: Peter Johanson <peter@peterjohanson.com>


Found this when testing the RP2040 I2C support. This allows the designware driver to actually be accessible and be enabled, and adds the standard dt-bindings header for things like the clock-frequency vaiues.