### PR TITLE
samples/mgmt/mcumgr: Remove info on BT tiny configuration

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/README.rst
@@ -85,10 +85,7 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
 
    .. group-tab:: Bluetooth
 
-      The sample application comes in two bluetooth flavours: a normal one and a tiny one
-      for resource constrained bluetooth devices.
-
-      To build the normal bluetooth sample:
+      To build the bluetooth sample:
 
       .. code-block:: console
 
@@ -97,16 +94,6 @@ Zephyr. The ``smp_svr`` sample comes in different flavours.
             samples/subsys/mgmt/mcumgr/smp_svr \
             -- \
             -DOVERLAY_CONFIG=overlay-bt.conf
-
-      And to build the tiny bluetooth sample:
-
-      .. code-block:: console
-
-         west build \
-            -b nrf51dk_nrf51422 \
-            samples/subsys/mgmt/mcumgr/smp_svr \
-            -- \
-            -DOVERLAY_CONFIG=overlay-bt-tiny.conf
 
    .. group-tab:: Serial
 


### PR DESCRIPTION
The BT tiny configuration has been removed some time ago,
but documentation has been still referencing it.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>