### PR TITLE
lib: smf: fix include

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "smf.h"
+#include <zephyr/smf.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smf);


### PR DESCRIPTION
State machine framework used double quotes for including its header file, so `migrate_includes.py` script missed this include.

- Change include from double quotes to angle brackets
- Add `zephyr/` prefix to include
