### PR TITLE
Bluetooth: Controller: df: CTE req not disabled if run in single shot

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -236,6 +236,11 @@ static void lp_comm_complete_cte_req(struct ll_conn *conn, struct proc_ctx *ctx)
 				if (conn->llcp.cte_req.req_interval != 0U) {
 					conn->llcp.cte_req.req_expire =
 						conn->llcp.cte_req.req_interval;
+				} else {
+					/* Disable the CTE request procedure when it is completed in
+					 * case it was executed as non-periodic.
+					 */
+					conn->llcp.cte_req.is_enabled = 0U;
 				}
 				ctx->state = LP_COMMON_STATE_IDLE;
 			} else if (llcp_ntf_alloc_is_available()) {


### PR DESCRIPTION
There is an error. CTE request control procedure can be run in single
shot or periodic mode. In case of run in single show, it is not
disabled after completion.

The code responsible for the disable was deleted by commit:
ac7d0506f88508e7440288c1ec4319a9f7d0ad44.

The cte_req.is_enabled should be set to zero if the CTE request
completes and cte_req.req_interval is zero.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/45725
Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>