### PR TITLE
Test adc support temperature sensor stm32 mcu

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -211,6 +211,16 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&adc4 {
+	pinctrl-0 = <&adc4_in19_pb1>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";

--- a/boards/arm/b_u585i_iot02a/doc/index.rst
+++ b/boards/arm/b_u585i_iot02a/doc/index.rst
@@ -191,6 +191,7 @@ The Zephyr b_u585i_iot02a board configuration supports the following hardware fe
 | USB       | on-chip    | usb_device                          |
 +-----------+------------+-------------------------------------+
 | PWM       | on-chip    | pwm                                 |
+| die-temp  | on-chip    | die temperature sensor              |
 +-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig file:

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -275,6 +275,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;

--- a/boards/arm/disco_l475_iot1/doc/index.rst
+++ b/boards/arm/disco_l475_iot1/doc/index.rst
@@ -131,6 +131,8 @@ The Zephyr Disco L475 IoT board configuration supports the following hardware fe
 +-----------+------------+-------------------------------------+
 | QSPI NOR  | on-chip    | off-chip flash                      |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_f091rc/doc/index.rst
+++ b/boards/arm/nucleo_f091rc/doc/index.rst
@@ -106,6 +106,8 @@ The Zephyr nucleo_f091rc board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DMA       | on-chip    | Direct Memory Access                |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -142,6 +142,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;

--- a/boards/arm/nucleo_f103rb/doc/index.rst
+++ b/boards/arm/nucleo_f103rb/doc/index.rst
@@ -97,6 +97,8 @@ The Zephyr nucleo_f103rb board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DMA       | on-chip    | Direct Memory Access                |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -125,6 +125,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dma1 {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f207zg/doc/index.rst
+++ b/boards/arm/nucleo_f207zg/doc/index.rst
@@ -106,6 +106,8 @@ The Zephyr nucleo_207zg board configuration supports the following hardware feat
 +-------------+------------+-------------------------------------+
 | DMA         | on-chip    | Direct Memory Access                |
 +-------------+------------+-------------------------------------+
+| die-temp    | on-chip    | die temperature sensor              |
++-------------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -151,6 +151,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dma2 {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f401re/doc/index.rst
+++ b/boards/arm/nucleo_f401re/doc/index.rst
@@ -87,6 +87,8 @@ The Zephyr nucleo_401re board configuration supports the following hardware feat
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | System Window Watchdog              |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -164,6 +164,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &wwdg {
 	status = "okay";
 };

--- a/boards/arm/nucleo_f429zi/doc/index.rst
+++ b/boards/arm/nucleo_f429zi/doc/index.rst
@@ -111,6 +111,8 @@ The Zephyr nucleo_f429zi board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DMA       | on-chip    | Direct Memory Access                |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -84,6 +84,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -172,6 +172,10 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &mac {
 	status = "okay";
 	pinctrl-0 = <&eth_mdc_pc1

--- a/boards/arm/nucleo_g071rb/doc/index.rst
+++ b/boards/arm/nucleo_g071rb/doc/index.rst
@@ -112,6 +112,8 @@ The Zephyr nucleo_g071rb board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | dac                                 |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -157,6 +157,10 @@
 	pinctrl-names = "default";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &flash0 {
 	partitions {
 		compatible = "fixed-partitions";

--- a/boards/arm/nucleo_g0b1re/doc/index.rst
+++ b/boards/arm/nucleo_g0b1re/doc/index.rst
@@ -108,6 +108,8 @@ The Zephyr nucleo_g0b1re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | dac                                 |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -167,6 +167,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;

--- a/boards/arm/nucleo_g474re/doc/index.rst
+++ b/boards/arm/nucleo_g474re/doc/index.rst
@@ -127,6 +127,8 @@ The Zephyr nucleo_g474re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -170,6 +170,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	pinctrl-0 = <&dac1_out1_pa4>;
 	pinctrl-names = "default";

--- a/boards/arm/nucleo_h743zi/doc/index.rst
+++ b/boards/arm/nucleo_h743zi/doc/index.rst
@@ -129,6 +129,8 @@ features:
 +-------------+------------+-------------------------------------+
 | CAN/CANFD   | on-chip    | canbus                              |
 +-------------+------------+-------------------------------------+
+| die-temp    | on-chip    | die temperature sensor              |
++-------------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -128,6 +128,16 @@ zephyr_udc0: &usbotg_fs {
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
+&adc3 {
+	pinctrl-0 = <&adc3_inp5_pf3>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac1_out1_pa4>;

--- a/boards/arm/nucleo_l073rz/doc/index.rst
+++ b/boards/arm/nucleo_l073rz/doc/index.rst
@@ -102,6 +102,8 @@ The Zephyr nucleo_l073rz board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RNG       | on-chip    | Random Number Generator             |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -112,6 +112,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;

--- a/boards/arm/nucleo_l152re/doc/index.rst
+++ b/boards/arm/nucleo_l152re/doc/index.rst
@@ -100,6 +100,8 @@ The Zephyr nucleo_l152re board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | DMA       | on-chip    | Direct Memory Access                |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported in this Zephyr port.
 

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -94,6 +94,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	pinctrl-0 = <&dac_out1_pa4>;

--- a/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
+++ b/boards/arm/nucleo_l552ze_q/doc/nucleol552ze_q.rst
@@ -163,6 +163,8 @@ hardware features:
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 The default configuration can be found in the defconfig and dts files:
 

--- a/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
+++ b/boards/arm/nucleo_l552ze_q/nucleo_l552ze_q-common.dtsi
@@ -73,6 +73,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &lpuart1 {
 	pinctrl-0 = <&lpuart1_tx_pg7 &lpuart1_rx_pg8>;
 	pinctrl-names = "default";

--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -173,6 +173,8 @@ The Zephyr nucleo_wb55rg board configuration supports the following hardware fea
 +-----------+------------+-------------------------------------+
 | RADIO     | on-chip    | Bluetooth Low Energy                |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -85,6 +85,10 @@
 	};
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &clk_hse {
 	status = "okay";
 };

--- a/boards/arm/nucleo_wl55jc/doc/nucleo_wl55jc.rst
+++ b/boards/arm/nucleo_wl55jc/doc/nucleo_wl55jc.rst
@@ -208,6 +208,8 @@ features:
 +-----------+------------+-------------------------------------+
 | DAC       | on-chip    | DAC Controller                      |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr port.
 

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -161,6 +161,10 @@
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &aes {
 	status = "okay";
 };

--- a/boards/arm/stm32f030_demo/doc/index.rst
+++ b/boards/arm/stm32f030_demo/doc/index.rst
@@ -56,6 +56,8 @@ hardware features:
 +-----------+------------+-------------------------------------+
 | WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on this Zephyr porting.
 

--- a/boards/arm/stm32f030_demo/stm32f030_demo.yaml
+++ b/boards/arm/stm32f030_demo/stm32f030_demo.yaml
@@ -11,3 +11,4 @@ flash: 16
 supported:
   - uart
   - gpio
+  - adc

--- a/boards/arm/stm32f3_disco/doc/index.rst
+++ b/boards/arm/stm32f3_disco/doc/index.rst
@@ -109,6 +109,8 @@ features:
 +-----------+------------+-------------------------------------+
 | DMA       | on-chip    | Direct Memory Access                |
 +-----------+------------+-------------------------------------+
+| die-temp  | on-chip    | die temperature sensor              |
++-----------+------------+-------------------------------------+
 
 Other hardware features are not yet supported on Zephyr porting.
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -208,6 +208,10 @@ zephyr_udc0: &usb {
 	status = "okay";
 };
 
+&die_temp {
+	status = "okay";
+};
+
 &dac1 {
 	status = "okay";
 	/* dac output pins(pa4,pa5,pa6) might conflict with spi1 pins */

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -686,13 +686,30 @@ static int start_read(const struct device *dev,
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32L0X)
 	LL_ADC_REG_SetSequencerChannels(adc, channel);
-#elif defined(CONFIG_SOC_SERIES_STM32G0X) || \
-	defined(CONFIG_SOC_SERIES_STM32WLX)
+#elif defined(CONFIG_SOC_SERIES_STM32WLX)
 	/* STM32G0 in "not fully configurable" sequencer mode */
 	LL_ADC_REG_SetSequencerChannels(adc, channel);
+	LL_ADC_REG_SetSequencerConfigurable(adc, LL_ADC_REG_SEQ_CONFIGURABLE);
 	while (LL_ADC_IsActiveFlag_CCRDY(adc) == 0) {
 	}
-	LL_ADC_ClearFlag_CCRDY(adc);	
+	LL_ADC_ClearFlag_CCRDY(adc);
+#elif defined(CONFIG_SOC_SERIES_STM32G0X)
+	/* STM32G0 in "not fully configurable" sequencer mode */
+	LL_ADC_REG_SetSequencerChannels(adc, channel);
+	LL_ADC_REG_SetSequencerConfigurable(adc, LL_ADC_REG_SEQ_FIXED);
+	while (LL_ADC_IsActiveFlag_CCRDY(adc) == 0) {
+	}
+	LL_ADC_ClearFlag_CCRDY(adc);
+#if defined(CONFIG_SOC_SERIES_STM32WLX)
+	/* Init the the ADC group for REGULAR conversion*/
+	LL_ADC_REG_SetTriggerSource(adc, LL_ADC_REG_TRIG_SOFTWARE);
+	LL_ADC_REG_SetSequencerLength(adc, LL_ADC_REG_SEQ_SCAN_DISABLE);
+	LL_ADC_REG_SetSequencerDiscont(adc, LL_ADC_REG_SEQ_DISCONT_DISABLE);
+	LL_ADC_REG_SetContinuousMode(adc, LL_ADC_REG_CONV_SINGLE);
+	LL_ADC_REG_SetOverrun(adc, LL_ADC_REG_OVR_DATA_OVERWRITTEN);
+	LL_ADC_REG_SetSequencerRanks(adc, LL_ADC_REG_RANK_1, channel);
+#endif /* CONFIG_SOC_SERIES_STM32WLX */
+
 #else
 	LL_ADC_REG_SetSequencerRanks(adc, table_rank[0], channel);
 	LL_ADC_REG_SetSequencerLength(adc, table_seq_len[0]);

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -342,9 +342,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <12 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFFF7B8>;
+			ts-cal2-addr = <0x1FFFF7C2>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <110>;
+			ts-cal-vrefanalog = <3300>;
+			io-channels = <&adc1 16>;
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -290,9 +290,19 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp";
+			io-channels = <&adc1 16>;
+			status = "disabled";
+			avgslope = <43>;
+			v25 = <1430>;
+			ntc;
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -335,9 +335,19 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000100>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp";
+			io-channels = <&adc1 16>;
+			status = "disabled";
+			v25 = <760>;
+			ntc;
+			avgslope = <25>;
 		};
 
 		dma1: dma@40026000 {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -238,6 +238,17 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFFF7B8>;
+			ts-cal2-addr = <0x1FFFF7C2>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <110>;
+			ts-cal-vrefanalog = <3300>;
+			io-channels = <&adc1 16>;
+			status = "disabled";
+		};
+
 		timers2: timers@40000000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40000000 0x400>;

--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -126,7 +126,10 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x10000000>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
+			has-temp-channel;
+			has-vref-channel;
 		};
 	};
 };

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -244,6 +244,17 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFF7A2C>;
+			ts-cal2-addr = <0x1FFF7A2E>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <110>;
+			ts-cal-vrefanalog = <3300>;
+			io-channels = <&adc1 16>;
+			status = "disabled";
+		};
+
 		spi1: spi@40013000 {
 			compatible = "st,stm32-spi";
 			#address-cells = <1>;
@@ -445,6 +456,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000100>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;

--- a/dts/arm/st/f4/stm32f401.dtsi
+++ b/dts/arm/st/f4/stm32f401.dtsi
@@ -63,5 +63,6 @@
 			dma-names = "tx", "rx";
 			status = "disabled";
 		};
+
 	};
 };

--- a/dts/arm/st/f4/stm32f410.dtsi
+++ b/dts/arm/st/f4/stm32f410.dtsi
@@ -67,6 +67,10 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			io-channels = <&adc1 18>;
+		};
+
 		timers6: timers@40001000 {
 			compatible = "st,stm32-timers";
 			reg = <0x40001000 0x400>;

--- a/dts/arm/st/f4/stm32f411.dtsi
+++ b/dts/arm/st/f4/stm32f411.dtsi
@@ -44,6 +44,10 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			io-channels = <&adc1 18>;
+		};
+
 		i2s5: i2s@40015000 {
 			compatible = "st,stm32-i2s";
 			#address-cells = <1>;

--- a/dts/arm/st/f4/stm32f427.dtsi
+++ b/dts/arm/st/f4/stm32f427.dtsi
@@ -81,6 +81,10 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			io-channels = <&adc1 18>;
+		};
+
 		fmc: memory-controller@a0000000 {
 			compatible = "st,stm32-fmc";
 			reg = <0xa0000000 0x400>;

--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -25,5 +25,6 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x04000000>;
 			status = "disabled";
 		};
+
 	};
 };

