### PR TITLE
sample: tfm: fix the digest index check

### DIFF
--- a/samples/tfm_integration/tfm_secure_partition/README.rst
+++ b/samples/tfm_integration/tfm_secure_partition/README.rst
@@ -42,10 +42,10 @@ Sample Output
 
    .. code-block:: console
 
-      *** Booting Zephyr OS build v2.6.0-rc1-ncs1-1-g58213e91eef1  ***
+      *** Booting Zephyr OS build zephyr-v3.0.0-3118-g953565e3b02a  ***
       Digest: be45cb2605bf36bebde684841a28f0fd43c69850a3dce5fedba69928ee3a8991
       Digest: 1452c8f04245d355722fdbfb03c69bcfd380b7dff911a3e425013397251f6a4e
       Digest: d3b4349010abb691b9584b6fd6b41ec54596ef7b98d853fb4f5bfa690f50f222
       Digest: 5afbcfede855ca834ff5b4e8a44a32206a51381f3cf52f5001a3241f017ac41a
       Digest: 983318380c325099da63de2e7ca57c1630693b28b4754e08817533295dbfcfbb
-      Status: -135
+      Digest: 374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb

--- a/samples/tfm_integration/tfm_secure_partition/dummy_partition/dummy_partition.c
+++ b/samples/tfm_integration/tfm_secure_partition/dummy_partition/dummy_partition.c
@@ -35,7 +35,7 @@ static psa_status_t tfm_dp_secret_digest(uint32_t secret_index,
 	psa_status_t status;
 
 	/* Check that secret_index is valid. */
-	if (secret_index >= NUM_SECRETS) {
+	if (secret_index > NUM_SECRETS) {
 		return PSA_ERROR_INVALID_ARGUMENT;
 	}
 

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -11,7 +11,7 @@ common:
         - "Digest: d3b4349010abb691b9584b6fd6b41ec54596ef7b98d853fb4f5bfa690f50f222"
         - "Digest: 5afbcfede855ca834ff5b4e8a44a32206a51381f3cf52f5001a3241f017ac41a"
         - "Digest: 983318380c325099da63de2e7ca57c1630693b28b4754e08817533295dbfcfbb"
-        - "Status: -135"
+        - "Digest: 374708fff7719dd5979ec875d56cd2286f6d3cf7ec317a3b25632aab28ec37bb"
 sample:
   name: "TFM Secure Partition Sample"
 


### PR DESCRIPTION
From non-secure to secure message digest valid index values from 0 to 5 but secure side check at the 5th index and return an error, so update the index validation to accept the 5th index message-digest request from non-secure side.

Signed-off-by: Rajkumar Kanagaraj <rajkumar.kanagaraj@linaro.org>