### PR TITLE
MAINTAINERS: posix: add cfriedt as maintainer

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1416,12 +1416,13 @@ nRF52 BSIM:
         - "platform: nRF52 BSIM"
 
 POSIX API layer:
-    status: odd fixes
+    status: maintained
+    maintainers:
+        - cfriedt
     collaborators:
         - pfalcon
         - enjiamai
         - KangJianX
-        - cfriedt
     files:
         - include/zephyr/posix/
         - lib/posix/


### PR DESCRIPTION
Adding myself as maintainer of the POSIX API layer.

Signed-off-by: Christopher Friedt <cfriedt@fb.com>