### PR TITLE
Bluetooth: controller: Tie Configure Data Path to Read Supported Codecs

### DIFF
--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -245,6 +245,7 @@ config BT_CTLR_ISOAL_SINKS
 config BT_CTLR_ISO_VENDOR_DATA_PATH
 	bool "Vendor-specific ISO data path"
 	depends on BT_CTLR_SYNC_ISO || BT_CTLR_CONN_ISO
+	select BT_CTLR_HCI_CODEC_AND_DELAY_INFO
 
 choice BT_CTLR_TX_PWR
 	prompt "Tx Power"

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -604,7 +604,7 @@ static void write_auth_payload_timeout(struct net_buf *buf,
 }
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
-#if defined(CONFIG_BT_CTLR_ISO)
+#if defined(CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO)
 static void configure_data_path(struct net_buf *buf,
 				struct net_buf **evt)
 {
@@ -624,7 +624,7 @@ static void configure_data_path(struct net_buf *buf,
 	rp = hci_cmd_complete(evt, sizeof(*rp));
 	rp->status = status;
 }
-#endif /* CONFIG_BT_CTLR_ISO */
+#endif /* CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO */
 
 #if defined(CONFIG_BT_CONN)
 static void read_tx_power_level(struct net_buf *buf, struct net_buf **evt)
@@ -694,11 +694,11 @@ static int ctrl_bb_cmd_handle(uint16_t  ocf, struct net_buf *cmd,
 		break;
 #endif /* CONFIG_BT_CTLR_LE_PING */
 
-#if defined(CONFIG_BT_CTLR_ISO)
+#if defined(CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO)
 	case BT_OCF(BT_HCI_OP_CONFIGURE_DATA_PATH):
 		configure_data_path(cmd, evt);
 		break;
-#endif /* CONFIG_BT_CTLR_ISO */
+#endif /* CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO */
 
 	default:
 		return -EINVAL;
@@ -973,8 +973,8 @@ static void read_supported_commands(struct net_buf *buf, struct net_buf **evt)
 #if defined(CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO)
 	/* Read Supported Codecs */
 	rp->commands[29] |= BIT(5);
-	/* Read Supported Codecs [v2], Codec Capabilities, Controller Delay */
-	rp->commands[45] |= BIT(2) | BIT(3) | BIT(4);
+	/* Read Supported Codecs [v2], Codec Capabilities, Controller Delay, Configure Data Path */
+	rp->commands[45] |= BIT(2) | BIT(3) | BIT(4) | BIT(5);
 #endif /* CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO */
 }
 

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -2877,3 +2877,19 @@ void *ull_rxfifo_release(uint8_t s, uint8_t n, uint8_t f, uint8_t *l, uint8_t *m
 
 	return rx;
 }
+
+#if defined(CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO)
+/* Contains vendor specific argument, function to be implemented by vendors */
+__weak uint8_t ll_configure_data_path(uint8_t data_path_dir,
+				      uint8_t data_path_id,
+				      uint8_t vs_config_len,
+				      uint8_t *vs_config)
+{
+	ARG_UNUSED(data_path_dir);
+	ARG_UNUSED(data_path_id);
+	ARG_UNUSED(vs_config_len);
+	ARG_UNUSED(vs_config);
+
+	return BT_HCI_ERR_CMD_DISALLOWED;
+}
+#endif /* CONFIG_BT_CTLR_HCI_CODEC_AND_DELAY_INFO */

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -136,20 +136,6 @@ __weak bool ll_data_path_configured(uint8_t data_path_dir,
 	return false;
 }
 
-/* Contains vendor specific argument, function to be implemented by vendors */
-__weak uint8_t ll_configure_data_path(uint8_t data_path_dir,
-				      uint8_t data_path_id,
-				      uint8_t vs_config_len,
-				      uint8_t *vs_config)
-{
-	ARG_UNUSED(data_path_dir);
-	ARG_UNUSED(data_path_id);
-	ARG_UNUSED(vs_config_len);
-	ARG_UNUSED(vs_config);
-
-	return BT_HCI_ERR_CMD_DISALLOWED;
-}
-
 uint8_t ll_read_iso_tx_sync(uint16_t handle, uint16_t *seq,
 			    uint32_t *timestamp, uint32_t *offset)
 {


### PR DESCRIPTION
The Configure Data Path command must be included when the read Local
Supported Codecs [v2] command is supported. The Configure Data Path
command is needed when vendor-specific ISO data paths are supported,
but not otherwise tied to ISO. The respective weak function is
therefore moved to ull.c.

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>