### PR TITLE
Bluetooth: controller: llcp: initialise DLE parameters

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -992,15 +992,6 @@ uint8_t ll_adv_enable(uint8_t enable)
 #endif /* CONFIG_BT_CTLR_ADV_EXT */
 #endif /* CONFIG_BT_CTLR_PHY */
 #endif
-#else /* CONFIG_BT_LL_SW_LLCP_LEGACY */
-#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
-#if defined(CONFIG_BT_CTLR_PHY) && defined(CONFIG_BT_CTLR_ADV_EXT)
-		const uint8_t phy = lll->phy_s;
-#else
-		const uint8_t phy = PHY_1M;
-#endif
-		ull_dle_init(conn, phy);
-#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
 #endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 #if defined(CONFIG_BT_CTLR_PHY)
@@ -1138,7 +1129,7 @@ uint8_t ll_adv_enable(uint8_t enable)
 
 		conn->tx_head = conn->tx_ctrl = conn->tx_ctrl_last =
 		conn->tx_data = conn->tx_data_last = 0;
-#else /* CONFIG_BT_LL_SW_LLCP_LEGACY */
+#else /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
 		/* Re-initialize the control procedure data structures */
 		ull_llcp_init(conn);
 
@@ -1157,9 +1148,22 @@ uint8_t ll_adv_enable(uint8_t enable)
 		conn->pause_rx_data = 0U;
 #endif /* CONFIG_BT_CTLR_LE_ENC */
 
+#if defined(CONFIG_BT_CTLR_DATA_LENGTH)
+		uint8_t phy_in_use = PHY_1M;
+
+
+#if defined(CONFIG_BT_CTLR_ADV_EXT)
+		if (pdu_adv->type == PDU_ADV_TYPE_EXT_IND) {
+			phy_in_use = lll->phy_s;
+		}
+#endif /* CONFIG_BT_CTLR_ADV_EXT */
+
+		ull_dle_init(conn, phy_in_use);
+#endif /* CONFIG_BT_CTLR_DATA_LENGTH */
+
 		/* Re-initialize the Tx Q */
 		ull_tx_q_init(&conn->tx_q);
-#endif /* CONFIG_BT_LL_SW_LLCP_LEGACY */
+#endif /* !CONFIG_BT_LL_SW_LLCP_LEGACY */
 
 		/* NOTE: using same link as supplied for terminate ind */
 		adv->link_cc_free = link;

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -8189,6 +8189,11 @@ void ull_dle_init(struct ll_conn *conn, uint8_t phy)
 	conn->lll.dle.remote.max_rx_time = max_time_min;
 #endif /* CONFIG_BT_CTLR_PHY */
 
+	/*
+	 * ref. Bluetooth Core Specification version 5.3, Vol. 6,
+	 * Part B, section 4.5.10 we can call ull_dle_update_eff
+	 * for initialisation
+	 */
 	ull_dle_update_eff(conn);
 
 	/* Check whether the controller should perform a data length update after


### PR DESCRIPTION
The initialisation of DLE parameters for the peripheral
was done before the intialisation of the PHY settings.
Since the DLE parameters depend on PHY settings this
can result in incorrect parameters for tx/rx time and
octets
One scenario is where a previous connection set the PHY to
2M or CODED, then when a new connection is established
it uses the same memory-locations for connection settings as the
previous connection, and the (uninitialised) PHY settings will be
set to 2M or CODED, and thus the DLE parameters will be wrong
This PR moves the initialisation of DLE parameters after
that of PHY settings

Additionally the initial values for effective tx/rx time and octets were wrong
EBQ tests effected include LL/CON/PER/BV-77-C.

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>