### PR TITLE
doc: release-notes: add pinctrl release notes

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -306,6 +306,18 @@ Drivers and Sensors
   * New platforms added to ``pinctrl`` state-based API:
 
     * Atmel SAM/SAM0
+    * Espressif ESP32
+    * ITE IT8XXX2
+    * Microchip XEC
+    * Nordic nRF (completed support)
+    * Nuvoton NPCX Embedded Controller (EC)
+    * NXP iMX
+    * NXP Kinetis
+    * NXP LPC
+    * RV32M1
+    * SiFive Freedom
+    * Telink B91
+    * TI CC13XX/CC26XX
 
 * PWM
 


### PR DESCRIPTION
Add list of platforms that have a new pinctrl driver to the release
notes.