### PR TITLE
drivers: display: stm32_ltdc: fix set orientation API

### DIFF
--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -129,16 +129,13 @@ static int stm32_ltdc_set_pixel_format(const struct device *dev,
 static int stm32_ltdc_set_orientation(const struct device *dev,
 				const enum display_orientation orientation)
 {
-	int err;
+	ARG_UNUSED(dev);
 
-	switch (orientation) {
-	case DISPLAY_ORIENTATION_NORMAL:
-		err = 0;
-	default:
-		err = -ENOTSUP;
+	if (orientation == DISPLAY_ORIENTATION_NORMAL) {
+		return 0;
 	}
 
-	return err;
+	return -ENOTSUP;
 }
 
 static void stm32_ltdc_get_capabilities(const struct device *dev,


### PR DESCRIPTION
Fixes orientation set return value for normal display orientation.
Refactors invalid `switch` into `if` statement.