### PR TITLE
arch: arm64: add WAIT_AT_RESET_VECTOR config

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -91,6 +91,13 @@ config PRIVILEGED_STACK_SIZE
 config KOBJECT_TEXT_AREA
 	default 512 if TEST
 
+config WAIT_AT_RESET_VECTOR
+	bool "Wait at reset vector"
+	default n
+	help
+	  Spin at reset vector waiting for debugger to attach and resume
+	  execution
+
 if CPU_CORTEX_A
 
 config ARMV8_A_NS

--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -102,6 +102,13 @@ SECTION_SUBSEC_FUNC(TEXT,_reset_section,__reset)
 
 GTEXT(__start)
 SECTION_SUBSEC_FUNC(TEXT,_reset_section,__start)
+
+#ifdef CONFIG_WAIT_AT_RESET_VECTOR
+resetwait:
+	wfe
+	b       resetwait
+#endif
+
 	/* Mask all exceptions */
 	msr	DAIFSet, #0xf
 


### PR DESCRIPTION
On platforms where reset vector catch is not possible
it is useful to have a compile-time option to spin
at the reset vector allowing a debugger to be attached
and then to manually resume execution.

Define a config option for arm64 to spin at the
reset vectdor so a debugger can be attached.

Signed-off-by: Eugene Cohen <quic_egmc@quicinc.com>