### PR TITLE
MAINTAINERS: Add new ARM64 collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -152,6 +152,7 @@ ARM64 arch:
     collaborators:
         - npitre
         - povergoing
+        - sgrrzhf
     files:
         - arch/arm64/
         - include/zephyr/arch/arm64/


### PR DESCRIPTION
I would like to join zephyr project members as a collaborator for contributing to the arm64 area.

I have pushed some PR about arm64 and I'm familiar with this area. I also want to be a reviewer to review PR related to arm64.