### PR TITLE
soc: gd32: Add HAS_SEGGER_RTT

### DIFF
--- a/soc/arm/gigadevice/Kconfig
+++ b/soc/arm/gigadevice/Kconfig
@@ -5,6 +5,7 @@ config SOC_FAMILY_GD32
 	bool
 	select HAS_GD32_HAL
 	select BUILD_OUTPUT_HEX
+	select HAS_SEGGER_RTT
 
 config SOC_FAMILY
 	string


### PR DESCRIPTION
Enable SEGGER RTT for GigaDevice family.

Signed-off-by: Alex Sergeev <asergeev@carbonrobotics.com>