### PR TITLE
sample: tfm: Improve the error handling at tfm_secure_partition non-secure side

### DIFF
--- a/samples/tfm_integration/tfm_secure_partition/README.rst
+++ b/samples/tfm_integration/tfm_secure_partition/README.rst
@@ -42,10 +42,10 @@ Sample Output
 
    .. code-block:: console
 
-      *** Booting Zephyr OS build v2.6.0-rc1-ncs1-1-g58213e91eef1  ***
+      *** Booting Zephyr OS build zephyr-v3.0.0-3061-g9bb87f4d46e9  ***
       Digest: be45cb2605bf36bebde684841a28f0fd43c69850a3dce5fedba69928ee3a8991
       Digest: 1452c8f04245d355722fdbfb03c69bcfd380b7dff911a3e425013397251f6a4e
       Digest: d3b4349010abb691b9584b6fd6b41ec54596ef7b98d853fb4f5bfa690f50f222
       Digest: 5afbcfede855ca834ff5b4e8a44a32206a51381f3cf52f5001a3241f017ac41a
       Digest: 983318380c325099da63de2e7ca57c1630693b28b4754e08817533295dbfcfbb
-      Status: -135
+      No valid secret for key, received expected error code

--- a/samples/tfm_integration/tfm_secure_partition/sample.yaml
+++ b/samples/tfm_integration/tfm_secure_partition/sample.yaml
@@ -11,7 +11,7 @@ common:
         - "Digest: d3b4349010abb691b9584b6fd6b41ec54596ef7b98d853fb4f5bfa690f50f222"
         - "Digest: 5afbcfede855ca834ff5b4e8a44a32206a51381f3cf52f5001a3241f017ac41a"
         - "Digest: 983318380c325099da63de2e7ca57c1630693b28b4754e08817533295dbfcfbb"
-        - "Status: -135"
+        - "No valid secret for key, received expected error code"
 sample:
   name: "TFM Secure Partition Sample"
 

--- a/samples/tfm_integration/tfm_secure_partition/src/main.c
+++ b/samples/tfm_integration/tfm_secure_partition/src/main.c
@@ -17,7 +17,9 @@ void main(void)
 	for (int key = 0; key < 6; key++) {
 		psa_status_t status = dp_secret_digest(key, digest, sizeof(digest));
 
-		if (status != PSA_SUCCESS) {
+		if (status == PSA_ERROR_INVALID_ARGUMENT && key == 5) {
+			printk("No valid secret for key, received expected error code\n");
+		} else if (status != PSA_SUCCESS) {
 			printk("Status: %d\n", status);
 		} else {
 			printk("Digest: ");


### PR DESCRIPTION

- Previously non-secure request at the 6th run expected to return status
  "-135 (PSA_ERROR_INVALID_ARGUMENT)" which is the expected status so updating
  "if" condition on the non-secure side handles this expected type error status
  from the secure side.
- update sample YAML harness config regex of Digest message as this gets
  compared at the run of twister.
- Update the readme console logs.

Signed-off-by: Rajkumar Kanagaraj <rajkumar.kanagaraj@linaro.org>