### PR TITLE
drivers: sensor: adxl345: Update driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -20,15 +20,11 @@ LOG_MODULE_REGISTER(ADXL345, CONFIG_SENSOR_LOG_LEVEL);
 static int adxl345_read_sample(const struct device *dev,
 			       struct adxl345_sample *sample)
 {
-	struct adxl345_dev_data *data = dev->data;
+	const struct adxl345_dev_config *cfg = dev->config;
 	int16_t raw_x, raw_y, raw_z;
 	uint8_t axis_data[6];
 
-	int rc = i2c_burst_read(data->i2c_master,
-				data->i2c_addr,
-				ADXL345_X_AXIS_DATA_0_REG,
-				axis_data,
-				6);
+	int rc = i2c_burst_read_dt(&cfg->i2c, ADXL345_X_AXIS_DATA_0_REG, axis_data, 6);
 
 	if (rc < 0) {
 		LOG_ERR("Samples read failed with rc=%d\n", rc);
@@ -60,13 +56,13 @@ static int adxl345_sample_fetch(const struct device *dev,
 				enum sensor_channel chan)
 {
 	struct adxl345_dev_data *data = dev->data;
+	const struct adxl345_dev_config *cfg = dev->config;
 	struct adxl345_sample sample;
 	uint8_t samples_count;
 	int rc;
 
 	data->sample_number = 0;
-	rc = i2c_reg_read_byte(data->i2c_master, data->i2c_addr,
-		ADXL345_FIFO_STATUS_REG, &samples_count);
+	rc = i2c_reg_read_byte_dt(&cfg->i2c, ADXL345_FIFO_STATUS_REG, &samples_count);
 	if (rc < 0) {
 		LOG_ERR("Failed to read FIFO status rc = %d\n", rc);
 		return rc;
@@ -137,44 +133,37 @@ static int adxl345_init(const struct device *dev)
 	uint8_t dev_id;
 
 	data->sample_number = 0;
-	data->i2c_master = device_get_binding(cfg->i2c_master_name);
-	data->i2c_addr = cfg->i2c_addr;
 
-	if (!data->i2c_master) {
-		LOG_ERR("Failed to get I2C master\n");
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("I2C bus device is not ready");
 		return -ENODEV;
 	}
 
-	rc = i2c_reg_read_byte(data->i2c_master, data->i2c_addr,
-		ADXL345_DEVICE_ID_REG, &dev_id);
+	rc = i2c_reg_read_byte_dt(&cfg->i2c, ADXL345_DEVICE_ID_REG, &dev_id);
 	if (rc < 0 || dev_id != ADXL345_PART_ID) {
 		LOG_ERR("Read PART ID failed: 0x%x\n", rc);
 		return -ENODEV;
 	}
 
-	rc = i2c_reg_write_byte(data->i2c_master, data->i2c_addr,
-		ADXL345_FIFO_CTL_REG, ADXL345_FIFO_STREAM_MODE);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, ADXL345_FIFO_CTL_REG, ADXL345_FIFO_STREAM_MODE);
 	if (rc < 0) {
 		LOG_ERR("FIFO enable failed\n");
 		return -EIO;
 	}
 
-	rc = i2c_reg_write_byte(data->i2c_master, data->i2c_addr,
-		ADXL345_DATA_FORMAT_REG, ADXL345_RANGE_16G);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, ADXL345_DATA_FORMAT_REG, ADXL345_RANGE_16G);
 	if (rc < 0) {
 		LOG_ERR("Data format set failed\n");
 		return -EIO;
 	}
 
-	rc = i2c_reg_write_byte(data->i2c_master, data->i2c_addr,
-		ADXL345_RATE_REG, ADXL345_RATE_25HZ);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, ADXL345_RATE_REG, ADXL345_RATE_25HZ);
 	if (rc < 0) {
 		LOG_ERR("Rate setting failed\n");
 		return -EIO;
 	}
 
-	rc = i2c_reg_write_byte(data->i2c_master, data->i2c_addr,
-		ADXL345_POWER_CTL_REG, ADXL345_ENABLE_MEASURE_BIT);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, ADXL345_POWER_CTL_REG, ADXL345_ENABLE_MEASURE_BIT);
 	if (rc < 0) {
 		LOG_ERR("Enable measure bit failed\n");
 		return -EIO;
@@ -186,8 +175,7 @@ static int adxl345_init(const struct device *dev)
 static struct adxl345_dev_data adxl345_data;
 
 static const struct adxl345_dev_config adxl345_config = {
-	.i2c_master_name = DT_INST_BUS_LABEL(0),
-	.i2c_addr = DT_INST_REG_ADDR(0),
+	.i2c = I2C_DT_SPEC_INST_GET(0),
 };
 
 DEVICE_DT_INST_DEFINE(0, adxl345_init, NULL,

--- a/drivers/sensor/adxl345/adxl345.h
+++ b/drivers/sensor/adxl345/adxl345.h
@@ -37,8 +37,6 @@
 
 struct adxl345_dev_data {
 	unsigned int sample_number;
-	const struct device *i2c_master;
-	uint8_t i2c_addr;
 
 	int16_t bufx[ADXL345_MAX_FIFO_SIZE];
 	int16_t bufy[ADXL345_MAX_FIFO_SIZE];
@@ -52,8 +50,7 @@ struct adxl345_sample {
 };
 
 struct adxl345_dev_config {
-	const char *i2c_master_name;
-	uint16_t i2c_addr;
+	struct i2c_dt_spec i2c;
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_ADX345_ADX345_H_ */


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>