### PR TITLE
Enable acmp driver for imxrt

### DIFF
--- a/boards/arm/mimxrt1170_evk/doc/index.rst
+++ b/boards/arm/mimxrt1170_evk/doc/index.rst
@@ -127,6 +127,8 @@ features:
 +-----------+------------+-------------------------------------+
 | DISPLAY   | on-chip    | display                             |
 +-----------+------------+-------------------------------------+
+| ACMP      | on-chip    | analog comparator                   |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:
 ``boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7_defconfig``

--- a/drivers/sensor/mcux_acmp/mcux_acmp.c
+++ b/drivers/sensor/mcux_acmp/mcux_acmp.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Vestas Wind Systems A/S
+ * Copyright 2022 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -14,24 +15,6 @@
 #include <zephyr/drivers/pinctrl.h>
 
 LOG_MODULE_REGISTER(mcux_acmp, CONFIG_SENSOR_LOG_LEVEL);
-
-#if defined(FSL_FEATURE_ACMP_HAS_C1_INPSEL_BIT) && (FSL_FEATURE_ACMP_HAS_C1_INPSEL_BIT == 1U)
-#define MCUX_ACMP_HAS_INPSEL 1
-#else
-#define MCUX_ACMP_HAS_INPSEL 0
-#endif
-
-#if defined(FSL_FEATURE_ACMP_HAS_C1_INNSEL_BIT) && (FSL_FEATURE_ACMP_HAS_C1_INNSEL_BIT == 1U)
-#define MCUX_ACMP_HAS_INNSEL 1
-#else
-#define MCUX_ACMP_HAS_INNSEL 0
-#endif
-
-#if defined(FSL_FEATURE_ACMP_HAS_C0_OFFSET_BIT) && (FSL_FEATURE_ACMP_HAS_C0_OFFSET_BIT == 1U)
-#define MCUX_ACMP_HAS_OFFSET 1
-#else
-#define MCUX_ACMP_HAS_OFFSET 0
-#endif
 
 #define MCUX_ACMP_DAC_LEVELS 256
 #define MCUX_ACMP_INPUT_CHANNELS 8
