### PR TITLE
boards: arm: nucleo_f429zi: remove old CMake file

### DIFF
--- a/boards/arm/nucleo_f429zi/old.CMakeLists.txt
+++ b/boards/arm/nucleo_f429zi/old.CMakeLists.txt
@@ -1,5 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-if(CONFIG_PINMUX)
-zephyr_library()
-endif()


### PR DESCRIPTION
An unused "old.CMakeLists.txt" was kept, probably an artifact from the
pinmux->pinctrl transition.