### PR TITLE
all: logging: Remove log_strdup function

### DIFF
--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -752,7 +752,7 @@ static void dump_entry(int level, void *virt, pentry_t entry)
 	DUMP_BIT(XD);
 
 	LOG_ERR("%sE: %p -> " PRI_ENTRY ": %s", info->name,
-		virtmap, entry & info->mask, log_strdup(buf));
+		virtmap, entry & info->mask, buf);
 
 	#undef DUMP_BIT
 }

--- a/drivers/console/gsm_mux.c
+++ b/drivers/console/gsm_mux.c
@@ -257,12 +257,12 @@ static void hexdump_packet(const char *header, uint8_t address, bool cmd_rsp,
 print:
 	if (IS_ENABLED(CONFIG_GSM_MUX_VERBOSE_DEBUG)) {
 		if (len > 0) {
-			LOG_HEXDUMP_DBG(data, len, log_strdup(out));
+			LOG_HEXDUMP_DBG(data, len, out);
 		} else {
-			LOG_DBG("%s", log_strdup(out));
+			LOG_DBG("%s", out);
 		}
 	} else {
-		LOG_DBG("%s", log_strdup(out));
+		LOG_DBG("%s", out);
 	}
 }
 

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -170,7 +170,7 @@ static int uart_mux_consume_ringbuf(struct uart_mux *uart_mux)
 
 		snprintk(tmp, sizeof(tmp), "RECV muxed %s",
 			 uart_mux->uart->name);
-		LOG_HEXDUMP_DBG(data, len, log_strdup(tmp));
+		LOG_HEXDUMP_DBG(data, len, tmp);
 	}
 
 	gsm_mux_recv_buf(uart_mux->mux, data, len);
@@ -217,7 +217,7 @@ static void uart_mux_tx_work(struct k_work *work)
 
 		snprintk(tmp, sizeof(tmp), "SEND %s",
 			 dev_data->dev->name);
-		LOG_HEXDUMP_DBG(data, len, log_strdup(tmp));
+		LOG_HEXDUMP_DBG(data, len, tmp);
 	}
 
 	(void)gsm_dlci_send(dev_data->dlci, data, len);
@@ -801,7 +801,7 @@ int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size)
 
 		snprintk(tmp, sizeof(tmp), "SEND muxed %s",
 			 dev_data->real_uart->uart->name);
-		LOG_HEXDUMP_DBG(buf, size, log_strdup(tmp));
+		LOG_HEXDUMP_DBG(buf, size, tmp);
 	}
 
 	k_mutex_lock(&dev_data->real_uart->lock, K_FOREVER);
@@ -831,7 +831,7 @@ int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,
 
 		snprintk(tmp, sizeof(tmp), "RECV %s",
 			 dev_data->dev->name);
-		LOG_HEXDUMP_DBG(data, len, log_strdup(tmp));
+		LOG_HEXDUMP_DBG(data, len, tmp);
 	}
 
 	wrote = ring_buf_put(dev_data->rx_ringbuf, data, len);

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -32,7 +32,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 									\
 	snprintk(_str, STR_SIZE, "%s: " fmt, __func__, ## args);	\
 									\
-	LOG_HEXDUMP_DBG(_buf, _len, log_strdup(_str));			\
+	LOG_HEXDUMP_DBG(_buf, _len, _str);			\
 })
 #else
 #define hexdump(args...)

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -473,7 +473,7 @@ static void eth_iface_init(struct net_if *iface)
 		ctx->if_name = ETH_NATIVE_POSIX_DRV_NAME;
 	}
 
-	LOG_DBG("Interface %p using \"%s\"", iface, log_strdup(ctx->if_name));
+	LOG_DBG("Interface %p using \"%s\"", iface, ctx->if_name);
 
 	net_if_set_link_addr(iface, ll_addr->addr, ll_addr->len,
 			     NET_LINK_ETHERNET);

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -158,8 +158,8 @@ static int modem_atoi(const char *s, const int err_value,
 
 	ret = (int)strtol(s, &endptr, 10);
 	if (!endptr || *endptr != '\0') {
-		LOG_ERR("bad %s '%s' in %s", log_strdup(s),
-			 log_strdup(desc), log_strdup(func));
+		LOG_ERR("bad %s '%s' in %s", s,
+			 desc, func);
 		return err_value;
 	}
 
@@ -258,7 +258,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_manufacturer)
 				    sizeof(gsm.minfo.mdm_manufacturer) - 1,
 				    data->rx_buf, 0, len);
 	gsm.minfo.mdm_manufacturer[out_len] = '\0';
-	LOG_INF("Manufacturer: %s", log_strdup(gsm.minfo.mdm_manufacturer));
+	LOG_INF("Manufacturer: %s", gsm.minfo.mdm_manufacturer);
 
 	return 0;
 }
@@ -272,7 +272,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_model)
 				    sizeof(gsm.minfo.mdm_model) - 1,
 				    data->rx_buf, 0, len);
 	gsm.minfo.mdm_model[out_len] = '\0';
-	LOG_INF("Model: %s", log_strdup(gsm.minfo.mdm_model));
+	LOG_INF("Model: %s", gsm.minfo.mdm_model);
 
 	return 0;
 }
@@ -286,7 +286,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_revision)
 				    sizeof(gsm.minfo.mdm_revision) - 1,
 				    data->rx_buf, 0, len);
 	gsm.minfo.mdm_revision[out_len] = '\0';
-	LOG_INF("Revision: %s", log_strdup(gsm.minfo.mdm_revision));
+	LOG_INF("Revision: %s", gsm.minfo.mdm_revision);
 
 	return 0;
 }
@@ -299,7 +299,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imei)
 	out_len = net_buf_linearize(gsm.minfo.mdm_imei, sizeof(gsm.minfo.mdm_imei) - 1,
 				    data->rx_buf, 0, len);
 	gsm.minfo.mdm_imei[out_len] = '\0';
-	LOG_INF("IMEI: %s", log_strdup(gsm.minfo.mdm_imei));
+	LOG_INF("IMEI: %s", gsm.minfo.mdm_imei);
 
 	return 0;
 }
@@ -313,7 +313,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imsi)
 	out_len = net_buf_linearize(gsm.minfo.mdm_imsi, sizeof(gsm.minfo.mdm_imsi) - 1,
 				    data->rx_buf, 0, len);
 	gsm.minfo.mdm_imsi[out_len] = '\0';
-	LOG_INF("IMSI: %s", log_strdup(gsm.minfo.mdm_imsi));
+	LOG_INF("IMSI: %s", gsm.minfo.mdm_imsi);
 
 	return 0;
 }
@@ -338,7 +338,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_iccid)
 			memmove(gsm.minfo.mdm_iccid, p+1, len+1);
 		}
 	}
-	LOG_INF("ICCID: %s", log_strdup(gsm.minfo.mdm_iccid));
+	LOG_INF("ICCID: %s", gsm.minfo.mdm_iccid);
 
 	return 0;
 }

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -1015,7 +1015,7 @@ static int send_at_cmd(struct hl7800_socket *sock, const uint8_t *data,
 			ictx.search_no_id_resp = true;
 		}
 
-		LOG_DBG("OUT: [%s]", log_strdup(data));
+		LOG_DBG("OUT: [%s]", data);
 		mdm_receiver_send(&ictx.mdm_ctx, data, strlen(data));
 		mdm_receiver_send(&ictx.mdm_ctx, "\r", 1);
 
@@ -1672,7 +1672,7 @@ static bool on_cmd_atcmdinfo_manufacturer(struct net_buf **buf, uint16_t len)
 				    sizeof(ictx.mdm_manufacturer) - 1, *buf, 0,
 				    len);
 	ictx.mdm_manufacturer[out_len] = 0;
-	LOG_INF("Manufacturer: %s", log_strdup(ictx.mdm_manufacturer));
+	LOG_INF("Manufacturer: %s", ictx.mdm_manufacturer);
 done:
 	return true;
 }
@@ -1706,7 +1706,7 @@ static bool on_cmd_atcmdinfo_model(struct net_buf **buf, uint16_t len)
 	out_len = net_buf_linearize(ictx.mdm_model, sizeof(ictx.mdm_model) - 1,
 				    *buf, 0, len);
 	ictx.mdm_model[out_len] = 0;
-	LOG_INF("Model: %s", log_strdup(ictx.mdm_model));
+	LOG_INF("Model: %s", ictx.mdm_model);
 done:
 	return true;
 }
@@ -1739,7 +1739,7 @@ static bool on_cmd_atcmdinfo_revision(struct net_buf **buf, uint16_t len)
 	out_len = net_buf_linearize(
 		ictx.mdm_revision, sizeof(ictx.mdm_revision) - 1, *buf, 0, len);
 	ictx.mdm_revision[out_len] = 0;
-	LOG_INF("Revision: %s", log_strdup(ictx.mdm_revision));
+	LOG_INF("Revision: %s", ictx.mdm_revision);
 	event_handler(HL7800_EVENT_REVISION, ictx.mdm_revision);
 done:
 	return true;
@@ -1774,7 +1774,7 @@ static bool on_cmd_atcmdinfo_imei(struct net_buf **buf, uint16_t len)
 				    *buf, 0, len);
 	ictx.mdm_imei[out_len] = 0;
 
-	LOG_INF("IMEI: %s", log_strdup(ictx.mdm_imei));
+	LOG_INF("IMEI: %s", ictx.mdm_imei);
 done:
 	return true;
 }
@@ -1806,7 +1806,7 @@ static bool on_cmd_atcmdinfo_iccid(struct net_buf **buf, uint16_t len)
 				    *buf, 0, len);
 	ictx.mdm_iccid[out_len] = 0;
 
-	LOG_INF("ICCID: %s", log_strdup(ictx.mdm_iccid));
+	LOG_INF("ICCID: %s", ictx.mdm_iccid);
 done:
 	return true;
 }
@@ -1842,7 +1842,7 @@ static bool on_cmd_atcmdinfo_imsi(struct net_buf **buf, uint16_t len)
 		memset(ictx.mdm_imsi, 0, sizeof(ictx.mdm_imsi));
 	}
 
-	LOG_INF("IMSI: %s", log_strdup(ictx.mdm_imsi));
+	LOG_INF("IMSI: %s", ictx.mdm_imsi);
 done:
 	return true;
 }
@@ -1962,14 +1962,14 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 	out_len = net_buf_linearize(value, sizeof(value), *buf, 0, len);
 	value[out_len] = 0;
 	search_start = value;
-	LOG_DBG("IP info: %s", log_strdup(value));
+	LOG_DBG("IP info: %s", value);
 
 	/* find all delimiters (,) */
 	for (int i = 0; i < num_delims; i++) {
 		delims[i] = strchr(search_start, ',');
 		if (!delims[i]) {
 			LOG_ERR("Could not find delim %d, val: %s", i,
-				log_strdup(value));
+				value);
 			return true;
 		}
 		/* Start next search after current delim location */
@@ -2009,7 +2009,7 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 	addr_len = sm_start - addr_start;
 	strncpy(temp_addr_str, addr_start, addr_len);
 	temp_addr_str[addr_len] = 0;
-	LOG_DBG("IP addr: %s", log_strdup(temp_addr_str));
+	LOG_DBG("IP addr: %s", temp_addr_str);
 	if (is_ipv4) {
 		ret = net_addr_pton(AF_INET, temp_addr_str, &new_ipv4_addr);
 	} else {
@@ -2052,7 +2052,7 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 		strncpy(ictx.dns_v4_string, addr_start, addr_len);
 		ictx.dns_v4_string[addr_len] = 0;
 		ret = net_addr_pton(AF_INET, ictx.dns_v4_string, &ictx.dns_v4);
-		LOG_DBG("IPv4 DNS addr: %s", log_strdup(ictx.dns_v4_string));
+		LOG_DBG("IPv4 DNS addr: %s", ictx.dns_v4_string);
 	}
 #ifdef CONFIG_NET_IPV6
 	else {
@@ -2062,7 +2062,7 @@ static bool on_cmd_atcmdinfo_ipaddr(struct net_buf **buf, uint16_t len)
 		ret = hl7800_net_addr6_pton(ictx.dns_v6_string, &ictx.dns_v6);
 		net_addr_ntop(AF_INET6, &ictx.dns_v6, ictx.dns_v6_string,
 			      sizeof(ictx.dns_v6_string));
-		LOG_DBG("IPv6 DNS addr: %s", log_strdup(ictx.dns_v6_string));
+		LOG_DBG("IPv6 DNS addr: %s", ictx.dns_v6_string);
 	}
 #endif
 	if (ret < 0) {
@@ -2138,7 +2138,7 @@ static bool on_cmd_atcmdinfo_operator_status(struct net_buf **buf, uint16_t len)
 		LOG_HEXDUMP_DBG(value, out_len, "Operator: ");
 		goto done;
 	} else {
-		LOG_INF("Operator: %s", log_strdup(value));
+		LOG_INF("Operator: %s", value);
 	}
 
 	/* Process AT+COPS? */
@@ -2154,7 +2154,7 @@ static bool on_cmd_atcmdinfo_operator_status(struct net_buf **buf, uint16_t len)
 	for (i = 0; i < num_delims; i++) {
 		delims[i] = strchr(search_start, ',');
 		if (!delims[i]) {
-			LOG_ERR("Could not find delim %d, val: %s", i, log_strdup(value));
+			LOG_ERR("Could not find delim %d, val: %s", i, value);
 			goto done;
 		}
 		/* Start next search after current delim location */
@@ -2212,7 +2212,7 @@ static bool on_cmd_atcmdinfo_serial_number(struct net_buf **buf, uint16_t len)
 
 	strncpy(ictx.mdm_sn, val_start, sn_len);
 	ictx.mdm_sn[sn_len] = 0;
-	LOG_INF("Serial #: %s", log_strdup(ictx.mdm_sn));
+	LOG_INF("Serial #: %s", ictx.mdm_sn);
 done:
 	return true;
 }
@@ -2465,8 +2465,8 @@ static char *get_fota_state_string(enum mdm_hl7800_fota_state state)
 static void set_fota_state(enum mdm_hl7800_fota_state state)
 {
 	LOG_INF("FOTA state: %s->%s",
-		log_strdup(get_fota_state_string(ictx.fw_update_state)),
-		log_strdup(get_fota_state_string(state)));
+		get_fota_state_string(ictx.fw_update_state),
+		get_fota_state_string(state));
 	ictx.fw_update_state = state;
 	generate_fota_state_event();
 }
@@ -2550,7 +2550,7 @@ static bool profile_handler(struct net_buf **buf, uint16_t len,
 		memset(line, 0, sizeof(line));
 		output_length = net_buf_linearize(line, SIZE_WITHOUT_NUL(line),
 						  *buf, 0, line_length);
-		LOG_DBG("length: %u: %s", line_length, log_strdup(line));
+		LOG_DBG("length: %u: %s", line_length, line);
 
 		/* Echo on off is the first thing on the line: E0, E1 */
 		if (output_length >= SIZE_WITHOUT_NUL("E?")) {
@@ -2611,7 +2611,7 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 		memset(line, 0, sizeof(line));
 		output_length = net_buf_linearize(line, SIZE_WITHOUT_NUL(line),
 						  *buf, 0, line_length);
-		LOG_DBG("length: %u: %s", line_length, log_strdup(line));
+		LOG_DBG("length: %u: %s", line_length, line);
 		if (output_length > 0) {
 			memset(ictx.mdm_apn.username, 0,
 			       sizeof(ictx.mdm_apn.username));
@@ -2630,7 +2630,7 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 				}
 			}
 			LOG_INF("APN Username: %s",
-				log_strdup(ictx.mdm_apn.username));
+				ictx.mdm_apn.username);
 
 			p = strchr(p + 1, '"');
 			if (p != NULL) {
@@ -2643,7 +2643,7 @@ static bool on_cmd_atcmdinfo_pdp_authentication_cfg(struct net_buf **buf,
 				}
 			}
 			LOG_INF("APN Password: %s",
-				log_strdup(ictx.mdm_apn.password));
+				ictx.mdm_apn.password);
 		}
 	}
 	net_buf_remove(buf, line_length);
@@ -2673,7 +2673,7 @@ static bool on_cmd_atcmdinfo_pdp_context(struct net_buf **buf, uint16_t len)
 		memset(line, 0, sizeof(line));
 		output_length = net_buf_linearize(line, SIZE_WITHOUT_NUL(line),
 						  *buf, 0, line_length);
-		LOG_DBG("length: %u: %s", line_length, log_strdup(line));
+		LOG_DBG("length: %u: %s", line_length, line);
 		if (output_length > 0) {
 			memset(ictx.mdm_apn.value, 0, sizeof(ictx.mdm_apn.value));
 			memset(ictx.mdm_pdp_addr_fam, 0, MDM_ADDR_FAM_MAX_LEN);
@@ -2689,7 +2689,7 @@ static bool on_cmd_atcmdinfo_pdp_context(struct net_buf **buf, uint16_t len)
 			while ((p != NULL) && (*p != '"') && (i < MDM_ADDR_FAM_MAX_LEN)) {
 				ictx.mdm_pdp_addr_fam[i++] = *p++;
 			}
-			LOG_DBG("PDP address family: %s", log_strdup(ictx.mdm_pdp_addr_fam));
+			LOG_DBG("PDP address family: %s", ictx.mdm_pdp_addr_fam);
 
 			/* APN after second , " */
 			p = strchr(p, ',');
@@ -2711,7 +2711,7 @@ static bool on_cmd_atcmdinfo_pdp_context(struct net_buf **buf, uint16_t len)
 				}
 			}
 
-			LOG_INF("APN: %s", log_strdup(ictx.mdm_apn.value));
+			LOG_INF("APN: %s", ictx.mdm_apn.value);
 		}
 	}
 done:
@@ -3466,7 +3466,7 @@ static bool on_cmd_rtc_query(struct net_buf **buf, uint16_t len)
 			len, str_len);
 	} else {
 		net_buf_linearize(rtc_string, str_len, *buf, 0, str_len);
-		LOG_INF("RTC string: '%s'", log_strdup(rtc_string));
+		LOG_INF("RTC string: '%s'", rtc_string);
 		ictx.local_time_valid = convert_time_string_to_struct(
 			&ictx.local_time, &ictx.local_time_offset, rtc_string);
 	}
@@ -3560,7 +3560,7 @@ static bool on_cmd_network_report(struct net_buf **buf, uint16_t len)
 				    sizeof(ictx.mdm_network_status) - 1, *buf,
 				    0, len);
 	ictx.mdm_network_status[out_len] = 0;
-	LOG_DBG("Network status: %s", log_strdup(ictx.mdm_network_status));
+	LOG_DBG("Network status: %s", ictx.mdm_network_status);
 	pos = strchr(ictx.mdm_network_status, ',');
 	if (pos) {
 		l = pos - ictx.mdm_network_status;
@@ -3602,7 +3602,7 @@ static bool on_cmd_atcmdinfo_rssi(struct net_buf **buf, uint16_t len)
 		delims[i] = strchr(search_start, ',');
 		if (!delims[i]) {
 			LOG_ERR("Could not find delim %d, val: %s", i,
-				log_strdup(value));
+				value);
 			goto done;
 		}
 		/* Start next search after current delim location */
@@ -3720,7 +3720,7 @@ static bool on_cmd_sock_error_code(struct net_buf **buf, uint16_t len)
 	out_len = net_buf_linearize(value, sizeof(value), *buf, 0, len);
 	value[out_len] = 0;
 
-	LOG_ERR("Error code: %s", log_strdup(value));
+	LOG_ERR("Error code: %s", value);
 
 	ictx.last_error = -EIO;
 	sock = socket_from_id(ictx.last_socket_id);
@@ -4019,7 +4019,7 @@ static void sock_read(struct net_buf **buf, uint16_t len)
 	/* remove EOF pattern from buffer */
 	net_buf_remove(buf, strlen(EOF_PATTERN));
 	if (strcmp(eof, EOF_PATTERN)) {
-		LOG_WRN("Could not find EOF [%s]", log_strdup(eof));
+		LOG_WRN("Could not find EOF [%s]", eof);
 	}
 
 	/* Make sure we have \r\nOK\r\n length in the buffer */
@@ -4047,7 +4047,7 @@ static void sock_read(struct net_buf **buf, uint16_t len)
 	/* remove the message from the buffer */
 	net_buf_remove(buf, strlen(OK_STRING));
 	if (strcmp(ok_resp, OK_STRING)) {
-		LOG_WRN("Could not find OK [%s]", log_strdup(ok_resp));
+		LOG_WRN("Could not find OK [%s]", ok_resp);
 	}
 
 	/* remove \r\n after OK */
@@ -6031,17 +6031,17 @@ int32_t mdm_hl7800_update_fw(char *file_path)
 	/* get file info */
 	ret = fs_stat(file_path, &file_info);
 	if (ret >= 0) {
-		LOG_DBG("file '%s' size %zu", log_strdup(file_info.name),
+		LOG_DBG("file '%s' size %zu", file_info.name,
 			file_info.size);
 	} else {
 		LOG_ERR("Failed to get file [%s] info: %d",
-			log_strdup(file_path), ret);
+			file_path, ret);
 		goto err;
 	}
 
 	ret = fs_open(&ictx.fw_update_file, file_path, FS_O_READ);
 	if (ret < 0) {
-		LOG_ERR("%s open err: %d", log_strdup(file_path), ret);
+		LOG_ERR("%s open err: %d", file_path, ret);
 		goto err;
 	}
 

--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -339,7 +339,7 @@ static void cmd_handler_process_rx_buf(struct modem_cmd_handler_data *data)
 				break;
 			} else if (ret > 0) {
 				LOG_DBG("match direct cmd [%s] (ret:%d)",
-					log_strdup(cmd->cmd), ret);
+					cmd->cmd, ret);
 				data->rx_buf = net_buf_skip(data->rx_buf, ret);
 			}
 
@@ -377,7 +377,7 @@ static void cmd_handler_process_rx_buf(struct modem_cmd_handler_data *data)
 		cmd = find_cmd_match(data);
 		if (cmd) {
 			LOG_DBG("match cmd [%s] (len:%zu)",
-				log_strdup(cmd->cmd), match_len);
+				cmd->cmd, match_len);
 
 			ret = process_cmd(cmd, match_len, data);
 			if (ret == -EAGAIN) {
@@ -385,7 +385,7 @@ static void cmd_handler_process_rx_buf(struct modem_cmd_handler_data *data)
 				break;
 			} else if (ret < 0) {
 				LOG_ERR("process cmd [%s] (len:%zu, ret:%d)",
-					log_strdup(cmd->cmd), match_len, ret);
+					cmd->cmd, match_len, ret);
 			}
 
 			/*
@@ -586,7 +586,7 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 
 		if (ret < 0) {
 			LOG_ERR("command %s ret:%d",
-				log_strdup(cmds[i].send_cmd), ret);
+				cmds[i].send_cmd, ret);
 			break;
 		}
 	}
@@ -622,7 +622,7 @@ int modem_cmd_handler_setup_cmds_nolock(struct modem_iface *iface,
 
 		if (ret < 0) {
 			LOG_ERR("command %s ret:%d",
-				log_strdup(cmds[i].send_cmd), ret);
+				cmds[i].send_cmd, ret);
 			break;
 		}
 	}

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -83,8 +83,8 @@ static int modem_atoi(const char *s, const int err_value,
 
 	ret = (int)strtol(s, &endptr, 10);
 	if (!endptr || *endptr != '\0') {
-		LOG_ERR("bad %s '%s' in %s", log_strdup(s), log_strdup(desc),
-			log_strdup(func));
+		LOG_ERR("bad %s '%s' in %s", s, desc,
+			func);
 		return err_value;
 	}
 
@@ -203,7 +203,7 @@ static void socket_close(struct modem_socket *sock)
 			     NULL, 0U, buf,
 			     &mdata.sem_response, MDM_CMD_TIMEOUT);
 	if (ret < 0) {
-		LOG_ERR("%s ret:%d", log_strdup(buf), ret);
+		LOG_ERR("%s ret:%d", buf, ret);
 	}
 
 	modem_socket_put(&mdata.socket_config, sock->sock_fd);
@@ -270,7 +270,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_manufacturer)
 					   sizeof(mdata.mdm_manufacturer) - 1,
 					   data->rx_buf, 0, len);
 	mdata.mdm_manufacturer[out_len] = '\0';
-	LOG_INF("Manufacturer: %s", log_strdup(mdata.mdm_manufacturer));
+	LOG_INF("Manufacturer: %s", mdata.mdm_manufacturer);
 	return 0;
 }
 
@@ -283,7 +283,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_model)
 	mdata.mdm_model[out_len] = '\0';
 
 	/* Log the received information. */
-	LOG_INF("Model: %s", log_strdup(mdata.mdm_model));
+	LOG_INF("Model: %s", mdata.mdm_model);
 	return 0;
 }
 
@@ -296,7 +296,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_revision)
 	mdata.mdm_revision[out_len] = '\0';
 
 	/* Log the received information. */
-	LOG_INF("Revision: %s", log_strdup(mdata.mdm_revision));
+	LOG_INF("Revision: %s", mdata.mdm_revision);
 	return 0;
 }
 
@@ -309,7 +309,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imei)
 	mdata.mdm_imei[out_len] = '\0';
 
 	/* Log the received information. */
-	LOG_INF("IMEI: %s", log_strdup(mdata.mdm_imei));
+	LOG_INF("IMEI: %s", mdata.mdm_imei);
 	return 0;
 }
 
@@ -323,7 +323,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imsi)
 	mdata.mdm_imsi[out_len] = '\0';
 
 	/* Log the received information. */
-	LOG_INF("IMSI: %s", log_strdup(mdata.mdm_imsi));
+	LOG_INF("IMSI: %s", mdata.mdm_imsi);
 	return 0;
 }
 
@@ -346,7 +346,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_iccid)
 		}
 	}
 
-	LOG_INF("ICCID: %s", log_strdup(mdata.mdm_iccid));
+	LOG_INF("ICCID: %s", mdata.mdm_iccid);
 	return 0;
 }
 #endif /* #if defined(CONFIG_MODEM_SIM_NUMBERS) */
@@ -741,7 +741,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 			     NULL, 0U, buf,
 			     &mdata.sem_response, K_SECONDS(1));
 	if (ret < 0) {
-		LOG_ERR("%s ret:%d", log_strdup(buf), ret);
+		LOG_ERR("%s ret:%d", buf, ret);
 		LOG_ERR("Closing the socket!!!");
 		socket_close(sock);
 		errno = -ret;

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -183,7 +183,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr, socklen_t add
 	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, cmd, ARRAY_SIZE(cmd), buf,
 			     &mdata.sem_response, MDM_CONNECT_TIMEOUT);
 	if (ret < 0) {
-		LOG_ERR("%s ret: %d", log_strdup(buf), ret);
+		LOG_ERR("%s ret: %d", buf, ret);
 		socket_close(sock);
 		goto error;
 	}
@@ -506,7 +506,7 @@ static void socket_close(struct modem_socket *sock)
 	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, buf, &mdata.sem_response,
 			     MDM_CMD_TIMEOUT);
 	if (ret < 0) {
-		LOG_ERR("%s ret: %d", log_strdup(buf), ret);
+		LOG_ERR("%s ret: %d", buf, ret);
 	}
 
 	modem_socket_put(&mdata.socket_config, sock->sock_fd);
@@ -652,7 +652,7 @@ MODEM_CMD_DEFINE(on_cmd_cdnsgip)
 
 	state = atoi(argv[0]);
 	if (state == 0) {
-		LOG_ERR("DNS lookup failed with error %s", log_strdup(argv[1]));
+		LOG_ERR("DNS lookup failed with error %s", argv[1]);
 		goto exit;
 	}
 
@@ -847,7 +847,7 @@ MODEM_CMD_DEFINE(on_urc_app_pdp)
 
 MODEM_CMD_DEFINE(on_urc_sms)
 {
-	LOG_INF("SMS: %s", log_strdup(argv[0]));
+	LOG_INF("SMS: %s", argv[0]);
 	return 0;
 }
 
@@ -958,7 +958,7 @@ MODEM_CMD_DEFINE(on_cmd_cgmi)
 	size_t out_len = net_buf_linearize(
 		mdata.mdm_manufacturer, sizeof(mdata.mdm_manufacturer) - 1, data->rx_buf, 0, len);
 	mdata.mdm_manufacturer[out_len] = '\0';
-	LOG_INF("Manufacturer: %s", log_strdup(mdata.mdm_manufacturer));
+	LOG_INF("Manufacturer: %s", mdata.mdm_manufacturer);
 	return 0;
 }
 
@@ -970,7 +970,7 @@ MODEM_CMD_DEFINE(on_cmd_cgmm)
 	size_t out_len = net_buf_linearize(mdata.mdm_model, sizeof(mdata.mdm_model) - 1,
 					   data->rx_buf, 0, len);
 	mdata.mdm_model[out_len] = '\0';
-	LOG_INF("Model: %s", log_strdup(mdata.mdm_model));
+	LOG_INF("Model: %s", mdata.mdm_model);
 	return 0;
 }
 
@@ -995,7 +995,7 @@ MODEM_CMD_DEFINE(on_cmd_cgmr)
 		memmove(mdata.mdm_revision, p + 1, out_len + 1);
 	}
 
-	LOG_INF("Revision: %s", log_strdup(mdata.mdm_revision));
+	LOG_INF("Revision: %s", mdata.mdm_revision);
 	return 0;
 }
 
@@ -1007,7 +1007,7 @@ MODEM_CMD_DEFINE(on_cmd_cgsn)
 	size_t out_len =
 		net_buf_linearize(mdata.mdm_imei, sizeof(mdata.mdm_imei) - 1, data->rx_buf, 0, len);
 	mdata.mdm_imei[out_len] = '\0';
-	LOG_INF("IMEI: %s", log_strdup(mdata.mdm_imei));
+	LOG_INF("IMEI: %s", mdata.mdm_imei);
 	return 0;
 }
 
@@ -1022,7 +1022,7 @@ MODEM_CMD_DEFINE(on_cmd_cimi)
 	mdata.mdm_imsi[out_len] = '\0';
 
 	/* Log the received information. */
-	LOG_INF("IMSI: %s", log_strdup(mdata.mdm_imsi));
+	LOG_INF("IMSI: %s", mdata.mdm_imsi);
 	return 0;
 }
 
@@ -1036,7 +1036,7 @@ MODEM_CMD_DEFINE(on_cmd_ccid)
 	mdata.mdm_iccid[out_len] = '\0';
 
 	/* Log the received information. */
-	LOG_INF("ICCID: %s", log_strdup(mdata.mdm_iccid));
+	LOG_INF("ICCID: %s", mdata.mdm_iccid);
 	return 0;
 }
 #endif /* defined(CONFIG_MODEM_SIM_NUMBERS) */

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -189,8 +189,8 @@ static int modem_atoi(const char *s, const int err_value,
 
 	ret = (int)strtol(s, &endptr, 10);
 	if (!endptr || *endptr != '\0') {
-		LOG_ERR("bad %s '%s' in %s", log_strdup(s), log_strdup(desc),
-			log_strdup(func));
+		LOG_ERR("bad %s '%s' in %s", s, desc,
+			func);
 		return err_value;
 	}
 
@@ -274,7 +274,7 @@ int modem_detect_apn(const char *imsi)
 	}
 
 	if (rc == 0) {
-		LOG_INF("Assign APN: \"%s\"", log_strdup(mdata.mdm_apn));
+		LOG_INF("Assign APN: \"%s\"", mdata.mdm_apn);
 	}
 
 	return rc;
@@ -561,7 +561,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_manufacturer)
 				    sizeof(mdata.mdm_manufacturer) - 1,
 				    data->rx_buf, 0, len);
 	mdata.mdm_manufacturer[out_len] = '\0';
-	LOG_INF("Manufacturer: %s", log_strdup(mdata.mdm_manufacturer));
+	LOG_INF("Manufacturer: %s", mdata.mdm_manufacturer);
 	return 0;
 }
 
@@ -574,7 +574,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_model)
 				    sizeof(mdata.mdm_model) - 1,
 				    data->rx_buf, 0, len);
 	mdata.mdm_model[out_len] = '\0';
-	LOG_INF("Model: %s", log_strdup(mdata.mdm_model));
+	LOG_INF("Model: %s", mdata.mdm_model);
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_AUTODETECT_VARIANT)
 	/* Set modem type */
@@ -600,7 +600,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_revision)
 				    sizeof(mdata.mdm_revision) - 1,
 				    data->rx_buf, 0, len);
 	mdata.mdm_revision[out_len] = '\0';
-	LOG_INF("Revision: %s", log_strdup(mdata.mdm_revision));
+	LOG_INF("Revision: %s", mdata.mdm_revision);
 	return 0;
 }
 
@@ -612,7 +612,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imei)
 	out_len = net_buf_linearize(mdata.mdm_imei, sizeof(mdata.mdm_imei) - 1,
 				    data->rx_buf, 0, len);
 	mdata.mdm_imei[out_len] = '\0';
-	LOG_INF("IMEI: %s", log_strdup(mdata.mdm_imei));
+	LOG_INF("IMEI: %s", mdata.mdm_imei);
 	return 0;
 }
 
@@ -624,7 +624,7 @@ MODEM_CMD_DEFINE(on_cmd_atcmdinfo_imsi)
 	out_len = net_buf_linearize(mdata.mdm_imsi, sizeof(mdata.mdm_imsi) - 1,
 				    data->rx_buf, 0, len);
 	mdata.mdm_imsi[out_len] = '\0';
