### PR TITLE
dma/cavs_hda: write aligned size to DGMBS register

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/cavs_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs_hda.h
@@ -178,6 +178,7 @@ static inline int cavs_hda_set_buffer(uint32_t base, uint32_t sid,
 
 	*DGBBA(base, sid) = aligned_addr;
 	*DGBS(base, sid) = aligned_size;
+	*DGMBS(base, sid) = aligned_size;
 
 	return 0;
 }


### PR DESCRIPTION
Write aligned size also to DGMBS register. At least SOF with linux
host and cavs25 seems to need this for the dma to trigger.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>