### PR TITLE
DTS cleanup for nRF5340 SoC and its IPC nodes

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -13,6 +13,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 	};
 
 	leds {

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -18,6 +18,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -12,6 +12,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 	};
 
 	buttons {

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -18,6 +18,7 @@
 		zephyr,uart-mcumgr = &uart0;
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,bt-c2h-uart = &uart0;
+		zephyr,bt-hci-rpmsg-ipc = &ipc0;
 		zephyr,sram = &sram1;
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;

--- a/drivers/bluetooth/hci/rpmsg.c
+++ b/drivers/bluetooth/hci/rpmsg.c
@@ -283,7 +283,8 @@ static struct ipc_ept_cfg hci_ept_cfg = {
 static int bt_rpmsg_open(void)
 {
 	int err;
-	const struct device *hci_ipc_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
+	const struct device *hci_ipc_instance =
+		DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_hci_rpmsg_ipc));
 
 	BT_DBG("");
 

--- a/dts/arm/nordic/nrf5340_cpuapp.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp.dtsi
@@ -97,6 +97,11 @@
 			};
 		};
 	};
+
+	/* Default IPC description */
+	ipc {
+		#include "nrf5340_cpuapp_ipc.dtsi"
+	};
 };
 
 &nvic {

--- a/dts/arm/nordic/nrf5340_cpuapp_ipc.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_ipc.dtsi
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+ipc0: ipc0 {
+	compatible = "zephyr,ipc-openamp-static-vrings";
+	memory-region = <&sram0_shared>;
+	mboxes = <&mbox 0>, <&mbox 1>;
+	mbox-names = "tx", "rx";
+	role = "host";
+	status = "okay";
+};

--- a/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuapp_peripherals.dtsi
@@ -416,15 +416,6 @@ i2s0: i2s@28000 {
 	label = "I2S_0";
 };
 
-ipc0: ipc0 {
-	compatible = "zephyr,ipc-openamp-static-vrings";
-	memory-region = <&sram0_shared>;
-	mboxes = <&mbox 0>, <&mbox 1>;
-	mbox-names = "tx", "rx";
-	role = "host";
-	status = "okay";
-};
-
 mbox: ipc: mbox@2a000 {
 	compatible = "nordic,mbox-nrf-ipc", "nordic,nrf-ipc";
 	reg = <0x2a000 0x1000>;

--- a/dts/arm/nordic/nrf5340_cpuappns.dtsi
+++ b/dts/arm/nordic/nrf5340_cpuappns.dtsi
@@ -49,6 +49,11 @@
 			#include "nrf5340_cpuapp_peripherals.dtsi"
 		};
 	};
+
+	/* Default IPC description */
+	ipc {
+		#include "nrf5340_cpuapp_ipc.dtsi"
+	};
 };
 
 &nvic {

--- a/dts/arm/nordic/nrf5340_cpunet.dtsi
+++ b/dts/arm/nordic/nrf5340_cpunet.dtsi
@@ -153,15 +153,6 @@
 			label = "RTC_0";
 		};
 
-		ipc0: ipc0 {
-			compatible = "zephyr,ipc-openamp-static-vrings";
-			memory-region = <&sram0_shared>;
-			mboxes = <&mbox 0>, <&mbox 1>;
-			mbox-names = "rx", "tx";
-			role = "remote";
-			status = "okay";
-		};
-
 		mbox: ipc: mbox@41012000 {
 			compatible = "nordic,mbox-nrf-ipc", "nordic,nrf-ipc";
 			reg = <0x41012000 0x1000>;
@@ -327,6 +318,18 @@
 			label = "GPIO_1";
 			status = "disabled";
 			port = <1>;
+		};
+	};
+
+	/* Default IPC description */
+	ipc {
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram0_shared>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "rx", "tx";
+			role = "remote";
+			status = "okay";
 		};
 	};
 };

--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -268,7 +268,8 @@ static struct ipc_ept_cfg hci_ept_cfg = {
 void main(void)
 {
 	int err;
-	const struct device *hci_ipc_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
+	const struct device *hci_ipc_instance =
+		DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_hci_rpmsg_ipc));
 
 	/* incoming events and data from the controller */
 	static K_FIFO_DEFINE(rx_queue);

