### PR TITLE
Bluetooth: Controller: df: Remove experimental for direction finding

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -34,9 +34,8 @@ config BT_CTLR_CTEINLINE_SUPPORT
 	bool
 
 menuconfig BT_CTLR_DF
-	bool "LE Direction Finding [EXPERIMENTAL]"
+	bool "LE Direction Finding"
 	depends on BT_CTLR_DF_CTE_TX_SUPPORT || BT_CTLR_DF_CTE_RX_SUPPORT
-	select EXPERIMENTAL
 	help
 	  Enable support for Bluetooth 5.1 Direction Finding
 


### PR DESCRIPTION
Removes label experimental for direction finding feature in
Bluetooth Controller.

The feature stays disabled by default because it requires additional
dedicated hardware to be used. Besides that it significantly enlarges
amount of memory used by the Controller.

End user has to enable the feature explicitly by use of configuration
options.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>