### PR TITLE
Several fixes for Xen event channel driver

### DIFF
--- a/drivers/xen/events.c
+++ b/drivers/xen/events.c
@@ -227,12 +227,12 @@ static void events_isr(void *data)
 	while (pos_selector) {
 		/* Find first position, clear it in selector and process */
 		pos_index = __builtin_ffsl(pos_selector) - 1;
-		pos_selector &= ~(1 << pos_index);
+		pos_selector &= ~(((xen_ulong_t) 1) << pos_index);
 
 		/* Find all active evtchn on selected position */
 		while ((events_pending = get_pending_events(pos_index)) != 0) {
 			event_index =  __builtin_ffsl(events_pending) - 1;
-			events_pending &= (1 << event_index);
+			events_pending &= (((xen_ulong_t) 1) << event_index);
 
 			port = (pos_index * 8 * sizeof(xen_ulong_t))
 					+ event_index;

--- a/drivers/xen/events.c
+++ b/drivers/xen/events.c
@@ -218,7 +218,7 @@ static void events_isr(void *data)
 	 */
 	vcpu->evtchn_upcall_pending = 0;
 
-	compiler_barrier();
+	dmb();
 
 	/* Can not use system atomic_t/atomic_set() due to 32-bit casting */
 	pos_selector = __atomic_exchange_n(&vcpu->evtchn_pending_sel,


### PR DESCRIPTION
This PR fixes 2 issues with current implementation of Xen events handling:
- use proper barrier to prevent write re-ordering;
- fix cast issues to prevent undefined value during shift with >32 bit value.

Huge thanks @jgrall for help.