### PR TITLE
lorawan: move `REQUIRES_FULL_LIBC` dependency

### DIFF
--- a/drivers/lora/Kconfig
+++ b/drivers/lora/Kconfig
@@ -8,7 +8,6 @@
 
 menuconfig LORA
 	bool "LoRa support [EXPERIMENTAL]"
-	select REQUIRES_FULL_LIBC
 	select POLL
 	select EXPERIMENTAL
 	help

--- a/subsys/lorawan/Kconfig
+++ b/subsys/lorawan/Kconfig
@@ -6,6 +6,7 @@
 menuconfig LORAWAN
 	bool "LoRaWAN support [EXPERIMENTAL]"
 	depends on LORA
+	select REQUIRES_FULL_LIBC
 	select HAS_SEMTECH_LORAMAC
 	select HAS_SEMTECH_SOFT_SE
 	select EXPERIMENTAL


### PR DESCRIPTION
Move the `REQUIRES_FULL_LIBC` dependency from `config LORA` to
`config LORAWAN`. The commit that added the `select` (f590d4fa) mentions
that this is required by `loramac-node`, which is only used by LoRaWAN,
not the base LoRa code.

This results in small FLASH savings when compiling the samples, but can
result in larger savings in more complex applications:
```
// With REQUIRES_FULL_LIBC
west build -b 96b_wistrio zephyr/samples/drivers/lora/send/
[162/162] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       37708 B       128 KB     28.77%
            SRAM:        8832 B        32 KB     26.95%
        IDT_LIST:          0 GB         2 KB      0.00%

// Without REQUIRES_FULL_LIBC
[181/181] Linking C executable zephyr/zephyr.elf
Memory region         Used Size  Region Size  %age Used
           FLASH:       37444 B       128 KB     28.57%
            SRAM:        8832 B        32 KB     26.95%
        IDT_LIST:          0 GB         2 KB      0.00%
```

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>