### PR TITLE
MAINTAINERS: Add 'Microchip SAM Platforms'

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1632,7 +1632,7 @@ NXP Platforms:
   labels:
     - "platform: NXP"
 
-Microchip Platforms:
+Microchip MEC Platforms:
   status: maintained
   maintainers:
     - jvasanth1
@@ -1645,7 +1645,7 @@ Microchip Platforms:
     - soc/arm/microchip_mec/
     - drivers/*/*mchp*.c
   labels:
-    - "platform: Microchip"
+    - "platform: Microchip MEC"
 
 nRF Platforms:
     status: maintained

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1647,6 +1647,22 @@ Microchip MEC Platforms:
   labels:
     - "platform: Microchip MEC"
 
+Microchip SAM Platforms:
+  status: maintained
+  maintainers:
+    - nandojve
+  collaborators:
+    - mnkp
+    - stephanosio
+  files:
+    - boards/arm/atsam*/
+    - boards/arm/sam*/
+    - dts/arm/atmel/
+    - soc/arm/atmel_sam*/
+    - drivers/*/*sam*.c
+  labels:
+    - "platform: Microchip SAM"
+
 nRF Platforms:
     status: maintained
     maintainers:


### PR DESCRIPTION
This series renames 'Microchip Platforms' to 'Microchip MEC Platforms' and adds 'Microchip SAM Platforms' entry, with @nandojve as the maintainer, and @mnkp and @stephanosio as collaborators.