### PR TITLE
scripts: ensure intended path for edtlib imports

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -27,8 +27,8 @@ import pickle
 import re
 import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), 'python-devicetree',
-                             'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
+                                'src'))
 
 from devicetree import edtlib
 

--- a/scripts/dts/gen_dts_cmake.py
+++ b/scripts/dts/gen_dts_cmake.py
@@ -45,8 +45,8 @@ import pickle
 import sys
 from collections import defaultdict
 
-sys.path.append(os.path.join(os.path.dirname(__file__), 'python-devicetree',
-                             'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'python-devicetree',
+                                'src'))
 
 
 def parse_args():

--- a/scripts/gen_handles.py
+++ b/scripts/gen_handles.py
@@ -39,8 +39,8 @@ from elftools.elf.sections import SymbolTableSection
 import elftools.elf.enums
 
 # This is needed to load edt.pickle files.
-sys.path.append(os.path.join(os.path.dirname(__file__),
-                             'dts', 'python-devicetree', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__),
+                                'dts', 'python-devicetree', 'src'))
 from devicetree import edtlib  # pylint: disable=unused-import
 
 if version.parse(elftools.__version__) < version.parse('0.24'):

--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -26,7 +26,7 @@ from zephyr_ext_common import ZEPHYR_SCRIPTS
 
 # Runners depend on edtlib. Make sure the copy in the tree is
 # available to them before trying to import any.
-sys.path.append(str(ZEPHYR_SCRIPTS / 'dts' / 'python-devicetree' / 'src'))
+sys.path.insert(0, str(ZEPHYR_SCRIPTS / 'dts' / 'python-devicetree' / 'src'))
 
 from runners import get_runner_cls, ZephyrBinaryRunner, MissingProgram
 from runners.core import RunnerConfig

--- a/scripts/west_commands/sign.py
+++ b/scripts/west_commands/sign.py
@@ -22,7 +22,7 @@ from zcmake import CMakeCache
 from zephyr_ext_common import Forceable, ZEPHYR_SCRIPTS
 
 # This is needed to load edt.pickle files.
-sys.path.append(str(ZEPHYR_SCRIPTS / 'dts' / 'python-devicetree' / 'src'))
+sys.path.insert(0, str(ZEPHYR_SCRIPTS / 'dts' / 'python-devicetree' / 'src'))
 
 SIGN_DESCRIPTION = '''\
 This command automates some of the drudgery of creating signed Zephyr


### PR DESCRIPTION
When updating `sys.path` to allow importing the pickled edtlib instance, add the path to the front of `sys.path`, not the end. This ensures that the `devicetree.edtlib` module that is imported is the one relative to the files being run, not some other version which may exist on the path.

`insert` instead of `append` is already being using in `kconfigfunctions.py`, so there is precedent for this convention in the tree.
We should be using the same convention throughout, and IMO ensuring we use the relative path makes more sense than always potentially using some other version elsewhere on the users path.

Because of a silly addition to my local path for other scripts, the current setup of append/insert was using two different `edtlib.py` files (which for some reason only caused build issues on one particular board...).