### PR TITLE
drivers: serial: uart_altera_jtag: Fix wrong register address used

### DIFF
--- a/drivers/serial/uart_altera_jtag.c
+++ b/drivers/serial/uart_altera_jtag.c
@@ -81,7 +81,7 @@ static int uart_altera_jtag_init(const struct device *dev)
 	uint32_t ctrl_val = sys_read32(config->base + UART_ALTERA_JTAG_CTRL_OFFSET);
 
 	ctrl_val &= ~(UART_IE_TX | UART_IE_RX);
-	sys_write32(ctrl_val, sys_read32(config->base + UART_ALTERA_JTAG_CTRL_OFFSET));
+	sys_write32(ctrl_val, config->base + UART_ALTERA_JTAG_CTRL_OFFSET);
 #endif /* CONFIG_UART_ALTERA_JTAG_HAL */
 	return 0;
 }


### PR DESCRIPTION
This pull request is to fix wrong control register address used in uart_altera_jtag_init function which caused memory corruption.

For testing, patch changes were verified with following samples on altera_max10 board.
hello_world
synchronization
philosophers

By default, ns16550 is selected as default console for altera_max10 board, thus following changes are needed to use Jtag Uart as console during testing.

/boards/nios2/altera_max10/altera_max10.dts
chosen {
zephyr,sram = &sram0;
zephyr,flash = &flash0;
zephyr,console = &jtag_uart;
zephyr,shell-uart = &jtag_uart;
};
};

&jtag_uart {
status = "okay";
};