### PR TITLE
Bluetooth: controller: nRF5: Convert to DEVICE_DT_GET

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -59,7 +59,7 @@ static struct {
 } event;
 
 /* Entropy device */
-static const struct device *dev_entropy;
+static const struct device *dev_entropy = DEVICE_DT_GET(DT_NODELABEL(rng));
 
 static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)
@@ -163,8 +163,7 @@ int lll_init(void)
 	int err;
 
 	/* Get reference to entropy device */
-	dev_entropy = device_get_binding(DT_LABEL(DT_NODELABEL(rng)));
-	if (!dev_entropy) {
+	if (!device_is_ready(dev_entropy)) {
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Move to using DEVICE_DT_GET so we can phase out DT_LABEL.

Signed-off-by: Kumar Gala <galak@kernel.org>