### PR TITLE
Bluetooth: Shell: Fix unused variable in iso.c

### DIFF
--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -112,19 +112,20 @@ static struct bt_iso_chan_ops iso_ops = {
 static struct bt_iso_chan_io_qos iso_tx_qos = DEFAULT_IO_QOS;
 static struct bt_iso_chan_io_qos iso_rx_qos = DEFAULT_IO_QOS;
 
-static struct bt_iso_chan_qos iso_qos = {
-	.tx		= &iso_tx_qos,
-	.rx		= &iso_rx_qos,
-};
 
 #if defined(CONFIG_BT_ISO_UNICAST)
 static uint32_t cis_sdu_interval_us;
+
+static struct bt_iso_chan_qos cis_iso_qos = {
+	.tx = &iso_tx_qos,
+	.rx = &iso_rx_qos,
+};
 
 #define CIS_ISO_CHAN_COUNT 1
 
 struct bt_iso_chan iso_chan = {
 	.ops = &iso_ops,
-	.qos = &iso_qos,
+	.qos = &cis_iso_qos,
 };
 
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU),


### PR DESCRIPTION
The `iso_qos` was only used for connected ISO, but
was placed outside of the CONFIG_BT_ISO_UNICAST
guard, such that for broadcast ISO-only it was unused.

Move the declaration and renamed to cis_iso_qos.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>