### PR TITLE
kernel: Allow Zephyr to use libc's internal errno

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -169,7 +169,7 @@ struct _mem_domain_info {
 
 #ifdef CONFIG_THREAD_USERSPACE_LOCAL_DATA
 struct _thread_userspace_local_data {
-#if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS)
+#if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS) && !defined(CONFIG_LIBC_ERRNO)
 	int errno_var;
 #endif
 };
@@ -274,7 +274,7 @@ struct k_thread {
 	struct _thread_userspace_local_data *userspace_local_data;
 #endif
 
-#if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS)
+#if defined(CONFIG_ERRNO) && !defined(CONFIG_ERRNO_IN_TLS) && !defined(CONFIG_LIBC_ERRNO)
 #ifndef CONFIG_USERSPACE
 	/** per-thread errno variable */
 	int errno_var;

--- a/include/zephyr/sys/errno_private.h
+++ b/include/zephyr/sys/errno_private.h
@@ -17,7 +17,15 @@ extern "C" {
  * and kernel.h
  */
 
-#ifdef CONFIG_ERRNO_IN_TLS
+#ifdef CONFIG_LIBC_ERRNO
+#include <errno.h>
+
+static inline int *z_errno(void)
+{
+	return &errno;
+}
+
+#elif defined(CONFIG_ERRNO_IN_TLS)
 extern __thread int z_errno_var;
 
 static inline int *z_errno(void)
@@ -41,7 +49,7 @@ __syscall int *z_errno(void);
 }
 #endif
 
-#ifndef CONFIG_ERRNO_IN_TLS
+#if !defined(CONFIG_ERRNO_IN_TLS) && !defined(CONFIG_LIBC_ERRNO)
 #include <syscalls/errno_private.h>
 #endif /* CONFIG_ERRNO_IN_TLS */
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -204,6 +204,12 @@ config THREAD_USERSPACE_LOCAL_DATA
 	depends on USERSPACE
 	default y if ERRNO && !ERRNO_IN_TLS
 
+config LIBC_ERRNO
+	bool
+	help
+	  Use external libc errno, not the internal one. This eliminates any
+	  locally allocated errno storage and usage.
+
 config ERRNO
 	bool "Errno support"
 	default y
@@ -215,7 +221,7 @@ config ERRNO
 
 config ERRNO_IN_TLS
 	bool "Store errno in thread local storage (TLS)"
-	depends on ERRNO && THREAD_LOCAL_STORAGE
+	depends on ERRNO && THREAD_LOCAL_STORAGE && !LIBC_ERRNO
 	default y
 	help
 	  Use thread local storage to store errno instead of storing it in

--- a/kernel/errno.c
+++ b/kernel/errno.c
@@ -24,7 +24,9 @@ const int _k_neg_eagain = -EAGAIN;
 
 #ifdef CONFIG_ERRNO
 
-#ifdef CONFIG_ERRNO_IN_TLS
+#if defined(CONFIG_LIBC_ERRNO)
+/* nothing needed here */
+#elif defined(CONFIG_ERRNO_IN_TLS)
 __thread int z_errno_var;
 #else
 


### PR DESCRIPTION
For a library which already provides a multi-thread aware errno, use
that instead of creating our own internal value.

This patch is a prerequisite for picolibc, see #44096 

Signed-off-by: Keith Packard <keithp@keithp.com>