### PR TITLE
drivers: can: stm32: support for dual CAN instances

### DIFF
--- a/boards/arm/nucleo_f446re/nucleo_f446re.dts
+++ b/boards/arm/nucleo_f446re/nucleo_f446re.dts
@@ -18,7 +18,7 @@
 		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		zephyr,canbus = &can1;
+		zephyr,canbus = &can2;
 	};
 
 	leds {
@@ -119,6 +119,13 @@
 &can1 {
 	/* CAUTION: PB8 and PB9 may conflict with same pins of I2C1 */
 	pinctrl-0 = <&can1_rx_pb8 &can1_tx_pb9>;
+	pinctrl-names = "default";
+	bus-speed = <125000>;
+	status = "okay";
+};
+
+&can2 {
+	pinctrl-0 = <&can2_rx_pb12 &can2_tx_pb13>;
 	pinctrl-names = "default";
 	bus-speed = <125000>;
 	status = "okay";

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -11,7 +11,7 @@ config CAN_STM32
 	select CAN_HAS_RX_TIMESTAMP
 	help
 	  Enable STM32 CAN Driver.
-	  Tested on stm32F0, stm32L4 and stm32F7 series.
+	  Tested on STM32F0, STM32F4, STM32L4 and STM32F7 series.
 
 config CAN_MAX_FILTER
 	int "Maximum number of concurrent active filters"
@@ -19,5 +19,5 @@ config CAN_MAX_FILTER
 	default 5
 	range 1 56
 	help
-	  Defines the array size of the callback/msgq pointers.
+	  Defines the array size of the callback pointers.
 	  Must be at least the size of concurrent reads.

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -24,7 +24,8 @@
 #define CAN_FIRX_EXT_STD_ID_POS (21U)
 #define CAN_FIRX_EXT_EXT_ID_POS (3U)
 
-#define CAN_BANK_IS_EMPTY(usage, bank_nr) (((usage >> ((bank_nr) * 4)) & 0x0F) == 0x0F)
+#define CAN_BANK_IS_EMPTY(usage, bank_nr, bank_offset) \
+	(((usage >> ((bank_nr - bank_offset) * 4)) & 0x0F) == 0x0F)
 #define CAN_BANK_IN_LIST_MODE(can, bank) ((can)->FM1R & (1U << (bank)))
 #define CAN_BANK_IN_32BIT_MODE(can, bank) ((can)->FS1R & (1U << (bank)))
 #define CAN_IN_16BIT_LIST_MODE(can, bank) (CAN_BANK_IN_LIST_MODE(can, bank) && \

--- a/dts/arm/st/f4/stm32f405.dtsi
+++ b/dts/arm/st/f4/stm32f405.dtsi
@@ -226,6 +226,7 @@
 			reg = <0x40006800 0x400>;
 			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
+			/* also enabling clock for can1 (master instance) */
 			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";

--- a/dts/arm/st/f4/stm32f446.dtsi
+++ b/dts/arm/st/f4/stm32f446.dtsi
@@ -67,7 +67,8 @@
 			reg = <0x40006800 0x400>;
 			interrupts = <63 0>, <64 0>, <65 0>, <66 0>;
 			interrupt-names = "TX", "RX0", "RX1", "SCE";
-			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x04000000>;
+			/* also enabling clock for can1 (master instance) */
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x06000000>;
 			master-can-reg = <0x40006400>;
 			status = "disabled";
 			label = "CAN_2";


### PR DESCRIPTION
This PR implements support for the STM32 dual CAN, where CAN1 and CAN2 share the memory for the filter banks.

Compared to the previous proposal #40531, this implementation only supports an equal split of the available 28 filter banks, which leads to the same amount of 14 filter banks per instance independent of the number of instances available in the MCU. This simplifies the driver implementation significantly and should cover most use cases.

The implementation was tested on a Nucleo F446RE and passes all tests with the following command (the board definition was updated to use `can2` instance instead of `can1` for testing):
```
scripts/twister --device-testing --device-serial /dev/ttyACM0 -p nucleo_f446re -T tests/drivers/can
```

In theory, also CAN3 available on some STM32F7 series MCUs should work if the missing devicetree nodes are added, but I don't have any hardware to test.