### PR TITLE
adc: stm32: g4: Add calibrated temp sensor

### DIFF
--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -618,6 +618,18 @@
 		};
 	};
 
+	die_temp: dietemp {
+		compatible = "st,stm32-temp-cal";
+		ts-cal1-addr = <0x1FFF75A8>;
+		ts-cal2-addr = <0x1FFF75CA>;
+		ts-cal1-temp = <30>;
+		ts-cal2-temp = <130>;
+		ts-cal-vrefanalog = <3000>;
+		ts-cal-offset = <30>;
+		status = "disabled";
+		label = "DIE_TEMP";
+	};
+
 	usb_fs_phy: usbphy {
 		compatible = "usb-nop-xceiv";
 		#phy-cells = <0>;


### PR DESCRIPTION
Add die_temp node with compatible st,stm32-temp-cal for all g4 STMs. The calibrated version should be more accurate and the properties are the same for all current g4 series chips.