### PR TITLE
test: Enable the GPIO tests on EHL_CRB.

### DIFF
--- a/boards/x86/ehl_crb/ehl_crb.yaml
+++ b/boards/x86/ehl_crb/ehl_crb.yaml
@@ -5,6 +5,8 @@ arch: x86
 toolchain:
   - zephyr
 ram: 2048
+supported:
+  - gpio
 testing:
   ignore_tags:
      - net

--- a/soc/x86/elkhart_lake/Kconfig.defconfig
+++ b/soc/x86/elkhart_lake/Kconfig.defconfig
@@ -20,4 +20,8 @@ config I2C_DW
 	default y
 	depends on I2C
 
+config GPIO_INTEL
+	default y
+	depends on GPIO
+
 endif # SOC_ELKHART_LAKE

--- a/tests/drivers/gpio/gpio_basic_api/boards/ehl_crb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/ehl_crb.overlay
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/* By default, EHL_CRB on SBL, SBL locks all gpio registeration configuration.
+ * Please follow up do the following changes:
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B04 -> GPIO Skip -> Disable
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B04 -> PadMode -> GPIO control of the pad
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B04 -> HostSoftPadOwn -> Host ownership to GPIO Driver mode
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B04 -> Direction -> DirOut
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B04 -> LockConfig -> PadUnlock
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B23 -> GPIO Skip -> Disable
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B23 -> PadMode -> GPIO control of the pad
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B23 -> HostSoftPadOwn -> Host ownership to GPIO Driver mode
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B23 -> Direction -> DirIn
+ * GPIO Settings -> GPIO_GPP_B -> GPP_B23 -> LockConfig -> PadUnlock
+ */
+/ {
+	resources {
+		compatible = "test-gpio-basic-api";
+
+		out-gpios = <&gpio_0_b 4 0>;
+		in-gpios  = <&gpio_0_b 23 0>;
+	};
+};


### PR DESCRIPTION
Enable testcases under tests/drivers/gpio/gpio_basic_api
To run in twister, "-X gpio_loopback" parameter is needed.

Signed-off-by: Yinfang Wang <yinfang.wang@intel.com>