### PR TITLE
samples: drivers: led_ws2812: add fixture to sample.yaml

### DIFF
--- a/samples/drivers/led_ws2812/sample.yaml
+++ b/samples/drivers/led_ws2812/sample.yaml
@@ -5,3 +5,5 @@ tests:
   sample.drivers.led.ws2812:
     tags: LED
     filter: dt_compat_enabled("worldsemi,ws2812-spi")
+    harness_config:
+        fixture: fixture_led_ws2812


### PR DESCRIPTION
samples: drivers: led_ws2812: add fixture to sample.yaml

This sample should be executed only when connecting external
hardware (Led strip). Thus it is necessary to add fixture to avoid
execution when no hardware is connected.

Note: This is linked to the merge of PR #46936 "Feature/ws2812 cpol and cpha"
It causes test to failed on nucelo_h743zi and nucleo_g071rb, whereas test used to be filtered (because no led strip connected to those boards on automatic tests bench)