### PR TITLE
doc: release: add release notes for disk drivers

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -401,6 +401,10 @@ Drivers and Sensors
 
 * Disk
 
+  * Added generic SDMMC disk driver, that uses the SD subsystem to interact with
+    disk devices. This disk driver will be used with any disk device declared
+    with the :dtcompatible:`zephyr,sdmmc-disk` compatible string
+
 * Display
 
   * STM32: Added basic support for LTDC driver. Currently supported on F4, F7, H7, L4+


### PR DESCRIPTION
Add release notes for disk drivers. Primary update since 3.0 was
addition of generic SDMMC disk driver.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>