@@ -73,6 +56,9 @@ struct mcux_acmp_data {
 	acmp_config_t config;
 	acmp_channel_config_t channels;
 	acmp_dac_config_t dac;
+#if MCUX_ACMP_HAS_DISCRETE_MODE
+	acmp_discrete_mode_config_t discrete_config;
+#endif
 #ifdef CONFIG_MCUX_ACMP_TRIGGER
 	const struct device *dev;
 	sensor_trigger_handler_t rising;
@@ -189,6 +175,72 @@ static int mcux_acmp_attr_set(const struct device *dev,
 			return -EINVAL;
 		}
 		break;
+#if MCUX_ACMP_HAS_DISCRETE_MODE
+	case SENSOR_ATTR_MCUX_ACMP_POSITIVE_DISCRETE_MODE:
+		if (val1 <= 1 && val1 >= 0) {
+			LOG_DBG("pdiscrete = %d", val1);
+			data->discrete_config.enablePositiveChannelDiscreteMode = val1;
+			ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_NEGATIVE_DISCRETE_MODE:
+		if (val1 <= 1 && val1 >= 0) {
+			LOG_DBG("ndiscrete = %d", val1);
+			data->discrete_config.enableNegativeChannelDiscreteMode = val1;
+			ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_CLOCK:
+		if (val1 <= kACMP_DiscreteClockFast && val1 >= kACMP_DiscreteClockSlow) {
+			LOG_DBG("discreteClk = %d", val1);
+			data->discrete_config.clockSource = val1;
+			ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_ENABLE_RESISTOR_DIVIDER:
+		if (val1 <= 1 && val1 >= 0) {
+			LOG_DBG("discreteClk = %d", val1);
+			data->discrete_config.enableResistorDivider = val1;
+			ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_SAMPLE_TIME:
+		if (val1 <= kACMP_DiscreteSampleTimeAs256T &&
+		    val1 >= kACMP_DiscreteSampleTimeAs1T) {
+			LOG_DBG("discrete sampleTime = %d", val1);
+			data->discrete_config.sampleTime = val1;
+			ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_PHASE1_TIME:
+		if (val1 <= kACMP_DiscretePhaseTimeAlt7 && val1 >= kACMP_DiscretePhaseTimeAlt0) {
+			LOG_DBG("discrete phase1Time = %d", val1);
+			data->discrete_config.phase1Time = val1;
+			ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+		} else {
+			return -EINVAL;
+		}
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_PHASE2_TIME:
+		if (val1 <= kACMP_DiscretePhaseTimeAlt7 && val1 >= kACMP_DiscretePhaseTimeAlt0) {
+			LOG_DBG("discrete phase2Time = %d", val1);
+			data->discrete_config.phase2Time = val1;
+			ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+		} else {
+			return -EINVAL;
+		}
+		break;
+#endif /* MCUX_ACMP_HAS_DISCRETE_MODE */
 	default:
 		return -ENOTSUP;
 	}
@@ -240,6 +292,29 @@ static int mcux_acmp_attr_get(const struct device *dev,
 	case SENSOR_ATTR_MCUX_ACMP_NEGATIVE_MUX_INPUT:
 		val->val1 = data->channels.minusMuxInput;
 		break;
+#if MCUX_ACMP_HAS_DISCRETE_MODE
+	case SENSOR_ATTR_MCUX_ACMP_POSITIVE_DISCRETE_MODE:
+		val->val1 = data->discrete_config.enablePositiveChannelDiscreteMode;
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_NEGATIVE_DISCRETE_MODE:
+		val->val1 = data->discrete_config.enableNegativeChannelDiscreteMode;
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_CLOCK:
+		val->val1 = data->discrete_config.clockSource;
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_ENABLE_RESISTOR_DIVIDER:
+		val->val1 = data->discrete_config.enableResistorDivider;
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_SAMPLE_TIME:
+		val->val1 = data->discrete_config.sampleTime;
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_PHASE1_TIME:
+		val->val1 = data->discrete_config.phase1Time;
+		break;
+	case SENSOR_ATTR_MCUX_ACMP_DISCRETE_PHASE2_TIME:
+		val->val1 = data->discrete_config.phase2Time;
+		break;
+#endif /* MCUX_ACMP_HAS_DISCRETE_MODE */
 	default:
 		return -ENOTSUP;
 	}
@@ -365,6 +440,11 @@ static int mcux_acmp_init(const struct device *dev)
 	data->config.useUnfilteredOutput = config->unfiltered;
 	data->config.enablePinOut = config->output;
 	ACMP_Init(config->base, &data->config);
+
+#if MCUX_ACMP_HAS_DISCRETE_MODE
+	ACMP_GetDefaultDiscreteModeConfig(&data->discrete_config);
+	ACMP_SetDiscreteModeConfig(config->base, &data->discrete_config);
+#endif
 
 	ACMP_EnableWindowMode(config->base, config->window);
 	ACMP_SetFilterConfig(config->base, &config->filter);

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -915,6 +915,42 @@
 			#io-channel-cells = <1>;
 		};
 
+		acmp1: cmp@401a4000 {
+			compatible = "nxp,kinetis-acmp";
+			reg = <0x401a4000 0x4000>;
+			interrupts = <157 0>;
+			label = "CMP_1";
+			status = "disabled";
+			#io-channel-cells = <2>;
+		};
+
+		acmp2: cmp@401a8000 {
+			compatible = "nxp,kinetis-acmp";
+			reg = <0x401a8000 0x4000>;
+			interrupts = <158 0>;
+			label = "CMP_2";
+			status = "disabled";
+			#io-channel-cells = <2>;
+		};
+
+		acmp3: cmp@401ac000 {
+			compatible = "nxp,kinetis-acmp";
+			reg = <0x401ac000 0x4000>;
+			interrupts = <159 0>;
+			label = "CMP_3";
+			status = "disabled";
+			#io-channel-cells = <2>;
+		};
+
+		acmp4: cmp@401b0000 {
+			compatible = "nxp,kinetis-acmp";
+			reg = <0x401b0000 0x4000>;
+			interrupts = <160 0>;
+			label = "CMP_4";
+			status = "disabled";
+			#io-channel-cells = <2>;
+		};
+
 		anatop: anatop@40c84000 {
 			compatible = "nxp,imx-anatop";
 			reg = <0x40c84000 0x4000>;

--- a/include/zephyr/drivers/sensor/mcux_acmp.h
+++ b/include/zephyr/drivers/sensor/mcux_acmp.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Vestas Wind Systems A/S
+ * Copyright 2022 NXP
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -17,6 +18,30 @@ extern "C" {
 #endif
 
 #include <zephyr/drivers/sensor.h>
+
+#if defined(FSL_FEATURE_ACMP_HAS_C1_INPSEL_BIT) && (FSL_FEATURE_ACMP_HAS_C1_INPSEL_BIT == 1U)
+#define MCUX_ACMP_HAS_INPSEL 1
+#else
+#define MCUX_ACMP_HAS_INPSEL 0
+#endif
+
+#if defined(FSL_FEATURE_ACMP_HAS_C1_INNSEL_BIT) && (FSL_FEATURE_ACMP_HAS_C1_INNSEL_BIT == 1U)
+#define MCUX_ACMP_HAS_INNSEL 1
+#else
+#define MCUX_ACMP_HAS_INNSEL 0
+#endif
+
+#if defined(FSL_FEATURE_ACMP_HAS_C0_OFFSET_BIT) && (FSL_FEATURE_ACMP_HAS_C0_OFFSET_BIT == 1U)
+#define MCUX_ACMP_HAS_OFFSET 1
+#else
+#define MCUX_ACMP_HAS_OFFSET 0
+#endif
+
+#if defined(FSL_FEATURE_ACMP_HAS_C3_REG) && (FSL_FEATURE_ACMP_HAS_C3_REG != 0U)
+#define MCUX_ACMP_HAS_DISCRETE_MODE 1
+#else
+#define MCUX_ACMP_HAS_DISCRETE_MODE 0
+#endif
 
 enum sensor_channel_mcux_acmp {
 	/** Analog Comparator Output. */
@@ -50,6 +75,22 @@ enum sensor_attribute_mcux_acmp {
 	SENSOR_ATTR_MCUX_ACMP_NEGATIVE_PORT_INPUT,
 	/** Analog Comparator negative mux input. */
 	SENSOR_ATTR_MCUX_ACMP_NEGATIVE_MUX_INPUT,
+#if MCUX_ACMP_HAS_DISCRETE_MODE
+	/** Analog Comparator Positive Channel Discrete Mode Enable. */
+	SENSOR_ATTR_MCUX_ACMP_POSITIVE_DISCRETE_MODE,
+	/** Analog Comparator Negative Channel Discrete Mode Enable. */
+	SENSOR_ATTR_MCUX_ACMP_NEGATIVE_DISCRETE_MODE,
+	/** Analog Comparator discrete mode clock selection. */
+	SENSOR_ATTR_MCUX_ACMP_DISCRETE_CLOCK,
+	/** Analog Comparator resistor divider enable. */
+	SENSOR_ATTR_MCUX_ACMP_DISCRETE_ENABLE_RESISTOR_DIVIDER,
+	/** Analog Comparator discrete sample selection. */
+	SENSOR_ATTR_MCUX_ACMP_DISCRETE_SAMPLE_TIME,
+	/** Analog Comparator discrete phase1 sampling time selection. */
+	SENSOR_ATTR_MCUX_ACMP_DISCRETE_PHASE1_TIME,
+	/** Analog Comparator discrete phase2 sampling time selection. */
+	SENSOR_ATTR_MCUX_ACMP_DISCRETE_PHASE2_TIME,
+#endif
 };
 
 #ifdef __cplusplus

--- a/samples/sensor/mcux_acmp/README.rst
+++ b/samples/sensor/mcux_acmp/README.rst
@@ -7,22 +7,38 @@ Overview
 ********
 
 This sample show how to use the NXP MCUX Analog Comparator (ACMP) driver. The
-sample supports the :ref:`twr_ke18f`.
+sample supports the :ref:`twr_ke18f`, :ref:`mimxrt1170_evk`.
 
 The input voltage for the the negative input of the analog comparator is
 provided by the ACMP Digital-to-Analog Converter (DAC). The input voltage for
-the positive input can be adjusted by turning the on-board potentiometer.
+the positive input can be adjusted by turning the on-board potentiometer for
+:ref:`twr_ke18f` board, for :ref:`mimxrt1170_evk` the voltage signal is
+captured on J25-13, need change the external voltage signal to check the
+output.
 
 The output value of the analog comparator is reported on the console.
 
 Building and Running
 ********************
 
+Building and Running for TWR-KE18F
+==================================
 Build the application for the :ref:`twr_ke18f` board, and adjust the
 ACMP input voltage by turning the on-board potentiometer.
 
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/mcux_acmp
    :board: twr_ke18f
+   :goals: flash
+   :compact:
+
+Building and Running for MIMXRT1170-EVK
+=======================================
+Build the application for the MIMXRT1170-EVK board, and adjust the
+ACMP input voltage by changing the voltage input to J25-13.
+
+.. zephyr-app-commands::
+   :zephyr-app: samples/drivers/mcux_acmp
+   :board: mimxrt1170_evk_cm7
    :goals: flash
    :compact:

--- a/samples/sensor/mcux_acmp/boards/mimxrt1170_evk_cm4.overlay
+++ b/samples/sensor/mcux_acmp/boards/mimxrt1170_evk_cm4.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	acmp1_default: acmp1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_01_acmp1_in2>;
+			drive-strength = "high";
+			bias-pull-up;
+			slew-rate = "fast";
+		};
+	};
+};
+
+&acmp1 {
+	status = "okay";
+	pinctrl-0 = <&acmp1_default>;
+	pinctrl-names = "default";
+};

--- a/samples/sensor/mcux_acmp/boards/mimxrt1170_evk_cm7.overlay
+++ b/samples/sensor/mcux_acmp/boards/mimxrt1170_evk_cm7.overlay
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 NXP
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&pinctrl {
+	acmp1_default: acmp1_default {
+		group0 {
+			pinmux = <&iomuxc_gpio_ad_01_acmp1_in2>;
+			drive-strength = "high";
+			bias-pull-up;
+			slew-rate = "fast";
+		};
+	};
+};
+
+&acmp1 {
+	status = "okay";
+	pinctrl-0 = <&acmp1_default>;
+	pinctrl-names = "default";
+};

--- a/samples/sensor/mcux_acmp/sample.yaml
+++ b/samples/sensor/mcux_acmp/sample.yaml
@@ -2,7 +2,7 @@ sample:
   description: Demonstration of the NXP MCUX ACMP sensor driver
   name: NXP MCUX ACMP sample
 common:
-  platform_allow: twr_ke18f
+  platform_allow: twr_ke18f mimxrt1170_evk_cm7 mimxrt1170_evk_cm4
   integration_platforms:
     - twr_ke18f
   tags: drivers

--- a/samples/sensor/mcux_acmp/src/main.c
+++ b/samples/sensor/mcux_acmp/src/main.c
@@ -16,6 +16,12 @@
 #define ACMP_POSITIVE 5
 #define ACMP_NEGATIVE 5
 #define ACMP_DAC_VREF 0
+#elif (defined(CONFIG_BOARD_MIMXRT1170_EVK_CM7) || defined(CONFIG_BOARD_MIMXRT1170_EVK_CM4))
+#define ACMP_NODE  DT_NODELABEL(acmp1)
+#define ACMP_POSITIVE 2
+#define ACMP_NEGATIVE 7
+/* Select Vin2. Vin1 is not used and tied to ground on this chip. Vin2 is from VDDA_1P8_IN. */
+#define ACMP_DAC_VREF 1
 #else
 #error Unsupported board
 #endif
@@ -28,13 +34,17 @@ struct acmp_attr {
 };
 
 static const struct acmp_attr attrs[] = {
+#if MCUX_ACMP_HAS_INPSEL
 	/* Positive input port set to MUX */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_POSITIVE_PORT_INPUT, .val = 1 },
+#endif
 	/* Positive input channel */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_POSITIVE_MUX_INPUT,
 	  .val = ACMP_POSITIVE },
+#if MCUX_ACMP_HAS_INNSEL
 	/* Negative input port set to DAC */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_NEGATIVE_PORT_INPUT, .val = 0 },
+#endif
 	/* Negative input channel */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_NEGATIVE_MUX_INPUT,
 	  .val = ACMP_NEGATIVE },
@@ -45,8 +55,14 @@ static const struct acmp_attr attrs[] = {
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_DAC_VALUE, .val = ACMP_DAC_VALUE },
 	/* Hysteresis level */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_HYSTERESIS_LEVEL, .val = 3 },
