### PR TITLE
RFC: Voltage divider sensor

### DIFF
--- a/drivers/sensor/CMakeLists.txt
+++ b/drivers/sensor/CMakeLists.txt
@@ -108,6 +108,7 @@ add_subdirectory_ifdef(CONFIG_TACH_NPCX		nuvoton_tach_npcx)
 add_subdirectory_ifdef(CONFIG_ADC_CMP_NPCX	nuvoton_adc_cmp_npcx)
 add_subdirectory_ifdef(CONFIG_TACH_IT8XXX2	ite_tach_it8xxx2)
 add_subdirectory_ifdef(CONFIG_VCMP_IT8XXX2	ite_vcmp_it8xxx2)
+add_subdirectory_ifdef(CONFIG_VOLTAGE_DIVIDER	voltage_divider)
 
 if(CONFIG_USERSPACE OR CONFIG_SENSOR_SHELL OR CONFIG_SENSOR_SHELL_BATTERY)
 # The above if() is needed or else CMake would complain about

--- a/drivers/sensor/Kconfig
+++ b/drivers/sensor/Kconfig
@@ -252,4 +252,6 @@ source "drivers/sensor/ite_tach_it8xxx2/Kconfig"
 
 source "drivers/sensor/ite_vcmp_it8xxx2/Kconfig"
 
+source "drivers/sensor/voltage_divider/Kconfig"
+
 endif # SENSOR

--- a/drivers/sensor/voltage_divider/CMakeLists.txt
+++ b/drivers/sensor/voltage_divider/CMakeLists.txt
@@ -1,0 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
+zephyr_library()
+
+zephyr_library_sources(voltage_divider.c)

--- a/drivers/sensor/voltage_divider/Kconfig
+++ b/drivers/sensor/voltage_divider/Kconfig
@@ -1,0 +1,12 @@
+# Voltage divider sensor configuration options
+
+# Copyright (c) 2022 Aurelien Jarno
+# SPDX-License-Identifier: Apache-2.0
+
+config VOLTAGE_DIVIDER
+	bool "Voltage divider"
+	default y
+	depends on DT_HAS_VOLTAGE_DIVIDER_ENABLED
+	depends on ADC
+	help
+	  Enable driver for Voltage Divider and then also ADC

