### PR TITLE
net: lwm2m: Fixes SenML CBOR composite read

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rw_senml_cbor.c
@@ -837,7 +837,7 @@ int do_composite_read_op_senml_cbor(struct lwm2m_message *msg)
 
 	lwm2m_engine_clear_duplicate_path(&lwm_path_list, &lwm_path_free_list);
 
-	return do_composite_read_op_for_parsed_path_senml_cbor(msg, &lwm_path_free_list);
+	return do_composite_read_op_for_parsed_path_senml_cbor(msg, &lwm_path_list);
 }
 
 


### PR DESCRIPTION
Path list was replaced accidentally with free list during refactoring.
This change does fix the issue.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>