### PR TITLE
spi: Remove deprecated fields from struct spi_cs_control

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -41,6 +41,9 @@ Removed APIs in this release
 * Removed support for enabling passthrough mode on MPU9150 to
   AK8975 sensor.
 
+* Removed deprecated SPI :c:struct:`spi_cs_control` fields for GPIO management
+  that have been replaced with :c:struct:`gpio_dt_spec`.
+
 Deprecated in this release
 ==========================
 

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -19,6 +19,11 @@ API Changes
 Changes in this release
 =======================
 
+* Changed :c:struct:`spi_cs_control` to remove anonymous struct.
+  This causes possible breakage for static initialization of the
+  struct.  Updated :c:macro:`SPI_CS_CONTROL_PTR_DT` to reflect
+  this change.
+
 Removed APIs in this release
 ============================
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -149,9 +149,7 @@ struct spi_cs_control {
 	 * equivalent to SPI_CS_ACTIVE_HIGH/SPI_CS_ACTIVE_LOW options in struct
 	 * spi_config.
 	 */
-	struct {
-		struct gpio_dt_spec gpio;
-	};
+	struct gpio_dt_spec gpio;
 	/**
 	 * Delay in microseconds to wait before starting the
 	 * transmission and before releasing the CS line.
@@ -258,9 +256,7 @@ struct spi_cs_control {
  */
 #define SPI_CS_CONTROL_PTR_DT(node_id, delay_)			  \
 	(&(struct spi_cs_control) {				  \
-		{						  \
-			.gpio = SPI_CS_GPIOS_DT_SPEC_GET(node_id),\
-		},						  \
+		.gpio = SPI_CS_GPIOS_DT_SPEC_GET(node_id),	  \
 		.delay = (delay_),				  \
 	})
 

--- a/include/zephyr/drivers/spi.h
+++ b/include/zephyr/drivers/spi.h
@@ -149,13 +149,8 @@ struct spi_cs_control {
 	 * equivalent to SPI_CS_ACTIVE_HIGH/SPI_CS_ACTIVE_LOW options in struct
 	 * spi_config.
 	 */
-	union {
+	struct {
 		struct gpio_dt_spec gpio;
-		struct {
-			const struct device *gpio_dev __deprecated;
-			gpio_pin_t gpio_pin __deprecated;
-			gpio_dt_flags_t gpio_dt_flags __deprecated;
-		};
 	};
 	/**
 	 * Delay in microseconds to wait before starting the


### PR DESCRIPTION
All in tree users are using the gpio_dt_spec so we can remove the
older gpio struct elements that have been deprecated for some
time.

Signed-off-by: Kumar Gala <galak@kernel.org>