### PR TITLE
twister: fix setting status on unprocessed tests

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1703,6 +1703,7 @@ class ScanPathResult:
                  sorted(other.ztest_suite_names)))
 
 class TestCase(DisablePyTestCollectionMixin):
+
     def __init__(self, name=None, testsuite=None):
         self.duration = 0
         self.name = name
@@ -1710,6 +1711,7 @@ class TestCase(DisablePyTestCollectionMixin):
         self.reason = None
         self.testsuite = testsuite
         self.output = ""
+        self.freeform = False
 
     def __lt__(self, other):
         return self.name < other.name
@@ -1779,8 +1781,9 @@ class TestSuite(DisablePyTestCollectionMixin):
         self.ztest_suite_names = []
 
 
-    def add_testcase(self, name):
+    def add_testcase(self, name, freeform=False):
         tc = TestCase(name=name, testsuite=self)
+        tc.freeform = freeform
         self.testcases.append(tc)
 
     @staticmethod
@@ -2056,7 +2059,7 @@ Tests should reference the category and subsystem with a dot as a separator.
                 self.add_testcase(name)
 
             if not subcases:
-                self.add_testcase(self.id)
+                self.add_testcase(self.id, freeform=True)
 
         self.ztest_suite_names = ztest_suite_names
 
@@ -2111,7 +2114,7 @@ class TestInstance(DisablePyTestCollectionMixin):
     # Fix an issue with copying objects from testsuite, need better solution.
     def init_cases(self):
         for c in self.testsuite.testcases:
-            self.add_testcase(c.name)
+            self.add_testcase(c.name, freeform=c.freeform)
 
     def _get_run_id(self):
         """ generate run id from instance unique identifier and a random
@@ -2148,8 +2151,9 @@ class TestInstance(DisablePyTestCollectionMixin):
             tc.reason = reason
         return tc
 
-    def add_testcase(self, name):
+    def add_testcase(self, name, freeform=False):
         tc = TestCase(name=name)
+        tc.freeform = freeform
         self.testcases.append(tc)
         return tc
 
@@ -4122,7 +4126,6 @@ class TestPlan(DisablePyTestCollectionMixin):
             if instance.status is not None:
                 suite["execution_time"] =  f"{float(handler_time):.2f}"
 
-
             testcases = []
 
             if len(instance.testcases) == 1:
@@ -4131,6 +4134,12 @@ class TestPlan(DisablePyTestCollectionMixin):
                 single_case_duration = 0
 
             for case in instance.testcases:
+                # freeform was set when no sub testcases were parsed, however,
+                # if we discover those at runtime, the fallback testcase wont be
+                # needed anymore and can be removed from the output, it does
+                # not have a status and would otherwise be reported as skipped.
+                if case.freeform and case.status is None and len(instance.testcases) > 1:
+                    continue
                 testcase = {}
                 testcase['identifier'] = case.name
                 if instance.status:

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -913,7 +913,7 @@ class DeviceHandler(Handler):
             stdout = stderr = None
             with subprocess.Popen(command, stderr=subprocess.PIPE, stdout=subprocess.PIPE) as proc:
                 try:
-                    (stdout, stderr) = proc.communicate(timeout=30)
+                    (stdout, stderr) = proc.communicate(timeout=60)
                     # ignore unencodable unicode chars
                     logger.debug(stdout.decode(errors = "ignore"))
 
@@ -924,6 +924,7 @@ class DeviceHandler(Handler):
                             dlog_fp.write(stderr.decode())
                         os.write(write_pipe, b'x')  # halt the thread
                 except subprocess.TimeoutExpired:
+                    logger.warning("Flash operation timed out.")
                     proc.kill()
                     (stdout, stderr) = proc.communicate()
                     self.instance.status = "error"
@@ -955,9 +956,6 @@ class DeviceHandler(Handler):
 
         handler_time = time.time() - start_time
 
-        if self.instance.status == "error":
-            self.instance.add_missing_testscases("blocked", self.instance.reason)
-
         if harness.is_pytest:
             harness.pytest_run(self.log)
 
@@ -969,6 +967,9 @@ class DeviceHandler(Handler):
         else:
             self.instance.status = "error"
             self.instance.reason = "No Console Output(Timeout)"
+
+        if self.instance.status == "error":
+            self.instance.add_missing_testscases("blocked", self.instance.reason)
 
         self._final_handle_actions(harness, handler_time)
 

--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -961,11 +961,6 @@ class DeviceHandler(Handler):
         if harness.is_pytest:
             harness.pytest_run(self.log)
 
-        # sometimes a test instance hasn't been executed successfully with no
-        # status, in order to include it into final report,
-        # so fill the results as blocked
-        self.instance.add_missing_testscases("blocked")
-
         self.instance.execution_time = handler_time
         if harness.state:
             self.instance.status = harness.state


### PR DESCRIPTION
- twister: do not mark tests as blocked if a testsuite has passed
- twister: do not set case status on flash timeout

Fixes #45845
