### PR TITLE
Revert "boards: mec1501modular: build without image gen tool"

### DIFF
--- a/boards/arm/mec1501modular_assy6885/CMakeLists.txt
+++ b/boards/arm/mec1501modular_assy6885/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
     set(EVERGLADES_SPI_GEN_FILENAME everglades_spi_gen.exe)
   endif()
 
-  find_file(EVERGLADES_SPI_GEN_FINDFILE ${EVERGLADES_SPI_GEN_FILENAME} NO_DEFAULT_PATH)
+  find_file(EVERGLADES_SPI_GEN_FINDFILE ${EVERGLADES_SPI_GEN_FILENAME})
   if(EVERGLADES_SPI_GEN_FINDFILE STREQUAL EVERGLADES_SPI_GEN_FINDFILE-NOTFOUND)
     message(WARNING "Microchip SPI Image Generation tool (${EVERGLADES_SPI_GEN_FILENAME}) is not available. SPI Image will not be generated.")
   else()


### PR DESCRIPTION
This reverts commit 209e4ee1a14a86ab03b6c32bec2f56412f43d068.
That commit broke the "spi_gen utility find" functionality.