### PR TITLE
drivers: serial: uart_stm32: init uses tx/rx swap

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -473,12 +473,6 @@ static int uart_stm32_configure(const struct device *dev,
 		data->baud_rate = cfg->baudrate;
 	}
 
-#ifdef LL_USART_TXRX_SWAPPED
-	if (config->tx_rx_swap) {
-		LL_USART_SetTXRXSwap(config->usart, LL_USART_TXRX_SWAPPED);
-	}
-#endif
-
 	LL_USART_Enable(config->usart);
 	return 0;
 };
@@ -1611,6 +1605,12 @@ static int uart_stm32_init(const struct device *dev)
 	if (config->single_wire) {
 		LL_USART_EnableHalfDuplex(config->usart);
 	}
+
+#ifdef LL_USART_TXRX_SWAPPED
+	if (config->tx_rx_swap) {
+		LL_USART_SetTXRXSwap(config->usart, LL_USART_TXRX_SWAPPED);
+	}
+#endif
 
 	LL_USART_Enable(config->usart);
 


### PR DESCRIPTION
Previously, the uart_stm32 driver was extended in #44487 to support swapping the tx and rx pins of supported STM32 UART peripherals. However, the original change only applied this configuration during the call to the `uart_stm32_configure()` function. This has now been added to the` uart_stm32_init()` function to ensure this behavior on startup for ports like the virtual com port. 

The application of this setting during the `uart_stm32_configure()` call has been retained for backwards compatibility, completeness, and future extension of the uart API to support this feature.