### PR TITLE
Bluetooth: Controller: Fix HCI AD Data fragment operation validations

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -437,6 +437,8 @@ uint8_t ll_adv_sync_param_set(uint8_t handle, uint16_t interval, uint16_t flags)
 
 	lll_adv_sync_data_enqueue(lll_sync, ter_idx);
 
+	sync->is_data_cmplt = 1U;
+
 	return 0;
 }
 
@@ -452,13 +454,6 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	struct ll_adv_set *adv;
 	uint8_t ter_idx;
 	uint8_t err;
-
-	/* TODO: handle other op values */
-	if (op != BT_HCI_LE_EXT_ADV_OP_COMPLETE_DATA &&
-	    op != BT_HCI_LE_EXT_ADV_OP_UNCHANGED_DATA) {
-		/* FIXME: error code */
-		return BT_HCI_ERR_CMD_DISALLOWED;
-	}
 
 	adv =  ull_adv_is_created_get(handle);
 	if (!adv) {
@@ -548,6 +543,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 	 */
 	adv_sync_pdu_chain_check_and_duplicate(pdu, pdu_prev);
 
+	/* Update time reservation if Periodic Advertising events are active */
 	if (sync->is_started) {
 		err = ull_adv_sync_time_update(sync, pdu);
 		if (err) {
@@ -555,9 +551,13 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 		}
 	}
 
+	/* Commit the updated Periodic Advertising Data */
 	lll_adv_sync_data_enqueue(lll_sync, ter_idx);
 
-	return err;
+	/* Check if Periodic Advertising Data is complete */
+	sync->is_data_cmplt = (op >= BT_HCI_LE_EXT_ADV_OP_LAST_FRAG);
+
+	return 0;
 }
 
 uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
@@ -572,16 +572,19 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 	uint8_t ter_idx;
 	uint8_t err;
 
+	/* Check for valid advertising set */
 	adv = ull_adv_is_created_get(handle);
 	if (!adv) {
 		return BT_HCI_ERR_UNKNOWN_ADV_IDENTIFIER;
 	}
 
+	/* Check if periodic advertising is associated with advertising set */
 	lll_sync = adv->lll.sync;
 	if (!lll_sync) {
 		return BT_HCI_ERR_CMD_DISALLOWED;
 	}
 
+	/* Check for invalid enable bit fields */
 	if ((enable > (BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE |
 		       BT_HCI_LE_SET_PER_ADV_ENABLE_ADI)) ||
 	    (!IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT) &&
@@ -591,6 +594,7 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 
 	sync = HDR_LLL2ULL(lll_sync);
 
+	/* Handle periodic advertising being disable */
 	if (!(enable & BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE)) {
 		if (!sync->is_enabled) {
 			return BT_HCI_ERR_CMD_DISALLOWED;
@@ -606,6 +610,7 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 		return err;
 	}
 
+	/* Check for advertising set type */
 	if (IS_ENABLED(CONFIG_BT_CTLR_PARAM_CHECK)) {
 		uint8_t err;
 
@@ -615,10 +620,14 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 		}
 	}
 
-	/* TODO: Check for periodic data being complete */
+	/* Check for periodic data being complete */
+	if (!sync->is_data_cmplt) {
+		return BT_HCI_ERR_CMD_DISALLOWED;
+	}
 
 	/* TODO: Check packet too long */
 
+	/* Check for already enabled periodic advertising set */
 	sync_got_enabled = 0U;
 	if (sync->is_enabled) {
 		/* TODO: Enabling an already enabled advertising changes its
@@ -671,6 +680,9 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 		adv_sync_pdu_chain_check_and_duplicate(pdu, pdu_prev);
 	}
 
+	/* Start Periodic Advertising events if Extended Advertising events are
+	 * active.
+	 */
 	if (adv->is_enabled && !sync->is_started) {
 		struct pdu_adv_sync_info *sync_info;
 		uint8_t value[1 + sizeof(sync_info)];
@@ -759,6 +771,9 @@ uint8_t ll_adv_sync_enable(uint8_t handle, uint8_t enable)
 		}
 	}
 
+	/* Commit the Periodic Advertising data if ADI supported and has been
+	 * updated.
+	 */
 	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_PERIODIC_ADI_SUPPORT)) {
 		lll_adv_sync_data_enqueue(lll_sync, ter_idx);
 	}

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -89,6 +89,7 @@ struct ll_adv_sync_set {
 
 	uint8_t is_enabled:1;
 	uint8_t is_started:1;
+	uint8_t is_data_cmplt:1;
 };
 
 struct ll_adv_iso_set {


### PR DESCRIPTION
Add initial support for Periodic Advertising Data fragment
operation support.

This commit is limited to detection of partial data if used
before Periodic Advertising is enabled, which will lead to
HCI error reason of command disallowed.

Fix implementation to reject setting fragment when periodic
advertising is enabled.

Fixes #44439.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>