### PR TITLE
zephyr: Fix n=0 for utf8_lcpy

### DIFF
--- a/include/zephyr/sys/util.h
+++ b/include/zephyr/sys/util.h
@@ -415,21 +415,23 @@ uint8_t u8_to_dec(char *buf, uint8_t buflen, uint8_t value);
  *
  * @param utf8_str NULL-terminated string
  *
- *  @return Pointer to the @p utf8_str
+ * @return Pointer to the @p utf8_str
  */
 char *utf8_trunc(char *utf8_str);
 
 /**
  * @brief Copies a UTF-8 encoded string from @p src to @p dst
  *
- * The resulting @p dst will always be NULL terminated, and the @p dst string
- * will always be properly UTF-8 truncated.
+ * The resulting @p dst will always be NULL terminated if @p n is larger than 0,
+ * and the @p dst string will always be properly UTF-8 truncated.
  *
  * @param dst The destination of the UTF-8 string.
  * @param src The source string
- * @param n   The size of the @p dst buffer. Shall not be 0.
+ * @param n   The size of the @p dst buffer. Maximum number of characters copied
+ *            is @p n - 1. If 0 nothing will be done, and the @p dst will not be
+ *            NULL terminated.
  *
- * return Pointer to the @p dst
+ * @return Pointer to the @p dst
  */
 char *utf8_lcpy(char *dst, const char *src, size_t n);
 

--- a/lib/os/utf8.c
+++ b/lib/os/utf8.c
@@ -61,13 +61,13 @@ char *utf8_trunc(char *utf8_str)
 
 char *utf8_lcpy(char *dst, const char *src, size_t n)
 {
-	__ASSERT(n > 0, "n shall not be 0");
+	if (n > 0) {
+		strncpy(dst, src, n - 1);
+		dst[n - 1] = '\0';
 
-	strncpy(dst, src, n - 1);
-	dst[n - 1] = '\0';
-
-	if (n != 1) {
-		utf8_trunc(dst);
+		if (n != 1) {
+			utf8_trunc(dst);
+		}
 	}
 
 	return dst;


### PR DESCRIPTION
The function used an assert if n was 0. Instead
of using an assert, the function will now just
not do anything. The documentation has also
been updated to reflect this.

The reasoning for this is that the strlcpy function
this (sort of) implements for utf8 works the same way.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>