### PR TITLE
drivers: sensor: lsm303dlhc_magn: Add multi-instance support

### DIFF
--- a/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
+++ b/drivers/sensor/lsm303dlhc_magn/lsm303dlhc_magn.c
@@ -126,13 +126,16 @@ static int lsm303dlhc_magn_init(const struct device *dev)
 	return 0;
 }
 
-static const struct lsm303dlhc_magn_config lsm303dlhc_magn_config = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-};
+#define LSM303DLHC_MAGN_DEFINE(inst)								\
+	static struct lsm303dlhc_magn_data lsm303dlhc_magn_data_##inst;				\
+												\
+	static const struct lsm303dlhc_magn_config lsm303dlhc_magn_config_##inst = {		\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(inst, lsm303dlhc_magn_init, NULL,					\
+			      &lsm303dlhc_magn_data_##inst, &lsm303dlhc_magn_config_##inst,	\
+			      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY,				\
+			      &lsm303dlhc_magn_driver_api);					\
 
-static struct lsm303dlhc_magn_data lsm303dlhc_magn_driver;
-
-DEVICE_DT_INST_DEFINE(0, lsm303dlhc_magn_init, NULL,
-		    &lsm303dlhc_magn_driver,
-		    &lsm303dlhc_magn_config, POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY, &lsm303dlhc_magn_driver_api);
+DT_INST_FOREACH_STATUS_OKAY(LSM303DLHC_MAGN_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>