### PR TITLE
drivers: flash: stm32_ospi: fix legacy includes

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -8,7 +8,7 @@
 
 #include <errno.h>
 #include <zephyr/kernel.h>
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <zephyr/arch/common/ffs.h>
 #include <zephyr/sys/util.h>
 #include <soc.h>


### PR DESCRIPTION
Adds `zephyr/...` prefix to `toolchain.h` include.

That allows building the OSPI driver with `CONFIG_LEGACY_INCLUDE_PATH=n`.