### PR TITLE
net: socket: Use exponential backoff in case of polling errors

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -657,11 +657,13 @@ static inline int z_vrfy_zsock_accept(int sock, struct sockaddr *addr,
 #include <syscalls/zsock_accept_mrsh.c>
 #endif /* CONFIG_USERSPACE */
 
-#define WAIT_BUFS K_MSEC(100)
+#define WAIT_BUFS_INITIAL_MS 10
+#define WAIT_BUFS_MAX_MS 100
 #define MAX_WAIT_BUFS K_SECONDS(10)
 
 static int send_check_and_wait(struct net_context *ctx, int status,
-			       uint64_t buf_timeout, k_timeout_t timeout)
+			       uint64_t buf_timeout, k_timeout_t timeout,
+			       uint32_t *retry_timeout)
 {
 	int64_t remaining;
 
@@ -693,7 +695,7 @@ static int send_check_and_wait(struct net_context *ctx, int status,
 
 	if (status == -ENOBUFS) {
 		/* We can monitor net_pkt/net_buf avaialbility, so just wait. */
-		k_sleep(WAIT_BUFS);
+		k_sleep(K_MSEC(*retry_timeout));
 	}
 
 	if (status == -EAGAIN) {
@@ -706,11 +708,15 @@ static int send_check_and_wait(struct net_context *ctx, int status,
 					  K_POLL_MODE_NOTIFY_ONLY,
 					  net_tcp_tx_sem_get(ctx));
 
-			k_poll(&event, 1, WAIT_BUFS);
+			k_poll(&event, 1, K_MSEC(*retry_timeout));
 		} else {
-			k_sleep(WAIT_BUFS);
+			k_sleep(K_MSEC(*retry_timeout));
 		}
 	}
+	/* Exponentially increase the retry timeout
+	 * Cap the value to WAIT_BUFS_MAX_MS
+	 */
+	*retry_timeout = MIN(WAIT_BUFS_MAX_MS, *retry_timeout << 1);
 
 	return 0;
 
@@ -724,6 +730,7 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 			 const struct sockaddr *dest_addr, socklen_t addrlen)
 {
 	k_timeout_t timeout = K_FOREVER;
+	uint32_t retry_timeout = WAIT_BUFS_INITIAL_MS;
 	uint64_t buf_timeout = 0;
 	int status;
 
@@ -756,7 +763,7 @@ ssize_t zsock_sendto_ctx(struct net_context *ctx, const void *buf, size_t len,
 
 		if (status < 0) {
 			status = send_check_and_wait(ctx, status, buf_timeout,
-						     timeout);
+						     timeout, &retry_timeout);
 			if (status < 0) {
 				return status;
 			}
@@ -813,6 +820,7 @@ ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 			  int flags)
 {
 	k_timeout_t timeout = K_FOREVER;
+	uint32_t retry_timeout = WAIT_BUFS_INITIAL_MS;
 	uint64_t buf_timeout = 0;
 	int status;
 
@@ -829,7 +837,7 @@ ssize_t zsock_sendmsg_ctx(struct net_context *ctx, const struct msghdr *msg,
 			if (status < 0) {
 				status = send_check_and_wait(ctx, status,
 							     buf_timeout,
-							     timeout);
+							     timeout, &retry_timeout);
 				if (status < 0) {
 					return status;
 				}


### PR DESCRIPTION
Some errors can occur in the sending process that have to be handled
in a polling fasion instead of blocking using semaphores. In this case
apply an exponentially growing backoff time. This will allow for fast
reactions in most situations and prevents high system loads in case
resolving the situation takes a little longer.

Signed-off-by: Sjors Hettinga <s.a.hettinga@gmail.com>