### PR TITLE
mgmt/mcumgr/lib: Use flash_img_bytes_written to check context

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -393,7 +393,7 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data, unsigned i
 		}
 	}
 
-	if (offset != ctx->stream.bytes_written + ctx->stream.buf_bytes) {
+	if (offset != flash_img_bytes_written(ctx) + ctx->stream.buf_bytes) {
 		rc = MGMT_ERR_EUNKNOWN;
 		goto out;
 	}


### PR DESCRIPTION
The commit replaces direct access to flash_img_context, for the
purpose of checking how much data has been written, with call
to the flash_img_bytes_written.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>