### PR TITLE
drivers: pinmux: deprecate pinmux

### DIFF
--- a/include/zephyr/drivers/pinmux.h
+++ b/include/zephyr/drivers/pinmux.h
@@ -21,6 +21,7 @@
 
 #include <zephyr/types.h>
 #include <zephyr/device.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,8 +85,8 @@ __subsystem struct pinmux_driver_api {
 	pmux_input input;
 };
 
-static inline int pinmux_pin_set(const struct device *dev, uint32_t pin,
-				 uint32_t func)
+__deprecated static inline int pinmux_pin_set(const struct device *dev,
+					      uint32_t pin, uint32_t func)
 {
 	const struct pinmux_driver_api *api =
 		(const struct pinmux_driver_api *)dev->api;
@@ -93,8 +94,8 @@ static inline int pinmux_pin_set(const struct device *dev, uint32_t pin,
 	return api->set(dev, pin, func);
 }
 
-static inline int pinmux_pin_get(const struct device *dev, uint32_t pin,
-				 uint32_t *func)
+__deprecated static inline int pinmux_pin_get(const struct device *dev,
+					      uint32_t pin, uint32_t *func)
 {
 	const struct pinmux_driver_api *api =
 		(const struct pinmux_driver_api *)dev->api;
@@ -102,8 +103,8 @@ static inline int pinmux_pin_get(const struct device *dev, uint32_t pin,
 	return api->get(dev, pin, func);
 }
 
-static inline int pinmux_pin_pullup(const struct device *dev, uint32_t pin,
-				    uint8_t func)
+__deprecated static inline int pinmux_pin_pullup(const struct device *dev,
+						 uint32_t pin, uint8_t func)
 {
 	const struct pinmux_driver_api *api =
 		(const struct pinmux_driver_api *)dev->api;
@@ -111,9 +112,9 @@ static inline int pinmux_pin_pullup(const struct device *dev, uint32_t pin,
 	return api->pullup(dev, pin, func);
 }
 
-static inline int pinmux_pin_input_enable(const struct device *dev,
-					  uint32_t pin,
-					  uint8_t func)
+__deprecated static inline int pinmux_pin_input_enable(const struct device *dev,
+						       uint32_t pin,
+						       uint8_t func)
 {
 	const struct pinmux_driver_api *api =
 		(const struct pinmux_driver_api *)dev->api;


### PR DESCRIPTION
Pinctrl API has taken over pinmux. As planned, pinmux is going to be
deprecated for the next release (3.2). This patch flags all pinmux APIs
as deprecated.

Platforms currently blocking deprecation:

- Microchip MEC1501 boards: mec15xxevb_assy6853 and mec1501modular_assy6885