### PR TITLE
fix and extend the Intel ADSP "smoke" test

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_deprecated.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_deprecated.h
@@ -27,6 +27,7 @@ struct unit_test {
 	void (*setup)(void);
 	void (*teardown)(void);
 	uint32_t thread_options;
+	uint32_t cpu_mask;
 };
 
 /**

--- a/subsys/testsuite/ztest/src/ztest.c
+++ b/subsys/testsuite/ztest/src/ztest.c
@@ -378,6 +378,19 @@ static int run_test(struct unit_test *test)
 		if (test->name != NULL) {
 			k_thread_name_set(&ztest_thread, test->name);
 		}
+#ifdef CONFIG_SCHED_CPU_MASK
+		if (test->cpu_mask) {
+			unsigned int mask = test->cpu_mask;
+			unsigned int bit;
+
+			k_thread_cpu_mask_clear(&ztest_thread);
+
+			while ((bit = find_msb_set(mask))) {
+				k_thread_cpu_mask_enable(&ztest_thread, --bit);
+				mask &= ~BIT(bit);
+			}
+		}
+#endif
 		k_thread_start(&ztest_thread);
 		k_thread_join(&ztest_thread, K_FOREVER);
 

--- a/tests/boards/intel_adsp/smoke/src/main.c
+++ b/tests/boards/intel_adsp/smoke/src/main.c
@@ -65,5 +65,7 @@ void test_main(void)
 	 */
 	k_msleep(1000);
 
+	_intel_adsp[1].cpu_mask = 1;
+
 	ztest_run_test_suite(intel_adsp);
 }


### PR DESCRIPTION
We should fix the "smoke" test to actually force the launching thread to stay affine to the launching core - the primary core