### PR TITLE
arch: support common 64-bit mmio read and write

### DIFF
--- a/include/zephyr/arch/arc/sys-io-common.h
+++ b/include/zephyr/arch/arc/sys-io-common.h
@@ -74,6 +74,28 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	compiler_barrier();
 }
 
+static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
+{
+	uint64_t value;
+
+	compiler_barrier();
+	value = *(volatile uint64_t *)addr;
+	compiler_barrier();
+
+	return value;
+}
+
+#define sys_read64_nonatomic sys_read64
+
+static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
+{
+	compiler_barrier();
+	*(volatile uint64_t *)addr = data;
+	compiler_barrier();
+}
+
+#define sys_write64_nonatomic sys_write64
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/sys_io.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/sys_io.h
@@ -66,6 +66,20 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	*(volatile uint32_t *)addr = data;
 }
 
+static ALWAYS_INLINE uint64_t sys_read64_nonatomic(mem_addr_t addr)
+{
+	uint64_t val = *(volatile uint64_t *)addr;
+
+	__DMB();
+	return val;
+}
+
+static ALWAYS_INLINE void sys_write64_nonatomic(uint64_t data, mem_addr_t addr)
+{
+	__DMB();
+	*(volatile uint64_t *)addr = data;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/arm64/sys_io.h
+++ b/include/zephyr/arch/arm64/sys_io.h
@@ -91,11 +91,15 @@ static ALWAYS_INLINE uint64_t sys_read64(mem_addr_t addr)
 	return val;
 }
 
+#define sys_read64_nonatomic sys_read64
+
 static ALWAYS_INLINE void sys_write64(uint64_t data, mem_addr_t addr)
 {
 	__DMB();
 	__asm__ volatile("str %x0, [%1]" : : "r" (data), "r" (addr));
 }
+
+#define sys_write64_nonatomic sys_write64
 
 #ifdef __cplusplus
 }

--- a/include/zephyr/arch/common/sys_io.h
+++ b/include/zephyr/arch/common/sys_io.h
@@ -50,6 +50,16 @@ static ALWAYS_INLINE void sys_write32(uint32_t data, mem_addr_t addr)
 	*(volatile uint32_t *)addr = data;
 }
 
+static ALWAYS_INLINE uint64_t sys_read64_nonatomic(mem_addr_t addr)
+{
+	return *(volatile uint64_t *)addr;
+}
+
+static ALWAYS_INLINE void sys_write64_nonatomic(uint64_t data, mem_addr_t addr)
+{
+	*(volatile uint64_t *)addr = data;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/zephyr/arch/x86/intel64/arch.h
+++ b/include/zephyr/arch/x86/intel64/arch.h
@@ -28,6 +28,8 @@ static ALWAYS_INLINE void sys_write64(uint64_t data, mm_reg_t addr)
 			 : "memory");
 }
 
+#define sys_write64_nonatomic sys_write64
+
 static ALWAYS_INLINE uint64_t sys_read64(mm_reg_t addr)
 {
 	uint64_t ret;
@@ -39,6 +41,8 @@ static ALWAYS_INLINE uint64_t sys_read64(mm_reg_t addr)
 
 	return ret;
 }
+
+#define sys_read64_nonatomic sys_read64
 
 static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 {

--- a/include/zephyr/sys/sys_io.h
+++ b/include/zephyr/sys/sys_io.h
@@ -233,6 +233,34 @@ typedef uintptr_t mem_addr_t;
  * @return the 64 bits read
  */
 
+/**
+ * @fn static inline void sys_write64_nonatomic(uint64_t data, mm_reg_t addr);
+ * @brief Write 64 bits to a memory mapped register
+ *
+ * This function writes 64 bits to the given memory mapped register.
+ * 
+ * Accesses may be non-atomic on some architectures so this function
+ * should only be used for registers that support non-atomic writes.
+ *
+ * @param data the 64 bits to write
+ * @param addr the memory mapped register address where to write the 64 bits
+ */
+
+/**
+ * @fn static inline uint64_t sys_read64_nonatomic(mm_reg_t addr);
+ * @brief Read 64 bits from a memory mapped register
+ *
+ * This function reads 64 bits from the given memory mapped register.
+ 
+ * Accesses may be non-atomic on some architectures so this function
+ * should only be used for registers that support non-atomic reads.
+ *
+ * @param addr the memory mapped register address from where to read
+ *        the 64 bits
+ *
+ * @return the 64 bits read
+ */
+
 /* Memory bits manipulation functions */
 
 /**


### PR DESCRIPTION
implement sys_read64 and sys_write64 to enable mmio to 64-bit
registers.  Previously these routines were only implemented
for 64-bit processor architectures.

Compilers for 32-bit architectures will generate instruction
load and store sequences for uint64_t types.  Atomicity of
these accesses is not guaranteed as the processor and/or
interconnects could split these accesses into smaller-sized
transactions.

Signed-off-by: Eugene Cohen <quic_egmc@quicinc.com>