### PR TITLE
drivers: sensor: ak8975: Update driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/ak8975/ak8975.h
+++ b/drivers/sensor/ak8975/ak8975.h
@@ -24,8 +24,6 @@
 #define AK8975_MICRO_GAUSS_PER_BIT	3000
 
 struct ak8975_data {
-	const struct device *i2c;
-
 	int16_t x_sample;
 	int16_t y_sample;
 	int16_t z_sample;
@@ -33,6 +31,10 @@ struct ak8975_data {
 	uint8_t x_adj;
 	uint8_t y_adj;
 	uint8_t z_adj;
+};
+
+struct ak8975_config {
+	struct i2c_dt_spec i2c;
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_AK8975_AK8975_H_ */


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>