### PR TITLE
Bluetooth: Controller: hci: Fix wrong periodic advertising report data status

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -7087,6 +7087,15 @@ no_ext_hdr:
 				 * mark as partial data.
 				 */
 				data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_PARTIAL;
+			} else if (ftr->aux_sched &&
+				   (data_len_total == CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX) &&
+				   (cte_type != BT_HCI_LE_NO_CTE)) {
+				/* No data left but: have AuxPtr, scheduled aux scan and CTE is
+				 * included in a PDU, there is another chained PDU that is empty
+				 * but has CTE.
+				 */
+				data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS_COMPLETE;
+
 			} else {
 				/* No data left, have AuxPtr but not aux scan scheduled,
 				 * mark as incomplete data.


### PR DESCRIPTION
The periodic advertising data status may be set to wrong value when
preparing a report event in HCI layer.

In case there periodic advertiser:
- sends a data with length that is equal to CONFIG_BT_CTLR_SCAN_DATA-
  _LEN_MAX.
- the periodic advertising has included CTE
- the number of PDUs in a chain is larger than required for transport
  of advertising data (e.g. for max AD payload of 1650 bytes, minimum
  required number of PDUs is 7). In other words there are empty PDUs
  added to the chain to transport CTE.
the event generated in HCI layer has data status set to BT_HCI_LE_AD-
_EVT_TYPE_DATA_STATUS_INCOMPLETE.

That is caused by missing else-if clause that checks case when no
more data are expected but there are advertising PDUs in a periodic
advertising train. In such situation: there is an AuxPtr, scan for
next PDU was scheduled, total amount of data reached max defined by
CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX and there is a CTE in a PDU the
report event is generated for.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/46121

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>