### PR TITLE
drivers: pinctrl: xec: Prevent glitch for QMSPI CS on MAF

### DIFF
--- a/drivers/pinctrl/pinctrl_mchp_xec.c
+++ b/drivers/pinctrl/pinctrl_mchp_xec.c
@@ -74,7 +74,7 @@ static int xec_config_pin(uint32_t portpin, uint32_t conf, uint32_t altf)
 
 	/* default input pad enabled, buffer type push-pull, no internal pulls */
 	msk |= (BIT(MCHP_GPIO_CTRL_INPAD_DIS_POS) | MCHP_GPIO_CTRL_BUFT_MASK |
-			MCHP_GPIO_CTRL_PUD_MASK | MCHP_GPIO_CTRL_DIR_MASK |
+			MCHP_GPIO_CTRL_PUD_MASK |
 			MCHP_GPIO_CTRL_MUX_MASK);
 
 	if (conf & BIT(MCHP_XEC_PIN_LOW_POWER_POS)) {


### PR DESCRIPTION
Whenever EC bootloader already configured a pin as output and
high, any further reconfiguration via pinctrl driver causes a
glitch in said pin with current sequence.

Defer pin direction configuration to be last to avoid the glitch

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>