### PR TITLE
lib: os/cbprintf: make char[] work in C++ and tagged arguments

### DIFF
--- a/include/zephyr/sys/cbprintf_cxx.h
+++ b/include/zephyr/sys/cbprintf_cxx.h
@@ -252,5 +252,43 @@ struct z_cbprintf_cxx_remove_cv < const volatile T > {
 	typedef T type;
 };
 
+/* Determine if a type is an array */
+template < typename T >
+struct z_cbprintf_cxx_is_array {
+	enum {
+		value = false
+	};
+};
+
+template < typename T >
+struct z_cbprintf_cxx_is_array < T[] > {
+	enum {
+		value = true
+	};
+};
+
+template < typename T, size_t N >
+struct z_cbprintf_cxx_is_array < T[N] > {
+	enum {
+		value = true
+	};
+};
+
+/* Determine the type of elements in an array */
+template < typename T >
+struct z_cbprintf_cxx_remove_extent {
+	typedef T type;
+};
+
+template < typename T >
+struct z_cbprintf_cxx_remove_extent < T[] > {
+	typedef T type;
+};
+
+template < typename T, size_t N >
+struct z_cbprintf_cxx_remove_extent < T[N] > {
+	typedef T type;
+};
+
 #endif /* __cplusplus */
 #endif /* ZEPHYR_INCLUDE_SYS_CBPRINTF_CXX_H_ */

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -505,6 +505,43 @@ do { \
 	> ::type
 
 /*
+ * Get the type of elements in an array.
+ */
+#define Z_CBPRINTF_CXX_ARG_ARRAY_TYPE(arg) \
+	z_cbprintf_cxx_remove_cv < \
+		z_cbprintf_cxx_remove_extent < decltype(arg) > ::type \
+	> ::type
+
+/*
+ * Determine if incoming type is char.
+ */
+#define Z_CBPRINTF_CXX_ARG_IS_TYPE_CHAR(type) \
+	(z_cbprintf_cxx_is_same_type < type, \
+	 char > :: value ? \
+	 true : \
+	 (z_cbprintf_cxx_is_same_type < type, \
+	  const char > :: value ? \
+	  true : \
+	  (z_cbprintf_cxx_is_same_type < type, \
+	   volatile char > :: value ? \
+	   true : \
+	   (z_cbprintf_cxx_is_same_type < type, \
+	    const volatile char > :: value ? \
+	    true : \
+	    false))))
+
+/*
+ * Figure out if this is a char array since (char *) and (char[])
+ * are of different types in C++.
+ */
+#define Z_CBPRINTF_CXX_ARG_IS_CHAR_ARRAY(arg) \
+	(z_cbprintf_cxx_is_array < decltype(arg) > :: value ? \
+	 (Z_CBPRINTF_CXX_ARG_IS_TYPE_CHAR(Z_CBPRINTF_CXX_ARG_ARRAY_TYPE(arg)) ? \
+	  true : \
+	  false) : \
+	 false)
+
+/*
  * Note that qualifiers of char * must be explicitly matched
  * due to type matching in C++, where remove_cv() does not work.
  */
@@ -560,7 +597,9 @@ do { \
 			 (z_cbprintf_cxx_is_same_type < Z_CBPRINTF_ARG_REMOVE_QUAL(arg), \
 			  const volatile char * > :: value ? \
 			  CBPRINTF_PACKAGE_ARG_TYPE_PTR_CHAR : \
-			  CBPRINTF_PACKAGE_ARG_TYPE_PTR_VOID)))))))))))))))))
+			  (Z_CBPRINTF_CXX_ARG_IS_CHAR_ARRAY(arg) ? \
+			   CBPRINTF_PACKAGE_ARG_TYPE_PTR_CHAR : \
+			   CBPRINTF_PACKAGE_ARG_TYPE_PTR_VOID))))))))))))))))))
 #else
 #define Z_CBPRINTF_ARG_TYPE(arg) \
 	_Generic(arg, \

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -218,7 +218,7 @@ ZTEST(test_log_api, test_log_various_messages)
 				CONFIG_LOG_DOMAIN_ID, LOG_LEVEL_ERR,
 				exp_timestamp++, "err");
 
-	LOG_WRN("wrn %s", (char *)dstr);
+	LOG_WRN("wrn %s", dstr);
 	dstr[0] = '\0';
 
 	LOG_ERR("err");


### PR DESCRIPTION
Strings in C++ are usually of type char[] instead of char*.
Therefore, this needs to be taken into account when doing
tagged arguments or else char[] would be tagged as simple
pointer. So fix this by adding a way to get the type of
elements in an array to determine if it is a char array.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>