--- a/dts/arm/st/f4/stm32f437.dtsi
+++ b/dts/arm/st/f4/stm32f437.dtsi
@@ -37,6 +37,10 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			io-channels = <&adc1 18>;
+		};
+
 		uart8: serial@40007c00 {
 			compatible = "st,stm32-uart";
 			reg = <0x40007c00 0x400>;

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -46,6 +46,10 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			io-channels = <&adc1 18>;
+		};
+
 		can1: can@40006400 {
 			compatible = "st,stm32-can";
 			reg = <0x40006400 0x400>;

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -627,9 +627,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000100>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FF07A2C>;
+			ts-cal2-addr = <0x1FF07A2E>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <110>;
+			ts-cal-vrefanalog = <3300>;
+			io-channels = <&adc1 18>;
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/f7/stm32f745.dtsi
+++ b/dts/arm/st/f7/stm32f745.dtsi
@@ -41,6 +41,11 @@
 			};
 		};
 
+		die_temp: dietemp {
+			ts-cal1-addr = <0x1FF0F44C>;
+			ts-cal2-addr = <0x1FF0F44E>;
+		};
+
 		i2c4: i2c@40006000 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -333,10 +333,22 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>;
 			interrupts = <12 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
 			has-vbat-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFF75A8>;
+			ts-cal2-addr = <0x1FFF75CA>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <130>;
+			ts-cal-vrefanalog = <3000>;
+			io-channels = <&adc1 12>;
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -110,17 +110,6 @@
 		};
 	};
 
