### PR TITLE
Clock ctrl g0 hsi div sysclk

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -19,6 +19,9 @@
 #include "stm32_hsem.h"
 
 /* Macros to fill up prescaler values */
+#define z_hsi_divider(v) LL_RCC_HSI_DIV_ ## v
+#define hsi_divider(v) z_hsi_divider(v)
+
 #define fn_ahb_prescaler(v) LL_RCC_SYSCLK_DIV_ ## v
 #define ahb_prescaler(v) fn_ahb_prescaler(v)
 
@@ -447,6 +450,9 @@ static void set_up_fixed_clock_sources(void)
 			/* Wait for HSI ready */
 			}
 		}
+#if STM32_HSI_DIV_ENABLED
+		LL_RCC_SetHSIDiv(hsi_divider(STM32_HSI_DIVISOR));
+#endif
 	}
 
 #if defined(STM32_MSI_ENABLED)

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -45,7 +45,8 @@
 
 		clk_hsi: clk-hsi {
 			#clock-cells = <0>;
-			compatible = "fixed-clock";
+			compatible = "st,stm32g0-hsi-clock";
+			hsi-div = <1>;
 			clock-frequency = <DT_FREQ_M(16)>;
 			status = "disabled";
 		};

--- a/dts/bindings/clock/st,stm32g0-hsi-clock.yaml
+++ b/dts/bindings/clock/st,stm32g0-hsi-clock.yaml
@@ -1,0 +1,41 @@
+# Copyright (c) 2022 STMicroelectronics
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+  STM32 HSI Clock node description for STM32G0 devices
+  On STM32G0, HSI is a 16MHz fixed clock.
+
+  It also produces a HSISYS secondary clk which can be used as system clock
+  source. In that case, a HSI divisor (ranges from 1 to 128) can be applied:
+  SYSCLK = HSI16 / HSI DIV
+        enum:
+        - 1 ==> HSISYS = 16MHZ
+        - 2 ==> HSISYS = 8MHZ
+        - 4 ==> HSISYS = 4MHZ
+        - 8 ==> HSISYS = 2MHZ
+        - 16 ==> HSISYS = 1MHZ
+        - 32 ==> HSISYS = 0.5MHz
+        - 64 ==> HSISYS = 0.25MHZ
+        - 128 ==> HSISYS = 0.125MHz
+
+compatible: "st,stm32g0-hsi-clock"
+
+include: [fixed-clock.yaml]
+
+properties:
+    hsi-div:
+      type: int
+      required: true
+      description: |
+        HSI clock divider. Configures the output HSI clock frequency (HSISYS),
+        It does not apply to HSI clk selected as peripheral source clock
+        (eg: RNG clk driven by HSI)
+      enum:
+        - 1
+        - 2
+        - 4
+        - 8
+        - 16
+        - 32
+        - 64
+        - 128

--- a/include/zephyr/drivers/clock_control/stm32_clock_control.h
+++ b/include/zephyr/drivers/clock_control/stm32_clock_control.h
@@ -241,13 +241,17 @@
 #endif
 
 #if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), fixed_clock, okay)
+#define STM32_HSI_DIV_ENABLED	0
 #define STM32_HSI_ENABLED	1
 #define STM32_HSI_FREQ		DT_PROP(DT_NODELABEL(clk_hsi), clock_frequency)
-#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32h7_hsi_clock, okay)
+#elif DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32h7_hsi_clock, okay) \
+	|| DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(clk_hsi), st_stm32g0_hsi_clock, okay)
+#define STM32_HSI_DIV_ENABLED	1
 #define STM32_HSI_ENABLED	1
 #define STM32_HSI_DIVISOR	DT_PROP(DT_NODELABEL(clk_hsi), hsi_div)
 #define STM32_HSI_FREQ		DT_PROP(DT_NODELABEL(clk_hsi), clock_frequency)
 #else
+#define STM32_HSI_DIV_ENABLED	0
 #define STM32_HSI_DIVISOR	1
 #define STM32_HSI_FREQ		0
 #endif

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/hsi_g0_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/hsi_g0_16.overlay
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {		/* HSI RC: 16MHz, hsi_clk = 16MHz */
+	status = "okay";
+	hsi-div = <1>;
+};
+
+&rcc {
+	clocks = <&clk_hsi>;
+	clock-frequency = <DT_FREQ_M(16)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/hsi_g0_16_div_2.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/hsi_g0_16_div_2.overlay
@@ -1,0 +1,23 @@
+ /*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+/* hsi_clk = 16MHz */
+
+&clk_hsi {
+	hsi-div = <2>; /* HSISYS = 8Mhz */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hsi>;
+	ahb-prescaler = <1>;
+	clock-frequency = <DT_FREQ_M(8)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/hsi_g0_16_div_4.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/hsi_g0_16_div_4.overlay
@@ -1,0 +1,23 @@
+ /*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+/* hsi_clk = 16MHz */
+
+&clk_hsi {
+	hsi-div = <4>; /* HSISYS = 4Mhz */
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hsi>;
+	ahb-prescaler = <1>;
+	clock-frequency = <DT_FREQ_M(4)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/pll_g0_64_hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/pll_g0_64_hsi_16.overlay
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	status = "okay";
+	hsi-div = <1>;
+};
+
+&pll {
+	div-m = <1>;
+	mul-n = <8>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hsi>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(64)>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/testcase.yaml
@@ -37,12 +37,24 @@ tests:
     harness: ztest
     harness_config:
       fixture: mco_sb_closed
-  drivers.stm32_clock_configuration.common_core.g0_g4.sysclksrc_pll_64_hsi_16:
+  drivers.stm32_clock_configuration.common_core.g0.sysclksrc_hsi_g0_16_div_2:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_g0_16_div_2.overlay"
+    platform_allow: nucleo_g071rb
+  drivers.stm32_clock_configuration.common_core.g0.sysclksrc_hsi_g0_16_div_4:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_g0_16_div_4.overlay"
+    platform_allow: nucleo_g071rb
+  drivers.stm32_clock_configuration.common_core.g4.sysclksrc_pll_64_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_64_hsi_16.overlay"
-    platform_allow: nucleo_g071rb nucleo_g474re
-  drivers.stm32_clock_configuration.common_core.g0_g4.sysclksrc_hsi_16:
+    platform_allow: nucleo_g474re
+  drivers.stm32_clock_configuration.common_core.g0.sysclksrc_pll_g0_64_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_g0_64_hsi_16.overlay"
+    platform_allow: nucleo_g071rb
+  drivers.stm32_clock_configuration.common_core.g4.sysclksrc_hsi_16:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
-    platform_allow: nucleo_g071rb nucleo_g474re
+    platform_allow: nucleo_g474re
+  drivers.stm32_clock_configuration.common_core.g0.sysclksrc_hsi_g0_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_g0_16.overlay"
+    platform_allow: nucleo_g071rb
   drivers.stm32_clock_configuration.common_core.g4.sysclksrc_hse_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_24.overlay"
     platform_allow: nucleo_g474re


### PR DESCRIPTION
Description of the bug:
WHen the HSI is selected as clock source of the SYSCLK on stm32G0 mcu, there is divider in the RCC CR to produce the HSISYS : to divide the HSI from 1 to 128 (default is 1)
Add the property in the DTS
Add the value in clock control driver
test