### PR TITLE
net: if: make driver name consistent for DT macros

### DIFF
--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2459,8 +2459,8 @@ struct net_if_api {
 				      api, l2, l2_ctx_type, mtu)	\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
 				   Z_DEVICE_DT_DEV_NAME(node_id),	\
-				   DT_LABEL(node_id), instance,		\
-				   init_fn,				\
+				   DT_PROP_OR(node_id, label, ""),	\
+				   instance, init_fn,			\
 				   pm_action_cb, data, cfg, prio, api,	\
 				   l2, l2_ctx_type, mtu)
 
@@ -2537,7 +2537,7 @@ struct net_if_api {
 #define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, mtu)		\
 	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
-				  DT_PROP_OR(node_id, label, NULL),	\
+				  DT_PROP_OR(node_id, label, ""),	\
 				  init_fn, pm_action_cb, data, cfg,	\
 				  prio, api, mtu)
 


### PR DESCRIPTION
Fixup how the drv_name field is set in NET_DEVICE_DT_OFFLOAD_DEFINE
and NET_DEVICE_DT_DEFINE_INSTANCE to be consistent with
NET_DEVICE_DT_DEFINE.

Signed-off-by: Kumar Gala <galak@kernel.org>