### PR TITLE
boards: remove usage of DT_LABEL

### DIFF
--- a/boards/arm/nrf9160_innblue21/innblue21_board_init.c
+++ b/boards/arm/nrf9160_innblue21/innblue21_board_init.c
@@ -31,14 +31,15 @@ static int pwr_ctrl_init(const struct device *dev)
 	const struct device *gpio;
 
 	/* Get handle of the GPIO device. */
-	gpio = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
+	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 
-	/* Valid handle? */
-	if (gpio != NULL) {
-		/* Configure the gpio pin. */
-		config_pin(gpio, VDD_3V3_PWR_CTRL_GPIO_PIN);
-		config_pin(gpio, VDD_5V0_PWR_CTRL_GPIO_PIN);
+	if (!device_is_ready(gpio)) {
+		return -ENODEV;
 	}
+
+	/* Configure the gpio pin. */
+	config_pin(gpio, VDD_3V3_PWR_CTRL_GPIO_PIN);
+	config_pin(gpio, VDD_5V0_PWR_CTRL_GPIO_PIN);
 
 	return 0;
 }

--- a/boards/arm/nrf9160_innblue22/innblue22_board_init.c
+++ b/boards/arm/nrf9160_innblue22/innblue22_board_init.c
@@ -15,23 +15,23 @@ static int pwr_ctrl_init(const struct device *dev)
 	int    err = -ENODEV;
 
 	/* Get handle of the GPIO device. */
