### PR TITLE
drivers: sensor: adt7420: Add multi-instance support

### DIFF
--- a/drivers/sensor/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adt7420/adt7420_trigger.c
@@ -101,6 +101,10 @@ int adt7420_trigger_set(const struct device *dev,
 	struct adt7420_data *drv_data = dev->data;
 	const struct adt7420_dev_config *cfg = dev->config;
 
+	if (!cfg->int_gpio.port) {
+		return -ENOTSUP;
+	}
+
 	setup_int(dev, false);
 
 	if (trig->type != SENSOR_TRIG_THRESHOLD) {


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>