### PR TITLE
Bluetooth: Mesh: Increase BT RX thread stack size for mesh

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -115,7 +115,7 @@ config BT_RX_STACK_SIZE
 	int "Size of the receiving thread stack"
 	default 768 if BT_HCI_RAW
 	default 3092 if BT_MESH_GATT_CLIENT
-	default 2048 if BT_MESH
+	default 2200 if BT_MESH
 	default 2048 if BT_AUDIO
 	default 2200 if BT_SETTINGS
 	default 1024


### PR DESCRIPTION
New logging system (v2) requires more stack size in deferred mode.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>