### PR TITLE
drivers: sensor: nrf5: Add multi-instance support

### DIFF
--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -135,13 +135,11 @@ static int temp_nrf5_init(const struct device *dev)
 	return 0;
 }
 
-static struct temp_nrf5_data temp_nrf5_driver;
+#define NRF_TEMP_DEFINE(inst)								\
+	static struct temp_nrf5_data temp_nrf5_data_##inst;				\
+											\
+	DEVICE_DT_INST_DEFINE(inst, temp_nrf5_init, NULL,				\
+			      &temp_nrf5_data_##inst, NULL, POST_KERNEL,		\
+			      CONFIG_SENSOR_INIT_PRIORITY, &temp_nrf5_driver_api);	\
 
-DEVICE_DT_INST_DEFINE(0,
-		    temp_nrf5_init,
-		    NULL,
-		    &temp_nrf5_driver,
-		    NULL,
-		    POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY,
-		    &temp_nrf5_driver_api);
+DT_INST_FOREACH_STATUS_OKAY(NRF_TEMP_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>