### PR TITLE
samples: drivers: flash: Add missing fixture requirement

### DIFF
--- a/samples/drivers/soc_flash_nrf/sample.yaml
+++ b/samples/drivers/soc_flash_nrf/sample.yaml
@@ -6,6 +6,7 @@ tests:
     tags: flash nrf52 nrf9160
     harness: console
     harness_config:
+      fixture: external_flash
       type: multi_line
       ordered: true
       regex:


### PR DESCRIPTION
This sample can only be tested if the DUT has external memory
connected. This commit aligns the yaml description, so the test
is not picked up on setups without required fixture.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>