### PR TITLE
tests: bluetooth: Fix bad Audio preset macro for broadcast sink

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/broadcast_sink_test.c
@@ -21,7 +21,9 @@ CREATE_FLAG(pa_sync_lost);
 static struct bt_audio_broadcast_sink *g_sink;
 
 /* Mandatory support preset by both source and sink */
-static struct bt_audio_lc3_preset preset = BT_AUDIO_LC3_BROADCAST_PRESET_16_2_1;
+static struct bt_audio_lc3_preset preset =
+	BT_AUDIO_LC3_BROADCAST_PRESET_16_2_1(BT_AUDIO_LOCATION_FRONT_LEFT,
+					     BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
 
 static bool scan_recv_cb(const struct bt_le_scan_recv_info *info,
 			 uint32_t broadcast_id)


### PR DESCRIPTION
Fix a bad macro usage after multiple commits were merged.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>