### PR TITLE
LwM2M suspend and  resume api

### DIFF
--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -168,13 +168,13 @@ struct lwm2m_ctx {
 	 */
 	bool use_dtls;
 
-#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 	/**
 	 * Flag to indicate that the socket connection is suspended.
 	 * With queue mode, this will tell if there is a need to reconnect.
 	 */
 	bool connection_suspended;
 
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 	/**
 	 * Flag to indicate that the client is buffering Notifications and Send messages.
 	 * True value buffer Notifications and Send messages.
@@ -1229,6 +1229,7 @@ enum lwm2m_rd_client_event {
 	LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE,
 	LWM2M_RD_CLIENT_EVENT_DISCONNECT,
 	LWM2M_RD_CLIENT_EVENT_QUEUE_MODE_RX_OFF,
+	LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED,
 	LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR,
 };
 
@@ -1283,6 +1284,29 @@ int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
  */
 int lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 			  lwm2m_ctx_event_cb_t event_cb, bool deregister);
+
+/**
+ * @brief Suspend the LwM2M engine Thread
+ *
+ * Suspend LwM2M engine. Use case could be when network connection is down.
+ * LwM2M Engine indicate before it suspend by
+ * LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED event.
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_pause(void);
+
+/**
+ * @brief Resume the LwM2M engine thread
+ *
+ * Resume suspended LwM2M engine. After successful resume call engine will do
+ * full registration or registration update based on suspended time.
+ * Event's LWM2M_RD_CLIENT_EVENT_REGISTRATION_COMPLETE or WM2M_RD_CLIENT_EVENT_REG_UPDATE_COMPLETE
+ * indicate that client is connected to server.
+ *
+ * @return 0 for success or negative in case of error.
+ */
+int lwm2m_engine_resume(void);
 
 /**
  * @brief Trigger a Registration Update of the LwM2M RD Client

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -466,6 +466,10 @@ static void rd_client_event(struct lwm2m_ctx *client,
 		LOG_DBG("Queue mode RX window closed");
 		break;
 
+	case LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED:
+		LOG_DBG("LwM2M engine suspended");
+		break;
+
 	case LWM2M_RD_CLIENT_EVENT_NETWORK_ERROR:
 		LOG_ERR("LwM2M engine reported a network error.");
 		lwm2m_rd_client_stop(client, rd_client_event, true);

--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -194,6 +194,12 @@ config LWM2M_TLS_SESSION_CACHING
 	help
 	  Enabling this only when feature is supported in TLS library.
 
+config LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE
+	bool "Socket close is skipped at RX_ON_IDLE state"
+	depends on LWM2M_RD_CLIENT_SUPPORT
+	help
+	  This config suspend socket handler which skip socket polling process.
+
 config LWM2M_RD_CLIENT_SUPPORT
 	bool "support for LWM2M client bootstrap/registration state machine"
 	default y

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -80,6 +80,9 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 static struct lwm2m_obj_path_list observe_paths[LWM2M_ENGINE_MAX_OBSERVER_PATH];
 #define MAX_PERIODIC_SERVICE 10
 
+static k_tid_t engine_thread_id;
+static bool suspend_engine_thread;
+
 struct service_node {
 	sys_snode_t node;
 	k_work_handler_t service_work;
@@ -108,6 +111,8 @@ struct lwm2m_ctx **lwm2m_sock_ctx(void) { return sock_ctx; }
 int lwm2m_sock_nfds(void) { return sock_nfds; }
 
 struct lwm2m_block_context *lwm2m_block1_context(void) { return block1_contexts; }
+
+static void lwm2m_socket_update(struct lwm2m_ctx *ctx);
 
 /* for debugging: to print IP addresses */
 char *lwm2m_sprint_ip_addr(const struct sockaddr *addr)
@@ -161,26 +166,101 @@ char *sprint_token(const uint8_t *token, uint8_t tkl)
 
 /* utility functions */
 
