### PR TITLE
boards: mps3_an547: Enable MVE on QEMU

### DIFF
--- a/boards/arm/mps3_an547/board.cmake
+++ b/boards/arm/mps3_an547/board.cmake
@@ -4,10 +4,10 @@
 # The AN547 FVP must be used to enable Ethos-U55 NPU support, but QEMU also
 # supports the AN547 without the NPU.
 #
-# To use QEMU instead of the FVP as an emulation platform, set 'EMU_PLATFORM'
-# to 'qemu' instead of 'armfvp', for example:
+# For emulation, QEMU is used by default. To use AN547 FVP as an emulation
+# use the 'run_armfvp' target, for example:
 #
-# $ west build -b mps3_an547 samples/hello°world -DEMU_PLATFORM=qemu -t run
+# $ west build -b mps3_an547 samples/hello_world -t run_armfvp
 
 set(SUPPORTED_EMU_PLATFORMS qemu armfvp)
 

--- a/modules/Kconfig.cmsis_dsp
+++ b/modules/Kconfig.cmsis_dsp
@@ -190,6 +190,7 @@ config CMSIS_DSP_TRANSFORM
 
 config CMSIS_DSP_SVM
 	bool "Support Vector Machine Functions"
+	select CMSIS_DSP_TABLES
 	help
 	  This option enables the Support Vector Machine Functions, which
 	  support the following algorithms:

--- a/soc/arm/arm/mps3/Kconfig.soc
+++ b/soc/arm/arm/mps3/Kconfig.soc
@@ -13,7 +13,7 @@ config SOC_MPS3_AN547
 	select CPU_HAS_ARM_MPU
 	select CPU_HAS_FPU
 	select ARMV8_M_DSP
-	select ARMV8_1_M_MVEI if !QEMU_TARGET
-	select ARMV8_1_M_MVEF if !QEMU_TARGET
+	select ARMV8_1_M_MVEI
+	select ARMV8_1_M_MVEF
 
 endchoice

