### PR TITLE
tests: Bluetooth: df: Fix build errors in direction finding unit tests

### DIFF
--- a/tests/bluetooth/df/connection_cte_tx_params/prj.conf
+++ b/tests/bluetooth/df/connection_cte_tx_params/prj.conf
@@ -9,6 +9,9 @@ CONFIG_BT_CENTRAL=y
 CONFIG_BT_CTLR=y
 CONFIG_BT_LL_SW_SPLIT=y
 
+# Enable new implementation of LLCP
+CONFIG_BT_LL_SW_LLCP=y
+
 # Enable Direction Finding Feature including AoA and AoD
 CONFIG_BT_DF=y
 CONFIG_BT_CTLR_DF=y

--- a/tests/bluetooth/df/connectionless_cte_rx/src/common.c
+++ b/tests/bluetooth/df/connectionless_cte_rx/src/common.c
@@ -50,7 +50,7 @@ void common_create_per_sync_set(void)
 	 * because it is not required to test DF functionality.
 	 */
 	scan = ull_scan_set_get(SCAN_HANDLE_1M);
-	sync = scan->per_scan.sync;
+	sync = scan->periodic.sync;
 	g_per_sync->handle = ull_sync_handle_get(sync);
 	sync->lll.phy = PHY_2M;
 	/* timeout_reload member is used by controller to check if sync was established. */


### PR DESCRIPTION
The ll_scan_set::per_sync was renamed to ll_scan_set::periodic.
Direction finding connectionless_cte_rx test didn't build.

There was missing kconfig option that enables refactored LLCPs.
That caused build error in Direction Finding connection_cte_tx_params.