### PR TITLE
include: fix the size of IRQn_Type

### DIFF
--- a/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
@@ -64,6 +64,7 @@ typedef enum {
 	DebugMonitor_IRQn             =  -4,
 	PendSV_IRQn                   =  -2,
 	SysTick_IRQn                  =  -1,
+	Max_IRQn                      =  CONFIG_NUM_IRQS,
 } IRQn_Type;
 
 #if defined(CONFIG_CPU_CORTEX_M0)


### PR DESCRIPTION
IRQn_Type is compiled to int8_t if __NVIC_PRIO_BITS is not set.  It
implies the maximum postive value of the peripheral irq is 127.  This
would lead to an irq number turns into a nagtive value if it is greater
than 127.

For example:
The input argument `irq` of arch_irq_enable is 130. But the input
argument of NVIC_EnableIRQ becomes (IRQn_Type)130 = -126 and results
error.

```
void arch_irq_enable(unsigned int irq)
{
	NVIC_EnableIRQ((IRQn_Type)irq);
}
```

By adding a maximum IRQ number, the bit width of IRQn_Type is guaranteed
to cover all IRQ numbers of the system.

Signed-off-by: Dylan Hung <dylan_hung@aspeedtech.com>