### PR TITLE
Simplified condition whether segmented sdu sent or normal sdu sent is…

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -1944,10 +1944,8 @@ static int l2cap_chan_le_send(struct bt_l2cap_le_chan *ch,
 
 	len = seg->len - sdu_hdr_len;
 
-	/* Set a callback if there is no data left in the buffer and sent
-	 * callback has been set.
-	 */
-	if ((buf == seg || !buf->len) && ch->chan.ops->sent) {
+	/* Set a callback if there is no data left in the buffer*/
+	if ((buf == seg || !buf->len)) {
 		err = bt_l2cap_send_cb(ch->chan.conn, ch->tx.cid, seg,
 				       l2cap_chan_sdu_sent,
 				       l2cap_tx_meta_data(buf));


### PR DESCRIPTION
Simplified condition whether segmented sdu sent or normal sdu sent is used, by removing the "sent calback is set" condition.

Signed-off-by: Kyra Lengfeld <kyra.lengfeld@nordicsemi.no>