### PR TITLE
doc: release-notes: Add ARM AArch32 release notes for 3.1

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -223,6 +223,8 @@ Architectures
 
   * AARCH32
 
+    * Added Cortex-R floating point support
+
   * AARCH64
 
 * Xtensa


### PR DESCRIPTION
This commit adds the ARM AArch32 architecture release notes for the
Zephyr 3.1 release.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>