### PR TITLE
drivers: i2c_ll_stm32_v2: add support for second target address

### DIFF
--- a/drivers/i2c/i2c_ll_stm32.h
+++ b/drivers/i2c/i2c_ll_stm32.h
@@ -64,6 +64,9 @@ struct i2c_stm32_data {
 #ifdef CONFIG_I2C_TARGET
 	bool master_active;
 	struct i2c_target_config *slave_cfg;
+#ifdef CONFIG_I2C_STM32_V2
+	struct i2c_target_config *slave2_cfg;
+#endif
 	bool slave_attached;
 #endif
 };


### PR DESCRIPTION
The Zephyr API supports multiple I2C targets addresses, and the STM32
I2C v2 implementation allows to define up to 2 targets addresses.
    
This patch adds support for a second I2C target address. It adds a new
config entry in the i2c_stm32_data structure, and uses the fact that
both addresses can be enabled and disabled independently. In the
interrupt, the target being addressed is determined using the address
match code from the interrupt status register.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>