-	gpio = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
+	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 
-	/* Valid handle? */
-	if (gpio != NULL) {
-
-		/* Configure this pin as output. */
-		err = gpio_pin_configure(gpio, VDD_5V0_PWR_CTRL_GPIO_PIN,
-							GPIO_OUTPUT_ACTIVE);
-		if (err == 0) {
-
-			/* Write "1" to this pin. */
-			err = gpio_pin_set(gpio, VDD_5V0_PWR_CTRL_GPIO_PIN, 1);
-		}
-
-		/* Wait for the rail to come up and stabilize. */
-		k_sleep(K_MSEC(10));
+	if (!device_is_ready(gpio)) {
+		return -ENODEV;
 	}
+
+	/* Configure this pin as output. */
+	err = gpio_pin_configure(gpio, VDD_5V0_PWR_CTRL_GPIO_PIN,
+						GPIO_OUTPUT_ACTIVE);
+	if (err == 0) {
+
+		/* Write "1" to this pin. */
+		err = gpio_pin_set(gpio, VDD_5V0_PWR_CTRL_GPIO_PIN, 1);
+	}
+
+	/* Wait for the rail to come up and stabilize. */
+	k_sleep(K_MSEC(10));
 
 	/* Operation status? */
 	return (err);

--- a/boards/arm/particle_boron/board.c
+++ b/boards/arm/particle_boron/board.c
@@ -40,8 +40,8 @@ static int board_particle_boron_init(const struct device *dev)
 	const struct device *gpio_dev;
 
 	/* Enable the serial buffer for SARA-R4 modem */
-	gpio_dev = device_get_binding(SERIAL_BUFFER_ENABLE_GPIO_NAME);
-	if (!gpio_dev) {
+	gpio_dev = DEVICE_DT_GET(SERIAL_BUFFER_ENABLE_GPIO_NODE);
+	if (!device_is_ready(gpio_dev)) {
 		return -ENODEV;
 	}
 

--- a/boards/arm/particle_boron/board.h
+++ b/boards/arm/particle_boron/board.h
@@ -8,7 +8,7 @@
 #define __INC_BOARD_H
 
 /* pin used to enable the buffer power */
-#define SERIAL_BUFFER_ENABLE_GPIO_NAME  DT_LABEL(DT_INST(0, nordic_nrf_gpio))
+#define SERIAL_BUFFER_ENABLE_GPIO_NODE  DT_INST(0, nordic_nrf_gpio)
 #define SERIAL_BUFFER_ENABLE_GPIO_PIN   25
 #define SERIAL_BUFFER_ENABLE_GPIO_FLAGS GPIO_ACTIVE_LOW
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/board.c
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/board.c
@@ -7,18 +7,17 @@
 #include <zephyr/init.h>
 #include <zephyr/drivers/gpio.h>
 
-#define GPIO0 DT_LABEL(DT_NODELABEL(gpio0))
+#define GPIO0 DT_NODELABEL(gpio0)
 #define POWER_LATCH_PIN 31
 
 static int board_sparkfun_thing_plus_nrf9160_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	/* Get the device binding */
-	const struct device *gpio = device_get_binding(GPIO0);
+	/* Get handle of the GPIO device. */
+	const struct device *gpio = DEVICE_DT_GET(GPIO0);
 
-	/* Return if NULL */
-	if (gpio == NULL) {
+	if (!device_is_ready(gpio)) {
 		return -ENODEV;
 	}
 

--- a/boards/arm/thingy52_nrf52832/board.c
+++ b/boards/arm/thingy52_nrf52832/board.c
@@ -12,22 +12,19 @@
 #define CCS_VDD_PWR_CTRL_GPIO_PIN 10
 
 struct pwr_ctrl_cfg {
-	const char *port;
+	const struct device *gpio_dev;
 	uint32_t pin;
 };
 
 static int pwr_ctrl_init(const struct device *dev)
 {
 	const struct pwr_ctrl_cfg *cfg = dev->config;
-	const struct device *gpio;
 
-	gpio = device_get_binding(cfg->port);
-	if (!gpio) {
-		printk("Could not bind device \"%s\"\n", cfg->port);
+	if (!device_is_ready(cfg->gpio_dev)) {
 		return -ENODEV;
 	}
 
-	gpio_pin_configure(gpio, cfg->pin, GPIO_OUTPUT_HIGH);
+	gpio_pin_configure(cfg->gpio_dev, cfg->pin, GPIO_OUTPUT_HIGH);
 
 	k_sleep(K_MSEC(1)); /* Wait for the rail to come up and stabilize */
 
@@ -48,7 +45,7 @@ static int pwr_ctrl_init(const struct device *dev)
 #endif
 
 static const struct pwr_ctrl_cfg vdd_pwr_ctrl_cfg = {
-	.port = DT_LABEL(DT_NODELABEL(gpio0)),
+	.gpio_dev = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
 	.pin = VDD_PWR_CTRL_GPIO_PIN,
 };
 
@@ -68,7 +65,7 @@ DEVICE_DEFINE(vdd_pwr_ctrl_init, "", pwr_ctrl_init, NULL, NULL,
 #endif
 
 static const struct pwr_ctrl_cfg ccs_vdd_pwr_ctrl_cfg = {
-	.port = DT_LABEL(DT_INST(0, semtech_sx1509b)),
+	.gpio_dev = DEVICE_DT_GET(DT_INST(0, semtech_sx1509b)),
 	.pin = CCS_VDD_PWR_CTRL_GPIO_PIN,
 };
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/board.c
+++ b/boards/arm/ubx_bmd345eval_nrf52840/board.c
@@ -18,9 +18,9 @@ static int bmd345_fem_init(const struct device *dev)
 	int ret;
 	const struct device *mode_asel_port_dev;
 
-	mode_asel_port_dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio1)));
+	mode_asel_port_dev = DEVICE_DT_GET(DT_NODELABEL(gpio1));
 
-	if (!mode_asel_port_dev) {
+	if (!device_is_ready(mode_asel_port_dev)) {
 		return -ENODEV;
 	}
 

--- a/boards/xtensa/esp_wrover_kit/board_init.c
+++ b/boards/xtensa/esp_wrover_kit/board_init.c
@@ -16,8 +16,8 @@ static int board_esp_wrover_kit_init(const struct device *dev)
 	ARG_UNUSED(dev);
 	const struct device *gpio;
 
-	gpio = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
-	if (!gpio) {
+	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));
+	if (!device_is_ready(gpio)) {
 		return -ENODEV;
 	}
 

--- a/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
+++ b/boards/xtensa/heltec_wifi_lora32_v2/board_init.c
@@ -14,8 +14,8 @@ static int board_heltec_wifi_lora32_v2_init(const struct device *dev)
 	ARG_UNUSED(dev);
 	const struct device *gpio;
 
-	gpio = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
-	if (!gpio) {
+	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));
+	if (!device_is_ready(gpio)) {
 		return -ENODEV;
 	}
 

--- a/boards/xtensa/odroid_go/board_init.c
+++ b/boards/xtensa/odroid_go/board_init.c
@@ -13,8 +13,8 @@ static int board_odroid_go_init(const struct device *dev)
 	ARG_UNUSED(dev);
 	const struct device *gpio;
 
-	gpio = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
-	if (!gpio) {
+	gpio = DEVICE_DT_GET(DT_NODELABEL(gpio0));
+	if (!device_is_ready(gpio)) {
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
A number of boards utilize device_get_binding(DT_LABEL(...)) to
get a gpio for some purpose.  Switch over to using DEVICE_DT_GET
and device_is_ready() instead.  This is part of the ongoing
cleanup towards phasing out usage of the "label" property in DTS.

Signed-off-by: Kumar Gala <galak@kernel.org>