### PR TITLE
drivers: opt3001: adding threshold interrupt.

### DIFF
--- a/drivers/sensor/opt3001/CMakeLists.txt
+++ b/drivers/sensor/opt3001/CMakeLists.txt
@@ -3,3 +3,4 @@
 zephyr_library()
 
 zephyr_library_sources(opt3001.c)
+zephyr_library_sources_ifdef(CONFIG_OPT3001_TRIGGER    opt3001_trigger.c)

--- a/drivers/sensor/opt3001/Kconfig
+++ b/drivers/sensor/opt3001/Kconfig
@@ -3,10 +3,55 @@
 # Copyright (c) 2019 Actinius
 # SPDX-License-Identifier: Apache-2.0
 
-config OPT3001
+menuconfig OPT3001
 	bool "OPT3001 Light Sensor"
 	default y
 	depends on DT_HAS_TI_OPT3001_ENABLED
 	select I2C
 	help
 	  Enable driver for OPT3001 light sensors.
+
+if OPT3001
+
+choice OPT3001_TRIGGER_MODE
+	prompt "Trigger mode"
+	help
+	  Specify the type of triggering to be used by the driver.
+
+config OPT3001_TRIGGER_NONE
+	bool "No trigger"
+
+config OPT3001_TRIGGER_GLOBAL_THREAD
+	bool "Use global thread"
+	depends on GPIO
+	select OPT3001_TRIGGER
+
+config OPT3001_TRIGGER_OWN_THREAD
+	bool "Use own thread"
+	depends on GPIO
+	select OPT3001_TRIGGER
+
+endchoice
+
+config OPT3001_TRIGGER
+	bool
+
+if OPT3001_TRIGGER
+
+config OPT3001_THREAD_PRIORITY
+	int "Thread priority"
+	depends on OPT3001_TRIGGER_OWN_THREAD
+	default 10
+	help
+	  Priority of thread used by the driver to handle interrupts.
+
+config OPT3001_THREAD_STACK_SIZE
+	int "Thread stack size"
+	depends on OPT3001_TRIGGER_OWN_THREAD
+	default 1024
+	help
+	  Stack size of thread used by the driver to handle interrupts.
+
+endif # OPT3001_TRIGGER
+
+endif # OPT3001

--- a/drivers/sensor/opt3001/opt3001.h
+++ b/drivers/sensor/opt3001/opt3001.h
@@ -7,8 +7,11 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_OPT3001_H_
 #define ZEPHYR_DRIVERS_SENSOR_OPT3001_H_
 
+#include <zephyr/device.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/gpio.h>
+
 
 #define OPT3001_REG_RESULT 0x00
 #define OPT3001_REG_CONFIG 0x01
@@ -24,12 +27,34 @@
 #define OPT3001_SAMPLE_EXPONENT_SHIFT 12
 #define OPT3001_MANTISSA_MASK 0xfff
 
-struct opt3001_data {
-	uint16_t sample;
-};
-
 struct opt3001_config {
+	struct gpio_dt_spec irq_spec;
 	struct i2c_dt_spec i2c;
 };
 
-#endif /* _SENSOR_OPT3001_ */
+struct opt3001_data {
+	uint16_t sample;
+#if defined(CONFIG_OPT3001_TRIGGER)
+	const struct device *dev;
+	struct gpio_callback gpio_cb;
+	sensor_trigger_handler_t limit_handler;
+#endif /* CONFIG_OPT3001_TRIGGER */
+#if defined(CONFIG_OPT3001_TRIGGER_OWN_THREAD)
+	K_KERNEL_STACK_MEMBER(thread_stack, CONFIG_OPT3001_THREAD_STACK_SIZE);
+	struct k_thread thread;
+	struct k_sem gpio_sem;
+#elif defined(CONFIG_OPT3001_TRIGGER_GLOBAL_THREAD)
+	struct k_work work;
+#endif /* CONFIG_OPT3001_TRIGGER_GLOBAL_THREAD */
+};
+
+#if defined(CONFIG_OPT3001_TRIGGER)
+int opt3001_trigger_init(const struct device *device);
+
+int opt3001_trigger_set(const struct device *dev,
+			const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler);
+int opt3001_set_th(const struct device *device, uint16_t value, uint8_t addr);
+#endif /* CONFIG_OPT3001_TRIGGER */
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_OPT3001_H_ */

