### PR TITLE
manifest: MCUboot update

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -174,7 +174,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: e58ea98aec6e5539c5f872a98059e461d0155bbb
+      revision: e7415b555134e671ba04f036b02f55cbc087d0e9
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
bring fix from mcu-tools/mcuboot:

- espressif:esp32: Move app entry point call back to
  iram_loader_seg region

fixes #45349
fixes #46093

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>