### PR TITLE
drivers: gpio: gpio_mcux_lpc: fix lost interrupts

### DIFF
--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -224,8 +224,10 @@ static void gpio_mcux_lpc_port_isr(const struct device *dev)
 				config->pint_base, data->pint_id[pin]);
 			enabled_int = int_flags << pin;
 
-			PINT_PinInterruptClrStatus(config->pint_base,
-						   data->pint_id[pin]);
+			if (int_flags) {
+				PINT_PinInterruptClrStatus(config->pint_base,
+							   data->pint_id[pin]);
+			}
 
 			gpio_fire_callbacks(&data->callbacks, dev, enabled_int);
 		}


### PR DESCRIPTION
if ISR got called for an event on pin X but
another event occurred on pin Y in between the call
to GetStatus() and ClrStatus(), pin Y event was getting
cleared without being processed

Signed-off-by: Maxim Adelman <imax@fb.com>

Fixes #46697