### PR TITLE
samples: spi_flash_at45: Convert to use DEVICE_DT_GET_ONE

### DIFF
--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -9,8 +9,6 @@
 #include <zephyr/logging/log_ctrl.h>
 #include <zephyr/pm/device.h>
 
-#define FLASH_DEVICE        DT_LABEL(DT_INST(0, atmel_at45))
-
 /* Set to 1 to test the chip erase functionality. Please be aware that this
  * operation takes quite a while (it depends on the chip size, but can easily
  * take tens of seconds).
@@ -29,7 +27,7 @@ void main(void)
 {
 	printk("DataFlash sample on %s\n", CONFIG_BOARD);
 
-	const struct device *flash_dev;
+	const struct device *flash_dev = DEVICE_DT_GET_ONE(atmel_at45);
 	int i;
 	int err;
 	uint8_t data;
@@ -38,9 +36,8 @@ void main(void)
 	size_t page_count, chip_size;
 #endif
 
-	flash_dev = device_get_binding(FLASH_DEVICE);
-	if (!flash_dev) {
-		printk("Device %s not found!\n", FLASH_DEVICE);
+	if (!device_is_ready(flash_dev)) {
+		printk("%s: device not ready.\n", flash_dev->name);
 		return;
 	}
 
@@ -49,7 +46,7 @@ void main(void)
 	(void)flash_get_page_info_by_idx(flash_dev, 0, &pages_info);
 	chip_size = page_count * pages_info.size;
 	printk("Using %s, chip size: %u bytes (page: %u)\n",
-	       FLASH_DEVICE, chip_size, pages_info.size);
+	       flash_dev->name, chip_size, pages_info.size);
 #endif
 
 	printk("Reading the first byte of the test region ... ");


### PR DESCRIPTION
Move to use DEVICE_DT_GET_ONE instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>