### PR TITLE
Bluetooth: Gatt: Subscription callback

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -87,6 +87,9 @@ Bluetooth
 
   * The :c:macro:bt_conn_index function now takes a `const struct bt_conn`.
 
+  * The `struct bt_gatt_subscribe_params` :c:func:`write` callback
+    function has been deprecated.  A :c:func:`subscribe` callback
+    function has been added to replace it.
 
 New APIs in this release
 ========================

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1619,6 +1619,16 @@ typedef uint8_t (*bt_gatt_notify_func_t)(struct bt_conn *conn,
 				      struct bt_gatt_subscribe_params *params,
 				      const void *data, uint16_t length);
 
+/** @typedef bt_gatt_subscribe_func_t
+ *  @brief Subscription callback function
+ *
+ *  @param conn Connection object.
+ *  @param err ATT error code.
+ *  @param params Subscription parameters used.
+ */
+typedef void (*bt_gatt_subscribe_func_t)(struct bt_conn *conn, uint8_t err,
+					 struct bt_gatt_subscribe_params *params);
+
 /** Subscription flags */
 enum {
 	/** @brief Persistence flag
@@ -1660,7 +1670,12 @@ enum {
 struct bt_gatt_subscribe_params {
 	/** Notification value callback */
 	bt_gatt_notify_func_t notify;
-	/** Subscribe CCC write request response callback */
+	/** Subscribe CCC write request response callback
+	 *  If given, called with the subscription parameters given when subscribing
+	 */
+	bt_gatt_subscribe_func_t subscribe;
+
+	/** @deprecated{subscribe CCC write response callback} */
 	bt_gatt_write_func_t write;
 	/** Subscribe value handle */
 	uint16_t value_handle;

--- a/subsys/bluetooth/audio/has_client.c
+++ b/subsys/bluetooth/audio/has_client.c
@@ -178,7 +178,7 @@ static uint8_t active_preset_notify_cb(struct bt_conn *conn,
 }
 
 static void active_index_subscribe_cb(struct bt_conn *conn, uint8_t att_err,
-				      struct bt_gatt_write_params *params)
+				      struct bt_gatt_subscribe_params *params)
 {
 	struct has_inst *inst = inst_by_conn(conn);
 
@@ -201,7 +201,7 @@ static int active_index_subscribe(struct has_inst *inst, uint16_t value_handle)
 	BT_DBG("conn %p handle 0x%04x", (void *)inst->conn, value_handle);
 
 	inst->active_index_subscription.notify = active_preset_notify_cb;
-	inst->active_index_subscription.write = active_index_subscribe_cb;
+	inst->active_index_subscription.subscribe = active_index_subscribe_cb;
 	inst->active_index_subscription.value_handle = value_handle;
 	inst->active_index_subscription.ccc_handle = 0x0000;
 	inst->active_index_subscription.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
@@ -265,7 +265,7 @@ static int active_index_read(struct has_inst *inst)
 }
 
 static void control_point_subscribe_cb(struct bt_conn *conn, uint8_t att_err,
-				       struct bt_gatt_write_params *write)
+				       struct bt_gatt_subscribe_params *subscribe)
 {
 	struct has_inst *inst = inst_by_conn(conn);
 	int err = att_err;
@@ -299,7 +299,7 @@ static int control_point_subscribe(struct has_inst *inst, uint16_t value_handle,
 	BT_DBG("conn %p handle 0x%04x", (void *)inst->conn, value_handle);
 
 	inst->control_point_subscription.notify = control_point_notify_cb;
-	inst->control_point_subscription.write = control_point_subscribe_cb;
+	inst->control_point_subscription.subscribe = control_point_subscribe_cb;
 	inst->control_point_subscription.value_handle = value_handle;
 	inst->control_point_subscription.ccc_handle = 0x0000;
 	inst->control_point_subscription.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
@@ -428,7 +428,7 @@ static int features_read(struct has_inst *inst, uint16_t value_handle)
 }
 
 static void features_subscribe_cb(struct bt_conn *conn, uint8_t att_err,
-				  struct bt_gatt_write_params *params)
+				  struct bt_gatt_subscribe_params *params)
 {
 	struct has_inst *inst = inst_by_conn(conn);
 	int err = att_err;
@@ -496,7 +496,7 @@ static int features_subscribe(struct has_inst *inst, uint16_t value_handle)
 	BT_DBG("conn %p handle 0x%04x", (void *)inst->conn, value_handle);
 
 	inst->features_subscription.notify = features_notify_cb;
-	inst->features_subscription.write = features_subscribe_cb;
+	inst->features_subscription.subscribe = features_subscribe_cb;
 	inst->features_subscription.value_handle = value_handle;
 	inst->features_subscription.ccc_handle = 0x0000;
 	inst->features_subscription.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4629,7 +4629,11 @@ static void gatt_write_ccc_rsp(struct bt_conn *conn, uint8_t err,
 		params->notify(conn, params, NULL, 0);
 	}
 
-	if (params->write) {
+	if (params->subscribe) {
+		params->subscribe(conn, err, params);
+	} else if (params->write) {
+		/* TODO: Remove after deprecation */
+		BT_WARN("write callback is deprecated, use subscribe cb instead");
 		params->write(conn, err, NULL);
 	}
 }

--- a/subsys/bluetooth/mesh/gatt_cli.c
+++ b/subsys/bluetooth/mesh/gatt_cli.c
@@ -76,7 +76,7 @@ static uint8_t notify_func(struct bt_conn *conn,
 }
 
 static void notify_enabled(struct bt_conn *conn, uint8_t err,
-			   struct bt_gatt_write_params *params)
+			   struct bt_gatt_subscribe_params *params)
 {
 	struct bt_mesh_gatt_server *server = get_server(conn);
 
@@ -143,7 +143,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 		(void)memset(&server->subscribe, 0, sizeof(server->subscribe));
 
 		server->subscribe.notify = notify_func;
-		server->subscribe.write = notify_enabled;
+		server->subscribe.subscribe = notify_enabled;
 		server->subscribe.value = BT_GATT_CCC_NOTIFY;
 		server->subscribe.ccc_handle = attr->handle;
 		server->subscribe.value_handle = attr->handle - 1;


### PR DESCRIPTION
Create separate callback for CCC subscriptions, to be able to return the subscription parameters.

This is an API change, discussed in https://github.com/zephyrproject-rtos/zephyr/issues/45237