### PR TITLE
STM32H7A3 flash driver improvements

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -24,12 +24,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(LOG_DOMAIN);
 
-#define STM32H7_FLASH_MAX_ERASE_TIME    4000
-
 /* Let's wait for double the max erase time to be sure that the operation is
  * completed.
  */
-#define STM32H7_FLASH_TIMEOUT   (2 * STM32H7_FLASH_MAX_ERASE_TIME)
+#define STM32H7_FLASH_TIMEOUT	\
+	(2 * DT_PROP(DT_INST(0, st_stm32_nv_flash), max_erase_time))
 
 #ifdef CONFIG_CPU_CORTEX_M4
 #error Flash driver on M4 core is not supported yet

--- a/dts/arm/st/h7/stm32h723.dtsi
+++ b/dts/arm/st/h7/stm32h723.dtsi
@@ -13,9 +13,11 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				write-block-size = <32>;
 				erase-block-size = <DT_SIZE_K(128)>;
+				/* maximum erase time for a 128K sector */
+				max-erase-time = <4000>;
 				label = "FLASH_STM32";
 			};
 		};

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -11,6 +11,8 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
 				write-block-size = <32>;
 				erase-block-size = <DT_SIZE_K(128)>;
 			};

--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -11,10 +11,12 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				label = "FLASH_STM32";
 				write-block-size = <32>;
 				erase-block-size = <DT_SIZE_K(128)>;
+				/* maximum erase time for a 128K sector */
+				max-erase-time = <4000>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h743Xi.dtsi
+++ b/dts/arm/st/h7/stm32h743Xi.dtsi
@@ -11,8 +11,6 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				label = "FLASH_STM32";
 				reg = <0x08000000 DT_SIZE_K(2048)>;
 			};
 		};

--- a/dts/arm/st/h7/stm32h745.dtsi
+++ b/dts/arm/st/h7/stm32h745.dtsi
@@ -11,14 +11,18 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				write-block-size = <32>;
 				erase-block-size = <DT_SIZE_K(128)>;
+				/* maximum erase time for a 128K sector */
+				max-erase-time = <4000>;
 			};
 			flash1: flash@8100000 {
-				compatible = "soc-nv-flash";
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				write-block-size = <32>;
 				erase-block-size = <DT_SIZE_K(128)>;
+				/* maximum erase time for a 128K sector */
+				max-erase-time = <4000>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h750.dtsi
+++ b/dts/arm/st/h7/stm32h750.dtsi
@@ -11,9 +11,11 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				write-block-size = <32>;
 				erase-block-size = <DT_SIZE_K(128)>;
+				/* maximum erase time for a 128K sector */
+				max-erase-time = <4000>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h753Xi.dtsi
+++ b/dts/arm/st/h7/stm32h753Xi.dtsi
@@ -11,8 +11,6 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				label = "FLASH_STM32";
 				reg = <0x08000000 DT_SIZE_K(2048)>;
 			};
 		};

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -11,10 +11,12 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
+				compatible = "st,stm32-nv-flash", "soc-nv-flash";
 				label = "FLASH_STM32";
 				write-block-size = <16>;
 				erase-block-size = <DT_SIZE_K(8)>;
+				/* maximum erase time for a 8K sector */
+				max-erase-time = <3>;
 			};
 		};
 

--- a/dts/arm/st/h7/stm32h7a3.dtsi
+++ b/dts/arm/st/h7/stm32h7a3.dtsi
@@ -11,6 +11,8 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
+				compatible = "soc-nv-flash";
+				label = "FLASH_STM32";
 				write-block-size = <16>;
 				erase-block-size = <DT_SIZE_K(8)>;
 			};

--- a/dts/arm/st/h7/stm32h7a3Xi.dtsi
+++ b/dts/arm/st/h7/stm32h7a3Xi.dtsi
@@ -10,8 +10,6 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				label = "FLASH_STM32";
 				reg = <0x08000000 DT_SIZE_K(2048)>;
 			};
 		};

--- a/dts/arm/st/h7/stm32h7b3Xi.dtsi
+++ b/dts/arm/st/h7/stm32h7b3Xi.dtsi
@@ -10,8 +10,6 @@
 	soc {
 		flash-controller@52002000 {
 			flash0: flash@8000000 {
-				compatible = "soc-nv-flash";
-				label = "FLASH_STM32";
 				reg = <0x08000000 DT_SIZE_K(2048)>;
 			};
 		};


### PR DESCRIPTION
This patchset started with improvements of the flash driver for the STM32H7A3 Soc (as opposed to STM32H7X with 128K flash pages), but also ended up with some small fixes for the whole STM32H7 family.