### PR TITLE
drivers: sensor: ams_iAQcore: Update driver to use DEVICE_DT_GET

### DIFF
--- a/drivers/sensor/ams_iAQcore/iAQcore.c
+++ b/drivers/sensor/ams_iAQcore/iAQcore.c
@@ -23,6 +23,7 @@ static int iaqcore_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
 	struct iaq_core_data *drv_data = dev->data;
+	const struct iaq_core_config *config = dev->config;
 	struct iaq_registers buf;
 	struct i2c_msg msg;
 	int ret, tries;
@@ -35,8 +36,7 @@ static int iaqcore_sample_fetch(const struct device *dev,
 
 	for (tries = 0; tries < CONFIG_IAQ_CORE_MAX_READ_RETRIES; tries++) {
 
-		ret = i2c_transfer(drv_data->i2c, &msg, 1,
-				   DT_INST_REG_ADDR(0));
+		ret = i2c_transfer_dt(&config->i2c, &msg, 1);
 		if (ret < 0) {
 			LOG_ERR("Failed to read registers data [%d].", ret);
 			return -EIO;
@@ -100,13 +100,11 @@ static const struct sensor_driver_api iaq_core_driver_api = {
 
 static int iaq_core_init(const struct device *dev)
 {
-	struct iaq_core_data *drv_data = dev->data;
+	const struct iaq_core_config *config = dev->config;
 
-	drv_data->i2c = device_get_binding(DT_INST_BUS_LABEL(0));
-	if (drv_data->i2c == NULL) {
-		LOG_ERR("Failed to get pointer to %s device!",
-			    DT_INST_BUS_LABEL(0));
-		return -EINVAL;
+	if (!device_is_ready(config->i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
+		return -ENODEV;
 	}
 
 	return 0;
@@ -114,6 +112,10 @@ static int iaq_core_init(const struct device *dev)
 
 static struct iaq_core_data iaq_core_driver;
 
+static const struct iaq_core_config iaq_core_config = {
+	.i2c = I2C_DT_SPEC_INST_GET(0),
+};
+
 DEVICE_DT_INST_DEFINE(0, iaq_core_init, NULL,
-		    &iaq_core_driver, NULL, POST_KERNEL,
+		    &iaq_core_driver, &iaq_core_config, POST_KERNEL,
 		    CONFIG_SENSOR_INIT_PRIORITY, &iaq_core_driver_api);

--- a/drivers/sensor/ams_iAQcore/iAQcore.h
+++ b/drivers/sensor/ams_iAQcore/iAQcore.h
@@ -17,8 +17,11 @@ struct iaq_registers {
 	uint16_t voc;
 } __packed;
 
+struct iaq_core_config {
+	struct i2c_dt_spec i2c;
+};
+
 struct iaq_core_data {
-	const struct device *i2c;
 	uint16_t co2;
 	uint16_t voc;
 	uint8_t status;

--- a/samples/sensor/ams_iAQcore/src/main.c
+++ b/samples/sensor/ams_iAQcore/src/main.c
@@ -14,9 +14,9 @@ void main(void)
 	const struct device *dev;
 	struct sensor_value co2, voc;
 
-	dev = device_get_binding(DT_LABEL(DT_INST(0, ams_iaqcore)));
-	if (!dev) {
-		printk("Failed to get device binding");
+	dev = DEVICE_DT_GET_ONE(ams_iaqcore);
+	if (!device_is_ready(dev)) {
+		printk("sensor: device not ready.\n");
 		return;
 	}
 


### PR DESCRIPTION
Move driver to use DEVICE_DT_GET for handling access to bus parent
device struct.

Signed-off-by: Kumar Gala <galak@kernel.org>