### PR TITLE
boards: stm32: use size helpers to describe size of storage partition

### DIFF
--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -150,7 +150,7 @@ zephyr_udc0: &usbotg_fs {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00008000>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
@@ -162,15 +162,15 @@ zephyr_udc0: &usbotg_fs {
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -180,7 +180,7 @@ arduino_i2c: &i2c1 {};
 		/* Set aside 32KiB for data at the end of the 192KiB flash */
 		storage_partition: partition@28000 {
 			label = "storage";
-			reg = <0x00028000 0x00008000>;
+			reg = <0x00028000 DT_SIZE_K(32)>;
 		};
 	};
 };

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -171,7 +171,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -182,20 +182,20 @@
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x0006C000>;
+			reg = <0x00020000 DT_SIZE_K(432)>;
 		};
 		slot1_partition: partition@8c000 {
 			label = "image-1";
-			reg = <0x0008C000 0x0006C000>;
+			reg = <0x0008C000 DT_SIZE_K(432)>;
 		};
 		scratch_partition: partition@f8000 {
 			label = "image-scratch";
-			reg = <0x000F8000 0x00004000>;
+			reg = <0x000F8000 DT_SIZE_K(16)>;
 		};
 
 		storage_partition: partition@fc000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000fc000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.dts
@@ -39,23 +39,23 @@
 		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x10000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x68000>;
+			reg = <0x00010000 DT_SIZE_K(416)>;
 		};
 		slot1_partition: partition@78000 {
 			label = "image-1";
-			reg = <0x00078000 0x68000>;
+			reg = <0x00078000 DT_SIZE_K(416)>;
 		};
 		scratch_partition: partition@e0000 {
 			label = "image-scratch";
-			reg = <0x000e0000 0x10000>;
+			reg = <0x000e0000 DT_SIZE_K(64)>;
 		};
 		storage_partition: partition@f0000 {
 			label = "storage";
-			reg = <0x000f0000 0x10000>;
+			reg = <0x000f0000 DT_SIZE_K(64)>;
 		};
 
 	};

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a_ns.dts
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a_ns.dts
@@ -41,18 +41,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00034000>;
+			reg = <0x00000000 DT_SIZE_K(208)>;
 			read-only;
 		};
 		/* Secure image primary slot */
 		slot0_partition: partition@34000 {
 			label = "image-0";
-			reg = <0x00034000 0x00040000>;
+			reg = <0x00034000 DT_SIZE_K(256)>;
 		};
 		/* Non-secure image primary slot */
 		slot1_partition: partition@74000 {
 			label = "image-1-nonsecure";
-			reg = <0x00074000 0x00080000>;
+			reg = <0x00074000 DT_SIZE_K(512)>;
 		};
 		/*
 		 * The flash starting at 0xEA000 and ending at
@@ -60,7 +60,7 @@
 		 */
 		storage_partition: partition@ea000 {
 			label = "storage";
-			reg = <0x000ea000 0x00001000>;
+			reg = <0x000ea000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
+++ b/boards/arm/blackpill_f401ce/blackpill_f401ce.dts
@@ -50,7 +50,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00008000>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
@@ -62,15 +62,15 @@
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
+++ b/boards/arm/blackpill_f411ce/blackpill_f411ce.dts
@@ -51,7 +51,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00008000>;
+			reg = <0x00000000 DT_SIZE_K(32)>;
 			read-only;
 		};
 
@@ -63,15 +63,15 @@
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -186,7 +186,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -197,12 +197,12 @@
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x000D8000>;
+			reg = <0x00020000 DT_SIZE_K(864)>;
 		};
 
 		scratch_partition: partition@f8000 {
 			label = "image-scratch";
-			reg = <0x000F8000 0x00004000>;
+			reg = <0x000F8000 DT_SIZE_K(16)>;
 		};
 	};
 };
@@ -284,7 +284,7 @@ zephyr_udc0: &usbotg_fs {
 
 			slot1_partition: partition@0 {
 				label = "image-1";
-				reg = <0x00000000 0x000d8000>;
+				reg = <0x00000000 DT_SIZE_K(864)>;
 				};
 
 			storage_partition: partition@d8000 {

--- a/boards/arm/google_kukui/google_kukui.dts
+++ b/boards/arm/google_kukui/google_kukui.dts
@@ -47,7 +47,7 @@
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
 			label = "storage";
-			reg = <0x0003e800 0x00001800>;
+			reg = <0x0003e800 DT_SIZE_K(6)>;
 		};
 	};
 };

