### PR TITLE
drivers/led: led_pwm: Remove superfluous parenthesis in init macro

### DIFF
--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -131,7 +131,7 @@ static const struct led_driver_api led_pwm_api = {
 	.set_brightness	= led_pwm_set_brightness,
 };
 
-#define PWM_DT_SPEC_GET_AND_COMMA(node_id) PWM_DT_SPEC_GET(node_id)),
+#define PWM_DT_SPEC_GET_AND_COMMA(node_id) PWM_DT_SPEC_GET(node_id),
 
 #define LED_PWM_DEVICE(id)					\
 								\


### PR DESCRIPTION
Remove superfluous parenthesis which was added when transitioning
to the use of PWM_DT_SPEC_GET.

Fixes #45226.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>