### PR TITLE
lib: migrate includes to <zephyr/...>

### DIFF
--- a/lib/libc/arcmwdt/libc-hooks.c
+++ b/lib/libc/arcmwdt/libc-hooks.c
@@ -6,10 +6,10 @@
  */
 
 #include <stdio.h>
-#include <sys/libc-hooks.h>
-#include <syscall_handler.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/syscall_handler.h>
 #include <string.h>
-#include <sys/errno_private.h>
+#include <zephyr/sys/errno_private.h>
 #include <unistd.h>
 #include <errno.h>
 

--- a/lib/libc/arcmwdt/threading.c
+++ b/lib/libc/arcmwdt/threading.c
@@ -6,11 +6,11 @@
 
 #ifdef CONFIG_MULTITHREADING
 
-#include <init.h>
-#include <kernel.h>
-#include <sys/__assert.h>
-#include <sys/mutex.h>
-#include <logging/log.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/mutex.h>
+#include <zephyr/logging/log.h>
 #include <../lib/src/c/inc/internal/thread.h>
 
 #ifndef CONFIG_USERSPACE

--- a/lib/libc/armstdc/include/errno.h
+++ b/lib/libc/armstdc/include/errno.h
@@ -39,7 +39,7 @@
  * @{
  */
 
-#include <sys/errno_private.h>
+#include <zephyr/sys/errno_private.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/libc/armstdc/src/libc-hooks.c
+++ b/lib/libc/armstdc/src/libc-hooks.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <stdio.h>
 
 static int _stdout_hook_default(int c)

--- a/lib/libc/armstdc/src/threading_weak.c
+++ b/lib/libc/armstdc/src/threading_weak.c
@@ -17,7 +17,7 @@
  * CONFIG_MULTITHREADING=n to ensure proper linking.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 int __weak z_impl_k_mutex_init(struct k_mutex *mutex)
 {

--- a/lib/libc/minimal/include/assert.h
+++ b/lib/libc/minimal/include/assert.h
@@ -8,7 +8,7 @@
 #ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_ASSERT_H_
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_ASSERT_H_
 
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/libc/minimal/include/errno.h
+++ b/lib/libc/minimal/include/errno.h
@@ -29,7 +29,7 @@
  * @{
  */
 
-#include <sys/errno_private.h>
+#include <zephyr/sys/errno_private.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/libc/minimal/include/stdio.h
+++ b/lib/libc/minimal/include/stdio.h
@@ -9,7 +9,7 @@
 #ifndef ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_STDIO_H_
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_STDIO_H_
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <stdarg.h>     /* Needed to get definition of va_list */
 #include <stddef.h>
 

--- a/lib/libc/minimal/include/string.h
+++ b/lib/libc/minimal/include/string.h
@@ -10,7 +10,7 @@
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_STRING_H_
 
 #include <stddef.h>
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/lib/libc/minimal/include/time.h
+++ b/lib/libc/minimal/include/time.h
@@ -9,7 +9,7 @@
 #define ZEPHYR_LIB_LIBC_MINIMAL_INCLUDE_TIME_H_
 
 #include <stdint.h>
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <sys/_types.h>
 #include <sys/_timespec.h>
 

--- a/lib/libc/minimal/source/stdlib/abort.c
+++ b/lib/libc/minimal/source/stdlib/abort.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdlib.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 void abort(void)
 {

--- a/lib/libc/minimal/source/stdlib/exit.c
+++ b/lib/libc/minimal/source/stdlib/exit.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdlib.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 void _exit(int status)
 {

--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -5,18 +5,18 @@
  */
 
 #include <stdlib.h>
-#include <zephyr.h>
-#include <init.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
 #include <errno.h>
-#include <sys/math_extras.h>
+#include <zephyr/sys/math_extras.h>
 #include <string.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/mutex.h>
-#include <sys/sys_heap.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/mutex.h>
+#include <zephyr/sys/sys_heap.h>
 #include <zephyr/types.h>
 
 #define LOG_LEVEL CONFIG_KERNEL_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef CONFIG_MINIMAL_LIBC_MALLOC

--- a/lib/libc/minimal/source/stdlib/qsort.c
+++ b/lib/libc/minimal/source/stdlib/qsort.c
@@ -8,7 +8,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <sys/types.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /*
  * Normally parent is defined parent(k) = floor((k-1) / 2) but we can avoid a

--- a/lib/libc/minimal/source/stdlib/rand.c
+++ b/lib/libc/minimal/source/stdlib/rand.c
@@ -5,8 +5,8 @@
  */
 
 #include <stdlib.h>
-#include <sys/libc-hooks.h>
-#include <app_memory/app_memdomain.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
 #define LIBC_DATA K_APP_DMEM(z_libc_partition)
 

--- a/lib/libc/minimal/source/stdout/fprintf.c
+++ b/lib/libc/minimal/source/stdout/fprintf.c
@@ -8,7 +8,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
-#include <sys/cbprintf.h>
+#include <zephyr/sys/cbprintf.h>
 
 #define DESC(d) ((void *)d)
 

--- a/lib/libc/minimal/source/stdout/sprintf.c
+++ b/lib/libc/minimal/source/stdout/sprintf.c
@@ -8,7 +8,7 @@
 
 #include <stdarg.h>
 #include <stdio.h>
-#include <sys/cbprintf.h>
+#include <zephyr/sys/cbprintf.h>
 
 struct emitter {
 	char *ptr;

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -7,8 +7,8 @@
  */
 
 #include <stdio.h>
-#include <sys/libc-hooks.h>
-#include <syscall_handler.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/syscall_handler.h>
 #include <string.h>
 
 static int _stdout_hook_default(int c)

--- a/lib/libc/minimal/source/time/time.c
+++ b/lib/libc/minimal/source/time/time.c
@@ -7,7 +7,7 @@
 #include <time.h>
 
 /* clock_gettime() prototype */
-#include <posix/time.h>
+#include <zephyr/posix/time.h>
 
 time_t time(time_t *tloc)
 {

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -4,23 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 #include <errno.h>
 #include <stdio.h>
 #include <malloc.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 #include <sys/stat.h>
-#include <linker/linker-defs.h>
-#include <sys/util.h>
-#include <sys/errno_private.h>
-#include <sys/heap_listener.h>
-#include <sys/libc-hooks.h>
-#include <syscall_handler.h>
-#include <app_memory/app_memdomain.h>
-#include <init.h>
-#include <sys/sem.h>
-#include <sys/mutex.h>
-#include <sys/mem_manage.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/errno_private.h>
+#include <zephyr/sys/heap_listener.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/sem.h>
+#include <zephyr/sys/mutex.h>
+#include <zephyr/sys/mem_manage.h>
 #include <sys/time.h>
 
 #define LIBC_BSS	K_APP_BMEM(z_libc_partition)

--- a/lib/open-amp/resource_table.c
+++ b/lib/open-amp/resource_table.c
@@ -26,7 +26,7 @@
  *   https://github.com/OpenAMP/open-amp/wiki/OpenAMP-Life-Cycle-Management
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <resource_table.h>
 
 extern char ram_console[];

--- a/lib/os/assert.c
+++ b/lib/os/assert.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/__assert.h>
-#include <sys/printk.h>
-#include <zephyr.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/zephyr.h>
 
 
 /**

--- a/lib/os/base64.c
+++ b/lib/os/base64.c
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 #include <errno.h>
-#include <sys/base64.h>
+#include <zephyr/sys/base64.h>
 
 static const uint8_t base64_enc_map[64] = {
 	'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',

--- a/lib/os/bitarray.c
+++ b/lib/os/bitarray.c
@@ -8,9 +8,9 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <stdio.h>
-#include <sys/bitarray.h>
-#include <sys/check.h>
-#include <sys/sys_io.h>
+#include <zephyr/sys/bitarray.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/sys/sys_io.h>
 
 /* Number of bits represented by one bundle */
 #define bundle_bitness(ba)	(sizeof(ba->bundles[0]) * 8)

--- a/lib/os/cbprintf.c
+++ b/lib/os/cbprintf.c
@@ -6,7 +6,7 @@
 
 #include <stdarg.h>
 #include <stddef.h>
-#include <sys/cbprintf.h>
+#include <zephyr/sys/cbprintf.h>
 
 int cbprintf(cbprintf_cb out, void *ctx, const char *format, ...)
 {

--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -14,10 +14,10 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <sys/types.h>
-#include <sys/util.h>
-#include <sys/cbprintf.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/cbprintf.h>
 
 /* newlib doesn't declare this function unless __POSIX_VISIBLE >= 200809.  No
  * idea how to make that happen, so lets put it right here.

--- a/lib/os/cbprintf_nano.c
+++ b/lib/os/cbprintf_nano.c
@@ -9,9 +9,9 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/cbprintf.h>
+#include <zephyr/sys/cbprintf.h>
 #include <sys/types.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_CBPRINTF_FULL_INTEGRAL
 typedef intmax_t int_value_type;

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -8,11 +8,11 @@
 #include <stdarg.h>
 #include <stdint.h>
 #include <string.h>
-#include <linker/utils.h>
-#include <sys/cbprintf.h>
+#include <zephyr/linker/utils.h>
+#include <zephyr/sys/cbprintf.h>
 #include <sys/types.h>
-#include <sys/util.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/__assert.h>
 
 
 /**

--- a/lib/os/crc16_sw.c
+++ b/lib/os/crc16_sw.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/crc.h>
+#include <zephyr/sys/crc.h>
 
 uint16_t crc16(uint16_t poly, uint16_t seed, const uint8_t *src, size_t len)
 {

--- a/lib/os/crc32_sw.c
+++ b/lib/os/crc32_sw.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/crc.h>
+#include <zephyr/sys/crc.h>
 
 uint32_t crc32_ieee(const uint8_t *data, size_t len)
 {

--- a/lib/os/crc32c_sw.c
+++ b/lib/os/crc32c_sw.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/crc.h>
+#include <zephyr/sys/crc.h>
 
 /* crc table generated from polynomial 0x1EDC6F41UL (Castagnoli) */
 static const uint32_t crc32c_table[16] = {

--- a/lib/os/crc7_sw.c
+++ b/lib/os/crc7_sw.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/crc.h>
+#include <zephyr/sys/crc.h>
 
 uint8_t crc7_be(uint8_t seed, const uint8_t *src, size_t len)
 {

--- a/lib/os/crc8_sw.c
+++ b/lib/os/crc8_sw.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/crc.h>
+#include <zephyr/sys/crc.h>
 
 static const uint8_t crc8_ccitt_small_table[16] = {
 	0x00, 0x07, 0x0e, 0x09, 0x1c, 0x1b, 0x12, 0x15,

--- a/lib/os/dec.c
+++ b/lib/os/dec.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value)
 {

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -15,11 +15,11 @@
 
 #include <errno.h>
 #include <fcntl.h>
-#include <kernel.h>
-#include <sys/fdtable.h>
-#include <sys/speculation.h>
-#include <syscall_handler.h>
-#include <sys/atomic.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/fdtable.h>
+#include <zephyr/sys/speculation.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/sys/atomic.h>
 
 struct fd_entry {
 	void *obj;

--- a/lib/os/heap-validate.c
+++ b/lib/os/heap-validate.c
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/sys_heap.h>
-#include <sys/util.h>
-#include <kernel.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/kernel.h>
 #include "heap.h"
 
 /* White-box sys_heap validation code.  Uses internal data structures.

--- a/lib/os/heap.c
+++ b/lib/os/heap.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/sys_heap.h>
-#include <sys/util.h>
-#include <sys/heap_listener.h>
-#include <kernel.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/heap_listener.h>
+#include <zephyr/kernel.h>
 #include <string.h>
 #include "heap.h"
 

--- a/lib/os/heap_listener.c
+++ b/lib/os/heap_listener.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <spinlock.h>
-#include <sys/heap_listener.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/heap_listener.h>
 
 static struct k_spinlock heap_listener_lock;
 static sys_slist_t heap_listener_list = SYS_SLIST_STATIC_INIT(&heap_listener_list);

--- a/lib/os/hex.c
+++ b/lib/os/hex.c
@@ -7,7 +7,7 @@
 #include <stddef.h>
 #include <zephyr/types.h>
 #include <errno.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 int char2hex(char c, uint8_t *x)
 {

--- a/lib/os/json.c
+++ b/lib/os/json.c
@@ -4,18 +4,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <limits.h>
-#include <sys/printk.h>
-#include <sys/util.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
 #include <zephyr/types.h>
 
-#include <data/json.h>
+#include <zephyr/data/json.h>
 
 struct token {
 	enum json_tokens type;

--- a/lib/os/mem_blocks.c
+++ b/lib/os/mem_blocks.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/__assert.h>
-#include <sys/check.h>
-#include <sys/heap_listener.h>
-#include <sys/mem_blocks.h>
-#include <sys/util.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/sys/heap_listener.h>
+#include <zephyr/sys/mem_blocks.h>
+#include <zephyr/sys/util.h>
 
 static void *alloc_blocks(sys_mem_blocks_t *mem_block, size_t num_blocks)
 {

--- a/lib/os/mpsc_pbuf.c
+++ b/lib/os/mpsc_pbuf.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/mpsc_pbuf.h>
+#include <zephyr/sys/mpsc_pbuf.h>
 
 #define MPSC_PBUF_DEBUG 0
 

--- a/lib/os/multi_heap.c
+++ b/lib/os/multi_heap.c
@@ -1,10 +1,10 @@
 /* Copyright (c) 2021 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/__assert.h>
-#include <sys/util.h>
-#include <sys/sys_heap.h>
-#include <sys/multi_heap.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/sys/multi_heap.h>
 
 void sys_multi_heap_init(struct sys_multi_heap *heap, sys_multi_heap_fn_t choice_fn)
 {

--- a/lib/os/mutex.c
+++ b/lib/os/mutex.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/mutex.h>
-#include <syscall_handler.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/mutex.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/kernel_structs.h>
 
 static struct k_mutex *get_k_mutex(struct sys_mutex *mutex)
 {

--- a/lib/os/notify.c
+++ b/lib/os/notify.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/notify.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/notify.h>
 
 int sys_notify_validate(struct sys_notify *notify)
 {

--- a/lib/os/onoff.c
+++ b/lib/os/onoff.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/onoff.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/onoff.h>
 #include <stdio.h>
 
 #define SERVICE_REFS_MAX UINT16_MAX

--- a/lib/os/p4wq.c
+++ b/lib/os/p4wq.c
@@ -3,12 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <logging/log.h>
-#include <sys/p4wq.h>
-#include <wait_q.h>
-#include <kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/p4wq.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 LOG_MODULE_REGISTER(p4wq);
 

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -12,14 +12,14 @@
  * init time. If no routine is installed, a nop routine is called.
  */
 
-#include <kernel.h>
-#include <sys/printk.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 #include <stdarg.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <syscall_handler.h>
-#include <logging/log.h>
-#include <sys/cbprintf.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/cbprintf.h>
 #include <sys/types.h>
 
 /* Option present only when CONFIG_USERSPACE enabled. */

--- a/lib/os/rb.c
+++ b/lib/os/rb.c
@@ -12,8 +12,8 @@
 #define CHECK(n) /**/
 /* #define CHECK(n) __ASSERT_NO_MSG(n) */
 
-#include <kernel.h>
-#include <sys/rb.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/rb.h>
 #include <stdbool.h>
 
 enum rb_color { RED = 0U, BLACK = 1U };

--- a/lib/os/reboot.c
+++ b/lib/os/reboot.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/timer/system_timer.h>
-#include <sys/reboot.h>
-#include <kernel.h>
-#include <sys/printk.h>
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
 
 extern void sys_arch_reboot(int type);
 

--- a/lib/os/ring_buffer.c
+++ b/lib/os/ring_buffer.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/ring_buffer.h>
+#include <zephyr/sys/ring_buffer.h>
 #include <string.h>
 
 uint32_t ring_buf_put_claim(struct ring_buf *buf, uint8_t **data, uint32_t size)

--- a/lib/os/sem.c
+++ b/lib/os/sem.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/sem.h>
-#include <syscall_handler.h>
+#include <zephyr/sys/sem.h>
+#include <zephyr/syscall_handler.h>
 
 #ifdef CONFIG_USERSPACE
 #define SYS_SEM_MINIMUM      0

--- a/lib/os/shared_multi_heap.c
+++ b/lib/os/shared_multi_heap.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <device.h>
-#include <sys/sys_heap.h>
-#include <sys/multi_heap.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/sys_heap.h>
+#include <zephyr/sys/multi_heap.h>
 
-#include <multi_heap/shared_multi_heap.h>
+#include <zephyr/multi_heap/shared_multi_heap.h>
 
 static struct sys_multi_heap shared_multi_heap;
 static struct sys_heap heap_pool[MAX_SHARED_MULTI_HEAP_ATTR][MAX_MULTI_HEAPS];

--- a/lib/os/thread_entry.c
+++ b/lib/os/thread_entry.c
@@ -11,7 +11,7 @@
  * This file provides the common thread entry function
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #ifdef CONFIG_THREAD_LOCAL_STORAGE
 __thread k_tid_t z_tls_current;

--- a/lib/os/timeutil.c
+++ b/lib/os/timeutil.c
@@ -13,7 +13,7 @@
 #include <zephyr/types.h>
 #include <errno.h>
 #include <stddef.h>
-#include <sys/timeutil.h>
+#include <zephyr/sys/timeutil.h>
 
 /** Convert a civil (proleptic Gregorian) date to days relative to
  * 1970-01-01.

--- a/lib/os/user_work.c
+++ b/lib/os/user_work.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 static void z_work_user_q_main(void *work_q_ptr, void *p2, void *p3)
 {

--- a/lib/os/utf8.c
+++ b/lib/os/utf8.c
@@ -6,7 +6,7 @@
 
 #include <stdint.h>
 #include <string.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 
 #define ASCII_CHAR 0x7F
 #define SEQUENCE_FIRST_MASK 0xC0

--- a/lib/os/winstream.c
+++ b/lib/os/winstream.c
@@ -2,8 +2,8 @@
  * Copyright (c) 2021 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <sys/util.h>
-#include <sys/winstream.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/winstream.h>
 
 /* This code may be used (e.g. for trace/logging) in very early
  * environments where the standard library isn't available yet.

--- a/lib/posix/clock.c
+++ b/lib/posix/clock.c
@@ -3,12 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <errno.h>
-#include <posix/time.h>
-#include <posix/sys/time.h>
-#include <syscall_handler.h>
-#include <spinlock.h>
+#include <zephyr/posix/time.h>
+#include <zephyr/posix/sys/time.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/spinlock.h>
 
 /*
  * `k_uptime_get` returns a timestamp based on an always increasing

--- a/lib/posix/eventfd.c
+++ b/lib/posix/eventfd.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <wait_q.h>
-#include <posix/sys/eventfd.h>
-#include <net/socket.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/posix/sys/eventfd.h>
+#include <zephyr/net/socket.h>
 #include <ksched.h>
 
 struct eventfd {

--- a/lib/posix/fs.c
+++ b/lib/posix/fs.c
@@ -5,15 +5,15 @@
  */
 
 #include <errno.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <limits.h>
-#include <posix/unistd.h>
-#include <posix/dirent.h>
+#include <zephyr/posix/unistd.h>
+#include <zephyr/posix/dirent.h>
 #include <string.h>
-#include <sys/fdtable.h>
+#include <zephyr/sys/fdtable.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <fs/fs.h>
+#include <zephyr/fs/fs.h>
 
 BUILD_ASSERT(PATH_MAX >= MAX_FILE_NAME, "PATH_MAX is less than MAX_FILE_NAME");
 

--- a/lib/posix/getopt/getopt.c
+++ b/lib/posix/getopt/getopt.c
@@ -33,7 +33,7 @@
 #include "getopt.h"
 #include "getopt_common.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(getopt);
 
 #define	BADCH	((int)'?')

--- a/lib/posix/getopt/getopt.h
+++ b/lib/posix/getopt/getopt.h
@@ -11,7 +11,7 @@
 extern "C" {
 #endif
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 struct getopt_state {
 	int opterr;	/* if error message should be printed */

--- a/lib/posix/getopt/getopt_common.c
+++ b/lib/posix/getopt/getopt_common.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <shell/shell.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/shell/shell.h>
 #include "getopt.h"
 
 /* Referring  below variables is not thread safe. They reflects getopt state

--- a/lib/posix/getopt/getopt_long.c
+++ b/lib/posix/getopt/getopt_long.c
@@ -53,7 +53,7 @@
 #include "getopt.h"
 #include "getopt_common.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(getopt);
 
 #define GNU_COMPATIBLE		/* Be more compatible, configure's use us! */

--- a/lib/posix/mqueue.c
+++ b/lib/posix/mqueue.c
@@ -3,12 +3,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <errno.h>
 #include <string.h>
-#include <sys/atomic.h>
-#include <posix/time.h>
-#include <posix/mqueue.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/posix/time.h>
+#include <zephyr/posix/mqueue.h>
 
 typedef struct mqueue_object {
 	sys_snode_t snode;

--- a/lib/posix/nanosleep.c
+++ b/lib/posix/nanosleep.c
@@ -5,13 +5,13 @@
  */
 
 #include <stdint.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <limits.h>
 #include <errno.h>
 /* required for struct timespec */
-#include <posix/time.h>
-#include <sys/util.h>
-#include <sys_clock.h>
+#include <zephyr/posix/time.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys_clock.h>
 
 /**
  * @brief Suspend execution for nanosecond intervals.

--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <stdio.h>
-#include <sys/atomic.h>
+#include <zephyr/sys/atomic.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <posix/pthread.h>
-#include <sys/slist.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/posix/pthread.h>
+#include <zephyr/sys/slist.h>
 
 #define PTHREAD_INIT_FLAGS	PTHREAD_CANCEL_ENABLE
 #define PTHREAD_CANCELED	((void *) -1)

--- a/lib/posix/pthread_barrier.c
+++ b/lib/posix/pthread_barrier.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <posix/pthread.h>
+#include <zephyr/kernel.h>
+#include <zephyr/posix/pthread.h>
 #include <ksched.h>
-#include <wait_q.h>
+#include <zephyr/wait_q.h>
 
 extern struct k_spinlock z_pthread_spinlock;
 

--- a/lib/posix/pthread_common.c
+++ b/lib/posix/pthread_common.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <posix/time.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/posix/time.h>
 
 #ifdef CONFIG_POSIX_CLOCK
 int64_t timespec_to_timeoutms(const struct timespec *abstime)

--- a/lib/posix/pthread_cond.c
+++ b/lib/posix/pthread_cond.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <posix/pthread.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/posix/pthread.h>
 
 extern struct k_spinlock z_pthread_spinlock;
 

--- a/lib/posix/pthread_key.c
+++ b/lib/posix/pthread_key.c
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
-#include <posix/pthread.h>
-#include <posix/pthread_key.h>
+#include <zephyr/kernel.h>
+#include <zephyr/posix/pthread.h>
+#include <zephyr/posix/pthread_key.h>
 
 struct k_sem pthread_key_sem;
 

--- a/lib/posix/pthread_mutex.c
+++ b/lib/posix/pthread_mutex.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <posix/pthread.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/posix/pthread.h>
 
 struct k_spinlock z_pthread_spinlock;
 

--- a/lib/posix/pthread_rwlock.c
+++ b/lib/posix/pthread_rwlock.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <errno.h>
-#include <posix/time.h>
-#include <posix/posix_types.h>
+#include <zephyr/posix/time.h>
+#include <zephyr/posix/posix_types.h>
 
 #define INITIALIZED 1
 #define NOT_INITIALIZED 0

--- a/lib/posix/pthread_sched.c
+++ b/lib/posix/pthread_sched.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <posix/posix_sched.h>
+#include <zephyr/kernel.h>
+#include <zephyr/posix/posix_sched.h>
 
 static bool valid_posix_policy(int policy)
 {

--- a/lib/posix/semaphore.c
+++ b/lib/posix/semaphore.c
@@ -5,7 +5,7 @@
  */
 
 #include <errno.h>
-#include <posix/pthread.h>
+#include <zephyr/posix/pthread.h>
 
 /**
  * @brief Destroy semaphore.

--- a/lib/posix/sleep.c
+++ b/lib/posix/sleep.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <posix/unistd.h>
+#include <zephyr/kernel.h>
+#include <zephyr/posix/unistd.h>
 
 /**
  * @brief Sleep for a specified number of seconds.

--- a/lib/posix/timer.c
+++ b/lib/posix/timer.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <errno.h>
 #include <string.h>
-#include <sys/printk.h>
-#include <posix/time.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/posix/time.h>
 
 #define ACTIVE 1
 #define NOT_ACTIVE 0

--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -6,7 +6,7 @@
 
 #include "smf.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smf);
 
 /*


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all lib code to the
new prefix <zephyr/...>. Note that the conversion has been scripted,
refer to zephyrproject-rtos#45388 for more details.