### PR TITLE
shell: check echo flag in z_shell_cursor_in_empty_line()

### DIFF
--- a/subsys/shell/shell_ops.c
+++ b/subsys/shell/shell_ops.c
@@ -50,8 +50,10 @@ static inline bool full_line_cmd(const struct shell *shell)
 /* Function returns true if cursor is at beginning of an empty line. */
 bool z_shell_cursor_in_empty_line(const struct shell *shell)
 {
-	return ((shell->ctx->cmd_buff_pos + z_shell_strlen(shell->ctx->prompt))
-			% shell->ctx->vt100_ctx.cons.terminal_wid == 0U);
+	return (((shell->ctx->cmd_buff_pos * shell->ctx->cfg.flags.echo) +
+		 z_shell_strlen(shell->ctx->prompt)) %
+			shell->ctx->vt100_ctx.cons.terminal_wid ==
+		0U);
 }
 
 void z_shell_op_cond_next_line(const struct shell *shell)


### PR DESCRIPTION
If the echo flag is disabled the cmd_buff isn't printed and the
characters in it must not be counted in this function.

Signed-off-by: Gerhard Jörges <joerges@metratec.com>