### PR TITLE
boards: hifive1: fix PWM LEDs period

### DIFF
--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -25,15 +25,15 @@
 	leds {
 		compatible = "pwm-leds";
 		led0: led_0 {
-			pwms = <&pwm1 1 0>;
+			pwms = <&pwm1 1 PWM_MSEC(20)>;
 			label = "Green LED";
 		};
 		led1: led_1 {
-			pwms = <&pwm1 2 0>;
+			pwms = <&pwm1 2 PWM_MSEC(20)>;
 			label = "Blue LED";
 		};
 		led2: led_2 {
-			pwms = <&pwm1 3 0>;
+			pwms = <&pwm1 3 PWM_MSEC(20)>;
 			label = "Red LED";
 		};
 	};

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pwm/pwm.h>
 #include <freq.h>
 
 / {


### PR DESCRIPTION
The PWM period was set to 0, a value that is not suitable to drive an
LED using a PWM signal. A period of 20 msec has been chosen, following
other platforms.