### PR TITLE
pinctrl: npcx: config pwm open-drain without enabling STORE_REG

### DIFF
--- a/drivers/pinctrl/Kconfig.npcx
+++ b/drivers/pinctrl/Kconfig.npcx
@@ -8,7 +8,6 @@ DT_COMPAT_ST_PINCTRL_NPCX := nuvoton,npcx-pinctrl
 config PINCTRL_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) pin controller driver"
 	depends on SOC_FAMILY_NPCX
-	select PINCTRL_STORE_REG
 	default $(dt_compat_enabled,$(DT_COMPAT_ST_PINCTRL_NPCX))
 	help
 	  This option enables the pin controller driver for NPCX family of

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -293,6 +293,7 @@
 		pwm0: pwm@40080000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40080000 0x2000>;
+			pwm-channel = <0>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 0>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -302,6 +303,7 @@
 		pwm1: pwm@40082000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40082000 0x2000>;
+			pwm-channel = <1>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 1>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -311,6 +313,7 @@
 		pwm2: pwm@40084000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40084000 0x2000>;
+			pwm-channel = <2>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 2>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -320,6 +323,7 @@
 		pwm3: pwm@40086000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40086000 0x2000>;
+			pwm-channel = <3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 3>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -329,6 +333,7 @@
 		pwm4: pwm@40088000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x40088000 0x2000>;
+			pwm-channel = <4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 4>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -338,6 +343,7 @@
 		pwm5: pwm@4008a000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x4008a000 0x2000>;
+			pwm-channel = <5>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 5>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -347,6 +353,7 @@
 		pwm6: pwm@4008c000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x4008c000 0x2000>;
