### PR TITLE
Enable USB DFU mode on RT10xx boards

### DIFF
--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -143,8 +143,11 @@ static int memc_flexspi_init(const struct device *dev)
 		return 0;
 	}
 
-	/* Apply pinctrl state */
-#ifdef CONFIG_PINCTRL
+	/*
+	 * SOCs such as the RT1064 and RT1024 have internal flash, and no pinmux
+	 * settings, so skip pin control state.
+	 */
+#if defined(CONFIG_PINCTRL) && !(defined(CONFIG_SOC_MIMXRT1064) || defined(CONFIG_SOC_MIMXRT1024))
 	int ret;
 
 	ret = pinctrl_apply_state(data->pincfg, PINCTRL_STATE_DEFAULT);

--- a/subsys/usb/device/class/dfu/Kconfig
+++ b/subsys/usb/device/class/dfu/Kconfig
@@ -6,7 +6,7 @@ menuconfig USB_DFU_CLASS
 	select MPU_ALLOW_FLASH_WRITE
 	select POLL
 	depends on IMG_MANAGER
-	select IMG_ERASE_PROGRESSIVELY if SOC_FLASH_NRF
+	select IMG_ERASE_PROGRESSIVELY if (SOC_FLASH_NRF || FLASH_MCUX_FLEXSPI_NOR)
 	help
 	  USB DFU class driver
 


### PR DESCRIPTION
Enable USB DFU mode on RT10xx boards using QSPI flash. This PR also fixes a minor issue with the FlexSPI driver: when executing from RAM, the FlexSPI driver will attempt to change pinmux settings for the FlexSPI peripheral. However, on parts like the RT1024 with internal flash, no pin mux settings will be required, so the `pinctrl_apply_state` call may return an error code.

Fixes #45359