### PR TITLE
drivers: xen: keep track of missed events on event channels

### DIFF
--- a/include/zephyr/xen/events.h
+++ b/include/zephyr/xen/events.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2021 EPAM Systems
+ * Copyright (c) 2022 Arm Limited (or its affiliates). All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -22,6 +23,7 @@ typedef struct event_channel_handle evtchn_handle_t;
 void notify_evtchn(evtchn_port_t port);
 int bind_event_channel(evtchn_port_t port, evtchn_cb_t cb, void *data);
 int unbind_event_channel(evtchn_port_t port);
+int get_missed_events(evtchn_port_t port);
 
 int xen_events_init(void);
 


### PR DESCRIPTION
The current implementation for events channel is using an empty
callback for every unbind channel and the interrupt is clearing
every event and calling the callback.
However in a scenario where a domain fires a notification when
another has not yet bind the channel, the event will be missed.

To address this limitation, this commit is keeping track of
missed event channel notification when the empty callback is
used, a function to retrieve and clear the missed event is
introduced.

Signed-off-by: Luca Fancellu <luca.fancellu@arm.com>