### PR TITLE
dts: augment the description of the display dts files

### DIFF
--- a/dts/bindings/display/ftdi,ft800.yaml
+++ b/dts/bindings/display/ftdi,ft800.yaml
@@ -1,7 +1,28 @@
 # Copyright (c) 2020 Hubert Miś <hubert.mis@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: FTDI FT800 graphic controller
+description: |
+    FTDI FT800 graphic controller
+
+    - Single chip for Display, Audio and Resistive Touch control
+    - Up to 512 x 512 pixel resolution
+    - 262K colours (6 Red, 6 Green, 6 Blue)
+    - Anti-Aliasing
+    - 2-bit colour dither
+    - Programmable HSYNC/VSYNC timing
+    - Backlight control
+    - Resistive touch control
+    - Object oriented programming approach
+    - Embedded widgets to assist with creating complex images
+    - Mono audio output
+    - 64 in-built polyphonic tones
+    - Decode for mono 8-bit linear PCM, 4-bit ADPCM and μ-Law coding format at sampling frequencies from 8kHz to 48kHz
+    - SPI/I2C interface to host MCU
+    - 1.8V to 3.3V IO levels to host MCU
+    - 3V3 levels on RGB pins
+    - Extended operating temperature range -40°C to 85°C
+    - Available in QFN-48 package (RoHS compliant)
+
 
 compatible: "ftdi,ft800"
 

--- a/dts/bindings/display/gooddisplay,gd7965.yaml
+++ b/dts/bindings/display/gooddisplay,gd7965.yaml
@@ -1,7 +1,18 @@
 # Copyright (c) 2020, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: GD7965 EPD display controller
+description: |
+    GD7965 electronic paper display (EPD) controller
+
+    - System-on-chip (SOC) for EPD (e-paper display)
+    - Timing controller supports several resolutions
+    - Up to 800 source x 600 gate resolution + 1 border + 1 VCOM
+    - 1 bit for white/black and 1 bit for red per pixel
+    - Cascade 2 or more chips cascade mode
+    - Memory (Max.) 800 x 600 x 2 bits SRAM
+    - 3-wire/4-wire (SPI) serial interface
+    - Clock rate up to 20MHz
+    - On-Chip Temperature sensor -25 ~ 50°C  2.0°C / 8-bit status
 
 compatible: "gooddisplay,gd7965"
 

--- a/dts/bindings/display/ilitek,ili9340.yaml
+++ b/dts/bindings/display/ilitek,ili9340.yaml
@@ -2,7 +2,27 @@
 # Copyright (c) 2020, Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9340 320x240 display controller
+description: |
+    ILI9340 320x240 display controller
+
+    - 240 x RGB](H) x 320(V) resolution
+    - a-TFT LCD driver with on-chip full display, RAM 172,800 bytes
+    - System Interfaces
+      - 8-bits, 9-bits, 16-bits, 18-bits interface with 8080-I/8080-II series MCU
+      - 6-bits, 16-bits, 18-bits RGB interface with graphic controller
+      - 3-line / 4-line serial interface
+    - Modes
+      - Full color mode (Idle mode OFF), 262K-color (selectable color depth mode by software)
+      - Reduce color mode (Idle mode ON), 8-color
+      - Power saving sleep mode
+    - On chip functions
+      - VCOM generator and adjustment
+      - Timing generator
+      - Oscillator
+      - DC/DC converter
+      - Line/frame inversion
+      - 4 preset Gamma curves with separate RGB Gamma correction
+    - Dynamic backlight control
 
 compatible: "ilitek,ili9340"
 

--- a/dts/bindings/display/ilitek,ili9341.yaml
+++ b/dts/bindings/display/ilitek,ili9341.yaml
@@ -4,7 +4,27 @@
 # Copyright (c) 2022, Konstantinos Papadopulos <kostas.papadopulos@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9341 320x240 display controller
