### PR TITLE
Bluetooth: Controller: CCM reads data before Radio stores them when DF enabled on PHY 1M

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/nrfx_glue/bt_ctlr_used_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/nrfx_glue/bt_ctlr_used_resources.h
@@ -103,6 +103,13 @@
 #define HAL_USED_PPI_CHANNELS_7 0
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+#define HAL_USED_PPI_CHANNELS_8 \
+	BIT(HAL_TRIGGER_CRYPT_DELAY_PPI)
+#else
+#define HAL_USED_PPI_CHANNELS_8 0
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
+
 /* Mask with all (D)PPI groups used by the bluetooth controller. */
 #if defined(SW_SWITCH_TIMER_TASK_GROUP_BASE)
 #define BT_CTLR_USED_PPI_GROUPS \

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -511,6 +511,7 @@ void radio_status_reset(void)
 	/* Clear it only for SoCs supporting DF extension */
 	NRF_RADIO->EVENTS_PHYEND = 0;
 	NRF_RADIO->EVENTS_CTEPRESENT = 0;
+	NRF_RADIO->EVENTS_BCMATCH = 0;
 #endif /* CONFIG_BT_CTLR_DF_SUPPORT && !CONFIG_ZTEST */
 	NRF_RADIO->EVENTS_DISABLED = 0;
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
@@ -1030,6 +1031,9 @@ void radio_tmr_status_reset(void)
 #if defined(CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE)
 			BIT(HAL_SW_SWITCH_TIMER_PHYEND_DELAY_COMPENSATION_DISABLE_PPI) |
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+			BIT(HAL_TRIGGER_CRYPT_DELAY_PPI) |
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 			BIT(HAL_TRIGGER_CRYPT_PPI));
 }
 
@@ -1493,12 +1497,30 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, uint8_t phy, void *pkt)
 		mode |= (CCM_MODE_DATARATE_1Mbit <<
 			 CCM_MODE_DATARATE_Pos) &
 			CCM_MODE_DATARATE_Msk;
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+		/* When direction finding CTE receive feature is enabled then on-the-fly PDU
+		 * parsing for CTEInfo is always done. In such situation, the CCM TASKS_CRYPT
+		 * must be started with short delay. That give the Radio time to store received bits
+		 * in shared memory.
+		 */
+		radio_bc_configure(CCM_TASKS_CRYPT_DELAY_BITS);
+		radio_bc_status_reset();
+		hal_trigger_crypt_by_bcmatch_ppi_config();
+		hal_radio_nrf_ppi_channels_enable(BIT(HAL_TRIGGER_CRYPT_DELAY_PPI));
+#else
+		hal_trigger_crypt_ppi_config();
+		hal_radio_nrf_ppi_channels_enable(BIT(HAL_TRIGGER_CRYPT_PPI));
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 		break;
 
 	case PHY_2M:
 		mode |= (CCM_MODE_DATARATE_2Mbit <<
 			 CCM_MODE_DATARATE_Pos) &
 			CCM_MODE_DATARATE_Msk;
+
+		hal_trigger_crypt_ppi_config();
+		hal_radio_nrf_ppi_channels_enable(BIT(HAL_TRIGGER_CRYPT_PPI));
+
 		break;
 
 #if defined(CONFIG_BT_CTLR_PHY_CODED)
@@ -1516,6 +1538,10 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, uint8_t phy, void *pkt)
 		hal_trigger_rateoverride_ppi_config();
 		hal_radio_nrf_ppi_channels_enable(
 			BIT(HAL_TRIGGER_RATEOVERRIDE_PPI));
+
+		hal_trigger_crypt_ppi_config();
+		hal_radio_nrf_ppi_channels_enable(BIT(HAL_TRIGGER_CRYPT_PPI));
+
 		break;
 #endif /* CONFIG_HAS_HW_NRF_RADIO_BLE_CODED */
 #endif /* CONFIG_BT_CTLR_PHY_CODED */
@@ -1537,11 +1563,9 @@ void *radio_ccm_rx_pkt_set(struct ccm *ccm, uint8_t phy, void *pkt)
 	NRF_CCM->OUTPTR = (uint32_t)pkt;
 	NRF_CCM->SCRATCHPTR = (uint32_t)_ccm_scratch;
 	NRF_CCM->SHORTS = 0;
+	NRF_CCM->EVENTS_ENDKSGEN = 0;
 	NRF_CCM->EVENTS_ENDCRYPT = 0;
 	NRF_CCM->EVENTS_ERROR = 0;
