### PR TITLE
drivers: gsm_ppp: Don't lock commands if they are never unlocked

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -1164,10 +1164,9 @@ void gsm_ppp_stop(const struct device *dev)
 		if (gsm->ppp_dev) {
 			uart_mux_disable(gsm->ppp_dev);
 		}
-	}
-
-	if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler, GSM_CMD_LOCK_TIMEOUT)) {
-		LOG_WRN("Failed locking modem cmds!");
+		if (modem_cmd_handler_tx_lock(&gsm->context.cmd_handler, GSM_CMD_LOCK_TIMEOUT)) {
+			LOG_WRN("Failed locking modem cmds!");
+		}
 	}
 
 	if (gsm->modem_off_cb) {


### PR DESCRIPTION
Modem commands in gsm_ppp are never unlocked if CONFIG_GSM_MUX=n,
which means they can be locked only once due to initial semaphore
count. If gsm_ppp is enabled more than once, this results with
`GSM_CMD_LOCK_TIMEOUT` wait on every next gsm_ppp_stop call
when muxing is disabled.