### PR TITLE
tests: kernel: stack_random: Disable -Wdangling-pointer warning

### DIFF
--- a/tests/kernel/mem_protect/stack_random/src/main.c
+++ b/tests/kernel/mem_protect/stack_random/src/main.c
@@ -14,6 +14,16 @@
 void *last_sp = (void *)0xFFFFFFFF;
 volatile unsigned int changed;
 
+/*
+ * The `alternate_thread` function deliberately makes use of a dangling pointer
+ * in order to test stack randomisation.
+ */
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wdangling-pointer"
+#endif
+
 void alternate_thread(void)
 {
 	int i;
@@ -32,6 +42,9 @@ void alternate_thread(void)
 	last_sp = sp_val;
 }
 
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 K_THREAD_STACK_DEFINE(alt_thread_stack_area, STACKSIZE);
 static struct k_thread alt_thread_data;


### PR DESCRIPTION
This commit selectively disables the dangling pointer warning
(`-Wdangling-pointer`) for the compilation of the `alternate_thread`
function because it deliberately makes use of a dangling pointer in
order to test stack randomisation.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>