### PR TITLE
mgmt/mcumgr/lib: Remove unused state variables from image management

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -84,10 +84,6 @@ struct img_mgmt_state {
 	/** Hash of image data; used for resumption of a partial upload. */
 	uint8_t data_sha_len;
 	uint8_t data_sha[IMG_MGMT_DATA_SHA_LEN];
-#if CONFIG_IMG_ERASE_PROGRESSIVELY
-	int sector_id;
-	uint32_t sector_end;
-#endif
 };
 
 /** Describes what to do during processing of an upload request. */

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -416,11 +416,7 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 		memset(&g_img_mgmt_state.data_sha[req.data_sha.len], 0,
 			   IMG_MGMT_DATA_SHA_LEN - req.data_sha.len);
 
-#if CONFIG_IMG_ERASE_PROGRESSIVELY
-		/* setup for lazy sector by sector erase */
-		g_img_mgmt_state.sector_id = -1;
-		g_img_mgmt_state.sector_end = 0;
-#else
+#ifndef CONFIG_IMG_ERASE_PROGRESSIVELY
 		/* erase the entire req.size all at once */
 		if (action.erase) {
 			rc = img_mgmt_impl_erase_image_data(0, req.size);


### PR DESCRIPTION
Image management state, struct img_mgmt_state, has been defining
sector_id and sector_end variables, supposed to be used by
progressive erase feature, that have no use in code.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>