### PR TITLE
dts: nrf: deprecate -pin properties

### DIFF
--- a/dts/bindings/audio/nordic,nrf-pdm.yaml
+++ b/dts/bindings/audio/nordic,nrf-pdm.yaml
@@ -16,10 +16,11 @@ properties:
 
     clk-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The CLK pin to use.
 
@@ -35,10 +36,11 @@ properties:
 
     din-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The DIN pin to use. The pin numbering scheme is the same as
         the clk-pin property's.

--- a/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
+++ b/dts/bindings/flash_controller/nordic,nrf-qspi.yaml
@@ -39,10 +39,11 @@ properties:
 
   sck-pin:
     type: int
+    deprecated: true
     required: false
     description: |
       IMPORTANT: This option will only be used if the new pin control driver
-      is not enabled. It will be deprecated in the future.
+      is not enabled.
 
       The SCK pin to use.
 
@@ -60,7 +61,7 @@ properties:
     required: false
     description: |
       IMPORTANT: This option will only be used if the new pin control driver
-      is not enabled. It will be deprecated in the future.
+      is not enabled.
 
       Pin numbers associated with IO0 through IO3 signals.
 
@@ -78,7 +79,7 @@ properties:
     required: false
     description: |
       IMPORTANT: This option will only be used if the new pin control driver
-      is not enabled. It will be deprecated in the future.
+      is not enabled.
 
       Chip select signal pin number. Exactly one pin should be
       given. The pin numbering scheme is the same as the

--- a/dts/bindings/i2c/nordic,nrf-twi-common.yaml
+++ b/dts/bindings/i2c/nordic,nrf-twi-common.yaml
@@ -15,10 +15,11 @@ properties:
 
     sda-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The SDA pin to use.
 
@@ -34,10 +35,11 @@ properties:
 
     scl-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The SCL pin to use. The pin numbering scheme is the same as
         the sda-pin property's.

--- a/dts/bindings/i2s/nordic,nrf-i2s.yaml
+++ b/dts/bindings/i2s/nordic,nrf-i2s.yaml
@@ -16,10 +16,11 @@ properties:
 
     sck-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The SCK pin to use.
 
@@ -35,40 +36,44 @@ properties:
 
     lrck-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The LRCK pin to use. The pin numbering scheme is the same as
         the sck-pin property's.
 
     sdout-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The SDOUT pin to use. The pin numbering scheme is the same as
         the sck-pin property's.
 
     sdin-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The SDIN pin to use. The pin numbering scheme is the same as
         the sck-pin property's.
 
     mck-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The MCK pin to use. The pin numbering scheme is the same as
         the sck-pin property's.

--- a/dts/bindings/pwm/nordic,nrf-pwm.yaml
+++ b/dts/bindings/pwm/nordic,nrf-pwm.yaml
@@ -15,10 +15,11 @@ properties:
 
     ch0-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The channel 0 pin to use.
 
@@ -34,10 +35,11 @@ properties:
 
     ch0-inverted:
       type: boolean
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
         When the pin control driver is enabled, use the "nordic,invert" property
         in the corresponding pin configuration group instead.
 
@@ -45,20 +47,22 @@ properties:
 
     ch1-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The channel 1 pin to use. The pin numbering scheme is the same
         as the ch0-pin property's.
 
     ch1-inverted:
       type: boolean
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
         When the pin control driver is enabled, use the "nordic,invert" property
         in the corresponding pin configuration group instead.
 
@@ -66,20 +70,22 @@ properties:
 
     ch2-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The channel 2 pin to use. The pin numbering scheme is the same
         as the ch0-pin property's.
 
     ch2-inverted:
       type: boolean
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
         When the pin control driver is enabled, use the "nordic,invert" property
         in the corresponding pin configuration group instead.
 
@@ -87,20 +93,22 @@ properties:
 
     ch3-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The channel 3 pin to use. The pin numbering scheme is the same
         as the ch0-pin property's.
 
     ch3-inverted:
       type: boolean
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
         When the pin control driver is enabled, use the "nordic,invert" property
         in the corresponding pin configuration group instead.
 

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -16,10 +16,11 @@ properties:
 
     a-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The A pin to use.
 
@@ -35,20 +36,22 @@ properties:
 
     b-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The B pin to use. The pin numbering scheme is the same as
         the a-pin property's.
 
     led-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The LED pin to use for a light based QDEC device. The pin
         numbering scheme is the same as the a-pin property's.

--- a/dts/bindings/serial/nordic,nrf-uart-common.yaml
+++ b/dts/bindings/serial/nordic,nrf-uart-common.yaml
@@ -39,9 +39,10 @@ properties:
 
     tx-pin:
       type: int
+      deprecated: true
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The TX pin to use.
 
@@ -57,43 +58,48 @@ properties:
 
     rx-pin:
       type: int
+      deprecated: true
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The RX pin to use. The pin numbering scheme is the same as the
         tx-pin property's.
 
     rts-pin:
       type: int
+      deprecated: true
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The RTS pin to use. The pin numbering scheme is the same as the
         tx-pin property's.
 
     cts-pin:
       type: int
+      deprecated: true
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The CTS pin to use. The pin numbering scheme is the same as the
         tx-pin property's.
 
     rx-pull-up:
       type: boolean
+      deprecated: true
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         Enable pull-up resistor on the RX pin.
 
     cts-pull-up:
       type: boolean
+      deprecated: true
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         Enable pull-up resistor on the CTS pin.

--- a/dts/bindings/spi/nordic,nrf-spi-common.yaml
+++ b/dts/bindings/spi/nordic,nrf-spi-common.yaml
@@ -14,10 +14,11 @@ properties:
 
     sck-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The SCK pin to use.
 
@@ -33,20 +34,22 @@ properties:
 
     mosi-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The MOSI pin to use. The pin numbering scheme is the same as
         the sck-pin property's.
 
     miso-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The MISO pin to use. The pin numbering scheme is the same as
         the sck-pin property's.

--- a/dts/bindings/spi/nordic,nrf-spis.yaml
+++ b/dts/bindings/spi/nordic,nrf-spis.yaml
@@ -10,10 +10,11 @@ include: nordic,nrf-spi-common.yaml
 properties:
     csn-pin:
       type: int
+      deprecated: true
       required: false
       description: |
         IMPORTANT: This option will only be used if the new pin control driver
-        is not enabled. It will be deprecated in the future.
+        is not enabled.
 
         The CSN pin to use. The pin numbering scheme is the same as
         the sck-pin property's.


### PR DESCRIPTION
-pin properties, e.g. tx-pin have been replaced by pinctrl. Mark them as
deprecated since old pin configuration schemes will be deprecated in
Zephyr 3.2.