### PR TITLE
boards: arm: seeeduino_xiao: fix vendor prefix

### DIFF
--- a/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
+++ b/boards/arm/seeeduino_xiao/seeeduino_xiao.dts
@@ -11,7 +11,7 @@
 
 / {
 	model = "Seeeduino XIAO";
-	compatible = "seeedstudio,seeeduino-xiao";
+	compatible = "seeed,seeeduino-xiao";
 
 	chosen {
 		zephyr,console = &sercom4;


### PR DESCRIPTION
Use "seeed" instead of "seeedstudio", as the former is registered in
`dts/bindings/vendor-prefixes.txt`.