### PR TITLE
Add separator version of DT_FOREACH* macros

### DIFF
--- a/arch/arm64/core/smp.c
+++ b/arch/arm64/core/smp.c
@@ -44,10 +44,8 @@ volatile struct boot_params __aligned(L1_CACHE_BYTES) arm64_cpu_boot_params = {
 	.mpid = -1,
 };
 
-#define CPU_REG_ID(cpu_node_id) DT_REG_ADDR(cpu_node_id),
-
 static const uint64_t cpu_node_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY(DT_PATH(cpus), CPU_REG_ID)
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
 };
 static uint16_t target_list_mask;
 

--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -61,11 +61,15 @@ node-macro =/ %s"DT_N" path-id %s"_PARENT"
 ; These are used internally by DT_FOREACH_CHILD, which iterates over
 ; each child node.
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_SEP"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_VARGS"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_SEP_VARGS"
 ; These are used internally by DT_FOREACH_CHILD_STATUS_OKAY, which iterates
 ; over each child node with status "okay".
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_SEP"
 node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_VARGS"
+node-macro =/ %s"DT_N" path-id %s"_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS"
 ; The node's zero-based index in the list of it's parent's child nodes.
 node-macro =/ %s"DT_N" path-id %s"_CHILD_IDX"
 ; The node's status macro; dt-name in this case is something like "okay"

--- a/drivers/gpio/gpio_nct38xx.c
+++ b/drivers/gpio/gpio_nct38xx.c
@@ -76,11 +76,10 @@ static int nct38xx_gpio_init(const struct device *dev)
 	return 0;
 }
 
-#define GPIO_DEV_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
-
 #define GPIO_NCT38XX_DEVICE_INSTANCE(inst)                                                         \
-	static const struct device *sub_gpio_dev_##inst[] = { DT_FOREACH_CHILD_STATUS_OKAY(        \
-		DT_DRV_INST(inst), GPIO_DEV_AND_COMMA) };                                          \
+	static const struct device *sub_gpio_dev_##inst[] = {                                      \
+		DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(inst, DEVICE_DT_GET, (,))                    \
+	};                                                                                         \
 	static const struct gpio_nct38xx_config gpio_nct38xx_cfg_##inst = {                        \
 		.i2c_dev = I2C_DT_SPEC_INST_GET(inst),                                             \
 		.sub_gpio_dev = sub_gpio_dev_##inst,                                               \

--- a/drivers/gpio/gpio_xlnx_ps.c
+++ b/drivers/gpio/gpio_xlnx_ps.c
@@ -94,11 +94,10 @@ static void gpio_xlnx_ps_isr(const struct device *dev)
  * devices for the parent controller device's config data struct
  * specified in the device tree.
  */
-#define GPIO_XLNX_PS_CHILD_CONCAT(idx) DEVICE_DT_GET(idx),
 
 #define GPIO_XLNX_PS_GEN_BANK_ARRAY(idx)\
 static const struct device *const gpio_xlnx_ps##idx##_banks[] = {\
-	DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(idx), GPIO_XLNX_PS_CHILD_CONCAT)\
+	DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(idx, DEVICE_DT_GET, (,))\
 };
 
 /* Device config & run-time data struct creation macros */

--- a/drivers/interrupt_controller/intc_gic.c
+++ b/drivers/interrupt_controller/intc_gic.c
@@ -15,9 +15,8 @@
 #include <zephyr/dt-bindings/interrupt-controller/arm-gic.h>
 #include <zephyr/drivers/interrupt_controller/gic.h>
 
