### PR TITLE
drivers: sensor: max30101: Update driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/max30101/max30101.c
+++ b/drivers/sensor/max30101/max30101.c
@@ -25,8 +25,8 @@ static int max30101_sample_fetch(const struct device *dev,
 
 	/* Read all the active channels for one sample */
 	num_bytes = data->num_channels * MAX30101_BYTES_PER_CHANNEL;
-	if (i2c_burst_read(data->i2c, config->i2c_addr,
-			   MAX30101_REG_FIFO_DATA, buffer, num_bytes)) {
+	if (i2c_burst_read_dt(&config->i2c, MAX30101_REG_FIFO_DATA, buffer,
+			      num_bytes)) {
 		LOG_ERR("Could not fetch sample");
 		return -EIO;
 	}
@@ -102,16 +102,14 @@ static int max30101_init(const struct device *dev)
 	uint32_t led_chan;
 	int fifo_chan;
 
-	/* Get the I2C device */
-	data->i2c = device_get_binding(config->i2c_label);
-	if (!data->i2c) {
-		LOG_ERR("Could not find I2C device");
-		return -EINVAL;
+	if (!device_is_ready(config->i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
+		return -ENODEV;
 	}
 
 	/* Check the part id to make sure this is MAX30101 */
-	if (i2c_reg_read_byte(data->i2c, config->i2c_addr,
-			      MAX30101_REG_PART_ID, &part_id)) {
+	if (i2c_reg_read_byte_dt(&config->i2c, MAX30101_REG_PART_ID,
+				 &part_id)) {
 		LOG_ERR("Could not get Part ID");
 		return -EIO;
 	}
@@ -122,50 +120,49 @@ static int max30101_init(const struct device *dev)
 	}
 
 	/* Reset the sensor */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_MODE_CFG,
-			       MAX30101_MODE_CFG_RESET_MASK)) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_MODE_CFG,
+				  MAX30101_MODE_CFG_RESET_MASK)) {
 		return -EIO;
 	}
 
 	/* Wait for reset to be cleared */
 	do {
-		if (i2c_reg_read_byte(data->i2c, config->i2c_addr,
-				      MAX30101_REG_MODE_CFG, &mode_cfg)) {
+		if (i2c_reg_read_byte_dt(&config->i2c, MAX30101_REG_MODE_CFG,
+					 &mode_cfg)) {
 			LOG_ERR("Could read mode cfg after reset");
 			return -EIO;
 		}
 	} while (mode_cfg & MAX30101_MODE_CFG_RESET_MASK);
 
 	/* Write the FIFO configuration register */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_FIFO_CFG, config->fifo)) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_FIFO_CFG,
+				  config->fifo)) {
 		return -EIO;
 	}
 
 	/* Write the mode configuration register */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_MODE_CFG, config->mode)) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_MODE_CFG,
+				  config->mode)) {
 		return -EIO;
 	}
 
 	/* Write the SpO2 configuration register */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_SPO2_CFG, config->spo2)) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_SPO2_CFG,
+				  config->spo2)) {
 		return -EIO;
 	}
 
 	/* Write the LED pulse amplitude registers */
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_LED1_PA, config->led_pa[0])) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_LED1_PA,
+				  config->led_pa[0])) {
 		return -EIO;
 	}
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_LED2_PA, config->led_pa[1])) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_LED2_PA,
+				  config->led_pa[1])) {
 		return -EIO;
 	}
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_LED3_PA, config->led_pa[2])) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_LED3_PA,
+				  config->led_pa[2])) {
 		return -EIO;
 	}
 
@@ -176,12 +173,12 @@ static int max30101_init(const struct device *dev)
 	multi_led[0] = (config->slot[1] << 4) | (config->slot[0]);
 	multi_led[1] = (config->slot[3] << 4) | (config->slot[2]);
 
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_MULTI_LED, multi_led[0])) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_MULTI_LED,
+				  multi_led[0])) {
 		return -EIO;
 	}
-	if (i2c_reg_write_byte(data->i2c, config->i2c_addr,
-			       MAX30101_REG_MULTI_LED + 1, multi_led[1])) {
+	if (i2c_reg_write_byte_dt(&config->i2c, MAX30101_REG_MULTI_LED + 1,
+				  multi_led[1])) {
 		return -EIO;
 	}
 #endif
@@ -208,8 +205,7 @@ static int max30101_init(const struct device *dev)
 }
 
 static struct max30101_config max30101_config = {
-	.i2c_label = DT_INST_BUS_LABEL(0),
-	.i2c_addr = DT_INST_REG_ADDR(0),
+	.i2c = I2C_DT_SPEC_INST_GET(0),
 	.fifo = (CONFIG_MAX30101_SMP_AVE << MAX30101_FIFO_CFG_SMP_AVE_SHIFT) |
 #ifdef CONFIG_MAX30101_FIFO_ROLLOVER_EN
 		MAX30101_FIFO_CFG_ROLLOVER_EN_MASK |

--- a/drivers/sensor/max30101/max30101.h
+++ b/drivers/sensor/max30101/max30101.h
@@ -86,8 +86,7 @@ enum max30101_pw {
 };
 
 struct max30101_config {
-	const char *i2c_label;
-	uint16_t i2c_addr;
+	struct i2c_dt_spec i2c;
 	uint8_t fifo;
 	uint8_t spo2;
 	uint8_t led_pa[MAX30101_MAX_NUM_CHANNELS];
@@ -96,7 +95,6 @@ struct max30101_config {
 };
 
 struct max30101_data {
-	const struct device *i2c;
 	uint32_t raw[MAX30101_MAX_NUM_CHANNELS];
 	uint8_t map[MAX30101_MAX_NUM_CHANNELS];
 	uint8_t num_channels;


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>