### PR TITLE
bluetooth: smp: Add authentication callbacks per connection

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -96,6 +96,8 @@ Bluetooth
 
 * Host
 
+  * Added :c:func:`bt_conn_auth_cb_overlay` to overlay authentication callbacks for a Bluetooth LE connection.
+
 * Mesh
 
 * Controller

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -1363,6 +1363,22 @@ struct bt_conn_auth_info_cb {
  */
 int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb);
 
+/** @brief Overlay authentication callbacks used for a given connection.
+ *
+ *  This function can be used only for Bluetooth LE connections.
+ *  The @kconfig{CONFIG_BT_SMP} must be enabled for this function.
+ *
+ *  The authentication callbacks for a given connection cannot be overlaid if
+ *  security procedures in the SMP module have already started. This function
+ *  can be called only once per connection.
+ *
+ *  @param conn	Connection object.
+ *  @param cb	Callback struct.
+ *
+ *  @return Zero on success or negative error code otherwise
+ */
+int bt_conn_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *cb);
+
 /** @brief Register authentication information callbacks.
  *
  *  Register callbacks to get authenticated pairing information. Multiple

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2840,6 +2840,26 @@ int bt_conn_auth_cb_register(const struct bt_conn_auth_cb *cb)
 	return 0;
 }
 
+#if defined(CONFIG_BT_SMP)
+int bt_conn_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *cb)
+{
+	/* The cancel callback must always be provided if the app provides
+	 * interactive callbacks.
+	 */
+	if (!cb->cancel &&
+	    (cb->passkey_display || cb->passkey_entry || cb->passkey_confirm ||
+	     cb->pairing_confirm)) {
+		return -EINVAL;
+	}
+
+	if (conn->type == BT_CONN_TYPE_LE) {
+		return bt_smp_auth_cb_overlay(conn, cb);
+	}
+
+	return -ENOTSUP;
+}
+#endif
+
 int bt_conn_auth_info_cb_register(struct bt_conn_auth_info_cb *cb)
 {
 	CHECKIF(cb == NULL) {
@@ -2866,16 +2886,15 @@ int bt_conn_auth_info_cb_unregister(struct bt_conn_auth_info_cb *cb)
 
 int bt_conn_auth_passkey_entry(struct bt_conn *conn, unsigned int passkey)
 {
-	if (!bt_auth) {
-		return -EINVAL;
-	}
-
 	if (IS_ENABLED(CONFIG_BT_SMP) && conn->type == BT_CONN_TYPE_LE) {
-		bt_smp_auth_passkey_entry(conn, passkey);
-		return 0;
+		return bt_smp_auth_passkey_entry(conn, passkey);
 	}
 
 	if (IS_ENABLED(CONFIG_BT_BREDR) && conn->type == BT_CONN_TYPE_BR) {
+		if (!bt_auth) {
+			return -EINVAL;
+		}
+
 		return bt_ssp_auth_passkey_entry(conn, passkey);
 	}
 
@@ -2884,17 +2903,15 @@ int bt_conn_auth_passkey_entry(struct bt_conn *conn, unsigned int passkey)
 
 int bt_conn_auth_passkey_confirm(struct bt_conn *conn)
 {
-	if (!bt_auth) {
-		return -EINVAL;
-	}
-
-	if (IS_ENABLED(CONFIG_BT_SMP) &&
-	    conn->type == BT_CONN_TYPE_LE) {
+	if (IS_ENABLED(CONFIG_BT_SMP) && conn->type == BT_CONN_TYPE_LE) {
 		return bt_smp_auth_passkey_confirm(conn);
 	}
 
-	if (IS_ENABLED(CONFIG_BT_BREDR) &&
-	    conn->type == BT_CONN_TYPE_BR) {
+	if (IS_ENABLED(CONFIG_BT_BREDR) && conn->type == BT_CONN_TYPE_BR) {
+		if (!bt_auth) {
+			return -EINVAL;
+		}
+
 		return bt_ssp_auth_passkey_confirm(conn);
 	}
 
@@ -2903,41 +2920,36 @@ int bt_conn_auth_passkey_confirm(struct bt_conn *conn)
 
 int bt_conn_auth_cancel(struct bt_conn *conn)
 {
-	if (!bt_auth) {
-		return -EINVAL;
-	}
-
 	if (IS_ENABLED(CONFIG_BT_SMP) && conn->type == BT_CONN_TYPE_LE) {
 		return bt_smp_auth_cancel(conn);
 	}
 
-#if defined(CONFIG_BT_BREDR)
-	if (conn->type == BT_CONN_TYPE_BR) {
+	if (IS_ENABLED(CONFIG_BT_BREDR) && conn->type == BT_CONN_TYPE_BR) {
+		if (!bt_auth) {
+			return -EINVAL;
+		}
+
 		return bt_ssp_auth_cancel(conn);
 	}
-#endif /* CONFIG_BT_BREDR */
 
 	return -EINVAL;
 }
 
 int bt_conn_auth_pairing_confirm(struct bt_conn *conn)
 {
-	if (!bt_auth) {
-		return -EINVAL;
+	if (IS_ENABLED(CONFIG_BT_SMP) && conn->type == BT_CONN_TYPE_LE) {
+		return bt_smp_auth_pairing_confirm(conn);
 	}
 
-	switch (conn->type) {
-#if defined(CONFIG_BT_SMP)
-	case BT_CONN_TYPE_LE:
-		return bt_smp_auth_pairing_confirm(conn);
-#endif /* CONFIG_BT_SMP */
-#if defined(CONFIG_BT_BREDR)
-	case BT_CONN_TYPE_BR:
+	if (IS_ENABLED(CONFIG_BT_BREDR) && conn->type == BT_CONN_TYPE_BR) {
+		if (!bt_auth) {
+			return -EINVAL;
+		}
+
 		return bt_ssp_auth_pairing_confirm(conn);
-#endif /* CONFIG_BT_BREDR */
-	default:
-		return -EINVAL;
 	}
+
+	return -EINVAL;
 }
 #endif /* CONFIG_BT_SMP || CONFIG_BT_BREDR */
 

--- a/subsys/bluetooth/host/smp.h
+++ b/subsys/bluetooth/host/smp.h
@@ -141,6 +141,7 @@ int bt_smp_br_send_pairing_req(struct bt_conn *conn);
 
 int bt_smp_init(void);
 
+int bt_smp_auth_cb_overlay(struct bt_conn *conn, const struct bt_conn_auth_cb *cb);
 int bt_smp_auth_passkey_entry(struct bt_conn *conn, unsigned int passkey);
 int bt_smp_auth_passkey_confirm(struct bt_conn *conn);
 int bt_smp_auth_pairing_confirm(struct bt_conn *conn);


### PR DESCRIPTION
Change introduces authentication callbacks used only for specified BLE connection. The feature can be used by devices that require reporting specific bonding capabilities only when pairing using vendor-specific procedures.

If per-connection authentication callbacks are defined for given connection, they are used instead of global authentication
callbacks. SMP latches authentication callbacks during the first access to prevent updating the callbacks while pairing.

Fixes: https://github.com/zephyrproject-rtos/zephyr/issues/38336

Signed-off-by: Marek Pieta <Marek.Pieta@nordicsemi.no>