### PR TITLE
dts: stm32: Add a st,stm32h7-spi compatible to enhance driver portability

### DIFF
--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -32,9 +32,7 @@ LOG_MODULE_REGISTER(spi_ll_stm32);
  * error flag, because STM32F1 SoCs do not support it and  STM32CUBE
  * for F1 family defines an unused LL_SPI_SR_FRE.
  */
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 #define SPI_STM32_ERR_MSK (LL_SPI_SR_UDR | LL_SPI_SR_CRCE | LL_SPI_SR_MODF | \
 			   LL_SPI_SR_OVR | LL_SPI_SR_TIFRE)
 #else
@@ -259,9 +257,7 @@ static void spi_stm32_shift_m(SPI_TypeDef *spi, struct spi_stm32_data *data)
 		/* NOP */
 	}
 
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	/* With the STM32MP1, STM32U5 and the STM32H7,
 	 * if the device is the SPI master,
 	 * we need to enable the start of the transfer with
@@ -545,9 +541,7 @@ static int spi_stm32_configure(const struct device *dev,
 	LL_SPI_DisableCRC(spi);
 
 	if (config->cs || !IS_ENABLED(CONFIG_SPI_STM32_USE_HW_SS)) {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 		if (SPI_OP_MODE_GET(config->operation) == SPI_OP_MODE_MASTER) {
 			if (LL_SPI_GetNSSPolarity(spi) == LL_SPI_NSS_POLARITY_LOW)
 				LL_SPI_SetInternalSSLevel(spi, LL_SPI_SS_LEVEL_HIGH);

--- a/drivers/spi/spi_ll_stm32.h
+++ b/drivers/spi/spi_ll_stm32.h
@@ -96,9 +96,7 @@ static inline uint32_t ll_func_spi_dma_busy(SPI_TypeDef *spi)
 
 static inline uint32_t ll_func_tx_is_empty(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return LL_SPI_IsActiveFlag_TXP(spi);
 #else
 	return LL_SPI_IsActiveFlag_TXE(spi);
@@ -107,9 +105,7 @@ static inline uint32_t ll_func_tx_is_empty(SPI_TypeDef *spi)
 
 static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return LL_SPI_IsActiveFlag_RXP(spi);
 #else
 	return LL_SPI_IsActiveFlag_RXNE(spi);
@@ -118,9 +114,7 @@ static inline uint32_t ll_func_rx_is_not_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_EnableIT_TXP(spi);
 #else
 	LL_SPI_EnableIT_TXE(spi);
@@ -129,9 +123,7 @@ static inline void ll_func_enable_int_tx_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_EnableIT_RXP(spi);
 #else
 	LL_SPI_EnableIT_RXNE(spi);
@@ -140,9 +132,7 @@ static inline void ll_func_enable_int_rx_not_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_EnableIT_UDR(spi);
 	LL_SPI_EnableIT_OVR(spi);
 	LL_SPI_EnableIT_CRCERR(spi);
@@ -155,9 +145,7 @@ static inline void ll_func_enable_int_errors(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_DisableIT_TXP(spi);
 #else
 	LL_SPI_DisableIT_TXE(spi);
@@ -166,9 +154,7 @@ static inline void ll_func_disable_int_tx_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_DisableIT_RXP(spi);
 #else
 	LL_SPI_DisableIT_RXNE(spi);
@@ -177,9 +163,7 @@ static inline void ll_func_disable_int_rx_not_empty(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_DisableIT_UDR(spi);
 	LL_SPI_DisableIT_OVR(spi);
 	LL_SPI_DisableIT_CRCERR(spi);
@@ -192,9 +176,7 @@ static inline void ll_func_disable_int_errors(SPI_TypeDef *spi)
 
 static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	return LL_SPI_IsActiveFlag_EOT(spi);
 #else
 	return LL_SPI_IsActiveFlag_BSY(spi);
@@ -207,9 +189,7 @@ static inline uint32_t ll_func_spi_is_busy(SPI_TypeDef *spi)
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_spi_fifo)
 static inline void ll_func_set_fifo_threshold_8bit(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_01DATA);
 #else
 	LL_SPI_SetRxFIFOThreshold(spi, LL_SPI_RX_FIFO_TH_QUARTER);
@@ -218,9 +198,7 @@ static inline void ll_func_set_fifo_threshold_8bit(SPI_TypeDef *spi)
 
 static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	LL_SPI_SetFIFOThreshold(spi, LL_SPI_FIFO_TH_02DATA);
 #else
 	LL_SPI_SetRxFIFOThreshold(spi, LL_SPI_RX_FIFO_TH_HALF);
@@ -230,9 +208,7 @@ static inline void ll_func_set_fifo_threshold_16bit(SPI_TypeDef *spi)
 
 static inline void ll_func_disable_spi(SPI_TypeDef *spi)
 {
-#if defined(CONFIG_SOC_SERIES_STM32MP1X) || \
-	defined(CONFIG_SOC_SERIES_STM32H7X) || \
-	defined(CONFIG_SOC_SERIES_STM32U5X)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32h7_spi)
 	if (LL_SPI_IsActiveMasterTransfer(spi)) {
 		LL_SPI_SuspendMasterTransfer(spi);
 		while (LL_SPI_IsActiveMasterTransfer(spi)) {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -384,7 +384,7 @@
 		};
 
 		spi1: spi@40013000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
@@ -396,7 +396,7 @@
 		};
 
 		spi2: spi@40003800 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
@@ -408,7 +408,7 @@
 		};
 
 		spi3: spi@40003c00 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003c00 0x400>;
@@ -420,7 +420,7 @@
 		};
 
 		spi4: spi@40013400 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013400 0x400>;
@@ -431,7 +431,7 @@
 		};
 
 		spi5: spi@40015000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40015000 0x400>;
@@ -442,7 +442,7 @@
 		};
 
 		spi6: spi@58001400 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x58001400 0x400>;

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -166,7 +166,7 @@
 		};
 
 		spi1: spi@44004000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			reg = <0x44004000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -177,7 +177,7 @@
 		};
 
 		spi2: spi@4000b000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			reg = <0x4000b000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -188,7 +188,7 @@
 		};
 
 		spi3: spi@4000c000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			reg = <0x4000c000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -199,7 +199,7 @@
 		};
 
 		spi4: spi@44005000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			reg = <0x44005000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -210,7 +210,7 @@
 		};
 
 		spi5: spi@44009000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			reg = <0x44009000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -286,7 +286,7 @@
 		};
 
 		spi1: spi@40013000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40013000 0x400>;
@@ -297,7 +297,7 @@
 		};
 
 		spi2: spi@40003800 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40003800 0x400>;
@@ -308,7 +308,7 @@
 		};
 
 		spi3: spi@46002000 {
-			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			compatible = "st,stm32h7-spi", "st,stm32-spi-fifo", "st,stm32-spi";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x46002000 0x400>;

--- a/dts/bindings/spi/st,stm32h7-spi.yaml
+++ b/dts/bindings/spi/st,stm32h7-spi.yaml
@@ -1,0 +1,14 @@
+# Copyright (c) 2022, Linaro Limited
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+        STM32H7 SPI controller
+        This compatible stands for all SPI hardware blocks matching the
+        version available in STM32H7 SoCs.
+        This version of STM32 SPI hardware block could be identified by the
+        presence of a dedicated interrupt enable register (IER).
+        For instance, but not limited  to: STM32MP1, STM32U5
+
+compatible: "st,stm32h7-spi"
+
+include: st,stm32-spi-common.yaml


### PR DESCRIPTION
Add a st,stm32h7-spi compatible and use it in stm32 spi driver to identify a specific code variant.
This compatible should be used (on top of other spi compatible values), by all series sharing this same spi hardware block.

This will prevent to update the driver next time that a compatible series is ported into zephyr.