### PR TITLE
Fix few missing zephyr/ prefixes

### DIFF
--- a/arch/posix/core/irq.c
+++ b/arch/posix/core/irq.c
@@ -8,7 +8,7 @@
 #include "board_irq.h"
 
 #ifdef CONFIG_IRQ_OFFLOAD
-#include "irq_offload.h"
+#include <zephyr/irq_offload.h>
 
 void arch_irq_offload(irq_offload_routine_t routine, const void *parameter)
 {

--- a/arch/posix/core/posix_core.c
+++ b/arch/posix/core/posix_core.c
@@ -46,7 +46,7 @@
 #include "posix_arch_internal.h"
 #include <zephyr/arch/posix/posix_soc_if.h>
 #include "kernel_internal.h"
-#include "kernel_structs.h"
+#include <zephyr/kernel_structs.h>
 #include "ksched.h"
 #include "kswap.h"
 

--- a/arch/posix/core/swap.c
+++ b/arch/posix/core/swap.c
@@ -13,10 +13,10 @@
  *
  */
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 #include <zephyr/kernel_structs.h>
 #include "posix_core.h"
-#include "irq.h"
+#include <zephyr/irq.h>
 #include "kswap.h"
 #include <zephyr/pm/pm.h>
 

--- a/arch/posix/include/posix_arch_internal.h
+++ b/arch/posix/include/posix_arch_internal.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_ARCH_POSIX_INCLUDE_POSIX_ARCH_INTERNAL_H_
 #define ZEPHYR_ARCH_POSIX_INCLUDE_POSIX_ARCH_INTERNAL_H_
 
-#include "toolchain.h"
+#include <zephyr/toolchain.h>
 
 #define PC_SAFE_CALL(a) pc_safe_call(a, #a)
 

--- a/arch/posix/include/posix_core.h
+++ b/arch/posix/include/posix_core.h
@@ -6,7 +6,7 @@
 #ifndef ZEPHYR_ARCH_POSIX_INCLUDE_POSIX_CORE_H_
 #define ZEPHYR_ARCH_POSIX_INCLUDE_POSIX_CORE_H_
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/arch/xtensa/core/xtensa_backtrace.c
+++ b/arch/xtensa/core/xtensa_backtrace.c
@@ -6,7 +6,7 @@
 
 #include "xtensa/corebits.h"
 #include "xtensa_backtrace.h"
-#include "sys/printk.h"
+#include <zephyr/sys/printk.h>
 #if defined(CONFIG_SOC_ESP32)
 #include "soc/soc_memory_layout.h"
 #elif defined(CONFIG_SOC_FAMILY_INTEL_ADSP)

--- a/arch/xtensa/core/xtensa_intgen.py
+++ b/arch/xtensa/core/xtensa_intgen.py
@@ -94,8 +94,8 @@ cprint("")
 
 # Re-include the core-isa header and be sure our definitions match, for sanity
 cprint("#include <xtensa/config/core-isa.h>")
-cprint("#include <sys/util.h>")
-cprint("#include <sw_isr_table.h>")
+cprint("#include <zephyr/sys/util.h>")
+cprint("#include <zephyr/sw_isr_table.h>")
 cprint("")
 for l in ints_by_lvl:
     for i in ints_by_lvl[l]:

--- a/boards/arc/hsdk/platform.c
+++ b/boards/arc/hsdk/platform.c
@@ -5,7 +5,7 @@
  */
 
 #include <soc.h>
-#include <init.h>
+#include <zephyr/init.h>
 
 #define HSDK_CREG_GPIO_MUX_REG	0xf0001484
 #define HSDK_CREG_GPIO_MUX_VAL	0x00000400

--- a/boards/arm/cyclonev_socdk/cyclonev_socdk.dts
+++ b/boards/arm/cyclonev_socdk/cyclonev_socdk.dts
@@ -7,7 +7,7 @@
  */
 
 #include "intel_socfpga_std/socfpga_cyclone5.dtsi"
-#include "dt-bindings/gpio/gpio.h"
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	model = "Altera SOCFPGA Cyclone V SoC Development Kit";

--- a/boards/arm/faze/faze-pinctrl.dtsi
+++ b/boards/arm/faze/faze-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/arm/lpcxpresso11u68/lpcxpresso11u68-pinctrl.dtsi
+++ b/boards/arm/lpcxpresso11u68/lpcxpresso11u68-pinctrl.dtsi
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/lpc11u6x-pinctrl.h>
 
 &pinctrl {
 	uart0_default: uart0_default {

--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -8,7 +8,7 @@
 #ifndef BOARDS_POSIX_NATIVE_POSIX_BOARD_IRQ_H
 #define BOARDS_POSIX_NATIVE_POSIX_BOARD_IRQ_H
 
-#include "sw_isr_table.h"
+#include <zephyr/sw_isr_table.h>
 #include "zephyr/types.h"
 
 #ifdef __cplusplus

--- a/boards/posix/native_posix/cmdline.c
+++ b/boards/posix/native_posix/cmdline.c
@@ -12,7 +12,7 @@
 #include "hw_models_top.h"
 #include "timer_model.h"
 #include "cmdline.h"
-#include "toolchain.h"
+#include <zephyr/toolchain.h>
 #include <zephyr/arch/posix/posix_trace.h>
 #include "native_tracing.h"
 

--- a/boards/posix/native_posix/irq_ctrl.c
+++ b/boards/posix/native_posix/irq_ctrl.c
@@ -11,7 +11,7 @@
 #include "hw_models_top.h"
 #include "irq_ctrl.h"
 #include "irq_handler.h"
-#include "arch/posix/arch.h" /* for find_lsb_set() */
+#include <zephyr/arch/posix/arch.h> /* for find_lsb_set() */
 #include "board_soc.h"
 #include "posix_soc.h"
 #include "zephyr/types.h"

--- a/boards/posix/native_posix/irq_handler.c
+++ b/boards/posix/native_posix/irq_handler.c
@@ -9,14 +9,14 @@
 
 #include <stdint.h>
 #include "irq_handler.h"
-#include "irq_offload.h"
-#include "kernel_structs.h"
+#include <zephyr/irq_offload.h>
+#include <zephyr/kernel_structs.h>
 #include "kernel_internal.h"
 #include "kswap.h"
 #include "irq_ctrl.h"
 #include "posix_core.h"
 #include "board_soc.h"
-#include "sw_isr_table.h"
+#include <zephyr/sw_isr_table.h>
 #include "soc.h"
 #include <zephyr/tracing/tracing.h>
 

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -8,7 +8,7 @@
 #ifndef BOARDS_POSIX_NRF52_BSIM_BOARD_IRQ_H
 #define BOARDS_POSIX_NRF52_BSIM_BOARD_IRQ_H
 
-#include "sw_isr_table.h"
+#include <zephyr/sw_isr_table.h>
 #include "zephyr/types.h"
 
 #ifdef __cplusplus

--- a/boards/posix/nrf52_bsim/board_soc.h
+++ b/boards/posix/nrf52_bsim/board_soc.h
@@ -26,7 +26,7 @@
 #include <stdbool.h>
 #include <zephyr/types.h>
 #include <stddef.h>
-#include "irq.h"
+#include <zephyr/irq.h>
 #include "irq_sources.h"
 #include <nrfx.h>
 #include "cmsis.h"

--- a/boards/posix/nrf52_bsim/bstests_entry.c
+++ b/boards/posix/nrf52_bsim/bstests_entry.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "init.h"
+#include <zephyr/init.h>
 #include <stdint.h>
 #include <string.h>
 #include "bs_types.h"

--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -7,14 +7,14 @@
  */
 
 #include <stdint.h>
-#include "irq_offload.h"
-#include "kernel_structs.h"
+#include <zephyr/irq_offload.h>
+#include <zephyr/kernel_structs.h>
 #include "kernel_internal.h"
 #include "kswap.h"
 #include "irq_ctrl.h"
 #include "posix_core.h"
 #include "board_soc.h"
-#include "sw_isr_table.h"
+#include <zephyr/sw_isr_table.h>
 #include "soc.h"
 #include "bs_tracing.h"
 #include <zephyr/tracing/tracing.h>

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/display/ili9xxx.h>
+#include <zephyr/dt-bindings/display/ili9xxx.h>
 
 / {
 	chosen {

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/display/ili9xxx.h>
+#include <zephyr/dt-bindings/display/ili9xxx.h>
 
 / {
 	chosen {

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -11,7 +11,7 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/drivers/bluetooth/hci_driver.h>
-#include "bluetooth/addr.h"
+#include <zephyr/bluetooth/addr.h>
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
 #include "app_conf.h"

--- a/drivers/clock_control/clock_stm32_mux.c
+++ b/drivers/clock_control/clock_stm32_mux.c
@@ -5,11 +5,11 @@
  *
  */
 
-#include <drivers/clock_control.h>
-#include <sys/util.h>
-#include <drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/clock_control.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 #include <soc.h>
 
 #define DT_DRV_COMPAT st_stm32_clock_mux

--- a/drivers/console/native_posix_console.c
+++ b/drivers/console/native_posix_console.c
@@ -6,9 +6,9 @@
 
 #include <stdio.h>
 #include <ctype.h>
-#include "init.h"
-#include "kernel.h"
-#include "console/console.h"
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/console/console.h>
 #include "posix_board_if.h"
 #include <string.h>
 #include <sys/time.h>

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -32,7 +32,7 @@
 #include <zephyr/sys/atomic.h>
 #include <zephyr/sys/printk.h>
 #ifdef CONFIG_UART_CONSOLE_MCUMGR
-#include "mgmt/mcumgr/serial.h"
+#include <zephyr/mgmt/mcumgr/serial.h>
 #endif
 
 static const struct device *uart_console_dev;

--- a/drivers/dma/dma_cavs_gpdma.c
+++ b/drivers/dma/dma_cavs_gpdma.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "drivers/dma.h"
+#include <zephyr/drivers/dma.h>
 #define DT_DRV_COMPAT intel_cavs_gpdma
 
 #define GPDMA_CTL_OFFSET 0x0004

--- a/drivers/entropy/fake_entropy_native_posix.c
+++ b/drivers/entropy/fake_entropy_native_posix.c
@@ -13,9 +13,9 @@
 
 #define DT_DRV_COMPAT zephyr_native_posix_rng
 
-#include "device.h"
+#include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
-#include "init.h"
+#include <zephyr/init.h>
 #include <zephyr/sys/util.h>
 #include <stdlib.h>
 #include <string.h>

--- a/drivers/gpio/gpio_imx.c
+++ b/drivers/gpio/gpio_imx.c
@@ -14,7 +14,7 @@
 #include <gpio_imx.h>
 #include <string.h>
 #ifdef CONFIG_PINCTRL
-#include <drivers/pinctrl.h>
+#include <zephyr/drivers/pinctrl.h>
 #endif
 
 #include "gpio_utils.h"

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/pwm.h>
 #include <soc.h>
 #include <device_imx.h>
-#include <drivers/pinctrl.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #define LOG_LEVEL CONFIG_PWM_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -15,7 +15,7 @@
 #include <math.h>
 
 #include "fdc2x1x.h"
-#include "drivers/sensor/fdc2x1x.h"
+#include <zephyr/drivers/sensor/fdc2x1x.h>
 
 LOG_MODULE_REGISTER(FDC2X1X, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/serial/uart_imx.c
+++ b/drivers/serial/uart_imx.c
@@ -20,7 +20,7 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/uart.h>
 #include <uart_imx.h>
-#include <drivers/pinctrl.h>
+#include <zephyr/drivers/pinctrl.h>
 
 #define UART_STRUCT(dev) \
 	((UART_Type *)((const struct imx_uart_config *const)(dev)->config)->base)

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -12,7 +12,7 @@
 #include <errno.h>
 #include <fsl_uart.h>
 #include <soc.h>
-#include <drivers/pinctrl.h>
+#include <zephyr/drivers/pinctrl.h>
 
 struct mcux_iuart_config {
 	UART_Type *base;

--- a/drivers/timer/native_posix_timer.c
+++ b/drivers/timer/native_posix_timer.c
@@ -11,10 +11,10 @@
  * POSIX arch and InfClock SOC
  */
 #include "zephyr/types.h"
-#include "irq.h"
-#include "device.h"
+#include <zephyr/irq.h>
+#include <zephyr/device.h>
 #include <zephyr/drivers/timer/system_timer.h>
-#include "sys_clock.h"
+#include <zephyr/sys_clock.h>
 #include "timer_model.h"
 #include "soc.h"
 #include <zephyr/arch/posix/posix_trace.h>

--- a/drivers/usb/device/usb_dc_dw.c
+++ b/drivers/usb/device/usb_dc_dw.c
@@ -22,7 +22,7 @@
 #include <zephyr/usb/usb_device.h>
 #include "usb_dw_registers.h"
 #include <soc.h>
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #define LOG_LEVEL CONFIG_USB_DRIVER_LOG_LEVEL
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(usb_dc_dw);

--- a/dts/arm/intel_socfpga_std/socfpga.dtsi
+++ b/dts/arm/intel_socfpga_std/socfpga.dtsi
@@ -6,8 +6,8 @@
  * heavily modified for Zephyr
  */
 
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 
 / {
 	#address-cells = <1>;

--- a/include/zephyr/drivers/console/native_posix_console.h
+++ b/include/zephyr/drivers/console/native_posix_console.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_CONSOLE_NATIVE_POSIX_CONSOLE_H_
 #define ZEPHYR_INCLUDE_DRIVERS_CONSOLE_NATIVE_POSIX_CONSOLE_H_
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/posix/unistd.h
+++ b/include/zephyr/posix/unistd.h
@@ -10,7 +10,7 @@
 #include "sys/stat.h"
 #ifdef CONFIG_NETWORKING
 /* For zsock_gethostname() */
-#include "net/socket.h"
+#include <zephyr/net/socket.h>
 #endif
 
 #ifdef CONFIG_POSIX_API

--- a/samples/drivers/lcd_cyclonev_socdk/src/main.c
+++ b/samples/drivers/lcd_cyclonev_socdk/src/main.c
@@ -5,10 +5,10 @@
  * Example to use LCD Display in Cyclone V SoC FPGA devkit
  */
 
-#include <sys/printk.h>
+#include <zephyr/sys/printk.h>
 #include <stdio.h>
 #include <string.h>
-#include <drivers/i2c.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/kernel.h>
 #include "commands.h"
 #define I2C_INST DT_NODELABEL(i2c0)

--- a/samples/drivers/uart/stm32/single_wire/src/main.c
+++ b/samples/drivers/uart/stm32/single_wire/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/zephyr.h>
-#include "kernel.h"
+#include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/uart.h>

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/device.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/sensor.h>
-#include "drivers/sensor/fdc2x1x.h"
+#include <zephyr/drivers/sensor/fdc2x1x.h>
 #include <stdio.h>
 
 #define CH_BUF_INIT(m)          {},

--- a/samples/subsys/settings/src/main.c
+++ b/samples/subsys/settings/src/main.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 
 #include <errno.h>
 #include <zephyr/sys/printk.h>

--- a/scripts/gen_cfb_font_header.py
+++ b/scripts/gen_cfb_font_header.py
@@ -155,8 +155,8 @@ def generate_header():
  *
  */
 
-#include <zephyr.h>
-#include <display/cfb.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/display/cfb.h>
 
 static const uint8_t cfb_font_{name:s}_{width:d}{height:d}[{elem:d}][{b:.0f}] = {{\n"""
                       .format(cmd=" ".join(clean_cmd),

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -719,9 +719,9 @@ header = """%compare-lengths
 %global-table
 %struct-type
 %{
-#include <kernel.h>
-#include <toolchain.h>
-#include <syscall_handler.h>
+#include <zephyr/kernel.h>
+#include <zephyr/toolchain.h>
+#include <zephyr/syscall_handler.h>
 #include <string.h>
 %}
 struct z_object;

--- a/scripts/gen_relocate_app.py
+++ b/scripts/gen_relocate_app.py
@@ -114,9 +114,9 @@ LINKER_SECTION_SEQ_MPU = """
 
 SOURCE_CODE_INCLUDES = """
 /* Auto generated code. Do not modify.*/
-#include <zephyr.h>
-#include <linker/linker-defs.h>
-#include <kernel_structs.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/linker/linker-defs.h>
+#include <zephyr/kernel_structs.h>
 #include <kernel_internal.h>
 """
 

--- a/soc/arm/intel_socfpga_std/cyclonev/soc.c
+++ b/soc/arm/intel_socfpga_std/cyclonev/soc.c
@@ -6,12 +6,12 @@
  * creating function to reserve the vector memory area
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <init.h>
-#include <sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/init.h>
+#include <zephyr/sys/util.h>
 #include <mmu.h>
-#include <arch/arm/aarch32/mmu/arm_mmu.h>
+#include <zephyr/arch/arm/aarch32/mmu/arm_mmu.h>
 #include "soc.h"
 
 void arch_reserved_pages_update(void)

--- a/soc/arm/nxp_imx/mimx8mq6_m4/pinctrl_soc.h
+++ b/soc/arm/nxp_imx/mimx8mq6_m4/pinctrl_soc.h
@@ -7,7 +7,7 @@
 #ifndef ZEPHYR_SOC_ARM_NXP_MIMX8MQ6_M4_PINCTRL_SOC_H_
 #define ZEPHYR_SOC_ARM_NXP_MIMX8MQ6_M4_PINCTRL_SOC_H_
 
-#include <devicetree.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/types.h>
 #include "fsl_common.h"
 

--- a/soc/xtensa/esp32/newlib_fix.c
+++ b/soc/xtensa/esp32/newlib_fix.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <unistd.h>

--- a/soc/xtensa/esp32/soc.c
+++ b/soc/xtensa/esp32/soc.c
@@ -27,7 +27,7 @@
 #include "esp_spi_flash.h"
 #include "esp_err.h"
 #include "esp32/spiram.h"
-#include "sys/printk.h"
+#include <zephyr/sys/printk.h>
 
 /*
  * This is written in C rather than assembly since, during the port bring up,

--- a/soc/xtensa/esp32s2/newlib_fix.c
+++ b/soc/xtensa/esp32s2/newlib_fix.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <toolchain.h>
+#include <zephyr/toolchain.h>
 #include <stdio.h>
 #include <stddef.h>
 #include <unistd.h>

--- a/soc/xtensa/esp32s2/soc.c
+++ b/soc/xtensa/esp32s2/soc.c
@@ -25,7 +25,7 @@
 #include "hal/cpu_ll.h"
 #include "esp_err.h"
 #include "esp32s2/spiram.h"
-#include "sys/printk.h"
+#include <zephyr/sys/printk.h>
 
 extern void rtc_clk_cpu_freq_set_xtal(void);
 

--- a/subsys/logging/log_backend_cavs_hda.c
+++ b/subsys/logging/log_backend_cavs_hda.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "arch/xtensa/cache.h"
+#include <zephyr/arch/xtensa/cache.h>
 #include <zephyr/logging/log_backend.h>
 #include <zephyr/logging/log_core.h>
 #include <zephyr/logging/log_msg.h>

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(hawkbit, CONFIG_HAWKBIT_LOG_LEVEL);
 
 #include "hawkbit_priv.h"
 #include "hawkbit_device.h"
-#include "mgmt/hawkbit.h"
+#include <zephyr/mgmt/hawkbit.h>
 #include "hawkbit_firmware.h"
 
 #if defined(CONFIG_NET_SOCKETS_SOCKOPT_TLS)

--- a/subsys/mgmt/hawkbit/shell.c
+++ b/subsys/mgmt/hawkbit/shell.c
@@ -9,7 +9,7 @@
 #include <zephyr/dfu/mcuboot.h>
 #include <zephyr/dfu/flash_img.h>
 #include <zephyr/sys/reboot.h>
-#include "mgmt/hawkbit.h"
+#include <zephyr/mgmt/hawkbit.h>
 #include "hawkbit_firmware.h"
 #include "hawkbit_device.h"
 

--- a/subsys/mgmt/mcumgr/buf.c
+++ b/subsys/mgmt/mcumgr/buf.c
@@ -6,8 +6,8 @@
 
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
-#include "net/buf.h"
-#include "mgmt/mcumgr/buf.h"
+#include <zephyr/net/buf.h>
+#include <zephyr/mgmt/mcumgr/buf.h>
 #include <mgmt/mgmt.h>
 #include <zcbor_common.h>
 #include <zcbor_decode.h>

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -8,7 +8,7 @@
 #define H_MGMT_MGMT_
 
 #include <inttypes.h>
-#include "mgmt/mcumgr/buf.h"
+#include <zephyr/mgmt/mcumgr/buf.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/mgmt/mcumgr/smp.c
+++ b/subsys/mgmt/mcumgr/smp.c
@@ -10,7 +10,7 @@
 #include <zephyr/mgmt/mcumgr/buf.h>
 #include "mgmt/mgmt.h"
 #include "smp/smp.h"
-#include "mgmt/mcumgr/smp.h"
+#include <zephyr/mgmt/mcumgr/smp.h>
 #include "smp_reassembly.h"
 
 #include <zephyr/logging/log.h>

--- a/subsys/mgmt/mcumgr/smp_shell.c
+++ b/subsys/mgmt/mcumgr/smp_shell.c
@@ -14,13 +14,13 @@
 #include <zephyr/net/buf.h>
 #include <zephyr/mgmt/mcumgr/buf.h>
 #include "mgmt/mgmt.h"
-#include "mgmt/mcumgr/serial.h"
-#include "mgmt/mcumgr/smp.h"
-#include "mgmt/mcumgr/smp_shell.h"
-#include "drivers/uart.h"
+#include <zephyr/mgmt/mcumgr/serial.h>
+#include <zephyr/mgmt/mcumgr/smp.h>
+#include <zephyr/mgmt/mcumgr/smp_shell.h>
+#include <zephyr/drivers/uart.h>
 #include "syscalls/uart.h"
-#include "shell/shell.h"
-#include "shell/shell_uart.h"
+#include <zephyr/shell/shell.h>
+#include <zephyr/shell/shell_uart.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(smp_shell);

--- a/subsys/mgmt/mcumgr/smp_uart.c
+++ b/subsys/mgmt/mcumgr/smp_uart.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/console/uart_mcumgr.h>
 #include "mgmt/mgmt.h"
 #include <zephyr/mgmt/mcumgr/serial.h>
-#include "mgmt/mcumgr/smp.h"
+#include <zephyr/mgmt/mcumgr/smp.h>
 
 struct device;
 

--- a/subsys/settings/include/settings/settings_fcb.h
+++ b/subsys/settings/include/settings/settings_fcb.h
@@ -9,7 +9,7 @@
 #define __SETTINGS_FCB_H_
 
 #include <zephyr/fs/fcb.h>
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/settings/include/settings/settings_file.h
+++ b/subsys/settings/include/settings/settings_file.h
@@ -8,7 +8,7 @@
 #ifndef __SETTINGS_FILE_H_
 #define __SETTINGS_FILE_H_
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/settings/include/settings/settings_nvs.h
+++ b/subsys/settings/include/settings/settings_nvs.h
@@ -9,7 +9,7 @@
 #define __SETTINGS_NVS_H_
 
 #include <zephyr/fs/nvs.h>
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -11,7 +11,7 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include "settings_priv.h"
 #include <zephyr/types.h>
 

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -10,7 +10,7 @@
 #include <zephyr/fs/fcb.h>
 #include <string.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include "settings/settings_fcb.h"
 #include "settings_priv.h"
 

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -11,7 +11,7 @@
 
 #include <zephyr/fs/fs.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include "settings/settings_file.h"
 #include "settings_priv.h"
 

--- a/subsys/settings/src/settings_init.c
+++ b/subsys/settings/src/settings_init.c
@@ -11,7 +11,7 @@
 
 #include <errno.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include "settings/settings_file.h"
 #include <zephyr/zephyr.h>
 

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -8,7 +8,7 @@
 #include <ctype.h>
 #include <string.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include "settings_priv.h"
 
 #include <zephyr/logging/log.h>

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -8,7 +8,7 @@
 #include <errno.h>
 #include <string.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include "settings/settings_nvs.h"
 #include "settings_priv.h"
 #include <zephyr/storage/flash_map.h>

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -14,7 +14,7 @@
 #include <errno.h>
 #include <zephyr/kernel.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include "settings_priv.h"
 
 #include <zephyr/logging/log.h>

--- a/subsys/task_wdt/task_wdt.c
+++ b/subsys/task_wdt/task_wdt.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "task_wdt/task_wdt.h"
+#include <zephyr/task_wdt/task_wdt.h>
 
 #include <zephyr/drivers/watchdog.h>
 #include <zephyr/sys/reboot.h>

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -21,7 +21,7 @@ static struct k_thread ztest_thread;
 #endif
 
 #ifdef CONFIG_ZTEST_SHUFFLE
-#include <random/rand32.h>
+#include <zephyr/random/rand32.h>
 #include <stdlib.h>
 #include <time.h>
 #define NUM_ITER_PER_SUITE CONFIG_ZTEST_SHUFFLE_SUITE_REPEAT_COUNT

--- a/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
@@ -5,8 +5,8 @@
  */
 
 #include <ztest.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 
 
 #define EXECUTION_TRACE_LENGTH 6

--- a/tests/benchmarks/mbedtls/src/benchmark.c
+++ b/tests/benchmarks/mbedtls/src/benchmark.c
@@ -72,7 +72,7 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/random/rand32.h>
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include <zephyr/sys/printk.h>
 #define  MBEDTLS_PRINT ((int(*)(const char *, ...)) printk)

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
@@ -4,7 +4,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_empty.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_empty.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include "kernel.h"
+#include <zephyr/kernel.h>
 #include "bs_types.h"
 #include "bs_tracing.h"
 #include "time_machine.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
@@ -10,7 +10,7 @@
 #ifndef ZEPHYR_TEST_BSIM_BT_AUDIO_TEST_
 #define ZEPHYR_TEST_BSIM_BT_AUDIO_TEST_
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/has_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/has_client_test.c
@@ -5,7 +5,7 @@
  */
 
 #ifdef CONFIG_BT_HAS_CLIENT
-#include "bluetooth/audio/has.h"
+#include <zephyr/bluetooth/audio/has.h>
 
 #include "common.h"
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/mics_test.c
@@ -5,7 +5,7 @@
  */
 
 #ifdef CONFIG_BT_MICS
-#include "bluetooth/audio/mics.h"
+#include <zephyr/bluetooth/audio/mics.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/vcs_test.c
@@ -5,7 +5,7 @@
  */
 
 #ifdef CONFIG_BT_VCS
-#include "bluetooth/audio/vcs.h"
+#include <zephyr/bluetooth/audio/vcs.h>
 #include "common.h"
 
 extern enum bst_result_t bst_result;

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt_notif/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt_notif/src/common.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_gatt/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_gatt/src/common.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_gatt_caching/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_gatt_caching/src/common.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
@@ -9,7 +9,7 @@
  */
 #ifndef ZEPHYR_TESTS_BLUETOOTH_BSIM_BT_BSIM_TEST_MESH_MESH_TEST_H_
 #define ZEPHYR_TESTS_BLUETOOTH_BSIM_BT_BSIM_TEST_MESH_MESH_TEST_H_
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/settings_test_backend.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/settings_test_backend.c
@@ -9,12 +9,12 @@
 #include <stdio.h>
 #include <stddef.h>
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 #include "zephyr/types.h"
 #include "errno.h"
-#include "zephyr.h"
+#include <zephyr/zephyr.h>
 
-#include "bluetooth/mesh.h"
+#include <zephyr/bluetooth/mesh.h>
 #include "argparse.h"
 
 #define LOG_MODULE_NAME settings_test_backend

--- a/tests/bluetooth/bsim_bt/bsim_test_notify/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_notify/src/common.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "kernel.h"
+#include <zephyr/kernel.h>
 
 #include "bs_types.h"
 #include "bs_tracing.h"

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver_bsim.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/common/edtt_driver_bsim.c
@@ -13,7 +13,7 @@
 #include <errno.h>
 
 #include "edtt_driver.h"
-#include "kernel.h"
+#include <zephyr/kernel.h>
 #include "soc.h"
 
 #include "bs_tracing.h"

--- a/tests/bluetooth/controller/ctrl_collision/src/main.c
+++ b/tests/bluetooth/controller/ctrl_collision/src/main.c
@@ -10,10 +10,10 @@
 
 #define ULL_LLCP_UNITTEST
 
-#include <bluetooth/hci.h>
-#include <sys/byteorder.h>
-#include <sys/slist.h>
-#include <sys/util.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
 #include "hal/ccm.h"
 
 #include "util/util.h"

--- a/tests/bluetooth/controller/mock_ctrl/src/util.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/util.c
@@ -6,7 +6,7 @@
  */
 
 #include <zephyr/types.h>
-#include "sys/byteorder.h"
+#include <zephyr/sys/byteorder.h>
 #include "util.h"
 #include "pdu.h"
 

--- a/tests/bluetooth/df/common/src/bt_conn_common.c
+++ b/tests/bluetooth/df/common/src/bt_conn_common.c
@@ -14,7 +14,7 @@
 
 #include <hal/ccm.h>
 
-#include <bluetooth/hci.h>
+#include <zephyr/bluetooth/hci.h>
 #include <pdu.h>
 #include <lll.h>
 #include <lll/lll_df_types.h>

--- a/tests/boards/intel_adsp/hda/src/dma.c
+++ b/tests/boards/intel_adsp/hda/src/dma.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "arch/xtensa/cache.h"
+#include <zephyr/arch/xtensa/cache.h>
 #include <zephyr/kernel.h>
 #include <ztest.h>
 #include <cavs_ipc.h>

--- a/tests/boards/intel_adsp/hda/src/smoke.c
+++ b/tests/boards/intel_adsp/hda/src/smoke.c
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "arch/xtensa/cache.h"
+#include <zephyr/arch/xtensa/cache.h>
 #include <zephyr/kernel.h>
 #include <ztest.h>
 #include <cavs_ipc.h>

--- a/tests/boards/intel_adsp/hda/src/tests.h
+++ b/tests/boards/intel_adsp/hda/src/tests.h
@@ -4,7 +4,7 @@
 #ifndef ZEPHYR_TESTS_INTEL_ADSP_TESTS_H
 #define ZEPHYR_TESTS_INTEL_ADSP_TESTS_H
 
-#include "sys_clock.h"
+#include <zephyr/sys_clock.h>
 #include <cavs_ipc.h>
 #include <cavstool.h>
 #include <stdint.h>

--- a/tests/boards/native_posix/native_tasks/src/main.c
+++ b/tests/boards/native_posix/native_tasks/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include "soc.h"
-#include "kernel.h"
+#include <zephyr/kernel.h>
 #include "posix_board_if.h"
 
 /**

--- a/tests/subsys/logging/log_syst/src/main.c
+++ b/tests/subsys/logging/log_syst/src/main.c
@@ -9,14 +9,14 @@
  * @brief Test log message
  */
 
-#include <zephyr.h>
-#include <logging/log.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/logging/log.h>
 #include "mock_backend.h"
-#include <sys/printk.h>
-#include <logging/log_backend.h>
-#include <logging/log_backend_std.h>
-#include <logging/log_ctrl.h>
-#include <logging/log_output.h>
+#include <zephyr/sys/printk.h>
+#include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_backend_std.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log_output.h>
 #include <tc_util.h>
 #include <stdbool.h>
 #include <ztest.h>

--- a/tests/subsys/logging/log_syst/src/mock_backend.c
+++ b/tests/subsys/logging/log_syst/src/mock_backend.c
@@ -6,8 +6,8 @@
 
 #include "mock_backend.h"
 #include <ztest.h>
-#include <logging/log_core.h>
-#include <logging/log_backend_std.h>
+#include <zephyr/logging/log_core.h>
+#include <zephyr/logging/log_backend_std.h>
 #include <stdlib.h>
 
 static uint32_t log_format_current = CONFIG_LOG_BACKEND_MOCK_OUTPUT_DEFAULT;

--- a/tests/subsys/logging/log_syst/src/mock_backend.h
+++ b/tests/subsys/logging/log_syst/src/mock_backend.h
@@ -7,7 +7,7 @@
 #ifndef SRC_MOCK_BACKEND_H__
 #define SRC_MOCK_BACKEND_H__
 
-#include <logging/log_backend.h>
+#include <zephyr/logging/log_backend.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/subsys/settings/fcb/src/settings_test.h
+++ b/tests/subsys/settings/fcb/src/settings_test.h
@@ -12,7 +12,7 @@
 #include <string.h>
 #include <ztest.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 #include <zephyr/storage/flash_map.h>
 
 #ifdef __cplusplus

--- a/tests/subsys/settings/fs/include/settings_test_fs.h
+++ b/tests/subsys/settings/fs/include/settings_test_fs.h
@@ -12,7 +12,7 @@
 #include <ztest.h>
 #include <zephyr/fs/fs.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/subsys/settings/nvs/src/settings_test.h
+++ b/tests/subsys/settings/nvs/src/settings_test.h
@@ -11,7 +11,7 @@
 #include <string.h>
 #include <ztest.h>
 
-#include "settings/settings.h"
+#include <zephyr/settings/settings.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/tests/ztest/base/src/main_userspace.c
+++ b/tests/ztest/base/src/main_userspace.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <kernel.h>
+#include <zephyr/kernel.h>
 #include <ztest.h>
 
 ZTEST_USER(framework_tests, test_userspace_is_user)


### PR DESCRIPTION
Fix a bunch of missing zephyr/ include prefixes, mostly double quote `#include` but also recent additions. Done by changing the migration script to catch those as well. We run a project that runs against few architectures and tests against native_posix and with this change we can run everything with `LEGACY_INCLUDE_PATH=n`. Also fix few generated include statements that have not been fixed yet.