### PR TITLE
clang-format: do not put enums in single line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,6 +12,7 @@
 ---
 BasedOnStyle: LLVM
 AlignConsecutiveMacros: AcrossComments
+AllowShortEnumsOnASingleLine: false
 AttributeMacros:
   - __aligned
   - __deprecated


### PR DESCRIPTION
clang-format puts short enums in one single line, making them
unreadable.

for example:

	enum ztest_result {
	    ZTEST_RESULT_PENDING,
	    ZTEST_RESULT_PASS,
	    ZTEST_RESULT_FAIL,
	    ZTEST_RESULT_SKIP
	};
	enum ztest_result { ZTEST_RESULT_PENDING, ZTEST_RESULT_PASS, ZTEST_RESULT_FAIL, ZTEST_RESULT_SKIP };

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
