### PR TITLE
drivers: pwm: stm32: fix PWM channel disabling

### DIFF
--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -245,21 +245,6 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 		return -EINVAL;
 	}
 
-	if (cfg->countermode == LL_TIM_COUNTERMODE_UP) {
-		/* remove 1 period cycle, accounts for 1 extra low cycle */
-		period_cycles -= 1U;
-	} else if (cfg->countermode == LL_TIM_COUNTERMODE_DOWN) {
-		/* remove 1 pulse cycle, accounts for 1 extra high cycle */
-		pulse_cycles -= 1U;
-		/* remove 1 period cycle, accounts for 1 extra low cycle */
-		period_cycles -= 1U;
-	} else if (is_center_aligned(cfg->countermode)) {
-		pulse_cycles /= 2U;
-		period_cycles /= 2U;
-	} else {
-		return -ENOTSUP;
-	}
-
 	/*
 	 * Non 32-bit timers count from 0 up to the value in the ARR register
 	 * (16-bit). Thus period_cycles cannot be greater than UINT16_MAX + 1.
@@ -298,6 +283,21 @@ static int pwm_stm32_set_cycles(const struct device *dev, uint32_t channel,
 	if (period_cycles == 0u) {
 		LL_TIM_CC_DisableChannel(cfg->timer, current_ll_channel);
 		return 0;
+	}
+
+	if (cfg->countermode == LL_TIM_COUNTERMODE_UP) {
+		/* remove 1 period cycle, accounts for 1 extra low cycle */
+		period_cycles -= 1U;
+	} else if (cfg->countermode == LL_TIM_COUNTERMODE_DOWN) {
+		/* remove 1 pulse cycle, accounts for 1 extra high cycle */
+		pulse_cycles -= 1U;
+		/* remove 1 period cycle, accounts for 1 extra low cycle */
+		period_cycles -= 1U;
+	} else if (is_center_aligned(cfg->countermode)) {
+		pulse_cycles /= 2U;
+		period_cycles /= 2U;
+	} else {
+		return -ENOTSUP;
 	}
 
 	if (!LL_TIM_CC_IsEnabledChannel(cfg->timer, current_ll_channel)) {


### PR DESCRIPTION
Move period and pulse computation to right before
the channel enable code.

That fixes the inability to disable the channel by
providing the period of 0.

Fixes #45372 