### PR TITLE
tests: Enable sbs_gauge driver testing with native_posix

### DIFF
--- a/subsys/emul/Kconfig
+++ b/subsys/emul/Kconfig
@@ -45,6 +45,12 @@ config EMUL_BMI160
 	  It supports both I2C and SPI which is why it is not in one of the
 	  i2c/ or spi/ directories.
 
+config EMUL_SBS_GAUGE
+	bool "Emulate an SBS 1.1 compliant smart battery fuel gauge"
+	help
+	  It provides readings which follow a simple sequence, thus allowing
+	  test code to check that things are working as expected.
+
 source "subsys/emul/i2c/Kconfig"
 source "subsys/emul/spi/Kconfig"
 source "subsys/emul/espi/Kconfig"

--- a/subsys/emul/i2c/CMakeLists.txt
+++ b/subsys/emul/i2c/CMakeLists.txt
@@ -3,3 +3,6 @@
 # Once we have more than 10 devices we should consider splitting them into
 # subdirectories to match the drivers/ structure.
 zephyr_library_sources_ifdef(CONFIG_EMUL_EEPROM_AT2X	emul_atmel_at24.c)
+
+zephyr_include_directories_ifdef(CONFIG_EMUL_SBS_GAUGE ${ZEPHYR_BASE}/drivers/sensor/sbs_gauge)
+zephyr_library_sources_ifdef(CONFIG_EMUL_SBS_GAUGE		emul_sbs_gauge.c)

