### PR TITLE
drivers: can: separate CAN classic and CAN-FD syscalls, allow enabling CAN-FD at run-time

### DIFF
--- a/doc/hardware/peripherals/canbus/controller.rst
+++ b/doc/hardware/peripherals/canbus/controller.rst
@@ -284,11 +284,7 @@ Setting the bitrate
 *******************
 
 The bitrate and sampling point is initially set at runtime. To change it from
-the application, one can use the :c:func:`can_set_timing` API. This function
-takes three arguments. The first timing parameter sets the timing for classic
-CAN and arbitration phase for CAN-FD. The second parameter sets the timing of
-the data phase for CAN-FD. For classic CAN, you can use only the first
-parameter and put NULL to the second one. The :c:func:`can_calc_timing`
+the application, one can use the :c:func:`can_set_timing` API. The :c:func:`can_calc_timing`
 function can calculate timing from a bitrate and sampling point in permille.
 The following example sets the bitrate to 250k baud with the sampling point at
 87.5%.
@@ -309,10 +305,13 @@ The following example sets the bitrate to 250k baud with the sampling point at
     return;
   }
 
-  ret = can_set_timing(can_dev, &timing, NULL);
+  ret = can_set_timing(can_dev, &timing);
   if (ret != 0) {
     LOG_ERR("Failed to set timing");
   }
+
+A similar API exists for calculating and setting the timing for the data phase for CAN-FD capable
+controllers. See :c:func:`can_set_timing_data` and :c:func:`can_calc_timing_data`.
 
 SocketCAN
 *********

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -207,12 +207,9 @@ uint16_t sample_point_for_bitrate(uint32_t bitrate)
 	return sample_pnt;
 }
 
-int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t bitrate_data)
+int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 {
 	struct can_timing timing;
-#ifdef CONFIG_CAN_FD_MODE
-	struct can_timing timing_data;
-#endif /* CONFIG_CAN_FD_MODE */
 	uint32_t max_bitrate;
 	uint16_t sample_pnt;
 	int ret;
@@ -241,7 +238,25 @@ int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t 
 
 	timing.sjw = CAN_SJW_NO_CHANGE;
 
+	return can_set_timing(dev, &timing);
+}
+
 #ifdef CONFIG_CAN_FD_MODE
+int z_impl_can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data)
+{
+	struct can_timing timing_data;
+	uint32_t max_bitrate;
+	uint16_t sample_pnt;
+	int ret;
+
+	ret = can_get_max_bitrate(dev, &max_bitrate);
+	if (ret == -ENOSYS) {
+		/* Maximum bitrate unknown */
+		max_bitrate = 0;
+	} else if (ret < 0) {
+		return ret;
+	}
+
 	if ((max_bitrate > 0) && (bitrate_data > max_bitrate)) {
 		return -ENOTSUP;
 	}
@@ -258,8 +273,6 @@ int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate, uint32_t 
 
 	timing_data.sjw = CAN_SJW_NO_CHANGE;
 
-	return can_set_timing(dev, &timing, &timing_data);
-#else /* CONFIG_CAN_FD_MODE */
-	return can_set_timing(dev, &timing, NULL);
-#endif /* !CONFIG_CAN_FD_MODE */
+	return can_set_timing_data(dev, &timing_data);
 }
+#endif /* CONFIG_CAN_FD_MODE */

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -151,8 +151,8 @@ int z_impl_can_calc_timing(const struct device *dev, struct can_timing *res,
 int z_impl_can_calc_timing_data(const struct device *dev, struct can_timing *res,
 				uint32_t bitrate, uint16_t sample_pnt)
 {
-	const struct can_timing *min = can_get_timing_min_data(dev);
-	const struct can_timing *max = can_get_timing_max_data(dev);
+	const struct can_timing *min = can_get_timing_data_min(dev);
+	const struct can_timing *max = can_get_timing_data_max(dev);
 	uint32_t core_clock;
 	int ret;
 

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -90,21 +90,21 @@ static int z_vrfy_can_calc_timing_data(const struct device *dev, struct can_timi
 }
 #include <syscalls/can_calc_timing_data_mrsh.c>
 
-static inline const struct can_timing *z_vrfy_can_get_timing_min_data(const struct device *dev)
+static inline const struct can_timing *z_vrfy_can_get_timing_data_min(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
-	return z_impl_can_get_timing_min_data(dev);
+	return z_impl_can_get_timing_data_min(dev);
 }
-#include <syscalls/can_get_timing_min_data_mrsh.c>
+#include <syscalls/can_get_timing_data_min_mrsh.c>
 
-static inline const struct can_timing *z_vrfy_can_get_timing_max_data(const struct device *dev)
+static inline const struct can_timing *z_vrfy_can_get_timing_data_max(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_CAN));
 
-	return z_impl_can_get_timing_max_data(dev);
+	return z_impl_can_get_timing_data_max(dev);
 }
-#include <syscalls/can_get_timing_max_data_mrsh.c>
+#include <syscalls/can_get_timing_data_max_mrsh.c>
 
 static inline int z_vrfy_can_set_timing_data(const struct device *dev,
 					     const struct can_timing *timing_data)

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -24,21 +24,14 @@ static int z_vrfy_can_calc_timing(const struct device *dev, struct can_timing *r
 #include <syscalls/can_calc_timing_mrsh.c>
 
 static inline int z_vrfy_can_set_timing(const struct device *dev,
-					const struct can_timing *timing,
-					const struct can_timing *timing_data)
+					const struct can_timing *timing)
 {
 	struct can_timing timing_copy;
-	struct can_timing timing_data_copy;
 
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_timing));
 	Z_OOPS(z_user_from_copy(&timing_copy, timing, sizeof(timing_copy)));
 
-	if (timing_data != NULL) {
-		Z_OOPS(z_user_from_copy(&timing_data_copy, timing_data, sizeof(timing_data_copy)));
-		return z_impl_can_set_timing(dev, &timing_copy, &timing_data_copy);
-	}
-
-	return z_impl_can_set_timing(dev, &timing_copy, NULL);
+	return z_impl_can_set_timing(dev, &timing_copy);
 }
 #include <syscalls/can_set_timing_mrsh.c>
 
