### PR TITLE
drivers: led_pwm: fix build error

### DIFF
--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -131,7 +131,7 @@ static const struct led_driver_api led_pwm_api = {
 	.set_brightness	= led_pwm_set_brightness,
 };
 
-#define PWM_DT_SPEC_GET_AND_COMMA(node_id) PWM_DT_SPEC_GET(node_id)),
+#define PWM_DT_SPEC_GET_AND_COMMA(node_id) PWM_DT_SPEC_GET(node_id),
 
 #define LED_PWM_DEVICE(id)					\
 								\


### PR DESCRIPTION
Remove stray parenthesis causing build error in led_pwm driver.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>

Fixes #45226