### PR TITLE
soc: riscv: telink_b91: add dfu support for Telink b91 platform

### DIFF
--- a/boards/riscv/tlsr9518adk80d/Kconfig.defconfig
+++ b/boards/riscv/tlsr9518adk80d/Kconfig.defconfig
@@ -49,4 +49,10 @@ endchoice
 
 endif # BT
 
+# Workaround for not being able to have commas in macro arguments
+DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
+
+config FLASH_LOAD_OFFSET
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
+
 endif

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.dts
@@ -16,6 +16,8 @@
 	aliases {
 		led0 = &led_blue;
 		led1 = &led_green;
+		led2 = &led_white;
+		led3 = &led_red;
 		sw0 = &key_1;
 		pwm-led0 = &pwm_led_blue;
 		pwm-0 = &pwm0;
@@ -69,6 +71,7 @@
 		zephyr,flash = &flash;
 		zephyr,flash-controller = &flash_mspi;
 		zephyr,entropy = &trng0;
+		zephyr,code-partition = &slot0_partition;
 	};
 };
 
@@ -86,6 +89,34 @@
 
 &flash {
 	reg = <0x20000000 0x100000>;
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 0x10000>;
+		};
+		slot0_partition: partition@10000 {
+			label = "image-0";
+			reg = <0x10000 0x70000>;
+		};
+		slot1_partition: partition@80000 {
+			label = "image-1";
+			reg = <0x80000 0x70000>;
+		};
+		scratch_partition: partition@f0000 {
+			label = "image-scratch";
+			reg = <0xf0000 0x4000>;
+		};
+		storage_partition: partition@f4000 {
+			label = "storage";
+			reg = <0xf4000 0x0000b000>;
+		/* region <0xff000 0x1000> is reserved for Telink B91 SDK's data */
+		};
+	};
 };
 
 &gpiob {
@@ -138,36 +169,4 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 	pinctrl-0 = <&i2c_scl_pe1_default &i2c_sda_pe3_default>;
 	pinctrl-names = "default";
-};
-
-&flash_mspi {
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		boot_partition: partition@0 {
-			label = "mcuboot";
-			reg = <0x00000000 0x8000>;
-		};
-		slot0_partition: partition@8000 {
-			label = "image-0";
-			reg = <0x00008000 0x1a000>;
-		};
-		slot1_partition: partition@22000 {
-			label = "image-1";
-			reg = <0x00022000 0x1a000>;
-		};
-		scratch_partition: partition@3c000 {
-			label = "image-scratch";
-			reg = <0x0003c000 0x2000>;
-		};
-		storage_partition: partition@f0000 {
-			label = "storage";
-			reg = <0x000f0000 0x00008000>;
-			/* region 0x000f8000 .. 0x000FFFFF
-			 * is reserved for factory calibration
-			 */
-		};
-	};
 };

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_defconfig
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_defconfig
@@ -16,3 +16,9 @@ CONFIG_UART_CONSOLE=y
 
 # HW DSP options
 CONFIG_TELINK_B91_HWDSP=n
+
+# Buffer for image writter shall be less(multiple of access alignment) or
+# equal to flash page. tlsr9518adk80d boards use external P25Q16 IC as
+# flesh memory. Flash page size of the IC is 256 bytes. So that, it is
+# maximum image writer buffer size for such kind of boards.
+CONFIG_IMG_BLOCK_BUF_SIZE=256

--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -35,6 +35,9 @@
 #define UART_STOP_BIT_1P5  BIT(4)
 #define UART_STOP_BIT_2    BIT(5)
 
+/* TX RX reset bits */
+#define UART_RX_RESET_BIT BIT(6)
+#define UART_TX_RESET_BIT BIT(7)
 
 /* B91 UART registers structure */
 struct uart_b91_t {
@@ -304,6 +307,12 @@ static int uart_b91_driver_init(const struct device *dev)
 	uint8_t bwpc = 0u;
 	volatile struct uart_b91_t *uart = GET_UART(dev);
 	const struct uart_b91_config *cfg = dev->config;
+	struct uart_b91_data *data = dev->data;
+
+	/* Reset Tx, Rx status before usage */
+	uart->status |= UART_RX_RESET_BIT | UART_TX_RESET_BIT;
+	data->rx_byte_index = 0;
+	data->tx_byte_index = 0;
 
 	/* configure pins */
 	status = pinctrl_apply_state(cfg->pcfg, PINCTRL_STATE_DEFAULT);

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.defconfig.series
@@ -50,4 +50,7 @@ config TEST_EXTRA_STACK_SIZE
 	int
 	default 1024
 
+config HAS_FLASH_LOAD_OFFSET
+	default y if BOOTLOADER_MCUBOOT
+
 endif # SOC_SERIES_RISCV_TELINK_B91

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -36,3 +36,7 @@ config SOC_RISCV_TELINK_B91
 	select INCLUDE_RESET_VECTOR
 
 endchoice
+
+config FLASH_BASE_ADDRESS
+	hex
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))

--- a/soc/riscv/riscv-privilege/telink_b91/linker.ld
+++ b/soc/riscv/riscv-privilege/telink_b91/linker.ld
@@ -21,6 +21,7 @@ SECTIONS
 {
 	SECTION_PROLOGUE(vector,,)
 	{
+		. = CONFIG_ROM_START_OFFSET;
 		. = ALIGN(4);
 		KEEP(*(.init.*))
 	} GROUP_LINK_IN(ROM_INIT)


### PR DESCRIPTION
This PR contains functionality required for correct work of Telink b91 platform with DFU subsystem and **mcuboot** bootloader.
It contains following changes:
- updates in default Kconfig and device tree for **tlsr9518adk80d** board
- fixes in UART driver to make it works properly after booting from **mcuboot** bootloader.
- add config for **smp_srv** sample.
- changes in linker script and Kconfig files for b91 soc.

Signed-off-by: Alexandr Kolosov <rikorsev@gmail.com>