### PR TITLE
drivers: pwm: b91: fix multi-instance support

### DIFF
--- a/drivers/pwm/pwm_b91.c
+++ b/drivers/pwm/pwm_b91.c
@@ -11,25 +11,24 @@
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
 
-
-#define PWM_PCLK_SPEED      DT_INST_PROP(0, clock_frequency)
-#define NUM_OF_CHANNELS     DT_INST_PROP(0, channels)
-
-PINCTRL_DT_INST_DEFINE(0);
-
-static const struct pinctrl_dev_config *pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0);
+struct pwm_b91_config {
+	const struct pinctrl_dev_config *pcfg;
+	uint32_t clock_frequency;
+	uint8_t channels;
+	uint8_t clk32k_ch_enable;
+};
 
 /* API implementation: init */
 static int pwm_b91_init(const struct device *dev)
 {
-	ARG_UNUSED(dev);
+	const struct pwm_b91_config *config = dev->config;
 
 	uint32_t status = 0;
 	uint8_t clk_32k_en = 0;
 	uint32_t pwm_clk_div = 0;
 
 	/* Calculate and check PWM clock divider */
-	pwm_clk_div = sys_clk.pclk * 1000 * 1000 / PWM_PCLK_SPEED - 1;
+	pwm_clk_div = sys_clk.pclk * 1000 * 1000 / config->clock_frequency - 1;
 	if (pwm_clk_div > 255) {
 		return -EINVAL;
 	}
@@ -38,16 +37,16 @@ static int pwm_b91_init(const struct device *dev)
 	pwm_set_clk((unsigned char) (pwm_clk_div & 0xFF));
 
 	/* Set PWM 32k Channel clock if enabled */
-	clk_32k_en |= DT_INST_PROP(0, clk32k_ch0_enable) ? PWM_CLOCK_32K_CHN_PWM0 : 0;
-	clk_32k_en |= DT_INST_PROP(0, clk32k_ch1_enable) ? PWM_CLOCK_32K_CHN_PWM1 : 0;
-	clk_32k_en |= DT_INST_PROP(0, clk32k_ch2_enable) ? PWM_CLOCK_32K_CHN_PWM2 : 0;
-	clk_32k_en |= DT_INST_PROP(0, clk32k_ch3_enable) ? PWM_CLOCK_32K_CHN_PWM3 : 0;
-	clk_32k_en |= DT_INST_PROP(0, clk32k_ch4_enable) ? PWM_CLOCK_32K_CHN_PWM4 : 0;
-	clk_32k_en |= DT_INST_PROP(0, clk32k_ch5_enable) ? PWM_CLOCK_32K_CHN_PWM5 : 0;
+	clk_32k_en |= (config->clk32k_ch_enable & BIT(0)) ? PWM_CLOCK_32K_CHN_PWM0 : 0;
+	clk_32k_en |= (config->clk32k_ch_enable & BIT(1)) ? PWM_CLOCK_32K_CHN_PWM1 : 0;
+	clk_32k_en |= (config->clk32k_ch_enable & BIT(2)) ? PWM_CLOCK_32K_CHN_PWM2 : 0;
+	clk_32k_en |= (config->clk32k_ch_enable & BIT(3)) ? PWM_CLOCK_32K_CHN_PWM3 : 0;
+	clk_32k_en |= (config->clk32k_ch_enable & BIT(4)) ? PWM_CLOCK_32K_CHN_PWM4 : 0;
+	clk_32k_en |= (config->clk32k_ch_enable & BIT(5)) ? PWM_CLOCK_32K_CHN_PWM5 : 0;
 	pwm_32k_chn_en(clk_32k_en);
 
 	/* Config PWM pins */
-	status = pinctrl_apply_state(pcfg, PINCTRL_STATE_DEFAULT);
+	status = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (status < 0) {
 		return status;
 	}
@@ -60,10 +59,10 @@ static int pwm_b91_set_cycles(const struct device *dev, uint32_t channel,
 			      uint32_t period_cycles, uint32_t pulse_cycles,
 			      pwm_flags_t flags)
 {
-	ARG_UNUSED(dev);
+	const struct pwm_b91_config *config = dev->config;
 
 	/* check pwm channel */
-	if (channel >= NUM_OF_CHANNELS) {
+	if (channel >= config->channels) {
 		return -EINVAL;
 	}
 
@@ -94,21 +93,14 @@ static int pwm_b91_set_cycles(const struct device *dev, uint32_t channel,
 static int pwm_b91_get_cycles_per_sec(const struct device *dev,
 				      uint32_t channel, uint64_t *cycles)
 {
-	ARG_UNUSED(dev);
+	const struct pwm_b91_config *config = dev->config;
 
 	/* check pwm channel */
-	if (channel >= NUM_OF_CHANNELS) {
+	if (channel >= config->channels) {
 		return -EINVAL;
 	}
 
-	if (
-		((channel == 0u) && DT_INST_PROP(0, clk32k_ch0_enable)) ||
-		((channel == 1u) && DT_INST_PROP(0, clk32k_ch1_enable)) ||
-		((channel == 2u) && DT_INST_PROP(0, clk32k_ch2_enable)) ||
-		((channel == 3u) && DT_INST_PROP(0, clk32k_ch3_enable)) ||
-		((channel == 4u) && DT_INST_PROP(0, clk32k_ch4_enable)) ||
-		((channel == 5u) && DT_INST_PROP(0, clk32k_ch5_enable))
-		) {
+	if ((config->clk32k_ch_enable & BIT(channel)) != 0U) {
 		*cycles = 32000u;
 	} else {
 		*cycles = sys_clk.pclk * 1000 * 1000 / (reg_pwm_clkdiv + 1);
@@ -123,14 +115,25 @@ static const struct pwm_driver_api pwm_b91_driver_api = {
 	.get_cycles_per_sec = pwm_b91_get_cycles_per_sec,
 };
 
-BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) <= 1,
-	     "unsupported PWM instance");
-
 /* PWM driver registration */
 #define PWM_B91_INIT(n)							       \
+	PINCTRL_DT_INST_DEFINE(n);					       \
+									       \
+	static const struct pwm_b91_config config##n = {		       \
+		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		       \
+		.clock_frequency = DT_INST_PROP(n, clock_frequency),	       \
+		.channels = DT_INST_PROP(n, channels),			       \
+		.clk32k_ch_enable =					       \
+			((DT_INST_PROP(n, clk32k_ch0_enable) << 0U) |	       \
+			 (DT_INST_PROP(n, clk32k_ch1_enable) << 1U) |	       \
+			 (DT_INST_PROP(n, clk32k_ch2_enable) << 2U) |	       \
+			 (DT_INST_PROP(n, clk32k_ch3_enable) << 3U) |	       \
+			 (DT_INST_PROP(n, clk32k_ch4_enable) << 4U) |	       \
+			 (DT_INST_PROP(n, clk32k_ch5_enable) << 5U)),	       \
+	};								       \
 									       \
 	DEVICE_DT_INST_DEFINE(n, pwm_b91_init,				       \
-			      NULL, NULL, NULL,				       \
+			      NULL, NULL, &config##n,			       \
 			      POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, \
 			      &pwm_b91_driver_api);
 

--- a/drivers/pwm/pwm_b91.c
+++ b/drivers/pwm/pwm_b91.c
@@ -6,8 +6,8 @@
 
 #define DT_DRV_COMPAT telink_b91_pwm
 
-#include "pwm.h"
-#include "clock.h"
+#include <pwm.h>
+#include <clock.h>
 #include <zephyr/drivers/pwm.h>
 #include <zephyr/drivers/pinctrl.h>
 


### PR DESCRIPTION
Driver was in a weird state: it made use of
DT_INST_FOREACH_STATUS_OKAY, however, it had an assertion to support a
single instance and used instance 0 properties.

Found these issues while trying `clang-format` on the PWM drivers.