### PR TITLE
modbus: serial: Convert to DEVICE_DT_GET

### DIFF
--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -35,7 +35,7 @@ DT_INST_FOREACH_STATUS_OKAY(MB_RTU_DEFINE_GPIO_CFGS)
 		    (&prop##_cfg_##inst), (NULL))
 
 #define MODBUS_DT_GET_SERIAL_DEV(inst) {			\
-		.dev_name = DT_INST_BUS_LABEL(inst),		\
+		.dev = DEVICE_DT_GET(DT_INST_BUS(inst)),	\
 		.de = MB_RTU_ASSIGN_GPIO_CFG(inst, de_gpios),	\
 		.re = MB_RTU_ASSIGN_GPIO_CFG(inst, re_gpios),	\
 	},

--- a/subsys/modbus/modbus_internal.h
+++ b/subsys/modbus/modbus_internal.h
@@ -81,8 +81,6 @@
 #define MODBUS_ADU_PROTO_ID			0x0000
 
 struct modbus_serial_config {
-	/* UART device name */
-	const char *dev_name;
 	/* UART device */
 	const struct device *dev;
 	/* RTU timeout (maximum inter-frame delay) */

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -516,10 +516,8 @@ int modbus_serial_init(struct modbus_context *ctx,
 		return -ENOTSUP;
 	}
 
-	cfg->dev = device_get_binding(cfg->dev_name);
-	if (cfg->dev == NULL) {
-		LOG_ERR("Failed to get UART device %s",
-			cfg->dev_name);
+	if (!device_is_ready(cfg->dev)) {
+		LOG_ERR("Bus device %s is not ready", cfg->dev->name);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Move to using DEVICE_DT_GET so we can phase out DT_LABEL.

Signed-off-by: Kumar Gala <galak@kernel.org>