### PR TITLE
tests: log_api: exclude XCC from runtime tagged argument tests

### DIFF
--- a/samples/subsys/logging/syst/sample.yaml
+++ b/samples/subsys/logging/syst/sample.yaml
@@ -35,6 +35,7 @@ tests:
     extra_configs:
       - CONFIG_LOG1=y
   sample.logger.syst.v2.deferred:
+    toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385
       - qemu_x86
@@ -48,6 +49,7 @@ tests:
         - "SYS-T RAW DATA: "
         - "SYST Sample Execution Completed"
   sample.logger.syst.v2.immediate:
+    toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_immediate.conf
     integration_platforms:
       - mps2_an385
@@ -61,6 +63,7 @@ tests:
         - "SYS-T RAW DATA: "
         - "SYST Sample Execution Completed"
   sample.logger.syst.catalog.v2.deferred:
+    toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
     integration_platforms:
       - mps2_an385
@@ -75,6 +78,7 @@ tests:
     extra_configs:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
   sample.logger.syst.catalog.v2.immediate:
+    toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385
       - qemu_x86
@@ -120,6 +124,7 @@ tests:
       - CONFIG_LOG1=y
       - CONFIG_CPLUSPLUS=y
   sample.logger.syst.v2.deferred_cpp:
+    toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
     integration_platforms:
       - mps2_an385
@@ -135,6 +140,7 @@ tests:
     extra_configs:
       - CONFIG_CPLUSPLUS=y
   sample.logger.syst.v2.immediate_cpp:
+    toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385
       - qemu_x86
@@ -149,6 +155,7 @@ tests:
     extra_configs:
       - CONFIG_CPLUSPLUS=y
   sample.logger.syst.catalog.v2.deferred_cpp:
+    toolchain_exclude: xcc
     extra_args: OVERLAY_CONFIG=overlay_deferred.conf
     integration_platforms:
       - mps2_an385
@@ -164,6 +171,7 @@ tests:
       - CONFIG_LOG_MIPI_SYST_USE_CATALOG=y
       - CONFIG_CPLUSPLUS=y
   sample.logger.syst.catalog.v2.immediate_cpp:
+    toolchain_exclude: xcc
     integration_platforms:
       - mps2_an385
       - qemu_x86

--- a/tests/subsys/logging/log_api/testcase.yaml
+++ b/tests/subsys/logging/log_api/testcase.yaml
@@ -468,6 +468,7 @@ tests:
   logging.log2_api_deferred_overflow_rt_filter.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
@@ -477,6 +478,7 @@ tests:
   logging.log2_api_deferred_overflow.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
@@ -485,6 +487,7 @@ tests:
   logging.log2_api_deferred_no_overflow.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=n
@@ -493,6 +496,7 @@ tests:
   logging.log2_api_deferred_static_filter.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -501,6 +505,7 @@ tests:
   logging.log2_api_deferred_printk.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -512,6 +517,7 @@ tests:
   logging.log2_api_deferred_func_prefix.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -521,6 +527,7 @@ tests:
   logging.log2_api_deferred_64b_timestamp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
@@ -530,6 +537,7 @@ tests:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
     platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_OVERRIDE_LEVEL=4
@@ -539,6 +547,7 @@ tests:
     # Testing on selected platforms as it enables all logs in the application
     # and it cannot be handled on many platforms.
     platform_allow: qemu_cortex_m3 qemu_cortex_a9
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
@@ -548,6 +557,7 @@ tests:
   logging.log2_api_immediate.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG2_USE_TAGGED_ARGUMENTS=y
@@ -555,6 +565,7 @@ tests:
   logging.log2_api_immediate_printk.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG_PRINTK=y
@@ -563,6 +574,7 @@ tests:
   logging.log2_api_immediate_rt_filter.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
@@ -571,6 +583,7 @@ tests:
   logging.log2_api_immediate_static_filter.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -579,6 +592,7 @@ tests:
   logging.log2_api_immediate_64b_timestamp.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
@@ -587,6 +601,7 @@ tests:
   logging.log2_api_deferred_overflow_rt_filter_cpp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
@@ -597,6 +612,7 @@ tests:
   logging.log2_api_deferred_overflow_cpp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=y
@@ -606,6 +622,7 @@ tests:
   logging.log2_api_deferred_no_overflow_cpp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_MODE_OVERFLOW=n
@@ -615,6 +632,7 @@ tests:
   logging.log2_api_deferred_static_filter_cpp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -624,6 +642,7 @@ tests:
   logging.log2_api_deferred_printk_cpp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -636,6 +655,7 @@ tests:
   logging.log2_api_deferred_func_prefix_cpp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -646,6 +666,7 @@ tests:
   logging.log2_api_deferred_64b_timestamp_cpp.tagged_args:
     # FIXME:see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_DEFERRED=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y
@@ -655,6 +676,7 @@ tests:
   logging.log2_api_immediate_cpp.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_CPLUSPLUS=y
@@ -663,6 +685,7 @@ tests:
   logging.log2_api_immediate_printk_cpp.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG_PRINTK=y
@@ -672,6 +695,7 @@ tests:
   logging.log2_api_immediate_rt_filter_cpp.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG_RUNTIME_FILTERING=y
@@ -681,6 +705,7 @@ tests:
   logging.log2_api_immediate_static_filter_cpp.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_SAMPLE_MODULE_LOG_LEVEL_DBG=y
@@ -690,6 +715,7 @@ tests:
   logging.log2_api_immediate_64b_timestamp_cpp.tagged_args:
     # FIXME: qemu_arc_hs6x excluded, see #38041
     platform_exclude: qemu_arc_hs6x
+    toolchain_exclude: xcc
     extra_configs:
       - CONFIG_LOG_MODE_IMMEDIATE=y
       - CONFIG_LOG_TIMESTAMP_64BIT=y


### PR DESCRIPTION
XCC does not support _Generic so it can't build the runtime tagged
argument tests. So exclude them.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>