### PR TITLE
test, please ignore

### DIFF
--- a/tests/subsys/logging/log_syst/CMakeLists.txt
+++ b/tests/subsys/logging/log_syst/CMakeLists.txt
@@ -1,0 +1,12 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(log_syst)
+
+zephyr_include_directories(
+${ZEPHYR_BASE}/tests/subsys/logging/log_syst/src
+)
+
+FILE(GLOB app_sources src/*.c)
+target_sources(app PRIVATE ${app_sources})

--- a/tests/subsys/logging/log_syst/Kconfig
+++ b/tests/subsys/logging/log_syst/Kconfig
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Intel Corporation
+
+config LOG_BACKEND_MOCK
+	bool "MOCK backend"
+	help
+	  When enabled MOCK backend is used for logging. It is
+	  used to capture the output buffer used for validation of
+	  log messages. It will not output any logs.
+
+if LOG_BACKEND_MOCK
+
+backend = MOCK
+backend-str = mock
+source "subsys/logging/Kconfig.template.log_format_config"
+
+endif # LOG_BACKEND_MOCK
+
+# Include Zephyr's Kconfig.
+source "Kconfig.zephyr"

--- a/tests/subsys/logging/log_syst/prj.conf
+++ b/tests/subsys/logging/log_syst/prj.conf
@@ -1,0 +1,20 @@
+CONFIG_LOG=y
+CONFIG_ASSERT=n
+CONFIG_ZTEST=y
+CONFIG_LOG_BACKEND_MOCK=y
+CONFIG_LOG_BACKEND_UART=n
+CONFIG_SOC_LOG_LEVEL_OFF=y
+CONFIG_ARCH_LOG_LEVEL_OFF=y
+CONFIG_KERNEL_LOG_LEVEL_OFF=y
+CONFIG_LOG_RUNTIME_FILTERING=n
+CONFIG_LOG_FUNC_NAME_PREFIX_DBG=n
+
+# Use immediate mode so all messages are being
+# printed. Under deferred mode, there may be
+# dropped messages as there are quite a number of
+# messages to be printed.
+CONFIG_LOG_MODE_IMMEDIATE=y
+
+# Need bigger stack for immediate mode
+CONFIG_MAIN_STACK_SIZE=4096
+CONFIG_ZTEST_STACK_SIZE=2048

--- a/tests/subsys/logging/log_syst/src/main.c
+++ b/tests/subsys/logging/log_syst/src/main.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Test log message
+ */
+
+#include <zephyr.h>
+#include <logging/log.h>
+#include "mock_backend.h"
+#include <sys/printk.h>
+#include <logging/log_backend.h>
+#include <logging/log_backend_std.h>
+#include <logging/log_ctrl.h>
+#include <logging/log_output.h>
+#include <tc_util.h>
+#include <stdbool.h>
+#include <ztest.h>
+#include <stdlib.h>
+
+/** Hex string corresponding to "Debug message example, %d, %d, %d", 1, 2, 3.
+ * PAYLOAD_MULTIPLE_ARGS defines the expected payload
+ * in SYST format when multiple arguments are passed to log API.
+ */
+#define PAYLOAD_MULTIPLE_ARGS "4465627567206D657373616765206578616D706C652C2025642C2025642C20256"\
+	"400010000000200000003000000"
+
+MOCK_LOG_BACKEND_DEFINE(backend1, false);
+
+#define LOG_MODULE_NAME test
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL_DBG);
+
+/**
+ * @brief Testcase to validate that the mock backend would use the expected
+ * processing function from the function pointer table format_table
+ */
+void test_log_syst_format_table_selection(void)
+{
+
+#ifdef CONFIG_LOG_MIPI_SYST_ENABLE
+	uint32_t test_log_type_syst = LOG_OUTPUT_SYST;
+
+	log_format_func_t test_log_output_func = log_format_func_t_get(test_log_type_syst);
+
+	zassert_equal_ptr(test_log_output_func, log_output_msg2_syst_process,
+					"Correct Function pointer for SYST log\n"
+					"format was not selected %p vs %p",
+					test_log_output_func, log_output_msg2_syst_process);
+
+#elif CONFIG_LOG_BACKEND_MOCK_OUTPUT_DEFAULT == LOG_OUTPUT_TEXT
+
+	uint32_t test_log_type_text = LOG_OUTPUT_TEXT;
+	log_format_func_t test_log_output_func = log_format_func_t_get(test_log_type_text);
+
+	zassert_equal_ptr(test_log_output_func, log_output_msg2_process,
+						"Function pointer for TEXT log format was not selected");
+
+#endif
+
+}
+
+#ifdef CONFIG_LOG_MIPI_SYST_ENABLE
+
+const char *type = "72";
+const char *optional_flags = "0A";
+const char *module_id = "00";
+
+#ifdef CONFIG_64BIT
+#define SUB_TYPE "0C"
+#else
+#define SUB_TYPE "0B"
+#endif
+
+/* Testcase to validate the SYST output of log data */
+void test_log_syst_data(void)
+{
+	LOG_DBG("Debug message example, %d", 1);
+
+	const char *sub_type = SUB_TYPE;
+	const char *payload =
+	"4465627567206D657373616765206578616D706C652C2025640001000000";
+
+	validate_msg(type, optional_flags, module_id, sub_type, payload);
+}
+
+/* Testcase to validate the SYST output of data with multiple arguments */
+void test_log_syst_data_multiple_args(void)
+{
+	LOG_DBG("Debug message example, %d, %d, %d", 1, 2, 3);
+
+	const char *sub_type = SUB_TYPE;
+	char *payload = PAYLOAD_MULTIPLE_ARGS;
+
+	validate_msg(type, optional_flags, module_id, sub_type, payload);
+}
+
+/* Testcase to validate the SYST output of float data */
+void test_log_syst_float_data(void)
+{
+	LOG_DBG("Debug message example, %f", 1.223);
+
+	const char *sub_type = SUB_TYPE;
+	const char *payload =
+	"4465627567206D657373616765206578616D706C652C20256600C520B0726891F33F";
+
+	validate_msg(type, optional_flags, module_id, sub_type, payload);
+}
+
+#else
+
+void test_log_syst_data(void)
+{
+	ztest_test_skip();
+}
+
+void test_log_syst_data_multiple_args(void)
+{
+	ztest_test_skip();
+}
+
+void test_log_syst_float_data(void)
+{
+	ztest_test_skip();
+}
+
+#endif
+/* test case main entry */
+void test_main(void)
+{
+	ztest_test_suite(test_log_syst,
+		ztest_unit_test(test_log_syst_format_table_selection),
+		ztest_unit_test(test_log_syst_data),
+		ztest_unit_test(test_log_syst_float_data),
+		ztest_unit_test(test_log_syst_data_multiple_args)
+		);
+	ztest_run_test_suite(test_log_syst);
+}

