### PR TITLE
net: net_context: Remove double assignment

### DIFF
--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -1039,8 +1039,6 @@ int net_context_connect(struct net_context *context,
 
 		/* FIXME - Add multicast and broadcast address check */
 
-		addr4 = (struct sockaddr_in *)&context->remote;
-
 		memcpy(&addr4->sin_addr, &net_sin(addr)->sin_addr,
 		       sizeof(struct in_addr));
 

--- a/subsys/net/lib/dns/dns_pack.c
+++ b/subsys/net/lib/dns/dns_pack.c
@@ -545,12 +545,10 @@ int dns_unpack_query(struct dns_msg_t *dns_msg, struct net_buf *buf,
 {
 	const uint8_t *end_of_label;
 	uint8_t *dns_query;
-	int remaining_size;
 	int ret;
 	int query_type, query_class;
 
 	dns_query = dns_msg->msg + dns_msg->query_offset;
-	remaining_size = dns_msg->msg_size - dns_msg->query_offset;
 
 	ret = dns_unpack_name(dns_msg->msg, dns_msg->msg_size, dns_query,
 			      buf, &end_of_label);

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -1000,7 +1000,7 @@ static int dns_resolve_cancel_with_hash(struct dns_resolve_context *ctx,
 unlock:
 	k_mutex_unlock(&ctx->lock);
 
-	return 0;
+	return ret;
 }
 
 int dns_resolve_cancel_with_name(struct dns_resolve_context *ctx,


### PR DESCRIPTION
Remove double assignment, the value is stored in initialization.