### PR TITLE
drivers: can: st: improve clock control

### DIFF
--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -6,6 +6,8 @@
  */
 
 #include <zephyr/drivers/can.h>
+#include <zephyr/drivers/clock_control/stm32_clock_control.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/kernel.h>
 #include <soc.h>
@@ -44,6 +46,7 @@ LOG_MODULE_REGISTER(can_stm32fd, CONFIG_CAN_LOG_LEVEL);
 #define DT_DRV_COMPAT st_stm32_fdcan
 
 struct can_stm32fd_config {
+	struct stm32_pclken pclken;
 	void (*config_irq)(void);
 	const struct pinctrl_dev_config *pcfg;
 };
@@ -64,8 +67,12 @@ static int can_stm32fd_get_core_clock(const struct device *dev, uint32_t *rate)
 	return 0;
 }
 
-static void can_stm32fd_clock_enable(void)
+static int can_stm32fd_clock_enable(const struct device *dev)
 {
+	int ret;
+	const struct can_mcan_config *mcan_cfg = dev->config;
+	const struct can_stm32fd_config *stm32fd_cfg = mcan_cfg->custom;
+
 	LL_RCC_SetFDCANClockSource(CAN_STM32FD_CLOCK_SOURCE);
 
 	/* LL_RCC API names do not align with PLL output name but are correct */
@@ -75,11 +82,11 @@ static void can_stm32fd_clock_enable(void)
 	LL_RCC_PLL2_EnableDomain_SAI();
 #endif
 
-#ifdef CONFIG_SOC_SERIES_STM32U5X
-	LL_APB1_GRP2_EnableClock(LL_APB1_GRP2_PERIPH_FDCAN1);
-#else
-	__HAL_RCC_FDCAN_CLK_ENABLE();
-#endif
+	ret = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+			       (clock_control_subsys_t *)&stm32fd_cfg->pclken);
+	if (ret < 0) {
+		return ret;
+	}
 
 	FDCAN_CONFIG->CKDIV = CAN_STM32FD_CLOCK_DIVISOR >> 1;
 }
@@ -97,7 +104,12 @@ static int can_stm32fd_init(const struct device *dev)
 		return ret;
 	}
 
-	can_stm32fd_clock_enable();
+	ret = can_stm32fd_clock_enable(dev);
+	if (ret < 0) {
+		LOG_ERR("Could not turn on CAN clock (%d)", ret);
+		return ret;
+	}
+
 	ret = can_mcan_init(dev);
 	if (ret != 0) {
 		return ret;
@@ -173,6 +185,10 @@ static void config_can_##inst##_irq(void)                                      \
 	PINCTRL_DT_INST_DEFINE(inst);					\
 									\
 	static const struct can_stm32fd_config can_stm32fd_cfg_##inst = { \
+		.pclken = {						\
+			.enr = DT_INST_CLOCKS_CELL(inst, bits),		\
+			.bus = DT_INST_CLOCKS_CELL(inst, bus),		\
+		},							\
 		.config_irq = config_can_##inst##_irq,			\
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),		\
 	};								\

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -369,6 +369,7 @@
 				reg-names = "m_can", "message_ram";
 				interrupts = <21 0>, <22 0>;
 				interrupt-names = "LINE_0", "LINE_1";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 				status = "disabled";
 				label = "CAN_1";
 				sjw = <1>;

--- a/dts/arm/st/g4/stm32g473.dtsi
+++ b/dts/arm/st/g4/stm32g473.dtsi
@@ -96,6 +96,7 @@
 				reg-names = "m_can", "message_ram";
 				interrupts = <88 0>, <89 0>;
 				interrupt-names = "LINE_0", "LINE_1";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 				status = "disabled";
 				label = "CAN_3";
 				sjw = <1>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -438,6 +438,7 @@
 				reg-names = "m_can", "message_ram";
 				interrupts = <39 0>, <40 0>;
 				interrupt-names = "LINE_0", "LINE_1";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 				status = "disabled";
 				label = "CAN_1";
 				sjw = <1>;

--- a/dts/bindings/can/st,stm32-fdcan.yaml
+++ b/dts/bindings/can/st,stm32-fdcan.yaml
@@ -10,3 +10,6 @@ properties:
 
     interrupts:
       required: true
+
+    clocks:
+      required: true


### PR DESCRIPTION
This PR improves the STM32 CAN driver by using the clock control instead of HAL. We should avoid using hard-coded values in HALs, as they bypass Devicetree as a source of hardware description. Also, this practice tends to make code less portable.

Note that there's still one hardcoded register access, `FDCAN_CONFIG`, it can be fixed later.

Found this _issue_ while working on <soc.h> cleanups.