### PR TITLE
tests: subsys: modbus: fix modbus hangs up without the fixture on frdm_k64f

### DIFF
--- a/tests/subsys/modbus/testcase.yaml
+++ b/tests/subsys/modbus/testcase.yaml
@@ -2,6 +2,7 @@ tests:
   modbus.rtu:
     tags: modbus
     platform_allow: frdm_k64f
+    harness: ztest
     harness_config:
       # MODBUS test fixture for FRDM-K64F:
       # UART3(PTC16)-RX <-> UART2(PTD3)-TX


### PR DESCRIPTION
In the case that frdm_k64f will block when running the modbus test with twister command, add "harness: ztest" in /tests/subsys/modbus/testcase.yaml to skip this test. In this way modbus test will not block with executing twister command. If modbus test is needed, only The fixture of uart_loopback needs to be added to the map.yml file.

Fixes #46635

Signed-off-by: Li, ShaoanX shaoanx.li@intel.com