-#define CPU_REG_ID(cpu_node_id) DT_REG_ADDR(cpu_node_id),
 static const uint64_t cpu_mpid_list[] = {
-	DT_FOREACH_CHILD_STATUS_OKAY(DT_PATH(cpus), CPU_REG_ID)
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_PATH(cpus), DT_REG_ADDR, (,))
 };
 
 BUILD_ASSERT(ARRAY_SIZE(cpu_mpid_list) >= CONFIG_MP_NUM_CPUS,

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -83,13 +83,10 @@ static const struct led_driver_api led_gpio_api = {
 	.set_brightness	= led_gpio_set_brightness,
 };
 
-#define LED_GPIO_DT_SPEC(led_node_id)				\
-	GPIO_DT_SPEC_GET(led_node_id, gpios),			\
-
 #define LED_GPIO_DEVICE(i)					\
 								\
-static const struct gpio_dt_spec gpio_dt_spec_##i[] = {	\
-	DT_INST_FOREACH_CHILD(i, LED_GPIO_DT_SPEC)		\
+static const struct gpio_dt_spec gpio_dt_spec_##i[] = {		\
+	DT_INST_FOREACH_CHILD_SEP_VARGS(i, GPIO_DT_SPEC_GET, (,), gpios) \
 };								\
 								\
 static const struct led_gpio_config led_gpio_config_##i = {	\

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -131,12 +131,10 @@ static const struct led_driver_api led_pwm_api = {
 	.set_brightness	= led_pwm_set_brightness,
 };
 
-#define PWM_DT_SPEC_GET_AND_COMMA(node_id) PWM_DT_SPEC_GET(node_id),
-
 #define LED_PWM_DEVICE(id)					\
 								\
 static const struct pwm_dt_spec led_pwm_##id[] = {		\
-	DT_INST_FOREACH_CHILD(id, PWM_DT_SPEC_GET_AND_COMMA)	\
+	DT_INST_FOREACH_CHILD_SEP(id, PWM_DT_SPEC_GET, (,))	\
 };								\
 								\
 static const struct led_pwm_config led_pwm_config_##id = {	\

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -1955,6 +1955,43 @@
 	DT_CAT(node_id, _FOREACH_CHILD)(fn)
 
 /**
+ * @brief Invokes "fn" for each child of "node_id" with a separator
+ *
+ * The macro "fn" must take one parameter, which will be the node
+ * identifier of a child node of "node_id".
+ *
+ * Example devicetree fragment:
+ *
+ *     n: node {
+ *             child-1 {
+ *                     ...
+ *             };
+ *             child-2 {
+ *                     ...
+ *             };
+ *     };
+ *
+ * Example usage:
+ *
+ *     const char *child_names[] = {
+ *         DT_FOREACH_CHILD_SEP(DT_NODELABEL(n), DT_NODE_FULL_NAME, (,))
+ *     };
+ *
+ * This expands to:
+ *
+ *     const char *child_names[] = {
+ *         "child-1", "child-2"
+ *     };
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ */
+#define DT_FOREACH_CHILD_SEP(node_id, fn, sep) \
+	DT_CAT(node_id, _FOREACH_CHILD_SEP)(fn, sep)
+
+/**
  * @brief Invokes "fn" for each child of "node_id" with multiple arguments
  *
  * The macro "fn" takes multiple arguments. The first should be the node
@@ -1973,6 +2010,24 @@
 	DT_CAT(node_id, _FOREACH_CHILD_VARGS)(fn, __VA_ARGS__)
 
 /**
+ * @brief Invokes "fn" for each child of "node_id" with separator and multiple
+ *        arguments.
+ *
+ * The macro "fn" takes multiple arguments. The first should be the node
+ * identifier for the child node. The remaining are passed-in by the caller.
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to fn
+ *
+ * @see DT_FOREACH_CHILD_VARGS
+ */
+#define DT_FOREACH_CHILD_SEP_VARGS(node_id, fn, sep, ...) \
+	DT_CAT(node_id, _FOREACH_CHILD_SEP_VARGS)(fn, sep, __VA_ARGS__)
+
+/**
  * @brief Call "fn" on the child nodes with status "okay"
  *
  * The macro "fn" should take one argument, which is the node
@@ -1989,6 +2044,25 @@
  */
 #define DT_FOREACH_CHILD_STATUS_OKAY(node_id, fn) \
 	DT_CAT(node_id, _FOREACH_CHILD_STATUS_OKAY)(fn)
