### PR TITLE
fix call to bin2hex

### DIFF
--- a/subsys/mgmt/hawkbit/hawkbit_device.c
+++ b/subsys/mgmt/hawkbit/hawkbit_device.c
@@ -17,7 +17,7 @@ bool hawkbit_get_device_identity(char *id, int id_max_len)
 	}
 
 	memset(id, 0, id_max_len);
-	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len - 1);
+	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len);
 
 	return length > 0;
 }

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -97,8 +97,7 @@ static int bin2hex_str(uint8_t *bin, size_t bin_len, char *str, size_t str_buf_l
 	}
 
 	memset(str, 0, str_buf_len);
-	/* str_buf_len - 1 ensure space for \0 */
-	bin2hex(bin, bin_len, str, str_buf_len - 1);
+	bin2hex(bin, bin_len, str, str_buf_len);
 
 	return 0;
 }

--- a/subsys/mgmt/updatehub/updatehub_device.c
+++ b/subsys/mgmt/updatehub/updatehub_device.c
@@ -18,7 +18,7 @@ bool updatehub_get_device_identity(char *id, int id_max_len)
 	}
 
 	memset(id, 0, id_max_len);
-	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len - 1);
+	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len);
 
 	return length > 0;
 }

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -86,7 +86,7 @@ bool __weak shell_mqtt_get_devid(char *id, int id_max_len)
 	}
 
 	(void)memset(id, 0, id_max_len);
-	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len - 1);
+	length = bin2hex(hwinfo_id, (size_t)length, id, id_max_len);
 
 	return length > 0;
 }


### PR DESCRIPTION
We noticed that in the master branch, updatehub fails to start. That is because of the behaviour change in bin2hex caused by commit f2affbd973a7 ("os: lib: bin2hex: fix memory overwrite").