### PR TITLE
logging: hide logging from jetbrains ide

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -448,10 +448,10 @@ static inline char *log_strdup(const char *str)
 				Z_LOG_RESOLVED_LEVEL(level, 0)
 
 /*
- * Eclipse CDT parser is sometimes confused by logging API code and freezes the
- * whole IDE. Following lines hides LOG_x macros from CDT.
+ * Eclipse CDT or JetBrains Clion parser is sometimes confused by logging API
+ * code and freezes the whole IDE. Following lines hides LOG_x macros from them.
  */
-#if defined(__CDT_PARSER__)
+#if defined(__CDT_PARSER__) || defined(__JETBRAINS_IDE__)
 #undef LOG_ERR
 #undef LOG_WRN
 #undef LOG_INF


### PR DESCRIPTION
For now, the logging subsystem is hidden from CDT to prevent freezing of
the IDE.
CLion has the same issue, where the IDE becomes very slow with big RAM spikes.
Fortunately, CLion automatically defines a macro ```__JETBRAINS_IDE__``` that we
can use

Signed-off-by: Giuliano Franchetto <giuliano.franchetto@intellinium.com>