### PR TITLE
Bluetooth: shell: Add RSSI filtering

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -93,6 +93,8 @@ static struct bt_scan_filter {
 	bool name_set;
 	char addr[18]; /* fits xx:xx:xx:xx:xx:xx\0 */
 	bool addr_set;
+	int rssi;
+	bool rssi_set;
 } scan_filter;
 
 
@@ -160,6 +162,10 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 	}
 
 	if (scan_filter.addr_set && !is_substring(scan_filter.addr, le_addr)) {
+		return;
+	}
+
+	if (scan_filter.rssi_set && (scan_filter.rssi > info->rssi)) {
 		return;
 	}
 
@@ -1072,6 +1078,22 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 	scan_filter.addr_set = true;
 
 	return 0;
+}
+
+static int cmd_scan_filter_set_rssi(const struct shell *sh, size_t argc, char *argv[])
+{
+	int rssi = strtol(argv[1], NULL, 10);
+
+	if ((rssi < 50) && (rssi > -200)) {
+		scan_filter.rssi = rssi;
+		scan_filter.rssi_set = true;
+		shell_print(sh, "RSSI cutoff set at %d dB", scan_filter.rssi);
+		return 0;
+	} else {
+		shell_print(sh, "value out of bounds (-200 to +50)");
+		shell_help(sh);
+		return SHELL_CMD_HELP_PRINTED;
+	}
 }
 
 static int cmd_scan_filter_clear_all(const struct shell *sh, size_t argc,
@@ -3244,6 +3266,7 @@ static int cmd_auth_oob_tk(const struct shell *sh, size_t argc, char *argv[])
 SHELL_STATIC_SUBCMD_SET_CREATE(bt_scan_filter_set_cmds,
 	SHELL_CMD_ARG(name, NULL, "<name>", cmd_scan_filter_set_name, 2, 0),
 	SHELL_CMD_ARG(addr, NULL, "<addr>", cmd_scan_filter_set_addr, 2, 0),
+	SHELL_CMD_ARG(rssi, NULL, "<rssi>", cmd_scan_filter_set_rssi, 1, 1),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
This adds an RSSI cutoff, so any scanned devices that are below the given
value (in dB) will not get printed out. Very useful in noisy environments.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>