### PR TITLE
Bluetooth: has: Add Preset Changed operation support

### DIFF
--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -181,6 +181,30 @@ int bt_has_preset_register(const struct bt_has_preset_register_param *param);
  */
 int bt_has_preset_unregister(uint8_t index);
 
+/**
+ * @brief Set the preset as available.
+ *
+ * Set the @ref BT_HAS_PROP_AVAILABLE property bit. This will notify preset availability
+ * to peer devices. Only available preset can be selected as active preset.
+ *
+ * @param index The index of preset that's became available.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ */
+int bt_has_preset_available(uint8_t index);
+
+/**
+ * @brief Set the preset as unavailable.
+ *
+ * Clear the @ref BT_HAS_PROP_AVAILABLE property bit. This will notify preset availability
+ * to peer devices. Unavailable preset cannot be selected as active preset.
+ *
+ * @param index The index of preset that's became unavailable.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ */
+int bt_has_preset_unavailable(uint8_t index);
+
 enum {
 	BT_HAS_PRESET_ITER_STOP = 0,
 	BT_HAS_PRESET_ITER_CONTINUE,

--- a/subsys/bluetooth/audio/has_internal.h
+++ b/subsys/bluetooth/audio/has_internal.h
@@ -44,6 +44,8 @@
 #define BT_HAS_CHANGE_ID_PRESET_AVAILABLE   0x02
 #define BT_HAS_CHANGE_ID_PRESET_UNAVAILABLE 0x03
 
+#define BT_HAS_IS_LAST 0x01
+
 struct bt_has {
 	/** Hearing Aid Features value */
 	uint8_t features;
@@ -72,6 +74,13 @@ struct bt_has_cp_read_preset_rsp {
 struct bt_has_cp_preset_changed {
 	uint8_t change_id;
 	uint8_t is_last;
+} __packed;
+
+struct bt_has_cp_generic_update {
+	uint8_t prev_index;
+	uint8_t index;
+	uint8_t properties;
+	uint8_t name[0];
 } __packed;
 
 struct bt_has_cp_write_preset_name {

--- a/subsys/bluetooth/shell/has.c
+++ b/subsys/bluetooth/shell/has.c
@@ -90,6 +90,44 @@ static int cmd_preset_list(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_preset_avail(const struct shell *sh, size_t argc, char **argv)
+{
+	int err = 0;
+	const uint8_t index = shell_strtoul(argv[1], 16, &err);
+
+	if (err < 0) {
+		shell_print(sh, "Invalid command parameter (err %d)", err);
+		return err;
+	}
+
+	err = bt_has_preset_available(index);
+	if (err < 0) {
+		shell_print(sh, "Preset availability set failed (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
+static int cmd_preset_unavail(const struct shell *sh, size_t argc, char **argv)
+{
+	int err = 0;
+	const uint8_t index = shell_strtoul(argv[1], 16, &err);
+
+	if (err < 0) {
+		shell_print(sh, "Invalid command parameter (err %d)", err);
+		return err;
+	}
+
+	err = bt_has_preset_unavailable(index);
+	if (err < 0) {
+		shell_print(sh, "Preset availability set failed (err %d)", err);
+		return err;
+	}
+
+	return 0;
+}
+
 static int cmd_has(const struct shell *sh, size_t argc, char **argv)
 {
 	if (argc > 1) {
@@ -106,6 +144,10 @@ SHELL_STATIC_SUBCMD_SET_CREATE(has_cmds,
 		      cmd_preset_reg, 4, 0),
 	SHELL_CMD_ARG(preset-unreg, NULL, "Unregister preset <index>", cmd_preset_unreg, 2, 0),
 	SHELL_CMD_ARG(preset-list, NULL, "List all presets", cmd_preset_list, 1, 0),
+	SHELL_CMD_ARG(preset-set-avail, NULL, "Set preset as available <index>",
+		      cmd_preset_avail, 2, 0),
+	SHELL_CMD_ARG(preset-set-unavail, NULL, "Set preset as unavailable <index>",
+		      cmd_preset_unavail, 2, 0),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
This extends implementation with sending Preset Changed notification/indication when preset changes its availability or is added or deleted.