### PR TITLE
drivers: i2c: Fix infinite recursion in driver unregister function

### DIFF
--- a/drivers/i2c/i2c_handlers.c
+++ b/drivers/i2c/i2c_handlers.c
@@ -81,7 +81,7 @@ static inline int z_vrfy_i2c_slave_driver_register(const struct device *dev)
 static inline int z_vrfy_i2c_slave_driver_unregister(const struct device *dev)
 {
 	Z_OOPS(Z_SYSCALL_OBJ(dev, K_OBJ_DRIVER_I2C));
-	return z_vrfy_i2c_slave_driver_unregister(dev);
+	return z_impl_i2c_slave_driver_unregister(dev);
 }
 #include <syscalls/i2c_slave_driver_unregister_mrsh.c>
 


### PR DESCRIPTION
This commit fixes an infinite recusion in the
`z_vrfy_i2c_slave_driver_unregister` function.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Fixes #46621