### PR TITLE
kernel: sched: Change cpu pin only for not executing threads 

### DIFF
--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -84,6 +84,14 @@ static ALWAYS_INLINE void arch_cohere_stacks(struct k_thread *old_thread,
 				 : "=r"(a0save));
 	}
 
+	/* The following option ensures that a living thread will never
+	 * be executed in a different CPU so we can safely return without
+	 * invalidate and/or flush threads cache.
+	 */
+	if (IS_ENABLED(CONFIG_SCHED_CPU_MASK_PIN_ONLY)) {
+		return;
+	}
+
 	/* The "live" area (the region between the switch handle,
 	 * which is the stack pointer, and the top of the stack
 	 * memory) of the inbound stack needs to be invalidated if we

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -148,7 +148,9 @@ config SCHED_CPU_MASK_PIN_ONLY
 	  architecture and want to make their own decisions about how
 	  to assign work to CPUs.  In that circumstance, some moderate
 	  optimizations can be made (e.g. having a separate run queue
-	  per CPU, keeping the list length shorter).  Most
+	  per CPU, keeping the list length shorter). When selected,
+	  the CPU mask becomes an immutable thread attribute. It can
+	  only be modified before a thread is started.  Most
 	  applications don't want this.
 
 config MAIN_STACK_SIZE

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1594,6 +1594,11 @@ static int cpu_mask_mod(k_tid_t thread, uint32_t enable_mask, uint32_t disable_m
 {
 	int ret = 0;
 
+#ifdef CONFIG_SCHED_CPU_MASK_PIN_ONLY
+	__ASSERT((thread->base.thread_state != _THREAD_PRESTART),
+		 "Only PRESTARTED threads can change CPU pin");
+#endif
+
 	LOCKED(&sched_spinlock) {
 		if (z_is_thread_prevented_from_running(thread)) {
 			thread->base.cpu_mask |= enable_mask;


### PR DESCRIPTION
Do not allow changing the CPU which a thread is pinned when it is
already being executed. This possibilities further optimizations in
some platforms with incoherent memory since we can safely assume that
the thread will run in the same CPU and avoid invalidate / flush the
cache during context switches.
