### PR TITLE
kernel: Allow non-zephyr toolchains to advertise TLS support

### DIFF
--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -922,7 +922,7 @@ config TICKLESS_KERNEL
 
 config TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
 	bool
-	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr"
+	default y if "$(ZEPHYR_TOOLCHAIN_VARIANT)" = "zephyr" || "$(ZEPHYR_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE)" = "y"
 	help
 	  Hidden option to signal that toolchain supports generating code
 	  with thread local storage.


### PR DESCRIPTION
Use a new environment variable,
ZEPHYR_TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE, to set the value for
TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE instead of setting it to 'n' for
all non-Zephyr toolchains. In particular, the Debian arm-none-eabi
toolchain has TLS support and with this option, can be used to build
Zephyr with thread local variables.

I couldn't find any other way to do this as this is a hidden config variable. Cmake could
figure this out at build time by testing the compiler for native TLS support, so if there was
some way to make this depend on the output of a cmake test, that seems like it would be better.

Signed-off-by: Keith Packard <keithp@keithp.com>