### PR TITLE
ARC: boards: nSIM: memory layout overhaul

### DIFF
--- a/boards/arc/nsim/nsim-ccm-mem.dtsi
+++ b/boards/arc/nsim/nsim-ccm-mem.dtsi
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2022, Synopsys, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "skeleton.dtsi"
+#include <mem.h>
+
+#ifndef ICCM_ADDR
+#define ICCM_ADDR 0
+#endif
+
+#ifndef ICCM_SIZE
+#define ICCM_SIZE DT_SIZE_M(1)
+#endif
+
+#ifndef DCCM_ADDR
+#define DCCM_ADDR 80000000
+#endif
+
+#ifndef DCCM_SIZE
+#define DCCM_SIZE DT_SIZE_M(1)
+#endif
+
+/ {
+	iccm0: iccm@ICCM_ADDR {
+		compatible = "arc,iccm";
+		reg = <DT_ADDR(ICCM_ADDR) ICCM_SIZE>;
+	};
+
+	dccm0: dccm@DCCM_ADDR {
+		compatible = "arc,dccm";
+		reg = <DT_ADDR(DCCM_ADDR) DCCM_SIZE>;
+	};
+
+	chosen {
+		zephyr,sram = &dccm0;
+	};
+};

--- a/boards/arc/nsim/nsim-flat-mem.dtsi
+++ b/boards/arc/nsim/nsim-flat-mem.dtsi
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2022, Synopsys, Inc. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "skeleton.dtsi"
+#include <mem.h>
+
+#ifndef DDR_ADDR
+#define DDR_ADDR 80000000
+#endif
+
+#ifndef DDR_SIZE
+#define DDR_SIZE DT_SIZE_M(1)
+#endif
+
+/ {
+	ddr0: memory@DDR_ADDR {
+		device_type = "memory";
+		reg = <DT_ADDR(DDR_ADDR) DDR_SIZE>;
+	};
+
+	chosen {
+		zephyr,sram = &ddr0;
+	};
+};

--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -9,22 +9,6 @@
 #include "skeleton.dtsi"
 #include <mem.h>
 
-#ifndef ICCM_ADDR
-#define ICCM_ADDR 0
-#endif
-
-#ifndef ICCM_SIZE
-#define ICCM_SIZE DT_SIZE_K(1024)
-#endif
-
-#ifndef DCCM_ADDR
-#define DCCM_ADDR 80000000
-#endif
-
-#ifndef DCCM_SIZE
-#define DCCM_SIZE DT_SIZE_K(1024)
-#endif
-
 / {
 	cpus {
 		#address-cells = <1>;
@@ -35,16 +19,6 @@
 			interrupt-controller;
 			#interrupt-cells = <2>;
 		};
-	};
-
-	iccm0: iccm@ICCM_ADDR {
-		compatible = "arc,iccm";
-		reg = <DT_ADDR(ICCM_ADDR) ICCM_SIZE>;
-	};
-
-	dccm0: dccm@DCCM_ADDR {
-		compatible = "arc,dccm";
-		reg = <DT_ADDR(DCCM_ADDR) DCCM_SIZE>;
 	};
 
 	uart0: uart@f0000000 {
@@ -58,7 +32,6 @@
 	};
 
 	chosen {
-		zephyr,sram = &dccm0;
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
 	};

--- a/boards/arc/nsim/nsim_em.dtsi
+++ b/boards/arc/nsim/nsim_em.dtsi
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include "nsim.dtsi"
+#include "nsim-ccm-mem.dtsi"
 
 / {
 	cpus {

--- a/boards/arc/nsim/nsim_hs.dts
+++ b/boards/arc/nsim/nsim_hs.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include "nsim.dtsi"
+#include "nsim-ccm-mem.dtsi"
 
 / {
 	model = "snps,nsim_hs";

--- a/boards/arc/nsim/nsim_hs6x.dts
+++ b/boards/arc/nsim/nsim_hs6x.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include "nsim.dtsi"
+#include "nsim-flat-mem.dtsi"
 
 / {
 	model = "snps,nsim_hs";

--- a/boards/arc/nsim/nsim_hs6x_smp.dts
+++ b/boards/arc/nsim/nsim_hs6x_smp.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include "nsim.dtsi"
+#include "nsim-flat-mem.dtsi"
 
 / {
 	model = "snps,nsim_hs";

--- a/boards/arc/nsim/nsim_hs_mpuv6.dts
+++ b/boards/arc/nsim/nsim_hs_mpuv6.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include "nsim.dtsi"
+#include "nsim-ccm-mem.dtsi"
 
 / {
 	model = "snps,nsim_hs";

--- a/boards/arc/nsim/nsim_hs_smp.dts
+++ b/boards/arc/nsim/nsim_hs_smp.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include "nsim.dtsi"
+#include "nsim-flat-mem.dtsi"
 
 / {
 	model = "snps,nsim_hs";

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs6x
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs6x
@@ -17,9 +17,6 @@ config NUM_IRQS
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 50000000
 
-config HARVARD
-	default y
-
 config CACHE_MANAGEMENT
 	default y
 

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs6x_smp
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs6x_smp
@@ -21,9 +21,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 config CACHE_MANAGEMENT
 	default y
 
-config HARVARD
-	default y
-
 config ARC_CONNECT
 	default y
 

--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs_smp
@@ -22,9 +22,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
         # SMP simulation is slower than single core, 1 Mhz seems reasonable match with wallclock
 	default 1000000
 
-config HARVARD
-	default y
-
 config ARC_FIRQ
 	default y
 

--- a/soc/arc/snps_nsim/linker.ld
+++ b/soc/arc/snps_nsim/linker.ld
@@ -27,4 +27,10 @@
 #define DCCM_SIZE		DT_REG_SIZE(DT_INST(0, arc_dccm))
 #endif
 
+/* SRAM - memory available for all cores in cluster. Can be used for both instructions and data */
+#if DT_NODE_HAS_PROP(DT_CHOSEN(zephyr_sram), reg) && (DT_REG_SIZE(DT_CHOSEN(zephyr_sram)) > 0)
+#define SRAM_START		DT_REG_ADDR(DT_CHOSEN(zephyr_sram))
+#define SRAM_SIZE		DT_REG_SIZE(DT_CHOSEN(zephyr_sram))
+#endif
+
 #include <arch/arc/v2/linker.ld>


### PR DESCRIPTION
Currently we use incorrect memory layout for SMP boards as we put data (which need do be accessible from all cores) to DCCM which is private for each CPU core.

This works for nSIM which doesn't simulate CCMs (as we don't pass corresponding nSIM options for SMP configurations) however, it won't work if we run that code on real HW (we want to achieve that nSIM configurations are also runnable on HAPS - FPGA platform). Moreover this gives incorrect example that we can use DCCM for shuch global data in case of SMP system.

Let's fix that issue by using DDR instead of CCMs for SMP configurations (nsim_hs_smp and nsim_hs6x_smp).

While I'm at it - switch UP HS6x configuration (nsim_hs6x) for DDR usage instead of CCMs - to make that configuration closer to the HAPS config we have.