### PR TITLE
tests: eeprom: use DEVICE_DT_GET

### DIFF
--- a/tests/drivers/eeprom/src/main.c
+++ b/tests/drivers/eeprom/src/main.c
@@ -11,15 +11,12 @@
 #include <zephyr/device.h>
 
 /* There is no obvious way to pass this to tests, so use a global */
-ZTEST_BMEM static const char *eeprom_label;
+ZTEST_BMEM static const struct device *eeprom;
 
 /* Test retrieval of eeprom size */
 static void test_size(void)
 {
-	const struct device *eeprom;
 	size_t size;
-
-	eeprom = device_get_binding(eeprom_label);
 
 	size = eeprom_get_size(eeprom);
 	zassert_not_equal(0, size, "Unexpected size of zero bytes");
@@ -29,11 +26,9 @@ static void test_size(void)
 static void test_out_of_bounds(void)
 {
 	const uint8_t data[4] = { 0x01, 0x02, 0x03, 0x03 };
-	const struct device *eeprom;
 	size_t size;
 	int rc;
 
-	eeprom = device_get_binding(eeprom_label);
 	size = eeprom_get_size(eeprom);
 
 	rc = eeprom_write(eeprom, size - 1, data, sizeof(data));
@@ -46,12 +41,10 @@ static void test_write_rewrite(void)
 	const uint8_t wr_buf1[4] = { 0xFF, 0xEE, 0xDD, 0xCC };
 	const uint8_t wr_buf2[sizeof(wr_buf1)] = { 0xAA, 0xBB, 0xCC, 0xDD };
 	uint8_t rd_buf[sizeof(wr_buf1)];
-	const struct device *eeprom;
 	size_t size;
 	off_t address;
 	int rc;
 
-	eeprom = device_get_binding(eeprom_label);
 	size = eeprom_get_size(eeprom);
 
 	address = 0;
@@ -88,12 +81,10 @@ static void test_write_at_fixed_address(void)
 {
 	const uint8_t wr_buf1[4] = { 0xFF, 0xEE, 0xDD, 0xCC };
 	uint8_t rd_buf[sizeof(wr_buf1)];
-	const struct device *eeprom;
 	size_t size;
 	const off_t address = 0;
 	int rc;
 
-	eeprom = device_get_binding(eeprom_label);
 	size = eeprom_get_size(eeprom);
 
 	for (int i = 0; i < 16; i++) {
@@ -113,10 +104,7 @@ static void test_write_byte(void)
 {
 	const uint8_t wr = 0x00;
 	uint8_t rd = 0xff;
-	const struct device *eeprom;
 	int rc;
-
-	eeprom = device_get_binding(eeprom_label);
 
 	for (off_t address = 0; address < 16; address++) {
 		rc = eeprom_write(eeprom, address, &wr, 1);
@@ -135,10 +123,7 @@ static void test_write_at_increasing_address(void)
 	const uint8_t wr_buf1[8] = {0xEE, 0xDD, 0xCC, 0xBB, 0xFF, 0xEE, 0xDD,
 				    0xCC };
 	uint8_t rd_buf[sizeof(wr_buf1)];
-	const struct device *eeprom;
 	int rc;
-
-	eeprom = device_get_binding(eeprom_label);
 
 	for (off_t address = 0; address < 4; address++) {
 		rc = eeprom_write(eeprom, address, wr_buf1, sizeof(wr_buf1));
@@ -158,10 +143,7 @@ static void test_zero_length_write(void)
 	const uint8_t wr_buf1[4] = { 0x10, 0x20, 0x30, 0x40 };
 	const uint8_t wr_buf2[sizeof(wr_buf1)] = { 0xAA, 0xBB, 0xCC, 0xDD };
 	uint8_t rd_buf[sizeof(wr_buf1)];
-	const struct device *eeprom;
 	int rc;
-
-	eeprom = device_get_binding(eeprom_label);
 
 	rc = eeprom_write(eeprom, 0, wr_buf1, sizeof(wr_buf1));
 	zassert_equal(0, rc, "Unexpected error code (%d)", rc);
@@ -183,22 +165,18 @@ static void test_zero_length_write(void)
 }
 
 /* Run all of our tests on EEPROM device with the given label */
-static void run_tests_on_eeprom(const char *label_eeprom, const char *label_i2c)
+static void run_tests_on_eeprom(const struct device *eeprom_dev, const struct device *i2c)
 {
-	const struct device *eeprom = device_get_binding(label_eeprom);
-	const struct device *i2c;
+	zassert_true(device_is_ready(eeprom_dev), "EEPROM device is NOT ready");
 
-	zassert_not_null(eeprom, "Unable to get EEPROM device");
-	k_object_access_grant(eeprom, k_current_get());
-	eeprom_label = label_eeprom;
-	if (label_i2c != NULL) {
-		i2c = device_get_binding(label_i2c);
-		if (i2c != NULL) {
-			/* If the test is using I2C, configure it */
-			k_object_access_grant(i2c, k_current_get());
-			i2c_configure(i2c, I2C_MODE_CONTROLLER |
-					I2C_SPEED_SET(I2C_SPEED_STANDARD));
-		}
+	k_object_access_grant(eeprom_dev, k_current_get());
+	eeprom = eeprom_dev;
+	/* if i2c is NULL, device_is_ready will report false */
+	if (device_is_ready(i2c)) {
+		/* If the test is using I2C, configure it */
+		k_object_access_grant(i2c, k_current_get());
+		i2c_configure(i2c, I2C_MODE_CONTROLLER |
+				I2C_SPEED_SET(I2C_SPEED_STANDARD));
 	}
 
 	ztest_test_suite(eeprom_api,
@@ -214,22 +192,22 @@ static void run_tests_on_eeprom(const char *label_eeprom, const char *label_i2c)
 
 void test_main(void)
 {
-	const char *i2c_eeprom_0;
+	const struct device *i2c_eeprom_0;
 #ifdef DT_N_ALIAS_eeprom_1
-	const char *i2c_eeprom_1;
+	const struct device *i2c_eeprom_1;
 #endif
 
 	i2c_eeprom_0 = COND_CODE_1(DT_NODE_EXISTS(DT_BUS(DT_ALIAS(eeprom_0))),
-			(DT_BUS_LABEL(DT_ALIAS(eeprom_0))), (NULL));
+			(DEVICE_DT_GET(DT_BUS(DT_ALIAS(eeprom_0)))), (NULL));
 #ifdef DT_N_ALIAS_eeprom_1
 	i2c_eeprom_1 = COND_CODE_1(DT_NODE_EXISTS(DT_BUS(DT_ALIAS(eeprom_1))),
-			(DT_BUS_LABEL(DT_ALIAS(eeprom_1))), (NULL));
+			(DEVICE_DT_GET(DT_BUS(DT_ALIAS(eeprom_1)))), (NULL));
 #endif
 
-	run_tests_on_eeprom(DT_LABEL(DT_ALIAS(eeprom_0)), i2c_eeprom_0);
+	run_tests_on_eeprom(DEVICE_DT_GET(DT_ALIAS(eeprom_0)), i2c_eeprom_0);
 
 #ifdef DT_N_ALIAS_eeprom_1
-	run_tests_on_eeprom(DT_LABEL(DT_ALIAS(eeprom_1)), i2c_eeprom_1);
+	run_tests_on_eeprom(DEVICE_DT_GET(DT_ALIAS(eeprom_1)), i2c_eeprom_1);
 #endif
 
 }


### PR DESCRIPTION
Convert test to use DEVICE_DT_GET instead of device_get_binding
to help phase out use of DT_BUS_LABEL.

Signed-off-by: Kumar Gala <galak@kernel.org>