### PR TITLE
cmake: Update cmake_minimum_required to 3.20.0

### DIFF
--- a/cmake/bintools/armclang/elfconvert_command.cmake
+++ b/cmake/bintools/armclang/elfconvert_command.cmake
@@ -2,7 +2,7 @@
 # Reason for that is because not a single command covers all use cases,
 # and it must therefore be possible to call individual commands, depending
 # on the arguments used.
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.20.0)
 
 # Handle stripping
 if (STRIP_DEBUG OR STRIP_ALL)

--- a/cmake/linker/armlink/scatter_script.cmake
+++ b/cmake/linker/armlink/scatter_script.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.17)
+cmake_minimum_required(VERSION 3.20.0)
 
 set(SORT_TYPE_NAME Lexical)
 

--- a/cmake/linker/ld/ld_script.cmake
+++ b/cmake/linker/ld/ld_script.cmake
@@ -1,6 +1,6 @@
 # ToDo:
 # - Ensure LMA / VMA sections are correctly grouped similar to scatter file creation.
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.20.0)
 
 set(SORT_TYPE_NAME SORT_BY_NAME)
 

--- a/cmake/package_helper.cmake
+++ b/cmake/package_helper.cmake
@@ -42,7 +42,7 @@
 #          find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 #       the 'foo.overlay' must be specified using '-DOVERLAY_CONFIG=foo.overlay'
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20.0)
 
 # add_custom_target and set_target_properties are not supported in script mode.
 # However, several Zephyr CMake modules create custom target for user convenience

--- a/samples/bluetooth/broadcaster/CMakeLists.txt
+++ b/samples/bluetooth/broadcaster/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(broadcaster)
 

--- a/samples/bluetooth/observer/CMakeLists.txt
+++ b/samples/bluetooth/observer/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(observer)
 

--- a/samples/boards/nrf/nrf53_sync_rtc/CMakeLists.txt
+++ b/samples/boards/nrf/nrf53_sync_rtc/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 set(NET_ZEPHYR_DIR ${CMAKE_CURRENT_BINARY_DIR}/sync_rtc_net-prefix/src/sync_rtc_net-build/zephyr)
 

--- a/samples/boards/nrf/nrf53_sync_rtc/net/CMakeLists.txt
+++ b/samples/boards/nrf/nrf53_sync_rtc/net/CMakeLists.txt
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 if("${BOARD}" STREQUAL "nrf5340dk_nrf5340_cpunet")
 	message(INFO " ${BOARD} compile as slave in this sample")

--- a/samples/drivers/audio/dmic/CMakeLists.txt
+++ b/samples/drivers/audio/dmic/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(dmic)

--- a/samples/drivers/fpga/fpga_controller/CMakeLists.txt
+++ b/samples/drivers/fpga/fpga_controller/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fpga_controller)
 

--- a/samples/drivers/fpga/fpga_controller_shell/CMakeLists.txt
+++ b/samples/drivers/fpga/fpga_controller_shell/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(fpga_controller)
 

--- a/samples/drivers/spi_bitbang/CMakeLists.txt
+++ b/samples/drivers/spi_bitbang/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(spi_bitbang)
 

--- a/samples/shields/x_nucleo_53l0a1/CMakeLists.txt
+++ b/samples/shields/x_nucleo_53l0a1/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 # This sample is specific to x_nucleo_53l0a1 shield. Enforce -DSHIELD option
 set(SHIELD x_nucleo_53l0a1)

--- a/samples/subsys/shell/devmem_load/CMakeLists.txt
+++ b/samples/subsys/shell/devmem_load/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(devmem_load)
 

--- a/samples/tfm_integration/psa_firmware/CMakeLists.txt
+++ b/samples/tfm_integration/psa_firmware/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
+++ b/samples/tfm_integration/tfm_secure_partition/CMakeLists.txt
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 

--- a/tests/arch/arm/arm_mem_protect/CMakeLists.txt
+++ b/tests/arch/arm/arm_mem_protect/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_mem_protect)
 

--- a/tests/arch/arm64/arm64_gicv3_its/CMakeLists.txt
+++ b/tests/arch/arm64/arm64_gicv3_its/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(arm_gicv3_its)

--- a/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
+++ b/tests/bluetooth/controller/ctrl_unsupported/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20.0)
 
 if (NOT BOARD STREQUAL unit_testing)
   message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")

--- a/tests/bluetooth/ctrl_isoal/CMakeLists.txt
+++ b/tests/bluetooth/ctrl_isoal/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_ctrl_isoal)

--- a/tests/bluetooth/df/connection_cte_req/CMakeLists.txt
+++ b/tests/bluetooth/df/connection_cte_req/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(bluetooth_df_connection_cte_req)
 

--- a/tests/drivers/build_all/ieee802154/CMakeLists.txt
+++ b/tests/drivers/build_all/ieee802154/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(build_all)
 

--- a/tests/drivers/espi/CMakeLists.txt
+++ b/tests/drivers/espi/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2021 Google LLC
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(espi)

--- a/tests/lib/devicetree/api_ext/CMakeLists.txt
+++ b/tests/lib/devicetree/api_ext/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(devicetree_extensions)

--- a/tests/lib/devicetree/memory_region/CMakeLists.txt
+++ b/tests/lib/devicetree/memory_region/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(memory_region)

--- a/tests/lib/smf/CMakeLists.txt
+++ b/tests/lib/smf/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(smf)
 

--- a/tests/misc/iterable_sections/CMakeLists.txt
+++ b/tests/misc/iterable_sections/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(iterable_sections)
 

--- a/tests/posix/getopt/CMakeLists.txt
+++ b/tests/posix/getopt/CMakeLists.txt
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(getopt)
 

--- a/tests/subsys/pm/device_wakeup_api/CMakeLists.txt
+++ b/tests/subsys/pm/device_wakeup_api/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 Intel Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-cmake_minimum_required(VERSION 3.13.1)
+cmake_minimum_required(VERSION 3.20.0)
 
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(pm-states-test)


### PR DESCRIPTION
Update all occurrences as current main requires CMake version 3.20.0.

Signed-off-by: Reto Schneider <reto.schneider@husqvarnagroup.com>