### PR TITLE
Remove riscv dtc warnings

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -91,7 +91,7 @@
 		#size-cells = <1>;
 
 		/* Reserve 60kB for the bootloader */
-		boot_partition: partition@0000 {
+		boot_partition: partition@0 {
 			label = "mcuboot";
 			reg = <0x00000000 0x0000F000>;
 			read-only;

--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -27,9 +27,10 @@
 			i-cache-line-size = <32>;
 			d-cache-line-size = <32>;
 			CPU0_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 		CPU1: cpu@1 {
@@ -43,9 +44,10 @@
 			i-cache-line-size = <32>;
 			d-cache-line-size = <32>;
 			CPU1_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 		CPU2: cpu@2 {
@@ -59,9 +61,10 @@
 			i-cache-line-size = <32>;
 			d-cache-line-size = <32>;
 			CPU2_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 		CPU3: cpu@3 {
@@ -75,9 +78,10 @@
 			i-cache-line-size = <32>;
 			d-cache-line-size = <32>;
 			CPU3_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 	};

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -47,8 +47,9 @@
 		};
 
 		intc: interrupt-controller@600c2000 {
-			#interrupt-cells = <1>;
 			compatible = "espressif,esp32-intc";
+			#address-cells = <0>;
+			#interrupt-cells = <1>;
 			interrupt-controller;
 			reg = <0x600c2000 0x198>;
 			label = "INTC_0";

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -45,8 +45,9 @@
 		};
 
 		eclic: interrupt-controller@d2000000 {
-			#interrupt-cells = <2>;
 			compatible = "nuclei,eclic";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg =  <0xd2000000 0x0001
 				0xd2000004 0x0004
@@ -157,6 +158,7 @@
 
 		exti: interrupt-controller@40010400 {
 			compatible = "gd,gd32-exti";
+			#address-cells = <0>;
 			interrupt-controller;
 			#interrupt-cells = <1>;
 			reg = <0x40010400 0x400>;

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -491,8 +491,9 @@
 		};
 
 		intc: interrupt-controller@f03f00 {
-			#interrupt-cells = <2>;
 			compatible = "ite,it8xxx2-intc";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = <0x00f03f00 0x0100>;
 		};

--- a/dts/riscv/microsemi/microsemi-miv.dtsi
+++ b/dts/riscv/microsemi/microsemi-miv.dtsi
@@ -18,8 +18,9 @@
 			reg = <0>;
 			riscv,isa = "rv32imac";
 			hlic: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -42,8 +43,9 @@
 		};
 
 		plic: interrupt-controller@40000000 {
-			#interrupt-cells = <2>;
 			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
 			reg = <0x40000000 0x2000

--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -18,8 +18,9 @@
 			reg = < 0x0 >;
 			riscv,isa = "rv64imac";
 			hlic0: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -31,8 +32,9 @@
 			reg = < 0x1 >;
 			riscv,isa = "rv64imafdc";
 			hlic1: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -55,9 +57,9 @@
 		};
 
 		plic: interrupt-controller@c000000 {
+			compatible = "sifive,plic-1.0.0";
 			#interrupt-cells = <2>;
 			#address-cells = <1>;
-			compatible = "sifive,plic-1.0.0";
 			interrupt-controller;
 			interrupts-extended = <&hlic0 11
 						&hlic1 11>;

--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -81,7 +81,7 @@
 			status = "disabled";
 		};
 
-		qspi0: qspi@21000000 {
+		qspi0: spi@21000000 {
 			compatible = "microchip,mpfs-qspi";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/neorv32.dtsi
+++ b/dts/riscv/neorv32.dtsi
@@ -30,6 +30,7 @@
 				#interrupt-cells = <1>;
 
 				firq: firq {
+					#address-cells = <1>;
 					interrupt-map-mask = <0x0 0xffffffff>;
 					interrupt-map = <
 						0  0 &intc 0 16

--- a/dts/riscv/openisa/rv32m1.dtsi
+++ b/dts/riscv/openisa/rv32m1.dtsi
@@ -71,6 +71,7 @@
 
 		event0: interrupt-controller@e0041000 {
 			compatible = "openisa,rv32m1-event-unit";
+			#address-cells = <0>;
 			#interrupt-cells = <1>;
 			interrupt-controller;
 			reg = <0xe0041000 0x88>;
@@ -78,6 +79,7 @@
 
 		event1: interrupt-controller@4101f000 {
 			compatible = "openisa,rv32m1-event-unit";
+			#address-cells = <0>;
 			#interrupt-cells = <1>;
 			interrupt-controller;
 			reg = <0x4101f000 0x88>;
@@ -96,6 +98,7 @@
 
 			intmux0_ch0: interrupt-controller@0 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH0_IRQ>;
@@ -106,6 +109,7 @@
 
 			intmux0_ch1: interrupt-controller@40 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH1_IRQ>;
@@ -116,6 +120,7 @@
 
 			intmux0_ch2: interrupt-controller@80 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH2_IRQ>;
@@ -126,6 +131,7 @@
 
 			intmux0_ch3: interrupt-controller@c0 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH3_IRQ>;
@@ -136,6 +142,7 @@
 
 			intmux0_ch4: interrupt-controller@100 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH4_IRQ>;
@@ -146,6 +153,7 @@
 
 			intmux0_ch5: interrupt-controller@140 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH5_IRQ>;
@@ -156,6 +164,7 @@
 
 			intmux0_ch6: interrupt-controller@180 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH6_IRQ>;
@@ -166,6 +175,7 @@
 
 			intmux0_ch7: interrupt-controller@1c0 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH7_IRQ>;
@@ -188,6 +198,7 @@
 
 			intmux1_ch0: interrupt-controller@0 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH0_IRQ>;
@@ -198,6 +209,7 @@
 
 			intmux1_ch1: interrupt-controller@40 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH1_IRQ>;
@@ -208,6 +220,7 @@
 
 			intmux1_ch2: interrupt-controller@80 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH2_IRQ>;
@@ -218,6 +231,7 @@
 
 			intmux1_ch3: interrupt-controller@c0 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH3_IRQ>;
@@ -228,6 +242,7 @@
 
 			intmux1_ch4: interrupt-controller@100 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH4_IRQ>;
@@ -238,6 +253,7 @@
 
 			intmux1_ch5: interrupt-controller@140 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH5_IRQ>;
@@ -248,6 +264,7 @@
 
 			intmux1_ch6: interrupt-controller@180 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH6_IRQ>;
@@ -258,6 +275,7 @@
 
 			intmux1_ch7: interrupt-controller@1c0 {
 				compatible = "openisa,rv32m1-intmux-ch";
+				#address-cells = <0>;
 				#interrupt-cells = <1>;
 				interrupt-controller;
 				interrupts = <INTMUX_CH7_IRQ>;

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -34,8 +34,9 @@
 		compatible = "litex,vexriscv";
 		ranges;
 		intc0: interrupt-controller@bc0 {
-			#interrupt-cells = <2>;
 			compatible = "vexriscv-intc0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = <0xbc0 0x4 0xfc0 0x4>;
 			reg-names = "irq_mask", "irq_pending";

--- a/dts/riscv/sifive/riscv32-fe310.dtsi
+++ b/dts/riscv/sifive/riscv32-fe310.dtsi
@@ -33,8 +33,9 @@
 			riscv,isa = "rv32imac";
 			status = "okay";
 			hlic: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -61,8 +62,9 @@
 			reg-names = "control";
 		};
 		clint: clint@2000000 {
-			#interrupt-cells = <1>;
 			compatible = "riscv,clint0";
+			#address-cells = <0>;
+			#interrupt-cells = <1>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 3 &hlic 7>;
 			reg = <0x2000000 0x10000>;
@@ -123,8 +125,9 @@
 			#size-cells = <0>;
 		};
 		plic: interrupt-controller@c000000 {
-			#interrupt-cells = <2>;
 			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
 			reg = <0x0c000000 0x00002000

--- a/dts/riscv/sifive/riscv64-fu540.dtsi
+++ b/dts/riscv/sifive/riscv64-fu540.dtsi
@@ -40,8 +40,9 @@
 			status = "okay";
 
 			hlic: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -102,8 +103,9 @@
 		};
 
 		clint: clint@2000000 {
-			#interrupt-cells = <1>;
 			compatible = "riscv,clint0";
+			#address-cells = <0>;
+			#interrupt-cells = <1>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 3 &hlic 7>;
 			reg = <0x2000000 0x10000>;
@@ -117,8 +119,9 @@
 		};
 
 		plic: interrupt-controller@c000000 {
-			#interrupt-cells = <2>;
 			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
 			reg = <0x0c000000 0x00002000

--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -39,8 +39,9 @@
 			status = "okay";
 
 			hlic: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -71,8 +72,9 @@
 		};
 
 		clint: clint@2000000 {
-			#interrupt-cells = <1>;
 			compatible = "riscv,clint0";
+			#address-cells = <0>;
+			#interrupt-cells = <1>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 3 &hlic 7>;
 			reg = <0x2000000 0x10000>;
@@ -87,8 +89,9 @@
 
 
 		plic: interrupt-controller@c000000 {
-			#interrupt-cells = <2>;
 			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&hlic 11>;
 			reg = <0x0c000000 0x00002000

--- a/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
+++ b/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
@@ -40,8 +40,9 @@
 			status = "okay";
 			tlb-split;
 			cpu0intctrl: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -68,8 +69,9 @@
 			status = "okay";
 			tlb-split;
 			cpu1intctrl: interrupt-controller {
-				#interrupt-cells = <1>;
 				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
 				interrupt-controller;
 			};
 		};
@@ -114,9 +116,10 @@
 		};
 
 		clint: clint@2000000 {
+			compatible = "riscv,clint0";
+			#address-cells = <0>;
 			#interrupt-cells = <1>;
 			interrupt-controller;
-			compatible = "riscv,clint0";
 			interrupts-extended = <&cpu0intctrl 3 &cpu0intctrl 7
 					       &cpu1intctrl 3 &cpu1intctrl 7 >;
 			reg = <0x0 0x2000000 0x0 0x10000>;
@@ -124,8 +127,9 @@
 		};
 
 		plic: plic@c000000 {
-			#interrupt-cells = <2>;
 			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
+			#interrupt-cells = <2>;
 			interrupt-controller;
 			interrupts-extended = <&cpu0intctrl 11 &cpu0intctrl 9
 					       &cpu1intctrl 11 &cpu1intctrl 9 >;

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -117,6 +117,7 @@
 
 		plic0: interrupt-controller@e4000000 {
 			compatible = "sifive,plic-1.0.0";
+			#address-cells = <0>;
 			#interrupt-cells = <2>;
 			interrupt-controller;
 			reg = < 0xe4000000 0x00001000

--- a/dts/riscv/virt.dtsi
+++ b/dts/riscv/virt.dtsi
@@ -46,9 +46,10 @@
 			compatible = "riscv";
 
 			hlic0: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 
@@ -59,9 +60,10 @@
 			compatible = "riscv";
 
 			hlic1: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 
@@ -72,9 +74,10 @@
 			compatible = "riscv";
 
 			hlic2: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 
@@ -85,9 +88,10 @@
 			compatible = "riscv";
 
 			hlic3: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 
@@ -98,9 +102,10 @@
 			compatible = "riscv";
 
 			hlic4: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 
@@ -111,9 +116,10 @@
 			compatible = "riscv";
 
 			hlic5: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 
@@ -124,9 +130,10 @@
 			compatible = "riscv";
 
 			hlic6: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 
@@ -137,9 +144,10 @@
 			compatible = "riscv";
 
 			hlic7: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
 				#interrupt-cells = < 0x01 >;
 				interrupt-controller;
-				compatible = "riscv,cpu-intc";
 			};
 		};
 	};
@@ -174,8 +182,8 @@
 			>;
 			interrupt-controller;
 			compatible = "sifive,plic-1.0.0";
-			#interrupt-cells = < 0x02 >;
 			#address-cells = < 0x00 >;
+			#interrupt-cells = < 0x02 >;
 		};
 
 		clint@2000000 {
@@ -191,6 +199,7 @@
 			>;
 			reg = < 0x2000000 0x10000 >;
 			compatible = "riscv,clint0";
+			#address-cells = <0>;
 			#interrupt-cells = <1>;
 			interrupt-controller;
 		};


### PR DESCRIPTION
This is a short series removing a number of dtc warnings on riscv platforms. The most verbose one is the lack of #address-cells in interrupt-controller nodes.

For more information on the need for address-cells, see the interrupt-map use cases in the specification: https://devicetree-specification.readthedocs.io/en/v0.3/devicetree-basics.html#properties-for-interrupt-controllers. Note that there's only one platform that uses interrupt-map in the tree to date, so I went with address-cells of 0 everywhere but that specific platform.

The other changes are minor (fixing a unit address 0000 -> 0) and a node name (qspi -> spi).