### PR TITLE
arch/xtensa: Fix return context for nested interupts

### DIFF
--- a/tests/kernel/common/src/main.c
+++ b/tests/kernel/common/src/main.c
@@ -126,7 +126,7 @@ void test_main(void)
 	ztest_test_suite(common,
 			 ztest_unit_test(test_bootdelay),
 			 ztest_unit_test(test_irq_offload),
-			 ztest_unit_test(test_nested_irq_offload),
+			 ztest_1cpu_unit_test(test_nested_irq_offload),
 			 ztest_unit_test(test_byteorder_memcpy_swap),
 			 ztest_unit_test(test_byteorder_mem_swap),
 			 ztest_unit_test(test_sys_get_be64),


### PR DESCRIPTION
The xtensa interrupt return path was forgetting to check the nested interrupt state and calling into the scheduler to select the context to which to return, which of course is completely wrong.  We MUST return to the ISR we interrupted.

In fact in practice this was only visible in the case of a nested interrupt that causes a context switch, otherwise the "interrupted" argument just gets returned and things work.  In particular, it can happen when the nested context is a fatal exception that aborts the current thread, which is how this was discovered.  The timing required to see this on live interrupts on real applications is likely to have been extremely difficult to detect. 