### PR TITLE
drivers:ethernet:eth_w5500 fixes,command read_back/reset pin toggle

### DIFF
--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -508,6 +508,7 @@ static int w5500_init(const struct device *dev)
 		}
 		gpio_pin_set_dt(&config->reset, 0);
 		k_usleep(500);
+		gpio_pin_set_dt(&config->reset, 1);
 	}
 
 	err = w5500_hw_reset(dev);

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -160,18 +160,17 @@ static int w5500_command(const struct device *dev, uint8_t cmd)
 	uint64_t end = sys_clock_timeout_end_calc(K_MSEC(100));
 
 	w5500_spi_write(dev, W5500_S0_CR, &cmd, 1);
-	do {
+	while (1) {
+		w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
+		if (!reg) {
+			break;
+			}
 		int64_t remaining = end - sys_clock_tick_get();
-
 		if (remaining <= 0) {
 			return -EIO;
+			}
+		k_busy_wait(W5500_PHY_ACCESS_DELAY);
 		}
-
-		w5500_spi_read(dev, W5500_S0_CR, &reg, 1);
-
-		k_msleep(1);
-	} while (reg != 0);
-
 	return 0;
 }
 

--- a/drivers/ethernet/eth_w5500_priv.h
+++ b/drivers/ethernet/eth_w5500_priv.h
@@ -76,6 +76,8 @@
 #define W5500_Sn_RX_MEM_START	0x30000
 #define W5500_RX_MEM_SIZE	0x04000
 
+/* Delay for PHY write/read operations (25.6 us) */
+#define W5500_PHY_ACCESS_DELAY		26U
 struct w5500_config {
 	struct spi_dt_spec spi;
 	struct gpio_dt_spec interrupt;


### PR DESCRIPTION
added changes for eth_w5500  command read back  and change from k_sleep to k_busy_wait
which will allow other threads to wakeup.
added  toggle reset gpio in w5500_init function

coverity CID:214870
