### PR TITLE
arch: arm: cache: Add cache maintenance functions

### DIFF
--- a/arch/arm/core/aarch32/CMakeLists.txt
+++ b/arch/arm/core/aarch32/CMakeLists.txt
@@ -21,6 +21,10 @@ zephyr_library_sources_ifdef(CONFIG_SW_VECTOR_RELAY irq_relay.S)
 zephyr_library_sources_ifdef(CONFIG_THREAD_LOCAL_STORAGE ../common/tls.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE userspace.S)
 
+if(CONFIG_HAS_ARCH_CACHE)
+  zephyr_library_sources_ifdef(CONFIG_CACHE_MANAGEMENT cache.c)
+endif()
+
 add_subdirectory_ifdef(CONFIG_CPU_CORTEX_M cortex_m)
 add_subdirectory_ifdef(CONFIG_CPU_CORTEX_M_HAS_CMSE cortex_m/cmse)
 add_subdirectory_ifdef(CONFIG_ARM_SECURE_FIRMWARE cortex_m/tz)

--- a/arch/arm/core/aarch32/cache.c
+++ b/arch/arm/core/aarch32/cache.c
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2013-2014 Wind River Systems, Inc.
+ * Copyright (c) 2020-2022 Qualcomm Innovation Center, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+/**
+ * @file
+ * @brief Cache manipulation
+ *
+ * This module contains functions for manipulation caches.
+ */
+
+#include <zephyr/arch/cpu.h>
+#include <zephyr/cache.h>
+
+void arch_dcache_enable(void)
+{
+	SCB_EnableDCache();
+}
+
+void arch_dcache_disable(void)
+{
+	SCB_DisableDCache();
+}
+
+void arch_icache_enable(void)
+{
+	SCB_EnableICache();
+}
+
+void arch_icache_disable(void)
+{
+	SCB_DisableICache();
+}
+
+static void arch_dcache_flush(void *start_addr, size_t size)
+{
+	SCB_CleanDCache_by_Addr(start_addr, size);
+}
+
+static void arch_dcache_invd(void *start_addr, size_t size)
+{
+	SCB_InvalidateDCache_by_Addr(start_addr, size);
+}
+
+static void arch_dcache_flush_and_invd(void *start_addr, size_t size)
+{
+	SCB_CleanInvalidateDCache_by_Addr(start_addr, size);
+}
+
+static void arch_icache_invd(void *start_addr, size_t size)
+{
+	SCB_InvalidateICache_by_Addr(start_addr, size);
+}
+
+int arch_dcache_range(void *addr, size_t size, int op)
+{
+	if (op == K_CACHE_INVD) {
+		arch_dcache_invd(addr, size);
+	} else if (op == K_CACHE_WB) {
+		arch_dcache_flush(addr, size);
+	} else if (op == K_CACHE_WB_INVD) {
+		arch_dcache_flush_and_invd(addr, size);
+	} else {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int arch_dcache_all(int op)
+{
+	if (op == K_CACHE_INVD) {
+		SCB_InvalidateDCache();
+	} else if (op == K_CACHE_WB) {
+		SCB_CleanDCache();
+	} else if (op == K_CACHE_WB_INVD) {
+		SCB_CleanInvalidateDCache();
+	} else {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int arch_icache_all(int op)
+{
+	if (op == K_CACHE_INVD) {
+		SCB_InvalidateICache();
+	} else {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+int arch_icache_range(void *addr, size_t size, int op)
+{
+	if (op == K_CACHE_INVD) {
+		arch_icache_invd(addr, size);
+	} else {
+		return -ENOTSUP;
+	}
+
+	return 0;
+}

--- a/arch/arm/core/aarch32/cortex_a_r/Kconfig
+++ b/arch/arm/core/aarch32/cortex_a_r/Kconfig
@@ -61,6 +61,12 @@ config GEN_ISR_TABLES
 config GEN_IRQ_VECTOR_TABLE
 	default n
 
+config DCACHE_LINE_SIZE
+	default 32
+
+config ICACHE_LINE_SIZE
+	default 32
+
 endif # CPU_AARCH32_CORTEX_A
 
 config CPU_CORTEX_R4
@@ -169,5 +175,13 @@ config DISABLE_TCM_ECC
 	bool "Disable ECC on TCM"
 	help
 	  This option disables ECC checks on Tightly Coupled Memory.
+
+config DCACHE_LINE_SIZE
+	default 64 if CPU_CORTEX_R52
+	default 32
+
+config ICACHE_LINE_SIZE
+	default 64 if CPU_CORTEX_R52
+	default 32
 
 endif # CPU_AARCH32_CORTEX_R

--- a/arch/arm/core/aarch32/cortex_m/Kconfig
+++ b/arch/arm/core/aarch32/cortex_m/Kconfig
@@ -93,6 +93,12 @@ config CPU_CORTEX_M_HAS_CACHE
 	  This option signifies that the CPU implements Data and Instruction
 	  Cache
 
+config DCACHE_LINE_SIZE
+	default 32 if CPU_CORTEX_M_HAS_CACHE
+
+config ICACHE_LINE_SIZE
+	default 32 if CPU_CORTEX_M_HAS_CACHE
+
 config CPU_CORTEX_M_HAS_DWT
 	bool
 	depends on !CPU_CORTEX_M0 && !CPU_CORTEX_M0PLUS && !CPU_CORTEX_M1


### PR DESCRIPTION
This commit adds icache and dcache maintenance functions
for aarch32.

Signed-off-by: Jamie Iles <quic_jiles@quicinc.com>
Signed-off-by: Dave Aldridge <quic_daldridg@quicinc.com>