### PR TITLE
drivers/adc: stm32f1 adc driver enables peripheral if not enabled

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -472,6 +472,9 @@ static void adc_stm32_oversampling(ADC_TypeDef *adc, uint8_t ratio, uint32_t shi
  */
 static int adc_stm32_enable(ADC_TypeDef *adc)
 {
+	if (LL_ADC_IsEnabled(adc) == 1UL) {
+		return 0;
+	}
 #if defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32L5X) || \
 	defined(CONFIG_SOC_SERIES_STM32WBX) || \
@@ -479,10 +482,6 @@ static int adc_stm32_enable(ADC_TypeDef *adc)
 	defined(CONFIG_SOC_SERIES_STM32G4X) || \
 	defined(CONFIG_SOC_SERIES_STM32H7X) || \
 	defined(CONFIG_SOC_SERIES_STM32WLX)
-
-	if (LL_ADC_IsEnabled(adc) == 1UL) {
-		return 0;
-	}
 
 	LL_ADC_ClearFlag_ADRDY(adc);
 	LL_ADC_Enable(adc);
@@ -504,6 +503,11 @@ static int adc_stm32_enable(ADC_TypeDef *adc)
 		}
 	}
 #else
+	/*
+	 * On the stm32F10x, do not re-enable the ADC :
+	 * if ADON holds 1 (LL_ADC_IsEnabled is true) and 1 is written,
+	 * then conversion starts ; that's not what is expected
+	 */
 	LL_ADC_Enable(adc);
 #endif
 


### PR DESCRIPTION
On the stm32f10x, this commit avoid re-enabling the ADC,
because this starts conversion.
According to the RefMan ([RM0008](https://www.st.com/content/ccc/resource/technical/document/reference_manual/59/b9/ba/7f/11/af/43/d5/CD00171190.pdf/files/CD00171190.pdf/jcr:content/translations/en.CD00171190.pdf)) of the stm32F10x mcu, enabling the ADC will start the conversion if the ADC is already enabled. "Conversion starts when this bit holds a value of 1 and a 1 is written to it."
That's not what we want.

Signed-off-by: Francois Ramu <francois.ramu@st.com>