### PR TITLE
twister: sort hardware map based on id

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -4639,7 +4639,7 @@ class HardwareMap:
             with open(hwm_file, 'r') as yaml_file:
                 hwm = yaml.load(yaml_file, Loader=SafeLoader)
                 if hwm:
-                    hwm.sort(key=lambda x: x.get('serial', ''))
+                    hwm.sort(key=lambda x: x.get('id', ''))
 
                     # disconnect everything
                     for h in hwm:


### PR DESCRIPTION
Serial is not required, in some cases it might be set to null or we
might be using serial_pty, so sort existing map file based on ID
instead.

Fixes #45713

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
