### PR TITLE
net: sockets: Fix uninitialized variable use in accept userspace check

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -639,9 +639,10 @@ static inline int z_vrfy_zsock_accept(int sock, struct sockaddr *addr,
 
 	Z_OOPS(addrlen && z_user_from_copy(&addrlen_copy, addrlen,
 					   sizeof(socklen_t)));
-	Z_OOPS(addr && Z_SYSCALL_MEMORY_WRITE(addr, addrlen_copy));
+	Z_OOPS(addr && Z_SYSCALL_MEMORY_WRITE(addr, addrlen ? addrlen_copy : 0));
 
-	ret = z_impl_zsock_accept(sock, (struct sockaddr *)addr, &addrlen_copy);
+	ret = z_impl_zsock_accept(sock, (struct sockaddr *)addr,
+				  addrlen ? &addrlen_copy : NULL);
 
 	Z_OOPS(ret >= 0 && addrlen && z_user_to_copy(addrlen, &addrlen_copy,
 						     sizeof(socklen_t)));


### PR DESCRIPTION
Prevent local "addrlen_copy" variable from being used uninitialized in
accept() userspace verification function.

Fixes #46570

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>