### PR TITLE
Bluetooth: Mesh: Configurable RPL module

### DIFF
--- a/subsys/bluetooth/mesh/CMakeLists.txt
+++ b/subsys/bluetooth/mesh/CMakeLists.txt
@@ -12,7 +12,6 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH
     subnet.c
     app_keys.c
     transport.c
-    rpl.c
     heartbeat.c
     crypto.c
     access.c
@@ -26,6 +25,8 @@ zephyr_library_sources_ifdef(CONFIG_BT_MESH_ADV_LEGACY adv_legacy.c)
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_ADV_EXT adv_ext.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_SETTINGS settings.c)
+
+zephyr_library_sources_ifdef(CONFIG_BT_MESH_RPL_STORAGE_MODE_SETTINGS rpl.c)
 
 zephyr_library_sources_ifdef(CONFIG_BT_MESH_LOW_POWER lpn.c)
 

--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -289,6 +289,46 @@ config BT_MESH_CRPL
 	  protection list. This option is similar to the network message
 	  cache size, but has a different purpose.
 
+choice BT_MESH_RPL_STORAGE_MODE
+	prompt "Replay protection list storage mode"
+	default BT_MESH_RPL_STORAGE_MODE_SETTINGS
+
+config BT_MESH_RPL_STORAGE_MODE_SETTINGS
+	bool "Persistent storage of RPL in Settings"
+	help
+	  Persistent storage of RPL in Settings. If BT_SETTINGS is not
+	  enabled this choise will provide a non-persistent implementation
+	  variant of the RPL list.
+
+endchoice
+
+if BT_MESH_RPL_STORAGE_MODE_SETTINGS && BT_SETTINGS
+
+config BT_MESH_RPL_STORE_TIMEOUT
+	int "Minimum interval after which unsaved RPL entries are updated in the settings subsystem"
+	range -1 1000000
+	default 5
+	help
+	  This value defines in seconds how soon unsaved RPL entries
+	  gets written to the persistent storage. Setting this value
+	  to a large number may lead to security vulnerabilities if a node
+	  gets powered off before the timer is fired. When flash is used
+	  as the persistent storage setting this value to a low number
+	  may wear out flash sooner or later. However, if the RPL gets
+	  updated infrequently a value as low as 0 (write immediately)
+	  may make sense. Setting this value to -1 will disable this timer.
+	  In this case, a user is responsible to store pending RPL entries
+	  using @ref bt_mesh_rpl_pending_store. In the mean time, when
+	  IV Index is updated, the outdated RPL entries will still be
+	  stored by @ref BT_MESH_STORE_TIMEOUT. Finding the right balance
+	  between this timeout and calling @ref bt_mesh_rpl_pending_store
+	  may reduce a risk of security vulnerability and flash wear out.
+	  Failure to store the RPL and becoming vulnerable after reboot
+	  will cause the device to not perform the replay protection
+	  required by the spec.
+
+endif # BT_MESH_RPL_STORAGE_MODE_SETTINGS && BT_SETTINGS
+
 config BT_MESH_MSG_CACHE_SIZE
 	int "Network message cache size"
 	default 32
@@ -844,29 +884,6 @@ config BT_MESH_SEQ_STORE_RATE
 	  will add this number to the last stored one, so that it starts
 	  off with a value that's guaranteed to be larger than the last
 	  one used before power off.
-
-config BT_MESH_RPL_STORE_TIMEOUT
-	int "Minimum interval after which unsaved RPL entries are updated in storage"
-	range -1 1000000
-	default 5
-	help
-	  This value defines in seconds how soon unsaved RPL entries
-	  gets written to the persistent storage. Setting this value
-	  to a large number may lead to security vulnerabilities if a node
-	  gets powered off before the timer is fired. When flash is used
-	  as the persistent storage setting this value to a low number
-	  may wear out flash sooner or later. However, if the RPL gets
-	  updated infrequently a value as low as 0 (write immediately)
-	  may make sense. Setting this value to -1 will disable this timer.
-	  In this case, a user is responsible to store pending RPL entries
-	  using @ref bt_mesh_rpl_pending_store. In the mean time, when
-	  IV Index is updated, the outdated RPL entries will still be
-	  stored by @ref BT_MESH_STORE_TIMEOUT. Finding the right balance
-	  between this timeout and calling @ref bt_mesh_rpl_pending_store
-	  may reduce a risk of security vulnerability and flash wear out.
-	  Failure to store the RPL and becoming vulnerable after reboot
-	  will cause the device to not perform the replay protection
-	  required by the spec.
 
 endif # BT_SETTINGS
 

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -31,6 +31,12 @@
 #include "settings.h"
 #include "cfg.h"
 
+#ifdef CONFIG_BT_MESH_RPL_STORE_TIMEOUT
+#define RPL_STORE_TIMEOUT CONFIG_BT_MESH_RPL_STORE_TIMEOUT
+#else
+#define RPL_STORE_TIMEOUT (-1)
+#endif
+
 static struct k_work_delayable pending_store;
 static ATOMIC_DEFINE(pending_flags, BT_MESH_SETTINGS_FLAG_COUNT);
 
@@ -111,10 +117,10 @@ void bt_mesh_settings_store_schedule(enum bt_mesh_settings_flag flag)
 
 	if (atomic_get(pending_flags) & NO_WAIT_PENDING_BITS) {
 		timeout_ms = 0;
-	} else if (CONFIG_BT_MESH_RPL_STORE_TIMEOUT >= 0 &&
+	} else if (IS_ENABLED(CONFIG_BT_MESH_RPL_STORAGE_MODE_SETTINGS) && RPL_STORE_TIMEOUT >= 0 &&
 		   atomic_test_bit(pending_flags, BT_MESH_SETTINGS_RPL_PENDING) &&
 		   !(atomic_get(pending_flags) & GENERIC_PENDING_BITS)) {
-		timeout_ms = CONFIG_BT_MESH_RPL_STORE_TIMEOUT * MSEC_PER_SEC;
+		timeout_ms = RPL_STORE_TIMEOUT * MSEC_PER_SEC;
 	} else {
 		timeout_ms = CONFIG_BT_MESH_STORE_TIMEOUT * MSEC_PER_SEC;
 	}
@@ -142,8 +148,8 @@ static void store_pending(struct k_work *work)
 {
 	BT_DBG("");
 
-	if (atomic_test_and_clear_bit(pending_flags,
-				      BT_MESH_SETTINGS_RPL_PENDING)) {
+	if (IS_ENABLED(CONFIG_BT_MESH_RPL_STORAGE_MODE_SETTINGS) &&
+	    atomic_test_and_clear_bit(pending_flags, BT_MESH_SETTINGS_RPL_PENDING)) {
 		bt_mesh_rpl_pending_store(BT_MESH_ADDR_ALL_NODES);
 	}
 


### PR DESCRIPTION
Introduce configuration options for chosen RPL implementations.

This will allow introducing alternate persistent storage schemes
for the replay protection list.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>