### PR TITLE
MAINTAINERS: Add Herman Berget to Bluetooth

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -168,6 +168,7 @@ Bluetooth:
     maintainers:
         - jhedberg
     collaborators:
+        - hermabe
         - jori-nordic
         - alwa-nordic
         - Vudentz


### PR DESCRIPTION
Herman (hermabe) has been involved in the Bluetooth host, mostly for
EATT. So we would like to add him as a reviewer to select PRs.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>