### PR TITLE
Add LiteX CSR metadata

### DIFF
--- a/drivers/clock_control/clock_control_litex.h
+++ b/drivers/clock_control/clock_control_litex.h
@@ -33,14 +33,14 @@
 /* Base address */
 #define DRP_BASE		DT_REG_ADDR_BY_IDX(MMCM, 0)
 /* Register address */
-#define DRP_ADDR_RESET		DT_REG_ADDR_BY_IDX(MMCM, 0/*DRP_RESET*/)
-#define DRP_ADDR_LOCKED		DT_REG_ADDR_BY_IDX(MMCM, 1/*DRP_LOCEKD*/)
-#define DRP_ADDR_READ		DT_REG_ADDR_BY_IDX(MMCM, 2/*DRP_READ*/)
-#define DRP_ADDR_WRITE		DT_REG_ADDR_BY_IDX(MMCM, 3/*DRP_WRITE*/)
-#define DRP_ADDR_DRDY		DT_REG_ADDR_BY_IDX(MMCM, 4/*DRP_DRDY*/)
-#define DRP_ADDR_ADR		DT_REG_ADDR_BY_IDX(MMCM, 5/*DRP_ADR*/)
-#define DRP_ADDR_DAT_W		DT_REG_ADDR_BY_IDX(MMCM, 6/*DRP_DAT_W*/)
-#define DRP_ADDR_DAT_R		DT_REG_ADDR_BY_IDX(MMCM, 7/*DRP_DAT_R*/)
+#define DRP_ADDR_RESET		DT_REG_ADDR_BY_NAME(MMCM, drp_reset)
+#define DRP_ADDR_LOCKED		DT_REG_ADDR_BY_NAME(MMCM, drp_locked)
+#define DRP_ADDR_READ		DT_REG_ADDR_BY_NAME(MMCM, drp_read)
+#define DRP_ADDR_WRITE		DT_REG_ADDR_BY_NAME(MMCM, drp_write)
+#define DRP_ADDR_DRDY		DT_REG_ADDR_BY_NAME(MMCM, drp_drdy)
+#define DRP_ADDR_ADR		DT_REG_ADDR_BY_NAME(MMCM, drp_adr)
+#define DRP_ADDR_DAT_W		DT_REG_ADDR_BY_NAME(MMCM, drp_dat_w)
+#define DRP_ADDR_DAT_R		DT_REG_ADDR_BY_NAME(MMCM, drp_dat_r)
 
 /* Devicetree global defines */
 #define LOCK_TIMEOUT		DT_PROP(MMCM, litex_lock_timeout)

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -29,30 +29,28 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define LITEETH_EV_RX		0x1
 
 /* slots */
-#define LITEETH_SLOT_BASE	DT_INST_REG_ADDR_BY_NAME(0, buffers)
-#define LITEETH_SLOT_RX0	((LITEETH_SLOT_BASE) + 0x0000)
-#define LITEETH_SLOT_RX1	((LITEETH_SLOT_BASE) + 0x0800)
-#define LITEETH_SLOT_TX0	((LITEETH_SLOT_BASE) + 0x1000)
-#define LITEETH_SLOT_TX1	((LITEETH_SLOT_BASE) + 0x1800)
+#define LITEETH_SLOT_BASE_ADDR		DT_INST_REG_ADDR_BY_NAME(0, buffers)
+#define LITEETH_SLOT_RX0_ADDR		(LITEETH_SLOT_BASE_ADDR + 0x0000)
+#define LITEETH_SLOT_RX1_ADDR		(LITEETH_SLOT_BASE_ADDR + 0x0800)
+#define LITEETH_SLOT_TX0_ADDR		(LITEETH_SLOT_BASE_ADDR + 0x1000)
+#define LITEETH_SLOT_TX1_ADDR		(LITEETH_SLOT_BASE_ADDR + 0x1800)
 
 /* sram - rx */
