### PR TITLE
tests: net: 6lo: move to new ztest API

### DIFF
--- a/tests/net/6lo/prj.conf
+++ b/tests/net/6lo/prj.conf
@@ -21,3 +21,4 @@ CONFIG_NET_6LO_CONTEXT=y
 #Before modifying this value, add respective code in src/main.c
 CONFIG_NET_MAX_6LO_CONTEXTS=2
 CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -1142,7 +1142,7 @@ static const struct {
 #endif
 };
 
-void test_loop(void)
+ZTEST(t_6lo, test_loop)
 {
 	int count;
 
@@ -1169,8 +1169,4 @@ void test_loop(void)
 }
 
 /*test case main entry*/
-void test_main(void)
-{
-	ztest_test_suite(test_6lo, ztest_unit_test(test_loop));
-	ztest_run_test_suite(test_6lo);
-}
+ZTEST_SUITE(t_6lo, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Move tests/net/6lo/ to use new ztest API.

Signed-off-by: Xiao Song <songx.xiao@intel.com>