### PR TITLE
 Add lib_code module type.

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/manifest.h
+++ b/soc/xtensa/intel_adsp/common/include/manifest.h
@@ -26,7 +26,8 @@ struct sof_man_module_type {
 	uint32_t auto_start:1;
 	uint32_t domain_ll:1;
 	uint32_t domain_dp:1;
-	uint32_t rsvd_:25;
+	uint32_t lib_code:1;
+	uint32_t rsvd_:24;
 };
 
 /* segment flags.type */


### PR DESCRIPTION
External libraries can contain processing module code or common library code.
Library manager need to distinguish between both type of modules for proper loading.

Signed-off-by: Jaroslaw Stelter <jaroslaw.stelter@intel.com>