### PR TITLE
drivers: sensor: pms7003: Add multi-instance support

### DIFF
--- a/drivers/sensor/pms7003/pms7003.c
+++ b/drivers/sensor/pms7003/pms7003.c
@@ -184,12 +184,15 @@ static int pms7003_init(const struct device *dev)
 	return 0;
 }
 
-static const struct pms7003_config pms7003_config = {
-	.uart_dev = DEVICE_DT_GET(DT_INST_BUS(0)),
-};
+#define PMS7003_DEFINE(inst)									\
+	static struct pms7003_data pms7003_data_##inst;						\
+												\
+	static const struct pms7003_config pms7003_config_##inst = {				\
+		.uart_dev = DEVICE_DT_GET(DT_INST_BUS(inst)),					\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(inst, &pms7003_init, NULL,					\
+			      &pms7003_data_##inst, &pms7003_config_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &pms7003_api);			\
 
-static struct pms7003_data pms7003_data;
-
-DEVICE_DT_INST_DEFINE(0, &pms7003_init, NULL,
-		    &pms7003_data, &pms7003_config, POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY, &pms7003_api);
+DT_INST_FOREACH_STATUS_OKAY(PMS7003_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>