+
+/**
+ * @brief Call "fn" on the child nodes with status "okay" with separator
+ *
+ * The macro "fn" should take one argument, which is the node
+ * identifier for the child node.
+ *
+ * As usual, both a missing status and an "ok" status are
+ * treated as "okay".
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ *
+ * @see DT_FOREACH_CHILD_STATUS_OKAY
+ */
+#define DT_FOREACH_CHILD_STATUS_OKAY_SEP(node_id, fn, sep) \
+	DT_CAT(node_id, _FOREACH_CHILD_STATUS_OKAY_SEP)(fn, sep)
 
 /**
  * @brief Call "fn" on the child nodes with status "okay" with multiple
@@ -2011,6 +2085,27 @@
  */
 #define DT_FOREACH_CHILD_STATUS_OKAY_VARGS(node_id, fn, ...) \
 	DT_CAT(node_id, _FOREACH_CHILD_STATUS_OKAY_VARGS)(fn, __VA_ARGS__)
+
+/**
+ * @brief Call "fn" on the child nodes with status "okay" with separator and
+ * multiple arguments
+ *
+ * The macro "fn" takes multiple arguments. The first should be the node
+ * identifier for the child node. The remaining are passed-in by the caller.
+ *
+ * As usual, both a missing status and an "ok" status are
+ * treated as "okay".
+ *
+ * @param node_id node identifier
+ * @param fn macro to invoke
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to fn
+ *
+ * @see DT_FOREACH_CHILD_SEP_STATUS_OKAY
+ */
+#define DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(node_id, fn, sep, ...) \
+	DT_CAT(node_id, _FOREACH_CHILD_STATUS_OKAY_SEP_VARGS)(fn, sep, __VA_ARGS__)
 
 /**
  * @brief Invokes "fn" for each element in the value of property "prop".
@@ -2456,6 +2551,22 @@
 	DT_FOREACH_CHILD(DT_DRV_INST(inst), fn)
 
 /**
+ * @brief Call "fn" on all child nodes of DT_DRV_INST(inst) with a separator
+ *
+ * The macro "fn" should take one argument, which is the node
+ * identifier for the child node.
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each child node identifier
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ *
+ * @see DT_FOREACH_CHILD_SEP
+ */
+#define DT_INST_FOREACH_CHILD_SEP(inst, fn, sep) \
+	DT_FOREACH_CHILD_SEP(DT_DRV_INST(inst), fn, sep)
+
+/**
  * @brief Call "fn" on all child nodes of DT_DRV_INST(inst).
  *
  * The macro "fn" takes multiple arguments. The first should be the node
@@ -2472,6 +2583,23 @@
  */
 #define DT_INST_FOREACH_CHILD_VARGS(inst, fn, ...) \
 	DT_FOREACH_CHILD_VARGS(DT_DRV_INST(inst), fn, __VA_ARGS__)
