### PR TITLE
drivers: sensor: vcnl4040: Add multi-instance support

### DIFF
--- a/drivers/sensor/vcnl4040/vcnl4040.c
+++ b/drivers/sensor/vcnl4040/vcnl4040.c
@@ -316,9 +316,11 @@ static int vcnl4040_init(const struct device *dev)
 	k_sem_init(&data->sem, 0, K_SEM_MAX_LIMIT);
 
 #if CONFIG_VCNL4040_TRIGGER
-	if (vcnl4040_trigger_init(dev)) {
-		LOG_ERR("Could not initialise interrupts");
-		return -EIO;
+	if (config->int_gpio.port) {
+		if (vcnl4040_trigger_init(dev)) {
+			LOG_ERR("Could not initialise interrupts");
+			return -EIO;
+		}
 	}
 #endif
 
@@ -338,22 +340,24 @@ static const struct sensor_driver_api vcnl4040_driver_api = {
 #endif
 };
 
-static const struct vcnl4040_config vcnl4040_config = {
-	.i2c = I2C_DT_SPEC_INST_GET(0),
-#ifdef CONFIG_VCNL4040_TRIGGER
-	.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),
-#endif
-	.led_i = DT_INST_ENUM_IDX(0, led_current),
-	.led_dc = DT_INST_ENUM_IDX(0, led_duty_cycle),
-	.als_it = DT_INST_ENUM_IDX(0, als_it),
-	.proxy_it = DT_INST_ENUM_IDX(0, proximity_it),
-	.proxy_type = DT_INST_ENUM_IDX(0, proximity_trigger),
-};
+#define VCNL4040_DEFINE(inst)									\
+	static struct vcnl4040_data vcnl4040_data_##inst;					\
+												\
+	static const struct vcnl4040_config vcnl4040_config_##inst = {				\
+		.i2c = I2C_DT_SPEC_INST_GET(inst),						\
+		IF_ENABLED(CONFIG_VCNL4040_TRIGGER,						\
+			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, int_gpios, { 0 }),))	\
+		.led_i = DT_INST_ENUM_IDX(inst, led_current),					\
+		.led_dc = DT_INST_ENUM_IDX(inst, led_duty_cycle),				\
+		.als_it = DT_INST_ENUM_IDX(inst, als_it),					\
+		.proxy_it = DT_INST_ENUM_IDX(inst, proximity_it),				\
+		.proxy_type = DT_INST_ENUM_IDX(inst, proximity_trigger),			\
+	};											\
+												\
+	PM_DEVICE_DT_INST_DEFINE(inst, vcnl4040_pm_action);					\
+												\
+	DEVICE_DT_INST_DEFINE(inst, vcnl4040_init, PM_DEVICE_DT_INST_GET(inst),			\
+			      &vcnl4040_data_##inst, &vcnl4040_config_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &vcnl4040_driver_api);		\
 
-static struct vcnl4040_data vcnl4040_data;
-
-PM_DEVICE_DT_INST_DEFINE(0, vcnl4040_pm_action);
-
-DEVICE_DT_INST_DEFINE(0, vcnl4040_init,
-	      PM_DEVICE_DT_INST_GET(0), &vcnl4040_data, &vcnl4040_config,
-	      POST_KERNEL, CONFIG_SENSOR_INIT_PRIORITY, &vcnl4040_driver_api);
+DT_INST_FOREACH_STATUS_OKAY(VCNL4040_DEFINE)

--- a/drivers/sensor/vcnl4040/vcnl4040_trigger.c
+++ b/drivers/sensor/vcnl4040/vcnl4040_trigger.c
@@ -123,7 +123,12 @@ int vcnl4040_attr_set(const struct device *dev,
 		      const struct sensor_value *val)
 {
 	struct vcnl4040_data *data = dev->data;
+	const struct vcnl4040_config *config = dev->config;
 	int ret = 0;
+
+	if (!config->int_gpio.port) {
+		return -ENOTSUP;
+	}
 
 	k_sem_take(&data->sem, K_FOREVER);
 


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>