### PR TITLE
tests/benchmarks/sys_kernel: Use K_THREAD_STACK_EXTERN in header file

### DIFF
--- a/tests/benchmarks/sys_kernel/src/syskernel.h
+++ b/tests/benchmarks/sys_kernel/src/syskernel.h
@@ -22,8 +22,8 @@
 #endif
 
 
-extern K_THREAD_STACK_DEFINE(thread_stack1, STACK_SIZE);
-extern K_THREAD_STACK_DEFINE(thread_stack2, STACK_SIZE);
+K_THREAD_STACK_EXTERN(thread_stack1);
+K_THREAD_STACK_EXTERN(thread_stack2);
 extern struct k_thread thread_data1;
 extern struct k_thread thread_data2;
 


### PR DESCRIPTION
K_THREAD_STACK_DEFINE is not correct in a header file as it may conflict
with K_THREAD_STACK_DEFINE usage in the source file.

Signed-off-by: Keith Packard <keithp@keithp.com>