### PR TITLE
test: tests/crypto/tinycrypt timeout

### DIFF
--- a/tests/crypto/tinycrypt/testcase.yaml
+++ b/tests/crypto/tinycrypt/testcase.yaml
@@ -2,7 +2,7 @@ tests:
   crypto.tinycrypt:
     tags: tinycrypt crypto aes ccm
     platform_exclude: qemu_arc_em qemu_arc_hs intel_adsp_cavs15 m2gl025_miv
-    timeout: 300
+    timeout: 500
     integration_platforms:
       - native_posix
     toolchain_exclude: xcc


### PR DESCRIPTION
It takes more than 300 seconds to finish the test in twister,
so enlarge the timeout value from 300 to 500(seconds)

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>