--- a/subsys/emul/i2c/emul_sbs_gauge.c
+++ b/subsys/emul/i2c/emul_sbs_gauge.c
@@ -1,0 +1,211 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Emulator for SBS 1.1 compliant smart battery fuel gauge.
+ * This emulator is *NOT* fully featured yet, only enough to get the sbs_gauge driver tests passing.
+ */
+
+#define DT_DRV_COMPAT sbs_sbs_gauge
+
+#define LOG_LEVEL CONFIG_SENSOR_LOG_LEVEL
+#include <logging/log.h>
+LOG_MODULE_REGISTER(sbs_sbs_gauge);
+
+#include <sbs_gauge.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/emul.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/drivers/i2c_emul.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/spi_emul.h>
+#include <zephyr/sys/byteorder.h>
+
+/** Run-time data used by the emulator */
+struct sbs_gauge_emul_data {
+	/** I2C emulator detail */
+	struct i2c_emul emul_i2c;
+	/** sbs_gauge device being emulated */
+	const struct device *dev;
+	uint8_t pmu_status;
+	/** Current register to read (address) */
+	uint32_t cur_reg;
+};
+
+/** Static configuration for the emulator */
+struct sbs_gauge_emul_cfg {
+	/** Label of the I2C bus this emulator connects to */
+	const char *bus_label;
+	/** Chip registers */
+	uint8_t *reg;
+	union {
+		/** I2C address of emulator */
+		uint16_t addr;
+	};
+};
+
+static void reg_write(const struct emul *emu, int regn, int val)
+{
+	/* Unimplemented reg_write handler */
+	struct sbs_gauge_emul_data *data = emu->data;
+	const struct sbs_gauge_emul_cfg *cfg = emu->cfg;
+
+	ARG_UNUSED(data);
+
+	LOG_INF("write %x = %x", regn, val);
+	cfg->reg[regn] = val;
+	switch (regn) {
+	default:
+		LOG_INF("Unknown write %x", regn);
+	}
+}
+
+static int reg_read(const struct emul *emu, int regn)
+{
+	struct sbs_gauge_emul_data *data = emu->data;
+	const struct sbs_gauge_emul_cfg *cfg = emu->cfg;
+	int val;
+
+	ARG_UNUSED(data);
+
+	LOG_INF("read %x =", regn);
+	val = cfg->reg[regn];
+	switch (regn) {
+	case SBS_GAUGE_CMD_VOLTAGE:
+	case SBS_GAUGE_CMD_AVG_CURRENT:
+	case SBS_GAUGE_CMD_TEMP:
+	case SBS_GAUGE_CMD_ASOC:
+	case SBS_GAUGE_CMD_FULL_CAPACITY:
+	case SBS_GAUGE_CMD_REM_CAPACITY:
+	case SBS_GAUGE_CMD_NOM_CAPACITY:
+	case SBS_GAUGE_CMD_AVG_TIME2EMPTY:
+	case SBS_GAUGE_CMD_AVG_TIME2FULL:
+	case SBS_GAUGE_CMD_CYCLE_COUNT:
+	case SBS_GAUGE_CMD_DESIGN_VOLTAGE:
+		val = 1;
+		break;
+	default:
+		LOG_INF("Unknown read %x", regn);
+	}
+	LOG_INF("       = %x", val);
+
+	return val;
+}
+
+static int sbs_gauge_emul_transfer_i2c(struct i2c_emul *emul, struct i2c_msg *msgs, int num_msgs,
+				       int addr)
+{
+	struct sbs_gauge_emul_data *data;
+	unsigned int val;
+
+	data = CONTAINER_OF(emul, struct sbs_gauge_emul_data, emul_i2c);
+
+	__ASSERT_NO_MSG(msgs && num_msgs);
+
+	i2c_dump_msgs("emul", msgs, num_msgs, addr);
+	switch (num_msgs) {
+	case 2:
+		if (msgs->flags & I2C_MSG_READ) {
+			LOG_ERR("Unexpected read");
+			return -EIO;
+		}
+		if (msgs->len != 1) {
+			LOG_ERR("Unexpected msg0 length %d", msgs->len);
+			return -EIO;
+		}
+		data->cur_reg = msgs->buf[0];
+
+		/* Now process the 'read' part of the message */
+		msgs++;
+		if (msgs->flags & I2C_MSG_READ) {
+			switch (msgs->len - 1) {
+			case 1:
+				val = reg_read(emul->parent, data->cur_reg);
+				msgs->buf[0] = val;
+				break;
+			default:
+				LOG_ERR("Unexpected msg1 length %d", msgs->len);
+				return -EIO;
+			}
+		} else {
+			if (msgs->len != 1) {
+				LOG_ERR("Unexpected msg1 length %d", msgs->len);
+			}
+			reg_write(emul->parent, data->cur_reg, msgs->buf[0]);
+		}
+		break;
+	default:
+		LOG_ERR("Invalid number of messages: %d", num_msgs);
+		return -EIO;
+	}
+
+	return 0;
+}
+
+/* Device instantiation below */
+
+static struct i2c_emul_api sbs_gauge_emul_api_i2c = {
+	.transfer = sbs_gauge_emul_transfer_i2c,
+};
+
+static void emul_sbs_gauge_init(const struct emul *emu, const struct device *parent)
+{
+	const struct sbs_gauge_emul_cfg *cfg = emu->cfg;
+	struct sbs_gauge_emul_data *data = emu->data;
+	uint8_t *reg = cfg->reg;
+
+	ARG_UNUSED(reg);
+
+	data->dev = parent;
+	data->pmu_status = 0;
+}
+
+/**
+ * Set up a new SBS_GAUGE emulator (I2C)
+ *
+ * This should be called for each SBS_GAUGE device that needs to be emulated. It
+ * registers it with the i2c emulation controller.
+ *
+ * @param emul Emulation information
+ * @param parent Device to emulate (must use sbs_gauge driver)
+ * @return 0 indicating success (always)
+ */
+static int emul_sbs_sbs_gauge_init_i2c(const struct emul *emu, const struct device *parent)
+{
+	const struct sbs_gauge_emul_cfg *cfg = emu->cfg;
+	struct sbs_gauge_emul_data *data = emu->data;
+
+	emul_sbs_gauge_init(emu, parent);
+	data->emul_i2c.api = &sbs_gauge_emul_api_i2c;
+	data->emul_i2c.addr = cfg->addr;
+	data->emul_i2c.parent = emu;
+
+	int rc = i2c_emul_register(parent, emu->dev_label, &data->emul_i2c);
+
+	return rc;
+}
+
+#define SBS_GAUGE_EMUL_DATA(n)                                                                     \
+	static uint8_t sbs_gauge_emul_reg_##n[2];                                                  \
+	static struct sbs_gauge_emul_data sbs_gauge_emul_data_##n;
+
+#define SBS_GAUGE_EMUL_DEFINE(n, type)                                                             \
+	EMUL_DEFINE(emul_sbs_sbs_gauge_init_##type, DT_DRV_INST(n), &sbs_gauge_emul_cfg_##n,       \
+		    &sbs_gauge_emul_data_##n)
+
+#define SBS_GAUGE_EMUL_I2C(n)                                                                      \
+	SBS_GAUGE_EMUL_DATA(n)                                                                     \
+	static const struct sbs_gauge_emul_cfg sbs_gauge_emul_cfg_##n = {                          \
+		.bus_label = DT_INST_BUS_LABEL(n),                                                 \
+		.reg = sbs_gauge_emul_reg_##n,                                                     \
+		.addr = DT_INST_REG_ADDR(n)                                                        \
+	};                                                                                         \
+	SBS_GAUGE_EMUL_DEFINE(n, i2c)
+
+/*
+ * Main instantiation macro. SBS Gauge Emulator only implemented for I2C
+ */
+#define SBS_GAUGE_EMUL(n) SBS_GAUGE_EMUL_I2C(n)
+
+DT_INST_FOREACH_STATUS_OKAY(SBS_GAUGE_EMUL)

