### PR TITLE
drivers: i2c: stm32: Use device tree as single source of compatibility

### DIFF
--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -19,8 +19,7 @@ config I2C_STM32_V1
 	select USE_STM32_LL_I2C
 	select I2C_STM32_INTERRUPT if I2C_SLAVE
 	help
-	  Enable I2C support on the STM32 F1 and F4X family of processors. This
-	  driver also supports the F2 and L1 series.
+	  Driver variant matching `st,stm32-i2c-v1` compatible.
 
 config I2C_STM32_V2
 	bool
@@ -29,9 +28,7 @@ config I2C_STM32_V2
 	select USE_STM32_LL_RCC if SOC_SERIES_STM32F0X || SOC_SERIES_STM32F3X
 	select I2C_STM32_INTERRUPT if I2C_SLAVE
 	help
-	  Enable I2C support on the STM32 F0, F3, F7, L4, WBX, MP1, G0, G4, WL and
-	  H7 family of processors.
-	  This driver also supports the L0 series.
+	  Driver variant matching `st,stm32-i2c-v2` compatible.
 	  If I2C_SLAVE is enabled it selects I2C_STM32_INTERRUPT, since slave mode
 	  is only supported by this driver with interrupts enabled.
 


### PR DESCRIPTION
Some text in help section was documenting the compatibility of driver
variants with stm32 series.
This is duplicate of information versus device tree which should be
used as single source of information for hardware description.
Remove these lines, so we don't have to touch this driver each time
a series is added.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>