### PR TITLE
drivers/can/rcar: Fix several issues

### DIFF
--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -22,17 +22,16 @@ LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 /* Control Register */
 #define RCAR_CAN_CTLR             0x0840
 /* Control Register bits */
-#define RCAR_CAN_CTLR_BOM         (3 << 11)   /* Bus-Off Recovery Mode Bits */
-#define RCAR_CAN_CTLR_BOM_ENT     BIT(11)     /* Entry to halt mode */
-					      /* at bus-off entry */
+#define RCAR_CAN_CTLR_BOM         (3 << 11)     /* Bus-Off Recovery Mode Bits */
+#define RCAR_CAN_CTLR_BOM_ENT     BIT(11)       /* Automatic halt mode entry at bus-off entry */
 #define RCAR_CAN_CTLR_SLPM        BIT(10)
 #define RCAR_CAN_CTLR_CANM_HALT   BIT(9)
 #define RCAR_CAN_CTLR_CANM_RESET  BIT(8)
 #define RCAR_CAN_CTLR_CANM_MASK   (3 << 8)
-#define RCAR_CAN_CTLR_MLM         BIT(3)      /* Message Lost Mode Select */
-#define RCAR_CAN_CTLR_IDFM        (3 << 1)    /* ID Format Mode Select Bits */
-#define RCAR_CAN_CTLR_IDFM_MIXED  BIT(2)      /* Mixed ID mode */
-#define RCAR_CAN_CTLR_MBM         BIT(0)      /* Mailbox Mode select */
+#define RCAR_CAN_CTLR_MLM         BIT(3)        /* Message Lost Mode Select */
+#define RCAR_CAN_CTLR_IDFM        (3 << 1)      /* ID Format Mode Select Bits */
+#define RCAR_CAN_CTLR_IDFM_MIXED  BIT(2)        /* Mixed ID mode */
+#define RCAR_CAN_CTLR_MBM         BIT(0)        /* Mailbox Mode select */
 
 /* Mask Register */
 #define RCAR_CAN_MKR0             0x0430
@@ -53,8 +52,8 @@ LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 #define RCAR_CAN_FIDCR1           0x0424
 
 /* FIFO Received ID Compare Registers 0 and 1 bits */
-#define RCAR_CAN_FIDCR_IDE        BIT(31)     /* ID Extension Bit */
-#define RCAR_CAN_FIDCR_RTR        BIT(30)     /* RTR Bit */
+#define RCAR_CAN_FIDCR_IDE        BIT(31)       /* ID Extension Bit */
+#define RCAR_CAN_FIDCR_RTR        BIT(30)       /* RTR Bit */
 
 /* Mask Invalid Register 0 */
 #define RCAR_CAN_MKIVLR0          0x0438
@@ -63,13 +62,13 @@ LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 /* Mailbox Interrupt Enable Registers*/
 #define RCAR_CAN_MIER0            0x043C
 #define RCAR_CAN_MIER1            0x042C
-#define RCAR_CAN_MIER1_RXFIE      BIT(28)     /* Rx FIFO Interrupt Enable */
-#define RCAR_CAN_MIER1_TXFIE      BIT(24)     /* Tx FIFO Interrupt Enable */
+#define RCAR_CAN_MIER1_RXFIE      BIT(28)       /* Rx FIFO Interrupt Enable */
+#define RCAR_CAN_MIER1_TXFIE      BIT(24)       /* Tx FIFO Interrupt Enable */
 
-#define RCAR_CAN_STR              0x0842      /* Status Register */
-#define RCAR_CAN_STR_RSTST        BIT(8)      /* Reset Status Bit */
-#define RCAR_CAN_STR_HLTST        BIT(9)      /* Halt Status Bit */
-#define RCAR_CAN_STR_SLPST        BIT(10)     /* Sleep Status Bit */
+#define RCAR_CAN_STR              0x0842        /* Status Register */
+#define RCAR_CAN_STR_RSTST        BIT(8)        /* Reset Status Bit */
+#define RCAR_CAN_STR_HLTST        BIT(9)        /* Halt Status Bit */
+#define RCAR_CAN_STR_SLPST        BIT(10)       /* Sleep Status Bit */
 #define MAX_STR_READS             0x100
 
 /* Bit Configuration Register */
