### PR TITLE
net: lwm2m: LwM2M timeout recovery

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1219,6 +1219,30 @@ int lwm2m_rd_client_connection_resume(struct lwm2m_ctx *client_ctx)
 }
 #endif
 
+int lwm2m_rd_client_timeout(struct lwm2m_ctx *client_ctx)
+{
+	if (client.ctx != client_ctx) {
+		return -EPERM;
+	}
+
+	if (!sm_is_registered()) {
+		return 0;
+	}
+
+	LOG_WRN("Confirmable Timeout -> Re-connect and register");
+	client.engine_state = ENGINE_DO_REGISTRATION;
+	return 0;
+}
+
+bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx)
+{
+	if (client.ctx != client_ctx || !sm_is_registered()) {
+		return false;
+	}
+
+	return true;
+}
+
 static int lwm2m_rd_client_init(const struct device *dev)
 {
 	k_mutex_init(&client.mutex);

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -40,6 +40,9 @@
 
 void engine_trigger_update(bool update_objects);
 int engine_trigger_bootstrap(void);
+
+int lwm2m_rd_client_timeout(struct lwm2m_ctx *client_ctx);
+bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx);
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 void engine_bootstrap_finish(void);
 #endif


### PR DESCRIPTION
- LwM2M engine is blocking new notification send.
- Notification or Send timeout trig Reconnect and registration state.
- Send/Notification  message is blocked if client is not connected.

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>