### PR TITLE
ztest: Add zassume* API 

### DIFF
--- a/doc/develop/test/ztest.rst
+++ b/doc/develop/test/ztest.rst
@@ -472,6 +472,26 @@ Example output for a failed macro from
 
 .. doxygengroup:: ztest_assert
 
+Assumptions
+===========
+
+These macros will instantly skip the test or suite if the related assumption fails.
+When an assumption fails, it will print the current file, line, and function,
+alongside a reason for the failure and an optional message. If the config
+option:`CONFIG_ZTEST_ASSERT_VERBOSE` is 0, the assumptions will only print the
+file and line numbers, reducing the binary size of the test.
+
+Example output for a failed macro from
+``zassume_equal(buf->ref, 2, "Invalid refcount")``:
+
+.. code-block::none
+
+    START - test_get_single_buffer
+        Assumption failed at main.c:62: test_get_single_buffer: Invalid refcount (buf->ref not equal to 2)
+     SKIP - test_get_single_buffer in 0.0 seconds
+
+.. doxygengroup:: ztest_assume
+
 Mocking
 =======
 

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -26,6 +26,7 @@ extern "C" {
 
 const char *ztest_relative_filename(const char *file);
 void ztest_test_fail(void);
+void ztest_test_skip(void);
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 0
 
 static inline bool z_zassert_(bool cond, const char *file, int line)
@@ -40,6 +41,19 @@ static inline bool z_zassert_(bool cond, const char *file, int line)
 }
 
 #define z_zassert(cond, default_msg, file, line, func, msg, ...) z_zassert_(cond, file, line)
+
+static inline bool z_zassume_(bool cond, const char *file, int line)
+{
+	if (cond == false) {
+		PRINT("\n    Assumption failed at %s:%d\n", ztest_relative_filename(file), line);
+		ztest_test_skip();
+		return false;
+	}
+
+	return true;
+}
+
+#define z_zassume(cond, default_msg, file, line, func, msg, ...) z_zassume_(cond, file, line)
 
 #else /* CONFIG_ZTEST_ASSERT_VERBOSE != 0 */
 
@@ -61,6 +75,30 @@ static inline bool z_zassert(bool cond, const char *default_msg, const char *fil
 #if CONFIG_ZTEST_ASSERT_VERBOSE == 2
 	else {
 		PRINT("\n   Assertion succeeded at %s:%d (%s)\n", ztest_relative_filename(file),
+		      line, func);
+	}
+#endif
+	return true;
+}
+
+static inline bool z_zassume(bool cond, const char *default_msg, const char *file, int line,
+			     const char *func, const char *msg, ...)
+{
+	if (cond == false) {
+		va_list vargs;
+
+		va_start(vargs, msg);
+		PRINT("\n    Assumption failed at %s:%d: %s: %s\n", ztest_relative_filename(file),
+		      line, func, default_msg);
+		vprintk(msg, vargs);
+		printk("\n");
+		va_end(vargs);
+		ztest_test_skip();
+		return false;
+	}
+#if CONFIG_ZTEST_ASSERT_VERBOSE == 2
+	else {
+		PRINT("\n   Assumption succeeded at %s:%d (%s)\n", ztest_relative_filename(file),
 		      line, func);
 	}
 #endif
@@ -103,6 +141,16 @@ static inline bool z_zassert(bool cond, const char *default_msg, const char *fil
 		}                                                                                  \
 	} while (0)
 
