### PR TITLE
tests: lib: c_lib: ifndef out gcc pragmas

### DIFF
--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -624,10 +624,14 @@ ZTEST(test_c_lib, test_str_operate)
 
 	zassert_true(strncat(ncat, str1, 2), "strncat failed");
 	zassert_not_null(strncat(str1, str3, 2), "strncat failed");
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 	zassert_not_null(strncat(str1, str3, 1), "strncat failed");
+#if defined(__GNUC__) && __GNUC__ >= 7
 #pragma GCC diagnostic pop
+#endif
 	zassert_equal(strcmp(ncat, "ddeeaa"), 0, "strncat failed");
 
 	zassert_is_null(strrchr(ncat, 'z'),


### PR DESCRIPTION
Ifndefs out GCC pragmas causing build failures for compilers with GNUC < 7, e.g. XCC <= 2020.

Signed-off-by: Lauren Murphy <lauren.murphy@intel.com>