### PR TITLE
bluetooth: kconfig: Hide host options if not available

### DIFF
--- a/samples/bluetooth/iso_connected_benchmark/sample.yaml
+++ b/samples/bluetooth/iso_connected_benchmark/sample.yaml
@@ -4,5 +4,5 @@ sample:
 tests:
   sample.bluetooth.iso_connected_benchmark:
     build_only: true
-    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp
+    platform_allow: nrf5340dk_nrf5340_cpuapp
     tags: bluetooth

--- a/subsys/bluetooth/Kconfig
+++ b/subsys/bluetooth/Kconfig
@@ -154,12 +154,14 @@ config BT_REMOTE_VERSION
 config BT_PHY_UPDATE
 	bool "PHY Update"
 	default y
+	depends on !BT_CTLR || BT_CTLR_PHY_UPDATE_SUPPORT
 	help
 	  Enable support for Bluetooth 5.0 PHY Update Procedure.
 
 config BT_DATA_LEN_UPDATE
 	bool "Data Length Update"
 	default y
+	depends on !BT_CTLR || BT_CTLR_DATA_LEN_UPDATE_SUPPORT
 	help
 	  Enable support for Bluetooth v4.2 LE Data Length Update procedure.
 endif # BT_CONN

--- a/subsys/bluetooth/Kconfig.adv
+++ b/subsys/bluetooth/Kconfig.adv
@@ -6,6 +6,7 @@
 
 config BT_EXT_ADV
 	bool "Extended Advertising and Scanning support [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_ADV_EXT_SUPPORT
 	select EXPERIMENTAL
 	help
 	  Select this to enable Extended Advertising API support.

--- a/subsys/bluetooth/Kconfig.iso
+++ b/subsys/bluetooth/Kconfig.iso
@@ -18,6 +18,7 @@ config BT_ISO_UNICAST
 
 config BT_ISO_PERIPHERAL
 	bool "Bluetooth Isochronous Channel Unicast Peripheral Support [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_PERIPHERAL_ISO_SUPPORT
 	select BT_PERIPHERAL
 	select BT_ISO_UNICAST
 	select EXPERIMENTAL
@@ -27,6 +28,7 @@ config BT_ISO_PERIPHERAL
 
 config BT_ISO_CENTRAL
 	bool "Bluetooth Isochronous Channel Unicast Central Support [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_CENTRAL_ISO_SUPPORT
 	select BT_CENTRAL
 	select BT_ISO_UNICAST
 	select EXPERIMENTAL
@@ -41,6 +43,7 @@ config BT_ISO_BROADCAST
 
 config BT_ISO_BROADCASTER
 	bool "Bluetooth Isochronous Broadcaster Support [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_ADV_ISO_SUPPORT
 	select BT_ISO_BROADCAST
 	select BT_BROADCASTER
 	select BT_PER_ADV
@@ -50,6 +53,7 @@ config BT_ISO_BROADCASTER
 
 config BT_ISO_SYNC_RECEIVER
 	bool "Bluetooth Isochronous Synchronized Receiver Support [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_SYNC_ISO_SUPPORT
 	select BT_ISO_BROADCAST
 	select BT_OBSERVER
 	select BT_PER_ADV_SYNC

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -614,6 +614,7 @@ config BT_ID_MAX
 
 config BT_DF
 	bool "Direction Finding support [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_DF_SUPPORT
 	select EXPERIMENTAL
 	help
 	  Enable support for Bluetooth 5.1 Direction Finding.
@@ -624,24 +625,28 @@ if BT_DF
 
 config BT_DF_CONNECTIONLESS_CTE_RX
 	bool "Support for receive of CTE in connectionless mode"
+	depends on !BT_CTLR || BT_CTLR_DF_CTE_RX_SUPPORT
 	help
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connectionless mode.
 
 config BT_DF_CONNECTIONLESS_CTE_TX
 	bool "Support for transmission of CTE in connectionless mode"
+	depends on !BT_CTLR || BT_CTLR_DF_CTE_TX_SUPPORT
 	help
 	  Enable support for transmission of Constant Tone Extension in
 	  connectionless mode.
 
 config BT_DF_CONNECTION_CTE_RX
 	bool "Support for receive of CTE in connection mode"
+	depends on !BT_CTLR || BT_CTLR_DF_CTE_RX_SUPPORT
 	help
 	  Enable support for reception and sampling of Constant Tone Extension
 	  in connection mode.
 
 config BT_DF_CONNECTION_CTE_TX
 	bool "Support for transmission of CTE in connection mode"
+	depends on !BT_CTLR || BT_CTLR_DF_CTE_TX_SUPPORT
 	help
 	  Enable support for transmission of Constant Tone Extension in
 	  connection mode.

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/Kconfig
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/Kconfig
@@ -1,0 +1,14 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Workaround for pretending that the controller
+# supports CIS as the host expects the controller
+# to support these features.
+
+config BT_LL_SW_SPLIT
+	select BT_CTLR_CENTRAL_ISO_SUPPORT
+	select BT_CTLR_PERIPHERAL_ISO_SUPPORT
+
+menu "Zephyr Kernel"
+source "Kconfig.zephyr"
+endmenu


### PR DESCRIPTION
When performing a combined host and controller build, there is no point
in presenting the option to enable a given host feature if the
controller does not support it. This reduces the list of presented
features to enable/disable.

Signed-off-by: Rubin Gerritsen <rubin.gerritsen@nordicsemi.no>