### PR TITLE
drivers: display: display_mcux_elcdif: Rework double framebuffer

### DIFF
--- a/boards/arm/mimxrt1170_evk/Kconfig.defconfig
+++ b/boards/arm/mimxrt1170_evk/Kconfig.defconfig
@@ -51,15 +51,6 @@ if DISPLAY
 config MIPI_DSI
 	default y
 
-# Adjust the memory pool block size for a 720x1280 display
-config MCUX_ELCDIF_POOL_BLOCK_MAX
-	default 0x1C3000
-
-# Memory from the heap pool is used to allocate display buffers.
-# Adjust HEAP_MEM_POOL_SIZE.
-config HEAP_MEM_POOL_SIZE
-	default 4194304
-
 config REGULATOR
 	default y
 

--- a/drivers/display/Kconfig.mcux_elcdif
+++ b/drivers/display/Kconfig.mcux_elcdif
@@ -1,36 +1,22 @@
 # Copyright (c) 2019, NXP
+# Copyright (c) 2022, Basalte bv
 # SPDX-License-Identifier: Apache-2.0
+
+DT_COMPAT_NXP_IMX_ELCIF := nxp,imx-elcdif
 
 menuconfig DISPLAY_MCUX_ELCDIF
 	bool "MCUX eLCDIF driver"
 	depends on HAS_MCUX_ELCDIF
+	default $(dt_compat_enabled,$(DT_COMPAT_NXP_IMX_ELCIF))
 	help
 	  Enable support for mcux eLCDIF driver.
 
 if DISPLAY_MCUX_ELCDIF
 
-config MCUX_ELCDIF_POOL_BLOCK_NUM
-	int "Number of memory pool blocks"
-	default 2
+config MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
+	bool "Double framebuffer"
+	default y
 	help
-	  Number of blocks in the frame buffer memory pool.
-
-config MCUX_ELCDIF_POOL_BLOCK_MIN
-	hex "Minimum memory pool block size"
-	default 0x400
-	help
-	  Minimum block size in the frame buffer memory pool.
-
-config MCUX_ELCDIF_POOL_BLOCK_MAX
-	hex "Maximum memory pool block size"
-	default 0x40000
-	help
-	  Maximum block size in the frame buffer memory pool.
-
-config MCUX_ELCDIF_POOL_BLOCK_ALIGN
-	int "Alignment of memory pool blocks"
-	default 64
-	help
-	  Byte alignment in the frame buffer memory pool.
+	  Optionally use two framebuffers and alternate between them.
 
 endif # DISPLAY_MCUX_ELCDIF

--- a/drivers/display/display_mcux_elcdif.c
+++ b/drivers/display/display_mcux_elcdif.c
@@ -1,5 +1,6 @@
 /*
- * Copyright 2019-22, NXP
+ * Copyright (c) 2019-22, NXP
+ * Copyright (c) 2022, Basalte bv
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -19,34 +20,28 @@
 
 LOG_MODULE_REGISTER(display_mcux_elcdif, CONFIG_DISPLAY_LOG_LEVEL);
 
-/* Pixel formats */
-#define MCUX_ELCDIF_PIXEL_FORMAT_RGB888 0U
-#define MCUX_ELCDIF_PIXEL_FORMAT_BGR565 1U
-
-K_HEAP_DEFINE(mcux_elcdif_pool,
-	      CONFIG_MCUX_ELCDIF_POOL_BLOCK_MAX *
-	      CONFIG_MCUX_ELCDIF_POOL_BLOCK_NUM);
+#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
+#define MCUX_ELCDIF_FB_NUM 2
+#else
+#define MCUX_ELCDIF_FB_NUM 1
+#endif
 
 struct mcux_elcdif_config {
 	LCDIF_Type *base;
 	void (*irq_config_func)(const struct device *dev);
 	elcdif_rgb_mode_config_t rgb_mode;
-	uint8_t pixel_format;
+	enum display_pixel_format pixel_format;
+	size_t pixel_bytes;
+	size_t fb_bytes;
 	const struct pinctrl_dev_config *pincfg;
 	const struct gpio_dt_spec backlight_gpio;
 };
 
-struct mcux_mem_block {
-	void *data;
-};
-
 struct mcux_elcdif_data {
-	struct mcux_mem_block fb[CONFIG_MCUX_ELCDIF_POOL_BLOCK_NUM];
+	uint8_t *fb_ptr;
+	uint8_t *fb[MCUX_ELCDIF_FB_NUM];
 	struct k_sem sem;
-	size_t pixel_bytes;
-	size_t fb_bytes;
 	uint8_t write_idx;
-	enum display_pixel_format pixel_format;
 };
 
 static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
