### PR TITLE
drivers: sensor: lsm6ds0: Update driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/lsm6ds0/lsm6ds0.c
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.c
@@ -24,13 +24,11 @@ LOG_MODULE_REGISTER(LSM6DS0, CONFIG_SENSOR_LOG_LEVEL);
 
 static inline int lsm6ds0_reboot(const struct device *dev)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 
-	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				LSM6DS0_REG_CTRL_REG8,
-				LSM6DS0_MASK_CTRL_REG8_BOOT,
-				1 << LSM6DS0_SHIFT_CTRL_REG8_BOOT) < 0) {
+	if (i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG8,
+				   LSM6DS0_MASK_CTRL_REG8_BOOT,
+				   1 << LSM6DS0_SHIFT_CTRL_REG8_BOOT) < 0) {
 		return -EIO;
 	}
 
@@ -42,29 +40,25 @@ static inline int lsm6ds0_reboot(const struct device *dev)
 static inline int lsm6ds0_accel_axis_ctrl(const struct device *dev, int x_en,
 					  int y_en, int z_en)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 	uint8_t state = (x_en << LSM6DS0_SHIFT_CTRL_REG5_XL_XEN_XL) |
 			(y_en << LSM6DS0_SHIFT_CTRL_REG5_XL_YEN_XL) |
 			(z_en << LSM6DS0_SHIFT_CTRL_REG5_XL_ZEN_XL);
 
-	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				   LSM6DS0_REG_CTRL_REG5_XL,
-				   LSM6DS0_MASK_CTRL_REG5_XL_XEN_XL |
-				   LSM6DS0_MASK_CTRL_REG5_XL_YEN_XL |
-				   LSM6DS0_MASK_CTRL_REG5_XL_ZEN_XL,
-				   state);
+	return i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG5_XL,
+				      LSM6DS0_MASK_CTRL_REG5_XL_XEN_XL |
+				      LSM6DS0_MASK_CTRL_REG5_XL_YEN_XL |
+				      LSM6DS0_MASK_CTRL_REG5_XL_ZEN_XL,
+				      state);
 }
 
 static int lsm6ds0_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 
-	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				LSM6DS0_REG_CTRL_REG6_XL,
-				LSM6DS0_MASK_CTRL_REG6_XL_FS_XL,
-				fs << LSM6DS0_SHIFT_CTRL_REG6_XL_FS_XL) < 0) {
+	if (i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG6_XL,
+				   LSM6DS0_MASK_CTRL_REG6_XL_FS_XL,
+				   fs << LSM6DS0_SHIFT_CTRL_REG6_XL_FS_XL) < 0) {
 		return -EIO;
 	}
 
@@ -73,13 +67,11 @@ static int lsm6ds0_accel_set_fs_raw(const struct device *dev, uint8_t fs)
 
 static int lsm6ds0_accel_set_odr_raw(const struct device *dev, uint8_t odr)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 
-	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				LSM6DS0_REG_CTRL_REG6_XL,
-				LSM6DS0_MASK_CTRL_REG6_XL_ODR_XL,
-				odr << LSM6DS0_SHIFT_CTRL_REG6_XL_ODR_XL) < 0) {
+	if (i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG6_XL,
+				   LSM6DS0_MASK_CTRL_REG6_XL_ODR_XL,
+				   odr << LSM6DS0_SHIFT_CTRL_REG6_XL_ODR_XL) < 0) {
 		return -EIO;
 	}
 
@@ -90,29 +82,25 @@ static inline int lsm6ds0_gyro_axis_ctrl(const struct device *dev, int x_en,
 					 int y_en,
 					 int z_en)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 	uint8_t state = (x_en << LSM6DS0_SHIFT_CTRL_REG4_XEN_G) |
 			(y_en << LSM6DS0_SHIFT_CTRL_REG4_YEN_G) |
 			(z_en << LSM6DS0_SHIFT_CTRL_REG4_ZEN_G);
 
