### PR TITLE
soc: xenvm: Add pl011 to mmu regions if configured

### DIFF
--- a/soc/arm64/xenvm/mmu_regions.c
+++ b/soc/arm64/xenvm/mmu_regions.c
@@ -1,5 +1,6 @@
 /*
  * Copyright 2020 EPAM Systems
+ * Copyright (c) 2022 Arm Limited (or its affiliates). All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -18,6 +19,16 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_ADDR_BY_IDX(DT_INST(0, arm_gic), 1),
 			      DT_REG_SIZE_BY_IDX(DT_INST(0, arm_gic), 1),
 			      MT_DEVICE_nGnRnE | MT_P_RW_U_RW | MT_NS),
+
+#ifdef CONFIG_UART_PL011
+
+	MMU_REGION_FLAT_ENTRY("UART0",
+			      DT_REG_ADDR(DT_NODELABEL(uart0)),
+			      DT_REG_SIZE(DT_NODELABEL(uart0)),
+			      MT_DEVICE_nGnRnE | MT_P_RW_U_RW | MT_NS),
+
+#endif
+
 };
 
 const struct arm_mmu_config mmu_config = {


### PR DESCRIPTION
Add entries for pl011 if the build system is configured to
use the real device instead of the Xen console.

Signed-off-by: Luca Fancellu <luca.fancellu@arm.com>