### PR TITLE
doc: project: Fix role nomination template URL

### DIFF
--- a/doc/project/project_roles.rst
+++ b/doc/project/project_roles.rst
@@ -61,7 +61,7 @@ level to the Zephyr GitHub repository.
 
 You may nominate yourself, or another GitHub user, for promotion to the Triage
 permission level by creating a GitHub issue, using the :github:`nomination
-template <new?assignees=&labels=bug&template=nomination.md&title=>`.
+template <new?assignees=&labels=Role+Nomination&template=nomination.md&title=>`.
 
 Contributors granted the Triage permission level are permitted to add reviewers
 to a pull request and can be added as a reviewer by other GitHub users.


### PR DESCRIPTION
This commit fixes the URL for the role nomination template that
incorrectly specified the 'bug' label instead of the 'Role Nomination'
label.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>