### PR TITLE
MAINTAINERS: add myself as collaborator for logging and cbprintf

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1069,6 +1069,8 @@ Formatted Output:
     status: maintained
     maintainers:
       - nordic-krch
+    collaborators:
+      - dcpleung
     files:
       - include/zephyr/sys/cbprintf*
       - tests/unit/cbprintf/
@@ -1173,6 +1175,7 @@ Logging:
     collaborators:
         - chen-png
         - aasthagr
+        - dcpleung
     files:
         - include/zephyr/logging/
         - samples/subsys/logging/


### PR DESCRIPTION
Adding myself as collaborator for both logging and cbprintf so that
I get notifications when PRs are submitted against them.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>