### PR TITLE
* lib: mem_blocks: add a usage test for a block

### DIFF
--- a/include/zephyr/sys/mem_blocks.h
+++ b/include/zephyr/sys/mem_blocks.h
@@ -254,6 +254,18 @@ int sys_mem_blocks_alloc_contiguous(sys_mem_blocks_t *mem_block, size_t count,
 int sys_mem_blocks_get(sys_mem_blocks_t *mem_block, void *in_block, size_t count);
 
 /**
+ * @brief check if the region is free
+ *
+ * @param[in]  mem_block  Pointer to memory block object.
+ * @param[in]  in_block   Address of the first block to check
+ * @param[in]  count      Number of blocks to check.
+ *
+ * @retval 1 All memory blocks are free
+ * @retval 0 At least one of the memory blocks is taken
+ */
+int sys_mem_blocks_is_region_free(sys_mem_blocks_t *mem_block, void *in_block, size_t count);
+
+/**
  * @brief Free multiple memory blocks
  *
  * Free multiple memory blocks according to the array of memory

--- a/lib/os/mem_blocks.c
+++ b/lib/os/mem_blocks.c
@@ -141,6 +141,23 @@ out:
 	return ret;
 }
 
+int sys_mem_blocks_is_region_free(sys_mem_blocks_t *mem_block, void *in_block, size_t count)
+{
+	bool result;
+	size_t offset;
+
+	__ASSERT_NO_MSG(mem_block != NULL);
+	__ASSERT_NO_MSG(mem_block->bitmap != NULL);
+	__ASSERT_NO_MSG(mem_block->buffer != NULL);
+
+	offset = ((uint8_t *)in_block - mem_block->buffer) >> mem_block->blk_sz_shift;
+
+	__ASSERT_NO_MSG(offset + count <= mem_block->num_blocks);
+
+	result = sys_bitarray_is_region_cleared(mem_block->bitmap, count, offset);
+	return result;
+}
+
 int sys_mem_blocks_get(sys_mem_blocks_t *mem_block, void *in_block, size_t count)
 {
 	int ret = 0;


### PR DESCRIPTION
add a sys_mem_blocks_is_region_free procedure to test
if the block in question is free or taken

Required for storage of memory banks in save to disk like operations
