### PR TITLE
samples/subsys/audio/sof: fix sys-ticks-per-sec to 15000

### DIFF
--- a/samples/subsys/audio/sof/prj.conf
+++ b/samples/subsys/audio/sof/prj.conf
@@ -17,3 +17,7 @@ CONFIG_COMPILER_OPT="-fstrict-overflow"
 CONFIG_SCHED_DEADLINE=y
 CONFIG_SCHED_CPU_MASK=y
 CONFIG_SMP_BOOT_DELAY=y
+
+# Fix the sys ticks value  until following bugs are solved:
+# - https://github.com/zephyrproject-rtos/zephyr/issues/46378
+CONFIG_SYS_CLOCK_TICKS_PER_SEC=15000


### PR DESCRIPTION
The value of CONFIG_SYS_CLOCK_TICKS_PER_SEC has side-effects that
are not expected with tickless kernel mode. In bug #46378, application
code is shown to run slower with higher sys clock tick value. In SOF
bug #5921, audio quality issues were root-caused to k_timer inaccuracy
with 50000 sys clock tick.

Set the the value to 15000 for all SOF applications. All existing
test cases pass with this value.

BugLink: https://github.com/zephyrproject-rtos/zephyr/issues/46378
BugLink: https://github.com/thesofproject/sof/issues/5921
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>