### PR TITLE
samples: usb: fix flash test subsections in USB MSC sample 

### DIFF
--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -34,7 +34,7 @@ tests:
     filter: dt_compat_enabled("nordic,qspi-nor")
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
-        - CONFIG_APP_MSC_STORAGE_FLASH_LITTLEFS=y
+        - CONFIG_APP_MSC_STORAGE_FLASH_FATFS=y
     tags: msd usb
     harness: console
     harness_config:
@@ -64,7 +64,7 @@ tests:
     filter: dt_compat_enabled("nordic,qspi-nor")
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
-        - CONFIG_APP_MSC_STORAGE_FLASH_FATFS=y
+        - CONFIG_APP_MSC_STORAGE_FLASH_LITTLEFS=y
     tags: msd usb
     harness: console
     harness_config:

--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -32,6 +32,10 @@ tests:
       - fatfs
     depends_on: usb_device
     filter: dt_compat_enabled("nordic,qspi-nor")
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - adafruit_feather_nrf52840
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
         - CONFIG_APP_MSC_STORAGE_FLASH_FATFS=y
@@ -62,6 +66,10 @@ tests:
     min_ram: 32
     depends_on: usb_device
     filter: dt_compat_enabled("nordic,qspi-nor")
+    integration_platforms:
+      - nrf52840dk_nrf52840
+      - nrf5340dk_nrf5340_cpuapp
+      - adafruit_feather_nrf52840
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
         - CONFIG_APP_MSC_STORAGE_FLASH_LITTLEFS=y


### PR DESCRIPTION
samples: usb: fix flash test subsections in USB MSC sample

Test sections, mass_flash_fatfs and mass_flash_littlefs,
and corresponding Kconfig options are mixed up.


Add integration platforms to mass_flash_fatfs and mass_flash_littlefs
tests as these options are tuned for specific platforms.

Resolves: #45581