### PR TITLE
soc: arm: microchip: mec172x: Add option to enable JTAG

### DIFF
--- a/soc/arm/microchip_mec/mec172x/Kconfig.soc
+++ b/soc/arm/microchip_mec/mec172x/Kconfig.soc
@@ -24,3 +24,50 @@ config SOC_MEC172X_PROC_CLK_DIV
 	  and main 96 MHz clock (MCK):
 	  HCLK = MCK / PROC_CLK_DIV
 	  Allowed divider values: 1, 3, 4, 16, and 48.
+
+choice
+	prompt "MEC172X debug interface general configuration"
+	default SOC_MEC172X_DEBUG_DISABLED
+	depends on SOC_SERIES_MEC172X
+	help
+	  Select Debug SoC interface support for MEC15xx SoC family
+
+	config SOC_MEC172X_DEBUG_DISABLED
+		bool "Disable debug support"
+		help
+		  Debug port is disabled, JTAG/SWD cannot be enabled. JTAG_RST#
+		  pin is ignored. All other JTAG pins can be used as GPIOs
+		  or other non-JTAG alternate functions.
+
+	config SOC_MEC172X_DEBUG_WITHOUT_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode. ADC00-03 can be used.
+
+	config SOC_MEC172X_DEBUG_AND_TRACING
+		bool "Debug support via Serial wire debug with tracing enabled"
+		help
+		  JTAG port is enabled in SWD mode. Refer to tracing options
+		  to see if ADC00-03 can be used or not.
+
+endchoice
+
+choice
+	prompt "MEC172X debug interface trace configuration"
+	default SOC_MEC172X_DEBUG_AND_ETM_TRACING
+	depends on SOC_MEC172X_DEBUG_AND_TRACING
+	help
+	  Select tracing mode for debug interface
+
+	config SOC_MEC172X_DEBUG_AND_ETM_TRACING
+		bool "Debug support via Serial wire debug"
+		help
+		  JTAG port in SWD mode and SWV as tracing method.
+		  ADC00-03 cannot be used.
+
+	config SOC_MEC172X_DEBUG_AND_SWV_TRACING
+		bool "debug support via Serial Wire Debug and Viewer"
+		help
+		  JTAG port in SWD mode and SWV as tracing method.
+		  ADC00-03 can be used.
+endchoice

--- a/soc/arm/microchip_mec/mec172x/soc.c
+++ b/soc/arm/microchip_mec/mec172x/soc.c
@@ -12,9 +12,39 @@
 #include <zephyr/arch/cpu.h>
 #include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
+
+#if defined(CONFIG_SOC_MEC172X_DEBUG_WITHOUT_TRACING) || \
+	defined(CONFIG_SOC_MEC172X_DEBUG_AND_TRACING)
+static uintptr_t ecs_regbase = DT_REG_ADDR(DT_NODELABEL(ecs));
+#endif
+
+static void configure_debug_interface(void)
+{
+#ifdef CONFIG_SOC_MEC172X_DEBUG_WITHOUT_TRACING
+	struct ecs_regs *regs = ((struct ecs_regs *)ecs_regbase);
+
+	regs->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD);
+#elif defined(CONFIG_SOC_MEC172X_DEBUG_AND_TRACING)
+	struct ecs_regs *regs = ((struct ecs_regs *)ecs_regbase);
+
+	#if defined(CONFIG_SOC_MEC172X_DEBUG_AND_ETM_TRACING)
+		regs->ETM_CTRL = MCHP_ECS_ETM_CTRL_EN;
+		regs->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD);
+	#elif defined(CONFIG_SOC_MEC172X_DEBUG_AND_SWV_TRACING)
+		regs->DEBUG_CTRL = (MCHP_ECS_DCTRL_DBG_EN |
+				MCHP_ECS_DCTRL_MODE_SWD_SWV);
+	#endif /* CONFIG_SOC_MEC172X_DEBUG_AND_TRACING */
+
+#endif /* CONFIG_SOC_MEC172X_DEBUG_WITHOUT_TRACING */
+}
+
 static int soc_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
+
+	configure_debug_interface();
 
 	return 0;
 }


### PR DESCRIPTION
Set different options for MEC172x SoC debug via JTAG.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>