### PR TITLE
drivers: sensor: lis3mdl: return -ENOTSUP on unsupported channels

### DIFF
--- a/drivers/sensor/lis3mdl/lis3mdl.c
+++ b/drivers/sensor/lis3mdl/lis3mdl.c
@@ -49,10 +49,12 @@ static int lis3mdl_channel_get(const struct device *dev,
 	} else if (chan == SENSOR_CHAN_MAGN_Z) {
 		lis3mdl_convert(val, drv_data->z_sample,
 				lis3mdl_magn_gain[LIS3MDL_FS_IDX]);
-	} else { /* chan == SENSOR_CHAN_DIE_TEMP */
+	} else if (chan == SENSOR_CHAN_DIE_TEMP) {
 		/* temp_val = 25 + sample / 8 */
 		lis3mdl_convert(val, drv_data->temp_sample, 8);
 		val->val1 += 25;
+	} else {
+		return -ENOTSUP;
 	}
 
 	return 0;


### PR DESCRIPTION
`sensor_channel_get()` API should return `-ENOTSUP` when requested channel
is not supported. This behavior allows to use `sensor get DEVNAME` shell
command easily, as all unsupported channels are filtered out.