### PR TITLE
drivers: pinctrl_nrf: Use S0D1 drive by default for TWI/TWIM pins

### DIFF
--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -107,7 +107,9 @@ child-binding:
           Pin output drive mode. Available drive modes are pre-defined in
           nrf-pinctrl.h. Note that extra modes may not be available on certain
           devices. Defaults to standard mode for 0 and 1 (NRF_DRIVE_S0S1), the
-          SoC default.
+          SoC default, except for the "nordic,nrf-twi" and "nordic,nrf-twim"
+          nodes where NRF_DRIVE_S0S1 is always overridden with NRF_DRIVE_S0D1
+          (standard '0', disconnect '1').
 
       nordic,invert:
         type: boolean


### PR DESCRIPTION
The default S0S1 drive setting is not suitable for TWI/TWIM pins.
Override it with S0D1 as for some SoCs (e.g. nRF52833) without
this the peripheral will not work properly.

This fixes a problem reported here: https://devzone.nordicsemi.com/f/nordic-q-a/89043/possible-regression-with-i2c-after-move-to-pin-control-interface-in-nordic-connect-sdk-2-0-0.