### PR TITLE
Fix QuickFeather board name in the docs

### DIFF
--- a/boards/arm/quick_feather/doc/index.rst
+++ b/boards/arm/quick_feather/doc/index.rst
@@ -94,7 +94,7 @@ To load basic sample via GDB:
 
 .. zephyr-app-commands::
    :zephyr-app: samples/hello_world
-   :board: quickfeather
+   :board: quick_feather
    :goals: build
 
 - Connect to the target using either OpenOCD or JLink


### PR DESCRIPTION
Change required to generate proper build command in the docs.