### PR TITLE
boards: riscv: longan_nano: Migrate to new SD subsystem

### DIFF
--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -105,10 +105,15 @@
 	cs-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
 
 	sdhc0: sdhc@0 {
-		compatible = "zephyr,mmc-spi-slot";
+		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		label = "SDHC0";
+		label = "SDHC_0";
 		spi-max-frequency = <24000000>;
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+			label = "SDMMC_0";
+		};
 	};
 };


### PR DESCRIPTION
Modify sdhc configuration to fit new SD subsystem.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>