### PR TITLE
soc: xtensa: add support for specifying the service port

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/doc/index.rst
+++ b/boards/xtensa/intel_adsp_cavs15/doc/index.rst
@@ -105,7 +105,7 @@ or
 
 .. code-block:: console
 
-   west flash --remote-host 192.168.x.x
+   west flash --remote-host 192.168.x.x --pty
 
 Then you can see the log message immediately:
 
@@ -125,8 +125,8 @@ a path to the same key file used above.
 .. code-block:: console
 
     ./scripts/twister --device-testing -p intel_adsp_cavs15 \
-      --device-serial-pty $ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,cavs15,-l \
-      --west-flash "--remote-host=cavs15,--pty"
+      --device-serial-pty $ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,myboard.local,-l \
+      --west-flash "--remote-host=myboard.local"
 
 And if you install the SOF software stack in rather than the default path,
 you also can specify the location of the rimage tool, signing key and the
@@ -135,8 +135,8 @@ toml config, for example:
 .. code-block:: console
 
     ./scripts/twister --device-testing -p intel_adsp_cavs15 \
-      --device-serial-pty $ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,cavs15,-l \
-      --west-flash "--remote-host=cavs15,--pty\
+      --device-serial-pty $ZEPHYR_BASE/soc/xtensa/intel_adsp/tools/cavstool_client.py,myboard.local,-l \
+      --west-flash "--remote-host=myboard.local,\
       --rimage-tool=/path/to/rimage_tool,\
       --key=/path/to/otc_private_key.pem,\
       --config-dir=/path/to/config_dir"

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -482,8 +482,6 @@ class DeviceHandler(Handler):
                         command.append("--tool-opt=-SelectEmuBySN  %s" % (board_id))
                     elif runner == "stm32cubeprogrammer":
                         command.append("--tool-opt=sn=%s" % (board_id))
-                    elif runner == "intel_adsp":
-                        command.append("--pty")
 
                     # Receive parameters from runner_params field.
                     if hardware.runner_params:

--- a/scripts/requirements-run-test.txt
+++ b/scripts/requirements-run-test.txt
@@ -16,6 +16,3 @@ cbor>=1.0.0
 
 # use for twister
 psutil
-
-# use for adsp runner
-netifaces

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -68,9 +68,9 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
                             help='the default basename of the key store in board.cmake')
         parser.add_argument('--key',
                             help='specify where the signing key is')
-        parser.add_argument('--pty', action="store_true",
-                            help='the log will not output immediately to STDOUT, you \
-                            can redirect it to a serial PTY')
+        parser.add_argument('--pty',
+                            help=''''Capture the output of cavstool.py running on --remote-host \
+                            and stream it remotely to west's standard output.''')
 
     @classmethod
     def do_create(cls, cfg, args):
@@ -122,15 +122,20 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
 
         # Copy the zephyr to target remote ADSP host and run
         self.run_cmd = ([f'{self.cavstool}','-s', f'{self.remote_host}', f'{send_bin_fw}'])
-        self.log_cmd = ([f'{self.cavstool}','-s', f'{self.remote_host}', '-l'])
 
-        self.logger.debug(f"cavstool({self.cavstool}), fw('{send_bin_fw})")
         self.logger.debug(f"rcmd: {self.run_cmd}")
 
         self.check_call(self.run_cmd)
 
-        # If the self.pty assigned, the output the log will
-        # not output to stdout directly. That means we can
-        # make the log output to the PTY.
-        if not self.pty:
+        # If the self.pty is assigned, the log will output to stdout
+        # directly. That means you don't have to execute the command:
+        #
+        #   cavstool_client.py -s {host}:{port} -l
+        #
+        # to get the result later separately.
+        if self.pty is not None:
+            self.log_cmd = ([f'{self.cavstool}','-s', f'{self.pty}', '-l'])
+
+            self.logger.debug(f"rcmd: {self.log_cmd}")
+
             self.check_call(self.log_cmd)

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -71,7 +71,7 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
                             help='the default basename of the key store in board.cmake')
         parser.add_argument('--key',
                             help='specify where the signing key is')
