### PR TITLE
dts: lpc: fix SRAM size allocation

### DIFF
--- a/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
+++ b/boards/arm/lpcxpresso54114/lpcxpresso54114_m4.dts
@@ -43,6 +43,17 @@
 	};
 };
 
+/*
+ * Default for this board is to allocate SRAM0-1 to M4 CPU but the
+ * application can have an application specific device tree to
+ * allocate the SRAM0-3 differently.
+ *
+ */
+&sram0 {
+	compatible = "mmio-sram";
+	reg = <0x20000000 DT_SIZE_K(128)>;
+};
+
 &cpu0 {
 	clock-frequency = <48000000>;
 };

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -65,6 +65,22 @@
 	};
 };
 
+/*
+ * Default for this board is to allocate SRAM0-2 to cpu0 but the
+ * application can have an application specific device tree to
+ * allocate the SRAM0-4 differently.
+ *
+ * For example, SRAM0-3 could be allocated to cpu0 with only SRAM4
+ * for cpu1. This would require the zephyr,sram chosen value for cpu1
+ * to be changed to sram4 and the value of sram0 to have a DT_SIZE_K
+ * of 256.
+ *
+ */
+&sram0 {
+	compatible = "mmio-sram";
+	reg = <0x20000000 DT_SIZE_K(192)>;
+};
+
 &gpio0 {
 	status = "okay";
 };

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
@@ -25,6 +25,23 @@
 	};
 };
 
+/*
+ * Default for this board is to allocate SRAM3-4 to cpu1 but the
+ * application can have an application specific device tree to
+ * allocate the SRAM0-4 differently.
+ *
+ * For example, SRAM0-3 could be allocated to cpu0 with only SRAM4
+ * for cpu1. This would require the zephyr,sram chosen value for cpu1
+ * to be changed to sram4 and the value of sram0 to have a DT_SIZE_K
+ * of 256.
+ *
+ */
+&sram3 {
+	compatible = "mmio-sram";
+	reg = <0x20030000 DT_SIZE_K(80)>;
+};
+
+
 &gpio0 {
 	status = "okay";
 };

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -44,6 +44,20 @@
 			#clock-cells = <1>;
 		};
 
+		/*
+		 * lpc54xxx Memory configurations:
+		 * (note: reference manual says "up to <n>K")
+		 * SRAM0 through SRAM3 will be contiguous
+		 *
+		 * LPC540xx: RAMX: 192K, SRAM0: 64K, SRAM1: 32K, SRAM2: 32K, SRAM3: 32K, USBRAM: 8K
+		 * LPC5410x: RAMX: ----, SRAM0: 64K, SRAM1: 32K, USBRAM: 8K @ 0x03400000
+		 * LPC5411x: RAMX: 32K,  SRAM0: 64K, SRAM1: 64K, SRAM2: 32K
+		 *
+		 * SRAM0-SRAM3 will be contiguous memory when present.
+		 *
+		 * The board level or application level device tree can override the memory sizes
+		 * to allocate memory to the different cores of the dual-core platforms.
+		 */
 		sram0:memory@20000000 {
 			compatible = "mmio-sram";
 			reg = <0x20000000 DT_SIZE_K(64)>;
@@ -61,9 +75,14 @@
 			zephyr,memory-region = "SRAM2";
 		};
 
