### PR TITLE
drivers: display: st7789v: Support 3-line serial interface

### DIFF
--- a/drivers/display/display_st7789v.h
+++ b/drivers/display/display_st7789v.h
@@ -8,6 +8,7 @@
 
 #include <zephyr/zephyr.h>
 
+#define ST7789V_CMD_NOP				0x00
 #define ST7789V_CMD_SW_RESET			0x01
 
 #define ST7789V_CMD_SLEEP_IN			0x10
@@ -66,5 +67,7 @@
 
 #define ST7789V_CMD_PVGAMCTRL			0xe0
 #define ST7789V_CMD_NVGAMCTRL			0xe1
+
+#define ST7789V_CMD_NONE			0xff
 
 #endif

--- a/dts/bindings/display/sitronix,st7789v.yaml
+++ b/dts/bindings/display/sitronix,st7789v.yaml
@@ -21,9 +21,11 @@ properties:
 
     cmd-data-gpios:
       type: phandle-array
-      required: true
+      required: false
       description: |
-        D/CX pin.
+        D/CX pin. If configured, 4-lines serial interface is used, otherwise
+        3-lines serial interface is used and a D/CX bit (9-bit) is added to
+        the protocol.
 
         The D/CX pin of ST7789V is active low (transmission command byte).
         If connected directly the MCU pin should be configured


### PR DESCRIPTION
The sitronix ST7789V serial interface can operate with 3- or 4-line protocol.

Tested on custom board.