@@ -113,6 +106,27 @@ static inline const struct can_timing *z_vrfy_can_get_timing_max_data(const stru
 }
 #include <syscalls/can_get_timing_max_data_mrsh.c>
 
+static inline int z_vrfy_can_set_timing_data(const struct device *dev,
+					     const struct can_timing *timing_data)
+{
+	struct can_timing timing_data_copy;
+
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_timing_data));
+	Z_OOPS(z_user_from_copy(&timing_data_copy, timing_data, sizeof(timing_data_copy)));
+
+	return z_impl_can_set_timing_data(dev, &timing_data_copy);
+}
+#include <syscalls/can_set_timing_data_mrsh.c>
+
+static inline int z_vrfy_can_set_bitrate_data(const struct device *dev,
+					      uint32_t bitrate_data)
+{
+	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_timing_data));
+
+	return z_impl_can_set_bitrate_data(dev, bitrate_data);
+}
+#include <syscalls/can_set_bitrate_data_mrsh.c>
+
 #endif /* CONFIG_CAN_FD_MODE */
 
 static inline int z_vrfy_can_get_max_filters(const struct device *dev, enum can_ide id_type)
@@ -132,12 +146,11 @@ static inline int z_vrfy_can_set_mode(const struct device *dev, enum can_mode mo
 }
 #include <syscalls/can_set_mode_mrsh.c>
 
-static inline int z_vrfy_can_set_bitrate(const struct device *dev, uint32_t bitrate,
-					 uint32_t bitrate_data)
+static inline int z_vrfy_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_timing));
 
-	return z_impl_can_set_bitrate(dev, bitrate, bitrate_data);
+	return z_impl_can_set_bitrate(dev, bitrate);
 }
 #include <syscalls/can_set_bitrate_mrsh.c>
 

--- a/drivers/can/can_handlers.c
+++ b/drivers/can/can_handlers.c
@@ -138,7 +138,7 @@ static inline int z_vrfy_can_get_max_filters(const struct device *dev, enum can_
 }
 #include <syscalls/can_get_max_filters_mrsh.c>
 
-static inline int z_vrfy_can_set_mode(const struct device *dev, enum can_mode mode)
+static inline int z_vrfy_can_set_mode(const struct device *dev, can_mode_t mode)
 {
 	Z_OOPS(Z_SYSCALL_DRIVER_CAN(dev, set_mode));
 

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -197,11 +197,11 @@ static void can_loopback_remove_rx_filter(const struct device *dev, int filter_i
 	k_mutex_unlock(&data->mtx);
 }
 
-static int can_loopback_set_mode(const struct device *dev, enum can_mode mode)
+static int can_loopback_set_mode(const struct device *dev, can_mode_t mode)
 {
 	struct can_loopback_data *data = dev->data;
 
-	data->loopback = mode == CAN_LOOPBACK_MODE ? 1 : 0;
+	data->loopback = (mode & CAN_MODE_LOOPBACK) != 0 ? 1 : 0;
 	return 0;
 }
 

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -206,12 +206,11 @@ static int can_loopback_set_mode(const struct device *dev, enum can_mode mode)
 }
 
 static int can_loopback_set_timing(const struct device *dev,
-				   const struct can_timing *timing,
-				   const struct can_timing *timing_data)
+				   const struct can_timing *timing)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(timing);
-	ARG_UNUSED(timing_data);
+
 	return 0;
 }
 

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -260,8 +260,10 @@ struct can_mcan_reg;
 int can_mcan_set_mode(const struct device *dev, enum can_mode mode);
 
 int can_mcan_set_timing(const struct device *dev,
-			const struct can_timing *timing,
-			const struct can_timing *timing_data);
+			const struct can_timing *timing);
+
+int can_mcan_set_timing_data(const struct device *dev,
+			     const struct can_timing *timing_data);
 
 int can_mcan_init(const struct device *dev);
 

--- a/drivers/can/can_mcan.h
+++ b/drivers/can/can_mcan.h
@@ -257,7 +257,7 @@ struct can_mcan_reg;
 		.custom = _custom_data,					\
 	}
 
-int can_mcan_set_mode(const struct device *dev, enum can_mode mode);
+int can_mcan_set_mode(const struct device *dev, can_mode_t mode);
 
 int can_mcan_set_timing(const struct device *dev,
 			const struct can_timing *timing);

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -330,10 +330,8 @@ static int mcp2515_get_max_bitrate(const struct device *dev, uint32_t *max_bitra
 }
 
 static int mcp2515_set_timing(const struct device *dev,
-			      const struct can_timing *timing,
-			      const struct can_timing *timing_data)
+			      const struct can_timing *timing)
 {
-	ARG_UNUSED(timing_data);
 	struct mcp2515_data *dev_data = dev->data;
 	int ret;
 
@@ -949,7 +947,7 @@ static int mcp2515_init(const struct device *dev)
 		}
 	}
 
-	ret = can_set_timing(dev, &timing, NULL);
+	ret = can_set_timing(dev, &timing);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -440,7 +440,7 @@ done:
 	return ret;
 }
 
