### PR TITLE
drivers/clock_control: stm32_common: Fixed PLL configuration 

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -391,7 +391,7 @@ static void set_up_plls(void)
 	}
 #endif
 
-#if STM32_PLL_Q_DIVISOR
+#if STM32_PLL_Q_ENABLED
 	MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ,
 		   STM32_PLL_Q_DIVISOR
 		   << RCC_PLLCFGR_PLLQ_Pos);


### PR DESCRIPTION
-Kept getting an error on STM32g0xx chips that didn't have q-divisor.
-Changed to set prescaler only if it's being used.