### PR TITLE
Bluetooth: controller: llcp: Fix data pause/resume

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -239,16 +239,21 @@ void llcp_tx_enqueue(struct ll_conn *conn, struct node_tx *tx)
 
 void llcp_tx_pause_data(struct ll_conn *conn, enum llcp_tx_q_pause_data_mask pause_mask)
 {
-	if ((conn->llcp.tx_q_pause_data_mask & pause_mask) == 0) {
-		conn->llcp.tx_q_pause_data_mask |= pause_mask;
+	/* Only pause the TX Q if we have not already paused it (by any procedure) */
+	if (conn->llcp.tx_q_pause_data_mask == 0) {
 		ull_tx_q_pause_data(&conn->tx_q);
 	}
+
+	/* Add the procedure that paused data */
+	conn->llcp.tx_q_pause_data_mask |= pause_mask;
 }
 
 void llcp_tx_resume_data(struct ll_conn *conn, enum llcp_tx_q_pause_data_mask resume_mask)
 {
+	/* Remove the procedure that paused data */
 	conn->llcp.tx_q_pause_data_mask &= ~resume_mask;
 
+	/* Only resume the TX Q if we have removed all procedures that paused data */
 	if (conn->llcp.tx_q_pause_data_mask == 0) {
 		ull_tx_q_resume_data(&conn->tx_q);
 	}


### PR DESCRIPTION
llcp_tx_pause_data() calls ull_tx_q_pause_data() for each pause_mask,
while llcp_tx_resume_data() only calls ull_tx_q_resume_data() when
conn->llcp.tx_q_pause_data_mask == 0 leading to an unbalanced number of
calls to ull_tx_q_pause_data()/ull_tx_q_resume_data() which can leave
the data path of the TX Q paused.

Fix such that only the first call to llcp_tx_pause_data() will pause the
data path of the TX Q.

Add unit test to verify correct pause/resume behavior.

Signed-off-by: Thomas Ebert Hansen <thoh@oticon.com>