### PR TITLE
west: openocd runner: Add an option to specify handle used in target script 

### DIFF
--- a/boards/arm/nucleo_h723zg/board.cmake
+++ b/boards/arm/nucleo_h723zg/board.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32H723ZG" "--speed=4000")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/nucleo_h743zi/board.cmake
+++ b/boards/arm/nucleo_h743zi/board.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(openocd --cmd-post-verify "reset halt")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 board_runner_args(jlink "--device=STM32H743ZI" "--speed=4000")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
 

--- a/boards/arm/nucleo_h745zi_q/board.cmake
+++ b/boards/arm/nucleo_h745zi_q/board.cmake
@@ -1,6 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32H745ZI" "--speed=4000")
+if(CONFIG_BOARD_NUCLEO_H745ZI_Q_M7)
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
+elseif(CONFIG_BOARD_NUCLEO_H745ZI_Q_M4)
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu1)
+endif()
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_h753zi/board.cmake
+++ b/boards/arm/nucleo_h753zi/board.cmake
@@ -2,6 +2,7 @@
 
 board_runner_args(jlink "--device=STM32H753ZI" "--speed=4000")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_h7a3zi_q/board.cmake
+++ b/boards/arm/nucleo_h7a3zi_q/board.cmake
@@ -2,6 +2,7 @@
 
 board_runner_args(jlink "--device=STM32H7A3ZI" "--speed=4000")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset=hw")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32h735g_disco/board.cmake
+++ b/boards/arm/stm32h735g_disco/board.cmake
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32H735IG" "--speed=4000")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/stm32h747i_disco/board.cmake
+++ b/boards/arm/stm32h747i_disco/board.cmake
@@ -2,8 +2,10 @@
 
 if(CONFIG_BOARD_STM32H747I_DISCO_M7)
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32h747i_disco_m7.cfg")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 elseif(CONFIG_BOARD_STM32H747I_DISCO_M4)
 board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd_stm32h747i_disco_m4.cfg")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu1)
 endif()
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)

--- a/boards/arm/stm32h7b3i_dk/board.cmake
+++ b/boards/arm/stm32h7b3i_dk/board.cmake
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(jlink "--device=STM32H7B3LI" "--speed=4000")
+board_runner_args(openocd --target-handle=_CHIPNAME.cpu0)
 
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)


### PR DESCRIPTION
Provide a way to specify the openocd target script handle used to describe the core target.
In most target scripts '_TARGETNAME' is used, but it can happen that '_TARGETNAME.foo' or '_CHIPNAME.bar' is used, specially on SoCs subject to multicore (STM32H7 SoCs for instance)

Today, this option is required to enable openocd thread awareness debug, using '$_TARGETNAME configure -rtos Zephyr' command, which is generated by this runner.

Apply this on STM32H7 based boards

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/45778
