### PR TITLE
samples|tests: migrate includes to <zephyr/...> in *.overlays

### DIFF
--- a/samples/basic/blinky_pwm/boards/esp32.overlay
+++ b/samples/basic/blinky_pwm/boards/esp32.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2021 Andrei-Edward Popa
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/samples/basic/blinky_pwm/boards/esp_wrover_kit.overlay
+++ b/samples/basic/blinky_pwm/boards/esp_wrover_kit.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/samples/drivers/led_lp503x/boards/lpcxpresso11u68.overlay
+++ b/samples/drivers/led_lp503x/boards/lpcxpresso11u68.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 &i2c0 {
 	/* TI LP5030 LED controller connected to I2C0. */

--- a/samples/drivers/led_pwm/boards/esp32.overlay
+++ b/samples/drivers/led_pwm/boards/esp32.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2021 Andrei-Edward Popa
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 STMicroelectronics
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 
 / {

--- a/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
@@ -4,7 +4,7 @@
  * Copyright (c) 2022 STMicroelectronics
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 
 / {

--- a/samples/drivers/led_ws2812/boards/bbc_microbit.overlay
+++ b/samples/drivers/led_ws2812/boards/bbc_microbit.overlay
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 / {
 	led_strip: ws2812 {

--- a/samples/drivers/led_ws2812/boards/nrf51dk_nrf51422.overlay
+++ b/samples/drivers/led_ws2812/boards/nrf51dk_nrf51422.overlay
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 / {
 	led_strip: ws2812 {

--- a/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.overlay
+++ b/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 #include "../nrf52-bindings.h"
 

--- a/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 #include "../f070rb-bindings.h"
 

--- a/samples/drivers/led_ws2812/boards/nucleo_g071rb.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_g071rb.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 &arduino_spi {
 	led_strip: ws2812@0 {

--- a/samples/drivers/led_ws2812/boards/nucleo_l476rg.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_l476rg.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 &arduino_spi {
 	led_strip: ws2812@0 {

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/ipc_service/static_vrings.h>
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 
 / {
 	chosen {

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/ipc_service/static_vrings.h>
+#include <zephyr/dt-bindings/ipc_service/static_vrings.h>
 
 / {
 	chosen {

--- a/tests/drivers/build_all/led_strip/app.overlay
+++ b/tests/drivers/build_all/led_strip/app.overlay
@@ -12,7 +12,7 @@
  */
 
 #include <freq.h>
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 / {
 	test {

--- a/tests/drivers/pwm/pwm_loopback/boards/disco_l475_iot1.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/disco_l475_iot1.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	pwm_loopback_0 {

--- a/tests/drivers/pwm/pwm_loopback/boards/frdm_k64f.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/frdm_k64f.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	pwm_loopback_0 {

--- a/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/nucleo_h743zi.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	pwm_loopback_0 {

--- a/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
+++ b/tests/drivers/pwm/pwm_loopback/boards/twr_ke18f.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 &pinctrl {
 	pwt_default: pwt_default {

--- a/tests/drivers/virtualization/ivshmem/app.overlay
+++ b/tests/drivers/virtualization/ivshmem/app.overlay
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <dt-bindings/pcie/pcie.h>
+#include <zephyr/dt-bindings/pcie/pcie.h>
 
 / {
 	pcie0 {


### PR DESCRIPTION
Leftover of of work done on #45420 and #45417.