### PR TITLE
soc/xtensa/intel_adsp: Add cAVS clock driver

### DIFF
--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -20,6 +20,12 @@ config CAVS_IPC
 	  Driver for the host IPC interrupt delivery mechanism.
 	  Currently SOF has its own driver for this hardware.
 
+config CAVS_CLOCK
+	bool
+	help
+	  Driver for the CAVS clocks. Allow type of clock (and
+	  thus frequency) to be chosen.
+
 config INTEL_ADSP_CAVS
 	bool
 	help

--- a/soc/xtensa/intel_adsp/cavs_v15/include/soc/clk.h
+++ b/soc/xtensa/intel_adsp/cavs_v15/include/soc/clk.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_CAVS15_CLK_H_
+#define ZEPHYR_SOC_INTEL_ADSP_CAVS15_CLK_H_
+
+enum cavs_clock_freq {
+	CAVS_CLOCK_FREQ_LPRO,
+	CAVS_CLOCK_UNDEFINED,
+	CAVS_CLOCK_FREQ_HPRO
+};
+
+#define CAVS_CLOCK_FREQ_DEFAULT CAVS_CLOCK_FREQ_HPRO
+#define CAVS_CLOCK_FREQ_LOWEST  CAVS_CLOCK_FREQ_LPRO
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS15_CLK_H_ */

--- a/soc/xtensa/intel_adsp/cavs_v18/include/soc/clk.h
+++ b/soc/xtensa/intel_adsp/cavs_v18/include/soc/clk.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_CAVS18_CLK_H_
+#define ZEPHYR_SOC_INTEL_ADSP_CAVS18_CLK_H_
+
+#include <cavs-shim.h>
+
+enum cavs_clock_freq {
+	CAVS_CLOCK_FREQ_LPRO,
+	CAVS_CLOCK_FREQ_HPRO
+};
+
+#define CAVS_CLOCK_FREQ_DEFAULT CAVS_CLOCK_FREQ_HPRO
+#define CAVS_CLOCK_FREQ_LOWEST  CAVS_CLOCK_FREQ_LPRO
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS18_CLK_H_ */

--- a/soc/xtensa/intel_adsp/cavs_v20/include/soc/clk.h
+++ b/soc/xtensa/intel_adsp/cavs_v20/include/soc/clk.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_CAVS20_CLK_H_
+#define ZEPHYR_SOC_INTEL_ADSP_CAVS20_CLK_H_
+
+#include <cavs-shim.h>
+
+enum cavs_clock_freq {
+	CAVS_CLOCK_FREQ_LPRO,
+	CAVS_CLOCK_FREQ_HPRO
+};
+
+#define CAVS_CLOCK_FREQ_DEFAULT CAVS_CLOCK_FREQ_HPRO
+#define CAVS_CLOCK_FREQ_LOWEST  CAVS_CLOCK_FREQ_LPRO
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS20_CLK_H_ */

--- a/soc/xtensa/intel_adsp/cavs_v25/include/soc/clk.h
+++ b/soc/xtensa/intel_adsp/cavs_v25/include/soc/clk.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_CAVS25_CLK_H_
+#define ZEPHYR_SOC_INTEL_ADSP_CAVS25_CLK_H_
+
+#include <cavs-shim.h>
+
+enum cavs_clock_freq {
+	CAVS_CLOCK_FREQ_WOVCRO,
+	CAVS_CLOCK_FREQ_LPRO,
+	CAVS_CLOCK_FREQ_HPRO
+};
+
+#define CAVS_CLOCK_FREQ_DEFAULT CAVS_CLOCK_FREQ_HPRO
+#define CAVS_CLOCK_FREQ_LOWEST  CAVS_CLOCK_FREQ_WOVCRO
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS25_CLK_H_ */

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -17,6 +17,8 @@ zephyr_library_sources_ifdef(CONFIG_INTEL_ADSP_CAVS
     rimage_modules.c
     boot.c)
 
