### PR TITLE
Bluetooth: GATT: Add SECURE Permission Check

### DIFF
--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -72,6 +72,18 @@ enum {
 	 *  passed to write callback.
 	 */
 	BT_GATT_PERM_PREPARE_WRITE = BIT(6),
+
+	/** @brief Attribute read permission with LE Secure Connection encryption.
+	 *
+	 *  If set, requires that LE Secure Connections is used for read access.
+	 */
+	BT_GATT_PERM_READ_LESC = BIT(7),
+
+	/** @brief Attribute write permission with LE Secure Connection encryption.
+	 *
+	 *  If set, requires that LE Secure Connections is used for write access.
+	 */
+	BT_GATT_PERM_WRITE_LESC = BIT(8),
 };
 
 /** @def BT_GATT_ERR
@@ -151,7 +163,7 @@ struct bt_gatt_attr {
 	/** Attribute handle */
 	uint16_t handle;
 	/** Attribute permissions */
-	uint8_t perm;
+	uint16_t perm;
 };
 
 /** @brief GATT Service structure */

--- a/subsys/bluetooth/audio/aics.c
+++ b/subsys/bluetooth/audio/aics.c
@@ -67,34 +67,34 @@ static ssize_t read_description(struct bt_conn *conn,
 	BT_GATT_SECONDARY_SERVICE(BT_UUID_AICS),                               \
 	BT_GATT_CHARACTERISTIC(BT_UUID_AICS_STATE,                             \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,        \
-			       BT_GATT_PERM_READ_ENCRYPT,                      \
+			       BT_GATT_PERM_READ_LESC,                         \
 			       read_aics_state, NULL, &_aics),                 \
 	BT_GATT_CCC(aics_state_cfg_changed,                                    \
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),           \
+		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_LESC),              \
 	BT_GATT_CHARACTERISTIC(BT_UUID_AICS_GAIN_SETTINGS,                     \
 			       BT_GATT_CHRC_READ,                              \
-			       BT_GATT_PERM_READ_ENCRYPT,                      \
+			       BT_GATT_PERM_READ_LESC,                         \
 			       read_aics_gain_settings, NULL, &_aics),         \
 	BT_GATT_CHARACTERISTIC(BT_UUID_AICS_INPUT_TYPE,                        \
 			       BT_GATT_CHRC_READ,                              \
-			       BT_GATT_PERM_READ_ENCRYPT,                      \
+			       BT_GATT_PERM_READ_LESC,                         \
 			       read_type, NULL, &_aics),                       \
 	BT_GATT_CHARACTERISTIC(BT_UUID_AICS_INPUT_STATUS,                      \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,        \
-			       BT_GATT_PERM_READ_ENCRYPT,                      \
+			       BT_GATT_PERM_READ_LESC,                         \
 			       read_input_status, NULL, &_aics),               \
 	BT_GATT_CCC(aics_input_status_cfg_changed,                             \
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),           \
+		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_LESC),              \
 	BT_GATT_CHARACTERISTIC(BT_UUID_AICS_CONTROL,                           \
 			       BT_GATT_CHRC_WRITE,                             \
-			       BT_GATT_PERM_WRITE_ENCRYPT,                     \
+			       BT_GATT_PERM_WRITE_LESC,                        \
 			       NULL, write_aics_control, &_aics),              \
 	BT_GATT_CHARACTERISTIC(BT_UUID_AICS_DESCRIPTION,                       \
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,        \
-			       BT_GATT_PERM_READ_ENCRYPT,                      \
+			       BT_GATT_PERM_READ_LESC,                         \
 			       read_description, NULL, &_aics),                \
 	BT_GATT_CCC(aics_description_cfg_changed,                              \
-		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT)            \
+		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_LESC)               \
 	}
 
 
@@ -456,7 +456,7 @@ int bt_aics_register(struct bt_aics *aics, struct bt_aics_register_param *param)
 
 				chrc = aics->srv.service_p->attrs[i - 1].user_data;
 				attr->write = write_description;
-				attr->perm |= BT_GATT_PERM_WRITE_ENCRYPT;
+				attr->perm |= BT_GATT_PERM_WRITE_LESC;
 				chrc->properties |= BT_GATT_CHRC_WRITE_WITHOUT_RESP;
 
 				break;

--- a/subsys/bluetooth/host/gatt_internal.h
+++ b/subsys/bluetooth/host/gatt_internal.h
@@ -13,14 +13,21 @@
 
 #define BT_GATT_PERM_READ_MASK			(BT_GATT_PERM_READ | \
 						BT_GATT_PERM_READ_ENCRYPT | \
-						BT_GATT_PERM_READ_AUTHEN)
+						BT_GATT_PERM_READ_AUTHEN | \
+						BT_GATT_PERM_READ_LESC)
 #define BT_GATT_PERM_WRITE_MASK			(BT_GATT_PERM_WRITE | \
 						BT_GATT_PERM_WRITE_ENCRYPT | \
-						BT_GATT_PERM_WRITE_AUTHEN)
+						BT_GATT_PERM_WRITE_AUTHEN | \
+						BT_GATT_PERM_WRITE_LESC)
 #define BT_GATT_PERM_ENCRYPT_MASK		(BT_GATT_PERM_READ_ENCRYPT | \
 						BT_GATT_PERM_WRITE_ENCRYPT)
 #define BT_GATT_PERM_AUTHEN_MASK		(BT_GATT_PERM_READ_AUTHEN | \
 						BT_GATT_PERM_WRITE_AUTHEN)
+#define BT_GATT_PERM_LESC_MASK			(BT_GATT_PERM_READ_LESC | \
+						BT_GATT_PERM_WRITE_LESC)
+#define BT_GATT_PERM_READ_ENCRYPT_MASK		(BT_GATT_PERM_READ_ENCRYPT | \
+						BT_GATT_PERM_READ_AUTHEN | \
+						BT_GATT_PERM_READ_LESC)
 
 void bt_gatt_init(void);
 void bt_gatt_connected(struct bt_conn *conn);
@@ -56,4 +63,4 @@ struct bt_gatt_attr;
 
 /* Check attribute permission */
 uint8_t bt_gatt_check_perm(struct bt_conn *conn, const struct bt_gatt_attr *attr,
-			uint8_t mask);
+			uint16_t mask);


### PR DESCRIPTION
Added possibility to check that the connection used for gatt is
secure, i.e. providing more fine grained checks that allows services
that requires secure connection to co-exists with those that doesn't.

Signed-off-by: Lars Knudsen <larsgk@gmail.com>
Signed-off-by: Fredrik Danebjer <fredrik@danebjer.com>