### PR TITLE
twisterlib: drain the serial leftover before new test

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -896,6 +896,15 @@ class DeviceHandler(Handler):
 
         ser.flush()
 
+        # turns out the ser.flush() is not enough to clear serial leftover from last case
+        # explicitly readline() can do it reliably
+        old_timeout = ser.timeout
+        ser.timeout = 1 # wait for 1s if no serial output
+        leftover_lines = ser.readlines(1000) # or read 1000 lines at most
+        for line in leftover_lines:
+            logger.debug(f"leftover log of previous test: {line}")
+        ser.timeout = old_timeout
+
         harness_name = self.instance.testsuite.harness.capitalize()
         harness_import = HarnessImporter(harness_name)
         harness = harness_import.instance


### PR DESCRIPTION
Some tests can cause serial leftover logs buffered on board.
A simple ser.flush() is not enough. So add explicit readline()
to drain such logs which prepares a clean serial context for
the case that follows.

Signed-off-by: Ming Shao <ming.shao@intel.com>

For example:
Run "tests/arch/arm/arm_runtime_nmi" on reel_board.
After twister finishes running, use command like `minicom -D /dev/ttyACM0` to read the serial port.
Some leftover log from the certain cases can be obtained. Such as below.

Such log will be captured by the next case and jeopardize its result.
And cause a chain of failures for the cases that follow due to mismatch between buffered serial logs and the executed test cases.

```
 10.51 seconds
===================================================================
TESTSUITE arm_runtime_nmi_fn succeeded
===================================================================
RunID: 674cbc6e5a1e2927ae5b4b389a9546d5
PROJECT EXECUTION SUCCESSFUL
```