-#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
-int lwm2m_engine_connection_resume(struct lwm2m_ctx *client_ctx)
+int lwm2m_open_socket(struct lwm2m_ctx *client_ctx)
 {
-#ifdef CONFIG_LWM2M_DTLS_SUPPORT
-	if (!client_ctx->use_dtls) {
-		return 0;
+	if (client_ctx->sock_fd < 0) {
+		/* open socket */
+
+		if (IS_ENABLED(CONFIG_LWM2M_DTLS_SUPPORT) && client_ctx->use_dtls) {
+			client_ctx->sock_fd = socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM,
+						     IPPROTO_DTLS_1_2);
+		} else {
+			client_ctx->sock_fd =
+				socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM, IPPROTO_UDP);
+		}
+
+		if (client_ctx->sock_fd < 0) {
+			LOG_ERR("Failed to create socket: %d", errno);
+			return -errno;
+		}
+
+		lwm2m_socket_update(client_ctx);
 	}
 
+	return 0;
+}
+
+int lwm2m_close_socket(struct lwm2m_ctx *client_ctx)
+{
+	int ret = 0;
+
+	if (client_ctx->sock_fd >= 0) {
+		ret = close(client_ctx->sock_fd);
+		if (ret) {
+			LOG_ERR("Failed to close socket: %d", errno);
+			ret = -errno;
+			return ret;
+		}
+
+		client_ctx->sock_fd = -1;
+		client_ctx->connection_suspended = true;
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+		/* Enable Queue mode buffer store */
+		client_ctx->buffer_client_messages = true;
+#endif
+		lwm2m_socket_update(client_ctx);
+	}
+
+	return ret;
+}
+
+
+int lwm2m_socket_suspend(struct lwm2m_ctx *client_ctx)
+{
+	int ret = 0;
+
+	if (client_ctx->sock_fd >= 0 && !client_ctx->connection_suspended) {
+		int socket_temp_id = client_ctx->sock_fd;
+
+		client_ctx->sock_fd = -1;
+		client_ctx->connection_suspended = true;
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+		/* Enable Queue mode buffer store */
+		client_ctx->buffer_client_messages = true;
+#endif
+		lwm2m_socket_update(client_ctx);
+		client_ctx->sock_fd = socket_temp_id;
+	}
+
+	return ret;
+}
+
+int lwm2m_engine_connection_resume(struct lwm2m_ctx *client_ctx)
+{
+	int ret;
+
 	if (client_ctx->connection_suspended) {
+		lwm2m_close_socket(client_ctx);
 		client_ctx->connection_suspended = false;
+		ret = lwm2m_open_socket(client_ctx);
+		if (ret) {
+			return ret;
+		}
+
+		if (!client_ctx->use_dtls) {
+			return 0;
+		}
+
 		LOG_DBG("Resume suspended connection");
 		return lwm2m_socket_start(client_ctx);
 	}
-#endif
+
 	return 0;
 }
-#endif
-#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+
 int lwm2m_push_queued_buffers(struct lwm2m_ctx *client_ctx)
 {
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 	client_ctx->buffer_client_messages = false;
 	while (!sys_slist_is_empty(&client_ctx->queued_messages)) {
 		sys_snode_t *msg_node = sys_slist_get(&client_ctx->queued_messages);
@@ -192,9 +272,9 @@ int lwm2m_push_queued_buffers(struct lwm2m_ctx *client_ctx)
 		msg = SYS_SLIST_CONTAINER(msg_node, msg, node);
 		sys_slist_append(&msg->ctx->pending_sends, &msg->node);
 	}
+#endif
 	return 0;
 }
-#endif
 
 bool lwm2m_engine_bootstrap_override(struct lwm2m_ctx *client_ctx, struct lwm2m_obj_path *path)
 {
@@ -434,43 +514,6 @@ static int32_t lwm2m_engine_service(const int64_t timestamp)
 	return engine_next_service_timeout_ms(ENGINE_UPDATE_INTERVAL_MS, timestamp);
 }
 
