### PR TITLE
Added leds node and alias for xtensa/esp32

### DIFF
--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -15,6 +15,7 @@
 	aliases {
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
+		led0 = &led0;
 	};
 
 	chosen {
@@ -22,6 +23,14 @@
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 		zephyr,flash = &flash0;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		led0: led_0 {
+			gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
+			label = "LED 0";
+		};
 	};
 };
 


### PR DESCRIPTION
Added leds node and alias for xtensa/esp32 which is used referencing LED on numerous samples such as basic/blinky, basic/button, basic/threads.

Signed-off-by: Niklas Salminen <xcb3djok@gmail.com>