### PR TITLE
Bluetooth: Mesh: Fix RPL fragmentation

### DIFF
--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -200,12 +200,13 @@ static struct bt_mesh_rpl *bt_mesh_rpl_alloc(uint16_t src)
 
 void bt_mesh_rpl_reset(void)
 {
-	int i;
+	int shift = 0;
+	int last = 0;
 
 	/* Discard "old old" IV Index entries from RPL and flag
 	 * any other ones (which are valid) as old.
 	 */
-	for (i = 0; i < ARRAY_SIZE(replay_list); i++) {
+	for (int i = 0; i < ARRAY_SIZE(replay_list); i++) {
 		struct bt_mesh_rpl *rpl = &replay_list[i];
 
 		if (rpl->src) {
@@ -215,15 +216,25 @@ void bt_mesh_rpl_reset(void)
 				} else {
 					(void)memset(rpl, 0, sizeof(*rpl));
 				}
+
+				shift++;
 			} else {
 				rpl->old_iv = true;
 
+				if (shift > 0) {
+					replay_list[i - shift] = *rpl;
+				}
+
 				if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
-					schedule_rpl_store(rpl, true);
+					schedule_rpl_store(&replay_list[i - shift], true);
 				}
 			}
+
+			last = i;
 		}
 	}
+
+	(void) memset(&replay_list[last - shift + 1], 0, sizeof(struct bt_mesh_rpl) * shift);
 }
 
 static int rpl_set(const char *name, size_t len_rd,

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_replay_cache.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_replay_cache.c
@@ -7,6 +7,8 @@
 #include "settings_test_backend.h"
 #include "mesh/mesh.h"
 #include "mesh/net.h"
+#include "mesh/rpl.h"
+#include "mesh/transport.h"
 
 #define LOG_MODULE_NAME test_rpc
 
@@ -192,6 +194,214 @@ static void test_rx_power_replay_attack(void)
 	PASS();
 }
 
