### PR TITLE
Stm32 clock ctrl common pll alternate clock sources + related fixes

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -178,7 +178,7 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 						clock_control_subsys_t sub_system,
 						void *data)
 {
-#if defined(STM32_SRC_CLOCK_MIN)
+#if defined(STM32_SRC_SYSCLK)
 	/* At least one alt src clock available */
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	volatile uint32_t *reg;

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -50,6 +50,21 @@
 #define RCC_PLLP_ENABLE() SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN)
 #define RCC_PLLQ_ENABLE() SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN)
 
+/**
+ * @brief Return frequency for pll with 2 dividers and a multiplier
+ */
+__unused
+static uint32_t get_pll_div_frequency(uint32_t pllsrc_freq,
+				      int pllm_div,
+				      int plln_mul,
+				      int pllout_div)
+{
+	__ASSERT_NO_MSG(pllm_div && pllout_div);
+
+	return (pllsrc_freq * plln_mul) /
+		(pllm_div * pllout_div);
+}
+
 static uint32_t get_bus_clock(uint32_t clock, uint32_t prescaler)
 {
 	return clock / prescaler;
@@ -126,6 +141,27 @@ static int enabled_clock(uint32_t src_clk)
 		}
 		break;
 #endif /* STM32_SRC_PLLCLK */
+#if defined(STM32_SRC_PLL_P)
+	case STM32_SRC_PLL_P:
+		if (!IS_ENABLED(STM32_PLL_P_ENABLED)) {
+			r = -ENOTSUP;
+		}
+		break;
+#endif /* STM32_SRC_PLL_P */
+#if defined(STM32_SRC_PLL_Q)
+	case STM32_SRC_PLL_Q:
+		if (!IS_ENABLED(STM32_PLL_Q_ENABLED)) {
+			r = -ENOTSUP;
+		}
+		break;
+#endif /* STM32_SRC_PLL_Q */
+#if defined(STM32_SRC_PLL_R)
+	case STM32_SRC_PLL_R:
+		if (!IS_ENABLED(STM32_PLL_R_ENABLED)) {
+			r = -ENOTSUP;
+		}
+		break;
+#endif /* STM32_SRC_PLL_R */
 	default:
 		return -ENOTSUP;
 	}
@@ -294,6 +330,33 @@ static int stm32_clock_control_get_subsys_rate(const struct device *clock,
 		*rate = get_pllout_frequency();
 		break;
 #endif
+#if defined(STM32_SRC_PLL_P) & STM32_PLL_P_ENABLED
+	case STM32_SRC_PLL_P:
+		*rate = get_pll_div_frequency(get_pllsrc_frequency(),
+					      STM32_PLL_M_DIVISOR,
+					      STM32_PLL_N_MULTIPLIER,
+					      STM32_PLL_P_DIVISOR);
+		break;
+#endif
+#if defined(STM32_SRC_PLL_Q) & STM32_PLL_Q_ENABLED
+	case STM32_SRC_PLL_Q:
+		*rate = get_pll_div_frequency(get_pllsrc_frequency(),
+					      STM32_PLL_M_DIVISOR,
+					      STM32_PLL_N_MULTIPLIER,
+					      STM32_PLL_Q_DIVISOR);
+		break;
+#endif
+#if defined(STM32_SRC_PLL_R) & STM32_PLL_R_ENABLED
+	case STM32_SRC_PLL_R:
+		*rate = get_pll_div_frequency(get_pllsrc_frequency(),
+					      STM32_PLL_M_DIVISOR,
+					      STM32_PLL_N_MULTIPLIER,
+					      STM32_PLL_R_DIVISOR);
+		break;
+#endif
+/* PLLSAI1x not supported yet */
+/* PLLSAI2x not supported yet */
+/* PLLI2Sx not supported yet */
 #if defined(STM32_SRC_LSE)
 	case STM32_SRC_LSE:
 		*rate = STM32_LSE_FREQ;

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -397,9 +397,7 @@ static void set_up_plls(void)
 #endif
 
 #if STM32_PLL_Q_ENABLED
-	MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ,
-		   STM32_PLL_Q_DIVISOR
-		   << RCC_PLLCFGR_PLLQ_Pos);
+	MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ, pllq(STM32_PLL_Q_DIVISOR));
 #endif
 
 	config_pll_sysclock();

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -47,6 +47,9 @@
 #define GET_CURRENT_FLASH_PRESCALER LL_RCC_GetAHBPrescaler
 #endif
 
+#define RCC_PLLP_ENABLE() SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN)
+#define RCC_PLLQ_ENABLE() SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN)
+
 static uint32_t get_bus_clock(uint32_t clock, uint32_t prescaler)
 {
 	return clock / prescaler;
@@ -396,8 +399,13 @@ static void set_up_plls(void)
 	}
 #endif
 
