### PR TITLE
MAINTAINERS: Add Xen as a maintaining area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1031,6 +1031,24 @@ Documentation:
     labels:
         - "area: Wifi"
 
+Xen Platform:
+    status: maintained
+    maintainers:
+        - povergoing
+    collaborators:
+        - SgrrZhf
+        - lorc
+        - firscity
+        - luca-fancellu
+    files:
+        - include/zephyr/xen/
+        - drivers/xen/
+        - arch/arm64/core/xen/
+        - soc/arm64/xenvm/
+        - boards/arm64/xenvm/
+    labels:
+        - "area: Xen Platform"
+
 Filesystems:
     status: maintained
     maintainers:


### PR DESCRIPTION
As @mbolivar-nordic mentioned here: https://github.com/zephyrproject-rtos/zephyr/pull/40969#issuecomment-1137815756
There is nothing for Xen in MAINTAINERS.
So I volunteer to maintain this area.

@SgrrZhf volunteered to be the collaborator
Would anyone else like to help?