-        parser.add_argument('--pty',
+        parser.add_argument('--pty', nargs='?', const="remote-host", type=str,
                             help=''''Capture the output of cavstool.py running on --remote-host \
                             and stream it remotely to west's standard output.''')
 
@@ -147,7 +147,10 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
         #
         # to get the result later separately.
         if self.pty is not None:
-            self.log_cmd = ([f'{self.cavstool}','-s', f'{self.pty}', '-l'])
+            if self.pty == 'remote-host':
+                self.log_cmd = ([f'{self.cavstool}','-s', f'{self.remote_host}', '-l'])
+            else:
+                self.log_cmd = ([f'{self.cavstool}','-s', f'{self.pty}', '-l'])
 
             self.logger.debug(f"rcmd: {self.log_cmd}")
 

--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -30,7 +30,8 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
                  config_dir,
                  default_key,
                  key,
-                 pty
+                 pty,
+                 tool_opt
                  ):
         super().__init__(cfg)
 
@@ -48,13 +49,15 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
         else:
             self.key = os.path.join(DEFAULT_KEY_DIR, default_key)
 
+        self.tool_opt_args = tool_opt
+
     @classmethod
     def name(cls):
         return 'intel_adsp'
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'})
+        return RunnerCaps(commands={'flash'}, tool_opt=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -73,6 +76,11 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
                             and stream it remotely to west's standard output.''')
 
     @classmethod
+    def tool_opt_help(cls) -> str:
+        return """Additional options for run/request service tool,
+        e.g. '--lock' """
+
+    @classmethod
     def do_create(cls, cfg, args):
         return IntelAdspBinaryRunner(cfg,
                                     remote_host=args.remote_host,
@@ -80,7 +88,8 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
                                     config_dir=args.config_dir,
                                     default_key=args.default_key,
                                     key=args.key,
-                                    pty=args.pty
+                                    pty=args.pty,
+                                    tool_opt=args.tool_opt
                                     )
 
     def do_run(self, command, **kwargs):
@@ -122,6 +131,10 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
 
         # Copy the zephyr to target remote ADSP host and run
         self.run_cmd = ([f'{self.cavstool}','-s', f'{self.remote_host}', f'{send_bin_fw}'])
+
+        # Add the extra tool options to run/request service tool
+        if self.tool_opt_args:
+            self.run_cmd = self.run_cmd + self.tool_opt_args
 
         self.logger.debug(f"rcmd: {self.run_cmd}")
 

--- a/soc/xtensa/intel_adsp/tools/cavstool.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool.py
@@ -13,7 +13,6 @@ import mmap
 import argparse
 import socketserver
 import threading
-import netifaces
 import hashlib
 from urllib.parse import urlparse
 
@@ -831,28 +830,6 @@ def adsp_log(output, server):
         sys.stdout.write(output)
         sys.stdout.flush()
 
