### PR TITLE
mgmt/mcumgr/lib: Remove dead code from img_mgmt_upload

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -438,15 +438,6 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 
 	/* Write the image data to flash. */
 	if (req.img_data.len != 0) {
-#if CONFIG_IMG_ERASE_PROGRESSIVELY
-		/* erase as we cross sector boundaries */
-		if (img_mgmt_impl_erase_if_needed(req.off, action.write_bytes) != 0) {
-			rc = MGMT_ERR_EUNKNOWN;
-			IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(&action,
-				img_mgmt_err_str_flash_erase_failed);
-			goto end;
-		}
-#endif
 		/* If this is the last chunk */
 		if (g_img_mgmt_state.off + req.img_data.len == g_img_mgmt_state.size) {
 			last = true;

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -488,14 +488,6 @@ end:
 	return rc;
 }
 
-#if CONFIG_IMG_ERASE_PROGRESSIVELY
-int img_mgmt_impl_erase_if_needed(uint32_t off, uint32_t len)
-{
-	/* This is done internally to the flash_img API. */
-	return 0;
-}
-#endif
-
 int
 img_mgmt_impl_swap_type(int slot)
 {


### PR DESCRIPTION
The img_mgmt_impl_erase_if_needed was only called when
CONFIG_IMG_ERASE_PROGRESSIVELY is y, and it does nothing anyway;
because the function always returns 0, and does nothing,
neither the function no result processing, from a call to the
function, is needed.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>