### PR TITLE
scripts: zspdx: fix writing custom license IDs

### DIFF
--- a/scripts/west_commands/zspdx/writer.py
+++ b/scripts/west_commands/zspdx/writer.py
@@ -128,7 +128,7 @@ Created: {datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ")}
 
     # write other license info, if any
     if len(doc.customLicenseIDs) > 0:
-        for lic in list(doc.customLicenseIDs).sort():
+        for lic in sorted(list(doc.customLicenseIDs)):
             writeOtherLicenseSPDX(f, lic)
 
 # Open SPDX document file for writing, write the document, and calculate


### PR DESCRIPTION
The builtin list function `.sort()` sorts the list in-place and returns
None. As this is an invalid type for iteration, use the builtin `sorted`
function, which returns a sorted copy of the list, which we can iterate
over.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>