--- a/tests/subsys/logging/log_syst/src/mock_backend.c
+++ b/tests/subsys/logging/log_syst/src/mock_backend.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include "mock_backend.h"
+#include <ztest.h>
+#include <logging/log_core.h>
+#include <logging/log_backend_std.h>
+#include <stdlib.h>
+
+static uint32_t log_format_current = CONFIG_LOG_BACKEND_MOCK_OUTPUT_DEFAULT;
+union log_msg2_generic *test_msg;
+
+static uint8_t mock_output_buf[1];
+uint8_t test_output_buf[256];
+int pos_in_buf;
+
+/**
+ * @brief This function takes in the characters and copies
+ * them in the temporary buffer.
+ *
+ * @return No. of characters copied to the temporary buffer.
+ */
+static int char_out(uint8_t *data, size_t length, void *ctx)
+{
+	ARG_UNUSED(ctx);
+	size_t output_length = length;
+
+	while (length > 0) {
+		test_output_buf[pos_in_buf] = *data;
+		pos_in_buf++;
+		data++;
+		length--;
+
+		zassert_not_equal(pos_in_buf, sizeof(test_output_buf)-1,
+				  "Increase the size of test_output_buf");
+	}
+	return output_length;
+}
+
+LOG_OUTPUT_DEFINE(log_output_mock, char_out, mock_output_buf, sizeof(mock_output_buf));
+
+static void process(const struct log_backend *const backend,
+		union log_msg2_generic *msg)
+{
+	uint32_t flags = log_backend_std_get_flags();
+
+	test_msg = msg;
+
+	log_format_func_t log_output_func = log_format_func_t_get(log_format_current);
+
+	log_output_func(&log_output_mock, &msg->log, flags);
+}
+
+bool is_kth_bit_set(int n, int k)
+{
+	return ((n & (1 << (k - 1))) != 0);
+}
+
+void validate_msg(const char *type, const char *optional_flags,
+		  const char *module_id, const char *sub_type,
+		  const char *payload)
+{
+	const char *raw_data_str = "SYS-T RAW DATA: ";
+	const char *output_str = test_output_buf;
+	const char *syst_format_headers[4] = {type, optional_flags, module_id, sub_type};
+	const char *syst_headers_name[4] = {"type", "optional_flags", "module_id", "sub_type"};
+
+	/* Validate "SYS-T RAW DATA: " prefix in the output_str */
+	zassert_mem_equal(raw_data_str, output_str, strlen(raw_data_str),
+			  "Incorrect Format comparison");
+
+	output_str += strlen(raw_data_str);
+
+	/* Validate the headers in the SYS-T data format */
+	for (int i = 0; i < ARRAY_SIZE(syst_format_headers); i++) {
+		zassert_mem_equal(output_str, syst_format_headers[i],
+				  strlen(syst_format_headers[i]),
+				  "Incorrect Comparison of %s", syst_headers_name[i]);
+
+		output_str = output_str+2;
+	}
+
+	/* After the headers the output_str will contain the content of optional flags.
+	 * Optional flags are contained in 1st byte of data in output_str. There are 4 bits
+	 * reserved for Optional flags. 1st bit = Location, 2nd Bit = payload length
+	 * 3rd bit = Sys-t Checksum, 4th bit = Sys-t Timestamp. Support for validating the
+	 * content based on optional flags is not supported, hence the corresponding
+	 * characters are skipped. skip_bytes array contains the number of hex characters
+	 * to skip in the output_str.
+	 */
+	size_t skip_bytes[5] = {0, 18, 4, 8, 16};
+
+	for (int i = 1; i < ARRAY_SIZE(skip_bytes); i++) {
+		if (is_kth_bit_set(strtol(optional_flags, 0, 16), i)) {
+			output_str += skip_bytes[i];
+		}
+	}
+
+	zassert_mem_equal(output_str, payload, strlen(payload),
+			  "Incorrect Comparison of payload");
+
+	memset(test_output_buf, 0, sizeof(test_output_buf));
+	pos_in_buf = 0;
+}
+
+static int format_set(const struct log_backend *const backend, uint32_t log_type)
+{
+	log_format_current = log_type;
+	return 0;
+}
+
+static void mock_init(struct log_backend const *const backend)
+{
+
+}
+
+static void panic(struct log_backend const *const backend)
+{
+
+}
+
+const struct log_backend_api mock_log_backend_api = {
+	.process = IS_ENABLED(CONFIG_LOG2) ? process : NULL,
+	.init = mock_init,
+	.format_set = IS_ENABLED(CONFIG_LOG1) ? NULL : format_set,
+	.panic = panic
+};
+
+LOG_BACKEND_DEFINE(log_backend_mock, mock_log_backend_api, true);

