### PR TITLE
manifest: update lvgl revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -163,7 +163,7 @@ manifest:
       revision: 12019623bbad9eb54fe51066847a7cbd4b4eac57
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: 9955c3e1e4f361884e938dc016da5a715a4527fe
+      revision: df717ac87a9fd80246cc8df24554475e59bda21f
       path: modules/lib/gui/lvgl
     - name: lz4
       revision: 8e303c264fc21c2116dc612658003a22e933124d


### PR DESCRIPTION
Latest revision fixes compilation of LVGL when
CONFIG_LEGACY_INCLUDE_PATH=n.

Fixes #45911 