### PR TITLE
manifest: MCUboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -174,7 +174,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: e86f575f68fdac2cab1898e0a893c8c6d8fd0fa1
+      revision: e58ea98aec6e5539c5f872a98059e461d0155bbb
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
bring fixes from mcu-tools/mcuboot

- disables CONFIG_USB_DEVICE_REMOTE_WAKEUP as it is unsupported by MCUboot
- fix CONFIG_MCUBOOT_INDICATION_LED usage
- bootutil: zephyr: Fix not including tinycrypt path when needed
- bootutil: zephyr: Fix not linking with mbedtls when needed
- boot: zephyr: add Kconfig for arm cortex-m that implements a cache

fixes #46020

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>