### PR TITLE
Bluetooth: Controller: Fix PHY update for unsupported PHY

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -4671,6 +4671,7 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 		struct lll_conn *lll = &conn->lll;
 		struct node_rx_pdu *rx;
 		uint8_t old_tx, old_rx;
+		uint8_t phy_bitmask;
 
 		/* Acquire additional rx node for Data length notification as
 		 * a peripheral.
@@ -4700,6 +4701,15 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 			conn->llcp_ack = conn->llcp_req;
 		}
 
+		/* supported PHYs mask */
+		phy_bitmask = PHY_1M;
+		if (IS_ENABLED(CONFIG_BT_CTLR_PHY_2M)) {
+			phy_bitmask |= PHY_2M;
+		}
+		if (IS_ENABLED(CONFIG_BT_CTLR_PHY_CODED)) {
+			phy_bitmask |= PHY_CODED;
+		}
+
 		/* apply new phy */
 		old_tx = lll->phy_tx;
 		old_rx = lll->phy_rx;
@@ -4713,7 +4723,10 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 
 		if (conn->llcp.phy_upd_ind.tx) {
-			lll->phy_tx = conn->llcp.phy_upd_ind.tx;
+			if (conn->llcp.phy_upd_ind.tx & phy_bitmask) {
+				lll->phy_tx = conn->llcp.phy_upd_ind.tx &
+					      phy_bitmask;
+			}
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 			eff_tx_time = calc_eff_time(lll->max_tx_octets,
@@ -4723,7 +4736,10 @@ static inline void event_phy_upd_ind_prep(struct ll_conn *conn,
 #endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 		}
 		if (conn->llcp.phy_upd_ind.rx) {
-			lll->phy_rx = conn->llcp.phy_upd_ind.rx;
+			if (conn->llcp.phy_upd_ind.rx & phy_bitmask) {
+				lll->phy_rx = conn->llcp.phy_upd_ind.rx &
+					      phy_bitmask;
+			}
 
 #if defined(CONFIG_BT_CTLR_DATA_LENGTH)
 			eff_rx_time =


### PR DESCRIPTION
Fix PHY update procedure to handle unsupported PHY requested
by peer central device. PHY update complete will not be
generated to Host, connection is maintained on the old
PHY and the Controller will not respond to PDUs received on
the unsupported PHY.

Fixes #46757

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>