### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 8.2

### DIFF
--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -26,7 +26,7 @@ unsigned char _irq_to_interrupt_vector[CONFIG_MAX_IRQ_LINES];
 
 #define NR_IRQ_VECTORS (IV_NR_VECTORS - IV_IRQS)  /* # vectors free for IRQs */
 
-void (*x86_irq_funcs[NR_IRQ_VECTORS])(const void *);
+void (*x86_irq_funcs[NR_IRQ_VECTORS])(const void *arg);
 const void *x86_irq_args[NR_IRQ_VECTORS];
 
 #if defined(CONFIG_INTEL_VTD_ICTL)

--- a/arch/x86/core/intel64/thread.c
+++ b/arch/x86/core/intel64/thread.c
@@ -10,7 +10,7 @@
 #include <offsets_short.h>
 #include <x86_mmu.h>
 
-extern void x86_sse_init(struct k_thread *); /* in locore.S */
+extern void x86_sse_init(struct k_thread *thread); /* in locore.S */
 
 /* FIXME: This exists to make space for a "return address" at the top
  * of the stack.  Obviously this is unused at runtime, but is required

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -96,11 +96,11 @@ static int console_out(int c)
 #endif
 
 #if defined(CONFIG_STDOUT_CONSOLE)
-extern void __stdout_hook_install(int (*hook)(int));
+extern void __stdout_hook_install(int (*hook)(int c));
 #endif
 
 #if defined(CONFIG_PRINTK)
-extern void __printk_hook_install(int (*fn)(int));
+extern void __printk_hook_install(int (*fn)(int c));
 #endif
 
 #if defined(CONFIG_CONSOLE_HANDLER)

--- a/lib/libc/minimal/source/stdout/stdout_console.c
+++ b/lib/libc/minimal/source/stdout/stdout_console.c
@@ -18,9 +18,9 @@ static int _stdout_hook_default(int c)
 	return EOF;
 }
 
-static int (*_stdout_hook)(int) = _stdout_hook_default;
+static int (*_stdout_hook)(int c) = _stdout_hook_default;
 
-void __stdout_hook_install(int (*hook)(int))
+void __stdout_hook_install(int (*hook)(int c))
 {
 	_stdout_hook = hook;
 }

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -51,7 +51,7 @@ __attribute__((weak)) int arch_printk_char_out(int c)
 }
 /* LCOV_EXCL_STOP */
 
-int (*_char_out)(int) = arch_printk_char_out;
+int (*_char_out)(int c) = arch_printk_char_out;
 
 /**
  * @brief Install the character output routine for printk
@@ -60,7 +60,7 @@ int (*_char_out)(int) = arch_printk_char_out;
  * routine that outputs one ASCII character at a time.
  * @param fn putc routine to install
  */
-void __printk_hook_install(int (*fn)(int))
+void __printk_hook_install(int (*fn)(int c))
 {
 	_char_out = fn;
 }


### PR DESCRIPTION
MISRA C:2012 Rule 8.2 (Function types shall be in prototype form with
named parameters.)

Added missing parameter names.

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>