-	return i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				   LSM6DS0_REG_CTRL_REG4,
-				   LSM6DS0_MASK_CTRL_REG4_XEN_G |
-				   LSM6DS0_MASK_CTRL_REG4_YEN_G |
-				   LSM6DS0_MASK_CTRL_REG4_ZEN_G,
-				   state);
+	return i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG4,
+				      LSM6DS0_MASK_CTRL_REG4_XEN_G |
+				      LSM6DS0_MASK_CTRL_REG4_YEN_G |
+				      LSM6DS0_MASK_CTRL_REG4_ZEN_G,
+				      state);
 }
 
 static int lsm6ds0_gyro_set_fs_raw(const struct device *dev, uint8_t fs)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 
-	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				LSM6DS0_REG_CTRL_REG1_G,
-				LSM6DS0_MASK_CTRL_REG1_G_FS_G,
-				fs << LSM6DS0_SHIFT_CTRL_REG1_G_FS_G) < 0) {
+	if (i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG1_G,
+				   LSM6DS0_MASK_CTRL_REG1_G_FS_G,
+				   fs << LSM6DS0_SHIFT_CTRL_REG1_G_FS_G) < 0) {
 		return -EIO;
 	}
 
@@ -121,13 +109,11 @@ static int lsm6ds0_gyro_set_fs_raw(const struct device *dev, uint8_t fs)
 
 static int lsm6ds0_gyro_set_odr_raw(const struct device *dev, uint8_t odr)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 
-	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				LSM6DS0_REG_CTRL_REG1_G,
-				LSM6DS0_MASK_CTRL_REG1_G_ODR_G,
-				odr << LSM6DS0_SHIFT_CTRL_REG1_G_ODR_G) < 0) {
+	if (i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG1_G,
+				   LSM6DS0_MASK_CTRL_REG1_G_ODR_G,
+				   odr << LSM6DS0_SHIFT_CTRL_REG1_G_ODR_G) < 0) {
 		return -EIO;
 	}
 
@@ -140,8 +126,7 @@ static int lsm6ds0_sample_fetch_accel(const struct device *dev)
 	const struct lsm6ds0_config *config = dev->config;
 	uint8_t buf[6];
 
