### PR TITLE
tests: ipv6: Fix DAD timeout test

### DIFF
--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -1106,14 +1106,9 @@ static void test_dad_timeout(void)
 
 	k_sleep(K_MSEC(200));
 
-	/* We should have received three DAD queries, make sure they are in
-	 * proper order.
-	 */
-	zassert_true(dad_time[0] < dad_time[1], "DAD timer 1+2 failure");
-	zassert_true(dad_time[1] < dad_time[2], "DAD timer 2+3 failure");
-	zassert_true((dad_time[2] - dad_time[0]) < 100,
-		     "DAD timers took too long time [%u] [%u] [%u]",
-		     dad_time[0], dad_time[1], dad_time[2]);
+	/* Check we have received three DAD queries */
+	zassert_true((dad_time[0] != 0U) && (dad_time[1] != 0U) &&
+			(dad_time[2] != 0U), "Did not get DAD reply");
 #endif
 }
 


### PR DESCRIPTION
DAD timeout was wrongly checking the reply order. The code will always
assign sequentially the reply to 0-2 with the current uptime. This means
that we will always have dad[0] < dad[1] < dad[2]. Check it is useless.
Instead, let just check if we got all replies.

The test checking the time between the first and last request is to
fragile. It is testing a constant independently of the tested platform
failing in several of them. Just remove it.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>