+#define zassume(cond, default_msg, msg, ...)                                                       \
+	do {                                                                                       \
+		bool _ret = z_zassume(cond, msg ? ("(" default_msg ")") : (default_msg), __FILE__, \
+				      __LINE__, __func__, msg ? msg : "", ##__VA_ARGS__);          \
+		if (!_ret) {                                                                       \
+			/* If kernel but without multithreading return. */                         \
+			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \
+				    ())                                                            \
+		}                                                                                  \
+	} while (0)
 /**
  * @brief Assert that this function call won't be reached
  * @param msg Optional message to print if the assertion fails
@@ -232,6 +280,167 @@ static inline bool z_zassert(bool cond, const char *default_msg, const char *fil
  */
 #define zassert_mem_equal__(buf, exp, size, msg, ...)                                              \
 	zassert(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, msg, ##__VA_ARGS__)
+
+/**
+ * @}
+ */
+
+/**
+ * @defgroup ztest_assume Ztest assumption macros
+ * @ingroup ztest
+ *
+ * This module provides assumptions when using Ztest.
+ *
+ * @{
+ */
+
+/**
+ * @brief Assume that @a cond is true
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param cond Condition to check
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_true(cond, msg, ...) zassume(cond, #cond " is false", msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a cond is false
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param cond Condition to check
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_false(cond, msg, ...) zassume(!(cond), #cond " is true", msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a cond is 0 (success)
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param cond Condition to check
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_ok(cond, msg, ...) zassume(!(cond), #cond " is non-zero", msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a ptr is NULL
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param ptr Pointer to compare
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_is_null(ptr, msg, ...)                                                             \
+	zassume((ptr) == NULL, #ptr " is not NULL", msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a ptr is not NULL
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param ptr Pointer to compare
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_not_null(ptr, msg, ...) zassume((ptr) != NULL, #ptr " is NULL", msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a a equals @a b
+ *
+ * @a a and @a b won't be converted and will be compared directly. If the
+ * assumption fails, the test will be marked as "skipped".
+ *
+ * @param a Value to compare
+ * @param b Value to compare
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_equal(a, b, msg, ...)                                                              \
+	zassume((a) == (b), #a " not equal to " #b, msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a a does not equal @a b
+ *
+ * @a a and @a b won't be converted and will be compared directly. If the
+ * assumption fails, the test will be marked as "skipped".
+ *
+ * @param a Value to compare
+ * @param b Value to compare
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_not_equal(a, b, msg, ...)                                                          \
+	zassume((a) != (b), #a " equal to " #b, msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a a equals @a b
+ *
+ * @a a and @a b will be converted to `void *` before comparing. If the
+ * assumption fails, the test will be marked as "skipped".
+ *
+ * @param a Value to compare
+ * @param b Value to compare
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_equal_ptr(a, b, msg, ...)                                                          \
+	zassume((void *)(a) == (void *)(b), #a " not equal to " #b, msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a a is within @a b with delta @a d
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param a Value to compare
+ * @param b Value to compare
+ * @param d Delta
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_within(a, b, d, msg, ...)                                                          \
+	zassume(((a) >= ((b) - (d))) && ((a) <= ((b) + (d))), #a " not within " #b " +/- " #d,     \
+		msg, ##__VA_ARGS__)
+
+/**
+ * @brief Assume that @a a is greater than or equal to @a l and less
+ *        than or equal to @a u
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @param a Value to compare
+ * @param l Lower limit
+ * @param u Upper limit
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_between_inclusive(a, l, u, msg, ...)                                               \
+	zassume(((a) >= (l)) && ((a) <= (u)), #a " not between " #l " and " #u " inclusive", msg,  \
+		##__VA_ARGS__)
+
+/**
+ * @brief Assume that 2 memory buffers have the same contents
+ *
+ * This macro calls the final memory comparison assumption macro.
+ * Using double expansion allows providing some arguments by macros that
+ * would expand to more than one values (ANSI-C99 defines that all the macro
+ * arguments have to be expanded before macro call).
+ *
+ * @param ... Arguments, see @ref zassume_mem_equal__
+ *            for real arguments accepted.
+ */
+#define zassume_mem_equal(...) zassume_mem_equal__(__VA_ARGS__)
+
+/**
+ * @brief Internal assume that 2 memory buffers have the same contents
+ *
+ * If the assumption fails, the test will be marked as "skipped".
+ *
+ * @note This is internal macro, to be used as a second expansion.
+ *       See @ref zassume_mem_equal.
+ *
+ * @param buf Buffer to compare
+ * @param exp Buffer with expected contents
+ * @param size Size of buffers
+ * @param msg Optional message to print if the assumption fails
+ */
+#define zassume_mem_equal__(buf, exp, size, msg, ...)                                              \
+	zassume(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, msg, ##__VA_ARGS__)
 
 /**
  * @}

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -4,27 +4,29 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
 #include <zephyr/app_memory/app_memdomain.h>
+
+#include <ztest.h>
 #ifdef CONFIG_USERSPACE
 #include <zephyr/sys/libc-hooks.h>
 #endif
-#include <zephyr/sys/reboot.h>
 #include <zephyr/logging/log_ctrl.h>
+#include <zephyr/sys/reboot.h>
 
 #ifdef KERNEL
 static struct k_thread ztest_thread;
 #endif
 
 #ifdef CONFIG_ZTEST_SHUFFLE
-#include <zephyr/random/rand32.h>
 #include <stdlib.h>
 #include <time.h>
+
+#include <zephyr/random/rand32.h>
 #define NUM_ITER_PER_SUITE CONFIG_ZTEST_SHUFFLE_SUITE_REPEAT_COUNT
-#define NUM_ITER_PER_TEST CONFIG_ZTEST_SHUFFLE_TEST_REPEAT_COUNT
+#define NUM_ITER_PER_TEST  CONFIG_ZTEST_SHUFFLE_TEST_REPEAT_COUNT
 #else
 #define NUM_ITER_PER_SUITE 1
-#define NUM_ITER_PER_TEST 1
+#define NUM_ITER_PER_TEST  1
 #endif
 
 /* ZTEST_DMEM and ZTEST_BMEM are used for the application shared memory test  */
@@ -176,16 +178,10 @@ void z_impl_z_test_1cpu_stop(void)
 }
 
 #ifdef CONFIG_USERSPACE
-void z_vrfy_z_test_1cpu_start(void)
-{
-	z_impl_z_test_1cpu_start();
-}
+void z_vrfy_z_test_1cpu_start(void) { z_impl_z_test_1cpu_start(); }
 #include <syscalls/z_test_1cpu_start_mrsh.c>
 
-void z_vrfy_z_test_1cpu_stop(void)
-{
-	z_impl_z_test_1cpu_stop();
-}
+void z_vrfy_z_test_1cpu_stop(void) { z_impl_z_test_1cpu_stop(); }
 #include <syscalls/z_test_1cpu_stop_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 #endif
@@ -219,8 +215,8 @@ static void run_test_functions(struct ztest_suite_node *suite, struct ztest_unit
  */
 #include <setjmp.h> /* parasoft-suppress MISRAC2012-RULE_21_4-a MISRAC2012-RULE_21_4-b*/
 #include <signal.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define FAIL_FAST 0
 
@@ -228,15 +224,9 @@ static jmp_buf test_fail;
 static jmp_buf test_pass;
 static jmp_buf stack_fail;
 
-void ztest_test_fail(void)
-{
-	raise(SIGABRT);
-}
+void ztest_test_fail(void) { raise(SIGABRT); }
 
-void ztest_test_pass(void)
-{
-	longjmp(test_pass, 1);
-}
+void ztest_test_pass(void) { longjmp(test_pass, 1); }
 
 /**
  * @brief Get a friendly name string for a given test phrase.
@@ -329,12 +319,7 @@ out:
 
 K_THREAD_STACK_DEFINE(ztest_thread_stack, CONFIG_ZTEST_STACK_SIZE + CONFIG_TEST_EXTRA_STACK_SIZE);
 
-enum ztest_result {
-	ZTEST_RESULT_PENDING,
-	ZTEST_RESULT_PASS,
-	ZTEST_RESULT_FAIL,
-	ZTEST_RESULT_SKIP
-};
+enum ztest_result { ZTEST_RESULT_PENDING, ZTEST_RESULT_PASS, ZTEST_RESULT_FAIL, ZTEST_RESULT_SKIP };
 static ZTEST_BMEM enum ztest_result test_result;
 
 static void test_finalize(void)
@@ -375,10 +360,7 @@ void ztest_simple_1cpu_after(void *data)
 	z_test_1cpu_stop();
 }
 
-static void init_testing(void)
-{
-	k_object_access_all_grant(&ztest_thread);
-}
+static void init_testing(void) { k_object_access_all_grant(&ztest_thread); }
 
 static void test_cb(void *a, void *b, void *c)
 {
@@ -657,15 +639,9 @@ void ztest_verify_all_test_suites_ran(void)
 	}
 }
 
-void ztest_run_all(const void *state)
-{
-	ztest_api.run_all(state);
-}
+void ztest_run_all(const void *state) { ztest_api.run_all(state); }
 
-void __weak test_main(void)
-{
-	ztest_run_all(NULL);
-}
+void __weak test_main(void) { ztest_run_all(NULL); }
 
 #ifndef KERNEL
 int main(void)

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -4,9 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
 #include <zephyr/irq_offload.h>
 #include <zephyr/syscall_handler.h>
+
+#include <ztest.h>
 #include <ztest_error_hook.h>
 
 #define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
@@ -360,3 +361,60 @@ static void *error_hook_tests_setup(void)
 	return NULL;
 }
 ZTEST_SUITE(error_hook_tests, NULL, error_hook_tests_setup, NULL, NULL, NULL);
+
+static void *fail_assume_in_setup_setup(void)
+{
+	/* Fail the assume, will skip all the tests */
+	zassume_true(false, NULL);
+	return NULL;
+}
+
+ZTEST_SUITE(fail_assume_in_setup, NULL, fail_assume_in_setup_setup, NULL, NULL, NULL);
+
+ZTEST(fail_assume_in_setup, test_to_skip0)
+{
+	/* This test should never be run */
+	ztest_test_fail();
+}
+
+ZTEST(fail_assume_in_setup, test_to_skip1)
+{
+	/* This test should never be run */
+	ztest_test_fail();
+}
+
+static void fail_assume_in_before_before(void *unused)
+{
+	ARG_UNUSED(unused);
+	zassume_true(false, NULL);
+}
+
+ZTEST_SUITE(fail_assume_in_before, NULL, NULL, fail_assume_in_before_before, NULL, NULL);
+
+ZTEST(fail_assume_in_before, test_to_skip0)
+{
+	/* This test should never be run */
+	ztest_test_fail();
+}
+
+ZTEST(fail_assume_in_before, test_to_skip1)
+{
+	/* This test should never be run */
+	ztest_test_fail();
+}
+
+ZTEST_SUITE(fail_assume_in_test, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST(fail_assume_in_test, test_to_skip)
+{
+	zassume_true(false, NULL);
+	ztest_test_fail();
+}
+
+void test_main(void)
+{
+	ztest_run_test_suites(NULL);
+	/* Can't run ztest_verify_all_test_suites_ran() since some tests are
+	 * skipped by design.
+	 */
+}


### PR DESCRIPTION
Add a `zassume*` API to ztest which parallels `zassert*` API. The main difference is that a failed condition of the assume API will cause the test to skip instead of fail. This drastically reduces the noise of failed tests when a core feature becomes broken.

Issue #42472