### PR TITLE
bluetooth: audio: pacs: Fix missing `CONFIG_`

### DIFF
--- a/subsys/bluetooth/audio/ascs_internal.h
+++ b/subsys/bluetooth/audio/ascs_internal.h
@@ -45,7 +45,7 @@
 #define BT_ASCS_QOS_FRAMING_UNFRAMED     0x00
 #define BT_ASCS_QOS_FRAMING_FRAMED       0x01
 
-/* Format of the ASE characteristic, defined in Table 4.6 */
+/* Format of the ASE characteristic, defined in Table 4.2 */
 struct bt_ascs_ase_status {
 	uint8_t  id;
 	uint8_t  state;
@@ -66,7 +66,7 @@ struct bt_ascs_codec {
 
 #define BT_ASCS_PD_NO_PREF 0x00000000
 
-/* ASE_State = 0x01 (Codec Configured), defined in Table 4.7. */
+/* ASE_State = 0x01 (Codec Configured), defined in Table 4.3. */
 struct bt_ascs_ase_status_config {
 	uint8_t  framing;
 	uint8_t  phy;
@@ -82,7 +82,7 @@ struct bt_ascs_ase_status_config {
 	struct bt_ascs_codec_config cc[0];
 } __packed;
 
-/* ASE_State = 0x02 (QoS Configured), defined in Table 4.8. */
+/* ASE_State = 0x02 (QoS Configured), defined in Table 4.4. */
 struct bt_ascs_ase_status_qos {
 	uint8_t  cig_id;
 	uint8_t  cis_id;
@@ -95,7 +95,7 @@ struct bt_ascs_ase_status_qos {
 	uint8_t  pd[3];
 } __packed;
 
-/* ASE_Status = 0x03 (Enabling) defined in Table 4.9.
+/* ASE_Status = 0x03 (Enabling) defined in Table 4.5.
  */
 struct bt_ascs_ase_status_enable {
 	uint8_t  cig_id;
@@ -104,7 +104,7 @@ struct bt_ascs_ase_status_enable {
 	uint8_t  metadata[0];
 } __packed;
 
-/* ASE_Status =  0x04 (Streaming) defined in Table 4.9.
+/* ASE_Status =  0x04 (Streaming) defined in Table 4.5.
  */
 struct bt_ascs_ase_status_stream {
 	uint8_t  cig_id;
@@ -113,7 +113,7 @@ struct bt_ascs_ase_status_stream {
 	uint8_t  metadata[0];
 } __packed;
 
-/* ASE_Status = 0x05 (Disabling) as defined in Table 4.9.
+/* ASE_Status = 0x05 (Disabling) as defined in Table 4.5.
  */
 struct bt_ascs_ase_status_disable {
 	uint8_t  cig_id;

--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -456,7 +456,7 @@ BT_GATT_SERVICE_DEFINE(pacs_svc,
 			       snk_loc_write,
 #else
 			       NULL,
-#endif /* BT_PAC_SRC_LOC_WRITEABLE */
+#endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE */
 			       NULL),
 	BT_GATT_CCC(snk_loc_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
@@ -476,11 +476,11 @@ BT_GATT_SERVICE_DEFINE(pacs_svc,
 			       BT_GATT_PERM_READ_ENCRYPT |
 			       BT_GATT_PERM_WRITE_ENCRYPT,
 			       src_loc_read,
-#if defined(BT_PAC_SRC_LOC_WRITEABLE)
+#if defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
 			       src_loc_write,
 #else
 			       NULL,
-#endif /* BT_PAC_SRC_LOC_WRITEABLE */
+#endif /* CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
 			       NULL),
 	BT_GATT_CCC(src_loc_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
@@ -510,7 +510,7 @@ static struct k_work_delayable *bt_pacs_get_work(enum bt_audio_dir dir)
 #if defined(CONFIG_BT_PAC_SRC)
 	case BT_AUDIO_DIR_SOURCE:
 		return &srcs_work;
-#endif /* CONFIG_BT_PAC_SNK */
+#endif /* CONFIG_BT_PAC_SRC */
 	default:
 		return NULL;
 	}
@@ -527,7 +527,7 @@ static struct k_work_delayable *bt_pacs_get_loc_work(enum bt_audio_dir dir)
 #if defined(CONFIG_BT_PAC_SRC)
 	case BT_AUDIO_DIR_SOURCE:
 		return &srcs_loc_work;
-#endif /* CONFIG_BT_PAC_SNK */
+#endif /* CONFIG_BT_PAC_SRC */
 	default:
 		return NULL;
 	}


### PR DESCRIPTION
`BT_PAC_SRC_LOC_WRITEABLE` should be `CONFIG_BT_PAC_SRC_LOC_WRITEABLE`

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>