### PR TITLE
samples: net: cloud: tagio: Drop pinmux dependency

### DIFF
--- a/samples/net/cloud/tagoio_http_post/prj.conf
+++ b/samples/net/cloud/tagoio_http_post/prj.conf
@@ -42,6 +42,3 @@ CONFIG_NET_HTTP_LOG_LEVEL_DBG=n
 # TagoIO API
 CONFIG_TAGOIO_DEVICE_TOKEN="<your device token API>"
 CONFIG_CBPRINTF_FP_SUPPORT=y
-
-# Fix #30029 - Undefined initialization levels used
-CONFIG_PINMUX=y


### PR DESCRIPTION
This dependency it is not required since majoprity of platforms are
working with new pinctrl API. This drops the pinmux dependency.

Fixes #46091

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>