### PR TITLE
MAINTAINERS: Add Toolchain Integration entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1775,6 +1775,20 @@ TF-M Integration:
     labels:
         - "area: TF-M"
 
+Toolchain Integration:
+    status: maintained
+    maintainers:
+        - tejlmand
+    collaborators:
+        - stephanosio
+    files:
+        - cmake/bintools/
+        - cmake/compiler/
+        - cmake/linker/
+        - cmake/toolchain/
+    labels:
+        - "area: Toolchains"
+
 Tracing:
     status: maintained
     maintainers:


### PR DESCRIPTION
This commit adds the MAINTAINERS entry for the Toolchain Integration,
with @tejlmand as the maintainer and @stephanosio as a collaborator.

The purpose of this is to provide a corresponding MAINTAINERS entry for
the "area: Toolchains" and differentiate the toolchain integration-
related maintenance tasks from the general build system maintenance
tasks.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>