### PR TITLE
testsuite: Make ztress header C++ compatible

### DIFF
--- a/subsys/testsuite/ztest/include/ztress.h
+++ b/subsys/testsuite/ztest/include/ztress.h
@@ -9,6 +9,10 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/kernel.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** @internal Internal ID's to distinguish context type. */
 #define ZTRESS_ID_THREAD 0
 #define ZTRESS_ID_K_TIMER 1
@@ -228,5 +232,9 @@ int ztress_preempt_count(uint32_t id);
  * @return Optimized timeout base.
  */
 uint32_t ztress_optimized_ticks(uint32_t id);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TESTSUITE_ZTEST_INCLUDE_ZTRESS_H__ */


### PR DESCRIPTION
This allows ztress to be linked correctly from C++ based tests.

Signed-off-by: Benjamin Gwin <bgwin@google.com>