-#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
-
-int lwm2m_engine_close_socket_connection(struct lwm2m_ctx *client_ctx)
-{
-	int ret = 0;
-	/* Enable Queue mode buffer store */
-	client_ctx->buffer_client_messages = true;
-
-#ifdef CONFIG_LWM2M_DTLS_SUPPORT
-	if (!client_ctx->use_dtls) {
-		return 0;
-	}
-
-	if (client_ctx->sock_fd >= 0) {
-		ret = close(client_ctx->sock_fd);
-		if (ret) {
-			LOG_ERR("Failed to close socket: %d", errno);
-			ret = -errno;
-			return ret;
-		}
-		client_ctx->sock_fd = -1;
-		client_ctx->connection_suspended = true;
-	}
-
-	/* Open socket again that Observation and re-send functionality works */
-	client_ctx->sock_fd =
-		socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM, IPPROTO_DTLS_1_2);
-
-	if (client_ctx->sock_fd < 0) {
-		LOG_ERR("Failed to create socket: %d", errno);
-		return -errno;
-	}
-#endif
-	return ret;
-}
-#endif
-
 /* LwM2M Socket Integration */
 
 int lwm2m_socket_add(struct lwm2m_ctx *ctx)
@@ -485,6 +528,17 @@ int lwm2m_socket_add(struct lwm2m_ctx *ctx)
 	sock_nfds++;
 
 	return 0;
+}
+
+static void lwm2m_socket_update(struct lwm2m_ctx *ctx)
+{
+	for (int i = 0; i < sock_nfds; i++) {
+		if (sock_ctx[i] != ctx) {
+			continue;
+		}
+		sock_fds[i].fd = ctx->sock_fd;
+		return;
+	}
 }
 
 void lwm2m_socket_del(struct lwm2m_ctx *ctx)
@@ -519,8 +573,8 @@ static void check_notifications(struct lwm2m_ctx *ctx, const int64_t timestamp)
 		if (!obs->event_timestamp || timestamp < obs->event_timestamp) {
 			continue;
 		}
-		/* Check That There is not pending process and client is registred */
-		if (obs->active_tx_operation || !lwm2m_rd_client_is_registred(ctx)) {
+		/* Check That There is not pending process*/
+		if (obs->active_tx_operation) {
 			continue;
 		}
 
@@ -602,6 +656,18 @@ static void socket_loop(void)
 	int32_t timeout, next_retransmit;
 
 	while (1) {
+		/* Check is Thread Suspend Requested */
+		if (suspend_engine_thread) {
+#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT)
+			lwm2m_rd_client_pause();
+#endif
+			suspend_engine_thread = false;
+			k_thread_suspend(engine_thread_id);
+#if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT)
+			lwm2m_rd_client_resume();
+#endif
+		}
+
 		timestamp = k_uptime_get();
 		timeout = lwm2m_engine_service(timestamp);
 
@@ -618,7 +684,8 @@ static void socket_loop(void)
 					timeout = next_retransmit;
 				}
 			}
-			if (sys_slist_is_empty(&sock_ctx[i]->pending_sends)) {
+			if (sys_slist_is_empty(&sock_ctx[i]->pending_sends) &&
+			    lwm2m_rd_client_is_registred(sock_ctx[i])) {
 				check_notifications(sock_ctx[i], timestamp);
 			}
 		}
