### PR TITLE
Support for USB controller on STM32H7A3

### DIFF
--- a/boards/arm/nucleo_h7a3zi_q/doc/index.rst
+++ b/boards/arm/nucleo_h7a3zi_q/doc/index.rst
@@ -71,7 +71,6 @@ Nucleo H7A3ZI-Q provides the following hardware components:
 - USART(5)
 - UART(5)
 - USB OTG Full Speed and High Speed(1)
-- USB OTG Full Speed(1)
 - CAN-FD(2)
 - SAI(2)
 - SPDIF_Rx(4)
@@ -107,6 +106,8 @@ features:
 | ADC         | on-chip    | adc                                |
 +-------------+------------+------------------------------------+
 | Backup SRAM | on-chip    | Backup SRAM                        |
++-------------+------------+------------------------------------+
+| USB OTG HS  | on-chip    | USB device                         |
 +-------------+------------+------------------------------------+
 
 

--- a/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -111,3 +111,9 @@
 	pinctrl-names = "default";
 	status = "okay";
 };
+
+zephyr_udc0: &usbotg_hs {
+	pinctrl-0 = <&usb_otg_hs_dm_pa11 &usb_otg_hs_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+};

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -394,8 +394,10 @@ static int usb_dc_stm32_init(void)
 #endif /* CONFIG_USB_DEVICE_SOF */
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
-	/* Currently assuming FS mode. Need to disable the ULPI clock on USB2.
-	 * Need to make this dependent on HS or FS config.
+	/* The USB2 controller only works in FS mode, but the ULPI clock needs
+	 * to be disabled in sleep mode for it to work. For the USB1
+	 * controller, as it is an HS one, the clock is disabled in the common
+	 * path.
 	 */
 
 	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB2OTGHSULPI);

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -394,14 +394,11 @@ static int usb_dc_stm32_init(void)
 #endif /* CONFIG_USB_DEVICE_SOF */
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
-	/* Currently assuming FS mode. Need to disable the ULPI clock on USB2 and
-	 * enable the FS clock. Need to make this dependent on HS or FS config.
+	/* Currently assuming FS mode. Need to disable the ULPI clock on USB2.
+	 * Need to make this dependent on HS or FS config.
 	 */
 
 	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB2OTGHSULPI);
-
-	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_USB2OTGHS);
-	LL_AHB1_GRP1_EnableClockSleep(LL_AHB1_GRP1_PERIPH_USB2OTGHS);
 
 	LL_PWR_EnableUSBVoltageDetector();
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -399,6 +399,7 @@ static int usb_dc_stm32_init(void)
 #endif /* CONFIG_USB_DEVICE_SOF */
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_otgfs)
 	/* The USB2 controller only works in FS mode, but the ULPI clock needs
 	 * to be disabled in sleep mode for it to work. For the USB1
 	 * controller, as it is an HS one, the clock is disabled in the common
@@ -406,6 +407,7 @@ static int usb_dc_stm32_init(void)
 	 */
 
 	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB2OTGHSULPI);
+#endif
 
 	LL_PWR_EnableUSBVoltageDetector();
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -305,6 +305,11 @@ static int usb_dc_stm32_clock_enable(void)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_usbphyc)
 	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
+#elif defined(CONFIG_SOC_SERIES_STM32H7X)
+	/* Disable ULPI interface (for external high-speed PHY) clock in sleep
+	 * mode.
+	 */
+	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB1OTGHSULPI);
 #else
 	/* Disable ULPI interface (for external high-speed PHY) clock in low
 	 * power mode. It is disabled by default in run power mode, no need to

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -306,8 +306,10 @@ static int usb_dc_stm32_clock_enable(void)
 	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 	LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_OTGPHYC);
 #else
-	/* Disable ULPI interface (for external high-speed PHY) clock */
-	LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
+	/* Disable ULPI interface (for external high-speed PHY) clock in low
+	 * power mode. It is disabled by default in run power mode, no need to
+	 * disable it.
+	 */
 	LL_AHB1_GRP1_DisableClockLowPower(LL_AHB1_GRP1_PERIPH_OTGHSULPI);
 #endif
 #endif
@@ -396,7 +398,6 @@ static int usb_dc_stm32_init(void)
 	 * enable the FS clock. Need to make this dependent on HS or FS config.
 	 */
 
-	LL_AHB1_GRP1_DisableClock(LL_AHB1_GRP1_PERIPH_USB2OTGHSULPI);
 	LL_AHB1_GRP1_DisableClockSleep(LL_AHB1_GRP1_PERIPH_USB2OTGHSULPI);
 
 	LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_USB2OTGHS);

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -24,6 +24,20 @@
 			dma-requests= <111>;
 		};
 
+		usbotg_hs: usb@40040000 {
+			compatible = "st,stm32-otghs";
+			reg = <0x40040000 0x40000>;
+			interrupts = <77 0>, <74 0>, <75 0>;
+			interrupt-names = "otghs", "ep1_out", "ep1_in";
+			num-bidir-endpoints = <9>;
+			ram-size = <4096>;
+			maximum-speed = "full-speed";
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x02000000>;
+			phys = <&otghs_fs_phy>;
+			status = "disabled";
+			label= "OTG_HS";
+		};
+
 		ltdc: display-controller@50001000 {
 			compatible = "st,stm32-ltdc";
 			reg = <0x50001000 0x200>;
@@ -82,4 +96,9 @@
 		zephyr,memory-region = "DTCM";
 	};
 
+	otghs_fs_phy: otghs_fs_phy {
+		compatible = "usb-nop-xceiv";
+		#phy-cells = <0>;
+		label = "OTGHS_FS_PHY";
+	};
 };


### PR DESCRIPTION
This patchset adds support for the USB controller on the STM32H7A3 SoC, which differs from the already supported STM32H7 SoC by the lack of the second USB controller.