### PR TITLE
Bluetooth: Controller: Fix RX_ENQUEUE_HOLD for LOW_LAT_ULL

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -1393,12 +1393,12 @@ void ull_conn_done(struct node_rx_event_done *done)
 	if (conn->llcp_rx_hold && rx_hold_is_done(conn)) {
 		rx_hold_flush(conn);
 
-#if !defined(CONFIG_BT_CTLR_LOW_LAT_ULL)
-		/* if done events have separate mayfly, explicit trigger of
-		 * rx_demux mayfly is necessary.
+		/* For both CONFIG_BT_CTLR_LOW_LAT_ULL or when done events have
+		 * separate mayfly, explicitly trigger rx_demux mayfly. In the
+		 * later we could be here without any node rx or tx ack being
+		 * processed hence an explicit ll_rx_sched call is necessary.
 		 */
 		ll_rx_sched();
-#endif /* !CONFIG_BT_CTLR_LOW_LAT_ULL */
 	}
 #endif /* CONFIG_BT_CTLR_RX_ENQUEUE_HOLD */
 


### PR DESCRIPTION
Fix BT_CTLR_RX_ENQUEUE_HOLD implementation that stalled
generating the CONN_UPDATE and PHY_UPDATE when there were
no Rx data or Tx acknowledgements to be processed when
the controller was built with BT_CTLR_LOW_LAT_ULL.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>