+			pwm-channel = <6>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 6>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -356,6 +363,7 @@
 		pwm7: pwm@4008e000 {
 			compatible = "nuvoton,npcx-pwm";
 			reg = <0x4008e000 0x2000>;
+			pwm-channel = <7>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 7>;
 			#pwm-cells = <3>;
 			status = "disabled";

--- a/dts/arm/nuvoton/npcx/npcx7/npcx7-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7/npcx7-pinctrl.dtsi
@@ -111,42 +111,34 @@
 	/* PWM peripheral interfaces */
 	/omit-if-no-ref/ pwm0_gpc3: periph-pwm0 {
 		pinmux = <&alt4_pwm0_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm1_gpc2: periph-pwm1 {
 		pinmux = <&alt4_pwm1_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm2_gpc4: periph-pwm2 {
 		pinmux = <&alt4_pwm2_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm3_gp80: periph-pwm3 {
 		pinmux = <&alt4_pwm3_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm4_gpb6: periph-pwm4 {
 		pinmux = <&alt4_pwm4_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm5_gpb7: periph-pwm5 {
 		pinmux = <&alt4_pwm5_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm6_gpc0: periph-pwm6 {
 		pinmux = <&alt4_pwm6_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm7_gp60: periph-pwm7 {
 		pinmux = <&alt4_pwm7_sl>;
-		drive-supported;
 	};
 
 	/* Keyboard peripheral interfaces. */

--- a/dts/arm/nuvoton/npcx/npcx9/npcx9-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9/npcx9-pinctrl.dtsi
@@ -111,42 +111,34 @@
 	/* PWM peripheral interfaces */
 	/omit-if-no-ref/ pwm0_gpc3: periph-pwm0 {
 		pinmux = <&alt4_pwm0_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm1_gpc2: periph-pwm1 {
 		pinmux = <&alt4_pwm1_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm2_gpc4: periph-pwm2 {
 		pinmux = <&alt4_pwm2_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm3_gp80: periph-pwm3 {
 		pinmux = <&alt4_pwm3_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm4_gpb6: periph-pwm4 {
 		pinmux = <&alt4_pwm4_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm5_gpb7: periph-pwm5 {
 		pinmux = <&alt4_pwm5_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm6_gpc0: periph-pwm6 {
 		pinmux = <&alt4_pwm6_sl>;
-		drive-supported;
 	};
 
 	/omit-if-no-ref/ pwm7_gp60: periph-pwm7 {
 		pinmux = <&alt4_pwm7_sl>;
-		drive-supported;
 	};
 
 	/* Keyboard peripheral interfaces. */

--- a/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
@@ -61,12 +61,6 @@ child-binding:
         description: |
           A map to PUPD_ENn register/bit that enable pull-up/down of NPCX peripheral devices.
           Please don't overwrite this property in the board-level DT driver.
-      drive-supported:
-        required: false
-        type: boolean
-        description: |
-          It indicates the pad's drive mode is selectable. So far, only PWM's pad has this
-          property in npcx series. Please don't overwrite it in the board-level DT driver.
       pinmux-locked:
         required: false
         type: boolean

--- a/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
+++ b/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
@@ -18,11 +18,11 @@ properties:
         required: true
     pinctrl-names:
         required: true
-    drive-open-drain:
-        type: boolean
+    pwm-channel:
+        type: int
         description: |
-            The PWM output will be configured as open-drain. If not set,
-            defaults to push-pull.
+            A index to indicate PWM module that generates a single PWM signal.
+            Please don't overwrite it in the board-level DT driver.
     clock-bus:
         required: false
         type: string

--- a/soc/arm/nuvoton_npcx/common/pinctrl_soc.h
+++ b/soc/arm/nuvoton_npcx/common/pinctrl_soc.h
@@ -102,9 +102,9 @@ typedef struct npcx_pinctrl pinctrl_soc_pin_t;
 	UTIL_OR(DT_PROP(node_id, bias_pull_down),	\
 		DT_PROP(node_id, bias_pull_up))
 
-#define Z_PINCTRL_NPCX_HAS_DRIVE_PROP(node_id)		\
-	UTIL_AND(DT_PROP(node_id, drive_open_drain),	\
-		DT_PROP(node_id, drive_supported))
+#define Z_PINCTRL_NPCX_HAS_DRIVE_PROP(node_id, node_periph)	\
+	UTIL_AND(DT_PROP(node_id, drive_open_drain),		\
+		DT_NODE_HAS_PROP(node_periph, pwm_channel))
 
 /**
  * @brief Utility macro to initialize a periphral pinmux configuration.
@@ -142,12 +142,14 @@ typedef struct npcx_pinctrl pinctrl_soc_pin_t;
  * @brief Utility macro to initialize a periphral drive mode configuration.
  *
  * @param node_id Node identifier.
+ * @param node_periph Peripheral node identifier.
  */
-#define Z_PINCTRL_NPCX_PERIPH_DRIVE_INIT(node_id)				\
+#define Z_PINCTRL_NPCX_PERIPH_DRIVE_INIT(node_id, node_periph)			\
 	{									\
 		.flags.type = NPCX_PINCTRL_TYPE_PERIPH,				\
 		.flags.io_drive_type = Z_PINCTRL_NPCX_DRIVE_TYPE(node_id),	\
 		.cfg.periph.type = NPCX_PINCTRL_TYPE_PERIPH_DRIVE,		\
+		.cfg.periph.group = DT_PROP(node_periph, pwm_channel),		\
 	},
 
 /**
@@ -158,9 +160,10 @@ typedef struct npcx_pinctrl pinctrl_soc_pin_t;
  * @param idx Property entry index.
  */
 #define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)					\
-	COND_CODE_1(Z_PINCTRL_NPCX_HAS_DRIVE_PROP(DT_PROP_BY_IDX(node_id, prop, idx)),	\
+	COND_CODE_1(Z_PINCTRL_NPCX_HAS_DRIVE_PROP(					\
+			DT_PROP_BY_IDX(node_id, prop, idx), node_id),			\
 		(Z_PINCTRL_NPCX_PERIPH_DRIVE_INIT(					\
-			DT_PROP_BY_IDX(node_id, prop, idx))), ())			\
+			DT_PROP_BY_IDX(node_id, prop, idx), node_id)), ())		\
 	COND_CODE_1(Z_PINCTRL_NPCX_HAS_PUPD_PROP(DT_PROP_BY_IDX(node_id, prop, idx)),	\
 		(Z_PINCTRL_NPCX_PERIPH_PUPD_INIT(					\
 			DT_PROP_BY_IDX(node_id, prop, idx), periph_pupd)), ())		\


### PR DESCRIPTION
Config pwm open-drain mode without enabling STORE_REG. This CL
collects all active PWM's base address and related index in an
array. Then, pinctrl driver configs its open-drain mode by
finding the corresponding 'channel' index.

Signed-off-by: Mulin Chao <mlchao@nuvoton.com>

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45795