### PR TITLE
mgmt/mcumgr/lib: Fix overriding returned error code

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -425,7 +425,6 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 		if (action.erase) {
 			rc = img_mgmt_impl_erase_image_data(0, req.size);
 			if (rc != 0) {
-				rc = MGMT_ERR_EUNKNOWN;
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(&action,
 					img_mgmt_err_str_flash_erase_failed);
 				goto end;


### PR DESCRIPTION
The img_mgmt_upload has been overriding return codes of several
utility function calls with MGMT_ERR_EUNKNOWN, even though
these utility functions would be returning MGMT_ERR_* type codes
already, overshadowing real reason of failure.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>