### PR TITLE
riscv: hifive1: Select QEMU_TARGET

### DIFF
--- a/boards/riscv/hifive1/Kconfig.board
+++ b/boards/riscv/hifive1/Kconfig.board
@@ -3,3 +3,4 @@
 config BOARD_HIFIVE1
 	bool "HiFive1 target"
 	depends on SOC_RISCV_SIFIVE_FREEDOM
+	select QEMU_TARGET


### PR DESCRIPTION
hifive1 was the first target for riscv, and used qemu emulation to
start. Since the use case is still enabled, make sure to select
QEMU_TARGET so that QEMU_ICOUNT_SHIFT gets honored.

Signed-off-by: Olof Johansson <olof@lixom.net>