### PR TITLE
Bluetooth: Audio: Fix order of checks in bt_audio_stream_qos

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -520,6 +520,12 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 		struct bt_iso_chan_io_qos *io;
 		struct bt_iso_chan_qos *iso_qos;
 
+		if (stream->conn != conn) {
+			/* Channel not part of this ACL, skip */
+			continue;
+		}
+		conn_stream_found = true;
+
 		if (stream->ep == NULL) {
 			BT_DBG("stream->ep is NULL");
 			return -EINVAL;
@@ -537,12 +543,6 @@ int bt_audio_stream_qos(struct bt_conn *conn,
 			       bt_audio_ep_state_str(stream->ep->status.state));
 			return -EINVAL;
 		}
-
-		if (stream->conn != conn) {
-			/* Channel not part of this ACL, skip */
-			continue;
-		}
-		conn_stream_found = true;
 
 		if (!bt_audio_valid_stream_qos(stream, qos)) {
 			return -EINVAL;


### PR DESCRIPTION
The bt_audio_stream_qos function checked if stream->ep was
NULL before checking if the stream were even valid for this
QoS procedure.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>