### PR TITLE
dts: arm: st: f7: add ITCM memory for STM32F723

### DIFF
--- a/dts/arm/st/f7/stm32f723.dtsi
+++ b/dts/arm/st/f7/stm32f723.dtsi
@@ -20,6 +20,12 @@
 		zephyr,memory-region = "DTCM";
 	};
 
+	itcm: memory@0 {
+		compatible = "zephyr,memory-region", "arm,itcm";
+		reg = <0x00000000 DT_SIZE_K(16)>;
+		zephyr,memory-region = "ITCM";
+	};
+
 	soc {
 		usbphyc: usbphyc@40017c00 {
 			compatible = "st,stm32-usbphyc";


### PR DESCRIPTION
The STM32F723 SoC has 16 kB of ITCM RAM mapped at address 0x00000000.

Tested using zephyr_code_relocate().

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>