### PR TITLE
it8xxx2: espi/kbc: read kbc event type before read input buffer

### DIFF
--- a/drivers/espi/espi_it8xxx2.c
+++ b/drivers/espi/espi_it8xxx2.c
@@ -378,14 +378,14 @@ static void kbc_it8xxx2_ibf_isr(const struct device *dev)
 
 	/* KBC Input Buffer Full event */
 	kbc_evt->evt = HOST_KBC_EVT_IBF;
-	/* The data in KBC Input Buffer */
-	kbc_evt->data = kbc_reg->KBHIDIR;
 	/*
 	 * Indicates if the host sent a command or data.
 	 * 0 = data
 	 * 1 = Command.
 	 */
 	kbc_evt->type = !!(kbc_reg->KBHISR & KBC_KBHISR_A2_ADDR);
+	/* The data in KBC Input Buffer */
+	kbc_evt->data = kbc_reg->KBHIDIR;
 
 	espi_send_callbacks(&data->callbacks, dev, evt);
 }


### PR DESCRIPTION
Host might send command or data immediately after EC read the
KBC input buffer (IBF gets cleared).
This change make sure EC won't get wrong event type in IBF ISR.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>