### PR TITLE
ITE drivers/pwm: Input frequency to PWM is not correct after the second call.

### DIFF
--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -141,8 +141,11 @@ static int pwm_it8xxx2_set_cycles(const struct device *dev,
 	 * <=324Hz in board dts. Now change prescaler clock source from 8MHz to
 	 * 32.768KHz to support pwm output in mode.
 	 */
-	if ((target_freq <= 324) && (inst->PCFSR & BIT(prs_sel))) {
-		inst->PCFSR &= ~BIT(prs_sel);
+	if (target_freq <= 324) {
+		if ((inst->PCFSR & BIT(prs_sel))) {
+			inst->PCFSR &= ~BIT(prs_sel);
+		}
+
 		pwm_clk_src = (uint64_t) 32768;
 	}
 


### PR DESCRIPTION
target frequency is less than or equal to 324Hz, the first time invokes function < pwm_it8xxx2_set_cycles > will operating in correct output frequency, after the second times will not operating in correct output frequency. 
The Root cause is when selected target frequency less than or equal to 324Hz will 'AND' condition with check PCFSR register for EC frequency. Since the first time default will being EC frequency and instead of 32KHz after selected target frequency less than or equal to 324Hz, so on, PCFSR will changed to 32KHz from EC frequency. The Second times being invoked, as PCFSR is selected as 32KHz, so target frequency (<= 32KHz) 'AND' condition with check PCFSR is not being true, and the 'pwm_clk_src' variable value is not 32768 instead of EC frequency.  

Solution :
An if statement only for checking target frequency less than or equal to 324Hz after, only this condition is true then checking PCFSR register for EC frequency and set 'pwm_clk_src'  variable as 32768.
if statement only checking target frequency less than or equal to 324Hz rather than 'AND' condition with checking PCFSR register for EC frequency.