### PR TITLE
tests: hda_log: cav15 timeout fixes

### DIFF
--- a/tests/boards/intel_adsp/hda_log/src/logger.c
+++ b/tests/boards/intel_adsp/hda_log/src/logger.c
@@ -26,16 +26,19 @@ void hda_log_hook(uint32_t written)
 	 */
 	bool done = false;
 
-	/* Previous message may not be done yet, wait for that */
-	do {
-		done = cavs_ipc_is_complete(CAVS_HOST_DEV);
-	} while (!done);
-
 	/*  Now send the next one */
 	do {
 		done = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_HDA_PRINT,
 					     (written << 8) | CHANNEL);
 	} while (!done);
+
+
+	/* Previous message may not be done yet, wait for that */
+	do {
+		done = cavs_ipc_is_complete(CAVS_HOST_DEV);
+	} while (!done);
+
+
 }
 
 


### PR DESCRIPTION
Fixes issues caused by the hda_log test for cavs15 caused by ipc
messaging issues. Wait for the ipc message to complete immediately after
sending it.

Fixes #45440 

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>