### PR TITLE
coding guidelines: comply with MISRA C:2012 Rule 9.3

### DIFF
--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -44,7 +44,7 @@ typedef struct sys_bitarray sys_bitarray_t;
 #define _SYS_BITARRAY_DEFINE(name, total_bits, sba_mod)			\
 	sba_mod uint32_t _sys_bitarray_bundles_##name			\
 		[(((total_bits + 8 - 1) / 8) + sizeof(uint32_t) - 1)	\
-		 / sizeof(uint32_t)] = {0U};				\
+		 / sizeof(uint32_t)] = {0};				\
 	sba_mod sys_bitarray_t name = {					\
 		.num_bits = total_bits,					\
 		.num_bundles = (((total_bits + 8 - 1) / 8)		\

--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -52,6 +52,8 @@ static struct fd_entry fdtable[CONFIG_POSIX_MAX_FDS] = {
 		.vtable = &stdinout_fd_op_vtable,
 		.refcount = ATOMIC_INIT(1)
 	},
+#else
+	0
 #endif
 };
 

--- a/scripts/gen_kobject_list.py
+++ b/scripts/gen_kobject_list.py
@@ -860,7 +860,7 @@ def write_gperf_table(fp, syms, objs, little_endian, static_begin, static_end):
         else:
             tname = "unused"
 
-        fp.write("\", {}, %s, %s, { .%s = %s }\n" % (obj_type, flags,
+        fp.write("\", {0}, %s, %s, { .%s = %s }\n" % (obj_type, flags,
 		tname, str(ko.data)))
 
         if obj_type == "K_OBJ_THREAD":


### PR DESCRIPTION
MISRA C:2012 Rule 9.3 (Arrays shall not be partially initialized.)

Systematically use `{0}' to specify full 0 initialization
(not `{}', not `{0U}').

Signed-off-by: Abramo Bagnara <abramo.bagnara@bugseng.com>