### PR TITLE
riscv: Rename __irq_wrapper to _isr_wrapper

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -112,7 +112,7 @@ GDATA(_k_syscall_table)
 #endif
 
 /* exports */
-GTEXT(__irq_wrapper)
+GTEXT(_isr_wrapper)
 
 /* use ABI name of registers for the sake of simplicity */
 
@@ -140,7 +140,7 @@ GTEXT(__irq_wrapper)
 /*
  * Handler called upon each exception/interrupt/fault
  */
-SECTION_FUNC(exception.entry, __irq_wrapper)
+SECTION_FUNC(exception.entry, _isr_wrapper)
 
 #ifdef CONFIG_USERSPACE
 	/*

--- a/soc/riscv/esp32c3/linker.ld
+++ b/soc/riscv/esp32c3/linker.ld
@@ -203,7 +203,7 @@ SECTIONS
 
     _iram_text_start = ABSOLUTE(.);
 
-    KEEP(*(.exception.entry*)); /* contains __irq_wrapper */
+    KEEP(*(.exception.entry*)); /* contains _isr_wrapper */
     *(.exception.other*)
     . = ALIGN(4);
 

--- a/soc/riscv/esp32c3/vectors.S
+++ b/soc/riscv/esp32c3/vectors.S
@@ -10,7 +10,7 @@
 #include <zephyr/toolchain.h>
 
 /* Imports */
-GTEXT(__irq_wrapper)
+GTEXT(_isr_wrapper)
 
 	/* This is the vector table. MTVEC points here.
 	 *
@@ -31,5 +31,5 @@ _esp32c3_vector_table:
 	.option push
 	.option norvc
 	.rept (32)
-	j __irq_wrapper		/* 32 identical entries, all pointing to the interrupt handler */
+	j _isr_wrapper		/* 32 identical entries, all pointing to the interrupt handler */
 	.endr

--- a/soc/riscv/openisa_rv32m1/vector.S
+++ b/soc/riscv/openisa_rv32m1/vector.S
@@ -8,7 +8,7 @@
 
 /* Imports */
 GTEXT(__initialize)
-GTEXT(__irq_wrapper)
+GTEXT(_isr_wrapper)
 
 /* Exports */
 GTEXT(__start)
@@ -33,44 +33,44 @@ SECTION_FUNC(vectors, ivt)
 	.option norvc
 
 	/* Interrupts */
-	j __irq_wrapper	/* IRQ 0 */
-	j __irq_wrapper	/* IRQ 1 */
-	j __irq_wrapper	/* IRQ 2 */
-	j __irq_wrapper	/* IRQ 3 */
-	j __irq_wrapper	/* IRQ 4 */
-	j __irq_wrapper	/* IRQ 5 */
-	j __irq_wrapper	/* IRQ 6 */
-	j __irq_wrapper	/* IRQ 7 */
-	j __irq_wrapper	/* IRQ 8 */
-	j __irq_wrapper	/* IRQ 9 */
-	j __irq_wrapper	/* IRQ 10 */
-	j __irq_wrapper	/* IRQ 11 */
-	j __irq_wrapper	/* IRQ 12 */
-	j __irq_wrapper	/* IRQ 13 */
-	j __irq_wrapper	/* IRQ 14 */
-	j __irq_wrapper	/* IRQ 15 */
-	j __irq_wrapper	/* IRQ 16 */
-	j __irq_wrapper	/* IRQ 17 */
-	j __irq_wrapper	/* IRQ 18 */
-	j __irq_wrapper	/* IRQ 19 */
-	j __irq_wrapper	/* IRQ 20 */
-	j __irq_wrapper	/* IRQ 21 */
-	j __irq_wrapper	/* IRQ 22 */
-	j __irq_wrapper	/* IRQ 23 */
-	j __irq_wrapper	/* IRQ 24 */
-	j __irq_wrapper	/* IRQ 25 */
-	j __irq_wrapper	/* IRQ 26 */
-	j __irq_wrapper	/* IRQ 27 */
-	j __irq_wrapper	/* IRQ 28 */
-	j __irq_wrapper	/* IRQ 29 */
-	j __irq_wrapper	/* IRQ 30 */
-	j __irq_wrapper	/* IRQ 31 */
+	j _isr_wrapper	/* IRQ 0 */
+	j _isr_wrapper	/* IRQ 1 */
+	j _isr_wrapper	/* IRQ 2 */
+	j _isr_wrapper	/* IRQ 3 */
+	j _isr_wrapper	/* IRQ 4 */
+	j _isr_wrapper	/* IRQ 5 */
+	j _isr_wrapper	/* IRQ 6 */
+	j _isr_wrapper	/* IRQ 7 */
+	j _isr_wrapper	/* IRQ 8 */
+	j _isr_wrapper	/* IRQ 9 */
+	j _isr_wrapper	/* IRQ 10 */
+	j _isr_wrapper	/* IRQ 11 */
+	j _isr_wrapper	/* IRQ 12 */
+	j _isr_wrapper	/* IRQ 13 */
+	j _isr_wrapper	/* IRQ 14 */
+	j _isr_wrapper	/* IRQ 15 */
+	j _isr_wrapper	/* IRQ 16 */
+	j _isr_wrapper	/* IRQ 17 */
+	j _isr_wrapper	/* IRQ 18 */
+	j _isr_wrapper	/* IRQ 19 */
+	j _isr_wrapper	/* IRQ 20 */
+	j _isr_wrapper	/* IRQ 21 */
+	j _isr_wrapper	/* IRQ 22 */
+	j _isr_wrapper	/* IRQ 23 */
+	j _isr_wrapper	/* IRQ 24 */
+	j _isr_wrapper	/* IRQ 25 */
+	j _isr_wrapper	/* IRQ 26 */
+	j _isr_wrapper	/* IRQ 27 */
+	j _isr_wrapper	/* IRQ 28 */
+	j _isr_wrapper	/* IRQ 29 */
+	j _isr_wrapper	/* IRQ 30 */
+	j _isr_wrapper	/* IRQ 31 */
 
 	/* Exceptions */
 	j __start		/* reset */
