### PR TITLE
dts: arm: st: stm32h743.dtsi: fix USB clock enable bit

### DIFF
--- a/dts/arm/st/h7/stm32h743.dtsi
+++ b/dts/arm/st/h7/stm32h743.dtsi
@@ -32,7 +32,7 @@
 			num-bidir-endpoints = <9>;
 			ram-size = <4096>;
 			maximum-speed = "full-speed";
-			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x80000000>;
+			clocks = <&rcc STM32_CLOCK_BUS_AHB1 0x08000000>;
 			phys = <&otghs_fs_phy>;
 			status = "disabled";
 			label= "OTG_FS";


### PR DESCRIPTION
Fix STM32 H743 DTS USB clock enable bit

Note: issue has been highlighted by the merge of PR #46546 