### PR TITLE
samples/drivers/adc: Fix output specification

### DIFF
--- a/samples/drivers/adc/sample.yaml
+++ b/samples/drivers/adc/sample.yaml
@@ -15,4 +15,4 @@ tests:
       type: multi_line
       regex:
         - "ADC reading:"
-        - " - .+, channel \\d+: \\d+"
+        - "- .+, channel \\d+: -?\\d+"

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -141,7 +141,7 @@ void main(void)
 	while (1) {
 		printk("ADC reading:\n");
 		for (uint8_t i = 0; i < ARRAY_SIZE(adc_channels); i++) {
-			printk(" - %s, channel %d: ",
+			printk("- %s, channel %d: ",
 				adc_labels[i], adc_channels[i].channel_id);
 
 			prepare_sequence(&sequence, &adc_channels[i]);


### PR DESCRIPTION
This is a follow-up to commit f5ffd05e6b3f5e7e64ba59d0dbe0380bedede345.

Since twister removes leading spaces from received lines before
further processing, the regular expression for checking the output
produced by the sample cannot contain such space. Also negative
values read from ADC channels need to be allowed.
For consistency, remove the leading space also in the actual string
printed by the sample.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>