### PR TITLE
tests: arch: arm: move test arm_irq_vector_table to new ztest API

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/prj.conf
+++ b/tests/arch/arm/arm_irq_vector_table/prj.conf
@@ -1,5 +1,6 @@
 CONFIG_ZTEST=y
 CONFIG_GEN_ISR_TABLES=n
 CONFIG_NUM_IRQS=3
+CONFIG_ZTEST_NEW_API=y
 # Force Bluetooth disable (required by platforms that enable Bluetooth by default)
 CONFIG_BT=n

--- a/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/arm_irq_vector_table.c
@@ -137,7 +137,7 @@ void isr2(void)
  * @see irq_enable(), z_irq_priority_set(), NVIC_SetPendingIRQ()
  *
  */
-void test_arm_irq_vector_table(void)
+ZTEST(vector_table, test_arm_irq_vector_table)
 {
 	printk("Test Cortex-M IRQs installed directly in the vector table\n");
 

--- a/tests/arch/arm/arm_irq_vector_table/src/main.c
+++ b/tests/arch/arm/arm_irq_vector_table/src/main.c
@@ -10,11 +10,4 @@
 
 #include <ztest.h>
 
-extern void test_arm_irq_vector_table(void);
-
-void test_main(void)
-{
-	ztest_test_suite(vector_table,
-		ztest_unit_test(test_arm_irq_vector_table));
-	ztest_run_test_suite(vector_table);
-}
+ZTEST_SUITE(vector_table, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Migrate the testsuite tests/arch/arm/arm_irq_vector_table to the
new ztest API.

Signed-off-by: Shaoan Li <shaoanx.li@intel.com>