### PR TITLE
enhance uart ns16550 driver to get clock frequency from clock manager

### DIFF
--- a/drivers/clock_control/clock_agilex.c
+++ b/drivers/clock_control/clock_agilex.c
@@ -1,7 +1,7 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (C) 2021, Intel Corporation
+ * Copyright (C) 2021-2022, Intel Corporation
  *
  */
 
@@ -25,9 +25,7 @@ static int clk_get_rate(const struct device *dev,
 {
 	ARG_UNUSED(dev);
 
-	struct clock_attr *attr = (struct clock_attr *)(sub_system);
-
-	switch (attr->clock_id) {
+	switch ((intptr_t) sub_system) {
 	case INTEL_SOCFPGA_CLOCK_MPU:
 		*rate = get_mpu_clk();
 		break;

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -4,7 +4,7 @@
 
 /*
  * Copyright (c) 2010, 2012-2015 Wind River Systems, Inc.
- * Copyright (c) 2020 Intel Corp.
+ * Copyright (c) 2020-2022 Intel Corp.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -28,6 +28,7 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/drivers/uart.h>
+#include <zephyr/drivers/clock_control.h>
 #include <zephyr/pm/policy.h>
 #include <zephyr/sys/sys_io.h>
 #include <zephyr/spinlock.h>
@@ -225,6 +226,8 @@ struct uart_ns16550_device_config {
 	uint32_t port;
 #endif
 	uint32_t sys_clk_freq;
+	const struct device *clock_dev;
+	clock_control_subsys_t clock_subsys;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	uart_irq_config_func_t	irq_config_func;
 #endif
@@ -283,19 +286,18 @@ static inline uintptr_t get_port(const struct device *dev)
 #endif
 }
 
-static void set_baud_rate(const struct device *dev, uint32_t baud_rate)
+static void set_baud_rate(const struct device *dev, uint32_t baud_rate, uint32_t pclk)
 {
-	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
 	struct uart_ns16550_dev_data * const dev_data = dev->data;
 	uint32_t divisor; /* baud rate divisor */
 	uint8_t lcr_cache;
 
-	if ((baud_rate != 0U) && (dev_cfg->sys_clk_freq != 0U)) {
+	if ((baud_rate != 0U) && (pclk != 0U)) {
 		/*
 		 * calculate baud rate divisor. a variant of
-		 * (uint32_t)(dev_cfg->sys_clk_freq / (16.0 * baud_rate) + 0.5)
+		 * (uint32_t)(pclk / (16.0 * baud_rate) + 0.5)
 		 */
-		divisor = ((dev_cfg->sys_clk_freq + (baud_rate << 3))
+		divisor = ((pclk + (baud_rate << 3))
 					/ baud_rate) >> 4;
 
 		/* set the DLAB to access the baud rate divisor registers */
@@ -317,6 +319,7 @@ static int uart_ns16550_configure(const struct device *dev,
 	struct uart_ns16550_dev_data * const dev_data = dev->data;
 	const struct uart_ns16550_device_config * const dev_cfg = dev->config;
 	uint8_t mdc = 0U;
+	uint32_t pclk = 0U;
 
 	/* temp for return value if error occurs in this locked region */
 	int ret = 0;
@@ -367,7 +370,23 @@ static int uart_ns16550_configure(const struct device *dev,
 	}
 #endif
 
-	set_baud_rate(dev, cfg->baudrate);
+	/*
+	 * set clock frequency from clock_frequency property if valid,
+	 * otherwise, get clock frequency from clock manager
+	 */
+	if (dev_cfg->sys_clk_freq != 0U) {
+		pclk = dev_cfg->sys_clk_freq;
+	} else {
+		if (dev_cfg->clock_dev == NULL) {
+			ret = -EINVAL;
+			goto out;
+		}
+
+		clock_control_get_rate(dev_cfg->clock_dev, dev_cfg->clock_subsys,
+			   &pclk);
+	}
+
+	set_baud_rate(dev, cfg->baudrate, pclk);
 
 	/* Local structure to hold temporary values to pass to OUTBYTE() */
 	struct uart_config uart_cfg;
@@ -1111,7 +1130,17 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 	UART_NS16550_IRQ_FUNC_DECLARE(n);                                            \
 	static const struct uart_ns16550_device_config uart_ns16550_dev_cfg_##n = {  \
 		DEV_CONFIG_REG_INIT(n)                                               \
-		.sys_clk_freq = DT_INST_PROP(n, clock_frequency),                    \
+		COND_CODE_1(DT_INST_NODE_HAS_PROP(n, clock_frequency), (             \
+				.sys_clk_freq = DT_INST_PROP(n, clock_frequency),    \
+				.clock_dev = NULL,                                   \
+				.clock_subsys = NULL,                                \
+			), (                                                         \
+				.sys_clk_freq = 0,                                   \
+				.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),  \
+				.clock_subsys = (clock_control_subsys_t) DT_INST_PHA(\
+								0, clocks, clkid),   \
+			)                                                            \
+		)                                                                    \
 		DEV_CONFIG_IRQ_FUNC_INIT(n)                                          \
 		DEV_CONFIG_PCP_INIT(n)                                               \
 		.reg_interval = (1 << DT_INST_PROP(n, reg_shift)),                   \

--- a/dts/arm64/intel/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex.dtsi
@@ -1,12 +1,13 @@
 /*
  * SPDX-License-Identifier: Apache-2.0
  *
- * Copyright (C) 2021, Intel Corporation
+ * Copyright (C) 2021-2022, Intel Corporation
  *
  */
 
 #include <arm64/armv8-a.dtsi>
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
+#include <zephyr/dt-bindings/clock/intel_socfpga_clock.h>
 
 / {
 	cpus {
@@ -70,7 +71,7 @@
 		interrupts = <GIC_SPI 108 IRQ_TYPE_LEVEL
 			      IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
-		clock-frequency = <100000000>;
+		clocks = <&clock INTEL_SOCFPGA_CLOCK_UART>;
 		label = "uart_0";
 		status = "disabled";
 	};

--- a/dts/bindings/clock/intel,agilex-clock.yaml
+++ b/dts/bindings/clock/intel,agilex-clock.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2022, Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+description: Agilex clock controller node
+
+compatible: "intel,agilex-clock"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    label:
+      required: true
+
+    "#clock-cells":
+      const: 1
+
+clock-cells:
+  - clkid

--- a/include/zephyr/drivers/clock_control/clock_agilex_ll.h
+++ b/include/zephyr/drivers/clock_control/clock_agilex_ll.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019-2021, Intel Corporation. All rights reserved.
+ * Copyright (c) 2019-2022, Intel Corporation. All rights reserved.
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -116,10 +116,6 @@
 #define CLKMGR_VCOCALIB_MSCNT_SET(x)		(((x) << 16) & 0x00ff0000)
 
 #define CLKMGR_CLR_LOSTLOCK_BYPASS		0x20000000
-
-struct clock_attr {
-	uint32_t clock_id;
-};
 
 void config_clkmgr_handoff(struct handoff *hoff_ptr);
 uint32_t get_mpu_clk(void);


### PR DESCRIPTION
This patch is to extend UART ns16550 driver support to get clock frequency from device tree or clock manager based on the configuration in device tree. The driver will prioritize to get the valid clock frequency defined in devicetree first, otherwise, it will get the clock frequency from clock manager.