### PR TITLE
Bluetooth: Audio: Use existing ATT macros for handle range

### DIFF
--- a/subsys/bluetooth/audio/csis_client.c
+++ b/subsys/bluetooth/audio/csis_client.c
@@ -39,9 +39,6 @@
 #define LOG_MODULE_NAME bt_csis_client
 #include "common/log.h"
 
-#define FIRST_HANDLE                    0x0001
-#define LAST_HANDLE                     0xFFFF
-
 static uint8_t gatt_write_buf[1];
 static struct bt_gatt_write_params write_params;
 static struct bt_gatt_read_params read_params;
@@ -1321,8 +1318,8 @@ int bt_csis_client_discover(struct bt_csis_client_set_member *member)
 	discover_params.func = primary_discover_func;
 	discover_params.uuid = &uuid.uuid;
 	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
-	discover_params.start_handle = FIRST_HANDLE;
-	discover_params.end_handle = LAST_HANDLE;
+	discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
+	discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
 	err = bt_gatt_discover(member->conn, &discover_params);
 	if (err == 0) {

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -41,9 +41,6 @@
 #define LOG_MODULE_NAME bt_mcc
 #include "common/log.h"
 
-#define FIRST_HANDLE			0x0001
-#define LAST_HANDLE			0xFFFF
-
 struct mcs_instance_t {
 	uint16_t start_handle;
 	uint16_t end_handle;
@@ -1494,8 +1491,8 @@ int bt_mcc_discover_mcs(struct bt_conn *conn, bool subscribe)
 	discover_params.func = discover_primary_func;
 	discover_params.uuid = &uuid.uuid;
 	discover_params.type = BT_GATT_DISCOVER_PRIMARY;
-	discover_params.start_handle = FIRST_HANDLE;
-	discover_params.end_handle = LAST_HANDLE;
+	discover_params.start_handle = BT_ATT_FIRST_ATTRIBUTE_HANDLE;
+	discover_params.end_handle = BT_ATT_LAST_ATTRIBUTE_HANDLE;
 
 	BT_DBG("start discovery of GMCS primary service");
 	return bt_gatt_discover(conn, &discover_params);


### PR DESCRIPTION
Use the existing macros for first and last handle instead of defining
own macros.

Signed-off-by: Asbjørn Sæbø <asbjorn.sabo@nordicsemi.no>