### PR TITLE
Bluetooth: Host: Fix crash if HCI send fails

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2393,8 +2393,6 @@ static void send_cmd(void)
 		BT_ERR("Unable to send to driver (err %d)", err);
 		k_sem_give(&bt_dev.ncmd_sem);
 		hci_cmd_done(cmd(buf)->opcode, BT_HCI_ERR_UNSPECIFIED, buf);
-		net_buf_unref(bt_dev.sent_cmd);
-		bt_dev.sent_cmd = NULL;
 		net_buf_unref(buf);
 	}
 }


### PR DESCRIPTION
bt_dev.sent_cmd is unreferenced and assigned NULL within hci_cmd_done().
Calling net_buf_unref() again causes a null pointer dereference