### PR TITLE
requirements: add netifaces, needed by adsp runner

### DIFF
--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -16,3 +16,6 @@ cbor>=1.0.0
 
 # use for twister
 psutil
+
+# use for adsp runner
+netifaces


### PR DESCRIPTION
Needed for running tests on intel_adsp_cavs boards, the cavstool.py
are using it to get the host ip address automatically.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>