### PR TITLE
driver: i2c: npcx: clear FIFO status before a transaction starts

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -627,6 +627,10 @@ static int i2c_ctrl_proc_write_msg(const struct device *dev,
 
 	if (data->oper_state == NPCX_I2C_IDLE) {
 		data->oper_state = NPCX_I2C_WAIT_START;
+
+		/* Clear FIFO status before starting a new transaction */
+		i2c_ctrl_fifo_clear_status(dev);
+
 		/* Issue a START, wait for transaction completed */
 		i2c_ctrl_start(dev);
 
@@ -654,6 +658,10 @@ static int i2c_ctrl_proc_read_msg(const struct device *dev, struct i2c_msg *msg)
 
 	if (data->oper_state == NPCX_I2C_IDLE) {
 		data->oper_state = NPCX_I2C_WAIT_START;
+
+		/* Clear FIFO status before starting a new transaction */
+		i2c_ctrl_fifo_clear_status(dev);
+
 		/* Issue a START, wait for transaction completed */
 		i2c_ctrl_start(dev);
 


### PR DESCRIPTION
When an I2C transaction completes, the driver should clear all the FIFO
status. Otherwise, it has the chance to break the operation of the next
transaction. This commit sets the CLR_FIFO bit in the SMBFIF_CTS
register to clear all the FIFO status at the beginning of an I2C
transaction.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>