-#if STM32_PLL_Q_ENABLED
+#if defined(STM32_SRC_PLL_P) & STM32_PLL_P_ENABLED
+	MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLP, pllp(STM32_PLL_P_DIVISOR));
+	RCC_PLLP_ENABLE();
+#endif
+#if defined(STM32_SRC_PLL_Q) & STM32_PLL_Q_ENABLED
 	MODIFY_REG(RCC->PLLCFGR, RCC_PLLCFGR_PLLQ, pllq(STM32_PLL_Q_DIVISOR));
+	RCC_PLLQ_ENABLE();
 #endif
 
 	config_pll_sysclock();

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -48,6 +48,7 @@
 #ifdef STM32_SYSCLK_SRC_PLL
 void config_pll_sysclock(void);
 uint32_t get_pllout_frequency(void);
+uint32_t get_pllsrc_frequency(void);
 #endif
 void config_enable_default_clocks(void);
 

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -32,6 +32,19 @@
 	#define MCO2_SOURCE		LL_RCC_MCO2SOURCE_PLLCLK
 #endif
 
+/* Macros to fill up multiplication and division factors values */
+#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
+#define pllm(v) z_pllm(v)
+
+#define z_pllp(v) LL_RCC_PLLP_DIV_ ## v
+#define pllp(v) z_pllp(v)
+
+#define z_pllq(v) LL_RCC_PLLQ_DIV_ ## v
+#define pllq(v) z_pllq(v)
+
+#define z_pllr(v) LL_RCC_PLLR_DIV_ ## v
+#define pllr(v) z_pllr(v)
+
 #ifdef STM32_SYSCLK_SRC_PLL
 void config_pll_sysclock(void);
 uint32_t get_pllout_frequency(void);

--- a/drivers/clock_control/clock_stm32_ll_common.h
+++ b/drivers/clock_control/clock_stm32_ll_common.h
@@ -45,7 +45,7 @@
 #define z_pllr(v) LL_RCC_PLLR_DIV_ ## v
 #define pllr(v) z_pllr(v)
 
-#ifdef STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 void config_pll_sysclock(void);
 uint32_t get_pllout_frequency(void);
 uint32_t get_pllsrc_frequency(void);

--- a/drivers/clock_control/clock_stm32f0_f3.c
+++ b/drivers/clock_control/clock_stm32f0_f3.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 
 /**
  * @brief Set up pll configuration
@@ -137,7 +137,7 @@ uint32_t get_pllout_frequency(void)
 #endif /* RCC_PLLSRC_PREDIV1_SUPPORT */
 }
 
-#endif /* STM32_SYSCLK_SRC_PLL */
+#endif /* defined(STM32_PLL_ENABLED) */
 
 /**
  * @brief Activate default clocks

--- a/drivers/clock_control/clock_stm32f1.c
+++ b/drivers/clock_control/clock_stm32f1.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 
 /*
  * Select PLL source for STM32F1 Connectivity line devices (STM32F105xx and
@@ -95,7 +95,7 @@ void config_pll_sysclock(void)
 	LL_RCC_PLL_ConfigDomain_SYS(pll_source, pll_mul);
 }
 
-#endif /* STM32_SYSCLK_SRC_PLL */
+#endif /* defined(STM32_PLL_ENABLED) */
 
 /**
  * @brief Activate default clocks

--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 
 /**
  * @brief Return PLL source
@@ -57,7 +57,7 @@ uint32_t get_pllout_frequency(void)
 					 pllp(STM32_PLL_P_DIVISOR));
 }
 
-#endif /* STM32_SYSCLK_SRC_PLL */
+#endif /* defined(STM32_PLL_ENABLED) */
 
 /**
  * @brief Activate default clocks

--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -17,13 +17,6 @@
 
 #if STM32_SYSCLK_SRC_PLL
 
-/* Macros to fill up division factors values */
-#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
-#define pllm(v) z_pllm(v)
-
-#define z_pllp(v) LL_RCC_PLLP_DIV_ ## v
-#define pllp(v) z_pllp(v)
-
 /**
  * @brief Return PLL source
  */

--- a/drivers/clock_control/clock_stm32g0.c
+++ b/drivers/clock_control/clock_stm32g0.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 
 /**
  * @brief Return PLL source
@@ -78,7 +78,7 @@ uint32_t get_pllout_frequency(void)
 					 pllr(STM32_PLL_R_DIVISOR));
 }
 
-#endif /* STM32_SYSCLK_SRC_PLL */
+#endif /* defined(STM32_PLL_ENABLED) */
 
 /**
  * @brief Activate default clocks

--- a/drivers/clock_control/clock_stm32g0.c
+++ b/drivers/clock_control/clock_stm32g0.c
@@ -65,19 +65,6 @@ void config_pll_sysclock(void)
 	LL_RCC_PLL_EnableDomain_SYS();
 }
 
-
-/**
- * @brief Return pllout frequency
- */
-__unused
-uint32_t get_pllout_frequency(void)
-{
-	return __LL_RCC_CALC_PLLCLK_FREQ(get_pll_source(),
-					 pllm(STM32_PLL_M_DIVISOR),
-					 STM32_PLL_N_MULTIPLIER,
-					 pllr(STM32_PLL_R_DIVISOR));
-}
-
 #endif /* defined(STM32_PLL_ENABLED) */
 
 /**

--- a/drivers/clock_control/clock_stm32g0.c
+++ b/drivers/clock_control/clock_stm32g0.c
@@ -18,13 +18,6 @@
 
 #if STM32_SYSCLK_SRC_PLL
 
-/* Macros to fill up multiplication and division factors values */
-#define z_pll_div(v) LL_RCC_PLLM_DIV_ ## v
-#define pll_div(v) z_pll_div(v)
-
-#define z_pllr(v) LL_RCC_PLLR_DIV_ ## v
-#define pllr(v) z_pllr(v)
-
 /**
  * @brief Return PLL source
  */
