### PR TITLE
samples: clock_control_litex: Fix stale devicetree node reference

### DIFF
--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -28,7 +28,7 @@ Basic configuration of the driver, including default settings for clock outputs,
    :end-at: };
 
 .. literalinclude:: ../../../dts/riscv/riscv32-litex-vexriscv.dtsi
-   :start-at: clock0: clock@82005000 {
+   :start-at: clock0: clock@e0004800 {
    :end-at: };
 
 This configuration defines 2 clock outputs: ``clk0`` and ``clk1`` with default frequency set to 100MHz, 0 degrees phase offset and 50% duty cycle. Special care should be taken when defining values for FPGA-specific configuration (parameters from ``litex,divclk-divide-min`` to ``litex,vco-margin``).


### PR DESCRIPTION
This commit fixes the stale reference to the devicetree
`clock0@82005000` node, which was changed in the commit
7b601b7f5000dcf832aa108cd8138f2df81d9844.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This bug was introduced in https://github.com/zephyrproject-rtos/zephyr/pull/45907.

Fixes the following CI documentation build failure:
https://github.com/zephyrproject-rtos/zephyr/runs/6633592716?check_suite_focus=true#step:7:52

```
Warning, treated as error:
/home/runner/work/zephyr/zephyr/doc/_build/src/samples/drivers/clock_control_litex/README.rst:30:start-at pattern not found: clock0: clock@82005000 {
```
