### PR TITLE
drivers: i2c: nrfx_twim: add support for device runtime PM

### DIFF
--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -269,8 +269,7 @@ static void deinit_twim(const struct device *dev)
 static int i2c_nrfx_twim_configure(const struct device *dev,
 				   uint32_t i2c_config)
 {
-	struct i2c_nrfx_twim_data *dev_data = dev->data;
-	nrf_twim_frequency_t frequency;
+	const struct i2c_nrfx_twim_config *dev_config = dev->config;
 
 	if (I2C_ADDR_10_BITS & i2c_config) {
 		return -EINVAL;
@@ -278,26 +277,22 @@ static int i2c_nrfx_twim_configure(const struct device *dev,
 
 	switch (I2C_SPEED_GET(i2c_config)) {
 	case I2C_SPEED_STANDARD:
-		frequency = NRF_TWIM_FREQ_100K;
+		nrf_twim_frequency_set(dev_config->twim.p_twim,
+				       NRF_TWIM_FREQ_100K);
 		break;
 	case I2C_SPEED_FAST:
-		frequency = NRF_TWIM_FREQ_400K;
+		nrf_twim_frequency_set(dev_config->twim.p_twim,
+				       NRF_TWIM_FREQ_400K);
 		break;
 #if NRF_TWIM_HAS_1000_KHZ_FREQ
 	case I2C_SPEED_FAST_PLUS:
-		frequency = NRF_TWIM_FREQ_1000K;
+		nrf_twim_frequency_set(dev_config->twim.p_twim,
+				       NRF_TWIM_FREQ_1000K);
 		break;
 #endif
 	default:
 		LOG_ERR("unsupported speed");
 		return -EINVAL;
-	}
-
-	if (frequency != dev_data->twim_config.frequency) {
-		dev_data->twim_config.frequency = frequency;
-
-		deinit_twim(dev);
-		return init_twim(dev);
 	}
 
 	return 0;

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -324,11 +324,11 @@ static int twim_nrfx_pm_action(const struct device *dev,
 			return ret;
 		}
 #endif
-		ret = init_twim(dev);
+		nrfx_twim_enable(&dev_config->twim);
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		nrfx_twim_uninit(&dev_config->twim);
+		nrfx_twim_disable(&dev_config->twim);
 
 #ifdef CONFIG_PINCTRL
 		ret = pinctrl_apply_state(dev_config->pcfg,

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -246,13 +246,6 @@ static int init_twim(const struct device *dev)
 	return 0;
 }
 
-static void deinit_twim(const struct device *dev)
-{
-	const struct i2c_nrfx_twim_config *dev_config = dev->config;
-
-	nrfx_twim_uninit(&dev_config->twim);
-}
-
 static int i2c_nrfx_twim_configure(const struct device *dev,
 				   uint32_t i2c_config)
 {
@@ -335,7 +328,7 @@ static int twim_nrfx_pm_action(const struct device *dev,
 		break;
 
 	case PM_DEVICE_ACTION_SUSPEND:
-		deinit_twim(dev);
+		nrfx_twim_uninit(&dev_config->twim);
 
 #ifdef CONFIG_PINCTRL
 		ret = pinctrl_apply_state(dev_config->pcfg,

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -319,18 +319,6 @@ struct pm_device {
 const char *pm_device_state_str(enum pm_device_state state);
 
 /**
- * @brief Obtain the power state of a device.
- *
- * @param dev Device instance.
- * @param state Pointer where device power state will be stored.
- *
- * @retval 0 If successful.
- * @retval -ENOSYS If device does not implement power management.
- */
-int pm_device_state_get(const struct device *dev,
-			enum pm_device_state *state);
-
-/**
  * @brief Run a pm action on a device.
  *
  * This function calls the device PM control callback so that the device does
@@ -365,6 +353,18 @@ void pm_device_children_action_run(const struct device *dev,
 		pm_device_action_failed_cb_t failure_cb);
 
 #if defined(CONFIG_PM_DEVICE) || defined(__DOXYGEN__)
+/**
+ * @brief Obtain the power state of a device.
+ *
+ * @param dev Device instance.
+ * @param state Pointer where device power state will be stored.
+ *
+ * @retval 0 If successful.
+ * @retval -ENOSYS If device does not implement power management.
+ */
+int pm_device_state_get(const struct device *dev,
+			enum pm_device_state *state);
+
 /**
  * @brief Initialize a device state to #PM_DEVICE_STATE_SUSPENDED.
  *
@@ -566,6 +566,16 @@ int pm_device_power_domain_remove(const struct device *dev,
  */
 bool pm_device_is_powered(const struct device *dev);
 #else
+static inline int pm_device_state_get(const struct device *dev,
+				      enum pm_device_state *state)
+{
+	ARG_UNUSED(dev);
+
+	*state = PM_DEVICE_STATE_ACTIVE;
+
+	return 0;
+}
+
 static inline void pm_device_init_suspended(const struct device *dev)
 {
 	ARG_UNUSED(dev);


### PR DESCRIPTION
Enable device runtime PM on the I2C driver. Note that this mechanism
replaces the old nrfx_twim_enable/disable calls with
pm_device_runtime_get/put, which means that driver will not save power
unless CONFIG_PM_DEVICE_RUNTIME=y.

Some quick measurements on thingy_52 running the samples/sensor/hts221
show a decrease of ~2-3uA in average when enabling device runtime PM.
Note that the driver already had implicit PM before, so the change for
users will be ~none, except that they now must enable the PM subsystem
features. While this case is not the best example, the PM subsystem will
turn to be beneficial as a whole when all devices in the board implement
it.

I've also done some minor cleanups as prep-work commits, please check the details