### PR TITLE
tests: net: udp: move to new ztest API

### DIFF
--- a/tests/net/udp/prj.conf
+++ b/tests/net/udp/prj.conf
@@ -23,3 +23,4 @@ CONFIG_NET_IF_UNICAST_IPV4_ADDR_COUNT=2
 # Turn off UDP checksum checking as the test fails otherwise.
 CONFIG_NET_UDP_CHECKSUM=n
 CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y

--- a/tests/net/udp/src/main.c
+++ b/tests/net/udp/src/main.c
@@ -419,7 +419,7 @@ static void set_port(sa_family_t family, struct sockaddr *raddr,
 	}
 }
 
-void test_udp(void)
+ZTEST(udp_fn_tests, test_udp)
 {
 	if (IS_ENABLED(CONFIG_NET_TC_THREAD_COOPERATIVE)) {
 		k_thread_priority_set(k_current_get(),
@@ -671,9 +671,4 @@ void test_udp(void)
 	zassert_false(test_failed, "udp tests failed");
 }
 
-void test_main(void)
-{
-	ztest_test_suite(test_udp_fn,
-		ztest_unit_test(test_udp));
-	ztest_run_test_suite(test_udp_fn);
-}
+ZTEST_SUITE(udp_fn_tests, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Move tests/net/udp/ to use new ztest API.

Signed-off-by: Xiao Song <songx.xiao@intel.com>