### PR TITLE
dts: fix a bunch of odd partition values dts entries

### DIFF
--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -123,7 +123,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -153,7 +153,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0xC000>;
+			reg = <0x00000000 0xC000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -337,7 +337,7 @@
 		/* 7MB */
 		lfs_partition: partition@100000 {
 			label = "lfs_storage";
-			reg = <0x00100000 0x000700000>;
+			reg = <0x00100000 0x00700000>;
 		};
 	};
 };

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -142,7 +142,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0xC000>;
+			reg = <0x00000000 0xC000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -163,7 +163,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
+++ b/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
@@ -101,7 +101,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00010000>;
+			reg = <0x00000000 0x00010000>;
 		};
 		slot0_partition: partition@10000 {
 			label = "image-0";

--- a/boards/arm/bl654_usb/bl654_usb.dts
+++ b/boards/arm/bl654_usb/bl654_usb.dts
@@ -72,16 +72,16 @@
 		 */
 		boot_partition: partition@1000 {
 			label = "mcuboot";
-			reg = <0x00001000 0x000f000>;
+			reg = <0x00001000 0x0000f000>;
 		};
 
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00005e000>;
+			reg = <0x00010000 0x0005e000>;
 		};
 		slot1_partition: partition@6e000 {
 			label = "image-1";
-			reg = <0x006e000 0x00005e000>;
+			reg = <0x0006e000 0x0005e000>;
 		};
 		storage_partition: partition@cc000 {
 			label = "storage";

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -141,17 +141,17 @@
 		/* 96K */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00018000>;
+			reg = <0x00000000 0x00018000>;
 		};
 		/* 396K */
 		slot0_partition: partition@18000 {
 			label = "image-0";
-			reg = <0x00018000 0x000063000>;
+			reg = <0x00018000 0x00063000>;
 		};
 		/* 396K */
 		slot1_partition: partition@7b000 {
 			label = "image-1";
-			reg = <0x0007b000 0x000063000>;
+			reg = <0x0007b000 0x00063000>;
 		};
 		/* 8K */
 		scratch_partition: partition@de000 {

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -307,7 +307,7 @@
 		/* 96K */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00018000>;
+			reg = <0x00000000 0x00018000>;
 		};
 		/* 896K */
 		slot0_partition: partition@18000 {
@@ -340,7 +340,7 @@
 		/* 896K */
 		slot1_partition: partition@0 {
 			label = "image-1";
-			reg = <0x0000000 0x000E0000>;
+			reg = <0x00000000 0x000E0000>;
 		};
 		/* 16K */
 		scratch_partition: partition@E0000 {
@@ -355,7 +355,7 @@
 		/* 7MB */
 		lfs_partition: partition@100000 {
 			label = "lfs_storage";
-			reg = <0x00100000 0x000700000>;
+			reg = <0x00100000 0x00700000>;
 		};
 	};
 };

--- a/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
+++ b/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
@@ -94,7 +94,7 @@ arduino_i2c: &i2c0 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -133,23 +133,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00014000>;
+			reg = <0x00000000 0x00014000>;
 		};
 		slot0_partition: partition@14000 {
 			label = "image-0";
-			reg = <0x000014000 0x0006e000>;
+			reg = <0x00014000 0x0006e000>;
 		};
 		slot1_partition: partition@82000 {
 			label = "image-1";
-			reg = <0x000082000 0x0006e000>;
+			reg = <0x00082000 0x0006e000>;
 		};
 		scratch_partition: partition@f0000 {
 			label = "image-scratch";
-			reg = <0x0000f0000 0x00008000>;
+			reg = <0x000f0000 0x00008000>;
 		};
 		storage_partition: partition@f8000 {
 			label = "storage";
-			reg = <0x0000f8000 0x00008000>;
+			reg = <0x000f8000 0x00008000>;
 		};
 	};
 };

--- a/boards/arm/efr32_radio/efr32_radio_brd4104a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4104a.dts
@@ -34,7 +34,7 @@
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x0008000 0x00037000>;
+			reg = <0x00008000 0x00037000>;
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */

--- a/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4250b.dts
@@ -55,7 +55,7 @@
 		/* Reserve 94 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x0008000 0x00017800>;
+			reg = <0x00008000 0x00017800>;
 		};
 
 		/* Reserve 94 kB for the application in slot 1 */

