### PR TITLE
boards: stm32: Add zephyr_udc0 when it is missing.

### DIFF
--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -165,7 +165,7 @@ arduino_i2c: &i2c1 {};
 	status = "okay";
 };
 
-&usb {
+zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -129,7 +129,7 @@
 	status = "okay";
 };
 
-&usb {
+zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
 	disconnect-gpios = <&gpioc 11 GPIO_ACTIVE_LOW>;

--- a/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
+++ b/boards/arm/olimex_stm32_h407/olimex_stm32_h407.dts
@@ -93,7 +93,7 @@
 	status = "okay";
 };
 
-&usbotg_fs {
+zephyr_udc0: &usbotg_fs {
 	pinctrl-0 = <&usb_otg_fs_dm_pa11 &usb_otg_fs_dp_pa12>;
 	pinctrl-names = "default";
 };

--- a/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
+++ b/boards/arm/stm32_min_dev/stm32_min_dev.dtsi
@@ -111,7 +111,7 @@
 	};
 };
 
-&usb {
+zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -106,7 +106,7 @@
 	};
 };
 
-&usb {
+zephyr_udc0: &usb {
 	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
 	pinctrl-names = "default";
 	status = "okay";


### PR DESCRIPTION
Some STM32 based boards where missing the alternate node label zephyr_udc0,
leading to build issues when compiling usb samples.

Fixes #46626

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>