### PR TITLE
Bluetooth: Host: Properly clean up `acl_tx_pool` user data

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-bt.ld
+++ b/include/zephyr/linker/common-rom/common-rom-bt.ld
@@ -1,6 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 	ITERABLE_SECTION_ROM(bt_l2cap_fixed_chan, 4)
+	ITERABLE_SECTION_ROM(l2cap_userdata_destroy, 4)
+	ITERABLE_SECTION_ROM(conn_userdata_destroy, 4)
 
 #if defined(CONFIG_BT_BREDR)
 	ITERABLE_SECTION_ROM(bt_l2cap_br_fixed_chan, 4)

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3612,11 +3612,18 @@ bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_conn_tx_cb_t func,
 		(bt_att_tx_meta_data(buf)->user_data == user_data));
 }
 
-void att_tx_destroy(void *meta_data)
+static bool att_tx_destroy(void *meta_data)
 {
 	__ASSERT_NO_MSG(meta_data);
 
 	if (PART_OF_ARRAY(tx_meta_data, (struct bt_att_tx_meta_data *)meta_data)) {
 		tx_meta_data_free(meta_data);
+		return true;
 	}
+
+	return false;
 }
+
+L2CAP_USERDATA_DESTROY(meta_destroy) = {
+	.destroy = att_tx_destroy,
+};

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -321,3 +321,5 @@ void bt_att_set_tx_meta_data(struct net_buf *buf, bt_conn_tx_cb_t func, void *us
 
 bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_conn_tx_cb_t func,
 			       const void *user_data);
+
+void att_tx_destroy(void *meta);

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -321,5 +321,3 @@ void bt_att_set_tx_meta_data(struct net_buf *buf, bt_conn_tx_cb_t func, void *us
 
 bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_conn_tx_cb_t func,
 			       const void *user_data);
-
-void att_tx_destroy(void *meta);

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -424,3 +424,10 @@ struct k_sem *bt_conn_get_pkts(struct bt_conn *conn);
 /* k_poll related helpers for the TX thread */
 int bt_conn_prepare_events(struct k_poll_event events[]);
 void bt_conn_process_tx(struct bt_conn *conn);
+
+struct conn_userdata_destroy {
+	bool (*destroy)(void *user_data);
+};
+
+#define CONN_USERDATA_DESTROY(_name)                                                               \
+	STRUCT_SECTION_ITERABLE(conn_userdata_destroy, _CONCAT(conn_userdata_destroy_, _name))

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -379,3 +379,5 @@ struct bt_l2cap_ecred_cb {
 
 /* Register callbacks for Enhanced Credit based Flow Control */
 void bt_l2cap_register_ecred_cb(const struct bt_l2cap_ecred_cb *cb);
+
+void l2cap_tx_destroy(void *meta_data);

--- a/subsys/bluetooth/host/l2cap_internal.h
+++ b/subsys/bluetooth/host/l2cap_internal.h
@@ -380,4 +380,9 @@ struct bt_l2cap_ecred_cb {
 /* Register callbacks for Enhanced Credit based Flow Control */
 void bt_l2cap_register_ecred_cb(const struct bt_l2cap_ecred_cb *cb);
 
-void l2cap_tx_destroy(void *meta_data);
+struct l2cap_userdata_destroy {
+	bool (*destroy)(void *user_data);
+};
+
+#define L2CAP_USERDATA_DESTROY(_name)                                                              \
+	STRUCT_SECTION_ITERABLE(l2cap_userdata_destroy, _CONCAT(l2cap_userdata_destroy_, _name))


### PR DESCRIPTION
The user data of the buffers from acl_tx_pool is used for many things,
some of which requires cleanup. In particular, the ATT and L2CAP meta
data were not cleaned up properly.

This patch uses the destroy callback for net_bufs to do the required
cleanup.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>

---

I think it would be nice if we cleaned up the usages of the buffer user data. It is currently used for many things in different places. I have seen at least these uses: Callback in ATT, callback and metadata for ECFC channels, callback and metadata in conn, buffer type in `send_acl`, and credits in L2CAP. Having a proper type for this instead of adding things to the buffer user data would be nice, though would require a fair bit of changes to the host.