### PR TITLE
Bluetooth: Shell: Set `ctx_shell` in `cmd_connections`

### DIFF
--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -2655,6 +2655,7 @@ static int cmd_connections(const struct shell *sh, size_t argc, char *argv[])
 	int conn_count = 0;
 
 	shell_print(sh, "Connected devices:");
+	ctx_shell = sh;
 	bt_conn_foreach(BT_CONN_TYPE_ALL, connection_info, &conn_count);
 	shell_print(sh, "Total %d", conn_count);
 


### PR DESCRIPTION
When using `CONFIG_BT_SHELL` with an application that takes care of
calling `bt_init`, it should not be neccessary to enter `bt init` on the
shell. (Especially since `bt init` will print an error in that case.)

However `bt connections` was relying on `bt init` to have been entered
first and set the global `ctx_shell`, and would cause undefined
behavior otherwise.

`ctx_shell` is a global variable used to pass the `sh` local variable to
callbacks to avoid threading the `sh` variable trough user-data-fields.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>