### PR TITLE
drivers: sensor: apds9960: Update driver to use new driver mechanisms

### DIFF
--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -66,7 +66,7 @@ static int apds9960_sample_fetch(const struct device *dev,
 #else
 	tmp = APDS9960_ENABLE_PON | APDS9960_ENABLE_PIEN;
 #endif
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_ENABLE_REG, tmp, tmp)) {
 		LOG_ERR("Power on bit not set.");
 		return -EIO;
@@ -75,21 +75,21 @@ static int apds9960_sample_fetch(const struct device *dev,
 	k_sem_take(&data->data_sem, K_FOREVER);
 #endif
 
-	if (i2c_reg_read_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_read_byte_dt(&config->i2c,
 			      APDS9960_STATUS_REG, &tmp)) {
 		return -EIO;
 	}
 
 	LOG_DBG("status: 0x%x", tmp);
 	if (tmp & APDS9960_STATUS_PINT) {
-		if (i2c_reg_read_byte(data->i2c, config->i2c_address,
+		if (i2c_reg_read_byte_dt(&config->i2c,
 				      APDS9960_PDATA_REG, &data->pdata)) {
 			return -EIO;
 		}
 	}
 
 	if (tmp & APDS9960_STATUS_AINT) {
-		if (i2c_burst_read(data->i2c, config->i2c_address,
+		if (i2c_burst_read_dt(&config->i2c,
 				   APDS9960_CDATAL_REG,
 				   (uint8_t *)&data->sample_crgb,
 				   sizeof(data->sample_crgb))) {
@@ -99,7 +99,7 @@ static int apds9960_sample_fetch(const struct device *dev,
 	}
 
 #ifndef CONFIG_APDS9960_TRIGGER
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_ENABLE_REG,
 				APDS9960_ENABLE_PON,
 				0)) {
@@ -107,7 +107,7 @@ static int apds9960_sample_fetch(const struct device *dev,
 	}
 #endif
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_AICLEAR_REG, 0)) {
 		return -EIO;
 	}
@@ -154,30 +154,29 @@ static int apds9960_channel_get(const struct device *dev,
 static int apds9960_proxy_setup(const struct device *dev)
 {
 	const struct apds9960_config *config = dev->config;
-	struct apds9960_data *data = dev->data;
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_POFFSET_UR_REG,
 			       APDS9960_DEFAULT_POFFSET_UR)) {
 		LOG_ERR("Default offset UR not set ");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_POFFSET_DL_REG,
 			       APDS9960_DEFAULT_POFFSET_DL)) {
 		LOG_ERR("Default offset DL not set ");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_PPULSE_REG,
 			       config->ppcount)) {
 		LOG_ERR("Default pulse count not set ");
 		return -EIO;
 	}
 
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_CONTROL_REG,
 				APDS9960_CONTROL_LDRIVE,
 				APDS9960_DEFAULT_LDRIVE)) {
@@ -185,7 +184,7 @@ static int apds9960_proxy_setup(const struct device *dev)
 		return -EIO;
 	}
 
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_CONFIG2_REG,
 				APDS9960_PLED_BOOST_300,
 				config->pled_boost)) {
@@ -193,26 +192,26 @@ static int apds9960_proxy_setup(const struct device *dev)
 		return -EIO;
 	}
 
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_CONTROL_REG, APDS9960_CONTROL_PGAIN,
 				(config->pgain & APDS9960_PGAIN_8X))) {
 		LOG_ERR("Gain is not set");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_PILT_REG, APDS9960_DEFAULT_PILT)) {
 		LOG_ERR("Low threshold not set");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_PIHT_REG, APDS9960_DEFAULT_PIHT)) {
 		LOG_ERR("High threshold not set");
 		return -EIO;
 	}
 
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_ENABLE_REG, APDS9960_ENABLE_PEN,
 				APDS9960_ENABLE_PEN)) {
 		LOG_ERR("Proximity mode is not enabled");
@@ -226,18 +225,17 @@ static int apds9960_proxy_setup(const struct device *dev)
 static int apds9960_ambient_setup(const struct device *dev)
 {
 	const struct apds9960_config *config = dev->config;
-	struct apds9960_data *data = dev->data;
 	uint16_t th;
 
 	/* ADC value */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_ATIME_REG, APDS9960_DEFAULT_ATIME)) {
 		LOG_ERR("Default integration time not set for ADC");
 		return -EIO;
 	}
 
 	/* ALS Gain */
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_CONTROL_REG,
 				APDS9960_CONTROL_AGAIN,
 				(config->again & APDS9960_AGAIN_64X))) {
@@ -246,7 +244,7 @@ static int apds9960_ambient_setup(const struct device *dev)
 	}
 
 	th = sys_cpu_to_le16(APDS9960_DEFAULT_AILT);
