### PR TITLE
arch: migrate includes to <zephyr/...>

### DIFF
--- a/arch/arc/arcmwdt/arcmwdt-dtr-stubs.c
+++ b/arch/arc/arcmwdt/arcmwdt-dtr-stubs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 
 __weak void *__dso_handle;
 

--- a/arch/arc/core/arc_connect.c
+++ b/arch/arc/core/arc_connect.c
@@ -10,9 +10,9 @@
  *
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <spinlock.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/spinlock.h>
 #include <kernel_internal.h>
 
 static struct k_spinlock arc_connect_spinlock;

--- a/arch/arc/core/arc_smp.c
+++ b/arch/arc/core/arc_smp.c
@@ -9,12 +9,12 @@
  * @brief codes required for ARC multicore and Zephyr smp support
  *
  */
-#include <device.h>
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <ksched.h>
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 
 #ifndef IRQ_ICI

--- a/arch/arc/core/cache.c
+++ b/arch/arc/core/cache.c
@@ -13,16 +13,16 @@
  * This module contains functions for manipulation of the d-cache.
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/util.h>
-#include <toolchain.h>
-#include <cache.h>
-#include <linker/linker-defs.h>
-#include <arch/arc/v2/aux_regs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/cache.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/aux_regs.h>
 #include <kernel_internal.h>
-#include <sys/__assert.h>
-#include <init.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/init.h>
 #include <stdbool.h>
 
 #if defined(CONFIG_DCACHE_LINE_SIZE_DETECT)

--- a/arch/arc/core/fatal.c
+++ b/arch/arc/core/fatal.c
@@ -12,12 +12,12 @@
  * ARCv2 CPUs.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <offsets_short.h>
-#include <arch/cpu.h>
-#include <logging/log.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/logging/log.h>
 #include <kernel_arch_data.h>
-#include <arch/arc/v2/exc.h>
+#include <zephyr/arch/arc/v2/exc.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/arch/arc/core/fault.c
+++ b/arch/arc/core/fault.c
@@ -11,15 +11,15 @@
  * Common fault handler for ARCv2 processors.
  */
 
-#include <toolchain.h>
-#include <linker/sections.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 #include <inttypes.h>
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <kernel_structs.h>
-#include <exc_handle.h>
-#include <logging/log.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/exc_handle.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef CONFIG_USERSPACE

--- a/arch/arc/core/irq_manage.c
+++ b/arch/arc/core/irq_manage.c
@@ -17,14 +17,14 @@
  * number from 16 to last IRQ number on the platform.
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/__assert.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <sw_isr_table.h>
-#include <irq.h>
-#include <sys/printk.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sw_isr_table.h>
+#include <zephyr/irq.h>
+#include <zephyr/sys/printk.h>
 
 
 /*

--- a/arch/arc/core/irq_offload.c
+++ b/arch/arc/core/irq_offload.c
@@ -8,8 +8,8 @@
  * @file Software interrupts utility code - ARC implementation
  */
 
-#include <kernel.h>
-#include <irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq_offload.h>
 
 static irq_offload_routine_t offload_routine;
 static const void *offload_param;

--- a/arch/arc/core/mpu/arc_core_mpu.c
+++ b/arch/arc/core/mpu/arc_core_mpu.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
-#include <arch/arc/v2/mpu/arc_core_mpu.h>
-#include <kernel_structs.h>
+#include <zephyr/arch/arc/v2/mpu/arc_core_mpu.h>
+#include <zephyr/kernel_structs.h>
 
 /*
  * @brief Configure MPU for the thread

--- a/arch/arc/core/mpu/arc_mpu.c
+++ b/arch/arc/core/mpu/arc_mpu.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
-#include <arch/arc/v2/aux_regs.h>
-#include <arch/arc/v2/mpu/arc_mpu.h>
-#include <arch/arc/v2/mpu/arc_core_mpu.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/aux_regs.h>
+#include <zephyr/arch/arc/v2/mpu/arc_mpu.h>
+#include <zephyr/arch/arc/v2/mpu/arc_core_mpu.h>
+#include <zephyr/linker/linker-defs.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mpu);
 
 /**

--- a/arch/arc/core/offsets/offsets.c
+++ b/arch/arc/core/offsets/offsets.c
@@ -22,7 +22,7 @@
  * completeness.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <gen_offset.h>
 #include <kernel_offsets.h>

--- a/arch/arc/core/prep_c.c
+++ b/arch/arc/core/prep_c.c
@@ -17,10 +17,10 @@
  */
 
 #include <zephyr/types.h>
-#include <toolchain.h>
-#include <linker/linker-defs.h>
-#include <arch/arc/v2/aux_regs.h>
-#include <kernel_structs.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/aux_regs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 
 

--- a/arch/arc/core/secureshield/arc_sjli.c
+++ b/arch/arc/core/secureshield/arc_sjli.c
@@ -4,14 +4,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/kernel.h>
 #include <errno.h>
 #include <zephyr/types.h>
-#include <init.h>
-#include <toolchain.h>
+#include <zephyr/init.h>
+#include <zephyr/toolchain.h>
 
-#include <arch/arc/v2/secureshield/arc_secure.h>
+#include <zephyr/arch/arc/v2/secureshield/arc_secure.h>
 
 static void _default_sjli_entry(void);
 /*

--- a/arch/arc/core/secureshield/secure_sys_services.c
+++ b/arch/arc/core/secureshield/secure_sys_services.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <errno.h>
-#include <kernel.h>
-#include <arch/cpu.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
 #include <zephyr/types.h>
 #include <soc.h>
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 
-#include <arch/arc/v2/secureshield/arc_secure.h>
+#include <zephyr/arch/arc/v2/secureshield/arc_secure.h>
 
 #define IRQ_PRIO_MASK (0xffff << ARC_N_IRQ_START_LEVEL)
 /*

--- a/arch/arc/core/thread.c
+++ b/arch/arc/core/thread.c
@@ -11,13 +11,13 @@
  * Core thread related primitives for the ARCv2 processor architecture.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
 #include <offsets_short.h>
-#include <wait_q.h>
+#include <zephyr/wait_q.h>
 
 #ifdef CONFIG_USERSPACE
-#include <arch/arc/v2/mpu/arc_core_mpu.h>
+#include <zephyr/arch/arc/v2/mpu/arc_core_mpu.h>
 #endif
 
 /*  initial stack frame */

--- a/arch/arc/core/timestamp.c
+++ b/arch/arc/core/timestamp.c
@@ -11,9 +11,9 @@
  * Provide 64-bit time stamp API
  */
 
