### PR TITLE
samples: lsm6dso: Convert to use DEVICE_DT_GET_ONE

### DIFF
--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
@@ -8,7 +8,6 @@ toolchain:
 supported:
   - gpio
   - i2c
-  - lsm6dso
   - lptim
   - pwm
   - watchdog

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.yaml
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_ns.yaml
@@ -8,7 +8,6 @@ toolchain:
 supported:
   - gpio
   - i2c
-  - lsm6dso
   - lptim
   - dac
   - spi

--- a/samples/sensor/lsm6dso/sample.yaml
+++ b/samples/sensor/lsm6dso/sample.yaml
@@ -4,8 +4,8 @@ tests:
   sample.sensor.lsm6dso:
     harness: console
     tags: sensors
-    depends_on: lsm6dso
     timeout: 15
+    filter: dt_compat_enabled("st,lsm6dso")
     harness_config:
       type: multi_line
       ordered: true

--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -9,15 +9,6 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/sensor.h>
 
-#define LSM6DSO DT_INST(0, st_lsm6dso)
-
-#if DT_NODE_HAS_STATUS(LSM6DSO, okay)
-#define LSM6DSO_LABEL DT_LABEL(LSM6DSO)
-#else
-#error Your devicetree has no enabled nodes with compatible "st,lsm6dso"
-#define LSM6DSO_LABEL "<none>"
-#endif
-
 static inline float out_ev(struct sensor_value *val)
 {
 	return (val->val1 + (float)val->val2 / 1000000);
@@ -115,10 +106,10 @@ static void test_polling_mode(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = device_get_binding(LSM6DSO_LABEL);
+	const struct device *dev = DEVICE_DT_GET_ONE(st_lsm6dso);
 
-	if (dev == NULL) {
-		printf("No device \"%s\" found.\n", LSM6DSO_LABEL);
+	if (!device_is_ready(dev)) {
+		printk("%s: device not ready.\n", dev->name);
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET_ONE instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>