### PR TITLE
lib/libc/minimal: Move sqrt/sqrtf from samples

### DIFF
--- a/lib/libc/minimal/CMakeLists.txt
+++ b/lib/libc/minimal/CMakeLists.txt
@@ -22,6 +22,8 @@ zephyr_library_sources(
   source/stdout/sprintf.c
   source/stdout/fprintf.c
   source/time/gmtime.c
+  source/math/sqrtf.c
+  source/math/sqrt.c
 )
 
 zephyr_library_sources_ifdef(CONFIG_POSIX_CLOCK source/time/time.c)

--- a/lib/libc/minimal/include/math.h
+++ b/lib/libc/minimal/include/math.h
@@ -51,6 +51,9 @@ extern "C" {
 #define M_SQRT2     1.41421356237309504880
 #define M_SQRT1_2   0.70710678118654752440
 
+float sqrtf(float square);
+double sqrt(double square);
+
 #ifdef __cplusplus
 }
 #endif

--- a/lib/libc/minimal/source/math/sqrt.c
+++ b/lib/libc/minimal/source/math/sqrt.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2019 Vestas Wind Systems A/S
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+
+double sqrt(double value)
+{
+	double sqrt = value / 3;
+	int i;
+
+	if (value <= 0) {
+		return 0;
+	}
+
+	for (i = 0; i < 6; i++) {
+		sqrt = (sqrt + value / sqrt) / 2;
+	}
+
+	return sqrt;
+}

--- a/lib/libc/minimal/source/math/sqrtf.c
+++ b/lib/libc/minimal/source/math/sqrtf.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018 Vikrant More
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <math.h>
+
+#define MINDIFF 2.25e-308
+
+float sqrtf(float square)
+{
+	float root, last, diff;
+
+	root = square / 3.0;
+	diff = 1;
+
+	if (square <= 0) {
+		return 0;
+	}
+
+	do {
+		last = root;
+		root = (root + square / root) / 2.0;
+		diff = root - last;
+	} while (diff > MINDIFF || diff < -MINDIFF);
+
+	return root;
+}

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/state_binding.c
@@ -5,6 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <math.h>
 #include <zephyr/drivers/gpio.h>
 
 #include "ble_mesh.h"
@@ -12,28 +13,6 @@
 #include "state_binding.h"
 #include "storage.h"
 #include "transition.h"
-
-#define MINDIFF 2.25e-308
-
-static float sqrt(float square)
-{
-	float root, last, diff;
-
-	root = square / 3.0;
-	diff = 1;
-
-	if (square <= 0) {
-		return 0;
-	}
-
-	do {
-		last = root;
-		root = (root + square / root) / 2.0;
-		diff = root - last;
-	} while (diff > MINDIFF || diff < -MINDIFF);
-
-	return root;
-}
 
 static int32_t ceiling(float num)
 {
@@ -58,7 +37,7 @@ static uint16_t actual_to_linear(uint16_t val)
 
 static uint16_t linear_to_actual(uint16_t val)
 {
-	return (uint16_t) (UINT16_MAX * sqrt(((float) val / UINT16_MAX)));
+	return (uint16_t) (UINT16_MAX * sqrtf(((float) val / UINT16_MAX)));
 }
 
 uint16_t constrain_lightness(uint16_t light)

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -26,24 +26,6 @@ LOG_MODULE_REGISTER(main);
 /* Bottom resistor value in ohms */
 #define BOTTOM_RESISTANCE 2000
 
-#ifndef CONFIG_NEWLIB_LIBC
-static double sqrt(double value)
-{
-	double sqrt = value / 3;
-	int i;
-
-	if (value <= 0) {
-		return 0;
-	}
-
-	for (i = 0; i < 6; i++) {
-		sqrt = (sqrt + value / sqrt) / 2;
-	}
-
-	return sqrt;
-}
-#endif /* CONFIG_NEWLIB_LIBC */
-
 static double rtd_temperature(int nom, double resistance)
 {
 	const double a0 =  3.90802E-3;


### PR DESCRIPTION
The lmp90100_evb sample included an implementation of double sqrt, and the
on_off_level_lighting_vnd_app sample included an implementation of float
sqrtf. Move that code into minimal libc instead of requiring applications
to hand-roll their own version.

Signed-off-by: Keith Packard <keithp@keithp.com>