### PR TITLE
Use picolibc printf to implement printk

### DIFF
--- a/include/zephyr/sys/printk.h
+++ b/include/zephyr/sys/printk.h
@@ -60,10 +60,21 @@ static inline __printf_like(1, 0) void vprintk(const char *fmt, va_list ap)
 }
 #endif
 
+#ifdef CONFIG_PICOLIBC
+
+#include <stdio.h>
+
+#define snprintk(...) snprintf(__VA_ARGS__)
+#define vsnprintk(str, size, fmt, ap) vsnprintf(str, size, fmt, ap)
+
+#else
+
 extern __printf_like(3, 4) int snprintk(char *str, size_t size,
 					const char *fmt, ...);
 extern __printf_like(3, 0) int vsnprintk(char *str, size_t size,
 					  const char *fmt, va_list ap);
+
+#endif
 
 #ifdef __cplusplus
 }

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -79,7 +79,6 @@ void *__printk_get_hook(void)
 }
 
 struct buf_out_context {
-	int count;
 	unsigned int buf_count;
 	char buf[CONFIG_PRINTK_BUFFER_SIZE];
 };
@@ -94,7 +93,6 @@ static int buf_char_out(int c, void *ctx_p)
 {
 	struct buf_out_context *ctx = ctx_p;
 
-	ctx->count++;
 	ctx->buf[ctx->buf_count++] = c;
 	if (ctx->buf_count == CONFIG_PRINTK_BUFFER_SIZE) {
 		buf_flush(ctx);
@@ -103,15 +101,9 @@ static int buf_char_out(int c, void *ctx_p)
 	return c;
 }
 
-struct out_context {
-	int count;
-};
-
 static int char_out(int c, void *ctx_p)
 {
-	struct out_context *ctx = ctx_p;
-
-	ctx->count++;
+	(void) ctx_p;
 	return _char_out(c);
 }
 
@@ -131,12 +123,11 @@ void vprintk(const char *fmt, va_list ap)
 			buf_flush(&ctx);
 		}
 	} else {
-		struct out_context ctx = { 0 };
 #ifdef CONFIG_PRINTK_SYNC
 		k_spinlock_key_t key = k_spin_lock(&lock);
 #endif
 
-		cbvprintf(char_out, &ctx, fmt, ap);
+		cbvprintf(char_out, NULL, fmt, ap);
 
 #ifdef CONFIG_PRINTK_SYNC
 		k_spin_unlock(&lock, key);

--- a/lib/os/printk.c
+++ b/lib/os/printk.c
@@ -202,6 +202,8 @@ void printk(const char *fmt, ...)
 }
 #endif /* defined(CONFIG_PRINTK) */
 
+#ifndef CONFIG_PICOLIBC
+
 struct str_context {
 	char *str;
 	int max;
@@ -248,3 +250,5 @@ int vsnprintk(char *str, size_t size, const char *fmt, va_list ap)
 
 	return ctx.count;
 }
+
+#endif

--- a/tests/kernel/common/src/printk.c
+++ b/tests/kernel/common/src/printk.c
@@ -15,6 +15,37 @@ void __printk_hook_install(int (*fn)(int));
 void *__printk_get_hook(void);
 int (*_old_char_out)(int);
 
+#if defined(CONFIG_PICOLIBC)
+char expected_32[] = "22 113 10000 32768 40000 22\n"
+	"p 112 -10000 -32768 -40000 -22\n"
+	"0x1 0x01 0x0001 0x00000001 0x0000000000000001\n"
+	"0x1 0x 1 0x   1 0x       1\n"
+	"42 42 0042 00000042\n"
+	"-42 -42 -042 -0000042\n"
+	"42 42   42       42\n"
+	"42 42 0042 00000042\n"
+	"255     42    abcdef        42\n"
+#if defined(CONFIG_PICOLIBC_IO_LONG_LONG) || defined(CONFIG_PICOLIBC_IO_FLOAT)
+	"68719476735 -1 18446744073709551615 ffffffffffffffff\n"
+#else
+	"-1 -1 4294967295 ffffffff\n"
+#endif
+	"0xcafebabe 0xbeef 0x2a\n"
+;
+char expected_64[] = "22 113 10000 32768 40000 22\n"
+	"p 112 -10000 -32768 -40000 -22\n"
+	"0x1 0x01 0x0001 0x00000001 0x0000000000000001\n"
+	"0x1 0x 1 0x   1 0x       1\n"
+	"42 42 0042 00000042\n"
+	"-42 -42 -042 -0000042\n"
+	"42 42   42       42\n"
+	"42 42 0042 00000042\n"
+	"255     42    abcdef        42\n"
+	"68719476735 -1 18446744073709551615 ffffffffffffffff\n"
+	"0xcafebabe 0xbeef 0x2a\n"
+;
+char *expected = (sizeof(long) == sizeof(long long)) ? expected_64 : expected_32;
+#else
 #if defined(CONFIG_CBPRINTF_FULL_INTEGRAL)
 char *expected = "22 113 10000 32768 40000 22\n"
 		 "p 112 -10000 -32768 -40000 -22\n"
@@ -54,6 +85,7 @@ char *expected = "22 113 10000 32768 40000 22\n"
 		 "ERR -1 ERR ERR\n"
 		 "0xcafebabe 0xbeef 0x2a\n"
 ;
+#endif
 #endif
 
 size_t stv = 22;


### PR DESCRIPTION
Just as with cbprintf, picolibc's stdio is flexible enough to provide a compatible interface for printk that eliminates a bunch of extra code in Zephyr.