### PR TITLE
doc: getting_started: add missing python3-venv installation

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -234,6 +234,12 @@ reason it is suggested to use `Python virtual environments`_.
 
          .. group-tab:: Install within virtual environment
 
+            #. Use ``apt`` to install Python ``venv`` package:
+
+               .. code-block:: bash
+
+                  sudo apt install python3-venv
+
             #. Create a new virtual environment:
 
                .. code-block:: bash


### PR DESCRIPTION
The venv package is not installed by default on Ubuntu, however, it is
required to follow the virtual environment installation path.

Fixes #46363