### PR TITLE
samples: tfm: Add fixed PID to custom partition

### DIFF
--- a/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_manifest_list.yaml.in
+++ b/samples/tfm_integration/tfm_secure_partition/dummy_partition/tfm_manifest_list.yaml.in
@@ -10,6 +10,7 @@
   "type": "manifest_list",
   "version_major": 0,
   "version_minor": 1,
+  "pid": 1000,
   "manifest_list": [
     {
       "name": "Dummy Partition",


### PR DESCRIPTION
As per 'Adding Secure Partition' in the TF-M documentation,
every secure partition must have a unique 32-bit partition ID.

If no value is provided, one will be auto-allocated by the
TF-M build system, but this can lead to unpredictable behaviour
in some cases. One example is key derivation where the partition
ID is used as part of the key derivation inputs. Different builds
can results in different PID values being assigned, resulting
in inconsistent key derivation output.

To avoid these problems, this commit sets a fixed PID as a
best pratice.

A value of 1000 has been set to place it within the
'PSA and user Partitions' range (256 - 2999) described in
the [documentation][1].

[1]: https://git.trustedfirmware.org/TF-M/trusted-firmware-m.git/tree/docs/integration_guide/services/tfm_secure_partition_addition.rst