### PR TITLE
Bluetooth: controller: llcp: fix issue re. version exchange

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -1022,8 +1022,10 @@ static void rp_comm_send_rsp(struct ll_conn *conn, struct proc_ctx *ctx, uint8_t
 		} else {
 			/* Invalid behaviour
 			 * A procedure already sent a LL_VERSION_IND and received a LL_VERSION_IND.
-			 * For now we chose to ignore the 'out of order' PDU
+			 * Ignore and complete the procedure.
 			 */
+			llcp_rr_complete(conn);
+			ctx->state = RP_COMMON_STATE_IDLE;
 		}
 
 		break;


### PR DESCRIPTION
Complete the remote initiated version exchange if a LL_VERSION_IND is
received while already having responded in an earlier version exchange
procedure.

Clarify comment regarding how to handle this invalid behaviour.

This has been seen when running the LL/CON/CEN/BI-12-C test on EBQ.

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>