@@ -77,7 +76,7 @@ LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 
 /* Clock Select Register */
 #define RCAR_CAN_CLKR             0x0847
-#define RCAR_CAN_CLKR_EXT_CLOCK   0x3	      /* External input clock */
+#define RCAR_CAN_CLKR_EXT_CLOCK   0x3         /* External input clock */
 #define RCAR_CAN_CLKR_CLKP2       0x1
 #define RCAR_CAN_CLKR_CLKP1       0x0
 
@@ -86,61 +85,60 @@ LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 
 /* Interrupt Enable Register */
 #define RCAR_CAN_IER              0x0860
-#define RCAR_CAN_IER_ERSIE        BIT(5)      /* Error Interrupt Enable Bit */
-#define RCAR_CAN_IER_RXFIE        BIT(4)      /* Rx FIFO Interrupt Enable Bit */
-#define RCAR_CAN_IER_TXFIE        BIT(3)      /* Tx FIFO Interrupt Enable Bit */
+#define RCAR_CAN_IER_ERSIE        BIT(5)        /* Error Interrupt Enable Bit */
+#define RCAR_CAN_IER_RXFIE        BIT(4)        /* Rx FIFO Interrupt Enable Bit */
+#define RCAR_CAN_IER_TXFIE        BIT(3)        /* Tx FIFO Interrupt Enable Bit */
 
 /* Interrupt Status Register */
 #define RCAR_CAN_ISR              0x0861
-#define RCAR_CAN_ISR_ERSF         BIT(5)      /* Error (ERS) Interrupt */
-#define RCAR_CAN_ISR_RXFF         BIT(4)      /* Reception FIFO Interrupt */
-#define RCAR_CAN_ISR_TXFF         BIT(3)      /* Transmission FIFO Interrupt */
+#define RCAR_CAN_ISR_ERSF         BIT(5)        /* Error (ERS) Interrupt */
+#define RCAR_CAN_ISR_RXFF         BIT(4)        /* Reception FIFO Interrupt */
+#define RCAR_CAN_ISR_TXFF         BIT(3)        /* Transmission FIFO Interrupt */
 
 /* Receive FIFO Control Register */
 #define RCAR_CAN_RFCR             0x0848
-#define RCAR_CAN_RFCR_RFE         BIT(0)      /* Receive FIFO Enable */
-#define RCAR_CAN_RFCR_RFEST       BIT(7)      /* Receive FIFO Empty Flag */
+#define RCAR_CAN_RFCR_RFE         BIT(0)        /* Receive FIFO Enable */
+#define RCAR_CAN_RFCR_RFEST       BIT(7)        /* Receive FIFO Empty Flag */
 
 /* Receive FIFO Pointer Control Register */
 #define RCAR_CAN_RFPCR            0x0849
 
 /* Transmit FIFO Control Register */
 #define RCAR_CAN_TFCR             0x084A
-#define RCAR_CAN_TFCR_TFE         BIT(0)      /* Transmit FIFO Enable */
-#define RCAR_CAN_TFCR_TFUST       (7 << 1)    /* Transmit FIFO Unsent Message */
-					      /* Number Status Bits */
-#define RCAR_CAN_TFCR_TFUST_SHIFT 1	      /* Offset of Tx FIFO Unsent */
+#define RCAR_CAN_TFCR_TFE         BIT(0)        /* Transmit FIFO Enable */
+#define RCAR_CAN_TFCR_TFUST       (7 << 1)      /* Transmit FIFO Unsent Msg Number Status Bits */
+#define RCAR_CAN_TFCR_TFUST_SHIFT 1             /* Offset of Tx FIFO Unsent */
 
 /* Transmit FIFO Pointer Control Register */
 #define RCAR_CAN_TFPCR            0x084B
 
 /* Error Code Store Register*/
