### PR TITLE
boards: nucleo_wb55rg: Fix documentation about BLE binary compatibility

### DIFF
--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -186,8 +186,9 @@ To operate bluetooth on Nucleo WB55RG, Cortex-M0 core should be flashed with
 a valid STM32WB Coprocessor binaries (either 'Full stack' or 'HCI Layer').
 These binaries are delivered in STM32WB Cube packages, under
 Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/
-To date, interoperability and backward compatibility has been tested and is
-guaranteed up to version 1.5 of STM32Cube package releases.
+For compatibility information with the various versions of these binaries,
+please check `modules/hal/stm32/lib/stm32wb/hci/README <https://github.com/zephyrproject-rtos/hal_stm32/blob/main/lib/stm32wb/hci/README>`__
+in the hal_stm32 repo.
 
 Connections and IOs
 ===================


### PR DESCRIPTION
Rather than stating a version information that will get out of date
at each release, refer to the source of information located in hal_stm32
module.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>