### PR TITLE
samples: Bluetooth: hci_uart: Add vendor specific HCI event generation for system fatal error

### DIFF
--- a/samples/bluetooth/hci_uart/Kconfig
+++ b/samples/bluetooth/hci_uart/Kconfig
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "HCI UART sample"
+
+config VS_HCI_SYSTEM_FATAL_ERROR_HANDLER
+	bool "Enable generation of vendor specific HCI event for system fatal error"
+	depends on CONFIG_CPU_CORTEX_M
+	default y
+endmenu
+
+menu "Zephyr Kernel"
+source "Kconfig.zephyr"
+endmenu


### PR DESCRIPTION
While using the hci_uart sample for Bluetooth conformance tests
it may happen that there is a system fault error.
Such errors are not visible in results of conformance tests.
Debugging of these errors is difficult and requires access to
testing hardware.

To enhance handling of such errors there is added a k_sys_fatal-
_error_handler that will log information about CPU state by use
of vendor specific HCI event.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>