### PR TITLE
requirements: bump pyelftools to >=0.27

### DIFF
--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -4,7 +4,7 @@
 # part of the recommended workflow
 
 # used by various build scripts
-pyelftools>=0.26
+pyelftools>=0.27
 
 # used by dts generation to parse binding YAMLs, also used by
 # twister to parse YAMLs, by west, zephyr_module,...


### PR DESCRIPTION
The minimum version of pyelftools is 0.27 to make it working
with databse_gen.py
