### PR TITLE
ADXL362 add separate triggers for activity/inactivity

### DIFF
--- a/drivers/sensor/adxl362/adxl362.h
+++ b/drivers/sensor/adxl362/adxl362.h
@@ -196,8 +196,10 @@ struct adxl362_data {
 	struct gpio_callback gpio_cb;
 	struct k_mutex trigger_mutex;
 
-	sensor_trigger_handler_t th_handler;
-	struct sensor_trigger th_trigger;
+	sensor_trigger_handler_t inact_handler;
+	struct sensor_trigger inact_trigger;
+	sensor_trigger_handler_t act_handler;
+	struct sensor_trigger act_trigger;
 	sensor_trigger_handler_t drdy_handler;
 	struct sensor_trigger drdy_trigger;
 

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -29,10 +29,15 @@ static void adxl362_thread_cb(const struct device *dev)
 	}
 
 	k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
-	if (drv_data->th_handler != NULL) {
-		if (ADXL362_STATUS_CHECK_INACT(status_buf) ||
-		    ADXL362_STATUS_CHECK_ACTIVITY(status_buf)) {
-			drv_data->th_handler(dev, &drv_data->th_trigger);
+	if (drv_data->inact_handler != NULL) {
+		if (ADXL362_STATUS_CHECK_INACT(status_buf)) {
+			drv_data->inact_handler(dev, &drv_data->inact_trigger);
+		}
+	}
+
+	if (drv_data->act_handler != NULL) {
+		if (ADXL362_STATUS_CHECK_ACTIVITY(status_buf)) {
+			drv_data->act_handler(dev, &drv_data->act_trigger);
 		}
 	}
 
@@ -82,13 +87,21 @@ int adxl362_trigger_set(const struct device *dev,
 	uint8_t int_mask, int_en, status_buf;
 
 	switch (trig->type) {
-	case SENSOR_TRIG_THRESHOLD:
+	case SENSOR_TRIG_MOTION:
 		k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
-		drv_data->th_handler = handler;
-		drv_data->th_trigger = *trig;
+		drv_data->act_handler = handler;
+		drv_data->act_trigger = *trig;
 		k_mutex_unlock(&drv_data->trigger_mutex);
-		int_mask = ADXL362_INTMAP1_ACT |
-			   ADXL362_INTMAP1_INACT;
+		int_mask = ADXL362_INTMAP1_ACT;
+		/* Clear activity and inactivity interrupts */
+		adxl362_get_status(dev, &status_buf);
+		break;
+	case SENSOR_TRIG_STATIONARY:
+		k_mutex_lock(&drv_data->trigger_mutex, K_FOREVER);
+		drv_data->inact_handler = handler;
+		drv_data->inact_trigger = *trig;
+		k_mutex_unlock(&drv_data->trigger_mutex);
+		int_mask = ADXL362_INTMAP1_INACT;
 		/* Clear activity and inactivity interrupts */
 		adxl362_get_status(dev, &status_buf);
 		break;

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -236,6 +236,11 @@ enum sensor_trigger_type {
 	/** Trigger fires when a free fall is detected. */
 	SENSOR_TRIG_FREEFALL,
 
+	/** Trigger fires when motion is detected. */
+	SENSOR_TRIG_MOTION,
+
+	/** Trigger fires when no motion has been detected for a while. */
+	SENSOR_TRIG_STATIONARY,
 	/**
 	 * Number of all common sensor triggers.
 	 */

--- a/samples/sensor/adxl362/src/main.c
+++ b/samples/sensor/adxl362/src/main.c
@@ -22,8 +22,11 @@ static void trigger_handler(const struct device *dev,
 		}
 		k_sem_give(&sem);
 		break;
-	case SENSOR_TRIG_THRESHOLD:
-		printf("Threshold trigger\n");
+	case SENSOR_TRIG_MOTION:
+		printf("Motion trigger\n");
+		break;
+	case SENSOR_TRIG_STATIONARY:
+		printf("Stationary trigger\n");
 		break;
 	default:
 		printf("Unknown trigger\n");
@@ -43,7 +46,13 @@ void main(void)
 	if (IS_ENABLED(CONFIG_ADXL362_TRIGGER)) {
 		struct sensor_trigger trig = { .chan = SENSOR_CHAN_ACCEL_XYZ };
 
-		trig.type = SENSOR_TRIG_THRESHOLD;
+		trig.type = SENSOR_TRIG_MOTION;
+		if (sensor_trigger_set(dev, &trig, trigger_handler)) {
+			printf("Trigger set error\n");
+			return;
+		}
+
+		trig.type = SENSOR_TRIG_STATIONARY;
 		if (sensor_trigger_set(dev, &trig, trigger_handler)) {
 			printf("Trigger set error\n");
 			return;


### PR DESCRIPTION
This patch adds separate triggers for activity and inactivity detection
for the ADXL362 accelerometer.
Previously, applications could not distinguish these events.

Signed-off-by: Maximilian Deubel [maximilian.deubel@nordicsemi.no](mailto:maximilian.deubel@nordicsemi.no)