### PR TITLE
Fix local doc build, add PWM dt doxygen tags

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -51,6 +51,12 @@ set(DOCS_SRC_DIR ${CMAKE_CURRENT_BINARY_DIR}/src)
 set(DOCS_HTML_DIR ${CMAKE_CURRENT_BINARY_DIR}/html)
 set(DOCS_LATEX_DIR ${CMAKE_CURRENT_BINARY_DIR}/latex)
 
+if(WIN32)
+  set(SEP $<SEMICOLON>)
+else()
+  set(SEP :)
+endif()
+
 #-------------------------------------------------------------------------------
 # Functions
 

--- a/include/zephyr/dt-bindings/pwm/pwm.h
+++ b/include/zephyr/dt-bindings/pwm/pwm.h
@@ -7,6 +7,13 @@
 #define ZEPHYR_INCLUDE_DT_BINDINGS_PWM_PWM_H_
 
 /**
+ * @brief PWM Interface
+ * @defgroup pwm_interface PWM Interface
+ * @ingroup io_interfaces
+ * @{
+ */
+
+/**
  * @name PWM period set helpers
  * The period cell in the PWM specifier needs to be provided in nanoseconds.
  * However, in some applications it is more convenient to use another scale.
@@ -45,6 +52,8 @@
 /** @cond INTERNAL_HIDDEN */
 #define PWM_POLARITY_MASK	0x1
 /** @endcond */
+/** @} */
+
 /** @} */
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PWM_PWM_H_ */


### PR DESCRIPTION
Two documentation changes:
- fix the documentation buildfile when PYTHONPATH is set
- add doxygen tags to the pwm dt file so it gets picked up in the PWM API pages