### PR TITLE
boards: doc: Update information about generating litex_vexriscv SoC

### DIFF
--- a/boards/riscv/litex_vexriscv/doc/index.rst
+++ b/boards/riscv/litex_vexriscv/doc/index.rst
@@ -5,15 +5,19 @@ LiteX VexRiscv
 
 LiteX VexRiscv is an example of a system on a chip (SoC) that consists of
 a `VexRiscv processor <https://github.com/SpinalHDL/VexRiscv>`_
-and additional peripherals. This setup has been generated using
-`LiteX SoC Builder <https://github.com/enjoy-digital/litex>`_ and can be used
-on various FPGA chips. The bitstream (FPGA configuration file) can be
-obtained using both vendor-specific tools and open-source tools, including the
-`SymbiFlow toolchain <https://symbiflow.github.io/>`_.
+and additional peripherals. This setup can be generated using
+`Zephyr on LiteX VexRiscv (reference platform)
+<https://github.com/litex-hub/zephyr-on-litex-vexriscv>`_
+or `LiteX SoC Builder <https://github.com/enjoy-digital/litex>`_
+and can be used on various FPGA chips.
+The bitstream (FPGA configuration file) can be obtained using both
+vendor-specific and open-source tools, including the
+`F4PGA toolchain <https://f4pga.org/>`_.
 
 The ``litex_vexriscv`` board configuration in Zephyr is meant for the
 LiteX VexRiscv SoC implementation generated for the
-`Digilent Arty A7-35T Development Board <https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-and-hobbyists>`_.
+`Digilent Arty A7-35T Development Board
+<https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-and-hobbyists>`_.
 
 .. image:: img/litex_vexriscv.jpg
    :width: 650px
@@ -39,58 +43,89 @@ The implementation is optimized for FPGA chips.
 More information about the project can be found on
 `VexRiscv's website <https://github.com/SpinalHDL/VexRiscv>`_.
 
-LiteX VexRiscv with SymbiFlow
-*****************************
+LiteX VexRiscv
+##############
 
 To run the ZephyrOS on the VexRiscv CPU, it is necessary to prepare the
 bitstream for the FPGA on a Digilent Arty A7-35 Board. This can be achieved
-using the LiteX SoC Builder together with the SymbiFlow toolchain.
+using the
+`Zephyr on LiteX VexRiscv <https://github.com/litex-hub/zephyr-on-litex-vexriscv>`_
+reference platform. You can also use the official LiteX SoC Builder.
 
-.. image:: img/symbiflow.svg
-   :width: 300px
-   :align: center
-   :alt: SymbiFlow Logo
+Bitstream generation
+********************
 
-SymbiFlow is an Open Source Verilog-to-Bitstream FPGA synthesis flow,
-targeting FPGAs of multiple vendors. Currently, it targets the Xilinx 7-Series,
-Lattice iCE40, Lattice ECP5 FPGAs, QuickLogic EOS S3 and is gradually being
-expanded to provide a comprehensive end-to-end FPGA synthesis flow.
-More information about the project can be found on
-`Symbiflow's website <https://symbiflow.github.io/>`_.
+Zephyr on LiteX VexRiscv
+========================
+Using this platform ensures that all registers addresses are in the proper place.
+All drivers were tested using this platform.
+In order to generate the bitstream for the Digilent Arty A7-35 Board,
+proceed with the following instruction:
 
-Bitstream Generation
-====================
-
-In order to generate the bitstream for the Digilent Arty A7-35 Board, proceed
-with the following instruction:
-
-1. Install the SymbiFlow toolchain using instruction available in the
-   `symbiflow-examples <https://github.com/SymbiFlow/symbiflow-examples>`_ repository.
-
-#. Install the RISC-V toolchain:
+1. Clone the repository and update all submodules:
 
    .. code-block:: bash
 
