### PR TITLE
drivers/clock_control: stm32u5: Wrong bus check in _get_rate()

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -201,11 +201,6 @@ static int stm32_clock_control_get_subsys_rate(const struct device *dev,
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sys);
 
-	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
-		/* Attemp to toggle a wrong periph clock bit */
-		return -ENOTSUP;
-	}
-
 	/*
 	 * Get AHB Clock (= SystemCoreClock = SYSCLK/prescaler)
 	 * SystemCoreClock is preferred to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC


### PR DESCRIPTION
Checking that provided pclken->bus fits bus range in
clock_control_get_rate() is wrong as it could actually be a source
clock and hence not belong to this range.
Also, this kind of check is just not needed since this function should
not be used before call to clock_control_on() or clock_control_configure()
which do the required verification.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45821

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>