### PR TITLE
net: openthread: align otPlatSettingsSet with new interface contract

### DIFF
--- a/subsys/net/lib/openthread/platform/settings.c
+++ b/subsys/net/lib/openthread/platform/settings.c
@@ -30,6 +30,9 @@ struct ot_setting_delete_ctx {
 
 	/* Operation result. */
 	int status;
+
+	/* Indicates if delete subtree root. */
+	bool delete_subtree_root;
 };
 
 static int ot_setting_delete_cb(const char *key, size_t len,
@@ -47,6 +50,10 @@ static int ot_setting_delete_cb(const char *key, size_t len,
 
 	if ((ctx->target_index != -1) && (ctx->target_index != ctx->index)) {
 		ctx->index++;
+		return 0;
+	}
+
+	if (key == NULL && ctx->delete_subtree_root == false) {
 		return 0;
 	}
 
@@ -75,14 +82,15 @@ static int ot_setting_delete_cb(const char *key, size_t len,
 	return 0;
 }
 
-static int ot_setting_delete_subtree(int key, int index)
+static int ot_setting_delete_subtree(int key, int index, bool delete_subtree_root)
 {
 	int ret;
 	char subtree[OT_SETTINGS_MAX_PATH_LEN];
 	struct ot_setting_delete_ctx delete_ctx = {
 		.subtree = subtree,
 		.status = -ENOENT,
-		.target_index = index
+		.target_index = index,
+		.delete_subtree_root = delete_subtree_root,
 	};
 
 	if (key == -1) {
@@ -252,10 +260,9 @@ otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey,
 
 	LOG_DBG("%s Entry aKey %u", __func__, aKey);
 
-	(void)ot_setting_delete_subtree(aKey, -1);
+	(void)ot_setting_delete_subtree(aKey, -1, false);
 
-	ret = snprintk(path, sizeof(path), "%s/%x/%08x", OT_SETTINGS_ROOT_KEY,
-		       aKey, sys_rand32_get());
+	ret = snprintk(path, sizeof(path), "%s/%x", OT_SETTINGS_ROOT_KEY, aKey);
 	__ASSERT(ret < sizeof(path), "Setting path buffer too small.");
 
 	ret = settings_save_one(path, aValue, aValueLength);
@@ -300,7 +307,7 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 
 	LOG_DBG("%s Entry aKey %u aIndex %d", __func__, aKey, aIndex);
 
-	ret = ot_setting_delete_subtree(aKey, aIndex);
+	ret = ot_setting_delete_subtree(aKey, aIndex, true);
 	if (ret != 0) {
 		LOG_DBG("Entry not found aKey %u aIndex %d", aKey, aIndex);
 		return OT_ERROR_NOT_FOUND;
@@ -313,7 +320,7 @@ void otPlatSettingsWipe(otInstance *aInstance)
 {
 	ARG_UNUSED(aInstance);
 
-	(void)ot_setting_delete_subtree(-1, -1);
+	(void)ot_setting_delete_subtree(-1, -1, true);
 }
 
 void otPlatSettingsDeinit(otInstance *aInstance)


### PR DESCRIPTION
The new interface contract guarantees that OpenThread stack uses
otPlatSettingsSet only for aKey which has at most one value at time.
This implies the simplification for key name used by settings subsystem
and decreases the count of records written each time when the value
for specific key is updated. In result non-volatile memory can be used
more efficiently.

It relates to zephyrproject-rtos/openthread commit: ed665e9 .

We still need to make sure that old entries are being removed for the
case with DFU.