### PR TITLE
counter: cmos: use device tree to instantiate driver

### DIFF
--- a/drivers/counter/counter_cmos.c
+++ b/drivers/counter/counter_cmos.c
@@ -11,14 +11,16 @@
  * crossing clock domains (no pun intended). Use accordingly.
  */
 
+#define DT_DRV_COMPAT motorola_mc146818
+
 #include <drivers/counter.h>
 #include <device.h>
 #include <soc.h>
 
 /* The "CMOS" device is accessed via an address latch and data port. */
 
-#define X86_CMOS_ADDR 0x70
-#define X86_CMOS_DATA 0x71
+#define X86_CMOS_ADDR (DT_INST_REG_ADDR_BY_IDX(0, 0))
+#define X86_CMOS_DATA (DT_INST_REG_ADDR_BY_IDX(0, 1))
 
 /*
  * A snapshot of the RTC state, or at least the state we're
@@ -208,5 +210,5 @@ static const struct counter_driver_api api = {
 	.get_value = get_value
 };
 
-DEVICE_DEFINE(counter_cmos, "CMOS", init, NULL, NULL, &info,
-		    POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY, &api);
+DEVICE_DT_INST_DEFINE(0, &init, NULL, NULL, &info,
+		      POST_KERNEL, CONFIG_COUNTER_INIT_PRIORITY, &api);

--- a/dts/bindings/counter/motorola,mc146818.yaml
+++ b/dts/bindings/counter/motorola,mc146818.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022, Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Motorola MC146818 compatible Real Timer Clock
+
+compatible: "motorola,mc146818"
+
+include: base.yaml
+
+properties:
+    label:
+      required: true

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -387,6 +387,14 @@
 
 			status = "okay";
 		};
+
+		counter: counter@70 {
+			label = "CMOS";
+			compatible = "motorola,mc146818";
+			reg = <0x70 0x0D 0x71 0x0D>;
+
+			status = "okay";
+		};
 	};
 
 	gpio_n: gpio-north {

--- a/dts/x86/atom.dtsi
+++ b/dts/x86/atom.dtsi
@@ -70,5 +70,13 @@
 
 			status = "disabled";
 		};
+
+		counter: counter@70 {
+			label = "CMOS";
+			compatible = "motorola,mc146818";
+			reg = <0x70 0x0D 0x71 0x0D>;
+
+			status = "okay";
+		};
 	};
 };

--- a/dts/x86/elkhart_lake.dtsi
+++ b/dts/x86/elkhart_lake.dtsi
@@ -688,5 +688,13 @@
 
 			status = "okay";
 		};
+
+		counter: counter@70 {
+			label = "CMOS";
+			compatible = "motorola,mc146818";
+			reg = <0x70 0x0D 0x71 0x0D>;
+
+			status = "okay";
+		};
 	};
 };

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -70,5 +70,13 @@
 
 			status = "disabled";
 		};
+
+		counter: counter@70 {
+			label = "CMOS";
+			compatible = "motorola,mc146818";
+			reg = <0x70 0x0D 0x71 0x0D>;
+
+			status = "okay";
+		};
 	};
 };

--- a/tests/arch/x86/info/src/timer.c
+++ b/tests/arch/x86/info/src/timer.c
@@ -9,6 +9,7 @@
 
 #define NR_SAMPLES 10	/* sample timer 10 times */
 
+#if defined(CONFIG_COUNTER_CMOS)
 static uint32_t sync(const struct device *cmos)
 {
 	uint32_t this, last;
@@ -31,11 +32,10 @@ static uint32_t sync(const struct device *cmos)
 
 	return sys_clock_cycle_get_32();
 }
+#endif
 
 void timer(void)
 {
-	const struct device *cmos;
-
 #if defined(CONFIG_APIC_TIMER)
 	printk("TIMER: new local APIC");
 #elif defined(CONFIG_HPET_TIMER)
@@ -47,7 +47,8 @@ void timer(void)
 	printk(", configured frequency = %dHz\n",
 		sys_clock_hw_cycles_per_sec());
 
-	cmos = device_get_binding("CMOS");
+#if defined(CONFIG_COUNTER_CMOS)
+	const struct device *cmos = device_get_binding("CMOS");
 	if (cmos == NULL) {
 		printk("\tCan't get reference CMOS clock device.\n");
 	} else {
@@ -68,6 +69,7 @@ void timer(void)
 
 		printk("\taverage = %uHz\n", (unsigned) (sum / NR_SAMPLES));
 	}
+#endif
 
 	printk("\n");
 }


### PR DESCRIPTION
This makes the necessary changes so that CMOS RTC driver can use device tree to instantiate the driver instance.