### PR TITLE
timing: Fix symbol extern for C++

### DIFF
--- a/include/zephyr/timing/timing.h
+++ b/include/zephyr/timing/timing.h
@@ -10,6 +10,10 @@
 #include <zephyr/sys/arch_interface.h>
 #include <zephyr/timing/types.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void soc_timing_init(void);
 void soc_timing_start(void);
 void soc_timing_stop(void);
@@ -174,5 +178,9 @@ static inline uint32_t timing_freq_get_mhz(void)
 /**
  * @}
  */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ZEPHYR_INCLUDE_TIMING_TIMING_H_ */


### PR DESCRIPTION
This commit adds `extern "C"` to `timing.h` so that C function names do
not get mangled when including this header file from a C++ source file.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #45337