### PR TITLE
subsys: settings: fcb: Reject equal sign in name

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -360,6 +360,14 @@ static int settings_fcb_save(struct settings_store *cs, const char *name,
 	}
 
 	/*
+	 * Equal signs is used internally as separator between name and value. Reject in order to
+	 * not corrupt the saved value.
+	 */
+	if (strchr(name, '=')) {
+		return -EINVAL;
+	}
+
+	/*
 	 * Check if we're writing the same value again.
 	 */
 	cdca.name = name;

--- a/tests/subsys/settings/fcb/src/settings_test_save_one_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_save_one_fcb.c
@@ -49,4 +49,7 @@ void test_config_save_one_fcb(void)
 	rc = settings_load();
 	zassert_true(rc == 0, "fcb read error");
 	zassert_true(val8 == 44U, "bad value read");
+
+	zassert_equal(-EINVAL, test_config_save_one_byte_value("myfoo/mybar=", 45),
+		      "Reject equal sign in name");
 }


### PR DESCRIPTION
Without this patch, the following happens:

```
 uart:~$ settings write test= AA
 uart:~$ settings list
 test
 uart:~$ settings read test
 00000000: 3d aa                                     |=.               |
```

This happens because the equal sign is used as separator between the
name and the value.

Since using an equal has never worked until now, this commit simply
rejects all names with an equal sign in it instead of trying to make it
work by introducing some more complicated code.

The above example will no yield this output:
```
 uart:~$ settings write test= AA
 Failed to write setting: -22
```
Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>