### PR TITLE
net: lwm2m: Allow longer lifetimes than uint16_t

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -164,14 +164,14 @@ config LWM2M_CANCEL_OBSERVE_BY_PATH
 config LWM2M_ENGINE_DEFAULT_LIFETIME
 	int "LWM2M engine default server connection lifetime"
 	default 30
-	range 15 65535
+	range 15 4294967295
 	help
 	  Set the default lifetime (in seconds) for the LWM2M library engine
 
 config LWM2M_SECONDS_TO_UPDATE_EARLY
 	int "LWM2M Registration Update transmission time before timeout"
 	default 6
-	range 1 65535
+	range 1 4294967295
 	help
 	  Time in seconds before the registration timeout, when the LWM2M
 	  Registration Update is sent by the engine. In networks with large


### PR DESCRIPTION
Lifetimes are really 32 bit values, so the limitation
did not make sense, and it did not allow 24 hour lifetime.

Signed-off-by: Seppo Takalo <seppo.takalo@nordicsemi.no>