### PR TITLE
samples: counter: maxim_ds3231: Convert to use DEVICE_DT_GET_ONE

### DIFF
--- a/samples/drivers/counter/maxim_ds3231/src/main.c
+++ b/samples/drivers/counter/maxim_ds3231/src/main.c
@@ -229,12 +229,10 @@ static void set_aligned_clock(const struct device *ds3231)
 
 void main(void)
 {
-	const struct device *ds3231;
-	const char *const dev_id = DT_LABEL(DT_INST(0, maxim_ds3231));
+	const struct device *ds3231 = DEVICE_DT_GET_ONE(maxim_ds3231);
 
-	ds3231 = device_get_binding(dev_id);
-	if (!ds3231) {
-		printk("No device %s available\n", dev_id);
+	if (!device_is_ready(ds3231)) {
+		printk("%s: device not ready.\n", ds3231->name);
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET_ONE instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>