### PR TITLE
drivers: i2c: Fix deprecated use of I2C_MODE_MASTER in mcux lpi2c driver

### DIFF
--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -273,7 +273,7 @@ static int mcux_lpi2c_recover_bus(const struct device *dev)
 
 	i2c_bitbang_init(&bitbang_ctx, &bitbang_io, (void *)config);
 
-	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate) | I2C_MODE_MASTER;
+	bitrate_cfg = i2c_map_dt_bitrate(config->bitrate) | I2C_MODE_CONTROLLER;
 	error = i2c_bitbang_configure(&bitbang_ctx, bitrate_cfg);
 	if (error != 0) {
 		LOG_ERR("failed to configure I2C bitbang (err %d)", error);


### PR DESCRIPTION
The I2C API recently updated terminology to replace "master" with
"controller", but this instance in the mcux lpi2c driver was missed.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes CI failure in #47005