### PR TITLE
ci: Support running tests using ARM FVP emulator

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: zephyr_runner
     needs: clang-build-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci-internal:v0.23.3.0
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: zephyr_runner
     needs: codecov-prep
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci-internal:v0.23.3.0
       options: '--entrypoint /bin/bash'
     strategy:
       fail-fast: false

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: zephyr_runner
     needs: twister-build-cleanup
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci-internal:v0.23.3.0
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject
@@ -120,7 +120,7 @@ jobs:
     needs: twister-build-prep
     if: needs.twister-build-prep.outputs.size != 0
     container:
-      image: ghcr.io/zephyrproject-rtos/ci:v0.23.3
+      image: ghcr.io/zephyrproject-rtos/ci-internal:v0.23.3.0
       options: '--entrypoint /bin/bash'
       volumes:
         - /home/runners/zephyrproject:/github/cache/zephyrproject

--- a/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.yaml
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.yaml
@@ -6,6 +6,7 @@ identifier: fvp_baser_aemv8r_aarch32
 name: FVP Emulation FVP_BaseR_AEMv8R AArch32
 arch: arm
 type: sim
+simulation: armfvp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.yaml
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.yaml
@@ -12,3 +12,5 @@ toolchain:
   - cross-compile
 ram: 2048
 flash: 64
+testing:
+  default: true

--- a/boards/arm/mps3_an547/mps3_an547.yaml
+++ b/boards/arm/mps3_an547/mps3_an547.yaml
@@ -16,6 +16,7 @@ toolchain:
 supported:
   - gpio
 testing:
+  default: true
   ignore_tags:
     - drivers
     - bluetooth

--- a/boards/arm/mps3_an547/mps3_an547.yaml
+++ b/boards/arm/mps3_an547/mps3_an547.yaml
@@ -8,7 +8,7 @@ identifier: mps3_an547
 name: Arm MPS3-AN547
 type: mcu
 arch: arm
-simulation: qemu
+simulation: armfvp
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm/mps3_an547/mps3_an547_ns.yaml
+++ b/boards/arm/mps3_an547/mps3_an547_ns.yaml
@@ -8,7 +8,7 @@ identifier: mps3_an547_ns
 name: Arm MPS3-AN547_ns
 type: mcu
 arch: arm
-simulation: qemu
+simulation: armfvp
 toolchain:
   - gnuarmemb
   - zephyr

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
@@ -5,6 +5,7 @@ identifier: fvp_base_revc_2xaemv8a
 name: FVP Emulation FVP_Base_RevC-2xAEMvA
 arch: arm64
 type: sim
+simulation: armfvp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.yaml
@@ -11,3 +11,5 @@ toolchain:
   - cross-compile
 ram: 2048
 flash: 64
+testing:
+  default: true

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.yaml
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.yaml
@@ -5,6 +5,7 @@ identifier: fvp_baser_aemv8r
 name: FVP Emulation FVP_BaseR_AEMv8R
 arch: arm64
 type: sim
+simulation: armfvp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.yaml
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.yaml
@@ -11,3 +11,5 @@ toolchain:
   - cross-compile
 ram: 2048
 flash: 64
+testing:
+  default: true

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r_smp.yaml
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r_smp.yaml
@@ -5,6 +5,7 @@ identifier: fvp_baser_aemv8r_smp
 name: FVP Emulation FVP_BaseR_AEMv8R
 arch: arm64
 type: sim
+simulation: armfvp
 toolchain:
   - zephyr
   - cross-compile

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r_smp.yaml
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r_smp.yaml
@@ -13,3 +13,4 @@ ram: 2048
 flash: 64
 testing:
   timeout_multiplier: 8
+  default: true

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2251,6 +2251,10 @@ class TestInstance(DisablePyTestCollectionMixin):
             if not find_executable("tsim-leon3"):
                 target_ready = False
 
+        if self.platform.simulation == "armfvp":
+            if not os.getenv("ARMFVP_BIN_PATH"):
+                target_ready = False
+
         testsuite_runnable = self.testsuite_runnable(self.testsuite, fixtures)
 
         return testsuite_runnable and target_ready


### PR DESCRIPTION
This series adds support for running tests using the ARM FVP emulator in the CI.

The ARM FVP cannot be included in the public CI Docker image due to licensing issues (redistribution is prohibited by the EULA), so a private CI Docker image (`docker-internal`) has been created.

The private CI Docker image includes the following ARM FVP models (note that the scope of this image may be expanded to include other proprietary toolchains in the future):

* FVP_BaseR_AEMv8R
* FVP_Base_RevC-2xAEMvA
* FVP_Corstone_SSE-300_Ethos-U55

With this, the following platforms, some of which were not being run at all, can now be tested in the CI:

* fvp_baser_aemv8r
* fvp_base_revc_2xaemv8a
* mps3_an547 (was previously using QEMU, but now uses FVP with more advanced emulation features such as the emulation of the Ethos-U NPU).

Closes #43852

Requires #45108, #45110, #45111 to be fixed prior to merging