### PR TITLE
sensor: iis2mdc: spi: Fix use of deprecated spi_cs_control field

### DIFF
--- a/drivers/sensor/iis2mdc/iis2mdc_spi.c
+++ b/drivers/sensor/iis2mdc/iis2mdc_spi.c
@@ -98,7 +98,7 @@ int iis2mdc_spi_init(const struct device *dev)
 	const struct iis2mdc_dev_config *const cfg = dev->config;
 	const struct spi_cs_control *cs_ctrl = cfg->bus_cfg.spi_cfg.cs;
 
-	if (!device_is_ready(cs_ctrl->gpio_dev)) {
+	if (!device_is_ready(cs_ctrl->gpio.port)) {
 		LOG_ERR("Cannot get pointer to CS gpio device");
 		return -ENODEV;
 	}


### PR DESCRIPTION
The gpio_dev field of struct spi_cs_control is deprecated.  The
driver was already using SPI_CONFIG_DT_INST, so we should be
using the associated gpio member of spi_cs_control.

Signed-off-by: Kumar Gala <galak@kernel.org>