### PR TITLE
drivers: sensor: stm32_temp: cleanup

### DIFF
--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -38,7 +38,6 @@ struct stm32_temp_config {
 	int cal1_temp;
 	int cal2_temp;
 	int cal_vrefanalog;
-	int cal_offset;
 #else
 	int avgslope;
 	int v25_mv;
@@ -91,7 +90,7 @@ static int stm32_temp_channel_get(const struct device *dev, enum sensor_channel 
 	temp -= *cfg->cal1_addr;
 	temp *= (cfg->cal2_temp - cfg->cal1_temp);
 	temp /= (*cfg->cal2_addr - *cfg->cal1_addr);
-	temp += cfg->cal_offset;
+	temp += cfg->cal1_temp;
 #else
 	/* Sensor value in millivolts */
 	int32_t mv = data->raw * adc_ref_internal(data->adc) / 0x0FFF;
@@ -142,7 +141,6 @@ static const struct stm32_temp_config stm32_temp_dev_config = {
 	.cal1_temp = DT_INST_PROP(0, ts_cal1_temp),
 	.cal2_temp = DT_INST_PROP(0, ts_cal2_temp),
 	.cal_vrefanalog = DT_INST_PROP(0, ts_cal_vrefanalog),
-	.cal_offset = DT_INST_PROP(0, ts_cal_offset)
 #else
 	.avgslope = DT_INST_PROP(0, avgslope),
 	.v25_mv = DT_INST_PROP(0, v25),

--- a/dts/arm/st/g0/stm32g0b1.dtsi
+++ b/dts/arm/st/g0/stm32g0b1.dtsi
@@ -127,7 +127,6 @@
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <130>;
 		ts-cal-vrefanalog = <3000>;
-		ts-cal-offset = <30>;
 		io-channels = <&adc1 12>;
 		status = "disabled";
 		label = "DIE_TEMP";

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -635,7 +635,6 @@
 		ts-cal1-temp = <30>;
 		ts-cal2-temp = <110>;
 		ts-cal-vrefanalog = <3000>;
-		ts-cal-offset = <30>;
 		io-channels = <&adc1 17>;
 		status = "disabled";
 		label = "DIE_TEMP";

--- a/dts/bindings/sensor/st,stm32-temp-cal.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-cal.yaml
@@ -38,8 +38,3 @@ properties:
       description: |
         Analog voltage reference (Vref+) voltage with which
         temperature sensor has been calibrated in production
-
-    ts-cal-offset:
-      type: int
-      required: true
-      description: Temperature offset in Celcius

--- a/dts/bindings/sensor/st,stm32-temp-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-common.yaml
@@ -8,8 +8,3 @@ properties:
     io-channels:
       required: true
       description: ADC channel for temperature sensor
-
-    ts-voltage-mv:
-      type: int
-      default: 3300
-      description: Temperature sensor voltage in millivolts


### PR DESCRIPTION
These two patches remove properties from the device tree that are redundant.