### PR TITLE
tests: ec_host_cmd: Make sure expected_dut_to_host fits in buffer

### DIFF
--- a/tests/subsys/mgmt/ec_host_cmd/src/main.c
+++ b/tests/subsys/mgmt/ec_host_cmd/src/main.c
@@ -62,7 +62,6 @@ struct tx_structure {
 	struct ec_host_cmd_response_header header;
 	union {
 		struct ec_response_add add;
-		struct ec_response_too_big too_big;
 		uint8_t raw[0];
 	};
 } __packed * const expected_dut_to_host = (void *)&expected_dut_to_host_buffer;


### PR DESCRIPTION
If struct ec_response_too_big is too large, then the size of 'struct
tx_structure' is larger than the buffer that expected_dut_to_host
references, leading the compiler to generate a warning about the
possibility of buffer overflow.

Shrink the size of 'struct ec_response_too_big' so that the outer struct
fits within the 256 byte buffer.

This was caught when using GCC 11.3.0 building the test for native_posix.

Signed-off-by: Keith Packard <keithp@keithp.com>