### PR TITLE
mcumgr: fix invalid condition for calling img_mgmt_dfu_stopped

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -265,7 +265,7 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 
 	rc = img_mgmt_impl_erase_slot();
 
-	if (!rc) {
+	if (rc != 0) {
 		img_mgmt_dfu_stopped();
 	}
 


### PR DESCRIPTION
In other places, img_mgmt_dfu_stopped() is called when a failure occurs and the DFU cannot be continued. In this place, however, the function is called on success which does not seem to be correct.

Fixes #45828.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>