### PR TITLE
net: sockets: Fix datagram AF_PACKET socket handling

### DIFF
--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -189,6 +189,10 @@ struct net_pkt {
 				 * defined(CONFIG_NET_ETHERNET_BRIDGE).
 				 */
 
+	uint8_t l2_processed : 1; /* Set to 1 if this packet has already been
+				   * processed by the L2
+				   */
+
 	union {
 		/* IPv6 hop limit or IPv4 ttl for this network packet.
 		 * The value is shared between IPv6 and IPv4.
@@ -357,6 +361,17 @@ static inline void net_pkt_set_l2_bridged(struct net_pkt *pkt, bool is_l2_bridge
 	if (IS_ENABLED(CONFIG_NET_ETHERNET_BRIDGE)) {
 		pkt->l2_bridged = is_l2_bridged;
 	}
+}
+
+static inline bool net_pkt_is_l2_processed(struct net_pkt *pkt)
+{
+	return !!(pkt->l2_processed);
+}
+
+static inline void net_pkt_set_l2_processed(struct net_pkt *pkt,
+					    bool is_l2_processed)
+{
+	pkt->l2_processed = is_l2_processed;
 }
 
 static inline uint8_t net_pkt_ip_hdr_len(struct net_pkt *pkt)

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -514,6 +514,15 @@ static bool conn_are_end_points_valid(struct net_pkt *pkt,
 static enum net_verdict conn_raw_socket(struct net_pkt *pkt,
 					struct net_conn *conn, uint8_t proto)
 {
+	if (proto == ETH_P_ALL) {
+		enum net_sock_type type = net_context_get_type(conn->context);
+
+		if ((type == SOCK_DGRAM && !net_pkt_is_l2_processed(pkt)) ||
+		    (type == SOCK_RAW && net_pkt_is_l2_processed(pkt))) {
+			goto out;
+		}
+	}
+
 	if (conn->flags & NET_CONN_LOCAL_ADDR_SET) {
 		struct net_if *pkt_iface = net_pkt_iface(pkt);
 		struct sockaddr_ll *local;
@@ -547,6 +556,7 @@ static enum net_verdict conn_raw_socket(struct net_pkt *pkt,
 		return NET_OK;
 	}
 
+out:
 	return NET_CONTINUE;
 }
 

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1568,15 +1568,18 @@ static int context_sendto(struct net_context *context,
 			return -EINVAL;
 		}
 
-		if (ll_addr->sll_ifindex < 0) {
-			return -EDESTADDRREQ;
-		}
+		iface = net_context_get_iface(context);
+		if (iface == NULL) {
+			if (ll_addr->sll_ifindex < 0) {
+				return -EDESTADDRREQ;
+			}
 
-		iface = net_if_get_by_index(ll_addr->sll_ifindex);
-		if (!iface) {
-			NET_ERR("Cannot bind to interface index %d",
-				ll_addr->sll_ifindex);
-			return -EDESTADDRREQ;
+			iface = net_if_get_by_index(ll_addr->sll_ifindex);
+			if (iface == NULL) {
+				NET_ERR("Cannot bind to interface index %d",
+					ll_addr->sll_ifindex);
+				return -EDESTADDRREQ;
+			}
 		}
 
 		if (net_context_get_type(context) == SOCK_DGRAM) {

--- a/subsys/net/ip/packet_socket.c
+++ b/subsys/net/ip/packet_socket.c
@@ -34,20 +34,6 @@ enum net_verdict net_packet_socket_input(struct net_pkt *pkt, uint8_t proto)
 		return NET_CONTINUE;
 	}
 #endif
-	/* Currently we are skipping L2 layer verification and not
-	 * removing L2 header from packet.
-	 * TODO :
-	 * 1) Pass it through L2 layer, so that L2 will verify
-	 * that packet is intended to us or not and sets src and dst lladdr.
-	 * And L2 should not pull off L2 header when combination of socket
-	 * like this AF_PACKET, SOCK_RAW and ETH_P_ALL proto.
-	 * 2) Socket combination of AF_INET, SOCK_RAW, IPPROTO_RAW
-	 * packet has to go through L2 and L2 verifies it's header and removes
-	 * header. Only packet with L3 header will be given to socket.
-	 * 3) If user opens raw and non raw socket together, based on raw
-	 * socket combination packet has to be feed to raw socket and only
-	 * data part to be feed to non raw socket.
-	 */
 
 	orig_family = net_pkt_family(pkt);
 

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -108,4 +108,12 @@ config NET_ETHERNET_BRIDGE_DEFAULT
 	  Say y if this is the case. If you only want to inspect
 	  existing bridge instances then say n.
 
+config NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE
+	bool "Forward unrecognized EtherType frames further into net stack"
+	default y if NET_SOCKETS_PACKET
+	help
+	  When enabled, the Ethernet L2 will forward even those frames for which
+	  it does not recognize the EtherType in the header. By default, such
+	  frames are dropped at the L2 processing.
+
 endif # NET_L2_ETHERNET

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -254,6 +254,11 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		goto drop;
 #endif
 	default:
+		if (IS_ENABLED(CONFIG_NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE)) {
+			family = AF_UNSPEC;
+			break;
+		}
+
 		NET_DBG("Unknown hdr type 0x%04x iface %p", type, iface);
 		goto drop;
 	}

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -40,6 +40,7 @@ static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)
 {
 	struct net_pkt *recv_pkt;
 	int ret;
+	struct net_if *target_iface;
 
 	ARG_UNUSED(dev);
 	ARG_UNUSED(pkt);
@@ -47,7 +48,15 @@ static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)
 	DBG("Sending data (%d bytes) to iface %d\n",
 	    net_pkt_get_len(pkt), net_if_get_by_iface(net_pkt_iface(pkt)));
 
