### PR TITLE
Modules: Percepio TraceRecorder: Update module from v4.6.0(RC1) to v4.6.3

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -224,7 +224,7 @@ manifest:
       groups:
         - crypto
     - name: TraceRecorderSource
-      revision: e8ca3b6a83d19b2fc4738a0d9607190436e5e452
+      revision: 9893bf1cf649a2c4ee2e27293f887994f3d0da5b
       path: modules/debug/TraceRecorder
       groups:
         - debug


### PR DESCRIPTION
This update updates the TraceRecorder module from version v4.6.0
(RC1) to v4.6.3. This update fixes some minor bugs where
deleted threads werent removed from the thread table. This
update is also in preparation for updates which changes
some trace hook arguments in Zephyr.

The update to v4.6.3 also improves syscall tracing by
including the id and name as parameters when logging
these events.

Signed-off-by: Torbjörn Leksell <torbjorn.leksell@percepio.com>