### PR TITLE
scripts: intel_adsp: always invoke west sign

### DIFF
--- a/scripts/west_commands/runners/intel_adsp.py
+++ b/scripts/west_commands/runners/intel_adsp.py
@@ -86,9 +86,15 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
     def do_run(self, command, **kwargs):
         self.logger.info('Starting Intel ADSP runner')
 
-        # If the zephyr.ri is not existing, it will build and sign it.
-        if self.bin_fw is None or not os.path.isfile(self.bin_fw):
-            self.sign(**kwargs)
+        # Always re-sign because here we cannot know whether `west
+        # flash` was invoked with `--skip-rebuild` or not and we have no
+        # way to tell whether there was any code change either.
+        #
+        # Signing does not belong here; it should be invoked either from
+        # some CMakeLists.txt file or an optional hook in some generic
+        # `west flash` code but right now it's in neither so we have to
+        # do this.
+        self.sign(**kwargs)
 
         if re.search("intel_adsp_cavs", self.platform):
             self.require(self.cavstool)
@@ -109,7 +115,7 @@ class IntelAdspBinaryRunner(ZephyrBinaryRunner):
         random_str = f"{random.getrandbits(64)}".encode()
         hash_object.update(random_str)
         send_bin_fw = str(self.bin_fw + "." + hash_object.hexdigest())
-        os.rename(self.bin_fw, send_bin_fw)
+        shutil.copy(self.bin_fw, send_bin_fw)
 
         # Copy the zephyr to target remote ADSP host and run
         self.run_cmd = ([f'{self.cavstool}','-s', f'{self.remote_host}', f'{send_bin_fw}'])


### PR DESCRIPTION
west flash invokes west build and we have no way to tell whether there
was any code change.

Also remove the rename() trick that achieved the same effect in a
a confusing way; just use copy() instead.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>