### PR TITLE
Bluetooth: hci: Prevent naming conflict in hci_ecc.c

### DIFF
--- a/subsys/bluetooth/host/hci_ecc.c
+++ b/subsys/bluetooth/host/hci_ecc.c
@@ -347,13 +347,15 @@ void bt_hci_ecc_supported_commands(uint8_t *supported_commands)
 	supported_commands[41] |= BIT(2);
 }
 
-int default_CSPRNG(uint8_t *dst, unsigned int len)
+static int ecc_csprng(uint8_t *dst, unsigned int len)
 {
 	return !bt_rand(dst, len);
 }
 
 void bt_hci_ecc_init(void)
 {
+	uECC_set_rgn(&ecc_csprng);
+
 	k_thread_create(&ecc_thread_data, ecc_thread_stack,
 			K_KERNEL_STACK_SIZEOF(ecc_thread_stack), ecc_thread,
 			NULL, NULL, NULL, K_PRIO_PREEMPT(10), 0, K_NO_WAIT);

--- a/tests/crypto/tinycrypt/src/ecc_dh.c
+++ b/tests/crypto/tinycrypt/src/ecc_dh.c
@@ -453,7 +453,7 @@ void test_ecc_dh(void)
 	TC_START("Performing ECC-DH tests:");
 
 	/* Setup of the Cryptographically Secure PRNG. */
-	uECC_set_rng(&default_CSPRNG);
+	uECC_set_rng(&early_prng);
 
 	bool verbose = true;
 

--- a/tests/crypto/tinycrypt/src/ecc_dsa.c
+++ b/tests/crypto/tinycrypt/src/ecc_dsa.c
@@ -611,7 +611,7 @@ int montecarlo_signverify(int num_tests, bool verbose)
 	return TC_PASS;
 }
 
-int default_CSPRNG(uint8_t *dest, unsigned int size)
+int early_prng(uint8_t *dest, unsigned int size)
 {
 	/* This is not a CSPRNG, but it's the only thing available in the
 	 * system at this point in time.  */
@@ -634,7 +634,7 @@ void test_ecc_dsa(void)
 
 	TC_START("Performing ECC-DSA tests:");
 	/* Setup of the Cryptographically Secure PRNG. */
-	uECC_set_rng(&default_CSPRNG);
+	uECC_set_rng(&early_prng);
 
 	bool verbose = true;
 


### PR DESCRIPTION
It seems JWT is using the same `default_CSPRNG` name as Bluetooth
in hci_ecc. Rename it, make it static and register it explicitly instead
of relying on global symbols.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>