### PR TITLE
west.yml: esp32: fix bluetooth adapter variable definition

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: bceaadfc8f4f812ace778937a6b042e3b6249215
+      revision: df85671c5d0405c0747c2939c8dfe808b7e4cf38
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
When newlibc is enabled, memcpy_chk fails due to
overflow when testing destination address length.
This updates the source and destination range defintion
so that it works as expected.

This also fixes the issue related to undefined references when newlibc is enabled.

Closes #45755
Closes #45632

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>