### PR TITLE
Bluetooth: Audio: Add broadcast source metadata update function

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -2077,7 +2077,7 @@ int bt_audio_broadcast_source_create(struct bt_audio_broadcast_source_create_par
 /** @brief Reconfigure audio broadcast source.
  *
  *  Reconfigure an audio broadcast source with a new codec and codec quality of
- *  service parameters.
+ *  service parameters. This can only be done when the source is stopped.
  *
  *  @param source      Pointer to the broadcast source
  *  @param codec       Codec configuration.
@@ -2088,6 +2088,22 @@ int bt_audio_broadcast_source_create(struct bt_audio_broadcast_source_create_par
 int bt_audio_broadcast_source_reconfig(struct bt_audio_broadcast_source *source,
 				       struct bt_codec *codec,
 				       struct bt_codec_qos *qos);
+
+/** @brief Modify the metadata of an audio broadcast source.
+ *
+ *  Modify the metadata an audio broadcast source. This can only be done when
+ *  the source is started. To update the metadata in the stopped state, use
+ *  bt_audio_broadcast_source_reconfig().
+ *
+ *  @param source      Pointer to the broadcast source.
+ *  @param meta        Metadata entries.
+ *  @param meta_count  Number of metadata entries.
+ *
+ *  @return Zero on success or (negative) error code otherwise.
+ */
+int bt_audio_broadcast_source_update_metadata(struct bt_audio_broadcast_source *source,
+					      const struct bt_codec_data meta[],
+					      size_t meta_count);
 
 /** @brief Start audio broadcast source.
  *

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1294,7 +1294,7 @@ struct bt_audio_stream {
 	/** Endpoint reference */
 	struct bt_audio_ep *ep;
 	/** Codec Configuration */
-	const struct bt_codec *codec;
+	struct bt_codec *codec;
 	/** QoS Configuration */
 	struct bt_codec_qos *qos;
 	/** Audio stream operations */
@@ -1804,7 +1804,7 @@ int bt_audio_stream_config(struct bt_conn *conn,
  *  @return 0 in case of success or negative value in case of error.
  */
 int bt_audio_stream_reconfig(struct bt_audio_stream *stream,
-			     const struct bt_codec *codec);
+			     struct bt_codec *codec);
 
 /** @brief Configure Audio Stream QoS
  *

--- a/subsys/bluetooth/audio/stream.c
+++ b/subsys/bluetooth/audio/stream.c
@@ -1103,7 +1103,7 @@ int bt_audio_unicast_group_delete(struct bt_audio_unicast_group *unicast_group)
 #endif /* CONFIG_BT_AUDIO_UNICAST_CLIENT */
 
 int bt_audio_stream_reconfig(struct bt_audio_stream *stream,
-			     const struct bt_codec *codec)
+			     struct bt_codec *codec)
 {
 	uint8_t state;
 	uint8_t role;

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
@@ -15,6 +15,7 @@ extern enum bst_result_t bst_result;
 
 CREATE_FLAG(broadcaster_found);
 CREATE_FLAG(base_received);
+CREATE_FLAG(flag_base_metadata_updated);
 CREATE_FLAG(pa_synced);
 CREATE_FLAG(flag_syncable);
 CREATE_FLAG(pa_sync_lost);
@@ -29,6 +30,8 @@ static struct bt_audio_lc3_preset preset_16_2_1 =
 
 static K_SEM_DEFINE(sem_started, 0U, ARRAY_SIZE(streams));
 static K_SEM_DEFINE(sem_stopped, 0U, ARRAY_SIZE(streams));
+
+static struct bt_codec_data metadata[CONFIG_BT_CODEC_MAX_METADATA_COUNT];
 
 /* Create a mask for the maximum BIS we can sync to using the number of streams
  * we have. We add an additional 1 since the bis indexes start from 1 and not
@@ -76,6 +79,17 @@ static void base_recv_cb(struct bt_audio_broadcast_sink *sink,
 	uint32_t base_bis_index_bitfield = 0U;
 
 	if (TEST_FLAG(base_received)) {
+
+		if (base->subgroup_count > 0 &&
+		    memcmp(metadata, base->subgroups[0].codec.meta,
+			   sizeof(base->subgroups[0].codec.meta)) != 0) {
+
+			(void)memcpy(metadata, base->subgroups[0].codec.meta,
+				     sizeof(base->subgroups[0].codec.meta));
+
+			SET_FLAG(flag_base_metadata_updated);
+		}
+
 		return;
 	}
 
@@ -235,6 +249,10 @@ static void test_main(void)
 	printk("Waiting for data\n");
 	WAIT_FOR_FLAG(flag_received);
 
+	/* Ensure that we also see the metadata update */
+	printk("Waiting for metadata update\n");
+	WAIT_FOR_FLAG(flag_base_metadata_updated)
+
 	/* The order of PA sync lost and BIG Sync lost is irrelevant
 	 * and depend on timeout parameters. We just wait for PA first, but
 	 * either way will work.
@@ -292,6 +310,10 @@ static void test_sink_disconnect(void)
 
 	printk("Waiting for data\n");
 	WAIT_FOR_FLAG(flag_received);
+
+	/* Ensure that we also see the metadata update */
+	printk("Waiting for metadata update\n");
+	WAIT_FOR_FLAG(flag_base_metadata_updated)
 
 	err = bt_audio_broadcast_sink_stop(g_sink);
 	if (err != 0) {

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_source_test.c
@@ -244,6 +244,8 @@ static int stop_extended_adv(struct bt_le_ext_adv *adv)
 
 static void test_main(void)
 {
+	struct bt_codec_data new_metadata[1] =
+		BT_CODEC_LC3_CONFIG_META(BT_AUDIO_CONTEXT_TYPE_ALERTS);
 	struct bt_audio_broadcast_source *source;
 	struct bt_le_ext_adv *adv;
 	int err;
@@ -298,6 +300,18 @@ static void test_main(void)
 
 	/* Keeping running for a little while */
 	k_sleep(K_SECONDS(15));
+
+	/* Update metadata while streaming */
+	printk("Updating metadata\n");
+	err = bt_audio_broadcast_source_update_metadata(source, new_metadata,
+							ARRAY_SIZE(new_metadata));
+	if (err != 0) {
+		FAIL("Failed to update metadata broadcast source: %d", err);
+		return;
+	}
+
+	/* Keeping running for a little while */
+	k_sleep(K_SECONDS(5));
 
 	printk("Stopping broadcast source\n");
 	SET_FLAG(flag_stopping);


### PR DESCRIPTION
Add API to do the BAP Broadcast Source Metadata update procedure,
which updates the metadata of a broadcast source while
it is streaming.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

depends on https://github.com/zephyrproject-rtos/zephyr/pull/49946