### PR TITLE
boards: arm: stm32h7b3i_dk: Enable CAN peripheral and transceiver

### DIFF
--- a/boards/arm/stm32h7b3i_dk/doc/index.rst
+++ b/boards/arm/stm32h7b3i_dk/doc/index.rst
@@ -64,6 +64,8 @@ The current Zephyr stm32h7b3i_dk board configuration supports the following hard
 +-----------+------------+-------------------------------------+
 | LTDC      | on-chip    | display                             |
 +-----------+------------+-------------------------------------+
+| CANFD     | on-chip    | can                                 |
++-----------+------------+-------------------------------------+
 
 
 Other hardware features have not been enabled yet for this board.
@@ -87,14 +89,18 @@ Default Zephyr Peripheral Mapping:
 - LD2 : PG2
 - USER_PB : PC13
 - SDMMC D0/D1/D2/D3/CK/CMD/CD : PC8/PC9/PC10/PC11/PC12/PD2/PI8
+- CANFD RX/TX/WAKE [#]_ : PA11/PA12/PH8
 - FMC SDRAM :
+
     - D0-D15 : PD14/PD15/PD0/PD1/PE7/PE8/PE9/PE10/PE11/PE12/PE13/PE14/PE15/PD8/PD9/PD10
     - A0-A11 : PF0/PF1/PF2/PF3/PF4/PF5/PF12/PF13/PF14/PF15/PG0/PG1
     - A14/A15 : PG4/PG5
     - SDNRAS/SDNCAS : PF11/PG15
     - NBL0/NBL1 : PE0/PE1
     - SDCLK/SDNWE/SDCKE1/SDNE1 : PG8/PH5/PH7/PH6
+
 - LTDC :
+
     - R0-R7 : PI15/PJ0/PJ1/PJ2/PJ3/PJ4/PJ5/PJ6
     - G0-G7 : PJ7/PJ8/PJ9/PJ10/PJ11/PK0/PK1/PK2
     - B0-B7 : PJ12/PK13/PJ14/PJ15/PK3/PK4/PK5/PK6
@@ -158,3 +164,10 @@ You can debug an application in the usual way.  Here is an example for the
 
 .. _STM32CubeProgrammer:
    https://www.st.com/en/development-tools/stm32cubeprog.html
+
+.. _STM32H7B3I_DK board schematics:
+   https://www.st.com/resource/en/schematic_pack/mb1332-h7b3i-c02_schematic.pdf
+
+.. [#] To use CAN, solder bridges SB3, SB4 and SB5 need to be connected.
+       Take note that CANFD pins are shared with STMOD+ connector (P1), so please check
+       `STM32H7B3I_DK board schematics`_ for possible collisions if using that connector.

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -20,6 +20,7 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,display = &ltdc;
+		zephyr,canbus = &can1;
 	};
 
 	leds {
@@ -49,6 +50,13 @@
 		zephyr,memory-region = "SDRAM2";
 	};
 
+	transceiver0: can-phy0 {
+		compatible = "microchip,mcp2562fd", "can-transceiver-gpio";
+		standby-gpios = <&gpioh 8 GPIO_ACTIVE_HIGH>;
+		max-bitrate = <5000000>;
+		#phy-cells = <0>;
+	};
+
 	aliases {
 		led0 = &blue_led;
 		led1 = &red_led;
@@ -62,17 +70,18 @@
 	status = "okay";
 };
 
+/* PLL1P is used for system clock (280 MHz), PLL1Q is used for FDCAN bit quantum clock (80 MHz) */
 &pll {
 	div-m = <12>;
 	mul-n = <280>;
 	div-p = <2>;
-	div-q = <2>;
+	div-q = <7>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
 	status = "okay";
 };
 
-/* PLLR is used for outputting 9 MHz pixel clock for LTDC */
+/* PLL3R is used for outputting 9 MHz pixel clock for LTDC */
 &pll3 {
 	div-m = <8>;
 	mul-n = <60>;
@@ -125,6 +134,18 @@
 &spi2 {
 	pinctrl-0 = <&spi2_sck_pa12 &spi2_miso_pb14 &spi2_mosi_pb15 &spi2_nss_pi0>;
 	pinctrl-names = "default";
+	status = "okay";
+};
+
+/* Connect solder bridges SB3, SB4 and SB5 to use CAN connector (CN21) */
+&can1 {
+	pinctrl-0 = <&fdcan1_rx_pa11 &fdcan1_tx_pa12>;
+	pinctrl-names = "default";
+	phys = <&transceiver0>;
+	bus-speed = <125000>;
+	bus-speed-data = <1000000>;
+	sample-point = <875>;
+	sample-point-data = <875>;
 	status = "okay";
 };
 

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.yaml
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.yaml
@@ -17,3 +17,5 @@ supported:
   - memc
   - backup_sram
   - display
+  - can
+  - canfd

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -113,14 +113,14 @@ static const struct can_driver_api can_stm32h7_driver_api = {
 	 * (FDCAN_NBTP).
 	 */
 	.timing_min = {
-		.sjw = 0x00,
+		.sjw = 0x01,
 		.prop_seg = 0x00,
-		.phase_seg1 = 0x00,
-		.phase_seg2 = 0x00,
-		.prescaler = 0x00
+		.phase_seg1 = 0x01,
+		.phase_seg2 = 0x01,
+		.prescaler = 0x01
 	},
 	.timing_max = {
-		.sjw = 0x7f,
+		.sjw = 0x80,
 		.prop_seg = 0x00,
 		.phase_seg1 = 0x100,
 		.phase_seg2 = 0x80,
@@ -133,11 +133,11 @@ static const struct can_driver_api can_stm32h7_driver_api = {
 	 * register (FDCAN_DBTP).
 	 */
 	.timing_data_min = {
-		.sjw = 0x00,
+		.sjw = 0x01,
 		.prop_seg = 0x00,
-		.phase_seg1 = 0x00,
-		.phase_seg2 = 0x00,
-		.prescaler = 0x00
+		.phase_seg1 = 0x01,
+		.phase_seg2 = 0x01,
+		.prescaler = 0x01
 	},
 	.timing_data_max = {
 		.sjw = 0x10,


### PR DESCRIPTION
- Add CAN transceiver to board DTS
- Enable CAN peripheral and set correct pinctrl config in board DTS
- Specify in board yaml file that board supports CAN and CANFD
- Modify board documentation

Fixes: #45790