### PR TITLE
Reset controller bug

### DIFF
--- a/doc/hardware/peripherals/reset.rst
+++ b/doc/hardware/peripherals/reset.rst
@@ -12,8 +12,8 @@ control over their reset input signals, including the ability to assert,
 deassert and toggle those signals. Also, the reset status of the reset input
 signal can be checked.
 
-Mainly, the assert and deassert API functions are optional because in most
-cases we want to toggle the reset signals.
+Mainly, the line_assert and line_deassert API functions are optional because
+in most cases we want to toggle the reset signals.
 
 Configuration Options
 *********************

--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -294,6 +294,10 @@ Drivers and Sensors
     easier to use the PWM API when the PWM channel, period and flags are taken
     from a Devicetree PWM cell.
 
+* Reset
+
+  * Added reset controller driver API.
+
 * Sensor
 
 * Serial

--- a/drivers/reset/reset_rpi_pico.c
+++ b/drivers/reset/reset_rpi_pico.c
@@ -106,26 +106,26 @@ static int reset_rpi_update(const struct device *dev, uint32_t id, uint8_t asser
 	return reset_rpi_write_register(dev, offset, value);
 }
 
-static int reset_rpi_assert(const struct device *dev, uint32_t id)
+static int reset_rpi_line_assert(const struct device *dev, uint32_t id)
 {
 	return reset_rpi_update(dev, id, 1);
 }
 
-static int reset_rpi_deassert(const struct device *dev, uint32_t id)
+static int reset_rpi_line_deassert(const struct device *dev, uint32_t id)
 {
 	return reset_rpi_update(dev, id, 0);
 }
 
-static int reset_rpi_toggle(const struct device *dev, uint32_t id)
+static int reset_rpi_line_toggle(const struct device *dev, uint32_t id)
 {
 	int ret;
 
-	ret = reset_rpi_assert(dev, id);
+	ret = reset_rpi_line_assert(dev, id);
 	if (ret) {
 		return ret;
 	}
 
-	return reset_rpi_deassert(dev, id);
+	return reset_rpi_line_deassert(dev, id);
 }
 
 static int reset_rpi_init(const struct device *dev)
@@ -137,9 +137,9 @@ static int reset_rpi_init(const struct device *dev)
 
 static const struct reset_driver_api reset_rpi_driver_api = {
 	.status = reset_rpi_status,
-	.assert = reset_rpi_assert,
-	.deassert = reset_rpi_deassert,
-	.toggle = reset_rpi_toggle,
+	.line_assert = reset_rpi_line_assert,
+	.line_deassert = reset_rpi_line_deassert,
+	.line_toggle = reset_rpi_line_toggle,
 };
 
 #define RPI_RESET_INIT(idx)							\

