### PR TITLE
dts: intel_cavs: cavs15 custom base IP base addrs

### DIFF
--- a/dts/xtensa/intel/intel_cavs.dtsi
+++ b/dts/xtensa/intel/intel_cavs.dtsi
@@ -31,11 +31,12 @@
 
 			status = "okay";
 		};
+
 		hda_link_out: dma@72400 {
 			compatible = "intel,cavs-hda-link-out";
 			#dma-cells = <1>;
 			reg = <0x00072400 0x40>;
-			dma-channels = <7>;
+			dma-channels = <9>;
 			label = "HDA_LINK_OUT";
 
 			status = "okay";
@@ -55,7 +56,7 @@
 			compatible = "intel,cavs-hda-host-out";
 			#dma-cells = <1>;
 			reg = <0x00072800 0x40>;
-			dma-channels = <7>;
+			dma-channels = <9>;
 			label = "HDA_HOST_OUT";
 
 			status = "okay";
@@ -70,7 +71,5 @@
 
 			status = "okay";
 		};
-
-
 	};
 };

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/intel/intel_cavs.dtsi>
+#include <xtensa/xtensa.dtsi>
 #include <mem.h>
 
 / {
@@ -124,6 +124,70 @@
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
+		};
+
+		lpgpdma0: dma@c000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0000c000 0x1000>;
+			shim = <0x00000c00 0x080>;
+			interrupts = <0x10 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_0";
+
+			status = "okay";
+		};
+
+		lpgpdma1: dma@d000 {
+			compatible = "intel,cavs-gpdma";
+			#dma-cells = <1>;
+			reg = <0x0000d000 0x1000>;
+			shim = <0x00000c80 0x080>;
+			interrupts = <0x0F 0 0>;
+			interrupt-parent = <&cavs3>;
+			label = "DMA_1";
+
+			status = "okay";
+		};
+
+		hda_link_out: dma@2400 {
+			compatible = "intel,cavs-hda-link-out";
+			#dma-cells = <1>;
+			reg = <0x00002400 0x40>;
+			dma-channels = <6>;
+			label = "HDA_LINK_OUT";
+
+			status = "okay";
+		};
+
+		hda_link_in: dma@2600 {
+			compatible = "intel,cavs-hda-link-in";
+			#dma-cells = <1>;
+			reg = <0x00002600 0x40>;
+			dma-channels = <7>;
+			label = "HDA_LINK_IN";
+
+			status = "okay";
+		};
+
+		hda_host_out: dma@2800 {
+			compatible = "intel,cavs-hda-host-out";
+			#dma-cells = <1>;
+			reg = <0x00002800 0x40>;
+			dma-channels = <6>;
+			label = "HDA_HOST_OUT";
+
+			status = "okay";
+		};
+
+		hda_host_in: dma@2c00 {
+			compatible = "intel,cavs-hda-host-in";
+			#dma-cells = <1>;
+			reg = <0x00002c00 0x40>;
+			dma-channels = <7>;
+			label = "HDA_HOST_IN";
+
+			status = "okay";
 		};
 
 		ssp0: ssp@8000 {


### PR DESCRIPTION
cavs15 uses different base addresses for IP blocks than the rest
and thus needs its own configuration in device tree.

Fixes hda and gpdma tests on cavs15

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>