### PR TITLE
arch/xtensa: Add CCOUNT-based timing API

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -123,6 +123,7 @@ config XTENSA
 	select USE_SWITCH
 	select USE_SWITCH_SUPPORTED
 	select IRQ_OFFLOAD_NESTED if IRQ_OFFLOAD
+	select ARCH_HAS_TIMING_FUNCTIONS
 	imply ATOMIC_OPERATIONS_ARCH
 	help
 	  Xtensa architecture

--- a/arch/xtensa/Kconfig
+++ b/arch/xtensa/Kconfig
@@ -87,4 +87,11 @@ config XTENSA_UNCACHED_REGION
 	  As for XTENSA_CACHED_REGION, this specifies which 512M
 	  region (0-7) contains the "uncached" mapping.
 
+config XTENSA_CCOUNT_HZ
+	int "CCOUNT cycle rate"
+	default 1000000
+	help
+	  Rate in HZ of the Xtensa core as measured by the value of
+	  the CCOUNT register.
+
 endmenu

--- a/arch/xtensa/core/CMakeLists.txt
+++ b/arch/xtensa/core/CMakeLists.txt
@@ -19,7 +19,7 @@ zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE tls.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_ENABLE_BACKTRACE xtensa_backtrace.c)
 zephyr_library_sources_ifdef(CONFIG_XTENSA_ENABLE_BACKTRACE debug_helpers_asm.S)
 zephyr_library_sources_ifdef(CONFIG_DEBUG_COREDUMP coredump.c)
-
+zephyr_library_sources_ifdef(CONFIG_TIMING_FUNCTIONS timing.c)
 zephyr_library_sources_ifdef(CONFIG_GDBSTUB gdbstub.c)
 
 if("${ZEPHYR_TOOLCHAIN_VARIANT}" STREQUAL "xcc")

--- a/arch/xtensa/core/timing.c
+++ b/arch/xtensa/core/timing.c
@@ -1,0 +1,58 @@
+/* Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr.h>
+
+void arch_timing_init(void)
+{
+}
+
+void arch_timing_start(void)
+{
+}
+
+void arch_timing_stop(void)
+{
+}
+
+uint64_t arch_timing_freq_get(void)
+{
+	return CONFIG_XTENSA_CCOUNT_HZ;
+}
+
+timing_t arch_timing_counter_get(void)
+{
+	uint32_t ccount;
+
+	__asm__ volatile ("rsr %0, CCOUNT" : "=r"(ccount));
+
+	return ccount;
+}
+
+uint64_t arch_timing_cycles_get(volatile timing_t *const start,
+				volatile timing_t *const end)
+{
+	int64_t dt = (int64_t) (*end - *start);
+
+	if (dt < 0) {
+		dt += 0x100000000ULL;
+	}
+
+	return (uint64_t) dt;
+}
+
+uint64_t arch_timing_cycles_to_ns(uint64_t cycles)
+{
+	return cycles * (1000000000ULL / CONFIG_XTENSA_CCOUNT_HZ);
+}
+
+uint64_t arch_timing_cycles_to_ns_avg(uint64_t cycles, uint32_t count)
+{
+	/* Why is this an arch API?  This is just math! */
+	return cycles / (uint64_t) count;
+}
+
+uint32_t arch_timing_freq_get_mhz(void)
+{
+	return arch_timing_freq_get() / 1000000ULL;
+}

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -1099,6 +1099,10 @@ void arch_timing_init(void);
  * Signal to the timing subsystem that timing information
  * will be gathered from this point forward.
  *
+ * @note Any call to arch_timing_counter_get() must be done between
+ * calls to arch_timing_start() and arch_timing_stop(), and on the
+ * same CPU core.
+ *
  * @see timing_start()
  */
 void arch_timing_start(void);
@@ -1109,12 +1113,27 @@ void arch_timing_start(void);
  * Signal to the timing subsystem that timing information
  * is no longer being gathered from this point forward.
  *
+ * @note Any call to arch_timing_counter_get() must be done between
+ * calls to arch_timing_start() and arch_timing_stop(), and on the
+ * same CPU core.
+ *
  * @see timing_stop()
  */
 void arch_timing_stop(void);
 
 /**
  * @brief Return timing counter.
+ *
+ * @note Any call to arch_timing_counter_get() must be done between
+ * calls to arch_timing_start() and arch_timing_stop(), and on the
+ * same CPU core.
+ *
+ * @note Not all platforms have a timing counter with 64 bit precision.  It
+ * is possible to see this value "go backwards" due to internal
+ * rollover.  Timing code must be prepared to address the rollover
+ * (with platform-dependent code, e.g. by casting to a uint32_t before
+ * subtraction) or by using arch_timing_cycles_get() which is required
+ * to understand the distinction.
  *
  * @return Timing counter.
  *
@@ -1125,8 +1144,10 @@ timing_t arch_timing_counter_get(void);
 /**
  * @brief Get number of cycles between @p start and @p end.
  *
- * For some architectures or SoCs, the raw numbers from counter
- * need to be scaled to obtain actual number of cycles.
+ * For some architectures or SoCs, the raw numbers from counter need
+ * to be scaled to obtain actual number of cycles, or may roll over
+ * internally.  This function computes a positive-definite interval
+ * between two returned cycle values.
  *
  * @param start Pointer to counter at start of a measured execution.
  * @param end Pointer to counter at stop of a measured execution.

--- a/soc/xtensa/intel_adsp/Kconfig.defconfig
+++ b/soc/xtensa/intel_adsp/Kconfig.defconfig
@@ -27,4 +27,8 @@ config I2S_CAVS
 	default y
 	depends on I2S
 
+config XTENSA_CCOUNT_HZ
+	default 400000000 if SOC_SERIES_INTEL_CAVS_V25
+	default 200000000
+
 endif # INTEL_ADSP_CAVS


### PR DESCRIPTION
Expose the Xtenesa CCOUNT timing register (the lowest level CPU cycle counter) using the arch_timing_*() API.

This is the simplest possible way to get this working.  Future work might focus on moving the rate configuration into devicetree in a standard way, integrating with the platform clock driver on intel_adsp such that the reported cycle rate tracks runtime changes (though IIRC this is not a SOF requirement), and adding better test coverage to the timing layer, which right now isn't exercised anywhere but in benchmarks. 
