### PR TITLE
drivers: stm32l5 FMC LCD display driver

### DIFF
--- a/boards/arm/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/arm/stm32l562e_dk/Kconfig.defconfig
@@ -1,6 +1,7 @@
 # STM32L562E-DK Discovery board configuration
 
 # Copyright (c) 2020 Yestin Sun
+# Copyright (c) 2022 Jeremy LOCHE
 # SPDX-License-Identifier: Apache-2.0
 
 if BOARD_STM32L562E_DK
@@ -44,5 +45,65 @@ config USE_DT_CODE_PARTITION
 	default y
 
 endif # TRUSTED_EXECUTION_NONSECURE
+
+if LVGL
+
+config LV_Z_VDB_SIZE
+	default 16
+
+config LV_Z_BITS_PER_PIXEL
+	default 16
+
+choice LV_COLOR_DEPTH
+	default LV_COLOR_DEPTH_16
+endchoice
+
+config KSCAN
+	default y
+
+config LV_Z_POINTER_KSCAN
+	default y
+
+config LV_Z_POINTER_KSCAN_DEV_NAME
+	default "FT5336"
+
+# Original orientation of the display needs to invert Y only
+
+config LV_Z_POINTER_KSCAN_INVERT_Y
+	default y
+
+endif # LVGL
+
+
+if KSCAN
+
+config I2C
+	default y
+
+config KSCAN_FT5336
+	default y
+
+config KSCAN_FT5336_INTERRUPT
+	default y
+
+config REGULATOR
+	default y
+
+endif # KSCAN
+
+
+if DISPLAY
+
+config REGULATOR
+	default y
+
+config MEMC_STM32_NOR_PSRAM
+	default y
+
+config MEMC
+	default y
+
+endif #DISPLAY
+
 
 endif # BOARD_STM32L562E_DK

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
@@ -19,11 +19,13 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,display = &st7789h2;
 	};
 
 	aliases {
 		led0 = &green_led_10;
 		sw0 = &user_button;
+		kscan0 = &touch_controller;
 	};
 };
 

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -7,6 +7,7 @@
 #include <st/l5/stm32l562Xe.dtsi>
 #include <st/l5/stm32l562qeixq-pinctrl.dtsi>
 #include "arduino_r3_connector.dtsi"
+#include <dt-bindings/memory-controller/stm32-fmc-nor-psram.h>
 
 / {
 	leds {
@@ -48,6 +49,16 @@
 			substate-id = <3>;
 			min-residency-us = <900>;
 		};
+	};
+
+	/* Voltage regulator needs to be enabled for LCD/Touch usage */
+	vdd_lcd_reg: vdd_lcd_reg {
+		compatible = "regulator-fixed-sync", "regulator-fixed";
+		label = "vdd_lcd_reg";
+		regulator-name = "vdd_lcd_reg";
+		enable-gpios = <&gpioh 0 GPIO_ACTIVE_LOW>;
+		status = "okay";
+		regulator-boot-on;
 	};
 };
 
@@ -104,6 +115,14 @@
 		reg = <0x6a>;
 		irq-gpios = <&gpiof 3 GPIO_ACTIVE_HIGH>;
 		label = "LSM6DSO";
+	};
+
+	/* Display touch panel controller FT6236 is compatible with FT5336*/
+	touch_controller: ft5336@38 {
+		compatible = "focaltech,ft5336";
+		reg = <0x38>;
+		label = "FT5336";
+		int-gpios = <&gpiof 1 GPIO_ACTIVE_LOW>;
 	};
 };
 
@@ -195,6 +214,88 @@
 	pinctrl-names = "default";
 	cs-gpios = <&gpioe 0 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	status = "okay";
