### PR TITLE
boards: arduino_nano_33_ble: Fix board initialization code

### DIFF
--- a/boards/arm/arduino_nano_33_ble/board.c
+++ b/boards/arm/arduino_nano_33_ble/board.c
@@ -18,7 +18,7 @@ static int board_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	return gpio_pin_configure_dt(&pull_up, GPIO_OUTPUT_INIT_HIGH);
+	return gpio_pin_configure_dt(&pull_up, GPIO_OUTPUT_HIGH);
 }
 
 SYS_INIT(board_init, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE);


### PR DESCRIPTION
This is a follow-up to commit 1b479d6a8aa25ab0bba59a7aff66726b63304d5d.

Use the `GPIO_OUTPUT_HIGH` flag instead of `GPIO_OUTPUT_INIT_HIGH`
as the latter does not actually configure the pin as an output
(it does not include `GPIO_OUTPUT`) what causes an assertion in
`gpio_pin_configure()` to fail.

Fixes #45856.