### PR TITLE
lib/os: winstream: properly include string.h for memcpy

### DIFF
--- a/lib/os/winstream.c
+++ b/lib/os/winstream.c
@@ -13,6 +13,7 @@
 # define MEMCPY(dst, src, n) \
 	do { for (int i = 0; i < (n); i++) { (dst)[i] = (src)[i]; } } while (0)
 #else
+# include <string.h>
 # define MEMCPY memcpy
 #endif
 


### PR DESCRIPTION
If system memcpy() is used, assert.h must be included. Fixes
a build warning on undeclared use of memcpy.

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>