-#include <kernel.h>
-#include <toolchain.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/kernel_structs.h>
 
 /*
  * @brief Read 64-bit timestamp value

--- a/arch/arc/core/tls.c
+++ b/arch/arc/core/tls.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 {

--- a/arch/arc/core/vector_table.c
+++ b/arch/arc/core/vector_table.c
@@ -24,7 +24,7 @@
  */
 
 #include <zephyr/types.h>
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include "vector_table.h"
 
 struct vector_table {

--- a/arch/arc/include/kernel_arch_data.h
+++ b/arch/arc/include/kernel_arch_data.h
@@ -20,16 +20,16 @@
 #ifndef ZEPHYR_ARCH_ARC_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_ARC_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 #include <vector_table.h>
 
 #ifndef _ASMLANGUAGE
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/util.h>
-#include <sys/dlist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/dlist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/arc/include/swap_macros.h
+++ b/arch/arc/include/swap_macros.h
@@ -9,12 +9,12 @@
 #ifndef ZEPHYR_ARCH_ARC_INCLUDE_SWAP_MACROS_H_
 #define ZEPHYR_ARCH_ARC_INCLUDE_SWAP_MACROS_H_
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <offsets_short.h>
-#include <toolchain.h>
-#include <arch/cpu.h>
-#include <arch/arc/tool-compat.h>
-#include <arch/arc/asm-compat/assembler.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arc/tool-compat.h>
+#include <zephyr/arch/arc/asm-compat/assembler.h>
 
 #ifdef _ASMLANGUAGE
 

--- a/arch/arc/include/v2/irq.h
+++ b/arch/arc/include/v2/irq.h
@@ -15,7 +15,7 @@
 #ifndef ZEPHYR_ARCH_ARC_INCLUDE_V2_IRQ_H_
 #define ZEPHYR_ARCH_ARC_INCLUDE_V2_IRQ_H_
 
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/arc/include/vector_table.h
+++ b/arch/arc/include/vector_table.h
@@ -25,8 +25,8 @@
 
 #ifdef _ASMLANGUAGE
 
-#include <toolchain.h>
-#include <linker/sections.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 
 GTEXT(__start)
 GTEXT(_VectorTable)

--- a/arch/arm/core/aarch32/__aeabi_atexit.c
+++ b/arch/arm/core/aarch32/__aeabi_atexit.c
@@ -9,7 +9,7 @@
  * @brief Basic C++ destructor module for globals for ARM
  */
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 
 EXTERN_C int __cxa_atexit(void (*destructor)(void *), void *objptr, void *dso);
 

--- a/arch/arm/core/aarch32/cortex_a_r/fault.c
+++ b/arch/arm/core/aarch32/cortex_a_r/fault.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <exc_handle.h>
-#include <logging/log.h>
+#include <zephyr/exc_handle.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #define FAULT_DUMP_VERBOSE	(CONFIG_FAULT_DUMP == 2)

--- a/arch/arm/core/aarch32/cortex_a_r/irq_init.c
+++ b/arch/arm/core/aarch32/cortex_a_r/irq_init.c
@@ -9,8 +9,8 @@
  * @brief ARM Cortex-A and Cortex-R interrupt initialization
  */
 
-#include <arch/cpu.h>
-#include <drivers/interrupt_controller/gic.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/interrupt_controller/gic.h>
 
 /**
  *

--- a/arch/arm/core/aarch32/cortex_a_r/reboot.c
+++ b/arch/arm/core/aarch32/cortex_a_r/reboot.c
@@ -9,9 +9,9 @@
  * @brief ARM Cortex-A and Cortex-R System Control Block interface
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
 
 /**
  *

--- a/arch/arm/core/aarch32/cortex_a_r/stacks.c
+++ b/arch/arm/core/aarch32/cortex_a_r/stacks.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <aarch32/cortex_a_r/stack.h>
 #include <string.h>
 #include <kernel_internal.h>

--- a/arch/arm/core/aarch32/cortex_a_r/tcm.c
+++ b/arch/arm/core/aarch32/cortex_a_r/tcm.c
@@ -3,8 +3,8 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
-#include <arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 
 void z_arm_tcm_disable_ecc(void)
 {

--- a/arch/arm/core/aarch32/cortex_a_r/thread.c
+++ b/arch/arm/core/aarch32/cortex_a_r/thread.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdbool.h>
-#include <arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 
 bool z_arm_thread_is_in_user_mode(void)
 {

--- a/arch/arm/core/aarch32/cortex_a_r/vector_table.h
+++ b/arch/arm/core/aarch32/cortex_a_r/vector_table.h
@@ -24,9 +24,9 @@
 
 #ifdef _ASMLANGUAGE
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <sys/util.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sys/util.h>
 
 GTEXT(__start)
 GDATA(_vector_table)

--- a/arch/arm/core/aarch32/cortex_m/cmse/arm_core_cmse.c
+++ b/arch/arm/core/aarch32/cortex_m/cmse/arm_core_cmse.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <aarch32/cortex_m/cmse.h>
 
 int arm_cmse_mpu_region_get(uint32_t addr)

--- a/arch/arm/core/aarch32/cortex_m/coredump.c
+++ b/arch/arm/core/aarch32/cortex_m/coredump.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <debug/coredump.h>
+#include <zephyr/debug/coredump.h>
 
 #define ARCH_HDR_VER			2
 

--- a/arch/arm/core/aarch32/cortex_m/debug.c
+++ b/arch/arm/core/aarch32/cortex_m/debug.c
@@ -10,7 +10,7 @@
  *
  */
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <aarch32/cortex_m/dwt.h>
 
 /**

--- a/arch/arm/core/aarch32/cortex_m/fault.c
+++ b/arch/arm/core/aarch32/cortex_m/fault.c
@@ -12,11 +12,11 @@
  * Common fault handler for ARM Cortex-M processors.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <inttypes.h>
-#include <exc_handle.h>
-#include <logging/log.h>
+#include <zephyr/exc_handle.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #if defined(CONFIG_PRINTK) || defined(CONFIG_LOG)

--- a/arch/arm/core/aarch32/cortex_m/fpu.c
+++ b/arch/arm/core/aarch32/cortex_m/fpu.c
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <arch/arm/aarch32/cortex_m/fpu.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/fpu.h>
 
 /**
  * @file @brief Helper functions for saving and restoring the FP context.

--- a/arch/arm/core/aarch32/cortex_m/irq_init.c
+++ b/arch/arm/core/aarch32/cortex_m/irq_init.c
@@ -10,8 +10,8 @@
  *
  */
 
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  *

--- a/arch/arm/core/aarch32/cortex_m/scb.c
+++ b/arch/arm/core/aarch32/cortex_m/scb.c
@@ -14,11 +14,11 @@
  * definitions and more complex routines, if needed.
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/util.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <linker/linker-defs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/linker/linker-defs.h>
 
 #if defined(CONFIG_CPU_HAS_NXP_MPU)
 #include <fsl_sysmpu.h>

--- a/arch/arm/core/aarch32/cortex_m/thread.c
+++ b/arch/arm/core/aarch32/cortex_m/thread.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdbool.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 bool z_arm_thread_is_in_user_mode(void)
 {

--- a/arch/arm/core/aarch32/cortex_m/thread_abort.c
+++ b/arch/arm/core/aarch32/cortex_m/thread_abort.c
@@ -16,13 +16,13 @@
  * must queue the PendSV exception.
  */
 
-#include <kernel.h>
-#include <toolchain.h>
-#include <linker/sections.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 #include <ksched.h>
 #include <kswap.h>
-#include <wait_q.h>
-#include <sys/__assert.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/sys/__assert.h>
 
 void z_impl_k_thread_abort(k_tid_t thread)
 {

--- a/arch/arm/core/aarch32/cortex_m/timing.c
+++ b/arch/arm/core/aarch32/cortex_m/timing.c
@@ -11,10 +11,10 @@
  *
  */
 
-#include <init.h>
-#include <timing/timing.h>
+#include <zephyr/init.h>
+#include <zephyr/timing/timing.h>
 #include <aarch32/cortex_m/dwt.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 /**
  * @brief Return the current frequency of the cycle counter

--- a/arch/arm/core/aarch32/cortex_m/tz/arm_core_tz.c
+++ b/arch/arm/core/aarch32/cortex_m/tz/arm_core_tz.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <aarch32/cortex_m/tz.h>
 #include <aarch32/cortex_m/exc.h>
 

--- a/arch/arm/core/aarch32/cortex_m/vector_table.h
+++ b/arch/arm/core/aarch32/cortex_m/vector_table.h
@@ -23,9 +23,9 @@
 
 #ifdef _ASMLANGUAGE
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <sys/util.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sys/util.h>
 
 GTEXT(__start)
 GDATA(_vector_table)

--- a/arch/arm/core/aarch32/fatal.c
+++ b/arch/arm/core/aarch32/fatal.c
@@ -12,9 +12,9 @@
  * and Cortex-R CPUs.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 static void esf_dump(const z_arch_esf_t *esf)

--- a/arch/arm/core/aarch32/irq_manage.c
+++ b/arch/arm/core/aarch32/irq_manage.c
@@ -14,21 +14,21 @@
  * connecting ISRs at runtime.
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
 #if defined(CONFIG_CPU_CORTEX_M)
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #elif defined(CONFIG_CPU_AARCH32_CORTEX_A) \
 	|| defined(CONFIG_CPU_AARCH32_CORTEX_R)
-#include <drivers/interrupt_controller/gic.h>
+#include <zephyr/drivers/interrupt_controller/gic.h>
 #endif
-#include <sys/__assert.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <sw_isr_table.h>
-#include <irq.h>
-#include <tracing/tracing.h>
-#include <pm/pm.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sw_isr_table.h>
+#include <zephyr/irq.h>
+#include <zephyr/tracing/tracing.h>
+#include <zephyr/pm/pm.h>
 
 extern void z_arm_reserved(void);
 

--- a/arch/arm/core/aarch32/irq_offload.c
+++ b/arch/arm/core/aarch32/irq_offload.c
@@ -8,8 +8,8 @@
  * @file Software interrupts utility code - ARM implementation
  */
 
-#include <kernel.h>
-#include <irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq_offload.h>
 
 volatile irq_offload_routine_t offload_routine;
 static const void *offload_param;

--- a/arch/arm/core/aarch32/mmu/arm_mmu.c
+++ b/arch/arm/core/aarch32/mmu/arm_mmu.c
@@ -18,19 +18,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 
-#include <linker/linker-defs.h>
-#include <logging/log.h>
-#include <sys/__assert.h>
-#include <sys/util.h>
-#include <sys/mem_manage.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/mem_manage.h>
 
-#include <arch/arm/aarch32/cortex_a_r/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_a_r/cmsis.h>
 
-#include <arch/arm/aarch32/mmu/arm_mmu.h>
+#include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
 #include "arm_mmu_priv.h"
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);

--- a/arch/arm/core/aarch32/mpu/arm_core_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_core_mpu.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 
 #include "arm_core_mpu_dev.h"
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mpu);
 
 /*

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -4,16 +4,16 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include "arm_core_mpu_dev.h"
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 #include <kernel_arch_data.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(mpu);
 
 #if defined(CONFIG_ARMV8_M_BASELINE) || defined(CONFIG_ARMV8_M_MAINLINE)

--- a/arch/arm/core/aarch32/mpu/arm_mpu_v7_internal.h
+++ b/arch/arm/core/aarch32/mpu/arm_mpu_v7_internal.h
@@ -9,11 +9,11 @@
 #define ZEPHYR_ARCH_ARM_CORE_AARCH32_MPU_ARM_MPU_V7_INTERNAL_H_
 
 
-#include <sys/math_extras.h>
+#include <zephyr/sys/math_extras.h>
 #include <arm_mpu_internal.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 /* Global MPU configuration at system initialization. */
 static void mpu_init(void)

--- a/arch/arm/core/aarch32/mpu/arm_mpu_v8_internal.h
+++ b/arch/arm/core/aarch32/mpu/arm_mpu_v8_internal.h
@@ -10,7 +10,7 @@
 
 #include <aarch32/cortex_m/cmse.h>
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 
 /**
  * @brief internal structure holding information of

--- a/arch/arm/core/aarch32/mpu/cortex_a_r/arm_mpu_internal.h
+++ b/arch/arm/core/aarch32/mpu/cortex_a_r/arm_mpu_internal.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 Lexmark International, Inc.
  */
 
-#include <sys/math_extras.h>
+#include <zephyr/sys/math_extras.h>
 
 /**
  *  Get the number of supported MPU regions.

--- a/arch/arm/core/aarch32/mpu/cortex_m/arm_mpu_internal.h
+++ b/arch/arm/core/aarch32/mpu/cortex_m/arm_mpu_internal.h
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 Lexmark International, Inc.
  */
 
-#include <sys/math_extras.h>
+#include <zephyr/sys/math_extras.h>
 
 /**
  *  Get the number of supported MPU regions.

--- a/arch/arm/core/aarch32/mpu/nxp_mpu.c
+++ b/arch/arm/core/aarch32/mpu/nxp_mpu.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <soc.h>
 #include "arm_core_mpu_dev.h"
-#include <sys/__assert.h>
-#include <sys/math_extras.h>
-#include <linker/linker-defs.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/math_extras.h>
+#include <zephyr/linker/linker-defs.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(mpu);
 
 /*

--- a/arch/arm/core/aarch32/nmi.c
+++ b/arch/arm/core/aarch32/nmi.c
@@ -13,12 +13,12 @@
  * custom run time handler.
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/printk.h>
-#include <sys/reboot.h>
-#include <toolchain.h>
-#include <linker/sections.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/reboot.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 
 extern void z_SysNmiOnReset(void);
 #if !defined(CONFIG_RUNTIME_NMI)

--- a/arch/arm/core/aarch32/prep_c.c
+++ b/arch/arm/core/aarch32/prep_c.c
@@ -16,9 +16,9 @@
  * initialization is performed.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 #if defined(CONFIG_ARMV7_R) || defined(CONFIG_ARMV7_A)
 #include <aarch32/cortex_a_r/stack.h>

--- a/arch/arm/core/aarch32/swap.c
+++ b/arch/arm/core/aarch32/swap.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
 
 extern const int _k_neg_eagain;

--- a/arch/arm/core/aarch32/thread.c
+++ b/arch/arm/core/aarch32/thread.c
@@ -12,9 +12,9 @@
  * Cortex-R processor architecture.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <wait_q.h>
+#include <zephyr/wait_q.h>
 
 #if (MPU_GUARD_ALIGN_AND_SIZE_FLOAT > MPU_GUARD_ALIGN_AND_SIZE)
 #define FP_GUARD_EXTRA_SIZE	(MPU_GUARD_ALIGN_AND_SIZE_FLOAT - \

--- a/arch/arm/core/common/tls.c
+++ b/arch/arm/core/common/tls.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/util.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/util.h>
 
 #ifdef CONFIG_CPU_CORTEX_M
 /*

--- a/arch/arm/core/offsets/offsets_aarch32.c
+++ b/arch/arm/core/offsets/offsets_aarch32.c
@@ -25,7 +25,7 @@
 #ifndef _ARM_OFFSETS_INC_
 #define _ARM_OFFSETS_INC_
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <kernel_offsets.h>
 

--- a/arch/arm/include/aarch32/cortex_a_r/exc.h
+++ b/arch/arm/include/aarch32/cortex_a_r/exc.h
@@ -14,7 +14,7 @@
 #ifndef ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_CORTEX_A_R_EXC_H_
 #define ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_CORTEX_A_R_EXC_H_
 
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 #ifdef _ASMLANGUAGE
 
@@ -22,7 +22,7 @@
 
 #else
 
-#include <irq_offload.h>
+#include <zephyr/irq_offload.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/arm/include/aarch32/cortex_m/dwt.h
+++ b/arch/arm/include/aarch32/cortex_m/dwt.h
@@ -20,7 +20,7 @@
 
 #else
 
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/arm/include/aarch32/cortex_m/exc.h
+++ b/arch/arm/include/aarch32/cortex_m/exc.h
@@ -14,7 +14,7 @@
 #ifndef ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_CORTEX_M_EXC_H_
 #define ZEPHYR_ARCH_ARM_INCLUDE_AARCH32_CORTEX_M_EXC_H_
 
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 #ifdef _ASMLANGUAGE
 
@@ -22,9 +22,9 @@
 
 #else
 
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <arch/arm/aarch32/exc.h>
-#include <irq_offload.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/exc.h>
+#include <zephyr/irq_offload.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/arm/include/aarch32/cortex_m/stack.h
+++ b/arch/arm/include/aarch32/cortex_m/stack.h
@@ -20,7 +20,7 @@
 
 #else
 
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/arm/include/kernel_arch_data.h
+++ b/arch/arm/include/kernel_arch_data.h
@@ -20,9 +20,9 @@
 #ifndef ZEPHYR_ARCH_ARM_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_ARM_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 
 #if defined(CONFIG_CPU_CORTEX_M)
 #include <aarch32/cortex_m/stack.h>
@@ -33,10 +33,10 @@
 #endif
 
 #ifndef _ASMLANGUAGE
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/dlist.h>
-#include <sys/atomic.h>
+#include <zephyr/sys/dlist.h>
+#include <zephyr/sys/atomic.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/arm64/core/cache.c
+++ b/arch/arm64/core/cache.c
@@ -13,7 +13,7 @@
  * This module contains functions for manipulation of the d-cache.
  */
 
-#include <cache.h>
+#include <zephyr/cache.h>
 
 #define	CTR_EL0_DMINLINE_SHIFT		16
 #define	CTR_EL0_DMINLINE_MASK		BIT_MASK(4)

--- a/arch/arm64/core/cortex_r/arm_mpu.c
+++ b/arch/arm64/core/cortex_r/arm_mpu.c
@@ -5,15 +5,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_func.h>
 #include <soc.h>
-#include <arch/arm64/mm.h>
-#include <linker/linker-defs.h>
-#include <logging/log.h>
-#include <sys/check.h>
+#include <zephyr/arch/arm64/mm.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/sys/check.h>
 
 LOG_MODULE_REGISTER(mpu, CONFIG_MPU_LOG_LEVEL);
 

--- a/arch/arm64/core/fatal.c
+++ b/arch/arm64/core/fatal.c
@@ -13,9 +13,9 @@
  * exceptions
  */
 
-#include <kernel.h>
-#include <logging/log.h>
-#include <exc_handle.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/exc_handle.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/arch/arm64/core/fpu.c
+++ b/arch/arm64/core/fpu.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_arch_interface.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 /* to be found in fpu.S */
 extern void z_arm64_fpu_save(struct z_arm64_fp_context *saved_fp_context);

--- a/arch/arm64/core/irq_init.c
+++ b/arch/arm64/core/irq_init.c
@@ -9,8 +9,8 @@
  * @brief ARM64 Cortex-A interrupt initialisation
  */
 
-#include <arch/cpu.h>
-#include <drivers/interrupt_controller/gic.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/interrupt_controller/gic.h>
 
 /**
  * @brief Initialise interrupts

--- a/arch/arm64/core/irq_manage.c
+++ b/arch/arm64/core/irq_manage.c
@@ -9,14 +9,14 @@
  * @brief ARM64 Cortex-A interrupt management
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <tracing/tracing.h>
-#include <irq.h>
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <sw_isr_table.h>
-#include <drivers/interrupt_controller/gic.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/tracing/tracing.h>
+#include <zephyr/irq.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sw_isr_table.h>
+#include <zephyr/drivers/interrupt_controller/gic.h>
 
 void z_arm64_fatal_error(unsigned int reason, z_arch_esf_t *esf);
 

--- a/arch/arm64/core/irq_offload.c
+++ b/arch/arm64/core/irq_offload.c
@@ -9,8 +9,8 @@
  * @brief Software interrupts utility code - ARM64 implementation
  */
 
-#include <kernel.h>
-#include <irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq_offload.h>
 #include <exc.h>
 
 void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)

