### PR TITLE
soc: arm: st_stm32: h7: support DT-defined MPU regions

### DIFF
--- a/soc/arm/st_stm32/stm32h7/mpu_regions.c
+++ b/soc/arm/st_stm32/stm32h7/mpu_regions.c
@@ -5,6 +5,8 @@
  */
 
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
+
 #include "../../common/cortex_m/arm_mpu_mem_cfg.h"
 
 static const struct arm_mpu_region mpu_regions[] = {
@@ -21,6 +23,8 @@ static const struct arm_mpu_region mpu_regions[] = {
 					 DT_REG_ADDR(DT_NODELABEL(sram3)),
 					 REGION_PPB_ATTR(REGION_256B)),
 #endif
+	/* DT-defined regions */
+	LINKER_DT_REGION_MPU(ARM_MPU_REGION_INIT)
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
Adds the ability to define MPU regions in the DTS.

Some MCUs (i.e. H730) require the MPU region to be configured before it's used (e.g. FMC PSRAM).

In combination with #45969, it is possible to configure the required MPU region for the FMC on
H730 MCU so that the FMC could be used with an external display.

For example:
```
	fmc_ext_mem: fmc_ext_mem@64000000 {
		compatible = "zephyr,memory-region", "mmio-sram";
		reg = <0x64000000 DT_SIZE_M(64)>;
		zephyr,memory-region = "PSRAM2";
		zephyr,memory-region-mpu = "IO";
	};
```