### PR TITLE
Bluetooth: controller: llcp: fix issue re. missing release of tx nodes

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -2539,6 +2539,8 @@ static void tx_ull_flush(struct ll_conn *conn)
 #else /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 	struct node_tx *tx;
 
+	ull_tx_q_resume_data(&conn->tx_q);
+
 	tx = tx_ull_dequeue(conn, NULL);
 	while (tx) {
 		memq_link_t *link;


### PR DESCRIPTION
On disconnect with refactored LLCP, if data tx is paused,
possibly 'waiting' tx nodes would not get released. To fix resume data
before flushing

Signed-off-by: Erik Brockhoff <erbr@oticon.com>