--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -7,20 +7,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <cache.h>
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/cache.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_func.h>
 #include <kernel_arch_interface.h>
 #include <kernel_internal.h>
-#include <logging/log.h>
-#include <arch/arm64/cpu.h>
-#include <arch/arm64/lib_helpers.h>
-#include <arch/arm64/mm.h>
-#include <linker/linker-defs.h>
-#include <spinlock.h>
-#include <sys/util.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/arch/arm64/cpu.h>
+#include <zephyr/arch/arm64/lib_helpers.h>
+#include <zephyr/arch/arm64/mm.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/sys/util.h>
 
 #include "mmu.h"
 

--- a/arch/arm64/core/offsets/offsets.c
+++ b/arch/arm64/core/offsets/offsets.c
@@ -26,7 +26,7 @@
 #define _ARM_OFFSETS_INC_
 
 #include <gen_offset.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <kernel_offsets.h>
 
@@ -58,7 +58,7 @@ GEN_ABSOLUTE_SYM(___esf_t_SIZEOF, sizeof(_esf_t));
 
 #ifdef CONFIG_HAS_ARM_SMCCC
 
-#include <arch/arm64/arm-smccc.h>
+#include <zephyr/arch/arm64/arm-smccc.h>
 
 GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a0, a0_a1);
 GEN_NAMED_OFFSET_SYM(arm_smccc_res_t, a2, a2_a3);

