### PR TITLE
include: riscv: linker: add missing generate linker sections from dt

### DIFF
--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -383,6 +383,9 @@ GROUP_END(DTCM)
 	KEEP(*(.gnu.attributes))
 	}
 
+    /* Sections generated from 'zephyr,memory-region' nodes */
+    LINKER_DT_SECTIONS()
+
 /* Because ROMABLE_REGION != RAMABLE_REGION in XIP-system, it is valid
  * to set __rom_region_end symbol at the end of linker script and
  * doesn't mistakenly contain the RAMABLE_REGION in it.


### PR DESCRIPTION
Riscv platfrom includes linker dt regions (LINKER_DT_REGIONS)
but was missing functionality to generate linker sections
from zephyr,memory-region dt nodes.

Signed-off-by: Lukasz Stepnicki <lukasz.stepnicki@nordicsemi.no>