### PR TITLE
Bluetooth: Controller: Fix missing reset of coded PHY scanning

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -4007,8 +4007,9 @@ static void le_ext_create_connection(struct net_buf *buf, struct net_buf **evt)
 			uint8_t type;
 
 			type = (phy << 1);
-			/* NOTE: Pass invalid interval value to not start
-			 *       scanning using this scan instance.
+			/* NOTE: Pass invalid interval value to reset the PHY
+			 *       value in the scan instance so not to start
+			 *       scanning on the unselected PHY.
 			 */
 			status = ll_scan_params_set(type, 0, 0, 0, 0);
 		}

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -325,6 +325,14 @@ int ull_scan_reset(void)
 
 	for (handle = 0U; handle < BT_CTLR_SCAN_SET; handle++) {
 		(void)disable(handle);
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		/* Initialize PHY value to 0 to not start scanning on the scan
+		 * instance if an explicit ll_scan_params_set() has not been
+		 * invoked from HCI to enable scanning on that PHY.
+		 */
+		ll_scan[handle].lll.phy = 0U;
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
 	}
 
 	if (IS_ENABLED(CONFIG_BT_CTLR_ADV_EXT)) {


### PR DESCRIPTION
When switching from Extended Scanning by Extended
Advertising HCI commands back to Legacy Scanning after a
HCI reset it is required that the coded PHY scanning
context is reset.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>