### PR TITLE
dts: nordic: Add missing qdec0 node labels

### DIFF
--- a/dts/arm/nordic/nrf51822.dtsi
+++ b/dts/arm/nordic/nrf51822.dtsi
@@ -229,7 +229,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf52805.dtsi
+++ b/dts/arm/nordic/nrf52805.dtsi
@@ -224,7 +224,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf52810.dtsi
+++ b/dts/arm/nordic/nrf52810.dtsi
@@ -220,7 +220,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf52811.dtsi
+++ b/dts/arm/nordic/nrf52811.dtsi
@@ -246,7 +246,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf52820.dtsi
+++ b/dts/arm/nordic/nrf52820.dtsi
@@ -249,7 +249,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf52832.dtsi
+++ b/dts/arm/nordic/nrf52832.dtsi
@@ -263,7 +263,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf52833.dtsi
+++ b/dts/arm/nordic/nrf52833.dtsi
@@ -265,7 +265,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/dts/arm/nordic/nrf52840.dtsi
+++ b/dts/arm/nordic/nrf52840.dtsi
@@ -260,7 +260,7 @@
 			label = "RTC_1";
 		};
 
-		qdec: qdec@40012000 {
+		qdec: qdec0: qdec@40012000 {
 			compatible = "nordic,nrf-qdec";
 			reg = <0x40012000 0x1000>;
 			interrupts = <18 NRF_DEFAULT_IRQ_PRIORITY>;

--- a/soc/arm/nordic_nrf/validate_base_addresses.c
+++ b/soc/arm/nordic_nrf/validate_base_addresses.c
@@ -28,6 +28,10 @@
 #define NRF_PDM0 NRF_PDM
 #endif
 
+#if !defined(NRF_QDEC0) && defined(NRF_QDEC)
+#define NRF_QDEC0 NRF_QDEC
+#endif
+
 #if !defined(NRF_SWI0) && defined(NRF_SWI_BASE)
 #define NRF_SWI0 ((0 * 0x1000) + NRF_SWI_BASE)
 #endif
@@ -146,7 +150,9 @@ CHECK_DT_REG(pwm0, NRF_PWM0);
 CHECK_DT_REG(pwm1, NRF_PWM1);
 CHECK_DT_REG(pwm2, NRF_PWM2);
 CHECK_DT_REG(pwm3, NRF_PWM3);
-CHECK_DT_REG(qdec, NRF_QDEC);
+CHECK_DT_REG(qdec, NRF_QDEC0);	/* this should be the same node as qdec0 */
+CHECK_DT_REG(qdec0, NRF_QDEC0);
+CHECK_DT_REG(qdec1, NRF_QDEC1);
 CHECK_DT_REG(radio, NRF_RADIO);
 CHECK_DT_REG(regulators, NRF_REGULATORS);
 CHECK_DT_REG(reset, NRF_RESET);


### PR DESCRIPTION
This is a follow-up to commit 586e26e8fc055f5bbbfb8c94b6f59363fd128c31.

Add missing `qdec0` node labels in definitions of SoCs that have only
one QDEC instance so that the `HAS_HW_NRF_QDEC0` option is properly set
for them. Use the same pattern as in the WDT case and keep the existing
`qdec` labels for backward compatibility.
Also update validation of base addresses so that both QDEC0/QDEC and
QDEC1 are checked.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>