### PR TITLE
cmake: use all compile options arguments for uniqueness

### DIFF
--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -497,7 +497,7 @@ function(zephyr_library_compile_options item)
   # zephyr_interface will be the first interface library that flags
   # are taken from.
 
-  string(MD5 uniqueness ${item})
+  string(MD5 uniqueness "${ARGV}")
   set(lib_name options_interface_lib_${uniqueness})
 
   if (NOT TARGET ${lib_name})


### PR DESCRIPTION
zephyr_library_compile_options() was attempting to create
unique hashes for compile options in order to prevent creating
them multiple times.  However, it was only using the first
argument to create the hash, so if multiple libraries had
different compile options but the first line was the same,
the second set would be mistaken for the first set and would
actually be passed the first set during compilation instead
of its own set.

The fix should be to use the entire compile options argument
list to create the hash so they should only match if the entire
options list is exactly the same.

This is a continued fix for #43835

Signed-off-by: Nicholas Lowell <nlowell@lexmark.com>