+
+/**
+ * @brief Call "fn" on all child nodes of DT_DRV_INST(inst) with separator.
+ *
+ * The macro "fn" takes multiple arguments. The first should be the node
+ * identifier for the child node. The remaining are passed-in by the caller.
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each child node identifier
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to fn
+ *
+ * @see DT_FOREACH_CHILD_SEP_VARGS
+ */
+#define DT_INST_FOREACH_CHILD_SEP_VARGS(inst, fn, sep, ...) \
+	DT_FOREACH_CHILD_SEP_VARGS(DT_DRV_INST(inst), fn, sep, __VA_ARGS__)
 
 /**
  * @brief Get a DT_DRV_COMPAT value's index into its enumeration values

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -2602,6 +2602,71 @@
 	DT_FOREACH_CHILD_SEP_VARGS(DT_DRV_INST(inst), fn, sep, __VA_ARGS__)
 
 /**
+ * @brief Call "fn" on all child nodes of DT_DRV_INST(inst) with status "okay".
+ *
+ * The macro "fn" should take one argument, which is the node
+ * identifier for the child node.
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each child node identifier
+ *
+ * @see DT_FOREACH_CHILD_STATUS_OKAY
+ */
+#define DT_INST_FOREACH_CHILD_STATUS_OKAY(inst, fn) \
+	DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(inst), fn)
+
+/**
+ * @brief Call "fn" on all child nodes of DT_DRV_INST(inst) with status "okay"
+ * and with separator.
+ *
+ * The macro "fn" should take one argument, which is the node
+ * identifier for the child node.
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each child node identifier
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ *
+ * @see DT_FOREACH_CHILD_STATUS_OKAY_SEP
+ */
+#define DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(inst, fn, sep) \
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP(DT_DRV_INST(inst), fn, sep)
+
+/**
+ * @brief Call "fn" on all child nodes of DT_DRV_INST(inst) with status "okay"
+ * and multiple arguments.
+ *
+ * The macro "fn" takes multiple arguments. The first should be the node
+ * identifier for the child node. The remaining are passed-in by the caller.
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each child node identifier
+ * @param ... variable number of arguments to pass to fn
+ *
+ * @see DT_FOREACH_CHILD_STATUS_OKAY_VARGS
+ */
+#define DT_INST_FOREACH_CHILD_STATUS_OKAY_VARGS(inst, fn, ...) \
+	DT_FOREACH_CHILD_STATUS_OKAY_VARGS(DT_DRV_INST(inst), fn, __VA_ARGS__)
+
+/**
+ * @brief Call "fn" on all child nodes of DT_DRV_INST(inst) with status "okay"
+ * and with separator and multiple arguments.
+ *
+ * The macro "fn" takes multiple arguments. The first should be the node
+ * identifier for the child node. The remaining are passed-in by the caller.
+ *
+ * @param inst instance number
+ * @param fn macro to invoke on each child node identifier
+ * @param sep Separator (e.g. comma or semicolon). Must be in parentheses;
+ *            this is required to enable providing a comma as separator.
+ * @param ... variable number of arguments to pass to fn
+ *
+ * @see DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS
+ */
+#define DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(inst, fn, sep, ...) \
+	DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(DT_DRV_INST(inst), fn, sep, __VA_ARGS__)
+
+/**
  * @brief Get a DT_DRV_COMPAT value's index into its enumeration values
  * @param inst instance number
  * @param prop lowercase-and-underscores property name

--- a/samples/drivers/led_pwm/src/main.c
+++ b/samples/drivers/led_pwm/src/main.c
@@ -16,10 +16,8 @@ LOG_MODULE_REGISTER(main, CONFIG_LOG_DEFAULT_LEVEL);
 
 #define LED_PWM_NODE_ID	 DT_COMPAT_GET_ANY_STATUS_OKAY(pwm_leds)
 
-#define LED_PWM_LABEL(led_node_id) DT_PROP_OR(led_node_id, label, NULL),
-
 const char *led_label[] = {
-	DT_FOREACH_CHILD(LED_PWM_NODE_ID, LED_PWM_LABEL)
+	DT_FOREACH_CHILD_SEP_VARGS(LED_PWM_NODE_ID, DT_PROP_OR, (,), label, NULL)
 };
 
 const int num_leds = ARRAY_SIZE(led_label);

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -521,21 +521,33 @@ def write_children(node):
             " ".join(f"fn(DT_{child.z_path_id})" for child in
                 node.children.values()))
 
+    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_SEP(fn, sep)",
+            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id})"
+            for child in node.children.values()))
+
     out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_VARGS(fn, ...)",
-            " ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)" for child in
-                node.children.values()))
+            " ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
+            for child in node.children.values()))
 
-    functions = ''
-    functions_args = ''
-    for child in node.children.values():
-        if child.status == "okay":
-            functions = functions + f"fn(DT_{child.z_path_id}) "
-            functions_args = functions_args + f"fn(DT_{child.z_path_id}, " \
-                                                            "__VA_ARGS__) "
+    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_SEP_VARGS(fn, sep, ...)",
+            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
+            for child in node.children.values()))
 
-    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY(fn)", functions)
+    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY(fn)",
+            " ".join(f"fn(DT_{child.z_path_id})"
+            for child in node.children.values() if child.status == "okay"))
+
+    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_SEP(fn, sep)",
+            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id})"
+            for child in node.children.values() if child.status == "okay"))
+
     out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_VARGS(fn, ...)",
-                                                                functions_args)
+            " ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
+            for child in node.children.values() if child.status == "okay"))
+
+    out_dt_define(f"{node.z_path_id}_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(fn, sep, ...)",
+            " DT_DEBRACKET_INTERNAL sep ".join(f"fn(DT_{child.z_path_id}, __VA_ARGS__)"
+            for child in node.children.values() if child.status == "okay"))
 
 
 def write_status(node):

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -102,6 +102,8 @@ def main():
     with open(args.header_out, "w", encoding="utf-8") as header_file:
         write_top_comment(edt)
 
+        write_utils()
+
         # populate all z_path_id first so any children references will
         # work correctly.
         for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
@@ -237,6 +239,13 @@ followed by /chosen nodes.
 """
 
     out_comment(s, blank_before=False)
+
+
+def write_utils():
+    # Writes utility macros
+
+    out_comment("Used to remove brackets from around a single argument")
+    out_define("DT_DEBRACKET_INTERNAL(...)", "__VA_ARGS__")
 
 
 def write_node_comment(node):

--- a/subsys/pm/state.c
+++ b/subsys/pm/state.c
@@ -39,23 +39,21 @@ BUILD_ASSERT(DT_NODE_EXISTS(DT_PATH(cpus)),
 /* Check that all power states are consistent */
 DT_FOREACH_CHILD(DT_PATH(cpus), CHECK_POWER_STATES_CONSISTENCY)
 
