### PR TITLE
lib: os: cbprintf: Fix variable assignment

### DIFF
--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -721,7 +721,7 @@ int cbprintf_package_convert(void *in_packaged,
 	bool ro_cpy;
 	struct z_cbprintf_desc *in_desc = in_packaged;
 
-	in_len != 0 ? in_len : get_package_len(in_packaged);
+	in_len = in_len != 0 ? in_len : get_package_len(in_packaged);
 
 	/* Get number of RO string indexes in the package and check if copying
 	 * includes appending those strings.


### PR DESCRIPTION
When in_len is 0 then length is calculated from the package and
assignment was missing.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>