### PR TITLE
Porting STM32 Ethernet HAL driver

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -16,6 +16,12 @@ menuconfig ETH_STM32_HAL
 
 if ETH_STM32_HAL
 
+config ETH_STM32_HAL_API_V2
+	bool "Use new HAL driver"
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F4X
+	help
+	  Use the new HAL driver instead of the legacy one.
+
 config ETH_STM32_HAL_RX_THREAD_STACK_SIZE
 	int "RX thread stack size"
 	default 1500

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -312,7 +312,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	heth = &dev_data->heth;
 
 	total_len = net_pkt_get_len(pkt);
-	if (total_len > ETH_STM32_TX_BUF_SIZE) {
+	if (total_len > (ETH_STM32_TX_BUF_SIZE * ETH_TXBUFNB)) {
 		LOG_ERR("PKT too big");
 		return -EIO;
 	}

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -193,14 +193,13 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 
 	heth = &dev_data->heth;
 
-	k_mutex_lock(&dev_data->tx_mutex, K_FOREVER);
-
 	total_len = net_pkt_get_len(pkt);
 	if (total_len > ETH_STM32_TX_BUF_SIZE) {
 		LOG_ERR("PKT too big");
-		res = -EIO;
-		goto error;
+		return -EIO;
 	}
+
+	k_mutex_lock(&dev_data->tx_mutex, K_FOREVER);
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	uint32_t cur_tx_desc_idx;

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -802,7 +802,33 @@ void HAL_ETH_TxCpltCallback(ETH_HandleTypeDef *heth_handle)
 }
 #endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_ETH_STM32_HAL_API_V2 */
 
-#ifdef CONFIG_SOC_SERIES_STM32H7X
+#if defined(CONFIG_ETH_STM32_HAL_API_V2)
+void HAL_ETH_ErrorCallback(ETH_HandleTypeDef *heth)
+{
+	__ASSERT_NO_MSG(heth != NULL);
+
+	const uint32_t error_code = HAL_ETH_GetError(heth);
+
+	switch (error_code) {
+	case HAL_ETH_ERROR_DMA:
+		LOG_ERR("%s errorcode:%x dmaerror:%x",
+			__func__,
+			error_code,
+			HAL_ETH_GetDMAError(heth));
+		break;
+	case HAL_ETH_ERROR_MAC:
+		LOG_ERR("%s errorcode:%x macerror:%x",
+			__func__,
+			error_code,
+			HAL_ETH_GetMACError(heth));
+		break;
+	default:
+		LOG_ERR("%s errorcode:%x",
+			__func__,
+			error_code);
+	}
+}
+#elif defined(CONFIG_SOC_SERIES_STM32H7X)
 /* DMA and MAC errors callback only appear in H7 series */
 void HAL_ETH_DMAErrorCallback(ETH_HandleTypeDef *heth_handle)
 {
@@ -849,7 +875,7 @@ void HAL_ETH_MACErrorCallback(ETH_HandleTypeDef *heth_handle)
 		return;
 	}
 }