-	LOG_INF("IMSI: %s", log_strdup(mdata.mdm_imsi));
+	LOG_INF("IMSI: %s", mdata.mdm_imsi);
 
 #if defined(CONFIG_MODEM_UBLOX_SARA_AUTODETECT_APN)
 	/* set the APN automatically */
@@ -766,7 +766,7 @@ MODEM_CMD_DEFINE(on_cmd_sockwrite)
 /* Handler: +USECMNG: 0,<type>[0],<internal_name>[1],<md5_string>[2] */
 MODEM_CMD_DEFINE(on_cmd_cert_write)
 {
-	LOG_DBG("cert md5: %s", log_strdup(argv[2]));
+	LOG_DBG("cert md5: %s", argv[2]);
 	return 0;
 }
 #endif
@@ -1455,7 +1455,7 @@ static int create_socket(struct modem_socket *sock, const struct sockaddr *addr)
 	return 0;
 
 error:
-	LOG_ERR("%s ret:%d", log_strdup(buf), ret);
+	LOG_ERR("%s ret:%d", buf, ret);
 	modem_socket_put(&mdata.socket_config, sock->sock_fd);
 	errno = -ret;
 	return -1;
@@ -1500,7 +1500,7 @@ static int offload_close(void *obj)
 				     NULL, 0U, buf,
 				     &mdata.sem_response, MDM_CMD_TIMEOUT);
 		if (ret < 0) {
-			LOG_ERR("%s ret:%d", log_strdup(buf), ret);
+			LOG_ERR("%s ret:%d", buf, ret);
 		}
 	}
 
@@ -1583,7 +1583,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 			     NULL, 0U, buf,
 			     &mdata.sem_response, MDM_CMD_CONN_TIMEOUT);
 	if (ret < 0) {
-		LOG_ERR("%s ret:%d", log_strdup(buf), ret);
+		LOG_ERR("%s ret:%d", buf, ret);
 		errno = -ret;
 		return -1;
 	}
@@ -2018,9 +2018,9 @@ static int offload_getaddrinfo(const char *node, const char *service,
 	}
 
 	LOG_DBG("DNS RESULT: %s",
-		log_strdup(net_addr_ntop(result.ai_family,
+		net_addr_ntop(result.ai_family,
 					 &net_sin(&result_addr)->sin_addr,
-					 sendbuf, NET_IPV4_ADDR_LEN)));
+					 sendbuf, NET_IPV4_ADDR_LEN));
 
 	*res = (struct zsock_addrinfo *)&result;
 	return 0;

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -333,12 +333,12 @@ MODEM_CMD_DEFINE(on_cmd_cipdns)
 		}
 
 		servers[i] = str_unquote(servers[i]);
-		LOG_DBG("DNS[%zu]: %s", i, log_strdup(servers[i]));
+		LOG_DBG("DNS[%zu]: %s", i, servers[i]);
 
 		err = net_addr_pton(AF_INET, servers[i], &addrs[i].sin_addr);
 		if (err) {
 			LOG_ERR("Invalid DNS address: %s",
-				log_strdup(servers[i]));
+				servers[i]);
 			addrs[i].sin_addr.s_addr = 0;
 			break;
 		}
@@ -431,7 +431,7 @@ MODEM_CMD_DEFINE(on_cmd_cipsta)
 	} else if (!strcmp(argv[0], "netmask")) {
 		net_addr_pton(AF_INET, ip, &dev->nm);
 	} else {
-		LOG_WRN("Unknown IP type %s", log_strdup(argv[0]));
+		LOG_WRN("Unknown IP type %s", argv[0]);
 	}
 
 	return 0;
@@ -573,7 +573,7 @@ static int cmd_ipd_parse_hdr(struct net_buf *buf, uint16_t len,
 
 	ipd_buf[match_len] = 0;
 	if (ipd_buf[len] != ',' || ipd_buf[len + 2] != ',') {
-		LOG_ERR("Invalid IPD: %s", log_strdup(ipd_buf));
+		LOG_ERR("Invalid IPD: %s", ipd_buf);
 		return -EBADMSG;
 	}
 
@@ -583,7 +583,7 @@ static int cmd_ipd_parse_hdr(struct net_buf *buf, uint16_t len,
 
 	if (endptr == &ipd_buf[len + 3] ||
 	    (*endptr == 0 && match_len >= MAX_IPD_LEN)) {
-		LOG_ERR("Invalid IPD len: %s", log_strdup(ipd_buf));
+		LOG_ERR("Invalid IPD len: %s", ipd_buf);
 		return -EBADMSG;
 	} else if (*endptr == 0) {
 		return -EAGAIN;

--- a/drivers/wifi/esp_at/esp_offload.c
+++ b/drivers/wifi/esp_at/esp_offload.c
@@ -69,7 +69,7 @@ static int _sock_connect(struct esp_data *dev, struct esp_socket *sock)
 
 	LOG_DBG("link %d, ip_proto %s, addr %s", sock->link_id,
 		esp_socket_ip_proto(sock) == IPPROTO_TCP ? "TCP" : "UDP",
-		log_strdup(addr_str));
+		addr_str);
 
 	ret = esp_cmd_send(dev, NULL, 0, connect_msg, ESP_CMD_TIMEOUT);
 	if (ret == 0) {
@@ -430,7 +430,7 @@ static int cmd_ciprecvdata_parse(struct esp_socket *sock,
 	if (endptr == &cmd_buf[len] ||
 	    (*endptr == 0 && match_len >= CIPRECVDATA_CMD_MAX_LEN) ||
 	    *data_len > CIPRECVDATA_MAX_LEN) {
-		LOG_ERR("Invalid cmd: %s", log_strdup(cmd_buf));
+		LOG_ERR("Invalid cmd: %s", cmd_buf);
 		return -EBADMSG;
 	} else if (*endptr == 0) {
 		return -EAGAIN;

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -246,8 +246,8 @@ static int eswifi_connect(struct eswifi_dev *eswifi)
 	char *rsp;
 	int err;
 
-	LOG_DBG("Connecting to %s (pass=%s)", log_strdup(eswifi->sta.ssid),
-		log_strdup(eswifi->sta.pass));
+	LOG_DBG("Connecting to %s (pass=%s)", eswifi->sta.ssid,
+		eswifi->sta.pass);
 
 	eswifi_lock(eswifi);
 

--- a/drivers/wifi/simplelink/simplelink_support.c
+++ b/drivers/wifi/simplelink/simplelink_support.c
@@ -292,7 +292,7 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 
 		LOG_INF("[WLAN EVENT] STA Connected to the AP: %s, "
 			"BSSID: %x:%x:%x:%x:%x:%x",
-			log_strdup(sl_conn.ssid), sl_conn.bssid[0],
+			sl_conn.ssid, sl_conn.bssid[0],
 			sl_conn.bssid[1], sl_conn.bssid[2],
 			sl_conn.bssid[3], sl_conn.bssid[4],
 			sl_conn.bssid[5]);
@@ -316,7 +316,7 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 		    event_data->ReasonCode) {
 			LOG_INF("[WLAN EVENT] "
 				"Device disconnected from the AP: %s",
-				log_strdup(event_data->SsidName));
+				event_data->SsidName);
 			LOG_INF("BSSID: %x:%x:%x:%x:%x:%x on application's"
 				" request", event_data->Bssid[0],
 				event_data->Bssid[1], event_data->Bssid[2],
@@ -326,7 +326,7 @@ void SimpleLinkWlanEventHandler(SlWlanEvent_t *wlan_event)
 		} else {
 			LOG_ERR("[WLAN ERROR] "
 				"Device disconnected from the AP: %s",
-				log_strdup(event_data->SsidName));
+				event_data->SsidName);
 			LOG_ERR("BSSID: %x:%x:%x:%x:%x:%x on error: %d",
 				event_data->Bssid[0],
 				event_data->Bssid[1], event_data->Bssid[2],

--- a/include/zephyr/debug/stack.h
+++ b/include/zephyr/debug/stack.h
@@ -32,7 +32,7 @@ static inline void log_stack_usage(const struct k_thread *thread)
 		}
 
 		LOG_INF("%p (%s):\tunused %zu\tusage %zu / %zu (%u %%)",
-			thread, log_strdup(tname), unused, size - unused, size,
+			thread, tname, unused, size - unused, size,
 			pcnt);
 	}
 #endif

--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -266,12 +266,6 @@ extern "C" {
  */
 void z_log_vprintk(const char *fmt, va_list ap);
 
-/** @brief Deprecated. */
-static inline char *log_strdup(const char *str)
-{
-	return (char *)str;
-}
-
 #ifdef __cplusplus
 }
 #define LOG_IN_CPLUSPLUS 1

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -1287,7 +1287,7 @@ void lwm2m_rd_client_update(void);
  *
  * @return Resulting formatted path string
  */
-char *lwm2m_path_log_strdup(char *buf, struct lwm2m_obj_path *path);
+char *lwm2m_path_log_buf(char *buf, struct lwm2m_obj_path *path);
 
 /** 
  * @brief LwM2M SEND operation to given path list

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -45,7 +45,7 @@ extern "C" {
 /* Network subsystem logging helpers */
 #ifdef CONFIG_THREAD_NAME
 #define NET_DBG(fmt, ...) LOG_DBG("(%s): " fmt,				\
-			log_strdup(k_thread_name_get(k_current_get())), \
+			k_thread_name_get(k_current_get()), \
 			##__VA_ARGS__)
 #else
 #define NET_DBG(fmt, ...) LOG_DBG("(%p): " fmt, k_current_get(),	\

--- a/kernel/fatal.c
+++ b/kernel/fatal.c
@@ -120,7 +120,7 @@ void z_fatal_error(unsigned int reason, const z_arch_esf_t *esf)
 #endif
 
 	LOG_ERR("Current thread: %p (%s)", thread,
-		log_strdup(thread_name_get(thread)));
+		thread_name_get(thread));
 
 	coredump(reason, esf, thread);
 

--- a/samples/bluetooth/ipsp/src/main.c
+++ b/samples/bluetooth/ipsp/src/main.c
@@ -138,7 +138,7 @@ static int build_reply(const char *name,
 	int reply_len = net_pkt_remaining_data(pkt);
 	int ret;
 
-	LOG_DBG("%s received %d bytes", log_strdup(name), reply_len);
+	LOG_DBG("%s received %d bytes", name, reply_len);
 
 	ret = net_pkt_read(pkt, buf, reply_len);
 	if (ret < 0) {

--- a/samples/boards/esp32/wifi_station/src/main.c
+++ b/samples/boards/esp32/wifi_station/src/main.c
@@ -30,19 +30,19 @@ static void handler_cb(struct net_mgmt_event_callback *cb,
 	char buf[NET_IPV4_ADDR_LEN];
 
 	LOG_INF("Your address: %s",
-		log_strdup(net_addr_ntop(AF_INET,
+		net_addr_ntop(AF_INET,
 				   &iface->config.dhcpv4.requested_ip,
-				   buf, sizeof(buf))));
+				   buf, sizeof(buf)));
 	LOG_INF("Lease time: %u seconds",
 			iface->config.dhcpv4.lease_time);
 	LOG_INF("Subnet: %s",
-		log_strdup(net_addr_ntop(AF_INET,
+		net_addr_ntop(AF_INET,
 					&iface->config.ip.ipv4->netmask,
-					buf, sizeof(buf))));
+					buf, sizeof(buf)));
 	LOG_INF("Router: %s",
-		log_strdup(net_addr_ntop(AF_INET,
+		net_addr_ntop(AF_INET,
 						&iface->config.ip.ipv4->gw,
-						buf, sizeof(buf))));
+						buf, sizeof(buf)));
 }
 
 void main(void)

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -29,7 +29,7 @@ void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
 	ARG_UNUSED(size);
 
 	LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
-		log_strdup(data), rssi, snr);
+		data, rssi, snr);
 
 	/* Stop receiving after 10 packets */
 	if (++cnt == 10) {
@@ -78,7 +78,7 @@ void main(void)
 		}
 
 		LOG_INF("Received data: %s (RSSI:%ddBm, SNR:%ddBm)",
-			log_strdup(data), rssi, snr);
+			data, rssi, snr);
 	}
 
 	/* Enable asynchronous reception */

--- a/samples/net/cloud/google_iot_mqtt/src/main.c
+++ b/samples/net/cloud/google_iot_mqtt/src/main.c
@@ -44,7 +44,7 @@ int do_sntp(void)
 
 		gmtime_r(&now, &now_tm);
 		strftime(time_str, sizeof(time_str), "%FT%T", &now_tm);
-		LOG_INF("  Acquired time: %s", log_strdup(time_str));
+		LOG_INF("  Acquired time: %s", time_str);
 
 	} else {
 		LOG_ERR("  Failed to acquire SNTP, code %d\n", rc);

--- a/samples/net/cloud/google_iot_mqtt/src/protocol.c
+++ b/samples/net/cloud/google_iot_mqtt/src/protocol.c
@@ -161,7 +161,7 @@ void mqtt_evt_handler(struct mqtt_client *const client,
 			pub->message_id,
 			pub->message.topic.qos);
 		LOG_INF("   item: %s",
-			log_strdup(pub->message.topic.topic.utf8));
+			pub->message.topic.topic.utf8);
 
 		/* assuming the config message is textual */
 		while (len) {
@@ -174,7 +174,7 @@ void mqtt_evt_handler(struct mqtt_client *const client,
 			}
 
 			d[bytes_read] = '\0';
-			LOG_INF("   payload: %s", log_strdup(d));
+			LOG_INF("   payload: %s", d);
 			len -= bytes_read;
 		}
 

--- a/samples/net/cloud/mqtt_azure/src/main.c
+++ b/samples/net/cloud/mqtt_azure/src/main.c
@@ -255,7 +255,7 @@ static void mqtt_event_handler(struct mqtt_client *const client,
 			}
 
 			data[bytes_read] = '\0';
-			LOG_INF("   payload: %s", log_strdup(data));
+			LOG_INF("   payload: %s", data);
 			len -= bytes_read;
 		}
 

--- a/samples/net/cloud/tagoio_http_post/src/sockets.c
+++ b/samples/net/cloud/tagoio_http_post/src/sockets.c
@@ -67,9 +67,9 @@ int tagoio_connect(struct tagoio_context *ctx)
 
 	LOG_DBG("%s address: %s",
 		(addr->ai_family == AF_INET ? "IPv4" : "IPv6"),
-		log_strdup(net_addr_ntop(addr->ai_family,
-					 &net_sin(addr->ai_addr)->sin_addr,
-					 hr_addr, sizeof(hr_addr))));
+		net_addr_ntop(addr->ai_family,
+			      &net_sin(addr->ai_addr)->sin_addr,
+			      hr_addr, sizeof(hr_addr)));
 
 	ctx->sock = socket(hints.ai_family,
 			   hints.ai_socktype,

--- a/samples/net/dhcpv4_client/src/main.c
+++ b/samples/net/dhcpv4_client/src/main.c
@@ -41,19 +41,19 @@ static void handler(struct net_mgmt_event_callback *cb,
 		}
 
 		LOG_INF("Your address: %s",
-			log_strdup(net_addr_ntop(AF_INET,
+			net_addr_ntop(AF_INET,
 			    &iface->config.ip.ipv4->unicast[i].address.in_addr,
-						  buf, sizeof(buf))));
+						  buf, sizeof(buf)));
 		LOG_INF("Lease time: %u seconds",
 			 iface->config.dhcpv4.lease_time);
 		LOG_INF("Subnet: %s",
-			log_strdup(net_addr_ntop(AF_INET,
+			net_addr_ntop(AF_INET,
 				       &iface->config.ip.ipv4->netmask,
-				       buf, sizeof(buf))));
+				       buf, sizeof(buf)));
 		LOG_INF("Router: %s",
-			log_strdup(net_addr_ntop(AF_INET,
+			net_addr_ntop(AF_INET,
 						 &iface->config.ip.ipv4->gw,
-						 buf, sizeof(buf))));
+						 buf, sizeof(buf)));
 	}
 }
 

--- a/samples/net/dns_resolve/src/main.c
+++ b/samples/net/dns_resolve/src/main.c
@@ -75,8 +75,8 @@ void dns_result_cb(enum dns_resolve_status status,
 
 	LOG_INF("%s %s address: %s", user_data ? (char *)user_data : "<null>",
 		hr_family,
-		log_strdup(net_addr_ntop(info->ai_family, addr,
-					 hr_addr, sizeof(hr_addr))));
+		net_addr_ntop(info->ai_family, addr,
+					 hr_addr, sizeof(hr_addr)));
 }
 
 void mdns_result_cb(enum dns_resolve_status status,
@@ -124,8 +124,8 @@ void mdns_result_cb(enum dns_resolve_status status,
 
 	LOG_INF("%s %s address: %s", user_data ? (char *)user_data : "<null>",
 		hr_family,
-		log_strdup(net_addr_ntop(info->ai_family, addr,
-					 hr_addr, sizeof(hr_addr))));
+		net_addr_ntop(info->ai_family, addr,
+					 hr_addr, sizeof(hr_addr)));
 }
 
 #if defined(CONFIG_NET_DHCPV4)
@@ -172,19 +172,19 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 		}
 
 		LOG_INF("IPv4 address: %s",
-			log_strdup(net_addr_ntop(AF_INET,
+			net_addr_ntop(AF_INET,
 						 &if_addr->address.in_addr,
-						 hr_addr, NET_IPV4_ADDR_LEN)));
+						 hr_addr, NET_IPV4_ADDR_LEN));
 		LOG_INF("Lease time: %u seconds",
 			 iface->config.dhcpv4.lease_time);
 		LOG_INF("Subnet: %s",
-			log_strdup(net_addr_ntop(AF_INET,
+			net_addr_ntop(AF_INET,
 					       &iface->config.ip.ipv4->netmask,
-					       hr_addr, NET_IPV4_ADDR_LEN)));
+					       hr_addr, NET_IPV4_ADDR_LEN));
 		LOG_INF("Router: %s",
-			log_strdup(net_addr_ntop(AF_INET,
+			net_addr_ntop(AF_INET,
 					       &iface->config.ip.ipv4->gw,
-					       hr_addr, NET_IPV4_ADDR_LEN)));
+					       hr_addr, NET_IPV4_ADDR_LEN));
 		break;
 	}
 

--- a/samples/net/dsa/src/dsa_lldp.c
+++ b/samples/net/dsa/src/dsa_lldp.c
@@ -139,7 +139,7 @@ void dsa_lldp_print_info(uint8_t *lldp_p, uint8_t lanid)
 		case LLDP_TLV_SYSTEM_NAME:
 			memset(t, 0, length + 1);
 			memcpy(t, p, length);
-			LOG_INF("\tSYSTEM NAME:\t%s", log_strdup(t));
+			LOG_INF("\tSYSTEM NAME:\t%s", t);
 			break;
 		}
 		lldp_p += length;

--- a/samples/net/gptp/src/main.c
+++ b/samples/net/gptp/src/main.c
@@ -137,8 +137,7 @@ static void gptp_phase_dis_cb(uint8_t *gm_identity,
 		memcpy(id, gm_identity, sizeof(id));
 
 		LOG_DBG("GM %s last phase %d.%" PRId64 "",
-			log_strdup(gptp_sprint_clock_id(gm_identity, output,
-							sizeof(output))),
+			gptp_sprint_clock_id(gm_identity, output, sizeof(output)),
 			last_gm_ph_change->high,
 			last_gm_ph_change->low);
 	}

--- a/samples/net/ipv4_autoconf/src/main.c
+++ b/samples/net/ipv4_autoconf/src/main.c
@@ -46,9 +46,9 @@ static void handler(struct net_mgmt_event_callback *cb,
 		}
 
 		LOG_INF("Your address: %s",
-			log_strdup(net_addr_ntop(AF_INET,
+			net_addr_ntop(AF_INET,
 				    &cfg->ip.ipv4->unicast[i].address.in_addr,
-				    buf, sizeof(buf))));
+				    buf, sizeof(buf)));
 	}
 }
 

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -487,20 +487,20 @@ static void observe_cb(enum lwm2m_observe_event event,
 	switch (event) {
 
 	case LWM2M_OBSERVE_EVENT_OBSERVER_ADDED:
-		LOG_INF("Observer added for %s", lwm2m_path_log_strdup(buf, path));
+		LOG_INF("Observer added for %s", lwm2m_path_log_buf(buf, path));
 		break;
 
 	case LWM2M_OBSERVE_EVENT_OBSERVER_REMOVED:
-		LOG_INF("Observer removed for %s", lwm2m_path_log_strdup(buf, path));
+		LOG_INF("Observer removed for %s", lwm2m_path_log_buf(buf, path));
 		break;
 
 	case LWM2M_OBSERVE_EVENT_NOTIFY_ACK:
-		LOG_INF("Notify acknowledged for %s", lwm2m_path_log_strdup(buf, path));
+		LOG_INF("Notify acknowledged for %s", lwm2m_path_log_buf(buf, path));
 		break;
 
 	case LWM2M_OBSERVE_EVENT_NOTIFY_TIMEOUT:
 		LOG_INF("Notify timeout for %s, trying registration update",
-			lwm2m_path_log_strdup(buf, path));
+			lwm2m_path_log_buf(buf, path));
 
 		lwm2m_rd_client_update();
 		break;

--- a/samples/net/mdns_responder/src/service.c
+++ b/samples/net/mdns_responder/src/service.c
@@ -99,7 +99,7 @@ void service(void)
 
 	inet_ntop(server_addr.sa_family, addrp, addrstr, sizeof(addrstr));
 	NET_DBG("bound to [%s]:%u",
-		log_strdup(addrstr), ntohs(*portp));
+		addrstr, ntohs(*portp));
 
 	r = listen(server_fd, 1);
 	if (r == -1) {
@@ -120,7 +120,7 @@ void service(void)
 
 		inet_ntop(server_addr.sa_family, addrp, addrstr, sizeof(addrstr));
 		NET_DBG("accepted connection from [%s]:%u",
-			log_strdup(addrstr), ntohs(*portp));
+			addrstr, ntohs(*portp));
 
 		/* send a banner */
 		r = welcome(client_fd);

--- a/samples/net/promiscuous_mode/src/main.c
+++ b/samples/net/promiscuous_mode/src/main.c
@@ -131,23 +131,23 @@ static void print_info(struct net_pkt *pkt)
 		if (next_hdr == IPPROTO_TCP || next_hdr == IPPROTO_UDP) {
 			LOG_INF("%s %s (%zd) %s:%u -> %s:%u",
 				"IPv4", proto, len,
-				log_strdup(src_addr), src_port,
-				log_strdup(dst_addr), dst_port);
+				src_addr, src_port,
+				dst_addr, dst_port);
 		} else {
 			LOG_INF("%s %s (%zd) %s -> %s", "IPv4", proto,
-				len, log_strdup(src_addr),
-				log_strdup(dst_addr));
+				len, src_addr,
+				dst_addr);
 		}
 	} else {
 		if (next_hdr == IPPROTO_TCP || next_hdr == IPPROTO_UDP) {
 			LOG_INF("%s %s (%zd) [%s]:%u -> [%s]:%u",
 				"IPv6", proto, len,
-				log_strdup(src_addr), src_port,
-				log_strdup(dst_addr), dst_port);
+				src_addr, src_port,
+				dst_addr, dst_port);
 		} else {
 			LOG_INF("%s %s (%zd) %s -> %s", "IPv6", proto,
-				len, log_strdup(src_addr),
-				log_strdup(dst_addr));
+				len, src_addr,
+				dst_addr);
 		}
 	}
 }

--- a/samples/net/sockets/coap_server/src/coap-server.c
+++ b/samples/net/sockets/coap_server/src/coap-server.c
@@ -101,7 +101,7 @@ static bool join_coap_multicast_group(void)
 	ret = net_ipv6_mld_join(iface, &mcast_addr.sin6_addr);
 	if (ret < 0) {
 		LOG_ERR("Cannot join %s IPv6 multicast group (%d)",
-			log_strdup(net_sprint_ipv6_addr(&mcast_addr.sin6_addr)), ret);
+			net_sprint_ipv6_addr(&mcast_addr.sin6_addr), ret);
 		return false;
 	}
 

--- a/samples/net/sockets/dumb_http_server_mt/src/main.c
+++ b/samples/net/sockets/dumb_http_server_mt/src/main.c
@@ -321,7 +321,7 @@ static int process_tcp(int *sock, int *accepted)
 
 		LOG_DBG("[%d] Connection #%d from %s",
 			client, ++counter,
-			log_strdup(addr_str));
+			addr_str);
 	}
 
 	return 0;

--- a/samples/net/sockets/txtime/src/main.c
+++ b/samples/net/sockets/txtime/src/main.c
@@ -314,7 +314,7 @@ static int create_socket(struct net_if *iface, struct sockaddr *peer)
 			return -EINVAL;
 		}
 
-		LOG_DBG("Binding to %s", log_strdup(addr_str));
+		LOG_DBG("Binding to %s", addr_str);
 	}
 
 	ret = bind(sock, &local, addrlen);
@@ -602,7 +602,7 @@ void main(void)
 	if (IS_ENABLED(CONFIG_NET_SAMPLE_UDP_SOCKET)) {
 		LOG_INF("Socket SO_TXTIME sample to %s port %d using "
 			"interface %d (%p) and PTP clock %p",
-			log_strdup(addr_str),
+			addr_str,
 			ntohs(net_sin(&data.peer)->sin_port),
 			if_index, iface, data.clk);
 	}

--- a/samples/net/telnet/src/telnet.c
+++ b/samples/net/telnet/src/telnet.c
@@ -40,19 +40,19 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 		}
 
 		LOG_INF("IPv4 address: %s",
-			log_strdup(net_addr_ntop(AF_INET,
-					       &if_addr->address.in_addr,
-					       hr_addr, NET_IPV4_ADDR_LEN)));
+			net_addr_ntop(AF_INET,
+				      &if_addr->address.in_addr,
+				      hr_addr, NET_IPV4_ADDR_LEN));
 		LOG_INF("Lease time: %u seconds",
 			 iface->config.dhcpv4.lease_time);
 		LOG_INF("Subnet: %s",
-			log_strdup(net_addr_ntop(AF_INET,
-					       &iface->config.ip.ipv4->netmask,
-					       hr_addr, NET_IPV4_ADDR_LEN)));
+			net_addr_ntop(AF_INET,
+				      &iface->config.ip.ipv4->netmask,
+				      hr_addr, NET_IPV4_ADDR_LEN));
 		LOG_INF("Router: %s",
-			log_strdup(net_addr_ntop(AF_INET,
-						 &iface->config.ip.ipv4->gw,
-						 hr_addr, NET_IPV4_ADDR_LEN)));
+			net_addr_ntop(AF_INET,
+				      &iface->config.ip.ipv4->gw,
+				      hr_addr, NET_IPV4_ADDR_LEN));
 		break;
 	}
 }
@@ -91,8 +91,8 @@ static void setup_ipv4(struct net_if *iface)
 	net_if_ipv4_addr_add(iface, &addr, NET_ADDR_MANUAL, 0);
 
 	LOG_INF("IPv4 address: %s",
-		log_strdup(net_addr_ntop(AF_INET, &addr, hr_addr,
-					 NET_IPV4_ADDR_LEN)));
+		net_addr_ntop(AF_INET, &addr, hr_addr,
+			      NET_IPV4_ADDR_LEN));
 }
 
 #else
@@ -120,8 +120,7 @@ static void setup_ipv6(struct net_if *iface)
 	net_if_ipv6_addr_add(iface, &addr, NET_ADDR_MANUAL, 0);
 
 	LOG_INF("IPv6 address: %s",
-		log_strdup(net_addr_ntop(AF_INET6, &addr, hr_addr,
-					 NET_IPV6_ADDR_LEN)));
+		net_addr_ntop(AF_INET6, &addr, hr_addr, NET_IPV6_ADDR_LEN));
 
 	if (net_addr_pton(AF_INET6, MCAST_IP6ADDR, &addr)) {
 		LOG_ERR("Invalid address: %s", MCAST_IP6ADDR);

--- a/samples/net/virtual/src/main.c
+++ b/samples/net/virtual/src/main.c
@@ -374,18 +374,15 @@ void main(void)
 
 	LOG_INF("My example tunnel interface %d (%s / %p)",
 		net_if_get_by_iface(ud.my_iface),
-		log_strdup(net_virtual_get_name(ud.my_iface, buf,
-						sizeof(buf))),
+		net_virtual_get_name(ud.my_iface, buf, sizeof(buf)),
 		ud.my_iface);
 	LOG_INF("Tunnel interface %d (%s / %p)",
 		net_if_get_by_iface(ud.ip_tunnel_1),
-		log_strdup(net_virtual_get_name(ud.ip_tunnel_1, buf,
-						sizeof(buf))),
+		net_virtual_get_name(ud.ip_tunnel_1, buf, sizeof(buf)),
 		ud.ip_tunnel_1);
 	LOG_INF("Tunnel interface %d (%s / %p)",
 		net_if_get_by_iface(ud.ip_tunnel_2),
-		log_strdup(net_virtual_get_name(ud.ip_tunnel_2, buf,
-						sizeof(buf))),
+		net_virtual_get_name(ud.ip_tunnel_2, buf, sizeof(buf)),
 		ud.ip_tunnel_2);
 	LOG_INF("IPIP interface %d (%p)",
 		net_if_get_by_iface(ud.ipip), ud.ipip);

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -74,27 +74,27 @@ static int littlefs_increase_infile_value(char *fname)
 	fs_file_t_init(&file);
 	rc = fs_open(&file, fname, FS_O_CREATE | FS_O_RDWR);
 	if (rc < 0) {
-		LOG_ERR("FAIL: open %s: %d", log_strdup(fname), rc);
+		LOG_ERR("FAIL: open %s: %d", fname, rc);
 		return rc;
 	}
 
 	rc = fs_read(&file, &boot_count, sizeof(boot_count));
 	if (rc < 0) {
-		LOG_ERR("FAIL: read %s: [rd:%d]", log_strdup(fname), rc);
+		LOG_ERR("FAIL: read %s: [rd:%d]", fname, rc);
 		goto out;
 	}
 	LOG_PRINTK("%s read count:%u (bytes: %d)\n", fname, boot_count, rc);
 
 	rc = fs_seek(&file, 0, FS_SEEK_SET);
 	if (rc < 0) {
-		LOG_ERR("FAIL: seek %s: %d", log_strdup(fname), rc);
+		LOG_ERR("FAIL: seek %s: %d", fname, rc);
 		goto out;
 	}
 
 	boot_count += 1;
 	rc = fs_write(&file, &boot_count, sizeof(boot_count));
 	if (rc < 0) {
-		LOG_ERR("FAIL: write %s: %d", log_strdup(fname), rc);
+		LOG_ERR("FAIL: write %s: %d", fname, rc);
 		goto out;
 	}
 
@@ -104,7 +104,7 @@ static int littlefs_increase_infile_value(char *fname)
  out:
 	ret = fs_close(&file);
 	if (ret < 0) {
-		LOG_ERR("FAIL: close %s: %d", log_strdup(fname), ret);
+		LOG_ERR("FAIL: close %s: %d", fname, ret);
 		return ret;
 	}
 
@@ -183,27 +183,27 @@ static int littlefs_binary_file_adj(char *fname)
 
 	rc = fs_open(&file, fname, FS_O_CREATE | FS_O_RDWR);
 	if (rc < 0) {
-		LOG_ERR("FAIL: open %s: %d", log_strdup(fname), rc);
+		LOG_ERR("FAIL: open %s: %d", fname, rc);
 		return rc;
 	}
 
 	rc = fs_stat(fname, &dirent);
 	if (rc < 0) {
-		LOG_ERR("FAIL: stat %s: %d", log_strdup(fname), rc);
+		LOG_ERR("FAIL: stat %s: %d", fname, rc);
 		goto out;
 	}
 
 	/* Check if the file exists - if not just write the pattern */
 	if (rc == 0 && dirent.type == FS_DIR_ENTRY_FILE && dirent.size == 0) {
 		LOG_INF("Test file: %s not found, create one!",
-			log_strdup(fname));
+			fname);
 		init_pattern(file_test_pattern, sizeof(file_test_pattern));
 	} else {
 		rc = fs_read(&file, file_test_pattern,
 			     sizeof(file_test_pattern));
 		if (rc < 0) {
 			LOG_ERR("FAIL: read %s: [rd:%d]",
-				log_strdup(fname), rc);
+				fname, rc);
 			goto out;
 		}
 		incr_pattern(file_test_pattern, sizeof(file_test_pattern), 0x1);
@@ -214,19 +214,19 @@ static int littlefs_binary_file_adj(char *fname)
 
 	rc = fs_seek(&file, 0, FS_SEEK_SET);
 	if (rc < 0) {
-		LOG_ERR("FAIL: seek %s: %d", log_strdup(fname), rc);
+		LOG_ERR("FAIL: seek %s: %d", fname, rc);
 		goto out;
 	}
 
 	rc = fs_write(&file, file_test_pattern, sizeof(file_test_pattern));
 	if (rc < 0) {
-		LOG_ERR("FAIL: write %s: %d", log_strdup(fname), rc);
+		LOG_ERR("FAIL: write %s: %d", fname, rc);
 	}
 
  out:
 	ret = fs_close(&file);
 	if (ret < 0) {
-		LOG_ERR("FAIL: close %s: %d", log_strdup(fname), ret);
+		LOG_ERR("FAIL: close %s: %d", fname, ret);
 		return ret;
 	}
 

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -176,17 +176,14 @@ static void severity_levels_showcase(void)
 
 /**
  * @brief Function demonstrates how transient strings can be logged.
- *
- * Logger ensures that allocated buffers are freed when log message is
- * processed.
  */
