### PR TITLE
riscv: native arch_proc_id() implementation

### DIFF
--- a/include/zephyr/arch/riscv/arch_inlines.h
+++ b/include/zephyr/arch/riscv/arch_inlines.h
@@ -11,26 +11,23 @@
 
 #include <zephyr/kernel_structs.h>
 
-static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
-{
-#ifdef CONFIG_SMP
-	uint32_t hartid;
-
-	__asm__ volatile("csrr %0, mhartid" : "=r" (hartid));
-
-	return &_kernel.cpus[hartid];
-#else
-	return &_kernel.cpus[0];
-#endif /* CONFIG_SMP */
-}
-
 static ALWAYS_INLINE uint32_t arch_proc_id(void)
 {
-	/*
-	 * Placeholder implementation to be replaced with an architecture
-	 * specific call to get processor ID
-	 */
-	return arch_curr_cpu()->id;
+	uint32_t hartid;
+
+#ifdef CONFIG_SMP
+	__asm__ volatile("csrr %0, mhartid" : "=r" (hartid));
+#else
+	hartid = 0;
+#endif
+
+	return hartid;
+}
+
+static ALWAYS_INLINE _cpu_t *arch_curr_cpu(void)
+{
+	/* linear hartid enumeration space assumed */
+	return &_kernel.cpus[arch_proc_id()];
 }
 
 #endif /* !_ASMLANGUAGE */


### PR DESCRIPTION
Return the hardware hartid value directly.

Redefine arch_curr_cpu() in terms of arch_proc_id() to remove
the hartid reading duplication. The code assumed a linear hartid
space already so add a comment to that effect.

