### PR TITLE
Bluetooth: Controller: Fix periodic advertising synchronization cancel and synchronization established synchronize

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync_types.h
@@ -18,7 +18,12 @@ struct ll_sync_set {
 
 	uint16_t skip;
 	uint16_t timeout;
-	uint16_t volatile timeout_reload; /* Non-zero when sync established */
+	/* Non-zero when sync is setup. It can be in two sub-stated:
+	 * - Waiting for first AUX_SYNC_IND, before sync established was notified to Host.
+	 *   If sync establishment is in progress node_rx_sync_estab is not NULL.
+	 * - sync is already established, node_rx_sync_estab is NULL.
+	 */
+	uint16_t volatile timeout_reload;
 	uint16_t timeout_expire;
 
 	/* Member to store periodic advertising sync prepare.
@@ -49,7 +54,7 @@ struct ll_sync_set {
 	uint8_t is_term:1;
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_CTE_TYPE_FILTERING && !CONFIG_BT_CTLR_CTEINLINE_SUPPORT */
 
-	uint8_t is_stop:1; /* sync terminate requested */
+	uint8_t is_stop:1; /* sync terminate or cancel requested */
 	uint8_t sync_expire:3; /* countdown of 6 before fail to establish */
 
 #if defined(CONFIG_BT_CTLR_CHECK_SAME_PEER_SYNC)
@@ -68,6 +73,9 @@ struct ll_sync_set {
 		};
 	} node_rx_lost;
 
+	/* Not-Null when sync was setup and Controller is waiting for first AUX_SYNC_IND PDU.
+	 * It means the sync was not estalished yet.
+	 */
 	struct node_rx_hdr *node_rx_sync_estab;
 
 #if defined(CONFIG_BT_CTLR_SYNC_ISO)


### PR DESCRIPTION
Current implementation of ll_sync_create_cancel does not allow to stop
synchronization after ull_sync_setup is called. When that is done,
sync->timeout_reload is not zero and the ll_sync_create_cancel will
return BT_HCI_ERR_CMD_DISALLOWED. That means the Controller is able to
cancel periodic advertising synchronization only in period between
call to ll_sync_create and reception of AUX_ADV_IND that has SyncInfo
field.

The Controller should be able to cancell synchronization until first
AUX_SYNC_IND PDU is received and host notified about synchronization
established.

Complete information about synchronization status is provdied by two
ll_sync_set members: node_rx_sync_established and timeout_reload.
These two members of the structure were used in ll_sync_create_cancel
function to do a proper cancel and cleanup.
The node_rx_sync_established member was not cleared when sync was
established or expired. That was required to get a proper information
about synchronization state.

Besides that, to avoid race condition between ll_sync_create_cancel
and ull_sync_established_report, the latter function was extended
to check if cancel operation or sync lost has happened.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/40204 and https://github.com/zephyrproject-rtos/zephyr/issues/45672

Signed-off-by: Piotr Pryga [piotr.pryga@nordicsemi.no](mailto:piotr.pryga@nordicsemi.no)