### PR TITLE
emul: refactor to resolve emulators at compile time

### DIFF
--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -225,14 +225,13 @@ static struct emul_espi_driver_api emul_espi_driver_api = {
 	.find_emul = espi_emul_find,
 };
 
+#define EMUL_DT_GET_AND_COMMA(node_id) EMUL_DT_GET(node_id),
+#define EMUL_DT_DECLARE_AND_SEMICOLON(node_id) EMUL_DT_DECLARE(node_id);
 
-#define EMUL_LINK_AND_COMMA(node_id) {	    \
-		.label = DT_LABEL(node_id), \
-},
-
-#define ESPI_EMUL_INIT(n)					      \
-	static const struct emul_link_for_bus emuls_##n[] = {	      \
-		DT_FOREACH_CHILD(DT_DRV_INST(n), EMUL_LINK_AND_COMMA) \
+#define ESPI_EMUL_INIT(n) \
+	DT_INST_FOREACH_CHILD(n, EMUL_DT_DECLARE_AND_SEMICOLON)	      \
+	static const struct emul *emuls_##n[] = {		      \
+		DT_INST_FOREACH_CHILD(n, EMUL_DT_GET_AND_COMMA)	      \
 	};							      \
 	static struct emul_list_for_bus espi_emul_cfg_##n = {	      \
 		.children = emuls_##n,				      \

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -139,13 +139,13 @@ static struct i2c_driver_api i2c_emul_api = {
 	.transfer = i2c_emul_transfer,
 };
 
-#define EMUL_LINK_AND_COMMA(node_id) {		\
-	.label = DT_LABEL(node_id),		\
-},
+#define EMUL_DT_GET_AND_COMMA(node_id) EMUL_DT_GET(node_id),
+#define EMUL_DT_DECLARE_AND_SEMICOLON(node_id) EMUL_DT_DECLARE(node_id);
 
 #define I2C_EMUL_INIT(n) \
-	static const struct emul_link_for_bus emuls_##n[] = { \
-		DT_FOREACH_CHILD(DT_DRV_INST(n), EMUL_LINK_AND_COMMA) \
+	DT_INST_FOREACH_CHILD(n, EMUL_DT_DECLARE_AND_SEMICOLON) \
+	static const struct emul *emuls_##n[] = { \
+		DT_INST_FOREACH_CHILD(n, EMUL_DT_GET_AND_COMMA) \
 	}; \
 	static struct emul_list_for_bus i2c_emul_cfg_##n = { \
 		.children = emuls_##n, \

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -117,13 +117,13 @@ static struct spi_driver_api spi_emul_api = {
 	.transceive = spi_emul_io,
 };
 
-#define EMUL_LINK_AND_COMMA(node_id) {		\
-	.label = DT_LABEL(node_id),		\
-},
+#define EMUL_DT_GET_AND_COMMA(node_id) EMUL_DT_GET(node_id),
+#define EMUL_DT_DECLARE_AND_SEMICOLON(node_id) EMUL_DT_DECLARE(node_id);
 
 #define SPI_EMUL_INIT(n) \
-	static const struct emul_link_for_bus emuls_##n[] = { \
-		DT_FOREACH_CHILD(DT_DRV_INST(0), EMUL_LINK_AND_COMMA) \
+	DT_INST_FOREACH_CHILD(n, EMUL_DT_DECLARE_AND_SEMICOLON) \
+	static const struct emul *emuls_##n[] = { \
+		DT_INST_FOREACH_CHILD(n, EMUL_DT_GET_AND_COMMA) \
 	}; \
 	static struct emul_list_for_bus spi_emul_cfg_##n = { \
 		.children = emuls_##n, \

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -13,19 +13,6 @@ LOG_MODULE_REGISTER(emul);
 #include <zephyr/drivers/emul.h>
 #include <string.h>
 
-const struct emul *emul_get_binding(const char *name)
-{
-	const struct emul *emul_it;
-
-	for (emul_it = __emul_list_start; emul_it < __emul_list_end; emul_it++) {
-		if (strcmp(emul_it->dev_label, name) == 0) {
-			return emul_it;
-		}
-	}
-
-	return NULL;
-}
-
 int emul_init_for_bus_from_list(const struct device *dev,
 				const struct emul_list_for_bus *list)
 {
@@ -35,22 +22,17 @@ int emul_init_for_bus_from_list(const struct device *dev,
 	 * Walk the list of children, find the corresponding emulator and
 	 * initialise it.
 	 */
-	const struct emul_link_for_bus *elp;
-	const struct emul_link_for_bus *const end =
-		cfg->children + cfg->num_children;
-
 	LOG_INF("Registering %d emulator(s) for %s", cfg->num_children,
 		dev->name);
-	for (elp = cfg->children; elp < end; elp++) {
-		const struct emul *emul = emul_get_binding(elp->label);
 
-		__ASSERT(emul, "Cannot find emulator for '%s'", elp->label);
+	for (unsigned int i = 0U; i < cfg->num_children; i++) {
+		const struct emul *emul = cfg->children[i];
 
 		int rc = emul->init(emul, dev);
 
 		if (rc != 0) {
 			LOG_WRN("Init %s emulator failed: %d\n",
-				 elp->label, rc);
+				emul->name, rc);
 		}
 	}
 

--- a/subsys/emul/emul_bmi160.c
+++ b/subsys/emul/emul_bmi160.c
@@ -347,7 +347,7 @@ static int emul_bosch_bmi160_init_spi(const struct emul *emul,
 	data->emul_spi.chipsel = cfg->chipsel;
 	data->emul_spi.parent = emul;
 
-	int rc = spi_emul_register(parent, emul->dev_label, &data->emul_spi);
+	int rc = spi_emul_register(parent, emul->name, &data->emul_spi);
 
 	return rc;
 }
@@ -375,7 +375,7 @@ static int emul_bosch_bmi160_init_i2c(const struct emul *emul,
 	data->emul_i2c.addr = cfg->addr;
 	data->emul_i2c.parent = emul;
 
-	int rc = i2c_emul_register(parent, emul->dev_label, &data->emul_i2c);
+	int rc = i2c_emul_register(parent, emul->name, &data->emul_i2c);
 
 	return rc;
 }

--- a/subsys/emul/espi/emul_espi_host.c
+++ b/subsys/emul/espi/emul_espi_host.c
@@ -262,7 +262,7 @@ static int emul_host_init(const struct emul *emul, const struct device *bus)
 	data->espi = bus;
 	emul_host_init_vw_state(data);
 
-	return espi_emul_register(bus, emul->dev_label, &data->emul);
+	return espi_emul_register(bus, emul->name, &data->emul);
 }
 
 #define HOST_EMUL(n)                                                                               \

--- a/subsys/emul/i2c/emul_atmel_at24.c
+++ b/subsys/emul/i2c/emul_atmel_at24.c
@@ -150,7 +150,7 @@ static int emul_atmel_at24_init(const struct emul *emul,
 	/* Start with an erased EEPROM, assuming all 0xff */
 	memset(cfg->buf, 0xff, cfg->size);
 
-	int rc = i2c_emul_register(parent, emul->dev_label, &data->emul);
+	int rc = i2c_emul_register(parent, emul->name, &data->emul);
 
 	return rc;
 }


### PR DESCRIPTION
I didn't like what I found in the emulator subsystem while looking for
places where I could apply DT_FOREACH_CHILD_SEP* macros.

This patch removes the unnecessary runtime overhead ("emul_get_binding")
by using the same tricks as regular devices do. There are probably other
issues that should be fixed in this subsystem, but that's something for
the future or for the maintainers.