### PR TITLE
Bluetooth: csis: add RSI advertising callback

### DIFF
--- a/include/zephyr/bluetooth/audio/csis.h
+++ b/include/zephyr/bluetooth/audio/csis.h
@@ -50,6 +50,9 @@ extern "C" {
 /** Size of the Set Identification Resolving Key (SIRK) */
 #define BT_CSIS_SET_SIRK_SIZE 16
 
+/** Size of the Resolvable Set Identifier (RSI) */
+#define BT_CSIS_RSI_SIZE                        6
+
 /* Coordinate Set Identification Service Error codes */
 /** Service is already locked */
 #define BT_CSIS_ERROR_LOCK_DENIED               0x80
@@ -93,6 +96,15 @@ struct bt_csis_cb {
 	 * @return A BT_CSIS_READ_SIRK_REQ_RSP_* response code.
 	 */
 	uint8_t (*sirk_read_req)(struct bt_conn *conn, struct bt_csis *csis);
+
+	/**
+	 * @brief Callback whenever the RSI changes.
+	 *
+	 * If this callback is not set, the stack will handle advertising of the RSI.
+	 *
+	 * @param rsi Pointer to the new 6-octet RSI data to be advertised.
+	 */
+	void (*rsi_changed)(const uint8_t rsi[BT_CSIS_RSI_SIZE]);
 };
 
 /** Register structure for Coordinated Set Identification Service */

--- a/subsys/bluetooth/audio/csis.c
+++ b/subsys/bluetooth/audio/csis.c
@@ -52,8 +52,6 @@
 #define SIRK_READ_PERM	(BT_GATT_PERM_READ_ENCRYPT)
 #endif
 
-static struct bt_csis_cb *csis_cbs;
-
 static struct bt_csis csis_insts[CONFIG_BT_CSIS_MAX_INSTANCE_COUNT];
 static bt_addr_le_t server_dummy_addr; /* 0'ed address */
 
@@ -200,7 +198,7 @@ static int generate_prand(uint32_t *dest)
 	return 0;
 }
 