--- a/tests/drivers/sensor/sbs_gauge/boards/native_posix.conf
+++ b/tests/drivers/sensor/sbs_gauge/boards/native_posix.conf
@@ -1,0 +1,7 @@
+# Copyright (c) 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_EMUL=y
+CONFIG_EMUL_SBS_GAUGE=y
+CONFIG_I2C=y
+CONFIG_I2C_EMUL=y

--- a/tests/drivers/sensor/sbs_gauge/boards/native_posix.overlay
+++ b/tests/drivers/sensor/sbs_gauge/boards/native_posix.overlay
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Leica Geosystems AG
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&i2c0 {
+	clock-frequency = <I2C_BITRATE_STANDARD>;
+	sbs_gauge_i2c: sbs_gauge@b {
+		compatible = "sbs,sbs-gauge";
+		reg = <0x0B>;
+		label = "sbs-gauge";
+		status = "okay";
+	};
+};

--- a/tests/drivers/sensor/sbs_gauge/src/main.c
+++ b/tests/drivers/sensor/sbs_gauge/src/main.c
@@ -13,21 +13,15 @@ void test_main(void)
 	ztest_test_suite(framework_tests,
 		ztest_unit_test(test_get_gauge_voltage),
 		ztest_unit_test(test_get_gauge_current),
-		ztest_unit_test(test_get_stdby_current),
-		ztest_unit_test(test_get_max_load_current),
 		ztest_unit_test(test_get_temperature),
 		ztest_unit_test(test_get_soc),
 		ztest_unit_test(test_get_full_charge_capacity),
 		ztest_unit_test(test_get_rem_charge_capacity),
 		ztest_unit_test(test_get_nom_avail_capacity),
 		ztest_unit_test(test_get_full_avail_capacity),
-		ztest_unit_test(test_get_average_power),
 		ztest_unit_test(test_get_average_time_to_empty),
 		ztest_unit_test(test_get_average_time_to_full),
 		ztest_unit_test(test_get_cycle_count),
-		ztest_unit_test(test_get_design_voltage),
-		ztest_unit_test(test_get_desired_voltage),
-		ztest_unit_test(test_get_desired_chg_current),
 		ztest_unit_test(test_not_supported_channel)
 	);
 

--- a/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.c
@@ -19,11 +19,12 @@ const struct device *get_fuel_gauge_device(void)
 
 void test_get_sensor_value(int16_t channel)
 {
+	/* Helper that only checks channel access success. */
 	struct sensor_value value;
 	const struct device *dev = get_fuel_gauge_device();
 
-	zassert_true(sensor_sample_fetch_chan(dev, channel) < 0, "Sample fetch failed");
-	zassert_true(sensor_channel_get(dev, channel, &value) < 0, "Get sensor value failed");
+	zassert_ok(sensor_sample_fetch_chan(dev, channel), "Sample fetch failed");
+	zassert_ok(sensor_channel_get(dev, channel, &value), "Get sensor value failed");
 }
 
 void test_get_sensor_value_not_supp(int16_t channel)
