### PR TITLE
drivers: serial: removes unused TIMEOUT constant

### DIFF
--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -77,8 +77,6 @@ uint32_t lpuartdiv_calc(const uint64_t clock_rate, const uint32_t baud_rate)
 #endif /* USART_PRESC_PRESCALER */
 #endif /* HAS_LPUART_1 */
 
-#define TIMEOUT 1000
-
 #ifdef CONFIG_PM
 static void uart_stm32_pm_policy_state_lock_get(const struct device *dev)
 {


### PR DESCRIPTION
The TIMEOUT constant in uart_stm32.c seems to be unused since
da210ba0ba0f2f9912352436d1f90433de0ea667, so I removed it.