### PR TITLE
Revert "ci: run twister with CONFIG_LEGACY_INCLUDE_PATH=n"

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -110,7 +110,7 @@ jobs:
           if [ -s testplan.csv ]; then
             echo "::set-output name=report_needed::1";
             # Full twister but with options based on changes
-            ./scripts/twister --inline-logs -M -N -v --load-tests testplan.csv --retry-failed 2 -x "CONFIG_LEGACY_INCLUDE_PATH=n"
+            ./scripts/twister --inline-logs -M -N -v --load-tests testplan.csv --retry-failed 2
           else
             # if nothing is run, skip reporting step
             echo "::set-output name=report_needed::0";

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -86,7 +86,7 @@ jobs:
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           mkdir -p coverage/reports
-          ./scripts/twister -N -v --filter runnable -p ${{ matrix.platform }} --coverage -T tests -x "CONFIG_LEGACY_INCLUDE_PATH=n"
+          ./scripts/twister -N -v --filter runnable -p ${{ matrix.platform }} --coverage -T tests
 
       - name: Generate Coverage Report
         run: |

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -131,7 +131,7 @@ jobs:
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
-      TWISTER_COMMON: ' --inline-logs -v -N -M --retry-failed 3 -x "CONFIG_LEGACY_INCLUDE_PATH=n" '
+      TWISTER_COMMON: ' --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all --no-skipped-report'
       PR_OPTIONS: ' --clobber-output --integration --no-skipped-report'
       PUSH_OPTIONS: ' --clobber-output -M --no-skipped-report'


### PR DESCRIPTION
This reverts commit e4ebba8025978861a694a22e505af758ace15dd9.

This is still not ready. We have lots of usages of old include paths.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
