### PR TITLE
soc: riscv: riscv-ite: fix include

### DIFF
--- a/soc/riscv/riscv-ite/common/pinctrl_soc.h
+++ b/soc/riscv/riscv-ite/common/pinctrl_soc.h
@@ -9,7 +9,7 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/dt-bindings/pinctrl/it8xxx2-pinctrl.h>
-#include <zephyr/zephyr/types.h>
+#include <zephyr/types.h>
 
 /**
  * @brief ITE IT8XXX2 pin type.


### PR DESCRIPTION
<zephyr/zephyr/types.h> is no longer available, <zephyr/types.h> should
be used instead.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>