-#define NUM_CPU_STATES(n) DT_NUM_CPU_POWER_STATES(n),
-
 #define DEFINE_CPU_STATES(n) \
 	static const struct pm_state_info pmstates_##n[] \
 		= PM_STATE_INFO_LIST_FROM_DT_CPU(n);
-#define CPU_STATE_REF(n) pmstates_##n,
+#define CPU_STATE_REF(n) pmstates_##n
 
 DT_FOREACH_CHILD(DT_PATH(cpus), DEFINE_CPU_STATES);
 
 /** CPU power states information for each CPU */
 static const struct pm_state_info *cpus_states[] = {
-	DT_FOREACH_CHILD(DT_PATH(cpus), CPU_STATE_REF)
+	DT_FOREACH_CHILD_SEP(DT_PATH(cpus), CPU_STATE_REF, (,))
 };
 
 /** Number of states for each CPU */
 static const uint8_t states_per_cpu[] = {
-	DT_FOREACH_CHILD(DT_PATH(cpus), NUM_CPU_STATES)
+	DT_FOREACH_CHILD_SEP(DT_PATH(cpus), DT_NUM_CPU_POWER_STATES, (,))
 };
 
 uint8_t pm_state_cpu_get_all(uint8_t cpu, const struct pm_state_info **states)

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1630,7 +1630,8 @@ ZTEST(devicetree_api, test_parent)
 #define DT_DRV_COMPAT vnd_child_bindings
 ZTEST(devicetree_api, test_child_nodes_list)
 {
-	#define TEST_FUNC(child) { DT_PROP(child, val) },
+	#define TEST_FUNC(child) { DT_PROP(child, val) }
+	#define TEST_FUNC_AND_COMMA(child) TEST_FUNC(child),
 	#define TEST_PARENT DT_PARENT(DT_NODELABEL(test_child_a))
 
 	struct vnd_child_binding {
@@ -1638,31 +1639,55 @@ ZTEST(devicetree_api, test_child_nodes_list)
 	};
 
 	struct vnd_child_binding vals[] = {
-		DT_FOREACH_CHILD(TEST_PARENT, TEST_FUNC)
+		DT_FOREACH_CHILD(TEST_PARENT, TEST_FUNC_AND_COMMA)
+	};
+
+	struct vnd_child_binding vals_sep[] = {
+		DT_FOREACH_CHILD_SEP(TEST_PARENT, TEST_FUNC, (,))
 	};
 
 	struct vnd_child_binding vals_inst[] = {
-		DT_INST_FOREACH_CHILD(0, TEST_FUNC)
+		DT_INST_FOREACH_CHILD(0, TEST_FUNC_AND_COMMA)
+	};
+
+	struct vnd_child_binding vals_inst_sep[] = {
+		DT_INST_FOREACH_CHILD_SEP(0, TEST_FUNC, (,))
 	};
 
 	struct vnd_child_binding vals_status_okay[] = {
-		DT_FOREACH_CHILD_STATUS_OKAY(TEST_PARENT, TEST_FUNC)
+		DT_FOREACH_CHILD_STATUS_OKAY(TEST_PARENT, TEST_FUNC_AND_COMMA)
+	};
+
+	struct vnd_child_binding vals_status_okay_sep[] = {
+		DT_FOREACH_CHILD_STATUS_OKAY_SEP(TEST_PARENT, TEST_FUNC, (,))
 	};
 
 	zassert_equal(ARRAY_SIZE(vals), 3, "");
+	zassert_equal(ARRAY_SIZE(vals_sep), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_inst), 3, "");
+	zassert_equal(ARRAY_SIZE(vals_inst_sep), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_status_okay), 2, "");
+	zassert_equal(ARRAY_SIZE(vals_status_okay_sep), 2, "");
 
 	zassert_equal(vals[0].val, 0, "");
 	zassert_equal(vals[1].val, 1, "");
 	zassert_equal(vals[2].val, 2, "");
