### PR TITLE
modules: tfm: Allow enabling FPU in the application with TF-M enabled

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -254,14 +254,10 @@ choice
 
 config FP_HARDABI
 	bool "Floating point Hard ABI"
-	depends on !BUILD_WITH_TFM
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling
 	  conventions.
-	  Note: the option is disabled for Zephyr builds with TF-M, as TF-M
-	  does not currently support building with Hard ABI, hence linking
-	  Zephyr with TF-M libraries would not be possible.
 
 config FP_SOFTABI
 	bool "Floating point Soft ABI"

--- a/modules/trusted-firmware-m/CMakeLists.txt
+++ b/modules/trusted-firmware-m/CMakeLists.txt
@@ -238,6 +238,13 @@ if (CONFIG_BUILD_WITH_TFM)
       )
   endif()
 
+  if(CONFIG_FPU AND CONFIG_FP_HARDABI)
+    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_FP=hard)
+    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_FP_ARCH=${FPU_FOR_${GCC_M_CPU}})
+  else()
+    list(APPEND TFM_CMAKE_ARGS -DCONFIG_TFM_FP=soft)
+  endif()
+
   file(MAKE_DIRECTORY ${TFM_BINARY_DIR})
   add_custom_target(tfm_cmake
     DEPENDS ${TFM_BINARY_DIR}/CMakeCache.txt


### PR DESCRIPTION
Allow the application to enable the FPU when TF-M has been enabled.
Pass the correct compilation flags according to the TF-M integration
guide.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>