### PR TITLE
lib/os/cbprintf: Use signed char for %hhd format

### DIFF
--- a/lib/os/cbprintf_complete.c
+++ b/lib/os/cbprintf_complete.c
@@ -1514,7 +1514,7 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *fp,
 				break;
 			}
 			if (length_mod == LENGTH_HH) {
-				value->sint = (char)value->sint;
+				value->sint = (signed char)value->sint;
 			} else if (length_mod == LENGTH_H) {
 				value->sint = (short)value->sint;
 			}


### PR DESCRIPTION
The cast to narrow for %hhd support must be 'signed char' instead of 'char'
to support targets where 'char' is unsigned, as on riscv.

Signed-off-by: Keith Packard <keithp@keithp.com>