--- a/boards/arm/efr32_radio/efr32_radio_brd4255a.dts
+++ b/boards/arm/efr32_radio/efr32_radio_brd4255a.dts
@@ -34,7 +34,7 @@
 		/* Reserve 220 kB for the application in slot 0 */
 		slot0_partition: partition@8000 {
 			label = "image-0";
-			reg = <0x0008000 0x00037000>;
+			reg = <0x00008000 0x00037000>;
 		};
 
 		/* Reserve 220 kB for the application in slot 1 */

--- a/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
+++ b/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
@@ -65,7 +65,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -247,7 +247,7 @@ fem_spi: &spi3 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -205,7 +205,7 @@ arduino_spi: &spi3 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0xC000>;
+			reg = <0x00000000 0xC000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -141,7 +141,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -164,7 +164,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/nrf52840_mdk_usb_dongle/fstab-debugger.dts
+++ b/boards/arm/nrf52840_mdk_usb_dongle/fstab-debugger.dts
@@ -17,16 +17,16 @@
 		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00012000>;
+			reg = <0x00000000 0x00012000>;
 		};
 
 		slot0_partition: partition@12000 {
 			label = "image-0";
-			reg = <0x00012000 0x000069000>;
+			reg = <0x00012000 0x00069000>;
 		};
 		slot1_partition: partition@7b000 {
 			label = "image-1";
-			reg = <0x0007b000 0x000069000>;
+			reg = <0x0007b000 0x00069000>;
 		};
 		scratch_partition: partition@e4000 {
 			label = "image-scratch";

--- a/boards/arm/nrf52840_mdk_usb_dongle/fstab-stock.dts
+++ b/boards/arm/nrf52840_mdk_usb_dongle/fstab-stock.dts
@@ -18,16 +18,16 @@
 		 */
 		boot_partition: partition@1000 {
 			label = "mcuboot";
-			reg = <0x00001000 0x000f000>;
+			reg = <0x00001000 0x0000f000>;
 		};
 
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00005e000>;
+			reg = <0x00010000 0x0005e000>;
 		};
 		slot1_partition: partition@6e000 {
 			label = "image-1";
-			reg = <0x006e000 0x00005e000>;
+			reg = <0x0006e000 0x0005e000>;
 		};
 		storage_partition: partition@cc000 {
 			label = "storage";

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -133,7 +133,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -252,7 +252,7 @@ arduino_spi: &spi3 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-debugger.dts
@@ -17,16 +17,16 @@
 		 */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00012000>;
+			reg = <0x00000000 0x00012000>;
 		};
 
 		slot0_partition: partition@12000 {
 			label = "image-0";
-			reg = <0x00012000 0x000069000>;
+			reg = <0x00012000 0x00069000>;
 		};
 		slot1_partition: partition@7b000 {
 			label = "image-1";
-			reg = <0x0007b000 0x000069000>;
+			reg = <0x0007b000 0x00069000>;
 		};
 		scratch_partition: partition@e4000 {
 			label = "image-scratch";

--- a/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/fstab-stock.dts
@@ -18,16 +18,16 @@
 		 */
 		boot_partition: partition@1000 {
 			label = "mcuboot";
-			reg = <0x00001000 0x000f000>;
+			reg = <0x00001000 0x0000f000>;
 		};
 
 		slot0_partition: partition@10000 {
 			label = "image-0";
-			reg = <0x00010000 0x00005e000>;
+			reg = <0x00010000 0x0005e000>;
 		};
 		slot1_partition: partition@6e000 {
 			label = "image-1";
-			reg = <0x006e000 0x00005e000>;
+			reg = <0x0006e000 0x0005e000>;
 		};
 		storage_partition: partition@cc000 {
 			label = "storage";

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -169,7 +169,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -133,7 +133,7 @@ feather_adc: &adc { /* feather ADC */
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -133,7 +133,7 @@ feather_adc: &adc { /* feather ADC */
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -133,7 +133,7 @@ feather_adc: &adc { /* feather ADC */
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -183,7 +183,7 @@
 		/* 96K */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00018000>;
+			reg = <0x00000000 0x00018000>;
 		};
 		/* 896K */
 		slot0_partition: partition@18000 {
@@ -216,7 +216,7 @@
 		/* 896K */
 		slot1_partition: partition@0 {
 			label = "image-1";
-			reg = <0x0000000 0x000E0000>;
+			reg = <0x00000000 0x000E0000>;
 		};
 		/* 128K */
 		scratch_partition: partition@E0000 {
@@ -226,7 +226,7 @@
 		/* 7MB */
 		lfs_partition: partition@100000 {
 			label = "lfs_storage";
-			reg = <0x00100000 0x000700000>;
+			reg = <0x00100000 0x00700000>;
 		};
 	};
 };

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -134,7 +134,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -140,7 +140,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -171,7 +171,7 @@ arduino_spi: &spi3 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
+++ b/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
@@ -120,7 +120,7 @@
 		/* 52K */
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		/* 188K */
 		slot0_partition: partition@c000 {
@@ -150,7 +150,7 @@
 		/* 68K */
 		lfs_partition: partition@30000 {
 			label = "lfs_storage";
-			reg = <0x00030000 0x000010000>;
+			reg = <0x00030000 0x00010000>;
 		};
 	};
 };

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -156,7 +156,7 @@ zephyr_udc0: &usbhs {
 		/* From sector 1 to sector 7 (included): slot0 (896 kbytes) */
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x0020000 0x000e0000>;
+			reg = <0x00020000 0x000e0000>;
 		};
 
 		/* From sector 8 to sector 14 (included): slot1 (896 kbytes) */

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -284,7 +284,7 @@ zephyr_udc0: &usbhs {
 		/* From sector 1 to sector 7 (included): slot0 (896 kbytes) */
 		slot0_partition: partition@20000 {
 			label = "image-0";
-			reg = <0x0020000 0x000e0000>;
+			reg = <0x00020000 0x000e0000>;
 		};
 
 		/* From sector 8 to sector 14 (included): slot1 (896 kbytes) */

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -260,7 +260,7 @@ arduino_spi: &spi3 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -266,7 +266,7 @@ arduino_spi: &spi3 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -199,7 +199,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
+++ b/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
@@ -188,7 +188,7 @@ arduino_i2c: &i2c0 {
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/arm/we_proteus3ev_nrf52840/we_proteus3ev_nrf52840.dts
+++ b/boards/arm/we_proteus3ev_nrf52840/we_proteus3ev_nrf52840.dts
@@ -101,7 +101,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/boards/posix/native_posix/native_posix.dts
+++ b/boards/posix/native_posix/native_posix.dts
@@ -75,15 +75,15 @@
 
 				boot_partition: partition@0 {
 					label = "mcuboot";
-					reg = <0x000000000 0x0000C000>;
+					reg = <0x00000000 0x0000C000>;
 				};
 				slot0_partition: partition@c000 {
 					label = "image-0";
-					reg = <0x0000C000 0x000069000>;
+					reg = <0x0000C000 0x00069000>;
 				};
 				slot1_partition: partition@75000 {
 					label = "image-1";
-					reg = <0x00075000 0x000069000>;
+					reg = <0x00075000 0x00069000>;
 				};
 				scratch_partition: partition@de000 {
 					label = "image-scratch";

--- a/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.dts
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega_ri5cy.dts
@@ -34,11 +34,11 @@
 
 		slot0_partition: partition@0 {
 			label = "image-0";
-			reg = <0x00000000 0x000069000>;
+			reg = <0x00000000 0x00069000>;
 		};
 		slot1_partition: partition@69000 {
 			label = "image-1";
-			reg = <0x00069000 0x000069000>;
+			reg = <0x00069000 0x00069000>;
 		};
 		scratch_partition: partition@d2000 {
 			label = "image-scratch";

--- a/dts/arm/st/f4/stm32f429.dtsi
+++ b/dts/arm/st/f4/stm32f429.dtsi
@@ -23,7 +23,7 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x004000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x04000000>;
 			status = "disabled";
 			label = "LTDC";
 		};

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -52,7 +52,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x000000008>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
 			label = "LTDC";
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -28,7 +28,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x080000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x80000000>;
 			phys = <&otghs_fs_phy>;
 			status = "disabled";
 			label= "OTG_FS";
@@ -39,7 +39,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x000000008>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
 			status = "disabled";
 			label = "LTDC";
 		};

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -31,7 +31,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x000000008>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
 			label = "LTDC";
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -26,7 +26,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x000000008>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
 			label = "LTDC";
 			status = "disabled";
 		};

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -25,7 +25,7 @@
 			reg = <0x50001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x000000008>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000008>;
 			label = "LTDC";
 			status = "disabled";
 		};

--- a/dts/arm/st/l4/stm32l4r9.dtsi
+++ b/dts/arm/st/l4/stm32l4r9.dtsi
@@ -15,7 +15,7 @@
 			reg = <0x40016800 0x200>;
 			interrupts = <91 0>, <92 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x040000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB2 0x40000000>;
 			label = "LTDC";
 			status = "disabled";
 		};

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -311,7 +311,7 @@
 			reg = <0x5A001000 0x200>;
 			interrupts = <88 0>, <89 0>;
 			interrupt-names = "ltdc", "ltdc_er";
-			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x000000001>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB4 0x00000001>;
 			label = "LTDC";
 			status = "disabled";
 		};

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -51,7 +51,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";

--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -71,7 +71,7 @@
 
 					test_p0: partition@0 {
 						label = "partition-0";
-						reg = <0x000000000 0x0000C000>;
+						reg = <0x00000000 0x0000C000>;
 					};
 					test_p1: partition@c000 {
 						label = "partition-1";

--- a/tests/subsys/dfu/mcuboot_multi/native_posix.overlay
+++ b/tests/subsys/dfu/mcuboot_multi/native_posix.overlay
@@ -16,23 +16,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x00069000>;
 		};
 		slot1_partition: partition@75000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00075000 0x00069000>;
 		};
 		slot2_partition: partition@DE000 {
 			label = "image-2";
-			reg = <0x0000DE000 0x000069000>;
+			reg = <0x000DE000 0x00069000>;
 		};
 		slot3_partition: partition@146000 {
 			label = "image-3";
-			reg = <0x00146000 0x000069000>;
+			reg = <0x00146000 0x00069000>;
 		};
 	};
 };

