### PR TITLE
device: make all struct device members mutable

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -461,9 +461,9 @@ struct device {
 	/** Address of the API structure exposed by the device instance */
 	const void *api;
 	/** Address of the common device state */
-	struct device_state * const state;
+	struct device_state *state;
 	/** Address of the device instance private data */
-	void * const data;
+	void *data;
 	/** optional pointer to handles associated with the device.
 	 *
 	 * This encodes a sequence of sets of device handles that have
@@ -471,11 +471,11 @@ struct device {
 	 * extracted with dedicated API, such as
 	 * device_required_handles_get().
 	 */
-	Z_DEVICE_HANDLES_CONST device_handle_t * const handles;
+	Z_DEVICE_HANDLES_CONST device_handle_t *handles;
 
 #ifdef CONFIG_PM_DEVICE
 	/** Reference to the device PM resources. */
-	struct pm_device * const pm;
+	struct pm_device *pm;
 #endif
 };
 


### PR DESCRIPTION
All `struct device` members except name, config and api are marked as read-only references. This means that, in practice, a `struct device` can only be initialized statically.

Device constness happens because `Z_DEVICE_DEFINE` defines `struct device`as`const`. This means that one can't modify any field of a `struct device` anyway, so constifying struct members doesn't add much value, if any (unless I'm missing something).

This patch makes all `struct device` references mutable, so that no assumptions on how `struct device` is used are made. In the future, one could e.g. dynamically allocate devices and assign any of the device fields at runtime.