### PR TITLE
irq: Add extern define to _isr_wrapper

### DIFF
--- a/include/zephyr/arch/arc/v2/irq.h
+++ b/include/zephyr/arch/arc/v2/irq.h
@@ -37,7 +37,6 @@ extern void sys_trace_isr_exit(void);
 
 extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
 			      uint32_t flags);
-extern void _isr_wrapper(void);
 extern void z_irq_spurious(const void *unused);
 
 /* Z_ISR_DECLARE will populate the .intList section with the interrupt's

--- a/include/zephyr/arch/arm/aarch32/irq.h
+++ b/include/zephyr/arch/arm/aarch32/irq.h
@@ -246,14 +246,6 @@ extern void z_arm_irq_direct_dynamic_dispatch_no_reschedule(void);
 /* Spurious interrupt handler. Throws an error if called */
 extern void z_irq_spurious(const void *unused);
 
-#ifdef CONFIG_GEN_SW_ISR_TABLE
-/* Architecture-specific common entry point for interrupts from the vector
- * table. Most likely implemented in assembly. Looks up the correct handler
- * and parameter from the _sw_isr_table and executes it.
- */
-extern void _isr_wrapper(void);
-#endif
-
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 /* Architecture-specific definition for the target security
  * state of an NVIC IRQ line.

--- a/include/zephyr/arch/arm64/irq.h
+++ b/include/zephyr/arch/arm64/irq.h
@@ -97,14 +97,6 @@ extern void z_arm64_interrupt_init(void);
 /* Spurious interrupt handler. Throws an error if called */
 extern void z_irq_spurious(const void *unused);
 
-#ifdef CONFIG_GEN_SW_ISR_TABLE
-/* Architecture-specific common entry point for interrupts from the vector
- * table. Most likely implemented in assembly. Looks up the correct handler
- * and parameter from the _sw_isr_table and executes it.
- */
-extern void _isr_wrapper(void);
-#endif
-
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -22,6 +22,9 @@
 extern "C" {
 #endif
 
+/* Default vector for the IRQ vector table */
+extern void _isr_wrapper(void);
+
 /*
  * Note the order: arg first, then ISR. This allows a table entry to be
  * loaded arg -> r0, isr -> r3 in _isr_wrapper with one ldmia instruction,


### PR DESCRIPTION
When `CONFIG_GEN_IRQ_VECTOR_TABLE` and `CONFIG_GEN_SW_ISR_TABLE` are enabled
the generate IRQ table is trying to reference the `_isr_wrapper` function.
Add an extern to that to avoid a failure when compiling:

`arch/common/isr_tables.c:48:38: error: '_isr_wrapper' undeclared here (not in a function)`

Signed-off-by: Carlo Caione <ccaione@baylibre.com>