### PR TITLE
tests/subsys/logging/log_switch_format: fix incomplete logs

### DIFF
--- a/tests/subsys/logging/log_switch_format/testcase.yaml
+++ b/tests/subsys/logging/log_switch_format/testcase.yaml
@@ -5,7 +5,7 @@ common:
   arch_exclude: mips nios2 posix sparc
   filter: not CONFIG_64BIT
 tests:
-  logger.syst.v2.deferred:
+  logging.log_switch_format.deferred:
     integration_platforms:
       - mps2_an385
       - qemu_x86
@@ -21,7 +21,7 @@ tests:
         - "hello sys-t on board"
         - "SYS-T RAW DATA: "
         - "SYST Sample Execution Completed"
-  logger.syst.v2.immediate:
+  logging.log_switch_format.immediate:
     extra_args: OVERLAY_CONFIG=overlay_immediate.conf
     integration_platforms:
       - mps2_an385
@@ -37,3 +37,4 @@ tests:
         - "hello sys-t on board"
         - "SYS-T RAW DATA: "
         - "SYST Sample Execution Completed"
+        - "PROJECT EXECUTION SUCCESSFUL"


### PR DESCRIPTION
log_Switch_format test has incomplete handler logs on frdm_k64f
and also a false positive for logging.log_switch_format.immediate
testcase due to harness console which does not wait for
completion of ztest testcases to indicate pass/fail status to twister.

Fixes #46368

Signed-off-by: Aastha Grover <aastha.grover@intel.com>