### PR TITLE
doc: extensions: kconfig: handle promptless choices showing as parents

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -337,7 +337,11 @@ def kconfig_build_resources(app: Sphinx) -> None:
                 iternode = node
                 while iternode.parent is not iternode.kconfig.top_node:
                     iternode = iternode.parent
-                    menupath = f" > {iternode.prompt[0]}" + menupath
+                    if iternode.prompt:
+                        title = iternode.prompt[0]
+                    else:
+                        title = kconfiglib.standard_sc_expr_str(iternode.item)
+                    menupath = f" > {title}" + menupath
 
                 menupath = "(Top)" + menupath
 


### PR DESCRIPTION
Promptless choices can show up as parents when, e.g., people define
choices in multiple locations, including modules. Render them using the
built-in Kconfig expression to string formatter, so that they show up as
'<choice (...)>'.