### PR TITLE
drivers: adc: stm32: suppress stm32h7 build warning

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -405,6 +405,7 @@ static void adc_stm32_oversampling_scope(ADC_TypeDef *adc, uint32_t ovs_scope)
 	LL_ADC_SetOverSamplingScope(adc, ovs_scope);
 }
 
+#if !defined(CONFIG_SOC_SERIES_STM32H7X)
 /*
  * Function to configure the oversampling ratio and shift. It is basically a
  * wrapper over LL_ADC_SetOverSamplingRatioShift() which in addition stops the
@@ -426,6 +427,7 @@ static void adc_stm32_oversampling_ratioshift(ADC_TypeDef *adc, uint32_t ratio, 
 #endif
 	LL_ADC_ConfigOverSamplingRatioShift(adc, ratio, shift);
 }
+#endif
 
 	/*
 	 * Function to configure the oversampling ratio and shit using stm32 LL


### PR DESCRIPTION
There is a build warning of unused `adc_stm32_oversampling_ratioshift`
function: `[-Werror=unused-function]`. This makes twister fail, as all
warnings are treated as errors.

Fix that by ifndef'ing `adc_stm32_oversampling_ratioshift()`.

Fixes: c57a41c5d2e4 ("drivers/adc: stm32: do not disable the ADC if
  resolution is unchanged")