@@ -49,7 +42,7 @@ __unused
 void config_pll_sysclock(void)
 {
 	LL_RCC_PLL_ConfigDomain_SYS(get_pll_source(),
-				    pll_div(STM32_PLL_M_DIVISOR),
+				    pllm(STM32_PLL_M_DIVISOR),
 				    STM32_PLL_N_MULTIPLIER,
 				    pllr(STM32_PLL_R_DIVISOR));
 
@@ -64,7 +57,7 @@ __unused
 uint32_t get_pllout_frequency(void)
 {
 	return __LL_RCC_CALC_PLLCLK_FREQ(get_pll_source(),
-					 pll_div(STM32_PLL_M_DIVISOR),
+					 pllm(STM32_PLL_M_DIVISOR),
 					 STM32_PLL_N_MULTIPLIER,
 					 pllr(STM32_PLL_R_DIVISOR));
 }

--- a/drivers/clock_control/clock_stm32g0.c
+++ b/drivers/clock_control/clock_stm32g0.c
@@ -36,6 +36,22 @@ static uint32_t get_pll_source(void)
 }
 
 /**
+ * @brief get the pll source frequency
+ */
+__unused
+uint32_t get_pllsrc_frequency(void)
+{
+	if (IS_ENABLED(STM32_PLL_SRC_HSI)) {
+		return STM32_HSI_FREQ;
+	} else if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
+		return STM32_HSE_FREQ;
+	}
+
+	__ASSERT(0, "Invalid source");
+	return 0;
+}
+
+/**
  * @brief Set up pll configuration
  */
 __unused

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -69,18 +69,6 @@ void config_pll_sysclock(void)
 	LL_RCC_PLL_EnableDomain_SYS();
 }
 
-/**
- * @brief Return pllout frequency
- */
-__unused
-uint32_t get_pllout_frequency(void)
-{
-	return __LL_RCC_CALC_PLLCLK_FREQ(get_pll_source(),
-					 pllm(STM32_PLL_M_DIVISOR),
-					 STM32_PLL_N_MULTIPLIER,
-					 pllr(STM32_PLL_R_DIVISOR));
-}
-
 #endif /* defined(STM32_PLL_ENABLED) */
 
 /**

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -17,13 +17,6 @@
 
 #if STM32_SYSCLK_SRC_PLL
 
-/* Macros to fill up division factors values */
-#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
-#define pllm(v) z_pllm(v)
-
-#define z_pllr(v) LL_RCC_PLLR_DIV_ ## v
-#define pllr(v) z_pllr(v)
-
 /**
  * @brief Return PLL source
  */

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 
 /**
  * @brief Return PLL source
@@ -81,7 +81,7 @@ uint32_t get_pllout_frequency(void)
 					 pllr(STM32_PLL_R_DIVISOR));
 }
 
-#endif /* STM32_SYSCLK_SRC_PLL */
+#endif /* defined(STM32_PLL_ENABLED) */
 
 /**
  * @brief Activate default clocks

--- a/drivers/clock_control/clock_stm32g4.c
+++ b/drivers/clock_control/clock_stm32g4.c
@@ -35,6 +35,22 @@ static uint32_t get_pll_source(void)
 }
 
 /**
+ * @brief get the pll source frequency
+ */
+__unused
+uint32_t get_pllsrc_frequency(void)
+{
+	if (IS_ENABLED(STM32_PLL_SRC_HSI)) {
+		return STM32_HSI_FREQ;
+	} else if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
+		return STM32_HSE_FREQ;
+	}
+
+	__ASSERT(0, "Invalid source");
+	return 0;
+}
+
+/**
  * @brief Set up pll configuration
  */
 __unused

--- a/drivers/clock_control/clock_stm32l0_l1.c
+++ b/drivers/clock_control/clock_stm32l0_l1.c
@@ -15,7 +15,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 
 /* Macros to fill up multiplication and division factors values */
 #define z_pll_mul(v) LL_RCC_PLL_MUL_ ## v
