### PR TITLE
samples: drivers: adc: Enable test for mec172xevb_assy6906

### DIFF
--- a/samples/drivers/adc/boards/mec172xevb_assy6906.overlay
+++ b/samples/drivers/adc/boards/mec172xevb_assy6906.overlay
@@ -1,0 +1,11 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 Intel Corporation
+ */
+
+/ {
+	zephyr,user {
+		io-channels =  <&adc0 0>, <&adc0 3>, <&adc0 4>, <&adc0 5>;
+	};
+};

--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -6,6 +6,7 @@ tests:
     depends_on: adc
     platform_allow: nucleo_l073rz disco_l475_iot1 cc3220sf_launchxl
         cc3235sf_launchxl stm32l496g_disco nrf51dk_nrf51422 nrf52840dk_nrf52840
+        mec172xevb_assy6906
     integration_platforms:
       - nucleo_l073rz
       - nrf52840dk_nrf52840


### PR DESCRIPTION
Add overlay for mec172xevb_assy6906 board to enable 4 channels.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>