### PR TITLE
twister: Exit with a bad status if there were build errors

### DIFF
--- a/scripts/twister
+++ b/scripts/twister
@@ -1373,7 +1373,7 @@ def main():
                        )
 
     logger.info("Run completed")
-    if results.failed or (tplan.warnings and options.warnings_as_errors):
+    if results.failed or results.error or (tplan.warnings and options.warnings_as_errors):
         sys.exit(1)
 
 


### PR DESCRIPTION
Previously, twister would exit with a 0 status code if there were build
failures but no execution failures. This makes it easier to catch
build breakages when using twister in CI workflows.

Signed-off-by: Benjamin Gwin <bgwin@google.com>