### PR TITLE
bluetooth: host: Fix missing log_strdup

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -365,7 +365,7 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 
 	err = bt_settings_decode_key(name, &addr);
 	if (err) {
-		BT_ERR("Unable to decode address %s", name);
+		BT_ERR("Unable to decode address %s", log_strdup(name));
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/keys_br.c
+++ b/subsys/bluetooth/host/keys_br.c
@@ -176,7 +176,7 @@ static int link_key_set(const char *name, size_t len_rd,
 
 	err = bt_settings_decode_key(name, &le_addr);
 	if (err) {
-		BT_ERR("Unable to decode address %s", name);
+		BT_ERR("Unable to decode address %s", log_strdup(name));
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Logging v1 requires all transient strings to be duplicated with log_strdup().