-	recv_pkt = net_pkt_clone(pkt, K_NO_WAIT);
+	recv_pkt = net_pkt_rx_clone(pkt, K_NO_WAIT);
+
+	if (memcmp(pkt->frags->data, lladdr1, sizeof(lladdr1)) == 0) {
+		target_iface = eth_fake_data1.iface;
+	} else {
+		target_iface = eth_fake_data2.iface;
+	}
+
+	net_pkt_set_iface(recv_pkt, target_iface);
 
 	k_sleep(K_MSEC(10)); /* Let the receiver run */
 
@@ -288,11 +297,12 @@ static void test_packet_sockets(void)
 static void test_packet_sockets_dgram(void)
 {
 	uint8_t data_to_send[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
-	uint8_t data_to_receive[sizeof(data_to_send)];
+	uint8_t data_to_receive[32];
 	socklen_t addrlen = sizeof(struct sockaddr_ll);
 	struct user_data ud = { 0 };
 	struct sockaddr_ll dst, src;
 	int ret, sock1, sock2;
+	int iter, max_iter = 10;
 
 	net_if_foreach(iface_cb, &ud);
 
@@ -311,9 +321,13 @@ static void test_packet_sockets_dgram(void)
 	ret = bind_socket(sock2, ud.second);
 	zassert_equal(ret, 0, "Cannot bind 2nd socket (%d)", -errno);
 
+	setblocking(sock1, false);
+	setblocking(sock2, false);
+
 	memset(&dst, 0, sizeof(dst));
-	dst.sll_ifindex = net_if_get_by_iface(ud.first);
 	dst.sll_family = AF_PACKET;
+	dst.sll_protocol = htons(ETH_P_IP);
+	memcpy(dst.sll_addr, lladdr1, sizeof(lladdr1));
 
 	ret = sendto(sock2, data_to_send, sizeof(data_to_send), 0,
 		     (const struct sockaddr *)&dst, sizeof(struct sockaddr_ll));
@@ -321,20 +335,25 @@ static void test_packet_sockets_dgram(void)
 		      -errno);
 
 	k_msleep(10); /* Let the packet enter the system */
-	setblocking(sock2, false);
 	memset(&src, 0, sizeof(src));
 
 	errno = 0;
-
+	iter = 0;
 	do {
-		ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive),
+		ret = recvfrom(sock1, data_to_receive, sizeof(data_to_receive),
 			       0, (struct sockaddr *)&src, &addrlen);
 		k_msleep(10);
-	} while (ret < 0 && errno == EAGAIN);
+		iter++;
+	} while (ret < 0 && errno == EAGAIN && iter < max_iter);
 
 	zassert_equal(ret, sizeof(data_to_send),
 		      "Cannot receive all data (%d vs %zd) (%d)",
 		      ret, sizeof(data_to_send), -errno);
