### PR TITLE
[RFC] Add pytest plugin for Babblesim tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ doc/themes/zephyr-docs-theme
 sanity-out*
 twister-out*
 bsim_bt_out
+bsim_tests_out*
 scripts/grub
 doc/reference/kconfig/*.rst
 doc/doc.warnings

--- a/doc/develop/test/babblesim.rst
+++ b/doc/develop/test/babblesim.rst
@@ -1,0 +1,481 @@
+.. _babblesim:
+
+BabbleSim tests support
+#######################
+
+Tests dedicated for BabbleSim simulator require special build and run workflow
+and at this moment they cannot be run by Twister test runner. To solve this
+problem special Pytest plugin was designed.
+
+Requirements
+************
+
+- Python >= 3.8
+
+Python modules:
+
+- pytest >= 7.1.2
+- strictyaml >= 1.6.1
+- filelock >= 3.7.1
+- pytest-xdist >= 2.5.0
+
+Pytest plugin
+*************
+
+In usual case Pytest test runner is used most often for Python unit tests.
+However, thanks to the extensive system of hooks and plugins Pytest make it
+possible to define how tests gathering should looks like and what should be
+performed during test run. It enables to design own plugin dedicated for
+BabbleSim tests.
+
+Using Pytest test runner allows to use ready-made functionalities as:
+
+- scanning directories for tests' definitions
+- filtering tests by name (including/excluding tests)
+- tests execution and storing tests' results
+- generating several types of test report (``junit`` (``xml``), ``json``,
+  ``html``)
+- splitting tests into sub-groups (by ``split-tests`` plugin)
+- running tests in parallel (by ``xdist`` plugin)
+
+How to run tests?
+*****************
+
+To run BabbleSim tests defined to run by Pytest, following environmental
+variables have to be exported (of course below paths may vary depending on
+user's Zephyr and BabbleSim installation place):
+
+::
+
+    export ZEPHYR_BASE="${HOME}/zephyrproject/zephyr"
+    export BSIM_OUT_PATH="${HOME}/bsim/"
+    export BSIM_COMPONENTS_PATH="${HOME}/bsim/components/"
+
+Next below command should be called (from ZEPHYR_BASE directory level):
+
+::
+
+    pytest tests/bluetooth/bsim_bt
+
+Exemplary output could look like:
+
+::
+
+    ========================= test session starts ==========================
+    platform linux -- Python 3.8.10, pytest-6.2.4, py-1.10.0, pluggy-0.13.1
+    rootdir: /home/redbeard/zephyrproject/zephyr
+    plugins: typeguard-2.13.3, forked-1.4.0, xdist-2.5.0
+    collected 8 items
+
+    tests/bluetooth/bsim_bt/bsim_test_advx/bs_testsuite.yaml .        [ 12%]
+    tests/bluetooth/bsim_bt/bsim_test_app/bs_testsuite.yaml ....      [ 62%]
+    tests/bluetooth/bsim_bt/bsim_test_eatt/bs_testsuite.yaml ..       [ 87%]
+    tests/bluetooth/bsim_bt/bsim_test_gatt/bs_testsuite.yaml .        [100%]
+
+    ===================== 8 passed in 67.68s (0:01:07) =====================
+
+For more verbose output special arguments could be added to basic command:
+
+::
+
+    pytest tests/bluetooth/bsim_bt -vv -o log_cli=true
+
+How it works
+************
+
+BabbleSim tests are defined in ``bs_testsuite.yaml`` files (similar to "classic"
+Twister approach with defining tests in ``testcase.yaml`` files). At the
+beginning Pytest scan directories and try to find ``bs_testsuite.yaml`` and
+tests defined inside it. Exemplary ``bs_testsuite.yaml`` for
+``tests/bluetooth/bsim_bt/bsim_test_gatt`` test may look like below:
+
+.. code-block:: yaml
+
+    tests:
+      bluetooth.bsim.gatt:
+        platform_allow:
+          - nrf52_bsim
+        tags:
+          - bluetooth
+        extra_args:
+          - '-DCMAKE_C_FLAGS="-Werror"'
+          - "-DCONFIG_COVERAGE=y"
+          - "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+        bsim_config:
+          devices:
+            - testid: gatt_client
+            - testid: gatt_server
+          phy_layer:
+            name: bs_2G4_phy_v1
+            sim_length: 60e6
+
+This YAML file define necessary information to build and run BabbleSim tests.
+Next after collecting all tests, Pytest filter tests if some filter rules were
+passed in CLI.
+
+Each test consists of two phases:
+
+1.  Building process
+        -   get CMake extra arguments from ``bs_testsuite.yaml`` file and
+            prepare CMake command
+        -   run CMake
+        -   run Ninja generator
+2.  Run simulation
+        -   parse ``bsim_config`` from ``bs_testsuite.yaml`` file and prepare
+            suitable commands to run each simulated devices and physical layer
+        -   run simulation
+        -   if some error/failure occurs during run simulation then mark test as
+            ``FAILED`` - otherwise as ``PASSED``
+
+There is also possibility to generate final report. More information about this
+can be found in chapter `reporting (from Pytest)`_.
+
+Minimal test configuration
+**************************
+
+When test source code is already prepared, then to make it possible to build
+and run them by Pytest, the ``bs_testsuite.yaml`` file have to be defined.
+Let's assume, that exemplary test source is placed in
+``tests\bluetooth\bsim_bt\some_test`` directory. Yaml file have to be defined
+inside them.
+
+Minimal ``bs_testsuite.yaml`` file consists list of test scenarios with
+BabbleSim configs. Each test scenario must have unique name among all test
+scenarios (otherwise Pytest will rise an error). This is very significant,
+because this name will be used to mark BabbleSim simulation ID and to create
+test output directory.
+
+Exemplary basic ``bs_testsuite.yaml`` file could look like:
+
+.. code-block:: yaml
+
+    tests:
+      bluetooth.bsim.some_test:
+        bsim_config:
+          devices:
+            - testid: name_of_first_device
+            - testid: name_of_second_device
+          phy_layer:
+            name: bs_2G4_phy_v1
+            sim_length: 60e6
+
+After running Pytest, it will scan such prepared yaml file and will save
+``bluetooth.bsim.some_test`` test on list of available tests. During test
+execution following CMake command will be called:
+
+::
+
+    cmake -B${ZEPHYR_BASE}/bsim_tests_out/bluetooth_bsim_some_test/build \
+    -S${ZEPHYR_BASE}/tests/bluetooth/bsim_bt/some_test -GNinja \
+    -DBOARD_ROOT=${ZEPHYR_BASE} -DBOARD=nrf52_bsim -DCONF_FILE=prj.conf
+
+As it can be observed some options are set by default:
+
+1.  output build directory is placed in
+    ``${ZEPHYR_BASE}/bsim_tests_out/bluetooth_bsim_some_test/build``
+2.  build system is ``Ninja``
+3.  the target board is ``nrf52_bsim``, and root dir for search this board
+    definition is ``${ZEPHYR_BASE}``
+4.  configuration file is ``prj.conf``
+
+At this moment only last option (configuration file) can be changed by user in
+``bs_testsuite.yaml`` file. It will be described more detailed in chapter
+`extra_args`_.
+
+After running this CMake command, the Ninja generator is run. Next built
+``zephyr.exe`` application is copied into ``${BSIM_OUT_PATH}/bin`` directory and
+renamed into ``bs_nrf52_bsim_bluetooth_bsim_some_test``.
+
+Finally for such defined tests in yaml file, following BabbleSim command is
+prepared:
+
+::
+
+    ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_bluetooth_bsim_some_test -s=bluetooth_bsim_some_test -d=0 -testid=name_of_first_device &
+    ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_bluetooth_bsim_some_test -s=bluetooth_bsim_some_test -d=1 -testid=name_of_second_device &
+    ${BSIM_OUT_PATH}/bin/bs_2G4_phy_v1 -s=bluetooth_bsim_some_test -D=2 -sim_length=60e6
+
+It is crated basing on those rules:
+
+1.  ``-s=bluetooth_bsim_some_test`` - simulation ID is the same as test scenario
+    name (dots are replaced by underscore)
+2.  ``-testid=name_of_first_device`` - test ID for particular simulated devices
+    is taken from yaml file from ``bsim_config -> devices`` options list
+3.  Physical layer name (``bs_2G4_phy_v1``) and simulation length
+    ``-sim_length=60e6`` are taken from yaml file from
+    ``bsim_config -> phy_layer`` options list
+
+Additional features
+*******************
+
+extra_args
+==========
+
+If user would like to pass some extra arguments to CMake command, it can be done
+by define ``extra_args`` option in yaml file. Listed arguments will be joined
+entirely to CMake call, so they should already start with "-D" (or similar)
+characters. By this option special conf file name could be passed. If it is not
+passed explicitly in ``extra_args`` the default name is ``prj.conf``.
+
+For example such defined ``extra_args`` in ``bs_testsuite.yaml`` file:
+
+.. code-block:: yaml
+
+    tests:
+      bluetooth.bsim.app_split:
+        extra_args:
+          - "-DCONF_FILE=prj_split.conf"
+        bsim_config:
+          ...
+
+will be used in CMake command as follow:
+
+::
+
+    cmake -B${ZEPHYR_BASE}/bsim_tests_out/bluetooth_bsim_app_split/build \
+    -S${ZEPHYR_BASE}/tests/bluetooth/bsim_bt/bsim_test_app -GNinja \
+    -DBOARD_ROOT=${ZEPHYR_BASE} -DBOARD=nrf52_bsim -DCONF_FILE=prj_split.conf
+
+extra_run_args in bsim_config
+=============================
+
+If user would like to pass some extra arguments to run simulated device or
+physical layer it can be done by ``extra_run_args`` option added in proper
+place in ``bsim_config`` option
+
+For example, such defined ``bsim_config`` with ``extra_run_args`` options in
+``bs_testsuite.yaml`` file:
+
+.. code-block:: yaml
+
+    tests:
+      bluetooth.bsim.app_split:
+        bsim_config:
+          devices:
+            - testid: peripheral
+              extra_run_args:
+                - "-rs=23"
+            - testid: central
+              extra_run_args:
+                - "-rs=6"
+          phy_layer:
+            name: bs_2G4_phy_v1
+            sim_length: 20e6
+            extra_run_args:
+              - "-v=5"
+
+will be used in BabbleSim run command as follow:
+
+::
+
+    ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_bluetooth_bsim_app_split -s=bluetooth_bsim_app_split -d=0 -testid=peripheral -rs=23 &
+    ${BSIM_OUT_PATH}/bin/bs_nrf52_bsim_bluetooth_bsim_app_split -s=bluetooth_bsim_app_split -d=1 -testid=central -rs=6 &
+    ${BSIM_OUT_PATH}/bin/bs_2G4_phy_v1 -s=bluetooth_bsim_app_split -D=2 -sim_length=60e6 -v=5
+
+
+common
+======
+
+Similar to "classic" Twister test defining approach, there is also possibility
+to define ``common`` option used by all test scenarios defined in
+``bs_testsuite.yaml`` file.
+
+When "common" entry is used in bs_testsuite.yaml file, then test scenario
+options can be updated with following rules:
+
+1.  If the same option occurs in ``common`` and test scenario entries and
+    they are a **list** (like for example ``extra_args``) then join them
+    together.
+2.  If the same options occur in "common" and test scenario entries and
+    they are **NOT a list** (like for example ``bsim_config``), then do **NOT**
+    overwrite test scenario option by common one.
+3.  If some option occurs in ``common`` and not occur in tests scenario entry,
+    then add this option to test scenario opitons.
+
+For example, such defined ``extra_args`` in ``common`` option in
+``bs_testsuite.yaml`` file:
+
+.. code-block:: yaml
+
+    common:
+      extra_args:
+        - '-DCMAKE_C_FLAGS="-Werror"'
+
+    tests:
+      bluetooth.bsim.app_split:
+        extra_args:
+          - "-DCONF_FILE=prj_split.conf"
+        bsim_config:
+          ...
+
+      bluetooth.bsim.app_split_low_lat:
+        extra_args:
+          - "-DCONF_FILE=prj_split_low_lat.conf"
+        bsim_config:
+          ...
+
+will be used during defining CMake command for both tests:
+
+::
+
+    # for bluetooth.bsim.app_split:
+    cmake -B${ZEPHYR_BASE}/bsim_tests_out/bluetooth_bsim_app_split/build \
+    -S${ZEPHYR_BASE}/tests/bluetooth/bsim_bt/bsim_test_app -GNinja \
+    -DBOARD_ROOT=${ZEPHYR_BASE} -DBOARD=nrf52_bsim -DCONF_FILE=prj_split.conf \
+    -DCMAKE_C_FLAGS="-Werror"
+
+    # for bluetooth.bsim.app_split_low_lat:
+    cmake -B${ZEPHYR_BASE}/bsim_tests_out/bluetooth_bsim_app_split/build \
+    -S${ZEPHYR_BASE}/tests/bluetooth/bsim_bt/bsim_test_app -GNinja \
+    -DBOARD_ROOT=${ZEPHYR_BASE} -DBOARD=nrf52_bsim \
+    -DCONF_FILE=prj_split_low_lat.conf -DCMAKE_C_FLAGS="-Werror"
+
+
+built_exe_name
+==============
+
+Some of tests do not need to be rebuilt every time and they can base on once
+built exe file. For this case ``built_exe_name`` option can be used. It defines
+how exe file name should looks like in ``${BSIM_OUT_PATH}/bin/`` directory.
+Normally this exe name is based on test scenario name as follow:
+
+::
+
+    bs_{platform_name}_{test_name}
+
+If two (or more) tests have explicitly defined the same ``built_exe_name``
+names, then this exe file will be built **only once during Pytest call**.
+
+Exemplary ``bs_testsuite.yaml`` file can looks like:
+
+.. code-block:: yaml
+
+    tests:
+      bluetooth.bsim.app_split:
+        bsim_config:
+          built_exe_name: "bs_nrf52_bsim_bluetooth_bsim_app_split"
+          ...
+
+      bluetooth.bsim.app_split_encrypted:
+        bsim_config:
+          built_exe_name: "bs_nrf52_bsim_bluetooth_bsim_app_split"
+          ...
+
+In this case when ``bluetooth.bsim.app_split`` test is run, after building
+process, built ``zephyr.exe`` file will be moved into ``${BSIM_OUT_PATH}/bin/``
+directory and renamed into ``bs_nrf52_bsim_bluetooth_bsim_app_split``. When
+``bluetooth.bsim.app_split_encrypted`` test is run, the building process will be
+skipped and this test will use already built exe file.
+
+.. warning::
+
+    ``built_exe_name`` has to be unique among whole BabbleSim tests to avoid
+    exe file overwriting. So, it is recommended to use for this at least one
+    affected test name (which ensures uniqueness).
+
+Information about what exe applications were already built are stored in
+``${ZEPHYR_BASE}/bsim_tests_out/build_info.json`` file. It is very important
+when tests are run in parallel and two tests which are based on the same exe
+file, are run at the same time. Then to avoid built overwriting, special lock
+mechanism is used and, in this situation, when first test start building
+process, second one wait until first will finish its job.
+
+Log saving
+==========
+
+During run BabbleSim tests by Pytest, following logs are saved:
+
+1.  Internal logs from plugin are saved in
+    ``${ZEPHYR_BASE}/bsim_tests_out/bsim_test_plugin.log`` file. They include
+    information about performed actions (CMake, Ninja, BabbleSim commands) and
+    location of saved logs from building and simulation.
+2.  Logs from building process (``cmake_out.log`` and ``ninja_out.log``) are
+    saved in ``${ZEPHYR_BASE}/bsim_tests_out/${TEST_NAME}/build`` directory.
+3.  Logs from executed simulation (from each simulated devices like ``central``
+    or ``peripheral`` and from physical layer) are stored in
+    ``${ZEPHYR_BASE}/bsim_tests_out/${TEST_NAME}`` directory.
+
+
+Test selection (from Pytest)
+============================
+
+Test selection based on its node ID
+-----------------------------------
+
+To specify particular test, it should be passed full path to specific yaml file,
+and test name after double colon (::) during Pytest call.
+
+Usage examples:
+
+::
+
+    # to run only bluetooth.bsim.eatt_encryption test:
+    pytest tests/bluetooth/bsim_bt/bsim_test_eatt/bs_testsuite.yaml::bluetooth.bsim.eatt_encryption
+
+    # # to run both bluetooth.bsim.eatt_encryption and bluetooth.bsim.eatt_collision tests:
+    pytest \
+    tests/bluetooth/bsim_bt/bsim_test_eatt/bs_testsuite.yaml::bluetooth.bsim.eatt_encryption \
+    tests/bluetooth/bsim_bt/bsim_test_eatt/bs_testsuite.yaml::bluetooth.bsim.eatt_collision
+
+
+More information about how this filter works can be found here:
+https://docs.pytest.org/en/latest/example/markers.html#selecting-tests-based-on-their-node-id
+
+Test selection based on its name
+--------------------------------
+
+In some cases it will be easier to select particular test or group of tests by
+their name. To do this, special argument ``-k`` (from "keyword") has to be added
+during Pytest call.
+
+Usage examples:
+
+::
+
+    # to run only bluetooth.bsim.gatt test:
+    pytest tests/bluetooth/bsim_bt -k "gatt"
+
+    # to run only bluetooth.bsim.gatt and bluetooth.bsim.advx tests:
+    pytest tests/bluetooth/bsim_bt -k "gatt or advx"
+
+    # to run all tests without bluetooth.bsim.app_ tests:
+    pytest tests/bluetooth/bsim_bt -k "not app"
+
+More information about how this filter works can be found here:
+https://docs.pytest.org/en/latest/example/markers.html#using-k-expr-to-select-tests-based-on-their-name
+
+Reporting (from Pytest)
+=======================
+
+To generate JUnit report ``--junitxml`` argument with report path has to be
+added to Pytest call. For example:
+
+::
+
+    pytest tests/bluetooth/bsim_bt \
+    --junitxml=${ZEPHYR_BASE}/bsim_tests_out/report.xml
+
+Parallelization (from Pytest)
+=============================
+
+To run tests in parallel (to accelerate time execution) ``pytest-xdist`` module
+has to be installed. Then ``-n`` argument with number of spawned processes has
+to be added to Pytest call. For example:
+
+::
+
+    pytest tests/bluetooth/bsim_bt -n 4
+
+More information about ``pytest-xdist`` can be found here:
+https://pytest-xdist.readthedocs.io/en/latest/
+
+Plugin debugging
+****************
+
+For development of Pytest plugin it may be necessary to debug it. For this
+purpose ``pytest.set_trace()`` method can be very useful. It should be added
+into source code in breakpoint line and then after running tests by Pytest,
+program will stop at this method and Python Debugger (``pdb``) will be enabled.
+
+More information about debugging with ``pdb`` can be found here:
+https://docs.python.org/3/library/pdb.html

--- a/doc/develop/test/index.rst
+++ b/doc/develop/test/index.rst
@@ -10,3 +10,4 @@ Testing
    twister
    coverage
    sparse
+   babblesim

--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -16,3 +16,9 @@ cbor>=1.0.0
 
 # use for twister
 psutil
+
+# used by Pytest plugin for BabbleSim to yaml parsing and validation
+strictyaml
+
+# used by Pytest plugin for BabbleSim during run tests in parallel
+filelock

--- a/tests/bluetooth/bsim_bt/bsim_test_advx/bs_testsuite.yaml
+++ b/tests/bluetooth/bsim_bt/bsim_test_advx/bs_testsuite.yaml
@@ -1,0 +1,13 @@
+tests:
+  bluetooth.bsim.advx:
+    extra_args:
+      - "-DCMAKE_C_FLAGS='-Werror'"
+      - "-DCONFIG_COVERAGE=y"
+      - "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+    bsim_config:
+      devices:
+        - testid: advx
+        - testid: scanx
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 60e6

--- a/tests/bluetooth/bsim_bt/bsim_test_app/bs_testsuite.yaml
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/bs_testsuite.yaml
@@ -1,0 +1,76 @@
+common:
+  extra_args:
+    - "-DCMAKE_C_FLAGS='-Werror'"
+    - "-DCONFIG_COVERAGE=y"
+    - "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+
+tests:
+  bluetooth.bsim.app_split:
+    extra_args:
+      - "-DCONF_FILE=prj_split.conf"
+    bsim_config:
+      built_exe_name: "bs_nrf52_bsim_bluetooth_bsim_app_split"
+      devices:
+        - testid: peripheral
+          extra_run_args:
+            - "-RealEncryption=0"
+            - "-rs=23"
+        - testid: central
+          extra_run_args:
+            - "-RealEncryption=0"
+            - "-rs=6"
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 20e6
+
+  bluetooth.bsim.app_split_encrypted:
+    extra_args:
+      - "-DCONF_FILE=prj_split.conf"
+    bsim_config:
+      built_exe_name: "bs_nrf52_bsim_bluetooth_bsim_app_split"
+      devices:
+        - testid: peripheral
+          extra_run_args:
+            - "-RealEncryption=1"
+            - "-rs=23"
+        - testid: central_encrypted
+          extra_run_args:
+            - "-RealEncryption=1"
+            - "-rs=6"
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 20e6
+
+  bluetooth.bsim.app_split_low_lat:
+    extra_args:
+      - "-DCONF_FILE=prj_split_low_lat.conf"
+    bsim_config:
+      devices:
+        - testid: peripheral
+          extra_run_args:
+            - "-RealEncryption=0"
+            - "-rs=23"
+        - testid: central
+          extra_run_args:
+            - "-RealEncryption=0"
+            - "-rs=6"
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 20e6
+
+  bluetooth.bsim.app_split_privacy_encrypted:
+    extra_args:
+      - "-DCONF_FILE=prj_split_privacy.conf"
+    bsim_config:
+      devices:
+        - testid: peripheral
+          extra_run_args:
+            - "-RealEncryption=1"
+            - "-rs=23"
+        - testid: central_encrypted
+          extra_run_args:
+            - "-RealEncryption=1"
+            - "-rs=6"
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 20e6

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/bs_testsuite.yaml
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/bs_testsuite.yaml
@@ -1,0 +1,49 @@
+common:
+  extra_args:
+    - "-DCMAKE_C_FLAGS='-Werror'"
+    - "-DCONFIG_COVERAGE=y"
+    - "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+  bsim_config:
+    devices:
+      - testid: central
+      - testid: peripheral
+    physical_layer:
+      name: bs_2G4_phy_v1
+      sim_length: 200e6
+
+tests:
+  bluetooth.bsim.eatt_encryption:
+    extra_args:
+      - "-DCONF_FILE=prj_encryption.conf"
+
+  bluetooth.bsim.eatt_collision:
+    extra_args:
+      - "-DCONF_FILE=prj_collision.conf"
+
+  bluetooth.bsim.eatt_multiple_conn:
+    extra_args:
+      - "-DCONF_FILE=prj_multiple_conn.conf"
+
+  bluetooth.bsim.eatt_autoconnect:
+    extra_args:
+      - "-DCONF_FILE=prj_autoconnect.conf"
+    bsim_config:
+      built_exe_name: "bs_nrf52_bsim_bluetooth_bsim_eatt_autoconnect"
+      devices:
+        - testid: central_autoconnect
+        - testid: peripheral_autoconnect
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 200e6
+
+  bluetooth.bsim.eatt_reconfigure:
+    extra_args:
+      - "-DCONF_FILE=prj_autoconnect.conf"
+    bsim_config:
+      built_exe_name: "bs_nrf52_bsim_bluetooth_bsim_eatt_autoconnect"
+      devices:
+        - testid: central_reconfigure
+        - testid: peripheral_reconfigure
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 60e6

--- a/tests/bluetooth/bsim_bt/bsim_test_gatt/bs_testsuite.yaml
+++ b/tests/bluetooth/bsim_bt/bsim_test_gatt/bs_testsuite.yaml
@@ -1,0 +1,13 @@
+tests:
+  bluetooth.bsim.gatt:
+    extra_args:
+      - "-DCMAKE_C_FLAGS='-Werror'"
+      - "-DCONFIG_COVERAGE=y"
+      - "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
+    bsim_config:
+      devices:
+        - testid: gatt_client
+        - testid: gatt_server
+      physical_layer:
+        name: bs_2G4_phy_v1
+        sim_length: 60e6

--- a/tests/bluetooth/bsim_bt/conftest.py
+++ b/tests/bluetooth/bsim_bt/conftest.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
 import os
 import sys
 import logging

--- a/tests/bluetooth/bsim_bt/conftest.py
+++ b/tests/bluetooth/bsim_bt/conftest.py
@@ -6,6 +6,7 @@ import pytest
 import json
 from test_utils.TestsuiteYamlParser import TestsuiteYamlParser
 from test_utils.BabbleSimBuild import BabbleSimBuild
+from test_utils.BabbleSimRun import BabbleSimRun
 from test_utils.BabbleSimError import BabbleSimError
 
 LOGGER_NAME = "bsim_plugin"
@@ -207,6 +208,15 @@ class YamlItem(pytest.Item):
             self.extra_build_args
         )
         bs_builder.build()
+
+        bs_runner = BabbleSimRun(
+            self.test_out_path,
+            self.sim_id,
+            self.general_exe_name,
+            self.devices,
+            self.phy
+        )
+        bs_runner.run()
 
     def repr_failure(self, excinfo, style=None):
         """Called when self.runtest() raises an exception."""

--- a/tests/bluetooth/bsim_bt/conftest.py
+++ b/tests/bluetooth/bsim_bt/conftest.py
@@ -1,0 +1,209 @@
+import os
+import sys
+import logging
+import shutil
+import pytest
+import json
+from test_utils.TestsuiteYamlParser import TestsuiteYamlParser
+from test_utils.BabbleSimError import BabbleSimError
+
+LOGGER_NAME = "bsim_plugin"
+logger = logging.getLogger(LOGGER_NAME)
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+if not ZEPHYR_BASE:
+    sys.exit("$ZEPHYR_BASE environment variable undefined")
+
+BSIM_TESTS_OUT_DIR_NAME = "bsim_tests_out"
+BSIM_TESTS_OUT_DIR_PATH = os.path.join(ZEPHYR_BASE, BSIM_TESTS_OUT_DIR_NAME)
+BUILD_INFO_FILE_NAME = "build_info.json"
+BUILD_INFO_FILE_PATH = \
+    os.path.join(BSIM_TESTS_OUT_DIR_PATH, BUILD_INFO_FILE_NAME)
+
+
+def prepare_bsim_test_out_dir():
+    """
+    Move previous (if exists) bsim_tests_out dir into historical one (like for
+    example bsim_tests_out_2). Create new clean output dir, where all tests
+    output will be stored (logs, build output, reports).
+    """
+    # TODO: refactor this to simplify out dir preparation and write "smarter"
+    #  detection of historical directories
+    if os.path.exists(BSIM_TESTS_OUT_DIR_PATH):
+        max_dir_number = 100
+        for idx in range(1, max_dir_number):
+            new_dir_path = f"{BSIM_TESTS_OUT_DIR_PATH}_{idx}"
+            if not os.path.exists(new_dir_path):
+                # Cannot use logger yet, so just use print
+                print(f"Copy output directories: "
+                      f"\nsrc: {BSIM_TESTS_OUT_DIR_PATH} "
+                      f"\ndst: {new_dir_path}")
+                shutil.move(BSIM_TESTS_OUT_DIR_PATH, new_dir_path)
+                break
+        else:
+            err_msg = f'Too many historical directories. Remove some ' \
+                      f'"{BSIM_TESTS_OUT_DIR_NAME}" folders.'
+            logger.error(err_msg)
+            sys.exit(err_msg)
+    os.mkdir(BSIM_TESTS_OUT_DIR_PATH)
+
+
+def setup_logger(config):
+    """
+    If tests are run in parallel (with pytest's xdist plugin), then create
+    several output log file (for each run worker/process).
+    """
+    if is_main_worker(config):
+        log_file_name = "bsim_test_plugin.log"
+    else:
+        worker_id = config.workerinput['workerid']
+        log_file_name = f'bsim_test_plugin_{worker_id}.log'
+    log_file_path = os.path.join(BSIM_TESTS_OUT_DIR_PATH, log_file_name)
+    file_handler = logging.FileHandler(log_file_path, mode="w")
+    formatter_file = logging.Formatter(
+        '%(asctime)s - %(levelname)s - %(message)s',
+        datefmt="%H:%M:%S"
+    )
+    file_handler.setFormatter(formatter_file)
+    logger.addHandler(file_handler)
+    logger.setLevel(logging.DEBUG)
+
+
+def pytest_configure(config):
+    if is_main_worker(config):
+        prepare_bsim_test_out_dir()
+        with open(BUILD_INFO_FILE_PATH, 'w', encoding='utf-8') as file:
+            json.dump({}, file, indent=4)
+    setup_logger(config)
+
+
+def pytest_unconfigure(config):
+    if is_main_worker(config):
+        build_info_lock_path = f"{BUILD_INFO_FILE_PATH}.lock"
+        if os.path.exists(build_info_lock_path) and \
+                os.path.isfile(build_info_lock_path):
+            os.remove(build_info_lock_path)
+
+
+def is_main_worker(config):
+    """
+    When tests are run in parallel (by xdist plugin), then several workers/
+    processes are created. This function help to verify if current process is
+    main worker/process, which is run at the very beginning of tests (before
+    "children" workers start) and is finished when all tests are performed
+    (after "children" workers will end). When tests are run sequentially (not by
+    xdist plugin), then only one process are run, which is "main worker".
+    """
+    is_worker_input = hasattr(config, 'workerinput')
+    return not is_worker_input
+
+
+def pytest_collect_file(parent, file_path):
+    """
+    Analyse only bs_testsuite.yaml or bs_testsuite.yml files.
+    """
+    if file_path.name.startswith("bs_testsuite") and \
+            (file_path.suffix in (".yaml", ".yml")):
+        return YamlFile.from_parent(parent, path=file_path)
+
+
+def pytest_collection_finish(session):
+    """
+    Verify uniqueness of collected test scenario names.
+    """
+    duplication_flag = False
+    test_scenario_names = [item.name for item in session.items]
+    for test_scenario in session.items:
+        if test_scenario_names.count(test_scenario.name) > 1:
+            duplication_flag = True
+            logger.error("Test scenario name is not unique: %s from:\n%s",
+                         test_scenario.name, test_scenario.test_src_path)
+    if duplication_flag:
+        exception_msg = "Test scenario names duplication found."
+        raise YamlException(exception_msg)
+
+
+class YamlFile(pytest.File):
+    def collect(self):
+        test_src_path = self.path.parent
+
+        parser = TestsuiteYamlParser()
+        yaml_data = parser.load(self.path)
+        common_config = yaml_data.get("common", {})
+        testscenarios = yaml_data.get("tests", {})
+        for testscenario_name, testscenario_config in testscenarios.items():
+            yield YamlItem.from_parent(
+                self,
+                test_src_path=test_src_path,
+                common_config=common_config,
+                testscenario_name=testscenario_name,
+                testscenario_config=testscenario_config
+            )
+
+
+class YamlItem(pytest.Item):
+    def __init__(self, parent, test_src_path, testscenario_name, common_config,
+                 testscenario_config):
+        super().__init__(testscenario_name, parent)
+
+        logger.debug("Found test scenario: %s", testscenario_name)
+
+        self.test_src_path = test_src_path
+
+        self.sim_id = testscenario_name.replace(".", "_")
+        self.test_out_path = os.path.join(BSIM_TESTS_OUT_DIR_PATH, self.sim_id)
+
+        self._update_testscenario_config(common_config, testscenario_config)
+
+        self.extra_build_args = testscenario_config.get("extra_args", [])
+        bsim_config = testscenario_config["bsim_config"]
+        self.devices = bsim_config.get("devices", [])
+        self.phy = bsim_config.get("physical_layer", {})
+        default_general_exe_name = f"bs_nrf52_bsim_{self.sim_id}"
+        self.general_exe_name = \
+            bsim_config.get("built_exe_name", default_general_exe_name)
+
+        self.build_info_file_path = BUILD_INFO_FILE_PATH
+
+    @staticmethod
+    def _update_testscenario_config(common_config, testscenario_config):
+        """
+        When "common" entry is used in bs_testsuite.yaml file, then update
+        testscenario configs with following rules:
+        1. If the same config occurs in "common" and testscenario entries and
+        they are a list (like for example "extra_args") then join them together.
+        2. If the same config occurs in "common" and testscenario entries and
+        they are NOT a list (like for example "bsim_config"), then do NOT
+        overwrite testscenario config by common config.
+        3. If some config occurs in "common" and not occur testscenario entry,
+        then add this config to testscenario configs.
+        """
+        if not common_config:
+            return
+
+        for config_name, config_value in common_config.items():
+            if config_name in testscenario_config:
+                if isinstance(testscenario_config[config_name], list) and \
+                        isinstance(config_value, list):
+                    # join testscenario and common configs if they are lists
+                    testscenario_config[config_name] += config_value
+                else:
+                    # do not overwrite testscenario_config
+                    pass
+            else:
+                testscenario_config[config_name] = config_value
+
+    def runtest(self):
+        logger.info("Start test: %s", self.name)
+
+        os.makedirs(self.test_out_path)
+
+    def repr_failure(self, excinfo, style=None):
+        """Called when self.runtest() raises an exception."""
+        if isinstance(excinfo.value, BabbleSimError):
+            failure_msg = excinfo.value.args[0]
+            return failure_msg
+
+
+class YamlException(Exception):
+    pass

--- a/tests/bluetooth/bsim_bt/conftest.py
+++ b/tests/bluetooth/bsim_bt/conftest.py
@@ -5,6 +5,7 @@ import shutil
 import pytest
 import json
 from test_utils.TestsuiteYamlParser import TestsuiteYamlParser
+from test_utils.BabbleSimBuild import BabbleSimBuild
 from test_utils.BabbleSimError import BabbleSimError
 
 LOGGER_NAME = "bsim_plugin"
@@ -197,6 +198,15 @@ class YamlItem(pytest.Item):
         logger.info("Start test: %s", self.name)
 
         os.makedirs(self.test_out_path)
+
+        bs_builder = BabbleSimBuild(
+            self.test_src_path,
+            self.test_out_path,
+            self.build_info_file_path,
+            self.general_exe_name,
+            self.extra_build_args
+        )
+        bs_builder.build()
 
     def repr_failure(self, excinfo, style=None):
         """Called when self.runtest() raises an exception."""

--- a/tests/bluetooth/bsim_bt/test_utils/BabbleSimBuild.py
+++ b/tests/bluetooth/bsim_bt/test_utils/BabbleSimBuild.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 import sys

--- a/tests/bluetooth/bsim_bt/test_utils/BabbleSimBuild.py
+++ b/tests/bluetooth/bsim_bt/test_utils/BabbleSimBuild.py
@@ -1,0 +1,258 @@
+import logging
+import os
+import sys
+import stat
+import subprocess
+import shutil
+import json
+import time
+from filelock import FileLock
+from test_utils.BabbleSimError import BabbleSimError
+
+LOGGER_NAME = f"bsim_plugin.{__name__.split('.')[-1]}"
+logger = logging.getLogger(LOGGER_NAME)
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+if not ZEPHYR_BASE:
+    sys.exit("$ZEPHYR_BASE environment variable undefined")
+
+BSIM_OUT_PATH = os.getenv("BSIM_OUT_PATH")
+if not BSIM_OUT_PATH:
+    sys.exit("$BSIM_OUT_PATH environment variable undefined")
+
+BSIM_BIN_DIR_NAME = "bin"
+BSIM_BIN_DIR_PATH = os.path.join(BSIM_OUT_PATH, BSIM_BIN_DIR_NAME)
+
+
+class BabbleSimBuild:
+    lock_timeout_duration = 120.0  # [s]
+    build_timeout_duration = 300.0  # [s]
+    board_root = ZEPHYR_BASE
+    cmake_generator = "Ninja"
+    board = "nrf52_bsim"
+    default_conf_file_name = "prj.conf"
+    extra_ninja_args = []
+
+    def __init__(self, test_src_path, test_out_path, build_info_file_path,
+                 general_exe_name, extra_build_args=None):
+        self.test_src_path = test_src_path
+        self.build_dir = os.path.join(test_out_path, "build")
+        self.build_info_file_path = build_info_file_path
+
+        if extra_build_args is None:
+            self.extra_build_args = []
+        else:
+            self.extra_build_args = extra_build_args
+
+        self.conf_file_name = self._get_conf_file_name()
+
+        self.general_exe_name = general_exe_name
+        self.general_exe_path = \
+            os.path.join(BSIM_BIN_DIR_PATH, general_exe_name)
+
+    def _get_conf_file_name(self):
+        """
+        Get conf file name from extra arguments, or if it not exists,
+        add to extra args "-DCONF_FILE=" entry with default conf file name.
+        """
+        conf_file_option_name = "-DCONF_FILE="
+        for extra_build_arg in self.extra_build_args:
+            if extra_build_arg.startswith(conf_file_option_name):
+                conf_file_name = extra_build_arg.split("=")[-1]
+                break
+        else:
+            conf_file_name = self.default_conf_file_name
+            self.extra_build_args += \
+                [f"{conf_file_option_name}{conf_file_name}"]
+        return conf_file_name
+
+    def _clean_build_folder(self):
+        if os.path.exists(self.build_dir) and os.path.isdir(self.build_dir):
+            shutil.rmtree(self.build_dir)
+        os.mkdir(self.build_dir)
+
+    def _check_build_status(self):
+        """
+        Check if desired exe file was already built in previous tests based on
+        build_info.json file. When tests are run in parallel (by xdist plugin),
+        then check if desired building is already in progress by other test - if
+        so, then just wait for finish those building.
+        Return information about whether the exe is already built.
+        """
+        build_status = BuildStatus.unknown
+        wait_for_build_duration = 1.0  # [s]
+        build_timeout = time.time() + self.build_timeout_duration
+
+        while build_status in (BuildStatus.unknown, BuildStatus.in_progress):
+            build_status = self._get_status_from_build_info_file()
+            time.sleep(wait_for_build_duration)
+            if time.time() > build_timeout:
+                failure_msg = "Wait for build timeout"
+                logger.error(failure_msg)
+                raise BabbleSimError(failure_msg)
+
+        return bool(build_status == BuildStatus.finished)
+
+    def _get_status_from_build_info_file(self):
+        """
+        If there are no information about build status, then add new entry to
+        build_info.json file with "in_progress" build status and return
+        "to_be_done" status.
+        """
+        lock = FileLock(f"{self.build_info_file_path}.lock")
+        with lock.acquire(timeout=self.lock_timeout_duration):
+            with open(self.build_info_file_path, "r") as file:
+                builds_info = json.load(file)
+            build_info = builds_info.get(self.general_exe_name, {})
+            build_status = build_info.get("status", BuildStatus.unknown)
+            if build_status == BuildStatus.unknown:
+                self._update_build_status(BuildStatus.in_progress)
+                build_status = BuildStatus.to_be_done
+            elif build_status == BuildStatus.finished:
+                build_path = build_info["build_path"]
+                log_msg = f"Used already existed build from: \n{build_path}"
+                self._save_short_logs(log_msg)
+            return build_status
+
+    def _update_build_status_lock(self, build_status):
+        lock = FileLock(f"{self.build_info_file_path}.lock")
+        with lock.acquire(timeout=self.lock_timeout_duration):
+            self._update_build_status(build_status)
+
+    def _update_build_status(self, build_status):
+        with open(self.build_info_file_path, "r") as file:
+            builds_info = json.load(file)
+
+        if builds_info.get(self.general_exe_name):
+            builds_info[self.general_exe_name]["status"] = build_status
+        else:
+            builds_info[self.general_exe_name] = {
+                "status": build_status,
+                "build_path": self.build_dir
+            }
+
+        with open(self.build_info_file_path, "w") as file:
+            json.dump(builds_info, file, indent=4)
+
+    def _run_cmake(self):
+        cmake_args = [
+            f"-B{self.build_dir}",
+            f"-S{self.test_src_path}",
+            f"-G{self.cmake_generator}",
+            f"-DBOARD_ROOT={self.board_root}",
+            f"-DBOARD={self.board}",
+        ]
+
+        cmake_args += self.extra_build_args
+
+        cmake_exe = shutil.which("cmake")
+        cmake_cmd = [cmake_exe] + cmake_args
+
+        cmake_cmd_log = " ".join(cmake_cmd)
+        logger.info("Run CMake with command: \n%s", cmake_cmd_log)
+
+        result = subprocess.run(
+            cmake_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=self.build_timeout_duration
+        )
+
+        self._save_logs("cmake", result.stdout, result.stderr)
+
+        if result.returncode != 0:
+            logger.error("CMake error \nstdout_data: \n%s \nstderr_data: \n%s",
+                         result.stdout, result.stderr)
+            raise BabbleSimError("CMake error")
+
+    def _run_ninja(self):
+        ninja_args = [
+            f'-C{self.build_dir}',
+        ]
+
+        ninja_args += self.extra_ninja_args
+
+        ninja_exe = shutil.which("ninja")
+        ninja_cmd = [ninja_exe] + ninja_args
+
+        ninja_cmd_log = " ".join(ninja_cmd)
+        logger.info("Run Ninja with command: \n%s", ninja_cmd_log)
+
+        result = subprocess.run(
+            ninja_cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=self.build_timeout_duration
+        )
+
+        self._save_logs("ninja", result.stdout, result.stderr)
+
+        if result.returncode != 0:
+            logger.error("Ninja error \nstdout_data: \n%s \nstderr_data: \n%s",
+                         result.stdout, result.stderr)
+            raise BabbleSimError("Ninja error")
+
+    def _copy_exe(self):
+        """
+        Copy built exe file to f"{BSIM_OUT_PATH}/bin" directory and set this
+        file executable mode.
+        """
+        current_exe_path = os.path.join(self.build_dir, "zephyr", "zephyr.exe")
+
+        dst_exe_path = self.general_exe_path
+
+        logger.info("Copy exe file: \nsrc: %s \ndst: %s",
+                    current_exe_path, dst_exe_path)
+
+        shutil.copyfile(current_exe_path, dst_exe_path)
+
+        # TODO: check why after copying user cannot execute program and if is
+        #  simpler method to give this access?
+        st = os.stat(dst_exe_path)
+        os.chmod(dst_exe_path, st.st_mode | stat.S_IEXEC)
+
+    def _save_logs(self, base_file_name, stdout_data, stderr_data):
+        all_log_file_paths = ""
+
+        out_file_name = f"{base_file_name}_out.log"
+        out_file_path = os.path.join(self.build_dir, out_file_name)
+        with open(out_file_path, "wb") as file:
+            file.write(stdout_data)
+        all_log_file_paths += f"\n{out_file_path}"
+
+        if stderr_data:
+            err_file_name = f"{base_file_name}_err.log"
+            err_file_path = os.path.join(self.build_dir, err_file_name)
+            with open(err_file_path, "wb") as file:
+                file.write(stderr_data)
+            all_log_file_paths += f"\n{err_file_path}"
+
+        logger.info("Logs saved at: %s", all_log_file_paths)
+
+    def _save_short_logs(self, log_msg):
+        logger.info(log_msg)
+        build_log_file_name = "build.log"
+        build_log_file_path = os.path.join(self.build_dir, build_log_file_name)
+        with open(build_log_file_path, "a") as file:
+            file.write(log_msg)
+
+    def build(self):
+        """
+        Before start building process check if desired exe is already built. If
+        so, then skip building process.
+        """
+        self._clean_build_folder()
+        already_built_flag = self._check_build_status()
+        if already_built_flag:
+            return
+        self._run_cmake()
+        self._run_ninja()
+        self._copy_exe()
+        self._update_build_status_lock(BuildStatus.finished)
+
+
+class BuildStatus:
+    unknown = "unknown"
+    to_be_done = "to_be_done"
+    in_progress = "in_progress"
+    finished = "finished"

--- a/tests/bluetooth/bsim_bt/test_utils/BabbleSimError.py
+++ b/tests/bluetooth/bsim_bt/test_utils/BabbleSimError.py
@@ -1,0 +1,10 @@
+# to import this in BabbleSimBuild or BabbleSimRun, add there:
+# from test_utils.BabbleSimError import BabbleSimError
+
+import logging
+
+LOGGER_NAME = f"bsim_plugin.{__name__.split('.')[-1]}"
+logger = logging.getLogger(LOGGER_NAME)
+
+class BabbleSimError(Exception):
+    pass

--- a/tests/bluetooth/bsim_bt/test_utils/BabbleSimError.py
+++ b/tests/bluetooth/bsim_bt/test_utils/BabbleSimError.py
@@ -1,5 +1,5 @@
-# to import this in BabbleSimBuild or BabbleSimRun, add there:
-# from test_utils.BabbleSimError import BabbleSimError
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
 
 import logging
 

--- a/tests/bluetooth/bsim_bt/test_utils/BabbleSimRun.py
+++ b/tests/bluetooth/bsim_bt/test_utils/BabbleSimRun.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 import os
 import sys

--- a/tests/bluetooth/bsim_bt/test_utils/BabbleSimRun.py
+++ b/tests/bluetooth/bsim_bt/test_utils/BabbleSimRun.py
@@ -1,0 +1,247 @@
+import logging
+import os
+import sys
+import subprocess
+import multiprocessing as mp
+import abc
+from test_utils.BabbleSimError import BabbleSimError
+
+LOGGER_NAME = f"bsim_plugin.{__name__.split('.')[-1]}"
+logger = logging.getLogger(LOGGER_NAME)
+
+ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
+if not ZEPHYR_BASE:
+    sys.exit("$ZEPHYR_BASE environment variable undefined")
+
+BSIM_OUT_PATH = os.getenv("BSIM_OUT_PATH")
+if not BSIM_OUT_PATH:
+    sys.exit("$BSIM_OUT_PATH environment variable undefined")
+
+BSIM_BIN_DIR_NAME = "bin"
+BSIM_BIN_DIR_PATH = os.path.join(BSIM_OUT_PATH, BSIM_BIN_DIR_NAME)
+
+RUN_SIM_TIMEOUT_DURATION = 300.0  # [s]
+
+
+class BabbleSimRun:
+    def __init__(self, test_out_path, sim_id, general_exe_name, devices_config,
+                 phy_config):
+        general_exe_path = os.path.join(BSIM_BIN_DIR_PATH, general_exe_name)
+        self.devices = []
+        for device_no, device_config in enumerate(devices_config):
+            device = Device(sim_id, general_exe_path, device_no, device_config,
+                            test_out_path)
+            self.devices.append(device)
+        self.phy = Phy(sim_id, len(self.devices), phy_config, test_out_path)
+
+    def run(self):
+        self._log_run_bsim_cmd()
+
+        if mp.get_start_method(allow_none=True) != "spawn":
+            mp.set_start_method("spawn", force=True)
+
+        number_processes = len(self.devices) + 1  # devices + phy
+        pool = mp.Pool(processes=number_processes)
+
+        for device in self.devices:
+            device.run_process_result = \
+                pool.apply_async(run_process, device.run_process_args)
+
+        self.phy.run_process_result = \
+            pool.apply_async(run_process, self.phy.run_process_args)
+
+        # TODO: add timeout here
+        pool.close()
+        pool.join()
+
+        self._log_run_bsim_info()
+
+        self._verify_run_bsim_results()
+
+    def _log_run_bsim_cmd(self):
+        general_log_msg = "Run BabbleSim simulation with commands:"
+        for device in self.devices:
+            device_cmd_log = " ".join(device.process_cmd)
+            general_log_msg += f"\n{device_cmd_log} &"
+
+        phy_cmd_log = " ".join(self.phy.process_cmd)
+        general_log_msg += f"\n{phy_cmd_log}"
+
+        logger.info(general_log_msg)
+
+    def _log_run_bsim_info(self):
+        general_log_msg = f"Logs saved at:"
+
+        for device in self.devices:
+            general_log_msg += f"\n{device.log_file_base_path}_out.log"
+            err_file_path = f"{device.log_file_base_path}_err.log"
+            if os.path.exists(err_file_path):
+                general_log_msg += f"\n{err_file_path}"
+
+        general_log_msg += f"\n{self.phy.log_file_base_path}_out.log"
+        err_file_path = f"{self.phy.log_file_base_path}_err.log"
+        if os.path.exists(err_file_path):
+            general_log_msg += f"\n{err_file_path}"
+
+        logger.info(general_log_msg)
+
+    def _verify_run_bsim_results(self):
+        failure_occur_flag = False
+        failures_msg = []
+
+        for device in self.devices:
+            if device.run_process_result.get() != 0:
+                failure_msg = f"Failure during simulate {device.name} device"
+                failures_msg += [failure_msg]
+                logger.error(failure_msg)
+                failure_occur_flag = True
+
+        if self.phy.run_process_result.get() != 0:
+            failure_msg = \
+                f"Failure during simulate {self.phy.name} physical layer"
+            failures_msg += [failure_msg]
+            logger.error(failure_msg)
+            failure_occur_flag = True
+
+        if failure_occur_flag:
+            failures_msg = "\n".join(failures_msg)
+            raise BabbleSimError(failures_msg)
+
+
+class BabbleSimObject(abc.ABC):
+    """
+    Abstract class to store information about BabbleSim "objects" like devices
+    (nodes/applications) or physical layer.
+    """
+    def __init__(self, sim_id, name, exe_path, extra_run_args, test_out_path):
+        self.sim_id = sim_id
+        self.name = name
+        self.exe_path = exe_path
+        self.extra_run_args = extra_run_args
+        self.log_file_base_path = os.path.join(test_out_path, name)
+        self.process_cmd = self._get_cmd()
+        self.run_process_args = self._prepare_run_process_args()
+        self.run_process_result = None
+
+    @abc.abstractmethod
+    def _get_cmd(self):
+        pass
+
+    def _prepare_run_process_args(self):
+        run_process_args = [
+            self.process_cmd,
+            self.log_file_base_path
+        ]
+        return run_process_args
+
+
+class Device(BabbleSimObject):
+    """
+    Device represents single node/application in whole simulation like "central"
+    or "peripheral" device.
+    """
+    def __init__(self, sim_id, exe_path, device_no, device_config,
+                 test_out_path):
+        name = device_config["testid"]
+        extra_run_args = device_config.get("extra_run_args", [])
+        self.device_no = device_no
+
+        super().__init__(sim_id, name, exe_path, extra_run_args, test_out_path)
+
+    def _get_cmd(self):
+        run_app_args = [
+            f'-s={self.sim_id}',
+            f'-d={self.device_no}',
+            f'-testid={self.name}'
+        ]
+        run_app_args += self.extra_run_args
+        run_app_cmd = [self.exe_path] + run_app_args
+        return run_app_cmd
+
+
+class Phy(BabbleSimObject):
+    """
+    Phy represents BabbleSim's wireless transport physical layer like
+    "bs_2G4_phy_v1".
+    """
+    def __init__(self, sim_id, number_devices, phy_config, test_out_path):
+        name = phy_config["name"]
+        exe_phy_path = os.path.join(BSIM_BIN_DIR_PATH, name)
+        extra_run_args = phy_config.get("extra_run_args", [])
+        self.sim_length = phy_config["sim_length"]
+        self.number_devices = number_devices
+
+        super().__init__(sim_id, name, exe_phy_path, extra_run_args,
+                         test_out_path)
+
+    def _get_cmd(self):
+        run_phy_args = [
+            f'-s={self.sim_id}',
+            f'-D={self.number_devices}',
+            f'-sim_length={self.sim_length}'
+        ]
+        run_phy_args += self.extra_run_args
+        run_phy_cmd = [self.exe_path] + run_phy_args
+        return run_phy_cmd
+
+
+def run_process(process_cmd, log_file_base_path):
+    """
+    Functions used during spawn several processes necessary when BabbleSim
+    simulation is launched.
+    """
+    ps_logger = ProcessLogger(log_file_base_path, debug_enable=False)
+
+    result = subprocess.run(
+        process_cmd,
+        cwd=BSIM_BIN_DIR_PATH,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=RUN_SIM_TIMEOUT_DURATION
+    )
+
+    ps_logger.save_out_log(result.stdout)
+    if result.stderr:
+        ps_logger.save_err_log(result.stderr)
+
+    return result.returncode
+
+
+class ProcessLogger:
+    """
+    Logger class designed to use particularly in run_process function, due to
+    the problem with use "classic" logger instance when this function is run
+    in separate process.
+    """
+    def __init__(self, log_file_base_path, debug_enable=False):
+        """
+        :param debug_enable: used only during plugin debugging
+        """
+        self.out_file_path = f"{log_file_base_path}_out.log"
+
+        self.err_file_path = f"{log_file_base_path}_err.log"
+
+        self.debug_file_path = f"{log_file_base_path}_debug.log"
+        self.debug_enable = debug_enable
+        process_name = os.path.basename(log_file_base_path)
+        self.save_debug_log(f"Debug logger for process: {process_name}, "
+                            f"with PID: {os.getpid()}\n\n")
+
+    def save_out_log(self, data):
+        self._save_log(self.out_file_path, data)
+
+    def save_err_log(self, data):
+        self._save_log(self.err_file_path, data)
+
+    @staticmethod
+    def _save_log(log_file_path, data):
+        with open(log_file_path, "wb") as file:
+            file.write(data)
+
+    def save_debug_log(self, log):
+        """
+        Used only during plugin debugging.
+        """
+        if self.debug_enable:
+            with open(self.debug_file_path, "a") as file:
+                file.write(log)

--- a/tests/bluetooth/bsim_bt/test_utils/TestsuiteYamlParser.py
+++ b/tests/bluetooth/bsim_bt/test_utils/TestsuiteYamlParser.py
@@ -1,3 +1,6 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
 import logging
 from strictyaml import load as strictyaml_load
 from strictyaml import Map, MapPattern, Optional, Seq, Str, YAMLError

--- a/tests/bluetooth/bsim_bt/test_utils/TestsuiteYamlParser.py
+++ b/tests/bluetooth/bsim_bt/test_utils/TestsuiteYamlParser.py
@@ -1,0 +1,65 @@
+import logging
+from strictyaml import load as strictyaml_load
+from strictyaml import Map, MapPattern, Optional, Seq, Str, YAMLError
+
+LOGGER_NAME = f"bsim_plugin.{__name__.split('.')[-1]}"
+logger = logging.getLogger(LOGGER_NAME)
+
+
+class TestsuiteYamlParser:
+    bsim_config_schema = Map(
+        {
+            "devices": Seq(Map(
+                {
+                    "testid": Str(),
+                    Optional("extra_run_args"): Seq(Str()),
+                }
+            )),
+            "physical_layer": Map(
+                {
+                    "name": Str(),
+                    "sim_length": Str(),
+                    Optional("extra_run_args"): Seq(Str()),
+                }
+            ),
+            Optional("built_exe_name"): Str(),
+        }
+    )
+
+    testscenario_schema = Map(
+        {
+            Optional("bsim_config"): bsim_config_schema,
+            Optional("extra_args"): Seq(Str()),
+        }
+    )
+
+    tests_schema = MapPattern(
+        Str(),  # testscenario name
+        testscenario_schema,
+        minimum_keys=1,  # tests require minimum one testscenario
+    )
+
+    testsuite_yaml_schema = Map(
+        {
+            Optional("common"): testscenario_schema,
+            "tests": tests_schema,
+        }
+    )
+
+    def __init__(self):
+        pass
+
+    def load(self, testsuite_yaml_path):
+        with open(testsuite_yaml_path, "r") as file_handler:
+            try:
+                yaml_data = strictyaml_load(
+                    file_handler.read(),
+                    self.testsuite_yaml_schema
+                )
+            except YAMLError as err:
+                if hasattr(err, "context"):
+                    err.context = f"while parsing a file \n" \
+                                  f"{testsuite_yaml_path}\n" + err.context
+                raise err
+            yaml_data = yaml_data.data
+        return yaml_data


### PR DESCRIPTION
The BabbleSim simulator has been available in the Zephyr project for 4 years. Since this time, the only way to write test, which can use this simulator (in not trivial case) is add new one to this directory: `tests/bluetooth/bsim_bt`. All of them are built and executed by system of bash scripts. In longer perspective it seems to be hard to maintain them in this form and standardize the way of adding new tests.

To solve partially this problem (and to make it possible to solve it entirely in the future), I prepared preliminary version of Pytest plugin dedicated for those tests. It allows to simply define test in yaml file (like with Twister test runner) and execute it by call Pytest. 

In this PR I attached extensive documentation about this plugin - how it works and how to use them. So, before any review or comments, please write them at first:
https://github.com/gopiotr/zephyr/blob/pr/add_pytest_plugin_for_babblesim/doc/develop/test/babblesim.rst

I worked with newest version of Pytest - 7.1.2 – if something doesn’t work, please start from upgrade your Pytest package. 

For parsing yaml files, I decided to use `strictyaml` package and for protect file, which stores information about built images, I used `filelock` package – I added them to `requirements-run-test.txt` so probably it will be necessary to install them on your environment. 

With this version of test runner, I limited myself to implement minimal version which allows to run current tests in similar way, how it is done by bash scripts. I created yaml files only for four group of Bluetooth tests (`advx`, `app`, `eatt`, `gatt`) to show you demo how could it work. If the opinion will be positive, I can prepare yaml files for rest of them.

**With this PR I would like to know your opinions on the sense of this plugin and whether it is generally a good direction for tests dedicated for BabbleSim.**

If your opinions will be positive, the draft plan for next is as follow:

In this PR:
- Add yaml files for the rest groups of Bluetooth tests (`audio`, `eatt_notif`, `gatt_caching`, `iso`, `l2cap`, `mesh`, `multiple`, `notify`)

In next PRs:
- Remove majority of bash scripts (beyond this one responsible for EDTT tests) used for compile and run `bsim_bt` tests and replace them by this plugin and yaml files in Github CI workflow.
- Add possibility to define BabbleSim tests based on existed samples (like `samples/bluetooth/central_hr` and `samples/bluetooth/peripheral_hr`) or tests written in `Ztest` test framework – this will open possibility for create tests both for BabbleSim and for hardware.
- Add handling for EDTT tests. 