-		sramx:memory@4000000{
+		/*
+		 * LPC54018: 192K @ 0x04000000
+		 * LPC540xx: 192K @ 0x04000000
+		 * LPC541xx:  32K @ 0x04000000
+		 */
+		sramx:memory@04000000{
 			compatible = "mmio-sram";
-			reg = <0x4000000 DT_SIZE_K(32)>;
+			reg = <0x04000000 DT_SIZE_K(32)>;
 		};
 
 		iap: flash-controller@4009c000 {

--- a/dts/arm/nxp/nxp_lpc55S06_ns.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S06_ns.dtsi
@@ -17,3 +17,19 @@
 };
 
 #include "nxp_lpc55S0x_common.dtsi"
+
+&sramx {
+	compatible = "zephyr,memory-region", "mmio-sram";
+	reg = <0x40000000 DT_SIZE_K(16)>;
+	zephyr,memory-region = "SRAMX";
+};
+
+/*
+ * lpc55S06:
+ * Combine SRAM0, SRAM1, SRAM2 for total of 80K RAM
+ */
+&sram0 {
+	compatible = "mmio-sram";
+	reg = <0x20000000 DT_SIZE_K(80)>;
+};
+

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -33,32 +33,31 @@
 	#address-cells = <1>;
 	#size-cells = <1>;
 
+	/* lpc55_0x Memory configurations:
+	 *
+	 * LPC5502:  RAMX: 16K, SRAM0: 32K
+	 * LPC55x04: RAMX: 16K, SRAM0: 32K, SRAM1: 16K
+	 * LPC55x06: RAMX: 16K, SRAM0: 32K, SRAM1: 16K, SRAM2: 16K, SRAM3: 16k
+	 */
 	sramx: memory@4000000 {
 		compatible = "mmio-sram";
-		reg = <0x4000000 DT_SIZE_K(16)>;
+		reg = <0x04000000 DT_SIZE_K(16)>;
 	};
-
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SIZE_K(32)>;
 	};
-
 	sram1: memory@20008000 {
-		compatible = "zephyr,memory-region","mmio-sram";
+		compatible = "mmio-sram";
 		reg = <0x20008000 DT_SIZE_K(16)>;
-		zephyr,memory-region = "SRAM1";
 	};
-
-	sram2: memory@2000c000 {
-		compatible = "zephyr,memory-region","mmio-sram";
-		reg = <0x2000c000 DT_SIZE_K(16)>;
-		zephyr,memory-region = "SRAM2";
+	sram2: memory@2000C000 {
+		compatible = "mmio-sram";
+		reg = <0x2000C000 DT_SIZE_K(16)>;
 	};
-
 	sram3: memory@20010000 {
-		compatible = "zephyr,memory-region","mmio-sram";
+		compatible = "mmio-sram";
 		reg = <0x20010000 DT_SIZE_K(16)>;
-		zephyr,memory-region = "SRAM3";
 	};
 };
 

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -51,33 +51,37 @@
 		reg = <0x4000000 DT_SIZE_K(32)>;
 	};
 
+	/* lpc55S6x Memory configurations:
+	 *
+	 * RAM blocks SRAM0 through SRAM4 are contiguous address ranges
+	 *
+	 * LPC55S66: 144KB RAM, RAMX: 32K, SRAM0: 32K
+	 * LPC55S69: 320KB RAM, RAMX: 32K, SRAM0: 64K, SRAM1: 64K,
+	 *                      SRAM2: 64K, SRAM3: 64K, SRAM4: 16K
+	 */
 	sram0: memory@20000000 {
 		compatible = "mmio-sram";
 		reg = <0x20000000 DT_SIZE_K(64)>;
 	};
 
 	sram1: memory@20010000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20010000 DT_SIZE_K(32)>;
-		zephyr,memory-region = "SRAM1";
+		compatible = "mmio-sram";
+		reg = <0x20010000 DT_SIZE_K(64)>;
 	};
 
 	sram2: memory@20018000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20018000 DT_SIZE_K(32)>;
-		zephyr,memory-region = "SRAM2";
+		compatible = "mmio-sram";
+		reg = <0x20020000 DT_SIZE_K(64)>;
 	};
 
 	sram3: memory@20020000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x20020000 DT_SIZE_K(32)>;
-		zephyr,memory-region = "SRAM3";
+		compatible = "mmio-sram";
+		reg = <0x20030000 DT_SIZE_K(64)>;
 	};
 
 	sram4: memory@40100000 {
-		compatible = "zephyr,memory-region", "mmio-sram";
-		reg = <0x40100000 DT_SIZE_K(16)>;
-		zephyr,memory-region = "SRAM4";
+		compatible = "mmio-sram";
+		reg = <0x20040000  DT_SIZE_K(16)>;
 	};
 };
 


### PR DESCRIPTION
LPC platforms define multiple SRAM memory blocks that are contiguous
in memory but the zephyr build system doesn't have a method to
specify all the nodes to be used for a CPU's chosen "zephyr,sram"
node. To be able to get full use of memory, sram0 is redefined to
80KB in size.

Fixes #43872

Signed-off-by: David Leach <david.leach@nxp.com>