### PR TITLE
bluetooth: host: Revert "bluetooth: host: Avoid sending duplicate dev…

### DIFF
--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3911,22 +3911,16 @@ static uint8_t smp_ident_addr_info(struct bt_smp *smp, struct net_buf *buf)
 		return BT_SMP_ERR_INVALID_PARAMS;
 	}
 
-	struct bt_keys *keys = bt_keys_find_addr(conn->id, &req->addr);
+	if (bt_addr_le_cmp(&conn->le.dst, &req->addr) != 0) {
+		struct bt_keys *keys = bt_keys_find_addr(conn->id, &req->addr);
 
-	if (keys) {
-		if (bt_addr_le_cmp(&conn->le.dst, &req->addr) != 0) {
+		if (keys) {
 			if (!update_keys_check(smp, keys)) {
 				return BT_SMP_ERR_UNSPECIFIED;
 			}
-		}
 
-		/* We found a key for this address.  We don't know if it has been added
-		 * to resolving list before.  Clear the key - because if we try to add
-		 * the same item to resolving list, controller have the option to
-		 * accept or reject the command.
-		 * Refer to Core v5.3, Vol 4, Part E, 7.8.38.
-		 */
-		bt_keys_clear(keys);
+			bt_keys_clear(keys);
+		}
 	}
 
 	if (atomic_test_bit(smp->flags, SMP_FLAG_BOND)) {


### PR DESCRIPTION
…ice to resolving list."

This reverts commit e11ff7df48bce7c98b05ff1626448cd8ab3d82c0.
This patch causes some PTS failure (see https://github.com/zephyrproject-rtos/zephyr/pull/45510#issuecomment-1153606013)
Another patch to address duplicate device will follow.

Fixes #46602.