### PR TITLE
Create GitHub workflow for snapshotting open bugs

### DIFF
--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -1,0 +1,57 @@
+# Copyright (c) 2021, 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Make a snapshot of open bugs as a python pickle file, compressed
+# using xz. Upload the xz file to Amazon S3.
+
+name: Bug Snapshot
+
+on:
+  workflow_dispatch:
+    branches: [ main ]
+
+jobs:
+  make_bugs_pickle:
+    name: Make bugs pickle
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install Python dependencies
+      run: |
+        sudo pip3 install -U setuptools wheel pip
+        pip3 install -U pygithub
+
+    - name: Snapshot bugs
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        BUGS_PICKLE_FILENAME="zephyr-bugs-$(date -I).pickle.xz"
+        BUGS_PICKLE_PATH="${RUNNER_TEMP}/${BUGS_PICKLE_FILENAME}"
+
+        set -euo pipefail
+        python3 scripts/make_bugs_pickle.py | xz > ${BUGS_PICKLE_PATH}
+
+        echo "BUGS_PICKLE_FILENAME=${BUGS_PICKLE_FILENAME}" >> ${GITHUB_ENV}
+        echo "BUGS_PICKLE_PATH=${BUGS_PICKLE_PATH}" >> ${GITHUB_ENV}
+
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_BUILDS_ZEPHYR_BUG_SNAPSHOT_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_BUILDS_ZEPHYR_BUG_SNAPSHOT_SECRET_ACCESS_KEY }}
+        aws-region: us-east-1
+
+    - name: Upload to AWS S3
+      run: |
+        PUBLISH_BUCKET="builds.zephyrproject.org"
+        PUBLISH_DOMAIN="builds.zephyrproject.io"
+        PUBLISH_ROOT="${{ github.event.repository.name }}/bug-snapshot"
+
+        PUBLISH_UPLOAD_URI="s3://${PUBLISH_BUCKET}/${PUBLISH_ROOT}/${BUGS_PICKLE_FILENAME}"
+        PUBLISH_DOWNLOAD_URI="https://${PUBLISH_DOMAIN}/${PUBLISH_ROOT}/${BUGS_PICKLE_FILENAME}"
+
+        aws s3 cp --quiet ${BUGS_PICKLE_PATH} ${PUBLISH_UPLOAD_URI}
+        echo "Bug pickle is available at: ${PUBLISH_DOWNLOAD_URI}" >> ${GITHUB_STEP_SUMMARY}

--- a/scripts/github_helpers.py
+++ b/scripts/github_helpers.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+'''
+Generic GitHub helper routines which may be useful to other scripts.
+
+This file is not meant to be run directly, but rather to be imported
+as a module from other scripts.
+'''
+
+# Note that the type annotations are not currently checked by mypy.
+# Unless that changes, they serve as documentation, rather than
+# guarantees from a type checker.
+
+# stdlib
+import getpass
+import os
+import netrc
+import sys
+from typing import Dict
+
+# third party
+import github
+
+def get_github_credentials(ask: bool = True) -> Dict[str, str]:
+    '''Get credentials for constructing a github.Github object.
+
+    This function tries to get github.com credentials from these
+    places, in order:
+
+    1. a ~/.netrc file, if one exists
+    2. a GITHUB_TOKEN environment variable
+    3. if the 'ask' kwarg is truthy, from the user on the
+       at the command line.
+
+    On failure, RuntimeError is raised.
+
+    Scripts often need credentials because anonym access to
+    api.github.com is rate limited more aggressively than
+    authenticated access. Scripts which use anonymous access are
+    therefore more likely to fail due to rate limiting.
+
+    The return value is a dict which can be passed to the
+    github.Github constructor as **kwargs.
+
+    :param ask: if truthy, the user will be prompted for credentials
+                if none are found from other sources
+    '''
+
+    try:
+        nrc = netrc.netrc()
+    except (FileNotFoundError, netrc.NetrcParseError):
+        nrc = None
+
+    if nrc is not None:
+        auth = nrc.authenticators('github.com')
+        if auth is not None:
+            return {'login_or_token': auth[0], 'password': auth[2]}
+
+    token = os.environ.get('GITHUB_TOKEN')
+    if token:
+        return {'login_or_token': token}
+
+    if ask:
+        print('Missing GitHub credentials:\n'
+              '~/.netrc file not found or has no github.com credentials, '
+              'and GITHUB_TOKEN is not set in the environment. '
+              'Please give your GitHub token.',
+              file=sys.stderr)
+        token = getpass.getpass('token: ')
+        return {'login_or_token': token}
+
+    raise RuntimeError('no credentials found')
+
+def get_github_object(ask: bool = True) -> github.Github:
+    '''Get a github.Github object, created with credentials.
+
+    :param ask: passed to get_github_credentials()
+    '''
+    return github.Github(**get_github_credentials())

--- a/scripts/make_bugs_pickle.py
+++ b/scripts/make_bugs_pickle.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# stdlib
+import argparse
+import pickle
+import sys
+from pathlib import Path
+from typing import BinaryIO, List
+
+# third party
+from github.Issue import Issue
+
+# other zephyr/scripts modules
+from github_helpers import get_github_object
+
+# Note that type annotations are not currently statically checked, and
+# should only be considered documentation.
+
+def parse_args() -> argparse.Namespace:
+    '''Parse command line arguments.'''
+    parser = argparse.ArgumentParser(
+        description='''
+A helper script which loads all open bugs in the
+zephyrproject-rtos/zephyr repository using the GitHub API, and writes
+them to a new pickle file as a list of github.Issue.Issue objects.
+
+For more information, see:
+
+  - GitHub API: https://docs.github.com/en/rest
+  - github.Issue.Issue:
+    https://pygithub.readthedocs.io/en/latest/github_objects/Issue.html
+  - pickle: https://docs.python.org/3/library/pickle.html
+''',
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('out_file', metavar='OUTFILE', type=Path, nargs='?',
+                        help='''file to write pickle data to (default:
+                        stdout)''')
+    return parser.parse_args()
+
+def get_open_bugs() -> List[Issue]:
+    zephyr_repo = get_github_object().get_repo('zephyrproject-rtos/zephyr')
+    return list(zephyr_repo.get_issues(state='open', labels=['bug']))
+
+def open_out_file(args: argparse.Namespace) -> BinaryIO:
+    if args.out_file is None:
+        return open(sys.stdout.fileno(), 'wb', closefd=False)
+
+    return open(args.out_file, 'wb')
+
+def main() -> None:
+    args = parse_args()
+    open_bugs = get_open_bugs()
+
+    with open_out_file(args) as out_file:
+        pickle.dump(open_bugs, out_file)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request follows up on discussion from the past few weeks' TSC and release readiness meetings.

At the TSC, I presented some basic bug analysis results using a script which can fetch bugs from GitHub, then categorize them by area, platform, and age. The TSC reaction was positive to using this framework for driving bug counts down during release times, and for tracking bugs over time.

On Discord, I followed up with @stephanosio about how to move this forward. We informally agreed that saving a snapshot of serialized bug data each week or so and uploading them to S3 for offline analysis would be best.

At subsequent release readiness meetings, I realized that the best time to do this snapshotting is right after we finish the initial triaging of that week's bugs. This ensures that priority, platform, and area are all set to the best of our ability as a project. @stephanosio suggested using a workflow_dispatch workflow for this purpose, so we can do this during the release meeting on demand.

This PR adds a simple script for saving the bugs, and a copy/pasted attempt at the workflow. I need some help from @stephanosio to finish the workflow itself and make sure I haven't missed anything there, but the bug snapshot script itself is working fine for me locally.