### PR TITLE
  storage: flash_map: remove `device_get_binding`

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -60,11 +60,8 @@ struct flash_area {
 	off_t fa_off;
 	/** Total size */
 	size_t fa_size;
-	/**
-	 * Name of the flash device, suitable for passing to
-	 * device_get_binding().
-	 */
-	const char *fa_dev_name;
+	/** Backing flash device */
+	const struct device *fa_dev;
 };
 
 /**

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -247,7 +247,7 @@ static int littlefs_flash_erase(unsigned int id)
 	}
 
 	LOG_PRINTK("Area %u at 0x%x on %s for %u bytes\n",
-		   id, (unsigned int)pfa->fa_off, pfa->fa_dev_name,
+		   id, (unsigned int)pfa->fa_off, pfa->fa_dev->name,
 		   (unsigned int)pfa->fa_size);
 
 	/* Optional wipe flash contents */

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -40,7 +40,7 @@ static int setup_flash(struct fs_mount_t *mnt)
 
 	rc = flash_area_open(id, &pfa);
 	printk("Area %u at 0x%x on %s for %u bytes\n",
-	       id, (unsigned int)pfa->fa_off, pfa->fa_dev_name,
+	       id, (unsigned int)pfa->fa_off, pfa->fa_dev->name,
 	       (unsigned int)pfa->fa_size);
 
 	if (rc < 0 && IS_ENABLED(CONFIG_APP_WIPE_STORAGE)) {

--- a/subsys/fs/fcb/fcb.c
+++ b/subsys/fs/fcb/fcb.c
@@ -101,7 +101,6 @@ fcb_init(int f_area_id, struct fcb *fcb)
 	int oldest = -1, newest = -1;
 	struct flash_sector *oldest_sector = NULL, *newest_sector = NULL;
 	struct fcb_disk_area fda;
-	const struct device *dev = NULL;
 	const struct flash_parameters *fparam;
 
 	if (!fcb->f_sectors || fcb->f_sector_cnt - fcb->f_scratch_cnt < 1) {
@@ -113,8 +112,7 @@ fcb_init(int f_area_id, struct fcb *fcb)
 		return -EINVAL;
 	}
 
-	dev = device_get_binding(fcb->fap->fa_dev_name);
-	fparam = flash_get_parameters(dev);
+	fparam = flash_get_parameters(fcb->fap->fa_dev);
 	fcb->f_erase_value = fparam->erase_value;
 
 	align = fcb_get_align(fcb);

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -640,7 +640,7 @@ static int littlefs_flash_init(struct fs_mount_t *mountp)
 	dev = flash_area_get_device(*fap);
 	if (dev == NULL) {
 		LOG_ERR("can't get flash device: %s",
-			(*fap)->fa_dev_name);
+			(*fap)->fa_dev->name);
 		return -ENODEV;
 	}
 

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -315,7 +315,7 @@ int settings_backend_init(void)
 	default_settings_nvs.cf_nvs.sector_size = nvs_sector_size;
 	default_settings_nvs.cf_nvs.sector_count = cnt;
 	default_settings_nvs.cf_nvs.offset = fa->fa_off;
-	default_settings_nvs.flash_dev_name = fa->fa_dev_name;
+	default_settings_nvs.flash_dev_name = fa->fa_dev->name;
 
 	rc = settings_nvs_backend_init(&default_settings_nvs);
 	if (rc) {

--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -37,7 +37,7 @@ int flash_area_open(uint8_t id, const struct flash_area **fap)
 		return -ENOENT;
 	}
 
