### PR TITLE
libmetal: Bump to v2022.04.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -152,7 +152,7 @@ manifest:
       groups:
         - hal
     - name: libmetal
-      revision: c6efe091dfe02704097586a522969b5a4cc197bd
+      revision: 850a3c3fd5bc655987021dc9106d8e8cd0f7e061
       path: modules/hal/libmetal
       groups:
         - hal


### PR DESCRIPTION
Bump libmetal to v2022.04.0

Signed-off-by: Carlo Caione <ccaione@baylibre.com>