### PR TITLE
net: lib: lwm2m: Don't create server object in bootstrap

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_server.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_server.c
@@ -343,7 +343,6 @@ static struct lwm2m_engine_obj_inst *server_create(uint16_t obj_inst_id)
 
 static int lwm2m_server_init(const struct device *dev)
 {
-	struct lwm2m_engine_obj_inst *obj_inst = NULL;
 	int ret = 0;
 
 	server.obj_id = LWM2M_OBJECT_SERVER_ID;
@@ -356,10 +355,14 @@ static int lwm2m_server_init(const struct device *dev)
 	server.create_cb = server_create;
 	lwm2m_register_obj(&server);
 
-	/* auto create the first instance */
-	ret = lwm2m_create_obj_inst(LWM2M_OBJECT_SERVER_ID, 0, &obj_inst);
-	if (ret < 0) {
-		LOG_ERR("Create LWM2M server instance 0 error: %d", ret);
+	/* don't create automatically when using bootstrap */
+	if (!IS_ENABLED(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)) {
+		struct lwm2m_engine_obj_inst *obj_inst = NULL;
+
+		ret = lwm2m_create_obj_inst(LWM2M_OBJECT_SERVER_ID, 0, &obj_inst);
+		if (ret < 0) {
+			LOG_ERR("Create LWM2M server instance 0 error: %d", ret);
+		}
 	}
 
 	return ret;

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -552,6 +552,7 @@ static int sm_select_server_inst(int sec_obj_inst, int *srv_obj_inst,
 		return -EINVAL;
 	}
 
+	sm_update_lifetime(obj_inst_id, lifetime);
 	*srv_obj_inst = obj_inst_id;
 
 	return 0;


### PR DESCRIPTION
When bootstrap is used, the server object shouldn't be autocreated.
Automatically creating object may cause problems after bootstrap
has been done and bootstrap server deletes and creates instances
for server object. In the next boot the auto-created server object
may have clashing server_id with the server object that the
bootstrap-server has created.

Also lifetime wasn't properly added to the registration message from
the server object.

Signed-off-by: Jarno Lamsa <jarno.lamsa@nordicsemi.no>