### PR TITLE
arch: aarch32: improve very early debugging

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/reset.S
+++ b/arch/arm/core/aarch32/cortex_m/reset.S
@@ -21,6 +21,9 @@ _ASM_FILE_PROLOGUE
 GTEXT(z_arm_reset)
 GTEXT(memset)
 GDATA(z_interrupt_stacks)
+#if defined(CONFIG_DEBUG_THREAD_INFO)
+GDATA(z_sys_post_kernel)
+#endif
 #if defined(CONFIG_PLATFORM_SPECIFIC_INIT)
 GTEXT(z_arm_platform_init)
 #endif
@@ -62,6 +65,13 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,z_arm_reset)
  * search for a __start symbol instead, so create that alias here.
  */
 SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
+
+#if defined(CONFIG_DEBUG_THREAD_INFO)
+    /* Clear z_sys_post_kernel flag for RTOS aware debuggers */
+    movs.n r0, #0
+    ldr r1, =z_sys_post_kernel
+    strb r0, [r1]
+#endif /* CONFIG_DEBUG_THREAD_INFO */
 
 #if defined(CONFIG_INIT_ARCH_HW_AT_BOOT)
     /* Reset CONTROL register */


### PR DESCRIPTION
Debugger plugins use the `z_sys_post_kernel` variable to detect whether
the kernel is currently running, and hence whether any threads exist. As
this is just a standard variable however, after a reset the initial
value of this variable is whatever it was before reset (true) until the
bss section is zeroed halfway through `z_arm_prep_c`. Debuggers are
therefore unable to differentiate between a normally running application
and the very first stages of the boot process.

Clearing this variable as the first action upon reset allows debuggers
to display the correct thread state after the first 3 instructions have
run.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>