### PR TITLE
twister: Fix dependency on west when checking for projects

### DIFF
--- a/scripts/zephyr_module.py
+++ b/scripts/zephyr_module.py
@@ -368,9 +368,14 @@ def west_projects():
     # West is imported here, as it is optional
     # (and thus maybe not installed)
     # if user is providing a specific modules list.
-    from west.manifest import Manifest
-    from west.util import WestNotFound
-    from west.version import __version__ as WestVersion
+    try:
+        from west.manifest import Manifest
+        from west.util import WestNotFound
+        from west.version import __version__ as WestVersion
+    except ImportError:
+        # West is not installed, so don't return any projects.
+        return None
+
     from packaging import version
     try:
         manifest = Manifest.from_file()


### PR DESCRIPTION
Twister should be partially usable even without West installed, however,
Twister unconditionally tries to import it when initializing to check
for west projects and crashes if it is not there.

This PR changes the behavior to return None if the west imports failed,
which appears to be more in line with what was intended. This allows
Twister to proceed and successfully run tests in a non-west environment.
There is no impact on environments that do have west installed.

Fixes #45355

Signed-off-by: Tristan Honscheid <honscheid@google.com>