### PR TITLE
Bluetooth: Audio: Add NULL check when creating the CIG

### DIFF
--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -411,7 +411,9 @@ static int bt_audio_cig_create(struct bt_audio_unicast_group *group,
 
 	cis_count = 0;
 	SYS_SLIST_FOR_EACH_CONTAINER(&group->streams, stream, node) {
-		group->cis[cis_count++] = stream->iso;
+		if (stream->iso != NULL) {
+			group->cis[cis_count++] = stream->iso;
+		}
 	}
 
 	param.num_cis = cis_count;


### PR DESCRIPTION
When create the CIG for a unicast group, we did not
verify whether stream->iso was NULL before attempting
to use that to create the CIG.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>