### PR TITLE
drivers: uart_imx: Fix the poll_in function

### DIFF
--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -113,16 +113,18 @@ static void uart_imx_poll_out(const struct device *dev, unsigned char c)
 static int uart_imx_poll_in(const struct device *dev, unsigned char *c)
 {
 	UART_Type *uart = UART_STRUCT(dev);
+	int ret = -1;
 
-	while (!UART_GetStatusFlag(uart, uartStatusRxDataReady)) {
+	if (UART_GetStatusFlag(uart, uartStatusRxDataReady)) {
+		*c = UART_Getchar(uart);
+
+		if (UART_GetStatusFlag(uart, uartStatusRxOverrun)) {
+			UART_ClearStatusFlag(uart, uartStatusRxOverrun);
+		}
+		ret = 0;
 	}
-	*c = UART_Getchar(uart);
 
-	if (UART_GetStatusFlag(uart, uartStatusRxOverrun)) {
-		UART_ClearStatusFlag(uart, uartStatusRxOverrun);
-	}
-
-	return 0;
+	return ret;
 }
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN


### PR DESCRIPTION
Current poll_in function implementation blocks when there is no data available. The Zephyr documentation for poll_in expects the function to return -1 when no data is available.

Fixes #45533