### PR TITLE
docs: Rework of getting started guide

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -645,6 +645,9 @@ Build the Blinky Sample
    does not meet Blinky's :ref:`blinky-sample-requirements`, then
    :ref:`hello_world` is a good alternative.
 
+   If you are unsure what name west uses for your board, ``west boards``
+   can be used to obtain a list of all boards Zephyr supports.
+
 Build the :ref:`blinky-sample` with :ref:`west build <west-building>`, changing
 ``<your-board-name>`` appropriately for your board:
 
@@ -655,24 +658,26 @@ Build the :ref:`blinky-sample` with :ref:`west build <west-building>`, changing
       .. code-block:: bash
 
          cd ~/zephyrproject/zephyr
-         west build -p auto -b <your-board-name> samples/basic/blinky
+         west build -p always -b <your-board-name> samples/basic/blinky
 
    .. group-tab:: macOS
 
       .. code-block:: bash
 
          cd ~/zephyrproject/zephyr
-         west build -p auto -b <your-board-name> samples/basic/blinky
+         west build -p always -b <your-board-name> samples/basic/blinky
 
    .. group-tab:: Windows
 
       .. code-block:: bat
 
          cd %HOMEPATH%\zephyrproject\zephyr
-         west build -p auto -b <your-board-name> samples\basic\blinky
+         west build -p always -b <your-board-name> samples\basic\blinky
 
-The ``-p auto`` option automatically cleans byproducts from a previous build
-if necessary, which is useful if you try building another sample.
+The ``-p always`` option forces a pristine build, and is recommended for new
+users. Users may also use the ``-p auto`` option, which will use
+heuristics to determine if a pristine build is required, such as when building
+another sample.
 
 .. rst-class:: numbered-step
 

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -184,11 +184,15 @@ Next, clone Zephyr and its :ref:`modules <modules>` into a new :ref:`west
 <west>` workspace named :file:`zephyrproject`. You'll also install Zephyr's
 additional Python dependencies.
 
-Python is used by the ``west`` meta-tool as well as by many scripts invoked by
-the build system. It is easy to run into package incompatibilities when
-installing dependencies at a system or user level. This situation can happen,
-for example, if working on multiple Zephyr versions at the same time. For this
-reason it is suggested to use `Python virtual environments`_.
+
+.. note::
+
+    It is easy to run into Python package incompatibilities when installing
+    dependencies at a system or user level. This situation can happen,
+    for example, if working on multiple Zephyr versions or other projects
+    using Python on the same machine.
+
+    For this reason it is suggested to use `Python virtual environments`_.
 
 .. _Python virtual environments: https://docs.python.org/3/library/venv.html
 
@@ -197,40 +201,6 @@ reason it is suggested to use `Python virtual environments`_.
    .. group-tab:: Ubuntu
 
       .. tabs::
-
-         .. group-tab:: Install globally
-
-            #. Install west, and make sure :file:`~/.local/bin` is on your
-               :envvar:`PATH` :ref:`environment variable <env_vars>`:
-
-               .. code-block:: bash
-
-                  pip3 install --user -U west
-                  echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
-                  source ~/.bashrc
-
-            #. Get the Zephyr source code:
-
-               .. code-block:: bash
-
-                  west init ~/zephyrproject
-                  cd ~/zephyrproject
-                  west update
-
-            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
-               automatically load boilerplate code required for building Zephyr
-               applications.
-
-               .. code-block:: console
-
-                  west zephyr-export
-
-            #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
-               dependencies. Install them with ``pip3``.
-
-               .. code-block:: bash
-
-                  pip3 install --user -r ~/zephyrproject/zephyr/scripts/requirements.txt
 
          .. group-tab:: Install within virtual environment
 
@@ -290,17 +260,16 @@ reason it is suggested to use `Python virtual environments`_.
 
                   pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
 
-   .. group-tab:: macOS
-
-      .. tabs::
-
          .. group-tab:: Install globally
 
-            #. Install west:
+            #. Install west, and make sure :file:`~/.local/bin` is on your
+               :envvar:`PATH` :ref:`environment variable <env_vars>`:
 
                .. code-block:: bash
 
-                  pip3 install -U west
+                  pip3 install --user -U west
+                  echo 'export PATH=~/.local/bin:"$PATH"' >> ~/.bashrc
+                  source ~/.bashrc
 
             #. Get the Zephyr source code:
 
@@ -323,7 +292,11 @@ reason it is suggested to use `Python virtual environments`_.
 
                .. code-block:: bash
 
-                  pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt
+                  pip3 install --user -r ~/zephyrproject/zephyr/scripts/requirements.txt
+
+   .. group-tab:: macOS
+
+      .. tabs::
 
          .. group-tab:: Install within virtual environment
 
@@ -377,41 +350,40 @@ reason it is suggested to use `Python virtual environments`_.
 
                   pip install -r ~/zephyrproject/zephyr/scripts/requirements.txt
 
