### PR TITLE
drivers: sensor: adt7420: Update driver to use new driver mechanisms

### DIFF
--- a/drivers/sensor/adt7420/adt7420.c
+++ b/drivers/sensor/adt7420/adt7420.c
@@ -214,9 +214,7 @@ static struct adt7420_data adt7420_driver;
 static const struct adt7420_dev_config adt7420_config = {
 	.i2c = I2C_DT_SPEC_INST_GET(0),
 #ifdef CONFIG_ADT7420_TRIGGER
-	.int_pin = DT_INST_GPIO_PIN(0, int_gpios),
-	.int_flags = DT_INST_GPIO_FLAGS(0, int_gpios),
-	.int_name = DT_INST_GPIO_LABEL(0, int_gpios),
+	.int_gpio = GPIO_DT_SPEC_INST_GET(0, int_gpios),
 #endif
 };
 

--- a/drivers/sensor/adt7420/adt7420.c
+++ b/drivers/sensor/adt7420/adt7420.c
@@ -22,11 +22,9 @@ LOG_MODULE_REGISTER(ADT7420, CONFIG_SENSOR_LOG_LEVEL);
 static int adt7420_temp_reg_read(const struct device *dev, uint8_t reg,
 				 int16_t *val)
 {
-	struct adt7420_data *drv_data = dev->data;
 	const struct adt7420_dev_config *cfg = dev->config;
 
-	if (i2c_burst_read(drv_data->i2c, cfg->i2c_addr,
-			   reg, (uint8_t *) val, 2) < 0) {
+	if (i2c_burst_read_dt(&cfg->i2c, reg, (uint8_t *) val, 2) < 0) {
 		return -EIO;
 	}
 
@@ -38,11 +36,10 @@ static int adt7420_temp_reg_read(const struct device *dev, uint8_t reg,
 static int adt7420_temp_reg_write(const struct device *dev, uint8_t reg,
 				  int16_t val)
 {
-	struct adt7420_data *drv_data = dev->data;
 	const struct adt7420_dev_config *cfg = dev->config;
 	uint8_t buf[3] = {reg, val >> 8, val & 0xFF};
 
-	return i2c_write(drv_data->i2c, buf, sizeof(buf), cfg->i2c_addr);
+	return i2c_write_dt(&cfg->i2c, buf, sizeof(buf));
 }
 
 static int adt7420_attr_set(const struct device *dev,
@@ -50,7 +47,6 @@ static int adt7420_attr_set(const struct device *dev,
 			    enum sensor_attribute attr,
 			    const struct sensor_value *val)
 {
-	struct adt7420_data *drv_data = dev->data;
 	const struct adt7420_dev_config *cfg = dev->config;
 	uint8_t val8, reg = 0U;
 	uint16_t rate;
@@ -75,10 +71,10 @@ static int adt7420_attr_set(const struct device *dev,
 			return -EINVAL;
 		}
 
-		if (i2c_reg_update_byte(drv_data->i2c, cfg->i2c_addr,
-					ADT7420_REG_CONFIG,
-					ADT7420_CONFIG_OP_MODE(~0),
-					ADT7420_CONFIG_OP_MODE(val8)) < 0) {
+		if (i2c_reg_update_byte_dt(&cfg->i2c,
+					   ADT7420_REG_CONFIG,
+					   ADT7420_CONFIG_OP_MODE(~0),
+					   ADT7420_CONFIG_OP_MODE(val8)) < 0) {
 			LOG_DBG("Failed to set attribute!");
 			return -EIO;
 		}
@@ -159,13 +155,11 @@ static const struct sensor_driver_api adt7420_driver_api = {
 
 static int adt7420_probe(const struct device *dev)
 {
-	struct adt7420_data *drv_data = dev->data;
 	const struct adt7420_dev_config *cfg = dev->config;
 	uint8_t value;
 	int ret;
 
-	ret = i2c_reg_read_byte(drv_data->i2c, cfg->i2c_addr,
-				ADT7420_REG_ID, &value);
+	ret = i2c_reg_read_byte_dt(&cfg->i2c, ADT7420_REG_ID, &value);
 	if (ret) {
 		return ret;
 	}
@@ -174,15 +168,15 @@ static int adt7420_probe(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
+	ret = i2c_reg_write_byte_dt(&cfg->i2c,
 			ADT7420_REG_CONFIG, ADT7420_CONFIG_RESOLUTION |
 			ADT7420_CONFIG_OP_MODE(ADT7420_OP_MODE_CONT_CONV));
 	if (ret) {
 		return ret;
 	}
 
-	ret = i2c_reg_write_byte(drv_data->i2c, cfg->i2c_addr,
-				 ADT7420_REG_HIST, CONFIG_ADT7420_TEMP_HYST);
+	ret = i2c_reg_write_byte_dt(&cfg->i2c,
+				    ADT7420_REG_HIST, CONFIG_ADT7420_TEMP_HYST);
 	if (ret) {
 		return ret;
 	}
@@ -205,13 +199,10 @@ static int adt7420_probe(const struct device *dev)
 
 static int adt7420_init(const struct device *dev)
 {
-	struct adt7420_data *drv_data = dev->data;
 	const struct adt7420_dev_config *cfg = dev->config;
 
-	drv_data->i2c = device_get_binding(cfg->i2c_port);
-	if (drv_data->i2c == NULL) {
-		LOG_DBG("Failed to get pointer to %s device!",
-			    cfg->i2c_port);
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
 		return -EINVAL;
 	}
 
@@ -221,8 +212,7 @@ static int adt7420_init(const struct device *dev)
 static struct adt7420_data adt7420_driver;
 
 static const struct adt7420_dev_config adt7420_config = {
-	.i2c_port = DT_INST_BUS_LABEL(0),
-	.i2c_addr = DT_INST_REG_ADDR(0),
+	.i2c = I2C_DT_SPEC_INST_GET(0),
 #ifdef CONFIG_ADT7420_TRIGGER
 	.int_pin = DT_INST_GPIO_PIN(0, int_gpios),
 	.int_flags = DT_INST_GPIO_FLAGS(0, int_gpios),

--- a/drivers/sensor/adt7420/adt7420.h
+++ b/drivers/sensor/adt7420/adt7420.h
@@ -59,7 +59,6 @@
 #define ADT7420_TEMP_SCALE		15625
 
 struct adt7420_data {
-	const struct device *i2c;
 	int16_t sample;
 #ifdef CONFIG_ADT7420_TRIGGER
 	const struct device *gpio;
@@ -82,8 +81,7 @@ struct adt7420_data {
 };
 
 struct adt7420_dev_config {
-	const char *i2c_port;
-	uint16_t i2c_addr;
+	struct i2c_dt_spec i2c;
 #ifdef CONFIG_ADT7420_TRIGGER
 	gpio_pin_t int_pin;
 	gpio_flags_t int_flags;

--- a/drivers/sensor/adt7420/adt7420.h
+++ b/drivers/sensor/adt7420/adt7420.h
@@ -61,7 +61,6 @@
 struct adt7420_data {
 	int16_t sample;
 #ifdef CONFIG_ADT7420_TRIGGER
-	const struct device *gpio;
 	struct gpio_callback gpio_cb;
 
 	sensor_trigger_handler_t th_handler;
@@ -83,9 +82,7 @@ struct adt7420_data {
 struct adt7420_dev_config {
 	struct i2c_dt_spec i2c;
 #ifdef CONFIG_ADT7420_TRIGGER
-	gpio_pin_t int_pin;
-	gpio_flags_t int_flags;
-	const char *int_name;
+	struct gpio_dt_spec int_gpio;
 #endif
 };
 

--- a/drivers/sensor/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adt7420/adt7420_trigger.c
@@ -19,13 +19,12 @@ LOG_MODULE_DECLARE(ADT7420, CONFIG_SENSOR_LOG_LEVEL);
 static void setup_int(const struct device *dev,
 		      bool enable)
 {
-	struct adt7420_data *drv_data = dev->data;
 	const struct adt7420_dev_config *cfg = dev->config;
 	gpio_flags_t flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
 
-	gpio_pin_interrupt_configure(drv_data->gpio, cfg->int_pin, flags);
+	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, flags);
 }
 
 static void handle_int(const struct device *dev)
@@ -60,7 +59,7 @@ static void process_int(const struct device *dev)
 	setup_int(dev, true);
 
 	/* Check for pin that asserted while we were offline */
-	int pv = gpio_pin_get(drv_data->gpio, cfg->int_pin);
+	int pv = gpio_pin_get_dt(&cfg->int_gpio);
 
 	if (pv > 0) {
 		handle_int(dev);
@@ -116,7 +115,7 @@ int adt7420_trigger_set(const struct device *dev,
 		setup_int(dev, true);
 
 		/* Check whether already asserted */
-		int pv = gpio_pin_get(drv_data->gpio, cfg->int_pin);
+		int pv = gpio_pin_get_dt(&cfg->int_gpio);
 
 		if (pv > 0) {
 			handle_int(dev);
@@ -132,24 +131,22 @@ int adt7420_init_interrupt(const struct device *dev)
 	const struct adt7420_dev_config *cfg = dev->config;
 	int rc;
 
-	drv_data->gpio = device_get_binding(cfg->int_name);
-	if (drv_data->gpio == NULL) {
-		LOG_DBG("Failed to get pointer to %s device!",
-			cfg->int_name);
-		return -EINVAL;
+	if (!device_is_ready(cfg->int_gpio.port)) {
+		LOG_ERR("%s: device %s is not ready", dev->name,
+			cfg->int_gpio.port->name);
+		return -ENODEV;
 	}
 
 	gpio_init_callback(&drv_data->gpio_cb,
 			   adt7420_gpio_callback,
-			   BIT(cfg->int_pin));
+			   BIT(cfg->int_gpio.pin));
 
-	rc = gpio_pin_configure(drv_data->gpio, cfg->int_pin,
-				GPIO_INPUT | cfg->int_flags);
+	rc = gpio_pin_configure_dt(&cfg->int_gpio, GPIO_INPUT | cfg->int_gpio.dt_flags);
 	if (rc < 0) {
 		return rc;
 	}
 
-	rc = gpio_add_callback(drv_data->gpio, &drv_data->gpio_cb);
+	rc = gpio_add_callback(cfg->int_gpio.port, &drv_data->gpio_cb);
 	if (rc < 0) {
 		return rc;
 	}

--- a/drivers/sensor/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adt7420/adt7420_trigger.c
@@ -48,8 +48,8 @@ static void process_int(const struct device *dev)
 	uint8_t status;
 
 	/* Clear the status */
-	if (i2c_reg_read_byte(drv_data->i2c, cfg->i2c_addr,
-			      ADT7420_REG_STATUS, &status) < 0) {
+	if (i2c_reg_read_byte_dt(&cfg->i2c,
+				 ADT7420_REG_STATUS, &status) < 0) {
 		return;
 	}
 

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -171,10 +171,10 @@ static void process(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = device_get_binding(DT_LABEL(DT_INST(0, adi_adt7420)));
+	const struct device *dev = DEVICE_DT_GET_ONE(adi_adt7420);
 
-	if (dev == NULL) {
-		printf("Failed to get device binding\n");
+	if (!device_is_ready(dev)) {
+		printk("sensor: device not ready.\n");
 		return;
 	}
 


### PR DESCRIPTION
Move driver to use gpio_dt_spec and DEVICE_DT_GET for handling access
to bus parent device struct.

Signed-off-by: Kumar Gala <galak@kernel.org>