### PR TITLE
samples: cdc_acm_composite: Use proper type for variable 'read'

### DIFF
--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -50,7 +50,8 @@ static void interrupt_handler(const struct device *dev, void *user_data)
 
 		if (uart_irq_rx_ready(dev)) {
 			uint8_t buf[64];
-			size_t read, wrote;
+			int read;
+			size_t wrote;
 			struct ring_buf *rb = &peer->data->rb;
 
 			read = uart_fifo_read(dev, buf, sizeof(buf));


### PR DESCRIPTION
Function uart_fifo_read() returns 'int' (it may return negative values
in error cases). Its return value is stored in the variable 'read' that
is, however, of type 'size_t'.

Change the type of the variable 'read' from 'size_t' to 'int' to
accomodate proper handling of uart_fifo_read() invocation.

Coverity-CID: 248408

Signed-off-by: Aleksandar Markovic <aleksandar.markovic.sa@gmail.com>