### PR TITLE
soc: it8xxx2: add soc variants

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81202bx
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81202bx
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 ITE Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_IT81202_BX
+
+config SOC
+	default "it81202bx"
+
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	default y
+
+endif

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81302bx
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81302bx
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 ITE Corporation.
+# SPDX-License-Identifier: Apache-2.0
+
+if SOC_IT81302_BX
+
+config SOC
+	default "it81302bx"
+
+config SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN
+	default n
+
+endif

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -108,4 +108,6 @@ config RISCV_SOC_INTERRUPT_INIT
 
 endif # ITE_IT8XXX2_INTC
 
+source "soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.it81*"
+
 endif # SOC_SERIES_RISCV32_IT8XXX2

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -20,6 +20,18 @@ endchoice
 
 if SOC_IT8XXX2
 
+choice IT8XXX2_SERIES
+	prompt "IT8XXX2 Series"
+	default SOC_IT81302_BX
+
+config SOC_IT81302_BX
+	bool "IT81302 BX version"
+
+config SOC_IT81202_BX
+	bool "IT81202 BX version"
+
+endchoice
+
 config SOC_IT8XXX2_PLL_FLASH_48M
 	bool "Flash frequency is 48MHz"
 	default y


### PR DESCRIPTION
Currently there are two soc variants (IT81202BX and IT81302BX) on
it8xxx2 series. The IT81202BX is 128-pin package (GPIO K and L groups
aren't bonding with pad).
This makes soc variant configurable and apply corresponding configuration
for a soc.

Signed-off-by: Dino Li <Dino.Li@ite.com.tw>