### PR TITLE
Smf terminate response fix

### DIFF
--- a/lib/smf/smf.c
+++ b/lib/smf/smf.c
@@ -281,5 +281,5 @@ int32_t smf_run_state(struct smf_ctx *const ctx)
 		}
 	}
 
-	return 0;
+	return internal->terminate ? ctx->terminate_val : 0;
 }

--- a/tests/lib/smf/src/test_lib_flat_smf.c
+++ b/tests/lib/smf/src/test_lib_flat_smf.c
@@ -36,8 +36,8 @@
 #define STATE_C_EXIT_BIT        (1 << 8)
 
 #define TEST_ENTRY_VALUE_NUM     0
-#define TEST_RUN_VALUE_NUM       4
-#define TEST_EXIT_VALUE_NUM      8
+#define TEST_RUN_VALUE_NUM       1
+#define TEST_EXIT_VALUE_NUM      2
 #define TEST_VALUE_NUM           9
 
 static uint32_t test_value[] = {
@@ -102,6 +102,11 @@ static void state_a_run(void *obj)
 	zassert_equal(o->transition_bits, test_value[o->tv_idx],
 		      "Test State A run failed");
 
+	if (o->terminate == RUN) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
+
 	o->transition_bits |= STATE_A_RUN_BIT;
 
 	smf_set_state(SMF_CTX(obj), &test_states[STATE_B]);
@@ -114,6 +119,11 @@ static void state_a_exit(void *obj)
 	o->tv_idx++;
 	zassert_equal(o->transition_bits, test_value[o->tv_idx],
 		      "Test State A exit failed");
+
+	if (o->terminate == EXIT) {
+		smf_set_terminate(obj, -1);
+		return;
+	}
 
 	o->transition_bits |= STATE_A_EXIT_BIT;
 }
@@ -263,8 +273,6 @@ void test_smf_flat(void)
 	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
 
 	ret = smf_run_state((struct smf_ctx *)&test_obj);
-	zassert_equal(0, ret, "Incorrect smf_run_state return value");
-	ret = smf_run_state((struct smf_ctx *)&test_obj);
 	zassert_equal(-1, ret, "Incorrect smf_run_state return value");
 
 	zassert_equal(TEST_RUN_VALUE_NUM, test_obj.tv_idx,
@@ -278,10 +286,6 @@ void test_smf_flat(void)
 	test_obj.terminate = EXIT;
 	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
 
-	ret = smf_run_state((struct smf_ctx *)&test_obj);
-	zassert_equal(0, ret, "Incorrect smf_run_state return value");
-	ret = smf_run_state((struct smf_ctx *)&test_obj);
-	zassert_equal(0, ret, "Incorrect smf_run_state return value");
 	ret = smf_run_state((struct smf_ctx *)&test_obj);
 	zassert_equal(-1, ret, "Incorrect smf_run_state return value");
 

--- a/tests/lib/smf/src/test_lib_flat_smf.c
+++ b/tests/lib/smf/src/test_lib_flat_smf.c
@@ -204,7 +204,7 @@ static void state_d_entry(void *obj)
 
 static void state_d_run(void *obj)
 {
-	/* Do nothing */
+	smf_set_terminate(obj, 1);
 }
 
 static void state_d_exit(void *obj)
@@ -223,15 +223,19 @@ void test_smf_flat(void)
 {
 	/* A) Test transitions */
 
+	int ret;
 	test_obj.transition_bits = 0;
 	test_obj.terminate = NONE;
 	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
 
-	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
-			break;
-		}
-	}
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(0, ret, "Incorrect smf_run_state return value");
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(0, ret, "Incorrect smf_run_state return value");
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(0, ret, "Incorrect smf_run_state return value");
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(1, ret, "Incorrect smf_run_state return value");
 
 	zassert_equal(TEST_VALUE_NUM, test_obj.tv_idx,
 		      "Incorrect test value index");
@@ -244,11 +248,8 @@ void test_smf_flat(void)
 	test_obj.terminate = ENTRY;
 	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
 
-	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
-			break;
-		}
-	}
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(-1, ret, "Incorrect smf_run_state return value");
 
 	zassert_equal(TEST_ENTRY_VALUE_NUM, test_obj.tv_idx,
 		      "Incorrect test value index for entry termination");
@@ -261,11 +262,10 @@ void test_smf_flat(void)
 	test_obj.terminate = RUN;
 	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
 
-	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
-			break;
-		}
-	}
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(0, ret, "Incorrect smf_run_state return value");
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(-1, ret, "Incorrect smf_run_state return value");
 
 	zassert_equal(TEST_RUN_VALUE_NUM, test_obj.tv_idx,
 		      "Incorrect test value index for run termination");
@@ -278,11 +278,12 @@ void test_smf_flat(void)
 	test_obj.terminate = EXIT;
 	smf_set_initial((struct smf_ctx *)&test_obj, &test_states[STATE_A]);
 
-	for (int i = 0; i < SMF_RUN; i++) {
-		if (smf_run_state((struct smf_ctx *)&test_obj)) {
-			break;
-		}
-	}
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(0, ret, "Incorrect smf_run_state return value");
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(0, ret, "Incorrect smf_run_state return value");
+	ret = smf_run_state((struct smf_ctx *)&test_obj);
+	zassert_equal(-1, ret, "Incorrect smf_run_state return value");
 
 	zassert_equal(TEST_EXIT_VALUE_NUM, test_obj.tv_idx,
 		      "Incorrect test value index for exit termination");


### PR DESCRIPTION
Currently, if the state machine is terminated, you have to run the state machine 1 more time to bubble up the exit code to the caller.  I think it would be more precise to notify the state machine driver that the state machine was terminated during the same instance that the state machine was terminated in.  

The main motivation for more precise state machine termination is because when writing unit tests, it is easier to setup assertions with out having to run the state machine 1 extra time to get the exit code.

To return the exit code to the caller on the same instance that the state machine was terminated in, we have to check the termination flag after running the state machine.

Most of the changes in this PR are to the test suite that no longer needs to use a for loop for driving the tests, since we can now calculate when the state machine will the terminate more clearly.