### PR TITLE
toolchain: Add macro for keeping an object in the binary

### DIFF
--- a/include/zephyr/linker/common-rom/common-rom-misc.ld
+++ b/include/zephyr/linker/common-rom/common-rom-misc.ld
@@ -17,6 +17,13 @@
 	} GROUP_LINK_IN(ROMABLE_REGION)
 #endif /* CONFIG_EMUL */
 
+	SECTION_DATA_PROLOGUE(symbol_to_keep,,)
+	{
+		__symbol_to_keep_start = .;
+		KEEP(*(SORT(.symbol_to_keep*)));
+		__symbol_to_keep_end = .;
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+
 	ITERABLE_SECTION_ROM(shell, 4)
 
 	SECTION_DATA_PROLOGUE(shell_root_cmds_sections,,)

--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -274,6 +274,17 @@
  * @}
  */ /* end of struct_section_apis */
 
+/** @brief Tag a symbol (e.g. function) to be kept in the binary even though it is not used.
+ *
+ * It prevents symbol from being removed by the linker garbage collector. It
+ * is achieved by adding a pointer to that symbol to the kept memory section.
+ *
+ * @param symbol Symbol to keep.
+ */
+#define LINKER_KEEP(symbol) \
+	static const void * const symbol##_ptr  __used \
+	__attribute__((__section__(".symbol_to_keep"))) = (void *)&symbol
+
 #define LOG2CEIL(x) \
 	((((x) <= 4) ? 2 : (((x) <= 8) ? 3 : (((x) <= 16) ? \
 	4 : (((x) <= 32) ? 5 : (((x) <= 64) ? 6 : (((x) <= 128) ? \


### PR DESCRIPTION
Add KEEP_OBJECT macro which can be used to prevent linker garbage
collector from removing unused object (function or variable).

Example use case is to use it for functions which are part of a test
application which has functions which are indirectly called by the
host test tools. Since they are not called explicitely by the
application so without marking them with KEEP_OBJECT they would be
removed by the linker garbage collector.

Fixes #34413.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>