-#define LITEETH_RX_BASE		DT_INST_REG_ADDR_BY_NAME(0, control)
-#define LITEETH_RX_SLOT		((LITEETH_RX_BASE) + 0x00)
-#define LITEETH_RX_LENGTH	((LITEETH_RX_BASE) + 0x04)
-#define LITEETH_RX_EV_PENDING	((LITEETH_RX_BASE) + 0x28)
-#define LITEETH_RX_EV_ENABLE	((LITEETH_RX_BASE) + 0x2c)
+#define LITEETH_RX_SLOT_ADDR		DT_INST_REG_ADDR_BY_NAME(0, rx_slot)
+#define LITEETH_RX_LENGTH_ADDR		DT_INST_REG_ADDR_BY_NAME(0, rx_length)
+#define LITEETH_RX_EV_PENDING_ADDR	DT_INST_REG_ADDR_BY_NAME(0, rx_ev_pending)
+#define LITEETH_RX_EV_ENABLE_ADDR	DT_INST_REG_ADDR_BY_NAME(0, rx_ev_enable)
 
 /* sram - tx */
-#define LITEETH_TX_BASE		((DT_INST_REG_ADDR_BY_NAME(0, control)) + 0x30)
-#define LITEETH_TX_START	((LITEETH_TX_BASE) + 0x00)
-#define LITEETH_TX_READY	((LITEETH_TX_BASE) + 0x04)
-#define LITEETH_TX_SLOT		((LITEETH_TX_BASE) + 0x0c)
-#define LITEETH_TX_LENGTH	((LITEETH_TX_BASE) + 0x10)
-#define LITEETH_TX_EV_PENDING	((LITEETH_TX_BASE) + 0x1c)
+#define LITEETH_TX_START_ADDR		DT_INST_REG_ADDR_BY_NAME(0, tx_start)
+#define LITEETH_TX_READY_ADDR		DT_INST_REG_ADDR_BY_NAME(0, tx_ready)
+#define LITEETH_TX_SLOT_ADDR		DT_INST_REG_ADDR_BY_NAME(0, tx_slot)
+#define LITEETH_TX_LENGTH_ADDR		DT_INST_REG_ADDR_BY_NAME(0, tx_length)
+#define LITEETH_TX_EV_PENDING_ADDR	DT_INST_REG_ADDR_BY_NAME(0, tx_ev_pending)
 
 /* irq */
-#define LITEETH_IRQ		DT_INST_IRQN(0)
-#define LITEETH_IRQ_PRIORITY	DT_INST_IRQ(0, priority)
+#define LITEETH_IRQ			DT_INST_IRQN(0)
+#define LITEETH_IRQ_PRIORITY		DT_INST_IRQ(0, priority)
 
 #define MAX_TX_FAILURE 100
 
@@ -93,11 +91,11 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	len = net_pkt_get_len(pkt);
 	net_pkt_read(pkt, context->tx_buf[context->txslot], len);
 
-	litex_write8(context->txslot, LITEETH_TX_SLOT);
-	litex_write16(len, LITEETH_TX_LENGTH);
+	litex_write8(context->txslot, LITEETH_TX_SLOT_ADDR);
+	litex_write16(len, LITEETH_TX_LENGTH_ADDR);
 
 	/* wait for the device to be ready to transmit */
