### PR TITLE
bluetooth: att: Fix L2CAP channel section order

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -3173,7 +3173,11 @@ static int bt_att_accept(struct bt_conn *conn, struct bt_l2cap_chan **ch)
 	return 0;
 }
 
-BT_L2CAP_CHANNEL_DEFINE(att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept, NULL);
+/* The L2CAP channel section is sorted lexicographically. Make sure that ATT fixed channel will be
+ * placed as the last one to ensure that SMP channel is properly initialized before bt_att_connected
+ * tries to send security request.
+ */
+BT_L2CAP_CHANNEL_DEFINE(z_att_fixed_chan, BT_L2CAP_CID_ATT, bt_att_accept, NULL);
 
 #if defined(CONFIG_BT_EATT)
 static k_timeout_t credit_based_connection_delay(struct bt_conn *conn)


### PR DESCRIPTION
The L2CAP channel section is sorted lexicographically. Make sure that ATT fixed channel will be placed as the last one to ensure
that SMP channel is properly initialized before bt_att_connected tries to send security request.

The issue can be replicated on main (used commit hash of 2dc866fa487ba524b426adc453d028bdd7aaa4e2) with `bluetooth/peripheral_hids` sample (checked on nrf52840dk_nrf528400):

* Build and program the sample
* Connect with device over BLE (e.g. with Android phone) and establish security
*  Disconnect
*  Reconnect

Right after reconnection, the following error log is observed:
```
[00:00:43.157,531] <err> bt_smp: Unable to find SMP channel
[00:00:43.157,562] <wrn> bt_gatt: Failed to set security for bonded peer (-128)
```
The error log is observed on every reconnection.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45820