### PR TITLE
dts: bindings: Add memory-region property

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -16,6 +16,7 @@
 #include <kernel.h>
 #include <soc.h>
 #include <helpers/nrfx_gppi.h>
+#include <linker/devicetree_regions.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);
@@ -86,7 +87,7 @@ struct uarte_async_cb {
 	const uint8_t *xfer_buf;
 	size_t xfer_len;
 
-	uint8_t tx_cache[CONFIG_UART_ASYNC_TX_CACHE_SIZE];
+	uint8_t *tx_cache;
 	size_t tx_cache_offset;
 
 	struct k_timer tx_timeout_timer;
@@ -144,8 +145,8 @@ struct uarte_nrfx_data {
 	struct uarte_async_cb *async;
 #endif
 	atomic_val_t poll_out_lock;
-	uint8_t char_out;
-	uint8_t rx_data;
+	uint8_t *char_out;
+	uint8_t *rx_data;
 	gppi_channel_t ppi_ch_endtx;
 };
 
@@ -776,7 +777,7 @@ static bool setup_tx_cache(struct uarte_nrfx_data *data)
 		return false;
 	}
 
-	size_t len = MIN(remaining, sizeof(data->async->tx_cache));
+	size_t len = MIN(remaining, CONFIG_UART_ASYNC_TX_CACHE_SIZE);
 
 	data->async->xfer_len = len;
 	data->async->xfer_buf = data->async->tx_cache;
@@ -1517,7 +1518,7 @@ static int uarte_nrfx_poll_in(const struct device *dev, unsigned char *c)
 		return -1;
 	}
 
-	*c = data->rx_data;
+	*c = *data->rx_data;
 
 	/* clear the interrupt */
 	nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
@@ -1559,8 +1560,8 @@ static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 		key = wait_tx_ready(dev);
 	}
 
-	data->char_out = c;
-	tx_start(dev, &data->char_out, 1);
+	*data->char_out = c;
+	tx_start(dev, data->char_out, 1);
 
 	irq_unlock(key);
 }
@@ -1580,9 +1581,7 @@ static int uarte_nrfx_fifo_fill(const struct device *dev,
 	}
 
 	/* Copy data to RAM buffer for EasyDMA transfer */
-	for (int i = 0; i < len; i++) {
-		data->int_driven->tx_buffer[i] = tx_data[i];
-	}
+	memcpy(data->int_driven->tx_buffer, tx_data, len);
 
 	int key = irq_lock();
 
@@ -1612,7 +1611,7 @@ static int uarte_nrfx_fifo_read(const struct device *dev,
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
 
 		/* Receive a character */
-		rx_data[num_rx++] = (uint8_t)data->rx_data;
+		rx_data[num_rx++] = *data->rx_data;
 
 		nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTRX);
 	}
@@ -1838,7 +1837,7 @@ static int uarte_instance_init(const struct device *dev,
 		if (!cfg->disable_rx) {
 			nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDRX);
 
-			nrf_uarte_rx_buffer_set(uarte, &data->rx_data, 1);
+			nrf_uarte_rx_buffer_set(uarte, data->rx_data, 1);
 			nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTRX);
 		}
 	}
@@ -1855,7 +1854,7 @@ static int uarte_instance_init(const struct device *dev,
 	 * Pointer to RAM variable (data->tx_buffer) is set because otherwise
 	 * such operation may result in HardFault or RAM corruption.
 	 */
-	nrf_uarte_tx_buffer_set(uarte, &data->char_out, 0);
+	nrf_uarte_tx_buffer_set(uarte, data->char_out, 0);
 	nrf_uarte_task_trigger(uarte, NRF_UARTE_TASK_STARTTX);
 
 	/* switch off transmitter to save an energy */
@@ -2019,7 +2018,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 #define UARTE_IRQ_CONFIGURE(idx, isr_handler)				       \
 	do {								       \
 		IRQ_CONNECT(DT_IRQN(UARTE(idx)), DT_IRQ(UARTE(idx), priority), \
-			    isr_handler, DEVICE_DT_GET(UARTE(idx)), 0); \
+			    isr_handler, DEVICE_DT_GET(UARTE(idx)), 0);	       \
 		irq_enable(DT_IRQN(UARTE(idx)));			       \
 	} while (0)
 