+};
+
+&fmc {
+	status = "okay";
+	/* ST7789H2 FMC pinout based on UM2614 */
+	pinctrl-0 = <&fmc_nce_pd7 &fmc_nwe_pd5 &fmc_noe_pd4
+		     &fmc_a0_pf0 &fmc_d0_pd14 &fmc_d1_pd15
+		     &fmc_d2_pd0 &fmc_d3_pd1 &fmc_d4_pe7 &fmc_d5_pe8 &fmc_d6_pe9
+		     &fmc_d7_pe10 &fmc_d8_pe11 &fmc_d9_pe12 &fmc_d10_pe13
+		     &fmc_d11_pe14 &fmc_d12_pe15 &fmc_d13_pd8 &fmc_d14_pd9
+		     &fmc_d15_pd10>;
+	pinctrl-names = "default";
+
+	/* ST7789H2 FMC SRAM interface*/
+	lcd_fmc_sram: sram {
+		compatible = "st,stm32-fmc-nor-psram";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		label = "STM32_FMC_NOR_PSRAM";
+		status = "okay";
+
+		lcd_data_bus: sram@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+
+			reg = <0>;
+
+			st,control = <STM32_FMC_DATA_ADDRESS_MUX_DISABLE
+					   STM32_FMC_MEMORY_TYPE_SRAM
+					   STM32_FMC_NORSRAM_MEM_BUS_WIDTH_16
+					   STM32_FMC_BURST_ACCESS_MODE_DISABLE
+					   STM32_FMC_WAIT_SIGNAL_POLARITY_LOW
+					   STM32_FMC_WAIT_TIMING_BEFORE_WS
+					   STM32_FMC_WRITE_OPERATION_ENABLE
+					   STM32_FMC_WAIT_SIGNAL_DISABLE
+					   STM32_FMC_EXTENDED_MODE_DISABLE
+					   STM32_FMC_ASYNCHRONOUS_WAIT_DISABLE
+					   STM32_FMC_WRITE_BURST_DISABLE
+					   STM32_FMC_CONTINUOUS_CLOCK_SYNC_ONLY
+					   STM32_FMC_WRITE_FIFO_DISABLE
+					   STM32_FMC_PAGE_SIZE_NONE>;
+
+			st,timing = <1 1 32 0 2 2 STM32_FMC_ACCESS_MODE_A>;
+			st,timing-ext = <5 1 3 2 STM32_FMC_ACCESS_MODE_A>;
+		};
+	};
+};
+
+&lcd_data_bus {
+	st7789h2: st7789h2@0 {
+		/* CMD reg */
+		/* DATA reg */
+		reg = <0x60000000
+		       0x60000002>;
+
+		compatible = "sitronix,st7789h2-st-fmc";
+		label = "DISPLAY";
+		status = "okay";
+
+		backlight-gpio = <&gpioe 1 GPIO_ACTIVE_HIGH>;
+		reset-gpio = <&gpiof 14 GPIO_ACTIVE_LOW>;
+		te-gpio = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+		height = <240>;
+		width = <240>;
+		x-offset = <0>;
+		y-offset = <0>;
+		vcom = <0x1f>;
+		gctrl = <0x35>;
+		vrhs = <0x12>;
+		vdvs = <0x20>;
+		mdac = <0>;
+		lcm = <0x2c>;
+		colmod = <0x55>;
+		gamma = <0x1>;
+		porch-param = [0C 0C 00 33 33];
+		cmd2en-param = [5a 69 02 01];
+		pwctrl1-param = [a4 a1];
+		pvgam-param = [D0 08 11 08 0C 15 39 33 50 36 13 14 29 2D];
+		nvgam-param = [D0 07 10 08 06 06 39 44 51 0B 16 14 2F 31];
+		ram-param = [00 F0];
+		rgb-param = [CD 08 14];
+	};
 };
 
 zephyr_udc0: &usb {

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.dts
@@ -19,11 +19,13 @@
 		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,display = &st7789h2;
 	};
 
 	aliases {
 		led0 = &green_led_10;
 		sw0 = &user_button;
+		kscan0 = &touch_controller;
 	};
 };
 

--- a/drivers/display/CMakeLists.txt
+++ b/drivers/display/CMakeLists.txt
@@ -18,6 +18,7 @@ zephyr_library_sources_ifdef(CONFIG_ST7789V		display_st7789v.c)
 zephyr_library_sources_ifdef(CONFIG_ST7735R		display_st7735r.c)
 zephyr_library_sources_ifdef(CONFIG_STM32_LTDC		display_stm32_ltdc.c)
 zephyr_library_sources_ifdef(CONFIG_RM68200		display_rm68200.c)
