### PR TITLE
Fixes found with -ffreestanding disabled

### DIFF
--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -118,6 +118,7 @@ void exit(int return_code)
 	LOG_ERR("exit(%d)", return_code);
 	k_panic();
 #endif
+	CODE_UNREACHABLE;
 }
 
 #ifdef XT_SIMULATOR

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -27,6 +27,7 @@ set_compiler_property(PROPERTY warning_base
                       -Wformat-security
                       -Wno-format-zero-length
                       -Wno-main
+                      -Wno-unused-but-set-variable
                       -Wno-typedef-redefinition
 )
 

--- a/drivers/flash/flash_ite_it8xxx2.c
+++ b/drivers/flash/flash_ite_it8xxx2.c
@@ -23,7 +23,7 @@
 LOG_MODULE_REGISTER(flash_ite_it8xxx2);
 
 /* RAM code start address */
-extern char _ram_code_start;
+extern char _ram_code_start[];
 #define FLASH_RAMCODE_START ((uint32_t)&_ram_code_start)
 #define	FLASH_RAMCODE_START_BIT19      BIT(19)
 /* RAM code section */

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -643,15 +643,18 @@ static int adxl372_attr_set_thresh(const struct device *dev,
 {
 	const struct adxl372_dev_config *cfg = dev->config;
 	struct adxl372_activity_threshold threshold;
+	int64_t llvalue;
 	int32_t value;
 	int64_t micro_ms2 = val->val1 * 1000000LL + val->val2;
 	uint8_t reg;
 
-	value = abs((micro_ms2 * 10) / SENSOR_G);
+	llvalue = llabs((micro_ms2 * 10) / SENSOR_G);
 
-	if (value > 2047) {
+	if (llvalue > 2047) {
 		return -EINVAL;
 	}
+
+	value = (int32_t) llvalue;
 
 	threshold.thresh = value;
 	threshold.enable = cfg->activity_th.enable;

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -129,19 +129,19 @@ static int open_tty(struct native_uart_status *driver_data,
 		err_nbr = errno;
 		close(master_pty);
 		ERROR("Could not grant access to the slave PTY side (%i)\n",
-			errno);
+			err_nbr);
 	}
 	ret = unlockpt(master_pty);
 	if (ret == -1) {
 		err_nbr = errno;
 		close(master_pty);
-		ERROR("Could not unlock the slave PTY side (%i)\n", errno);
+		ERROR("Could not unlock the slave PTY side (%i)\n", err_nbr);
 	}
 	slave_pty_name = ptsname(master_pty);
 	if (slave_pty_name == NULL) {
 		err_nbr = errno;
 		close(master_pty);
-		ERROR("Error getting slave PTY device name (%i)\n", errno);
+		ERROR("Error getting slave PTY device name (%i)\n", err_nbr);
 	}
 	/* Set the master PTY as non blocking */
 	flags = fcntl(master_pty, F_GETFL);
@@ -149,7 +149,7 @@ static int open_tty(struct native_uart_status *driver_data,
 		err_nbr = errno;
 		close(master_pty);
 		ERROR("Could not read the master PTY file status flags (%i)\n",
-			errno);
+			err_nbr);
 	}
 
 	ret = fcntl(master_pty, F_SETFL, flags | O_NONBLOCK);
@@ -157,8 +157,10 @@ static int open_tty(struct native_uart_status *driver_data,
 		err_nbr = errno;
 		close(master_pty);
 		ERROR("Could not set the master PTY as non-blocking (%i)\n",
-			errno);
+			err_nbr);
 	}
+
+	(void) err_nbr;
 
 	/*
 	 * Set terminal in "raw" mode:
@@ -291,6 +293,7 @@ static void np_uart_poll_out(const struct device *dev,
 	 * but we do not need the return value for anything.
 	 */
 	ret = write(d->out_fd, &out_char, 1);
+	(void) ret;
 }
 
 /**

--- a/samples/subsys/logging/syst/src/main.c
+++ b/samples/subsys/logging/syst/src/main.c
@@ -117,7 +117,7 @@ void log_msgs(void)
 #endif
 }
 
-void main(void)
+int main(void)
 {
 	log_msgs();
 
@@ -140,5 +140,5 @@ void main(void)
 	/* raw string */
 	printk("SYST Sample Execution Completed\n");
 #endif
-
+	return 0;
 }

--- a/subsys/usb/device/class/hid/core.c
+++ b/subsys/usb/device/class/hid/core.c
@@ -327,8 +327,8 @@ void hid_sof_handler(struct hid_device_info *dev_data)
 			continue;
 		}
 
-		uint32_t diff = abs(dev_data->idle_rate[i] * 4U -
-				    dev_data->sof_cnt[i]);
+		int32_t diff = abs((int32_t) ((uint32_t) dev_data->idle_rate[i] * 4U -
+					      dev_data->sof_cnt[i]));
 
 		if (diff < 2 && reported == false) {
 			dev_data->sof_cnt[i] = 0U;

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -17,7 +17,7 @@ struct timer_data {
 #define DURATION 100
 #define PERIOD 50
 #define EXPIRE_TIMES 4
-#define WITHIN_ERROR(var, target, epsilon) (abs((target) - (var)) <= (epsilon))
+#define WITHIN_ERROR(var, target, epsilon) (llabs((int64_t) ((target) - (var))) <= (epsilon))
 
 /* ms can be converted precisely to ticks only when a ms is exactly
  * represented by an integral number of ticks.  If the conversion is
@@ -104,7 +104,7 @@ static bool interval_check(int64_t interval, int64_t desired)
 		slop += 2 * k_ticks_to_ms_ceil32(1);
 	}
 
-	if (abs(interval - desired) > slop) {
+	if (!WITHIN_ERROR(interval, desired, slop)) {
 		return false;
 	}
 

--- a/tests/lib/newlib/heap_listener/src/main.c
+++ b/tests/lib/newlib/heap_listener/src/main.c
@@ -35,6 +35,8 @@ static void heap_resized(uintptr_t heap_id, void *old_heap_end, void *new_heap_e
 
 static HEAP_LISTENER_RESIZE_DEFINE(listener, HEAP_ID_LIBC, heap_resized);
 
+void *ptr;
+
 /**
  * @brief Test that heap listener is notified when libc heap size changes.
  *
@@ -45,7 +47,6 @@ static HEAP_LISTENER_RESIZE_DEFINE(listener, HEAP_ID_LIBC, heap_resized);
 void test_alloc_and_trim(void)
 {
 	uintptr_t saved_heap_end;
-	void *ptr;
 
 	TC_PRINT("Allocating memory...\n");
 


### PR DESCRIPTION
Here's a collection of fixes to drivers, subsys, tests and samples to resolve compiler warnings and errors found when -ffreestanding is taken out of the compiler command line, leaving it able to detect problems when using standard C library functions.

I think there are a couple of real bugs found here, although most of the changes relate to buffers sized for numbers not expected to span the full range of their declared type.

This series is no longer stacked on top of the picolibc-module series so printk/cbprintf errors will not be checked until those patches are also merged.

Closes: #45157 

Depends on #44096 (includes commits from #44096)