### PR TITLE
scripts: update imgtool version to 1.9.0

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -16,7 +16,7 @@ lpc_checksum
 Pillow
 
 # can be used to sign a Zephyr application binary for consumption by a bootloader
-imgtool>=1.7.1
+imgtool>=1.9.0
 
 # used by nanopb module to generate sources from .proto files
 protobuf


### PR DESCRIPTION
ESP32+MCUboot requires flash/block alignment of 32 bytes in order to work. Current imgtool version only accepts 1,2,4 and 8 bytes. This causes failure when signing ESP32 binary using imgtool.
The commit below in mcuboot repository added that support a while ago:  
https://github.com/zephyrproject-rtos/mcuboot/commit/73c38c6fde489746d5307a691dc7006234372279
https://github.com/mcu-tools/mcuboot/commit/73c38c6fde489746d5307a691dc7006234372279

However, this is available only in imgtool 1.9.0.

What would be the proper way to avoid having new issues opened about this?

a) Having imgtool min rev updated in requirements.
b) Only document that MCUBoot and ESP32 requires this tool update. How?
c) Somehow force imgtool provided in Zephyr's MCUBoot repository (which contains the fix).

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>