### PR TITLE
twister: support standalone run without build

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -759,3 +759,41 @@ dependencies between test cases.  For native_posix platforms, you can provide
 the seed to the random number generator by providing ``-seed=value`` as an
 argument to twister. See :ref:`Shuffling Test Sequence <ztest_shuffle>` for more
 details.
+
+Running test only mode
+**********************
+Enable prebuild binary to be used to test with twister scripts in given test plan.
+
+- Step 1
+
+Create a test plan with below command line.
+
+``
+scripts/twister -p <your platform> -T <test application path> -s <test case name> --build-only --save-tests <path to your saved plan.json>
+``
+
+e.g.
+
+``
+scripts/twister -p frdm_k64f -T tests/kernel/common/ -s "tests/kernel/common/kernel.common"  --build-only --save-tests testplan.json
+``
+
+- Step 2
+
+Put your prebuild zephyr application .bin or .elf or .hex somewhare e.g. ./zephyr.bin
+This file need to pass to west flash with '--bin-file', see below.
+or change to --elf-file, --hex-file, accordigly.
+
+- Step 3
+
+Create your board .config file which only need copy one build from hello_world.
+Put the .config to you run machine e.g. ~/zephyr_runner/zephyr/.config
+And this will be used as --force-board-config-path for west to reference
+
+- Step 4
+
+run below command to download your pre-build binary. e.g.
+
+``
+scripts/twister -p frdm_k64f --device-testing --hardware-map ~/frdm_k64f.yml --test-only --load-tests testplan.json --west-flash="--device=MK64FN1M0xxx12,--bin-file=./zephyr.bin" --force-board-config-path=~/zephyr_runner/
+``

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -808,7 +808,13 @@ class DeviceHandler(Handler):
         logger.debug(f"Using serial device {serial_device} @ {hardware.baud} baud")
 
         if (self.testplan.west_flash is not None) or runner:
-            command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
+            if self.testplan.force_run:
+                os.makedirs(self.build_dir, exist_ok=True)
+                command = ["west", "flash", "-f", "--skip-rebuild",
+                    "-d", self.testplan.force_board_config_path]
+            else:
+                # binary will provide by command line through --west-flash
+                command = ["west", "flash", "--skip-rebuild", "-d", self.build_dir]
             command_extra_args = []
 
             # There are three ways this option is used.

--- a/scripts/twister
+++ b/scripts/twister
@@ -1255,7 +1255,8 @@ def main():
 
     if options.save_tests:
         tplan.json_report(options.save_tests)
-        return
+        if not options.build_only:
+            return
 
     if options.device_testing and not options.build_only:
         print("\nDevice testing on:")

--- a/scripts/twister
+++ b/scripts/twister
@@ -498,6 +498,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         help="Always output ANSI color escape sequences "
                              "even when the output is redirected (not a tty)")
 
+    parser.add_argument(
+        "--force-board-config-path",
+        help="force to use gien board config path "
+             " need use with --force-run.")
+
     parser.add_argument("--force-toolchain", action="store_true",
                         help="Do not filter based on toolchain, use the set "
                              " toolchain unconditionally")
@@ -942,6 +947,9 @@ def main():
     tplan.suite_name_check = not options.disable_suite_name_check
     tplan.seed = options.seed
     tplan.detailed_skipped_report = options.detailed_skipped_report
+    if options.force_board_config_path is not None:
+        tplan.force_run = True
+        tplan.force_board_config_path = os.path.expanduser(options.force_board_config_path)
 
     # get all enabled west projects
     west_proj = west_projects()

--- a/scripts/west_commands/flash.py
+++ b/scripts/west_commands/flash.py
@@ -26,4 +26,7 @@ class Flash(WestCommand):
         return add_parser_common(self, parser_adder)
 
     def do_run(self, my_args, runner_args):
-        do_run_common(self, my_args, runner_args)
+        die_on_error = True
+        if my_args.force:
+            die_on_error = False
+        do_run_common(self, my_args, runner_args, die_on_error)


### PR DESCRIPTION
Enable twister to support standalone run with prebuild image.
skip west local dependency on build information from cmake.

e.g.
```
scripts/twister -p frdm_k64f --device-testing \
--hardware-map ~/frdm_k64f.yml --test-only \
--load-tests testplan.json \
--west-flash="--device=MK64FN1M0xxx12,--bin-file=/home/shared/temp/zephyr.bin" \
--force-board-config-path=~/zephyr_runner/
```
Read the twister guide "Running test only mode" for more

This will enable twister to support distribute build and run