### PR TITLE
samples: spi_flash: Convert to use DEVICE_DT_GET

### DIFF
--- a/drivers/flash/Kconfig.nor
+++ b/drivers/flash/Kconfig.nor
@@ -1,12 +1,15 @@
 # Copyright (c) 2018 Savoir-Faire Linux.
 # SPDX-License-Identifier: Apache-2.0
 
+DT_COMPAT_JEDEC_SPI_NOR := jedec,spi-nor
+
 menuconfig SPI_NOR
 	bool "SPI NOR Flash"
 	select FLASH_HAS_DRIVER_ENABLED
 	select FLASH_HAS_PAGE_LAYOUT
 	select FLASH_JESD216
 	depends on SPI
+	default $(dt_compat_enabled,$(DT_COMPAT_JEDEC_SPI_NOR))
 
 if SPI_NOR
 

--- a/samples/drivers/spi_flash/sample.yaml
+++ b/samples/drivers/spi_flash/sample.yaml
@@ -4,6 +4,7 @@ tests:
   sample.drivers.spi.flash:
     tags: spi flash
     filter: dt_compat_enabled("jedec,spi-nor") or dt_compat_enabled("st,stm32-qspi-nor") or dt_compat_enabled("st,stm32-ospi-nor")
+    platform_exclude: hifive_unmatched
     harness: console
     harness_config:
         type: multi_line
@@ -18,6 +19,7 @@ tests:
   sample.drivers.spi.flash_dpd:
     tags: spi flash
     filter: dt_compat_enabled("jedec,spi-nor")
+    platform_exclude: hifive_unmatched
     build_only: true
     extra_configs:
       - CONFIG_SPI_NOR_IDLE_IN_DPD=y

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -13,18 +13,14 @@
 
 #if (CONFIG_SPI_NOR - 0) ||				\
 	DT_NODE_HAS_STATUS(DT_INST(0, jedec_spi_nor), okay)
-#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, jedec_spi_nor))
-#define SPI_FLASH_NAME "JEDEC SPI-NOR"
+#define SPI_FLASH_NODE DT_INST(0, jedec_spi_nor)
 #elif (CONFIG_NORDIC_QSPI_NOR - 0) || \
 	DT_NODE_HAS_STATUS(DT_INST(0, nordic_qspi_nor), okay)
-#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, nordic_qspi_nor))
-#define SPI_FLASH_NAME "JEDEC QSPI-NOR"
+#define SPI_FLASH_NODE DT_INST(0, nordic_qspi_nor)
 #elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_qspi_nor), okay)
-#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, st_stm32_qspi_nor))
-#define SPI_FLASH_NAME "JEDEC QSPI-NOR"
+#define SPI_FLASH_NODE DT_INST(0, st_stm32_qspi_nor)
 #elif DT_NODE_HAS_STATUS(DT_INST(0, st_stm32_ospi_nor), okay)
-#define SPI_FLASH_DEVICE DT_LABEL(DT_INST(0, st_stm32_ospi_nor))
-#define SPI_FLASH_NAME "JEDEC OSPI-NOR"
+#define SPI_FLASH_NODE DT_INST(0, st_stm32_ospi_nor)
 #else
 #error Unsupported flash driver
 #endif
@@ -52,16 +48,16 @@ void main(void)
 	const struct device *flash_dev;
 	int rc;
 
-	printf("\n" SPI_FLASH_NAME " SPI flash testing\n");
-	printf("==========================\n");
+	flash_dev = DEVICE_DT_GET(SPI_FLASH_NODE);
 
-	flash_dev = device_get_binding(SPI_FLASH_DEVICE);
-
-	if (!flash_dev) {
-		printf("SPI flash driver %s was not found!\n",
-		       SPI_FLASH_DEVICE);
+	if (!device_is_ready(flash_dev)) {
+		printk("%s: device not ready.\n", flash_dev->name);
 		return;
 	}
+
+	printf("\n%s SPI flash testing\n", flash_dev->name);
+	printf("==========================\n");
+
 
 	/* Write protection needs to be disabled before each write or
 	 * erase, since the flash component turns on write protection


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>