### PR TITLE
ipc: static_vrings: Drop support for timeout

### DIFF
--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -251,6 +251,7 @@ int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len);
  *		 backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
  *  @retval -ENOTSUP when the operation is not supported by backend.
+ *  @retval -ENOBUFS when there are no TX buffers available.
  *
  *  @retval size TX buffer size on success.
  *  @retval other errno codes depending on the implementation of the backend.

--- a/include/zephyr/ipc/ipc_service_backend.h
+++ b/include/zephyr/ipc/ipc_service_backend.h
@@ -80,6 +80,7 @@ struct ipc_service_backend {
 	 *
 	 *  @retval -EINVAL when instance is invalid.
 	 *  @retval -ENOTSUP when the operation is not supported.
+	 *  @retval -ENOBUFS when there are no TX buffers available.
 	 *
 	 *  @retval size TX buffer size on success.
 	 *  @retval other errno codes depending on the implementation of the

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
@@ -255,7 +255,7 @@ static void ipc1_entry(void *dummy0, void *dummy1, void *dummy2)
 
 		printk("REMOTE [1]: %d\n", *((unsigned char *) recv_data));
 
-		ret = ipc_service_get_tx_buffer(&ipc1_ept, &data, &len, K_FOREVER);
+		ret = ipc_service_get_tx_buffer(&ipc1_ept, &data, &len, K_NO_WAIT);
 		if (ret < 0) {
 			printk("ipc_service_get_tx_buffer failed with ret %d\n", ret);
 			break;

--- a/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
@@ -249,7 +249,7 @@ static void ipc1_entry(void *dummy0, void *dummy1, void *dummy2)
 		uint32_t len = 0;
 		void *data;
 
-		ret = ipc_service_get_tx_buffer(&ipc1_ept, &data, &len, K_FOREVER);
+		ret = ipc_service_get_tx_buffer(&ipc1_ept, &data, &len, K_NO_WAIT);
 		if (ret < 0) {
 			printk("ipc_service_get_tx_buffer failed with ret %d\n", ret);
 			break;


### PR DESCRIPTION
The ipc_service_get_tx_buffer() has a timeout parameter that can be used
to wait a certain amount of time for a TX buffer to be available.

Unfortunately, for the static vrings backend, an asymmetry
between remote and host exists that makes the usage of this parameter
confusing when the user requests a buffer when no buffers are available
at that time.

When the remote endpoints requests a TX buffer specifying a certain
size and there are no TX buffers available, the function ignores the
parameter and ipc_service_get_tx_buffer() immediately returns -ENOMEM.

The same case on the host endpoint works correctly only when the
specified timeout is <= 15 seconds. All timeouts > 15 seconds simply
returns -EIO after 15 seconds.

Instead of trying to implement a timeout mechanism in the backend,
remove support for any timeout different from K_NO_WAIT and offload the
retry task to the user.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

Fixes: #45934