### PR TITLE
drivers: can: initialize CAN transceivers prior to CAN controllers

### DIFF
--- a/drivers/can/transceiver/Kconfig
+++ b/drivers/can/transceiver/Kconfig
@@ -7,7 +7,7 @@ menu "CAN transceiver drivers"
 
 config CAN_TRANSCEIVER_INIT_PRIORITY
 	int "CAN transceiver driver init priority"
-	default 70
+	default 45
 	help
 	  CAN transceiver device driver initialization priority.
 


### PR DESCRIPTION
Change the default initialization priority for CAN transceiver from 70 to 45 to initialize them before the CAN controllers (with default a initialization priority of 50).

Fixes: #45219

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>