### PR TITLE
kernel: pipe functions should __ASSERT if called from ISR

### DIFF
--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -87,6 +87,8 @@ void z_impl_k_pipe_flush(struct k_pipe *pipe)
 {
 	size_t  bytes_read;
 
+	__ASSERT(!arch_is_in_isr(), "pipes cannot be used inside ISRs");
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, flush, pipe);
 
 	k_spinlock_key_t key = k_spin_lock(&pipe->lock);
@@ -401,6 +403,8 @@ int z_impl_k_pipe_put(struct k_pipe *pipe, void *data, size_t bytes_to_write,
 	sys_dlist_t    xfer_list;
 	size_t         num_bytes_written = 0;
 	size_t         bytes_copied;
+
+	__ASSERT(!arch_is_in_isr(), "pipes cannot be used inside ISRs");
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, put, pipe, timeout);
 
@@ -724,6 +728,8 @@ static int pipe_get_internal(k_spinlock_key_t key, struct k_pipe *pipe,
 int z_impl_k_pipe_get(struct k_pipe *pipe, void *data, size_t bytes_to_read,
 		     size_t *bytes_read, size_t min_xfer, k_timeout_t timeout)
 {
+	__ASSERT(!arch_is_in_isr(), "pipes cannot be used inside ISRs");
+
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_pipe, get, pipe, timeout);
 
 	CHECKIF((min_xfer > bytes_to_read) || bytes_read == NULL) {


### PR DESCRIPTION
Documentation says pipes cannot be used from ISRs but we missed this. Add
__ASSERTS to enable developers to catch the issue if asserts are enabled.

In our case we were running for a few months using pipes from ISRs before
catching a corruption issue that we tracked down to misuse of pipes.

Signed-off-by: Chris Morgan <cmorgan@boston-engineering.com>