### PR TITLE
net: coap: make coap vars configurable

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -264,9 +264,6 @@ typedef int (*coap_reply_t)(const struct coap_packet *response,
 			    struct coap_reply *reply,
 			    const struct sockaddr *from);
 
-#define COAP_DEFAULT_MAX_RETRANSMIT 4
-#define COAP_DEFAULT_ACK_RANDOM_FACTOR 1.5
-
 /**
  * @brief Represents a request awaiting for an acknowledgment (ACK).
  */

--- a/subsys/net/lib/coap/Kconfig
+++ b/subsys/net/lib/coap/Kconfig
@@ -69,6 +69,19 @@ config COAP_RANDOMIZE_ACK_TIMEOUT
 	  COAP_INIT_ACK_TIMEOUT_MS option). Otherwise, the initial ACK timeout
 	  will be fixed to the value of COAP_INIT_ACK_TIMEOUT_MS option.
 
+config COAP_ACK_RANDOM_PERCENT
+	int "Random factor for ACK timeout described as percentage"
+	default 150
+	depends on COAP_RANDOMIZE_ACK_TIMEOUT
+	help
+	  Factor described as percentage to extend CoAP ACK timeout. A value
+	  of 150 means a factor of 1.50.
+
+config COAP_MAX_RETRANSMIT
+	int "Max retransmission of a CoAP packet"
+	default 4
+	range 1 10
+
 config COAP_URI_WILDCARD
 	bool "Wildcards in CoAP resource path"
 	default y

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -1251,7 +1251,7 @@ static uint32_t init_ack_timeout(void)
 {
 #if defined(CONFIG_COAP_RANDOMIZE_ACK_TIMEOUT)
 	const uint32_t max_ack = CONFIG_COAP_INIT_ACK_TIMEOUT_MS *
-				 COAP_DEFAULT_ACK_RANDOM_FACTOR;
+				 CONFIG_COAP_ACK_RANDOM_PERCENT / 100;
 	const uint32_t min_ack = CONFIG_COAP_INIT_ACK_TIMEOUT_MS;
 
 	/* Randomly generated initial ACK timeout

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -365,7 +365,7 @@ int lwm2m_init_message(struct lwm2m_message *msg)
 	}
 
 	r = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr,
-			      COAP_DEFAULT_MAX_RETRANSMIT);
+			      CONFIG_COAP_MAX_RETRANSMIT);
 	if (r < 0) {
 		LOG_ERR("Unable to initialize a pending "
 			"retransmission (err:%d).",
@@ -2122,7 +2122,7 @@ static int lwm2m_response_promote_to_con(struct lwm2m_message *msg)
 	}
 
 	ret = coap_pending_init(msg->pending, &msg->cpkt, &msg->ctx->remote_addr,
-				COAP_DEFAULT_MAX_RETRANSMIT);
+				CONFIG_COAP_MAX_RETRANSMIT);
 	if (ret < 0) {
 		LOG_ERR("Unable to initialize a pending "
 			"retransmission (err:%d).",

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -747,7 +747,7 @@ static void test_retransmit_second_round(void)
 	zassert_not_null(pending, "No free pending");
 
 	r = coap_pending_init(pending, &cpkt, (struct sockaddr *) &dummy_addr,
-			      COAP_DEFAULT_MAX_RETRANSMIT);
+			      CONFIG_COAP_MAX_RETRANSMIT);
 	zassert_equal(r, 0, "Could not initialize packet");
 
 	/* We "send" the packet the first time here */


### PR DESCRIPTION
COAP_DEFAULT_MAX_RETRANSMIT and COAP_DEFAULT_ACK_RANDOM_FACTOR
should be configurable to determine the max transmission
timeout of a CoAP packet.