### PR TITLE
modules: cmsis_nn: Move Kconfig prompt out of CMSIS-DSP menu

### DIFF
--- a/modules/Kconfig.cmsis
+++ b/modules/Kconfig.cmsis
@@ -30,7 +30,8 @@ endif
 
 menuconfig CMSIS_NN
 	bool "CMSIS-NN Library Support"
-	depends on CPU_CORTEX_M && CMSIS_DSP
+	depends on CPU_CORTEX_M
+	select CMSIS_DSP
 
 if CMSIS_NN
 source "modules/Kconfig.cmsis_nn"


### PR DESCRIPTION
The `CMSIS_NN` Kconfig previously depended on the `CMSIS_DSP` Kconfig,
and this placed the "CMSIS-NN Library Support" prompt under the "CMSIS-
DSP Library Support" menu (note that CMSIS-DSP is a menuconfig).

Since the CMSIS-NN library, although it requires the CMSIS-DSP library,
is not a subordinate component of the CMSIS-DSP library, remove its
dependency on `CMSIS_DSP` and make it select the Kconfig symbol
instead.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

-----

**Before**
<img src="https://user-images.githubusercontent.com/11345418/166729192-2b535647-ca48-4455-8d35-0ab0ad0c8468.png" width="70%" height="70%">

**After**
<img src="https://user-images.githubusercontent.com/11345418/166728743-c9eae7c3-1098-4cd3-bd1f-f253bb8fb7ab.png" width="70%" height="70%">