### PR TITLE
samples: video: Convert to use DEVICE_DT_GET_ONE

### DIFF
--- a/samples/subsys/video/capture/src/main.c
+++ b/samples/subsys/video/capture/src/main.c
@@ -15,10 +15,6 @@ LOG_MODULE_REGISTER(main);
 
 #define VIDEO_DEV_SW "VIDEO_SW_GENERATOR"
 
-#if defined(CONFIG_VIDEO_MCUX_CSI)
-#define VIDEO_DEV DT_LABEL(DT_INST(0, nxp_imx_csi))
-#endif
-
 void main(void)
 {
 	struct video_buffer *buffers[2], *vbuf;
@@ -37,20 +33,18 @@ void main(void)
 	}
 
 	/* But would be better to use a real video device if any */
-#ifdef VIDEO_DEV
-	{
-		const struct device *dev = device_get_binding(VIDEO_DEV);
+#if defined(CONFIG_VIDEO_MCUX_CSI)
+	const struct device *dev = DEVICE_DT_GET_ONE(nxp_imx_csi);
 
-		if (dev == NULL) {
-			LOG_ERR("Video device %s not found, "
-				"fallback to software generator.", VIDEO_DEV);
-		} else {
-			video = dev;
-		}
+	if (!device_is_ready(dev)) {
+		LOG_ERR("%s: device not ready.\n", dev->name);
+		return;
 	}
+
+	video = dev;
 #endif
 
-	printk("- Device name: %s\n", VIDEO_DEV);
+	printk("- Device name: %s\n", video->name);
 
 	/* Get capabilities */
 	if (video_get_caps(video, VIDEO_EP_OUT, &caps)) {

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -15,12 +15,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
-#if defined(CONFIG_VIDEO_MCUX_CSI)
-#define VIDEO_CAPTURE_DEV DT_LABEL(DT_INST(0, nxp_imx_csi))
-#else
-#define VIDEO_CAPTURE_DEV "VIDEO_SW_GENERATOR"
-#endif
-
 #define MY_PORT 5000
 #define MAX_CLIENT_QUEUE 1
 
@@ -46,7 +40,7 @@ void main(void)
 	struct video_buffer *buffers[2], *vbuf;
 	int i, ret, sock, client;
 	struct video_format fmt;
-	const struct device *video;
+	const struct device *video = DEVICE_DT_GET_ONE(nxp_imx_csi);
 
 	/* Prepare Network */
 	(void)memset(&addr, 0, sizeof(addr));
@@ -73,11 +67,8 @@ void main(void)
 		return;
 	}
 
-	/* Prepare Video Capture */
-	video = device_get_binding(VIDEO_CAPTURE_DEV);
-	if (video == NULL) {
-		LOG_ERR("Video device %s not found. Aborting test.",
-			VIDEO_CAPTURE_DEV);
+	if (!device_is_ready(video)) {
+		LOG_ERR("%s: device not ready.\n", video->name);
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET_ONE instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>