### PR TITLE
tests: sched: preempt: Fix the skipped testing when enabling SMP

### DIFF
--- a/tests/kernel/sched/metairq/testcase.yaml
+++ b/tests/kernel/sched/metairq/testcase.yaml
@@ -1,12 +1,10 @@
 tests:
   kernel.scheduler.metairq:
     tags: kernel
-    filter: not CONFIG_SMP
     platform_exclude: nrf52dk_nrf52810
   kernel.scheduler.metairq.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator
-    filter: not CONFIG_SMP
     platform_exclude: nrf52dk_nrf52810
     extra_configs:
       - CONFIG_CMAKE_LINKER_GENERATOR=y

--- a/tests/kernel/sched/preempt/testcase.yaml
+++ b/tests/kernel/sched/preempt/testcase.yaml
@@ -1,12 +1,10 @@
 tests:
   kernel.scheduler.preempt:
     tags: kernel
-    filter: not CONFIG_SMP
     platform_exclude: nrf52dk_nrf52810
   kernel.scheduler.preempt.linker_generator:
     platform_allow: qemu_cortex_m3
     tags: kernel linker_generator
-    filter: not CONFIG_SMP
     platform_exclude: nrf52dk_nrf52810
     extra_configs:
       - CONFIG_CMAKE_LINKER_GENERATOR=y


### PR DESCRIPTION
When SMP feature is enabled on board, this test suite will skip.
Enable the test suite by removing the filter.
Note that these testings only run SMP platform on single core
which are handled by setting MP_NUM_CPUS=1 in prj.conf.