### PR TITLE
tests: bluetooth: ctrl_isoal: Remove unnecessary test_main

### DIFF
--- a/tests/bluetooth/ctrl_isoal/src/main.c
+++ b/tests/bluetooth/ctrl_isoal/src/main.c
@@ -7757,10 +7757,3 @@ ZTEST(test_rx_framed, test_rx_framed_single_invalid_pdu_single_sdu)
 ZTEST_SUITE(test_rx_basics, NULL, NULL, NULL, NULL, NULL);
 ZTEST_SUITE(test_rx_unframed, NULL, NULL, NULL, NULL, NULL);
 ZTEST_SUITE(test_rx_framed, NULL, NULL, NULL, NULL, NULL);
-
-void test_main(void)
-{
-	ztest_run_test_suite(test_rx_basics);
-	ztest_run_test_suite(test_rx_unframed);
-	ztest_run_test_suite(test_rx_framed);
-}


### PR DESCRIPTION
With thew new ztest API, test_main() is not required anymore, so get rid
of it.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>