### PR TITLE
boards: nrf9160dk_nrf9160: Add arduino_spi definition

### DIFF
--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160.yaml
@@ -11,6 +11,8 @@ flash: 256
 supported:
   - arduino_gpio
   - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - gpio
   - i2c
   - pwm

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common-pinctrl.dtsi
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common-pinctrl.dtsi
@@ -91,6 +91,23 @@
 		};
 	};
 
+	spi1_default: spi1_default {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 12)>,
+				<NRF_PSEL(SPIM_MISO, 0, 11)>;
+		};
+	};
+
+	spi1_sleep: spi1_sleep {
+		group1 {
+			psels = <NRF_PSEL(SPIM_SCK, 0, 13)>,
+				<NRF_PSEL(SPIM_MOSI, 0, 12)>,
+				<NRF_PSEL(SPIM_MISO, 0, 11)>;
+			low-power-enable;
+		};
+	};
+
 	spi3_default: spi3_default {
 		group1 {
 			psels = <NRF_PSEL(SPIM_SCK, 0, 19)>,
@@ -107,5 +124,4 @@
 			low-power-enable;
 		};
 	};
-
 };

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -173,7 +173,7 @@
 };
 
 arduino_serial: &uart1 {
-	status = "okay";
+	/* Cannot be used together with spi1, hence disabled by default. */
 	current-speed = <115200>;
 	pinctrl-0 = <&uart1_default>;
 	pinctrl-1 = <&uart1_sleep>;
@@ -198,6 +198,14 @@ arduino_i2c: &i2c2 {
 	status = "okay";
 	pinctrl-0 = <&pwm0_default>;
 	pinctrl-1 = <&pwm0_sleep>;
+	pinctrl-names = "default", "sleep";
+};
+
+arduino_spi: &spi1 {
+	/* Cannot be used together with uart1, hence disabled by default. */
+	cs-gpios = <&arduino_header 16 GPIO_ACTIVE_LOW>; /* D10 */
+	pinctrl-0 = <&spi1_default>;
+	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";
 };
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_ns.yaml
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_ns.yaml
@@ -11,6 +11,8 @@ flash: 192
 supported:
   - arduino_gpio
   - arduino_i2c
+  - arduino_serial
+  - arduino_spi
   - i2c
   - pwm
   - watchdog

--- a/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
+++ b/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
@@ -64,6 +64,7 @@
 };
 
 &arduino_spi {
+	status = "okay";
 	cs-gpios = <&arduino_header  8 GPIO_ACTIVE_LOW>, /* U5: eeprom4 */
 		   <&arduino_header 15 GPIO_ACTIVE_LOW>, /* U6: eeprom5 */
 		   <&arduino_header 16 GPIO_ACTIVE_LOW>; /* U7: eeprom6 */


### PR DESCRIPTION
Assign proper pins and add the arduino_spi node label to one SPI node
so that shields that require SPI can be used with the nRF9160 DK.
Due to the limited resources of the nRF9160 SoC, the arduino_spi (spi1)
and arduino_serial (uart1) interfaces cannot be used together on this
board, so remove the default "okay" status from the arduino_serial node
(this status is supposed to be set in a shield overlay that uses this
interface).
The spi1 node was selected as arduino_spi because:
- spi0 could not be used together with uart0 that is used by the Zephyr
  console
- spi2 could not be used together with i2c2, which is arduino_i2c and
  in newer nRF9160 DK revisions (0.14.0+) also provides communication
  with the onboard GPIO expander
- spi3 is used in newer nRF9160 DK revisions for communication with the
  onboard flash chip

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>