### PR TITLE
MAINTAINERS: Add picolibc entry

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -293,6 +293,7 @@ C library:
          - nashif
          - enjiamai
          - KangJianX
+         - keith-packard
     files:
          - lib/libc/
          - tests/lib/c_lib/

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2370,6 +2370,16 @@ West:
     labels:
         - manifest-openthread
 
+"West project: picolibc":
+    status: maintained
+    maintainers:
+        - keith-packard
+    collaborators:
+        - stephanosio
+    files: []
+    labels:
+        - manifest-picolibc
+
 "West project: segger":
     status: odd fixes
     collaborators:


### PR DESCRIPTION
This commit adds a MAINTAINERS entry for the picolibc module with
@keith-packard as the maintainer and @stephanosio as a collaborator.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>