### PR TITLE
ITE soc/it8xxx2: disable unused integrated cc module

### DIFF
--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -1240,5 +1240,19 @@
 			kso16-gpios = <&gpioc 3 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
 			kso17-gpios = <&gpioc 5 (GPIO_OPEN_DRAIN | GPIO_PULL_UP)>;
 		};
+
+		usbpd0: usbpd@f03700 {
+			compatible = "ite,it8xxx2-usbpd";
+			reg = <0x00f03700 0x100>;
+			label = "USB_PD_PORT0";
+			status = "disabled";
+		};
+
+		usbpd1: usbpd@f03800 {
+			compatible = "ite,it8xxx2-usbpd";
+			reg = <0x00f03800 0x100>;
+			label = "USB_PD_PORT1";
+			status = "disabled";
+		};
 	};
 };

--- a/soc/riscv/riscv-ite/common/chip_chipregs.h
+++ b/soc/riscv/riscv-ite/common/chip_chipregs.h
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2020 ITE Corporation. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -1339,6 +1339,45 @@ struct peci_it8xxx2_regs {
 #define CECIE			ECREG(EC_REG_BASE_ADDR + 0x2E05)
 #define CECOPSTS		ECREG(EC_REG_BASE_ADDR + 0x2E06)
 #define CECCRH			ECREG(EC_REG_BASE_ADDR + 0x2E07)
+
+/**
+ *
+ * (37xxh, 38xxh) USBPD Controller
+ *
+ */
+#ifndef __ASSEMBLER__
+struct usbpd_it8xxx2_regs {
+	/* 0x000~0x003: Reserved1 */
+	volatile uint8_t Reserved1[4];
+	/* 0x004: CC General Configuration */
+	volatile uint8_t CCGCR;
+	/* 0x005: CC Channel Setting */
+	volatile uint8_t CCCSR;
+	/* 0x006: CC Pad Setting */
+	volatile uint8_t CCPSR;
+};
+#endif /* !__ASSEMBLER__ */
+
+/* USBPD controller register fields */
+/* 0x004: CC General Configuration */
+#define IT8XXX2_USBPD_DISABLE_CC			BIT(7)
+#define IT8XXX2_USBPD_DISABLE_CC_VOL_DETECTOR		BIT(6)
+#define IT8XXX2_USBPD_CC_SELECT_RP_RESERVED		(BIT(3) | BIT(2) | BIT(1))
+#define IT8XXX2_USBPD_CC_SELECT_RP_DEF			(BIT(3) | BIT(2))
+#define IT8XXX2_USBPD_CC_SELECT_RP_1A5			BIT(3)
+#define IT8XXX2_USBPD_CC_SELECT_RP_3A0			BIT(2)
+#define IT8XXX2_USBPD_CC1_CC2_SELECTION			BIT(0)
+/* 0x005: CC Channel Setting */
+#define IT8XXX2_USBPD_CC2_DISCONNECT			BIT(7)
+#define IT8XXX2_USBPD_CC2_DISCONNECT_5_1K_TO_GND	BIT(6)
+#define IT8XXX2_USBPD_CC1_DISCONNECT			BIT(3)
+#define IT8XXX2_USBPD_CC1_DISCONNECT_5_1K_TO_GND	BIT(2)
+#define IT8XXX2_USBPD_CC1_CC2_RP_RD_SELECT		(BIT(1) | BIT(5))
+/* 0x006: CC Pad Setting */
+#define IT8XXX2_USBPD_DISCONNECT_5_1K_CC2_DB		BIT(6)
+#define IT8XXX2_USBPD_DISCONNECT_POWER_CC2		BIT(5)
+#define IT8XXX2_USBPD_DISCONNECT_5_1K_CC1_DB		BIT(2)
+#define IT8XXX2_USBPD_DISCONNECT_POWER_CC1		BIT(1)
 
 /**
  *

--- a/soc/riscv/riscv-ite/it8xxx2/soc.c
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.c
@@ -303,6 +303,47 @@ static int ite_it8xxx2_init(const struct device *arg)
 	IT8XXX2_GPIO_GRC1 |= BIT(2);
 
 #endif /* DT_NODE_HAS_STATUS(DT_NODELABEL(uart2), okay) */
+
+#if (SOC_USBPD_ITE_PHY_PORT_COUNT > 0)
+	int port;
+
+	/*
+	 * To prevent cc pins leakage, we disable board not active ITE
+	 * TCPC port cc modules, then cc pins can be used as gpio if needed.
+	 */
+	for (port = SOC_USBPD_ITE_ACTIVE_PORT_COUNT;
+	     port < SOC_USBPD_ITE_PHY_PORT_COUNT; port++) {
+		struct usbpd_it8xxx2_regs *base;
+
+		if (port == 0) {
+			base = (struct usbpd_it8xxx2_regs *)DT_REG_ADDR(DT_NODELABEL(usbpd0));
+		} else if (port == 1) {
+			base = (struct usbpd_it8xxx2_regs *)DT_REG_ADDR(DT_NODELABEL(usbpd1));
+		} else {
+			/* Currently all ITE embedded pd chip support max two ports */
+			break;
+		}
+
+		/* Power down all CC, and disable CC voltage detector */
+		base->CCGCR |= (IT8XXX2_USBPD_DISABLE_CC |
+				IT8XXX2_USBPD_DISABLE_CC_VOL_DETECTOR);
+		/*
+		 * Disconnect CC analog module (ex.UP/RD/DET/TX/RX), and
+		 * disconnect CC 5.1K to GND
+		 */
+		base->CCCSR |= (IT8XXX2_USBPD_CC2_DISCONNECT |
+				IT8XXX2_USBPD_CC2_DISCONNECT_5_1K_TO_GND |
+				IT8XXX2_USBPD_CC1_DISCONNECT |
+				IT8XXX2_USBPD_CC1_DISCONNECT_5_1K_TO_GND);
+		/* Disconnect CC 5V tolerant */
+		base->CCPSR |= (IT8XXX2_USBPD_DISCONNECT_POWER_CC2 |
+				IT8XXX2_USBPD_DISCONNECT_POWER_CC1);
+		/* Dis-connect 5.1K dead battery resistor to CC */
+		base->CCPSR |= (IT8XXX2_USBPD_DISCONNECT_5_1K_CC2_DB |
+				IT8XXX2_USBPD_DISCONNECT_5_1K_CC1_DB);
+	}
+#endif /* (SOC_USBPD_ITE_PHY_PORT_COUNT > 0) */
+
 	return 0;
 }
 SYS_INIT(ite_it8xxx2_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);

