### PR TITLE
ipc_service: static_vrings: Fix TX virtqueue alignment

### DIFF
--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -239,7 +239,8 @@ static int vr_shm_configure(struct ipc_static_vrings *vr, const struct backend_c
 	vr->shm_size = shm_size(num_desc, conf->buffer_size) - VDEV_STATUS_SIZE;
 
 	vr->rx_addr = vr->shm_addr + VRING_COUNT * vq_ring_size(num_desc, conf->buffer_size);
-	vr->tx_addr = vr->rx_addr + vring_size(num_desc, VRING_ALIGNMENT);
+	vr->tx_addr = ROUND_UP(vr->rx_addr + vring_size(num_desc, VRING_ALIGNMENT),
+			       VRING_ALIGNMENT);
 
 	vr->status_reg_addr = conf->shm_addr;
 


### PR DESCRIPTION
This patch fixes an issues where the TX virtqueue is misaligned by
2 bytes due to the way the virtqueue start address is calculated.
It is currently set to immediatelly follow the RX virtqueue:

    vr->tx_addr = vr->rx_addr + vring_size(num_desc, VRING_ALIGNMENT);

but the RX virtqueue does not end on an aligned boundary (last field,
avail_event is uint16_t). The resulting misaligned virtqueue causes
alignment faults on architectures that do not support unaligned
accesses (and is suboptimal otherwise)

The fix is to realign tx_addr to requested VRING_ALIGNMENT.

Fixes #46733

Signed-off-by: Aleksandar Radovanovic <aleksandar.radovanovic@amd.com>