### PR TITLE
Bluetooth: Host-based Privacy: RPA rotation changes

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2022,6 +2022,26 @@ static inline int bt_le_whitelist_clear(void)
 int bt_le_set_chan_map(uint8_t chan_map[5]);
 
 /**
+ * @brief Set the Resolvable Private Address timeout in runtime
+ *
+ * The new RPA timeout value will be used for the next RPA rotation
+ * and all subsequent rotations until another override is scheduled
+ * with this API.
+ *
+ * Initially, the if @kconfig{CONFIG_BT_RPA_TIMEOUT} is used as the
+ * RPA timeout.
+ *
+ * This symbol is linkable if @kconfig{CONFIG_BT_RPA_TIMEOUT_DYNAMIC}
+ * is enabled.
+ *
+ * @param new_rpa_timeout Resolvable Private Address timeout in seconds
+ *
+ * @retval 0 Success.
+ * @retval -EINVAL RPA timeout value is invalid. Valid range is 1s - 3600s.
+ */
+int bt_le_set_rpa_timeout(uint16_t new_rpa_timeout);
+
+/**
  * @brief Helper for parsing advertising (or EIR or OOB) data.
  *
  * A helper for parsing the basic data types used for Extended Inquiry

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -114,6 +114,22 @@ struct bt_le_ext_adv_cb {
 	 */
 	void (*scanned)(struct bt_le_ext_adv *adv,
 			struct bt_le_ext_adv_scanned_info *info);
+
+#if defined(CONFIG_BT_PRIVACY)
+	/**
+	 * @brief The RPA validity of the advertising set has expired.
+	 *
+	 * This callback notifies the application that the RPA validity of
+	 * the advertising set has expired. The user can use this callback
+	 * to synchronize the advertising payload update with the RPA rotation.
+	 *
+	 * @param adv  The advertising set object.
+	 *
+	 * @return true to rotate the current RPA, or false to use it for the
+	 *         next rotation period.
+	 */
+	bool (*rpa_expired)(struct bt_le_ext_adv *adv);
+#endif /* defined(CONFIG_BT_PRIVACY) */
 };
 
 /**

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -350,6 +350,13 @@ config BT_RPA_TIMEOUT
 	  This option defines how often resolvable private address is rotated.
 	  Value is provided in seconds and defaults to 900 seconds (15 minutes).
 
+config BT_RPA_TIMEOUT_DYNAMIC
+	bool "Support setting the Resolvable Private Address timeout at runtime"
+	depends on BT_PRIVACY
+	help
+	  This option allows the user to override the default value of
+	  the Resolvable Private Address timeout using dedicated APIs.
+
 config BT_SIGNING
 	bool "Data signing support"
 	help

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2492,7 +2492,7 @@ static bool create_param_validate(const struct bt_conn_le_create_param *param)
 {
 #if defined(CONFIG_BT_PRIVACY)
 	/* Initiation timeout cannot be greater than the RPA timeout */
-	const uint32_t timeout_max = (MSEC_PER_SEC / 10) * CONFIG_BT_RPA_TIMEOUT;
+	const uint32_t timeout_max = (MSEC_PER_SEC / 10) * bt_dev.rpa_timeout;
 
 	if (param->timeout > timeout_max) {
 		return false;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -76,6 +76,9 @@ static void init_work(struct k_work *work);
 
 struct bt_dev bt_dev = {
 	.init          = Z_WORK_INITIALIZER(init_work),
+#if defined(CONFIG_BT_PRIVACY)
+	.rpa_timeout   = CONFIG_BT_RPA_TIMEOUT,
+#endif
 #if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
 	.appearance = CONFIG_BT_DEVICE_APPEARANCE,
 #endif
@@ -2975,7 +2978,7 @@ static int le_init(void)
 		}
 
 		cp = net_buf_add(buf, sizeof(*cp));
-		cp->rpa_timeout = sys_cpu_to_le16(CONFIG_BT_RPA_TIMEOUT);
+		cp->rpa_timeout = sys_cpu_to_le16(bt_dev.rpa_timeout);
 		err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_RPA_TIMEOUT, buf,
 					   NULL);
 		if (err) {
@@ -3932,6 +3935,24 @@ int bt_le_set_chan_map(uint8_t chan_map[5])
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_HOST_CHAN_CLASSIF,
 				    buf, NULL);
 }
