### PR TITLE
dts: nxp: fix address of NXP PFR region for LPC55sx6 SOC

### DIFF
--- a/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S0x_common.dtsi
@@ -95,7 +95,7 @@
 
 		uuid: flash@9fc70 {
 			compatible = "nxp,lpc-uid";
-			reg = <0x9fc70 0x10>;
+			reg = <0x3fc70 0x10>;
 		};
 
 		boot_rom: flash@3000000 {

--- a/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
+++ b/dts/arm/nxp/nxp_lpc55S1x_common.dtsi
@@ -98,7 +98,7 @@
 
 		uuid: flash@9fc70 {
 			compatible = "nxp,lpc-uid";
-			reg = <0x9fc70 0x10>;
+			reg = <0x3fc70 0x10>;
 		};
 
 		boot_rom: flash@3000000 {


### PR DESCRIPTION
LPC55sx6 SOC has NXP Manufacturing Programmed Area(NMPA) stored at
offsets 0x3EC00-0x3FDFF. Correct uuid offset to be within this region.

Fixes #43870

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>