### PR TITLE
drivers: usb: device: stm32: Configure USB Prescaler for F103

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -279,10 +279,10 @@ static int usb_dc_stm32_clock_enable(void)
 	 */
 	if (LL_RCC_GetSysClkSource() == LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {
 		switch (sys_clock_hw_cycles_per_sec()) {
-		case 48000000U:
+		case MHZ(48):
 			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL_DIV_2);
 			break;
-		case 72000000U:
+		case MHZ(72):
 			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL_DIV_3);
 			break;
 		default:
@@ -300,10 +300,10 @@ static int usb_dc_stm32_clock_enable(void)
 	 */
 	if (LL_RCC_GetSysClkSource() == LL_RCC_SYS_CLKSOURCE_STATUS_PLL) {
 		switch (sys_clock_hw_cycles_per_sec()) {
-		case 48000000U:
+		case MHZ(48):
 			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL);
 			break;
-		case 72000000U:
+		case MHZ(72):
 			LL_RCC_SetUSBClockSource(LL_RCC_USB_CLKSOURCE_PLL_DIV_1_5);
 			break;
 		default:


### PR DESCRIPTION
- If the HAL headers expose the USBPRE flag, then we're probably
  dealing with a F103 - using the same fundamental logic as the
  code for the OTG models, set-up the USB Prescaler correctly.

- Fixes #47146