### PR TITLE
gen_isr_tables: Cleanup IRQ vector table generation

### DIFF
--- a/arch/common/gen_isr_tables.py
+++ b/arch/common/gen_isr_tables.py
@@ -133,12 +133,6 @@ source_header = """
 #include <zephyr/sw_isr_table.h>
 #include <zephyr/arch/cpu.h>
 
-#if defined(CONFIG_GEN_SW_ISR_TABLE) && defined(CONFIG_GEN_IRQ_VECTOR_TABLE)
-#define ISR_WRAPPER ((uintptr_t)&_isr_wrapper)
-#else
-#define ISR_WRAPPER NULL
-#endif
-
 typedef void (* ISR)(const void *);
 """
 
@@ -230,8 +224,8 @@ def main():
     if nvec > pow(2, 15):
         raise ValueError('nvec is too large, check endianness.')
 
-    spurious_handler = "&z_irq_spurious"
-    sw_irq_handler   = "ISR_WRAPPER"
+    spurious_handler = "((uintptr_t)&z_irq_spurious)"
+    sw_irq_handler   = "((uintptr_t)&_isr_wrapper)"
 
     debug('offset is ' + str(offset))
     debug('num_vectors is ' + str(nvec))


### PR DESCRIPTION
Under no circumstances the generated IRQ vector table can and should
contain NULL values. This is correctly enforced at generation time by
the gen_isr_tables.py script making the existence of the ISR_WRAPPER
define useless.

The enforced behaviour is:
- When the ISR software table exists defaults to _isr_wrapper
- Otherwise defaults to z_irq_spurious

Signed-off-by: Carlo Caione <ccaione@baylibre.com>