+zephyr_library_sources_ifdef(CONFIG_ST7789H2_ST_FMC	display_st7789h2_st_fmc.c)
 
 zephyr_library_sources_ifdef(CONFIG_MICROBIT_DISPLAY
 	mb_display.c

--- a/drivers/display/Kconfig
+++ b/drivers/display/Kconfig
@@ -34,6 +34,7 @@ source "drivers/display/Kconfig.gd7965"
 source "drivers/display/Kconfig.dummy"
 source "drivers/display/Kconfig.ls0xx"
 source "drivers/display/Kconfig.rm68200"
+source "drivers/display/Kconfig.st7789h2_st_fmc"
 
 config FRAMEBUF_DISPLAY
 	# Hidden, selected by client drivers.

--- a/drivers/display/Kconfig.st7789h2_st_fmc
+++ b/drivers/display/Kconfig.st7789h2_st_fmc
@@ -1,0 +1,13 @@
+# ST7789H2 display driver configuration options
+
+# Copyright (c) 2022, Jeremy LOCHE
+# SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_ST7789H2_ST_FMC := sitronix,st7789h2-st-fmc
+
+config ST7789H2_ST_FMC
+	bool "ST7789H2 display driver"
+	depends on MEMC_STM32_NOR_PSRAM
+	default $(dt_compat_enabled,$(DT_COMPAT_ST7789H2_ST_FMC))
+	help
+	  Enable driver for ST7789H2 display driver using ST FMC peripheral.

--- a/drivers/display/display_st7789h2_st_fmc.c
+++ b/drivers/display/display_st7789h2_st_fmc.c
@@ -1,0 +1,430 @@
+/*
+ * Copyright (c) 2022, Jeremy LOCHE
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#define DT_DRV_COMPAT sitronix_st7789h2_st_fmc
+
+#include "display_st7789v.h"
+
+#include <zephyr/pm/device.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/display.h>
+
+#define LOG_LEVEL CONFIG_DISPLAY_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(display_st7789h2, CONFIG_DISPLAY_LOG_LEVEL);
+
+struct st7789h2_fmc_data {
+	uint16_t height;
+	uint16_t width;
+	uint16_t x_offset;
+	uint16_t y_offset;
+};
+
+struct st7789h2_fmc_config {
+	uint16_t *bus_register_addr;
+	uint16_t *bus_data_addr;
+	const struct gpio_dt_spec reset_gpio;
+	const struct gpio_dt_spec backlight_gpio;
+	const struct gpio_dt_spec te_gpio;
+	uint8_t vcom[1];
+	uint8_t gctrl[1];
+	uint8_t vdvvrhen;
+	uint8_t vrhs[1];
+	uint8_t vdvs[1];
+	uint8_t mdac[1];
+	uint8_t lcm[1];
+	uint8_t colmod[1];
+	uint8_t gamma[1];
+	uint8_t porch_param[5];
+	uint8_t cmd2en_param[4];
+	uint8_t pwctrl1_param[2];
+	uint8_t pvgam_param[14];
+	uint8_t nvgam_param[14];
+	uint8_t ram_param[2];
+	uint8_t rgb_param[3];
+};
+
+#define ST7789H2_PIXEL_SIZE 2u
+
+static void st7789h2_set_lcd_margins(struct st7789h2_fmc_data *data,
+			     uint16_t x_offset, uint16_t y_offset)
+{
+	data->x_offset = x_offset;
+	data->y_offset = y_offset;
+}
+
+static void st7789h2_transmit(const struct device *dev, uint8_t cmd,
+		uint8_t *tx_data, size_t tx_count)
+{
+	const struct st7789h2_fmc_config *config = dev->config;
+
+	/* Write register address */
+	*(config->bus_register_addr) = cmd;
+
+	if (tx_data != NULL) {
+		for (size_t count = 0; count < tx_count; count++) {
+			*(config->bus_data_addr) = (uint16_t) tx_data[count];
+		}
+	}
+}
+
+static inline void st7789h2_backlight_on(const struct st7789h2_fmc_config *config)
+{
+	if (config->backlight_gpio.port == NULL) {
+		return;
+	}
+
+	gpio_pin_set_dt(&config->backlight_gpio, 1);
+}
+
+static inline void st7789h2_backlight_off(const struct st7789h2_fmc_config *config)
+{
+	if (config->backlight_gpio.port == NULL) {
+		return;
+	}
+
+	gpio_pin_set_dt(&config->backlight_gpio, 0);
+}
+
+static void st7789h2_exit_sleep(const struct device *dev)
+{
+	st7789h2_transmit(dev, ST7789V_CMD_SLEEP_OUT, NULL, 0);
+	/* Datasheet advises to wait 5ms before any new command */
+	/* and 120 ms before sending another sleep-in command */
+	/* just wait the maximum of the two delays */
+	k_sleep(K_MSEC(120));
+}
+
+static void st7789h2_reset_display(const struct device *dev)
+{
+	const struct st7789h2_fmc_config *config = dev->config;
+
+	LOG_DBG("Resetting display");
+
+	if (config->reset_gpio.port) {
+		gpio_pin_set_dt(&config->reset_gpio, 1);
+		/* Minimum duration for reset pulse is 10us */
+		k_sleep(K_MSEC(1));
+		gpio_pin_set_dt(&config->reset_gpio, 0);
+		/* Allow for reset procedure to finish in max 5ms */
+		k_sleep(K_MSEC(5));
+	} else {
+		st7789h2_transmit(dev, ST7789V_CMD_SW_RESET, NULL, 0);
+		k_sleep(K_MSEC(5));
+	}
+}
+
+static int st7789h2_blanking_on(const struct device *dev)
+{
+	st7789h2_transmit(dev, ST7789V_CMD_DISP_OFF, NULL, 0);
+	return 0;
+}
+
+static int st7789h2_blanking_off(const struct device *dev)
+{
+	st7789h2_transmit(dev, ST7789V_CMD_DISP_ON, NULL, 0);
+	return 0;
+}
+
+static int st7789h2_read(const struct device *dev,
+			const uint16_t x,
+			const uint16_t y,
+			const struct display_buffer_descriptor *desc,
+			void *buf)
+{
+	return -ENOTSUP;
+}
+
+static void st7789h2_set_mem_area(const struct device *dev, const uint16_t x,
+				 const uint16_t y, const uint16_t w, const uint16_t h)
+{
+	struct st7789h2_fmc_data *data = dev->data;
+	uint16_t ram_x = x + data->x_offset;
+	uint16_t ram_y = y + data->y_offset;
+	uint16_t tmp_data[2];
+
+	tmp_data[0] = sys_cpu_to_be16(ram_x);
+	tmp_data[1] = sys_cpu_to_be16(ram_x + w - 1);
+	st7789h2_transmit(dev, ST7789V_CMD_CASET, (uint8_t *)&tmp_data[0], 4);
+
+	tmp_data[0] = sys_cpu_to_be16(ram_y);
+	tmp_data[1] = sys_cpu_to_be16(ram_y + h - 1);
+	st7789h2_transmit(dev, ST7789V_CMD_RASET, (uint8_t *)&tmp_data[0], 4);
+}
+
+static int st7789h2_write(const struct device *dev,
+			 const uint16_t x,
+			 const uint16_t y,
+			 const struct display_buffer_descriptor *desc,
+			 const void *buf)
+{
+	const struct st7789h2_fmc_config *config = dev->config;
+
+	__ASSERT(desc->width <= desc->pitch, "Pitch is smaller then width");
+	__ASSERT((desc->pitch * ST7789H2_PIXEL_SIZE * desc->height) <= desc->buf_size,
+			"Input buffer to small");
+
+	LOG_DBG("Writing %dx%d (w,h) @ %dx%d (x,y) p=%d n=%d",
+			desc->width, desc->height, x, y, desc->pitch, desc->buf_size);
+
+	st7789h2_set_mem_area(dev, x, y, desc->width, desc->height);
+
+	st7789h2_transmit(dev, ST7789V_CMD_RAMWR, NULL, 0);
+
+	/* Write register address */
+	uint16_t *buffer = (void *)buf;
+	size_t len = desc->buf_size/ST7789H2_PIXEL_SIZE;
+
+	for (size_t i = 0; i < len; i++) {
+		*(config->bus_data_addr) = buffer[i];
+	}
+
+	return 0;
+}
+
+static void *st7789h2_get_framebuffer(const struct device *dev)
+{
+	return NULL;
+}
+
+static int st7789h2_set_brightness(const struct device *dev,
+			   const uint8_t brightness)
+{
+	return -ENOTSUP;
+}
+
+static int st7789h2_set_contrast(const struct device *dev,
+			 const uint8_t contrast)
+{
+	return -ENOTSUP;
+}
+
+static void st7789h2_get_capabilities(const struct device *dev,
+			      struct display_capabilities *capabilities)
+{
+	struct st7789h2_fmc_data *data = dev->data;
+
+	memset(capabilities, 0, sizeof(struct display_capabilities));
+	capabilities->x_resolution = data->width;
+	capabilities->y_resolution = data->height;
+
+	capabilities->supported_pixel_formats = PIXEL_FORMAT_RGB_565;
+	capabilities->current_pixel_format = PIXEL_FORMAT_RGB_565;
+
+	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
+}
+
+static int st7789h2_set_pixel_format(const struct device *dev,
+			     const enum display_pixel_format pixel_format)
+{
+
+	if (pixel_format == PIXEL_FORMAT_RGB_565) {
+		return 0;
+	}
+	LOG_WRN("Pixel format change not implemented");
+	return -ENOTSUP;
+}
+
+static int st7789h2_set_orientation(const struct device *dev,
+			    const enum display_orientation orientation)
+{
+	if (orientation == DISPLAY_ORIENTATION_NORMAL) {
+		return 0;
+	}
+	LOG_WRN("Changing display orientation not implemented");
+	return -ENOTSUP;
+}
+
+static void st7789h2_lcd_init(const struct device *dev)
+{
+	const struct st7789h2_fmc_config *config = dev->config;
+	struct st7789h2_fmc_data *data = dev->data;
+	uint8_t tmp;
+
+	st7789h2_set_lcd_margins(data, data->x_offset,
+				data->y_offset);
+
+	st7789h2_transmit(dev, ST7789V_CMD_CMD2EN, (uint8_t *) config->cmd2en_param,
+			 sizeof(config->cmd2en_param));
+
+	st7789h2_transmit(dev, ST7789V_CMD_PORCTRL, (uint8_t *) config->porch_param,
+			 sizeof(config->porch_param));
+
+	/* Digital Gamma Enable, default disabled */
+	tmp = 0x00;
+	st7789h2_transmit(dev, ST7789V_CMD_DGMEN, &tmp, 1);
+
+	/* Frame Rate Control in Normal Mode, default value */
+	tmp = 0x1e; /* 40 Hz */
+	st7789h2_transmit(dev, ST7789V_CMD_FRCTRL2, &tmp, 1);
+
+	st7789h2_transmit(dev, ST7789V_CMD_GCTRL, (uint8_t *) config->gctrl, 1);
+
+	st7789h2_transmit(dev, ST7789V_CMD_VCOMS, (uint8_t *) config->vcom, 1);
+
+	if (config->vdvvrhen) {
+		tmp = 0x01;
+		st7789h2_transmit(dev, ST7789V_CMD_VDVVRHEN, &tmp, 1);
+		st7789h2_transmit(dev, ST7789V_CMD_VRH, (uint8_t *) config->vrhs, 1);
+		st7789h2_transmit(dev, ST7789V_CMD_VDS, (uint8_t *) config->vdvs, 1);
+	}
+
+	st7789h2_transmit(dev, ST7789V_CMD_PWCTRL1, (uint8_t *) config->pwctrl1_param,
+			 sizeof(config->pwctrl1_param));
+
+	/* Memory Data Access Control */
+	st7789h2_transmit(dev, ST7789V_CMD_MADCTL, (uint8_t *) config->mdac, 1);
+
+	/* Interface Pixel Format */
+	st7789h2_transmit(dev, ST7789V_CMD_COLMOD, (uint8_t *) config->colmod, 1);
+
+	st7789h2_transmit(dev, ST7789V_CMD_LCMCTRL, (uint8_t *) config->lcm, 1);
+
+	st7789h2_transmit(dev, ST7789V_CMD_GAMSET, (uint8_t *) config->gamma, 1);
+
+	st7789h2_transmit(dev, ST7789V_CMD_INV_ON, NULL, 0);
+
+	st7789h2_transmit(dev, ST7789V_CMD_PVGAMCTRL, (uint8_t *) config->pvgam_param,
+			 sizeof(config->pvgam_param));
+
+	st7789h2_transmit(dev, ST7789V_CMD_NVGAMCTRL, (uint8_t *) config->nvgam_param,
+			 sizeof(config->nvgam_param));
+
+	st7789h2_transmit(dev, ST7789V_CMD_RAMCTRL, (uint8_t *) config->ram_param,
+			 sizeof(config->ram_param));
+
+	st7789h2_transmit(dev, ST7789V_CMD_RGBCTRL, (uint8_t *) config->rgb_param,
+			 sizeof(config->rgb_param));
+}
+
+static int st7789h2_init(const struct device *dev)
+{
+	const struct st7789h2_fmc_config *config = dev->config;
+
+	LOG_INF("fmc address: %p / %p", config->bus_data_addr,
+					config->bus_register_addr);
+
+	/* Optional GPIOs are set to NULL when not used */
+	if (config->reset_gpio.port) {
+		if (!device_is_ready(config->reset_gpio.port)) {
+			LOG_ERR("reset_gpio is not ready");
+			return -ENODEV;
+		}
+
+		if (gpio_pin_configure_dt(&config->reset_gpio, GPIO_OUTPUT_ACTIVE)) {
+			LOG_ERR("Couldn't configure reset pin");
+			return -EIO;
+		}
+	}
+
+	if (config->backlight_gpio.port) {
+		if (!device_is_ready(config->backlight_gpio.port)) {
+			LOG_ERR("backlight_gpio is not ready");
+			return -ENODEV;
+		}
+
+		if (gpio_pin_configure_dt(&config->backlight_gpio, GPIO_OUTPUT_ACTIVE)) {
+			LOG_ERR("Couldn't configure backlight pin");
+			return -EIO;
+		}
+	}
+
+	st7789h2_backlight_on(config);
+
+	st7789h2_reset_display(dev);
+
+	st7789h2_blanking_on(dev);
+
+	st7789h2_lcd_init(dev);
+
+	st7789h2_exit_sleep(dev);
+
+	return 0;
+}
+
+#ifdef CONFIG_PM_DEVICE
+static int st7789h2_pm_control(const struct device *dev,
+			      enum pm_device_action action)
+{
+	int ret = 0;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		st7789h2_exit_sleep(dev);
+		break;
+	case PM_DEVICE_ACTION_SUSPEND:
+		st7789h2_transmit(dev, ST7789V_CMD_SLEEP_IN, NULL, 0);
+		break;
+	default:
+		ret = -ENOTSUP;
+		break;
+	}
+
+	return ret;
+}
+#endif /* CONFIG_PM_DEVICE */
+
+static const struct display_driver_api st7789h2_api = {
+	.blanking_on = st7789h2_blanking_on,
+	.blanking_off = st7789h2_blanking_off,
+	.write = st7789h2_write,
+	.read = st7789h2_read,
+	.get_framebuffer = st7789h2_get_framebuffer,
+	.set_brightness = st7789h2_set_brightness,
+	.set_contrast = st7789h2_set_contrast,
+	.get_capabilities = st7789h2_get_capabilities,
+	.set_pixel_format = st7789h2_set_pixel_format,
+	.set_orientation = st7789h2_set_orientation,
+};
+
+
+#define ST7789H2_DATA_INIT(inst) \
+	static struct st7789h2_fmc_data st7789h2_fmc_data_ ## inst = {                             \
+		.width = DT_INST_PROP(inst, width),                                                \
+		.height = DT_INST_PROP(inst, height),                                              \
+		.x_offset = DT_INST_PROP(inst, x_offset),                                          \
+		.y_offset = DT_INST_PROP(inst, y_offset),                                          \
+	};
+
+#define ST7789H2_CONFIG_INIT(inst) \
+	static const struct st7789h2_fmc_config st7789h2_fmc_config_ ## inst = {                   \
+		.bus_register_addr = (uint16_t *) (DT_INST_REG_ADDR_BY_IDX(inst, 0)),              \
+		.bus_data_addr = (uint16_t *) (DT_INST_REG_ADDR_BY_IDX(inst, 1)),                  \
+		.vcom = { DT_INST_PROP(inst, vcom) },                                              \
+		.gctrl = { DT_INST_PROP(inst, gctrl) },                                            \
+		.vdvvrhen = DT_INST_NODE_HAS_PROP(inst, vdvs) && DT_INST_NODE_HAS_PROP(inst, vrhs),\
+		.vrhs = { DT_INST_PROP(inst, vrhs) },                                              \
+		.vdvs = { DT_INST_PROP(inst, vdvs) },                                              \
+		.mdac = { DT_INST_PROP(inst, mdac) },                                              \
+		.lcm = { DT_INST_PROP(inst, lcm) },                                                \
+		.colmod = { DT_INST_PROP(inst, colmod) },                                          \
+		.gamma = { DT_INST_PROP(inst, gamma) },                                            \
+		.porch_param = DT_INST_PROP(inst, porch_param),                                    \
+		.cmd2en_param = DT_INST_PROP(inst, cmd2en_param),                                  \
+		.pwctrl1_param = DT_INST_PROP(inst, pwctrl1_param),                                \
+		.pvgam_param = DT_INST_PROP(inst, pvgam_param),                                    \
+		.nvgam_param = DT_INST_PROP(inst, nvgam_param),                                    \
+		.ram_param = DT_INST_PROP(inst, ram_param),                                        \
+		.rgb_param = DT_INST_PROP(inst, rgb_param),                                        \
+		.reset_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, reset_gpio, { 0 }),                   \
+		.backlight_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, backlight_gpio, { 0 }),           \
+		.te_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, te_gpio, { 0 }),                         \
+	};
+
+#define ST7789H2_INIT(inst)                                                                        \
+	ST7789H2_CONFIG_INIT(inst);                                                                \
+	ST7789H2_DATA_INIT(inst);                                                                  \
+	PM_DEVICE_DT_DEFINE(inst, st7789h2_pm_control);                                            \
+	DEVICE_DT_INST_DEFINE(inst, st7789h2_init, PM_DEVICE_DT_GET(inst),                         \
+			      &st7789h2_fmc_data_ ## inst,                                         \
+			      &st7789h2_fmc_config_ ## inst,                                       \
+			      POST_KERNEL, CONFIG_DISPLAY_INIT_PRIORITY,                           \
+			      &st7789h2_api);                                                      \
+
+
+DT_INST_FOREACH_STATUS_OKAY(ST7789H2_INIT)

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -620,6 +620,16 @@
 			status = "disabled";
 			label = "UCPD_1";
 		};
