### PR TITLE
dts: bindings: add binding for zephyr,sdmmc-disk

### DIFF
--- a/dts/bindings/sd/sd-device.yaml
+++ b/dts/bindings/sd/sd-device.yaml
@@ -1,0 +1,7 @@
+# Copyright 2022 NXP
+
+# Fields common to all SD devices
+
+on-bus: sd
+
+include: [base.yaml]

--- a/dts/bindings/sd/zephyr,sdmmc-disk.yaml
+++ b/dts/bindings/sd/zephyr,sdmmc-disk.yaml
@@ -1,0 +1,9 @@
+description: |
+  Zephyr MMC disk node. A binding with this compatible present within an SD
+  host controller device node indicates that an SDMMC disk is attached to that
+  SD bus. This binding will enable that disk to be used with the disk driver
+  API and any subsystems that utilize it.
+
+compatible: "zephyr,sdmmc-disk"
+
+include: [sd-device.yaml]

--- a/dts/bindings/sdhc/sdhc.yaml
+++ b/dts/bindings/sdhc/sdhc.yaml
@@ -5,6 +5,8 @@
 
 include: base.yaml
 
+bus: sd
+
 properties:
   max-current-330:
     type: int


### PR DESCRIPTION
Add binding for zephyr sdmmc disk device, which uses the SD
subsystem to manage an SD memory card.

Fixes #46410
Fixes #46266

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>