### PR TITLE
doc/hardware/arch: Add RISC-V information

### DIFF
--- a/doc/hardware/arch/index.rst
+++ b/doc/hardware/arch/index.rst
@@ -8,5 +8,6 @@ Architecture-related Guides
 
    arc-support-status.rst
    arm_cortex_m.rst
+   risc-v.rst
    semihost.rst
    x86.rst

--- a/doc/hardware/arch/risc-v.rst
+++ b/doc/hardware/arch/risc-v.rst
@@ -1,0 +1,37 @@
+Zephyr support status on RISC-V processors
+##########################################
+
+Overview
+********
+
+This page describes current state of Zephyr for RISC-V processors.
+Currently, there's support for some boards, as well as Qemu support
+and support for some FPGA implementations such as neorv32 and
+litex_vexriscv.
+
+Zephyr support includes PMP, :ref:`user mode<usermode_api>`, several
+ISA extensions as well as :ref:`semihosting<semihost_guide>`.
+
+User mode and PMP support
+**************************
+
+When the platform has Physical Memory Protection (PMP) support, enabling
+it on Zephyr allows user space support and stack protection to be
+selected.
+
+ISA extensions
+**************
+
+It's possible to set in Zephyr which ISA extensions (RV32/64I(E)MAFD(G)QC)
+are available on a given platform, by setting the appropriate `RISCV_ISA_*`
+kconfig. Look at :file:`arch/riscv/Kconfig.isa` for more information.
+
+Note that Zephyr SDK toolchain support may not be defined for all
+combinations.
+
+SMP support
+***********
+
+SMP is supported on RISC-V, but currently only on Qemu platforms. In
+order to test the SMP support, one can use `qemu_riscv32_smp` or
+`qemu_riscv64_smp` boards.


### PR DESCRIPTION
This is just a stub with bits of information about RISC-V support on
Zephyr, that can and should be improved over time.

Signed-off-by: Ederson de Souza <ederson.desouza@intel.com>