### PR TITLE
boards: fix pin documentation for LPUART1 on teensy4

### DIFF
--- a/boards/arm/teensy4/teensy4-pinctrl.dtsi
+++ b/boards/arm/teensy4/teensy4-pinctrl.dtsi
@@ -151,7 +151,7 @@
 		};
 	};
 
-	/* LPUART1 TX/RX on Teensy-Pins 20/21 */
+	/* LPUART1 TX/RX on Teensy-Pins 24/25 */
 	pinmux_lpuart1: pinmux_lpuart1 {
 		group0 {
 			pinmux = <&iomuxc_gpio_ad_b0_13_lpuart1_rx>,


### PR DESCRIPTION
LPUART1 is configured on pins ad_b0_12 and ad_b0_13, which corresponds to teensy pins 24/25

Pins 24/25 are already correctly identified as ad_b0_12/13 earlier in the file: https://github.com/zephyrproject-rtos/zephyr/blob/main/boards/arm/teensy4/teensy4-pinctrl.dtsi#L115-L126

Teensy documentation: https://github.com/KurtE/TeensyDocuments/blob/master/Teensy4.1%20Pins%20Mux.pdf

Signed-off-by: Jonas Otto <jonas@jonasotto.com>