### PR TITLE
driver: i2c: mec15xx: recover from error for LAB

### DIFF
--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -261,6 +261,7 @@ static int wait_completion(const struct device *dev)
 		/* Is Lost arbitration ? */
 		status = MCHP_I2C_SMB_STS_RO(ba);
 		if (status & MCHP_I2C_SMB_STS_LAB) {
+			recover_from_error(dev);
 			return -EPERM;
 		}
 

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -425,8 +425,8 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 		ret = wait_bus_free(dev);
 		if (ret) {
 			data->error_seen = 1;
-			LOG_DBG("%s: %s wait_bus_free failure",
-				__func__, dev->name);
+			LOG_DBG("%s: %s wait_bus_free failure %d",
+				__func__, dev->name, ret);
 			return ret;
 		}
 
@@ -450,8 +450,8 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 
 		default:
 			data->error_seen = 1;
-			LOG_ERR("%s: %s wait_comp error for addr send",
-				__func__, dev->name);
+			LOG_ERR("%s: %s wait_comp error %d for addr send",
+				__func__, dev->name, ret);
 			return ret;
 		}
 	}
@@ -478,8 +478,8 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 
 		default:
 			data->error_seen = 1;
-			LOG_ERR("%s: %s wait_completion error for data send",
-				__func__, dev->name);
+			LOG_ERR("%s: %s wait_completion error %d for data send",
+				__func__, dev->name, ret);
 			return ret;
 		}
 	}
@@ -560,8 +560,8 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 		ret = wait_bus_free(dev);
 		if (ret) {
 			data->error_seen = 1;
-			LOG_DBG("%s: %s wait_bus_free failure",
-				__func__, dev->name);
+			LOG_DBG("%s: %s wait_bus_free failure %d",
+				__func__, dev->name, ret);
 			return ret;
 		}
 	}
@@ -595,8 +595,8 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 
 	default:
 		data->error_seen = 1;
-		LOG_ERR("%s: %s wait_completion error for address send",
-			__func__, dev->name);
+		LOG_ERR("%s: %s wait_completion error %d for address send",
+			__func__, dev->name, ret);
 		return ret;
 	}
 
@@ -628,8 +628,8 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 
 		default:
 			data->error_seen = 1;
-			LOG_ERR("%s: %s wait_completion error for data send",
-				__func__, dev->name);
+			LOG_ERR("%s: %s wait_completion error %d for data send",
+				__func__, dev->name, ret);
 			return ret;
 		}
 


### PR DESCRIPTION
For lost arbitration error condition add recover from
error logic to reset the i2c controller

Signed-off-by: Jay Vasanth <jay.vasanth@microchip.com>