### PR TITLE
ci: doc-build: Update doxygen to 1.9.4

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -30,7 +30,7 @@ env:
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5
-  DOXYGEN_VERSION: 1.9.2
+  DOXYGEN_VERSION: 1.9.4
 
 jobs:
   doc-build-html:


### PR DESCRIPTION
    This fixes a documentation build error with PRs as the doxygen 1.9.2
    file has been removed from the doxygen site.