-	die_temp: dietemp {
-		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x1FFF75A8>;
-		ts-cal2-addr = <0x1FFF75CA>;
-		ts-cal1-temp = <30>;
-		ts-cal2-temp = <130>;
-		ts-cal-vrefanalog = <3000>;
-		io-channels = <&adc1 12>;
-		status = "disabled";
-	};
-
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -80,9 +80,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-vref-channel;
 			has-temp-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFF75A8>;
+			ts-cal2-addr = <0x1FFF75CA>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <130>;
+			ts-cal-vrefanalog = <3000>;
+			io-channels = <&adc1 16>;
+			status = "disabled";
 		};
 
 		adc2: adc@50000100 {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -676,6 +676,20 @@
 			interrupts = <18 0>;
 			status = "disabled";
 			#io-channel-cells = <1>;
+			has-temp-channel;
+			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FF1E820>;
+			ts-cal2-addr = <0x1FF1E840>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <110>;
+			ts-cal-vrefanalog = <3300>;
+			ts-cal-resolution = <16>;
+			io-channels = <&adc3 18>;
+			status = "disabled";
 		};
 
 		adc2: adc@40022100 {
@@ -703,6 +717,7 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB4 0x01000000>;
 			interrupts = <127 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -30,6 +30,11 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			io-channels = <&adc3 17>;
+			ts-cal2-temp = <130>;
+		};
+
 		usart10: serial@40011c00 {
 			compatible = "st,stm32-usart", "st,stm32-uart";
 			reg = <0x40011c00 0x400>;

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -57,6 +57,13 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			ts-cal1-addr = <0x08FFF814>;
+			ts-cal2-addr = <0x08FFF818>;
+			io-channels = <&adc2 18>;
+			ts-cal2-temp = <130>;
+		};
+
 		octospi2: octospi@5200a000 {
 			compatible = "st,stm32-ospi";
 			reg = <0x5200a000 0x1000>;

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -264,9 +264,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <12 0>;
 			status = "disabled";
+			vref-mv = <3000>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FF8007A>;
+			ts-cal2-addr = <0x1FF8007E>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <130>;
+			ts-cal-vrefanalog = <3000>;
+			io-channels = <&adc1 18>;
+			status = "disabled";
 		};
 
 		dma1: dma@40020000 {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -201,9 +201,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3000>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FF800FA>;
+			ts-cal2-addr = <0x1FF800FE>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <110>;
+			ts-cal-vrefanalog = <3000>;
+			io-channels = <&adc1 16>;
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -342,7 +342,19 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3000>;
 			#io-channel-cells = <1>;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFF75A8>;
+			ts-cal2-addr = <0x1FFF75CA>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <110>;
+			ts-cal-vrefanalog = <3000>;
+			io-channels = <&adc1 17>;
+			status = "disabled";
 		};
 
 		adc2: adc@50040100 {

--- a/dts/arm/st/l4/stm32l412.dtsi
+++ b/dts/arm/st/l4/stm32l412.dtsi
@@ -31,6 +31,10 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			ts-cal2-temp = <130>;
+		};
+
 		adc1: adc@50040000 {
 			has-temp-channel;
 			has-vref-channel;

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -44,6 +44,10 @@
 			sample-point = <875>;
 		};
 