--- a/include/zephyr/drivers/reset.h
+++ b/include/zephyr/drivers/reset.h
@@ -114,32 +114,32 @@ typedef int (*reset_api_status)(const struct device *dev, uint32_t id, uint8_t *
 /**
  * API template to put the device in reset state.
  *
- * @see reset_assert
+ * @see reset_line_assert
  */
-typedef int (*reset_api_assert)(const struct device *dev, uint32_t id);
+typedef int (*reset_api_line_assert)(const struct device *dev, uint32_t id);
 
 /**
  * API template to take out the device from reset state.
  *
- * @see reset_deassert
+ * @see reset_line_deassert
  */
-typedef int (*reset_api_deassert)(const struct device *dev, uint32_t id);
+typedef int (*reset_api_line_deassert)(const struct device *dev, uint32_t id);
 
 /**
  * API template to reset the device.
  *
- * @see reset_toggle
+ * @see reset_line_toggle
  */
-typedef int (*reset_api_toggle)(const struct device *dev, uint32_t id);
+typedef int (*reset_api_line_toggle)(const struct device *dev, uint32_t id);
 
 /**
  * @brief Reset Controller driver API
  */
 __subsystem struct reset_driver_api {
 	reset_api_status status;
-	reset_api_assert assert;
-	reset_api_deassert deassert;
-	reset_api_toggle toggle;
+	reset_api_line_assert line_assert;
+	reset_api_line_deassert line_deassert;
+	reset_api_line_toggle line_toggle;
 };
 
 /** @endcond */
@@ -200,17 +200,17 @@ static inline int reset_status_dt(const struct reset_dt_spec *spec, uint8_t *sta
  * @retval -ENOSYS If the functionality is not implemented by the driver.
  * @retval -errno Other negative errno in case of failure.
  */
-__syscall int reset_assert(const struct device *dev, uint32_t id);
+__syscall int reset_line_assert(const struct device *dev, uint32_t id);
 
-static inline int z_impl_reset_assert(const struct device *dev, uint32_t id)
+static inline int z_impl_reset_line_assert(const struct device *dev, uint32_t id)
 {
 	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
 
-	if (api->assert == NULL) {
+	if (api->line_assert == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->assert(dev, id);
+	return api->line_assert(dev, id);
 }
 
 /**
@@ -218,15 +218,15 @@ static inline int z_impl_reset_assert(const struct device *dev, uint32_t id)
  *
  * This is equivalent to:
  *
- *     reset_assert(spec->dev, spec->id);
+ *     reset_line_assert(spec->dev, spec->id);
  *
  * @param spec Reset controller specification from devicetree
  *
- * @return a value from reset_assert()
+ * @return a value from reset_line_assert()
  */
-static inline int reset_assert_dt(const struct reset_dt_spec *spec)
+static inline int reset_line_assert_dt(const struct reset_dt_spec *spec)
 {
-	return reset_assert(spec->dev, spec->id);
+	return reset_line_assert(spec->dev, spec->id);
 }
 
 /**
@@ -242,17 +242,17 @@ static inline int reset_assert_dt(const struct reset_dt_spec *spec)
  * @retval -ENOSYS If the functionality is not implemented by the driver.
  * @retval -errno Other negative errno in case of failure.
  */
-__syscall int reset_deassert(const struct device *dev, uint32_t id);
+__syscall int reset_line_deassert(const struct device *dev, uint32_t id);
 
-static inline int z_impl_reset_deassert(const struct device *dev, uint32_t id)
+static inline int z_impl_reset_line_deassert(const struct device *dev, uint32_t id)
 {
 	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
 
-	if (api->deassert == NULL) {
+	if (api->line_deassert == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->deassert(dev, id);
+	return api->line_deassert(dev, id);
 }
 
 /**
@@ -260,15 +260,15 @@ static inline int z_impl_reset_deassert(const struct device *dev, uint32_t id)
  *
  * This is equivalent to:
  *
- *     reset_deassert(spec->dev, spec->id)
+ *     reset_line_deassert(spec->dev, spec->id)
  *
  * @param spec Reset controller specification from devicetree
  *
- * @return a value from reset_deassert()
+ * @return a value from reset_line_deassert()
  */
-static inline int reset_deassert_dt(const struct reset_dt_spec *spec)
+static inline int reset_line_deassert_dt(const struct reset_dt_spec *spec)
 {
-	return reset_deassert(spec->dev, spec->id);
+	return reset_line_deassert(spec->dev, spec->id);
 }
 
 /**
@@ -283,17 +283,17 @@ static inline int reset_deassert_dt(const struct reset_dt_spec *spec)
  * @retval -ENOSYS If the functionality is not implemented by the driver.
  * @retval -errno Other negative errno in case of failure.
  */
-__syscall int reset_toggle(const struct device *dev, uint32_t id);
+__syscall int reset_line_toggle(const struct device *dev, uint32_t id);
 
-static inline int z_impl_reset_toggle(const struct device *dev, uint32_t id)
+static inline int z_impl_reset_line_toggle(const struct device *dev, uint32_t id)
 {
 	const struct reset_driver_api *api = (const struct reset_driver_api *)dev->api;
 
-	if (api->toggle == NULL) {
+	if (api->line_toggle == NULL) {
 		return -ENOSYS;
 	}
 
-	return api->toggle(dev, id);
+	return api->line_toggle(dev, id);
 }
 
 /**
@@ -301,15 +301,15 @@ static inline int z_impl_reset_toggle(const struct device *dev, uint32_t id)
  *
  * This is equivalent to:
  *
- *     reset_toggle(spec->dev, spec->id)
+ *     reset_line_toggle(spec->dev, spec->id)
  *
  * @param spec Reset controller specification from devicetree
  *
- * @return a value from reset_toggle()
+ * @return a value from reset_line_toggle()
  */
-static inline int reset_toggle_dt(const struct reset_dt_spec *spec)
+static inline int reset_line_toggle_dt(const struct reset_dt_spec *spec)
 {
-	return reset_toggle(spec->dev, spec->id);
+	return reset_line_toggle(spec->dev, spec->id);
 }
 
 /**


### PR DESCRIPTION
After the discussion in issue https://github.com/zephyrproject-rtos/zephyr/issues/46023 I changed the assert and deassert names from reset controller driver API to line_assert and line_deassert because of newlib assert macro. Also, I added in another commit the reset controller as new driver inside release notes 3.1. 