### PR TITLE
drivers: ethernet: stm32_hal: Add a HW checksum option

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -99,6 +99,14 @@ config ETH_STM32_AUTO_NEGOTIATION_ENABLE
 	help
 	  Enable this if using autonegotiation
 
+config ETH_STM32_HW_CHECKSUM
+	bool "Use TX and RX hardware checksum"
+	depends on !SOC_SERIES_STM32H7X
+	help
+	  Enable receive and transmit checksum offload to enhance throughput
+	  performances.
+	  See reference manual for more information on this feature.
+
 if !ETH_STM32_AUTO_NEGOTIATION_ENABLE
 
 config ETH_STM32_SPEED_10M

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1242,6 +1242,10 @@ static enum ethernet_hw_caps eth_stm32_hal_get_capabilities(const struct device 
 #if defined(CONFIG_NET_LLDP)
 		| ETHERNET_LLDP
 #endif
+#if defined(CONFIG_ETH_STM32_HW_CHECKSUM)
+		| ETHERNET_HW_RX_CHKSUM_OFFLOAD
+		| ETHERNET_HW_TX_CHKSUM_OFFLOAD
+#endif
 		;
 }
 
@@ -1360,7 +1364,11 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 #endif /* !CONFIG_ETH_STM32_AUTO_NEGOTIATION_ENABLE */
 			.PhyAddress = PHY_ADDR,
 			.RxMode = ETH_RXINTERRUPT_MODE,
+#if defined(CONFIG_ETH_STM32_HW_CHECKSUM)
+			.ChecksumMode = ETH_CHECKSUM_BY_HARDWARE,
+#else
 			.ChecksumMode = ETH_CHECKSUM_BY_SOFTWARE,
+#endif
 #endif /* !CONFIG_SOC_SERIES_STM32H7X */
 #if defined(CONFIG_ETH_STM32_HAL_MII)
 			.MediaInterface = ETH_MEDIA_INTERFACE_MII,

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1351,30 +1351,18 @@ static struct eth_stm32_hal_dev_data eth0_data = {
 			.AutoNegotiation = ETH_AUTONEGOTIATION_ENABLE,
 #else
 			.AutoNegotiation = ETH_AUTONEGOTIATION_DISABLE,
-#if defined(CONFIG_ETH_STM32_SPEED_10M)
-			.Speed = ETH_SPEED_10M,
-#else
-			.Speed = ETH_SPEED_100M,
-#endif
-#if defined(CONFIG_ETH_STM32_MODE_HALFDUPLEX)
-			.DuplexMode = ETH_MODE_HALFDUPLEX,
-#else
-			.DuplexMode = ETH_MODE_FULLDUPLEX,
-#endif
+			.Speed = IS_ENABLED(CONFIG_ETH_STM32_SPEED_10M) ?
+				 ETH_SPEED_10M : ETH_SPEED_100M,
+			.DuplexMode = IS_ENABLED(CONFIG_ETH_STM32_MODE_HALFDUPLEX) ?
+				      ETH_MODE_HALFDUPLEX : ETH_MODE_FULLDUPLEX,
 #endif /* !CONFIG_ETH_STM32_AUTO_NEGOTIATION_ENABLE */
 			.PhyAddress = PHY_ADDR,
 			.RxMode = ETH_RXINTERRUPT_MODE,
-#if defined(CONFIG_ETH_STM32_HW_CHECKSUM)
-			.ChecksumMode = ETH_CHECKSUM_BY_HARDWARE,
-#else
-			.ChecksumMode = ETH_CHECKSUM_BY_SOFTWARE,
-#endif
+			.ChecksumMode = IS_ENABLED(CONFIG_ETH_STM32_HW_CHECKSUM) ?
+					ETH_CHECKSUM_BY_HARDWARE : ETH_CHECKSUM_BY_SOFTWARE,
 #endif /* !CONFIG_SOC_SERIES_STM32H7X */
-#if defined(CONFIG_ETH_STM32_HAL_MII)
-			.MediaInterface = ETH_MEDIA_INTERFACE_MII,
-#else
-			.MediaInterface = ETH_MEDIA_INTERFACE_RMII,
-#endif
+			.MediaInterface = IS_ENABLED(CONFIG_ETH_STM32_HAL_MII) ?
+					  ETH_MEDIA_INTERFACE_MII : ETH_MEDIA_INTERFACE_RMII,
 		},
 	},
 	.mac_addr = {


### PR DESCRIPTION
Add a HW checksum option that can potentially enhance performances on STM32 SoCs (except STM32H7).
Suggested by @rlubos in https://github.com/zephyrproject-rtos/zephyr/pull/46340#issuecomment-1148805746.

Not tested so testing and feedbacks of STM32 ethernet users welcome.