### PR TITLE
net: tcp: Acknowledge FIN packets in TIMED_WAIT state

### DIFF
--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -357,7 +357,7 @@ endif # NET_TCP
 config NET_TCP_TIME_WAIT_DELAY
 	int "How long to wait in TIME_WAIT state (in milliseconds)"
 	depends on NET_TCP
-	default 250
+	default 1500
 	help
 	  To avoid a (low-probability) issue when delayed packets from
 	  previous connection get delivered to next connection reusing
@@ -371,7 +371,7 @@ config NET_TCP_TIME_WAIT_DELAY
 	  DoS attacks). At the same time, the issue of packet misdelivery
 	  is largely alleviated in the modern TCP stacks by using random,
 	  non-repeating port numbers and initial sequence numbers. Due
-	  to this, Zephyr uses much lower value of 250ms by default.
+	  to this, Zephyr uses much lower value of 1500ms by default.
 	  Value of 0 disables TIME_WAIT state completely.
 
 config NET_TCP_ACK_TIMEOUT

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2185,6 +2185,14 @@ next_state:
 		}
 		break;
 	case TCP_TIME_WAIT:
+		/* Acknowledge any FIN attempts, in case retransmission took
+		 * place.
+		 */
+		if (th && (FL(&fl, ==, (FIN | ACK), th_seq(th) + 1 == conn->ack) ||
+			   FL(&fl, ==, FIN, th_seq(th) + 1 == conn->ack))) {
+			tcp_out(conn, ACK);
+		}
+
 		k_work_reschedule_for_queue(
 			&tcp_work_q, &conn->timewait_timer,
 			K_MSEC(CONFIG_NET_TCP_TIME_WAIT_DELAY));


### PR DESCRIPTION
In case TCP stack enters TIMED_WAIT state (after receiving FIN/ACK reply
from peer), it should stil be ready to reply with ACK for any
consecutive FIN attempts. Othewise, in case the final ACK from Zephyr
side is lost, the connection is not properly closed on the other end,
and peer keeps retransmitting the final FIN packet.

Additinally, increase the default value of `NET_TCP_TIME_WAIT_DELAY`,
 so that the TCP stack has better chance to actually catch  FIN retransmission 
in that state.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>