### PR TITLE
ITE drivers/pwm: fix target frequency below 324Hz on it8xxx2

### DIFF
--- a/drivers/pwm/pwm_ite_it8xxx2.c
+++ b/drivers/pwm/pwm_ite_it8xxx2.c
@@ -141,8 +141,11 @@ static int pwm_it8xxx2_set_cycles(const struct device *dev,
 	 * <=324Hz in board dts. Now change prescaler clock source from 8MHz to
 	 * 32.768KHz to support pwm output in mode.
 	 */
-	if ((target_freq <= 324) && (inst->PCFSR & BIT(prs_sel))) {
-		inst->PCFSR &= ~BIT(prs_sel);
+	if (target_freq <= 324) {
+		if (inst->PCFSR & BIT(prs_sel)) {
+			inst->PCFSR &= ~BIT(prs_sel);
+		}
+
 		pwm_clk_src = (uint64_t) 32768;
 	}
 


### PR DESCRIPTION
Target frequency is less than or equal to 324Hz, the first time invokes function < pwm_it8xxx2_set_cycles > will operating in correct output frequency, after the second times will not operating in correct output frequency.
The Root cause is when selected target frequency less than or equal to 324Hz will 'AND' condition with check PCFSR register for EC frequency. Since the first time default will being EC frequency and instead of 32KHz after selected target frequency less than or equal to 324Hz, so on, PCFSR will changed to 32KHz from EC frequency. The Second times being invoked, as PCFSR is selected as 32KHz, so target frequency (<= 32KHz) 'AND' condition with check PCFSR is not being true, and the 'pwm_clk_src' variable value is not 32768 instead of EC frequency.

Signed-off-by: yimjiajun <yimjiajun@icloud.com>