### PR TITLE
LE Audio: Add support for sequence number and timestamp

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1505,12 +1505,21 @@ int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache);
  *  @note Data will not be sent to linked streams since linking is only
  *  consider for procedures affecting the state machine.
  *
- *  @param stream Stream object.
- *  @param buf Buffer containing data to be sent.
+ *  @param stream   Stream object.
+ *  @param buf      Buffer containing data to be sent.
+ *  @param seq_num  Packet Sequence number. This value shall be incremented for
+ *                  each call to this function and at least once per SDU
+ *                  interval for a specific channel.
+ *  @param ts       Timestamp of the SDU in microseconds (us).
+ *                  This value can be used to transmit multiple
+ *                  SDUs in the same SDU interval in a CIG or BIG. Can be
+ *                  omitted by using @ref BT_ISO_TIMESTAMP_NONE which will
+ *                  simply enqueue the ISO SDU in a FIFO manner.
  *
  *  @return Bytes sent in case of success or negative value in case of error.
  */
-int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf);
+int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf,
+			 uint32_t seq_num, uint32_t ts);
 
 /** @brief Create audio unicast group.
  *

--- a/samples/bluetooth/broadcast_audio_source/src/main.c
+++ b/samples/bluetooth/broadcast_audio_source/src/main.c
@@ -25,6 +25,7 @@ NET_BUF_POOL_FIXED_DEFINE(tx_pool,
 			  TOTAL_BUF_NEEDED,
 			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_TX_MTU), 8, NULL);
 static uint8_t mock_data[CONFIG_BT_ISO_TX_MTU];
+static uint32_t seq_num;
 static bool stopping;
 
 static K_SEM_DEFINE(sem_started, 0U, ARRAY_SIZE(streams));
@@ -61,7 +62,8 @@ static void stream_sent_cb(struct bt_audio_stream *stream)
 
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 	net_buf_add_mem(buf, mock_data, preset_16_2_1.qos.sdu);
-	ret = bt_audio_stream_send(stream, buf);
+	ret = bt_audio_stream_send(stream, buf, seq_num++,
+				   BT_ISO_TIMESTAMP_NONE);
 	if (ret < 0) {
 		/* This will end broadcasting on this stream. */
 		printk("Unable to broadcast data on %p: %d\n", stream, ret);
@@ -162,5 +164,6 @@ void main(void)
 		}
 		printk("Broadcast source deleted\n");
 		broadcast_source = NULL;
+		seq_num = 0;
 	}
 }

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -21,7 +21,10 @@ static struct bt_conn *default_conn;
 static struct k_work_delayable audio_send_work;
 static struct bt_audio_unicast_group *unicast_group;
 static struct bt_codec *remote_codec_capabilities[CONFIG_BT_AUDIO_UNICAST_CLIENT_PAC_COUNT];
-static struct bt_audio_ep *sinks[CONFIG_BT_AUDIO_UNICAST_CLIENT_ASE_SNK_COUNT];
+static struct bt_audio_sink {
+	struct bt_audio_ep *ep;
+	uint32_t seq_num;
+} sinks[CONFIG_BT_AUDIO_UNICAST_CLIENT_ASE_SNK_COUNT];
 static struct bt_audio_ep *sources[CONFIG_BT_AUDIO_UNICAST_CLIENT_ASE_SRC_COUNT];
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, CONFIG_BT_AUDIO_UNICAST_CLIENT_ASE_SNK_COUNT,
 			  CONFIG_BT_ISO_TX_MTU + BT_ISO_CHAN_SEND_RESERVE,
@@ -47,6 +50,19 @@ static K_SEM_DEFINE(sem_stream_configured, 0, 1);
 static K_SEM_DEFINE(sem_stream_qos, 0, 1);
 static K_SEM_DEFINE(sem_stream_enabled, 0, 1);
 static K_SEM_DEFINE(sem_stream_started, 0, 1);
