### PR TITLE
dts: arm/arm64: remove DTS 'label' property requirement from gic and …

### DIFF
--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -45,7 +45,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 	};
 
 	uartclk: apb-pclk {
@@ -63,7 +62,6 @@
 			      <0x2f100000 0x200000>; // GICR
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "GIC";
 			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -71,7 +69,6 @@
 			its: msi-controller@2f020000 {
 				compatible = "arm,gic-v3-its";
 				reg = <0x2f020000 0x20000>;
-				label = "ITS";
 				status = "okay";
 			};
 		};

--- a/boards/arm64/xenvm/xenvm.dts
+++ b/boards/arm64/xenvm/xenvm.dts
@@ -54,7 +54,6 @@
 
 	gic: interrupt-controller@3001000 {
 		compatible = "arm,gic";
-		label = "GIC";
 		#interrupt-cells = <0x04>;
 		#address-cells = <0x00>;
 		interrupt-controller;
@@ -67,7 +66,6 @@
 			      GIC_PPI 0x0e IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY
 			      GIC_PPI 0x0b IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 		interrupt-parent = <&gic>;
-		label = "arch_timer";
 	};
 
 	hypervisor: hypervisor@38000000 {

--- a/dts/arm/broadcom/viper-a72.dtsi
+++ b/dts/arm/broadcom/viper-a72.dtsi
@@ -32,7 +32,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 	};
 
 	soc {
@@ -42,7 +41,6 @@
 			      <0x42780000 0x600000>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "GIC";
 			status = "okay";
 		};
 	};

--- a/dts/arm/intel_socfpga_std/socfpga.dtsi
+++ b/dts/arm/intel_socfpga_std/socfpga.dtsi
@@ -115,7 +115,6 @@
 				IRQ_DEFAULT_PRIORITY>;
 			 reg = <0xfffec200 0x1C>;
 			 clocks = <&osc1>;
-			 label = "arch_timer";
 		};
 
 		uart0: serial0@ffc02000 {

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -37,7 +37,6 @@
 			      <0xf1060000 0x20000>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "GIC";
 			status = "okay";
 		};
 

--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -37,7 +37,6 @@
 				     <GIC_PPI 10 IRQ_TYPE_EDGE
 					IRQ_DEFAULT_PRIORITY>;
 			reg = <0xf8f00200 0x1C>;
-			label = "arch_timer";
 		};
 
 		gic: interrupt-controller@f8f01000 {

--- a/dts/arm/xilinx/zynqmp_rpu.dtsi
+++ b/dts/arm/xilinx/zynqmp_rpu.dtsi
@@ -27,7 +27,6 @@
 					<0xf9001000 0x100>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "GIC";
 			status = "okay";
 		};
 	};

--- a/dts/arm64/broadcom/viper-a72.dtsi
+++ b/dts/arm64/broadcom/viper-a72.dtsi
@@ -32,7 +32,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 	};
 
 	soc {
@@ -42,7 +41,6 @@
 			      <0x42780000 0x600000>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "GIC";
 			status = "okay";
 		};
 	};

--- a/dts/arm64/fvp/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp/fvp-aemv8r.dtsi
@@ -48,7 +48,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 	};
 
 	uartclk: apb-pclk {
@@ -66,7 +65,6 @@
 			      <0xaf100000 0x100>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "GIC";
 			status = "okay";
 		};
 

--- a/dts/arm64/intel/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex.dtsi
@@ -41,7 +41,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 26 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 	};
 
 	sysmgr: sysmgr@ffd12000 {

--- a/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
@@ -47,7 +47,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 		interrupt-parent = <&gic>;
 	};
 
@@ -57,7 +56,6 @@
 		      <0x38880000 0xc0000>; /* GICR (RD_base + SGI_base) */
 		interrupt-controller;
 		#interrupt-cells = <4>;
-		label = "GIC";
 		status = "okay";
 	};
 

--- a/dts/arm64/nxp/nxp_imx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_imx8mp_a53.dtsi
@@ -47,7 +47,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 		interrupt-parent = <&gic>;
 	};
 
@@ -57,7 +56,6 @@
 		      <0x38880000 0xc0000>; /* GICR (RD_base + SGI_base) */
 		interrupt-controller;
 		#interrupt-cells = <4>;
-		label = "GIC";
 		status = "okay";
 	};
 

--- a/dts/arm64/nxp/nxp_ls1046a.dtsi
+++ b/dts/arm64/nxp/nxp_ls1046a.dtsi
@@ -43,7 +43,6 @@
 		      <0x0142f000 0x1000>; /* GICC */
 		interrupt-controller;
 		#interrupt-cells = <4>;
-			label = "GIC";
 		status = "okay";
 	};
 
@@ -68,7 +67,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 	};
 
 	uart1: serial@21c0600 {

--- a/dts/arm64/qemu/qemu-virt-a53.dtsi
+++ b/dts/arm64/qemu/qemu-virt-a53.dtsi
@@ -49,7 +49,6 @@
 			      IRQ_DEFAULT_PRIORITY>,
 			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
-		label = "arch_timer";
 	};
 
 	uartclk: apb-pclk {
@@ -71,7 +70,6 @@
 			      <0x00 0x80a0000 0x00 0xf60000>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "GIC";
 			status = "okay";
 		};
 

--- a/dts/bindings/interrupt-controller/arm,gic-v3-its.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic-v3-its.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/interrupt-controller/arm,gic.yaml
+++ b/dts/bindings/interrupt-controller/arm,gic.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
 interrupt-cells:
   - type
   - irq

--- a/dts/bindings/timer/arm,armv8-timer.yaml
+++ b/dts/bindings/timer/arm,armv8-timer.yaml
@@ -7,6 +7,3 @@ include: base.yaml
 properties:
     interrupts:
       required: true
-
-    label:
-      required: true


### PR DESCRIPTION
…timer

The armv8 timer, arm gic, and arm gic-v3-its don't use or need the devicetree
label property.  Update the dts bindings to not require it and remove setting of
the label property in dts files.

Signed-off-by: Kumar Gala <galak@kernel.org>