### PR TITLE
alternate clock configuration for the stm32 ospi driver

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -45,7 +45,8 @@ typedef void (*irq_config_func_t)(const struct device *dev);
 
 struct flash_stm32_ospi_config {
 	OCTOSPI_TypeDef *regs;
-	struct stm32_pclken pclken;
+	const struct stm32_pclken *pclken; /* clock subsystem */
+	size_t pclk_len; /* number of clock subsystems */
 	irq_config_func_t irq_config;
 	size_t flash_size;
 	uint32_t max_frequency;
@@ -1568,21 +1569,33 @@ static int flash_stm32_ospi_init(const struct device *dev)
 		return ret;
 	}
 
-	/* Initializes the independent peripherals clock */
-	__HAL_RCC_OSPI_CONFIG(RCC_OSPICLKSOURCE_SYSCLK); /* */
-
 	/* Clock configuration */
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			     (clock_control_subsys_t) &dev_cfg->pclken) != 0) {
+			     (clock_control_subsys_t) &dev_cfg->pclken[0]) != 0) {
 		LOG_ERR("Could not enable OSPI clock");
 		return -EIO;
 	}
-
-	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			(clock_control_subsys_t) &dev_cfg->pclken,
-			&ahb_clock_freq) < 0) {
-		LOG_ERR("Failed to get AHB clock frequency");
-		return -EIO;
+	/* Alternate clock config for peripheral if any */
+	if (dev_cfg->pclk_len > 1) {
+		if (clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+					(clock_control_subsys_t) &dev_cfg->pclken[1],
+					NULL) != 0) {
+			LOG_ERR("Could not select OSPI source clock pclk[1]");
+			return -EIO;
+		}
+		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+					   (clock_control_subsys_t) &dev_cfg->pclken[1],
+					   &ahb_clock_freq) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclk[1])");
+			return -EIO;
+		}
+	} else {
+		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+					   (clock_control_subsys_t) &dev_cfg->pclken[0],
+					   &ahb_clock_freq) < 0) {
+			LOG_ERR("Failed call clock_control_get_rate(pclk[0])");
+			return -EIO;
+		}
 	}
 
 	for (; prescaler <= STM32_OSPI_CLOCK_PRESCALER_MAX; prescaler++) {
@@ -1773,12 +1786,12 @@ static void flash_stm32_ospi_irq_config_func(const struct device *dev);
 
 PINCTRL_DT_DEFINE(STM32_OSPI_NODE);
 
+static const struct stm32_pclken pclken_id[] = STM32_DT_CLOCKS(STM32_OSPI_NODE);
+
 static const struct flash_stm32_ospi_config flash_stm32_ospi_cfg = {
 	.regs = (OCTOSPI_TypeDef *)DT_REG_ADDR(STM32_OSPI_NODE),
-	.pclken = {
-		.enr = DT_CLOCKS_CELL(STM32_OSPI_NODE, bits),
-		.bus = DT_CLOCKS_CELL(STM32_OSPI_NODE, bus)
-	},
+	.pclken = pclken_id,
+	.pclk_len = DT_NUM_CLOCKS(STM32_OSPI_NODE),
 	.irq_config = flash_stm32_ospi_irq_config_func,
 	.flash_size = DT_INST_PROP(0, size) / 8U,
 	.max_frequency = DT_INST_PROP(0, ospi_max_frequency),

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -397,7 +397,8 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x44021000 0x400>;
 			interrupts = <76 0>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB3 0x00000100>,
+					<&rcc STM32_SRC_SYSCLK OSPI_SEL(0)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -360,7 +360,8 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x420d1400 0x400>;
 			interrupts = <76 0>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2_2 0x00000010>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2_2 0x00000010>,
+				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -371,7 +372,8 @@
 			compatible = "st,stm32-ospi";
 			reg = <0x420d2400 0x400>;
 			interrupts = <120 0>;
-			clocks = <&rcc STM32_CLOCK_BUS_AHB2_2 0x00000100>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB2_2 0x00000100>,
+				<&rcc STM32_SRC_SYSCLK OCTOSPI_SEL(0)>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";


### PR DESCRIPTION
For stm32 MCUs, this PR is configuring the clock source for the ospi peripheral based on the definition of the DTS.

The clock source of the Octospi is set by a bit field in one independent clock configuration register of the  RCC.
In the clock control driver, the alternate clock source of the peripheral is defined by the macro OCTOSPI_SEL() or OSPI_SEL() depending on the serie. This is valid for any stm32 device with octospi peripheral. 
The DTS of the board gives the clock source to be applied like: 
-   stm32l562e_dk
-   b_u585i_iot02a


Signed-off-by: Francois Ramu <francois.ramu@st.com>