### PR TITLE
doc: SETTINGS_REGISTER_STATIC got renamed

### DIFF
--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -125,7 +125,7 @@ struct settings_handler {
 /**
  * @struct settings_handler_static
  * Config handlers without the node element, used for static handlers.
- * These are registered using a call to SETTINGS_REGISTER_STATIC().
+ * These are registered using a call to SETTINGS_STATIC_HANDLER_DEFINE().
  */
 struct settings_handler_static {
 


### PR DESCRIPTION
Renaming this reference got forgotten in 5f19c8160ade6d5ef5ef5e440e86cf4468210542 [subsys/settings: Update bluetooth module]

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>