### PR TITLE
soc: it8xxx2: The "M" extension is disabled by default

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/CMakeLists.txt
+++ b/soc/riscv/riscv-ite/it8xxx2/CMakeLists.txt
@@ -1,6 +1,7 @@
 zephyr_sources(
 	soc.c
 )
+zephyr_library_sources_ifndef(CONFIG_RISCV_ISA_EXT_M __arithmetic.S)
 
 # IMPORTANT:
 # The h2ram section must be first added to RAM_SECTIONS to avoid gap.

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
@@ -4,7 +4,10 @@
 config SOC_SERIES_RISCV32_IT8XXX2
 	bool "ITE IT8XXX2 implementation"
 	#depends on RISCV
-	select CPU_HAS_FPU
+	# TODO:
+	# Error of can't link soft-float modules with single-float modules.
+	# No library built with -mabi=ilp32f -march=rv32iafc?
+	select CPU_HAS_FPU if RISCV_ISA_EXT_M
 	select SOC_FAMILY_RISCV_ITE
 	help
 	    Enable support for ITE IT8XXX2

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -10,7 +10,9 @@ config SOC_IT8XXX2
 	select RISCV
 	select ATOMIC_OPERATIONS_BUILTIN
 	select RISCV_ISA_RV32I
-	select RISCV_ISA_EXT_M
+	# Workaround mul instruction bug, see:
+	# https://www.ite.com.tw/uploads/product_download/it81202-bx-chip-errata.pdf
+	#select RISCV_ISA_EXT_M
 	select RISCV_ISA_EXT_A
 	select RISCV_ISA_EXT_C
 

--- a/soc/riscv/riscv-ite/it8xxx2/__arithmetic.S
+++ b/soc/riscv/riscv-ite/it8xxx2/__arithmetic.S
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022 ITE Corporation.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * When the 'M' extension is disabled, compiler can not recognize div/mul
+ * instructions. So mul/div instructions in the below integer arithmetic
+ * routines are hard coded by opcodes.
+ *
+ * IMPORTANT:
+ * The workaround requires the nop instruction, please don't optimize it.
+ */
+
+.macro __int_arithmetic func opcode
+.section .__ram_code
+.align 2
+.globl \func
+.type \func, @function
+\func:
+.word \opcode
+nop
+ret
+.size \func, .-\func
+.endm
+
+/* signed 32 bit multiplication. opcode of mul a0,a0,a1 is 0x02b50533 */
+__int_arithmetic __mulsi3 0x02b50533
+
+/* signed 32 bit division. opcode of div a0,a0,a1 is 0x02b54533 */
+__int_arithmetic __divsi3 0x02b54533
+
+/* unsigned 32 bit division. opcode of divu a0,a0,a1 is 0x02b55533 */
+__int_arithmetic __udivsi3 0x02b55533
+
+/*
+ * This function return the remainder of the signed division.
+ * opcode of rem a0,a0,a1 is 0x02b56533
+ */
+__int_arithmetic __modsi3 0x02b56533
+
+/*
+ * This function return the remainder of the unsigned division.
+ * opcode of remu a0,a0,a1 is 0x02b57533
+ */
+__int_arithmetic __umodsi3 0x02b57533


### PR DESCRIPTION
There is a mul instruction bug.
The bug may cause instructions of writing back CPU GPR (e.g mv a0,s2)
which following the mul instruction to fail.
This patch disables the 'M' extension and overwrite integer
multiplication and division arithmetic library routines with using
hardware multiplication and division and nop instructions.
This will ensure that there is no write back GPR instruction to follow
mul instruction to avoid the bug.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>