### PR TITLE
samples: spi_bitbang: Convert to use DEVICE_DT_GET

### DIFF
--- a/samples/drivers/spi_bitbang/src/main.c
+++ b/samples/drivers/spi_bitbang/src/main.c
@@ -120,13 +120,10 @@ void test_8bit_xfer(const struct device *dev, struct spi_cs_control *cs)
 
 void main(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET(SPIBB_NODE);
 
-	dev = device_get_binding(DT_LABEL(SPIBB_NODE));
-
-	if (!dev) {
-		printf("SPI bitbang driver %s was not found!\n",
-				DT_LABEL(SPIBB_NODE));
+	if (!device_is_ready(dev)) {
+		printk("%s: device not ready.\n", dev->name);
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>