### PR TITLE
Bluetooth: Controller: Fix radio_tmr_start_now for incorrect start time

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1206,13 +1206,14 @@ uint32_t radio_tmr_start_now(uint8_t trx)
 		start = (now << 1) - start;
 
 		/* Setup compare event with min. 1 us offset */
+		EVENT_TIMER->EVENTS_COMPARE[0] = 0U;
 		nrf_timer_cc_set(EVENT_TIMER, 0, start + 1);
 
 		/* Capture the current time */
 		nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_CAPTURE1);
 
 		now = EVENT_TIMER->CC[1];
-	} while (now > start);
+	} while ((now > start) && (EVENT_TIMER->EVENTS_COMPARE[0] == 0U));
 
 	return start + 1;
 }


### PR DESCRIPTION
Fix radio_tmr_start_now from returning delayed start time
under race conditions where the capture time has elapsed but
the compare has triggered at the same time.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>