### PR TITLE
boards: migrate includes to <zephyr/...>

### DIFF
--- a/boards/arc/em_starterkit/arc_mpu_regions.c
+++ b/boards/arc/em_starterkit/arc_mpu_regions.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
-#include <arch/arc/v2/mpu/arc_mpu.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/mpu/arc_mpu.h>
+#include <zephyr/linker/linker-defs.h>
 
 /*
  * for secure firmware, MPU entries are only set up for secure world.

--- a/boards/arc/em_starterkit/pmodmux.c
+++ b/boards/arc/em_starterkit/pmodmux.c
@@ -5,7 +5,7 @@
  */
 
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #define PMODMUX_BASE_ADDR	0xF0000000
 

--- a/boards/arc/emsdp/arc_mpu_regions.c
+++ b/boards/arc/emsdp/arc_mpu_regions.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
-#include <arch/arc/v2/mpu/arc_mpu.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/mpu/arc_mpu.h>
+#include <zephyr/linker/linker-defs.h>
 
 static struct arc_mpu_region mpu_regions[] = {
 	/* Region ICCM */

--- a/boards/arc/hsdk/pinmux.c
+++ b/boards/arc/hsdk/pinmux.c
@@ -5,8 +5,8 @@
  */
 
 #include <soc.h>
-#include <init.h>
-#include <drivers/pinmux.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/pinmux.h>
 
 static int board_pinmux_init(const struct device *dev)
 {

--- a/boards/arc/iotdk/arc_mpu_regions.c
+++ b/boards/arc/iotdk/arc_mpu_regions.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
-#include <arch/arc/v2/mpu/arc_mpu.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/mpu/arc_mpu.h>
+#include <zephyr/linker/linker-defs.h>
 
 static struct arc_mpu_region mpu_regions[] = {
 	/* Region ICCM */

--- a/boards/arc/nsim/arc_mpu_regions.c
+++ b/boards/arc/nsim/arc_mpu_regions.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
-#include <arch/arc/v2/mpu/arc_mpu.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/mpu/arc_mpu.h>
+#include <zephyr/linker/linker-defs.h>
 
 /*
  * for secure firmware, MPU entries are only set up for secure world.

--- a/boards/arc/qemu_arc/arc_mpu_regions.c
+++ b/boards/arc/qemu_arc/arc_mpu_regions.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <soc.h>
-#include <arch/arc/v2/mpu/arc_mpu.h>
-#include <linker/linker-defs.h>
+#include <zephyr/arch/arc/v2/mpu/arc_mpu.h>
+#include <zephyr/linker/linker-defs.h>
 
 /*
  * for secure firmware, MPU entries are only set up for secure world.

--- a/boards/arm/96b_meerkat96/pinmux.c
+++ b/boards/arm/96b_meerkat96/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "device_imx.h"
 
 static int meerakt96_pinmux_init(const struct device *dev)

--- a/boards/arm/96b_wistrio/rf.c
+++ b/boards/arm/96b_wistrio/rf.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
-#include <init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/init.h>
 
 static int rf_init(const struct device *dev)
 {

--- a/boards/arm/actinius_icarus/board.c
+++ b/boards/arm/actinius_icarus/board.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(board_control, CONFIG_BOARD_ICARUS_LOG_LEVEL);
 
 #define SIM_SELECT_PIN 8

--- a/boards/arm/actinius_icarus_bee/board.c
+++ b/boards/arm/actinius_icarus_bee/board.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(board_control, CONFIG_BOARD_ICARUS_BEE_LOG_LEVEL);
 
 #define SIM_SELECT_PIN 12

--- a/boards/arm/actinius_icarus_som/board.c
+++ b/boards/arm/actinius_icarus_som/board.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(board_control, CONFIG_BOARD_ICARUS_SOM_LOG_LEVEL);
 
 #define SIM_SELECT_PIN 12

--- a/boards/arm/arduino_nano_33_ble/board.c
+++ b/boards/arm/arduino_nano_33_ble/board.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
 static int board_init(const struct device *dev)
 {

--- a/boards/arm/arty/board.c
+++ b/boards/arm/arty/board.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/gpio.h>
-#include <init.h>
-#include <logging/log.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(board, CONFIG_LOG_DEFAULT_LEVEL);
 
 #include "board.h"

--- a/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
+++ b/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 
 / {

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpunet_reset.c
@@ -5,9 +5,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <init.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
 
 #include <soc.h>
 

--- a/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl-pinctrl.dtsi
+++ b/boards/arm/cc1352r1_launchxl/cc1352r1_launchxl-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
 
 &pinctrl {
 	/* UART0 */

--- a/boards/arm/cc1352r_sensortag/cc1352r_sensortag-pinctrl.dtsi
+++ b/boards/arm/cc1352r_sensortag/cc1352r_sensortag-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
 
 &pinctrl {
 	/* UART0 */

--- a/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl-pinctrl.dtsi
+++ b/boards/arm/cc26x2r1_launchxl/cc26x2r1_launchxl-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/cc13xx_cc26xx-pinctrl.h>
 
 &pinctrl {
 	/* UART0 */

--- a/boards/arm/cc3220sf_launchxl/pinmux.c
+++ b/boards/arm/cc3220sf_launchxl/pinmux.c
@@ -55,9 +55,9 @@
  * at runtime.
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 
-#include <drivers/pinmux.h>
+#include <zephyr/drivers/pinmux.h>
 
 #include <inc/hw_types.h>
 #include <inc/hw_memmap.h>

--- a/boards/arm/cc3235sf_launchxl/pinmux.c
+++ b/boards/arm/cc3235sf_launchxl/pinmux.c
@@ -30,9 +30,9 @@
  * at runtime.
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 
-#include <drivers/pinmux.h>
+#include <zephyr/drivers/pinmux.h>
 
 #include <inc/hw_types.h>
 #include <inc/hw_memmap.h>

--- a/boards/arm/colibri_imx7d_m4/pinmux.c
+++ b/boards/arm/colibri_imx7d_m4/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "device_imx.h"
 
 static int colibri_imx7d_m4_pinmux_init(const struct device *dev)

--- a/boards/arm/efm32gg_slwstk6121a/board.c
+++ b/boards/arm/efm32gg_slwstk6121a/board.c
@@ -6,9 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 #include "em_cmu.h"
 #include "board.h"
 

--- a/boards/arm/efm32gg_stk3701a/board.c
+++ b/boards/arm/efm32gg_stk3701a/board.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "board.h"
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 #include "em_cmu.h"
 
 static int efm32gg_stk3701a_init(const struct device *dev)

--- a/boards/arm/efm32hg_slstk3400a/board.c
+++ b/boards/arm/efm32hg_slstk3400a/board.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "board.h"
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 static int efm32hg_slstk3400a_init(const struct device *dev)
 {

--- a/boards/arm/efm32pg_stk3401a/board.c
+++ b/boards/arm/efm32pg_stk3401a/board.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "board.h"
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 static int efm32pg_stk3401a_init(const struct device *dev)
 {

--- a/boards/arm/efm32pg_stk3402a/board.c
+++ b/boards/arm/efm32pg_stk3402a/board.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "board.h"
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 static int efm32pg_stk3402a_init(const struct device *dev)
 {

--- a/boards/arm/efm32wg_stk3800/board.c
+++ b/boards/arm/efm32wg_stk3800/board.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "board.h"
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 static int efm32wg_stk3800_init(const struct device *dev)
 {

--- a/boards/arm/efr32_radio/board.c
+++ b/boards/arm/efr32_radio/board.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 /* This pin is used to enable the serial port using the board controller */
 #ifdef CONFIG_BOARD_EFR32_RADIO_BRD4180A

--- a/boards/arm/efr32mg_sltb004a/board.c
+++ b/boards/arm/efr32mg_sltb004a/board.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 struct supply_cfg {
 	const struct device *gpio;

--- a/boards/arm/faze/faze.dts
+++ b/boards/arm/faze/faze.dts
@@ -7,8 +7,8 @@
 /dts-v1/;
 
 #include <nxp/nxp_lpc11u67.dtsi>
-#include <dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 / {
 	model = "Seagate FireCuda Gaming SSD (FaZe)";

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_k2x.dtsi>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "frdm_k22f-pinctrl.dtsi"
 
 / {

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 #include <nxp/nxp_k82fn256vxx15.dtsi>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "frdm_k82f-pinctrl.dtsi"
 
 / {

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -3,7 +3,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_k6x.dtsi>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "hexiwear_k64-pinctrl.dtsi"
 
 / {

--- a/boards/arm/legend/legend.dts
+++ b/boards/arm/legend/legend.dts
@@ -7,8 +7,8 @@
 /dts-v1/;
 #include <st/f0/stm32f070Xb.dtsi>
 #include <st/f0/stm32f070cbtx-pinctrl.dtsi>
-#include <dt-bindings/led/led.h>
-#include <dt-bindings/led/seagate_legend_b1414.h>
+#include <zephyr/dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/seagate_legend_b1414.h>
 
 / {
 	chosen {

--- a/boards/arm/lpcxpresso11u68/lpcxpresso11u68.dts
+++ b/boards/arm/lpcxpresso11u68/lpcxpresso11u68.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_lpc11u68.dtsi>
-#include <dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
 
 / {
 	model = "NXP LPCXPRESSO11U68 board";

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -8,7 +8,7 @@
 
 #include <nxp/nxp_lpc55S6x.dtsi>
 #include "lpcxpresso55s69.dtsi"
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	model = "NXP LPCXpresso55S69 board";

--- a/boards/arm/lpcxpresso55s69/pinmux.c
+++ b/boards/arm/lpcxpresso55s69/pinmux.c
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/pinmux.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/pinmux.h>
 #include <fsl_common.h>
 #include <fsl_iocon.h>
 #include <soc.h>

--- a/boards/arm/mec1501modular_assy6885/pinmux.c
+++ b/boards/arm/mec1501modular_assy6885/pinmux.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <drivers/pinmux.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/pinmux.h>
 
 #include "soc.h"
 

--- a/boards/arm/mec15xxevb_assy6853/pinmux.c
+++ b/boards/arm/mec15xxevb_assy6853/pinmux.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <drivers/pinmux.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/pinmux.h>
 
 #include "soc.h"
 

--- a/boards/arm/mec2016evb_assy6797/pinmux.c
+++ b/boards/arm/mec2016evb_assy6797/pinmux.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
 
 #include "soc.h"
 

--- a/boards/arm/mercury_xu/board.c
+++ b/boards/arm/mercury_xu/board.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <init.h>
+#include <zephyr/init.h>
 #define MIO_PIN_18	0xff180048
 #define MIO_PIN_19	0xff18004c
 #define MIO_PIN_38	0xff180098

--- a/boards/arm/mimx8mm_evk/pinmux.c
+++ b/boards/arm/mimx8mm_evk/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <fsl_iomuxc.h>
 
 static int mimx8mm_evk_pinmux_init(const struct device *dev)

--- a/boards/arm/mimx8mp_evk/pinmux.c
+++ b/boards/arm/mimx8mp_evk/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <fsl_iomuxc.h>
 
 static int mimx8mp_evk_pinmux_init(const struct device *dev)

--- a/boards/arm/mimx8mq_evk/pinmux.c
+++ b/boards/arm/mimx8mq_evk/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <fsl_iomuxc.h>
 
 static int mimx8mq_evk_pinmux_init(const struct device *dev)

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -7,8 +7,8 @@
 /dts-v1/;
 
 #include <nxp/nxp_rt6xx.dtsi>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/regulator/pca9420_i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/regulator/pca9420_i2c.h>
 
 #include "mimxrt685_evk_cm33-pinctrl.dtsi"
 

--- a/boards/arm/mimxrt685_evk/pinmux.c
+++ b/boards/arm/mimxrt685_evk/pinmux.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <fsl_iopctl.h>
 #include <soc.h>
 

--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -3,7 +3,7 @@
 /dts-v1/;
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	compatible = "arm,mps2";

--- a/boards/arm/mps2_an385/pinmux.c
+++ b/boards/arm/mps2_an385/pinmux.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <drivers/pinmux.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/pinmux.h>
 #include <soc.h>
-#include <sys/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <gpio/gpio_cmsdk_ahb.h>
 
 /**

--- a/boards/arm/mps2_an521/empty_cpu0/src/main.c
+++ b/boards/arm/mps2_an521/empty_cpu0/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 extern void wakeup_cpu1(void);
 

--- a/boards/arm/mps2_an521/mps2_an521.dts
+++ b/boards/arm/mps2_an521/mps2_an521.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	compatible = "arm,mps2";

--- a/boards/arm/mps2_an521/mps2_an521_ns.dts
+++ b/boards/arm/mps2_an521/mps2_an521_ns.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	compatible = "arm,mps2";

--- a/boards/arm/mps2_an521/mps2_an521_remote.dts
+++ b/boards/arm/mps2_an521/mps2_an521_remote.dts
@@ -8,7 +8,7 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	compatible = "arm,mps2";

--- a/boards/arm/mps2_an521/pinmux.c
+++ b/boards/arm/mps2_an521/pinmux.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <drivers/pinmux.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/pinmux.h>
 #include <soc.h>
-#include <sys/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <gpio/gpio_cmsdk_ahb.h>
 
 /**

--- a/boards/arm/mps3_an547/mps3_an547.dts
+++ b/boards/arm/mps3_an547/mps3_an547.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <arm/armv8.1-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {

--- a/boards/arm/mps3_an547/mps3_an547_ns.dts
+++ b/boards/arm/mps3_an547/mps3_an547_ns.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <arm/armv8.1-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {

--- a/boards/arm/nrf52840dongle_nrf52840/board.c
+++ b/boards/arm/nrf52840dongle_nrf52840/board.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <hal/nrf_power.h>
 
 static int board_nrf52840dongle_nrf52840_init(const struct device *dev)

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <init.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/logging/log.h>
 
 #include <soc.h>
 #include <soc_secure.h>

--- a/boards/arm/nrf9160_innblue21/innblue21_board_init.c
+++ b/boards/arm/nrf9160_innblue21/innblue21_board_init.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
 #define VDD_3V3_PWR_CTRL_GPIO_PIN  12   /* ENABLE_3V3_SENSOR --> i2c sensors  */
 #define VDD_5V0_PWR_CTRL_GPIO_PIN  21   /* ENABLE_5V0_BOOST  --> speed sensor */

--- a/boards/arm/nrf9160_innblue22/innblue22_board_init.c
+++ b/boards/arm/nrf9160_innblue22/innblue22_board_init.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
 #define VDD_5V0_PWR_CTRL_GPIO_PIN  21   /* ENABLE_5V0_BOOST  --> speed sensor */
 

--- a/boards/arm/nrf9160dk_nrf52840/board.c
+++ b/boards/arm/nrf9160dk_nrf52840/board.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <init.h>
-#include <drivers/gpio.h>
-#include <devicetree.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
 #include <hal/nrf_gpio.h>
 
 LOG_MODULE_REGISTER(board_control, CONFIG_BOARD_NRF9160DK_LOG_LEVEL);

--- a/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
+++ b/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
-#include <drivers/uart.h>
-#include <device.h>
-#include <devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/uart.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 
 #define RESET_NODE DT_NODELABEL(nrf52840_reset)
 

--- a/boards/arm/particle_argon/board.c
+++ b/boards/arm/particle_argon/board.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 #include "board.h"
 
 static inline void external_antenna(bool on)

--- a/boards/arm/particle_boron/board.c
+++ b/boards/arm/particle_boron/board.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 #include "board.h"
 
 static inline void external_antenna(bool on)

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include "mesh_feather.dtsi"
 #include "particle_boron-pinctrl.dtsi"
 

--- a/boards/arm/particle_xenon/board.c
+++ b/boards/arm/particle_xenon/board.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 #include "board.h"
 
 static inline void external_antenna(bool on)

--- a/boards/arm/pico_pi_m4/pinmux.c
+++ b/boards/arm/pico_pi_m4/pinmux.c
@@ -5,7 +5,7 @@
  */
 
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "device_imx.h"
 
 static int pico_pi_m4_pinmux_init(const struct device *dev)

--- a/boards/arm/pinetime_devkit0/key_out.c
+++ b/boards/arm/pinetime_devkit0/key_out.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
-#include <logging/log.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(pine64_pinetime_key_out);
 

--- a/boards/arm/qemu_cortex_a9/qemu_cortex_a9.dts
+++ b/boards/arm/qemu_cortex_a9/qemu_cortex_a9.dts
@@ -6,7 +6,7 @@
 /dts-v1/;
 
 #include <xilinx/zynq7000.dtsi>
-#include <dt-bindings/ethernet/xlnx_gem.h>
+#include <zephyr/dt-bindings/ethernet/xlnx_gem.h>
 
 / {
 	model = "QEMU Cortex-A9";

--- a/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
+++ b/boards/arm/qemu_cortex_m0/nrf_timer_timer.c
@@ -6,12 +6,12 @@
  */
 
 #include <soc.h>
-#include <drivers/clock_control.h>
-#include <drivers/clock_control/nrf_clock_control.h>
-#include <drivers/timer/system_timer.h>
-#include <sys_clock.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/drivers/clock_control/nrf_clock_control.h>
+#include <zephyr/drivers/timer/system_timer.h>
+#include <zephyr/sys_clock.h>
 #include <hal/nrf_timer.h>
-#include <spinlock.h>
+#include <zephyr/spinlock.h>
 
 #define TIMER NRF_TIMER0
 

--- a/boards/arm/quick_feather/board.c
+++ b/boards/arm/quick_feather/board.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <soc.h>
 #include <board.h>
 

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 #include <nordic/nrf52840_qiaa.dtsi>
-#include <dt-bindings/lora/sx126x.h>
+#include <zephyr/dt-bindings/lora/sx126x.h>
 #include "rak4631_nrf52840-pinctrl.dtsi"
 
 / {

--- a/boards/arm/rcar_h3_salvatorx/rcar_h3_salvatorx_cr7-pinctrl.dtsi
+++ b/boards/arm/rcar_h3_salvatorx/rcar_h3_salvatorx_cr7-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
+#include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
 
 &pfc {
 	can0_data_a_tx_default: can0_data_a_tx_default {

--- a/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7-pinctrl.dtsi
+++ b/boards/arm/rcar_h3ulcb/rcar_h3ulcb_cr7-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
+#include <zephyr/dt-bindings/pinctrl/renesas/pinctrl-r8a77951.h>
 
 &pfc {
 	can0_data_a_tx_default: can0_data_a_tx_default {

--- a/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
+++ b/boards/arm/rddrone_fmuk66/rddrone_fmuk66.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_k66.dtsi>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "rddrone_fmuk66-pinctrl.dtsi"
 
 / {

--- a/boards/arm/reel_board/board.c
+++ b/boards/arm/reel_board/board.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <soc.h>
 
 /* Peripheral voltage ON/OFF GPIO */

--- a/boards/arm/rpi_pico/rpi_pico-pinctrl.dtsi
+++ b/boards/arm/rpi_pico/rpi_pico-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/rpi-pico-rp2040-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/arm/rpi_pico/rpi_pico.dts
+++ b/boards/arm/rpi_pico/rpi_pico.dts
@@ -9,7 +9,7 @@
 #include <rpi_pico/rp2040.dtsi>
 #include "rpi_pico-pinctrl.dtsi"
 
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {

--- a/boards/arm/sam4e_xpro/pinmux.c
+++ b/boards/arm/sam4e_xpro/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 
 static int sam4e_xpro_init(const struct device *dev)
 {

--- a/boards/arm/sparkfun_thing_plus_nrf9160/board.c
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/board.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
 #define GPIO0 DT_LABEL(DT_NODELABEL(gpio0))
 #define POWER_LATCH_PIN 31

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -7,8 +7,8 @@
 /dts-v1/;
 #include <st/f4/stm32f429Xi.dtsi>
 #include <st/f4/stm32f429zitx-pinctrl.dtsi>
-#include <dt-bindings/display/stm32_ltdc.h>
-#include <dt-bindings/display/ili9xxx.h>
+#include <zephyr/dt-bindings/display/stm32_ltdc.h>
+#include <zephyr/dt-bindings/display/ili9xxx.h>
 
 / {
 	model = "STMicroelectronics STM32F429I_DISC1 board";

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 #include <st/g0/stm32g071Xb.dtsi>
 #include <st/g0/stm32g071r(6-8-b)tx-pinctrl.dtsi>
-#include <dt-bindings/sensor/ina230.h>
+#include <zephyr/dt-bindings/sensor/ina230.h>
 
 / {
 	model = "STM32G071B DEMO board";

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -7,7 +7,7 @@
 /dts-v1/;
 #include <st/h7/stm32h7b3Xi.dtsi>
 #include <st/h7/stm32h7b3lihxq-pinctrl.dtsi>
-#include <dt-bindings/display/stm32_ltdc.h>
+#include <zephyr/dt-bindings/display/stm32_ltdc.h>
 #include "arduino_r3_connector.dtsi"
 
 / {

--- a/boards/arm/stm32l496g_disco/board_adc_vref.c
+++ b/boards/arm/stm32l496g_disco/board_adc_vref.c
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <init.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/init.h>
 #include <stm32_ll_adc.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 
 static int enable_adc_reference(const struct device *dev)
 {

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
-#include <sys/printk.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/printk.h>
 
 #define VDD_PWR_CTRL_GPIO_PIN 30
 #define CCS_VDD_PWR_CTRL_GPIO_PIN 10

--- a/boards/arm/thingy53_nrf5340/board.c
+++ b/boards/arm/thingy53_nrf5340/board.c
@@ -4,13 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include <hal/nrf_gpio.h>
 #include <nrfx.h>
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(thingy53_board_init);
 
 #define ADXL362_NODE			DT_NODELABEL(adxl362)

--- a/boards/arm/twr_ke18f/pinmux.c
+++ b/boards/arm/twr_ke18f/pinmux.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/pinctrl.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/pinctrl.h>
 
 static int twr_ke18f_pinmux_init(const struct device *dev)
 {

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -7,8 +7,8 @@
 /dts-v1/;
 
 #include <nxp/nxp_ke18f512vlx16.dtsi>
-#include <dt-bindings/clock/kinetis_scg.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/clock/kinetis_scg.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include "twr_ke18f-pinctrl.dtsi"
 
 / {

--- a/boards/arm/ubx_bmd345eval_nrf52840/board.c
+++ b/boards/arm/ubx_bmd345eval_nrf52840/board.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <drivers/gpio.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
 
 #define MODE_PIN	4 /* P1.04 */
 #define A_SEL_PIN	2 /* P1.02 */

--- a/boards/arm/udoo_neo_full_m4/pinmux.c
+++ b/boards/arm/udoo_neo_full_m4/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "device_imx.h"
 
 static int udoo_neo_full_m4_init(const struct device *dev)

--- a/boards/arm/v2m_beetle/pinmux.c
+++ b/boards/arm/v2m_beetle/pinmux.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <drivers/pinmux.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/pinmux.h>
 #include <soc.h>
-#include <sys/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 #include <gpio/gpio_cmsdk_ahb.h>
 
 /**

--- a/boards/arm/v2m_musca_b1/pinmux.c
+++ b/boards/arm/v2m_musca_b1/pinmux.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <drivers/pinmux.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/pinmux.h>
 #include <soc.h>
-#include <sys/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 
 #define IOMUX_MAIN_INSEL	(0x68 >> 2)
 #define IOMUX_MAIN_OUTSEL	(0x70 >> 2)

--- a/boards/arm/v2m_musca_s1/pinmux.c
+++ b/boards/arm/v2m_musca_s1/pinmux.c
@@ -4,12 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <init.h>
-#include <kernel.h>
-#include <drivers/pinmux.h>
+#include <zephyr/device.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/pinmux.h>
 #include <soc.h>
-#include <sys/sys_io.h>
+#include <zephyr/sys/sys_io.h>
 
 #define IOMUX_MAIN_INSEL        (0x868 >> 2)
 #define IOMUX_MAIN_OUTSEL       (0x870 >> 2)

--- a/boards/arm/warp7_m4/pinmux.c
+++ b/boards/arm/warp7_m4/pinmux.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
+#include <zephyr/init.h>
 #include "device_imx.h"
 
 static int warp7_m4_pinmux_init(const struct device *dev)

--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -7,7 +7,7 @@
 
 #include <mem.h>
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	model = "FVP Base RevC 2xAEMv8A";

--- a/boards/arm64/xenvm/xenvm.dts
+++ b/boards/arm64/xenvm/xenvm.dts
@@ -15,7 +15,7 @@
 
 #include <mem.h>
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	model = "XENVM-4.15";

--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -13,7 +13,7 @@
 #include "timer_model.h"
 #include "cmdline.h"
 #include "toolchain.h"
-#include <arch/posix/posix_trace.h>
+#include <zephyr/arch/posix/posix_trace.h>
 #include "native_tracing.h"
 
 static int s_argc, test_argc;

--- a/boards/posix/native_posix/cmdline_common.c
+++ b/boards/posix/native_posix/cmdline_common.c
@@ -10,7 +10,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <math.h>
-#include <arch/posix/posix_trace.h>
+#include <zephyr/arch/posix/posix_trace.h>
 #include "posix_board_if.h"
 #include "zephyr/types.h"
 #include "cmdline_common.h"

--- a/boards/posix/native_posix/cpu_wait.c
+++ b/boards/posix/native_posix/cpu_wait.c
@@ -6,7 +6,7 @@
 
 #include <stdbool.h>
 #include "timer_model.h"
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 #include <posix_board_if.h>
 #include <posix_soc.h>
 

--- a/boards/posix/native_posix/hw_models_top.c
+++ b/boards/posix/native_posix/hw_models_top.c
@@ -19,10 +19,10 @@
 #include "irq_ctrl.h"
 #include "posix_board_if.h"
 #include "hw_counter.h"
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 #include "posix_arch_internal.h"
 #include "sdl_events.h"
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 
 
 static uint64_t simu_time; /* The actual time as known by the HW models */

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -18,7 +18,7 @@
 #include "board_soc.h"
 #include "sw_isr_table.h"
 #include "soc.h"
-#include <tracing/tracing.h>
+#include <zephyr/tracing/tracing.h>
 
 typedef void (*normal_irq_f_ptr)(const void *);
 typedef int (*direct_irq_f_ptr)(void);

--- a/boards/posix/native_posix/main.c
+++ b/boards/posix/native_posix/main.c
@@ -29,7 +29,7 @@
 #include <soc.h>
 #include "hw_models_top.h"
 #include <stdlib.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include "cmdline.h"
 
 void posix_exit(int exit_code)

--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -6,8 +6,8 @@
 
 /dts-v1/;
 #include <posix/posix.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	model = "Native POSIX Board";

--- a/boards/posix/native_posix/native_rtc.c
+++ b/boards/posix/native_posix/native_rtc.c
@@ -11,7 +11,7 @@
 #include "native_rtc.h"
 #include "hw_models_top.h"
 #include "timer_model.h"
-#include <arch/posix/posix_trace.h>
+#include <zephyr/arch/posix/posix_trace.h>
 
 /**
  * Return the (simulation) time in microseconds

--- a/boards/posix/native_posix/sdl_events.c
+++ b/boards/posix/native_posix/sdl_events.c
@@ -6,7 +6,7 @@
 
 #include <SDL.h>
 #include "posix_board_if.h"
-#include <arch/posix/posix_trace.h>
+#include <zephyr/arch/posix/posix_trace.h>
 #include "posix_arch_internal.h"
 #include "soc.h"
 #include "hw_models_top.h"

--- a/boards/posix/native_posix/timer_model.c
+++ b/boards/posix/native_posix/timer_model.c
@@ -26,8 +26,8 @@
 #include "irq_ctrl.h"
 #include "board_soc.h"
 #include "zephyr/types.h"
-#include <arch/posix/posix_trace.h>
-#include <sys/util.h>
+#include <zephyr/arch/posix/posix_trace.h>
+#include <zephyr/sys/util.h>
 #include "cmdline.h"
 #include "soc.h"
 

--- a/boards/posix/nrf52_bsim/board_soc.h
+++ b/boards/posix/nrf52_bsim/board_soc.h
@@ -19,8 +19,8 @@
 #ifndef _POSIX_NRF52_BOARD_SOC_H
 #define _POSIX_NRF52_BOARD_SOC_H
 
-#include <toolchain.h>
-#include <sys/util.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/sys/util.h>
 
 #include <stdint.h>
 #include <stdbool.h>

--- a/boards/posix/nrf52_bsim/cpu_wait.c
+++ b/boards/posix/nrf52_bsim/cpu_wait.c
@@ -8,7 +8,7 @@
 #include "zephyr/types.h"
 #include "fake_timer.h"
 #include "time_machine.h"
-#include <arch/posix/posix_soc_if.h>
+#include <zephyr/arch/posix/posix_soc_if.h>
 #include <posix_board_if.h>
 #include <posix_soc.h>
 

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -17,7 +17,7 @@
 #include "sw_isr_table.h"
 #include "soc.h"
 #include "bs_tracing.h"
-#include <tracing/tracing.h>
+#include <zephyr/tracing/tracing.h>
 #include "bstests.h"
 
 static bool CPU_will_be_awaken_from_WFE;

--- a/boards/posix/nrf52_bsim/trace_hook.c
+++ b/boards/posix/nrf52_bsim/trace_hook.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdarg.h>
 #include <stdio.h>
-#include <init.h>
+#include <zephyr/init.h>
 #include "bs_tracing.h"
 #include "posix_board_if.h"
 

--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32c3-pinctrl.h>
-#include <dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
+#include <zephyr/dt-bindings/pinctrl/esp32c3-gpio-sigmap.h>
 
 &pinctrl {
 

--- a/boards/riscv/hifive1/hifive1-pinctrl.dtsi
+++ b/boards/riscv/hifive1/hifive1-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/sifive-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/sifive-pinctrl.h>
 
 &pinctrl {
 	/* UART0 */

--- a/boards/riscv/hifive1_revb/hifive1_revb-pinctrl.dtsi
+++ b/boards/riscv/hifive1_revb/hifive1_revb-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/sifive-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/sifive-pinctrl.h>
 
 &pinctrl {
 	/* UART0 */

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -4,7 +4,7 @@
 /dts-v1/;
 
 #include <riscv32-fe310.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "hifive1_revb-pinctrl.dtsi"
 
 / {

--- a/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
+++ b/boards/riscv/it8xxx2_evb/it8xxx2_evb.dts
@@ -5,7 +5,7 @@
 
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <it8xxx2.dtsi>
 #include <ite/it8xxx2-pinctrl-map.dtsi>
 

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_xip-pinctrl.dtsi
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_xip-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/sifive-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/sifive-pinctrl.h>
 
 &pinctrl {
 	/* UART0 */

--- a/boards/riscv/rv32m1_vega/board.c
+++ b/boards/riscv/rv32m1_vega/board.c
@@ -5,8 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <init.h>
-#include <drivers/gpio.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/gpio.h>
 
 static int rv32m1_vega_board_init(const struct device *dev)
 {

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-pinctrl.dtsi
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/b91-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/b91-pinctrl.h>
 
 &pinctrl {
 	/* Set pad-mul-sel register value.

--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/display/ili9xxx.h>
+#include <zephyr/dt-bindings/display/ili9xxx.h>
 
 / {
 	chosen {

--- a/boards/xtensa/esp32/esp32-pinctrl.dtsi
+++ b/boards/xtensa/esp32/esp32-pinctrl.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <dt-bindings/pinctrl/esp32-gpio-sigmap.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32s2-pinctrl.h>
-#include <dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
+#include <zephyr/dt-bindings/pinctrl/esp32s2-gpio-sigmap.h>
 
 &pinctrl {
 

--- a/boards/xtensa/esp_wrover_kit/board_init.c
+++ b/boards/xtensa/esp_wrover_kit/board_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #define LED_R_PIN  DT_GPIO_PIN(DT_ALIAS(led2), gpios)
 #define LED_G_PIN  DT_GPIO_PIN(DT_ALIAS(led1), gpios)

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <dt-bindings/pinctrl/esp32-gpio-sigmap.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 

--- a/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
+++ b/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #define VEXT_PIN  DT_GPIO_PIN(DT_NODELABEL(vext), gpios)
 #define OLED_RST  DT_GPIO_PIN(DT_NODELABEL(oledrst), gpios)

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <dt-bindings/pinctrl/esp32-gpio-sigmap.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 

--- a/boards/xtensa/intel_s1000_crb/pinmux.c
+++ b/boards/xtensa/intel_s1000_crb/pinmux.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
-#include <init.h>
-#include <drivers/pinmux.h>
+#include <zephyr/kernel.h>
+#include <zephyr/init.h>
+#include <zephyr/drivers/pinmux.h>
 #include "iomux.h"
 
 /*

--- a/boards/xtensa/odroid_go/board_init.c
+++ b/boards/xtensa/odroid_go/board_init.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
+#include <zephyr/drivers/gpio.h>
 
 #define LED_B_PIN  DT_GPIO_PIN(DT_ALIAS(led0), gpios)
 

--- a/boards/xtensa/odroid_go/odroid_go-pinctrl.dtsi
+++ b/boards/xtensa/odroid_go/odroid_go-pinctrl.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <dt-bindings/pinctrl/esp32-gpio-sigmap.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/esp-pinctrl-common.h>
+#include <zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
-#include <dt-bindings/pinctrl/esp32-gpio-sigmap.h>
+#include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
 	uart0_tx_gpio1: uart0_tx_gpio1 {


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all boards code to the
new prefix <zephyr/...>. Note that the conversion has been scripted,
refer to zephyrproject-rtos#45388 for more details.