### PR TITLE
include: stm32: clock_control: Ease usage of STM32_DT_CLOCKS macro

### DIFF
--- a/drivers/clock_control/clock_stm32_mux.c
+++ b/drivers/clock_control/clock_stm32_mux.c
@@ -37,7 +37,7 @@ static int stm32_clk_mux_init(const struct device *dev)
 #define STM32_MUX_CLK_INIT(id)						\
 									\
 static const struct stm32_clk_mux_config stm32_clk_mux_cfg_##id = {	\
-	.pclken = STM32_INST_CLOCK_INFO(id, 0)				\
+	.pclken = STM32_CLOCK_INFO(0, DT_DRV_INST(id))			\
 };									\
 									\
 DEVICE_DT_INST_DEFINE(id, &stm32_clk_mux_init, NULL,			\

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -281,27 +281,19 @@ struct stm32_pclken {
 
 /** Device tree clocks helpers  */
 
-#define STM32_CLOCK_INFO(clk_index, id)					\
+#define STM32_CLOCK_INFO(clk_index, node_id)				\
 	{								\
-	.enr = DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(id), clk_index, bits),\
-	.bus = DT_CLOCKS_CELL_BY_IDX(DT_NODELABEL(id), clk_index, bus)	\
+	.enr = DT_CLOCKS_CELL_BY_IDX(node_id, clk_index, bits),		\
+	.bus = DT_CLOCKS_CELL_BY_IDX(node_id, clk_index, bus)		\
 	}
-#define STM32_DT_CLOCKS(id)						\
+#define STM32_DT_CLOCKS(node_id)					\
 	{								\
-		LISTIFY(DT_NUM_CLOCKS(DT_NODELABEL(id)),		\
-			STM32_CLOCK_INFO, (,), id)			\
+		LISTIFY(DT_NUM_CLOCKS(node_id),				\
+			STM32_CLOCK_INFO, (,), node_id)			\
 	}
 
-#define STM32_INST_CLOCK_INFO(clk_index, inst)				\
-	{								\
-	.enr = DT_INST_CLOCKS_CELL_BY_IDX(inst, clk_index, bits),	\
-	.bus = DT_INST_CLOCKS_CELL_BY_IDX(inst, clk_index, bus)		\
-	}
 #define STM32_DT_INST_CLOCKS(inst)					\
-	{								\
-		LISTIFY(DT_INST_NUM_CLOCKS(inst),			\
-			STM32_INST_CLOCK_INFO, (,), inst)		\
-	}
+	STM32_DT_CLOCKS(DT_DRV_INST(inst))
 
 #define STM32_OPT_CLOCK_INST_SUPPORT(inst) DT_INST_CLOCKS_HAS_IDX(inst, 1) ||
 #define STM32_DT_INST_DEV_OPT_CLOCK_SUPPORT				\

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
@@ -41,7 +41,7 @@ static void test_sysclk_freq(void)
 
 static void test_i2c_clk_config(void)
 {
-	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(i2c1);
+	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_NODELABEL(i2c1));
 
 	uint32_t dev_dt_clk_freq, dev_actual_clk_freq;
 	uint32_t dev_actual_clk_src;
@@ -136,7 +136,7 @@ static void test_i2c_clk_config(void) {}
 
 static void test_lptim_clk_config(void)
 {
-	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(lptim1);
+	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_NODELABEL(lptim1));
 
 	uint32_t dev_dt_clk_freq, dev_actual_clk_freq;
 	uint32_t dev_actual_clk_src;

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
@@ -35,7 +35,7 @@ static void test_sysclk_freq(void)
 
 static void test_spi_clk_config(void)
 {
-	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(spi1);
+	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_NODELABEL(spi1));
 	struct stm32_pclken spi1_reg_clk_cfg = pclken[0];
 
 	uint32_t spi1_actual_clk_src, spi1_dt_ker_clk_src;

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/src/test_stm32_clock_configuration.c
@@ -35,7 +35,7 @@ static void test_sysclk_freq(void)
 
 static void test_spi_clk_config(void)
 {
-	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(spi1);
+	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_NODELABEL(spi1));
 
 	uint32_t spi1_actual_clk_src;
 	uint32_t spi1_dt_clk_freq, spi1_actual_clk_freq;


### PR DESCRIPTION
STM32_DT_CLOCKS was designed to take a device tree node label name as
argument: STM32_DT_CLOCKS(uart1)
Change its implementation to take a node identifier instead:
STM32_DT_CLOCKS(DT_NODELABEL(uart1)).

This make its usage more flexible since the argument can now be extracted
from other DT macros such as DT_PARENT. Then, the following can be done:
STM32_DT_CLOCKS(DT_PARENT(child_node_label)).

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>