--- a/samples/subsys/ipc/ipc_service/icmsg/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ipc0;
-
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
@@ -23,12 +21,16 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-icmsg";
-		tx-region = <&sram_tx>;
-		rx-region = <&sram_rx>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "tx", "rx";
-		status = "okay";
+	ipc {
+		/delete-node/ ipc0;
+
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "tx", "rx";
+			status = "okay";
+		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &ipc0;
-
 / {
 	chosen {
 		/delete-property/ zephyr,ipc_shm;
@@ -23,12 +21,16 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-icmsg";
-		tx-region = <&sram_tx>;
-		rx-region = <&sram_rx>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "rx", "tx";
-		status = "okay";
+	ipc {
+		/delete-node/ ipc0;
+
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-icmsg";
+			tx-region = <&sram_tx>;
+			rx-region = <&sram_rx>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "rx", "tx";
+			status = "okay";
+		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -11,12 +11,6 @@
 		/delete-property/ zephyr,ipc_shm;
 	};
 
-	soc {
-		peripheral@50000000 {
-			/delete-node/ ipc0;
-		};
-	};
-
 	reserved-memory {
 		/delete-node/ memory@20070000;
 
@@ -29,22 +23,26 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc0>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "tx", "rx";
-		role = "host";
-		status = "okay";
-	};
+	ipc {
+		/delete-node/ ipc0;
 
-	ipc1: ipc1 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc1>;
-		mboxes = <&mbox 2>, <&mbox 3>;
-		mbox-names = "tx", "rx";
-		role = "host";
-		zephyr,priority = <1 PRIO_COOP>;
-		status = "okay";
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc0>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "tx", "rx";
+			role = "host";
+			status = "okay";
+		};
+
+		ipc1: ipc1 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc1>;
+			mboxes = <&mbox 2>, <&mbox 3>;
+			mbox-names = "tx", "rx";
+			role = "host";
+			zephyr,priority = <1 PRIO_COOP>;
+			status = "okay";
+		};
 	};
 };

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -11,10 +11,6 @@
 		/delete-property/ zephyr,ipc_shm;
 	};
 
-	soc {
-		/delete-node/ ipc0;
-	};
-
 	reserved-memory {
 		/delete-node/ memory@20070000;
 
@@ -27,22 +23,26 @@
 		};
 	};
 
-	ipc0: ipc0 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc0>;
-		mboxes = <&mbox 0>, <&mbox 1>;
-		mbox-names = "rx", "tx";
-		role = "remote";
-		status = "okay";
-	};
+	ipc {
+		/delete-node/ ipc0;
 
-	ipc1: ipc1 {
-		compatible = "zephyr,ipc-openamp-static-vrings";
-		memory-region = <&sram_ipc1>;
-		mboxes = <&mbox 2>, <&mbox 3>;
-		mbox-names = "rx", "tx";
-		role = "remote";
-		zephyr,priority = <2 PRIO_PREEMPT>;
-		status = "okay";
+		ipc0: ipc0 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc0>;
+			mboxes = <&mbox 0>, <&mbox 1>;
+			mbox-names = "rx", "tx";
+			role = "remote";
+			status = "okay";
+		};
+
+		ipc1: ipc1 {
+			compatible = "zephyr,ipc-openamp-static-vrings";
+			memory-region = <&sram_ipc1>;
+			mboxes = <&mbox 2>, <&mbox 3>;
+			mbox-names = "rx", "tx";
+			role = "remote";
+			zephyr,priority = <2 PRIO_PREEMPT>;
+			status = "okay";
+		};
 	};
 };


### PR DESCRIPTION
1st commit:

Cleaned up the IPC configuration for nRF5340 SoC in Device Tree. This
change fixes the (simple_bus_reg) warning about the missing or empty
reg/ranges property.

This is a follow-up to commit cf6a58d3f61aa163d149a3c3ff6389285bd09c13.

2nd commit:

Added chosen syntax in Device Tree to abstract the IPC device that is
used with the IPC service module in the Bluetooth HCI RPMsg driver.
Ported affected boards to declare this alias.