### PR TITLE
Bluetooth: ISO: Add function for reading TX sync

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -234,6 +234,18 @@ struct bt_iso_recv_info {
 	uint8_t flags;
 };
 
+/** @brief ISO Meta Data structure for transmitted ISO packets. */
+struct bt_iso_tx_info {
+	/** CIG reference point or BIG anchor point of a transmitted SDU, in microseconds. */
+	uint32_t ts;
+
+	/** Time offset, in microseconds */
+	uint32_t offset;
+
+	/** Packet sequence number */
+	uint16_t seq_num;
+};
+
 
 /** Opaque type representing an Connected Isochronous Group (CIG). */
 struct bt_iso_cig;
@@ -782,6 +794,22 @@ int bt_iso_chan_get_info(const struct bt_iso_chan *chan,
  *                               will be BT_ISO_CHAN_TYPE_NONE.
  */
 enum bt_iso_chan_type bt_iso_chan_get_type(const struct bt_iso_chan *chan);
+
+/** @brief Get ISO transmission timing info
+ *
+ *  @details Reads timing information for transmitted ISO packet on an ISO channel.
+ *           The HCI_LE_Read_ISO_TX_Sync HCI command is used to retrieve this information
+ *           from the controller.
+ *
+ *  @note An SDU must have already been successfully transmitted on the ISO channel
+ *        for this function to return successfully.
+ *
+ *  @param[in]  chan Channel object.
+ *  @param[out] info Transmit info object.
+ *
+ *  @return Zero on success or (negative) error code on failure.
+ */
+int bt_iso_chan_get_tx_sync(const struct bt_iso_chan *chan, struct bt_iso_tx_info *info);
 
 /** @brief Creates a BIG as a broadcaster
  *

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -782,6 +782,61 @@ static bool valid_chan_io_qos(const struct bt_iso_chan_io_qos *io_qos,
 	return true;
 }
 #endif /* CONFIG_BT_ISO_CENTRAL || CONFIG_BT_ISO_BROADCASTER */
+
+int bt_iso_chan_get_tx_sync(const struct bt_iso_chan *chan, struct bt_iso_tx_info *info)
+{
+	struct bt_hci_cp_le_read_iso_tx_sync *cp;
+	struct bt_hci_rp_le_read_iso_tx_sync *rp;
+	struct net_buf *buf;
+	struct net_buf *rsp = NULL;
+	int err;
+
+	CHECKIF(chan == NULL) {
+		BT_DBG("chan is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(chan->iso == NULL) {
+		BT_DBG("chan->iso is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(info == NULL) {
+		BT_DBG("info is NULL");
+		return -EINVAL;
+	}
+
+	CHECKIF(chan->state != BT_ISO_STATE_CONNECTED) {
+		return -ENOTCONN;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_READ_ISO_TX_SYNC, sizeof(*cp));
+	if (!buf) {
+		return -ENOMEM;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(chan->iso->handle);
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_ISO_TX_SYNC, buf, &rsp);
+	if (err) {
+		return err;
+	}
+
+	if (rsp) {
+		rp = (struct bt_hci_rp_le_read_iso_tx_sync *)rsp->data;
+
+		info->ts = sys_le32_to_cpu(rp->timestamp);
+		info->seq_num = sys_le16_to_cpu(rp->seq);
+		info->offset = sys_get_le24(rp->offset);
+
+		net_buf_unref(rsp);
+	} else {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
 #endif /* CONFIG_BT_ISO_UNICAST) || CONFIG_BT_ISO_BROADCASTER */
 
 #if defined(CONFIG_BT_ISO_UNICAST)

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -416,6 +416,28 @@ static int cmd_disconnect(const struct shell *sh, size_t argc,
 
 	return 0;
 }
+
+static int cmd_tx_sync_read_cis(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct bt_iso_tx_info tx_info;
+	int err;
+
+	if (!iso_chan.iso) {
+		shell_error(sh, "Not bound");
+		return 0;
+	}
+
+	err = bt_iso_chan_get_tx_sync(&iso_chan, &tx_info);
+	if (err) {
+		shell_error(sh, "Unable to read sync info (err %d)", err);
+		return 0;
+	}
+
+	shell_print(sh, "TX sync info:\n\tTimestamp=%u\n\tOffset=%u\n\tSequence number=%u",
+		tx_info.ts, tx_info.offset, tx_info.seq_num);
+
+	return 0;
+}
 #endif /* CONFIG_BT_ISO_UNICAST */
 
 #if defined(CONFIG_BT_ISO_BROADCAST)
@@ -537,6 +559,28 @@ static int cmd_big_create(const struct shell *sh, size_t argc, char *argv[])
 
 	return 0;
 }
+
+static int cmd_tx_sync_read_bis(const struct shell *sh, size_t argc, char *argv[])
+{
+	struct bt_iso_tx_info tx_info;
+	int err;
+
+	if (!bis_iso_chan.iso) {
+		shell_error(sh, "BIG not created");
+		return -ENOEXEC;
+	}
+
+	err = bt_iso_chan_get_tx_sync(&bis_iso_chan, &tx_info);
+	if (err) {
+		shell_error(sh, "Unable to read sync info (err %d)", err);
+		return 0;
+	}
+
+	shell_print(sh, "TX sync info:\n\tTimestamp=%u\n\tOffset=%u\n\tSequence number=%u",
+		tx_info.ts, tx_info.offset, tx_info.seq_num);
+
+	return 0;
+}
 #endif /* CONFIG_BT_ISO_BROADCASTER */
 
 #if defined(CONFIG_BT_ISO_SYNC_RECEIVER)
@@ -640,11 +684,13 @@ SHELL_STATIC_SUBCMD_SET_CREATE(iso_cmds,
 		      cmd_send, 1, 1),
 	SHELL_CMD_ARG(disconnect, NULL, "Disconnect ISO Channel",
 		      cmd_disconnect, 1, 0),
+	SHELL_CMD_ARG(tx_sync_read_cis, NULL, "Read CIS TX sync info", cmd_tx_sync_read_cis, 1, 0),
 #endif /* CONFIG_BT_ISO_UNICAST */
 #if defined(CONFIG_BT_ISO_BROADCASTER)
 	SHELL_CMD_ARG(create-big, NULL, "Create a BIG as a broadcaster [enc <broadcast code>]",
 		      cmd_big_create, 1, 2),
 	SHELL_CMD_ARG(broadcast, NULL, "Broadcast on ISO channels", cmd_broadcast, 1, 1),
+	SHELL_CMD_ARG(tx_sync_read_bis, NULL, "Read BIS TX sync info", cmd_tx_sync_read_bis, 1, 0),
 #endif /* CONFIG_BT_ISO_BROADCASTER */
 #if defined(CONFIG_BT_ISO_SYNC_RECEIVER)
 	SHELL_CMD_ARG(sync-big, NULL, "Synchronize to a BIG as a receiver <BIS bitfield> [mse] "


### PR DESCRIPTION
This function retrieves TX sync information
(timestamp, offset, and sequence number)
from controller using HCI command HCI_LE_Read_ISO_TX_Sync.

Signed-off-by: Audun Korneliussen <audun.korneliussen@nordicsemi.no>