### PR TITLE
drivers: modem: delay after each AT command

### DIFF
--- a/drivers/modem/modem_cmd_handler.c
+++ b/drivers/modem/modem_cmd_handler.c
@@ -569,9 +569,6 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 	size_t i;
 
 	for (i = 0; i < cmds_len; i++) {
-		if (i) {
-			k_sleep(K_MSEC(50));
-		}
 
 		if (cmds[i].handle_cmd.cmd && cmds[i].handle_cmd.func) {
 			ret = modem_cmd_send(iface, handler,
@@ -583,6 +580,8 @@ int modem_cmd_handler_setup_cmds(struct modem_iface *iface,
 					     NULL, 0, cmds[i].send_cmd,
 					     sem, timeout);
 		}
+
+		k_sleep(K_MSEC(50));
 
 		if (ret < 0) {
 			LOG_ERR("command %s ret:%d",
@@ -605,9 +604,6 @@ int modem_cmd_handler_setup_cmds_nolock(struct modem_iface *iface,
 	size_t i;
 
 	for (i = 0; i < cmds_len; i++) {
-		if (i) {
-			k_sleep(K_MSEC(50));
-		}
 
 		if (cmds[i].handle_cmd.cmd && cmds[i].handle_cmd.func) {
 			ret = modem_cmd_send_nolock(iface, handler,
@@ -619,6 +615,8 @@ int modem_cmd_handler_setup_cmds_nolock(struct modem_iface *iface,
 						    NULL, 0, cmds[i].send_cmd,
 						    sem, timeout);
 		}
+
+		k_sleep(K_MSEC(50));
 
 		if (ret < 0) {
 			LOG_ERR("command %s ret:%d",


### PR DESCRIPTION
Change logic in `modem_cmd_handler_setup_cmds` and
`modem_cmd_handler_setup_cmds_nolock` to always sleep
after each sent AT command.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/47082

Signed-off-by: Jeppe Odgaard <jeppe.odgaard@prevas.dk>