### PR TITLE
net/tcp continue in retransmission

### DIFF
--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -1201,8 +1201,6 @@ static void tcp_resend_data(struct k_work *work)
 	conn->data_mode = TCP_DATA_MODE_RESEND;
 	conn->unacked_len = 0;
 
-	(void)k_sem_take(&conn->tx_sem, K_NO_WAIT);
-
 	ret = tcp_send_data(conn);
 	conn->send_data_retries++;
 	if (ret == 0) {
@@ -1226,10 +1224,6 @@ static void tcp_resend_data(struct k_work *work)
 		}
 	} else if (ret == -ENODATA) {
 		conn->data_mode = TCP_DATA_MODE_SEND;
-
-		if (!tcp_window_full(conn)) {
-			k_sem_give(&conn->tx_sem);
-		}
 
 		goto out;
 	} else if (ret == -ENOBUFS) {

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -2373,11 +2373,6 @@ int net_tcp_queue_data(struct net_context *context, struct net_pkt *pkt)
 		goto out;
 	}
 
-	if (conn->data_mode == TCP_DATA_MODE_RESEND) {
-		ret = -EAGAIN;
-		goto out;
-	}
-
 	len = net_pkt_get_len(pkt);
 
 	if (conn->send_data->buffer) {


### PR DESCRIPTION
Since the overfilling of the send_data has been properly fixed in the `window_full` function. It is now safe to accept data again in retransmission mode. This avoids stalling the application when the TCP socket goes into re-transmission mode.