### PR TITLE
drivers: can: Fix blocking canbus send command

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -321,7 +321,7 @@ static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 	shell_print(sh, "Send frame with ID 0x%x (%s ID) and %d data bytes",
 		    frame.id, ext ? "extended" : "standard", frame.dlc);
 
-	ret = can_send(can_dev, &frame, K_FOREVER, NULL, NULL);
+	ret = can_send(can_dev, &frame, K_MSEC(100), NULL, NULL);
 	if (ret) {
 		shell_error(sh, "Failed to send frame [%d]", ret);
 		return -EIO;


### PR DESCRIPTION
The canbus send cli command is blocking when it is not possible to send a CAN message, for example when there is no external CAN device connected on the canbus. Adding a timeout prevents the shell from being blocked and prints an error message instead.

Signed-off-by: JarniVanmal <Jarni.vanmal@gmail.com>