### PR TITLE
esp32: pinctrl: bring pin grouping support

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm-pinctrl.dtsi
@@ -10,44 +10,36 @@
 
 &pinctrl {
 
-	uart0_tx_gpio21: uart0_tx_gpio21 {
-		pinmux = <UART0_TX_GPIO21>;
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO21>;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO20>;
+			bias-pull-up;
+		};
 	};
 
-	uart0_rx_gpio20: uart0_rx_gpio20 {
-		pinmux = <UART0_RX_GPIO20>;
-		bias-pull-up;
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO2>,
+				 <SPIM2_SCLK_GPIO6>,
+				 <SPIM2_CSEL_GPIO10>;
+		};
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO7>;
+			output-low;
+		};
 	};
 
-	spim2_miso_gpio2: spim2_miso_gpio2 {
-		pinmux = <SPIM2_MISO_GPIO2>;
-	};
-
-	spim2_mosi_gpio7: spim2_mosi_gpio7 {
-		pinmux = <SPIM2_MOSI_GPIO7>;
-		output-low;
-	};
-
-	spim2_sclk_gpio6: spim2_sclk_gpio6 {
-		pinmux = <SPIM2_SCLK_GPIO6>;
-	};
-
-	spim2_csel_gpio10: spim2_csel_gpio10 {
-		pinmux = <SPIM2_CSEL_GPIO10>;
-	};
-
-	i2c0_sda_gpio1: i2c0_sda_gpio1 {
-		pinmux = <I2C0_SDA_GPIO1>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c0_scl_gpio3: i2c0_scl_gpio3 {
-		pinmux = <I2C0_SCL_GPIO3>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO1>,
+				 <I2C0_SCL_GPIO3>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
 };

--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -41,7 +41,7 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart0_tx_gpio21 &uart0_rx_gpio20>;
+	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
 };
 
@@ -50,7 +50,7 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	sda-pin = <1>;
 	scl-pin = <3>;
-	pinctrl-0 = <&i2c0_sda_gpio1 &i2c0_scl_gpio3>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 
@@ -62,8 +62,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim2_miso_gpio2 &spim2_mosi_gpio7
-		     &spim2_sclk_gpio6 &spim2_csel_gpio10>;
+	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/xtensa/esp32/esp32-pinctrl.dtsi
+++ b/boards/xtensa/esp32/esp32-pinctrl.dtsi
@@ -10,79 +10,68 @@
 
 &pinctrl {
 
-	uart0_tx_gpio1: uart0_tx_gpio1 {
-		pinmux = <UART0_TX_GPIO1>;
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO1>;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO3>;
+			bias-pull-up;
+		};
 	};
 
-	uart0_rx_gpio3: uart0_rx_gpio3 {
-		pinmux = <UART0_RX_GPIO3>;
-		bias-pull-up;
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_GPIO10>;
+		};
+		group2 {
+			pinmux = <UART1_RX_GPIO9>;
+			bias-pull-up;
+		};
 	};
 
-	uart1_tx_gpio10: uart1_tx_gpio10 {
-		pinmux = <UART1_TX_GPIO10>;
+	uart2_default: uart2_default {
+		group1 {
+			pinmux = <UART2_TX_GPIO17>;
+		};
+		group2 {
+			pinmux = <UART2_RX_GPIO16>;
+			bias-pull-up;
+		};
 	};
 
-	uart1_rx_gpio9: uart1_rx_gpio9 {
-		pinmux = <UART1_RX_GPIO9>;
-		bias-pull-up;
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO12>,
+				 <SPIM2_SCLK_GPIO14>,
+				 <SPIM2_CSEL_GPIO15>;
+		};
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO13>;
+			output-low;
+		};
 	};
 
-	uart2_tx_gpio17: uart2_tx_gpio17 {
-		pinmux = <UART2_TX_GPIO17>;
+	spim3_default: spim3_default {
+		group1 {
+			pinmux = <SPIM3_MISO_GPIO19>,
+				 <SPIM3_SCLK_GPIO18>,
+				 <SPIM3_CSEL_GPIO5>;
+		};
+		group2 {
+			pinmux = <SPIM3_MOSI_GPIO23>;
+			output-low;
+		};
 	};
 
-	uart2_rx_gpio16: uart2_rx_gpio16 {
-		pinmux = <UART2_RX_GPIO16>;
-		bias-pull-up;
-	};
-
-	spim2_miso_gpio12: spim2_miso_gpio12 {
-		pinmux = <SPIM2_MISO_GPIO12>;
-	};
-
-	spim2_mosi_gpio13: spim2_mosi_gpio13 {
-		pinmux = <SPIM2_MOSI_GPIO13>;
-		output-low;
-	};
-
-	spim2_sclk_gpio14: spim2_sclk_gpio14 {
-		pinmux = <SPIM2_SCLK_GPIO14>;
-	};
-
-	spim2_csel_gpio15: spim2_csel_gpio15 {
-		pinmux = <SPIM2_CSEL_GPIO15>;
-	};
-
-	spim3_miso_gpio19: spim3_miso_gpio19 {
-		pinmux = <SPIM3_MISO_GPIO19>;
-	};
-
-	spim3_mosi_gpio23: spim3_mosi_gpio23 {
-		pinmux = <SPIM3_MOSI_GPIO23>;
-		output-low;
-	};
-
-	spim3_sclk_gpio18: spim3_sclk_gpio18 {
-		pinmux = <SPIM3_SCLK_GPIO18>;
-	};
-
-	spim3_csel_gpio5: spim3_csel_gpio5 {
-		pinmux = <SPIM3_CSEL_GPIO5>;
-	};
-
-	i2c0_sda_gpio21: i2c0_sda_gpio21 {
-		pinmux = <I2C0_SDA_GPIO21>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c0_scl_gpio22: i2c0_scl_gpio22 {
-		pinmux = <I2C0_SCL_GPIO22>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO21>,
+				 <I2C0_SCL_GPIO22>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
 };

--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -36,19 +36,19 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart0_tx_gpio1 &uart0_rx_gpio3>;
+	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
 };
 
 &uart1 {
 	current-speed = <115200>;
-	pinctrl-0 = <&uart1_tx_gpio10 &uart1_rx_gpio9>;
+	pinctrl-0 = <&uart1_default>;
 	pinctrl-names = "default";
 };
 
 &uart2 {
 	current-speed = <115200>;
-	pinctrl-0 = <&uart2_tx_gpio17 &uart2_rx_gpio16>;
+	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";
 };
 
@@ -65,7 +65,7 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	sda-pin = <21>;
 	scl-pin = <22>;
-	pinctrl-0 = <&i2c0_sda_gpio21 &i2c0_scl_gpio22>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 
@@ -73,8 +73,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim2_miso_gpio12 &spim2_mosi_gpio13
-		     &spim2_sclk_gpio14 &spim2_csel_gpio15>;
+	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 };
 
