### PR TITLE
stm32g0x  ADC drivers apply errata during sampling config

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -792,6 +792,10 @@ static void adc_stm32_setup_speed(const struct device *dev, uint8_t id,
 	LL_ADC_SetSamplingTimeCommonChannels(adc,
 		table_samp_time[acq_time_index]);
 #elif defined(CONFIG_SOC_SERIES_STM32G0X)
+	/* Errata ES0418 and more: ADC sampling time might be one cycle longer */
+	if (acq_time_index  < 2) {
+		acq_time_index = 2;
+	}
 	LL_ADC_SetSamplingTimeCommonChannels(adc, LL_ADC_SAMPLINGTIME_COMMON_1,
 		table_samp_time[acq_time_index]);
 #else

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -52,7 +52,8 @@
 
 #elif defined(CONFIG_BOARD_NUCLEO_F207ZG) || \
 	defined(CONFIG_BOARD_NUCLEO_F429ZI) || \
-	defined(CONFIG_BOARD_NUCLEO_F746ZG)
+	defined(CONFIG_BOARD_NUCLEO_F746ZG) || \
+	defined(CONFIG_BOARD_NUCLEO_G071RB)
 /*
  * DAC output on PA4
  * ADC input read from PA0

--- a/tests/drivers/dac/dac_loopback/testcase.yaml
+++ b/tests/drivers/dac/dac_loopback/testcase.yaml
@@ -9,4 +9,4 @@ tests:
     platform_allow: |
       frdm_k22f frdm_k64f nucleo_f207zg nucleo_l073rz nucleo_l152re twr_ke18f
       bl652_dvk bl653_dvk bl654_dvk bl5340_dvk_cpuapp stm32f3_disco stm32l562e_dk
-      nucleo_l552ze_q nucleo_f429zi nucleo_f746zg nucleo_wl55jc
+      nucleo_l552ze_q nucleo_f429zi nucleo_f746zg nucleo_g071rb nucleo_wl55jc


### PR DESCRIPTION
This PR applies what is described by the Errata sheet  : ADC sampling time might be one cycle longer
_For sampling time set to 1.5 or 3.5 cycles, the sampling in a single ADC conversion or in the first conversion of a
sequence takes one extra cycle._
The workaround minimize the acq_time_index to 2 when `LL_ADC_SetSamplingTimeCommonChannels` during the channel setup.
The problem is reported for 

- [ES0418: STM32G071xx device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/7d/72/f5/7b/7a/61/45/89/DM00463881/files/DM00463881.pdf/jcr:content/translations/en.DM00463881.pdf)
- [ES0547: STM32G0B0CE/KE/RE/VE device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/0e/a9/6b/b4/2c/dd/44/3e/DM00760231/files/DM00760231.pdf/jcr:content/translations/en.DM00760231.pdf)
- [ES0548: STM32G0B1xB/xC/xE device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/5b/85/f7/7e/5e/a1/49/c5/DM00760234/files/DM00760234.pdf/jcr:content/translations/en.DM00760234.pdf)
- [ES0549: STM32G0C1xC/xE device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/49/06/ca/d8/5b/78/43/a5/DM00760235/files/DM00760235.pdf/jcr:content/translations/en.DM00760235.pdf)
- [ES0486: STM32G030x6/x8 device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/0d/32/9d/5a/16/42/45/41/DM00625292/files/DM00625292.pdf/jcr:content/translations/en.DM00625292.pdf)
- [ES0487: STM32G031x4/x6/x8 device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/63/98/e3/8c/5a/64/49/80/DM00625293/files/DM00625293.pdf/jcr:content/translations/en.DM00625293.pdf)
- [ES0488: STM32G041x6/x8 device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/44/16/6b/6d/80/fc/40/60/DM00625294/files/DM00625294.pdf/jcr:content/translations/en.DM00625294.pdf)
- [ES0544: STM32G050x6/x8 device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/52/74/82/ae/29/ce/48/75/DM00760221/files/DM00760221.pdf/jcr:content/translations/en.DM00760221.pdf)
- [ES0545: STM32G051x6/x8 device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/61/27/97/f9/7c/41/46/46/DM00760224/files/DM00760224.pdf/jcr:content/translations/en.DM00760224.pdf)
- [ES0546: STM32G061x6/x8 device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/3d/22/39/02/c7/e5/4c/67/DM00760228/files/DM00760228.pdf/jcr:content/translations/en.DM00760228.pdf)
- [ES0468: STM32G070CB/KB/RB device errata](https://www.st.com/content/ccc/resource/technical/document/errata_sheet/group0/d0/b9/8e/cb/9d/4b/48/2e/DM00558728/files/DM00558728.pdf/jcr:content/translations/en.DM00558728.pdf)





Fixes https://github.com/zephyrproject-rtos/zephyr/issues/46124

Signed-off-by: Francois Ramu <francois.ramu@st.com>