+	zassert_equal(vals_sep[0].val, 0, "");
+	zassert_equal(vals_sep[1].val, 1, "");
+	zassert_equal(vals_sep[2].val, 2, "");
 	zassert_equal(vals_inst[0].val, 0, "");
 	zassert_equal(vals_inst[1].val, 1, "");
 	zassert_equal(vals_inst[2].val, 2, "");
+	zassert_equal(vals_inst_sep[0].val, 0, "");
+	zassert_equal(vals_inst_sep[1].val, 1, "");
+	zassert_equal(vals_inst_sep[2].val, 2, "");
 	zassert_equal(vals_status_okay[0].val, 0, "");
 	zassert_equal(vals_status_okay[1].val, 1, "");
+	zassert_equal(vals_status_okay_sep[0].val, 0, "");
+	zassert_equal(vals_status_okay_sep[1].val, 1, "");
 
 	#undef TEST_PARENT
+	#undef TEST_FUNC_AND_COMMA
 	#undef TEST_FUNC
 }
 
@@ -1670,7 +1695,8 @@ ZTEST(devicetree_api, test_child_nodes_list)
 #define DT_DRV_COMPAT vnd_child_bindings
 ZTEST(devicetree_api, test_child_nodes_list_varg)
 {
-	#define TEST_FUNC(child, arg) { DT_PROP(child, val) + arg },
+	#define TEST_FUNC(child, arg) { DT_PROP(child, val) + arg }
+	#define TEST_FUNC_AND_COMMA(child, arg) TEST_FUNC(child, arg),
 	#define TEST_PARENT DT_PARENT(DT_NODELABEL(test_child_a))
 
 	struct vnd_child_binding {
@@ -1678,31 +1704,55 @@ ZTEST(devicetree_api, test_child_nodes_list_varg)
 	};
 
 	struct vnd_child_binding vals[] = {
-		DT_FOREACH_CHILD_VARGS(TEST_PARENT, TEST_FUNC, 1)
+		DT_FOREACH_CHILD_VARGS(TEST_PARENT, TEST_FUNC_AND_COMMA, 1)
+	};
+
+	struct vnd_child_binding vals_sep[] = {
+		DT_FOREACH_CHILD_SEP_VARGS(TEST_PARENT, TEST_FUNC, (,), 1)
 	};
 
 	struct vnd_child_binding vals_inst[] = {
-		DT_INST_FOREACH_CHILD_VARGS(0, TEST_FUNC, 1)
+		DT_INST_FOREACH_CHILD_VARGS(0, TEST_FUNC_AND_COMMA, 1)
+	};
+
+	struct vnd_child_binding vals_inst_sep[] = {
+		DT_INST_FOREACH_CHILD_SEP_VARGS(0, TEST_FUNC, (,), 1)
 	};
 
 	struct vnd_child_binding vals_status_okay[] = {
-		DT_FOREACH_CHILD_STATUS_OKAY_VARGS(TEST_PARENT, TEST_FUNC, 1)
+		DT_FOREACH_CHILD_STATUS_OKAY_VARGS(TEST_PARENT, TEST_FUNC_AND_COMMA, 1)
+	};
+
+	struct vnd_child_binding vals_status_okay_sep[] = {
+		DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(TEST_PARENT, TEST_FUNC, (,), 1)
 	};
 
 	zassert_equal(ARRAY_SIZE(vals), 3, "");
+	zassert_equal(ARRAY_SIZE(vals_sep), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_inst), 3, "");
+	zassert_equal(ARRAY_SIZE(vals_inst_sep), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_status_okay), 2, "");
+	zassert_equal(ARRAY_SIZE(vals_status_okay_sep), 2, "");
 
 	zassert_equal(vals[0].val, 1, "");
 	zassert_equal(vals[1].val, 2, "");
 	zassert_equal(vals[2].val, 3, "");
