### PR TITLE
Sprintk buffer overflow mitigation

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1230,7 +1230,7 @@ int32_t mdm_hl7800_get_functionality(void)
 int32_t mdm_hl7800_set_functionality(enum mdm_hl7800_functionality mode)
 {
 	int ret;
-	char buf[sizeof("AT+CFUN=0,0")] = { 0 };
+	char buf[sizeof("AT+CFUN=###,0")] = { 0 };
 
 	hl7800_lock();
 	wakeup_hl7800();
@@ -3829,7 +3829,7 @@ done:
 
 static int delete_socket(struct hl7800_socket *sock, enum net_sock_type type, uint8_t id)
 {
-	char cmd[sizeof("AT+KUDPCLOSE=##")];
+	char cmd[sizeof("AT+KUDPCLOSE=###")];
 
 	if (type == SOCK_STREAM) {
 		snprintk(cmd, sizeof(cmd), "AT+KTCPDEL=%d", id);
@@ -4105,7 +4105,7 @@ done:
 
 static int start_socket_rx(struct hl7800_socket *sock, uint16_t rx_size)
 {
-	char sendbuf[sizeof("AT+KTCPRCV=##,####")];
+	char sendbuf[sizeof("AT+KTCPRCV=+#########,#####")];
 
 	if ((sock->socket_id <= 0) || (sock->rx_size <= 0)) {
 		LOG_WRN("Cannot start socket RX, ID: %d rx size: %d",

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -688,7 +688,9 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 	uint16_t	    dst_port  = 0;
 	char		    *protocol = "TCP";
 	struct modem_cmd    cmd[]     = { MODEM_CMD("+QIOPEN: ", on_cmd_atcmdinfo_sockopen, 2U, ",") };
-	char		    buf[sizeof("AT+QIOPEN=#,##,###,####.####.####.####,######")] = {0};
+	char		    buf[sizeof("AT+QIOPEN=#,#,'###','###',"
+				       "####.####.####.####.####.####.####.####,######,"
+				       "0,0")] = {0};
 	int		    ret;
 	char		    ip_str[NET_IPV6_ADDR_LEN];
 

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -291,7 +291,9 @@ static ssize_t send_socket_data(void *obj,
 				k_timeout_t timeout)
 {
 	int ret;
-	char send_buf[sizeof("AT+USO**=#,!###.###.###.###!,#####,####\r\n")];
+	char send_buf[sizeof("AT+USO**=###,"
+			     "!####.####.####.####.####.####.####.####!,"
+			     "#####,#########\r\n")];
 	uint16_t dst_port = 0U;
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	const struct modem_cmd handler_cmds[] = {
@@ -1530,7 +1532,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 {
 	struct modem_socket *sock = (struct modem_socket *)obj;
 	int ret;
-	char buf[sizeof("AT+USOCO=#,!###.###.###.###!,#####,#\r")];
+	char buf[sizeof("AT+USOCO=###,!####.####.####.####.####.####.####.####!,#####,#\r")];
 	uint16_t dst_port = 0U;
 	char ip_str[NET_IPV6_ADDR_LEN];
 

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -912,7 +912,7 @@ static void on_cmd_sockdataind(struct net_buf **buf, uint16_t len)
 	size_t out_len;
 	char *delim1, *delim2;
 	char value[sizeof("#,#,#####\r")];
-	char sendbuf[sizeof("AT@SOCKREAD=#,#####\r")];
+	char sendbuf[sizeof("AT@SOCKREAD=-#####,-#####\r")];
 	struct wncm14a2a_socket *sock = NULL;
 
 	out_len = net_buf_linearize(value, sizeof(value) - 1, *buf, 0, len);
@@ -1519,7 +1519,7 @@ static int offload_get(sa_family_t family,
 		       struct net_context **context)
 {
 	int ret;
-	char buf[sizeof("AT@SOCKCREAT=#,#\r")];
+	char buf[sizeof("AT@SOCKCREAT=###,#\r")];
 	struct wncm14a2a_socket *sock = NULL;
 
 	/* new socket */

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -38,7 +38,7 @@ static int esp_listen(struct net_context *context, int backlog)
 
 static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 {
-	char connect_msg[sizeof("AT+CIPSTART=0,\"TCP\",\"\",65535,7200") +
+	char connect_msg[sizeof("AT+CIPSTART=000,\"TCP\",\"\",65535,7200") +
 			 NET_IPV4_ADDR_LEN];
 	char addr_str[NET_IPV4_ADDR_LEN];
 	struct sockaddr dst;
@@ -482,7 +482,7 @@ void esp_recvdata_work(struct k_work *work)
 	struct esp_socket *sock = CONTAINER_OF(work, struct esp_socket,
 					       recvdata_work);
 	struct esp_data *data = esp_socket_to_dev(sock);
-	char cmd[sizeof("AT+CIPRECVDATA=0,"STRINGIFY(CIPRECVDATA_MAX_LEN))];
+	char cmd[sizeof("AT+CIPRECVDATA=000,"STRINGIFY(CIPRECVDATA_MAX_LEN))];
 	static const struct modem_cmd cmds[] = {
 		MODEM_CMD_DIRECT(_CIPRECVDATA, on_cmd_ciprecvdata),
 	};

--- a/drivers/wifi/esp_at/esp_socket.c
+++ b/drivers/wifi/esp_at/esp_socket.c
@@ -198,7 +198,7 @@ void esp_socket_rx(struct esp_socket *sock, struct net_buf *buf,
 void esp_socket_close(struct esp_socket *sock)
 {
 	struct esp_data *dev = esp_socket_to_dev(sock);
-	char cmd_buf[sizeof("AT+CIPCLOSE=0")];
+	char cmd_buf[sizeof("AT+CIPCLOSE=000")];
 	int ret;
 
 	snprintk(cmd_buf, sizeof(cmd_buf), "AT+CIPCLOSE=%d",

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -44,7 +44,7 @@ struct virtual_test_context {
 static void virtual_test_iface_init(struct net_if *iface)
 {
 	struct virtual_test_context *ctx = net_if_get_device(iface)->data;
-	char name[16];
+	char name[sizeof("VirtualTest-+##########")];
 	static int count;
 
 	if (ctx->init_done) {


### PR DESCRIPTION
These patches increase stack buffers used with sprintk to hold the largest possible result, rather than the results expected in normal operation.