### PR TITLE
cmake: bintools: gnu: Update GDB executable names for Zephyr SDK 0.15

### DIFF
--- a/cmake/bintools/gnu/target.cmake
+++ b/cmake/bintools/gnu/target.cmake
@@ -30,7 +30,5 @@ if(NOT CMAKE_GDB OR GDB_CFG_ERR)
   endif()
 endif()
 
-find_program(CMAKE_GDB     gdb-multiarch           PATHS ${TOOLCHAIN_HOME}                )
-
 # Include bin tool properties
 include(${ZEPHYR_BASE}/cmake/bintools/gnu/target_bintools.cmake)

--- a/cmake/bintools/gnu/target.cmake
+++ b/cmake/bintools/gnu/target.cmake
@@ -11,7 +11,7 @@ find_program(CMAKE_READELF ${CROSS_COMPILE}readelf PATHS ${TOOLCHAIN_HOME} NO_DE
 find_program(CMAKE_NM      ${CROSS_COMPILE}nm      PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 find_program(CMAKE_STRIP   ${CROSS_COMPILE}strip   PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
-find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb     PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+find_program(CMAKE_GDB     ${CROSS_COMPILE}gdb-py  PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
 
 if(CMAKE_GDB)
   execute_process(
@@ -20,12 +20,13 @@ if(CMAKE_GDB)
     OUTPUT_QUIET
     ERROR_QUIET
     )
-  if (${GDB_CFG_ERR})
-    # Failed to execute GDB, likely because of Python deps
-    find_program(CMAKE_GDB_NO_PY  ${CROSS_COMPILE}gdb-no-py  PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
-    if (CMAKE_GDB_NO_PY)
-      set(CMAKE_GDB ${CMAKE_GDB_NO_PY} CACHE FILEPATH "Path to a program." FORCE)
-    endif()
+endif()
+
+if(NOT CMAKE_GDB OR GDB_CFG_ERR)
+  find_program(CMAKE_GDB_NO_PY ${CROSS_COMPILE}gdb PATHS ${TOOLCHAIN_HOME} NO_DEFAULT_PATH)
+
+  if(CMAKE_GDB_NO_PY)
+    set(CMAKE_GDB ${CMAKE_GDB_NO_PY} CACHE FILEPATH "Path to a program." FORCE)
   endif()
 endif()
 


### PR DESCRIPTION
The Zephyr SDK 0.15.0 release has changed the default GDB executable to
be Python-less and introduced an alternate Python-capable variant
called `gdb-py` (note that the Zephyr SDK previously provided
`gdb-no-py` instead).

This commit updates the CMake toolchain detection routine to attempt
using the Python-capable GDB variant (gdb-py) first and, if it is not
available or fails to launch due to a missing libpython dependency,
use the Python-less GDB variant (gdb).

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Zephyr SDK-side PR: https://github.com/zephyrproject-rtos/crosstool-ng/pull/17 and https://github.com/zephyrproject-rtos/sdk-ng/pull/472

**NOTE: To be merged after Zephyr SDK 0.15.0 is released and the Zephyr minimum required SDK version is set to 0.15.0 and above.**