### PR TITLE
drivers: sensor: iis2dh: Add multi-instance support

### DIFF
--- a/drivers/sensor/iis2dh/iis2dh_trigger.c
+++ b/drivers/sensor/iis2dh/iis2dh_trigger.c
@@ -42,8 +42,13 @@ int iis2dh_trigger_set(const struct device *dev,
 		       sensor_trigger_handler_t handler)
 {
 	struct iis2dh_data *iis2dh = dev->data;
+	const struct iis2dh_device_config *cfg = dev->config;
 	int16_t raw[3];
 	int state = (handler != NULL) ? PROPERTY_ENABLE : PROPERTY_DISABLE;
+
+	if (!cfg->int_gpio.port) {
+		return -ENOTSUP;
+	}
 
 	switch (trig->type) {
 	case SENSOR_TRIG_DATA_READY:


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>