### PR TITLE
ITE: drivers/i2c: Add command queue mode

### DIFF
--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -20,3 +20,26 @@ config I2C_ITE_ENHANCE
 	help
 	  This option can enable the enhance I2C
 	  of IT8XXX2 and support three channels.
+
+if I2C_ITE_ENHANCE
+
+config I2C_IT8XXX2_CQ_MODE
+	bool "IT8XXX2 I2C command queue mode"
+	default y
+	select SOC_IT8XXX2_CPU_IDLE_GATING
+	help
+	  This is an option to enable command queue mode which can
+	  reduce the time between each byte to improve the I2C bus
+	  clock stretching during I2C transaction.
+	  I2C command queue mode of it8xxx2 can support I2C APIs
+	  including: i2c_write(), i2c_read(), i2c_burst_read.
+
+config I2C_CQ_MODE_MAX_PAYLOAD_SIZE
+	int "It is allowed to configure the size up to 2K bytes."
+	range 32 2048
+	default 64
+	help
+	  This is the command queue mode payload size which size
+	  up to 2k bytes.
+
+endif # I2C_ITE_ENHANCE

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1696,7 +1696,15 @@ enum chip_pll_mode {
 #define IT8XXX2_I2C_IRQ_ST(base)      ECREG(base + 0x0D)
 #define IT8XXX2_I2C_IDR(base)         ECREG(base + 0x06)
 #define IT8XXX2_I2C_TOS(base)         ECREG(base + 0x07)
+#define IT8XXX2_I2C_STR2(base)        ECREG(base + 0x12)
+#define IT8XXX2_I2C_NST(base)         ECREG(base + 0x13)
+#define IT8XXX2_I2C_TO_ARB_ST(base)   ECREG(base + 0x18)
+#define IT8XXX2_I2C_ERR_ST(base)      ECREG(base + 0x19)
+#define IT8XXX2_I2C_FST(base)         ECREG(base + 0x1B)
+#define IT8XXX2_I2C_EM(base)          ECREG(base + 0x1C)
+#define IT8XXX2_I2C_MODE_SEL(base)    ECREG(base + 0x1D)
 #define IT8XXX2_I2C_IDR2(base)        ECREG(base + 0x1F)
+#define IT8XXX2_I2C_CTR2(base)        ECREG(base + 0x20)
 #define IT8XXX2_I2C_RAMHA(base)       ECREG(base + 0x23)
 #define IT8XXX2_I2C_RAMLA(base)       ECREG(base + 0x24)
 #define IT8XXX2_I2C_RAMHA2(base)      ECREG(base + 0x2B)
@@ -1737,7 +1745,17 @@ enum chip_pll_mode {
 #define IT8XXX2_I2C_SCL_IN            BIT(2)
 #define IT8XXX2_I2C_SDA_IN            BIT(0)
 /* 0x0A: Control 1 */
+#define IT8XXX2_I2C_COMQ_EN           BIT(7)
 #define IT8XXX2_I2C_MDL_EN            BIT(1)
+/* 0x13: Nack Status */
+#define IT8XXX2_I2C_NST_CNS           BIT(7)
+#define IT8XXX2_I2C_NST_ID_NACK       BIT(3)
+/* 0x19: Error Status */
+#define IT8XXX2_I2C_ERR_ST_DEV1_EIRQ  BIT(0)
+/* 0x1B: Finish Status */
+#define IT8XXX2_I2C_FST_DEV1_IRQ      BIT(4)
+/* 0x1C: Error Mask */
+#define IT8XXX2_I2C_EM_DEV1_IRQ       BIT(4)
 
 /* --- General Control (GCTRL) --- */
 #define IT83XX_GCTRL_BASE 0x00F02000

--- a/soc/riscv/riscv-ite/common/soc_common.h
+++ b/soc/riscv/riscv-ite/common/soc_common.h
@@ -57,6 +57,12 @@ uint32_t chip_get_pll_freq(void);
 void chip_pll_ctrl(enum chip_pll_mode mode);
 void riscv_idle(enum chip_pll_mode mode, unsigned int key);
 
+#ifdef CONFIG_SOC_IT8XXX2_CPU_IDLE_GATING
+void chip_permit_idle(void);
+void chip_block_idle(void);
+bool cpu_idle_not_allowed(void);
+#endif
+
 #endif /* !_ASMLANGUAGE */
 
 #endif /* __SOC_COMMON_H_ */

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.soc
@@ -59,6 +59,13 @@ config SOC_IT8XXX2_GPIO_H7_DEFAULT_OUTPUT_LOW
 	  capability to pull it down. We can only set it as output low,
 	  so we enable output low for it at initialization to prevent leakage.
 
+config SOC_IT8XXX2_CPU_IDLE_GATING
+	bool
+	help
+	  This option determines whether the entering CPU idle mode can be
+	  gated by individual drivers. When this option is disabled, CPU idle
+	  mode is always permitted.
+
 choice
 	prompt "Clock source for PLL reference clock"
 

--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -176,6 +176,26 @@ BUILD_ASSERT(CONFIG_FLASH_INIT_PRIORITY < CONFIG_IT8XXX2_PLL_SEQUENCE_PRIORITY,
 	"CONFIG_FLASH_INIT_PRIORITY must be less than CONFIG_IT8XXX2_PLL_SEQUENCE_PRIORITY");
 #endif /* CONFIG_SOC_IT8XXX2_PLL_FLASH_48M */
 
+#ifdef CONFIG_SOC_IT8XXX2_CPU_IDLE_GATING
+/* Preventing CPU going into idle mode during command queue. */
+static atomic_t cpu_idle_disabled;
+
+void chip_permit_idle(void)
+{
+	atomic_dec(&cpu_idle_disabled);
+}
+
+void chip_block_idle(void)
+{
+	atomic_inc(&cpu_idle_disabled);
+}
+
+bool cpu_idle_not_allowed(void)
+{
+	return !!(atomic_get(&cpu_idle_disabled));
+}
+#endif
+
 /* The routine must be called with interrupts locked */
 void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 {
@@ -214,7 +234,20 @@ void riscv_idle(enum chip_pll_mode mode, unsigned int key)
 
 void arch_cpu_idle(void)
 {
-	riscv_idle(CHIP_PLL_DOZE, MSTATUS_IEN);
+#ifdef CONFIG_SOC_IT8XXX2_CPU_IDLE_GATING
+	/*
+	 * The EC processor(CPU) cannot be in the k_cpu_idle() during
+	 * the transactions with the CQ mode(DMA mode). Otherwise,
+	 * the EC processor would be clock gated.
+	 */
+	if (cpu_idle_not_allowed()) {
+		/* Restore global interrupt lockout state */
+		irq_unlock(MSTATUS_IEN);
+	} else
+#endif
+	{
+		riscv_idle(CHIP_PLL_DOZE, MSTATUS_IEN);
+	}
 }
 
 void arch_cpu_atomic_idle(unsigned int key)


### PR DESCRIPTION
Adding command queue mode can reduce the time between each byte to
improve the I2C bus clock stretching during I2C transaction.

I2C command queue mode of it8xxx2 can support I2C APIs including:
i2c_write(), i2c_read(), i2c_burst_read.

Test:
1. tests\drivers\i2c\i2c_api --> pass
2. Reading 16 bytes of data through i2c_burst_read() can reduce
   0.72ms(2.54ms->1.82ms) compared to the original pio mode when the
   frequency is 100KHz.
3. krabby platform can boot normally.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>