### PR TITLE
led_strip: ws2812: Remove dead code

### DIFF
--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -208,7 +208,6 @@ static const uint8_t ws2812_gpio_##idx##_color_mapping[] =		\
  *
  * TODO: try to make this portable, or at least port to more devices.
  */
-#define WS2812_GPIO_CLK(idx) DT_LABEL(DT_INST(0, nordic_nrf_clock))
 
 #define WS2812_GPIO_DEVICE(idx)					\
 									\


### PR DESCRIPTION
Remove unused WS2812_GPIO_CLK macro that references DT_LABEL.  The
WS2812_GPIO_CLK macro isn't used anywhere so remove it since we
want to minimal DT_LABEL references in drivers.

Signed-off-by: Kumar Gala <galak@kernel.org>