### PR TITLE
rpi_pico: Fix bootloader linking

### DIFF
--- a/modules/hal_rpi_pico/CMakeLists.txt
+++ b/modules/hal_rpi_pico/CMakeLists.txt
@@ -22,6 +22,8 @@ if(CONFIG_HAS_RPI_PICO)
     endforeach()
 
     set(rp2_bootloader_prefix ${CMAKE_BINARY_DIR}/bootloader)
+    set(rp2_bootloader_asm ${rp2_bootloader_prefix}/boot_stage2.S)
+
     ExternalProject_Add(
       second_stage_bootloader
       SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/bootloader
@@ -35,11 +37,14 @@ if(CONFIG_HAS_RPI_PICO)
         -DFLASH_TYPE=${flash_type}
         -DPYTHON_EXECUTABLE=${Python3_EXECUTABLE}
         -DCONFIG_LEGACY_INCLUDE_PATH=$<BOOL:${CONFIG_LEGACY_INCLUDE_PATH}>
+        -DRP2_BOOTLOADER_BYPRODUCT=${rp2_bootloader_asm}
       INSTALL_COMMAND "" # No installation needed
-      BUILD_BYPRODUCTS ${rp2_bootloader_prefix}/boot_stage2
+      BUILD_BYPRODUCTS ${rp2_bootloader_asm}
       BUILD_ALWAYS TRUE
       )
-    zephyr_library_sources(${rp2_bootloader_prefix}/boot_stage2)
+
+      add_dependencies(${ZEPHYR_CURRENT_LIBRARY} second_stage_bootloader)
+      zephyr_library_sources(${rp2_bootloader_asm})
   endif()
 
   # Pico sources and headers necessary for every build.

--- a/modules/hal_rpi_pico/bootloader/CMakeLists.txt
+++ b/modules/hal_rpi_pico/bootloader/CMakeLists.txt
@@ -64,7 +64,7 @@ add_custom_command(TARGET boot_stage2
 # Checksums the binary, pads it, and generates an assembly file
 add_custom_command(TARGET boot_stage2
   POST_BUILD
-  BYPRODUCTS boot_stage2.S
+  BYPRODUCTS ${RP2_BOOTLOADER_BYPRODUCT}
   COMMAND ${PYTHON_EXECUTABLE} ${boot_stage_dir}/pad_checksum
-  -s 0xffffffff boot_stage2.bin boot_stage2.S
+  -s 0xffffffff boot_stage2.bin ${RP2_BOOTLOADER_BYPRODUCT}
   )


### PR DESCRIPTION
A recent change to hal_rpi_pico's cmake (#46062), intended to fix the compilation via Unix Makefiles, ended up not linking the BL to the final ELF. This commit fixes both problems.
This was tested with and without `-G"Unix Makefiles"`, and was tested on hardware.

Fixes #46573

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>