### PR TITLE
drivers: lora: sx127x: fix missing reset gpio instantiation

### DIFF
--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -176,6 +176,7 @@ struct sx127x_config {
 
 static const struct sx127x_config dev_config = {
 	.bus = SPI_DT_SPEC_INST_GET(0, SPI_WORD_SET(8) | SPI_TRANSFER_MSB, 0),
+	.reset = GPIO_DT_SPEC_INST_GET(0, reset_gpios),
 #if DT_INST_NODE_HAS_PROP(0, antenna_enable_gpios)
 	.antenna_enable = GPIO_DT_SPEC_INST_GET(0, antenna_enable_gpios),
 #endif


### PR DESCRIPTION
…e tree.

It seems to me that the lora functions cannot be executed correctly without initializing the reset pin for the SX1272 and SX1276.
Tested on a dedicated board integrating a SX1272.

Signed-off-by: Adrien Rouault <adrien.rouault@nemeus.fr>