### PR TITLE
Bluetooth: Controller: llcp: Fix wrong effective time calculation if PHY changed

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -244,16 +244,19 @@ static uint8_t pu_update_eff_times(struct ll_conn *conn, struct proc_ctx *ctx)
 	struct lll_conn *lll = &conn->lll;
 	uint16_t eff_tx_time = lll->dle.eff.max_tx_time;
 	uint16_t eff_rx_time = lll->dle.eff.max_rx_time;
+	uint16_t max_rx_time, max_tx_time;
+
+	ull_dle_max_time_get(conn, &max_rx_time, &max_tx_time);
 
 	if ((ctx->data.pu.p_to_c_phy && (lll->role == BT_HCI_ROLE_PERIPHERAL)) ||
 	    (ctx->data.pu.c_to_p_phy && (lll->role == BT_HCI_ROLE_CENTRAL))) {
-		eff_tx_time = pu_calc_eff_time(lll->dle.eff.max_tx_octets, lll->phy_tx,
-					       lll->dle.local.max_tx_time);
+		eff_tx_time =
+			pu_calc_eff_time(lll->dle.eff.max_tx_octets, lll->phy_tx, max_tx_time);
 	}
 	if ((ctx->data.pu.p_to_c_phy && (lll->role == BT_HCI_ROLE_CENTRAL)) ||
 	    (ctx->data.pu.c_to_p_phy && (lll->role == BT_HCI_ROLE_PERIPHERAL))) {
-		eff_rx_time = pu_calc_eff_time(lll->dle.eff.max_rx_octets, lll->phy_rx,
-					       lll->dle.local.max_rx_time);
+		eff_rx_time =
+			pu_calc_eff_time(lll->dle.eff.max_rx_octets, lll->phy_rx, max_rx_time);
 	}
 
 	if ((eff_tx_time != lll->dle.eff.max_tx_time) ||

--- a/tests/bluetooth/controller/ctrl_hci/src/main.c
+++ b/tests/bluetooth/controller/ctrl_hci/src/main.c
@@ -319,8 +319,8 @@ void test_hci_dle(void)
 	ll_length_max_get(&max_tx_octets, &max_tx_time, &max_rx_octets, &max_rx_time);
 	zassert_equal(max_tx_octets, LL_LENGTH_OCTETS_RX_MAX, NULL);
 	zassert_equal(max_rx_octets, LL_LENGTH_OCTETS_RX_MAX, NULL);
-	zassert_equal(max_tx_time, 2120, "Actual time is %d", max_tx_time);
-	zassert_equal(max_rx_time, 2120, "Actual time is %d", max_rx_time);
+	zassert_equal(max_tx_time, 17040, "Actual time is %d", max_tx_time);
+	zassert_equal(max_rx_time, 17040, "Actual time is %d", max_rx_time);
 
 	err = ll_length_default_set(0x00, 0x00);
 	ll_length_default_get(&max_tx_octets, &max_tx_time);

--- a/tests/bluetooth/controller/mock_ctrl/include/kconfig.h
+++ b/tests/bluetooth/controller/mock_ctrl/include/kconfig.h
@@ -28,8 +28,13 @@
 #ifndef CONFIG_BT_CTLR_PHY
 #define CONFIG_BT_CTLR_PHY 1
 #endif
+
 #ifndef CONFIG_BT_CTLR_PHY_2M
 #define CONFIG_BT_CTLR_PHY_2M y
+#endif
+
+#ifndef CONFIG_BT_CTLR_PHY_CODED
+#define CONFIG_BT_CTLR_PHY_CODED y
 #endif
 
 #ifndef CONFIG_BT_CTLR_LOW_LAT


### PR DESCRIPTION
If there is a PHY change on a connection it may happen that effective
RX and TX time changes also. That change is applied after an instant.

Implemented handling of effective time calculation is based on the
maximum PDU length, new PHY and local (default) maximum TX or RX time.

The maximum TX value is set to default one that corresponds to PHY 1M
during the Controller initialization. It can be updated by host to other
value. By default Zephyr Host updates it to max possible TX time for all
supported PHYs. If PHY CODED is enabled, it is the longest possible TX
duration 17040 us.

The maximum RX value is set to default during connection creation.
In case of use of legacy advertising, the value is also related with
PHY 1M. It can be updated by data length extension procedure.

If the maximum RX value is set to some value and there is a change
of a PHY to one that requires more time to send a PDU with the same
length, then the maximum RX value is wrongly calculated.

Function pu_calc_eff_time returns a value that is the default_time
argument. The problem is that the default_time should be adjusted
to new maximum RX time required for a new PHY.

To solve that there should be an evaluation of a new maximum RX and
TX time based on new PHY.

The commit adds missing evaluation.

The problem occurred in DF tests that check collision mitigation
between PHY update control procedure and CTE request control procedure.

There was missing CONFIG_BT_CTLR_PHY_CODED option in CTE request
unit tests. The code was working because the ULL implementation of
PHY change control procedure does not verify if PHY CODED is supported.

When missing support was enabled, tests showed wrong evaluation of
maximum RX time. It also unveiled error in CTE request unit tests
implementation. The default_tx_time was set to wrong value 2120 us
as if PHY CODED was not supported. To fix it, the value was changed
to PDU_DC_PAYLOAD_TIME_MAX_CODED.

There was also added a mock for a feature exchange procedure done
during unit tests setup step. That allows to correctly calculate
maximum TX time by ull_dle_max_time_get function.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/46026

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>