### PR TITLE
Improve Emulator API 

### DIFF
--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -31,8 +31,7 @@ struct espi_emul_data {
 	sys_slist_t callbacks;
 };
 
-static struct espi_emul *espi_emul_find(const struct device *dev,
-					unsigned int chipsel)
+static struct espi_emul *espi_emul_find(const struct device *dev, unsigned int chipsel)
 {
 	struct espi_emul_data *data = dev->data;
 	sys_snode_t *node;
@@ -60,9 +59,7 @@ static int espi_emul_config(const struct device *dev, struct espi_cfg *cfg)
 	return 0;
 }
 
-
-static int emul_espi_trigger_event(const struct device *dev,
-				   struct espi_event *evt)
+static int emul_espi_trigger_event(const struct device *dev, struct espi_event *evt)
 {
 	struct espi_emul_data *data = dev->data;
 
@@ -70,8 +67,8 @@ static int emul_espi_trigger_event(const struct device *dev,
 	     !(data->cfg.channel_caps & ESPI_CHANNEL_VWIRE)) ||
 	    ((evt->evt_type & ESPI_BUS_EVENT_OOB_RECEIVED) &&
 	     !(data->cfg.channel_caps & ESPI_CHANNEL_OOB)) ||
-	    ((evt->evt_type & ESPI_BUS_PERIPHERAL_NOTIFICATION)
-	     && !(data->cfg.channel_caps & ESPI_CHANNEL_PERIPHERAL))) {
+	    ((evt->evt_type & ESPI_BUS_PERIPHERAL_NOTIFICATION) &&
+	     !(data->cfg.channel_caps & ESPI_CHANNEL_PERIPHERAL))) {
 		return -EIO;
 	}
 
@@ -87,8 +84,7 @@ static bool espi_emul_get_channel_status(const struct device *dev, enum espi_cha
 	return (data->cfg.channel_caps & ch);
 }
 