-static void log_strdup_showcase(void)
+static void log_transient_string_showcase(void)
 {
 	char transient_str[] = "transient_string";
 
 	printk("String logging showcase.\n");
 
-	LOG_INF("Logging transient string:%s", log_strdup(transient_str));
+	LOG_INF("Logging transient string:%s", transient_str);
 
 	/* Overwrite transient string to show that the logger has a copy. */
 	transient_str[0] = '\0';
@@ -310,7 +307,7 @@ static void log_demo_thread(void *p1, void *p2, void *p3)
 
 	wait_on_log_flushed();
 
-	log_strdup_showcase();
+	log_transient_string_showcase();
 
 	severity_levels_showcase();
 

--- a/samples/subsys/modbus/tcp_gateway/src/main.c
+++ b/samples/subsys/modbus/tcp_gateway/src/main.c
@@ -34,7 +34,7 @@ static int init_backend_iface(void)
 	backend = modbus_iface_get_by_name(bend_name);
 	if (backend < 0) {
 		LOG_ERR("Failed to get iface index for %s",
-			log_strdup(bend_name));
+			bend_name);
 		return -ENODEV;
 	}
 
@@ -138,7 +138,7 @@ void main(void)
 		inet_ntop(client_addr.sin_family, &client_addr.sin_addr,
 			  addr_str, sizeof(addr_str));
 		LOG_INF("Connection #%d from %s",
-			counter++, log_strdup(addr_str));
+			counter++, addr_str);
 
 		do {
 			rc = modbus_tcp_connection(client);
@@ -146,6 +146,6 @@ void main(void)
 
 		close(client);
 		LOG_INF("Connection from %s closed, errno %d",
-			log_strdup(addr_str), rc);
+			addr_str, rc);
 	}
 }

--- a/samples/subsys/modbus/tcp_server/src/main.c
+++ b/samples/subsys/modbus/tcp_server/src/main.c
@@ -158,7 +158,7 @@ static int init_modbus_server(void)
 
 	if (server_iface < 0) {
 		LOG_ERR("Failed to get iface index for %s",
-			log_strdup(iface_name));
+			iface_name);
 		return -ENODEV;
 	}
 
@@ -272,7 +272,7 @@ void main(void)
 		inet_ntop(client_addr.sin_family, &client_addr.sin_addr,
 			  addr_str, sizeof(addr_str));
 		LOG_INF("Connection #%d from %s",
-			counter++, log_strdup(addr_str));
+			counter++, addr_str);
 
 		do {
 			rc = modbus_tcp_connection(client);
@@ -280,6 +280,6 @@ void main(void)
 
 		close(client);
 		LOG_INF("Connection from %s closed, errno %d",
-			log_strdup(addr_str), rc);
+			addr_str, rc);
 	}
 }

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -322,7 +322,7 @@ static ssize_t write_description(struct bt_conn *conn,
 		}
 	}
 
-	BT_DBG("%s", log_strdup(inst->srv.description));
+	BT_DBG("%s", inst->srv.description);
 
 	return len;
 }
@@ -334,7 +334,7 @@ static ssize_t read_description(struct bt_conn *conn,
 {
 	struct bt_aics *inst = attr->user_data;
 
-	BT_DBG("%s", log_strdup(inst->srv.description));
+	BT_DBG("%s", inst->srv.description);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
 				 &inst->srv.description, strlen(inst->srv.description));
@@ -433,7 +433,7 @@ int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param)
 		if (IS_ENABLED(CONFIG_BT_DEBUG_AICS) &&
 		    strcmp(aics->srv.description, param->description)) {
 			BT_DBG("Input desc clipped to %s",
-			       log_strdup(aics->srv.description));
+			       aics->srv.description);
 		}
 	}
 

--- a/subsys/bluetooth/audio/aics_client.c
+++ b/subsys/bluetooth/audio/aics_client.c
@@ -105,7 +105,7 @@ uint8_t aics_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 
 		memcpy(desc, data, length);
 		desc[length] = '\0';
-		BT_DBG("Inst %p: Input description: %s", inst, log_strdup(desc));
+		BT_DBG("Inst %p: Input description: %s", inst, desc);
 		if (inst->cli.cb && inst->cli.cb->description) {
 			inst->cli.cb->description(inst, 0, desc);
 		}
@@ -527,7 +527,7 @@ static uint8_t aics_client_read_desc_cb(struct bt_conn *conn, uint8_t err,
 	}
 
 	desc[length] = '\0';
-	BT_DBG("Input description: %s", log_strdup(desc));
+	BT_DBG("Input description: %s", desc);
 
 	if (inst->cli.cb && inst->cli.cb->description) {
 		inst->cli.cb->description(inst, cb_err, desc);

--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -32,7 +32,7 @@
 		if (IS_ENABLED(CONFIG_BT_DEBUG_MCS)) { \
 			char t[BT_OTS_OBJ_ID_STR_LEN]; \
 			(void)bt_ots_obj_id_to_str(id64, t, sizeof(t)); \
-			BT_DBG(text "0x%s", log_strdup(t)); \
+			BT_DBG(text "0x%s", t); \
 		} \
 	} while (0)
 
@@ -199,7 +199,7 @@ static uint8_t mcc_read_player_name_cb(struct bt_conn *conn, uint8_t err,
 
 		(void)memcpy(&name, data, length);
 		name[length] = '\0';
-		BT_DBG("Player name: %s", log_strdup(name));
+		BT_DBG("Player name: %s", name);
 	}
 
 	if (mcc_cb && mcc_cb->read_player_name) {
@@ -258,7 +258,7 @@ static uint8_t mcc_read_icon_url_cb(struct bt_conn *conn, uint8_t err,
 		BT_HEXDUMP_DBG(data, length, "Icon URL");
 		(void)memcpy(&url, data, length);
 		url[length] = '\0';
-		BT_DBG("Icon URL: %s", log_strdup(url));
+		BT_DBG("Icon URL: %s", url);
 	}
 
 	if (mcc_cb && mcc_cb->read_icon_url) {
@@ -288,7 +288,7 @@ static uint8_t mcc_read_track_title_cb(struct bt_conn *conn, uint8_t err,
 		}
 		(void)memcpy(&title, data, length);
 		title[length] = '\0';
-		BT_DBG("Track title: %s", log_strdup(title));
+		BT_DBG("Track title: %s", title);
 	}
 
 	if (mcc_cb && mcc_cb->read_track_title) {
@@ -2432,7 +2432,7 @@ int on_track_segments_content(struct bt_ots_client *otc_inst,
 		for (int i = 0; i < track_segments.cnt; i++) {
 			BT_DBG("Track segment %i:", i);
 			BT_DBG("\t-Name\t:%s",
-			       log_strdup(track_segments.segs[i].name));
+			       track_segments.segs[i].name);
 			BT_DBG("\t-Position\t:%d", track_segments.segs[i].pos);
 		}
 #endif /* CONFIG_BT_DEBUG_MCC */
@@ -2571,7 +2571,7 @@ int on_parent_group_content(struct bt_ots_client *otc_inst,
 			(void)bt_ots_obj_id_to_str(group.ids[i].id, t,
 						   BT_OTS_OBJ_ID_STR_LEN);
 			BT_DBG("Object type: %d, object  ID: %s",
-			       group.ids[i].type, log_strdup(t));
+			       group.ids[i].type, t);
 		}
 #endif /* CONFIG_BT_DEBUG_MCC */
 
@@ -2617,7 +2617,7 @@ int on_current_group_content(struct bt_ots_client *otc_inst,
 			(void)bt_ots_obj_id_to_str(group.ids[i].id, t,
 						   BT_OTS_OBJ_ID_STR_LEN);
 			BT_DBG("Object type: %d, object  ID: %s",
-			       group.ids[i].type, log_strdup(t));
+			       group.ids[i].type, t);
 		}
 #endif /* CONFIG_BT_DEBUG_MCC */
 

--- a/subsys/bluetooth/audio/mcs.c
+++ b/subsys/bluetooth/audio/mcs.c
@@ -50,7 +50,7 @@ static ssize_t read_player_name(struct bt_conn *conn,
 {
 	const char *name = media_proxy_sctrl_get_player_name();
 
-	BT_DBG("Player name read: %s", log_strdup(name));
+	BT_DBG("Player name read: %s", name);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, name,
 				 strlen(name));
@@ -82,7 +82,7 @@ static ssize_t read_icon_url(struct bt_conn *conn,
 	const char *url = media_proxy_sctrl_get_icon_url();
 
 	BT_DBG("Icon URL read, offset: %d, len:%d, URL: %s", offset, len,
-	       log_strdup(url));
+	       url);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, url,
 				 strlen(url));
@@ -100,7 +100,7 @@ static ssize_t read_track_title(struct bt_conn *conn,
 	const char *title = media_proxy_sctrl_get_track_title();
 
 	BT_DBG("Track title read, offset: %d, len:%d, title: %s", offset, len,
-	       log_strdup(title));
+	       title);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, title,
 				 strlen(title));
@@ -276,7 +276,7 @@ static ssize_t write_current_track_id(struct bt_conn *conn,
 		char str[BT_OTS_OBJ_ID_STR_LEN];
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
 		BT_DBG("Current track write: offset: %d, len: %d, track ID: %s",
-		       offset, len, log_strdup(str));
+		       offset, len, str);
 	}
 
 	media_proxy_sctrl_set_current_track_id(id);
@@ -331,7 +331,7 @@ static ssize_t write_next_track_id(struct bt_conn *conn,
 		char str[BT_OTS_OBJ_ID_STR_LEN];
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
 		BT_DBG("Next  track write: offset: %d, len: %d, track ID: %s",
-		       offset, len, log_strdup(str));
+		       offset, len, str);
 	}
 
 	media_proxy_sctrl_set_next_track_id(id);
@@ -396,7 +396,7 @@ static ssize_t write_current_group_id(struct bt_conn *conn,
 		char str[BT_OTS_OBJ_ID_STR_LEN];
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
 		BT_DBG("Current group ID write: offset: %d, len: %d, track ID: %s",
-		       offset, len, log_strdup(str));
+		       offset, len, str);
 	}
 
 	media_proxy_sctrl_set_current_group_id(id);
@@ -848,7 +848,7 @@ void media_proxy_sctrl_track_changed_cb(void)
 
 void media_proxy_sctrl_track_title_cb(const char *title)
 {
-	BT_DBG("Notifying track title: %s", log_strdup(title));
+	BT_DBG("Notifying track title: %s", title);
 	notify_string(BT_UUID_MCS_TRACK_TITLE, title);
 }
 

--- a/subsys/bluetooth/audio/media_proxy_internal.h
+++ b/subsys/bluetooth/audio/media_proxy_internal.h
@@ -21,7 +21,7 @@
 		if (IS_ENABLED(CONFIG_BT_DEBUG_MCS)) { \
 			char t[BT_OTS_OBJ_ID_STR_LEN]; \
 			(void)bt_ots_obj_id_to_str(id64, t, sizeof(t)); \
-			BT_DBG(text "0x%s", log_strdup(t)); \
+			BT_DBG(text "0x%s", t); \
 		} \
 	} while (0)
 

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -822,7 +822,7 @@ static ssize_t on_object_send(struct bt_ots *ots, struct bt_conn *conn,
 	if (IS_ENABLED(CONFIG_BT_DEBUG_MPL)) {
 		char t[BT_OTS_OBJ_ID_STR_LEN];
 		(void)bt_ots_obj_id_to_str(id, t, sizeof(t));
-		BT_DBG("Object Id %s, offset %lu, length %zu", log_strdup(t),
+		BT_DBG("Object Id %s, offset %lu, length %zu", t,
 		       (long)offset, len);
 	}
 
@@ -872,53 +872,53 @@ static struct bt_ots_cb ots_cbs = {
 void do_prev_segment(struct mpl_mediaplayer *pl)
 {
 	BT_DBG("Segment name before: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 
 	if (pl->group->track->segment->prev != NULL) {
 		pl->group->track->segment = pl->group->track->segment->prev;
 	}
 
 	BT_DBG("Segment name after: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 }
 
 void do_next_segment(struct mpl_mediaplayer *pl)
 {
 	BT_DBG("Segment name before: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 
 	if (pl->group->track->segment->next != NULL) {
 		pl->group->track->segment = pl->group->track->segment->next;
 	}
 
 	BT_DBG("Segment name after: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 }
 
 void do_first_segment(struct mpl_mediaplayer *pl)
 {
 	BT_DBG("Segment name before: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 
 	while (pl->group->track->segment->prev != NULL) {
 		pl->group->track->segment = pl->group->track->segment->prev;
 	}
 
 	BT_DBG("Segment name after: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 }
 
 void do_last_segment(struct mpl_mediaplayer *pl)
 {
 	BT_DBG("Segment name before: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 
 	while (pl->group->track->segment->next != NULL) {
 		pl->group->track->segment = pl->group->track->segment->next;
 	}
 
 	BT_DBG("Segment name after: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 }
 
 void do_goto_segment(struct mpl_mediaplayer *pl, int32_t segnum)
@@ -926,7 +926,7 @@ void do_goto_segment(struct mpl_mediaplayer *pl, int32_t segnum)
 	int32_t k;
 
 	BT_DBG("Segment name before: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 
 	if (segnum > 0) {
 		/* Goto first segment */
@@ -959,7 +959,7 @@ void do_goto_segment(struct mpl_mediaplayer *pl, int32_t segnum)
 	}
 
 	BT_DBG("Segment name after: %s",
-	       log_strdup(pl->group->track->segment->name));
+	       pl->group->track->segment->name);
 }
 
 static bool do_prev_track(struct mpl_mediaplayer *pl)
@@ -2797,14 +2797,14 @@ void mpl_debug_dump_state(void)
 	struct mpl_track *track;
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
-	BT_DBG("Mediaplayer name: %s", log_strdup(pl.name));
+	BT_DBG("Mediaplayer name: %s", pl.name);
 
 #if CONFIG_BT_MPL_OBJECTS
 	(void)bt_ots_obj_id_to_str(pl.icon_id, t, sizeof(t));
-	BT_DBG("Icon ID: %s", log_strdup(t));
+	BT_DBG("Icon ID: %s", t);
 #endif /* CONFIG_BT_MPL_OBJECTS */
 
-	BT_DBG("Icon URL: %s", log_strdup(pl.icon_url));
+	BT_DBG("Icon URL: %s", pl.icon_url);
 	BT_DBG("Track position: %d", pl.track_pos);
 	BT_DBG("Media state: %d", pl.state);
 	BT_DBG("Playback speed parameter: %d", pl.playback_speed_param);
@@ -2816,28 +2816,28 @@ void mpl_debug_dump_state(void)
 
 #if CONFIG_BT_MPL_OBJECTS
 	(void)bt_ots_obj_id_to_str(pl.group->parent->id, t, sizeof(t));
-	BT_DBG("Current group's parent: %s", log_strdup(t));
+	BT_DBG("Current group's parent: %s", t);
 
 	(void)bt_ots_obj_id_to_str(pl.group->id, t, sizeof(t));
-	BT_DBG("Current group: %s", log_strdup(t));
+	BT_DBG("Current group: %s", t);
 
 	(void)bt_ots_obj_id_to_str(pl.group->track->id, t, sizeof(t));
-	BT_DBG("Current track: %s", log_strdup(t));
+	BT_DBG("Current track: %s", t);
 
 	if (pl.next_track_set) {
 		(void)bt_ots_obj_id_to_str(pl.next.track->id, t, sizeof(t));
-		BT_DBG("Next track: %s", log_strdup(t));
+		BT_DBG("Next track: %s", t);
 	} else if (pl.group->track->next) {
 		(void)bt_ots_obj_id_to_str(pl.group->track->next->id, t,
 					   sizeof(t));
-		BT_DBG("Next track: %s", log_strdup(t));
+		BT_DBG("Next track: %s", t);
 	} else {
 		BT_DBG("No next track");
 	}
 
 	if (pl.search_results_id) {
 		(void)bt_ots_obj_id_to_str(pl.search_results_id, t, sizeof(t));
-		BT_DBG("Search results: %s", log_strdup(t));
+		BT_DBG("Search results: %s", t);
 	} else {
 		BT_DBG("No search results");
 	}
@@ -2851,12 +2851,12 @@ void mpl_debug_dump_state(void)
 
 	while (group) {
 		(void)bt_ots_obj_id_to_str(group->id, t, sizeof(t));
-		BT_DBG("Group: %s, %s", log_strdup(t),
-		       log_strdup(group->title));
+		BT_DBG("Group: %s, %s", t,
+		       group->title);
 
 		(void)bt_ots_obj_id_to_str(group->parent->id, t, sizeof(t));
-		BT_DBG("\tParent: %s, %s", log_strdup(t),
-		       log_strdup(group->parent->title));
+		BT_DBG("\tParent: %s, %s", t,
+		       group->parent->title);
 
 		track = group->track;
 		while (track->prev != NULL) {
@@ -2865,8 +2865,8 @@ void mpl_debug_dump_state(void)
 
 		while (track) {
 			(void)bt_ots_obj_id_to_str(track->id, t, sizeof(t));
-			BT_DBG("\tTrack: %s, %s, duration: %d", log_strdup(t),
-			       log_strdup(track->title), track->duration);
+			BT_DBG("\tTrack: %s, %s, duration: %d", t,
+			       track->title, track->duration);
 			track = track->next;
 		}
 

--- a/subsys/bluetooth/audio/tbs.c
+++ b/subsys/bluetooth/audio/tbs.c
@@ -502,13 +502,13 @@ static ssize_t read_provider_name(struct bt_conn *conn,
 
 	if (IS_ENABLED(CONFIG_BT_GTBS) && attr->user_data == &gtbs_inst) {
 		provider_name = gtbs_inst.provider_name;
-		BT_DBG("GTBS: Provider name %s", log_strdup(provider_name));
+		BT_DBG("GTBS: Provider name %s", provider_name);
 	} else {
 		const struct tbs_service_inst *inst = (struct tbs_service_inst *)attr->user_data;
 
 		provider_name = inst->provider_name;
 		BT_DBG("Index %u, Provider name %s",
-		       inst->index, log_strdup(provider_name));
+		       inst->index, provider_name);
 	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
@@ -535,12 +535,12 @@ static ssize_t read_uci(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 
 	if (IS_ENABLED(CONFIG_BT_GTBS) && attr->user_data == &gtbs_inst) {
 		uci = gtbs_inst.uci;
-		BT_DBG("GTBS: UCI %s", log_strdup(uci));
+		BT_DBG("GTBS: UCI %s", uci);
 	} else {
 		const struct tbs_service_inst *inst = (struct tbs_service_inst *)attr->user_data;
 
 		uci = inst->uci;
-		BT_DBG("Index %u: UCI %s", inst->index, log_strdup(uci));
+		BT_DBG("Index %u: UCI %s", inst->index, uci);
 	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
@@ -602,7 +602,7 @@ static ssize_t read_uri_scheme_list(struct bt_conn *conn,
 		}
 		/* Add null terminator for printing */
 		read_buf.data[read_buf.len] = '\0';
-		BT_DBG("GTBS: URI scheme %s", log_strdup(read_buf.data));
+		BT_DBG("GTBS: URI scheme %s", read_buf.data);
 	} else {
 		const struct tbs_service_inst *inst = (struct tbs_service_inst *)attr->user_data;
 
@@ -611,7 +611,7 @@ static ssize_t read_uri_scheme_list(struct bt_conn *conn,
 		/* Add null terminator for printing */
 		read_buf.data[read_buf.len] = '\0';
 		BT_DBG("Index %u: URI scheme %s", inst->index,
-		       log_strdup(read_buf.data));
+		       read_buf.data);
 	}
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset,
@@ -829,14 +829,14 @@ static ssize_t read_incoming_uri(struct bt_conn *conn,
 		inc_call_target = &gtbs_inst.incoming_uri;
 		BT_DBG("GTBS: call index 0x%02X, URI %s",
 		       inc_call_target->call_index,
-		       log_strdup(inc_call_target->uri));
+		       inc_call_target->uri);
 	} else {
 		const struct tbs_service_inst *inst = (struct tbs_service_inst *)attr->user_data;
 
 		inc_call_target = &inst->incoming_uri;
 		BT_DBG("Index %u: call index 0x%02X, URI %s",
 		       inst->index, inc_call_target->call_index,
-		       log_strdup(inc_call_target->uri));
+		       inc_call_target->uri);
 	}
 
 	if (!inc_call_target->call_index) {
@@ -1075,7 +1075,7 @@ static int originate_call(struct tbs_service_inst *inst,
 	(void)memcpy(call->remote_uri, ccp->uri, uri_len);
 	call->remote_uri[uri_len] = '\0';
 	if (!bt_tbs_valid_uri(call->remote_uri)) {
-		BT_DBG("Invalid URI: %s", log_strdup(call->remote_uri));
+		BT_DBG("Invalid URI: %s", call->remote_uri);
 		call->index = BT_TBS_FREE_CALL_INDEX;
 
 		return BT_TBS_RESULT_CODE_INVALID_URI;
@@ -1523,14 +1523,14 @@ static ssize_t read_friendly_name(struct bt_conn *conn,
 		friendly_name = &gtbs_inst.friendly_name;
 		BT_DBG("GTBS: call index 0x%02X, URI %s",
 		       friendly_name->call_index,
-		       log_strdup(friendly_name->uri));
+		       friendly_name->uri);
 	} else {
 		const struct tbs_service_inst *inst = (struct tbs_service_inst *)attr->user_data;
 
 		friendly_name = &inst->friendly_name;
 		BT_DBG("Index %u: call index 0x%02X, URI %s",
 		       inst->index, friendly_name->call_index,
-		       log_strdup(friendly_name->uri));
+		       friendly_name->uri);
 	}
 
 	if (friendly_name->call_index == BT_TBS_FREE_CALL_INDEX) {
@@ -1567,14 +1567,14 @@ static ssize_t read_incoming_call(struct bt_conn *conn,
 	if (IS_ENABLED(CONFIG_BT_GTBS) && attr->user_data == &gtbs_inst) {
 		remote_uri = &gtbs_inst.in_call;
 		BT_DBG("GTBS: call index 0x%02X, URI %s",
-		       remote_uri->call_index, log_strdup(remote_uri->uri));
+		       remote_uri->call_index, remote_uri->uri);
 	} else {
 		const struct tbs_service_inst *inst = (struct tbs_service_inst *)attr->user_data;
 
 		remote_uri = &inst->in_call;
 		BT_DBG("Index %u: call index 0x%02X, URI %s",
 		       inst->index, remote_uri->call_index,
-		       log_strdup(remote_uri->uri));
+		       remote_uri->uri);
 	}
 
 	if (remote_uri->call_index == BT_TBS_FREE_CALL_INDEX) {
@@ -1944,7 +1944,7 @@ int bt_tbs_originate(uint8_t bearer_index, char *remote_uri,
 	if (bearer_index >= CONFIG_BT_TBS_BEARER_COUNT) {
 		return -EINVAL;
 	} else if (!bt_tbs_valid_uri(remote_uri)) {
-		BT_DBG("Invalid URI %s", log_strdup(remote_uri));
+		BT_DBG("Invalid URI %s", remote_uri);
 		return -EINVAL;
 	}
 
@@ -2102,10 +2102,10 @@ int bt_tbs_remote_incoming(uint8_t bearer_index, const char *to,
 	if (bearer_index >= CONFIG_BT_TBS_BEARER_COUNT) {
 		return -EINVAL;
 	} else if (!bt_tbs_valid_uri(to)) {
-		BT_DBG("Invalid \"to\" URI: %s", log_strdup(to));
+		BT_DBG("Invalid \"to\" URI: %s", to);
 		return -EINVAL;
 	} else if (!bt_tbs_valid_uri(from)) {
-		BT_DBG("Invalid \"from\" URI: %s", log_strdup(from));
+		BT_DBG("Invalid \"from\" URI: %s", from);
 		return -EINVAL;
 	}
 
@@ -2421,7 +2421,7 @@ int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char **uri_list,
 	(void)strcpy(inst->uri_scheme_list, uri_scheme_list);
 
 	BT_DBG("TBS instance %u uri prefix list is now %s",
-	       bearer_index, log_strdup(inst->uri_scheme_list));
+	       bearer_index, inst->uri_scheme_list);
 
 	bt_gatt_notify_uuid(NULL, BT_UUID_TBS_URI_LIST,
 			    inst->service_p->attrs, &inst->uri_scheme_list,
@@ -2447,7 +2447,7 @@ int bt_tbs_set_uri_scheme_list(uint8_t bearer_index, const char **uri_list,
 
 		/* Add null terminator for printing */
 		uri_scheme_buf.data[uri_scheme_buf.len] = '\0';
-		BT_DBG("GTBS: URI scheme %s", log_strdup(uri_scheme_buf.data));
+		BT_DBG("GTBS: URI scheme %s", uri_scheme_buf.data);
 
 		bt_gatt_notify_uuid(NULL, BT_UUID_TBS_URI_LIST,
 				    gtbs_inst.service_p->attrs,
@@ -2477,7 +2477,7 @@ void bt_tbs_dbg_print_calls(void)
 			BT_DBG("  Call #%u", call->index);
 			BT_DBG("    State: %s", bt_tbs_state_str(call->state));
 			BT_DBG("    Flags: 0x%02X", call->flags);
-			BT_DBG("    URI  : %s", log_strdup(call->remote_uri));
+			BT_DBG("    URI  : %s", call->remote_uri);
 		}
 	}
 }

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -291,7 +291,7 @@ static void provider_name_notify_handler(struct bt_conn *conn,
 	const char *name = parse_string_value(data, length,
 					      CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH);
 
-	BT_DBG("%s", log_strdup(name));
+	BT_DBG("%s", name);
 
 	if (tbs_client_cbs != NULL && tbs_client_cbs->bearer_provider_name != NULL) {
 		tbs_client_cbs->bearer_provider_name(conn, 0, tbs_inst->index, name);
@@ -401,7 +401,7 @@ static void incoming_uri_notify_handler(struct bt_conn *conn,
 	const char *uri = parse_string_value(data, length,
 					     CONFIG_BT_TBS_MAX_URI_LENGTH);
 
-	BT_DBG("%s", log_strdup(uri));
+	BT_DBG("%s", uri);
 
 	if (tbs_client_cbs != NULL && tbs_client_cbs->call_uri != NULL) {
 		tbs_client_cbs->call_uri(conn, 0, tbs_inst->index, uri);
@@ -493,7 +493,7 @@ static void in_call_notify_handler(struct bt_conn *conn,
 	const char *uri = parse_string_value(data, length,
 					     CONFIG_BT_TBS_MAX_URI_LENGTH);
 
-	BT_DBG("%s", log_strdup(uri));
+	BT_DBG("%s", uri);
 
 	if (tbs_client_cbs != NULL && tbs_client_cbs->remote_uri != NULL) {
 		tbs_client_cbs->remote_uri(conn, 0, tbs_inst->index, uri);
@@ -507,7 +507,7 @@ static void friendly_name_notify_handler(struct bt_conn *conn,
 	const char *name = parse_string_value(data, length,
 					      CONFIG_BT_TBS_MAX_URI_LENGTH);
 
-	BT_DBG("%s", log_strdup(name));
+	BT_DBG("%s", name);
 
 	if (tbs_client_cbs != NULL && tbs_client_cbs->friendly_name != NULL) {
 		tbs_client_cbs->friendly_name(conn, 0, tbs_inst->index, name);
@@ -625,7 +625,7 @@ static uint8_t read_bearer_provider_name_cb(struct bt_conn *conn, uint8_t err,
 			provider_name =
 				parse_string_value(data, length,
 					CONFIG_BT_TBS_MAX_PROVIDER_NAME_LENGTH);
-			BT_DBG("%s", log_strdup(provider_name));
+			BT_DBG("%s", provider_name);
 		}
 
 		inst->busy = false;
@@ -661,7 +661,7 @@ static uint8_t read_bearer_uci_cb(struct bt_conn *conn, uint8_t err,
 		} else if (data != NULL) {
 			bearer_uci = parse_string_value(data, length,
 							BT_TBS_MAX_UCI_SIZE);
-			BT_DBG("%s", log_strdup(bearer_uci));
+			BT_DBG("%s", bearer_uci);
 		}
 
 		inst->busy = false;
@@ -740,7 +740,7 @@ static uint8_t read_uri_list_cb(struct bt_conn *conn, uint8_t err,
 		} else if (data != NULL) {
 			uri_scheme_list = parse_string_value(data, length,
 						MAX_URI_SCHEME_LIST_SIZE);
-			BT_DBG("%s", log_strdup(uri_scheme_list));
+			BT_DBG("%s", uri_scheme_list);
 		}
 
 		inst->busy = false;
@@ -1038,7 +1038,7 @@ static uint8_t read_call_uri_cb(struct bt_conn *conn, uint8_t err,
 			in_target_uri = parse_string_value(
 						data, length,
 						CONFIG_BT_TBS_MAX_URI_LENGTH);
-			BT_DBG("%s", log_strdup(in_target_uri));
+			BT_DBG("%s", in_target_uri);
 		}
 
 		inst->busy = false;
@@ -1208,7 +1208,7 @@ static uint8_t read_remote_uri_cb(struct bt_conn *conn, uint8_t err,
 		} else if (data != NULL) {
 			remote_uri = parse_string_value(data, length,
 							CONFIG_BT_TBS_MAX_URI_LENGTH);
-			BT_DBG("%s", log_strdup(remote_uri));
+			BT_DBG("%s", remote_uri);
 		}
 
 		inst->busy = false;
@@ -1245,7 +1245,7 @@ static uint8_t read_friendly_name_cb(struct bt_conn *conn, uint8_t err,
 		} else if (data != NULL) {
 			friendly_name = parse_string_value(data, length,
 							   CONFIG_BT_TBS_MAX_URI_LENGTH);
-			BT_DBG("%s", log_strdup(friendly_name));
+			BT_DBG("%s", friendly_name);
 		}
 		inst->busy = false;
 
@@ -1603,7 +1603,7 @@ int bt_tbs_client_originate_call(struct bt_conn *conn, uint8_t inst_index,
 	} else if (!valid_inst_index(conn, inst_index)) {
 		return -EINVAL;
 	} else if (!bt_tbs_valid_uri(uri)) {
-		BT_DBG("Invalid URI: %s", log_strdup(uri));
+		BT_DBG("Invalid URI: %s", uri);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/audio/vocs.c
+++ b/subsys/bluetooth/audio/vocs.c
@@ -193,7 +193,7 @@ static ssize_t write_output_desc(struct bt_conn *conn, const struct bt_gatt_attr
 		}
 	}
 
-	BT_DBG("%s", log_strdup(inst->srv.output_desc));
+	BT_DBG("%s", inst->srv.output_desc);
 
 	return len;
 }
@@ -204,7 +204,7 @@ static ssize_t read_output_desc(struct bt_conn *conn, const struct bt_gatt_attr 
 {
 	struct bt_vocs *inst = attr->user_data;
 
-	BT_DBG("%s", log_strdup(inst->srv.output_desc));
+	BT_DBG("%s", inst->srv.output_desc);
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, &inst->srv.output_desc,
 				 strlen(inst->srv.output_desc));
 }
@@ -311,7 +311,7 @@ int bt_vocs_register(struct bt_vocs *vocs,
 		vocs->srv.output_desc[sizeof(vocs->srv.output_desc) - 1] = '\0';
 		if (IS_ENABLED(CONFIG_BT_DEBUG_VOCS) &&
 		    strcmp(vocs->srv.output_desc, param->output_desc)) {
-			BT_DBG("Output desc clipped to %s", log_strdup(vocs->srv.output_desc));
+			BT_DBG("Output desc clipped to %s", vocs->srv.output_desc);
 		}
 	}
 

--- a/subsys/bluetooth/audio/vocs_client.c
+++ b/subsys/bluetooth/audio/vocs_client.c
@@ -90,7 +90,7 @@ uint8_t vocs_client_notify_handler(struct bt_conn *conn, struct bt_gatt_subscrib
 
 		memcpy(desc, data, length);
 		desc[length] = '\0';
-		BT_DBG("Inst %p: Output description: %s", inst, log_strdup(desc));
+		BT_DBG("Inst %p: Output description: %s", inst, desc);
 		if (inst->cli.cb && inst->cli.cb->description) {
 			inst->cli.cb->description(inst, 0, desc);
 		}
@@ -324,7 +324,7 @@ static uint8_t vcs_client_read_output_desc_cb(struct bt_conn *conn, uint8_t err,
 			memcpy(desc, data, length);
 		}
 		desc[length] = '\0';
-		BT_DBG("Output description: %s", log_strdup(desc));
+		BT_DBG("Output description: %s", desc);
 	}
 
 	if (inst->cli.cb && inst->cli.cb->description) {

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -92,14 +92,10 @@ const char *bt_addr_str_real(const bt_addr_t *addr);
 const char *bt_addr_le_str_real(const bt_addr_le_t *addr);
 const char *bt_uuid_str_real(const struct bt_uuid *uuid);
 
-/* NOTE: log_strdup does not guarantee a duplication of the string.
- * It is therefore still the responsibility of the user to handle the
- * restrictions in the underlying function call.
- */
-#define bt_hex(buf, len) log_strdup(bt_hex_real(buf, len))
-#define bt_addr_str(addr) log_strdup(bt_addr_str_real(addr))
-#define bt_addr_le_str(addr) log_strdup(bt_addr_le_str_real(addr))
-#define bt_uuid_str(uuid) log_strdup(bt_uuid_str_real(uuid))
+#define bt_hex(buf, len) bt_hex_real(buf, len)
+#define bt_addr_str(addr) bt_addr_str_real(addr)
+#define bt_addr_le_str(addr) bt_addr_le_str_real(addr)
+#define bt_uuid_str(uuid) bt_uuid_str_real(uuid)
 
 #ifdef __cplusplus
 }

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -343,7 +343,7 @@ static void sc_store(struct gatt_sc_cfg *cfg)
 	}
 
 	BT_DBG("stored SC for %s (%s, 0x%04x-0x%04x)",
-	       bt_addr_le_str(&cfg->peer), log_strdup(key), cfg->data.start,
+	       bt_addr_le_str(&cfg->peer), key, cfg->data.start,
 	       cfg->data.end);
 }
 
@@ -383,7 +383,7 @@ static int bt_gatt_clear_sc(uint8_t id, const bt_addr_le_t *addr)
 		} else {
 			BT_DBG("deleted SC for %s (%s)",
 			       bt_addr_le_str(&cfg->peer),
-			       log_strdup(key));
+			       key);
 		}
 	}
 
@@ -956,7 +956,7 @@ static int bt_gatt_store_cf(struct bt_conn *conn)
 		return err;
 	}
 
-	BT_DBG("Stored CF for %s (%s)", bt_addr_le_str(&conn->le.dst), log_strdup(key));
+	BT_DBG("Stored CF for %s (%s)", bt_addr_le_str(&conn->le.dst), key);
 #endif /* CONFIG_BT_GATT_CACHING */
 	return 0;
 
@@ -5085,7 +5085,7 @@ static int ccc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 
 		err = bt_settings_decode_key(name, &addr);
 		if (err) {
-			BT_ERR("Unable to decode address %s", log_strdup(name));
+			BT_ERR("Unable to decode address %s", name);
 			return -EINVAL;
 		}
 
@@ -5140,7 +5140,7 @@ static int ccc_set_direct(const char *key, size_t len, settings_read_cb read_cb,
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		const char *name;
 
-		BT_DBG("key: %s", log_strdup((const char *)param));
+		BT_DBG("key: %s", (const char *)param);
 
 		/* Only "bt/ccc" settings should ever come here */
 		if (!settings_name_steq((const char *)param, "bt/ccc", &name)) {
@@ -5397,7 +5397,7 @@ int bt_gatt_store_ccc(uint8_t id, const bt_addr_le_t *addr)
 	}
 
 	BT_DBG("Stored CCCs for %s (%s)", bt_addr_le_str(addr),
-	       log_strdup(key));
+	       key);
 	if (len) {
 		for (size_t i = 0; i < save.count; i++) {
 			BT_DBG("  CCC: handle 0x%04x value 0x%04x",
@@ -5428,7 +5428,7 @@ static int sc_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 
 	err = bt_settings_decode_key(name, &addr);
 	if (err) {
-		BT_ERR("Unable to decode address %s", log_strdup(name));
+		BT_ERR("Unable to decode address %s", name);
 		return -EINVAL;
 	}
 
@@ -5513,7 +5513,7 @@ static int cf_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 
 	err = bt_settings_decode_key(name, &addr);
 	if (err) {
-		BT_ERR("Unable to decode address %s", log_strdup(name));
+		BT_ERR("Unable to decode address %s", name);
 		return -EINVAL;
 	}
 

--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -302,7 +302,7 @@ void bt_keys_clear(struct bt_keys *keys)
 					       &keys->addr, NULL);
 		}
 
-		BT_DBG("Deleting key %s", log_strdup(key));
+		BT_DBG("Deleting key %s", key);
 		settings_delete(key);
 	}
 
@@ -333,7 +333,7 @@ int bt_keys_store(struct bt_keys *keys)
 	}
 
 	BT_DBG("Stored keys for %s (%s)", bt_addr_le_str(&keys->addr),
-	       log_strdup(key));
+	       key);
 
 	return 0;
 }
@@ -360,7 +360,7 @@ static int keys_set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		return -EINVAL;
 	}
 
-	BT_DBG("name %s val %s", log_strdup(name),
+	BT_DBG("name %s val %s", name,
 	       (len) ? bt_hex(val, sizeof(val)) : "(null)");
 
 	err = bt_settings_decode_key(name, &addr);

--- a/subsys/bluetooth/host/keys_br.c
+++ b/subsys/bluetooth/host/keys_br.c
@@ -171,7 +171,7 @@ static int link_key_set(const char *name, size_t len_rd,
 		return -EINVAL;
 	}
 
-	BT_DBG("name %s val %s", log_strdup(name),
+	BT_DBG("name %s val %s", name,
 	       len ? bt_hex(val, sizeof(val)) : "(null)");
 
 	err = bt_settings_decode_key(name, &le_addr);

--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -37,7 +37,7 @@ void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 			 addr->type);
 	}
 
-	BT_DBG("Encoded path %s", log_strdup(path));
+	BT_DBG("Encoded path %s", path);
 }
 #else
 void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
@@ -86,7 +86,7 @@ void bt_settings_encode_key(char *path, size_t path_size, const char *subsys,
 		*path = '\0';
 	}
 
-	BT_DBG("Encoded path %s", log_strdup(path));
+	BT_DBG("Encoded path %s", path);
 }
 #endif
 
@@ -108,7 +108,7 @@ int bt_settings_decode_key(const char *key, bt_addr_le_t *addr)
 		hex2bin(&key[i * 2], 2, &addr->a.val[5 - i], 1);
 	}
 
-	BT_DBG("Decoded %s as %s", log_strdup(key), bt_addr_le_str(addr));
+	BT_DBG("Decoded %s as %s", key, bt_addr_le_str(addr));
 
 	return 0;
 }
@@ -178,7 +178,7 @@ static int set(const char *name, size_t len_rd, settings_read_cb read_cb,
 		} else {
 			bt_dev.name[len] = '\0';
 
-			BT_DBG("Name set to %s", log_strdup(bt_dev.name));
+			BT_DBG("Name set to %s", bt_dev.name);
 		}
 		return 0;
 	}

--- a/subsys/bluetooth/mesh/access.c
+++ b/subsys/bluetooth/mesh/access.c
@@ -1115,9 +1115,9 @@ static void store_pending_mod_bind(struct bt_mesh_model *mod, bool vnd)
 	}
 
 	if (err) {
-		BT_ERR("Failed to store %s value", log_strdup(path));
+		BT_ERR("Failed to store %s value", path);
 	} else {
-		BT_DBG("Stored %s value", log_strdup(path));
+		BT_DBG("Stored %s value", path);
 	}
 }
 
@@ -1143,9 +1143,9 @@ static void store_pending_mod_sub(struct bt_mesh_model *mod, bool vnd)
 	}
 
 	if (err) {
-		BT_ERR("Failed to store %s value", log_strdup(path));
+		BT_ERR("Failed to store %s value", path);
 	} else {
-		BT_DBG("Stored %s value", log_strdup(path));
+		BT_DBG("Stored %s value", path);
 	}
 }
 
@@ -1172,9 +1172,9 @@ static void store_pending_mod_pub(struct bt_mesh_model *mod, bool vnd)
 	}
 
 	if (err) {
-		BT_ERR("Failed to store %s value", log_strdup(path));
+		BT_ERR("Failed to store %s value", path);
 	} else {
-		BT_DBG("Stored %s value", log_strdup(path));
+		BT_DBG("Stored %s value", path);
 	}
 }
 
@@ -1245,9 +1245,9 @@ int bt_mesh_model_data_store(struct bt_mesh_model *mod, bool vnd,
 	}
 
 	if (err) {
-		BT_ERR("Failed to store %s value", log_strdup(path));
+		BT_ERR("Failed to store %s value", path);
 	} else {
-		BT_DBG("Stored %s value", log_strdup(path));
+		BT_DBG("Stored %s value", path);
 	}
 	return err;
 }

--- a/subsys/bluetooth/mesh/app_keys.c
+++ b/subsys/bluetooth/mesh/app_keys.c
@@ -111,9 +111,9 @@ static void store_app_key(uint16_t app_idx)
 
 	err = settings_save_one(path, &key, sizeof(key));
 	if (err) {
-		BT_ERR("Failed to store AppKey %s value", log_strdup(path));
+		BT_ERR("Failed to store AppKey %s value", path);
 	} else {
-		BT_DBG("Stored AppKey %s value", log_strdup(path));
+		BT_DBG("Stored AppKey %s value", path);
 	}
 }
 

--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -421,9 +421,9 @@ static void store_cdb_node(const struct bt_mesh_cdb_node *node)
 
 	err = settings_save_one(path, &val, sizeof(val));
 	if (err) {
-		BT_ERR("Failed to store Node %s value", log_strdup(path));
+		BT_ERR("Failed to store Node %s value", path);
 	} else {
-		BT_DBG("Stored Node %s value", log_strdup(path));
+		BT_DBG("Stored Node %s value", path);
 	}
 }
 
@@ -498,9 +498,9 @@ static void store_cdb_app_key(const struct bt_mesh_cdb_app_key *app)
 
 	err = settings_save_one(path, &key, sizeof(key));
 	if (err) {
-		BT_ERR("Failed to store AppKey %s value", log_strdup(path));
+		BT_ERR("Failed to store AppKey %s value", path);
 	} else {
-		BT_DBG("Stored AppKey %s value", log_strdup(path));
+		BT_DBG("Stored AppKey %s value", path);
 	}
 }
 

--- a/subsys/bluetooth/mesh/prov.c
+++ b/subsys/bluetooth/mesh/prov.c
@@ -302,7 +302,7 @@ int bt_mesh_input_number(uint32_t num)
 
 int bt_mesh_input_string(const char *str)
 {
-	BT_DBG("%s", log_strdup(str));
+	BT_DBG("%s", str);
 
 	if (strlen(str) > PROV_IO_OOB_SIZE_MAX ||
 			strlen(str) > bt_mesh_prov_link.oob_size) {

--- a/subsys/bluetooth/mesh/rpl.c
+++ b/subsys/bluetooth/mesh/rpl.c
@@ -309,9 +309,9 @@ static void store_rpl(struct bt_mesh_rpl *entry)
 
 	err = settings_save_one(path, &rpl, sizeof(rpl));
 	if (err) {
-		BT_ERR("Failed to store RPL %s value", log_strdup(path));
+		BT_ERR("Failed to store RPL %s value", path);
 	} else {
-		BT_DBG("Stored RPL %s value", log_strdup(path));
+		BT_DBG("Stored RPL %s value", path);
 	}
 }
 

--- a/subsys/bluetooth/mesh/transport.c
+++ b/subsys/bluetooth/mesh/transport.c
@@ -1857,11 +1857,11 @@ void bt_mesh_va_pending_store(void)
 		if (err) {
 			BT_ERR("Failed to %s %s value (err %d)",
 			       IS_VA_DEL(lab) ? "delete" : "store",
-			       log_strdup(path), err);
+			       path, err);
 		} else {
 			BT_DBG("%s %s value",
 			       IS_VA_DEL(lab) ? "Deleted" : "Stored",
-			       log_strdup(path));
+			       path);
 		}
 	}
 }

