### PR TITLE
drivers: sensor: grove: Add multi-instance support

### DIFF
--- a/drivers/sensor/grove/light_sensor.c
+++ b/drivers/sensor/grove/light_sensor.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/adc.h>
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <math.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/zephyr.h>
@@ -112,12 +113,16 @@ static int gls_init(const struct device *dev)
 	return 0;
 }
 
-static struct gls_data gls_data;
-static const struct gls_config gls_cfg = {
-	.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(0)),
-	.adc_channel = DT_INST_IO_CHANNELS_INPUT(0),
-};
+#define GLS_DEFINE(inst)							\
+	static struct gls_data gls_data_##inst;					\
+										\
+	static const struct gls_config gls_cfg_##inst = {			\
+		.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(inst)),		\
+		.adc_channel = DT_INST_IO_CHANNELS_INPUT(inst),			\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(inst, &gls_init, NULL,				\
+			      &gls_data_##inst, &gls_cfg_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &gls_api);		\
 
-DEVICE_DT_INST_DEFINE(0, &gls_init, NULL,
-		&gls_data, &gls_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		&gls_api);
+DT_INST_FOREACH_STATUS_OKAY(GLS_DEFINE)

--- a/drivers/sensor/grove/temperature_sensor.c
+++ b/drivers/sensor/grove/temperature_sensor.c
@@ -8,6 +8,7 @@
 
 #include <zephyr/drivers/adc.h>
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <math.h>
 #include <zephyr/drivers/sensor.h>
 #include <zephyr/zephyr.h>
@@ -114,15 +115,19 @@ static int gts_init(const struct device *dev)
 	return 0;
 }
 
-static struct gts_data gts_data;
-static const struct gts_config gts_cfg = {
-	.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(0)),
-	.b_const = (IS_ENABLED(DT_INST_PROP(0, v1p0))
-		    ? 3975
-		    : 4250),
-	.adc_channel = DT_INST_IO_CHANNELS_INPUT(0),
-};
+#define GTS_DEFINE(inst)							\
+	static struct gts_data gts_data_##inst;					\
+										\
+	static const struct gts_config gts_cfg_##inst = {			\
+		.adc = DEVICE_DT_GET(DT_INST_IO_CHANNELS_CTLR(inst)),		\
+		.b_const = (IS_ENABLED(DT_INST_PROP(inst, v1p0))		\
+			? 3975							\
+			: 4250),						\
+		.adc_channel = DT_INST_IO_CHANNELS_INPUT(inst),			\
+	};									\
+										\
+	DEVICE_DT_INST_DEFINE(inst, &gts_init, NULL,				\
+			      &gts_data_##inst, &gts_cfg_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &gts_api);		\
 
-DEVICE_DT_INST_DEFINE(0, &gts_init, NULL,
-		&gts_data, &gts_cfg, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		&gts_api);
+DT_INST_FOREACH_STATUS_OKAY(GTS_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>