### PR TITLE
RFC: Reserve MGMT_ERR_EBUSY error code and propose OS reset code extension

### DIFF
--- a/doc/services/device_mgmt/smp_groups/smp_group_0.rst
+++ b/doc/services/device_mgmt/smp_groups/smp_group_0.rst
@@ -431,7 +431,25 @@ System reset request header fields:
     | ``2``  | ``0``        |  ``5``         |
     +--------+--------------+----------------+
 
-The command sends empty CBOR map as data.
+Normally the command sends empty CBOR map as data, but if previous
+reset attempt has been responded with "rc" code equal ``10`` (busy),
+then following map may be send to force the reset:
+
+.. code-block:: none
+
+    {
+        (opt)"force"       : (int)
+    }
+
+where:
+
+.. table::
+    :align: center
+
+    +-----------------------+---------------------------------------------------+
+    | "force"               | Force reset if value > 0, optional if 0.          |
+    +-----------------------+---------------------------------------------------+
+
 
 System reset response
 =====================

--- a/doc/services/device_mgmt/smp_protocol.rst
+++ b/doc/services/device_mgmt/smp_protocol.rst
@@ -240,6 +240,10 @@ Status/error codes in responses
     +---------------+-----------------------------------------------+
     | ``9``         | Corrupted payload received.                   |
     +---------------+-----------------------------------------------+
+    | ``10``        | Device is busy with processing previous SMP   |
+    |               | request and may not process incoming one.     |
+    |               | Client should re-try later.                   |
+    +---------------+-----------------------------------------------+
     | ``256``       | This is base error number of user defined     |
     |               | error codes.                                  |
     +---------------+-----------------------------------------------+

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -52,6 +52,7 @@ extern "C" {
 #define MGMT_ERR_EMSGSIZE	7	/* Response too large. */
 #define MGMT_ERR_ENOTSUP	8	/* Command not supported. */
 #define MGMT_ERR_ECORRUPT	9	/* Corrupt */
+#define MGMT_ERR_EBUSY		10	/* Command blocked by processing of other command */
 #define MGMT_ERR_EPERUSER	256
 
 #define MGMT_HDR_SIZE		8

--- a/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/mgmt/include/mgmt/mgmt.h
@@ -48,10 +48,10 @@ extern "C" {
 #define MGMT_ERR_EINVAL		3
 #define MGMT_ERR_ETIMEOUT	4
 #define MGMT_ERR_ENOENT		5
-#define MGMT_ERR_EBADSTATE	6	   /* Current state disallows command. */
-#define MGMT_ERR_EMSGSIZE	7	   /* Response too large. */
-#define MGMT_ERR_ENOTSUP	8	   /* Command not supported. */
-#define MGMT_ERR_ECORRUPT	9	   /* Corrupt */
+#define MGMT_ERR_EBADSTATE	6	/* Current state disallows command. */
+#define MGMT_ERR_EMSGSIZE	7	/* Response too large. */
+#define MGMT_ERR_ENOTSUP	8	/* Command not supported. */
+#define MGMT_ERR_ECORRUPT	9	/* Corrupt */
 #define MGMT_ERR_EPERUSER	256
 
 #define MGMT_HDR_SIZE		8
@@ -65,7 +65,7 @@ extern "C" {
 
 struct mgmt_hdr {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-	uint8_t  nh_op:3;		   /* MGMT_OP_[...] */
+	uint8_t  nh_op:3;		/* MGMT_OP_[...] */
 	uint8_t  _res1:5;
 #endif
 #if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__


### PR DESCRIPTION
The PR consists of three commits:

 0) Correct some tabs/spaces (not really important stuff, but annoying);
 1) Reserves MGMT_ERR_EBUSY (10) error code and provides documentation for new code;
 2) Extends OS reset command specification with optional support for returning the busy code and option to force reset.