### PR TITLE
tests: Misc test fixes for fvp_base_revc_2xaemv8a

### DIFF
--- a/tests/kernel/mem_protect/mem_map/boards/fvp_base_revc_2xaemv8a.conf
+++ b/tests/kernel/mem_protect/mem_map/boards/fvp_base_revc_2xaemv8a.conf
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+# Simply needs more space for the translation table
+# for the mapping exhaustion test.
+CONFIG_MAX_XLAT_TABLES=16

--- a/tests/kernel/mem_protect/syscalls/src/main.c
+++ b/tests/kernel/mem_protect/syscalls/src/main.c
@@ -12,7 +12,12 @@
 #include <mmu.h>
 
 #define BUF_SIZE	32
+
+#if defined(CONFIG_BOARD_FVP_BASE_REVC_2XAEMV8A)
+#define SLEEP_MS_LONG	30000
+#else
 #define SLEEP_MS_LONG	15000
+#endif
 
 #if defined(CONFIG_BOARD_NUCLEO_F429ZI) || defined(CONFIG_BOARD_NUCLEO_F207ZG) \
 	|| defined(CONFIG_BOARD_NUCLEO_L073RZ) \
@@ -375,8 +380,8 @@ void test_syscall_torture(void)
 				2, K_INHERIT_PERMS | K_USER, K_NO_WAIT);
 	}
 
-	/* Let the torture threads hog the system for 15 seconds before we
-	 * abort them.
+	/* Let the torture threads hog the system for several seconds before
+	 * we abort them.
 	 * They will all be hammering the cpu(s) with system calls,
 	 * hopefully smoking out any issues and causing a crash.
 	 */

--- a/tests/kernel/mem_protect/syscalls/testcase.yaml
+++ b/tests/kernel/mem_protect/syscalls/testcase.yaml
@@ -5,3 +5,4 @@ tests:
     # FIXME: This test may fail for qemu_arc_em on certain host systems.
     #        See foss-for-synopsys-dwc-arc-processors/qemu#66.
     platform_exclude: qemu_arc_em
+    timeout: 180

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -120,7 +120,7 @@ __no_optimization static void trigger_fault_divide_zero(void)
 	defined(CONFIG_BOARD_QEMU_CORTEX_A53) || defined(CONFIG_SOC_QEMU_ARC) || \
 	defined(CONFIG_ARMV6_M_ARMV8_M_BASELINE) || \
 	defined(CONFIG_BOARD_QEMU_CORTEX_R5) || \
-	defined(CONFIG_BOARD_FVP_BASER_AEMV8R)
+	defined(CONFIG_BOARD_FVP_BASER_AEMV8R) || defined(CONFIG_BOARD_FVP_BASE_REVC_2XAEMV8A)
 	ztest_test_skip();
 #endif
 }


### PR DESCRIPTION
Fix several tests for the `fvp_base_revc_2xaemv8a` board.

See https://github.com/zephyrproject-rtos/zephyr/issues/43852#issuecomment-1107855478 

Fixes #45111 