### PR TITLE
drivers: display: dummy: set default pixel format through kconfig

### DIFF
--- a/drivers/display/Kconfig.dummy
+++ b/drivers/display/Kconfig.dummy
@@ -7,3 +7,33 @@ config DUMMY_DISPLAY
 	bool "Dummy display driver"
 	help
 	  Enable dummy display driver compliant with display driver API.
+
+if DUMMY_DISPLAY
+
+choice DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT
+	prompt "Default pixel format"
+	default DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888
+	help
+	  Default pixel format to be used by the display
+
+	config DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_ARGB_8888
+		bool "ARGB 8888"
+
+	config DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888
+		bool "RGB 888"
+
+	config DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01
+		bool "Mono Black=0"
+
+	config DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10
+		bool "Mono Black=1"
+
+	config DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565
+		bool "RGB 565"
+
+	config DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_565
+		bool "BGR 565"
+
+endchoice
+
+endif # DUMMY_DISPLAY

--- a/drivers/display/display_dummy.c
+++ b/drivers/display/display_dummy.c
@@ -24,7 +24,20 @@ static int dummy_display_init(const struct device *dev)
 {
 	struct dummy_display_data *disp_data = dev->data;
 
-	disp_data->current_pixel_format = PIXEL_FORMAT_ARGB_8888;
+	disp_data->current_pixel_format =
+#if defined(CONFIG_DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_888)
+		PIXEL_FORMAT_RGB_888;
+#elif defined(CONFIG_DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO01)
+		PIXEL_FORMAT_MONO01;
+#elif defined(CONFIG_DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT_MONO10)
+		PIXEL_FORMAT_MONO10;
+#elif defined(CONFIG_DEFAULT_DISPLAY_DEFAULT_PIXEL_FORMAT_RGB_565)
+		PIXEL_FORMAT_RGB_565;
+#elif defined(CONFIG_DEFAULT_DISPLAY_DEFAULT_PIXEL_FORMAT_BGR_565)
+		PIXEL_FORMAT_BGR_565;
+#else /* CONFIG_DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT */
+		PIXEL_FORMAT_ARGB_8888;
+#endif /* CONFIG_DUMMY_DISPLAY_DEFAULT_PIXEL_FORMAT */
 
 	return 0;
 }


### PR DESCRIPTION
Allow to set a desired configuration for the dummy display for testing at
build time.

Signed-off-by: nu wu42 <github-nuwu4290@mailbox.org>