### PR TITLE
net: if: Add method to set default interface

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -903,6 +903,13 @@ static inline struct net_if_config *net_if_config_get(struct net_if *iface)
 void net_if_router_rm(struct net_if_router *router);
 
 /**
+ * @brief Set the default network interface.
+ *
+ * @param iface New default interface, or NULL to revert to the one set by Kconfig.
+ */
+void net_if_set_default(struct net_if *iface);
+
+/**
  * @brief Get the default network interface.
  *
  * @return Default interface or NULL if no interfaces are configured.

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -44,6 +44,8 @@ static K_MUTEX_DEFINE(lock);
 extern struct net_if _net_if_list_start[];
 extern struct net_if _net_if_list_end[];
 
+static struct net_if *default_iface;
+
 #if defined(CONFIG_NET_NATIVE_IPV4) || defined(CONFIG_NET_NATIVE_IPV6)
 static struct net_if_router routers[CONFIG_NET_MAX_ROUTERS];
 static struct k_work_delayable router_timer;
@@ -552,12 +554,21 @@ struct net_if *net_if_lookup_by_dev(const struct device *dev)
 	return NULL;
 }
 
+void net_if_set_default(struct net_if *iface)
+{
+	default_iface = iface;
+}
+
 struct net_if *net_if_get_default(void)
 {
 	struct net_if *iface = NULL;
 
 	if (_net_if_list_start == _net_if_list_end) {
 		return NULL;
+	}
+
+	if (default_iface != NULL) {
+		return default_iface;
 	}
 
 #if defined(CONFIG_NET_DEFAULT_IF_ETHERNET)


### PR DESCRIPTION
This complements the Kconfig possibility, and allows setting an
interface as default on runtime. Changing the default interface also
works around limitations when trying to use an offloaded interface
together with a native one.

Signed-off-by: Ole Morten Haaland <omh@icsys.no>