### PR TITLE
drivers: sensor: hp206c: Add multi-instance support

### DIFF
--- a/drivers/sensor/hp206c/hp206c.c
+++ b/drivers/sensor/hp206c/hp206c.c
@@ -313,12 +313,15 @@ static int hp206c_init(const struct device *dev)
 	return 0;
 }
 
-static struct hp206c_device_data hp206c_data;
+#define HP206C_DEFINE(inst)								\
+	static struct hp206c_device_data hp206c_data_##inst;				\
+											\
+	static const struct hp206c_device_config hp206c_config_##inst = {		\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, hp206c_init, NULL,					\
+			      &hp206c_data_##inst, &hp206c_config_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &hp206c_api);		\
 
-static const struct hp206c_device_config hp206c_config = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-};
-
-DEVICE_DT_INST_DEFINE(0, hp206c_init, NULL, &hp206c_data,
-		    &hp206c_config, POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,
-		    &hp206c_api);
+DT_INST_FOREACH_STATUS_OKAY(HP206C_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>