### PR TITLE
clang-format: restore column limit value of 100

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,6 +20,7 @@ AttributeMacros:
   - __syscall
   - __subsystem
 BreakBeforeBraces: Linux
+ColumnLimit: 100
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
 ForEachMacros:


### PR DESCRIPTION
Restore line length limit of 100 characters as introduced in 6432a56ae9595f6b771930b5d1d3e8bc6820ec66.

Fixes: bac0dbe8f26a4c9a1e4248c3d41c926d4378c91d

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>