### PR TITLE
Removal of compilation warnings for C++ files compilation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,8 @@ zephyr_compile_options("SHELL: $<TARGET_PROPERTY:compiler,imacros> ${AUTOCONF_H}
 
 if(NOT CONFIG_PICOLIBC)
   # @Intent: Set compiler specific flag for bare metal freestanding option
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,freestanding>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,freestanding>>)
+  zephyr_compile_options($<$<COMPILE_LANGUAGE:ASM>:$<TARGET_PROPERTY:compiler,freestanding>>)
 endif()
 
 # @Intent: Set compiler specific flag for tentative definitions, no-common

--- a/cmake/compiler/clang/compiler_flags.cmake
+++ b/cmake/compiler/clang/compiler_flags.cmake
@@ -21,14 +21,14 @@ set_compiler_property(PROPERTY diagnostic -fcolor-diagnostics)
 #######################################################
 
 # clang option standard warning base in Zephyr
-set_compiler_property(PROPERTY warning_base
-                      -Wall
-                      -Wformat
-                      -Wformat-security
-                      -Wno-format-zero-length
-                      -Wno-main
-                      -Wno-unused-but-set-variable
-                      -Wno-typedef-redefinition
+check_set_compiler_property(PROPERTY warning_base
+                            -Wall
+                            -Wformat
+                            -Wformat-security
+                            -Wno-format-zero-length
+                            -Wno-main
+                            -Wno-unused-but-set-variable
+                            -Wno-typedef-redefinition
 )
 
 check_set_compiler_property(APPEND PROPERTY warning_base -Wno-pointer-sign)

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -26,7 +26,7 @@ set_compiler_property(PROPERTY optimization_size  -Os)
 #######################################################
 
 # GCC Option standard warning base in Zephyr
-set_compiler_property(PROPERTY warning_base
+check_set_compiler_property(PROPERTY warning_base
     -Wall
     -Wformat
     -Wformat-security
@@ -160,7 +160,7 @@ endif()
 check_set_compiler_property(APPEND PROPERTY hosted -fno-freestanding)
 
 # gcc flag for a freestanding application
-set_compiler_property(PROPERTY freestanding -ffreestanding)
+check_set_compiler_property(PROPERTY freestanding -ffreestanding)
 
 # Flag to enable debugging
 set_compiler_property(PROPERTY debug -g)

--- a/cmake/compiler/xcc/compiler_flags.cmake
+++ b/cmake/compiler/xcc/compiler_flags.cmake
@@ -6,6 +6,6 @@ include(${ZEPHYR_BASE}/cmake/compiler/gcc/compiler_flags.cmake)
 # fact that linkage semantics differed between C99 and GNU at the
 # time.  Suppress the warning, it's the best we can do given that
 # it's a legacy compiler.
-set_compiler_property(APPEND PROPERTY warning_base "-fgnu89-inline")
+check_set_compiler_property(APPEND PROPERTY warning_base "-fgnu89-inline")
 
 set_compiler_property(PROPERTY warning_error_misra_sane)


### PR DESCRIPTION
Compilation warnings appears for C++ files when SOF Converged code is build. 
Following flags not supported by C++ are reported:
cc1plus.exe: warning: command line option "-ffreestanding" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-Wno-format-zero-length" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-Wno-main" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-fgnu89-inline" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-std=gnu99" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-ffreestanding" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-Wno-format-zero-length" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-Wno-main" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-fgnu89-inline" is valid for C/ObjC but not for C++
cc1plus.exe: warning: command line option "-std=gnu99" is valid for C/ObjC but not for C++

This commit adds checks to filter out unsupported flags for C++.
