### PR TITLE
ec_host_cmd: Convert to DEVICE_DT_GET

### DIFF
--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -55,10 +55,12 @@ static void handle_host_cmds_entry(void *arg1, void *arg2, void *arg3)
 	ARG_UNUSED(arg1);
 	ARG_UNUSED(arg2);
 	ARG_UNUSED(arg3);
-	const struct device *ec_host_cmd_dev;
+	const struct device *ec_host_cmd_dev = DEVICE_DT_GET(DT_HOST_CMD_DEV);
 	struct ec_host_cmd_periph_rx_ctx rx;
 
-	ec_host_cmd_dev = device_get_binding(DT_LABEL(DT_HOST_CMD_DEV));
+	if (!device_is_ready(ec_host_cmd_dev)) {
+		return;
+	}
 
 	ec_host_cmd_periph_init(ec_host_cmd_dev, &rx);
 


### PR DESCRIPTION
We are working on phasing out use of the devicetree 'label'
property.  We can use DEVICE_DT_GET and drop use of DT_LABEL.

Signed-off-by: Kumar Gala <galak@kernel.org>