-def get_host_ip(net_iface):
-    """
-    Helper tool use to detect host's serving ip address.
-    """
-    interfaces = netifaces.interfaces()
-
-    for i in interfaces:
-        if i != "lo":
-            try:
-                netifaces.ifaddresses(i)
-                ip = netifaces.ifaddresses(i)[netifaces.AF_INET][0]['addr']
-                log.info (f"Found interface {i}, IP address: {ip}")
-            except Exception:
-                log.info(f"Ignore the interface {i} which is not activated.")
-
-            if i == net_iface:
-                log.info(f"Serve on interface {i} only, IP address: {ip}")
-                return ip
-
-    log.info("Serve on all found available interface.")
-    return None
-
 
 ap = argparse.ArgumentParser(description="DSP loader/logger tool")
 ap.add_argument("-q", "--quiet", action="store_true",
@@ -865,8 +842,6 @@ ap.add_argument("-n", "--no-history", action="store_true",
                 help="No current log buffer at start, just new output")
 ap.add_argument("-s", "--server-addr",
                 help="Specify the only IP address the log server will LISTEN on")
-ap.add_argument("-i", "--interface",
-                help="Specify the network interface the service will LISTEN to")
 ap.add_argument("-p", "--log-port",
                 help="Specify the PORT that the log server to active")
 ap.add_argument("-r", "--req-port",
@@ -899,11 +874,6 @@ if args.log_port:
 
 if args.req_port:
     PORT_REQ = int(args.req_port)
-
-iface =  get_host_ip(args.interface)
-
-if args.interface:
-    HOST = iface
 
 log.info(f"Serve on LOG PORT: {PORT_LOG} REQ PORT: {PORT_REQ}")
 

--- a/soc/xtensa/intel_adsp/tools/cavstool_client.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool_client.py
@@ -9,9 +9,11 @@ import argparse
 import socket
 import struct
 import hashlib
+from urllib.parse import urlparse
 
 RET = 0
 HOST = None
+PORT = 0
 PORT_LOG = 9999
 PORT_REQ = PORT_LOG + 1
 BUF_SIZE = 4096
@@ -110,14 +112,14 @@ def main():
         log.info("Monitor process")
 
         try:
-            client = cavstool_client(HOST, PORT_LOG, args)
+            client = cavstool_client(HOST, PORT, args)
             client.send_cmd(CMD_LOG_START)
         except KeyboardInterrupt:
             pass
 
     else:
         log.info("Uploading process")
-        client = cavstool_client(HOST, PORT_REQ, args)
+        client = cavstool_client(HOST, PORT, args)
         client.send_cmd(CMD_DOWNLOAD)
 
 ap = argparse.ArgumentParser(description="DSP loader/logger client tool")
@@ -133,7 +135,21 @@ args = ap.parse_args()
 if args.quiet:
     log.setLevel(logging.WARN)
 
-HOST = args.server_addr
+if args.server_addr:
+    url = urlparse("//" + args.server_addr)
+
+    if url.hostname:
+        HOST = url.hostname
+
+    if url.port:
+        PORT = int(url.port)
+    else:
+        if args.log_only:
+            PORT = PORT_LOG
+        else:
+            PORT = PORT_REQ
+
+log.info(f"REMOTE HOST: {HOST} PORT: {PORT}")
 
 if __name__ == "__main__":
     main()

--- a/soc/xtensa/intel_adsp/tools/cavstool_client.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool_client.py
@@ -129,11 +129,21 @@ ap.add_argument("-l", "--log-only", action="store_true",
                 help="Don't load firmware, just show log output")
 ap.add_argument("-s", "--server-addr", default="localhost",
                 help="Specify the adsp server address")
+ap.add_argument("-p", "--log-port", type=int,
+                help="Specify the PORT that connected to log server")
+ap.add_argument("-r", "--req-port", type=int,
+                help="Specify the PORT that connected to request server")
 ap.add_argument("fw_file", nargs="?", help="Firmware file")
 args = ap.parse_args()
 
 if args.quiet:
     log.setLevel(logging.WARN)
+
+if args.log_port:
+    PORT_LOG = args.log_port
+
+if args.req_port:
+    PORT_REQ = args.req_port
 
 if args.server_addr:
     url = urlparse("//" + args.server_addr)


### PR DESCRIPTION
This PR includes adding parameters for supporting:

- Specifying the service port for west / twister /hardware map
  (This also change the behavior that west flash have to add --pty {host} to show the output immediately.) 
- Specifying the service port for the cavs server
- Add --tool-opt for the west to pass to cavstool 
- Update the zephyr doc for these changes.
- Remove the dependency of netifaces python package.


**Details:**
Add specifying the port for the remote cavstool remote service.
Ex.
  
```
       west flash --remote-host {host}:{port} \
                  --pty {host}:{port}
```

Specify the port is optional when running west.

And another major change is now we have to specify the remote log
service by --pty to make it output the log message immediately.
Previously it will output directly. Why we make this change is
because this is more close to the behavior we use west flash.
```
west flash --remote-host=192.168.0.1:12345
```
Then get the log by:
```
soc/xtensa/intel_adsp/cavstool_client.py -s 192.168.0.1:54321
```

Or doing following command to output log immediately:
```
west flash --remote-host=192.168.0.1:12345 --pty=192.168.0.1:54321
```

Also add specifying the port and network interface for cavs-server:
```
cavstool.py -s 192.168.0.1:54321 --r 12345
OR
cavstool.py -s 192.168.0.1 -p 54321 --r 12345
```

Fixes #46865
Fixes #48584 

Signed-off-by: Enjia Mai <enjia.mai@intel.com>

PS: this PR is spilt from https://github.com/zephyrproject-rtos/zephyr/pull/46880