### PR TITLE
include: zephyr: remove __ZEPHYR__

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -31,6 +31,13 @@ Changes in this release
   release.  The :zephyr_file:`scripts/utils/migrate_includes.py` script is
   provided to automate the migration.
 
+* :zephyr_file:`include/zephyr/zephyr.h` no longer defines ``__ZEPHYR__``.
+  This definition can be used by third-party code to compile code conditional
+  to Zephyr. The definition is already injected by the Zephyr build system.
+  Therefore, any third-party code integrated using the Zephyr build system will
+  require no changes. External build systems will need to inject the definition
+  by themselves, if they did not already.
+
 Removed APIs in this release
 ============================
 

--- a/include/zephyr/zephyr.h
+++ b/include/zephyr/zephyr.h
@@ -7,14 +7,6 @@
 #ifndef ZEPHYR_INCLUDE_ZEPHYR_H_
 #define ZEPHYR_INCLUDE_ZEPHYR_H_
 
-/*
- * Applications can identify whether they are built for Zephyr by
- * macro below. (It may be already defined by a makefile or toolchain.)
- */
-#ifndef __ZEPHYR__
-#define __ZEPHYR__
-#endif
-
 #include <zephyr/kernel.h>
 
 #endif /* ZEPHYR_INCLUDE_ZEPHYR_H_ */


### PR DESCRIPTION
CMake always injects `__ZEPHYR__` to any code being built on Zephyr (e.g.
a module, an application, etc.). Requiring an include that defines
`__ZEPHYR__` to determine if I'm on Zephyr is problematic as well: it
requires including a Zephyr header (which will exist if building for...
Zephyr! unless a "mock" is provided).

Note that this change leaves <zephyr/zephyr.h> in a questionable
position: why shouldn't I just include <zephyr/kernel.h>?