### PR TITLE
doc: Suggest filing GitHub issue for broken links

### DIFF
--- a/doc/404.rst
+++ b/doc/404.rst
@@ -33,11 +33,10 @@ It's also possible we've removed or renamed the page you're looking for.
 Please try using the navigation links on the left of this page to navigate
 the major sections of our site, or use the search box.
 
-If you got this error by following a link, please let us know by sending
-us a message using this `contact us form`_, or send an email message to
-info@zephyrproject.org
+If you got this error by following a link, please let us know by creating an
+issue on `GitHub`_.
 
-.. _contact us form: https://www.zephyrproject.org/contact-us/
+.. _GitHub: https://github.com/zephyrproject-rtos/zephyr/issues
 
 .. raw:: html
 


### PR DESCRIPTION
This commit updates the documentation 404 page to suggest filing a
GitHub issue for broken links instead of sending an email or using the
"contact us" form.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>