### PR TITLE
Bluetooth: Controller: Config ticker with slot window to yield

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -720,6 +720,14 @@ config BT_TICKER_EXT
 	  are invoked by using available '_ext' versions of ticker interface
 	  functions.
 
+config BT_TICKER_EXT_SLOT_WINDOW_YIELD
+	bool "Tickers with slot window always yields"
+	depends on BT_TICKER_EXT
+	default y if BT_CTLR_ADV_ISO
+	help
+	  This options forces tickers with slot window extensions to yield to
+	  normal tickers and be placed at the end of their slot window.
+
 config BT_TICKER_SLOT_AGNOSTIC
 	bool "Slot agnostic ticker mode"
 	help

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -807,6 +807,7 @@ static uint8_t ticker_resolve_collision(struct ticker_node *nodes,
 				(lazy_next - ticker_next->priority) >
 				(lazy_current - ticker->priority);
 
+#if defined(CONFIG_BT_TICKER_EXT_SLOT_WINDOW_YIELD)
 			/* Can the current ticker with ticks_slot_window be
 			 * scheduled after the colliding ticker?
 			 */
@@ -829,6 +830,10 @@ static uint8_t ticker_resolve_collision(struct ticker_node *nodes,
 					   ticker_next->ext_data->ticks_slot_window -
 					   ticker_next->ticks_slot) <
 					  ticker->ticks_slot));
+#else /* !CONFIG_BT_TICKER_EXT_SLOT_WINDOW_YIELD */
+			uint8_t curr_has_ticks_slot_window = 0U;
+			uint8_t next_not_ticks_slot_window = 1U;
+#endif /* !CONFIG_BT_TICKER_EXT_SLOT_WINDOW_YIELD */
 
 			/* Check if next node is within this reservation slot
 			 * and wins conflict resolution


### PR DESCRIPTION
Add Kconfig option to conditionally enable tickers with slot
window to yield to normal tickers and be placed at the end
of their slot window if possible.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>