### PR TITLE
test: Enable the GPIO tests on mec172xevb_assy6906

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/mec172xevb_assy6906.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/mec172xevb_assy6906.overlay
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+
+		/*
+		 * Connect the JP71 pin 11 and 13 to test the GPIO loopback
+		 */
+		in-gpios  = <&gpio_140_176 14 0>; /* GPIO_156, JP71 Pin 11 */
+		out-gpios = <&gpio_140_176 15 0>; /* GPIO_157, JP71 Pin 13 */
+	};
+};


### PR DESCRIPTION
Enable testcases under tests/drivers/gpio/gpio_basic_api
To run in twister, "-X gpio_loopback" parameter is needed

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>