### PR TITLE
cavstwist: Add --tool-path option for rimage

### DIFF
--- a/soc/xtensa/intel_adsp/tools/cavstwist.sh
+++ b/soc/xtensa/intel_adsp/tools/cavstwist.sh
@@ -100,7 +100,8 @@ if [ "$DO_SIGN" = "1" ]; then
     ELF=$BLDDIR/zephyr/zephyr.elf.mod
     BOOT=$BLDDIR/zephyr/bootloader.elf.mod
     (cd $BLDDIR;
-     west sign --tool-data=$CAVS_RIMAGE/config -t rimage -- -k $CAVS_KEY)
+     west sign --tool-data="$CAVS_RIMAGE"/config -t rimage --tool-path "$CAVS_RIMAGE"/rimage -- -k $CAVS_KEY
+     )
     cp $BLDDIR/zephyr/zephyr.ri $IMAGE
 fi
 


### PR DESCRIPTION
Explicitly add --tool-path option when invoking "west sign"
from cavstwist.sh. The $CAVS_RIMAGE is meant for that.
So no need to modify the $PATH.

Signed-off-by: Ming Shao <ming.shao@intel.com>