### PR TITLE
TLS credential management documentation cleanup

### DIFF
--- a/include/zephyr/net/tls_credentials.h
+++ b/include/zephyr/net/tls_credentials.h
@@ -35,8 +35,11 @@ enum tls_credential_type {
 	TLS_CREDENTIAL_CA_CERTIFICATE,
 
 	/** A public server certificate. Use this to register your own server
-	 *  certificate. Should be registered together with a corresponding
-	 *  private key. Used with certificate-based ciphersuites.
+	 *  certificate, such as a certificate identifying the client device
+	 *  when enabling mutual TLS authentication with a certificate and private
+	 *  key on each side of the TLS connection. Should be registered together
+	 *  with a corresponding private key. Used with certificate-based
+	 *  ciphersuites.
 	 */
 	TLS_CREDENTIAL_SERVER_CERTIFICATE,
 

--- a/include/zephyr/net/tls_credentials.h
+++ b/include/zephyr/net/tls_credentials.h
@@ -61,11 +61,10 @@ enum tls_credential_type {
  * Secure tag can be used to reference credential after it was registered
  * in the system.
  *
- * @note Some TLS credentials come in pairs:
+ * @note Some TLS credentials come in pairs, and must be assigned the same
+ *    secure tag to be correctly handled in the system:
  *    - TLS_CREDENTIAL_SERVER_CERTIFICATE with TLS_CREDENTIAL_PRIVATE_KEY,
  *    - TLS_CREDENTIAL_PSK with TLS_CREDENTIAL_PSK_ID.
- *    Such pairs of credentials must be assigned the same secure tag to be
- *    correctly handled in the system.
  */
 typedef int sec_tag_t;
 


### PR DESCRIPTION
Some minor fixes to improve the documentation around TLS credential management:

- Fixes a rendering issues where a text block is included as part of a bullet item
  (See: https://docs.zephyrproject.org/apidoc/latest/group__tls__credentials.html#details)
- Identifies `TLS_CREDENTIAL_SERVER_CERTIFICATE` as the correct credential type
  to use with Mutual TLS client certificate(s) despite the misleading name in that
  particular case.