### PR TITLE
scripts: dts: add bus to support multiple bus types

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -355,8 +355,8 @@ def write_bus(node):
     if not bus.label:
         err(f"missing 'label' property on bus node {bus!r}")
 
-    out_comment(f"Bus info (controller: '{bus.path}', type: '{node.on_bus}')")
-    out_dt_define(f"{node.z_path_id}_BUS_{str2ident(node.on_bus)}", 1)
+    out_comment(f"Bus info (controller: '{bus.path}', type: '{node.bounded_bus}')")
+    out_dt_define(f"{node.z_path_id}_BUS_{str2ident(node.bounded_bus)}", 1)
     out_dt_define(f"{node.z_path_id}_BUS", f"DT_{bus.z_path_id}")
 
 
@@ -861,7 +861,7 @@ def write_global_compat_info(edt):
     compat2buses = defaultdict(list)  # just for "okay" nodes
     for compat, okay_nodes in edt.compat2okay.items():
         for node in okay_nodes:
-            bus = node.on_bus
+            bus = node.bounded_bus
             if bus is not None and bus not in compat2buses[compat]:
                 compat2buses[compat].append(bus)
 

--- a/scripts/dts/python-devicetree/tests/test-bindings/bazbar-bus.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/bazbar-bus.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Bazbar bus controller
+
+compatible: "bazbar-bus"
+
+bus: ["baz", "bar"]

--- a/scripts/dts/python-devicetree/tests/test-bindings/device-also-on-bar-bus.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/device-also-on-bar-bus.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Device also on bar bus
+
+compatible: "also-on-bus"
+
+on-bus: "bar"

--- a/scripts/dts/python-devicetree/tests/test-bindings/device-on-baz-bus.yaml
+++ b/scripts/dts/python-devicetree/tests/test-bindings/device-on-baz-bus.yaml
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: BSD-3-Clause
+
+description: Device on baz bus
+
+compatible: "on-bus"
+
+on-bus: "baz"

--- a/scripts/dts/python-devicetree/tests/test.dts
+++ b/scripts/dts/python-devicetree/tests/test.dts
@@ -452,6 +452,15 @@
 				compatible = "on-bus";
 			};
 		};
+		bazbar-bus {
+			compatible = "bazbar-bus";
+			node1 {
+				compatible = "on-bus";
+			};
+			node2 {
+				compatible = "also-on-bus";
+			};
+		};
 		no-bus-node {
 			compatible = "on-any-bus";
 		};

--- a/scripts/dts/python-devicetree/tests/test_edtlib.py
+++ b/scripts/dts/python-devicetree/tests/test_edtlib.py
@@ -15,9 +15,9 @@ from devicetree import edtlib
 #
 # Run it using pytest (https://docs.pytest.org/en/stable/usage.html):
 #
-#   $ pytest testedtlib.py
+#   $ pytest test_edtlib.py
 #
-# See the comment near the top of testdtlib.py for additional pytest advice.
+# See the comment near the top of test_edtlib.py for additional pytest advice.
 #
 # test.dts is the main test file. test-bindings/ and test-bindings-2/ has
 # bindings. The tests mostly use string comparisons via the various __repr__()
@@ -311,6 +311,15 @@ def test_bus():
     assert edt.get_node("/buses/foo-bus/node1/nested").on_bus == "foo"
     assert str(edt.get_node("/buses/foo-bus/node1/nested").binding_path) == \
         hpath("test-bindings/device-on-foo-bus.yaml")
+
+    # Some buses can support other bus types, ensure that the priority is
+    # maintained in the ordering with a device that can support multiple
+    # bus types
+    assert str(edt.get_node("/buses/bazbar-bus/node1").binding_path) == \
+        hpath("test-bindings/device-on-baz-bus.yaml")
+    # ensure that a node with only the latter bus will bind
+    assert str(edt.get_node("/buses/bazbar-bus/node2").binding_path) == \
+        hpath("test-bindings/device-also-on-bar-bus.yaml")
 
 def test_child_binding():
     '''Test 'child-binding:' in bindings'''


### PR DESCRIPTION
Some upcoming buses, such as i3c, have backward compatibility with i2c.
Currently, the bus parameter only supports a single string. This will
be problematic for binding on an i3c bus which can utilize all the
existing i2c drivers and have their on-bus: i2c which won't bind to
something defined as bus: i3c.

bus: would have to be defined as a list (ex. bus: [i3c, i2c]) for
it to bind both i3c and i2c devices. This also leaves support for it to
just be defined as a string. The preference is also encoded in the list
order so if there are bindings for both i3c and i2c, it will choose i3c
as that is first in the list.

Signed-off-by: Ryan McClelland <ryanmcclelland@fb.com>