### PR TITLE
Bluetooth: Controller: Fix missing PDU next pointer initialization

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -266,6 +266,10 @@ int lll_adv_data_init(struct lll_adv_pdu *pdu)
 		return -ENOMEM;
 	}
 
+#if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)
+	PDU_ADV_NEXT_PTR(p) = NULL;
+#endif /* CONFIG_BT_CTLR_ADV_PDU_LINK */
+
 	p->len = 0U;
 	pdu->pdu[0] = (void *)p;
 
@@ -518,6 +522,10 @@ int lll_adv_and_extra_data_init(struct lll_adv_pdu *pdu)
 	if (!p) {
 		return -ENOMEM;
 	}
+
+#if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)
+	PDU_ADV_NEXT_PTR(p) = NULL;
+#endif /* CONFIG_BT_CTLR_ADV_PDU_LINK */
 
 	pdu->pdu[0] = (void *)p;
 


### PR DESCRIPTION
When supporting chain PDUs, after HCI reset the first PDU
allocated did not initialize its next pointer causing use
of unallocated PDUs for chaining while a duplicate of such
PDU buffer being allocated for other states/roles. This
causes in certain cases both Extended and Periodic PDUs
having same data, the Extended Advertising PDU being
transmitted at the instant of the Periodic Advertising.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>