### PR TITLE
Bluetooth: Mesh: fix pb gatt fast advertising

### DIFF
--- a/subsys/bluetooth/mesh/pb_gatt_srv.c
+++ b/subsys/bluetooth/mesh/pb_gatt_srv.c
@@ -44,7 +44,9 @@
 	 BT_LE_ADV_OPT_ONE_TIME | ADV_OPT_USE_IDENTITY |                       \
 	 ADV_OPT_USE_NAME)
 
-static bool prov_fast_adv;
+#define FAST_ADV_TIME (60LL * MSEC_PER_SEC)
+
+static int64_t fast_adv_timestamp;
 
 static int gatt_send(struct bt_conn *conn,
 		     const void *data, uint16_t len,
@@ -188,7 +190,7 @@ int bt_mesh_pb_gatt_srv_enable(void)
 
 	(void)bt_gatt_service_register(&prov_svc);
 	service_registered = true;
-	prov_fast_adv = true;
+	fast_adv_timestamp = k_uptime_get();
 
 	return 0;
 }
@@ -277,11 +279,12 @@ int bt_mesh_pb_gatt_srv_adv_start(void)
 	};
 	struct bt_data prov_sd[1];
 	size_t prov_sd_len;
-	int err;
+	int64_t timestamp = fast_adv_timestamp;
+	int64_t elapsed_time = k_uptime_delta(&timestamp);
 
 	prov_sd_len = gatt_prov_adv_create(prov_sd);
 
-	if (!prov_fast_adv) {
+	if (elapsed_time > FAST_ADV_TIME) {
 		struct bt_le_adv_param slow_adv_param = {
 			.options = ADV_OPT_PROV,
 			ADV_SLOW_INT,
@@ -291,15 +294,12 @@ int bt_mesh_pb_gatt_srv_adv_start(void)
 					      ARRAY_SIZE(prov_ad), prov_sd, prov_sd_len);
 	}
 
+	BT_DBG("remaining fast adv time (%lld ms)", (FAST_ADV_TIME - elapsed_time));
 	/* Advertise 60 seconds using fast interval */
-	err = bt_mesh_adv_gatt_start(&fast_adv_param, (60 * MSEC_PER_SEC),
-				     prov_ad, ARRAY_SIZE(prov_ad),
-				     prov_sd, prov_sd_len);
-	if (!err) {
-		prov_fast_adv = false;
-	}
+	return bt_mesh_adv_gatt_start(&fast_adv_param, (FAST_ADV_TIME - elapsed_time),
+				      prov_ad, ARRAY_SIZE(prov_ad),
+				      prov_sd, prov_sd_len);
 
-	return err;
 }
 
 BT_CONN_CB_DEFINE(conn_callbacks) = {


### PR DESCRIPTION
pb gatt server starts fast advertising for the first 60 seconds.
After that, server goes into slow mode.
When pb gatt and pb adv work in parallel pd gatt changes fast to
slow modes after the first tx frame in pd adv (about 110ms)
since they both are handled in the same thread.
Actually, pb gatt never worked in fast mode
if pb adv was enabled (in most configuration cases).

Signed-off-by: Aleksandr Khromykh <Aleksandr.Khromykh@nordicsemi.no>