### PR TITLE
drivers: disk: Remove use of unused devicetree "label" property

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -200,7 +200,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -118,7 +118,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -189,7 +189,6 @@ zephyr_udc0: &usb1 {
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };
 

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -180,6 +180,5 @@ zephyr_udc0: &usb1 {
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -270,7 +270,6 @@ zephyr_udc0: &usb1 {
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };
 

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -229,7 +229,6 @@ zephyr_udc0: &usb1 {
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };
 

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -296,7 +296,6 @@ zephyr_udc0: &usb1 {
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };
 

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -163,7 +163,6 @@
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };
 

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -416,7 +416,6 @@ i2s1: &flexcomm3 {
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 	pinctrl-0 = <&pinmux_usdhc>;
 	pinctrl-names = "default";

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -187,7 +187,6 @@
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };
 

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -133,7 +133,6 @@ uext_serial: &usart1 {};
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/arm/teensy4/teensy41.dts
+++ b/boards/arm/teensy4/teensy41.dts
@@ -36,6 +36,5 @@
 	mmc {
 		compatible = "zephyr,sdmmc-disk";
 		status = "okay";
-		label = "SDMMC_0";
 	};
 };

--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -113,7 +113,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -45,7 +45,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/shields/v2c_daplink/v2c_daplink.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink.overlay
@@ -44,7 +44,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
@@ -35,7 +35,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
+++ b/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
@@ -18,7 +18,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/doc/services/storage/disk/access.rst
+++ b/doc/services/storage/disk/access.rst
@@ -54,7 +54,6 @@ at 24 MHz once the SD card has been initialized:
 		    mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		    };
                     spi-max-frequency = <24000000>;
             };


### PR DESCRIPTION
We should avoid use of the label property in devicetrees.  The
'zephyr,sdmmc-disk' compatible node has a 'label' property set
but there isn't any code utilizing this so removing the property
from any devicetrees that have it set (as well as example in docs).

Signed-off-by: Kumar Gala <galak@kernel.org>