### PR TITLE
drivers: dma: return einval if specified channel not found

### DIFF
--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -487,12 +487,12 @@ static inline int z_impl_dma_request_channel(const struct device *dev,
 
 	for (i = 0; i < dma_ctx->dma_channels; i++) {
 		if (!atomic_test_and_set_bit(dma_ctx->atomic, i)) {
-			channel = i;
 			if (api->chan_filter &&
-			    !api->chan_filter(dev, channel, filter_param)) {
-				atomic_clear_bit(dma_ctx->atomic, channel);
+			    !api->chan_filter(dev, i, filter_param)) {
+				atomic_clear_bit(dma_ctx->atomic, i);
 				continue;
 			}
+			channel = i;
 			break;
 		}
 	}


### PR DESCRIPTION
chan_filter is used when a specified channel is required
so a specified channel needs to be returned,
otherwise it should return einval instead of the last channel tried