### PR TITLE
samples: alarm: Convert sample to use DEVICE_DT_GET

### DIFF
--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -16,23 +16,23 @@
 struct counter_alarm_cfg alarm_cfg;
 
 #if defined(CONFIG_BOARD_ATSAMD20_XPRO)
-#define TIMER DT_LABEL(DT_NODELABEL(tc4))
+#define TIMER DT_NODELABEL(tc4)
 #elif defined(CONFIG_SOC_FAMILY_SAM)
-#define TIMER DT_LABEL(DT_NODELABEL(tc0))
+#define TIMER DT_NODELABEL(tc0)
 #elif defined(CONFIG_COUNTER_MICROCHIP_MCP7940N)
-#define TIMER DT_LABEL(DT_NODELABEL(extrtc0))
+#define TIMER DT_NODELABEL(extrtc0)
 #elif defined(CONFIG_COUNTER_RTC0)
-#define TIMER DT_LABEL(DT_NODELABEL(rtc0))
+#define TIMER DT_NODELABEL(rtc0)
 #elif defined(CONFIG_COUNTER_RTC_STM32)
-#define TIMER DT_LABEL(DT_INST(0, st_stm32_rtc))
+#define TIMER DT_INST(0, st_stm32_rtc)
 #elif defined(CONFIG_COUNTER_NATIVE_POSIX)
-#define TIMER DT_LABEL(DT_NODELABEL(counter0))
+#define TIMER DT_NODELABEL(counter0)
 #elif defined(CONFIG_COUNTER_XLNX_AXI_TIMER)
-#define TIMER DT_LABEL(DT_INST(0, xlnx_xps_timer_1_00_a))
+#define TIMER DT_INST(0, xlnx_xps_timer_1_00_a)
 #elif defined(CONFIG_COUNTER_ESP32)
-#define TIMER DT_LABEL(DT_NODELABEL(timer0))
+#define TIMER DT_NODELABEL(timer0)
 #elif defined(CONFIG_COUNTER_MCUX_CTIMER)
-#define TIMER DT_LABEL(DT_NODELABEL(ctimer0))
+#define TIMER DT_NODELABEL(ctimer0)
 #endif
 
 static void test_counter_interrupt_fn(const struct device *counter_dev,
@@ -74,13 +74,13 @@ static void test_counter_interrupt_fn(const struct device *counter_dev,
 
 void main(void)
 {
-	const struct device *counter_dev;
+	const struct device *counter_dev = DEVICE_DT_GET(TIMER);
 	int err;
 
 	printk("Counter alarm sample\n\n");
-	counter_dev = device_get_binding(TIMER);
-	if (counter_dev == NULL) {
-		printk("Device not found\n");
+
+	if (!device_is_ready(counter_dev)) {
+		printk("device not ready.\n");
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as we
work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>