### PR TITLE
net: lwm2m: uses default stack size with SenML CBOR content format

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -86,7 +86,6 @@ config LWM2M_DNS_SUPPORT
 
 config LWM2M_ENGINE_STACK_SIZE
 	int "LWM2M engine stack size"
-	default 14336 if LWM2M_RW_SENML_CBOR_SUPPORT
 	default 2560 if NET_LOG
 	default 2048
 	help


### PR DESCRIPTION
SenML CBOR data is stored statically in RAM and does not use process
stack.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>