### PR TITLE
tests: fpu_sharing: Add interleaved isr/thread test

### DIFF
--- a/tests/kernel/fpu_sharing/generic/CMakeLists.txt
+++ b/tests/kernel/fpu_sharing/generic/CMakeLists.txt
@@ -13,5 +13,9 @@ project(fpu_sharing)
 set_ifndef(PI_NUM_ITERATIONS 700000)
 zephyr_compile_definitions(PI_NUM_ITERATIONS=${PI_NUM_ITERATIONS})
 
+if(DISABLE_INT_TEST)
+  zephyr_compile_definitions(DISABLE_INT_TEST=${DISABLE_INT_TEST})
+endif()
+
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/kernel/fpu_sharing/generic/testcase.yaml
+++ b/tests/kernel/fpu_sharing/generic/testcase.yaml
@@ -21,21 +21,21 @@ tests:
     tags: fpu kernel
     timeout: 600
   kernel.fpu_sharing.generic.riscv32:
-    extra_args: PI_NUM_ITERATIONS=500
+    extra_args: PI_NUM_ITERATIONS=500 DISABLE_INT_TEST=1
     filter: CONFIG_CPU_HAS_FPU
     arch_allow: riscv32
     tags: fpu kernel
     timeout: 600
     min_ram: 16
   kernel.fpu_sharing.generic.riscv64:
-    extra_args: PI_NUM_ITERATIONS=500
+    extra_args: PI_NUM_ITERATIONS=500 DISABLE_INT_TEST=1
     filter: CONFIG_CPU_HAS_FPU
     arch_allow: riscv64
     tags: fpu kernel
     timeout: 600
     min_ram: 16
   kernel.fpu_sharing.generic.sparc:
-    extra_args: PI_NUM_ITERATIONS=70000
+    extra_args: PI_NUM_ITERATIONS=70000 DISABLE_INT_TEST=1
     filter: CONFIG_CPU_HAS_FPU
     arch_allow: sparc
     tags: fpu kernel


### PR DESCRIPTION
This was originally part of #44753 , but @stephanosio suggested it needs more visibility outside the ARM realm.  I am not sure who to add to the reviewers aside from the main names I see in the arm(64), sparc, and riscv logs.

Create a timer that runs during the pi calculation test to make sure
FPU sharing works with interrupts using the FPU concurrently with normal
threads.

Commit 53a4acb2dcdc ("SPARC: add FPU support") states that the FPU is
disabled when calling the ISR so this test will not work for SPARC.
Disable it here.

The RISC-V platforms fail as well with the following crash
START - test_pi
E:
E:  mcause: 2, Illegal instruction
E:   mtval: 0
E:      a0: 8000e2c4    t0: 00000000
E:      a1: 00000000    t1: 8000953c
E:      a2: 00000000    t2: 800041c4
E:      a3: 00000080    t3: 00000000
E:      a4: 00000000    t4: 00000002
E:      a5: 80009000    t5: 80009000
E:      a6: 80009000    t6: 8000791e
E:      a7: 800065a6
E:      tp: 8000c6ac
E:      ra: 800029f6
E:    mepc: 800012b6
E: mstatus: 00001880
E:
E: >>> ZEPHYR FATAL ERROR 0: CPU exception on CPU 0
E: Current thread: 0x80009910 (test_pi)
E: Halting system

Disable them as well.

Signed-off-by: Bradley Bolen <bbolen@lexmark.com>