### PR TITLE
toolchain: xtensa: Define __sync_synchronize

### DIFF
--- a/include/zephyr/toolchain/xcc.h
+++ b/include/zephyr/toolchain/xcc.h
@@ -144,6 +144,10 @@
 #define __builtin_unreachable() do { __ASSERT(false, "Unreachable code"); } \
 	while (true)
 
+/* Not a full barrier, just a SW barrier */
+#define __sync_synchronize() do { __asm__ __volatile__ ("" ::: "memory"); } \
+	while (false)
+
 #ifdef __deprecated
 /*
  * XCC does not support using deprecated attribute in enum,


### PR DESCRIPTION
This builtin gcc function is not available in xcc compiler.

Adding a memory compiler barrier as it is done in compiler_barrier.
compiler_barrier() and __sync_synchronize() are not the same, the
former is a sw barrier while the latter can be a hw barrier
like (mfence/sfence) in X86.

I didn't find anything equivalent for xtensa so just implementing a
SW barrier.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>