### PR TITLE
samples/mgmt/mcumgr: Fix CDC ACM sample build information

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -130,7 +130,8 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
             -b nrf52840dk_nrf52840 \
             samples/subsys/mgmt/mcumgr/smp_svr \
             -- \
-            -DOVERLAY_CONFIG=overlay-cdc.conf
+            -DOVERLAY_CONFIG=overlay-cdc.conf \
+            -DDTC_OVERLAY_FILE=usb.overlay
 
    .. group-tab:: Shell
 


### PR DESCRIPTION
The commit adds missing info on required usb.overlay.

Fixes: #45834

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>