### PR TITLE
Bluetooth: Mesh: RFU fixed group addresses can be used for subscription

### DIFF
--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -50,7 +50,7 @@ extern "C" {
 
 #define BT_MESH_ADDR_IS_UNICAST(addr) ((addr) && (addr) < 0x8000)
 #define BT_MESH_ADDR_IS_GROUP(addr) ((addr) >= 0xc000 && (addr) < 0xff00)
-#define BT_MESH_ADDR_IS_FIXED_GROUP(addr) ((addr) >= 0xfffc && (addr) < 0xffff)
+#define BT_MESH_ADDR_IS_FIXED_GROUP(addr) ((addr) >= 0xff00 && (addr) < 0xffff)
 #define BT_MESH_ADDR_IS_VIRTUAL(addr) ((addr) >= 0x8000 && (addr) < 0xc000)
 #define BT_MESH_ADDR_IS_RFU(addr) ((addr) >= 0xff00 && (addr) <= 0xfffb)
 


### PR DESCRIPTION
Mesh 1.0.1 specification doesn't prohibit to use full range of
the fixed group addresses for subscription.
The immediate use case is upcoming IPT transport models
which will also work on Mesh 1.0 devices. The models
declare their own fixed group addresses.

Signed-off-by: Aleksandr Khromykh <Aleksandr.Khromykh@nordicsemi.no>