### PR TITLE
boards: mimxrt11xxx: update partition alignment for MCUBoot

### DIFF
--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
@@ -64,28 +64,29 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			/* Note: CM4 does not boot from flexspi, but CM7 code will be
-			 * stored in slot0
-			 */
+
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00020000 0x301000>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@321000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@610000 {
+			scratch_partition: partition@621000 {
 				label = "image-scratch";
-				reg = <0x00610000 DT_SIZE_K(128)>;
+				reg = <0x00621000 DT_SIZE_K(128)>;
 			};
-			storage_partition: partition@630000 {
+			storage_partition: partition@641000 {
 				label = "storage";
-				reg = <0x00630000 DT_SIZE_K(1856)>;
+				reg = <0x00641000 DT_SIZE_K(1856)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -78,23 +78,26 @@
 
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00020000 0x301000>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@321000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@610000 {
+			scratch_partition: partition@621000 {
 				label = "image-scratch";
-				reg = <0x00610000 DT_SIZE_K(128)>;
+				reg = <0x00621000 DT_SIZE_K(128)>;
 			};
-			storage_partition: partition@630000 {
+			storage_partition: partition@641000 {
 				label = "storage";
-				reg = <0x00630000 DT_SIZE_K(1856)>;
+				reg = <0x00641000 DT_SIZE_K(1856)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
@@ -64,28 +64,29 @@
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			/* Note: CM4 does not boot from flexspi, but CM7 code will be
-			 * stored in slot0
-			 */
+
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00020000 0x301000>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@321000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@610000 {
+			scratch_partition: partition@621000 {
 				label = "image-scratch";
-				reg = <0x00610000 DT_SIZE_K(128)>;
+				reg = <0x00621000 DT_SIZE_K(128)>;
 			};
-			storage_partition: partition@630000 {
+			storage_partition: partition@641000 {
 				label = "storage";
-				reg = <0x00630000 DT_SIZE_K(1856)>;
+				reg = <0x00641000 DT_SIZE_K(1856)>;
 			};
 		};
 	};

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -130,23 +130,26 @@
 
 			boot_partition: partition@0 {
 				label = "mcuboot";
-				reg = <0x00000000 DT_SIZE_K(64)>;
+				reg = <0x00000000 DT_SIZE_K(128)>;
 			};
-			slot0_partition: partition@10000 {
+			/* Note slot 0 has one additional sector,
+			 * this is intended for use with the swap move algorithm
+			 */
+			slot0_partition: partition@20000 {
 				label = "image-0";
-				reg = <0x00010000 DT_SIZE_M(3)>;
+				reg = <0x00020000 0x301000>;
 			};
-			slot1_partition: partition@310000 {
+			slot1_partition: partition@321000 {
 				label = "image-1";
-				reg = <0x00310000 DT_SIZE_M(3)>;
+				reg = <0x00321000 0x300000>;
 			};
-			scratch_partition: partition@610000 {
+			scratch_partition: partition@621000 {
 				label = "image-scratch";
-				reg = <0x00610000 DT_SIZE_K(128)>;
+				reg = <0x00621000 DT_SIZE_K(128)>;
 			};
-			storage_partition: partition@630000 {
+			storage_partition: partition@641000 {
 				label = "storage";
-				reg = <0x00630000 DT_SIZE_K(1856)>;
+				reg = <0x00641000 DT_SIZE_K(1856)>;
 			};
 		};
 	};


### PR DESCRIPTION
update partition alignment for iMX RT1170 and RT1160 to enable storing
MCUBoot image in boot partition.

Fixes #45486

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>