### PR TITLE
boards: nrf52_bsim: Remove useless include of irq_sources.h

### DIFF
--- a/boards/posix/nrf52_bsim/board_soc.h
+++ b/boards/posix/nrf52_bsim/board_soc.h
@@ -27,7 +27,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <zephyr/irq.h>
-#include "irq_sources.h"
 #include <nrfx.h>
 #include "cmsis.h"
 


### PR DESCRIPTION
This file defines IRQ numbers that are already defined in the MDK
headers, so there is no need of including it.

This will later allow us to remove it from the HW models.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>