### PR TITLE
twister: add option to flash before opening serial port

### DIFF
--- a/scripts/schemas/twister/hwmap-schema.yaml
+++ b/scripts/schemas/twister/hwmap-schema.yaml
@@ -41,6 +41,9 @@ sequence:
       "baud":
         type: int
         required: false
+      "flash_before":
+        type: bool
+        required: false
       "post_script":
         type: str
         required: false

--- a/scripts/twister
+++ b/scripts/twister
@@ -616,6 +616,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
                         before device handler open serial port and invoke runner.
                         """)
 
+    parser.add_argument("--flash-before", action="store_true", default=False,
+                        help="""perform flash operation before device handler
+                        open serial port and invoke runner.
+                        """)
+
     parser.add_argument("-Q", "--error-on-deprecations", action="store_false",
                         help="Error on deprecation warnings.")
 
@@ -995,6 +1000,7 @@ def main():
                                    options.platform[0],
                                    options.pre_script,
                                    False,
+                                   flash_before=options.flash_before,
                                    baud=options.device_serial_baud
                                    )
                 else:


### PR DESCRIPTION
Current implementation performs the following sequence:
1) Open serial port to listen to board log output
2) Flash device

In case of ESP32 where it uses the same serial port
for both operations, flashing needs to come first.

This PR adds a twister option name --flash-before
which enables the process above, allowing tests to be
performed properly.

However, there is a caveat in this approach:
As serial port is opened after flashing, it might miss
partial log content, causing the test to failure/timeout.
In case such issue happens, we will need to work this out.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>