### PR TITLE
mgmt/mcumgr/lib: Remove flash_area_open_ex

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/zephyr_img_mgmt.c
@@ -27,22 +27,6 @@ BUILD_ASSERT(CONFIG_IMG_MGMT_UPDATABLE_IMAGE_NUMBER == 1 ||
 	      FLASH_AREA_LABEL_EXISTS(image_3)),
 	     "Missing partitions?");
 
-static int flash_area_open_ex(uint8_t id, const struct flash_area **fa)
-{
-	const struct flash_area *lfa;
-	int rc = flash_area_open(id, &lfa);
-
-	if (rc == 0) {
-		if (flash_area_get_device(lfa) != NULL) {
-			*fa = lfa;
-		} else {
-			rc = -ENODEV;
-		}
-	}
-
-	return rc;
-}
-
 static int
 zephyr_img_mgmt_slot_to_image(int slot)
 {
@@ -76,7 +60,7 @@ zephyr_img_mgmt_flash_check_empty(uint8_t fa_id, bool *out_empty)
 	uint8_t erased_val;
 	uint32_t erased_val_32;
 
-	rc = flash_area_open_ex(fa_id, &fa);
+	rc = flash_area_open(fa_id, &fa);
 	if (rc != 0) {
 		return MGMT_ERR_EUNKNOWN;
 	}
@@ -319,7 +303,7 @@ img_mgmt_impl_read(int slot, unsigned int offset, void *dst,
 		return MGMT_ERR_EUNKNOWN;
 	}
 
-	rc = flash_area_open_ex(area_id, &fa);
+	rc = flash_area_open(area_id, &fa);
 	if (rc != 0) {
 		return MGMT_ERR_EUNKNOWN;
 	}
@@ -425,7 +409,7 @@ img_mgmt_impl_erase_image_data(unsigned int off, unsigned int num_bytes)
 		goto end;
 	}
 
-	rc = flash_area_open_ex(g_img_mgmt_state.area_id, &fa);
+	rc = flash_area_open(g_img_mgmt_state.area_id, &fa);
 	if (rc != 0) {
 		LOG_ERR("Can't bind to the flash area (err %d)", rc);
 		rc = MGMT_ERR_EUNKNOWN;
@@ -593,7 +577,7 @@ img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 
 #if defined(CONFIG_IMG_MGMT_REJECT_DIRECT_XIP_MISMATCHED_SLOT)
 		if (hdr->ih_flags & IMAGE_F_ROM_FIXED_ADDR) {
-			rc = flash_area_open_ex(action->area_id, &fa);
+			rc = flash_area_open(action->area_id, &fa);
 			if (rc) {
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(action,
 					img_mgmt_err_str_flash_open_failed);
@@ -670,7 +654,7 @@ img_mgmt_impl_erased_val(int slot, uint8_t *erased_val)
 		return MGMT_ERR_EUNKNOWN;
 	}
 
-	rc = flash_area_open_ex(area_id, &fa);
+	rc = flash_area_open(area_id, &fa);
 	if (rc != 0) {
 		return MGMT_ERR_EUNKNOWN;
 	}


### PR DESCRIPTION
The function is no longer neede with fix provided by commit
aa5d20aaef (storage/flash_map: Return -ENODEV from flash_area_open).

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>