### PR TITLE
drivers: sensor: bmg160: Add multi-instance support

### DIFF
--- a/drivers/sensor/bmg160/bmg160.c
+++ b/drivers/sensor/bmg160/bmg160.c
@@ -20,8 +20,6 @@
 
 LOG_MODULE_REGISTER(BMG160, CONFIG_SENSOR_LOG_LEVEL);
 
-struct bmg160_device_data bmg160_data;
-
 static inline int bmg160_bus_config(const struct device *dev)
 {
 	const struct bmg160_device_config *dev_cfg = dev->config;
@@ -136,6 +134,7 @@ static int bmg160_attr_set(const struct device *dev, enum sensor_channel chan,
 			   const struct sensor_value *val)
 {
 	struct bmg160_device_data *bmg160 = dev->data;
+	const struct bmg160_device_config *config = dev->config;
 	int idx;
 	uint16_t range_dps;
 
@@ -184,6 +183,10 @@ static int bmg160_attr_set(const struct device *dev, enum sensor_channel chan,
 #ifdef CONFIG_BMG160_TRIGGER
 	case SENSOR_ATTR_SLOPE_TH:
 	case SENSOR_ATTR_SLOPE_DUR:
+		if (!config->int_gpio.port) {
+			return -ENOTSUP;
+		}
+
 		return bmg160_slope_config(dev, attr, val);
 #endif
 	default:
@@ -327,19 +330,26 @@ int bmg160_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_BMG160_TRIGGER
-	bmg160_trigger_init(dev);
+	if (cfg->int_gpio.port) {
+		bmg160_trigger_init(dev);
+	}
 #endif
 
 	return 0;
 }
 
-static const struct bmg160_device_config bmg160_config = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-	IF_ENABLED(CONFIG_BMG160_TRIGGER,
-		   (.int_gpio = GPIO_DT_SPEC_INST_GET(0, int_gpios),))
-};
+#define BMG160_DEFINE(inst)									\
+	static struct bmg160_device_data bmg160_data_##inst;					\
+												\
+	static const struct bmg160_device_config bmg160_config_##inst = {			\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+		IF_ENABLED(CONFIG_BMG160_TRIGGER,						\
+			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
+												\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(inst, bmg160_init, NULL,						\
+			      &bmg160_data_##inst, &bmg160_config_##inst,			\
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &bmg160_api);		\
 
-DEVICE_DT_INST_DEFINE(0, bmg160_init, NULL,
-		    &bmg160_data,
-		    &bmg160_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		    &bmg160_api);
+DT_INST_FOREACH_STATUS_OKAY(BMG160_DEFINE)

--- a/drivers/sensor/bmg160/bmg160_trigger.c
+++ b/drivers/sensor/bmg160/bmg160_trigger.c
@@ -121,6 +121,12 @@ int bmg160_trigger_set(const struct device *dev,
 		       const struct sensor_trigger *trig,
 		       sensor_trigger_handler_t handler)
 {
+	const struct bmg160_device_config *config = dev->config;
+
+	if (!config->int_gpio.port) {
+		return -ENOTSUP;
+	}
+
 	if (trig->type == SENSOR_TRIG_DELTA) {
 		return bmg160_anymotion_set(dev, handler);
 	} else if (trig->type == SENSOR_TRIG_DATA_READY) {


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>