### PR TITLE
boards: arm: nrf: do not use spi3 as fem_spi or arduino_spi

### DIFF
--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840-pinctrl.dtsi
@@ -124,34 +124,34 @@
 
 	spi2_default: spi2_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
-				<NRF_PSEL(SPIM_MISO, 0, 21)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
 		};
 	};
 
 	spi2_sleep: spi2_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
-				<NRF_PSEL(SPIM_MISO, 0, 21)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
 			low-power-enable;
 		};
 	};
 
 	spi3_default: spi3_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MISO, 1, 14)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
+				<NRF_PSEL(SPIM_MISO, 0, 21)>;
 		};
 	};
 
 	spi3_sleep: spi3_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MISO, 1, 14)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
+				<NRF_PSEL(SPIM_MISO, 0, 21)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -212,20 +212,12 @@ arduino_i2c: &i2c0 {
 	pinctrl-names = "default", "sleep";
 };
 
-&spi2 {
-	compatible = "nordic,nrf-spi";
-	status = "disabled";
-	pinctrl-0 = <&spi2_default>;
-	pinctrl-1 = <&spi2_sleep>;
-	pinctrl-names = "default", "sleep";
-};
-
-fem_spi: &spi3 {
+fem_spi: &spi2 {
 	status = "okay";
 	cs-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
 
-	pinctrl-0 = <&spi3_default>;
-	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-0 = <&spi2_default>;
+	pinctrl-1 = <&spi2_sleep>;
 	pinctrl-names = "default", "sleep";
 	nrf_radio_fem_spi: nrf21540_fem_spi@0 {
 		compatible = "nordic,nrf21540-fem-spi";
@@ -236,6 +228,13 @@ fem_spi: &spi3 {
 	};
 };
 
+&spi3 {
+	compatible = "nordic,nrf-spi";
+	status = "disabled";
+	pinctrl-0 = <&spi3_default>;
+	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-names = "default", "sleep";
+};
 &radio {
 	fem = <&nrf_radio_fem>;
 };

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833-pinctrl.dtsi
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833-pinctrl.dtsi
@@ -122,7 +122,7 @@
 		};
 	};
 
-	spi3_default: spi3_default {
+	spi2_default: spi2_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 23)>,
 				<NRF_PSEL(SPIM_MISO, 0, 22)>,
@@ -130,7 +130,7 @@
 		};
 	};
 
-	spi3_sleep: spi3_sleep {
+	spi2_sleep: spi2_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 23)>,
 				<NRF_PSEL(SPIM_MISO, 0, 22)>,

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -190,11 +190,11 @@ arduino_i2c: &i2c0 {
 	pinctrl-names = "default", "sleep";
 };
 
-arduino_spi: &spi3 {
+arduino_spi: &spi2 {
 	status = "okay";
 	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
-	pinctrl-0 = <&spi3_default>;
-	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-0 = <&spi2_default>;
+	pinctrl-1 = <&spi2_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -124,17 +124,17 @@
 
 	spi2_default: spi2_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
-				<NRF_PSEL(SPIM_MISO, 0, 21)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
 		};
 	};
 
 	spi2_sleep: spi2_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
-				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
-				<NRF_PSEL(SPIM_MISO, 0, 21)>;
+			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
+				<NRF_PSEL(SPIM_MISO, 1, 14)>,
+				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
 			low-power-enable;
 		};
 	};
@@ -164,17 +164,17 @@
 
 	spi3_default: spi3_default {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MISO, 1, 14)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
+				<NRF_PSEL(SPIM_MISO, 0, 21)>;
 		};
 	};
 
 	spi3_sleep: spi3_sleep {
 		group1 {
-			psels = <NRF_PSEL(SPIM_SCK, 1, 15)>,
-				<NRF_PSEL(SPIM_MISO, 1, 14)>,
-				<NRF_PSEL(SPIM_MOSI, 1, 13)>;
+			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 20)>,
+				<NRF_PSEL(SPIM_MISO, 0, 21)>;
 			low-power-enable;
 		};
 	};

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -201,9 +201,9 @@ arduino_i2c: &i2c0 {
 	pinctrl-names = "default", "sleep";
 };
 
-&spi2 {
+arduino_spi: &spi2 {
 	compatible = "nordic,nrf-spi";
-	status = "disabled";
+	status = "okay";
 	pinctrl-0 = <&spi2_default>;
 	pinctrl-1 = <&spi2_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -211,6 +211,7 @@ arduino_i2c: &i2c0 {
 
 &qspi {
 	status = "okay";
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
 	pinctrl-0 = <&qspi_default>;
 	pinctrl-1 = <&qspi_sleep>;
 	pinctrl-names = "default", "sleep";
@@ -237,9 +238,8 @@ arduino_i2c: &i2c0 {
 	};
 };
 
-arduino_spi: &spi3 {
-	status = "okay";
-	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+&spi3 {
+	status = "disabled";
 	pinctrl-0 = <&spi3_default>;
 	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
@@ -49,7 +49,7 @@
 		};
 	};
 
-	spi3_default: spi3_default {
+	spi2_default: spi2_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 29)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 28)>,
@@ -57,7 +57,7 @@
 		};
 	};
 
-	spi3_sleep: spi3_sleep {
+	spi2_sleep: spi2_sleep {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 29)>,
 				<NRF_PSEL(SPIM_MOSI, 0, 28)>,

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -171,15 +171,15 @@
 	};
 };
 
-&spi3 {
+&spi2 {
 	compatible = "nordic,nrf-spim";
 	status = "okay";
 	cs-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>,
 		   <&gpio1 4  GPIO_ACTIVE_LOW>,
 		   <&gpio0 24 GPIO_ACTIVE_LOW>;
 
-	pinctrl-0 = <&spi3_default>;
-	pinctrl-1 = <&spi3_sleep>;
+	pinctrl-0 = <&spi2_default>;
+	pinctrl-1 = <&spi2_sleep>;
 	pinctrl-names = "default", "sleep";
 	adxl362: spi-dev-adxl362@0 {
 		compatible = "adi,adxl362";


### PR DESCRIPTION
Due to hardware problems nRF21540 software won't work properly with spi3. This PR changes fem_spi and arduino_spi to spi2 if spi3 was used. The change of arduino_spi is motivated by the usage of arduino_spi on the nordic nRF21540 EK shield.

Signed-off-by: Artur Hadasz <artur.hadasz@nordicsemi.no>