### PR TITLE
Bluetooth: Controller: Fix Extended Scan Address Resolution

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1721,8 +1721,10 @@ uint32_t radio_ar_has_match(void)
 	return 0U;
 }
 
-void radio_ar_resolve(const uint8_t *addr)
+uint8_t radio_ar_resolve(const uint8_t *addr)
 {
+	uint8_t retval;
+
 	NRF_AAR->ENABLE = (AAR_ENABLE_ENABLE_Enabled << AAR_ENABLE_ENABLE_Pos) &
 			  AAR_ENABLE_ENABLE_Msk;
 
@@ -1748,8 +1750,13 @@ void radio_ar_resolve(const uint8_t *addr)
 
 	NVIC_ClearPendingIRQ(nrfx_get_irq_number(NRF_AAR));
 
+	retval = (NRF_AAR->EVENTS_RESOLVED && !NRF_AAR->EVENTS_NOTRESOLVED) ?
+		 1U : 0U;
+
 	NRF_AAR->ENABLE = (AAR_ENABLE_ENABLE_Disabled << AAR_ENABLE_ENABLE_Pos) &
 			  AAR_ENABLE_ENABLE_Msk;
+
+	return retval;
 
 }
 #endif /* CONFIG_BT_CTLR_PRIVACY */

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.h
@@ -163,7 +163,7 @@ void radio_ar_configure(uint32_t nirk, void *irk, uint8_t flags);
 uint32_t radio_ar_match_get(void);
 void radio_ar_status_reset(void);
 uint32_t radio_ar_has_match(void);
-void radio_ar_resolve(const uint8_t *addr);
+uint8_t radio_ar_resolve(const uint8_t *addr);
 
 /* Enables CTE inline configuration to automatically setup sampling and
  * switching according to CTEInfo in received PDU.

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -392,8 +392,7 @@ bool lll_scan_aux_addr_match_get(const struct lll_scan *lll,
 
 			(void)ull_filter_lll_irks_get(&count);
 			if (count) {
-				radio_ar_resolve(adva);
-				*irkmatch_ok = radio_ar_has_match();
+				*irkmatch_ok = radio_ar_resolve(adva);
 				*irkmatch_id = radio_ar_match_get();
 			}
 		}


### PR DESCRIPTION
Fix Extended Scanning Address Resolution that incorrectly
checked for Bit Count Comparison which is not to be checked
when explicit resolution is performed in the Rx ISR.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>