### PR TITLE
drivers: gpio: Add Support for GPIO ALT FUNC.

### DIFF
--- a/include/zephyr/drivers/gpio.h
+++ b/include/zephyr/drivers/gpio.h
@@ -229,6 +229,9 @@ extern "C" {
 #define GPIO_DIR_MASK		(GPIO_INPUT | GPIO_OUTPUT)
 /** @endcond */
 
+/** Enables pin's Alt Func. */
+#define GPIO_ALT_FUNC              (1U << 27)
+
 /**
  * @brief Identifies a set of pins associated with a port.
  *


### PR DESCRIPTION
Changes include:
1-Adding new flag GPIO_ALT_FUNC to enable/indicate GPIO's alternate function.
2-Updating cmsdk GPIO driver to enable GPIO's alt function in config.

Signed-off-by: Ravik Hasija <ravikh@fb.com>