### PR TITLE
stm32U5 spi driver and dma transfer

### DIFF
--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -62,13 +62,13 @@ struct spi_stm32_data {
 	volatile uint32_t status_flags;
 	struct stream dma_rx;
 	struct stream dma_tx;
-#endif
+#endif /* CONFIG_SPI_STM32_DMA */
 };
 
 #ifdef CONFIG_SPI_STM32_DMA
 static inline uint32_t ll_func_dma_get_reg_addr(SPI_TypeDef *spi, uint32_t location)
 {
-#if defined(CONFIG_SOC_SERIES_STM32H7X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (location == SPI_STM32_DMA_TX) {
 		/* use direct register location until the LL_SPI_DMA_GetTxRegAddr exists */
 		return (uint32_t)&(spi->TXDR);
@@ -78,7 +78,7 @@ static inline uint32_t ll_func_dma_get_reg_addr(SPI_TypeDef *spi, uint32_t locat
 #else
 	ARG_UNUSED(location);
 	return (uint32_t)LL_SPI_DMA_GetRegAddr(spi);
-#endif /* CONFIG_SOC_SERIES_STM32H7X */
+#endif /* st_stm32h7_spi */
 }
 
 /* checks that DMA Tx packet is fully transmitted over the SPI */
@@ -90,7 +90,7 @@ static inline uint32_t ll_func_spi_dma_busy(SPI_TypeDef *spi)
 	/* the SPI Tx empty and busy flags are needed */
 	return (LL_SPI_IsActiveFlag_TXE(spi) &&
 		!LL_SPI_IsActiveFlag_BSY(spi));
-#endif
+#endif /* LL_SPI_SR_TXC */
 }
 #endif /* CONFIG_SPI_STM32_DMA */
 
@@ -100,7 +100,7 @@ static inline uint32_t ll_func_tx_is_empty(SPI_TypeDef *spi)
 	return LL_SPI_IsActiveFlag_TXP(spi);
 #else
 	return LL_SPI_IsActiveFlag_TXE(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
@@ -109,7 +109,7 @@ static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
 	return LL_SPI_IsActiveFlag_RXP(spi);
 #else
 	return LL_SPI_IsActiveFlag_RXNE(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
@@ -118,7 +118,7 @@ static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
 	LL_SPI_EnableIT_TXP(spi);
 #else
 	LL_SPI_EnableIT_TXE(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
@@ -127,7 +127,7 @@ static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
 	LL_SPI_EnableIT_RXP(spi);
 #else
 	LL_SPI_EnableIT_RXNE(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
@@ -140,7 +140,7 @@ static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
 	LL_SPI_EnableIT_MODF(spi);
 #else
 	LL_SPI_EnableIT_ERR(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
@@ -149,7 +149,7 @@ static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
 	LL_SPI_DisableIT_TXP(spi);
 #else
 	LL_SPI_DisableIT_TXE(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
@@ -158,7 +158,7 @@ static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
 	LL_SPI_DisableIT_RXP(spi);
 #else
 	LL_SPI_DisableIT_RXNE(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
@@ -171,7 +171,7 @@ static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
 	LL_SPI_DisableIT_MODF(spi);
 #else
 	LL_SPI_DisableIT_ERR(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
@@ -180,7 +180,7 @@ static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
 	return LL_SPI_IsActiveFlag_EOT(spi);
 #else
 	return LL_SPI_IsActiveFlag_BSY(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 /* Header is compiled first, this switch avoid the compiler to lookup for
@@ -193,7 +193,7 @@ static inline void ll_func_set_fifo_threshold_8bit(SPI_TypeDef *spi)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_01DATA);
 #else
 	LL_SPI_SetRxFIFOThreshold(spi, LL_SPI_RX_FIFO_TH_QUARTER);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
@@ -202,9 +202,9 @@ static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_02DATA);
 #else
 	LL_SPI_SetRxFIFOThreshold(spi, LL_SPI_RX_FIFO_TH_HALF);
-#endif
+#endif /* st_stm32h7_spi */
 }
-#endif
+#endif /* st_stm32_spi_fifo */
 
 static inline void ll_func_disable_spi(SPI_TypeDef *spi)
 {
@@ -228,7 +228,7 @@ static inline void ll_func_disable_spi(SPI_TypeDef *spi)
 	LL_SPI_ClearFlag_SUSP(spi);
 #else
 	LL_SPI_Disable(spi);
-#endif
+#endif /* st_stm32h7_spi */
 }
 
 #endif	/* ZEPHYR_DRIVERS_SPI_SPI_LL_STM32_H_ */

--- a/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/b_u585i_iot02a.overlay
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021 STMicroelectronics
+ * Copyright (c) 2022 STMicroelectronics
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -9,6 +9,9 @@
 };
 
 &spi1 {
+	dmas = <&gpdma1 0 7 0x440
+		&gpdma1 1 6 0x480>;
+	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
@@ -9,6 +9,9 @@
 };
 
 &spi1 {
+	dmas = <&gpdma1 0 7 0x440
+		&gpdma1 1 6 0x480>;
+	dma-names = "tx", "rx";
 	slow@0 {
 		compatible = "test-spi-loopback-slow";
 		reg = <0>;


### PR DESCRIPTION
This PR is updating the spi driver for the stm32U5 family
and also the DMA drivers for using on spi transfer.

It requires the https://github.com/zephyrproject-rtos/zephyr/pull/45350

The DMA is the GP DMA peripheral of the stm32u5.
The spi1 pins are enabled from the board DTS and two DMA channels are choosen (by the overlay file) from 0 to 11 ( periph to/from SRAM)
The DMA request is selected from the programmed table. 

tested on the disco kit b_u585i_iot02a and nucleo_u575zi_q  board, when D11 and D12 pins (spi MISO <--> MOSI) are connected on the target board.
```
$ west build -p auto -b b_u585i_iot02a -- -DOVERLAY_CONFIG="overlay-stm32-spi.conf" tests/drivers/spi/spi_loopback/
$ west build -p auto -b b_u585i_iot02a -- -DOVERLAY_CONFIG="overlay-stm32-spi-dma.conf" tests/drivers/spi/spi_loopback/
```

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)
