### PR TITLE
MAINAINERS.yaml: Add GeorgeCGV to STM32 Platforms

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1686,6 +1686,7 @@ STM32 Platforms:
         - ABOSTM
         - FRASTM
         - gmarull
+        - GeorgeCGV
     files:
         - boards/arm/nucleo_*/
         - boards/arm/stm32*_disco/


### PR DESCRIPTION
Adds GeorgeCGV as a collaborator on STM32 Platforms.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>