### PR TITLE
drivers: clock_control: Set calibration default off for 5340_CPUAPP

### DIFF
--- a/drivers/clock_control/Kconfig.nrf
+++ b/drivers/clock_control/Kconfig.nrf
@@ -57,7 +57,7 @@ endchoice
 config CLOCK_CONTROL_NRF_K32SRC_RC_CALIBRATION
 	bool "LF clock calibration"
 	depends on !SOC_SERIES_NRF91X && CLOCK_CONTROL_NRF_K32SRC_RC
-	default y
+	default y if !BOARD_ENABLE_CPUNET
 	help
 	  If calibration is disabled when RC is used for low frequency clock then
 	  accuracy of the low frequency clock will degrade. Disable on your own


### PR DESCRIPTION
To prevent both net and app core calibrating.

Signed-off-by: Sean Madigan <sean.madigan@nordicsemi.no>