### PR TITLE
test: Remove usec test for pwm_api

### DIFF
--- a/tests/drivers/pwm/pwm_api/src/main.c
+++ b/tests/drivers/pwm/pwm_api/src/main.c
@@ -10,7 +10,6 @@
 #include <zephyr/device.h>
 
 const struct device *get_pwm_device(void);
-void test_pwm_usec(void);
 void test_pwm_cycle(void);
 void test_pwm_nsec(void);
 
@@ -22,7 +21,6 @@ void test_main(void)
 	k_object_access_grant(dev, k_current_get());
 
 	ztest_test_suite(pwm_basic_test,
-			 ztest_user_unit_test(test_pwm_usec),
 			 ztest_user_unit_test(test_pwm_nsec),
 			 ztest_user_unit_test(test_pwm_cycle));
 	ztest_run_test_suite(pwm_basic_test);

--- a/tests/drivers/pwm/pwm_api/src/test_pwm.c
+++ b/tests/drivers/pwm/pwm_api/src/test_pwm.c
@@ -6,8 +6,8 @@
 
 /**
  * @file
- * @brief Verify PWM can work well when configure through usec,
- * nsec, or cycle.
+ * @brief Verify PWM can work well when configure through nsec,
+ * or cycle.
  *
  * @details
  * - Test Steps
@@ -55,15 +55,11 @@
 	defined(CONFIG_SOC_MKW41Z4)
 #define DEFAULT_PERIOD_CYCLE 1024
 #define DEFAULT_PULSE_CYCLE 512
-#define DEFAULT_PERIOD_USEC 2000
-#define DEFAULT_PULSE_USEC 500
 #define DEFAULT_PERIOD_NSEC 2000000
 #define DEFAULT_PULSE_NSEC 500000
 #else
 #define DEFAULT_PERIOD_CYCLE 64000
 #define DEFAULT_PULSE_CYCLE 32000
-#define DEFAULT_PERIOD_USEC 2000
-#define DEFAULT_PULSE_USEC 1000
 #define DEFAULT_PERIOD_NSEC 2000000
 #define DEFAULT_PULSE_NSEC 1000000
 #endif
@@ -94,8 +90,7 @@
 #endif
 
 #define UNIT_CYCLES	0
-#define UNIT_USECS	1
-#define UNIT_NSECS	2
+#define UNIT_NSECS	1
 
 const struct device *get_pwm_device(void)
 {
@@ -129,24 +124,6 @@ static int test_task(uint32_t port, uint32_t period, uint32_t pulse, uint8_t uni
 	}
 
 	return TC_PASS;
-}
-
-void test_pwm_usec(void)
-{
-	/* Period : Pulse (2000 : 1000), unit (usec). Voltage : 1.65V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
-				DEFAULT_PULSE_USEC, UNIT_USECS) == TC_PASS, NULL);
-	k_sleep(K_MSEC(1000));
-
-	/* Period : Pulse (2000 : 2000), unit (usec). Voltage : 3.3V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
-				DEFAULT_PERIOD_USEC, UNIT_USECS) == TC_PASS, NULL);
-	k_sleep(K_MSEC(1000));
-
-	/* Period : Pulse (2000 : 0), unit (usec). Voltage : 0V */
-	zassert_true(test_task(DEFAULT_PWM_PORT, DEFAULT_PERIOD_USEC,
-				0, UNIT_USECS) == TC_PASS, NULL);
-	k_sleep(K_MSEC(1000));
 }
 
 void test_pwm_nsec(void)


### PR DESCRIPTION
As the pwm interface only takes nanosecond for parameter,
the original test case for mircosecond is not needed.
Check github issue #44887 for more info.

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/45458