### PR TITLE
tests: log_immediate: Increase tests timeout

### DIFF
--- a/tests/subsys/logging/log_immediate/testcase.yaml
+++ b/tests/subsys/logging/log_immediate/testcase.yaml
@@ -5,10 +5,12 @@ common:
 tests:
   logging.log_immediate:
     tags: log_core logging
+    timeout: 80
     platform_exclude: nucleo_l053r8 nucleo_f030r8 intel_adsp_cavs15
       stm32f0_disco nrf52_bsim
   logging.log_immediate.clean_output:
     extra_args: CONFIG_LOG_IMMEDIATE_CLEAN_OUTPUT=y
     tags: log_core logging
+    timeout: 80
     platform_exclude: nucleo_l053r8 nucleo_f030r8 intel_adsp_cavs15
       stm32f0_disco nrf52_bsim


### PR DESCRIPTION
Slightly increase timeout for these tests since it is often failing in
xtensa simulator.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>