### PR TITLE
dts: add binding for intel ssp

### DIFF
--- a/dts/bindings/i2s/intel,ssp-sspbase.yaml
+++ b/dts/bindings/i2s/intel,ssp-sspbase.yaml
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel SSP SHIM controller
+
+compatible: "intel,ssp-sspbase"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true


### PR DESCRIPTION
Add ssp (sspbase) node for Intel ssp.

Signed-off-by: ArsenEloglian <ArsenX.Eloglian@intel.com>