### PR TITLE
LE Audio: BAP data path

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -203,6 +203,8 @@ struct bt_codec_data {
  */
 #define BT_CODEC(_id, _cid, _vid, _data, _meta) \
 	{ \
+		/* Use HCI data path as default, can be overwritten by application */ \
+		.path_id = BT_ISO_DATA_PATH_HCI, \
 		.id = _id, \
 		.cid = _cid, \
 		.vid = _vid, \
@@ -249,6 +251,12 @@ enum bt_audio_location {
 
 /** @brief Codec structure. */
 struct bt_codec {
+	/** Data path ID
+	 *
+	 * @ref BT_ISO_DATA_PATH_HCI for HCI path, or any other value for
+	 * vendor specific ID.
+	 */
+	uint8_t path_id;
 	/** Codec ID */
 	uint8_t  id;
 	/** Codec Company ID */

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -192,8 +192,8 @@ struct bt_iso_chan_path {
 	uint32_t			delay;
 	/** Codec Configuration length*/
 	uint8_t				cc_len;
-	/** Codec Configuration */
-	uint8_t				cc[0];
+	/** Pointer to an array containing the Codec Configuration */
+	uint8_t				*cc;
 };
 
 /** ISO packet status flag bits */

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -937,6 +937,8 @@ static int ascs_ep_stream_bind_audio_iso(struct bt_audio_stream *stream,
 		audio_iso->iso_chan.ops = &ascs_iso_ops;
 		audio_iso->iso_chan.qos = &audio_iso->iso_qos;
 		audio_iso->iso_chan.qos->tx = &audio_iso->source_io_qos;
+		audio_iso->iso_chan.qos->rx->path = &audio_iso->sink_path;
+		audio_iso->iso_chan.qos->rx->path->cc = audio_iso->source_path_cc;
 	} else if (dir == BT_AUDIO_DIR_SINK) {
 		if (audio_iso->sink_stream == NULL) {
 			audio_iso->sink_stream = stream;
@@ -948,6 +950,8 @@ static int ascs_ep_stream_bind_audio_iso(struct bt_audio_stream *stream,
 		audio_iso->iso_chan.ops = &ascs_iso_ops;
 		audio_iso->iso_chan.qos = &audio_iso->iso_qos;
 		audio_iso->iso_chan.qos->rx = &audio_iso->sink_io_qos;
+		audio_iso->iso_chan.qos->rx->path = &audio_iso->sink_path;
+		audio_iso->iso_chan.qos->rx->path->cc = audio_iso->sink_path_cc;
 	} else {
 		__ASSERT(false, "Invalid dir: %u", dir);
 	}
@@ -1412,8 +1416,9 @@ static int ase_stream_qos(struct bt_audio_stream *stream,
 
 static void ase_qos(struct bt_ascs_ase *ase, const struct bt_ascs_qos *qos)
 {
-	struct bt_audio_stream *stream = ase->ep.stream;
-	struct bt_codec_qos *cqos = &ase->ep.qos;
+	struct bt_audio_ep *ep = &ase->ep;
+	struct bt_audio_stream *stream = ep->stream;
+	struct bt_codec_qos *cqos = &ep->qos;
 	const uint8_t cig_id = qos->cig;
 	const uint8_t cis_id = qos->cis;
 	int err;
@@ -1464,10 +1469,22 @@ static void ase_qos(struct bt_ascs_ase *ase, const struct bt_ascs_qos *qos)
 		ascs_cp_rsp_add_errno(ASE_ID(ase), BT_ASCS_QOS_OP,
 				      err, reason);
 		return;
+	} else {
+		/* We setup the data path here, as this is the earliest where
+		 * we have the ISO <-> EP coupling completed (due to setting
+		 * the CIS ID in the QoS procedure).
+		 */
+		if (ep->dir == BT_AUDIO_DIR_SINK) {
+			bt_audio_codec_to_iso_path(&ep->iso->sink_path,
+						   stream->codec);
+		} else {
+			bt_audio_codec_to_iso_path(&ep->iso->source_path,
+						   stream->codec);
+		}
 	}
 
-	ase->ep.cig_id = cig_id;
-	ase->ep.cis_id = cis_id;
+	ep->cig_id = cig_id;
+	ep->cis_id = cis_id;
 
 	ascs_cp_rsp_success(ASE_ID(ase), BT_ASCS_QOS_OP);
 }

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -951,9 +951,12 @@ static int bt_audio_broadcast_sink_setup_stream(uint8_t index,
 	 * but the `rx` and `qos` pointers need to be set. This should be fixed.
 	 */
 	stream->iso->qos->rx = &sink_chan_io_qos;
+	stream->iso->qos->rx->path = &ep->iso->sink_path;
+	stream->iso->qos->rx->path->cc = ep->iso->sink_path_cc;
 	stream->iso->qos->tx = NULL;
 	stream->qos = &codec_qos;
 	bt_audio_codec_qos_to_iso_qos(stream->iso->qos->rx, &codec_qos);
+	bt_audio_codec_to_iso_path(stream->iso->qos->rx->path, codec);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -270,8 +270,11 @@ static int bt_audio_broadcast_source_setup_stream(uint8_t index,
 	bt_audio_stream_attach(NULL, stream, ep, codec);
 	ep->iso->source_stream = stream;
 	stream->qos = qos;
+	stream->iso->qos->tx->path = &ep->iso->source_path;
+	stream->iso->qos->tx->path->cc = ep->iso->source_path_cc;
 	stream->iso->qos->rx = NULL;
 	bt_audio_codec_qos_to_iso_qos(stream->iso->qos->tx, qos);
+	bt_audio_codec_to_iso_path(stream->iso->qos->tx->path, codec);
 
 	return 0;
 }

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -36,6 +36,15 @@ struct bt_audio_iso {
 	struct bt_iso_chan_qos iso_qos;
 	struct bt_iso_chan_io_qos sink_io_qos;
 	struct bt_iso_chan_io_qos source_io_qos;
+	struct bt_iso_chan_path sink_path;
+	/* TODO: The sink/source path CC will basically be a duplicate of
+	 * bt_codec.data, but since struct bt_codec stores the information as an
+	 * array of bt_codec_data, and ISO expect a uint8_t array, we need to
+	 * duplicate the data. This should be optimized.
+	 */
+	uint8_t sink_path_cc[CONFIG_BT_CODEC_MAX_DATA_COUNT * CONFIG_BT_CODEC_MAX_DATA_LEN];
+	struct bt_iso_chan_path	source_path;
+	uint8_t source_path_cc[CONFIG_BT_CODEC_MAX_DATA_COUNT * CONFIG_BT_CODEC_MAX_DATA_LEN];
 	struct bt_audio_stream *sink_stream;
 	struct bt_audio_stream *source_stream;
 };

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -28,12 +28,42 @@
 #define LOG_MODULE_NAME bt_audio_stream
 #include "common/log.h"
 
-void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
-				  const struct bt_codec_qos *codec)
+static uint8_t pack_bt_codec_cc(const struct bt_codec *codec, uint8_t cc[])
 {
-	io->sdu = codec->sdu;
-	io->phy = codec->phy;
-	io->rtn = codec->rtn;
+	uint8_t len;
+
+	len = 0U;
+	for (size_t i = 0U; i < codec->data_count; i++) {
+		const struct bt_data *data = &codec->data[i].data;
+
+		/* We assume that data_len and data has previously been verified
+		 * and that based on the Kconfigs we can assume that the length
+		 * will always fit in `cc`
+		 */
+		(void)memcpy(cc + len, data->data, data->data_len);
+		len += data->data_len;
+	}
+
+	return len;
+}
+
+void bt_audio_codec_to_iso_path(struct bt_iso_chan_path *path,
+				const struct bt_codec *codec)
+{
+	path->pid = codec->path_id;
+	path->format = codec->id;
+	path->cid = codec->cid;
+	path->vid = codec->vid;
+	path->delay = 0; /* TODO: Add to bt_codec? Use presentation delay? */
+	path->cc_len = pack_bt_codec_cc(codec, path->cc);
+}
+
+void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
+				   const struct bt_codec_qos *codec_qos)
+{
+	io->sdu = codec_qos->sdu;
+	io->phy = codec_qos->phy;
+	io->rtn = codec_qos->rtn;
 }
 
 void bt_audio_stream_attach(struct bt_conn *conn,

--- a/subsys/bluetooth/audio/stream.h
+++ b/subsys/bluetooth/audio/stream.h
@@ -42,8 +42,10 @@ void bt_audio_stream_attach(struct bt_conn *conn, struct bt_audio_stream *stream
 			    struct bt_audio_ep *ep,
 			    struct bt_codec *codec);
 
+void bt_audio_codec_to_iso_path(struct bt_iso_chan_path *path,
+				const struct bt_codec *codec);
 void bt_audio_codec_qos_to_iso_qos(struct bt_iso_chan_io_qos *io,
-				   const struct bt_codec_qos *codec);
+				   const struct bt_codec_qos *codec_qos);
 
 void bt_audio_stream_detach(struct bt_audio_stream *stream);
 

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -266,12 +266,16 @@ void bt_unicast_client_stream_bind_audio_iso(struct bt_audio_stream *stream,
 		 */
 		audio_iso->sink_stream = stream;
 		qos->rx = &audio_iso->sink_io_qos;
+		qos->rx->path = &audio_iso->sink_path;
+		qos->rx->path->cc = audio_iso->sink_path_cc;
 	} else if (dir == BT_AUDIO_DIR_SINK) {
 		/* If the endpoint is a sink, then we need to
 		 * configure our TX parameters
 		 */
 		audio_iso->source_stream = stream;
 		qos->tx = &audio_iso->source_io_qos;
+		qos->tx->path = &audio_iso->source_path;
+		qos->tx->path->cc = audio_iso->source_path_cc;
 	} else {
 		__ASSERT(false, "Invalid dir: %u", dir);
 	}
@@ -602,6 +606,24 @@ static void unicast_client_ep_qos_state(struct bt_audio_ep *ep,
 	/* Disconnect ISO if connected */
 	if (stream->iso->state == BT_ISO_STATE_CONNECTED) {
 		bt_audio_stream_disconnect(stream);
+	} else {
+		/* We setup the data path here, as this is the earliest where
+		 * we have the ISO <-> EP coupling completed (due to setting
+		 * the CIS ID in the QoS procedure).
+		 */
+		if (ep->dir == BT_AUDIO_DIR_SOURCE) {
+			/* If the endpoint is a source, then we need to
+			 * configure our RX parameters
+			 */
+			bt_audio_codec_to_iso_path(&ep->iso->sink_path,
+						   stream->codec);
+		} else {
+			/* If the endpoint is a sink, then we need to
+			 * configure our TX parameters
+			 */
+			bt_audio_codec_to_iso_path(&ep->iso->source_path,
+						   stream->codec);
+		}
 	}
 
 	/* Notify upper layer */

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -194,6 +194,18 @@ static int hci_le_setup_iso_data_path(const struct bt_conn *iso, uint8_t dir,
 	uint8_t *cc;
 	int err;
 
+	__ASSERT(dir == BT_HCI_DATAPATH_DIR_HOST_TO_CTLR ||
+		 dir == BT_HCI_DATAPATH_DIR_CTLR_TO_HOST,
+		 "invalid ISO data path dir: %u", dir);
+
+	if ((path->cc == NULL && path->cc_len != 0) ||
+	    (path->cc != NULL && path->cc_len == 0)) {
+		BT_DBG("Invalid ISO data path CC: %p %u",
+		       path->cc, path->cc_len);
+
+		return -EINVAL;
+	}
+
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SETUP_ISO_PATH, sizeof(*cp));
 	if (!buf) {
 		return -ENOBUFS;


### PR DESCRIPTION
This PR updates the BAP API such that it is possible to use non-HCI data path with BAP. 

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45613

depends on https://github.com/zephyrproject-rtos/zephyr/pull/46168