### PR TITLE
sd: fix for busy wait in subsystem, and minor improvement to SDHC api

### DIFF
--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -586,7 +586,7 @@ static int imx_usdhc_request(const struct device *dev, struct sdhc_command *cmd,
 	host_cmd.index = cmd->opcode;
 	host_cmd.argument = cmd->arg;
 	/* Mask out part of response type field used for SPI commands */
-	host_cmd.responseType = (cmd->response_type & 0xF);
+	host_cmd.responseType = (cmd->response_type & SDHC_NATIVE_RESPONSE_MASK);
 	transfer.command = &host_cmd;
 	if (cmd->timeout_ms == SDHC_TIMEOUT_FOREVER) {
 		request.command_timeout = K_FOREVER;
@@ -711,8 +711,10 @@ static int imx_usdhc_request(const struct device *dev, struct sdhc_command *cmd,
 	k_mutex_unlock(&dev_data->access_mutex);
 	/* Record command response */
 	memcpy(cmd->response, host_cmd.response, sizeof(cmd->response));
-	/* Record number of bytes xfered */
-	data->bytes_xfered = dev_data->transfer_handle.transferredWords;
+	if (data) {
+		/* Record number of bytes xfered */
+		data->bytes_xfered = dev_data->transfer_handle.transferredWords;
+	}
 	return ret;
 }
 

--- a/drivers/sdhc/sdhc_spi.c
+++ b/drivers/sdhc/sdhc_spi.c
@@ -231,7 +231,7 @@ static int sdhc_spi_response_get(const struct device *dev, struct sdhc_command *
 		}
 		/* else IDLE_STATE bit is set, which is not an error, card is just resetting */
 	}
-	switch ((cmd->response_type & 0xF0)) {
+	switch ((cmd->response_type & SDHC_SPI_RESPONSE_TYPE_MASK)) {
 	case SD_SPI_RSP_TYPE_R1:
 		/* R1 response - one byte*/
 		break;

--- a/include/zephyr/drivers/sdhc.h
+++ b/include/zephyr/drivers/sdhc.h
@@ -48,6 +48,9 @@ struct sdhc_command {
 	int timeout_ms; /*!< Command timeout in milliseconds */
 };
 
+#define SDHC_NATIVE_RESPONSE_MASK 0xF
+#define SDHC_SPI_RESPONSE_TYPE_MASK 0xF0
+
 /**
  * @brief SD host controller data structure
  *

--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -1172,7 +1172,7 @@ static int sdmmc_read_status(struct sd_card *card)
 /* Waits for SD card to be ready for data. Returns 0 if card is ready */
 static int sdmmc_wait_ready(struct sd_card *card)
 {
-	int ret, timeout = CONFIG_SD_DATA_TIMEOUT;
+	int ret, timeout = CONFIG_SD_DATA_TIMEOUT * 1000;
 	bool busy = true;
 
 	do {


### PR DESCRIPTION
The SD subsystem was incorrectly using a busy timeout in microseconds when checking to make sure a card was ready for data after an SD transfer, when milliseconds were supposed to be used. Multiply the wait time by 1000 to fix this error.

This PR also adds convenience definitions for the SD host controller response fields, to mask out the SPI or SD mode response type depending on which mode the SD host controller driver uses. 