### PR TITLE
soc/xtensa/intel_adsp/tools: Do not use grep Perl extensions

### DIFF
--- a/soc/xtensa/intel_adsp/tools/cavstool.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool.py
@@ -202,7 +202,7 @@ class HDAStream:
 
 
 def map_regs():
-    p = runx(f"grep -iPl 'PCI_CLASS=40(10|38)0' /sys/bus/pci/devices/*/uevent")
+    p = runx(f"grep -iEl 'PCI_CLASS=40(10|38)0' /sys/bus/pci/devices/*/uevent")
     pcidir = os.path.dirname(p)
 
     # Platform/quirk detection.  ID lists cribbed from the SOF kernel driver


### PR DESCRIPTION
They may be disabled in some environments (such as Gentoo based
developer mode on Chromebooks). Use extended regular expressions
instead.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>