### PR TITLE
Bluetooth: Allow support for Multiple Variable Length Read without EATT

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -28,6 +28,7 @@ config BT_EATT
 	bool "Enhanced ATT Bearers support [EXPERIMENTAL]"
 	depends on BT_L2CAP_ECRED
 	select EXPERIMENTAL
+	select BT_GATT_READ_MULT_VAR_LEN
 	help
 	  This option enables support for Enhanced ATT bearers support. When
 	  enabled additional L2CAP channels can be connected as bearers enabling
@@ -141,6 +142,14 @@ config BT_GATT_READ_MULTIPLE
 	help
 	  This option enables support for the GATT Read Multiple Characteristic
 	  Values procedure.
+
+config BT_GATT_READ_MULT_VAR_LEN
+	bool "GATT Read Multiple Variable Length Characteristic Values support"
+	default y
+	help
+	  This option enables support for the GATT Read Multiple Variable Length
+	  Characteristic Values procedure. Mandatory if EATT is enabled, optional
+	  otherwise (Core spec v5.3, Vol 3, Part G, Section 4.2, Table 4.1).
 
 config BT_GATT_AUTO_DISCOVER_CCC
 	bool "Support to automatic discover the CCC handles of characteristics"

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -1516,8 +1516,9 @@ static uint8_t att_read_mult_req(struct bt_att_chan *chan, struct net_buf *buf)
 
 	return 0;
 }
+#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
 
-#if defined(CONFIG_BT_EATT)
+#if defined(CONFIG_BT_GATT_READ_MULT_VAR_LEN)
 static uint8_t read_vl_cb(const struct bt_gatt_attr *attr, uint16_t handle,
 			  void *user_data)
 {
@@ -1611,8 +1612,7 @@ static uint8_t att_read_mult_vl_req(struct bt_att_chan *chan, struct net_buf *bu
 
 	return 0;
 }
-#endif /* CONFIG_BT_EATT */
-#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+#endif /* CONFIG_BT_GATT_READ_MULT_VAR_LEN */
 
 struct read_group_data {
 	struct bt_att_chan *chan;
@@ -2361,7 +2361,9 @@ static uint8_t att_handle_read_mult_rsp(struct bt_att_chan *chan,
 	return att_handle_rsp(chan, buf->data, buf->len, 0);
 }
 
-#if defined(CONFIG_BT_EATT)
+#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+
+#if defined(CONFIG_BT_GATT_READ_MULT_VAR_LEN)
 static uint8_t att_handle_read_mult_vl_rsp(struct bt_att_chan *chan,
 					struct net_buf *buf)
 {
@@ -2369,8 +2371,7 @@ static uint8_t att_handle_read_mult_vl_rsp(struct bt_att_chan *chan,
 
 	return att_handle_rsp(chan, buf->data, buf->len, 0);
 }
-#endif /* CONFIG_BT_EATT */
-#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+#endif /* CONFIG_BT_GATT_READ_MULT_VAR_LEN */
 
 static uint8_t att_handle_read_group_rsp(struct bt_att_chan *chan,
 				      struct net_buf *buf)
@@ -2489,13 +2490,13 @@ static const struct att_handler {
 		BT_ATT_READ_MULT_MIN_LEN_REQ,
 		ATT_REQUEST,
 		att_read_mult_req },
-#if defined(CONFIG_BT_EATT)
+#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+#if defined(CONFIG_BT_GATT_READ_MULT_VAR_LEN)
 	{ BT_ATT_OP_READ_MULT_VL_REQ,
 		BT_ATT_READ_MULT_MIN_LEN_REQ,
 		ATT_REQUEST,
 		att_read_mult_vl_req },
-#endif /* CONFIG_BT_EATT */
-#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+#endif /* CONFIG_BT_GATT_READ_MULT_VAR_LEN */
 	{ BT_ATT_OP_READ_GROUP_REQ,
 		sizeof(struct bt_att_read_group_req),
 		ATT_REQUEST,
@@ -2561,13 +2562,13 @@ static const struct att_handler {
 		0,
 		ATT_RESPONSE,
 		att_handle_read_mult_rsp },
-#if defined(CONFIG_BT_EATT)
+#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+#if defined(CONFIG_BT_GATT_READ_MULT_VAR_LEN)
 	{ BT_ATT_OP_READ_MULT_VL_RSP,
 		sizeof(struct bt_att_read_mult_vl_rsp),
 		ATT_RESPONSE,
 		att_handle_read_mult_vl_rsp },
-#endif /* CONFIG_BT_EATT */
-#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+#endif /* CONFIG_BT_GATT_READ_MULT_VAR_LEN */
 	{ BT_ATT_OP_READ_GROUP_RSP,
 		sizeof(struct bt_att_read_group_rsp),
 		ATT_RESPONSE,

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4231,7 +4231,15 @@ static int gatt_read_mult(struct bt_conn *conn,
 			     params->handle_count * sizeof(uint16_t));
 }
 
-#if defined(CONFIG_BT_EATT)
+#else
+static int gatt_read_mult(struct bt_conn *conn,
+			      struct bt_gatt_read_params *params)
+{
+	return -ENOTSUP;
+}
+#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
+
+#if defined(CONFIG_BT_GATT_READ_MULT_VAR_LEN)
 static void gatt_read_mult_vl_rsp(struct bt_conn *conn, uint8_t err,
 				  const void *pdu, uint16_t length,
 				  void *user_data)
@@ -4295,23 +4303,14 @@ static int gatt_read_mult_vl(struct bt_conn *conn,
 			     BT_ATT_OP_READ_MULT_VL_REQ,
 			     params->handle_count * sizeof(uint16_t));
 }
-#endif /* CONFIG_BT_EATT */
 
 #else
-static int gatt_read_mult(struct bt_conn *conn,
-			      struct bt_gatt_read_params *params)
-{
-	return -ENOTSUP;
-}
-#endif /* CONFIG_BT_GATT_READ_MULTIPLE */
-
-#if !defined(CONFIG_BT_GATT_READ_MULTIPLE) || !defined(CONFIG_BT_EATT)
 static int gatt_read_mult_vl(struct bt_conn *conn,
 			     struct bt_gatt_read_params *params)
 {
 	return -ENOTSUP;
 }
-#endif
+#endif /* CONFIG_BT_GATT_READ_MULT_VAR_LEN */
 
 static int gatt_read_encode(struct net_buf *buf, size_t len, void *user_data)
 {


### PR DESCRIPTION
EATT is not a requirement for the Multiple Variable Length Read procedure, but previously one had to enable CONFIG_BT_EATT to enable support for it.

Questions:
- Does `BT_GATT_READ_MULTIPLE_VARIABLE_LENGTH` need to depend on `BT_GATT_READ_MULTIPLE` or should it be independent?
- Should `BT_EATT` select `BT_GATT_READ_MULTIPLE_VARIABLE_LENGTH`, since support for the Multiple Variable Length Read procedure is mandatory if EATT is supported?
