### PR TITLE
modem: ublox-sara-r4: do not truncate outgoing datagrams

### DIFF
--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -352,6 +352,11 @@ static ssize_t send_socket_data(void *obj,
 	 * the socket in one command
 	 */
 	if (buf_len > MDM_MAX_DATA_LENGTH) {
+		if (sock->type == SOCK_DGRAM) {
+			errno = EMSGSIZE;
+			return -1;
+		}
+
 		buf_len = MDM_MAX_DATA_LENGTH;
 	}
 


### PR DESCRIPTION
Do not truncate outgoing datagrams if they do not fit in maximum handled
packet size. Set EMSGSIZE errno and return -1 instead.

Fixes: #45951