### PR TITLE
doc: dts: bindings: formalize case and separator

### DIFF
--- a/doc/build/dts/bindings.rst
+++ b/doc/build/dts/bindings.rst
@@ -1011,6 +1011,12 @@ General rules
 
   Do not use any other style for long or multi-line strings.
 
+- Do not use uppercase letters (``A`` through ``Z``) or underscores (``_``) in
+  property names. Use lowercase letters (``a`` through ``z``) instead of
+  uppercase. Use dashes (``-``) instead of underscores. (The one exception to
+  this rule is if you are replicating a well-established binding from somewhere
+  like Linux.)
+
 Vendor prefixes
 ===============
 


### PR DESCRIPTION
It is a general recommendation to use lowercase characters and dashes
in property names instead of uppercase and underscores. Make this a
formal rule for upstream Zephyr bindings.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>