### PR TITLE
drivers: sensor: ams_iAQcode: Add multi-instance support

### DIFF
--- a/drivers/sensor/ams_iAQcore/iAQcore.c
+++ b/drivers/sensor/ams_iAQcore/iAQcore.c
@@ -110,12 +110,15 @@ static int iaq_core_init(const struct device *dev)
 	return 0;
 }
 
-static struct iaq_core_data iaq_core_driver;
+#define IAQ_CORE_DEFINE(inst)								\
+	static struct iaq_core_data iaq_core_data_##inst;				\
+											\
+	static const struct iaq_core_config iaq_core_config_##inst = {			\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, iaq_core_init, NULL, &iaq_core_data_##inst,		\
+			      &iaq_core_config_##inst, POST_KERNEL,			\
+			      CONFIG_SENSOR_INIT_PRIORITY, &iaq_core_driver_api);	\
 
-static const struct iaq_core_config iaq_core_config = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-};
-
-DEVICE_DT_INST_DEFINE(0, iaq_core_init, NULL,
-		    &iaq_core_driver, &iaq_core_config, POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY, &iaq_core_driver_api);
+DT_INST_FOREACH_STATUS_OKAY(IAQ_CORE_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>