### PR TITLE
Accept unspecified src address if dst is broadcast

### DIFF
--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -278,7 +278,8 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 		goto drop;
 	}
 
-	if (net_ipv4_is_addr_unspecified((struct in_addr *)hdr->src)) {
+	if (net_ipv4_is_addr_unspecified((struct in_addr *)hdr->src) &&
+	    !net_ipv4_is_addr_bcast(net_pkt_iface(pkt), (struct in_addr *)hdr->dst)) {
 		NET_DBG("DROP: src addr is %s", "unspecified");
 		goto drop;
 	}


### PR DESCRIPTION
To be able to accept DHCP discover/request incoming packets the ip stack
neeeds to accept unspecified src addr if the destination is broadcast
address.

Signed-off-by: Olof Winge <olof@skyshaper.net>