-static int espi_emul_read_lpc_request(const struct device *dev,
-				      enum lpc_peripheral_opcode op,
+static int espi_emul_read_lpc_request(const struct device *dev, enum lpc_peripheral_opcode op,
 				      uint32_t *data)
 {
 	const struct emul_espi_device_api *api;
@@ -153,7 +149,8 @@ static int espi_emul_send_vwire(const struct device *dev, enum espi_vwire_signal
 	return api->set_vw(emul, vw, level);
 }
 
-static int espi_emul_receive_vwire(const struct device *dev, enum espi_vwire_signal vw, uint8_t *level)
+static int espi_emul_receive_vwire(const struct device *dev, enum espi_vwire_signal vw,
+				   uint8_t *level)
 {
 	const struct emul_espi_device_api *api;
 	struct espi_emul *emul;
@@ -176,7 +173,8 @@ static int espi_emul_receive_vwire(const struct device *dev, enum espi_vwire_sig
 	return api->get_vw(emul, vw, level);
 }
 
-static int espi_emul_manage_callback(const struct device *dev, struct espi_callback *callback, bool set)
+static int espi_emul_manage_callback(const struct device *dev, struct espi_callback *callback,
+				     bool set)
 {
 	struct espi_emul_data *data = dev->data;
 
@@ -198,8 +196,7 @@ static int espi_emul_init(const struct device *dev)
 	return emul_init_for_bus_from_list(dev, list);
 }
 
-int espi_emul_register(const struct device *dev, const char *name,
-		       struct espi_emul *emul)
+int espi_emul_register(const struct device *dev, const char *name, struct espi_emul *emul)
 {
 	struct espi_emul_data *data = dev->data;
 
@@ -212,41 +209,31 @@ int espi_emul_register(const struct device *dev, const char *name,
 
 /* Device instantiation */
 static struct emul_espi_driver_api emul_espi_driver_api = {
-	.espi_api = {
-		.config = espi_emul_config,
-		.get_channel_status = espi_emul_get_channel_status,
-		.read_lpc_request = espi_emul_read_lpc_request,
-		.write_lpc_request = espi_emul_write_lpc_request,
-		.send_vwire = espi_emul_send_vwire,
-		.receive_vwire = espi_emul_receive_vwire,
-		.manage_callback = espi_emul_manage_callback
-	},
+	.espi_api = { .config = espi_emul_config,
+		      .get_channel_status = espi_emul_get_channel_status,
+		      .read_lpc_request = espi_emul_read_lpc_request,
+		      .write_lpc_request = espi_emul_write_lpc_request,
+		      .send_vwire = espi_emul_send_vwire,
+		      .receive_vwire = espi_emul_receive_vwire,
+		      .manage_callback = espi_emul_manage_callback },
 	.trigger_event = emul_espi_trigger_event,
 	.find_emul = espi_emul_find,
 };
 
+#define EMUL_LINK_AND_COMMA(node_id)                                                               \
+	{                                                                                          \
+		.label = DT_LABEL(node_id),                                                        \
+	},
 
-#define EMUL_LINK_AND_COMMA(node_id) {	    \
-		.label = DT_LABEL(node_id), \
-},
-
-#define ESPI_EMUL_INIT(n)					      \
-	static const struct emul_link_for_bus emuls_##n[] = {	      \
-		DT_FOREACH_CHILD(DT_DRV_INST(n), EMUL_LINK_AND_COMMA) \
-	};							      \
-	static struct emul_list_for_bus espi_emul_cfg_##n = {	      \
-		.children = emuls_##n,				      \
-		.num_children = ARRAY_SIZE(emuls_##n),		      \
-	};							      \
-	static struct espi_emul_data espi_emul_data_##n;	      \
-	DEVICE_DT_INST_DEFINE(n,				      \
-			      &espi_emul_init,			      \
-			      NULL,				      \
-			      &espi_emul_data_##n,		      \
-			      &espi_emul_cfg_##n,		      \
-			      POST_KERNEL,			      \
-			      CONFIG_ESPI_INIT_PRIORITY,	      \
-			      &emul_espi_driver_api);
-
+#define ESPI_EMUL_INIT(n)                                                                          \
+	static const struct emul_link_for_bus emuls_##n[] = { DT_FOREACH_CHILD(                    \
+		DT_DRV_INST(n), EMUL_LINK_AND_COMMA) };                                            \
+	static struct emul_list_for_bus espi_emul_cfg_##n = {                                      \
+		.children = emuls_##n,                                                             \
+		.num_children = ARRAY_SIZE(emuls_##n),                                             \
+	};                                                                                         \
+	static struct espi_emul_data espi_emul_data_##n;                                           \
+	DEVICE_DT_INST_DEFINE(n, &espi_emul_init, NULL, &espi_emul_data_##n, &espi_emul_cfg_##n,   \
+			      POST_KERNEL, CONFIG_ESPI_INIT_PRIORITY, &emul_espi_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(ESPI_EMUL_INIT)

--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -91,6 +91,8 @@ static int espi_emul_read_lpc_request(const struct device *dev, enum lpc_periphe
 	struct espi_emul *emul;
 	struct espi_emul_data *emul_data = dev->data;
 
+	ARG_UNUSED(data);
+
 	if (!(emul_data->cfg.channel_caps & ESPI_CHANNEL_VWIRE)) {
 		LOG_ERR("bad channel vwire");
 		return -EINVAL;
@@ -122,6 +124,8 @@ static int espi_emul_write_lpc_request(const struct device *dev, enum lpc_periph
 				       uint32_t *data)
 {
 	ARG_UNUSED(dev);
+	ARG_UNUSED(op);
+	ARG_UNUSED(data);
 
 	return -EINVAL;
 }

--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -109,7 +109,7 @@ static int espi_emul_read_lpc_request(const struct device *dev, enum lpc_periphe
 #ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
 	case EACPI_GET_SHARED_MEMORY:
 		__ASSERT_NO_MSG(api->get_acpi_shm);
-		*data = (uint32_t)api->get_acpi_shm(emul);
+		*data = (uint32_t)api->get_acpi_shm(emul->target);
 		break;
 #endif
 	default:
@@ -146,7 +146,7 @@ static int espi_emul_send_vwire(const struct device *dev, enum espi_vwire_signal
 	__ASSERT_NO_MSG(emul->api->set_vw);
 	api = emul->api;
 
-	return api->set_vw(emul, vw, level);
+	return api->set_vw(emul->target, vw, level);
 }
 
 static int espi_emul_receive_vwire(const struct device *dev, enum espi_vwire_signal vw,
@@ -170,7 +170,7 @@ static int espi_emul_receive_vwire(const struct device *dev, enum espi_vwire_sig
 	__ASSERT_NO_MSG(emul->api->get_vw);
 	api = emul->api;
 
-	return api->get_vw(emul, vw, level);
+	return api->get_vw(emul->target, vw, level);
 }
 
 static int espi_emul_manage_callback(const struct device *dev, struct espi_callback *callback,
@@ -189,11 +189,10 @@ static int espi_emul_manage_callback(const struct device *dev, struct espi_callb
 static int espi_emul_init(const struct device *dev)
 {
 	struct espi_emul_data *data = dev->data;
-	const struct emul_list_for_bus *list = dev->config;
 
 	sys_slist_init(&data->emuls);
 
-	return emul_init_for_bus_from_list(dev, list);
+	return emul_init_for_bus(dev);
 }
 
 int espi_emul_register(const struct device *dev, const char *name, struct espi_emul *emul)

--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -225,7 +225,7 @@ static struct emul_espi_driver_api emul_espi_driver_api = {
 
 #define EMUL_LINK_AND_COMMA(node_id)                                                               \
 	{                                                                                          \
-		.label = DT_LABEL(node_id),                                                        \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
 	},
 
 #define ESPI_EMUL_INIT(n)                                                                          \

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -90,7 +90,7 @@ static int i2c_emul_transfer(const struct device *dev, struct i2c_msg *msgs, uin
 	__ASSERT_NO_MSG(emul->api);
 	__ASSERT_NO_MSG(emul->api->transfer);
 
-	ret = api->transfer(emul, msgs, num_msgs, addr);
+	ret = api->transfer(emul->target, msgs, num_msgs, addr);
 	if (ret) {
 		return ret;
 	}
@@ -106,12 +106,11 @@ static int i2c_emul_transfer(const struct device *dev, struct i2c_msg *msgs, uin
 static int i2c_emul_init(const struct device *dev)
 {
 	struct i2c_emul_data *data = dev->data;
-	const struct emul_list_for_bus *list = dev->config;
 	int rc;
 
 	sys_slist_init(&data->emuls);
 
-	rc = emul_init_for_bus_from_list(dev, list);
+	rc = emul_init_for_bus(dev);
 
 	/* Set config to an uninitialized state */
 	data->config = (I2C_MODE_CONTROLLER | i2c_map_dt_bitrate(data->bitrate));

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -74,8 +74,8 @@ static int i2c_emul_get_config(const struct device *dev, uint32_t *dev_config)
 	return 0;
 }
 
-static int i2c_emul_transfer(const struct device *dev, struct i2c_msg *msgs,
-			     uint8_t num_msgs, uint16_t addr)
+static int i2c_emul_transfer(const struct device *dev, struct i2c_msg *msgs, uint8_t num_msgs,
+			     uint16_t addr)
 {
 	struct i2c_emul *emul;
 	const struct i2c_emul_api *api;
@@ -119,8 +119,7 @@ static int i2c_emul_init(const struct device *dev)
 	return rc;
 }
 
-int i2c_emul_register(const struct device *dev, const char *name,
-		      struct i2c_emul *emul)
+int i2c_emul_register(const struct device *dev, const char *name, struct i2c_emul *emul)
 {
 	struct i2c_emul_data *data = dev->data;
 
@@ -139,28 +138,22 @@ static struct i2c_driver_api i2c_emul_api = {
 	.transfer = i2c_emul_transfer,
 };
 
-#define EMUL_LINK_AND_COMMA(node_id) {		\
-	.label = DT_LABEL(node_id),		\
-},
+#define EMUL_LINK_AND_COMMA(node_id)                                                               \
+	{                                                                                          \
+		.label = DT_LABEL(node_id),                                                        \
+	},
 
-#define I2C_EMUL_INIT(n) \
-	static const struct emul_link_for_bus emuls_##n[] = { \
-		DT_FOREACH_CHILD(DT_DRV_INST(n), EMUL_LINK_AND_COMMA) \
-	}; \
-	static struct emul_list_for_bus i2c_emul_cfg_##n = { \
-		.children = emuls_##n, \
-		.num_children = ARRAY_SIZE(emuls_##n), \
-	}; \
-	static struct i2c_emul_data i2c_emul_data_##n = { \
-		.bitrate = DT_INST_PROP(n, clock_frequency), \
-	}; \
-	I2C_DEVICE_DT_INST_DEFINE(n, \
-			    i2c_emul_init, \
-			    NULL, \
-			    &i2c_emul_data_##n, \
-			    &i2c_emul_cfg_##n, \
-			    POST_KERNEL, \
-			    CONFIG_I2C_INIT_PRIORITY, \
-			    &i2c_emul_api);
+#define I2C_EMUL_INIT(n)                                                                           \
+	static const struct emul_link_for_bus emuls_##n[] = { DT_FOREACH_CHILD(                    \
+		DT_DRV_INST(n), EMUL_LINK_AND_COMMA) };                                            \
+	static struct emul_list_for_bus i2c_emul_cfg_##n = {                                       \
+		.children = emuls_##n,                                                             \
+		.num_children = ARRAY_SIZE(emuls_##n),                                             \
+	};                                                                                         \
+	static struct i2c_emul_data i2c_emul_data_##n = {                                          \
+		.bitrate = DT_INST_PROP(n, clock_frequency),                                       \
+	};                                                                                         \
+	I2C_DEVICE_DT_INST_DEFINE(n, i2c_emul_init, NULL, &i2c_emul_data_##n, &i2c_emul_cfg_##n,   \
+				  POST_KERNEL, CONFIG_I2C_INIT_PRIORITY, &i2c_emul_api);
 
 DT_INST_FOREACH_STATUS_OKAY(I2C_EMUL_INIT)

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -139,7 +139,7 @@ static struct i2c_driver_api i2c_emul_api = {
 
 #define EMUL_LINK_AND_COMMA(node_id)                                                               \
 	{                                                                                          \
-		.label = DT_LABEL(node_id),                                                        \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
 	},
 
 #define I2C_EMUL_INIT(n)                                                                           \

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -78,7 +78,7 @@ static int spi_emul_io(const struct device *dev, const struct spi_config *config
 	__ASSERT_NO_MSG(emul->api);
 	__ASSERT_NO_MSG(emul->api->io);
 
-	return api->io(emul, config, tx_bufs, rx_bufs);
+	return api->io(emul->target, config, tx_bufs, rx_bufs);
 }
 
 /**
@@ -89,11 +89,10 @@ static int spi_emul_io(const struct device *dev, const struct spi_config *config
 static int spi_emul_init(const struct device *dev)
 {
 	struct spi_emul_data *data = dev->data;
-	const struct emul_list_for_bus *list = dev->config;
 
 	sys_slist_init(&data->emuls);
 
-	return emul_init_for_bus_from_list(dev, list);
+	return emul_init_for_bus(dev);
 }
 
 int spi_emul_register(const struct device *dev, const char *name, struct spi_emul *emul)

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -46,8 +46,7 @@ uint32_t spi_emul_get_config(const struct device *dev)
  * @return emulator to use
  * @return NULL if not found
  */
-static struct spi_emul *spi_emul_find(const struct device *dev,
-				      unsigned int chipsel)
+static struct spi_emul *spi_emul_find(const struct device *dev, unsigned int chipsel)
 {
 	struct spi_emul_data *data = dev->data;
 	sys_snode_t *node;
@@ -64,10 +63,8 @@ static struct spi_emul *spi_emul_find(const struct device *dev,
 	return NULL;
 }
 
-static int spi_emul_io(const struct device *dev,
-		       const struct spi_config *config,
-		       const struct spi_buf_set *tx_bufs,
-		       const struct spi_buf_set *rx_bufs)
+static int spi_emul_io(const struct device *dev, const struct spi_config *config,
+		       const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs)
 {
 	struct spi_emul *emul;
 	const struct spi_emul_api *api;
@@ -99,8 +96,7 @@ static int spi_emul_init(const struct device *dev)
 	return emul_init_for_bus_from_list(dev, list);
 }
 
-int spi_emul_register(const struct device *dev, const char *name,
-		      struct spi_emul *emul)
+int spi_emul_register(const struct device *dev, const char *name, struct spi_emul *emul)
 {
 	struct spi_emul_data *data = dev->data;
 
@@ -117,26 +113,20 @@ static struct spi_driver_api spi_emul_api = {
 	.transceive = spi_emul_io,
 };
 
-#define EMUL_LINK_AND_COMMA(node_id) {		\
-	.label = DT_LABEL(node_id),		\
-},
+#define EMUL_LINK_AND_COMMA(node_id)                                                               \
+	{                                                                                          \
+		.label = DT_LABEL(node_id),                                                        \
+	},
 
-#define SPI_EMUL_INIT(n) \
-	static const struct emul_link_for_bus emuls_##n[] = { \
-		DT_FOREACH_CHILD(DT_DRV_INST(0), EMUL_LINK_AND_COMMA) \
-	}; \
-	static struct emul_list_for_bus spi_emul_cfg_##n = { \
-		.children = emuls_##n, \
-		.num_children = ARRAY_SIZE(emuls_##n), \
-	}; \
-	static struct spi_emul_data spi_emul_data_##n; \
-	DEVICE_DT_INST_DEFINE(n, \
-			    spi_emul_init, \
-			    NULL, \
-			    &spi_emul_data_##n, \
-			    &spi_emul_cfg_##n, \
-			    POST_KERNEL, \
-			    CONFIG_SPI_INIT_PRIORITY, \
-			    &spi_emul_api);
+#define SPI_EMUL_INIT(n)                                                                           \
+	static const struct emul_link_for_bus emuls_##n[] = { DT_FOREACH_CHILD(                    \
+		DT_DRV_INST(0), EMUL_LINK_AND_COMMA) };                                            \
+	static struct emul_list_for_bus spi_emul_cfg_##n = {                                       \
+		.children = emuls_##n,                                                             \
+		.num_children = ARRAY_SIZE(emuls_##n),                                             \
+	};                                                                                         \
+	static struct spi_emul_data spi_emul_data_##n;                                             \
+	DEVICE_DT_INST_DEFINE(n, spi_emul_init, NULL, &spi_emul_data_##n, &spi_emul_cfg_##n,       \
+			      POST_KERNEL, CONFIG_SPI_INIT_PRIORITY, &spi_emul_api);
 
 DT_INST_FOREACH_STATUS_OKAY(SPI_EMUL_INIT)

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -114,7 +114,7 @@ static struct spi_driver_api spi_emul_api = {
 
 #define EMUL_LINK_AND_COMMA(node_id)                                                               \
 	{                                                                                          \
-		.label = DT_LABEL(node_id),                                                        \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
 	},
 
 #define SPI_EMUL_INIT(n)                                                                           \

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -45,8 +45,7 @@ struct emul_list_for_bus {
  * @param emul Emulator to init
  * @param parent Parent device that is using the emulator
  */
-typedef int (*emul_init_t)(const struct emul *emul,
-			   const struct device *parent);
+typedef int (*emul_init_t)(const struct emul *emul, const struct device *parent);
 
 /** An emulator instance */
 struct emul {
@@ -99,8 +98,7 @@ extern const struct emul __emul_list_end[];
  * @return 0 if OK
  * @return negative value on error
  */
-int emul_init_for_bus_from_list(const struct device *dev,
-				const struct emul_list_for_bus *list);
+int emul_init_for_bus_from_list(const struct device *dev, const struct emul_list_for_bus *list);
 
 /**
  * @brief Retrieve the emul structure for an emulator by name

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -18,8 +18,22 @@
 extern "C" {
 #endif /* __cplusplus */
 
-struct device;
 struct emul;
+
+/* #includes required after forward-declaration of struct emul later defined in this header. */
+#include <zephyr/drivers/espi_emul.h>
+#include <zephyr/drivers/i2c_emul.h>
+#include <zephyr/drivers/spi_emul.h>
+#include <zephyr/device.h>
+
+/**
+ * The types of supported buses.
+ */
+enum emul_bus_type {
+	EMUL_BUS_TYPE_I2C,
+	EMUL_BUS_TYPE_ESPI,
+	EMUL_BUS_TYPE_SPI,
+};
 
 /**
  * Structure uniquely identifying a device to be emulated
@@ -47,7 +61,10 @@ struct emul_list_for_bus {
  */
 typedef int (*emul_init_t)(const struct emul *emul, const struct device *parent);
 
-/** An emulator instance */
+/** An emulator instance - represents the *target* emulated device/peripheral that is
+ * interacted with through an emulated bus. Instances of emulated bus nodes (e.g. i2c_emul)
+ * and emulators (i.e. struct emul) are exactly 1..1
+ */
 struct emul {
 	/** function used to initialise the emulator state */
 	emul_init_t init;
@@ -57,6 +74,14 @@ struct emul {
 	const void *cfg;
 	/** Emulator-specific data */
 	void *data;
+	/** The bus type that the emulator is attached to */
+	enum emul_bus_type bus_type;
+	/** Pointer to the emulated bus node */
+	union bus {
+		struct i2c_emul *i2c;
+		struct espi_emul *espi;
+		struct spi_emul *spi;
+	} bus;
 };
 
 /**
@@ -69,6 +94,17 @@ extern const struct emul __emul_list_end[];
 /* Use the devicetree node identifier as a unique name. */
 #define EMUL_REG_NAME(node_id) (_CONCAT(__emulreg_, node_id))
 
+/* Get a unique identifier based on the given _dev_node_id's reg property and
+ * the bus its on. Intended for use in other internal macros when declaring {bus}_emul
+ * structs in peripheral emulators.
+ */
+#define Z_EMUL_REG_BUS_IDENTIFIER(_dev_node_id) (_CONCAT(_CONCAT(__emulreg_, _dev_node_id), _bus))
+
+/* Conditionally places text based on what bus _dev_node_id is on. */
+#define Z_EMUL_BUS(_dev_node_id, _i2c, _espi, _spi)                                                \
+	COND_CODE_1(DT_ON_BUS(_dev_node_id, i2c), (_i2c),                                          \
+		    (COND_CODE_1(DT_ON_BUS(_dev_node_id, espi), (_espi),                           \
+				 (COND_CODE_1(DT_ON_BUS(_dev_node_id, spi), (_spi), (-EINVAL))))))
 /**
  * Define a new emulator
  *
@@ -80,25 +116,34 @@ extern const struct emul __emul_list_end[];
  * @param node_id Node ID of the driver to emulate (e.g. DT_DRV_INST(n))
  * @param cfg_ptr emulator-specific configuration data
  * @param data_ptr emulator-specific data
+ * @param bus_api emulator-specific bus api
  */
-#define EMUL_DEFINE(init_ptr, node_id, cfg_ptr, data_ptr)                                          \
+#define EMUL_DEFINE(init_ptr, node_id, cfg_ptr, data_ptr, bus_api)                                 \
+	static struct Z_EMUL_BUS(node_id, i2c_emul, espi_emul, spi_emul)                           \
+		Z_EMUL_REG_BUS_IDENTIFIER(node_id) = {                                             \
+			.api = bus_api,                                                            \
+			.Z_EMUL_BUS(node_id, addr, chipsel, chipsel) = DT_REG_ADDR(node_id),       \
+	};                                                                                         \
 	static struct emul EMUL_REG_NAME(node_id) __attribute__((__section__(".emulators")))       \
 	__used = {                                                                                 \
 		.init = (init_ptr),                                                                \
 		.dev_label = DT_LABEL(node_id),                                                    \
 		.cfg = (cfg_ptr),                                                                  \
 		.data = (data_ptr),                                                                \
+		.bus_type = Z_EMUL_BUS(node_id, EMUL_BUS_TYPE_I2C, EMUL_BUS_TYPE_ESPI,             \
+				       EMUL_BUS_TYPE_SPI),                                         \
+		.bus = {.Z_EMUL_BUS(node_id, i2c, espi, spi) =                                     \
+				&(Z_EMUL_REG_BUS_IDENTIFIER(node_id))},                            \
 	};
 
 /**
  * Set up a list of emulators
  *
  * @param dev Device the emulators are attached to (e.g. an I2C controller)
- * @param list List of devices to set up
  * @return 0 if OK
  * @return negative value on error
  */
-int emul_init_for_bus_from_list(const struct device *dev, const struct emul_list_for_bus *list);
+int emul_init_for_bus(const struct device *dev);
 
 /**
  * @brief Retrieve the emul structure for an emulator by name

--- a/include/zephyr/drivers/emul.h
+++ b/include/zephyr/drivers/emul.h
@@ -37,11 +37,9 @@ enum emul_bus_type {
 
 /**
  * Structure uniquely identifying a device to be emulated
- *
- * Currently this uses the device node label, but that will go away by 2.5.
  */
 struct emul_link_for_bus {
-	const char *label;
+	const struct device *dev;
 };
 
 /** List of emulators attached to a bus */
@@ -69,7 +67,7 @@ struct emul {
 	/** function used to initialise the emulator state */
 	emul_init_t init;
 	/** handle to the device for which this provides low-level emulation */
-	const char *dev_label;
+	const struct device *dev;
 	/** Emulator-specific configuration data */
 	const void *cfg;
 	/** Emulator-specific data */
@@ -113,7 +111,8 @@ extern const struct emul __emul_list_end[];
  *
  * @param init_ptr function to call to initialise the emulator (see emul_init
  *	typedef)
- * @param node_id Node ID of the driver to emulate (e.g. DT_DRV_INST(n))
+ * @param node_id Node ID of the driver to emulate (e.g. DT_DRV_INST(n)); the node_id *MUST* have a
+ * corresponding DEVICE_DT_DEFINE().
  * @param cfg_ptr emulator-specific configuration data
  * @param data_ptr emulator-specific data
  * @param bus_api emulator-specific bus api
@@ -127,7 +126,7 @@ extern const struct emul __emul_list_end[];
 	static struct emul EMUL_REG_NAME(node_id) __attribute__((__section__(".emulators")))       \
 	__used = {                                                                                 \
 		.init = (init_ptr),                                                                \
-		.dev_label = DT_LABEL(node_id),                                                    \
+		.dev = DEVICE_DT_GET(node_id),                                                     \
 		.cfg = (cfg_ptr),                                                                  \
 		.data = (data_ptr),                                                                \
 		.bus_type = Z_EMUL_BUS(node_id, EMUL_BUS_TYPE_I2C, EMUL_BUS_TYPE_ESPI,             \

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -7,16 +7,16 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_ESPI_SPI_EMUL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_ESPI_SPI_EMUL_H_
 
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/espi.h>
+#include <zephyr/types.h>
+
 /**
  * @file
  *
  * @brief Public APIs for the eSPI emulation drivers.
  */
-
-#include <zephyr/types.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/espi.h>
-#include <zephyr/drivers/emul.h>
 
 /**
  * @brief eSPI Emulation Interface
@@ -37,39 +37,39 @@ struct espi_emul;
  * Passes eSPI virtual wires set request (virtual wire packet) to the emulator.
  * The emulator updates the state (level) of its virtual wire.
  *
- * @param emul Emulator instance
+ * @param target The device Emulator instance
  * @param vw The signal to be set.
  * @param level The level of signal requested LOW(0) or HIGH(1).
  *
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*emul_espi_api_set_vw)(struct espi_emul *emul, enum espi_vwire_signal vw,
+typedef int (*emul_espi_api_set_vw)(const struct emul *target, enum espi_vwire_signal vw,
 				    uint8_t level);
 
 /**
  * Passes eSPI virtual wires get request (virtual wire packet) to the emulator.
  * The emulator returns the state (level) of its virtual wire.
  *
- * @param emul Emulator instance
+ * @param target The device Emulator instance
  * @param vw The signal to be get.
  * @param level The level of the signal to be get.
  *
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*emul_espi_api_get_vw)(struct espi_emul *emul, enum espi_vwire_signal vw,
+typedef int (*emul_espi_api_get_vw)(const struct emul *target, enum espi_vwire_signal vw,
 				    uint8_t *level);
 
 #ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
 /**
  * Get the ACPI shared memory address owned by the emulator.
  *
- * @param emul Emulator instance.
+ * @param target The device Emulator instance
  *
  * @retval The address of the memory.
  */
-typedef uintptr_t (*emul_espi_api_get_acpi_shm)(struct espi_emul *emul);
+typedef uintptr_t (*emul_espi_api_get_acpi_shm)(const struct emul *target);
 #endif
 
 /**
@@ -80,7 +80,7 @@ typedef uintptr_t (*emul_espi_api_get_acpi_shm)(struct espi_emul *emul);
  *
  * @param dev eSPI emulation controller device
  * @param chipsel Chip-select value
- * @return emulator to use
+ * @return espi_emul to use
  * @return NULL if not found
  */
 typedef struct espi_emul *(*emul_find_emul)(const struct device *dev, unsigned int chipsel);
@@ -109,8 +109,8 @@ struct emul_espi_device_api {
 /** Node in a linked list of emulators for eSPI devices */
 struct espi_emul {
 	sys_snode_t node;
-	/** Parent emulator */
-	const struct emul *parent;
+	/** Target emulator - REQUIRED for all emulated bus nodes of any type */
+	const struct emul *target;
 	/** API provided for this device */
 	const struct emul_espi_device_api *api;
 	/** eSPI chip-select of the emulated device */

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -44,8 +44,7 @@ struct espi_emul;
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*emul_espi_api_set_vw)(struct espi_emul *emul,
-				    enum espi_vwire_signal vw,
+typedef int (*emul_espi_api_set_vw)(struct espi_emul *emul, enum espi_vwire_signal vw,
 				    uint8_t level);
 
 /**
@@ -59,8 +58,7 @@ typedef int (*emul_espi_api_set_vw)(struct espi_emul *emul,
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*emul_espi_api_get_vw)(struct espi_emul *emul,
-				    enum espi_vwire_signal vw,
+typedef int (*emul_espi_api_get_vw)(struct espi_emul *emul, enum espi_vwire_signal vw,
 				    uint8_t *level);
 
 #ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
@@ -85,8 +83,7 @@ typedef uintptr_t (*emul_espi_api_get_acpi_shm)(struct espi_emul *emul);
  * @return emulator to use
  * @return NULL if not found
  */
-typedef struct espi_emul *(*emul_find_emul)(const struct device *dev,
-					    unsigned int chipsel);
+typedef struct espi_emul *(*emul_find_emul)(const struct device *dev, unsigned int chipsel);
 
 /**
  * Triggers an event on the emulator of eSPI controller side which causes
@@ -98,8 +95,7 @@ typedef struct espi_emul *(*emul_find_emul)(const struct device *dev,
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*emul_trigger_event)(const struct device *dev,
-				  struct espi_event *evt);
+typedef int (*emul_trigger_event)(const struct device *dev, struct espi_event *evt);
 
 /** Definition of the eSPI device emulator API */
 struct emul_espi_device_api {
@@ -140,8 +136,7 @@ struct emul_espi_driver_api {
  * @param emul eSPI emulator to use
  * @return 0 indicating success (always)
  */
-int espi_emul_register(const struct device *dev, const char *name,
-		       struct espi_emul *emul);
+int espi_emul_register(const struct device *dev, const char *name, struct espi_emul *emul);
 
 /**
  * Sets the eSPI virtual wire on the host side, which will
@@ -154,8 +149,7 @@ int espi_emul_register(const struct device *dev, const char *name,
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-int emul_espi_host_send_vw(const struct device *espi_dev,
-			   enum espi_vwire_signal vw, uint8_t level);
+int emul_espi_host_send_vw(const struct device *espi_dev, enum espi_vwire_signal vw, uint8_t level);
 
 /**
  * Perform port80 write on the emulated host side, which will
@@ -179,7 +173,6 @@ int emul_espi_host_port80_write(const struct device *espi_dev, uint32_t data);
  */
 uintptr_t emul_espi_host_get_acpi_shm(const struct device *espi_dev);
 #endif
-
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -13,16 +13,16 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_I2C_I2C_EMUL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_I2C_I2C_EMUL_H_
 
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/types.h>
+
 /**
  * @brief I2C Emulation Interface
  * @defgroup i2c_emul_interface I2C Emulation Interface
  * @ingroup io_emulators
  * @{
  */
-
-#include <zephyr/types.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/emul.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -35,8 +35,8 @@ struct i2c_emul_api;
 struct i2c_emul {
 	sys_snode_t node;
 
-	/** Parent emulator */
-	const struct emul *parent;
+	/** Target emulator - REQUIRED for all emulated bus nodes of any type */
+	const struct emul *target;
 
 	/* API provided for this device */
 	const struct i2c_emul_api *api;
@@ -49,16 +49,16 @@ struct i2c_emul {
  * Passes I2C messages to the emulator. The emulator updates the data with what
  * was read back.
  *
- * @param emul Emulator instance
+ * @param target The device Emulator instance.
  * @param msgs Array of messages to transfer. For 'read' messages, this function
- *	updates the 'buf' member with the data that was read
+ *	updates the 'buf' member with the data that was read.
  * @param num_msgs Number of messages to transfer.
  * @param addr Address of the I2C target device.
  *
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*i2c_emul_transfer_t)(struct i2c_emul *emul, struct i2c_msg *msgs, int num_msgs,
+typedef int (*i2c_emul_transfer_t)(const struct emul *target, struct i2c_msg *msgs, int num_msgs,
 				   int addr);
 
 /**

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -58,8 +58,8 @@ struct i2c_emul {
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*i2c_emul_transfer_t)(struct i2c_emul *emul, struct i2c_msg *msgs,
-				   int num_msgs, int addr);
+typedef int (*i2c_emul_transfer_t)(struct i2c_emul *emul, struct i2c_msg *msgs, int num_msgs,
+				   int addr);
 
 /**
  * Register an emulated device on the controller
@@ -69,8 +69,7 @@ typedef int (*i2c_emul_transfer_t)(struct i2c_emul *emul, struct i2c_msg *msgs,
  * @param emul I2C emulator to use
  * @return 0 indicating success (always)
  */
-int i2c_emul_register(const struct device *dev, const char *name,
-		      struct i2c_emul *emul);
+int i2c_emul_register(const struct device *dev, const char *name, struct i2c_emul *emul);
 
 /** Definition of the emulator API */
 struct i2c_emul_api {

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -7,15 +7,16 @@
 #ifndef ZEPHYR_INCLUDE_DRIVERS_SPI_SPI_EMUL_H_
 #define ZEPHYR_INCLUDE_DRIVERS_SPI_SPI_EMUL_H_
 
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/types.h>
+
 /**
  * @file
  *
  * @brief Public APIs for the SPI emulation drivers.
  */
-
-#include <zephyr/types.h>
-#include <zephyr/device.h>
-#include <zephyr/drivers/emul.h>
 
 /**
  * @brief SPI Emulation Interface
@@ -35,8 +36,8 @@ struct spi_emul_api;
 struct spi_emul {
 	sys_snode_t node;
 
-	/** Parent emulator */
-	const struct emul *parent;
+	/** Target emulator - REQUIRED for all bus emulators */
+	const struct emul *target;
 
 	/* API provided for this device */
 	const struct spi_emul_api *api;
@@ -49,7 +50,7 @@ struct spi_emul {
  * Passes SPI messages to the emulator. The emulator updates the data with what
  * was read back.
  *
- * @param emul Emulator instance
+ * @param target The device Emulator instance
  * @param config Pointer to a valid spi_config structure instance.
  *        Pointer-comparison may be used to detect changes from
  *        previous operations.
@@ -61,7 +62,7 @@ struct spi_emul {
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*spi_emul_io_t)(struct spi_emul *emul, const struct spi_config *config,
+typedef int (*spi_emul_io_t)(const struct emul *target, const struct spi_config *config,
 			     const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs);
 
 /**

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -61,10 +61,8 @@ struct spi_emul {
  * @retval 0 If successful.
  * @retval -EIO General input / output error.
  */
-typedef int (*spi_emul_io_t)(struct spi_emul *emul,
-			     const struct spi_config *config,
-			     const struct spi_buf_set *tx_bufs,
-			     const struct spi_buf_set *rx_bufs);
+typedef int (*spi_emul_io_t)(struct spi_emul *emul, const struct spi_config *config,
+			     const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs);
 
 /**
  * Register an emulated device on the controller
@@ -74,8 +72,7 @@ typedef int (*spi_emul_io_t)(struct spi_emul *emul,
  * @param emul SPI emulator to use
  * @return 0 indicating success (always)
  */
-int spi_emul_register(const struct device *dev, const char *name,
-		      struct spi_emul *emul);
+int spi_emul_register(const struct device *dev, const char *name, struct spi_emul *emul);
 
 /** Definition of the emulator API */
 struct spi_emul_api {

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -26,7 +26,7 @@ const struct emul *emul_get_binding(const char *name)
 	return NULL;
 }
 
-int emul_init_for_bus_from_list(const struct device *dev, const struct emul_list_for_bus *list)
+int emul_init_for_bus(const struct device *dev)
 {
 	const struct emul_list_for_bus *cfg = dev->config;
 
@@ -43,10 +43,48 @@ int emul_init_for_bus_from_list(const struct device *dev, const struct emul_list
 
 		__ASSERT(emul, "Cannot find emulator for '%s'", elp->label);
 
+		switch (emul->bus_type) {
+		case EMUL_BUS_TYPE_I2C:
+			emul->bus.i2c->target = emul;
+			break;
+		case EMUL_BUS_TYPE_ESPI:
+			emul->bus.espi->target = emul;
+			break;
+		case EMUL_BUS_TYPE_SPI:
+			emul->bus.spi->target = emul;
+			break;
+		}
 		int rc = emul->init(emul, dev);
 
 		if (rc != 0) {
-			LOG_WRN("Init %s emulator failed: %d\n", elp->label, rc);
+			LOG_WRN("Init %s emulator failed: %d",
+				 elp->label, rc);
+		}
+
+		switch (emul->bus_type) {
+#ifdef CONFIG_I2C_EMUL
+		case EMUL_BUS_TYPE_I2C:
+			rc = i2c_emul_register(dev, emul->dev_label, emul->bus.i2c);
+			break;
+#endif /* CONFIG_I2C_EMUL */
+#ifdef CONFIG_ESPI_EMUL
+		case EMUL_BUS_TYPE_ESPI:
+			rc = espi_emul_register(dev, emul->dev_label, emul->bus.espi);
+			break;
+#endif /* CONFIG_ESPI_EMUL */
+#ifdef CONFIG_SPI_EMUL
+		case EMUL_BUS_TYPE_SPI:
+			rc = spi_emul_register(dev, emul->dev_label, emul->bus.spi);
+			break;
+#endif /* CONFIG_SPI_EMUL */
+		default:
+			rc = -EINVAL;
+			LOG_WRN("Found no emulated bus enabled to register emulator %s",
+				elp->label);
+		}
+
+		if (rc != 0) {
+			LOG_WRN("Failed to register emulator for %s: %d", elp->label, rc);
 		}
 	}
 

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -26,8 +26,7 @@ const struct emul *emul_get_binding(const char *name)
 	return NULL;
 }
 
-int emul_init_for_bus_from_list(const struct device *dev,
-				const struct emul_list_for_bus *list)
+int emul_init_for_bus_from_list(const struct device *dev, const struct emul_list_for_bus *list)
 {
 	const struct emul_list_for_bus *cfg = dev->config;
 
@@ -36,11 +35,9 @@ int emul_init_for_bus_from_list(const struct device *dev,
 	 * initialise it.
 	 */
 	const struct emul_link_for_bus *elp;
-	const struct emul_link_for_bus *const end =
-		cfg->children + cfg->num_children;
+	const struct emul_link_for_bus *const end = cfg->children + cfg->num_children;
 
-	LOG_INF("Registering %d emulator(s) for %s", cfg->num_children,
-		dev->name);
+	LOG_INF("Registering %d emulator(s) for %s", cfg->num_children, dev->name);
 	for (elp = cfg->children; elp < end; elp++) {
 		const struct emul *emul = emul_get_binding(elp->label);
 
@@ -49,8 +46,7 @@ int emul_init_for_bus_from_list(const struct device *dev,
 		int rc = emul->init(emul, dev);
 
 		if (rc != 0) {
-			LOG_WRN("Init %s emulator failed: %d\n",
-				 elp->label, rc);
+			LOG_WRN("Init %s emulator failed: %d\n", elp->label, rc);
 		}
 	}
 

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -18,7 +18,7 @@ const struct emul *emul_get_binding(const char *name)
 	const struct emul *emul_it;
 
 	for (emul_it = __emul_list_start; emul_it < __emul_list_end; emul_it++) {
-		if (strcmp(emul_it->dev_label, name) == 0) {
+		if (strcmp(emul_it->dev->name, name) == 0) {
 			return emul_it;
 		}
 	}
@@ -39,9 +39,9 @@ int emul_init_for_bus(const struct device *dev)
 
 	LOG_INF("Registering %d emulator(s) for %s", cfg->num_children, dev->name);
 	for (elp = cfg->children; elp < end; elp++) {
-		const struct emul *emul = emul_get_binding(elp->label);
+		const struct emul *emul = emul_get_binding(elp->dev->name);
 
-		__ASSERT(emul, "Cannot find emulator for '%s'", elp->label);
+		__ASSERT(emul, "Cannot find emulator for '%s'", elp->dev->name);
 
 		switch (emul->bus_type) {
 		case EMUL_BUS_TYPE_I2C:
@@ -58,33 +58,33 @@ int emul_init_for_bus(const struct device *dev)
 
 		if (rc != 0) {
 			LOG_WRN("Init %s emulator failed: %d",
-				 elp->label, rc);
+				 elp->dev->name, rc);
 		}
 
 		switch (emul->bus_type) {
 #ifdef CONFIG_I2C_EMUL
 		case EMUL_BUS_TYPE_I2C:
-			rc = i2c_emul_register(dev, emul->dev_label, emul->bus.i2c);
+			rc = i2c_emul_register(dev, emul->dev->name, emul->bus.i2c);
 			break;
 #endif /* CONFIG_I2C_EMUL */
 #ifdef CONFIG_ESPI_EMUL
 		case EMUL_BUS_TYPE_ESPI:
-			rc = espi_emul_register(dev, emul->dev_label, emul->bus.espi);
+			rc = espi_emul_register(dev, emul->dev->name, emul->bus.espi);
 			break;
 #endif /* CONFIG_ESPI_EMUL */
 #ifdef CONFIG_SPI_EMUL
 		case EMUL_BUS_TYPE_SPI:
-			rc = spi_emul_register(dev, emul->dev_label, emul->bus.spi);
+			rc = spi_emul_register(dev, emul->dev->name, emul->bus.spi);
 			break;
 #endif /* CONFIG_SPI_EMUL */
 		default:
 			rc = -EINVAL;
 			LOG_WRN("Found no emulated bus enabled to register emulator %s",
-				elp->label);
+				elp->dev->name);
 		}
 
 		if (rc != 0) {
-			LOG_WRN("Failed to register emulator for %s: %d", elp->label, rc);
+			LOG_WRN("Failed to register emulator for %s: %d", elp->dev->name, rc);
 		}
 	}
 

--- a/subsys/emul/emul_bmi160.c
+++ b/subsys/emul/emul_bmi160.c
@@ -46,7 +46,7 @@ struct bmi160_emul_cfg {
 /* Names for the PMU components */
 static const char *const pmu_name[] = { "acc", "gyr", "mag", "INV" };
 
-static void sample_read(struct bmi160_emul_data *data, union bmi160_sample *buf)
+static void sample_read(union bmi160_sample *buf)
 {
 	/*
 	 * Use hard-coded scales to get values just above 0, 1, 2 and
@@ -175,6 +175,8 @@ static int bmi160_emul_io_spi(const struct emul *emulator, const struct spi_conf
 	unsigned int regn, val;
 	int count;
 
+	ARG_UNUSED(config);
+
 	data = emulator->data;
 
 	__ASSERT_NO_MSG(tx_bufs || rx_bufs);
@@ -206,7 +208,7 @@ static int bmi160_emul_io_spi(const struct emul *emulator, const struct spi_conf
 				break;
 			case BMI160_SAMPLE_SIZE:
 				if (regn & BMI160_REG_READ) {
-					sample_read(data, rxd->buf);
+					sample_read(rxd->buf);
 				} else {
 					LOG_INF("Unknown sample write");
 				}
@@ -263,7 +265,7 @@ static int bmi160_emul_transfer_i2c(const struct emul *emulator, struct i2c_msg 
 				msgs->buf[0] = val;
 				break;
 			case BMI160_SAMPLE_SIZE:
-				sample_read(data, (void *)msgs->buf);
+				sample_read((void *)msgs->buf);
 				break;
 			default:
 				LOG_ERR("Unexpected msg1 length %d", msgs->len);
@@ -304,6 +306,8 @@ static int emul_bosch_bmi160_init(const struct emul *target, const struct device
 	const struct bmi160_emul_cfg *cfg = target->cfg;
 	struct bmi160_emul_data *data = target->data;
 	uint8_t *reg = cfg->reg;
+
+	ARG_UNUSED(parent);
 
 	data->pmu_status = 0;
 

--- a/subsys/emul/emul_bmi160.c
+++ b/subsys/emul/emul_bmi160.c
@@ -39,6 +39,8 @@ struct bmi160_emul_data {
 
 /** Static configuration for the emulator */
 struct bmi160_emul_cfg {
+	/** Label of the SPI bus this emulator connects to */
+	const char *bus_label;
 	/** Chip registers */
 	uint8_t *reg;
 	union {
@@ -50,7 +52,7 @@ struct bmi160_emul_cfg {
 };
 
 /* Names for the PMU components */
-static const char *const pmu_name[] = {"acc", "gyr", "mag", "INV"};
+static const char *const pmu_name[] = { "acc", "gyr", "mag", "INV" };
 
 static void sample_read(struct bmi160_emul_data *data, union bmi160_sample *buf)
 {
@@ -64,8 +66,8 @@ static void sample_read(struct bmi160_emul_data *data, union bmi160_sample *buf)
 	 * acc[y] = 0x0689  // 1 * 1000000 / BMI160_ACC_SCALE(2) + 1
 	 * acc[z] = 0x0d11  // 2 * 1000000 / BMI160_ACC_SCALE(2) + 1
 	 */
-	static uint8_t raw_data[] = { 0x01, 0x0b, 0xac, 0x0e, 0x57, 0x12, 0x01, 0x00,
-							0x89, 0x06, 0x11, 0x0d };
+	static uint8_t raw_data[] = { 0x01, 0x0b, 0xac, 0x0e, 0x57, 0x12,
+				      0x01, 0x00, 0x89, 0x06, 0x11, 0x0d };
 
 	LOG_INF("Sample read");
 	memcpy(buf->raw, raw_data, ARRAY_SIZE(raw_data));
@@ -98,8 +100,7 @@ static void reg_write(const struct emul *emulator, int regn, int val)
 			break;
 		default:
 			if ((val & BMI160_CMD_PMU_BIT) == BMI160_CMD_PMU_BIT) {
-				int which = (val & BMI160_CMD_PMU_MASK) >>
-					 BMI160_CMD_PMU_SHIFT;
+				int which = (val & BMI160_CMD_PMU_MASK) >> BMI160_CMD_PMU_SHIFT;
 				int shift;
 				int pmu_val = val & BMI160_CMD_PMU_VAL_MASK;
 
@@ -117,8 +118,7 @@ static void reg_write(const struct emul *emulator, int regn, int val)
 				}
 				data->pmu_status &= 3 << shift;
 				data->pmu_status |= pmu_val << shift;
-				LOG_INF("   * pmu %s = %x, new status %x",
-					pmu_name[which], pmu_val,
+				LOG_INF("   * pmu %s = %x, new status %x", pmu_name[which], pmu_val,
 					data->pmu_status);
 			} else {
 				LOG_INF("Unknown command %x", val);
@@ -175,10 +175,8 @@ static int reg_read(const struct emul *emulator, int regn)
 }
 
 #if BMI160_BUS_SPI
-static int bmi160_emul_io_spi(struct spi_emul *emul,
-			      const struct spi_config *config,
-			      const struct spi_buf_set *tx_bufs,
-			      const struct spi_buf_set *rx_bufs)
+static int bmi160_emul_io_spi(struct spi_emul *emul, const struct spi_config *config,
+			      const struct spi_buf_set *tx_bufs, const struct spi_buf_set *rx_bufs)
 {
 	struct bmi160_emul_data *data;
 	const struct spi_buf *tx, *txd, *rxd;
@@ -188,8 +186,7 @@ static int bmi160_emul_io_spi(struct spi_emul *emul,
 	data = CONTAINER_OF(emul, struct bmi160_emul_data, emul_spi);
 
 	__ASSERT_NO_MSG(tx_bufs || rx_bufs);
-	__ASSERT_NO_MSG(!tx_bufs || !rx_bufs ||
-			tx_bufs->count == rx_bufs->count);
+	__ASSERT_NO_MSG(!tx_bufs || !rx_bufs || tx_bufs->count == rx_bufs->count);
 	count = tx_bufs ? tx_bufs->count : rx_bufs->count;
 
 	switch (count) {
@@ -242,8 +239,8 @@ static int bmi160_emul_io_spi(struct spi_emul *emul,
 #endif
 
 #if BMI160_BUS_I2C
-static int bmi160_emul_transfer_i2c(struct i2c_emul *emul, struct i2c_msg *msgs,
-				    int num_msgs, int addr)
+static int bmi160_emul_transfer_i2c(struct i2c_emul *emul, struct i2c_msg *msgs, int num_msgs,
+				    int addr)
 {
 	struct bmi160_emul_data *data;
 	unsigned int val;
@@ -310,8 +307,7 @@ static struct i2c_emul_api bmi160_emul_api_i2c = {
 };
 #endif
 
-static void emul_bosch_bmi160_init(const struct emul *emul,
-				   const struct device *parent)
+static void emul_bosch_bmi160_init(const struct emul *emul, const struct device *parent)
 {
 	const struct bmi160_emul_cfg *cfg = emul->cfg;
 	struct bmi160_emul_data *data = emul->data;
@@ -334,8 +330,7 @@ static void emul_bosch_bmi160_init(const struct emul *emul,
  * @param parent Device to emulate (must use BMI160 driver)
  * @return 0 indicating success (always)
  */
-static int emul_bosch_bmi160_init_spi(const struct emul *emul,
-				      const struct device *parent)
+static int emul_bosch_bmi160_init_spi(const struct emul *emul, const struct device *parent)
 {
 	const struct bmi160_emul_cfg *cfg = emul->cfg;
 	struct bmi160_emul_data *data = emul->data;
@@ -362,8 +357,7 @@ static int emul_bosch_bmi160_init_spi(const struct emul *emul,
  * @param parent Device to emulate (must use BMI160 driver)
  * @return 0 indicating success (always)
  */
-static int emul_bosch_bmi160_init_i2c(const struct emul *emul,
-				      const struct device *parent)
+static int emul_bosch_bmi160_init_i2c(const struct emul *emul, const struct device *parent)
 {
 	const struct bmi160_emul_cfg *cfg = emul->cfg;
 	struct bmi160_emul_data *data = emul->data;
@@ -379,38 +373,37 @@ static int emul_bosch_bmi160_init_i2c(const struct emul *emul,
 }
 #endif
 
-#define BMI160_EMUL_DATA(n) \
-	static uint8_t bmi160_emul_reg_##n[BMI160_REG_COUNT]; \
+#define BMI160_EMUL_DATA(n)                                                                        \
+	static uint8_t bmi160_emul_reg_##n[BMI160_REG_COUNT];                                      \
 	static struct bmi160_emul_data bmi160_emul_data_##n;
 
-#define BMI160_EMUL_DEFINE(n, type) \
-	EMUL_DEFINE(emul_bosch_bmi160_init_##type, DT_DRV_INST(n), \
-		&bmi160_emul_cfg_##n, &bmi160_emul_data_##n)
+#define BMI160_EMUL_DEFINE(n, type)                                                                \
+	EMUL_DEFINE(emul_bosch_bmi160_init_##type, DT_DRV_INST(n), &bmi160_emul_cfg_##n,           \
+		    &bmi160_emul_data_##n)
 
 /* Instantiation macros used when a device is on a SPI bus */
-#define BMI160_EMUL_SPI(n) \
-	BMI160_EMUL_DATA(n) \
-	static const struct bmi160_emul_cfg bmi160_emul_cfg_##n = { \
-		.reg = bmi160_emul_reg_##n, \
-		.chipsel = DT_INST_REG_ADDR(n) \
-	}; \
+#define BMI160_EMUL_SPI(n)                                                                         \
+	BMI160_EMUL_DATA(n)                                                                        \
+	static const struct bmi160_emul_cfg bmi160_emul_cfg_##n = { .bus_label =                   \
+									    DT_INST_BUS_LABEL(n),  \
+								    .reg = bmi160_emul_reg_##n,    \
+								    .chipsel =                     \
+									    DT_INST_REG_ADDR(n) }; \
 	BMI160_EMUL_DEFINE(n, spi)
 
-#define BMI160_EMUL_I2C(n) \
-	BMI160_EMUL_DATA(n) \
-	static const struct bmi160_emul_cfg bmi160_emul_cfg_##n = { \
-		.reg = bmi160_emul_reg_##n, \
-		.addr = DT_INST_REG_ADDR(n) \
-	}; \
+#define BMI160_EMUL_I2C(n)                                                                         \
+	BMI160_EMUL_DATA(n)                                                                        \
+	static const struct bmi160_emul_cfg bmi160_emul_cfg_##n = { .bus_label =                   \
+									    DT_INST_BUS_LABEL(n),  \
+								    .reg = bmi160_emul_reg_##n,    \
+								    .addr = DT_INST_REG_ADDR(n) }; \
 	BMI160_EMUL_DEFINE(n, i2c)
 
 /*
  * Main instantiation macro. Use of COND_CODE_1() selects the right
  * bus-specific macro at preprocessor time.
  */
-#define BMI160_EMUL(n) \
-	COND_CODE_1(DT_INST_ON_BUS(n, spi), \
-		    (BMI160_EMUL_SPI(n)), \
-		    (BMI160_EMUL_I2C(n)))
+#define BMI160_EMUL(n)                                                                             \
+	COND_CODE_1(DT_INST_ON_BUS(n, spi), (BMI160_EMUL_SPI(n)), (BMI160_EMUL_I2C(n)))
 
 DT_INST_FOREACH_STATUS_OKAY(BMI160_EMUL)

--- a/subsys/emul/espi/emul_espi_host.c
+++ b/subsys/emul/espi/emul_espi_host.c
@@ -250,6 +250,8 @@ static int emul_host_init(const struct emul *emul, const struct device *bus)
 {
 	struct espi_host_emul_data *data = emul->data;
 
+	ARG_UNUSED(bus);
+
 	emul_host_init_vw_state(data);
 
 	return 0;

--- a/subsys/emul/espi/emul_espi_host.c
+++ b/subsys/emul/espi/emul_espi_host.c
@@ -31,33 +31,33 @@ struct vw_data {
 
 /** Declare the default state of virtual wires */
 const static struct vw_data vw_state_default[] = {
-	{ ESPI_VWIRE_SIGNAL_SLP_S3,        0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_SLP_S4,        0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_SLP_S5,        0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_SUS_STAT,      0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_PLTRST,        0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_OOB_RST_WARN,  0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_OOB_RST_ACK,   0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_WAKE,          0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_PME,           0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_SLP_S3, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_SLP_S4, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_SLP_S5, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_SUS_STAT, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_PLTRST, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_OOB_RST_WARN, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_OOB_RST_ACK, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_WAKE, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_PME, 0, ESPI_SLAVE_TO_MASTER },
 	{ ESPI_VWIRE_SIGNAL_SLV_BOOT_DONE, 0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_ERR_FATAL,     0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_ERR_FATAL, 0, ESPI_SLAVE_TO_MASTER },
 	{ ESPI_VWIRE_SIGNAL_ERR_NON_FATAL, 0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_SLV_BOOT_STS,  0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_SCI,           0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_SMI,           0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_RST_CPU_INIT,  0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_HOST_RST_ACK,  0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_SLV_BOOT_STS, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_SCI, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_SMI, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_RST_CPU_INIT, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_HOST_RST_ACK, 0, ESPI_SLAVE_TO_MASTER },
 	{ ESPI_VWIRE_SIGNAL_HOST_RST_WARN, 0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_SUS_ACK,       0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_DNX_ACK,       0, ESPI_SLAVE_TO_MASTER },
-	{ ESPI_VWIRE_SIGNAL_SUS_WARN,      0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_SUS_ACK, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_DNX_ACK, 0, ESPI_SLAVE_TO_MASTER },
+	{ ESPI_VWIRE_SIGNAL_SUS_WARN, 0, ESPI_MASTER_TO_SLAVE },
 	{ ESPI_VWIRE_SIGNAL_SUS_PWRDN_ACK, 0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_SLP_A,         0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_SLP_LAN,       0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_SLP_WLAN,      0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_HOST_C10,      0, ESPI_MASTER_TO_SLAVE },
-	{ ESPI_VWIRE_SIGNAL_DNX_WARN,      0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_SLP_A, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_SLP_LAN, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_SLP_WLAN, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_HOST_C10, 0, ESPI_MASTER_TO_SLAVE },
+	{ ESPI_VWIRE_SIGNAL_DNX_WARN, 0, ESPI_MASTER_TO_SLAVE },
 };
 
 #define NUMBER_OF_VWIRES ARRAY_SIZE(vw_state_default)
@@ -109,8 +109,7 @@ static void emul_host_init_vw_state(struct espi_host_emul_data *data)
  * @return index in the array
  * @return -1 if not found
  */
-static int emul_host_find_index(struct espi_host_emul_data *data,
-				enum espi_vwire_signal vw)
+static int emul_host_find_index(struct espi_host_emul_data *data, enum espi_vwire_signal vw)
 {
 	int idx;
 
@@ -123,8 +122,7 @@ static int emul_host_find_index(struct espi_host_emul_data *data,
 	return -1;
 }
 
-static int emul_host_set_vw(struct espi_emul *emul, enum espi_vwire_signal vw,
-			    uint8_t level)
+static int emul_host_set_vw(struct espi_emul *emul, enum espi_vwire_signal vw, uint8_t level)
 {
 	struct espi_host_emul_data *data;
 	int idx;
@@ -142,8 +140,7 @@ static int emul_host_set_vw(struct espi_emul *emul, enum espi_vwire_signal vw,
 	return 0;
 }
 
-static int emul_host_get_vw(struct espi_emul *emul, enum espi_vwire_signal vw,
-			    uint8_t *level)
+static int emul_host_get_vw(struct espi_emul *emul, enum espi_vwire_signal vw, uint8_t *level)
 {
 	struct espi_host_emul_data *data;
 	int idx;
@@ -161,8 +158,7 @@ static int emul_host_get_vw(struct espi_emul *emul, enum espi_vwire_signal vw,
 	return 0;
 }
 
-int emul_espi_host_send_vw(const struct device *espi_dev, enum espi_vwire_signal vw,
-			   uint8_t level)
+int emul_espi_host_send_vw(const struct device *espi_dev, enum espi_vwire_signal vw, uint8_t level)
 {
 	struct espi_emul *emul_espi;
 	struct espi_event evt;
@@ -218,8 +214,7 @@ int emul_espi_host_port80_write(const struct device *espi_dev, uint32_t data)
 #ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
 static uintptr_t emul_espi_dev_get_acpi_shm(struct espi_emul *emul)
 {
-	struct espi_host_emul_data *data =
-		CONTAINER_OF(emul, struct espi_host_emul_data, emul);
+	struct espi_host_emul_data *data = CONTAINER_OF(emul, struct espi_host_emul_data, emul);
 
 	return (uintptr_t)data->shm_acpi_mmap;
 }
@@ -231,7 +226,7 @@ uintptr_t emul_espi_host_get_acpi_shm(const struct device *espi_dev)
 
 	__ASSERT_NO_MSG(rc == 0);
 
-	return (uintptr_t) shm;
+	return (uintptr_t)shm;
 }
 #endif
 

--- a/subsys/emul/espi/emul_espi_host.c
+++ b/subsys/emul/espi/emul_espi_host.c
@@ -109,7 +109,8 @@ static void emul_host_init_vw_state(struct espi_host_emul_data *data)
  * @return index in the array
  * @return -1 if not found
  */
-static int emul_host_find_index(struct espi_host_emul_data *data, enum espi_vwire_signal vw)
+static int emul_host_find_index(struct espi_host_emul_data *data,
+				enum espi_vwire_signal vw)
 {
 	int idx;
 
@@ -122,12 +123,12 @@ static int emul_host_find_index(struct espi_host_emul_data *data, enum espi_vwir
 	return -1;
 }
 
-static int emul_host_set_vw(struct espi_emul *emul, enum espi_vwire_signal vw, uint8_t level)
+static int emul_host_set_vw(const struct emul *emulator,
+			    enum espi_vwire_signal vw, uint8_t level)
 {
-	struct espi_host_emul_data *data;
+	struct espi_host_emul_data *data = emulator->data;
 	int idx;
 
-	data = CONTAINER_OF(emul, struct espi_host_emul_data, emul);
 	idx = emul_host_find_index(data, vw);
 
 	if (idx < 0 || data->vw_state[idx].dir != ESPI_SLAVE_TO_MASTER) {
@@ -140,12 +141,12 @@ static int emul_host_set_vw(struct espi_emul *emul, enum espi_vwire_signal vw, u
 	return 0;
 }
 
-static int emul_host_get_vw(struct espi_emul *emul, enum espi_vwire_signal vw, uint8_t *level)
+static int emul_host_get_vw(const struct emul *emulator,
+			    enum espi_vwire_signal vw, uint8_t *level)
 {
-	struct espi_host_emul_data *data;
+	struct espi_host_emul_data *data = emulator->data;
 	int idx;
 
-	data = CONTAINER_OF(emul, struct espi_host_emul_data, emul);
 	idx = emul_host_find_index(data, vw);
 
 	if (idx < 0 || data->vw_state[idx].dir != ESPI_MASTER_TO_SLAVE) {
@@ -158,7 +159,8 @@ static int emul_host_get_vw(struct espi_emul *emul, enum espi_vwire_signal vw, u
 	return 0;
 }
 
-int emul_espi_host_send_vw(const struct device *espi_dev, enum espi_vwire_signal vw, uint8_t level)
+int emul_espi_host_send_vw(const struct device *espi_dev, enum espi_vwire_signal vw,
+			   uint8_t level)
 {
 	struct espi_emul *emul_espi;
 	struct espi_event evt;
@@ -173,7 +175,7 @@ int emul_espi_host_send_vw(const struct device *espi_dev, enum espi_vwire_signal
 	__ASSERT_NO_MSG(api->find_emul);
 
 	emul_espi = api->find_emul(espi_dev, EMUL_ESPI_HOST_CHIPSEL);
-	data_host = CONTAINER_OF(emul_espi, struct espi_host_emul_data, emul);
+	data_host = espi_dev->data;
 
 	idx = emul_host_find_index(data_host, vw);
 	if (idx < 0 || data_host->vw_state[idx].dir != ESPI_MASTER_TO_SLAVE) {
@@ -212,9 +214,9 @@ int emul_espi_host_port80_write(const struct device *espi_dev, uint32_t data)
 }
 
 #ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
-static uintptr_t emul_espi_dev_get_acpi_shm(struct espi_emul *emul)
+static uintptr_t emul_espi_dev_get_acpi_shm(const struct emul *emulator)
 {
-	struct espi_host_emul_data *data = CONTAINER_OF(emul, struct espi_host_emul_data, emul);
+	struct espi_host_emul_data *data = emulator->data;
 
 	return (uintptr_t)data->shm_acpi_mmap;
 }
@@ -226,7 +228,7 @@ uintptr_t emul_espi_host_get_acpi_shm(const struct device *espi_dev)
 
 	__ASSERT_NO_MSG(rc == 0);
 
-	return (uintptr_t)shm;
+	return (uintptr_t) shm;
 }
 #endif
 
@@ -246,16 +248,11 @@ static struct emul_espi_device_api ap_emul_api = {
  */
 static int emul_host_init(const struct emul *emul, const struct device *bus)
 {
-	const struct espi_host_emul_cfg *cfg = emul->cfg;
 	struct espi_host_emul_data *data = emul->data;
 
-	data->emul.api = &ap_emul_api;
-	data->emul.chipsel = cfg->chipsel;
-	data->emul.parent = emul;
-	data->espi = bus;
 	emul_host_init_vw_state(data);
 
-	return espi_emul_register(bus, emul->dev_label, &data->emul);
+	return 0;
 }
 
 #define HOST_EMUL(n)                                                                               \
@@ -264,6 +261,6 @@ static int emul_host_init(const struct emul *emul, const struct device *bus)
 		.chipsel = DT_INST_REG_ADDR(n),                                                    \
 	};                                                                                         \
 	EMUL_DEFINE(emul_host_init, DT_DRV_INST(n), &espi_host_emul_cfg_##n,                       \
-		    &espi_host_emul_data_##n)
+		    &espi_host_emul_data_##n, &ap_emul_api)
 
 DT_INST_FOREACH_STATUS_OKAY(HOST_EMUL)

--- a/subsys/emul/espi/emul_espi_host.c
+++ b/subsys/emul/espi/emul_espi_host.c
@@ -123,10 +123,10 @@ static int emul_host_find_index(struct espi_host_emul_data *data,
 	return -1;
 }
 
-static int emul_host_set_vw(const struct emul *emulator,
+static int emul_host_set_vw(const struct emul *target,
 			    enum espi_vwire_signal vw, uint8_t level)
 {
-	struct espi_host_emul_data *data = emulator->data;
+	struct espi_host_emul_data *data = target->data;
 	int idx;
 
 	idx = emul_host_find_index(data, vw);
@@ -141,10 +141,10 @@ static int emul_host_set_vw(const struct emul *emulator,
 	return 0;
 }
 
-static int emul_host_get_vw(const struct emul *emulator,
+static int emul_host_get_vw(const struct emul *target,
 			    enum espi_vwire_signal vw, uint8_t *level)
 {
-	struct espi_host_emul_data *data = emulator->data;
+	struct espi_host_emul_data *data = target->data;
 	int idx;
 
 	idx = emul_host_find_index(data, vw);
@@ -214,9 +214,9 @@ int emul_espi_host_port80_write(const struct device *espi_dev, uint32_t data)
 }
 
 #ifdef CONFIG_ESPI_PERIPHERAL_ACPI_SHM_REGION
-static uintptr_t emul_espi_dev_get_acpi_shm(const struct emul *emulator)
+static uintptr_t emul_espi_dev_get_acpi_shm(const struct emul *target)
 {
-	struct espi_host_emul_data *data = emulator->data;
+	struct espi_host_emul_data *data = target->data;
 
 	return (uintptr_t)data->shm_acpi_mmap;
 }

--- a/subsys/emul/i2c/emul_atmel_at24.c
+++ b/subsys/emul/i2c/emul_atmel_at24.c
@@ -52,8 +52,7 @@ struct at24_emul_cfg {
  * @retval 0 If successful
  * @retval -EIO General input / output error
  */
-static int at24_emul_transfer(struct i2c_emul *emul, struct i2c_msg *msgs,
-			      int num_msgs, int addr)
+static int at24_emul_transfer(struct i2c_emul *emul, struct i2c_msg *msgs, int num_msgs, int addr)
 {
 	struct at24_emul_data *data;
 	const struct at24_emul_cfg *cfg;
@@ -65,8 +64,7 @@ static int at24_emul_transfer(struct i2c_emul *emul, struct i2c_msg *msgs,
 	cfg = emul->parent->cfg;
 
 	if (cfg->addr != addr) {
-		LOG_ERR("Address mismatch, expected %02x, got %02x", cfg->addr,
-			addr);
+		LOG_ERR("Address mismatch, expected %02x, got %02x", cfg->addr, addr);
 		return -EIO;
 	}
 
@@ -135,8 +133,7 @@ static struct i2c_emul_api at24_emul_api = {
  * @param parent Device to emulate (must use AT24 driver)
  * @return 0 indicating success (always)
  */
-static int emul_atmel_at24_init(const struct emul *emul,
-				const struct device *parent)
+static int emul_atmel_at24_init(const struct emul *emul, const struct device *parent)
 {
 	const struct at24_emul_cfg *cfg = emul->cfg;
 	struct at24_emul_data *data = emul->data;

--- a/subsys/emul/i2c/emul_atmel_at24.c
+++ b/subsys/emul/i2c/emul_atmel_at24.c
@@ -52,7 +52,7 @@ struct at24_emul_cfg {
  * @retval 0 If successful
  * @retval -EIO General input / output error
  */
-static int at24_emul_transfer(const struct emul *emulator, struct i2c_msg *msgs,
+static int at24_emul_transfer(const struct emul *target, struct i2c_msg *msgs,
 			      int num_msgs, int addr)
 {
 	struct at24_emul_data *data;
@@ -61,8 +61,8 @@ static int at24_emul_transfer(const struct emul *emulator, struct i2c_msg *msgs,
 	bool too_fast;
 	uint32_t i2c_cfg;
 
-	data = emulator->data;
-	cfg = emulator->cfg;
+	data = target->data;
+	cfg = target->cfg;
 
 	if (cfg->addr != addr) {
 		LOG_ERR("Address mismatch, expected %02x, got %02x", cfg->addr,
@@ -131,18 +131,18 @@ static struct i2c_emul_api bus_api = {
  * This should be called for each AT24 device that needs to be emulated. It
  * registers it with the I2C emulation controller.
  *
- * @param emulator Emulation information
+ * @param target Emulation information
  * @param parent Device to emulate (must use AT24 driver)
  * @return 0 indicating success (always)
  */
-static int emul_atmel_at24_init(const struct emul *emulator, const struct device *parent)
+static int emul_atmel_at24_init(const struct emul *target, const struct device *parent)
 {
-	const struct at24_emul_cfg *cfg = emulator->cfg;
-	struct at24_emul_data *data = emulator->data;
+	const struct at24_emul_cfg *cfg = target->cfg;
+	struct at24_emul_data *data = target->data;
 
 	data->emul.api = &bus_api;
 	data->emul.addr = cfg->addr;
-	data->emul.target = emulator;
+	data->emul.target = target;
 	data->i2c = parent;
 	data->cur_reg = 0;
 

--- a/tests/drivers/espi/src/stub_espi_emul_host.c
+++ b/tests/drivers/espi/src/stub_espi_emul_host.c
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+
+#define DT_DRV_COMPAT zephyr_espi_emul_espi_host
+
+/* Stub out an espi host device struct to use espi_host emulator. */
+static int emul_espi_host_init_stub(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+struct emul_espi_host_stub_dev_data {
+	/* Stub */
+};
+struct emul_espi_host_stub_dev_config {
+	/* Stub */
+};
+struct emul_espi_host_stub_dev_api {
+	/* Stub */
+};
+
+/* Since this is only stub, allocate the structs once. */
+static struct emul_espi_host_stub_dev_data stub_host_data;
+static struct emul_espi_host_stub_dev_config stub_host_config;
+static struct emul_espi_host_stub_dev_api stub_host_api;
+
+#define EMUL_ESPI_HOST_DEVICE_STUB(n)                                                              \
+	DEVICE_DT_INST_DEFINE(n, &emul_espi_host_init_stub, NULL, &stub_host_data,                 \
+			      &stub_host_config, POST_KERNEL, CONFIG_ESPI_INIT_PRIORITY,           \
+			      &stub_host_api)
+
+DT_INST_FOREACH_STATUS_OKAY(EMUL_ESPI_HOST_DEVICE_STUB);


### PR DESCRIPTION
This change simplifies and reduces the amount of boilerplate
code needed to get a device emulator up and running, thus reducing excise work
to writing tests.

Due to the change in EMUL_DEFINE and other code. This is a breaking-change for emulators.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/39486


Recreation of https://github.com/zephyrproject-rtos/zephyr/pull/45445 due to recreating my fork (ugh I didn't realize it would make my pull-requests go dead).