### PR TITLE
drivers: ethernet: w5500: fix the stack overflow

### DIFF
--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -544,7 +544,6 @@ static int w5500_init(const struct device *dev)
 		}
 		gpio_pin_set_dt(&config->reset, 0);
 		k_usleep(500);
-		gpio_pin_set_dt(&config->reset, 1);
 	}
 
 	err = w5500_hw_reset(dev);


### PR DESCRIPTION
It will fix #46684. add the temporary rx buffer corresponding to the L2 frame MTU instead of dynamic array. add the sanity check for the L2 frame length. it will reopen the MACRAW socket when frame length is invalid and can't recover by RX_RSR.
[Update]~~Also it changes(fixes) the disabling interrupt by writing 0 to SIMR register as datasheet.~~

Signed-off-by: Pengxiang Gao <honestech74@gmail.com>