@@ -63,7 +63,7 @@ uint32_t get_pllout_frequency(void)
 					 pll_div(STM32_PLL_DIVISOR));
 }
 
-#endif /* STM32_SYSCLK_SRC_PLL */
+#endif /* defined(STM32_PLL_ENABLED) */
 
 /**
  * @brief Activate default clocks

--- a/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
@@ -18,6 +18,13 @@
 
 #if STM32_SYSCLK_SRC_PLL
 
+#if defined(LL_RCC_MSIRANGESEL_RUN)
+#define CALC_RUN_MSI_FREQ(range) __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGESEL_RUN, \
+							range << RCC_CR_MSIRANGE_Pos);
+#else
+#define CALC_RUN_MSI_FREQ(range) __LL_RCC_CALC_MSI_FREQ(range << RCC_CR_MSIRANGE_Pos);
+#endif
+
 /**
  * @brief Return PLL source
  */
@@ -31,6 +38,26 @@ static uint32_t get_pll_source(void)
 		return LL_RCC_PLLSOURCE_HSE;
 	} else if (IS_ENABLED(STM32_PLL_SRC_MSI)) {
 		return LL_RCC_PLLSOURCE_MSI;
+	}
+
+	__ASSERT(0, "Invalid source");
+	return 0;
+}
+
+/**
+ * @brief get the pll source frequency
+ */
+__unused
+uint32_t get_pllsrc_frequency(void)
+{
+	if (IS_ENABLED(STM32_PLL_SRC_HSI)) {
+		return STM32_HSI_FREQ;
+	} else if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
+		return STM32_HSE_FREQ;
+#if defined(STM32_MSI_ENABLED)
+	} else if (IS_ENABLED(STM32_PLL_SRC_MSI)) {
+		return CALC_RUN_MSI_FREQ(STM32_MSI_RANGE);
+#endif
 	}
 
 	__ASSERT(0, "Invalid source");

--- a/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
@@ -84,18 +84,6 @@ void config_pll_sysclock(void)
 	LL_RCC_PLL_EnableDomain_SYS();
 }
 
-/**
- * @brief Return pllout frequency
- */
-__unused
-uint32_t get_pllout_frequency(void)
-{
-	return __LL_RCC_CALC_PLLCLK_FREQ(get_pll_source(),
-					 pllm(STM32_PLL_M_DIVISOR),
-					 STM32_PLL_N_MULTIPLIER,
-					 pllr(STM32_PLL_R_DIVISOR));
-}
-
 #endif /* defined(STM32_PLL_ENABLED) */
 
 /**

--- a/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
@@ -16,7 +16,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include "clock_stm32_ll_common.h"
 
-#if STM32_SYSCLK_SRC_PLL
+#if defined(STM32_PLL_ENABLED)
 
 #if defined(LL_RCC_MSIRANGESEL_RUN)
 #define CALC_RUN_MSI_FREQ(range) __LL_RCC_CALC_MSI_FREQ(LL_RCC_MSIRANGESEL_RUN, \
@@ -96,7 +96,7 @@ uint32_t get_pllout_frequency(void)
 					 pllr(STM32_PLL_R_DIVISOR));
 }
 
-#endif /* STM32_SYSCLK_SRC_PLL */
+#endif /* defined(STM32_PLL_ENABLED) */
 
 /**
  * @brief Activate default clocks

--- a/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
+++ b/drivers/clock_control/clock_stm32l4_l5_wb_wl.c
@@ -18,13 +18,6 @@
 
 #if STM32_SYSCLK_SRC_PLL
 
-/* Macros to fill up division factors values */
-#define z_pllm(v) LL_RCC_PLLM_DIV_ ## v
-#define pllm(v) z_pllm(v)
-
-#define z_pllr(v) LL_RCC_PLLR_DIV_ ## v
-#define pllr(v) z_pllr(v)
-
 /**
  * @brief Return PLL source
  */

--- a/include/zephyr/dt-bindings/clock/stm32f0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f0_clock.h
@@ -27,9 +27,6 @@
 /** PLL clock */
 #define STM32_SRC_PLLCLK	0x006
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSI
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PLLCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32f3_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f3_clock.h
@@ -28,9 +28,6 @@
 /** PLL clock */
 #define STM32_SRC_PLLCLK	0x006
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSI
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PLLCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -27,8 +27,10 @@
 #define STM32_SRC_SYSCLK	0x005
 /** Peripheral bus clock */
 #define STM32_SRC_PCLK		0x006
-/** PLL clock */
-#define STM32_SRC_PLLCLK	0x007
+/** PLL clock outputs */
+#define STM32_SRC_PLL_P		0x007
+#define STM32_SRC_PLL_Q		0x008
+#define STM32_SRC_PLL_R		0x009
 
 /**
  * @brief STM32 clock configuration bit field.

--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -30,9 +30,6 @@
 /** PLL clock */
 #define STM32_SRC_PLLCLK	0x007
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSI
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PLLCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -30,8 +30,10 @@
 #define STM32_SRC_SYSCLK	0x006
 /** Bus clock */
 #define STM32_SRC_PCLK		0x007