@@ -2039,7 +2038,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 /* Low power mode is used when rx pin is not defined or in async mode if
  * kconfig option is enabled.
  */
-#define USE_LOW_POWER(idx) \
+#define USE_LOW_POWER(idx)						       \
 	((UARTE_HAS_PROP(idx, rx_pin) &&				       \
 	COND_CODE_1(CONFIG_UART_##idx##_ASYNC,				       \
 		(!IS_ENABLED(CONFIG_UART_##idx##_NRF_ASYNC_LOW_POWER)),	       \
@@ -2055,6 +2054,8 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 	UARTE_INT_DRIVEN(idx);						       \
 	UARTE_ASYNC(idx);						       \
 	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(UARTE(idx));))	       \
+	static uint8_t uarte##idx##_char_out UARTE_MEMORY_SECTION(idx);	       \
+	static uint8_t uarte##idx##_rx_data UARTE_MEMORY_SECTION(idx);	       \
 	static struct uarte_nrfx_data uarte_##idx##_data = {		       \
 		UARTE_CONFIG(idx),					       \
 		IF_ENABLED(CONFIG_UART_##idx##_ASYNC,			       \
@@ -2082,7 +2083,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 			(IS_ENABLED(CONFIG_UART_##idx##_ENHANCED_POLL_OUT) ?   \
 				UARTE_CFG_FLAG_PPI_ENDTX : 0) |		       \
 			USE_LOW_POWER(idx),				       \
-		UARTE_DISABLE_RX_INIT(UARTE(idx)),				       \
+		UARTE_DISABLE_RX_INIT(UARTE(idx)),			       \
 		IF_ENABLED(CONFIG_UART_##idx##_NRF_HW_ASYNC,		       \
 			(.timer = NRFX_TIMER_INSTANCE(			       \
 				CONFIG_UART_##idx##_NRF_HW_ASYNC_TIMER),))     \
@@ -2109,6 +2110,8 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 		      &uart_nrfx_uarte_driver_api)
 
 #define UARTE_CONFIG(idx)						       \
+	.char_out = &uarte##idx##_char_out,				       \
+	.rx_data = &uarte##idx##_rx_data,				       \
 	.uart_config = {						       \
 		.baudrate = UARTE_PROP(idx, current_speed),		       \
 		.data_bits = UART_CFG_DATA_BITS_8,			       \
@@ -2116,28 +2119,39 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 		.parity = IS_ENABLED(CONFIG_UART_##idx##_NRF_PARITY_BIT)       \
 			  ? UART_CFG_PARITY_EVEN			       \
 			  : UART_CFG_PARITY_NONE,			       \
-		.flow_ctrl = UARTE_PROP(idx, hw_flow_control)  \
+		.flow_ctrl = UARTE_PROP(idx, hw_flow_control)		       \
 			     ? UART_CFG_FLOW_CTRL_RTS_CTS		       \
 			     : UART_CFG_FLOW_CTRL_NONE,			       \
 	}
 
 #define UARTE_ASYNC(idx)						       \
-	IF_ENABLED(CONFIG_UART_##idx##_ASYNC,				       \
-		(struct uarte_async_cb uarte##idx##_async = {		       \
+	IF_ENABLED(CONFIG_UART_##idx##_ASYNC, (				       \
+		static uint8_t						       \
+			uarte##idx##_tx_cache[CONFIG_UART_ASYNC_TX_CACHE_SIZE] \
+			UARTE_MEMORY_SECTION(idx);			       \
+		struct uarte_async_cb uarte##idx##_async = {		       \
+			.tx_cache = uarte##idx##_tx_cache,		       \
 			.hw_rx_counting =				       \
 				IS_ENABLED(CONFIG_UART_##idx##_NRF_HW_ASYNC),  \
 		}))
 
 #define UARTE_INT_DRIVEN(idx)						       \
-	IF_ENABLED(CONFIG_UART_##idx##_INTERRUPT_DRIVEN,	       \
-		(static uint8_t uarte##idx##_tx_buffer[\
-			MIN(CONFIG_UART_##idx##_NRF_TX_BUFFER_SIZE,	       \
-			    BIT_MASK(UARTE##idx##_EASYDMA_MAXCNT_SIZE))];      \
+	IF_ENABLED(CONFIG_UART_##idx##_INTERRUPT_DRIVEN,		       \
+		(static uint8_t uarte##idx##_tx_buffer			       \
+			[MIN(CONFIG_UART_##idx##_NRF_TX_BUFFER_SIZE,	       \
+			     BIT_MASK(UARTE##idx##_EASYDMA_MAXCNT_SIZE))]      \
+			UARTE_MEMORY_SECTION(idx);			       \
 		 static struct uarte_nrfx_int_driven			       \
 			uarte##idx##_int_driven = {			       \
 				.tx_buffer = uarte##idx##_tx_buffer,	       \
 				.tx_buff_size = sizeof(uarte##idx##_tx_buffer),\
 			};))
+
+#define UARTE_MEMORY_SECTION(idx)					       \
+	COND_CODE_1(UARTE_HAS_PROP(idx, memory_regions),		       \
+		(__attribute__((__section__(LINKER_DT_NODE_REGION_NAME(	       \
+			DT_PHANDLE(UARTE(idx), memory_regions)))))),	       \
+		())
 
 #ifdef CONFIG_UART_0_NRF_UARTE
 UART_NRF_UARTE_DEVICE(0);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -15,11 +15,16 @@
 #include <nrfx_spim.h>
 #include <hal/nrf_clock.h>
 #include <string.h>
+#include <linker/devicetree_regions.h>
 
 #include <logging/log.h>
 LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);
 
 #include "spi_context.h"
+
+#if (CONFIG_SPI_NRFX_RAM_BUFFER_SIZE > 0)
+#define SPI_BUFFER_IN_RAM 1
+#endif
 
 struct spi_nrfx_data {
 	struct spi_context ctx;
@@ -27,8 +32,8 @@ struct spi_nrfx_data {
 	size_t  chunk_len;
 	bool    busy;
 	bool    initialized;
-#if (CONFIG_SPI_NRFX_RAM_BUFFER_SIZE > 0)
-	uint8_t buffer[CONFIG_SPI_NRFX_RAM_BUFFER_SIZE];
+#if SPI_BUFFER_IN_RAM
+	uint8_t *buffer;
 #endif
 #ifdef CONFIG_SOC_NRF52832_ALLOW_SPIM_DESPITE_PAN_58
 	bool    anomaly_58_workaround_active;
@@ -291,8 +296,8 @@ static void transfer_next_chunk(const struct device *dev)
 		const uint8_t *tx_buf = ctx->tx_buf;
 #if (CONFIG_SPI_NRFX_RAM_BUFFER_SIZE > 0)
 		if (spi_context_tx_buf_on(ctx) && !nrfx_is_in_ram(tx_buf)) {
-			if (chunk_len > sizeof(dev_data->buffer)) {
-				chunk_len = sizeof(dev_data->buffer);
+			if (chunk_len > CONFIG_SPI_NRFX_RAM_BUFFER_SIZE) {
+				chunk_len = CONFIG_SPI_NRFX_RAM_BUFFER_SIZE;
 			}
 
 			memcpy(dev_data->buffer, tx_buf, chunk_len);
@@ -481,11 +486,12 @@ static int spim_nrfx_pm_action(const struct device *dev,
  * being operated on. Since DT_INST() makes no guarantees about that,
  * it won't work.
  */
-#define SPIM(idx) DT_NODELABEL(spi##idx)
-#define SPIM_PROP(idx, prop) DT_PROP(SPIM(idx), prop)
+#define SPIM(idx)			DT_NODELABEL(spi##idx)
+#define SPIM_PROP(idx, prop)		DT_PROP(SPIM(idx), prop)
+#define SPIM_HAS_PROP(idx, prop)	DT_NODE_HAS_PROP(SPIM(idx), prop)
 
-#define SPIM_NRFX_MISO_PULL_DOWN(idx) DT_PROP(SPIM(idx), miso_pull_down)
-#define SPIM_NRFX_MISO_PULL_UP(idx) DT_PROP(SPIM(idx), miso_pull_up)
+#define SPIM_NRFX_MISO_PULL_DOWN(idx)	DT_PROP(SPIM(idx), miso_pull_down)
+#define SPIM_NRFX_MISO_PULL_UP(idx)	DT_PROP(SPIM(idx), miso_pull_up)
 
 #define SPIM_NRFX_MISO_PULL(idx)			\
 	(SPIM_PROP(idx, miso_pull_up)			\
@@ -546,10 +552,16 @@ static int spim_nrfx_pm_action(const struct device *dev,
 		(return anomaly_58_workaround_init(dev);),		       \
 		(return 0;))						       \
 	}								       \
+	IF_ENABLED(SPI_BUFFER_IN_RAM,					       \
+		(static uint8_t spim_##idx##_buffer			       \
+			[CONFIG_SPI_NRFX_RAM_BUFFER_SIZE]		       \
+			SPIM_MEMORY_SECTION(idx);))			       \
 	static struct spi_nrfx_data spi_##idx##_data = {		       \
 		SPI_CONTEXT_INIT_LOCK(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_INIT_SYNC(spi_##idx##_data, ctx),		       \
 		SPI_CONTEXT_CS_GPIOS_INITIALIZE(SPIM(idx), ctx)		       \
+		IF_ENABLED(SPI_BUFFER_IN_RAM,				       \
+			(.buffer = spim_##idx##_buffer,))		       \
 		.dev  = DEVICE_DT_GET(SPIM(idx)),			       \
 		.busy = false,						       \
 	};								       \
@@ -579,6 +591,12 @@ static int spim_nrfx_pm_action(const struct device *dev,
 		      &spi_##idx##z_config,				       \
 		      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY,		       \
 		      &spi_nrfx_driver_api)
+
+#define SPIM_MEMORY_SECTION(idx)					       \
+	COND_CODE_1(SPIM_HAS_PROP(idx, memory_regions),			       \
+		(__attribute__((__section__(LINKER_DT_NODE_REGION_NAME(	       \
+			DT_PHANDLE(SPIM(idx), memory_regions)))))),	       \
+		())
 
 #ifdef CONFIG_SPI_0_NRF_SPIM
 SPI_NRFX_SPIM_DEVICE(0);

--- a/dts/bindings/reserved-memory/memory-region.yaml
+++ b/dts/bindings/reserved-memory/memory-region.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Memory region nodes may be referenced by other device nodes
+# by adding a memory-region property to the device node.
+
+properties:
+    memory-regions:
+      required: false
+      type: phandle-array
+      description: List of memory region phandles
+
+    memory-region-names:
+      required: false
+      type: string-array
+      description: A list of names, one for each corresponding phandle in memory-region

--- a/dts/bindings/serial/nordic,nrf-uarte.yaml
+++ b/dts/bindings/serial/nordic,nrf-uarte.yaml
@@ -2,4 +2,4 @@ description: Nordic nRF family UARTE (UART with EasyDMA)
 
 compatible: "nordic,nrf-uarte"
 
-include: nordic,nrf-uart-common.yaml
+include: ["nordic,nrf-uart-common.yaml", "memory-region.yaml"]

--- a/dts/bindings/spi/nordic,nrf-spim.yaml
+++ b/dts/bindings/spi/nordic,nrf-spim.yaml
@@ -5,7 +5,7 @@ description: Nordic nRF family SPIM (SPI master with EasyDMA)
 
 compatible: "nordic,nrf-spim"
 
-include: nordic,nrf-spi-common.yaml
+include: ["nordic,nrf-spi-common.yaml", "memory-region.yaml"]
 
 properties:
     miso-pull-up:


### PR DESCRIPTION
Since the introduction of the `zephyr,memory-region` compatible to create new
memory region, drivers can now use the newly defined region in the DT by using
the macro LINKER_DT_NODE_REGION_NAME() on the node_id to retrieve the region
name and possibly allocated data or variables in that region (or for whatever
other use). This is assuming though that the driver knows in advance the node_id to
reference.

A better approach is to add a new generic 'memory-region' property that can be
used by any driver to reference a region by using a phandle, so that the driver
can use that to retrieve the memory-region of interest.

Signed-off-by: Adam Wojasinski <adam.wojasinski@nordicsemi.no>
Signed-off-by: Carlo Caione <ccaione@baylibre.com>