### PR TITLE
lib: os: spsc_pbuf: Improve data cache configuration

### DIFF
--- a/include/zephyr/sys/spsc_pbuf.h
+++ b/include/zephyr/sys/spsc_pbuf.h
@@ -7,6 +7,9 @@
 #ifndef ZEPHYR_INCLUDE_SYS_SPSC_PBUF_H_
 #define ZEPHYR_INCLUDE_SYS_SPSC_PBUF_H_
 
+#include <zephyr/cache.h>
+#include <zephyr/devicetree.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -32,9 +35,18 @@ extern "C" {
 
 /**@} */
 
-#ifndef CONFIG_SPSC_PBUF_CACHE_LINE
-#define CONFIG_SPSC_PBUF_CACHE_LINE 0
+#if CONFIG_DCACHE_LINE_SIZE != 0
+#define Z_SPSC_PBUF_LOCAL_DCACHE_LINE CONFIG_DCACHE_LINE_SIZE
+#else
+#define Z_SPSC_PBUF_LOCAL_DCACHE_LINE DT_PROP_OR(CPU, d_cache_line_size, 0)
 #endif
+
+#ifndef CONFIG_SPSC_PBUF_REMOTE_DCACHE_LINE
+#define CONFIG_SPSC_PBUF_REMOTE_DCACHE_LINE 0
+#endif
+
+#define Z_SPSC_PBUF_DCACHE_LINE \
+	MAX(CONFIG_SPSC_PBUF_REMOTE_DCACHE_LINE, Z_SPSC_PBUF_LOCAL_DCACHE_LINE)
 
 /** @brief Maximum packet length. */
 #define SPSC_PBUF_MAX_LEN 0xFF00
