### PR TITLE
pm: device: improved handling of power up failures

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -30,6 +30,8 @@ struct device;
 enum pm_device_flag {
 	/** Indicate if the device is busy or not. */
 	PM_DEVICE_FLAG_BUSY,
+	/** Indicate if the device failed to power up. */
+	PM_DEVICE_FLAG_TURN_ON_FAILED,
 	/**
 	 * Indicates whether or not the device is capable of waking the system
 	 * up.

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -75,6 +75,11 @@ int pm_device_action_run(const struct device *dev,
 		 */
 		switch (action) {
 		case PM_DEVICE_ACTION_TURN_ON:
+			/* Store an error flag when the transition explicitly fails */
+			if (ret != -ENOTSUP) {
+				atomic_set_bit(&pm->flags, PM_DEVICE_FLAG_TURN_ON_FAILED);
+			}
+			__fallthrough;
 		case PM_DEVICE_ACTION_TURN_OFF:
 			pm->state = action_target_state[action];
 			break;
@@ -85,6 +90,10 @@ int pm_device_action_run(const struct device *dev,
 	}
 
 	pm->state = action_target_state[action];
+	/* Power up failure flag is no longer relevant */
+	if (action == PM_DEVICE_ACTION_TURN_OFF) {
+		atomic_clear_bit(&pm->flags, PM_DEVICE_FLAG_TURN_ON_FAILED);
+	}
 
 	return 0;
 }

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -142,6 +142,12 @@ int pm_device_runtime_get(const struct device *dev)
 		if (ret != 0) {
 			goto unlock;
 		}
+		/* Check if powering up this device failed */
+		if (atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_TURN_ON_FAILED)) {
+			(void)pm_device_runtime_put(PM_DOMAIN(pm));
+			ret = -EAGAIN;
+			goto unlock;
+		}
 	}
 
 	pm->usage++;


### PR DESCRIPTION
Improve the handling of devices on power domains that fail to transition properly when powering up.
The fact that a device has failed to power up is now stored as a flag in a PM struct.

`pm_device_runtime_get` now checks that the provided device has correctly powered up before proceeding to run additional actions. This makes its behaviour a bit more sane for failing devices, while still allowing the following scenario to work:
* Power domain with devices A and B
* `pm_device_runtime_get(&A);`
* Power domain turned on
* `PM_DEVICE_ACTION_TURN_ON` on device B fails

The power domain is left on until `pm_device_runtime_put(&A);` is run, and A can be used even though device B failed.
A call to `pm_device_runtime_get(&B);` before the domain is turned off will fail immediately due to the previous failure to power up.