### PR TITLE
lib: os: cbprintf: fix cbprintf_enums include path 

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -225,7 +225,7 @@ BUILD_ASSERT(Z_IS_POW2(CBPRINTF_PACKAGE_ALIGNMENT));
 
 /**@} */
 
-#include <sys/cbprintf_enums.h>
+#include <zephyr/sys/cbprintf_enums.h>
 
 /** @brief Signature for a cbprintf callback function.
  *


### PR DESCRIPTION
Corrects `cbprintf_enums.h` include path to contain `<zephyr/...>` prefix.

That allows building with `CONFIG_LEGACY_INCLUDE_PATH=n`.

Fixes #46383