### PR TITLE
cpp: Include additional contents in <cstddef>

### DIFF
--- a/subsys/cpp/include/cstddef
+++ b/subsys/cpp/include/cstddef
@@ -9,3 +9,17 @@
  *
  * @brief Stub header allowing compilation of `#include <cstddef>`
  */
+
+#ifndef ZEPHYR_SUBSYS_CPP_INCLUDE_CSTDDEF_
+#define ZEPHYR_SUBSYS_CPP_INCLUDE_CSTDDEF_
+
+#include <stddef.h>
+
+namespace std {
+	using ::ptrdiff_t;
+	using ::size_t;
+	using ::max_align_t;
+	using nullptr_t = decltype(nullptr);
+}
+
+#endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_CSTDDEF_ */


### PR DESCRIPTION
Similar to <cstdint>, this file should provide the contents of stddef.h
for C++ users.

Signed-off-by: Benjamin Gwin <bgwin@google.com>