### PR TITLE
drivers: dma: stm32 define the dma stream offset for the first dma channel Nb

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -96,14 +96,13 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 #ifdef CONFIG_DMAMUX_STM32
 	callback_arg = stream->mux_channel;
 #else
-	callback_arg = id + STREAM_OFFSET;
+	callback_arg = id + STM32_DMA_STREAM_OFFSET;
 #endif /* CONFIG_DMAMUX_STM32 */
-
 	if (!IS_ENABLED(CONFIG_DMAMUX_STM32)) {
 		stream->busy = false;
 	}
 
-	/* the dma stream id is in range from STREAM_OFFSET..<dma-requests> */
+	/* the dma stream id is in range from STM32_DMA_STREAM_OFFSET..<dma-requests> */
 	if (stm32_dma_is_ht_irq_active(dma, id)) {
 		/* Let HAL DMA handle flags on its own */
 		if (!stream->hal_override) {
@@ -263,7 +262,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 {
 	const struct dma_stm32_config *dev_config = dev->config;
 	struct dma_stm32_stream *stream =
-				&dev_config->streams[id - STREAM_OFFSET];
+				&dev_config->streams[id - STM32_DMA_STREAM_OFFSET];
 	DMA_TypeDef *dma = (DMA_TypeDef *)dev_config->base;
 	LL_DMA_InitTypeDef DMA_InitStruct;
 	int ret;
@@ -271,7 +270,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	LL_DMA_StructInit(&DMA_InitStruct);
 
 	/* give channel from index 0 */
-	id = id - STREAM_OFFSET;
+	id = id - STM32_DMA_STREAM_OFFSET;
 
 	/* Check potential DMA override */
 	if (config->linked_channel == STM32_DMA_HAL_OVERRIDE) {
@@ -503,7 +502,7 @@ DMA_STM32_EXPORT_API int dma_stm32_reload(const struct device *dev, uint32_t id,
 	struct dma_stm32_stream *stream;
 
 	/* give channel from index 0 */
-	id = id - STREAM_OFFSET;
+	id = id - STM32_DMA_STREAM_OFFSET;
 
 	if (id >= config->max_streams) {
 		return -EINVAL;
@@ -548,7 +547,7 @@ DMA_STM32_EXPORT_API int dma_stm32_start(const struct device *dev, uint32_t id)
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 
 	/* give channel from index 0 */
-	id = id - STREAM_OFFSET;
+	id = id - STM32_DMA_STREAM_OFFSET;
 
 	/* Only M2P or M2M mode can be started manually. */
 	if (id >= config->max_streams) {
@@ -565,11 +564,11 @@ DMA_STM32_EXPORT_API int dma_stm32_start(const struct device *dev, uint32_t id)
 DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
-	struct dma_stm32_stream *stream = &config->streams[id - STREAM_OFFSET];
+	struct dma_stm32_stream *stream = &config->streams[id - STM32_DMA_STREAM_OFFSET];
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
 
 	/* give channel from index 0 */
-	id = id - STREAM_OFFSET;
+	id = id - STM32_DMA_STREAM_OFFSET;
 
 	if (id >= config->max_streams) {
 		return -EINVAL;
@@ -627,7 +626,7 @@ DMA_STM32_EXPORT_API int dma_stm32_get_status(const struct device *dev,
 	struct dma_stm32_stream *stream;
 
 	/* give channel from index 0 */
-	id = id - STREAM_OFFSET;
+	id = id - STM32_DMA_STREAM_OFFSET;
 	if (id >= config->max_streams) {
 		return -EINVAL;
 	}

--- a/drivers/dma/dma_stm32.h
+++ b/drivers/dma/dma_stm32.h
@@ -45,18 +45,6 @@ struct dma_stm32_config {
 	struct dma_stm32_stream *streams;
 };
 
-#if !defined(CONFIG_DMA_STM32_V1)
-/* from DTS the dma stream id is in range 1..<dma-requests> */
-/* so decrease to set range from 0 from now on */
-#define STREAM_OFFSET 1
-#elif defined(CONFIG_DMA_STM32_V1) && defined(CONFIG_DMAMUX_STM32)
-/* typically on the stm32H7 serie, DMA V1 with mux */
-#define STREAM_OFFSET 1
-#else
-/* from DTS the dma stream id is in range 0..<dma-requests>-1 */
-#define STREAM_OFFSET 0
-#endif /* ! CONFIG_DMA_STM32_V1 */
-
 uint32_t dma_stm32_id_to_stream(uint32_t id);
 #if !defined(CONFIG_DMAMUX_STM32)
 uint32_t dma_stm32_slot_to_channel(uint32_t id);

--- a/include/zephyr/drivers/dma/dma_stm32.h
+++ b/include/zephyr/drivers/dma/dma_stm32.h
@@ -12,6 +12,21 @@
  */
 #define STM32_DMA_HAL_OVERRIDE      0x7F
 
+/* @brief gives the first DMA channel : 0 or 1 in the register map
+ * when counting channels from 1 to N or from 0 to N-1
+ */
+#if !defined(CONFIG_DMA_STM32_V1)
+/* from DTS the dma stream id is in range 1..N */
+/* so decrease to set range from 0 from now on */
+#define STM32_DMA_STREAM_OFFSET 1
+#elif defined(CONFIG_DMA_STM32_V1) && defined(CONFIG_DMAMUX_STM32)
+/* typically on the stm32H7 serie, DMA V1 with mux */
+#define STM32_DMA_STREAM_OFFSET 1
+#else
+/* from DTS the dma stream id is in range 0..N-1 */
+#define STM32_DMA_STREAM_OFFSET 0
+#endif /* ! CONFIG_DMA_STM32_V1 */
+
 /* macro for dma slot (only for dma-v1 or dma-v2 types) */
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_dma_v2bis)
 #define STM32_DMA_SLOT(id, dir, slot) 0


### PR DESCRIPTION
This is changing the definition of the STM32_DMA_STREAM_OFFSET which is setting the first nb of the dma channel
O or 1.
The stm32 and dma peripheral is counting the channel from 0 to N-1 (STM32_DMA_STREAM_OFFSET is 0 ) or from 1 to N  (STM32_DMA_STREAM_OFFSET is 1).
N is the max nb of channels given by the DTS in the <dma-channels> property.

The definition is moved from the include/zephyr/drivers/dma/dma_stm32.h
The reason behind this is to prepare the support of the DMA for the NOR octo-Flash.

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)


