### PR TITLE
ci: Run twister with forced color output

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -110,7 +110,7 @@ jobs:
           if [ -s testplan.json ]; then
             echo "::set-output name=report_needed::1";
             # Full twister but with options based on changes
-            ./scripts/twister --inline-logs -M -N -v --load-tests testplan.json --retry-failed 2
+            ./scripts/twister --force-color --inline-logs -M -N -v --load-tests testplan.json --retry-failed 2
           else
             # if nothing is run, skip reporting step
             echo "::set-output name=report_needed::0";

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -86,7 +86,7 @@ jobs:
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           mkdir -p coverage/reports
-          ./scripts/twister -N -v --filter runnable -p ${{ matrix.platform }} --coverage -T tests
+          ./scripts/twister --force-color -N -v --filter runnable -p ${{ matrix.platform }} --coverage -T tests
 
       - name: Generate Coverage Report
         run: |

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -131,7 +131,7 @@ jobs:
     env:
       ZEPHYR_SDK_INSTALL_DIR: /opt/toolchains/zephyr-sdk-0.14.2
       CLANG_ROOT_DIR: /usr/lib/llvm-12
-      TWISTER_COMMON: ' --inline-logs -v -N -M --retry-failed 3 '
+      TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all'
       PR_OPTIONS: ' --clobber-output --integration'
       PUSH_OPTIONS: ' --clobber-output -M'

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -4716,4 +4716,5 @@ class HardwareMap:
 
         print(tabulate(table, headers=header, tablefmt="github"))
 
-colorama.init()
+def init(colorama_strip):
+    colorama.init(strip=colorama_strip)

--- a/scripts/twister
+++ b/scripts/twister
@@ -205,6 +205,7 @@ except ImportError:
 
 sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/pylib/twister"))
 
+import twisterlib
 from twisterlib import HardwareMap, TestPlan, SizeCalculator, CoverageTool, ExecutionCounter
 
 logger = logging.getLogger('twister')
@@ -492,6 +493,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         built and if a test is runnable (emulation or a connected device), it
         is run. This option allows for example to only build tests that can
         actually be run. Runnable is a subset of buildable.""")
+
+    parser.add_argument("--force-color", action="store_true",
+                        help="Always output ANSI color escape sequences "
+                             "even when the output is redirected (not a tty)")
 
     parser.add_argument("--force-toolchain", action="store_true",
                         help="Do not filter based on toolchain, use the set "
@@ -833,9 +838,13 @@ def setup_logging(outdir, log_file, verbose, timestamps):
 def main():
     start_time = time.time()
 
-    colorama.init()
-
     options = parse_arguments()
+
+    # Configure color output
+    color_strip = False if options.force_color else None
+
+    colorama.init(strip=color_strip)
+    twisterlib.init(colorama_strip=color_strip)
 
     previous_results = None
     # Cleanup


### PR DESCRIPTION
The GitHub Actions runner redirects the stdout and stderr console
outputs and, now that twister properly invokes the Colorama module
initialisation function, the color output is disabled when running the
twister in the CI.

This commit adds the `--force-color` option when invoking the twister
so that the ANSI color escape sequences are output even when the output
is redirected by the GitHub Actions runner (note that the web console
properly displays the color escape sequences).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This fixes the side effect introduced by #45897, in which the colorised output from the twister is disabled when running in the CI.