### PR TITLE
doc: gsg: Include instructions to set SDK env vars

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -621,6 +621,12 @@ that are used to emulate, flash and debug Zephyr applications.
             You must rerun the setup script if you relocate the Zephyr SDK bundle directory after
             the initial setup.
 
+.. note::
+
+   You might need to set the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` and
+   :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variables. See the
+   :ref:`toolchain_zephyr_sdk` section for details.
+
 .. _getting_started_run_sample:
 
 .. rst-class:: numbered-step

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -20,6 +20,33 @@ The Zephyr SDK supports the following target architectures:
 * x86 (32-bit and 64-bit)
 * Xtensa
 
+The Zephyr SDK bundle supports all major operating systems (Linux, macOS and
+Windows) and is delivered as a compressed file.
+The installation consists of extracting the file and running the included setup
+script. Additional OS-specific instructions are described in the sections below.
+
+By default, the Zephyr build system assumes that the toolchain will be obtained
+from the Zephyr SDK. You can enforce this by setting the environment variable
+:envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``.
+
+If you install the Zephyr SDK outside any of the default locations (listed in
+the operating system specific instructions below), you must register the Zephyr
+SDK in the CMake package registry by running the setup script or setting
+:envvar:`ZEPHYR_SDK_INSTALL_DIR` to point to the Zephyr SDK installation
+directory.
+
+You can also set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to point to a directory
+containing multiple Zephyr SDKs, allowing for automatic toolchain selection. For
+example, you can set ``ZEPHYR_SDK_INSTALL_DIR`` to ``/company/tools``, where the
+``company/tools`` folder contains the following subfolders:
+
+* ``/company/tools/zephyr-sdk-0.13.2``
+* ``/company/tools/zephyr-sdk-a.b.c``
+* ``/company/tools/zephyr-sdk-x.y.z``
+
+This allows the Zephyr build system to choose the correct version of the SDK,
+while allowing multiple Zephyr SDKs to be grouped together at a specific path.
+
 .. _toolchain_zephyr_sdk_install_linux:
 
 Install Zephyr SDK on Linux
@@ -59,7 +86,8 @@ If you want to uninstall the SDK, remove the directory where you installed it.
 If you relocate the SDK directory, you need to re-run the setup script.
 
 .. note::
-   It is recommended to extract the Zephyr SDK bundle at one of the following locations:
+   It is recommended to extract the Zephyr SDK bundle at one of the following
+   default locations:
 
    * ``$HOME``
    * ``$HOME/.local``
@@ -71,24 +99,6 @@ If you relocate the SDK directory, you need to re-run the setup script.
    The Zephyr SDK bundle archive contains the ``zephyr-sdk-0.14.2`` directory and, when
    extracted under ``$HOME``, the resulting installation path will be
    ``$HOME/zephyr-sdk-0.14.2``.
-
-   If you install the Zephyr SDK outside any of these locations, you must
-   register the Zephyr SDK in the CMake package registry by running the setup
-   script, or set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to point to the Zephyr SDK
-   installation directory.
-
-   You can also use :envvar:`ZEPHYR_SDK_INSTALL_DIR` for pointing to a
-   directory containing multiple Zephyr SDKs, allowing for automatic toolchain
-   selection. For example, ``ZEPHYR_SDK_INSTALL_DIR=/company/tools``, where
-   the ``company/tools`` folder contains the following subfolders:
-
-   * ``/company/tools/zephyr-sdk-0.13.2``
-   * ``/company/tools/zephyr-sdk-a.b.c``
-   * ``/company/tools/zephyr-sdk-x.y.z``
-
-   This allows the Zephyr build system to choose the correct version of the
-   SDK, while allowing multiple Zephyr SDKs to be grouped together at a
-   specific path.
 
 .. _toolchain_zephyr_sdk_install_macos:
 
@@ -113,7 +123,8 @@ Install Zephyr SDK on macOS
       tar xvf zephyr-sdk-0.14.2_macos-x86_64.tar.gz
 
    .. note::
-      It is recommended to extract the Zephyr SDK bundle at one of the following locations:
+      It is recommended to extract the Zephyr SDK bundle at one of the following
+      default locations:
 
       * ``$HOME``
       * ``$HOME/.local``
@@ -160,7 +171,8 @@ Install Zephyr SDK on Windows
       unzip zephyr-sdk-0.14.2_windows-x86_64.zip
 
    .. note::
-      It is recommended to extract the Zephyr SDK bundle at one of the following locations:
+      It is recommended to extract the Zephyr SDK bundle at one of the following
+      default locations:
 
       * ``%HOMEPATH%``
       * ``%PROGRAMFILES%``


### PR DESCRIPTION
The basic environment variables need to be set to be able to build
blinky (at least ZEPHYR_TOOLCHAIN_VARIANT) but were not inlcuded in the
GSG.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>