### PR TITLE
samples: tfm_integration: Cleanup CI board support

### DIFF
--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -6,7 +6,7 @@ sample:
 tests:
     sample.psa_crypto:
         tags: introduction tfm crypto csr
-        platform_allow: mps2_an521_ns lpcxpresso55s69_ns nrf5340dk_nrf5340_cpuapp_ns
+        platform_allow: mps2_an521_ns nrf5340dk_nrf5340_cpuapp_ns
           nrf9160dk_nrf9160_ns v2m_musca_s1_ns stm32l562e_dk_ns
           bl5340_dvk_cpuapp_ns
         harness: console

--- a/samples/tfm_integration/psa_crypto/sample.yaml
+++ b/samples/tfm_integration/psa_crypto/sample.yaml
@@ -6,9 +6,9 @@ sample:
 tests:
     sample.psa_crypto:
         tags: introduction tfm crypto csr
-        platform_allow: mps2_an521_ns nrf5340dk_nrf5340_cpuapp_ns
-          nrf9160dk_nrf9160_ns v2m_musca_s1_ns stm32l562e_dk_ns
-          bl5340_dvk_cpuapp_ns
+        platform_allow: mps2_an521_ns mps3_an547_ns v2m_musca_s1_ns
+          nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
+          stm32l562e_dk_ns bl5340_dvk_cpuapp_ns
         harness: console
         harness_config:
           type: multi_line

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -5,7 +5,7 @@ sample:
 tests:
     sample.tfm_ipc:
         tags: introduction tfm
-        platform_allow: mps2_an521_ns
+        platform_allow: mps2_an521_ns mps3_an547_ns
           nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns nucleo_l552ze_q_ns
           stm32l562e_dk_ns v2m_musca_s1_ns v2m_musca_b1_ns bl5340_dvk_cpuapp_ns
         harness: console

--- a/samples/tfm_integration/tfm_ipc/sample.yaml
+++ b/samples/tfm_integration/tfm_ipc/sample.yaml
@@ -5,7 +5,7 @@ sample:
 tests:
     sample.tfm_ipc:
         tags: introduction tfm
-        platform_allow: mps2_an521_ns lpcxpresso55s69_ns
+        platform_allow: mps2_an521_ns
           nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns nucleo_l552ze_q_ns
           stm32l562e_dk_ns v2m_musca_s1_ns v2m_musca_b1_ns bl5340_dvk_cpuapp_ns
         harness: console

--- a/samples/tfm_integration/tfm_regression_test/sample.yaml
+++ b/samples/tfm_integration/tfm_regression_test/sample.yaml
@@ -1,7 +1,6 @@
 common:
     tags: tfm
-    platform_allow: lpcxpresso55s69_ns
-                    nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
+    platform_allow: nrf5340dk_nrf5340_cpuapp_ns nrf9160dk_nrf9160_ns
                     v2m_musca_s1_ns
     harness: console
     harness_config:


### PR DESCRIPTION
This commit adds some required cleanup to the board list for CI with TF-M:

- It adds the `mps3_an547_ns` target to certain samples, enabling testing on the Cortex-M55.
- It also (temporarily) removes the `lpcxpresso55s69_ns` target from certain tests due to the upstream support code for this platform being out of date with the tagged 1.6.0 release.

As per the notes in the LPC commit, NXP has updated their downloadable SDK to include support for TF-M 1.6.0, but related changes weren't committed upstream to the TF-M project. This results in build failures on certain samples in Zephyr's fork of TF-M.

Once these conflicts have been resolved, support for these samples on the LPC55s69 in CI can be restored, but the CI failures are problematic for the pending Zephyr 3.1.0 release and some related PRs.

Related: https://github.com/zephyrproject-rtos/zephyr/pull/45767