### PR TITLE
ns16550: simplify reg-shift handling

### DIFF
--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -29,6 +29,7 @@
 		label = "UART_0";
 		interrupt-parent = <&intc>;
 		interrupts = <24 1>;
+		reg-shift = <2>;
 	};
 
 	chosen {

--- a/boards/arc/qemu_arc/qemu_arc.dtsi
+++ b/boards/arc/qemu_arc/qemu_arc.dtsi
@@ -43,6 +43,7 @@
 		label = "UART_0";
 		interrupt-parent = <&intc>;
 		interrupts = <24 1>;
+		reg-shift = <2>;
 	};
 
 	uart@f0002000 {
@@ -53,6 +54,7 @@
 		label = "UART_1";
 		interrupt-parent = <&intc>;
 		interrupts = <25 1>;
+		reg-shift = <2>;
 	};
 
 	chosen {

--- a/boards/x86/qemu_x86/qemu_x86_lakemont.dts
+++ b/boards/x86/qemu_x86/qemu_x86_lakemont.dts
@@ -45,7 +45,7 @@
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 			current-speed = <115200>;
-
+			reg-shift = <2>;
 			status = "okay";
 		};
 

--- a/dts/arc/synopsys/arc_hsdk.dtsi
+++ b/dts/arc/synopsys/arc_hsdk.dtsi
@@ -72,6 +72,7 @@
 			reg = <0xf0005000 0x1000>;
 			label = "UART_0";
 			interrupts = <30 1>;
+			reg-shift = <2>;
 		};
 
 		uart1: uart@f0026000{
@@ -80,7 +81,7 @@
 			reg = <0xf0026000 0x1000>;
 			label = "UART_1";
 			interrupts = <46 1>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 
@@ -90,7 +91,7 @@
 			reg = <0xf0027000 0x1000>;
 			label = "UART_2";
 			interrupts = <47 1>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 
@@ -100,7 +101,7 @@
 			reg = <0xf0028000 0x1000>;
 			label = "UART_3";
 			interrupts = <48 1>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 

--- a/dts/arc/synopsys/arc_iot.dtsi
+++ b/dts/arc/synopsys/arc_iot.dtsi
@@ -69,6 +69,7 @@
 			interrupts = <86 0>;
 			interrupt-parent = <&intc>;
 			dlf = <0x01>;
+			reg-shift = <2>;
 		};
 
 		uart1: uart@80014100 {
@@ -78,7 +79,7 @@
 			label = "UART_1";
 			interrupts = <87 0>;
 			interrupt-parent = <&intc>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 
@@ -89,7 +90,7 @@
 			label = "UART_2";
 			interrupts = <88 0>;
 			interrupt-parent = <&intc>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 
@@ -100,7 +101,7 @@
 			label = "UART_3";
 			interrupts = <89 0>;
 			interrupt-parent = <&intc>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 

--- a/dts/arc/synopsys/emsdp.dtsi
+++ b/dts/arc/synopsys/emsdp.dtsi
@@ -59,6 +59,7 @@
 			reg = <0xf0004000 0x1000>;
 			label = "UART_0";
 			interrupt-parent = <&intc>;
+			reg-shift = <2>;
 		};
 
 		gpio0: gpio@f0002000 {

--- a/dts/arc/synopsys/emsk.dtsi
+++ b/dts/arc/synopsys/emsk.dtsi
@@ -72,6 +72,7 @@
 			reg = <0xf0008000 0x1000>;
 			label = "UART_0";
 			interrupt-parent = <&intc>;
+			reg-shift = <2>;
 		};
 
 		uart1: uart@f0009000 {
@@ -80,7 +81,7 @@
 			reg = <0xf0009000 0x1000>;
 			label = "UART_1";
 			interrupt-parent = <&intc>;
-
+			reg-shift = <2>;
 		};
 
 		uart2: uart@f000a000 {
@@ -89,7 +90,7 @@
 			reg = <0xf000a000 0x1000>;
 			label = "UART_2";
 			interrupt-parent = <&intc>;
-
+			reg-shift = <2>;
 		};
 
 		gpio0: gpio@f0002000 {

--- a/dts/arm/aspeed/ast10x0.dtsi
+++ b/dts/arm/aspeed/ast10x0.dtsi
@@ -35,6 +35,7 @@
 			interrupts = <8 0>;
 			status = "disabled";
 			label = "UART_5";
+			reg-shift = <2>;
 		};
 	};
 };

