### PR TITLE
west: Fix --openocd-search argument

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -140,7 +140,7 @@ def add_parser_common(command, parser_adder=None, parser=None):
     group.add_argument('--gdb', help='path to GDB')
     group.add_argument('--openocd', help='path to openocd')
     group.add_argument(
-        '--openocd-search', metavar='DIR',
+        '--openocd-search', metavar='DIR', action='append',
         help='path to add to openocd search path, if applicable')
 
     return parser


### PR DESCRIPTION
Running west flash with the --openocd-search arg will result in the
openocd command being run with a -s param added for every character in
the passed DIR.

Fix the argparser to append all openocd-search DIRs into a list, instead
of just passing a string to the subcommand.