### PR TITLE
modules: hal_infineon: fix CMake Warning when build non Infineon device

### DIFF
--- a/modules/hal_infineon/CMakeLists.txt
+++ b/modules/hal_infineon/CMakeLists.txt
@@ -2,7 +2,9 @@
 # Copyright (c) 2022 Cypress Semiconductor Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-zephyr_library_named(modules_hal_infineon)
+if(CONFIG_HAS_XMCLIB OR CONFIG_SOC_FAMILY_PSOC6)
+  zephyr_library_named(modules_hal_infineon)
+endif()
 
 ## Add PDL sources for XMC devices
 if (CONFIG_HAS_XMCLIB)


### PR DESCRIPTION
Problem:
pull/43494 is causing the CMake warning `No SOURCES given to Zephyr library: modules_hal_infineon`

modules_hal_infineon library was defined even if none of the below subdirectories is added; so, when not building for
Infineon/Cypress devices, the source list for this library will be empty.

Refer to https://github.com/zephyrproject-rtos/zephyr/pull/43494#pullrequestreview-973308640 for background information. 

Fix:
Added `zephyr_library_named(modules_hal_infineon)` under condition `if(CONFIG_HAS_XMCLIB OR CONFIG_SOC_FAMILY_PSOC6)`

Signed-off-by: Nazar Palamar <nazar.palamar@infineon.com>