### PR TITLE
drivers: sensor: amg88xx: Update driver to use new driver mechanisms

### DIFF
--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -29,7 +29,7 @@ static int amg88xx_sample_fetch(const struct device *dev,
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
-	if (i2c_burst_read(drv_data->i2c, config->i2c_address,
+	if (i2c_burst_read_dt(&config->i2c,
 			   AMG88XX_OUTPUT_BASE,
 			   (uint8_t *)drv_data->sample,
 			   sizeof(drv_data->sample))) {
@@ -66,11 +66,10 @@ static int amg88xx_channel_get(const struct device *dev,
 
 static int amg88xx_init_device(const struct device *dev)
 {
-	struct amg88xx_data *drv_data = dev->data;
 	const struct amg88xx_config *config = dev->config;
 	uint8_t tmp;
 
-	if (i2c_reg_read_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_read_byte_dt(&config->i2c,
 			      AMG88XX_PCLT, &tmp)) {
 		LOG_ERR("Failed to read Power mode");
 		return -EIO;
@@ -78,8 +77,7 @@ static int amg88xx_init_device(const struct device *dev)
 
 	LOG_DBG("Power mode 0x%02x", tmp);
 	if (tmp != AMG88XX_PCLT_NORMAL_MODE) {
-		if (i2c_reg_write_byte(drv_data->i2c,
-				       config->i2c_address,
+		if (i2c_reg_write_byte_dt(&config->i2c,
 				       AMG88XX_PCLT,
 				       AMG88XX_PCLT_NORMAL_MODE)) {
 			return -EIO;
@@ -87,14 +85,14 @@ static int amg88xx_init_device(const struct device *dev)
 		k_busy_wait(AMG88XX_WAIT_MODE_CHANGE_US);
 	}
 
-	if (i2c_reg_write_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       AMG88XX_RST, AMG88XX_RST_INITIAL_RST)) {
 		return -EIO;
 	}
 
 	k_busy_wait(AMG88XX_WAIT_INITIAL_RESET_US);
 
-	if (i2c_reg_write_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       AMG88XX_FPSC, AMG88XX_FPSC_10FPS)) {
 		return -EIO;
 	}
@@ -106,13 +104,10 @@ static int amg88xx_init_device(const struct device *dev)
 
 int amg88xx_init(const struct device *dev)
 {
-	struct amg88xx_data *drv_data = dev->data;
 	const struct amg88xx_config *config = dev->config;
 
-	drv_data->i2c = device_get_binding(config->i2c_name);
-	if (drv_data->i2c == NULL) {
-		LOG_ERR("Failed to get pointer to %s device!",
-			config->i2c_name);
+	if (!device_is_ready(config->i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
 		return -EINVAL;
 	}
 
@@ -144,8 +139,7 @@ static const struct sensor_driver_api amg88xx_driver_api = {
 };
 
 static const struct amg88xx_config amg88xx_config = {
-	.i2c_name = DT_INST_BUS_LABEL(0),
-	.i2c_address = DT_INST_REG_ADDR(0),
+	.i2c = I2C_DT_SPEC_INST_GET(0),
 #ifdef CONFIG_AMG88XX_TRIGGER
 	.gpio_name = DT_INST_GPIO_LABEL(0, int_gpios),
 	.gpio_pin = DT_INST_GPIO_PIN(0, int_gpios),

--- a/drivers/sensor/amg88xx/amg88xx.c
+++ b/drivers/sensor/amg88xx/amg88xx.c
@@ -141,9 +141,7 @@ static const struct sensor_driver_api amg88xx_driver_api = {
 static const struct amg88xx_config amg88xx_config = {
 	.i2c = I2C_DT_SPEC_INST_GET(0),
 #ifdef CONFIG_AMG88XX_TRIGGER
-	.gpio_name = DT_INST_GPIO_LABEL(0, int_gpios),
-	.gpio_pin = DT_INST_GPIO_PIN(0, int_gpios),
-	.gpio_flags = DT_INST_GPIO_FLAGS(0, int_gpios),
+	.int_gpio = GPIO_DT_SPEC_INST_GET(0, int_gpios),
 #endif
 };
 

--- a/drivers/sensor/amg88xx/amg88xx.h
+++ b/drivers/sensor/amg88xx/amg88xx.h
@@ -69,9 +69,7 @@
 struct amg88xx_config {
 	const struct i2c_dt_spec i2c;
 #ifdef CONFIG_AMG88XX_TRIGGER
-	char *gpio_name;
-	uint8_t gpio_pin;
-	gpio_dt_flags_t gpio_flags;
+	const struct gpio_dt_spec int_gpio;
 #endif
 };
 
@@ -80,8 +78,6 @@ struct amg88xx_data {
 
 #ifdef CONFIG_AMG88XX_TRIGGER
 	const struct device *dev;
-	const struct device *gpio;
-	uint8_t gpio_pin;
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t drdy_handler;

--- a/drivers/sensor/amg88xx/amg88xx.h
+++ b/drivers/sensor/amg88xx/amg88xx.h
@@ -67,17 +67,15 @@
 #define AMG88XX_WAIT_INITIAL_RESET_US	2000
 
 struct amg88xx_config {
-	char *i2c_name;
+	const struct i2c_dt_spec i2c;
 #ifdef CONFIG_AMG88XX_TRIGGER
 	char *gpio_name;
 	uint8_t gpio_pin;
 	gpio_dt_flags_t gpio_flags;
 #endif
-	uint8_t i2c_address;
 };
 
 struct amg88xx_data {
-	const struct device *i2c;
 	int16_t sample[64];
 
 #ifdef CONFIG_AMG88XX_TRIGGER

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -35,7 +35,6 @@ int amg88xx_attr_set(const struct device *dev,
 		     enum sensor_attribute attr,
 		     const struct sensor_value *val)
 {
-	struct amg88xx_data *drv_data = dev->data;
 	const struct amg88xx_config *config = dev->config;
 	int16_t int_level = (val->val1 * 1000000 + val->val2) /
 			  AMG88XX_TREG_LSB_SCALING;
@@ -58,13 +57,13 @@ int amg88xx_attr_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	if (i2c_reg_write_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       intl_reg, (uint8_t)int_level)) {
 		LOG_DBG("Failed to set INTxL attribute!");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       inth_reg, (uint8_t)(int_level >> 8))) {
 		LOG_DBG("Failed to set INTxH attribute!");
 		return -EIO;
@@ -94,7 +93,7 @@ static void amg88xx_thread_cb(const struct device *dev)
 	const struct amg88xx_config *config = dev->config;
 	uint8_t status;
 
-	if (i2c_reg_read_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_read_byte_dt(&config->i2c,
 			      AMG88XX_STAT, &status) < 0) {
 		return;
 	}
@@ -136,7 +135,7 @@ int amg88xx_trigger_set(const struct device *dev,
 	struct amg88xx_data *drv_data = dev->data;
 	const struct amg88xx_config *config = dev->config;
 
-	if (i2c_reg_write_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       AMG88XX_INTC, AMG88XX_INTC_DISABLED)) {
 		return -EIO;
 	}
@@ -153,7 +152,7 @@ int amg88xx_trigger_set(const struct device *dev,
 
 	amg88xx_setup_int(drv_data, true);
 
-	if (i2c_reg_write_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       AMG88XX_INTC, AMG88XX_INTC_ABS_MODE)) {
 		return -EIO;
 	}

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -18,16 +18,14 @@ extern struct amg88xx_data amg88xx_driver;
 #include <zephyr/logging/log.h>
 LOG_MODULE_DECLARE(AMG88XX, CONFIG_SENSOR_LOG_LEVEL);
 
-static inline void amg88xx_setup_int(struct amg88xx_data *drv_data,
+static inline void amg88xx_setup_int(const struct amg88xx_config *cfg,
 				     bool enable)
 {
 	unsigned int flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
 
-	gpio_pin_interrupt_configure(drv_data->gpio,
-				     drv_data->gpio_pin,
-				     flags);
+	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, flags);
 }
 
 int amg88xx_attr_set(const struct device *dev,
@@ -77,8 +75,9 @@ static void amg88xx_gpio_callback(const struct device *dev,
 {
 	struct amg88xx_data *drv_data =
 		CONTAINER_OF(cb, struct amg88xx_data, gpio_cb);
+	const struct amg88xx_config *config = drv_data->dev->config;
 
-	amg88xx_setup_int(drv_data, false);
+	amg88xx_setup_int(config, false);
 
 #if defined(CONFIG_AMG88XX_TRIGGER_OWN_THREAD)
 	k_sem_give(&drv_data->gpio_sem);
@@ -106,7 +105,7 @@ static void amg88xx_thread_cb(const struct device *dev)
 		drv_data->th_handler(dev, &drv_data->th_trigger);
 	}
 
-	amg88xx_setup_int(drv_data, true);
+	amg88xx_setup_int(config, true);
 }
 
 #ifdef CONFIG_AMG88XX_TRIGGER_OWN_THREAD
@@ -140,7 +139,7 @@ int amg88xx_trigger_set(const struct device *dev,
 		return -EIO;
 	}
 
-	amg88xx_setup_int(drv_data, false);
+	amg88xx_setup_int(config, false);
 
 	if (trig->type == SENSOR_TRIG_THRESHOLD) {
 		drv_data->th_handler = handler;
@@ -150,7 +149,7 @@ int amg88xx_trigger_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	amg88xx_setup_int(drv_data, true);
+	amg88xx_setup_int(config, true);
 
 	if (i2c_reg_write_byte_dt(&config->i2c,
 			       AMG88XX_INTC, AMG88XX_INTC_ABS_MODE)) {
@@ -165,24 +164,19 @@ int amg88xx_init_interrupt(const struct device *dev)
 	struct amg88xx_data *drv_data = dev->data;
 	const struct amg88xx_config *config = dev->config;
 
-	/* setup gpio interrupt */
-	drv_data->gpio = device_get_binding(config->gpio_name);
-	if (drv_data->gpio == NULL) {
-		LOG_DBG("Failed to get pointer to %s device!",
-			config->gpio_name);
-		return -EINVAL;
+	if (!device_is_ready(config->int_gpio.port)) {
+		LOG_ERR("%s: device %s is not ready", dev->name,
+				config->int_gpio.port->name);
+		return -ENODEV;
 	}
 
-	drv_data->gpio_pin = config->gpio_pin;
-
-	gpio_pin_configure(drv_data->gpio, config->gpio_pin,
-			   GPIO_INPUT | config->gpio_flags);
+	gpio_pin_configure_dt(&config->int_gpio, GPIO_INPUT | config->int_gpio.dt_flags);
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   amg88xx_gpio_callback,
-			   BIT(config->gpio_pin));
+			   BIT(config->int_gpio.pin));
 
-	if (gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb) < 0) {
+	if (gpio_add_callback(config->int_gpio.port, &drv_data->gpio_cb) < 0) {
 		LOG_DBG("Failed to set gpio callback!");
 		return -EIO;
 	}
@@ -200,7 +194,7 @@ int amg88xx_init_interrupt(const struct device *dev)
 #elif defined(CONFIG_AMG88XX_TRIGGER_GLOBAL_THREAD)
 	drv_data->work.handler = amg88xx_work_cb;
 #endif
-	amg88xx_setup_int(drv_data, true);
+	amg88xx_setup_int(config, true);
 
 	return 0;
 }

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -51,11 +51,10 @@ void print_buffer(void *ptr, size_t l)
 void main(void)
 {
 	int ret;
-	const struct device *dev = device_get_binding(
-				DT_LABEL(DT_INST(0, panasonic_amg88xx)));
+	const struct device *dev = DEVICE_DT_GET_ONE(panasonic_amg88xx);
 
-	if (dev == NULL) {
-		printk("Could not get AMG88XX device\n");
+	if (!device_is_ready(dev)) {
+		printk("sensor: device not ready.\n");
 		return;
 	}
 


### PR DESCRIPTION
Move driver to use gpio_dt_spec and DEVICE_DT_GET for handling access
to bus parent device struct.

Signed-off-by: Kumar Gala <galak@kernel.org>