### PR TITLE
Deprecate civetweb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1824,6 +1824,8 @@ if(CONFIG_SOC_DEPRECATED_RELEASE)
   )
 endif()
 
+include(modules/deprecation_warnings.cmake)
+
 # In CMake projects, 'CMAKE_BUILD_TYPE' usually determines the
 # optimization flag, but in Zephyr it is determined through
 # Kconfig. Here we give a warning when there is a mismatch between the

--- a/modules/Kconfig.civetweb
+++ b/modules/Kconfig.civetweb
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config CIVETWEB
-	bool "Civetweb Support"
+	bool "Civetweb Support (DEPRECATED)"
 	# The CONFIG_NET_TCP_ISN_RFC6528 option would pull in mbedtls,
 	# and there are include file issues if CONFIG_POSIX_API is set.
 	# Because Civetweb sets the POSIX API option in the samples,
@@ -11,3 +11,7 @@ config CIVETWEB
 	depends on !NET_TCP_ISN_RFC6528
 	help
 	  This option enables the civetweb HTTP API.
+	  Support for this module is now deprecated due to a lack
+	  of maintainers. Please volunteer to maintain this module
+	  if you would like to see support for it remain in upstream
+	  Zephyr.

--- a/modules/deprecation_warnings.cmake
+++ b/modules/deprecation_warnings.cmake
@@ -1,0 +1,13 @@
+# Copyright 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# This file is included to warn the user about any deprecated modules
+# they are using. To create a warning, follow the pattern:
+#
+#     if(CONFIG_FOO)
+#       message(WARNING "The foo module is deprecated. <More information>")
+#     endif()
+#
+# This is done in a separate CMake file because the modules.cmake file
+# in this same directory is evaluated before Kconfig runs.
+

--- a/modules/deprecation_warnings.cmake
+++ b/modules/deprecation_warnings.cmake
@@ -11,3 +11,9 @@
 # This is done in a separate CMake file because the modules.cmake file
 # in this same directory is evaluated before Kconfig runs.
 
+if(CONFIG_CIVETWEB)
+  message(WARNING "The civetweb module is deprecated. \
+                   Unless someone volunteers to maintain this module, \
+                   support for it will be removed in Zephyr v3.2."
+    )
+endif()


### PR DESCRIPTION
This module has gone unmaintained and we do not have the resources to
respond to bug reports for it.

The TSC has decided to deprecate it for Zephyr v3.1 and remove it
entirely in Zephyr v3.2 unless a maintainer volunteers to keep this
module up to date and fix bugs.

This commit generates a warning at CMake time if this module is
compiled in. The warning will appear in the cmake output in the same
place that deprecated board or SoC warnings would.
