### PR TITLE
ARC: SMP: debug: workaround MDB changing debug_select value

### DIFF
--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -23,6 +23,8 @@
 
 #define ARCV2_ICI_IRQ_PRIORITY 1
 
+#define MP_PRIMARY_CPU_ID 0
+
 volatile struct {
 	arch_cpustart_t fn;
 	void *arg;
@@ -71,7 +73,14 @@ static void arc_connect_debug_mask_update(int cpu_num)
 {
 	uint32_t core_mask = 1 << cpu_num;
 
-	core_mask |= z_arc_connect_debug_select_read();
+	/*
+	 * MDB debugger may modify debug_select and debug_mask registers on start, so we can't
+	 * rely on debug_select reset value.
+	 */
+	if (cpu_num != MP_PRIMARY_CPU_ID) {
+		core_mask |= z_arc_connect_debug_select_read();
+	}
+
 	z_arc_connect_debug_select_set(core_mask);
 	/* Debugger halts cores at all conditions:
 	 * ARC_CONNECT_CMD_DEBUG_MASK_H: Core global halt.
@@ -147,7 +156,7 @@ static int arc_smp_init(const struct device *dev)
 
 	if (bcr.dbg) {
 		/* configure inter-core debug unit if available */
-		arc_connect_debug_mask_update(0);
+		arc_connect_debug_mask_update(MP_PRIMARY_CPU_ID);
 	}
 
 	if (bcr.ipi) {


### PR DESCRIPTION
MDB debugger may modify debug_select and debug_mask registers on start, so we can't rely on debug_select reset value.

Let's set correct value on primary CPU without reading initial value from debug_select.

Internal ID: P10019563-50516