### PR TITLE
Extend STM32 QSPI with QER (SFDP, DTS), custom quad write opcode, and 1-1-4 read mode 

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -137,18 +137,13 @@ static inline int qspi_prepare_quad_read(const struct device *dev,
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
 
-	switch (dev_data->mode) {
-	case JESD216_MODE_114:
-		cmd->AddressMode = QSPI_ADDRESS_1_LINE;
-		break;
-	case JESD216_MODE_144:
-		cmd->AddressMode = QSPI_ADDRESS_4_LINES;
-		break;
-	default:
-		return -ENOTSUP;
-	}
+	__ASSERT_NO_MSG(dev_data->mode == JESD216_MODE_114 ||
+			dev_data->mode == JESD216_MODE_144);
 
 	cmd->Instruction = dev_data->qspi_read_cmd;
+	cmd->AddressMode = ((dev_data->mode == JESD216_MODE_114)
+				? QSPI_ADDRESS_1_LINE
+				: QSPI_ADDRESS_4_LINES);
 	cmd->DataMode = QSPI_DATA_4_LINES;
 	cmd->DummyCycles = dev_data->qspi_read_cmd_latency;
 
@@ -160,19 +155,13 @@ static inline int qspi_prepare_quad_program(const struct device *dev,
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
 
+	__ASSERT_NO_MSG(dev_data->qspi_write_cmd == SPI_NOR_CMD_PP_1_1_4 ||
+			dev_data->qspi_write_cmd == SPI_NOR_CMD_PP_1_4_4);
+
 	cmd->Instruction = dev_data->qspi_write_cmd;
-
-	switch (cmd->Instruction) {
-	case SPI_NOR_CMD_PP_1_1_4:
-		cmd->AddressMode = QSPI_ADDRESS_1_LINE;
-		break;
-	case SPI_NOR_CMD_PP_1_4_4:
-		cmd->AddressMode = QSPI_ADDRESS_4_LINES;
-		break;
-	default:
-		return -ENOTSUP;
-	}
-
+	cmd->AddressMode = ((cmd->Instruction == SPI_NOR_CMD_PP_1_1_4)
+				? QSPI_ADDRESS_1_LINE
+				: QSPI_ADDRESS_4_LINES);
 	cmd->DataMode = QSPI_DATA_4_LINES;
 	cmd->DummyCycles = 0;
 

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -141,7 +141,7 @@ static inline int qspi_prepare_quad_read(const struct device *dev,
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
 
-	if (IS_ENABLED(STM32_QSPI_USE_QUAD_IO) && dev_data->flag_quad_io_en) {
+	if (dev_data->flag_quad_io_en) {
 		switch (dev_data->mode) {
 		case JESD216_MODE_114:
 			cmd->AddressMode = QSPI_ADDRESS_1_LINE;
@@ -166,7 +166,7 @@ static inline int qspi_prepare_quad_program(const struct device *dev,
 {
 	struct flash_stm32_qspi_data *dev_data = dev->data;
 
-	if (IS_ENABLED(STM32_QSPI_USE_QUAD_IO) && dev_data->flag_quad_io_en) {
+	if (dev_data->flag_quad_io_en) {
 		cmd->Instruction = dev_data->qspi_write_cmd;
 
 		switch (cmd->Instruction) {
@@ -344,10 +344,13 @@ static int flash_stm32_qspi_read(const struct device *dev, off_t addr,
 	};
 
 	qspi_set_address_size(dev, &cmd);
-	ret = qspi_prepare_quad_read(dev, &cmd);
-	if (ret < 0) {
-		return ret;
+	if (IS_ENABLED(STM32_QSPI_USE_QUAD_IO)) {
+		ret = qspi_prepare_quad_read(dev, &cmd);
+		if (ret < 0) {
+			return ret;
+		}
 	}
+
 	qspi_lock_thread(dev);
 
 	ret = qspi_read_access(dev, &cmd, data, size);
@@ -404,10 +407,13 @@ static int flash_stm32_qspi_write(const struct device *dev, off_t addr,
 	};
 
 	qspi_set_address_size(dev, &cmd_pp);
-	ret = qspi_prepare_quad_program(dev, &cmd_pp);
-	if (ret < 0) {
-		return ret;
+	if (IS_ENABLED(STM32_QSPI_USE_QUAD_IO)) {
+		ret = qspi_prepare_quad_program(dev, &cmd_pp);
+		if (ret < 0) {
+			return ret;
+		}
 	}
+
 	qspi_lock_thread(dev);
 
 	while (size > 0) {

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1029,6 +1029,16 @@ static int spi_nor_process_bfp(const struct device *dev,
 
 		LOG_INF("Quad read mode %d instr [0x%x] will be used", data->mode, res.instr);
 
+		/* try to decode QE requirement type */
+		rc = jesd216_bfp_decode_dw15(php, bfp, &dw15);
+		if (rc < 0) {
+			/* will use QER from DTS or default (refer to device data) */
+			LOG_WRN("Unable to decode QE requirement [DW15]: %d", rc);
+		} else {
+			/* bypass DTS QER value */
+			data->qer_type = dw15.qer;
+		}
+
 		LOG_INF("QE requirement mode: %x", data->qer_type);
 
 		/* enable QE */

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -20,6 +20,7 @@
 #include <zephyr/drivers/flash.h>
 #include <zephyr/drivers/dma.h>
 #include <zephyr/drivers/dma/dma_stm32.h>
+#include <zephyr/drivers/gpio.h>
 
 #if DT_INST_NODE_HAS_PROP(0, spi_bus_width) && \
 	DT_INST_PROP(0, spi_bus_width) == 4
@@ -29,9 +30,7 @@
 #endif
 
 #define STM32_QSPI_RESET_GPIO DT_INST_NODE_HAS_PROP(0, reset_gpios)
-#if STM32_QSPI_RESET_GPIO
-#include <zephyr/drivers/gpio.h>
-#endif
+
 #include <stm32_ll_dma.h>
 
 #include "spi_nor.h"

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -60,7 +60,6 @@ uint32_t table_p_size[] = {
 
 typedef void (*irq_config_func_t)(const struct device *dev);
 
-
 struct stream {
 	DMA_TypeDef *reg;
 	const struct device *dev;
@@ -1107,8 +1106,6 @@ static int flash_stm32_qspi_init(const struct device *dev)
 		return -ENODEV;
 	}
 #endif /* CONFIG_FLASH_PAGE_LAYOUT */
-
-	LOG_INF("Device %s initialized", dev->name);
 
 	return 0;
 }

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -92,6 +92,7 @@ struct flash_stm32_qspi_data {
 	struct jesd216_erase_type erase_types[JESD216_NUM_ERASE_TYPES];
 	/* Number of bytes per page */
 	uint16_t page_size;
+	enum jesd216_dw15_qer_type qer_type;
 	enum jesd216_mode_type mode;
 	int cmd_status;
 	struct stream dma;
@@ -756,26 +757,83 @@ static int qspi_program_addr_4b(const struct device *dev)
 	return ret;
 }
 
-static int qspi_read_status_register(const struct device *dev, uint8_t *reg)
+static int qspi_read_status_register(const struct device *dev, uint8_t reg_num, uint8_t *reg)
 {
 	QSPI_CommandTypeDef cmd = {
-		.Instruction = SPI_NOR_CMD_RDSR,
 		.InstructionMode = QSPI_INSTRUCTION_1_LINE,
 		.DataMode = QSPI_DATA_1_LINE,
 	};
 
+	switch (reg_num) {
+	case 1U:
+		cmd.Instruction = SPI_NOR_CMD_RDSR;
+		break;
+	case 2U:
+		cmd.Instruction = SPI_NOR_CMD_RDSR2;
+		break;
+	case 3U:
+		cmd.Instruction = SPI_NOR_CMD_RDSR3;
+		break;
+	default:
+		return -EINVAL;
+	}
+
 	return qspi_read_access(dev, &cmd, reg, sizeof(*reg));
 }
 
-static int qspi_write_status_register(const struct device *dev, uint8_t reg)
+static int qspi_write_status_register(const struct device *dev, uint8_t reg_num, uint8_t reg)
 {
+	struct flash_stm32_qspi_data *dev_data = dev->data;
+	size_t size;
+	uint8_t regs[4] = { 0 };
+	uint8_t *regs_p;
+	int ret;
+
 	QSPI_CommandTypeDef cmd = {
 		.Instruction = SPI_NOR_CMD_WRSR,
 		.InstructionMode = QSPI_INSTRUCTION_1_LINE,
 		.DataMode = QSPI_DATA_1_LINE,
 	};
 
-	return qspi_write_access(dev, &cmd, &reg, sizeof(reg));
+	if (reg_num == 1) {
+		size = 1U;
+		regs[0] = reg;
+		regs_p = &regs[0];
+		/* 1 byte write clears SR2, write SR2 as well */
+		if (dev_data->qer_type == JESD216_DW15_QER_S2B1v1) {
+			ret = qspi_read_status_register(dev, 2, &regs[1]);
+			if (ret < 0) {
+				return ret;
+			}
+			size = 2U;
+		}
+	} else if (reg_num == 2) {
+		cmd.Instruction = SPI_NOR_CMD_WRSR2;
+		size = 1U;
+		regs[1] = reg;
+		regs_p = &regs[1];
+		/* if SR2 write needs SR1 */
+		if ((dev_data->qer_type == JESD216_DW15_QER_VAL_S2B1v1) ||
+		    (dev_data->qer_type == JESD216_DW15_QER_VAL_S2B1v4) ||
+		    (dev_data->qer_type == JESD216_DW15_QER_VAL_S2B1v5)) {
+			ret = qspi_read_status_register(dev, 1, &regs[0]);
+			if (ret < 0) {
+				return ret;
+			}
+			cmd.Instruction = SPI_NOR_CMD_WRSR;
+			size = 2U;
+			regs_p = &regs[0];
+		}
+	} else if (reg_num == 3) {
+		cmd.Instruction = SPI_NOR_CMD_WRSR3;
+		size = 1U;
+		regs[2] = reg;
+		regs_p = &regs[2];
+	} else {
+		return -EINVAL;
+	}
+
+	return qspi_write_access(dev, &cmd, regs_p, size);
 }
 
 static int qspi_write_enable(const struct device *dev)
@@ -794,7 +852,7 @@ static int qspi_write_enable(const struct device *dev)
 	}
 
 	do {
-		ret = qspi_read_status_register(dev, &reg);
+		ret = qspi_read_status_register(dev, 1U, &reg);
 	} while (!ret && !(reg & SPI_NOR_WEL_BIT));
 
 	return ret;
@@ -803,50 +861,74 @@ static int qspi_write_enable(const struct device *dev)
 static int qspi_program_quad_io(const struct device *dev)
 {
 	struct flash_stm32_qspi_data *data = dev->data;
+	uint8_t qe_reg_num;
+	uint8_t qe_bit;
 	uint8_t reg;
 	int ret;
 
-	/* Check if QE bit setting is required */
-	ret = qspi_read_status_register(dev, &reg);
-	if (ret) {
+	switch (data->qer_type) {
+	case JESD216_DW15_QER_NONE:
+		/* no QE bit, device detects reads based on opcode */
+		return 0;
+	case JESD216_DW15_QER_S1B6:
+		qe_reg_num = 1U;
+		qe_bit = BIT(6U);
+		break;
+	case JESD216_DW15_QER_S2B7:
+		qe_reg_num = 2U;
+		qe_bit = BIT(7U);
+		break;
+	case JESD216_DW15_QER_S2B1v1:
+		__fallthrough;
+	case JESD216_DW15_QER_S2B1v4:
+		__fallthrough;
+	case JESD216_DW15_QER_S2B1v5:
+		__fallthrough;
+	case JESD216_DW15_QER_S2B1v6:
+		qe_reg_num = 2U;
+		qe_bit = BIT(1U);
+		break;
+	default:
+		return -ENOTSUP;
+	}
+
+	ret = qspi_read_status_register(dev, qe_reg_num, &reg);
+	if (ret < 0) {
 		return ret;
 	}
 
-	/* Quit early when QE bit is already set */
-	if (reg & SPI_NOR_QE_BIT) {
-		goto out;
+	/* exit early if QE bit is already set */
+	if ((reg & qe_bit) != 0U) {
+		return 0;
 	}
+
+	reg |= qe_bit;
 
 	ret = qspi_write_enable(dev);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
-	reg |= SPI_NOR_QE_BIT;
-	ret = qspi_write_status_register(dev, reg);
-	if (ret) {
+	ret = qspi_write_status_register(dev, qe_reg_num, reg);
+	if (ret < 0) {
 		return ret;
 	}
 
 	ret = qspi_wait_until_ready(dev);
-	if (ret) {
+	if (ret < 0) {
 		return ret;
 	}
 
-	ret = qspi_read_status_register(dev, &reg);
-	if (ret) {
+	/* validate that QE bit is set */
+	ret = qspi_read_status_register(dev, qe_reg_num, &reg);
+	if (ret < 0) {
 		return ret;
 	}
 
-	/* Check if QE bit programming is finished */
-	if (!(reg & SPI_NOR_QE_BIT)) {
-		LOG_ERR("Quad Enable [QE] bit in status reg not set");
+	if ((reg & qe_bit) == 0U) {
+		LOG_ERR("Status Register %u [0x%02x] not set", qe_reg_num, reg);
 		return -EIO;
 	}
-
- out:
-	LOG_INF("Flash - QUAD mode enabled [SR:0x%02x]", reg);
-	data->flag_quad_io_en = true;
 
 	return ret;
 }
@@ -947,6 +1029,8 @@ static int spi_nor_process_bfp(const struct device *dev,
 
 		LOG_INF("Quad read mode %d instr [0x%x] will be used", data->mode, res.instr);
 
+		LOG_INF("QE requirement mode: %x", data->qer_type);
+
 		/* enable QE */
 		rc = qspi_program_quad_io(dev);
 		if (rc < 0) {
@@ -954,6 +1038,8 @@ static int spi_nor_process_bfp(const struct device *dev,
 			return rc;
 		}
 
+		data->flag_quad_io_en = true;
+		LOG_INF("Quad mode enabled");
 	}
 
 	return 0;
@@ -1198,6 +1284,12 @@ static void flash_stm32_qspi_irq_config_func(const struct device *dev);
 		    (_CONCAT(SPI_NOR_CMD_, DT_STRING_TOKEN(DT_DRV_INST(inst), writeoc))),    \
 		    ((default_value)))
 
+#define DT_QER_PROP_OR(inst, default_value)                                                  \
+	COND_CODE_1(DT_INST_NODE_HAS_PROP(inst, quad_enable_requirements),                   \
+		    (_CONCAT(JESD216_DW15_QER_VAL_,                                          \
+			     DT_STRING_TOKEN(DT_DRV_INST(inst), quad_enable_requirements))), \
+		    ((default_value)))
+
 #define STM32_QSPI_NODE DT_INST_PARENT(0)
 
 PINCTRL_DT_DEFINE(STM32_QSPI_NODE);
@@ -1227,6 +1319,7 @@ static struct flash_stm32_qspi_data flash_stm32_qspi_dev_data = {
 			.ClockMode = QSPI_CLOCK_MODE_0,
 			},
 	},
+	.qer_type = DT_QER_PROP_OR(0, JESD216_DW15_QER_VAL_S1B6),
 	.qspi_write_cmd = DT_WRITEOC_PROP_OR(0, SPI_NOR_CMD_PP_1_4_4),
 	QSPI_DMA_CHANNEL(STM32_QSPI_NODE, tx_rx)
 };

--- a/drivers/flash/jesd216.h
+++ b/drivers/flash/jesd216.h
@@ -457,7 +457,7 @@ enum jesd216_dw15_qer_type {
 struct jesd216_bfp_dw15 {
 	/* If true clear NVECR bit 4 to disable HOLD/RESET */
 	bool hold_reset_disable: 1;
-	/* Encoded jesd216_qer_type */
+	/* Encoded jesd216_dw15_qer_type */
 	unsigned int qer: 3;
 	/* 0-4-4 mode entry method */
 	unsigned int entry_044: 4;

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -30,7 +30,8 @@
 #define SPI_NOR_CMD_WREN        0x06    /* Write enable */
 #define SPI_NOR_CMD_WRDI        0x04    /* Write disable */
 #define SPI_NOR_CMD_PP          0x02    /* Page program */
-#define SPI_NOR_CMD_4PP         0x38    /* Page program (1-4-4) */
+#define SPI_NOR_CMD_PP_1_1_4    0x32    /* Quad Page program (1-1-4) */
+#define SPI_NOR_CMD_PP_1_4_4    0x38    /* Quad Page program (1-4-4) */
 #define SPI_NOR_CMD_RDCR        0x15    /* Read control register */
 #define SPI_NOR_CMD_SE          0x20    /* Sector erase */
 #define SPI_NOR_CMD_BE_32K      0x52    /* Block erase 32KB */

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -14,7 +14,6 @@
 /* Status register bits */
 #define SPI_NOR_WIP_BIT         BIT(0)  /* Write in progress */
 #define SPI_NOR_WEL_BIT         BIT(1)  /* Write enable latch */
-#define SPI_NOR_QE_BIT          BIT(6)  /* Enable quad mode */
 
 /* Control register bits */
 #define SPI_NOR_4BYTE_BIT       BIT(5)  /* 4B addressing */

--- a/drivers/flash/spi_nor.h
+++ b/drivers/flash/spi_nor.h
@@ -23,6 +23,8 @@
 #define SPI_NOR_CMD_RDSR        0x05    /* Read status register */
 #define SPI_NOR_CMD_WRSR2       0x31    /* Write status register 2 */
 #define SPI_NOR_CMD_RDSR2       0x35    /* Read status register 2 */
+#define SPI_NOR_CMD_RDSR3       0x15    /* Read status register 3 */
+#define SPI_NOR_CMD_WRSR3       0x11    /* Write status register 3 */
 #define SPI_NOR_CMD_READ        0x03    /* Read data */
 #define SPI_NOR_CMD_DREAD       0x3B    /* Read data (1-1-2) */
 #define SPI_NOR_CMD_QREAD       0x6B    /* Read data (1-1-4) */

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -49,3 +49,18 @@ properties:
       required: false
       description: The width of (Q)SPI bus to which flash memory is connected.
                    Now only value of 4 (when using SIO[0123]) is supported.
+    writeoc:
+      type: string
+      required: false
+      enum:
+        - "PP_1_1_4"      # Quad data line SPI, PP 1-1-4 (0x32)
+        - "PP_1_4_4"      # Quad data line SPI, PP 1-4-4 (0x38)
+      description: |
+        The value encodes number of I/O lines used for the opcode,
+        address, and data.
+
+        There is no info about quad page program opcodes in the SFDP
+        tables, hence it has been assumed that NOR flash memory
+        supporting 1-4-4 mode also would support fast page programming.
+
+        If absent, then 1-4-4 program page is used in quad mode.


### PR DESCRIPTION
Extends existing STM32 QSPI NOR driver.

Adds:

* Support every QE requirement - can be specified in DTS. However, SFDP BFP DW15 bypasses the DTS value (if DW15 is present).
* Add support to specify what quad program (_write_) opcode is going to be used:

  - `PP_1_1_4` (**_new_**)
  - `PP_1_4_4` (_used originally_)

  Some flash ICs support a different set of opcodes for programming and reading. The inspiration is taken from the 
  `nrf_qspi_nor` driver, but `spi_nor` defines are used. 
* Add support for 1-1-4 read mode. The driver auto-detects the fastest supported quad read mode from SFDP BFP 

This PR enables STM32 QSPI NOR driver usage with different kinds of QSPI Flash ICs.

Tested using custom H750 board with W25Q128JVSIQ.

<details>
  <summary>Flash test output</summary>

> [00:00:00.000,000] <inf> flash_stm32_qspi: flash_stm32_qspi_init: W25Q128JVSIQ: SFDP v 1.5 AP ff with 1 PH
> [00:00:00.000,000] <inf> flash_stm32_qspi: flash_stm32_qspi_init: PH0: ff00 rev 1.5: 16 DW @ 80
> [00:00:00.000,000] <inf> flash_stm32_qspi: W25Q128JVSIQ: 16 MiBy flash
> [00:00:00.000,000] <inf> flash_stm32_qspi: Quad read mode 4 instr [0x6b] supported
> [00:00:00.000,000] <inf> flash_stm32_qspi: Quad read mode 7 instr [0xeb] supported
> [00:00:00.000,000] <inf> flash_stm32_qspi: Quad read mode 7 instr [0xeb] will be used
> [00:00:00.000,000] <inf> flash_stm32_qspi: QE Requirement mode: 4
> [00:00:00.000,000] <inf> flash_stm32_qspi: Quad mode enabled
>
> uart:~$ flash test W25Q128JVSIQ 0x0 0x1000 3
> Erase OK.
> Write OK.
> Erase OK.
> Write OK.
> Erase OK.
> Write OK.
> Erase-Write test done.
>
> uart:~$ flash erase W25Q128JVSIQ 0x0 0x1000
> Erase success.
>
> uart:~$ flash read  W25Q128JVSIQ 0x0 0x16
> 00000000: ff ff ff ff ff ff ff ff  ff ff ff ff ff ff ff ff |........ ........|
> 00000010: ff ff ff ff ff ff                                |......           |
>
> uart:~$ flash write W25Q128JVSIQ 0x0 0xAABBCCDD
> Write OK.
> Verified.
>
> uart:~$ flash read  W25Q128JVSIQ 0x0 0x16
> 00000000: dd cc bb aa ff ff ff ff  ff ff ff ff ff ff ff ff |........ ........|
> 00000010: ff ff ff ff ff ff                                |......           |
>
> uart:~$

</details