### PR TITLE
python: Fix the requirement for libmagic to be installed

### DIFF
--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -93,7 +93,7 @@ The current minimum required version for the main dependencies are:
             sudo apt install --no-install-recommends git cmake ninja-build gperf \
               ccache dfu-util device-tree-compiler wget \
               python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
-              make gcc gcc-multilib g++-multilib libsdl2-dev
+              make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
 
       #. Verify the versions of the main dependencies installed on your system by entering::
 
@@ -119,7 +119,7 @@ The current minimum required version for the main dependencies are:
 
          .. code-block:: bash
 
-            brew install cmake ninja gperf python3 ccache qemu dtc wget
+            brew install cmake ninja gperf python3 ccache qemu dtc wget libmagic
 
    .. group-tab:: Windows
 

--- a/doc/develop/getting_started/installation_linux.rst
+++ b/doc/develop/getting_started/installation_linux.rst
@@ -79,7 +79,7 @@ need one.
          sudo apt-get install --no-install-recommends git cmake ninja-build gperf \
            ccache dfu-util device-tree-compiler wget \
            python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file libpython3.8-dev \
-           make gcc gcc-multilib g++-multilib libsdl2-dev
+           make gcc gcc-multilib g++-multilib libsdl2-dev libmagic1
 
    .. group-tab:: Fedora
 

--- a/scripts/requirements-compliance.txt
+++ b/scripts/requirements-compliance.txt
@@ -2,5 +2,6 @@
 
 # used by ci/check_compliance
 python-magic
+python-magic-bin; sys_platform == "win32"
 junitparser<2
 pylint


### PR DESCRIPTION
The Python python-magic module that we install for compliance checks
requires libmagic to be installed on the system to work. This requires
extra OS packages on Ubuntu and macOS, and an extra wheel on Windows.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>