### PR TITLE
logging: backend: notify when process thread finishes one cycle

### DIFF
--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -31,6 +31,19 @@ struct log_backend;
  * @brief Backend events
  */
 enum log_backend_evt {
+	/**
+	 * @brief Event when process thread finishes processing.
+	 *
+	 * This event is emitted when the process thread finishes
+	 * processing pending log messages.
+	 *
+	 * @note This is not emitted when there are no pending
+	 *       log messages being processed.
+	 *
+	 * @note Deferred mode only.
+	 */
+	LOG_BACKEND_EVT_PROCESS_THREAD_DONE,
+
 	/** @brief Maximum number of backend events */
 	LOG_BACKEND_EVT_MAX,
 };

--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -26,6 +26,23 @@ extern "C" {
 /* Forward declaration of the log_backend type. */
 struct log_backend;
 
+
+/**
+ * @brief Backend events
+ */
+enum log_backend_evt {
+	/** @brief Maximum number of backend events */
+	LOG_BACKEND_EVT_MAX,
+};
+
+/**
+ * @brief Argument(s) for backend events.
+ */
+union log_backend_evt_arg {
+	/** @brief Unspecified argument(s). */
+	void *raw;
+};
+
 /**
  * @brief Logger backend API.
  */
@@ -39,6 +56,10 @@ struct log_backend_api {
 	int (*is_ready)(const struct log_backend *const backend);
 	int (*format_set)(const struct log_backend *const backend,
 				uint32_t log_type);
+
+	void (*notify)(const struct log_backend *const backend,
+		       enum log_backend_evt event,
+		       union log_backend_evt_arg *arg);
 };
 
 /**
@@ -296,6 +317,24 @@ static inline int log_backend_format_set(const struct log_backend *backend, uint
 	}
 
 	return backend->api->format_set(backend, log_type);
+}
+
+/**
+ * @brief Notify a backend of an event.
+ *
+ * @param backend Pointer to the backend instance.
+ * @param event Event to be notified.
+ * @param arg Pointer to the argument(s).
+ */
+static inline void log_backend_notify(const struct log_backend *const backend,
+				      enum log_backend_evt event,
+				      union log_backend_evt_arg *arg)
+{
+	__ASSERT_NO_MSG(backend != NULL);
+
+	if (backend->api->notify) {
+		backend->api->notify(backend, event, arg);
+	}
 }
 
 /**

--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -614,6 +614,16 @@ int log_mem_get_max_usage(uint32_t *max)
 	return mpsc_pbuf_get_max_utilization(&log_buffer, max);
 }
 
+static void log_backend_notify_all(enum log_backend_evt event,
+				   union log_backend_evt_arg *arg)
+{
+	for (int i = 0; i < log_backend_count_get(); i++) {
+		const struct log_backend *backend = log_backend_get(i);
+
+		log_backend_notify(backend, event, arg);
+	}
+}
+
 static void log_process_thread_timer_expiry_fn(struct k_timer *timer)
 {
 	k_sem_give(&log_process_thread_sem);
@@ -625,6 +635,7 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 
 	uint32_t activate_mask = z_log_init(false, false);
 	k_timeout_t timeout = K_MSEC(50); /* Arbitrary value */
+	bool processed_any = false;
 
 	thread_set(k_current_get());
 
@@ -640,7 +651,13 @@ static void log_process_thread_func(void *dummy1, void *dummy2, void *dummy3)
 		}
 
 		if (log_process() == false) {
+			if (processed_any) {
+				processed_any = false;
+				log_backend_notify_all(LOG_BACKEND_EVT_PROCESS_THREAD_DONE, NULL);
+			}
 			(void)k_sem_take(&log_process_thread_sem, timeout);
+		} else {
+			processed_any = true;
 		}
 	}
 }

--- a/tests/subsys/logging/log_api/src/mock_backend.h
+++ b/tests/subsys/logging/log_api/src/mock_backend.h
@@ -34,6 +34,11 @@ struct mock_log_backend {
 	int msg_proc_idx;
 	int exp_drop_cnt;
 	int drop_cnt;
+
+#if defined(CONFIG_LOG_MODE_DEFERRED) && \
+	defined(CONFIG_LOG_PROCESS_THREAD)
+	bool evt_notified;
+#endif
 };
 
 void mock_log_backend_reset(const struct log_backend *backend);


### PR DESCRIPTION
This adds the bits to allow the process thread to notify backends when it has finished processing pending log messages.

This allows, for example, flash-based backends to group writing log messages to storage to limit wear, since log_output_flush() is called per message. Also the backend does not have to resort to using timer to periodically flush its buffer to storage, avoiding waking up the device when there are no messages. Another use of this is for backends requiring DMA transfers. Grouping all pending log messages into one DMA transfer is sometimes preferrable.