### PR TITLE
Misc documentation/cosmetic fixes

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -365,7 +365,7 @@ static int pwm_nrfx_pm_action(const struct device *dev,
 				(PWM_CH_INVERTED(idx, 3) ? BIT(3) : 0),))     \
 	};								      \
 	IF_ENABLED(CONFIG_PINCTRL, (PINCTRL_DT_DEFINE(PWM(idx))));	      \
-	static const struct pwm_nrfx_config pwm_nrfx_##idx##config = {	      \
+	static const struct pwm_nrfx_config pwm_nrfx_##idx##_config = {	      \
 		.pwm = NRFX_PWM_INSTANCE(idx),				      \
 		.initial_config = {					      \
 			COND_CODE_1(CONFIG_PINCTRL,			      \
@@ -394,7 +394,7 @@ static int pwm_nrfx_pm_action(const struct device *dev,
 	DEVICE_DT_DEFINE(PWM(idx),					      \
 			 pwm_nrfx_init, PM_DEVICE_DT_GET(PWM(idx)),	      \
 			 &pwm_nrfx_##idx##_data,			      \
-			 &pwm_nrfx_##idx##config,			      \
+			 &pwm_nrfx_##idx##_config,			      \
 			 POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE,     \
 			 &pwm_nrfx_drv_api_funcs)
 

--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -47,7 +47,7 @@ description: |
     Each group can specify a list of pin function selections in the 'psels'
     property. The NRF_PSEL macro is used to specify a pin function selection.
     Available pin functions can be found in the
-    include/dt-bindings/pinctrl/nrf-pinctrl.h header file.
+    include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h header file.
 
     A group can also specify shared pin properties common to all the specified
     pins, such as the 'bias-pull-up' property in group 2. Here is a list of

--- a/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32-pinctrl.yaml
@@ -76,7 +76,7 @@ child-binding:
 
             To simplify the usage, macro is available to generate "pinmux" field.
             This macro is available here:
-              -include/dt-bindings/pinctrl/stm32-pinctrl-common.h
+              -include/zephyr/dt-bindings/pinctrl/stm32-pinctrl-common.h
             Some examples of macro usage:
                GPIO A9 set as alernate function 2
             ... {

--- a/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
+++ b/dts/bindings/pinctrl/st,stm32f1-pinctrl.yaml
@@ -83,7 +83,7 @@ child-binding:
             * 4 : Full remap
             To simplify the usage, macro is available to generate "pinmux" field.
             This macro is available here:
-              -include/dt-bindings/pinctrl/stm32f1-pinctrl.h
+              -include/zephyr/dt-bindings/pinctrl/stm32f1-pinctrl.h
             Some examples of macro usage:
                GPIO A9 set as alernate with no remap
             ... {

--- a/dts/bindings/sensor/ite,it8xxx2-vcmp.yaml
+++ b/dts/bindings/sensor/ite,it8xxx2-vcmp.yaml
@@ -27,7 +27,8 @@ properties:
     required: true
     description: |
       Select the scan interval for all comparator channel.
-      Check include/dt-bindings/sensor/it8xxx2_vcmp.h file for pre-defined values.
+      Check include/zephyr/dt-bindings/sensor/it8xxx2_vcmp.h file for
+      pre-defined values.
 
   comparison:
     type: int
@@ -35,14 +36,16 @@ properties:
     description: |
       Determines the condition to be met between ADC data and
       threshold assert value that will trigger comparator interrupt.
-      Check include/dt-bindings/sensor/it8xxx2_vcmp.h file for pre-defined values.
+      Check include/zephyr/dt-bindings/sensor/it8xxx2_vcmp.h file for
+      pre-defined values.
 
   threshold-mv:
     type: int
     required: true
     description: |
       16-bit value in milli-volts present on ADC data as threshold assert.
-      Check include/dt-bindings/sensor/it8xxx2_vcmp.h file for pre-defined values.
+      Check include/zephyr/dt-bindings/sensor/it8xxx2_vcmp.h file for
+      pre-defined values.
 
   io-channels:
     type: phandle-array

--- a/dts/bindings/sensor/ti,ina230.yaml
+++ b/dts/bindings/sensor/ti,ina230.yaml
@@ -7,9 +7,9 @@
 
 description: |
     TI INA230 and INA231 Bidirectional Current and Power Monitor.
-    The <include/dt-bindings/sensor/ina230.h> file should be included
-    in the DeviceTree and it provides macro that can be used for
-    initializing the configuration register.
+    The <zephyr/dt-bindings/sensor/ina230.h> file should be included in the
+    DeviceTree and it provides macro that can be used for initializing the
+    configuration register.
 
 compatible: "ti,ina230"
 

--- a/dts/bindings/sensor/ti,ina237.yaml
+++ b/dts/bindings/sensor/ti,ina237.yaml
@@ -6,9 +6,9 @@
 
 description: |
     TI INA237 Bidirectional Current and Power Monitor.
-    The <include/dt-bindings/sensor/ina237.h> file should be included
-    in the DeviceTree and it provides macros that can be used for
-    initializing the configuration registers.
+    The <zephyr/dt-bindings/sensor/ina237.h> file should be included in the
+    DeviceTree and it provides macros that can be used for initializing the
+    configuration registers.
 
 compatible: "ti,ina237"
 

--- a/scripts/twister
+++ b/scripts/twister
@@ -231,8 +231,8 @@ def parse_arguments():
                                             """
 Artificially long but functional example:
     $ ./scripts/twister -v     \\
-      --testcase-root tests/ztest/base    \\
-      --testcase-root tests/kernel   \\
+      --testsuite-root tests/ztest/base    \\
+      --testsuite-root tests/kernel   \\
       --test      tests/ztest/base/testing.ztest.verbose_0  \\
       --test      tests/kernel/fifo/fifo_api/kernel.fifo
 
@@ -284,7 +284,7 @@ Artificially long but functional example:
 
     case_select.add_argument("--list-tests", action="store_true",
                              help="""List of all sub-test functions recursively found in
-        all --testcase-root arguments. Note different sub-tests can share
+        all --testsuite-root arguments. Note different sub-tests can share
         the same section name and come from different directories.
         The output is flattened and reports --sub-test names only,
         not their directories. For instance net.socket.getaddrinfo_ok


### PR DESCRIPTION
Hi, few cosmetic things I bumped into:
- incoherent variable name in the nrfx_pwm driver
- renamed flag in twister, old one in the help text
- outdated path in the dts binding descriptions