### PR TITLE
drivers: dai: add fifo depth parameter to dai properties

### DIFF
--- a/include/zephyr/drivers/dai.h
+++ b/include/zephyr/drivers/dai.h
@@ -169,11 +169,13 @@ enum dai_trigger_cmd {
  * for example to setup dma outside the driver code.
  *
  * @param fifo_address Fifo hw address for e.g. when connecting to dma.
+ * @param fifo_depth Fifo depth.
  * @param dma_hs_id Dma handshake id.
  * @param reg_init_delay Delay for initializing registers.
  */
 struct dai_properties {
 	uint32_t fifo_address; /* fifo address */
+	uint32_t fifo_depth; /* fifo depth */
 	uint32_t dma_hs_id; /* dma handshake id */
 	uint32_t reg_init_delay; /* delay for register init */
 };


### PR DESCRIPTION
The fifo depth parameter was missing as it was not visible in original
sof driver interface (which the dai interface is based on). So add it to
properties as it might be used by apps using future alh and dmic drivers.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>