### PR TITLE
dts/arm/st: Stm32g0: fix STM32_PERIPH_BUS_MAX definition

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -139,6 +139,11 @@ static inline int stm32_clock_control_on(const struct device *dev,
 
 	ARG_UNUSED(dev);
 
+	if (IN_RANGE(pclken->bus, STM32_PERIPH_BUS_MIN, STM32_PERIPH_BUS_MAX) == 0) {
+		/* Attemp to change a wrong periph clock bit */
+		return -ENOTSUP;
+	}
+
 	reg = (uint32_t *)(DT_REG_ADDR(DT_NODELABEL(rcc)) + pclken->bus);
 	reg_val = *reg;
 	reg_val |= pclken->enr;

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -13,7 +13,7 @@
 #define STM32_CLOCK_BUS_APB2    0x040
 
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_IOP
-#define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB1
+#define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB2
 
 /** Peripheral clock sources */
 /* RM0444, §5.4.21/22 Clock configuration register (RCC_CCIPRx) */


### PR DESCRIPTION
All STM32G0 SoCs have two sets of registers for APB (APB1_x and APB2_x).
Therefore STM32_PERIPH_BUS_MAX should be set to 0x40 (STM32_CLOCK_BUS_APB2) not 0x3c for this series.

Additionally, this PR adds a check for the validity of the "sub_system" parameter in clock_control_on() in stm32 common clock control driver.