+description: |
+    ILI9341 320x240 display controller
+
+    - 240 x RGB](H) x 320(V) resolution
+    - a-TFT LCD driver with on-chip full display, RAM 172,800 bytes
+    - System Interfaces
+      - 8-bits, 9-bits, 16-bits, 18-bits interface with 8080-I/8080-II series MCU
+      - 6-bits, 16-bits, 18-bits RGB interface with graphic controller
+      - 3-line / 4-line serial interface
+    - Modes
+      - Full color mode (Idle mode OFF), 262K-color (selectable color depth mode by software)
+      - Reduce color mode (Idle mode ON), 8-color
+      - Power saving sleep mode
+    - On chip functions
+      - VCOM generator and adjustment
+      - Timing generator
+      - Oscillator
+      - DC/DC converter
+      - Line/frame inversion
+      - 1 preset Gamma curves with separate RGB Gamma correction
+    - Content Adaptive Brightness Control
 
 compatible: "ilitek,ili9341"
 

--- a/dts/bindings/display/ilitek,ili9488.yaml
+++ b/dts/bindings/display/ilitek,ili9488.yaml
@@ -1,7 +1,53 @@
 # Copyright (c) 2020, Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-description: ILI9488 320x480 display controller
+description: |
+    ILI9488 320x480 display controller
+
+    - 320 (RGB) (H) x 480 (V) resolution
+    - a-Si TFT LCD Single Chip Driver
+    - Display color modes:
+      - Full color modes
+        - 16.7M colors with dithering function (24-bit data, R: 8-bit, G: 8-bit, B: 8-bit)
+      - Reduced color modes:
+        - 262K colors (18-bit data, R: 6-bit, G: 6-bit, B: 6-bit)
+        - 65K colors(16-bit data, R: 5-bit, G: 6-bit, B: 5-bit)
+        - 8 colors (3-bit data, R: 1-bit, G: 1-bit, B: 1-bit)
+    - Display module:
+      - On-chip Frame Memory size 345,600 bytes, 320 (RGB) (H) x 480 (V) x 18 bits
+      - Supports 960 source channel outputs
+      - Supports up to a maximum of 480 gate lines
+      - Supports 24-bits input image function
+      - Supports column/1-/2-dot inversion
+      - On-module DC VCOM control (-2 to 0V common electrode output voltage range)
+    - Display Interface types:
+      - MIPI-DBI (Display Bus Interface)
+        - Type B (i-80 system), 8-/9-/16-/18-/24-bit bus
+        - Type C (Serial data transfer interface, 3/4-line SPI)
+      - MIPI-DPI (Display Pixel Interface)
+        - Supports 24 bit/pixel (R: 8-bit, G: 8-bit, B: 8-bit)
+        - Supports 18 bit/pixel (R: 6-bit, G: 6-bit, B: 6-bit)
+        - Supports 16 bit/pixel (R: 5-bit, G: 6-bit, B: 5-bit)
+      - MIPI-DSI (Display Serial Interface)
+        - Supports one data lane/maximum speed 500Mbps
+        - Supports DSI version 1.01
+        - Supports D-PHY version 1.00
+    - Power saving modes:
+      - Deep-standby mode
+      - Sleep mode
+    - Other on-chip functions/Miscellaneous
+      - Supports partial display mode
+      - Supports inversion mode
+      - Oscillator for display clock generation
+      - LVD function (GAS bit) prevents image sticking for abnormal power off
+      - Supports DC VCOM driving
+      - DC VCOM voltage generator and adjustment
+      - OTP memory store initialization register settings (MATCDL, VRH1, VRH2 and BT)
+      - MTP (provides 4 times OTP to store DC VCOM setting, ID1/ID2/ID3 setting)
+      - Supports CABC function
+      - Supports 3-Gamma DGC function
+      - Supports dither function. (The dither function is only available in Bypass mode of DPI 24-bit and MIPI-DSI.)
+      - Supports color enhancement function
 
 compatible: "ilitek,ili9488"
 

--- a/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
+++ b/dts/bindings/display/rocktech,rk043fn02h-ct.yaml
@@ -1,7 +1,19 @@
 # Copyright (c) 2019, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-description: Rocktech LCD module with LED backlight and capacitive touch panel
