### PR TITLE
drivers: sensor: bmm150: Add multi-instance support

### DIFF
--- a/drivers/sensor/bmm150/bmm150.c
+++ b/drivers/sensor/bmm150/bmm150.c
@@ -590,12 +590,15 @@ static int bmm150_init(const struct device *dev)
 	return 0;
 }
 
-static const struct bmm150_config bmm150_config = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-};
+#define BMM150_DEFINE(inst)								\
+	static struct bmm150_data bmm150_data_##inst;					\
+											\
+	static const struct bmm150_config bmm150_config_##inst = {			\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, bmm150_init, NULL,					\
+			      &bmm150_data_##inst, &bmm150_config_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &bmm150_api_funcs);		\
 
-static struct bmm150_data bmm150_data;
-
-DEVICE_DT_INST_DEFINE(0, bmm150_init, NULL,
-			&bmm150_data, &bmm150_config, POST_KERNEL,
-			CONFIG_SENSOR_INIT_PRIORITY, &bmm150_api_funcs);
+DT_INST_FOREACH_STATUS_OKAY(BMM150_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>