-#define RCAR_CAN_ECSR             0x0850      /* Error Code Store Register */
-#define RCAR_CAN_ECSR_EDPM        BIT(7)      /* Error Display Mode Select */
-#define RCAR_CAN_ECSR_ADEF        BIT(6)      /* ACK Delimiter Error Flag */
-#define RCAR_CAN_ECSR_BE0F        BIT(5)      /* Bit Error (dominant) Flag */
-#define RCAR_CAN_ECSR_BE1F        BIT(4)      /* Bit Error (recessive) Flag */
-#define RCAR_CAN_ECSR_CEF         BIT(3)      /* CRC Error Flag */
-#define RCAR_CAN_ECSR_AEF         BIT(2)      /* ACK Error Flag */
-#define RCAR_CAN_ECSR_FEF         BIT(1)      /* Form Error Flag */
-#define RCAR_CAN_ECSR_SEF         BIT(0)      /* Stuff Error Flag */
+#define RCAR_CAN_ECSR             0x0850        /* Error Code Store Register */
+#define RCAR_CAN_ECSR_EDPM        BIT(7)        /* Error Display Mode Select */
+#define RCAR_CAN_ECSR_ADEF        BIT(6)        /* ACK Delimiter Error Flag */
+#define RCAR_CAN_ECSR_BE0F        BIT(5)        /* Bit Error (dominant) Flag */
+#define RCAR_CAN_ECSR_BE1F        BIT(4)        /* Bit Error (recessive) Flag */
+#define RCAR_CAN_ECSR_CEF         BIT(3)        /* CRC Error Flag */
+#define RCAR_CAN_ECSR_AEF         BIT(2)        /* ACK Error Flag */
+#define RCAR_CAN_ECSR_FEF         BIT(1)        /* Form Error Flag */
+#define RCAR_CAN_ECSR_SEF         BIT(0)        /* Stuff Error Flag */
 
 /* Test Control Register */
 #define RCAR_CAN_TCR              0x0858
-#define RCAR_CAN_TCR_TSTE         BIT(0)      /* Test Mode Enable Bit*/
+#define RCAR_CAN_TCR_TSTE         BIT(0)        /* Test Mode Enable Bit*/
 #define RCAR_CAN_TCR_LISTEN_ONLY  BIT(1)
-#define RCAR_CAN_TCR_INT_LOOP     (3 << 1)    /* Internal loopback*/
+#define RCAR_CAN_TCR_INT_LOOP     (3 << 1)      /* Internal loopback*/
 
 /* Error Interrupt Factor Judge Register bits */
 #define RCAR_CAN_EIFR             0x084D
-#define RCAR_CAN_EIFR_BLIF        BIT(7)      /* Bus Lock Detect Flag */
-#define RCAR_CAN_EIFR_OLIF        BIT(6)      /* Overload Frame Transmission */
-#define RCAR_CAN_EIFR_ORIF        BIT(5)      /* Receive Overrun Detect Flag */
-#define RCAR_CAN_EIFR_BORIF       BIT(4)      /* Bus-Off Recovery Detect Flag */
-#define RCAR_CAN_EIFR_BOEIF       BIT(3)      /* Bus-Off Entry Detect Flag */
-#define RCAR_CAN_EIFR_EPIF        BIT(2)      /* Error Passive Detect Flag */
-#define RCAR_CAN_EIFR_EWIF        BIT(1)      /* Error Warning Detect Flag */
-#define RCAR_CAN_EIFR_BEIF        BIT(0)      /* Bus Error Detect Flag */
+#define RCAR_CAN_EIFR_BLIF        BIT(7)        /* Bus Lock Detect Flag */
+#define RCAR_CAN_EIFR_OLIF        BIT(6)        /* Overload Frame Transmission */
+#define RCAR_CAN_EIFR_ORIF        BIT(5)        /* Receive Overrun Detect Flag */
+#define RCAR_CAN_EIFR_BORIF       BIT(4)        /* Bus-Off Recovery Detect Flag */
+#define RCAR_CAN_EIFR_BOEIF       BIT(3)        /* Bus-Off Entry Detect Flag */
+#define RCAR_CAN_EIFR_EPIF        BIT(2)        /* Error Passive Detect Flag */
+#define RCAR_CAN_EIFR_EWIF        BIT(1)        /* Error Warning Detect Flag */
+#define RCAR_CAN_EIFR_BEIF        BIT(0)        /* Bus Error Detect Flag */
 
 /* Receive Error Count Register */
 #define RCAR_CAN_RECR             0x084D