@@ -54,7 +66,7 @@ struct spsc_pbuf_common {
 
 /* Padding to fill cache line. */
 #define Z_SPSC_PBUF_PADDING \
-	MAX(0, CONFIG_SPSC_PBUF_CACHE_LINE - (int)sizeof(struct spsc_pbuf_common))
+	MAX(0, Z_SPSC_PBUF_DCACHE_LINE - (int)sizeof(struct spsc_pbuf_common))
 
 /** @brief Remaining part of a packet buffer when cache is used.
  *
@@ -116,7 +128,7 @@ static inline uint32_t spsc_pbuf_capacity(struct spsc_pbuf *pb)
  *
  * @param buf			Pointer to a memory region on which buffer is
  *				created. When cache is used it must be aligned to
- *				CONFIG_SPSC_PBUF_CACHE_LINE, otherwise it must
+ *				Z_SPSC_PBUF_DCACHE_LINE, otherwise it must
  *				be 32 bit word aligned.
  * @param blen			Length of the buffer. Must be large enough to
  *				contain the internal structure and at least two

--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -80,12 +80,14 @@ config SPSC_PBUF_NO_CACHE
 
 if SPSC_PBUF_CACHE_FLAG || SPSC_PBUF_CACHE_ALWAYS
 
-config SPSC_PBUF_CACHE_LINE
-	int "Maximum cache line"
+config SPSC_PBUF_REMOTE_DCACHE_LINE
+	int "Remote cache line size"
 	default 32
 	help
-	  If buffer is used by 2 cores then value should be set to the length of
-	  of the longer cache line.
+	  If a packet buffer is used for data sharing between two cores then
+	  this value should be set to the data cache line size of the remote core.
+	  If local data cache line is detected at runtime then it should be
+	  maximum of local and remote line size.
 
 endif # SPSC_PBUF_CACHE_FLAG || SPSC_PBUF_CACHE_ALWAYS
 

--- a/lib/os/spsc_pbuf.c
+++ b/lib/os/spsc_pbuf.c
@@ -95,9 +95,9 @@ static uint32_t get_len(size_t blen, uint32_t flags)
 
 static bool check_alignment(void *buf, uint32_t flags)
 {
-	if ((CONFIG_SPSC_PBUF_CACHE_LINE > 0) && (IS_ENABLED(CONFIG_SPSC_PBUF_CACHE_ALWAYS) ||
+	if ((Z_SPSC_PBUF_DCACHE_LINE > 0) && (IS_ENABLED(CONFIG_SPSC_PBUF_CACHE_ALWAYS) ||
 	    (IS_ENABLED(CONFIG_SPSC_PBUF_CACHE_FLAG) && (flags & SPSC_PBUF_CACHE)))) {
-		return ((uintptr_t)buf & (CONFIG_SPSC_PBUF_CACHE_LINE - 1)) == 0;
+		return ((uintptr_t)buf & (Z_SPSC_PBUF_DCACHE_LINE - 1)) == 0;
 	}
 
 	return (((uintptr_t)buf & (sizeof(uint32_t) - 1)) == 0) ? true : false;

--- a/tests/lib/spsc_pbuf/src/main.c
+++ b/tests/lib/spsc_pbuf/src/main.c
@@ -21,7 +21,7 @@ static bool use_cache(uint32_t flags)
 
 static void test_spsc_pbuf_flags(uint32_t flags)
 {
-	static uint8_t memory_area[216] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t memory_area[216] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	static uint8_t rbuf[198];
 	static uint8_t message[20] = {'a'};
 	struct spsc_pbuf *ib;
@@ -175,7 +175,7 @@ static void packet_consume(struct spsc_pbuf *pb,
 
 ZTEST(test_spsc_pbuf, test_0cpy)
 {
-	static uint8_t buffer[64] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	struct spsc_pbuf *pb = spsc_pbuf_init(buffer, sizeof(buffer), 0);
 	uint32_t capacity = spsc_pbuf_capacity(pb);
 	uint16_t len1;
@@ -207,7 +207,7 @@ ZTEST(test_spsc_pbuf, test_0cpy)
 
 ZTEST(test_spsc_pbuf, test_0cpy_smaller)
 {
-	static uint8_t buffer[64] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	struct spsc_pbuf *pb = spsc_pbuf_init(buffer, sizeof(buffer), 0);
 	uint32_t capacity = spsc_pbuf_capacity(pb);
 	uint16_t len1;
@@ -227,7 +227,7 @@ ZTEST(test_spsc_pbuf, test_0cpy_smaller)
 
 ZTEST(test_spsc_pbuf, test_0cpy_discard)
 {
-	static uint8_t buffer[96] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	struct spsc_pbuf *pb = spsc_pbuf_init(buffer, sizeof(buffer), 0);
 	uint32_t capacity = spsc_pbuf_capacity(pb);
 	int len1, len2;
@@ -257,7 +257,7 @@ ZTEST(test_spsc_pbuf, test_0cpy_discard)
 
 ZTEST(test_spsc_pbuf, test_0cpy_corner1)
 {
-	static uint8_t buffer[64] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	struct spsc_pbuf *pb;
 	uint32_t capacity;
 	char *buf;
@@ -293,7 +293,7 @@ ZTEST(test_spsc_pbuf, test_0cpy_corner1)
 
 ZTEST(test_spsc_pbuf, test_0cpy_corner2)
 {
-	static uint8_t buffer[64] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	struct spsc_pbuf *pb;
 	uint32_t capacity;
 	uint16_t len1;
@@ -333,7 +333,7 @@ ZTEST(test_spsc_pbuf, test_0cpy_corner2)
 
 ZTEST(test_spsc_pbuf, test_largest_alloc)
 {
-	static uint8_t buffer[96] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	struct spsc_pbuf *pb;
 	uint32_t capacity;
 	uint16_t len1;
@@ -368,7 +368,7 @@ ZTEST(test_spsc_pbuf, test_largest_alloc)
 
 ZTEST(test_spsc_pbuf, test_utilization)
 {
-	static uint8_t buffer[64] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	struct spsc_pbuf *pb;
 	uint32_t capacity;
 	uint16_t len1, len2, len3;
@@ -457,7 +457,7 @@ bool stress_write(void *user_data, uint32_t cnt, bool last, int prio)
 
 ZTEST(test_spsc_pbuf, test_stress)
 {
-	static uint8_t buffer[128] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	static struct stress_data ctx;
 	uint32_t repeat = 0;
 
@@ -518,7 +518,7 @@ bool stress_alloc_commit(void *user_data, uint32_t cnt, bool last, int prio)
 
 ZTEST(test_spsc_pbuf, test_stress_0cpy)
 {
-	static uint8_t buffer[128] __aligned(MAX(CONFIG_SPSC_PBUF_CACHE_LINE, 4));
+	static uint8_t buffer[128] __aligned(MAX(Z_SPSC_PBUF_DCACHE_LINE, 4));
 	static struct stress_data ctx;
 	uint32_t repeat = 0;
 


### PR DESCRIPTION
Use CONFIG_DCACHE_LINE_SIZE to determine distance between
fields modified by different cores.
Add option which specifies what is the data cache line
of the remote core. Maximum from local and remote cache
line sizes is used as distance and alignement.

This was discussed here https://github.com/zephyrproject-rtos/zephyr/pull/46006#discussion_r910148798 but PR was merged before change was applied.

Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>