--- a/drivers/sensor/opt3001/opt3001_trigger.c
+++ b/drivers/sensor/opt3001/opt3001_trigger.c
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2022 Intellinium <giuliano.franchetto@intellinium.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/sys/byteorder.h>
+#include "opt3001.h"
+
+#define DT_DRV_COMPAT ti_opt3001
+
+static void opt3001_gpio_callback(const struct device *dev,
+				  struct gpio_callback *cb, uint32_t pins)
+{
+	ARG_UNUSED(dev);
+	ARG_UNUSED(pins);
+
+	struct opt3001_data *data =
+		CONTAINER_OF(cb, struct opt3001_data, gpio_cb);
+	const struct opt3001_config *cfg = data->dev->config;
+
+	gpio_pin_interrupt_configure_dt(&cfg->irq_spec, GPIO_INT_DISABLE);
+
+#if defined(CONFIG_OPT3001_TRIGGER_OWN_THREAD)
+	k_sem_give(&data->gpio_sem);
+#elif defined(CONFIG_OPT3001_TRIGGER_GLOBAL_THREAD)
+	k_work_submit(&data->work);
+#endif /* CONFIG_OPT3001_TRIGGER_OWN_THREAD */
+}
+
+static void opt3001_handle_interrupt(const struct device *dev)
+{
+	int err;
+	uint16_t config;
+	struct opt3001_data *data = dev->data;
+	const struct opt3001_config *cfg = dev->config;
+	struct sensor_trigger limit_trig = {
+		.type = SENSOR_TRIG_THRESHOLD,
+		.chan = SENSOR_CHAN_ALL,
+	};
+
+	/* Reading the configuration field to clear irq */
+	err = i2c_burst_read_dt(&cfg->i2c, 0x01, (uint8_t *) &config, 2);
+	if (err) {
+		goto rearm;
+	}
+
+	if (!data->limit_handler) {
+		goto rearm;
+	}
+
+	data->limit_handler(dev, &limit_trig);
+
+rearm:
+	gpio_pin_interrupt_configure_dt(&cfg->irq_spec,
+					GPIO_INT_EDGE_TO_ACTIVE);
+}
+
+#if CONFIG_OPT3001_TRIGGER_OWN_THREAD
+static void opt3001_thread(struct opt3001_data *data)
+{
+	while (1) {
+		k_sem_take(&data->gpio_sem, K_FOREVER);
+		opt3001_handle_interrupt(data->dev);
+	}
+}
+#endif /* CONFIG_OPT3001_TRIGGER_OWN_THREAD */
+
+#ifdef CONFIG_OPT3001_TRIGGER_GLOBAL_THREAD
+static void opt3001_work_cb(struct k_work *work)
+{
+	struct opt3001_data *data =
+		CONTAINER_OF(work, struct opt3001_data, work);
+
+	opt3001_handle_interrupt(data->dev);
+}
+#endif /* CONFIG_OPT3001_TRIGGER_GLOBAL_THREAD */
+
+int opt3001_set_th(const struct device *dev,
+		   uint16_t value,
+		   uint8_t addr)
+{
+	uint8_t le;
+	uint16_t tl;
+	uint32_t v;
+	struct opt3001_data *data = dev->data;
+	const struct opt3001_config *cfg = dev->config;
+
+	/* The values used here are the full-scale range limits for each
+	 * low-limit register exponent.
+	 * More information can be found using Table 12 of the opt3001
+	 * datasheet
+	 */
+	if (value <= 40.95) {
+		le = 0;
+	} else if (40.95 < value && value <= 81.90) {
+		le = 1;
+	} else if (81.90 < value && value <= 163.80) {
+		le = 2;
+	} else if (163.80 < value && value <= 327.60) {
+		le = 3;
+	} else if (327.60 < value && value <= 655.20) {
+		le = 4;
+	} else if (655.20 < value && value <= 1310.40) {
+		le = 5;
+	} else if (1310.40 < value && value <= 2620.80) {
+		le = 6;
+	} else if (2620.80 < value && value <= 5241.60) {
+		le = 7;
+	} else if (5241.60 < value && value <= 10483.20) {
+		le = 8;
+	} else if (10483.20 < value && value <= 20966.40) {
+		le = 9;
+	} else if (20966.40 < value && value <= 41932.80) {
+		le = 10;
+	} else {
+		le = 11;
+	}
+
+	v = ((uint32_t) (value * 100.0)) >> le;
+	tl = (v & 0x0FFF) | (le << 12);
+	tl = sys_be16_to_cpu(tl);
+
+	uint8_t buf[3] = {
+		addr,
+		tl & 0xff,
+		tl >> 8
+	};
+
+	return i2c_write_dt(&cfg->i2c, buf, 3);
+}
+
+static int opt3001_set_higher_th(const struct device *dev, uint16_t value)
+{
+	return opt3001_set_th(dev, value, 0x03);
+}
+
+static int opt3001_set_lower_th(const struct device *dev, uint16_t value)
+{
+	return opt3001_set_th(dev, value, 0x02);
+}
+
+static int opt3001_enable_int(const struct device *dev, bool enabled)
+{
+	int err;
+	const struct opt3001_config *config = dev->config;
+
+	if (enabled) {
+		gpio_pin_interrupt_configure_dt(&config->irq_spec,
+						GPIO_INT_EDGE_TO_ACTIVE);
+		return 0;
+	}
+
+	gpio_pin_interrupt_configure_dt(&config->irq_spec,
+					GPIO_INT_DISABLE);
+
+	err = opt3001_set_lower_th(dev, 0x0000);
+	if (err) {
+		return err;
+	}
+
+	return opt3001_set_higher_th(dev, 0xBFFF);
+}
+
+int opt3001_trigger_set(const struct device *dev,
+			const struct sensor_trigger *trig,
+			sensor_trigger_handler_t handler)
+{
+	struct opt3001_data *data = dev->data;
+	bool enabled = handler != NULL;
+
+	switch (trig->type) {
+	case SENSOR_TRIG_THRESHOLD:
+		data->limit_handler = handler;
+		return opt3001_enable_int(dev, enabled);
+	default:
+		return -EINVAL;
+	}
+}
+
+int opt3001_trigger_init(const struct device *dev)
+{
+	int err;
+	struct opt3001_data *data = dev->data;
+	const struct opt3001_config *cfg = dev->config;
+
+	if (!device_is_ready(cfg->irq_spec.port)) {
+		return -ENOSYS;
+	}
+
+	data->dev = dev;
+
+	err = gpio_pin_configure_dt(&cfg->irq_spec, GPIO_INPUT);
+	if (err) {
+		return err;
+	}
+
+	gpio_init_callback(&data->gpio_cb,
+			   opt3001_gpio_callback,
+			   BIT(cfg->irq_spec.pin));
+
+	err = gpio_add_callback(cfg->irq_spec.port, &data->gpio_cb);
+	if (err) {
+		return err;
+	}
+
+#if defined(CONFIG_OPT3001_TRIGGER_OWN_THREAD)
+	k_sem_init(&data->gpio_sem, 0, K_SEM_MAX_LIMIT);
+
+	k_thread_create(&data->thread, data->thread_stack,
+			CONFIG_OPT3001_THREAD_STACK_SIZE,
+			(k_thread_entry_t) opt3001_thread, data,
+			NULL, NULL, K_PRIO_COOP(CONFIG_OPT3001_THREAD_PRIORITY),
+			0, K_NO_WAIT);
+#elif defined(CONFIG_OPT3001_TRIGGER_GLOBAL_THREAD)
+	data->work.handler = opt3001_work_cb;
+#endif /* CONFIG_OPT3001_TRIGGER_GLOBAL_THREAD */
+
+	return 0;
+}

--- a/dts/bindings/sensor/ti,opt3001.yaml
+++ b/dts/bindings/sensor/ti,opt3001.yaml
@@ -6,3 +6,9 @@ description: Texas Instruments OPT3001 ambient light sensor
 compatible: "ti,opt3001"
 
 include: [sensor-device.yaml, i2c-device.yaml]
+
+properties:
+    irq-gpios:
+      # This signal is active high when produced by the sensor
+      type: phandle-array
+      required: false


### PR DESCRIPTION
This commit adds interrupt management on the opt300x sensors. The
only available interrupt is a lower/upper threshold, as defined in
the component datasheet.

Signed-off-by: GiulianoFranchetto <giuliano.franchetto@intellinium.com>