@@ -57,42 +52,49 @@ static int mcux_elcdif_write(const struct device *dev, const uint16_t x,
 	const struct mcux_elcdif_config *config = dev->config;
 	struct mcux_elcdif_data *dev_data = dev->data;
 
-	uint8_t write_idx = dev_data->write_idx;
-	uint8_t read_idx = !write_idx;
+	uint8_t write_idx = (dev_data->write_idx + 1) % MCUX_ELCDIF_FB_NUM;
 
 	int h_idx;
 	const uint8_t *src;
 	uint8_t *dst;
 
-	__ASSERT((dev_data->pixel_bytes * desc->pitch * desc->height) <=
+	__ASSERT((config->pixel_bytes * desc->pitch * desc->height) <=
 		 desc->buf_size, "Input buffer too small");
 
 	LOG_DBG("W=%d, H=%d, @%d,%d", desc->width, desc->height, x, y);
 
+#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
 	k_sem_take(&dev_data->sem, K_FOREVER);
 
-	memcpy(dev_data->fb[write_idx].data, dev_data->fb[read_idx].data,
-	       dev_data->fb_bytes);
+	memcpy(dev_data->fb[write_idx], dev_data->fb[dev_data->write_idx],
+	       config->fb_bytes);
+#else
+	/* wait for the next frame done */
+	k_sem_reset(&dev_data->sem);
+	k_sem_take(&dev_data->sem, K_FOREVER);
+#endif
 
 	src = buf;
-	dst = dev_data->fb[dev_data->write_idx].data;
-	dst += dev_data->pixel_bytes * (y * config->rgb_mode.panelWidth + x);
+	dst = dev_data->fb[write_idx];
+	dst += config->pixel_bytes * (y * config->rgb_mode.panelWidth + x);
 
 	for (h_idx = 0; h_idx < desc->height; h_idx++) {
-		memcpy(dst, src, dev_data->pixel_bytes * desc->width);
-		src += dev_data->pixel_bytes * desc->pitch;
-		dst += dev_data->pixel_bytes * config->rgb_mode.panelWidth;
+		memcpy(dst, src, config->pixel_bytes * desc->width);
+		src += config->pixel_bytes * desc->pitch;
+		dst += config->pixel_bytes * config->rgb_mode.panelWidth;
 	}
 
 #ifdef CONFIG_HAS_MCUX_CACHE
-	DCACHE_CleanByRange((uint32_t) dev_data->fb[write_idx].data,
-			    dev_data->fb_bytes);
+	DCACHE_CleanByRange((uint32_t) dev_data->fb[write_idx],
+			    config->fb_bytes);
 #endif
 
+#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
 	ELCDIF_SetNextBufferAddr(config->base,
-				 (uint32_t) dev_data->fb[write_idx].data);
+				 (uint32_t) dev_data->fb[write_idx]);
+#endif
 
-	dev_data->write_idx = read_idx;
+	dev_data->write_idx = write_idx;
 
 	return 0;
 }
