### PR TITLE
Remove redundant <zephyr/zephyr.h> includes

### DIFF
--- a/drivers/adc/adc_emul.c
+++ b/drivers/adc/adc_emul.c
@@ -18,7 +18,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/zephyr.h>
 
 LOG_MODULE_REGISTER(adc_emul, CONFIG_ADC_LOG_LEVEL);
 

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -16,7 +16,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/crc.h>
-#include <zephyr/zephyr.h>
 
 #define LOG_LEVEL CONFIG_ADC_LOG_LEVEL
 #include <zephyr/logging/log.h>

--- a/drivers/adc/adc_mcp320x.c
+++ b/drivers/adc/adc_mcp320x.c
@@ -16,7 +16,6 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/sys/util.h>
-#include <zephyr/zephyr.h>
 
 LOG_MODULE_REGISTER(adc_mcp320x, CONFIG_ADC_LOG_LEVEL);
 

--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/i2c.h>
 #include <zephyr/drivers/dac.h>

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -12,7 +12,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>

--- a/drivers/interrupt_controller/intc_intel_vtd.c
+++ b/drivers/interrupt_controller/intc_intel_vtd.c
@@ -15,7 +15,6 @@
 #include <zephyr/init.h>
 #include <string.h>
 
-#include <zephyr/zephyr.h>
 
 #include <zephyr/cache.h>
 

--- a/drivers/interrupt_controller/intc_vexriscv_litex.c
+++ b/drivers/interrupt_controller/intc_vexriscv_litex.c
@@ -11,7 +11,6 @@
 #include <zephyr/init.h>
 #include <zephyr/irq.h>
 #include <zephyr/device.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/types.h>
 
 #define IRQ_MASK		DT_REG_ADDR_BY_NAME(DT_INST(0, vexriscv_intc0), irq_mask)

--- a/drivers/modem/quectel-bg9x.h
+++ b/drivers/modem/quectel-bg9x.h
@@ -10,7 +10,6 @@
 #include <zephyr/kernel.h>
 #include <ctype.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>

