### PR TITLE
modules: mbedtls: remove MBEDTLS_ECP_MAX_BITS from mbedTLS configs

### DIFF
--- a/modules/mbedtls/configs/config-suite-b.h
+++ b/modules/mbedtls/configs/config-suite-b.h
@@ -109,7 +109,6 @@
 #define MBEDTLS_AES_ROM_TABLES
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS   384
 #define MBEDTLS_MPI_MAX_SIZE    48 // 384 bits is 48 bytes
 
 /* Save RAM at the expense of speed, see ecp.h */

--- a/modules/mbedtls/configs/config-thread.h
+++ b/modules/mbedtls/configs/config-thread.h
@@ -109,7 +109,6 @@
 #define MBEDTLS_AES_ROM_TABLES
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             256
 #define MBEDTLS_MPI_MAX_SIZE              32 // 256 bits is 32 bytes
 
 /* Save ROM and a few bytes of RAM by specifying our own ciphersuite list */

--- a/modules/mbedtls/configs/config-threadnet.h
+++ b/modules/mbedtls/configs/config-threadnet.h
@@ -95,7 +95,6 @@
 #define MBEDTLS_AES_ROM_TABLES
 
 /* Save RAM by adjusting to our exact needs */
-#define MBEDTLS_ECP_MAX_BITS             256
 #define MBEDTLS_MPI_MAX_SIZE              32 // 256 bits is 32 bytes
 
 #define MBEDTLS_SSL_MAX_CONTENT_LEN 1024


### PR DESCRIPTION
According to mbedTLS' Changelog "Mbed TLS 3.0.0 branch released
2021-07-07" -> "Removals":

>MBEDTLS_ECP_MAX_BITS is no longer a configuration option because it
>is now determined automatically based on supported curves.

Hence remove MBEDTLS_ECP_MAX_BITS from configuration files to fix build
issues with Zephyr when there is unfortunate order of include
statements.

Related build failures visible in #46572 (https://github.com/zephyrproject-rtos/zephyr/runs/6902644058?check_suite_focus=true)