### PR TITLE
subsys: nvs: Add support for read operation at specific offset

### DIFF
--- a/include/zephyr/fs/nvs.h
+++ b/include/zephyr/fs/nvs.h
@@ -138,6 +138,24 @@ int nvs_delete(struct nvs_fs *fs, uint16_t id);
 ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len);
 
 /**
+ * @brief nvs_read_offset
+ *
+ * Read an entry from the file system with offset parameter.
+ *
+ * @param fs Pointer to file system
+ * @param id Id of the entry to be read
+ * @param data Pointer to data buffer
+ * @param len Number of bytes to be read
+ * @param offset Offset of bytes to be read
+ *
+ * @return Number of bytes read. On success, it will be equal to the number of bytes requested
+ * to be read. When the return value is larger than the number of bytes requested to read this
+ * indicates not all bytes were read, and more data is available. On error, returns negative
+ * value of errno.h defined error codes.
+ */
+ssize_t nvs_read_offset(struct nvs_fs *fs, uint16_t id, void *data, size_t len, size_t offset);
+
+/**
  * @brief nvs_read_hist
  *
  * Read a history entry from the file system.
@@ -154,6 +172,26 @@ ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len);
  * value of errno.h defined error codes.
  */
 ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len, uint16_t cnt);
+
+/**
+ * @brief nvs_read_hist_offset
+ *
+ * Read a history entry from the file system.
+ *
+ * @param fs Pointer to file system
+ * @param id Id of the entry to be read
+ * @param data Pointer to data buffer
+ * @param len Number of bytes to be read
+ * @param offset Offset of bytes to be read
+ * @param cnt History counter: 0: latest entry, 1: one before latest ...
+ *
+ * @return Number of bytes read. On success, it will be equal to the number of bytes requested
+ * to be read. When the return value is larger than the number of bytes requested to read this
+ * indicates not all bytes were read, and more data is available. On error, returns negative
+ * value of errno.h defined error codes.
+ */
+ssize_t nvs_read_hist_offset(struct nvs_fs *fs, uint16_t id, void *data, size_t len,
+			     size_t offset, uint16_t cnt);
 
 /**
  * @brief nvs_calc_free_space

--- a/subsys/fs/nvs/nvs.c
+++ b/subsys/fs/nvs/nvs.c
@@ -1110,8 +1110,8 @@ int nvs_delete(struct nvs_fs *fs, uint16_t id)
 	return nvs_write(fs, id, NULL, 0);
 }
 
-ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len,
-		      uint16_t cnt)
+ssize_t nvs_read_hist_offset(struct nvs_fs *fs, uint16_t id, void *data, size_t len,
+			     size_t offset, uint16_t cnt)
 {
 	int rc;
 	uint32_t wlk_addr, rd_addr;
@@ -1165,7 +1165,8 @@ ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len,
 
 	rd_addr &= ADDR_SECT_MASK;
 	rd_addr += wlk_ate.offset;
-	rc = nvs_flash_rd(fs, rd_addr, data, MIN(len, wlk_ate.len));
+	rd_addr += offset;
+	rc = nvs_flash_rd(fs, rd_addr, data, MIN(len, wlk_ate.len - offset));
 	if (rc) {
 		goto err;
 	}
@@ -1176,11 +1177,24 @@ err:
 	return rc;
 }
 
+ssize_t nvs_read_hist(struct nvs_fs *fs, uint16_t id, void *data, size_t len, uint16_t cnt)
+{
+	return nvs_read_hist_offset(fs, id, data, len, 0, cnt);
+}
+
 ssize_t nvs_read(struct nvs_fs *fs, uint16_t id, void *data, size_t len)
 {
 	int rc;
 
 	rc = nvs_read_hist(fs, id, data, len, 0);
+	return rc;
+}
+
+ssize_t nvs_read_offset(struct nvs_fs *fs, uint16_t id, void *data, size_t len, size_t offset)
+{
+	int rc;
+
+	rc = nvs_read_hist_offset(fs, id, data, len, offset, 0);
 	return rc;
 }
 


### PR DESCRIPTION
In case of big file read operations, the application already provides a buffer for read data. If data is offset in a structure, this parameter allow to directly access to wanted data.