### PR TITLE
twister: use original reason with qemu failures

### DIFF
--- a/scripts/pylib/twister/twisterlib.py
+++ b/scripts/pylib/twister/twisterlib.py
@@ -1249,7 +1249,8 @@ class QEMUHandler(Handler):
             if is_timeout:
                 self.instance.reason = "Timeout"
             else:
-                self.instance.reason = "Exited with {}".format(self.returncode)
+                if not self.instance.reason:
+                    self.instance.reason = "Exited with {}".format(self.returncode)
             self.instance.add_missing_case_status("blocked")
 
         self._final_handle_actions(harness, 0)


### PR DESCRIPTION
If we already have recorded the reason during the qemu run, do not
override it at the final stage of status processing.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
