### PR TITLE
Add more temporary files from emacs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@
 *.swp
 *.swo
 *~
+.\#*
+\#*\#
 build*/
 !doc/guides/build
 !tests/drivers/build_all


### PR DESCRIPTION
Emacs creates autosave and temporary files when editing.

These should be ignored by git.
