### PR TITLE
test: Increase the tolerance between A3/A5

### DIFF
--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -526,7 +526,7 @@ void test_thread_stats_usage(void)
 
 	zassert_true(stats4.average_cycles > stats3.average_cycles, NULL);
 	zassert_true(stats4.average_cycles > stats5.average_cycles, NULL);
-	zassert_true(stats5.average_cycles > stats3.average_cycles, NULL);
+	zassert_true(stats5.average_cycles >= stats3.average_cycles, NULL);
 #endif
 
 	/* Abort the helper thread */


### PR DESCRIPTION
As the type of A(n) is integer, and A3 and A5 are close to
each other. Sometimes A3 is equal to A5. So change the ">" to
">="

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>