### PR TITLE
net: lib: lwm2m: Cancel firmware DOWNLOADED state with NULL byte

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -239,14 +239,17 @@ static int package_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 		 * make sure it fail after timeout
 		 */
 		lwm2m_firmware_set_update_state_inst(obj_inst_id, STATE_DOWNLOADING);
-	} else if (state != STATE_DOWNLOADING) {
-		if (data_len == 0U && state == STATE_DOWNLOADED) {
+	} else if (state == STATE_DOWNLOADED) {
+		if (data_len == 0U || (data_len == 1U && data[0] == '\0')) {
 			/* reset to state idle and result default */
 			lwm2m_firmware_set_update_result_inst(obj_inst_id, RESULT_DEFAULT);
+			LOG_DBG("Update canceled by writing %d bytes", data_len);
 			return 0;
 		}
-
-		LOG_DBG("Cannot download: state = %d", state);
+		LOG_WRN("Download has already completed");
+		return -EPERM;
+	} else if (state != STATE_DOWNLOADING) {
+		LOG_WRN("Cannot download: state = %d", state);
 		return -EPERM;
 	}
 


### PR DESCRIPTION
Allow to cancel a firmware update in DOWNLOADED state by writing a
NULL byte as described in the Firmware Update object version 1.1
(urn:oma:lwm2m:oma:5:1.1). Keep object version 1.0 mechanism with
an `empty string`.

Signed-off-by: Marc Lasch <marc.lasch@husqvarnagroup.com>