-/** PLL clocks */
-#define STM32_SRC_PLLCLK	0x008
+/** PLL clock outputs */
+#define STM32_SRC_PLL_P		0x008
+#define STM32_SRC_PLL_Q		0x009
+#define STM32_SRC_PLL_R		0x00a
 /* TODO: PLLSAI clocks */
 
 /**

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -34,9 +34,6 @@
 #define STM32_SRC_PLLCLK	0x008
 /* TODO: PLLSAI clocks */
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSI
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PLLCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32h7_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32h7_clock.h
@@ -37,9 +37,6 @@
 /** Clock muxes */
 #define STM32_SRC_CKPER		0x013
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_PLL1_P
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_CKPER
-
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB3    0x0D4
 #define STM32_CLOCK_BUS_AHB1    0x0D8

--- a/include/zephyr/dt-bindings/clock/stm32l0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l0_clock.h
@@ -28,9 +28,6 @@
 /** Bus clock */
 #define STM32_SRC_PCLK		0x006
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSE
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32l1_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l1_clock.h
@@ -22,9 +22,6 @@
 #define STM32_SRC_LSE		0x002
 #define STM32_SRC_LSI		0x003
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSE
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_LSI
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -30,8 +30,10 @@
 #define STM32_SRC_SYSCLK	0x006
 /** Bus clock */
 #define STM32_SRC_PCLK		0x007
-/** PLL clocks */
-#define STM32_SRC_PLLCLK	0x008
+/** PLL clock outputs */
+#define STM32_SRC_PLL_P		0x008
+#define STM32_SRC_PLL_Q		0x009
+#define STM32_SRC_PLL_R		0x00a
 /* TODO: PLLSAI clocks */
 
 /**

--- a/include/zephyr/dt-bindings/clock/stm32l4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32l4_clock.h
@@ -34,9 +34,6 @@
 #define STM32_SRC_PLLCLK	0x008
 /* TODO: PLLSAI clocks */
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSI
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PLLCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32u5_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32u5_clock.h
@@ -34,9 +34,6 @@
 /** Clock muxes */
 /* #define STM32_SRC_ICLK	0x012 */
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_PLL1_P
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_SYSCLK
-
 /** Bus clocks */
 #define STM32_CLOCK_BUS_AHB1    0x088
 #define STM32_CLOCK_BUS_AHB2    0x08C

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -30,8 +30,10 @@
 #define STM32_SRC_SYSCLK	0x006
 /** Bus clock */
 #define STM32_SRC_PCLK		0x007
-/** PLL clocks */
-#define STM32_SRC_PLLCLK	0x008
+/** PLL clock outputs */
+#define STM32_SRC_PLL_P		0x008
+#define STM32_SRC_PLL_Q		0x009
+#define STM32_SRC_PLL_R		0x00a
 /* TODO: PLLSAI clocks */
 
 /**

--- a/include/zephyr/dt-bindings/clock/stm32wb_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wb_clock.h
@@ -34,9 +34,6 @@
 #define STM32_SRC_PLLCLK	0x008
 /* TODO: PLLSAI clocks */
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSI
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PLLCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -30,8 +30,10 @@
 #define STM32_SRC_SYSCLK	0x005
 /** Bus clock */
 #define STM32_SRC_PCLK		0x006
-/** PLL clock */
-#define STM32_SRC_PLLCLK	0x007
+/** PLL clock outputs */
+#define STM32_SRC_PLL_P		0x007
+#define STM32_SRC_PLL_Q		0x008
+#define STM32_SRC_PLL_R		0x009
 
 /**
  * @brief STM32 clock configuration bit field.

--- a/include/zephyr/dt-bindings/clock/stm32wl_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32wl_clock.h
@@ -33,9 +33,6 @@
 /** PLL clock */
 #define STM32_SRC_PLLCLK	0x007
 
-#define STM32_SRC_CLOCK_MIN	STM32_SRC_HSI
-#define STM32_SRC_CLOCK_MAX	STM32_SRC_PLLCLK
-
 /**
  * @brief STM32 clock configuration bit field.
  *

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/wl_32_hse.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/wl_32_hse.overlay
@@ -12,7 +12,7 @@
 
 &clk_hse {
 	hse-tcxo;
-	clock-frequency = <DT_FREQ_M(32)>; /* STLink 32MHz clock */
+	clock-frequency = <DT_FREQ_M(32)>;
 	status = "okay";
 };
 

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/wl_pll_48_hse_32.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_core/boards/wl_pll_48_hse_32.overlay
@@ -13,7 +13,7 @@
 &clk_hse {
 	hse-tcxo;
 	hse-div2;
-	clock-frequency = <DT_FREQ_M(32)>; /* STLink 32MHz clock */
+	clock-frequency = <DT_FREQ_M(32)>;
 	status = "okay";
 };
 

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f0_i2c1_hsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f0_i2c1_hsi.overlay
@@ -68,3 +68,7 @@
 			<&rcc STM32_SRC_HSI I2C1_SEL(2)>;
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f3_i2c1_hsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/f3_i2c1_hsi.overlay
@@ -40,6 +40,7 @@
 	/delete-property/ clock-frequency;
 };
 
