### PR TITLE
west: Update liblc3

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2354,6 +2354,7 @@ West:
   status: maintained
   maintainers:
     - Casper-Bonde-Bose
+    - MariuszSkamra
   collaborators:
     - thalley
     - asbjornsabo

--- a/modules/liblc3codec/CMakeLists.txt
+++ b/modules/liblc3codec/CMakeLists.txt
@@ -1,7 +1,7 @@
 if(CONFIG_LIBLC3CODEC)
 
 zephyr_library_named(liblc3codec)
-zephyr_library_compile_options(-O3 -ffast-math -Wno-array-bounds)
+zephyr_library_compile_options(-O3 -std=c11 -ffast-math -Wno-array-bounds)
 
 zephyr_include_directories(${ZEPHYR_LIBLC3CODEC_MODULE_DIR}/include)
 zephyr_include_directories(${ZEPHYR_LIBLC3CODEC_MODULE_DIR}/src)

--- a/west.yml
+++ b/west.yml
@@ -149,8 +149,8 @@ manifest:
       path: modules/hal/libmetal
       groups:
         - hal
-    - name: liblc3codec
-      revision: 3951cf1b71ff3be086c9b9b595e473e12301337c
+    - name: liblc3
+      revision: 54c047249bc6b8089e85c1433b5aa6001bbc1ba9
       path: modules/lib/liblc3codec
     - name: littlefs
       path: modules/fs/littlefs


### PR DESCRIPTION
Start using new liblc3 fork.

Fixes: https://github.com/zephyrproject-rtos/liblc3codec/issues/10
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>