### PR TITLE
manifest: Update hal_nordic revision

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -86,7 +86,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d9e50d7287fc381792f6f2ee6d37093e036fbd10
+      revision: d892b442b0c74a33ffbbff0ed2a2c2122b4d3925
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Pull in a fix in the nrfx_qspi driver for a problem with incorrect
status returned by `nrfx_qspi_mem_busy_check()`.

Fixes #46285.