### PR TITLE
samples: boards: nrfx: Align code with the recent nrfx_gpiote API

### DIFF
--- a/samples/boards/nrf/nrfx/src/main.c
+++ b/samples/boards/nrf/nrfx/src/main.c
@@ -20,7 +20,9 @@ LOG_MODULE_REGISTER(nrfx_sample, LOG_LEVEL_INF);
 #define INPUT_PIN	DT_GPIO_PIN(DT_ALIAS(sw0), gpios)
 #define OUTPUT_PIN	DT_GPIO_PIN(DT_ALIAS(led0), gpios)
 
-static void button_handler(nrfx_gpiote_pin_t pin, nrf_gpiote_polarity_t action)
+static void button_handler(nrfx_gpiote_pin_t pin,
+			   nrfx_gpiote_trigger_t trigger,
+			   void *context)
 {
 	LOG_INF("GPIO input event callback");
 }
@@ -30,6 +32,8 @@ void main(void)
 	LOG_INF("nrfx_gpiote sample on %s", CONFIG_BOARD);
 
 	nrfx_err_t err;
+	uint8_t in_channel, out_channel;
+	uint8_t ppi_channel;
 
 	/* Connect GPIOTE_0 IRQ to nrfx_gpiote_irq_handler */
 	IRQ_CONNECT(DT_IRQN(DT_NODELABEL(gpiote)),
@@ -41,57 +45,74 @@ void main(void)
 	 */
 	err = nrfx_gpiote_init(0);
 	if (err != NRFX_SUCCESS) {
-		LOG_ERR("nrfx_gpiote_init error: %08x", err);
+		LOG_ERR("nrfx_gpiote_init error: 0x%08X", err);
 		return;
 	}
 
-	nrfx_gpiote_in_config_t const in_config = {
-		.sense = NRF_GPIOTE_POLARITY_HITOLO,
-		.pull = NRF_GPIO_PIN_PULLUP,
-		.is_watcher = false,
-		.hi_accuracy = true,
-		.skip_gpio_setup = false,
-	};
+	err = nrfx_gpiote_channel_alloc(&in_channel);
+	if (err != NRFX_SUCCESS) {
+		LOG_ERR("Failed to allocate in_channel, error: 0x%08X", err);
+		return;
+	}
+
+	err = nrfx_gpiote_channel_alloc(&out_channel);
+	if (err != NRFX_SUCCESS) {
+		LOG_ERR("Failed to allocate out_channel, error: 0x%08X", err);
+		return;
+	}
 
 	/* Initialize input pin to generate event on high to low transition
 	 * (falling edge) and call button_handler()
 	 */
-	err = nrfx_gpiote_in_init(INPUT_PIN, &in_config, button_handler);
+	static const nrfx_gpiote_input_config_t input_config = {
+		.pull = NRF_GPIO_PIN_PULLUP,
+	};
+	const nrfx_gpiote_trigger_config_t trigger_config = {
+		.trigger = NRFX_GPIOTE_TRIGGER_HITOLO,
+		.p_in_channel = &in_channel,
+	};
+	static const nrfx_gpiote_handler_config_t handler_config = {
+		.handler = button_handler,
+	};
+	err = nrfx_gpiote_input_configure(INPUT_PIN,
+					  &input_config,
+					  &trigger_config,
+					  &handler_config);
 	if (err != NRFX_SUCCESS) {
-		LOG_ERR("nrfx_gpiote_in_init error: %08x", err);
+		LOG_ERR("nrfx_gpiote_input_configure error: 0x%08X", err);
 		return;
 	}
-
-	nrfx_gpiote_out_config_t const out_config = {
-		.action = NRF_GPIOTE_POLARITY_TOGGLE,
-		.init_state = 1,
-		.task_pin = true,
-	};
 
 	/* Initialize output pin. SET task will turn the LED on,
 	 * CLR will turn it off and OUT will toggle it.
 	 */
-	err = nrfx_gpiote_out_init(OUTPUT_PIN, &out_config);
+	static const nrfx_gpiote_output_config_t output_config = {
+		.drive = NRF_GPIO_PIN_S0S1,
+		.input_connect = NRF_GPIO_PIN_INPUT_DISCONNECT,
+		.pull = NRF_GPIO_PIN_NOPULL,
+	};
+	const nrfx_gpiote_task_config_t task_config = {
+		.task_ch = out_channel,
+		.polarity = NRF_GPIOTE_POLARITY_TOGGLE,
+		.init_val = 1,
+	};
+	err = nrfx_gpiote_output_configure(OUTPUT_PIN,
+					   &output_config,
+					   &task_config);
 	if (err != NRFX_SUCCESS) {
-		LOG_ERR("nrfx_gpiote_out_init error: %08x", err);
+		LOG_ERR("nrfx_gpiote_output_configure error: 0x%08X", err);
 		return;
 	}
 
-	nrfx_gpiote_in_event_enable(INPUT_PIN, true);
+	nrfx_gpiote_trigger_enable(INPUT_PIN, true);
 	nrfx_gpiote_out_task_enable(OUTPUT_PIN);
 
 	LOG_INF("nrfx_gpiote initialized");
 
 	/* Allocate a (D)PPI channel. */
-#if defined(DPPI_PRESENT)
-	uint8_t channel;
-	err = nrfx_dppi_channel_alloc(&channel);
-#else
-	nrf_ppi_channel_t channel;
-	err = nrfx_ppi_channel_alloc(&channel);
-#endif
+	err = nrfx_gppi_channel_alloc(&ppi_channel);
 	if (err != NRFX_SUCCESS) {
-		LOG_ERR("(D)PPI channel allocation error: %08x", err);
+		LOG_ERR("nrfx_gppi_channel_alloc error: 0x%08X", err);
 		return;
 	}
 
@@ -99,20 +120,12 @@ void main(void)
 	 * connected with the output pin OUT task. This means that each time
 	 * the button is pressed, the LED pin will be toggled.
 	 */
-	nrfx_gppi_channel_endpoints_setup(channel,
+	nrfx_gppi_channel_endpoints_setup(ppi_channel,
 		nrfx_gpiote_in_event_addr_get(INPUT_PIN),
 		nrfx_gpiote_out_task_addr_get(OUTPUT_PIN));
 
-	/* Enable (D)PPI channel. */
-#if defined(DPPI_PRESENT)
-	err = nrfx_dppi_channel_enable(channel);
-#else
-	err = nrfx_ppi_channel_enable(channel);
-#endif
-	if (err != NRFX_SUCCESS) {
-		LOG_ERR("Failed to enable (D)PPI channel, error: %08x", err);
-		return;
-	}
+	/* Enable the channel. */
+	nrfx_gppi_channels_enable(BIT(ppi_channel));
 
 	LOG_INF("(D)PPI configured, leaving main()");
 }


### PR DESCRIPTION
Replace calls to nrfx_gpiote functions deprecated in nrfx 2.6.0
with recommended equivalents.
On the occasion, switch to using available `nrfx_gppi_*` functions
instead of separate paths for DPPI and PPI channels.

Fixes #46645