### PR TITLE
Provide missing libc primitives for civetweb examples

### DIFF
--- a/samples/net/civetweb/common/src/libc_extensions.c
+++ b/samples/net/civetweb/common/src/libc_extensions.c
@@ -11,10 +11,22 @@ LOG_MODULE_REGISTER(lib_extensions, LOG_LEVEL_DBG);
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <errno.h>
 
 #include "libc_extensions.h"
 
 #define FN_MISSING() LOG_DBG("[IMPLEMENTATION MISSING : %s]\n", __func__)
+
+int fileno(FILE *stream)
+{
+	errno = EBADF;
+	return -1;
+}
+
+int ferror(FILE *stream)
+{
+	return -1;
+}
 
 int iscntrl(int c)
 {


### PR DESCRIPTION
Implement simple failing versions of fileno and ferror.

Solves: https://github.com/zephyrproject-rtos/zephyr/issues/45658