### PR TITLE
Bluetooth: Fix compilation for entropy_bt_hci

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -9,7 +9,7 @@ config BOARD
 	default "nrf5340dk_nrf5340_cpuapp" if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
 config ENTROPY_BT_HCI
-	default y if BT_HCI
+	default y if BT_HCI_HOST
 	depends on ENTROPY_GENERATOR
 
 # By default, if we build for a Non-Secure version of the board,

--- a/drivers/entropy/Kconfig.bt_hci
+++ b/drivers/entropy/Kconfig.bt_hci
@@ -4,7 +4,7 @@
 
 config ENTROPY_BT_HCI
 	bool "Bluetooth HCI RNG driver"
-	depends on BT_HCI
+	depends on BT_HCI_HOST
 	select ENTROPY_HAS_DRIVER
 	help
 	  Enable Random Number Generator from a Bluetooth HCI device.


### PR DESCRIPTION
An application with the following config fails to link on nrf53 app core:

```
CONFIG_BT=y
CONFIG_BT_HCI_RAW=y
CONFIG_ENTROPY_GENERATOR=y
```

This happens because `entropy_bt_hci.c` uses functions from
`hci_core.c`, which is only compiled if `BT_HCI_HOST` is selected.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>

---

To reproduce check out https://github.com/hermabe/zephyr/commit/36f624cf462c9e367b20a48de1b96635310ef21d and run `west build -b nrf5340dk_nrf5340_cpuapp tests/bluetooth/entropy/ --build-dir build -p`. This results in two unresolved symbols: `bt_is_ready` and `bt_hci_le_rand`.

This entropy source was added in https://github.com/zephyrproject-rtos/zephyr/pull/41424 by @JordanYates. If the entropy source is supposed to be available with `CONFIG_BT_HCI_RAW` it must be rewritten to not use anything from `hci_core.c`.