### PR TITLE
Bluetooth: Controller: fix per sync hang if wrong CTE and list filter

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_sync.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_sync.h
@@ -7,7 +7,8 @@
 /* Periodic advertisements synchronization status. */
 enum sync_status {
 	SYNC_STAT_ALLOWED,
-	SYNC_STAT_READY_OR_CONT_SCAN,
+	SYNC_STAT_READY,
+	SYNC_STAT_CONT_SCAN,
 	SYNC_STAT_TERM
 };
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -814,7 +814,7 @@ static void isr_rx_adv_sync_estab(void *param)
 isr_rx_done:
 #if defined(CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING) && \
 	defined(CONFIG_BT_CTLR_CTEINLINE_SUPPORT)
-	isr_rx_done_cleanup(lll, crc_ok, sync_ok == SYNC_STAT_TERM);
+	isr_rx_done_cleanup(lll, crc_ok, sync_ok != SYNC_STAT_ALLOWED);
 #else
 	isr_rx_done_cleanup(lll, crc_ok, false);
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING && CONFIG_BT_CTLR_CTEINLINE_SUPPORT */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -226,7 +226,7 @@ enum sync_status lll_sync_cte_is_allowed(uint8_t cte_type_mask, uint8_t filter_p
 	}
 
 	if (!cte_ok) {
-		return filter_policy ? SYNC_STAT_READY_OR_CONT_SCAN : SYNC_STAT_TERM;
+		return filter_policy ? SYNC_STAT_CONT_SCAN : SYNC_STAT_TERM;
 	}
 
 	return SYNC_STAT_ALLOWED;
@@ -869,8 +869,8 @@ static void isr_rx_adv_sync(void *param)
 	 * affect synchronization even when new CTE type is not allowed by sync parameters.
 	 * Hence the SYNC_STAT_READY is set.
 	 */
-	err = isr_rx(lll, NODE_RX_TYPE_SYNC_REPORT, crc_ok, phy_flags_rx,
-		     cte_ready, rssi_ready, SYNC_STAT_READY_OR_CONT_SCAN);
+	err = isr_rx(lll, NODE_RX_TYPE_SYNC_REPORT, crc_ok, phy_flags_rx, cte_ready, rssi_ready,
+		     SYNC_STAT_READY);
 	if (err == -EBUSY) {
 		return;
 	}
@@ -938,8 +938,8 @@ static void isr_rx_aux_chain(void *param)
 	 * affect synchronization even when new CTE type is not allowed by sync parameters.
 	 * Hence the SYNC_STAT_READY is set.
 	 */
-	err = isr_rx(lll, NODE_RX_TYPE_EXT_AUX_REPORT, crc_ok, phy_flags_rx,
-		     cte_ready, rssi_ready, SYNC_STAT_READY_OR_CONT_SCAN);
+	err = isr_rx(lll, NODE_RX_TYPE_EXT_AUX_REPORT, crc_ok, phy_flags_rx, cte_ready, rssi_ready,
+		     SYNC_STAT_READY);
 
 	if (err == -EBUSY) {
 		return;

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -815,13 +815,13 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	 * host. If the periodic filtering list is used then stop synchronization with this
 	 * particular periodic advertised but continue to search for other one.
 	 */
-	sync->is_term = (sync_status != SYNC_STAT_ALLOWED);
+	sync->is_term = ((sync_status == SYNC_STAT_TERM) || (sync_status == SYNC_STAT_CONT_SCAN));
 #endif /* CONFIG_BT_CTLR_CTEINLINE_SUPPORT */
 
 	/* Send periodic advertisement sync established report when sync has correct CTE type
 	 * or the CTE type is incorrect and filter policy doesn't allow to continue scanning.
 	 */
-	if (sync_status != SYNC_STAT_READY_OR_CONT_SCAN) {
+	if (sync_status == SYNC_STAT_ALLOWED || sync_status == SYNC_STAT_TERM) {
 #else /* !CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
 
 	if (1) {
@@ -853,7 +853,7 @@ void ull_sync_established_report(memq_link_t *link, struct node_rx_hdr *rx)
 	 * the sync was found or was established in the past. The report is not send if
 	 * scanning is terminated due to wrong CTE type.
 	 */
-	if (sync_status == SYNC_STAT_ALLOWED) {
+	if (sync_status == SYNC_STAT_ALLOWED || sync_status == SYNC_STAT_READY) {
 #else /* !CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING */
 
 	if (1) {


### PR DESCRIPTION
In case of use of filtering based on: periodic advertising list and
CTE type, the synchronization can hang. That is possible if a periodic
advertiser uses wrong CTE type. In such situation the sync is not
released in `ull_sync_done` call. What more the `sync->timeout_reload`
is not cleared and Host is not able to cancel the synchronization.
The periodic advertising is in a semi-sync-established state.
There are no reports send to Host. Host can't use the sync set to
synchronize with other device. It is only able to terminate the
sync (call to `ll_sync_terminate`).

To fix the issue following changes should be applied:
- `isr_rx_adv_sync_estab` should call `isr_rx_done_cleanup`
with `sync_term` parameter in case the `sync_ok` isn't `SYNC_STAT_ALLOWED`.
In any case the CTE type is wrong, no matter is the periodic
advertising list filtering is enabled or not.
- `ull_sync_established_report` should set `sync->is_term` to true
in case the CTE type is not allowed. That change is required for devices
that do not support Direction Finding Extension. For those devices CTE
type based filtering is done in ULL by `ull_sync_established_report`
function. The `sync->is_term` should be set unconditionally, hence is
moved up in the function.

With these two changes done, `ull_sync_done` function will execute
`sync_ticker_release` in case the CTE has wrong type. ULL, depending on
notifications prepared by `ull_sync_established_report`, will follow up
on sync termination if required.

Besides that the PR splits `SYNC_STAT_READY_OR_CONT_SCAN` into 
`SYNC_STAT_READY` and `SYNC_STAT_CONT_SCAN`. 
The state was split because now Controller terminates sync ticker and
continues search for other periodic advertised. The split improves
readability and makes code easier to understand.