### PR TITLE
doc: Fix settings_handler_static::h_export example

### DIFF
--- a/doc/services/settings/index.rst
+++ b/doc/services/settings/index.rst
@@ -199,7 +199,7 @@ export functionality, for example, writing to the shell console).
     }
 
     static int foo_settings_export(int (*storage_func)(const char *name,
-                                                       void *value,
+                                                       const void *value,
                                                        size_t val_len))
     {
         return storage_func("foo/bar", &foo_val, sizeof(foo_val));


### PR DESCRIPTION
Callback takes a const data pointer.

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>