### PR TITLE
init: reconstructable `struct init_entry` names

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -50,6 +50,10 @@ New APIs in this release
 Kernel
 ******
 
+* Source files using multiple :c:macro:`SYS_INIT` macros with the
+  same initialisation function must now use :c:macro:`SYS_INIT_NAMED`
+  with unique names per instance.
+
 Architectures
 *************
 

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -53,10 +53,14 @@ struct init_entry {
 
 void z_sys_init_run_level(int32_t level);
 
-/* A counter is used to avoid issues when two or more system devices
- * are declared in the same C file with the same init function.
+/**
+ * @def Z_SYS_NAME
+ *
+ * @brief Construct a namespaced identifier for SYS_INIT instance
+ *
+ * @param _name Base unique name
  */
-#define Z_SYS_NAME(_init_fn) _CONCAT(_CONCAT(sys_init_, _init_fn), __COUNTER__)
+#define Z_SYS_NAME(_name) _CONCAT(sys_init_, _name)
 
 /**
  * @def Z_INIT_ENTRY_DEFINE

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -133,7 +133,28 @@ void z_sys_init_run_level(int32_t level);
  * (e.g. CONFIG_KERNEL_INIT_PRIORITY_DEFAULT + 5).
  */
 #define SYS_INIT(_init_fn, _level, _prio)					\
-	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(_init_fn), _init_fn, NULL, _level, _prio)
+	SYS_INIT_NAMED(_init_fn, _init_fn, _level, _prio)
+
+/**
+ * @def SYS_INIT_NAMED
+ *
+ * @ingroup device_model
+ *
+ * @brief Run an initialization function at boot at specified priority
+ *
+ * @details This macro lets you run a function at system boot.
+ *
+ * @param _name Unique name for SYS_INIT entry. Allows specifying multiple init
+ *              entries that utilise the same function.
+ *
+ * @param _init_fn See @ref SYS_INIT
+ *
+ * @param _level See @ref SYS_INIT
+ *
+ * @param _prio See @ref SYS_INIT
+ */
+#define SYS_INIT_NAMED(_name, _init_fn, _level, _prio)				\
+	Z_INIT_ENTRY_DEFINE(Z_SYS_NAME(_name), _init_fn, NULL, _level, _prio)
 
 #ifdef __cplusplus
 }

--- a/kernel/kheap.c
+++ b/kernel/kheap.c
@@ -52,13 +52,13 @@ static int statics_init(const struct device *unused)
 	return 0;
 }
 
-SYS_INIT(statics_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
+SYS_INIT_NAMED(statics_init_pre, statics_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);
 
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
 /* Need to wait for paging mechanism to be initialized before
  * heaps that are not in pinned sections can be initialized.
  */
-SYS_INIT(statics_init, POST_KERNEL, 0);
+SYS_INIT_NAMED(statics_init_post, statics_init, POST_KERNEL, 0);
 #endif /* CONFIG_DEMAND_PAGING && !CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT */
 
 void *k_heap_aligned_alloc(struct k_heap *h, size_t align, size_t bytes,

--- a/kernel/userspace.c
+++ b/kernel/userspace.c
@@ -895,13 +895,15 @@ static int app_shmem_bss_zero(const struct device *unused)
 	return 0;
 }
 
-SYS_INIT(app_shmem_bss_zero, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT_NAMED(app_shmem_bss_zero_pre, app_shmem_bss_zero,
+	       PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 #if defined(CONFIG_DEMAND_PAGING) && !defined(CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT)
 /* When BSS sections are not present at boot, we need to wait for
  * paging mechanism to be initialized before we can zero out BSS.
  */
-SYS_INIT(app_shmem_bss_zero, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT_NAMED(app_shmem_bss_zero_post, app_shmem_bss_zero,
+	       POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #endif /* CONFIG_DEMAND_PAGING && !CONFIG_LINKER_GENERIC_SECTIONS_PRESENT_AT_BOOT */
 
 /*

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -236,6 +236,24 @@ ZTEST(device, test_device_list)
 	zassert_false((devcount == 0), NULL);
 }
 
+static int sys_init_counter;
+
+static int init_fn(const struct device *dev)
+{
+	sys_init_counter++;
+	return 0;
+}
+
+SYS_INIT(init_fn, APPLICATION, 0);
+SYS_INIT_NAMED(init1, init_fn, APPLICATION, 1);
+SYS_INIT_NAMED(init2, init_fn, APPLICATION, 2);
+SYS_INIT_NAMED(init3, init_fn, APPLICATION, 2);
+
+ZTEST(device, test_sys_init_multiple)
+{
+	zassert_equal(sys_init_counter, 4, "");
+}
+
 /* this is for storing sequence during initialization */
 extern int init_level_sequence[4];
 extern int init_priority_sequence[4];


### PR DESCRIPTION
Allow the names of `struct init_entry` instances to be reconstructed from macro arguments. This is required to allow `SYS_INIT` instances to be registered as device dependencies, which is required for progress towards #22545.

Achieving this requires removing the `__COUNTER__` concatenation in `Z_SYS_NAME`, which in turn requires a new variant of `SYS_INIT` for the rare times when multiple `SYS_INIT` macros use the same initialisation function.