@@ -41,16 +42,6 @@ void test_get_gauge_voltage(void)
 void test_get_gauge_current(void)
 {
 	test_get_sensor_value(SENSOR_CHAN_GAUGE_AVG_CURRENT);
-}
-
-void test_get_stdby_current(void)
-{
-	test_get_sensor_value(SENSOR_CHAN_GAUGE_STDBY_CURRENT);
-}
-
-void test_get_max_load_current(void)
-{
-	test_get_sensor_value(SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT);
 }
 
 void test_get_temperature(void)
@@ -83,11 +74,6 @@ void test_get_full_avail_capacity(void)
 	test_get_sensor_value(SENSOR_CHAN_GAUGE_FULL_AVAIL_CAPACITY);
 }
 
-void test_get_average_power(void)
-{
-	test_get_sensor_value(SENSOR_CHAN_GAUGE_AVG_POWER);
-}
-
 void test_get_average_time_to_empty(void)
 {
 	test_get_sensor_value(SENSOR_CHAN_GAUGE_TIME_TO_EMPTY);
@@ -103,21 +89,6 @@ void test_get_cycle_count(void)
 	test_get_sensor_value(SENSOR_CHAN_GAUGE_CYCLE_COUNT);
 }
 
-void test_get_design_voltage(void)
-{
-	test_get_sensor_value(SENSOR_CHAN_GAUGE_DESIGN_VOLTAGE);
-}
-
-void test_get_desired_voltage(void)
-{
-	test_get_sensor_value(SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE);
-}
-
-void test_get_desired_chg_current(void)
-{
-	test_get_sensor_value(SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT);
-}
-
 void test_not_supported_channel(void)
 {
 	uint8_t channel;
@@ -127,4 +98,10 @@ void test_not_supported_channel(void)
 	}
 	/* SOH is not defined in the SBS 1.1 specifications */
 	test_get_sensor_value_not_supp(SENSOR_CHAN_GAUGE_STATE_OF_HEALTH);
+
+	/* These readings are not presently supported by the sbs_gauge driver. */
+	test_get_sensor_value_not_supp(SENSOR_CHAN_GAUGE_STDBY_CURRENT);
+	test_get_sensor_value_not_supp(SENSOR_CHAN_GAUGE_MAX_LOAD_CURRENT);
+	test_get_sensor_value_not_supp(SENSOR_CHAN_GAUGE_DESIRED_VOLTAGE);
+	test_get_sensor_value_not_supp(SENSOR_CHAN_GAUGE_DESIRED_CHARGING_CURRENT);
 }

--- a/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.h
+++ b/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.h
@@ -14,7 +14,6 @@ void test_get_sensor_value_not_supp(int16_t channel);
 
 void test_get_gauge_voltage(void);
 void test_get_gauge_current(void);
-void test_get_stdby_current(void);
 void test_get_max_load_current(void);
 void test_get_temperature(void);
 void test_get_soc(void);
@@ -22,11 +21,9 @@ void test_get_full_charge_capacity(void);
 void test_get_rem_charge_capacity(void);
 void test_get_nom_avail_capacity(void);
 void test_get_full_avail_capacity(void);
-void test_get_average_power(void);
 void test_get_average_time_to_empty(void);
 void test_get_average_time_to_full(void);
 void test_get_cycle_count(void);
-void test_get_design_voltage(void);
 void test_get_desired_voltage(void);
 void test_get_desired_chg_current(void);
 

--- a/tests/drivers/sensor/sbs_gauge/testcase.yaml
+++ b/tests/drivers/sensor/sbs_gauge/testcase.yaml
@@ -6,3 +6,8 @@ tests:
     filter: dt_compat_enabled("sbs,sbs-gauge")
     integration_platforms:
       - nucleo_f070rb
+  drivers.sbs_gauge.emulated:
+    tags: test_framework
+    filter: dt_compat_enabled("sbs,sbs-gauge")
+    platform_allow:
+      native_posix


### PR DESCRIPTION
This part of the work for adding a [battery API.](https://github.com/zephyrproject-rtos/zephyr/pull/46817)