### PR TITLE
samples: display: do not build if lvgl is not available

### DIFF
--- a/samples/subsys/display/lvgl/sample.yaml
+++ b/samples/subsys/display/lvgl/sample.yaml
@@ -12,3 +12,5 @@ tests:
     min_ram: 32
     harness: none
     tags: samples display gui
+    modules:
+      - lvgl


### PR DESCRIPTION
This sample depends on lvgl, so do not try and build it if lvgl is not
part of the workspace and if it was excluded in a local manifest.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
