### PR TITLE
ipc: static_vrings: Add -ENOMEM case

### DIFF
--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -233,6 +233,7 @@ int ipc_service_register_endpoint(const struct device *instance,
  *  @retval -EBADMSG when the data is invalid (i.e. invalid data format,
  *		     invalid length, ...)
  *  @retval -EBUSY when the instance is busy.
+ *  @retval -ENOMEM when no memory / buffers are available.
  *
  *  @retval bytes number of bytes sent.
  *  @retval other errno codes depending on the implementation of the backend.

--- a/include/zephyr/ipc/ipc_service_backend.h
+++ b/include/zephyr/ipc/ipc_service_backend.h
@@ -47,6 +47,7 @@ struct ipc_service_backend {
 	 *  @retval -EINVAL when instance is invalid.
 	 *  @retval -EBADMSG when the message is invalid.
 	 *  @retval -EBUSY when the instance is busy or not ready.
+	 *  @retval -ENOMEM when no memory / buffers are available.
 	 *
 	 *  @retval bytes number of bytes sent.
 	 *  @retval other errno codes depending on the implementation of the

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -394,6 +394,7 @@ static int send(const struct device *instance, void *token,
 {
 	struct backend_data_t *data = instance->data;
 	struct ipc_rpmsg_ept *rpmsg_ept;
+	int ret;
 
 	/* Instance is not ready */
 	if (atomic_get(&data->state) != STATE_INITED) {
@@ -407,7 +408,14 @@ static int send(const struct device *instance, void *token,
 
 	rpmsg_ept = (struct ipc_rpmsg_ept *) token;
 
-	return rpmsg_send(&rpmsg_ept->ep, msg, len);
+	ret = rpmsg_send(&rpmsg_ept->ep, msg, len);
+
+	/* No buffers available */
+	if (ret == RPMSG_ERR_NO_BUFF) {
+		return -ENOMEM;
+	}
+
+	return ret;
 }
 
 static int send_nocopy(const struct device *instance, void *token,


### PR DESCRIPTION
Sometimes it is important to know when the backend fails to send out
data because no memory / buffers are available. Return -ENOMEM in that
case.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

Fixes: #45630