### PR TITLE
samples: gsm_modem: Remove use of DT_BUS_LABEL

### DIFF
--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -118,8 +118,7 @@ int main(void)
 
 	LOG_INF("Board '%s' APN '%s' UART '%s' device %p (%s)",
 		CONFIG_BOARD, CONFIG_MODEM_GSM_APN,
-		DT_BUS_LABEL(DT_INST(0, zephyr_gsm_ppp)), uart_dev,
-		gsm_dev->name);
+		uart_dev->name, uart_dev, gsm_dev->name);
 
 	net_mgmt_init_event_callback(&mgmt_cb, event_handler,
 				     NET_EVENT_L4_CONNECTED |


### PR DESCRIPTION
The use of DT_BUS_LABEL in a logging call can easily be replaced
with uart_dev->name.  This moves us slowly forward to removing
use of devicetree `label` property.

Signed-off-by: Kumar Gala <galak@kernel.org>