### PR TITLE
doc: gsg: Edit instructions to set SDK env vars

### DIFF
--- a/doc/develop/beyond-GSG.rst
+++ b/doc/develop/beyond-GSG.rst
@@ -74,6 +74,29 @@ setting :ref:`environment variables <env_vars>` such as
 :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to a supported value, along with
 additional variable(s) specific to the toolchain variant.
 
+.. _gs_toolchain_update:
+
+Updating the Zephyr SDK toolchain
+*********************************
+
+When updating Zephyr SDK, check whether the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
+or :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variables are already set.
+
+* If the variables are not set, the latest compatible version of Zephyr SDK will be selected
+  by default. Proceed to next step without making any changes.
+
+* If :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` is set, the corresponding toolchain will be selected
+  at build time. Zephyr SDK is identified by the value ``zephyr``.
+  If the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` environment variable is not ``zephyr``, then either
+  unset it or change its value to ``zephyr`` to make sure Zephyr SDK is selected.
+
+* If the :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variable is set, it will override
+  the default lookup location for Zephyr SDK. If you install Zephyr SDK to one
+  of the :ref:`recommended locations <toolchain_zephyr_sdk_bundle_variables>`,
+  you can unset this variable. Otherwise, set it to your chosen install location.
+
+For more information about these environment variables in Zephyr, see :ref:`env_vars_important`.
+
 Cloning the Zephyr Repositories
 *******************************
 

--- a/doc/develop/env_vars.rst
+++ b/doc/develop/env_vars.rst
@@ -187,6 +187,9 @@ the :ref:`toolchain <gs_toolchain>` used to build Zephyr applications.
   ``ZEPHYR_TOOLCHAIN_VARIANT=llvm``, use :envvar:`LLVM_TOOLCHAIN_PATH`. (Note
   the capitalization when forming the environment variable name.)
 
+You might need to update some of these variables when you
+:ref:`update the Zephyr SDK toolchain <gs_toolchain_update>`.
+
 Emulators and boards may also depend on additional programs. The build system
 will try to locate those programs automatically, but may rely on additional
 CMake or environment variables to do so. Please consult your emulator's or

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -621,12 +621,6 @@ that are used to emulate, flash and debug Zephyr applications.
             You must rerun the setup script if you relocate the Zephyr SDK bundle directory after
             the initial setup.
 
-.. note::
-
-   You might need to set the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` and
-   :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variables. See the
-   :ref:`toolchain_zephyr_sdk` section for details.
-
 .. _getting_started_run_sample:
 
 .. rst-class:: numbered-step
@@ -707,6 +701,24 @@ Here are some next steps for exploring Zephyr:
 * Check out :ref:`beyond-GSG` for additional setup alternatives and ideas
 * Discover :ref:`project-resources` for getting help from the Zephyr
   community
+
+.. _troubleshooting_installation:
+
+Troubleshooting Installation
+****************************
+
+Here are some tips for fixing some issues related to the installation process.
+
+.. _toolchain_zephyr_sdk_update:
+
+Double Check the Zephyr SDK Variables When Updating
+===================================================
+
+When updating Zephyr SDK, check whether the :envvar:`ZEPHYR_TOOLCHAIN_VARIANT`
+or :envvar:`ZEPHYR_SDK_INSTALL_DIR` environment variables are already set.
+See :ref:`gs_toolchain_update` for more information.
+
+For more information about these environment variables in Zephyr, see :ref:`env_vars_important`.
 
 .. _help:
 

--- a/doc/develop/toolchains/zephyr_sdk.rst
+++ b/doc/develop/toolchains/zephyr_sdk.rst
@@ -10,6 +10,9 @@ as custom QEMU and OpenOCD.
 Use of the Zephyr SDK is highly recommended and may even be required under
 certain conditions (for example, running tests in QEMU for some architectures).
 
+Supported architectures
+***********************
+
 The Zephyr SDK supports the following target architectures:
 
 * ARC (32-bit and 64-bit; ARCv1, ARCv2, ARCv3)
@@ -20,19 +23,25 @@ The Zephyr SDK supports the following target architectures:
 * x86 (32-bit and 64-bit)
 * Xtensa
 
+.. _toolchain_zephyr_sdk_bundle_variables:
+
+Installation bundle and variables
+*********************************
+
 The Zephyr SDK bundle supports all major operating systems (Linux, macOS and
 Windows) and is delivered as a compressed file.
 The installation consists of extracting the file and running the included setup
 script. Additional OS-specific instructions are described in the sections below.
 
-By default, the Zephyr build system assumes that the toolchain will be obtained
-from the Zephyr SDK. You can enforce this by setting the environment variable
+If no toolchain is selected, the build system looks for Zephyr SDK and uses the toolchain
+from there. You can enforce this by setting the environment variable
 :envvar:`ZEPHYR_TOOLCHAIN_VARIANT` to ``zephyr``.
 
 If you install the Zephyr SDK outside any of the default locations (listed in
-the operating system specific instructions below), you must register the Zephyr
-SDK in the CMake package registry by running the setup script or setting
-:envvar:`ZEPHYR_SDK_INSTALL_DIR` to point to the Zephyr SDK installation
+the operating system specific instructions below) and you want automatic discovery
+of the Zephyr SDK, then you must register the Zephyr SDK in the CMake package registry
+by running the setup script. If you decide not to register the Zephyr SDK in the CMake registry,
+then the :envvar:`ZEPHYR_SDK_INSTALL_DIR` can be used to point to the Zephyr SDK installation
 directory.
 
 You can also set :envvar:`ZEPHYR_SDK_INSTALL_DIR` to point to a directory


### PR DESCRIPTION
Edited the changes added in PR #46319.
The changes aim at including the variable info
in each OS installation procedure for major visibility.
Also added subsections on zephyr_sdk.rst page.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>