### PR TITLE
drivers: pinctrl: Fix unused parameter warnings when compiling with -…

### DIFF
--- a/include/zephyr/drivers/pinctrl.h
+++ b/include/zephyr/drivers/pinctrl.h
@@ -238,7 +238,7 @@ struct pinctrl_dev_config {
 	LISTIFY(DT_NUM_PINCTRL_STATES(node_id),				       \
 		     Z_PINCTRL_STATE_PINS_DEFINE, (;), node_id);	       \
 	Z_PINCTRL_STATES_DEFINE(node_id)				       \
-	Z_PINCTRL_DEV_CONFIG_CONST Z_PINCTRL_DEV_CONFIG_STATIC		       \
+	Z_PINCTRL_DEV_CONFIG_STATIC Z_PINCTRL_DEV_CONFIG_CONST		       \
 	struct pinctrl_dev_config Z_PINCTRL_DEV_CONFIG_NAME(node_id) =	       \
 	Z_PINCTRL_DEV_CONFIG_INIT(node_id)
 
@@ -320,6 +320,7 @@ static inline int pinctrl_apply_state_direct(
 #ifdef CONFIG_PINCTRL_STORE_REG
 	reg = config->reg;
 #else
+	ARG_UNUSED(config);
 	reg = PINCTRL_REG_NONE;
 #endif
 
@@ -441,6 +442,9 @@ static inline int pinctrl_update_states(
 	struct pinctrl_dev_config *config,
 	const struct pinctrl_state *states, uint8_t state_cnt)
 {
+	ARG_UNUSED(config);
+	ARG_UNUSED(states);
+	ARG_UNUSED(state_cnt);
 	return -ENOSYS;
 }
 #endif /* defined(CONFIG_PINCTRL_DYNAMIC) || defined(__DOXYGEN__) */


### PR DESCRIPTION
…Wextra

Since the pinctrl header file can be included by user-created drivers,
an application developer including this file and only applying
-Wextra to the application source files will see many warnings.

-Wold-style-declaration warning is also emitted if 'static' is not
at the beginning of a declaration.

Signed-off-by: Pete Dietl <petedietl@gmail.com>