### PR TITLE
Fix for mcumgr getting into endless loop on write fail

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -370,11 +370,6 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data, unsigned i
 		}
 	}
 
-	if (offset != flash_img_bytes_written(ctx) + ctx->stream.buf_bytes) {
-		rc = MGMT_ERR_EUNKNOWN;
-		goto out;
-	}
-
 	if (flash_img_buffered_write(ctx, data, num_bytes, last) != 0) {
 		rc = MGMT_ERR_EUNKNOWN;
 		goto out;
@@ -400,10 +395,6 @@ img_mgmt_impl_write_image_data(unsigned int offset, const void *data, unsigned i
 		if (flash_img_init_id(&ctx, g_img_mgmt_state.area_id) != 0) {
 			return MGMT_ERR_EUNKNOWN;
 		}
-	}
-
-	if (offset != ctx.stream.bytes_written + ctx.stream.buf_bytes) {
-		return MGMT_ERR_EUNKNOWN;
 	}
 
 	if (flash_img_buffered_write(&ctx, data, num_bytes, last) != 0) {


### PR DESCRIPTION
The PR contains two commits:
1) Removing redundant offset checking code from the `img_mgmt_impl_write_image_data`
2) Altering  `img_mgmt_upload` to fix looping problem by resetting upload state and returning an error code.

Fixes #44219

~~Depends on https://github.com/zephyrproject-rtos/zephyr/pull/46013~~