### PR TITLE
tests: timer_monotonic: Enable APIC timer's TSC deadline mode on ehl_crb

### DIFF
--- a/tests/kernel/timer/timer_monotonic/testcase.yaml
+++ b/tests/kernel/timer/timer_monotonic/testcase.yaml
@@ -4,6 +4,12 @@ tests:
     # FIXME: This test may fail for qemu_arc_hs on certain host systems.
     #        See foss-for-synopsys-dwc-arc-processors/qemu#67.
     platform_exclude: qemu_arc_hs
+  kernel.timer.monotonic.apic.tsc:
+     tags: kernel timer apic_tsc
+     platform_allow: ehl_crb
+     extra_configs:
+      - CONFIG_APIC_TSC_DEADLINE_TIMER=y
+      - CONFIG_HPET_TIMER=n
   kernel.timer.monotonic.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel timer linker_generator


### PR DESCRIPTION
ehl_crb supports HPET timer by default. Add test suite to test APIC
timer's TSC deadline mode on ehl_crb.