### PR TITLE
dts: stm32u5: correct can1 clocks property

### DIFF
--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -438,7 +438,7 @@
 				reg-names = "m_can", "message_ram";
 				interrupts = <39 0>, <40 0>;
 				interrupt-names = "LINE_0", "LINE_1";
-				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
+				clocks = <&rcc STM32_CLOCK_BUS_APB1_2 0x00000200>;
 				status = "disabled";
 				label = "CAN_1";
 				sjw = <1>;


### PR DESCRIPTION
In #46480 the `st,stm32-fdcan` driver was updated to use `clock_control` to configure peripheral bus clocks. However, the default `clocks` property added to the `can1` node of `stm32u5.dtsi` was not correct.

This correction has been tested on known good hardware which uses the STM32U5 and FDCAN peripheral.