--- a/subsys/bluetooth/services/ots/ots.c
+++ b/subsys/bluetooth/services/ots/ots.c
@@ -265,7 +265,7 @@ static ssize_t ots_obj_id_read(struct bt_conn *conn,
 
 	bt_ots_obj_id_to_str(ots->cur_obj->id, id_str,
 				      sizeof(id_str));
-	LOG_DBG("Current Object ID: %s", log_strdup(id_str));
+	LOG_DBG("Current Object ID: %s", id_str);
 
 	return bt_gatt_attr_read(conn, attr, buf, len, offset, id, sizeof(id));
 }
@@ -575,7 +575,7 @@ static void ots_delete_empty_name_objects(struct bt_ots *ots, struct bt_conn *co
 
 		if (strlen(obj->metadata.name) == 0) {
 			bt_ots_obj_id_to_str(obj->id, id_str, sizeof(id_str));
-			LOG_DBG("Deleting object with %s ID due to empty name", log_strdup(id_str));
+			LOG_DBG("Deleting object with %s ID due to empty name", id_str);
 
 			if (ots->cb && ots->cb->obj_deleted) {
 				ots->cb->obj_deleted(ots, conn, obj->id);
@@ -583,7 +583,7 @@ static void ots_delete_empty_name_objects(struct bt_ots *ots, struct bt_conn *co
 
 			if (bt_gatt_ots_obj_manager_obj_delete(obj)) {
 				LOG_ERR("Failed to remove object with %s ID from object manager",
-					log_strdup(id_str));
+					id_str);
 			}
 		}
 	}

--- a/subsys/bluetooth/services/ots/ots_client.c
+++ b/subsys/bluetooth/services/ots/ots_client.c
@@ -201,17 +201,17 @@ static void chan_closed(struct bt_gatt_ots_l2cap *l2cap_ctx,
 static void print_oacp_response(enum bt_gatt_ots_oacp_proc_type req_opcode,
 				enum bt_gatt_ots_oacp_res_code result_code)
 {
-	BT_DBG("Request OP Code: %s", log_strdup(lit_request[req_opcode]));
-	BT_DBG("Result Code    : %s", log_strdup(lit_result[result_code]));
+	BT_DBG("Request OP Code: %s", lit_request[req_opcode]);
+	BT_DBG("Result Code    : %s", lit_result[result_code]);
 }
 
 static void print_olcp_response(enum bt_gatt_ots_olcp_proc_type req_opcode,
 				enum bt_gatt_ots_olcp_res_code result_code)
 {
 	BT_DBG("Request OP Code: %s",
-	       log_strdup(lit_olcp_request[req_opcode]));
+	       lit_olcp_request[req_opcode]);
 	BT_DBG("Result Code    : %s",
-	       log_strdup(lit_olcp_result[result_code]));
+	       lit_olcp_result[result_code]);
 }
 
 static void date_time_decode(struct net_buf_simple *buf,
@@ -808,7 +808,7 @@ static uint8_t read_obj_id_cb(struct bt_conn *conn, uint8_t err,
 				&inst->otc_inst->cur_object;
 
 			(void)bt_ots_obj_id_to_str(obj_id, t, sizeof(t));
-			BT_DBG("Object Id : %s", log_strdup(t));
+			BT_DBG("Object Id : %s", t);
 
 			if (cur_object->id != OTS_CLIENT_UNKNOWN_ID &&
 			    cur_object->id != obj_id) {
@@ -817,7 +817,7 @@ static uint8_t read_obj_id_cb(struct bt_conn *conn, uint8_t err,
 				(void)bt_ots_obj_id_to_str(cur_object->id, str,
 							   sizeof(str));
 				BT_INFO("Read Obj Id %s not selected obj Id %s",
-					log_strdup(t), log_strdup(str));
+					t, str);
 			} else {
 				BT_INFO("Read Obj Id confirmed correct Obj Id");
 				cur_object->id = obj_id;
@@ -903,7 +903,7 @@ static uint8_t read_obj_type_cb(struct bt_conn *conn, uint8_t err,
 			bt_uuid_create(uuid, data, length);
 
 			bt_uuid_to_str(uuid, uuid_str, sizeof(uuid_str));
-			BT_DBG("UUID type read: %s", log_strdup(uuid_str));
+			BT_DBG("UUID type read: %s", uuid_str);
 
 			BT_OTS_SET_METADATA_REQ_TYPE(inst->metadata_read);
 		} else {
@@ -1302,7 +1302,7 @@ static int decode_record(struct net_buf_simple *buf,
 		char t[BT_OTS_OBJ_ID_STR_LEN];
 
 		(void)bt_ots_obj_id_to_str(rec->metadata.id, t, sizeof(t));
-		BT_DBG("Object ID 0x%s", log_strdup(t));
+		BT_DBG("Object ID 0x%s", t);
 	}
 
 	if ((start_len - buf->len) + sizeof(uint8_t) > rec->len) {
@@ -1488,8 +1488,8 @@ void bt_ots_metadata_display(struct bt_ots_obj_metadata *metadata,
 		char t[BT_OTS_OBJ_ID_STR_LEN];
 
 		(void)bt_ots_obj_id_to_str(metadata->id, t, sizeof(t));
-		BT_INFO("Object ID: 0x%s", log_strdup(t));
-		BT_INFO("Object name: %s", log_strdup(metadata->name_c));
+		BT_INFO("Object ID: 0x%s", t);
+		BT_INFO("Object name: %s", metadata->name_c);
 		BT_INFO("Object Current Size: %u", metadata->size.cur);
 		BT_INFO("Object Allocate Size: %u", metadata->size.alloc);
 

--- a/subsys/bluetooth/services/ots/ots_dir_list.c
+++ b/subsys/bluetooth/services/ots/ots_dir_list.c
@@ -139,7 +139,7 @@ static int bt_ots_dir_list_search_forward(struct bt_ots_dir_list *dir_list, void
 
 	bt_ots_obj_id_to_str(obj->id, id_str, sizeof(id_str));
 	LOG_DBG("Searching forward for offset %ld starting at %ld with object ID %s",
-		(long)offset, (long)dir_list->anchor_offset, log_strdup(id_str));
+		(long)offset, (long)dir_list->anchor_offset, id_str);
 
 	while (dir_list->anchor_offset + rec_len <= offset) {
 
@@ -166,7 +166,7 @@ static int bt_ots_dir_list_search_backward(struct bt_ots_dir_list *dir_list, voi
 
 	bt_ots_obj_id_to_str(obj->id, id_str, sizeof(id_str));
 	LOG_DBG("Searching backward for offset %ld starting at %ld with object ID %s",
-		(long)offset, (long)dir_list->anchor_offset, log_strdup(id_str));
+		(long)offset, (long)dir_list->anchor_offset, id_str);
 
 	while (dir_list->anchor_offset > offset) {
 
@@ -226,7 +226,7 @@ static int bt_ots_dir_list_search(struct bt_ots_dir_list *dir_list, void *obj_ma
 
 	bt_ots_obj_id_to_str(dir_list->anchor_object->id, id_str, sizeof(id_str));
 	LOG_DBG("Found offset %ld starting at %ld in object with ID %s",
-		(long)offset, (long)dir_list->anchor_offset, log_strdup(id_str));
+		(long)offset, (long)dir_list->anchor_offset, id_str);
 
 	return 0;
 }

--- a/subsys/bluetooth/services/ots/ots_oacp.c
+++ b/subsys/bluetooth/services/ots/ots_oacp.c
@@ -62,7 +62,7 @@ static enum bt_gatt_ots_oacp_res_code oacp_create_proc_validate(
 
 	bt_uuid_to_str(&param.type.uuid, str, BT_UUID_STR_LEN);
 	LOG_DBG("Validating Create procedure with size: 0x%08X and "
-		"type: %s", param.size, log_strdup(str));
+		"type: %s", param.size, str);
 
 	if (!BT_OTS_OACP_GET_FEAT_CREATE(ots->features.oacp)) {
 		LOG_DBG("Create Procedure is not supported.");

--- a/subsys/bluetooth/services/ots/ots_olcp.c
+++ b/subsys/bluetooth/services/ots/ots_olcp.c
@@ -262,7 +262,7 @@ ssize_t bt_gatt_ots_olcp_write(struct bt_conn *conn,
 			bt_ots_obj_id_to_str(ots->cur_obj->id, id,
 						sizeof(id));
 			LOG_DBG("Selecting a new Current Object with id: %s",
-				log_strdup(id));
+				id);
 
 			if (IS_ENABLED(CONFIG_BT_OTS_DIR_LIST_OBJ)) {
 				bt_ots_dir_list_selected(ots->dir_list, ots->obj_manager,

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -975,7 +975,7 @@ int cmd_mcc_send_search_raw(const struct shell *sh, size_t argc, char *argv[])
 
 	search.len = strlen(argv[1]);
 	memcpy(search.search, argv[1], search.len);
-	BT_DBG("Search string: %s", log_strdup(argv[1]));
+	BT_DBG("Search string: %s", argv[1]);
 
 	result = bt_mcc_send_search(default_conn, &search);
 	if (result) {

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -767,7 +767,7 @@ int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
 
 	search.len = strlen(argv[1]);
 	memcpy(search.search, argv[1], search.len);
-	BT_DBG("Search string: %s", log_strdup(argv[1]));
+	BT_DBG("Search string: %s", argv[1]);
 
 	err = media_proxy_ctrl_send_search(current_player, &search);
 	if (err) {

--- a/subsys/debug/coredump/coredump_backend_logging.c
+++ b/subsys/debug/coredump/coredump_backend_logging.c
@@ -75,7 +75,7 @@ static void coredump_logging_backend_buffer_output(uint8_t *buf, size_t buflen)
 
 		if ((log_ptr >= LOG_BUF_SZ) || (remaining == 0)) {
 			log_buf[log_ptr] = '\0';
-			LOG_ERR(COREDUMP_PREFIX_STR "%s", log_strdup(log_buf));
+			LOG_ERR(COREDUMP_PREFIX_STR "%s", log_buf);
 			log_ptr = 0;
 		}
 	}

--- a/subsys/debug/thread_analyzer.c
+++ b/subsys/debug/thread_analyzer.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(thread_analyzer, CONFIG_THREAD_ANALYZER_LOG_LEVEL);
 #else
 #define THREAD_ANALYZER_PRINT(...) LOG_INF(__VA_ARGS__)
 #define THREAD_ANALYZER_FMT(str)   str
-#define THREAD_ANALYZER_VSTR(str)  log_strdup(str)
+#define THREAD_ANALYZER_VSTR(str)  str
 #endif
 
 /* @brief Maximum length of the pointer when converted to string

--- a/subsys/fs/fs.c
+++ b/subsys/fs/fs.c
@@ -693,7 +693,7 @@ int fs_mount(struct fs_mount_t *mp)
 
 	if (fs->unmount == NULL) {
 		LOG_WRN("mount path %s is not unmountable",
-			log_strdup(mp->mnt_point));
+			mp->mnt_point);
 	}
 
 	rc = fs->mount(mp);
@@ -707,7 +707,7 @@ int fs_mount(struct fs_mount_t *mp)
 	mp->fs = fs;
 
 	sys_dlist_append(&fs_mnt_list, &mp->node);
-	LOG_DBG("fs mounted at %s", log_strdup(mp->mnt_point));
+	LOG_DBG("fs mounted at %s", mp->mnt_point);
 
 mount_err:
 	k_mutex_unlock(&mutex);
@@ -747,7 +747,7 @@ int fs_unmount(struct fs_mount_t *mp)
 
 	/* remove mount node from the list */
 	sys_dlist_remove(&mp->node);
-	LOG_DBG("fs unmounted from %s", log_strdup(mp->mnt_point));
+	LOG_DBG("fs unmounted from %s", mp->mnt_point);
 
 unmount_err:
 	k_mutex_unlock(&mutex);

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -640,7 +640,7 @@ static int littlefs_flash_init(struct fs_mount_t *mountp)
 	dev = flash_area_get_device(*fap);
 	if (dev == NULL) {
 		LOG_ERR("can't get flash device: %s",
-			log_strdup((*fap)->fa_dev_name));
+			(*fap)->fa_dev_name);
 		return -ENODEV;
 	}
 
@@ -770,7 +770,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 		const struct device *dev =
 			flash_area_get_device((struct flash_area *)fs->backend);
 		LOG_INF("FS at %s:0x%x is %u 0x%x-byte blocks with %u cycle",
-			log_strdup(dev->name),
+			dev->name,
 			(uint32_t)((struct flash_area *)fs->backend)->fa_off,
 			block_count, block_size, block_cycles);
 		LOG_INF("sizes: rd %u ; pr %u ; ca %u ; la %u",
@@ -848,7 +848,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 		}
 	}
 
-	LOG_INF("%s mounted", log_strdup(mountp->mnt_point));
+	LOG_INF("%s mounted", mountp->mnt_point);
 
 out:
 	if (ret < 0) {
@@ -875,7 +875,7 @@ static int littlefs_unmount(struct fs_mount_t *mountp)
 	fs->backend = NULL;
 	fs_unlock(fs);
 
-	LOG_INF("%s unmounted", log_strdup(mountp->mnt_point));
+	LOG_INF("%s unmounted", mountp->mnt_point);
 
 	return 0;
 }

--- a/subsys/ipc/rpmsg_service/rpmsg_service.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_service.c
@@ -61,7 +61,7 @@ static void ns_bind_cb(struct rpmsg_device *rdev,
 
 			if (err != 0) {
 				LOG_ERR("Creating remote endpoint %s"
-					" failed wirh error %d", log_strdup(name), err);
+					" failed wirh error %d", name, err);
 			} else {
 				endpoints[i].bound = true;
 			}
@@ -70,7 +70,7 @@ static void ns_bind_cb(struct rpmsg_device *rdev,
 		}
 	}
 
-	LOG_ERR("Remote endpoint %s not registered locally", log_strdup(name));
+	LOG_ERR("Remote endpoint %s not registered locally", name);
 }
 
 #endif
@@ -146,7 +146,7 @@ int rpmsg_service_register_endpoint(const char *name, rpmsg_ept_cb cb)
 		}
 	}
 
-	LOG_ERR("No free slots to register endpoint %s", log_strdup(name));
+	LOG_ERR("No free slots to register endpoint %s", name);
 
 	return -ENOMEM;
 }

--- a/subsys/lorawan/nvm/lorawan_nvm_settings.c
+++ b/subsys/lorawan/nvm/lorawan_nvm_settings.c
@@ -94,19 +94,19 @@ static int load_setting(void *tgt, size_t tgt_size,
 {
 	if (len != tgt_size) {
 		LOG_ERR("Can't load '%s' state, size mismatch.",
-			log_strdup(key));
+			key);
 		return -EINVAL;
 	}
 
 	if (!tgt) {
 		LOG_ERR("Can't load '%s' state, no target.",
-			log_strdup(key));
+			key);
 		return -EINVAL;
 	}
 
 	if (read_cb(cb_arg, tgt, len) != len) {
 		LOG_ERR("Can't load '%s' state, short read.",
-			log_strdup(key));
+			key);
 		return -EINVAL;
 	}
 
@@ -120,7 +120,7 @@ static int on_setting_loaded(const char *key, size_t len,
 	int err;
 	LoRaMacNvmData_t *nvm = param;
 
-	LOG_DBG("Key: %s", log_strdup(key));
+	LOG_DBG("Key: %s", key);
 
 	for (uint32_t i = 0; i < ARRAY_SIZE(nvm_setting_descriptors); i++) {
 		const struct lorawan_nvm_setting_descr *descr =
@@ -136,7 +136,7 @@ static int on_setting_loaded(const char *key, size_t len,
 		}
 	}
 
-	LOG_WRN("Unknown LoRaWAN setting: %s", log_strdup(key));
+	LOG_WRN("Unknown LoRaWAN setting: %s", key);
 	return 0;
 }
 

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -354,7 +354,7 @@ static void hawkbit_update_sleep(struct hawkbit_ctl_res *hawkbit_res)
 	const char *sleep = hawkbit_res->config.polling.sleep;
 
 	if (strlen(sleep) != HAWKBIT_SLEEP_LENGTH) {
-		LOG_ERR("Invalid poll sleep: %s", log_strdup(sleep));
+		LOG_ERR("Invalid poll sleep: %s", sleep);
 	} else {
 		sleep_time = hawkbit_time2sec(sleep);
 		if (sleep_time > 0 && poll_sleep != (MSEC_PER_SEC * sleep_time)) {
@@ -382,14 +382,14 @@ static int hawkbit_find_cancelAction_base(struct hawkbit_ctl_res *res, char *can
 	helper = strstr(href, "cancelAction/");
 	if (!helper) {
 		/* A badly formatted cancel base is a server error */
-		LOG_ERR("Missing cancelBase/ in href %s", log_strdup(href));
+		LOG_ERR("Missing cancelBase/ in href %s", href);
 		return -EINVAL;
 	}
 
 	len = strlen(helper);
 	if (len > CANCEL_BASE_SIZE - 1) {
 		/* Lack of memory is an application error */
-		LOG_ERR("cancelBase %s is too big (len %zu, max %zu)", log_strdup(helper), len,
+		LOG_ERR("cancelBase %s is too big (len %zu, max %zu)", helper, len,
 			CANCEL_BASE_SIZE - 1);
 		return -ENOMEM;
 	}
@@ -434,14 +434,14 @@ static int hawkbit_find_deployment_base(struct hawkbit_ctl_res *res, char *deplo
 	helper = strstr(href, "deploymentBase/");
 	if (!helper) {
 		/* A badly formatted deployment base is a server error */
-		LOG_ERR("Missing deploymentBase/ in href %s", log_strdup(href));
+		LOG_ERR("Missing deploymentBase/ in href %s", href);
 		return -EINVAL;
 	}
 
 	len = strlen(helper);
 	if (len > DEPLOYMENT_BASE_SIZE - 1) {
 		/* Lack of memory is an application error */
-		LOG_ERR("deploymentBase %s is too big (len %zu, max %zu)", log_strdup(helper), len,
+		LOG_ERR("deploymentBase %s is too big (len %zu, max %zu)", helper, len,
 			DEPLOYMENT_BASE_SIZE - 1);
 		return -ENOMEM;
 	}
@@ -481,7 +481,7 @@ static int hawkbit_parse_deployment(struct hawkbit_dep_res *res, int32_t *json_a
 
 	chunk = &res->deployment.chunks[0];
 	if (strcmp("bApp", chunk->part)) {
-		LOG_ERR("Only part 'bApp' is supported; got %s", log_strdup(chunk->part));
+		LOG_ERR("Only part 'bApp' is supported; got %s", chunk->part);
 		return -EINVAL;
 	}
 
@@ -516,7 +516,7 @@ static int hawkbit_parse_deployment(struct hawkbit_dep_res *res, int32_t *json_a
 
 	helper = strstr(href, "/DEFAULT/controller/v1");
 	if (!helper) {
-		LOG_ERR("Unexpected download-http href format: %s", log_strdup(helper));
+		LOG_ERR("Unexpected download-http href format: %s", helper);
 		return -EINVAL;
 	}
 
@@ -525,7 +525,7 @@ static int hawkbit_parse_deployment(struct hawkbit_dep_res *res, int32_t *json_a
 		LOG_ERR("Empty download-http");
 		return -EINVAL;
 	} else if (len > DOWNLOAD_HTTP_SIZE - 1) {
-		LOG_ERR("download-http %s is too big (len: %zu, max: %zu)", log_strdup(helper), len,
+		LOG_ERR("download-http %s is too big (len: %zu, max: %zu)", helper, len,
 			DOWNLOAD_HTTP_SIZE - 1);
 		return -ENOMEM;
 	}
@@ -538,10 +538,10 @@ static int hawkbit_parse_deployment(struct hawkbit_dep_res *res, int32_t *json_a
 
 static void hawkbit_dump_base(struct hawkbit_ctl_res *r)
 {
-	LOG_DBG("config.polling.sleep=%s", log_strdup(r->config.polling.sleep));
-	LOG_DBG("_links.deploymentBase.href=%s", log_strdup(r->_links.deploymentBase.href));
-	LOG_DBG("_links.configData.href=%s", log_strdup(r->_links.configData.href));
-	LOG_DBG("_links.cancelAction.href=%s", log_strdup(r->_links.cancelAction.href));
+	LOG_DBG("config.polling.sleep=%s", r->config.polling.sleep);
+	LOG_DBG("_links.deploymentBase.href=%s", r->_links.deploymentBase.href);
+	LOG_DBG("_links.configData.href=%s", r->_links.configData.href);
+	LOG_DBG("_links.cancelAction.href=%s", r->_links.cancelAction.href);
 }
 
 static void hawkbit_dump_deployment(struct hawkbit_dep_res *d)
@@ -550,19 +550,19 @@ static void hawkbit_dump_deployment(struct hawkbit_dep_res *d)
 	struct hawkbit_dep_res_arts *a = &c->artifacts[0];
 	struct hawkbit_dep_res_links *l = &a->_links;
 
-	LOG_DBG("id=%s", log_strdup(d->id));
-	LOG_DBG("download=%s", log_strdup(d->deployment.download));
-	LOG_DBG("update=%s", log_strdup(d->deployment.update));
-	LOG_DBG("chunks[0].part=%s", log_strdup(c->part));
-	LOG_DBG("chunks[0].name=%s", log_strdup(c->name));
-	LOG_DBG("chunks[0].version=%s", log_strdup(c->version));
-	LOG_DBG("chunks[0].artifacts[0].filename=%s", log_strdup(a->filename));
-	LOG_DBG("chunks[0].artifacts[0].hashes.sha1=%s", log_strdup(a->hashes.sha1));
-	LOG_DBG("chunks[0].artifacts[0].hashes.md5=%s", log_strdup(a->hashes.md5));
-	LOG_DBG("chunks[0].artifacts[0].hashes.sha256=%s", log_strdup(a->hashes.sha256));
+	LOG_DBG("id=%s", d->id);
+	LOG_DBG("download=%s", d->deployment.download);
+	LOG_DBG("update=%s", d->deployment.update);
+	LOG_DBG("chunks[0].part=%s", c->part);
+	LOG_DBG("chunks[0].name=%s", c->name);
+	LOG_DBG("chunks[0].version=%s", c->version);
+	LOG_DBG("chunks[0].artifacts[0].filename=%s", a->filename);
+	LOG_DBG("chunks[0].artifacts[0].hashes.sha1=%s", a->hashes.sha1);
+	LOG_DBG("chunks[0].artifacts[0].hashes.md5=%s", a->hashes.md5);
+	LOG_DBG("chunks[0].artifacts[0].hashes.sha256=%s", a->hashes.sha256);
 	LOG_DBG("chunks[0].size=%d", a->size);
-	LOG_DBG("download-http=%s", log_strdup(l->download_http.href));
-	LOG_DBG("md5sum =%s", log_strdup(l->md5sum_http.href));
+	LOG_DBG("download-http=%s", l->download_http.href);
+	LOG_DBG("md5sum =%s", l->md5sum_http.href);
 }
 
 int hawkbit_init(void)

--- a/subsys/mgmt/updatehub/updatehub.c
+++ b/subsys/mgmt/updatehub/updatehub.c
@@ -878,7 +878,7 @@ enum updatehub_response updatehub_probe(void)
 		       SHA256_HEX_DIGEST_SIZE);
 		update_info.image_size = metadata_any_boards.objects[1].objects.size;
 		LOG_DBG("metadata_any: %s",
-			log_strdup(update_info.sha256sum_image));
+			update_info.sha256sum_image);
 	} else {
 		if (metadata_some_boards.objects_len != 2) {
 			LOG_ERR("Could not parse json");
@@ -908,7 +908,7 @@ enum updatehub_response updatehub_probe(void)
 		update_info.image_size =
 			metadata_some_boards.objects[1].objects.size;
 		LOG_DBG("metadata_some: %s",
-			log_strdup(update_info.sha256sum_image));
+			update_info.sha256sum_image);
 	}
 
 	ctx.code_status = UPDATEHUB_HAS_UPDATE;

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -519,7 +519,7 @@ int modbus_serial_init(struct modbus_context *ctx,
 	cfg->dev = device_get_binding(cfg->dev_name);
 	if (cfg->dev == NULL) {
 		LOG_ERR("Failed to get UART device %s",
-			log_strdup(cfg->dev_name));
+			cfg->dev_name);
 		return -ENODEV;
 	}
 

--- a/subsys/net/hostname.c
+++ b/subsys/net/hostname.c
@@ -52,7 +52,7 @@ int net_hostname_set_postfix(const uint8_t *hostname_postfix,
 			 2 + 1, "%02x", hostname_postfix[i]);
 	}
 
-	NET_DBG("New hostname %s", log_strdup(hostname));
+	NET_DBG("New hostname %s", hostname);
 
 #if !defined(CONFIG_NET_HOSTNAME_UNIQUE_UPDATE)
 	postfix_set = true;

--- a/subsys/net/ip/connection.c
+++ b/subsys/net/ip/connection.c
@@ -71,13 +71,11 @@ void conn_register_debug(struct net_conn *conn,
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    conn->family == AF_INET6) {
 			snprintk(dst, sizeof(dst), "%s",
-				 log_strdup(net_sprint_ipv6_addr(
-				    &net_sin6(&conn->remote_addr)->sin6_addr)));
+				 net_sprint_ipv6_addr(&net_sin6(&conn->remote_addr)->sin6_addr));
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 			   conn->family == AF_INET) {
 			snprintk(dst, sizeof(dst), "%s",
-				 log_strdup(net_sprint_ipv4_addr(
-				    &net_sin(&conn->remote_addr)->sin_addr)));
+				 net_sprint_ipv4_addr(&net_sin(&conn->remote_addr)->sin_addr));
 		} else {
 			snprintk(dst, sizeof(dst), "%s", "?");
 		}
@@ -89,13 +87,11 @@ void conn_register_debug(struct net_conn *conn,
 		if (IS_ENABLED(CONFIG_NET_IPV6) &&
 		    conn->family == AF_INET6) {
 			snprintk(src, sizeof(src), "%s",
-				 log_strdup(net_sprint_ipv6_addr(
-				    &net_sin6(&conn->local_addr)->sin6_addr)));
+				 net_sprint_ipv6_addr(&net_sin6(&conn->local_addr)->sin6_addr));
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 			   conn->family == AF_INET) {
 			snprintk(src, sizeof(src), "%s",
-				 log_strdup(net_sprint_ipv4_addr(
-				    &net_sin(&conn->local_addr)->sin_addr)));
+				 net_sprint_ipv4_addr(&net_sin(&conn->local_addr)->sin_addr));
 		} else {
 			snprintk(src, sizeof(src), "%s", "?");
 		}
@@ -105,9 +101,9 @@ void conn_register_debug(struct net_conn *conn,
 
 	NET_DBG("[%p/%d/%u/0x%02x] remote %s/%u ",
 		conn, conn->proto, conn->family, conn->flags,
-		log_strdup(dst), remote_port);
+		dst, remote_port);
 	NET_DBG("  local %s/%u cb %p ud %p",
-		log_strdup(src), local_port, conn->cb, conn->user_data);
+		src, local_port, conn->cb, conn->user_data);
 }
 #else
 #define conn_register_debug(...)

--- a/subsys/net/ip/dhcpv4.c
+++ b/subsys/net/ip/dhcpv4.c
@@ -390,10 +390,10 @@ static uint32_t dhcpv4_send_request(struct net_if *iface)
 	}
 
 	NET_DBG("send request dst=%s xid=0x%x ciaddr=%s%s%s timeout=%us",
-		log_strdup(net_sprint_ipv4_addr(server_addr)),
+		net_sprint_ipv4_addr(server_addr),
 		iface->config.dhcpv4.xid,
 		ciaddr ?
-		log_strdup(net_sprint_ipv4_addr(ciaddr)) : "<unknown>",
+		net_sprint_ipv4_addr(ciaddr) : "<unknown>",
 		with_server_id ? " +server-id" : "",
 		with_requested_ip ? " +requested-ip" : "",
 		timeout);
@@ -703,7 +703,7 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 
 			net_if_ipv4_set_netmask(iface, &netmask);
 			NET_DBG("options_subnet_mask %s",
-				log_strdup(net_sprint_ipv4_addr(&netmask)));
+				net_sprint_ipv4_addr(&netmask));
 			break;
 		}
 		case DHCPV4_OPTIONS_ROUTER: {
@@ -727,7 +727,7 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 			}
 
 			NET_DBG("options_router: %s",
-				log_strdup(net_sprint_ipv4_addr(&router)));
+				net_sprint_ipv4_addr(&router));
 			net_if_ipv4_set_gw(iface, &router);
 			router_present = true;
 