--- a/tests/subsys/logging/log_syst/src/mock_backend.h
+++ b/tests/subsys/logging/log_syst/src/mock_backend.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef SRC_MOCK_BACKEND_H__
+#define SRC_MOCK_BACKEND_H__
+
+#include <logging/log_backend.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern const struct log_backend_api mock_log_backend_api;
+struct mock_log_backend {
+	bool panic;
+};
+
+/**
+ * @brief This function validates the log message.
+ *
+ * @param type Field in message header to indicate the type of SyS-T message.
+ * @param optional_flags Optional Flags in message header.
+ * @param module_id ModuleID in a Message Header distinguish between multiple
+ *					instances of the same Origin.
+ * @param sub_type Enumerated types for representing the sub-type of a Message.
+ * @param payload The content of the Message.
+ */
+void validate_msg(const char *type, const char *optional_flags,
+		  const char *module_id, const char *sub_type,
+		  const char *payload);
+
+#define MOCK_LOG_BACKEND_DEFINE(name, autostart) \
+	static struct mock_log_backend name##_mock; \
+	LOG_BACKEND_DEFINE(name, mock_log_backend_api, autostart, &name##_mock)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SRC_MOCK_BACKEND_H__ */

--- a/tests/subsys/logging/log_syst/testcase.yaml
+++ b/tests/subsys/logging/log_syst/testcase.yaml
@@ -1,0 +1,24 @@
+tests:
+  logging.log_syst.mipi_syst:
+    tags: log_syst logging
+    arch_exclude: mips nios2 posix sparc
+    filter: not CONFIG_64BIT
+    integration_platforms:
+      - mps2_an385
+      - qemu_x86
+      - sam_e70_xplained
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "SYS-T RAW DATA: "
+    extra_configs:
+      - CONFIG_LOG_MIPI_SYST_ENABLE=y
+      - CONFIG_LOG_BACKEND_MOCK_OUTPUT_SYST=y
+  logging.log_syst.text:
+    tags: log_syst logging
+    arch_exclude: mips nios2 posix sparc
+    filter: not CONFIG_64BIT
+    extra_configs:
+      - CONFIG_LOG_MIPI_SYST_ENABLE=n
+      - CONFIG_LOG_BACKEND_MOCK_OUTPUT_SYST=n


### PR DESCRIPTION
Adding testcases for mipi syst logging format. Excluding
problem architectures from the testcase as SYS-T does not
support 64-bit or big endian architectures. The posix arch
is excluded as it generates numerous anomalous runtime messages
because it does not have the means to determine when data
resides in the rodata section.

Signed-off-by: Aastha Grover <aastha.grover@intel.com>
