### PR TITLE
usb: bt_h4: Set stack sizes using Kconfig

### DIFF
--- a/subsys/usb/device/class/bt_h4.c
+++ b/subsys/usb/device/class/bt_h4.c
@@ -32,9 +32,9 @@ static K_FIFO_DEFINE(tx_queue);
 #define BT_H4_IN_EP_IDX                 1
 
 /* HCI RX/TX threads */
-static K_KERNEL_STACK_DEFINE(rx_thread_stack, 512);
+static K_KERNEL_STACK_DEFINE(rx_thread_stack, CONFIG_BT_RX_STACK_SIZE);
 static struct k_thread rx_thread_data;
-static K_KERNEL_STACK_DEFINE(tx_thread_stack, 512);
+static K_KERNEL_STACK_DEFINE(tx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 static struct k_thread tx_thread_data;
 
 /* HCI USB state flags */


### PR DESCRIPTION
The previously used stack sizes where in many cases too small.