-	if (i2c_burst_write(data->i2c, config->i2c_address,
+	if (i2c_burst_write_dt(&config->i2c,
 			    APDS9960_INT_AILTL_REG,
 			    (uint8_t *)&th, sizeof(th))) {
 		LOG_ERR("ALS low threshold not set");
@@ -254,7 +252,7 @@ static int apds9960_ambient_setup(const struct device *dev)
 	}
 
 	th = sys_cpu_to_le16(APDS9960_DEFAULT_AIHT);
-	if (i2c_burst_write(data->i2c, config->i2c_address,
+	if (i2c_burst_write_dt(&config->i2c,
 			    APDS9960_INT_AIHTL_REG,
 			    (uint8_t *)&th, sizeof(th))) {
 		LOG_ERR("ALS low threshold not set");
@@ -262,7 +260,7 @@ static int apds9960_ambient_setup(const struct device *dev)
 	}
 
 	/* Enable ALS */
-	if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_ENABLE_REG, APDS9960_ENABLE_AEN,
 				APDS9960_ENABLE_AEN)) {
 		LOG_ERR("ALS is not enabled");
@@ -276,10 +274,9 @@ static int apds9960_ambient_setup(const struct device *dev)
 static int apds9960_sensor_setup(const struct device *dev)
 {
 	const struct apds9960_config *config = dev->config;
-	struct apds9960_data *data = dev->data;
 	uint8_t chip_id;
 
-	if (i2c_reg_read_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_read_byte_dt(&config->i2c,
 			      APDS9960_ID_REG, &chip_id)) {
 		LOG_ERR("Failed reading chip id");
 		return -EIO;
@@ -291,52 +288,52 @@ static int apds9960_sensor_setup(const struct device *dev)
 	}
 
 	/* Disable all functions and interrupts */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_ENABLE_REG, 0)) {
 		LOG_ERR("ENABLE register is not cleared");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_AICLEAR_REG, 0)) {
 		return -EIO;
 	}
 
 	/* Disable gesture interrupt */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_GCONFIG4_REG, 0)) {
 		LOG_ERR("GCONFIG4 register is not cleared");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_WTIME_REG, APDS9960_DEFAULT_WTIME)) {
 		LOG_ERR("Default wait time not set");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_CONFIG1_REG,
 			       APDS9960_DEFAULT_CONFIG1)) {
 		LOG_ERR("Default WLONG not set");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_CONFIG2_REG,
 			       APDS9960_DEFAULT_CONFIG2)) {
 		LOG_ERR("Configuration Register Two not set");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_CONFIG3_REG,
 			       APDS9960_DEFAULT_CONFIG3)) {
 		LOG_ERR("Configuration Register Three not set");
 		return -EIO;
 	}
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+	if (i2c_reg_write_byte_dt(&config->i2c,
 			       APDS9960_PERS_REG,
 			       APDS9960_DEFAULT_PERS)) {
 		LOG_ERR("Interrupt persistence not set");
@@ -388,7 +385,7 @@ static int apds9960_init_interrupt(const struct device *dev)
 #ifdef CONFIG_APDS9960_TRIGGER
 	drv_data->work.handler = apds9960_work_cb;
 	drv_data->dev = dev;
-	if (i2c_reg_update_byte(drv_data->i2c, config->i2c_address,
+	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_ENABLE_REG,
 				APDS9960_ENABLE_PON,
 				APDS9960_ENABLE_PON)) {
@@ -413,12 +410,11 @@ static int apds9960_pm_action(const struct device *dev,
 			      enum pm_device_action action)
 {
 	const struct apds9960_config *config = dev->config;
-	struct apds9960_data *data = dev->data;
 	int ret = 0;
 
 	switch (action) {
 	case PM_DEVICE_ACTION_RESUME:
-		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+		if (i2c_reg_update_byte_dt(&config->i2c,
 					APDS9960_ENABLE_REG,
 					APDS9960_ENABLE_PON,
 					APDS9960_ENABLE_PON)) {
@@ -426,13 +422,13 @@ static int apds9960_pm_action(const struct device *dev,
 		}
 		break;
 	case PM_DEVICE_ACTION_SUSPEND:
-		if (i2c_reg_update_byte(data->i2c, config->i2c_address,
+		if (i2c_reg_update_byte_dt(&config->i2c,
 					APDS9960_ENABLE_REG,
 					APDS9960_ENABLE_PON, 0)) {
 			ret = -EIO;
 		}
 
-		if (i2c_reg_write_byte(data->i2c, config->i2c_address,
+		if (i2c_reg_write_byte_dt(&config->i2c,
 				       APDS9960_AICLEAR_REG, 0)) {
 			ret = -EIO;
 		}
@@ -452,11 +448,9 @@ static int apds9960_init(const struct device *dev)
 
 	/* Initialize time 5.7ms */
 	k_sleep(K_MSEC(6));
-	data->i2c = device_get_binding(config->i2c_name);
 
-	if (data->i2c == NULL) {
-		LOG_ERR("Failed to get pointer to %s device!",
-			config->i2c_name);
+	if (!device_is_ready(config->i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
 		return -EINVAL;
 	}
 
@@ -486,8 +480,7 @@ static const struct sensor_driver_api apds9960_driver_api = {
 };
 
 static const struct apds9960_config apds9960_config = {
-	.i2c_name = DT_INST_BUS_LABEL(0),
-	.i2c_address = DT_INST_REG_ADDR(0),
+	.i2c = I2C_DT_SPEC_INST_GET(0),
 	.gpio_name = DT_INST_GPIO_LABEL(0, int_gpios),
 	.gpio_pin = DT_INST_GPIO_PIN(0, int_gpios),
 	.gpio_flags = DT_INST_GPIO_FLAGS(0, int_gpios),

--- a/drivers/sensor/apds9960/apds9960.h
+++ b/drivers/sensor/apds9960/apds9960.h
@@ -213,11 +213,10 @@
 #define APDS9960_DEFAULT_GCONF3		0
 
 struct apds9960_config {
-	char *i2c_name;
+	struct i2c_dt_spec i2c;
 	char *gpio_name;
 	uint8_t gpio_pin;
 	unsigned int gpio_flags;
-	uint8_t i2c_address;
 	uint8_t pgain;
 	uint8_t again;
 	uint8_t ppcount;
@@ -225,7 +224,6 @@ struct apds9960_config {
 };
 
 struct apds9960_data {
-	const struct device *i2c;
 	const struct device *gpio;
 	struct gpio_callback gpio_cb;
 	struct k_work work;

--- a/drivers/sensor/apds9960/apds9960.h
+++ b/drivers/sensor/apds9960/apds9960.h
@@ -214,9 +214,7 @@
 
 struct apds9960_config {
 	struct i2c_dt_spec i2c;
-	char *gpio_name;
-	uint8_t gpio_pin;
-	unsigned int gpio_flags;
+	struct gpio_dt_spec int_gpio;
 	uint8_t pgain;
 	uint8_t again;
 	uint8_t ppcount;
@@ -224,13 +222,11 @@ struct apds9960_config {
 };
 
 struct apds9960_data {
-	const struct device *gpio;
 	struct gpio_callback gpio_cb;
 	struct k_work work;
 	const struct device *dev;
 	uint16_t sample_crgb[4];
 	uint8_t pdata;
-	uint8_t gpio_pin;
 
 #ifdef CONFIG_APDS9960_TRIGGER
 	sensor_trigger_handler_t p_th_handler;
@@ -240,16 +236,14 @@ struct apds9960_data {
 #endif
 };
 
-static inline void apds9960_setup_int(struct apds9960_data *drv_data,
+static inline void apds9960_setup_int(const struct apds9960_config *cfg,
 				      bool enable)
 {
 	unsigned int flags = enable
 		? GPIO_INT_EDGE_TO_ACTIVE
 		: GPIO_INT_DISABLE;
 
-	gpio_pin_interrupt_configure(drv_data->gpio,
-				     drv_data->gpio_pin,
-				     flags);
+	gpio_pin_interrupt_configure_dt(&cfg->int_gpio, flags);
 }
 
 #ifdef CONFIG_APDS9960_TRIGGER

--- a/drivers/sensor/apds9960/apds9960_trigger.c
+++ b/drivers/sensor/apds9960/apds9960_trigger.c
@@ -37,24 +37,21 @@ int apds9960_attr_set(const struct device *dev,
 		      const struct sensor_value *val)
 {
 	const struct apds9960_config *config = dev->config;
-	struct apds9960_data *data = dev->data;
 
 	if (chan == SENSOR_CHAN_PROX) {
 		if (attr == SENSOR_ATTR_UPPER_THRESH) {
-			if (i2c_reg_write_byte(data->i2c,
-					       config->i2c_address,
-					       APDS9960_PIHT_REG,
-					       (uint8_t)val->val1)) {
+			if (i2c_reg_write_byte_dt(&config->i2c,
+						  APDS9960_PIHT_REG,
+						  (uint8_t)val->val1)) {
 				return -EIO;
 			}
 
 			return 0;
 		}
 		if (attr == SENSOR_ATTR_LOWER_THRESH) {
-			if (i2c_reg_write_byte(data->i2c,
-					       config->i2c_address,
-					       APDS9960_PILT_REG,
-					       (uint8_t)val->val1)) {
+			if (i2c_reg_write_byte_dt(&config->i2c,
+						  APDS9960_PILT_REG,
+						  (uint8_t)val->val1)) {
 				return -EIO;
 			}
 
@@ -78,11 +75,10 @@ int apds9960_trigger_set(const struct device *dev,
 	case SENSOR_TRIG_THRESHOLD:
 		if (trig->chan == SENSOR_CHAN_PROX) {
 			data->p_th_handler = handler;
-			if (i2c_reg_update_byte(data->i2c,
-						config->i2c_address,
-						APDS9960_ENABLE_REG,
-						APDS9960_ENABLE_PIEN,
-						APDS9960_ENABLE_PIEN)) {
+			if (i2c_reg_update_byte_dt(&config->i2c,
+						   APDS9960_ENABLE_REG,
+						   APDS9960_ENABLE_PIEN,
+						   APDS9960_ENABLE_PIEN)) {
 				return -EIO;
 			}
 		} else {

--- a/drivers/sensor/apds9960/apds9960_trigger.c
+++ b/drivers/sensor/apds9960/apds9960_trigger.c
@@ -28,7 +28,7 @@ void apds9960_work_cb(struct k_work *work)
 		data->p_th_handler(dev, &data->p_th_trigger);
 	}
 
-	apds9960_setup_int(data, true);
+	apds9960_setup_int(dev->config, true);
 }
 
 int apds9960_attr_set(const struct device *dev,
@@ -69,7 +69,7 @@ int apds9960_trigger_set(const struct device *dev,
 	const struct apds9960_config *config = dev->config;
 	struct apds9960_data *data = dev->data;
 
-	apds9960_setup_int(data, false);
+	apds9960_setup_int(dev->config, false);
 
 	switch (trig->type) {
 	case SENSOR_TRIG_THRESHOLD:
@@ -90,8 +90,8 @@ int apds9960_trigger_set(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	apds9960_setup_int(data, true);
-	if (gpio_pin_get(data->gpio, data->gpio_pin) > 0) {
+	apds9960_setup_int(config, true);
+	if (gpio_pin_get_dt(&config->int_gpio) > 0) {
 		k_work_submit(&data->work);
 	}
 

--- a/samples/sensor/apds9960/src/main.c
+++ b/samples/sensor/apds9960/src/main.c
@@ -30,9 +30,9 @@ void main(void)
 	struct sensor_value intensity, pdata;
 
 	printk("APDS9960 sample application\n");
-	dev = device_get_binding(DT_LABEL(DT_INST(0, avago_apds9960)));
-	if (!dev) {
-		printk("sensor: device not found.\n");
+	dev = DEVICE_DT_GET_ONE(avago_apds9960);
+	if (!device_is_ready(dev)) {
+		printk("sensor: device not ready.\n");
 		return;
 	}
 


### PR DESCRIPTION
Move driver to use gpio_dt_spec and DEVICE_DT_GET for handling access
to bus parent device struct.

Signed-off-by: Kumar Gala <galak@kernel.org>