### PR TITLE
RFC: arch/Kconfig: set default FLASH_{SIZE,BASE_ADDRESS} when CONFIG_XIP=n

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -205,6 +205,7 @@ DT_CHOSEN_Z_FLASH := zephyr,flash
 config FLASH_SIZE
 	int "Flash Size in kB"
 	default $(dt_chosen_reg_size_int,$(DT_CHOSEN_Z_FLASH),0,K) if (XIP && (ARM ||ARM64)) || !ARM
+	default 0
 	help
 	  This option specifies the size of the flash in kB.  It is normally set by
 	  the board's defconfig file and the user should generally avoid modifying
@@ -213,6 +214,7 @@ config FLASH_SIZE
 config FLASH_BASE_ADDRESS
 	hex "Flash Base Address"
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH)) if (XIP && (ARM || ARM64)) || !ARM
+	default 0
 	help
 	  This option specifies the base address of the flash on the board. It is
 	  normally set by the board's defconfig file and the user should generally


### PR DESCRIPTION
Currently these values are not set when CONFIG_XIP=n and samples/tests
will fail to build with cryptic error messages i.e.

$ cd $ZEPHYR_BASE/tests/drivers/uart/uart_basic_api
$ echo "CONFIG_XIP=n" > overlay.conf
$ west build -b xmc45_relax_kit . -DOVERLAY_CONFIG=overlay.conf
..
/tmp/ccMqxKmL.s: Assembler messages:
/tmp/ccMqxKmL.s:67: Error: missing expression
/tmp/ccMqxKmL.s:73: Error: missing expression
[39/160] Building C object zephyr/CMakeFiles/zephyr.dir/lib/os/bitarray.c.obj
ninja: build stopped: subcommand failed.

Setting the default values to 0 fixes the build; the example
uart_basic_api also successfully runs out of SRAM.

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>