+
+		/* Non secure address 0x44020000 */
+		/* Secure address 0x54020000*/
+		fmc: memory-controller@44020000 {
+			compatible = "st,stm32-fmc";
+			reg = <0x44020000 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000001>;
+			label = "STM32_FMC";
+			status = "disabled";
+		};
 	};
 
 	usb_fs_phy: usbphy {

--- a/dts/bindings/display/sitronix,st7789h2-st-fmc.yaml
+++ b/dts/bindings/display/sitronix,st7789h2-st-fmc.yaml
@@ -1,0 +1,217 @@
+# Copyright (c) 2022, Jeremy LOCHE
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  ST7789H2 320x240 display controller
+
+  Using the FMC peripheral of STM32 microcontrollers parallel bus
+  interface for the read/write operations to the display.
+
+  You need to configure the FMC peripheral as an SRAM controller
+  with correct bank access timing and configuration.
+
+  This drivers only needs 2 address to work and defined in "reg = <>":
+    Register/Command address:
+      Used to write the LCD controller registers
+    Data address:
+      Used to write LCD RAM display data
+
+  Example configuration:
+
+  &fmc {
+    status = "okay";
+    /* ST7789H2 FMC pinout based on your boards layout */
+    pinctrl-0 = <...>;
+    pinctrl-names = "default";
+
+    /* ST7789H2 FMC SRAM interface*/
+    lcd_fmc_sram: sram {
+      compatible = "st,stm32-fmc-nor-psram";
+      #address-cells = <1>;
+      #size-cells = <0>;
+      label = "STM32_FMC_NOR_PSRAM";
+      status = "okay";
+
+      lcd_data_bus: sram@0 {
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        reg = <0>;
+
+        /* Configure the FMC bus */
+        st,control = <STM32_FMC_DATA_ADDRESS_MUX_DISABLE
+                      STM32_FMC_MEMORY_TYPE_SRAM
+                      STM32_FMC_NORSRAM_MEM_BUS_WIDTH_16
+                      STM32_FMC_BURST_ACCESS_MODE_DISABLE
+                      STM32_FMC_WAIT_SIGNAL_POLARITY_LOW
+                      STM32_FMC_WAIT_TIMING_BEFORE_WS
+                      STM32_FMC_WRITE_OPERATION_ENABLE
+                      STM32_FMC_WAIT_SIGNAL_DISABLE
+                      STM32_FMC_EXTENDED_MODE_DISABLE
+                      STM32_FMC_ASYNCHRONOUS_WAIT_DISABLE
+                      STM32_FMC_WRITE_BURST_DISABLE
+                      STM32_FMC_CONTINUOUS_CLOCK_SYNC_ONLY
+                      STM32_FMC_WRITE_FIFO_DISABLE
+                      STM32_FMC_PAGE_SIZE_NONE>;
+
+        st,timing = <1 1 32 0 2 2 STM32_FMC_ACCESS_MODE_A>;
+        st,timing-ext = <5 1 3 2 STM32_FMC_ACCESS_MODE_A>;
+      };
+    };
+  };
+
+  &lcd_data_bus {
+    st7789h2: st7789h2@0 {
+      /* CMD reg */
+      /* DATA reg */
+      reg = <0x60000000
+            0x60000002>;
+
+      compatible = "sitronix,st7789h2-st-fmc";
+      label = "DISPLAY";
+      status = "okay";
+
+      backlight-gpio = <&gpioe 1 GPIO_ACTIVE_HIGH>;
+      reset-gpio = <&gpiof 14 GPIO_ACTIVE_LOW>;
+      te-gpio = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+      height = <240>;
+      width = <240>;
+      x-offset = <0>;
+      y-offset = <0>;
+      vcom = <0x1f>;
+      gctrl = <0x35>;
+      vrhs = <0x12>;
+      vdvs = <0x20>;
+      mdac = <0>;
+      lcm = <0x2c>;
+      colmod = <0x55>;
+      gamma = <0x1>;
+      porch-param = [0C 0C 00 33 33];
+      cmd2en-param = [5a 69 02 01];
+      pwctrl1-param = [a4 a1];
+      pvgam-param = [D0 08 11 08 0C 15 39 33 50 36 13 14 29 2D];
+      nvgam-param = [D0 07 10 08 06 06 39 44 51 0B 16 14 2F 31];
+      ram-param = [00 F0];
+      rgb-param = [CD 08 14];
+    };
+  };
+
+
+
+
+compatible: "sitronix,st7789h2-st-fmc"
+
+include: display-controller.yaml
+
+properties:
+
+    backlight-gpio:
+      type: phandle-array
+      specifier-space: gpio
+      required: false
+      description: BACKLIGHT pin
+
+    reset-gpio:
+      type: phandle-array
+      specifier-space: gpio
+      required: false
+      description: |
+        RESET pin.
+
+        The RESET pin of ST7789H2 is active low.
+        If connected directly the MCU pin should be configured
+        as active low.
+
+    te-gpio:
+      type: phandle-array
+      specifier-space: gpio
+      required: false
+      description: |
+        Tearing effect line pin
+
+        The TE pin of ST7789H2 is used as VSYNC line
+
+    x-offset:
+      type: int
+      required: true
+      description: The column offset in pixels of the LCD to the controller memory
+
+    y-offset:
+      type: int
+      required: true
+      description: The row offset in pixels of the LCD to the controller memory
+
+    vcom:
+      type: int
+      required: true
+      description: VCOM Setting
+
+    gctrl:
+      type: int
+      required: true
+      description: Gate Control
+
+    vrhs:
+      type: int
+      required: false
+      description: VRH Setting
+
+    vdvs:
+      type: int
+      required: false
+      description: VDV Setting
+
+    mdac:
+      type: int
+      required: true
+      description: Memory Data Access Control
+
+    lcm:
+      type: int
+      required: true
+      description: LCM Setting
+
+    colmod:
+      type: int
+      required: true
+      description: Interface Pixel Format
+
+    gamma:
+      type: int
+      required: true
+      description: Gamma Setting
+
+    porch-param:
+      type: uint8-array
+      required: true
+      description: Porch Setting
+
+    cmd2en-param:
+      type: uint8-array
+      required: true
+      description: Command 2 Enable Parameter
+
+    pwctrl1-param:
+      type: uint8-array
+      required: true
+      description: Power Control 1 Parameter
+
+    pvgam-param:
+      type: uint8-array
+      required: true
+      description: Positive Voltage Gamma Control Parameter
+
+    nvgam-param:
+      type: uint8-array
+      required: true
+      description: Negative Voltage Gamma Control Parameter
+
+    ram-param:
+      type: uint8-array
+      required: true
+      description: RAM Control Parameter
+
+    rgb-param:
+      type: uint8-array
+      required: true
+      description: RGB Interface Control Parameter


### PR DESCRIPTION
Fixes #39289

Improvement to PR #39335 now that #44448 has been merged.

Adds support for STM32L562E-DK driver TFT color display based on the ST7789H2 driver.
The implementation uses the FMC peripheral to drive the ST7789H2 with a 16bit parallel interface.

Initial support added to STM32L562E_DK board.