### PR TITLE
doc: coverage: fix coverage report generation instruction

### DIFF
--- a/doc/develop/test/coverage.rst
+++ b/doc/develop/test/coverage.rst
@@ -50,7 +50,7 @@ These steps will produce an HTML coverage report for a single application.
 
    .. zephyr-app-commands::
       :board: mps2_an385
-      :gen-args: -DCONFIG_COVERAGE=y
+      :gen-args: -DCONFIG_COVERAGE=y -DCONFIG_COVERAGE_DUMP=y
       :goals: build
       :compact:
 


### PR DESCRIPTION
Fix build step to enable CONFIG_COVERAGE_DUMP, otherwise we won't get coverage data dump required for next step.