### PR TITLE
boards: arm: mec172x: Configure KSI with internal pull-up

### DIFF
--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -236,6 +236,38 @@
 	pinctrl-names = "default";
 };
 
+&ksi0_gpio017 {
+	bias-pull-up;
+};
+
+&ksi1_gpio020 {
+	bias-pull-up;
+};
+
+&ksi2_gpio021 {
+	bias-pull-up;
+};
+
+&ksi3_gpio026 {
+	bias-pull-up;
+};
+
+&ksi4_gpio027 {
+	bias-pull-up;
+};
+
+&ksi5_gpio030 {
+	bias-pull-up;
+};
+
+&ksi6_gpio031 {
+	bias-pull-up;
+};
+
+&ksi7_gpio032 {
+	bias-pull-up;
+};
+
 &pwm0 {
 	status = "okay";
 	pinctrl-0 = <&pwm0_gpio053>;


### PR DESCRIPTION
Even though possible to use external pull-up and open drain buffer,
prefer internal pull-up to reduce power consumption.

Signed-off-by: Jose Alberto Meza <jose.a.meza.arellano@intel.com>