### PR TITLE
dts: x86: intel: ia32: fix uart reg-shift

### DIFF
--- a/dts/x86/intel/ia32.dtsi
+++ b/dts/x86/intel/ia32.dtsi
@@ -46,7 +46,7 @@
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
-			reg-shift = <2>;
+			reg-shift = <0>;
 			status = "disabled";
 		};
 
@@ -57,7 +57,7 @@
 			clock-frequency = <1843200>;
 			interrupts = <3 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
-			reg-shift = <2>;
+			reg-shift = <0>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Platforms that enable UART_NS16550_ACCESS_IOPORT (the case for ia32)
require reg-shift to be zero. Fix this issue introduced in
4c8a8149de0705c9aaa498ae3c228349c9fe9a3e.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/46650