### PR TITLE
twister: Delete less files during artifact cleanup

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -2795,6 +2795,11 @@ class ProjectBuilder(FilterBuilder):
             'build.log',
             'device.log',
             'recording.csv',
+            # below ones are needed to make --test-only work as well
+            'Makefile',
+            'CMakeCache.txt',
+            'build.ninja',
+            'CMakeFiles/rules.ninja'
             ]
 
         allow += additional_keep


### PR DESCRIPTION
Option --runtime-artifact-cleanup/-M allows to clean build artifacts
during runtime to save space usage. However, if one wanted to combine
it with --build-only and then --test-only, they would get an error.
This commit expands the list of files stored with -M with files
required to made --test-only also to work afterwards. Such change can
be useful for setups where building is done on one node and then
minimal amount of artifacts are transfered to another one.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>