### PR TITLE
tests: uart: fix integration platforms

### DIFF
--- a/tests/drivers/uart/uart_basic_api/testcase.yaml
+++ b/tests/drivers/uart/uart_basic_api/testcase.yaml
@@ -1,23 +1,25 @@
-common:
-  integration_platforms:
-    - mps2_an385
-
 tests:
   drivers.uart.basic_api:
     tags: drivers
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    integration_platforms:
+      - mps2_an385
   drivers.uart.basic_api.poll:
     extra_args: CONF_FILE=prj_poll.conf
     tags: drivers
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    integration_platforms:
+      - mps2_an385
   drivers.uart.basic_api.shell:
     extra_args: CONF_FILE=prj_shell.conf
     min_flash: 64
     tags: drivers
     filter: CONFIG_UART_CONSOLE
     harness: keyboard
+    integration_platforms:
+      - mps2_an385
   drivers.uart.basic_api.cdc_acm:
     extra_args: OVERLAY_CONFIG="overlay-usb.conf"
                 DTC_OVERLAY_FILE="usb.overlay"


### PR DESCRIPTION
Fix usage of integration_platforms and apply it individually instead of
the common section.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
