### PR TITLE
Bluetooth: controller: llcp: fix update max dle times on feature exchange

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn.h
@@ -102,6 +102,8 @@ struct lll_conn {
 		struct data_pdu_length local;
 		struct data_pdu_length remote;
 		struct data_pdu_length eff;
+		uint16_t default_tx_time;
+		uint16_t default_tx_octets;
 		uint8_t update;
 	} dle;
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -7869,10 +7869,10 @@ static inline void dle_max_time_get(struct ll_conn *conn, uint16_t *max_rx_time,
 	rx_time = PDU_DC_MAX_US(LL_LENGTH_OCTETS_RX_MAX, phy_select);
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	tx_time = MIN(conn->lll.dle.local.max_tx_time,
+	tx_time = MIN(conn->lll.dle.default_tx_time,
 		      PDU_DC_MAX_US(LL_LENGTH_OCTETS_RX_MAX, phy_select));
 #else /* !CONFIG_BT_CTLR_PHY */
-	tx_time = PDU_DC_MAX_US(conn->lll.dle.local.max_tx_octets, phy_select);
+	tx_time = PDU_DC_MAX_US(conn->lll.dle.default_tx_octets, phy_select);
 #endif /* !CONFIG_BT_CTLR_PHY */
 
 	/*
@@ -7943,13 +7943,14 @@ uint8_t ull_dle_update_eff(struct ll_conn *conn)
 
 void ull_dle_local_tx_update(struct ll_conn *conn, uint16_t tx_octets, uint16_t tx_time)
 {
-	conn->lll.dle.local.max_tx_octets = tx_octets;
+	conn->lll.dle.default_tx_octets = tx_octets;
 
 #if defined(CONFIG_BT_CTLR_PHY)
-	conn->lll.dle.local.max_tx_time = tx_time;
+	conn->lll.dle.default_tx_time = tx_time;
 #endif /* CONFIG_BT_CTLR_PHY */
 
 	dle_max_time_get(conn, &conn->lll.dle.local.max_rx_time, &conn->lll.dle.local.max_tx_time);
+	conn->lll.dle.local.max_tx_octets = conn->lll.dle.default_tx_octets;
 }
 
 void ull_dle_init(struct ll_conn *conn, uint8_t phy)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -644,6 +644,13 @@ static void lp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 #endif /* CONFIG_BT_CTLR_LE_PING */
 	case PDU_DATA_LLCTRL_TYPE_FEATURE_RSP:
 		llcp_pdu_decode_feature_rsp(conn, pdu);
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH) && defined(CONFIG_BT_CTLR_PHY)
+		/* If Coded PHY is now supported we must update local max tx/rx times to reflect */
+		if (feature_phy_coded(conn)) {
+			ull_dle_max_time_get(conn, &conn->lll.dle.local.max_rx_time,
+					     &conn->lll.dle.local.max_tx_time);
+		}
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH && CONFIG_BT_CTLR_PHY */
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN)
 	case PDU_DATA_LLCTRL_TYPE_MIN_USED_CHAN_IND:
@@ -795,6 +802,13 @@ static void rp_comm_rx_decode(struct ll_conn *conn, struct proc_ctx *ctx, struct
 	case PDU_DATA_LLCTRL_TYPE_PER_INIT_FEAT_XCHG:
 #endif /* CONFIG_BT_CTLR_PER_INIT_FEAT_XCHG && CONFIG_BT_CENTRAL */
 		llcp_pdu_decode_feature_req(conn, pdu);
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH) && defined(CONFIG_BT_CTLR_PHY)
+		/* If Coded PHY is now supported we must update local max tx/rx times to reflect */
+		if (feature_phy_coded(conn)) {
+			ull_dle_max_time_get(conn, &conn->lll.dle.local.max_rx_time,
+					     &conn->lll.dle.local.max_tx_time);
+		}
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH && CONFIG_BT_CTLR_PHY */
 		break;
 #if defined(CONFIG_BT_CTLR_MIN_USED_CHAN) && defined(CONFIG_BT_CENTRAL)
 	case PDU_DATA_LLCTRL_TYPE_MIN_USED_CHAN_IND:


### PR DESCRIPTION
On a completion of feature exchange the max DLE times needs to be
updated if Coded PHY has become supported. 
For this now also keep a separate store of the default_tx_octets/time
for the sake of re-calculation of local versions of DLE values 