### PR TITLE
soc: migrate includes to <zephyr/...>

### DIFF
--- a/soc/arc/snps_arc_hsdk/soc.c
+++ b/soc/arc/snps_arc_hsdk/soc.c
@@ -8,8 +8,8 @@
  * This module provides routines to initialize and support soc-level hardware
  * for the HS Development Kit
  */
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include "soc.h"
 
 static int arc_hsdk_init(const struct device *dev)

--- a/soc/arc/snps_arc_hsdk/soc.h
+++ b/soc/arc/snps_arc_hsdk/soc.h
@@ -14,7 +14,7 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 
 /* ARC HS Core IRQs */
@@ -25,8 +25,8 @@
 #ifndef _ASMLANGUAGE
 
 
-#include <sys/util.h>
-#include <random/rand32.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/random/rand32.h>
 
 /* PINMUX IO Hardware Functions */
 #define HSDK_PINMUX_FUNS		8

--- a/soc/arc/snps_arc_iot/soc.c
+++ b/soc/arc/snps_arc_iot/soc.c
@@ -9,8 +9,8 @@
  * for the IoT Development Kit board.
  *
  */
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include "sysconf.h"
 
 #define CPU_FREQ DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency)

--- a/soc/arc/snps_arc_iot/soc.h
+++ b/soc/arc/snps_arc_iot/soc.h
@@ -14,7 +14,7 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /* default system clock */
 #define SYSCLK_DEFAULT_IOSC_HZ			MHZ(16)
@@ -36,8 +36,8 @@
 #ifndef _ASMLANGUAGE
 
 
-#include <sys/util.h>
-#include <random/rand32.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/random/rand32.h>
 
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arc/snps_emsdp/soc.h
+++ b/soc/arc/snps_emsdp/soc.h
@@ -14,7 +14,7 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /* default system clock */
 #define SYSCLK_DEFAULT_IOSC_HZ			MHZ(100)
@@ -26,8 +26,8 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <sys/util.h>
-#include <random/rand32.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/random/rand32.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arc/snps_emsk/soc.h
+++ b/soc/arc/snps_emsk/soc.h
@@ -14,7 +14,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /* default system clock */
 /* On the EM Starter Kit board, the peripheral bus clock frequency is 50Mhz */
@@ -39,8 +39,8 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <sys/util.h>
-#include <random/rand32.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/random/rand32.h>
 
 #define INT_ENABLE_ARC				~(0x00000001 << 8)
 #define INT_ENABLE_ARC_BIT_POS			(8)

--- a/soc/arc/snps_emsk/soc_config.c
+++ b/soc/arc/snps_emsk/soc_config.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include "soc.h"
 
 

--- a/soc/arc/snps_nsim/CMakeLists.txt
+++ b/soc/arc/snps_nsim/CMakeLists.txt
@@ -53,7 +53,4 @@ else()
   zephyr_ld_option_ifdef(CONFIG_SOC_NSIM_HS_MPUV6 -Hlib=hs38_full)
 endif()
 
-zephyr_sources(
-  soc.c
-  soc_config.c
-  )
+zephyr_sources(soc.c)

--- a/soc/arc/snps_nsim/soc.c
+++ b/soc/arc/snps_nsim/soc.c
@@ -12,8 +12,8 @@
  *
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include "soc.h"
 
 #ifdef CONFIG_SMP

--- a/soc/arc/snps_nsim/soc.h
+++ b/soc/arc/snps_nsim/soc.h
@@ -14,7 +14,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /* ARC EM Core IRQs */
 #define IRQ_TIMER0				16
@@ -24,8 +24,8 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <sys/util.h>
-#include <random/rand32.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/random/rand32.h>
 
 #define INT_ENABLE_ARC				~(0x00000001 << 8)
 #define INT_ENABLE_ARC_BIT_POS			(8)

--- a/soc/arc/snps_nsim/soc_config.c
+++ b/soc/arc/snps_nsim/soc_config.c
@@ -4,6 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include "soc.h"

--- a/soc/arc/snps_nsim/soc_config.c
+++ b/soc/arc/snps_nsim/soc_config.c
@@ -1,9 +1,0 @@
-/*
- * Copyright (c) 2018 Synopsys, Inc. All rights reserved.
- *
- * SPDX-License-Identifier: Apache-2.0
- */
-
-#include <zephyr/device.h>
-#include <zephyr/init.h>
-#include "soc.h"

--- a/soc/arm/arm/beetle/power.c
+++ b/soc/arm/arm/beetle/power.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <pm/pm.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
 #include <soc_power.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(gpio0), okay)
 #define CLK_BIT_GPIO0	_BEETLE_GPIO0

--- a/soc/arm/arm/beetle/soc.c
+++ b/soc/arm/arm/beetle/soc.c
@@ -12,12 +12,12 @@
  * for the ARM LTD Beetle SoC.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/arm/beetle/soc.h
+++ b/soc/arm/arm/beetle/soc.h
@@ -12,7 +12,7 @@
 #ifndef _ARM_BEETLE_SOC_H_
 #define _ARM_BEETLE_SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 #include "CMSDK_BEETLE.h"

