### PR TITLE
samples: drivers: spi_flash rename definitions

### DIFF
--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -13,36 +13,36 @@
 
 #if (CONFIG_SPI_NOR - 0) ||				\
 	DT_NODE_HAS_STATUS(DT_INST(0, jedec_spi_nor), okay)
-#define FLASH_DEVICE DT_LABEL(DT_INST(0, jedec_spi_nor))
-#define FLASH_NAME "JEDEC SPI-NOR"
+#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, jedec_spi_nor))
+#define SPI_FLASH_NAME "JEDEC SPI-NOR"
 #elif (CONFIG_NORDIC_QSPI_NOR - 0) || \
 	DT_NODE_HAS_STATUS(DT_INST(0, nordic_qspi_nor), okay)
-#define FLASH_DEVICE DT_LABEL(DT_INST(0, nordic_qspi_nor))
-#define FLASH_NAME "JEDEC QSPI-NOR"
+#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, nordic_qspi_nor))
+#define SPI_FLASH_NAME "JEDEC QSPI-NOR"
 #elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_qspi_nor), okay)
-#define FLASH_DEVICE DT_LABEL(DT_INST(0, st_stm32_qspi_nor))
-#define FLASH_NAME "JEDEC QSPI-NOR"
+#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, st_stm32_qspi_nor))
+#define SPI_FLASH_NAME "JEDEC QSPI-NOR"
 #elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_ospi_nor), okay)
-#define FLASH_DEVICE DT_LABEL(DT_INST(0, st_stm32_ospi_nor))
-#define FLASH_NAME "JEDEC OSPI-NOR"
+#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, st_stm32_ospi_nor))
+#define SPI_FLASH_NAME "JEDEC OSPI-NOR"
 #else
 #error Unsupported flash driver
 #endif
 
 #if defined(CONFIG_BOARD_ADAFRUIT_FEATHER_STM32F405)
-#define FLASH_TEST_REGION_OFFSET 0xf000
+#define SPI_FLASH_TEST_REGION_OFFSET 0xf000
 #elif defined(CONFIG_BOARD_ARTY_A7_ARM_DESIGNSTART_M1) || \
 	defined(CONFIG_BOARD_ARTY_A7_ARM_DESIGNSTART_M3)
 /* The FPGA bitstream is stored in the lower 536 sectors of the flash. */
-#define FLASH_TEST_REGION_OFFSET \
+#define SPI_FLASH_TEST_REGION_OFFSET \
 	DT_REG_SIZE(DT_NODE_BY_FIXED_PARTITION_LABEL(fpga_bitstream))
 #elif defined(CONFIG_BOARD_NPCX9M6F_EVB) || \
 	defined(CONFIG_BOARD_NPCX7M6FB_EVB)
-#define FLASH_TEST_REGION_OFFSET 0x7F000
+#define SPI_FLASH_TEST_REGION_OFFSET 0x7F000
 #else
-#define FLASH_TEST_REGION_OFFSET 0xff000
+#define SPI_FLASH_TEST_REGION_OFFSET 0xff000
 #endif
-#define FLASH_SECTOR_SIZE        4096
+#define SPI_FLASH_SECTOR_SIZE        4096
 
 void main(void)
 {
@@ -52,14 +52,14 @@ void main(void)
 	const struct device *flash_dev;
 	int rc;
 
-	printf("\n" FLASH_NAME " SPI flash testing\n");
+	printf("\n" SPI_FLASH_NAME " SPI flash testing\n");
 	printf("==========================\n");
 
-	flash_dev = device_get_binding(FLASH_DEVICE);
+	flash_dev = device_get_binding(SPI_FLASH_DEVICE);
 
 	if (!flash_dev) {
 		printf("SPI flash driver %s was not found!\n",
-		       FLASH_DEVICE);
+		       SPI_FLASH_DEVICE);
 		return;
 	}
 
@@ -70,9 +70,11 @@ void main(void)
 	 */
 	printf("\nTest 1: Flash erase\n");
 
-	/* full flash erase if FLASH_TEST_REGION_OFFSET = 0  FLASH_SECTOR_SIZE = flash size */
-	rc = flash_erase(flash_dev, FLASH_TEST_REGION_OFFSET,
-			 FLASH_SECTOR_SIZE);
+	/* Full flash erase if SPI_FLASH_TEST_REGION_OFFSET = 0 and
+	 * SPI_FLASH_SECTOR_SIZE = flash size
+	 */
+	rc = flash_erase(flash_dev, SPI_FLASH_TEST_REGION_OFFSET,
+			 SPI_FLASH_SECTOR_SIZE);
 	if (rc != 0) {
 		printf("Flash erase failed! %d\n", rc);
 	} else {
@@ -82,14 +84,14 @@ void main(void)
 	printf("\nTest 2: Flash write\n");
 
 	printf("Attempting to write %zu bytes\n", len);
-	rc = flash_write(flash_dev, FLASH_TEST_REGION_OFFSET, expected, len);
+	rc = flash_write(flash_dev, SPI_FLASH_TEST_REGION_OFFSET, expected, len);
 	if (rc != 0) {
 		printf("Flash write failed! %d\n", rc);
 		return;
 	}
 
 	memset(buf, 0, len);
-	rc = flash_read(flash_dev, FLASH_TEST_REGION_OFFSET, buf, len);
+	rc = flash_read(flash_dev, SPI_FLASH_TEST_REGION_OFFSET, buf, len);
 	if (rc != 0) {
 		printf("Flash read failed! %d\n", rc);
 		return;
@@ -105,7 +107,7 @@ void main(void)
 		printf("Data read does not match data written!!\n");
 		while (rp < rpe) {
 			printf("%08x wrote %02x read %02x %s\n",
-			       (uint32_t)(FLASH_TEST_REGION_OFFSET + (rp - buf)),
+			       (uint32_t)(SPI_FLASH_TEST_REGION_OFFSET + (rp - buf)),
 			       *wp, *rp, (*rp == *wp) ? "match" : "MISMATCH");
 			++rp;
 			++wp;


### PR DESCRIPTION
This commits prefixes all the definitions
with SPI_  to be used by the sample application _samples/drivers/spi_flash_ 

In that spi_flash sample, the #define are identified with SPI_FLASH_xxx and this will avoid conflicts with other `FLASH_SECTOR_SIZE` used by any driver or hal elsewhere.
Typically stm32h7b3xx defines FLASH_SECTOR_SIZE for itself.

Signed-off-by: Francois Ramu <francois.ramu@st.com>