+
+static uint32_t get_and_incr_seq_num(const struct bt_audio_stream *stream)
+{
+	for (size_t i = 0U; i < configured_sink_stream_count; i++) {
+		if (stream->ep == sinks[i].ep) {
+			return sinks[i].seq_num++;
+		}
+	}
+
+	printk("Could not find endpoint from stream %p\n", stream);
+
+	return 0;
+}
 
 #if defined(CONFIG_LIBLC3CODEC)
 
@@ -158,6 +174,7 @@ static void lc3_audio_timer_timeout(struct k_work *work)
 		}
 
 		for (size_t i = 0U; i < configured_sink_stream_count; i++) {
+			struct bt_audio_stream *stream = &streams[i];
 			struct net_buf *buf_to_send;
 			int ret;
 
@@ -168,7 +185,9 @@ static void lc3_audio_timer_timeout(struct k_work *work)
 				buf_to_send = net_buf_clone(buf, K_FOREVER);
 			}
 
-			ret = bt_audio_stream_send(&streams[i], buf_to_send);
+			ret = bt_audio_stream_send(stream, buf_to_send,
+						   get_and_incr_seq_num(stream),
+						   BT_ISO_TIMESTAMP_NONE);
 			if (ret < 0) {
 				printk("  Failed to send LC3 audio data on streams[%zu] (%d)\n",
 				       i, ret);
@@ -272,6 +291,7 @@ static void audio_timer_timeout(struct k_work *work)
 	 * data going to the server)
 	 */
 	for (size_t i = 0U; i < configured_sink_stream_count; i++) {
+		struct bt_audio_stream *stream = &streams[i];
 		struct net_buf *buf_to_send;
 		int ret;
 
@@ -282,7 +302,9 @@ static void audio_timer_timeout(struct k_work *work)
 			buf_to_send = net_buf_clone(buf, K_FOREVER);
 		}
 
-		ret = bt_audio_stream_send(&streams[i], buf_to_send);
+		ret = bt_audio_stream_send(stream, buf_to_send,
+					   get_and_incr_seq_num(stream),
+					   BT_ISO_TIMESTAMP_NONE);
 		if (ret < 0) {
 			printk("Failed to send audio data on streams[%zu]: (%d)\n",
 			       i, ret);
@@ -454,6 +476,14 @@ static void stream_started(struct bt_audio_stream *stream)
 {
 	printk("Audio Stream %p started\n", stream);
 
+	/* Reset sequence number for sinks */
+	for (size_t i = 0U; i < configured_sink_stream_count; i++) {
+		if (stream->ep == sinks[i].ep) {
+			sinks[i].seq_num = 0U;
+			break;
+		}
+	}
+
 	k_sem_give(&sem_stream_started);
 }
 
@@ -520,7 +550,7 @@ static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)
 		return;
 	}
 