+
 /* Core set up
  * Aim of this part is to provide a base working clock config
  */
@@ -72,5 +73,9 @@
 	/delete-property/ clocks;
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
 			<&rcc STM32_SRC_HSI I2C1_SEL(2)>;
+	status = "okay";
+};
+
+&adc1 {
 	status = "okay";
 };

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g0_i2c1_hsi_lptim1_lse_adc1_pllp.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g0_i2c1_hsi_lptim1_lse_adc1_pllp.overlay
@@ -49,7 +49,7 @@
 &pll {
 	div-m = <1>;
 	mul-n = <8>;
-	div-p = <2>;
+	div-p = <20>; /* 6.4 MHz */
 	div-q = <2>;
 	div-r = <2>;
 	clocks = <&clk_hsi>;
@@ -73,5 +73,11 @@
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 			<&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
+	status = "okay";
+};
+
+&adc1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00100000>,
+			<&rcc STM32_SRC_PLL_P ADC_SEL(1)>;
 	status = "okay";
 };

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g0_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g0_i2c1_sysclk_lptim1_lsi.overlay
@@ -75,3 +75,7 @@
 			<&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g4_i2c1_hsi_adc1_pllp.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/g4_i2c1_hsi_adc1_pllp.overlay
@@ -45,7 +45,7 @@
 &pll {
 	div-m = <1>;
 	mul-n = <8>;
-	div-p = <2>;
+	div-p = <20>; /* 6.4 MHz */
 	div-q = <2>;
 	div-r = <2>;
 	clocks = <&clk_hsi>;
@@ -63,5 +63,12 @@
 	/delete-property/ clocks;
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00200000>,
 			<&rcc STM32_SRC_HSI I2C1_SEL(2)>;
+	status = "okay";
+};
+
+&adc1 {
+	/* changes clock source for both ADC1 and ADC2 */
+	clocks = <&rcc STM32_CLOCK_BUS_AHB2 0x00002000>,
+			<&rcc STM32_SRC_PLL_P ADC12_SEL(1)>;
 	status = "okay";
 };

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_hsi_lptim1_lse.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_hsi_lptim1_lse.overlay
@@ -81,3 +81,7 @@
 			<&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/l4_i2c1_sysclk_lptim1_lsi.overlay
@@ -81,3 +81,7 @@
 			<&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wb_i2c1_hsi_lptim1_lse.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wb_i2c1_hsi_lptim1_lse.overlay
@@ -81,3 +81,7 @@
 			<&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wb_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wb_i2c1_sysclk_lptim1_lsi.overlay
@@ -75,3 +75,7 @@
 			<&rcc STM32_SRC_SYSCLK I2C1_SEL(1)>;
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_hsi_lptim1_lse.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_hsi_lptim1_lse.overlay
@@ -47,6 +47,7 @@
  */
 
 &clk_hse {
+	hse-tcxo;
 	status = "okay";
 	clock-frequency = <DT_FREQ_M(32)>;
 };

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_hsi_lptim1_lse_adc1_pllp.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_hsi_lptim1_lse_adc1_pllp.overlay
@@ -60,6 +60,16 @@
 	status = "okay";
 };
 
+&pll {
+	div-m = <1>;
+	mul-n = <8>;
+	div-p = <20>; /* 12.8 MHz */
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
 &rcc {
 	clocks = <&clk_hse>;
 	clock-frequency = <DT_FREQ_M(32)>;
@@ -82,5 +92,11 @@
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 			<&rcc STM32_SRC_LSE LPTIM1_SEL(3)>;
+	status = "okay";
+};
+
+&adc1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB2 0x00000200>,
+			<&rcc STM32_SRC_PLL_P ADC_SEL(2)>;
 	status = "okay";
 };

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_sysclk_lptim1_lsi.overlay
@@ -47,6 +47,7 @@
  */
 
 &clk_hse {
+	hse-tcxo;
 	status = "okay";
 	clock-frequency = <DT_FREQ_M(32)>;
 };

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_sysclk_lptim1_lsi.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/boards/wl_i2c1_sysclk_lptim1_lsi.overlay
@@ -80,3 +80,7 @@
 			<&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 	status = "okay";
 };
+
+&adc1 {
+	status = "okay";
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
@@ -208,7 +208,7 @@ static void test_lptim_clk_config(void)
 				(clock_control_subsys_t) &pclken[0]);
 	zassert_true((r == 0), "Could not disable LPTIM1 gating clk");
 
