### PR TITLE
boards: ehl_crb: Add llvm to supported toolchains

### DIFF
--- a/boards/x86/ehl_crb/ehl_crb.yaml
+++ b/boards/x86/ehl_crb/ehl_crb.yaml
@@ -4,6 +4,7 @@ type: mcu
 arch: x86
 toolchain:
   - zephyr
+  - llvm
 ram: 2048
 supported:
   - gpio


### PR DESCRIPTION
Adding llvm allows to use twister testing.