+static void send_end_cb(int err, void *cb_data)
+{
+	struct k_sem *sem = cb_data;
+
+	ASSERT_EQUAL(err, 0);
+	k_sem_give(sem);
+}
+
+static bool msg_send(uint16_t src, uint16_t dst)
+{
+	struct bt_mesh_send_cb cb = {
+		.end = send_end_cb,
+	};
+	struct bt_mesh_msg_ctx ctx = {
+		.net_idx = 0,
+		.app_idx = 0,
+		.addr = dst,
+		.send_rel = false,
+		.send_ttl = BT_MESH_TTL_DEFAULT,
+	};
+	struct bt_mesh_net_tx tx = {
+		.ctx = &ctx,
+		.src = src,
+	};
+	struct k_sem sem;
+	int err;
+
+	k_sem_init(&sem, 0, 1);
+	BT_MESH_MODEL_BUF_DEFINE(msg, TEST_MSG_OP_1, 0);
+
+	bt_mesh_model_msg_init(&msg, TEST_MSG_OP_1);
+
+	err = bt_mesh_trans_send(&tx, &msg, &cb, &sem);
+	if (err) {
+		LOG_ERR("Failed to send message (err %d)", err);
+		return false;
+	}
+
+	err = k_sem_take(&sem, K_SECONDS(10));
+	if (err) {
+		LOG_ERR("Send timed out (err %d)", err);
+		return false;
+	}
+
+	return true;
+}
+
+static bool msg_recv(uint16_t expected_addr)
+{
+	struct bt_mesh_test_msg msg;
+	int err;
+
+	err = bt_mesh_test_recv_msg(&msg, K_SECONDS(10));
+	if (err) {
+		LOG_ERR("Failed to receive message from %u (err %d)", expected_addr, err);
+		return false;
+	}
+
+	LOG_DBG("Received msg from %u", msg.ctx.addr);
+	ASSERT_EQUAL(expected_addr, msg.ctx.addr);
+
+	return true;
+}
+
+static bool ivi_update_toggle(void)
+{
+	bool res;
+
+	bt_mesh_iv_update_test(true);
+	res = bt_mesh_iv_update();
+	bt_mesh_iv_update_test(false);
+
+	return res;
+}
+
+static void test_rx_rpl_frag(void)
+{
+	settings_test_backend_clear();
+	bt_mesh_test_setup();
+
+	k_sleep(K_SECONDS(10));
+
+	/* Wait 3 messages from different sources. */
+	for (int i = 0; i < 3; i++) {
+		ASSERT_TRUE(msg_recv(100 + i));
+	}
+
+	/* Ask tx node to proceed to next test step. */
+	ASSERT_TRUE(msg_send(rx_cfg.addr, tx_cfg.addr));
+
+	/* Start IVI Update. This will set old_iv for all entries in RPL to 1. */
+	ASSERT_TRUE(ivi_update_toggle());
+
+	/* Receive messages from even nodes with new IVI. RPL entry with odd address will stay
+	 * with old IVI.
+	 */
+	ASSERT_TRUE(msg_recv(100));
+	ASSERT_TRUE(msg_recv(102));
+
+	/* Ask tx node to proceed to next test step. */
+	ASSERT_TRUE(msg_send(rx_cfg.addr, tx_cfg.addr));
+
+	/* Complete IVI Update. */
+	ASSERT_FALSE(ivi_update_toggle());
+
+	/* Bump SeqNum in RPL for even addresses. */
+	ASSERT_TRUE(msg_recv(100));
+	ASSERT_TRUE(msg_recv(102));
+
+	/* Start IVI Update again. */
+	/* RPL entry with odd address should be removed causing fragmentation in RPL. old_iv flag
+	 * for even entries will be set to 1.
+	 */
+	ASSERT_TRUE(ivi_update_toggle());
+
+	/* Ask tx node to proceed to next test step. */
+	ASSERT_TRUE(msg_send(rx_cfg.addr, tx_cfg.addr));
+
+	/* Complete IVI Update. */
+	ASSERT_FALSE(ivi_update_toggle());
+
+	/* Odd address entry should have been removed keeping even addresses accessible. */
+	struct bt_mesh_rpl *rpl = NULL;
+	struct bt_mesh_net_rx rx = {
+		.old_iv = 1,
+		.seq = 0,
+		.ctx.addr = 100,
+		.local_match = 1,
+	};
+	ASSERT_TRUE(bt_mesh_rpl_check(&rx, &rpl));
+	rx.ctx.addr = 101;
+	ASSERT_FALSE(bt_mesh_rpl_check(&rx, &rpl));
+	rx.ctx.addr = 102;
+	ASSERT_TRUE(bt_mesh_rpl_check(&rx, &rpl));
+
+	/* Let the settings store RPL. */
+	k_sleep(K_SECONDS(CONFIG_BT_MESH_RPL_STORE_TIMEOUT));
+
+	PASS();
+}
+
+static void test_tx_rpl_frag(void)
+{
+	settings_test_backend_clear();
+	bt_mesh_test_setup();
+
+	k_sleep(K_SECONDS(10));
+
+	/* Send message for 3 different addresses. */
+	for (size_t i = 0; i < 3; i++) {
+		ASSERT_TRUE(msg_send(100 + i, rx_cfg.addr));
+	}
+
+	k_sleep(K_SECONDS(3));
+
+	/* Wait for the rx node. */
+	ASSERT_TRUE(msg_recv(rx_cfg.addr));
+
+	/* Start IVI Update. */
+	ASSERT_TRUE(ivi_update_toggle());
+
+	/* Send msg from elem 1 and 3 with new IVI. 2nd elem should have old IVI. */
+	ASSERT_TRUE(msg_send(100, rx_cfg.addr));
+	ASSERT_TRUE(msg_send(102, rx_cfg.addr));
+
+	/* Wait for the rx node. */
+	ASSERT_TRUE(msg_recv(rx_cfg.addr));
+
+	/* Complete IVI Update. */
+	ASSERT_FALSE(ivi_update_toggle());
+
+	/* Send message from even addresses with new IVI keeping odd address with old IVI. */
+	ASSERT_TRUE(msg_send(100, rx_cfg.addr));
+	ASSERT_TRUE(msg_send(102, rx_cfg.addr));
+
+	/* Start IVI Update again to be in sync with rx node. */
+	ASSERT_TRUE(ivi_update_toggle());
+
+	/* Wait for rx node. */
+	ASSERT_TRUE(msg_recv(rx_cfg.addr));
+
+	/* Complete IVI Update. */
+	ASSERT_FALSE(ivi_update_toggle());
+
+	PASS();
+}
+
+static void test_rx_reboot_after_defrag(void)
+{
+	bt_mesh_test_setup();
+
+	/* Test that RPL entries are restored correctly after defrag and reboot. */
+	struct bt_mesh_rpl *rpl = NULL;
+	struct bt_mesh_net_rx rx = {
+		.old_iv = 1,
+		.seq = 0,
+		.ctx.addr = 100,
+		.local_match = 1,
+	};
+	ASSERT_TRUE(bt_mesh_rpl_check(&rx, &rpl));
+	rx.ctx.addr = 101;
+	ASSERT_FALSE(bt_mesh_rpl_check(&rx, &rpl));
+	rx.ctx.addr = 102;
+	ASSERT_TRUE(bt_mesh_rpl_check(&rx, &rpl));
+
+	PASS();
+}
+
 #define TEST_CASE(role, name, description)                     \
 	{                                                      \
 		.test_id = "rpc_" #role "_" #name,             \
@@ -204,9 +414,12 @@ static void test_rx_power_replay_attack(void)
 static const struct bst_test_instance test_rpc[] = {
 	TEST_CASE(tx, immediate_replay_attack, "RPC: perform replay attack immediately"),
 	TEST_CASE(tx, power_replay_attack,     "RPC: perform replay attack after power cycle"),
+	TEST_CASE(tx, rpl_frag, "RPC: Send messages after double IVI Update"),
 
 	TEST_CASE(rx, immediate_replay_attack, "RPC: device under immediate attack"),
 	TEST_CASE(rx, power_replay_attack,     "RPC: device under power cycle reply attack"),
+	TEST_CASE(rx, rpl_frag, "RPC: Test RPL fragmentation after double IVI Update"),
+	TEST_CASE(rx, reboot_after_defrag, "RPC: Test PRL after defrag and reboot"),
 	BSTEST_END_MARKER
 };
 

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/replay_cache/rpl_frag.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/tests_scripts/replay_cache/rpl_frag.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Copyright 2022 Nordic Semiconductor
+# SPDX-License-Identifier: Apache-2.0
+
+source $(dirname "${BASH_SOURCE[0]}")/../../_mesh_test.sh
+
+# Test fragmentation of RPL:
+# 1. Send a message from 3 different consecutive nodes starting from address 100;
+# 2. Toggle IV index update;
+# 3. Send a new message from even addresses. This should update IVI index of RPL for these nodes.
+#   The RPL entry odd address should stay unchanged;
+# 4. Complete IVI Update;
+# 5. Repeate steps 2 - 4 to remove RPL entry with odd address from RPL and cause fragmentation;
+conf=prj_pst_conf
+RunTest mesh_replay_fragmentation rpc_rx_rpl_frag rpc_tx_rpl_frag
+
+# Simulate reboot and test that RPL entries are restored correctly after defragmentation
+conf=prj_pst_conf
+RunTest mesh_replay_fragmentation rpc_rx_reboot_after_defrag


### PR DESCRIPTION
`bt_mesh_rpl_check` stops iterating `replay_list` if either it found an
entry with the requested source address or unassigned address. When IV
index updated, `bt_mesh_rpl_reset` is called. It will set `old_iv` to 1
for all entries with fresh IV index and remove entries with old IV index.
If the entries with old IV index are mixed with other entries, this will
cause fragmentation of `replay_list`. The next time `bt_mesh_rpl_check`
is called, it may stop iterating `replay_list` earlier than it should
because it will meet an empty entry before it iterates over all entries
in the list.

This commit does defragmentatino of `replay_list` on every
`bt_mesh_rpl_reset` by shiting existing entries to the vacated places.

This PR also adds a test that checks this issue.