### PR TITLE
samples: edac: Convert to use DEVICE_DT_GET

### DIFF
--- a/samples/subsys/edac/src/main.c
+++ b/samples/subsys/edac/src/main.c
@@ -30,15 +30,12 @@ static void notification_callback(const struct device *dev, void *data)
 	atomic_set(&handled, true);
 }
 
-#define DEVICE_NAME DT_LABEL(DT_NODELABEL(ibecc))
-
 void main(void)
 {
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 
-	dev = device_get_binding(DEVICE_NAME);
-	if (!dev) {
-		LOG_ERR("Cannot open EDAC device: %s", DEVICE_NAME);
+	if (!device_is_ready(dev)) {
+		printk("%s: device not ready.\n", dev->name);
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>