### PR TITLE
scripts: checkpatch: allow leading spaces in multi-lines macros

### DIFF
--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -3284,9 +3284,11 @@ sub process {
 		next if ($realfile !~ /\.(h|c|pl|dtsi|dts)$/);
 
 # at the beginning of a line any tabs must come first and anything
-# more than $tabsize must use tabs.
+# more than $tabsize must use tabs, except multi-line macros which may start
+# with spaces on empty lines
 		if ($rawline =~ /^\+\s* \t\s*\S/ ||
-		    $rawline =~ /^\+\s*        \s*/) {
+		    $rawline =~ /^\+\s*        \s*/ &&
+		    $rawline !~ /^\+\s*\\$/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			$rpt_cleaners = 1;
 			if (ERROR("CODE_INDENT",
@@ -3549,7 +3551,9 @@ sub process {
 #  1) within comments
 #  2) indented preprocessor commands
 #  3) hanging labels
-		if ($rawline =~ /^\+ / && $line !~ /^\+ *(?:$;|#|$Ident:)/)  {
+#  4) empty lines in multi-line macros
+		if ($rawline =~ /^\+ / && $line !~ /^\+ *(?:$;|#|$Ident:)/ &&
+		    $rawline !~ /^\+\s+\\$/) {
 			my $herevet = "$here\n" . cat_vet($rawline) . "\n";
 			if (WARN("LEADING_SPACE",
 				 "please, no spaces at the start of a line\n" . $herevet) &&


### PR DESCRIPTION
With the current clang-format rules, we have that multi-line macros that
contain empty lines (usual in driver definition macros) are formatted
with spaces only, no leading tabs. For example:

```c
 #define MYDRIVER_DEFINE(i)                 \
 	 struct mydriver_data data##i;      \
                                            \ /* starts with spaces */
	 struct mydriver_config config##i;  \
	 ...
```

This patch makes checkpatch ignore such cases, so that clang-format can
be used in tree while keeping checkpatch happy.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>