### PR TITLE
drivers: gsm_ppp: Fix null pointer dereference in log message

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -830,7 +830,7 @@ attaching:
 #endif
 	}
 
-	LOG_DBG("modem RSSI: %d, %s", *gsm->context.data_rssi, "enable PPP");
+	LOG_DBG("modem RSSI: %d, %s", gsm->minfo.mdm_rssi, "enable PPP");
 
 	ret = modem_cmd_handler_setup_cmds_nolock(&gsm->context.iface,
 						  &gsm->context.cmd_handler,


### PR DESCRIPTION
Log message references gsm->context.data_rssi which is NULL
when CONFIG_MODEM_SHELL=n. Use gsm->minfo.mdm_rssi which is
internally when accessing RSSI value.

Signed-off-by: Marek Metelski <marek@metelski.dev>