### PR TITLE
pm: Include a constant to represent FOREVER

### DIFF
--- a/include/zephyr/dt-bindings/power/power.h
+++ b/include/zephyr/dt-bindings/power/power.h
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_POWER_POWER_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_POWER_POWER_H_
+
+#include <limits.h>
+
+#define FOREVER UINT32_MAX
+
+#endif

--- a/subsys/pm/policy.c
+++ b/subsys/pm/policy.c
@@ -14,6 +14,7 @@
 #include <zephyr/sys/time_units.h>
 #include <zephyr/sys/atomic.h>
 #include <zephyr/toolchain.h>
+#include <zephyr/dt-bindings/power/power.h>
 
 #define DT_SUB_LOCK_INIT(node_id)				\
 	{ .state = PM_STATE_DT_INIT(node_id),			\
@@ -89,6 +90,11 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 	for (int16_t i = (int16_t)num_cpu_states - 1; i >= 0; i--) {
 		const struct pm_state_info *state = &cpu_states[i];
 		uint32_t min_residency, exit_latency;
+
+		/* skip a state that set min_residency to FOREVER .*/
+		if (state->min_residency_us == FOREVER) {
+			continue;
+		}
 
 		/* check if there is a lock on state + substate */
 		if (pm_policy_state_lock_is_active(state->state, state->substate_id)) {


### PR DESCRIPTION
There are power states that an application may not want to
automatically use, like PM_STATE_SOFT_OFF. For those states the
application may use the API to force a state and bypass the policy.

The problem is that there is no way to declare such state in device
tree and make clear to the policy that the state should not be
selected. This pr introduces a constant that basically tells the
policy that a state using it should not be selected.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>