### PR TITLE
python-devicetree: CI hotfix

### DIFF
--- a/scripts/dts/python-devicetree/tox.ini
+++ b/scripts/dts/python-devicetree/tox.ini
@@ -5,7 +5,7 @@ envlist=py3
 deps =
     setuptools-scm
     pytest
-    types-PyYAML
+    types-PyYAML==6.0.7
     mypy
 setenv =
     TOXTEMPDIR={envtmpdir}


### PR DESCRIPTION
Pin the types-PyYAML version to 6.0.7. Version 6.0.8 is causing CI
errors for other pull requests, so we need this in to get other PRs
moving.

Fixes: #46286

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>