### PR TITLE
samples: tfm: psa: Increase timeout for psa_protected_storage_test

### DIFF
--- a/samples/tfm_integration/tfm_psa_test/sample.yaml
+++ b/samples/tfm_integration/tfm_psa_test/sample.yaml
@@ -15,6 +15,6 @@ sample:
 tests:
   sample.tfm.psa_protected_storage_test:
     extra_args: "CONFIG_TFM_PSA_TEST_PROTECTED_STORAGE=y"
-    timeout: 100
+    timeout: 120
   sample.tfm.psa_internal_trusted_storage_test:
     extra_args: "CONFIG_TFM_PSA_TEST_INTERNAL_TRUSTED_STORAGE=y"


### PR DESCRIPTION
The test takes longer and requires its timeout to be increased
as in this commit.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>