### PR TITLE
mgmt/mcumgr/lib: Cleanups in img management group

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/CMakeLists.txt
@@ -9,10 +9,10 @@ target_include_directories(MCUMGR INTERFACE
 )
 
 zephyr_library_sources(
-    src/zephyr_img_mgmt.c
     src/img_mgmt.c
     src/img_mgmt_state.c
     src/img_mgmt_util.c
+    src/img_mgmt_priv.c
 )
 
 if(CONFIG_MCUBOOT_IMG_MANAGER)

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/CMakeLists.txt
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/CMakeLists.txt
@@ -10,7 +10,6 @@ target_include_directories(MCUMGR INTERFACE
 
 zephyr_library_sources(
     src/zephyr_img_mgmt.c
-    src/zephyr_img_mgmt_log.c
     src/img_mgmt.c
     src/img_mgmt_state.c
     src/img_mgmt_util.c

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt_impl.h
@@ -138,14 +138,6 @@ int img_mgmt_impl_upload_inspect(const struct img_mgmt_upload_req *req,
 #define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
 int img_mgmt_impl_erased_val(int slot, uint8_t *erased_val);
 
-int img_mgmt_impl_log_upload_start(int status);
-
-int img_mgmt_impl_log_upload_done(int status, const uint8_t *hashp);
-
-int img_mgmt_impl_log_pending(int status, const uint8_t *hash);
-
-int img_mgmt_impl_log_confirm(int status, const uint8_t *hash);
-
 #ifdef __cplusplus
 }
 #endif

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -19,9 +19,8 @@
 
 #include "img_mgmt/image.h"
 #include "img_mgmt/img_mgmt.h"
-#include "img_mgmt/img_mgmt_impl.h"
-#include "img_mgmt_priv.h"
 #include "img_mgmt/img_mgmt_config.h"
+#include "img_mgmt_priv.h"
 
 #ifdef CONFIG_IMG_ENABLE_IMAGE_CHECK
 #include <zephyr/dfu/flash_img.h>
@@ -55,7 +54,7 @@ img_mgmt_find_tlvs(int slot, size_t *start_off, size_t *end_off,
 	struct image_tlv_info tlv_info;
 	int rc;
 
-	rc = img_mgmt_impl_read(slot, *start_off, &tlv_info, sizeof(tlv_info));
+	rc = img_mgmt_read(slot, *start_off, &tlv_info, sizeof(tlv_info));
 	if (rc != 0) {
 		/* Read error. */
 		return MGMT_ERR_EUNKNOWN;
@@ -112,12 +111,12 @@ img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
 	uint32_t erased_val_32;
 	int rc;
 
-	rc = img_mgmt_impl_erased_val(image_slot, &erased_val);
+	rc = img_mgmt_erased_val(image_slot, &erased_val);
 	if (rc != 0) {
 		return MGMT_ERR_EUNKNOWN;
 	}
 
-	rc = img_mgmt_impl_read(image_slot, 0, &hdr, sizeof(hdr));
+	rc = img_mgmt_read(image_slot, 0, &hdr, sizeof(hdr));
 	if (rc != 0) {
 		return MGMT_ERR_EUNKNOWN;
 	}
@@ -162,7 +161,7 @@ img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
 
 	hash_found = false;
 	while (data_off + sizeof(tlv) <= data_end) {
-		rc = img_mgmt_impl_read(image_slot, data_off, &tlv, sizeof(tlv));
+		rc = img_mgmt_read(image_slot, data_off, &tlv, sizeof(tlv));
 		if (rc != 0) {
 			return MGMT_ERR_EUNKNOWN;
 		}
@@ -186,7 +185,7 @@ img_mgmt_read_info(int image_slot, struct image_version *ver, uint8_t *hash,
 			if (data_off + IMAGE_HASH_LEN > data_end) {
 				return MGMT_ERR_EUNKNOWN;
 			}
-			rc = img_mgmt_impl_read(image_slot, data_off, hash,
+			rc = img_mgmt_read(image_slot, data_off, hash,
 									IMAGE_HASH_LEN);
 			if (rc != 0) {
 				return MGMT_ERR_EUNKNOWN;
@@ -282,7 +281,7 @@ img_mgmt_erase(struct mgmt_ctxt *ctxt)
 		}
 	}
 
-	rc = img_mgmt_impl_erase_slot(slot);
+	rc = img_mgmt_erase_slot(slot);
 	if (rc != 0) {
 		img_mgmt_dfu_stopped();
 		return rc;
@@ -379,7 +378,7 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 	}
 
 	/* Determine what actions to take as a result of this request. */
-	rc = img_mgmt_impl_upload_inspect(&req, &action);
+	rc = img_mgmt_upload_inspect(&req, &action);
 	if (rc != 0) {
 		img_mgmt_dfu_stopped();
 		MGMT_CTXT_SET_RC_RSN(ctxt, IMG_MGMT_UPLOAD_ACTION_RC_RSN(&action));
@@ -453,7 +452,7 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 #ifndef CONFIG_IMG_ERASE_PROGRESSIVELY
 		/* erase the entire req.size all at once */
 		if (action.erase) {
-			rc = img_mgmt_impl_erase_image_data(0, req.size);
+			rc = img_mgmt_erase_image_data(0, req.size);
 			if (rc != 0) {
 				IMG_MGMT_UPLOAD_ACTION_SET_RC_RSN(&action,
 					img_mgmt_err_str_flash_erase_failed);
@@ -472,7 +471,7 @@ img_mgmt_upload(struct mgmt_ctxt *ctxt)
 			last = true;
 		}
 
-		rc = img_mgmt_impl_write_image_data(req.off, req.img_data.value, action.write_bytes,
+		rc = img_mgmt_write_image_data(req.off, req.img_data.value, action.write_bytes,
 						    last);
 		if (rc == 0) {
 			g_img_mgmt_state.off += action.write_bytes;

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt.c
@@ -325,10 +325,6 @@ img_mgmt_upload_log(bool is_first, bool is_last, int status)
 	const uint8_t *hashp;
 	int rc;
 
-	if (is_first) {
-		return img_mgmt_impl_log_upload_start(status);
-	}
-
 	if (is_last || status != 0) {
 		/* Log the image hash if we know it. */
 		rc = img_mgmt_read_info(1, NULL, hash, NULL);
@@ -337,11 +333,8 @@ img_mgmt_upload_log(bool is_first, bool is_last, int status)
 		} else {
 			hashp = hash;
 		}
-
-		return img_mgmt_impl_log_upload_done(status, hashp);
 	}
 
-	/* Nothing to log. */
 	return 0;
 }
 

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_priv.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2018-2021 mcumgr authors
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -7,56 +8,132 @@
 #ifndef H_IMG_MGMT_PRIV_
 #define H_IMG_MGMT_PRIV_
 
-#include <stdint.h>
+#include <stdbool.h>
+#include <inttypes.h>
+#include "img_mgmt/img_mgmt.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/*
- * Response to list:
- * {
- *	"images":[ <version1>, <version2>]
- * }
+/**
+ * @brief Ensures the spare slot (slot 1) is fully erased.
  *
+ * @param slot		A slot to erase.
  *
- * Request to boot to version:
- * {
- *	"test":<version>
- * }
- *
- *
- * Response to boot read:
- * {
- *	"test":<version>,
- *	"main":<version>,
- *	"active":<version>
- * }
- *
- *
- * Request to image upload:
- * {
- *	"off":<offset>,
- *	"len":<img_size>		inspected when off = 0
- *	"data":<base64encoded binary>
- * }
- *
- *
- * Response to upload:
- * {
- *	"off":<offset>
- * }
- *
- *
- * Request to image upload:
- * {
- *	"off":<offset>
- *	"name":<filename>	inspected when off = 0
- *	"len":<file_size>	inspected when off = 0
- *	"data":<base64encoded binary>
- * }
+ * @return 0 on success, MGMT_ERR_[...] code on failure.
  */
+int img_mgmt_erase_slot(int slot);
 
+/**
+ * @brief Marks the image in the specified slot as pending. On the next reboot,
+ * the system will perform a boot of the specified image.
+ *
+ * @param slot		The slot to mark as pending.  In the typical use case, this is 1.
+ * @param permanent	Whether the image should be used permanently or only tested once:
+ *				0=run image once, then confirm or revert.
+ *				1=run image forever.
+ *
+ * @return 0 on success, MGMT_ERR_[...] code on failure.
+ */
+int img_mgmt_write_pending(int slot, bool permanent);
+
+/**
+ * @brief Marks the image in slot 0 as confirmed. The system will continue
+ * booting into the image in slot 0 until told to boot from a different slot.
+ *
+ * @return 0 on success, MGMT_ERR_[...] code on failure.
+ */
+int img_mgmt_write_confirmed(void);
+
+/**
+ * @brief Reads the specified chunk of data from an image slot.
+ *
+ * @param slot		The index of the slot to read from.
+ * @param offset	The offset within the slot to read from.
+ * @param dst		On success, the read data gets written here.
+ * @param num_bytes	The number of bytes to read.
+ *
+ * @return 0 on success, MGMT_ERR_[...] code on failure.
+ */
+int img_mgmt_read(int slot, unsigned int offset, void *dst, unsigned int num_bytes);
+
+/**
+ * @brief Writes the specified chunk of image data to slot 1.
+ *
+ * @param offset	The offset within slot 1 to write to.
+ * @param data		The image data to write.
+ * @param num_bytes	The number of bytes to write.
+ * @param last		Whether this chunk is the end of the image:
+ *				false=additional image chunks are forthcoming.
+ *				true=last image chunk; flush unwritten data to disk.
+ *
+ * @return 0 on success, MGMT_ERR_[...] code on failure.
+ */
+int img_mgmt_write_image_data(unsigned int offset, const void *data, unsigned int num_bytes,
+			      bool last);
+
+/**
+ * @brief Indicates the type of swap operation that will occur on the next
+ * reboot, if any, between provided slot and it's pair.
+ * Querying any slots of the same pair will give the same result.
+ *
+ * @param slot                  An slot number;
+ *
+ * @return                      An IMG_MGMT_SWAP_TYPE_[...] code.
+ */
+int img_mgmt_swap_type(int slot);
+
+/**
+ * Collects information about the specified image slot.
+ *
+ * @return Flags of the specified image slot
+ */
+uint8_t img_mgmt_state_flags(int query_slot);
+
+/**
+ * Erases image data at given offset
+ *
+ * @param offset	The offset within slot 1 to erase at.
+ * @param num_bytes	The number of bytes to erase.
+ *
+ * @return 0 on success, MGMT_ERR_[...] code on failure.
+ */
+int img_mgmt_erase_image_data(unsigned int off, unsigned int num_bytes);
+
+/**
+ * Erases a flash sector as image upload crosses a sector boundary.
+ * Erasing the entire flash size at one time can take significant time,
+ *   causing a bluetooth disconnect or significant battery sag.
+ * Instead we will erase immediately prior to crossing a sector.
+ * We could check for empty to increase efficiency, but instead we always erase
+ *   for consistency and simplicity.
+ *
+ * @param off		Offset that is about to be written
+ * @param len		Number of bytes to be written
+ *
+ * @return 0 if success ERROR_CODE if could not erase sector
+ */
+int img_mgmt_erase_if_needed(uint32_t off, uint32_t len);
+
+/**
+ * Verifies an upload request and indicates the actions that should be taken
+ * during processing of the request.  This is a "read only" function in the
+ * sense that it doesn't write anything to flash and doesn't modify any global
+ * variables.
+ *
+ * @param req		The upload request to inspect.
+ * @param action	On success, gets populated with information about how to
+ *                      process the request.
+ *
+ * @return 0 if processing should occur;
+ *           A MGMT_ERR code if an error response should be sent instead.
+ */
+int img_mgmt_upload_inspect(const struct img_mgmt_upload_req *req,
+			    struct img_mgmt_upload_action *action);
+
+#define ERASED_VAL_32(x) (((x) << 24) | ((x) << 16) | ((x) << 8) | (x))
+int img_mgmt_erased_val(int slot, uint8_t *erased_val);
 struct mgmt_ctxt;
 
 int img_mgmt_find_by_hash(uint8_t *find, struct image_version *ver);
@@ -68,4 +145,4 @@ int img_mgmt_state_write(struct mgmt_ctxt *njb);
 }
 #endif
 
-#endif /* __IMG_MGMT_PRIV_H */
+#endif

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -160,12 +160,6 @@ done:
 		hashp = hash;
 	}
 
-	if (permanent) {
-		(void) img_mgmt_impl_log_confirm(rc, hashp);
-	} else {
-		(void) img_mgmt_impl_log_pending(rc, hashp);
-	}
-
 	return rc;
 }
 
@@ -191,7 +185,7 @@ img_mgmt_state_confirm(void)
 
 	img_mgmt_dfu_confirmed();
 err:
-	return img_mgmt_impl_log_confirm(rc, NULL);
+	return 0;
 }
 
 /**

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/src/img_mgmt_state.c
@@ -54,7 +54,7 @@ img_mgmt_state_flags(int query_slot)
 	/* Determine if this is is pending or confirmed (only applicable for
 	 * unified images and loaders.
 	 */
-	swap_type = img_mgmt_impl_swap_type(query_slot);
+	swap_type = img_mgmt_swap_type(query_slot);
 	switch (swap_type) {
 	case IMG_MGMT_SWAP_TYPE_NONE:
 		if (query_slot == IMG_MGMT_BOOT_CURR_SLOT) {
@@ -147,7 +147,7 @@ img_mgmt_state_set_pending(int slot, int permanent)
 		goto done;
 	}
 
-	rc = img_mgmt_impl_write_pending(slot, permanent);
+	rc = img_mgmt_write_pending(slot, permanent);
 	if (rc != 0) {
 		rc = MGMT_ERR_EUNKNOWN;
 	}
@@ -178,7 +178,7 @@ img_mgmt_state_confirm(void)
 		goto err;
 	}
 
-	rc = img_mgmt_impl_write_confirmed();
+	rc = img_mgmt_write_confirmed();
 	if (rc != 0) {
 		rc = MGMT_ERR_EUNKNOWN;
 	}


### PR DESCRIPTION
Two commits:
 1) Removal of unfinished event logging via SMP protocol - except from some callbacks and vague SMP fram descriptions nothing has been implemented;
 2) Merging private headers of img management and removing zephyr_ and _impl_ from function names to reduce name length.

- [x] Testing 