### PR TITLE
soc: stm32wb: Move MB_MEM2 linker section to SRAM1

### DIFF
--- a/soc/arm/st_stm32/stm32wb/ipm.ld
+++ b/soc/arm/st_stm32/stm32wb/ipm.ld
@@ -6,4 +6,4 @@
 
    MAPPING_TABLE (NOLOAD) : {_sMAPPING_TABLE = .; *(MAPPING_TABLE); _eMAPPING_TABLE = .; } >SRAM1
    MB_MEM1 (NOLOAD) : { _sMB_MEM1 = .; *(MB_MEM1); _eMB_MEM1 = .; } >SRAM1
-   MB_MEM2 (NOLOAD) : { _sMB_MEM2 = .; *(MB_MEM2); _eMB_MEM2 = .; } >SRAM2
+   MB_MEM2 (NOLOAD) : { _sMB_MEM2 = .; *(MB_MEM2); _eMB_MEM2 = .; } >SRAM1


### PR DESCRIPTION
There was a confusion on MB_MEMx definitions. Both MB_MEM1/2
should be located in SRAM1. Fix this.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>