+	zassert_equal(vals_sep[0].val, 1, "");
+	zassert_equal(vals_sep[1].val, 2, "");
+	zassert_equal(vals_sep[2].val, 3, "");
 	zassert_equal(vals_inst[0].val, 1, "");
 	zassert_equal(vals_inst[1].val, 2, "");
 	zassert_equal(vals_inst[2].val, 3, "");
+	zassert_equal(vals_inst_sep[0].val, 1, "");
+	zassert_equal(vals_inst_sep[1].val, 2, "");
+	zassert_equal(vals_inst_sep[2].val, 3, "");
 	zassert_equal(vals_status_okay[0].val, 1, "");
 	zassert_equal(vals_status_okay[1].val, 2, "");
+	zassert_equal(vals_status_okay_sep[0].val, 1, "");
+	zassert_equal(vals_status_okay_sep[1].val, 2, "");
 
 	#undef TEST_PARENT
+	#undef TEST_FUNC_AND_COMMA
 	#undef TEST_FUNC
 }
 

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1658,8 +1658,16 @@ ZTEST(devicetree_api, test_child_nodes_list)
 		DT_FOREACH_CHILD_STATUS_OKAY(TEST_PARENT, TEST_FUNC_AND_COMMA)
 	};
 
+	struct vnd_child_binding vals_status_okay_inst[] = {
+		DT_INST_FOREACH_CHILD_STATUS_OKAY(0, TEST_FUNC_AND_COMMA)
+	};
+
 	struct vnd_child_binding vals_status_okay_sep[] = {
 		DT_FOREACH_CHILD_STATUS_OKAY_SEP(TEST_PARENT, TEST_FUNC, (,))
+	};
+
+	struct vnd_child_binding vals_status_okay_inst_sep[] = {
+		DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP(0, TEST_FUNC, (,))
 	};
 
 	zassert_equal(ARRAY_SIZE(vals), 3, "");
@@ -1667,7 +1675,9 @@ ZTEST(devicetree_api, test_child_nodes_list)
 	zassert_equal(ARRAY_SIZE(vals_inst), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_inst_sep), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_status_okay), 2, "");
+	zassert_equal(ARRAY_SIZE(vals_status_okay_inst), 2, "");
 	zassert_equal(ARRAY_SIZE(vals_status_okay_sep), 2, "");
+	zassert_equal(ARRAY_SIZE(vals_status_okay_inst_sep), 2, "");
 
 	zassert_equal(vals[0].val, 0, "");
 	zassert_equal(vals[1].val, 1, "");
@@ -1683,8 +1693,12 @@ ZTEST(devicetree_api, test_child_nodes_list)
 	zassert_equal(vals_inst_sep[2].val, 2, "");
 	zassert_equal(vals_status_okay[0].val, 0, "");
 	zassert_equal(vals_status_okay[1].val, 1, "");
+	zassert_equal(vals_status_okay_inst[0].val, 0, "");
+	zassert_equal(vals_status_okay_inst[1].val, 1, "");
 	zassert_equal(vals_status_okay_sep[0].val, 0, "");
 	zassert_equal(vals_status_okay_sep[1].val, 1, "");
