### PR TITLE
boards: nrf: Fix sw_pwm channel definitions

### DIFF
--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -89,7 +89,7 @@
 
 &sw_pwm {
 	status ="okay";
-	channel-gpios = <&gpio0 21 0>;
+	channel-gpios = <&gpio0 21 PWM_POLARITY_INVERTED>;
 	clock-prescaler = <8>;
 };
 

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -57,7 +57,7 @@
 
 &sw_pwm {
 	status ="okay";
-	channel-gpios = <&gpio0 21 0>;
+	channel-gpios = <&gpio0 21 PWM_POLARITY_INVERTED>;
 	clock-prescaler = <8>;
 };
 

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -76,6 +76,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		led3 = &led3;
+		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
@@ -84,6 +85,12 @@
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
 	};
+};
+
+&sw_pwm {
+	status ="okay";
+	channel-gpios = <&gpio0 13 PWM_POLARITY_INVERTED>;
+	clock-prescaler = <8>;
 };
 
 &gpiote {


### PR DESCRIPTION
This is a follow-up to commit f301dc2382dca20c879fe2d73676fc61524e90b6.

Add missing GPIO_ACTIVE_LOW flag to sw_pwm channel definitions for
nRF51 DK and nRF51 Dongle so that the initial state of their PWM
outputs is properly set up.
Add missing sw_pwm channel definition in the nrf52833dk_nrf52820 target
that was modified in 793362ae5a9e02c94d03fbf8736cf19b473965e3 instead
of in f301dc2382dca20c879fe2d73676fc61524e90b6. Add also the pwm-led0
alias for its PWM LED so that it can be used with standard samples.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>