### PR TITLE
samples: esp32: flash_encryption: Convert to use DEVICE_DT_GET

### DIFF
--- a/samples/boards/esp32/flash_encryption/src/main.c
+++ b/samples/boards/esp32/flash_encryption/src/main.c
@@ -26,13 +26,9 @@ void main(void)
 	const struct device *flash_device;
 	off_t address = FLASH_AREA_OFFSET(storage);
 
-	flash_device = device_get_binding(DT_LABEL(DT_CHOSEN(zephyr_flash_controller)));
-
-	if (flash_device) {
-		LOG_INF("Found flash controller %s\n\r",
-			DT_LABEL(DT_CHOSEN(zephyr_flash_controller)));
-	} else {
-		LOG_INF("Flash controller not available\n\r");
+	flash_device = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+	if (!device_is_ready(flash_device)) {
+		printk("%s: device not ready.\n", flash_device->name);
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>