### PR TITLE
net/tcp packet dropping reliability

### DIFF
--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1468,7 +1468,7 @@ static void tcp_cb(struct tcp *conn, void *user_data)
 	struct net_shell_user_data *data = user_data;
 	const struct shell *shell = data->shell;
 	int *count = data->user_data;
-	uint16_t recv_mss = net_tcp_get_recv_mss(conn);
+	uint16_t recv_mss = net_tcp_get_supported_mss(conn);
 
 	PR("%p %p   %5u    %5u %10u %10u %5u   %s\n",
 	   conn, conn->context,

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2351,6 +2351,19 @@ int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt)
 		goto out;
 	}
 
+	if ((ret == -ENOBUFS) &&
+		(conn->send_data_total < (conn->unacked_len + len))) {
+		/* Some of the data has been sent, we cannot remove the
+		 * whole chunk, the remainder portion is already
+		 * in the send_data and will be transmitted upon a
+		 * received ack or the next send call
+		 *
+		 * Set the return code back to 0 to pretend we just
+		 * transmitted the chunk
+		 */
+		ret = 0;
+	}
+
 	if (ret == -ENOBUFS) {
 		/* Restore the original data so that we do not resend the pkt
 		 * data multiple times.

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1192,6 +1192,8 @@ static void tcp_resend_data(struct k_work *work)
 		}
 
 		goto out;
+	} else if (ret == -ENOBUFS) {
+		NET_ERR("TCP failed to allocate buffer in retransmission");
 	}
 
 	k_work_reschedule_for_queue(&tcp_work_q, &conn->send_data_timer,

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -836,7 +836,7 @@ static int net_tcp_set_mss_opt(struct tcp *conn, struct net_pkt *pkt)
 		return -ENOBUFS;
 	}
 
-	recv_mss = net_tcp_get_recv_mss(conn);
+	recv_mss = net_tcp_get_supported_mss(conn);
 	recv_mss |= (NET_TCP_MSS_OPT << 24) | (NET_TCP_MSS_SIZE << 16);
 
 	UNALIGNED_PUT(htonl(recv_mss), (uint32_t *)mss);
@@ -2916,7 +2916,7 @@ void net_tcp_foreach(net_tcp_cb_t cb, void *user_data)
 	k_mutex_unlock(&tcp_lock);
 }
 
-uint16_t net_tcp_get_recv_mss(const struct tcp *conn)
+uint16_t net_tcp_get_supported_mss(const struct tcp *conn)
 {
 	sa_family_t family = net_context_get_family(conn->context);
 

--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -38,9 +38,9 @@ extern "C" {
  * @return Maximum Segment Size
  */
 #if defined(CONFIG_NET_NATIVE_TCP)
-uint16_t net_tcp_get_recv_mss(const struct tcp *conn);
+uint16_t net_tcp_get_supported_mss(const struct tcp *conn);
 #else
-static inline uint16_t net_tcp_get_recv_mss(const struct tcp *conn)
+static inline uint16_t net_tcp_get_supported_mss(const struct tcp *conn)
 {
 	ARG_UNUSED(conn);
 	return 0;

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -112,7 +112,8 @@
 
 #define conn_mss(_conn)					\
 	((_conn)->recv_options.mss_found ?		\
-	 (_conn)->recv_options.mss : (uint16_t)NET_IPV6_MTU)
+	 MIN((_conn)->recv_options.mss, \
+	 net_tcp_get_supported_mss(_conn)) : net_tcp_get_supported_mss(_conn))
 
 #define conn_state(_conn, _s)						\
 ({									\


### PR DESCRIPTION
During testing with artificial packet loss a few problems surfaced namely:

- A deadlock in updating the receive window size
- Silently failing the resend due to insufficient buffer size
- The send timer being canceled by new data being transmitted for which no buffer was available
- Incorrect computation of the transmit MSS

This PR fixes the issues above