### PR TITLE
drivers: i2c: tca954X: Enable driver if needed

### DIFF
--- a/drivers/i2c/Kconfig.tca954x
+++ b/drivers/i2c/Kconfig.tca954x
@@ -1,8 +1,13 @@
 # Copyright (c) 2020 Innoseis BV
 # SPDX-License-Identifier: Apache-2.0
 
+DT_COMPAT_TI_TCA9546A := ti,tca9546a
+DT_COMPAT_TI_TCA9548A := ti,tca9548a
+
 menuconfig I2C_TCA954X
 	bool "I2C addressable switch"
+	default $(dt_compat_enabled,$(DT_COMPAT_TI_TCA9546A)) || \
+		$(dt_compat_enabled,$(DT_COMPAT_TI_TCA9548A))
 	help
 	  Enable TCA954x series I2C bus switch
 


### PR DESCRIPTION
TCA954X driver was not enabled since introduction of
new compatibility fields.

We now set I2C_TCA954X depending on related "okay"
compat fields in DT.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>