### PR TITLE
tests: i2c_target_api: Fix project name

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/CMakeLists.txt
+++ b/tests/drivers/i2c/i2c_target_api/CMakeLists.txt
@@ -3,7 +3,7 @@
 cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(i2c_slave_api)
+project(i2c_target_api)
 
 add_subdirectory(common)
 


### PR DESCRIPTION
In renaming of I2C terminology this project name in CMakeLists.txt
got missed.  Should be i2c_target_api.

Signed-off-by: Kumar Gala <galak@kernel.org>