### PR TITLE
Bluetooth: Mesh: Don't open prov link after being provisioned

### DIFF
--- a/subsys/bluetooth/mesh/pb_adv.c
+++ b/subsys/bluetooth/mesh/pb_adv.c
@@ -214,7 +214,13 @@ static void reset_adv_link(void)
 		(void)memset(&link, 0, offsetof(struct pb_adv, tx.retransmit));
 		link.rx.id = XACT_ID_NVAL;
 	} else {
-		/* Accept another provisioning attempt */
+		/* If provisioned, reset the link callback to stop receiving provisioning advs,
+		 * otherwise keep the callback to accept another provisioning attempt.
+		 */
+		if (bt_mesh_is_provisioned()) {
+			link.cb = NULL;
+		}
+
 		link.id = 0;
 		atomic_clear(link.flags);
 		link.rx.id = XACT_ID_MAX;


### PR DESCRIPTION
It is possible to open provisioning link again after being provisioned.
Though this has no immediate consequences, the node shall not open
provisioning after being provisioned.

Reset link.cb so that any following provisioning advs are dropped.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>