### PR TITLE
ADXL362: fix write to FIFO_SAMPLES register

### DIFF
--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -354,7 +354,7 @@ static int adxl362_fifo_setup(const struct device *dev, uint8_t mode,
 		return ret;
 	}
 
-	ret = adxl362_set_reg(dev, water_mark_lvl, ADXL362_REG_FIFO_SAMPLES, 2);
+	ret = adxl362_set_reg(dev, water_mark_lvl, ADXL362_REG_FIFO_SAMPLES, 1);
 	if (ret) {
 		return ret;
 	}


### PR DESCRIPTION
This patch removes a superfluous write to the INTMAP1 register
that happens because the byte count was previously wrong.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>