+description: |
+    Rocktech LCD module with LED backlight and capacitive touch panel
+
+    - Display Mode: Normally White transmissive
+    - Viewing Direction: 12 O’CLOCK
+    - Input Signals: RGB 24 bit
+    - Outside Dimensions: 105.5 (W) x67.2(H) x4.35(D) Max With CTP
+    - Active Area: 95.04mm(W)×53.86mm(H)
+    - Number of Pixels: 480(RGB)×272
+    - Dot Pitch 0.198mm(H)×0.198mm(W)
+    - Pixel Arrangement RGB Vertical stripes
+    - Drive IC: OTA5180A
+    - CTP IC: FT5336GQQ
 
 compatible: "rocktech,rk043fn02h-ct"
 

--- a/dts/bindings/display/sharp,ls0xx.yaml
+++ b/dts/bindings/display/sharp,ls0xx.yaml
@@ -1,7 +1,30 @@
 # Copyright (c) 2020, Rohit Gujarathi
 # SPDX-License-Identifier: Apache-2.0
 
-description: Sharp memory display controller
+description: |
+  Sharp memory display controller
+
+  - LS013B7DH03
+    - Reflective active-matrix with slightly transmissive panel of white and black.
+    - 1.28” screen has 128 x 128 resolusion. (16384 pixels stripe array)
+    - Display control by serial data signal communication.
+    - Arbitrary line data renewable.
+    - 1bit internal memory for data storage within the panel.
+    - Thin, light-weight and compact module with monolithic technology.
+    - Super low power consumption TFT panel.
+    - Front polarizer surface is Antiglare
+  - Other models:
+    Type:         Size:   Res. H x V:
+    LS010B7DH04   1,03    128 x 128
+    LS011B7DH03   1,08    160 x 68
+    LS012B7DD01   1.17    184 x 38
+    LS012B7DD06   1,19    240 x 240
+    LS012B7DD06A  1,19    240 x 240
+    LS013B7DH03   1.28    128 x 128
+    LS013B7DH05   1.26    144 x 168
+    LS018B7DH02   1,80    230 x 303
+    LS027B7DH01   2.7     400 x 240
+    LS027B7DH01A  2.7     400 x 240
 
 compatible: "sharp,ls0xx"
 

--- a/dts/bindings/display/sitronix,st7735r.yaml
+++ b/dts/bindings/display/sitronix,st7735r.yaml
@@ -1,7 +1,43 @@
 # Copyright (c) 2020, Kim Bøndergaard <kim@fam-boendergaard.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7735R 160x128 display controller
+description: |
+    ST7735R 160x128 display controller
+
+    - 132 (H) x RGB x 162 (V) bits
+    - LCD Driver Output Circuits:
+      - Source Outputs: 132 RGB channels
+      - Gate Outputs: 162 channels
+      - Common electrode output
+    - Display Colors (Color Mode)
+      - Full Color: 262K, RGB=(666) max., Idle Mode OFF
+      - Color Reduce: 8-color, RGB=(111), Idle Mode ON
+    - Programmable Pixel Color Format (Color Depth) for
+      Various Display Data input Format
+      - 12-bit/pixel: RGB=(444) using the 384k-bit frame memory
+        and LUT
+      - 16-bit/pixel: RGB=(565) using the 384k-bit frame memory
+        and LUT
+      - 18-bit/pixel: RGB=(666) using the 384k-bit frame memory
+        and LUT
+    - Various Interfaces
+      - Parallel 8080-series MCU Interface
+        (8-bit, 9-bit, 16-bit & 18-bit)
+      - Parallel 6800-series MCU Interface
+        (8-bit, 9-bit, 16-bit & 18-bit)
+      - 3-line serial interface
+      - 4-line serial interface
+    - Display Features
+      - Support both normal-black & normal-white LC
+      - Software programmable color depth mode
+    - Built-in Circuits
+      - DC/DC converter
+      - Adjustable VCOM generation
+      - Non-volatile (NV) memory to store initial register setting
+      - Oscillator for display clock generation
+      - Factory default value (module ID, module version, etc) are
+        stored in NV memory
+      - Timing controller
 
 compatible: "sitronix,st7735r"
 

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -2,7 +2,49 @@
 # Copyright (c) 2019, PHYTEC Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: ST7789V 320x240 display controller