-static int mcp2515_set_mode(const struct device *dev, enum can_mode mode)
+static int mcp2515_set_mode(const struct device *dev, can_mode_t mode)
 {
 	const struct mcp2515_config *dev_cfg = dev->config;
 	struct mcp2515_data *dev_data = dev->data;
@@ -448,13 +448,13 @@ static int mcp2515_set_mode(const struct device *dev, enum can_mode mode)
 	int ret;
 
 	switch (mode) {
-	case CAN_NORMAL_MODE:
+	case CAN_MODE_NORMAL:
 		mcp2515_mode = MCP2515_MODE_NORMAL;
 		break;
-	case CAN_SILENT_MODE:
+	case CAN_MODE_LISTENONLY:
 		mcp2515_mode = MCP2515_MODE_SILENT;
 		break;
-	case CAN_LOOPBACK_MODE:
+	case CAN_MODE_LOOPBACK:
 		mcp2515_mode = MCP2515_MODE_LOOPBACK;
 		break;
 	default:
@@ -952,7 +952,7 @@ static int mcp2515_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_set_mode(dev, CAN_NORMAL_MODE);
+	ret = can_set_mode(dev, CAN_MODE_NORMAL);
 
 	return ret;
 }

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -179,12 +179,17 @@ static int mcux_flexcan_set_timing(const struct device *dev,
 	return 0;
 }
 
-static int mcux_flexcan_set_mode(const struct device *dev, enum can_mode mode)
+static int mcux_flexcan_set_mode(const struct device *dev, can_mode_t mode)
 {
 	const struct mcux_flexcan_config *config = dev->config;
 	uint32_t ctrl1;
 	uint32_t mcr;
 	int err;
+
+	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) != 0) {
+		LOG_ERR("unsupported mode: 0x%08x", mode);
+		return -ENOTSUP;
+	}
 
 	if (config->phy != NULL) {
 		err = can_transceiver_enable(config->phy);
@@ -199,7 +204,7 @@ static int mcux_flexcan_set_mode(const struct device *dev, enum can_mode mode)
 	ctrl1 = config->base->CTRL1;
 	mcr = config->base->MCR;
 
-	if (mode == CAN_LOOPBACK_MODE || mode == CAN_SILENT_LOOPBACK_MODE) {
+	if ((mode & CAN_MODE_LOOPBACK) != 0) {
 		/* Enable loopback and self-reception */
 		ctrl1 |= CAN_CTRL1_LPB_MASK;
 		mcr &= ~(CAN_MCR_SRXDIS_MASK);
@@ -209,7 +214,7 @@ static int mcux_flexcan_set_mode(const struct device *dev, enum can_mode mode)
 		mcr |= CAN_MCR_SRXDIS_MASK;
 	}
 
-	if (mode == CAN_SILENT_MODE || mode == CAN_SILENT_LOOPBACK_MODE) {
+	if ((mode & CAN_MODE_LISTENONLY) != 0) {
 		/* Enable listen-only mode */
 		ctrl1 |= CAN_CTRL1_LOM_MASK;
 	} else {

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -152,10 +152,8 @@ static int mcux_flexcan_get_max_bitrate(const struct device *dev, uint32_t *max_
 }
 
 static int mcux_flexcan_set_timing(const struct device *dev,
-				   const struct can_timing *timing,
-				   const struct can_timing *timing_data)
+				   const struct can_timing *timing)
 {
-	ARG_UNUSED(timing_data);
 	struct mcux_flexcan_data *data = dev->data;
 	const struct mcux_flexcan_config *config = dev->config;
 	uint8_t sjw_backup = data->timing.sjw;

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -103,14 +103,14 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 	 * the register field limits are physical values minus 1 (which is
 	 * handled by the register assignments in the common MCAN driver code).
 	 */
-	.timing_min_data = {
+	.timing_data_min = {
 		.sjw = 1,
 		.prop_seg = 0,
 		.phase_seg1 = 1,
 		.phase_seg2 = 1,
 		.prescaler = 1,
 	},
-	.timing_max_data = {
+	.timing_data_max = {
 		.sjw = 16,
 		.prop_seg = 0,
 		.phase_seg1 = 16,

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -94,6 +94,7 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 		.prescaler = 512,
 	},
 #ifdef CONFIG_CAN_FD_MODE
+	.set_timing_data = can_mcan_set_timing_data,
 	/*
 	 * MCUX MCAN data timing limits are specified in the "Data bit timing
 	 * and prescaler register (DBTP)" table in the SoC reference manual.

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -648,14 +648,11 @@ static void can_rcar_set_bittiming(const struct can_rcar_cfg *config,
 }
 
 static int can_rcar_set_timing(const struct device *dev,
-			       const struct can_timing *timing,
-			       const struct can_timing *timing_data)
+			       const struct can_timing *timing)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
 	int ret = 0;
-
-	ARG_UNUSED(timing_data);
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 
@@ -955,7 +952,7 @@ static int can_rcar_init(const struct device *dev)
 		}
 	}
 
-	ret = can_rcar_set_timing(dev, &timing, NULL);
+	ret = can_rcar_set_timing(dev, &timing);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -566,30 +566,34 @@ static int can_rcar_enter_operation_mode(const struct can_rcar_cfg *config)
 	return 0;
 }
 
-static int can_rcar_set_mode(const struct device *dev, enum can_mode mode)
+static int can_rcar_set_mode(const struct device *dev, can_mode_t mode)
 {
 	const struct can_rcar_cfg *config = dev->config;
 	struct can_rcar_data *data = dev->data;
 	uint8_t tcr = 0;
 	int ret = 0;
 
+	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) != 0) {
+		LOG_ERR("Unsupported mode: 0x%08x", mode);
+		return -ENOTSUP;
+	}
+
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
-	switch (mode) {
-	case CAN_NORMAL_MODE:
-		tcr = 0;
-		break;
-	/*Controller is not allowed to send dominant bits*/
-	case CAN_SILENT_MODE:
-		tcr = RCAR_CAN_TCR_LISTEN_ONLY | RCAR_CAN_TCR_TSTE;
-		break;
-	/*Controller is in loopback mode (receive own messages)*/
-	case CAN_LOOPBACK_MODE:
-		tcr = RCAR_CAN_TCR_INT_LOOP | RCAR_CAN_TCR_TSTE;
-		break;
-	/*Combination of loopback and silent*/
-	case CAN_SILENT_LOOPBACK_MODE:
+
+	if ((mode & (CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) ==
+		(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) {
+		LOG_ERR("Combination of loopback and listenonly modes not supported");
 		ret = -ENOTSUP;
 		goto unlock;
+	} else if ((mode & CAN_MODE_LOOPBACK) != 0) {
+		/* Loopback mode */
+		tcr = RCAR_CAN_TCR_INT_LOOP | RCAR_CAN_TCR_TSTE;
+	} else if ((mode & CAN_MODE_LISTENONLY) != 0) {
+		/* Listen-only mode */
+		tcr = RCAR_CAN_TCR_LISTEN_ONLY | RCAR_CAN_TCR_TSTE;
+	} else {
+		/* Normal mode */
+		tcr = 0;
 	}
 
 	/* Enable CAN transceiver */
@@ -957,7 +961,7 @@ static int can_rcar_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_rcar_set_mode(dev, CAN_NORMAL_MODE);
+	ret = can_rcar_set_mode(dev, CAN_MODE_NORMAL);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -96,14 +96,14 @@ static const struct can_driver_api can_sam_driver_api = {
 		},
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = can_mcan_set_timing_data,
-	.timing_min_data = {
+	.timing_data_min = {
 		.sjw = 0x01,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x01,
 		.phase_seg2 = 0x01,
 		.prescaler = 0x01
 		},
-	.timing_max_data = {
+	.timing_data_max = {
 		.sjw = 0x10,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x20,

--- a/drivers/can/can_sam.c
+++ b/drivers/can/can_sam.c
@@ -95,6 +95,7 @@ static const struct can_driver_api can_sam_driver_api = {
 		.prescaler = 0x200
 		},
 #ifdef CONFIG_CAN_FD_MODE
+	.set_timing_data = can_mcan_set_timing_data,
 	.timing_min_data = {
 		.sjw = 0x01,
 		.prop_seg = 0x00,

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -272,7 +272,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	ret = can_set_bitrate(can_dev, bitrate, 0);
+	ret = can_set_bitrate(can_dev, bitrate);
 	if (ret) {
 		shell_error(sh, "Failed to set bitrate [%d]",
 			    ret);

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -20,7 +20,7 @@ static struct k_poll_event msgq_events[1] = {
 };
 
 static inline int read_config_options(const struct shell *sh, int pos,
-				      char **argv, bool *silent, bool *loopback)
+				      char **argv, bool *listenonly, bool *loopback)
 {
 	char *arg = argv[pos];
 
@@ -31,10 +31,10 @@ static inline int read_config_options(const struct shell *sh, int pos,
 	for (arg = &arg[1]; *arg; arg++) {
 		switch (*arg) {
 		case 's':
-			if (silent == NULL) {
+			if (listenonly == NULL) {
 				shell_error(sh, "Unknown option %c", *arg);
 			} else {
-				*silent = true;
+				*listenonly = true;
 			}
 			break;
 		case 'l':
@@ -231,8 +231,8 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *can_dev;
 	int pos = 1;
-	bool silent = false, loopback = false;
-	enum can_mode mode;
+	bool listenonly = false, loopback = false;
+	can_mode_t mode = CAN_MODE_NORMAL;
 	uint32_t bitrate;
 	int ret;
 
@@ -245,19 +245,17 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 
 	pos++;
 
-	pos = read_config_options(sh, pos, argv, &silent, &loopback);
+	pos = read_config_options(sh, pos, argv, &listenonly, &loopback);
 	if (pos < 0) {
 		return -EINVAL;
 	}
 
-	if (silent && loopback) {
-		mode = CAN_SILENT_LOOPBACK_MODE;
-	} else if (silent) {
-		mode = CAN_SILENT_MODE;
-	} else if (loopback) {
-		mode = CAN_LOOPBACK_MODE;
-	} else {
-		mode = CAN_NORMAL_MODE;
+	if (listenonly) {
+		mode |= CAN_MODE_LISTENONLY;
+	}
+
+	if (loopback) {
+		mode |= CAN_MODE_LOOPBACK;
 	}
 
 	ret = can_set_mode(can_dev, mode);
@@ -447,8 +445,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_can,
 	SHELL_CMD_ARG(config, NULL,
 		      "Configure CAN controller.\n"
 		      " Usage: config device_name [-sl] bitrate\n"
-		      " -s Silent mode\n"
-		      " -l Listen-only mode",
+		      " -s Listen-only mode\n"
+		      " -l Loopback mode",
 		      cmd_config, 3, 1),
 	SHELL_CMD_ARG(send, NULL,
 		      "Send a CAN frame.\n"

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -402,15 +402,12 @@ done:
 }
 
 static int can_stm32_set_timing(const struct device *dev,
-				const struct can_timing *timing,
-				const struct can_timing *timing_data)
+				const struct can_timing *timing)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
 	struct can_stm32_data *data = dev->data;
 	int ret = -EIO;
-
-	ARG_UNUSED(timing_data);
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 	ret = can_enter_init_mode(can);
@@ -566,7 +563,7 @@ static int can_stm32_init(const struct device *dev)
 		}
 	}
 
-	ret = can_stm32_set_timing(dev, &timing, NULL);
+	ret = can_stm32_set_timing(dev, &timing);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -341,7 +341,7 @@ static int can_leave_sleep_mode(CAN_TypeDef *can)
 	return 0;
 }
 
-static int can_stm32_set_mode(const struct device *dev, enum can_mode mode)
+static int can_stm32_set_mode(const struct device *dev, can_mode_t mode)
 {
 	const struct can_stm32_config *cfg = dev->config;
 	CAN_TypeDef *can = cfg->can;
@@ -349,6 +349,11 @@ static int can_stm32_set_mode(const struct device *dev, enum can_mode mode)
 	int ret;
 
 	LOG_DBG("Set mode %d", mode);
+
+	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) != 0) {
+		LOG_ERR("unsupported mode: 0x%08x", mode);
+		return -ENOTSUP;
+	}
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 
@@ -366,23 +371,18 @@ static int can_stm32_set_mode(const struct device *dev, enum can_mode mode)
 		goto done;
 	}
 
-	switch (mode) {
-	case CAN_NORMAL_MODE:
-		can->BTR &= ~(CAN_BTR_LBKM | CAN_BTR_SILM);
-		break;
-	case CAN_LOOPBACK_MODE:
-		can->BTR &= ~(CAN_BTR_SILM);
+	if ((mode & CAN_MODE_LOOPBACK) != 0) {
+		/* Loopback mode */
 		can->BTR |= CAN_BTR_LBKM;
-		break;
-	case CAN_SILENT_MODE:
-		can->BTR &= ~(CAN_BTR_LBKM);
+	} else {
+		can->BTR &= ~CAN_BTR_LBKM;
+	}
+
+	if ((mode & CAN_MODE_LISTENONLY) != 0) {
+		/* Silent mode */
 		can->BTR |= CAN_BTR_SILM;
-		break;
-	case CAN_SILENT_LOOPBACK_MODE:
-		can->BTR |= CAN_BTR_LBKM | CAN_BTR_SILM;
-		break;
-	default:
-		break;
+	} else {
+		can->BTR &= ~CAN_BTR_SILM;
 	}
 
 done:
@@ -568,7 +568,7 @@ static int can_stm32_init(const struct device *dev)
 		return ret;
 	}
 
-	ret = can_stm32_set_mode(dev, CAN_NORMAL_MODE);
+	ret = can_stm32_set_mode(dev, CAN_MODE_NORMAL);
 	if (ret) {
 		return ret;
 	}

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -137,6 +137,7 @@ static const struct can_driver_api can_stm32fd_driver_api = {
 		.prescaler = 0x200
 	},
 #ifdef CONFIG_CAN_FD_MODE
+	.set_timing_data = can_mcan_set_timing_data,
 	.timing_min_data = {
 		.sjw = 0x01,
 		.prop_seg = 0x00,

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -138,14 +138,14 @@ static const struct can_driver_api can_stm32fd_driver_api = {
 	},
 #ifdef CONFIG_CAN_FD_MODE
 	.set_timing_data = can_mcan_set_timing_data,
-	.timing_min_data = {
+	.timing_data_min = {
 		.sjw = 0x01,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x01,
 		.phase_seg2 = 0x01,
 		.prescaler = 0x01
 	},
-	.timing_max_data = {
+	.timing_data_max = {
 		.sjw = 0x10,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x20,

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -132,14 +132,14 @@ static const struct can_driver_api can_stm32h7_driver_api = {
 	 * (RM0433 Rev 7), section 56.5.3, FDCAN data bit timing and prescaler
 	 * register (FDCAN_DBTP).
 	 */
-	.timing_min_data = {
+	.timing_data_min = {
 		.sjw = 0x00,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x00,
 		.phase_seg2 = 0x00,
 		.prescaler = 0x00
 	},
-	.timing_max_data = {
+	.timing_data_max = {
 		.sjw = 0x10,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x20,

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -127,6 +127,7 @@ static const struct can_driver_api can_stm32h7_driver_api = {
 		.prescaler = 0x200
 	},
 #ifdef CONFIG_CAN_FD_MODE
+	.set_timing_data = can_mcan_set_timing_data,
 	/* Data timing limits are per the STM32H7 Reference Manual
 	 * (RM0433 Rev 7), section 56.5.3, FDCAN data bit timing and prescaler
 	 * register (FDCAN_DBTP).

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -79,18 +79,32 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Defines the mode of the CAN controller
+ * @name CAN controller mode flags
+ * @anchor CAN_MODE_FLAGS
+ *
+ * @{
  */
-enum can_mode {
-	/** Normal mode. */
-	CAN_NORMAL_MODE,
-	/** Controller is not allowed to send dominant bits. */
-	CAN_SILENT_MODE,
-	/** Controller is in loopback mode (receives own frames). */
-	CAN_LOOPBACK_MODE,
-	/** Combination of loopback and silent modes. */
-	CAN_SILENT_LOOPBACK_MODE
-};
+
+/** Normal mode. */
+#define CAN_MODE_NORMAL     0
+
+/** Controller is in loopback mode (receives own frames). */
+#define CAN_MODE_LOOPBACK   BIT(0)
+
+/** Controller is not allowed to send dominant bits. */
+#define CAN_MODE_LISTENONLY BIT(1)
+
+/** @} */
+
+/**
+ * @brief Provides a type to hold CAN controller configuration flags.
+ *
+ * The lower 24 bits are reserved for common CAN controller mode flags. The upper 8 bits are
+ * reserved for CAN controller/driver specific flags.
+ *
+ * @see @ref CAN_MODE_FLAGS.
+ */
+typedef uint32_t can_mode_t;
 
 /**
  * @brief Defines the state of the CAN bus
@@ -310,7 +324,7 @@ typedef int (*can_set_timing_data_t)(const struct device *dev,
  * @brief Callback API upon setting CAN controller mode
  * See @a can_set_mode() for argument description
  */
-typedef int (*can_set_mode_t)(const struct device *dev, enum can_mode mode);
+typedef int (*can_set_mode_t)(const struct device *dev, can_mode_t mode);
 
 /**
  * @brief Callback API upon sending a CAN frame
@@ -891,9 +905,9 @@ static inline int z_impl_can_set_timing(const struct device *dev,
  * @retval 0 If successful.
  * @retval -EIO General input/output error, failed to configure device.
  */
-__syscall int can_set_mode(const struct device *dev, enum can_mode mode);
+__syscall int can_set_mode(const struct device *dev, can_mode_t mode);
 
-static inline int z_impl_can_set_mode(const struct device *dev, enum can_mode mode)
+static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -396,9 +396,9 @@ __subsystem struct can_driver_api {
 #if defined(CONFIG_CAN_FD_MODE) || defined(__DOXYGEN__)
 	can_set_timing_data_t set_timing_data;
 	/* Min values for the timing registers during the data phase */
-	struct can_timing timing_min_data;
+	struct can_timing timing_data_min;
 	/* Max values for the timing registers during the data phase */
-	struct can_timing timing_max_data;
+	struct can_timing timing_data_max;
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
@@ -724,13 +724,13 @@ __syscall int can_calc_timing(const struct device *dev, struct can_timing *res,
  * @return Pointer to the minimum supported timing parameter values, or NULL if
  *         CAN-FD is not supported.
  */
-__syscall const struct can_timing *can_get_timing_min_data(const struct device *dev);
+__syscall const struct can_timing *can_get_timing_data_min(const struct device *dev);
 
-static inline const struct can_timing *z_impl_can_get_timing_min_data(const struct device *dev)
+static inline const struct can_timing *z_impl_can_get_timing_data_min(const struct device *dev)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
-	return &api->timing_min_data;
+	return &api->timing_data_min;
 }
 
 /**
@@ -746,13 +746,13 @@ static inline const struct can_timing *z_impl_can_get_timing_min_data(const stru
  * @return Pointer to the maximum supported timing parameter values, or NULL if
  *         CAN-FD is not supported.
  */
-__syscall const struct can_timing *can_get_timing_max_data(const struct device *dev);
+__syscall const struct can_timing *can_get_timing_data_max(const struct device *dev);
 
-static inline const struct can_timing *z_impl_can_get_timing_max_data(const struct device *dev)
+static inline const struct can_timing *z_impl_can_get_timing_data_max(const struct device *dev)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
-	return &api->timing_max_data;
+	return &api->timing_data_max;
 }
 
 /**

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -709,8 +709,6 @@ static inline const struct can_timing *z_impl_can_get_timing_max(const struct de
 __syscall int can_calc_timing(const struct device *dev, struct can_timing *res,
 			      uint32_t bitrate, uint16_t sample_pnt);
 
-#if defined(CONFIG_CAN_FD_MODE) || defined(__DOXYGEN__)
-
 /**
  * @brief Get the minimum supported timing parameter values for the data phase.
  *
@@ -726,12 +724,14 @@ __syscall int can_calc_timing(const struct device *dev, struct can_timing *res,
  */
 __syscall const struct can_timing *can_get_timing_data_min(const struct device *dev);
 
+#ifdef CONFIG_CAN_FD_MODE
 static inline const struct can_timing *z_impl_can_get_timing_data_min(const struct device *dev)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
 	return &api->timing_data_min;
 }
+#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Get the maximum supported timing parameter values for the data phase.
@@ -748,12 +748,14 @@ static inline const struct can_timing *z_impl_can_get_timing_data_min(const stru
  */
 __syscall const struct can_timing *can_get_timing_data_max(const struct device *dev);
 
+#ifdef CONFIG_CAN_FD_MODE
 static inline const struct can_timing *z_impl_can_get_timing_data_max(const struct device *dev)
 {
 	const struct can_driver_api *api = (const struct can_driver_api *)dev->api;
 
 	return &api->timing_data_max;
 }
+#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Calculate timing parameters for the data phase
@@ -795,6 +797,7 @@ __syscall int can_calc_timing_data(const struct device *dev, struct can_timing *
 __syscall int can_set_timing_data(const struct device *dev,
 				  const struct can_timing *timing_data);
 
+#ifdef CONFIG_CAN_FD_MODE
 static inline int z_impl_can_set_timing_data(const struct device *dev,
 					     const struct can_timing *timing_data)
 {
@@ -802,6 +805,7 @@ static inline int z_impl_can_set_timing_data(const struct device *dev,
 
 	return api->set_timing_data(dev, timing_data);
 }
+#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Set the bitrate for the data phase of the CAN-FD controller
@@ -829,8 +833,6 @@ static inline int z_impl_can_set_timing_data(const struct device *dev,
  * @retval -EIO General input/output error, failed to set bitrate.
  */
 __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data);
-
-#endif /* CONFIG_CAN_FD_MODE */
 
 /**
  * @brief Fill in the prescaler value for a given bitrate and timing

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -94,6 +94,9 @@ extern "C" {
 /** Controller is not allowed to send dominant bits. */
 #define CAN_MODE_LISTENONLY BIT(1)
 
+/** Controller allows transmitting/receiving CAN-FD frames. */
+#define CAN_MODE_FD         BIT(2)
+
 /** @} */
 
 /**

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -229,7 +229,7 @@ CO_ReturnError_t CO_CANmodule_init(CO_CANmodule_t *CANmodule,
 		return CO_ERROR_ILLEGAL_ARGUMENT;
 	}
 
-	err = can_set_mode(CANmodule->dev, CAN_NORMAL_MODE);
+	err = can_set_mode(CANmodule->dev, CAN_MODE_NORMAL);
 	if (err) {
 		LOG_ERR("failed to configure CAN interface (err %d)", err);
 		return CO_ERROR_ILLEGAL_ARGUMENT;
@@ -250,7 +250,7 @@ void CO_CANmodule_disable(CO_CANmodule_t *CANmodule)
 
 	canopen_detach_all_rx_filters(CANmodule);
 
-	err = can_set_mode(CANmodule->dev, CAN_SILENT_MODE);
+	err = can_set_mode(CANmodule->dev, CAN_MODE_LISTENONLY);
 	if (err) {
 		LOG_ERR("failed to disable CAN interface (err %d)", err);
 	}

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -223,7 +223,7 @@ CO_ReturnError_t CO_CANmodule_init(CO_CANmodule_t *CANmodule,
 		txArray[i].bufferFull = false;
 	}
 
-	err = can_set_bitrate(CANmodule->dev, KHZ(CANbitRate), 0);
+	err = can_set_bitrate(CANmodule->dev, KHZ(CANbitRate));
 	if (err) {
 		LOG_ERR("failed to configure CAN bitrate (err %d)", err);
 		return CO_ERROR_ILLEGAL_ARGUMENT;

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -220,7 +220,11 @@ void main(void)
 	}
 
 #ifdef CONFIG_LOOPBACK_MODE
-	can_set_mode(can_dev, CAN_LOOPBACK_MODE);
+	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
+	if (ret != 0) {
+		printk("Error setting CAN mode [%d]", ret);
+		return;
+	}
 #endif
 
 	if (led.port != NULL) {

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -181,7 +181,7 @@ static int setup_socket(void)
 	}
 
 #ifdef CONFIG_SAMPLE_SOCKETCAN_LOOPBACK_MODE
-	can_set_mode(DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus)), CAN_LOOPBACK_MODE);
+	can_set_mode(DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus)), CAN_MODE_LOOPBACK);
 #endif
 
 	fd = socket(AF_CAN, SOCK_RAW, CAN_RAW);

--- a/soc/arm/st_stm32/stm32f0/soc.h
+++ b/soc/arm/st_stm32/stm32f0/soc.h
@@ -22,6 +22,10 @@
 
 #include <stm32f0xx.h>
 
+/* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+#undef CAN_MODE_LOOPBACK
+
 /* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 

--- a/soc/arm/st_stm32/stm32f1/soc.h
+++ b/soc/arm/st_stm32/stm32f1/soc.h
@@ -22,6 +22,10 @@
 
 #include <stm32f1xx.h>
 
+/* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+#undef CAN_MODE_LOOPBACK
+
 /* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 

--- a/soc/arm/st_stm32/stm32f2/soc.h
+++ b/soc/arm/st_stm32/stm32f2/soc.h
@@ -21,6 +21,10 @@
 
 #include <stm32f2xx.h>
 
+/* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+#undef CAN_MODE_LOOPBACK
+
 /* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 

--- a/soc/arm/st_stm32/stm32f3/soc.h
+++ b/soc/arm/st_stm32/stm32f3/soc.h
@@ -23,6 +23,10 @@
 
 #include <stm32f3xx.h>
 
+/* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+#undef CAN_MODE_LOOPBACK
+
 /* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 

--- a/soc/arm/st_stm32/stm32f4/soc.h
+++ b/soc/arm/st_stm32/stm32f4/soc.h
@@ -22,6 +22,10 @@
 
 #include <stm32f4xx.h>
 
+/* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+#undef CAN_MODE_LOOPBACK
+
 /* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 

--- a/soc/arm/st_stm32/stm32f7/soc.h
+++ b/soc/arm/st_stm32/stm32f7/soc.h
@@ -21,6 +21,10 @@
 
 #include <stm32f7xx.h>
 
+/* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+#undef CAN_MODE_LOOPBACK
+
 /* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 

--- a/soc/arm/st_stm32/stm32l4/soc.h
+++ b/soc/arm/st_stm32/stm32l4/soc.h
@@ -23,6 +23,10 @@
 
 #include <stm32l4xx.h>
 
+/* The STM32 HAL headers define these, but they conflict with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+#undef CAN_MODE_LOOPBACK
+
 /* Add generated devicetree information and STM32 helper macros */
 #include <st_stm32_dt.h>
 

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -661,7 +661,7 @@ static void test_set_loopback(void)
 {
 	int err;
 
-	err = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
+	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
 }
 
@@ -953,10 +953,10 @@ static void test_filters_preserved_through_mode_change(void)
 	zassert_equal(err, 0, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
-	err = can_set_mode(can_dev, CAN_NORMAL_MODE);
+	err = can_set_mode(can_dev, CAN_MODE_NORMAL);
 	zassert_equal(err, 0, "failed to set normal mode (err %d)", err);
 
-	err = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
+	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
 
 	send_test_frame(can_dev, &test_std_frame_1);

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -636,7 +636,7 @@ static void test_set_bitrate_too_high(void)
 	zassert_equal(err, 0, "failed to get max bitrate (err %d)", err);
 	zassert_not_equal(max, 0, "max bitrate is 0");
 
-	err = can_set_bitrate(can_dev, max + 1, max + 1);
+	err = can_set_bitrate(can_dev, max + 1);
 	zassert_equal(err, -ENOTSUP, "too high bitrate accepted");
 }
 
@@ -647,7 +647,7 @@ static void test_set_bitrate(void)
 {
 	int err;
 
-	err = can_set_bitrate(can_dev, TEST_BITRATE_1, 0);
+	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
 	zassert_equal(err, 0, "failed to set bitrate");
 }
 
@@ -981,10 +981,10 @@ static void test_filters_preserved_through_bitrate_change(void)
 	zassert_equal(err, 0, "receive timeout");
 	assert_frame_equal(&frame, &test_std_frame_1, 0);
 
-	err = can_set_bitrate(can_dev, TEST_BITRATE_2, 0);
+	err = can_set_bitrate(can_dev, TEST_BITRATE_2);
 	zassert_equal(err, 0, "failed to set bitrate");
 
-	err = can_set_bitrate(can_dev, TEST_BITRATE_1, 0);
+	err = can_set_bitrate(can_dev, TEST_BITRATE_1);
 	zassert_equal(err, 0, "failed to set bitrate");
 
 	send_test_frame(can_dev, &test_std_frame_1);

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -349,7 +349,7 @@ static void test_set_loopback(void)
 {
 	int err;
 
-	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
+	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK | CAN_MODE_FD);
 	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
 }
 

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -348,7 +348,7 @@ static void test_set_loopback(void)
 {
 	int err;
 
-	err = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
+	err = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback-mode (err %d)", err);
 }
 

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -125,6 +125,7 @@ static inline void assert_frame_equal(const struct zcan_frame *frame1,
 				      const struct zcan_frame *frame2)
 {
 	zassert_equal(frame1->id_type, frame2->id_type, "ID type does not match");
+	zassert_equal(frame1->fd, frame2->fd, "FD bit does not match");
 	zassert_equal(frame1->rtr, frame2->rtr, "RTR bit does not match");
 	zassert_equal(frame1->id, frame2->id, "ID does not match");
 	zassert_equal(frame1->dlc, frame2->dlc, "DLC does not match");

--- a/tests/drivers/can/stm32/src/main.c
+++ b/tests/drivers/can/stm32/src/main.c
@@ -146,7 +146,7 @@ static void test_filter_handling(void)
 	zassert_true(device_is_ready(dev), "CAN device not ready");
 
 	/* Set driver to loopback mode */
-	err = can_set_mode(dev, CAN_LOOPBACK_MODE);
+	err = can_set_mode(dev, CAN_MODE_LOOPBACK);
 	zassert_equal(err, 0, "failed to set loopback mode");
 
 	/* Add a extended and masked filter (1 bank/filter) */

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -202,14 +202,10 @@ static void test_timing_values(const struct device *dev, const struct can_timing
 		assert_timing_within_bounds(&timing, min, max);
 		assert_sp_within_margin(&timing, test->sp, SAMPLE_POINT_MARGIN);
 
-		if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
-			if (data_phase) {
-				err = can_set_timing(dev, can_get_timing_min(dev), &timing);
-			} else {
-				err = can_set_timing(dev, &timing, can_get_timing_min_data(dev));
-			}
+		if (IS_ENABLED(CONFIG_CAN_FD_MODE) && data_phase) {
+			err = can_set_timing_data(dev, &timing);
 		} else {
-			err = can_set_timing(dev, &timing, NULL);
+			err = can_set_timing(dev, &timing);
 		}
 		zassert_equal(err, 0, "failed to set timing (err %d)", err);
 
@@ -258,12 +254,13 @@ void test_set_timing_min(void)
 	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	int err;
 
-	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
-		err = can_set_timing(dev, can_get_timing_min(dev), can_get_timing_min_data(dev));
-	} else {
-		err = can_set_timing(dev, can_get_timing_min(dev), NULL);
-	}
+	err = can_set_timing(dev, can_get_timing_min(dev));
 	zassert_equal(err, 0, "failed to set minimum timing parameters (err %d)", err);
+
+	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
+		err = can_set_timing_data(dev, can_get_timing_min_data(dev));
+		zassert_equal(err, 0, "failed to set minimum timing data parameters (err %d)", err);
+	}
 }
 
 /**
@@ -274,12 +271,13 @@ void test_set_timing_max(void)
 	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	int err;
 
-	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
-		err = can_set_timing(dev, can_get_timing_max(dev), can_get_timing_max_data(dev));
-	} else {
-		err = can_set_timing(dev, can_get_timing_max(dev), NULL);
-	}
+	err = can_set_timing(dev, can_get_timing_max(dev));
 	zassert_equal(err, 0, "failed to set maximum timing parameters (err %d)", err);
+
+	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
+		err = can_set_timing_data(dev, can_get_timing_max_data(dev));
+		zassert_equal(err, 0, "failed to set maximum timing data parameters (err %d)", err);
+	}
 }
 
 void test_main(void)

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -175,8 +175,8 @@ static void test_timing_values(const struct device *dev, const struct can_timing
 
 	if (data_phase) {
 		if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
-			min = can_get_timing_min_data(dev);
-			max = can_get_timing_max_data(dev);
+			min = can_get_timing_data_min(dev);
+			max = can_get_timing_data_max(dev);
 			sp_err = can_calc_timing_data(dev, &timing, test->bitrate, test->sp);
 		} else {
 			zassert_unreachable("data phase timing test without CAN-FD support");
@@ -258,7 +258,7 @@ void test_set_timing_min(void)
 	zassert_equal(err, 0, "failed to set minimum timing parameters (err %d)", err);
 
 	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
-		err = can_set_timing_data(dev, can_get_timing_min_data(dev));
+		err = can_set_timing_data(dev, can_get_timing_data_min(dev));
 		zassert_equal(err, 0, "failed to set minimum timing data parameters (err %d)", err);
 	}
 }
@@ -275,7 +275,7 @@ void test_set_timing_max(void)
 	zassert_equal(err, 0, "failed to set maximum timing parameters (err %d)", err);
 
 	if (IS_ENABLED(CONFIG_CAN_FD_MODE)) {
-		err = can_set_timing_data(dev, can_get_timing_max_data(dev));
+		err = can_set_timing_data(dev, can_get_timing_data_max(dev));
 		zassert_equal(err, 0, "failed to set maximum timing data parameters (err %d)", err);
 	}
 }

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -969,7 +969,7 @@ void test_main(void)
 
 	zassert_true(device_is_ready(can_dev), "CAN device not ready");
 
-	ret = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
+	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(ret, 0, "Failed to set loopback mode [%d]", ret);
 
 	k_sem_init(&send_compl_sem, 0, 1);

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -417,7 +417,7 @@ void test_main(void)
 
 	zassert_true(device_is_ready(can_dev), "CAN device not ready");
 
-	ret = can_set_mode(can_dev, CAN_LOOPBACK_MODE);
+	ret = can_set_mode(can_dev, CAN_MODE_LOOPBACK);
 	zassert_equal(ret, 0, "Configuring loopback mode failed (%d)", ret);
 
 	ztest_test_suite(isotp,


### PR DESCRIPTION
Split CAN classic and CAN-FD syscalls into two:
- `can_set_timing()` -> `can_set_timing()` + `can_set_timing_data()`
- `can_set_bitrate()` -> `can_set_bitrate()` + `can_set_bitrate_data()`

Rename the CAN data phase API functions to `timing_data_*` for consistency:
- `can_get_timing_min_data()` -> `can_get_timing_data_min()`
- `can_get_timing_max_data()` -> `can_get_timing_data_max()`
- `.timing_min_data` -> `.timing_data_min`
- `.timing_max_data` -> `timing_data_max`

Convert the can_mode enum to a bit field to prepare for future extensions (CAN-FD mode, transmitter delay compensation, one-shot mode, 3-samples mode, ...). Rename the existing modes:
- `CAN_NORMAL_MODE` -> `CAN_MODE_NORMAL`
- `CAN_SILENT_MODE` -> `CAN_MODE_LISTENONLY`
- `CAN_LOOPBACK_MODE` -> `CAN_MODE_LOOPBACK`
    
These mode names align with the Linux naming for CAN control modes. The old `CAN_SILENT_LOOPBACK_MODE` can be set with the bitmask `(CAN_MODE_LISTENONLY | CAN_MODE_LOOPBACK)`.

Finally, add support for enabling/disabling CAN-FD frame transmission/reception at run-time.

Fixes: #45303