### PR TITLE
ci: doc-build: embed doc preview link to GH summary

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -104,7 +104,7 @@ jobs:
         DOC_URL="https://builds.zephyrproject.io/${REPO_NAME}/pr/${PR_NUM}/docs/"
 
         echo "${PR_NUM}" > pr_num
-        echo "::notice:: Documentation will be available shortly at: ${DOC_URL}"
+        echo "Documentation will be available shortly at: ${DOC_URL}" >> $GITHUB_STEP_SUMMARY
 
     - name: upload-pr-number
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
Github summary is rendered using GH markdown engine, so hopefully
documentation preview link will be clickable. This change should improve
user experience, as one had to manually select and copy+paste the URL.