### PR TITLE
Bluetooth: Controller: df: Fix wrong ant after switch pattern exhausted

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -153,13 +153,13 @@ config BT_CTLR_DF_SAMPLE_CTE_FOR_PDU_WITH_BAD_CRC
 
 config BT_CTLR_DF_MAX_ANT_SW_PATTERN_LEN
 	int "Maximum length of antenna switch pattern"
-	range 3 39 if SOC_COMPATIBLE_NRF
+	range 2 38 if SOC_COMPATIBLE_NRF
 	range 2 75 if !SOC_COMPATIBLE_NRF
 	default 12
 	help
 	  Defines maximum length of antenna switch pattern that controller
 	  is able to store. For nRF5x-based controllers, the hardware imposes
-	  the value is within range 3 to 40, where last value is maximum.
+	  the value is within range 2 to 38, where last value is maximum.
 	  For general use cases Bluetooth Core 5.1 spec. required the value
 	  to be within range 2 up to 75.
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -33,6 +33,9 @@
 #define FOR_EACH_DFE_GPIO(fn, sep) \
 	FOR_EACH(fn, sep, 0, 1, 2, 3, 4, 5, 6, 7)
 
+/* Index of antenna id in antenna switching pattern used for GUARD and REFERENCE period */
+#define GUARD_REF_ANTENNA_PATTERN_IDX 1U
+
 /* Direction Finding antenna matrix configuration */
 struct df_ant_cfg {
 	uint8_t ant_num;
@@ -105,6 +108,15 @@ void radio_df_ant_switch_pattern_set(const uint8_t *patterns, uint8_t len)
 	for (uint8_t idx = 0; idx < len; ++idx) {
 		NRF_RADIO->SWITCHPATTERN = patterns[idx];
 	}
+
+	/* Store antenna id used for GUARD and REFERENCE period at the end of SWITCHPATTERN buffer.
+	 * It is required to apply reference antenna id when user provided switchpattern is
+	 * exhausted.
+	 * Maximum length of the switch pattern provided to this function is at maximum lower by one
+	 * than capacity of SWITCHPATTERN buffer. Hence there is always space for reference antenna
+	 * id after end of switch pattern.
+	 */
+	NRF_RADIO->SWITCHPATTERN = patterns[GUARD_REF_ANTENNA_PATTERN_IDX];
 }
 
 /*


### PR DESCRIPTION
Direction finding functionality does antenna switching during CTE
reception in AoA mode and CTE transmission in AoD mode. Antennas are
switched according to user provided antenna switch pattern. If a CTE
length is enough to exhaust all antenna ids in a switch pattern then
radio should loopback to reference antenna and continue from switching
from that. Current implementation loops back to antenna that is just
after reference antenna in the switch pattern.

The commit fixes that by insertion of the reference antenna
at the end of switch pattern. Radio will operate as it was before,
it will restart switching from the same index in a switch pattern.
At the same time reference antenna will be inserted into the loop
if siwttching pattern is exhausted. That also means, the maximum
number of antenna ids in a switch pattern has to be decreased by
one.

The commit also fixes lower bound in the BT_CTLR_DF_MAX_ANT_SW_PATTERN-
_LEN that should be equal two. It was set to three, because in the
past the antenna at index zero was used for reception of a PDU.
Now this antenna ID is provided by device tree configuration.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>