### PR TITLE
drivers: counter: stm32: Add support for HSE as RTC clock source

### DIFF
--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -30,6 +30,14 @@ config COUNTER_RTC_STM32_CLOCK_LSE
 	help
 	  Use LSE as RTC clock
 
+config COUNTER_RTC_STM32_CLOCK_HSE
+	bool "HSE"
+	depends on SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || \
+		   SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X || \
+		   SOC_SERIES_STM32L0X || SOC_SERIES_STM32L1X
+	help
+	  Use HSE as RTC clock. An appropriate prescaler must be set.
+
 endchoice #COUNTER_RTC_STM32_CLOCK_SRC
 
 if !SOC_SERIES_STM32F4X
@@ -74,6 +82,13 @@ config COUNTER_RTC_STM32_LSE_BYPASS
 	depends on COUNTER_RTC_STM32_CLOCK_LSE
 	help
 	  Enable LSE bypass
+
+config COUNTER_RTC_STM32_HSE_DIV
+	int "HSE prescaler"
+	depends on COUNTER_RTC_STM32_CLOCK_HSE
+	default 0
+	help
+	  HSE division factor for obtaining a 1 MHz RTC clock
 
 config COUNTER_RTC_STM32_BACKUP_DOMAIN_RESET
 	bool "Do backup domain reset"


### PR DESCRIPTION
Add Kconfig options COUNTER_RTC_STM32_CLOCK_HSE and COUNTER_RTC_STM32_HSE_DIV
to allow configuring HSE as the RTC clock source.

Signed-off-by: Markus Fuchs <markus.fuchs@ch.sauter-bc.com>