### PR TITLE
ARC: boards: hsdk_2cores: allow mwdt toolchain usage

### DIFF
--- a/boards/arc/hsdk/hsdk_2cores.yaml
+++ b/boards/arc/hsdk/hsdk_2cores.yaml
@@ -5,6 +5,7 @@ arch: arc
 toolchain:
   - zephyr
   - xtools
+  - arcmwdt
 testing:
   ignore_tags:
     - net


### PR DESCRIPTION
Allow mwdt toolchain usage for 2 cores HSDK configuration as we have it for 4 cores configuration.