### PR TITLE
drivers: adc: sam0: Fix adc_reference implementation

### DIFF
--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -133,7 +133,6 @@ static int adc_sam0_channel_setup(const struct device *dev,
 	adc->SAMPCTRL.reg = sampctrl;
 	wait_synchronization(adc);
 
-
 	uint8_t refctrl;
 
 	switch (channel_cfg->reference) {
@@ -142,14 +141,14 @@ static int adc_sam0_channel_setup(const struct device *dev,
 		/* Enable the internal bandgap reference */
 		ADC_BGEN = 1;
 		break;
-	case ADC_REF_VDD_1_2:
-		refctrl = ADC_REFCTRL_REFSEL_VDD_1_2 | ADC_REFCTRL_REFCOMP;
-		break;
 #ifdef ADC_REFCTRL_REFSEL_VDD_1
 	case ADC_REF_VDD_1:
 		refctrl = ADC_REFCTRL_REFSEL_VDD_1 | ADC_REFCTRL_REFCOMP;
 		break;
 #endif
+	case ADC_REF_VDD_1_2:
+		refctrl = ADC_REFCTRL_REFSEL_VDD_1_2 | ADC_REFCTRL_REFCOMP;
+		break;
 	case ADC_REF_EXTERNAL0:
 		refctrl = ADC_REFCTRL_REFSEL_AREFA;
 		break;

--- a/soc/arm/atmel_sam0/common/adc_fixup_sam0.h
+++ b/soc/arm/atmel_sam0/common/adc_fixup_sam0.h
@@ -106,6 +106,9 @@
 #endif
 #endif /* MCLK */
 
+/*
+ * All SAM0 define the internal voltage reference as 1.0V by default.
+ */
 #ifndef ADC_REFCTRL_REFSEL_INTERNAL
 #  ifdef ADC_REFCTRL_REFSEL_INTREF
 #    define ADC_REFCTRL_REFSEL_INTERNAL ADC_REFCTRL_REFSEL_INTREF
@@ -114,17 +117,27 @@
 #  endif
 #endif
 
-#ifndef ADC_REFCTRL_REFSEL_VDD_1_2
-#  ifdef ADC_REFCTRL_REFSEL_INTVCC0
-#    define ADC_REFCTRL_REFSEL_VDD_1_2 ADC_REFCTRL_REFSEL_INTVCC0
-#  else
-#    define ADC_REFCTRL_REFSEL_VDD_1_2 ADC_REFCTRL_REFSEL_INTVCC1
+/*
+ * Some SAM0 devices can use VDDANA as a direct reference. For the devices
+ * that not offer this option, the internal 1.0V reference will be used.
+ */
+#ifndef ADC_REFCTRL_REFSEL_VDD_1
+#  if defined(ADC0_BANDGAP)
+#    define ADC_REFCTRL_REFSEL_VDD_1 ADC_REFCTRL_REFSEL_INTVCC1
+#  elif defined(ADC_REFCTRL_REFSEL_INTVCC2)
+#    define ADC_REFCTRL_REFSEL_VDD_1 ADC_REFCTRL_REFSEL_INTVCC2
 #  endif
 #endif
 
-#ifndef ADC_REFCTRL_REFSEL_VDD_1
-#  ifdef ADC_REFCTRL_REFSEL_INTVCC1
-#    define ADC_REFCTRL_REFSEL_VDD_1 ADC_REFCTRL_REFSEL_INTVCC1
+/*
+ * SAMD/E5x define ADC[0-1]_BANDGAP symbol. Only those devices use INTVCC0 to
+ * implement VDDANA / 2.
+ */
+#ifndef ADC_REFCTRL_REFSEL_VDD_1_2
+#  ifdef ADC0_BANDGAP
+#    define ADC_REFCTRL_REFSEL_VDD_1_2 ADC_REFCTRL_REFSEL_INTVCC0
+#  else
+#    define ADC_REFCTRL_REFSEL_VDD_1_2 ADC_REFCTRL_REFSEL_INTVCC1
 #  endif
 #endif
 


### PR DESCRIPTION
The current sam0 adc driver not implement correctly the adc_reference enum values because the current fixuips not reflect all sam0 variants.

This merges ADC_REF_INTERNAL and ADC_REF_VDD_1 implementation because there are devices that only support 1.0V. This assumption is valid for those devices that have a bandgap which allows user to change the internal voltage reference to other values then 1.0V. However, that option is out of scope and it is currently not supported.

The other common adc reference with mistakes is ADC_REF_VDD_1_2. This was fixed selecting the proper INTVCCx reference.

Fixes #45443

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>