### PR TITLE
ci: Add pull request assigner workflow

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -1,0 +1,34 @@
+name: Pull Request Assigner
+
+on:
+  pull_request_target:
+    branches:
+    - main
+    - v*-branch
+
+jobs:
+  assignment:
+    name: Pull Request Assignment
+    runs-on: ubuntu-20.04
+
+    steps:
+    - name: Install Python dependencies
+      run: |
+        sudo pip3 install -U setuptools wheel pip
+        pip3 install -U PyGithub>=1.55
+
+    - name: Check out source code
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+
+    - name: Run assignment script
+      env:
+        GITHUB_TOKEN: ${{ secrets.ZB_GITHUB_TOKEN }}
+      run: |
+        python3 scripts/set_assignees.py \
+          -v \
+          -o ${{ github.event.repository.owner.login }} \
+          -r ${{ github.event.repository.name }} \
+          -M MAINTAINERS.yml \
+          -P ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This commit adds the "Pull Request Assigner" workflow that
automatically assigns the reviewers, assignee and labels for a pull
request.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>