### PR TITLE
includes: shell: uart: fix legacy includes

### DIFF
--- a/include/zephyr/shell/shell_uart.h
+++ b/include/zephyr/shell/shell_uart.h
@@ -10,7 +10,7 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/atomic.h>
-#include "mgmt/mcumgr/smp_shell.h"
+#include <zephyr/mgmt/mcumgr/smp_shell.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
Adds `zephyr/...` prefix to `smp_shell.h` include.

That allows building with `CONFIG_LEGACY_INCLUDE_PATH=n`.