### PR TITLE
boards: Refactor comment on default and identation on help text

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -36,8 +36,7 @@ endif # DAC
 endif # BOARD_BL5340_DVK_CPUAPP
 
 # By default, if we build for a Non-Secure version of the board,
-# force building with TF-M as the Secure Execution Environment.
-
+# enable building with TF-M as the Secure Execution Environment.
 config BUILD_WITH_TFM
 	default y if BOARD_BL5340_DVK_CPUAPP_NS
 

--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -13,8 +13,7 @@ config ENTROPY_BT_HCI
 	depends on ENTROPY_GENERATOR
 
 # By default, if we build for a Non-Secure version of the board,
-# force building with TF-M as the Secure Execution Environment.
-
+# enable building with TF-M as the Secure Execution Environment.
 config BUILD_WITH_TFM
 	default y if BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -9,8 +9,7 @@ config BOARD
 	default "nrf9160dk_nrf9160"
 
 # By default, if we build for a Non-Secure version of the board,
-# force building with TF-M as the Secure Execution Environment.
-
+# enable building with TF-M as the Secure Execution Environment.
 config BUILD_WITH_TFM
 	default y if BOARD_NRF9160DK_NRF9160_NS
 

--- a/modules/trusted-firmware-m/Kconfig.tfm
+++ b/modules/trusted-firmware-m/Kconfig.tfm
@@ -317,11 +317,10 @@ endif # !TFM_BL2
 config TFM_FLASH_MERGED_BINARY
 	bool
 	help
-		This option instructs west flash to program the
-		combined (merged) binary consisting of the TF-M
-		Secure firmware image, optionally, the BL2 image
-		(if building with TFM_BL2 is enabled), and the
-		Non-Secure application firmware.
+	  This option instructs west flash to program the combined (merged)
+	  binary consisting of the TF-M Secure firmware image, optionally, the
+	  BL2 image (if building with TFM_BL2 is enabled), and the Non-Secure
+	  application firmware.
 
 config TFM_LOG_LEVEL_SILENCE
 	bool "TF-M Disable secure logging"


### PR DESCRIPTION
~Enable TF-M by default for nordic nRF5340 and nrf9160 SoC boards.~

Refactor help text for TFM_FLASH_MERGED_BINARY to use the standard
indentation of tab plus 2 spaces.
Reword BUILD_WITH_TFM default comment, TF-M is enabled by default, not
forced enabled.
