### PR TITLE
drivers: interrupt: stm32 several exti can share one irq

### DIFF
--- a/drivers/interrupt_controller/Kconfig.stm32
+++ b/drivers/interrupt_controller/Kconfig.stm32
@@ -213,4 +213,10 @@ config EXTI_STM32_LPTIM1_IRQ_PRI
 	help
 	  IRQ priority of LPTIM1 interrupt
 
+config EXTI_STM32_ONE_IRQ
+	bool "multiple EXTI one IRQ"
+	depends on EXTI_STM32
+	help
+	  multiple EXTI lines trigger one single IRQ
+
 endif # SOC_FAMILY_STM32

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -434,9 +434,11 @@ int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 	const struct device *dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 
+#if !defined(CONFIG_EXTI_STM32_ONE_IRQ)
 	if (data->cb[line].cb) {
 		return -EBUSY;
 	}
+#endif /* ! CONFIG_EXTI_STM32_ONE_IRQ */
 
 	data->cb[line].cb = cb;
 	data->cb[line].data = arg;


### PR DESCRIPTION
With this CONFIG_EXTI_STM32_ONE_IRQ,
the stm32 several pins can share one interrupt
(instead of one irq per pin).
Then one callback function is common to all sources.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/45234

Signed-off-by: Francois Ramu <francois.ramu@st.com>