### PR TITLE
Bluetooth: gatt: Update bt_gatt_is_subscribed documentation

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1175,12 +1175,13 @@ int bt_gatt_indicate(struct bt_conn *conn,
  *
  *  @param conn Connection object.
  *  @param attr Attribute object.
- *  @param ccc_value The subscription type, either notifications or indications.
+ *  @param ccc_type The subscription type, @ref BT_GATT_CCC_NOTIFY and/or
+ *                  @ref BT_GATT_CCC_INDICATE.
  *
  *  @return true if the attribute object has been subscribed.
  */
 bool bt_gatt_is_subscribed(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr, uint16_t ccc_value);
+			   const struct bt_gatt_attr *attr, uint16_t ccc_type);
 
 /** @brief Get ATT MTU for a connection
  *

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2883,7 +2883,7 @@ static uint8_t disconnected_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 }
 
 bool bt_gatt_is_subscribed(struct bt_conn *conn,
-			   const struct bt_gatt_attr *attr, uint16_t ccc_value)
+			   const struct bt_gatt_attr *attr, uint16_t ccc_type)
 {
 	const struct _bt_gatt_ccc *ccc;
 
@@ -2924,7 +2924,7 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 		const struct bt_gatt_ccc_cfg *cfg = &ccc->cfg[i];
 
 		if (bt_conn_is_peer_addr_le(conn, cfg->id, &cfg->peer) &&
-		    (ccc_value & ccc->cfg[i].value)) {
+		    (ccc_type & ccc->cfg[i].value)) {
 			return true;
 		}
 	}


### PR DESCRIPTION
This updates the documentation of bt_gatt_is_subscribed function that
can take a bitfield of BT_GATT_CCC_NOTIFY and BT_GATT_CCC_INDICATE.
This might be useful if one wants to test if peer is subscribed, but
does not matter which method was used.

The gatt.c implementation handles API usage already, because it performs
bitwise AND:
if (bt_conn_is_peer_addr_le(conn, cfg->id, &cfg->peer) &&
    (ccc_value & ccc->cfg[i].value)) {
	return true;
}

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>