### PR TITLE
Arc nsim hs5x hw clock fix

### DIFF
--- a/soc/arc/snps_nsim/Kconfig.defconfig.hs5x
+++ b/soc/arc/snps_nsim/Kconfig.defconfig.hs5x
@@ -15,7 +15,7 @@ config NUM_IRQS
 	default 30
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC
-	default 5000000
+	default 50000000
 
 config CACHE_MANAGEMENT
 	default y


### PR DESCRIPTION
Default clock frequency for real HW is 50MHz.
Wrong CLK settings cause test fault
(test/kernel/context::test_busy_wait).

Signed-off-by: Agishev Nikolay <agishev@synopsys.com>