### PR TITLE
drivers: eeprom: Fix format strings

### DIFF
--- a/drivers/eeprom/eeprom_shell.c
+++ b/drivers/eeprom/eeprom_shell.c
@@ -48,7 +48,7 @@ static int cmd_read(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Reading %d bytes from EEPROM, offset %d...", len,
+	shell_print(shell, "Reading %zu bytes from EEPROM, offset %zu...", len,
 		    addr);
 
 	for (upto = 0; upto < len; upto += pending) {
@@ -84,7 +84,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 	len = argc - args_indx.data;
 
 	if (len > sizeof(wr_buf)) {
-		shell_error(shell, "Write buffer size (%d bytes) exceeded",
+		shell_error(shell, "Write buffer size (%zu bytes) exceeded",
 			    sizeof(wr_buf));
 		return -EINVAL;
 	}
@@ -104,7 +104,7 @@ static int cmd_write(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Writing %d bytes to EEPROM...", len);
+	shell_print(shell, "Writing %zu bytes to EEPROM...", len);
 
 	err = eeprom_write(eeprom, offset, wr_buf, len);
 	if (err) {
@@ -140,7 +140,7 @@ static int cmd_size(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	shell_print(shell, "%d bytes", eeprom_get_size(eeprom));
+	shell_print(shell, "%zu bytes", eeprom_get_size(eeprom));
 	return 0;
 }
 
@@ -173,7 +173,7 @@ static int cmd_fill(const struct shell *shell, size_t argc, char **argv)
 		return -EINVAL;
 	}
 
-	shell_print(shell, "Writing %d bytes of 0x%02lx to EEPROM...", len,
+	shell_print(shell, "Writing %zu bytes of 0x%02lx to EEPROM...", len,
 		    pattern);
 
 	addr = initial_offset;

--- a/samples/drivers/eeprom/overlay-shell.conf
+++ b/samples/drivers/eeprom/overlay-shell.conf
@@ -1,0 +1,3 @@
+# Ensure EEPROM shell can be compiled
+CONFIG_SHELL=y
+CONFIG_EEPROM_SHELL=y

--- a/samples/drivers/eeprom/sample.yaml
+++ b/samples/drivers/eeprom/sample.yaml
@@ -1,19 +1,28 @@
 sample:
   name: EEPROM Sample
-common:
+
+tests:
+  sample.drivers.eeprom:
     tags: eeprom
+    platform_allow: >
+      gd32f450i_eval
+      native_posix
+      native_posix_64
+    integration_platforms:
+      - native_posix_64
     harness: console
     harness_config:
       type: one_line
       regex:
         - "Reset the MCU to see the increasing boot counter."
-
-tests:
-  sample.drivers.eeprom:
+  sample.drivers.eeprom.shell:
     tags: eeprom
-    platform_allow: native_posix gd32f450i_eval
-    integration_platforms:
-      - native_posix
+    platform_allow: >
+      gd32f450i_eval
+      native_posix
+      native_posix_64
+    extra_args: OVERLAY_CONFIG=overlay-shell.conf
+    harness: keyboard
   sample.drivers.eeprom.shield.x_nucleo_eeprma2:
     tags: eeprom shield
     depends_on: arduino_gpio arduino_i2c arduino_spi

--- a/samples/drivers/eeprom/src/main.c
+++ b/samples/drivers/eeprom/src/main.c
@@ -47,7 +47,7 @@ void main(void)
 	}
 
 	eeprom_size = eeprom_get_size(eeprom);
-	printk("Using eeprom with size of: %d.\n", eeprom_size);
+	printk("Using eeprom with size of: %zu.\n", eeprom_size);
 
 	rc = eeprom_read(eeprom, EEPROM_SAMPLE_OFFSET, &values, sizeof(values));
 	if (rc < 0) {


### PR DESCRIPTION
Building for native_posix_64 exposes faulty format strings.

Changes in this commit also ensure that the shell code gets built in CI,
thus this kind of problem can not be introduced again later on.