### PR TITLE
drivers: sensor: mpu6050: Add multi-instance support

### DIFF
--- a/drivers/sensor/mpu6050/mpu6050_trigger.c
+++ b/drivers/sensor/mpu6050/mpu6050_trigger.c
@@ -21,6 +21,10 @@ int mpu6050_trigger_set(const struct device *dev,
 	struct mpu6050_data *drv_data = dev->data;
 	const struct mpu6050_config *cfg = dev->config;
 
+	if (!cfg->int_gpio.port) {
+		return -ENOTSUP;
+	}
+
 	if (trig->type != SENSOR_TRIG_DATA_READY) {
 		return -ENOTSUP;
 	}


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>