### PR TITLE
drivers: i2c: Fix get_regs() to happen after DEVICE_MMIO_MAP

### DIFF
--- a/drivers/i2c/i2c_dw.c
+++ b/drivers/i2c/i2c_dw.c
@@ -838,7 +838,6 @@ static int i2c_dw_initialize(const struct device *dev)
 	const struct i2c_dw_rom_config * const rom = dev->config;
 	struct i2c_dw_dev_config * const dw = dev->data;
 	union ic_con_register ic_con;
-	uint32_t reg_base = get_regs(dev);
 	int ret = 0;
 
 #if defined(CONFIG_PINCTRL)
@@ -868,6 +867,7 @@ static int i2c_dw_initialize(const struct device *dev)
 	}
 
 	k_sem_init(&dw->device_sync_sem, 0, K_SEM_MAX_LIMIT);
+	uint32_t reg_base = get_regs(dev);
 
 	/* verify that we have a valid DesignWare register first */
 	if (read_comp_type(reg_base) != I2C_DW_MAGIC_KEY) {


### PR DESCRIPTION
Fixing a bug where get_regs() was being executed before MMIO mapping
moving the declaration of reg_base after DEVICE_MMIO_MAP

Signed-off-by: Esteban Valverde <esteban.valverde.vega@intel.com>