### PR TITLE
boards: lpcxpresso55s69: fix JLink device name

### DIFF
--- a/boards/arm/lpcxpresso55s69/board.cmake
+++ b/boards/arm/lpcxpresso55s69/board.cmake
@@ -9,10 +9,10 @@
 ## until then jlink can be used or copy image to storage
 
 if(CONFIG_BOARD_LPCXPRESSO55S69_CPU0)
-board_runner_args(jlink "--device=LPC55S69_core0")
+board_runner_args(jlink "--device=LPC55S69_M33_0")
 endif()
 if(CONFIG_BOARD_LPCXPRESSO55S69_CPU1)
-board_runner_args(jlink "--device=LPC55S69_core1")
+board_runner_args(jlink "--device=LPC55S69_M33_1")
 endif()
 
 board_runner_args(pyocd "--target=lpc55s69")


### PR DESCRIPTION
Incorrect device name for JLink runner causing wrong device selected,
causing issues flashing the device when flash size is large.

Resolves #45518