### PR TITLE
doc: k_sleep does not take raw integers

### DIFF
--- a/doc/services/settings/index.rst
+++ b/doc/services/settings/index.rst
@@ -274,7 +274,7 @@ up from where it was before restart.
 
         printk("foo: %d\n", foo_val);
 
-        k_sleep(1000);
+        k_msleep(1000);
         sys_reboot(SYS_REBOOT_COLD);
     }
 


### PR DESCRIPTION
Using k_msleep seems easier than k_sleep(K_MSEC(1000));

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>