--- a/tests/subsys/dfu/mcuboot_multi/native_posix_64.overlay
+++ b/tests/subsys/dfu/mcuboot_multi/native_posix_64.overlay
@@ -15,23 +15,23 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x0000C000>;
+			reg = <0x00000000 0x0000C000>;
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000C000 0x000069000>;
+			reg = <0x0000C000 0x00069000>;
 		};
 		slot1_partition: partition@75000 {
 			label = "image-1";
-			reg = <0x00075000 0x000069000>;
+			reg = <0x00075000 0x00069000>;
 		};
 		slot2_partition: partition@DE000 {
 			label = "image-2";
-			reg = <0x0000DE000 0x000069000>;
+			reg = <0x000DE000 0x00069000>;
 		};
 		slot3_partition: partition@146000 {
 			label = "image-3";
-			reg = <0x00146000 0x000069000>;
+			reg = <0x00146000 0x00069000>;
 		};
 	};
 };

--- a/tests/subsys/dfu/mcuboot_multi/nrf52840dk_nrf52840.overlay
+++ b/tests/subsys/dfu/mcuboot_multi/nrf52840dk_nrf52840.overlay
@@ -18,7 +18,7 @@
 
 		boot_partition: partition@0 {
 			label = "mcuboot";
-			reg = <0x000000000 0x00010000>;
+			reg = <0x00000000 0x00010000>;
 		};
 		slot0_partition: partition@10000 {
 			label = "image-0";
@@ -34,7 +34,7 @@
 		};
 		slot3_partition: partition@2E000 {
 			label = "image-3";
-			reg = <0x0002E000 0x00000A000>;
+			reg = <0x0002E000 0x0000A000>;
 		};
 	};
 };


### PR DESCRIPTION
Hey, spotted a bunch of odd 9/7 nibbles values on fixed-partition board definitions. I don't think they are intentional and make somewhat hard to tweak the partitioning by hand, figure I'd have a go at clearing them up.

-- 8< --

Fix various board fixed-partition definitions where the devicetree cell
has been defined oddly, such as 9 nibbles (which makes no sense since
the cells are 32 bit) or 7 nibbles where all the others are 8.