### PR TITLE
Bluetooth: audio: Fix call control client build

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.tbs
+++ b/subsys/bluetooth/audio/Kconfig.tbs
@@ -126,20 +126,6 @@ config BT_TBS_AUTHORIZATION
 	  If set to true, then any writable characteristics will require
 	  authorization per connection.
 
-config BT_TBS_MAX_URI_LENGTH
-	int "The maximum length of the call URI supported"
-	default 30
-	range 4 253
-	help
-	  Sets the maximum length of the call URI supported. Note that if this
-	  value is lower than a call URI, the call request will be rejected.
-
-config BT_TBS_MAX_PROVIDER_NAME_LENGTH
-	int "The maximum length of the bearer provider name"
-	default 30
-	range 0 512
-	help
-	  Sets the maximum length of the bearer provider name.
 
 ############# DEBUG #############
 
@@ -184,21 +170,6 @@ config BT_TBS_CLIENT_MAX_TBS_INSTANCES
 	  Sets the maximum number of Telephone Bearer Service (TBS)
 	  instances to setup and use.
 
-config BT_TBS_CLIENT_MAX_URI_LENGTH
-	int "The maximum length of the call URI supported"
-	default 30
-	range 4 253
-	help
-	  Sets the maximum length of the call URI supported. Note that if this
-	  value is lower than a call URI, the call request will be rejected.
-
-config BT_TBS_CLIENT_MAX_PROVIDER_NAME_LENGTH
-	int "The maximum length of the bearer provider name"
-	default 30
-	range 0 512
-	help
-	  Sets the maximum length of the bearer provider name.
-
 ############# DEBUG #############
 
 config BT_DEBUG_TBS_CLIENT
@@ -208,5 +179,24 @@ config BT_DEBUG_TBS_CLIENT
 	  for the Bluetooth Audio functionality.
 
 endif # BT_TBS_CLIENT
+
+if BT_TBS || BT_TBS_CLIENT
+
+config BT_TBS_MAX_URI_LENGTH
+	int "The maximum length of the call URI supported"
+	default 30
+	range 4 253
+	help
+	  Sets the maximum length of the call URI supported. Note that if this
+	  value is lower than a call URI, the call request will be rejected.
+
+config BT_TBS_MAX_PROVIDER_NAME_LENGTH
+	int "The maximum length of the bearer provider name"
+	default 30
+	range 0 512
+	help
+	  Sets the maximum length of the bearer provider name.
+
+endif # BT_TBS || BT_TBS_CLIENT
 
 endif # BT_AUDIO

--- a/tests/bluetooth/shell/testcase.yaml
+++ b/tests/bluetooth/shell/testcase.yaml
@@ -213,3 +213,17 @@ tests:
     platform_allow: native_posix
     extra_configs:
       - CONFIG_BT_HAS_CLIENT=n
+  bluetooth.shell.audio.no_tbs:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_BT_TBS=n
+    tags: bluetooth
+  bluetooth.shell.audio.no_tbs_client:
+    extra_args: CONF_FILE="audio.conf"
+    build_only: true
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_BT_TBS_CLIENT=n
+    tags: bluetooth


### PR DESCRIPTION
error: 'CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH' undeclared (first use
			in this function); did you mean
			'CONFIG_BT_TBS_CLIENT_MAX_PROVIDER_NAME_LENGTH'?
  292 |            CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      |            CONFIG_BT_TBS_CLIENT_MAX_PROVIDER_NAME_LENGTH
etc.

This fixes build errors that were seen while building call control
client without server side (`CONFIG_BT_TBS`) enabled.
The options like BT_TBS_CLIENT_MAX_URI_LENGTH and
BT_TBS_CLIENT_MAX_PROVIDER_NAME_LENGTH have been removed because those
were not used in the code. In fact the client implementation used the
common options for BT_TBS_MAX_URI_LENGTH and
BT_TBS_MAX_PROVIDER_NAME_LENGTH that were moved in this patch to the
common Kconfig section.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>