### PR TITLE
mgmt: smp: Allow building with POSIX API in UDP transport

### DIFF
--- a/subsys/mgmt/mcumgr/Kconfig
+++ b/subsys/mgmt/mcumgr/Kconfig
@@ -303,7 +303,7 @@ menuconfig MCUMGR_SMP_UDP
 	select NETWORKING
 	select NET_UDP
 	select NET_SOCKETS
-	select NET_SOCKETS_POSIX_NAMES
+	select NET_SOCKETS_POSIX_NAMES if !POSIX_API
 	help
 	  Enables handling of SMP commands received over UDP.
 	  Will start a thread for listening on the configured UDP port.

--- a/subsys/mgmt/mcumgr/smp_udp.c
+++ b/subsys/mgmt/mcumgr/smp_udp.c
@@ -11,7 +11,12 @@
 
 #include <zephyr/zephyr.h>
 #include <zephyr/init.h>
+#if defined(CONFIG_POSIX_API)
+#include <zephyr/posix/unistd.h>
+#include <zephyr/posix/sys/socket.h>
+#else
 #include <zephyr/net/socket.h>
+#endif
 #include <errno.h>
 #include <mgmt/mgmt.h>
 #include <zephyr/mgmt/mcumgr/smp_udp.h>


### PR DESCRIPTION
This PR makes it possible to build the SMP UDP transport with the POSIX API enabled (i.e. `POSIX_API`) by not selecting the conflicting `NET_SOCKETS_POSIX_NAMES` option and using the POSIX headers instead.
