### PR TITLE
github: workflows: fix documentation build error

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -30,7 +30,7 @@ env:
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5
-  DOXYGEN_VERSION: 1.9.2
+  DOXYGEN_VERSION: 1.9.4
 
 jobs:
   doc-build-html:


### PR DESCRIPTION
Fix the documentation build error due to the broken link.
doxygen-1.9.2.linux.bin.tar.gz is not found hence changing
the doxygen version.

Signed-off-by: Aastha Grover <aastha.grover@intel.com>