### PR TITLE
pm: power_domain: enforce strict initialisation sequencing

### DIFF
--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -88,6 +88,12 @@ static int pd_gpio_init(const struct device *dev)
 		LOG_ERR("GPIO port %s is not ready", cfg->enable.port->name);
 		return -ENODEV;
 	}
+	if (dev->pm->domain && !device_is_ready(dev->pm->domain)) {
+		LOG_ERR("Invalid domain sequencing! %s depends on %s",
+			dev->name, dev->pm->domain->name);
+		return -EINVAL;
+	}
+
 	/* We can't know how long the domain has been off for before boot */
 	data->next_boot = K_TIMEOUT_ABS_US(cfg->off_on_delay_us);
 

--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -109,17 +109,17 @@ static int pd_gpio_init(const struct device *dev)
 	return rc;
 }
 
-#define POWER_DOMAIN_DEVICE(id)						   \
-	static const struct pd_gpio_config pd_gpio_##id##_cfg = {	   \
-		.enable = GPIO_DT_SPEC_INST_GET(id, enable_gpios),	   \
-		.startup_delay_us = DT_INST_PROP(id, startup_delay_us),	   \
-		.off_on_delay_us = DT_INST_PROP(id, off_on_delay_us),	   \
-	};								   \
-	static struct pd_gpio_data pd_gpio_##id##_data;			   \
-	PM_DEVICE_DT_INST_DEFINE(id, pd_gpio_pm_action);		   \
-	DEVICE_DT_INST_DEFINE(id, pd_gpio_init, PM_DEVICE_DT_INST_GET(id), \
-			      &pd_gpio_##id##_data, &pd_gpio_##id##_cfg,   \
-			      POST_KERNEL, 75,				   \
+#define POWER_DOMAIN_DEVICE(id)						    \
+	static const struct pd_gpio_config pd_gpio_##id##_cfg = {	    \
+		.enable = GPIO_DT_SPEC_INST_GET(id, enable_gpios),	    \
+		.startup_delay_us = DT_INST_PROP(id, startup_delay_us),	    \
+		.off_on_delay_us = DT_INST_PROP(id, off_on_delay_us),	    \
+	};								    \
+	static struct pd_gpio_data pd_gpio_##id##_data;			    \
+	PM_DEVICE_DT_INST_DEFINE(id, pd_gpio_pm_action);		    \
+	DEVICE_DT_INST_DEFINE(id, pd_gpio_init, PM_DEVICE_DT_INST_GET(id),  \
+			      &pd_gpio_##id##_data, &pd_gpio_##id##_cfg,    \
+			      POST_KERNEL, DT_INST_PROP(id, init_priority), \
 			      NULL);
 
 DT_INST_FOREACH_STATUS_OKAY(POWER_DOMAIN_DEVICE)

--- a/dts/bindings/power-domain/power-domain-gpio.yaml
+++ b/dts/bindings/power-domain/power-domain-gpio.yaml
@@ -30,3 +30,13 @@ properties:
     required: false
     default: 0
     description: Off delay time, in microseconds
+
+  init-priority:
+    type: int
+    default: 75
+    description: |
+      Device initialisation priority within the POST_KERNEL level.
+      75 is the previous Kconfig hardcoded value to avoid changing
+      initialisation orders. The default will need to change if the
+      power domain depends on another power domain, to ensure that
+      root domains are initialised first.

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -383,7 +383,8 @@ bool pm_device_is_powered(const struct device *dev)
 	 */
 	return (pm == NULL) ||
 	       (pm->domain == NULL) ||
-	       (pm->domain->pm->state == PM_DEVICE_STATE_ACTIVE);
+	       (device_is_ready(pm->domain) &&
+		(pm->domain->pm->state == PM_DEVICE_STATE_ACTIVE));
 #else
 	return true;
 #endif

--- a/tests/subsys/pm/device_power_domains/app.overlay
+++ b/tests/subsys/pm/device_power_domains/app.overlay
@@ -16,5 +16,14 @@
 		label = "test-reg-chained";
 		enable-gpios = <&gpio0 2 0>;
 		power-domain = <&test_reg_0>;
+		init-priority = <76>;
+	};
+
+	test_reg_bad_sequence: test_reg_bad_sequence {
+		compatible = "power-domain-gpio";
+		label = "test-reg-bad-sequence";
+		enable-gpios = <&gpio0 3 0>;
+		power-domain = <&test_reg_0>;
+		init-priority = <74>;
 	};
 };

--- a/tests/subsys/pm/device_power_domains/src/main.c
+++ b/tests/subsys/pm/device_power_domains/src/main.c
@@ -14,11 +14,19 @@ static void test_demo(void)
 	const struct device *reg_0 = DEVICE_DT_GET(DT_NODELABEL(test_reg_0));
 	const struct device *reg_1 = DEVICE_DT_GET(DT_NODELABEL(test_reg_1));
 	const struct device *reg_chained = DEVICE_DT_GET(DT_NODELABEL(test_reg_chained));
+	const struct device *reg_bad_sequence = DEVICE_DT_GET(DT_NODELABEL(test_reg_bad_sequence));
+
+	/* Initalization succeeded */
+	zassert_true(device_is_ready(reg_0), "");
+	zassert_true(device_is_ready(reg_1), "");
+	zassert_true(device_is_ready(reg_chained), "");
+	zassert_false(device_is_ready(reg_bad_sequence), "");
 
 	/* Initial power state */
 	zassert_true(pm_device_is_powered(reg_0), "");
 	zassert_true(pm_device_is_powered(reg_1), "");
 	zassert_false(pm_device_is_powered(reg_chained), "");
+	zassert_false(pm_device_is_powered(reg_bad_sequence), "");
 
 	TC_PRINT("Enabling runtime power management on regulators\n");
 


### PR DESCRIPTION
Enforce strict initialisation ordering on power domains that depend on each other. Domains higher in the "chain" MUST be initialised first. This is required so that dependent devices can correctly query the higher level device for their own power state.

Priority cannot be set in Kconfig as per usual because different instances of the same driver need different levels.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>