### PR TITLE
soc: stm32: h7: Generate MPU regions from DT nodes

### DIFF
--- a/soc/arm/st_stm32/stm32h7/mpu_regions.c
+++ b/soc/arm/st_stm32/stm32h7/mpu_regions.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/devicetree.h>
+#include <zephyr/linker/devicetree_regions.h>
 #include "../../common/cortex_m/arm_mpu_mem_cfg.h"
 
 static const struct arm_mpu_region mpu_regions[] = {
@@ -21,6 +22,9 @@ static const struct arm_mpu_region mpu_regions[] = {
 					 DT_REG_ADDR(DT_NODELABEL(sram3)),
 					 REGION_PPB_ATTR(REGION_256B)),
 #endif
+
+	/* DT-defined regions */
+	LINKER_DT_REGION_MPU(ARM_MPU_REGION_INIT)
 };
 
 const struct arm_mpu_config mpu_config = {


### PR DESCRIPTION
Commit b91d21d32cc added the possibility to define MPU regions from the
device tree, however commit c276088567b5 removed that possibility for H7
SoC, as it now uses a SoC specific definition of the MPU regions without
the DT-defined regions (probably because the two PRs got developped in
parallel).

Fix that by adding the macro which adds the DT-defined regions to the
STM32H7 specific file.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>