--- a/drivers/sensor/voltage_divider/voltage_divider.c
+++ b/drivers/sensor/voltage_divider/voltage_divider.c
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2022 Aurelien Jarno
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/device.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/logging/log.h>
+
+LOG_MODULE_REGISTER(voltage_divider, CONFIG_SENSOR_LOG_LEVEL);
+
+#if DT_HAS_COMPAT_STATUS_OKAY(voltage_divider)
+#define DT_DRV_COMPAT voltage_divider
+#else
+#error "No compatible devicetree node found"
+#endif
+
+struct voltage_divider_data {
+	const struct adc_dt_spec adc_channel;
+	const struct gpio_dt_spec power_gpios;
+	struct adc_sequence adc_seq;
+	struct k_mutex mutex;
+	int16_t sample_buffer;
+	int16_t raw; /* raw adc Sensor value */
+};
+
+struct voltage_divider_config {
+	/* output_ohm is used as a flag value: if it is nonzero then
+	 * the voltage is measured through a voltage divider;
+	 * otherwise it is assumed to be directly connected.
+	 */
+	uint32_t output_ohms;
+	uint32_t full_ohms;
+};
+
+static int voltage_divider_enable(const struct device *dev, bool enable)
+{
+	struct voltage_divider_data *data = dev->data;
+	int rc = 0;
+
+	if (data->power_gpios.port) {
+		rc = gpio_pin_set_dt(&data->power_gpios, 1);
+		if (rc) {
+			LOG_ERR("Failed to set GPIO %s.%u: %d",
+				data->power_gpios.port->name, data->power_gpios.pin, rc);
+		}
+	}
+
+	return rc;
+}
+
+static int voltage_divider_sample_fetch(const struct device *dev, enum sensor_channel chan)
+{
+	struct voltage_divider_data *data = dev->data;
+	struct adc_sequence *sp = &data->adc_seq;
+	int rc;
+
+	if (chan != SENSOR_CHAN_ALL && chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	k_mutex_lock(&data->mutex, K_FOREVER);
+
+	rc = voltage_divider_enable(dev, 1);
+	if (rc) {
+		goto unlock;
+	}
+
+	rc = adc_channel_setup_dt(&data->adc_channel);
+
+	if (rc) {
+		LOG_ERR("Setup AIN%u got %d", data->adc_channel.channel_id, rc);
+		goto unlock;
+	}
+
+	rc = adc_read(data->adc_channel.dev, sp);
+	if (rc == 0) {
+		data->raw = data->sample_buffer;
+	}
+
+unlock:
+	rc = voltage_divider_enable(dev, 0);
+
+	k_mutex_unlock(&data->mutex);
+
+	return rc;
+}
+
+static int voltage_divider_channel_get(const struct device *dev, enum sensor_channel chan,
+				  struct sensor_value *val)
+{
+	struct voltage_divider_data *data = dev->data;
+	const struct voltage_divider_config *cfg = dev->config;
+	int32_t mv;
+	float voltage;
+
+	if (chan != SENSOR_CHAN_VOLTAGE) {
+		return -ENOTSUP;
+	}
+
+	/* Sensor value in millivolts */
+	mv = data->raw;
+	adc_raw_to_millivolts_dt(&data->adc_channel, &mv);
+
+	/* Convert to volts */
+	voltage = mv / 1000.0f;
+
+	/* considering the voltage input through a resistor bridge */
+	if (cfg->output_ohms != 0) {
+		voltage *= (float)cfg->full_ohms / cfg->output_ohms;
+	}
+
+	return sensor_value_from_double(val, voltage);
+}
+
+static const struct sensor_driver_api voltage_divider_driver_api = {
+	.sample_fetch = voltage_divider_sample_fetch,
+	.channel_get = voltage_divider_channel_get,
+};
+
+static int voltage_divider_init(const struct device *dev)
+{
+	struct voltage_divider_data *data = dev->data;
+	struct adc_sequence *asp = &data->adc_seq;
+	int rc;
+
+	k_mutex_init(&data->mutex);
+
+	if (!device_is_ready(data->adc_channel.dev)) {
+		LOG_ERR("Device %s is not ready", data->adc_channel.dev->name);
+		return -ENODEV;
+	}
+
+	/* Configure the power GPIO if available */
+	if (data->power_gpios.port) {
+		if (!device_is_ready(data->power_gpios.port)) {
+			LOG_ERR("Failed to get GPIO %s", data->power_gpios.port->name);
+			return -ENODEV;
+		}
+
+		rc = gpio_pin_configure_dt(&data->power_gpios, GPIO_OUTPUT_INACTIVE);
+		if (rc) {
+			LOG_ERR("Failed to control feed %s.%u: %d",
+				data->power_gpios.port->name, data->power_gpios.pin, rc);
+			return rc;
+		}
+	}
+
+	adc_sequence_init_dt(&data->adc_channel, asp);
+	asp->buffer = &data->sample_buffer;
+	asp->buffer_size = sizeof(data->sample_buffer);
+
+	return 0;
+}
+
+/* Main instantiation macro */
+#define DEFINE_VOLTAGE_DIVIDER(inst) \
+	static const struct voltage_divider_config voltage_divider_dev_config_##inst = { \
+		.output_ohms = DT_INST_PROP(inst, output_ohms), \
+		.full_ohms = DT_INST_PROP(inst, full_ohms), \
+	}; \
+	static struct voltage_divider_data voltage_divider_dev_data_##inst = { \
+		.adc_channel = ADC_DT_SPEC_INST_GET(inst), \
+		.power_gpios = GPIO_DT_SPEC_INST_GET_OR(inst, power_gpios, {0}) \
+	}; \
+	DEVICE_DT_INST_DEFINE(inst, voltage_divider_init, NULL, \
+		&voltage_divider_dev_data_##inst, &voltage_divider_dev_config_##inst, \
+		POST_KERNEL, \
+		CONFIG_SENSOR_INIT_PRIORITY, &voltage_divider_driver_api);
+
+DT_INST_FOREACH_STATUS_OKAY(DEFINE_VOLTAGE_DIVIDER)

--- a/samples/sensor/stm32_vbat_sensor/README.rst
+++ b/samples/sensor/stm32_vbat_sensor/README.rst
@@ -7,7 +7,7 @@ Overview
 ********
 
 This sample reads the Vbat from the STM32 Internal
