### PR TITLE
drivers: lora: sx126x: Replace use of DT_INST_LABEL

### DIFF
--- a/drivers/lora/sx126x.c
+++ b/drivers/lora/sx126x.c
@@ -433,7 +433,7 @@ static int sx126x_lora_init(const struct device *dev)
 	const struct sx126x_config *config = dev->config;
 	int ret;
 
-	LOG_DBG("Initializing %s", DT_INST_LABEL(0));
+	LOG_DBG("Initializing sx126x");
 
 	if (sx12xx_configure_pin(antenna_enable, GPIO_OUTPUT_INACTIVE) ||
 	    sx12xx_configure_pin(rx_enable, GPIO_OUTPUT_INACTIVE) ||


### PR DESCRIPTION
As we work to phase out devicetree 'label' properties, convert
driver to just use sx126x instead of DT_INST_LABEL for logging
purposes.

Signed-off-by: Kumar Gala <galak@kernel.org>