### PR TITLE
west.yml: hal_atmel: Add include directory only for atmel devices

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: a48627169e6897a504d0ee1410a886551bb2bbf2
+      revision: bb4e7104132bdc22c7cc7e20057434c2979e6706
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
The main CMakeLists.txt for hal_atmel adds an include directory
without checking that the module is enabled. This causes ALL Zephyr
builds to have modules/hal/atmel/include in their included
directories. This commit updates west.yml to point to a fix for
this issue.

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>