### PR TITLE
boards: mimxrt1xxx: change flash controller to correct node

### DIFF
--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -19,7 +19,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp064;
 		zephyr,flash = &is25wp064;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sdram0;

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -20,7 +20,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp032;
 		zephyr,flash = &is25wp032;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sdram0;

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -10,7 +10,7 @@
 
 / {
 	chosen {
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp064;
 		zephyr,flash = &is25wp064;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -21,7 +21,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp064;
 		zephyr,flash = &is25wp064;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sdram0;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -22,7 +22,7 @@
 	};
 
 	chosen {
-		zephyr,flash-controller = &flexspi2;
+		zephyr,flash-controller = &is25wp064;
 		zephyr,flash = &w25q32jvwj0;
 		zephyr,code-partition = &slot0_partition;
 		zephyr,sram = &sdram0;

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
@@ -23,7 +23,7 @@
 		zephyr,sram = &sram1;
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;
 	};
 

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;
 		zephyr,code-partition = &slot0_partition;
 	};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
@@ -24,7 +24,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan2;
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;
 	};
 

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -20,7 +20,7 @@
 		zephyr,console = &lpuart1;
 		zephyr,shell-uart = &lpuart1;
 		zephyr,canbus = &flexcan3;
-		zephyr,flash-controller = &flexspi;
+		zephyr,flash-controller = &is25wp128;
 		zephyr,flash = &is25wp128;
 		zephyr,code-partition = &slot0_partition;
 	};


### PR DESCRIPTION
flash controller on RT boards should be the flash device, rather than
the flexspi, as the flash device's driver implements flash APIs.

Fixes #45505, when combined with https://github.com/mcu-tools/mcuboot/pull/1364 in order to enable progressive erase for these platforms.

This change is required on the RT1050 and RT1060 to enable support for progressive erase, but I have updated the remaining RT platforms because the FlexSPI flash controller itself does not implement the flash driver API, the flash chip device object does.