### PR TITLE
modem: simcom-sim7080: do not send fragmented data as multiple datagrams

### DIFF
--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -444,6 +444,7 @@ exit:
  */
 static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 {
+	struct modem_socket *sock = obj;
 	ssize_t sent = 0;
 	const char *buf;
 	size_t len;
@@ -453,6 +454,17 @@ static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 	if (get_state() != SIM7080_STATE_NETWORKING) {
 		LOG_ERR("Modem currently not attached to the network!");
 		return -EAGAIN;
+	}
+
+	if (sock->type == SOCK_DGRAM) {
+		/*
+		 * Current implementation only handles single contiguous fragment at a time, so
+		 * prevent sending multiple datagrams.
+		 */
+		if (msghdr_non_empty_iov_count(msg) > 1) {
+			errno = EMSGSIZE;
+			return -1;
+		}
 	}
 
 	for (int i = 0; i < msg->msg_iovlen; i++) {

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -465,8 +465,7 @@ static ssize_t offload_sendmsg(void *obj, const struct msghdr *msg, int flags)
 				if (ret == -EAGAIN) {
 					k_sleep(K_SECONDS(1));
 				} else {
-					sent = ret;
-					break;
+					return ret;
 				}
 			} else {
 				sent += ret;


### PR DESCRIPTION
Check if there are multiple non-empty data fragments passed to sendmsg()
function. If positive, then set EMSGSIZE errno and return -1, as that case
is not handled properly with current implementation.

Fixes: #45953
~~Depends on: #45949~~