### PR TITLE
drivers: sensor: ti_hdc: Add multi-instance support

### DIFF
--- a/drivers/sensor/ti_hdc/ti_hdc.h
+++ b/drivers/sensor/ti_hdc/ti_hdc.h
@@ -23,20 +23,16 @@
 
 struct ti_hdc_config {
 	struct i2c_dt_spec i2c;
-#if DT_INST_NODE_HAS_PROP(0, drdy_gpios)
 	struct gpio_dt_spec drdy;
-#endif
 };
 
 struct ti_hdc_data {
 	uint16_t t_sample;
 	uint16_t rh_sample;
 
-#if DT_INST_NODE_HAS_PROP(0, drdy_gpios)
 	struct gpio_callback gpio_cb;
 	struct k_sem data_sem;
 	const struct device *dev;
-#endif  /* DT_INST_NODE_HAS_PROP(0, drdy_gpios) */
 };
 
 #endif


### PR DESCRIPTION
drivers: sensor: ti_hdc: Add multi-instance support
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>