### PR TITLE
ipc_service: static_vrings: Set WQ priority back to PRIO_PREEMPT

### DIFF
--- a/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
+++ b/dts/bindings/ipc/zephyr,ipc-openamp-static-vrings.yaml
@@ -42,7 +42,7 @@ properties:
       or for K_PRIO_PREEMPT(2)
         priority = <2 PRIO_PREEMPT>;
 
-      When this property is missing a default priority of <0 PRIO_COOP> is
+      When this property is missing a default priority of <0 PRIO_PREEMPT> is
       assumed.
 
   zephyr,buffer-size:

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -623,7 +623,7 @@ static int backend_init(const struct device *instance)
 			   (0)),							\
 		.wq_prio_type = COND_CODE_1(DT_INST_NODE_HAS_PROP(i, zephyr_priority),	\
 			   (DT_INST_PROP_BY_IDX(i, zephyr_priority, 1)),		\
-			   (PRIO_COOP)),						\
+			   (PRIO_PREEMPT)),						\
 		.buffer_size = DT_INST_PROP_OR(i, zephyr_buffer_size,			\
 					       RPMSG_BUFFER_SIZE),			\
 		.id = i,								\


### PR DESCRIPTION
This reverts commit 7f51907fda2dd30f18d01262f06c175714a9be3f.

The problem with setting the priority at the highest priority possible
is that when the IPC is under high traffic, the WQ could starve the
scheduler.

Move back to a more sane preemptive priority as default value.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

Fixes: #46170