### PR TITLE
twister: update ci options for twister

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -132,9 +132,9 @@ jobs:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.1
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TWISTER_COMMON: ' --inline-logs -v -N -M --retry-failed 3 '
-      DAILY_OPTIONS: ' -M --build-only --all --no-skipped-report'
-      PR_OPTIONS: ' --clobber-output --integration --no-skipped-report'
-      PUSH_OPTIONS: ' --clobber-output -M --no-skipped-report'
+      DAILY_OPTIONS: ' -M --build-only --all'
+      PR_OPTIONS: ' --clobber-output --integration'
+      PUSH_OPTIONS: ' --clobber-output -M'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
     steps:

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -289,7 +289,7 @@ def parse_args():
             help="Commit range in the form: a..b")
     parser.add_argument('-m', '--modified-files', default=None,
             help="File with information about changed/deleted/added files.")
-    parser.add_argument('-o', '--output-file', default="testplan.csv",
+    parser.add_argument('-o', '--output-file', default="testplan.json",
             help="JSON file with the test plan to be passed to twister")
     parser.add_argument('-P', '--pull-request', action="store_true",
             help="This is a pull request")


### PR DESCRIPTION
Now that we have partially oerhauled twister in the tree, modify actions
with new options:
- not reporting filtered tests is now default
- output is json, not csv

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
