### PR TITLE
drivers: flash: stm32h7x: Fix wrong flash write offset

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -373,7 +373,7 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 	const uint8_t nbytes = FLASH_NB_32BITWORD_IN_FLASHWORD * 4;
 	uint8_t unaligned_datas[nbytes];
 
-	for (i = 0; i < len && i + 32 <= len; i += 32, offset += 32U) {
+	for (i = 0; i < len && i + nbytes <= len; i += nbytes, offset += nbytes) {
 		rc = write_ndwords(dev, offset,
 				   (const uint64_t *) data + (i >> 3),
 				   ndwords);

--- a/samples/subsys/fs/littlefs/boards/nucleo_h7a3zi_q.conf
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h7a3zi_q.conf
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2022 Christoph Heller
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# Set MPU to allow write accesses to flash memory.
+# This is required by the flash driver to be able
+# to write to the internal flash.
+CONFIG_MPU_ALLOW_FLASH_WRITE=y

--- a/samples/subsys/fs/littlefs/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h7a3zi_q.overlay
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Christoph Heller
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	fstab {
+		compatible = "zephyr,fstab";
+		lfs1: lfs1 {
+			compatible = "zephyr,fstab,littlefs";
+			read-size = <1>;
+			prog-size = <16>;
+			cache-size = <256>;
+			lookahead-size = <32>;
+			block-cycles = <512>;
+			partition = <&lfs1_partition>;
+			mount-point = "/lfs1";
+    };
+	};
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		/* Use second half of flash for the filesystem. */
+		lfs1_partition: partition@100000 {
+			label = "storage";
+			reg = <0x10000 DT_SIZE_K(1024)>;
+		};
+	};
+};


### PR DESCRIPTION
This PR fixes issue #45568

**Changes:**
- Add specific configuration and DTS overlay files for NUCLEO-H7A3ZI-Q
board to the littlefs example project. The second half of the SOC flash
is used as flash partition for littlefs.

- The flash_stm32_write_range() function of the STM32H7x flash
driver partially uses a wrong flash program word size for certain
SOC types when calculating the flash write offset. If the used
SOC is not having a flash program word size of 256 bits / 32 bytes
the written data might get corrupted, as the flash write offset
value does not match the number of bytes that were actually
written.

The fix was verified by executing the littlefs example application on a nucleo_h7a3zi_q board (uses SOC: STM32H7A3).
See issue for more details.
