### PR TITLE
Ztest userspace

### DIFF
--- a/subsys/testsuite/CMakeLists.txt
+++ b/subsys/testsuite/CMakeLists.txt
@@ -8,7 +8,3 @@ zephyr_include_directories_ifdef(CONFIG_TEST
 add_subdirectory_ifdef(CONFIG_COVERAGE_GCOV coverage)
 
 zephyr_library_sources_ifdef(CONFIG_TEST_BUSY_SIM busy_sim/busy_sim.c)
-
-if(NOT BOARD STREQUAL unit_testing)
-  zephyr_linker_sources(RODATA include/ztest.ld)
-endif()

--- a/subsys/testsuite/include/ztest.ld
+++ b/subsys/testsuite/include/ztest.ld
@@ -1,5 +1,0 @@
-/*
- * Copyright 2021 Google LLC
- *
- * SPDX-License-Identifier: Apache-2.0
- */

--- a/subsys/testsuite/ztest/include/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/ztest_test_new.h
@@ -56,7 +56,7 @@ struct ztest_suite_stats {
  */
 struct ztest_suite_node {
 	/** The name of the test suite. */
-	const char * const name;
+	const char *const name;
 	/**
 	 * Setup function to run before running this suite
 	 *
@@ -90,13 +90,12 @@ struct ztest_suite_node {
 	 */
 	bool (*const predicate)(const void *state);
 	/** Stats */
-	struct ztest_suite_stats * const stats;
+	struct ztest_suite_stats *const stats;
 };
 
 extern struct ztest_suite_node _ztest_suite_node_list_start[];
 extern struct ztest_suite_node _ztest_suite_node_list_end[];
 #define ZTEST_SUITE_COUNT (_ztest_suite_node_list_end - _ztest_suite_node_list_start)
-
 
 /**
  * Create and register a ztest suite. Using this macro creates a new test suite (using
@@ -112,17 +111,17 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
  * @param after_fn The function to call after each unit test in this suite
  * @param teardown_fn The function to call after running all the tests in this suite
  */
-#define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)  \
-	struct ztest_suite_stats UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME);        \
-	static const STRUCT_SECTION_ITERABLE(ztest_suite_node,				\
-				       UTIL_CAT(z_ztest_test_node_, SUITE_NAME)) = {    \
-		.name = STRINGIFY(SUITE_NAME),                                          \
-		.setup = (setup_fn),                                                    \
-		.before = (before_fn),                                                  \
-		.after = (after_fn),                                                    \
-		.teardown = (teardown_fn),                                              \
-		.predicate = PREDICATE,                                                 \
-		.stats = &UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME),               \
+#define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)             \
+	struct ztest_suite_stats UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME);                   \
+	static const STRUCT_SECTION_ITERABLE(ztest_suite_node,                                     \
+					     UTIL_CAT(z_ztest_test_node_, SUITE_NAME)) = {         \
+		.name = STRINGIFY(SUITE_NAME),                                                     \
+		.setup = (setup_fn),                                                               \
+		.before = (before_fn),                                                             \
+		.after = (after_fn),                                                               \
+		.teardown = (teardown_fn),                                                         \
+		.predicate = PREDICATE,                                                            \
+		.stats = &UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME),                          \
 	}
 /**
  * Run the registered unit tests which return true from their pragma function.


### PR DESCRIPTION
Clean up a few loose ends left over from https://github.com/zephyrproject-rtos/zephyr/pull/45262. The PR was merged in order to make the 3.1 release. This change simply cleans up a few things that don't need to make it into the release. There's no time rush on it to merge.