### PR TITLE
drivers: gpio: nrfx: Use abs_pin for GPIOTE channel obtaining

### DIFF
--- a/drivers/gpio/gpio_nrfx.c
+++ b/drivers/gpio/gpio_nrfx.c
@@ -125,7 +125,7 @@ static int gpio_nrfx_pin_configure(const struct device *port, gpio_pin_t pin,
 		.trigger = NRFX_GPIOTE_TRIGGER_NONE
 	};
 
-	err = nrfx_gpiote_channel_get(pin, &ch);
+	err = nrfx_gpiote_channel_get(abs_pin, &ch);
 	free_ch = (err == NRFX_SUCCESS);
 
 	/* Remove previously configured trigger when pin is reconfigured. */


### PR DESCRIPTION
It used the relative pin of a port in the past, which would have
issue if the same position of another port is configured too. For
example, P0.04 and P1.04 are used for the gpiote interrupts together.
The latter will free the previous one's GPIOTE channel. As a result,
the previous gpiote interrupt would not work any more. This issue
may be a typo here since other places use the right abs_pin.

Signed-off-by: Kevin Ai <kevin.ai@nordicsemi.no>