### PR TITLE
Add explicit info about supported Ubuntu releases

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -24,7 +24,7 @@ Click the operating system you are using.
 
    .. group-tab:: Ubuntu
 
-      This guide covers Ubuntu version 18.04 LTS and later.
+      This guide covers Ubuntu version 18.04 LTS and 20.04 LTS.
 
       .. code-block:: bash
 


### PR DESCRIPTION
As of 10th June, latest Ubuntu release i.e. 22.04 LTS was not supported.