### PR TITLE
pm: remove PM_DEVICE_ACTION_FORCE_SUSPEND

### DIFF
--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -87,8 +87,6 @@ enum pm_device_action {
 	 *     Action triggered only by a power domain.
 	 */
 	PM_DEVICE_ACTION_TURN_ON,
-	/** Force suspend. */
-	PM_DEVICE_ACTION_FORCE_SUSPEND,
 };
 
 /** @cond INTERNAL_HIDDEN */

--- a/subsys/pm/device.c
+++ b/subsys/pm/device.c
@@ -41,8 +41,6 @@ int pm_device_action_run(const struct device *dev,
 	}
 
 	switch (action) {
-	case PM_DEVICE_ACTION_FORCE_SUSPEND:
-		__fallthrough;
 	case PM_DEVICE_ACTION_SUSPEND:
 		if (pm->state == PM_DEVICE_STATE_SUSPENDED) {
 			return -EALREADY;


### PR DESCRIPTION
PM_DEVICE_ACTION_FORCE_SUSPEND has been equivalent to
PM_DEVICE_ACTION_SUSPEND for a while.