### PR TITLE
drivers: MCP7940N initialization fails on Sunday

### DIFF
--- a/drivers/counter/rtc_mcp7940n.c
+++ b/drivers/counter/rtc_mcp7940n.c
@@ -306,9 +306,7 @@ static int set_day_of_week(const struct device *dev, time_t *unix_time)
 	struct tm time_buffer = { 0 };
 	int rc = 0;
 
-	gmtime_r(unix_time, &time_buffer);
-
-	if (time_buffer.tm_wday != 0) {
+	if (gmtime_r(unix_time, &time_buffer) != NULL) {
 		data->registers.rtc_weekday.weekday = time_buffer.tm_wday;
 		rc = write_register(dev, REG_RTC_WDAY,
 			*((uint8_t *)(&data->registers.rtc_weekday)));


### PR DESCRIPTION
There was a wrong check to test if gmtime_r() call was successful. time_buffer.tm_wday == 0 is perfectly valid for Sunday.