### PR TITLE
kernel/sched: Panic on aborting essential threads

### DIFF
--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -1712,6 +1712,13 @@ void z_thread_abort(struct k_thread *thread)
 {
 	k_spinlock_key_t key = k_spin_lock(&sched_spinlock);
 
+	if ((thread->base.user_options & K_ESSENTIAL) != 0) {
+		k_spin_unlock(&sched_spinlock, key);
+		__ASSERT(false, "aborting essential thread %p", thread);
+		k_panic();
+		return;
+	}
+
 	if ((thread->base.thread_state & _THREAD_DEAD) != 0U) {
 		k_spin_unlock(&sched_spinlock, key);
 		return;

--- a/tests/kernel/fatal/message_capture/src/main.c
+++ b/tests/kernel/fatal/message_capture/src/main.c
@@ -9,6 +9,8 @@
 
 static volatile int expected_reason = -1;
 
+void z_thread_essential_clear(void);
+
 void k_sys_fatal_error_handler(unsigned int reason, const z_arch_esf_t *pEsf)
 {
 	printk("Caught system error -- reason %d\n", reason);
@@ -73,5 +75,13 @@ void test_message_capture(void)
 
 void main(void)
 {
+	/* main() is an essential thread, and we try to OOPS it.  When
+	 * this test was written, that worked (even though it wasn't
+	 * supposed to per docs).  Now we trap a different error (a
+	 * panic and not an oops).  Set the thread non-essential as a
+	 * workaround.
+	 */
+	z_thread_essential_clear();
+
 	test_message_capture();
 }

--- a/tests/kernel/threads/thread_apis/src/test_essential_thread.c
+++ b/tests/kernel/threads/thread_apis/src/test_essential_thread.c
@@ -14,6 +14,8 @@ struct k_thread kthread_thread;
 K_THREAD_STACK_DEFINE(kthread_stack, STACKSIZE);
 K_SEM_DEFINE(sync_sem, 0, 1);
 
+static bool fatal_error_signaled;
+
 static void thread_entry(void *p1, void *p2, void *p3)
 {
 	z_thread_essential_set();
@@ -55,6 +57,8 @@ void k_sys_fatal_error_handler(unsigned int reason,
 	ARG_UNUSED(esf);
 	ARG_UNUSED(reason);
 
+	fatal_error_signaled = true;
+
 	z_thread_essential_clear();
 }
 
@@ -85,6 +89,8 @@ static void abort_thread_entry(void *p1, void *p2, void *p3)
 
 void test_essential_thread_abort(void)
 {
+	fatal_error_signaled = false;
+
 	k_tid_t tid = k_thread_create(&kthread_thread, kthread_stack, STACKSIZE,
 				      (k_thread_entry_t)abort_thread_entry,
 				      NULL, NULL, NULL, K_PRIO_PREEMPT(0), 0,
@@ -93,4 +99,5 @@ void test_essential_thread_abort(void)
 	k_sem_take(&sync_sem, K_FOREVER);
 	k_thread_abort(tid);
 
+	zassert_true(fatal_error_signaled, "fatal error was not signaled");
 }


### PR DESCRIPTION
Documentation specifies that aborting/terminating/exiting essential
threads is a system panic condition, but we didn't actually implement
that and allowed it as for other threads. At least one app wants to
exploit this documented behavior as a "watchdog" kind of condition,
and that seems reasonable.  Do what we say we're supposed to do.

This also includes a small fix to a test, which seemed like it was
written to exercise exactly this condition.  Except that it failed to
detect whether or not a system fatal error was actually signaled and
was (incorrectly) indicating "success".  Check that we actually enter
the handler.

Fixes #45545

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>