### PR TITLE
drivers: gpio: fix gpio_emul driver to allow multiple instances

### DIFF
--- a/drivers/gpio/gpio_emul.c
+++ b/drivers/gpio/gpio_emul.c
@@ -738,6 +738,6 @@ static int gpio_emul_pm_device_pm_action(const struct device *dev,
 			    &gpio_emul_data_##_num,			\
 			    &gpio_emul_config_##_num, POST_KERNEL,	\
 			    CONFIG_GPIO_INIT_PRIORITY,			\
-			    &gpio_emul_driver)
+			    &gpio_emul_driver);
 
-DT_INST_FOREACH_STATUS_OKAY(DEFINE_GPIO_EMUL);
+DT_INST_FOREACH_STATUS_OKAY(DEFINE_GPIO_EMUL)


### PR DESCRIPTION
Without this change, Zephyr does not build if more than one "zephyr,gpio-emul" compatible device is defined in the device tree.

Signed-off-by: Jan Peters <peters@kt-elektronik.de>