### PR TITLE
dts: bindings: nordic,nrf-qdec: Remove requirement for a-pin and b-bin

### DIFF
--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -16,7 +16,7 @@ properties:
 
     a-pin:
       type: int
-      required: true
+      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled. It will be deprecated in the future.
@@ -35,7 +35,7 @@ properties:
 
     b-pin:
       type: int
-      required: true
+      required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
         is not enabled. It will be deprecated in the future.


### PR DESCRIPTION
This is a follow-up to commit 1a01ca2adf9cb57bb7bcdaf4af780e56fc1f9e8b.

Since support for pinctrl has been added to the qdec_nrfx driver,
the related binding can no longer require the `a-pin` and `b-pin`
properties to be defined.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>