### PR TITLE
tests/samples: fix usage of integration_platforms and twister filter optimizations

### DIFF
--- a/samples/drivers/lcd_cyclonev_socdk/sample.yaml
+++ b/samples/drivers/lcd_cyclonev_socdk/sample.yaml
@@ -3,8 +3,6 @@ sample:
   name: lcd_cyclonev_socdk
 common:
     tags: introduction
-    integration_platforms:
-      - native_posix
     harness: console
     harness_config:
       type: one_line

--- a/samples/sensor/mpr/sample.yaml
+++ b/samples/sensor/mpr/sample.yaml
@@ -4,7 +4,6 @@ tests:
   sample.sensor.mpr:
     harness: sensor
     tags: sensors
-    depends_on: i2c
     platform_allow: arduino_due
     integration_platforms:
       - arduino_due

--- a/samples/sensor/vcnl4040/sample.yaml
+++ b/samples/sensor/vcnl4040/sample.yaml
@@ -7,5 +7,4 @@ tests:
     integration_platforms:
       - adafruit_feather_stm32f405
     tags: sensors
-    depends_on: i2c gpio
     filter: dt_compat_enabled("vishay,vcnl4040")

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1761,6 +1761,7 @@ class TestSuite(DisablePyTestCollectionMixin):
         self.skip = False
         self.platform_exclude = None
         self.platform_allow = None
+        self.platform_type = []
         self.toolchain_exclude = None
         self.toolchain_allow = None
         self.ts_filter = None
@@ -3012,6 +3013,7 @@ class TestPlan(DisablePyTestCollectionMixin):
                        "extra_sections": {"type": "list", "default": []},
                        "integration_platforms": {"type": "list", "default": []},
                        "testcases": {"type": "list", "default": []},
+                       "platform_type": {"type": "list", "default": []},
                        "platform_exclude": {"type": "set"},
                        "platform_allow": {"type": "set"},
                        "toolchain_exclude": {"type": "set"},
@@ -3389,6 +3391,7 @@ class TestPlan(DisablePyTestCollectionMixin):
                         ts.skip = ts_dict["skip"]
                         ts.platform_exclude = ts_dict["platform_exclude"]
                         ts.platform_allow = ts_dict["platform_allow"]
+                        ts.platform_type = ts_dict["platform_type"]
                         ts.toolchain_exclude = ts_dict["toolchain_exclude"]
                         ts.toolchain_allow = ts_dict["toolchain_allow"]
                         ts.ts_filter = ts_dict["filter"]
@@ -3672,6 +3675,9 @@ class TestPlan(DisablePyTestCollectionMixin):
 
                 if ts.platform_allow and plat.name not in ts.platform_allow:
                     discards[instance] = discards.get(instance, "Not in testsuite platform allow list")
+
+                if ts.platform_type and plat.type not in ts.platform_type:
+                    discards[instance] = discards.get(instance, "Not in testsuite platform type list")
 
                 if ts.toolchain_allow and toolchain not in ts.toolchain_allow:
                     discards[instance] = discards.get(instance, "Not in testsuite toolchain allow list")

--- a/scripts/schemas/twister/testsuite-schema.yaml
+++ b/scripts/schemas/twister/testsuite-schema.yaml
@@ -104,6 +104,11 @@ mapping:
       "platform_allow":
         type: str
         required: false
+      "platform_type":
+        type: seq
+        required: false
+        sequence:
+          - type: str
       "tags":
         type: str
         required: false
@@ -247,6 +252,11 @@ mapping:
           "platform_allow":
             type: str
             required: false
+          "platform_type":
+            type: seq
+            required: false
+            sequence:
+              - type: str
           "tags":
             type: str
             required: false

--- a/tests/arch/common/semihost/testcase.yaml
+++ b/tests/arch/common/semihost/testcase.yaml
@@ -1,4 +1,5 @@
 tests:
   arch.common.semihost:
     arch_allow: arm arm64 riscv32 riscv64
-    filter: CONFIG_QEMU_TARGET
+    platform_type:
+      - qemu

--- a/tests/drivers/console/testcase.yaml
+++ b/tests/drivers/console/testcase.yaml
@@ -13,5 +13,6 @@ tests:
   drivers.console.semihost:
     tags: drivers console
     arch_allow: arm arm64 riscv32 riscv64
-    filter: CONFIG_QEMU_TARGET
+    platform_type:
+      - qemu
     extra_args: CONF_FILE=prj_semihost.conf

--- a/tests/lib/cbprintf_package/testcase.yaml
+++ b/tests/lib/cbprintf_package/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  filter: CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX
+  platform_type:
+    - qemu
+    - native
   tags: cbprintf
   # FIXME: qemu_arc_hs6x excluded, see #38041
   platform_exclude: qemu_arc_hs6x

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -130,7 +130,7 @@ tests:
   logging.log2_api_deferred_override_level:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
-    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9 native_posix
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_OVERRIDE_LEVEL=4
@@ -138,7 +138,7 @@ tests:
   logging.log2_api_deferred_override_level_rt_filtering:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
-    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9 native_posix
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
@@ -203,7 +203,7 @@ tests:
   logging.log_api_frontend_immediate_override_level:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
-    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9 native_posix
     extra_configs:
       - CONFIG_LOG_FRONTEND=y
       - CONFIG_LOG_MODE_IMMEDIATE=y
@@ -212,7 +212,7 @@ tests:
   logging.log2_api_deferred_override_level_rt_filtering:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
-    platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    platform_allow: qemu_cortex_m3 qemu_cortex_a9 native_posix
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_RUNTIME_FILTERING=y

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  filter: CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX
+  platform_type:
+    - qemu
+    - native
   tags: log_api logging
   integration_platforms:
     - native_posix

--- a/tests/subsys/logging/log_msg2/testcase.yaml
+++ b/tests/subsys/logging/log_msg2/testcase.yaml
@@ -1,5 +1,7 @@
 common:
-  filter: CONFIG_QEMU_TARGET or CONFIG_BOARD_NATIVE_POSIX
+  platform_type:
+    - qemu
+    - native
   tags: log_api logging
   # FIXME: qemu_arc_hs6x excluded, see #38041
   platform_exclude: qemu_arc_hs6x

--- a/tests/subsys/logging/log_stack/testcase.yaml
+++ b/tests/subsys/logging/log_stack/testcase.yaml
@@ -1,5 +1,6 @@
 common:
-  filter: CONFIG_QEMU_TARGET
+  platform_type:
+    - qemu
   tags: log_api logging
   integration_platforms:
     - qemu_x86

--- a/tests/ztest/ztress/testcase.yaml
+++ b/tests/ztest/ztress/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags: test_framework
-  filter: CONFIG_QEMU_TARGET
+  platform_type:
+    - qemu
 tests:
   testing.ztest.ztress:
     integration_platforms:


### PR DESCRIPTION
integration platforms can't be filtered out, adapt tests so that those
platforms are always available for testing.

Also introduced platform_type to avoid relying on runtime filters, for example if we only want to run on emulation platforms.
