### PR TITLE
Define write block size property for NXP Hyperflash 

### DIFF
--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -133,6 +133,8 @@ arduino_serial: &lpuart3 {
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
+		erase-block-size = <4096>;
+		write-block-size = <16>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -42,6 +42,8 @@
 		ahb-write-wait-unit = <2>;
 		ahb-write-wait-interval = <20>;
 		status = "okay";
+		erase-block-size = <4096>;
+		write-block-size = <16>;
 
 		partitions {
 			compatible = "fixed-partitions";

--- a/drivers/flash/flash_mcux_flexspi_hyperflash.c
+++ b/drivers/flash/flash_mcux_flexspi_hyperflash.c
@@ -38,7 +38,6 @@ LOG_MODULE_REGISTER(flexspi_hyperflash, CONFIG_FLASH_LOG_LEVEL);
 #define SPI_HYPERFLASH_SECTOR_SIZE              (0x40000U)
 #define SPI_HYPERFLASH_PAGE_SIZE                (512U)
 
-#define HYPERFLASH_WRITE_SIZE                   (16)
 #define HYPERFLASH_ERASE_VALUE                  (0xFF)
 
 #ifdef CONFIG_FLASH_MCUX_FLEXSPI_HYPERFLASH_WRITE_BUFFER
@@ -667,7 +666,7 @@ static const struct flash_driver_api flash_flexspi_hyperflash_api = {
 			.pages_size = SPI_HYPERFLASH_SECTOR_SIZE,	\
 		},							\
 		.flash_parameters = {					\
-			.write_block_size = HYPERFLASH_WRITE_SIZE,	\
+			.write_block_size = DT_INST_PROP(n, write_block_size), \
 			.erase_value = HYPERFLASH_ERASE_VALUE,		\
 		},							\
 	};								\

--- a/dts/bindings/mtd/nxp,imx-flexspi-hyperflash.yaml
+++ b/dts/bindings/mtd/nxp,imx-flexspi-hyperflash.yaml
@@ -1,8 +1,8 @@
-# Copyright 2020 NXP
+# Copyright 2020-22 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 description: NXP FlexSPI HyperFlash
 
 compatible: "nxp,imx-flexspi-hyperflash"
 
-include: nxp,imx-flexspi-device.yaml
+include: ["nxp,imx-flexspi-device.yaml", soc-nv-flash.yaml]


### PR DESCRIPTION
Add erase/write block sizes for nxp hyperflash. This needed for applications such as `mcuboot`. Also use this property in the Hyperflash driver rather than a #defined value. This should address the build failures reported in Issue https://github.com/zephyrproject-rtos/zephyr/issues/44647
