### PR TITLE
Bluetooth: Mesh: encapsulate tinycrypt dependency

### DIFF
--- a/subsys/bluetooth/mesh/crypto.c
+++ b/subsys/bluetooth/mesh/crypto.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,12 +18,14 @@
 #include <tinycrypt/aes.h>
 #include <tinycrypt/cmac_mode.h>
 #include <tinycrypt/ccm_mode.h>
+#include <tinycrypt/ecc.h>
+#include <tinycrypt/ecc_dh.h>
 
 #include <bluetooth/mesh.h>
 #include <bluetooth/crypto.h>
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_MESH_DEBUG_CRYPTO)
-#define LOG_MODULE_NAME bt_mesh_crypto
+#define LOG_MODULE_NAME bt_mesh_tc_crypto
 #include "common/log.h"
 
 #include "mesh.h"
@@ -31,8 +34,13 @@
 #define NET_MIC_LEN(pdu) (((pdu)[1] & 0x80) ? 8 : 4)
 #define APP_MIC_LEN(aszmic) ((aszmic) ? 8 : 4)
 
-int bt_mesh_aes_cmac(const uint8_t key[16], struct bt_mesh_sg *sg,
-		     size_t sg_len, uint8_t mac[16])
+struct bt_mesh_sg {
+	const void *data;
+	size_t len;
+};
+
+static int bt_mesh_aes_cmac(const uint8_t key[16], struct bt_mesh_sg *sg,
+			size_t sg_len, uint8_t mac[16])
 {
 	struct tc_aes_key_sched_struct sched;
 	struct tc_cmac_struct state;
@@ -53,6 +61,21 @@ int bt_mesh_aes_cmac(const uint8_t key[16], struct bt_mesh_sg *sg,
 	}
 
 	return 0;
+}
+
+static int bt_mesh_aes_cmac_one(const uint8_t key[16], const void *m,
+				size_t len, uint8_t mac[16])
+{
+	struct bt_mesh_sg sg = { m, len };
+
+	return bt_mesh_aes_cmac(key, &sg, 1, mac);
+}
+
+int bt_mesh_s1(const char *m, uint8_t salt[16])
+{
+	const uint8_t zero[16] = { 0 };
+
+	return bt_mesh_aes_cmac_one(zero, m, strlen(m), salt);
 }
 
 int bt_mesh_k1(const uint8_t *ikm, size_t ikm_len, const uint8_t salt[16],
@@ -491,6 +514,19 @@ int bt_mesh_virtual_addr(const uint8_t virtual_label[16], uint16_t *addr)
 	return 0;
 }
 
+int bt_mesh_prov_salt(const uint8_t conf_salt[16], const uint8_t prov_rand[16],
+		      const uint8_t dev_rand[16], uint8_t prov_salt[16])
+{
+	const uint8_t prov_salt_key[16] = { 0 };
+	struct bt_mesh_sg sg[] = {
+		{ conf_salt, 16 },
+		{ prov_rand, 16 },
+		{ dev_rand, 16 },
+	};
+
+	return bt_mesh_aes_cmac(prov_salt_key, sg, ARRAY_SIZE(sg), prov_salt);
+}
+
 int bt_mesh_prov_conf_salt(const uint8_t conf_inputs[145], uint8_t salt[16])
 {
 	const uint8_t conf_salt_key[16] = { 0 };
@@ -551,4 +587,18 @@ int bt_mesh_beacon_auth(const uint8_t beacon_key[16], uint8_t flags,
 	}
 
 	return err;
+}
+
+int bt_mesh_dhkey_gen(const uint8_t *pub_key, const uint8_t *priv_key, uint8_t *dhkey)
+{
+	if (uECC_valid_public_key(pub_key, &curve_secp256r1)) {
+		BT_ERR("Public key is not valid");
+		return -EIO;
+	} else if (uECC_shared_secret(pub_key, priv_key, dhkey,
+				&curve_secp256r1) != TC_CRYPTO_SUCCESS) {
+		BT_ERR("DHKey generation failed");
+		return -EIO;
+	}
+
+	return 0;
 }