--- a/boards/arm/legend/legend.dts
+++ b/boards/arm/legend/legend.dts
@@ -132,11 +132,11 @@
 
 			product_info: partition@0 {
 				label = "product-info";
-				reg = <0x00000000 0x1000>;
+				reg = <0x00000000 DT_SIZE_K(4)>;
 			};
 			led_das: partition@10000 {
 				label = "led-das";
-				reg = <0x00001000 0x0000f000>;
+				reg = <0x00001000 DT_SIZE_K(60)>;
 			};
 		};
 	};

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -192,7 +192,7 @@ grove_i2c: &i2c2 {};
 		/* 16KB (8x2kB pages) of storage at the end of the flash */
 		storage_partition: partition@3c000 {
 			label = "storage";
-			reg = <0x0003c000 0x00004000>;
+			reg = <0x0003c000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -130,7 +130,7 @@
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
 			label = "storage";
-			reg = <0x0003e800 0x00001800>;
+			reg = <0x0003e800 DT_SIZE_K(6)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -137,7 +137,7 @@
 		/* Set 2KB of storage at the end of 128KB flash */
 		storage_partition: partition@1f800 {
 			label = "storage";
-			reg = <0x0001f800 0x00000800>;
+			reg = <0x0001f800 DT_SIZE_K(2)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -179,7 +179,7 @@ zephyr_udc0: &usbotg_fs {
 		 */
 		storage_partition: partition@e0000 {
 			label = "storage";
-			reg = <0x000e0000 0x00020000>;
+			reg = <0x000e0000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -126,7 +126,7 @@
 		/* Set 6Kb of storage at the end of the 64Kb of flash */
 		storage_partition: partition@e800 {
 			label = "storage";
-			reg = <0x0000e800 0x00001800>;
+			reg = <0x0000e800 DT_SIZE_K(6)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -119,7 +119,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -130,15 +130,15 @@
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
+++ b/boards/arm/nucleo_f410rb/nucleo_f410rb.dts
@@ -119,7 +119,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -130,20 +130,20 @@
 		 */
 		storage_partition: partition@10000 {
 			label = "storage";
-			reg = <0x00010000 0x00010000>;
+			reg = <0x00010000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -172,32 +172,32 @@ zephyr_udc0: &usbotg_fs {
 		/* 64KB for bootloader */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
 		/* storage: 64KB for settings */
 		storage_partition: partition@10000 {
 			label = "storage";
-			reg = <0x00010000 0x00010000>;
+			reg = <0x00010000 DT_SIZE_K(64)>;
 		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00040000>;
+			reg = <0x00020000 DT_SIZE_K(256)>;
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@60000 {
 			label = "image-1";
-			reg = <0x00060000 0x00040000>;
+			reg = <0x00060000 DT_SIZE_K(256)>;
 		};
 
 		/* swap slot: 128KB */
 		scratch_partition: partition@a0000 {
 			label = "image-scratch";
-			reg = <0x000a0000 0x00020000>;
+			reg = <0x000a0000 DT_SIZE_K(128)>;
 		};
 
 	};

--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -133,7 +133,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -144,20 +144,20 @@
 		 */
 		storage_partition: partition@10000 {
 			label = "storage";
-			reg = <0x00010000 0x00010000>;
+			reg = <0x00010000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
+++ b/boards/arm/nucleo_f446ze/nucleo_f446ze.dts
@@ -181,7 +181,7 @@ zephyr_udc0: &usbotg_fs {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -192,20 +192,20 @@ zephyr_udc0: &usbotg_fs {
 		 */
 		storage_partition: partition@10000 {
 			label = "storage";
-			reg = <0x00010000 0x00010000>;
+			reg = <0x00010000 DT_SIZE_K(64)>;
 		};
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -200,7 +200,7 @@ zephyr_udc0: &usbotg_fs {
 		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x0 0x00010000>;
+			reg = <0x0 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -211,7 +211,7 @@ zephyr_udc0: &usbotg_fs {
 		 */
 		storage_partition: partition@10000 {
 			label = "storage";
-			reg = <0x00010000 0x00010000>;
+			reg = <0x00010000 DT_SIZE_K(64)>;
 		};
 
 		/*
@@ -223,7 +223,7 @@ zephyr_udc0: &usbotg_fs {
 		 */
 		slot0_partition: partition@40000 {
 			label = "image-0";
-			reg = <0x00040000 0x000C0000>;
+			reg = <0x00040000 DT_SIZE_K(768)>;
 		};
 
 		/*
@@ -231,7 +231,7 @@ zephyr_udc0: &usbotg_fs {
 		 */
 		slot1_partition: partition@100000 {
 			label = "image-1";
-			reg = <0x00100000 0x000C0000>;
+			reg = <0x00100000 DT_SIZE_K(768)>;
 		};
 
 		/*
@@ -239,7 +239,7 @@ zephyr_udc0: &usbotg_fs {
 		 */
 		scratch_partition: partition@1C0000 {
 			label = "image-scratch";
-			reg = <0x001C0000 0x00040000>;
+			reg = <0x001C0000 DT_SIZE_K(256)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -160,7 +160,7 @@
 		/* Set 2KB of storage at the end of 128KB flash */
 		storage_partition: partition@1f800 {
 			label = "storage";
-			reg = <0x0001f800 0x00000800>;
+			reg = <0x0001f800 DT_SIZE_K(2)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -176,21 +176,21 @@ zephyr_udc0: &usb {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x0000C000>;
+			reg = <0x00000000 DT_SIZE_K(48)>;
 			read-only;
 		};
 		slot0_partition: partition@C000 {
 			label = "image-0";
-			reg = <0x0000C000 0x00032000>;
+			reg = <0x0000C000 DT_SIZE_K(200)>;
 		};
 		slot1_partition: partition@3E000 {
 			label = "image-1";
-			reg = <0x0003E000 0x00032000>;
+			reg = <0x0003E000 DT_SIZE_K(200)>;
 		};
 		/* final 64KiB reserved for app storage partition */
 		storage_partition: partition@70000 {
 			label = "storage";
-			reg = <0x00070000 0x00010000>;
+			reg = <0x00070000 DT_SIZE_K(64)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -140,7 +140,7 @@
 		/* Set 4Kb of storage at the end of the 128Kb of flash */
 		storage_partition: partition@1f000 {
 			label = "storage";
-			reg = <0x0001f000 0x00001000>;
+			reg = <0x0001f000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -187,32 +187,32 @@ zephyr_udc0: &usbotg_fs {
 		/* 128KB for bootloader */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00020000>;
+			reg = <0x00000000 DT_SIZE_K(128)>;
 			read-only;
 		};
 
 		/* storage: 128KB for settings */
 		storage_partition: partition@20000 {
 			label = "storage";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {
 			label = "image-0";
-			reg = <0x00040000 0x00040000>;
+			reg = <0x00040000 DT_SIZE_K(256)>;
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@80000 {
 			label = "image-1";
-			reg = <0x00080000 0x00040000>;
+			reg = <0x00080000 DT_SIZE_K(256)>;
 		};
 
 		/* swap slot: 128KB */
 		scratch_partition: partition@c0000 {
 			label = "image-scratch";
-			reg = <0x000c0000 0x00020000>;
+			reg = <0x000c0000 DT_SIZE_K(128)>;
 		};
 
 	};

--- a/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
+++ b/boards/arm/nucleo_h753zi/nucleo_h753zi.dts
@@ -177,32 +177,32 @@ zephyr_udc0: &usbotg_fs {
 		/* 128KB for bootloader */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00020000>;
+			reg = <0x00000000 DT_SIZE_K(128)>;
 			read-only;
 		};
 
 		/* storage: 128KB for settings */
 		storage_partition: partition@20000 {
 			label = "storage";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 
 		/* application image slot: 256KB */
 		slot0_partition: partition@40000 {
 			label = "image-0";
-			reg = <0x00040000 0x00040000>;
+			reg = <0x00040000 DT_SIZE_K(256)>;
 		};
 
 		/* backup slot: 256KB */
 		slot1_partition: partition@80000 {
 			label = "image-1";
-			reg = <0x00080000 0x00040000>;
+			reg = <0x00080000 DT_SIZE_K(256)>;
 		};
 
 		/* swap slot: 128KB */
 		scratch_partition: partition@c0000 {
 			label = "image-scratch";
-			reg = <0x000c0000 0x00020000>;
+			reg = <0x000c0000 DT_SIZE_K(128)>;
 		};
 
 	};

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -108,7 +108,7 @@
 		/* Set 2KB of storage at the end of 512KB flash */
 		storage_partition: partition@7f800 {
 			label = "storage";
-			reg = <0x0007f800 0x00000800>;
+			reg = <0x0007f800 DT_SIZE_K(2)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
+++ b/boards/arm/nucleo_l412rb_p/nucleo_l412rb_p.dts
@@ -129,7 +129,7 @@
 		 */
 		storage_partition: partition@1c276 {
 			label = "storage";
-			reg = <0x0001c276 0x00004000>;
+			reg = <0x0001c276 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
+++ b/boards/arm/nucleo_l432kc/nucleo_l432kc.dts
@@ -118,7 +118,7 @@
 		 */
 		storage_partition: partition@3c000 {
 			label = "storage";
-			reg = <0x0003c000 0x00004000>;
+			reg = <0x0003c000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
+++ b/boards/arm/nucleo_l433rc_p/nucleo_l433rc_p.dts
@@ -135,7 +135,7 @@
 		 */
 		storage_partition: partition@3c000 {
 			label = "storage";
-			reg = <0x0003c000 0x00004000>;
+			reg = <0x0003c000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
+++ b/boards/arm/nucleo_l4r5zi/nucleo_l4r5zi.dts
@@ -188,7 +188,7 @@ zephyr_udc0: &usbotg_fs {
 		/* Reserve last 16KiB for property storage */
 		storage_partition: partition@1FB000 {
 			label = "storage";
-			reg = <0x001FB000 0x00004000>;
+			reg = <0x001FB000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -204,23 +204,23 @@ zephyr_udc0: &usb {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0xc000>;
+			reg = <0x00000000 DT_SIZE_K(48)>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000c000 0x5a000>;
+			reg = <0x0000c000 DT_SIZE_K(360)>;
 		};
 		slot1_partition: partition@66000 {
 			label = "image-1";
-			reg = <0x00066000 0x5a000>;
+			reg = <0x00066000 DT_SIZE_K(360)>;
 		};
 		scratch_partition: partition@c0000 {
 			label = "image-scratch";
-			reg = <0x000c0000 0x4000>;
+			reg = <0x000c0000 DT_SIZE_K(16)>;
 		};
 		storage_partition: partition@c4000 {
 			label = "storage";
-			reg = <0x000c4000 0x2000>;
+			reg = <0x000c4000 DT_SIZE_K(8)>;
 		};
 
 	};

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -193,7 +193,7 @@
 		 */
 		storage_partition: partition@3c000 {
 			label = "storage";
-			reg = <0x0003c000 0x00004000>;
+			reg = <0x0003c000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -189,7 +189,7 @@ zephyr_udc0: &usbotg_fs {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 
@@ -200,20 +200,20 @@ zephyr_udc0: &usbotg_fs {
 
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x0006C000>;
+			reg = <0x00020000 DT_SIZE_K(432)>;
 		};
 		slot1_partition: partition@8c000 {
 			label = "image-1";
-			reg = <0x0008C000 0x0006C000>;
+			reg = <0x0008C000 DT_SIZE_K(432)>;
 		};
 		scratch_partition: partition@f8000 {
 			label = "image-scratch";
-			reg = <0x000F8000 0x00006000>;
+			reg = <0x000F8000 DT_SIZE_K(24)>;
 		};
 
 		storage_partition: partition@fc000 {
 			label = "storage";
-			reg = <0x000fc000 0x00004000>;
+			reg = <0x000fc000 DT_SIZE_K(24)>;
 		};
 	};
 };

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -92,7 +92,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00002000>;
+			reg = <0x00000000 DT_SIZE_K(8)>;
 			read-only;
 		};
 
@@ -103,15 +103,15 @@
 
 		slot0_partition: partition@4000 {
 			label = "image-0";
-			reg = <0x00004000 0x00004000>;
+			reg = <0x00004000 DT_SIZE_K(16)>;
 		};
 		slot1_partition: partition@8000 {
 			label = "image-1";
-			reg = <0x00008000 0x00004000>;
+			reg = <0x00008000 DT_SIZE_K(16)>;
 		};
 		scratch_partition: partition@c000 {
 			label = "image-scratch";
-			reg = <0x0000C000 0x00004000>;
+			reg = <0x0000C000 DT_SIZE_K(16)>;
 		};
 	};
 };

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -182,7 +182,7 @@ zephyr_udc0: &usb {
 		/* Set 6Kb of storage at the end of the 256Kb of flash */
 		storage_partition: partition@3e800 {
 			label = "storage";
-			reg = <0x0003e800 0x00001800>;
+			reg = <0x0003e800 DT_SIZE_K(6)>;
 		};
 	};
 };

--- a/boards/arm/stm32f401_mini/stm32f401_mini.dts
+++ b/boards/arm/stm32f401_mini/stm32f401_mini.dts
@@ -49,20 +49,20 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00010000>;
+			reg = <0x00000000 DT_SIZE_K(64)>;
 			read-only;
 		};
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x00020000 0x00020000>;
+			reg = <0x00020000 DT_SIZE_K(128)>;
 		};
 		slot1_partition: partition@40000 {
 			label = "image-1";
-			reg = <0x00040000 0x00020000>;
+			reg = <0x00040000 DT_SIZE_K(128)>;
 		};
 		scratch_partition: partition@60000 {
 			label = "image-scratch";
-			reg = <0x00060000 0x00020000>;
+			reg = <0x00060000 DT_SIZE_K(128)>;
 		};
 	};
 };

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -175,7 +175,7 @@ zephyr_udc0: &usbotg_fs {
 
 			slot1_partition: partition@0 {
 				label = "image-1";
-				reg = <0x00000000 0x000a0000>;
+				reg = <0x00000000 DT_SIZE_K(640)>;
 				};
 
 			storage_partition: partition@a0000 {

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -179,7 +179,7 @@ arduino_serial: &usart6 {};
 
 			slot1_partition: partition@0 {
 				label = "image-1";
-				reg = <0x00000000 0x001a0000>;
+				reg = <0x00000000 DT_SIZE_K(1664)>;
 				};
 
 			storage_partition: partition@1a0000 {

--- a/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
+++ b/boards/arm/stm32h747i_disco/stm32h747i_disco_m7.dts
@@ -91,7 +91,7 @@
 		/* Set 2KB of storage at the end of first 1MB flash */
 		storage_partition: partition@ff800 {
 			label = "storage";
-			reg = <0x000ff800 0x00000800>;
+			reg = <0x000ff800 DT_SIZE_K(2)>;
 		};
 	};
 };

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
@@ -56,7 +56,7 @@
 		/* 2KB at the end of 512KB flash is set for storage */
 		storage_partition: partition@7f800 {
 			   label = "storage";
-			   reg = <0x0007f800 0x00000800>;
+			   reg = <0x0007f800 DT_SIZE_K(2)>;
 		   };
 	};
 };

--- a/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
@@ -41,7 +41,7 @@
 
 			   partition@0 {
 			       label = "storage";
-			       reg = <0x01000000 0x00800000>;
+			       reg = <0x01000000 DT_SIZE_M(8)>;
 			   };
 		};
 	};

--- a/samples/tfm_integration/psa_crypto/boards/stm32l562e_dk_ns.overlay
+++ b/samples/tfm_integration/psa_crypto/boards/stm32l562e_dk_ns.overlay
@@ -27,18 +27,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00019000>;
+			reg = <0x00000000 DT_SIZE_K(100)>;
 			read-only;
 		};
 		/* Secure image primary slot */
 		slot0_partition: partition@19000 {
 			label = "image-0";
-			reg = <0x00019000 0x0003C000>;
+			reg = <0x00019000 DT_SIZE_K(240)>;
 		};
 		/* Non-secure image primary slot */
 		slot1_partition: partition@55000 {
 			label = "image-1";
-			reg = <0x00055000 0x0002A000>;
+			reg = <0x00055000 DT_SIZE_K(168)>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at
@@ -46,7 +46,7 @@
 		 */
 		storage_partition: partition@7f000 {
 			label = "storage";
-			reg = <0x0007F000 0x00001000>;
+			reg = <0x0007F000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/nucleo_l552ze_q_ns.overlay
@@ -29,18 +29,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00014000>;
+			reg = <0x00000000 DT_SIZE_K(80)>;
 			read-only;
 		};
 		/* Secure image primary slot */
 		slot0_partition: partition@14000 {
 			label = "image-0";
-			reg = <0x00014000 0x0002D000>;
+			reg = <0x00014000 DT_SIZE_K(180)>;
 		};
 		/* Non-secure image primary slot */
 		slot1_partition: partition@41000 {
 			label = "image-1";
-			reg = <0x00041000 0x00009000>;
+			reg = <0x00041000 DT_SIZE_K(36)>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at
@@ -48,7 +48,7 @@
 		 */
 		storage_partition: partition@7f000 {
 			label = "storage";
-			reg = <0x0007F000 0x00001000>;
+			reg = <0x0007F000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/samples/tfm_integration/tfm_ipc/boards/stm32l562e_dk_ns.overlay
+++ b/samples/tfm_integration/tfm_ipc/boards/stm32l562e_dk_ns.overlay
@@ -27,18 +27,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00019000>;
+			reg = <0x00000000 DT_SIZE_K(100)>;
 			read-only;
 		};
 		/* Secure image primary slot */
 		slot0_partition: partition@19000 {
 			label = "image-0";
-			reg = <0x00019000 0x0003C000>;
+			reg = <0x00019000 DT_SIZE_K(240)>;
 		};
 		/* Non-secure image primary slot */
 		slot1_partition: partition@55000 {
 			label = "image-1";
-			reg = <0x00055000 0x0002A000>;
+			reg = <0x00055000 DT_SIZE_K(168)>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at
@@ -46,7 +46,7 @@
 		 */
 		storage_partition: partition@7f000 {
 			label = "storage";
-			reg = <0x0007F000 0x00001000>;
+			reg = <0x0007F000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/tests/arch/arm/arm_thread_swap_tz/boards/nucleo_l552ze_q_ns.overlay
+++ b/tests/arch/arm/arm_thread_swap_tz/boards/nucleo_l552ze_q_ns.overlay
@@ -27,18 +27,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00014000>;
+			reg = <0x00000000 DT_SIZE_K(80)>;
 			read-only;
 		};
 		/* Secure image primary slot */
 		slot0_partition: partition@00014000 {
 			label = "image-0";
-			reg = <0x00014000 0x0002A000>;
+			reg = <0x00014000 DT_SIZE_K(168)>;
 		};
 		/* Non-secure image primary slot */
 		slot1_partition: partition@41000 {
 			label = "image-1";
-			reg = <0x00041000 0x00009000>;
+			reg = <0x00041000 DT_SIZE_K(36)>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at
@@ -46,7 +46,7 @@
 		 */
 		storage_partition: partition@7F000 {
 			label = "storage";
-			reg = <0x0007F000 0x00001000>;
+			reg = <0x0007F000 DT_SIZE_K(4)>;
 		};
 	};
 };

--- a/tests/arch/arm/arm_thread_swap_tz/boards/stm32l562e_dk_ns.overlay
+++ b/tests/arch/arm/arm_thread_swap_tz/boards/stm32l562e_dk_ns.overlay
@@ -27,18 +27,18 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x00000000 0x00019000>;
+			reg = <0x00000000 DT_SIZE_K(100)>;
 			read-only;
 		};
 		/* Secure image primary slot */
 		slot0_partition: partition@19000 {
 			label = "image-0";
-			reg = <0x00019000 0x0003C000>;
+			reg = <0x00019000 DT_SIZE_K(240)>;
 		};
 		/* Non-secure image primary slot */
 		slot1_partition: partition@55000 {
 			label = "image-1";
-			reg = <0x00055000 0x0002A000>;
+			reg = <0x00055000 DT_SIZE_K(168)>;
 		};
 		/*
 		 * The flash starting at 0x7F000 and ending at
@@ -46,7 +46,7 @@
 		 */
 		storage_partition: partition@7f000 {
 			label = "storage";
-			reg = <0x0007F000 0x00001000>;
+			reg = <0x0007F000 DT_SIZE_K(4)>;
 		};
 	};
 };


### PR DESCRIPTION
The goal of this commit is to update existing STM32 boards descriptions
to use these size "DT_SIZE" macros to enhance readability. To realize this
i used a python script, which will detect the STM32 Boards /zephyr/board/arm,
and then will update in the dts files the partition description using
"DT_SIZE_K" and "DT_SIZE_M" macros.
Check manually and modify in .overlay files in samples and tests.

Signed-off-by: TLIG Dhaou <dhaou.tlig-ext@st.com>