+
+	zassert_mem_equal(data_to_send, data_to_receive, sizeof(data_to_send),
+			  "Data mismatch");
+
+	memcpy(dst.sll_addr, lladdr2, sizeof(lladdr2));
 
 	/* Send to socket 2 but read from socket 1. There should not be any
 	 * data in socket 1
@@ -345,7 +364,6 @@ static void test_packet_sockets_dgram(void)
 		      -errno);
 
 	k_msleep(10);
-	setblocking(sock1, false);
 	memset(&src, 0, sizeof(src));
 
 	ret = recvfrom(sock1, data_to_receive, sizeof(data_to_receive), 0,
@@ -356,18 +374,222 @@ static void test_packet_sockets_dgram(void)
 	memset(&src, 0, sizeof(src));
 
 	errno = 0;
-
+	iter = 0;
 	do {
 		ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive),
 			       0, (struct sockaddr *)&src, &addrlen);
 		k_msleep(10);
-	} while (ret < 0 && errno == EAGAIN);
+		iter++;
+	} while (ret < 0 && errno == EAGAIN && iter < max_iter);
 
 	zassert_equal(ret, sizeof(data_to_send), "Cannot receive all data (%d)",
 		      -errno);
+	zassert_mem_equal(data_to_send, data_to_receive, sizeof(data_to_send),
+			  "Data mismatch");
 
 	close(sock1);
 	close(sock2);
+}
+
+static void test_raw_and_dgram_socket_exchange(void)
+{
+	uint8_t data_to_send[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+	uint8_t data_to_receive[32];
+	socklen_t addrlen = sizeof(struct sockaddr_ll);
+	struct user_data ud = { 0 };
+	struct sockaddr_ll dst, src;
+	int ret, sock1, sock2;
+	int iter, max_iter = 10;
+	const uint8_t expected_payload_raw[] = {
+		0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* Dst ll addr */
+		0x01, 0x01, 0x01, 0x01, 0x01, 0x01, /* Src ll addr */
+		ETH_P_IP >> 8, ETH_P_IP & 0xFF, /* EtherType */
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9 /* Payload */
+	};
+	const uint8_t send_payload_raw[] = {
+		0x01, 0x01, 0x01, 0x01, 0x01, 0x01, /* Dst ll addr */
+		0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* Src ll addr */
+		ETH_P_IP >> 8, ETH_P_IP & 0xFF, /* EtherType */
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9 /* Payload */
+	};
+
+
+	net_if_foreach(iface_cb, &ud);
+
+	zassert_not_null(ud.first, "1st Ethernet interface not found");
+	zassert_not_null(ud.second, "2nd Ethernet interface not found");
+
+	sock1 = setup_socket(ud.first, SOCK_DGRAM, ETH_P_ALL);
+	zassert_true(sock1 >= 0, "Cannot create 1st socket (%d)", sock1);
+
+	sock2 = setup_socket(ud.second, SOCK_RAW, ETH_P_ALL);
+	zassert_true(sock2 >= 0, "Cannot create 2nd socket (%d)", sock2);
+
+	ret = bind_socket(sock1, ud.first);
+	zassert_equal(ret, 0, "Cannot bind 1st socket (%d)", -errno);
+
+	ret = bind_socket(sock2, ud.second);
+	zassert_equal(ret, 0, "Cannot bind 2nd socket (%d)", -errno);
+
+	setblocking(sock1, false);
+	setblocking(sock2, false);
+
+	memset(&dst, 0, sizeof(dst));
+	dst.sll_family = AF_PACKET;
+	dst.sll_protocol = htons(ETH_P_IP);
+	memcpy(dst.sll_addr, lladdr2, sizeof(lladdr1));
+
+	/* SOCK_DGRAM to SOCK_RAW */
+
+	ret = sendto(sock1, data_to_send, sizeof(data_to_send), 0,
+		     (const struct sockaddr *)&dst, sizeof(struct sockaddr_ll));
+	zassert_equal(ret, sizeof(data_to_send), "Cannot send all data (%d)",
+		      -errno);
+
+	k_msleep(10); /* Let the packet enter the system */
+	memset(&src, 0, sizeof(src));
+
+	errno = 0;
+	iter = 0;
+	do {
+		ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive),
+			       0, (struct sockaddr *)&src, &addrlen);
+		k_msleep(10);
+		iter++;
+	} while (ret < 0 && errno == EAGAIN && iter < max_iter);
+
+	zassert_equal(ret, sizeof(expected_payload_raw),
+		      "Cannot receive all data (%d vs %zd) (%d)",
+		      ret, sizeof(expected_payload_raw), -errno);
+
+	zassert_mem_equal(expected_payload_raw, data_to_receive,
+			  sizeof(expected_payload_raw), "Data mismatch");
+
+	memset(&dst, 0, sizeof(dst));
+	dst.sll_family = AF_PACKET;
+	dst.sll_protocol = htons(ETH_P_IP);
+
+	/* SOCK_RAW to SOCK_DGRAM */
+
+	ret = sendto(sock2, send_payload_raw, sizeof(send_payload_raw), 0,
+		     (const struct sockaddr *)&dst, sizeof(struct sockaddr_ll));
+	zassert_equal(ret, sizeof(send_payload_raw), "Cannot send all data (%d)",
+		      -errno);
+
+	k_msleep(10);
+	memset(&src, 0, sizeof(src));
+
+	errno = 0;
+	iter = 0;
+	do {
+		ret = recvfrom(sock1, data_to_receive, sizeof(data_to_receive),
+			       0, (struct sockaddr *)&src, &addrlen);
+		k_msleep(10);
+		iter++;
+	} while (ret < 0 && errno == EAGAIN && iter < max_iter);
+
+	zassert_equal(ret, sizeof(data_to_send), "Cannot receive all data (%d)",
+		      -errno);
+	zassert_mem_equal(data_to_send, data_to_receive, sizeof(data_to_send),
+			  "Data mismatch");
+
+	close(sock1);
+	close(sock2);
+}
+
+static void test_raw_and_dgram_socket_recv(void)
+{
+	uint8_t data_to_send[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
+	uint8_t data_to_receive[32];
+	socklen_t addrlen = sizeof(struct sockaddr_ll);
+	struct user_data ud = { 0 };
+	struct sockaddr_ll dst, src;
+	int ret, sock1, sock2, sock3;
+	int iter, max_iter = 10;
+	const uint8_t expected_payload_raw[] = {
+		0x02, 0x02, 0x02, 0x02, 0x02, 0x02, /* Dst ll addr */
+		0x01, 0x01, 0x01, 0x01, 0x01, 0x01, /* Src ll addr */
+		ETH_P_IP >> 8, ETH_P_IP & 0xFF, /* EtherType */
+		0, 1, 2, 3, 4, 5, 6, 7, 8, 9 /* Payload */
+	};
+
+	net_if_foreach(iface_cb, &ud);
+
+	zassert_not_null(ud.first, "1st Ethernet interface not found");
+	zassert_not_null(ud.second, "2nd Ethernet interface not found");
+
+	sock1 = setup_socket(ud.first, SOCK_DGRAM, ETH_P_ALL);
+	zassert_true(sock1 >= 0, "Cannot create 1st socket (%d)", sock1);
+
+	sock2 = setup_socket(ud.second, SOCK_RAW, ETH_P_ALL);
+	zassert_true(sock2 >= 0, "Cannot create 2nd socket (%d)", sock2);
+
+	sock3 = setup_socket(ud.second, SOCK_RAW, ETH_P_ALL);
+	zassert_true(sock3 >= 0, "Cannot create 2nd socket (%d)", sock3);
+
+	ret = bind_socket(sock1, ud.first);
+	zassert_equal(ret, 0, "Cannot bind 1st socket (%d)", -errno);
+
+	ret = bind_socket(sock2, ud.second);
+	zassert_equal(ret, 0, "Cannot bind 2nd socket (%d)", -errno);
+
+	ret = bind_socket(sock3, ud.second);
+	zassert_equal(ret, 0, "Cannot bind 2nd socket (%d)", -errno);
+
+	setblocking(sock1, false);
+	setblocking(sock2, false);
+	setblocking(sock3, false);
+
+	memset(&dst, 0, sizeof(dst));
+	dst.sll_family = AF_PACKET;
+	dst.sll_protocol = htons(ETH_P_IP);
+	memcpy(dst.sll_addr, lladdr2, sizeof(lladdr1));
+
+	ret = sendto(sock1, data_to_send, sizeof(data_to_send), 0,
+		     (const struct sockaddr *)&dst, sizeof(struct sockaddr_ll));
+	zassert_equal(ret, sizeof(data_to_send), "Cannot send all data (%d)",
+		      -errno);
+
+	k_msleep(10); /* Let the packet enter the system */
+	memset(&src, 0, sizeof(src));
+
+	/* Both SOCK_DGRAM to SOCK_RAW sockets should receive packet. */
+
+	errno = 0;
+	iter = 0;
+	do {
+		ret = recvfrom(sock2, data_to_receive, sizeof(data_to_receive),
+			       0, (struct sockaddr *)&src, &addrlen);
+		k_msleep(10);
+		iter++;
+	} while (ret < 0 && errno == EAGAIN && iter < max_iter);
+
+	zassert_equal(ret, sizeof(expected_payload_raw),
+		      "Cannot receive all data (%d vs %zd) (%d)",
+		      ret, sizeof(expected_payload_raw), -errno);
+
+	zassert_mem_equal(expected_payload_raw, data_to_receive,
+			  sizeof(expected_payload_raw), "Data mismatch");
+
+	memset(&src, 0, sizeof(src));
+
+	errno = 0;
+	iter = 0;
+	do {
+		ret = recvfrom(sock3, data_to_receive, sizeof(data_to_receive),
+			       0, (struct sockaddr *)&src, &addrlen);
+		k_msleep(10);
+		iter++;
+	} while (ret < 0 && errno == EAGAIN && iter < max_iter);
+
+	zassert_equal(ret, sizeof(expected_payload_raw),
+		      "Cannot receive all data (%d)", -errno);
+	zassert_mem_equal(expected_payload_raw, data_to_receive,
+			  sizeof(expected_payload_raw), "Data mismatch");
+
+	close(sock1);
+	close(sock2);
+	close(sock3);
 }
 
 void test_main(void)
@@ -375,6 +597,8 @@ void test_main(void)
 	ztest_test_suite(socket_packet,
 			 ztest_unit_test(test_packet_sockets),
 			 ztest_unit_test(test_raw_packet_sockets),
-			 ztest_unit_test(test_packet_sockets_dgram));
+			 ztest_unit_test(test_packet_sockets_dgram),
+			 ztest_unit_test(test_raw_and_dgram_socket_exchange),
+			 ztest_unit_test(test_raw_and_dgram_socket_recv));
 	ztest_run_test_suite(socket_packet);
 }


### PR DESCRIPTION
This PR fixes the datagram AF_PACKET socket handling, which improperly received packet a packet before it was processed by L2 layer.

Additionally, fix the existing unit test to work correctly after update, so that the packets used in the test are not rejected by L2. Finally add two new unit tests for DGRAM sockets to improve test coverage.

Fixes #45514