--- a/soc/arm/arm/designstart/soc.c
+++ b/soc/arm/arm/designstart/soc.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 
 static int arm_designstart_init(const struct device *arg)
 {

--- a/soc/arm/arm/mps2/soc.c
+++ b/soc/arm/arm/mps2/soc.c
@@ -7,11 +7,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
-#include <drivers/gpio/gpio_mmio32.h>
-#include <init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/gpio/gpio_mmio32.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 
 /* Setup GPIO drivers for accessing FPGAIO registers */

--- a/soc/arm/arm/mps2/soc_registers.h
+++ b/soc/arm/arm/mps2/soc_registers.h
@@ -12,7 +12,7 @@
 #ifndef _ARM_MPS2_REGS_H_
 #define _ARM_MPS2_REGS_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
 /* Registers in the FPGA system control block */

--- a/soc/arm/arm/mps3/soc.c
+++ b/soc/arm/arm/mps3/soc.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
-#include <drivers/gpio/gpio_mmio32.h>
-#include <init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/gpio/gpio_mmio32.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 
 /* Setup GPIO drivers for accessing FPGAIO registers */

--- a/soc/arm/arm/musca_b1/soc.c
+++ b/soc/arm/arm/musca_b1/soc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
-#include <init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 /* (Secure System Control) Base Address */
 #define SSE_200_SYSTEM_CTRL_S_BASE	(0x50021000UL)

--- a/soc/arm/arm/musca_b1/soc.h
+++ b/soc/arm/arm/musca_b1/soc.h
@@ -9,7 +9,7 @@
 
 #ifndef _ASMLANGUAGE
 #include "system_cmsdk_musca_b1.h"
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #endif
 
 extern void wakeup_cpu1(void);

--- a/soc/arm/arm/musca_s1/soc.c
+++ b/soc/arm/arm/musca_s1/soc.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
-#include <init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
 /**

--- a/soc/arm/arm/musca_s1/soc.h
+++ b/soc/arm/arm/musca_s1/soc.h
@@ -9,7 +9,7 @@
 
 #ifndef _ASMLANGUAGE
 #include "system_cmsdk_musca_s1.h"
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #endif
 
 #endif /* _SOC_H_ */

--- a/soc/arm/aspeed/aspeed_util.h
+++ b/soc/arm/aspeed/aspeed_util.h
@@ -5,9 +5,9 @@
  */
 #ifndef ZEPHYR_SOC_ARM_ASPEED_UTIL_H_
 #define ZEPHYR_SOC_ARM_ASPEED_UTIL_H_
-#include <sys/util.h>
-#include <devicetree.h>
-#include <toolchain/gcc.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/toolchain/gcc.h>
 
 /* gcc.h doesn't define __section but checkpatch.pl will complain for this. so
  * temporarily add a macro here.

--- a/soc/arm/aspeed/ast10x0/soc.c
+++ b/soc/arm/aspeed/ast10x0/soc.c
@@ -4,13 +4,13 @@
  * Copyright (c) 2021 ASPEED Technology Inc.
  */
 
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <stdint.h>
 #include <string.h>
-#include <linker/linker-defs.h>
-#include <device.h>
-#include <cache.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/device.h>
+#include <zephyr/cache.h>
 #include <soc.h>
 
 extern char __bss_nc_start__[];

--- a/soc/arm/atmel_sam/common/atmel_sam_dt.h
+++ b/soc/arm/atmel_sam/common/atmel_sam_dt.h
@@ -11,7 +11,7 @@
 #ifndef _ATMEL_SAM_DT_H_
 #define _ATMEL_SAM_DT_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* Devicetree macros related to clock */
 

--- a/soc/arm/atmel_sam/common/pinctrl_soc.h
+++ b/soc/arm/atmel_sam/common/pinctrl_soc.h
@@ -12,6 +12,6 @@
 #ifndef ZEPHYR_SOC_ARM_ATMEL_SAM_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_ATMEL_SAM_COMMON_PINCTRL_SOC_H_
 
-#include <drivers/pinctrl/pinctrl_soc_sam_common.h>
+#include <zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h>
 
 #endif /* ZEPHYR_SOC_ARM_ATMEL_SAM_COMMON_PINCTRL_SOC_H_ */

--- a/soc/arm/atmel_sam/common/soc_gpio.c
+++ b/soc/arm/atmel_sam/common/soc_gpio.c
@@ -8,7 +8,7 @@
  * module HAL driver.
  */
 
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 #include "soc_gpio.h"
 
 /*

--- a/soc/arm/atmel_sam/common/soc_pmc.c
+++ b/soc/arm/atmel_sam/common/soc_pmc.c
@@ -9,8 +9,8 @@
  */
 
 #include <soc.h>
-#include <sys/__assert.h>
-#include <sys/util.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
 
 #if ID_PERIPH_COUNT > 74
 #error "Unsupported SoC, update soc_pmc.c functions"

--- a/soc/arm/atmel_sam/common/soc_sam4l_gpio.c
+++ b/soc/arm/atmel_sam/common/soc_sam4l_gpio.c
@@ -8,7 +8,7 @@
  * module HAL driver.
  */
 
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 #include "soc_gpio.h"
 
 static void configure_common_attr(volatile Gpio *gpio,

--- a/soc/arm/atmel_sam/common/soc_sam4l_pm.c
+++ b/soc/arm/atmel_sam/common/soc_sam4l_pm.c
@@ -9,8 +9,8 @@
  */
 
 #include <soc.h>
-#include <sys/__assert.h>
-#include <sys/util.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
 
 /**
  * SAM4L define peripheral-ids out of order.  This maps peripheral-id group

--- a/soc/arm/atmel_sam/sam3x/soc.c
+++ b/soc/arm/atmel_sam/sam3x/soc.c
@@ -13,12 +13,12 @@
  * for the Atmel SAM3X series processor.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /*
  * PLL clock = Main * (MULA + 1) / DIVA

--- a/soc/arm/atmel_sam/sam4e/soc.c
+++ b/soc/arm/atmel_sam/sam4e/soc.c
@@ -15,11 +15,11 @@
  * for the Atmel SAM4E series processor.
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  * @brief Setup various clock on SoC at boot time.

--- a/soc/arm/atmel_sam/sam4e/soc.h
+++ b/soc/arm/atmel_sam/sam4e/soc.h
@@ -15,7 +15,7 @@
 #ifndef _ATMEL_SAM4E_SOC_H_
 #define _ATMEL_SAM4E_SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/atmel_sam/sam4l/soc.c
+++ b/soc/arm/atmel_sam/sam4l/soc.c
@@ -11,10 +11,10 @@
  * for the Atmel SAM4L series processor.
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /** Watchdog control register first write keys */
 #define WDT_FIRST_KEY     0x55ul

--- a/soc/arm/atmel_sam/sam4s/soc.c
+++ b/soc/arm/atmel_sam/sam4s/soc.c
@@ -14,11 +14,11 @@
  * for the Atmel SAM4S series processor.
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  * @brief Setup various clock on SoC at boot time.

--- a/soc/arm/atmel_sam/sam4s/soc.h
+++ b/soc/arm/atmel_sam/sam4s/soc.h
@@ -15,7 +15,7 @@
 #ifndef _ATMEL_SAM4S_SOC_H_
 #define _ATMEL_SAM4S_SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/atmel_sam/same70/soc.c
+++ b/soc/arm/atmel_sam/same70/soc.c
@@ -10,12 +10,12 @@
  * for the Atmel SAM E70 MCU.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <logging/log.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/atmel_sam/same70/soc.h
+++ b/soc/arm/atmel_sam/same70/soc.h
@@ -13,7 +13,7 @@
 #ifndef _ATMEL_SAME70_SOC_H_
 #define _ATMEL_SAME70_SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/atmel_sam/same70/soc_config.c
+++ b/soc/arm/atmel_sam/same70/soc_config.c
@@ -7,10 +7,10 @@
  * @brief System module to support early Atmel SAM E70 MCU configuration
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Perform SoC configuration at boot.

--- a/soc/arm/atmel_sam/samv71/soc.c
+++ b/soc/arm/atmel_sam/samv71/soc.c
@@ -11,12 +11,12 @@
  * for the Atmel SAM V71 MCU.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <logging/log.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/atmel_sam/samv71/soc.h
+++ b/soc/arm/atmel_sam/samv71/soc.h
@@ -14,7 +14,7 @@
 #ifndef _ATMEL_SAMV71_SOC_H_
 #define _ATMEL_SAMV71_SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/atmel_sam/samv71/soc_config.c
+++ b/soc/arm/atmel_sam/samv71/soc_config.c
@@ -8,10 +8,10 @@
  * @brief System module to support early Atmel SAM V71 MCU configuration
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Perform SoC configuration at boot.

--- a/soc/arm/atmel_sam0/common/bossa.c
+++ b/soc/arm/atmel_sam0/common/bossa.c
@@ -5,9 +5,9 @@
  */
 
 #include <soc.h>
-#include <drivers/uart/cdc_acm.h>
-#include <drivers/usb/usb_dc.h>
-#include <usb/class/usb_cdc.h>
+#include <zephyr/drivers/uart/cdc_acm.h>
+#include <zephyr/drivers/usb/usb_dc.h>
+#include <zephyr/usb/class/usb_cdc.h>
 
 /*
  * Magic value that causes the bootloader to stay in bootloader mode instead of

--- a/soc/arm/atmel_sam0/common/pinctrl_soc.h
+++ b/soc/arm/atmel_sam0/common/pinctrl_soc.h
@@ -12,6 +12,6 @@
 #ifndef ZEPHYR_SOC_ARM_ATMEL_SAM_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_ATMEL_SAM_COMMON_PINCTRL_SOC_H_
 
-#include <drivers/pinctrl/pinctrl_soc_sam_common.h>
+#include <zephyr/drivers/pinctrl/pinctrl_soc_sam_common.h>
 
 #endif /* ZEPHYR_SOC_ARM_ATMEL_SAM_COMMON_PINCTRL_SOC_H_ */

--- a/soc/arm/atmel_sam0/common/soc_samd2x.c
+++ b/soc/arm/atmel_sam0/common/soc_samd2x.c
@@ -9,11 +9,11 @@
  * @brief Atmel SAMD MCU series initialization code
  */
 
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
 static void flash_waitstates_init(void)

--- a/soc/arm/atmel_sam0/common/soc_samd5x.c
+++ b/soc/arm/atmel_sam0/common/soc_samd5x.c
@@ -9,10 +9,10 @@
  * @brief Atmel SAMD MCU series initialization code
  */
 
-#include <arch/cpu.h>
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
 #define SAM0_DFLL_FREQ_HZ		(48000000U)

--- a/soc/arm/bcm_vk/valkyrie/soc.c
+++ b/soc/arm/bcm_vk/valkyrie/soc.c
@@ -3,10 +3,10 @@
  * Copyright 2018 Broadcom.
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/bcm_vk/valkyrie/soc.h
+++ b/soc/arm/bcm_vk/valkyrie/soc.h
@@ -6,8 +6,8 @@
 #ifndef SOC_H
 #define SOC_H
 
-#include <sys/util.h>
-#include <toolchain.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/bcm_vk/viper/soc.c
+++ b/soc/arm/bcm_vk/viper/soc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/bcm_vk/viper/soc.h
+++ b/soc/arm/bcm_vk/viper/soc.h
@@ -7,8 +7,8 @@
 #ifndef SOC_H
 #define SOC_H
 
-#include <sys/util.h>
-#include <toolchain.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/common/cortex_m/arm_mpu_mem_cfg.h
+++ b/soc/arm/common/cortex_m/arm_mpu_mem_cfg.h
@@ -6,7 +6,7 @@
 #ifndef _ARM_CORTEX_M_MPU_MEM_CFG_H_
 #define _ARM_CORTEX_M_MPU_MEM_CFG_H_
 
-#include <arch/arm/aarch32/mpu/arm_mpu.h>
+#include <zephyr/arch/arm/aarch32/mpu/arm_mpu.h>
 
 #if !defined(CONFIG_ARMV8_M_BASELINE) && !defined(CONFIG_ARMV8_M_MAINLINE)
 

--- a/soc/arm/common/cortex_m/arm_mpu_regions.c
+++ b/soc/arm/common/cortex_m/arm_mpu_regions.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/slist.h>
-#include <arch/arm/aarch32/mpu/arm_mpu.h>
-#include <linker/devicetree_regions.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/arch/arm/aarch32/mpu/arm_mpu.h>
+#include <zephyr/linker/devicetree_regions.h>
 
 #include "arm_mpu_mem_cfg.h"
 

--- a/soc/arm/cypress/common/cypress_psoc6_dt.h
+++ b/soc/arm/cypress/common/cypress_psoc6_dt.h
@@ -12,7 +12,7 @@
 #ifndef _CYPRESS_PSOC6_DT_H_
 #define _CYPRESS_PSOC6_DT_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /*
  * Devicetree macros related to interrupt

--- a/soc/arm/cypress/psoc6/soc.c
+++ b/soc/arm/cypress/psoc6/soc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #include "cy_syslib.h"
 #include "cy_gpio.h"

--- a/soc/arm/cypress/psoc6/soc.h
+++ b/soc/arm/cypress/psoc6/soc.h
@@ -15,7 +15,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/gigadevice/common/pinctrl_soc.h
+++ b/soc/arm/gigadevice/common/pinctrl_soc.h
@@ -12,6 +12,6 @@
 #ifndef ZEPHYR_SOC_ARM_GIGADEVICE_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_GIGADEVICE_COMMON_PINCTRL_SOC_H_
 
-#include <drivers/pinctrl/pinctrl_soc_gd32_common.h>
+#include <zephyr/drivers/pinctrl/pinctrl_soc_gd32_common.h>
 
 #endif /* ZEPHYR_SOC_ARM_GIGADEVICE_COMMON_PINCTRL_SOC_H_ */

--- a/soc/arm/gigadevice/gd32e10x/soc.c
+++ b/soc/arm/gigadevice/gd32e10x/soc.c
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
 static int gd32e10x_soc_init(const struct device *dev)

--- a/soc/arm/gigadevice/gd32f3x0/soc.c
+++ b/soc/arm/gigadevice/gd32f3x0/soc.c
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
 static int gd32f3x0_init(const struct device *dev)

--- a/soc/arm/gigadevice/gd32f403/soc.c
+++ b/soc/arm/gigadevice/gd32f403/soc.c
@@ -11,8 +11,8 @@
  * hardware for the GigaDevice GD32 SoC.
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/gigadevice/gd32f403/soc.h
+++ b/soc/arm/gigadevice/gd32f403/soc.h
@@ -10,7 +10,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 #include <gd32f403.h>

--- a/soc/arm/gigadevice/gd32f4xx/soc.c
+++ b/soc/arm/gigadevice/gd32f4xx/soc.c
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 
 static int gd32f4xx_soc_init(const struct device *dev)
 {

--- a/soc/arm/infineon_xmc/4xxx/soc.c
+++ b/soc/arm/infineon_xmc/4xxx/soc.c
@@ -6,8 +6,8 @@
  *
  */
 
-#include <kernel.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
 #define PMU_FLASH_WS		(0x3U)

--- a/soc/arm/microchip_mec/common/pinctrl_soc.h
+++ b/soc/arm/microchip_mec/common/pinctrl_soc.h
@@ -14,10 +14,10 @@
 #ifndef ZEPHYR_SOC_ARM_MICROCHIP_XEC_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_MICROCHIP_XEC_COMMON_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
-#include <dt-bindings/pinctrl/mchp-xec-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/mchp-xec-pinctrl.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/microchip_mec/common/soc_espi_saf.h
+++ b/soc/arm/microchip_mec/common/soc_espi_saf.h
@@ -12,7 +12,7 @@
 #define _SOC_ESPI_SAF_H_
 
 #include <stdint.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <soc.h>
 
 #define MCHP_SAF_MAX_FLASH_DEVICES 2U

--- a/soc/arm/microchip_mec/common/soc_i2c.c
+++ b/soc/arm/microchip_mec/common/soc_i2c.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/sys_io.h>
-#include <sys/__assert.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/__assert.h>
 #include <soc.h>
 #include "soc_i2c.h"
 

--- a/soc/arm/microchip_mec/mec1501/device_power.c
+++ b/soc/arm/microchip_mec/mec1501/device_power.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/sys_io.h>
-#include <sys/__assert.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
 
 /*

--- a/soc/arm/microchip_mec/mec1501/power.c
+++ b/soc/arm/microchip_mec/mec1501/power.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/sys_io.h>
-#include <sys/__assert.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
 #include "device_power.h"
 

--- a/soc/arm/microchip_mec/mec1501/soc.c
+++ b/soc/arm/microchip_mec/mec1501/soc.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /* MEC devices IDs with special PLL handling */
 #define MCHP_GCFG_DID_DEV_ID_MEC150x    0x0020U

--- a/soc/arm/microchip_mec/mec1501/timing.c
+++ b/soc/arm/microchip_mec/mec1501/timing.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm/aarch32/arch.h>
-#include <kernel.h>
-#include <sys_clock.h>
-#include <timing/timing.h>
+#include <zephyr/arch/arm/aarch32/arch.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/timing/timing.h>
 #include <soc.h>
 
 void soc_timing_init(void)

--- a/soc/arm/microchip_mec/mec1701/soc.c
+++ b/soc/arm/microchip_mec/mec1701/soc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 
 static int soc_init(const struct device *dev)

--- a/soc/arm/microchip_mec/mec172x/reg/mec172x_ecia.h
+++ b/soc/arm/microchip_mec/mec172x/reg/mec172x_ecia.h
@@ -9,7 +9,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #define ECIA_BASE_ADDR			DT_REG_ADDR(DT_NODELABEL(ecia))
 

--- a/soc/arm/microchip_mec/mec172x/soc.c
+++ b/soc/arm/microchip_mec/mec172x/soc.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/__assert.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 static int soc_init(const struct device *dev)
 {

--- a/soc/arm/microchip_mec/mec172x/soc.h
+++ b/soc/arm/microchip_mec/mec172x/soc.h
@@ -242,7 +242,7 @@ typedef enum {
 	MAX_IRQn
 } IRQn_Type;
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /* chip specific register defines */
 #include "reg/mec172x_defs.h"

--- a/soc/arm/microchip_mec/mec172x/timing.c
+++ b/soc/arm/microchip_mec/mec172x/timing.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm/aarch32/arch.h>
-#include <kernel.h>
-#include <sys_clock.h>
-#include <timing/timing.h>
+#include <zephyr/arch/arm/aarch32/arch.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/timing/timing.h>
 #include <soc.h>
 
 /*

--- a/soc/arm/nordic_nrf/common/pinctrl_soc.h
+++ b/soc/arm/nordic_nrf/common/pinctrl_soc.h
@@ -12,8 +12,8 @@
 #ifndef ZEPHYR_SOC_ARM_NORDIC_NRF_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_NORDIC_NRF_COMMON_PINCTRL_SOC_H_
 
-#include <devicetree.h>
-#include <dt-bindings/pinctrl/nrf-pinctrl.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/dt-bindings/pinctrl/nrf-pinctrl.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus

--- a/soc/arm/nordic_nrf/common/soc_nrf_common.h
+++ b/soc/arm/nordic_nrf/common/soc_nrf_common.h
@@ -12,8 +12,8 @@
 
 #ifndef _ASMLANGUAGE
 #include <nrfx.h>
-#include <devicetree.h>
-#include <toolchain.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/toolchain.h>
 
 /**
  * @brief Get a PSEL value out of a foo-gpios or foo-pin devicetree property

--- a/soc/arm/nordic_nrf/nrf51/power.c
+++ b/soc/arm/nordic_nrf/nrf51/power.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <hal/nrf_power.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */

--- a/soc/arm/nordic_nrf/nrf51/soc.c
+++ b/soc/arm/nordic_nrf/nrf51/soc.c
@@ -13,11 +13,11 @@
  * for the Nordic Semiconductor nRF51 family processor.
  */
 
-#include <kernel.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <hal/nrf_power.h>
 #include <soc/nrfx_coredep.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);

--- a/soc/arm/nordic_nrf/nrf52/power.c
+++ b/soc/arm/nordic_nrf/nrf52/power.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <hal/nrf_power.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */

--- a/soc/arm/nordic_nrf/nrf52/soc.c
+++ b/soc/arm/nordic_nrf/nrf52/soc.c
@@ -12,12 +12,12 @@
  * for the Nordic Semiconductor nRF52 family processor.
  */
 
-#include <kernel.h>
-#include <init.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <hal/nrf_power.h>
 #include <soc/nrfx_coredep.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);

--- a/soc/arm/nordic_nrf/nrf53/power.c
+++ b/soc/arm/nordic_nrf/nrf53/power.c
@@ -4,12 +4,12 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 
 #include <hal/nrf_regulators.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */

--- a/soc/arm/nordic_nrf/nrf53/soc.c
+++ b/soc/arm/nordic_nrf/nrf53/soc.c
@@ -12,15 +12,15 @@
  * for the Nordic Semiconductor nRF53 family processor.
  */
 
-#include <kernel.h>
-#include <init.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <soc/nrfx_coredep.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #include <nrf_erratas.h>
 #if defined(CONFIG_SOC_NRF5340_CPUAPP)
-#include <drivers/gpio.h>
-#include <devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/devicetree.h>
 #include <hal/nrf_cache.h>
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_oscillators.h>

--- a/soc/arm/nordic_nrf/nrf53/sync_rtc.c
+++ b/soc/arm/nordic_nrf/nrf53/sync_rtc.c
@@ -6,11 +6,11 @@
 #include <nrfx_dppi.h>
 #include <hal/nrf_ipc.h>
 #include <helpers/nrfx_gppi.h>
-#include <drivers/timer/nrf_rtc_timer.h>
-#include <drivers/ipm.h>
-#include <drivers/mbox.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
+#include <zephyr/drivers/timer/nrf_rtc_timer.h>
+#include <zephyr/drivers/ipm.h>
+#include <zephyr/drivers/mbox.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sync_rtc, CONFIG_SYNC_RTC_LOG_LEVEL);
 
 /* Arbitrary delay is used needed to handle cases when offset between cores is

--- a/soc/arm/nordic_nrf/nrf91/power.c
+++ b/soc/arm/nordic_nrf/nrf91/power.c
@@ -4,11 +4,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <hal/nrf_regulators.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */

--- a/soc/arm/nordic_nrf/nrf91/soc.c
+++ b/soc/arm/nordic_nrf/nrf91/soc.c
@@ -12,11 +12,11 @@
  * for the Nordic Semiconductor nRF91 family processor.
  */
 
-#include <kernel.h>
-#include <init.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <soc/nrfx_coredep.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #ifdef CONFIG_RUNTIME_NMI
 extern void z_arm_nmi_init(void);

--- a/soc/arm/nordic_nrf/timing.c
+++ b/soc/arm/nordic_nrf/timing.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm/aarch32/arch.h>
-#include <kernel.h>
-#include <sys_clock.h>
-#include <timing/timing.h>
+#include <zephyr/arch/arm/aarch32/arch.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/timing/timing.h>
 #include <nrfx.h>
 
 #if defined(CONFIG_NRF_RTC_TIMER)

--- a/soc/arm/nordic_nrf/validate_base_addresses.c
+++ b/soc/arm/nordic_nrf/validate_base_addresses.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /*
  * Account for MDK inconsistencies

--- a/soc/arm/nordic_nrf/validate_enabled_instances.c
+++ b/soc/arm/nordic_nrf/validate_enabled_instances.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #define I2C_ENABLED(idx)  (IS_ENABLED(CONFIG_I2C) && \
 			   DT_NODE_HAS_STATUS(DT_NODELABEL(i2c##idx), okay))

--- a/soc/arm/nuvoton_npcx/common/power.c
+++ b/soc/arm/nuvoton_npcx/common/power.c
@@ -45,16 +45,16 @@
  * INCLUDE FILES: soc_clock.h
  */
 
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <zephyr.h>
-#include <drivers/espi.h>
-#include <pm/pm.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/espi.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
 
 #include "soc_host.h"
 #include "soc_power.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* The steps that npcx ec enters sleep/deep mode and leaves it. */

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -9,10 +9,10 @@
 
 #include <stdint.h>
 
-#include <devicetree.h>
-#include <sys/__assert.h>
-#include <sys/util_macro.h>
-#include <toolchain.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 /*
  * NPCX register structure size/offset checking macro function to mitigate

--- a/soc/arm/nuvoton_npcx/common/registers.c
+++ b/soc/arm/nuvoton_npcx/common/registers.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <soc.h>
 
 /* CDCG register structure check */

--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/gpio.h>
-#include <dt-bindings/pinctrl/npcx-pinctrl.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/dt-bindings/pinctrl/npcx-pinctrl.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
 #include "soc_gpio.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pimux_npcx, LOG_LEVEL_ERR);
 
 /* Driver config */

--- a/soc/arm/nuvoton_npcx/common/soc_clock.h
+++ b/soc/arm/nuvoton_npcx/common/soc_clock.h
@@ -10,7 +10,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -7,9 +7,9 @@
 #ifndef _NUVOTON_NPCX_SOC_DT_H_
 #define _NUVOTON_NPCX_SOC_DT_H_
 
-#include <devicetree.h>
-#include <irq.h>
-#include <sys/util_macro.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/util_macro.h>
 
 /**
  * @brief Like DT_PROP(), but expand parameters with

--- a/soc/arm/nuvoton_npcx/common/soc_espi.h
+++ b/soc/arm/nuvoton_npcx/common/soc_espi.h
@@ -7,7 +7,7 @@
 #ifndef _NUVOTON_NPCX_SOC_ESPI_H_
 #define _NUVOTON_NPCX_SOC_ESPI_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nuvoton_npcx/common/soc_gpio.h
+++ b/soc/arm/nuvoton_npcx/common/soc_gpio.h
@@ -7,7 +7,7 @@
 #ifndef _NUVOTON_NPCX_SOC_GPIO_H_
 #define _NUVOTON_NPCX_SOC_GPIO_H_
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nuvoton_npcx/common/soc_host.h
+++ b/soc/arm/nuvoton_npcx/common/soc_host.h
@@ -9,9 +9,9 @@
 
 #include <stdint.h>
 
-#include <device.h>
-#include <drivers/espi.h>
-#include <sys/slist.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/espi.h>
+#include <zephyr/sys/slist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nuvoton_npcx/common/soc_miwu.h
+++ b/soc/arm/nuvoton_npcx/common/soc_miwu.h
@@ -9,8 +9,8 @@
 
 #include <stdint.h>
 
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nuvoton_npcx/npcx7/soc.c
+++ b/soc/arm/nuvoton_npcx/npcx7/soc.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 

--- a/soc/arm/nuvoton_npcx/npcx9/soc.c
+++ b/soc/arm/nuvoton_npcx/npcx9/soc.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 

--- a/soc/arm/nuvoton_numicro/m48x/soc.c
+++ b/soc/arm/nuvoton_numicro/m48x/soc.c
@@ -5,8 +5,8 @@
  * Author: Saravanan Sekar <saravanan@linumiz.com>
  */
 
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 
 void z_arm_platform_init(void)
 {

--- a/soc/arm/nuvoton_numicro/m48x/soc.h
+++ b/soc/arm/nuvoton_numicro/m48x/soc.h
@@ -8,7 +8,7 @@
 #ifndef ZEPHYR_SOC_ARM_NUVOTON_M48X_SOC_H_
 #define ZEPHYR_SOC_ARM_NUVOTON_M48X_SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <NuMicro.h>
 
 #endif /* ZEPHYR_SOC_ARM_NUVOTON_M48X_SOC_H_*/

--- a/soc/arm/nxp_imx/mcimx6x_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx6x_m4/soc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <dt-bindings/rdc/imx_rdc.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include "wdog_imx.h"
 
 /* Initialize Resource Domain Controller. */

--- a/soc/arm/nxp_imx/mcimx7_m4/soc.c
+++ b/soc/arm/nxp_imx/mcimx7_m4/soc.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include "wdog_imx.h"
 
 /* Initialize clock. */

--- a/soc/arm/nxp_imx/mimx8ml8_m7/mpu_regions.c
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include "../../common/cortex_m/arm_mpu_mem_cfg.h"
 
 #define REGION_MASK_BASE_ADDRESS			0x00000000U

--- a/soc/arm/nxp_imx/mimx8ml8_m7/soc.c
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/soc.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_rdc.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
-#include <dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
 
 /* OSC/PLL is already initialized by ROM and Cortex-A53 (u-boot) */
 static void SOC_RdcInit(void)

--- a/soc/arm/nxp_imx/mimx8mm6_m4/soc.c
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/soc.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_rdc.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
-#include <dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
 
 /* OSC/PLL is already initialized by ROM and Cortex-A53 (u-boot) */
 static void SOC_RdcInit(void)

--- a/soc/arm/nxp_imx/mimx8mq6_m4/soc.c
+++ b/soc/arm/nxp_imx/mimx8mq6_m4/soc.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <fsl_clock.h>
 #include <fsl_common.h>
 #include <fsl_rdc.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 
-#include <dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
 
 /* OSC/PLL is already initialized by ROM and Cortex-A53 (u-boot) */
 static void SOC_RdcInit(void)

--- a/soc/arm/nxp_imx/rt/lpm_rt1064.c
+++ b/soc/arm/nxp_imx/rt/lpm_rt1064.c
@@ -7,9 +7,9 @@
  * to the flexspi modules must be linked to RAM, or within this file
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <power_rt10xx.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include "clock_config.h"
 
 

--- a/soc/arm/nxp_imx/rt/mpu_regions.c
+++ b/soc/arm/nxp_imx/rt/mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include "../../common/cortex_m/arm_mpu_mem_cfg.h"
 #define IS_CHOSEN_SRAM(x) (DT_DEP_ORD(DT_NODELABEL(x)) == DT_DEP_ORD(DT_CHOSEN(zephyr_sram)))
 

--- a/soc/arm/nxp_imx/rt/pinctrl_rt10xx.h
+++ b/soc/arm/nxp_imx/rt/pinctrl_rt10xx.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_IMX_RT_PINCTRL_RT10XX_H_
 #define ZEPHYR_SOC_ARM_NXP_IMX_RT_PINCTRL_RT10XX_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 #include "fsl_common.h"
 

--- a/soc/arm/nxp_imx/rt/pinctrl_rt11xx.h
+++ b/soc/arm/nxp_imx/rt/pinctrl_rt11xx.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_IMX_RT_PINCTRL_RT11XX_H_
 #define ZEPHYR_SOC_ARM_NXP_IMX_RT_PINCTRL_RT11XX_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 #include "fsl_common.h"
 

--- a/soc/arm/nxp_imx/rt/power_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt10xx.c
@@ -6,15 +6,15 @@
  * Note: this file is linked to RAM. Any functions called while preparing for
  * sleep mode must be defined within this file, or linked to RAM.
  */
-#include <zephyr.h>
-#include <device.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/pm/pm.h>
 #include <fsl_dcdc.h>
 #include <fsl_pmu.h>
 #include <fsl_gpc.h>
 #include <fsl_lpuart.h>
 #include <fsl_clock.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #include "power_rt10xx.h"
 

--- a/soc/arm/nxp_imx/rt/power_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/power_rt11xx.c
@@ -3,15 +3,15 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <device.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/pm/pm.h>
 #include <fsl_dcdc.h>
 #include <fsl_gpc.h>
-#include <dt-bindings/pm/imx_spc.h>
+#include <zephyr/dt-bindings/pm/imx_spc.h>
 #include "power_rt11xx.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /*

--- a/soc/arm/nxp_imx/rt/soc.h
+++ b/soc/arm/nxp_imx/rt/soc.h
@@ -7,14 +7,14 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 
 #include <fsl_common.h>
 
 /* Add include for DTS generated information */
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nxp_imx/rt/soc_rt10xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt10xx.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <linker/sections.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/linker/linker-defs.h>
 #include <fsl_clock.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <fsl_flexspi_nor_boot.h>
-#include <dt-bindings/clock/imx_ccm.h>
+#include <zephyr/dt-bindings/clock/imx_ccm.h>
 #include <fsl_iomuxc.h>
 #if CONFIG_USB_DC_NXP_EHCI
 #include "usb_phy.h"

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <linker/sections.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/linker/linker-defs.h>
 #include <fsl_clock.h>
 #include <fsl_gpc.h>
 #include <fsl_pmu.h>
 #include <fsl_dcdc.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <fsl_flexspi_nor_boot.h>
-#include <dt-bindings/clock/imx_ccm_rev2.h>
+#include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
 #if CONFIG_USB_DC_NXP_EHCI
 #include "usb_phy.h"
 #include "usb_dc_mcux.h"

--- a/soc/arm/nxp_imx/rt5xx/pinctrl_soc.h
+++ b/soc/arm/nxp_imx/rt5xx/pinctrl_soc.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_IMX_RT5XX_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_NXP_IMX_RT5XX_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -12,7 +12,7 @@
  * hardware for the RT5XX platforms.
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include "flash_clock_setup.h"
 #include "fsl_power.h"

--- a/soc/arm/nxp_imx/rt5xx/soc.h
+++ b/soc/arm/nxp_imx/rt5xx/soc.h
@@ -16,7 +16,7 @@
 #define _SOC__H_
 
 #ifndef _ASMLANGUAGE
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <fsl_common.h>
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/nxp_imx/rt6xx/pinctrl_soc.h
+++ b/soc/arm/nxp_imx/rt6xx/pinctrl_soc.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_IMX_RT6XX_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_NXP_IMX_RT6XX_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus

--- a/soc/arm/nxp_imx/rt6xx/power.c
+++ b/soc/arm/nxp_imx/rt6xx/power.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include "fsl_power.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /*!< Power down all unnecessary blocks and enable RBB during deep sleep. */

--- a/soc/arm/nxp_imx/rt6xx/soc.c
+++ b/soc/arm/nxp_imx/rt6xx/soc.c
@@ -12,13 +12,13 @@
  * hardware for the nxp_lpc55s69 platform.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <drivers/uart.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 #include <aarch32/cortex_m/exc.h>
 #include <fsl_power.h>
 #include <fsl_clock.h>

--- a/soc/arm/nxp_imx/rt6xx/soc.h
+++ b/soc/arm/nxp_imx/rt6xx/soc.h
@@ -16,11 +16,11 @@
 #define _SOC__H_
 
 #ifndef _ASMLANGUAGE
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <fsl_common.h>
 
 /* Add include for DTS generated information */
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/common/pinctrl_soc.h
+++ b/soc/arm/nxp_kinetis/common/pinctrl_soc.h
@@ -12,7 +12,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_KINETIS_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_NXP_KINETIS_COMMON_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus

--- a/soc/arm/nxp_kinetis/flash_configuration.c
+++ b/soc/arm/nxp_kinetis/flash_configuration.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <linker/sections.h>
+#include <zephyr/kernel.h>
+#include <zephyr/linker/sections.h>
 
 uint8_t __kinetis_flash_config_section __kinetis_flash_config[] = {
 	/* Backdoor Comparison Key (unused) */

--- a/soc/arm/nxp_kinetis/k2x/soc.c
+++ b/soc/arm/nxp_kinetis/k2x/soc.c
@@ -15,15 +15,15 @@
  * hardware for the fsl_frdm_k22f platform.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <drivers/uart.h>
+#include <zephyr/drivers/uart.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #define TIMESRC_OSCERCLK        (2)
 

--- a/soc/arm/nxp_kinetis/k2x/soc.h
+++ b/soc/arm/nxp_kinetis/k2x/soc.h
@@ -17,7 +17,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -30,9 +30,9 @@ extern "C" {
 #ifndef _ASMLANGUAGE
 
 #include <fsl_common.h>
-#include <device.h>
-#include <sys/util.h>
-#include <random/rand32.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/random/rand32.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/k6x/nxp_mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <soc.h>
-#include <arch/arm/aarch32/mpu/nxp_mpu.h>
+#include <zephyr/arch/arm/aarch32/mpu/nxp_mpu.h>
 
 static const struct nxp_mpu_region mpu_regions[] = {
 	/* Region 0 */

--- a/soc/arm/nxp_kinetis/k6x/soc.c
+++ b/soc/arm/nxp_kinetis/k6x/soc.c
@@ -13,15 +13,15 @@
  * hardware for the fsl_frdm_k64f platform.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <drivers/uart.h>
+#include <zephyr/drivers/uart.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #define LPUART0SRC_OSCERCLK     (1)
 

--- a/soc/arm/nxp_kinetis/k6x/soc.h
+++ b/soc/arm/nxp_kinetis/k6x/soc.h
@@ -15,7 +15,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /* address bases */
 

--- a/soc/arm/nxp_kinetis/k8x/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/k8x/nxp_mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <soc.h>
-#include <arch/arm/aarch32/mpu/nxp_mpu.h>
+#include <zephyr/arch/arm/aarch32/mpu/nxp_mpu.h>
 
 static const struct nxp_mpu_region mpu_regions[] = {
 	/* Region 0 */

--- a/soc/arm/nxp_kinetis/k8x/soc.c
+++ b/soc/arm/nxp_kinetis/k8x/soc.c
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
 

--- a/soc/arm/nxp_kinetis/k8x/soc.h
+++ b/soc/arm/nxp_kinetis/k8x/soc.h
@@ -7,7 +7,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nxp_kinetis/ke1xf/nxp_mpu_regions.c
+++ b/soc/arm/nxp_kinetis/ke1xf/nxp_mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <soc.h>
-#include <arch/arm/aarch32/mpu/nxp_mpu.h>
+#include <zephyr/arch/arm/aarch32/mpu/nxp_mpu.h>
 
 static const struct nxp_mpu_region mpu_regions[] = {
 	/* Region 0 */

--- a/soc/arm/nxp_kinetis/ke1xf/power.c
+++ b/soc/arm/nxp_kinetis/ke1xf/power.c
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <logging/log.h>
-#include <pm/pm.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
 
 LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);

--- a/soc/arm/nxp_kinetis/ke1xf/soc.c
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.c
@@ -8,12 +8,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <fsl_clock.h>
 #include <fsl_cache.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #define ASSERT_WITHIN_RANGE(val, min, max, str) \
 	BUILD_ASSERT(val >= min && val <= max, str)

--- a/soc/arm/nxp_kinetis/ke1xf/soc.h
+++ b/soc/arm/nxp_kinetis/ke1xf/soc.h
@@ -7,7 +7,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/nxp_kinetis/kl2x/soc.c
+++ b/soc/arm/nxp_kinetis/kl2x/soc.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 #define LPSCI0SRC_MCGFLLCLK	(1)
 

--- a/soc/arm/nxp_kinetis/kl2x/soc.h
+++ b/soc/arm/nxp_kinetis/kl2x/soc.h
@@ -7,7 +7,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #define UART0_CLK_SRC kCLOCK_CoreSysClk
 

--- a/soc/arm/nxp_kinetis/kv5x/soc.c
+++ b/soc/arm/nxp_kinetis/kv5x/soc.c
@@ -8,9 +8,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
 

--- a/soc/arm/nxp_kinetis/kv5x/soc.h
+++ b/soc/arm/nxp_kinetis/kv5x/soc.h
@@ -7,7 +7,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/nxp_kinetis/kwx/soc.h
+++ b/soc/arm/nxp_kinetis/kwx/soc.h
@@ -8,7 +8,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #if defined(CONFIG_SOC_MKW40Z4) || defined(CONFIG_SOC_MKW41Z4)
 

--- a/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw2xd.c
@@ -6,15 +6,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <drivers/uart.h>
+#include <zephyr/drivers/uart.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #define PLLFLLSEL_MCGFLLCLK	(0)
 #define PLLFLLSEL_MCGPLLCLK	(1)

--- a/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
+++ b/soc/arm/nxp_kinetis/kwx/soc_kw4xz.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <drivers/uart.h>
+#include <zephyr/drivers/uart.h>
 #include <fsl_common.h>
 #include <fsl_clock.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 #define LPUART0SRC_OSCERCLK	(1)
 #define TPMSRC_MCGPLLCLK	(1)

--- a/soc/arm/nxp_lpc/lpc11u6x/soc.c
+++ b/soc/arm/nxp_lpc/lpc11u6x/soc.c
@@ -12,12 +12,12 @@
  * hardware for the nxp_lpc11u6x platform.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 #include <aarch32/cortex_m/exc.h>
 
 /**

--- a/soc/arm/nxp_lpc/lpc11u6x/soc.h
+++ b/soc/arm/nxp_lpc/lpc11u6x/soc.h
@@ -16,7 +16,7 @@
 #define _SOC__H_
 
 #ifndef _ASMLANGUAGE
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/arm/nxp_lpc/lpc54xxx/pinctrl_soc.h
+++ b/soc/arm/nxp_lpc/lpc54xxx/pinctrl_soc.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_LPC_54xxx_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_NXP_LPC_54xxx_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.c
@@ -12,13 +12,13 @@
  * hardware for the nxp_lpc54114 platform.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <drivers/uart.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 #include <aarch32/cortex_m/exc.h>
 #include <fsl_power.h>
 #include <fsl_clock.h>

--- a/soc/arm/nxp_lpc/lpc54xxx/soc.h
+++ b/soc/arm/nxp_lpc/lpc54xxx/soc.h
@@ -16,7 +16,7 @@
 #define _SOC__H_
 
 #ifndef _ASMLANGUAGE
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <fsl_common.h>
 
 

--- a/soc/arm/nxp_lpc/lpc55xxx/pinctrl_soc.h
+++ b/soc/arm/nxp_lpc/lpc55xxx/pinctrl_soc.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_LPC_55xxx_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_NXP_LPC_55xxx_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
 #ifdef __cplusplus

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.c
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.c
@@ -12,13 +12,13 @@
  * hardware for the nxp_lpc55s69 platform.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <drivers/uart.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 #include <aarch32/cortex_m/exc.h>
 #include <fsl_power.h>
 #include <fsl_clock.h>

--- a/soc/arm/nxp_lpc/lpc55xxx/soc.h
+++ b/soc/arm/nxp_lpc/lpc55xxx/soc.h
@@ -16,7 +16,7 @@
 #define _SOC__H_
 
 #ifndef _ASMLANGUAGE
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <fsl_common.h>
 
 

--- a/soc/arm/quicklogic_eos_s3/soc.c
+++ b/soc/arm/quicklogic_eos_s3/soc.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <soc_pinmap.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 void eos_s3_lock_enable(void)
 {

--- a/soc/arm/quicklogic_eos_s3/soc.h
+++ b/soc/arm/quicklogic_eos_s3/soc.h
@@ -7,7 +7,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <eoss3_dev.h>
 
 /* Available frequencies */

--- a/soc/arm/renesas_rcar/gen3/pfc_r8a77951.c
+++ b/soc/arm/renesas_rcar/gen3/pfc_r8a77951.c
@@ -6,7 +6,7 @@
  */
 
 #include "pinctrl_soc.h"
-#include <dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
+#include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
 
 const struct pfc_drive_reg pfc_drive_regs[] = {
 	/* DRVCTRL0 */

--- a/soc/arm/renesas_rcar/gen3/pinctrl_soc.h
+++ b/soc/arm/renesas_rcar/gen3/pinctrl_soc.h
@@ -8,10 +8,10 @@
 #ifndef ZEPHYR_SOC_ARM_RENESAS_RCAR_GEN3_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_RENESAS_RCAR_GEN3_PINCTRL_SOC_H_
 
-#include <devicetree.h>
-#include <dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-rcar-common.h>
 #include <stdint.h>
-#include <sys/util_macro.h>
+#include <zephyr/sys/util_macro.h>
 
 struct rcar_pin_func {
 	uint8_t bank:5;      /* bank number 0 - 18 */

--- a/soc/arm/renesas_rcar/gen3/soc.c
+++ b/soc/arm/renesas_rcar/gen3/soc.c
@@ -5,9 +5,9 @@
  *
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 
 /**
  *

--- a/soc/arm/rpi_pico/rp2/pinctrl_soc.h
+++ b/soc/arm/rpi_pico/rp2/pinctrl_soc.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_RPI_PICO_RP2_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_RPI_PICO_RP2_PINCTRL_SOC_H_
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 /**
  * @brief Type to hold a pin's pinctrl configuration.

--- a/soc/arm/rpi_pico/rp2/soc.c
+++ b/soc/arm/rpi_pico/rp2/soc.c
@@ -13,9 +13,9 @@
  * for the Raspberry Pi RP2040 family processor.
  */
 
-#include <kernel.h>
-#include <init.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
 
 #include <hardware/regs/resets.h>
 #include <hardware/clocks.h>

--- a/soc/arm/silabs_exx32/common/soc.c
+++ b/soc/arm/silabs_exx32/common/soc.c
@@ -9,16 +9,16 @@
  * @brief Common SoC initialization for the EXX32
  */
 
-#include <kernel.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <em_cmu.h>
 #include <em_emu.h>
 #include <em_chip.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(soc, CONFIG_SOC_LOG_LEVEL);
 

--- a/soc/arm/silabs_exx32/common/soc_power.c
+++ b/soc/arm/silabs_exx32/common/soc_power.c
@@ -3,11 +3,11 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <em_emu.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /*

--- a/soc/arm/silabs_exx32/efm32gg11b/soc.h
+++ b/soc/arm/silabs_exx32/efm32gg11b/soc.h
@@ -14,7 +14,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32gg11b/soc_pinmap.h
@@ -15,7 +15,7 @@
 #ifndef _SILABS_EFM32GG11B_SOC_PINMAP_H_
 #define _SILABS_EFM32GG11B_SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32hg/soc.h
+++ b/soc/arm/silabs_exx32/efm32hg/soc.h
@@ -13,12 +13,12 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 
 #include <em_common.h>
-#include <device.h>
+#include <zephyr/device.h>
 
 #include "soc_pinmap.h"
 #include "../common/soc_gpio.h"

--- a/soc/arm/silabs_exx32/efm32jg12b/soc.h
+++ b/soc/arm/silabs_exx32/efm32jg12b/soc.h
@@ -13,7 +13,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32jg12b/soc_pinmap.h
@@ -13,7 +13,7 @@
 #ifndef _SILABS_EFM32JG12B_SOC_PINMAP_H_
 #define _SILABS_EFM32JG12B_SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32pg12b/soc.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc.h
@@ -13,7 +13,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg12b/soc_pinmap.h
@@ -13,7 +13,7 @@
 #ifndef _SILABS_EFM32PG12B_SOC_PINMAP_H_
 #define _SILABS_EFM32PG12B_SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32pg1b/soc.h
+++ b/soc/arm/silabs_exx32/efm32pg1b/soc.h
@@ -13,7 +13,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efm32pg1b/soc_pinmap.h
@@ -13,7 +13,7 @@
 #ifndef _SILABS_EFM32PG1B_SOC_PINMAP_H_
 #define _SILABS_EFM32PG1B_SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efm32wg/soc.h
+++ b/soc/arm/silabs_exx32/efm32wg/soc.h
@@ -13,7 +13,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efr32bg13p/soc.h
+++ b/soc/arm/silabs_exx32/efr32bg13p/soc.h
@@ -13,7 +13,7 @@
 #ifndef EFR32BG13P_SOC_H_
 #define EFR32BG13P_SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efr32bg13p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32bg13p/soc_pinmap.h
@@ -10,7 +10,7 @@
 #ifndef SOC_PINMAP_H_
 #define SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <em_gpio.h>
 
 #define GPIO_NODE DT_INST(0, silabs_gecko_gpio)

--- a/soc/arm/silabs_exx32/efr32fg13p/soc.h
+++ b/soc/arm/silabs_exx32/efr32fg13p/soc.h
@@ -13,7 +13,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32fg13p/soc_pinmap.h
@@ -13,7 +13,7 @@
 #ifndef _SILABS_EFR32FG13P_SOC_PINMAP_H_
 #define _SILABS_EFR32FG13P_SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efr32fg1p/soc.h
+++ b/soc/arm/silabs_exx32/efr32fg1p/soc.h
@@ -13,7 +13,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32fg1p/soc_pinmap.h
@@ -13,7 +13,7 @@
 #ifndef _SILABS_EFR32FG1P_SOC_PINMAP_H_
 #define _SILABS_EFR32FG1P_SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
 #include <em_gpio.h>
 

--- a/soc/arm/silabs_exx32/efr32mg12p/soc.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc.h
@@ -13,7 +13,7 @@
 #ifndef _SOC__H_
 #define _SOC__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
+++ b/soc/arm/silabs_exx32/efr32mg12p/soc_pinmap.h
@@ -13,7 +13,7 @@
 #ifndef _SOC_PINMAP_H_
 #define _SOC_PINMAP_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <em_gpio.h>
 
 #define GPIO_NODE DT_INST(0, silabs_gecko_gpio)

--- a/soc/arm/silabs_exx32/efr32mg21/soc.h
+++ b/soc/arm/silabs_exx32/efr32mg21/soc.h
@@ -13,7 +13,7 @@
 #ifndef ZEPHYR_SOC_ARM_SILABS_EXX32_EFR32MG21_SOC_H
 #define ZEPHYR_SOC_ARM_SILABS_EXX32_EFR32MG21_SOC_H
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/arm/st_stm32/common/pinctrl_soc.h
+++ b/soc/arm/st_stm32/common/pinctrl_soc.h
@@ -13,13 +13,13 @@
 #ifndef ZEPHYR_SOC_ARM_ST_STM32_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_ST_STM32_COMMON_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
 #ifdef CONFIG_SOC_SERIES_STM32F1X
-#include <dt-bindings/pinctrl/stm32f1-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/stm32f1-pinctrl.h>
 #else
-#include <dt-bindings/pinctrl/stm32-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/stm32-pinctrl.h>
 #endif
 
 #ifdef __cplusplus

--- a/soc/arm/st_stm32/common/soc_config.c
+++ b/soc/arm/st_stm32/common/soc_config.c
@@ -8,10 +8,10 @@
  * @brief System module to support early STM32 MCU configuration
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 #include <stm32_ll_system.h>
 #include <stm32_ll_bus.h>
 

--- a/soc/arm/st_stm32/common/st_stm32_dt.h
+++ b/soc/arm/st_stm32/common/st_stm32_dt.h
@@ -11,7 +11,7 @@
 #ifndef _ST_STM32_DT_H_
 #define _ST_STM32_DT_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* Devicetree related macros to construct pinctrl config data */
 

--- a/soc/arm/st_stm32/common/stm32_backup_sram.c
+++ b/soc/arm/st_stm32/common/stm32_backup_sram.c
@@ -6,12 +6,12 @@
 
 #define DT_DRV_COMPAT st_stm32_backup_sram
 
-#include <device.h>
-#include <drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
 #include <stm32_ll_pwr.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(stm32_backup_sram, CONFIG_SOC_LOG_LEVEL);
 
 struct stm32_backup_sram_config {

--- a/soc/arm/st_stm32/common/stm32_hsem.h
+++ b/soc/arm/st_stm32/common/stm32_hsem.h
@@ -8,7 +8,7 @@
 
 #include <soc.h>
 #include <stm32_ll_hsem.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #if defined(CONFIG_SOC_SERIES_STM32WBX) || defined(CONFIG_STM32H7_DUAL_CORE)
 /** HW semaphore Complement ID list defined in hw_conf.h from STM32WB

--- a/soc/arm/st_stm32/common/stm32cube_hal.c
+++ b/soc/arm/st_stm32/common/stm32cube_hal.c
@@ -12,7 +12,7 @@
  *        implementations.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 /**
  * @brief This function configures the source of stm32cube time base.

--- a/soc/arm/st_stm32/stm32f0/soc.c
+++ b/soc/arm/st_stm32/stm32f0/soc.c
@@ -9,12 +9,12 @@
  * @brief System/hardware module for STM32F0 processor
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <stm32_ll_system.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/linker/linker-defs.h>
 #include <string.h>
 
 #if defined(CONFIG_SW_VECTOR_RELAY) || defined(CONFIG_SW_VECTOR_RELAY_CLIENT)

--- a/soc/arm/st_stm32/stm32f1/soc.c
+++ b/soc/arm/st_stm32/stm32f1/soc.c
@@ -9,10 +9,10 @@
  * @brief System/hardware module for STM32F1 processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/st_stm32/stm32f2/soc.c
+++ b/soc/arm/st_stm32/stm32f2/soc.c
@@ -9,14 +9,14 @@
  * @brief System/hardware module for stm32f2 processor
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <stm32_ll_system.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 #include <string.h>
 
 /**

--- a/soc/arm/st_stm32/stm32f3/soc.c
+++ b/soc/arm/st_stm32/stm32f3/soc.c
@@ -9,10 +9,10 @@
  * @brief System/hardware module for STM32F3 processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/st_stm32/stm32f4/soc.c
+++ b/soc/arm/st_stm32/stm32f4/soc.c
@@ -10,10 +10,10 @@
  * @brief System/hardware module for STM32F4 processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <stm32_ll_system.h>
 
 /**

--- a/soc/arm/st_stm32/stm32f7/soc.c
+++ b/soc/arm/st_stm32/stm32f7/soc.c
@@ -9,12 +9,12 @@
  * @brief System/hardware module for STM32F7 processor
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <stm32_ll_system.h>
 
 /**

--- a/soc/arm/st_stm32/stm32g0/power.c
+++ b/soc/arm/st_stm32/stm32g0/power.c
@@ -4,10 +4,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <stm32g0xx_ll_utils.h>
 #include <stm32g0xx_ll_bus.h>
@@ -16,7 +16,7 @@
 #include <stm32g0xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Invoke Low Power/System Off specific Tasks */

--- a/soc/arm/st_stm32/stm32g0/soc.c
+++ b/soc/arm/st_stm32/stm32g0/soc.c
@@ -10,11 +10,11 @@
  * @brief System/hardware module for STM32G0 processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <linker/linker-defs.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #if defined(SYSCFG_CFGR1_UCPD1_STROBE) || defined(SYSCFG_CFGR1_UCPD2_STROBE)
 #include <stm32_ll_system.h>

--- a/soc/arm/st_stm32/stm32g4/soc.c
+++ b/soc/arm/st_stm32/stm32g4/soc.c
@@ -9,11 +9,11 @@
  * @brief System/hardware module for STM32G4 processor
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <stm32_ll_system.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #if defined(PWR_CR3_UCPD_DBDIS)
 #include <stm32_ll_bus.h>

--- a/soc/arm/st_stm32/stm32h7/mpu_regions.c
+++ b/soc/arm/st_stm32/stm32h7/mpu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include "../../common/cortex_m/arm_mpu_mem_cfg.h"
 
 static const struct arm_mpu_region mpu_regions[] = {

--- a/soc/arm/st_stm32/stm32h7/soc_m4.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m4.c
@@ -9,17 +9,17 @@
  * @brief System/hardware module for STM32H7 CM4 processor
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_cortex.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_system.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include "stm32_hsem.h"
 
 /**

--- a/soc/arm/st_stm32/stm32h7/soc_m7.c
+++ b/soc/arm/st_stm32/stm32h7/soc_m7.c
@@ -9,16 +9,16 @@
  * @brief System/hardware module for STM32H7 CM7 processor
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_rcc.h>
 #include <stm32_ll_system.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include "stm32_hsem.h"
 
 #if defined(CONFIG_STM32H7_DUAL_CORE)

--- a/soc/arm/st_stm32/stm32l0/power.c
+++ b/soc/arm/st_stm32/stm32l0/power.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <stm32l0xx_ll_utils.h>
 #include <stm32l0xx_ll_bus.h>
@@ -15,9 +15,9 @@
 #include <stm32l0xx_ll_rcc.h>
 #include <stm32l0xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
-#include <drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* Select MSI as wake-up system clock if configured, HSI otherwise */

--- a/soc/arm/st_stm32/stm32l0/soc.c
+++ b/soc/arm/st_stm32/stm32l0/soc.c
@@ -9,11 +9,11 @@
  * @brief System/hardware module for STM32L0 processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <linker/linker-defs.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>

--- a/soc/arm/st_stm32/stm32l1/soc.c
+++ b/soc/arm/st_stm32/stm32l1/soc.c
@@ -9,11 +9,11 @@
  * @brief System/hardware module for STM32L1 processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <linker/linker-defs.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/linker/linker-defs.h>
 #include <string.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>

--- a/soc/arm/st_stm32/stm32l4/power.c
+++ b/soc/arm/st_stm32/stm32l4/power.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <stm32l4xx_ll_utils.h>
 #include <stm32l4xx_ll_bus.h>
@@ -15,9 +15,9 @@
 #include <stm32l4xx_ll_rcc.h>
 #include <stm32l4xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
-#include <drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* select MSI as wake-up system clock if configured, HSI otherwise */

--- a/soc/arm/st_stm32/stm32l4/soc.c
+++ b/soc/arm/st_stm32/stm32l4/soc.c
@@ -10,11 +10,11 @@
  * @brief System/hardware module for STM32L4 processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/st_stm32/stm32l5/power.c
+++ b/soc/arm/st_stm32/stm32l5/power.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <stm32l5xx_ll_utils.h>
 #include <stm32l5xx_ll_bus.h>
@@ -15,9 +15,9 @@
 #include <stm32l5xx_ll_rcc.h>
 #include <stm32l5xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
-#include <drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* select MSI as wake-up system clock if configured, HSI otherwise */

--- a/soc/arm/st_stm32/stm32l5/soc.c
+++ b/soc/arm/st_stm32/stm32l5/soc.c
@@ -9,14 +9,14 @@
  * @brief System/hardware module for STM32L5 processor
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <stm32l5xx_ll_icache.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/st_stm32/stm32mp1/soc.c
+++ b/soc/arm/st_stm32/stm32mp1/soc.c
@@ -9,13 +9,13 @@
  * @brief System/hardware module for STM32L4 processor
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <stm32_ll_bus.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm/st_stm32/stm32u5/power.c
+++ b/soc/arm/st_stm32/stm32u5/power.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <stm32u5xx_ll_utils.h>
 #include <stm32u5xx_ll_bus.h>
@@ -16,7 +16,7 @@
 #include <stm32u5xx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* select MSI as wake-up system clock if configured, HSI otherwise */

--- a/soc/arm/st_stm32/stm32u5/soc.c
+++ b/soc/arm/st_stm32/stm32u5/soc.c
@@ -9,15 +9,15 @@
  * @brief System/hardware module for STM32U5 processor
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <stm32_ll_bus.h>
 #include <stm32_ll_pwr.h>
 #include <stm32_ll_icache.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/st_stm32/stm32wb/power.c
+++ b/soc/arm/st_stm32/stm32wb/power.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <stm32wbxx_ll_utils.h>
 #include <stm32wbxx_ll_bus.h>
@@ -16,7 +16,7 @@
 #include <clock_control/clock_stm32_ll_common.h>
 #include "stm32_hsem.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /*

--- a/soc/arm/st_stm32/stm32wb/soc.c
+++ b/soc/arm/st_stm32/stm32wb/soc.c
@@ -9,11 +9,11 @@
  * @brief System/hardware module for STM32WB processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);

--- a/soc/arm/st_stm32/stm32wl/power.c
+++ b/soc/arm/st_stm32/stm32wl/power.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <stm32wlxx_ll_utils.h>
 #include <stm32wlxx_ll_bus.h>
@@ -15,9 +15,9 @@
 #include <stm32wlxx_ll_rcc.h>
 #include <stm32wlxx_ll_system.h>
 #include <clock_control/clock_stm32_ll_common.h>
-#include <drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
 
 /* select MSI as wake-up system clock if configured, HSI otherwise */

--- a/soc/arm/st_stm32/stm32wl/soc.c
+++ b/soc/arm/st_stm32/stm32wl/soc.c
@@ -9,10 +9,10 @@
  * @brief System/hardware module for STM32WL processor
  */
 
-#include <device.h>
-#include <init.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <stm32wlxx_ll_system.h>
 
 /**

--- a/soc/arm/ti_lm3s6965/soc.c
+++ b/soc/arm/ti_lm3s6965/soc.c
@@ -12,12 +12,12 @@
  * for the ti_lm3s6965 platform.
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  *

--- a/soc/arm/ti_lm3s6965/soc.h
+++ b/soc/arm/ti_lm3s6965/soc.h
@@ -15,7 +15,7 @@
 #ifndef _BOARD__H_
 #define _BOARD__H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 /* default system clock */
 

--- a/soc/arm/ti_lm3s6965/soc_config.c
+++ b/soc/arm/ti_lm3s6965/soc_config.c
@@ -8,15 +8,15 @@
  * @file Board config file
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #include "soc.h"
 
 #ifdef CONFIG_UART_STELLARIS
-#include <drivers/uart.h>
+#include <zephyr/drivers/uart.h>
 
 #define RCGC1 (*((volatile uint32_t *)0x400FE104))
 

--- a/soc/arm/ti_lm3s6965/sys_arch_reboot.c
+++ b/soc/arm/ti_lm3s6965/sys_arch_reboot.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/util.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  *

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/power.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <init.h>
-#include <pm/pm.h>
-#include <pm/policy.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
 
 #include <driverlib/pwr_ctrl.h>
 #include <driverlib/sys_ctrl.h>
@@ -20,7 +20,7 @@
 #include <ti/devices/cc13x2_cc26x2/driverlib/vims.h>
 #include <ti/devices/cc13x2_cc26x2/driverlib/sys_ctrl.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
 LOG_MODULE_REGISTER(soc);
 

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/soc.c
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/soc.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <driverlib/setup.h>
 

--- a/soc/arm/ti_simplelink/cc32xx/soc.c
+++ b/soc/arm/ti_simplelink/cc32xx/soc.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <driverlib/rom.h>
 #include <driverlib/rom_map.h>

--- a/soc/arm/ti_simplelink/msp432p4xx/soc.c
+++ b/soc/arm/ti_simplelink/msp432p4xx/soc.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
 static int ti_msp432p4xx_init(const struct device *arg)

--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <init.h>
-#include <sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
 
-#include <arch/arm/aarch32/mmu/arm_mmu.h>
+#include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
 #include "soc.h"
 
 static const struct arm_mmu_region mmu_regions[] = {

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <init.h>
-#include <sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
 
-#include <arch/arm/aarch32/mmu/arm_mmu.h>
+#include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
 #include "soc.h"
 
 static const struct arm_mmu_region mmu_regions[] = {

--- a/soc/arm/xilinx_zynqmp/arm_mpu_regions.c
+++ b/soc/arm/xilinx_zynqmp/arm_mpu_regions.c
@@ -3,8 +3,8 @@
  * Copyright (c) 2021 Lexmark International, Inc.
  */
 
-#include <kernel.h>
-#include <arch/arm/aarch32/mpu/arm_mpu.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/arm/aarch32/mpu/arm_mpu.h>
 
 #define MPUTYPE_READ_ONLY \
 	{ \

--- a/soc/arm/xilinx_zynqmp/soc.c
+++ b/soc/arm/xilinx_zynqmp/soc.c
@@ -5,10 +5,10 @@
  *
  */
 
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
-#include <arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 
 /**
  *

--- a/soc/arm64/arm/fvp_aemv8a/mmu_regions.c
+++ b/soc/arm64/arm/fvp_aemv8a/mmu_regions.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <soc.h>
-#include <arch/arm64/arm_mmu.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
 

--- a/soc/arm64/arm/fvp_aemv8a/soc.h
+++ b/soc/arm64/arm/fvp_aemv8a/soc.h
@@ -8,11 +8,11 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
+++ b/soc/arm64/arm/fvp_aemv8r/arm_mpu_regions.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/slist.h>
-#include <linker/linker-defs.h>
-#include <arch/arm64/cortex_r/arm_mpu.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/arch/arm64/cortex_r/arm_mpu.h>
 
 
 #define DEVICE_REGION_START 0x80000000UL

--- a/soc/arm64/arm/fvp_aemv8r/soc.c
+++ b/soc/arm64/arm/fvp_aemv8r/soc.c
@@ -2,7 +2,7 @@
  * Copyright (c) 2021 Arm Limited (or its affiliates). All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #ifdef CONFIG_SOC_FVP_AEMV8R_EL2_INIT
 

--- a/soc/arm64/bcm_vk/viper/mmu_regions.c
+++ b/soc/arm64/bcm_vk/viper/mmu_regions.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
-#include <sys/util.h>
-#include <arch/arm64/arm_mmu.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
 
 
 #define PCIE_OB_HIGHMEM_ADDR	DT_REG_ADDR_BY_NAME(DT_NODELABEL(pcie0_ep), \

--- a/soc/arm64/bcm_vk/viper/plat_core.c
+++ b/soc/arm64/bcm_vk/viper/plat_core.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 
 void z_arm64_el3_plat_init(void)
 {

--- a/soc/arm64/bcm_vk/viper/soc.c
+++ b/soc/arm64/bcm_vk/viper/soc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm64/bcm_vk/viper/soc.h
+++ b/soc/arm64/bcm_vk/viper/soc.h
@@ -7,8 +7,8 @@
 #ifndef SOC_H
 #define SOC_H
 
-#include <sys/util.h>
-#include <toolchain.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 /* Registers block */
 #define CRMU_MCU_EXTRA_EVENT_STATUS	0x40070054

--- a/soc/arm64/intel_socfpga/agilex/mmu_regions.c
+++ b/soc/arm64/intel_socfpga/agilex/mmu_regions.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
-#include <arch/arm64/arm_mmu.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
 

--- a/soc/arm64/nxp_imx/imx8m/dummy.c
+++ b/soc/arm64/nxp_imx/imx8m/dummy.c
@@ -8,9 +8,9 @@
 
 #define DT_DRV_COMPAT nxp_imx_iuart
 
-#include <device.h>
-#include <drivers/uart.h>
-#include <drivers/clock_control.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/drivers/clock_control.h>
 #include <errno.h>
 #include <soc.h>
 

--- a/soc/arm64/nxp_imx/imx8m/mmu_regions.c
+++ b/soc/arm64/nxp_imx/imx8m/mmu_regions.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <soc.h>
-#include <arch/arm64/arm_mmu.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
 

--- a/soc/arm64/nxp_imx/imx8m/soc.h
+++ b/soc/arm64/nxp_imx/imx8m/soc.h
@@ -7,8 +7,8 @@
 #ifndef SOC_H
 #define SOC_H
 
-#include <sys/util.h>
-#include <toolchain.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 /* TODO: Place Holder */
 

--- a/soc/arm64/nxp_layerscape/ls1046a/mmu_regions.c
+++ b/soc/arm64/nxp_layerscape/ls1046a/mmu_regions.c
@@ -3,10 +3,10 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
-#include <sys/util.h>
-#include <arch/arm64/arm_mmu.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
 

--- a/soc/arm64/nxp_layerscape/ls1046a/soc.c
+++ b/soc/arm64/nxp_layerscape/ls1046a/soc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Perform basic hardware initialization at boot.

--- a/soc/arm64/nxp_layerscape/ls1046a/soc.h
+++ b/soc/arm64/nxp_layerscape/ls1046a/soc.h
@@ -7,8 +7,8 @@
 #ifndef SOC_H
 #define SOC_H
 
-#include <sys/util.h>
-#include <toolchain.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
 
 #ifndef _ASMLANGUAGE
 #endif /* _ASMLANGUAGE */

--- a/soc/arm64/qemu_cortex_a53/mmu_regions.c
+++ b/soc/arm64/qemu_cortex_a53/mmu_regions.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <soc.h>
-#include <arch/arm64/arm_mmu.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
 
 #define SZ_1K	1024
 

--- a/soc/arm64/qemu_cortex_a53/plat_core.c
+++ b/soc/arm64/qemu_cortex_a53/plat_core.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 
 void z_arm64_el3_plat_init(void)
 {

--- a/soc/arm64/qemu_cortex_a53/soc.h
+++ b/soc/arm64/qemu_cortex_a53/soc.h
@@ -8,11 +8,11 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/arm64/xenvm/mmu_regions.c
+++ b/soc/arm64/xenvm/mmu_regions.c
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <devicetree.h>
-#include <sys/util.h>
-#include <arch/arm64/arm_mmu.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/arch/arm64/arm_mmu.h>
 
 static const struct arm_mmu_region mmu_regions[] = {
 

--- a/soc/arm64/xenvm/soc.h
+++ b/soc/arm64/xenvm/soc.h
@@ -8,11 +8,11 @@
 #ifndef _SOC_H_
 #define _SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
 
-#include <device.h>
+#include <zephyr/device.h>
 
 #endif /* !_ASMLANGUAGE */
 

--- a/soc/posix/inf_clock/posix_soc.h
+++ b/soc/posix/inf_clock/posix_soc.h
@@ -7,7 +7,7 @@
 #ifndef _POSIX_POSIX_SOC_INF_CLOCK_H
 #define _POSIX_POSIX_SOC_INF_CLOCK_H
 
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/posix/inf_clock/soc.c
+++ b/soc/posix/inf_clock/soc.c
@@ -27,7 +27,7 @@
 #include <pthread.h>
 #include <stdbool.h>
 #include <unistd.h>
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 #include "posix_soc.h"
 #include "posix_board_if.h"
 #include "posix_core.h"

--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -7,7 +7,7 @@
 #ifndef _POSIX_SOC_INF_CLOCK_SOC_H
 #define _POSIX_SOC_INF_CLOCK_SOC_H
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include "board_soc.h"
 #include "posix_soc.h"
 

--- a/soc/riscv/esp32c3/idle.c
+++ b/soc/riscv/esp32c3/idle.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
-#include <irq.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/irq.h>
+#include <zephyr/arch/cpu.h>
 
 /**
  * @brief Power save idle routine

--- a/soc/riscv/esp32c3/loader.c
+++ b/soc/riscv/esp32c3/loader.c
@@ -9,9 +9,9 @@
 #include "soc/extmem_reg.h"
 #include <bootloader_flash_priv.h>
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <soc.h>
-#include <storage/flash_map.h>
+#include <zephyr/storage/flash_map.h>
 #include <esp_log.h>
 #include <stdlib.h>
 

--- a/soc/riscv/esp32c3/pinctrl_soc.h
+++ b/soc/riscv/esp32c3/pinctrl_soc.h
@@ -12,10 +12,10 @@
 #ifndef ZEPHYR_SOC_RISCV_ESP32C3_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_RISCV_ESP32C3_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/soc/riscv/esp32c3/soc.c
+++ b/soc/riscv/esp32c3/soc.c
@@ -14,12 +14,12 @@
 #include "hal/soc_ll.h"
 #include "esp_spi_flash.h"
 #include <soc/interrupt_reg.h>
-#include <drivers/interrupt_controller/intc_esp32c3.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <string.h>
-#include <toolchain/gcc.h>
+#include <zephyr/toolchain/gcc.h>
 #include <soc.h>
 
 /*

--- a/soc/riscv/esp32c3/soc.h
+++ b/soc/riscv/esp32c3/soc.h
@@ -15,7 +15,7 @@
 #include <esp_clk.h>
 #endif
 
-#include <arch/riscv/arch.h>
+#include <zephyr/arch/riscv/arch.h>
 
 /* IRQ numbers */
 #define RISCV_MACHINE_SOFT_IRQ 3 /* Machine Software Interrupt */

--- a/soc/riscv/esp32c3/soc_irq.c
+++ b/soc/riscv/esp32c3/soc_irq.c
@@ -14,11 +14,11 @@
 #include <riscv/interrupt.h>
 #include <soc/interrupt_reg.h>
 #include <soc/periph_defs.h>
-#include <drivers/interrupt_controller/intc_esp32c3.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <string.h>
-#include <toolchain/gcc.h>
+#include <zephyr/toolchain/gcc.h>
 #include <soc.h>
 
 #define ESP32C3_INTSTATUS_SLOT1_THRESHOLD	32

--- a/soc/riscv/litex-vexriscv/soc.h
+++ b/soc/riscv/litex-vexriscv/soc.h
@@ -8,7 +8,7 @@
 #define __RISCV32_LITEX_VEXRISCV_SOC_H_
 
 #include "../riscv-privilege/common/soc_common.h"
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* lib-c hooks required RAM defined variables */
 #define RISCV_RAM_BASE              DT_REG_ADDR(DT_INST(0, mmio_sram))

--- a/soc/riscv/openisa_rv32m1/soc.c
+++ b/soc/riscv/openisa_rv32m1/soc.c
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
-#include <device.h>
-#include <init.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <fsl_clock.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #if defined(CONFIG_MULTI_LEVEL_INTERRUPTS)
 #include <errno.h>
-#include <irq_nextlevel.h>
+#include <zephyr/irq_nextlevel.h>
 #endif
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(soc);
 
 #define SCG_LPFLL_DISABLE 0U

--- a/soc/riscv/riscv-ite/common/check_regs.c
+++ b/soc/riscv/riscv-ite/common/check_regs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <soc.h>
 
 /* SMFI register structure check */

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -6,7 +6,7 @@
 #ifndef CHIP_CHIPREGS_H
 #define CHIP_CHIPREGS_H
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #define EC_REG_BASE_ADDR 0x00f00000
 

--- a/soc/riscv/riscv-ite/common/power.c
+++ b/soc/riscv/riscv-ite/common/power.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <pm/pm.h>
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /* Handle when enter deep doze mode. */
 static void ite_power_soc_deep_doze(void)

--- a/soc/riscv/riscv-ite/common/soc_common_irq.c
+++ b/soc/riscv/riscv-ite/common/soc_common_irq.c
@@ -9,7 +9,7 @@
  * @brief interrupt management code for riscv SOCs supporting the riscv
 	  privileged architecture specification
  */
-#include <irq.h>
+#include <zephyr/irq.h>
 
 void arch_irq_enable(unsigned int irq)
 {

--- a/soc/riscv/riscv-ite/common/soc_espi.h
+++ b/soc/riscv/riscv-ite/common/soc_espi.h
@@ -7,8 +7,8 @@
 #ifndef _ITE_IT8XXX2_SOC_ESPI_H_
 #define _ITE_IT8XXX2_SOC_ESPI_H_
 
-#include <device.h>
-#include <sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -5,13 +5,13 @@
  *
  */
 
-#include <arch/riscv/csr.h>
-#include <kernel.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/arch/riscv/csr.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include "soc_espi.h"
-#include <dt-bindings/interrupt-controller/ite-intc.h>
+#include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>
 
 #ifdef CONFIG_SOC_IT8XXX2_PLL_FLASH_48M
 #define __intc_ram_code __attribute__((section(".__ram_code")))

--- a/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
+++ b/soc/riscv/riscv-privilege/andes_v5/l2_cache.c
@@ -10,9 +10,9 @@
  * @brief Andes V5 L2 Cache Controller driver
  */
 
-#include <init.h>
-#include <kernel.h>
-#include <arch/cpu.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
 #include <soc.h>
 
 /*

--- a/soc/riscv/riscv-privilege/andes_v5/pma.c
+++ b/soc/riscv/riscv-privilege/andes_v5/pma.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <linker/linker-defs.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/linker/linker-defs.h>
 
 /* Programmable PMA mechanism is supported */
 #define MMSC_CFG_PPMA		(1 << 30)

--- a/soc/riscv/riscv-privilege/andes_v5/smu.h
+++ b/soc/riscv/riscv-privilege/andes_v5/smu.h
@@ -11,8 +11,8 @@
 #ifndef SOC_RISCV_ANDES_V5_SMU_H_
 #define SOC_RISCV_ANDES_V5_SMU_H_
 
-#include <devicetree.h>
-#include <sys/util_macro.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/sys/util_macro.h>
 
 /*
  * SMU Register Base Address

--- a/soc/riscv/riscv-privilege/common/idle.c
+++ b/soc/riscv/riscv-privilege/common/idle.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
-#include <irq.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/irq.h>
+#include <zephyr/arch/cpu.h>
 
-#include <tracing/tracing.h>
+#include <zephyr/tracing/tracing.h>
 
 static ALWAYS_INLINE void riscv_idle(unsigned int key)
 {

--- a/soc/riscv/riscv-privilege/common/nuclei/nuclei_csr.h
+++ b/soc/riscv/riscv-privilege/common/nuclei/nuclei_csr.h
@@ -16,7 +16,7 @@
 #ifndef ZEPHYR_SOC_RISCV_RISCV_PRIVILEGE_COMMON_NUCLEI_NUCLEI_CSR_H_
 #define ZEPHYR_SOC_RISCV_RISCV_PRIVILEGE_COMMON_NUCLEI_NUCLEI_CSR_H_
 
-#include <sys/util_macro.h>
+#include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/soc/riscv/riscv-privilege/common/soc_common_irq.c
+++ b/soc/riscv/riscv-privilege/common/soc_common_irq.c
@@ -9,7 +9,7 @@
  * @brief interrupt management code for riscv SOCs supporting the riscv
 	  privileged architecture specification
  */
-#include <irq.h>
+#include <zephyr/irq.h>
 
 void arch_irq_enable(unsigned int irq)
 {

--- a/soc/riscv/riscv-privilege/gd32vf103/pinctrl_soc.h
+++ b/soc/riscv/riscv-privilege/gd32vf103/pinctrl_soc.h
@@ -12,6 +12,6 @@
 #ifndef ZEPHYR_SOC_RISCV_RISCV_PRIVILEGE_NUCLEI_GD32VF103_COMMON_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_RISCV_RISCV_PRIVILEGE_NUCLEI_GD32VF103_COMMON_PINCTRL_SOC_H_
 
-#include <drivers/pinctrl/pinctrl_soc_gd32_common.h>
+#include <zephyr/drivers/pinctrl/pinctrl_soc_gd32_common.h>
 
 #endif /* ZEPHYR_SOC_RISCV_RISCV_PRIVILEGE_NUCLEI_GD32VF103_COMMON_PINCTRL_SOC_H_ */

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.c
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 
 static int gigadevice_gd32v_soc_init(const struct device *dev)
 {

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.h
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.h
@@ -12,14 +12,14 @@
 #define RISCV_GD32VF103_SOC_H_
 
 #include <soc_common.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 /* Timer configuration */
 #define RISCV_MTIME_BASE      DT_REG_ADDR_BY_IDX(DT_NODELABEL(mtimer), 0)
 #define RISCV_MTIMECMP_BASE   DT_REG_ADDR_BY_IDX(DT_NODELABEL(mtimer), 1)
 
 #ifndef _ASMLANGUAGE
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <gd32vf103.h>
 #endif  /* !_ASMLANGUAGE */
 

--- a/soc/riscv/riscv-privilege/neorv32/soc.c
+++ b/soc/riscv/riscv-privilege/neorv32/soc.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <irq.h>
+#include <zephyr/irq.h>
 #include <soc.h>
 
 #if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)

--- a/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fe310_clock.c
@@ -5,7 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "fe310_prci.h"
 
 #define CORECLK_HZ (DT_PROP(DT_NODELABEL(coreclk), clock_frequency))

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu540_clock.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "fu540_prci.h"
 
 BUILD_ASSERT(MHZ(1000) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),

--- a/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
+++ b/soc/riscv/riscv-privilege/sifive-freedom/fu740_clock.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "fu740_prci.h"
 
 BUILD_ASSERT(MHZ(1000) == DT_PROP(DT_NODELABEL(coreclk), clock_frequency),

--- a/soc/riscv/riscv-privilege/telink_b91/pinctrl_soc.h
+++ b/soc/riscv/riscv-privilege/telink_b91/pinctrl_soc.h
@@ -8,8 +8,8 @@
 #define SOC_RISCV_TELINK_B91_PINCTRL_SOC_H
 
 #include <stdint.h>
-#include <devicetree.h>
-#include <dt-bindings/pinctrl/b91-pinctrl.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/dt-bindings/pinctrl/b91-pinctrl.h>
 
 /**
  * @brief Telink B91 pin type.

--- a/soc/riscv/riscv-privilege/telink_b91/soc.c
+++ b/soc/riscv/riscv-privilege/telink_b91/soc.c
@@ -6,7 +6,7 @@
 
 #include "sys.h"
 #include "clock.h"
-#include <device.h>
+#include <zephyr/device.h>
 
 /* Software reset defines */
 #define reg_reset                   REG_ADDR8(0x1401ef)

--- a/soc/riscv/riscv-privilege/virt/soc.c
+++ b/soc/riscv/riscv-privilege/virt/soc.c
@@ -9,9 +9,9 @@
  * @brief QEMU RISC-V virt machine hardware depended interface
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
 
 /*
  * Exit QEMU and tell error number.

--- a/soc/sparc/leon3/idle.c
+++ b/soc/sparc/leon3/idle.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <tracing/tracing.h>
+#include <zephyr/kernel.h>
+#include <zephyr/tracing/tracing.h>
 
 static void leon_idle(unsigned int key)
 {

--- a/soc/x86/apollo_lake/cpu.c
+++ b/soc/x86/apollo_lake/cpu.c
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 uint8_t x86_cpu_loapics[] = { 0x00, 0x02, 0x04, 0x06 };

--- a/soc/x86/apollo_lake/soc.h
+++ b/soc/x86/apollo_lake/soc.h
@@ -16,18 +16,18 @@
 #ifndef __SOC_H_
 #define __SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
-#include <device.h>
-#include <random/rand32.h>
+#include <zephyr/device.h>
+#include <zephyr/random/rand32.h>
 #endif
 
 #ifdef CONFIG_GPIO_INTEL
 #include "soc_gpio.h"
 #endif
 
-#include <drivers/pcie/pcie.h>
+#include <zephyr/drivers/pcie/pcie.h>
 
 /* This expands to "PCIE_BDF(0, 0x18, 0)" on this platform */
 #define X86_SOC_EARLY_SERIAL_PCIDEV DT_REG_ADDR(DT_CHOSEN(zephyr_console))

--- a/soc/x86/atom/soc.h
+++ b/soc/x86/atom/soc.h
@@ -15,11 +15,11 @@
 #ifndef __SOC_H_
 #define __SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
-#include <device.h>
-#include <random/rand32.h>
+#include <zephyr/device.h>
+#include <zephyr/random/rand32.h>
 #endif
 
 /*

--- a/soc/x86/elkhart_lake/cpu.c
+++ b/soc/x86/elkhart_lake/cpu.c
@@ -3,6 +3,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 uint8_t x86_cpu_loapics[] = { 0x00, 0x02, 0x04, 0x06 };

--- a/soc/x86/elkhart_lake/soc.h
+++ b/soc/x86/elkhart_lake/soc.h
@@ -16,11 +16,11 @@
 #ifndef __SOC_H_
 #define __SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
-#include <device.h>
-#include <random/rand32.h>
+#include <zephyr/device.h>
+#include <zephyr/random/rand32.h>
 #endif
 
 #ifdef CONFIG_GPIO_INTEL
@@ -28,7 +28,7 @@
 #endif
 
 #if DT_ON_BUS(DT_CHOSEN(zephyr_console), pcie)
-#include <drivers/pcie/pcie.h>
+#include <zephyr/drivers/pcie/pcie.h>
 #define X86_SOC_EARLY_SERIAL_PCIDEV DT_REG_ADDR(DT_CHOSEN(zephyr_console))
 #else
 #define X86_SOC_EARLY_SERIAL_MMIO8_ADDR DT_REG_ADDR(DT_CHOSEN(zephyr_console))

--- a/soc/x86/ia32/soc.h
+++ b/soc/x86/ia32/soc.h
@@ -15,11 +15,11 @@
 #ifndef __SOC_H_
 #define __SOC_H_
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
-#include <device.h>
-#include <random/rand32.h>
+#include <zephyr/device.h>
+#include <zephyr/random/rand32.h>
 #endif
 
 /*

--- a/soc/xtensa/esp32/esp32-mp.c
+++ b/soc/xtensa/esp32/esp32-mp.c
@@ -9,12 +9,12 @@
 #include "soc/gpio_periph.h"
 #include "soc/rtc_periph.h"
 
-#include <drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <soc.h>
-#include <device.h>
-#include <zephyr.h>
-#include <spinlock.h>
-#include <kernel_structs.h>
+#include <zephyr/device.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/kernel_structs.h>
 
 #define Z_REG(base, off) (*(volatile uint32_t *)((base) + (off)))
 

--- a/soc/xtensa/esp32/gdbstub.c
+++ b/soc/xtensa/esp32/gdbstub.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <xtensa-asm2-context.h>
-#include <debug/gdbstub.h>
+#include <zephyr/debug/gdbstub.h>
 
 /*
  * Address Mappings From ESP32 Technical Reference Manual Version 4.5

--- a/soc/xtensa/esp32/include/_soc_inthandlers.h
+++ b/soc/xtensa/esp32/include/_soc_inthandlers.h
@@ -11,8 +11,8 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sys/util.h>
-#include <sw_isr_table.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 1
 #error core-isa.h interrupt level does not match dispatcher!

--- a/soc/xtensa/esp32/loader.c
+++ b/soc/xtensa/esp32/loader.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <soc.h>
-#include <storage/flash_map.h>
+#include <zephyr/storage/flash_map.h>
 #include <esp_log.h>
 
 #include <esp32/rom/cache.h>

--- a/soc/xtensa/esp32/pinctrl_soc.h
+++ b/soc/xtensa/esp32/pinctrl_soc.h
@@ -12,10 +12,10 @@
 #ifndef ZEPHYR_SOC_XTENSA_ESP32_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_XTENSA_ESP32_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -8,13 +8,13 @@
 #include "soc.h"
 #include <soc/rtc_cntl_reg.h>
 #include <soc/timer_group_reg.h>
-#include <drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <xtensa/config/core-isa.h>
 #include <xtensa/corebits.h>
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <string.h>
-#include <toolchain/gcc.h>
+#include <zephyr/toolchain/gcc.h>
 #include <zephyr/types.h>
 
 #include "esp_private/system_internal.h"

--- a/soc/xtensa/esp32/soc.h
+++ b/soc/xtensa/esp32/soc.h
@@ -14,7 +14,7 @@
 
 #include <zephyr/types.h>
 #include <stdbool.h>
-#include <arch/xtensa/arch.h>
+#include <zephyr/arch/xtensa/arch.h>
 
 #include <xtensa/core-macros.h>
 #include <esp32/clk.h>

--- a/soc/xtensa/esp32s2/include/_soc_inthandlers.h
+++ b/soc/xtensa/esp32s2/include/_soc_inthandlers.h
@@ -17,8 +17,8 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sys/util.h>
-#include <sw_isr_table.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 1
 #error core-isa.h interrupt level does not match dispatcher!

--- a/soc/xtensa/esp32s2/loader.c
+++ b/soc/xtensa/esp32s2/loader.c
@@ -5,9 +5,9 @@
  */
 
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <soc.h>
-#include <storage/flash_map.h>
+#include <zephyr/storage/flash_map.h>
 #include <esp_log.h>
 #include <stdlib.h>
 

--- a/soc/xtensa/esp32s2/pinctrl_soc.h
+++ b/soc/xtensa/esp32s2/pinctrl_soc.h
@@ -12,10 +12,10 @@
 #ifndef ZEPHYR_SOC_XTENSA_ESP32S2_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_XTENSA_ESP32S2_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/soc/xtensa/esp32s2/soc.c
+++ b/soc/xtensa/esp32s2/soc.c
@@ -8,14 +8,14 @@
 #include "soc.h"
 #include <soc/rtc_cntl_reg.h>
 #include <soc/timer_group_reg.h>
-#include <drivers/interrupt_controller/intc_esp32.h>
+#include <zephyr/drivers/interrupt_controller/intc_esp32.h>
 #include <xtensa/config/core-isa.h>
 #include <xtensa/corebits.h>
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <string.h>
-#include <toolchain/gcc.h>
+#include <zephyr/toolchain/gcc.h>
 #include <zephyr/types.h>
 
 #include "esp_private/system_internal.h"

--- a/soc/xtensa/esp32s2/soc.h
+++ b/soc/xtensa/esp32s2/soc.h
@@ -18,7 +18,7 @@
 
 #include <zephyr/types.h>
 #include <stdbool.h>
-#include <arch/xtensa/arch.h>
+#include <zephyr/arch/xtensa/arch.h>
 #include <stdlib.h>
 
 void __esp_platform_start(void);

--- a/soc/xtensa/intel_adsp/common/boot.c
+++ b/soc/xtensa/intel_adsp/common/boot.c
@@ -2,12 +2,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <stddef.h>
 #include <stdint.h>
 
 #include <soc.h>
-#include <arch/xtensa/cache.h>
+#include <zephyr/arch/xtensa/cache.h>
 #include <cavs-shim.h>
 #include <cavs-mem.h>
 #include <cpu_init.h>

--- a/soc/xtensa/intel_adsp/common/cavs_ipc.c
+++ b/soc/xtensa/intel_adsp/common/cavs_ipc.c
@@ -3,7 +3,7 @@
  */
 #include <cavs_ipc.h>
 #include <cavs-ipc-regs.h>
-#include <spinlock.h>
+#include <zephyr/spinlock.h>
 
 void cavs_ipc_set_message_handler(const struct device *dev,
 				  cavs_ipc_handler_t fn, void *arg)

--- a/soc/xtensa/intel_adsp/common/include/_soc_inthandlers.h
+++ b/soc/xtensa/intel_adsp/common/include/_soc_inthandlers.h
@@ -15,8 +15,8 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sys/util.h>
-#include <sw_isr_table.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 1
 #error core-isa.h interrupt level does not match dispatcher!

--- a/soc/xtensa/intel_adsp/common/include/cavs-mem.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-mem.h
@@ -4,7 +4,7 @@
 #ifndef _ZEPHYR_SOC_INTEL_ADSP_MEM
 #define _ZEPHYR_SOC_INTEL_ADSP_MEM
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <cavs-vectors.h>
 
 #define L2_SRAM_BASE (DT_REG_ADDR(DT_NODELABEL(sram0)))

--- a/soc/xtensa/intel_adsp/common/include/cavs_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs_hda.h
@@ -5,9 +5,9 @@
 #ifndef ZEPHYR_INCLUDE_CAVS_HDA_H
 #define ZEPHYR_INCLUDE_CAVS_HDA_H
 
-#include <arch/xtensa/cache.h>
-#include <kernel.h>
-#include <device.h>
+#include <zephyr/arch/xtensa/cache.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
 #include <cavs-shim.h>
 #include <cavs-mem.h>
 

--- a/soc/xtensa/intel_adsp/common/include/cavs_ipc.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs_ipc.h
@@ -4,8 +4,8 @@
 #ifndef ZEPHYR_INCLUDE_CAVS_IPC_H
 #define ZEPHYR_INCLUDE_CAVS_IPC_H
 
-#include <kernel.h>
-#include <device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
 
 struct cavs_ipc_config {
 	volatile struct cavs_ipc *regs;

--- a/soc/xtensa/intel_adsp/common/include/cpu_init.h
+++ b/soc/xtensa/intel_adsp/common/include/cpu_init.h
@@ -4,7 +4,7 @@
 #ifndef __INTEL_ADSP_CPU_INIT_H
 #define __INTEL_ADSP_CPU_INIT_H
 
-#include <arch/xtensa/cache.h>
+#include <zephyr/arch/xtensa/cache.h>
 #include <xtensa/config/core-isa.h>
 
 #define CxL1CCAP (*(volatile uint32_t *)0x9F080080)

--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -8,7 +8,7 @@
 
 #include <string.h>
 #include <errno.h>
-#include <arch/xtensa/cache.h>
+#include <zephyr/arch/xtensa/cache.h>
 
 /* macros related to interrupt handling */
 #define XTENSA_IRQ_NUM_SHIFT			0

--- a/soc/xtensa/intel_adsp/common/irq-cavs.c
+++ b/soc/xtensa/intel_adsp/common/irq-cavs.c
@@ -2,19 +2,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <xtensa/xtruntime.h>
-#include <irq_nextlevel.h>
+#include <zephyr/irq_nextlevel.h>
 #include <xtensa/hal.h>
-#include <init.h>
-#include <logging/log.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
 
 #include <cavs-shim.h>
 #include <cavs-idc.h>
 #include "soc.h"
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
-#include <sw_isr_table.h>
+#include <zephyr/sw_isr_table.h>
 #endif
 
 LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);

--- a/soc/xtensa/intel_adsp/common/mp_cavs.c
+++ b/soc/xtensa/intel_adsp/common/mp_cavs.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2021 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <cavs-idc.h>
 #include <cavs-mem.h>
 #include <cavs-shim.h>

--- a/soc/xtensa/intel_adsp/common/rimage_modules.c
+++ b/soc/xtensa/intel_adsp/common/rimage_modules.c
@@ -3,7 +3,7 @@
  */
 #include <manifest.h>
 #include <cavs-mem.h>
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 
 /* These two modules defined here aren't runtime data used by Zephyr or
  * SOF with IPC3, but instead are inserted to *MANIFEST* of the final

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <xtensa/xtruntime.h>
-#include <irq_nextlevel.h>
+#include <zephyr/irq_nextlevel.h>
 #include <xtensa/hal.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include <cavs-shim.h>
 #include <cavs-idc.h>
 #include "soc.h"
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
-#include <sw_isr_table.h>
+#include <zephyr/sw_isr_table.h>
 #endif
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(soc);
 
 #ifndef CONFIG_SOC_SERIES_INTEL_CAVS_V15

--- a/soc/xtensa/intel_adsp/common/soc_mp.c
+++ b/soc/xtensa/intel_adsp/common/soc_mp.c
@@ -4,23 +4,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <toolchain.h>
-#include <sys/__assert.h>
-#include <sys/sys_io.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/sys_io.h>
 
 #include <xtensa/config/core-isa.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 
 #include <zsr.h>
 #include <cavs-idc.h>
 #include <soc.h>
-#include <arch/xtensa/cache.h>
+#include <zephyr/arch/xtensa/cache.h>
 #include <cavs-shim.h>
 #include <cavs-mem.h>
 #include <cpu_init.h>

--- a/soc/xtensa/intel_adsp/common/trace_out.c
+++ b/soc/xtensa/intel_adsp/common/trace_out.c
@@ -1,10 +1,10 @@
 /* Copyright (c) 2021 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <soc.h>
 #include <cavs-mem.h>
-#include <sys/winstream.h>
+#include <zephyr/sys/winstream.h>
 
 struct k_spinlock trace_lock;
 

--- a/soc/xtensa/intel_s1000/include/_soc_inthandlers.h
+++ b/soc/xtensa/intel_s1000/include/_soc_inthandlers.h
@@ -11,7 +11,7 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sw_isr_table.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 1
 #error core-isa.h interrupt level does not match dispatcher!

--- a/soc/xtensa/intel_s1000/soc.c
+++ b/soc/xtensa/intel_s1000/soc.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <xtensa/xtruntime.h>
-#include <irq_nextlevel.h>
+#include <zephyr/irq_nextlevel.h>
 #include <xtensa/hal.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include "soc.h"
 
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(soc);
 
 static uint32_t ref_clk_freq;

--- a/soc/xtensa/intel_s1000/soc.h
+++ b/soc/xtensa/intel_s1000/soc.h
@@ -6,7 +6,7 @@
 #ifndef __INC_SOC_H
 #define __INC_SOC_H
 
-#include <arch/xtensa/cache.h>
+#include <zephyr/arch/xtensa/cache.h>
 
 /* macros related to interrupt handling */
 #define XTENSA_IRQ_NUM_SHIFT			0

--- a/soc/xtensa/intel_s1000/soc/shim.h
+++ b/soc/xtensa/intel_s1000/soc/shim.h
@@ -9,7 +9,7 @@
 #ifndef __PLATFORM_LIB_SHIM_H__
 #define __PLATFORM_LIB_SHIM_H__
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <memory.h>
 
 #ifndef ASSEMBLY
@@ -17,8 +17,8 @@
 #endif
 
 #if !defined(__ASSEMBLER__) && !defined(LINKER)
-#include <sys/sys_io.h>
-#include <arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/arch/common/sys_io.h>
 #endif
 
 #ifndef BIT

--- a/soc/xtensa/intel_s1000/soc_mp.c
+++ b/soc/xtensa/intel_s1000/soc_mp.c
@@ -4,22 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <sys/sys_io.h>
-#include <sys/__assert.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/__assert.h>
 #include <xtensa/corebits.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(soc_mp, CONFIG_SOC_LOG_LEVEL);
 
 #include "soc.h"
 #include "memory.h"
 
 #ifdef CONFIG_SCHED_IPI_SUPPORTED
-#include <drivers/ipm.h>
+#include <zephyr/drivers/ipm.h>
 #include <ipm/ipm_cavs_idc.h>
 
 static const struct device *idc;

--- a/soc/xtensa/intel_s1000/xcc/newlib_fixes.c
+++ b/soc/xtensa/intel_s1000/xcc/newlib_fixes.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <unistd.h>

--- a/soc/xtensa/nxp_adsp/common/include/adsp/io.h
+++ b/soc/xtensa/nxp_adsp/common/include/adsp/io.h
@@ -9,8 +9,8 @@
 
 #include <stdint.h>
 #include <soc/memory.h>
-#include <sys/sys_io.h>
-#include <arch/common/sys_io.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/arch/common/sys_io.h>
 
 static inline uint32_t io_reg_read(uint32_t reg)
 {

--- a/soc/xtensa/nxp_adsp/common/include/soc.h
+++ b/soc/xtensa/nxp_adsp/common/include/soc.h
@@ -7,7 +7,7 @@
 #include <string.h>
 #include <errno.h>
 
-#include <sys/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 
 #include <adsp/cache.h>
 

--- a/soc/xtensa/nxp_adsp/common/soc.c
+++ b/soc/xtensa/nxp_adsp/common/soc.c
@@ -4,19 +4,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <xtensa/xtruntime.h>
-#include <irq_nextlevel.h>
+#include <zephyr/irq_nextlevel.h>
 #include <xtensa/hal.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #include "soc.h"
 
 #ifdef CONFIG_DYNAMIC_INTERRUPTS
-#include <sw_isr_table.h>
+#include <zephyr/sw_isr_table.h>
 #endif
 #define LOG_LEVEL CONFIG_SOC_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(soc);
 
 void z_soc_irq_enable(uint32_t irq)

--- a/soc/xtensa/nxp_adsp/imx8/include/_soc_inthandlers.h
+++ b/soc/xtensa/nxp_adsp/imx8/include/_soc_inthandlers.h
@@ -16,8 +16,8 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sys/util.h>
-#include <sw_isr_table.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 5
 #error core-isa.h interrupt level does not match dispatcher!

--- a/soc/xtensa/nxp_adsp/imx8m/include/_soc_inthandlers.h
+++ b/soc/xtensa/nxp_adsp/imx8m/include/_soc_inthandlers.h
@@ -16,8 +16,8 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sys/util.h>
-#include <sw_isr_table.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 5
 #error core-isa.h interrupt level does not match dispatcher!

--- a/soc/xtensa/sample_controller/include/_soc_inthandlers.h
+++ b/soc/xtensa/sample_controller/include/_soc_inthandlers.h
@@ -11,7 +11,7 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sw_isr_table.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 1
 #error core-isa.h interrupt level does not match dispatcher!


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all soc code to the
new prefix <zephyr/...>. Note that the conversion has been scripted,
refer to zephyrproject-rtos#45388 for more details.