### PR TITLE
video: ov2640: cleanup unused struct fields

### DIFF
--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -438,9 +438,6 @@ struct ov2640_config {
 };
 
 struct ov2640_data {
-	const struct device *reset_gpio;
-	uint8_t reset_pin;
-	gpio_dt_flags_t reset_pin_flags;
 	struct video_format fmt;
 };
 


### PR DESCRIPTION
When we moved to gpio_dt_spec forgot to remove the older
fields used for gpio related access.  Remove them as they
are used by the driver anymore.

Signed-off-by: Kumar Gala <galak@kernel.org>