### PR TITLE
MAINTAINERS: Add CMSIS-NN entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -322,6 +322,18 @@ CMSIS-DSP integration:
     labels:
         - "area: CMSIS-DSP"
 
+CMSIS-NN integration:
+    status: maintained
+    maintainers:
+        - JordanYates
+    collaborators:
+        - stephanosio
+    files:
+        - modules/Kconfig.cmsis_nn
+        - tests/lib/cmsis_nn/
+    labels:
+        - "area: CMSIS-NN"
+
 Common Architecture Interface:
     status: odd fixes
     collaborators:


### PR DESCRIPTION
This commit adds the MAINTAINERS entry for the CMSIS-NN integration,
with @JordanYates, the initial contributor, as the maintainer and
@stephanosio as a collaborator.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>