@@ -840,8 +840,7 @@ static bool dhcpv4_parse_options(struct net_pkt *pkt,
 			}
 
 			NET_DBG("options_server_id: %s",
-				log_strdup(net_sprint_ipv4_addr(
-					   &iface->config.dhcpv4.server_id)));
+				net_sprint_ipv4_addr(&iface->config.dhcpv4.server_id));
 			break;
 		case DHCPV4_OPTIONS_MSG_TYPE: {
 			if (length != 1U) {
@@ -913,8 +912,7 @@ static void dhcpv4_handle_msg_ack(struct net_if *iface)
 		break;
 	case NET_DHCPV4_REQUESTING:
 		NET_INFO("Received: %s",
-			 log_strdup(net_sprint_ipv4_addr(
-					 &iface->config.dhcpv4.requested_ip)));
+			 net_sprint_ipv4_addr(&iface->config.dhcpv4.requested_ip));
 
 		if (!net_if_ipv4_addr_add(iface,
 					  &iface->config.dhcpv4.requested_ip,
@@ -1030,7 +1028,7 @@ static enum net_verdict net_dhcpv4_input(struct net_conn *conn,
 		"secs=%u flags=0x%x chaddr=%s",
 		msg->op, msg->htype, msg->hlen, ntohl(msg->xid),
 		msg->secs, msg->flags,
-		log_strdup(net_sprint_ll_addr(msg->chaddr, 6)));
+		net_sprint_ll_addr(msg->chaddr, 6));
 	NET_DBG("  ciaddr=%d.%d.%d.%d",
 		msg->ciaddr[0], msg->ciaddr[1], msg->ciaddr[2], msg->ciaddr[3]);
 	NET_DBG("  yiaddr=%d.%d.%d.%d",

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -424,8 +424,8 @@ static enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt,
 	}
 
 	NET_DBG("Received Echo Request from %s to %s",
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->src)),
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->dst)));
+		net_sprint_ipv4_addr(&ip_hdr->src),
+		net_sprint_ipv4_addr(&ip_hdr->dst));
 
 	payload_len = net_pkt_get_len(pkt) -
 		      net_pkt_ip_hdr_len(pkt) -
@@ -474,8 +474,8 @@ static enum net_verdict icmpv4_handle_echo_request(struct net_pkt *pkt,
 	net_ipv4_finalize(reply, IPPROTO_ICMP);
 
 	NET_DBG("Sending Echo Reply from %s to %s",
-		log_strdup(net_sprint_ipv4_addr(src)),
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->src)));
+		net_sprint_ipv4_addr(src),
+		net_sprint_ipv4_addr(&ip_hdr->src));
 
 	if (net_send_data(reply) < 0) {
 		goto drop;
@@ -553,8 +553,8 @@ int net_icmpv4_send_echo_request(struct net_if *iface,
 
 	NET_DBG("Sending ICMPv4 Echo Request type %d from %s to %s",
 		NET_ICMPV4_ECHO_REQUEST,
-		log_strdup(net_sprint_ipv4_addr(src)),
-		log_strdup(net_sprint_ipv4_addr(dst)));
+		net_sprint_ipv4_addr(src),
+		net_sprint_ipv4_addr(dst));
 
 	if (net_send_data(pkt) >= 0) {
 		net_stats_update_icmp_sent(iface);
@@ -606,7 +606,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		 * were sent to broadcast
 		 */
 		NET_DBG("Not sending error to bcast pkt from %s on proto %s",
-			log_strdup(net_sprint_ipv4_addr(&ip_hdr->src)),
+			net_sprint_ipv4_addr(&ip_hdr->src),
 			net_proto2str(AF_INET, ip_hdr->proto));
 		goto drop_no_pkt;
 	}
@@ -646,8 +646,8 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 
 	NET_DBG("Sending ICMPv4 Error Message type %d code %d from %s to %s",
 		type, code,
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->dst)),
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->src)));
+		net_sprint_ipv4_addr(&ip_hdr->dst),
+		net_sprint_ipv4_addr(&ip_hdr->src));
 
 	if (net_send_data(pkt) >= 0) {
 		net_stats_update_icmp_sent(net_pkt_iface(orig));

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -114,8 +114,8 @@ enum net_verdict icmpv6_handle_echo_request(struct net_pkt *pkt,
 	ARG_UNUSED(icmp_hdr);
 
 	NET_DBG("Received Echo Request from %s to %s",
-		log_strdup(net_sprint_ipv6_addr(&ip_hdr->src)),
-		log_strdup(net_sprint_ipv6_addr(&ip_hdr->dst)));
+		net_sprint_ipv6_addr(&ip_hdr->src),
+		net_sprint_ipv6_addr(&ip_hdr->dst));
 
 	payload_len = ntohs(ip_hdr->len) -
 		net_pkt_ipv6_ext_len(pkt) - NET_ICMPH_LEN;
@@ -161,8 +161,8 @@ enum net_verdict icmpv6_handle_echo_request(struct net_pkt *pkt,
 	net_ipv6_finalize(reply, IPPROTO_ICMPV6);
 
 	NET_DBG("Sending Echo Reply from %s to %s",
-		log_strdup(net_sprint_ipv6_addr(src)),
-		log_strdup(net_sprint_ipv6_addr(&ip_hdr->src)));
+		net_sprint_ipv6_addr(src),
+		net_sprint_ipv6_addr(&ip_hdr->src));
 
 	if (net_send_data(reply) < 0) {
 		goto drop;
@@ -313,8 +313,8 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 
 	NET_DBG("Sending ICMPv6 Error Message type %d code %d param %d"
 		" from %s to %s", type, code, param,
-		log_strdup(net_sprint_ipv6_addr(src)),
-		log_strdup(net_sprint_ipv6_addr(&ip_hdr->src)));
+		net_sprint_ipv6_addr(src),
+		net_sprint_ipv6_addr(&ip_hdr->src));
 
 	if (net_send_data(pkt) >= 0) {
 		net_stats_update_icmp_sent(net_pkt_iface(pkt));
@@ -377,8 +377,8 @@ int net_icmpv6_send_echo_request(struct net_if *iface,
 
 	NET_DBG("Sending ICMPv6 Echo Request type %d from %s to %s",
 		NET_ICMPV6_ECHO_REQUEST,
-		log_strdup(net_sprint_ipv6_addr(src)),
-		log_strdup(net_sprint_ipv6_addr(dst)));
+		net_sprint_ipv6_addr(src),
+		net_sprint_ipv6_addr(dst));
 
 	if (net_send_data(pkt) >= 0) {
 		net_stats_update_icmp_sent(iface);

--- a/subsys/net/ip/igmp.c
+++ b/subsys/net/ip/igmp.c
@@ -33,8 +33,8 @@ static const struct in_addr all_routers = { { { 224, 0, 0, 2 } } };
 
 #define dbg_addr(action, pkt_str, src, dst)				\
 	NET_DBG("%s %s from %s to %s", action, pkt_str,			\
-		log_strdup(net_sprint_ipv4_addr(src)),			\
-		log_strdup(net_sprint_ipv4_addr(dst)));
+		net_sprint_ipv4_addr(src),			\
+		net_sprint_ipv4_addr(dst));
 
 #define dbg_addr_recv(pkt_str, src, dst) \
 	dbg_addr("Received", pkt_str, src, dst)

--- a/subsys/net/ip/ipv4.c
+++ b/subsys/net/ip/ipv4.c
@@ -319,8 +319,8 @@ enum net_verdict net_ipv4_input(struct net_pkt *pkt)
 	net_pkt_set_family(pkt, PF_INET);
 
 	NET_DBG("IPv4 packet received from %s to %s",
-		log_strdup(net_sprint_ipv4_addr(&hdr->src)),
-		log_strdup(net_sprint_ipv4_addr(&hdr->dst)));
+		net_sprint_ipv4_addr(&hdr->src),
+		net_sprint_ipv4_addr(&hdr->dst));
 
 	switch (hdr->proto) {
 	case IPPROTO_ICMP:

--- a/subsys/net/ip/ipv4_autoconf.c
+++ b/subsys/net/ip/ipv4_autoconf.c
@@ -125,9 +125,9 @@ enum net_verdict net_ipv4_autoconf_input(struct net_if *iface,
 	}
 
 	NET_DBG("Conflict detected from %s for %s, state %d",
-		log_strdup(net_sprint_ll_addr((uint8_t *)&arp_hdr->src_hwaddr,
-					      arp_hdr->hwlen)),
-		log_strdup(net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr)),
+		net_sprint_ll_addr((uint8_t *)&arp_hdr->src_hwaddr,
+					      arp_hdr->hwlen),
+		net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr),
 		cfg->ipv4auto.state);
 
 	cfg->ipv4auto.conflict_cnt++;

--- a/subsys/net/ip/ipv6.c
+++ b/subsys/net/ip/ipv6.c
@@ -267,7 +267,7 @@ static struct net_route_entry *add_route(struct net_if *iface,
 			      NET_ROUTE_PREFERENCE_LOW);
 
 	NET_DBG("%s route to %s/%d iface %p", route ? "Add" : "Cannot add",
-		log_strdup(net_sprint_ipv6_addr(addr)), prefix_len, iface);
+		net_sprint_ipv6_addr(addr), prefix_len, iface);
 
 	return route;
 }
@@ -278,8 +278,8 @@ static void ipv6_no_route_info(struct net_pkt *pkt,
 			       struct in6_addr *dst)
 {
 	NET_DBG("Will not route pkt %p ll src %s to dst %s between interfaces",
-		pkt, log_strdup(net_sprint_ipv6_addr(src)),
-		log_strdup(net_sprint_ipv6_addr(dst)));
+		pkt, net_sprint_ipv6_addr(src),
+		net_sprint_ipv6_addr(dst));
 }
 
 #if defined(CONFIG_NET_ROUTE)
@@ -339,7 +339,7 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 		if (ret < 0) {
 			NET_DBG("Cannot re-route pkt %p via %s "
 				"at iface %p (%d)",
-				pkt, log_strdup(net_sprint_ipv6_addr(nexthop)),
+				pkt, net_sprint_ipv6_addr(nexthop),
 				net_pkt_iface(pkt), ret);
 		} else {
 			return NET_OK;
@@ -360,7 +360,7 @@ static enum net_verdict ipv6_route_packet(struct net_pkt *pkt,
 		}
 
 		NET_DBG("No route to %s pkt %p dropped",
-			log_strdup(net_sprint_ipv6_addr(&hdr->dst)), pkt);
+			net_sprint_ipv6_addr(&hdr->dst), pkt);
 	}
 
 drop:
@@ -466,8 +466,8 @@ enum net_verdict net_ipv6_input(struct net_pkt *pkt, bool is_loopback)
 	}
 
 	NET_DBG("IPv6 packet len %d received from %s to %s", pkt_len,
-		log_strdup(net_sprint_ipv6_addr(&hdr->src)),
-		log_strdup(net_sprint_ipv6_addr(&hdr->dst)));
+		net_sprint_ipv6_addr(&hdr->src),
+		net_sprint_ipv6_addr(&hdr->dst));
 
 	if (net_ipv6_is_addr_unspecified((struct in6_addr *)hdr->src)) {
 		NET_DBG("DROP: src addr is %s", "unspecified");

--- a/subsys/net/ip/ipv6_fragment.c
+++ b/subsys/net/ip/ipv6_fragment.c
@@ -205,8 +205,8 @@ static bool reassembly_cancel(uint32_t id,
 static void reassembly_info(char *str, struct net_ipv6_reassembly *reass)
 {
 	NET_DBG("%s id 0x%x src %s dst %s remain %d ms", str, reass->id,
-		log_strdup(net_sprint_ipv6_addr(&reass->src)),
-		log_strdup(net_sprint_ipv6_addr(&reass->dst)),
+		net_sprint_ipv6_addr(&reass->src),
+		net_sprint_ipv6_addr(&reass->dst),
 		k_ticks_to_ms_ceil32(
 			k_work_delayable_remaining_get(&reass->timer)));
 }

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -289,8 +289,8 @@ drop:
 #define dbg_addr(action, pkt_str, src, dst)				\
 	do {								\
 		NET_DBG("%s %s from %s to %s", action, pkt_str,         \
-			log_strdup(net_sprint_ipv6_addr(src)),		\
-			log_strdup(net_sprint_ipv6_addr(dst)));		\
+			net_sprint_ipv6_addr(src),		\
+			net_sprint_ipv6_addr(dst));		\
 	} while (0)
 
 #define dbg_addr_recv(pkt_str, src, dst)	\

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -244,11 +244,10 @@ void nbr_print(void)
 			net_ipv6_nbr_data(nbr)->pending,
 			nbr->iface, nbr->idx,
 			nbr->idx == NET_NBR_LLADDR_UNKNOWN ? "?" :
-			log_strdup(net_sprint_ll_addr(
+			net_sprint_ll_addr(
 				net_nbr_get_lladdr(nbr->idx)->addr,
-				net_nbr_get_lladdr(nbr->idx)->len)),
-			log_strdup(net_sprint_ipv6_addr(
-					   &net_ipv6_nbr_data(nbr)->addr)));
+				net_nbr_get_lladdr(nbr->idx)->len),
+			net_sprint_ipv6_addr(&net_ipv6_nbr_data(nbr)->addr));
 	}
 }
 #else
@@ -385,8 +384,7 @@ static void ipv6_ns_reply_timeout(struct k_work *work)
 
 		NET_DBG("NS nbr %p pending %p timeout to %s", nbr,
 			data->pending,
-			log_strdup(net_sprint_ipv6_addr(
-					 &NET_IPV6_HDR(data->pending)->dst)));
+			net_sprint_ipv6_addr(&NET_IPV6_HDR(data->pending)->dst));
 
 		/* To unref when pending variable was set */
 		net_pkt_unref(data->pending);
@@ -433,7 +431,7 @@ static struct net_nbr *nbr_new(struct net_if *iface,
 
 	NET_DBG("nbr %p iface %p/%d state %d IPv6 %s",
 		nbr, iface, net_if_get_by_iface(iface), state,
-		log_strdup(net_sprint_ipv6_addr(addr)));
+		net_sprint_ipv6_addr(addr));
 
 	return nbr;
 }
@@ -448,10 +446,9 @@ static void dbg_update_neighbor_lladdr(const struct net_linkaddr *new_lladdr,
 		 net_sprint_ll_addr(old_lladdr->addr, old_lladdr->len));
 
 	NET_DBG("Updating neighbor %s lladdr %s (was %s)",
-		log_strdup(net_sprint_ipv6_addr(addr)),
-		log_strdup(net_sprint_ll_addr(new_lladdr->addr,
-					      new_lladdr->len)),
-		log_strdup(out));
+		net_sprint_ipv6_addr(addr),
+		net_sprint_ll_addr(new_lladdr->addr, new_lladdr->len),
+		out);
 }
 
 static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
