### PR TITLE
ring_buffer: fix designated initializer order in RING_BUF_ITEM_DECLARE

### DIFF
--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -102,8 +102,8 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
 		RING_BUFFER_SIZE_ASSERT_MSG); \
 	static uint32_t __noinit _ring_buffer_data_##name[size32]; \
 	struct ring_buf name = { \
-		.size = 4 * (size32), \
-		.buffer = (uint8_t *) _ring_buffer_data_##name \
+		.buffer = (uint8_t *) _ring_buffer_data_##name, \
+		.size = 4 * (size32) \
 	}
 
 /**


### PR DESCRIPTION
Commit a36995e2a36a ("ring_buffer: fix designated initializer order
in RING_BUF_DECLARE") missed the RING_BUF_ITEM_DECLARE case.

This is related to #45697 partially fixed in #45698