+zephyr_library_sources_ifdef(CONFIG_CAVS_CLOCK clk.c)
+
 if(CONFIG_SMP OR CONFIG_MP_NUM_CPUS GREATER 1)
   zephyr_library_sources(soc_mp.c)
   if(CONFIG_INTEL_ADSP_CAVS)

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <device.h>
+
+#include <cavs-clk.h>
+#include <cavs-shim.h>
+
+static struct cavs_clock_info platform_clocks[CONFIG_MP_NUM_CPUS];
+static struct k_spinlock lock;
+
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V15
+const uint32_t cavs_clock_freq_enc[] = {
+	0x3,
+	0x1,
+	0x0
+};
+#elif CONFIG_SOC_SERIES_INTEL_CAVS_V18
+const uint32_t cavs_clock_freq_enc[] = {
+	CAVS_CLKCTL_RLROSCC | CAVS_CLKCTL_LMCS,
+	CAVS_CLKCTL_RHROSCC | CAVS_CLKCTL_OCS | CAVS_CLKCTL_LMCS
+};
+
+const uint32_t cavs_clock_freq_status_mask[] = {
+	CAVS_CLKCTL_RLROSCC,
+	CAVS_CLKCTL_RHROSCC
+};
+#elif CONFIG_SOC_SERIES_INTEL_CAVS_V20
+const uint32_t cavs_clock_freq_enc[] = {
+	CAVS_CLKCTL_RLROSCC | CAVS_CLKCTL_LMCS,
+	CAVS_CLKCTL_RHROSCC | CAVS_CLKCTL_OCS | CAVS_CLKCTL_LMCS
+};
+
+const uint32_t cavs_clock_freq_status_mask[] = {
+	CAVS_CLKCTL_RLROSCC,
+	CAVS_CLKCTL_RHROSCC
+};
+#elif CONFIG_SOC_SERIES_INTEL_CAVS_V25
+const uint32_t cavs_clock_freq_enc[] = {
+	CAVS_CLKCTL_WOVCROSC | CAVS_CLKCTL_WOVCRO | CAVS_CLKCTL_LMCS,
+	CAVS_CLKCTL_RLROSCC | CAVS_CLKCTL_LMCS,
+	CAVS_CLKCTL_RHROSCC | CAVS_CLKCTL_OCS | CAVS_CLKCTL_LMCS
+};
+
+const uint32_t cavs_clock_freq_status_mask[] = {
+	CAVS_CLKCTL_WOVCRO,
+	CAVS_CLKCTL_RLROSCC,
+	CAVS_CLKCTL_RHROSCC
+};
+#endif
+
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V15
+static void select_cpu_clock_hw(enum cavs_clock_freq freq)
+{
+	uint8_t cpu_id = _current_cpu->id;
+	uint32_t enc = cavs_clock_freq_enc[freq] << (8 + cpu_id * 2);
+	uint32_t mask = CAVS15_CLKCTL_DPCS_MASK(cpu_id);
+
+	CAVS_SHIM.clkctl &= ~CAVS15_CLKCTL_HDCS;
+	CAVS_SHIM.clkctl = (CAVS_SHIM.clkctl & ~mask) | (enc & mask);
+}
+#else
+static void select_cpu_clock_hw(enum cavs_clock_freq freq)
+{
+	uint32_t enc = cavs_clock_freq_enc[freq];
+	uint32_t status_mask = cavs_clock_freq_status_mask[freq];
+
+	/* Request clock */
+	CAVS_SHIM.clkctl |= enc;
+
+	/* Wait for requested clock to be on */
+	while ((CAVS_SHIM.clkctl & status_mask) != status_mask) {
+		k_busy_wait(10);
+	}
+
+	/* Switch to requested clock */
+	CAVS_SHIM.clkctl = (CAVS_SHIM.clkctl & ~CAVS_CLKCTL_OSC_SOURCE_MASK) |
+			    enc;
+
+	/* Release other clocks */
+	CAVS_SHIM.clkctl &= ~CAVS_CLKCTL_OSC_REQUEST_MASK | enc;
+}
+#endif
+
+void cavs_clock_set_freq(enum cavs_clock_freq freq)
+{
+	k_spinlock_key_t k;
+	int i;
+
+	k = k_spin_lock(&lock);
+
+	select_cpu_clock_hw(freq);
+	for (i = 0; i < CONFIG_MP_NUM_CPUS; i++)
+		platform_clocks[i].current_freq = freq;
+
+	k_spin_unlock(&lock, k);
+}
+
+struct cavs_clock_info *cavs_clocks_get(void)
+{
+	return platform_clocks;
+}
+
+void cavs_clock_init(void)
+{
+	enum cavs_clock_freq platform_lowest_freq_idx = CAVS_CLOCK_FREQ_LOWEST;
+	int i;
+
+#ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
+	CAVS_SHIM.clkctl |= CAVS_CLKCTL_WOVCRO;
+	if (CAVS_SHIM.clkctl & CAVS_CLKCTL_WOVCRO)
+		CAVS_SHIM.clkctl = CAVS_SHIM.clkctl & ~CAVS_CLKCTL_WOVCRO;
+	else
+		platform_lowest_freq_idx = CAVS_CLOCK_FREQ_WOVCRO;
+#endif
+
+	for (i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
+		platform_clocks[i].default_freq = CAVS_CLOCK_FREQ_DEFAULT;
+		platform_clocks[i].current_freq = CAVS_CLOCK_FREQ_DEFAULT;
+		platform_clocks[i].lowest_freq = platform_lowest_freq_idx;
+	}
+}

