### PR TITLE
modules: migrate includes to <zephyr/...>

### DIFF
--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -4,15 +4,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <drivers/can.h>
-#include <init.h>
-#include <sys/util.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/drivers/can.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
 
 #include <canopennode.h>
 
 #define LOG_LEVEL CONFIG_CANOPEN_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(canopen_driver);
 
 K_KERNEL_STACK_DEFINE(canopen_tx_workq_stack,

--- a/modules/canopennode/CO_driver_target.h
+++ b/modules/canopennode/CO_driver_target.h
@@ -18,10 +18,10 @@
 extern "C" {
 #endif
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <zephyr/types.h>
-#include <device.h>
-#include <toolchain.h>
+#include <zephyr/device.h>
+#include <zephyr/toolchain.h>
 
 /* Use static variables instead of calloc() */
 #define CO_USE_GLOBALS

--- a/modules/canopennode/canopen_program.c
+++ b/modules/canopennode/canopen_program.c
@@ -7,13 +7,13 @@
 #include <CANopen.h>
 
 #include <canopennode.h>
-#include <dfu/flash_img.h>
-#include <dfu/mcuboot.h>
-#include <storage/flash_map.h>
-#include <sys/crc.h>
+#include <zephyr/dfu/flash_img.h>
+#include <zephyr/dfu/mcuboot.h>
+#include <zephyr/storage/flash_map.h>
+#include <zephyr/sys/crc.h>
 
 #define LOG_LEVEL CONFIG_CANOPEN_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(canopen_program);
 
 /* Object dictionary indexes */

--- a/modules/canopennode/canopen_storage.c
+++ b/modules/canopennode/canopen_storage.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <settings/settings.h>
+#include <zephyr/settings/settings.h>
 
 #include <CANopen.h>
 #include <CO_Emergency.h>
@@ -13,7 +13,7 @@
 #include <canopennode.h>
 
 #define LOG_LEVEL CONFIG_CANOPEN_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(canopen_storage);
 
 /* 's', 'a', 'v', 'e' from LSB to MSB */

--- a/modules/fff/include/c_test_framework.h
+++ b/modules/fff/include/c_test_framework.h
@@ -7,7 +7,7 @@
 #define MODULES_FFF_TEST_INCLUDE_C_TEST_FRAMEWORK_H_
 
 #include <ztest.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 void setup(void);
 void fff_test_suite(void);

--- a/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
@@ -6,7 +6,7 @@
 
 
 #include <platform/nrf_802154_temperature.h>
-#include <drivers/entropy.h>
+#include <zephyr/drivers/entropy.h>
 
 static uint32_t state;
 

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_init_net.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 
 #include "nrf_802154.h"
 #include "nrf_802154_serialization.h"

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_serialization_crit_sect.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_serialization_crit_sect.c
@@ -7,7 +7,7 @@
 #include "nrf_802154_serialization_crit_sect.h"
 
 #ifndef TEST
-#include <irq.h>
+#include <zephyr/irq.h>
 #endif
 
 void nrf_802154_serialization_crit_sect_enter(uint32_t *p_critical_section)

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <ipc/ipc_service.h>
-#include <device.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/ipc/ipc_service.h>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
 
 #include "nrf_802154_spinel_backend_callouts.h"
 #include "nrf_802154_serialization_error.h"

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_log.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_log.c
@@ -7,7 +7,7 @@
 #include <stdint.h>
 #include <stddef.h>
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 void nrf_802154_spinel_log(const char *p_fmt, ...)
 {

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_response_notifier.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_response_notifier.c
@@ -9,8 +9,8 @@
 #include <assert.h>
 #include <string.h>
 
-#include <logging/log.h>
-#include <zephyr.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/zephyr.h>
 
 #include "../spinel_base/spinel.h"
 #include "nrf_802154_spinel_log.h"

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_clock_zephyr.c
@@ -9,8 +9,8 @@
 #include <stddef.h>
 
 #include <compiler_abstraction.h>
-#include <drivers/clock_control/nrf_clock_control.h>
-#include <drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nrf_clock_control.h>
+#include <zephyr/drivers/clock_control.h>
 
 static bool hfclk_is_running;
 static bool lfclk_is_running;

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
@@ -9,10 +9,10 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include <sys/__assert.h>
-#include <device.h>
-#include <toolchain.h>
-#include <drivers/gpio.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/device.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/drivers/gpio.h>
 
 #include <hal/nrf_gpio.h>
 #include <nrf_802154_sl_coex.h>

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_irq_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_irq_zephyr.c
@@ -6,7 +6,7 @@
 
 #include <platform/nrf_802154_irq.h>
 
-#include <irq.h>
+#include <zephyr/irq.h>
 #include <nrfx.h>
 
 void nrf_802154_irq_init(uint32_t irqn, int32_t prio, nrf_802154_isr_t isr)

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
@@ -13,10 +13,10 @@
 
 #include "platform/nrf_802154_temperature.h"
 
-#include <device.h>
-#include <drivers/sensor.h>
-#include <kernel.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 
 /** @brief Default temperature [C] reported if NRF_802154_TEMPERATURE_UPDATE is disabled. */
 #define DEFAULT_TEMPERATURE 20

--- a/modules/hal_nordic/nrfx/nrfx_glue.c
+++ b/modules/hal_nordic/nrfx/nrfx_glue.c
@@ -5,7 +5,7 @@
  */
 
 #include <nrfx.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 void nrfx_isr(const void *irq_handler)
 {

--- a/modules/hal_nordic/nrfx/nrfx_glue.h
+++ b/modules/hal_nordic/nrfx/nrfx_glue.h
@@ -7,9 +7,9 @@
 #ifndef NRFX_GLUE_H__
 #define NRFX_GLUE_H__
 
-#include <sys/__assert.h>
-#include <sys/atomic.h>
-#include <irq.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/irq.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/hal_nordic/nrfx/nrfx_log.h
+++ b/modules/hal_nordic/nrfx/nrfx_log.h
@@ -7,7 +7,7 @@
 #ifndef NRFX_LOG_H__
 #define NRFX_LOG_H__
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/modules/hal_nxp/usb/usb_dc_mcux.h
+++ b/modules/hal_nxp/usb/usb_dc_mcux.h
@@ -7,8 +7,8 @@
 #ifndef __USB_DC_MCUX_H__
 #define __USB_DC_MCUX_H__
 
-#include <drivers/usb/usb_dc.h>
-#include <sys/byteorder.h>
+#include <zephyr/drivers/usb/usb_dc.h>
+#include <zephyr/sys/byteorder.h>
 #include "usb_spec.h"
 #include "usb.h"
 #include "usb_device_dci.h"

--- a/modules/hal_rpi_pico/pico/config_autogen.h
+++ b/modules/hal_rpi_pico/pico/config_autogen.h
@@ -21,7 +21,7 @@
  * static_assert is not supported, so BUILD_ASSERT is used instead.
  * BUILD_ASSERT is included through toolchain.h.
  */
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #define static_assert(expr, msg...) BUILD_ASSERT((expr), "" msg)
 
 /* Convert uses of asm, which is not supported in c99, to __asm */

--- a/modules/littlefs/zephyr_lfs_config.h
+++ b/modules/littlefs/zephyr_lfs_config.h
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #endif
 #ifndef LFS_NO_ASSERT
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 #endif
 
 #if !defined(LFS_NO_DEBUG) || \
@@ -29,7 +29,7 @@
 	    !defined(LFS_NO_ERROR) || \
 	    defined(LFS_YES_TRACE)
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 #ifdef LFS_LOG_REGISTER
 LOG_MODULE_REGISTER(littlefs, CONFIG_FS_LOG_LEVEL);

--- a/modules/mbedtls/shell.c
+++ b/modules/mbedtls/shell.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <shell/shell.h>
+#include <zephyr/shell/shell.h>
 #include <mbedtls/memory_buffer_alloc.h>
 
 #if defined(MBEDTLS_MEMORY_DEBUG)

--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -10,8 +10,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <app_memory/app_memdomain.h>
+#include <zephyr/init.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
 #if defined(CONFIG_MBEDTLS)
 #if !defined(CONFIG_MBEDTLS_CFG_FILE)

--- a/modules/segger/SEGGER_RTT_zephyr.c
+++ b/modules/segger/SEGGER_RTT_zephyr.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
 #include "SEGGER_RTT.h"
 
 /*

--- a/modules/segger/SEGGER_SYSVIEW_Conf.h
+++ b/modules/segger/SEGGER_SYSVIEW_Conf.h
@@ -6,7 +6,7 @@
 #pragma once
 
 #include <stdint.h>
-#include <irq.h>
+#include <zephyr/irq.h>
 
 #define SEGGER_SYSVIEW_GET_TIMESTAMP sysview_get_timestamp
 #define SEGGER_SYSVIEW_GET_INTERRUPT_ID sysview_get_interrupt

--- a/modules/trusted-firmware-m/interface/interface.c
+++ b/modules/trusted-firmware-m/interface/interface.c
@@ -5,11 +5,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <arch/arm/aarch32/cortex_m/fpu.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/fpu.h>
 
 #include <tfm_ns_interface.h>
 

--- a/modules/trusted-firmware-m/src/reboot.c
+++ b/modules/trusted-firmware-m/src/reboot.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "tfm_platform_api.h"
 

--- a/modules/trusted-firmware-m/src/zephyr_tfm_log.c
+++ b/modules/trusted-firmware-m/src/zephyr_tfm_log.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 int tfm_log_printf(const char *fmt, ...)
 {

--- a/modules/trusted-firmware-m/src/zephyr_tfm_psa_test.c
+++ b/modules/trusted-firmware-m/src/zephyr_tfm_psa_test.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /**
  * \brief This symbol is the entry point provided by the PSA API compliance


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all modules code to the
new prefix <zephyr/...>. Note that the conversion has been scripted,
refer to zephyrproject-rtos#45388 for more details.