### PR TITLE
ITE tests/kernel/sleep: tune CONFIG_SYS_CLOCK_TICKS_PER_SEC down

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -26,7 +26,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 8192
+	default 4096
 
 config UART_NS16550
 	default y


### PR DESCRIPTION
We need more time to run codes because of the performance,
so I tune CONFIG_SYS_CLOCK_TICKS_PER_SEC down to reduce
the times of running k_usleep(1), then it can pass test_usleep().

Verified by follow test pattern:
west build -p always -b it8xxx2_evb tests/kernel/sleep

fixes #46208

Signed-off-by: Ruibin Chang <Ruibin.Chang@ite.com.tw>