+	zassert_equal(vals_status_okay_inst_sep[0].val, 0, "");
+	zassert_equal(vals_status_okay_inst_sep[1].val, 1, "");
 
 	#undef TEST_PARENT
 	#undef TEST_FUNC_AND_COMMA
@@ -1723,8 +1737,16 @@ ZTEST(devicetree_api, test_child_nodes_list_varg)
 		DT_FOREACH_CHILD_STATUS_OKAY_VARGS(TEST_PARENT, TEST_FUNC_AND_COMMA, 1)
 	};
 
+	struct vnd_child_binding vals_status_okay_inst[] = {
+		DT_INST_FOREACH_CHILD_STATUS_OKAY_VARGS(0, TEST_FUNC_AND_COMMA, 1)
+	};
+
 	struct vnd_child_binding vals_status_okay_sep[] = {
 		DT_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(TEST_PARENT, TEST_FUNC, (,), 1)
+	};
+
+	struct vnd_child_binding vals_status_okay_inst_sep[] = {
+		DT_INST_FOREACH_CHILD_STATUS_OKAY_SEP_VARGS(0, TEST_FUNC, (,), 1)
 	};
 
 	zassert_equal(ARRAY_SIZE(vals), 3, "");
@@ -1732,7 +1754,9 @@ ZTEST(devicetree_api, test_child_nodes_list_varg)
 	zassert_equal(ARRAY_SIZE(vals_inst), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_inst_sep), 3, "");
 	zassert_equal(ARRAY_SIZE(vals_status_okay), 2, "");
+	zassert_equal(ARRAY_SIZE(vals_status_okay_inst), 2, "");
 	zassert_equal(ARRAY_SIZE(vals_status_okay_sep), 2, "");
+	zassert_equal(ARRAY_SIZE(vals_status_okay_inst_sep), 2, "");
 
 	zassert_equal(vals[0].val, 1, "");
 	zassert_equal(vals[1].val, 2, "");
@@ -1748,8 +1772,12 @@ ZTEST(devicetree_api, test_child_nodes_list_varg)
 	zassert_equal(vals_inst_sep[2].val, 3, "");
 	zassert_equal(vals_status_okay[0].val, 1, "");
 	zassert_equal(vals_status_okay[1].val, 2, "");
+	zassert_equal(vals_status_okay_inst[0].val, 1, "");
+	zassert_equal(vals_status_okay_inst[1].val, 2, "");
 	zassert_equal(vals_status_okay_sep[0].val, 1, "");
 	zassert_equal(vals_status_okay_sep[1].val, 2, "");
+	zassert_equal(vals_status_okay_inst_sep[0].val, 1, "");
+	zassert_equal(vals_status_okay_inst_sep[1].val, 2, "");
 
 	#undef TEST_PARENT
 	#undef TEST_FUNC_AND_COMMA


### PR DESCRIPTION
It is frequent to see in Devicetree code constructs like:

```c
#define LABEL_AND_COMMA(node_id) DT_LABEL(node_id),

const char *child_labels[] = {
	DT_FOREACH_CHILD(DT_NODELABEL(n), LABEL_AND_COMMA)
};
```

That is, an auxiliary macro to append a separator character in
DT_FOREACH* macros. Non-DT API, e.g. FOR_EACH(), takes a separator
argument to avoid such intermediate macros.

This patch adds DT_FOREACH_CHILD_SEP (and instance version
of it). It takes an extra argument: a separator. With this change, the
example above can be simplified to:

```c
const char *child_labels[] = {
	DT_FOREACH_CHILD_SEP(DT_NODELABEL(n), DT_LABEL, (,))
};
```

Notes:
- Other DT_FOREACH* macros could/should be extended as well
- We could modify original macros to always take a separator, to align
  with non-DT FOREACH* macros, but that would be a breaking change
- Placement of `sep` argument: `DT_FOREACH_CHILD_SEP(DT_NODELABEL(n), DT_LABEL, (,))` or `DT_FOREACH_CHILD_SEP(DT_NODELABEL(n), (,), DT_LABEL)`? (relevant for the VARGS case)