### PR TITLE
samples: Bluetooth: Fix bad info->flags check in unicast_server

### DIFF
--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -287,7 +287,7 @@ static void stream_recv_lc3_codec(struct bt_audio_stream *stream,
 		return;
 	}
 
-	if (info->flags != BT_ISO_FLAGS_VALID) {
+	if ((info->flags & BT_ISO_FLAGS_VALID) == 0) {
 		printk("Bad packet: 0x%02X\n", info->flags);
 
 		in_buf = NULL;


### PR DESCRIPTION
The check did not properly check the info->flags as a bitfield,
and thus never decoded the data.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/45836