### PR TITLE
drivers: sensor: lis2dh: Update driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/lis2dh/lis2dh.h
+++ b/drivers/sensor/lis2dh/lis2dh.h
@@ -182,7 +182,7 @@ union lis2dh_sample {
 
 union lis2dh_bus_cfg {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-	uint16_t i2c_slv_addr;
+	struct i2c_dt_spec i2c;
 #endif
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
@@ -198,7 +198,6 @@ struct temperature {
 };
 
 struct lis2dh_config {
-	const char *bus_name;
 	int (*bus_init)(const struct device *dev);
 	const union lis2dh_bus_cfg bus_cfg;
 #ifdef CONFIG_LIS2DH_TRIGGER

--- a/drivers/sensor/lis2dh/lis2dh_i2c.c
+++ b/drivers/sensor/lis2dh/lis2dh_i2c.c
@@ -23,56 +23,43 @@ LOG_MODULE_DECLARE(lis2dh, CONFIG_SENSOR_LOG_LEVEL);
 static int lis2dh_i2c_read_data(const struct device *dev, uint8_t reg_addr,
 				 uint8_t *value, uint8_t len)
 {
-	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
 
-	return i2c_burst_read(data->bus, cfg->bus_cfg.i2c_slv_addr,
-			      reg_addr | LIS2DH_AUTOINCREMENT_ADDR,
-			      value, len);
+	return i2c_burst_read_dt(&cfg->bus_cfg.i2c, reg_addr | LIS2DH_AUTOINCREMENT_ADDR, value,
+				 len);
 }
 
 static int lis2dh_i2c_write_data(const struct device *dev, uint8_t reg_addr,
 				  uint8_t *value, uint8_t len)
 {
-	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
 
-	return i2c_burst_write(data->bus, cfg->bus_cfg.i2c_slv_addr,
-			       reg_addr | LIS2DH_AUTOINCREMENT_ADDR,
-			       value, len);
+	return i2c_burst_write_dt(&cfg->bus_cfg.i2c, reg_addr | LIS2DH_AUTOINCREMENT_ADDR, value,
+				  len);
 }
 
 static int lis2dh_i2c_read_reg(const struct device *dev, uint8_t reg_addr,
 				uint8_t *value)
 {
-	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
 
-	return i2c_reg_read_byte(data->bus,
-				 cfg->bus_cfg.i2c_slv_addr,
-				 reg_addr, value);
+	return i2c_reg_read_byte_dt(&cfg->bus_cfg.i2c, reg_addr, value);
 }
 
 static int lis2dh_i2c_write_reg(const struct device *dev, uint8_t reg_addr,
 				uint8_t value)
 {
-	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
 
-	return i2c_reg_write_byte(data->bus,
-				  cfg->bus_cfg.i2c_slv_addr,
-				  reg_addr, value);
+	return i2c_reg_write_byte_dt(&cfg->bus_cfg.i2c, reg_addr, value);
 }
 
 static int lis2dh_i2c_update_reg(const struct device *dev, uint8_t reg_addr,
 				  uint8_t mask, uint8_t value)
 {
-	struct lis2dh_data *data = dev->data;
 	const struct lis2dh_config *cfg = dev->config;
 
-	return i2c_reg_update_byte(data->bus,
-				   cfg->bus_cfg.i2c_slv_addr,
-				   reg_addr, mask, value);
+	return i2c_reg_update_byte_dt(&cfg->bus_cfg.i2c, reg_addr, mask, value);
 }
 
 static const struct lis2dh_transfer_function lis2dh_i2c_transfer_fn = {
@@ -86,6 +73,12 @@ static const struct lis2dh_transfer_function lis2dh_i2c_transfer_fn = {
 int lis2dh_i2c_init(const struct device *dev)
 {
 	struct lis2dh_data *data = dev->data;
+	const struct lis2dh_config *cfg = dev->config;
+
+	if (!device_is_ready(cfg->bus_cfg.i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
+		return -ENODEV;
+	}
 
 	data->hw_tf = &lis2dh_i2c_transfer_fn;
 


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>