### PR TITLE
scripts: runners: add frequency setting support for blackmagicprobe

### DIFF
--- a/scripts/west_commands/tests/test_blackmagicprobe.py
+++ b/scripts/west_commands/tests/test_blackmagicprobe.py
@@ -22,6 +22,7 @@ EXPECTED_COMMANDS = {
       '-ex', "set confirm off",
       '-ex', "target extended-remote {}".format(TEST_GDB_SERIAL),
       '-ex', "monitor swdp_scan",
+      '-ex', "monitor frequency 50000",
       '-ex', "attach 1",
       '-ex', "file {}".format(RC_KERNEL_ELF)],),
     'debug':
@@ -29,6 +30,7 @@ EXPECTED_COMMANDS = {
       '-ex', "set confirm off",
       '-ex', "target extended-remote {}".format(TEST_GDB_SERIAL),
       '-ex', "monitor swdp_scan",
+      '-ex', "monitor frequency 50000",
       '-ex', "attach 1",
       '-ex', "file {}".format(RC_KERNEL_ELF),
       '-ex', "load {}".format(RC_KERNEL_ELF)],),
@@ -37,6 +39,7 @@ EXPECTED_COMMANDS = {
       '-ex', "set confirm off",
       '-ex', "target extended-remote {}".format(TEST_GDB_SERIAL),
       '-ex', "monitor swdp_scan",
+      '-ex', "monitor frequency 50000",
       '-ex', "attach 1",
       '-ex', "load {}".format(RC_KERNEL_ELF),
       '-ex', "kill",


### PR DESCRIPTION
Black Magic Probe supports a "monitor frequency" command that sets
adapter frequency. [1]

Not really documented in blackmagicprobe docs, but does in fact change
upload speed.

[1] https://github.com/blackmagic-debug/blackmagic/blob/master/src/command.c#L75

Signed-off-by: Krzysztof Pochwała <k.pochwala@gmail.com>