### PR TITLE
drivers/modem: add user_data to modem_cmd_handler_data

### DIFF
--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -118,6 +118,9 @@ struct modem_cmd_handler_data {
 	/* locks */
 	struct k_sem sem_tx_lock;
 	struct k_sem sem_parse_lock;
+
+	/* user data */
+	void * user_data;
 };
 
 /**

--- a/drivers/modem/modem_cmd_handler.h
+++ b/drivers/modem/modem_cmd_handler.h
@@ -120,7 +120,7 @@ struct modem_cmd_handler_data {
 	struct k_sem sem_parse_lock;
 
 	/* user data */
-	void * user_data;
+	void *user_data;
 };
 
 /**


### PR DESCRIPTION
added user_data to allow for multiple instances of modems which use the cmd handler, the only identifiable parameter passed to the modem command handlers is the modem_cmd_handler_data struct.

The user_data variable allows for the a modem driver to pass its dev or data pointer to the modem_cmd_handler_data struct to be retrieved from within the modem command callbacks.

Signed-off-by: Bjarki AA <baa@trackunit.com>