### PR TITLE
test: interrupt: add some nop operations to make sure the interrupt is handled.

### DIFF
--- a/subsys/testsuite/include/interrupt_util.h
+++ b/subsys/testsuite/include/interrupt_util.h
@@ -110,8 +110,6 @@ static inline void trigger_irq(int irq)
 #define LOAPIC_ICR_IPI_TEST  0x00004000U
 #endif
 
-#define TRIGGER_IRQ_INT(vector) __asm__ volatile("int %0" : : "i" (vector) : "memory")
-
 /*
  * We can emulate the interrupt by sending the IPI to
  * core itself by the LOAPIC for x86 platform.

--- a/subsys/testsuite/include/interrupt_util.h
+++ b/subsys/testsuite/include/interrupt_util.h
@@ -133,6 +133,8 @@ static inline void trigger_irq(int irq)
  */
 static inline void trigger_irq(int vector)
 {
+	uint8_t i;
+
 #ifdef CONFIG_X2APIC
 	x86_write_x2apic(LOAPIC_SELF_IPI, ((VECTOR_MASK & vector)));
 #else
@@ -144,6 +146,14 @@ static inline void trigger_irq(int vector)
 #endif
 	z_loapic_ipi(cpu_id, LOAPIC_ICR_IPI_TEST, vector);
 #endif /* CONFIG_X2APIC */
+
+	/*
+	 * add some nop operations here to cost some cycles to make sure
+	 * the IPI interrupt is handled before do our check.
+	 */
+	for (i = 0; i < 10; i++) {
+		arch_nop();
+	}
 }
 
 #elif defined(CONFIG_ARCH_POSIX)

--- a/tests/kernel/interrupt/src/dynamic_isr.c
+++ b/tests/kernel/interrupt/src/dynamic_isr.c
@@ -70,7 +70,7 @@ void test_isr_dynamic(void)
  */
 #if defined(CONFIG_X86)
 #define IV_IRQS 32	/* start of vectors available for x86 IRQs */
-#define TEST_IRQ_DYN_LINE 16
+#define TEST_IRQ_DYN_LINE 25
 
 #elif defined(CONFIG_ARCH_POSIX)
 #define TEST_IRQ_DYN_LINE 5

--- a/tests/kernel/interrupt/src/interrupt_offload.c
+++ b/tests/kernel/interrupt/src/interrupt_offload.c
@@ -86,7 +86,7 @@ void isr_handler(const void *param)
  * Other arch will be add later.
  */
 #if defined(CONFIG_X86)
-#define TEST_IRQ_DYN_LINE 17
+#define TEST_IRQ_DYN_LINE 26
 
 #elif defined(CONFIG_ARCH_POSIX)
 #define TEST_IRQ_DYN_LINE 5


### PR DESCRIPTION
On X86 platforms, the interrupt trigger method has been changed
from using INT command to using APIC IPI, we need to make sure
the IPI interrupt is handled before do our check, so add some
nop operations.

Also change the test interrupt line number to a bigger one, because
the low number usually will be used by other devices. 