### PR TITLE
drivers: spi: Added Async API to SPI Emulator

### DIFF
--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -84,6 +84,29 @@ static int spi_emul_io(const struct device *dev,
 	return api->io(emul, config, tx_bufs, rx_bufs);
 }
 
+#ifdef CONFIG_SPI_ASYNC
+static int spi_emul_io_async(const struct device *dev,
+		       const struct spi_config *config,
+		       const struct spi_buf_set *tx_bufs,
+		       const struct spi_buf_set *rx_bufs,
+				       struct k_poll_signal *async)
+{
+	struct spi_emul *emul;
+	const struct spi_emul_api *api;
+
+	emul = spi_emul_find(dev, config->slave);
+	if (!emul) {
+		return -EIO;
+	}
+
+	api = emul->api;
+	__ASSERT_NO_MSG(emul->api);
+	__ASSERT_NO_MSG(emul->api->io_async);
+
+	return api->io_async(emul, config, tx_bufs, rx_bufs, async);
+}
+#endif /* CONFIG_SPI_ASYNC */
+
 /**
  * Set up a new emulator and add it to the list
  *
@@ -115,6 +138,9 @@ int spi_emul_register(const struct device *dev, const char *name,
 
 static struct spi_driver_api spi_emul_api = {
 	.transceive = spi_emul_io,
+#ifdef CONFIG_SPI_ASYNC
+	.transceive_async = spi_emul_io_async,
+#endif
 };
 
 #define EMUL_LINK_AND_COMMA(node_id) {		\


### PR DESCRIPTION
- Added io_async handler within the API.
- Added hooks to trigger it upon spi_transceive_async() calls.

Signed-off-by: Luis Ubieda <luisf@croxel.com>