### PR TITLE
drivers: flash: stm32 qspi  driver setting dma priority

### DIFF
--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -60,6 +60,14 @@ uint32_t table_p_size[] = {
 	LL_DMA_PDATAALIGN_WORD,
 };
 
+/* Lookup table to set dma priority from the DTS */
+uint32_t table_priority[] = {
+	DMA_PRIORITY_LOW,
+	DMA_PRIORITY_MEDIUM,
+	DMA_PRIORITY_HIGH,
+	DMA_PRIORITY_VERY_HIGH,
+};
+
 typedef void (*irq_config_func_t)(const struct device *dev);
 
 struct stream {
@@ -1103,7 +1111,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	hdma.Init.PeriphInc = DMA_PINC_DISABLE;
 	hdma.Init.MemInc = DMA_MINC_ENABLE;
 	hdma.Init.Mode = DMA_NORMAL;
-	hdma.Init.Priority = dma_cfg.channel_priority;
+	hdma.Init.Priority = table_priority[dma_cfg.channel_priority];
 #ifdef CONFIG_DMA_STM32_V1
 	/* TODO: Not tested in this configuration */
 	hdma.Init.Channel = dma_cfg.dma_slot;


### PR DESCRIPTION
This adds a table to set the dma channel priority from the DTS
The config bits are converted through the table_priority
to match the DMA_Priority_level of the stm32cube HAL.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/46725

Signed-off-by: Francois Ramu <francois.ramu@st.com>