### PR TITLE
shell: suppress newlines on boot when promt is an empty string

### DIFF
--- a/subsys/shell/backends/Kconfig.backends
+++ b/subsys/shell/backends/Kconfig.backends
@@ -37,7 +37,8 @@ config SHELL_PROMPT_UART
 	string "Displayed prompt name"
 	default "uart:~$ "
 	help
-	  Displayed prompt name for UART backend.
+	  Displayed prompt name for UART backend. If prompt is set, the shell will
+	  send two newlines during initialization.
 
 # Internal config to enable UART interrupts if supported.
 config SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN
@@ -133,7 +134,8 @@ config SHELL_PROMPT_RTT
 	string "Displayed prompt name"
 	default "rtt:~$ "
 	help
-	  Displayed prompt name for RTT backend.
+	  Displayed prompt name for RTT backend. If prompt is set, the shell will
+	  send two newlines during initialization.
 
 config SHELL_RTT_RX_POLL_PERIOD
 	int "RX polling period (in milliseconds)"
@@ -296,7 +298,8 @@ config SHELL_PROMPT_TELNET
 	string "Displayed prompt name"
 	default "~$ "
 	help
-	  Displayed prompt name for TELNET backend.
+	  Displayed prompt name for TELNET backend. If prompt is set, the shell will
+	  send two newlines during initialization.
 
 config SHELL_TELNET_PORT
 	int "Telnet port number"
@@ -390,7 +393,8 @@ config SHELL_PROMPT_DUMMY
 	string "Displayed prompt name"
 	default "~$ "
 	help
-	  Displayed prompt name for DUMMY backend.
+	  Displayed prompt name for DUMMY backend. If prompt is set, the shell will
+	  send two newlines during initialization.
 
 config SHELL_BACKEND_DUMMY_BUF_SIZE
 	int "Size of dummy buffer size"

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -1413,7 +1413,9 @@ int shell_start(const struct shell *shell)
 		z_shell_vt100_color_set(shell, SHELL_NORMAL);
 	}
 
-	z_shell_raw_fprintf(shell->fprintf_ctx, "\n\n");
+	if (z_shell_strlen(shell->default_prompt) > 0) {
+		z_shell_raw_fprintf(shell->fprintf_ctx, "\n\n");
+	}
 	state_set(shell, SHELL_STATE_ACTIVE);
 
 	k_mutex_unlock(&shell->ctx->wr_mtx);


### PR DESCRIPTION
If the user sets the default_prompt to an empty string no newlines will be printed during boot.