### PR TITLE
test: exclude riscv and xtensa for test/kernel/fatal/exception

### DIFF
--- a/tests/kernel/fatal/exception/testcase.yaml
+++ b/tests/kernel/fatal/exception/testcase.yaml
@@ -22,5 +22,6 @@ tests:
   kernel.common.stack_sentinel:
     extra_args: CONF_FILE=sentinel.conf
     # FIXME: See issue #39948
+    arch_exclude: riscv32 riscv64 xtensa
     platform_exclude: qemu_cortex_a9
     tags: kernel ignore_faults


### PR DESCRIPTION
riscv and xtensa does not support this test, so exclude it

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>