@@ -470,8 +467,8 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 	do {								\
 		NET_DBG("%s %s from %s to %s iface %p/%d",		\
 			action, pkt_str,				\
-			log_strdup(net_sprint_ipv6_addr(src)),		\
-			log_strdup(net_sprint_ipv6_addr(dst)),		\
+			net_sprint_ipv6_addr(src),		\
+			net_sprint_ipv6_addr(dst),		\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
 	} while (0)
@@ -487,9 +484,9 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 		NET_DBG("%s %s from %s to %s, target %s iface %p/%d",	\
 			action,						\
 			pkt_str,                                        \
-			log_strdup(net_sprint_ipv6_addr(src)),		\
-			log_strdup(net_sprint_ipv6_addr(dst)),		\
-			log_strdup(net_sprint_ipv6_addr(target)),	\
+			net_sprint_ipv6_addr(src),		\
+			net_sprint_ipv6_addr(dst),		\
+			net_sprint_ipv6_addr(target),	\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
 	} while (0)
@@ -594,9 +591,8 @@ struct net_nbr *net_ipv6_nbr_add(struct net_if *iface,
 	nbr = add_nbr(iface, addr, is_router, state);
 	if (!nbr) {
 		NET_ERR("Could not add router neighbor %s [%s]",
-			log_strdup(net_sprint_ipv6_addr(addr)),
-			log_strdup(net_sprint_ll_addr(lladdr->addr,
-						      lladdr->len)));
+			net_sprint_ipv6_addr(addr),
+			net_sprint_ll_addr(lladdr->addr, lladdr->len));
 		return NULL;
 	}
 
@@ -632,8 +628,8 @@ struct net_nbr *net_ipv6_nbr_add(struct net_if *iface,
 
 	NET_DBG("[%d] nbr %p state %d router %d IPv6 %s ll %s iface %p/%d",
 		nbr->idx, nbr, state, is_router,
-		log_strdup(net_sprint_ipv6_addr(addr)),
-		log_strdup(net_sprint_ll_addr(lladdr->addr, lladdr->len)),
+		net_sprint_ipv6_addr(addr),
+		net_sprint_ll_addr(lladdr->addr, lladdr->len),
 		nbr->iface, net_if_get_by_iface(nbr->iface));
 
 #if defined(CONFIG_NET_MGMT_EVENT_INFO)
@@ -730,7 +726,7 @@ static struct in6_addr *check_route(struct net_if *iface,
 
 		NET_DBG("Route %p nexthop %s iface %p/%d",
 			route,
-			nexthop ? log_strdup(net_sprint_ipv6_addr(nexthop)) :
+			nexthop ? net_sprint_ipv6_addr(nexthop) :
 			"<unknown>",
 			iface, net_if_get_by_iface(iface));
 
@@ -738,7 +734,7 @@ static struct in6_addr *check_route(struct net_if *iface,
 			net_route_del(route);
 
 			NET_DBG("No route to host %s",
-				log_strdup(net_sprint_ipv6_addr(dst)));
+				net_sprint_ipv6_addr(dst));
 
 			return NULL;
 		}
@@ -749,7 +745,7 @@ static struct in6_addr *check_route(struct net_if *iface,
 		router = net_if_ipv6_router_find_default(NULL, dst);
 		if (!router) {
 			NET_DBG("No default route to %s",
-				log_strdup(net_sprint_ipv6_addr(dst)));
+				net_sprint_ipv6_addr(dst));
 
 			/* Try to send the packet anyway */
 			nexthop = dst;
@@ -763,7 +759,7 @@ static struct in6_addr *check_route(struct net_if *iface,
 		nexthop = &router->address.in6_addr;
 
 		NET_DBG("Router %p nexthop %s", router,
-			log_strdup(net_sprint_ipv6_addr(nexthop)));
+			net_sprint_ipv6_addr(nexthop));
 	}
 
 	return nexthop;
@@ -904,7 +900,7 @@ try_send:
 	NET_DBG("Neighbor lookup %p (%d) iface %p/%d addr %s state %s", nbr,
 		nbr ? nbr->idx : NET_NBR_LLADDR_UNKNOWN,
 		iface, net_if_get_by_iface(iface),
-		log_strdup(net_sprint_ipv6_addr(nexthop)),
+		net_sprint_ipv6_addr(nexthop),
 		nbr ? net_ipv6_nbr_state2str(net_ipv6_nbr_data(nbr)->state) :
 		"-");
 
@@ -917,8 +913,7 @@ try_send:
 		net_pkt_lladdr_dst(pkt)->len = lladdr->len;
 
 		NET_DBG("Neighbor %p addr %s", nbr,
-			log_strdup(net_sprint_ll_addr(lladdr->addr,
-						      lladdr->len)));
+			net_sprint_ll_addr(lladdr->addr, lladdr->len));
 
 		/* Start the NUD if we are in STALE state.
 		 * See RFC 4861 ch 7.3.3 for details.
@@ -1131,13 +1126,13 @@ static void ns_routing_info(struct net_pkt *pkt,
 
 		if (net_ipv6_addr_cmp(nexthop, tgt)) {
 			NET_DBG("Routing to %s iface %p/%d",
-				log_strdup(out),
+				out,
 				net_pkt_iface(pkt),
 				net_if_get_by_iface(net_pkt_iface(pkt)));
 		} else {
 			NET_DBG("Routing to %s via %s iface %p/%d",
-				log_strdup(net_sprint_ipv6_addr(tgt)),
-				log_strdup(out),
+				net_sprint_ipv6_addr(tgt),
+				out,
 				net_pkt_iface(pkt),
 				net_if_get_by_iface(net_pkt_iface(pkt)));
 		}
@@ -1270,9 +1265,7 @@ static enum net_verdict handle_ns_input(struct net_pkt *pkt,
 				if (!na_src) {
 					NET_DBG("DROP: No interface address "
 						"for dst %s iface %p/%d",
-						log_strdup(
-						  net_sprint_ipv6_addr(
-							  &ip_hdr->src)),
+						net_sprint_ipv6_addr(&ip_hdr->src),
 						net_pkt_iface(pkt),
 						net_if_get_by_iface(
 							net_pkt_iface(pkt)));
@@ -1285,7 +1278,7 @@ static enum net_verdict handle_ns_input(struct net_pkt *pkt,
 		}
 
 		NET_DBG("DROP: No such interface address %s",
-			log_strdup(net_sprint_ipv6_addr(&ns_hdr->tgt)));
+			net_sprint_ipv6_addr(&ns_hdr->tgt));
 		goto drop;
 	} else {
 		tgt = &ifaddr->address.in6_addr;
@@ -1306,14 +1299,13 @@ nexthop_found:
 
 		if (!net_ipv6_is_addr_solicited_node((struct in6_addr *)ip_hdr->dst)) {
 			NET_DBG("DROP: Not solicited node addr %s",
-				log_strdup(net_sprint_ipv6_addr(&ip_hdr->dst)));
+				net_sprint_ipv6_addr(&ip_hdr->dst));
 			goto drop;
 		}
 
 		if (ifaddr->addr_state == NET_ADDR_TENTATIVE) {
 			NET_DBG("DROP: DAD failed for %s iface %p/%d",
-				log_strdup(net_sprint_ipv6_addr(
-						   &ifaddr->address.in6_addr)),
+				net_sprint_ipv6_addr(&ifaddr->address.in6_addr),
 				net_pkt_iface(pkt),
 				net_if_get_by_iface(net_pkt_iface(pkt)));
 
@@ -1339,7 +1331,7 @@ nexthop_found:
 
 	if (net_ipv6_is_my_addr((struct in6_addr *)ip_hdr->src)) {
 		NET_DBG("DROP: Duplicate IPv6 %s address",
-			log_strdup(net_sprint_ipv6_addr(&ip_hdr->src)));
+			net_sprint_ipv6_addr(&ip_hdr->src));
 		goto drop;
 	}
 
@@ -1484,14 +1476,14 @@ static void ipv6_nd_reachable_timeout(struct k_work *work)
 
 			NET_DBG("nbr %p moving %s state to STALE (%d)",
 				nbr,
-				log_strdup(net_sprint_ipv6_addr(&data->addr)),
+				net_sprint_ipv6_addr(&data->addr),
 				data->state);
 			break;
 
 		case NET_IPV6_NBR_STATE_STALE:
 			NET_DBG("nbr %p removing stale address %s",
 				nbr,
-				log_strdup(net_sprint_ipv6_addr(&data->addr)));
+				net_sprint_ipv6_addr(&data->addr));
 			net_ipv6_nbr_rm(nbr->iface, &data->addr);
 			break;
 
@@ -1501,7 +1493,7 @@ static void ipv6_nd_reachable_timeout(struct k_work *work)
 
 			NET_DBG("nbr %p moving %s state to PROBE (%d)",
 				nbr,
-				log_strdup(net_sprint_ipv6_addr(&data->addr)),
+				net_sprint_ipv6_addr(&data->addr),
 				data->state);
 
 			/* Intentionally continuing to probe state */
@@ -1563,7 +1555,7 @@ static inline bool handle_na_neighbor(struct net_pkt *pkt,
 
 	NET_DBG("Neighbor lookup %p iface %p/%d addr %s", nbr,
 		net_pkt_iface(pkt), net_if_get_by_iface(net_pkt_iface(pkt)),
-		log_strdup(net_sprint_ipv6_addr(&na_hdr->tgt)));
+		net_sprint_ipv6_addr(&na_hdr->tgt));
 
 	if (!nbr) {
 		nbr_print();
@@ -1601,9 +1593,8 @@ static inline bool handle_na_neighbor(struct net_pkt *pkt,
 
 		NET_DBG("[%d] nbr %p state %d IPv6 %s ll %s",
 			nbr->idx, nbr, net_ipv6_nbr_data(nbr)->state,
-			log_strdup(net_sprint_ipv6_addr(&na_hdr->tgt)),
-			log_strdup(net_sprint_ll_addr(nbr_lladdr.addr,
-						      nbr_lladdr.len)));
+			net_sprint_ipv6_addr(&na_hdr->tgt),
+			net_sprint_ll_addr(nbr_lladdr.addr, nbr_lladdr.len));
 	}
 
 	cached_lladdr = net_nbr_get_lladdr(nbr->idx);
@@ -1711,8 +1702,7 @@ send_pending:
 	pending = net_ipv6_nbr_data(nbr)->pending;
 	if (pending) {
 		NET_DBG("Sending pending %p to lladdr %s", pending,
-			log_strdup(net_sprint_ll_addr(cached_lladdr->addr,
-						      cached_lladdr->len)));
+			net_sprint_ll_addr(cached_lladdr->addr, cached_lladdr->len));
 
 		if (net_send_data(pending) < 0) {
 			nbr_clear_ns_pending(net_ipv6_nbr_data(nbr));
@@ -1809,7 +1799,7 @@ static enum net_verdict handle_na_input(struct net_pkt *pkt,
 		NET_DBG("Interface %p/%d already has address %s",
 			net_pkt_iface(pkt),
 			net_if_get_by_iface(net_pkt_iface(pkt)),
-			log_strdup(net_sprint_ipv6_addr(&na_hdr->tgt)));
+			net_sprint_ipv6_addr(&na_hdr->tgt));
 
 #if defined(CONFIG_NET_IPV6_DAD)
 		if (ifaddr->addr_state == NET_ADDR_TENTATIVE) {
@@ -1870,7 +1860,7 @@ int net_ipv6_send_ns(struct net_if *iface,
 
 		if (net_ipv6_is_addr_unspecified(src)) {
 			NET_DBG("No source address for NS (tgt %s)",
-				log_strdup(net_sprint_ipv6_addr(tgt)));
+				net_sprint_ipv6_addr(tgt));
 			ret = -EINVAL;
 
 			goto drop;
@@ -1925,7 +1915,7 @@ int net_ipv6_send_ns(struct net_if *iface,
 		      NET_IPV6_NBR_STATE_INCOMPLETE);
 	if (!nbr) {
 		NET_DBG("Could not create new neighbor %s",
-			log_strdup(net_sprint_ipv6_addr(&ns_hdr->tgt)));
+			net_sprint_ipv6_addr(&ns_hdr->tgt));
 		goto drop;
 	}
 
@@ -2089,15 +2079,13 @@ static inline void handle_prefix_onlink(struct net_pkt *pkt,
 			NET_DBG("Interface %p/%d add prefix %s/%d lifetime %u",
 				net_pkt_iface(pkt),
 				net_if_get_by_iface(net_pkt_iface(pkt)),
-				log_strdup(net_sprint_ipv6_addr(
-						   &prefix_info->prefix)),
+				net_sprint_ipv6_addr(&prefix_info->prefix),
 				prefix_info->prefix_len,
 				prefix_info->valid_lifetime);
 		} else {
 			NET_ERR("Prefix %s/%d could not be added to "
 				"iface %p/%d",
-				log_strdup(net_sprint_ipv6_addr(
-						   &prefix_info->prefix)),
+				net_sprint_ipv6_addr(&prefix_info->prefix),
 				prefix_info->prefix_len,
 				net_pkt_iface(pkt),
 				net_if_get_by_iface(net_pkt_iface(pkt)));
@@ -2111,7 +2099,7 @@ static inline void handle_prefix_onlink(struct net_pkt *pkt,
 		NET_DBG("Interface %p/%d delete prefix %s/%d",
 			net_pkt_iface(pkt),
 			net_if_get_by_iface(net_pkt_iface(pkt)),
-			log_strdup(net_sprint_ipv6_addr(&prefix_info->prefix)),
+			net_sprint_ipv6_addr(&prefix_info->prefix),
 			prefix_info->prefix_len);
 
 		net_if_ipv6_prefix_rm(net_pkt_iface(pkt),
@@ -2123,7 +2111,7 @@ static inline void handle_prefix_onlink(struct net_pkt *pkt,
 		NET_DBG("Interface %p/%d prefix %s/%d infinite",
 			net_pkt_iface(pkt),
 			net_if_get_by_iface(net_pkt_iface(pkt)),
-			log_strdup(net_sprint_ipv6_addr(&prefix->prefix)),
+			net_sprint_ipv6_addr(&prefix->prefix),
 			prefix->len);
 
 		net_if_ipv6_prefix_set_lf(prefix, true);
@@ -2133,7 +2121,7 @@ static inline void handle_prefix_onlink(struct net_pkt *pkt,
 		NET_DBG("Interface %p/%d update prefix %s/%u lifetime %u",
 			net_pkt_iface(pkt),
 			net_if_get_by_iface(net_pkt_iface(pkt)),
-			log_strdup(net_sprint_ipv6_addr(&prefix_info->prefix)),
+			net_sprint_ipv6_addr(&prefix_info->prefix),
 			prefix_info->prefix_len, prefix_info->valid_lifetime);
 
 		net_if_ipv6_prefix_set_lf(prefix, false);
@@ -2178,7 +2166,7 @@ static inline void handle_prefix_autonomous(struct net_pkt *pkt,
 		     remaining_lifetime(ifaddr))) {
 			NET_DBG("Timer updating for address %s "
 				"long lifetime %u secs",
-				log_strdup(net_sprint_ipv6_addr(&addr)),
+				net_sprint_ipv6_addr(&addr),
 				prefix_info->valid_lifetime);
 
 			net_if_ipv6_addr_update_lifetime(
@@ -2186,7 +2174,7 @@ static inline void handle_prefix_autonomous(struct net_pkt *pkt,
 		} else {
 			NET_DBG("Timer updating for address %s "
 				"lifetime %u secs",
-				log_strdup(net_sprint_ipv6_addr(&addr)),
+				net_sprint_ipv6_addr(&addr),
 				TWO_HOURS);
 
 			net_if_ipv6_addr_update_lifetime(ifaddr, TWO_HOURS);
@@ -2527,8 +2515,7 @@ static enum net_verdict handle_ra_input(struct net_pkt *pkt,
 	if (nbr && net_ipv6_nbr_data(nbr)->pending) {
 		NET_DBG("Sending pending pkt %p to %s",
 			net_ipv6_nbr_data(nbr)->pending,
-			log_strdup(net_sprint_ipv6_addr(&NET_IPV6_HDR(
-				net_ipv6_nbr_data(nbr)->pending)->dst)));
+			net_sprint_ipv6_addr(&NET_IPV6_HDR(net_ipv6_nbr_data(nbr)->pending)->dst));
 
 		if (net_send_data(net_ipv6_nbr_data(nbr)->pending) < 0) {
 			net_pkt_unref(net_ipv6_nbr_data(nbr)->pending);

--- a/subsys/net/ip/nbr.c
+++ b/subsys/net/ip/nbr.c
@@ -223,9 +223,9 @@ void net_nbr_print(struct net_nbr_table *table)
 				nbr->idx,
 				nbr->idx == NET_NBR_LLADDR_UNKNOWN ?
 				"<unknown>" :
-				log_strdup(net_sprint_ll_addr(
+				net_sprint_ll_addr(
 				   net_neighbor_lladdr[nbr->idx].lladdr.addr,
-				   net_neighbor_lladdr[nbr->idx].lladdr.len)));
+				   net_neighbor_lladdr[nbr->idx].lladdr.len));
 		}
 	}
 }

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -573,8 +573,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 		if (!iface) {
 			NET_ERR("Cannot bind to %s",
-				log_strdup(net_sprint_ipv6_addr(
-						   &addr6->sin6_addr)));
+				net_sprint_ipv6_addr(&addr6->sin6_addr));
 
 			return -EADDRNOTAVAIL;
 		}
@@ -617,7 +616,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			context,
 			net_proto2str(AF_INET6,
 				      net_context_get_ip_proto(context)),
-			log_strdup(net_sprint_ipv6_addr(ptr)),
+			net_sprint_ipv6_addr(ptr),
 			ntohs(addr6->sin6_port),
 			net_if_get_by_iface(iface), iface);
 
@@ -672,8 +671,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 
 		if (!iface) {
 			NET_ERR("Cannot bind to %s",
-				log_strdup(net_sprint_ipv4_addr(
-						   &addr4->sin_addr)));
+				net_sprint_ipv4_addr(&addr4->sin_addr));
 
 			return -EADDRNOTAVAIL;
 		}
@@ -716,7 +714,7 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 			context,
 			net_proto2str(AF_INET,
 				      net_context_get_ip_proto(context)),
-			log_strdup(net_sprint_ipv4_addr(ptr)),
+			net_sprint_ipv4_addr(ptr),
 			ntohs(addr4->sin_port),
 			net_if_get_by_iface(iface), iface);
 
@@ -773,9 +771,9 @@ int net_context_bind(struct net_context *context, const struct sockaddr *addr,
 		NET_DBG("Context %p bind to type 0x%04x iface[%d] %p addr %s",
 			context, htons(net_context_get_ip_proto(context)),
 			ll_addr->sll_ifindex, iface,
-			log_strdup(net_sprint_ll_addr(
+			net_sprint_ll_addr(
 				net_sll_ptr(&context->local)->sll_addr,
-				net_sll_ptr(&context->local)->sll_halen)));
+				net_sll_ptr(&context->local)->sll_halen));
 
 		k_mutex_unlock(&context->lock);
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -702,8 +702,7 @@ static void iface_router_notify_deletion(struct net_if_router *router,
 	if (IS_ENABLED(CONFIG_NET_IPV6) &&
 	    router->address.family == AF_INET6) {
 		NET_DBG("IPv6 router %s %s",
-			log_strdup(net_sprint_ipv6_addr(
-					   net_if_router_ipv6(router))),
+			net_sprint_ipv6_addr(net_if_router_ipv6(router)),
 			delete_reason);
 
 		net_mgmt_event_notify_with_info(NET_EVENT_IPV6_ROUTER_DEL,
@@ -713,8 +712,7 @@ static void iface_router_notify_deletion(struct net_if_router *router,
 	} else if (IS_ENABLED(CONFIG_NET_IPV4) &&
 		   router->address.family == AF_INET) {
 		NET_DBG("IPv4 router %s %s",
-			log_strdup(net_sprint_ipv4_addr(
-					   net_if_router_ipv4(router))),
+			net_sprint_ipv4_addr(net_if_router_ipv4(router)),
 			delete_reason);
 
 		net_mgmt_event_notify_with_info(NET_EVENT_IPV4_ROUTER_DEL,
@@ -841,8 +839,7 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 
 			NET_DBG("interface %p router %s lifetime %u default %d "
 				"added", iface,
-				log_strdup(net_sprint_ipv6_addr(
-						   (struct in6_addr *)addr)),
+				net_sprint_ipv6_addr((struct in6_addr *)addr),
 				lifetime, routers[i].is_default);
 		} else if (IS_ENABLED(CONFIG_NET_IPV4) && family == AF_INET) {
 			memcpy(net_if_router_ipv4(&routers[i]), addr,
@@ -856,8 +853,7 @@ static struct net_if_router *iface_router_add(struct net_if *iface,
 
 			NET_DBG("interface %p router %s lifetime %u default %d "
 				"added", iface,
-				log_strdup(net_sprint_ipv4_addr(
-						   (struct in_addr *)addr)),
+				net_sprint_ipv4_addr((struct in_addr *)addr),
 				lifetime, is_default);
 		}
 
@@ -1082,7 +1078,7 @@ static void join_mcast_allnodes(struct net_if *iface)
 	ret = net_ipv6_mld_join(iface, &addr);
 	if (ret < 0 && ret != -EALREADY) {
 		NET_ERR("Cannot join all nodes address %s (%d)",
-			log_strdup(net_sprint_ipv6_addr(&addr)), ret);
+			net_sprint_ipv6_addr(&addr), ret);
 	}
 }
 
@@ -1098,7 +1094,7 @@ static void join_mcast_solicit_node(struct net_if *iface,
 	ret = net_ipv6_mld_join(iface, &addr);
 	if (ret < 0 && ret != -EALREADY) {
 		NET_ERR("Cannot join solicit node address %s (%d)",
-			log_strdup(net_sprint_ipv6_addr(&addr)), ret);
+			net_sprint_ipv6_addr(&addr), ret);
 	}
 }
 
@@ -1172,8 +1168,7 @@ static void dad_timeout(struct k_work *work)
 		sys_slist_remove(&active_dad_timers, NULL, &ifaddr->dad_node);
 
 		NET_DBG("DAD succeeded for %s",
-			log_strdup(net_sprint_ipv6_addr(
-					   &ifaddr->address.in6_addr)));
+			net_sprint_ipv6_addr(&ifaddr->address.in6_addr));
 
 		ifaddr->addr_state = NET_ADDR_PREFERRED;
 
@@ -1213,11 +1208,10 @@ static void net_if_ipv6_start_dad(struct net_if *iface,
 	if (net_if_is_up(iface)) {
 		NET_DBG("Interface %p ll addr %s tentative IPv6 addr %s",
 			iface,
-			log_strdup(net_sprint_ll_addr(
+			net_sprint_ll_addr(
 					   net_if_get_link_addr(iface)->addr,
-					   net_if_get_link_addr(iface)->len)),
-			log_strdup(net_sprint_ipv6_addr(
-					   &ifaddr->address.in6_addr)));
+					   net_if_get_link_addr(iface)->len),
+			net_sprint_ipv6_addr(&ifaddr->address.in6_addr));
 
 		ifaddr->dad_count = 1U;
 
@@ -1234,8 +1228,7 @@ static void net_if_ipv6_start_dad(struct net_if *iface,
 	} else {
 		NET_DBG("Interface %p is down, starting DAD for %s later.",
 			iface,
-			log_strdup(net_sprint_ipv6_addr(
-					   &ifaddr->address.in6_addr)));
+			net_sprint_ipv6_addr(&ifaddr->address.in6_addr));
 	}
 }
 
@@ -1268,7 +1261,7 @@ void net_if_start_dad(struct net_if *iface)
 	ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF, 0);
 	if (!ifaddr) {
 		NET_ERR("Cannot add %s address to interface %p, DAD fails",
-			log_strdup(net_sprint_ipv6_addr(&addr)), iface);
+			net_sprint_ipv6_addr(&addr), iface);
 	}
 
 	/* Start DAD for all the addresses that were added earlier when
@@ -1299,7 +1292,7 @@ void net_if_ipv6_dad_failed(struct net_if *iface, const struct in6_addr *addr)
 	ifaddr = net_if_ipv6_addr_lookup(addr, &iface);
 	if (!ifaddr) {
 		NET_ERR("Cannot find %s address in interface %p",
-			log_strdup(net_sprint_ipv6_addr(addr)), iface);
+			net_sprint_ipv6_addr(addr), iface);
 		goto out;
 	}
 
@@ -1555,7 +1548,7 @@ static inline int z_vrfy_net_if_ipv6_addr_lookup_by_index(
 static void address_expired(struct net_if_addr *ifaddr)
 {
 	NET_DBG("IPv6 address %s is deprecated",
-		log_strdup(net_sprint_ipv6_addr(&ifaddr->address.in6_addr)));
+		net_sprint_ipv6_addr(&ifaddr->address.in6_addr));
 
 	ifaddr->addr_state = NET_ADDR_DEPRECATED;
 
@@ -1626,7 +1619,7 @@ void net_if_ipv6_addr_update_lifetime(struct net_if_addr *ifaddr,
 	k_mutex_lock(&lock, K_FOREVER);
 
 	NET_DBG("Updating expire time of %s by %u secs",
-		log_strdup(net_sprint_ipv6_addr(&ifaddr->address.in6_addr)),
+		net_sprint_ipv6_addr(&ifaddr->address.in6_addr),
 		vlifetime);
 
 	ifaddr->addr_state = NET_ADDR_PREFERRED;
@@ -1673,7 +1666,7 @@ static inline void net_if_addr_init(struct net_if_addr *ifaddr,
 		ifaddr->is_infinite = false;
 
 		NET_DBG("Expiring %s in %u secs",
-			log_strdup(net_sprint_ipv6_addr(addr)),
+			net_sprint_ipv6_addr(addr),
 			vlifetime);
 
 		net_if_ipv6_addr_update_lifetime(ifaddr, vlifetime);
@@ -1711,7 +1704,7 @@ struct net_if_addr *net_if_ipv6_addr_add(struct net_if *iface,
 				 vlifetime);
 
 		NET_DBG("[%d] interface %p address %s type %s added", i,
-			iface, log_strdup(net_sprint_ipv6_addr(addr)),
+			iface, net_sprint_ipv6_addr(addr),
 			net_addr_type2str(addr_type));
 
 		if (!(l2_flags_get(iface) & NET_L2_POINT_TO_POINT) &&
@@ -1798,7 +1791,7 @@ bool net_if_ipv6_addr_rm(struct net_if *iface, const struct in6_addr *addr)
 		net_if_ipv6_maddr_rm(iface, &maddr);
 
 		NET_DBG("[%d] interface %p address %s type %s removed",
-			i, iface, log_strdup(net_sprint_ipv6_addr(addr)),
+			i, iface, net_sprint_ipv6_addr(addr),
 			net_addr_type2str(ipv6->unicast[i].addr_type));
 
 		/* Using the IPv6 address pointer here can give false
@@ -1910,13 +1903,13 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 
 	if (!net_ipv6_is_addr_mcast(addr)) {
 		NET_DBG("Address %s is not a multicast address.",
-			log_strdup(net_sprint_ipv6_addr(addr)));
+			net_sprint_ipv6_addr(addr));
 		goto out;
 	}
 
 	if (net_if_ipv6_maddr_lookup(addr, &iface)) {
 		NET_WARN("Multicast address %s is is already registered.",
-			log_strdup(net_sprint_ipv6_addr(addr)));
+			net_sprint_ipv6_addr(addr));
 		goto out;
 	}
 
@@ -1930,7 +1923,7 @@ struct net_if_mcast_addr *net_if_ipv6_maddr_add(struct net_if *iface,
 		memcpy(&ipv6->mcast[i].address.in6_addr, addr, 16);
 
 		NET_DBG("[%d] interface %p address %s added", i, iface,
-			log_strdup(net_sprint_ipv6_addr(addr)));
+			net_sprint_ipv6_addr(addr));
 
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_IPV6_MADDR_ADD, iface,
@@ -1973,7 +1966,7 @@ bool net_if_ipv6_maddr_rm(struct net_if *iface, const struct in6_addr *addr)
 		ipv6->mcast[i].is_used = false;
 
 		NET_DBG("[%d] interface %p address %s removed",
-			i, iface, log_strdup(net_sprint_ipv6_addr(addr)));
+			i, iface, net_sprint_ipv6_addr(addr));
 
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_IPV6_MADDR_DEL, iface,
@@ -2086,7 +2079,7 @@ static void prefix_lifetime_expired(struct net_if_ipv6_prefix *ifprefix)
 	struct net_if_ipv6 *ipv6;
 
 	NET_DBG("Prefix %s/%d expired",
-		log_strdup(net_sprint_ipv6_addr(&ifprefix->prefix)),
+		net_sprint_ipv6_addr(&ifprefix->prefix),
 		ifprefix->len);
 
 	ifprefix->is_used = false;
@@ -2110,7 +2103,7 @@ static void prefix_timer_remove(struct net_if_ipv6_prefix *ifprefix)
 	k_mutex_lock(&lock, K_FOREVER);
 
 	NET_DBG("IPv6 prefix %s/%d removed",
-		log_strdup(net_sprint_ipv6_addr(&ifprefix->prefix)),
+		net_sprint_ipv6_addr(&ifprefix->prefix),
 		ifprefix->len);
 
 	sys_slist_find_and_remove(&active_prefix_lifetime_timers,
@@ -2249,7 +2242,7 @@ struct net_if_ipv6_prefix *net_if_ipv6_prefix_add(struct net_if *iface,
 					len, lifetime);
 
 		NET_DBG("[%d] interface %p prefix %s/%d added", i, iface,
-			log_strdup(net_sprint_ipv6_addr(prefix)), len);
+			net_sprint_ipv6_addr(prefix), len);
 
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_IPV6_PREFIX_ADD, iface,
@@ -2460,7 +2453,7 @@ void net_if_ipv6_router_update_lifetime(struct net_if_router *router,
 					uint16_t lifetime)
 {
 	NET_DBG("Updating expire time of %s by %u secs",
-		log_strdup(net_sprint_ipv6_addr(&router->address.in6_addr)),
+		net_sprint_ipv6_addr(&router->address.in6_addr),
 		lifetime);
 
 	router->life_start = k_uptime_get_32();
@@ -3520,7 +3513,7 @@ struct net_if_addr *net_if_ipv4_addr_add(struct net_if *iface,
 		ifaddr->addr_state = NET_ADDR_PREFERRED;
 
 		NET_DBG("[%d] interface %p address %s type %s added", i, iface,
-			log_strdup(net_sprint_ipv4_addr(addr)),
+			net_sprint_ipv4_addr(addr),
 			net_addr_type2str(addr_type));
 
 		net_mgmt_event_notify_with_info(NET_EVENT_IPV4_ADDR_ADD, iface,
@@ -3561,7 +3554,7 @@ bool net_if_ipv4_addr_rm(struct net_if *iface, const struct in_addr *addr)
 		ipv4->unicast[i].is_used = false;
 
 		NET_DBG("[%d] interface %p address %s removed",
-			i, iface, log_strdup(net_sprint_ipv4_addr(addr)));
+			i, iface, net_sprint_ipv4_addr(addr));
 
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_IPV4_ADDR_DEL, iface,
@@ -3695,7 +3688,7 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 
 	if (!net_ipv4_is_addr_mcast(addr)) {
 		NET_DBG("Address %s is not a multicast address.",
-			log_strdup(net_sprint_ipv4_addr(addr)));
+			net_sprint_ipv4_addr(addr));
 		goto out;
 	}
 
@@ -3706,7 +3699,7 @@ struct net_if_mcast_addr *net_if_ipv4_maddr_add(struct net_if *iface,
 		maddr->address.in_addr.s4_addr32[0] = addr->s4_addr32[0];
 
 		NET_DBG("interface %p address %s added", iface,
-			log_strdup(net_sprint_ipv4_addr(addr)));
+			net_sprint_ipv4_addr(addr));
 
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_IPV4_MADDR_ADD, iface,
@@ -3732,7 +3725,7 @@ bool net_if_ipv4_maddr_rm(struct net_if *iface, const struct in_addr *addr)
 		maddr->is_used = false;
 
 		NET_DBG("interface %p address %s removed",
-			iface, log_strdup(net_sprint_ipv4_addr(addr)));
+			iface, net_sprint_ipv4_addr(addr));
 
 		net_mgmt_event_notify_with_info(
 			NET_EVENT_IPV4_MADDR_DEL, iface,

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -229,13 +229,13 @@ static inline void net_pkt_hexdump(struct net_pkt *pkt, const char *str)
 	char pkt_str[sizeof("0x") + sizeof(intptr_t) * 2];
 
 	if (str && str[0]) {
-		LOG_DBG("%s", log_strdup(str));
+		LOG_DBG("%s", str);
 	}
 
 	snprintk(pkt_str, sizeof(pkt_str), "%p", pkt);
 
 	while (buf) {
-		LOG_HEXDUMP_DBG(buf->data, buf->len, log_strdup(pkt_str));
+		LOG_HEXDUMP_DBG(buf->data, buf->len, pkt_str);
 		buf = buf->frags;
 	}
 }

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -178,15 +178,14 @@ void net_routes_print(void)
 
 		NET_DBG("[%d] %p %d addr %s/%d",
 			i, nbr, nbr->ref,
-			log_strdup(net_sprint_ipv6_addr(
-					   &net_route_data(nbr)->addr)),
+			net_sprint_ipv6_addr(&net_route_data(nbr)->addr),
 			net_route_data(nbr)->prefix_len);
 		NET_DBG("    iface %p idx %d ll %s",
 			nbr->iface, nbr->idx,
 			nbr->idx == NET_NBR_LLADDR_UNKNOWN ? "?" :
-			log_strdup(net_sprint_ll_addr(
+			net_sprint_ll_addr(
 				net_nbr_get_lladdr(nbr->idx)->addr,
-				net_nbr_get_lladdr(nbr->idx)->len)));
+				net_nbr_get_lladdr(nbr->idx)->len));
 	}
 
 	k_mutex_unlock(&lock);
@@ -216,7 +215,7 @@ static struct net_nbr *nbr_new(struct net_if *iface,
 
 	NET_DBG("[%d] nbr %p iface %p IPv6 %s/%d",
 		nbr->idx, nbr, iface,
-		log_strdup(net_sprint_ipv6_addr(&net_route_data(nbr)->addr)),
+		net_sprint_ipv6_addr(&net_route_data(nbr)->addr),
 		prefix_len);
 
 	return nbr;
@@ -244,7 +243,7 @@ static struct net_nbr *nbr_nexthop_get(struct net_if *iface,
 
 	NET_DBG("[%d] nbr %p iface %p IPv6 %s",
 		nbr->idx, nbr, iface,
-		log_strdup(net_sprint_ipv6_addr(addr)));
+		net_sprint_ipv6_addr(addr));
 
 	return nbr;
 }
@@ -269,8 +268,8 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 		NET_ASSERT(naddr, "Unknown nexthop address");	\
 									\
 		NET_DBG("%s route to %s via %s (iface %p)", str,	\
-			log_strdup(net_sprint_ipv6_addr(dst)),		\
-			log_strdup(net_sprint_ipv6_addr(naddr)),	\
+			net_sprint_ipv6_addr(dst),		\
+			net_sprint_ipv6_addr(naddr),	\
 			route->iface);					\
 	} } while (0)
 
@@ -364,7 +363,7 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 	nbr_nexthop = net_ipv6_nbr_lookup(iface, nexthop);
 	if (!nbr_nexthop) {
 		NET_DBG("No such neighbor %s found",
-			log_strdup(net_sprint_ipv6_addr(nexthop)));
+			net_sprint_ipv6_addr(nexthop));
 		goto exit;
 	}
 
@@ -373,9 +372,9 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 	NET_ASSERT(nexthop_lladdr);
 
 	NET_DBG("Nexthop %s lladdr is %s",
-		log_strdup(net_sprint_ipv6_addr(nexthop)),
-		log_strdup(net_sprint_ll_addr(nexthop_lladdr->addr,
-					      nexthop_lladdr->len)));
+		net_sprint_ipv6_addr(nexthop),
+		net_sprint_ll_addr(nexthop_lladdr->addr,
+					      nexthop_lladdr->len));
 
 	route = net_route_lookup(iface, addr);
 	if (route) {
@@ -401,7 +400,7 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 		}
 
 		NET_DBG("Old route to %s found",
-			log_strdup(net_sprint_ipv6_addr(nexthop_addr)));
+			net_sprint_ipv6_addr(nexthop_addr));
 
 		net_route_del(route);
 	}
@@ -428,12 +427,10 @@ struct net_route_entry *net_route_add(struct net_if *iface,
 
 				NET_DBG("Removing the oldest route %s "
 					"via %s [%s]",
-					log_strdup(net_sprint_ipv6_addr(
-							   &route->addr)),
-					log_strdup(net_sprint_ipv6_addr(tmp)),
-					log_strdup(net_sprint_ll_addr(
-							   llstorage->addr,
-							   llstorage->len)));
+					net_sprint_ipv6_addr(&route->addr),
+					net_sprint_ipv6_addr(tmp),
+					net_sprint_ll_addr(llstorage->addr,
+							   llstorage->len));
 			}
 		}
 
@@ -495,7 +492,7 @@ exit:
 static void route_expired(struct net_route_entry *route)
 {
 	NET_DBG("Route to %s expired",
-		log_strdup(net_sprint_ipv6_addr(&route->addr)));
+		net_sprint_ipv6_addr(&route->addr));
 
 	sys_slist_find_and_remove(&active_route_lifetime_timers,
 				  &route->lifetime.node);
@@ -539,7 +536,7 @@ static void route_lifetime_timeout(struct k_work *work)
 void net_route_update_lifetime(struct net_route_entry *route, uint32_t lifetime)
 {
 	NET_DBG("Updating route lifetime of %s to %u secs",
-		log_strdup(net_sprint_ipv6_addr(&route->addr)),
+		net_sprint_ipv6_addr(&route->addr),
 		lifetime);
 
 	if (!route) {
@@ -924,7 +921,7 @@ bool net_route_mcast_del(struct net_route_entry_mcast *route)
 
 	NET_ASSERT(route->is_used,
 		   "Multicast route %p to %s was already removed", route,
-		   log_strdup(net_sprint_ipv6_addr(&route->group)));
+		   net_sprint_ipv6_addr(&route->group));
 
 	route->is_used = false;
 
@@ -1014,7 +1011,7 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	nbr = net_ipv6_nbr_lookup(NULL, nexthop);
 	if (!nbr) {
 		NET_DBG("Cannot find %s neighbor",
-			log_strdup(net_sprint_ipv6_addr(nexthop)));
+			net_sprint_ipv6_addr(nexthop));
 		err = -ENOENT;
 		goto error;
 	}
@@ -1022,7 +1019,7 @@ int net_route_packet(struct net_pkt *pkt, struct in6_addr *nexthop)
 	lladdr = net_nbr_get_lladdr(nbr->idx);
 	if (!lladdr) {
 		NET_DBG("Cannot find %s neighbor link layer address.",
-			log_strdup(net_sprint_ipv6_addr(nexthop)));
+			net_sprint_ipv6_addr(nexthop));
 		err = -ESRCH;
 		goto error;
 	}

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -295,7 +295,7 @@ end:
 
 static void tcp_send(struct net_pkt *pkt)
 {
-	NET_DBG("%s", log_strdup(tcp_th(pkt)));
+	NET_DBG("%s", tcp_th(pkt));
 
 	tcp_pkt_ref(pkt);
 
@@ -468,7 +468,7 @@ static bool tcp_send_process_no_lock(struct tcp *conn)
 		goto out;
 	}
 
-	NET_DBG("%s %s", log_strdup(tcp_th(pkt)), conn->in_retransmission ?
+	NET_DBG("%s %s", tcp_th(pkt), conn->in_retransmission ?
 		"in_retransmission" : "");
 
 	if (conn->in_retransmission) {
@@ -550,7 +550,7 @@ static void tcp_send_timer_cancel(struct tcp *conn)
 		struct net_pkt *pkt = tcp_slist(conn, &conn->send_queue, get,
 						struct net_pkt, next);
 		if (pkt) {
-			NET_DBG("%s", log_strdup(tcp_th(pkt)));
+			NET_DBG("%s", tcp_th(pkt));
 			tcp_pkt_unref(pkt);
 		}
 	}
@@ -970,7 +970,7 @@ static int tcp_out_ext(struct tcp *conn, uint8_t flags, struct net_pkt *data,
 		goto out;
 	}
 
-	NET_DBG("%s", log_strdup(tcp_th(pkt)));
+	NET_DBG("%s", tcp_th(pkt));
 
 	if (tcp_send_cb) {
 		ret = tcp_send_cb(pkt);
@@ -1246,7 +1246,7 @@ static void tcp_timewait_timeout(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct tcp *conn = CONTAINER_OF(dwork, struct tcp, timewait_timer);
 
-	NET_DBG("conn: %p %s", conn, log_strdup(tcp_conn_state(conn, NULL)));
+	NET_DBG("conn: %p %s", conn, tcp_conn_state(conn, NULL));
 
 	/* Extra unref from net_tcp_put() */
 	net_context_unref(conn->context);
@@ -1255,7 +1255,7 @@ static void tcp_timewait_timeout(struct k_work *work)
 static void tcp_establish_timeout(struct tcp *conn)
 {
 	NET_DBG("Did not receive %s in %dms", "ACK", ACK_TIMEOUT_MS);
-	NET_DBG("conn: %p %s", conn, log_strdup(tcp_conn_state(conn, NULL)));
+	NET_DBG("conn: %p %s", conn, tcp_conn_state(conn, NULL));
 
 	(void)tcp_conn_unref(conn, -ETIMEDOUT);
 }
@@ -1271,7 +1271,7 @@ static void tcp_fin_timeout(struct k_work *work)
 	}
 
 	NET_DBG("Did not receive %s in %dms", "FIN", FIN_TIMEOUT_MS);
-	NET_DBG("conn: %p %s", conn, log_strdup(tcp_conn_state(conn, NULL)));
+	NET_DBG("conn: %p %s", conn, tcp_conn_state(conn, NULL));
 
 	/* Extra unref from net_tcp_put() */
 	net_context_unref(conn->context);
@@ -1612,10 +1612,10 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 	}
 
 	NET_DBG("conn: src: %s, dst: %s",
-		log_strdup(net_sprint_addr(conn->src.sa.sa_family,
-				(const void *)&conn->src.sin.sin_addr)),
-		log_strdup(net_sprint_addr(conn->dst.sa.sa_family,
-				(const void *)&conn->dst.sin.sin_addr)));
+		net_sprint_addr(conn->src.sa.sa_family,
+				(const void *)&conn->src.sin.sin_addr),
+		net_sprint_addr(conn->dst.sa.sa_family,
+				(const void *)&conn->dst.sin.sin_addr));
 
 	memcpy(&context->remote, &conn->dst, sizeof(context->remote));
 	context->flags |= NET_CONTEXT_REMOTE_ADDR_SET;
@@ -1652,12 +1652,10 @@ static struct tcp *tcp_conn_new(struct net_pkt *pkt)
 	}
 
 	NET_DBG("context: local: %s, remote: %s",
-		log_strdup(net_sprint_addr(
-		      local_addr.sa_family,
-		      (const void *)&net_sin(&local_addr)->sin_addr)),
-		log_strdup(net_sprint_addr(
-		      context->remote.sa_family,
-		      (const void *)&net_sin(&context->remote)->sin_addr)));
+		net_sprint_addr(local_addr.sa_family,
+				(const void *)&net_sin(&local_addr)->sin_addr),
+		net_sprint_addr(context->remote.sa_family,
+				(const void *)&net_sin(&context->remote)->sin_addr));
 
 	ret = net_conn_register(IPPROTO_TCP, af,
 				&context->remote, &local_addr,
@@ -1845,7 +1843,7 @@ static void tcp_in(struct tcp *conn, struct net_pkt *pkt)
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
-	NET_DBG("%s", log_strdup(tcp_conn_state(conn, pkt)));
+	NET_DBG("%s", tcp_conn_state(conn, pkt));
 
 	if (th && th_off(th) < 5) {
 		tcp_out(conn, RST);
@@ -2248,10 +2246,10 @@ int net_tcp_put(struct net_context *context)
 
 	k_mutex_lock(&conn->lock, K_FOREVER);
 
-	NET_DBG("%s", conn ? log_strdup(tcp_conn_state(conn, NULL)) : "");
+	NET_DBG("%s", conn ? tcp_conn_state(conn, NULL) : "");
 	NET_DBG("context %p %s", context,
-		log_strdup(({ const char *state = net_context_state(context);
-					state ? state : "<unknown>"; })));
+		({ const char *state = net_context_state(context);
+					state ? state : "<unknown>"; }));
 
 	if (conn && conn->state == TCP_ESTABLISHED) {
 		/* Send all remaining data if possible. */
@@ -2465,12 +2463,10 @@ int net_tcp_connect(struct net_context *context,
 	int ret = 0;
 
 	NET_DBG("context: %p, local: %s, remote: %s", context,
-		log_strdup(net_sprint_addr(
-			    local_addr->sa_family,
-			    (const void *)&net_sin(local_addr)->sin_addr)),
-		log_strdup(net_sprint_addr(
-			    remote_addr->sa_family,
-			    (const void *)&net_sin(remote_addr)->sin_addr)));
+		net_sprint_addr(local_addr->sa_family,
+				(const void *)&net_sin(local_addr)->sin_addr),
+		net_sprint_addr(remote_addr->sa_family,
+				(const void *)&net_sin(remote_addr)->sin_addr));
 
 	conn = context->tcp;
 	conn->iface = net_context_get_iface(context);
@@ -2539,10 +2535,10 @@ int net_tcp_connect(struct net_context *context,
 	}
 
 	NET_DBG("conn: %p src: %s, dst: %s", conn,
-		log_strdup(net_sprint_addr(conn->src.sa.sa_family,
-				(const void *)&conn->src.sin.sin_addr)),
-		log_strdup(net_sprint_addr(conn->dst.sa.sa_family,
-				(const void *)&conn->dst.sin.sin_addr)));
+		net_sprint_addr(conn->src.sa.sa_family,
+				(const void *)&conn->src.sin.sin_addr),
+		net_sprint_addr(conn->dst.sa.sa_family,
+				(const void *)&conn->dst.sin.sin_addr));
 
 	net_context_set_state(context, NET_CONTEXT_CONNECTING);
 

--- a/subsys/net/ip/utils.c
+++ b/subsys/net/ip/utils.c
@@ -720,13 +720,11 @@ static bool parse_ipv6(const char *str, size_t str_len,
 		net_sin6(addr)->sin6_port = htons(port);
 
 		NET_DBG("IPv6 host %s port %d",
-			log_strdup(net_addr_ntop(AF_INET6, addr6,
-						 ipaddr, sizeof(ipaddr) - 1)),
+			net_addr_ntop(AF_INET6, addr6, ipaddr, sizeof(ipaddr) - 1),
 			port);
 	} else {
 		NET_DBG("IPv6 host %s",
-			log_strdup(net_addr_ntop(AF_INET6, addr6,
-						 ipaddr, sizeof(ipaddr) - 1)));
+			net_addr_ntop(AF_INET6, addr6, ipaddr, sizeof(ipaddr) - 1));
 	}
 
 	return true;
