### PR TITLE
scripts: requirements: extras: add clang-format

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -9,6 +9,9 @@ gitlint
 # helper for developers
 junit2html
 
+# helper for developers - code formatter
+clang-format>=1.12x
+
 # Script used to build firmware images for NXP LPC MCUs.
 lpc_checksum
 


### PR DESCRIPTION
Add clang-format to the requirements-extras.txt and require a version compatible with the configuration options present in the .clang-format file.

This is an alternative to #46649.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>