### PR TITLE
bluetooth: smp: Verify if authentication callbacks can be updated

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1354,7 +1354,10 @@ struct bt_conn_auth_info_cb {
  *
  *  @param cb Callback struct.
  *
- *  @return Zero on success or negative error code otherwise
+ *  @retval 0		Success.
+ *  @retval -EALREADY	Callbacks are already registered.
+ *  @retval -EBUSY	Callbacks are in use and cannot be modified.
+ *  @retval -EINVAL	Invalid callback struct.
  */
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb);
 

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2810,6 +2810,10 @@ struct net_buf *bt_conn_create_frag_timeout(size_t reserve, k_timeout_t timeout)
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 {
+	if (IS_ENABLED(CONFIG_BT_SMP) && !bt_smp_auth_can_update_auth_cb()) {
+		return -EBUSY;
+	}
+
 	if (!cb) {
 		bt_auth = NULL;
 		return 0;

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -141,6 +141,7 @@ int bt_smp_br_send_pairing_req(struct bt_conn *conn);
 
 int bt_smp_init(void);
 
+bool bt_smp_auth_can_update_auth_cb(void);
 int bt_smp_auth_passkey_entry(struct bt_conn *conn, unsigned int passkey);
 int bt_smp_auth_passkey_confirm(struct bt_conn *conn);
 int bt_smp_auth_pairing_confirm(struct bt_conn *conn);


### PR DESCRIPTION
Change adds an additional check to verify if the Bluetooth authentication callbacks can be updated.