-      wget https://static.dev.sifive.com/dev-tools/riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14.tar.gz
-      tar -xf riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14.tar.gz
-      export PATH=$PATH:$PWD/riscv64-unknown-elf-gcc-8.1.0-2019.01.0-x86_64-linux-ubuntu14/bin/
+      git clone https://github.com/litex-hub/zephyr-on-litex-vexriscv.git
+      cd zephyr-on-litex-vexriscv
+      git submodule update --init --recursive
 
-#. Download LiteX:
+   First, you have to install the F4PGA toolchain. It can be done by following instructions in
+   `this tutorial <https://f4pga-examples.readthedocs.io/en/latest/getting.html>`_.
+
+#. Next, get all required packages and run the install script:
 
    .. code-block:: bash
 
-      wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
-      chmod +x litex_setup.py
-      ./litex_setup.py init
-      ./litex_setup.py install
+      apt-get install build-essential bzip2 python3 python3-dev python3-pip
+      ./install.sh
 
 #. Generate the bitstream:
 
    .. code-block:: bash
 
-      cd litex/litex/boards/targets && ./arty.py --toolchain symbiflow --cpu-type vexriscv --sys-clk-freq 80e6 --build
+      source ./init
+      export INSTALL_DIR="path/to/f4pga"
+      FPGA_FAM="xc7"
+      export PATH="$INSTALL_DIR/$FPGA_FAM/install/bin:$PATH";
+      source "$INSTALL_DIR/$FPGA_FAM/conda/etc/profile.d/conda.sh"
+      conda activate $FPGA_FAM
+      ./make.py --board=arty --build --toolchain=symbiflow
 
-Programming and debugging
+
+Official LiteX SoC builder
+==========================
+You can also generate the bitstream using the `official LiteX repository <https://github.com/enjoy-digital/litex>`_.
+In that case you must also generate a dts overlay.
+
+1. Install Migen/LiteX and the LiteX's cores:
+
+   .. code-block:: bash
+
+      wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
+      chmod +x litex_setup.py
+      ./litex_setup.py --init --install --user (--user to install to user directory) --config=(minimal, standard, full)
+
+#. Install the RISC-V toolchain:
+
+   .. code-block:: bash
+
+      pip3 install meson ninja
+      ./litex_setup.py --gcc=riscv
+
+#. Build the target:
+
+   .. code-block:: bash
+
+      ./litex-boards/litex_boards/targets/digilent_arty.py --build --timer-uptime --csr-json csr.json
+
+#. Generate the dts and config overlay:
+
+   .. code-block:: bash
+
+      ./litex/litex/tools/litex_json2dts_zephyr.py --dts overlay.dts --config overlay.config csr.json
+
+Programming and booting
 *************************
 
 Building
@@ -101,11 +136,23 @@ Applications for the ``litex_vexriscv`` board configuration can be built as usua
 In order to build the application for ``litex_vexriscv``, set the ``BOARD`` variable
 to ``litex_vexriscv``.
 
-Booting
-=======
-
-You can boot from a serial port using `flterm: <https://github.com/timvideos/flterm>`_, e.g.:
+If you were generating bitstream with the official LiteX SoC builder you need to pass an additional argument:
 
 .. code-block:: bash
 
-    flterm --port /dev/ttyUSB0 --kernel <path_to_zephyr.bin> --kernel-adr 0x40000000
+   west build -b litex_vexriscv path/to/app -DDTC_OVERLAY_FILE=path/to/overlay.dts
+
+Booting
+=======
+
+To upload bitstream you can use `xc3sprog <https://github.com/matrix-io/xc3sprog>`_:
+
+.. code-block:: bash
+
+   xc3sprog -c nexys4 digilent_arty.bit
+
+You can boot from a serial port using litex_term (replace `ttyUSBX` with your device) , e.g.:
+
+.. code-block:: bash
+
+   litex_term /dev/ttyUSBX --speed 115200 --kernel zephyr.bin


### PR DESCRIPTION
This PR updates information about running ZephyrOS on litex_vexriscv SoC. It also add information about generating bitstream with [Zephyr-on-LiteX-VexRiscv](https://github.com/litex-hub/zephyr-on-litex-vexriscv) and LiteX SoC Builder.