### PR TITLE
Bluetooth: Host: Option for disabling of ATT auto retry

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -24,6 +24,14 @@ config BT_ATT_PREPARE_COUNT
 	  Number of buffers available for ATT prepare write, setting
 	  this to 0 disables GATT long/reliable writes.
 
+config BT_ATT_RETRY_ON_SEC_ERR
+	bool "Automatic security elevation and retry on security errors"
+	default y
+	depends on BT_SMP
+	help
+	  If an ATT request fails due to insufficient security, the host will
+	  try to elevate the security level and retry the ATT request.
+
 config BT_EATT
 	bool "Enhanced ATT Bearers support [EXPERIMENTAL]"
 	depends on BT_L2CAP_ECRED

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -2221,7 +2221,7 @@ static uint8_t att_signed_write_cmd(struct bt_att_chan *chan, struct net_buf *bu
 #endif /* CONFIG_BT_SIGNING */
 
 #if defined(CONFIG_BT_GATT_CLIENT)
-#if defined(CONFIG_BT_SMP)
+#if defined(CONFIG_BT_ATT_RETRY_ON_SEC_ERR)
 static int att_change_security(struct bt_conn *conn, uint8_t err)
 {
 	bt_security_t sec;
@@ -2281,7 +2281,7 @@ static int att_change_security(struct bt_conn *conn, uint8_t err)
 
 	return bt_conn_set_security(conn, sec);
 }
-#endif /* CONFIG_BT_SMP */
+#endif /* CONFIG_BT_ATT_RETRY_ON_SEC_ERR */
 
 static uint8_t att_error_rsp(struct bt_att_chan *chan, struct net_buf *buf)
 {
@@ -2300,13 +2300,13 @@ static uint8_t att_error_rsp(struct bt_att_chan *chan, struct net_buf *buf)
 	}
 
 	err = rsp->error;
-#if defined(CONFIG_BT_SMP)
+#if defined(CONFIG_BT_ATT_RETRY_ON_SEC_ERR)
 	/* Check if error can be handled by elevating security. */
 	if (!att_change_security(chan->chan.chan.conn, err)) {
 		chan->req->retrying = true;
 		return 0;
 	}
-#endif /* CONFIG_BT_SMP */
+#endif /* CONFIG_BT_ATT_RETRY_ON_SEC_ERR */
 
 done:
 	return att_handle_rsp(chan, NULL, 0, err);


### PR DESCRIPTION
The automatic elevation of security and retry of ATT requests interferes
with some tests that expect authentication failures.

Affecting GATT/CL/GAR/BI-42-C

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>