-
-	hal_trigger_crypt_ppi_config();
-	hal_radio_nrf_ppi_channels_enable(BIT(HAL_TRIGGER_CRYPT_PPI));
 
 	nrf_ccm_task_trigger(NRF_CCM, NRF_CCM_TASK_KSGEN);
 
@@ -1573,6 +1597,7 @@ void *radio_ccm_tx_pkt_set(struct ccm *ccm, void *pkt)
 	NRF_CCM->OUTPTR = (uint32_t)_pkt_scratch;
 	NRF_CCM->SCRATCHPTR = (uint32_t)_ccm_scratch;
 	NRF_CCM->SHORTS = CCM_SHORTS_ENDKSGEN_CRYPT_Msk;
+	NRF_CCM->EVENTS_ENDKSGEN = 0;
 	NRF_CCM->EVENTS_ENDCRYPT = 0;
 	NRF_CCM->EVENTS_ERROR = 0;
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5.h
@@ -29,6 +29,9 @@
 #define RADIO_EVENTS_PHYEND_DELAY_US 16
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
+/* Delay of CCM TASKS_CRYPT start in number of bits for Radio Bit counter */
+#define CCM_TASKS_CRYPT_DELAY_BITS 3
+
 /* EVENTS_TIMER capture register used for sampling TIMER time-stamps. */
 #define HAL_EVENT_TIMER_SAMPLE_CC_OFFSET 3
 #define HAL_EVENT_TIMER_SAMPLE_TASK NRF_TIMER_TASK_CAPTURE3

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi.h
@@ -130,6 +130,32 @@ static inline void hal_trigger_crypt_ppi_config(void)
 	nrf_ccm_subscribe_set(NRF_CCM, NRF_CCM_TASK_CRYPT, HAL_RADIO_RECV_TIMEOUT_CANCEL_PPI);
 }
 
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+/*******************************************************************************
+ * Trigger encryption task on Bit counter match:
+ * wire the RADIO EVENTS_BCMATCH event to the CCM TASKS_CRYPT task.
+ *
+ * PPI channel HAL_TRIGGER_CRYPT_DELAY_PPI is also used for HAL_TRIGGER-
+ * _RATEOVERRIDE_PPI.
+ * Make sure the same PPI is not configured for both events at once.
+ *
+ *   EEP: RADIO->EVENTS_BCMATCH
+ *   TEP: CCM->TASKS_CRYPT
+ */
+static inline void hal_trigger_crypt_by_bcmatch_ppi_config(void)
+{
+	/* Configure Bit counter to trigger EVENTS_BCMATCH for CCM_TASKS_CRYPT-
+	 * _DELAY_BITS bit. This is a time required for Radio to store
+	 * received data in memory before the CCM TASKS_CRYPT starts. This
+	 * makes CCM to do not read the memory before Radio stores received
+	 * data.
+	 */
+	nrf_radio_publish_set(NRF_RADIO,
+			      NRF_RADIO_EVENT_BCMATCH, HAL_TRIGGER_CRYPT_DELAY_PPI);
+	nrf_ccm_subscribe_set(NRF_CCM, NRF_CCM_TASK_CRYPT, HAL_TRIGGER_CRYPT_DELAY_PPI);
+}
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
+
 /*******************************************************************************
  * Trigger automatic address resolution on Bit counter match:
  * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_dppi_resources.h
@@ -141,6 +141,17 @@
 #define HAL_SW_SWITCH_TIMER_PHYEND_DELAY_COMPENSATION_DISABLE_PPI 16
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+/* Trigger encryption task upon bit counter match event fire:
+ * wire the RADIO EVENTS_BCMATCH event to the CCM TASKS_CRYPT task.
+ *
+ * Note: The PPI number is shared with HAL_TRIGGER_RATEOVERRIDE_PPI because it is used only
+ * when direction finding RX and PHY is set to PHY1M. Due to that it can be shared with Radio Rate
+ * override.
+ */
+#define HAL_TRIGGER_CRYPT_DELAY_PPI 13
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
+
 /* The 2 adjacent PPI groups used for implementing SW_SWITCH_TIMER-based
  * auto-switch for TIFS. 'index' must be 0 or 1.
  */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi.h
