### PR TITLE
esp32: pinctrl: move pinctrl node

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -591,6 +591,7 @@
 /include/zephyr/dt-bindings/clock/kinetis_scg.h  @henrikbrixandersen
 /include/zephyr/dt-bindings/ethernet/xlnx_gem.h  @ibirnbaum
 /include/zephyr/dt-bindings/pcie/                @dcpleung
+/include/zephyr/dt-bindings/pinctrl/esp*         @glaubermaroto
 /include/zephyr/dt-bindings/pwm/*it8xxx2*        @RuibinChang
 /include/zephyr/dt-bindings/usb/usb.h            @galak
 /include/zephyr/drivers/emul.h                   @sjg20

--- a/dts/bindings/pinctrl/espressif,esp32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/espressif,esp32-pinctrl.yaml
@@ -152,7 +152,7 @@ child-binding:
               assigned to ESP_NOSIG
             To simplify the usage, macro is available to generate "pinmux" field.
             This macro is available here:
-              -include/dt-bindings/pinctrl/esp-pinctrl-common.h
+              -include/zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h
             Some examples of macro usage:
                GPIO 3 set as UART0's RX pin
             ... {

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -30,6 +30,11 @@
 		};
 	};
 
+	pinctrl: pin-controller {
+		compatible = "espressif,esp32-pinctrl";
+		status = "okay";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -39,11 +44,6 @@
 		sram0: memory@3fc7c000 {
 			compatible = "mmio-sram";
 			reg = <0x3fc7c000 0x50000>;
-		};
-
-		pinctrl: pin-controller {
-			compatible = "espressif,esp32-pinctrl";
-			status = "okay";
 		};
 
 		intc: interrupt-controller@600c2000 {

--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -40,6 +40,11 @@
 		status = "disabled";
 	};
 
+	pinctrl: pin-controller {
+		compatible = "espressif,esp32-pinctrl";
+		status = "okay";
+	};
+
 	soc {
 		sram0: memory@3ffb0000 {
 			compatible = "mmio-sram";
@@ -126,11 +131,6 @@
 			label = "UART_2";
 			clocks = <&rtc ESP32_UART2_MODULE>;
 			status = "disabled";
-		};
-
-		pinctrl: pin-controller {
-			compatible = "espressif,esp32-pinctrl";
-			status = "okay";
 		};
 
 		ledc0: ledc@3ff59000 {

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -36,6 +36,11 @@
 		status = "disabled";
 	};
 
+	pinctrl: pin-controller {
+		compatible = "espressif,esp32-pinctrl";
+		status = "okay";
+	};
+
 	soc {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -101,11 +106,6 @@
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			current-speed = <115200>;
-		};
-
-		pinctrl: pin-controller {
-			compatible = "espressif,esp32-pinctrl";
-			status = "okay";
 		};
 
 		gpio0: gpio@3f404000 {


### PR DESCRIPTION
On Espressif SoCs, the pin controller is a virtual device, pin settings are actually controlled in a distributed way.
Therefore, that node does not belong to the SoC bus. This PR moves the pinctrl node out of that bus.

It also updates Espressif's pinctrl documentation and the CODEOWNERS file.