### PR TITLE
drivers: adc: add dt-spec helper functions

### DIFF
--- a/include/zephyr/drivers/adc.h
+++ b/include/zephyr/drivers/adc.h
@@ -724,7 +724,7 @@ static inline uint16_t adc_ref_internal(const struct device *dev)
  * @param gain the ADC gain configuration used to sample the input
  *
  * @param resolution the number of bits in the absolute value of the
- * sample.  For differential sampling this may be one less than the
+ * sample.  For differential sampling this needs to be one less than the
  * resolution in struct adc_sequence.
  *
  * @param valp pointer to the raw measurement value on input, and the

--- a/samples/drivers/adc/README.rst
+++ b/samples/drivers/adc/README.rst
@@ -27,12 +27,11 @@ a devicetree overlay. The example overlay in the ``boards`` subdirectory for
 the ``nucleo_l073rz`` board can be easily adjusted for other boards.
 
 Configuration of channels (settings like gain, reference, or acquisition time)
-can be specified in devicetree, in ADC controller child nodes. Also the ADC
-resolution and oversampling setting to be used for particular channels can
-be specified there. See :zephyr_file:`boards/nrf52840dk_nrf52840.overlay
+also needs to be specified in devicetree, in ADC controller child nodes. Also
+the ADC resolution and oversampling setting (if used) need to be specified
+there. See :zephyr_file:`boards/nrf52840dk_nrf52840.overlay
 <samples/drivers/adc/boards/nrf52840dk_nrf52840.overlay>` for an example of
-such setup. If these parameters are not specified in devicetree, default values,
-supposed to be supported by most ADCs, are used instead.
+such setup.
 
 Building and Running for ST Nucleo L073RZ
 =========================================
@@ -56,6 +55,7 @@ You should get a similar output as below, repeated every second:
 
 .. code-block:: console
 
-   ADC reading(s): 42 (raw)
+   ADC reading:
+   - ADC_0, channel 7: 36 = 65mV
 
 .. note:: If the ADC is not supported, the output will be an error message.

--- a/samples/drivers/adc/boards/atsamd21_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamd21_xpro.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 Argentum Systems Ltd.
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* EXT-1, pin 3 ADC(+) */
 		io-channels = <&adc 8>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@8 {
+		reg = <8>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/atsame54_xpro.overlay
+++ b/samples/drivers/adc/boards/atsame54_xpro.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* EXT-1 ADC(+) */
 		io-channels = <&adc1 6>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/atsamr21_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamr21_xpro.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 Gerson Fernando Budke <nandojve@gmail.com>
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* EXT-1 ADC(+) */
 		io-channels = <&adc 6>;
+	};
+};
+
+&adc {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@6 {
+		reg = <6>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/cc3220sf_launchxl.overlay
+++ b/samples/drivers/adc/boards/cc3220sf_launchxl.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 Pavlo Hamov <pasha.gamov@gmail.com>
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/cc3235sf_launchxl.overlay
+++ b/samples/drivers/adc/boards/cc3235sf_launchxl.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 Pavlo Hamov <pasha.gamov@gmail.com>
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/adc/boards/disco_l475_iot1.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2020 Linaro Limited
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 5>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/frdm_k64f.overlay
+++ b/samples/drivers/adc/boards/frdm_k64f.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2022 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 14>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@e {
+		reg = <14>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
+++ b/samples/drivers/adc/boards/lpcxpresso55s69_cpu0.overlay
@@ -4,9 +4,24 @@
  * Copyright 2022 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc0 0>;
+	};
+};
+
+&adc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1010_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1010_evk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1015_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1015_evk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 13>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@d {
+		reg = <13>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1020_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1020_evk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 10>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1024_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1024_evk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 10>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@a {
+		reg = <10>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1050_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1050_evk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2020 Linaro Limited
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 0>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1060_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1060_evk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 0>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1064_evk.overlay
+++ b/samples/drivers/adc/boards/mimxrt1064_evk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 0>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1160_evk_cm7.overlay
+++ b/samples/drivers/adc/boards/mimxrt1160_evk_cm7.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021, NXP
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>;
+	};
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt1170_evk_cm7.overlay
+++ b/samples/drivers/adc/boards/mimxrt1170_evk_cm7.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2020 Linaro Limited
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>;
+	};
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
+++ b/samples/drivers/adc/boards/mimxrt685_evk_cm33.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2020 Linaro Limited
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&lpadc0 0>;
+	};
+};
+
+&lpadc0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/adc/boards/nrf52840dk_nrf52840.overlay
@@ -21,6 +21,7 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN1>; /* P0.03 */
+		zephyr,resolution = <12>;
 	};
 
 	channel@1 {
@@ -41,5 +42,6 @@
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,input-positive = <NRF_SAADC_AIN6>; /* P0.30 */
 		zephyr,input-negative = <NRF_SAADC_AIN7>; /* P0.31 */
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/nucleo_h7a3zi_q.overlay
+++ b/samples/drivers/adc/boards/nucleo_h7a3zi_q.overlay
@@ -1,9 +1,24 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 15>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@f {
+		reg = <15>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/nucleo_l073rz.overlay
+++ b/samples/drivers/adc/boards/nucleo_l073rz.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2020 Libre Solar Technologies GmbH
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/nucleo_l552ze_q.overlay
+++ b/samples/drivers/adc/boards/nucleo_l552ze_q.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 STMicroelectronics
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/nucleo_wl55jc.overlay
+++ b/samples/drivers/adc/boards/nucleo_wl55jc.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2022 QRTECH
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 5>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@5 {
+		reg = <5>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/sam_e70_xplained.overlay
+++ b/samples/drivers/adc/boards/sam_e70_xplained.overlay
@@ -4,9 +4,32 @@
  * Copyright (c) 2022, Gerson Fernando Budke
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&afec0 0>, <&afec0 8>;
+	};
+};
+
+&afec0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@8 {
+		reg = <8>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/sam_v71_xult.overlay
+++ b/samples/drivers/adc/boards/sam_v71_xult.overlay
@@ -4,9 +4,32 @@
  * Copyright (c) 2022, Gerson Fernando Budke
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&afec0 0>, <&afec0 8>;
+	};
+};
+
+&afec0 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@0 {
+		reg = <0>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
+	};
+
+	channel@8 {
+		reg = <8>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/stm32l496g_disco.overlay
+++ b/samples/drivers/adc/boards/stm32l496g_disco.overlay
@@ -1,9 +1,24 @@
 /* Copyright (c) 2021 STMicroelectronics
    SPDX-License-Identifier: Apache-2.0 */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
  / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 2>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@2 {
+		reg = <2>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/adc/boards/stm32l562e_dk.overlay
@@ -4,9 +4,24 @@
  * Copyright (c) 2021 STMicroelectronics
  */
 
+#include <zephyr/dt-bindings/adc/adc.h>
+
 / {
 	zephyr,user {
 		/* adjust channel number according to pinmux in board.dts */
 		io-channels = <&adc1 13>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@d {
+		reg = <13>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -22,15 +22,6 @@ static const struct adc_dt_spec adc_channels[] = {
 			     DT_SPEC_AND_COMMA)
 };
 
-#define LABEL_AND_COMMA(node_id, prop, idx) \
-	DT_LABEL(DT_IO_CHANNELS_CTLR_BY_IDX(node_id, idx)),
-
-/* Labels of ADC controllers referenced by the above io-channels. */
-static const char *const adc_labels[] = {
-	DT_FOREACH_PROP_ELEM(DT_PATH(zephyr_user), io_channels,
-			     LABEL_AND_COMMA)
-};
-
 /*
  * Common settings supported by most ADCs.
  * If for a given channel a configuration is available in devicetree, values
@@ -142,7 +133,8 @@ void main(void)
 		printk("ADC reading:\n");
 		for (uint8_t i = 0; i < ARRAY_SIZE(adc_channels); i++) {
 			printk("- %s, channel %d: ",
-				adc_labels[i], adc_channels[i].channel_id);
+			       adc_channels[i].dev->name,
+			       adc_channels[i].channel_id);
 
 			prepare_sequence(&sequence, &adc_channels[i]);
 


### PR DESCRIPTION
This patch adds the following dt-spec helpers:

- `adc_channel_setup_dt()`
- `adc_raw_to_millivolts_dt()`
- `adc_sequence_init_dt()`

The objective of these functions is to reduce application boilerplate
when Devicetree is used to configure the ADC.

`sampled/drivers/adc` has been refactored to make use of these helpers. It now requires usage of Devicetree to configure channels, making it simpler and more portable.