-Sensor and displays the results.
+Sensor using the Voltage Divider driver and displays the results.
 
 Building and Running
 ********************
@@ -19,20 +19,30 @@ board DT file or with a board overlay in the samples/sensor/stm32_temp_sensor/bo
 .. code-block:: dts
 
     stm32_vbat: stm32vbat {
-        compatible = "st,stm32-vbat";
+        compatible = "voltage_divider";
         io-channels = <&adc1 14>;
-        ratio = <3>;
+        full-ohms = <3>;
+        output-ohms = <1>;
         status = "okay";
     };
 
 
-Enable the corresponding ADC, with the correct vref value (in mV)
+Enable the corresponding ADC, with the correct vref value (in mV) and the corresponding
+channel configuration
 
 .. code-block:: dts
 
     &adc1 {
 	vref-mv = <3000>;
 	status = "okay";
+
+        channel@14 {
+            reg = <14>;
+            zephyr,gain = "ADC_GAIN_1";
+            zephyr,reference = "ADC_REF_INTERNAL";
+            zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+            zephyr,resolution = <12>;
+        };
     };
 
 

--- a/samples/sensor/stm32_vbat_sensor/boards/nucleo_g071rb.overlay
+++ b/samples/sensor/stm32_vbat_sensor/boards/nucleo_g071rb.overlay
@@ -3,14 +3,30 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Application overlay for creating vbat sensor device instance
+ * Application overlay for creating voltage divider device instance
  */
+
+#include <zephyr/dt-bindings/adc/adc.h>
 
 / {
 	stm-vbat {
-		compatible = "st,stm32-vbat";
-		ratio = <3>;
+		compatible = "voltage-divider";
 		io-channels = <&adc1 14>;
+	        full-ohms = <3>;
+	        output-ohms = <1>;
 		status = "okay";
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@e {
+		reg = <14>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
 	};
 };

--- a/samples/sensor/stm32_vbat_sensor/boards/nucleo_wb55rg.overlay
+++ b/samples/sensor/stm32_vbat_sensor/boards/nucleo_wb55rg.overlay
@@ -3,14 +3,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  *
- * Application overlay for creating vbat sensor device instance
+ * Application overlay for creating voltage divider device instance
  */
+
+#include <zephyr/dt-bindings/adc/adc.h>
 
 / {
 	stm-vbat {
-		compatible = "st,stm32-vbat";
-		ratio = <3>;
+		compatible = "voltage-divider";
 		io-channels = <&adc1 18>;
+	        full-ohms = <3>;
+	        output-ohms = <1>;
 		status = "okay";
 	};
 };
@@ -18,4 +21,15 @@
 &adc1 {
 	has-vbat-channel;
 	vref-mv = <3300>;
+
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@12 {
+		reg = <18>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_MAX>;
+		zephyr,resolution = <12>;
+	};
 };

--- a/samples/sensor/stm32_vbat_sensor/src/main.c
+++ b/samples/sensor/stm32_vbat_sensor/src/main.c
@@ -13,10 +13,10 @@ void main(void)
 {
 	struct sensor_value val;
 	int rc;
-	const struct device *dev = DEVICE_DT_GET_ONE(st_stm32_vbat);
+	const struct device *dev = DEVICE_DT_GET_ONE(voltage_divider);
 
 	if (!device_is_ready(dev)) {
-		printk("VBAT sensor is not ready\n");
+		printk("Voltage divider sensor is not ready\n");
 		return;
 	}
 


### PR DESCRIPTION
There is already a `voltage-divider` binding defined, which is only used by the `boards/nrf/battery` sample. Looking at the recently added `stm32_vbat` sensor driver, I realized it might be a good idea to implement a more generic sensor using the existing binding, that can replace the `stm32_vbat` sensor and big part of the battery sample. As a bonus it allows to easily measure other voltages with only 2 resistors. It is actually more versatile than existing sample and drivers as it allows to tune all ADC parameters (resolution, oversampling, gain, ...) at the expense of more entries in the device tree.

For now this is just a RFC to demonstrate the idea. I have fully tested the driver itself. I have converted the `sensor/stm32_vbat_sensor` sample to show the changes are minimal, but only tested compiled it, as I don't have the corresponding boards. If this driver sounds like a good idea, I can also convert the `boards/nrf/battery` sample.