+
+#if defined(CONFIG_BT_RPA_TIMEOUT_DYNAMIC)
+int bt_le_set_rpa_timeout(uint16_t new_rpa_timeout)
+{
+	if ((new_rpa_timeout == 0) || (new_rpa_timeout > 3600)) {
+		return -EINVAL;
+	}
+
+	if (new_rpa_timeout == bt_dev.rpa_timeout) {
+		return 0;
+	}
+
+	bt_dev.rpa_timeout = new_rpa_timeout;
+	atomic_set_bit(bt_dev.flags, BT_DEV_RPA_TIMEOUT_CHANGED);
+
+	return 0;
+}
+#endif
 
 void bt_data_parse(struct net_buf_simple *ad,
 		   bool (*func)(struct bt_data *data, void *user_data),

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -44,6 +44,7 @@ enum {
 	BT_DEV_INITIATING,
 
 	BT_DEV_RPA_VALID,
+	BT_DEV_RPA_TIMEOUT_CHANGED,
 
 	BT_DEV_ID_PENDING,
 	BT_DEV_STORE_ID,
@@ -358,6 +359,9 @@ struct bt_dev {
 
 	/* Work used for RPA rotation */
 	struct k_work_delayable rpa_update;
+
+	/* The RPA timeout value. */
+	uint16_t rpa_timeout;
 #endif
 
 	/* Local Name */

--- a/subsys/bluetooth/host/id.h
+++ b/subsys/bluetooth/host/id.h
@@ -5,8 +5,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define RPA_TIMEOUT_MS       (CONFIG_BT_RPA_TIMEOUT * MSEC_PER_SEC)
-#define RPA_TIMEOUT          K_MSEC(RPA_TIMEOUT_MS)
+#define RPA_TIMEOUT_MS(_rpa_timeout) (_rpa_timeout * MSEC_PER_SEC)
 
 static inline bool bt_id_rpa_is_new(void)
 {
@@ -16,7 +15,7 @@ static inline bool bt_id_rpa_is_new(void)
 	/* RPA is considered new if there is less than half a second since the
 	 * timeout was started.
 	 */
-	return remaining_ms > (RPA_TIMEOUT_MS - 500);
+	return remaining_ms > (RPA_TIMEOUT_MS(bt_dev.rpa_timeout) - 500);
 #else
 	return false;
 #endif


### PR DESCRIPTION
This PR attempts to improve Host-based Privacy in the Bluetooth subsystem.

Rationale:
1) Synchronizing RPA rotations between multiple advertising sets (prevention from identity bridging).
2) Synchronization of advertising payload and RPA rotation for each advertising set (advertising payloads containing random value compromise privacy if the random part does not change in sync with the RPA).
3) Possibility to delay the rotation on each RPA timeout (seed used to generate the next value of rotating payload cannot be updated).
4) Redefining RPA rotation periods in runtime (possibility to randomize RPA timeout improves privacy).

See the code example below for a demonstration of how to use the new API:

 ```
#define RPA_TIMEOUT_AVERAGE (15 * SEC_PER_MIN)
#define RPA_TIMEOUT_OFFSET_MAX (1 * SEC_PER_MIN)

static uint16_t app_rpa_timeout_randomize(void)
{
	int err;
	int8_t rand;
	uint16_t rpa_timeout = RPA_TIMEOUT_AVERAGE;

	err = sys_csrand_get(&rand, sizeof(rand));
	if (!err) {
		int16_t rand_timeout_diff;

		rand_timeout_diff = (((int)(RPA_TIMEOUT_OFFSET_MAX * MSEC_PER_SEC)) / INT8_MAX);
		rand_timeout_diff *= rand;
		rand_timeout_diff /= ((int) MSEC_PER_SEC);

		rpa_timeout += rand_timeout_diff;
	} else {
		LOG_WRN("Cannot get random RPA timeout (err: %d). Used fixed value", err);
	}

	return rpa_timeout;
}

static bool app_rpa_expired(struct bt_le_ext_adv *adv)
{
	int err;
	uint16_t next_rpa_timeout;

	LOG_INF("RPA expired");

	/* Randomize the next RPA timeout. */
	next_rpa_timeout = app_rpa_timeout_randomize();

	err = bt_le_set_rpa_timeout(next_rpa_timeout);
	if (err) {
		LOG_ERR("bt_le_set_rpa_timeout failed: %d", err);
	} else {
		LOG_INF("Setting RPA timeout to %d [s]", next_rpa_timeout);
	}

	/* Update the advertising payload in sync with the RPA timeout. */
	err = bt_le_ext_adv_set_data(adv, ad, ARRAY_SIZE(ad), sd, ARRAY_SIZE(sd));
	if (err) {
		LOG_ERR("Cannot set advertising data (err: %d)", err);
		return false;
	}

	return true;
}
```