### PR TITLE
nxp_imx: rt: add mcux xbara kconfig option

### DIFF
--- a/drivers/pinctrl/Kconfig.imx
+++ b/drivers/pinctrl/Kconfig.imx
@@ -6,3 +6,10 @@ config PINCTRL_IMX
 	depends on HAS_MCUX_IOMUXC || HAS_IMX_IOMUXC
 	help
 	  Enable pin controller driver for NXP iMX series MCUs
+
+# TODO: Find better place for this option
+config MCUX_XBARA
+	bool "MCUX XBARA driver"
+	depends on HAS_MCUX_XBARA
+	help
+	  Enable the MCUX XBARA driver.

--- a/modules/Kconfig.mcux
+++ b/modules/Kconfig.mcux
@@ -361,4 +361,9 @@ config HAS_MCUX_ADC_ETC
 	  Set if the ADC External Trigger Control module is present
 	  on the SoC.
 
+config HAS_MCUX_XBARA
+	bool
+	help
+	  Set if the XBARA module is present on the SoC.
+
 endif # HAS_MCUX

--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -254,6 +254,7 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_ADC_ETC
 	select HAS_MCUX_SRC
 	select HAS_SWO
+	select HAS_MCUX_XBARA
 
 config SOC_MIMXRT1064
 	bool "SOC_MIMXRT1064"

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 5cefb64458d0c2bac83e940ba520afa6c85832a0
+      revision: b4d43b80ee33d58683072f117c28ca669b0a56b7
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Add the missing XBARA Inter-Peripheral Crossbar Switch module Kconfig option and select it for MIMXRT1062 SOC.

Signed-off-by: Bartosz Bilas [bartosz.bilas@hotmail.com](mailto:bartosz.bilas@hotmail.com)