### PR TITLE
net: buf: keep memory alignment provided by k_heap_alloc and k_malloc

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5122,6 +5122,7 @@ void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,
  * timeout API, or K_NO_WAIT or K_FOREVER) waiting for memory to be
  * freed.  If the allocation cannot be performed by the expiration of
  * the timeout, NULL will be returned.
+ * Allocated memory is aligned on a multiple of pointer sizes.
  *
  * @note @a timeout must be set to K_NO_WAIT if called from ISR.
  * @note When CONFIG_MULTITHREADING=n any @a timeout is treated as K_NO_WAIT.
@@ -5250,6 +5251,7 @@ extern void *k_aligned_alloc(size_t align, size_t size);
  *
  * This routine provides traditional malloc() semantics. Memory is
  * allocated from the heap memory pool.
+ * Allocated memory is aligned on a multiple of pointer sizes.
  *
  * @param size Amount of memory requested (in bytes).
  *

--- a/subsys/net/buf.c
+++ b/subsys/net/buf.c
@@ -107,7 +107,7 @@ static uint8_t *mem_pool_data_alloc(struct net_buf *buf, size_t *size,
 	uint8_t *ref_count;
 
 	/* Reserve extra space for a ref-count (uint8_t) */
-	void *b = k_heap_alloc(pool, 1 + *size, timeout);
+	void *b = k_heap_alloc(pool, sizeof(void *) + *size, timeout);
 
 	if (b == NULL) {
 		return NULL;
@@ -117,7 +117,7 @@ static uint8_t *mem_pool_data_alloc(struct net_buf *buf, size_t *size,
 	*ref_count = 1U;
 
 	/* Return pointer to the byte following the ref count */
-	return ref_count + 1;
+	return ref_count + sizeof(void *);
 }
 
 static void mem_pool_data_unref(struct net_buf *buf, uint8_t *data)
@@ -126,7 +126,7 @@ static void mem_pool_data_unref(struct net_buf *buf, uint8_t *data)
 	struct k_heap *pool = buf_pool->alloc->alloc_data;
 	uint8_t *ref_count;
 
-	ref_count = data - 1;
+	ref_count = data - sizeof(void *);
 	if (--(*ref_count)) {
 		return;
 	}
@@ -169,21 +169,21 @@ static uint8_t *heap_data_alloc(struct net_buf *buf, size_t *size,
 {
 	uint8_t *ref_count;
 
-	ref_count = k_malloc(1 + *size);
+	ref_count = k_malloc(sizeof(void *) + *size);
 	if (!ref_count) {
 		return NULL;
 	}
 
 	*ref_count = 1U;
 
-	return ref_count + 1;
+	return ref_count + sizeof(void *);
 }
 
 static void heap_data_unref(struct net_buf *buf, uint8_t *data)
 {
 	uint8_t *ref_count;
 
-	ref_count = data - 1;
+	ref_count = data - sizeof(void *);
 	if (--(*ref_count)) {
 		return;
 	}


### PR DESCRIPTION
Allocation callback in net_buf_heap_cb and net_buf_var_cb
used for net_bufs with variable size payloads, defined by
NET_BUF_POOL_HEAP_DEFINE or NET_BUF_POOL_VAR_DEFINE,
allocate one more octet for internal variable ref_count,
used in function generic_data_ref(), which in turn is needed
for net_buf_clone()).
The user gets a buffer which is shifted by one octet in memory
block. This breaks alignment provided k_heap_alloc and k_malloc.