### PR TITLE
dts: arm: st: u5: update m_can compatible

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -392,7 +392,7 @@
 		};
 
 		can {
-			compatible = "bosch,m-can-base";
+			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			std-filter-elements = <28>;


### PR DESCRIPTION
In #45014 the m_can compatible identifier was changed from "m-can-base" to "m_can-base" while #45216 was being developed. This updates the `.dtsi` for the STM32U5 series to the latest format.