### PR TITLE
Bluetooth: host: Save new IRK upon rebonding

### DIFF
--- a/subsys/bluetooth/host/keys.c
+++ b/subsys/bluetooth/host/keys.c
@@ -279,6 +279,24 @@ void bt_keys_add_type(struct bt_keys *keys, int type)
 	keys->keys |= type;
 }
 
+void bt_keys_clear_other_keys_with_identity(uint8_t id, const bt_addr_le_t *id_addr,
+					    const struct bt_keys *keep_these_keys)
+{
+	for (size_t i = 0; i < ARRAY_SIZE(key_pool); i++) {
+		if (&key_pool[i] == keep_these_keys) {
+			/* Skip the keep_this_key */
+			continue;
+		}
+
+		if ((key_pool[i].id == id) && (!bt_addr_le_cmp(&key_pool[i].addr, id_addr))) {
+			/* Remove the key from the controller's resolve list */
+			bt_id_del(&key_pool[i]);
+			/* Clear this key, because it has the same id and identity address. */
+			(void)memset(&key_pool[i], 0, sizeof(key_pool[i]));
+		}
+	}
+}
+
 void bt_keys_clear(struct bt_keys *keys)
 {
 	BT_DBG("%s (keys 0x%04x)", bt_addr_le_str(&keys->addr), keys->keys);

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -83,6 +83,8 @@ struct bt_keys *bt_keys_find_irk(uint8_t id, const bt_addr_le_t *addr);
 struct bt_keys *bt_keys_find_addr(uint8_t id, const bt_addr_le_t *addr);
 
 void bt_keys_add_type(struct bt_keys *keys, int type);
+void bt_keys_clear_other_keys_with_identity(uint8_t id, const bt_addr_le_t *id_addr,
+					    const struct bt_keys *keep_these_keys);
 void bt_keys_clear(struct bt_keys *keys);
 
 #if defined(CONFIG_BT_SETTINGS)

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -3957,6 +3957,15 @@ static uint8_t smp_ident_addr_info(struct bt_smp *smp, struct net_buf *buf)
 			 * present before ie. due to re-pairing.
 			 */
 			if (!bt_addr_le_is_identity(&conn->le.dst)) {
+				/* Clear all keys with the same identity address, except for
+				 * the currently used key. This is done to make sure there is only
+				 * one entry in the key pool with the identity address in req->addr.
+				 * There might be entries from previous bondings with the same
+				 * identity as req->addr in the key pool since this new bonding
+				 * could be a re-bonding.
+				 */
+				bt_keys_clear_other_keys_with_identity(conn->id, &req->addr, keys);
+
 				bt_addr_le_copy(&keys->addr, &req->addr);
 				bt_addr_le_copy(&conn->le.dst, &req->addr);
 


### PR DESCRIPTION
Fixes #46798

Delete the identity entry in the controller's resolve list,
if it exists, and then add a new entry with the new IRK.
This will ensure that a a potentially new IRK is saved
upon rebonding.