### PR TITLE
Trivial fixes

### DIFF
--- a/samples/drivers/soc_flash_nrf/src/main.c
+++ b/samples/drivers/soc_flash_nrf/src/main.c
@@ -155,8 +155,8 @@ void main(void)
 
 	if (!rc) {
 		printf("   Offset  0x%08x:\n", FLASH_TEST_OFFSET2);
-		printf("     belongs to the page %u of start offset 0x%08x\n",
-		       info.index, info.start_offset);
+		printf("     belongs to the page %u of start offset 0x%08lx\n",
+		       info.index, (unsigned long) info.start_offset);
 		printf("     and the size of 0x%08x B.\n", info.size);
 	} else {
 		printf("   Error: flash_get_page_info_by_offs returns %d\n",
@@ -166,9 +166,9 @@ void main(void)
 	rc = flash_get_page_info_by_idx(flash_dev, FLASH_TEST_PAGE_IDX, &info);
 
 	if (!rc) {
-		printf("   Page of number %u has start offset 0x%08x\n",
+		printf("   Page of number %u has start offset 0x%08lx\n",
 		       FLASH_TEST_PAGE_IDX,
-		       info.start_offset);
+		       (unsigned long) info.start_offset);
 		printf("     and size of 0x%08x B.\n", info.size);
 		if (info.index == FLASH_TEST_PAGE_IDX) {
 			printf("     Page index resolved properly\n");

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -8,6 +8,7 @@
 #include <limits.h>
 #include <assert.h>
 #include <string.h>
+#include <zephyr/toolchain.h>
 
 #include <zcbor_common.h>
 #include <zcbor_decode.h>

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -6,6 +6,7 @@
 
 #include <assert.h>
 #include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #include <string.h>
 #include <zcbor_common.h>

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -43,10 +43,10 @@ struct spi_cs_control spi_cs = {
 #define BUF2_SIZE 36
 
 #if CONFIG_NOCACHE_MEMORY
-static const char tx_data[] = "0123456789abcdef\0";
+static const char tx_data[BUF_SIZE] = "0123456789abcdef\0";
 static __aligned(32) char buffer_tx[BUF_SIZE] __used __attribute__((__section__(".nocache")));
 static __aligned(32) char buffer_rx[BUF_SIZE] __used __attribute__((__section__(".nocache")));
-static const char tx2_data[] = "Thequickbrownfoxjumpsoverthelazydog\0";
+static const char tx2_data[BUF2_SIZE] = "Thequickbrownfoxjumpsoverthelazydog\0";
 static __aligned(32) char buffer2_tx[BUF2_SIZE] __used __attribute__((__section__(".nocache")));
 static __aligned(32) char buffer2_rx[BUF2_SIZE] __used __attribute__((__section__(".nocache")));
 #else

--- a/tests/kernel/common/src/errno.c
+++ b/tests/kernel/common/src/errno.c
@@ -7,6 +7,7 @@
 #include <ztest.h>
 #include <zephyr/zephyr.h>
 #include <errno.h>
+#include <zephyr/sys/errno_private.h>
 
 /**
  * @brief Test the thread context

--- a/tests/lib/c_lib/src/test_qsort.c
+++ b/tests/lib/c_lib/src/test_qsort.c
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#define _GNU_SOURCE
 #include <stdbool.h>
 #include <stdlib.h>
 #include <ztest.h>

--- a/tests/lib/mem_alloc/src/main.c
+++ b/tests/lib/mem_alloc/src/main.c
@@ -16,6 +16,15 @@
  * it guarantee that ALL functionality provided is working correctly.
  */
 
+#if defined(__GNUC__)
+/*
+ * Don't complain about ridiculous alloc size requests
+ */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Walloc-size-larger-than="
+#endif
+
+#define _BSD_SOURCE
 #include <zephyr/zephyr.h>
 #include <ztest.h>
 #include <stdlib.h>


### PR DESCRIPTION
Here's a selection of trivial fixes, mostly in sample and test code, that clean up some improper API usage and make the code more compatible with the C standard library. The only change in the core OS is in the img_mgmt subsystem to add
an additional header reference.