### PR TITLE
samples: boards: nrfx_prs: Fix use of deprecated spi_cs_control fields

### DIFF
--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -288,9 +288,7 @@ static bool background_transfer(const struct device *spi_dev)
 	static const uint8_t tx_buffer[] = "Nordic Semiconductor";
 	static uint8_t rx_buffer[sizeof(tx_buffer)];
 	static const struct spi_cs_control spi_dev_cs_ctrl = {
-		.gpio_dev = DEVICE_DT_GET(DT_GPIO_CTLR(SPI_DEV_NODE, cs_gpios)),
-		.gpio_pin = DT_GPIO_PIN(SPI_DEV_NODE, cs_gpios),
-		.gpio_dt_flags = DT_GPIO_FLAGS(SPI_DEV_NODE, cs_gpios)
+		.gpio = GPIO_DT_SPEC_GET(SPI_DEV_NODE, cs_gpios),
 	};
 	static const struct spi_config spi_dev_cfg = {
 		.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(8) |


### PR DESCRIPTION
The gpio_dev, gpio_pin, etc fields of struct spi_cs_control are
deprecated.  Move to using the gpio field.

Signed-off-by: Kumar Gala <galak@kernel.org>