### PR TITLE
Use picolibc for cbprintf (when building with picolibc)

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -684,11 +684,15 @@ int z_cbvprintf_impl(cbprintf_cb out, void *ctx, const char *format,
  * @return the number of characters generated, or a negative error value
  * returned from invoking @p out.
  */
+#ifdef CONFIG_PICOLIBC
+int cbvprintf(cbprintf_cb out, void *ctx, const char *format, va_list ap);
+#else
 static inline
 int cbvprintf(cbprintf_cb out, void *ctx, const char *format, va_list ap)
 {
 	return z_cbvprintf_impl(out, ctx, format, ap, 0);
 }
+#endif
 
 /** @brief varargs-aware *printf-like output through a callback with tagged arguments.
  *
@@ -760,6 +764,17 @@ int cbpprintf(cbprintf_cb out, void *ctx, void *packaged)
 }
 
 #ifdef CONFIG_CBPRINTF_LIBC_SUBSTS
+
+#ifdef CONFIG_PICOLIBC
+
+#define fprintfcb(stream, ...) fprintf(stream, __VA_ARGS__)
+#define vfprintfcb(stream, format, ap) (stream, format, ap)
+#define printfcb(format, ...) printf(format, __VA_ARGS__)
+#define vprintfcb(format, ap) vfprintf(format, ap)
+#define snprintfcb(str, size, ...) snprintf(str, size, __VA_ARGS__)
+#define vsnprintfcb(str, size, format, ap) vsnprintf(str, size, format, ap)
+
+#else
 
 /** @brief fprintf using Zephyrs cbprintf infrastructure.
  *
@@ -887,6 +902,7 @@ int snprintfcb(char *str, size_t size, const char *format, ...);
  */
 int vsnprintfcb(char *str, size_t size, const char *format, va_list ap);
 
+#endif /* CONFIG_PICOLIBC */
 #endif /* CONFIG_CBPRINTF_LIBC_SUBSTS */
 
 /**

--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -193,6 +193,32 @@ int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
 	return nbytes;
 }
 
+#include <sys/cbprintf.h>
+
+struct cb_bits {
+	FILE f;
+	cbprintf_cb out;
+	void	*ctx;
+};
+
+static int cbputc(char c, FILE *_s)
+{
+	struct cb_bits *s = (struct cb_bits *) _s;
+
+	(*s->out) (c, s->ctx);
+	return 0;
+}
+
+int cbvprintf(cbprintf_cb out, void *ctx, const char *fp, va_list ap)
+{
+	struct cb_bits	s = {
+		.f = FDEV_SETUP_STREAM(cbputc, NULL, NULL, _FDEV_SETUP_WRITE),
+		.out = out,
+		.ctx = ctx,
+	};
+	return vfprintf(&s.f, fp, ap);
+}
+
 #ifndef CONFIG_POSIX_API
 int _read(int fd, char *buf, int nbytes)
 {

--- a/lib/os/CMakeLists.txt
+++ b/lib/os/CMakeLists.txt
@@ -3,7 +3,6 @@
 zephyr_sources_ifdef(CONFIG_BASE64 base64.c)
 
 zephyr_sources(
-  cbprintf.c
   cbprintf_packaged.c
   crc32c_sw.c
   crc32_sw.c
@@ -28,6 +27,10 @@ zephyr_sources(
 
 zephyr_sources_ifdef(CONFIG_CBPRINTF_COMPLETE cbprintf_complete.c)
 zephyr_sources_ifdef(CONFIG_CBPRINTF_NANO cbprintf_nano.c)
+
+if(NOT CONFIG_PICOLIBC)
+  zephyr_sources(cbprintf.c)
+endif()
 
 zephyr_sources_ifdef(CONFIG_JSON_LIBRARY json.c)
 

--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -31,6 +31,7 @@ choice CBPRINTF_INTEGRAL_CONV
 # 01: 0% / 0 B (01 / 00)
 config CBPRINTF_FULL_INTEGRAL
 	bool "Convert the full range of integer values"
+	select PICOLIBC_IO_LONG_LONG if PICOLIBC
 	help
 	  Build cbprintf with buffers sized to support converting the full
 	  range of all integral and pointer values.
@@ -64,6 +65,7 @@ config CBPRINTF_FP_SUPPORT
 	bool "Floating point formatting in cbprintf"
 	default y if FPU
 	depends on CBPRINTF_COMPLETE
+	select PICOLIBC_IO_FLOAT if PICOLIBC
 	help
 	  Build the cbprintf utility function with support for floating
 	  point format specifiers.  Selecting this increases stack size

--- a/tests/lib/cbprintf_package/testcase.yaml
+++ b/tests/lib/cbprintf_package/testcase.yaml
@@ -106,3 +106,92 @@ tests:
     extra_configs:
       - CONFIG_CPLUSPLUS=y
       - CONFIG_CBPRINTF_NANO=y
+
+  libraries.cbprintf_package.picolibc:
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_PICOLIBC=y
+
+  libraries.cbprintf_package_no_generic.picolibc:
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_COMPILER_OPT="-DZ_C_GENERIC=0"
+      - CONFIG_PICOLIBC=y
+
+  libraries.cbprintf_package_fp.picolibc:
+    filter: CONFIG_CPU_HAS_FPU
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CBPRINTF_FP_SUPPORT=y
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_FPU=y
+      - CONFIG_PICOLIBC=y
+
+  libraries.cbprintf_package_long_double.picolibc:
+    filter: CONFIG_CPU_HAS_FPU
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CBPRINTF_FP_SUPPORT=y
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE=y
+      - CONFIG_FPU=y
+      - CONFIG_PICOLIBC=y
+
+  libraries.cbprintf_package_long_double_align_offset:
+    filter: CONFIG_CPU_HAS_FPU
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CBPRINTF_FP_SUPPORT=y
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE=y
+      - CONFIG_COMPILER_OPT="-DCBPRINTF_PACKAGE_ALIGN_OFFSET=1"
+      - CONFIG_FPU=y
+      - CONFIG_PICOLIBC=y
+
+  # Same test but with test compiled as C++
+  libraries.cbprintf_package_cpp.picolibc:
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CPLUSPLUS=y
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_PICOLIBC=y
+
+  libraries.cbprintf_package_no_generic_cpp.picolibc:
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CPLUSPLUS=y
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_COMPILER_OPT="-DZ_C_GENERIC=0"
+      - CONFIG_PICOLIBC=y
+
+  libraries.cbprintf_package_fp_cpp.picolibc:
+    filter: CONFIG_CPU_HAS_FPU
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CPLUSPLUS=y
+      - CONFIG_CBPRINTF_FP_SUPPORT=y
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_FPU=y
+      - CONFIG_PICOLIBC=y
+
+  libraries.cbprintf_package_long_double_cpp.picolibc:
+    filter: CONFIG_CPU_HAS_FPU
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_CPLUSPLUS=y
+      - CONFIG_CBPRINTF_FP_SUPPORT=y
+      - CONFIG_CBPRINTF_COMPLETE=y
+      - CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE=y
+      - CONFIG_FPU=y
+      - CONFIG_PICOLIBC=y


### PR DESCRIPTION
Picolibc's tinystdio implementation already provides a callback-based architecture, so `cbvprintf` can be implemented using that instead of replicating that functionality in Zephyr. This provides a few benefits:

 1. Smaller code size. Picolibc's printf implementation is smaller than the zephyr cbprintf implementation
 2. Verified standards conformance. Picolibc's printf code is continuously validated against a large suite of tests ensuring that it generates POSIX compatible output.
 3. Sharing with applications using stdio. Any application which uses both stdio functions (like sprintf) and cbprintf APIs will now share a common underlying formatted output path, further saving code space.
 4. Matching functionality between stdio and cbprintf APIs. Applications can count on precisely the same results using either API.

A second PR to use picolibc for printk will be posted shortly; that required an update to picolibc's cmake support which is winding its way through picolibc CI.