### PR TITLE
Bluetooth: controller: llcp: pause data during PHY update procedure

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -8166,3 +8166,8 @@ uint8_t ull_conn_lll_phy_active(struct ll_conn *conn, uint8_t phys)
 }
 
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
+
+uint8_t ull_is_lll_tx_queue_empty(struct ll_conn *conn)
+{
+	return (memq_peek(conn->lll.memq_tx.head, conn->lll.memq_tx.tail, NULL) == NULL);
+}

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -125,3 +125,8 @@ void ull_conn_pause_rx_data(struct ll_conn *conn);
 void ull_conn_resume_rx_data(struct ll_conn *conn);
 
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
+
+/**
+ * @brief Check if the lower linked layer transmit queue is empty
+ */
+uint8_t ull_is_lll_tx_queue_empty(struct ll_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn_internal.h
@@ -127,6 +127,6 @@ void ull_conn_resume_rx_data(struct ll_conn *conn);
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 /**
- * @brief Check if the lower linked layer transmit queue is empty
+ * @brief Check if the lower link layer transmit queue is empty
  */
 uint8_t ull_is_lll_tx_queue_empty(struct ll_conn *conn);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -569,7 +569,7 @@ static void lp_pu_st_wait_tx_ack_phy_req(struct ll_conn *conn, struct proc_ctx *
 			/* Unknown role */
 			LL_ASSERT(0);
 		}
-		llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
+
 		break;
 	default:
 		/* Ignore other evts */
@@ -653,6 +653,7 @@ static void lp_pu_st_wait_rx_phy_update_ind(struct ll_conn *conn, struct proc_ct
 			ctx->data.pu.ntf_pu = ctx->data.pu.host_initiated;
 			lp_pu_complete(conn, ctx, evt, param);
 		}
+		llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
 		break;
 	case LP_PU_EVT_REJECT:
 		llcp_rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
@@ -660,6 +661,7 @@ static void lp_pu_st_wait_rx_phy_update_ind(struct ll_conn *conn, struct proc_ct
 		ctx->data.pu.error = ctx->reject_ext_ind.error_code;
 		ctx->data.pu.ntf_pu = 1;
 		lp_pu_complete(conn, ctx, evt, param);
+		llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
 	default:
 		/* Ignore other evts */
 		break;
@@ -887,7 +889,8 @@ static void rp_pu_send_phy_update_ind(struct ll_conn *conn, struct proc_ctx *ctx
 				      void *param)
 {
 	if (llcp_rr_ispaused(conn) || !llcp_tx_alloc_peek(conn, ctx) ||
-	(llcp_rr_get_paused_cmd(conn) == PROC_PHY_UPDATE)) {
+	(llcp_rr_get_paused_cmd(conn) == PROC_PHY_UPDATE) ||
+	    !ull_is_lll_tx_queue_empty(conn)) {
 		ctx->state = RP_PU_STATE_WAIT_TX_PHY_UPDATE_IND;
 	} else {
 		llcp_rr_set_paused_cmd(conn, PROC_CTE_REQ);
@@ -933,6 +936,7 @@ static void rp_pu_st_wait_rx_phy_req(struct ll_conn *conn, struct proc_ctx *ctx,
 	/* Combine with the 'Preferred' the phys in conn->phy_pref_?x */
 	pu_combine_phys(conn, ctx, conn->phy_pref_tx, conn->phy_pref_rx);
 	llcp_tx_pause_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
+
 	switch (evt) {
 	case RP_PU_EVT_PHY_REQ:
 		switch (conn->lll.role) {

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -563,6 +563,7 @@ static void lp_pu_st_wait_tx_ack_phy_req(struct ll_conn *conn, struct proc_ctx *
 				conn, pu_select_phy_timing_restrict(conn, ctx->data.pu.tx));
 			ctx->state = LP_PU_STATE_WAIT_RX_PHY_UPDATE_IND;
 			ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND;
+			llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
 			break;
 #endif /* CONFIG_BT_PERIPHERAL */
 		default:

--- a/tests/bluetooth/controller/ctrl_collision/src/main.c
+++ b/tests/bluetooth/controller/ctrl_collision/src/main.c
@@ -198,14 +198,14 @@ void test_phy_update_central_loc_collision(void)
 	/* TX Ack */
 	event_tx_ack(&conn, tx);
 
-	/* Check that data tx is not paused */
-	zassert_equal(conn.tx_q.pause_data, 0U, "Data tx is paused");
+	/* Check that data tx is paused */
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is paused");
 
 	/* Done */
 	event_done(&conn);
 
 	/* Check that data tx is not paused */
-	zassert_equal(conn.tx_q.pause_data, 0U, "Data tx is paused");
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is not paused");
 
 	/* Release Tx */
 	ull_cp_release_tx(&conn, tx);

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -730,13 +730,13 @@ void test_phy_update_central_loc_collision(void)
 	event_tx_ack(&conn, tx);
 
 	/* Check that data tx is not paused */
-	zassert_equal(conn.tx_q.pause_data, 0U, "Data tx is paused");
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is not paused");
 
 	/* Done */
 	event_done(&conn);
 
 	/* Check that data tx is not paused */
-	zassert_equal(conn.tx_q.pause_data, 0U, "Data tx is paused");
+	zassert_equal(conn.tx_q.pause_data, 1U, "Data tx is not paused");
 
 	/* Release Tx */
 	ull_cp_release_tx(&conn, tx);


### PR DESCRIPTION
This PR fixes the PHY update procedures for conformance tests when
being a Central by pausing data transmission during the PHY update 
procedure
    
To be more precise, following tests are fixed:
    LL/CON/CEN/BV-49-C
    LL/CON/CEN/BV-50-C
    LL/CON/CEN/BV-53-C
    LL/CON/CEN/BV-54-C

Unittests are also updated
    

The 3rd commit avoids regression errors on the Peripheral PHY tests:

LL/CON/PER/BV-49-C
LL/CON/PER/BV-50-C
LL/CON/PER/BV-52-C
LL/CON/PER/BV-53-C
LL/CON/PER/BV-54-C
LL/CON/PER/BV-55-C
LL/CON/PER/BV-56-C
LL/CON/PER/BV-58-C

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>

