### PR TITLE
drivers: can: stm32: enable can1 clock also for can2

### DIFF
--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -1248,7 +1248,9 @@ static const struct can_stm32_config can_stm32_cfg_2 = {
 	.ts2 = DT_PROP_OR(DT_NODELABEL(can2), phase_seg2, 0),
 	.one_shot = DT_PROP(DT_NODELABEL(can2), one_shot),
 	.pclken = {
-		.enr = DT_CLOCKS_CELL(DT_NODELABEL(can2), bits),
+		/* can1 (master) clock must be enabled for can2 as well */
+		.enr = DT_CLOCKS_CELL(DT_NODELABEL(can1), bits) |
+		       DT_CLOCKS_CELL(DT_NODELABEL(can2), bits),
 		.bus = DT_CLOCKS_CELL(DT_NODELABEL(can2), bus),
 	},
 	.config_irq = config_can_2_irq,


### PR DESCRIPTION
For devices with more than one CAN peripherals, CAN1 is the master and its clock has to be enabled also if only CAN2 is used.

Without this fix, CAN2 only receives and sends garbage. This issue is also described [here](https://community.st.com/s/question/0D50X0000A1nrx4SQA/using-can2-slave-without-can1-master).

Both CAN peripherals are on the same bus for all MCUs I checked, so I think it is valid to just add that enable bit and assume it's the same clock.