### PR TITLE
drivers: flash: stm32 ospi driver align erase on sector size

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -723,7 +723,7 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 		return -EINVAL;
 	}
 
-	if ((size != SPI_NOR_SECTOR_SIZE) && (size < dev_cfg->flash_size)) {
+	if (((size % SPI_NOR_SECTOR_SIZE) != 0) && (size < dev_cfg->flash_size)) {
 		LOG_ERR("Error: wrong sector size 0x%x", size);
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
When erasing the flash, the size to erase must be
compared to a multiple of SECTOR_SIZE.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/46931

Signed-off-by: Francois Ramu <francois.ramu@st.com>