### PR TITLE
test: cmsis_rtos_v2: Initialize versionInfos in case get_version_chec…

### DIFF
--- a/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
@@ -63,7 +63,20 @@ void lock_unlock_check(const void *arg)
 
 void test_kernel_apis(void)
 {
-	versionInfo version, version_irq;
+	versionInfo version = {
+		.os_info = {
+			.api = 0xfefefefe,
+			.kernel = 0xfdfdfdfd,
+		},
+		.info = "local function call info is uninitialized"
+	};
+	versionInfo version_irq = {
+		.os_info = {
+			.api = 0xfcfcfcfc,
+			.kernel = 0xfbfbfbfb,
+		},
+		.info = "irq_offload function call info is uninitialized"
+	};
 
 	get_version_check(&version);
 	irq_offload(get_version_check, (const void *)&version_irq);


### PR DESCRIPTION
…k fails

get_version_check will leave the version info unchanged if osKernelGetInfo
fails. This lead to a compiler warning when those results were used.

Initialize the values with data that will cause a failure that should be
easily diagnosed.

Signed-off-by: Keith Packard <keithp@keithp.com>