### PR TITLE
lib/cbprintf: Disable tagged arguments with picolibc

### DIFF
--- a/lib/os/Kconfig.cbprintf
+++ b/lib/os/Kconfig.cbprintf
@@ -144,6 +144,7 @@ config CBPRINTF_PACKAGE_HEADER_STORE_CREATION_FLAGS
 
 config CBPRINTF_PACKAGE_SUPPORT_TAGGED_ARGUMENTS
 	bool
+	depends on !PICOLIBC
 	select CBPRINTF_PACKAGE_HEADER_STORE_CREATION_FLAGS
 	help
 	  Hidden option to support tagged arguments in cbvprint_package().

--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -31,6 +31,7 @@ if LOG_MIPI_SYST_ENABLE
 
 config LOG_MIPI_SYST_USE_CATALOG
 	bool "Use MIPI Sys-T Catalog for logging"
+	depends on !PICOLIBC
 	select LOG_FMT_SECTION
 	select LOG_USE_TAGGED_ARGUMENTS
 	help

--- a/subsys/logging/Kconfig.misc
+++ b/subsys/logging/Kconfig.misc
@@ -57,6 +57,7 @@ config LOG_FMT_SECTION
 
 config LOG_USE_TAGGED_ARGUMENTS
 	bool "Using tagged arguments for packaging"
+	depends on !PICOLIBC
 	select CBPRINTF_PACKAGE_SUPPORT_TAGGED_ARGUMENTS
 	select LOG_ALWAYS_RUNTIME
 	help


### PR DESCRIPTION
Picolibc doesn't have the non-standard printf support required for tagged
arguments in cbprintf. Disable this and use the format string parsing code
instead.

Signed-off-by: Keith Packard <keithp@keithp.com>