### PR TITLE
drivers: {spi,uart}_nrf: fix !LEGACY_INCLUDE_PATH

### DIFF
--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -16,7 +16,7 @@
 #include <zephyr/kernel.h>
 #include <soc.h>
 #include <helpers/nrfx_gppi.h>
-#include <linker/devicetree_regions.h>
+#include <zephyr/linker/devicetree_regions.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(uart_nrfx_uarte, CONFIG_UART_LOG_LEVEL);

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -15,7 +15,7 @@
 #include <nrfx_spim.h>
 #include <hal/nrf_clock.h>
 #include <string.h>
-#include <linker/devicetree_regions.h>
+#include <zephyr/linker/devicetree_regions.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(spi_nrfx_spim, CONFIG_SPI_LOG_LEVEL);


### PR DESCRIPTION
Add missing zephyr/ prefix to fix CONFIG_LEGACY_INCLUDE_PATH=n build.