--- a/arch/arm64/core/prep_c.c
+++ b/arch/arm64/core/prep_c.c
@@ -15,7 +15,7 @@
  */
 
 #include <kernel_internal.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 
 __weak void z_arm64_mm_init(bool is_primary_core) { }
 

--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -10,19 +10,19 @@
  * @brief codes required for AArch64 multicore and Zephyr smp support
  */
 
-#include <cache.h>
-#include <device.h>
-#include <devicetree.h>
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/cache.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <ksched.h>
 #include <soc.h>
-#include <init.h>
-#include <arch/arm64/mm.h>
-#include <arch/cpu.h>
-#include <drivers/interrupt_controller/gic.h>
-#include <drivers/pm_cpu_ops.h>
-#include <sys/arch_interface.h>
+#include <zephyr/init.h>
+#include <zephyr/arch/arm64/mm.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/drivers/interrupt_controller/gic.h>
+#include <zephyr/drivers/pm_cpu_ops.h>
+#include <zephyr/sys/arch_interface.h>
 #include "boot.h"
 
 #define SGI_SCHED_IPI	0

--- a/arch/arm64/core/thread.c
+++ b/arch/arm64/core/thread.c
@@ -11,10 +11,10 @@
  * Core thread related primitives for the ARM64 Cortex-A
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <wait_q.h>
-#include <arch/cpu.h>
+#include <zephyr/wait_q.h>
+#include <zephyr/arch/cpu.h>
 
 /*
  * Note about stack usage:

--- a/arch/arm64/core/tls.c
+++ b/arch/arm64/core/tls.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/util.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/util.h>
 
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 {

--- a/arch/arm64/core/xen/enlighten.c
+++ b/arch/arm64/core/xen/enlighten.c
@@ -4,17 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm64/hypercall.h>
-#include <xen/events.h>
-#include <xen/generic.h>
-#include <xen/public/xen.h>
-#include <xen/public/memory.h>
+#include <zephyr/arch/arm64/hypercall.h>
+#include <zephyr/xen/events.h>
+#include <zephyr/xen/generic.h>
+#include <zephyr/xen/public/xen.h>
+#include <zephyr/xen/public/memory.h>
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <kernel/thread.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel/thread.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(xen_enlighten);
 

--- a/arch/arm64/include/exc.h
+++ b/arch/arm64/include/exc.h
@@ -14,7 +14,7 @@
 #ifndef ZEPHYR_ARCH_ARM64_INCLUDE_EXC_H_
 #define ZEPHYR_ARCH_ARM64_INCLUDE_EXC_H_
 
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 
 #ifdef _ASMLANGUAGE
 

--- a/arch/arm64/include/kernel_arch_data.h
+++ b/arch/arm64/include/kernel_arch_data.h
@@ -20,17 +20,17 @@
 #ifndef ZEPHYR_ARCH_ARM64_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_ARM64_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 
 #include <exc.h>
 
 #ifndef _ASMLANGUAGE
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/dlist.h>
-#include <sys/atomic.h>
+#include <zephyr/sys/dlist.h>
+#include <zephyr/sys/atomic.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/common/isr_tables.c
+++ b/arch/common/isr_tables.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <sw_isr_table.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/sw_isr_table.h>
+#include <zephyr/arch/cpu.h>
 
 /* There is an additional member at the end populated by the linker script
  * which indicates the number of interrupts specified

--- a/arch/common/sw_isr_common.c
+++ b/arch/common/sw_isr_common.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <sw_isr_table.h>
-#include <arch/cpu.h>
-#include <sys/__assert.h>
+#include <zephyr/sw_isr_table.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/__assert.h>
 /*
  * Common code for arches that use software ISR tables (CONFIG_GEN_ISR_TABLES)
  */

