### PR TITLE
drivers: sensor: dht: Add multi-instance support

### DIFF
--- a/drivers/sensor/dht/dht.c
+++ b/drivers/sensor/dht/dht.c
@@ -234,11 +234,15 @@ static int dht_init(const struct device *dev)
 	return rc;
 }
 
-static struct dht_data dht_data;
-static const struct dht_config dht_config = {
-	.dio_gpio = GPIO_DT_SPEC_INST_GET(0, dio_gpios),
-};
+#define DHT_DEFINE(inst)								\
+	static struct dht_data dht_data_##inst;						\
+											\
+	static const struct dht_config dht_config_##inst = {				\
+		.dio_gpio = GPIO_DT_SPEC_INST_GET(inst, dio_gpios),			\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, &dht_init, NULL,					\
+			      &dht_data_##inst, &dht_config_##inst,			\
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &dht_api);	\
 
-DEVICE_DT_INST_DEFINE(0, &dht_init, NULL,
-		    &dht_data, &dht_config,
-		    POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &dht_api);
+DT_INST_FOREACH_STATUS_OKAY(DHT_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>