### PR TITLE
Bluetooth: Controller: Implement bt_hci_driver::close

### DIFF
--- a/subsys/bluetooth/controller/include/ll.h
+++ b/subsys/bluetooth/controller/include/ll.h
@@ -6,6 +6,7 @@
  */
 
 int ll_init(struct k_sem *sem_rx);
+int ll_deinit(void);
 void ll_reset(void);
 
 uint8_t ll_set_host_feature(uint8_t bit_number, uint8_t bit_value);

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -537,6 +537,7 @@ struct node_tx_iso;
 void lll_done_score(void *param, uint8_t result);
 
 int lll_init(void);
+int lll_deinit(void);
 int lll_reset(void);
 void lll_resume(void *param);
 void lll_disable(void *param);

--- a/subsys/bluetooth/controller/ll_sw/lll_clock.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_clock.h
@@ -5,6 +5,7 @@
  */
 
 int lll_clock_init(void);
+int lll_clock_deinit(void);
 int lll_clock_wait(void);
 int lll_hfclock_on(void);
 int lll_hfclock_on_wait(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -202,12 +202,34 @@ int lll_init(void)
 	irq_enable(RADIO_IRQn);
 	irq_enable(RTC0_IRQn);
 	irq_enable(HAL_SWI_RADIO_IRQ);
-#if defined(CONFIG_BT_CTLR_LOW_LAT) || \
-	(CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)
-	irq_enable(HAL_SWI_JOB_IRQ);
-#endif
+	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) ||
+		(CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)) {
+		irq_enable(HAL_SWI_JOB_IRQ);
+	}
 
 	radio_setup();
+
+	return 0;
+}
+
+int lll_deinit(void)
+{
+	int err;
+
+	/* Release clocks */
+	err = lll_clock_deinit();
+	if (err < 0) {
+		return err;
+	}
+
+	/* Disable IRQs */
+	irq_disable(RADIO_IRQn);
+	irq_disable(RTC0_IRQn);
+	irq_disable(HAL_SWI_RADIO_IRQ);
+	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) ||
+		(CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)) {
+		irq_disable(HAL_SWI_JOB_IRQ);
+	}
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -64,6 +64,14 @@ int lll_clock_init(void)
 	return onoff_request(mgr, &lf_cli);
 }
 
+int lll_clock_deinit(void)
+{
+	struct onoff_manager *mgr =
+		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
+
+	return onoff_release(mgr);
+}
+
 int lll_clock_wait(void)
 {
 	struct onoff_manager *mgr;

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -155,13 +155,27 @@ int lll_init(void)
 	irq_enable(LL_RADIO_IRQn);
 	irq_enable(LL_RTC0_IRQn);
 	irq_enable(HAL_SWI_RADIO_IRQ);
-#if defined(CONFIG_BT_CTLR_LOW_LAT) || \
-	(CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)
-	irq_enable(HAL_SWI_JOB_IRQ);
-#endif
+	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) ||
+	    (CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)) {
+		irq_enable(HAL_SWI_JOB_IRQ);
+	}
 
 	/* Call it after IRQ enable to be able to measure ISR latency */
 	radio_setup();
+
+	return 0;
+}
+
+int lll_deinit(void)
+{
+	/* Disable IRQs */
+	irq_disable(LL_RADIO_IRQn);
+	irq_disable(LL_RTC0_IRQn);
+	irq_disable(HAL_SWI_RADIO_IRQ);
+	if (IS_ENABLED(CONFIG_BT_CTLR_LOW_LAT) ||
+	    (CONFIG_BT_CTLR_ULL_HIGH_PRIO != CONFIG_BT_CTLR_ULL_LOW_PRIO)) {
+		irq_disable(HAL_SWI_JOB_IRQ);
+	}
 
 	return 0;
 }

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -699,6 +699,12 @@ int ll_init(struct k_sem *sem_rx)
 	return  0;
 }
 
+int ll_deinit(void)
+{
+	ll_reset();
+	return lll_deinit();
+}
+
 void ll_reset(void)
 {
 	int err;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -76,16 +76,6 @@ static void init_work(struct k_work *work);
 
 struct bt_dev bt_dev = {
 	.init          = Z_WORK_INITIALIZER(init_work),
-	/* Give cmd_sem allowing to send first HCI_Reset cmd, the only
-	 * exception is if the controller requests to wait for an
-	 * initial Command Complete for NOP.
-	 */
-#if !defined(CONFIG_BT_WAIT_NOP)
-	.ncmd_sem      = Z_SEM_INITIALIZER(bt_dev.ncmd_sem, 1, 1),
-#else
-	.ncmd_sem      = Z_SEM_INITIALIZER(bt_dev.ncmd_sem, 0, 1),
-#endif
-	.cmd_tx_queue  = Z_FIFO_INITIALIZER(bt_dev.cmd_tx_queue),
 #if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
 	.appearance = CONFIG_BT_DEVICE_APPEARANCE,
 #endif
@@ -3655,6 +3645,16 @@ int bt_enable(bt_ready_cb_t cb)
 
 	ready_cb = cb;
 
+	/* Give cmd_sem allowing to send first HCI_Reset cmd, the only
+	 * exception is if the controller requests to wait for an
+	 * initial Command Complete for NOP.
+	 */
+	if (!IS_ENABLED(CONFIG_BT_WAIT_NOP)) {
+		k_sem_init(&bt_dev.ncmd_sem, 1, 1);
+	} else {
+		k_sem_init(&bt_dev.ncmd_sem, 0, 1);
+	}
+	k_fifo_init(&bt_dev.cmd_tx_queue);
 	/* TX thread */
 	k_thread_create(&tx_thread_data, tx_thread_stack,
 			K_KERNEL_STACK_SIZEOF(tx_thread_stack),


### PR DESCRIPTION
The open source controller did not expose support for shutting it down
via the close() API in the HCI driver. Add support for it, which
completes the support for disabling and enabling the Bluetooth stack in
Zephyr.

Closes #3192.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>