-	zassert_true(!__HAL_RCC_I2C1_IS_CLK_ENABLED(), "LPTIM1 gating clk should be off");
+	zassert_true(!__HAL_RCC_LPTIM1_IS_CLK_ENABLED(), "LPTIM1 gating clk should be off");
 	TC_PRINT("LPTIM1 gating clk off\n");
 
 	/* Test clock_off(srce) */

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
@@ -218,12 +218,125 @@ static void test_lptim_clk_config(void)
 static void test_lptim_clk_config(void) {}
 #endif
 
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay)
+
+#undef DT_DRV_COMPAT
+#define DT_DRV_COMPAT st_stm32_adc
+
+#if STM32_DT_INST_DEV_OPT_CLOCK_SUPPORT
+#define STM32_ADC_OPT_CLOCK_SUPPORT 1
+#else
+#define STM32_ADC_OPT_CLOCK_SUPPORT 0
+#endif
+
+#if defined(__HAL_RCC_GET_ADC12_SOURCE)
+#define PERIPHCLK_ADC		RCC_PERIPHCLK_ADC12
+#define ADC_IS_CLK_ENABLED	__HAL_RCC_ADC12_IS_CLK_ENABLED
+#define GET_ADC_SOURCE		__HAL_RCC_GET_ADC12_SOURCE
+#define ADC_SOURCE_SYSCLK	RCC_ADC12CLKSOURCE_SYSCLK
+#elif defined(__HAL_RCC_GET_ADC_SOURCE)
+#define PERIPHCLK_ADC		RCC_PERIPHCLK_ADC
+#define ADC_IS_CLK_ENABLED	__HAL_RCC_ADC_IS_CLK_ENABLED
+#define GET_ADC_SOURCE		__HAL_RCC_GET_ADC_SOURCE
+#define ADC_SOURCE_SYSCLK	RCC_ADCCLKSOURCE_SYSCLK
+#else
+#define PERIPHCLK_ADC		(-1)
+#define ADC_IS_CLK_ENABLED	__HAL_RCC_ADC1_IS_CLK_ENABLED
+#define GET_ADC_SOURCE()	(-1);
+#endif
+
+#if defined(RCC_ADC12CLKSOURCE_PLL)
+#define ADC_SOURCE_PLL		RCC_ADC12CLKSOURCE_PLL
+#elif defined(RCC_ADCCLKSOURCE_PLLADC)
+#define ADC_SOURCE_PLL		RCC_ADCCLKSOURCE_PLLADC
+#elif defined(RCC_ADCCLKSOURCE_PLL)
+#define ADC_SOURCE_PLL		RCC_ADCCLKSOURCE_PLL
+#else
+#define ADC_SOURCE_PLL		(-1)
+#endif
+
+static void test_adc_clk_config(void)
+{
+	static const struct stm32_pclken pclken[] = STM32_DT_CLOCKS(DT_NODELABEL(adc1));
+
+	uint32_t dev_dt_clk_freq, dev_actual_clk_freq;
+	uint32_t dev_actual_clk_src;
+	int r;
+
+	/* Test clock_on(gating clock) */
+	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				(clock_control_subsys_t) &pclken[0]);
+	zassert_true((r == 0), "Could not enable ADC1 gating clock");
+
+	zassert_true(ADC_IS_CLK_ENABLED(), "ADC1 gating clock should be on");
+	TC_PRINT("ADC1 gating clock on\n");
+
+	if (IS_ENABLED(STM32_ADC_OPT_CLOCK_SUPPORT) && DT_NUM_CLOCKS(DT_NODELABEL(adc1)) > 1) {
+		/* Test clock_on(ker_clk) */
+		r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+					    (clock_control_subsys_t) &pclken[1],
+					    NULL);
+		zassert_true((r == 0), "Could not enable ADC1 soure clock");
+		TC_PRINT("ADC1 source clock configured\n");
+
+		/* Test clock source */
+		zassert_true((ADC_SOURCE_PLL != -1), "Invalid ADC_SOURCE_PLL defined for target.");
+		dev_actual_clk_src = GET_ADC_SOURCE();
+
+		switch (pclken[1].bus) {
+#if defined(STM32_SRC_PLL_P)
+		case STM32_SRC_PLL_P:
+			zassert_equal(dev_actual_clk_src, ADC_SOURCE_PLL,
+					"Expected ADC1 src: PLL (0x%lx). Actual ADC1 src: 0x%x",
+					ADC_SOURCE_PLL, dev_actual_clk_src);
+			break;
+#endif
+		default:
+			zassert_true(0, "Unexpected src clk (%d)", dev_actual_clk_src);
+		}
+
+		/* Test get_rate(srce clk) */
+		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+					(clock_control_subsys_t) &pclken[1],
+					&dev_dt_clk_freq);
+		zassert_true((r == 0), "Could not get ADC1 clk srce freq");
+
+		dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(PERIPHCLK_ADC);
+		zassert_equal(dev_dt_clk_freq, dev_actual_clk_freq,
+				"Expected DT freq: %d Hz. Actual freq: %d Hz",
+				dev_dt_clk_freq, dev_actual_clk_freq);
+
+		TC_PRINT("ADC1 clock source rate: %d Hz\n", dev_dt_clk_freq);
+	} else {
+		zassert_true((DT_NUM_CLOCKS(DT_NODELABEL(adc1)) == 1), "test config issue");
+		/* No alt clock available, don't check gating clock as for adc there is no
+		 * uniform way to verify via hal.
+		 */
+		TC_PRINT("ADC1 no alt clock defined. Skipped check\n");
+	}
+
+	/* Test clock_off(reg_clk) */
+	r = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
+				(clock_control_subsys_t) &pclken[0]);
+	zassert_true((r == 0), "Could not disable ADC1 gating clk");
+
+	zassert_true(!ADC_IS_CLK_ENABLED(), "ADC1 gating clk should be off");
+	TC_PRINT("ADC1 gating clk off\n");
+
+	/* Test clock_off(srce) */
+	/* Not supported today */
+}
+#else
+static void test_adc_clk_config(void) {}
+#endif
+
 void test_main(void)
 {
 	ztest_test_suite(test_stm32_common_devices_clocks,
 		ztest_unit_test(test_sysclk_freq),
 		ztest_unit_test(test_i2c_clk_config),
-		ztest_unit_test(test_lptim_clk_config)
+		ztest_unit_test(test_lptim_clk_config),
+		ztest_unit_test(test_adc_clk_config)
 			 );
 	ztest_run_test_suite(test_stm32_common_devices_clocks);
 }

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/testcase.yaml
@@ -10,11 +10,11 @@ tests:
   drivers.stm32_clock_configuration.common_device.g0.i2c1_sysclk_lptim1_lsi:
     extra_args: DTC_OVERLAY_FILE="boards/g0_i2c1_sysclk_lptim1_lsi.overlay"
     platform_allow: nucleo_g071rb
