### PR TITLE
arch/arm64: Use large code model when text or data base is above 4GB boundary

### DIFF
--- a/arch/arm64/core/CMakeLists.txt
+++ b/arch/arm64/core/CMakeLists.txt
@@ -15,6 +15,18 @@ zephyr_library_sources(
   vector_table.S
 )
 
+# Use large code model for addresses larger than 32 bits,
+# This is 10 characters long (0x12345678). We can't use a
+# simple numeric comparison because these values may be
+# beyond the numeric range of integers for cmake.
+
+string(LENGTH "x${CONFIG_SRAM_BASE_ADDRESS}" SRAM_LENGTH)
+string(LENGTH "x${CONFIG_KERNEL_VM_BASE}" KERNEL_VM_LENGTH)
+
+if(${SRAM_LENGTH} GREATER 11 OR ${KERNEL_VM_LENGTH} GREATER 11)
+  zephyr_cc_option(-mcmodel=large)
+endif()
+
 zephyr_library_sources_ifdef(CONFIG_FPU_SHARING fpu.c fpu.S)
 zephyr_library_sources_ifdef(CONFIG_ARM_MMU mmu.c mmu.S)
 zephyr_library_sources_ifdef(CONFIG_ARM_MPU cortex_r/arm_mpu.c)

--- a/tests/arch/arm64/arm64_high_addresses/testcase.yaml
+++ b/tests/arch/arm64/arm64_high_addresses/testcase.yaml
@@ -23,3 +23,31 @@ tests:
     extra_configs:
       - CONFIG_SRAM_BASE_ADDRESS=0x200880000
       - CONFIG_KERNEL_VM_BASE=0x200800000
+
+  arch.arm64.high_addr.high_sram_low_vm.picolibc:
+    tags: picolibc
+    extra_configs:
+      - CONFIG_SRAM_BASE_ADDRESS=0x200880000
+      - CONFIG_KERNEL_VM_BASE=0x00400000
+      - CONFIG_PICOLIBC=y
+
+  arch.arm64.high_addr.low_sram_high_vm.picolibc:
+    tags: picolibc
+    extra_configs:
+      - CONFIG_SRAM_BASE_ADDRESS=0x00400000
+      - CONFIG_KERNEL_VM_BASE=0x200880000
+      - CONFIG_PICOLIBC=y
+
+  arch.arm64.high_addr.high_sram_equal_vm.picolibc:
+    tags: picolibc
+    extra_configs:
+      - CONFIG_SRAM_BASE_ADDRESS=0x200880000
+      - CONFIG_KERNEL_VM_BASE=0x200880000
+      - CONFIG_PICOLIBC=y
+
+  arch.arm64.high_addr.high_sram_high_vm.picolibc:
+    tags: picolibc
+    extra_configs:
+      - CONFIG_SRAM_BASE_ADDRESS=0x200880000
+      - CONFIG_KERNEL_VM_BASE=0x200800000
+      - CONFIG_PICOLIBC=y


### PR DESCRIPTION
The TLS initialization code has some clever use of linker-generated values to avoid doing computation at runtime. That works great on most targets, but on arm64, the linker can end up unable to generate working code in some memory configurations.
    
Avoid this by using the large code model when the memory configuration places text or data above the 4GB boundary.