### PR TITLE
mgmt/mcumgr/lib: Change image, size and offset types

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -65,9 +65,9 @@ extern struct img_mgmt_state g_img_mgmt_state;
 
 /** Represents an individual upload request. */
 struct img_mgmt_upload_req {
-	unsigned long long image;	/* 0 by default */
-	unsigned long long off;		/* -1 if unspecified */
-	unsigned long long size;	/* -1 if unspecified */
+	uint32_t image;	/* 0 by default */
+	size_t off;	/* SIZE_MAX if unspecified */
+	size_t size;	/* SIZE_MAX if unspecified */
 	struct zcbor_string img_data;
 	struct zcbor_string data_sha;
 	bool upgrade;			/* Only allow greater version numbers. */
@@ -78,9 +78,9 @@ struct img_mgmt_state {
 	/** Flash area being written; -1 if no upload in progress. */
 	int area_id;
 	/** Flash offset of next chunk. */
-	uint32_t off;
+	size_t off;
 	/** Total size of image data. */
-	uint32_t size;
+	size_t size;
 	/** Hash of image data; used for resumption of a partial upload. */
 	uint8_t data_sha_len;
 	uint8_t data_sha[IMG_MGMT_DATA_SHA_LEN];

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -29,6 +29,16 @@ const struct img_mgmt_dfu_callbacks_t *img_mgmt_dfu_callbacks_fn;
 
 struct img_mgmt_state g_img_mgmt_state;
 
+#if SIZE_MAX == UINT32_MAX
+#define zcbor_size_decode	zcbor_uint32_decode
+#define zcbor_size_put		zcbor_uint32_put
+#elif SIZE_MAX == UINT64_MAX
+#define zcbor_size_decode	zcbor_uint64_decode
+#define zcbor_size_put		zcbor_uint64_put
+#else
+#error "Unsupported size_t encoding"
+#endif
+
 #if CONFIG_IMG_MGMT_VERBOSE_ERR
 const char *img_mgmt_err_str_app_reject = "app reject";
 const char *img_mgmt_err_str_hdr_malformed = "header malformed";
@@ -285,7 +295,7 @@ img_mgmt_upload_good_rsp(struct mgmt_ctxt *ctxt)
 	ok = zcbor_tstr_put_lit(zse, "rc")			&&
 	     zcbor_int32_put(zse, MGMT_ERR_EOK)			&&
 	     zcbor_tstr_put_lit(zse, "off")			&&
-	     zcbor_int32_put(zse,  g_img_mgmt_state.off);
+	     zcbor_size_put(zse, g_img_mgmt_state.off);
 
 	return ok ? MGMT_ERR_EOK : MGMT_ERR_EMSGSIZE;
 }
@@ -337,8 +347,8 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 	bool ok;
 	size_t decoded = 0;
 	struct img_mgmt_upload_req req = {
-		.off = -1,
-		.size = -1,
+		.off = SIZE_MAX,
+		.size = SIZE_MAX,
 		.img_data = { 0 },
 		.data_sha = { 0 },
 		.upgrade = false,
@@ -349,10 +359,10 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 	bool last = false;
 
 	struct zcbor_map_decode_key_val image_upload_decode[] = {
-		ZCBOR_MAP_DECODE_KEY_VAL(image, zcbor_int64_decode, &req.image),
+		ZCBOR_MAP_DECODE_KEY_VAL(image, zcbor_uint32_decode, &req.image),
 		ZCBOR_MAP_DECODE_KEY_VAL(data, zcbor_bstr_decode, &req.img_data),
-		ZCBOR_MAP_DECODE_KEY_VAL(len, zcbor_uint64_decode, &req.size),
-		ZCBOR_MAP_DECODE_KEY_VAL(off, zcbor_uint64_decode, &req.off),
+		ZCBOR_MAP_DECODE_KEY_VAL(len, zcbor_size_decode, &req.size),
+		ZCBOR_MAP_DECODE_KEY_VAL(off, zcbor_size_decode, &req.off),
 		ZCBOR_MAP_DECODE_KEY_VAL(sha, zcbor_bstr_decode, &req.data_sha),
 		ZCBOR_MAP_DECODE_KEY_VAL(upgrade, zcbor_bool_decode, &req.upgrade)
 	};

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -530,7 +530,7 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 
 	memset(action, 0, sizeof(*action));
 
-	if (req->off == -1) {
+	if (req->off == SIZE_MAX) {
 		/* Request did not include an `off` field. */
 		IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_hdr_malformed);
 		return MGMT_ERR_EINVAL;
@@ -544,7 +544,7 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 			return MGMT_ERR_EINVAL;
 		}
 
-		if (req->size == -1) {
+		if (req->size == SIZE_MAX) {
 			/* Request did not include a `len` field. */
 			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action, img_mgmt_err_str_hdr_malformed);
 			return MGMT_ERR_EINVAL;


### PR DESCRIPTION
The commit changes types of image, size and offset elements of
img_mgmt_upload_req structure from unsigned long long to ~~uint32_t~~ size_t,
as there is no need for such large type here.

This commit also fixes comments and conditional statements, where
these identifiers have been compared against -1, although they have
been clearly defined as unsigned.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>