+description: |
+  ST7789V 320x240 display controller
+
+  - Single chip TFT-LCD Controller/Driver with On-chip Frame Memory (FM)
+  - Display Resolution: 240*RGB (H) *320(V)
+  - Frame Memory Size: 240 x 320 x 18-bit = 1,382,400 bits
+  - LCD Driver Output Circuits
+    - Source Outputs: 240 RGB Channels
+    - Gate Outputs: 320 Channels
+    - Common Electrode Output
+  - Display Colors (Color Mode)
+    - Full Color: 262K, RGB=(666) max., Idle Mode Off
+    - Color Reduce: 8-color, RGB=(111), Idle Mode On
+  - Programmable Pixel Color Format (Color Depth) for Various Display Data input Format
+    - 12-bit/pixel: RGB=(444)
+    - 16-bit/pixel: RGB=(565)
+    - 18-bit/pixel: RGB=(666)
+  - MCU Interface
+    - Parallel 8080-series MCU Interface (8-bit, 9-bit, 16-bit & 18-bit)
+    - 6/16/18 RGB Interface(VSYNC, HSYNC, DOTCLK, ENABLE, DB[17:0])
+    - Serial Peripheral Interface(SPI Interface)
+    - VSYNC Interface
+  - Display Features
+    - Programmable Partial Display Duty
+    - CABC for saving current consumption
+    - Color enhancement
+  - On Chip Build-In Circuits
+    - DC/DC Converter
+    - Adjustable VCOM Generation
+    - Non-Volatile (NV) Memory to Store Initial Register Setting and Factory Default Value (Module ID,
+      Module Version, etc)
+    - Timing Controller
+    - 4 preset Gamma curve with separated RGB Gamma setting
+  - Build-In NV Memory for LCD Initial Register Setting
+    - 8-bits for ID1 setting
+    - 8-bits for ID2 setting
+    - 8-bits for ID3 setting
+    - 6-bits for VCOM Offset adjustment
+  - Driving Algorithm
+    - Dot Inversion
+    - Column Inversion
+  - Lower Power Consumption
+
 
 compatible: "sitronix,st7789v"
 

--- a/dts/bindings/display/solomon,ssd1306fb-i2c.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-i2c.yaml
@@ -1,7 +1,26 @@
 # Copyright (c) 2020, Marco Peter
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1306 128x64 dot-matrix display controller on I2C bus
+description: |
+    SSD1306 128x64 dot-matrix display controller on I2C bus
+
+    - Resolution: 128 x 64 dot matrix panel
+    - For matrix display
+      - OLED driving output voltage, 15V maximum
+      - Segment maximum source current: 100uA
+      - Common maximum sink current: 15mA
+      - 256 step contrast brightness current control
+    - Embedded 128 x 64 bit SRAM display buffer
+    - Pin selectable MCU Interfaces:
+      - 8-bit 6800/8080-series parallel interface
+      - 3 /4 wire Serial Peripheral Interface
+      - I2C Interface
+    - Screen saving continuous scrolling function in both horizontal and vertical direction
+    - RAM write synchronization signal
+    - Programmable Frame Rate and Multiplexing Ratio
+    - Row Re-mapping and Column Re-mapping
+    - On-Chip Oscillator
+    - Chip layout for COG & COF
 
 compatible: "solomon,ssd1306fb"
 

--- a/dts/bindings/display/solomon,ssd1306fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-spi.yaml
@@ -1,7 +1,26 @@
 # Copyright (c) 2020, Marco Peter
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD1306 128x64 dot-matrix display controller on SPI bus
+description: |
+    SSD1306 128x64 dot-matrix display controller on SPI bus
+
+    - Resolution: 128 x 64 dot matrix panel
+    - For matrix display
+      - OLED driving output voltage, 15V maximum
+      - Segment maximum source current: 100uA
+      - Common maximum sink current: 15mA
+      - 256 step contrast brightness current control
+    - Embedded 128 x 64 bit SRAM display buffer
+    - Pin selectable MCU Interfaces:
+      - 8-bit 6800/8080-series parallel interface
+      - 3 /4 wire Serial Peripheral Interface
+      - I2C Interface
+    - Screen saving continuous scrolling function in both horizontal and vertical direction
+    - RAM write synchronization signal
+    - Programmable Frame Rate and Multiplexing Ratio
+    - Row Re-mapping and Column Re-mapping
+    - On-Chip Oscillator
+    - Chip layout for COG & COF
 
 compatible: "solomon,ssd1306fb"
 

