### PR TITLE
Bluetooth: Mesh: Fix segmentation when sending proxy message

### DIFF
--- a/subsys/bluetooth/mesh/proxy_msg.c
+++ b/subsys/bluetooth/mesh/proxy_msg.c
@@ -164,7 +164,7 @@ int bt_mesh_proxy_msg_send(struct bt_conn *conn, uint8_t type,
 	net_buf_simple_pull(msg, mtu);
 
 	while (msg->len) {
-		if (msg->len + 1 < mtu) {
+		if (msg->len + 1 <= mtu) {
 			net_buf_simple_push_u8(msg, PDU_HDR(SAR_LAST, type));
 			err = role->cb.send(conn, msg->data, msg->len, end, user_data);
 			if (err) {


### PR DESCRIPTION
Previous check in the if-statement would never allow to send last
segment if msg->len + 2 == MTU * x.

Fixes #45394

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>