### PR TITLE
sys: util: Accept empty FOR_EACH

### DIFF
--- a/include/zephyr/sys/util_loops.h
+++ b/include/zephyr/sys/util_loops.h
@@ -408,7 +408,7 @@
 		Z_FOR_LOOP_3, \
 		Z_FOR_LOOP_2, \
 		Z_FOR_LOOP_1, \
-		Z_FOR_LOOP_0)(x, sep, fixed_arg0, fixed_arg1, ##__VA_ARGS__)
+		Z_FOR_LOOP_0)(x, sep, fixed_arg0, fixed_arg1, __VA_ARGS__)
 
 #define Z_GET_ARG_1(_0, ...) _0
 


### PR DESCRIPTION
The `##` part of `##__VA_ARGS__` in the `Z_FOR_EACH_ENGINE` macro technically
breaks the invocation of empty `FOR_EACH` sequences, as the empty
`__VA_ARGS__` gets squashed with in the invocation of `Z_FOR_LOOP_1()` in
`Z_FOR_LOOP_2()`, which makes the macro only pass 4 arguments to
`Z_FOR_LOOP_1`.

This breaks IntelliSense in Microsoft's C/C++ extension for VS Code,
which is strict about the amount of arguments you can pass to a variadic
macro.

Signed-off-by: Trond Einar Snekvik <Trond.Einar.Snekvik@nordicsemi.no>