### PR TITLE
tests: Bluetooth: df: Add integration_plaform to enable df test

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -44,6 +44,9 @@ jobs:
       TESTS_PER_BUILDER: 700
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
+      BSIM_OUT_PATH: /opt/bsim/
+      BSIM_COMPONENTS_PATH: /opt/bsim/components
+      EDTT_PATH: ../tools/edtt
     steps:
       - name: Apply container owner mismatch workaround
         run: |
@@ -137,6 +140,9 @@ jobs:
       PUSH_OPTIONS: ' --clobber-output -M --no-skipped-report'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
+      BSIM_OUT_PATH: /opt/bsim/
+      BSIM_COMPONENTS_PATH: /opt/bsim/components
+      EDTT_PATH: ../tools/edtt
     steps:
       - name: Apply container owner mismatch workaround
         run: |

--- a/tests/bluetooth/df/connection_cte_req/testcase.yaml
+++ b/tests/bluetooth/df/connection_cte_req/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.df.conection_cte_req:
     platform_allow: nrf52_bsim
+    integration_platforms:
+     - nrf52_bsim
     tags: bluetooth

--- a/tests/bluetooth/df/connection_cte_tx_params/testcase.yaml
+++ b/tests/bluetooth/df/connection_cte_tx_params/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.df.conection_cte_tx_params:
     platform_allow: nrf52_bsim
+    integration_platforms:
+     - nrf52_bsim
     tags: bluetooth

--- a/tests/bluetooth/df/connectionless_cte_rx/testcase.yaml
+++ b/tests/bluetooth/df/connectionless_cte_rx/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.df.conectionless_cte_rx:
     platform_allow: nrf52_bsim
+    integration_platforms:
+     - nrf52_bsim
     tags: bluetooth

--- a/tests/bluetooth/df/connectionless_cte_tx/testcase.yaml
+++ b/tests/bluetooth/df/connectionless_cte_tx/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.df.conectionless_cte_tx:
     platform_allow: nrf52_bsim
+    integration_platforms:
+     - nrf52_bsim
     tags: bluetooth

--- a/tests/bluetooth/df/testcase.yaml
+++ b/tests/bluetooth/df/testcase.yaml
@@ -1,4 +1,6 @@
 tests:
   bluetooth.df:
     platform_allow: nrf52_bsim
+    integration_platforms:
+     - nrf52_bsim
     tags: bluetooth


### PR DESCRIPTION
The direction finding tests were not executed for every PR that
changes Bluetooth source code. Due to that, it was not discovered
that UT were not building at all.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>