### PR TITLE
dts: migrate includes to <zephyr/...>

### DIFF
--- a/dts/arc/arc_hsdk.dtsi
+++ b/dts/arc/arc_hsdk.dtsi
@@ -6,8 +6,8 @@
 
 #include "skeleton.dtsi"
 
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {

--- a/dts/arc/arc_iot.dtsi
+++ b/dts/arc/arc_iot.dtsi
@@ -6,8 +6,8 @@
 
 #include "skeleton.dtsi"
 
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {

--- a/dts/arc/emsdp.dtsi
+++ b/dts/arc/emsdp.dtsi
@@ -6,8 +6,8 @@
 
 #include "skeleton.dtsi"
 
-//#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+//#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 #define DT_APB_CLK_HZ	100000000
 

--- a/dts/arc/emsk.dtsi
+++ b/dts/arc/emsk.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 #define DT_APB_CLK_HZ	50000000
 

--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	aliases {

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	aliases {

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	chosen {

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -6,8 +6,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	aliases {

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -6,9 +6,9 @@
 
 #include <mem.h>
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -6,9 +6,9 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/dts/arm/broadcom/viper-a72.dtsi
+++ b/dts/arm/broadcom/viper-a72.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <arm/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 #include "viper-common.dtsi"
 

--- a/dts/arm/cypress/pinctrl_cypress_psoc6.h
+++ b/dts/arm/cypress/pinctrl_cypress_psoc6.h
@@ -7,7 +7,7 @@
 #ifndef PINCTRL_CYPRESS_PSOC6_H_
 #define PINCTRL_CYPRESS_PSOC6_H_
 
-#include <dt-bindings/dt-util.h>
+#include <zephyr/dt-bindings/dt-util.h>
 
 /**
  * Functions are defined using HSIOM SEL

--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <mem.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 #include "psoc6-pinctrl.dtsi"
 

--- a/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
+++ b/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {

--- a/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
+++ b/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -6,9 +6,9 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	cpus {

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -5,10 +5,10 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	cpus {

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {

--- a/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
+++ b/dts/arm/microchip/mec172x/mec172xnsz-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/mchp-xec-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/mchp-xec-pinctrl.h>
 
 &pinctrl {
 	/* ADC */

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -6,10 +6,10 @@
 
 #include <arm/armv7-m.dtsi>
 
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/clock/mchp_xec_pcr.h>
-#include <dt-bindings/interrupt-controller/mchp-xec-ecia.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 
 #include "mec172x/mec172x-vw-routing.dtsi"
 

--- a/dts/arm/nordic/nrf_common.dtsi
+++ b/dts/arm/nordic/nrf_common.dtsi
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pinctrl/nrf-pinctrl.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pinctrl/nrf-pinctrl.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 #include <arm/nordic/override.dtsi>
 /*

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -7,12 +7,12 @@
 #include <arm/armv7-m.dtsi>
 
 /* Macros for device tree declarations of npcx soc family */
-#include <dt-bindings/clock/npcx_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pinctrl/npcx-pinctrl.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/sensor/npcx_tach.h>
+#include <zephyr/dt-bindings/clock/npcx_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pinctrl/npcx-pinctrl.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/sensor/npcx_tach.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/nuvoton/npcx/npcx-espi-vws-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-espi-vws-map.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/espi/npcx_espi.h>
+#include <zephyr/dt-bindings/espi/npcx_espi.h>
 
 /*
  *                Nuvoton NPCX7 eSPI Virtual Wires Mapping Table

--- a/dts/arm/nxp/nxp_imx6sx_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx6sx_m4.dtsi
@@ -6,9 +6,9 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/rdc/imx_rdc.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_imx7d_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx7d_m4.dtsi
@@ -6,9 +6,9 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_imx8m_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx8m_m4.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/imx_ccm.h>
-#include <dt-bindings/rdc/imx_rdc.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/imx_ccm.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 
 / {

--- a/dts/arm/nxp/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx8ml_m7.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/imx_ccm.h>
-#include <dt-bindings/rdc/imx_rdc.h>
+#include <zephyr/dt-bindings/clock/imx_ccm.h>
+#include <zephyr/dt-bindings/rdc/imx_rdc.h>
 #include <mem.h>
 
 / {

--- a/dts/arm/nxp/nxp_k2x.dtsi
+++ b/dts/arm/nxp/nxp_k2x.dtsi
@@ -6,10 +6,10 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_k6x.dtsi
+++ b/dts/arm/nxp/nxp_k6x.dtsi
@@ -2,10 +2,10 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	aliases {

--- a/dts/arm/nxp/nxp_k8x.dtsi
+++ b/dts/arm/nxp/nxp_k8x.dtsi
@@ -5,10 +5,10 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	aliases {

--- a/dts/arm/nxp/nxp_ke1xf.dtsi
+++ b/dts/arm/nxp/nxp_ke1xf.dtsi
@@ -5,10 +5,10 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/kinetis_pcc.h>
-#include <dt-bindings/clock/kinetis_scg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/kinetis_pcc.h>
+#include <zephyr/dt-bindings/clock/kinetis_scg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	aliases {

--- a/dts/arm/nxp/nxp_kl25z.dtsi
+++ b/dts/arm/nxp/nxp_kl25z.dtsi
@@ -2,10 +2,10 @@
 
 #include <mem.h>
 #include "armv6-m.dtsi"
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_kv5x.dtsi
+++ b/dts/arm/nxp/nxp_kv5x.dtsi
@@ -5,10 +5,10 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_kw2xd.dtsi
+++ b/dts/arm/nxp/nxp_kw2xd.dtsi
@@ -2,10 +2,10 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 /* Include package pinmux file for the spi modem settings */
 #include <nxp/kinetis/MKW24D512VHA5-pinctrl.h>

--- a/dts/arm/nxp/nxp_kw40z.dtsi
+++ b/dts/arm/nxp/nxp_kw40z.dtsi
@@ -2,11 +2,11 @@
 
 #include <mem.h>
 #include "armv6-m.dtsi"
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -6,11 +6,11 @@
 
 #include <mem.h>
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/clock/kinetis_sim.h>
-#include <dt-bindings/clock/kinetis_mcg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/clock/kinetis_sim.h>
+#include <zephyr/dt-bindings/clock/kinetis_mcg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_lpc11u6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc11u6x.dtsi
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/clock/lpc11u6x_clock.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/lpc11u6x_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc54xxx.dtsi
+++ b/dts/arm/nxp/nxp_lpc54xxx.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include <mem.h>
-#include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S2x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x.dtsi
@@ -6,8 +6,8 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	soc {

--- a/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S2x_common.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {

--- a/dts/arm/nxp/nxp_lpc55S6x.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x.dtsi
@@ -6,8 +6,8 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	soc {

--- a/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S6x_common.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include <mem.h>
-#include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <arm/armv8-m.dtsi>
 
 / {

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -6,10 +6,10 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/imx_ccm.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/clock/imx_ccm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -6,11 +6,11 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/imx_ccm_rev2.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pm/imx_spc.h>
+#include <zephyr/dt-bindings/clock/imx_ccm_rev2.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pm/imx_spc.h>
 
 / {
 	cpus {

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -6,9 +6,9 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -6,9 +6,9 @@
 
 #include <mem.h>
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/mcux_lpc_syscon_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/mcux_lpc_syscon_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	chosen {

--- a/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
+++ b/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
@@ -6,7 +6,7 @@
 
 #include <mem.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	cpus {

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -6,10 +6,10 @@
 
 #include <mem.h>
 #include <arm/armv7-r.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
-#include <dt-bindings/clock/renesas_rcar_cpg.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/clock/renesas_rcar_cpg.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 #include "rpi_pico_common.dtsi"

--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -6,8 +6,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {

--- a/dts/arm/silabs/efm32_pg_1b.dtsi
+++ b/dts/arm/silabs/efm32_pg_1b.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {

--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -6,8 +6,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -1,8 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	chosen {

--- a/dts/arm/silabs/efr32mg21.dtsi
+++ b/dts/arm/silabs/efr32mg21.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {

--- a/dts/arm/silabs/efr32xg13p.dtsi
+++ b/dts/arm/silabs/efr32xg13p.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include "gpio_gecko.h"
 
 / {

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/clock/stm32f1_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32f1_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32f1_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32f1_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32f4_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32f4_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32f1_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32f1_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32f4_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32f4_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <st/f4/stm32f407.dtsi>
-#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {
 	soc {

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <st/f4/stm32f407.dtsi>
-#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {
 	soc {

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <st/f4/stm32f401.dtsi>
-#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 
 / {
 	soc {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -6,12 +6,12 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32f4_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
-#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/clock/stm32f4_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -9,11 +9,11 @@
  */
 
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/clock/stm32g0_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32g0_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -7,11 +7,11 @@
 
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32l4_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32l4_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -7,12 +7,12 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32h7_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
-#include <dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/clock/stm32h7_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/clock/stm32l0_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32l0_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32l1_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32l1_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -7,11 +7,11 @@
 
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32l4_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32l4_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -7,11 +7,11 @@
 
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/stm32l4_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32l4_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -8,11 +8,11 @@
 #include <mem.h>
 #include <freq.h>
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/clock/stm32_clock.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/stm32_clock.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 
 / {
 	cpus {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -7,9 +7,9 @@
 
 
 #include <arm/armv8-m.dtsi>
-#include <dt-bindings/clock/stm32u5_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/stm32u5_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -6,11 +6,11 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32l4_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32l4_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -5,12 +5,12 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/clock/stm32wl_clock.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/lora/sx126x.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/clock/stm32wl_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/lora/sx126x.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -5,8 +5,8 @@
  */
 
 #include <arm/armv7-m.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	chosen {

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -2,8 +2,8 @@
 
 #include <arm/armv7-m.dtsi>
 
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 #define INT_UARTA0              21          // UART0 Rx and Tx
 #define INT_UARTA1              22          // UART1 Rx and Tx

--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -5,8 +5,8 @@
 
 #include <mem.h>
 #include <arm/armv7-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
-#include <dt-bindings/ethernet/xlnx_gem.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/ethernet/xlnx_gem.h>
 
 / {
 	soc {

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -6,8 +6,8 @@
 
 #include <mem.h>
 #include <arm/armv7-r.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
-#include <dt-bindings/ethernet/xlnx_gem.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/ethernet/xlnx_gem.h>
 
 / {
 	soc {

--- a/dts/arm64/broadcom/viper-a72.dtsi
+++ b/dts/arm64/broadcom/viper-a72.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 #include "viper-common.dtsi"
 

--- a/dts/arm64/fvp-aemv8r/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp-aemv8r/fvp-aemv8r.dtsi
@@ -5,7 +5,7 @@
 
 #include <mem.h>
 #include <arm64/armv8-r.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	cpus {

--- a/dts/arm64/intel_socfpga/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel_socfpga/intel_socfpga_agilex.dtsi
@@ -6,7 +6,7 @@
  */
 
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	cpus {

--- a/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
@@ -7,8 +7,8 @@
 #include <mem.h>
 #include <freq.h>
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/clock/imx_ccm.h>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/clock/imx_ccm.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/arm64/nxp/nxp_imx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_imx8mp_a53.dtsi
@@ -7,8 +7,8 @@
 #include <mem.h>
 #include <freq.h>
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/clock/imx_ccm.h>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/clock/imx_ccm.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/arm64/nxp/nxp_ls1046a.dtsi
+++ b/dts/arm64/nxp/nxp_ls1046a.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <mem.h>
 
 / {

--- a/dts/arm64/qemu-virt/qemu-virt-a53.dtsi
+++ b/dts/arm64/qemu-virt/qemu-virt-a53.dtsi
@@ -15,7 +15,7 @@
 
 #include <mem.h>
 #include <arm64/armv8-a.dtsi>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	#address-cells = <2>;

--- a/dts/nios2/nios2f.dtsi
+++ b/dts/nios2/nios2f.dtsi
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
 / {
 	cpus {

--- a/dts/riscv/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes_v5_ae350.dtsi
@@ -5,7 +5,7 @@
  */
 
 /dts-v1/;
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
 
 / {

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <mem.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/interrupt-controller/esp-esp32c3-intmux.h>
-#include <dt-bindings/clock/esp32c3_clock.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/interrupt-controller/esp-esp32c3-intmux.h>
+#include <zephyr/dt-bindings/clock/esp32c3_clock.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
 
 / {

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/timer/riscv-machine-timer.h>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/timer/riscv-machine-timer.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/it8xxx2.dtsi
+++ b/dts/riscv/it8xxx2.dtsi
@@ -6,16 +6,16 @@
  */
 
 #include <mem.h>
-#include <dt-bindings/dt-util.h>
-#include <dt-bindings/interrupt-controller/ite-intc.h>
-#include <dt-bindings/interrupt-controller/it8xxx2-wuc.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/i2c/it8xxx2-i2c.h>
-#include <dt-bindings/pinctrl/it8xxx2-pinctrl.h>
-#include <dt-bindings/pwm/pwm.h>
-#include <dt-bindings/pwm/it8xxx2_pwm.h>
-#include <dt-bindings/sensor/it8xxx2_vcmp.h>
-#include <dt-bindings/sensor/it8xxx2_tach.h>
+#include <zephyr/dt-bindings/dt-util.h>
+#include <zephyr/dt-bindings/interrupt-controller/ite-intc.h>
+#include <zephyr/dt-bindings/interrupt-controller/it8xxx2-wuc.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/it8xxx2-i2c.h>
+#include <zephyr/dt-bindings/pinctrl/it8xxx2-pinctrl.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/it8xxx2_pwm.h>
+#include <zephyr/dt-bindings/sensor/it8xxx2_vcmp.h>
+#include <zephyr/dt-bindings/sensor/it8xxx2_tach.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include "ite/it8xxx2-wuc-map.dtsi"
 

--- a/dts/riscv/ite/it8xxx2-wuc-map.dtsi
+++ b/dts/riscv/ite/it8xxx2-wuc-map.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/dt-util.h>
+#include <zephyr/dt-bindings/dt-util.h>
 
 / {
 	/* Mapping between wuc bits and source device */

--- a/dts/riscv/neorv32.dtsi
+++ b/dts/riscv/neorv32.dtsi
@@ -7,7 +7,7 @@
 /dts-v1/;
 
 #include <skeleton.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	chosen {

--- a/dts/riscv/riscv32-fe310.dtsi
+++ b/dts/riscv/riscv32-fe310.dtsi
@@ -1,7 +1,7 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 #include <freq.h>
 
 / {

--- a/dts/riscv/riscv64-fu540.dtsi
+++ b/dts/riscv/riscv64-fu540.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <freq.h>
 
 / {

--- a/dts/riscv/riscv64-fu740.dtsi
+++ b/dts/riscv/riscv64-fu740.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <freq.h>
 
 / {

--- a/dts/riscv/rv32m1.dtsi
+++ b/dts/riscv/rv32m1.dtsi
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/interrupt-controller/openisa-intmux.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/interrupt-controller/openisa-intmux.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
+++ b/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include "starfive_jh7100_clk.dtsi"
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	#address-cells = <2>;

--- a/dts/riscv/telink_b91.dtsi
+++ b/dts/riscv/telink_b91.dtsi
@@ -6,9 +6,9 @@
 
 /dts-v1/;
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	#address-cells = <1>;

--- a/dts/x86/apollo_lake.dtsi
+++ b/dts/x86/apollo_lake.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/interrupt-controller/intel-ioapic.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pcie/pcie.h>
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pcie/pcie.h>
 
 / {
 	cpus {

--- a/dts/x86/atom.dtsi
+++ b/dts/x86/atom.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 
 / {
 	cpus {

--- a/dts/x86/elkhart_lake.dtsi
+++ b/dts/x86/elkhart_lake.dtsi
@@ -5,9 +5,9 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/interrupt-controller/intel-ioapic.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pcie/pcie.h>
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pcie/pcie.h>
 
 / {
 	cpus {

--- a/dts/x86/ia32.dtsi
+++ b/dts/x86/ia32.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 
 / {
 	cpus {

--- a/dts/x86/lakemont.dtsi
+++ b/dts/x86/lakemont.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include "skeleton.dtsi"
-#include <dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 
 / {
 	cpus {

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -5,10 +5,10 @@
  */
 #include <mem.h>
 #include <xtensa/xtensa.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/clock/esp32_clock.h>
-#include <dt-bindings/interrupt-controller/esp-xtensa-intmux.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/esp32_clock.h>
+#include <zephyr/dt-bindings/interrupt-controller/esp-xtensa-intmux.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
 
 / {

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -5,10 +5,10 @@
  */
 #include <mem.h>
 #include <xtensa/xtensa.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/clock/esp32s2_clock.h>
-#include <dt-bindings/interrupt-controller/esp32s2-xtensa-intmux.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/clock/esp32s2_clock.h>
+#include <zephyr/dt-bindings/interrupt-controller/esp32s2-xtensa-intmux.h>
 #include <dt-bindings/pinctrl/esp32-pinctrl.h>
 
 / {

--- a/dts/xtensa/intel/intel_s1000.dtsi
+++ b/dts/xtensa/intel/intel_s1000.dtsi
@@ -1,10 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 #include <xtensa/xtensa.dtsi>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 #include <mem.h>
-#include <dt-bindings/interrupt-controller/intel-ioapic.h>
+#include <zephyr/dt-bindings/interrupt-controller/intel-ioapic.h>
 
 
 / {

--- a/dts/xtensa/nxp/nxp_imx8.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <xtensa/xtensa.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {

--- a/dts/xtensa/nxp/nxp_imx8m.dtsi
+++ b/dts/xtensa/nxp/nxp_imx8m.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <xtensa/xtensa.dtsi>
-#include <dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
 #include <mem.h>
 
 / {


### PR DESCRIPTION
In order to bring consistency in-tree, migrate all dts code to the new
prefix <zephyr/...>. Note that the conversion has been scripted, refer
to zephyrproject-rtos#45388 for more details.