### PR TITLE
logging: Reduce code size for frontend only case

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -203,6 +203,13 @@ void log_core_init(void)
 	panic_mode = false;
 	dropped_cnt = 0;
 
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
+		log_frontend_init();
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY)) {
+			return;
+		}
+	}
+
 	/* Set default timestamp. */
 	if (sys_clock_hw_cycles_per_sec() > 1000000) {
 		_timestamp_func = default_lf_get_timestamp;
@@ -220,10 +227,6 @@ void log_core_init(void)
 
 	if (IS_ENABLED(CONFIG_LOG_RUNTIME_FILTERING)) {
 		z_log_runtime_filters_init();
-	}
-
-	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
-		log_frontend_init();
 	}
 }
 
@@ -250,6 +253,10 @@ static uint32_t activate_foreach_backend(uint32_t mask)
 static uint32_t z_log_init(bool blocking, bool can_sleep)
 {
 	uint32_t mask = 0;
+
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY)) {
+		return 0;
+	}
 
 	__ASSERT_NO_MSG(log_backend_count_get() < LOG_FILTERS_NUM_OF_SLOTS);
 	int i;
@@ -347,6 +354,9 @@ void z_impl_log_panic(void)
 
 	if (IS_ENABLED(CONFIG_LOG_FRONTEND)) {
 		log_frontend_panic();
+		if (IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY)) {
+			goto out;
+		}
 	}
 
 	for (int i = 0; i < log_backend_count_get(); i++) {
@@ -363,6 +373,7 @@ void z_impl_log_panic(void)
 		}
 	}
 
+out:
 	panic_mode = true;
 }
 

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -149,6 +149,10 @@ static void process_and_validate(bool backend2_enable, bool panic)
 		return;
 	}
 
+	if (IS_ENABLED(CONFIG_LOG_FRONTEND_ONLY)) {
+		return;
+	}
+
 	mock_log_backend_validate(&backend1, panic);
 
 	if (backend2_enable) {


### PR DESCRIPTION
Add early returns from functions which are not used when
there is only one frontend in the system (no backends). This
allows to significantly reduce logging code size in that
configuration.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>