### PR TITLE
doc: doxygen: strip include/ from path

### DIFF
--- a/doc/zephyr.doxyfile.in
+++ b/doc/zephyr.doxyfile.in
@@ -152,7 +152,7 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        = @ZEPHYR_BASE@
+STRIP_FROM_PATH        = @ZEPHYR_BASE@/include
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which


### PR DESCRIPTION
Include hints shown in the Doxygen documentation need to exclude
'include/' so that we have, e.g. <zephyr/sys/crc.h> and not
<include/zephyr/sys/crc.h>.