@@ -797,8 +795,7 @@ static bool parse_ipv4(const char *str, size_t str_len,
 	net_sin(addr)->sin_port = htons(port);
 
 	NET_DBG("IPv4 host %s port %d",
-		log_strdup(net_addr_ntop(AF_INET, addr4,
-					 ipaddr, sizeof(ipaddr) - 1)),
+		net_addr_ntop(AF_INET, addr4, ipaddr, sizeof(ipaddr) - 1),
 		port);
 	return true;
 }

--- a/subsys/net/l2/bluetooth/bluetooth.c
+++ b/subsys/net/l2/bluetooth/bluetooth.c
@@ -173,7 +173,7 @@ static void ipsp_connected(struct bt_l2cap_chan *chan)
 		bt_addr_le_to_str(info.le.dst, dst, sizeof(dst));
 
 		NET_DBG("Channel %p Source %s connected to Destination %s",
-			chan, log_strdup(src), log_strdup(dst));
+			chan, src, dst);
 	}
 
 	/* Swap bytes since net APIs expect big endian address */
@@ -432,7 +432,7 @@ static bool eir_found(uint8_t type, const uint8_t *data, uint8_t data_len,
 			char dev[BT_ADDR_LE_STR_LEN];
 
 			bt_addr_le_to_str(addr, dev, sizeof(dev));
-			NET_DBG("[DEVICE]: %s", log_strdup(dev));
+			NET_DBG("[DEVICE]: %s", dev);
 		}
 
 		/* TODO: Notify device address found */
@@ -563,7 +563,7 @@ static void connected(struct bt_conn *conn, uint8_t err)
 					  sizeof(addr));
 
 			NET_ERR("Failed to connect to %s (%u)\n",
-				log_strdup(addr), err);
+				addr, err);
 		}
 
 		return;
@@ -596,7 +596,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 		bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 		NET_DBG("Disconnected: %s (reason 0x%02x)\n",
-			log_strdup(addr), reason);
+			addr, reason);
 	}
 
 	bt_conn_unref(default_conn);

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -59,7 +59,7 @@ static struct arp_entry *arp_entry_find(sys_slist_t *list,
 
 	SYS_SLIST_FOR_EACH_CONTAINER(list, entry, node) {
 		NET_DBG("iface %p dst %s",
-			iface, log_strdup(net_sprint_ipv4_addr(&entry->ip)));
+			iface, net_sprint_ipv4_addr(&entry->ip));
 
 		if (entry->iface == iface &&
 		    net_ipv4_addr_cmp(&entry->ip, dst)) {
@@ -80,7 +80,7 @@ static inline struct arp_entry *arp_entry_find_move_first(struct net_if *iface,
 	sys_snode_t *prev = NULL;
 	struct arp_entry *entry;
 
-	NET_DBG("dst %s", log_strdup(net_sprint_ipv4_addr(dst)));
+	NET_DBG("dst %s", net_sprint_ipv4_addr(dst));
 
 	entry = arp_entry_find(&arp_table, iface, dst, &prev);
 	if (entry) {
@@ -102,7 +102,7 @@ static inline
 struct arp_entry *arp_entry_find_pending(struct net_if *iface,
 					 struct in_addr *dst)
 {
-	NET_DBG("dst %s", log_strdup(net_sprint_ipv4_addr(dst)));
+	NET_DBG("dst %s", net_sprint_ipv4_addr(dst));
 
 	return arp_entry_find(&arp_pending_entries, iface, dst, NULL);
 }
@@ -113,7 +113,7 @@ static struct arp_entry *arp_entry_get_pending(struct net_if *iface,
 	sys_snode_t *prev = NULL;
 	struct arp_entry *entry;
 
-	NET_DBG("dst %s", log_strdup(net_sprint_ipv4_addr(dst)));
+	NET_DBG("dst %s", net_sprint_ipv4_addr(dst));
 
 	entry = arp_entry_find(&arp_pending_entries, iface, dst, &prev);
 	if (entry) {
@@ -164,7 +164,7 @@ static struct arp_entry *arp_entry_get_last_from_table(void)
 
 static void arp_entry_register_pending(struct arp_entry *entry)
 {
-	NET_DBG("dst %s", log_strdup(net_sprint_ipv4_addr(&entry->ip)));
+	NET_DBG("dst %s", net_sprint_ipv4_addr(&entry->ip));
 
 	sys_slist_append(&arp_pending_entries, &entry->node);
 
@@ -395,9 +395,9 @@ struct net_pkt *net_arp_prepare(struct net_pkt *pkt,
 	net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
 
 	NET_DBG("ARP using ll %s for IP %s",
-		log_strdup(net_sprint_ll_addr(net_pkt_lladdr_dst(pkt)->addr,
-					      sizeof(struct net_eth_addr))),
-		log_strdup(net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst)));
+		net_sprint_ll_addr(net_pkt_lladdr_dst(pkt)->addr,
+				   sizeof(struct net_eth_addr)),
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->dst));
 
 	return pkt;
 }
@@ -412,12 +412,10 @@ static void arp_gratuitous(struct net_if *iface,
 	entry = arp_entry_find(&arp_table, iface, src, &prev);
 	if (entry) {
 		NET_DBG("Gratuitous ARP hwaddr %s -> %s",
-			log_strdup(net_sprint_ll_addr(
-					   (const uint8_t *)&entry->eth,
-					   sizeof(struct net_eth_addr))),
-			log_strdup(net_sprint_ll_addr(
-					   (const uint8_t *)hwaddr,
-					   sizeof(struct net_eth_addr))));
+			net_sprint_ll_addr((const uint8_t *)&entry->eth,
+					   sizeof(struct net_eth_addr)),
+			net_sprint_ll_addr((const uint8_t *)hwaddr,
+					   sizeof(struct net_eth_addr)));
 
 		memcpy(&entry->eth, hwaddr, sizeof(struct net_eth_addr));
 	}
@@ -432,7 +430,7 @@ static void arp_update(struct net_if *iface,
 	struct arp_entry *entry;
 	struct net_pkt *pkt;
 
-	NET_DBG("src %s", log_strdup(net_sprint_ipv4_addr(src)));
+	NET_DBG("src %s", net_sprint_ipv4_addr(src));
 
 	entry = arp_entry_get_pending(iface, src);
 	if (!entry) {
@@ -477,7 +475,7 @@ static void arp_update(struct net_if *iface,
 		(uint8_t *) &NET_ETH_HDR(entry->pending)->dst.addr;
 
 	NET_DBG("dst %s pending %p frag %p",
-		log_strdup(net_sprint_ipv4_addr(&entry->ip)),
+		net_sprint_ipv4_addr(&entry->ip),
 		entry->pending, entry->pending->frags);
 
 	pkt = entry->pending;
@@ -620,12 +618,10 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 		}
 
 		NET_DBG("ARP request from %s [%s] for %s",
-			log_strdup(net_sprint_ipv4_addr(&arp_hdr->src_ipaddr)),
-			log_strdup(net_sprint_ll_addr(
-					   (uint8_t *)&arp_hdr->src_hwaddr,
-					   arp_hdr->hwlen)),
-			log_strdup(net_sprint_ipv4_addr(
-					   &arp_hdr->dst_ipaddr)));
+			net_sprint_ipv4_addr(&arp_hdr->src_ipaddr),
+			net_sprint_ll_addr((uint8_t *)&arp_hdr->src_hwaddr,
+					   arp_hdr->hwlen),
+			net_sprint_ipv4_addr(&arp_hdr->dst_ipaddr));
 
 		/* Update the ARP cache if the sender MAC address has
 		 * changed. In this case the target MAC address is all zeros
@@ -633,11 +629,9 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 		 */
 		if (net_eth_is_addr_unspecified(&arp_hdr->dst_hwaddr)) {
 			NET_DBG("Updating ARP cache for %s [%s]",
-				log_strdup(net_sprint_ipv4_addr(
-						 &arp_hdr->src_ipaddr)),
-				log_strdup(net_sprint_ll_addr(
-						 (uint8_t *)&arp_hdr->src_hwaddr,
-						 arp_hdr->hwlen)));
+				net_sprint_ipv4_addr(&arp_hdr->src_ipaddr),
+				net_sprint_ll_addr((uint8_t *)&arp_hdr->src_hwaddr,
+						   arp_hdr->hwlen));
 
 			arp_update(net_pkt_iface(pkt),
 				   (struct in_addr *)arp_hdr->src_ipaddr,

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -84,9 +84,9 @@ void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
 					    sizeof(struct net_eth_addr))); \
 									   \
 		NET_DBG("iface %p src %s dst %s type 0x%x len %zu",	   \
-			net_pkt_iface(pkt), log_strdup(out),		   \
-			log_strdup(net_sprint_ll_addr((dst)->addr,	   \
-					    sizeof(struct net_eth_addr))), \
+			net_pkt_iface(pkt), out,		   \
+			net_sprint_ll_addr((dst)->addr,	   \
+					    sizeof(struct net_eth_addr)), \
 			type, (size_t)len);				   \
 	}
 
@@ -101,9 +101,9 @@ void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
 									   \
 		NET_DBG("iface %p src %s dst %s type 0x%x "		   \
 			"tag %d %spri %d len %zu",			   \
-			net_pkt_iface(pkt), log_strdup(out),		   \
-			log_strdup(net_sprint_ll_addr((dst)->addr,	   \
-				   sizeof(struct net_eth_addr))),	   \
+			net_pkt_iface(pkt), out,		   \
+			net_sprint_ll_addr((dst)->addr,	   \
+				   sizeof(struct net_eth_addr)),	   \
 			type, net_eth_vlan_get_vid(tci),		   \
 			tagstrip ? "(stripped) " : "",			   \
 			net_eth_vlan_get_pcp(tci), (size_t)len);	   \
@@ -303,9 +303,8 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		 * are different.
 		 */
 		NET_DBG("Dropping frame, not for me [%s]",
-			log_strdup(net_sprint_ll_addr(
-					   net_if_get_link_addr(iface)->addr,
-					   sizeof(struct net_eth_addr))));
+			net_sprint_ll_addr(net_if_get_link_addr(iface)->addr,
+					   sizeof(struct net_eth_addr)));
 		goto drop;
 	}
 
@@ -321,9 +320,8 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	if (IS_ENABLED(CONFIG_NET_ARP) &&
 	    family == AF_INET && type == NET_ETH_PTYPE_ARP) {
 		NET_DBG("ARP packet from %s received",
-			log_strdup(net_sprint_ll_addr(
-					   (uint8_t *)hdr->src.addr,
-					   sizeof(struct net_eth_addr))));
+			net_sprint_ll_addr((uint8_t *)hdr->src.addr,
+					   sizeof(struct net_eth_addr)));
 
 		if (IS_ENABLED(CONFIG_NET_IPV4_AUTO) &&
 		    net_ipv4_autoconf_input(iface, pkt) == NET_DROP) {
@@ -914,7 +912,7 @@ static void setup_ipv6_link_local_addr(struct net_if *iface)
 	ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF, 0);
 	if (!ifaddr) {
 		NET_DBG("Cannot add %s address to VLAN interface %p",
-			log_strdup(net_sprint_ipv6_addr(&addr)), iface);
+			net_sprint_ipv6_addr(&addr), iface);
 	}
 }
 

--- a/subsys/net/l2/ethernet/gptp/gptp.c
+++ b/subsys/net/l2/ethernet/gptp/gptp.c
@@ -84,12 +84,8 @@ static void gptp_compute_clock_identity(int port)
 	}
 }
 
-/* Note that we do not use log_strdup() here when printing msg as currently the
- * msg variable is always a const string that is not allocated from the stack.
- * If this changes at some point, then add log_strdup(msg) here.
- */
 #define PRINT_INFO(msg, hdr, pkt)				\
-	NET_DBG("Received %s seq %d pkt %p", msg,		\
+	NET_DBG("Received %s seq %d pkt %p", (const char *)msg,	\
 		ntohs(hdr->sequence_id), pkt)			\
 
 

--- a/subsys/net/l2/ethernet/gptp/gptp_messages.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_messages.c
@@ -46,7 +46,7 @@ static const struct net_eth_addr gptp_multicast_eth_addr = {
 				ann->root_system_id.clk_quality.clock_class, \
 				ann->root_system_id.clk_quality.clock_accuracy,\
 				ann->root_system_id.grand_master_prio2,	\
-				log_strdup(output));			\
+				output);			\
 		} else {						\
 			NET_DBG("Sending %s seq %d pkt %p",		\
 				msg,					\

--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -173,7 +173,7 @@ static void ot_state_changed_handler(uint32_t flags, void *context)
 
 	NET_INFO("State changed! Flags: 0x%08" PRIx32 " Current role: %s",
 		flags,
-		log_strdup(otThreadDeviceRoleToString(otThreadGetDeviceRole(ot_context->instance)))
+		otThreadDeviceRoleToString(otThreadGetDeviceRole(ot_context->instance))
 		);
 
 	if (flags & OT_CHANGED_IP6_ADDRESS_REMOVED) {
@@ -432,7 +432,7 @@ int openthread_start(struct openthread_context *ot_context)
 	}
 
 	NET_INFO("Network name: %s",
-		 log_strdup(otThreadGetNetworkName(ot_instance)));
+		 otThreadGetNetworkName(ot_instance));
 
 	/* Start the network. */
 	error = otThreadSetEnabled(ot_instance, true);

--- a/subsys/net/l2/openthread/openthread_utils.c
+++ b/subsys/net/l2/openthread/openthread_utils.c
@@ -116,9 +116,9 @@ void add_ipv6_addr_to_zephyr(struct openthread_context *context)
 			char buf[NET_IPV6_ADDR_LEN];
 
 			NET_DBG("Adding %s",
-				log_strdup(net_addr_ntop(AF_INET6,
+				net_addr_ntop(AF_INET6,
 				       (struct in6_addr *)(&address->mAddress),
-				       buf, sizeof(buf))));
+				       buf, sizeof(buf)));
 		}
 
 		/* Thread and SLAAC are clearly AUTOCONF, handle
@@ -217,9 +217,7 @@ void add_ipv6_addr_to_ot(struct openthread_context *context,
 		char buf[NET_IPV6_ADDR_LEN];
 
 		NET_DBG("Added %s",
-			log_strdup(net_addr_ntop(AF_INET6,
-						 &addr.mAddress, buf,
-						 sizeof(buf))));
+			net_addr_ntop(AF_INET6, &addr.mAddress, buf, sizeof(buf)));
 	}
 }
 
@@ -238,8 +236,7 @@ void add_ipv6_maddr_to_ot(struct openthread_context *context,
 		char buf[NET_IPV6_ADDR_LEN];
 
 		NET_DBG("Added multicast %s",
-			log_strdup(net_addr_ntop(AF_INET6, &addr,
-						 buf, sizeof(buf))));
+			net_addr_ntop(AF_INET6, &addr, buf, sizeof(buf)));
 	}
 }
 
@@ -260,10 +257,10 @@ void add_ipv6_maddr_to_zephyr(struct openthread_context *context)
 			char buf[NET_IPV6_ADDR_LEN];
 
 			NET_DBG("Adding multicast %s",
-				log_strdup(net_addr_ntop(AF_INET6,
-							 (struct in6_addr *)
-							 (&maddress->mAddress),
-							 buf, sizeof(buf))));
+				net_addr_ntop(AF_INET6,
+					      (struct in6_addr *)
+					      (&maddress->mAddress),
+					      buf, sizeof(buf)));
 		}
 
 		zmaddr = net_if_ipv6_maddr_add(context->iface,
@@ -318,9 +315,9 @@ void rm_ipv6_addr_from_zephyr(struct openthread_context *context)
 				char buf[NET_IPV6_ADDR_LEN];
 
 				NET_DBG("Removing %s",
-					log_strdup(net_addr_ntop(AF_INET6,
+					net_addr_ntop(AF_INET6,
 					      &zephyr_addr->address.in6_addr,
-					      buf, sizeof(buf))));
+					      buf, sizeof(buf)));
 			}
 
 			net_if_ipv6_addr_rm(context->iface,
@@ -366,9 +363,9 @@ void rm_ipv6_maddr_from_zephyr(struct openthread_context *context)
 				char buf[NET_IPV6_ADDR_LEN];
 
 				NET_DBG("Removing multicast %s",
-					log_strdup(net_addr_ntop(AF_INET6,
+					net_addr_ntop(AF_INET6,
 					      &zephyr_addr->address.in6_addr,
-					      buf, sizeof(buf))));
+					      buf, sizeof(buf)));
 			}
 
 			net_if_ipv6_maddr_rm(context->iface,

--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -860,7 +860,7 @@ static enum net_verdict fsm_recv_terminate_req(struct ppp_fsm *fsm, uint8_t id,
 
 			NET_DBG("[%s/%p] %s (%s)",
 				fsm->name, fsm, "Terminated by peer",
-				log_strdup(fsm->terminate_reason));
+				fsm->terminate_reason);
 		} else {
 			NET_DBG("[%s/%p] Terminated by peer",
 				fsm->name, fsm);

--- a/subsys/net/l2/ppp/ipcp.c
+++ b/subsys/net/l2/ppp/ipcp.c
@@ -201,7 +201,7 @@ static int ipcp_ip_address_parse(struct ppp_fsm *fsm, struct net_pkt *pkt,
 					 sizeof(dst));
 
 		NET_DBG("[IPCP] Received peer address %s",
-			log_strdup(addr_str));
+			addr_str);
 	}
 
 	data->addr_present = true;
@@ -409,11 +409,11 @@ static void ipcp_up(struct ppp_fsm *fsm)
 				    NET_ADDR_MANUAL,
 				    0);
 	if (addr == NULL) {
-		NET_ERR("Could not set IP address %s", log_strdup(addr_str));
+		NET_ERR("Could not set IP address %s", addr_str);
 		return;
 	}
 
-	NET_DBG("PPP up with address %s", log_strdup(addr_str));
+	NET_DBG("PPP up with address %s", addr_str);
 	ppp_network_up(ctx, PPP_IP);
 
 	ctx->is_ipcp_up = true;

--- a/subsys/net/l2/ppp/ipv6cp.c
+++ b/subsys/net/l2/ppp/ipv6cp.c
@@ -107,7 +107,7 @@ static int ipv6cp_interface_identifier_parse(struct ppp_fsm *fsm,
 				       iid_str, sizeof(iid_str));
 
 		NET_DBG("[%s/%p] Received %siid %s",
-			fsm->name, fsm, "peer ", log_strdup(iid_str));
+			fsm->name, fsm, "peer ", iid_str);
 	}
 
 	data->iface_id_present = true;
@@ -179,7 +179,7 @@ static int ipv6cp_config_info_ack(struct ppp_fsm *fsm,
 				       iid_str, sizeof(iid_str));
 
 		NET_DBG("[%s/%p] Received %siid %s",
-			fsm->name, fsm, "", log_strdup(iid_str));
+			fsm->name, fsm, "", iid_str);
 	}
 
 	return 0;
@@ -227,7 +227,7 @@ static void add_iid_address(struct net_if *iface, uint8_t *iid)
 	ifaddr = net_if_ipv6_addr_add(iface, &addr, NET_ADDR_AUTOCONF, 0);
 	if (!ifaddr) {
 		NET_ERR("Cannot add %s address to interface %p",
-			log_strdup(net_sprint_ipv6_addr(&addr)), iface);
+			net_sprint_ipv6_addr(&addr), iface);
 	} else {
 		/* As DAD is disabled, we need to mark the address
 		 * as a preferred one.
@@ -271,8 +271,7 @@ static void ipv6cp_up(struct ppp_fsm *fsm)
 	if (!nbr) {
 		NET_ERR("[%s/%p] Cannot add peer %s to nbr table",
 			fsm->name, fsm,
-			log_strdup(net_sprint_addr(AF_INET6,
-						   (const void *)&peer_addr)));
+			net_sprint_addr(AF_INET6, (const void *)&peer_addr));
 	} else {
 		if (CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG) {
 			uint8_t iid_str[sizeof("xx:xx:xx:xx:xx:xx:xx:xx")];
@@ -287,8 +286,8 @@ static void ipv6cp_up(struct ppp_fsm *fsm)
 						 sizeof(dst));
 
 			NET_DBG("[%s/%p] Peer %s [%s] %s nbr cache",
-				fsm->name, fsm, log_strdup(addr_str),
-				log_strdup(iid_str), "added to");
+				fsm->name, fsm, addr_str,
+				iid_str, "added to");
 		}
 	}
 }
@@ -327,8 +326,7 @@ static void ipv6cp_down(struct ppp_fsm *fsm)
 	if (!ret) {
 		NET_ERR("[%s/%p] Cannot rm peer %s from nbr table",
 			fsm->name, fsm,
-			log_strdup(net_sprint_addr(AF_INET6,
-						   (const void *)&peer_addr)));
+			net_sprint_addr(AF_INET6, (const void *)&peer_addr));
 	} else {
 		if (CONFIG_NET_L2_PPP_LOG_LEVEL >= LOG_LEVEL_DBG) {
 			uint8_t iid_str[sizeof("xx:xx:xx:xx:xx:xx:xx:xx")];
@@ -343,8 +341,8 @@ static void ipv6cp_down(struct ppp_fsm *fsm)
 						 sizeof(dst));
 
 			NET_DBG("[%s/%p] Peer %s [%s] %s nbr cache",
-				fsm->name, fsm, log_strdup(addr_str),
-				log_strdup(iid_str), "removed from");
+				fsm->name, fsm, addr_str,
+				iid_str, "removed from");
 		}
 	}
 }

--- a/subsys/net/l2/virtual/ipip/ipip.c
+++ b/subsys/net/l2/virtual/ipip/ipip.c
@@ -415,7 +415,7 @@ static int interface_attach(struct net_if *iface, struct net_if *lower_iface)
 					      0);
 		if (!ifaddr) {
 			NET_ERR("Cannot add %s address to interface %p",
-				log_strdup(net_sprint_ipv6_addr(&iid)),
+				net_sprint_ipv6_addr(&iid),
 				iface);
 		}
 	}
@@ -456,7 +456,7 @@ static int interface_set_config(struct net_if *iface,
 
 			NET_DBG("Interface %d peer address %s attached to %d",
 				net_if_get_by_iface(iface),
-				log_strdup(addr_str),
+				addr_str,
 				net_if_get_by_iface(ctx->attached_to));
 
 			ctx->my4addr = NULL;
@@ -485,7 +485,7 @@ static int interface_set_config(struct net_if *iface,
 
 			NET_DBG("Interface %d peer address %s attached to %d",
 				net_if_get_by_iface(iface),
-				log_strdup(addr_str),
+				addr_str,
 				net_if_get_by_iface(ctx->attached_to));
 
 			ctx->my6addr = NULL;

--- a/subsys/net/lib/capture/capture.c
+++ b/subsys/net/lib/capture/capture.c
@@ -194,7 +194,7 @@ static int setup_iface(struct net_if *iface, const char *ipaddr,
 
 	if (!net_ipaddr_parse(ipaddr, strlen(ipaddr), addr)) {
 		NET_ERR("Tunnel local address \"%s\" invalid.",
-			log_strdup(ipaddr));
+			ipaddr);
 		return -EINVAL;
 	}
 
@@ -207,7 +207,7 @@ static int setup_iface(struct net_if *iface, const char *ipaddr,
 					      NET_ADDR_MANUAL, 0);
 		if (!ifaddr) {
 			NET_ERR("Cannot add %s to interface %d",
-				log_strdup(ipaddr), net_if_get_by_iface(iface));
+				ipaddr, net_if_get_by_iface(iface));
 			return -EINVAL;
 		}
 
@@ -223,7 +223,7 @@ static int setup_iface(struct net_if *iface, const char *ipaddr,
 					      NET_ADDR_MANUAL, 0);
 		if (!ifaddr) {
 			NET_ERR("Cannot add %s to interface %d",
-				log_strdup(ipaddr), net_if_get_by_iface(iface));
+				ipaddr, net_if_get_by_iface(iface));
 			return -EINVAL;
 		}
 
@@ -248,8 +248,7 @@ static int cleanup_iface(struct net_if *iface, struct sockaddr *addr)
 		ret = net_if_ipv6_addr_rm(iface, &net_sin6(addr)->sin6_addr);
 		if (!ret) {
 			NET_ERR("Cannot remove %s from interface %d",
-				log_strdup(net_sprint_ipv6_addr(
-						  &net_sin6(addr)->sin6_addr)),
+				net_sprint_ipv6_addr(&net_sin6(addr)->sin6_addr),
 				net_if_get_by_iface(iface));
 			ret = -EINVAL;
 		}
@@ -260,8 +259,7 @@ static int cleanup_iface(struct net_if *iface, struct sockaddr *addr)
 		ret = net_if_ipv4_addr_rm(iface, &net_sin(addr)->sin_addr);
 		if (!ret) {
 			NET_ERR("Cannot remove %s from interface %d",
-				log_strdup(net_sprint_ipv4_addr(
-						  &net_sin(addr)->sin_addr)),
+				net_sprint_ipv4_addr(&net_sin(addr)->sin_addr),
 				net_if_get_by_iface(iface));
 		}
 

--- a/subsys/net/lib/config/init.c
+++ b/subsys/net/lib/config/init.c
@@ -76,19 +76,19 @@ static void ipv4_addr_add_handler(struct net_mgmt_event_callback *cb,
 
 #if CONFIG_NET_CONFIG_LOG_LEVEL >= LOG_LEVEL_INF
 		NET_INFO("IPv4 address: %s",
-			 log_strdup(net_addr_ntop(AF_INET,
-						  &if_addr->address.in_addr,
-						  hr_addr, sizeof(hr_addr))));
+			 net_addr_ntop(AF_INET,
+					&if_addr->address.in_addr,
+					hr_addr, sizeof(hr_addr)));
 		NET_INFO("Lease time: %u seconds",
 			 iface->config.dhcpv4.lease_time);
 		NET_INFO("Subnet: %s",
-			 log_strdup(net_addr_ntop(AF_INET,
+			 net_addr_ntop(AF_INET,
 				       &iface->config.ip.ipv4->netmask,
-				       hr_addr, sizeof(hr_addr))));
+				       hr_addr, sizeof(hr_addr)));
 		NET_INFO("Router: %s",
-			 log_strdup(net_addr_ntop(AF_INET,
-						  &iface->config.ip.ipv4->gw,
-						  hr_addr, sizeof(hr_addr))));
+			 net_addr_ntop(AF_INET,
+					&iface->config.ip.ipv4->gw,
+					hr_addr, sizeof(hr_addr)));
 #endif
 		break;
 	}
@@ -153,8 +153,7 @@ static void setup_ipv4(struct net_if *iface)
 
 #if CONFIG_NET_CONFIG_LOG_LEVEL >= LOG_LEVEL_INF
 	NET_INFO("IPv4 address: %s",
-		 log_strdup(net_addr_ntop(AF_INET, &addr, hr_addr,
-					  sizeof(hr_addr))));
+		 net_addr_ntop(AF_INET, &addr, hr_addr, sizeof(hr_addr)));
 #endif
 
 	if (sizeof(CONFIG_NET_CONFIG_MY_IPV4_NETMASK) > 1) {
@@ -232,8 +231,7 @@ static void ipv6_event_handler(struct net_mgmt_event_callback *cb,
 
 #if CONFIG_NET_CONFIG_LOG_LEVEL >= LOG_LEVEL_INF
 		NET_INFO("IPv6 address: %s",
-			 log_strdup(net_addr_ntop(AF_INET6, &laddr, hr_addr,
-						  NET_IPV6_ADDR_LEN)));
+			 net_addr_ntop(AF_INET6, &laddr, hr_addr, NET_IPV6_ADDR_LEN));
 #endif
 
 		services_notify_ready(NET_CONFIG_NEED_IPV6);
@@ -344,7 +342,7 @@ int net_config_init_by_iface(struct net_if *iface, const char *app_info,
 	int count;
 
 	if (app_info) {
-		NET_INFO("%s", log_strdup(app_info));
+		NET_INFO("%s", app_info);
 	}
 
 	if (!iface) {

--- a/subsys/net/lib/dns/llmnr_responder.c
+++ b/subsys/net/lib/dns/llmnr_responder.c
@@ -427,10 +427,8 @@ static int send_response(struct net_context *ctx, struct net_pkt *pkt,
 	if (ret < 0) {
 		NET_DBG("Cannot send LLMNR reply to %s (%d)",
 			net_pkt_family(pkt) == AF_INET ?
-			log_strdup(net_sprint_ipv4_addr(
-					   &net_sin(&dst)->sin_addr)) :
-			log_strdup(net_sprint_ipv6_addr(
-					   &net_sin6(&dst)->sin6_addr)),
+			net_sprint_ipv4_addr(&net_sin(&dst)->sin_addr) :
+			net_sprint_ipv6_addr(&net_sin6(&dst)->sin6_addr),
 			ret);
 	}
 
@@ -485,8 +483,8 @@ static int dns_read(struct net_context *ctx,
 	NET_DBG("Received %d %s from %s (id 0x%04x)", queries,
 		queries > 1 ? "queries" : "query",
 		net_pkt_family(pkt) == AF_INET ?
-		log_strdup(net_sprint_ipv4_addr(&ip_hdr->ipv4->src)) :
-		log_strdup(net_sprint_ipv6_addr(&ip_hdr->ipv6->src)),
+		net_sprint_ipv4_addr(&ip_hdr->ipv4->src) :
+		net_sprint_ipv6_addr(&ip_hdr->ipv6->src),
 		dns_id);
 
 	do {
@@ -503,13 +501,13 @@ static int dns_read(struct net_context *ctx,
 
 		NET_DBG("[%d] query %s/%s label %s (%d bytes)", queries,
 			qtype == DNS_RR_TYPE_A ? "A" : "AAAA", "IN",
-			log_strdup(result->data), ret);
+			result->data, ret);
 
 		/* If the query matches to our hostname, then send reply */
 		if (!strncasecmp(hostname, result->data + 1, hostname_len) &&
 		    (result->len - 1) >= hostname_len) {
 			NET_DBG("LLMNR query to our hostname %s",
-				log_strdup(hostname));
+				hostname);
 			ret = send_response(ctx, pkt, ip_hdr, result, qtype,
 					    dns_id);
 			if (ret < 0) {
@@ -576,7 +574,7 @@ static void iface_ipv6_cb(struct net_if *iface, void *user_data)
 	ret = net_ipv6_mld_join(iface, addr);
 	if (ret < 0) {
 		NET_DBG("Cannot join %s IPv6 multicast group (%d)",
-			log_strdup(net_sprint_ipv6_addr(addr)), ret);
+			net_sprint_ipv6_addr(addr), ret);
 	}
 }
 

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -484,8 +484,8 @@ static int dns_read(struct net_context *ctx,
 	NET_DBG("Received %d %s from %s", queries,
 		queries > 1 ? "queries" : "query",
 		net_pkt_family(pkt) == AF_INET ?
-		log_strdup(net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src)) :
-		log_strdup(net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src)));
+		net_sprint_ipv4_addr(&NET_IPV4_HDR(pkt)->src) :
+		net_sprint_ipv6_addr(&NET_IPV6_HDR(pkt)->src));
 
 	do {
 		enum dns_rr_type qtype;
@@ -508,7 +508,7 @@ static int dns_read(struct net_context *ctx,
 
 		NET_DBG("[%d] query %s/%s label %s (%d bytes)", queries,
 			qtype_to_string(qtype), "IN",
-			log_strdup(result->data), ret);
+			result->data, ret);
 
 		/* If the query matches to our hostname, then send reply.
 		 * We skip the first dot, and make sure there is dot after
@@ -518,7 +518,7 @@ static int dns_read(struct net_context *ctx,
 		    (result->len - 1) >= hostname_len &&
 		    &(result->data + 1)[hostname_len] == lquery) {
 			NET_DBG("mDNS query to our hostname %s.local",
-				log_strdup(hostname));
+				hostname);
 			send_response(ctx, pkt, ip_hdr, result, qtype);
 		} else if (IS_ENABLED(CONFIG_MDNS_RESPONDER_DNS_SD)
 			&& qtype == DNS_RR_TYPE_PTR) {
@@ -585,7 +585,7 @@ static void iface_ipv6_cb(struct net_if *iface, void *user_data)
 	ret = net_ipv6_mld_join(iface, addr);
 	if (ret < 0) {
 		NET_DBG("Cannot join %s IPv6 multicast group (%d)",
-			log_strdup(net_sprint_ipv6_addr(addr)), ret);
+			net_sprint_ipv6_addr(addr), ret);
 	}
 }
 

--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -229,7 +229,7 @@ static int dns_resolve_init_locked(struct dns_resolve_context *ctx,
 
 			dns_postprocess_server(ctx, idx);
 
-			NET_DBG("[%d] %s%s%s", i, log_strdup(servers[i]),
+			NET_DBG("[%d] %s%s%s", i, servers[i],
 				IS_ENABLED(CONFIG_MDNS_RESOLVER) ?
 				(ctx->servers[i].is_mdns ? " mDNS" : "") : "",
 				IS_ENABLED(CONFIG_LLMNR_RESOLVER) ?
@@ -992,7 +992,7 @@ static int dns_resolve_cancel_with_hash(struct dns_resolve_context *ctx,
 	}
 
 	NET_DBG("Cancelling DNS req %u (name %s type %d hash %u)", dns_id,
-		log_strdup(query_name), ctx->queries[i].query_type,
+		query_name, ctx->queries[i].query_type,
 		query_hash);
 
 	dns_resolve_cancel_slot(ctx, i);

--- a/subsys/net/lib/http/http_client.c
+++ b/subsys/net/lib/http/http_client.c
@@ -148,7 +148,7 @@ static void print_header_field(size_t len, const char *str)
 
 		snprintk(output, len + 1, "%s", str);
 
-		NET_DBG("[%zd] %s", len, log_strdup(output));
+		NET_DBG("[%zd] %s", len, output);
 	}
 }
 
@@ -181,7 +181,7 @@ static int on_status(struct http_parser *parser, const char *at, size_t length)
 		(uint16_t)parser->status_code;
 
 	NET_DBG("HTTP response status %d %s", parser->status_code,
-		log_strdup(req->internal.response.http_status));
+		req->internal.response.http_status);
 
 	if (req->internal.response.http_cb &&
 	    req->internal.response.http_cb->on_status) {

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -703,8 +703,8 @@ static void engine_observe_node_init(struct observe_node *obs, const uint8_t *to
 		}
 	}
 
-	LOG_DBG("token:'%s' addr:%s", log_strdup(sprint_token(token, tkl)),
-		log_strdup(lwm2m_sprint_ip_addr(&ctx->remote_addr)));
+	LOG_DBG("token:'%s' addr:%s", sprint_token(token, tkl),
+		lwm2m_sprint_ip_addr(&ctx->remote_addr));
 }
 
 static void remove_observer_path_from_list(struct lwm2m_ctx *ctx, struct observe_node *obs,
@@ -712,7 +712,7 @@ static void remove_observer_path_from_list(struct lwm2m_ctx *ctx, struct observe
 {
 	char buf[LWM2M_MAX_PATH_STR_LEN];
 
-	LOG_DBG("Removing observer %p for path %s", obs, lwm2m_path_log_strdup(buf, &o_p->path));
+	LOG_DBG("Removing observer %p for path %s", obs, lwm2m_path_log_buf(buf, &o_p->path));
 	if (ctx->observe_cb) {
 		ctx->observe_cb(LWM2M_OBSERVE_EVENT_OBSERVER_REMOVED, &o_p->path, NULL);
 	}
@@ -851,7 +851,7 @@ static int engine_add_observer(struct lwm2m_message *msg,
 
 		LOG_DBG("OBSERVER DUPLICATE %u/%u/%u(%u) [%s]", msg->path.obj_id,
 			msg->path.obj_inst_id, msg->path.res_id, msg->path.level,
-			log_strdup(lwm2m_sprint_ip_addr(&msg->ctx->remote_addr)));
+			lwm2m_sprint_ip_addr(&msg->ctx->remote_addr));
 
 		return 0;
 	}
@@ -912,7 +912,7 @@ static int engine_add_composite_observer(struct lwm2m_message *msg,
 		obs->tkl = tkl;
 
 		LOG_DBG("OBSERVER Composite DUPLICATE [%s]",
-			log_strdup(lwm2m_sprint_ip_addr(&msg->ctx->remote_addr)));
+			lwm2m_sprint_ip_addr(&msg->ctx->remote_addr));
 
 		return do_composite_read_op_for_parsed_list(msg, format, &lwm2m_path_list);
 	}
@@ -960,7 +960,7 @@ static int engine_remove_observer_by_token(struct lwm2m_ctx *ctx, const uint8_t 
 
 	remove_observer_from_list(ctx, prev_node, obs);
 
-	LOG_DBG("observer '%s' removed", log_strdup(sprint_token(token, tkl)));
+	LOG_DBG("observer '%s' removed", sprint_token(token, tkl));
 
 	return 0;
 }
@@ -999,20 +999,20 @@ static int engine_remove_composite_observer(struct lwm2m_message *msg, const uin
 
 	remove_observer_from_list(msg->ctx, prev_node, obs);
 
-	LOG_DBG("observer '%s' removed", log_strdup(sprint_token(token, tkl)));
+	LOG_DBG("observer '%s' removed", sprint_token(token, tkl));
 
 	return do_composite_read_op_for_parsed_list(msg, format, &lwm2m_path_list);
 
 }
 
 #if defined(CONFIG_LOG)
-char *lwm2m_path_log_strdup(char *buf, struct lwm2m_obj_path *path)
+char *lwm2m_path_log_buf(char *buf, struct lwm2m_obj_path *path)
 {
 	size_t cur;
 
 	if (!path) {
 		sprintf(buf, "/");
-		return log_strdup(buf);
+		return buf;
 	}
 
 	cur = sprintf(buf, "%u", path->obj_id);
@@ -1027,7 +1027,7 @@ char *lwm2m_path_log_strdup(char *buf, struct lwm2m_obj_path *path)
 		cur += sprintf(buf + cur, "/%u", path->res_inst_id);
 	}
 
-	return log_strdup(buf);
+	return buf;
 }
 #endif /* CONFIG_LOG */
 
@@ -1052,7 +1052,7 @@ static int engine_remove_observer_by_path(struct lwm2m_ctx *ctx,
 	}
 
 	LOG_INF("Removing observer for path %s",
-		lwm2m_path_log_strdup(buf, path));
+		lwm2m_path_log_buf(buf, path));
 
 	remove_observer_from_list(ctx, prev_node, obs);
 
