### PR TITLE
drivers: clock_control: mcux_sim: Remove dead code

### DIFF
--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -57,7 +57,6 @@ static int mcux_sim_get_subsys_rate(const struct device *dev,
 
 #if DT_NODE_HAS_STATUS(DT_INST(0, nxp_kinetis_ke1xf_sim), okay)
 #define NXP_KINETIS_SIM_NODE DT_INST(0, nxp_kinetis_ke1xf_sim)
-#define NXP_KINETIS_SIM_LABEL DT_LABEL(DT_INST(0, nxp_kinetis_ke1xf_sim))
 #if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_ke1xf_sim), clkout_source)
 	#define NXP_KINETIS_SIM_CLKOUT_SOURCE \
 			DT_PROP(DT_INST(0, nxp_kinetis_ke1xf_sim), clkout_source)
@@ -67,7 +66,6 @@ static int mcux_sim_get_subsys_rate(const struct device *dev,
 			DT_PROP(DT_INST(0, nxp_kinetis_ke1xf_sim), clkout_divider)
 #endif
 #else
-#define NXP_KINETIS_SIM_LABEL DT_LABEL(DT_INST(0, nxp_kinetis_sim))
 #define NXP_KINETIS_SIM_NODE DT_INST(0, nxp_kinetis_sim)
 #if DT_NODE_HAS_PROP(DT_INST(0, nxp_kinetis_sim), clkout_source)
 	#define NXP_KINETIS_SIM_CLKOUT_SOURCE \


### PR DESCRIPTION
The define NXP_KINETIS_SIM_LABEL is not used so lets remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>