### PR TITLE
ipc: static_vrings: Support DT-defined buffer size

### DIFF
--- a/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
@@ -44,3 +44,10 @@ properties:
 
       When this property is missing a default priority of <0 PRIO_COOP> is
       assumed.
+
+  zephyr,buffer-size:
+    type: int
+    required: false
+    description: |
+      The size of the buffer used to send data between host and remote. Default
+      value is RPMSG_BUFFER_SIZE. This property must be the same for host and remote.

--- a/include/zephyr/ipc/ipc_rpmsg.h
+++ b/include/zephyr/ipc/ipc_rpmsg.h
@@ -91,6 +91,7 @@ struct ipc_rpmsg_instance {
  *
  *  @param instance Pointer to the RPMsg instance struct.
  *  @param role Host / Remote role.
+ *  @param buffer_size Size of the buffer used to send data between host and remote.
  *  @param shm_io SHM IO region pointer.
  *  @param vdev VirtIO device pointer.
  *  @param shb Shared memory region pointer.
@@ -105,6 +106,7 @@ struct ipc_rpmsg_instance {
  */
 int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
 		   unsigned int role,
+		   unsigned int buffer_size,
 		   struct metal_io_region *shm_io,
 		   struct virtio_device *vdev,
 		   void *shb, size_t size,

--- a/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -42,6 +42,7 @@
 			mbox-names = "tx", "rx";
 			role = "host";
 			zephyr,priority = <1 PRIO_COOP>;
+			zephyr,buffer-size = <128>;
 			status = "okay";
 		};
 	};

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/boards/nrf5340dk_nrf5340_cpunet.overlay
@@ -42,6 +42,7 @@
 			mbox-names = "rx", "tx";
 			role = "remote";
 			zephyr,priority = <2 PRIO_PREEMPT>;
+			zephyr,buffer-size = <128>;
 			status = "okay";
 		};
 	};

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.h
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.h
@@ -138,24 +138,24 @@
 #define ROLE_HOST		VIRTIO_DEV_DRIVER
 #define ROLE_REMOTE		VIRTIO_DEV_DEVICE
 
-static inline size_t vq_ring_size(unsigned int num)
+static inline size_t vq_ring_size(unsigned int num, unsigned int buf_size)
 {
-	return (RPMSG_BUFFER_SIZE * num);
+	return (buf_size * num);
 }
 
-static inline size_t shm_size(unsigned int num)
+static inline size_t shm_size(unsigned int num, unsigned int buf_size)
 {
-	return (VDEV_STATUS_SIZE + (VRING_COUNT * vq_ring_size(num)) +
+	return (VDEV_STATUS_SIZE + (VRING_COUNT * vq_ring_size(num, buf_size)) +
 	       (VRING_COUNT * vring_size(num, VRING_ALIGNMENT)));
 }
 
-static inline unsigned int optimal_num_desc(size_t shm_size)
+static inline unsigned int optimal_num_desc(size_t shm_size, unsigned int buf_size)
 {
 	size_t available, single_alloc;
 	unsigned int num_desc;
 
 	available = shm_size - VDEV_STATUS_SIZE;
-	single_alloc = VRING_COUNT * (vq_ring_size(1) + vring_size(1, VRING_ALIGNMENT));
+	single_alloc = VRING_COUNT * (vq_ring_size(1, buf_size) + vring_size(1, VRING_ALIGNMENT));
 
 	num_desc = (unsigned int) (available / single_alloc);
 

--- a/subsys/ipc/ipc_service/lib/ipc_rpmsg.c
+++ b/subsys/ipc/ipc_service/lib/ipc_rpmsg.c
@@ -71,6 +71,7 @@ int ipc_rpmsg_register_ept(struct ipc_rpmsg_instance *instance, unsigned int rol
 
 int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
 		   unsigned int role,
+		   unsigned int buffer_size,
 		   struct metal_io_region *shm_io,
 		   struct virtio_device *vdev,
 		   void *shb, size_t size,
@@ -87,9 +88,16 @@ int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
 	}
 
 	if (role == RPMSG_HOST) {
+		struct rpmsg_virtio_config config;
+
+		config.h2r_buf_size = (uint32_t) buffer_size;
+		config.r2h_buf_size = (uint32_t) buffer_size;
+
 		rpmsg_virtio_init_shm_pool(&instance->shm_pool, shb, size);
-		return rpmsg_init_vdev(&instance->rvdev, vdev, bind_cb,
-				       shm_io, &instance->shm_pool);
+
+		return rpmsg_init_vdev_with_config(&instance->rvdev, vdev, bind_cb,
+						   shm_io, &instance->shm_pool,
+						   &config);
 	} else {
 		return rpmsg_init_vdev(&instance->rvdev, vdev, bind_cb, shm_io, NULL);
 	}


### PR DESCRIPTION
Recently OpenAMP introduced the possibility to set the sizes for TX and
RX buffers per created instance. Expose this also to Zephyr users by
using a DT property "buffer-size".

Signed-off-by: Carlo Caione <ccaione@baylibre.com>