### PR TITLE
pm: device_runtime: return -ENOTSUP if PM not supported

### DIFF
--- a/include/zephyr/pm/device_runtime.h
+++ b/include/zephyr/pm/device_runtime.h
@@ -34,6 +34,7 @@ extern "C" {
  *
  * @retval 0 If the device runtime PM is enabled successfully.
  * @retval -EPERM If device has power state locked.
+ * @retval -ENOTSUP If the device does not support PM.
  * @retval -ENOSYS If the functionality is not available.
  * @retval -errno Other negative errno, result of suspending the device.
  *
@@ -51,6 +52,7 @@ int pm_device_runtime_enable(const struct device *dev);
  * @param dev Device instance.
  *
  * @retval 0 If the device runtime PM is disabled successfully.
+ * @retval -ENOTSUP If the device does not support PM.
  * @retval -ENOSYS If the functionality is not available.
  * @retval -errno Other negative errno, result of resuming the device.
  */
@@ -73,6 +75,7 @@ int pm_device_runtime_disable(const struct device *dev);
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
+ * @retval -ENOTSUP If the device does not support PM.
  * @retval -errno Other negative errno, result of the PM action callback.
  */
 int pm_device_runtime_get(const struct device *dev);
@@ -91,6 +94,7 @@ int pm_device_runtime_get(const struct device *dev);
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
+ * @retval -ENOTSUP If the device does not support PM.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
  * @retval -errno Other negative errno, result of the action callback.
@@ -116,6 +120,7 @@ int pm_device_runtime_put(const struct device *dev);
  *
  * @retval 0 If it succeeds. In case device runtime PM is not enabled or not
  * available this function will be a no-op and will also return 0.
+ * @retval -ENOTSUP If the device does not support PM.
  * @retval -EALREADY If device is already suspended (can only happen if get/put
  * calls are unbalanced).
  *

--- a/subsys/pm/device_runtime.c
+++ b/subsys/pm/device_runtime.c
@@ -119,6 +119,10 @@ int pm_device_runtime_get(const struct device *dev)
 	int ret = 0;
 	struct pm_device *pm = dev->pm;
 
+	if (pm == NULL) {
+		return -ENOTSUP;
+	}
+
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_get, dev);
 
 	if (!k_is_pre_kernel()) {
@@ -175,6 +179,10 @@ int pm_device_runtime_put(const struct device *dev)
 {
 	int ret;
 
+	if (dev->pm == NULL) {
+		return -ENOTSUP;
+	}
+
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put, dev);
 	ret = runtime_suspend(dev, false);
 
@@ -193,6 +201,10 @@ int pm_device_runtime_put_async(const struct device *dev)
 {
 	int ret;
 
+	if (dev->pm == NULL) {
+		return -ENOTSUP;
+	}
+
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_put_async, dev);
 	ret = runtime_suspend(dev, true);
 	SYS_PORT_TRACING_FUNC_EXIT(pm, device_runtime_put_async, dev, ret);
@@ -204,6 +216,10 @@ int pm_device_runtime_enable(const struct device *dev)
 {
 	int ret = 0;
 	struct pm_device *pm = dev->pm;
+
+	if (pm == NULL) {
+		return -ENOTSUP;
+	}
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_enable, dev);
 
@@ -253,6 +269,10 @@ int pm_device_runtime_disable(const struct device *dev)
 	int ret = 0;
 	struct pm_device *pm = dev->pm;
 
+	if (pm == NULL) {
+		return -ENOTSUP;
+	}
+
 	SYS_PORT_TRACING_FUNC_ENTER(pm, device_runtime_disable, dev);
 
 	if (!k_is_pre_kernel()) {
@@ -297,5 +317,5 @@ bool pm_device_runtime_is_enabled(const struct device *dev)
 {
 	struct pm_device *pm = dev->pm;
 
-	return atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED);
+	return pm && atomic_test_bit(&pm->flags, PM_DEVICE_FLAG_RUNTIME_ENABLED);
 }

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -217,6 +217,25 @@ static void test_api(void)
 	zassert_equal(ret, 0, NULL);
 }
 
+static int pm_unsupported_init(const struct device *dev)
+{
+	return 0;
+}
+
+DEVICE_DEFINE(pm_unsupported_device, "PM Unsupported", pm_unsupported_init,
+	      NULL, NULL, NULL, APPLICATION, 0, NULL);
+
+static void test_unsupported(void)
+{
+	const struct device *dev = DEVICE_GET(pm_unsupported_device);
+
+	zassert_false(pm_device_runtime_is_enabled(dev), "");
+	zassert_equal(pm_device_runtime_enable(dev), -ENOTSUP, "");
+	zassert_equal(pm_device_runtime_disable(dev), -ENOTSUP, "");
+	zassert_equal(pm_device_runtime_get(dev), -ENOTSUP, "");
+	zassert_equal(pm_device_runtime_put(dev), -ENOTSUP, "");
+}
+
 void test_main(void)
 {
 	dev = device_get_binding("test_driver");
@@ -225,6 +244,7 @@ void test_main(void)
 	ztest_test_suite(device_runtime_api,
 			 ztest_unit_test_setup_teardown(test_api,
 							test_api_setup,
-							test_api_teardown));
+							test_api_teardown),
+			 ztest_unit_test(test_unsupported));
 	ztest_run_test_suite(device_runtime_api);
 }


### PR DESCRIPTION
Return `-ENOTSUP` on calls to device_runtime functions if the underlying
device does not support power management, instead of hard-faulting.

Fixes #45648.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>