### PR TITLE
soc: gigadevice: undefine CAN_MODE_NORMAL

### DIFF
--- a/soc/arm/gigadevice/gd32f403/soc.h
+++ b/soc/arm/gigadevice/gd32f403/soc.h
@@ -14,6 +14,10 @@
 
 #ifndef _ASMLANGUAGE
 #include <gd32f403.h>
+
+/* The GigaDevice HAL headers define this, but it conflicts with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* _SOC__H_ */

--- a/soc/arm/gigadevice/gd32f4xx/soc.h
+++ b/soc/arm/gigadevice/gd32f4xx/soc.h
@@ -10,6 +10,9 @@
 
 #include <gd32f4xx.h>
 
+/* The GigaDevice HAL headers define this, but it conflicts with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+
 #endif /* _ASMLANGUAGE */
 
 #endif /* _SOC_ARM_GIGADEVICE_GD32F4XX_SOC_H_ */

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.h
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.h
@@ -21,6 +21,10 @@
 #ifndef _ASMLANGUAGE
 #include <zephyr/toolchain.h>
 #include <gd32vf103.h>
+
+/* The GigaDevice HAL headers define this, but it conflicts with the Zephyr can.h */
+#undef CAN_MODE_NORMAL
+
 #endif  /* !_ASMLANGUAGE */
 
 #endif  /* RISCV_GD32VF103_SOC_H */


### PR DESCRIPTION
The GigaDevice HAL defines `CAN_MODE_NORMAL`, which conflicts with the `zephyr/drivers/can.h` header definition. Undefine it in `soc.h`.

Fixes: #45611