### PR TITLE
Bluetooth: Audio: Remove CSIS minimum set size requirement

### DIFF
--- a/include/zephyr/bluetooth/audio/csis.h
+++ b/include/zephyr/bluetooth/audio/csis.h
@@ -35,9 +35,6 @@ extern "C" {
 #define BT_CSIS_CLIENT_MAX_CSIS_INSTANCES 0
 #endif /* CONFIG_BT_CSIS_CLIENT */
 
-/** Minimum size of a set */
-#define BT_CSIS_MINIMUM_SET_SIZE                2
-
 /** Accept the request to read the SIRK as plaintext */
 #define BT_CSIS_READ_SIRK_REQ_RSP_ACCEPT        0x00
 /** Accept the request to read the SIRK, but return encrypted SIRK */
@@ -113,7 +110,6 @@ struct bt_csis_register_param {
 	 * @brief Size of the set.
 	 *
 	 * If set to 0, the set size characteristic won't be initialized.
-	 * Otherwise shall be set to minimum 2.
 	 */
 	uint8_t set_size;
 

--- a/subsys/bluetooth/audio/csis.c
+++ b/subsys/bluetooth/audio/csis.c
@@ -842,11 +842,6 @@ static bool valid_register_param(const struct bt_csis_register_param *param)
 		return false;
 	}
 
-	if (param->set_size > 0 && param->set_size < BT_CSIS_MINIMUM_SET_SIZE) {
-		BT_DBG("Invalid set size: %u", param->set_size);
-		return false;
-	}
-
 #if CONFIG_BT_CSIS_MAX_INSTANCE_COUNT > 1
 	if (param->parent == NULL) {
 		BT_DBG("Parent service not provided");


### PR DESCRIPTION
The requirement was removed by
https://www.bluetooth.org/errata/errata_view.cfm?errata_id=17007
and the implementation has been updated.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/45130