### PR TITLE
boards: hifive1_revb: add pinctrl configs for spi

### DIFF
--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -108,10 +108,20 @@
 
 &spi1 {
 	status = "okay";
+	pinctrl-0 = <&spi1_cs0_default
+		     &spi1_mosi_default
+		     &spi1_miso_default
+		     &spi1_sck_default>;
+	pinctrl-names = "default";
 };
 
 &spi2 {
 	status = "okay";
+	pinctrl-0 = <&spi1_cs2_default
+		     &spi1_mosi_default
+		     &spi1_miso_default
+		     &spi1_sck_default>;
+	pinctrl-names = "default";
 };
 
 &pwm0 {


### PR DESCRIPTION
This patch adds lack pinctrl configs for spi1 and spi2.
