### PR TITLE
requirements: Require pyelftools >= 0.29

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -168,10 +168,6 @@ check_set_compiler_property(PROPERTY freestanding -ffreestanding)
 # Flag to enable debugging
 set_compiler_property(PROPERTY debug -g)
 
-# GCC 11 by default emits DWARF version 5 which cannot be parsed by
-# pyelftools. Can be removed once pyelftools supports v5.
-check_set_compiler_property(APPEND PROPERTY debug -gdwarf-4)
-
 set_compiler_property(PROPERTY no_common -fno-common)
 
 # GCC compiler flags for imacros. The specific header must be appended by user.

--- a/scripts/requirements-base.txt
+++ b/scripts/requirements-base.txt
@@ -4,7 +4,7 @@
 # part of the recommended workflow
 
 # used by various build scripts
-pyelftools>=0.27
+pyelftools>=0.29
 
 # used by dts generation to parse binding YAMLs, also used by
 # twister to parse YAMLs, by west, zephyr_module,...


### PR DESCRIPTION
This commit updates the base requirements file to require the
pyelftools package of a version greater than or equal to 0.29.

pyelftools 0.29 or above is required to properly support the DWARF 5
debugging format used by default on GCC 11 and above.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>