-  drivers.stm32_clock_configuration.common_device.g0.i2c1_hsi_lptim1_lse:
-    extra_args: DTC_OVERLAY_FILE="boards/g0_i2c1_hsi_lptim1_lse.overlay"
+  drivers.stm32_clock_configuration.common_device.g0.i2c1_hsi_lptim1_lse_adc1_pllp:
+    extra_args: DTC_OVERLAY_FILE="boards/g0_i2c1_hsi_lptim1_lse_adc1_pllp.overlay"
     platform_allow: nucleo_g071rb
-  drivers.stm32_clock_configuration.common_device.wl.i2c1_hsi_lptim1_lse:
-    extra_args: DTC_OVERLAY_FILE="boards/wl_i2c1_hsi_lptim1_lse.overlay"
+  drivers.stm32_clock_configuration.common_device.wl.i2c1_hsi_lptim1_lse_adc1_pllp:
+    extra_args: DTC_OVERLAY_FILE="boards/wl_i2c1_hsi_lptim1_lse_adc1_pllp.overlay"
     platform_allow: nucleo_wl55jc
   drivers.stm32_clock_configuration.common_device.wl.i2c1_sysclk_lptim1_lsi:
     extra_args: DTC_OVERLAY_FILE="boards/wl_i2c1_sysclk_lptim1_lsi.overlay"
@@ -25,8 +25,8 @@ tests:
   drivers.stm32_clock_configuration.common_device.l4.i2c1_hsi_lptim1_lse:
     extra_args: DTC_OVERLAY_FILE="boards/l4_i2c1_hsi_lptim1_lse.overlay"
     platform_allow: disco_l475_iot1
-  drivers.stm32_clock_configuration.common_device.g4.i2c1_hsi:
-    extra_args: DTC_OVERLAY_FILE="boards/g4_i2c1_hsi.overlay"
+  drivers.stm32_clock_configuration.common_device.g4.i2c1_hsi_adc1_pllp:
+    extra_args: DTC_OVERLAY_FILE="boards/g4_i2c1_hsi_adc1_pllp.overlay"
     platform_allow: nucleo_g474re
   drivers.stm32_clock_configuration.common_device.f0.i2c1_hsi:
     extra_args: DTC_OVERLAY_FILE="boards/f0_i2c1_hsi.overlay"


### PR DESCRIPTION
This PR allows select STM32 SOCs to configure the PLL_P, PLL_Q, PLL_R outputs as alternate clock source.
The PLL outputs are enabled during initialization in case the respective divider is defined in dts.

The functionality is verified by extending the stm32_common_devices test with a test case that configures an alternate clock source for ADC1. Test configurations for STMG0, STM32G4, and STM32WL were changed accordingly.

Additionally, some related testcase and driver fixes are included:
- tests: drivers: clock_control: stm32_wl fix external clock dts
- drivers/clock_control: fix stm32 common pll_q divider setup
  Closes #47101 
- tests/drivers/clock_control: stm32_common_devices: lptim check disabled

Tested only on G0, G4, L4, WB, and WL targets.