+		die_temp: dietemp {
+			ts-cal2-temp = <130>;
+		};
+
 		usb: usb@40006800 {
 			compatible = "st,stm32-usb";
 			reg = <0x40006800 0x40000>;

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -39,6 +39,10 @@
 			status = "disabled";
 		};
 
+		die_temp: dietemp {
+			ts-cal2-temp = <130>;
+		};
+
 		i2c2: i2c@40005800 {
 			compatible = "st,stm32-i2c-v2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;

--- a/dts/arm/st/l4/stm32l496.dtsi
+++ b/dts/arm/st/l4/stm32l496.dtsi
@@ -32,6 +32,10 @@
 			};
 		};
 
+		die_temp: dietemp {
+			ts-cal2-temp = <130>;
+		};
+
 		adc3: adc@50040200 {
 			compatible = "st,stm32-adc";
 			reg = <0x50040200 0x100>;

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -537,9 +537,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <37 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x0BFA05A8>;
+			ts-cal2-addr = <0x0BFA05CA>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <130>;
+			ts-cal-vrefanalog = <3000>;
+			io-channels = <&adc1 17>;
+			status = "disabled";
 		};
 
 		adc2: adc@42028100 {
@@ -577,16 +589,6 @@
 		#phy-cells = <0>;
 	};
 
