### PR TITLE
Bluetooth: pacs: Make location characteristics non-writable by default

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.pacs
+++ b/subsys/bluetooth/audio/Kconfig.pacs
@@ -45,7 +45,6 @@ config BT_PAC_SNK_LOC
 
 config BT_PAC_SNK_LOC_WRITEABLE
 	bool "Sink PAC Location Writable Support"
-	default y
 	depends on BT_PAC_SNK_LOC
 	help
 	  This option enables support for clients to write to the Sink PAC
@@ -87,7 +86,6 @@ config BT_PAC_SRC_LOC
 
 config BT_PAC_SRC_LOC_WRITEABLE
 	bool "Source PAC Location Writable Support"
-	default y
 	depends on BT_PAC_SRC_LOC
 	help
 	  This option enables support for clients to write to the Source PAC


### PR DESCRIPTION
The Sink Audio Locations and Source Audio Locations characteristics are
optionally writtable as defined in PACS_v1.0.
If the property is not mandatory in the specification it should be
disabled in implementation by default. It is more likely that the
location value will not change over time, as the end-product would
be designed to be used in specific way (in specific location).
If the user wants to make use of the writtable location feature, then
one has to enable it explicitly.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>