### PR TITLE
dts: arm: st: f1: added DAC

### DIFF
--- a/dts/arm/st/f1/stm32f100Xb.dtsi
+++ b/dts/arm/st/f1/stm32f100Xb.dtsi
@@ -42,5 +42,14 @@
 			status = "disabled";
 			label = "SPI_2";
 		};
+
+		dac1: dac@40007400 {
+			compatible = "st,stm32-dac";
+			reg = <0x40007400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x20000000>;
+			status = "disabled";
+			label = "DAC_1";
+			#io-channel-cells = <1>;
+		};
 	};
 };

--- a/dts/arm/st/f1/stm32f103Xc.dtsi
+++ b/dts/arm/st/f1/stm32f103Xc.dtsi
@@ -92,6 +92,15 @@
 			status = "disabled";
 		};
 
+		dac1: dac@40007400 {
+			compatible = "st,stm32-dac";
+			reg = <0x40007400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x20000000>;
+			status = "disabled";
+			label = "DAC_1";
+			#io-channel-cells = <1>;
+		};
+
 		pinctrl: pin-controller@40010800 {
 			reg = <0x40010800 0x2000>;
 

--- a/dts/arm/st/f1/stm32f105.dtsi
+++ b/dts/arm/st/f1/stm32f105.dtsi
@@ -55,6 +55,15 @@
 			sample-point = <875>;
 		};
 
+		dac1: dac@40007400 {
+			compatible = "st,stm32-dac";
+			reg = <0x40007400 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x20000000>;
+			status = "disabled";
+			label = "DAC_1";
+			#io-channel-cells = <1>;
+		};
+
 		uart4: serial@40004c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40004c00 0x400>;


### PR DESCRIPTION
Adds DAC to stm32f103Xc, stm32f105Xc, stm32f107Xc.

> Low-density devices are STM32F101xx, STM32F102xx and STM32F103xx 
> microcontrollers where the Flash memory density ranges between 16 and 32 Kbytes.
> 
> Medium-density devices are STM32F101xx, STM32F102xx and STM32F103xx 
> microcontrollers where the Flash memory density ranges between 64 and 128 Kbytes.
> 
> High-density devices are STM32F101xx and STM32F103xx microcontrollers where the 
> Flash memory density ranges between 256 and 512 Kbytes.
> 
> XL-density devices are STM32F101xx and STM32F103xx microcontrollers where the 
> Flash memory density ranges between 768 Kbytes and 1 Mbyte.
> 
> Connectivity line devices are STM32F105xx and STM32F107xx microcontrollers.
> 
> This section applies to connectivity line, high-density and XL-density STM32F101xx and 
> STM32F103xx devices only.

Only DAC1 is added so far. Tested with stm32f103vc on a custom board.