### PR TITLE
soc: esp32: opt to make device handles in dram

### DIFF
--- a/soc/riscv/esp32c3/Kconfig.defconfig
+++ b/soc/riscv/esp32c3/Kconfig.defconfig
@@ -19,6 +19,9 @@ config MCUBOOT_GENERATE_CONFIRMED_IMAGE
 config ROM_START_OFFSET
 	default 0x20
 
+config HAS_DYNAMIC_DEVICE_HANDLES
+	default y
+
 endif
 
 config SOC

--- a/soc/xtensa/esp32/Kconfig.defconfig
+++ b/soc/xtensa/esp32/Kconfig.defconfig
@@ -17,6 +17,9 @@ if BOOTLOADER_MCUBOOT
 
 	config ROM_START_OFFSET
 		default 0x20
+
+	config HAS_DYNAMIC_DEVICE_HANDLES
+		default y
 endif
 
 config SOC


### PR DESCRIPTION
ESP32 linker loader needs all sections to be align correctly.
When MCUBoot is enabled, device handles provide by device-handles.ld
does not make the ALIGN(4) at the end, which breaks the loader
initialization. This PR make sure that this particular section
is placed in DRAM instead.

For now this is a workaround until this can be handled in loader script.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>