@@ -1108,8 +1108,8 @@ static struct lwm2m_engine_obj *get_engine_obj(int obj_id)
 	return NULL;
 }
 
-struct lwm2m_engine_obj_field *
-lwm2m_get_engine_obj_field(struct lwm2m_engine_obj *obj, int res_id)
+struct lwm2m_engine_obj_field *lwm2m_get_engine_obj_field(struct lwm2m_engine_obj *obj,
+							  int res_id)
 {
 	int i;
 
@@ -1895,7 +1895,7 @@ int lwm2m_engine_create_obj_inst(const char *pathstr)
 	struct lwm2m_engine_obj_inst *obj_inst;
 	int ret = 0;
 
-	LOG_DBG("path:%s", log_strdup(pathstr));
+	LOG_DBG("path:%s", pathstr);
 
 	/* translate path -> path_obj */
 	ret = lwm2m_string_to_path(pathstr, &path, '/');
@@ -1925,7 +1925,7 @@ int lwm2m_engine_delete_obj_inst(const char *pathstr)
 	struct lwm2m_obj_path path;
 	int ret = 0;
 
-	LOG_DBG("path: %s", log_strdup(pathstr));
+	LOG_DBG("path: %s", pathstr);
 
 	/* translate path -> path_obj */
 	ret = lwm2m_string_to_path(pathstr, &path, '/');
@@ -2006,7 +2006,7 @@ static int lwm2m_engine_set(const char *pathstr, void *value, uint16_t len)
 	int ret = 0;
 	bool changed = false;
 
-	LOG_DBG("path:%s, value:%p, len:%d", log_strdup(pathstr), value, len);
+	LOG_DBG("path:%s, value:%p, len:%d", pathstr, value, len);
 
 	/* translate path -> path_obj */
 	ret = lwm2m_string_to_path(pathstr, &path, '/');
@@ -2299,7 +2299,7 @@ static int lwm2m_engine_get(const char *pathstr, void *buf, uint16_t buflen)
 	void *data_ptr = NULL;
 	size_t data_len = 0;
 
-	LOG_DBG("path:%s, buf:%p, buflen:%d", log_strdup(pathstr), buf, buflen);
+	LOG_DBG("path:%s, buf:%p, buflen:%d", pathstr, buf, buflen);
 
 	/* translate path -> path_obj */
 	ret = lwm2m_string_to_path(pathstr, &path, '/');
@@ -2511,11 +2511,11 @@ static int lwm2m_update_or_allocate_attribute(void *ref, uint8_t type, void *dat
 
 		if (type <= LWM2M_ATTR_PMAX) {
 			attr->int_val = *(int32_t *)data;
-			LOG_DBG("Update %s to %d", log_strdup(LWM2M_ATTR_STR[type]),
+			LOG_DBG("Update %s to %d", LWM2M_ATTR_STR[type],
 				attr->int_val);
 		} else {
 			attr->float_val = *(double *)data;
-			LOG_DBG("Update %s to %f", log_strdup(LWM2M_ATTR_STR[type]),
+			LOG_DBG("Update %s to %f", LWM2M_ATTR_STR[type],
 				attr->float_val);
 		}
 		return 0;
@@ -2539,10 +2539,10 @@ static int lwm2m_update_or_allocate_attribute(void *ref, uint8_t type, void *dat
 
 	if (type <= LWM2M_ATTR_PMAX) {
 		attr->int_val = *(int32_t *)data;
-		LOG_DBG("Add %s to %d", log_strdup(LWM2M_ATTR_STR[type]), attr->int_val);
+		LOG_DBG("Add %s to %d", LWM2M_ATTR_STR[type], attr->int_val);
 	} else {
 		attr->float_val = *(double *)data;
-		LOG_DBG("Add %s to %f", log_strdup(LWM2M_ATTR_STR[type]), attr->float_val);
+		LOG_DBG("Add %s to %f", LWM2M_ATTR_STR[type], attr->float_val);
 	}
 	return 0;
 }
@@ -3661,7 +3661,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 
 		if (ret < 0) {
 			LOG_ERR("invalid attr[%s] value",
-				log_strdup(LWM2M_ATTR_STR[type]));
+				LWM2M_ATTR_STR[type]);
 			/* bad request */
 			return -EEXIST;
 		}
@@ -3709,7 +3709,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 
 		if (!(BIT(type) & nattrs.flags)) {
 			LOG_DBG("Unset attr %s",
-				log_strdup(LWM2M_ATTR_STR[type]));
+				LWM2M_ATTR_STR[type]);
 			(void)memset(attr, 0, sizeof(*attr));
 
 			if (type <= LWM2M_ATTR_PMAX) {
@@ -3729,7 +3729,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 			attr->int_val = *(int32_t *)nattr_ptrs[type];
 			update_observe_node = true;
 
-			LOG_DBG("Update %s to %d", log_strdup(LWM2M_ATTR_STR[type]),
+			LOG_DBG("Update %s to %d", LWM2M_ATTR_STR[type],
 				attr->int_val);
 		} else {
 			if (attr->float_val == *(double *)nattr_ptrs[type]) {
@@ -3738,7 +3738,7 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 
 			attr->float_val = *(double *)nattr_ptrs[type];
 
-			LOG_DBG("Update %s to %f", log_strdup(LWM2M_ATTR_STR[type]),
+			LOG_DBG("Update %s to %f", LWM2M_ATTR_STR[type],
 				attr->float_val);
 		}
 	}
@@ -3768,12 +3768,12 @@ static int lwm2m_write_attr_handler(struct lwm2m_engine_obj *obj,
 			attr->int_val = *(int32_t *)nattr_ptrs[type];
 			update_observe_node = true;
 
-			LOG_DBG("Add %s to %d", log_strdup(LWM2M_ATTR_STR[type]),
+			LOG_DBG("Add %s to %d", LWM2M_ATTR_STR[type],
 				attr->int_val);
 		} else {
 			attr->float_val = *(double *)nattr_ptrs[type];
 
-			LOG_DBG("Add %s to %f", log_strdup(LWM2M_ATTR_STR[type]),
+			LOG_DBG("Add %s to %f", LWM2M_ATTR_STR[type],
 				attr->float_val);
 		}
 
@@ -5174,7 +5174,7 @@ static void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx,
 	}
 
 	LOG_DBG("checking for reply from [%s]",
-		log_strdup(lwm2m_sprint_ip_addr(from_addr)));
+		lwm2m_sprint_ip_addr(from_addr));
 	reply = coap_response_received(&response, from_addr,
 				       client_ctx->replies,
 				       ARRAY_SIZE(client_ctx->replies));
@@ -5344,7 +5344,7 @@ static int notify_message_reply_cb(const struct coap_packet *response,
 		type,
 		COAP_RESPONSE_CODE_CLASS(code),
 		COAP_RESPONSE_CODE_DETAIL(code),
-		log_strdup(sprint_token(reply->token, reply->tkl)));
+		sprint_token(reply->token, reply->tkl));
 
 	msg = find_msg(NULL, reply);
 
@@ -5402,8 +5402,8 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 		memcpy(&msg->path, path, sizeof(struct lwm2m_obj_path));
 		LOG_DBG("[%s] NOTIFY MSG START: %u/%u/%u(%u) token:'%s' [%s] %lld",
 			obs->resource_update ? "MANUAL" : "AUTO", path->obj_id, path->obj_inst_id,
-			path->res_id, path->level, log_strdup(sprint_token(obs->token, obs->tkl)),
-			log_strdup(lwm2m_sprint_ip_addr(&ctx->remote_addr)),
+			path->res_id, path->level, sprint_token(obs->token, obs->tkl),
+			lwm2m_sprint_ip_addr(&ctx->remote_addr),
 			(long long)k_uptime_get());
 
 		obj_inst = get_engine_obj_inst(path->obj_id, path->obj_inst_id);
@@ -5416,8 +5416,8 @@ static int generate_notify_message(struct lwm2m_ctx *ctx,
 	} else {
 		LOG_DBG("[%s] NOTIFY MSG START: (Composite)) token:'%s' [%s] %lld",
 		obs->resource_update ? "MANUAL" : "AUTO",
-		log_strdup(sprint_token(obs->token, obs->tkl)),
-		log_strdup(lwm2m_sprint_ip_addr(&ctx->remote_addr)),
+		sprint_token(obs->token, obs->tkl),
+		lwm2m_sprint_ip_addr(&ctx->remote_addr),
 		(long long)k_uptime_get());
 	}
 
@@ -5881,7 +5881,7 @@ static int load_tls_credential(struct lwm2m_ctx *client_ctx, uint16_t res_id,
 	ret = lwm2m_engine_get_res_buf(pathstr, &cred, NULL, &cred_len, &cred_flags);
 	if (ret < 0) {
 		LOG_ERR("Unable to get resource data for '%s'",
-			log_strdup(pathstr));
+			pathstr);
 		return ret;
 	}
 
@@ -6043,12 +6043,12 @@ int lwm2m_parse_peerinfo(char *url, struct lwm2m_ctx *client_ctx, bool is_firmwa
 	uint16_t off, len;
 	uint8_t tmp;
 
-	LOG_DBG("Parse url: %s", log_strdup(url));
+	LOG_DBG("Parse url: %s", url);
 
 	http_parser_url_init(&parser);
 	ret = http_parser_parse_url(url, strlen(url), 0, &parser);
 	if (ret < 0) {
-		LOG_ERR("Invalid url: %s", log_strdup(url));
+		LOG_ERR("Invalid url: %s", url);
 		return -ENOTSUP;
 	}
 

--- a/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_firmware.c
@@ -287,7 +287,7 @@ static int package_uri_write_cb(uint16_t obj_inst_id, uint16_t res_id,
 				uint16_t res_inst_id, uint8_t *data, uint16_t data_len,
 				bool last_block, size_t total_size)
 {
-	LOG_DBG("PACKAGE_URI WRITE: %s", log_strdup(package_uri[obj_inst_id]));
+	LOG_DBG("PACKAGE_URI WRITE: %s", package_uri[obj_inst_id]);
 
 #ifdef CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_SUPPORT
 	uint8_t state = lwm2m_firmware_get_update_state_inst(obj_inst_id);

--- a/subsys/net/lib/lwm2m/lwm2m_pull_context.c
+++ b/subsys/net/lib/lwm2m/lwm2m_pull_context.c
@@ -105,14 +105,14 @@ static int transfer_request(struct coap_block_context *ctx, uint8_t *token, uint
 
 	ret = coap_packet_append_option(&msg->cpkt, COAP_OPTION_URI_PATH, cursor, strlen(cursor));
 	if (ret < 0) {
-		LOG_ERR("Error adding URI_PATH '%s'", log_strdup(cursor));
+		LOG_ERR("Error adding URI_PATH '%s'", cursor);
 		goto cleanup;
 	}
 #else
 	http_parser_url_init(&parser);
 	ret = http_parser_parse_url(context.uri, strlen(context.uri), 0, &parser);
 	if (ret < 0) {
-		LOG_ERR("Invalid firmware url: %s", log_strdup(context.uri));
+		LOG_ERR("Invalid firmware url: %s", context.uri);
 		ret = -ENOTSUP;
 		goto cleanup;
 	}
@@ -158,7 +158,7 @@ static int transfer_request(struct coap_block_context *ctx, uint8_t *token, uint
 	ret = coap_packet_append_option(&msg->cpkt, COAP_OPTION_PROXY_URI, context.uri,
 					strlen(context.uri));
 	if (ret < 0) {
-		LOG_ERR("Error adding PROXY_URI '%s'", log_strdup(context.uri));
+		LOG_ERR("Error adding PROXY_URI '%s'", context.uri);
 		goto cleanup;
 	}
 #else
@@ -352,7 +352,7 @@ static void firmware_transfer(void)
 #if defined(CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_SUPPORT)
 	server_addr = CONFIG_LWM2M_FIRMWARE_UPDATE_PULL_COAP_PROXY_ADDR;
 	if (strlen(server_addr) >= LWM2M_PACKAGE_URI_LEN) {
-		LOG_ERR("Invalid Proxy URI: %s", log_strdup(server_addr));
+		LOG_ERR("Invalid Proxy URI: %s", server_addr);
 		ret = -ENOTSUP;
 		goto error;
 	}
@@ -377,7 +377,7 @@ static void firmware_transfer(void)
 		goto error;
 	}
 
-	LOG_INF("Connecting to server %s", log_strdup(context.uri));
+	LOG_INF("Connecting to server %s", context.uri);
 
 	/* reset block transfer context */
 	coap_block_transfer_init(&context.block_ctx, lwm2m_default_block_size(), 0);

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -418,7 +418,7 @@ static int do_registration_reply_cb(const struct coap_packet *response,
 		client.server_ep[options[1].len] = '\0';
 		set_sm_state(ENGINE_REGISTRATION_DONE);
 		LOG_INF("Registration Done (EP='%s')",
-			log_strdup(client.server_ep));
+			client.server_ep);
 
 		return 0;
 	}
@@ -682,7 +682,7 @@ static int sm_send_bootstrap_registration(void)
 
 	/* log the bootstrap attempt */
 	LOG_DBG("Register ID with bootstrap server as '%s'",
-		log_strdup(query_buffer));
+		query_buffer);
 
 	lwm2m_send_message_async(msg);
 
@@ -713,7 +713,7 @@ static int sm_do_bootstrap_reg(void)
 	}
 
 	LOG_INF("Bootstrap started with endpoint '%s' with client lifetime %d",
-		log_strdup(client.ep_name), client.lifetime);
+		client.ep_name, client.lifetime);
 
 	ret = lwm2m_engine_start(client.ctx);
 	if (ret < 0) {
@@ -890,7 +890,7 @@ static int sm_send_registration(bool send_obj_support_data,
 
 	/* log the registration attempt */
 	LOG_DBG("registration sent [%s]",
-		log_strdup(lwm2m_sprint_ip_addr(&client.ctx->remote_addr)));
+		lwm2m_sprint_ip_addr(&client.ctx->remote_addr));
 
 	return 0;
 
@@ -943,7 +943,7 @@ static int sm_do_registration(void)
 	}
 
 	LOG_INF("RD Client started with endpoint '%s' with client lifetime %d",
-		log_strdup(client.ep_name), client.lifetime);
+		client.ep_name, client.lifetime);
 
 	ret = lwm2m_engine_start(client.ctx);
 	if (ret < 0) {
@@ -1055,7 +1055,7 @@ static int sm_do_deregister(void)
 		goto cleanup;
 	}
 
-	LOG_INF("Deregister from '%s'", log_strdup(client.server_ep));
+	LOG_INF("Deregister from '%s'", client.server_ep);
 
 	lwm2m_send_message_async(msg);
 
@@ -1195,7 +1195,7 @@ int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 	set_sm_state(ENGINE_INIT);
 	strncpy(client.ep_name, ep_name, CLIENT_EP_LEN - 1);
 	client.ep_name[CLIENT_EP_LEN - 1] = '\0';
-	LOG_INF("Start LWM2M Client: %s", log_strdup(client.ep_name));
+	LOG_INF("Start LWM2M Client: %s", client.ep_name);
 
 	k_mutex_unlock(&client.mutex);
 	return 0;
@@ -1220,7 +1220,7 @@ int lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 		set_sm_state(ENGINE_DEREGISTERED);
 	}
 
-	LOG_INF("Stop LWM2M Client: %s", log_strdup(client.ep_name));
+	LOG_INF("Stop LWM2M Client: %s", client.ep_name);
 
 	k_mutex_unlock(&client.mutex);
 

--- a/subsys/net/lib/openthread/platform/settings.c
+++ b/subsys/net/lib/openthread/platform/settings.c
@@ -54,11 +54,11 @@ static int ot_setting_delete_cb(const char *key, size_t len,
 		       key ? "/" : "", key ? key : "");
 	__ASSERT(ret < sizeof(path), "Setting path buffer too small.");
 
-	LOG_DBG("Removing: %s", log_strdup(path));
+	LOG_DBG("Removing: %s", path);
 
 	ret = settings_delete(path);
 	if (ret != 0) {
-		LOG_ERR("Failed to remove setting %s, ret %d", log_strdup(path),
+		LOG_ERR("Failed to remove setting %s, ret %d", path,
 			ret);
 		__ASSERT_NO_MSG(false);
 	}

--- a/subsys/net/lib/sockets/sockets_tls.c
+++ b/subsys/net/lib/sockets/sockets_tls.c
@@ -256,7 +256,7 @@ static void tls_debug(void *ctx, int level, const char *file,
 	}
 
 	NET_DBG("%s:%04d: |%d| %s", basename, line, level,
-		log_strdup(str));
+		str);
 }
 #endif /* defined(MBEDTLS_DEBUG_C) && (CONFIG_NET_SOCKETS_LOG_LEVEL >= LOG_LEVEL_DBG) */
 

--- a/subsys/net/lib/tftp/tftp_client.c
+++ b/subsys/net/lib/tftp/tftp_client.c
@@ -103,7 +103,7 @@ static int tftp_send_request(int sock, struct sockaddr *server_addr,
 		tx_count++;
 
 		LOG_DBG("Sending TFTP request %d file %s", request,
-			log_strdup(remote_file));
+			remote_file);
 
 		/* Send the request to the server */
 		ret = sendto(sock, tftpc_buffer, req_size, 0, server_addr,

--- a/subsys/settings/src/settings.c
+++ b/subsys/settings/src/settings.c
@@ -218,12 +218,12 @@ int settings_call_set_handler(const char *name,
 
 		if (rc != 0) {
 			LOG_ERR("set-value failure. key: %s error(%d)",
-				log_strdup(name), rc);
+				name, rc);
 			/* Ignoring the error */
 			rc = 0;
 		} else {
 			LOG_DBG("set-value OK. key: %s",
-				log_strdup(name));
+				name);
 		}
 	}
 	return rc;

--- a/subsys/shell/backends/shell_mqtt.c
+++ b/subsys/shell/backends/shell_mqtt.c
@@ -335,8 +335,8 @@ static void sh_mqtt_subscribe_handler(struct k_work *work)
 		(void)sh_mqtt_work_reschedule(&sh_mqtt->process_dwork, PROCESS_INTERVAL);
 		sh_mqtt_context_unlock();
 
-		LOG_INF("Logs will be published to: %s", log_strdup(sh_mqtt->pub_topic));
-		LOG_INF("Subscribing shell cmds from: %s", log_strdup(sh_mqtt->sub_topic));
+		LOG_INF("Logs will be published to: %s", sh_mqtt->pub_topic);
+		LOG_INF("Subscribing shell cmds from: %s", sh_mqtt->sub_topic);
 
 		return;
 	}
@@ -555,7 +555,7 @@ static void mqtt_evt_handler(struct mqtt_client *const client, const struct mqtt
 
 		LOG_DBG("MQTT publish received %d, %d bytes", evt->result, payload_left);
 		LOG_DBG("   id: %d, qos: %d", pub->message_id, pub->message.topic.qos);
-		LOG_DBG("   item: %s", log_strdup(pub->message.topic.topic.utf8));
+		LOG_DBG("   item: %s", pub->message.topic.topic.utf8);
 
 		/* For MQTT_QOS_0_AT_MOST_ONCE no acknowledgment needed */
 		if (pub->message.topic.qos == MQTT_QOS_1_AT_LEAST_ONCE) {
@@ -637,7 +637,7 @@ static int init(const struct shell_transport *transport, const void *config,
 		(void)snprintf(sh_mqtt->device_id, sizeof("dummy"), "dummy");
 	}
 
-	LOG_DBG("Client ID is %s", log_strdup(sh_mqtt->device_id));
+	LOG_DBG("Client ID is %s", sh_mqtt->device_id);
 
 	(void)snprintf(sh_mqtt->pub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_tx", sh_mqtt->device_id);
 	(void)snprintf(sh_mqtt->sub_topic, SH_MQTT_TOPIC_MAX_SIZE, "%s_rx", sh_mqtt->device_id);

--- a/tests/bluetooth/tester/src/gap.c
+++ b/tests/bluetooth/tester/src/gap.c
@@ -355,7 +355,7 @@ static void oob_data_request(struct bt_conn *conn,
 	{
 		LOG_DBG("Set %s OOB SC data for %s, ",
 			oob_config_str(oob_info->lesc.oob_config),
-			log_strdup(addr));
+			addr);
 
 		struct bt_le_oob_sc_data *oobd_local =
 			oob_info->lesc.oob_config != BT_CONN_OOB_REMOTE_ONLY ?
@@ -378,7 +378,7 @@ static void oob_data_request(struct bt_conn *conn,
 		    bt_addr_le_cmp(info.le.local, &oob_sc_local.addr)) {
 			bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
 			LOG_DBG("No OOB data available for local %s",
-				log_strdup(addr));
+				addr);
 			bt_conn_auth_cancel(conn);
 			return;
 		}
@@ -394,7 +394,7 @@ static void oob_data_request(struct bt_conn *conn,
 
 #if !defined(CONFIG_BT_SMP_SC_PAIR_ONLY)
 	case BT_CONN_OOB_LE_LEGACY:
-		LOG_DBG("Legacy OOB TK requested from remote %s", log_strdup(addr));
+		LOG_DBG("Legacy OOB TK requested from remote %s", addr);
 
 		err = bt_le_oob_set_legacy_tk(conn, oob_legacy_tk);
 		if (err < 0) {

--- a/tests/bluetooth/tester/src/gatt.c
+++ b/tests/bluetooth/tester/src/gatt.c
@@ -1966,7 +1966,7 @@ static void get_attrs(uint8_t *data, uint16_t len)
 
 		bt_uuid_to_str(&uuid.uuid, uuid_str, sizeof(uuid_str));
 		LOG_DBG("start 0x%04x end 0x%04x, uuid %s", start_handle,
-			end_handle, log_strdup(uuid_str));
+			end_handle, uuid_str);
 
 		foreach.uuid = &uuid.uuid;
 	} else {

--- a/tests/bluetooth/tester/src/mesh.c
+++ b/tests/bluetooth/tester/src/mesh.c
@@ -352,7 +352,7 @@ static int output_string(const char *str)
 	struct mesh_out_string_action_ev *ev;
 	struct net_buf_simple *buf = NET_BUF_SIMPLE(BTP_DATA_MAX_SIZE);
 
-	LOG_DBG("str %s", log_strdup(str));
+	LOG_DBG("str %s", str);
 
 	net_buf_simple_init(buf, 0);
 

--- a/tests/net/socket/af_packet_ipproto_raw/src/main.c
+++ b/tests/net/socket/af_packet_ipproto_raw/src/main.c
@@ -136,7 +136,7 @@ void test_sckt_raw_packet_raw_ip(void)
 	recv_data_len = recv(sock, receive_buffer, sizeof(receive_buffer), 0);
 	zassert_true(recv_data_len == ARRAY_SIZE(testing_data), "Expected data not received");
 
-	NET_DBG("Received successfully data %s", log_strdup(receive_buffer));
+	NET_DBG("Received successfully data %s", receive_buffer);
 
 	close(sock);
 }

--- a/tests/net/socket/getaddrinfo/src/main.c
+++ b/tests/net/socket/getaddrinfo/src/main.c
@@ -85,7 +85,7 @@ static bool check_dns_query(uint8_t *buf, int buf_len)
 
 	NET_DBG("[%d] query %s/%s label %s (%d bytes)", queries,
 		qtype == DNS_RR_TYPE_A ? "A" : "AAAA", "IN",
-		log_strdup(result->data), ret);
+		result->data, ret);
 
 	/* In this test we are just checking if the query came to us in correct
 	 * form, we are not creating a DNS server implementation here.
@@ -194,13 +194,13 @@ void test_getaddrinfo_setup(void)
 	}
 
 	addr_str = inet_ntop(AF_INET, &addr_v4.sin_addr, str, sizeof(str));
-	NET_DBG("v4: [%s]:%d", log_strdup(addr_str), ntohs(addr_v4.sin_port));
+	NET_DBG("v4: [%s]:%d", addr_str, ntohs(addr_v4.sin_port));
 
 	sock_v4 = prepare_listen_sock_udp_v4(&addr_v4);
 	zassert_true(sock_v4 >= 0, "Invalid IPv4 socket");
 
 	addr_str = inet_ntop(AF_INET6, &addr_v6.sin6_addr, str, sizeof(str));
-	NET_DBG("v6: [%s]:%d", log_strdup(addr_str), ntohs(addr_v6.sin6_port));
+	NET_DBG("v6: [%s]:%d", addr_str, ntohs(addr_v6.sin6_port));
 
 	sock_v6 = prepare_listen_sock_udp_v6(&addr_v6);
 	zassert_true(sock_v6 >= 0, "Invalid IPv6 socket");

--- a/tests/net/socket/tls_ext/src/main.c
+++ b/tests/net/socket/tls_ext/src/main.c
@@ -172,7 +172,7 @@ static void server_thread_fn(void *arg0, void *arg1, void *arg2)
 	zassert_not_equal(addrstrp, NULL, "inet_ntop() failed (%d)", errno);
 
 	NET_DBG("accepted connection from [%s]:%d as fd %d",
-		log_strdup(addrstr), ntohs(sa.sin_port), client_fd);
+		addrstr, ntohs(sa.sin_port), client_fd);
 
 	NET_DBG("calling recv()");
 	r = recv(client_fd, addrstr, sizeof(addrstr), 0);
@@ -286,7 +286,7 @@ static void test_common(int peer_verify)
 	zassert_not_equal(addrstrp, NULL, "inet_ntop() failed (%d)", errno);
 
 	NET_DBG("listening on [%s]:%d as fd %d",
-		log_strdup(addrstr), ntohs(sa.sin_port), server_fd);
+		addrstr, ntohs(sa.sin_port), server_fd);
 
 	NET_DBG("Creating server thread");
 	server_thread_id = k_thread_create(&server_thread, server_stack,
@@ -360,7 +360,7 @@ static void test_common(int peer_verify)
 	zassert_not_equal(addrstrp, NULL, "inet_ntop() failed (%d)", errno);
 
 	NET_DBG("connecting to [%s]:%d with fd %d",
-		log_strdup(addrstr), ntohs(sa.sin_port), client_fd);
+		addrstr, ntohs(sa.sin_port), client_fd);
 
 	r = connect(client_fd, (struct sockaddr *)&sa, sizeof(sa));
 	zassert_not_equal(r, -1, "failed to connect (%d)", errno);

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -218,7 +218,7 @@ ZTEST(test_log_api, test_log_various_messages)
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_ERR,
 				exp_timestamp++, "err");
 
-	LOG_WRN("wrn %s", log_strdup(dstr));
+	LOG_WRN("wrn %s", dstr);
 	dstr[0] = '\0';
 
 	LOG_ERR("err");

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -218,7 +218,7 @@ ZTEST(test_log_api, test_log_various_messages)
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_ERR,
 				exp_timestamp++, "err");
 
-	LOG_WRN("wrn %s", dstr);
+	LOG_WRN("wrn %s", (char *)dstr);
 	dstr[0] = '\0';
 
 	LOG_ERR("err");

--- a/tests/subsys/logging/log_benchmark/src/main.c
+++ b/tests/subsys/logging/log_benchmark/src/main.c
@@ -214,7 +214,7 @@ void test_log_message_with_string(void)
 	int repeat = 8;
 
 	for (int i = 0; i < repeat; i++) {
-		LOG_ERR("test with string to duplicate: %s", log_strdup(strbuf));
+		LOG_ERR("test with string to duplicate: %s", strbuf);
 	}
 
 	cyc = test_helpers_cycle_get() - cyc;

--- a/west.yml
+++ b/west.yml
@@ -161,7 +161,7 @@ manifest:
       revision: 12019623bbad9eb54fe51066847a7cbd4b4eac57
       path: modules/lib/loramac-node
     - name: lvgl
-      revision: df717ac87a9fd80246cc8df24554475e59bda21f
+      revision: 07eab463f991f9ea1738a671fa81ad1e54f50ffb
       path: modules/lib/gui/lvgl
     - name: lz4
       revision: 8e303c264fc21c2116dc612658003a22e933124d


### PR DESCRIPTION
Logging v1 has been removed and log_strdup wrapper function is no
longer needed. Removing the function and its use in the tree.

Part of #46500.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>