### PR TITLE
kernel: migrate includes to <zephyr/...>

### DIFF
--- a/kernel/atomic_c.c
+++ b/kernel/atomic_c.c
@@ -18,11 +18,11 @@
  * (originally from x86's atomic.c)
  */
 
-#include <toolchain.h>
-#include <arch/cpu.h>
-#include <spinlock.h>
-#include <sys/atomic.h>
-#include <kernel_structs.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/kernel_structs.h>
 
 /* Single global spinlock for atomic operations.  This is fallback
  * code, not performance sensitive.  At least by not using irq_lock()
@@ -37,7 +37,7 @@ static struct k_spinlock lock;
  * forbidden.
  */
 #ifdef CONFIG_USERSPACE
-#include <syscall_handler.h>
+#include <zephyr/syscall_handler.h>
 
 #define ATOMIC_SYSCALL_HANDLER_TARGET(name) \
 	static inline atomic_val_t z_vrfy_##name(atomic_t *target) \

--- a/kernel/banner.c
+++ b/kernel/banner.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/util.h>
-#include <init.h>
-#include <device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/init.h>
+#include <zephyr/device.h>
 #include <version.h>
 
 /* boot banner items */

--- a/kernel/cache_handlers.c
+++ b/kernel/cache_handlers.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <cache.h>
-#include <syscall_handler.h>
+#include <zephyr/cache.h>
+#include <zephyr/syscall_handler.h>
 
 static inline int z_vrfy_sys_cache_data_all(int op)
 {

--- a/kernel/compiler_stack_protect.c
+++ b/kernel/compiler_stack_protect.c
@@ -16,13 +16,13 @@
  * function __stack_chk_fail and global variable __stack_chk_guard.
  */
 
-#include <toolchain.h> /* compiler specific configurations */
+#include <zephyr/toolchain.h> /* compiler specific configurations */
 
-#include <kernel_structs.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <kernel.h>
-#include <app_memory/app_memdomain.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/kernel.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
 /**
  *

--- a/kernel/condvar.c
+++ b/kernel/condvar.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <toolchain.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/toolchain.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <syscall_handler.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/syscall_handler.h>
 
 static struct k_spinlock lock;
 

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -5,9 +5,9 @@
  */
 
 #include <string.h>
-#include <device.h>
-#include <sys/atomic.h>
-#include <syscall_handler.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/syscall_handler.h>
 
 extern const struct init_entry __init_start[];
 extern const struct init_entry __init_PRE_KERNEL_1_start[];

--- a/kernel/errno.c
+++ b/kernel/errno.c
@@ -12,8 +12,8 @@
  * context switching.
  */
 
-#include <kernel.h>
-#include <syscall_handler.h>
+#include <zephyr/kernel.h>
+#include <zephyr/syscall_handler.h>
 
 /*
  * Define _k_neg_eagain for use in assembly files as errno.h is

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -21,17 +21,17 @@
  * @brief Kernel event object
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
-#include <wait_q.h>
-#include <sys/dlist.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/sys/dlist.h>
 #include <ksched.h>
-#include <init.h>
-#include <syscall_handler.h>
-#include <tracing/tracing.h>
-#include <sys/check.h>
+#include <zephyr/init.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/tracing/tracing.h>
+#include <zephyr/sys/check.h>
 
 #define K_EVENT_WAIT_ANY      0x00   /* Wait for any events */
 #define K_EVENT_WAIT_ALL      0x01   /* Wait for all events */

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 #include <kernel_internal.h>
-#include <kernel_structs.h>
-#include <sys/__assert.h>
-#include <arch/cpu.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
-#include <fatal.h>
-#include <debug/coredump.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/fatal.h>
+#include <zephyr/debug/coredump.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/kernel/futex.c
+++ b/kernel/futex.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <spinlock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/spinlock.h>
 #include <kswap.h>
-#include <syscall_handler.h>
-#include <init.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/init.h>
 #include <ksched.h>
 
 static struct z_futex_data *k_futex_find_data(struct k_futex *futex)

--- a/kernel/idle.c
+++ b/kernel/idle.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <drivers/timer/system_timer.h>
-#include <wait_q.h>
-#include <pm/pm.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/pm/pm.h>
 #include <stdbool.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #include <ksched.h>
 #include <kswap.h>
 

--- a/kernel/include/gen_offset.h
+++ b/kernel/include/gen_offset.h
@@ -50,7 +50,7 @@
  * /@ include struct definitions for which offsets symbols are to be
  * generated @/
  *
- * #include <kernel_structs.h>
+ * #include <zephyr/kernel_structs.h>
  * GEN_ABS_SYM_BEGIN (_OffsetAbsSyms)	/@ the name parameter is arbitrary @/
  * /@ _kernel_t structure member offsets @/
  *
@@ -76,7 +76,7 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_GEN_OFFSET_H_
 #define ZEPHYR_KERNEL_INCLUDE_GEN_OFFSET_H_
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <stddef.h>
 
 /* definition of the GEN_OFFSET_SYM() macros is toolchain independent  */

--- a/kernel/include/kernel_arch_interface.h
+++ b/kernel/include/kernel_arch_interface.h
@@ -17,8 +17,8 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_ARCH_INTERFACE_H_
 #define ZEPHYR_KERNEL_INCLUDE_KERNEL_ARCH_INTERFACE_H_
 
-#include <kernel.h>
-#include <sys/arch_interface.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/arch_interface.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/kernel/include/kernel_internal.h
+++ b/kernel/include/kernel_internal.h
@@ -14,7 +14,7 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_INTERNAL_H_
 #define ZEPHYR_KERNEL_INCLUDE_KERNEL_INTERNAL_H_
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_interface.h>
 #include <string.h>
 

--- a/kernel/include/kernel_offsets.h
+++ b/kernel/include/kernel_offsets.h
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <device.h>
+#include <zephyr/device.h>
 
-#include <pm/device.h>
+#include <zephyr/pm/device.h>
 
 #ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_
 #define ZEPHYR_KERNEL_INCLUDE_KERNEL_OFFSETS_H_

--- a/kernel/include/kernel_tls.h
+++ b/kernel/include/kernel_tls.h
@@ -14,7 +14,7 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_KERNEL_TLS_H_
 #define ZEPHYR_KERNEL_INCLUDE_KERNEL_TLS_H_
 
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 /**
  * @brief Return the total size of TLS data/bss areas

--- a/kernel/include/ksched.h
+++ b/kernel/include/ksched.h
@@ -7,10 +7,10 @@
 #ifndef ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 #define ZEPHYR_KERNEL_INCLUDE_KSCHED_H_
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
-#include <timeout_q.h>
-#include <tracing/tracing.h>
+#include <zephyr/timeout_q.h>
+#include <zephyr/tracing/tracing.h>
 #include <stdbool.h>
 
 BUILD_ASSERT(K_LOWEST_APPLICATION_THREAD_PRIO

--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_KERNEL_INCLUDE_KSWAP_H_
 
 #include <ksched.h>
-#include <spinlock.h>
+#include <zephyr/spinlock.h>
 #include <kernel_arch_func.h>
 
 #ifdef CONFIG_STACK_SENTINEL

--- a/kernel/include/mmu.h
+++ b/kernel/include/mmu.h
@@ -9,11 +9,11 @@
 #ifdef CONFIG_MMU
 
 #include <stdint.h>
-#include <sys/slist.h>
-#include <sys/__assert.h>
-#include <sys/util.h>
-#include <sys/mem_manage.h>
-#include <linker/linker-defs.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/mem_manage.h>
+#include <zephyr/linker/linker-defs.h>
 
 /*
  * At present, page frame management is only done for main system RAM,

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -11,30 +11,30 @@
  * This module contains routines that are used to initialize the kernel.
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <offsets_short.h>
-#include <kernel.h>
-#include <sys/printk.h>
-#include <debug/stack.h>
-#include <random/rand32.h>
-#include <linker/sections.h>
-#include <toolchain.h>
-#include <kernel_structs.h>
-#include <device.h>
-#include <init.h>
-#include <linker/linker-defs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/debug/stack.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/linker/linker-defs.h>
 #include <ksched.h>
 #include <string.h>
-#include <sys/dlist.h>
+#include <zephyr/sys/dlist.h>
 #include <kernel_internal.h>
-#include <drivers/entropy.h>
-#include <logging/log_ctrl.h>
-#include <tracing/tracing.h>
+#include <zephyr/drivers/entropy.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/tracing/tracing.h>
 #include <stdbool.h>
-#include <debug/gcov.h>
+#include <zephyr/debug/gcov.h>
 #include <kswap.h>
-#include <timing/timing.h>
-#include <logging/log.h>
+#include <zephyr/timing/timing.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* the only struct z_kernel instance */

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <init.h>
-#include <linker/linker-defs.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/init.h>
+#include <zephyr/linker/linker-defs.h>
 
 void k_heap_init(struct k_heap *h, void *mem, size_t bytes)
 {

--- a/kernel/mailbox.c
+++ b/kernel/mailbox.c
@@ -8,16 +8,16 @@
  * @brief Mailboxes.
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
-#include <linker/sections.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 #include <string.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <sys/dlist.h>
-#include <init.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/sys/dlist.h>
+#include <zephyr/init.h>
 
 #if (CONFIG_NUM_MBOX_ASYNC_MSGS > 0)
 

--- a/kernel/mem_domain.c
+++ b/kernel/mem_domain.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
-#include <sys/__assert.h>
+#include <zephyr/sys/__assert.h>
 #include <stdbool.h>
-#include <spinlock.h>
-#include <sys/check.h>
-#include <sys/libc-hooks.h>
-#include <logging/log.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 struct k_spinlock z_mem_domain_lock;

--- a/kernel/mem_slab.c
+++ b/kernel/mem_slab.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <wait_q.h>
-#include <sys/dlist.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/sys/dlist.h>
 #include <ksched.h>
-#include <init.h>
-#include <sys/check.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/check.h>
 
 /**
  * @brief Initialize kernel memory slab subsystem.

--- a/kernel/mempool.c
+++ b/kernel/mempool.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <string.h>
-#include <sys/math_extras.h>
-#include <sys/util.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/util.h>
 
 static void *z_heap_aligned_alloc(struct k_heap *heap, size_t align, size_t size)
 {

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -8,16 +8,16 @@
 
 #include <stdint.h>
 #include <kernel_arch_interface.h>
-#include <spinlock.h>
+#include <zephyr/spinlock.h>
 #include <mmu.h>
-#include <init.h>
+#include <zephyr/init.h>
 #include <kernel_internal.h>
-#include <syscall_handler.h>
-#include <toolchain.h>
-#include <linker/linker-defs.h>
-#include <sys/bitarray.h>
-#include <timing/timing.h>
-#include <logging/log.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/sys/bitarray.h>
+#include <zephyr/timing/timing.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /*

--- a/kernel/msg_q.c
+++ b/kernel/msg_q.c
@@ -10,20 +10,20 @@
  */
 
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
-#include <linker/sections.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 #include <string.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <sys/dlist.h>
-#include <sys/math_extras.h>
-#include <init.h>
-#include <syscall_handler.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/sys/dlist.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/init.h>
+#include <zephyr/syscall_handler.h>
 #include <kernel_internal.h>
-#include <sys/check.h>
+#include <zephyr/sys/check.h>
 
 #ifdef CONFIG_POLL
 static inline void handle_poll_events(struct k_msgq *msgq, uint32_t state)

--- a/kernel/mutex.c
+++ b/kernel/mutex.c
@@ -26,17 +26,17 @@
  * unexpected priority levels (too high, or too low).
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <toolchain.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/toolchain.h>
 #include <ksched.h>
-#include <wait_q.h>
+#include <zephyr/wait_q.h>
 #include <errno.h>
-#include <init.h>
-#include <syscall_handler.h>
-#include <tracing/tracing.h>
-#include <sys/check.h>
-#include <logging/log.h>
+#include <zephyr/init.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/tracing/tracing.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* We use a global spinlock here because some of the synchronization

--- a/kernel/paging/statistics.c
+++ b/kernel/paging/statistics.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <syscall_handler.h>
-#include <toolchain.h>
-#include <sys/mem_manage.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/mem_manage.h>
 
 extern struct k_mem_paging_stats_t paging_stats;
 

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -10,16 +10,16 @@
  * @brief Pipes
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <init.h>
-#include <syscall_handler.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/init.h>
+#include <zephyr/syscall_handler.h>
 #include <kernel_internal.h>
-#include <sys/check.h>
+#include <zephyr/sys/check.h>
 
 struct k_pipe_desc {
 	unsigned char *buffer;           /* Position in src/dest buffer */

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -14,15 +14,15 @@
  * constructs.
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
-#include <wait_q.h>
+#include <zephyr/wait_q.h>
 #include <ksched.h>
-#include <syscall_handler.h>
-#include <sys/dlist.h>
-#include <sys/util.h>
-#include <sys/__assert.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/sys/dlist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/__assert.h>
 #include <stdbool.h>
 
 /* Single subsystem lock.  Locking per-event would be better on highly

--- a/kernel/queue.c
+++ b/kernel/queue.c
@@ -11,16 +11,16 @@
  */
 
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
-#include <wait_q.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/wait_q.h>
 #include <ksched.h>
-#include <init.h>
-#include <syscall_handler.h>
+#include <zephyr/init.h>
+#include <zephyr/syscall_handler.h>
 #include <kernel_internal.h>
-#include <sys/check.h>
+#include <zephyr/sys/check.h>
 
 struct alloc_node {
 	sys_sfnode_t node;

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -3,21 +3,21 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <spinlock.h>
-#include <kernel/sched_priq.h>
-#include <wait_q.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/kernel/sched_priq.h>
+#include <zephyr/wait_q.h>
 #include <kswap.h>
 #include <kernel_arch_func.h>
-#include <syscall_handler.h>
-#include <drivers/timer/system_timer.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/drivers/timer/system_timer.h>
 #include <stdbool.h>
 #include <kernel_internal.h>
-#include <logging/log.h>
-#include <sys/atomic.h>
-#include <sys/math_extras.h>
-#include <timing/timing.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/timing/timing.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/kernel/sem.c
+++ b/kernel/sem.c
@@ -17,17 +17,17 @@
  * having to poll.
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
-#include <wait_q.h>
-#include <sys/dlist.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/sys/dlist.h>
 #include <ksched.h>
-#include <init.h>
-#include <syscall_handler.h>
-#include <tracing/tracing.h>
-#include <sys/check.h>
+#include <zephyr/init.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/tracing/tracing.h>
+#include <zephyr/sys/check.h>
 
 /* We use a system-wide lock to synchronize semaphores, which has
  * unfortunate performance impact vs. using a per-object lock

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -2,9 +2,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <spinlock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/spinlock.h>
 #include <kswap.h>
 #include <kernel_internal.h>
 

--- a/kernel/stack.c
+++ b/kernel/stack.c
@@ -8,15 +8,15 @@
  * @brief fixed-size stack object
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <sys/check.h>
-#include <init.h>
-#include <syscall_handler.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/init.h>
+#include <zephyr/syscall_handler.h>
 #include <kernel_internal.h>
 
 void k_stack_init(struct k_stack *stack, stack_data_t *buffer,

--- a/kernel/system_work_q.c
+++ b/kernel/system_work_q.c
@@ -11,8 +11,8 @@
  * System workqueue.
  */
 
-#include <kernel.h>
-#include <init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
 
 static K_KERNEL_STACK_DEFINE(sys_work_q_stack,
 			     CONFIG_SYSTEM_WORKQUEUE_STACK_SIZE);

--- a/kernel/thread.c
+++ b/kernel/thread.c
@@ -11,24 +11,24 @@
  * This module provides general purpose thread support.
  */
 
-#include <kernel.h>
-#include <spinlock.h>
-#include <sys/math_extras.h>
-#include <sys_clock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/sys_clock.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <syscall_handler.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/syscall_handler.h>
 #include <kernel_internal.h>
 #include <kswap.h>
-#include <init.h>
-#include <tracing/tracing.h>
+#include <zephyr/init.h>
+#include <zephyr/tracing/tracing.h>
 #include <string.h>
 #include <stdbool.h>
-#include <irq_offload.h>
-#include <sys/check.h>
-#include <random/rand32.h>
-#include <sys/atomic.h>
-#include <logging/log.h>
+#include <zephyr/irq_offload.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/sys/atomic.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef CONFIG_THREAD_MONITOR

--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <spinlock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/spinlock.h>
 #include <ksched.h>
-#include <timeout_q.h>
-#include <syscall_handler.h>
-#include <drivers/timer/system_timer.h>
-#include <sys_clock.h>
+#include <zephyr/timeout_q.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/sys_clock.h>
 
 static uint64_t curr_tick;
 

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <syscall_handler.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/syscall_handler.h>
 #include <stdbool.h>
-#include <spinlock.h>
+#include <zephyr/spinlock.h>
 
 static struct k_spinlock lock;
 

--- a/kernel/usage.c
+++ b/kernel/usage.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
-#include <timing/timing.h>
+#include <zephyr/timing/timing.h>
 #include <ksched.h>
-#include <spinlock.h>
-#include <sys/check.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/check.h>
 
 /* Need one of these for this to work */
 #if !defined(CONFIG_USE_SWITCH) && !defined(CONFIG_INSTRUMENT_THREAD_SWITCHING)

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -5,23 +5,23 @@
  */
 
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <string.h>
-#include <sys/math_extras.h>
-#include <sys/rb.h>
-#include <kernel_structs.h>
-#include <sys/sys_io.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/sys/rb.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/sys/sys_io.h>
 #include <ksched.h>
-#include <syscall.h>
-#include <syscall_handler.h>
-#include <device.h>
-#include <init.h>
+#include <zephyr/syscall.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
 #include <stdbool.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/libc-hooks.h>
-#include <sys/mutex.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/libc-hooks.h>
+#include <zephyr/sys/mutex.h>
 #include <inttypes.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 #ifdef Z_LIBC_PARTITION_EXISTS
 K_APPMEM_PARTITION_DEFINE(z_libc_partition);
@@ -35,7 +35,7 @@ K_APPMEM_PARTITION_DEFINE(z_libc_partition);
 K_APPMEM_PARTITION_DEFINE(k_mbedtls_partition);
 #endif
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* The originally synchronization strategy made heavy use of recursive

--- a/kernel/userspace_handler.c
+++ b/kernel/userspace_handler.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <syscall_handler.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/syscall_handler.h>
+#include <zephyr/kernel_structs.h>
 
 static struct z_object *validate_any_object(const void *obj)
 {

--- a/kernel/work.c
+++ b/kernel/work.c
@@ -10,13 +10,13 @@
  * Second generation work queue implementation
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <wait_q.h>
-#include <spinlock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/spinlock.h>
 #include <errno.h>
 #include <ksched.h>
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 
 static inline void flag_clear(uint32_t *flagp,
 			      uint32_t bit)

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -6,10 +6,10 @@
  */
 
 
-#include <zephyr.h>
-#include <kernel.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 #ifdef CONFIG_STACK_CANARIES
 extern volatile uintptr_t __stack_chk_guard;


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all kernel code to the
new prefix <zephyr/...>. Note that the conversion has been scripted,
refer to zephyrproject-rtos#45388 for more details.