### PR TITLE
drivers: gpio: pca953x fix nINT pin

### DIFF
--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -428,7 +428,7 @@ static int gpio_pca953x_init(const struct device *dev)
 
 		k_work_init(&drv_data->work, gpio_pca953x_work_handler);
 
-		rc = gpio_pin_configure_dt(&cfg->gpio_int, GPIO_INPUT);
+		rc = gpio_pin_configure_dt(&cfg->gpio_int, GPIO_INPUT | GPIO_ACTIVE_LOW);
 		if (rc) {
 			goto out;
 		}


### PR DESCRIPTION
According to Texas Instruments SCPS199D or SCPS126G PCA9538 has an inverted interrupt pin and cfg->gpio_int should be set to GPIO_ACTIVE_LOW.

Signed-off-by: Maxim Kolchurin <maxim.kolchurin@gmail.com>