### PR TITLE
Bluetooth: Tester: Add support for EATT connection

### DIFF
--- a/tests/bluetooth/tester/src/bttester.h
+++ b/tests/bluetooth/tester/src/bttester.h
@@ -723,6 +723,13 @@ struct gatt_change_db_cmd {
 	uint8_t visibility;
 } __packed;
 
+#define GATT_EATT_CONNECT		0x1f
+struct gatt_eatt_connect_cmd {
+	uint8_t address_type;
+	uint8_t address[6];
+	uint8_t num_channels;
+} __packed;
+
 #define GATT_READ_MULTIPLE_VAR		0x20
 
 /* GATT events */


### PR DESCRIPTION
A new command is added to connect EATT channels.

Affects L2CAP/TIM/BV-03-C, which tests requirements on ATT.

Signed-off-by: Herman Berget <herman.berget@nordicsemi.no>

Corresponding auto-pts PR: https://github.com/intel/auto-pts/pull/759