### PR TITLE
modules: fix advice on deprecating a module

### DIFF
--- a/modules/deprecation_warnings.cmake
+++ b/modules/deprecation_warnings.cmake
@@ -5,7 +5,7 @@
 # they are using. To create a warning, follow the pattern:
 #
 #     if(CONFIG_FOO)
-#       message(WARNING "The foo module is deprecated. <More information>")
+#       message(DEPRECATION "The foo module is deprecated. <More information>")
 #     endif()
 #
 # This is done in a separate CMake file because the modules.cmake file


### PR DESCRIPTION
Commit d169171a6644fc3d9f0f67f1bb9ac72272d69d87
("cmake: Use CMake DEPRECATION level instead of WARNING")
altered the way we handle deprecation warnings in CMake.

The deprecation_warnings.cmake file has some commented-out example
code which should be updated to match the pattern introduced in that
commit, for consistency.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>