@@ -184,6 +184,32 @@ static inline void hal_trigger_crypt_ppi_config(void)
 	/* No need to configure anything for the pre-programmed channel. */
 }
 
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+/*******************************************************************************
+ * Trigger encryption task on Bit counter match:
+ * wire the RADIO EVENTS_BCMATCH event to the CCM TASKS_CRYPT task.
+ *
+ * PPI channel HAL_TRIGGER_CRYPT_DELAY_PPI is also used for HAL_TRIGGER-
+ * _RATEOVERRIDE_PPI.
+ * Make sure the same PPI is not configured for both events at once.
+ *
+ *   EEP: RADIO->EVENTS_BCMATCH
+ *   TEP: CCM->TASKS_CRYPT
+ */
+static inline void hal_trigger_crypt_by_bcmatch_ppi_config(void)
+{
+	/* Configure Bit counter to trigger EVENTS_BCMATCH for CCM_TASKS_CRYPT-
+	 * _DELAY_BITS bit. This is a time required for Radio to store
+	 * received data in memory before the CCM TASKS_CRYPT starts. This
+	 * makes CCM to do not read the memory before Radio stores received
+	 * data.
+	 */
+	nrf_ppi_channel_endpoint_setup(NRF_PPI, HAL_TRIGGER_CRYPT_DELAY_PPI,
+				       (uint32_t)&(NRF_RADIO->EVENTS_BCMATCH),
+				       (uint32_t)&(NRF_CCM->TASKS_CRYPT));
+}
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
+
 /*******************************************************************************
  * Trigger automatic address resolution on Bit counter match:
  * wire the RADIO EVENTS_BCMATCH event to the AAR TASKS_START task.

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_nrf5_ppi_resources.h
@@ -179,6 +179,17 @@
 #define HAL_SW_SWITCH_TIMER_PHYEND_DELAY_COMPENSATION_DISABLE_PPI 19
 #endif /* CONFIG_BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE */
 
+#if defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+/* Trigger encryption task upon bit counter match event fire:
+ * wire the RADIO EVENTS_BCMATCH event to the CCM TASKS_CRYPT task.
+ *
+ * Note: The PPI number is shared with HAL_TRIGGER_RATEOVERRIDE_PPI because it is used only
+ * when direction finding RX and PHY is set to PHY1M. Due to that it can be shared with Radio Rate
+ * override.
+ */
+#define HAL_TRIGGER_CRYPT_DELAY_PPI 14
+#endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
+
 /* The 2 adjacent PPI groups used for implementing SW_SWITCH_TIMER-based
  * auto-switch for TIFS. 'index' must be 0 or 1.
  */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -201,8 +201,6 @@ static int prepare_cb(struct lll_prepare_param *p)
 	radio_tx_power_set(RADIO_TXP_DEFAULT);
 #endif /* CONFIG_BT_CTLR_TX_PWR_DYNAMIC_CONTROL */
 
-	lll_conn_rx_pkt_set(lll);
-
 	radio_aa_set(lll->access_addr);
 	radio_crc_configure(PDU_CRC_POLYNOMIAL,
 				sys_get_le24(lll->crc_init));
@@ -264,6 +262,11 @@ static int prepare_cb(struct lll_prepare_param *p)
 		radio_switch_complete_and_tx(0, 0, 0, 0);
 #endif /* !CONFIG_BT_CTLR_PHY */
 	}
+
+	/* The call can use Radio interface that alternates NRF_RADIO->SHORTS. The register is
+	 * set by radio_switch_complete_XXX functions, hence any changes done before are cleared.
+	 */
+	lll_conn_rx_pkt_set(lll);
 
 	ticks_at_event = p->ticks_at_expire;
 	ull = HDR_LLL2ULL(lll);


### PR DESCRIPTION
CCM during on-the-fly decryption of a received packet starts operation
when Radio triggers EVETNS_ADDRESS. In case there is possibility a
packet may include Constant Tone Extension, on-the-fly parsing of a
received packet for CTEInfo is enabled.

If there is a PHY 1M enabled the Radio stores received bits with a
delay, that is equal to time required to receive 3 bits. CCM TASKS_CRYPT,
related with packet decryption, should be delayed by the time the Radio
needs to store received data.

The commit provides changes required to delay start of the CCM
TASKS_CRYPT. It uses NRF_RADIO Bit counter feature. The Bit counter is
configured to trigger NRF_RADIO->EVENTS_BCMATCH on reception of 3rd bit.
The event is connected through PPI with CCM TASKS_CRYPT.

The PPI used is shared with Radio Rate override. That is possible because
direction finding feature is not allowed on PHY Coded and CCM needs a delay
only when used PHY 1M.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/45883

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>