-	die_temp: dietemp {
-		compatible = "st,stm32-temp-cal";
-		ts-cal1-addr = <0x0BFA05A8>;
-		ts-cal2-addr = <0x0BFA05CA>;
-		ts-cal1-temp = <30>;
-		ts-cal2-temp = <110>;
-		ts-cal-vrefanalog = <3000>;
-		io-channels = <&adc1 17>;
-		status = "disabled";
-	};
 };
 
 &nvic {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -534,9 +534,22 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00000400>;
 			interrupts = <37 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x0BFA0710>;
+			ts-cal2-addr = <0x0BFA0742>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <130>;
+			ts-cal-vrefanalog = <3000>;
+			ts-cal-resolution = <14>;
+			io-channels = <&adc1 19>;
+			status = "disabled";
 		};
 
 		adc4: adc@46021000 {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -333,9 +333,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFF75A8>;
+			ts-cal2-addr = <0x1FFF75CA>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <130>;
+			ts-cal-vrefanalog = <3000>;
+			io-channels = <&adc1 17>;
+			status = "disabled";
 		};
 
 		iwdg: watchdog@40003000 {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -289,9 +289,21 @@
 			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>;
 			interrupts = <18 0>;
 			status = "disabled";
+			vref-mv = <3300>;
 			#io-channel-cells = <1>;
 			has-temp-channel;
 			has-vref-channel;
+		};
+
+		die_temp: dietemp {
+			compatible = "st,stm32-temp-cal";
+			ts-cal1-addr = <0x1FFF75A8>;
+			ts-cal2-addr = <0x1FFF75C8>;
+			ts-cal1-temp = <30>;
+			ts-cal2-temp = <130>;
+			ts-cal-vrefanalog = <3300>;
+			io-channels = <&adc1 12>;
+			status = "disabled";
 		};
 
 		dac1: dac@40007400 {

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -38,3 +38,17 @@ properties:
       description: |
         Analog voltage reference (Vref+) voltage with which
         temperature sensor has been calibrated in production
+
+    ts-cal-resolution:
+      type: int
+      required: false
+      description: |
+        Temperature calibration resolution with which the ts-cal1-temp and
+        ts-cal2-temp are measured.
+        For most stm32 series a native 12-bit ADC is embedded in the device,
+        except for H7 on 16-bit and U5 on 14-bit
+      default: 12
+      enum:
+      - 12
+      - 14
+      - 16

--- a/samples/sensor/stm32_temp_sensor/sample.yaml
+++ b/samples/sensor/stm32_temp_sensor/sample.yaml
@@ -5,5 +5,10 @@ tests:
   sample.sensor.stm32_temp_sensor:
     depends_on: adc
     tags: sensors
-    build_only: true
-    platform_allow: nucleo_f401re stm32f103_mini stm32l562e_dk
+    tags: tests
+    filter: dt_compat_enabled("st,stm32-temp-cal") or dt_compat_enabled("st,stm32-temp")
+    harness: console
+    harness_config:
+      type: one_line
+      regex:
+        - "Current temperature: [1-5][0-9].[0-9] °C"


### PR DESCRIPTION
The goal is to test the junction temperature sensor and the
vref int property in the ADC device-tree node of each stm32 where it is
available.

Check all the ADC of the stm32 mcus where the temp and VrefInt monitoring
is available (based on the Ref Man).
Check that has-temp-channel; and has-vref-channel; in the corresponding
ADC node of the DTS of each stm32 mcu is correctly set.
Verify the VTEMP/ VREFINT activation in the in adc_stm32.c for example).
It is necessary to add and activate the node die-temp in the boards dts files.
Execute the testcase running the samples/sensor/stm32_temp_sensor on
each available target board.