### PR TITLE
samples: updatehub: Remove use of DT_BUS_LABEL

### DIFF
--- a/samples/subsys/mgmt/updatehub/src/main.c
+++ b/samples/subsys/mgmt/updatehub/src/main.c
@@ -142,7 +142,7 @@ void main(void)
 		DEVICE_DT_GET(DT_BUS(DT_INST(0, zephyr_gsm_ppp)));
 
 	LOG_INF("APN '%s' UART '%s' device %p", CONFIG_MODEM_GSM_APN,
-		DT_BUS_LABEL(DT_INST(0, zephyr_gsm_ppp)), uart_dev);
+		uart_dev->name, uart_dev);
 #endif
 
 	net_mgmt_init_event_callback(&mgmt_cb, event_handler, EVENT_MASK);


### PR DESCRIPTION
The use of DT_BUS_LABEL in a logging call can easily be replaced
with uart_dev->name.  This moves us slowly forward to removing
use of devicetree `label` property.

Signed-off-by: Kumar Gala <galak@kernel.org>