### PR TITLE
Bluetooth: Controller: llcp: fix wrong condition in prepare instant 

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -310,7 +310,7 @@ static void pu_prepare_instant(struct ll_conn *conn, struct proc_ctx *ctx)
 	/* Set instance only in case there is actual PHY change. Otherwise the instant should be
 	 * set to 0.
 	 */
-	if (ctx->data.pu.tx != 0 && ctx->data.pu.rx != 0) {
+	if (ctx->data.pu.c_to_p_phy  != 0 || ctx->data.pu.p_to_c_phy != 0) {
 		ctx->data.pu.instant = ull_conn_event_counter(conn) + PHY_UPDATE_INSTANT_DELTA;
 	} else {
 		ctx->data.pu.instant = 0;
@@ -342,6 +342,7 @@ static void lp_pu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 #if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND:
 		pu_prep_update_ind(conn, ctx);
+		pu_prepare_instant(conn, ctx);
 		llcp_pdu_encode_phy_update_ind(ctx, pdu);
 		break;
 #endif /* CONFIG_BT_CENTRAL */
@@ -473,7 +474,6 @@ static void lp_pu_send_phy_update_ind(struct ll_conn *conn, struct proc_ctx *ctx
 	if (llcp_lr_ispaused(conn) || !llcp_tx_alloc_peek(conn, ctx)) {
 		ctx->state = LP_PU_STATE_WAIT_TX_PHY_UPDATE_IND;
 	} else {
-		pu_prepare_instant(conn, ctx);
 		lp_pu_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND);
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_UNUSED;
 		ctx->state = LP_PU_STATE_WAIT_TX_ACK_PHY_UPDATE_IND;
@@ -815,6 +815,7 @@ static void rp_pu_tx(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t opcode)
 #if defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND:
 		pu_prep_update_ind(conn, ctx);
+		pu_prepare_instant(conn, ctx);
 		llcp_pdu_encode_phy_update_ind(ctx, pdu);
 		break;
 #endif /* CONFIG_BT_CENTRAL */
@@ -886,7 +887,6 @@ static void rp_pu_send_phy_update_ind(struct ll_conn *conn, struct proc_ctx *ctx
 		ctx->state = RP_PU_STATE_WAIT_TX_PHY_UPDATE_IND;
 	} else {
 		llcp_rr_set_paused_cmd(conn, PROC_CTE_REQ);
-		pu_prepare_instant(conn, ctx);
 		rp_pu_tx(conn, ctx, PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND);
 
 		ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_UNUSED;

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -42,6 +42,8 @@
 #define PREFER_S8_CODING 1
 #define PREFER_S2_CODING 0
 
+#define HOST_INITIATED 1U
+
 static struct ll_conn conn;
 
 static void setup(void)
@@ -130,7 +132,7 @@ void test_phy_update_central_loc(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an PHY Update Procedure */
-	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/* Prepare */
@@ -234,7 +236,7 @@ void test_phy_update_central_loc_invalid(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an PHY Update Procedure */
-	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/* Prepare */
@@ -285,7 +287,7 @@ void test_phy_update_central_loc_unsupp_feat(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an PHY Update Procedure */
-	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/* Prepare */
@@ -441,7 +443,7 @@ void test_phy_update_periph_loc(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an PHY Update Procedure */
-	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/* Prepare */
@@ -706,7 +708,7 @@ void test_phy_update_central_loc_collision(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	/* Initiate an PHY Update Procedure */
-	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/*** ***/
@@ -893,7 +895,7 @@ void test_phy_update_central_rem_collision(void)
 	/*** ***/
 
 	/* Initiate an PHY Update Procedure */
-	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/*** ***/
@@ -1051,7 +1053,7 @@ void test_phy_update_periph_loc_collision(void)
 	/*** ***/
 
 	/* Initiate an PHY Update Procedure */
-	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
+	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
 
 	/* Prepare */
@@ -1147,6 +1149,284 @@ void test_phy_update_periph_loc_collision(void)
 				  "Free CTX buffers %d", ctx_buffers_free());
 }
 
+void test_phy_update_central_loc_no_act_change(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct node_rx_pdu *ntf;
+	struct pdu_data *pdu;
+	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_1M, .tx_phys = PHY_1M };
+	struct pdu_data_llctrl_phy_req rsp = { .rx_phys = PHY_1M | PHY_2M,
+					       .tx_phys = PHY_1M | PHY_2M };
+	struct pdu_data_llctrl_phy_upd_ind ind = { .instant = 0, .c_to_p_phy = 0, .p_to_c_phy = 0 };
+	uint16_t instant;
+
+	struct node_rx_pu pu = { .status = BT_HCI_ERR_SUCCESS };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate an PHY Update Procedure */
+	err = ull_cp_phy_update(&conn, PHY_1M, PREFER_S8_CODING, PHY_1M, HOST_INITIATED);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_REQ, &conn, &tx, &req);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_PHY_RSP, &conn, &rsp);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Check that data tx was paused */
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is not paused");
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_UPDATE_IND, &conn, &tx, &ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Check that data tx is no longer paused */
+	zassert_equal(conn.tx_q.pause_data, 0U, "Data tx is paused");
+
+	/* Done */
+	event_done(&conn);
+
+	/* Save Instant */
+	pdu = (struct pdu_data *)tx->pdu;
+	instant = sys_le16_to_cpu(pdu->llctrl.phy_upd_ind.instant);
+
+	/* Check if instant is zero, due to no actual PHY change */
+	zassert_equal(instant, 0, "Unexpected instant %d", instant);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* There should be one host notifications, due to host initiated PHY upd */
+	ut_rx_node(NODE_PHY_UPDATE, &ntf, &pu);
+	ut_rx_q_is_empty();
+
+	/* Release Ntf */
+	ull_cp_release_ntf(ntf);
+
+	CHECK_CURRENT_PHY_STATE(conn, PHY_1M, PREFER_S8_CODING, PHY_1M);
+	CHECK_PREF_PHY_STATE(conn, PHY_1M, PHY_1M);
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(), "Free CTX buffers %d",
+		      ctx_buffers_free());
+}
+
+void test_phy_update_central_rem_no_actual_change(void)
+{
+	struct node_tx *tx;
+	struct pdu_data *pdu;
+	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_1M, .tx_phys = PHY_1M };
+	struct pdu_data_llctrl_phy_upd_ind ind = { .instant = 0, .c_to_p_phy = 0, .p_to_c_phy = 0 };
+	uint16_t instant;
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_CENTRAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Rx */
+	lt_tx(LL_PHY_REQ, &conn, &req);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Check that data tx was paused */
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is not paused");
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_UPDATE_IND, &conn, &tx, &ind);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Check that data tx is no longer paused */
+	zassert_equal(conn.tx_q.pause_data, 0U, "Data tx is paused");
+
+	/* Save Instant */
+	pdu = (struct pdu_data *)tx->pdu;
+	instant = sys_le16_to_cpu(pdu->llctrl.phy_upd_ind.instant);
+
+	/* Check if instant is zero, due to no actual PHY change */
+	zassert_equal(instant, 0, "Unexpected instant %d", instant);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* There is not actual PHY change, so there shouldn't be host notification */
+	ut_rx_q_is_empty();
+
+	CHECK_CURRENT_PHY_STATE(conn, PHY_1M, PREFER_S8_CODING, PHY_1M);
+	CHECK_PREF_PHY_STATE(conn, PHY_1M | PHY_2M | PHY_CODED, PHY_1M | PHY_2M | PHY_CODED);
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(), "Free CTX buffers %d",
+		      ctx_buffers_free());
+}
+
+void test_phy_update_periph_loc_no_actual_change(void)
+{
+	uint8_t err;
+	struct node_tx *tx;
+	struct node_rx_pdu *ntf;
+	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_1M, .tx_phys = PHY_1M };
+	struct node_rx_pu pu = { .status = BT_HCI_ERR_SUCCESS };
+	struct pdu_data_llctrl_phy_upd_ind phy_update_ind = { .instant = 0,
+							      .c_to_p_phy = 0,
+							      .p_to_c_phy = 0 };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Initiate an PHY Update Procedure */
+	err = ull_cp_phy_update(&conn, PHY_1M, PREFER_S8_CODING, PHY_1M, HOST_INITIATED);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_REQ, &conn, &tx, &req);
+	lt_rx_q_is_empty(&conn);
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_PHY_UPDATE_IND, &conn, &phy_update_ind);
+
+	/* Done */
+	event_done(&conn);
+
+	/* There should be one notification due to Host initiated PHY UPD */
+	ut_rx_node(NODE_PHY_UPDATE, &ntf, &pu);
+	ut_rx_q_is_empty();
+
+	/* Release Ntf */
+	ull_cp_release_ntf(ntf);
+
+	CHECK_CURRENT_PHY_STATE(conn, PHY_1M, PREFER_S8_CODING, PHY_1M);
+	CHECK_PREF_PHY_STATE(conn, PHY_1M, PHY_1M);
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(), "Free CTX buffers %d",
+		      ctx_buffers_free());
+}
+
+void test_phy_update_periph_rem_no_actual_change(void)
+{
+	struct node_tx *tx;
+	struct pdu_data_llctrl_phy_req req = { .rx_phys = PHY_1M, .tx_phys = PHY_1M };
+	struct pdu_data_llctrl_phy_req rsp = { .rx_phys = PHY_1M | PHY_2M | PHY_CODED,
+					       .tx_phys = PHY_1M | PHY_2M | PHY_CODED };
+	struct pdu_data_llctrl_phy_upd_ind ind = { .instant = 0, .c_to_p_phy = 0, .p_to_c_phy = 0 };
+
+	/* Role */
+	test_set_role(&conn, BT_HCI_ROLE_PERIPHERAL);
+
+	/* Connect */
+	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should NOT have a LL Control PDU */
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_PHY_REQ, &conn, &req);
+
+	/* Done */
+	event_done(&conn);
+
+	/* We received a REQ, so data tx should be paused */
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is not paused");
+
+	/* Prepare */
+	event_prepare(&conn);
+
+	/* Tx Queue should have one LL Control PDU */
+	lt_rx(LL_PHY_RSP, &conn, &tx, &rsp);
+	lt_rx_q_is_empty(&conn);
+
+	/* Rx */
+	lt_tx(LL_PHY_UPDATE_IND, &conn, &ind);
+
+	/* We are sending RSP, so data tx should be paused until after tx ack */
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is not paused");
+
+	/* TX Ack */
+	event_tx_ack(&conn, tx);
+
+	/* Check that data tx is no longer paused */
+	zassert_equal(conn.tx_q.pause_data, 0U, "Data tx is paused");
+
+	/* Done */
+	event_done(&conn);
+
+	/* Release Tx */
+	ull_cp_release_tx(&conn, tx);
+
+	/* There should be no host notification */
+	ut_rx_q_is_empty();
+
+	CHECK_CURRENT_PHY_STATE(conn, PHY_1M, PREFER_S8_CODING, PHY_1M);
+	CHECK_PREF_PHY_STATE(conn, PHY_1M | PHY_2M | PHY_CODED, PHY_1M | PHY_2M | PHY_CODED);
+
+	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(), "Free CTX buffers %d",
+		      ctx_buffers_free());
+}
+
 void test_main(void)
 {
 	ztest_test_suite(
@@ -1166,6 +1446,14 @@ void test_main(void)
 		ztest_unit_test_setup_teardown(test_phy_update_central_rem_collision, setup,
 					       unit_test_noop),
 		ztest_unit_test_setup_teardown(test_phy_update_periph_loc_collision, setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_phy_update_central_loc_no_act_change, setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_phy_update_central_rem_no_actual_change, setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_phy_update_periph_rem_no_actual_change, setup,
+					       unit_test_noop),
+		ztest_unit_test_setup_teardown(test_phy_update_periph_loc_no_actual_change, setup,
 					       unit_test_noop));
 
 	ztest_run_test_suite(phy);


### PR DESCRIPTION
In a function pu_prepare_instant there is a condition that
checks if there is actual change of a PHY. That condition
was based on ctx->data.pu.tx and ctx->data.pu.rx.
These members store PHY that is or will be used, hence
the condition is wrong. Even there is no actual change in
the PHY, values could be not equal to zero. In such case
the instant value would be set to wrong value.
What more the condition be an 'or' not an 'and' because
one of the values must be different than zero to have the
PHY change and instant different than zero.

After update of the condition, the function call places
must be changed. The ctx->data.pu.c_to_p_phy and
ctx->data.pu.p_to_c_phy are set in pu_prepare_update_ind
function, hence pu_prepare_instant should be called after
that.

There were no unit tests that verify if instant value send in
LL_PHY_UPDATE_IND PDU are correct. The commit adds missing tests.

Besides that there is a small update to all ull_cp_phy_update calls,
to improve readability of the code. Magic number was changed to
HOST_INITIATED macro.
