### PR TITLE
doc: release: 3.1: Add notes related to Atmel and Gigadevice

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -224,6 +224,8 @@ Boards & SoC Support
 
 * Made these changes in other SoC series:
 
+  * Added Atmel SAM UPLL clock support
+
 * Changes for ARC boards:
 
 * Added support for these ARM boards:
@@ -240,6 +242,9 @@ Boards & SoC Support
 
 * Made these changes in other boards:
 
+  * sam4s_xplained: Add support for HWINFO
+  * sam_e70_xlained: Add support for HWINFO and CAN-FD
+  * sam_v71_xult: Add support for HWINFO and CAN-FD
   * gd32e103v_eval: Add prescaler to timer
   * longan_nano: Add support for TF-Card slot
 
@@ -250,6 +255,8 @@ Drivers and Sensors
 *******************
 
 * ADC
+
+  * Atmel SAM0: Fixed adc voltage reference
 
 * CAN
 
@@ -280,6 +287,10 @@ Drivers and Sensors
 
 * GPIO
 
+* HWINFO
+
+  * Atmel SAM: Added RSTC support
+
 * I2C
 
 * I2S
@@ -291,6 +302,10 @@ Drivers and Sensors
 * MEMC
 
 * Pin control
+
+  * New platforms added to ``pinctrl`` state-based API:
+
+    * Atmel SAM/SAM0
 
 * PWM
 
@@ -364,6 +379,16 @@ Libraries / Subsystems
 
 HALs
 ****
+
+* Atmel
+
+  * Added dt-bindings, documentation and scripts to support state-based pin
+    control (``pinctrl``) API.
+  * Imported new SoCs header files:
+
+    * SAML21
+    * SAMR34
+    * SAMR35
 
 * GigaDevice
 

--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -236,7 +236,12 @@ Boards & SoC Support
 
 * Added support for these RISC-V boards:
 
+  * GigaDevice GD32VF103C-EVAL
+
 * Made these changes in other boards:
+
+  * gd32e103v_eval: Add prescaler to timer
+  * longan_nano: Add support for TF-Card slot
 
 * Added support for these following shields:
 
@@ -359,6 +364,11 @@ Libraries / Subsystems
 
 HALs
 ****
+
+* GigaDevice
+
+  * Fixed GD32_REMAP_MSK macro
+  * Fixed gd32f403z pc3 missing pincodes
 
 MCUboot
 *******


### PR DESCRIPTION
Add 3.1.0 release notes for Atmel and Gigadevice hal, SoCs, drivers and boards.