-	while (litex_read8(LITEETH_TX_READY) == 0) {
+	while (litex_read8(LITEETH_TX_READY_ADDR) == 0) {
 		if (attempts++ == MAX_TX_FAILURE) {
 			goto error;
 		}
@@ -105,7 +103,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	}
 
 	/* start transmitting */
-	litex_write8(1, LITEETH_TX_START);
+	litex_write8(1, LITEETH_TX_START_ADDR);
 
 	/* change slot */
 	context->txslot = (context->txslot + 1) % 2;
@@ -131,10 +129,10 @@ static void eth_rx(const struct device *port)
 	key = irq_lock();
 
 	/* get frame's length */
-	len = litex_read32(LITEETH_RX_LENGTH);
+	len = litex_read32(LITEETH_RX_LENGTH_ADDR);
 
 	/* which slot is the frame in */
-	context->rxslot = litex_read8(LITEETH_RX_SLOT);
+	context->rxslot = litex_read8(LITEETH_RX_SLOT_ADDR);
 
 	/* obtain rx buffer */
 	pkt = net_pkt_rx_alloc_with_buffer(context->iface, len, AF_UNSPEC, 0,
@@ -165,19 +163,19 @@ out:
 static void eth_irq_handler(const struct device *port)
 {
 	/* check sram reader events (tx) */
-	if (litex_read8(LITEETH_TX_EV_PENDING) & LITEETH_EV_TX) {
+	if (litex_read8(LITEETH_TX_EV_PENDING_ADDR) & LITEETH_EV_TX) {
 		/* TX event is not enabled nor used by this driver; ack just
 		 * in case if some rogue TX event appeared
 		 */
-		litex_write8(LITEETH_EV_TX, LITEETH_TX_EV_PENDING);
+		litex_write8(LITEETH_EV_TX, LITEETH_TX_EV_PENDING_ADDR);
 	}
 
 	/* check sram writer events (rx) */
-	if (litex_read8(LITEETH_RX_EV_PENDING) & LITEETH_EV_RX) {
+	if (litex_read8(LITEETH_RX_EV_PENDING_ADDR) & LITEETH_EV_RX) {
 		eth_rx(port);
 
 		/* ack writer irq */
-		litex_write8(LITEETH_EV_RX, LITEETH_RX_EV_PENDING);
+		litex_write8(LITEETH_EV_RX, LITEETH_RX_EV_PENDING_ADDR);
 	}
 }
 
@@ -222,18 +220,18 @@ static void eth_iface_init(struct net_if *iface)
 	}
 
 	/* clear pending events */
-	litex_write8(LITEETH_EV_TX, LITEETH_TX_EV_PENDING);
-	litex_write8(LITEETH_EV_RX, LITEETH_RX_EV_PENDING);
+	litex_write8(LITEETH_EV_TX, LITEETH_TX_EV_PENDING_ADDR);
+	litex_write8(LITEETH_EV_RX, LITEETH_RX_EV_PENDING_ADDR);
 
 	/* setup tx slots */
 	context->txslot = 0;
-	context->tx_buf[0] = (uint8_t *)LITEETH_SLOT_TX0;
-	context->tx_buf[1] = (uint8_t *)LITEETH_SLOT_TX1;
+	context->tx_buf[0] = (uint8_t *)LITEETH_SLOT_TX0_ADDR;
+	context->tx_buf[1] = (uint8_t *)LITEETH_SLOT_TX1_ADDR;
 
 	/* setup rx slots */
 	context->rxslot = 0;
-	context->rx_buf[0] = (uint8_t *)LITEETH_SLOT_RX0;
-	context->rx_buf[1] = (uint8_t *)LITEETH_SLOT_RX1;
+	context->rx_buf[0] = (uint8_t *)LITEETH_SLOT_RX0_ADDR;
+	context->rx_buf[1] = (uint8_t *)LITEETH_SLOT_RX1_ADDR;
 
 	init_done = true;
 }
@@ -260,7 +258,7 @@ static void eth_irq_config(void)
 	IRQ_CONNECT(LITEETH_IRQ, LITEETH_IRQ_PRIORITY, eth_irq_handler,
 		    DEVICE_DT_INST_GET(0), 0);
 	irq_enable(LITEETH_IRQ);
-	litex_write8(1, LITEETH_RX_EV_ENABLE);
+	litex_write8(1, LITEETH_RX_EV_ENABLE_ADDR);
 }
 
 #endif /* CONFIG_ETH_LITEETH_0 */

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -14,16 +14,18 @@
 #include <drivers/uart.h>
 #include <zephyr/types.h>
 
-#define UART_EV_TX	(1 << 0)
-#define UART_EV_RX	(1 << 1)
-#define UART_BASE_ADDR	DT_INST_REG_ADDR(0)
-#define UART_RXTX	((UART_BASE_ADDR) + 0x00)
-#define UART_TXFULL	((UART_BASE_ADDR) + 0x04)
-#define UART_RXEMPTY	((UART_BASE_ADDR) + 0x08)
-#define UART_EV_STATUS	((UART_BASE_ADDR) + 0x0c)
-#define UART_EV_PENDING	((UART_BASE_ADDR) + 0x10)
-#define UART_EV_ENABLE	((UART_BASE_ADDR) + 0x14)
-#define UART_IRQ	DT_INST_IRQN(0)
+#define UART_RXTX_ADDR		DT_INST_REG_ADDR_BY_NAME(0, rxtx)
+#define UART_TXFULL_ADDR	DT_INST_REG_ADDR_BY_NAME(0, txfull)
+#define UART_RXEMPTY_ADDR	DT_INST_REG_ADDR_BY_NAME(0, rxempty)
+#define UART_EV_STATUS_ADDR	DT_INST_REG_ADDR_BY_NAME(0, ev_status)
+#define UART_EV_PENDING_ADDR	DT_INST_REG_ADDR_BY_NAME(0, ev_pending)
+#define UART_EV_ENABLE_ADDR	DT_INST_REG_ADDR_BY_NAME(0, ev_enable)
+#define UART_TXEMPTY_ADDR	DT_INST_REG_ADDR_BY_NAME(0, txempty)
+#define UART_RXFULL_ADDR	DT_INST_REG_ADDR_BY_NAME(0, rxfull)
+
+#define UART_EV_TX		(1 << 0)
+#define UART_EV_RX		(1 << 1)
+#define UART_IRQ		DT_INST_IRQN(0)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 typedef void (*irq_cfg_func_t)(void);
@@ -56,10 +58,10 @@ struct uart_liteuart_data {
 static void uart_liteuart_poll_out(const struct device *dev, unsigned char c)
 {
 	/* wait for space */
-	while (litex_read8(UART_TXFULL)) {
+	while (litex_read8(UART_TXFULL_ADDR)) {
 	}
 
-	litex_write8(c, UART_RXTX);
+	litex_write8(c, UART_RXTX_ADDR);
 }
 
 /**
@@ -72,13 +74,13 @@ static void uart_liteuart_poll_out(const struct device *dev, unsigned char c)
  */
 static int uart_liteuart_poll_in(const struct device *dev, unsigned char *c)
 {
-	if (!litex_read8(UART_RXEMPTY)) {
-		*c = litex_read8(UART_RXTX);
+	if (!litex_read8(UART_RXEMPTY_ADDR)) {
+		*c = litex_read8(UART_RXTX_ADDR);
 
 		/* refresh UART_RXEMPTY by writing UART_EV_RX
 		 * to UART_EV_PENDING
 		 */
-		litex_write8(UART_EV_RX, UART_EV_PENDING);
+		litex_write8(UART_EV_RX, UART_EV_PENDING_ADDR);
 		return 0;
 	} else {
 		return -1;
@@ -93,9 +95,9 @@ static int uart_liteuart_poll_in(const struct device *dev, unsigned char *c)
  */
 static void uart_liteuart_irq_tx_enable(const struct device *dev)
 {
-	uint8_t enable = litex_read8(UART_EV_ENABLE);
+	uint8_t enable = litex_read8(UART_EV_ENABLE_ADDR);
 
-	litex_write8(enable | UART_EV_TX, UART_EV_ENABLE);
+	litex_write8(enable | UART_EV_TX, UART_EV_ENABLE_ADDR);
 }
 
 /**
@@ -105,9 +107,9 @@ static void uart_liteuart_irq_tx_enable(const struct device *dev)
  */
 static void uart_liteuart_irq_tx_disable(const struct device *dev)
 {
-	uint8_t enable = litex_read8(UART_EV_ENABLE);
+	uint8_t enable = litex_read8(UART_EV_ENABLE_ADDR);
 
-	litex_write8(enable & ~(UART_EV_TX), UART_EV_ENABLE);
+	litex_write8(enable & ~(UART_EV_TX), UART_EV_ENABLE_ADDR);
 }
 
 /**
@@ -117,9 +119,9 @@ static void uart_liteuart_irq_tx_disable(const struct device *dev)
  */
 static void uart_liteuart_irq_rx_enable(const struct device *dev)
 {
-	uint8_t enable = litex_read8(UART_EV_ENABLE);
+	uint8_t enable = litex_read8(UART_EV_ENABLE_ADDR);
 
-	litex_write8(enable | UART_EV_RX, UART_EV_ENABLE);
+	litex_write8(enable | UART_EV_RX, UART_EV_ENABLE_ADDR);
 }
 
 /**
@@ -129,9 +131,9 @@ static void uart_liteuart_irq_rx_enable(const struct device *dev)
  */
 static void uart_liteuart_irq_rx_disable(const struct device *dev)
 {
-	uint8_t enable = litex_read8(UART_EV_ENABLE);
+	uint8_t enable = litex_read8(UART_EV_ENABLE_ADDR);
 
-	litex_write8(enable & ~(UART_EV_RX), UART_EV_ENABLE);
+	litex_write8(enable & ~(UART_EV_RX), UART_EV_ENABLE_ADDR);
 }
 
 /**
@@ -143,7 +145,7 @@ static void uart_liteuart_irq_rx_disable(const struct device *dev)
  */
 static int uart_liteuart_irq_tx_ready(const struct device *dev)
 {
-	uint8_t val = litex_read8(UART_TXFULL);
+	uint8_t val = litex_read8(UART_TXFULL_ADDR);
 
 	return !val;
 }
@@ -159,7 +161,7 @@ static int uart_liteuart_irq_rx_ready(const struct device *dev)
 {
 	uint8_t pending;
 
-	pending = litex_read8(UART_EV_PENDING);
+	pending = litex_read8(UART_EV_PENDING_ADDR);
 
 	if (pending & UART_EV_RX) {
 		return 1;
@@ -182,8 +184,8 @@ static int uart_liteuart_fifo_fill(const struct device *dev,
 {
 	int i;
 
-	for (i = 0; i < size && !litex_read8(UART_TXFULL); i++) {
-		litex_write8(tx_data[i], UART_RXTX);
+	for (i = 0; i < size && !litex_read8(UART_TXFULL_ADDR); i++) {
+		litex_write8(tx_data[i], UART_RXTX_ADDR);
 	}
 
 	return i;
@@ -203,13 +205,13 @@ static int uart_liteuart_fifo_read(const struct device *dev,
 {
 	int i;
 
-	for (i = 0; i < size && !litex_read8(UART_RXEMPTY); i++) {
-		rx_data[i] = litex_read8(UART_RXTX);
+	for (i = 0; i < size && !litex_read8(UART_RXEMPTY_ADDR); i++) {
+		rx_data[i] = litex_read8(UART_RXTX_ADDR);
 
 		/* refresh UART_RXEMPTY by writing UART_EV_RX
 		 * to UART_EV_PENDING
 		 */
-		litex_write8(UART_EV_RX, UART_EV_PENDING);
+		litex_write8(UART_EV_RX, UART_EV_PENDING_ADDR);
 	}
 
 	return i;
@@ -231,7 +233,7 @@ static int uart_liteuart_irq_is_pending(const struct device *dev)
 {
 	uint8_t pending;
 
-	pending = litex_read8(UART_EV_PENDING);
+	pending = litex_read8(UART_EV_PENDING_ADDR);
 
 	if (pending & (UART_EV_TX | UART_EV_RX)) {
 		return 1;
@@ -272,7 +274,7 @@ static void liteuart_uart_irq_handler(const struct device *dev)
 	}
 
 	/* clear events */
-	litex_write8(UART_EV_TX | UART_EV_RX, UART_EV_PENDING);
+	litex_write8(UART_EV_TX | UART_EV_RX, UART_EV_PENDING_ADDR);
 
 	irq_unlock(key);
 }
@@ -303,7 +305,7 @@ static struct uart_liteuart_data uart_liteuart_data_0;
 static int uart_liteuart_init(const struct device *dev);
 
 static const struct uart_liteuart_device_config uart_liteuart_dev_cfg_0 = {
-	.port		= UART_BASE_ADDR,
+	.port		= UART_RXTX_ADDR,
 	.baud_rate	= DT_INST_PROP(0, current_speed)
 };
 
@@ -316,7 +318,7 @@ DEVICE_DT_INST_DEFINE(0,
 
 static int uart_liteuart_init(const struct device *dev)
 {
-	litex_write8(UART_EV_TX | UART_EV_RX, UART_EV_PENDING);
+	litex_write8(UART_EV_TX | UART_EV_RX, UART_EV_PENDING_ADDR);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	IRQ_CONNECT(UART_IRQ, DT_INST_IRQ(0, priority),

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -13,20 +13,20 @@
 #include <spinlock.h>
 #include <drivers/timer/system_timer.h>
 
-#define TIMER_BASE	        DT_INST_REG_ADDR(0)
-#define TIMER_LOAD_ADDR		((TIMER_BASE) + 0x00)
-#define TIMER_RELOAD_ADDR	((TIMER_BASE) + 0x10)
-#define TIMER_EN_ADDR		((TIMER_BASE) + 0x20)
-#define TIMER_EV_PENDING_ADDR	((TIMER_BASE) + 0x3c)
-#define TIMER_EV_ENABLE_ADDR	((TIMER_BASE) + 0x40)
-#define TIMER_TOTAL_UPDATE	((TIMER_BASE) + 0x44)
-#define TIMER_TOTAL		((TIMER_BASE) + 0x48)
+#define TIMER_LOAD_ADDR		DT_INST_REG_ADDR_BY_NAME(0, load)
+#define TIMER_RELOAD_ADDR	DT_INST_REG_ADDR_BY_NAME(0, reload)
+#define TIMER_EN_ADDR		DT_INST_REG_ADDR_BY_NAME(0, en)
+#define TIMER_UPDATE_VALUE_ADDR	DT_INST_REG_ADDR_BY_NAME(0, update_value)
+#define TIMER_VALUE_ADDR	DT_INST_REG_ADDR_BY_NAME(0, value)
+#define TIMER_EV_STATUS_ADDR	DT_INST_REG_ADDR_BY_NAME(0, ev_status)
+#define TIMER_EV_PENDING_ADDR	DT_INST_REG_ADDR_BY_NAME(0, ev_pending)
+#define TIMER_EV_ENABLE_ADDR	DT_INST_REG_ADDR_BY_NAME(0, ev_enable)
 
-#define TIMER_EV	0x1
-#define TIMER_IRQ	DT_INST_IRQN(0)
-#define TIMER_DISABLE	0x0
-#define TIMER_ENABLE	0x1
-#define UPDATE_TOTAL	0x1
+#define TIMER_EV		0x1
+#define TIMER_IRQ		DT_INST_IRQN(0)
+#define TIMER_DISABLE		0x0
+#define TIMER_ENABLE		0x1
+#define TIMER_UPDATE_VALUE	0x1
 
 static void litex_timer_irq_handler(const void *device)
 {
@@ -41,29 +41,29 @@ static void litex_timer_irq_handler(const void *device)
 uint32_t sys_clock_cycle_get_32(void)
 {
 	static struct k_spinlock lock;
-	uint32_t timer_total;
+	uint32_t timer_value;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	litex_write8(UPDATE_TOTAL, TIMER_TOTAL_UPDATE);
-	timer_total = (uint32_t)litex_read64(TIMER_TOTAL);
+	litex_write8(TIMER_UPDATE_VALUE, TIMER_UPDATE_VALUE_ADDR);
+	timer_value = (uint32_t)litex_read64(TIMER_VALUE_ADDR);
 
 	k_spin_unlock(&lock, key);
 
-	return timer_total;
+	return timer_value;
 }
 
 uint64_t sys_clock_cycle_get_64(void)
 {
 	static struct k_spinlock lock;
-	uint64_t timer_total;
+	uint64_t timer_value;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
-	litex_write8(UPDATE_TOTAL, TIMER_TOTAL_UPDATE);
-	timer_total = litex_read64(TIMER_TOTAL);
+	litex_write8(TIMER_UPDATE_VALUE, TIMER_UPDATE_VALUE_ADDR);
+	timer_value = litex_read64(TIMER_VALUE_ADDR);
 
 	k_spin_unlock(&lock, key);
 
-	return timer_total;
+	return timer_value;
 }
 
 /* tickless kernel is not supported */

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -104,9 +104,28 @@
 			compatible = "litex,eth0";
 			interrupt-parent = <&intc0>;
 			interrupts = <3 0>;
-			reg = <0xe0009800 0x6b 0xb0000000 0x2000>;
+			reg = <0xe0009800 0x4
+				0xe0009804 0x8
+				0xe0009828 0x4
+				0xe000982c 0x4
+				0xe0009830 0x4
+				0xe0009834 0x4
+				0xe000983c 0x4
+				0xe0009840 0x8
+				0xe000984c 0x4
+				0xb0000000 0x2000>;
 			local-mac-address = [10 e2 d5 00 00 02];
-			reg-names = "control", "buffers";
+			reg-names =
+				"rx_slot",
+				"rx_length",
+				"rx_ev_pending",
+				"rx_ev_enable",
+				"tx_start",
+				"tx_ready",
+				"tx_slot",
+				"tx_length",
+				"tx_ev_pending",
+				"buffers";
 			label = "eth0";
 			status = "disabled";
 		};

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -65,8 +65,23 @@
 			compatible = "litex,timer0";
 			interrupt-parent = <&intc0>;
 			interrupts = <1 0>;
-			reg = <0xe0002800 0x40>;
-			reg-names = "control";
+			reg = <0xe0002800 0x10
+				0xe0002810 0x10
+				0xe0002820 0x4
+				0xe0002824 0x4
+				0xe0002828 0x10
+				0xe0002838 0x4
+				0xe000283c 0x4
+				0xe0002840 0x4>;
+			reg-names =
+				"load",
+				"reload",
+				"en",
+				"update_value",
+				"value",
+				"ev_status",
+				"ev_pending",
+				"ev_enable";
 			label = "timer0";
 			status = "disabled";
 		};

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -45,8 +45,23 @@
 			compatible = "litex,uart0";
 			interrupt-parent = <&intc0>;
 			interrupts = <2 10>;
-			reg = <0xe0001800 0x18>;
-			reg-names = "control";
+			reg = <0xe0001800 0x4
+				0xe0001804 0x4
+				0xe0001808 0x4
+				0xe000180c 0x4
+				0xe0001810 0x4
+				0xe0001814 0x4
+				0xe0001818 0x4
+				0xe000181c 0x4>;
+			reg-names =
+				"rxtx",
+				"txfull",
+				"rxempty",
+				"ev_status",
+				"ev_pending",
+				"ev_enable",
+				"txempty",
+				"rxfull";
 			label = "uart0";
 			status = "disabled";
 		};


### PR DESCRIPTION
**This is one of two PRs needed to fully support both 8-bit and 32-bit LiteX CSRs (the other one is #45196)**

Mainly created to fix issues mentioned in https://github.com/enjoy-digital/litex/issues/1062, but there have been multiple other reports about Zephyr incompatibility with 32-bit CSRs.

It also does what #39304 tried to do, but without breaking support for 8-bit CSRs.

## What and why

As described in #45196, CSR that takes 4 subregisters with 8-bit data width, takes only 1 subregister when data width is 32-bits (`|S...|S...|S...|S...| -> |SSSS|`).
This means, that offsets of individual registers can vary depending on configured CSR data width.
Current Zephyr drivers have those offsets hardcoded for 8-bit CSRs.

This PR splits register regions provided in DTS into separate, named registers.
Otherwise drivers would have to calculate address of each register based on address of preceding register and it's size.

This approach makes it also future proof if there are any changes in LiteX regarding ordering of CSRs.

I also added `_ADDR` suffix to defines where it was missing and updated register names in timer driver.

---

1. When #45196 is merged, I will rebase this, because there are some places where both branches touch the same code.

2. Although overlays can be written manually, LiteX has litex_json2dts_zephyr script, which needs to be updated after this is merged https://github.com/enjoy-digital/litex/pull/1287.