### PR TITLE
net/tcp: prevent infinite TCP resend data buffer allocation errors

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1126,6 +1126,8 @@ static void tcp_resend_data(struct k_work *work)
 	bool conn_unref = false;
 	int ret;
 
+	k_mutex_lock(&conn->context->lock, K_FOREVER);
+
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
 	NET_DBG("send_data_retries=%hu", conn->send_data_retries);
@@ -1170,6 +1172,8 @@ static void tcp_resend_data(struct k_work *work)
 
  out:
 	k_mutex_unlock(&conn->lock);
+
+	k_mutex_unlock(&conn->context->lock);
 
 	if (conn_unref) {
 		tcp_conn_unref(conn);


### PR DESCRIPTION
This PR eliminates potential race condition between socket send and TCP resend,
which may lead to endless Data buffer allocation and TCP connection effectively stopping.

context_sendto may be called again and again (via aggressive socket call),
thus occupying TX buffers most of the time. Then once resend time comes, it doesn't have TX buffers.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45426

_Update_: after PR https://github.com/zephyrproject-rtos/zephyr/pull/44227 infinite resend doesn't happen, but some iterations may be skipped, still resulting in occasional `Data buffer allocation error`.
Using mutex ensures that resend is called right away once context_sendto is finished.

All further details are in the issue.

Signed-off-by: Andrey Dodonov <Andrey.Dodonov@endress.com>