### PR TITLE
scripts: intel_adsp: don't invoke west sign with --tool-path None

### DIFF
--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -98,9 +98,12 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
             sys.exit(1)
 
     def sign(self, **kwargs):
-        sign_cmd = ['west', 'sign', '-d', f'{self.cfg.build_dir}', '-t', 'rimage', '-p', f'{self.rimage_tool}',
-                '-D', f'{self.config_dir}', '--', '-k', f'{self.key}']
-
+        path_opt = ['-p', f'{self.rimage_tool}'] if self.rimage_tool else []
+        sign_cmd = (
+            ['west', 'sign', '-d', f'{self.cfg.build_dir}', '-t', 'rimage']
+            + path_opt + ['-D', f'{self.config_dir}', '--', '-k', f'{self.key}']
+        )
+        self.logger.info(" ".join(sign_cmd))
         self.check_call(sign_cmd)
 
     def flash(self, **kwargs):


### PR DESCRIPTION
When there is no rimage found in the path, don't invoke west sign with
"-tool-path None". This enhances the error message from the somewhat
cryptic:
```
  ERROR: --tool-path None: not an executable
```
... to the user friendlier:
```
  FATAL ERROR: rimage not found; either install it or provide --tool-path
```
Also log the complete west sign command at the "info" level before
running it to show that no signed firmware was found, to show which
rimage is used and in case other rimage problems arise. Invoking an
external command is an important "checkpoint".

Signed-off-by: Marc Herbert <marc.herbert@intel.com>