### PR TITLE
dts: arm64: intel: Enable arm timer for Intel Agilex SoC FPGA

### DIFF
--- a/dts/arm64/intel/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex.dtsi
@@ -33,13 +33,13 @@
 	arch_timer: timer {
 		compatible = "arm,armv8-timer";
 		interrupt-parent = <&gic>;
-		interrupts = <GIC_PPI 29 IRQ_TYPE_LEVEL
+		interrupts = <GIC_PPI 13 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>,
-			     <GIC_PPI 30 IRQ_TYPE_LEVEL
+			     <GIC_PPI 14 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>,
-			     <GIC_PPI 27 IRQ_TYPE_LEVEL
+			     <GIC_PPI 11 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>,
-			     <GIC_PPI 26 IRQ_TYPE_LEVEL
+			     <GIC_PPI 10 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
 	};
 


### PR DESCRIPTION
This patch is to enable arm timer driver for Intel Agilex SoC FPGA.
The PPI's interrupt ID will be mapped into the interrupt ID
defined by SBSA in GIC-400 controller.

Signed-off-by: Teik Heng Chong <teik.heng.chong@intel.com>