-	sinks[index] = ep;
+	sinks[index].ep = ep;
 }
 
 static void add_remote_codec(struct bt_codec *codec_capabilities, int index,
@@ -770,7 +800,7 @@ static int configure_streams(void)
 	int err;
 
 	for (size_t i = 0; i < ARRAY_SIZE(sinks); i++) {
-		struct bt_audio_ep *ep = sinks[i];
+		struct bt_audio_ep *ep = sinks[i].ep;
 		struct bt_audio_stream *stream = &streams[i];
 
 		if (ep == NULL) {

--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -40,7 +40,10 @@ static struct bt_codec lc3_codec =
 static struct bt_conn *default_conn;
 static struct k_work_delayable audio_send_work;
 static struct bt_audio_stream streams[CONFIG_BT_ASCS_ASE_SNK_COUNT + CONFIG_BT_ASCS_ASE_SRC_COUNT];
-static struct bt_audio_stream *source_streams[CONFIG_BT_ASCS_ASE_SRC_COUNT];
+static struct bt_audio_source {
+	struct bt_audio_stream *stream;
+	uint32_t seq_num;
+} source_streams[CONFIG_BT_ASCS_ASE_SRC_COUNT];
 static size_t configured_source_stream_count;
 
 static K_SEM_DEFINE(sem_disconnected, 0, 1);
@@ -61,6 +64,19 @@ static const struct bt_data ad[] = {
 	BT_DATA_BYTES(BT_DATA_UUID16_ALL, BT_UUID_16_ENCODE(BT_UUID_ASCS_VAL)),
 	BT_DATA(BT_DATA_SVC_DATA16, unicast_server_addata, ARRAY_SIZE(unicast_server_addata)),
 };
+
+static uint32_t get_and_incr_seq_num(const struct bt_audio_stream *stream)
+{
+	for (size_t i = 0U; i < configured_source_stream_count; i++) {
+		if (stream == source_streams[i].stream) {
+			return source_streams[i].seq_num++;
+		}
+	}
+
+	printk("Could not find endpoint from stream %p\n", stream);
+
+	return 0;
+}
 
 #if defined(CONFIG_LIBLC3CODEC)
 
@@ -171,14 +187,16 @@ static void audio_timer_timeout(struct k_work *work)
 	 * data going to the server)
 	 */
 	for (size_t i = 0; i < configured_source_stream_count; i++) {
-		struct bt_audio_stream *stream = source_streams[i];
+		struct bt_audio_stream *stream = source_streams[i].stream;
 
 		buf = net_buf_alloc(&tx_pool, K_FOREVER);
 		net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 
 		net_buf_add_mem(buf, buf_data, len_to_send);
 
-		ret = bt_audio_stream_send(stream, buf);
+		ret = bt_audio_stream_send(stream, buf,
+					   get_and_incr_seq_num(stream),
+					   BT_ISO_TIMESTAMP_NONE);
 		if (ret < 0) {
 			printk("Failed to send audio data on streams[%zu] (%p): (%d)\n",
 			       i, stream, ret);
@@ -214,7 +232,7 @@ static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 		if (!stream->conn) {
 			printk("ASE Codec Config stream %p\n", stream);
 			if (dir == BT_AUDIO_DIR_SOURCE) {
-				source_streams[configured_source_stream_count++] = stream;
+				source_streams[configured_source_stream_count++].stream = stream;
 			}
 
 			return stream;
@@ -298,6 +316,13 @@ static int lc3_enable(struct bt_audio_stream *stream,
 static int lc3_start(struct bt_audio_stream *stream)
 {
 	printk("Start: stream %p\n", stream);
+
+	for (size_t i = 0U; i < configured_source_stream_count; i++) {
+		if (source_streams[i].stream == stream) {
+			source_streams[i].seq_num = 0U;
+			break;
+		}
+	}
 
 	if (configured_source_stream_count > 0 &&
 	    !k_work_delayable_is_pending(&audio_send_work)) {

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -376,8 +376,6 @@ static void ascs_iso_connected(struct bt_iso_chan *chan)
 
 	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
-	ep->seq_num = 0U;
-
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
 		       bt_audio_ep_state_str(ep->status.state));

--- a/subsys/bluetooth/audio/broadcast_source.c
+++ b/subsys/bluetooth/audio/broadcast_source.c
@@ -148,7 +148,6 @@ static void broadcast_source_iso_connected(struct bt_iso_chan *chan)
 	BT_DBG("stream %p ep %p", chan, ep);
 
 	broadcast_source_set_ep_state(ep, BT_AUDIO_EP_STATE_STREAMING);
-	ep->seq_num = 0U;
 
 	if (ops != NULL && ops->started != NULL) {
 		ops->started(ep->stream);

--- a/subsys/bluetooth/audio/endpoint.h
+++ b/subsys/bluetooth/audio/endpoint.h
@@ -42,8 +42,6 @@ struct bt_audio_ep {
 	uint16_t cp_handle;
 	uint8_t  cig_id;
 	uint8_t  cis_id;
-	/* ISO sequence number */
-	uint32_t seq_num;
 	struct bt_ascs_ase_status status;
 	struct bt_audio_stream *stream;
 	struct bt_codec codec;

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -57,7 +57,8 @@ void bt_audio_stream_attach(struct bt_conn *conn,
 }
 
 #if defined(CONFIG_BT_AUDIO_UNICAST) || defined(CONFIG_BT_AUDIO_BROADCAST_SOURCE)
-int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf)
+int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf,
+			 uint32_t seq_num, uint32_t ts)
 {
 	struct bt_audio_ep *ep;
 
@@ -75,9 +76,7 @@ int bt_audio_stream_send(struct bt_audio_stream *stream, struct net_buf *buf)
 
 	/* TODO: Add checks for broadcast sink */
 
-	/* TODO: Ensure that the sequence number is incremented per SDU interval */
-	return bt_iso_chan_send(stream->iso, buf, ep->seq_num++,
-				BT_ISO_TIMESTAMP_NONE);
+	return bt_iso_chan_send(stream->iso, buf, seq_num, ts);
 }
 #endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SOURCE */
 

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -124,8 +124,6 @@ static void unicast_client_ep_iso_connected(struct bt_iso_chan *chan)
 
 	BT_DBG("stream %p ep %p dir %u", chan, ep, ep != NULL ? ep->dir : 0);
 
-	ep->seq_num = 0U;
-
 	if (ep->status.state != BT_AUDIO_EP_STATE_ENABLING) {
 		BT_DBG("endpoint not in enabling state: %s",
 		       bt_audio_ep_state_str(ep->status.state));

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -46,6 +46,7 @@ static struct bt_audio_stream broadcast_sink_streams[BROADCAST_SNK_STREAM_CNT];
 static struct bt_audio_broadcast_sink *default_sink;
 #endif /* CONFIG_BT_AUDIO_BROADCAST_SINK */
 static struct bt_audio_stream *default_stream;
+static uint32_t seq_num;
 static bool connecting;
 
 struct named_lc3_preset {
@@ -375,6 +376,8 @@ static int lc3_enable(struct bt_audio_stream *stream,
 static int lc3_start(struct bt_audio_stream *stream)
 {
 	shell_print(ctx_shell, "Start: stream %p", stream);
+
+	seq_num = 0;
 
 	return 0;
 }
@@ -1382,6 +1385,28 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 #define DATA_MTU CONFIG_BT_ISO_TX_MTU
 NET_BUF_POOL_FIXED_DEFINE(tx_pool, 1, DATA_MTU, 8, NULL);
 
+static uint32_t get_next_seq_num(uint32_t interval_us)
+{
+	static int64_t last_ticks;
+	int64_t uptime_ticks, delta_ticks;
+	uint64_t delta_us;
+	uint64_t seq_num_incr;
+	uint64_t next_seq_num;
+
+	/* Note: This does not handle wrapping of ticks when they go above
+	 * 2^(62-1)
+	 */
+	uptime_ticks = k_uptime_ticks();
+	delta_ticks = uptime_ticks - last_ticks;
+	last_ticks = uptime_ticks;
+
+	delta_us = k_ticks_to_us_near64((uint64_t)delta_ticks);
+	seq_num_incr = delta_us / interval_us;
+	next_seq_num = (seq_num_incr + seq_num);
+
+	return (uint32_t)next_seq_num;
+}
+
 static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 {
 	static uint8_t data[DATA_MTU - BT_ISO_CHAN_SEND_RESERVE];
@@ -1404,7 +1429,11 @@ static int cmd_send(const struct shell *sh, size_t argc, char *argv[])
 	net_buf_reserve(buf, BT_ISO_CHAN_SEND_RESERVE);
 
 	net_buf_add_mem(buf, data, len);
-	ret = bt_audio_stream_send(default_stream, buf);
+
+	seq_num = get_next_seq_num(default_preset->preset.qos.interval);
+
+	ret = bt_audio_stream_send(default_stream, buf, seq_num,
+				   BT_ISO_TIMESTAMP_NONE);
 	if (ret < 0) {
 		shell_print(sh, "Unable to send: %d", -ret);
 		net_buf_unref(buf);


### PR DESCRIPTION
Adds support for using sequence number and timestamp when sending audio data. 

fixes https://github.com/zephyrproject-rtos/zephyr/issues/46474