-static int csis_update_psri(struct bt_csis *csis)
+static int csis_update_rsi(struct bt_csis *csis)
 {
 	int res = 0;
 	uint32_t prand;
@@ -220,12 +218,12 @@ static int csis_update_psri(struct bt_csis *csis)
 
 	res = bt_csis_sih(csis->srv.set_sirk.value, prand, &hash);
 	if (res != 0) {
-		BT_WARN("Could not generate new PSRI");
+		BT_WARN("Could not generate new RSI");
 		return res;
 	}
 
-	(void)memcpy(csis->srv.psri, &hash, BT_CSIS_SIH_HASH_SIZE);
-	(void)memcpy(csis->srv.psri + BT_CSIS_SIH_HASH_SIZE, &prand,
+	(void)memcpy(csis->srv.rsi, &hash, BT_CSIS_SIH_HASH_SIZE);
+	(void)memcpy(csis->srv.rsi + BT_CSIS_SIH_HASH_SIZE, &prand,
 		     BT_CSIS_SIH_PRAND_SIZE);
 	return res;
 }
@@ -240,13 +238,18 @@ int csis_adv_resume(struct bt_csis *csis)
 
 	BT_DBG("Restarting CSIS advertising");
 
-	if (csis_update_psri(csis) != 0) {
+	if (csis_update_rsi(csis) != 0) {
 		return -EAGAIN;
 	}
 
+	if (csis->srv.cb != NULL && csis->srv.cb->rsi_changed != NULL) {
+		csis->srv.cb->rsi_changed(csis->srv.rsi);
+		return 0;
+	}
+
 	ad[1].type = BT_DATA_CSIS_RSI;
-	ad[1].data_len = sizeof(csis->srv.psri);
-	ad[1].data = csis->srv.psri;
+	ad[1].data_len = sizeof(csis->srv.rsi);
+	ad[1].data = csis->srv.rsi;
 
 #if defined(CONFIG_BT_EXT_ADV)
 	struct bt_le_ext_adv_start_param start_param;
@@ -303,11 +306,11 @@ static ssize_t read_set_sirk(struct bt_conn *conn,
 	struct bt_csis_set_sirk *sirk;
 	struct bt_csis *csis = attr->user_data;
 
-	if (csis_cbs != NULL && csis_cbs->sirk_read_req != NULL) {
+	if (csis->srv.cb != NULL && csis->srv.cb->sirk_read_req != NULL) {
 		uint8_t cb_rsp;
 
 		/* Ask higher layer for what SIRK to return, if any */
-		cb_rsp = csis_cbs->sirk_read_req(conn, &csis_insts[0]);
+		cb_rsp = csis->srv.cb->sirk_read_req(conn, &csis_insts[0]);
 
 		if (cb_rsp == BT_CSIS_READ_SIRK_REQ_RSP_ACCEPT) {
 			sirk = &csis->srv.set_sirk;
@@ -330,13 +333,14 @@ static ssize_t read_set_sirk(struct bt_conn *conn,
 			return BT_GATT_ERR(BT_ATT_ERR_AUTHORIZATION);
 		} else if (cb_rsp == BT_CSIS_READ_SIRK_REQ_RSP_OOB_ONLY) {
 			return BT_GATT_ERR(BT_CSIS_ERROR_SIRK_OOB_ONLY);
+		} else {
+			BT_ERR("Invalid callback response: %u", cb_rsp);
+			return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
 		}
-
-		BT_ERR("Invalid callback response: %u", cb_rsp);
-		return BT_GATT_ERR(BT_ATT_ERR_UNLIKELY);
+	} else {
+		sirk = &csis->srv.set_sirk;
 	}
 
-	sirk = &csis->srv.set_sirk;
 
 	BT_DBG("Set sirk %sencrypted",
 	       sirk->type ==  BT_CSIS_SIRK_TYPE_PLAIN ? "not " : "");
@@ -444,10 +448,10 @@ static ssize_t write_set_lock(struct bt_conn *conn,
 		 */
 		notify_clients(csis, conn);
 
-		if (csis_cbs != NULL && csis_cbs->lock_changed != NULL) {
+		if (csis->srv.cb != NULL && csis->srv.cb->lock_changed != NULL) {
 			bool locked = csis->srv.set_lock == BT_CSIS_LOCK_VALUE;
 
-			csis_cbs->lock_changed(conn, csis, locked);
+			csis->srv.cb->lock_changed(conn, csis, locked);
 		}
 	}
 	return len;
@@ -486,10 +490,10 @@ static void set_lock_timer_handler(struct k_work *work)
 	csis->srv.set_lock = BT_CSIS_RELEASE_VALUE;
 	notify_clients(csis, NULL);
 
-	if (csis_cbs != NULL && csis_cbs->lock_changed != NULL) {
+	if (csis->srv.cb != NULL && csis->srv.cb->lock_changed != NULL) {
 		bool locked = csis->srv.set_lock == BT_CSIS_LOCK_VALUE;
 
-		csis_cbs->lock_changed(NULL, csis, locked);
+		csis->srv.cb->lock_changed(NULL, csis, locked);
 	}
 }
 
@@ -574,10 +578,10 @@ static void handle_csis_disconnect(struct bt_csis *csis, struct bt_conn *conn)
 		csis->srv.set_lock = BT_CSIS_RELEASE_VALUE;
 		notify_clients(csis, NULL);
 
-		if (csis_cbs != NULL && csis_cbs->lock_changed != NULL) {
+		if (csis->srv.cb != NULL && csis->srv.cb->lock_changed != NULL) {
 			bool locked = csis->srv.set_lock == BT_CSIS_LOCK_VALUE;
 
-			csis_cbs->lock_changed(conn, csis, locked);
+			csis->srv.cb->lock_changed(conn, csis, locked);
 		}
 	}
 
@@ -899,6 +903,7 @@ int bt_csis_register(const struct bt_csis_register_param *param,
 	inst->srv.set_size = param->set_size;
 	inst->srv.set_lock = BT_CSIS_RELEASE_VALUE;
 	inst->srv.set_sirk.type = BT_CSIS_SIRK_TYPE_PLAIN;
+	inst->srv.cb = param->cb;
 
 	if (IS_ENABLED(CONFIG_BT_CSIS_TEST_SAMPLE_DATA)) {
 		uint8_t test_sirk[] = {
@@ -926,7 +931,7 @@ int bt_csis_register(const struct bt_csis_register_param *param,
 
 int bt_csis_advertise(struct bt_csis *csis, bool enable)
 {
-	int err;
+	int err = 0;
 
 	if (enable) {
 		if (csis->srv.adv_enabled) {
@@ -944,14 +949,16 @@ int bt_csis_advertise(struct bt_csis *csis, bool enable)
 		if (!csis->srv.adv_enabled) {
 			return -EALREADY;
 		}
+		if (csis->srv.cb == NULL || csis->srv.cb->rsi_changed == NULL) {
 #if defined(CONFIG_BT_EXT_ADV)
-		err = bt_le_ext_adv_stop(csis->srv.adv);
+			err = bt_le_ext_adv_stop(csis->srv.adv);
 #else
-		err = bt_le_adv_stop();
+			err = bt_le_adv_stop();
 #endif /* CONFIG_BT_EXT_ADV */
-		if (err != 0) {
-			BT_DBG("Could not stop start adv: %d", err);
-			return err;
+			if (err != 0) {
+				BT_DBG("Could not stop start adv: %d", err);
+				return err;
+			}
 		}
 		csis->srv.adv_enabled = false;
 	}
@@ -974,8 +981,8 @@ int bt_csis_lock(struct bt_csis *csis, bool lock, bool force)
 		csis->srv.set_lock = BT_CSIS_RELEASE_VALUE;
 		notify_clients(csis, NULL);
 
-		if (csis_cbs != NULL && csis_cbs->lock_changed != NULL) {
-			csis_cbs->lock_changed(NULL, &csis_insts[0], false);
+		if (csis->srv.cb != NULL && csis->srv.cb->lock_changed != NULL) {
+			csis->srv.cb->lock_changed(NULL, &csis_insts[0], false);
 		}
 	} else {
 		err = write_set_lock(NULL, NULL, &lock_val, sizeof(lock_val), 0,

--- a/subsys/bluetooth/audio/csis_client.c
+++ b/subsys/bluetooth/audio/csis_client.c
@@ -643,7 +643,7 @@ bool bt_csis_client_is_set_member(uint8_t set_sirk[BT_CSIS_SET_SIRK_SIZE],
 				  struct bt_data *data)
 {
 	if (data->type == BT_DATA_CSIS_RSI &&
-	    data->data_len == BT_CSIS_PSRI_SIZE) {
+	    data->data_len == BT_CSIS_RSI_SIZE) {
 		uint8_t err;
 
 		uint32_t hash = sys_get_le24(data->data);

--- a/subsys/bluetooth/audio/csis_crypto.h
+++ b/subsys/bluetooth/audio/csis_crypto.h
@@ -16,8 +16,8 @@
 /**
  * @brief Private Set Unique identifier hash function sih.
  *
- * The PSRI hash function sih is used to generate a hash value that is
- * used in PSRIs - Used by the Coordinated Set Identification service and
+ * The RSI hash function sih is used to generate a hash value that is
+ * used in RSIs - Used by the Coordinated Set Identification service and
  * profile.
  *
  * @param sirk The 16-byte SIRK

--- a/subsys/bluetooth/audio/csis_internal.h
+++ b/subsys/bluetooth/audio/csis_internal.h
@@ -16,8 +16,6 @@
 #define BT_CSIS_RELEASE_VALUE                   0x01
 #define BT_CSIS_LOCK_VALUE                      0x02
 
-#define BT_CSIS_PSRI_SIZE                       6
-
 struct csis_pending_notifications {
 	bt_addr_le_t addr;
 	bool pending;
@@ -62,10 +60,11 @@ struct bt_csis_client_svc_inst {
 /* TODO: Rename to bt_csis_svc_inst */
 struct bt_csis_server {
 	struct bt_csis_set_sirk set_sirk;
-	uint8_t psri[BT_CSIS_PSRI_SIZE];
+	uint8_t rsi[BT_CSIS_RSI_SIZE];
 	uint8_t set_size;
 	uint8_t set_lock;
 	uint8_t rank;
+	struct bt_csis_cb *cb;
 	bool adv_enabled;
 	struct k_work_delayable set_lock_timer;
 	bt_addr_le_t lock_client_addr;

--- a/subsys/bluetooth/shell/csis.c
+++ b/subsys/bluetooth/shell/csis.c
@@ -132,24 +132,24 @@ static int cmd_csis_advertise(const struct shell *sh, size_t argc,
 	return 0;
 }
 
-static int cmd_csis_update_psri(const struct shell *sh, size_t argc,
+static int cmd_csis_update_rsi(const struct shell *sh, size_t argc,
 				char *argv[])
 {
 	int err;
 
 	if (bt_csis_advertise(csis, false) != 0) {
 		shell_error(sh,
-			    "Failed to stop advertising - psri not updated");
+			    "Failed to stop advertising - rsi not updated");
 		return -ENOEXEC;
 	}
 	err = bt_csis_advertise(csis, true);
 	if (err != 0) {
 		shell_error(sh,
-			    "Failed to start advertising  - psri not updated");
+			    "Failed to start advertising  - rsi not updated");
 		return -ENOEXEC;
 	}
 
-	shell_print(sh, "PSRI and optionally RPA updated");
+	shell_print(sh, "RSI and optionally RPA updated");
 
 	return 0;
 }
@@ -235,11 +235,11 @@ SHELL_STATIC_SUBCMD_SET_CREATE(csis_cmds,
 		      "[size <int>] [rank <int>] [not-lockable] [sirk <data>]",
 		      cmd_csis_register, 1, 4),
 	SHELL_CMD_ARG(advertise, NULL,
-		      "Start/stop advertising CSIS PSRIs <on/off>",
+		      "Start/stop advertising CSIS RSIs <on/off>",
 		      cmd_csis_advertise, 2, 0),
-	SHELL_CMD_ARG(update_psri, NULL,
-		      "Update the advertised PSRI",
-		      cmd_csis_update_psri, 1, 0),
+	SHELL_CMD_ARG(update_rsi, NULL,
+		      "Update the advertised RSI",
+		      cmd_csis_update_rsi, 1, 0),
 	SHELL_CMD_ARG(lock, NULL,
 		      "Lock the set",
 		      cmd_csis_lock, 1, 0),


### PR DESCRIPTION
Makes it possible for an application to
handle CSIS RSI advertising by registering a
callback, which will disable the internal
CSIS advertising.

Also fixes registering callbacks in CSIS.

Signed-off-by: Lars Knudsen <larsgk@gmail.com>