### PR TITLE
Bluetooth: audio: Improve audio context capabilities handling

### DIFF
--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -276,6 +276,14 @@ int bt_audio_capability_set_location(enum bt_audio_dir dir,
 int bt_audio_capability_set_available_contexts(enum bt_audio_dir dir,
 					       enum bt_audio_context contexts);
 
+/** @brief Get the available contexts for an endpoint type
+ *
+ * @param dir      Direction of the endpoints to get contexts for.
+ *
+ * @return Bitmask of available contexts.
+ */
+enum bt_audio_context bt_audio_capability_get_available_contexts(enum bt_audio_dir dir);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -270,7 +270,7 @@ int bt_audio_capability_set_location(enum bt_audio_dir dir,
 
 /** @brief Set the available contexts for an endpoint type
  *
- * @param dir      Direction of the endpoints to change location for.
+ * @param dir      Direction of the endpoints to change available contexts for.
  * @param contexts The contexts to be set.
  */
 int bt_audio_capability_set_available_contexts(enum bt_audio_dir dir,

--- a/subsys/bluetooth/audio/capabilities.c
+++ b/subsys/bluetooth/audio/capabilities.c
@@ -470,7 +470,15 @@ int bt_audio_capability_set_location(enum bt_audio_dir dir,
 static int set_available_contexts(enum bt_audio_dir dir,
 				  enum bt_audio_context contexts)
 {
+	enum bt_audio_context supported;
+
 	IF_ENABLED(CONFIG_BT_PAC_SNK, (
+		supported = CONFIG_BT_PACS_SNK_CONTEXT;
+
+		if (contexts & ~supported) {
+			return -ENOTSUP;
+		}
+
 		if (dir == BT_AUDIO_DIR_SINK) {
 			sink_available_contexts = contexts;
 			return 0;
@@ -478,11 +486,19 @@ static int set_available_contexts(enum bt_audio_dir dir,
 	));
 
 	IF_ENABLED(CONFIG_BT_PAC_SRC, (
+		supported = CONFIG_BT_PACS_SRC_CONTEXT;
+
+		if (contexts & ~supported) {
+			return -ENOTSUP;
+		}
+
 		if (dir == BT_AUDIO_DIR_SOURCE) {
 			source_available_contexts = contexts;
 			return 0;
 		}
 	));
+
+	ARG_UNUSED(supported);
 
 	BT_ERR("Invalid endpoint dir: %u", dir);
 


### PR DESCRIPTION
This adds getter method for currently available contexts and disallows user to set unsupported context as available