### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/assigner.yml
+++ b/.github/workflows/assigner.yml
@@ -11,6 +11,9 @@ on:
     - main
     - v*-branch
 
+permissions:
+  contents: read
+
 jobs:
   assignment:
     name: Pull Request Assignment

--- a/.github/workflows/bluetooth-tests.yaml
+++ b/.github/workflows/bluetooth-tests.yaml
@@ -11,8 +11,13 @@ on:
       - "soc/posix/**"
       - "arch/posix/**"
 
+permissions:
+  contents: read
+
 jobs:
   bluetooth-test-prep:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -4,6 +4,8 @@ on: pull_request_target
 
 jobs:
   clang-build-prep:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   codecov-prep:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:

--- a/.github/workflows/coding_guidelines.yml
+++ b/.github/workflows/coding_guidelines.yml
@@ -2,6 +2,9 @@ name: Coding Guidelines
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   compliance_job:
     runs-on: ubuntu-latest

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -2,6 +2,9 @@ name: Compliance Checks
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   maintainer_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/daily_test_version.yml
+++ b/.github/workflows/daily_test_version.yml
@@ -10,6 +10,9 @@ on:
     branches:
       - refs/tags/*
 
+permissions:
+  contents: read
+
 jobs:
   get_version:
     runs-on: ubuntu-latest

--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -14,6 +14,9 @@ on:
     - 'scripts/dts/**'
     - '.github/workflows/devicetree_checks.yml'
 
+permissions:
+  contents: read
+
 jobs:
   devicetree-checks:
     name: Devicetree script tests

--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -4,8 +4,13 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   do-not-merge:
+    permissions:
+      contents: none
     if: ${{ contains(github.event.*.labels.*.name, 'DNM') }}
     name: Prevent Merging
     runs-on: ubuntu-latest

--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -32,6 +32,9 @@ env:
   CMAKE_VERSION: 3.20.5
   DOXYGEN_VERSION: 1.9.4
 
+permissions:
+  contents: read
+
 jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"

--- a/.github/workflows/doc-publish.yml
+++ b/.github/workflows/doc-publish.yml
@@ -13,8 +13,14 @@ on:
     types:
     - completed
 
+permissions:
+  contents: read
+
 jobs:
   doc-publish:
+    permissions:
+      actions: read  # for dawidd6/action-download-artifact to query and download artifacts
+      pull-requests: read  # for dawidd6/action-download-artifact to query commit hash
     name: Publish Documentation
     runs-on: ubuntu-latest
     if: |

--- a/.github/workflows/errno.yml
+++ b/.github/workflows/errno.yml
@@ -6,6 +6,9 @@ on:
       - 'lib/libc/minimal/include/errno.h'
       - 'scripts/ci/errno.py'
 
+permissions:
+  contents: read
+
 jobs:
   check-errno:
     runs-on: ubuntu-latest

--- a/.github/workflows/footprint-tracking.yml
+++ b/.github/workflows/footprint-tracking.yml
@@ -13,8 +13,13 @@ on:
       # same commit
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   footprint-tracking-cancel:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:

--- a/.github/workflows/footprint.yml
+++ b/.github/workflows/footprint.yml
@@ -2,8 +2,13 @@ name: Footprint Delta
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   footprint-cancel:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
     steps:
@@ -12,6 +17,9 @@ jobs:
         with:
           access_token: ${{ github.token }}
   footprint-delta:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
+      contents: read  # for actions/checkout to fetch code
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'
     needs: footprint-cancel

--- a/.github/workflows/stale_issue.yml
+++ b/.github/workflows/stale_issue.yml
@@ -3,8 +3,14 @@ on:
   schedule:
   - cron: "16 00 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   stale:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     name: Find Stale issues and PRs
     runs-on: ubuntu-latest
     if: github.repository == 'zephyrproject-rtos/zephyr'

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   twister-build-cleanup:
+    permissions:
+      actions: write  # for styfle/cancel-workflow-action to cancel/stop running workflows
     runs-on: ubuntu-latest
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -17,6 +17,9 @@ on:
     - 'scripts/tests/twister/**'
     - '.github/workflows/twister_tests.yml'
 
+permissions:
+  contents: read
+
 jobs:
   twister-tests:
     name: Twister Unit Tests

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -15,6 +15,9 @@ on:
     - 'scripts/west_commands/**'
     - '.github/workflows/west_cmds.yml'
 
+permissions:
+  contents: read
+
 jobs:
   west-commnads:
     name: West Command Tests


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: nathannaveen <42319948+nathannaveen@users.noreply.github.com>
