### PR TITLE
net: openthread: Fix build with NET_MGMT_EVENT_INFO disabled

### DIFF
--- a/subsys/net/l2/openthread/openthread.c
+++ b/subsys/net/l2/openthread/openthread.c
@@ -116,11 +116,12 @@ static struct net_mgmt_event_callback ip6_addr_cb;
 static void ipv6_addr_event_handler(struct net_mgmt_event_callback *cb,
 				    uint32_t mgmt_event, struct net_if *iface)
 {
-	struct openthread_context *ot_context = net_if_l2_data(iface);
-
 	if (net_if_l2(iface) != &NET_L2_GET_NAME(OPENTHREAD)) {
 		return;
 	}
+
+#ifdef CONFIG_NET_MGMT_EVENT_INFO
+	struct openthread_context *ot_context = net_if_l2_data(iface);
 
 	if (cb->info == NULL || cb->info_length != sizeof(struct in6_addr)) {
 		return;
@@ -131,8 +132,12 @@ static void ipv6_addr_event_handler(struct net_mgmt_event_callback *cb,
 	} else if (mgmt_event == NET_EVENT_IPV6_MADDR_ADD) {
 		add_ipv6_maddr_to_ot(ot_context, (const struct in6_addr *)cb->info);
 	}
+#else
+	NET_WARN("No address info provided with event, "
+		 "please enable CONFIG_NET_MGMT_EVENT_INFO");
+#endif /* CONFIG_NET_MGMT_EVENT_INFO */
 }
-#endif
+#endif /* CONFIG_NET_MGMT_EVENT */
 
 static int ncp_hdlc_send(const uint8_t *buf, uint16_t len)
 {


### PR DESCRIPTION
In case NET_MGMT_EVENT module was enabled but w/o NET_MGMT_EVENT_INFO,
the OpenThread integration layer failed to build as the "info" field in
the net mgmt callback structure is not available then.

Fix this by conditionally enabling code processing the event only if
NET_MGMT_EVENT_INFO is enabled. Otherwise, print a warning, as the event
is not really useful if no address information is provided.

Fixes #46594

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>