--- a/dts/arm/broadcom/valkyrie.dtsi
+++ b/dts/arm/broadcom/valkyrie.dtsi
@@ -38,6 +38,7 @@
 			clock-frequency = <25000000>;
 			interrupts = <MCU_AON_UART_INTR 3>;
 			label = "UART_0";
+			reg-shift = <2>;
 			status = "disabled";
 		};
 
@@ -47,6 +48,7 @@
 			clock-frequency = <100000000>;
 			interrupts = <UART0_INTR 3>;
 			label = "UART_1";
+			reg-shift = <2>;
 			status = "disabled";
 		};
 	};

--- a/dts/arm/broadcom/viper-common.dtsi
+++ b/dts/arm/broadcom/viper-common.dtsi
@@ -16,6 +16,7 @@
 			reg = <0x40020000 0x400>;
 			clock-frequency = <25000000>;
 			label = "CRMU_UART";
+			reg-shift = <2>;
 			status = "disabled";
 		};
 
@@ -24,6 +25,7 @@
 			reg = <0x48100000 0x400>;
 			clock-frequency = <100000000>;
 			label = "CCG_UART0";
+			reg-shift = <2>;
 			status = "disabled";
 		};
 

--- a/dts/arm64/broadcom/viper-common.dtsi
+++ b/dts/arm64/broadcom/viper-common.dtsi
@@ -14,6 +14,7 @@
 		uart0: uart@40020000 {
 			compatible = "ns16550";
 			reg = <0x40020000 0x400>;
+			reg-shift = <2>;
 			clock-frequency = <25000000>;
 			label = "CRMU_UART";
 			status = "disabled";
@@ -22,6 +23,7 @@
 		uart1: uart@48100000 {
 			compatible = "ns16550";
 			reg = <0x48100000 0x400>;
+			reg-shift = <2>;
 			clock-frequency = <100000000>;
 			label = "CCG_UART0";
 			status = "disabled";

--- a/dts/arm64/nxp/nxp_ls1046a.dtsi
+++ b/dts/arm64/nxp/nxp_ls1046a.dtsi
@@ -78,6 +78,7 @@
 			interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			clock-frequency = <350000000>;
 			label = "UART_1";
+			reg-shift = <2>;
 			status = "disabled";
 		};
 };

--- a/dts/bindings/serial/ns16550.yaml
+++ b/dts/bindings/serial/ns16550.yaml
@@ -10,7 +10,7 @@ properties:
 
     reg-shift:
       type: int
-      required: false
+      required: true
       description: quantity to shift the register offsets by
 
     pcp:

--- a/dts/nios2/intel/nios2-qemu.dtsi
+++ b/dts/nios2/intel/nios2-qemu.dtsi
@@ -47,7 +47,7 @@
 			interrupts = <1>;
 			clock-frequency = <50000000>;
 			label = "UART_0";
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 	};

--- a/dts/nios2/intel/nios2f.dtsi
+++ b/dts/nios2/intel/nios2f.dtsi
@@ -40,7 +40,7 @@
 			clock-frequency = <50000000>;
 			interrupts = <1 0>;
 			label = "UART_0";
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -505,6 +505,7 @@
 			clock-frequency = <1804800>;
 			interrupts = <38 IRQ_TYPE_EDGE_RISING>;
 			interrupt-parent = <&intc>;
+			reg-shift = <0>;
 		};
 		uart2: uart@f02800 {
 			compatible = "ns16550";
@@ -515,6 +516,7 @@
 			clock-frequency = <1804800>;
 			interrupts = <39 IRQ_TYPE_EDGE_RISING>;
 			interrupt-parent = <&intc>;
+			reg-shift = <0>;
 		};
 
 		ite_uart1_wrapper: uartwrapper@f02720 {

--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -46,6 +46,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x18,0) PCIE_ID(0x8086,0x5abc)>;
+			reg-shift = <2>;
 
 			label = "UART_0";
 			clock-frequency = <1843200>;
