### PR TITLE
hal: gigadevice: Update gd32f4xx to firmware 3.0.0

### DIFF
--- a/drivers/pinctrl/pinctrl_gd32_af.c
+++ b/drivers/pinctrl/pinctrl_gd32_af.c
@@ -25,7 +25,7 @@ BUILD_ASSERT((GD32_OSPEED_2MHZ == GPIO_OSPEED_2MHZ) &&
 #else
 	     (GD32_OSPEED_25MHZ == GPIO_OSPEED_25MHZ) &&
 	     (GD32_OSPEED_50MHZ == GPIO_OSPEED_50MHZ) &&
-	     (GD32_OSPEED_200MHZ == GPIO_OSPEED_200MHZ) &&
+	     (GD32_OSPEED_MAX == GPIO_OSPEED_MAX) &&
 #endif /* CONFIG_SOC_SERIES_GD32F3X0 */
 	     1U,
 	     "pinctrl output speed definitions != HAL definitions");

--- a/include/zephyr/drivers/pinctrl/pinctrl_soc_gd32_common.h
+++ b/include/zephyr/drivers/pinctrl/pinctrl_soc_gd32_common.h
@@ -116,8 +116,8 @@ typedef uint32_t pinctrl_soc_pin_t;
 #define GD32_OSPEED_25MHZ 1U
 /** Maximum 50MHz */
 #define GD32_OSPEED_50MHZ 2U
-/** Maximum 200MHz */
-#define GD32_OSPEED_200MHZ 3U
+/** Maximum speed */
+#define GD32_OSPEED_MAX 3U
 #endif /* CONFIG_SOC_SERIES_GD32F3X0 */
 #else
 /** Maximum 10MHz */

--- a/tests/drivers/pinctrl/gd32/src/main_af.c
+++ b/tests/drivers/pinctrl/gd32/src/main_af.c
@@ -109,7 +109,7 @@ static void test_dt_extract(void)
 	zassert_equal(GD32_AF_GET(pin), GD32_AF10, NULL);
 	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
 	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_200MHZ, NULL);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_MAX, NULL);
 
 	pin = scfg->pins[11];
 	zassert_equal(GD32_PORT_GET(pin), 2, NULL);

--- a/west.yml
+++ b/west.yml
@@ -68,7 +68,7 @@ manifest:
       groups:
         - hal
     - name: hal_gigadevice
-      revision: cc8bc14c612e5ecfcb0435f6da53f3302e25014a
+      revision: 7f15468b07807ae6a913e0e9cbabfaa23a206bc6
       path: modules/hal/gigadevice
       groups:
         - hal


### PR DESCRIPTION
This PR is associated with  : 
- [hal_gigadevice/pull/24](https://github.com/zephyrproject-rtos/hal_gigadevice/pull/24)
- [hal_gigadevice/pull/25](https://github.com/zephyrproject-rtos/hal_gigadevice/pull/25)

Signed-off-by: Alexandre Duchesne [alexandre.duchesne@rtone.fr](mailto:alexandre.duchesne@rtone.fr)