### PR TITLE
Fix test_thread_stats_usage fail on arm FVP

### DIFF
--- a/drivers/timer/arm_arch_timer.c
+++ b/drivers/timer/arm_arch_timer.c
@@ -194,7 +194,8 @@ static int sys_clock_driver_init(const struct device *dev)
 	IRQ_CONNECT(ARM_ARCH_TIMER_IRQ, ARM_ARCH_TIMER_PRIO,
 		    arm_arch_timer_compare_isr, NULL, ARM_ARCH_TIMER_FLAGS);
 	arm_arch_timer_init();
-	arm_arch_timer_set_compare(arm_arch_timer_count() + CYC_PER_TICK);
+	last_cycle = arm_arch_timer_count();
+	arm_arch_timer_set_compare(last_cycle + CYC_PER_TICK);
 	arm_arch_timer_enable(true);
 	irq_enable(ARM_ARCH_TIMER_IRQ);
 	arm_arch_timer_set_irq_mask(false);


### PR DESCRIPTION
This PR can fix https://github.com/zephyrproject-rtos/zephyr/issues/46366.

More detailed information can be seen in the code.