-	j __irq_wrapper	/* illegal instruction */
-	j __irq_wrapper	/* ecall */
-	j __irq_wrapper	/* load store eunit error */
+	j _isr_wrapper	/* illegal instruction */
+	j _isr_wrapper	/* ecall */
+	j _isr_wrapper	/* load store eunit error */
 
 SECTION_FUNC(vectors, __start)
 	/* Set mtvec to point at ivt. */

--- a/soc/riscv/openisa_rv32m1/vector_table.ld
+++ b/soc/riscv/openisa_rv32m1/vector_table.ld
@@ -25,7 +25,7 @@
 #endif
 
 KEEP(*(.reset.*))
-KEEP(*(".exception.entry.*")) /* contains __irq_wrapper */
+KEEP(*(".exception.entry.*")) /* contains _isr_wrapper */
 *(".exception.other.*")
 
 KEEP(*(.openocd_debug))

--- a/soc/riscv/riscv-ite/common/vector.S
+++ b/soc/riscv/riscv-ite/common/vector.S
@@ -13,7 +13,7 @@ GTEXT(__start)
 
 /* imports */
 GTEXT(__initialize)
-GTEXT(__irq_wrapper)
+GTEXT(_isr_wrapper)
 
 SECTION_FUNC(vectors, __start)
 #ifdef CONFIG_RISCV_GP
@@ -28,9 +28,9 @@ SECTION_FUNC(vectors, __start)
 
 	/*
 	 * Set mtvec (Machine Trap-Vector Base-Address Register)
-	 * to __irq_wrapper.
+	 * to _isr_wrapper.
 	 */
-	la t0, __irq_wrapper
+	la t0, _isr_wrapper
 	csrw mtvec, t0
 	csrwi mie, 0
 

--- a/soc/riscv/riscv-privilege/common/vector.S
+++ b/soc/riscv/riscv-privilege/common/vector.S
@@ -12,7 +12,7 @@ GTEXT(__start)
 
 /* imports */
 GTEXT(__initialize)
-GTEXT(__irq_wrapper)
+GTEXT(_isr_wrapper)
 
 SECTION_FUNC(vectors, __start)
 #if defined(CONFIG_RISCV_GP)
@@ -43,9 +43,9 @@ SECTION_FUNC(vectors, __start)
 #else
 	/*
 	 * Set mtvec (Machine Trap-Vector Base-Address Register)
-	 * to __irq_wrapper.
+	 * to _isr_wrapper.
 	 */
-	la t0, __irq_wrapper
+	la t0, _isr_wrapper
 #endif
 
 	csrw mtvec, t0
@@ -59,6 +59,6 @@ SECTION_FUNC(reset,  __ivt)
 	.option norvc
 	.balign 0x100 /* must be 256 byte aligned per specification */
 	.rept (CONFIG_NUM_IRQS)
-	j __irq_wrapper
+	j _isr_wrapper
 	.endr
 #endif

--- a/soc/riscv/riscv-privilege/gd32vf103/entry.S
+++ b/soc/riscv/riscv-privilege/gd32vf103/entry.S
@@ -57,4 +57,4 @@ _start0800:
 
 .align 6
 trap_entry:
-	tail __irq_wrapper
+	tail _isr_wrapper


### PR DESCRIPTION
For some reasons RISCV is the only arch where the vector table entry is
called `__irq_wrapper` instead of `_isr_wrapper`. This is not only a
cosmetic change but Zephyr expects the common ISR handler to be called
`_isr_wrapper` (for example when generating the IRQ vector table).

Change it.

`find ./ -type f -exec sed -i 's/__irq_wrapper/_isr_wrapper/g' {} \;`

Signed-off-by: Carlo Caione <ccaione@baylibre.com>