### PR TITLE
libc: minimal: Add PRIx{FAST,LEAST}N and PRIxMAX macros

### DIFF
--- a/include/zephyr/toolchain/zephyr_stdint.h
+++ b/include/zephyr/toolchain/zephyr_stdint.h
@@ -22,16 +22,29 @@
 
 #undef __INT32_TYPE__
 #undef __UINT32_TYPE__
+#undef __INT_FAST32_TYPE__
+#undef __UINT_FAST32_TYPE__
 #undef __INT_LEAST32_TYPE__
 #undef __UINT_LEAST32_TYPE__
 #undef __INT64_TYPE__
 #undef __UINT64_TYPE__
+#undef __INT_FAST64_TYPE__
+#undef __UINT_FAST64_TYPE__
+#undef __INT_LEAST64_TYPE__
+#undef __UINT_LEAST64_TYPE__
+
 #define __INT32_TYPE__ int
 #define __UINT32_TYPE__ unsigned int
+#define __INT_FAST32_TYPE__ __INT32_TYPE__
+#define __UINT_FAST32_TYPE__ __UINT32_TYPE__
 #define __INT_LEAST32_TYPE__ __INT32_TYPE__
 #define __UINT_LEAST32_TYPE__ __UINT32_TYPE__
 #define __INT64_TYPE__ long long int
 #define __UINT64_TYPE__ unsigned long long int
+#define __INT_FAST64_TYPE__ __INT64_TYPE__
+#define __UINT_FAST64_TYPE__ __UINT64_TYPE__
+#define __INT_LEAST64_TYPE__ __INT64_TYPE__
+#define __UINT_LEAST64_TYPE__ __UINT64_TYPE__
 
 /*
  * The confusion also exists with __INTPTR_TYPE__ which is either an int

--- a/lib/libc/minimal/include/inttypes.h
+++ b/lib/libc/minimal/include/inttypes.h
@@ -14,36 +14,84 @@
 #define	PRId16			"d"		/* int16_t */
 #define	PRId32			"d"		/* int32_t */
 #define	PRId64			"lld"		/* int64_t */
+#define	PRIdFAST8		"d"		/* int_fast8_t */
+#define	PRIdFAST16		"d"		/* int_fast16_t */
+#define	PRIdFAST32		"d"		/* int_fast32_t */
+#define	PRIdFAST64		"lld"		/* int_fast64_t */
+#define	PRIdLEAST8		"d"		/* int_least8_t */
+#define	PRIdLEAST16		"d"		/* int_least16_t */
+#define	PRIdLEAST32		"d"		/* int_least32_t */
+#define	PRIdLEAST64		"lld"		/* int_least64_t */
 #define	PRIdPTR			"ld"		/* intptr_t */
 
 #define	PRIi8			"i"		/* int8_t */
 #define	PRIi16			"i"		/* int16_t */
 #define	PRIi32			"i"		/* int32_t */
 #define	PRIi64			"lli"		/* int64_t */
+#define	PRIiFAST8		"i"		/* int_fast8_t */
+#define	PRIiFAST16		"i"		/* int_fast16_t */
+#define	PRIiFAST32		"i"		/* int_fast32_t */
+#define	PRIiFAST64		"lli"		/* int_fast64_t */
+#define	PRIiLEAST8		"i"		/* int_least8_t */
+#define	PRIiLEAST16		"i"		/* int_least16_t */
+#define	PRIiLEAST32		"i"		/* int_least32_t */
+#define	PRIiLEAST64		"lli"		/* int_least64_t */
 #define	PRIiPTR			"li"		/* intptr_t */
 
 #define	PRIo8			"o"		/* int8_t */
 #define	PRIo16			"o"		/* int16_t */
 #define	PRIo32			"o"		/* int32_t */
 #define	PRIo64			"llo"		/* int64_t */
+#define	PRIoFAST8		"o"		/* int_fast8_t */
+#define	PRIoFAST16		"o"		/* int_fast16_t */
+#define	PRIoFAST32		"o"		/* int_fast32_t */
+#define	PRIoFAST64		"llo"		/* int_fast64_t */
+#define	PRIoLEAST8		"o"		/* int_least8_t */
+#define	PRIoLEAST16		"o"		/* int_least16_t */
+#define	PRIoLEAST32		"o"		/* int_least32_t */
+#define	PRIoLEAST64		"llo"		/* int_least64_t */
 #define	PRIoPTR			"lo"		/* intptr_t */
 
 #define	PRIu8			"u"		/* uint8_t */
 #define	PRIu16			"u"		/* uint16_t */
 #define	PRIu32			"u"		/* uint32_t */
 #define	PRIu64			"llu"		/* uint64_t */
+#define	PRIuFAST8		"u"		/* uint_fast8_t */
+#define	PRIuFAST16		"u"		/* uint_fast16_t */
+#define	PRIuFAST32		"u"		/* uint_fast32_t */
+#define	PRIuFAST64		"llu"		/* uint_fast64_t */
+#define	PRIuLEAST8		"u"		/* uint_least8_t */
+#define	PRIuLEAST16		"u"		/* uint_least16_t */
+#define	PRIuLEAST32		"u"		/* uint_least32_t */
+#define	PRIuLEAST64		"llu"		/* uint_least64_t */
 #define	PRIuPTR			"lu"		/* uintptr_t */
 
 #define	PRIx8			"x"		/* uint8_t */
 #define	PRIx16			"x"		/* uint16_t */
 #define	PRIx32			"x"		/* uint32_t */
 #define	PRIx64			"llx"		/* uint64_t */
