### PR TITLE
soc: arm: gigadevice: use common API headers

### DIFF
--- a/drivers/dac/dac_gd32.c
+++ b/drivers/dac/dac_gd32.c
@@ -9,7 +9,9 @@
 #include <errno.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/dac.h>
-#include <soc.h>
+
+#include <gd32_dac.h>
+#include <gd32_rcu.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(dac_gd32, CONFIG_DAC_LOG_LEVEL);

--- a/drivers/gpio/gpio_gd32.c
+++ b/drivers/gpio/gpio_gd32.c
@@ -8,7 +8,9 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/interrupt_controller/gd32_exti.h>
-#include <soc.h>
+
+#include <gd32_gpio.h>
+#include <gd32_rcu.h>
 
 #include "gpio_utils.h"
 

--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -11,7 +11,9 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/i2c.h>
-#include <soc.h>
+
+#include <gd32_i2c.h>
+#include <gd32_rcu.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_gd32, CONFIG_I2C_LOG_LEVEL);

--- a/drivers/interrupt_controller/intc_gd32_exti.c
+++ b/drivers/interrupt_controller/intc_gd32_exti.c
@@ -8,9 +8,10 @@
 
 #include <zephyr/device.h>
 #include <zephyr/drivers/interrupt_controller/gd32_exti.h>
-#include <soc.h>
 #include <zephyr/sys/__assert.h>
 #include <zephyr/sys/util_macro.h>
+
+#include <gd32_exti.h>
 
 /** Unsupported line indicator */
 #define EXTI_NOTSUP 0xFFU

--- a/drivers/pinctrl/pinctrl_gd32_af.c
+++ b/drivers/pinctrl/pinctrl_gd32_af.c
@@ -5,7 +5,9 @@
  */
 
 #include <zephyr/drivers/pinctrl.h>
-#include <soc.h>
+
+#include <gd32_gpio.h>
+#include <gd32_rcu.h>
 
 BUILD_ASSERT((GD32_PUPD_NONE == GPIO_PUPD_NONE) &&
 	     (GD32_PUPD_PULLUP == GPIO_PUPD_PULLUP) &&

--- a/drivers/pinctrl/pinctrl_gd32_afio.c
+++ b/drivers/pinctrl/pinctrl_gd32_afio.c
@@ -5,7 +5,9 @@
  */
 
 #include <zephyr/drivers/pinctrl.h>
-#include <soc.h>
+
+#include <gd32_gpio.h>
+#include <gd32_rcu.h>
 
 /** AFIO DT node */
 #define AFIO_NODE DT_NODELABEL(afio)

--- a/drivers/pwm/pwm_gd32.c
+++ b/drivers/pwm/pwm_gd32.c
@@ -10,8 +10,10 @@
 
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
-#include <soc.h>
 #include <zephyr/sys/util_macro.h>
+
+#include <gd32_rcu.h>
+#include <gd32_timer.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(pwm_gd32, CONFIG_PWM_LOG_LEVEL);

--- a/drivers/serial/usart_gd32.c
+++ b/drivers/serial/usart_gd32.c
@@ -8,7 +8,9 @@
 #include <errno.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/uart.h>
-#include <soc.h>
+
+#include <gd32_usart.h>
+#include <gd32_rcu.h>
 
 /* Unify GD32 HAL USART status register name to USART_STAT */
 #ifndef USART_STAT

--- a/drivers/spi/spi_gd32.c
+++ b/drivers/spi/spi_gd32.c
@@ -10,7 +10,9 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/pinctrl.h>
 #include <zephyr/drivers/spi.h>
-#include <soc.h>
+
+#include <gd32_rcu.h>
+#include <gd32_spi.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(spi_gd32);

--- a/modules/hal_gigadevice/CMakeLists.txt
+++ b/modules/hal_gigadevice/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 zephyr_include_directories(${gd32_soc_sys_dir}/include)
 zephyr_include_directories(${gd32_std_dir}/include)
 zephyr_include_directories(${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/include)
+zephyr_include_directories(${ZEPHYR_HAL_GIGADEVICE_MODULE_DIR}/common_include)
 
 zephyr_library_sources(${gd32_soc_sys_dir}/source/system_${CONFIG_SOC_SERIES}.c)
 

--- a/west.yml
+++ b/west.yml
@@ -71,7 +71,7 @@ manifest:
       groups:
         - hal
     - name: hal_gigadevice
-      revision: 63a72ca90b7e0d7257211ddc5c79e8c0b940371b
+      revision: cc8bc14c612e5ecfcb0435f6da53f3302e25014a
       path: modules/hal/gigadevice
       groups:
         - hal


### PR DESCRIPTION
Stop relying on <soc.h> to access HAL APIs. Use generic, per-API headers
instead. Note that <soc.h> has been left as is for now, since ARM MPU
relies on a fragile chain of includes/type definitions.

This change should improve compilation efficiency, as we no longer pull
APIs that are not needed. A similar approach is followed by STM32
drivers.

Related to https://github.com/zephyrproject-rtos/zephyr/pull/46147 and https://github.com/zephyrproject-rtos/zephyr/issues/41543