### PR TITLE
CMSIS: NN fixes

### DIFF
--- a/tests/lib/cmsis_nn/testcase.yaml
+++ b/tests/lib/cmsis_nn/testcase.yaml
@@ -4,7 +4,7 @@ common:
 
 tests:
   libraries.cmsis_nn:
-    filter: CPU_CORTEX_M and TOOLCHAIN_HAS_NEWLIB == 1
+    filter: CONFIG_CPU_CORTEX_M and TOOLCHAIN_HAS_NEWLIB == 1
     integration_platforms:
       - frdm_k64f
       - sam_e70_xplained

--- a/west.yml
+++ b/west.yml
@@ -35,7 +35,7 @@ manifest:
       revision: 094aeb41bb93e9199d24d665ee43e9e05d6d7b1c
       path: modules/lib/civetweb
     - name: cmsis
-      revision: ed63b704bbfaceb71220557b658304c5ea3d5b88
+      revision: e6e0c9c65a6ff371932b90ebc2153ac93386662b
       path: modules/hal/cmsis
       groups:
         - hal


### PR DESCRIPTION
Imports a missing function that is not marked as TFL-micro compliant yet is required by TFL-micro compliant functions. Updates the CMSIS-NN test so that it is actually run by CI.