### PR TITLE
device: macros to obtain `struct init_entry`

### DIFF
--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -404,6 +404,28 @@ typedef int16_t device_handle_t;
 #define DEVICE_DECLARE(name) static const struct device DEVICE_NAME_GET(name)
 
 /**
+ * @def DEVICE_INIT_DT_GET
+ *
+ * @brief Get a <tt>const struct init_entry*</tt> from a devicetree node
+ *
+ * @param node_id A devicetree node identifier
+ *
+ * @return A pointer to the init_entry object created for that node
+ */
+#define DEVICE_INIT_DT_GET(node_id) (&Z_INIT_ENTRY_NAME(DEVICE_DT_NAME_GET(node_id)))
+
+/**
+ * @def DEVICE_INIT_GET
+ *
+ * @brief Get a <tt>const struct init_entry*</tt> from a device by name
+ *
+ * @param name The same as dev_name provided to DEVICE_DEFINE()
+ *
+ * @return A pointer to the init_entry object created for that device
+ */
+#define DEVICE_INIT_GET(name) (&Z_INIT_ENTRY_NAME(DEVICE_NAME_GET(name)))
+
+/**
  * @brief Runtime device dynamic structure (in RAM) per driver instance
  *
  * Fields in this are expected to be default-initialized to zero. The

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -59,6 +59,15 @@ void z_sys_init_run_level(int32_t level);
 #define Z_SYS_NAME(_init_fn) _CONCAT(_CONCAT(sys_init_, _init_fn), __COUNTER__)
 
 /**
+ * @def Z_INIT_ENTRY_NAME
+ *
+ * @brief Construct a namespaced identifier for @ref init_entry instance
+ *
+ * @param _entry_name Base unique name
+ */
+#define Z_INIT_ENTRY_NAME(_entry_name) _CONCAT(__init_, _entry_name)
+
+/**
  * @def Z_INIT_ENTRY_DEFINE
  *
  * @brief Create an init entry object and set it up for boot time initialization
@@ -84,7 +93,7 @@ void z_sys_init_run_level(int32_t level);
  */
 #define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
-		_CONCAT(__init_, _entry_name) __used			\
+		Z_INIT_ENTRY_NAME(_entry_name) __used			\
 	__attribute__((__section__(".z_init_" #_level STRINGIFY(_prio)"_"))) = { \
 		.init = (_init_fn),					\
 		.dev = (_device),					\

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -51,27 +51,58 @@ DEVICE_DT_DEFINE(TEST_PARTITION, dev_init, NULL,
 /* Device with both an existing and missing injected dependency */
 DEVICE_DT_DEFINE(TEST_GPIO_INJECTED, dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 70, NULL, DT_DEP_ORD(TEST_DEVB), 999);
+/* Manually specified device */
+DEVICE_DEFINE(manual_dev, "Manual Device", dev_init, NULL,
+		 NULL, NULL, POST_KERNEL, 80, NULL);
 
 #define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
+#define DEV_HDL_NAME(name) device_handle_get(DEVICE_GET(name))
+
+static void test_init_get(void)
+{
+	/* Check device pointers */
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->dev,
+		      DEVICE_DT_GET(TEST_GPIO), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->dev,
+		      DEVICE_DT_GET(TEST_I2C), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->dev,
+		      DEVICE_DT_GET(TEST_DEVA), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->dev,
+		      DEVICE_DT_GET(TEST_DEVB), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->dev,
+		      DEVICE_DT_GET(TEST_GPIOX), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->dev,
+		      DEVICE_DT_GET(TEST_DEVC), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->dev,
+		      DEVICE_DT_GET(TEST_PARTITION), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->dev,
+		      DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
+	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev,
+		      DEVICE_GET(manual_dev), NULL);
+
+	/* Check init functions */
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_GET(manual_dev)->init, dev_init, NULL);
+}
 
 static void test_init_order(void)
 {
-	zassert_equal(init_order[0], DEV_HDL(TEST_GPIO),
-		      NULL);
-	zassert_equal(init_order[1], DEV_HDL(TEST_I2C),
-		      NULL);
-	zassert_equal(init_order[2], DEV_HDL(TEST_DEVA),
-		      NULL);
-	zassert_equal(init_order[3], DEV_HDL(TEST_DEVB),
-		      NULL);
-	zassert_equal(init_order[4], DEV_HDL(TEST_GPIOX),
-		      NULL);
-	zassert_equal(init_order[5], DEV_HDL(TEST_DEVC),
-		      NULL);
-	zassert_equal(init_order[6], DEV_HDL(TEST_PARTITION),
-		      NULL);
-	zassert_equal(init_order[7], DEV_HDL(TEST_GPIO_INJECTED),
-		      NULL);
+	zassert_equal(init_order[0], DEV_HDL(TEST_GPIO), NULL);
+	zassert_equal(init_order[1], DEV_HDL(TEST_I2C), NULL);
+	zassert_equal(init_order[2], DEV_HDL(TEST_DEVA), NULL);
+	zassert_equal(init_order[3], DEV_HDL(TEST_DEVB), NULL);
+	zassert_equal(init_order[4], DEV_HDL(TEST_GPIOX), NULL);
+	zassert_equal(init_order[5], DEV_HDL(TEST_DEVC), NULL);
+	zassert_equal(init_order[6], DEV_HDL(TEST_PARTITION), NULL);
+	zassert_equal(init_order[7], DEV_HDL(TEST_GPIO_INJECTED), NULL);
+	zassert_equal(init_order[8], DEV_HDL_NAME(manual_dev), NULL);
 }
 
 static bool check_handle(device_handle_t hdl,
@@ -297,6 +328,7 @@ void test_main(void)
 	devlist_end = devlist + ndevs;
 
 	ztest_test_suite(devicetree_driver,
+			 ztest_unit_test(test_init_get),
 			 ztest_unit_test(test_init_order),
 			 ztest_unit_test(test_requires),
 			 ztest_unit_test(test_injected),


### PR DESCRIPTION
Add macros to obtain the `const struct init_entry` associated with a `const struct device`.

Injected dependencies for devices (as required by #22545) need to handle both devices and `SYS_INIT` macros, where the only common element is the `struct init_entry`. Passing dependencies in this form is painful without helper macros for obtaining the pointers.