@@ -638,6 +705,11 @@ static void socket_loop(void)
 		}
 
 		for (i = 0; i < sock_nfds; i++) {
+
+			if (sock_ctx[i]->sock_fd < 0) {
+				continue;
+			}
+
 			if ((sock_fds[i].revents & POLLERR) || (sock_fds[i].revents & POLLNVAL) ||
 			    (sock_fds[i].revents & POLLHUP)) {
 				LOG_ERR("Poll reported a socket error, %02x.", sock_fds[i].revents);
@@ -732,21 +804,10 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 
 	if (client_ctx->sock_fd < 0) {
 		allocate_socket = true;
-#if defined(CONFIG_LWM2M_DTLS_SUPPORT)
-		if (client_ctx->use_dtls) {
-			client_ctx->sock_fd = socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM,
-						     IPPROTO_DTLS_1_2);
-		} else
-#endif /* CONFIG_LWM2M_DTLS_SUPPORT */
-		{
-			client_ctx->sock_fd =
-				socket(client_ctx->remote_addr.sa_family, SOCK_DGRAM, IPPROTO_UDP);
+		ret = lwm2m_open_socket(client_ctx);
+		if (ret) {
+			return ret;
 		}
-	}
-
-	if (client_ctx->sock_fd < 0) {
-		LOG_ERR("Failed to create socket: %d", errno);
-		return -errno;
 	}
 
 #if defined(CONFIG_LWM2M_DTLS_SUPPORT)
@@ -859,6 +920,44 @@ int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 	return lwm2m_socket_start(client_ctx);
 }
 
+int lwm2m_engine_pause(void)
+{
+	char buffer[32];
+	const char *str;
+
+	str = k_thread_state_str(engine_thread_id, buffer, sizeof(buffer));
+	if (suspend_engine_thread || !strcmp(str, "suspended")) {
+		LOG_WRN("Engine thread already suspended");
+		return 0;
+	}
+
+	suspend_engine_thread = true;
+
+	while (strcmp(str, "suspended")) {
+		k_msleep(10);
+		str = k_thread_state_str(engine_thread_id, buffer, sizeof(buffer));
+	}
+	LOG_INF("LWM2M engine thread paused (%s) ", str);
+	return 0;
+}
+
+int lwm2m_engine_resume(void)
+{
+	char buffer[32];
+	const char *str;
+
+	str = k_thread_state_str(engine_thread_id, buffer, sizeof(buffer));
+	if (strcmp(str, "suspended")) {
+		LOG_WRN("LWM2M engine thread state not ok for resume %s", str);
+		return -EPERM;
+	}
+
+	k_thread_resume(engine_thread_id);
+	str = k_thread_state_str(engine_thread_id, buffer, sizeof(buffer));
+	LOG_INF("LWM2M engine thread resume (%s)", str);
+	return 0;
+}
+
 static int lwm2m_engine_init(const struct device *dev)
 {
 	int i;
@@ -870,7 +969,7 @@ static int lwm2m_engine_init(const struct device *dev)
 	(void)memset(block1_contexts, 0, sizeof(block1_contexts));
 
 	/* start sock receive thread */
-	k_thread_create(&engine_thread_data, &engine_thread_stack[0],
+	engine_thread_id = k_thread_create(&engine_thread_data, &engine_thread_stack[0],
 			K_KERNEL_STACK_SIZEOF(engine_thread_stack), (k_thread_entry_t)socket_loop,
 			NULL, NULL, NULL, THREAD_PRIORITY, 0, K_NO_WAIT);
 	k_thread_name_set(&engine_thread_data, "lwm2m-sock-recv");

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -83,11 +83,11 @@ uint8_t lwm2m_firmware_get_update_result(void);
 int lwm2m_socket_add(struct lwm2m_ctx *ctx);
 void lwm2m_socket_del(struct lwm2m_ctx *ctx);
 int lwm2m_socket_start(struct lwm2m_ctx *client_ctx);
-#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
-int lwm2m_engine_close_socket_connection(struct lwm2m_ctx *client_ctx);
 int lwm2m_engine_connection_resume(struct lwm2m_ctx *client_ctx);
+int lwm2m_open_socket(struct lwm2m_ctx *client_ctx);
+int lwm2m_close_socket(struct lwm2m_ctx *client_ctx);
+int lwm2m_socket_suspend(struct lwm2m_ctx *client_ctx);
 int lwm2m_push_queued_buffers(struct lwm2m_ctx *client_ctx);
-#endif
 
 /* Resources */
 struct lwm2m_ctx **lwm2m_sock_ctx(void);

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -196,8 +196,9 @@ int lwm2m_engine_context_close(struct lwm2m_ctx *client_ctx)
 	coap_pendings_clear(client_ctx->pendings, ARRAY_SIZE(client_ctx->pendings));
 	coap_replies_clear(client_ctx->replies, ARRAY_SIZE(client_ctx->replies));
 
-#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
+
 	client_ctx->connection_suspended = false;
+#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 	client_ctx->buffer_client_messages = true;
 #endif
 	lwm2m_socket_del(client_ctx);
@@ -213,9 +214,9 @@ void lwm2m_engine_context_init(struct lwm2m_ctx *client_ctx)
 {
 	sys_slist_init(&client_ctx->pending_sends);
 	sys_slist_init(&client_ctx->observer);
+	client_ctx->connection_suspended = false;
 #if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 	client_ctx->buffer_client_messages = true;
-	client_ctx->connection_suspended = false;
 	sys_slist_init(&client_ctx->queued_messages);
 #endif
 }

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.h
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.h
@@ -40,15 +40,15 @@
 
 void engine_trigger_update(bool update_objects);
 int engine_trigger_bootstrap(void);
+int lwm2m_rd_client_pause(void);
+int lwm2m_rd_client_resume(void);
 
 int lwm2m_rd_client_timeout(struct lwm2m_ctx *client_ctx);
 bool lwm2m_rd_client_is_registred(struct lwm2m_ctx *client_ctx);
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
 void engine_bootstrap_finish(void);
 #endif
-#if defined(CONFIG_LWM2M_QUEUE_MODE_ENABLED)
 int lwm2m_rd_client_connection_resume(struct lwm2m_ctx *client_ctx);
-#endif
 void engine_update_tx_time(void);
 struct lwm2m_message *lwm2m_get_ongoing_rd_msg(void);
 

--- a/subsys/net/lib/lwm2m/lwm2m_shell.c
+++ b/subsys/net/lib/lwm2m/lwm2m_shell.c
@@ -45,6 +45,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define LWM2M_HELP_STOP "Stop the LwM2M RD (De-register) Client\nstop [OPTIONS]\n" \
 	"-f \tForce close the connection\n"
 #define LWM2M_HELP_UPDATE "Trigger Registration Update of the LwM2M RD Client\n"
+#define LWM2M_HELP_PAUSE "LwM2M engine thread pause"
+#define LWM2M_HELP_RESUME "LwM2M engine thread resume"
 
 static int cmd_send(const struct shell *sh, size_t argc, char **argv)
 {
@@ -433,6 +435,24 @@ static int cmd_update(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
+static int cmd_pause(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return lwm2m_engine_pause();
+}
+
+static int cmd_resume(const struct shell *sh, size_t argc, char **argv)
+{
+	ARG_UNUSED(sh);
+	ARG_UNUSED(argc);
+	ARG_UNUSED(argv);
+
+	return lwm2m_engine_resume();
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(
 	sub_lwm2m,
 	SHELL_COND_CMD_ARG(CONFIG_LWM2M_VERSION_1_1, send, NULL,
@@ -443,6 +463,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(
 	SHELL_CMD_ARG(start, NULL, LWM2M_HELP_START, cmd_start, 2, 2),
 	SHELL_CMD_ARG(stop, NULL, LWM2M_HELP_STOP, cmd_stop, 1, 1),
 	SHELL_CMD_ARG(update, NULL, LWM2M_HELP_UPDATE, cmd_update, 1, 0),
+	SHELL_CMD_ARG(pause, NULL, LWM2M_HELP_PAUSE, cmd_pause, 1, 0),
+	SHELL_CMD_ARG(resume, NULL, LWM2M_HELP_RESUME, cmd_resume, 1, 0),
 	SHELL_SUBCMD_SET_END);
 SHELL_COND_CMD_ARG_REGISTER(CONFIG_LWM2M_SHELL, lwm2m, &sub_lwm2m,
 			    LWM2M_HELP_CMD, NULL, 1, 0);


### PR DESCRIPTION
New API for suspend and resume LwM2M engine.

New event LWM2M_RD_CLIENT_EVENT_ENGINE_SUSPENDED for indicate application
that engine is suspended.

Simplify stack suspend and resume state same time for queue mode.

New CONFIG_LWM2M_RD_CLIENT_SUSPEND_SOCKET_AT_IDLE for enable skip socket close
at RX_OFF_IDLE state that socket is only suspended and close is called only
when connection is resumed.