### PR TITLE
tests: log_api: workaround QEMU crashing on qemu_leon3

### DIFF
--- a/tests/subsys/logging/log_api/boards/qemu_leon3.conf
+++ b/tests/subsys/logging/log_api/boards/qemu_leon3.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+# QEMU crashes during log2_api_immediate_printk_cpp.
+# Workaround it by making the main stack larger.
+# See #46056.
+CONFIG_MAIN_STACK_SIZE=4096


### PR DESCRIPTION
When running twister during logging.log2_api_immediate_printk_cpp
on qemu_leon3, it reports unexpected eof even though the tests
reported successful. This results in twister reporting the test
being failed due to "unexpected eof".

When running it using west build, QEMU quits immediately after
printing PROJECT EXECUTION SUCCESSFUL instead of simply waiting
there for Ctrl-A X.

So workaround this by changing the main stack size to 4096.

Related to #46056

Signed-off-by: Daniel Leung <daniel.leung@intel.com>