### PR TITLE
drivers: pwm: shell: fix struct variable name

### DIFF
--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -15,7 +15,7 @@
 
 struct args_index {
 	uint8_t device;
-	uint8_t pwm;
+	uint8_t channel;
 	uint8_t period;
 	uint8_t pulse;
 	uint8_t flags;

--- a/drivers/pwm/pwm_shell.c
+++ b/drivers/pwm/pwm_shell.c
@@ -85,7 +85,7 @@ static int cmd_usec(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_set_cycles_usec(dev, channel, period, pulse, flags);
+	err = pwm_set(dev, channel, PWM_USEC(period), PWM_USEC(pulse), flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;
@@ -117,7 +117,7 @@ static int cmd_nsec(const struct shell *shell, size_t argc, char **argv)
 		flags = strtoul(argv[args_indx.flags], NULL, 0);
 	}
 
-	err = pwm_set_cycles_nsec(dev, channel, period, pulse, flags);
+	err = pwm_set(dev, channel, period, pulse, flags);
 	if (err) {
 		shell_error(shell, "failed to setup PWM (err %d)", err);
 		return err;


### PR DESCRIPTION
The pwm field in struct args_index was missed when pwm was renamed to
channel in all drivers. As a result, the PWM shell could no longer be
built.