-   .. group-tab:: Windows
-
-      .. tabs::
-
          .. group-tab:: Install globally
 
             #. Install west:
 
-               .. code-block:: bat
+               .. code-block:: bash
 
                   pip3 install -U west
 
             #. Get the Zephyr source code:
 
-               .. code-block:: bat
+               .. code-block:: bash
 
-                  cd %HOMEPATH%
-                  west init zephyrproject
-                  cd zephyrproject
+                  west init ~/zephyrproject
+                  cd ~/zephyrproject
                   west update
 
             #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
                automatically load boilerplate code required for building Zephyr
                applications.
 
-               .. code-block:: bat
+               .. code-block:: console
 
                   west zephyr-export
 
-            #. Zephyr's ``scripts\requirements.txt`` file declares additional Python
+            #. Zephyr's ``scripts/requirements.txt`` file declares additional Python
                dependencies. Install them with ``pip3``.
 
-               .. code-block:: bat
+               .. code-block:: bash
 
-                  pip3 install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
+                  pip3 install -r ~/zephyrproject/zephyr/scripts/requirements.txt
+
+   .. group-tab:: Windows
+
+      .. tabs::
 
          .. group-tab:: Install within virtual environment
 
@@ -420,7 +392,7 @@ reason it is suggested to use `Python virtual environments`_.
                .. code-block:: bat
 
                   cd %HOMEPATH%
-                  python3 -m venv zephyrproject\.venv
+                  python -m venv zephyrproject\.venv
 
             #. Activate the virtual environment:
 
@@ -469,7 +441,40 @@ reason it is suggested to use `Python virtual environments`_.
 
                   pip install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
 
+         .. group-tab:: Install globally
+
+            #. Install west:
+
+               .. code-block:: bat
+
+                  pip3 install -U west
+
+            #. Get the Zephyr source code:
+
+               .. code-block:: bat
+
+                  cd %HOMEPATH%
+                  west init zephyrproject
+                  cd zephyrproject
+                  west update
+
+            #. Export a :ref:`Zephyr CMake package <cmake_pkg>`. This allows CMake to
+               automatically load boilerplate code required for building Zephyr
+               applications.
+
+               .. code-block:: bat
+
+                  west zephyr-export
+
+            #. Zephyr's ``scripts\requirements.txt`` file declares additional Python
+               dependencies. Install them with ``pip3``.
+
+               .. code-block:: bat
+
+                  pip3 install -r %HOMEPATH%\zephyrproject\zephyr\scripts\requirements.txt
+
 .. rst-class:: numbered-step
+
 
 Install Zephyr SDK
 ******************


### PR DESCRIPTION
This PR is an attempt to clarify some issues I have encountered while helping developers new to Zephyr get started with it. Since this a relatively large change, I've listed out each change I've made to the getting started guide below, along with my reasoning. Changes are divided up into commits based on which section of the guide they affect.

Feedback on these proposed changes is welcome. My goal here is to make it possible for a new Zephyr user to read the getting started guide, while following the recommended path for each setup step, and end up with a working Zephyr environment every time without needing to ask for assistance.

### Changed the ordering of the tabs in the "Get Zephyr and install Python dependencies" section to direct the user to install Zephyr dependencies in a virtual environment
- Every developer I have helped through the getting started guide has encountered some type of issue with the `pip3 install -U west` command (while running on Windows). Additionally, the PATH modification step given for Ubuntu is specific to bash, and may not work with an alternative shell.
- Virtual environments are recommended by the getting started guide itself:
   > Python is used by the west meta-tool as well as by many scripts invoked by the build system. It is easy to run into package incompatibilities when installing dependencies at a system or user level. This situation can happen, for example, if working on multiple Zephyr versions at the same time. For this reason it is suggested to use [Python virtual environments](https://docs.python.org/3/library/venv.html).
- Virtual environments will isolate the Zephyr python dependencies by design, making it less likely for a user to introduce issues with their Zephyr environment when working on another python project
### Changed the python virtual environment initialization command for Windows
- On Windows, the chocolatey installer does not create a `python3` alias, so `python -m venv zephyrproject\.venv` is the correct command, not `python3 -m venv zephyrproject\.venv`
### Added a note about the `west boards` command to the "Build the Blinky Sample" section
- Some developers I have worked with have had issues determining what identifier west uses for their board when getting started. For example, they are aware that their K64 evaluation board is supported, but not that the correct board name is `frdm_k64f`.
- While `west build` will produce a useful error message when an invalid board name is used, I feel that developers may have an easier time getting started if they don't have to guess what name to use for their board, and can use the west command to find it.
### Changed the `-p auto` directive to  `-p always` in the "Build the Blinky Sample" section
- If a user makes an error on their first invocation of `west build`, the `-p auto` option isn't always *perfect* at detecting when a clean build is required. I made this change to help users when troubleshooting, so they can force a clean build and remove any invalid CMake configuration their last build attempt saved.
