### PR TITLE
st7789-no-cs-pin

### DIFF
--- a/drivers/display/display_st7789v.c
+++ b/drivers/display/display_st7789v.c
@@ -422,7 +422,7 @@ static const struct display_driver_api st7789v_api = {
 #define ST7789V_INIT(inst)							\
 	static const struct st7789v_config st7789v_config_ ## inst = {		\
 		.bus = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER |          \
-							  SPI_WORD_SET(8), 0),	\
+			SPI_WORD_SET(8) | (DT_INST_PROP(inst, inverted_sck) ? SPI_MODE_CPOL : 0), 0),	\
 		.cmd_data_gpio = GPIO_DT_SPEC_INST_GET(inst, cmd_data_gpios),	\
 		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpios, {}),	\
 		.vcom = DT_INST_PROP(inst, vcom),				\

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -113,3 +113,8 @@ properties:
       type: uint8-array
       required: true
       description: RGB Interface Control Parameter
+
+    inverted-sck:
+      type: boolean
+      required: false
+      description: Only necessary if the display don't have a CS pin


### PR DESCRIPTION
### Motivation
Some versions of the `ST7789` display do not have a CS pin in the header, the pin is connected directly to GND.

![st7789-chinese](https://user-images.githubusercontent.com/23710201/166084549-30792235-f5e0-44d8-affc-d09cbbcef133.jpg)

This feature can lead to some problems with SPI transfers, so the display will not work properly:

- [Error in ST7789 without CS](https://lowreal.net/2020/10/23/1)
- [ST7789 without CS in Raspberry Pi](https://raspberrypi.stackexchange.com/questions/108168/get-cheap-st7789-tft-display-working-through-spi-without-cs-pin)

Because of this, in order for these displays to work correctly, we need to use one of the following workarounds:

- Add CS pin manually
- Invert SPI Clock polarity

### Proposal
Create a boolean property called `inverted-sck` in DTS binding file to indicates if display don't have a CS pin:

`dts/bindings/display/sitronix,st7789v.yaml`
```yml
inverted-sck:
    type: boolean
    required: false
    description: Only necessary if the display don't have a CS pin
```

If this property exists in DTS file (`.overlay`), the display driver will add `SPI_MODE_CPOL` to SPI configuration:

`drivers/display/display_st7789v.c`
```c
#define ST7789V_INIT(inst)							\
	static const struct st7789v_config st7789v_config_ ## inst = {		\
		.bus = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER |          \
			SPI_WORD_SET(8) | (DT_INST_PROP(inst, inverted_sck) ? SPI_MODE_CPOL : 0), 0),	\
```

Will be necessary an overlay file to use these type of displays in boards without Arduino connector:

`YOUR-BOARD.overlay`
```d
&spi0 {
	compatible = "nordic,nrf-spi";
	status = "okay";
	pinctrl-0 = <&spi0_default>;
	pinctrl-1 = <&spi0_sleep>;
	cs-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
	pinctrl-names = "default", "sleep";
	
	st7789v: st7789v@0 {
		compatible = "sitronix,st7789v";
		label = "ST7789V";
		spi-max-frequency = <20000000>;
		reg = <0>;
		cmd-data-gpios = <&gpio0 31 GPIO_ACTIVE_LOW>;
		reset-gpios = <&gpio0 30 GPIO_ACTIVE_LOW>;
		width = <240>;
		height = <240>;
		x-offset = <0>;
		y-offset = <0>;
		vcom = <0x19>;
		gctrl = <0x35>;
		vrhs = <0x12>;
		vdvs = <0x20>;
		mdac = <0x00>;
		lcm = <0x2c>;
		colmod = <0x05>;
		gamma = <0x01>;
		porch-param = [0c 0c 00 33 33];
		cmd2en-param = [5a 69 02 01];
		pwctrl1-param = [a4 a1];
		pvgam-param = [D0 04 0D 11 13 2B 3F 54 4C 18 0D 0B 1F 23];
		nvgam-param = [D0 04 0C 11 13 2C 3F 44 51 2F 1F 1F 20 23];
		ram-param = [00 F0];
		rgb-param = [CD 08 14];
		inverted-sck;
	};

};
```

### Tests
These [changes](https://github.com/JON95Git/lvgl-nrf52840-mdk-sample) was tested in `nRF52840_mdk` board and a `ST7789` cheap display.

### Helpful links
- [Adding CS Pin to ST7789](https://www.instructables.com/Adding-CS-Pin-to-13-LCD/)
- [ST7789 driver example - CPOL LOW](https://github.com/Floyd-Fish/ST7789-STM32)

### Thanks
Thank you to @anangl  for giving me this idea in [Discord](https://discord.com/channels/720317445772017664/720317445772017667/968518871608881182) channel
