### PR TITLE
west.yml: hal_stm32: Use remap info in stm32f1 pinctrl nodes names

### DIFF
--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -83,7 +83,7 @@
 };
 
 &i2c1 {
-	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	pinctrl-0 = <&i2c1_scl_remap1_pb8 &i2c1_sda_remap1_pb9>;
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -74,7 +74,7 @@
 };
 
 &usart3 {
-	pinctrl-0 = <&usart3_tx_pc10 &usart3_rx_pc11>;
+	pinctrl-0 = <&usart3_tx_remap1_pc10 &usart3_rx_remap1_pc11>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 };

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -161,7 +161,7 @@ zephyr_udc0: &usb {
 };
 
 &can1 {
-	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
+	pinctrl-0 = <&can_rx_remap1_pb8 &can_tx_remap1_pb9>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
 	phys = <&transceiver0>;

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -63,7 +63,7 @@
 };
 
 &usart2 {
-	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
+	pinctrl-0 = <&usart2_tx_remap1_pd5 &usart2_rx_remap1_pd6>;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -71,7 +71,7 @@
 };
 
 &i2c1 {
-	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	pinctrl-0 = <&i2c1_scl_remap1_pb8 &i2c1_sda_remap1_pb9>;
 	pinctrl-names = "default";
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -139,7 +139,7 @@
 };
 
 &can1 {
-	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
+	pinctrl-0 = <&can_rx_remap1_pb8 &can_tx_remap1_pb9>;
 	pinctrl-names = "default";
 	/*
 	 * make sure CAN and USB are not enabled at the same time

--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -71,9 +71,15 @@ Changes in this release
     * The previous ``CAN_SILENT_LOOPBACK_MODE`` can be set using the bitmask ``(CAN_MODE_LISTENONLY |
       CAN_MODE_LOOPBACK)``.
 
-* STM32H7 The `CONFIG_NOCACHE_MEMORY` no longer is responsible for disabling
-  data cache when defined. Now the newly introduced `CONFIG_DCACHE=n` explicitly
-  does that.
+  * STM32H7 The `CONFIG_NOCACHE_MEMORY` no longer is responsible for disabling
+    data cache when defined. Now the newly introduced `CONFIG_DCACHE=n` explicitly
+    does that.
+
+  * Converted the STM32F1 pin nodes configuration names to include remap information (in
+    cases other than NO_REMAP/REMAP_0)
+    For instance:
+
+    * ``i2c1_scl_pb8`` renamed to ``i2c1_scl_remap1_pb8``
 
 Removed APIs in this release
 ============================

--- a/west.yml
+++ b/west.yml
@@ -127,7 +127,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 6253094a4147cbd30d2b466c975eb4013ac6be90
+      revision: 51b373cd3455b8c2b9babbf6ff41918116a442ac
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
Fixes #45916

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>