### PR TITLE
ci: assigner: Skip assignment for draft pull requests

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -2,6 +2,11 @@ name: Pull Request Assigner
 
 on:
   pull_request_target:
+    types:
+    - opened
+    - synchronize
+    - reopened
+    - ready_for_review
     branches:
     - main
     - v*-branch
@@ -9,6 +14,7 @@ on:
 jobs:
   assignment:
     name: Pull Request Assignment
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
This commit updates the pull request assigner workflow to skip the
reviewers, assignee and labels assignment for the pull requests that
are marked as draft.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>