### PR TITLE
samples: migrate includes to contain <zephyr/...> prefix

### DIFF
--- a/samples/application_development/code_relocation/src/main.c
+++ b/samples/application_development/code_relocation/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 
 
 /* This function will allow execute from sram region.
@@ -17,7 +17,7 @@
  */
 
 #ifdef CONFIG_ARM_MPU
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 void disable_mpu_rasr_xn(void)
 {
 	uint32_t index;

--- a/samples/application_development/code_relocation/src/test_file1.c
+++ b/samples/application_development/code_relocation/src/test_file1.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 uint32_t var_sram2_data = 10U;
 uint32_t var_sram2_bss;

--- a/samples/application_development/code_relocation/src/test_file2.c
+++ b/samples/application_development/code_relocation/src/test_file2.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 void function_in_sram(int32_t value)
 {

--- a/samples/application_development/code_relocation/src/test_file3.c
+++ b/samples/application_development/code_relocation/src/test_file3.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 uint32_t var_file3_sram_data = 10U;
 uint32_t var_file3_sram2_bss;

--- a/samples/application_development/code_relocation_nocopy/boards/nrf5340dk_nrf5340_cpuapp/ext_mem_init.c
+++ b/samples/application_development/code_relocation_nocopy/boards/nrf5340dk_nrf5340_cpuapp/ext_mem_init.c
@@ -5,12 +5,12 @@
  */
 
 #include <errno.h>
-#include <init.h>
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/init.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #include <nrfx_qspi.h>
 #include <hal/nrf_clock.h>
-#include <drivers/pinctrl.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #define QSPI_STD_CMD_WRSR  0x01
 #define QSPI_STD_CMD_WRDI  0x04

--- a/samples/application_development/code_relocation_nocopy/src/ext_code.c
+++ b/samples/application_development/code_relocation_nocopy/src/ext_code.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 uint32_t var_ext_sram_data = 10U;
 

--- a/samples/application_development/code_relocation_nocopy/src/main.c
+++ b/samples/application_development/code_relocation_nocopy/src/main.c
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 
 /*
  * This function will allow execute from sram region.  This is needed only for
@@ -16,7 +16,7 @@
  * to configure the region appropriately in arm_mpu_regions.c.
  */
 #ifdef CONFIG_ARM_MPU
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 void disable_mpu_rasr_xn(void)
 {
 	uint32_t index;

--- a/samples/application_development/code_relocation_nocopy/src/sram_code.c
+++ b/samples/application_development/code_relocation_nocopy/src/sram_code.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 uint32_t var_sram_data = 10U;
 

--- a/samples/application_development/external_lib/src/main.c
+++ b/samples/application_development/external_lib/src/main.c
@@ -7,7 +7,7 @@
 /* hello world example: calling functions from a static library */
 
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
 
 #include <mylib.h>

--- a/samples/application_development/out_of_tree_board/src/main.c
+++ b/samples/application_development/out_of_tree_board/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 void main(void)
 {

--- a/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
+++ b/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.c
@@ -6,7 +6,7 @@
 
 #include "hello_world_driver.h"
 #include <zephyr/types.h>
-#include <syscall_handler.h>
+#include <zephyr/syscall_handler.h>
 
 /**
  * This is a minimal example of an out-of-tree driver

--- a/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.h
+++ b/samples/application_development/out_of_tree_driver/hello_world_module/zephyr/hello_world_driver.h
@@ -10,7 +10,7 @@
 extern "C" {
 #endif
 
-#include <device.h>
+#include <zephyr/device.h>
 
 /*
  * This 'Hello World' driver has a 'print' syscall that prints the

--- a/samples/application_development/out_of_tree_driver/src/main.c
+++ b/samples/application_development/out_of_tree_driver/src/main.c
@@ -6,7 +6,7 @@
 
 #include "hello_world_driver.h"
 #include <stdio.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 const struct device *dev;
 

--- a/samples/arch/mpu/mpu_test/src/main.c
+++ b/samples/arch/mpu/mpu_test/src/main.c
@@ -6,11 +6,11 @@
  */
 #include <stdlib.h>
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/flash.h>
-#include <shell/shell.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/shell/shell.h>
 
 #define PR_SHELL(shell, fmt, ...)				\
 	shell_fprintf(shell, SHELL_NORMAL, fmt, ##__VA_ARGS__)

--- a/samples/arch/smp/pi/src/main.c
+++ b/samples/arch/smp/pi/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
 
 /* Amount of execution threads to create and run */

--- a/samples/arch/smp/pktqueue/src/main.h
+++ b/samples/arch/smp/pktqueue/src/main.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
-#include <sys/crc.h>
-#include <random/rand32.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/random/rand32.h>
 
 
 /* Amount of parallel processed sender/receiver queues of packet headers */

--- a/samples/arch/smp/pktqueue/src/pktqueue.h
+++ b/samples/arch/smp/pktqueue/src/pktqueue.h
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
-#include <sys/crc.h>
-#include <random/rand32.h>
+#include <zephyr/sys/crc.h>
+#include <zephyr/random/rand32.h>
 
 struct phdr_desc {
 	struct phdr_desc  *next;    /* Next pkt descriptor in respective queue */

--- a/samples/basic/blinky/src/main.c
+++ b/samples/basic/blinky/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
 
 /* 1000 msec = 1 sec */
 #define SLEEP_TIME_MS   1000

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -9,10 +9,10 @@
  * @file Sample app to demonstrate PWM.
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/pwm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
 
 static const struct pwm_dt_spec pwm_led0 = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
 

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <sys/util.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/printk.h>
 #include <inttypes.h>
 
 #define SLEEP_TIME_MS	1

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -9,10 +9,10 @@
  * @file Sample app to demonstrate PWM-based LED fade
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/pwm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
 
 static const struct pwm_dt_spec pwm_led0 = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
 

--- a/samples/basic/minimal/src/main.c
+++ b/samples/basic/minimal/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 void main(void)
 {

--- a/samples/basic/rgb_led/src/main.c
+++ b/samples/basic/rgb_led/src/main.c
@@ -8,10 +8,10 @@
  * @file Sample app to demonstrate PWM-based RGB LED control
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/pwm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
 
 static const struct pwm_dt_spec red_pwm_led =
 	PWM_DT_SPEC_GET(DT_ALIAS(red_pwm_led));

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -8,10 +8,10 @@
  * @file Sample app to demonstrate PWM-based servomotor control
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/pwm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/pwm.h>
 
 static const struct pwm_dt_spec servo = PWM_DT_SPEC_GET(DT_NODELABEL(servo));
 static const uint32_t min_pulse = DT_PROP(DT_NODELABEL(servo), min_pulse);

--- a/samples/basic/threads/src/main.c
+++ b/samples/basic/threads/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <sys/printk.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/__assert.h>
 #include <string.h>
 
 /* size of stack area used by each thread */

--- a/samples/bluetooth/beacon/src/main.c
+++ b/samples/bluetooth/beacon/src/main.c
@@ -8,11 +8,11 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)

--- a/samples/bluetooth/broadcast_audio_sink/src/main.c
+++ b/samples/bluetooth/broadcast_audio_sink/src/main.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/audio/audio.h>
 
 #define SEM_TIMEOUT K_SECONDS(10)
 

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/audio/audio.h>
 
 /* When BROADCAST_ENQUEUE_COUNT > 1 we can enqueue enough buffers to ensure that
  * the controller is never idle

--- a/samples/bluetooth/broadcaster/src/main.c
+++ b/samples/bluetooth/broadcaster/src/main.c
@@ -8,11 +8,11 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
 
 static uint8_t mfg_data[] = { 0xff, 0xff, 0x00 };
 

--- a/samples/bluetooth/central/src/main.c
+++ b/samples/bluetooth/central/src/main.c
@@ -9,15 +9,15 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/byteorder.h>
 
 static void start_scan(void);
 

--- a/samples/bluetooth/central_hr/src/main.c
+++ b/samples/bluetooth/central_hr/src/main.c
@@ -9,15 +9,15 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/byteorder.h>
 
 static void start_scan(void);
 

--- a/samples/bluetooth/central_ht/src/main.c
+++ b/samples/bluetooth/central_ht/src/main.c
@@ -10,15 +10,15 @@
 #include <stddef.h>
 #include <errno.h>
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 static int scan_start(void);
 

--- a/samples/bluetooth/central_iso/src/main.c
+++ b/samples/bluetooth/central_iso/src/main.c
@@ -7,16 +7,16 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/iso.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/byteorder.h>
 
 static void start_scan(void);
 

--- a/samples/bluetooth/central_multilink/src/central_multilink.c
+++ b/samples/bluetooth/central_multilink/src/central_multilink.c
@@ -10,15 +10,15 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/byteorder.h>
 
 #define SCAN_INTERVAL 0x0640 /* 1000 ms */
 #define SCAN_WINDOW   0x0030 /* 30 ms */

--- a/samples/bluetooth/central_past/src/main.c
+++ b/samples/bluetooth/central_past/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 
 #define NAME_LEN            30
 

--- a/samples/bluetooth/direction_finding_central/src/main.c
+++ b/samples/bluetooth/direction_finding_central/src/main.c
@@ -7,16 +7,16 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/direction.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/direction.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/sys/byteorder.h>
 
 /* Latency set to zero, to enforce PDU exchange every connection event */
 #define CONN_LATENCY 0U

--- a/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_rx/src/main.c
@@ -6,15 +6,15 @@
 
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/gap.h>
-#include <bluetooth/direction.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gap.h>
+#include <zephyr/bluetooth/direction.h>
 
 #define DEVICE_NAME     CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)

--- a/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
+++ b/samples/bluetooth/direction_finding_connectionless_tx/src/main.c
@@ -7,13 +7,13 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/direction.h>
-#include <sys/byteorder.h>
-#include <sys/util.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/direction.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 /* Length of CTE in unit of 8[us] */
 #define CTE_LEN (0x14U)

--- a/samples/bluetooth/direction_finding_peripheral/src/main.c
+++ b/samples/bluetooth/direction_finding_peripheral/src/main.c
@@ -8,18 +8,18 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/services/bas.h>
-#include <bluetooth/services/hrs.h>
-#include <bluetooth/direction.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/services/bas.h>
+#include <zephyr/bluetooth/services/hrs.h>
+#include <zephyr/bluetooth/direction.h>
 
 #define DF_FEAT_ENABLED BIT64(BT_LE_FEAT_BIT_CONN_CTE_RESP)
 

--- a/samples/bluetooth/eddystone/src/main.c
+++ b/samples/bluetooth/eddystone/src/main.c
@@ -10,16 +10,16 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/util.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 #define NUMBER_OF_SLOTS 1
 #define EDS_VERSION 0x00

--- a/samples/bluetooth/handsfree/src/main.c
+++ b/samples/bluetooth/handsfree/src/main.c
@@ -10,13 +10,13 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/hfp_hf.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/hfp_hf.h>
 
 static void connected(struct bt_conn *conn)
 {

--- a/samples/bluetooth/hci_pwr_ctrl/src/main.c
+++ b/samples/bluetooth/hci_pwr_ctrl/src/main.c
@@ -8,18 +8,18 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/printk.h>
-#include <sys/util.h>
-#include <sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/hci_vs.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_vs.h>
 
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/services/hrs.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/services/hrs.h>
 
 static struct bt_conn *default_conn;
 static uint16_t default_conn_handle;

--- a/samples/bluetooth/hci_rpmsg/src/main.c
+++ b/samples/bluetooth/hci_rpmsg/src/main.c
@@ -9,19 +9,19 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <device.h>
-#include <zephyr.h>
-#include <sys/byteorder.h>
-#include <sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
-#include <ipc/ipc_service.h>
+#include <zephyr/ipc/ipc_service.h>
 
-#include <net/buf.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/l2cap.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/buf.h>
-#include <bluetooth/hci_raw.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/hci_raw.h>
 
 #define BT_DBG_ENABLED 0
 #define LOG_MODULE_NAME hci_rpmsg

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -10,22 +10,22 @@
 #include <stddef.h>
 #include <stdio.h>
 
-#include <zephyr.h>
-#include <sys/byteorder.h>
-#include <logging/log.h>
-#include <debug/stack.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/debug/stack.h>
 
-#include <device.h>
-#include <init.h>
-#include <drivers/gpio.h>
-#include <drivers/spi.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
 
-#include <net/buf.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/l2cap.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/buf.h>
-#include <bluetooth/hci_raw.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/hci_raw.h>
 
 #define LOG_MODULE_NAME hci_spi
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -10,22 +10,22 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <zephyr.h>
-#include <arch/cpu.h>
-#include <sys/byteorder.h>
-#include <logging/log.h>
-#include <sys/util.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/util.h>
 
-#include <device.h>
-#include <init.h>
-#include <drivers/uart.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/uart.h>
 
-#include <net/buf.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/l2cap.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/buf.h>
-#include <bluetooth/hci_raw.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/bluetooth/hci_raw.h>
 
 #define LOG_MODULE_NAME hci_uart
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);

--- a/samples/bluetooth/hci_usb/src/main.c
+++ b/samples/bluetooth/hci_usb/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <usb/usb_device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/usb/usb_device.h>
 
 void main(void)
 {

--- a/samples/bluetooth/hci_usb_h4/src/main.c
+++ b/samples/bluetooth/hci_usb_h4/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <usb/usb_device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/usb/usb_device.h>
 
 void main(void)
 {

--- a/samples/bluetooth/ibeacon/src/main.c
+++ b/samples/bluetooth/ibeacon/src/main.c
@@ -6,11 +6,11 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
 
 #ifndef IBEACON_RSSI
 #define IBEACON_RSSI 0xc8

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
 LOG_MODULE_REGISTER(ipsp);
@@ -14,16 +14,16 @@ LOG_MODULE_REGISTER(ipsp);
 /* Preventing log module registration in net_core.h */
 #define NET_LOG_ENABLED	0
 
-#include <zephyr.h>
-#include <linker/sections.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/sections.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/net_pkt.h>
-#include <net/net_if.h>
-#include <net/net_core.h>
-#include <net/net_context.h>
-#include <net/udp.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/udp.h>
 
 /* Define my IP address where to expect messages */
 #define MY_IP6ADDR { { { 0x20, 0x01, 0x0d, 0xb8, 0, 0, 0, 0, \

--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/iso.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/byteorder.h>
 
 #define BIG_TERMINATE_TIMEOUT 60 /* seconds */
 

--- a/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/broadcaster.c
@@ -6,12 +6,12 @@
 
 #include <ctype.h>
 #include <stdlib.h>
-#include <console/console.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/iso.h>
-#include <sys/byteorder.h>
+#include <zephyr/console/console.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(iso_broadcast_broadcaster, LOG_LEVEL_DBG);
 
 #define DEFAULT_BIS_RTN         2

--- a/samples/bluetooth/iso_broadcast_benchmark/src/main.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/main.c
@@ -6,13 +6,13 @@
 
 #include <ctype.h>
 
-#include <console/console.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/iso.h>
+#include <zephyr/console/console.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/iso.h>
 
 #include "common.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(iso_broadcast_main, LOG_LEVEL_DBG);
 
 enum benchmark_role {

--- a/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
+++ b/samples/bluetooth/iso_broadcast_benchmark/src/receiver.c
@@ -5,13 +5,13 @@
  */
 
 #include <ctype.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/iso.h>
-#include <sys/byteorder.h>
-#include <console/console.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/console/console.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(iso_broadcast_receiver, LOG_LEVEL_DBG);
 
 #define DEVICE_NAME	CONFIG_BT_DEVICE_NAME

--- a/samples/bluetooth/iso_connected_benchmark/src/main.c
+++ b/samples/bluetooth/iso_connected_benchmark/src/main.c
@@ -5,18 +5,18 @@
  */
 
 #include <ctype.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include <stdlib.h>
 #include <zephyr/types.h>
 
 
-#include <console/console.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/iso.h>
-#include <sys/byteorder.h>
+#include <zephyr/console/console.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(iso_connected, LOG_LEVEL_DBG);
 
 #define DEVICE_NAME	CONFIG_BT_DEVICE_NAME

--- a/samples/bluetooth/iso_receive/src/main.c
+++ b/samples/bluetooth/iso_receive/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/iso.h>
-#include <sys/byteorder.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/iso.h>
+#include <zephyr/sys/byteorder.h>
 
 #define TIMEOUT_SYNC_CREATE K_SECONDS(10)
 #define NAME_LEN            30

--- a/samples/bluetooth/mesh/src/board.c
+++ b/samples/bluetooth/mesh/src/board.c
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/mesh.h>
-#include <drivers/gpio.h>
+#include <zephyr/bluetooth/mesh.h>
+#include <zephyr/drivers/gpio.h>
 #include "board.h"
 
 /* Locate led0 as alias or label by that name */

--- a/samples/bluetooth/mesh/src/main.c
+++ b/samples/bluetooth/mesh/src/main.c
@@ -6,17 +6,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <settings/settings.h>
-#include <devicetree.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <drivers/hwinfo.h>
-#include <sys/byteorder.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/mesh.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/mesh.h>
 
 #include "board.h"
 

--- a/samples/bluetooth/mesh/src/microbit.c
+++ b/samples/bluetooth/mesh/src/microbit.c
@@ -7,9 +7,9 @@
  */
 
 
-#include <bluetooth/mesh.h>
-#include <display/mb_display.h>
-#include <drivers/gpio.h>
+#include <zephyr/bluetooth/mesh.h>
+#include <zephyr/display/mb_display.h>
+#include <zephyr/drivers/gpio.h>
 #include "board.h"
 
 static uint32_t oob_number;

--- a/samples/bluetooth/mesh_demo/src/main.c
+++ b/samples/bluetooth/mesh_demo/src/main.c
@@ -6,12 +6,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/mesh.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/mesh.h>
 
 #include "board.h"
 

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -6,16 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 #include <soc.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include <ctype.h>
-#include <drivers/gpio.h>
-#include <drivers/pwm.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
 
-#include <display/mb_display.h>
+#include <zephyr/display/mb_display.h>
 
-#include <bluetooth/mesh.h>
+#include <zephyr/bluetooth/mesh.h>
 
 #include "board.h"
 

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/mesh.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/mesh.h>
 
 static const uint16_t net_idx;
 static const uint16_t app_idx;

--- a/samples/bluetooth/observer/src/main.c
+++ b/samples/bluetooth/observer/src/main.c
@@ -8,11 +8,11 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
 
 static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 			 struct net_buf_simple *ad)

--- a/samples/bluetooth/periodic_adv/src/main.c
+++ b/samples/bluetooth/periodic_adv/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 static uint8_t mfg_data[] = { 0xff, 0xff, 0x00 };
 

--- a/samples/bluetooth/periodic_sync/src/main.c
+++ b/samples/bluetooth/periodic_sync/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <bluetooth/bluetooth.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 #define TIMEOUT_SYNC_CREATE K_SECONDS(10)
 #define NAME_LEN            30

--- a/samples/bluetooth/peripheral/src/cts.c
+++ b/samples/bluetooth/peripheral/src/cts.c
@@ -12,15 +12,15 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 static uint8_t ct[10];
 static uint8_t ct_update;

--- a/samples/bluetooth/peripheral/src/main.c
+++ b/samples/bluetooth/peripheral/src/main.c
@@ -10,20 +10,20 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/services/bas.h>
-#include <bluetooth/services/hrs.h>
-#include <bluetooth/services/ias.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/services/bas.h>
+#include <zephyr/bluetooth/services/hrs.h>
+#include <zephyr/bluetooth/services/ias.h>
 
 #include "cts.h"
 

--- a/samples/bluetooth/peripheral_csc/src/main.c
+++ b/samples/bluetooth/peripheral_csc/src/main.c
@@ -11,17 +11,17 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <random/rand32.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/services/bas.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/services/bas.h>
 
 #define CSC_SUPPORTED_LOCATIONS		{ CSC_LOC_OTHER, \
 					  CSC_LOC_FRONT_WHEEL, \

--- a/samples/bluetooth/peripheral_dis/src/main.c
+++ b/samples/bluetooth/peripheral_dis/src/main.c
@@ -10,16 +10,16 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <settings/settings.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/settings/settings.h>
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),

--- a/samples/bluetooth/peripheral_esp/src/main.c
+++ b/samples/bluetooth/peripheral_esp/src/main.c
@@ -11,16 +11,16 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/services/bas.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/services/bas.h>
 
 #define SENSOR_1_NAME				"Temperature Sensor 1"
 #define SENSOR_2_NAME				"Temperature Sensor 2"

--- a/samples/bluetooth/peripheral_hids/src/hog.c
+++ b/samples/bluetooth/peripheral_hids/src/hog.c
@@ -12,15 +12,15 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 enum {
 	HIDS_REMOTE_WAKE = BIT(0),

--- a/samples/bluetooth/peripheral_hids/src/main.c
+++ b/samples/bluetooth/peripheral_hids/src/main.c
@@ -10,17 +10,17 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 #include "hog.h"
 

--- a/samples/bluetooth/peripheral_hr/src/main.c
+++ b/samples/bluetooth/peripheral_hr/src/main.c
@@ -10,17 +10,17 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/services/bas.h>
-#include <bluetooth/services/hrs.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/services/bas.h>
+#include <zephyr/bluetooth/services/hrs.h>
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -14,16 +14,16 @@
 #include <string.h>
 #include <errno.h>
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 #ifdef CONFIG_TEMP_NRF5
 static const struct device *temp_dev = DEVICE_DT_GET_ANY(nordic_nrf_temp);

--- a/samples/bluetooth/peripheral_ht/src/main.c
+++ b/samples/bluetooth/peripheral_ht/src/main.c
@@ -10,16 +10,16 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/services/bas.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/services/bas.h>
 
 #include "hts.h"
 

--- a/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
+++ b/samples/bluetooth/peripheral_identity/src/peripheral_identity.c
@@ -8,10 +8,10 @@
  */
 
 #include <stddef.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 
 static struct k_work work_adv_start;
 static uint8_t volatile conn_count;

--- a/samples/bluetooth/peripheral_iso/src/main.c
+++ b/samples/bluetooth/peripheral_iso/src/main.c
@@ -8,14 +8,14 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/iso.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/iso.h>
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),

--- a/samples/bluetooth/peripheral_ots/src/main.c
+++ b/samples/bluetooth/peripheral_ots/src/main.c
@@ -7,14 +7,14 @@
 #include <zephyr/types.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
 
-#include <bluetooth/services/ots.h>
+#include <zephyr/bluetooth/services/ots.h>
 
 #define DEVICE_NAME      CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN  (sizeof(DEVICE_NAME) - 1)

--- a/samples/bluetooth/peripheral_past/src/main.c
+++ b/samples/bluetooth/peripheral_past/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
 
 static struct bt_conn *default_conn;
 

--- a/samples/bluetooth/peripheral_sc_only/src/main.c
+++ b/samples/bluetooth/peripheral_sc_only/src/main.c
@@ -10,15 +10,15 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_FLAGS, (BT_LE_AD_GENERAL | BT_LE_AD_NO_BREDR)),

--- a/samples/bluetooth/scan_adv/src/main.c
+++ b/samples/bluetooth/scan_adv/src/main.c
@@ -8,11 +8,11 @@
 
 #include <zephyr/types.h>
 #include <stddef.h>
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
 
 static uint8_t mfg_data[] = { 0xff, 0xff, 0x00 };
 

--- a/samples/bluetooth/st_ble_sensor/src/button_svc.c
+++ b/samples/bluetooth/st_ble_sensor/src/button_svc.c
@@ -10,14 +10,14 @@
 
 #include "button_svc.h"
 
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 
 LOG_MODULE_REGISTER(button_svc);
 

--- a/samples/bluetooth/st_ble_sensor/src/button_svc.h
+++ b/samples/bluetooth/st_ble_sensor/src/button_svc.h
@@ -11,7 +11,7 @@
 #ifndef ST_BLE_SENSOR_BUTTON_SVC_H_
 #define ST_BLE_SENSOR_BUTTON_SVC_H_
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/bluetooth/st_ble_sensor/src/led_svc.c
+++ b/samples/bluetooth/st_ble_sensor/src/led_svc.c
@@ -10,9 +10,9 @@
 
 #include "led_svc.h"
 
-#include <zephyr.h>
-#include <drivers/gpio.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(led_svc);
 

--- a/samples/bluetooth/st_ble_sensor/src/main.c
+++ b/samples/bluetooth/st_ble_sensor/src/main.c
@@ -11,17 +11,17 @@
 #include <stddef.h>
 #include <string.h>
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
-#include <drivers/gpio.h>
-#include <logging/log.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/gatt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/gatt.h>
 #include "button_svc.h"
 #include "led_svc.h"
 

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -7,13 +7,13 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/audio/audio.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/sys/byteorder.h>
 
 static void start_scan(void);
 

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -7,14 +7,14 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/audio/audio.h>
-#include <bluetooth/audio/capabilities.h>
-#include <sys/byteorder.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/audio/audio.h>
+#include <zephyr/bluetooth/audio/capabilities.h>
+#include <zephyr/sys/byteorder.h>
 
 #define MAX_PAC 1
 

--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -5,13 +5,13 @@
  */
 
 #include <string.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <drivers/gpio.h>
-#include <drivers/led.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/led.h>
 
-#include <audio/dmic.h>
+#include <zephyr/audio/dmic.h>
 
 /* uncomment if you want PCM output in ascii */
 /*#define PCM_OUTPUT_IN_ASCII		1  */

--- a/samples/boards/96b_argonkey/sensors/src/main.c
+++ b/samples/boards/96b_argonkey/sensors/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <drivers/gpio.h>
-#include <drivers/led.h>
-#include <drivers/i2c.h>
-#include <drivers/spi.h>
-#include <drivers/sensor.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/sensor.h>
 
 #include <stdio.h>
 

--- a/samples/boards/arc_secure_services/src/main.c
+++ b/samples/boards/arc_secure_services/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <soc.h>
 
 #if defined(CONFIG_SOC_NSIM_SEM)

--- a/samples/boards/bbc_microbit/display/src/main.c
+++ b/samples/boards/bbc_microbit/display/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/gpio.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/device.h>
 
-#include <display/mb_display.h>
+#include <zephyr/display/mb_display.h>
 
 static struct mb_image smiley = MB_IMAGE({ 0, 1, 0, 1, 0 },
 					 { 0, 1, 0, 1, 0 },

--- a/samples/boards/bbc_microbit/line_follower_robot/src/main.c
+++ b/samples/boards/bbc_microbit/line_follower_robot/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/gpio.h>
-#include <drivers/i2c.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/device.h>
 
 #define I2C_SLV_ADDR 0x10
 #define I2C0_LABEL DT_LABEL(DT_NODELABEL(i2c0))

--- a/samples/boards/bbc_microbit/pong/src/ble.c
+++ b/samples/boards/bbc_microbit/pong/src/ble.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/gpio.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/device.h>
 #include <string.h>
 
-#include <display/mb_display.h>
+#include <zephyr/display/mb_display.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/uuid.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/gatt.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/uuid.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/hci.h>
 
 
 #include "pong.h"

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/gpio.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/device.h>
 #include <string.h>
-#include <drivers/pwm.h>
-#include <debug/stack.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/debug/stack.h>
 
-#include <display/mb_display.h>
+#include <zephyr/display/mb_display.h>
 
-#include <bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/bluetooth.h>
 
 #include "pong.h"
 

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/gpio.h>
-#include <drivers/pwm.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
+#include <zephyr/device.h>
 
-#include <display/mb_display.h>
+#include <zephyr/display/mb_display.h>
 
 #define BUZZER_PWM_CHANNEL 0
 

--- a/samples/boards/esp32/flash_encryption/src/main.c
+++ b/samples/boards/esp32/flash_encryption/src/main.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/flash.h>
-#include <storage/flash_map.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
 
 #include <esp_spi_flash.h>
 #include <soc.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(flash_encryption, CONFIG_LOG_DEFAULT_LEVEL);
 
 #if !defined(CONFIG_SOC_ESP32)

--- a/samples/boards/esp32/spiram_test/src/main.c
+++ b/samples/boards/esp32/spiram_test/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <soc/soc_memory_layout.h>
 
 static int check_allocated_memory(int *m1, size_t size)

--- a/samples/boards/esp32/wifi_station/src/main.c
+++ b/samples/boards/esp32/wifi_station/src/main.c
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 #include <esp_wifi.h>
 #include <esp_timer.h>
 #include <esp_event.h>
 
-#include <net/net_if.h>
-#include <net/net_core.h>
-#include <net/net_context.h>
-#include <net/net_mgmt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_mgmt.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(esp32_wifi_sta, LOG_LEVEL_DBG);
 
 static struct net_mgmt_event_callback dhcp_cb;

--- a/samples/boards/google_kukui/src/main.c
+++ b/samples/boards/google_kukui/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 void main(void)
 {

--- a/samples/boards/intel_s1000_crb/audio/src/audio_core.c
+++ b/samples/boards/intel_s1000_crb/audio/src/audio_core.c
@@ -5,10 +5,10 @@
  */
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(audio_core);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "audio_core.h"
 
 /*

--- a/samples/boards/intel_s1000_crb/audio/src/audio_driver.c
+++ b/samples/boards/intel_s1000_crb/audio/src/audio_driver.c
@@ -5,17 +5,17 @@
  */
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(audio_io);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include <soc.h>
-#include <device.h>
-#include <drivers/i2s.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2s.h>
 
-#include <audio/codec.h>
-#include <audio/dmic.h>
+#include <zephyr/audio/codec.h>
+#include <zephyr/audio/dmic.h>
 #include "audio_core.h"
 
 #define DMIC_DEV_NAME		"PDM"

--- a/samples/boards/intel_s1000_crb/audio/src/audio_proc.c
+++ b/samples/boards/intel_s1000_crb/audio/src/audio_proc.c
@@ -5,10 +5,10 @@
  */
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(audio_proc);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "audio_core.h"
 

--- a/samples/boards/intel_s1000_crb/audio/src/framework.c
+++ b/samples/boards/intel_s1000_crb/audio/src/framework.c
@@ -5,10 +5,10 @@
  */
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(framework);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "audio_core.h"
 

--- a/samples/boards/intel_s1000_crb/audio/src/tuning_driver.c
+++ b/samples/boards/intel_s1000_crb/audio/src/tuning_driver.c
@@ -5,13 +5,13 @@
  */
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tuning);
 
-#include <sys/byteorder.h>
+#include <zephyr/sys/byteorder.h>
 
 #include <string.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "audio_core.h"
 #include "usb_transport.h"

--- a/samples/boards/intel_s1000_crb/audio/src/usb_transport.c
+++ b/samples/boards/intel_s1000_crb/audio/src/usb_transport.c
@@ -5,13 +5,13 @@
  */
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usb_transport);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <usb/usb_device.h>
-#include <usb/class/usb_hid.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_hid.h>
 
 #include "usb_transport.h"
 

--- a/samples/boards/intel_s1000_crb/dmic/src/dmic_sample.c
+++ b/samples/boards/intel_s1000_crb/dmic/src/dmic_sample.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <audio/dmic.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/audio/dmic.h>
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dmic_sample);
 
 #define AUDIO_SAMPLE_FREQ	48000

--- a/samples/boards/intel_s1000_crb/i2s/src/i2s_sample.c
+++ b/samples/boards/intel_s1000_crb/i2s/src/i2s_sample.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/i2s.h>
-#include <audio/codec.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/i2s.h>
+#include <zephyr/audio/codec.h>
 
 #include <string.h>
 #include <math.h>
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2s_sample);
 
 #define AUDIO_SAMPLE_FREQ		(48000)

--- a/samples/boards/mec15xxevb_assy6853/power_management/src/main.c
+++ b/samples/boards/mec15xxevb_assy6853/power_management/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #define LOG_LEVEL LOG_LEVEL_INF
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(mec15_brd_test);
 #include "power_mgmt.h"
 

--- a/samples/boards/mec15xxevb_assy6853/power_management/src/power_mgmt.c
+++ b/samples/boards/mec15xxevb_assy6853/power_management/src/power_mgmt.c
@@ -5,11 +5,11 @@
  */
 
 #include <errno.h>
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #include <soc.h>
-#include <pm/pm.h>
-#include <logging/log.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/logging/log.h>
 #define LOG_LEVEL LOG_LEVEL_DBG
 LOG_MODULE_REGISTER(pwrmgmt_test);
 

--- a/samples/boards/nrf/battery/src/battery.c
+++ b/samples/boards/nrf/battery/src/battery.c
@@ -9,12 +9,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <zephyr.h>
-#include <init.h>
-#include <drivers/gpio.h>
-#include <drivers/adc.h>
-#include <drivers/sensor.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
 
 #include "battery.h"
 

--- a/samples/boards/nrf/battery/src/main.c
+++ b/samples/boards/nrf/battery/src/main.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "battery.h"
 
 /** A discharge curve specific to the power source. */

--- a/samples/boards/nrf/clock_skew/src/main.c
+++ b/samples/boards/nrf/clock_skew/src/main.c
@@ -5,11 +5,11 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <sys/timeutil.h>
-#include <drivers/clock_control.h>
-#include <drivers/clock_control/nrf_clock_control.h>
-#include <drivers/counter.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/timeutil.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nrf_clock_control.h>
+#include <zephyr/drivers/counter.h>
 #include <nrfx_clock.h>
 
 #define TIMER_NODE DT_NODELABEL(timer0)

--- a/samples/boards/nrf/dynamic_pinctrl/src/main.c
+++ b/samples/boards/nrf/dynamic_pinctrl/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 void main(void)
 {

--- a/samples/boards/nrf/dynamic_pinctrl/src/remap.c
+++ b/samples/boards/nrf/dynamic_pinctrl/src/remap.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/gpio.h>
-#include <drivers/pinctrl.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pinctrl.h>
 
 /* make sure devices and remap hook are initialized in the correct order */
 BUILD_ASSERT((CONFIG_GPIO_INIT_PRIORITY < CONFIG_REMAP_INIT_PRIORITY) &&

--- a/samples/boards/nrf/ieee802154/802154_rpmsg/src/main.c
+++ b/samples/boards/nrf/ieee802154/802154_rpmsg/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/__assert.h>
-#include <zephyr.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/zephyr.h>
 
 #include <nrf_802154_serialization_error.h>
 

--- a/samples/boards/nrf/mesh/onoff-app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff-app/src/main.c
@@ -36,16 +36,16 @@
  *
  */
 
-#include <sys/printk.h>
-#include <settings/settings.h>
-#include <sys/byteorder.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/l2cap.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/mesh.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/mesh.h>
 #include <stdio.h>
 
 /* Model Operation Codes */

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/app_gpio.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "app_gpio.h"
 #include "publisher.h"

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "app_gpio.h"
 #include "ble_mesh.h"
@@ -16,7 +16,7 @@
 #include "transition.h"
 
 #if defined(CONFIG_MCUMGR)
-#include <mgmt/mcumgr/smp_bt.h>
+#include <zephyr/mgmt/mcumgr/smp_bt.h>
 #include "smp_svr.h"
 #endif
 

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.h
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/ble_mesh.h
@@ -8,12 +8,12 @@
 #ifndef _BLE_MESH_H
 #define _BLE_MESH_H
 
-#include <settings/settings.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/l2cap.h>
-#include <bluetooth/hci.h>
-#include <bluetooth/mesh.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/l2cap.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/mesh.h>
 
 /* Model Operation Codes */
 #define	BT_MESH_MODEL_OP_GEN_ONOFF_GET          BT_MESH_MODEL_OP_2(0x82, 0x01)

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/device_composition.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "ble_mesh.h"
 #include "common.h"

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "app_gpio.h"
 #include "ble_mesh.h"

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "ble_mesh.h"
 #include "device_composition.h"

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/transition.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "ble_mesh.h"
 #include "common.h"

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/smp_svr.c
@@ -5,16 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/__assert.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/gatt.h>
-#include <mgmt/mcumgr/buf.h>
-#include <mgmt/mcumgr/smp_bt.h>
-#include <stats/stats.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/mgmt/mcumgr/buf.h>
+#include <zephyr/mgmt/mcumgr/smp_bt.h>
+#include <zephyr/stats/stats.h>
 #include <stdlib.h>
 #include <string.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #ifdef CONFIG_MCUMGR_CMD_IMG_MGMT
 #include "img_mgmt/img_mgmt.h"

--- a/samples/boards/nrf/nrf53_sync_rtc/net/src/main.c
+++ b/samples/boards/nrf/nrf53_sync_rtc/net/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/mbox.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/mbox.h>
 #include <hal/nrf_ipc.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
-#include <drivers/timer/nrf_rtc_timer.h>
-#include <logging/log.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/timer/nrf_rtc_timer.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 static void sync_callback(void)

--- a/samples/boards/nrf/nrf53_sync_rtc/src/main.c
+++ b/samples/boards/nrf/nrf53_sync_rtc/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #include <hal/nrf_ipc.h>
-#include <sys/printk.h>
-#include <logging/log.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 static void timeout_handler(struct k_timer *timer)

--- a/samples/boards/nrf/nrf_led_matrix/src/main.c
+++ b/samples/boards/nrf/nrf_led_matrix/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/display.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/display.h>
 #include <string.h>
 
 #define PIXEL_BIT(idx, val)  (val ? BIT(idx) : 0)

--- a/samples/boards/nrf/nrfx/src/main.c
+++ b/samples/boards/nrf/nrfx/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include <nrfx_gpiote.h>
 #include <helpers/nrfx_gppi.h>
@@ -14,7 +14,7 @@
 #include <nrfx_ppi.h>
 #endif
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(nrfx_sample, LOG_LEVEL_INF);
 
 #define INPUT_PIN	DT_GPIO_PIN(DT_ALIAS(sw0), gpios)

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/gpio.h>
-#include <drivers/spi.h>
-#include <drivers/pinctrl.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #include <nrfx_spim.h>
 #include <nrfx_uarte.h>

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -5,12 +5,12 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <device.h>
-#include <init.h>
-#include <pm/pm.h>
-#include <pm/device.h>
-#include <pm/policy.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/policy.h>
 #include <soc.h>
 #include "retained.h"
 #include <hal/nrf_gpio.h>

--- a/samples/boards/nrf/system_off/src/retained.c
+++ b/samples/boards/nrf/system_off/src/retained.c
@@ -5,10 +5,10 @@
  */
 
 #include <string.h>
-#include <zephyr.h>
-#include <devicetree.h>
-#include <sys/byteorder.h>
-#include <sys/crc.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/crc.h>
 #include <hal/nrf_power.h>
 #include "retained.h"
 

--- a/samples/boards/qemu_cortex_a53/reserved_memory/src/main.c
+++ b/samples/boards/qemu_cortex_a53/reserved_memory/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <linker/linker-defs.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/linker-defs.h>
 
 /* Variables placed in reserved sections */
 uint32_t var_in_res0 __attribute((__section__(".res0"))) = 0xaabbccdd;

--- a/samples/boards/reel_board/mesh_badge/src/main.c
+++ b/samples/boards/reel_board/mesh_badge/src/main.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 #include <string.h>
 
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/gatt.h>
-#include <drivers/sensor.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/drivers/sensor.h>
 
 #include "mesh.h"
 #include "board.h"

--- a/samples/boards/reel_board/mesh_badge/src/mesh.c
+++ b/samples/boards/reel_board/mesh_badge/src/mesh.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/mesh.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/mesh.h>
+#include <zephyr/bluetooth/hci.h>
 
-#include <drivers/sensor.h>
+#include <zephyr/drivers/sensor.h>
 
 #include "mesh.h"
 #include "board.h"

--- a/samples/boards/reel_board/mesh_badge/src/periphs.c
+++ b/samples/boards/reel_board/mesh_badge/src/periphs.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/gpio.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
 #include "board.h"
 #include "mesh.h"
 
-#include <bluetooth/mesh.h>
+#include <zephyr/bluetooth/mesh.h>
 
 struct device_info {
 	const struct device *dev;

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -5,21 +5,21 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <display/cfb.h>
-#include <sys/printk.h>
-#include <drivers/flash.h>
-#include <storage/flash_map.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/display/cfb.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/drivers/sensor.h>
 
 #include <string.h>
 #include <stdio.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/mesh/access.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/mesh/access.h>
 
 #include "mesh.h"
 #include "board.h"

--- a/samples/boards/sensortile_box/src/main.c
+++ b/samples/boards/sensortile_box/src/main.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <drivers/gpio.h>
-#include <drivers/led.h>
-#include <drivers/i2c.h>
-#include <drivers/spi.h>
-#include <drivers/sensor.h>
-#include <usb/usb_device.h>
-#include <drivers/uart.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/drivers/uart.h>
 
 #include <stdio.h>
 

--- a/samples/boards/stm32/backup_sram/src/main.c
+++ b/samples/boards/stm32/backup_sram/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 /** Value stored in backup SRAM. */
 __stm32_backup_sram_section uint32_t backup_value;

--- a/samples/boards/stm32/ccm/src/main.c
+++ b/samples/boards/stm32/ccm/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #include <stdio.h>
 #include <string.h>
 
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 #define CCM_DATA_VAR_8_VAL	0x12
 #define CCM_DATA_VAR_16_VAL	0x3456

--- a/samples/boards/stm32/h7_dual_core/src/main.c
+++ b/samples/boards/stm32/h7_dual_core/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/ipm.h>
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 #define SLEEP_TIME_MS   1000
 

--- a/samples/boards/stm32/power_mgmt/blinky/src/main.c
+++ b/samples/boards/stm32/power_mgmt/blinky/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 #define SLEEP_TIME_MS   2000
 

--- a/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
+++ b/samples/boards/stm32/power_mgmt/stm32wb_ble/src/main.c
@@ -8,14 +8,14 @@
  */
 
 #include <zephyr/types.h>
-#include <device.h>
+#include <zephyr/device.h>
 #include <stddef.h>
-#include <sys/printk.h>
-#include <sys/util.h>
-#include <pm/pm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/pm/pm.h>
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
 
 #define DEVICE_NAME CONFIG_BT_DEVICE_NAME
 #define DEVICE_NAME_LEN (sizeof(DEVICE_NAME) - 1)

--- a/samples/boards/stm32/usbc/sink/src/main.c
+++ b/samples/boards/stm32/usbc/sink/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
 #include "usbc_snk.h"

--- a/samples/boards/stm32/usbc/sink/src/stm32g081b_eval_board.c
+++ b/samples/boards/stm32/usbc/sink/src/stm32g081b_eval_board.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <drivers/adc.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/adc.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(board, LOG_LEVEL_DBG);
 
 #define VBUS DT_PATH(vbus)

--- a/samples/boards/stm32/usbc/sink/src/usbc_snk.c
+++ b/samples/boards/stm32/usbc/sink/src/usbc_snk.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <smf.h>
-#include <drivers/usbc/usbc_tcpc.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/smf.h>
+#include <zephyr/drivers/usbc/usbc_tcpc.h>
 
 #include "board.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(snk, LOG_LEVEL_DBG);
 
 #define TCPC_NODE       DT_ALIAS(tcpc)

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/ext_flash.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/ext_flash.c
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 
 #include <driverlib/cpu.h>
 

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -6,11 +6,11 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <init.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/pm/pm.h>
 
 #include <driverlib/ioc.h>
 

--- a/samples/boards/up_squared/gpio_counter/src/main.c
+++ b/samples/boards/up_squared/gpio_counter/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include <board.h>
 #include <soc.h>
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
 /**
  * @file

--- a/samples/compression/lz4/src/main.c
+++ b/samples/compression/lz4/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
 #include <stdlib.h>
 #include "lz4.h"

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/adc.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/adc.h>
 
 #if !DT_NODE_EXISTS(DT_PATH(zephyr_user)) || \
 	!DT_NODE_HAS_PROP(DT_PATH(zephyr_user), io_channels)

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <audio/dmic.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/audio/dmic.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dmic_sample);
 
 #define MAX_SAMPLE_RATE  16000

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <kernel.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/can.h>
-#include <drivers/gpio.h>
-#include <sys/byteorder.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/can.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/byteorder.h>
 
 #define RX_THREAD_STACK_SIZE 512
 #define RX_THREAD_PRIORITY 2

--- a/samples/drivers/clock_control_litex/src/main.c
+++ b/samples/drivers/clock_control_litex/src/main.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
-#include <devicetree.h>
-#include <drivers/clock_control.h>
-#include <drivers/clock_control/clock_control_litex.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/clock_control_litex.h>
 /* Test defines */
 
 /* Select clock outputs for tests [0-6] */

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <device.h>
-#include <drivers/counter.h>
-#include <sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/sys/printk.h>
 
 #define DELAY 2000000
 #define ALARM_CHANNEL_ID 0

--- a/samples/drivers/counter/maxim_ds3231/src/main.c
+++ b/samples/drivers/counter/maxim_ds3231/src/main.c
@@ -6,11 +6,11 @@
 
 #include <stdio.h>
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/counter.h>
-#include <sys/printk.h>
-#include <drivers/rtc/maxim_ds3231.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/rtc/maxim_ds3231.h>
 
 /* Format times as: YYYY-MM-DD HH:MM:SS DOW DOY */
 static const char *format_time(time_t time,

--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -8,13 +8,13 @@
  * and ciphertexts used for crosschecking are from TinyCrypt.
  */
 
-#include <device.h>
-#include <zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <crypto/crypto.h>
+#include <zephyr/crypto/crypto.h>
 
 #define LOG_LEVEL CONFIG_CRYPTO_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #ifdef CONFIG_CRYPTO_TINYCRYPT_SHIM

--- a/samples/drivers/dac/src/main.c
+++ b/samples/drivers/dac/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/dac.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/dac.h>
 
 #define ZEPHYR_USER_NODE DT_PATH(zephyr_user)
 

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -7,12 +7,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sample, LOG_LEVEL_INF);
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/display.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
 
 #ifdef CONFIG_ARCH_POSIX
 #include "posix_board_if.h"

--- a/samples/drivers/eeprom/src/main.c
+++ b/samples/drivers/eeprom/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/eeprom.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/eeprom.h>
+#include <zephyr/device.h>
 
 #define EEPROM_SAMPLE_OFFSET 0
 #define EEPROM_SAMPLE_MAGIC  0xEE9703

--- a/samples/drivers/espi/src/espi_oob_handler.c
+++ b/samples/drivers/espi/src/espi_oob_handler.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <soc.h>
-#include <drivers/gpio.h>
-#include <drivers/espi.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/espi.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
 #include "espi_oob_handler.h"
 
 LOG_MODULE_DECLARE(espi, CONFIG_ESPI_LOG_LEVEL);

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -5,15 +5,15 @@
  */
 
 #include <errno.h>
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #include <soc.h>
-#include <drivers/gpio.h>
-#include <drivers/espi.h>
-#include <drivers/espi_saf.h>
-#include <drivers/spi.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/espi.h>
+#include <zephyr/drivers/espi_saf.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
 /* OOB operations will be attempted regardless of channel enabled or not */
 #include "espi_oob_handler.h"
 LOG_MODULE_DECLARE(espi, CONFIG_ESPI_LOG_LEVEL);

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -6,13 +6,13 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <zephyr.h>
-#include <devicetree.h>
-#include <sys/printk.h>
-#include <logging/log.h>
-#include <shell/shell.h>
-#include <drivers/flash.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/device.h>
 #include <soc.h>
 #include <stdlib.h>
 

--- a/samples/drivers/fpga/fpga_controller/src/main.c
+++ b/samples/drivers/fpga/fpga_controller/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <sys/printk.h>
-#include <drivers/fpga.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/fpga.h>
 #include "redled.h"
 #include "greenled.h"
 #include <eoss3_dev.h>

--- a/samples/drivers/fpga/fpga_controller_shell/src/main.c
+++ b/samples/drivers/fpga/fpga_controller_shell/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <shell/shell.h>
-#include <device.h>
-#include <sys/printk.h>
-#include <drivers/fpga.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/fpga.h>
 #include "redled.h"
 #include "greenled.h"
 #include <eoss3_dev.h>

--- a/samples/drivers/ht16k33/src/main.c
+++ b/samples/drivers/ht16k33/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/led.h>
-#include <drivers/kscan.h>
-#include <logging/log.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/drivers/kscan.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 

--- a/samples/drivers/i2c_fujitsu_fram/src/main.c
+++ b/samples/drivers/i2c_fujitsu_fram/src/main.c
@@ -5,10 +5,10 @@
  */
 
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/i2c.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
 
 /**
  * @file Sample app using the Fujitsu MB85RC256V FRAM through I2C.

--- a/samples/drivers/i2s/echo/src/codec.c
+++ b/samples/drivers/i2s/echo/src/codec.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "codec.h"
-#include <sys/printk.h>
-#include <drivers/i2c.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/i2c.h>
 
 #if DT_ON_BUS(WM8731_NODE, i2c)
 

--- a/samples/drivers/i2s/echo/src/main.c
+++ b/samples/drivers/i2s/echo/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "codec.h"
-#include <sys/printk.h>
-#include <drivers/i2s.h>
-#include <drivers/gpio.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/i2s.h>
+#include <zephyr/drivers/gpio.h>
 #include <string.h>
 
 

--- a/samples/drivers/i2s/litex/src/main.c
+++ b/samples/drivers/i2s/litex/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/i2s.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/i2s.h>
 #include <stdlib.h>
 #include <string.h>
 #define AUDIO_SAMPLE_FREQ (44100)

--- a/samples/drivers/ipm/ipm_imx/src/main.c
+++ b/samples/drivers/ipm/ipm_imx/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/ipm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/ipm.h>
 
 static void ipm_callback(const struct device *dev, void *context,
 			 uint32_t id, volatile void *data)

--- a/samples/drivers/ipm/ipm_mcux/remote/src/main_remote.c
+++ b/samples/drivers/ipm/ipm_mcux/remote/src/main_remote.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/ipm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/ipm.h>
 
 void ping_ipm_callback(const struct device *dev, void *context,
 		       uint32_t id, volatile void *data)

--- a/samples/drivers/ipm/ipm_mcux/src/main_master.c
+++ b/samples/drivers/ipm/ipm_mcux/src/main_master.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/ipm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/ipm.h>
 
 int gcounter;
 

--- a/samples/drivers/ipm/ipm_mhu_dual_core/src/main.c
+++ b/samples/drivers/ipm/ipm_mhu_dual_core/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/ipm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/ipm.h>
 
 enum cpu_id_t {
 	MHU_CPU0 = 0,

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/flash.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/flash.h>
 #include <jesd216.h>
 #include <stdio.h>
 #include <inttypes.h>

--- a/samples/drivers/kscan/src/main.c
+++ b/samples/drivers/kscan/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
 #include <soc.h>
-#include <drivers/kscan.h>
+#include <zephyr/drivers/kscan.h>
 
 #define LOG_LEVEL LOG_LEVEL_DBG
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(main);
 

--- a/samples/drivers/kscan_touch/src/main.c
+++ b/samples/drivers/kscan_touch/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
 #include <soc.h>
-#include <drivers/kscan.h>
+#include <zephyr/drivers/kscan.h>
 
 #define LOG_LEVEL LOG_LEVEL_DBG
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(main);
 

--- a/samples/drivers/lcd_hd44780/src/main.c
+++ b/samples/drivers/lcd_hd44780/src/main.c
@@ -64,10 +64,10 @@
  *	--------------------
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
-#include <drivers/gpio.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/gpio.h>
 #include <string.h>
 
 

--- a/samples/drivers/led_apa102/src/main.c
+++ b/samples/drivers/led_apa102/src/main.c
@@ -9,14 +9,14 @@
 #include <string.h>
 
 #define LOG_LEVEL 4
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#include <zephyr.h>
-#include <drivers/led_strip.h>
-#include <device.h>
-#include <drivers/spi.h>
-#include <sys/util.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/led_strip.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/util.h>
 
 /*
  * Number of RGB LEDs in the LED strip, adjust as needed.

--- a/samples/drivers/led_apa102c_bitbang/src/main.c
+++ b/samples/drivers/led_apa102c_bitbang/src/main.c
@@ -16,12 +16,12 @@
  * Protect your eyes and do not look directly into those LEDs.
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 /* in millisecond */
 #define SLEEPTIME	K_MSEC(250)
 

--- a/samples/drivers/led_lp3943/src/main.c
+++ b/samples/drivers/led_lp3943/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
-#include <drivers/led.h>
-#include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/zephyr.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app);
 
 #define NUM_LEDS 16

--- a/samples/drivers/led_lp503x/src/main.c
+++ b/samples/drivers/led_lp503x/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
-#include <drivers/led.h>
-#include <drivers/led/lp503x.h>
-#include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/drivers/led/lp503x.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/zephyr.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #define MAX_BRIGHTNESS	100

--- a/samples/drivers/led_lp5562/src/main.c
+++ b/samples/drivers/led_lp5562/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
-#include <drivers/led.h>
-#include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/zephyr.h>
 
 #define LOG_LEVEL 4
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #define NUM_LEDS 4

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -8,14 +8,14 @@
 #include <string.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#include <zephyr.h>
-#include <drivers/led_strip.h>
-#include <device.h>
-#include <drivers/spi.h>
-#include <sys/util.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/led_strip.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/util.h>
 
 /*
  * Number of RGB LEDs in the LED strip, adjust as needed.

--- a/samples/drivers/led_pca9633/src/main.c
+++ b/samples/drivers/led_pca9633/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
-#include <drivers/led.h>
-#include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/zephyr.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #define NUM_LEDS 4

--- a/samples/drivers/led_pwm/src/main.c
+++ b/samples/drivers/led_pwm/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
-#include <drivers/led.h>
-#include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/drivers/led.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/zephyr.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
 #if DT_NODE_HAS_STATUS(DT_INST(0, pwm_leds), okay)

--- a/samples/drivers/led_sx1509b_intensity/src/main.c
+++ b/samples/drivers/led_sx1509b_intensity/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <drivers/gpio/gpio_sx1509b.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/gpio/gpio_sx1509b.h>
 
 #define NUMBER_OF_LEDS 3
 #define GREEN_LED DT_GPIO_PIN(DT_NODELABEL(led0), gpios)

--- a/samples/drivers/led_ws2812/src/main.c
+++ b/samples/drivers/led_ws2812/src/main.c
@@ -9,14 +9,14 @@
 #include <string.h>
 
 #define LOG_LEVEL 4
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#include <zephyr.h>
-#include <drivers/led_strip.h>
-#include <device.h>
-#include <drivers/spi.h>
-#include <sys/util.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/led_strip.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/util.h>
 
 #define STRIP_NODE		DT_ALIAS(led_strip)
 #define STRIP_NUM_PIXELS	DT_PROP(DT_ALIAS(led_strip), chain_length)

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/lora.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/lora.h>
 #include <errno.h>
-#include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/zephyr.h>
 
 #define DEFAULT_RADIO_NODE DT_ALIAS(lora0)
 BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
@@ -17,7 +17,7 @@ BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
 #define MAX_DATA_LEN 255
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lora_receive);
 
 void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/lora.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/lora.h>
 #include <errno.h>
-#include <sys/util.h>
-#include <zephyr.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/zephyr.h>
 
 #define DEFAULT_RADIO_NODE DT_ALIAS(lora0)
 BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
@@ -17,7 +17,7 @@ BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
 #define MAX_DATA_LEN 10
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lora_send);
 
 char data[MAX_DATA_LEN] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};

--- a/samples/drivers/mbox/remote/src/main.c
+++ b/samples/drivers/mbox/remote/src/main.c
@@ -6,8 +6,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <zephyr.h>
-#include <drivers/mbox.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/mbox.h>
 
 #define TX_ID (0)
 #define RX_ID (1)

--- a/samples/drivers/mbox/src/main.c
+++ b/samples/drivers/mbox/src/main.c
@@ -6,8 +6,8 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <zephyr.h>
-#include <drivers/mbox.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/mbox.h>
 
 #define TX_ID (1)
 #define RX_ID (0)

--- a/samples/drivers/misc/ft800/src/main.c
+++ b/samples/drivers/misc/ft800/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <drivers/misc/ft8xx/ft8xx.h>
-#include <drivers/misc/ft8xx/ft8xx_copro.h>
-#include <drivers/misc/ft8xx/ft8xx_dl.h>
+#include <zephyr/drivers/misc/ft8xx/ft8xx.h>
+#include <zephyr/drivers/misc/ft8xx/ft8xx_copro.h>
+#include <zephyr/drivers/misc/ft8xx/ft8xx_dl.h>
 
 /**
  * @file Display a counter using FT800.

--- a/samples/drivers/misc/grove_display/src/main.c
+++ b/samples/drivers/misc/grove_display/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <device.h>
-#include <drivers/i2c.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/i2c.h>
 
-#include <drivers/misc/grove_lcd/grove_lcd.h>
+#include <zephyr/drivers/misc/grove_lcd/grove_lcd.h>
 
 /**
  * @file Display a counter through I2C and Grove LCD.

--- a/samples/drivers/peci/src/main.c
+++ b/samples/drivers/peci/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/peci.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/peci.h>
 #include <soc.h>
 
 #define TASK_STACK_SIZE         1024

--- a/samples/drivers/ps2/src/main.c
+++ b/samples/drivers/ps2/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/ps2.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/ps2.h>
 #include <soc.h>
 #define LOG_LEVEL LOG_LEVEL_DBG
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #define LOG_MODULE_NAME main
 
 LOG_MODULE_REGISTER();

--- a/samples/drivers/soc_flash_nrf/src/main.c
+++ b/samples/drivers/soc_flash_nrf/src/main.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/flash.h>
-#include <storage/flash_map.h>
-#include <device.h>
-#include <devicetree.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <stdio.h>
 
 

--- a/samples/drivers/spi_bitbang/src/main.c
+++ b/samples/drivers/spi_bitbang/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app, LOG_LEVEL_INF);
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <stdio.h>
 #include <string.h>
-#include <drivers/spi.h>
+#include <zephyr/drivers/spi.h>
 
 #define SPIBB_NODE	DT_NODELABEL(spibb0)
 

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/flash.h>
-#include <device.h>
-#include <devicetree.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/flash.h>
-#include <logging/log_ctrl.h>
-#include <pm/device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/pm/device.h>
 
 #define FLASH_DEVICE        DT_LABEL(DT_INST(0, atmel_at45))
 

--- a/samples/drivers/spi_fujitsu_fram/src/main.c
+++ b/samples/drivers/spi_fujitsu_fram/src/main.c
@@ -5,10 +5,10 @@
  */
 
 #include <errno.h>
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <device.h>
-#include <drivers/spi.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
 
 /**
  * @file Sample app using the Fujitsu MB85RS64V FRAM through SPI.

--- a/samples/drivers/uart/echo_bot/src/main.c
+++ b/samples/drivers/uart/echo_bot/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
 
 #include <string.h>
 

--- a/samples/drivers/uart/stm32/single_wire/src/main.c
+++ b/samples/drivers/uart/stm32/single_wire/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "kernel.h"
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/uart.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/uart.h>
 
 #define UART_NODE1 DT_ALIAS(single_line_uart1)
 #define UART_NODE2 DT_ALIAS(single_line_uart2)

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/watchdog.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/sys/printk.h>
 #include <stdbool.h>
 
 #define WDT_FEED_TRIES 5

--- a/samples/hello_world/src/main.c
+++ b/samples/hello_world/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 void main(void)
 {

--- a/samples/kernel/condition_variables/condvar/src/main.c
+++ b/samples/kernel/condition_variables/condvar/src/main.c
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <arch/cpu.h>
-#include <sys/arch_interface.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/arch_interface.h>
 
 #define NUM_THREADS 3
 #define TCOUNT 10

--- a/samples/kernel/condition_variables/simple/src/main.c
+++ b/samples/kernel/condition_variables/simple/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <arch/cpu.h>
-#include <sys/arch_interface.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/arch_interface.h>
 
 #define NUM_THREADS 20
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)

--- a/samples/kernel/metairq_dispatch/src/main.c
+++ b/samples/kernel/metairq_dispatch/src/main.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "msgdev.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 
 #define STACK_SIZE 2048

--- a/samples/kernel/metairq_dispatch/src/msgdev.c
+++ b/samples/kernel/metairq_dispatch/src/msgdev.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <timeout_q.h>
+#include <zephyr/timeout_q.h>
 #include "msgdev.h"
 
 /* This file implements a fake device that creates and enqueues

--- a/samples/modules/canopennode/src/main.c
+++ b/samples/modules/canopennode/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/gpio.h>
-#include <sys/reboot.h>
-#include <settings/settings.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/settings/settings.h>
 #include <canopennode.h>
 
 #define LOG_LEVEL CONFIG_CANOPEN_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app);
 
 #define CAN_INTERFACE DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus))

--- a/samples/modules/chre/src/echoapp.cpp
+++ b/samples/modules/chre/src/echoapp.cpp
@@ -3,7 +3,7 @@
  */
 
 #include <cinttypes>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 #include "chre_api/chre/event.h"
 #include "chre/core/event_loop_manager.h"

--- a/samples/modules/chre/src/main.cpp
+++ b/samples/modules/chre/src/main.cpp
@@ -2,8 +2,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 #include "apps.hpp"
 #include "chre/core/event_loop_manager.h"

--- a/samples/modules/nanopb/src/main.c
+++ b/samples/modules/nanopb/src/main.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 #include <pb_encode.h>
 #include <pb_decode.h>

--- a/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
+++ b/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
@@ -16,11 +16,11 @@
 
 #include "accelerometer_handler.hpp"
 
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 #include <string.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #define BUFLEN 300
 int begin_index = 0;

--- a/samples/net/capture/src/main.c
+++ b/samples/net/capture/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_capture_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 void main(void)
 {

--- a/samples/net/civetweb/common/include/helper.h
+++ b/samples/net/civetweb/common/include/helper.h
@@ -7,7 +7,7 @@
 #ifndef __HELPER__
 #define __HELPER__
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #define STR_LOG_ALLOC(str)	((str == NULL) ? log_strdup("null") :\
 						  log_strdup(str))

--- a/samples/net/civetweb/common/include/libc_extensions.h
+++ b/samples/net/civetweb/common/include/libc_extensions.h
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
 #include <stdio.h>
 #include <sys/types.h>
-#include <net/socket.h>
+#include <zephyr/net/socket.h>
 
 #define pollfd zsock_pollfd
 #define fcntl zsock_fcntl

--- a/samples/net/civetweb/common/src/libc_extensions.c
+++ b/samples/net/civetweb/common/src/libc_extensions.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lib_extensions, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/net/civetweb/http_server/src/main.c
+++ b/samples/net/civetweb/http_server/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <posix/pthread.h>
-#include <data/json.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/posix/pthread.h>
+#include <zephyr/data/json.h>
 
 #include "civetweb.h"
 

--- a/samples/net/civetweb/websocket_server/src/http_server_handlers.c
+++ b/samples/net/civetweb/websocket_server/src/http_server_handlers.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(http_server_handlers, LOG_LEVEL_DBG);
 
 #include "http_server_handlers.h"

--- a/samples/net/civetweb/websocket_server/src/main.c
+++ b/samples/net/civetweb/websocket_server/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <posix/pthread.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/posix/pthread.h>
 
 #include "civetweb.h"
 

--- a/samples/net/civetweb/websocket_server/src/websocket_server_handlers.c
+++ b/samples/net/civetweb/websocket_server/src/websocket_server_handlers.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(websocket_server_handlers, LOG_LEVEL_DBG);
 
 #include "websocket_server_handlers.h"

--- a/samples/net/cloud/google_iot_mqtt/src/dhcp.c
+++ b/samples/net/cloud/google_iot_mqtt/src/dhcp.c
@@ -6,16 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(net_google_iot_mqtt, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/net_if.h>
-#include <net/net_core.h>
-#include <net/net_context.h>
-#include <net/net_mgmt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_mgmt.h>
 
 static struct net_mgmt_event_callback mgmt_cb;
 

--- a/samples/net/cloud/google_iot_mqtt/src/main.c
+++ b/samples/net/cloud/google_iot_mqtt/src/main.c
@@ -6,17 +6,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "dhcp.h"
 #include "protocol.h"
 
-#include <net/sntp.h>
-#include <net/net_config.h>
-#include <net/net_event.h>
+#include <zephyr/net/sntp.h>
+#include <zephyr/net/net_config.h>
+#include <zephyr/net/net_event.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(net_google_iot_mqtt, LOG_LEVEL_INF);
 

--- a/samples/net/cloud/google_iot_mqtt/src/protocol.c
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.c
@@ -5,18 +5,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(net_google_iot_mqtt, LOG_LEVEL_DBG);
 #include "protocol.h"
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <data/jwt.h>
-#include <drivers/entropy.h>
+#include <zephyr/data/jwt.h>
+#include <zephyr/drivers/entropy.h>
 
-#include <net/tls_credentials.h>
-#include <net/mqtt.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/net/mqtt.h>
 
 #include <mbedtls/platform.h>
 #include <mbedtls/ssl.h>

--- a/samples/net/cloud/google_iot_mqtt/src/protocol.h
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.h
@@ -11,7 +11,7 @@
 #ifndef PROTOCOL_H__
 #define PROTOCOL_H__
 
-#include <net/socket.h>
+#include <zephyr/net/socket.h>
 
 void mqtt_startup(char *hostname, int port);
 

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mqtt_azure, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <net/socket.h>
-#include <net/mqtt.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/mqtt.h>
 
-#include <sys/printk.h>
-#include <random/rand32.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/random/rand32.h>
 #include <string.h>
 #include <errno.h>
 

--- a/samples/net/cloud/tagoio_http_post/src/main.c
+++ b/samples/net/cloud/tagoio_http_post/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tagoio_http_post, CONFIG_TAGOIO_HTTP_POST_LOG_LEVEL);
 
-#include <zephyr.h>
-#include <net/socket.h>
-#include <net/http_client.h>
-#include <random/rand32.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/http_client.h>
+#include <zephyr/random/rand32.h>
 #include <stdio.h>
 
 #include "wifi.h"

--- a/samples/net/cloud/tagoio_http_post/src/sockets.c
+++ b/samples/net/cloud/tagoio_http_post/src/sockets.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(tagoio_http_post, CONFIG_TAGOIO_HTTP_POST_LOG_LEVEL);
 
-#include <net/net_ip.h>
-#include <net/socket.h>
-#include <net/socketutils.h>
-#include <net/dns_resolve.h>
-#include <net/tls_credentials.h>
-#include <net/http_client.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/socketutils.h>
+#include <zephyr/net/dns_resolve.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/net/http_client.h>
 
 #include "sockets.h"
 

--- a/samples/net/cloud/tagoio_http_post/src/wifi.c
+++ b/samples/net/cloud/tagoio_http_post/src/wifi.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(tagoio_http_post, CONFIG_TAGOIO_HTTP_POST_LOG_LEVEL);
 
-#include <net/wifi_mgmt.h>
+#include <zephyr/net/wifi_mgmt.h>
 
 static int connected;
 static struct net_mgmt_event_callback wifi_shell_mgmt_cb;

--- a/samples/net/dhcpv4_client/src/main.c
+++ b/samples/net/dhcpv4_client/src/main.c
@@ -7,18 +7,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_dhcpv4_client_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <linker/sections.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/sections.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/net_if.h>
-#include <net/net_core.h>
-#include <net/net_context.h>
-#include <net/net_mgmt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_mgmt.h>
 
 static struct net_mgmt_event_callback mgmt_cb;
 

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_dns_resolve_client_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <linker/sections.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/sections.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/net_core.h>
-#include <net/net_if.h>
-#include <net/net_mgmt.h>
-#include <net/dns_resolve.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/dns_resolve.h>
 
 #if defined(CONFIG_MDNS_RESOLVER)
 #if defined(CONFIG_NET_IPV4)

--- a/samples/net/dsa/src/dsa_lldp.c
+++ b/samples/net/dsa/src/dsa_lldp.c
@@ -8,16 +8,16 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <net/socket.h>
-#include <net/net_core.h>
-#include <net/net_l2.h>
-#include <net/net_if.h>
-#include <net/socket.h>
-#include <net/ethernet.h>
-#include <net/lldp.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/lldp.h>
 #include <errno.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #include "main.h"
 
 /* Loglevel of dsa_lldp function */

--- a/samples/net/dsa/src/main.c
+++ b/samples/net/dsa/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_dsa_lldp_sample, CONFIG_NET_DSA_LOG_LEVEL);
 
-#include <net/dsa.h>
+#include <zephyr/net/dsa.h>
 #include "main.h"
 
 static void iface_cb(struct net_if *iface, void *user_data)

--- a/samples/net/dsa/src/main.h
+++ b/samples/net/dsa/src/main.h
@@ -7,14 +7,14 @@
 #ifndef __DSA_SAMPLE__
 #define __DSA_SAMPLE__
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 
-#include <net/net_core.h>
-#include <net/net_l2.h>
-#include <net/net_if.h>
-#include <net/socket.h>
-#include <net/ethernet.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/ethernet.h>
 
 #define MCAST_DEST_MAC0 0x01
 #define MCAST_DEST_MAC1 0x80

--- a/samples/net/eth_native_posix/src/main.c
+++ b/samples/net/eth_native_posix/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_native_posix_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 
-#include <net/net_core.h>
+#include <zephyr/net/net_core.h>
 
 /* This application itself does nothing as there is net-shell that can be used
  * to monitor things.

--- a/samples/net/gptp/src/gptp.c
+++ b/samples/net/gptp/src/gptp.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_gptp_sample);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdlib.h>
 
-#include <net/net_core.h>
-#include <net/gptp.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/gptp.h>
 
 #include "ethernet/gptp/gptp_messages.h"
 #include "ethernet/gptp/gptp_data_set.h"

--- a/samples/net/gptp/src/main.c
+++ b/samples/net/gptp/src/main.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_gptp_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 
-#include <net/net_core.h>
-#include <net/net_l2.h>
-#include <net/net_if.h>
-#include <net/ethernet.h>
-#include <net/gptp.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/gptp.h>
 
 extern void init_testing(void);
 

--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <shell/shell.h>
-#include <drivers/uart.h>
-#include <net/net_mgmt.h>
-#include <net/net_event.h>
-#include <net/net_conn_mgr.h>
-#include <drivers/modem/gsm_ppp.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_conn_mgr.h>
+#include <zephyr/drivers/modem/gsm_ppp.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sample_gsm_ppp, LOG_LEVEL_DBG);
 
 static const struct device *gsm_dev;

--- a/samples/net/ipv4_autoconf/src/main.c
+++ b/samples/net/ipv4_autoconf/src/main.c
@@ -7,18 +7,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_ipv4_autoconf_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <linker/sections.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/sections.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/net_if.h>
-#include <net/net_core.h>
-#include <net/net_context.h>
-#include <net/net_mgmt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_mgmt.h>
 
 static struct net_mgmt_event_callback mgmt_cb;
 

--- a/samples/net/lldp/src/main.c
+++ b/samples/net/lldp/src/main.c
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_lldp_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 
-#include <net/net_core.h>
-#include <net/net_l2.h>
-#include <net/net_if.h>
-#include <net/ethernet.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/ethernet.h>
 
 static struct lldp_system_name_tlv {
 	uint16_t type_length;

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -8,14 +8,14 @@
 #define LOG_MODULE_NAME net_lwm2m_client_app
 #define LOG_LEVEL LOG_LEVEL_DBG
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <drivers/hwinfo.h>
-#include <zephyr.h>
-#include <drivers/gpio.h>
-#include <drivers/sensor.h>
-#include <net/lwm2m.h>
+#include <zephyr/drivers/hwinfo.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/net/lwm2m.h>
 
 #define APP_BANNER "Run LWM2M client"
 

--- a/samples/net/mdns_responder/src/main.c
+++ b/samples/net/mdns_responder/src/main.c
@@ -6,11 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_mdns_responder_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <net/net_core.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/net/net_core.h>
 
 extern void service(void);
 

--- a/samples/net/mdns_responder/src/service.c
+++ b/samples/net/mdns_responder/src/service.c
@@ -5,15 +5,15 @@
  */
 
 #include <errno.h>
-#include <net/dns_sd.h>
-#include <net/socket.h>
-#include <posix/netinet/in.h>
+#include <zephyr/net/dns_sd.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/posix/netinet/in.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mdns_echo_service, LOG_LEVEL_DBG);
 
 /* A default port of 0 causes bind(2) to request an ephemeral port */

--- a/samples/net/mqtt_publisher/src/main.c
+++ b/samples/net/mqtt_publisher/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_mqtt_publisher_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <net/socket.h>
-#include <net/mqtt.h>
-#include <random/rand32.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/mqtt.h>
+#include <zephyr/random/rand32.h>
 
 #include <string.h>
 #include <errno.h>
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(net_mqtt_publisher_sample, LOG_LEVEL_DBG);
 #include "config.h"
 
 #if defined(CONFIG_USERSPACE)
-#include <app_memory/app_memdomain.h>
+#include <zephyr/app_memory/app_memdomain.h>
 K_APPMEM_PARTITION_DEFINE(app_partition);
 struct k_mem_domain app_domain;
 #define APP_BMEM K_APP_BMEM(app_partition)

--- a/samples/net/openthread/coprocessor/src/main.c
+++ b/samples/net/openthread/coprocessor/src/main.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(ot_br, LOG_LEVEL_DBG);
 
 #define APP_BANNER "***** OpenThread NCP on Zephyr %s *****"

--- a/samples/net/promiscuous_mode/src/main.c
+++ b/samples/net/promiscuous_mode/src/main.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_promisc_sample, LOG_LEVEL_INF);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdlib.h>
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 
-#include <net/net_core.h>
-#include <net/promiscuous.h>
-#include <net/udp.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/promiscuous.h>
+#include <zephyr/net/udp.h>
 
 static void net_pkt_hexdump(struct net_pkt *pkt, const char *str)
 {

--- a/samples/net/sockets/big_http_download/src/big_http_download.c
+++ b/samples/net/sockets/big_http_download/src/big_http_download.c
@@ -21,11 +21,11 @@
 
 #else
 
-#include <net/socket.h>
-#include <kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/kernel.h>
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
-#include <net/tls_credentials.h>
+#include <zephyr/net/tls_credentials.h>
 #include "ca_certificate.h"
 #endif
 

--- a/samples/net/sockets/can/src/main.c
+++ b/samples/net/sockets/can/src/main.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_socket_can_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/socket.h>
-#include <net/socket_can.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/socket_can.h>
 
 #ifdef CONFIG_SAMPLE_SOCKETCAN_LOOPBACK_MODE
-#include <drivers/can.h>
+#include <zephyr/drivers/can.h>
 #endif
 
 #define PRIORITY  k_thread_priority_get(k_current_get())

--- a/samples/net/sockets/coap_client/src/coap-client.c
+++ b/samples/net/sockets/coap_client/src/coap-client.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_coap_client_sample, LOG_LEVEL_DBG);
 
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <net/socket.h>
-#include <net/net_mgmt.h>
-#include <net/net_ip.h>
-#include <net/udp.h>
-#include <net/coap.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/udp.h>
+#include <zephyr/net/coap.h>
 
 #include "net_private.h"
 

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_coap_server_sample, LOG_LEVEL_DBG);
 
 #include <errno.h>
-#include <sys/printk.h>
-#include <sys/byteorder.h>
-#include <zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/zephyr.h>
 
-#include <net/socket.h>
-#include <net/net_mgmt.h>
-#include <net/net_ip.h>
-#include <net/udp.h>
-#include <net/coap.h>
-#include <net/coap_link_format.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/udp.h>
+#include <zephyr/net/coap.h>
+#include <zephyr/net/coap_link_format.h>
 
 #include "net_private.h"
 #if defined(CONFIG_NET_IPV6)

--- a/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
+++ b/samples/net/sockets/dumb_http_server/src/socket_dumb_http.c
@@ -17,10 +17,10 @@
 
 #else
 
-#include <net/socket.h>
-#include <kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/kernel.h>
 
-#include <net/net_pkt.h>
+#include <zephyr/net/net_pkt.h>
 
 #endif
 

--- a/samples/net/sockets/dumb_http_server_mt/src/main.c
+++ b/samples/net/sockets/dumb_http_server_mt/src/main.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #define LOG_LEVEL LOG_LEVEL_DBG
 LOG_MODULE_REGISTER(net_dumb_http_srv_mt_sample);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
-#include <net/net_ip.h>
-#include <net/socket.h>
-#include <net/tls_credentials.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
 
-#include <net/net_mgmt.h>
-#include <net/net_event.h>
-#include <net/net_conn_mgr.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_conn_mgr.h>
 
 #define MY_PORT 8080
 

--- a/samples/net/sockets/echo/src/socket_echo.c
+++ b/samples/net/sockets/echo/src/socket_echo.c
@@ -17,8 +17,8 @@
 
 #else
 
-#include <net/socket.h>
-#include <kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/kernel.h>
 
 #endif
 

--- a/samples/net/sockets/echo_async/src/socket_echo.c
+++ b/samples/net/sockets/echo_async/src/socket_echo.c
@@ -23,8 +23,8 @@
 #else
 
 #include <fcntl.h>
-#include <net/socket.h>
-#include <kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/kernel.h>
 
 #ifdef CONFIG_NET_IPV6
 #define USE_IPV6

--- a/samples/net/sockets/echo_async_select/src/socket_echo_select.c
+++ b/samples/net/sockets/echo_async_select/src/socket_echo_select.c
@@ -25,8 +25,8 @@
 #else
 
 #include <fcntl.h>
-#include <net/socket.h>
-#include <kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/kernel.h>
 
 /* Generic read()/write() are not defined, so use socket-specific recv(). */
 #define READ(fd, buf, sz) recv(fd, buf, sz, 0)

--- a/samples/net/sockets/echo_client/src/common.h
+++ b/samples/net/sockets/echo_client/src/common.h
@@ -11,7 +11,7 @@
 #define PEER_PORT 4242
 
 #if defined(CONFIG_USERSPACE)
-#include <app_memory/app_memdomain.h>
+#include <zephyr/app_memory/app_memdomain.h>
 extern struct k_mem_partition app_partition;
 extern struct k_mem_domain app_domain;
 #define APP_BMEM K_APP_BMEM(app_partition)

--- a/samples/net/sockets/echo_client/src/echo-client.c
+++ b/samples/net/sockets/echo_client/src/echo-client.c
@@ -17,22 +17,22 @@
  * This might not be what you want to do in your app so caveat emptor.
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_echo_client_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/socket.h>
-#include <net/tls_credentials.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
 
-#include <net/net_mgmt.h>
-#include <net/net_event.h>
-#include <net/net_conn_mgr.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_conn_mgr.h>
 
 #if defined(CONFIG_USERSPACE)
-#include <app_memory/app_memdomain.h>
+#include <zephyr/app_memory/app_memdomain.h>
 K_APPMEM_PARTITION_DEFINE(app_partition);
 struct k_mem_domain app_domain;
 #endif

--- a/samples/net/sockets/echo_client/src/tcp.c
+++ b/samples/net/sockets/echo_client/src/tcp.c
@@ -7,16 +7,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/socket.h>
-#include <net/tls_credentials.h>
-#include <random/rand32.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/random/rand32.h>
 
 #include "common.h"
 #include "ca_certificate.h"

--- a/samples/net/sockets/echo_client/src/udp.c
+++ b/samples/net/sockets/echo_client/src/udp.c
@@ -7,16 +7,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/socket.h>
-#include <net/tls_credentials.h>
-#include <random/rand32.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/random/rand32.h>
 
 #include "common.h"
 #include "ca_certificate.h"

--- a/samples/net/sockets/echo_client/src/vlan.c
+++ b/samples/net/sockets/echo_client/src/vlan.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_client_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/ethernet.h>
+#include <zephyr/net/ethernet.h>
 
 /* User data for the interface callback */
 struct ud {

--- a/samples/net/sockets/echo_server/src/common.h
+++ b/samples/net/sockets/echo_server/src/common.h
@@ -24,7 +24,7 @@
 #define STATS_TIMER 60 /* How often to print statistics (in seconds) */
 
 #if defined(CONFIG_USERSPACE)
-#include <app_memory/app_memdomain.h>
+#include <zephyr/app_memory/app_memdomain.h>
 extern struct k_mem_partition app_partition;
 extern struct k_mem_domain app_domain;
 #define APP_BMEM K_APP_BMEM(app_partition)

--- a/samples/net/sockets/echo_server/src/echo-server.c
+++ b/samples/net/sockets/echo_server/src/echo-server.c
@@ -7,20 +7,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_echo_server_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <linker/sections.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/sections.h>
 #include <errno.h>
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 
-#include <net/net_core.h>
-#include <net/tls_credentials.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/tls_credentials.h>
 
-#include <net/net_mgmt.h>
-#include <net/net_event.h>
-#include <net/net_conn_mgr.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_conn_mgr.h>
 
 #include "common.h"
 #include "certificate.h"

--- a/samples/net/sockets/echo_server/src/tcp.c
+++ b/samples/net/sockets/echo_server/src/tcp.c
@@ -7,15 +7,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_server_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/socket.h>
-#include <net/tls_credentials.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
 
 #include "common.h"
 #include "certificate.h"

--- a/samples/net/sockets/echo_server/src/tunnel.c
+++ b/samples/net/sockets/echo_server/src/tunnel.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_server_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/ethernet.h>
-#include <net/virtual_mgmt.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/virtual_mgmt.h>
 
 /* User data for the interface callback */
 struct ud {

--- a/samples/net/sockets/echo_server/src/udp.c
+++ b/samples/net/sockets/echo_server/src/udp.c
@@ -7,15 +7,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_server_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/socket.h>
-#include <net/tls_credentials.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
 
 #include "common.h"
 #include "certificate.h"

--- a/samples/net/sockets/echo_server/src/usb.c
+++ b/samples/net/sockets/echo_server/src/usb.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_server_sample, LOG_LEVEL_DBG);
 
-#include <usb/usb_device.h>
-#include <net/net_config.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/net/net_config.h>
 
 int init_usb(void)
 {

--- a/samples/net/sockets/echo_server/src/vlan.c
+++ b/samples/net/sockets/echo_server/src/vlan.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_echo_server_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/ethernet.h>
+#include <zephyr/net/ethernet.h>
 
 /* User data for the interface callback */
 struct ud {

--- a/samples/net/sockets/http_client/src/main.c
+++ b/samples/net/sockets/http_client/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_http_client_sample, LOG_LEVEL_DBG);
 
-#include <net/net_ip.h>
-#include <net/socket.h>
-#include <net/tls_credentials.h>
-#include <net/http_client.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/net/http_client.h>
 
 #include "ca_certificate.h"
 

--- a/samples/net/sockets/http_get/src/http_get.c
+++ b/samples/net/sockets/http_get/src/http_get.c
@@ -17,11 +17,11 @@
 
 #else
 
-#include <net/socket.h>
-#include <kernel.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/kernel.h>
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
-#include <net/tls_credentials.h>
+#include <zephyr/net/tls_credentials.h>
 #include "ca_certificate.h"
 #endif
 

--- a/samples/net/sockets/net_mgmt/src/main.c
+++ b/samples/net/sockets/net_mgmt/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_mgmt_sock_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
-#include <net/socket.h>
-#include <net/socket_net_mgmt.h>
-#include <net/net_if.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/socket_net_mgmt.h>
+#include <zephyr/net/net_if.h>
 
 #define MAX_BUF_LEN 64
 #define STACK_SIZE 1024

--- a/samples/net/sockets/packet/src/packet.c
+++ b/samples/net/sockets/packet/src/packet.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_pkt_sock_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/socket.h>
-#include <net/ethernet.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/ethernet.h>
 
 #define STACK_SIZE 1024
 #if IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE)

--- a/samples/net/sockets/sntp_client/src/main.c
+++ b/samples/net/sockets/sntp_client/src/main.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_sntp_client_sample, LOG_LEVEL_DBG);
 
-#include <net/sntp.h>
+#include <zephyr/net/sntp.h>
 #ifdef CONFIG_POSIX_API
 #include <arpa/inet.h>
 #endif

--- a/samples/net/sockets/socketpair/src/socketpair_example.c
+++ b/samples/net/sockets/socketpair/src/socketpair_example.c
@@ -7,10 +7,10 @@
 	|| defined(CONFIG_BOARD_NATIVE_POSIX_64BIT) \
 	|| defined(CONFIG_SOC_SERIES_BSIM_NRFXX))
 
-#include <net/socket.h>
-#include <posix/pthread.h>
-#include <sys/util.h>
-#include <posix/unistd.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/posix/pthread.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/posix/unistd.h>
 
 #else
 

--- a/samples/net/sockets/tcp/src/main.c
+++ b/samples/net/sockets/tcp/src/main.c
@@ -10,9 +10,9 @@
 #include <stdlib.h>
 #include <errno.h>
 
-#include <net/socket.h>
+#include <zephyr/net/socket.h>
 
-#include <data/json.h>
+#include <zephyr/data/json.h>
 #include <tp.h>
 
 #define UDP_PORT 4242

--- a/samples/net/sockets/txtime/src/main.c
+++ b/samples/net/sockets/txtime/src/main.c
@@ -4,23 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_txtime_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 #include <stdio.h>
 #include <inttypes.h>
-#include <drivers/ptp_clock.h>
-#include <shell/shell.h>
+#include <zephyr/drivers/ptp_clock.h>
+#include <zephyr/shell/shell.h>
 
-#include <net/net_mgmt.h>
-#include <net/net_event.h>
-#include <net/net_conn_mgr.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_conn_mgr.h>
 
-#include <net/socket.h>
-#include <net/ethernet.h>
-#include <net/ethernet_mgmt.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/ethernet_mgmt.h>
 
 #define APP_BANNER "Run SO_TXTIME client"
 

--- a/samples/net/sockets/txtime/src/vlan.c
+++ b/samples/net/sockets/txtime/src/vlan.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_txtime_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/ethernet.h>
+#include <zephyr/net/ethernet.h>
 
 /* User data for the interface callback */
 struct ud {

--- a/samples/net/sockets/websocket_client/src/main.c
+++ b/samples/net/sockets/websocket_client/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_websocket_client_sample, LOG_LEVEL_DBG);
 
-#include <net/net_ip.h>
-#include <net/socket.h>
-#include <net/tls_credentials.h>
-#include <net/websocket.h>
-#include <random/rand32.h>
-#include <shell/shell.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/socket.h>
+#include <zephyr/net/tls_credentials.h>
+#include <zephyr/net/websocket.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/shell/shell.h>
 
 #include "ca_certificate.h"
 

--- a/samples/net/stats/src/main.c
+++ b/samples/net/stats/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_stats_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 
-#include <net/net_core.h>
-#include <net/net_if.h>
-#include <net/net_stats.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_stats.h>
 
 static struct k_work_delayable stats_timer;
 

--- a/samples/net/syslog_net/src/main.c
+++ b/samples/net/syslog_net/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_syslog, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <logging/log_backend.h>
+#include <zephyr/logging/log_backend.h>
 
 #include <stdlib.h>
 

--- a/samples/net/telnet/src/telnet.c
+++ b/samples/net/telnet/src/telnet.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_telnet_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <linker/sections.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/sections.h>
 #include <errno.h>
 #include <stdio.h>
 
-#include <net/net_core.h>
-#include <net/net_if.h>
-#include <net/net_mgmt.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_mgmt.h>
 
 #if defined(CONFIG_NET_DHCPV4)
 static struct net_mgmt_event_callback mgmt_cb;

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_virtual_interface_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #include <errno.h>
 
-#include <net/net_core.h>
-#include <net/ethernet.h>
-#include <net/virtual.h>
-#include <net/virtual_mgmt.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/ethernet.h>
+#include <zephyr/net/virtual.h>
+#include <zephyr/net/virtual_mgmt.h>
 
 /* User data for the interface callback */
 struct ud {

--- a/samples/net/vlan/src/main.c
+++ b/samples/net/vlan/src/main.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_vlan_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 
-#include <net/net_core.h>
-#include <net/net_l2.h>
-#include <net/net_if.h>
-#include <net/ethernet.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_l2.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/ethernet.h>
 
 #if CONFIG_NET_VLAN_COUNT > 1
 #define CREATE_MULTIPLE_TAGS

--- a/samples/net/wifi/src/wifi_test.c
+++ b/samples/net/wifi/src/wifi_test.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <errno.h>
 
 void main(void)

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -12,17 +12,17 @@
  * with popular Contiki-based native border routers.
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wpan_serial, CONFIG_USB_DEVICE_LOG_LEVEL);
 
-#include <drivers/uart.h>
-#include <zephyr.h>
-#include <usb/usb_device.h>
-#include <random/rand32.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/random/rand32.h>
 
-#include <net/buf.h>
+#include <zephyr/net/buf.h>
 #include <net_private.h>
-#include <net/ieee802154_radio.h>
+#include <zephyr/net/ieee802154_radio.h>
 
 #if IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE)
 #define THREAD_PRIORITY K_PRIO_COOP(CONFIG_NUM_COOP_PRIORITIES - 1)

--- a/samples/net/wpanusb/src/wpanusb.c
+++ b/samples/net/wpanusb/src/wpanusb.c
@@ -5,14 +5,14 @@
  */
 
 #define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wpanusb);
 
-#include <usb/usb_device.h>
+#include <zephyr/usb/usb_device.h>
 #include <usb_descriptor.h>
 
-#include <net/buf.h>
-#include <net/ieee802154_radio.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/net/ieee802154_radio.h>
 #include <ieee802154/ieee802154_frame.h>
 #include <net_private.h>
 

--- a/samples/net/zperf/src/main.c
+++ b/samples/net/zperf/src/main.c
@@ -8,8 +8,8 @@
  * @file
  * @brief Zperf sample.
  */
-#include <usb/usb_device.h>
-#include <net/net_config.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/net/net_config.h>
 
 void main(void)
 {

--- a/samples/net/zperf/src/shell_utils.c
+++ b/samples/net/zperf/src/shell_utils.c
@@ -5,12 +5,12 @@
  */
 
 #include <ctype.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "shell_utils.h"
 

--- a/samples/net/zperf/src/shell_utils.h
+++ b/samples/net/zperf/src/shell_utils.h
@@ -6,7 +6,7 @@
 #ifndef __SHELL_UTILS_H
 #define __SHELL_UTILS_H
 
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 
 #define IPV4_STR_LEN_MAX 15
 #define IPV4_STR_LEN_MIN 7

--- a/samples/net/zperf/src/zperf_internal.h
+++ b/samples/net/zperf/src/zperf_internal.h
@@ -7,8 +7,8 @@
 #define __ZPERF_INTERNAL_H
 
 #include <limits.h>
-#include <net/net_ip.h>
-#include <shell/shell.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/shell/shell.h>
 
 #define IP6PREFIX_STR2(s) #s
 #define IP6PREFIX_STR(p) IP6PREFIX_STR2(p)

--- a/samples/net/zperf/src/zperf_session.c
+++ b/samples/net/zperf/src/zperf_session.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_zperf_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/net_pkt.h>
-#include <net/udp.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/udp.h>
 
 #include "zperf_session.h"
 

--- a/samples/net/zperf/src/zperf_session.h
+++ b/samples/net/zperf/src/zperf_session.h
@@ -6,14 +6,14 @@
 #ifndef __ZPERF_SESSION_H
 #define __ZPERF_SESSION_H
 
-#include <linker/sections.h>
-#include <toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/toolchain.h>
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <net/net_ip.h>
-#include <net/net_core.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_core.h>
 
 #include "zperf.h"
 #include "zperf_internal.h"

--- a/samples/net/zperf/src/zperf_shell.c
+++ b/samples/net/zperf/src/zperf_shell.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(net_zperf_sample, LOG_LEVEL_DBG);
 
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <shell/shell.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/shell/shell.h>
 
-#include <net/net_ip.h>
-#include <net/net_core.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_core.h>
 
 #include "zperf.h"
 #include "zperf_internal.h"

--- a/samples/net/zperf/src/zperf_tcp_receiver.c
+++ b/samples/net/zperf/src/zperf_tcp_receiver.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_zperf_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <linker/sections.h>
-#include <toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/toolchain.h>
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <net/net_core.h>
-#include <net/net_ip.h>
-#include <net/net_pkt.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_pkt.h>
 
 #include "zperf.h"
 #include "zperf_internal.h"

--- a/samples/net/zperf/src/zperf_tcp_uploader.c
+++ b/samples/net/zperf/src/zperf_tcp_uploader.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_zperf_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include <errno.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <net/net_pkt.h>
-#include <net/net_ip.h>
-#include <net/net_core.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_core.h>
 
 #include "zperf.h"
 #include "zperf_internal.h"

--- a/samples/net/zperf/src/zperf_udp_receiver.c
+++ b/samples/net/zperf/src/zperf_udp_receiver.c
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_zperf_sample, LOG_LEVEL_DBG);
 
-#include <linker/sections.h>
-#include <toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/toolchain.h>
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <net/net_core.h>
-#include <net/net_pkt.h>
-#include <net/udp.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_pkt.h>
+#include <zephyr/net/udp.h>
 
 #include "zperf.h"
 #include "zperf_internal.h"

--- a/samples/net/zperf/src/zperf_udp_uploader.c
+++ b/samples/net/zperf/src/zperf_udp_uploader.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(net_zperf_sample, LOG_LEVEL_DBG);
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <net/net_core.h>
-#include <net/net_ip.h>
-#include <net/net_pkt.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_ip.h>
+#include <zephyr/net/net_pkt.h>
 
 #include "zperf.h"
 #include "zperf_internal.h"

--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -35,15 +35,15 @@
  * header file.
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 #include <stdio.h>
 #else
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #endif
 
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #define SEMAPHORES 1
 #define MUTEXES 2

--- a/samples/sensor/adc_cmp_npcx/src/main.c
+++ b/samples/sensor/adc_cmp_npcx/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/sensor.h>
-#include <drivers/sensor/adc_cmp_npcx.h>
-#include <sys/atomic.h>
-#include <zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/adc_cmp_npcx.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/zephyr.h>
 
 #include <stdio.h>
 

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #define DELAY_WITH_TRIGGER K_SECONDS(5)
 #define DELAY_WITHOUT_TRIGGER K_SECONDS(1)

--- a/samples/sensor/adxl362/src/main.c
+++ b/samples/sensor/adxl362/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 
 K_SEM_DEFINE(sem, 0, 1);
 

--- a/samples/sensor/adxl372/src/main.c
+++ b/samples/sensor/adxl372/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 #define pow2(x) ((x) * (x))

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
 
 static struct sensor_value temp_value[64];
 

--- a/samples/sensor/ams_iAQcore/src/main.c
+++ b/samples/sensor/ams_iAQcore/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
 
 void main(void)
 {

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/device.h>
 #include <stdio.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 #ifdef CONFIG_APDS9960_TRIGGER
 K_SEM_DEFINE(sem, 0, 1);

--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
 
 /*
  * Get a device structure from a devicetree node with compatible

--- a/samples/sensor/bme680/src/main.c
+++ b/samples/sensor/bme680/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 void main(void)

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
-#include <sys_clock.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys_clock.h>
 #include <stdio.h>
 
-#include <device.h>
-#include <drivers/sensor.h>
-#include <drivers/i2c.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
 
 #define MAX_TEST_TIME	15000
 #define SLEEPTIME	300

--- a/samples/sensor/bmi270/src/main.c
+++ b/samples/sensor/bmi270/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 void main(void)

--- a/samples/sensor/bmm150/src/main.c
+++ b/samples/sensor/bmm150/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <sys/printk.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 void do_main(const struct device *dev)

--- a/samples/sensor/bq274xx/src/main.c
+++ b/samples/sensor/bq274xx/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
 
 static void bq274xx_show_values(const char *type, struct sensor_value value)
 {

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
-#include <drivers/sensor/ccs811.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/sensor/ccs811.h>
 #include <stdio.h>
 
 static bool app_fw_2;

--- a/samples/sensor/dht/src/main.c
+++ b/samples/sensor/dht/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 static const char *now_str(void)

--- a/samples/sensor/dps310/src/main.c
+++ b/samples/sensor/dps310/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdlib.h>
 
 void main(void)

--- a/samples/sensor/ens210/src/main.c
+++ b/samples/sensor/ens210/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
 
 void main(void)
 {

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <sys/util.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/sensor.h>
 #include "drivers/sensor/fdc2x1x.h"
 #include <stdio.h>
 

--- a/samples/sensor/fxas21002/src/main.c
+++ b/samples/sensor/fxas21002/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 K_SEM_DEFINE(sem, 0, 1);	/* starts off "not available" */

--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -5,12 +5,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <usb/usb_device.h>
-#include <usb/class/usb_hid.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_hid.h>
 
 #define LOG_LEVEL LOG_LEVEL_DBG
 LOG_MODULE_REGISTER(main);
@@ -38,7 +38,7 @@ LOG_MODULE_REGISTER(main);
 #define LED_FLAGS	DT_GPIO_FLAGS(DT_ALIAS(led0), gpios)
 
 #ifdef CONFIG_FXOS8700
-#include <drivers/sensor.h>
+#include <zephyr/drivers/sensor.h>
 #define SENSOR_ACCEL_NAME DT_LABEL(DT_INST(0, nxp_fxos8700))
 #endif
 

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 K_SEM_DEFINE(sem, 0, 1);	/* starts off "not available" */

--- a/samples/sensor/grove_light/src/main.c
+++ b/samples/sensor/grove_light/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <init.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
 #include <stdio.h>
-#include <drivers/sensor.h>
+#include <zephyr/drivers/sensor.h>
 
 #define SLEEP_TIME	K_MSEC(1000)
 

--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <init.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
 #include <stdio.h>
-#include <drivers/sensor.h>
+#include <zephyr/drivers/sensor.h>
 
 #ifdef CONFIG_GROVE_LCD_RGB
-#include <drivers/misc/grove_lcd/grove_lcd.h>
+#include <zephyr/drivers/misc/grove_lcd/grove_lcd.h>
 #include <stdio.h>
 #include <string.h>
 #endif

--- a/samples/sensor/hmc5883l/src/main.c
+++ b/samples/sensor/hmc5883l/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 
 static int32_t read_sensor(const struct device *sensor)

--- a/samples/sensor/hts221/src/main.c
+++ b/samples/sensor/hts221/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 static void process_sample(const struct device *dev)
 {

--- a/samples/sensor/i3g4250d/src/main.c
+++ b/samples/sensor/i3g4250d/src/main.c
@@ -5,9 +5,9 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 
 #define SAMPLING_INTERVAL_MS 10
 #define DISPLAY_INTERVAL_MS 50

--- a/samples/sensor/icm42605/src/main.c
+++ b/samples/sensor/icm42605/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 static const char *now_str(void)

--- a/samples/sensor/ina219/src/main.c
+++ b/samples/sensor/ina219/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
-#include <drivers/sensor.h>
+#include <zephyr/drivers/sensor.h>
 
 
 void main(void)

--- a/samples/sensor/isl29035/src/main.c
+++ b/samples/sensor/isl29035/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #define LUX_ALERT_DELTA 50
 

--- a/samples/sensor/lis2dh/src/main.c
+++ b/samples/sensor/lis2dh/src/main.c
@@ -5,9 +5,9 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 
 static void fetch_and_display(const struct device *sensor)
 {

--- a/samples/sensor/lps22hb/src/main.c
+++ b/samples/sensor/lps22hb/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 static void process_sample(const struct device *dev)
 {

--- a/samples/sensor/lps22hh/src/main.c
+++ b/samples/sensor/lps22hh/src/main.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 static void process_sample(const struct device *dev)
 {

--- a/samples/sensor/lsm303dlhc/src/main.c
+++ b/samples/sensor/lsm303dlhc/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 static int32_t read_sensor(const struct device *sensor,
 			   enum sensor_channel channel)

--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 static inline float out_ev(struct sensor_value *val)
 {

--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -5,9 +5,9 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 
 #define LSM6DSO DT_INST(0, st_lsm6dso)
 

--- a/samples/sensor/magn_polling/src/main.c
+++ b/samples/sensor/magn_polling/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
 #include <stdio.h>
 
 static void do_main(const struct device *dev)

--- a/samples/sensor/max17262/src/main.c
+++ b/samples/sensor/max17262/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
 
 #define MAX17262 DT_INST(0, maxim_max17262)
 

--- a/samples/sensor/max30101/src/main.c
+++ b/samples/sensor/max30101/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 void main(void)

--- a/samples/sensor/max44009/src/main.c
+++ b/samples/sensor/max44009/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/sensor.h>
 
 /**
  * @file Sample app using the MAX44009 light sensor through ARC I2C.

--- a/samples/sensor/max6675/src/main.c
+++ b/samples/sensor/max6675/src/main.c
@@ -6,9 +6,9 @@
 
 #include <stdio.h>
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 
 /**
  * @file Sample app using the MAX6675 cold-junction-compensated K-thermocouple

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 #define UCEL_PER_CEL 1000000

--- a/samples/sensor/mcux_acmp/src/main.c
+++ b/samples/sensor/mcux_acmp/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/sensor.h>
-#include <drivers/sensor/mcux_acmp.h>
-#include <zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/mcux_acmp.h>
+#include <zephyr/zephyr.h>
 
 #include <stdio.h>
 

--- a/samples/sensor/mhz19b/src/main.c
+++ b/samples/sensor/mhz19b/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <drivers/sensor.h>
-#include <drivers/sensor/mhz19b.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/mhz19b.h>
 
 void main(void)
 {

--- a/samples/sensor/mpr/src/main.c
+++ b/samples/sensor/mpr/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 void main(void)

--- a/samples/sensor/mpu6050/src/main.c
+++ b/samples/sensor/mpu6050/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 static const char *now_str(void)

--- a/samples/sensor/ms5837/src/main.c
+++ b/samples/sensor/ms5837/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 void main(void)

--- a/samples/sensor/qdec/src/main.c
+++ b/samples/sensor/qdec/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 void main(void)

--- a/samples/sensor/sensor_shell/src/main.c
+++ b/samples/sensor/sensor_shell/src/main.c
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(app);

--- a/samples/sensor/sgp40_sht4x/src/main.c
+++ b/samples/sensor/sgp40_sht4x/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
-#include <drivers/sensor/sgp40.h>
-#include <drivers/sensor/sht4x.h>
+#include <zephyr/drivers/sensor/sgp40.h>
+#include <zephyr/drivers/sensor/sht4x.h>
 
 #if !DT_HAS_COMPAT_STATUS_OKAY(sensirion_sgp40)
 #error "No sensirion,sgp40 compatible node found in the device tree"

--- a/samples/sensor/sht3xd/src/main.c
+++ b/samples/sensor/sht3xd/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 #define ALERT_HUMIDITY_LO 50

--- a/samples/sensor/sm351lt/src/main.c
+++ b/samples/sensor/sm351lt/src/main.c
@@ -6,10 +6,10 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
 
 static void fetch_and_display(const struct device *sensor)
 {

--- a/samples/sensor/stm32_temp_sensor/src/main.c
+++ b/samples/sensor/stm32_temp_sensor/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
 
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp)
 #define TEMP_NODE DT_INST(0, st_stm32_temp)

--- a/samples/sensor/sx9500/src/main.c
+++ b/samples/sensor/sx9500/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #ifdef CONFIG_SX9500_TRIGGER
 
 static void sensor_trigger_handler(const struct device *dev,

--- a/samples/sensor/th02/src/main.c
+++ b/samples/sensor/th02/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 
-#include <drivers/misc/grove_lcd/grove_lcd.h>
+#include <zephyr/drivers/misc/grove_lcd/grove_lcd.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/samples/sensor/thermometer/src/main.c
+++ b/samples/sensor/thermometer/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
 
 void main(void)

--- a/samples/sensor/ti_hdc/src/main.c
+++ b/samples/sensor/ti_hdc/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
-#include <sys/__assert.h>
-#include <logging/log.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/gpio.h>
 
 void main(void)
 {

--- a/samples/sensor/tmp108/src/main.c
+++ b/samples/sensor/tmp108/src/main.c
@@ -6,9 +6,9 @@
 
 #include <stdio.h>
 
-#include <zephyr.h>
-#include <drivers/sensor.h>
-#include <drivers/sensor/tmp108.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/sensor/tmp108.h>
 
 void temperature_one_shot(const struct device *dev,
 			  const struct sensor_trigger *trigger)

--- a/samples/sensor/tmp112/src/main.c
+++ b/samples/sensor/tmp112/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <sys/printk.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/__assert.h>
 
 static void do_main(const struct device *dev)
 {

--- a/samples/sensor/tmp116/src/main.c
+++ b/samples/sensor/tmp116/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <drivers/eeprom.h>
-#include <drivers/sensor/tmp116.h>
-#include <sys/printk.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/eeprom.h>
+#include <zephyr/drivers/sensor/tmp116.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/__assert.h>
 
 static uint8_t eeprom_content[EEPROM_TMP116_SIZE];
 

--- a/samples/sensor/vcnl4040/src/main.c
+++ b/samples/sensor/vcnl4040/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
-#include <sys_clock.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys_clock.h>
 #include <stdio.h>
 
-#include <device.h>
-#include <drivers/sensor.h>
-#include <drivers/i2c.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
 
 #define MAX_TEST_TIME	5000
 #define SLEEPTIME	300

--- a/samples/sensor/vl53l0x/src/main.c
+++ b/samples/sensor/vl53l0x/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 void main(void)
 {

--- a/samples/sensor/wsen_itds/src/main.c
+++ b/samples/sensor/wsen_itds/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <sys/printk.h>
-#include <sys_clock.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys_clock.h>
 #include <stdio.h>
 
-#include <device.h>
-#include <drivers/sensor.h>
-#include <drivers/i2c.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
 
 #define MAX_TEST_TIME	5000
 #define SLEEPTIME	300

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/adc.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/adc.h>
 #include <stdio.h>
 #include <math.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 /* Nominal RTD (PT100) resistance in ohms */

--- a/samples/shields/x_nucleo_53l0a1/src/display_7seg.c
+++ b/samples/shields/x_nucleo_53l0a1/src/display_7seg.c
@@ -6,8 +6,8 @@
 
 #include "display_7seg.h"
 
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 
 const uint8_t DISPLAY_OFF[4] = { CHAR_OFF, CHAR_OFF, CHAR_OFF, CHAR_OFF };
 const uint8_t TEXT_Err[4] = { CHAR_E, CHAR_r, CHAR_r, CHAR_OFF };

--- a/samples/shields/x_nucleo_53l0a1/src/main.c
+++ b/samples/shields/x_nucleo_53l0a1/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/gpio.h>
 
 #include "display_7seg.h"
 

--- a/samples/shields/x_nucleo_iks01a1/src/main.c
+++ b/samples/shields/x_nucleo_iks01a1/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_LIS3MDL_TRIGGER
 static int lis3mdl_trig_cnt;

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_LSM6DSL_TRIGGER
 static int lsm6dsl_trig_cnt;

--- a/samples/shields/x_nucleo_iks01a2/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/standard/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_LSM6DSL_TRIGGER
 static int lsm6dsl_trig_cnt;

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_LIS2DW12_TRIGGER
 static int lis2dw12_trig_cnt;

--- a/samples/shields/x_nucleo_iks01a3/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/standard/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_LIS2MDL_TRIGGER
 static int lis2mdl_trig_cnt;

--- a/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
@@ -5,10 +5,10 @@
  */
 
 #include <string.h>
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
-#include <audio/dmic.h>
+#include <zephyr/audio/dmic.h>
 
 /* uncomment if you want PCM output in ascii */
 /*#define PCM_OUTPUT_IN_ASCII		1  */

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_IIS2DLPC_TRIGGER
 static int iis2dlpc_trig_cnt;

--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/sensor.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
 #include <stdio.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_IIS2DLPC_TRIGGER
 static int iis2dlpc_trig_cnt;

--- a/samples/subsys/audio/sof/src/main.c
+++ b/samples/subsys/audio/sof/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, LOG_LEVEL_DBG);
 
 /**

--- a/samples/subsys/canbus/isotp/src/main.c
+++ b/samples/subsys/canbus/isotp/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <canbus/isotp.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/canbus/isotp.h>
 
 
 #define RX_THREAD_STACK_SIZE 512

--- a/samples/subsys/console/echo/src/main.c
+++ b/samples/subsys/console/echo/src/main.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <console/console.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/console/console.h>
 
 static const char prompt[] = "Start typing characters to see them echoed back\r\n";
 

--- a/samples/subsys/console/getchar/src/main.c
+++ b/samples/subsys/console/getchar/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <console/console.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/console/console.h>
 
 void main(void)
 {

--- a/samples/subsys/console/getline/src/main.c
+++ b/samples/subsys/console/getline/src/main.c
@@ -5,9 +5,9 @@
  */
 
 #include <string.h>
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <console/console.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/console/console.h>
 
 void main(void)
 {

--- a/samples/subsys/cpp/cpp_synchronization/src/main.cpp
+++ b/samples/subsys/cpp/cpp_synchronization/src/main.cpp
@@ -19,9 +19,9 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <arch/cpu.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/printk.h>
 
 /**
  * @class semaphore the basic pure virtual semaphore class

--- a/samples/subsys/debug/gdbstub/src/main.c
+++ b/samples/subsys/debug/gdbstub/src/main.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 #define STACKSIZE 512
 

--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <display/cfb.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/display/cfb.h>
 #include <stdio.h>
 
 void main(void)

--- a/samples/subsys/display/cfb_custom_font/src/main.c
+++ b/samples/subsys/display/cfb_custom_font/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <display/cfb.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/display/cfb.h>
+#include <zephyr/sys/printk.h>
 
 #include "cfb_font_dice.h"
 

--- a/samples/subsys/display/cfb_shell/src/main.c
+++ b/samples/subsys/display/cfb_shell/src/main.c
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(app);

--- a/samples/subsys/display/lvgl/src/main.c
+++ b/samples/subsys/display/lvgl/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/display.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/display.h>
 #include <lvgl.h>
 #include <stdio.h>
 #include <string.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app);
 
 void main(void)

--- a/samples/subsys/edac/src/main.c
+++ b/samples/subsys/edac/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <devicetree.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 
-#include <drivers/edac.h>
+#include <zephyr/drivers/edac.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define STACKSIZE	1024

--- a/samples/subsys/fs/fat_fs/src/main.c
+++ b/samples/subsys/fs/fat_fs/src/main.c
@@ -6,11 +6,11 @@
 
 /* Sample which uses the filesystem API and SDHC driver */
 
-#include <zephyr.h>
-#include <device.h>
-#include <storage/disk_access.h>
-#include <logging/log.h>
-#include <fs/fs.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/storage/disk_access.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/fs/fs.h>
 #include <ff.h>
 
 LOG_MODULE_REGISTER(main);

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -9,12 +9,12 @@
 
 #include <stdio.h>
 
-#include <zephyr.h>
-#include <device.h>
-#include <fs/fs.h>
-#include <fs/littlefs.h>
-#include <logging/log.h>
-#include <storage/flash_map.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/fs/fs.h>
+#include <zephyr/fs/littlefs.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/storage/flash_map.h>
 
 LOG_MODULE_REGISTER(main);
 

--- a/samples/subsys/ipc/ipc_service/icmsg/remote/src/main.c
+++ b/samples/subsys/ipc/ipc_service/icmsg/remote/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 
-#include <ipc/ipc_service.h>
+#include <zephyr/ipc/ipc_service.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(remote, LOG_LEVEL_INF);
 
 #define MLEN_0 40

--- a/samples/subsys/ipc/ipc_service/icmsg/src/main.c
+++ b/samples/subsys/ipc/ipc_service/icmsg/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 
-#include <ipc/ipc_service.h>
+#include <zephyr/ipc/ipc_service.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(host, LOG_LEVEL_INF);
 
 #define MLEN_0 40

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 
-#include <ipc/ipc_service.h>
+#include <zephyr/ipc/ipc_service.h>
 
 #define STACKSIZE	(1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define PRIORITY	K_PRIO_PREEMPT(2)

--- a/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 
-#include <ipc/ipc_service.h>
+#include <zephyr/ipc/ipc_service.h>
 
 #define STACKSIZE	(4096 + CONFIG_TEST_EXTRA_STACK_SIZE)
 #define PRIORITY	K_PRIO_PREEMPT(2)

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -6,10 +6,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -6,14 +6,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <openamp/open_amp.h>
 #include <metal/device.h>

--- a/samples/subsys/ipc/openamp_performance/remote/src/main.c
+++ b/samples/subsys/ipc/openamp_performance/remote/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/samples/subsys/ipc/openamp_performance/src/main.c
+++ b/samples/subsys/ipc/openamp_performance/src/main.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <openamp/open_amp.h>
 #include <metal/device.h>

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <drivers/ipm.h>
+#include <zephyr/drivers/ipm.h>
 
 #include <openamp/open_amp.h>
 #include <metal/device.h>
 #include <resource_table.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(openamp_rsc_table, LOG_LEVEL_DBG);
 
 #define SHM_DEVICE_NAME	"shm"

--- a/samples/subsys/ipc/rpmsg_service/remote/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/remote/src/main.c
@@ -6,15 +6,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#include <ipc/rpmsg_service.h>
+#include <zephyr/ipc/rpmsg_service.h>
 
 #define APP_TASK_STACK_SIZE (1024)
 K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);

--- a/samples/subsys/ipc/rpmsg_service/src/main.c
+++ b/samples/subsys/ipc/rpmsg_service/src/main.c
@@ -6,16 +6,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/ipm.h>
-#include <sys/printk.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/device.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <init.h>
+#include <zephyr/init.h>
 
-#include <ipc/rpmsg_service.h>
+#include <zephyr/ipc/rpmsg_service.h>
 
 #define APP_TASK_STACK_SIZE (1024)
 K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);

--- a/samples/subsys/logging/dictionary/src/main.c
+++ b/samples/subsys/logging/dictionary/src/main.c
@@ -6,10 +6,10 @@
  */
 
 #include <inttypes.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <sys/printk.h>
-#include <logging/log.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(hello_world, 4);
 

--- a/samples/subsys/logging/logger/src/ext_log_system.c
+++ b/samples/subsys/logging/logger/src/ext_log_system.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <app_memory/app_memdomain.h>
+#include <zephyr/app_memory/app_memdomain.h>
 #include "ext_log_system.h"
 
 K_APP_BMEM(app_part) static ext_log_handler log_handler;

--- a/samples/subsys/logging/logger/src/ext_log_system_adapter.c
+++ b/samples/subsys/logging/logger/src/ext_log_system_adapter.c
@@ -8,7 +8,7 @@
 #include "ext_log_system.h"
 
 #define LOG_MODULE_NAME ext_log_system
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(ext_log_system);
 

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include "sample_instance.h"
 #include "sample_module.h"
 #include "ext_log_system.h"
 #include "ext_log_system_adapter.h"
-#include <logging/log_ctrl.h>
-#include <app_memory/app_memdomain.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #ifdef CONFIG_USERSPACE

--- a/samples/subsys/logging/logger/src/sample_instance.c
+++ b/samples/subsys/logging/logger/src/sample_instance.c
@@ -9,7 +9,7 @@
 /* Note: no name is defined because only instance logging is used.
  * Instances are registered as logging sources not module.
  */
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_LEVEL_SET(LOG_LEVEL_INF);
 

--- a/samples/subsys/logging/logger/src/sample_instance.h
+++ b/samples/subsys/logging/logger/src/sample_instance.h
@@ -6,9 +6,9 @@
 #ifndef SAMPLE_INSTANCE_H
 #define SAMPLE_INSTANCE_H
 
-#include <kernel.h>
-#include <logging/log_instance.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log_instance.h>
+#include <zephyr/logging/log.h>
 
 #define SAMPLE_INSTANCE_NAME sample_instance
 

--- a/samples/subsys/logging/logger/src/sample_module.c
+++ b/samples/subsys/logging/logger/src/sample_module.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #include "sample_module.h"
 
 LOG_MODULE_REGISTER(MODULE_NAME, CONFIG_SAMPLE_MODULE_LOG_LEVEL);

--- a/samples/subsys/logging/logger/src/sample_module.h
+++ b/samples/subsys/logging/logger/src/sample_module.h
@@ -6,7 +6,7 @@
 #ifndef SAMPLE_MODULE_H
 #define SAMPLE_MODULE_H
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/subsys/logging/syst/src/main.c
+++ b/samples/subsys/logging/syst/src/main.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
-#include <sys/printk.h>
-#include <logging/log_ctrl.h>
-#include <logging/log_output.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log_output.h>
 
 #define DATA_MAX_DLEN 8
 #define LOG_MODULE_NAME syst

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <lorawan/lorawan.h>
-#include <zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/lorawan/lorawan.h>
+#include <zephyr/zephyr.h>
 
 #define DEFAULT_RADIO_NODE DT_ALIAS(lora0)
 BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
@@ -27,7 +27,7 @@ BUILD_ASSERT(DT_NODE_HAS_STATUS(DEFAULT_RADIO_NODE, okay),
 #define DELAY K_MSEC(10000)
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(lorawan_class_a);
 
 char data[] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};

--- a/samples/subsys/mgmt/hawkbit/src/dhcp.c
+++ b/samples/subsys/mgmt/hawkbit/src/dhcp.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
-#include <net/net_if.h>
-#include <net/net_core.h>
-#include <net/net_context.h>
-#include <net/net_mgmt.h>
+#include <zephyr/net/net_if.h>
+#include <zephyr/net/net_core.h>
+#include <zephyr/net/net_context.h>
+#include <zephyr/net/net_mgmt.h>
 
 static struct net_mgmt_event_callback mgmt_cb;
 

--- a/samples/subsys/mgmt/hawkbit/src/main.c
+++ b/samples/subsys/mgmt/hawkbit/src/main.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <mgmt/hawkbit.h>
-#include <dfu/mcuboot.h>
-#include <sys/printk.h>
-#include <sys/reboot.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/mgmt/hawkbit.h>
+#include <zephyr/dfu/mcuboot.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/logging/log.h>
 
 #include "dhcp.h"
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)
-#include <net/tls_credentials.h>
+#include <zephyr/net/tls_credentials.h>
 #include "ca_certificate.h"
 #endif
 

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/bluetooth.c
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/conn.h>
-#include <bluetooth/gatt.h>
-#include <mgmt/mcumgr/smp_bt.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/conn.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/mgmt/mcumgr/smp_bt.h>
 
 #define LOG_LEVEL LOG_LEVEL_DBG
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smp_bt_sample);
 
 static struct k_work advertise_work;

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/main.c
@@ -5,15 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <stats/stats.h>
-#include <usb/usb_device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/stats/stats.h>
+#include <zephyr/usb/usb_device.h>
 
 #ifdef CONFIG_MCUMGR_CMD_FS_MGMT
-#include <device.h>
-#include <fs/fs.h>
+#include <zephyr/device.h>
+#include <zephyr/fs/fs.h>
 #include "fs_mgmt/fs_mgmt.h"
-#include <fs/littlefs.h>
+#include <zephyr/fs/littlefs.h>
 #endif
 #ifdef CONFIG_MCUMGR_CMD_OS_MGMT
 #include "os_mgmt/os_mgmt.h"
@@ -32,7 +32,7 @@
 #endif
 
 #define LOG_LEVEL LOG_LEVEL_DBG
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smp_sample);
 
 #include "common.h"

--- a/samples/subsys/mgmt/mcumgr/smp_svr/src/udp.c
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/src/udp.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <mgmt/mcumgr/smp_udp.h>
-#include <net/net_mgmt.h>
-#include <net/net_event.h>
-#include <net/net_conn_mgr.h>
+#include <zephyr/mgmt/mcumgr/smp_udp.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_conn_mgr.h>
 
 #define LOG_LEVEL LOG_LEVEL_DBG
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smp_udp_sample);
 
 #define EVENT_MASK (NET_EVENT_L4_CONNECTED | NET_EVENT_L4_DISCONNECTED)

--- a/samples/subsys/mgmt/osdp/control_panel/src/main.c
+++ b/samples/subsys/mgmt/osdp/control_panel/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <mgmt/osdp.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/mgmt/osdp.h>
 
 /* The devicetree node identifier for the "led0" alias. */
 #define LED0_NODE DT_ALIAS(led0)

--- a/samples/subsys/mgmt/osdp/peripheral_device/src/main.c
+++ b/samples/subsys/mgmt/osdp/peripheral_device/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <mgmt/osdp.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/mgmt/osdp.h>
 
 /* The devicetree node identifier for the "led0" alias. */
 #define LED0_NODE DT_ALIAS(led0)

--- a/samples/subsys/mgmt/updatehub/src/main.c
+++ b/samples/subsys/mgmt/updatehub/src/main.c
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <updatehub.h>
-#include <net/net_mgmt.h>
-#include <net/net_event.h>
-#include <net/net_conn_mgr.h>
-#include <net/wifi_mgmt.h>
-#include <dfu/mcuboot.h>
+#include <zephyr/net/net_mgmt.h>
+#include <zephyr/net/net_event.h>
+#include <zephyr/net/net_conn_mgr.h>
+#include <zephyr/net/wifi_mgmt.h>
+#include <zephyr/dfu/mcuboot.h>
 
 #if defined(CONFIG_UPDATEHUB_DTLS)
-#include <net/tls_credentials.h>
+#include <zephyr/net/tls_credentials.h>
 #include "c_certificates.h"
 #endif
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #define EVENT_MASK (NET_EVENT_L4_CONNECTED | \

--- a/samples/subsys/modbus/rtu_client/src/main.c
+++ b/samples/subsys/modbus/rtu_client/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/util.h>
-#include <drivers/gpio.h>
-#include <modbus/modbus.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/modbus/modbus.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mbc_sample, LOG_LEVEL_INF);
 
 static int client_iface;

--- a/samples/subsys/modbus/rtu_server/src/main.c
+++ b/samples/subsys/modbus/rtu_server/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/util.h>
-#include <drivers/gpio.h>
-#include <modbus/modbus.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/modbus/modbus.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mbs_sample, LOG_LEVEL_INF);
 
 static uint16_t holding_reg[8];

--- a/samples/subsys/modbus/tcp_gateway/src/main.c
+++ b/samples/subsys/modbus/tcp_gateway/src/main.c
@@ -5,12 +5,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/util.h>
-#include <modbus/modbus.h>
-#include <net/socket.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/modbus/modbus.h>
+#include <zephyr/net/socket.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tcp_gateway, LOG_LEVEL_INF);
 
 #define MODBUS_TCP_PORT 502

--- a/samples/subsys/modbus/tcp_server/src/main.c
+++ b/samples/subsys/modbus/tcp_server/src/main.c
@@ -5,14 +5,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/util.h>
-#include <drivers/gpio.h>
-#include <modbus/modbus.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/modbus/modbus.h>
 
-#include <net/socket.h>
+#include <zephyr/net/socket.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(tcp_modbus, LOG_LEVEL_INF);
 
 #define MODBUS_TCP_PORT 502

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -38,13 +38,13 @@
  */
 
 
-#include <zephyr.h>
-#include <sys/reboot.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/device.h>
 #include <string.h>
-#include <drivers/flash.h>
-#include <storage/flash_map.h>
-#include <fs/nvs.h>
+#include <zephyr/drivers/flash.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/fs/nvs.h>
 
 static struct nvs_fs fs;
 

--- a/samples/subsys/pm/device_pm/src/dummy_driver.c
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <pm/device.h>
-#include <pm/device_runtime.h>
-#include <sys/printk.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/sys/printk.h>
 #include "dummy_parent.h"
 #include "dummy_driver.h"
 

--- a/samples/subsys/pm/device_pm/src/dummy_driver.h
+++ b/samples/subsys/pm/device_pm/src/dummy_driver.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #define DUMMY_DRIVER_NAME	"dummy_driver"
 
 typedef int (*dummy_api_open_t)(const struct device *dev);

--- a/samples/subsys/pm/device_pm/src/dummy_parent.c
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <pm/device.h>
-#include <pm/device_runtime.h>
-#include <sys/printk.h>
+#include <zephyr/pm/device.h>
+#include <zephyr/pm/device_runtime.h>
+#include <zephyr/sys/printk.h>
 #include "dummy_parent.h"
 
 static uint32_t store_value;

--- a/samples/subsys/pm/device_pm/src/dummy_parent.h
+++ b/samples/subsys/pm/device_pm/src/dummy_parent.h
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 #define DUMMY_PARENT_NAME	"dummy_parent"
 
 #define DUMMY_PARENT_RD		0

--- a/samples/subsys/pm/device_pm/src/main.c
+++ b/samples/subsys/pm/device_pm/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include "dummy_driver.h"
 
 /* Application main Thread */

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
@@ -27,17 +27,17 @@
  * object attributes array in the phil_obj_abstract.h
  * header file.
  */
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <cmsis_os.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 #include <stdio.h>
 #else
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #endif
 
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #include "phil_obj_abstract.h"
 

--- a/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/timer_synchronization/src/main.c
@@ -8,7 +8,7 @@
  * @file Synchronization demo using CMSIS RTOS V1 APIs.
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <cmsis_os.h>
 
 /* specify delay between greetings (in ms); compute equivalent in ticks */

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
@@ -28,12 +28,12 @@
  * header file.
  */
 
-#include <zephyr.h>
-#include <kernel.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <cmsis_os2.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #include "phil_obj_abstract.h"
 

--- a/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v2/timer_synchronization/src/main.c
@@ -8,7 +8,7 @@
  * @file Synchronization demo using CMSIS RTOS V2 APIs.
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <cmsis_os2.h>
 
 /* specify delay between greetings (in ms); compute equivalent in ticks */

--- a/samples/subsys/settings/src/main.c
+++ b/samples/subsys/settings/src/main.c
@@ -10,11 +10,11 @@
 #include "settings/settings.h"
 
 #include <errno.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 #if IS_ENABLED(CONFIG_SETTINGS_FS)
-#include <fs/fs.h>
-#include <fs/littlefs.h>
+#include <zephyr/fs/fs.h>
+#include <zephyr/fs/littlefs.h>
 #endif
 
 #define GAMMA_DEFAULT_VAl 0

--- a/samples/subsys/shell/fs/src/main.c
+++ b/samples/subsys/shell/fs/src/main.c
@@ -6,7 +6,7 @@
 
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(app);
 
 void main(void)

--- a/samples/subsys/shell/shell_module/src/dynamic_cmd.c
+++ b/samples/subsys/shell/shell_module/src/dynamic_cmd.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 #include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/samples/subsys/shell/shell_module/src/main.c
+++ b/samples/subsys/shell/shell_module/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <shell/shell.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/shell/shell.h>
 #include <version.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #include <stdlib.h>
-#include <drivers/uart.h>
-#include <usb/usb_device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/usb/usb_device.h>
 #include <ctype.h>
 
 LOG_MODULE_REGISTER(app);

--- a/samples/subsys/shell/shell_module/src/test_module.c
+++ b/samples/subsys/shell/shell_module/src/test_module.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <logging/log.h>
-#include <shell/shell.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
 LOG_MODULE_REGISTER(app_test);
 
 void foo(void)

--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <shell/shell.h>
-#include <shell/shell_uart.h>
-#include <drivers/uart.h>
-#include <device.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_uart.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/device.h>
 
 void shell_init_from_work(struct k_work *work)
 {

--- a/samples/subsys/task_wdt/src/main.c
+++ b/samples/subsys/task_wdt/src/main.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/watchdog.h>
-#include <sys/reboot.h>
-#include <task_wdt/task_wdt.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/watchdog.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/task_wdt/task_wdt.h>
+#include <zephyr/sys/printk.h>
 #include <stdbool.h>
 
 /*

--- a/samples/subsys/tracing/src/main.c
+++ b/samples/subsys/tracing/src/main.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <logging/log.h>
-#include <usb/usb_device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/usb/usb_device.h>
 
 /*
  * The hello world demo has two threads that utilize semaphores and sleeping

--- a/samples/subsys/usb/audio/headphones_microphone/src/main.c
+++ b/samples/subsys/usb/audio/headphones_microphone/src/main.c
@@ -9,10 +9,10 @@
  * @brief Sample app for Audio class
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
-#include <usb/usb_device.h>
-#include <usb/class/usb_audio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_audio.h>
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 

--- a/samples/subsys/usb/audio/headset/src/main.c
+++ b/samples/subsys/usb/audio/headset/src/main.c
@@ -9,10 +9,10 @@
  * @brief Sample app for Audio class
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
-#include <usb/usb_device.h>
-#include <usb/class/usb_audio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_audio.h>
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 

--- a/samples/subsys/usb/cdc_acm/src/main.c
+++ b/samples/subsys/usb/cdc_acm/src/main.c
@@ -14,13 +14,13 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <device.h>
-#include <drivers/uart.h>
-#include <zephyr.h>
-#include <sys/ring_buffer.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/ring_buffer.h>
 
-#include <usb/usb_device.h>
-#include <logging/log.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(cdc_acm_echo, LOG_LEVEL_INF);
 
 #define RING_BUF_SIZE 1024

--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -14,13 +14,13 @@
 
 #include <stdio.h>
 #include <string.h>
-#include <device.h>
-#include <drivers/uart.h>
-#include <zephyr.h>
-#include <sys/ring_buffer.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/ring_buffer.h>
 
-#include <usb/usb_device.h>
-#include <logging/log.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(cdc_acm_composite, LOG_LEVEL_INF);
 
 #define RING_BUF_SIZE	(64 * 2)

--- a/samples/subsys/usb/console/src/main.c
+++ b/samples/subsys/usb/console/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <usb/usb_device.h>
-#include <drivers/uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/drivers/uart.h>
 
 BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart),
 	     "Console device is not ACM CDC UART device");

--- a/samples/subsys/usb/dfu/src/main.c
+++ b/samples/subsys/usb/dfu/src/main.c
@@ -7,9 +7,9 @@
 
 /* Sample app for USB DFU class driver. */
 
-#include <zephyr.h>
-#include <logging/log.h>
-#include <usb/usb_device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/usb/usb_device.h>
 LOG_MODULE_REGISTER(main);
 
 void main(void)

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -3,16 +3,16 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <drivers/uart.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/uart.h>
 #include <string.h>
-#include <random/rand32.h>
+#include <zephyr/random/rand32.h>
 
-#include <usb/usb_device.h>
-#include <usb/class/usb_hid.h>
-#include <usb/class/usb_cdc.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_hid.h>
+#include <zephyr/usb/class/usb_cdc.h>
 
 #define LOG_LEVEL LOG_LEVEL_DBG
 LOG_MODULE_REGISTER(main);

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -4,12 +4,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <usb/usb_device.h>
-#include <usb/class/usb_hid.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_hid.h>
 
 #define LOG_LEVEL LOG_LEVEL_DBG
 LOG_MODULE_REGISTER(main);

--- a/samples/subsys/usb/hid/src/main.c
+++ b/samples/subsys/usb/hid/src/main.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <init.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
 
-#include <usb/usb_device.h>
-#include <usb/class/usb_hid.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/class/usb_hid.h>
 
 #define LOG_LEVEL LOG_LEVEL_INF
 LOG_MODULE_REGISTER(main);

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -5,16 +5,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
-#include <usb/usb_device.h>
-#include <fs/fs.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/fs/fs.h>
 #include <stdio.h>
 
 LOG_MODULE_REGISTER(main);
 
 #if CONFIG_DISK_DRIVER_FLASH
-#include <storage/flash_map.h>
+#include <zephyr/storage/flash_map.h>
 #endif
 
 #if CONFIG_FAT_FILESYSTEM_ELM
@@ -22,7 +22,7 @@ LOG_MODULE_REGISTER(main);
 #endif
 
 #if CONFIG_FILE_SYSTEM_LITTLEFS
-#include <fs/littlefs.h>
+#include <zephyr/fs/littlefs.h>
 FS_LITTLEFS_DECLARE_DEFAULT_CONFIG(storage);
 #endif
 

--- a/samples/subsys/usb/testusb/src/main.c
+++ b/samples/subsys/usb/testusb/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
-#include <usb/usb_device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/usb/usb_device.h>
 LOG_MODULE_REGISTER(main);
 
 void main(void)

--- a/samples/subsys/usb/webusb/src/main.c
+++ b/samples/subsys/usb/webusb/src/main.c
@@ -14,12 +14,12 @@
  */
 
 #define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#include <sys/byteorder.h>
-#include <usb/usb_device.h>
-#include <usb/bos.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/usb/usb_device.h>
+#include <zephyr/usb/bos.h>
 
 #include "webusb.h"
 

--- a/samples/subsys/usb/webusb/src/webusb.c
+++ b/samples/subsys/usb/webusb/src/webusb.c
@@ -13,11 +13,11 @@
  */
 
 #define LOG_LEVEL CONFIG_USB_DEVICE_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(webusb);
 
-#include <sys/byteorder.h>
-#include <usb/usb_device.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/usb/usb_device.h>
 #include <usb_descriptor.h>
 
 #include "webusb.h"

--- a/samples/subsys/video/capture/src/main.c
+++ b/samples/subsys/video/capture/src/main.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 
-#include <drivers/video.h>
+#include <zephyr/drivers/video.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #define VIDEO_DEV_SW "VIDEO_SW_GENERATOR"

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
 
-#include <net/socket.h>
+#include <zephyr/net/socket.h>
 
-#include <drivers/video.h>
+#include <zephyr/drivers/video.h>
 
 #define LOG_LEVEL CONFIG_LOG_DEFAULT_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
 #if defined(CONFIG_VIDEO_MCUX_CSI)

--- a/samples/synchronization/src/main.c
+++ b/samples/synchronization/src/main.c
@@ -6,8 +6,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
 
 /*
  * The hello world demo has two threads that utilize semaphores and sleeping

--- a/samples/tfm_integration/psa_crypto/src/main.c
+++ b/samples/tfm_integration/psa_crypto/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
 
 #include "tfm_ns_interface.h"
 #include "psa_attestation.h"

--- a/samples/tfm_integration/psa_crypto/src/psa_attestation.c
+++ b/samples/tfm_integration/psa_crypto/src/psa_attestation.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #include "psa/initial_attestation.h"
 #include "psa_attestation.h"

--- a/samples/tfm_integration/psa_crypto/src/psa_crypto.c
+++ b/samples/tfm_integration/psa_crypto/src/psa_crypto.c
@@ -6,10 +6,10 @@
 
 #include <stdio.h>
 
-#include <zephyr.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
-#include <data/json.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/data/json.h>
 
 #include "mbedtls/pk.h"
 #include "mbedtls/x509.h"

--- a/samples/tfm_integration/psa_crypto/src/psa_crypto.h
+++ b/samples/tfm_integration/psa_crypto/src/psa_crypto.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "psa/crypto.h"
 #include "psa/error.h"

--- a/samples/tfm_integration/psa_crypto/src/shell.c
+++ b/samples/tfm_integration/psa_crypto/src/shell.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <ctype.h>
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 
 #if CONFIG_PSA_SHELL
 

--- a/samples/tfm_integration/psa_crypto/src/util_app_cfg.c
+++ b/samples/tfm_integration/psa_crypto/src/util_app_cfg.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #include "psa/error.h"
 #include "psa/protected_storage.h"

--- a/samples/tfm_integration/psa_crypto/src/util_app_cfg.h
+++ b/samples/tfm_integration/psa_crypto/src/util_app_cfg.h
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "psa/error.h"
 

--- a/samples/tfm_integration/psa_crypto/src/util_app_log.c
+++ b/samples/tfm_integration/psa_crypto/src/util_app_log.c
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
 
 #include "psa/crypto.h"
 #include "util_app_log.h"

--- a/samples/tfm_integration/psa_crypto/src/util_sformat.h
+++ b/samples/tfm_integration/psa_crypto/src/util_sformat.h
@@ -8,7 +8,7 @@
 #define _SFORMAT_H_
 
 #include <stdint.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/samples/tfm_integration/psa_firmware/src/main.c
+++ b/samples/tfm_integration/psa_firmware/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
 #include <psa/update.h>
 
 #include "tfm_ns_interface.h"

--- a/samples/tfm_integration/psa_protected_storage/src/main.c
+++ b/samples/tfm_integration/psa_protected_storage/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <string.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include <psa/storage_common.h>
 #include <psa/protected_storage.h>
 

--- a/samples/tfm_integration/tfm_ipc/src/main.c
+++ b/samples/tfm_integration/tfm_ipc/src/main.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <sys/reboot.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/reboot.h>
 
 #include "tfm_api.h"
 #include "tfm_ns_interface.h"

--- a/samples/tfm_integration/tfm_psa_test/src/main.c
+++ b/samples/tfm_integration/tfm_psa_test/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /* Run the PSA test suite */
 void psa_test(void);

--- a/samples/tfm_integration/tfm_regression_test/src/main.c
+++ b/samples/tfm_integration/tfm_regression_test/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 __attribute__((noreturn))
 void main(void)

--- a/samples/tfm_integration/tfm_secure_partition/src/main.c
+++ b/samples/tfm_integration/tfm_secure_partition/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <tfm_veneers.h>
 #include <tfm_ns_interface.h>
 

--- a/samples/userspace/hello_world_user/src/main.c
+++ b/samples/userspace/hello_world_user/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
 #define USER_STACKSIZE	2048
 

--- a/samples/userspace/prod_consumer/src/app_a.c
+++ b/samples/userspace/prod_consumer/src/app_a.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <sys/libc-hooks.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/logging/log.h>
 
 #include "sample_driver.h"
 #include "app_shared.h"

--- a/samples/userspace/prod_consumer/src/app_a.h
+++ b/samples/userspace/prod_consumer/src/app_a.h
@@ -7,8 +7,8 @@
 #ifndef PROD_CONSUMER_APP_A_H
 #define PROD_CONSUMER_APP_A_H
 
-#include <kernel.h>
-#include <app_memory/app_memdomain.h>
+#include <zephyr/kernel.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
 void app_a_entry(void *p1, void *p2, void *p3);
 

--- a/samples/userspace/prod_consumer/src/app_b.c
+++ b/samples/userspace/prod_consumer/src/app_b.c
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <sys/libc-hooks.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/logging/log.h>
 
 #include "app_shared.h"
 #include "app_b.h"

--- a/samples/userspace/prod_consumer/src/app_b.h
+++ b/samples/userspace/prod_consumer/src/app_b.h
@@ -7,8 +7,8 @@
 #ifndef PROD_CONSUMER_APP_B_H
 #define PROD_CONSUMER_APP_B_H
 
-#include <kernel.h>
-#include <app_memory/app_memdomain.h>
+#include <zephyr/kernel.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
 void app_b_entry(void *p1, void *p2, void *p3);
 

--- a/samples/userspace/prod_consumer/src/app_shared.h
+++ b/samples/userspace/prod_consumer/src/app_shared.h
@@ -7,9 +7,9 @@
 #ifndef APP_SHARED_H
 #define APP_SHARED_H
 
-#include <kernel.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/sys_heap.h>
+#include <zephyr/kernel.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/sys_heap.h>
 
 #include "sample_driver.h"
 

--- a/samples/userspace/prod_consumer/src/app_syscall.c
+++ b/samples/userspace/prod_consumer/src/app_syscall.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <syscall_handler.h>
-#include <logging/log.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(app_syscall);
 

--- a/samples/userspace/prod_consumer/src/main.c
+++ b/samples/userspace/prod_consumer/src/main.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/printk.h>
-#include <sys/libc-hooks.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/logging/log.h>
 
 #include "app_shared.h"
 #include "app_a.h"

--- a/samples/userspace/prod_consumer/src/sample_driver.h
+++ b/samples/userspace/prod_consumer/src/sample_driver.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_FAKE_DRIVER_H
 #define ZEPHYR_FAKE_DRIVER_H
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #define SAMPLE_DRIVER_NAME_0	"SAMPLE_DRIVER_0"
 #define SAMPLE_DRIVER_MSG_SIZE	128

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -6,8 +6,8 @@
 
 #include "sample_driver.h"
 #include <string.h>
-#include <kernel.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(sample_driver);
 

--- a/samples/userspace/prod_consumer/src/sample_driver_handlers.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_handlers.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <syscall_handler.h>
+#include <zephyr/kernel.h>
+#include <zephyr/syscall_handler.h>
 #include "sample_driver.h"
 
 int z_vrfy_sample_driver_state_set(const struct device *dev, bool active)

--- a/samples/userspace/shared_mem/src/enc.h
+++ b/samples/userspace/shared_mem/src/enc.h
@@ -8,7 +8,7 @@
 #ifndef ENC_H
 #define ENC_H
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 #define WHEEL_SIZE 26
 #define IMOD(a, b) ((a + b) % WHEEL_SIZE)

--- a/samples/userspace/shared_mem/src/main.c
+++ b/samples/userspace/shared_mem/src/main.c
@@ -14,8 +14,8 @@
  *
  */
 
-#include <sys/__assert.h>
-#include <sys/libc-hooks.h> /* for z_libc_partition */
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/libc-hooks.h> /* for z_libc_partition */
 
 #include "main.h"
 #include "enc.h"

--- a/samples/userspace/shared_mem/src/main.h
+++ b/samples/userspace/shared_mem/src/main.h
@@ -7,17 +7,17 @@
 #ifndef MAIN_H
 #define MAIN_H
 
-#include <zephyr.h>
-#include <sys/printk.h>
-#include <kernel_structs.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/kernel_structs.h>
 #include <string.h>
 #include <stdlib.h>
 
-#include <app_memory/app_memdomain.h>
-#include <sys/util.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/util.h>
 
 #if defined(CONFIG_ARC)
-#include <arch/arc/v2/mpu/arc_core_mpu.h>
+#include <zephyr/arch/arc/v2/mpu/arc_core_mpu.h>
 #endif
 
 void enc(void);

--- a/samples/userspace/syscall_perf/src/main.c
+++ b/samples/userspace/syscall_perf/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
 
 #include "main.h"

--- a/samples/userspace/syscall_perf/src/main.h
+++ b/samples/userspace/syscall_perf/src/main.h
@@ -7,7 +7,7 @@
 #ifndef MAIN_H
 #define MAIN_H
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #define csr_read(csr)						\
 ({								\

--- a/samples/userspace/syscall_perf/src/test_supervisor.c
+++ b/samples/userspace/syscall_perf/src/test_supervisor.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
 
 #include "main.h"

--- a/samples/userspace/syscall_perf/src/test_user.c
+++ b/samples/userspace/syscall_perf/src/test_user.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <stdio.h>
 
 #include "main.h"

--- a/samples/userspace/syscall_perf/src/thread_def.h
+++ b/samples/userspace/syscall_perf/src/thread_def.h
@@ -7,7 +7,7 @@
 #ifndef THREAD_DEF_H
 #define THREAD_DEF_H
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #define THREAD_STACKSIZE	2048
 


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all samples to the use
the new prefix <zephyr/...>. Note that the conversion has been scripted:

```python
from pathlib import Path
import re

EXTENSIONS = ("c", "h", "cpp", "rst")

for p in Path(".").glob("samples/**/*"):
    if not p.is_file() or p.suffix and p.suffix[1:] not in EXTENSIONS:
        continue

    content = ""
    with open(p) as f:
        for line in f:
            m = re.match(r"^(.*)#include <(.*)>(.*)$", line)
            if (m and
                not m.group(2).startswith("zephyr/") and
                (Path(".") / "include" / "zephyr" / m.group(2)).exists()):
                content += (
                    m.group(1) +
                    "#include <zephyr/" + m.group(2) +">" +
                    m.group(3) + "\n"
                )
            else:
                content += line

    with open(p, "w") as f:
        f.write(content)
```

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>