### PR TITLE
dma: Buffer alignment property

### DIFF
--- a/dts/bindings/dma/dma-controller.yaml
+++ b/dts/bindings/dma/dma-controller.yaml
@@ -33,3 +33,8 @@ properties:
       type: int
       required: false
       description: Number of DMA request signals supported by the controller.
+
+    dma-buf-alignment:
+      type: int
+      required: false
+      description: Memory alignment requirement for DMA buffers used by the controller.

--- a/dts/bindings/dma/intel,cavs-hda.yaml
+++ b/dts/bindings/dma/intel,cavs-hda.yaml
@@ -14,3 +14,6 @@ properties:
 
     "#dma-cells":
       const: 1
+
+    "dma-buf-alignment":
+      required: true

--- a/dts/xtensa/intel/intel_cavs.dtsi
+++ b/dts/xtensa/intel/intel_cavs.dtsi
@@ -37,6 +37,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072400 0x40>;
 			dma-channels = <9>;
+			dma-buf-alignment = <128>;
 			label = "HDA_LINK_OUT";
 
 			status = "okay";
@@ -47,6 +48,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072600 0x40>;
 			dma-channels = <7>;
+			dma-buf-alignment = <128>;
 			label = "HDA_LINK_IN";
 
 			status = "okay";
@@ -57,6 +59,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
+			dma-buf-alignment = <128>;
 			label = "HDA_HOST_OUT";
 
 			status = "okay";
@@ -67,6 +70,7 @@
 			#dma-cells = <1>;
 			reg = <0x00072c00 0x40>;
 			dma-channels = <7>;
+			dma-buf-alignment = <128>;
 			label = "HDA_HOST_IN";
 
 			status = "okay";

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -155,6 +155,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002400 0x40>;
 			dma-channels = <6>;
+			dma-buf-alignment = <128>;
 			label = "HDA_LINK_OUT";
 
 			status = "okay";
@@ -165,6 +166,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002600 0x40>;
 			dma-channels = <7>;
+			dma-buf-alignment = <128>;
 			label = "HDA_LINK_IN";
 
 			status = "okay";
@@ -175,6 +177,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002800 0x40>;
 			dma-channels = <6>;
+			dma-buf-alignment = <128>;
 			label = "HDA_HOST_OUT";
 
 			status = "okay";
@@ -185,6 +188,7 @@
 			#dma-cells = <1>;
 			reg = <0x00002c00 0x40>;
 			dma-channels = <7>;
+			dma-buf-alignment = <128>;
 			label = "HDA_HOST_IN";
 
 			status = "okay";

--- a/include/zephyr/drivers/dma.h
+++ b/include/zephyr/drivers/dma.h
@@ -641,6 +641,17 @@ static inline uint32_t dma_burst_index(uint32_t burst)
 }
 
 /**
+ * Get the device tree property describing the buffer alignment
+ *
+ * Useful when statically defining or allocating buffers for DMA usage where
+ * memory alignment often matters.
+ *
+ * @param node Node identifier, e.g. DT_NODELABEL(dma_0)
+ * @return alignment Memory byte alignment required for DMA buffers
+ */
+#define DMA_BUF_ALIGNMENT(node) DT_PROP(node, dma_buf_alignment)
+
+/**
  * @}
  */
 

--- a/subsys/logging/log_backend_cavs_hda.c
+++ b/subsys/logging/log_backend_cavs_hda.c
@@ -20,7 +20,8 @@ static uint32_t hda_log_chan;
 /*
  * HDA requires 128 byte aligned data and 128 byte aligned transfers.
  */
-static __aligned(128) uint8_t hda_log_buf[CONFIG_LOG_BACKEND_CAVS_HDA_SIZE];
+#define ALIGNMENT DMA_BUF_ALIGNMENT(DT_NODELABEL(hda_host_in))
+static __aligned(ALIGNMENT) uint8_t hda_log_buf[CONFIG_LOG_BACKEND_CAVS_HDA_SIZE];
 static volatile uint32_t hda_log_buffered;
 static struct k_spinlock hda_log_lock;
 static struct k_timer hda_log_timer;

--- a/tests/boards/intel_adsp/hda/src/dma.c
+++ b/tests/boards/intel_adsp/hda/src/dma.c
@@ -14,7 +14,8 @@
 #define TRANSFER_SIZE 256
 #define TRANSFER_COUNT 8
 
-static __aligned(128) uint8_t dma_buf[DMA_BUF_SIZE];
+#define ALIGNMENT DMA_BUF_ALIGNMENT(DT_NODELABEL(hda_host_in))
+static __aligned(ALIGNMENT) uint8_t dma_buf[DMA_BUF_SIZE];
 
 #define HDA_HOST_IN_BASE DT_PROP_BY_IDX(DT_NODELABEL(hda_host_in), reg, 0)
 #define HDA_HOST_OUT_BASE DT_PROP_BY_IDX(DT_NODELABEL(hda_host_out), reg, 0)

--- a/tests/boards/intel_adsp/hda/src/smoke.c
+++ b/tests/boards/intel_adsp/hda/src/smoke.c
@@ -20,7 +20,8 @@
 #define HDA_BUF_SIZE 256
 #define TRANSFER_COUNT 8
 
-static __aligned(128) uint8_t hda_buf[HDA_BUF_SIZE];
+#define ALIGNMENT DT_PROP(DT_NODELABEL(hda_host_in), dma_buf_alignment)
+static __aligned(ALIGNMENT) uint8_t hda_buf[HDA_BUF_SIZE];
 
 static volatile int msg_cnt;
 static volatile int msg_res;


### PR DESCRIPTION
Adds a DMA controller buffer alignment property and uses it for Intel's HDA DMA controller

Should be useful for other DMA controllers as well where DMA alignment is known statically and does not change depending on transfer settings, e.g. burst size