### PR TITLE
tests/intel_adsp/smoke: Revert WAIT_FOR breakage

### DIFF
--- a/tests/boards/intel_adsp/smoke/src/cpus.c
+++ b/tests/boards/intel_adsp/smoke/src/cpus.c
@@ -182,7 +182,7 @@ void halt_and_restart(int cpu)
 	/* Startup can be slow */
 	k_msleep(50);
 
-	zassert_true(WAIT_FOR(alive_flag == true, 10000, k_msleep(1)), NULL);
+	AWAIT(alive_flag == true);
 
 	k_thread_abort(&run_on_threads[cpu]);
 }

--- a/tests/boards/intel_adsp/smoke/src/hostipc.c
+++ b/tests/boards/intel_adsp/smoke/src/hostipc.c
@@ -41,8 +41,8 @@ void test_host_ipc(void)
 	done_flag = false;
 	ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_SIGNAL_DONE, 0);
 	zassert_true(ret, "send failed");
-	zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)), NULL);
-	zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
+	AWAIT(cavs_ipc_is_complete(CAVS_HOST_DEV));
+	AWAIT(done_flag);
 
 	/* Request the host to return a message which we will complete
 	 * immediately.
@@ -53,9 +53,9 @@ void test_host_ipc(void)
 	ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_RETURN_MSG,
 				    RETURN_MSG_SYNC_VAL);
 	zassert_true(ret, "send failed");
-	zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
-	zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)), NULL);
-	zassert_true(WAIT_FOR(msg_flag, 10000, k_msleep(1)), NULL);
+	AWAIT(done_flag);
+	AWAIT(cavs_ipc_is_complete(CAVS_HOST_DEV));
+	AWAIT(msg_flag);
 
 	/* Do exactly the same thing again to check for state bugs
 	 * (e.g. failing to signal done on one side or the other)
@@ -66,9 +66,9 @@ void test_host_ipc(void)
 	ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_RETURN_MSG,
 				    RETURN_MSG_SYNC_VAL);
 	zassert_true(ret, "send failed");
-	zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
-	zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)), NULL);
-	zassert_true(WAIT_FOR(msg_flag, 10000, k_msleep(1)), NULL);
+	AWAIT(done_flag);
+	AWAIT(cavs_ipc_is_complete(CAVS_HOST_DEV));
+	AWAIT(msg_flag);
 
 	/* Same, but we'll complete it asynchronously (1.8+ only) */
 	if (!IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V15)) {
@@ -78,10 +78,9 @@ void test_host_ipc(void)
 		ret = cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_RETURN_MSG,
 					    RETURN_MSG_ASYNC_VAL);
 		zassert_true(ret, "send failed");
-		zassert_true(WAIT_FOR(done_flag, 10000, k_msleep(1)), NULL);
-		zassert_true(WAIT_FOR(cavs_ipc_is_complete(CAVS_HOST_DEV), 10000, k_msleep(1)),
-			     NULL);
-		zassert_true(WAIT_FOR(msg_flag, 10000, k_msleep(1)), NULL);
+		AWAIT(done_flag);
+		AWAIT(cavs_ipc_is_complete(CAVS_HOST_DEV));
+		AWAIT(msg_flag);
 		cavs_ipc_complete(CAVS_HOST_DEV);
 	}
 

--- a/tests/boards/intel_adsp/smoke/src/main.c
+++ b/tests/boards/intel_adsp/smoke/src/main.c
@@ -31,7 +31,7 @@ void test_clock_calibrate(void)
 	/* Now do it again, but with a handler to catch the result */
 	cyc1 = k_cycle_get_32();
 	cavs_ipc_send_message(CAVS_HOST_DEV, IPCCMD_TIMESTAMP, 0);
-	zassert_true(WAIT_FOR(host_dt != 0, 10000, k_msleep(1)), NULL);
+	AWAIT(host_dt != 0);
 	cavs_ipc_set_message_handler(CAVS_HOST_DEV, NULL, NULL);
 
 	hz = 1000000ULL * (cyc1 - cyc0) / host_dt;

--- a/tests/boards/intel_adsp/smoke/src/tests.h
+++ b/tests/boards/intel_adsp/smoke/src/tests.h
@@ -7,6 +7,19 @@
 #include <cavs_ipc.h>
 #include <cavstool.h>
 
+/* Helper to escape from infinite polling loops with a test failure
+ * instead of a hang.  Spins with a relaxation loop so that it works
+ * in interrupt context and doesn't stress shared resources like SRAM
+ */
+#define AWAIT(expr) do {                                                \
+		int i;							\
+		for (i = 0; !(expr) && i < 10000; i++) {		\
+			for (volatile int j = 0; j < 1000; j++) {	\
+			}						\
+		}							\
+		zassert_true(i < 10000, "timeout waiting for %s", #expr); \
+	} while (0)
+
 void test_post_boot_ipi(void);
 void test_smp_boot_delay(void);
 void test_host_ipc(void);


### PR DESCRIPTION
The evolution of the original WAIT_FOR trick in this test, first to
move it to a generic spot and then to make it take a delay
paramatrization, have had the unfortunate side effect of breaking the
original usage.

And... it's really not following the design intent anyway.  The idea
here was to spin hard waiting on external hardware (a python script
running on the host) to deliver an interrupt.  Both of the new tricks
(suspending the thread with a sleep and hammering the HDA wall clock
for time) can affect interrupt delivery.

Just restore the original implementation (albeit with a new name,
"AWAIT", since the original was stolen) until someone has a chance to
make this work properly with the new API.  There's no reason it can't,
it just doesn't yet.

Fixes #43828

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>