### PR TITLE
logging: Hide log macros from CLion parser

### DIFF
--- a/include/zephyr/logging/log.h
+++ b/include/zephyr/logging/log.h
@@ -418,10 +418,10 @@ void z_log_vprintk(const char *fmt, va_list ap);
 				Z_LOG_RESOLVED_LEVEL(level, 0)
 
 /*
- * Eclipse CDT parser is sometimes confused by logging API code and freezes the
- * whole IDE. Following lines hides LOG_x macros from CDT.
+ * The logging macros are too complex for some IDEs and can cause freezes.
+ * Following lines hide LOG_x macros from Eclipse CDT and CLion.
  */
-#if defined(__CDT_PARSER__)
+#if defined(__CDT_PARSER__) || defined(__CLION_IDE__)
 #undef LOG_ERR
 #undef LOG_WRN
 #undef LOG_INF


### PR DESCRIPTION
The LOG_x macros are too complex for the CLion parser and cause significant IDE performance issues.
Modifies the existing Eclipse CDT workaround to also apply to CLion.

Signed-off-by: Jack Dähn <jack@jkdhn.me>