### PR TITLE
net: lwm2m: Fix socket offload and native TLS conflict

### DIFF
--- a/subsys/net/lib/lwm2m/Kconfig
+++ b/subsys/net/lib/lwm2m/Kconfig
@@ -44,9 +44,6 @@ config LWM2M_SHELL
 
 config LWM2M_DTLS_SUPPORT
 	bool "DTLS support in the LwM2M client"
-	select TLS_CREDENTIALS
-	select NET_SOCKETS_SOCKOPT_TLS
-	select NET_SOCKETS_ENABLE_DTLS
 
 choice
 	prompt "LwM2M Security object version"

--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -5861,7 +5861,7 @@ static void socket_loop(void)
 	}
 }
 
-#if defined(CONFIG_LWM2M_DTLS_SUPPORT)
+#if defined(CONFIG_LWM2M_DTLS_SUPPORT) && defined(CONFIG_TLS_CREDENTIALS)
 static int load_tls_credential(struct lwm2m_ctx *client_ctx, uint16_t res_id,
 			       enum tls_credential_type type)
 {
@@ -5897,7 +5897,7 @@ static int load_tls_credential(struct lwm2m_ctx *client_ctx, uint16_t res_id,
 
 	return ret;
 }
-#endif /* CONFIG_LWM2M_DTLS_SUPPORT */
+#endif /* CONFIG_LWM2M_DTLS_SUPPORT && CONFIG_TLS_CREDENTIALS*/
 
 int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 {
@@ -5914,7 +5914,9 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 		if (ret < 0) {
 			return ret;
 		}
-	} else {
+	}
+#if defined(CONFIG_TLS_CREDENTIALS)
+	else {
 		ret = load_tls_credential(client_ctx, 3, TLS_CREDENTIAL_PSK_ID);
 		if (ret < 0) {
 			return ret;
@@ -5925,6 +5927,7 @@ int lwm2m_socket_start(struct lwm2m_ctx *client_ctx)
 			return ret;
 		}
 	}
+#endif /* CONFIG_TLS_CREDENTIALS */
 #endif /* CONFIG_LWM2M_DTLS_SUPPORT */
 
 	if (client_ctx->sock_fd < 0) {


### PR DESCRIPTION
Removed auto select from LWM2M_DTLS_SUPPORT
* TLS_CREDENTIALS
* NET_SOCKETS_SOCKOPT_TLS
* NET_SOCKETS_ENABLE_DTLS

LwM2M stack shouldn't enforce these options as they are not needed with socket offloading

Signed-off-by: Juha Heiskanen <juha.heiskanen@nordicsemi.no>