### PR TITLE
toolchain: common: Extending macro set for memory sections

### DIFF
--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -244,6 +244,33 @@
 	     iterator++)
 
 /**
+ * @brief Get element from section.
+ *
+ * @note There is no protection against reading beyond the section.
+ *
+ * @param[in]  struct_type Struct type.
+ * @param[in]  i Index.
+ * @param[out] dst Pointer to location where pointer to element is written.
+ */
+#define STRUCT_SECTION_GET(struct_type, i, dst) do { \
+	extern struct struct_type _CONCAT(_##struct_type, _list_start)[]; \
+	*(dst) = &_CONCAT(_##struct_type, _list_start)[i]; \
+} while (0)
+
+/**
+ * @brief Count elements in a section.
+ *
+ * @param[in]  struct_type Struct type
+ * @param[out] dst Pointer to location where result is written.
+ */
+#define STRUCT_SECTION_COUNT(struct_type, dst) do { \
+	extern struct struct_type _CONCAT(_##struct_type, _list_start)[]; \
+	extern struct struct_type _CONCAT(_##struct_type, _list_end)[]; \
+	*(dst) = ((uintptr_t)_CONCAT(_##struct_type, _list_end) - \
+		  (uintptr_t)_CONCAT(_##struct_type, _list_start)) / sizeof(struct struct_type); \
+} while (0)
+
+/**
  * @}
  */ /* end of struct_section_apis */
 


### PR DESCRIPTION
Added macro for getting nth element from section.
Added macro for counting elements in the section.

Extracted from #43797.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>