### PR TITLE
net: wifi: Pass ssid as const

### DIFF
--- a/include/zephyr/net/wifi_mgmt.h
+++ b/include/zephyr/net/wifi_mgmt.h
@@ -97,7 +97,7 @@ struct wifi_scan_result {
 };
 
 struct wifi_connect_req_params {
-	uint8_t *ssid;
+	const uint8_t *ssid;
 	uint8_t ssid_length; /* Max 32 */
 
 	uint8_t *psk;


### PR DESCRIPTION
There shouldn't be any reason to be able to modify the passed in SSID,
and having this non-const gives application warnings if passing a
constant string.

Signed-off-by: Ole Morten Haaland <omh@icsys.no>