### PR TITLE
Update editorconfig and add additional file types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -31,6 +31,11 @@ indent_size = 4
 indent_style = tab
 indent_size = 8
 
+# reStructuredText
+[*.rst]
+indent_style = space
+indent_size = 3
+
 # YAML
 [*.{yml,yaml}]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,11 @@ indent_size = 8
 indent_style = tab
 indent_size = 8
 
+# C++
+[*.{cpp,hpp}]
+indent_style = tab
+indent_size = 8
+
 # Linker Script
 [*.ld]
 indent_style = tab

--- a/.editorconfig
+++ b/.editorconfig
@@ -68,7 +68,7 @@ indent_size = 8
 
 # Git commit messages
 [COMMIT_EDITMSG]
-max_line_length = 72
+max_line_length = 75
 
 # Kconfig
 [Kconfig*]

--- a/.editorconfig
+++ b/.editorconfig
@@ -21,6 +21,11 @@ indent_size = 8
 indent_style = tab
 indent_size = 8
 
+# Linker Script
+[*.ld]
+indent_style = tab
+indent_size = 8
+
 # Python
 [*.py]
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ charset = utf-8
 end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
-max_line_length = 80
+max_line_length = 100
 
 # Assembly
 [*.S]

--- a/.editorconfig
+++ b/.editorconfig
@@ -75,6 +75,7 @@ indent_size = 2
 # Makefile
 [Makefile]
 indent_style = tab
+indent_size = 8
 
 # Device tree
 [*.{dts,dtsi,overlay}]
@@ -87,4 +88,5 @@ max_line_length = 75
 
 # Kconfig
 [Kconfig*]
-indent_style=tab
+indent_style = tab
+indent_size = 8


### PR DESCRIPTION
This series updates the `.editorconfig` to match the currently enforced styles and also adds some additional file types.