### PR TITLE
Fix MCUBoot Usage Fault

### DIFF
--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -17,6 +17,8 @@
  * called while interacting with the flexspi MUST be relocated to SRAM or ITCM
  * at runtime, so that the chip does not access the flexspi to read program
  * instructions while it is being written to
+ *
+ * Additionally, no data used by this driver should be stored in flash.
  */
 #if defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP) && (CONFIG_FLASH_LOG_LEVEL > 0)
 #warning "Enabling flash driver logging and XIP mode simultaneously can cause \
@@ -240,21 +242,17 @@ static const uint32_t flash_flexspi_hyperflash_lut[CUSTOM_LUT_LENGTH] = {
 				kFLEXSPI_Command_DDR, kFLEXSPI_8PAD, 0x10),
 };
 
-struct flash_flexspi_hyperflash_config {
-	flexspi_port_t port;
+/* Device variables used in critical sections should be in this structure */
+struct flash_flexspi_hyperflash_data {
+	const struct device *controller;
 	flexspi_device_config_t config;
+	flexspi_port_t port;
 	struct flash_pages_layout layout;
 	struct flash_parameters flash_parameters;
 };
 
-/* Device variables used in critical sections should be in this structure */
-struct flash_flexspi_hyperflash_data {
-	const struct device *controller;
-};
-
 static int flash_flexspi_hyperflash_wait_bus_busy(const struct device *dev)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 	flexspi_transfer_t transfer;
 	int ret;
@@ -262,7 +260,7 @@ static int flash_flexspi_hyperflash_wait_bus_busy(const struct device *dev)
 	uint32_t read_value;
 
 	transfer.deviceAddress = 0;
-	transfer.port = config->port;
+	transfer.port = data->port;
 	transfer.cmdType = kFLEXSPI_Read;
 	transfer.SeqNumber = 2;
 	transfer.seqIndex = READ_STATUS;
@@ -288,13 +286,12 @@ static int flash_flexspi_hyperflash_wait_bus_busy(const struct device *dev)
 
 static int flash_flexspi_hyperflash_write_enable(const struct device *dev, uint32_t address)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 	flexspi_transfer_t transfer;
 	int ret;
 
 	transfer.deviceAddress = address;
-	transfer.port = config->port;
+	transfer.port = data->port;
 	transfer.cmdType = kFLEXSPI_Command;
 	transfer.SeqNumber = 2;
 	transfer.seqIndex = WRITE_ENABLE;
@@ -306,7 +303,6 @@ static int flash_flexspi_hyperflash_write_enable(const struct device *dev, uint3
 
 static int flash_flexspi_hyperflash_check_vendor_id(const struct device *dev)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 	uint8_t writebuf[4] = {0x00, 0x98};
 	uint32_t buffer[2];
@@ -314,7 +310,7 @@ static int flash_flexspi_hyperflash_check_vendor_id(const struct device *dev)
 	flexspi_transfer_t transfer;
 
 	transfer.deviceAddress = (0x555 * 2);
-	transfer.port = config->port;
+	transfer.port = data->port;
 	transfer.cmdType = kFLEXSPI_Write;
 	transfer.SeqNumber = 1;
 	transfer.seqIndex = WRITE_DATA;
@@ -330,7 +326,7 @@ static int flash_flexspi_hyperflash_check_vendor_id(const struct device *dev)
 	}
 
 	transfer.deviceAddress = (0x10 * 2);
-	transfer.port = config->port;
+	transfer.port = data->port;
 	transfer.cmdType = kFLEXSPI_Read;
 	transfer.SeqNumber = 1;
 	transfer.seqIndex = READ_DATA;
@@ -351,7 +347,7 @@ static int flash_flexspi_hyperflash_check_vendor_id(const struct device *dev)
 
 	writebuf[1] = 0xF0;
 	transfer.deviceAddress = 0;
-	transfer.port = config->port;
+	transfer.port = data->port;
 	transfer.cmdType = kFLEXSPI_Write;
 	transfer.SeqNumber = 1;
 	transfer.seqIndex = WRITE_DATA;
@@ -372,12 +368,11 @@ static int flash_flexspi_hyperflash_check_vendor_id(const struct device *dev)
 static int flash_flexspi_hyperflash_page_program(const struct device *dev, off_t
 		offset, const void *buffer, size_t len)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Write,
 		.SeqNumber = 2,
 		.seqIndex = PAGE_PROGRAM,
@@ -393,11 +388,10 @@ static int flash_flexspi_hyperflash_page_program(const struct device *dev, off_t
 static int flash_flexspi_hyperflash_read(const struct device *dev, off_t offset,
 		void *buffer, size_t len)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 
 	uint8_t *src = memc_flexspi_get_ahb_address(data->controller,
-			config->port,
+			data->port,
 			offset);
 	if (!src) {
 		return -EINVAL;
@@ -411,7 +405,6 @@ static int flash_flexspi_hyperflash_read(const struct device *dev, off_t offset,
 static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset,
 		const void *buffer, size_t len)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 	size_t size = len;
 	uint8_t *src = (uint8_t *)buffer;
@@ -420,7 +413,7 @@ static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset
 	int ret = -1;
 
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
-			config->port,
+			data->port,
 			offset);
 	if (!dst) {
 		return -EINVAL;
@@ -488,7 +481,6 @@ static int flash_flexspi_hyperflash_write(const struct device *dev, off_t offset
 
 static int flash_flexspi_hyperflash_erase(const struct device *dev, off_t offset, size_t size)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 	flexspi_transfer_t transfer;
 	int ret = -1;
@@ -496,7 +488,7 @@ static int flash_flexspi_hyperflash_erase(const struct device *dev, off_t offset
 	unsigned int key = 0;
 	int num_sectors = size / SPI_HYPERFLASH_SECTOR_SIZE;
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
-			config->port,
+			data->port,
 			offset);
 
 	if (!dst) {
@@ -532,7 +524,7 @@ static int flash_flexspi_hyperflash_erase(const struct device *dev, off_t offset
 		LOG_DBG("Erasing sector at 0x%08x", offset);
 
 		transfer.deviceAddress = offset;
-		transfer.port = config->port;
+		transfer.port = data->port;
 		transfer.cmdType = kFLEXSPI_Command;
 		transfer.SeqNumber = 4;
 		transfer.seqIndex = ERASE_SECTOR;
@@ -571,9 +563,9 @@ static int flash_flexspi_hyperflash_erase(const struct device *dev, off_t offset
 static const struct flash_parameters *flash_flexspi_hyperflash_get_parameters(
 		const struct device *dev)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
+	struct flash_flexspi_hyperflash_data *data = dev->data;
 
-	return &config->flash_parameters;
+	return &data->flash_parameters;
 }
 
 
@@ -581,15 +573,14 @@ static void flash_flexspi_hyperflash_pages_layout(const struct device *dev,
 		const struct flash_pages_layout **layout,
 		size_t *layout_size)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
+	struct flash_flexspi_hyperflash_data *data = dev->data;
 
-	*layout = &config->layout;
+	*layout = &data->layout;
 	*layout_size = 1;
 }
 
 static int flash_flexspi_hyperflash_init(const struct device *dev)
 {
-	const struct flash_flexspi_hyperflash_config *config = dev->config;
 	struct flash_flexspi_hyperflash_data *data = dev->data;
 
 	if (!device_is_ready(data->controller)) {
@@ -599,8 +590,8 @@ static int flash_flexspi_hyperflash_init(const struct device *dev)
 
 	memc_flexspi_wait_bus_idle(data->controller);
 
-	if (memc_flexspi_set_device_config(data->controller, &config->config,
-				config->port)) {
+	if (memc_flexspi_set_device_config(data->controller, &data->config,
+				data->port)) {
 		LOG_ERR("Could not set device configuration");
 		return -EINVAL;
 	}
@@ -665,10 +656,11 @@ static const struct flash_driver_api flash_flexspi_hyperflash_api = {
 	}								\
 
 #define FLASH_FLEXSPI_HYPERFLASH(n)					\
-	static const struct flash_flexspi_hyperflash_config		\
-		flash_flexspi_hyperflash_config_##n = {			\
-		.port = DT_INST_REG_ADDR(n),				\
+	static struct flash_flexspi_hyperflash_data			\
+		flash_flexspi_hyperflash_data_##n = {			\
+		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
 		.config = FLASH_FLEXSPI_DEVICE_CONFIG(n),		\
+		.port = DT_INST_REG_ADDR(n),				\
 		.layout = {						\
 			.pages_count = DT_INST_PROP(n, size) / 8	\
 				/ SPI_HYPERFLASH_SECTOR_SIZE,		\
@@ -680,16 +672,11 @@ static const struct flash_driver_api flash_flexspi_hyperflash_api = {
 		},							\
 	};								\
 									\
-	static struct flash_flexspi_hyperflash_data			\
-		flash_flexspi_hyperflash_data_##n = {			\
-		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
-	};								\
-									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      flash_flexspi_hyperflash_init,		\
 			      NULL,					\
 			      &flash_flexspi_hyperflash_data_##n,	\
-			      &flash_flexspi_hyperflash_config_##n,	\
+			      NULL,					\
 			      POST_KERNEL,				\
 			      CONFIG_FLASH_INIT_PRIORITY,		\
 			      &flash_flexspi_hyperflash_api);

--- a/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
+++ b/drivers/flash/flash_mcux_flexspi_mx25um51345g.c
@@ -28,6 +28,8 @@ static uint8_t nor_write_buf[SPI_NOR_PAGE_SIZE];
  * called while interacting with the flexspi MUST be relocated to SRAM or ITCM
  * at runtime, so that the chip does not access the flexspi to read program
  * instructions while it is being written to
+ *
+ * Additionally, no data used by this driver should be stored in flash.
  */
 #if defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP) && (CONFIG_FLASH_LOG_LEVEL > 0)
 #warning "Enabling flash driver logging and XIP mode simultaneously can cause \
@@ -50,16 +52,13 @@ enum {
 	ERASE_CHIP,
 };
 
-struct flash_flexspi_nor_config {
-	flexspi_port_t port;
-	flexspi_device_config_t config;
-	struct flash_pages_layout layout;
-	struct flash_parameters flash_parameters;
-};
-
 /* Device variables used in critical sections should be in this structure */
 struct flash_flexspi_nor_data {
 	const struct device *controller;
+	flexspi_device_config_t config;
+	flexspi_port_t port;
+	struct flash_pages_layout layout;
+	struct flash_parameters flash_parameters;
 };
 
 static const uint32_t flash_flexspi_nor_lut[][4] = {
@@ -131,14 +130,13 @@ static const uint32_t flash_flexspi_nor_lut[][4] = {
 static int flash_flexspi_nor_get_vendor_id(const struct device *dev,
 		uint8_t *vendor_id)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint32_t buffer = 0;
 	int ret;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Read,
 		.SeqNumber = 1,
 		.seqIndex = READ_ID_OPI,
@@ -157,12 +155,11 @@ static int flash_flexspi_nor_get_vendor_id(const struct device *dev,
 static int flash_flexspi_nor_read_status(const struct device *dev,
 		uint32_t *status)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Read,
 		.SeqNumber = 1,
 		.seqIndex = READ_STATUS_REG,
@@ -178,12 +175,11 @@ static int flash_flexspi_nor_read_status(const struct device *dev,
 static int flash_flexspi_nor_write_status(const struct device *dev,
 		uint32_t *status)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Write,
 		.SeqNumber = 1,
 		.seqIndex = ENTER_OPI,
@@ -199,12 +195,11 @@ static int flash_flexspi_nor_write_status(const struct device *dev,
 static int flash_flexspi_nor_write_enable(const struct device *dev,
 		bool enableOctal)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	flexspi_transfer_t transfer;
 
 	transfer.deviceAddress = 0;
-	transfer.port = config->port;
+	transfer.port = data->port;
 	transfer.cmdType = kFLEXSPI_Command;
 	transfer.SeqNumber = 1;
 	if (enableOctal) {
@@ -223,12 +218,11 @@ static int flash_flexspi_nor_write_enable(const struct device *dev,
 static int flash_flexspi_nor_erase_sector(const struct device *dev,
 		off_t offset)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Command,
 		.SeqNumber = 1,
 		.seqIndex = ERASE_SECTOR,
@@ -243,12 +237,11 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 
 static int flash_flexspi_nor_erase_chip(const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Command,
 		.SeqNumber = 1,
 		.seqIndex = ERASE_CHIP,
@@ -264,12 +257,11 @@ static int flash_flexspi_nor_erase_chip(const struct device *dev)
 static int flash_flexspi_nor_page_program(const struct device *dev,
 		off_t offset, const void *buffer, size_t len)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Write,
 		.SeqNumber = 1,
 		.seqIndex = PAGE_PROGRAM,
@@ -316,10 +308,9 @@ static int flash_flexspi_enable_octal_mode(const struct device *dev)
 static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 		void *buffer, size_t len)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint8_t *src = memc_flexspi_get_ahb_address(data->controller,
-						    config->port,
+						    data->port,
 						    offset);
 
 	memcpy(buffer, src, len);
@@ -330,7 +321,6 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		const void *buffer, size_t len)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	size_t size = len;
 	uint8_t *src = (uint8_t *) buffer;
@@ -338,7 +328,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	unsigned int key = 0;
 
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
-						    config->port,
+						    data->port,
 						    offset);
 
 	if (memc_flexspi_is_running_xip(data->controller)) {
@@ -387,14 +377,13 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		size_t size)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	int num_sectors = size / SPI_NOR_SECTOR_SIZE;
 	int i;
 	unsigned int key = 0;
 
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
-						    config->port,
+						    data->port,
 						    offset);
 
 	if (offset % SPI_NOR_SECTOR_SIZE) {
@@ -416,7 +405,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		key = irq_lock();
 	}
 
-	if ((offset == 0) && (size == config->config.flashSize * KB(1))) {
+	if ((offset == 0) && (size == data->config.flashSize * KB(1))) {
 		flash_flexspi_nor_write_enable(dev, true);
 		flash_flexspi_nor_erase_chip(dev);
 		flash_flexspi_nor_wait_bus_busy(dev);
@@ -446,25 +435,24 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 static const struct flash_parameters *flash_flexspi_nor_get_parameters(
 		const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
-	return &config->flash_parameters;
+	return &data->flash_parameters;
 }
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 static void flash_flexspi_nor_pages_layout(const struct device *dev,
 		const struct flash_pages_layout **layout, size_t *layout_size)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
-	*layout = &config->layout;
+	*layout = &data->layout;
 	*layout_size = 1;
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
 static int flash_flexspi_nor_init(const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint8_t vendor_id;
 
@@ -474,8 +462,8 @@ static int flash_flexspi_nor_init(const struct device *dev)
 	}
 
 	if (!memc_flexspi_is_running_xip(data->controller) &&
-	    memc_flexspi_set_device_config(data->controller, &config->config,
-					   config->port)) {
+	    memc_flexspi_set_device_config(data->controller, &data->config,
+					   data->port)) {
 		LOG_ERR("Could not set device configuration");
 		return -EINVAL;
 	}
@@ -546,10 +534,11 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 	}								\
 
 #define FLASH_FLEXSPI_NOR(n)						\
-	static const struct flash_flexspi_nor_config			\
-		flash_flexspi_nor_config_##n = {			\
-		.port = DT_INST_REG_ADDR(n),				\
+	static struct flash_flexspi_nor_data				\
+		flash_flexspi_nor_data_##n = {				\
+		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
 		.config = FLASH_FLEXSPI_DEVICE_CONFIG(n),		\
+		.port = DT_INST_REG_ADDR(n),				\
 		.layout = {						\
 			.pages_count = DT_INST_PROP(n, size) / 8	\
 				/ SPI_NOR_SECTOR_SIZE,			\
@@ -561,16 +550,11 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 		},							\
 	};								\
 									\
-	static struct flash_flexspi_nor_data				\
-		flash_flexspi_nor_data_##n = {				\
-		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
-	};								\
-									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      flash_flexspi_nor_init,			\
 			      NULL,					\
 			      &flash_flexspi_nor_data_##n,		\
-			      &flash_flexspi_nor_config_##n,		\
+			      NULL,					\
 			      POST_KERNEL,				\
 			      CONFIG_FLASH_INIT_PRIORITY,		\
 			      &flash_flexspi_nor_api);

--- a/drivers/flash/flash_mcux_flexspi_nor.c
+++ b/drivers/flash/flash_mcux_flexspi_nor.c
@@ -28,6 +28,8 @@ static uint8_t nor_write_buf[SPI_NOR_PAGE_SIZE];
  * called while interacting with the flexspi MUST be relocated to SRAM or ITCM
  * at runtime, so that the chip does not access the flexspi to read program
  * instructions while it is being written to
+ *
+ * Additionally, no data used by this driver should be stored in flash.
  */
 #if defined(CONFIG_FLASH_MCUX_FLEXSPI_XIP) && (CONFIG_FLASH_LOG_LEVEL > 0)
 #warning "Enabling flash driver logging and XIP mode simultaneously can cause \
@@ -54,16 +56,13 @@ enum {
 	ERASE_CHIP,
 };
 
-struct flash_flexspi_nor_config {
-	flexspi_port_t port;
-	flexspi_device_config_t config;
-	struct flash_pages_layout layout;
-	struct flash_parameters flash_parameters;
-};
-
 /* Device variables used in critical sections should be in this structure */
 struct flash_flexspi_nor_data {
 	const struct device *controller;
+	flexspi_device_config_t config;
+	flexspi_port_t port;
+	struct flash_pages_layout layout;
+	struct flash_parameters flash_parameters;
 };
 
 static const uint32_t flash_flexspi_nor_lut[][4] = {
@@ -151,14 +150,13 @@ static const uint32_t flash_flexspi_nor_lut[][4] = {
 static int flash_flexspi_nor_get_vendor_id(const struct device *dev,
 		uint8_t *vendor_id)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint32_t buffer = 0;
 	int ret;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Read,
 		.SeqNumber = 1,
 		.seqIndex = READ_ID,
@@ -177,12 +175,11 @@ static int flash_flexspi_nor_get_vendor_id(const struct device *dev,
 static int flash_flexspi_nor_read_status(const struct device *dev,
 		uint32_t *status)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Read,
 		.SeqNumber = 1,
 		.seqIndex = READ_STATUS_REG,
@@ -198,12 +195,11 @@ static int flash_flexspi_nor_read_status(const struct device *dev,
 static int flash_flexspi_nor_write_status(const struct device *dev,
 		uint32_t *status)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Write,
 		.SeqNumber = 1,
 		.seqIndex = WRITE_STATUS_REG,
@@ -218,12 +214,11 @@ static int flash_flexspi_nor_write_status(const struct device *dev,
 
 static int flash_flexspi_nor_write_enable(const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Command,
 		.SeqNumber = 1,
 		.seqIndex = WRITE_ENABLE,
@@ -239,12 +234,11 @@ static int flash_flexspi_nor_write_enable(const struct device *dev)
 static int flash_flexspi_nor_erase_sector(const struct device *dev,
 	off_t offset)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Command,
 		.SeqNumber = 1,
 		.seqIndex = ERASE_SECTOR,
@@ -259,12 +253,11 @@ static int flash_flexspi_nor_erase_sector(const struct device *dev,
 
 static int flash_flexspi_nor_erase_chip(const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = 0,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Command,
 		.SeqNumber = 1,
 		.seqIndex = ERASE_CHIP,
@@ -280,12 +273,11 @@ static int flash_flexspi_nor_erase_chip(const struct device *dev)
 static int flash_flexspi_nor_page_program(const struct device *dev,
 		off_t offset, const void *buffer, size_t len)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 
 	flexspi_transfer_t transfer = {
 		.deviceAddress = offset,
-		.port = config->port,
+		.port = data->port,
 		.cmdType = kFLEXSPI_Write,
 		.SeqNumber = 1,
 		.seqIndex = PAGE_PROGRAM_QUAD_INPUT,
@@ -330,10 +322,9 @@ static int flash_flexspi_nor_enable_quad_mode(const struct device *dev)
 static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 		void *buffer, size_t len)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint8_t *src = memc_flexspi_get_ahb_address(data->controller,
-						    config->port,
+						    data->port,
 						    offset);
 
 	memcpy(buffer, src, len);
@@ -344,7 +335,6 @@ static int flash_flexspi_nor_read(const struct device *dev, off_t offset,
 static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 		const void *buffer, size_t len)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	size_t size = len;
 	uint8_t *src = (uint8_t *) buffer;
@@ -352,7 +342,7 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 	unsigned int key = 0;
 
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
-						    config->port,
+						    data->port,
 						    offset);
 
 	if (memc_flexspi_is_running_xip(data->controller)) {
@@ -401,14 +391,13 @@ static int flash_flexspi_nor_write(const struct device *dev, off_t offset,
 static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		size_t size)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	int num_sectors = size / SPI_NOR_SECTOR_SIZE;
 	int i;
 	unsigned int key = 0;
 
 	uint8_t *dst = memc_flexspi_get_ahb_address(data->controller,
-						    config->port,
+						    data->port,
 						    offset);
 
 	if (offset % SPI_NOR_SECTOR_SIZE) {
@@ -430,7 +419,7 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 		key = irq_lock();
 	}
 
-	if ((offset == 0) && (size == config->config.flashSize * KB(1))) {
+	if ((offset == 0) && (size == data->config.flashSize * KB(1))) {
 		flash_flexspi_nor_write_enable(dev);
 		flash_flexspi_nor_erase_chip(dev);
 		flash_flexspi_nor_wait_bus_busy(dev);
@@ -460,25 +449,24 @@ static int flash_flexspi_nor_erase(const struct device *dev, off_t offset,
 static const struct flash_parameters *flash_flexspi_nor_get_parameters(
 		const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
-	return &config->flash_parameters;
+	return &data->flash_parameters;
 }
 
 #if defined(CONFIG_FLASH_PAGE_LAYOUT)
 static void flash_flexspi_nor_pages_layout(const struct device *dev,
 		const struct flash_pages_layout **layout, size_t *layout_size)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
+	struct flash_flexspi_nor_data *data = dev->data;
 
-	*layout = &config->layout;
+	*layout = &data->layout;
 	*layout_size = 1;
 }
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
 
 static int flash_flexspi_nor_init(const struct device *dev)
 {
-	const struct flash_flexspi_nor_config *config = dev->config;
 	struct flash_flexspi_nor_data *data = dev->data;
 	uint8_t vendor_id;
 
@@ -488,8 +476,8 @@ static int flash_flexspi_nor_init(const struct device *dev)
 	}
 
 	if (!memc_flexspi_is_running_xip(data->controller) &&
-	    memc_flexspi_set_device_config(data->controller, &config->config,
-					   config->port)) {
+	    memc_flexspi_set_device_config(data->controller, &data->config,
+					   data->port)) {
 		LOG_ERR("Could not set device configuration");
 		return -EINVAL;
 	}
@@ -560,10 +548,11 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 	}								\
 
 #define FLASH_FLEXSPI_NOR(n)						\
-	static const struct flash_flexspi_nor_config			\
-		flash_flexspi_nor_config_##n = {			\
-		.port = DT_INST_REG_ADDR(n),				\
+	static struct flash_flexspi_nor_data				\
+		flash_flexspi_nor_data_##n = {				\
+		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
 		.config = FLASH_FLEXSPI_DEVICE_CONFIG(n),		\
+		.port = DT_INST_REG_ADDR(n),				\
 		.layout = {						\
 			.pages_count = DT_INST_PROP(n, size) / 8	\
 				/ SPI_NOR_SECTOR_SIZE,			\
@@ -574,16 +563,12 @@ static const struct flash_driver_api flash_flexspi_nor_api = {
 			.erase_value = NOR_ERASE_VALUE,			\
 		},							\
 	};								\
-	static struct flash_flexspi_nor_data				\
-		flash_flexspi_nor_data_##n = {				\
-		.controller = DEVICE_DT_GET(DT_INST_BUS(n)),		\
-	};								\
 									\
 	DEVICE_DT_INST_DEFINE(n,					\
 			      flash_flexspi_nor_init,			\
 			      NULL,					\
 			      &flash_flexspi_nor_data_##n,		\
-			      &flash_flexspi_nor_config_##n,		\
+			      NULL,					\
 			      POST_KERNEL,				\
 			      CONFIG_FLASH_INIT_PRIORITY,		\
 			      &flash_flexspi_nor_api);


### PR DESCRIPTION
MCUBoot was encountering a usage fault due to read-while-write hazards in the mcux flash driver. Move all device data for the MCUX flash drivers out of flash and into RAM to prevent this fault.

Fixes #45182 