### PR TITLE
pm: Fix possible assert and unnecessary check

### DIFF
--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -22,6 +22,9 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pm, CONFIG_PM_LOG_LEVEL);
 
+#define CURRENT_CPU \
+	(COND_CODE_1(CONFIG_SMP, (arch_curr_cpu()->id), (_current_cpu->id)))
+
 static ATOMIC_DEFINE(z_post_ops_required, CONFIG_MP_NUM_CPUS);
 static sys_slist_t pm_notifiers = SYS_SLIST_STATIC_INIT(&pm_notifiers);
 
@@ -161,7 +164,7 @@ static inline void pm_state_notify(bool entering_state)
 
 void pm_system_resume(void)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = CURRENT_CPU;
 
 	/*
 	 * This notification is called from the ISR of the event

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -202,7 +202,7 @@ bool pm_state_force(uint8_t cpu, const struct pm_state_info *info)
 
 bool pm_system_suspend(int32_t ticks)
 {
-	uint8_t id = _current_cpu->id;
+	uint8_t id = CURRENT_CPU;
 	k_spinlock_key_t key;
 
 	SYS_PORT_TRACING_FUNC_ENTER(pm, system_suspend, ticks);


### PR DESCRIPTION
`pm_system_resume()` can be called from the idle thread with interruptions unmasked. In this situation, `_current_cpu` will call
`z_smp_cpu_mobile()` that will return true and cause an assert.

`pm_system_suspend() `is called from the idle thread (each cpu has its own) and  with locked this check is redundant. Just use
`arch_curr_cpu()` to avoid it.