### PR TITLE
soc: esp32: move libc strings in dram area

### DIFF
--- a/soc/riscv/esp32c3/linker.ld
+++ b/soc/riscv/esp32c3/linker.ld
@@ -237,6 +237,7 @@ SECTIONS
     *libsoc.a:cpu_util.*(.literal .text .literal.* .text.*)
     *liblib__libc__newlib.a:string.*(.literal .text .literal.* .text.*)
     *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
+    *libc.a:*(.literal .text .literal.* .text.*)
     *libphy.a:( .phyiram .phyiram.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
 

--- a/soc/xtensa/esp32/linker.ld
+++ b/soc/xtensa/esp32/linker.ld
@@ -348,6 +348,7 @@ SECTIONS
     *libzephyr.a:loader.*(.literal .text .literal.* .text.*)
     *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
     *liblib__libc__newlib.a:string.*(.literal .text .literal.* .text.*)
+    *libc.a:*(.literal .text .literal.* .text.*)
     *libphy.a:( .phyiram .phyiram.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
 

--- a/soc/xtensa/esp32s2/linker.ld
+++ b/soc/xtensa/esp32s2/linker.ld
@@ -267,6 +267,7 @@ SECTIONS
     *libzephyr.a:loader.*(.literal .text .literal.* .text.*)
     *liblib__libc__minimal.a:string.*(.literal .text .literal.* .text.*)
     *liblib__libc__newlib.a:string.*(.literal .text .literal.* .text.*)
+    *libc.a:*(.literal .text .literal.* .text.*)
     *libphy.a:( .phyiram .phyiram.*)
     *libgcov.a:(.literal .text .literal.* .text.*)
 


### PR DESCRIPTION
Move libc strings to RAM area so that ESP32
doesn't crash when flash cache is disabled

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>