### PR TITLE
drivers: sensor: bmc150_magn: Add multi-instance support

### DIFF
--- a/drivers/sensor/bmc150_magn/bmc150_magn.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn.c
@@ -577,22 +577,27 @@ static int bmc150_magn_init(const struct device *dev)
 	}
 
 #if defined(CONFIG_BMC150_MAGN_TRIGGER_DRDY)
-	if (bmc150_magn_init_interrupt(dev) < 0) {
-		LOG_ERR("failed to initialize interrupts");
-		return -EINVAL;
+	if (config->int_gpio.port) {
+		if (bmc150_magn_init_interrupt(dev) < 0) {
+			LOG_ERR("failed to initialize interrupts");
+			return -EINVAL;
+		}
 	}
 #endif
 	return 0;
 }
 
-static const struct bmc150_magn_config bmc150_magn_config = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-	IF_ENABLED(CONFIG_BMC150_MAGN_TRIGGER_DRDY,
-		   (.int_gpio = GPIO_DT_SPEC_INST_GET(0, drdy_gpios),))
-};
+#define BMC150_MAGN_DEFINE(inst)								\
+	static struct bmc150_magn_data bmc150_magn_data_##inst;					\
+												\
+	static const struct bmc150_magn_config bmc150_magn_config_##inst = {			\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+		IF_ENABLED(CONFIG_BMC150_MAGN_TRIGGER_DRDY,					\
+			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, drdy_gpios, { 0 }),))	\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(inst, bmc150_magn_init, NULL,					\
+		&bmc150_magn_data_##inst, &bmc150_magn_config_##inst, POST_KERNEL,		\
+		CONFIG_SENSOR_INIT_PRIORITY, &bmc150_magn_api_funcs);				\
 
-static struct bmc150_magn_data bmc150_magn_data;
-
-DEVICE_DT_INST_DEFINE(0, bmc150_magn_init, NULL,
-	    &bmc150_magn_data, &bmc150_magn_config, POST_KERNEL,
-	    CONFIG_SENSOR_INIT_PRIORITY, &bmc150_magn_api_funcs);
+DT_INST_FOREACH_STATUS_OKAY(BMC150_MAGN_DEFINE)

--- a/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
+++ b/drivers/sensor/bmc150_magn/bmc150_magn_trigger.c
@@ -35,6 +35,10 @@ int bmc150_magn_trigger_set(const struct device *dev,
 					dev->config;
 	uint8_t state;
 
+	if (!config->int_gpio.port) {
+		return -ENOTSUP;
+	}
+
 #if defined(CONFIG_BMC150_MAGN_TRIGGER_DRDY)
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
 		setup_drdy(dev, false);


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>