### PR TITLE
net: context: prevent truncating outgoing datagrams

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1660,6 +1660,11 @@ static int context_sendto(struct net_context *context,
 	tmp_len = net_pkt_available_payload_buffer(
 				pkt, net_context_get_ip_proto(context));
 	if (tmp_len < len) {
+		if (net_context_get_type(context) == SOCK_DGRAM) {
+			NET_ERR("Available payload buffer (%zu) is not enough for requested DGRAM (%zu)",
+				tmp_len, len);
+			return -ENOMEM;
+		}
 		len = tmp_len;
 	}
 

--- a/tests/net/socket/udp/CMakeLists.txt
+++ b/tests/net/socket/udp/CMakeLists.txt
@@ -4,6 +4,29 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(socket_udp)
 
+function(generate_c_string FILENAME SIZE)
+  set(FILEPATH ${ZEPHYR_BINARY_DIR}/include/generated/${FILENAME})
+
+  add_custom_command(
+    OUTPUT ${FILEPATH}
+    COMMAND
+    ${PYTHON_EXECUTABLE}
+    ${CMAKE_CURRENT_LIST_DIR}/generate-c-string.py
+    --size ${SIZE}
+    ${FILEPATH})
+
+  generate_unique_target_name_from_filename(${FILEPATH} TARGET_NAME)
+  add_custom_target(${TARGET_NAME} DEPENDS
+    ${FILEPATH})
+  add_dependencies(app ${TARGET_NAME})
+endfunction()
+
+math(EXPR
+  ALL_TX_BUFS_SIZE
+  "${CONFIG_NET_BUF_TX_COUNT} * ${CONFIG_NET_BUF_DATA_SIZE}"
+  OUTPUT_FORMAT DECIMAL)
+generate_c_string(string_all_tx_bufs.inc ${ALL_TX_BUFS_SIZE})
+
 target_include_directories(app PRIVATE ${ZEPHYR_BASE}/subsys/net/ip)
 FILE(GLOB app_sources src/*.c)
 target_sources(app PRIVATE ${app_sources})

--- a/tests/net/socket/udp/generate-c-string.py
+++ b/tests/net/socket/udp/generate-c-string.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022 Golioth, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from argparse import ArgumentParser
+from math import ceil
+
+
+CHUNK = "This is a fragment of generated C string. "
+
+
+parser = ArgumentParser(description="Generate C string of arbitrary size")
+parser.add_argument("-s", "--size", help="Size of string (without NULL termination)",
+                    required=True, type=int)
+parser.add_argument("filepath", help="Output filepath")
+args = parser.parse_args()
+
+
+with open(args.filepath, "w", encoding="UTF-8") as fp:
+    fp.write('"')
+    chunks = CHUNK * ceil(args.size / len(CHUNK))
+    fp.write(chunks[:args.size])
+    fp.write('"')

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -35,12 +35,17 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 	"from across the industry to build a best-in-breed small, scalable, " \
 	"real-time operating system (RTOS) optimized for resource-" \
 	"constrained devices, across multiple architectures."
+/* More than available TX buffers */
+static const char test_str_all_tx_bufs[] =
+#include <string_all_tx_bufs.inc>
+"!"
+;
 
 #define ANY_PORT 0
 #define SERVER_PORT 4242
 #define CLIENT_PORT 9898
 
-static ZTEST_BMEM char rx_buf[400];
+static ZTEST_BMEM char rx_buf[NET_ETH_MTU + 1];
 
 /* Common routine to communicate packets over pair of sockets. */
 static void comm_sendto_recvfrom(int client_sock,
@@ -1212,6 +1217,123 @@ void test_v6_msg_trunc(void)
 		       (struct sockaddr *)&server_addr, sizeof(server_addr));
 }
 
+static void test_dgram_overflow(int sock_c, int sock_s,
+				struct sockaddr *addr_c, socklen_t addrlen_c,
+				struct sockaddr *addr_s, socklen_t addrlen_s,
+				const void *buf, size_t buf_size)
+{
+	int rv;
+
+	rv = bind(sock_s, addr_s, addrlen_s);
+	zassert_equal(rv, 0, "server bind failed");
+
+	rv = bind(sock_c, addr_c, addrlen_c);
+	zassert_equal(rv, 0, "client bind failed");
+
+	rv = connect(sock_c, addr_s, addrlen_s);
+	zassert_equal(rv, 0, "connect failed");
+
+	rv = send(sock_c, buf, buf_size, 0);
+	zassert_equal(rv, -1, "send succeeded");
+	zassert_equal(errno, ENOMEM, "incorrect errno value");
+
+	rv = close(sock_c);
+	zassert_equal(rv, 0, "close failed");
+	rv = close(sock_s);
+	zassert_equal(rv, 0, "close failed");
+}
+
+static void test_dgram_fragmented(int sock_c, int sock_s,
+				  struct sockaddr *addr_c, socklen_t addrlen_c,
+				  struct sockaddr *addr_s, socklen_t addrlen_s,
+				  const void *buf, size_t buf_size)
+{
+	int rv;
+
+	rv = bind(sock_s, addr_s, addrlen_s);
+	zassert_equal(rv, 0, "server bind failed");
+
+	rv = bind(sock_c, addr_c, addrlen_c);
+	zassert_equal(rv, 0, "client bind failed");
+
+	rv = connect(sock_c, addr_s, addrlen_s);
+	zassert_equal(rv, 0, "connect failed");
+
+	rv = send(sock_c, buf, buf_size, 0);
+	zassert_equal(rv, buf_size, "send failed");
+
+	memset(rx_buf, 0, sizeof(rx_buf));
+	rv = recv(sock_s, rx_buf, sizeof(rx_buf), 0);
+	zassert_equal(rv, buf_size, "recv failed");
+	zassert_mem_equal(rx_buf, buf, buf_size, "wrong data");
+
+	rv = close(sock_c);
+	zassert_equal(rv, 0, "close failed");
+	rv = close(sock_s);
+	zassert_equal(rv, 0, "close failed");
+}
+
+void test_v4_dgram_overflow(void)
+{
+	int client_sock;
+	int server_sock;
+	struct sockaddr_in client_addr;
+	struct sockaddr_in server_addr;
+
+	prepare_sock_udp_v4(CONFIG_NET_CONFIG_MY_IPV4_ADDR, ANY_PORT,
+			    &client_sock, &client_addr);
+	prepare_sock_udp_v4(CONFIG_NET_CONFIG_MY_IPV4_ADDR, SERVER_PORT,
+			    &server_sock, &server_addr);
+
+	test_dgram_overflow(client_sock, server_sock,
+			    (struct sockaddr *)&client_addr, sizeof(client_addr),
+			    (struct sockaddr *)&server_addr, sizeof(server_addr),
+			    test_str_all_tx_bufs, NET_ETH_MTU + 1);
+}
+
+void test_v6_dgram_fragmented_or_overflow(void)
+{
+	int client_sock;
+	int server_sock;
+	struct sockaddr_in6 client_addr;
+	struct sockaddr_in6 server_addr;
+
+	prepare_sock_udp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, ANY_PORT,
+			    &client_sock, &client_addr);
+	prepare_sock_udp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, SERVER_PORT,
+			    &server_sock, &server_addr);
+
+	if (IS_ENABLED(CONFIG_NET_IPV6_FRAGMENT)) {
+		test_dgram_fragmented(client_sock, server_sock,
+				      (struct sockaddr *)&client_addr, sizeof(client_addr),
+				      (struct sockaddr *)&server_addr, sizeof(server_addr),
+				      test_str_all_tx_bufs, NET_ETH_MTU + 1);
+	} else {
+		test_dgram_overflow(client_sock, server_sock,
+				    (struct sockaddr *)&client_addr, sizeof(client_addr),
+				    (struct sockaddr *)&server_addr, sizeof(server_addr),
+				    test_str_all_tx_bufs, NET_ETH_MTU + 1);
+	}
+}
+
+void test_v6_dgram_overflow(void)
+{
+	int client_sock;
+	int server_sock;
+	struct sockaddr_in6 client_addr;
+	struct sockaddr_in6 server_addr;
+
+	prepare_sock_udp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, ANY_PORT,
+			    &client_sock, &client_addr);
+	prepare_sock_udp_v6(CONFIG_NET_CONFIG_MY_IPV6_ADDR, SERVER_PORT,
+			    &server_sock, &server_addr);
+
+	test_dgram_overflow(client_sock, server_sock,
+			    (struct sockaddr *)&client_addr, sizeof(client_addr),
+			    (struct sockaddr *)&server_addr, sizeof(server_addr),
+			    BUF_AND_SIZE(test_str_all_tx_bufs));
+}
+
 void test_main(void)
 {
 	k_thread_system_pool_assign(k_current_get());
@@ -1242,7 +1364,10 @@ void test_main(void)
 			 ztest_unit_test(test_v6_sendmsg_with_txtime),
 			 ztest_user_unit_test(test_v6_sendmsg_with_txtime),
 			 ztest_unit_test(test_v4_msg_trunc),
-			 ztest_unit_test(test_v6_msg_trunc)
+			 ztest_unit_test(test_v6_msg_trunc),
+			 ztest_unit_test(test_v4_dgram_overflow),
+			 ztest_unit_test(test_v6_dgram_fragmented_or_overflow),
+			 ztest_unit_test(test_v6_dgram_overflow)
 		);
 
 	ztest_run_test_suite(socket_udp);

--- a/tests/net/socket/udp/testcase.yaml
+++ b/tests/net/socket/udp/testcase.yaml
@@ -10,3 +10,6 @@ tests:
   net.socket.udp.preempt:
     extra_configs:
       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
+  net.socket.udp.ipv6_fragment:
+    extra_configs:
+      - CONFIG_NET_IPV6_FRAGMENT=y


### PR DESCRIPTION
Datagrams should either be fully sent or not sent at all if networking
buffers or network interface MTU does not allow that. So far the behavior
was to truncate outgoing packets, even for datagram sockets.

When there is not enough available payload buffer to fit all requested
data, fail if that happens for datagram socket.

Fixes: #45946