### PR TITLE
modules: hal_nordic: Adapt nrfx_busy_wait() for !SYS_CLOCK_EXISTS case

### DIFF
--- a/modules/hal_nordic/nrfx/nrfx_glue.c
+++ b/modules/hal_nordic/nrfx/nrfx_glue.c
@@ -6,6 +6,7 @@
 
 #include <nrfx.h>
 #include <zephyr/kernel.h>
+#include <soc/nrfx_coredep.h>
 
 void nrfx_isr(const void *irq_handler)
 {
@@ -14,7 +15,11 @@ void nrfx_isr(const void *irq_handler)
 
 void nrfx_busy_wait(uint32_t usec_to_wait)
 {
-	k_busy_wait(usec_to_wait);
+	if (IS_ENABLED(CONFIG_SYS_CLOCK_EXISTS)) {
+		k_busy_wait(usec_to_wait);
+	} else {
+		nrfx_coredep_delay_us(usec_to_wait);
+	}
 }
 
 char const *nrfx_error_string_get(nrfx_err_t code)


### PR DESCRIPTION
When the SYS_CLOCK_EXISTS Kconfig option is not enabled, k_busy_wait()
has no implementation, so in such case, call nrfx_coredep_delay_us()
directly.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>