### PR TITLE
Revert "net: tcp: Correctly determine when the TCP transmit window is…

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -978,7 +978,7 @@ static int tcp_pkt_peek(struct net_pkt *to, struct net_pkt *from, size_t pos,
 
 static bool tcp_window_full(struct tcp *conn)
 {
-	bool window_full = (conn->send_data_total >= conn->send_win);
+	bool window_full = !(conn->unacked_len < conn->send_win);
 
 	NET_DBG("conn: %p window_full=%hu", conn, window_full);
 


### PR DESCRIPTION
… full"

Revert this commit, because it interfers with the newly added TCP polling.
Take the time to fix it at a later time.

Signed-off-by: Sjors Hettinga <s.a.hettinga@gmail.com>

This reverts commit c668199b5d09add7ef2ed83233828d7ac733c07e.