### PR TITLE
soc/xtensa/intel_adsp/tools: Dial back stream reset sleep

### DIFF
--- a/soc/xtensa/intel_adsp/tools/cavstool.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool.py
@@ -469,7 +469,7 @@ def load_firmware(fw_file):
     # chromebook) putting the two writes next each other also hangs
     # the DSP!
     sd.CTL &= ~2 # clear START
-    time.sleep(1)
+    time.sleep(0.1)
     sd.CTL |= 1
     log.info(f"cAVS firmware load complete")
 


### PR DESCRIPTION
A full second is too much, and since "Ack local interrupt before
processing IPC" patch, it doesn't seem necessary. This whole second
wait would break tests that log too much content, as the firmware
is already running during the reset - and the host script wouldn't read
the contents, thus some of the logs would be overwritten.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>

---

Fixes #44338

This should address the (second coming) of https://github.com/zephyrproject-rtos/zephyr/issues/44338 - hopefully, without breaking https://github.com/zephyrproject-rtos/zephyr/issues/44925 again.