### PR TITLE
arch: arm64: program TG[1] in mmu init

### DIFF
--- a/arch/arm64/core/mmu.c
+++ b/arch/arm64/core/mmu.c
@@ -777,11 +777,14 @@ static uint64_t get_tcr(int el)
 		tcr = (tcr_ps_bits << TCR_EL3_PS_SHIFT);
 
 	tcr |= TCR_T0SZ(va_bits);
+
 	/*
 	 * Translation table walk is cacheable, inner/outer WBWA and
-	 * inner shareable
+	 * inner shareable.  Due to Cortex-A57 erratum #822227 we must
+	 * set TG1[1] = 4KB.
 	 */
-	tcr |= TCR_TG0_4K | TCR_SHARED_INNER | TCR_ORGN_WBWA | TCR_IRGN_WBWA;
+	tcr |= TCR_TG1_4K | TCR_TG0_4K | TCR_SHARED_INNER |
+	       TCR_ORGN_WBWA | TCR_IRGN_WBWA;
 
 	return tcr;
 }

--- a/include/zephyr/arch/arm64/arm_mmu.h
+++ b/include/zephyr/arch/arm64/arm_mmu.h
@@ -138,6 +138,9 @@
 #define TCR_TG0_64K		(1ULL << 14)
 #define TCR_TG0_16K		(2ULL << 14)
 #define TCR_EPD1_DISABLE	(1ULL << 23)
+#define TCR_TG1_16K		(1ULL << 30)
+#define TCR_TG1_4K		(2ULL << 30)
+#define TCR_TG1_64K		(3ULL << 30)
 
 #define TCR_PS_BITS_4GB		0x0ULL
 #define TCR_PS_BITS_64GB	0x1ULL


### PR DESCRIPTION
In performing a double check of Zephyr arm64 MMU config
against edk2, a different in the programming of the
Translation Control Register (TCR) was found.  TCR.TG[1]
should be set to address Cortex-A57 erratum 822227:

"Using unsupported 16K translation granules might cause
Cortex-A57 to incorrectly trigger a domain fault"

Signed-off-by: Eugene Cohen <quic_egmc@quicinc.com>