### PR TITLE
storage: flash_map: handle disabled flash devices

### DIFF
--- a/subsys/storage/flash_map/flash_map.c
+++ b/subsys/storage/flash_map/flash_map.c
@@ -37,7 +37,7 @@ int flash_area_open(uint8_t id, const struct flash_area **fap)
 		return -ENOENT;
 	}
 
-	if (!device_is_ready(area->fa_dev)) {
+	if (!area->fa_dev || !device_is_ready(area->fa_dev)) {
 		return -ENODEV;
 	}
 

--- a/subsys/storage/flash_map/flash_map_default.c
+++ b/subsys/storage/flash_map/flash_map_default.c
@@ -11,10 +11,10 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/storage/flash_map.h>
 
-#define FLASH_AREA_FOO(part)						\
-	{.fa_id = DT_FIXED_PARTITION_ID(part),				\
-	 .fa_off = DT_REG_ADDR(part),					\
-	 .fa_dev = DEVICE_DT_GET(DT_MTD_FROM_FIXED_PARTITION(part)),	\
+#define FLASH_AREA_FOO(part)							\
+	{.fa_id = DT_FIXED_PARTITION_ID(part),					\
+	 .fa_off = DT_REG_ADDR(part),						\
+	 .fa_dev = DEVICE_DT_GET_OR_NULL(DT_MTD_FROM_FIXED_PARTITION(part)),	\
 	 .fa_size = DT_REG_SIZE(part),},
 
 #define FOREACH_PARTITION(n) DT_FOREACH_CHILD(DT_DRV_INST(n), FLASH_AREA_FOO)

--- a/tests/subsys/storage/flash_map/app.overlay
+++ b/tests/subsys/storage/flash_map/app.overlay
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022, Commonwealth Scientific and Industrial Research
+ * Organisation (CSIRO) ABN 41 687 119 230.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Test compilation with disabled flash nodes.
+ */
+
+/{
+	disabled_flash@0 {
+		compatible = "vnd,flash";
+		reg = <0x00 0x1000>;
+		label = "DISABLED FLASH";
+		status = "disabled";
+
+		partitions {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+
+			disabled_a: partition@0 {
+				label = "disabled_a";
+				reg = <0x00000000 0x00001000>;
+			};
+			disabled_b: partition@1000 {
+				label = "disabled_b";
+				reg = <0x00001000 0x00001000>;
+			};
+		};
+	};
+};

--- a/tests/subsys/storage/flash_map/src/main.c
+++ b/tests/subsys/storage/flash_map/src/main.c
@@ -13,6 +13,18 @@
 extern int flash_map_entries;
 struct flash_sector fs_sectors[256];
 
+void test_flash_area_disabled_device(void)
+{
+	const struct flash_area *fa;
+	int rc;
+
+	/* Test that attempting to open a disabled flash area fails */
+	rc = flash_area_open(FLASH_AREA_ID(disabled_a), &fa);
+	zassert_equal(rc, -ENODEV, "Open did not fail");
+	rc = flash_area_open(FLASH_AREA_ID(disabled_b), &fa);
+	zassert_equal(rc, -ENODEV, "Open did not fail");
+}
+
 /**
  * @brief Test flash_area_get_sectors()
  */
@@ -178,6 +190,7 @@ void test_flash_area_erased_val(void)
 void test_main(void)
 {
 	ztest_test_suite(test_flash_map,
+			ztest_unit_test(test_flash_area_disabled_device),
 			 ztest_unit_test(test_flash_area_erased_val),
 			 ztest_unit_test(test_flash_area_get_sectors),
 			 ztest_unit_test(test_flash_area_check_int_sha256)


### PR DESCRIPTION
The changes in #47193 broke compilation when `fixed-partition`'s exist on a flash device that has no driver compiled into the application. This PR provides a workaround.

Disabling the parent flash device with `status = "disabled"` will now result in `.fa_dev == NULL`. This does not fix the case where a partition exists on a device with `status = "okay"` but no driver exists for the device. That situation still results in a `undefined reference to "__device_dts_ord_17"`.

The alternative is to revert #47193 pending a rework of how the `default_flash_map` is constructed.