### PR TITLE
Bluetooth: Controller: Fix not clearing Static Random Address on reset

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -52,9 +52,17 @@ uint8_t ll_addr_set(uint8_t addr_type, uint8_t const *const bdaddr)
 	}
 
 	if (addr_type) {
-		memcpy(rnd_addr, bdaddr, BDADDR_SIZE);
+		if (bdaddr) {
+			(void)memcpy(rnd_addr, bdaddr, BDADDR_SIZE);
+		} else {
+			(void)memset(rnd_addr, 0, BDADDR_SIZE);
+		}
 	} else {
-		memcpy(pub_addr, bdaddr, BDADDR_SIZE);
+		if (bdaddr) {
+			(void)memcpy(pub_addr, bdaddr, BDADDR_SIZE);
+		} else {
+			(void)memset(pub_addr, 0, BDADDR_SIZE);
+		}
 	}
 
 	return 0;

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -849,6 +849,9 @@ void ll_reset(void)
 	err = ull_df_reset();
 	LL_ASSERT(!err);
 #endif
+
+	/* clear static random address */
+	(void)ll_addr_set(1U, NULL);
 }
 
 /**


### PR DESCRIPTION
When host issue HCI Reset controller should clear LE Static Random
address. Otherwise controller may incorrectly use one from before
HCI reset insread of rejecting HCI commands.

This was affecting following qualification test cases:
HCI/CCO/BI-51-C
HCI/CCO/BI-53-C
HCI/CCO/BI-54-C
HCI/CCO/BI-56-C
HCI/DDI/BI-06-C
HCI/DDI/BI-07-C

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>