### PR TITLE
npcx: Do not switch the eSPI pin setting and gate its clock at initialization

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -218,7 +218,12 @@ static int npcx_clock_control_init(const struct device *dev)
 	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL3) = 0x1F; /* No GDMA_PD */
 	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL4) = 0xFF;
 	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL5) = 0xFA;
+#if CONFIG_ESPI
+	/* Don't gate the clock of the eSPI module if eSPI interface is required */
+	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL6) = 0xEF;
+#else
 	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL6) = 0xFF;
+#endif
 #if defined(CONFIG_SOC_SERIES_NPCX7)
 	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL7) = 0xE7;
 #elif defined(CONFIG_SOC_SERIES_NPCX9)

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -25,7 +25,6 @@
 		pinctrl-0 = <&alt0_gpio_no_spip
 			   &alt0_gpio_no_fpip
 			   &alt1_no_pwrgd
-			   &alt1_no_lpc_espi
 			   &alta_no_peci_en
 			   &altd_npsl_in1_sl
 			   &altd_npsl_in2_sl

--- a/dts/arm/nuvoton/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx9.dtsi
@@ -25,7 +25,6 @@
 		pinctrl-0 = <&alt0_gpio_no_spip
 			   &alt0_gpio_no_fpip
 			   &alt1_no_pwrgd
-			   &alt1_no_lpc_espi
 			   &alta_no_peci_en
 			   &altd_npsl_in1_sl
 			   &altd_npsl_in2_sl


### PR DESCRIPTION
In the Chromebook  application,  the system may jump between two built Zephyr images when necessary.
When jumping from the current image to the other, if we change the eSPI pinmux or gate its clock, It causes the eSPI to reset and breaks the eSPI communication which is established by previous image after the image jump.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>
