### PR TITLE
ci: do not add assignees if already set

### DIFF
--- a/scripts/set_assignees.py
+++ b/scripts/set_assignees.py
@@ -170,7 +170,7 @@ def process_pr(gh, maintainer_file, number):
 
     ms = []
     # assignees
-    if maintainer != 'None':
+    if maintainer != 'None' and not pr.assignee:
         try:
             u = gh.get_user(maintainer)
             ms.append(u)
@@ -181,6 +181,8 @@ def process_pr(gh, maintainer_file, number):
             log(f"Adding assignee {mm}...")
             if not args.dry_run:
                 pr.add_to_assignees(mm)
+    else:
+        log("not setting assignee")
 
     time.sleep(1)
 


### PR DESCRIPTION
If PR already has an assignee, do not add additional assignees to the
PR. Each PR should only have one assignee (in most cases)

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
