### PR TITLE
drivers: uart_stm32: fix device is ready for tx dma in async init

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1410,7 +1410,7 @@ static int uart_stm32_async_init(const struct device *dev)
 	}
 
 	if (data->dma_tx.dma_dev != NULL) {
-		if (!device_is_ready(data->dma_rx.dma_dev)) {
+		if (!device_is_ready(data->dma_tx.dma_dev)) {
 			return -ENODEV;
 		}
 	}


### PR DESCRIPTION
Fixes #45155 - TX DMA device "is ready" check in the async initialization function.
