### PR TITLE
boards: arm: arduino_nicla_sense_me: Add user button

### DIFF
--- a/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
+++ b/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
@@ -12,6 +12,15 @@
 	model = "Arduino Nicla Sense ME";
 	compatible = "arduino,arduino_nicla_sense_me";
 
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button: button {
+			label = "user button";
+			gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
+			status = "okay";
+		};
+	};
+
 	chosen {
 		zephyr,console = &uart0;
 		zephyr,shell-uart = &uart0;
@@ -21,6 +30,10 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
+	};
+
+	aliases {
+		sw0 = &user_button;
 	};
 };
 


### PR DESCRIPTION
This commit adds a user button to the board DTS.

The button is not connected to nRESET as suggested
by the board schematics, but rather connected to
P0.21. The source code found in the Arduino IDE
connects an interrupt to this GPIO and calls
NVIC_System_Reset from there to cause the reset.

The button was therefore added as a regular button
to cover the most general case.

This has been verified on an Arduino Nicla Sense ME.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>