@@ -82,8 +81,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim3_miso_gpio19 &spim3_mosi_gpio23
-		     &spim3_sclk_gpio18 &spim3_csel_gpio5>;
+	pinctrl-0 = <&spim3_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola-pinctrl.dtsi
@@ -10,75 +10,58 @@
 
 &pinctrl {
 
-	uart0_tx_gpio43: uart0_tx_gpio43 {
-		pinmux = <UART0_TX_GPIO43>;
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO43>;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO44>;
+			bias-pull-up;
+		};
 	};
 
-	uart0_rx_gpio44: uart0_rx_gpio44 {
-		pinmux = <UART0_RX_GPIO44>;
-		bias-pull-up;
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO13>,
+				 <SPIM2_SCLK_GPIO12>,
+				 <SPIM2_CSEL_GPIO10>;
+		};
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO11>;
+			output-low;
+		};
 	};
 
-	spim2_miso_gpio13: spim2_miso_gpio13 {
-		pinmux = <SPIM2_MISO_GPIO13>;
+	spim3_default: spim3_default {
+		group1 {
+			pinmux = <SPIM3_MISO_GPIO37>,
+				 <SPIM3_SCLK_GPIO36>,
+				 <SPIM3_CSEL_GPIO34>;
+		};
+		group2 {
+			pinmux = <SPIM3_MOSI_GPIO35>;
+			output-low;
+		};
 	};
 
-	spim2_mosi_gpio11: spim2_mosi_gpio11 {
-		pinmux = <SPIM2_MOSI_GPIO11>;
-		output-low;
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO8>,
+				 <I2C0_SCL_GPIO9>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
-	spim2_sclk_gpio12: spim2_sclk_gpio12 {
-		pinmux = <SPIM2_SCLK_GPIO12>;
-	};
-
-	spim2_csel_gpio10: spim2_csel_gpio10 {
-		pinmux = <SPIM2_CSEL_GPIO10>;
-	};
-
-	spim3_miso_gpio37: spim3_miso_gpio37 {
-		pinmux = <SPIM3_MISO_GPIO37>;
-	};
-
-	spim3_mosi_gpio35: spim3_mosi_gpio35 {
-		pinmux = <SPIM3_MOSI_GPIO35>;
-		output-low;
-	};
-
-	spim3_sclk_gpio36: spim3_sclk_gpio36 {
-		pinmux = <SPIM3_SCLK_GPIO36>;
-	};
-
-	spim3_csel_gpio34: spim3_csel_gpio34 {
-		pinmux = <SPIM3_CSEL_GPIO34>;
-	};
-
-	i2c0_sda_gpio8: i2c0_sda_gpio8 {
-		pinmux = <I2C0_SDA_GPIO8>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c0_scl_gpio9: i2c0_scl_gpio9 {
-		pinmux = <I2C0_SCL_GPIO9>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c1_sda_gpio3: i2c1_sda_gpio3 {
-		pinmux = <I2C1_SDA_GPIO3>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c1_scl_gpio4: i2c1_scl_gpio4 {
-		pinmux = <I2C1_SCL_GPIO4>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
+	i2c1_default: i2c1_default {
+		group1 {
+			pinmux = <I2C1_SDA_GPIO3>,
+				 <I2C1_SCL_GPIO4>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
 };

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -32,7 +32,7 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart0_tx_gpio43 &uart0_rx_gpio44>;
+	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
 };
 
@@ -63,13 +63,13 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	pinctrl-0 = <&i2c0_sda_gpio8 &i2c0_scl_gpio9>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 
 &i2c1 {
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	pinctrl-0 = <&i2c1_sda_gpio3 &i2c1_scl_gpio4>;
+	pinctrl-0 = <&i2c1_default>;
 	pinctrl-names = "default";
 };
 
@@ -81,8 +81,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim2_miso_gpio13 &spim2_mosi_gpio11
-		     &spim2_sclk_gpio12 &spim2_csel_gpio10>;
+	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 };
 
@@ -90,8 +89,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim3_miso_gpio37 &spim3_mosi_gpio35
-		     &spim3_sclk_gpio36 &spim3_csel_gpio34>;
+	pinctrl-0 = <&spim3_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit-pinctrl.dtsi
@@ -10,91 +10,57 @@
 
 &pinctrl {
 
-	uart0_tx_gpio1: uart0_tx_gpio1 {
-		pinmux = <UART0_TX_GPIO1>;
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO1>;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO3>;
+			bias-pull-up;
+		};
 	};
 
-	uart0_rx_gpio3: uart0_rx_gpio3 {
-		pinmux = <UART0_RX_GPIO3>;
-		bias-pull-up;
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO12>,
+				 <SPIM2_SCLK_GPIO14>,
+				 <SPIM2_CSEL_GPIO15>;
+		};
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO13>;
+			output-low;
+		};
 	};
 
-	spim2_miso_gpio12: spim2_miso_gpio12 {
-		pinmux = <SPIM2_MISO_GPIO12>;
+	spim3_default: spim3_default {
+		group1 {
+			pinmux = <SPIM3_MISO_GPIO25>,
+				 <SPIM3_SCLK_GPIO19>,
+				 <SPIM3_CSEL_GPIO22>;
+		};
+		group2 {
+			pinmux = <SPIM3_MOSI_GPIO23>;
+			output-low;
+		};
 	};
 
-	spim2_mosi_gpio13: spim2_mosi_gpio13 {
-		pinmux = <SPIM2_MOSI_GPIO13>;
-		output-low;
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO21>,
+				 <I2C0_SCL_GPIO22>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
-	spim2_sclk_gpio14: spim2_sclk_gpio14 {
-		pinmux = <SPIM2_SCLK_GPIO14>;
-	};
-
-	spim2_csel_gpio15: spim2_csel_gpio15 {
-		pinmux = <SPIM2_CSEL_GPIO15>;
-	};
-
-	spim3_miso_gpio25: spim3_miso_gpio25 {
-		pinmux = <SPIM3_MISO_GPIO25>;
-	};
-
-	spim3_mosi_gpio23: spim3_mosi_gpio23 {
-		pinmux = <SPIM3_MOSI_GPIO23>;
-		output-low;
-	};
-
-	spim3_sclk_gpio19: spim3_sclk_gpio19 {
-		pinmux = <SPIM3_SCLK_GPIO19>;
-	};
-
-	spim3_csel_gpio22: spim3_csel_gpio22 {
-		pinmux = <SPIM3_CSEL_GPIO22>;
-	};
-
-	i2c0_sda_gpio21: i2c0_sda_gpio21 {
-		pinmux = <I2C0_SDA_GPIO21>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c0_scl_gpio22: i2c0_scl_gpio22 {
-		pinmux = <I2C0_SCL_GPIO22>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	ledc0_ch0_gpio0: ledc0_ch0_gpio0 {
-		pinmux = <LEDC_CH0_GPIO0>;
-		output-enable;
-	};
-
-	ledc0_ch1_gpio2: ledc0_ch1_gpio2 {
-		pinmux = <LEDC_CH1_GPIO2>;
-		output-enable;
-	};
-
-	ledc0_ch2_gpio4: ledc0_ch2_gpio4 {
-		pinmux = <LEDC_CH2_GPIO4>;
-		output-enable;
-	};
-
-	ledc0_ch8_gpio0: ledc0_ch8_gpio0 {
-		pinmux = <LEDC_CH8_GPIO0>;
-		output-enable;
-	};
-
-	ledc0_ch9_gpio2: ledc0_ch9_gpio2 {
-		pinmux = <LEDC_CH9_GPIO2>;
-		output-enable;
-	};
-
-	ledc0_ch10_gpio4: ledc0_ch10_gpio4 {
-		pinmux = <LEDC_CH10_GPIO4>;
-		output-enable;
+	ledc0_default: ledc0_default {
+		group1 {
+			pinmux = <LEDC_CH0_GPIO0>,
+				 <LEDC_CH1_GPIO2>,
+				 <LEDC_CH2_GPIO4>;
+			output-enable;
+		};
 	};
 
 };

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -81,7 +81,7 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart0_tx_gpio1 &uart0_rx_gpio3>;
+	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
 };
 
@@ -98,7 +98,7 @@
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	sda-pin = <21>;
 	scl-pin = <22>;
-	pinctrl-0 = <&i2c0_sda_gpio21 &i2c0_scl_gpio22>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 
@@ -106,8 +106,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim2_miso_gpio12 &spim2_mosi_gpio13
-		     &spim2_sclk_gpio14 &spim2_csel_gpio15>;
+	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 };
 
@@ -115,8 +114,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim3_miso_gpio25 &spim3_mosi_gpio23
-		     &spim3_sclk_gpio19 &spim3_csel_gpio22>;
+	pinctrl-0 = <&spim3_default>;
 	pinctrl-names = "default";
 
 	ili9341: ili9341@0 {
@@ -134,7 +132,7 @@
 };
 
 &ledc0 {
-	pinctrl-0 = <&ledc0_ch0_gpio0 &ledc0_ch1_gpio2 &ledc0_ch2_gpio4>;
+	pinctrl-0 = <&ledc0_default>;
 	pinctrl-names = "default";
 	status = "okay";
 	#address-cells = <1>;

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2-pinctrl.dtsi
@@ -10,27 +10,24 @@
 
 &pinctrl {
 
-	uart0_tx_gpio1: uart0_tx_gpio1 {
-		pinmux = <UART0_TX_GPIO1>;
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO1>;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO3>;
+			bias-pull-up;
+		};
 	};
 
-	uart0_rx_gpio3: uart0_rx_gpio3 {
-		pinmux = <UART0_RX_GPIO3>;
-		bias-pull-up;
-	};
-
-	i2c0_sda_gpio4: i2c0_sda_gpio4 {
-		pinmux = <I2C0_SDA_GPIO4>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c0_scl_gpio15: i2c0_scl_gpio15 {
-		pinmux = <I2C0_SCL_GPIO15>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO4>,
+				 <I2C0_SCL_GPIO15>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
 };

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -67,7 +67,7 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart0_tx_gpio1 &uart0_rx_gpio3>;
+	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
 };
 
@@ -80,7 +80,7 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <4>;
 	scl-pin = <15>;
-	pinctrl-0 = <&i2c0_sda_gpio4 &i2c0_scl_gpio15>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 

--- a/boards/xtensa/odroid_go/odroid_go-pinctrl.dtsi
+++ b/boards/xtensa/odroid_go/odroid_go-pinctrl.dtsi
@@ -10,44 +10,36 @@
 
 &pinctrl {
 
-	uart0_tx_gpio1: uart0_tx_gpio1 {
-		pinmux = <UART0_TX_GPIO1>;
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO1>;
+		};
+		group2 {
+			pinmux = <UART0_RX_GPIO3>;
+			bias-pull-up;
+		};
 	};
 
-	uart0_rx_gpio3: uart0_rx_gpio3 {
-		pinmux = <UART0_RX_GPIO3>;
-		bias-pull-up;
+	spim3_default: spim3_default {
+		group1 {
+			pinmux = <SPIM3_MISO_GPIO19>,
+				 <SPIM3_SCLK_GPIO18>,
+				 <SPIM3_CSEL_GPIO5>;
+		};
+		group2 {
+			pinmux = <SPIM3_MOSI_GPIO23>;
+			output-low;
+		};
 	};
 
-	spim3_miso_gpio19: spim3_miso_gpio19 {
-		pinmux = <SPIM3_MISO_GPIO19>;
-	};
-
-	spim3_mosi_gpio23: spim3_mosi_gpio23 {
-		pinmux = <SPIM3_MOSI_GPIO23>;
-		output-low;
-	};
-
-	spim3_sclk_gpio18: spim3_sclk_gpio18 {
-		pinmux = <SPIM3_SCLK_GPIO18>;
-	};
-
-	spim3_csel_gpio5: spim3_csel_gpio5 {
-		pinmux = <SPIM3_CSEL_GPIO5>;
-	};
-
-	i2c0_sda_gpio4: i2c0_sda_gpio4 {
-		pinmux = <I2C0_SDA_GPIO4>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c0_scl_gpio15: i2c0_scl_gpio15 {
-		pinmux = <I2C0_SCL_GPIO15>;
-		bias-pull-up;
-		drive-open-drain;
-		output-high;
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SDA_GPIO4>,
+				 <I2C0_SCL_GPIO15>;
+			bias-pull-up;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
 };

--- a/boards/xtensa/odroid_go/odroid_go.dts
+++ b/boards/xtensa/odroid_go/odroid_go.dts
@@ -82,7 +82,7 @@
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart0_tx_gpio1 &uart0_rx_gpio3>;
+	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
 };
 
@@ -99,7 +99,7 @@
 	clock-frequency = <I2C_BITRATE_FAST>;
 	sda-pin = <4>;
 	scl-pin = <15>;
-	pinctrl-0 = <&i2c0_sda_gpio4 &i2c0_scl_gpio15>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 
@@ -107,8 +107,7 @@
 	#address-cells = <1>;
 	#size-cells = <0>;
 	status = "okay";
-	pinctrl-0 = <&spim3_miso_gpio19 &spim3_mosi_gpio23
-		     &spim3_sclk_gpio18 &spim3_csel_gpio5>;
+	pinctrl-0 = <&spim3_default>;
 	pinctrl-names = "default";
 
 	ili9341: ili9341@0 {

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb-pinctrl.dtsi
@@ -9,48 +9,39 @@
 #include <zephyr/dt-bindings/pinctrl/esp32-gpio-sigmap.h>
 
 &pinctrl {
-	uart0_tx_gpio1: uart0_tx_gpio1 {
-		pinmux = <UART0_TX_GPIO1>;
+	uart0_default: uart0_default {
+		group1 {
+			pinmux = <UART0_TX_GPIO1>,
+				 <UART0_RX_GPIO3>;
+		};
 	};
 
-	uart0_rx_gpio3: uart0_rx_gpio3 {
-		pinmux = <UART0_RX_GPIO3>;
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_GPIO4>,
+				 <UART1_RX_GPIO36>;
+		};
 	};
 
-	uart1_tx_gpio4: uart1_tx_gpio4 {
-		pinmux = <UART1_TX_GPIO4>;
+	i2c0_default: i2c0_default {
+		group1 {
+			pinmux = <I2C0_SCL_GPIO16>,
+				 <I2C0_SDA_GPIO13>;
+			drive-open-drain;
+			output-high;
+		};
 	};
 
-	uart1_rx_gpio36: uart1_rx_gpio36 {
-		pinmux = <UART1_RX_GPIO36>;
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO15>,
+				 <SPIM2_SCLK_GPIO14>,
+				 <SPIM2_CSEL_GPIO17>;
+		};
+		group2 {
+			pinmux = <SPIM2_MOSI_GPIO2>;
+			output-low;
+		};
 	};
 
-	i2c0_scl_gpio16: i2c0_scl_gpio16 {
-		pinmux = <I2C0_SCL_GPIO16>;
-		drive-open-drain;
-		output-high;
-	};
-
-	i2c0_sda_gpio13: i2c0_sda_gpio13 {
-		pinmux = <I2C0_SDA_GPIO13>;
-		drive-open-drain;
-		output-high;
-	};
-
-	spim2_miso_gpio15: spim2_miso_gpio15 {
-		pinmux = <SPIM2_MISO_GPIO15>;
-	};
-
-	spim2_mosi_gpio2: spim2_mosi_gpio2 {
-		pinmux = <SPIM2_MOSI_GPIO2>;
-		output-low;
-	};
-
-	spim2_sclk_gpio14: spim2_sclk_gpio14 {
-		pinmux = <SPIM2_SCLK_GPIO14>;
-	};
-
-	spim2_csel_gpio17: spim2_csel_gpio17 {
-		pinmux = <SPIM2_CSEL_GPIO17>;
-	};
 };

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
@@ -66,14 +66,14 @@ uext_spi: &spi2 {};
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart0_tx_gpio1 &uart0_rx_gpio3>;
+	pinctrl-0 = <&uart0_default>;
 	pinctrl-names = "default";
 };
 
 &uart1 {
 	status = "okay";
 	current-speed = <115200>;
-	pinctrl-0 = <&uart1_tx_gpio4 &uart1_rx_gpio36>;
+	pinctrl-0 = <&uart1_default>;
 	pinctrl-names = "default";
 };
 
@@ -82,14 +82,13 @@ uext_spi: &spi2 {};
 	clock-frequency = <I2C_BITRATE_STANDARD>;
 	sda-pin = <16>;
 	scl-pin = <13>;
-	pinctrl-0 = <&i2c0_scl_gpio16 &i2c0_sda_gpio13>;
+	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };
 
 &spi2 {
 	status = "okay";
-	pinctrl-0 = <&spim2_miso_gpio15 &spim2_mosi_gpio2
-		     &spim2_sclk_gpio14 &spim2_csel_gpio17>;
+	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 	#address-cells = <1>;
 	#size-cells = <0>;

--- a/dts/bindings/pinctrl/espressif,esp32-pinctrl.yaml
+++ b/dts/bindings/pinctrl/espressif,esp32-pinctrl.yaml
@@ -2,12 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 description: |
-    Espressif's Pin controller Node
-    Based on pincfg-node.yaml binding.
     Espressif's pin controller is in charge of controlling pin configurations, pin
     functionalities and pin properties as defined by pin states. In its turn, pin
-    states are composed of pre-defined pin muxing definitions and user-provided
-    pin properties.
+    states are composed by groups of pre-defined pin muxing definitions and user
+    provided pin properties.
 
     Each Zephyr-based application has its own set of pin muxing/pin configuration
     requirements. The next steps use ESP-WROVER-KIT's I2C_0 to illustrate how one
@@ -17,31 +15,33 @@ description: |
     Suppose an application running on top of the ESP-WROVER-KIT board, for some
     reason it needs I2C_0's SDA signal to be routed to GPIO_33. When looking at
     that board's original device tree source file (i.e., 'esp_wrover_kit.dts'),
-    you'll notice that the I2C_0 node is already assigned to a set of states.
+    you'll notice that the I2C_0 node is already assigned to a pre-defined state.
     Below is highlighted the information that most interests us on that file
 
 
         #include "esp_wrover_kit-pinctrl.dtsi"
 
         &i2c0 {
-                pinctrl-0 = <&i2c0_sda_gpio21 &i2c0_scl_gpio22>;
+                ...
+                pinctrl-0 = <&i2c0_default>;
                 pinctrl-names = "default";
         };
 
 
-    From the above excerpt, the pincrl-0 property is composed of 'i2c0_sda_gpio21'
-    and 'i2c0_scl_gpio22' pin states. The naming convention makes it clear that
-    I2C_0's SDA signal is, by default, routed to GPIO_21 on the target board. Pin
-    states are defined on another file (i.e, 'esp_wrover_kit-pinctrl.dtsi') on
-    the same folder of the DTS file. Check below the excerpt describing SDA's
-    pin state
+    From the above excerpt, the pincrl-0 property is assigned the 'i2c0_default'
+    state value. This and other pin states of the board are defined on another file
+    (in this case, 'esp_wrover_kit-pinctrl.dtsi') on the same folder of the DTS file.
+    Check below the excerpt describing I2C_0's default state on that file
 
 
-        i2c0_sda_gpio21: i2c0_sda_gpio21 {
-                pinmux = <I2C0_SDA_GPIO21>;
-                bias-pull-up;
-                drive-open-drain;
-                output-high;
+        i2c0_default: i2c0_default {
+                group1 {
+                        pinmux = <I2C0_SDA_GPIO21>,
+                                 <I2C0_SCL_GPIO22>;
+                        bias-pull-up;
+                        drive-open-drain;
+                        output-high;
+                };
         };
 
 
@@ -51,10 +51,10 @@ description: |
     pull-up resistor soldered to GPIO_21's pin pad, in which case, 'bias-pull-up'
     could be no longer required.
 
-    Back to our fictional application, the previous SDA state definition does not
-    meet our expectations, remember, we would like to route I2C_0's SDA signal to
-    GPIO_33 and not to GPIO_21. To achieve our goal, we need to update the 'pinmux'
-    property accordingly.
+    Back to our fictional application, the previous I2C_0 state definition does not
+    meet our expectations as we would like to route I2C_0's SDA signal to GPIO_33
+    instead of to GPIO_21. To achieve it, we need to update the 'pinmux' property
+    accordingly.
 
     Note that replacing 'I2C0_SDA_GPIO21' by 'I2C0_SDA_GPIO33' is very tempting and
     may even work, however, unless you have checked the hardware documentation first,
@@ -82,25 +82,18 @@ description: |
     definition above, yielding
 
 
-        i2c0_sda_gpio33: i2c0_sda_gpio33 {
-                pinmux = <I2C0_SDA_GPIO33>;
-                bias-pull-up;
-                drive-open-drain;
-                output-high;
+        i2c0_default: i2c0_default {
+                group1 {
+                        pinmux = <I2C0_SDA_GPIO33>,
+                                 <I2C0_SCL_GPIO22>;
+                        bias-pull-up;
+                        drive-open-drain;
+                        output-high;
+                };
         };
 
 
-    Finally, update the I2C0 node state information in the device tree source using the
-    new (or updated) state
-
-
-        &ic20 {
-                pinctrl-0 = <&i2c0_sda_gpio33 &i2c0_scl_gpio22>;
-                pinctrl-names = "default";
-        };
-
-
-    With proper adaptations, the same steps above apply when using different
+    With proper modifications, the same steps above apply when using different
     combinations of boards, SoCs, peripherals and peripheral pins.
 
     Note: Not all pins are available for a given peripheral, it depends if that
@@ -112,49 +105,40 @@ description: |
           property is meaningful to the peripheral signal and that it is also
           available in the target GPIO.
 
+          Another thing worth noting is that all pin properties should be grouped.
+          All pins sharing common properties go under a common group (in the above
+          example, all pins are in 'group1'). Other peripherals can have more than
+          one group.
 
 compatible: "espressif,esp32-pinctrl"
 
 include:
     - name: base.yaml
-    - name: pincfg-node.yaml
+    - name: pincfg-node-group.yaml
       child-binding:
-        property-allowlist:
-          - bias-disable
-          - bias-pull-down
-          - bias-pull-up
-          - drive-push-pull
-          - drive-open-drain
-          - input-enable
-          - output-enable
-          - output-high
-          - output-low
-
-properties:
-    reg:
-      required: false
+        child-binding:
+          property-allowlist:
+            - bias-disable
+            - bias-pull-down
+            - bias-pull-up
+            - drive-push-pull
+            - drive-open-drain
+            - input-enable
+            - output-enable
+            - output-high
+            - output-low
 
 child-binding:
-    description: |
-        This binding gives a base representation of the ESP32 pins configuration
-
+  description: |
+    Espressif pin controller pin configuration state nodes.
+  child-binding:
+    description:
+      Espressif pin controller pin configuration group.
     properties:
-        pinmux:
-          required: true
-          type: int
-          description: |
-            Integer value, represents pin mux settings.
-            With:
-            - pin: The gpio pin number (0, 1, ..., GPIO_NUM_MAX)
-            - sigi: The input signal assigned to a pin, if not available, it gets
-              assigned to ESP_NOSIG
-            - sigo: The output signal assigned to a pin, if not available, it gets
-              assigned to ESP_NOSIG
-            To simplify the usage, macro is available to generate "pinmux" field.
-            This macro is available here:
-              -include/zephyr/dt-bindings/pinctrl/esp-pinctrl-common.h
-            Some examples of macro usage:
-               GPIO 3 set as UART0's RX pin
-            ... {
-                     pinmux = <ESP32_PINMUX(3, ESP_U0RXD_IN, ESP_NOSIG)>;
-            };
+      pinmux:
+        required: true
+        type: array
+        description: |
+          Each array element represents pin muxing information of an individual
+          pin. The array elements are pre-declared macros taken from Espressif's
+          HAL.

--- a/dts/bindings/pwm/espressif,esp32-ledc.yaml
+++ b/dts/bindings/pwm/espressif,esp32-ledc.yaml
@@ -11,32 +11,46 @@ description: |
   The mapping between the channel and GPIO is done through pinctrl
 
     &ledc0 {
-      pinctrl-0 = <&ledc0_ch0_gpio0>;
+      pinctrl-0 = <&ledc0_default>;
       pinctrl-names = "default";
     }
 
-  The 'ledc0_ch0_gpio0' node is defined in <board>-pinctrl.dtsi.
+  The 'ledc0_default' node state is defined in <board>-pinctrl.dtsi.
 
-    ledc0_ch0_gpio0: ledc0_ch0_gpio0 {
-      pinmux = <LEDC_CH0_GPIO0>;
-      output-enable;
+    ledc0_default: ledc0_default {
+            group1 {
+                    pinmux = <LEDC_CH0_GPIO0>,
+                             <LEDC_CH1_GPIO2>,
+                             <LEDC_CH2_GPIO4>;
+                    output-enable;
+            };
     };
 
-  If another mapping is desired, just check if the <board>-pinctrl.dtsi already have it defined, or feel free to include a new node.
+  If another GPIO mapping is desired, check if <board>-pinctrl.dtsi already have it defined, otherwise, define the
+  required mapping at your own application folder into a custom <board>.overlay file.
   The 'pinmux' property uses a macro defined in https://github.com/zephyrproject-rtos/hal_espressif/tree/zephyr/include/dt-bindings/pinctrl
   Before including a new node, check if the desired mapping is available according to the SoC.
 
-  It is possible to include multiple channel's mapping in the 'pinmux' property:
+  As an example, the 'ledc0_custom' state below illustrates an alternate mapping using another set of channels and
+  pins in a custom overlay file.
 
-    &ledc0 {
-      pinctrl-0 = <&ledc0_ch0_gpio0 &ledc0_ch9_gpio2 &ledc0_ch10_gpio4>;
-      pinctrl-names = "default";
-    }
+    &pinctrl {
+
+            ledc0_custom:  ledc0_custom {
+                    group1 {
+                            pinmux = <LEDC_CH0_GPIO0>,
+                                     <LEDC_CH9_GPIO2>,
+                                     <LEDC_CH10_GPIO4>;
+                            output-enable;
+                    };
+             };
+
+    };
 
   Use the child bindings to configure the desired channel:
 
     &ledc0 {
-      pinctrl-0 = <&ledc0_ch0_gpio0 &ledc0_ch9_gpio2 &ledc0_ch10_gpio4>;
+      pinctrl-0 = <&ledc0_custom>;
       pinctrl-names = "default";
       status = "okay";
       #address-cells = <1>;

--- a/samples/basic/blinky_pwm/boards/esp32.overlay
+++ b/samples/basic/blinky_pwm/boards/esp32.overlay
@@ -24,14 +24,16 @@
 };
 
 &pinctrl {
-	ledc0_ch0_gpio2: ledc0_ch0_gpio2 {
-		pinmux = <LEDC_CH0_GPIO2>;
-		output-enable;
+	ledc0_default: ledc0_default {
+		group1 {
+			pinmux = <LEDC_CH0_GPIO2>;
+			output-enable;
+		};
 	};
 };
 
 &ledc0 {
-	pinctrl-0 = <&ledc0_ch0_gpio2>;
+	pinctrl-0 = <&ledc0_default>;
 	pinctrl-names = "default";
 	status = "okay";
 	#address-cells = <1>;

--- a/samples/basic/blinky_pwm/boards/esp32c3_devkitm.overlay
+++ b/samples/basic/blinky_pwm/boards/esp32c3_devkitm.overlay
@@ -24,14 +24,16 @@
 };
 
 &pinctrl {
-	ledc0_ch0_gpio2: ledc0_ch0_gpio2 {
-		pinmux = <LEDC_CH0_GPIO2>;
-		output-enable;
+	ledc0_default: ledc0_default {
+		group1 {
+			pinmux = <LEDC_CH0_GPIO2>;
+			output-enable;
+		};
 	};
 };
 
 &ledc0 {
-	pinctrl-0 = <&ledc0_ch0_gpio2>;
+	pinctrl-0 = <&ledc0_default>;
 	pinctrl-names = "default";
 	status = "okay";
 	#address-cells = <1>;

--- a/samples/basic/blinky_pwm/boards/esp32s2_saola.overlay
+++ b/samples/basic/blinky_pwm/boards/esp32s2_saola.overlay
@@ -24,14 +24,16 @@
 };
 
 &pinctrl {
-	ledc0_ch0_gpio2: ledc0_ch0_gpio2 {
-		pinmux = <LEDC_CH0_GPIO2>;
-		output-enable;
+	ledc0_default: ledc0_default {
+		group1 {
+			pinmux = <LEDC_CH0_GPIO2>;
+			output-enable;
+		};
 	};
 };
 
 &ledc0 {
-	pinctrl-0 = <&ledc0_ch0_gpio2>;
+	pinctrl-0 = <&ledc0_default>;
 	pinctrl-names = "default";
 	status = "okay";
 	#address-cells = <1>;

--- a/samples/bluetooth/hci_uart/boards/esp32.overlay
+++ b/samples/bluetooth/hci_uart/boards/esp32.overlay
@@ -12,21 +12,16 @@
 
 &pinctrl {
 
-	uart1_tx_gpio5: uart1_tx_gpio5 {
-		pinmux = <UART1_TX_GPIO5>;
-	};
-
-	uart1_rx_gpio18: uart1_rx_gpio18 {
-		pinmux = <UART1_RX_GPIO18>;
-	};
-
-	uart1_rts_gpio19: uart1_rts_gpio19 {
-		pinmux = <UART1_RTS_GPIO19>;
-	};
-
-	uart1_cts_gpio23: uart1_cts_gpio23 {
-		pinmux = <UART1_CTS_GPIO23>;
-		bias-pull-up;
+	uart1_default: uart1_default {
+		group1 {
+			pinmux = <UART1_TX_GPIO5>,
+				 <UART1_RX_GPIO18>,
+				 <UART1_RTS_GPIO19>;
+		};
+		group2 {
+			pinmux = <UART1_CTS_GPIO23>;
+			bias-pull-up;
+		};
 	};
 
 };
@@ -34,7 +29,6 @@
 &uart1 {
 	status = "okay";
 	current-speed = <921600>;
-	pinctrl-0 = <&uart1_tx_gpio5 &uart1_rx_gpio18
-		     &uart1_rts_gpio19 &uart1_cts_gpio23>;
+	pinctrl-0 = <&uart1_default>;
 	pinctrl-names = "default";
 };

--- a/samples/subsys/fs/fat_fs/boards/esp_wrover_kit.overlay
+++ b/samples/subsys/fs/fat_fs/boards/esp_wrover_kit.overlay
@@ -6,23 +6,19 @@
 
 &pinctrl {
 
-	spim2_miso_gpio2: spim2_miso_gpio2 {
-		pinmux = <SPIM2_MISO_GPIO2>;
-	};
-
-	spim2_mosi_gpio15: spim2_mosi_gpio15 {
-		pinmux = <SPIM2_MOSI_GPIO15>;
-	};
-
-	spim2_sclk_gpio14: spim2_sclk_gpio14 {
-		pinmux = <SPIM2_SCLK_GPIO14>;
+	spim2_default: spim2_default {
+		group1 {
+			pinmux = <SPIM2_MISO_GPIO2>,
+				 <SPIM2_MOSI_GPIO15>,
+				 <SPIM2_SCLK_GPIO14>;
+		};
 	};
 
 };
 
 &spi2 {
 	status = "okay";
-	pinctrl-0 = <&spim2_miso_gpio2 &spim2_mosi_gpio15 &spim2_sclk_gpio14>;
+	pinctrl-0 = <&spim2_default>;
 	pinctrl-names = "default";
 	cs-gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
 

--- a/soc/riscv/esp32c3/pinctrl_soc.h
+++ b/soc/riscv/esp32c3/pinctrl_soc.h
@@ -32,14 +32,15 @@ typedef struct pinctrl_soc_pin {
  *
  * @param node_id Node identifier.
  */
-#define Z_PINCTRL_ESP32_PINMUX_INIT(node_id) DT_PROP(node_id, pinmux)
+#define Z_PINCTRL_ESP32_PINMUX_INIT(node_id, prop, idx) \
+	DT_PROP_BY_IDX(node_id, prop, idx)
 
 /**
  * @brief Utility macro to initialize pincfg field in #pinctrl_pin_t.
  *
  * @param node_id Node identifier.
  */
-#define Z_PINCTRL_ESP32_PINCFG_INIT(node_id)	\
+#define Z_PINCTRL_ESP32_PINCFG_INIT(node_id)							\
 	(((ESP32_NO_PULL * DT_PROP(node_id, bias_disable)) << ESP32_PIN_BIAS_SHIFT) |		\
 	 ((ESP32_PULL_UP * DT_PROP(node_id, bias_pull_up)) << ESP32_PIN_BIAS_SHIFT) |		\
 	 ((ESP32_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << ESP32_PIN_BIAS_SHIFT) |	\
@@ -52,14 +53,12 @@ typedef struct pinctrl_soc_pin {
  * @brief Utility macro to initialize each pin.
  *
  * @param node_id Node identifier.
- * @param state_prop State property name.
- * @param idx State property entry index.
+ * @param prop Property name.
+ * @param idx Property entry index.
  */
-#define Z_PINCTRL_STATE_PIN_INIT(node_id, state_prop, idx)			\
-	{ .pinmux = Z_PINCTRL_ESP32_PINMUX_INIT(				\
-		DT_PROP_BY_IDX(node_id, state_prop, idx)),			\
-	  .pincfg = Z_PINCTRL_ESP32_PINCFG_INIT(				\
-		DT_PROP_BY_IDX(node_id, state_prop, idx)) },
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)				\
+	{ .pinmux = Z_PINCTRL_ESP32_PINMUX_INIT(node_id, prop, idx),		\
+	  .pincfg = Z_PINCTRL_ESP32_PINCFG_INIT(node_id) },
 
 /**
  * @brief Utility macro to initialize state pins contained in a given property.
@@ -68,7 +67,9 @@ typedef struct pinctrl_soc_pin {
  * @param prop Property name describing state pins.
  */
 #define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)			       \
-	{DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),		       \
+				DT_FOREACH_PROP_ELEM, pinmux,		       \
+				Z_PINCTRL_STATE_PIN_INIT)}
 
 /** @endcond */
 

--- a/soc/xtensa/esp32/pinctrl_soc.h
+++ b/soc/xtensa/esp32/pinctrl_soc.h
@@ -32,14 +32,15 @@ typedef struct pinctrl_soc_pin {
  *
  * @param node_id Node identifier.
  */
-#define Z_PINCTRL_ESP32_PINMUX_INIT(node_id) DT_PROP(node_id, pinmux)
+#define Z_PINCTRL_ESP32_PINMUX_INIT(node_id, prop, idx) \
+	DT_PROP_BY_IDX(node_id, prop, idx)
 
 /**
  * @brief Utility macro to initialize pincfg field in #pinctrl_pin_t.
  *
  * @param node_id Node identifier.
  */
-#define Z_PINCTRL_ESP32_PINCFG_INIT(node_id)	\
+#define Z_PINCTRL_ESP32_PINCFG_INIT(node_id)							\
 	(((ESP32_NO_PULL * DT_PROP(node_id, bias_disable)) << ESP32_PIN_BIAS_SHIFT) |		\
 	 ((ESP32_PULL_UP * DT_PROP(node_id, bias_pull_up)) << ESP32_PIN_BIAS_SHIFT) |		\
 	 ((ESP32_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << ESP32_PIN_BIAS_SHIFT) |	\
@@ -52,14 +53,12 @@ typedef struct pinctrl_soc_pin {
  * @brief Utility macro to initialize each pin.
  *
  * @param node_id Node identifier.
- * @param state_prop State property name.
- * @param idx State property entry index.
+ * @param prop Property name.
+ * @param idx Property entry index.
  */
-#define Z_PINCTRL_STATE_PIN_INIT(node_id, state_prop, idx)			\
-	{ .pinmux = Z_PINCTRL_ESP32_PINMUX_INIT(				\
-		DT_PROP_BY_IDX(node_id, state_prop, idx)),			\
-	  .pincfg = Z_PINCTRL_ESP32_PINCFG_INIT(				\
-		DT_PROP_BY_IDX(node_id, state_prop, idx)) },
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)				\
+	{ .pinmux = Z_PINCTRL_ESP32_PINMUX_INIT(node_id, prop, idx),		\
+	  .pincfg = Z_PINCTRL_ESP32_PINCFG_INIT(node_id) },
 
 /**
  * @brief Utility macro to initialize state pins contained in a given property.
@@ -68,7 +67,9 @@ typedef struct pinctrl_soc_pin {
  * @param prop Property name describing state pins.
  */
 #define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)			       \
-	{DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),		       \
+				DT_FOREACH_PROP_ELEM, pinmux,		       \
+				Z_PINCTRL_STATE_PIN_INIT)}
 
 /** @endcond */
 

--- a/soc/xtensa/esp32s2/pinctrl_soc.h
+++ b/soc/xtensa/esp32s2/pinctrl_soc.h
@@ -32,14 +32,15 @@ typedef struct pinctrl_soc_pin {
  *
  * @param node_id Node identifier.
  */
-#define Z_PINCTRL_ESP32_PINMUX_INIT(node_id) DT_PROP(node_id, pinmux)
+#define Z_PINCTRL_ESP32_PINMUX_INIT(node_id, prop, idx) \
+	DT_PROP_BY_IDX(node_id, prop, idx)
 
 /**
  * @brief Utility macro to initialize pincfg field in #pinctrl_pin_t.
  *
  * @param node_id Node identifier.
  */
-#define Z_PINCTRL_ESP32_PINCFG_INIT(node_id)	\
+#define Z_PINCTRL_ESP32_PINCFG_INIT(node_id)							\
 	(((ESP32_NO_PULL * DT_PROP(node_id, bias_disable)) << ESP32_PIN_BIAS_SHIFT) |		\
 	 ((ESP32_PULL_UP * DT_PROP(node_id, bias_pull_up)) << ESP32_PIN_BIAS_SHIFT) |		\
 	 ((ESP32_PULL_DOWN * DT_PROP(node_id, bias_pull_down)) << ESP32_PIN_BIAS_SHIFT) |	\
@@ -52,14 +53,12 @@ typedef struct pinctrl_soc_pin {
  * @brief Utility macro to initialize each pin.
  *
  * @param node_id Node identifier.
- * @param state_prop State property name.
- * @param idx State property entry index.
+ * @param prop Property name.
+ * @param idx Property entry index.
  */
-#define Z_PINCTRL_STATE_PIN_INIT(node_id, state_prop, idx)			\
-	{ .pinmux = Z_PINCTRL_ESP32_PINMUX_INIT(				\
-		DT_PROP_BY_IDX(node_id, state_prop, idx)),			\
-	  .pincfg = Z_PINCTRL_ESP32_PINCFG_INIT(				\
-		DT_PROP_BY_IDX(node_id, state_prop, idx)) },
+#define Z_PINCTRL_STATE_PIN_INIT(node_id, prop, idx)				\
+	{ .pinmux = Z_PINCTRL_ESP32_PINMUX_INIT(node_id, prop, idx),		\
+	  .pincfg = Z_PINCTRL_ESP32_PINCFG_INIT(node_id) },
 
 /**
  * @brief Utility macro to initialize state pins contained in a given property.
@@ -68,7 +67,9 @@ typedef struct pinctrl_soc_pin {
  * @param prop Property name describing state pins.
  */
 #define Z_PINCTRL_STATE_PINS_INIT(node_id, prop)			       \
-	{DT_FOREACH_PROP_ELEM(node_id, prop, Z_PINCTRL_STATE_PIN_INIT)}
+	{DT_FOREACH_CHILD_VARGS(DT_PHANDLE(node_id, prop),		       \
+				DT_FOREACH_PROP_ELEM, pinmux,		       \
+				Z_PINCTRL_STATE_PIN_INIT)}
 
 /** @endcond */
 


### PR DESCRIPTION
This PR modifies current Espressif's pinctrl support to be based on pin groupings instead.

Thus, it also updates all esp32/s2/c3-based boards' DTS and overlays.