### PR TITLE
hal: espressif: allow building without ZEPHYR_BASE being set in the environment

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -6,8 +6,9 @@
 import os
 import pickle
 import sys
+from pathlib import Path
 
-ZEPHYR_BASE = os.environ["ZEPHYR_BASE"]
+ZEPHYR_BASE = str(Path(__file__).resolve().parents[2])
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts", "dts",
                                 "python-devicetree", "src"))
 

--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: 12d88df9caf69c8b4f3ad44efc7780b0f0e50db2
+      revision: bceaadfc8f4f812ace778937a6b042e3b6249215
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
- Use a path relative to the script itself to determine the ZEPHYR_BASE path instead of relying on the environment variable. This allows for modules to use the Zephyr kconfiglib without having ZEPHYR_BASE set in the environment.
- Update the espressif HAL to allow building without having ZEPHYR_BASE set in the environment.

Fixes: https://github.com/zephyrproject-rtos/hal_espressif/issues/100