### PR TITLE
tests: arm: runtime nmi testcase is flushing DCACHE

### DIFF
--- a/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
+++ b/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c
@@ -61,6 +61,12 @@ void test_arm_runtime_nmi(void)
 	/* Trigger NMI: Should fire immediately */
 	SCB->ICSR |= SCB_ICSR_NMIPENDSET_Msk;
 
+#ifdef ARM_CACHEL1_ARMV7_H
+	/* Flush Data Cache now if enabled */
+	if (IS_ENABLED(CONFIG_DCACHE)) {
+		SCB_CleanDCache();
+	}
+#endif /* ARM_CACHEL1_ARMV7_H */
 	zassert_true(nmi_triggered, "Isr not triggered!\n");
 }
 /**


### PR DESCRIPTION
On mcu with Data Cache, when it is enabled (CONFIG_DCACHE=y),
the DCACHE must be flushed after the NMI loop to trig all the irq, else the last one is missing.

This is the required especially on stm32h7 and stm32f7 devices from STMicroelectronics.
on mcu with **ARM_CACHEL1_ARMV7_H**
when the CONFIG_DCACHE=y  (default).
Else the test case fails:

```
Running TESTSUITE arm_runtime_nmi_fn
===================================================================
START - test_arm_runtime_nmi                                                                                    
Trigger NMI in 10s: 0 s                                                                                         
Trigger NMI in 10s: 1 s                                                                                         
Trigger NMI in 10s: 2 s                                                                                         
Trigger NMI in 10s: 3 s                                                                                         
Trigger NMI in 10s: 4 s                                                                                         
Trigger NMI in 10s: 5 s                                                                                         
Trigger NMI in 10s: 6 s                                                                                         
Trigger NMI in 10s: 7 s                                                                                         
Trigger NMI in 10s: 8 s                                                                                         
Trigger NMI in 10s: 9 s                                                                                         
NMI triggered (test_handler_isr)!                                                                               
                                                                                                                
    Assertion failed at WEST_TOPDIR/zephyr/tests/arch/arm/arm_runtime_nmi/src/arm_runtime_nmi.c:66: test_arm_ru)
Isr not triggered!       
```                                                                                       
                                                                                                                
 FAIL - test_arm_runtime_nmi in 10.39 seconds                                                                   


Signed-off-by: Francois Ramu <francois.ramu@st.com>