--- a/soc/xtensa/intel_adsp/common/include/cavs-clk.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-clk.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_CAVS_CLK_H_
+#define ZEPHYR_SOC_INTEL_ADSP_CAVS_CLK_H_
+
+#include <stdint.h>
+
+#include <soc/clk.h>
+
+enum cavs_clock_freq;
+
+struct cavs_clock_info {
+	uint32_t default_freq;
+	uint32_t current_freq;
+	uint32_t lowest_freq;
+};
+
+extern const uint32_t cavs_clock_freq_enc[];
+extern const uint32_t cavs_clock_freq_status_mask[];
+
+void cavs_clock_init(void);
+
+/** @brief Set cAVS clock frequency
+ *
+ * Set xtensa core clock speed.
+ *
+ * @param freq Clock frequency to be set
+ */
+void cavs_clock_set_freq(enum cavs_clock_freq freq);
+
+/** @brief Get list of cAVS clock information
+ *
+ * Returns an array of clock information, one for each core.
+ *
+ * @return array with clock information
+ */
+struct cavs_clock_info *cavs_clocks_get(void);
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS_CLK_H_ */

--- a/soc/xtensa/intel_adsp/common/include/cavs-shim.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-shim.h
@@ -104,6 +104,8 @@ struct cavs_win {
 #define CAVS_CLKCTL_SLIMFDCGB BIT(25)   /* Slimbus force dynamic clock gating*/
 #define CAVS_CLKCTL_TCPLCG(x) BIT(16+x) /* Set bit: prevent clock gating on core x */
 #define CAVS_CLKCTL_SLIMCSS   BIT(6)    /* Slimbus clock (0: XTAL, 1: Audio) */
+#define CAVS_CLKCTL_WOVCRO    BIT(4)    /* Request WOVCRO clock */
+#define CAVS_CLKCTL_WOVCROSC  BIT(3)    /* WOVCRO select */
 #define CAVS_CLKCTL_OCS       BIT(2)    /* Oscillator clock (0: LP, 1: HP) */
 #define CAVS_CLKCTL_LMCS      BIT(1)    /* LP mem divisor (0: div/2, 1: div/4) */
 #define CAVS_CLKCTL_HMCS      BIT(0)    /* HP mem divisor (0: div/2, 1: div/4) */
@@ -125,6 +127,7 @@ struct cavs_win {
 #define CAVS15_CLKCTL_HDOCS           BIT(2)
 #define CAVS15_CLKCTL_LMPCS           BIT(1)
 #define CAVS15_CLKCTL_HMPCS           BIT(0)
+#define CAVS15_CLKCTL_DPCS_MASK(x)    (0x3 << (8 + (x) * 2))
 
 #define CAVS_PWRCTL_TCPDSPPG(x) BIT(x)
 #define CAVS_PWRSTS_PDSPPGS(x)  BIT(x)
@@ -141,5 +144,8 @@ struct cavs_win {
 
 #define CAVS_DMWBA_ENABLE   BIT(0)
 #define CAVS_DMWBA_READONLY BIT(1)
+
+#define CAVS_CLKCTL_OSC_SOURCE_MASK   BIT_MASK(2)
+#define CAVS_CLKCTL_OSC_REQUEST_MASK  (~BIT_MASK(28))
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS_SHIM_H_ */

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -11,6 +11,7 @@
 #include <init.h>
 
 #include <cavs-shim.h>
+#include <cavs-clk.h>
 #include <cavs-idc.h>
 #include "soc.h"
 
@@ -123,6 +124,10 @@ static __imr int soc_init(const struct device *dev)
 	} else {
 		power_init();
 	}
+
+#ifdef CONFIG_CAVS_CLOCK
+	cavs_clock_init();
+#endif
 
 #if CONFIG_MP_NUM_CPUS > 1
 	soc_mp_init();


### PR DESCRIPTION
Simple driver that allows one to choose the clock speed of xtensa cores.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>