### PR TITLE
doc/release-notes: Add mcumgr note on fixing MGMT_ERR_ENOMEM issue

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -349,6 +349,11 @@ Libraries / Subsystems
     allowed or declined.
   * Made the img mgmt ``img_mgmt_vercmp`` function public to allow application-
     level comparison of image versions.
+  * mcumgr will now only return `MGMT_ERR_ENOMEM` when it fails to allocate
+    a memory buffer for request processing, when previously it would wrongly
+    report this error when the SMP response failed to fit into a buffer;
+    now when encoding of response fails `MGMT_ERR_EMSGSIZE` will be
+    reported. This addresses issue :github:`44535`.
 
 * SD Subsystem
 


### PR DESCRIPTION
The commit adds release notes on fixing github issue 44535,
which describes problem with incorrect use of MGMT_ERR_ENOMEM when
MGMT_ERR_EMSGSIZE should have been used.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>