### PR TITLE
esp32: Drop IRAM_ATTR from forward declarations

### DIFF
--- a/drivers/gpio/gpio_esp32.c
+++ b/drivers/gpio/gpio_esp32.c
@@ -415,7 +415,7 @@ static void IRAM_ATTR gpio_esp32_fire_callbacks(const struct device *dev)
 	}
 }
 
-static void IRAM_ATTR gpio_esp32_isr(void *param);
+static void gpio_esp32_isr(void *param);
 
 static int gpio_esp32_init(const struct device *dev)
 {

--- a/soc/xtensa/esp32s2/soc.h
+++ b/soc/xtensa/esp32s2/soc.h
@@ -68,7 +68,7 @@ extern uint8_t g_rom_spiflash_dummy_len_plus[];
 extern uint32_t esp_rom_g_ticks_per_us_pro;
 
 /* cache initialization functions */
-void IRAM_ATTR esp_config_instruction_cache_mode(void);
-void IRAM_ATTR esp_config_data_cache_mode(void);
+void esp_config_instruction_cache_mode(void);
+void esp_config_data_cache_mode(void);
 
 #endif /* __SOC_H__ */


### PR DESCRIPTION
This commit drops the `IRAM_ATTR` macro from the function declarations
because:

1. `IRAM_ATTR` macro makes use of the `__COUNTER__` preprocessor macro,
   which increments for every macro invocation and causes the section
   specified in the forward declaration to not match that of the
   function definition.

2. Section attributes need not be specified for forward declarations.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>