### PR TITLE
kernel: timeout: next timeout is closer to elapsed time

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -67,14 +67,13 @@ static int32_t elapsed(void)
 static int32_t next_timeout(void)
 {
 	struct _timeout *to = first();
-	int32_t ticks_elapsed = elapsed();
 	int32_t ret;
 
 	if ((to == NULL) ||
-	    ((int64_t)(to->dticks - ticks_elapsed) > (int64_t)INT_MAX)) {
+	    ((int64_t)(to->dticks - elapsed()) > (int64_t)INT_MAX)) {
 		ret = MAX_WAIT;
 	} else {
-		ret = MAX(0, to->dticks - ticks_elapsed);
+		ret = MAX(0, to->dticks - elapsed());
 	}
 
 #ifdef CONFIG_TIMESLICING


### PR DESCRIPTION
Directly get the elapsed time instead of writing a variable
So is the calculated next timeout value as close to the
elapsed time as possible.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/46641

Signed-off-by: Francois Ramu <francois.ramu@st.com>