### PR TITLE
modules: rpi_pico: fix boot_stage2 generation when using Makefiles

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -36,10 +36,10 @@ if(CONFIG_HAS_RPI_PICO)
         -DPYTHON_EXECUTABLE=${Python3_EXECUTABLE}
         -DCONFIG_LEGACY_INCLUDE_PATH=$<BOOL:${CONFIG_LEGACY_INCLUDE_PATH}>
       INSTALL_COMMAND "" # No installation needed
-      BUILD_BYPRODUCTS ${rp2_bootloader_prefix}/boot_stage2.S
+      BUILD_BYPRODUCTS ${rp2_bootloader_prefix}/boot_stage2
       BUILD_ALWAYS TRUE
       )
-    zephyr_library_sources(${rp2_bootloader_prefix}/boot_stage2.S)
+    zephyr_library_sources(${rp2_bootloader_prefix}/boot_stage2)
   endif()
 
   # Pico sources and headers necessary for every build.


### PR DESCRIPTION
Hey, this seems to fix the RPi Pico bootloader build fail when using Makefiles, for example:

`west build -p -b rpi_pico samples/basic/blinky -G"Unix Makefiles"`

and

`./scripts/twister -v -p rpi_pico -T samples/basic/blinky`

Work correctly now.

I'm not trying to pretend that I know why though. Guess the Makefile dependency check was getting confused somehow.

Fixes #46027

-- 8< --

RPi Pico second stage bootloader generation seems to fail when using
Makefiles with:

gmake[2]: *** No rule to make target 'bootloader/boot_stage2.S'...

Changing the ExternalProject_Add byproduct to the actual generated file
and not the .S seems to fix the problem.