### PR TITLE
boards/arm/96b_wistrio: fix GPIO initialization code

### DIFF
--- a/boards/arm/96b_wistrio/rf.c
+++ b/boards/arm/96b_wistrio/rf.c
@@ -25,9 +25,9 @@ static int rf_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	(void)gpio_pin_configure_dt(&rf1, GPIO_OUTPUT_INIT_HIGH);
-	(void)gpio_pin_configure_dt(&rf2, GPIO_OUTPUT_INIT_HIGH);
-	(void)gpio_pin_configure_dt(&rf3, GPIO_OUTPUT_INIT_LOW);
+	(void)gpio_pin_configure_dt(&rf1, GPIO_OUTPUT_HIGH);
+	(void)gpio_pin_configure_dt(&rf2, GPIO_OUTPUT_HIGH);
+	(void)gpio_pin_configure_dt(&rf3, GPIO_OUTPUT_LOW);
 
 	return 0;
 }


### PR DESCRIPTION
This PR fixes the flags that are used in the board initialization code. Without this fix, the assertion [here](https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/gpio.h#L707-L709) is triggered.

`GPIO_OUTPUT_INIT_HIGH` and `GPIO_OUTPUT_INIT_LOW` don't initialize pin directions. Use correct initialization values (`GPIO_OUTPUT_HIGH` and `GPIO_OUTPUT_LOW` respectively).