--- a/dts/bindings/display/solomon,ssd16xxfb.yaml
+++ b/dts/bindings/display/solomon,ssd16xxfb.yaml
@@ -1,7 +1,24 @@
 # Copyright (c) 2018, Phytec Messtechnik GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-description: SSD16XX 250x150 EPD display controller
+description: |
+    SSD16XX 250x150 electronic paper display (EPD) controller
+
+    - SSD1633:      160 x 160, Gate Mono Black/White Active Matrix EPD Display Driver with Controller
+                    Build in Ram, waveform control, booster
+    - SSD1681:      200 x 200, Gate Mono Black/White, Mono 3-color Active Matrix EPD Display Driver with Controller
+                    Build in Ram, waveform control, booster
+    - SSD1675B      160 x 296, Gate Mono Black/White, Mono 3-color Active Matrix EPD Display Driver with Controller
+                    Build in Ram, waveform control, booster
+    - SSD1680/80A:  176 x 296, Gate Mono Black/White, Mono 3-color Active Matrix EPD Display Driver with Controller
+                    Build in Ram, waveform control, booster
+    - SSD1619A:     400 x 300, Gate Active Matrix Bi-stable Display Driver with Controller
+                    Build in Ram, waveform control, booster
+    - SSD1683:      400 x 300, Gate Mono Black/White, Mono 3-color Active Matrix EPD Display Driver with Controller
+                    Build in Ram, waveform control, booster
+    - SSD1677:      960 x 680, Gate Mono Black/White, Mono 3-color Active Matrix EPD Display Driver with Controller
+                    Build in Ram, waveform control, booster
+    - SSD1603:      132 x 64, Passive Matrix Cholesteric Display Driver, Built in RAM, waveform control, charge pump
 
 compatible: "solomon,ssd16xxfb"
 

--- a/dts/bindings/display/st,stm32-ltdc.yaml
+++ b/dts/bindings/display/st,stm32-ltdc.yaml
@@ -1,7 +1,33 @@
 # Copyright (c) 2022, Byte-Lab d.o.o. <dev@byte-lab.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: STM32 LCD-TFT display controller
+description: |
+    STM32 LCD-TFT display controller (LTDC)
+
+    - 24-bit RGB Parallel Pixel Output; 8 bits-per-pixel (RGB888)
+    - 2 display layers with dedicated FIFO (64x32-bit)
+    - Color Look-Up Table (CLUT) up to 256 color (256x24-bit) per layer
+    - Supports up to XGA (1024x768) resolution
+    - Programmable timings for different display panels
+    - Programmable Background color
+    - Programmable polarity for HSync, VSync and Data Enable
+    - Up to 8 Input color formats selectable per layer
+      – ARGB8888
+      – RGB888
+      – RGB565
+      – ARGB1555
+      – ARGB4444
+      – L8 (8-bit Luminance or CLUT)
+      – AL44 (4-bit alpha + 4-bit luminance)
+      – AL88 (8-bit alpha + 8-bit luminance)
+    - Pseudo-random dithering output for low bits per channel
+      – Dither width 2-bits for Red, Green, Blue
+    - Flexible blending between two layers using alpha value (per pixel or constant)
+    - Color Keying (transparency color)
+    - Programmable Window position and size
+    - Supports thin film transistor (TFT) color displays
+    - AHB master interface with burst of 16 words
+    - Up to 4 programmable interrupt events
 
 compatible: "st,stm32-ltdc"
 


### PR DESCRIPTION
To better find all the supported display controllers
by their features (OLED, TFT, i2c, spi, motorola 6800,
intel8080, resolution etc.) the description of the display
dts yaml files are augmented with the main features
as stated by the vendors.

Background:
I had to go through the display controller and see if the ssd1306 is the only one for OLEDs. In order to have it easier the next time or for others, I felt it a good idea to have the main features as listed by the manufacturer datasheet / manual (as far as quickly available from the internet) in the dts yaml files description field.