### PR TITLE
Tests: bluetooth: fix ctrl_user_ext and init tests

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -55,6 +55,10 @@
 #include "ull_df_types.h"
 #include "ull_df_internal.h"
 
+#if defined(CONFIG_BT_CTLR_USER_EXT)
+#include "ull_vendor.h"
+#endif /* CONFIG_BT_CTLR_USER_EXT */
+
 #include "isoal.h"
 #include "ull_internal.h"
 #include "ull_iso_internal.h"
@@ -71,10 +75,6 @@
 
 #include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
-
-#if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
-#endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "ll.h"
 #include "ll_feat.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -41,6 +41,11 @@
 #include "ull_iso_types.h"
 #include "ull_conn_types.h"
 #include "ull_conn_iso_types.h"
+
+#if defined(CONFIG_BT_CTLR_USER_EXT)
+#include "ull_vendor.h"
+#endif /* CONFIG_BT_CTLR_USER_EXT */
+
 #include "ull_internal.h"
 #include "ull_sched_internal.h"
 #include "ull_chan_internal.h"
@@ -52,9 +57,6 @@
 #include "ull_conn_iso_internal.h"
 #include "ull_peripheral_iso_internal.h"
 
-#if defined(CONFIG_BT_CTLR_USER_EXT)
-#include "ull_vendor.h"
-#endif /* CONFIG_BT_CTLR_USER_EXT */
 
 #include "ll.h"
 #include "ll_feat.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_internal.h
@@ -12,7 +12,6 @@
 #define CONN_INTERVAL_MIN(x) (6)
 #else /* CONFIG_BT_CTLR_USER_CPR_INTERVAL_MIN */
 /* Proprietary user defined CPR Interval Minimum */
-extern uint16_t ull_conn_interval_min_get(struct ll_conn *conn);
 #define CONN_INTERVAL_MIN(x) (MAX(ull_conn_interval_min_get(x), 1))
 #endif /* CONFIG_BT_CTLR_USER_CPR_INTERVAL_MIN */
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -37,6 +37,7 @@
 #include "ull_adv_types.h"
 #include "ull_filter.h"
 
+#include "ull_conn_types.h"
 #include "ull_internal.h"
 #include "ull_adv_internal.h"
 #include "ull_scan_types.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -34,6 +34,11 @@
 #include "lll_conn.h"
 #include "lll_filter.h"
 
+#if !defined(CONFIG_BT_LL_SW_LLCP_LEGACY)
+#include "ull_tx_queue.h"
+#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
+
+
 #include "ull_adv_types.h"
 #include "ull_filter.h"
 


### PR DESCRIPTION
The tests/bluetooth/ctrl_user_ext test fails due to
compilation errors, which are fixed with this PR

There are also failing tests in tests/bluetooth/init which are also 
fixed by this PR

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>