### PR TITLE
sd: add proper handling for DISK_IOCTL_CTRL_SYNC

### DIFF
--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -1501,6 +1501,12 @@ int sdmmc_ioctl(struct sd_card *card, uint8_t cmd, void *buf)
 	case DISK_IOCTL_GET_ERASE_BLOCK_SZ:
 		(*(uint32_t *)buf) = card->block_size;
 		break;
+	case DISK_IOCTL_CTRL_SYNC:
+		/* Ensure card is not busy with data write.
+		 * Note that SD stack does not support enabling caching, so
+		 * cache flush is not required here
+		 */
+		return sdmmc_wait_ready(card);
 	default:
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
Add handling for DISK_IOCTL_CTRL_SYNC to SD subsystem. Note that
SD caching is not enabled by the SD stack, so the only required
operation to sync the disk is to wait for any active data programming
to complete.

Fixes #46689

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>