### PR TITLE
Add support for stm32u5 fdcan

### DIFF
--- a/drivers/can/Kconfig.stm32fd
+++ b/drivers/can/Kconfig.stm32fd
@@ -42,13 +42,27 @@ config CAN_STM32FD_CLOCK_SOURCE_HSE
 
 config CAN_STM32FD_CLOCK_SOURCE_PLL
 	bool "PLL"
+	depends on !SOC_SERIES_STM32U5X
 	help
 	  PLL "Q" clock used ad FDCAN clock source.
 
 config CAN_STM32FD_CLOCK_SOURCE_PCLK1
 	bool "PCLK1"
+	depends on !SOC_SERIES_STM32U5X
 	help
 	  PCLK1 clock used ad FDCAN clock source.
+
+config CAN_STM32FD_CLOCK_SOURCE_PLL1Q
+	bool "PLL1Q"
+	depends on SOC_SERIES_STM32U5X
+	help
+	  PLL1 "Q" clock used as FDCAN clock source.
+
+config CAN_STM32FD_CLOCK_SOURCE_PLL2P
+	bool "PLL2P"
+	depends on SOC_SERIES_STM32U5X
+	help
+	  PLL2 "P" clock used as FDCAN clock source.
 
 endchoice
 

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -10,6 +10,7 @@
 #include <kernel.h>
 #include <soc.h>
 #include <stm32_ll_rcc.h>
+#include <stm32_ll_bus.h>
 #include <logging/log.h>
 
 #include "can_stm32fd.h"
@@ -22,6 +23,10 @@ LOG_MODULE_REGISTER(can_stm32fd, CONFIG_CAN_LOG_LEVEL);
 #define CAN_STM32FD_CLOCK_SOURCE LL_RCC_FDCAN_CLKSOURCE_PLL
 #elif defined(CONFIG_CAN_STM32FD_CLOCK_SOURCE_PCLK1)
 #define CAN_STM32FD_CLOCK_SOURCE LL_RCC_FDCAN_CLKSOURCE_PCLK1
+#elif defined(CONFIG_CAN_STM32FD_CLOCK_SOURCE_PLL1Q)
+#define CAN_STM32FD_CLOCK_SOURCE LL_RCC_FDCAN_CLKSOURCE_PLL1
+#elif defined(CONFIG_CAN_STM32FD_CLOCK_SOURCE_PLL2P)
+#define CAN_STM32FD_CLOCK_SOURCE LL_RCC_FDCAN_CLKSOURCE_PLL2
 #else
 #error "Unsupported FDCAN clock source"
 #endif
@@ -56,7 +61,19 @@ static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 static void can_stm32fd_clock_enable(void)
 {
 	LL_RCC_SetFDCANClockSource(CAN_STM32FD_CLOCK_SOURCE);
+
+	/* LL_RCC API names do not align with PLL output name but are correct */
+#ifdef CONFIG_CAN_STM32FD_CLOCK_SOURCE_PLL1Q
+	LL_RCC_PLL1_EnableDomain_48M();
+#elif CONFIG_CAN_STM32FD_CLOCK_SOURCE_PLL2P
+	LL_RCC_PLL2_EnableDomain_SAI();
+#endif
+
+#ifdef CONFIG_SOC_SERIES_STM32U5X
+	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_FDCAN1);
+#else
 	__HAL_RCC_FDCAN_CLK_ENABLE();
+#endif
 
 	FDCAN_CONFIG->CKDIV = CAN_STM32FD_CLOCK_DIVISOR >> 1;
 }

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -390,6 +390,32 @@
 			has-vref-channel;
 		};
 
+		can {
+			compatible = "bosch,m-can-base";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			std-filter-elements = <28>;
+			ext-filter-elements = <8>;
+			rx-fifo0-elements = <3>;
+			rx-fifo1-elements = <3>;
+			rx-buffer-elements = <0>;
+			tx-buffer-elements = <3>;
+
+			can1: can@4000a400 {
+				compatible = "st,stm32-fdcan";
+				reg = <0x4000a400 0x400>, <0x4000ac00 0x350>;
+				reg-names = "m_can", "message_ram";
+				interrupts = <39 0>, <40 0>;
+				interrupt-names = "LINE_0", "LINE_1";
+				status = "disabled";
+				label = "CAN_1";
+				sjw = <1>;
+				sample-point = <875>;
+				sjw-data = <1>;
+				sample-point-data = <875>;
+			};
+		};
+
 		ucpd1: ucpd@4000dc00 {
 			compatible = "st,stm32-ucpd";
 			reg = <0x4000dc00 0x400>;


### PR DESCRIPTION
This addresses #45123 in the near term.

Since the clock configuration on STM32 is set to change with #42097 in the future, this only supports clocking from PLL1Q, which should be sufficient for most applications.

Fixes: #45123