--- a/arch/common/timing.c
+++ b/arch/common/timing.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys_clock.h>
-#include <timing/timing.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/timing/timing.h>
 
 void arch_timing_init(void)
 {

--- a/arch/mips/core/cpu_idle.c
+++ b/arch/mips/core/cpu_idle.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <irq.h>
+#include <zephyr/irq.h>
 
-#include <tracing/tracing.h>
+#include <zephyr/tracing/tracing.h>
 
 static ALWAYS_INLINE void mips_idle(unsigned int key)
 {

--- a/arch/mips/core/fatal.c
+++ b/arch/mips/core/fatal.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/printk.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_mips_fatal_error(unsigned int reason,

--- a/arch/mips/core/irq_manage.c
+++ b/arch/mips/core/irq_manage.c
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kswap.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 

--- a/arch/mips/core/irq_offload.c
+++ b/arch/mips/core/irq_offload.c
@@ -6,11 +6,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
-#include <irq.h>
-#include <irq_offload.h>
+#include <zephyr/irq.h>
+#include <zephyr/irq_offload.h>
 
 volatile irq_offload_routine_t _offload_routine;
 static volatile const void *offload_param;

--- a/arch/mips/core/prep_c.c
+++ b/arch/mips/core/prep_c.c
@@ -10,7 +10,7 @@
  */
 
 #include <kernel_internal.h>
-#include <irq.h>
+#include <zephyr/irq.h>
 
 static void interrupt_init(void)
 {

--- a/arch/mips/core/thread.c
+++ b/arch/mips/core/thread.c
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 
 extern uint32_t mips_cp0_status_int_mask;
 

--- a/arch/mips/include/kernel_arch_data.h
+++ b/arch/mips/include/kernel_arch_data.h
@@ -17,14 +17,14 @@
 #ifndef ZEPHYR_ARCH_MIPS_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_MIPS_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/arch/cpu.h>
 
 #ifndef _ASMLANGUAGE
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/util.h>
-#include <sys/dlist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/dlist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/nios2/core/cache.c
+++ b/arch/nios2/core/cache.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/cpu.h>
-#include <sys/__assert.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/__assert.h>
 
 
 /**

--- a/arch/nios2/core/cpu_idle.c
+++ b/arch/nios2/core/cpu_idle.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 
 void arch_cpu_idle(void)
 {

--- a/arch/nios2/core/fatal.c
+++ b/arch/nios2/core/fatal.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/kernel_structs.h>
 #include <inttypes.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_nios2_fatal_error(unsigned int reason,

--- a/arch/nios2/core/irq_manage.c
+++ b/arch/nios2/core/irq_manage.c
@@ -11,15 +11,15 @@
  */
 
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <arch/cpu.h>
-#include <irq.h>
-#include <sw_isr_table.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/irq.h>
+#include <zephyr/sw_isr_table.h>
 #include <ksched.h>
 #include <kswap.h>
-#include <tracing/tracing.h>
-#include <logging/log.h>
+#include <zephyr/tracing/tracing.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)

--- a/arch/nios2/core/irq_offload.c
+++ b/arch/nios2/core/irq_offload.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/irq_offload.h>
 
 volatile irq_offload_routine_t _offload_routine;
 static volatile const void *offload_param;

--- a/arch/nios2/core/offsets/offsets.c
+++ b/arch/nios2/core/offsets/offsets.c
@@ -24,7 +24,7 @@
  */
 
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <gen_offset.h>
 #include <kernel_offsets.h>

--- a/arch/nios2/core/prep_c.c
+++ b/arch/nios2/core/prep_c.c
@@ -17,9 +17,9 @@
  */
 
 #include <zephyr/types.h>
-#include <toolchain.h>
-#include <linker/linker-defs.h>
-#include <kernel_structs.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 
 /**

--- a/arch/nios2/core/thread.c
+++ b/arch/nios2/core/thread.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
 
 /* forward declaration to asm function to adjust setup the arguments

--- a/arch/nios2/core/timing.c
+++ b/arch/nios2/core/timing.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys_clock.h>
-#include <timing/timing.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/timing/timing.h>
 #include "altera_avalon_timer_regs.h"
 
 #define NIOS2_SUBTRACT_CLOCK_CYCLES(val)                                       \

--- a/arch/nios2/include/kernel_arch_data.h
+++ b/arch/nios2/include/kernel_arch_data.h
@@ -21,16 +21,16 @@
 #ifndef ZEPHYR_ARCH_NIOS2_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_NIOS2_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 
 #ifndef _ASMLANGUAGE
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/util.h>
-#include <sys/dlist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/dlist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/posix/core/cpuhalt.c
+++ b/arch/posix/core/cpuhalt.c
@@ -22,8 +22,8 @@
 
 #include "posix_core.h"
 #include "posix_board_if.h"
-#include <arch/posix/posix_soc_if.h>
-#include <tracing/tracing.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
+#include <zephyr/tracing/tracing.h>
 
 #if !defined(CONFIG_ARCH_HAS_CUSTOM_BUSY_WAIT)
 #error "The POSIX architecture needs a custom busy_wait implementation. \

--- a/arch/posix/core/fatal.c
+++ b/arch/posix/core/fatal.c
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <kernel_structs.h>
-#include <sys/printk.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/sys/printk.h>
 #include <inttypes.h>
-#include <logging/log_ctrl.h>
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 
 FUNC_NORETURN void arch_system_halt(unsigned int reason)
 {

--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 #include "board_irq.h"
 
 #ifdef CONFIG_IRQ_OFFLOAD

--- a/arch/posix/core/offsets/offsets.c
+++ b/arch/posix/core/offsets/offsets.c
@@ -23,7 +23,7 @@
  * completeness.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <gen_offset.h>
 #include <kernel_offsets.h>

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -44,7 +44,7 @@
 
 #include "posix_core.h"
 #include "posix_arch_internal.h"
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 #include "kernel_internal.h"
 #include "kernel_structs.h"
 #include "ksched.h"

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -14,11 +14,11 @@
  */
 
 #include "kernel.h"
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include "posix_core.h"
 #include "irq.h"
 #include "kswap.h"
-#include <pm/pm.h>
+#include <zephyr/pm/pm.h>
 
 int arch_swap(unsigned int key)
 {

--- a/arch/posix/core/thread.c
+++ b/arch/posix/core/thread.c
@@ -13,13 +13,13 @@
  * architecture
  */
 
-#include <toolchain.h>
-#include <kernel_structs.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/kernel_structs.h>
 #include <ksched.h>
-#include <wait_q.h>
+#include <zephyr/wait_q.h>
 
 #include "posix_core.h"
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 
 /* Note that in this arch we cheat quite a bit: we use as stack a normal
  * pthreads stack and therefore we ignore the stack size

--- a/arch/posix/include/asm_inline.h
+++ b/arch/posix/include/asm_inline.h
@@ -16,7 +16,7 @@
 
 #if defined(__GNUC__)
 #include <asm_inline_gcc.h> /* The empty one.. */
-#include <arch/posix/asm_inline_gcc.h>
+#include <zephyr/arch/posix/asm_inline_gcc.h>
 #else
 #include <asm_inline_other.h>
 #endif /* __GNUC__ */

--- a/arch/riscv/core/coredump.c
+++ b/arch/riscv/core/coredump.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <debug/coredump.h>
+#include <zephyr/debug/coredump.h>
 
 #define ARCH_HDR_VER 1
 

--- a/arch/riscv/core/cpu_idle.c
+++ b/arch/riscv/core/cpu_idle.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <irq.h>
+#include <zephyr/irq.h>
 
 /*
  * In RISC-V there is no conventional way to handle CPU power save.

--- a/arch/riscv/core/fatal.c
+++ b/arch/riscv/core/fatal.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <inttypes.h>
-#include <exc_handle.h>
-#include <logging/log.h>
+#include <zephyr/exc_handle.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef CONFIG_USERSPACE

--- a/arch/riscv/core/irq_manage.c
+++ b/arch/riscv/core/irq_manage.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)

--- a/arch/riscv/core/irq_offload.c
+++ b/arch/riscv/core/irq_offload.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <irq_offload.h>
-#include <arch/riscv/syscall.h>
+#include <zephyr/irq_offload.h>
+#include <zephyr/arch/riscv/syscall.h>
 
 void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 {

--- a/arch/riscv/core/offsets/offsets.c
+++ b/arch/riscv/core/offsets/offsets.c
@@ -13,7 +13,7 @@
  * structures.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <gen_offset.h>
 #include <kernel_offsets.h>

--- a/arch/riscv/core/pmp.c
+++ b/arch/riscv/core/pmp.c
@@ -25,15 +25,15 @@
  * which are never modified.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <linker/linker-defs.h>
+#include <zephyr/linker/linker-defs.h>
 #include <pmp.h>
-#include <sys/arch_interface.h>
-#include <arch/riscv/csr.h>
+#include <zephyr/sys/arch_interface.h>
+#include <zephyr/arch/riscv/csr.h>
 
 #define LOG_LEVEL CONFIG_MPU_LOG_LEVEL
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mpu);
 
 #define PMP_DEBUG_DUMP 0

--- a/arch/riscv/core/prep_c.c
+++ b/arch/riscv/core/prep_c.c
@@ -16,8 +16,8 @@
  */
 
 #include <stddef.h>
-#include <toolchain.h>
-#include <kernel_structs.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 
 /**

--- a/arch/riscv/core/reboot.c
+++ b/arch/riscv/core/reboot.c
@@ -9,9 +9,9 @@
  * @brief RISC-V reboot interface
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/util.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
 
 /**
  * @brief Reset the system

--- a/arch/riscv/core/smp.c
+++ b/arch/riscv/core/smp.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
 
 volatile struct {

--- a/arch/riscv/core/thread.c
+++ b/arch/riscv/core/thread.c
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <arch/riscv/csr.h>
+#include <zephyr/arch/riscv/csr.h>
 #include <stdio.h>
 #include <pmp.h>
 

--- a/arch/riscv/core/tls.c
+++ b/arch/riscv/core/tls.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/util.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/util.h>
 
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 {

--- a/arch/riscv/include/kernel_arch_data.h
+++ b/arch/riscv/include/kernel_arch_data.h
@@ -15,15 +15,15 @@
 #ifndef ZEPHYR_ARCH_RISCV_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_RISCV_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 
 #ifndef _ASMLANGUAGE
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/util.h>
-#include <sys/dlist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/dlist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/sparc/core/fatal.c
+++ b/arch/sparc/core/fatal.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /*

--- a/arch/sparc/core/irq_manage.c
+++ b/arch/sparc/core/irq_manage.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <kswap.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 FUNC_NORETURN void z_irq_spurious(const void *unused)

--- a/arch/sparc/core/irq_offload.c
+++ b/arch/sparc/core/irq_offload.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
-#include <irq.h>
-#include <irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/irq.h>
+#include <zephyr/irq_offload.h>
 
 volatile irq_offload_routine_t _offload_routine;
 static volatile const void *offload_param;

--- a/arch/sparc/core/offsets/offsets.c
+++ b/arch/sparc/core/offsets/offsets.c
@@ -12,7 +12,7 @@
  * value represents the member offsets for various SPARC kernel structures.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <gen_offset.h>
 #include <kernel_offsets.h>

--- a/arch/sparc/core/thread.c
+++ b/arch/sparc/core/thread.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
 
 void z_thread_entry_wrapper(k_thread_entry_t thread,

--- a/arch/sparc/core/tls.c
+++ b/arch/sparc/core/tls.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/util.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/util.h>
 
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 {

--- a/arch/sparc/include/kernel_arch_data.h
+++ b/arch/sparc/include/kernel_arch_data.h
@@ -15,15 +15,15 @@
 #ifndef ZEPHYR_ARCH_SPARC_INCLUDE_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_SPARC_INCLUDE_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <linker/sections.h>
-#include <arch/cpu.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
+#include <zephyr/arch/cpu.h>
 
 #ifndef _ASMLANGUAGE
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/util.h>
-#include <sys/dlist.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sys/dlist.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -2,9 +2,9 @@
  * Copyright (c) 2020 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <kernel.h>
-#include <arch/x86/acpi.h>
-#include <arch/x86/efi.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/x86/acpi.h>
+#include <zephyr/arch/x86/efi.h>
 
 static struct acpi_rsdp *rsdp;
 static bool is_rsdp_searched;

--- a/arch/x86/core/cache.c
+++ b/arch/x86/core/cache.c
@@ -11,11 +11,11 @@
  * This module contains functions for manipulation caches.
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <sys/util.h>
-#include <toolchain.h>
-#include <cache.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/cache.h>
 #include <stdbool.h>
 
 /**

--- a/arch/x86/core/cpuhalt.c
+++ b/arch/x86/core/cpuhalt.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <tracing/tracing.h>
-#include <arch/cpu.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/tracing/tracing.h>
+#include <zephyr/arch/cpu.h>
 
 __pinned_func
 void arch_cpu_idle(void)

--- a/arch/x86/core/cpuid.c
+++ b/arch/x86/core/cpuid.c
@@ -6,9 +6,9 @@
 
 #include <cpuid.h> /* Header provided by the toolchain. */
 
-#include <kernel_structs.h>
-#include <arch/x86/cpuid.h>
-#include <kernel.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/arch/x86/cpuid.h>
+#include <zephyr/kernel.h>
 
 uint32_t z_x86_cpuid_extended_features(void)
 {

--- a/arch/x86/core/early_serial.c
+++ b/arch/x86/core/early_serial.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/device_mmio.h>
-#include <sys/util.h>
-#include <drivers/pcie/pcie.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/pcie/pcie.h>
 #include <soc.h>
 
 

--- a/arch/x86/core/efi.c
+++ b/arch/x86/core/efi.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <spinlock.h>
-#include <arch/x86/efi.h>
-#include <sys/mem_manage.h>
+#include <zephyr/spinlock.h>
+#include <zephyr/arch/x86/efi.h>
+#include <zephyr/sys/mem_manage.h>
 #include "../zefi/efi.h" /* ZEFI not on include path */
 
 #define EFI_CON_BUFSZ 128

--- a/arch/x86/core/fatal.c
+++ b/arch/x86/core/fatal.c
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
-#include <exc_handle.h>
-#include <logging/log.h>
+#include <zephyr/exc_handle.h>
+#include <zephyr/logging/log.h>
 #include <x86_mmu.h>
 #include <mmu.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);

--- a/arch/x86/core/ia32/coredump.c
+++ b/arch/x86/core/ia32/coredump.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <debug/coredump.h>
+#include <zephyr/debug/coredump.h>
 
 #define ARCH_HDR_VER			1
 

--- a/arch/x86/core/ia32/fatal.c
+++ b/arch/x86/core/ia32/fatal.c
@@ -9,17 +9,17 @@
  * @brief Kernel fatal error handler
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <drivers/interrupt_controller/sysapic.h>
-#include <arch/x86/ia32/segmentation.h>
-#include <arch/syscall.h>
+#include <zephyr/drivers/interrupt_controller/sysapic.h>
+#include <zephyr/arch/x86/ia32/segmentation.h>
+#include <zephyr/arch/syscall.h>
 #include <ia32/exception.h>
 #include <inttypes.h>
-#include <exc_handle.h>
-#include <logging/log.h>
+#include <zephyr/exc_handle.h>
+#include <zephyr/logging/log.h>
 #include <x86_mmu.h>
-#include <sys/mem_manage.h>
+#include <zephyr/sys/mem_manage.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/arch/x86/core/ia32/float.c
+++ b/arch/x86/core/ia32/float.c
@@ -43,7 +43,7 @@
  * to enable FP register sharing on its behalf.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
 
 /* SSE control/status register default value (used by assembler code) */

--- a/arch/x86/core/ia32/gdbstub.c
+++ b/arch/x86/core/ia32/gdbstub.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <ia32/exception.h>
 #include <inttypes.h>
-#include <debug/gdbstub.h>
+#include <zephyr/debug/gdbstub.h>
 
 
 static struct gdb_ctx ctx;

--- a/arch/x86/core/ia32/irq_manage.c
+++ b/arch/x86/core/ia32/irq_manage.c
@@ -14,15 +14,15 @@
  * global variable.)
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <kernel_structs.h>
-#include <sys/__assert.h>
-#include <sys/printk.h>
-#include <irq.h>
-#include <tracing/tracing.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/kernel_structs.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/irq.h>
+#include <zephyr/tracing/tracing.h>
 #include <kswap.h>
-#include <arch/x86/ia32/segmentation.h>
+#include <zephyr/arch/x86/ia32/segmentation.h>
 
 extern void z_SpuriousIntHandler(void *handler);
 extern void z_SpuriousIntNoErrCodeHandler(void *handler);

--- a/arch/x86/core/ia32/irq_offload.c
+++ b/arch/x86/core/ia32/irq_offload.c
@@ -8,8 +8,8 @@
  * @file IRQ offload - x86 implementation
  */
 
-#include <kernel.h>
-#include <irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq_offload.h>
 
 extern void (*_irq_sw_handler)(void);
 NANO_CPU_INT_REGISTER(_irq_sw_handler, NANO_SOFT_IRQ,

--- a/arch/x86/core/ia32/soft_float_stubs.c
+++ b/arch/x86/core/ia32/soft_float_stubs.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <toolchain.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
 
 /**
  * @file

--- a/arch/x86/core/ia32/thread.c
+++ b/arch/x86/core/ia32/thread.c
@@ -12,9 +12,9 @@
  * processor architecture.
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <arch/x86/mmustructs.h>
+#include <zephyr/arch/x86/mmustructs.h>
 #include <kswap.h>
 #include <x86_mmu.h>
 

--- a/arch/x86/core/ia32/tls.c
+++ b/arch/x86/core/ia32/tls.c
@@ -5,8 +5,8 @@
  */
 
 #include <kernel_internal.h>
-#include <arch/x86/ia32/arch.h>
-#include <arch/x86/ia32/segmentation.h>
+#include <zephyr/arch/x86/ia32/arch.h>
+#include <zephyr/arch/x86/ia32/segmentation.h>
 
 #define ENTRY_NUM	(GS_TLS_SEG >> 3)
 

--- a/arch/x86/core/intel64/coredump.c
+++ b/arch/x86/core/intel64/coredump.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <debug/coredump.h>
+#include <zephyr/debug/coredump.h>
 
 #define ARCH_HDR_VER			1
 

--- a/arch/x86/core/intel64/cpu.c
+++ b/arch/x86/core/intel64/cpu.c
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <kernel_arch_func.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
-#include <arch/x86/multiboot.h>
+#include <zephyr/arch/x86/multiboot.h>
 #include <x86_mmu.h>
-#include <drivers/interrupt_controller/loapic.h>
-#include <arch/x86/acpi.h>
+#include <zephyr/drivers/interrupt_controller/loapic.h>
+#include <zephyr/arch/x86/acpi.h>
 
 /*
  * Map of CPU logical IDs to CPU local APIC IDs. By default,

--- a/arch/x86/core/intel64/fatal.c
+++ b/arch/x86/core/intel64/fatal.c
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 /* NMI handlers should override weak implementation

--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <arch/cpu.h>
+#include <zephyr/arch/cpu.h>
 #include <kernel_arch_data.h>
 #include <kernel_arch_func.h>
-#include <drivers/interrupt_controller/sysapic.h>
-#include <drivers/interrupt_controller/loapic.h>
-#include <irq.h>
-#include <logging/log.h>
+#include <zephyr/drivers/interrupt_controller/sysapic.h>
+#include <zephyr/drivers/interrupt_controller/loapic.h>
+#include <zephyr/irq.h>
+#include <zephyr/logging/log.h>
 #include <x86_mmu.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
@@ -31,8 +31,8 @@ const void *x86_irq_args[NR_IRQ_VECTORS];
 
 #if defined(CONFIG_INTEL_VTD_ICTL)
 
-#include <device.h>
-#include <drivers/interrupt_controller/intel_vtd.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/interrupt_controller/intel_vtd.h>
 
 static const struct device *vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 
@@ -138,7 +138,7 @@ int arch_irq_connect_dynamic(unsigned int irq, unsigned int priority,
 }
 
 #ifdef CONFIG_IRQ_OFFLOAD
-#include <irq_offload.h>
+#include <zephyr/irq_offload.h>
 
 void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 {

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <offsets_short.h>
 #include <x86_mmu.h>

--- a/arch/x86/core/memmap.c
+++ b/arch/x86/core/memmap.c
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <string.h>
-#include <arch/x86/memmap.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/x86/memmap.h>
+#include <zephyr/linker/linker-defs.h>
 #include <kernel_arch_data.h>
 
 struct x86_memmap_exclusion x86_memmap_exclusions[] = {

--- a/arch/x86/core/multiboot.c
+++ b/arch/x86/core/multiboot.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <string.h>
-#include <arch/x86/multiboot.h>
-#include <arch/x86/memmap.h>
+#include <zephyr/arch/x86/multiboot.h>
+#include <zephyr/arch/x86/memmap.h>
 
 struct multiboot_info multiboot_info;
 
@@ -133,7 +133,7 @@ void z_multiboot_init(struct multiboot_info *info_pa)
 
 #ifdef CONFIG_MULTIBOOT_FRAMEBUF
 
-#include <display/framebuf.h>
+#include <zephyr/display/framebuf.h>
 
 static struct framebuf_dev_data multiboot_framebuf_data = {
 	.width = CONFIG_MULTIBOOT_FRAMEBUF_X,

--- a/arch/x86/core/offsets/ia32_offsets.c
+++ b/arch/x86/core/offsets/ia32_offsets.c
@@ -27,7 +27,7 @@
 #ifndef _X86_OFFSETS_INC_
 #define _X86_OFFSETS_INC_
 
-#include <arch/x86/mmustructs.h>
+#include <zephyr/arch/x86/mmustructs.h>
 
 #if defined(CONFIG_LAZY_FPU_SHARING)
 GEN_OFFSET_SYM(_thread_arch_t, excNestCount);

--- a/arch/x86/core/offsets/offsets.c
+++ b/arch/x86/core/offsets/offsets.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_arch_data.h>
 #include <gen_offset.h>
 #include <kernel_offsets.h>

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -4,20 +4,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/device_mmio.h>
-#include <drivers/pcie/pcie.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/device_mmio.h>
+#include <zephyr/drivers/pcie/pcie.h>
 
 #ifdef CONFIG_ACPI
-#include <arch/x86/acpi.h>
+#include <zephyr/arch/x86/acpi.h>
 #endif
 
 #ifdef CONFIG_PCIE_MSI
 #include <kernel_arch_func.h>
-#include <device.h>
-#include <drivers/pcie/msi.h>
-#include <drivers/interrupt_controller/sysapic.h>
-#include <arch/x86/cpuid.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/pcie/msi.h>
+#include <zephyr/drivers/interrupt_controller/sysapic.h>
+#include <zephyr/arch/x86/cpuid.h>
 #endif
 
 /* PCI Express Extended Configuration Mechanism (MMIO) */
@@ -161,8 +161,8 @@ void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
 
 #ifdef CONFIG_INTEL_VTD_ICTL
 
-#include <drivers/interrupt_controller/intel_vtd.h>
-#include <arch/x86/acpi.h>
+#include <zephyr/drivers/interrupt_controller/intel_vtd.h>
+#include <zephyr/arch/x86/acpi.h>
 
 static const struct device *vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 

--- a/arch/x86/core/prep_c.c
+++ b/arch/x86/core/prep_c.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <arch/x86/acpi.h>
-#include <arch/x86/multiboot.h>
-#include <arch/x86/efi.h>
+#include <zephyr/arch/x86/acpi.h>
+#include <zephyr/arch/x86/multiboot.h>
+#include <zephyr/arch/x86/efi.h>
 #include <x86_mmu.h>
 
 extern FUNC_NORETURN void z_cstart(void);

--- a/arch/x86/core/reboot_rst_cnt.c
+++ b/arch/x86/core/reboot_rst_cnt.c
@@ -10,8 +10,8 @@
  * @details Implements the required 'arch' sub-APIs.
  */
 
-#include <kernel.h>
-#include <sys/reboot.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/reboot.h>
 
 /* reboot through Reset Control Register (I/O port 0xcf9) */
 

--- a/arch/x86/core/spec_ctrl.c
+++ b/arch/x86/core/spec_ctrl.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <kernel_structs.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_arch_data.h>
 #include <kernel_arch_func.h>
-#include <arch/x86/msr.h>
-#include <arch/x86/cpuid.h>
-#include <kernel.h>
+#include <zephyr/arch/x86/msr.h>
+#include <zephyr/arch/x86/cpuid.h>
+#include <zephyr/kernel.h>
 
 /*
  * See:

--- a/arch/x86/core/tls.c
+++ b/arch/x86/core/tls.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 size_t arch_tls_stack_setup(struct k_thread *new_thread, char *stack_ptr)
 {

--- a/arch/x86/core/userspace.c
+++ b/arch/x86/core/userspace.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <sys/speculation.h>
-#include <syscall_handler.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys/speculation.h>
+#include <zephyr/syscall_handler.h>
 #include <kernel_arch_func.h>
 #include <ksched.h>
 #include <x86_mmu.h>

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -5,23 +5,23 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <arch/x86/mmustructs.h>
-#include <sys/mem_manage.h>
-#include <sys/__assert.h>
-#include <sys/check.h>
-#include <logging/log.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/x86/mmustructs.h>
+#include <zephyr/sys/mem_manage.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/check.h>
+#include <zephyr/logging/log.h>
 #include <errno.h>
 #include <ctype.h>
-#include <spinlock.h>
+#include <zephyr/spinlock.h>
 #include <kernel_arch_func.h>
 #include <x86_mmu.h>
-#include <init.h>
+#include <zephyr/init.h>
 #include <kernel_internal.h>
 #include <mmu.h>
-#include <drivers/interrupt_controller/loapic.h>
+#include <zephyr/drivers/interrupt_controller/loapic.h>
 #include <mmu.h>
-#include <arch/x86/memmap.h>
+#include <zephyr/arch/x86/memmap.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/arch/x86/include/ia32/exception.h
+++ b/arch/x86/include/ia32/exception.h
@@ -9,7 +9,7 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <toolchain/common.h>
+#include <zephyr/toolchain/common.h>
 
 #define _EXCEPTION_INTLIST(vector, dpl) \
 	".pushsection .gnu.linkonce.intList.exc_" #vector "\n\t" \

--- a/arch/x86/include/ia32/kernel_arch_data.h
+++ b/arch/x86/include/ia32/kernel_arch_data.h
@@ -26,15 +26,15 @@
 #ifndef ZEPHYR_ARCH_X86_INCLUDE_IA32_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_X86_INCLUDE_IA32_KERNEL_ARCH_DATA_H_
 
-#include <toolchain.h>
-#include <linker/sections.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 #include <ia32/exception.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifndef _ASMLANGUAGE
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <zephyr/types.h>
-#include <sys/dlist.h>
+#include <zephyr/sys/dlist.h>
 #endif
 
 /* Some configurations require that the stack/registers be adjusted before
@@ -52,7 +52,7 @@
 
 #ifndef _ASMLANGUAGE
 
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/x86/include/intel64/kernel_arch_data.h
+++ b/arch/x86/include/intel64/kernel_arch_data.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_DATA_H_
 #define ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_DATA_H_
 
-#include <arch/x86/mmustructs.h>
+#include <zephyr/arch/x86/mmustructs.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/arch/x86/include/intel64/kernel_arch_func.h
+++ b/arch/x86/include/intel64/kernel_arch_func.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_FUNC_H_
 #define ZEPHYR_ARCH_X86_INCLUDE_INTEL64_KERNEL_ARCH_FUNC_H_
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 
 #ifndef _ASMLANGUAGE
 

--- a/arch/x86/include/kernel_arch_func.h
+++ b/arch/x86/include/kernel_arch_func.h
@@ -7,7 +7,7 @@
 #define ZEPHYR_ARCH_X86_INCLUDE_KERNEL_ARCH_FUNC_H_
 
 #include <kernel_arch_data.h>
-#include <arch/x86/mmustructs.h>
+#include <zephyr/arch/x86/mmustructs.h>
 
 #ifdef CONFIG_X86_64
 #include <intel64/kernel_arch_func.h>

--- a/arch/x86/include/x86_mmu.h
+++ b/arch/x86/include/x86_mmu.h
@@ -12,9 +12,9 @@
 #ifndef ZEPHYR_ARCH_X86_INCLUDE_X86_MMU_H
 #define ZEPHYR_ARCH_X86_INCLUDE_X86_MMU_H
 
-#include <kernel.h>
-#include <arch/x86/mmustructs.h>
-#include <sys/mem_manage.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/x86/mmustructs.h>
+#include <zephyr/sys/mem_manage.h>
 
 #if defined(CONFIG_X86_64) || defined(CONFIG_X86_PAE)
 #define XD_SUPPORTED

--- a/arch/x86/timing.c
+++ b/arch/x86/timing.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/x86/arch.h>
-#include <kernel.h>
-#include <sys_clock.h>
-#include <timing/timing.h>
-#include <app_memory/app_memdomain.h>
+#include <zephyr/arch/x86/arch.h>
+#include <zephyr/kernel.h>
+#include <zephyr/sys_clock.h>
+#include <zephyr/timing/timing.h>
+#include <zephyr/app_memory/app_memdomain.h>
 
 K_APP_BMEM(z_libc_partition) static uint64_t tsc_freq;
 

--- a/arch/x86/zefi/efi.h
+++ b/arch/x86/zefi/efi.h
@@ -10,7 +10,7 @@
 #ifndef _ASMLANGUAGE
 
 #include <stdbool.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 #define __abi __attribute__((ms_abi))
 

--- a/arch/x86/zefi/zefi.c
+++ b/arch/x86/zefi/zefi.c
@@ -9,7 +9,7 @@
 #include "efi.h"
 #include "printf.h"
 #include <zefi-segments.h>
-#include <arch/x86/efi.h>
+#include <zephyr/arch/x86/efi.h>
 
 #define PUTCHAR_BUFSZ 128
 

--- a/arch/xtensa/core/coredump.c
+++ b/arch/xtensa/core/coredump.c
@@ -5,7 +5,7 @@
  */
 
 #include <string.h>
-#include <debug/coredump.h>
+#include <zephyr/debug/coredump.h>
 #include <xtensa-asm2.h>
 
 #define ARCH_HDR_VER			1

--- a/arch/xtensa/core/cpu_idle.c
+++ b/arch/xtensa/core/cpu_idle.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <tracing/tracing.h>
+#include <zephyr/tracing/tracing.h>
 
 void arch_cpu_idle(void)
 {

--- a/arch/xtensa/core/fatal.c
+++ b/arch/xtensa/core/fatal.c
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <arch/cpu.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/kernel_structs.h>
 #include <inttypes.h>
 #include <xtensa/config/specreg.h>
 #include <xtensa-asm2-context.h>
@@ -14,7 +14,7 @@
 #include <xtensa_backtrace.h>
 #endif
 #endif
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 
 #ifdef XT_SIMULATOR

--- a/arch/xtensa/core/gdbstub.c
+++ b/arch/xtensa/core/gdbstub.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <kernel_internal.h>
-#include <toolchain.h>
-#include <debug/gdbstub.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/debug/gdbstub.h>
 
 #include <xtensa-asm2-context.h>
 #include <xtensa/corebits.h>

--- a/arch/xtensa/core/irq_manage.c
+++ b/arch/xtensa/core/irq_manage.c
@@ -5,8 +5,8 @@
 
 #include <zephyr/types.h>
 #include <stdio.h>
-#include <arch/xtensa/irq.h>
-#include <sys/__assert.h>
+#include <zephyr/arch/xtensa/irq.h>
+#include <zephyr/sys/__assert.h>
 
 /**
  * @internal

--- a/arch/xtensa/core/irq_offload.c
+++ b/arch/xtensa/core/irq_offload.c
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <irq_offload.h>
+#include <zephyr/kernel.h>
+#include <zephyr/irq_offload.h>
 #include <zsr.h>
 
 #define CURR_CPU (IS_ENABLED(CONFIG_SMP) ? arch_curr_cpu()->id : 0)

--- a/arch/xtensa/core/tls.c
+++ b/arch/xtensa/core/tls.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kernel_tls.h>
-#include <app_memory/app_memdomain.h>
-#include <sys/util.h>
+#include <zephyr/app_memory/app_memdomain.h>
+#include <zephyr/sys/util.h>
 
 #if XCHAL_HAVE_THREADPTR == 0
 #error SoC does not support THREADPTR for thread local storage.

--- a/arch/xtensa/core/xcc_stubs.c
+++ b/arch/xtensa/core/xcc_stubs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 
 __weak int atexit(void (*function)(void))
 {

--- a/arch/xtensa/core/xtensa-asm2.c
+++ b/arch/xtensa/core/xtensa-asm2.c
@@ -5,14 +5,14 @@
  */
 #include <string.h>
 #include <xtensa-asm2.h>
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ksched.h>
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 #include <kswap.h>
 #include <_soc_inthandlers.h>
-#include <toolchain.h>
-#include <logging/log.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_DECLARE(os, CONFIG_KERNEL_LOG_LEVEL);
 

--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -13,7 +13,7 @@
 #ifndef _ASMLANGUAGE
 #include <kernel_internal.h>
 #include <string.h>
-#include <arch/xtensa/cache.h>
+#include <zephyr/arch/xtensa/cache.h>
 #include <zsr.h>
 
 #ifdef __cplusplus

--- a/arch/xtensa/include/xtensa-asm2.h
+++ b/arch/xtensa/include/xtensa-asm2.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_ASM2_H_
 #define ZEPHYR_ARCH_XTENSA_INCLUDE_XTENSA_ASM2_H_
 
-#include <kernel_structs.h>
+#include <zephyr/kernel_structs.h>
 #include "xtensa-asm2-context.h"
 
 /**


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all arch code to the new
prefix <zephyr/...>. Note that the conversion has been scripted, refer
to zephyrproject-rtos#45388 for more details.