### PR TITLE
action: doc: use doxygen 1.9.4

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -30,7 +30,7 @@ env:
   # The latest CMake available directly with apt is 3.18, but we need >=3.20
   # so we fetch that through pip.
   CMAKE_VERSION: 3.20.5
-  DOXYGEN_VERSION: 1.9.2
+  DOXYGEN_VERSION: 1.9.4
 
 jobs:
   doc-build-html:


### PR DESCRIPTION
1.9.2 distribution does not exist any more. Use the 1.9.4 which is the
latest.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
