### PR TITLE
drivers: cc13xx_cc26xx: update HAL TI SimpleLink SDK 4.40

### DIFF
--- a/drivers/entropy/entropy_cc13xx_cc26xx.c
+++ b/drivers/entropy/entropy_cc13xx_cc26xx.c
@@ -16,6 +16,7 @@
 #include <zephyr/sys/ring_buffer.h>
 #include <zephyr/sys/sys_io.h>
 
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 #include <driverlib/trng.h>
 

--- a/drivers/gpio/gpio_cc13xx_cc26xx.c
+++ b/drivers/gpio/gpio_cc13xx_cc26xx.c
@@ -16,6 +16,7 @@
 #include <driverlib/gpio.h>
 #include <driverlib/interrupt.h>
 #include <driverlib/ioc.h>
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 
 #include <inc/hw_aon_event.h>

--- a/drivers/i2c/i2c_cc13xx_cc26xx.c
+++ b/drivers/i2c/i2c_cc13xx_cc26xx.c
@@ -17,6 +17,8 @@
 LOG_MODULE_REGISTER(i2c_cc13xx_cc26xx);
 
 #include <driverlib/i2c.h>
+#include <driverlib/ioc.h>
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 
 #include <ti/drivers/Power.h>

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -14,6 +14,8 @@
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
 
+#include <driverlib/ioc.h>
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 #include <driverlib/uart.h>
 

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -15,6 +15,7 @@ LOG_MODULE_REGISTER(spi_cc13xx_cc26xx);
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/policy.h>
 
+#include <driverlib/rom.h>
 #include <driverlib/prcm.h>
 #include <driverlib/ssi.h>
 


### PR DESCRIPTION
Hello, this is a follow up for #38425 (closed PR).

I thought it would be nice to have a more (minor) up-to-date SDK (although version **6** is the latest one, still WIP when I get to it).
Tested on both CC1352P LaunchXL and several custom-made CC1352R boards (using GPIO, timers and Sub-GHz radio).

Note: SDK renamed `PRCMPowerDomainStatus` to `PRCMPowerDomainsAllOn`, so drivers were changed too.

Linked hal_ti PR: https://github.com/zephyrproject-rtos/hal_ti/pull/27 .

Thanks.