### PR TITLE
tests: posix: increase coverage for picolibc

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,7 +1,7 @@
 common:
+  arch_exclude: posix
   tags: posix
   min_ram: 64
-  arch_exclude: posix
   timeout: 120
 
 tests:

--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -4,6 +4,10 @@ common:
 tests:
   portability.posix.eventfd:
     min_ram: 32
+  portability.posix.eventfd.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
   portability.posix.eventfd.picolibc:
     tags: picolibc
     filter: CONFIG_PICOLIBC_SUPPORTED

--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -1,5 +1,11 @@
+common:
+  arch_exclude: posix
+  tags: posix eventfd
 tests:
   portability.posix.eventfd:
-    arch_exclude: posix
     min_ram: 32
-    tags: posix pthread eventfd
+  portability.posix.eventfd.picolibc:
+    tags: picolibc
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_PICOLIBC=y

--- a/tests/posix/eventfd_basic/testcase.yaml
+++ b/tests/posix/eventfd_basic/testcase.yaml
@@ -9,3 +9,13 @@ tests:
   portability.posix.eventfd_basic.posix_api:
     extra_configs:
       - CONFIG_POSIX_API=y
+  portability.posix.eventfd_basic.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+      - CONFIG_POSIX_API=n
+  portability.posix.eventfd_basic.newlib.posix_api:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+      - CONFIG_POSIX_API=y

--- a/tests/posix/eventfd_basic/testcase.yaml
+++ b/tests/posix/eventfd_basic/testcase.yaml
@@ -1,11 +1,11 @@
 common:
   arch_exclude: posix
+  tags: posix eventfd
   min_ram: 32
-  tags: posix pthread eventfd
 tests:
-  posix.eventfd_basic:
+  portability.posix.eventfd_basic:
     extra_configs:
       - CONFIG_POSIX_API=n
-  posix.eventfd_basic.posix_api:
+  portability.posix.eventfd_basic.posix_api:
     extra_configs:
       - CONFIG_POSIX_API=y

--- a/tests/posix/eventfd_basic/testcase.yaml
+++ b/tests/posix/eventfd_basic/testcase.yaml
@@ -19,3 +19,13 @@ tests:
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
       - CONFIG_POSIX_API=y
+  portability.posix.eventfd_basic.picolibc:
+    tags: picolibc
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_PICOLIBC=y
+  portability.posix.eventfd_basic.picolibc.posix_api:
+    tags: picolibc
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_PICOLIBC=y

--- a/tests/posix/fs/testcase.yaml
+++ b/tests/posix/fs/testcase.yaml
@@ -1,7 +1,7 @@
 common:
   arch_exclude: nios2 posix
-  min_ram: 128
   tags: posix filesystem
+  min_ram: 128
   modules:
     - fatfs
 tests:

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -11,3 +11,8 @@ tests:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y
+  portability.posix.getopt.picolibc:
+    tags: picolibc
+    filter: CONFIG_PICOLIBC_SUPPORTED
+    extra_configs:
+      - CONFIG_PICOLIBC=y

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -1,13 +1,13 @@
 common:
-  platform_exclude: native_posix native_posix_64
-  tags: getopt
+  arch_exclude: posix
+  tags: posix getopt
 tests:
-  shell.getopt:
+  portability.posix.getopt:
     integration_platforms:
       - qemu_x86
     min_flash: 64
     min_ram: 32
-  shell.getopt.newlib:
+  portability.posix.getopt.newlib:
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y

--- a/tests/posix/getopt/testcase.yaml
+++ b/tests/posix/getopt/testcase.yaml
@@ -1,9 +1,13 @@
+common:
+  platform_exclude: native_posix native_posix_64
+  tags: getopt
 tests:
   shell.getopt:
-    tags: getopt
-    platform_exclude: native_posix native_posix_64
     integration_platforms:
       - qemu_x86
     min_flash: 64
     min_ram: 32
-    filter: (CONFIG_GETOPT and not CONFIG_NEWLIB_LIBC)
+  shell.getopt.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
* remove unnecessary filter for getopt, add newlib coverage
* increase consistency in naming / tagging of `tests/posix/*`
* additional testing against newlib (for consistency)
* add picolibc test coverage to remaining areas of `tests/posix/*`

Fixes #47288