### PR TITLE
ci: doc-publish: Do not run for pull requests

### DIFF
--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -18,6 +18,7 @@ jobs:
     name: Publish Documentation
     runs-on: ubuntu-latest
     if: |
+      github.event.workflow_run.event != 'pull_request' &&
       github.event.workflow_run.conclusion == 'success' &&
       github.repository == 'zephyrproject-rtos/zephyr'
 


### PR DESCRIPTION
GitHub Actions may trigger the `workflow_run` event type when the
pull request source branch name matches one of the branches specified
under `branches:`.

This commit updates the documentation publish workflow to skip when the
preceding event type is `pull_request`, in order to prevent pull
request documentation from being uploaded as main documentation.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>