### PR TITLE
drivers/sensor: Add navigational (GPS/GNSS) channels to API

### DIFF
--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -177,6 +177,17 @@ enum sensor_channel {
 	/** Desired charging current in mA */
 	SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT,
 
+	/** Latitudal position in decimal degrees (0 to +-180) */
+	SENSOR_CHAN_NAV_LATITUDE,
+	/** Longitudal position in decimal degrees (0 to +-180) */
+	SENSOR_CHAN_NAV_LONGITUDE,
+	/** Tracking angle relative to true north pole in decimal degrees (0 to 360) */
+	SENSOR_CHAN_NAV_TRACKING_ANGLE,
+	/** Speed over ground in meters pr second */
+	SENSOR_CHAN_NAV_SPEED,
+	/** Dilution of precision */
+	SENSOR_CHAN_NAV_DOP,
+
 	/** All channels. */
 	SENSOR_CHAN_ALL,
 

--- a/include/zephyr/drivers/sensor.h
+++ b/include/zephyr/drivers/sensor.h
@@ -185,8 +185,8 @@ enum sensor_channel {
 	SENSOR_CHAN_NAV_TRACKING_ANGLE,
 	/** Speed over ground in meters pr second */
 	SENSOR_CHAN_NAV_SPEED,
-	/** Dilution of precision */
-	SENSOR_CHAN_NAV_DOP,
+	/** Accuracy radius in meters within 68% certainty */
+	SENSOR_CHAN_NAV_ACCURACY,
 
 	/** All channels. */
 	SENSOR_CHAN_ALL,


### PR DESCRIPTION
Global positioning sensors are currently not
supported by the sensor API. This addition will
add support for the basic positioning data, using
units which are intuitive and easy to work with.

**The added channels are described here:**

Latitude and longitude. These channels must be
in decimal degrees. A decimal degree is floating
point representation of an angle from 0 to +-180
degrees. These angles can be directly converted
to doubles when computing distances for
example.

Speed over ground in meters pr second,

Altitude in meters above sea level.

Tracking angle in in decimal degrees from 0 to
360, relative to True North (Above earths
rotational axis)

Dilution of precision for position, it can be
determined from HDOP, VDOP, GDOP, PDOP etc.

**How to use the sensor API:**

To check if the sensor has a fix, indicating
that its positional data is valid, the
sensor_sample_fetch() function is used. If the
data is valid, the latest positional data is
updated and 0 is returned. If data is not
valid, an error is returned.

After fetching a sample, the
sensor_channel_get() function is used as usual.

To set the update rate of the positional
sensor, the attribute
SENSOR_ATTR_SAMPLING_FREQUENCY is used. This
allows for power saving by using features like
periodic scanning if a low update rate is
sufficient.

**In defence of the specified units:**

The units used should be SI units, that are
represent-able by a double (signed decimal
number), which in turn can be represented by a
sensor_value struct.

The sensor driver must read, parse, validate
and convert the navigational data to the units
described above.

The application is then tasked with converting
these units to whatever format it needs.

Signed-off-by: Bjarki AA <baa@trackunit.com>