### PR TITLE
Bluetooth: Host: Properly clean up `acl_tx_pool` user data (Take 2)

### DIFF
--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -139,7 +139,7 @@ static k_tid_t att_handle_rsp_thread;
 
 struct bt_att_tx_meta_data {
 	struct bt_att_chan *att_chan;
-	bt_conn_tx_cb_t func;
+	bt_gatt_complete_func_t func;
 	void *user_data;
 };
 
@@ -3719,7 +3719,7 @@ bool bt_att_out_of_sync_sent_on_fixed(struct bt_conn *conn)
 	return atomic_test_bit(att_chan->flags, ATT_OUT_OF_SYNC_SENT);
 }
 
-void bt_att_set_tx_meta_data(struct net_buf *buf, bt_conn_tx_cb_t func, void *user_data)
+void bt_att_set_tx_meta_data(struct net_buf *buf, bt_gatt_complete_func_t func, void *user_data)
 {
 	struct bt_att_tx_meta_data *data = bt_att_tx_meta_data(buf);
 
@@ -3727,7 +3727,7 @@ void bt_att_set_tx_meta_data(struct net_buf *buf, bt_conn_tx_cb_t func, void *us
 	data->user_data = user_data;
 }
 
-bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_conn_tx_cb_t func,
+bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_gatt_complete_func_t func,
 			       const void *user_data)
 {
 	return ((bt_att_tx_meta_data(buf)->func == func) &&

--- a/subsys/bluetooth/host/att.c
+++ b/subsys/bluetooth/host/att.c
@@ -418,14 +418,17 @@ static void chan_tx_complete(struct bt_conn *conn, void *user_data, int err)
 {
 	struct bt_att_tx_meta_data *data = user_data;
 	struct bt_att_chan *chan = data->att_chan;
+	bt_gatt_complete_func_t func = data->func;
+	void *ud = data->user_data;
 
 	BT_DBG("TX Complete chan %p CID 0x%04X", chan, chan->chan.tx.cid);
 
-	if (!err && data->func) {
-		data->func(conn, data->user_data);
+	tx_meta_data_free(data);
+
+	if (!err && func) {
+		func(conn, ud);
 	}
 
-	tx_meta_data_free(data);
 }
 
 static void chan_unknown(struct bt_conn *conn, void *user_data, int err)

--- a/subsys/bluetooth/host/att_internal.h
+++ b/subsys/bluetooth/host/att_internal.h
@@ -317,7 +317,9 @@ void bt_att_clear_out_of_sync_sent(struct bt_conn *conn);
 /* Check if BT_ATT_ERR_DB_OUT_OF_SYNC has been sent on the fixed ATT channel */
 bool bt_att_out_of_sync_sent_on_fixed(struct bt_conn *conn);
 
-void bt_att_set_tx_meta_data(struct net_buf *buf, bt_conn_tx_cb_t func, void *user_data);
 
-bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_conn_tx_cb_t func,
+typedef void (*bt_gatt_complete_func_t) (struct bt_conn *conn, void *user_data);
+void bt_att_set_tx_meta_data(struct net_buf *buf, bt_gatt_complete_func_t func, void *user_data);
+
+bool bt_att_tx_meta_data_match(const struct net_buf *buf, bt_gatt_complete_func_t func,
 			       const void *user_data);

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -48,6 +48,23 @@ struct tx_meta {
 #define tx_data(buf) ((struct tx_meta *)net_buf_user_data(buf))
 K_FIFO_DEFINE(free_tx);
 
+static void tx_free(struct bt_conn_tx *tx);
+
+static void conn_tx_destroy(struct bt_conn *conn, struct bt_conn_tx *tx)
+{
+	__ASSERT_NO_MSG(tx);
+
+	bt_conn_tx_cb_t cb = tx->cb;
+	void *user_data = tx->user_data;
+
+	/* Free up TX metadata before calling callback in case the callback
+	 * tries to allocate metadata
+	 */
+	tx_free(tx);
+
+	cb(conn, user_data, -ESHUTDOWN);
+}
+
 #if defined(CONFIG_BT_CONN_TX)
 static void tx_complete_work(struct k_work *work);
 #endif /* CONFIG_BT_CONN_TX */
@@ -537,7 +554,7 @@ static bool send_frag(struct bt_conn *conn, struct net_buf *buf, uint8_t flags,
 fail:
 	k_sem_give(bt_conn_get_pkts(conn));
 	if (tx) {
-		tx_free(tx);
+		conn_tx_destroy(conn, tx);
 	}
 
 	if (always_consume) {
@@ -650,7 +667,7 @@ static void conn_cleanup(struct bt_conn *conn)
 	/* Give back any allocated buffers */
 	while ((buf = net_buf_get(&conn->tx_queue, K_NO_WAIT))) {
 		if (tx_data(buf)->tx) {
-			tx_free(tx_data(buf)->tx);
+			conn_tx_destroy(conn, tx_data(buf)->tx);
 		}
 
 		net_buf_unref(buf);
@@ -778,7 +795,7 @@ static void process_unack_tx(struct bt_conn *conn)
 		tx->pending_no_cb = 0U;
 		irq_unlock(key);
 
-		tx_free(tx);
+		conn_tx_destroy(conn, tx);
 
 		k_sem_give(bt_conn_get_pkts(conn));
 	}

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -194,7 +194,7 @@ static void tx_notify(struct bt_conn *conn)
 		 * allocate new buffers since the TX should have been
 		 * unblocked by tx_free.
 		 */
-		cb(conn, user_data);
+		cb(conn, user_data, 0);
 	}
 }
 

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -134,7 +134,7 @@ struct bt_conn_iso {
 	struct bt_iso_info info;
 };
 
-typedef void (*bt_conn_tx_cb_t)(struct bt_conn *conn, void *user_data);
+typedef void (*bt_conn_tx_cb_t)(struct bt_conn *conn, void *user_data, int err);
 
 struct bt_conn_tx {
 	sys_snode_t node;

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -66,7 +66,7 @@ static struct bt_iso_big *lookup_big_by_handle(uint8_t big_handle);
 #endif /* CONFIG_BT_ISO_BROADCAST */
 
 #if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_BROADCASTER)
-static void bt_iso_send_cb(struct bt_conn *iso, void *user_data)
+static void bt_iso_send_cb(struct bt_conn *iso, void *user_data, int err)
 {
 	struct bt_iso_chan *chan = iso->iso.chan;
 	struct bt_iso_chan_ops *ops;
@@ -75,7 +75,7 @@ static void bt_iso_send_cb(struct bt_conn *iso, void *user_data)
 
 	ops = chan->ops;
 
-	if (ops != NULL && ops->sent != NULL) {
+	if (!err && ops != NULL && ops->sent != NULL) {
 		ops->sent(chan);
 	}
 }

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1944,10 +1944,8 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 
 	len = seg->len - sdu_hdr_len;
 
-	/* Set a callback if there is no data left in the buffer and sent
-	 * callback has been set.
-	 */
-	if ((buf == seg || !buf->len) && ch->chan.ops->sent) {
+	/* Set a callback if there is no data left in the buffer */
+	if (buf == seg || !buf->len) {
 		err = bt_l2cap_send_cb(ch->chan.conn, ch->tx.cid, seg,
 				       l2cap_chan_sdu_sent,
 				       l2cap_tx_meta_data(buf));

--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1845,7 +1845,7 @@ static void l2cap_chan_tx_resume(struct bt_l2cap_le_chan *ch)
 	k_work_submit(&ch->tx_work);
 }
 
-static void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data)
+static void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data, int err)
 {
 	struct l2cap_tx_meta_data *data = user_data;
 	struct bt_l2cap_chan *chan;
@@ -1870,13 +1870,13 @@ static void l2cap_chan_sdu_sent(struct bt_conn *conn, void *user_data)
 	}
 
 	if (cb) {
-		cb(conn, cb_user_data);
+		cb(conn, cb_user_data, 0);
 	}
 
 	l2cap_chan_tx_resume(BT_L2CAP_LE_CHAN(chan));
 }
 
-static void l2cap_chan_seg_sent(struct bt_conn *conn, void *user_data)
+static void l2cap_chan_seg_sent(struct bt_conn *conn, void *user_data, int err)
 {
 	struct l2cap_tx_meta_data *data = user_data;
 	struct bt_l2cap_chan *chan;

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -845,16 +845,20 @@ static void smp_check_complete(struct bt_conn *conn, uint8_t dist_complete)
 #endif
 
 #if defined(CONFIG_BT_PRIVACY)
-static void smp_id_sent(struct bt_conn *conn, void *user_data)
+static void smp_id_sent(struct bt_conn *conn, void *user_data, int err)
 {
-	smp_check_complete(conn, BT_SMP_DIST_ID_KEY);
+	if (!err) {
+		smp_check_complete(conn, BT_SMP_DIST_ID_KEY);
+	}
 }
 #endif /* CONFIG_BT_PRIVACY */
 
 #if defined(CONFIG_BT_SIGNING)
-static void smp_sign_info_sent(struct bt_conn *conn, void *user_data)
+static void smp_sign_info_sent(struct bt_conn *conn, void *user_data, int err)
 {
-	smp_check_complete(conn, BT_SMP_DIST_SIGN);
+	if (!err) {
+		smp_check_complete(conn, BT_SMP_DIST_SIGN);
+	}
 }
 #endif /* CONFIG_BT_SIGNING */
 
@@ -2109,9 +2113,11 @@ static uint8_t smp_send_pairing_confirm(struct bt_smp *smp)
 }
 
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
-static void smp_ident_sent(struct bt_conn *conn, void *user_data)
+static void smp_ident_sent(struct bt_conn *conn, void *user_data, int err)
 {
-	smp_check_complete(conn, BT_SMP_DIST_ENC_KEY);
+	if (!err) {
+		smp_check_complete(conn, BT_SMP_DIST_ENC_KEY);
+	}
 }
 
 static void legacy_distribute_keys(struct bt_smp *smp)


### PR DESCRIPTION
Replaces #45682

This is a different approach to cleaning up the buffer user data. Instead of having separate cleanup functions, the callbacks are always called and they are responsible for cleaning up the user data. An error parameter is added to the callback functions to that they can decide what to do.

Fixes #43718