### PR TITLE
doc: services: storage: add flash_img section

### DIFF
--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -1,6 +1,7 @@
 # Each line should contain the regular expression of a known Sphinx warning
 # that should be filtered out
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: dma_config'.*
+.*Duplicate C declaration.*\n.*'\.\. c:.*:: flash_img_check'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: zsock_fd_set'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: net_if_mcast_monitor'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: fs_statvfs'.*

--- a/doc/services/storage/flash_img/flash_img.rst
+++ b/doc/services/storage/flash_img/flash_img.rst
@@ -1,0 +1,13 @@
+.. _flash_img_api:
+
+Flash Image
+###########
+
+The flash image API as part of the Device Firmware Upgrade (DFU) subsystem
+provides an abstraction on top of Flash Stream to simplify writing firmware
+image chunks to flash.
+
+API Reference
+*************
+
+.. doxygengroup:: flash_img_api

--- a/doc/services/storage/index.rst
+++ b/doc/services/storage/index.rst
@@ -9,5 +9,6 @@ Storage
    nvs/nvs.rst
    disk/access.rst
    flash_map/flash_map.rst
+   flash_img/flash_img.rst
    fcb/fcb.rst
    stream/stream_flash.rst

--- a/include/zephyr/dfu/flash_img.h
+++ b/include/zephyr/dfu/flash_img.h
@@ -5,10 +5,24 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/**
+ * @file
+ * @brief Flash image header file
+ *
+ * This header file declares prototypes for the flash image APIs used for DFU.
+ */
+
 #ifndef ZEPHYR_INCLUDE_DFU_FLASH_IMG_H_
 #define ZEPHYR_INCLUDE_DFU_FLASH_IMG_H_
 
 #include <zephyr/storage/stream_flash.h>
+
+/**
+ * @brief Abstraction layer to write firmware images to flash
+ *
+ * @defgroup flash_img_api Flash image API
+ * @{
+ */
 
 #ifdef __cplusplus
 extern "C" {
@@ -99,5 +113,9 @@ int flash_img_check(struct flash_img_context *ctx,
 #ifdef __cplusplus
 }
 #endif
+
+/**
+ * @}
+ */
 
 #endif	/* ZEPHYR_INCLUDE_DFU_FLASH_IMG_H_ */


### PR DESCRIPTION
Doxygen comments were existing, but they were not rendered anywhere in the docs.

The code is located in the DFU subsystem, but I think it makes sense to document it under storage, next to similar flash-related APIs.
