### PR TITLE
cmake: gcc: Use --sysroot with gcc when SYSROOT_DIR is provided

### DIFF
--- a/cmake/compiler/gcc/target.cmake
+++ b/cmake/compiler/gcc/target.cmake
@@ -71,6 +71,22 @@ elseif("${ARCH}" STREQUAL "mips")
   include(${CMAKE_CURRENT_LIST_DIR}/target_mips.cmake)
 endif()
 
+if(SYSROOT_DIR)
+  # The toolchain has specified a sysroot dir, pass it to the compiler
+  list(APPEND TOOLCHAIN_C_FLAGS
+    --sysroot=${SYSROOT_DIR}
+    )
+
+  # Use sysroot dir to set the libc path's
+  execute_process(
+    COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-multi-directory
+    OUTPUT_VARIABLE NEWLIB_DIR
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+
+  set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${NEWLIB_DIR}")
+endif()
+
 # This libgcc code is partially duplicated in compiler/*/target.cmake
 execute_process(
   COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-libgcc-file-name
@@ -86,18 +102,6 @@ assert_exists(LIBGCC_DIR)
 
 LIST(APPEND LIB_INCLUDE_DIR "-L\"${LIBGCC_DIR}\"")
 LIST(APPEND TOOLCHAIN_LIBS gcc)
-
-if(SYSROOT_DIR)
-  # The toolchain has specified a sysroot dir that we can use to set
-  # the libc path's
-  execute_process(
-    COMMAND ${CMAKE_C_COMPILER} ${TOOLCHAIN_C_FLAGS} --print-multi-directory
-    OUTPUT_VARIABLE NEWLIB_DIR
-    OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-
-  set(LIBC_LIBRARY_DIR "\"${SYSROOT_DIR}\"/lib/${NEWLIB_DIR}")
-endif()
 
 # For CMake to be able to test if a compiler flag is supported by the
 # toolchain we need to give CMake the necessary flags to compile and


### PR DESCRIPTION
When SYSROOT_DIR is provided, gcc should use it through the --sysroot=
option otherwise some commands won't work as expected.

For example, in the Yocto environment when cross compiling,
--print-libgcc-file-name prints only "libgcc.a" instead of the full
path to it and the subsequent assert_exists(LIBGCC_FILE_NAME) will
fail.

Fixes #45578
Signed-off-by: Luca Fancellu <luca.fancellu@arm.com>