### PR TITLE
soc: arch: snps_arc_iot: select UART_NS16550_ACCESS_IOPORT

### DIFF
--- a/soc/arc/snps_arc_iot/Kconfig.defconfig
+++ b/soc/arc/snps_arc_iot/Kconfig.defconfig
@@ -38,4 +38,7 @@ config UART_NS16550
 	default y
 	depends on SERIAL
 
+config UART_NS16550_ACCESS_IOPORT
+	default y
+
 endif # ARC_IOT

--- a/soc/arc/snps_arc_iot/soc.h
+++ b/soc/arc/snps_arc_iot/soc.h
@@ -19,11 +19,6 @@
 /* default system clock */
 #define SYSCLK_DEFAULT_IOSC_HZ			MHZ(16)
 
-/*
- * UART: use lr and sr to access subsystem uart IP
- */
-#define UART_NS16550_ACCESS_IOPORT
-
 /* ARC EM Core IRQs */
 #define IRQ_TIMER0				16
 #define IRQ_TIMER1				17


### PR DESCRIPTION
NS16550 driver no longer relies on definitions found in <soc.h>, SoC can
select UART_NS16550_ACCESS_IOPORT instead.

Ref. https://github.com/zephyrproject-rtos/zephyr/commit/92f488497fb5bb7cf40fd027cae2a97d426b16a1