### PR TITLE
twister: add a hardware map support for using serial pty

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -525,6 +525,16 @@ only one board at a time, specified using the ``--platform`` option.
 The ``--device-serial-baud`` option is only needed if your device does not run at
 115200 baud.
 
+To support devices without a physical serial port, use the ``--device-serial-pty``
+option. In this cases, log messages are captured for example using a script.
+In this case you can run twister with the following options::
+
+    scripts/twister --device-testing --device-serial-pty "script.py" \
+    -p intel_adsp_cavs25 -T tests/kernel
+
+The script is user-defined and handles delivering the messages which can be
+used by twister to determine the test execution status.
+
 
 Executing tests on multiple devices
 ===================================
@@ -593,6 +603,46 @@ on those platforms.
   Currently only boards with support for both pyocd and nrfjprog are supported
   with the hardware map features. Boards that require other runners to flash the
   Zephyr binary are still work in progress.
+
+Serial PTY support using ``--device-serial-pty``  can also be used in the
+hardware map::
+
+ - connected: true
+   id: None
+   platform: intel_adsp_cavs18
+   product: None
+   runner: intel_adsp
+   serial_pty: path/to/script.py
+   runner_params:
+     - --remote-host=remote_host_ip_addr
+     - --key=/path/to/key.pem
+ - connected: true
+   id: None
+   platform: intel_adsp_cavs25
+   product: None
+   runner: intel_adsp
+   serial_pty: path/to/script.py
+   runner_params:
+     - --remote-host=remote_host_ip_addr
+     - --key=/path/to/key.pem
+
+
+The runner_params field indicates the parameters you want to pass to the
+west runner. For some boards the west runner needs some extra parameters to
+work. It is equivalent to following west and twister commands::
+
+   west flash --remote-host remote_host_ip_addr --key /path/to/key.pem
+
+   twister -p intel_adsp_cavs18 --device-testing --device-serial-pty script.py
+   --west-flash="--remote-host=remote_host_ip_addr,--key=/path/to/key.pem"
+
+
+.. note::
+
+  For serial PTY, the "--generate-hardware-map" option cannot scan it out
+  and generate a correct hardware map automatically. You have to edit it
+  manually according to above example. This is because the serial port
+  of the PTY is not fixed and being allocated in the system at runtime.
 
 Fixtures
 +++++++++

--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -27,6 +27,14 @@ sequence:
       "runner":
         type: str
         required: true
+      "runner_params":
+        type: seq
+        required: false
+        sequence:
+          - type: str
+      "serial_pty":
+        type: str
+        required: false
       "serial":
         type: str
         required: false


### PR DESCRIPTION
The hardware map feature can be used with serial pty mode in
this change. And also add an extra_params option for passing
more parameters from hardware map file to west runner. Note
that you need to create this map file manually because it
cannot be scanned out correctly due to pty is not a physical
HW device existing in system.

And also update doc/develop/test/twister.rst for the usage.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>