-#endif /* CONFIG_SOC_SERIES_STM32H7X */
+#endif /* CONFIG_ETH_STM32_HAL_API_V2 */
 
 void HAL_ETH_RxCpltCallback(ETH_HandleTypeDef *heth_handle)
 {

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -91,7 +91,32 @@ static ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB] __eth_stm32_desc;
 static uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_STM32_RX_BUF_SIZE] __eth_stm32_buf;
 static uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_STM32_TX_BUF_SIZE] __eth_stm32_buf;
 
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
+#if defined(CONFIG_ETH_STM32_HAL_API_V2)
+
+BUILD_ASSERT(ETH_STM32_RX_BUF_SIZE % 4 == 0, "Rx buffer size must be a multiple of 4");
+
+struct eth_stm32_rx_buffer_header {
+	struct eth_stm32_rx_buffer_header *next;
+	uint16_t size;
+	bool used;
+};
+
+struct eth_stm32_tx_buffer_header {
+	ETH_BufferTypeDef tx_buff;
+	bool used;
+};
+
+struct eth_stm32_tx_context {
+	struct net_pkt *pkt;
+	uint16_t first_tx_buffer_index;
+};
+
+static struct eth_stm32_rx_buffer_header dma_rx_buffer_header[ETH_RXBUFNB];
+static struct eth_stm32_tx_buffer_header dma_tx_buffer_header[ETH_TXBUFNB];
+
+#endif /* CONFIG_ETH_STM32_HAL_API_V2 */
+
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_ETH_STM32_HAL_API_V2)
 static ETH_TxPacketConfig tx_config;
 #endif
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -59,8 +59,6 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define ETH_MEDIA_INTERFACE_MII		HAL_ETH_MII_MODE
 #define ETH_MEDIA_INTERFACE_RMII	HAL_ETH_RMII_MODE
 
-#define ETH_DMA_TX_TIMEOUT_MS	20U  /* transmit timeout in milliseconds */
-
 /* Only one tx_buffer is sufficient to pass only 1 dma_buffer */
 #define ETH_TXBUF_DEF_NB	1U
 #else
@@ -69,6 +67,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 							ETH_DMATXDESC_OWN)
 
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
+
+#define ETH_DMA_TX_TIMEOUT_MS	20U  /* transmit timeout in milliseconds */
 
 #if defined(CONFIG_ETH_STM32_HAL_USE_DTCM_FOR_DMA_BUFFER) && \
 	    DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_dtcm), okay)

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1111,7 +1111,7 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 	.heth = {
 		.Instance = (ETH_TypeDef *)DT_INST_REG_ADDR(0),
 		.Init = {
-#if !defined(CONFIG_SOC_SERIES_STM32H7X)
+#if !defined(CONFIG_SOC_SERIES_STM32H7X) && !defined(CONFIG_ETH_STM32_HAL_API_V2)
 #if defined(CONFIG_ETH_STM32_AUTO_NEGOTIATION_ENABLE)
 			.AutoNegotiation = ETH_AUTONEGOTIATION_ENABLE,
 #else

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -41,9 +41,9 @@ struct eth_stm32_hal_dev_data {
 	const struct device *clock;
 	struct k_mutex tx_mutex;
 	struct k_sem rx_int_sem;
-#ifdef CONFIG_SOC_SERIES_STM32H7X
+#if defined(CONFIG_SOC_SERIES_STM32H7X) || defined(CONFIG_ETH_STM32_HAL_API_V2)
 	struct k_sem tx_int_sem;
-#endif /* CONFIG_SOC_SERIES_STM32H7X */
+#endif /* CONFIG_SOC_SERIES_STM32H7X || CONFIG_ETH_STM32_HAL_API_V2*/
 	K_KERNEL_STACK_MEMBER(rx_thread_stack,
 		CONFIG_ETH_STM32_HAL_RX_THREAD_STACK_SIZE);
 	struct k_thread rx_thread;

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 642e199c59828137dc6b1c7044a289d4269886d1
+      revision: 15993325e3aa961fbf5ffc17583ab1d4fed1e0bc
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
This is a follow-up of #45260 to fix #41380.

A new Kconfig option (<del>`ETH_STM32_USE_HAL_DRIVER_WITH_NEW_API`</del>`ETH_STM32_HAL_API_V2`) is introduced to switch to the non-legacy ETH HAL driver. Furthermore, multiple receive buffers can be used for one single packet, which means that the rx buffer size can be reduced and doesn't have to match the maximum ethernet packet length anymore.

Future work:
 - [ ] Make rx buffer size selectable by config option (?)
 - [x] Support multiple buffers for TX path as well for the same reason
 - [ ] Use new PTP HAL

Depends on zephyrproject-rtos/hal_stm32#139