### PR TITLE
Add support for optimized CMSIS-NN kernels with TFLM

### DIFF
--- a/modules/tflite-micro/CMakeLists.txt
+++ b/modules/tflite-micro/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 Intel Corporation
+# Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 if(CONFIG_TENSORFLOW_LITE_MICRO)
@@ -13,6 +14,14 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/third_party_static/flatbuffers/include
     ${TENSORFLOW_LITE_MICRO_DIR}/third_party_static/ruy
   )
+
+  if(CONFIG_TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS)
+    set(CMSIS_NN_OPTIMIZED_KERNEL_DIR cmsis_nn)
+    set(tflm_cmsis_nn_glue_path ${ZEPHYR_CMSIS_MODULE_DIR})
+
+    zephyr_library_include_directories(${tflm_cmsis_nn_glue_path})
+    zephyr_library_compile_definitions(CMSIS_NN)
+  endif()
 
   zephyr_library_sources(
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/simple_memory_allocator.cc
@@ -45,7 +54,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/schema/schema_utils.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/activations.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/activations_common.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/add.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/add.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/add_n.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/arg_min_max.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/batch_to_space_nd.cc
@@ -54,11 +63,11 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/circular_buffer.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/comparisons.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/concatenation.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/conv.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/conv.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/conv_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/cumsum.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/depth_to_space.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/depthwise_conv.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/depthwise_conv.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/depthwise_conv_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/dequantize.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/detection_postprocess.cc
@@ -71,7 +80,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/floor.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/floor_div.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/floor_mod.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/fully_connected.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/fully_connected.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/fully_connected_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/gather.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/gather_nd.cc
@@ -89,11 +98,11 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/logistic_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/log_softmax.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/maximum_minimum.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/mul.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/mul.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/neg.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/pack.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/pad.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/pooling.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/pooling.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/pooling_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/prelu.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/quantize.cc
@@ -104,7 +113,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/resize_nearest_neighbor.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/round.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/shape.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/softmax.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/softmax.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/softmax_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/space_to_batch_nd.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/space_to_depth.cc
@@ -113,7 +122,7 @@ if(CONFIG_TENSORFLOW_LITE_MICRO)
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/squeeze.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/strided_slice.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/sub.cc
-    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/svdf.cc
+    ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/${CMSIS_NN_OPTIMIZED_KERNEL_DIR}/svdf.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/svdf_common.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/tanh.cc
     ${TENSORFLOW_LITE_MICRO_DIR}/tensorflow/lite/micro/kernels/transpose.cc

--- a/modules/tflite-micro/Kconfig
+++ b/modules/tflite-micro/Kconfig
@@ -1,4 +1,5 @@
 # Copyright (c) 2021 Intel Corporation
+# Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: Apache-2.0
 
 config ZEPHYR_TFLITE-MICRO_MODULE
@@ -8,3 +9,24 @@ config TENSORFLOW_LITE_MICRO
 	bool "TensorFlow Lite Micro Support"
 	help
 	  This option enables the TensorFlow Lite Micro library.
+
+if CPU_CORTEX_M
+
+config TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS
+	bool "TensorFlow Lite Micro with optimized CMSIS-NN kernels"
+	depends on TENSORFLOW_LITE_MICRO
+	select CMSIS_NN
+	select CMSIS_NN_ACTIVATION
+	select CMSIS_NN_BASICMATH
+	select CMSIS_NN_CONCATENATION
+	select CMSIS_NN_CONVOLUTION
+	select CMSIS_NN_FULLYCONNECTED
+	select CMSIS_NN_NNSUPPORT
+	select CMSIS_NN_POOLING
+	select CMSIS_NN_RESHAPE
+	select CMSIS_NN_SOFTMAX
+	select CMSIS_NN_SVD
+	help
+	  This option adds support for CMSIS-NN optimized kernels when using TensorFlow Lite Micro.
+
+endif # CPU_CORTEX_M

--- a/samples/modules/tflite-micro/hello_world/README.rst
+++ b/samples/modules/tflite-micro/hello_world/README.rst
@@ -18,6 +18,9 @@ The sample also includes a full end-to-end workflow of training
 a model and converting it for use with TensorFlow Lite Micro for
 running inference on a microcontroller.
 
+The sample comes in two flavors. One with TensorFlow Lite Micro
+reference kernels and one with CMSIS-NN optimized kernels.
+
 .. Note::
    This README and sample have been modified from
    `the TensorFlow Hello World sample for Zephyr`_.
@@ -28,10 +31,10 @@ running inference on a microcontroller.
 Building and Running
 ********************
 
-This sample should work on most boards since it does not rely
+The sample should work on most boards since it does not rely
 on any sensors.
 
-This application can be built and executed on QEMU as follows:
+The reference kernel application can be built and executed on QEMU as follows:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/modules/tensorflow/hello_world
@@ -41,6 +44,23 @@ This application can be built and executed on QEMU as follows:
    :compact:
 
 Exit QEMU by pressing :kbd:`CTRL+A` :kbd:`x`.
+
+The CMSIS-NN kernel application can be built and executed on any Arm(R) Cortex(R)-M core based platform,
+for example based on Arm Corstone(TM)-300 software. A reference implementation of Corstone-300
+can be downloaded either as a FPGA bitfile for the
+[MPS3 FPGA prototyping board](https://developer.arm.com/tools-and-software/development-boards/fpga-prototyping-boards/mps3),
+or as a
+[Fixed Virtual Platform](https://developer.arm.com/tools-and-software/open-source-software/arm-platforms-software/arm-ecosystem-fvps)
+that can be emulated on a host machine.
+
+Assuming that the Corstone-300 FVP has been downloaded, installed and added to
+the `PATH` variable, then building and testing can be done with following
+commands.
+
+```
+$ west build -p auto -b mps3_an547 samples/modules/tflite-micro/hello_world/ -T sample.tensorflow.helloworld.cmsis_nn
+$ FVP_Corstone_SSE-300_Ethos-U55 build/zephyr/zephyr.elf
+```
 
 Sample Output
 =============
@@ -76,6 +96,14 @@ TensorFlow, you must enable the below Kconfig options in your :file:`prj.conf`:
     CONFIG_CPLUSPLUS=y
     CONFIG_NEWLIB_LIBC=y
     CONFIG_TENSORFLOW_LITE_MICRO=y
+
+Note that the CMSIS-NN kernel sample demonstrates how to use CMSIS-NN optimized kernels with
+TensorFlow Lite Micro, in that is sets below Kconfig option. Note also that this
+Kconfig option is only set for Arm Cortex-M cores, i.e. option CPU_CORTEX_M is set.
+
+.. code-block:: kconfig
+
+    CONFIG_TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS=y
 
 Training
 ********

--- a/samples/modules/tflite-micro/hello_world/sample.yaml
+++ b/samples/modules/tflite-micro/hello_world/sample.yaml
@@ -16,3 +16,8 @@ tests:
   sample.tensorflow.helloworld:
     platform_allow: qemu_x86 qemu_x86_64
     tags: tensorflow
+  sample.tensorflow.helloworld.cmsis_nn:
+    tags: tensorflow
+    platform_allow: mps3_an547
+    extra_configs:
+    - CONFIG_TENSORFLOW_LITE_MICRO_CMSIS_NN_KERNELS=y


### PR DESCRIPTION
Updates TensorFlow Lite Micro module with option for CMSIS-NN optimized
kernels.
Updates corresponding sample hello_world to use CMSIS-NN optimized kernels.

Signed-off-by: Måns Nilsson <mans.nilsson@arm.com>