### PR TITLE
mgmt/mcumgr/lib: Fix OS taskstat passing incorrect value

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/os_mgmt/src/os_mgmt.c
@@ -140,7 +140,7 @@ os_mgmt_taskstat_encode_stack_info(zcbor_state_t *zse,
 	ok = zcbor_tstr_put_lit(zse, "stksiz")		&&
 	     zcbor_uint64_put(zse, stack_size)		&&
 	     zcbor_tstr_put_lit(zse, "stkuse")		&&
-	     zcbor_uint64_put(zse, stack_unused);
+	     zcbor_uint64_put(zse, stack_used);
 
 	return ok;
 #else


### PR DESCRIPTION
The commit fixes incorrect value being passed as used stack
information and also prevents compilation error when
CONFIG_INIT_STACKS is n.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>