### PR TITLE
drivers: watchdog: cmsdk_apb: Drop dependency

### DIFF
--- a/drivers/watchdog/Kconfig.cmsdk_apb
+++ b/drivers/watchdog/Kconfig.cmsdk_apb
@@ -5,7 +5,6 @@
 
 config WDOG_CMSDK_APB
 	bool "CMSDK APB Watchdog Driver for ARM family of MCUs"
-	depends on SOC_FAMILY_ARM
 	depends on RUNTIME_NMI
 	help
 	  Enable CMSDK APB Watchdog (WDOG_CMSDK_APB) Driver for ARM


### PR DESCRIPTION
The Kconfig encodes a dependency on SOC_FAMILY_ARM
even though there is no actual dependency.

This is generic ARM IP and can be used in any SoC.

Signed-off-by: Moritz Fischer <moritzf@google.com>