### PR TITLE
Bluetooth: Host: Various fixes for L2CAP collision mitigation

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -543,6 +543,9 @@ static int l2cap_ecred_conn_req(struct bt_l2cap_chan **chan, int channels)
 	for (i = 0; i < channels; i++) {
 		ch = BT_L2CAP_LE_CHAN(chan[i]);
 
+		__ASSERT(ch->psm == req->psm,
+			 "The PSM shall be the same for channels in the same request.");
+
 		ch->ident = ident;
 
 		net_buf_add_le16(buf, ch->rx.cid);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -372,9 +372,8 @@ void bt_l2cap_br_recv(struct bt_conn *conn, struct net_buf *buf);
 
 struct bt_l2cap_ecred_cb {
 	void (*ecred_conn_rsp)(struct bt_conn *conn, uint16_t result, uint8_t attempted,
-			       uint8_t succeeded);
-	void (*ecred_conn_req)(struct bt_conn *conn, uint16_t result, uint8_t attempted,
-			       uint8_t succeeded);
+			       uint8_t succeeded, uint16_t psm);
+	void (*ecred_conn_req)(struct bt_conn *conn, uint16_t result, uint16_t psm);
 };
 
 /* Register callbacks for Enhanced Credit based Flow Control */


### PR DESCRIPTION
This fixes various issues with the L2CAP collision mitigation as found by @alwa-nordic in https://github.com/zephyrproject-rtos/zephyr/pull/43037#discussion_r813707314.

- The number of channels requested in the retry was wrong in some cases, using the number of channels from the incoming request instead of outgoing request.
- If the peer disconnected between the time the retry was scheduled and when it was executed, a null pointer would be dereferenced.
- Collisions were detected for other PSMs than the EATT PSM.
- Two outgoing connection requests to the same peer being rejected with "No resources" would trigger the retry. The retry shall only be triggered if both an incoming and an outgoing request are rejected with "No resources".
