### PR TITLE
boards/riscv/hifive_unleashed: add Renode simulation support

### DIFF
--- a/boards/riscv/hifive_unleashed/board.cmake
+++ b/boards/riscv/hifive_unleashed/board.cmake
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
+set(SUPPORTED_EMU_PLATFORMS renode)
+set(RENODE_SCRIPT ${CMAKE_CURRENT_LIST_DIR}/support/hifive_unleashed.resc)
 set(OPENOCD_USE_LOAD_IMAGE NO)
 
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_hifive_unleashed.cfg")

--- a/boards/riscv/hifive_unleashed/hifive_unleashed.yaml
+++ b/boards/riscv/hifive_unleashed/hifive_unleashed.yaml
@@ -5,10 +5,14 @@ arch: riscv64
 toolchain:
   - zephyr
 ram: 3840
+simulation: renode
 testing:
   ignore_tags:
     - net
     - bluetooth
+    - flash
+    - newlib
+    - crypto
 supported:
   - gpio
   - spi

--- a/boards/riscv/hifive_unleashed/support/hifive_unleashed.resc
+++ b/boards/riscv/hifive_unleashed/support/hifive_unleashed.resc
@@ -1,0 +1,25 @@
+:description: This script is prepared to run Zephyr on SiFive-FU540 board.
+:name: SiFive-FU540
+
+$name?="SiFive-FU540"
+
+using sysbus
+mach create $name
+
+set platform
+"""
+using "platforms/cpus/sifive-fu540.repl"
+
+clint:
+    frequency: 10000000
+"""
+
+machine LoadPlatformDescriptionFromString $platform
+machine PyDevFromFile @scripts/pydev/flipflop.py 0x10000000 0x100 True
+showAnalyzer uart0
+
+macro reset
+"""
+    sysbus LoadELF $bin
+"""
+runMacro $reset


### PR DESCRIPTION
This PR adds Renode simulation support to the HiFive Unleashed board.