### PR TITLE
net: lib: call socket poll if could not send data completely in http or ws (websocket)

### DIFF
--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -30,6 +30,10 @@ config HTTP_CLIENT
 	help
 	  HTTP client API
 
+config HTTP_CLIENT_SOCKET_POLL_TIMEOUT_MS
+	int "Timeout in milliseconds for polling socket when sending data"
+	default 2000
+
 module = NET_HTTP
 module-dep = NET_LOG
 module-str = Log level for HTTP client library

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -34,7 +34,19 @@ static int sendall(int sock, const void *buf, size_t len)
 	while (len) {
 		ssize_t out_len = zsock_send(sock, buf, len, 0);
 
-		if (out_len < 0) {
+		if ((out_len == 0) || (out_len < 0 && errno == EAGAIN)) {
+			struct zsock_pollfd pfd;
+			int pollres;
+
+			pfd.fd = sock;
+			pfd.events = ZSOCK_POLLOUT;
+			pollres = zsock_poll(&pfd, 1, CONFIG_HTTP_CLIENT_SOCKET_POLL_TIMEOUT_MS);
+			if (pollres >= 0) {
+				continue;
+			} else {
+				return -errno;
+			}
+		} else if (out_len < 0) {
 			return -errno;
 		}
 

--- a/subsys/net/lib/websocket/Kconfig
+++ b/subsys/net/lib/websocket/Kconfig
@@ -21,6 +21,10 @@ config WEBSOCKET_MAX_CONTEXTS
 	help
 	  How many Websockets can be created in the system.
 
+config WS_CLIENT_SOCKET_POLL_TIMEOUT_MS
+	int "Timeout in milliseconds for polling socket when sending data"
+	default 2000
+
 module = NET_WEBSOCKET
 module-dep = NET_LOG
 module-str = Log level for Websocket


### PR DESCRIPTION
In http_client, if we couldn't send all (or any data) via the socket,
invoke poll instead of blindly retrying and flooding the socket.

It's especially relevant after adding https://github.com/zephyrproject-rtos/zephyr/pull/45626
