### PR TITLE
logging: adsp: Allow format timestamp

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -136,7 +136,8 @@ config LOG_TAG_DEFAULT
 config LOG_BACKEND_FORMAT_TIMESTAMP
 	bool "Timestamp formatting in the backend"
 	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
-	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM || LOG_BACKEND_FS
+	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM || LOG_BACKEND_FS \
+	           || LOG_BACKEND_ADSP
 	default y
 	help
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.


### PR DESCRIPTION
LOG_BACKEND_ADSP supports LOG_BACKEND_FORMAT_TIMESTAMP.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>