--- a/drivers/modem/simcom-sim7080.h
+++ b/drivers/modem/simcom-sim7080.h
@@ -11,7 +11,6 @@
 #include <ctype.h>
 #include <inttypes.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/modem/simcom-sim7080.h>
 #include <zephyr/device.h>

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -12,7 +12,6 @@ LOG_MODULE_REGISTER(modem_ublox_sara_r4, CONFIG_MODEM_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <ctype.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -13,7 +13,6 @@ LOG_MODULE_REGISTER(wifi_esp_at, CONFIG_WIFI_LOG_LEVEL);
 #include <zephyr/kernel.h>
 #include <ctype.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/device.h>
 #include <zephyr/init.h>
 #include <stdlib.h>

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -8,7 +8,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(wifi_esp_at_offload, CONFIG_WIFI_LOG_LEVEL);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/drivers/wifi/eswifi/eswifi.h
+++ b/drivers/wifi/eswifi/eswifi.h
@@ -7,7 +7,6 @@
 #ifndef ZEPHYR_DRIVERS_WIFI_ESWIFI_ESWIFI_H_
 #define ZEPHYR_DRIVERS_WIFI_ESWIFI_ESWIFI_H_
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <stdio.h>
 #include <zephyr/kernel_structs.h>

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -8,7 +8,6 @@
 #include "eswifi_log.h"
 LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/drivers/wifi/eswifi/eswifi_bus_uart.c
+++ b/drivers/wifi/eswifi/eswifi_bus_uart.c
@@ -10,7 +10,6 @@
 #include "eswifi_log.h"
 LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -13,7 +13,6 @@
 #include "eswifi_log.h"
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/drivers/wifi/eswifi/eswifi_offload.c
+++ b/drivers/wifi/eswifi/eswifi_offload.c
@@ -7,7 +7,6 @@
 #include "eswifi_log.h"
 LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/drivers/wifi/eswifi/eswifi_socket.c
+++ b/drivers/wifi/eswifi/eswifi_socket.c
@@ -7,7 +7,6 @@
 #include "eswifi_log.h"
 LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/drivers/wifi/eswifi/eswifi_socket_offload.c
+++ b/drivers/wifi/eswifi/eswifi_socket_offload.c
@@ -7,7 +7,6 @@
 #include "eswifi_log.h"
 LOG_MODULE_DECLARE(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <string.h>

--- a/drivers/wifi/simplelink/simplelink.c
+++ b/drivers/wifi/simplelink/simplelink.c
@@ -7,7 +7,6 @@
 #include "simplelink_log.h"
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/net/net_if.h>

--- a/drivers/wifi/winc1500/wifi_winc1500.c
+++ b/drivers/wifi/winc1500/wifi_winc1500.c
@@ -10,7 +10,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/device.h>

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -11,7 +11,6 @@
  * This module contains routines that are used to initialize the kernel.
  */
 
-#include <zephyr/zephyr.h>
 #include <offsets_short.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>

--- a/kernel/xip.c
+++ b/kernel/xip.c
@@ -6,7 +6,6 @@
  */
 
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <kernel_internal.h>
 #include <zephyr/linker/linker-defs.h>

--- a/samples/application_development/code_relocation/src/main.c
+++ b/samples/application_development/code_relocation/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 

--- a/samples/application_development/code_relocation_nocopy/src/main.c
+++ b/samples/application_development/code_relocation_nocopy/src/main.c
@@ -5,7 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/sys/printk.h>
 #include <zephyr/device.h>

--- a/samples/drivers/uart/stm32/single_wire/src/main.c
+++ b/samples/drivers/uart/stm32/single_wire/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
 #include <zephyr/devicetree.h>

--- a/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v1/philosophers/src/main.c
@@ -29,7 +29,6 @@
  */
 #include <zephyr/kernel.h>
 #include <cmsis_os.h>
-#include <zephyr/zephyr.h>
 
 #if defined(CONFIG_STDOUT_CONSOLE)
 #include <stdio.h>

--- a/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
+++ b/samples/subsys/portability/cmsis_rtos_v2/philosophers/src/main.c
@@ -28,7 +28,6 @@
  * header file.
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <cmsis_os2.h>
 #include <zephyr/sys/printk.h>

--- a/soc/riscv/riscv-ite/common/power.c
+++ b/soc/riscv/riscv-ite/common/power.c
@@ -7,7 +7,6 @@
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <zephyr/zephyr.h>
 
 /* Handle when enter deep doze mode. */
 static void ite_power_soc_deep_doze(void)

--- a/subsys/mgmt/osdp/src/osdp.c
+++ b/subsys/mgmt/osdp/src/osdp.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/device.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/timeout_q.h>
 #include <zephyr/init.h>

--- a/tests/benchmarks/footprints/src/footprint.h
+++ b/tests/benchmarks/footprints/src/footprint.h
@@ -8,7 +8,6 @@
 #define _FOOTPRINT_H_
 
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/app_memory/app_memdomain.h>
 
 K_THREAD_STACK_EXTERN(my_stack_area);

--- a/tests/benchmarks/footprints/src/heap.c
+++ b/tests/benchmarks/footprints/src/heap.c
@@ -11,7 +11,6 @@
  *
  */
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <ksched.h>
 
 #include "footprint.h"

--- a/tests/benchmarks/footprints/src/libc.c
+++ b/tests/benchmarks/footprints/src/libc.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <ksched.h>
 
 #include "footprint.h"

--- a/tests/benchmarks/footprints/src/main.c
+++ b/tests/benchmarks/footprints/src/main.c
@@ -11,7 +11,6 @@
  *
  */
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <ksched.h>
 #include <zephyr/sys/libc-hooks.h>
 #include "footprint.h"

--- a/tests/benchmarks/footprints/src/mutex.c
+++ b/tests/benchmarks/footprints/src/mutex.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 
 #include "footprint.h"
 

--- a/tests/benchmarks/footprints/src/semaphore.c
+++ b/tests/benchmarks/footprints/src/semaphore.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <ksched.h>
 
 #include "footprint.h"

--- a/tests/benchmarks/footprints/src/system_thread.c
+++ b/tests/benchmarks/footprints/src/system_thread.c
@@ -11,7 +11,6 @@
  *
  */
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <ksched.h>
 
 #include "footprint.h"

--- a/tests/benchmarks/footprints/src/timer.c
+++ b/tests/benchmarks/footprints/src/timer.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <ksched.h>
 
 #include "footprint.h"

--- a/tests/benchmarks/footprints/src/userspace.c
+++ b/tests/benchmarks/footprints/src/userspace.c
@@ -10,7 +10,6 @@
  *
  */
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <ksched.h>
 #include <zephyr/syscall_handler.h>
 #include <zephyr/app_memory/app_memdomain.h>

--- a/tests/benchmarks/footprints/src/workq.c
+++ b/tests/benchmarks/footprints/src/workq.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/kernel.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/syscall_handler.h>
 
 #include "footprint.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect1.c
@@ -14,7 +14,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/sys/printk.h>
 
 #include <zephyr/bluetooth/bluetooth.h>

--- a/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_app/src/test_connect2.c
@@ -14,7 +14,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/sys/printk.h>
 
 #include <zephyr/bluetooth/bluetooth.h>

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/common.h
@@ -20,7 +20,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/sys_clock.h>
 
 #include <zephyr/bluetooth/bluetooth.h>

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt_notif/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt_notif/src/common.h
@@ -16,7 +16,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bluetooth/bsim_bt/bsim_test_gatt/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_gatt/src/common.h
@@ -16,7 +16,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bluetooth/bsim_bt/bsim_test_gatt_caching/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_gatt_caching/src/common.h
@@ -17,7 +17,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/mesh_test.h
@@ -19,7 +19,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/sys/printk.h>
 
 #include <zephyr/bluetooth/bluetooth.h>

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/settings_test_backend.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/settings_test_backend.c
@@ -12,7 +12,6 @@
 #include <zephyr/kernel.h>
 #include "zephyr/types.h"
 #include "errno.h"
-#include <zephyr/zephyr.h>
 
 #include <zephyr/bluetooth/mesh.h>
 #include "argparse.h"

--- a/tests/bluetooth/bsim_bt/bsim_test_notify/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_notify/src/common.h
@@ -16,7 +16,6 @@
 #include <zephyr/types.h>
 #include <stddef.h>
 #include <errno.h>
-#include <zephyr/zephyr.h>
 
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>

--- a/tests/boards/altera_max10/qspi/src/qspi_flash.c
+++ b/tests/boards/altera_max10/qspi/src/qspi_flash.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/device.h>

--- a/tests/kernel/mp/src/main.c
+++ b/tests/kernel/mp/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <tc_util.h>
 #include <ztest.h>
 #include <zephyr/kernel.h>

--- a/tests/kernel/pending/src/main.c
+++ b/tests/kernel/pending/src/main.c
@@ -5,7 +5,6 @@
  */
 
 #include <tc_util.h>
-#include <zephyr/zephyr.h>
 #include <ztest.h>
 #include <zephyr/kernel.h>
 #include <zephyr/kernel_structs.h>

--- a/tests/kernel/sched/metairq/src/main.c
+++ b/tests/kernel/sched/metairq/src/main.c
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr/zephyr.h>
 #include <ztest.h>
 #include <zephyr/kernel.h>
 

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <tc_util.h>
 #include <ztest.h>
 #include <zephyr/kernel.h>

--- a/tests/kernel/spinlock/src/main.c
+++ b/tests/kernel/spinlock/src/main.c
@@ -3,7 +3,6 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr/zephyr.h>
 #include <tc_util.h>
 #include <ztest.h>
 #include <zephyr/kernel.h>

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/sys/printk.h>
-#include <zephyr/zephyr.h>
 #include <zephyr/types.h>
 #include <zephyr/pm/device.h>
 #include <zephyr/pm/device_runtime.h>

--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
 #include <zephyr/kernel.h>
 #include <ztest.h>
 #include <zephyr/pm/pm.h>


### PR DESCRIPTION
Files including <zephyr/kernel.h> do not have to include
<zephyr/zephyr.h>, a shim to <zephyr/kernel.h>.

Changes have been scripted:

```python
from pathlib import Path
import re

for p in Path(".").glob("**/*"):
    if not p.is_file() or not p.suffix or p.suffix[1:] not in ("c", "cpp", "h"):
        continue

    with open(p) as f:
        lines = f.readlines()

    zephyr_index = -1
    has_zephyr = False
    has_kernel = False
    for i, line in enumerate(lines):
        m = re.match(r"^.*#include <zephyr/zephyr\.h>.*$", line)
        if m:
            has_zephyr = True
            zephyr_index = i
        m = re.match(r"^.*#include <zephyr/kernel\.h>.*$", line)
        if m:
            has_kernel = True

    if has_zephyr and has_kernel and zephyr_index >= 0:
        del lines[zephyr_index]
        with open(p, "w") as f:
            f.write("".join(lines))
```