### PR TITLE
Bluetooth: Shell: Fix unused iso_rx_qos variable

### DIFF
--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -110,11 +110,11 @@ static struct bt_iso_chan_ops iso_ops = {
 }
 
 static struct bt_iso_chan_io_qos iso_tx_qos = DEFAULT_IO_QOS;
-static struct bt_iso_chan_io_qos iso_rx_qos = DEFAULT_IO_QOS;
-
 
 #if defined(CONFIG_BT_ISO_UNICAST)
 static uint32_t cis_sdu_interval_us;
+
+static struct bt_iso_chan_io_qos iso_rx_qos = DEFAULT_IO_QOS;
 
 static struct bt_iso_chan_qos cis_iso_qos = {
 	.tx = &iso_tx_qos,


### PR DESCRIPTION
The iso_rx_qos is only used for unicast audio, as
we do not set the RX QOS for the broadcast sink, nor
can a broadcast source set RX QOS.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>