### PR TITLE
test: Enable the counter_basic_api test on mec172x board

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -296,3 +296,7 @@
 	pinctrl-0 = <&ps2_clk0a_gpio114 &ps2_dat0a_gpio115>;
 	pinctrl-names = "default";
 };
+
+&timer5 {
+	status = "okay";
+};

--- a/drivers/counter/counter_mchp_xec.c
+++ b/drivers/counter/counter_mchp_xec.c
@@ -46,7 +46,7 @@ struct counter_xec_data {
 };
 
 #define COUNTER_XEC_REG_BASE(_dev)			\
-	((BTMR_Type *)					\
+	((struct btmr_regs *)					\
 	 ((const struct counter_xec_config * const)	\
 	  _dev->config)->base_address)
 
@@ -59,7 +59,7 @@ struct counter_xec_data {
 
 static int counter_xec_start(const struct device *dev)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 
 	if (counter->CTRL & MCHP_BTMR_CTRL_ENABLE) {
 		return -EALREADY;
@@ -74,7 +74,7 @@ static int counter_xec_start(const struct device *dev)
 
 static int counter_xec_stop(const struct device *dev)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 	uint32_t reg;
 
 	if (!(counter->CTRL & MCHP_BTMR_CTRL_ENABLE)) {
@@ -100,7 +100,7 @@ static int counter_xec_stop(const struct device *dev)
 
 static int counter_xec_get_value(const struct device *dev, uint32_t *ticks)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 
 	*ticks = counter->CNT;
 	return 0;
@@ -109,7 +109,7 @@ static int counter_xec_get_value(const struct device *dev, uint32_t *ticks)
 static int counter_xec_set_alarm(const struct device *dev, uint8_t chan_id,
 				 const struct counter_alarm_cfg *alarm_cfg)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 	struct counter_xec_data *data = COUNTER_XEC_DATA(dev);
 
 	if (chan_id != 0) {
@@ -153,7 +153,7 @@ static int counter_xec_set_alarm(const struct device *dev, uint8_t chan_id,
 
 static int counter_xec_cancel_alarm(const struct device *dev, uint8_t chan_id)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 	struct counter_xec_data *data = COUNTER_XEC_DATA(dev);
 
 	if (chan_id != 0) {
@@ -174,14 +174,14 @@ static int counter_xec_cancel_alarm(const struct device *dev, uint8_t chan_id)
 
 static uint32_t counter_xec_get_pending_int(const struct device *dev)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 
 	return counter->STS;
 }
 
 static uint32_t counter_xec_get_top_value(const struct device *dev)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 
 	return counter->PRLD;
 }
@@ -189,7 +189,7 @@ static uint32_t counter_xec_get_top_value(const struct device *dev)
 static int counter_xec_set_top_value(const struct device *dev,
 				     const struct counter_top_cfg *cfg)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 	const struct counter_xec_config *counter_cfg = COUNTER_XEC_CONFIG(dev);
 	struct counter_xec_data *data = COUNTER_XEC_DATA(dev);
 	int ret = 0;
@@ -243,14 +243,19 @@ static int counter_xec_set_top_value(const struct device *dev,
 
 static void counter_xec_isr(const struct device *dev)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 	const struct counter_xec_config *counter_cfg = COUNTER_XEC_CONFIG(dev);
 	struct counter_xec_data *data = COUNTER_XEC_DATA(dev);
 	counter_alarm_callback_t alarm_cb;
 	void *user_data;
 
 	counter->STS = MCHP_BTMR_STS_ACTIVE;
+
+#if defined(CONFIG_SOC_MEC172X_NSZ)
+	mchp_soc_ecia_girq_src_clr(counter_cfg->girq_id, counter_cfg->girq_bit);
+#else
 	MCHP_GIRQ_SRC(counter_cfg->girq_id) = BIT(counter_cfg->girq_bit);
+#endif
 
 	LOG_DBG("%p Counter ISR", dev);
 
@@ -281,7 +286,7 @@ static const struct counter_driver_api counter_xec_api = {
 
 static int counter_xec_init(const struct device *dev)
 {
-	BTMR_Type *counter = COUNTER_XEC_REG_BASE(dev);
+	struct btmr_regs *counter = COUNTER_XEC_REG_BASE(dev);
 	const struct counter_xec_config *counter_cfg = COUNTER_XEC_CONFIG(dev);
 
 	counter_xec_stop(dev);
@@ -294,7 +299,11 @@ static int counter_xec_init(const struct device *dev)
 	counter->PRLD = counter_cfg->info.max_top_value;
 	counter->CNT = counter_cfg->info.max_top_value;
 
+#if defined(CONFIG_SOC_MEC172X_NSZ)
+	mchp_soc_ecia_girq_src_en(counter_cfg->girq_id, counter_cfg->girq_bit);
+#else
 	MCHP_GIRQ_ENSET(counter_cfg->girq_id) = BIT(counter_cfg->girq_bit);
+#endif
 
 	counter_cfg->config_func();
 

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -157,6 +157,7 @@ static void counter_tear_down_instance(const struct device *dev)
 static void test_all_instances(counter_test_func_t func,
 				counter_capability_func_t capability_check)
 {
+	zassert_true(ARRAY_SIZE(devices) > 0, "No device found");
 	for (int i = 0; i < ARRAY_SIZE(devices); i++) {
 		counter_setup_instance(devices[i]);
 		if ((capability_check == NULL) ||


### PR DESCRIPTION
1. enable timer5 on dts
2. Replace all BTMR_Type with struct btmr_regs, to make it compatiable
   on both mec 15 and 17
3. As MEC15 and MEC17 have different ways to access the register, use
   "#if defined" to access counter_cfg->girq_id on different board.
4. Fix a bug, when no device is found and the counter test is not
   acutaly run, it will still return PASS.

Test pass on mec172xevb_assy6906

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>