### PR TITLE
pinctrl: psl: npcx: use pinctrl mechanism to confiigure PSL device

### DIFF
--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -691,6 +691,12 @@
 			label = "I2C_7_PORT_0";
 			status = "disabled";
 		};
+
+		power_ctrl_psl: power-ctrl-psl {
+			compatible = "nuvoton,npcx-power-psl";
+			label = "POWER_CONTROL_PSL";
+			status = "disabled";
+		};
 	};
 
 	soc-id {

--- a/dts/arm/nuvoton/npcx/npcx7/npcx7-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx7/npcx7-pinctrl.dtsi
@@ -342,18 +342,26 @@
 	/* PSL peripheral interfaces. */
 	/omit-if-no-ref/ psl_in1_gpd2: periph-psl-in1 {
 		pinmux = <&altd_npsl_in1_sl>;
+		psl-offset = <0>;
+		psl-polarity = <&altd_psl_in1_ahi>;
 	};
 
 	/omit-if-no-ref/ psl_in2_gp00: periph-psl-in2 {
 		pinmux = <&altd_npsl_in2_sl>;
+		psl-offset = <1>;
+		psl-polarity = <&altd_psl_in2_ahi>;
 	};
 
 	/omit-if-no-ref/ psl_in3_gp01: periph-psl-in3 {
 		pinmux = <&altd_psl_in3_sl>;
+		psl-offset = <2>;
+		psl-polarity = <&altd_psl_in3_ahi>;
 	};
 
 	/omit-if-no-ref/ psl_in4_gp02: periph-psl-in4 {
 		pinmux = <&altd_psl_in4_sl>;
+		psl-offset = <3>;
+		psl-polarity = <&altd_psl_in4_ahi>;
 	};
 
 	/* UART peripheral interfaces */

--- a/dts/arm/nuvoton/npcx/npcx9/npcx9-pinctrl.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx9/npcx9-pinctrl.dtsi
@@ -350,18 +350,26 @@
 	/* PSL peripheral interfaces */
 	/omit-if-no-ref/ psl_in1_gpd2: periph-psl-in1 {
 		pinmux = <&altd_npsl_in1_sl>;
+		psl-offset = <0>;
+		psl-polarity = <&altd_psl_in1_ahi>;
 	};
 
 	/omit-if-no-ref/ psl_in2_gp00: periph-psl-in2 {
 		pinmux = <&altd_npsl_in2_sl>;
+		psl-offset = <1>;
+		psl-polarity = <&altd_psl_in2_ahi>;
 	};
 
 	/omit-if-no-ref/ psl_in3_gp01: periph-psl-in3 {
 		pinmux = <&altd_psl_in3_sl>;
+		psl-offset = <2>;
+		psl-polarity = <&altd_psl_in3_ahi>;
 	};
 
 	/omit-if-no-ref/ psl_in4_gp02: periph-psl-in4 {
 		pinmux = <&altd_psl_in4_sl>;
+		psl-offset = <3>;
+		psl-polarity = <&altd_psl_in4_ahi>;
 	};
 
 	/omit-if-no-ref/ psl_gpo_gpd7: periph-psl-gpo {

--- a/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nuvoton,npcx-pinctrl.yaml
@@ -14,6 +14,8 @@ description: |
   Custom pin properties for npcx series are available also:
     - pinmux-locked: Lock pinmux configuration for peripheral device
     - pinmux-gpio: Inverse pinmux back to gpio
+    - psl-in-mode: Select the assertion detection mode of PSL input
+    - psl-in-pol: Select the assertion detection polarity of PSL input
 
   An example for NPCX7 family, include the chip level pinctrl DTSI file in the
   board level DTS:
@@ -61,6 +63,17 @@ child-binding:
         description: |
           A map to PUPD_ENn register/bit that enable pull-up/down of NPCX peripheral devices.
           Please don't overwrite this property in the board-level DT driver.
+      psl-offset:
+        type: int
+        description: |
+          Offset to PSL_CTS register that is used for PSL input's status and detection mode.
+          Please don't overwrite this property in the board-level DT driver.
+      psl-polarity:
+        type: phandle
+        required: false
+        description: |
+          A map to DEVALTn that configures detection polarity of PSL input pads.
+          Please don't overwrite this property in the board-level DT driver.
       pinmux-locked:
         required: false
         type: boolean
@@ -69,3 +82,23 @@ child-binding:
         required: false
         type: boolean
         description: Inverse pinmux selection to GPIO
+      psl-in-mode:
+        type: string
+        required: false
+        description: |
+          The assertion detection mode of PSL input selection
+          - "level": Select the detection mode to level detection
+          - "edge": Select the detection mode to edge detection
+        enum:
+          - "level"
+          - "edge"
+      psl-in-pol:
+        type: string
+        required: false
+        description: |
+          The assertion detection polarity of PSL input selection
+          - "low-falling": Select the detection polarity to low/falling
+          - "high-rising": Select the detection polarity to high/rising
+        enum:
+          - "low-falling"
+          - "high-rising"

--- a/dts/bindings/power/nuvoton,npcx-power-psl.yaml
+++ b/dts/bindings/power/nuvoton,npcx-power-psl.yaml
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Nuvoton Technology Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Nuvoton, NPCX Power Switch Logic (PSL) control node
+
+compatible: "nuvoton,npcx-power-psl"
+
+include: [base.yaml, pinctrl-device.yaml]
+
+properties:
+  enable-gpios:
+    type: phandle-array
+    required: true
+    description: |
+      GPIO to used to turn on/off the Core Domain power supply (VCC1) of NPCX
+      embedded controller (EC)
+  pinctrl-0:
+    required: true
+  pinctrl-names:
+    required: true

--- a/soc/arm/nuvoton_npcx/common/reg/reg_def.h
+++ b/soc/arm/nuvoton_npcx/common/reg/reg_def.h
@@ -280,6 +280,12 @@ struct glue_reg {
 	volatile uint8_t PSL_CTS;
 };
 
+/* GLUE register fields */
+/* PSL input detection mode is configured by bits 7:4 of PSL_CTS */
+#define NPCX_PSL_CTS_MODE_BIT(bit) BIT(bit + 4)
+/* PSL input assertion events are reported by bits 3:0 of PSL_CTS */
+#define NPCX_PSL_CTS_EVENT_BIT(bit) BIT(bit)
+
 /*
  * Universal Asynchronous Receiver-Transmitter (UART) device registers
  */

--- a/soc/arm/nuvoton_npcx/common/scfg.c
+++ b/soc/arm/nuvoton_npcx/common/scfg.c
@@ -52,11 +52,6 @@ static const struct npcx_scfg_config npcx_scfg_cfg = {
 
 #define HAL_GLUE_INST() (struct glue_reg *)(npcx_scfg_cfg.base_glue)
 
-/* PSL input detection mode is configured by bits 7:4 of PSL_CTS */
-#define NPCX_PSL_CTS_MODE_BIT(bit) BIT(bit + 4)
-/* PSL input assertion events are reported by bits 3:0 of PSL_CTS */
-#define NPCX_PSL_CTS_EVENT_BIT(bit) BIT(bit)
-
 /* Pin-control local functions */
 static void npcx_pinctrl_alt_sel(const struct npcx_alt *alt, int alt_func)
 {

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -700,4 +700,20 @@
 #define NPCX_BOOTER_IS_HIF_TYPE_SET() \
 	DT_PROP(DT_PATH(booter_variant), hif_type_auto)
 
+/**
+ * @brief Helper macro to get address of system configuration module which is
+ * used by serval peripheral device drivers in npcx series.
+ *
+ * @return base address of system configuration module.
+ */
+#define NPCX_SCFG_REG_ADDR DT_REG_ADDR_BY_NAME(DT_NODELABEL(scfg), scfg)
+
+/**
+ * @brief Helper macro to get address of system glue module which is
+ * used by serval peripheral device drivers in npcx series.
+ *
+ * @return base address of system glue module.
+ */
+#define NPCX_GLUE_REG_ADDR DT_REG_ADDR_BY_NAME(DT_NODELABEL(scfg), glue)
+
 #endif /* _NUVOTON_NPCX_SOC_DT_H_ */


### PR DESCRIPTION
This PR is an attempt to use the pinctrl mechanism to configure PSL module that aims to ultra-low power consumption in the Nuvoton npcx series. The first commit includes:
1. Add two enum properties for PSL input detection mode.
    - ```psl-in-mode```
    - ```psl-in-pol```
2. Add macro functions to get PSL input detection configuration and pin-muxing
   configurations from ```pinmux```, ```psl-offset``` abd ```psl-polarity``` properties.

Here is an example to configure the detection mode and polarity of PSL_IN2.
```
/* A falling edge detection type for PSL_IN2 */
&psl_in2_gp00 {
	psl-in-mode = "edge";
	psl-in-pol = "low-falling";
};
```
Then, the second commit introduces a power control device that contains PSL pinctrl configurations only.

[CL3697271](https://chromium-review.googlesource.com/c/chromiumos/platform/ec/+/3697271) is an example to use pinctrl mechanism to configure PSL module in the drivers of downstream repo. And [CL 3698178](https://chromium-review.googlesource.com/c/chromiumos/platform/ec/+/3698178) that demonstrates how to use PSL input pads for minimal power consumption in board DT file.

By this PR, we can clean up the unused soc drivers and DT nodes for PSL later.