### PR TITLE
tests: newlib: thread_safety: Add min. RAM constraint for stress tests

### DIFF
--- a/tests/lib/newlib/thread_safety/testcase.yaml
+++ b/tests/lib/newlib/thread_safety/testcase.yaml
@@ -1,9 +1,9 @@
 common:
   filter: TOOLCHAIN_HAS_NEWLIB == 1
-  min_ram: 64
 tests:
   libraries.libc.newlib.thread_safety:
     tags: clib newlib
+    min_ram: 64
     testcases:
     - sfp_lock
     - env_lock
@@ -17,6 +17,7 @@ tests:
     - CONFIG_NEWLIB_THREAD_SAFETY_TEST_STRESS=y
     slow: true
     tags: clib newlib
+    min_ram: 192
     testcases:
     - sfp_lock
     - env_lock
@@ -30,6 +31,7 @@ tests:
     extra_args: CONF_FILE=prj_userspace.conf
     filter: CONFIG_ARCH_HAS_USERSPACE
     tags: clib newlib userspace
+    min_ram: 64
     testcases:
     - sfp_lock
     - env_lock
@@ -46,6 +48,7 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE
     slow: true
     tags: clib newlib userspace
+    min_ram: 192
     testcases:
     - sfp_lock
     - env_lock
@@ -61,6 +64,7 @@ tests:
     - CONFIG_NEWLIB_LIBC_NANO=y
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
     tags: clib newlib
+    min_ram: 64
     testcases:
     - sfp_lock
     - env_lock
@@ -76,6 +80,7 @@ tests:
     filter: CONFIG_HAS_NEWLIB_LIBC_NANO
     slow: true
     tags: clib newlib
+    min_ram: 192
     testcases:
     - sfp_lock
     - env_lock
@@ -91,6 +96,7 @@ tests:
     - CONFIG_NEWLIB_LIBC_NANO=y
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_HAS_NEWLIB_LIBC_NANO
     tags: clib newlib userspace
+    min_ram: 64
     testcases:
     - sfp_lock
     - env_lock
@@ -108,6 +114,7 @@ tests:
     filter: CONFIG_ARCH_HAS_USERSPACE and CONFIG_HAS_NEWLIB_LIBC_NANO
     slow: true
     tags: clib newlib userspace
+    min_ram: 192
     testcases:
     - sfp_lock
     - env_lock


### PR DESCRIPTION
This commit adds a separate minimum RAM constraint for the thread-
safety stress tests because they have a significantly higher RAM
usage compared to the basic functional tests.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #45593