### PR TITLE
manifest: update mcuboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: e7415b555134e671ba04f036b02f55cbc087d0e9
+      revision: 3b791288bb037f8d64bd93ffac89ab72d62111bd
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
MCUboot was synchronized up to upstream:
7d2f0bf425f7429b0117191f0207a9907fff54f3

- boot_serial: refactoring and optimalization (mainly afects
  progressive erase implementation)
- migrate includes to <zephyr/...>
- switched DFU detection GPIO-pin configuration to be done through DTS.
  That pin is assigned thanks to `mcuboot-button0` pin-alias.
- boot_serial: Fix echo command code no longer compiling
- Added MCUboot status callback support, see `CONFIG_MCUBOOT_ACTION_HOOKS`
  Kconfig option.
- reworked LED usage, prefer DTS mcuboot-led0 alias over bootloader-led0
  alias
- Added initial support for leverage RAM-LOAD mode with the zephyr-rtos
  port
- boot_serial: Upgrade from cddl-gen 0.1.0 to zcbor 0.4.0

- imgtool: Added support for providing the signature by 3rd party

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>