### PR TITLE
drivers: watchdog: remove unused HAS_DTS_WDT Kconfig symbol

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -6,7 +6,6 @@
 
 menuconfig WATCHDOG
 	bool "Watchdog Support"
-	select HAS_DTS_WDT
 	help
 	  Include support for watchdogs.
 

--- a/dts/Kconfig
+++ b/dts/Kconfig
@@ -12,10 +12,3 @@ config HAS_DTS_GPIO
 	help
 	  This option specifies that the target platform supports device tree
 	  configuration for GPIO.
-
-config HAS_DTS_WDT
-	bool
-	depends on HAS_DTS
-	help
-	  This option specifies that the target platform supports device tree
-	  configuration for WDT.


### PR DESCRIPTION
All the watchdog drivers are based on devicetree and we dont utilize
HAS_DTS_WDT anywhere so we can remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>