### PR TITLE
west.yaml: hal_stm32: STM32Cube dts pin update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -132,7 +132,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: e31e840271efc9939c8650598e169aa314208bdd
+      revision: 1131096de36fdeb4cfd6b1d431b4017d0da5f196
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Take the new hal_stm32 DTS which provides octospi interface
to stm32u5 stm32l5, stm32l4+ and stm32h7

Signed-off-by: Francois Ramu <francois.ramu@st.com>