--- a/soc/riscv/riscv-ite/it8xxx2/soc.h
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.h
@@ -12,6 +12,23 @@
 #define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
 #define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)
 
+/*
+ * This define gets the total number of USBPD ports available on the
+ * ITE EC chip from dtsi (include status disable). Both it81202 and
+ * it81302 support two USBPD ports.
+ */
+#define SOC_USBPD_ITE_PHY_PORT_COUNT \
+COND_CODE_1(DT_NODE_EXISTS(DT_INST(1, ite_it8xxx2_usbpd)), (2), (1))
+
+/*
+ * This define gets the number of active USB Power Delivery (USB PD)
+ * ports in use on the ITE microcontroller from dts (only status okay).
+ * The active port usage should follow the order of ITE TCPC port index,
+ * ex. if we're active only one ITE USB PD port, then the port should be
+ * 0x3700 (port0 register base), instead of 0x3800 (port1 register base).
+ */
+#define SOC_USBPD_ITE_ACTIVE_PORT_COUNT DT_NUM_INST_STATUS_OKAY(ite_it8xxx2_usbpd)
+
 #ifndef _ASMLANGUAGE
 void soc_interrupt_init(void);
 #endif


### PR DESCRIPTION
ITE EC chip it81202 and it81302 both have embedded integrated
pd module (support two usbpd ports), this is different from
standalone TCPC. To prevent cc pins leakage, we disable not
active ITE USBPD port cc modules, then cc pins can be used
as gpio if needed.

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>