--- a/subsys/bluetooth/mesh/crypto.h
+++ b/subsys/bluetooth/mesh/crypto.h
@@ -1,40 +1,14 @@
 /*
  * Copyright (c) 2017 Intel Corporation
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-struct bt_mesh_sg {
-	const void *data;
-	size_t len;
-};
-
-int bt_mesh_aes_cmac(const uint8_t key[16], struct bt_mesh_sg *sg,
-		     size_t sg_len, uint8_t mac[16]);
-
-static inline int bt_mesh_aes_cmac_one(const uint8_t key[16], const void *m,
-				       size_t len, uint8_t mac[16])
-{
-	struct bt_mesh_sg sg = { m, len };
-
-	return bt_mesh_aes_cmac(key, &sg, 1, mac);
-}
-
-static inline bool bt_mesh_s1(const char *m, uint8_t salt[16])
-{
-	const uint8_t zero[16] = { 0 };
-
-	return bt_mesh_aes_cmac_one(zero, m, strlen(m), salt);
-}
+int bt_mesh_s1(const char *m, uint8_t salt[16]);
 
 int bt_mesh_k1(const uint8_t *ikm, size_t ikm_len, const uint8_t salt[16],
 	       const char *info, uint8_t okm[16]);
-
-#define bt_mesh_k1_str(ikm, ikm_len, salt_str, info, okm) \
-({ \
-	const uint8_t salt[16] = salt_str; \
-	bt_mesh_k1(ikm, ikm_len, salt, info, okm); \
-})
 
 int bt_mesh_k2(const uint8_t n[16], const uint8_t *p, size_t p_len,
 	       uint8_t net_id[1], uint8_t enc_key[16], uint8_t priv_key[16]);
@@ -48,7 +22,9 @@ int bt_mesh_id128(const uint8_t n[16], const char *s, uint8_t out[16]);
 static inline int bt_mesh_id_resolving_key(const uint8_t net_key[16],
 					   uint8_t resolving_key[16])
 {
-	return bt_mesh_k1_str(net_key, 16, "smbt", "smbi", resolving_key);
+	const uint8_t salt[16] = "smbt";
+
+	return bt_mesh_k1(net_key, 16, salt, "smbi", resolving_key);
 }
 
 static inline int bt_mesh_identity_key(const uint8_t net_key[16],
@@ -101,20 +77,8 @@ static inline int bt_mesh_dev_key(const uint8_t dhkey[32],
 	return bt_mesh_k1(dhkey, 32, prov_salt, "prdk", dev_key);
 }
 
-static inline int bt_mesh_prov_salt(const uint8_t conf_salt[16],
-				    const uint8_t prov_rand[16],
-				    const uint8_t dev_rand[16],
-				    uint8_t prov_salt[16])
-{
-	const uint8_t prov_salt_key[16] = { 0 };
-	struct bt_mesh_sg sg[] = {
-		{ conf_salt, 16 },
-		{ prov_rand, 16 },
-		{ dev_rand, 16 },
-	};
-
-	return bt_mesh_aes_cmac(prov_salt_key, sg, ARRAY_SIZE(sg), prov_salt);
-}
+int bt_mesh_prov_salt(const uint8_t conf_salt[16], const uint8_t prov_rand[16],
+		      const uint8_t dev_rand[16], uint8_t prov_salt[16]);
 
 int bt_mesh_net_obfuscate(uint8_t *pdu, uint32_t iv_index,
 			  const uint8_t privacy_key[16]);
@@ -163,3 +127,5 @@ int bt_mesh_prov_decrypt(const uint8_t key[16], uint8_t nonce[13],
 
 int bt_mesh_prov_encrypt(const uint8_t key[16], uint8_t nonce[13],
 			 const uint8_t data[25], uint8_t out[25 + 8]);
+
+int bt_mesh_dhkey_gen(const uint8_t *pub_key, const uint8_t *priv_key, uint8_t *dhkey);

--- a/subsys/bluetooth/mesh/prov_device.c
+++ b/subsys/bluetooth/mesh/prov_device.c
@@ -11,10 +11,6 @@
 #include <sys/util.h>
 #include <sys/byteorder.h>
 
-#include <tinycrypt/constants.h>
-#include <tinycrypt/ecc.h>
-#include <tinycrypt/ecc_dh.h>
-
 #include <net/buf.h>
 #include <bluetooth/bluetooth.h>
 #include <bluetooth/conn.h>
@@ -321,18 +317,14 @@ static void prov_dh_key_gen(void)
 
 	if (IS_ENABLED(CONFIG_BT_MESH_PROV_OOB_PUBLIC_KEY) &&
 	    atomic_test_bit(bt_mesh_prov_link.flags, OOB_PUB_KEY)) {
-		if (uECC_valid_public_key(remote_pk, &curve_secp256r1)) {
-			BT_ERR("Public key is not valid");
-		} else if (uECC_shared_secret(remote_pk, bt_mesh_prov->private_key_be,
-					      bt_mesh_prov_link.dhkey,
-					      &curve_secp256r1) != TC_CRYPTO_SUCCESS) {
-			BT_ERR("DHKey generation failed");
-		} else {
-			dh_key_gen_complete();
+
+		if (bt_mesh_dhkey_gen(remote_pk, bt_mesh_prov->private_key_be,
+				bt_mesh_prov_link.dhkey)) {
+			prov_fail(PROV_ERR_UNEXP_ERR);
 			return;
 		}
 
-		prov_fail(PROV_ERR_UNEXP_ERR);
+		dh_key_gen_complete();
 		return;
 	}
 


### PR DESCRIPTION
Bluetooth Mesh uses tinycrypt library for security related
algorithms. This PR encapsulates tinycrypt dependency within
one file to make the current implementation more portable.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>