### PR TITLE
Bluetooth: Controller: lll: Fix warning when building for Nordic

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -16,6 +16,7 @@
 #include "util/memq.h"
 #include "util/mayfly.h"
 #include "util/dbuf.h"
+#include "util/mem.h"
 
 #include "ticker/ticker.h"
 


### PR DESCRIPTION
[140/235] Building C object zephyr/subsys/bluetooth/controller/CMakeFiles/subsys__bluetooth__controller.dir/ll_sw/ull_sched.c.obj
In file included from /zephyr/subsys/bluetooth/controller/ll_sw/ull_sched.c:28:
/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h: In function 'lll_adv_pdu_linked_next_get':
/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h:8:32: warning: implicit declaration of function 'MROUND' [-Wimplicit-function-declaration]
    8 | #define PDU_ADV_MEM_SIZE       MROUND(PDU_AC_LL_HEADER_SIZE + \
      |                                ^~~~~~
/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h:12:11: note: in expansion of macro 'PDU_ADV_MEM_SIZE'
   12 |           PDU_ADV_MEM_SIZE - \
      |           ^~~~~~~~~~~~~~~~
/zephyr/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_pdu.h:197:9: note: in expansion of macro 'PDU_ADV_NEXT_PTR'
  197 |  return PDU_ADV_NEXT_PTR(pdu);

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>