### PR TITLE
picolibc: Use Zephyr native errno for non-TLS targets

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -38,8 +38,8 @@ config MINIMAL_LIBC
 
 config PICOLIBC
 	bool "Picolibc library"
-	select LIBC_ERRNO
 	select THREAD_LOCAL_STORAGE if ARCH_HAS_THREAD_LOCAL_STORAGE
+	select LIBC_ERRNO if THREAD_LOCAL_STORAGE
 	depends on !NATIVE_APPLICATION
 	help
 	  Build with picolibc library. The picolibc library is built as

--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -448,3 +448,17 @@ void abort(void)
 	k_panic();
 	CODE_UNREACHABLE;
 }
+
+#ifndef CONFIG_LIBC_ERRNO
+
+/*
+ * Picolibc needs to be able to declare this itself so that the library
+ * doesn't end up needing zephyr header files. That means using a regular
+ * function instead of an inline.
+ */
+int *z_errno_wrap(void)
+{
+	return z_errno();
+}
+
+#endif

--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -26,3 +26,9 @@ tests:
     extra_configs:
       - CONFIG_CBPRINTF_NANO=y
       - CONFIG_CBPRINTF_FULL_INTEGRAL=y
+  kernel.common.picolibc:
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    tags: picolibc
+    extra_configs:
+      - CONFIG_PICOLIBC=y
+      - CONFIG_PICOLIBC_ALIGNED_HEAP_SIZE=8192

--- a/west.yml
+++ b/west.yml
@@ -198,7 +198,7 @@ manifest:
       path: modules/lib/openthread
     - name: picolibc
       path: modules/lib/picolibc
-      revision: 4f8076520240192be284843a114c92853e29bbbc
+      revision: e87b2fc37345a62361478f0a6efd140e14180ba5
     - name: segger
       revision: 3a52ab222133193802d3c3b4d21730b9b1f1d2f6
       path: modules/debug/segger


### PR DESCRIPTION
I added all of the necessary infra to picolibc to allow use of z_errno() a long time ago and somehow forgot to hook it up in zephyr. This moves the picolibc commit to bring in the cmake bits there for this; that's where the bulk of the changes live. This series mostly just enables tests that make sure it works.