### PR TITLE
doc: getting_started: Add missing dependencies

### DIFF
--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -77,7 +77,7 @@ need one.
       .. code-block:: console
 
          sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
-           ccache dfu-util device-tree-compiler wget \
+           ccache dfu-util device-tree-compiler wget protobuf-compiler srecord \
            python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file libpython3.8-dev \
            make gcc gcc-multilib g++-multilib libsdl2-dev
 


### PR DESCRIPTION
The lpcxpresso devices need srec_cat from the srecord package to
generate their image files, and the nanopb module obviously requires
the hostside protobuf tooling.

Both of these are default platforms in an unadorned twister run, and
so produce failures on new systems that had only followed the
instructions in the guide.

Signed-off-by: Andy Ross <andyross@google.com>