### PR TITLE
video: mcux_csi: Set driver Kconfig default based on devicetree

### DIFF
--- a/drivers/video/Kconfig.mcux_csi
+++ b/drivers/video/Kconfig.mcux_csi
@@ -3,6 +3,9 @@
 # Copyright (c) 2019, Linaro Limited
 # SPDX-License-Identifier: Apache-2.0
 
+DT_COMPAT_NXP_IMX_CSI := nxp,imx-csi
+
 config VIDEO_MCUX_CSI
 	bool "NXP MCUX CMOS Sensor Interface (CSI) driver"
+	default $(dt_compat_enabled,$(DT_COMPAT_NXP_IMX_CSI))
 	depends on HAS_MCUX_CSI

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -195,10 +195,6 @@ choice USB_MCUX_CONTROLLER_TYPE
 	default USB_DC_NXP_EHCI
 endchoice
 
-config VIDEO_MCUX_CSI
-	default y if HAS_MCUX_CSI
-	depends on VIDEO
-
 config DMA_MCUX_EDMA
 	default y if HAS_MCUX_EDMA
 	depends on DMA


### PR DESCRIPTION
Change Kconfig default to be based on if the devicetree has the
nxp,imx-csi driver enabled.

Signed-off-by: Kumar Gala <galak@kernel.org>