### PR TITLE
dts: arm: stm32g4: fix bosch m_can compatible

### DIFF
--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -353,7 +353,7 @@
 		};
 
 		can {
-			compatible = "bosch,m-can-base";
+			compatible = "bosch,m_can-base";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			std-filter-elements = <28>;


### PR DESCRIPTION
The compatible was erroneously changed in commit 988fe8d, which led to build failures for `nucleo_g474re` board. This commit reverts the change.
