### PR TITLE
doc: release-notes-3.1: Add more entries for ADC and PWM drivers and info about dt_nodelabel_has_compat

### DIFF
--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -397,6 +397,9 @@ Drivers and Sensors
 
   * Atmel SAM0: Fixed adc voltage reference
   * STM32: Added support for :c:enumerator:`adc_reference.ADC_REF_INTERNAL`.
+  * Added the :c:struct:`adc_dt_spec` structure and associated helper macros,
+    e.g. :c:macro:`ADC_DT_SPEC_GET`, to facilitate getting configuration of
+    ADC channels from devicetree nodes.
 
 * CAN
 
@@ -536,6 +539,13 @@ Drivers and Sensors
     :c:macro:`PWM_STM32_COMPLEMENTARY` to specify that PWM output should happen on a
     complementary channel pincfg (eg:``tim1_ch2n_pb14``).
   * STM32: Added counter mode support. See :dtcompatible:`st,stm32-timers`.
+  * Aligned nRF PWM drivers (pwm_nrfx and pwm_nrf5_sw) with the updated PWM API.
+    In particular, this means that the :c:func:`pwm_set` and
+    :c:func:`pwm_set_cycles` functions need to be called with a PWM channel
+    as a parameter, not with a pin number like it was for the deprecated
+    ``pwm_pin_set_*`` functions. Also, the ``flags`` parameter is now supported
+    by the drivers, so either the :c:macro:`PWM_POLARITY_INVERTED` or
+    :c:macro:`PWM_POLARITY_NORMAL` flag must be provided in each call.
 
 * Reset
 

--- a/doc/releases/release-notes-3.1.rst
+++ b/doc/releases/release-notes-3.1.rst
@@ -45,6 +45,12 @@ Changes in this release
   with SD cards. See :ref:`the disk access api <disk_access_api>` for an
   example of the new devicetree binding format required.
 
+* Kconfig preprocessor function ``dt_nodelabel_has_compat`` was redefined, for
+  consistency with the ``dt_nodelabel_has_prop`` function and devicetree macros
+  like :c:func:`DT_NODE_HAS_COMPAT`. Now the function does not take into account
+  the status of the checked node. Its former functionality is provided by the
+  newly introduced ``dt_nodelabel_enabled_with_compat`` function.
+
 * CAN
 
   * Added ``const struct device`` parameter to the following CAN callback function signatures:


### PR DESCRIPTION
- Add information about new ADC facilities and about significant changes in nRF PWM drivers
- Add information about redefined Kconfig preprocessor function dt_nodelabel_has_compat