### PR TITLE
tests: timer_monotonic: Use volatile for timing variables

### DIFF
--- a/tests/kernel/timer/timer_monotonic/src/main.c
+++ b/tests/kernel/timer/timer_monotonic/src/main.c
@@ -10,7 +10,8 @@
 
 int test_frequency(void)
 {
-	uint32_t start, end, delta, pct;
+	volatile uint32_t start, end;
+	uint32_t delta, pct;
 
 	TC_PRINT("Testing system tick frequency\n");
 
@@ -49,7 +50,8 @@ int test_frequency(void)
  */
 void test_timer(void)
 {
-	uint32_t t_last, t_now, i, errors;
+	volatile uint32_t t_last, t_now;
+	uint32_t i, errors;
 	int32_t diff;
 
 	errors = 0U;


### PR DESCRIPTION
This commit adds the `volatile` qualifier to the timing variables, in
order to ensure that the compiler does not try to optimise the test in
a way that can affect the execution time measurements.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: This fixes the `qemu_arc_hs6x` failure seen [here](https://github.com/zephyrproject-rtos/zephyr/runs/6443039222?check_suite_focus=true#step:11:2256). For more details, refer to [the discussion on Discord](https://discord.com/channels/720317445772017664/975575202190753882/975583539804381256).