### PR TITLE
ARC: boards: increase timeouts for nsim_hs5x_smp platform

### DIFF
--- a/boards/arc/nsim/nsim_hs5x_smp.yaml
+++ b/boards/arc/nsim/nsim_hs5x_smp.yaml
@@ -7,6 +7,7 @@ toolchain:
   - arcmwdt
   - cross-compile
 testing:
+  timeout_multiplier: 1.5
   ignore_tags:
     - net
     - bluetooth


### PR DESCRIPTION
nSIM SMP simulation is a bit slower than single-core one, so let's increase timeouts for nsim_hs5x_smp platforms as we have for nsim_hs_smp and nsim_hs6x_smp