### PR TITLE
arch: arm64: enable single thread support config

### DIFF
--- a/arch/arm64/core/Kconfig
+++ b/arch/arm64/core/Kconfig
@@ -9,6 +9,7 @@ config CPU_CORTEX_A
 	select HAS_FLASH_LOAD_OFFSET
 	select SCHED_IPI_SUPPORTED if SMP
 	select CPU_HAS_FPU
+	select ARCH_HAS_SINGLE_THREAD_SUPPORT
 	imply FPU
 	imply FPU_SHARING
 	help


### PR DESCRIPTION
Enable single-threaded support for the arm64 archtecture.

This mode of execution is supported on an soc under
development and is validated regularly.

Signed-off-by: Eugene Cohen <quic_egmc@quicinc.com>