### PR TITLE
drivers: gsm_ppp: Wait for NET_IF_DOWN in gsm_ppp_stop only if iface was up

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1154,11 +1154,11 @@ void gsm_ppp_stop(const struct device *dev)
 
 	gsm_ppp_lock(gsm);
 
-	net_if_l2(iface)->enable(iface, false);
-
 	/* wait for the interface to be properly down */
-	(void)k_sem_take(&gsm->sem_if_down, K_FOREVER);
-
+	if (net_if_is_up(iface)) {
+		net_if_l2(iface)->enable(iface, false);
+		(void)k_sem_take(&gsm->sem_if_down, K_FOREVER);
+	}
 	if (IS_ENABLED(CONFIG_GSM_MUX)) {
 
 		if (gsm->ppp_dev) {


### PR DESCRIPTION
Check if ppp iface was actually up before taking it down and waiting
for NET_EVENT_IF_DOWN. This allows to call gsm_ppp_stop() even if
the PPP was never started, which previously caused the call to lock
forever. This case is useful, for example, if the modem didn't attach
to network in desirable time and user wants to abort PPP setup.

Signed-off-by: Marek Metelski <marek@metelski.dev>