### PR TITLE
ARC: west: mdb runner: fix folder where MDB is run

### DIFF
--- a/scripts/west_commands/runners/core.py
+++ b/scripts/west_commands/runners/core.py
@@ -651,7 +651,7 @@ class ZephyrBinaryRunner(abc.ABC):
             return b''
         return subprocess.check_output(cmd, **kwargs)
 
-    def popen_ignore_int(self, cmd: List[str]) -> subprocess.Popen:
+    def popen_ignore_int(self, cmd: List[str], **kwargs) -> subprocess.Popen:
         '''Spawn a child command, ensuring it ignores SIGINT.
 
         The returned subprocess.Popen object must be manually terminated.'''
@@ -671,7 +671,7 @@ class ZephyrBinaryRunner(abc.ABC):
         if _DRY_RUN:
             return _DebugDummyPopen()  # type: ignore
 
-        return subprocess.Popen(cmd, creationflags=cflags, preexec_fn=preexec)
+        return subprocess.Popen(cmd, creationflags=cflags, preexec_fn=preexec, **kwargs)
 
     def ensure_output(self, output_type: str) -> None:
         '''Ensure self.cfg has a particular output artifact.

--- a/scripts/west_commands/runners/mdb.py
+++ b/scripts/west_commands/runners/mdb.py
@@ -104,7 +104,7 @@ def mdb_do_run(mdb_runner, command):
             # core will download the shared image.
                          ('-prop=download=2' if i > 0 else '')] +
                          mdb_basic_options + mdb_target + [mdb_runner.elf_name])
-            mdb_runner.check_call(mdb_sub_cmd)
+            mdb_runner.check_call(mdb_sub_cmd, cwd=mdb_runner.build_dir)
             mdb_multifiles += ('core{}'.format(mdb_runner.cores-1-i) if i == 0 else ',core{}'.format(mdb_runner.cores-1-i))
 
         # to enable multi-core aware mode for use with the MetaWare debugger,
@@ -116,7 +116,7 @@ def mdb_do_run(mdb_runner, command):
     else:
         raise ValueError('unsupported cores {}'.format(mdb_runner.cores))
 
-    process = mdb_runner.popen_ignore_int(mdb_cmd)
+    process = mdb_runner.popen_ignore_int(mdb_cmd, cwd=mdb_runner.build_dir)
     record_cld_pid(mdb_runner, process)
 
 

--- a/scripts/west_commands/tests/test_mdb.py
+++ b/scripts/west_commands/tests/test_mdb.py
@@ -10,7 +10,7 @@ from unittest.mock import call
 import pytest
 
 from runners.mdb import MdbNsimBinaryRunner, MdbHwBinaryRunner
-from conftest import RC_KERNEL_ELF, RC_BOARD_DIR
+from conftest import RC_KERNEL_ELF, RC_BOARD_DIR, RC_BUILD_DIR
 
 
 TEST_DRIVER_CMD = 'mdb'
@@ -156,7 +156,7 @@ def require_patch(program):
 def test_flash_nsim(require, cc, t, gcp, test_case, mdb_nsim):
     mdb_nsim(test_case['i']).run('flash')
     assert require.called
-    cc.assert_called_once_with(test_case['o'])
+    cc.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_NSIM_DEBUG_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
@@ -166,7 +166,7 @@ def test_flash_nsim(require, cc, t, gcp, test_case, mdb_nsim):
 def test_debug_nsim(require, pii, t, gcp, test_case, mdb_nsim):
     mdb_nsim(test_case['i']).run('debug')
     assert require.called
-    pii.assert_called_once_with(test_case['o'])
+    pii.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_NSIM_MULTICORE_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
@@ -177,9 +177,9 @@ def test_debug_nsim(require, pii, t, gcp, test_case, mdb_nsim):
 def test_multicores_nsim(require, pii, cc, t, gcp, test_case, mdb_nsim):
     mdb_nsim(test_case).run('flash')
     assert require.called
-    cc_calls = [call(TEST_NSIM_CORE1), call(TEST_NSIM_CORE2)]
+    cc_calls = [call(TEST_NSIM_CORE1, cwd=RC_BUILD_DIR), call(TEST_NSIM_CORE2, cwd=RC_BUILD_DIR)]
     cc.assert_has_calls(cc_calls)
-    pii.assert_called_once_with(TEST_NSIM_CORES_LAUNCH)
+    pii.assert_called_once_with(TEST_NSIM_CORES_LAUNCH, cwd=RC_BUILD_DIR)
 
 
 # mdb-hw test cases
@@ -191,7 +191,7 @@ def test_multicores_nsim(require, pii, cc, t, gcp, test_case, mdb_nsim):
 def test_flash_hw(require, cc, t, gcp, test_case, mdb_hw):
     mdb_hw(test_case['i']).run('flash')
     assert require.called
-    cc.assert_called_once_with(test_case['o'])
+    cc.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_HW_DEBUG_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
@@ -201,7 +201,7 @@ def test_flash_hw(require, cc, t, gcp, test_case, mdb_hw):
 def test_debug_hw(require, pii, t, gcp, test_case, mdb_hw):
     mdb_hw(test_case['i']).run('debug')
     assert require.called
-    pii.assert_called_once_with(test_case['o'])
+    pii.assert_called_once_with(test_case['o'], cwd=RC_BUILD_DIR)
 
 @pytest.mark.parametrize('test_case', TEST_HW_MULTICORE_CASES)
 @patch('runners.mdb.get_cld_pid', return_value=(False, -1))
@@ -212,6 +212,6 @@ def test_debug_hw(require, pii, t, gcp, test_case, mdb_hw):
 def test_multicores_hw(require, pii, cc, t, gcp, test_case, mdb_hw):
     mdb_hw(test_case).run('flash')
     assert require.called
-    cc_calls = [call(TEST_HW_CORE1), call(TEST_HW_CORE2)]
+    cc_calls = [call(TEST_HW_CORE1, cwd=RC_BUILD_DIR), call(TEST_HW_CORE2, cwd=RC_BUILD_DIR)]
     cc.assert_has_calls(cc_calls)
-    pii.assert_called_once_with(TEST_HW_CORES_LAUNCH)
+    pii.assert_called_once_with(TEST_HW_CORES_LAUNCH, cwd=RC_BUILD_DIR)


### PR DESCRIPTION
Fix folder where mdb is run by changing it to the build folder explicitly. Otherwise mdb will store the .sc.project folder in the place where twister is launched - so .sc.project folder will be shared across the multiple twister runs and across multiple processes in one twister launch which causes unexpected MDB behavior.

For that we add **kwargs argument to popen_ignore_int method so we can pass a cwd argument to the Popen constructor.