### PR TITLE
test: Remove the TC_XXX macro in tests/arch/arm/arm_runtime_nmi

### DIFF
--- a/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -18,12 +18,13 @@
 
 extern void z_NmiHandlerSet(void (*pHandler)(void));
 
+static bool nmi_triggered;
+
 static void nmi_test_isr(void)
 {
-	printk("NMI received (test_handler_isr)! Rebooting...\n");
+	printk("NMI triggered (test_handler_isr)!\n");
 	/* ISR triggered correctly: test passed! */
-	TC_END_RESULT(TC_PASS);
-	TC_END_REPORT(TC_PASS);
+	nmi_triggered = true;
 }
 
 /**
@@ -49,7 +50,6 @@ void test_arm_runtime_nmi(void)
 {
 	uint32_t i = 0U;
 
-	TC_START("nmi_test_isr");
 	/* Configure the NMI isr */
 	z_NmiHandlerSet(nmi_test_isr);
 
@@ -60,6 +60,8 @@ void test_arm_runtime_nmi(void)
 
 	/* Trigger NMI: Should fire immediately */
 	SCB->ICSR |= SCB_ICSR_NMIPENDSET_Msk;
+
+	zassert_true(nmi_triggered, "Isr not triggered!\n");
 }
 /**
  * @}

--- a/tests/arch/arm/arm_runtime_nmi/testcase.yaml
+++ b/tests/arch/arm/arm_runtime_nmi/testcase.yaml
@@ -1,5 +1,5 @@
 tests:
   arch.interrupt.arm.nmi:
-    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE
+    filter: CONFIG_ARMV6_M_ARMV8_M_BASELINE or CONFIG_ARMV7_M_ARMV8_M_MAINLINE and not CONFIG_BUILD_WITH_TFM
     arch_allow: arm
     tags: nmi interrupt arm


### PR DESCRIPTION
As the test case is using ztest framework, so the TC_XXX macro
is never needed.

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>