@@ -108,8 +110,14 @@ static int mcux_elcdif_read(const struct device *dev, const uint16_t x,
 
 static void *mcux_elcdif_get_framebuffer(const struct device *dev)
 {
-	LOG_ERR("Direct framebuffer access not implemented");
+#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
+	LOG_ERR("Direct framebuffer access not available");
 	return NULL;
+#else
+	struct mcux_elcdif_data *dev_data = dev->data;
+
+	return dev_data->fb_ptr;
+#endif
 }
 
 static int mcux_elcdif_display_blanking_off(const struct device *dev)
@@ -144,9 +152,9 @@ static int mcux_elcdif_set_pixel_format(const struct device *dev,
 					const enum display_pixel_format
 					pixel_format)
 {
-	struct mcux_elcdif_data *dev_data = dev->data;
+	const struct mcux_elcdif_config *config = dev->config;
 
-	if (pixel_format == dev_data->pixel_format) {
+	if (pixel_format == config->pixel_format) {
 		return 0;
 	}
 	LOG_ERR("Pixel format change not implemented");
@@ -167,13 +175,12 @@ static void mcux_elcdif_get_capabilities(const struct device *dev,
 		struct display_capabilities *capabilities)
 {
 	const struct mcux_elcdif_config *config = dev->config;
-	struct mcux_elcdif_data *dev_data = dev->data;
 
 	memset(capabilities, 0, sizeof(struct display_capabilities));
 	capabilities->x_resolution = config->rgb_mode.panelWidth;
 	capabilities->y_resolution = config->rgb_mode.panelHeight;
-	capabilities->supported_pixel_formats = dev_data->pixel_format;
-	capabilities->current_pixel_format = dev_data->pixel_format;
+	capabilities->supported_pixel_formats = config->pixel_format;
+	capabilities->current_pixel_format = config->pixel_format;
 	capabilities->current_orientation = DISPLAY_ORIENTATION_NORMAL;
 }
 
@@ -193,7 +200,7 @@ static int mcux_elcdif_init(const struct device *dev)
 {
 	const struct mcux_elcdif_config *config = dev->config;
 	struct mcux_elcdif_data *dev_data = dev->data;
-	int i, err;
+	int err;
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {
@@ -211,30 +218,18 @@ static int mcux_elcdif_init(const struct device *dev)
 	rgb_mode.polarityFlags = rgb_mode.polarityFlags << LCDIF_VDCTRL0_ENABLE_POL_SHIFT;
 
 	/* Set the Pixel format */
-	if (config->pixel_format == MCUX_ELCDIF_PIXEL_FORMAT_BGR565) {
+	if (config->pixel_format == PIXEL_FORMAT_BGR_565) {
 		rgb_mode.pixelFormat = kELCDIF_PixelFormatRGB565;
-		dev_data->pixel_format = PIXEL_FORMAT_BGR_565;
-		dev_data->pixel_bytes = 2;
-	} else if (config->pixel_format == MCUX_ELCDIF_PIXEL_FORMAT_RGB888) {
+	} else if (config->pixel_format == PIXEL_FORMAT_RGB_888) {
 		rgb_mode.pixelFormat = kELCDIF_PixelFormatRGB888;
-		dev_data->pixel_format = PIXEL_FORMAT_RGB_888;
-		dev_data->pixel_bytes = 3;
 	}
 
-	dev_data->fb_bytes = dev_data->pixel_bytes *
-			 rgb_mode.panelWidth * rgb_mode.panelHeight;
-	dev_data->write_idx = 1U;
+	dev_data->fb[0] = dev_data->fb_ptr;
+#ifdef CONFIG_MCUX_ELCDIF_DOUBLE_FRAMEBUFFER
+	dev_data->fb[1] = dev_data->fb_ptr + config->fb_bytes;
+#endif
 
-	for (i = 0; i < ARRAY_SIZE(dev_data->fb); i++) {
-		dev_data->fb[i].data = k_heap_alloc(&mcux_elcdif_pool,
-						dev_data->fb_bytes, K_NO_WAIT);
-		if (dev_data->fb[i].data == NULL) {
-			LOG_ERR("Could not allocate frame buffer %d", i);
-			return -ENOMEM;
-		}
-		memset(dev_data->fb[i].data, 0, dev_data->fb_bytes);
-	}
-	rgb_mode.bufferAddr = (uint32_t) dev_data->fb[0].data;
+	rgb_mode.bufferAddr = (uint32_t) dev_data->fb_ptr;
 
 	k_sem_init(&dev_data->sem, 1, 1);
 
@@ -261,7 +256,10 @@ static const struct display_driver_api mcux_elcdif_api = {
 	.set_orientation = mcux_elcdif_set_orientation,
 };
 
-#define MCUX_ELDCIF_DEVICE(id)							\
+#define MCUX_ELCDIF_PIXEL_BYTES(id)						\
+	COND_CODE_1(DT_INST_ENUM_IDX(id, pixel_format),	(2), (3))
+
+#define MCUX_ELCDIF_DEVICE_INIT(id)						\
 	PINCTRL_DT_INST_DEFINE(id);						\
 	static void mcux_elcdif_config_func_##id(const struct device *dev);	\
 	static const struct mcux_elcdif_config mcux_elcdif_config_##id = {	\
@@ -280,11 +278,22 @@ static const struct display_driver_api mcux_elcdif_api = {
 			.dataBus = LCDIF_CTRL_LCD_DATABUS_WIDTH(		\
 					DT_INST_ENUM_IDX(id, data_buswidth)),	\
 		},								\
-		.pixel_format = DT_INST_ENUM_IDX(id, pixel_format),		\
+		.pixel_format = COND_CODE_1(DT_INST_ENUM_IDX(id, pixel_format),	\
+			(PIXEL_FORMAT_BGR_565),					\
+			(PIXEL_FORMAT_RGB_888)),				\
+		.pixel_bytes = MCUX_ELCDIF_PIXEL_BYTES(id),			\
+		.fb_bytes = DT_INST_PROP(id, width) * DT_INST_PROP(id, height)	\
+			* MCUX_ELCDIF_PIXEL_BYTES(id),				\
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(id),			\
 		.backlight_gpio = GPIO_DT_SPEC_INST_GET(id, backlight_gpios),	\
 	};									\
-	static struct mcux_elcdif_data mcux_elcdif_data_##id;			\
+	static uint8_t __aligned(64) frame_buffer_##id[MCUX_ELCDIF_FB_NUM	\
+			* DT_INST_PROP(id, width)				\
+			* DT_INST_PROP(id, height)				\
+			* MCUX_ELCDIF_PIXEL_BYTES(id)];				\
+	static struct mcux_elcdif_data mcux_elcdif_data_##id = {		\
+		.fb_ptr = frame_buffer_##id,					\
+	};									\
 	DEVICE_DT_INST_DEFINE(id,						\
 			    &mcux_elcdif_init,					\
 			    NULL,						\
@@ -303,4 +312,4 @@ static const struct display_driver_api mcux_elcdif_api = {
 		irq_enable(DT_INST_IRQN(id));					\
 	}
 
-DT_INST_FOREACH_STATUS_OKAY(MCUX_ELDCIF_DEVICE)
+DT_INST_FOREACH_STATUS_OKAY(MCUX_ELCDIF_DEVICE_INIT)


### PR DESCRIPTION
Improved the eLCDIF driver implementation:
* Optional (working) double framebuffers
* Statically allocated framebuffer(s)
* Removed obsolete Kconfig entries

Also modified the mimxrt1170 EVK default config.