### PR TITLE
soc: select HAS_MCUX_SRC for MIMXRT1062

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -245,6 +245,7 @@ config SOC_MIMXRT1062
 	select HAS_MCUX_PMU
 	select HAS_MCUX_IOMUXC
 	select HAS_MCUX_ADC_ETC
+	select HAS_MCUX_SRC
 
 config SOC_MIMXRT1064
 	bool "SOC_MIMXRT1064"


### PR DESCRIPTION
Select missing HAS_MCUX_SRC Kconfig symbol for MIMXRT1062, that allows using NXP i.MX mcux SRC hwinfo driver.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>