### PR TITLE
Bluetooth: controller: llcp: fix phy regression errors on EBQ

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -563,6 +563,7 @@ static void lp_pu_st_wait_tx_ack_phy_req(struct ll_conn *conn, struct proc_ctx *
 				conn, pu_select_phy_timing_restrict(conn, ctx->data.pu.tx));
 			ctx->state = LP_PU_STATE_WAIT_RX_PHY_UPDATE_IND;
 			ctx->rx_opcode = PDU_DATA_LLCTRL_TYPE_PHY_UPD_IND;
+			llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
 			break;
 #endif /* CONFIG_BT_PERIPHERAL */
 		default:


### PR DESCRIPTION
Some of the peripheral PHY EBQ tests started failing due to 
regression error:
transmission of data was paused but not resumed.
This is fixed by this commit

Affected tests on EBQ:
LL/CON/PER/BV-49-C
LL/CON/PER/BV-50-C
LL/CON/PER/BV-52-C
LL/CON/PER/BV-53-C
LL/CON/PER/BV-54-C
LL/CON/PER/BV-55-C
LL/CON/PER/BV-56-C
LL/CON/PER/BV-58-C

depends on PR46394


Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>
