### PR TITLE
ISO Broadcaster fails silently on unsupported RTN/SDU_Interval combination

### DIFF
--- a/samples/bluetooth/iso_broadcast/src/main.c
+++ b/samples/bluetooth/iso_broadcast/src/main.c
@@ -37,7 +37,7 @@ static struct bt_iso_chan_ops iso_ops = {
 
 static struct bt_iso_chan_io_qos iso_tx_qos = {
 	.sdu = sizeof(uint32_t), /* bytes */
-	.rtn = 2,
+	.rtn = 8,
 	.phy = BT_GAP_LE_PHY_2M,
 };
 
@@ -55,7 +55,7 @@ static struct bt_iso_chan *bis[BIS_ISO_CHAN_COUNT] = { &bis_iso_chan };
 static struct bt_iso_big_create_param big_create_param = {
 	.num_bis = BIS_ISO_CHAN_COUNT,
 	.bis_channels = bis,
-	.interval = 10000, /* in microseconds */
+	.interval = 8000, /* in microseconds */
 	.latency = 10, /* milliseconds */
 	.packing = 0, /* 0 - sequential, 1 - interleaved */
 	.framing = 0, /* 0 - unframed, 1 - framed */


### PR DESCRIPTION
Draft to support https://github.com/zephyrproject-rtos/zephyr/issues/46186