### PR TITLE
drivers: sensor: sx9500: Add multi-instance support

### DIFF
--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -31,6 +31,10 @@ int sx9500_trigger_set(const struct device *dev,
 	struct sx9500_data *data = dev->data;
 	const struct sx9500_config *cfg = dev->config;
 
+	if (!cfg->int_gpio.port) {
+		return -ENOTSUP;
+	}
+
 	switch (trig->type) {
 	case SENSOR_TRIG_DATA_READY:
 		if (i2c_reg_update_byte_dt(&cfg->i2c,


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>