### PR TITLE
west.yml: update to latest hal_espressif's pinctrl macros

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -65,7 +65,7 @@ manifest:
       groups:
         - hal
     - name: hal_espressif
-      revision: df85671c5d0405c0747c2939c8dfe808b7e4cf38
+      revision: db4a5893e45db100497fbe5262847280fb749dac
       path: modules/hal/espressif
       west-commands: west/west-commands.yml
       groups:


### PR DESCRIPTION
Updates hal_espressif's version to include the latest pinctrl macro definitions.

Closes #46434