### PR TITLE
storeage/flash_map: Fix typos in flash_area_open documentation

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -118,7 +118,7 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
  * @p ID is unknown, it will be NULL on output.
  *
  * @return  0 on success, -EACCES if the flash_map is not available ,
- * -ENOENT if @p ID is unknown, -EDEV if there is not driver attached
+ * -ENOENT if @p ID is unknown, -ENODEV if there is no driver attached
  * to the area.
  */
 int flash_area_open(uint8_t id, const struct flash_area **fa);


### PR DESCRIPTION
Fixed typos.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>