@@ -155,10 +153,10 @@ LOG_MODULE_REGISTER(can_rcar, CONFIG_CAN_LOG_LEVEL);
 #define RCAR_CAN_MB_56            0x0380
 #define RCAR_CAN_MB_60            0x03C0
 /* DLC must be accessed as a 16 bit register */
-#define RCAR_CAN_MB_DLC_OFFSET    0x4     /* Data length code */
-#define RCAR_CAN_MB_DATA_OFFSET   0x6     /* Data section */
-#define RCAR_CAN_MB_TSH_OFFSET    0x14    /* Timestamp upper byte */
-#define RCAR_CAN_MB_TSL_OFFSET    0x15    /* Timestamp lower byte */
+#define RCAR_CAN_MB_DLC_OFFSET    0x4           /* Data length code */
+#define RCAR_CAN_MB_DATA_OFFSET   0x6           /* Data section */
+#define RCAR_CAN_MB_TSH_OFFSET    0x14          /* Timestamp upper byte */
+#define RCAR_CAN_MB_TSL_OFFSET    0x15          /* Timestamp lower byte */
 #define RCAR_CAN_FIFO_DEPTH       4
 #define RCAR_CAN_MB_SID_SHIFT     18
 #define RCAR_CAN_MB_RTR           BIT(30)
@@ -225,7 +223,7 @@ static void can_rcar_tx_done(const struct device *dev)
 	struct can_rcar_data *data = dev->data;
 	struct can_rcar_tx_cb *tx_cb;
 
