### PR TITLE
Use cachable flash address space while reading on infineon xmc4xxx

### DIFF
--- a/dts/arm/infineon/xmc4500_F100x1024.dtsi
+++ b/dts/arm/infineon/xmc4500_F100x1024.dtsi
@@ -21,7 +21,7 @@
 };
 
 &flash0 {
-	reg = <0xc000000 DT_SIZE_M(1)>;
+	reg = <0xc000000 DT_SIZE_M(1) 0x8000000 DT_SIZE_M(1)>;
 };
 
 &gpio0 {

--- a/soc/arm/infineon_xmc/4xxx/linker.ld
+++ b/soc/arm/infineon_xmc/4xxx/linker.ld
@@ -11,4 +11,26 @@
  * This is the linker script for both standard images and XIP images.
  */
 
+#include <zephyr/linker/linker-tool.h>
+
+#define ROM_VMA_ADDR (CONFIG_FLASH_VMA_BASE_ADDRESS + CONFIG_FLASH_LOAD_OFFSET)
+
+#if CONFIG_FLASH_LOAD_SIZE > 0
+	#define ROM_VMA_SIZE CONFIG_FLASH_LOAD_SIZE
+#else
+	#define ROM_VMA_SIZE (CONFIG_FLASH_SIZE*1K - CONFIG_FLASH_LOAD_OFFSET)
+#endif
+
+MEMORY
+     {
+	 FLASH_VMA  (rx) : ORIGIN = ROM_VMA_ADDR, LENGTH = ROM_VMA_SIZE
+     }
+
+#if defined(CONFIG_XIP)
+#undef GROUP_LINK_IN
+#define GROUP_LINK_IN(where) > FLASH_VMA AT > where
+#undef GROUP_ROM_LINK_IN
+#define GROUP_ROM_LINK_IN(vregion, lregion) > FLASH_VMA AT > lregion
+#endif
+
 #include <zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld>

--- a/soc/arm/infineon_xmc/Kconfig
+++ b/soc/arm/infineon_xmc/Kconfig
@@ -19,4 +19,15 @@ source "soc/arm/infineon_xmc/*/Kconfig.soc"
 config SOC_PART_NUMBER
 	default SOC_PART_NUMBER_XMC_4XXX if SOC_SERIES_XMC_4XXX
 
+DT_CHOSEN_Z_FLASH := zephyr,flash
+
+config FLASH_VMA_BASE_ADDRESS
+	hex "VMA Flash Base Address"
+	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH),1)
+	help
+		XMC4xxx devices have an cached and uncached flash address space. The cached address space is
+		used for reads; The uncached address space is used for erase/write operations. This option
+		points to the cached address. The uncached base address remains CONFIG_FLASH_BASE_ADDRESS which
+		is the base address for flashing the device.
+
 endif # SOC_FAMILY_XMC


### PR DESCRIPTION
The infineon xmc4xxx series has two ways to access flash: One is the
cachable address space at 0x8000000 which can use pre-fetched data to
reduce flash access latency; The second is uncached space at 0xc000000
which is mainly used for write and erase operations.
The two address spaces point to the physical flash.
    
This patch adds support for using the cachable read access by setting
it as the virtual address in the linker script for the rom section.