-	if (i2c_burst_read(data->i2c_master, config->i2c_slave_addr,
-			   LSM6DS0_REG_OUT_X_L_XL, buf, sizeof(buf)) < 0) {
+	if (i2c_burst_read_dt(&config->i2c, LSM6DS0_REG_OUT_X_L_XL, buf, sizeof(buf)) < 0) {
 		LOG_DBG("failed to read sample");
 		return -EIO;
 	}
@@ -168,8 +153,7 @@ static int lsm6ds0_sample_fetch_gyro(const struct device *dev)
 	const struct lsm6ds0_config *config = dev->config;
 	uint8_t buf[6];
 
-	if (i2c_burst_read(data->i2c_master, config->i2c_slave_addr,
-			   LSM6DS0_REG_OUT_X_L_G, buf, sizeof(buf)) < 0) {
+	if (i2c_burst_read_dt(&config->i2c, LSM6DS0_REG_OUT_X_L_G, buf, sizeof(buf)) < 0) {
 		LOG_DBG("failed to read sample");
 		return -EIO;
 	}
@@ -197,8 +181,7 @@ static int lsm6ds0_sample_fetch_temp(const struct device *dev)
 	const struct lsm6ds0_config *config = dev->config;
 	uint8_t buf[2];
 
-	if (i2c_burst_read(data->i2c_master, config->i2c_slave_addr,
-			   LSM6DS0_REG_OUT_TEMP_L, buf, sizeof(buf)) < 0) {
+	if (i2c_burst_read_dt(&config->i2c, LSM6DS0_REG_OUT_TEMP_L, buf, sizeof(buf)) < 0) {
 		LOG_DBG("failed to read sample");
 		return -EIO;
 	}
@@ -408,7 +391,6 @@ static const struct sensor_driver_api lsm6ds0_api_funcs = {
 
 static int lsm6ds0_init_chip(const struct device *dev)
 {
-	struct lsm6ds0_data *data = dev->data;
 	const struct lsm6ds0_config *config = dev->config;
 	uint8_t chip_id;
 
@@ -417,8 +399,7 @@ static int lsm6ds0_init_chip(const struct device *dev)
 		return -EIO;
 	}
 
-	if (i2c_reg_read_byte(data->i2c_master, config->i2c_slave_addr,
-			      LSM6DS0_REG_WHO_AM_I, &chip_id) < 0) {
+	if (i2c_reg_read_byte_dt(&config->i2c, LSM6DS0_REG_WHO_AM_I, &chip_id) < 0) {
 		LOG_DBG("failed reading chip id");
 		return -EIO;
 	}
@@ -466,15 +447,14 @@ static int lsm6ds0_init_chip(const struct device *dev)
 		return -EIO;
 	}
 
-	if (i2c_reg_update_byte(data->i2c_master, config->i2c_slave_addr,
-				LSM6DS0_REG_CTRL_REG8,
-				LSM6DS0_MASK_CTRL_REG8_BDU |
-				LSM6DS0_MASK_CTRL_REG8_BLE |
-				LSM6DS0_MASK_CTRL_REG8_IF_ADD_INC,
-				(1 << LSM6DS0_SHIFT_CTRL_REG8_BDU) |
-				(0 << LSM6DS0_SHIFT_CTRL_REG8_BLE) |
-				(1 << LSM6DS0_SHIFT_CTRL_REG8_IF_ADD_INC))
-				< 0) {
+	if (i2c_reg_update_byte_dt(&config->i2c, LSM6DS0_REG_CTRL_REG8,
+				   LSM6DS0_MASK_CTRL_REG8_BDU |
+				   LSM6DS0_MASK_CTRL_REG8_BLE |
+				   LSM6DS0_MASK_CTRL_REG8_IF_ADD_INC,
+				   (1 << LSM6DS0_SHIFT_CTRL_REG8_BDU) |
+				   (0 << LSM6DS0_SHIFT_CTRL_REG8_BLE) |
+				   (1 << LSM6DS0_SHIFT_CTRL_REG8_IF_ADD_INC))
+				   < 0) {
 		LOG_DBG("failed to set BDU, BLE and burst");
 		return -EIO;
 	}
@@ -485,13 +465,10 @@ static int lsm6ds0_init_chip(const struct device *dev)
 static int lsm6ds0_init(const struct device *dev)
 {
 	const struct lsm6ds0_config * const config = dev->config;
-	struct lsm6ds0_data *data = dev->data;
 
-	data->i2c_master = device_get_binding(config->i2c_master_dev_name);
-	if (!data->i2c_master) {
-		LOG_DBG("i2c master not found: %s",
-			    config->i2c_master_dev_name);
-		return -EINVAL;
+	if (!device_is_ready(config->i2c.bus)) {
+		LOG_ERR("I2C bus device not ready");
+		return -ENODEV;
 	}
 
 	if (lsm6ds0_init_chip(dev) < 0) {
@@ -503,8 +480,7 @@ static int lsm6ds0_init(const struct device *dev)
 }
 
 static const struct lsm6ds0_config lsm6ds0_config = {
-	.i2c_master_dev_name = DT_INST_BUS_LABEL(0),
-	.i2c_slave_addr = DT_INST_REG_ADDR(0),
+	.i2c = I2C_DT_SPEC_INST_GET(0),
 };
 
 static struct lsm6ds0_data lsm6ds0_data;

--- a/drivers/sensor/lsm6ds0/lsm6ds0.h
+++ b/drivers/sensor/lsm6ds0/lsm6ds0.h
@@ -460,13 +460,10 @@
 #endif
 
 struct lsm6ds0_config {
-	char *i2c_master_dev_name;
-	uint16_t i2c_slave_addr;
+	struct i2c_dt_spec i2c;
 };
 
 struct lsm6ds0_data {
-	const struct device *i2c_master;
-
 #if defined(CONFIG_LSM6DS0_ACCEL_ENABLE_X_AXIS)
 	int accel_sample_x;
 #endif


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>