### PR TITLE
doc: releases: 3.1: remove empty EEPROM section

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -418,8 +418,6 @@ Drivers and Sensors
   * Adds support for Intel HDA for audio device and host streams.
   * Fixes for NXP eDMA to pass scatter gather tests
 
-* EEPROM
-
 * Entropy
 
   * STM32: Prevent  core to enter stop modes during entropy operations.


### PR DESCRIPTION
Remove the empty EEPROM section. There are user-facing changes to the EEPROM drivers/API for this release.

Fixes: #46213

Signed-off-by: Henrik Brix Andersen <henrik@brixandersen.dk>