### PR TITLE
tests: kernel: common: increase timeout

### DIFF
--- a/tests/kernel/common/testcase.yaml
+++ b/tests/kernel/common/testcase.yaml
@@ -1,6 +1,7 @@
 common:
   tags: base userspace
   min_flash: 33
+  timeout: 120
 tests:
   kernel.common:
     build_on_all: true


### PR DESCRIPTION
Some platforms need more time when under load, 60s are not enough.

Seen on hifive_unleashed.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
