### PR TITLE
drivers: can: stm32: fix return type missed

### DIFF
--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -89,6 +89,8 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 	}
 
 	FDCAN_CONFIG->CKDIV = CAN_STM32FD_CLOCK_DIVISOR >> 1;
+
+	return 0;
 }
 
 static int can_stm32fd_init(const struct device *dev)


### PR DESCRIPTION
the return is missing at the end of function which causes compilation
warning and block the build on github.
"warning: control reaches end of non-void function [-Wreturn-type]
   92 | }| ^"

Signed-off-by: TLIG Dhaou <dhaou.tlig-ext@st.com>