### PR TITLE
samples: drivers: pwm led running on stm32 boards

### DIFF
--- a/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_f091rc.overlay
@@ -4,30 +4,11 @@
  * Copyright (c) 2022 STMicroelectronics
  */
 
-#include <zephyr/dt-bindings/pwm/pwm.h>
-
-
-/ {
-	pwmleds {
-		compatible = "pwm-leds";
-
-		green_pwm_led: green_pwm_led {
-			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
-		};
-	};
-
-	aliases {
-		pwm-led0 = &green_pwm_led;
-	};
+&pwmleds {
+	/* NOTE: enable here because it is disabled by default */
+	status = "okay";
 };
 
-&timers2 {
-	st,prescaler = <10000>;
+&pwm2 {
 	status = "okay";
-
-	pwm2: pwm {
-		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa5>; /* might conflict with SPI1 */
-		pinctrl-names = "default";
-	};
 };

--- a/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
+++ b/samples/drivers/led_pwm/boards/nucleo_l073rz.overlay
@@ -4,30 +4,11 @@
  * Copyright (c) 2022 STMicroelectronics
  */
 
-#include <zephyr/dt-bindings/pwm/pwm.h>
-
-
-/ {
-	pwmleds {
-		compatible = "pwm-leds";
-
-		green_pwm_led: green_pwm_led {
-			pwms = <&pwm2 1 4 PWM_POLARITY_NORMAL>;
-		};
-	};
-
-	aliases {
-		pwm-led0 = &green_pwm_led;
-	};
+&pwmleds {
+	/* NOTE: enable here because it is disabled by default */
+	status = "okay";
 };
 
-&timers2 {
-	st,prescaler = <10000>;
+&pwm2 {
 	status = "okay";
-
-	pwm2: pwm {
-		status = "okay";
-		pinctrl-0 = <&tim2_ch1_pa5>; /* might conflict with SPI1 */
-		pinctrl-names = "default";
-	};
 };


### PR DESCRIPTION
On the stm32l073rz nucleo and stm32f091rc nucleo
boards, the DTS pwm-leds node is disabled, because
the output pin might conflict with SPI1.
It is necessary to enable the node in the overlay
to compile and run the sample.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45686

Signed-off-by: Francois Ramu <francois.ramu@st.com>