### PR TITLE
twister: Initialise Colorama during module load

### DIFF
--- a/scripts/footprint/fpdiff.py
+++ b/scripts/footprint/fpdiff.py
@@ -18,6 +18,7 @@ from anytree.importer import DictImporter
 from anytree import PreOrderIter
 from anytree.search  import find
 
+import colorama
 from colorama import Fore
 import json
 import argparse
@@ -33,6 +34,8 @@ def parse_args():
     return parser.parse_args()
 
 def main():
+    colorama.init()
+
     args = parse_args()
 
     with open(args.file1, "r") as f:

--- a/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
+++ b/scripts/logging/dictionary/dictionary_parser/log_parser_v1.py
@@ -14,6 +14,7 @@ version 1 databases.
 import logging
 import math
 import struct
+import colorama
 from colorama import Fore
 
 from .log_parser import LogParser
@@ -468,3 +469,5 @@ class LogParserV1(LogParser):
                 return False
 
         return True
+
+colorama.init()

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -28,6 +28,7 @@ import xml.etree.ElementTree as ET
 import logging
 from pathlib import Path
 from distutils.spawn import find_executable
+import colorama
 from colorama import Fore
 import pickle
 import platform
@@ -4714,3 +4715,5 @@ class HardwareMap:
                 table.append([platform, p.id, p.serial])
 
         print(tabulate(table, headers=header, tablefmt="github"))
+
+colorama.init()

--- a/scripts/tracing/parse_ctf.py
+++ b/scripts/tracing/parse_ctf.py
@@ -20,6 +20,7 @@ Generate trace using samples/subsys/tracing for example:
 
 import sys
 import datetime
+import colorama
 from colorama import Fore
 import argparse
 try:
@@ -38,6 +39,8 @@ def parse_args():
     return args
 
 def main():
+    colorama.init()
+
     args = parse_args()
 
     msg_it = bt2.TraceCollectionMessageIterator(args.trace)

--- a/scripts/twister
+++ b/scripts/twister
@@ -173,6 +173,7 @@ import shutil
 from collections import OrderedDict
 import multiprocessing
 from itertools import islice
+import colorama
 from colorama import Fore
 from pathlib import Path
 from multiprocessing.managers import BaseManager
@@ -831,6 +832,8 @@ def setup_logging(outdir, log_file, verbose, timestamps):
 
 def main():
     start_time = time.time()
+
+    colorama.init()
 
     options = parse_arguments()
 

--- a/soc/arm/nuvoton_npcx/common/ecst/ecst_args.py
+++ b/soc/arm/nuvoton_npcx/common/ecst/ecst_args.py
@@ -8,6 +8,7 @@
 
 import sys
 import argparse
+import colorama
 from colorama import Fore
 
 INVALID_INPUT = -1
@@ -244,3 +245,5 @@ def exit_with_failure(message):
     print(Fore.RED + message)
 
     sys.exit(EXIT_FAILURE_STATUS)
+
+colorama.init()


### PR DESCRIPTION
This commit adds a call to the Colorama initialisation function during
the module execution so that ANSI color sequences are properly
converted to the relevant Win32 API calls on the Windows.

Note that the init function needs to be called per module, hence it is
also called in the `twisterlib.py`.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #21409

This series also contains similar fixes for other scripts that utilise the Colorama module.