-	if (device_get_binding(area->fa_dev_name) == NULL) {
+	if (!device_is_ready(area->fa_dev)) {
 		return -ENODEV;
 	}
 
@@ -54,62 +54,40 @@ void flash_area_close(const struct flash_area *fa)
 int flash_area_read(const struct flash_area *fa, off_t off, void *dst,
 		    size_t len)
 {
-	const struct device *dev;
-
 	if (!is_in_flash_area_bounds(fa, off, len)) {
 		return -EINVAL;
 	}
 
-	dev = device_get_binding(fa->fa_dev_name);
-
-	return flash_read(dev, fa->fa_off + off, dst, len);
+	return flash_read(fa->fa_dev, fa->fa_off + off, dst, len);
 }
 
 int flash_area_write(const struct flash_area *fa, off_t off, const void *src,
 		     size_t len)
 {
-	const struct device *flash_dev;
-	int rc;
-
 	if (!is_in_flash_area_bounds(fa, off, len)) {
 		return -EINVAL;
 	}
 
-	flash_dev = device_get_binding(fa->fa_dev_name);
-
-	rc = flash_write(flash_dev, fa->fa_off + off, (void *)src, len);
-
-	return rc;
+	return flash_write(fa->fa_dev, fa->fa_off + off, (void *)src, len);
 }
 
 int flash_area_erase(const struct flash_area *fa, off_t off, size_t len)
 {
-	const struct device *flash_dev;
-	int rc;
-
 	if (!is_in_flash_area_bounds(fa, off, len)) {
 		return -EINVAL;
 	}
 
-	flash_dev = device_get_binding(fa->fa_dev_name);
-
-	rc = flash_erase(flash_dev, fa->fa_off + off, len);
-
-	return rc;
+	return flash_erase(fa->fa_dev, fa->fa_off + off, len);
 }
 
 uint32_t flash_area_align(const struct flash_area *fa)
 {
-	const struct device *dev;
-
-	dev = device_get_binding(fa->fa_dev_name);
-
-	return flash_get_write_block_size(dev);
+	return flash_get_write_block_size(fa->fa_dev);
 }
 
 int flash_area_has_driver(const struct flash_area *fa)
 {
-	if (device_get_binding(fa->fa_dev_name) == NULL) {
+	if (!device_is_ready(fa->fa_dev)) {
 		return -ENODEV;
 	}
 
@@ -118,14 +96,14 @@ int flash_area_has_driver(const struct flash_area *fa)
 
 const struct device *flash_area_get_device(const struct flash_area *fa)
 {
-	return device_get_binding(fa->fa_dev_name);
+	return fa->fa_dev;
 }
 
 uint8_t flash_area_erased_val(const struct flash_area *fa)
 {
 	const struct flash_parameters *param;
 
-	param = flash_get_parameters(device_get_binding(fa->fa_dev_name));
+	param = flash_get_parameters(fa->fa_dev);
 
 	return param->erase_value;
 }

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -7,13 +7,14 @@
 
 #define DT_DRV_COMPAT fixed_partitions
 
+#include <zephyr/device.h>
 #include <zephyr/zephyr.h>
 #include <zephyr/storage/flash_map.h>
 
 #define FLASH_AREA_FOO(part)						\
 	{.fa_id = DT_FIXED_PARTITION_ID(part),				\
 	 .fa_off = DT_REG_ADDR(part),					\
-	 .fa_dev_name = DT_LABEL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
+	 .fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),	\
 	 .fa_size = DT_REG_SIZE(part),},
 
 #define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)

--- a/subsys/storage/flash_map/flash_map_integrity.c
+++ b/subsys/storage/flash_map/flash_map_integrity.c
@@ -38,7 +38,6 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
 	mbedtls_md_context_t mbed_hash_ctx;
 	const mbedtls_md_info_t *mbed_hash_info;
 #endif
-	const struct device *dev;
 	int to_read;
 	int pos;
 	int rc;
@@ -71,7 +70,6 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
 	}
 #endif
 
-	dev = device_get_binding(fa->fa_dev_name);
 	to_read = fac->rblen;
 
 	for (pos = 0; pos < fac->clen; pos += to_read) {
@@ -79,7 +77,7 @@ int flash_area_check_int_sha256(const struct flash_area *fa,
 			to_read = fac->clen - pos;
 		}
 
-		rc = flash_read(dev, (fa->fa_off + fac->off + pos),
+		rc = flash_read(fa->fa_dev, (fa->fa_off + fac->off + pos),
 				fac->rbuf, to_read);
 		if (rc != 0) {
 #if defined(CONFIG_FLASH_AREA_CHECK_INTEGRITY_TC)

--- a/subsys/storage/flash_map/flash_map_layout.c
+++ b/subsys/storage/flash_map/flash_map_layout.c
@@ -84,7 +84,7 @@ flash_page_cb cb, struct layout_data *cb_data)
 	cb_data->ret_len = *cnt;
 	cb_data->status = 0;
 
-	flash_dev = device_get_binding(fa->fa_dev_name);
+	flash_dev = fa->fa_dev;
 	flash_area_close(fa);
 	if (flash_dev == NULL) {
 		return -ENODEV;

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -24,7 +24,7 @@ static void fa_cb(const struct flash_area *fa, void *user_data)
 	struct shell *shell = user_data;
 
 	shell_print(shell, "%-4d %-8d %-20s  0x%-10x 0x%-12x",
-		    fa->fa_id, fa->fa_device_id, fa->fa_dev_name,
+		    fa->fa_id, fa->fa_device_id, fa->fa_dev->name,
 		    fa->fa_off, fa->fa_size);
 }
 

--- a/tests/subsys/fs/fcb/src/main.c
+++ b/tests/subsys/fs/fcb/src/main.c
@@ -157,7 +157,7 @@ void test_get_flash_erase_value(void)
 	rc = flash_area_open(TEST_FCB_FLASH_AREA_ID, &fa);
 	zassert_equal(rc, 0, "Failed top open flash area");
 
-	dev = device_get_binding(fa->fa_dev_name);
+	dev = fa->fa_dev;
 	flash_area_close(fa);
 
 	zassert_true(dev != NULL, "Failed to obtain device");

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -166,7 +166,7 @@ void test_flash_area_erased_val(void)
 
 	val = flash_area_erased_val(fa);
 
-	param = flash_get_parameters(device_get_binding(fa->fa_dev_name));
+	param = flash_get_parameters(fa->fa_dev);
 
 	zassert_equal(param->erase_value, val,
 		      "value different than the flash erase value");

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -93,6 +93,7 @@ void test_flash_area_get_sectors(void)
 		zassert_true(rc == 0, "area not erased");
 	}
 
+	flash_area_close(fa);
 }
 
 void test_flash_area_check_int_sha256(void)
@@ -170,6 +171,8 @@ void test_flash_area_erased_val(void)
 
 	zassert_equal(param->erase_value, val,
 		      "value different than the flash erase value");
+
+	flash_area_close(fa);
 }
 
 void test_main(void)


### PR DESCRIPTION
Remove all usage of `device_get_binding` in the subsys by directly storing the `const struct device*` in the `struct flash_area`.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>