### PR TITLE
linker: Fix _vector_end symbol location

### DIFF
--- a/include/zephyr/linker/irq-vector-table-section.ld
+++ b/include/zephyr/linker/irq-vector-table-section.ld
@@ -2,3 +2,10 @@
 
 . = ALIGN(CONFIG_ARCH_IRQ_VECTOR_TABLE_ALIGN);
 KEEP(*(_IRQ_VECTOR_TABLE_SECTION_SYMS))
+
+/*
+ * Some ARM platforms require this symbol to be placed after the IRQ vector
+ * table (like STM32F0). The symbol defined here is overriding the one in
+ * arch/arm/core/aarch32/vector_table.ld when the IRQ vector table is enbled.
+ */
+ _vector_end = .;


### PR DESCRIPTION
The 219d5b5adb22 commit is breaking the STM32F0 platforms.

The problem is that the PR is changing the location the _vector_end
symbol is pointing to. These platforms require the symbol to be pointing
to a location in memory after the IRQ vector table.

Fix the issue by introducing a new _vector_end symbol when the IRQ
vector table is present that points to the correct location.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

Fixes: #47273