-	tx_cb =	&data->tx_cb[data->tx_tail];
+	tx_cb = &data->tx_cb[data->tx_tail];
 	data->tx_tail++;
 	if (data->tx_tail >= RCAR_CAN_FIFO_DEPTH) {
 		data->tx_tail = 0;
@@ -459,7 +457,7 @@ static void can_rcar_isr(const struct device *dev)
 		while (1) {
 			unsent = sys_read8(config->reg_addr + RCAR_CAN_TFCR);
 			unsent = (unsent & RCAR_CAN_TFCR_TFUST) >>
-				RCAR_CAN_TFCR_TFUST_SHIFT;
+				 RCAR_CAN_TFCR_TFUST_SHIFT;
 			if (data->tx_unsent <= unsent) {
 				break;
 			}
@@ -588,7 +586,7 @@ static int can_rcar_set_mode(const struct device *dev, can_mode_t mode)
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);
 
 	if ((mode & (CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) ==
-		(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) {
+	    (CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) {
 		LOG_ERR("Combination of loopback and listenonly modes not supported");
 		ret = -ENOTSUP;
 		goto unlock;
@@ -1003,14 +1001,13 @@ static int can_rcar_init(const struct device *dev)
 	}
 
 	ctlr = can_rcar_read16(config, RCAR_CAN_CTLR);
-	ctlr |= RCAR_CAN_CTLR_IDFM_MIXED; /* Select mixed ID mode */
+	ctlr |= RCAR_CAN_CTLR_IDFM_MIXED;       /* Select mixed ID mode */
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
-	ctlr |= RCAR_CAN_CTLR_BOM_ENT;	  /* Entry to halt mode automatically */
-					  /* at bus-off */
+	ctlr |= RCAR_CAN_CTLR_BOM_ENT;          /* Entry to halt mode automatically at bus-off */
 #endif
-	ctlr |= RCAR_CAN_CTLR_MBM;	  /* Select FIFO mailbox mode */
-	ctlr |= RCAR_CAN_CTLR_MLM;	  /* Overrun mode */
-	ctlr &= ~RCAR_CAN_CTLR_SLPM;	  /* Clear CAN Sleep mode */
+	ctlr |= RCAR_CAN_CTLR_MBM;              /* Select FIFO mailbox mode */
+	ctlr |= RCAR_CAN_CTLR_MLM;              /* Overrun mode */
+	ctlr &= ~RCAR_CAN_CTLR_SLPM;            /* Clear CAN Sleep mode */
 	can_rcar_write16(config, RCAR_CAN_CTLR, ctlr);
 
 	/* Accept all SID and EID */
@@ -1135,13 +1132,13 @@ static const struct can_driver_api can_rcar_driver_api = {
 	static struct can_rcar_data can_rcar_data_##n;				\
 										\
 	CAN_DEVICE_DT_INST_DEFINE(n, can_rcar_init,				\
-			      NULL,						\
-			      &can_rcar_data_##n,				\
-			      &can_rcar_cfg_##n,				\
-			      POST_KERNEL,					\
-			      CONFIG_CAN_INIT_PRIORITY,				\
-			      &can_rcar_driver_api				\
-			      );						\
+				  NULL,						\
+				  &can_rcar_data_##n,				\
+				  &can_rcar_cfg_##n,				\
+				  POST_KERNEL,					\
+				  CONFIG_CAN_INIT_PRIORITY,			\
+				  &can_rcar_driver_api				\
+				  );						\
 	static void can_rcar_##n##_init(const struct device *dev)		\
 	{									\
 		IRQ_CONNECT(DT_INST_IRQN(n),					\

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -530,6 +530,10 @@ static int can_rcar_enter_halt_mode(const struct can_rcar_cfg *config)
 	ctlr &= ~RCAR_CAN_CTLR_CANM_MASK;
 	ctlr |= RCAR_CAN_CTLR_CANM_HALT;
 	can_rcar_write16(config, RCAR_CAN_CTLR, ctlr);
+
+	/* Wait for controller to apply high bit timing settings */
+	k_usleep(1);
+
 	for (i = 0; i < MAX_STR_READS; i++) {
 		if (can_rcar_read16(config, RCAR_CAN_STR) & RCAR_CAN_STR_HLTST) {
 			return 0;
@@ -547,6 +551,9 @@ static int can_rcar_enter_operation_mode(const struct can_rcar_cfg *config)
 	ctlr = can_rcar_read16(config, RCAR_CAN_CTLR);
 	ctlr &= ~RCAR_CAN_CTLR_CANM_MASK;
 	can_rcar_write16(config, RCAR_CAN_CTLR, ctlr);
+
+	/* Wait for controller to apply high bit timing settings */
+	k_usleep(1);
 
 	for (i = 0; i < MAX_STR_READS; i++) {
 		str = can_rcar_read16(config, RCAR_CAN_STR);


### PR DESCRIPTION
This pull request fix #45168 and fix #45169 and doing some rcar can driver cleanup.

Both `can-api` and `can-timing` test suite including new tests are now running fine on h3ulcb board.

#45168:
After several tests, we validated that the CAN controller is taking more time to apply high bit timing settings.
The issue was both happening at run time (using set_bitrate) and at initialization.
Applying the setting is done while switching controller mode, so the fix has been done at this moment.

#45169:
In order to change bit timing when called from `set_bitrate`, the controller has to be put in reset mode.
When switching to this mode, the controller is wiping several registers to their default values including the register that is enabling the controller loopback mode.
I fixed that issue by storing and restoring useful registers values after mode switching.
So the issue was not that we were not preserving can filters but that the controller was not able to receive sent frames anymore during the test suite execution.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>