### PR TITLE
soc: arm: xilinx_zynq7000: add MMU PTEs for all AXI GPIO instances

### DIFF
--- a/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxx/soc.c
@@ -15,6 +15,11 @@
 /* System Level Control Registers (SLCR) */
 #define SLCR_UNLOCK     0x0008
 #define SLCR_UNLOCK_KEY 0xdf0d
+#define AXI_GPIO_MMU_ENTRY(id)\
+	MMU_REGION_FLAT_ENTRY("axigpio",\
+			      DT_REG_ADDR(id),\
+			      DT_REG_SIZE(id),\
+			      MT_DEVICE | MATTR_SHARED | MPERM_R | MPERM_W),
 
 static const struct arm_mmu_region mmu_regions[] = {
 
@@ -67,6 +72,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_SIZE(DT_NODELABEL(psgpio)),
 			      MT_DEVICE | MATTR_SHARED | MPERM_R | MPERM_W),
 #endif
+
+DT_FOREACH_STATUS_OKAY(xlnx_xps_gpio_1_00_a, AXI_GPIO_MMU_ENTRY)
 
 };
 

--- a/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
+++ b/soc/arm/xilinx_zynq7000/xc7zxxxs/soc.c
@@ -15,6 +15,11 @@
 /* System Level Configuration Registers */
 #define SLCR_UNLOCK     0x0008
 #define SLCR_UNLOCK_KEY 0xdf0d
+#define AXI_GPIO_MMU_ENTRY(id)\
+	MMU_REGION_FLAT_ENTRY("axigpio",\
+			      DT_REG_ADDR(id),\
+			      DT_REG_SIZE(id),\
+			      MT_DEVICE | MATTR_SHARED | MPERM_R | MPERM_W),
 
 static const struct arm_mmu_region mmu_regions[] = {
 
@@ -67,6 +72,8 @@ static const struct arm_mmu_region mmu_regions[] = {
 			      DT_REG_SIZE(DT_NODELABEL(psgpio)),
 			      MT_DEVICE | MATTR_SHARED | MPERM_R | MPERM_W),
 #endif
+
+DT_FOREACH_STATUS_OKAY(xlnx_xps_gpio_1_00_a, AXI_GPIO_MMU_ENTRY)
 
 };
 


### PR DESCRIPTION
Add the MMU page table entries for all instances of the Xilinx AXI GPIO controller IP core. Other than any Zynq-7000 peripheral supported so far, the existance of 1..n instances of the IP core within the FPGA part of the SoC is optional. Therefore, other than addressing instances of supported peripherals using their DT nodelabel as has always been the case so far, the data for the MMU page table is added using the DT_FOREACH_STATUS_OKAY macro.

Signed-off-by: Immo Birnbaum <Immo.Birnbaum@weidmueller.com>