### PR TITLE
drivers: serial: sam0: fix baudrate assignment to config_cache in init

### DIFF
--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -561,7 +561,7 @@ static int uart_sam0_init(const struct device *dev)
 	if (retval != 0) {
 		return retval;
 	}
-	dev_data->config_cache.data_bits = cfg->baudrate;
+	dev_data->config_cache.baudrate = cfg->baudrate;
 
 #if CONFIG_UART_INTERRUPT_DRIVEN || CONFIG_UART_ASYNC_API
 	cfg->irq_config_func(dev);


### PR DESCRIPTION
SAM0 driver assigns baudrate to `data_bits` field in `uart_sam0_init`, this overwrites its default setting and results in invalid config being returned from `uart_config_get`.

Signed-off-by: Piotr Binkowski <p.binkowski@cthings.co>