### PR TITLE
twisterlib: fix the execution time for device testing

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -966,12 +966,12 @@ class DeviceHandler(Handler):
         # so fill the results as blocked
         self.instance.add_missing_testscases("blocked")
 
+        self.instance.execution_time = handler_time
         if harness.state:
             self.instance.status = harness.state
             if harness.state == "failed":
                 self.instance.reason = "Failed"
         else:
-            self.instance.execution_time = handler_time
             self.instance.status = "error"
             self.instance.reason = "No Console Output(Timeout)"
 


### PR DESCRIPTION
At the end of DeviceHandler.handle(), the execution time
should be recorded no matter what the harness.state is.
This reflects how much time has been spent on the device.
And it is also used later to determine if a test has been
attempted on a real device or just build-only.

Signed-off-by: Ming Shao <ming.shao@intel.com>