### PR TITLE
drivers: sensor: th02: Update driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/th02/th02.c
+++ b/drivers/sensor/th02/th02.c
@@ -19,23 +19,22 @@
 
 LOG_MODULE_REGISTER(TH02, CONFIG_SENSOR_LOG_LEVEL);
 
-static uint8_t read8(const struct device *dev, uint8_t d)
+static uint8_t read8(const struct i2c_dt_spec *i2c, uint8_t d)
 {
 	uint8_t buf;
 
-	if (i2c_reg_read_byte(dev, TH02_I2C_DEV_ID, d, &buf) < 0) {
+	if (i2c_reg_read_byte_dt(i2c, d, &buf) < 0) {
 		LOG_ERR("Error reading register.");
 	}
 	return buf;
 }
 
-static int is_ready(const struct device *dev)
+static int is_ready(const struct i2c_dt_spec *i2c)
 {
 
 	uint8_t status;
 
-	if (i2c_reg_read_byte(dev, TH02_I2C_DEV_ID,
-			      TH02_REG_STATUS, &status) < 0) {
+	if (i2c_reg_read_byte_dt(i2c, TH02_REG_STATUS, &status) < 0) {
 		LOG_ERR("error reading status register");
 	}
 
@@ -46,39 +45,37 @@ static int is_ready(const struct device *dev)
 	}
 }
 
-static uint16_t get_humi(const struct device *dev)
+static uint16_t get_humi(const struct i2c_dt_spec *i2c)
 {
 	uint16_t humidity = 0U;
 
-	if (i2c_reg_write_byte(dev, TH02_I2C_DEV_ID,
-			       TH02_REG_CONFIG, TH02_CMD_MEASURE_HUMI) < 0) {
+	if (i2c_reg_write_byte_dt(i2c, TH02_REG_CONFIG, TH02_CMD_MEASURE_HUMI) < 0) {
 		LOG_ERR("Error writing register");
 		return 0;
 	}
-	while (!is_ready(dev)) {
+	while (!is_ready(i2c)) {
 	}
 
-	humidity = read8(dev, TH02_REG_DATA_H) << 8;
-	humidity |= read8(dev, TH02_REG_DATA_L);
+	humidity = read8(i2c, TH02_REG_DATA_H) << 8;
+	humidity |= read8(i2c, TH02_REG_DATA_L);
 	humidity >>= 4;
 
 	return humidity;
 }
 
-uint16_t get_temp(const struct device *dev)
+uint16_t get_temp(const struct i2c_dt_spec *i2c)
 {
 	uint16_t temperature = 0U;
 
-	if (i2c_reg_write_byte(dev, TH02_I2C_DEV_ID,
-			       TH02_REG_CONFIG, TH02_CMD_MEASURE_TEMP) < 0) {
+	if (i2c_reg_write_byte_dt(i2c, TH02_REG_CONFIG, TH02_CMD_MEASURE_TEMP) < 0) {
 		LOG_ERR("Error writing register");
 		return 0;
 	}
-	while (!is_ready(dev)) {
+	while (!is_ready(i2c)) {
 	}
 
-	temperature = read8(dev, TH02_REG_DATA_H) << 8;
-	temperature |= read8(dev, TH02_REG_DATA_L);
+	temperature = read8(i2c, TH02_REG_DATA_H) << 8;
+	temperature |= read8(i2c, TH02_REG_DATA_L);
 	temperature >>= 2;
 
 	return temperature;
@@ -88,12 +85,13 @@ static int th02_sample_fetch(const struct device *dev,
 			     enum sensor_channel chan)
 {
 	struct th02_data *drv_data = dev->data;
+	const struct th02_config *cfg = dev->config;
 
 	__ASSERT_NO_MSG(chan == SENSOR_CHAN_ALL || chan == SENSOR_CHAN_AMBIENT_TEMP);
 
-	drv_data->t_sample = get_temp(drv_data->i2c);
+	drv_data->t_sample = get_temp(&cfg->i2c);
 	LOG_INF("temp: %u", drv_data->t_sample);
-	drv_data->rh_sample = get_humi(drv_data->i2c);
+	drv_data->rh_sample = get_humi(&cfg->i2c);
 	LOG_INF("rh: %u", drv_data->rh_sample);
 
 	return 0;
@@ -128,20 +126,22 @@ static const struct sensor_driver_api th02_driver_api = {
 
 static int th02_init(const struct device *dev)
 {
-	struct th02_data *drv_data = dev->data;
+	const struct th02_config *cfg = dev->config;
 
-	drv_data->i2c = device_get_binding(DT_INST_BUS_LABEL(0));
-	if (drv_data->i2c == NULL) {
-		LOG_ERR("Failed to get pointer to %s device!",
-			    DT_INST_BUS_LABEL(0));
-		return -EINVAL;
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
+		return -ENODEV;
 	}
 
 	return 0;
 }
 
+static const struct th02_config th02_config = {
+	.i2c = I2C_DT_SPEC_INST_GET(0),
+};
+
 static struct th02_data th02_driver;
 
 DEVICE_DT_INST_DEFINE(0, th02_init, NULL, &th02_driver,
-		    NULL, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
+		    &th02_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
 		    &th02_driver_api);

--- a/drivers/sensor/th02/th02.h
+++ b/drivers/sensor/th02/th02.h
@@ -10,7 +10,6 @@
 #include <zephyr/device.h>
 #include <zephyr/sys/util.h>
 
-#define TH02_I2C_DEV_ID         0x40
 #define TH02_REG_STATUS         0x00
 #define TH02_REG_DATA_H         0x01
 #define TH02_REG_DATA_L         0x02
@@ -25,8 +24,11 @@
 #define TH02_WR_REG_MODE        0xC0
 #define TH02_RD_REG_MODE        0x80
 
+struct th02_config {
+	struct i2c_dt_spec i2c;
+};
+
 struct th02_data {
-	const struct device *i2c;
 	uint16_t t_sample;
 	uint16_t rh_sample;
 };


### PR DESCRIPTION
Move driver to use i2c_dt_spec for I2C bus access.

Signed-off-by: Kumar Gala <galak@kernel.org>