### PR TITLE
Revert "drivers: ethernet: w5500: Toggle reset gpio"

### DIFF
--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -508,7 +508,6 @@ static int w5500_init(const struct device *dev)
 		}
 		gpio_pin_set_dt(&config->reset, 0);
 		k_usleep(500);
-		gpio_pin_set_dt(&config->reset, 1);
 	}
 
 	err = w5500_hw_reset(dev);


### PR DESCRIPTION
This reverts commit 17f8f627896c4189bd2dbe134040b4a6bf5e51c5.

This commit introduces a RTR Read problem

Reverting it fixes #46139