### PR TITLE
Fix version string formatting

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_util.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_util.c
@@ -16,8 +16,9 @@ img_mgmt_ver_str(const struct image_version *ver, char *dst)
 	int rc = 0;
 	int rc1 = 0;
 
-	rc = snprintf(dst, IMG_MGMT_VER_MAX_STR_LEN, "%hhu.%hhu.%hu",
-		ver->iv_major, ver->iv_minor, ver->iv_revision);
+	rc = snprintf(dst, IMG_MGMT_VER_MAX_STR_LEN, "%hu.%hu.%hu",
+		(uint16_t)ver->iv_major, (uint16_t)ver->iv_minor,
+		ver->iv_revision);
 
 	if (rc >= 0 && ver->iv_build_num != 0) {
 		rc1 = snprintf(&dst[rc], IMG_MGMT_VER_MAX_STR_LEN - rc, ".%u",

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_util.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_util.c
@@ -16,7 +16,7 @@ img_mgmt_ver_str(const struct image_version *ver, char *dst)
 	int rc = 0;
 	int rc1 = 0;
 
-	rc = snprintf(dst, IMG_MGMT_VER_MAX_STR_LEN, "%hhu.%hhu.%.hu",
+	rc = snprintf(dst, IMG_MGMT_VER_MAX_STR_LEN, "%hhu.%hhu.%hu",
 		ver->iv_major, ver->iv_minor, ver->iv_revision);
 
 	if (rc >= 0 && ver->iv_build_num != 0) {


### PR DESCRIPTION
Fixes astray dot (my bad) and a problem with newlib not recognizing %hhu formatting ~~(their bad)~~ when `CONFIG_NEWLIB_LIBC_NANO=y`

Fixes #45261