### PR TITLE
drivers: sensor: si7055: Add multi-instance support

### DIFF
--- a/drivers/sensor/si7055/si7055.c
+++ b/drivers/sensor/si7055/si7055.c
@@ -144,11 +144,15 @@ static int si7055_init(const struct device *dev)
 	return 0;
 }
 
-static struct si7055_data si_data;
+#define SI7055_DEFINE(inst)								\
+	static struct si7055_data si7055_data_##inst;					\
+											\
+	static const struct si7055_config si7055_config_##inst = {			\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),					\
+	};										\
+											\
+	DEVICE_DT_INST_DEFINE(inst, si7055_init, NULL,					\
+			      &si7055_data_##inst, &si7055_config_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &si7055_api);		\
 
-static const struct si7055_config si7055_config_inst = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-};
-
-DEVICE_DT_INST_DEFINE(0, si7055_init, NULL, &si_data, &si7055_config_inst,
-		      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &si7055_api);
+DT_INST_FOREACH_STATUS_OKAY(SI7055_DEFINE)


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>