### PR TITLE
Introduce CONFIG_EARLY_INIT

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -484,6 +484,13 @@ config INIT_ARCH_HW_AT_BOOT
 	  implementation details refer to each architecture where
 	  this feature is supported.
 
+config EARLY_INIT
+	bool "Call early init function"
+	depends on ARCH_HAS_EARLY_INIT
+	help
+	  The early init function (must be called z_early_init) is the first
+	  function called after the stack is setup and C functions can be used.
+
 endmenu
 
 #
@@ -537,6 +544,9 @@ config ARCH_HAS_COHERENCE
 	  memory using the ".cached" linker section.
 
 config ARCH_HAS_THREAD_LOCAL_STORAGE
+	bool
+
+config ARCH_HAS_EARLY_INIT
 	bool
 
 #

--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -34,6 +34,7 @@ config ARM
 	# is really only necessary for Cortex-M with ARM MPU!
 	select GEN_PRIV_STACKS
 	select ARCH_HAS_THREAD_LOCAL_STORAGE if CPU_AARCH32_CORTEX_R || CPU_CORTEX_M
+	select ARCH_HAS_EARLY_INIT
 	help
 	  ARM architecture
 

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -184,6 +184,10 @@ static inline void z_arm_floating_point_init(void)
 
 extern FUNC_NORETURN void z_cstart(void);
 
+#if defined(CONFIG_EARLY_INIT)
+extern void z_early_init(void);
+#endif /* CONFIG_EARLY_INIT */
+
 /**
  *
  * @brief Prepare to and run C code
@@ -193,6 +197,9 @@ extern FUNC_NORETURN void z_cstart(void);
  */
 void z_arm_prep_c(void)
 {
+#if defined(CONFIG_EARLY_INIT)
+	z_early_init();
+#endif
 	relocate_vector_table();
 #if defined(CONFIG_CPU_HAS_FPU)
 	z_arm_floating_point_init();


### PR DESCRIPTION
Sometimes the application or the user requires some code to be run as early as possible during the kernel init stage, immediately after the stack has been setup (to be able to use C) but before the kernel has actually started.
    
Currently Zephyr defines `CONFIG_INIT_ARCH_HW_AT_BOOT` for all the architectures and `CONFIG_PLATFORM_SPECIFIC_INIT` only for ARM that can be somehow used for that, but both have some limitations.
    
`CONFIG_INIT_ARCH_HW_AT_BOOT` has a much more limited scope, and it is used only to force the initialization of the internal architectural state and it is usually run before the stack has been setup.
    
`CONFIG_PLATFORM_SPECIFIC_INIT` is ARM-specific and it is alredy used by several SoCs for system and platform initialization, so that is not available to the user.
    
This patch wants to introduce a new Kconfig symbol `CONFIG_EARLY_INIT` (with `CONFIG_ARCH_HAS_EARLY_INIT`) that can be used to introduce a `z_early_init()` function that is the first function called after the stack is setup and before the rest of the kernel is started.
    
Enable this symbol for ARM as template.
