### PR TITLE
net: tcp: Implement Nagle's algorithm

### DIFF
--- a/subsys/net/ip/tcp_internal.h
+++ b/subsys/net/ip/tcp_internal.h
@@ -30,6 +30,10 @@ extern "C" {
 
 #include "tcp_private.h"
 
+enum tcp_conn_option {
+	TCP_OPT_NODELAY	= 1,
+};
+
 /**
  * @brief Calculates and returns the MSS for a given TCP context
  *
@@ -365,6 +369,57 @@ static inline int net_tcp_put(struct net_context *context)
 void net_tcp_init(void);
 #else
 #define net_tcp_init(...)
+#endif
+
+/**
+ * @brief Set tcp specific options of a socket
+ *
+ * @param context Network context
+ *
+ * @return 0 on success, -EINVAL if the value is not allowed
+ */
+#if defined(CONFIG_NET_NATIVE_TCP)
+int net_tcp_set_option(struct net_context *context,
+		       enum tcp_conn_option option,
+		       const void *value, size_t len);
+#else
+static inline int net_tcp_set_option(struct net_context *context,
+				     enum tcp_conn_option option,
+				     const void *value, size_t len)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(option);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
+	return -EPROTONOSUPPORT;
+}
+#endif
+
+
+/**
+ * @brief Obtain tcp specific options of a socket
+ *
+ * @param context Network context
+ *
+ * @return 0 on success
+ */
+#if defined(CONFIG_NET_NATIVE_TCP)
+int net_tcp_get_option(struct net_context *context,
+		       enum tcp_conn_option option,
+		       void *value, size_t *len);
+#else
+static inline int net_tcp_get_option(struct net_context *context,
+				     enum tcp_conn_option option,
+				     void *value, size_t *len)
+{
+	ARG_UNUSED(context);
+	ARG_UNUSED(option);
+	ARG_UNUSED(value);
+	ARG_UNUSED(len);
+
+	return -EPROTONOSUPPORT;
+}
 #endif
 
 /**

--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -269,6 +269,7 @@ struct tcp { /* TCP connection */
 	bool in_retransmission : 1;
 	bool in_connect : 1;
 	bool in_close : 1;
+	bool tcp_nodelay : 1;
 };
 
 #define _flags(_fl, _op, _mask, _cond)					\

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -1852,6 +1852,12 @@ int zsock_getsockopt_ctx(struct net_context *ctx, int level, int optname,
 			}
 			break;
 		}
+	case IPPROTO_TCP:
+		switch (optname) {
+		case TCP_NODELAY:
+			ret = net_tcp_get_option(ctx, TCP_OPT_NODELAY, optval, optlen);
+			return ret;
+		}
 	}
 
 	errno = ENOPROTOOPT;
@@ -2099,10 +2105,9 @@ int zsock_setsockopt_ctx(struct net_context *ctx, int level, int optname,
 	case IPPROTO_TCP:
 		switch (optname) {
 		case TCP_NODELAY:
-			/* Ignore for now. Provided to let port
-			 * existing apps.
-			 */
-			return 0;
+			ret = net_tcp_set_option(ctx,
+						 TCP_OPT_NODELAY, optval, optlen);
+			return ret;
 		}
 		break;
 


### PR DESCRIPTION
To improve the performance with small chunks send, implement Nagle's
algorithm. Provide the option TCP_NODELAY to disable the algorithm.

Fixes #30365.

Signed-off-by: Sjors Hettinga <s.a.hettinga@gmail.com>