### PR TITLE
STM32H7A3ZI-Q-NUCLEO: Increase CPU frequency to 280 MHz 

### DIFF
--- a/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
+++ b/boards/arm/nucleo_h7a3zi_q/nucleo_h7a3zi_q.dts
@@ -65,9 +65,9 @@
 
 &pll {
 	div-m = <1>;
-	mul-n = <24>;
-	div-p = <2>;
-	div-q = <4>;
+	mul-n = <35>;
+	div-p = <1>;
+	div-q = <5>;
 	div-r = <2>;
 	clocks = <&clk_hse>;
 	status = "okay";
@@ -75,7 +75,7 @@
 
 &rcc {
 	clocks = <&pll>;
-	clock-frequency = <DT_FREQ_M(96)>;
+	clock-frequency = <DT_FREQ_M(280)>;
 	d1cpre = <1>;
 	hpre = <1>;
 	d1ppre = <2>;

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -253,6 +253,8 @@ static int32_t prepare_regulator_voltage_scale(void)
 	/* Make sure to put the CPU in highest Voltage scale during clock configuration */
 	/* Highest voltage is SCALE0 */
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
+	while (LL_PWR_IsActiveFlag_VOS() == 0) {
+	}
 	return 0;
 }
 
@@ -286,6 +288,8 @@ static int32_t optimize_regulator_voltage_scale(uint32_t sysclk_freq)
 	LL_PWR_ConfigSupply(LL_PWR_LDO_SUPPLY);
 #endif
 	LL_PWR_SetRegulVoltageScaling(LL_PWR_REGU_VOLTAGE_SCALE0);
+	while (LL_PWR_IsActiveFlag_VOS() == 0) {
+	}
 	return 0;
 }
 


### PR DESCRIPTION
The STM32H7A3ZI-Q-NUCLEO board has a STM32H7A3 SoC which can run up to 280 MHz, while it currently only runs at 96 MHz. This patchset does the necessary changes to increase the frequency.