@@ -59,6 +60,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x18,1) PCIE_ID(0x8086,0x5abe)>;
+			reg-shift = <2>;
 
 			label = "UART_1";
 			clock-frequency = <1843200>;
@@ -73,6 +75,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x18,2) PCIE_ID(0x8086,0x5ac0)>;
+			reg-shift = <2>;
 
 			label = "UART_2";
 			clock-frequency = <1843200>;
@@ -87,6 +90,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x18,3) PCIE_ID(0x8086,0x5aee)>;
+			reg-shift = <2>;
 
 			label = "UART_3";
 			clock-frequency = <1843200>;

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -46,7 +46,7 @@
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
-
+			reg-shift = <0>;
 			status = "disabled";
 		};
 
@@ -57,7 +57,7 @@
 			clock-frequency = <1843200>;
 			interrupts = <3 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
-
+			reg-shift = <0>;
 			status = "disabled";
 		};
 

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -61,6 +61,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x1e,0) PCIE_ID(0x8086,0x4b28)>;
+			reg-shift = <2>;
 
 			label = "UART_0";
 			clock-frequency = <1843200>;
@@ -74,6 +75,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x1e,1) PCIE_ID(0x8086,0x4b29)>;
+			reg-shift = <2>;
 
 			label = "UART_1";
 			clock-frequency = <1843200>;
@@ -88,6 +90,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x19,2) PCIE_ID(0x8086,0x4b4d)>;
+			reg-shift = <2>;
 
 			label = "UART_2";
 			clock-frequency = <1843200>;
@@ -102,6 +105,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x11,0) PCIE_ID(0x8086,0x4b96)>;
+			reg-shift = <2>;
 
 			label = "UART_PSE_0";
 			clock-frequency = <1843200>;
@@ -116,6 +120,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x11,1) PCIE_ID(0x8086,0x4b97)>;
+			reg-shift = <2>;
 
 			label = "UART_PSE_1";
 			clock-frequency = <1843200>;
@@ -130,6 +135,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x11,2) PCIE_ID(0x8086,0x4b98)>;
+			reg-shift = <2>;
 
 			label = "UART_PSE_2";
 			clock-frequency = <1843200>;
@@ -144,6 +150,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x11,3) PCIE_ID(0x8086,0x4b99)>;
+			reg-shift = <2>;
 
 			label = "UART_PSE_3";
 			clock-frequency = <1843200>;
@@ -158,6 +165,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x11,4) PCIE_ID(0x8086,0x4b9a)>;
+			reg-shift = <2>;
 
 			label = "UART_PSE_4";
 			clock-frequency = <1843200>;
@@ -172,6 +180,7 @@
 			compatible = "ns16550";
 
 			reg = <PCIE_BDF(0,0x11,5) PCIE_ID(0x8086,0x4b9b)>;
+			reg-shift = <2>;
 
 			label = "UART_PSE_5";
 			clock-frequency = <1843200>;

--- a/dts/x86/intel/ia32.dtsi
+++ b/dts/x86/intel/ia32.dtsi
@@ -46,7 +46,7 @@
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 
@@ -57,7 +57,7 @@
 			clock-frequency = <1843200>;
 			interrupts = <3 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
-
+			reg-shift = <2>;
 			status = "disabled";
 		};
 

--- a/soc/arc/snps_arc_iot/soc.h
+++ b/soc/arc/snps_arc_iot/soc.h
@@ -23,8 +23,6 @@
  * UART: use lr and sr to access subsystem uart IP
  */
 #define UART_NS16550_ACCESS_IOPORT
-#define UART_REG_ADDR_INTERVAL 4
-
 
 /* ARC EM Core IRQs */
 #define IRQ_TIMER0				16

--- a/soc/riscv/riscv-ite/it8xxx2/soc.h
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.h
@@ -8,8 +8,6 @@
  */
 #include <soc_common.h>
 
-#define UART_REG_ADDR_INTERVAL 1
-
 /* lib-c hooks required RAM defined variables */
 #define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
 #define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)


### PR DESCRIPTION
The driver supported getting register shift from Devicetree, from a
custom definition in SoC headers (fragile) or, it took a default value.
This change simplifies things by making reg-shift property required in
all instances.

Found this _issue_ while doing <soc.h> cleanups.