### PR TITLE
manifest: Update nrf_hw_models

### DIFF
--- a/boards/posix/nrf52_bsim/irq_handler.c
+++ b/boards/posix/nrf52_bsim/irq_handler.c
@@ -29,46 +29,6 @@ static struct _isr_list irq_vector_table[NRF_HW_NBR_IRQs];
 
 static int currently_running_irq = -1;
 
-const char *irqnames[] = { /*just for the traces*/
-	"POWER_CLOCK", /*0 */
-	"RADIO",       /*1 */
-	"UART0",       /*2 */
-	"SPI0_TWI0",   /*3 */
-	"SPI1_TWI1",   /*4 */
-	"NFCT",        /*5 */
-	"GPIOTE",      /*6 */
-	"ADC",         /*7 */
-	"TIMER0",      /*8 */
-	"TIMER1",      /*9 */
-	"TIMER2",      /*10*/
-	"RTC0",        /*11*/
-	"TEMP",        /*12*/
-	"RNG",         /*13*/
-	"ECB",         /*14*/
-	"CCM_AAR",     /*15*/
-	"WDT",         /*16*/
-	"RTC1",        /*17*/
-	"QDEC",        /*18*/
-	"LPCOMP",      /*19*/
-	"SWI0",        /*20*/
-	"SWI1",        /*21*/
-	"SWI2",        /*22*/
-	"SWI3",        /*23*/
-	"SWI4",        /*24*/
-	"SWI5",        /*25*/
-	"TIMER3",      /*26*/
-	"TIMER4",      /*27*/
-	"PWM0",        /*28*/
-	"PDM",         /*29*/
-	"MWU",         /*30*/
-	"PWM1",        /*31*/
-	"PWM2",        /*32*/
-	"SPIM2_SPIS2_SPI2", /*33*/
-	"RTC2",        /*34*/
-	"I2S",         /*35*/
-	"FPU"          /*36*/
-};
-
 static inline void vector_to_irq(int irq_nbr, int *may_swap)
 {
 	/**
@@ -83,7 +43,7 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 	}
 
 	bs_trace_raw_time(6, "Vectoring to irq %i (%s)\n", irq_nbr,
-			  irqnames[irq_nbr]);
+			  hw_irq_ctrl_get_name(irq_nbr));
 
 	sys_trace_isr_enter();
 
@@ -109,7 +69,7 @@ static inline void vector_to_irq(int irq_nbr, int *may_swap)
 
 	sys_trace_isr_exit();
 
-	bs_trace_raw_time(7, "Irq %i (%s) ended\n", irq_nbr, irqnames[irq_nbr]);
+	bs_trace_raw_time(7, "Irq %i (%s) ended\n", irq_nbr, hw_irq_ctrl_get_name(irq_nbr));
 }
 
 /**

--- a/west.yml
+++ b/west.yml
@@ -191,7 +191,7 @@ manifest:
       groups:
         - tools
     - name: nrf_hw_models
-      revision: b8cea37dbdc8fc58cc14b4e19fa850877a9da520
+      revision: 93406267eca506003bcb86a86927777a32e729d9
       path: modules/bsim_hw_models/nrf_hw_models
     - name: open-amp
       revision: 8d53544871e1f300c478224faca6be8384ab0d04


### PR DESCRIPTION
Updates the maintainability of the nrf_hw_models. 

As a result, all source files in the nrf52_bsim folder are now free of nrf52832 specific references. Therefore these can in theory be used for other models as well.