+#if MCUX_ACMP_HAS_DISCRETE_MODE
+	/* Discrete mode */
+	{ .attr = SENSOR_ATTR_MCUX_ACMP_POSITIVE_DISCRETE_MODE, .val = 1 },
+#endif
+#if MCUX_ACMP_HAS_OFFSET
 	/* Offset level */
 	{ .attr = SENSOR_ATTR_MCUX_ACMP_OFFSET_LEVEL, .val = 0 },
+#endif
 };
 
 static const int16_t triggers[] = {

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -317,6 +317,7 @@ config SOC_MIMXRT1176_CM7
 	select HAS_MCUX_GPC
 	select HAS_MCUX_I2S
 	select HAS_MCUX_USB_EHCI
+	select HAS_MCUX_ACMP
 	select HAS_MCUX_SRC_V2
 	select HAS_MCUX_IOMUXC
 
@@ -345,6 +346,7 @@ config SOC_MIMXRT1176_CM4
 	select HAS_MCUX_ENET
 	select HAS_MCUX_GPC
 	select HAS_MCUX_I2S
+	select HAS_MCUX_ACMP
 	select HAS_MCUX_SRC_V2
 	select HAS_MCUX_IOMUXC
 

--- a/soc/arm/nxp_imx/rt/soc_rt11xx.c
+++ b/soc/arm/nxp_imx/rt/soc_rt11xx.c
@@ -406,6 +406,15 @@ static ALWAYS_INLINE void clock_init(void)
 #endif
 #endif
 
+#ifdef CONFIG_MCUX_ACMP
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(acmp1), okay)
+	/* Configure ACMP1 using Osc48MDiv2*/
+	rootCfg.mux = kCLOCK_ACMP_ClockRoot_MuxOscRc48MDiv2;
+	rootCfg.div = 1;
+	CLOCK_SetRootClock(kCLOCK_Root_Acmp, &rootCfg);
+#endif
+#endif
+
 #ifdef CONFIG_DISPLAY_MCUX_ELCDIF
 	rootCfg.mux = kCLOCK_LCDIF_ClockRoot_MuxSysPll2Out;
 	rootCfg.div = 9;


### PR DESCRIPTION
Updated mcu_acmp driver to support discrete mode configuration for i.MXRT11xx.
Add ACMP support on MIMXRT1170 EVK