### PR TITLE
doc: Bluetooth: Document the services APIs

### DIFF
--- a/doc/connectivity/bluetooth/api/index.rst
+++ b/doc/connectivity/bluetooth/api/index.rst
@@ -22,6 +22,7 @@ Bluetooth APIs
    mesh.rst
    microphone.rst
    rfcomm.rst
+   services.rst
    sdp.rst
    volume.rst
    uuid.rst

--- a/doc/connectivity/bluetooth/api/services.rst
+++ b/doc/connectivity/bluetooth/api/services.rst
@@ -1,0 +1,24 @@
+.. _bluetooth_services:
+
+Bluetooth standard services
+###########################
+
+Battery Service
+***************
+
+.. doxygengroup:: bt_bas
+
+Heart Rate Service
+******************
+
+.. doxygengroup:: bt_hrs
+
+Immediate Alert Service
+***********************
+
+.. doxygengroup:: bt_ias
+
+Object Transfer Service
+***********************
+
+.. doxygengroup:: bt_ots

--- a/doc/known-warnings.txt
+++ b/doc/known-warnings.txt
@@ -15,3 +15,4 @@
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct in6_addr.*'.*
 .*Duplicate C declaration.*\n.*'\.\. c:.*:: .*struct net_if.*'.*
+.*Duplicate C declaration.*\n.*'\.\. c:struct:: bt_ots_init'.*


### PR DESCRIPTION
The Bluetooth documentation was missing all the Doxygen API information
regarding the standard services implemented in the Host. Import the
Doxygen API doc in a single page.

Fixes #42520.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>