### PR TITLE
samples: cc13x2_cc26x2: system_off: fix force state usage

### DIFF
--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -69,6 +69,12 @@ void main(void)
 	 */
 	pm_state_force(0u, &(struct pm_state_info){PM_STATE_SOFT_OFF, 0, 0});
 
+	/* Now we need to go sleep. This will let the idle thread runs and
+	 * the pm subsystem will use the forced state. To confirm that the
+	 * forced state is used, lets set the same timeout used previously.
+	 */
+	k_sleep(K_SECONDS(SLEEP_S));
+
 	printk("ERROR: System off failed\n");
 	while (true) {
 		/* spin to avoid fall-off behavior */


### PR DESCRIPTION
This is the same fix as the one introduced in 49520eea57 ("samples: nrf: system_off: Fix force state usage") for nRF boards.
Quoting original commit:
```
The sample cannot spin in an infinity loop because the idle thread
will not run and consequently the forced state will not be used.
```
Without this fix, the system doesn't enter `SOFT_OFF` state:
```
  *** Booting Zephyr OS build zephyr-v3.0.0-3495-ga456c5274614  ***

  cc1352r1_launchxl system off demo
  Busy-wait 5 s
  Sleep 2000 us (IDLE)
  Sleep 3 s (STANDBY)
  Entering system off (SHUTDOWN); press BUTTON1 to restart
  ERROR: System off failed
```