### PR TITLE
bluetooth: conn: Add getter for authentication callbacks

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1347,6 +1347,14 @@ struct bt_conn_auth_info_cb {
 	sys_snode_t node;
 };
 
+/** @brief Get authentication callbacks.
+ *
+ *  Get registered authentication callbacks.
+ *
+ *  @return Registered authentication callbacks or NULL if no callbacks were registered.
+ */
+const struct bt_conn_auth_cb *bt_conn_auth_cb_get(void);
+
 /** @brief Register authentication callbacks.
  *
  *  Register callbacks to handle authenticated pairing. Passing NULL

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2808,6 +2808,11 @@ struct net_buf *bt_conn_create_frag_timeout(size_t reserve, k_timeout_t timeout)
 }
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
+const struct bt_conn_auth_cb *bt_conn_auth_cb_get(void)
+{
+	return bt_auth;
+}
+
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 {
 	if (!cb) {


### PR DESCRIPTION
Change introduces getter API for the registered Bluetooth authentication callbacks.