### PR TITLE
drivers: adc: Refactor code to remove warning

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -805,18 +805,16 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 {
 	const struct adc_stm32_cfg *config = dev->config;
 #ifdef CONFIG_SOC_SERIES_STM32G4X
-	ADC_TypeDef *adc = config->base;
-
 	if (config->has_temp_channel) {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay)
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC1) == channel_id)
-		    && (adc == ADC1)) {
+		    && (config->base == ADC1)) {
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 		}
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc5), okay)
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC5) == channel_id)
-		   && (adc == ADC5)) {
+		   && (config->base == ADC5)) {
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 		}
 #endif


### PR DESCRIPTION
Refactor code so that an unused variable 'adc' warning
is not generated when building for CONFIG_SOC_SERIES_STM32G4X
and not using adc1 or adc5.

Signed-off-by: Sam Hurst <sbh1187@gmail.com>