### PR TITLE
samples: nrf: onoff_level_lighting_vnd_app: Convert to use gpio_dt_spec

### DIFF
--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/app_gpio.h
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/app_gpio.h
@@ -9,8 +9,8 @@
 #define _APP_GPIO_H
 
 /* GPIO */
-extern const struct device *button_device[4];
-extern const struct device *led_device[4];
+extern const struct gpio_dt_spec button_device[];
+extern const struct gpio_dt_spec led_device[];
 
 void app_gpio_init(void);
 

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/main.c
@@ -94,8 +94,7 @@ static void light_default_status_init(void)
 void update_vnd_led_gpio(void)
 {
 #ifndef ONE_LED_ONE_BUTTON_BOARD
-	gpio_pin_set(led_device[1], DT_GPIO_PIN(DT_ALIAS(led1), gpios),
-		     vnd_user_data.current == STATE_ON);
+	gpio_pin_set_dt(&led_device[1], vnd_user_data.current == STATE_ON);
 #endif
 }
 
@@ -109,13 +108,10 @@ void update_led_gpio(void)
 
 	printk("power-> %d, color-> %d\n", power, color);
 
-	gpio_pin_set(led_device[0], DT_GPIO_PIN(DT_ALIAS(led0), gpios),
-		     ctl->light->current);
+	gpio_pin_set_dt(&led_device[0], ctl->light->current);
 #ifndef ONE_LED_ONE_BUTTON_BOARD
-	gpio_pin_set(led_device[2], DT_GPIO_PIN(DT_ALIAS(led2), gpios),
-		     power < 50);
-	gpio_pin_set(led_device[3], DT_GPIO_PIN(DT_ALIAS(led3), gpios),
-		     color < 50);
+	gpio_pin_set_dt(&led_device[2], power < 50);
+	gpio_pin_set_dt(&led_device[3], color < 50);
 #endif
 }
 

--- a/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
+++ b/samples/boards/nrf/mesh/onoff_level_lighting_vnd_app/src/mesh/publisher.c
@@ -22,8 +22,7 @@ void publish(struct k_work *work)
 	int err = 0;
 
 #ifndef ONE_LED_ONE_BUTTON_BOARD
-	if (gpio_pin_get(button_device[0],
-			 DT_GPIO_PIN(DT_ALIAS(sw0), gpios)) == 1) {
+	if (gpio_pin_get_dt(&button_device[0]) == 1) {
 #if defined(ONOFF)
 		bt_mesh_model_msg_init(root_models[3].pub->msg,
 				       BT_MESH_MODEL_OP_GEN_ONOFF_SET_UNACK);
@@ -45,8 +44,7 @@ void publish(struct k_work *work)
 		net_buf_simple_add_u8(vnd_models[0].pub->msg, tid++);
 		err = bt_mesh_model_publish(&vnd_models[0]);
 #endif
-	} else if (gpio_pin_get(button_device[1],
-				DT_GPIO_PIN(DT_ALIAS(sw1), gpios)) == 1) {
+	} else if (gpio_pin_get_dt(&button_device[1]) == 1) {
 #if defined(ONOFF)
 		bt_mesh_model_msg_init(root_models[3].pub->msg,
 				       BT_MESH_MODEL_OP_GEN_ONOFF_SET_UNACK);
@@ -68,8 +66,7 @@ void publish(struct k_work *work)
 		net_buf_simple_add_u8(vnd_models[0].pub->msg, tid++);
 		err = bt_mesh_model_publish(&vnd_models[0]);
 #endif
-	} else if (gpio_pin_get(button_device[2],
-				DT_GPIO_PIN(DT_ALIAS(sw2), gpios)) == 1) {
+	} else if (gpio_pin_get_dt(&button_device[2]) == 1) {
 #if defined(GENERIC_LEVEL)
 		bt_mesh_model_msg_init(root_models[5].pub->msg,
 				       BT_MESH_MODEL_OP_GEN_LEVEL_SET_UNACK);
@@ -139,8 +136,7 @@ void publish(struct k_work *work)
 		net_buf_simple_add_u8(root_models[16].pub->msg, tid++);
 		err = bt_mesh_model_publish(&root_models[16]);
 #endif
-	} else if (gpio_pin_get(button_device[3],
-				DT_GPIO_PIN(DT_ALIAS(sw3), gpios)) == 1) {
+	} else if (gpio_pin_get_dt(&button_device[3]) == 1) {
 #if defined(GENERIC_LEVEL)
 		bt_mesh_model_msg_init(root_models[5].pub->msg,
 				       BT_MESH_MODEL_OP_GEN_LEVEL_SET_UNACK);
@@ -208,8 +204,7 @@ void publish(struct k_work *work)
 #endif
 	}
 #else
-	if (gpio_pin_get(button_device[0],
-			 DT_GPIO_PIN(DT_ALIAS(sw0), gpios)) == 1) {
+	if (gpio_pin_get_dt(&button_device[0]) == 1) {
 #if defined(ONOFF)
 		static uint8_t state = STATE_ON;
 


### PR DESCRIPTION
Move sample to use gpio_dt_spec for GPIO access.

Signed-off-by: Kumar Gala <galak@kernel.org>