### PR TITLE
xtensa: define arch_proc_id() for xtensa

### DIFF
--- a/include/zephyr/arch/arc/arch_inlines.h
+++ b/include/zephyr/arch/arc/arch_inlines.h
@@ -27,5 +27,14 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 #endif /* CONFIG_SMP */
 }
 
+static ALWAYS_INLINE uint32_t arch_proc_id(void)
+{
+	/*
+	 * Placeholder implementation to be replaced with an architecture
+	 * specific call to get processor ID
+	 */
+	return arch_curr_cpu()->id;
+}
+
 #endif /* !_ASMLANGUAGE */
 #endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_ARCH_INLINES_H_ */

--- a/include/zephyr/arch/arm/aarch32/arch_inlines.h
+++ b/include/zephyr/arch/arm/aarch32/arch_inlines.h
@@ -17,4 +17,13 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 }
 #endif
 
+static ALWAYS_INLINE uint32_t arch_proc_id(void)
+{
+	/*
+	 * Placeholder implementation to be replaced with an architecture
+	 * specific call to get processor ID
+	 */
+	return arch_curr_cpu()->id;
+}
+
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM_AARCH32_ARCH_INLINES_H */

--- a/include/zephyr/arch/arm64/arch_inlines.h
+++ b/include/zephyr/arch/arm64/arch_inlines.h
@@ -23,5 +23,14 @@ static ALWAYS_INLINE int arch_exception_depth(void)
 	return (read_tpidrro_el0() & TPIDRROEL0_EXC_DEPTH) / TPIDRROEL0_EXC_UNIT;
 }
 
+static ALWAYS_INLINE uint32_t arch_proc_id(void)
+{
+	/*
+	 * Placeholder implementation to be replaced with an architecture
+	 * specific call to get processor ID
+	 */
+	return arch_curr_cpu()->id;
+}
+
 #endif /* !_ASMLANGUAGE */
 #endif /* ZEPHYR_INCLUDE_ARCH_ARM64_ARCH_INLINES_H */

--- a/include/zephyr/arch/riscv/arch_inlines.h
+++ b/include/zephyr/arch/riscv/arch_inlines.h
@@ -24,5 +24,14 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 #endif /* CONFIG_SMP */
 }
 
+static ALWAYS_INLINE uint32_t arch_proc_id(void)
+{
+	/*
+	 * Placeholder implementation to be replaced with an architecture
+	 * specific call to get processor ID
+	 */
+	return arch_curr_cpu()->id;
+}
+
 #endif /* !_ASMLANGUAGE */
 #endif /* ZEPHYR_INCLUDE_ARCH_RISCV_ARCH_INLINES_H_ */

--- a/include/zephyr/arch/x86/arch_inlines.h
+++ b/include/zephyr/arch/x86/arch_inlines.h
@@ -26,6 +26,15 @@ static inline struct _cpu *arch_curr_cpu(void)
 	return cpu;
 }
 
+static ALWAYS_INLINE uint32_t arch_proc_id(void)
+{
+	/*
+	 * Placeholder implementation to be replaced with an architecture
+	 * specific call to get processor ID
+	 */
+	return arch_curr_cpu()->id;
+}
+
 #endif /* CONFIG_X86_64 */
 
 #endif /* !_ASMLANGUAGE */

--- a/include/zephyr/arch/xtensa/arch_inlines.h
+++ b/include/zephyr/arch/xtensa/arch_inlines.h
@@ -32,6 +32,14 @@ static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
 	return cpu;
 }
 
+static ALWAYS_INLINE uint32_t arch_proc_id(void)
+{
+	uint32_t prid;
+
+	__asm__ volatile("rsr %0, PRID" : "=r"(prid));
+	return prid;
+}
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* ZEPHYR_INCLUDE_ARCH_XTENSA_ARCH_INLINES_H_ */

--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -431,6 +431,28 @@ void arch_irq_offload(irq_offload_routine_t routine, const void *parameter);
 /** Return the CPU struct for the currently executing CPU */
 static inline struct _cpu *arch_curr_cpu(void);
 
+
+/**
+ * @brief Processor hardware ID
+ *
+ * Most multiprocessor architectures have a low-level unique ID value
+ * associated with the current CPU that can be retrieved rapidly and
+ * efficiently in kernel context.  Note that while the numbering of
+ * the CPUs is guaranteed to be unique, the values are
+ * platform-defined. In particular, they are not guaranteed to match
+ * Zephyr's own sequential CPU IDs (even though on some platforms they
+ * do).
+ *
+ * @note There is an inherent race with this API: the system may
+ * preempt the current thread and migrate it to another CPU before the
+ * value is used.  Safe usage requires knowing the migration is
+ * impossible (e.g. because the code is in interrupt context, holds a
+ * spinlock, or cannot migrate due to k_cpu_mask state).
+ *
+ * @return Unique ID for currently-executing CPU
+ */
+static inline uint32_t arch_proc_id(void);
+
 /**
  * Broadcast an interrupt to all CPUs
  *

--- a/soc/xtensa/intel_adsp/common/mp_cavs.c
+++ b/soc/xtensa/intel_adsp/common/mp_cavs.c
@@ -45,17 +45,9 @@ __imr void soc_mp_startup(uint32_t cpu)
 	}
 }
 
-static ALWAYS_INLINE uint32_t prid(void)
-{
-	uint32_t prid;
-
-	__asm__ volatile("rsr %0, PRID" : "=r"(prid));
-	return prid;
-}
-
 void soc_start_core(int cpu_num)
 {
-	uint32_t curr_cpu = prid();
+	uint32_t curr_cpu = arch_proc_id();
 
 #ifdef CONFIG_SOC_SERIES_INTEL_CAVS_V25
 	/* On cAVS v2.5, MP startup works differently.  The core has
@@ -131,7 +123,7 @@ void soc_start_core(int cpu_num)
 
 void arch_sched_ipi(void)
 {
-	uint32_t curr = prid();
+	uint32_t curr = arch_proc_id();
 
 	for (int c = 0; c < CONFIG_MP_NUM_CPUS; c++) {
 		if (c != curr && soc_cpus_active[c]) {
@@ -155,7 +147,7 @@ void idc_isr(const void *param)
 	 * CPU".
 	 */
 	for (int i = 0; i < CONFIG_MP_NUM_CPUS; i++) {
-		IDC[prid()].core[i].tfc = BIT(31);
+		IDC[arch_proc_id()].core[i].tfc = BIT(31);
 	}
 }
 


### PR DESCRIPTION

This interface is currently defined in the soc. Make it more generic and define it on the architecture level so we can use it elsewhere.

- xtensa: add arch_proc_id()
- intel_adsp: use arch_proc_id() instead of local function
