### PR TITLE
mgmt/mcumgr/lib: Fix usage of MGMT_ERR_ENOMEM

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/fs_mgmt/src/fs_mgmt.c
@@ -156,7 +156,7 @@ fs_mgmt_file_download(struct mgmt_ctxt *ctxt)
 	     ((off != 0)							||
 		(zcbor_tstr_put_lit(zse, "len") && zcbor_uint64_put(zse, file_len)));
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 /**
@@ -248,7 +248,7 @@ fs_mgmt_file_upload(struct mgmt_ctxt *ctxt)
 
 	/* Send the response. */
 	return fs_mgmt_file_rsp(zse, MGMT_ERR_EOK, fs_mgmt_ctxt.off) ?
-			MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+			MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 #if defined(CONFIG_FS_MGMT_FILE_STATUS)
@@ -297,10 +297,10 @@ fs_mgmt_file_status(struct mgmt_ctxt *ctxt)
 	}
 
 	if (!ok) {
-		return MGMT_ERR_ENOMEM;
+		return MGMT_ERR_EMSGSIZE;
 	}
 
-	return 0;
+	return MGMT_ERR_EOK;
 }
 #endif
 
@@ -438,7 +438,7 @@ fs_mgmt_file_hash_checksum(struct mgmt_ctxt *ctxt)
 	}
 
 	if (!ok) {
-		return MGMT_ERR_ENOMEM;
+		return MGMT_ERR_EMSGSIZE;
 	}
 
 	return MGMT_ERR_EOK;

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -272,7 +272,7 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 	ok = zcbor_tstr_put_lit(zse, "rc")	&&
 	     zcbor_int32_put(zse, rc);
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 static int
@@ -286,7 +286,7 @@ img_mgmt_upload_good_rsp(struct mgmt_ctxt *ctxt)
 	     zcbor_tstr_put_lit(zse, "off")			&&
 	     zcbor_int32_put(zse,  g_img_mgmt_state.off);
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 /**

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -258,7 +258,7 @@ img_mgmt_state_read(struct mgmt_ctxt *ctxt)
 		     zcbor_int32_put(zse, 0);
 	}
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 /**

--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -72,7 +72,7 @@ os_mgmt_echo(struct mgmt_ctxt *ctxt)
 	ok = zcbor_tstr_put_lit(zse, "r")		&&
 	     zcbor_tstr_encode(zse, &value);
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 #endif
 
@@ -224,7 +224,7 @@ static int os_mgmt_taskstat_read(struct mgmt_ctxt *ctxt)
 	}
 
 	if (!ok || !zcbor_map_end_encode(zse, CONFIG_OS_MGMT_TASKSTAT_MAX_NUM_THREADS)) {
-		return MGMT_ERR_ENOMEM;
+		return MGMT_ERR_EMSGSIZE;
 	}
 
 	return 0;
@@ -265,7 +265,7 @@ os_mgmt_mcumgr_params(struct mgmt_ctxt *ctxt)
 	     zcbor_tstr_put_lit(zse, "buf_count")		&&
 	     zcbor_uint32_put(zse, CONFIG_MCUMGR_BUF_COUNT);
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 #endif
 

--- a/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/shell_mgmt/src/shell_mgmt.c
@@ -115,7 +115,7 @@ shell_mgmt_exec(struct mgmt_ctxt *ctxt)
 
 	zcbor_map_end_decode(zsd);
 
-	return ok ? 0 : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 static struct mgmt_handler shell_mgmt_handlers[] = {

--- a/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/stat_mgmt/src/stat_mgmt.c
@@ -106,7 +106,7 @@ stat_mgmt_cb_encode(zcbor_state_t *zse, struct stat_mgmt_entry *entry)
 	bool ok = zcbor_tstr_put_term(zse, entry->name) &&
 		  zcbor_uint32_put(zse, entry->value);
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 /**
@@ -169,12 +169,10 @@ stat_mgmt_show(struct mgmt_ctxt *ctxt)
 		if (rc != MGMT_ERR_EOK) {
 			return rc;
 		}
-	} else {
-		return MGMT_ERR_ENOMEM;
 	}
 
-	ok = zcbor_map_end_encode(zse, counter);
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	ok = ok && zcbor_map_end_encode(zse, counter);
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 /**
@@ -201,7 +199,7 @@ stat_mgmt_list(struct mgmt_ctxt *ctxt)
 	     zcbor_list_start_encode(zse, counter);
 
 	if (!ok) {
-		return MGMT_ERR_ENOMEM;
+		return MGMT_ERR_EMSGSIZE;
 	}
 	/* Iterate the list of stat groups, encoding each group's name in the CBOR
 	 * array.
@@ -215,7 +213,7 @@ stat_mgmt_list(struct mgmt_ctxt *ctxt)
 	} while (ok && cur != NULL);
 
 	if (!ok || !zcbor_list_end_encode(zse, counter)) {
-		return MGMT_ERR_ENOMEM;
+		return MGMT_ERR_EMSGSIZE;
 	}
 
 	return 0;

--- a/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/mgmt/src/mgmt.c
@@ -138,7 +138,7 @@ mgmt_write_rsp_status(struct mgmt_ctxt *ctxt, int errcode)
 	}
 #endif
 
-	return ok ? MGMT_ERR_EOK : MGMT_ERR_ENOMEM;
+	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
 
 void

--- a/subsys/mgmt/mcumgr/lib/smp/src/smp.c
+++ b/subsys/mgmt/mcumgr/lib/smp/src/smp.c
@@ -75,7 +75,7 @@ smp_build_err_rsp(struct smp_streamer *streamer, const struct mgmt_hdr *req_hdr,
 	     zcbor_map_end_encode(zsp, 1);
 
 	if (!ok) {
-		return MGMT_ERR_ENOMEM;
+		return MGMT_ERR_EMSGSIZE;
 	}
 
 	smp_make_rsp_hdr(req_hdr, &rsp_hdr,
@@ -135,7 +135,7 @@ smp_handle_single_payload(struct mgmt_ctxt *cbuf, const struct mgmt_hdr *req_hdr
 		/* End response payload. */
 		if (!zcbor_map_end_encode(cbuf->cnbe->zs, CONFIG_MGMT_MAX_MAIN_MAP_ENTRIES) &&
 		    rc == 0) {
-			rc = MGMT_ERR_ENOMEM;
+			rc = MGMT_ERR_EMSGSIZE;
 		}
 	} else {
 		rc = MGMT_ERR_ENOTSUP;


### PR DESCRIPTION
The commit replaces MGMT_ERR_ENOMEM with MGMT_ERR_EMSGSIZE where it
was used to indicate that SMP response does not fit in response
buffer.

Fixes #44535

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>