### PR TITLE
drivers: pcie: fix inverted translation for PCIe controller

### DIFF
--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -181,8 +181,8 @@ bool pcie_get_mbar(pcie_bdf_t bdf,
 	if (!pcie_ctrl_region_translate(dev, bdf, PCIE_CONF_BAR_MEM(phys_addr),
 					PCIE_CONF_BAR_64(phys_addr),
 					PCIE_CONF_BAR_MEM(phys_addr) ?
-						PCIE_CONF_BAR_IO_ADDR(phys_addr)
-						: PCIE_CONF_BAR_ADDR(phys_addr),
+						PCIE_CONF_BAR_ADDR(phys_addr)
+						: PCIE_CONF_BAR_IO_ADDR(phys_addr),
 					&mbar->phys_addr)) {
 		return false;
 	}


### PR DESCRIPTION
Invert the physical address given to pcie_ctrl_region_translate() to
match the PCI BAR layout. Previously, physical addresses for memory
space BAR were exposed to bit 3 (prefetchable bit) and 2 (1 type bit) of
the header.

Signed-off-by: Rodrigo Cataldo <rodrigo.cataldo@huawei.com>
---
Introduction
===
Hello everyone,
this is my first contribution to the Zephyr project.

thanks to the work of @superna9999, we are now able to run PCI devices on arm64. I have been working on ivshmem support on arm64 and i realize that an if-then-else clause is using a reverted mask (present since the original commit).

the `phys_addr` variable at `pcie_get_mbar()` is tested to see if it is a memory or I/O space BAR (line 183), then the wrong mask is applied. The I/O mask is applied in the case of memory space, where the memory mask should have been applied.

The following sections detail the test scenario used and how to set it up.

Test Scenario
===
I'm using `test/drivers/virtualization/ivshmem` as the test application with `qemu_cortex_a53` for the platform. This requires minor changes in Zephyr (see next section for details).

compile line:
```bash
west build -b qemu_cortex_a53 -p auto test/drivers/virtualizatio/ivshmem
```

here is the unpatched, main branch, logging information:
```
...
I: [00:01.0] BAR0 size 0x100 assigned [mem 0x10000000-0x100000ff -> 0x10000000-0x100000ff]
I: [00:01.0] BAR2 size 0x100000 assigned [mem64 0x8000000000-0x80000fffff -> 0x8000000000-0x80000fffff]
D: ivshmem found at bdf 0x800
D: ivshmem configured:
D: - Registers at 0x10000000 (mapped to 0xbfffe000)
D: - Shared memory of 1048576 bytes at 0x800000000c (mapped to 0xbfefd00c)
```
Note that BAR2 is assigned to 0x8000000000, but when ivshmem is initializing (`ivshmem_configure()`), the physical address received is ORed with 0xC (0x800000000c): containing the prefetchable and (half) of the type bits.

`phys_addr` 32 bits of (physical address + control bits) are read [here](https://github.com/zephyrproject-rtos/zephyr/blob/fd0767557439d04c4a220a9857e901d8d71498db/drivers/pcie/host/pcie.c#L129), they are ORed with the rest of the address [here](https://github.com/zephyrproject-rtos/zephyr/blob/fd0767557439d04c4a220a9857e901d8d71498db/drivers/pcie/host/pcie.c#L148), then they should have been masked with `PCIE_CONF_BAR_ADDR` (0xF), but they are not, because the mask `PCIE_CONF_BAR_IO_ADDR` is used, which only mask 0x3.

The test (`test/drivers/virtualization/ivshmem`) will still work, because only a single position is written. If the test writes to all positions (using the provided size by `ivshmem_api_get_mem()`), the test fails at the end (because it will go over 0x80000fffff)

Now, with the patch provided in this PR:
```
I: [00:01.0] BAR0 size 0x100 assigned [mem 0x10000000-0x100000ff -> 0x10000000-0x100000ff]
I: [00:01.0] BAR2 size 0x100000 assigned [mem64 0x8000000000-0x80000fffff -> 0x8000000000-0x80000fffff]
D: ivshmem found at bdf 0x800
D: ivshmem configured:
D: - Registers at 0x10000000 (mapped to 0xbfffe000)
D: - Shared memory of 1048576 bytes at 0x8000000000 (mapped to 0xbfefe000)
```
The correct physical address is received.

ivshmem test setup
===
Some minor modifications are required for ivshmem test to run on arm64/qemu (this can be provided as another PR if it is useful)

1. add overlay for pcie controller (pcie_ecam) for the test application (using dumpdtb from qemu) and mark this pcie controller as the `chosen`.
2. disable MSI config options (not required for this test), or create a specific-prj file for qemu scenario.
3. enable the following config options: `CONFIG_PCIE_CONTROLLER`, `CONFIG_PCIE_ECAM`. This is the controller used for qemu.
4. `CONFIG_KERNEL_VM_SIZE` need to be large enough for PCI mappings (256MB) and we need 40 bits for BAR2 access (`CONFIG_ARM64_PA_BITS_40`). Both requirements are from QEMU virt: https://github.com/zephyrproject-rtos/qemu/blob/2cc2e86de6e0e4316265d34e8e935afade8c422e/hw/arm/virt.c#L181
5. add an #ifdef CONFIG_IVSHMEM_DOORBELL for the msi.h include at `drivers/virtualization/virt_ivshmem.h`

1. (Optional) change `drivers/pcie/host/pcie.c` LOG_REGISTER from `LOG_LEVEL_ERR` to `LOG_LEVEL_DBG`. Bump from `PRE_KERNEL_1` to `PRE_KERNEL_2` so that we can see output on the uart.
2. (Optional) add ITS dts in qemu board dts file, since this is emulated since QEMU 6.2 (already used in current sdk). This is optional because this test scenario does not require ITS/MSI, but it is nice to match the overlay done in 2 (msi-parent)