--- a/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
@@ -12,6 +12,7 @@ tests:
     filter: (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: benchmark cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/benchmarks/cmsis_dsp/basicmath/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   benchmark.cmsis_dsp.basicmath:
     filter: (CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1

--- a/tests/lib/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/basicmath/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.basicmath:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/basicmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/basicmath/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/bayes/testcase.yaml
+++ b/tests/lib/cmsis_dsp/bayes/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/bayes/testcase.yaml
+++ b/tests/lib/cmsis_dsp/bayes/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.bayes:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/complexmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/complexmath/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/complexmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/complexmath/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.complexmath:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/distance/testcase.yaml
+++ b/tests/lib/cmsis_dsp/distance/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/distance/testcase.yaml
+++ b/tests/lib/cmsis_dsp/distance/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.distance:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/fastmath/src/f16.c
+++ b/tests/lib/cmsis_dsp/fastmath/src/f16.c
@@ -20,6 +20,15 @@
 #define ABS_ERROR_THRESH	(1.0e-3)
 #define ABS_LOG_ERROR_THRESH	(3.0e-2)
 
+#ifdef CONFIG_ARMV8_1_M_MVEF
+/*
+ * NOTE: The MVE vector version of the `vinverse` function is slightly less
+ *       accurate than the scalar version.
+ */
+#undef REL_ERROR_THRESH
+#define REL_ERROR_THRESH	(1.1e-3)
+#endif
+
 #if 0
 /*
  * NOTE: These tests must be enabled once the F16 sine and cosine function

--- a/tests/lib/cmsis_dsp/fastmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/fastmath/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/fastmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/fastmath/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.fastmath:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/filtering/src/biquad_f16.c
+++ b/tests/lib/cmsis_dsp/filtering/src/biquad_f16.c
@@ -27,20 +27,31 @@ static void test_arm_biquad_cascade_df1_f16_default(void)
 	const float16_t *ref = (const float16_t *)ref_default;
 	float16_t *state, *output_buf, *output;
 	arm_biquad_casd_df1_inst_f16 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	arm_biquad_mod_coef_f16 *coeff_mod;
+#endif
 
 	/* Allocate buffers */
-	state = malloc(128 * sizeof(float16_t));
+	state = calloc(128, sizeof(float16_t));
 	zassert_not_null(state, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
-	output_buf = malloc(length * sizeof(float16_t));
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	coeff_mod = calloc(47, sizeof(arm_biquad_mod_coef_f16)); /* 47 stages */
+	zassert_not_null(coeff_mod, ASSERT_MSG_BUFFER_ALLOC_FAILED);
+#endif
+
+	/* FIXME: `length + 2` is required here because of ARM-software/CMSIS_5#1475 */
+	output_buf = calloc(length + 2, sizeof(float16_t));
 	zassert_not_null(output_buf, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	output = output_buf;
 
 	/* Initialise instance */
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	arm_biquad_cascade_df1_mve_init_f16(&inst, 3, coeff, coeff_mod, state);
+#else
 	arm_biquad_cascade_df1_init_f16(&inst, 3, coeff, state);
-
-	/* TODO: Add MVEF support */
+#endif
 
 	/* Enumerate blocks */
 	for (index = 0; index < 2; index++) {
@@ -128,12 +139,20 @@ static void test_arm_biquad_cascade_df1_f16_rand(void)
 	const float16_t *ref = (const float16_t *)ref_rand_mono;
 	float16_t *state, *output_buf, *output;
 	arm_biquad_casd_df1_inst_f16 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	arm_biquad_mod_coef_f16 *coeff_mod;
+#endif
 
 	/* Allocate buffers */
-	state = malloc(128 * sizeof(float16_t));
+	state = calloc(128, sizeof(float16_t));
 	zassert_not_null(state, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
-	output_buf = malloc(length * sizeof(float16_t));
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	coeff_mod = calloc(47, sizeof(arm_biquad_mod_coef_f16)); /* 47 stages */
+	zassert_not_null(coeff_mod, ASSERT_MSG_BUFFER_ALLOC_FAILED);
+#endif
+
+	output_buf = calloc(length, sizeof(float16_t));
 	zassert_not_null(output_buf, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	output = output_buf;
@@ -145,10 +164,11 @@ static void test_arm_biquad_cascade_df1_f16_rand(void)
 		block_size = config[1];
 
 		/* Initialise instance */
-		arm_biquad_cascade_df1_init_f16(
-			&inst, stage_count, coeff, state);
-
-		/* TODO: Add MVEF support */
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+		arm_biquad_cascade_df1_mve_init_f16(&inst, stage_count, coeff, coeff_mod, state);
+#else
+		arm_biquad_cascade_df1_init_f16(&inst, stage_count, coeff, state);
+#endif
 
 		/* Run test function */
 		arm_biquad_cascade_df1_f16(&inst, input, output, block_size);

--- a/tests/lib/cmsis_dsp/filtering/src/biquad_f32.c
+++ b/tests/lib/cmsis_dsp/filtering/src/biquad_f32.c
@@ -26,20 +26,31 @@ static void test_arm_biquad_cascade_df1_f32_default(void)
 	const float32_t *ref = (const float32_t *)ref_default;
 	float32_t *state, *output_buf, *output;
 	arm_biquad_casd_df1_inst_f32 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	arm_biquad_mod_coef_f32 *coeff_mod;
+#endif
 
 	/* Allocate buffers */
-	state = malloc(128 * sizeof(float32_t));
+	state = calloc(128, sizeof(float32_t));
 	zassert_not_null(state, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
-	output_buf = malloc(length * sizeof(float32_t));
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	coeff_mod = calloc(47, sizeof(arm_biquad_mod_coef_f32)); /* 47 stages */
+	zassert_not_null(coeff_mod, ASSERT_MSG_BUFFER_ALLOC_FAILED);
+#endif
+
+	/* FIXME: `length + 2` is required here because of ARM-software/CMSIS_5#1475 */
+	output_buf = calloc(length + 2, sizeof(float32_t));
 	zassert_not_null(output_buf, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	output = output_buf;
 
 	/* Initialise instance */
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	arm_biquad_cascade_df1_mve_init_f32(&inst, 3, coeff, coeff_mod, state);
+#else
 	arm_biquad_cascade_df1_init_f32(&inst, 3, coeff, state);
-
-	/* TODO: Add MVEF support */
+#endif
 
 	/* Enumerate blocks */
 	for (index = 0; index < 2; index++) {
@@ -125,12 +136,20 @@ static void test_arm_biquad_cascade_df1_f32_rand(void)
 	const float32_t *ref = (const float32_t *)ref_rand_mono;
 	float32_t *state, *output_buf, *output;
 	arm_biquad_casd_df1_inst_f32 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	arm_biquad_mod_coef_f32 *coeff_mod;
+#endif
 
 	/* Allocate buffers */
-	state = malloc(128 * sizeof(float32_t));
+	state = calloc(128, sizeof(float32_t));
 	zassert_not_null(state, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
-	output_buf = malloc(length * sizeof(float32_t));
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	coeff_mod = calloc(47, sizeof(arm_biquad_mod_coef_f32)); /* 47 stages */
+	zassert_not_null(coeff_mod, ASSERT_MSG_BUFFER_ALLOC_FAILED);
+#endif
+
+	output_buf = calloc(length, sizeof(float32_t));
 	zassert_not_null(output_buf, ASSERT_MSG_BUFFER_ALLOC_FAILED);
 
 	output = output_buf;
@@ -142,10 +161,11 @@ static void test_arm_biquad_cascade_df1_f32_rand(void)
 		block_size = config[1];
 
 		/* Initialise instance */
-		arm_biquad_cascade_df1_init_f32(
-			&inst, stage_count, coeff, state);
-
-		/* TODO: Add MVEF support */
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+		arm_biquad_cascade_df1_mve_init_f32(&inst, stage_count, coeff, coeff_mod, state);
+#else
+		arm_biquad_cascade_df1_init_f32(&inst, stage_count, coeff, state);
+#endif
 
 		/* Run test function */
 		arm_biquad_cascade_df1_f32(&inst, input, output, block_size);

--- a/tests/lib/cmsis_dsp/filtering/src/fir_f16.c
+++ b/tests/lib/cmsis_dsp/filtering/src/fir_f16.c
@@ -16,6 +16,8 @@
 #define SNR_ERROR_THRESH	((float32_t)60)
 #define REL_ERROR_THRESH	(1.0e-2)
 
+#define COEFF_PADDING		(4)
+
 static void test_arm_fir_f16(void)
 {
 	size_t sample_index, block_index;
@@ -28,6 +30,10 @@ static void test_arm_fir_f16(void)
 	const float16_t *ref = (const float16_t *)ref_val;
 	float16_t *state, *output_buf, *output;
 	arm_fir_instance_f16 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	float16_t coeff_padded[32];
+	int round;
+#endif
 
 	/* Allocate buffers */
 	state = malloc(2 * 47 * sizeof(float16_t));
@@ -44,10 +50,24 @@ static void test_arm_fir_f16(void)
 		block_size = config[0];
 		tap_count = config[1];
 
-		/* Initialise instance */
-		arm_fir_init_f16(&inst, tap_count, coeff, state, block_size);
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+		/* Copy coefficients and pad to zero */
+		memset(coeff_padded, 127, sizeof(coeff_padded));
+		round = tap_count / COEFF_PADDING;
+		if ((round * COEFF_PADDING) < tap_count) {
+			round++;
+		}
+		round = round * COEFF_PADDING;
+		memset(coeff_padded, 0, round * sizeof(float16_t));
+		memcpy(coeff_padded, coeff, tap_count * sizeof(float16_t));
+#endif
 
-		/* TODO: Add MEVF support */
+		/* Initialise instance */
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+		arm_fir_init_f16(&inst, tap_count, coeff_padded, state, block_size);
+#else
+		arm_fir_init_f16(&inst, tap_count, coeff, state, block_size);
+#endif
 
 		/* Reset input pointer */
 		input = (const float16_t *)in_val;

--- a/tests/lib/cmsis_dsp/filtering/src/fir_f32.c
+++ b/tests/lib/cmsis_dsp/filtering/src/fir_f32.c
@@ -16,6 +16,8 @@
 #define SNR_ERROR_THRESH	((float32_t)120)
 #define REL_ERROR_THRESH	(3.0e-5)
 
+#define COEFF_PADDING		(4)
+
 static void test_arm_fir_f32(void)
 {
 	size_t sample_index, block_index;
@@ -28,6 +30,10 @@ static void test_arm_fir_f32(void)
 	const float32_t *ref = (const float32_t *)ref_val;
 	float32_t *state, *output_buf, *output;
 	arm_fir_instance_f32 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+	float32_t coeff_padded[32];
+	int round;
+#endif
 
 	/* Allocate buffers */
 	state = malloc(2 * 47 * sizeof(float32_t));
@@ -44,10 +50,24 @@ static void test_arm_fir_f32(void)
 		block_size = config[0];
 		tap_count = config[1];
 
-		/* Initialise instance */
-		arm_fir_init_f32(&inst, tap_count, coeff, state, block_size);
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+		/* Copy coefficients and pad to zero */
+		memset(coeff_padded, 127, sizeof(coeff_padded));
+		round = tap_count / COEFF_PADDING;
+		if ((round * COEFF_PADDING) < tap_count) {
+			round++;
+		}
+		round = round * COEFF_PADDING;
+		memset(coeff_padded, 0, round * sizeof(float32_t));
+		memcpy(coeff_padded, coeff, tap_count * sizeof(float32_t));
+#endif
 
-		/* TODO: Add MEVF support */
+		/* Initialise instance */
+#if defined(CONFIG_ARMV8_1_M_MVEF) && defined(CONFIG_FPU)
+		arm_fir_init_f32(&inst, tap_count, coeff_padded, state, block_size);
+#else
+		arm_fir_init_f32(&inst, tap_count, coeff, state, block_size);
+#endif
 
 		/* Reset input pointer */
 		input = (const float32_t *)in_val;

--- a/tests/lib/cmsis_dsp/filtering/src/fir_q15.c
+++ b/tests/lib/cmsis_dsp/filtering/src/fir_q15.c
@@ -16,6 +16,8 @@
 #define SNR_ERROR_THRESH	((float32_t)59)
 #define ABS_ERROR_THRESH_Q15	((q15_t)2)
 
+#define COEFF_PADDING		(8)
+
 static void test_arm_fir_q15(void)
 {
 	size_t sample_index, block_index;
@@ -28,6 +30,10 @@ static void test_arm_fir_q15(void)
 	const q15_t *ref = (const q15_t *)ref_val;
 	q15_t *state, *output_buf, *output;
 	arm_fir_instance_q15 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+	q15_t coeff_padded[32];
+	int round;
+#endif
 
 	/* Allocate buffers */
 	state = malloc(3 * 41 * sizeof(q15_t));
@@ -44,10 +50,24 @@ static void test_arm_fir_q15(void)
 		block_size = config[0];
 		tap_count = config[1];
 
-		/* Initialise instance */
-		arm_fir_init_q15(&inst, tap_count, coeff, state, block_size);
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+		/* Copy coefficients and pad to zero */
+		memset(coeff_padded, 127, sizeof(coeff_padded));
+		round = tap_count / COEFF_PADDING;
+		if ((round * COEFF_PADDING) < tap_count) {
+			round++;
+		}
+		round = round * COEFF_PADDING;
+		memset(coeff_padded, 0, round * sizeof(q15_t));
+		memcpy(coeff_padded, coeff, tap_count * sizeof(q15_t));
+#endif
 
-		/* TODO: Add MEVI support */
+		/* Initialise instance */
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+		arm_fir_init_q15(&inst, tap_count, coeff_padded, state, block_size);
+#else
+		arm_fir_init_q15(&inst, tap_count, coeff, state, block_size);
+#endif
 
 		/* Reset input pointer */
 		input = (const q15_t *)in_val;

--- a/tests/lib/cmsis_dsp/filtering/src/fir_q31.c
+++ b/tests/lib/cmsis_dsp/filtering/src/fir_q31.c
@@ -16,6 +16,8 @@
 #define SNR_ERROR_THRESH	((float32_t)100)
 #define ABS_ERROR_THRESH_Q31	((q31_t)2)
 
+#define COEFF_PADDING		(4)
+
 static void test_arm_fir_q31(void)
 {
 	size_t sample_index, block_index;
@@ -28,6 +30,10 @@ static void test_arm_fir_q31(void)
 	const q31_t *ref = (const q31_t *)ref_val;
 	q31_t *state, *output_buf, *output;
 	arm_fir_instance_q31 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+	q31_t coeff_padded[32];
+	int round;
+#endif
 
 	/* Allocate buffers */
 	state = malloc(3 * 47 * sizeof(q31_t));
@@ -44,10 +50,24 @@ static void test_arm_fir_q31(void)
 		block_size = config[0];
 		tap_count = config[1];
 
-		/* Initialise instance */
-		arm_fir_init_q31(&inst, tap_count, coeff, state, block_size);
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+		/* Copy coefficients and pad to zero */
+		memset(coeff_padded, 127, sizeof(coeff_padded));
+		round = tap_count / COEFF_PADDING;
+		if ((round * COEFF_PADDING) < tap_count) {
+			round++;
+		}
+		round = round * COEFF_PADDING;
+		memset(coeff_padded, 0, round * sizeof(q31_t));
+		memcpy(coeff_padded, coeff, tap_count * sizeof(q31_t));
+#endif
 
-		/* TODO: Add MEVI support */
+		/* Initialise instance */
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+		arm_fir_init_q31(&inst, tap_count, coeff_padded, state, block_size);
+#else
+		arm_fir_init_q31(&inst, tap_count, coeff, state, block_size);
+#endif
 
 		/* Reset input pointer */
 		input = (const q31_t *)in_val;

--- a/tests/lib/cmsis_dsp/filtering/src/fir_q7.c
+++ b/tests/lib/cmsis_dsp/filtering/src/fir_q7.c
@@ -16,6 +16,8 @@
 #define SNR_ERROR_THRESH	((float32_t)10)
 #define ABS_ERROR_THRESH_Q7	((q7_t)2)
 
+#define COEFF_PADDING		(16)
+
 static void test_arm_fir_q7(void)
 {
 	size_t sample_index, block_index;
@@ -28,6 +30,10 @@ static void test_arm_fir_q7(void)
 	const q7_t *ref = (const q7_t *)ref_val;
 	q7_t *state, *output_buf, *output;
 	arm_fir_instance_q7 inst;
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+	q7_t coeff_padded[32];
+	int round;
+#endif
 
 	/* Allocate buffers */
 	state = malloc(47 * sizeof(q7_t));
@@ -44,10 +50,24 @@ static void test_arm_fir_q7(void)
 		block_size = config[0];
 		tap_count = config[1];
 
-		/* Initialise instance */
-		arm_fir_init_q7(&inst, tap_count, coeff, state, block_size);
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+		/* Copy coefficients and pad to zero */
+		memset(coeff_padded, 127, sizeof(coeff_padded));
+		round = tap_count / COEFF_PADDING;
+		if ((round * COEFF_PADDING) < tap_count) {
+			round++;
+		}
+		round = round * COEFF_PADDING;
+		memset(coeff_padded, 0, round * sizeof(q7_t));
+		memcpy(coeff_padded, coeff, tap_count * sizeof(q7_t));
+#endif
 
-		/* TODO: Add MEVI support */
+		/* Initialise instance */
+#if defined(CONFIG_ARMV8_1_M_MVEI) && defined(CONFIG_FPU)
+		arm_fir_init_q7(&inst, tap_count, coeff_padded, state, block_size);
+#else
+		arm_fir_init_q7(&inst, tap_count, coeff, state, block_size);
+#endif
 
 		/* Reset input pointer */
 		input = (const q7_t *)in_val;

--- a/tests/lib/cmsis_dsp/filtering/testcase.yaml
+++ b/tests/lib/cmsis_dsp/filtering/testcase.yaml
@@ -1,7 +1,5 @@
 common:
   toolchain_exclude: llvm
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
 
 tests:
   libraries.cmsis_dsp.filtering:

--- a/tests/lib/cmsis_dsp/filtering/testcase.yaml
+++ b/tests/lib/cmsis_dsp/filtering/testcase.yaml
@@ -23,6 +23,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -47,6 +48,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -71,6 +73,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -95,6 +98,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 256
     min_ram: 64

--- a/tests/lib/cmsis_dsp/interpolation/testcase.yaml
+++ b/tests/lib/cmsis_dsp/interpolation/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/interpolation/testcase.yaml
+++ b/tests/lib/cmsis_dsp/interpolation/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.interpolation:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.matrix:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/matrix/testcase.yaml
+++ b/tests/lib/cmsis_dsp/matrix/testcase.yaml
@@ -20,6 +20,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -44,6 +45,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -68,6 +70,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -91,6 +94,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -115,6 +119,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -139,6 +144,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64
@@ -164,6 +170,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     platform_exclude: frdm_kw41z
     min_flash: 128
@@ -190,6 +197,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     platform_exclude: frdm_kw41z
     min_flash: 128
@@ -216,6 +224,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     platform_exclude: frdm_kw41z
     min_flash: 128
@@ -240,6 +249,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 144
@@ -265,6 +275,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     platform_exclude: frdm_kw41z
     min_flash: 128
@@ -291,6 +302,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     platform_exclude: frdm_kw41z
     min_flash: 128

--- a/tests/lib/cmsis_dsp/quaternionmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/quaternionmath/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     extra_configs:
       - CONFIG_FPU=y

--- a/tests/lib/cmsis_dsp/quaternionmath/testcase.yaml
+++ b/tests/lib/cmsis_dsp/quaternionmath/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.quaternionmath:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/statistics/src/f16.c
+++ b/tests/lib/cmsis_dsp/statistics/src/f16.c
@@ -20,6 +20,18 @@
 #define REL_ERROR_THRESH_KB	(5.0e-3)
 #define ABS_ERROR_THRESH_KB	(5.0e-3)
 
+#ifdef CONFIG_ARMV8_1_M_MVEF
+/*
+ * NOTE: The MVE vector version of the statistics functions are slightly less
+ *       accurate than the scalar version.
+ */
+#undef REL_ERROR_THRESH
+#define REL_ERROR_THRESH	(10.0e-3)
+
+#undef SNR_ERROR_THRESH_KB
+#define SNR_ERROR_THRESH_KB	((float32_t)39)
+#endif
+
 static void test_arm_max_f16(
 	const uint16_t *input1, int ref_index, size_t length)
 {

--- a/tests/lib/cmsis_dsp/statistics/testcase.yaml
+++ b/tests/lib/cmsis_dsp/statistics/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.statistics:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/statistics/testcase.yaml
+++ b/tests/lib/cmsis_dsp/statistics/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64

--- a/tests/lib/cmsis_dsp/support/testcase.yaml
+++ b/tests/lib/cmsis_dsp/support/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64

--- a/tests/lib/cmsis_dsp/support/testcase.yaml
+++ b/tests/lib/cmsis_dsp/support/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.support:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/svm/testcase.yaml
+++ b/tests/lib/cmsis_dsp/svm/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.svm:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_dsp/svm/testcase.yaml
+++ b/tests/lib/cmsis_dsp/svm/testcase.yaml
@@ -13,6 +13,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 128
     min_ram: 64

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -20,6 +20,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
     min_ram: 64
@@ -44,6 +45,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
     min_ram: 64
@@ -68,6 +70,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -92,6 +95,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -115,6 +119,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
     min_ram: 64
@@ -138,6 +143,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1)
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
     min_ram: 64
@@ -162,6 +168,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64
@@ -186,6 +193,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 512
     min_ram: 64
@@ -210,6 +218,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 96
@@ -234,6 +243,7 @@ tests:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and CONFIG_CPU_HAS_FPU and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX
     integration_platforms:
       - mps2_an521_remote
+      - mps3_an547
     tags: cmsis_dsp fpu
     min_flash: 1024
     min_ram: 64

--- a/tests/lib/cmsis_dsp/transform/testcase.yaml
+++ b/tests/lib/cmsis_dsp/transform/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_dsp.transform:
     filter: ((CONFIG_CPU_AARCH32_CORTEX_R or CONFIG_CPU_CORTEX_M) and TOOLCHAIN_HAS_NEWLIB == 1) or CONFIG_ARCH_POSIX

--- a/tests/lib/cmsis_nn/testcase.yaml
+++ b/tests/lib/cmsis_nn/testcase.yaml
@@ -1,7 +1,3 @@
-common:
-  # TODO: Remove when QEMU 6.2 is released with MVE emulation (see #37694).
-  platform_exclude: mps3_an547
-
 tests:
   libraries.cmsis_nn:
     filter: CONFIG_CPU_CORTEX_M and TOOLCHAIN_HAS_NEWLIB == 1

--- a/west.yml
+++ b/west.yml
@@ -35,7 +35,7 @@ manifest:
       revision: 094aeb41bb93e9199d24d665ee43e9e05d6d7b1c
       path: modules/lib/civetweb
     - name: cmsis
-      revision: e6e0c9c65a6ff371932b90ebc2153ac93386662b
+      revision: 5f86244bad4ad5a590e084f0e72ba7a1416c2edf
       path: modules/hal/cmsis
       groups:
         - hal


### PR DESCRIPTION
This series re-enables the M-Profile Vector Extension (MVE) feature when QEMU emulation is used.

Note that the MVE was disabled for QEMU because earlier versions (< 6.2) did not support the emulation of the MVE instructions: see #40569 and #41018.

This series also includes some fixes for the CMSIS-DSP integration and tests so that they can build successfully with the MVE enabled.

Fixes #40970

~~Merge after #45301~~ merged