### PR TITLE
Bluetooth: Audio: Remove codec from bt_audio_broadcast_sink_sync

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -2093,10 +2093,9 @@ int bt_audio_broadcast_sink_scan_stop(void);
  *  @param indexes_bitfield   Bitfield of the BIS index to sync to. To sync to
  *                            e.g. BIS index 1 and 2, this should have the value
  *                            of BIT(1) | BIT(2).
- *  @param streams            Stream object pointerss to be used for the
+ *  @param streams            Stream objects pointers to be used for the
  *                            receiver. If multiple BIS indexes shall be
  *                            synchronized, multiple streams shall be provided.
- *  @param codec              Codec configuration.
  *  @param broadcast_code     The 16-octet broadcast code. Shall be supplied if
  *                            the broadcast is encrypted (see the syncable
  *                            callback).
@@ -2106,7 +2105,6 @@ int bt_audio_broadcast_sink_scan_stop(void);
 int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 				 uint32_t indexes_bitfield,
 				 struct bt_audio_stream *streams[],
-				 struct bt_codec *codec,
 				 const uint8_t broadcast_code[16]);
 
 /** @brief Stop audio broadcast sink.

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -17,11 +17,6 @@ static K_SEM_DEFINE(sem_pa_sync_lost, 0U, 1U);
 static struct bt_audio_broadcast_sink *broadcast_sink;
 static struct bt_audio_stream streams[CONFIG_BT_AUDIO_BROADCAST_SNK_STREAM_COUNT];
 
-/* Mandatory support preset by both source and sink */
-static struct bt_audio_lc3_preset preset_16_2_1 =
-	BT_AUDIO_LC3_BROADCAST_PRESET_16_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,
-					     BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
-
 /* Create a mask for the maximum BIS we can sync to using the number of streams
  * we have. We add an additional 1 since the bis indexes start from 1 and not
  * 0.
@@ -242,7 +237,7 @@ void main(void)
 		err = bt_audio_broadcast_sink_sync(broadcast_sink,
 						   bis_index_bitfield,
 						   streams_p,
-						   &preset_16_2_1.codec, NULL);
+						   NULL);
 		if (err != 0) {
 			printk("Unable to sync to broadcast source: %d\n", err);
 			return;

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -492,16 +492,15 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 	}
 
 	codec_qos.pd = net_buf_simple_pull_le24(&net_buf);
-	sink->subgroup_count = net_buf_simple_pull_u8(&net_buf);
+	base.subgroup_count = net_buf_simple_pull_u8(&net_buf);
 
-	if (sink->subgroup_count > ARRAY_SIZE(base.subgroups)) {
+	if (base.subgroup_count > ARRAY_SIZE(base.subgroups)) {
 		BT_DBG("Cannot decode BASE with %u subgroups (max supported is %zu)",
-		       sink->subgroup_count, ARRAY_SIZE(base.subgroups));
+		       base.subgroup_count, ARRAY_SIZE(base.subgroups));
 
 		return false;
 	}
 
-	base.subgroup_count = sink->subgroup_count;
 	for (int i = 0; i < base.subgroup_count; i++) {
 		if (!net_buf_decode_subgroup(&net_buf, &base.subgroups[i])) {
 			BT_DBG("Failed to decode subgroup %d", i);
@@ -521,6 +520,11 @@ static bool pa_decode_base(struct bt_data *data, void *user_data)
 			return false;
 		}
 	}
+
+	/* We only overwrite the sink->base data once the base has successfully
+	 * been decoded to avoid overwriting it with invalid data
+	 */
+	(void)memcpy(&sink->base, &base, sizeof(base));
 
 	SYS_SLIST_FOR_EACH_CONTAINER(&sink_cbs, listener, node) {
 		if (listener->base_recv != NULL) {
@@ -900,13 +904,29 @@ static void broadcast_sink_cleanup(struct bt_audio_broadcast_sink *sink)
 	(void)memset(sink, 0, sizeof(*sink));
 }
 
+static struct bt_codec *codec_from_base_by_index(struct bt_audio_base *base,
+						 uint8_t index)
+{
+	for (size_t i = 0U; i < base->subgroup_count; i++) {
+		struct bt_audio_base_subgroup *subgroup = &base->subgroups[i];
+
+		for (size_t j = 0U; j < subgroup->bis_count; j++) {
+			if (subgroup->bis_data[j].index == index) {
+				return &subgroup->codec;
+			}
+		}
+	}
+
+	return NULL;
+}
+
 int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 				 uint32_t indexes_bitfield,
 				 struct bt_audio_stream *streams[],
-				 struct bt_codec *codec,
 				 const uint8_t broadcast_code[16])
 {
 	struct bt_iso_big_sync_param param;
+	struct bt_codec *codecs[BROADCAST_SNK_STREAM_CNT] = { NULL };
 	uint8_t stream_count;
 	int err;
 
@@ -953,7 +973,17 @@ int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 	stream_count = 0;
 	for (int i = 1; i < BT_ISO_MAX_GROUP_ISO_COUNT; i++) {
 		if ((indexes_bitfield & BIT(i)) != 0) {
-			stream_count++;
+			struct bt_codec *codec = codec_from_base_by_index(&sink->base, i);
+
+			__ASSERT(codec != NULL, "Codec[%d] was NULL", i);
+
+			codecs[stream_count++] = codec;
+
+			if (stream_count > BROADCAST_SNK_STREAM_CNT) {
+				BT_DBG("Cannot sync to more than %d streams",
+				       BROADCAST_SNK_STREAM_CNT);
+				return -EINVAL;
+			}
 		}
 	}
 
@@ -966,14 +996,15 @@ int bt_audio_broadcast_sink_sync(struct bt_audio_broadcast_sink *sink,
 
 	sink->stream_count = stream_count;
 	sink->streams = streams;
-	sink->codec = codec;
 	for (size_t i = 0; i < stream_count; i++) {
 		struct bt_audio_stream *stream;
+		struct bt_codec *codec;
 
 		stream = streams[i];
+		codec = codecs[i];
 
 		err = bt_audio_broadcast_sink_setup_stream(sink->index, stream,
-							   sink->codec);
+							   codec);
 		if (err != 0) {
 			BT_DBG("Failed to setup streams[%zu]: %d", i, err);
 			broadcast_sink_cleanup_streams(sink);

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -87,7 +87,6 @@ struct bt_audio_broadcast_source {
 struct bt_audio_broadcast_sink {
 	uint8_t index; /* index of broadcast_snks array */
 	uint8_t stream_count;
-	uint8_t subgroup_count;
 	uint16_t pa_interval;
 	uint16_t iso_interval;
 	uint16_t biginfo_num_bis;
@@ -95,8 +94,8 @@ struct bt_audio_broadcast_sink {
 	bool syncing;
 	bool big_encrypted;
 	uint32_t broadcast_id; /* 24 bit */
+	struct bt_audio_base base;
 	struct bt_le_per_adv_sync *pa_sync;
-	struct bt_codec *codec;
 	struct bt_iso_big *big;
 	struct bt_iso_chan *bis[BROADCAST_SNK_STREAM_CNT];
 	/* The streams used to create the broadcast sink */

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1290,9 +1290,7 @@ static int cmd_sync_broadcast(const struct shell *sh, size_t argc, char *argv[])
 	}
 
 	err = bt_audio_broadcast_sink_sync(default_sink, bis_bitfield,
-					   streams,
-					   &default_preset->preset.codec,
-					   NULL);
+					   streams, NULL);
 	if (err != 0) {
 		shell_error(sh, "Failed to sync to broadcast: %d", err);
 		return err;


### PR DESCRIPTION
The codec (or rather codec configuration) is now taken from the
previously received BASE. This also means that the BASE (with
the codec configurations) is now also stored statically.

When the application attempts to synk to the broadcaster
the stack will lookup the codec configuration based on the
bis index, as a BASE may have multiple subgroups
with multiple codec configurations.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/44455