+#define	PRIxFAST8		"x"		/* uint_fast8_t */
+#define	PRIxFAST16		"x"		/* uint_fast16_t */
+#define	PRIxFAST32		"x"		/* uint_fast32_t */
+#define	PRIxFAST64		"llx"		/* uint_fast64_t */
+#define	PRIxLEAST8		"x"		/* uint_least8_t */
+#define	PRIxLEAST16		"x"		/* uint_least16_t */
+#define	PRIxLEAST32		"x"		/* uint_least32_t */
+#define	PRIxLEAST64		"llx"		/* uint_least64_t */
 #define	PRIxPTR			"lx"		/* uintptr_t */
 
 #define	PRIX8			"X"		/* uint8_t */
 #define	PRIX16			"X"		/* uint16_t */
 #define	PRIX32			"X"		/* uint32_t */
 #define	PRIX64			"llX"		/* uint64_t */
+#define	PRIXFAST8		"X"		/* uint_fast8_t */
+#define	PRIXFAST16		"X"		/* uint_fast16_t */
+#define	PRIXFAST32		"X"		/* uint_fast32_t */
+#define	PRIXFAST64		"llX"		/* uint_fast64_t */
+#define	PRIXLEAST8		"X"		/* uint_least8_t */
+#define	PRIXLEAST16		"X"		/* uint_least16_t */
+#define	PRIXLEAST32		"X"		/* uint_least32_t */
+#define	PRIXLEAST64		"llX"		/* uint_least64_t */
 #define	PRIXPTR			"lX"		/* uintptr_t */
 
 #endif

--- a/lib/libc/minimal/include/inttypes.h
+++ b/lib/libc/minimal/include/inttypes.h
@@ -22,6 +22,7 @@
 #define	PRIdLEAST16		"d"		/* int_least16_t */
 #define	PRIdLEAST32		"d"		/* int_least32_t */
 #define	PRIdLEAST64		"lld"		/* int_least64_t */
+#define	PRIdMAX			"lld"		/* intmax_t */
 #define	PRIdPTR			"ld"		/* intptr_t */
 
 #define	PRIi8			"i"		/* int8_t */
@@ -36,6 +37,7 @@
 #define	PRIiLEAST16		"i"		/* int_least16_t */
 #define	PRIiLEAST32		"i"		/* int_least32_t */
 #define	PRIiLEAST64		"lli"		/* int_least64_t */
+#define	PRIiMAX			"lli"		/* intmax_t */
 #define	PRIiPTR			"li"		/* intptr_t */
 
 #define	PRIo8			"o"		/* int8_t */
@@ -50,6 +52,7 @@
 #define	PRIoLEAST16		"o"		/* int_least16_t */
 #define	PRIoLEAST32		"o"		/* int_least32_t */
 #define	PRIoLEAST64		"llo"		/* int_least64_t */
+#define	PRIoMAX			"llo"		/* intmax_t */
 #define	PRIoPTR			"lo"		/* intptr_t */
 
 #define	PRIu8			"u"		/* uint8_t */
@@ -64,6 +67,7 @@
 #define	PRIuLEAST16		"u"		/* uint_least16_t */
 #define	PRIuLEAST32		"u"		/* uint_least32_t */
 #define	PRIuLEAST64		"llu"		/* uint_least64_t */
+#define	PRIuMAX			"llu"		/* uintmax_t */
 #define	PRIuPTR			"lu"		/* uintptr_t */
 
 #define	PRIx8			"x"		/* uint8_t */
@@ -78,6 +82,7 @@
 #define	PRIxLEAST16		"x"		/* uint_least16_t */
 #define	PRIxLEAST32		"x"		/* uint_least32_t */
 #define	PRIxLEAST64		"llx"		/* uint_least64_t */
+#define	PRIxMAX			"llx"		/* uintmax_t */
 #define	PRIxPTR			"lx"		/* uintptr_t */
 
 #define	PRIX8			"X"		/* uint8_t */
@@ -92,6 +97,7 @@
 #define	PRIXLEAST16		"X"		/* uint_least16_t */
 #define	PRIXLEAST32		"X"		/* uint_least32_t */
 #define	PRIXLEAST64		"llX"		/* uint_least64_t */
+#define	PRIXMAX			"llX"		/* uintmax_t */
 #define	PRIXPTR			"lX"		/* uintptr_t */
 
 #endif

--- a/modules/zcbor/Kconfig
+++ b/modules/zcbor/Kconfig
@@ -26,9 +26,6 @@ config ZCBOR_STOP_ON_ERROR
 config ZCBOR_VERBOSE
 	bool "Make zcbor code print messages"
 
-	# TODO: FIXME: Remove when Minimal LIBC has been fixed.
-	depends on !MINIMAL_LIBC # Because Minimal LIBC doesn't have PRIuFAST32 and PRIxFAST32.
-
 config ZCBOR_ASSERT
 	def_bool ASSERT
 


### PR DESCRIPTION
This series adds the C99 `PRIx{FAST,LEAST}N` and `PRIxMAX` integer type format specifier macros that were missing in the minimal C library.

Fixes #45209