### PR TITLE
test: twister: fix false negative in device test

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -972,6 +972,8 @@ class DeviceHandler(Handler):
                 self.instance.reason = "Failed"
         else:
             self.instance.execution_time = handler_time
+            self.instance.status = "error"
+            self.instance.reason = "No Console Output(Timeout)"
 
         self._final_handle_actions(harness, handler_time)
 


### PR DESCRIPTION
in device test when harness is Test, when there is no console output, the self.state is None,
as at this time the test instance self.instance.state is "pass", as the last step cmake is "pass".
so it will report "pass", but actually there is no console output issue

you can easily reproduce this issue by set
line='' at the begining of the Test.handle function

Fixes #45942
Fixes #45904

Signed-off-by: Hake Huang <hake.huang@oss.nxp.com>