### PR TITLE
clocks: stm32h7: fix wrong pclken.enr on wwdg1

### DIFF
--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -241,7 +241,7 @@
 		wwdg1: watchdog@50003000 {
 			compatible = "st,stm32-window-watchdog";
 			reg = <0x50003000 0x1000>;
-			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000800>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00000040>;
 			interrupts = <0 7>;
 			status = "disabled";
 			label = "WWDG_1";


### PR DESCRIPTION
WWDG1 doesn't work on STM32H7 because its peripheral clock
is never enabled due to wrong enable bit in RCC_APB3ENR

See https://www.st.com/resource/en/reference_manual/dm00314099-stm32h742-stm32h743-753-and-stm32h750-value-line-advanced-arm-based-32-bit-mcus-stmicroelectronics.pdf page 457 where we can see that the enable bit for wwdg1 is 0x40