### PR TITLE
mgmt/mcumgr/lib: Fix image list command crashing when no device

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -41,6 +41,7 @@ extern "C" {
 #define IMG_MGMT_SWAP_TYPE_TEST		1
 #define IMG_MGMT_SWAP_TYPE_PERM		2
 #define IMG_MGMT_SWAP_TYPE_REVERT	3
+#define IMG_MGMT_SWAP_TYPE_UNKNOWN	255
 
 /**
  * Command IDs for image management group.

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -511,8 +511,7 @@ img_mgmt_impl_swap_type(int slot)
 	case BOOT_SWAP_TYPE_REVERT:
 		return IMG_MGMT_SWAP_TYPE_REVERT;
 	default:
-		assert(0);
-		return IMG_MGMT_SWAP_TYPE_NONE;
+		return IMG_MGMT_SWAP_TYPE_UNKNOWN;
 	}
 }
 


### PR DESCRIPTION
It is possible, in case of two application images, to have no access
to one of devices of the secondary image.
When asserts are enabled, such situation causes crash even though the
image list command can handle it with no problem.
The commit removes the assert and adds additional swap type:
IMG_MGMT_SWAP_TYPE_UNKNOWN to indicate situations where it was
not possible to obtain swap type from boot_util.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>