### PR TITLE
ztest: Add Z_TEST_SKIP_IFNDEF macro

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -249,6 +249,17 @@ static inline void unit_test_noop(void)
 #define Z_TEST_SKIP_IFDEF(config) COND_CODE_1(config, (ztest_test_skip()), ())
 
 /**
+ * @brief Skips the test if config is not enabled
+ *
+ * Use this macro at the start of your test case, to skip it when
+ * config is not enabled.  Useful when your need to skip test if some
+ * conifiguration option is not enabled.
+ *
+ * @param config The Kconfig option used to skip the test (if not enabled).
+ */
+#define Z_TEST_SKIP_IFNDEF(config) COND_CODE_1(config, (), (ztest_test_skip()))
+
+/**
  * @brief Create and register a new unit test.
  *
  * Calling this macro will create a new unit test and attach it to the declared `suite`. The `suite`

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -41,6 +41,12 @@ ZTEST(framework_tests, test_skip_config)
 	zassert_true(false, NULL);
 }
 
+ZTEST(framework_tests, test_skip_no_config)
+{
+	Z_TEST_SKIP_IFNDEF(CONFIG_BUGyyyyy);
+	ztest_test_fail();
+}
+
 /***************************************************************************************************
  * Sample fixture tests
  **************************************************************************************************/

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -38,7 +38,7 @@ ZTEST(framework_tests, test_assert_mem_equal)
 ZTEST(framework_tests, test_skip_config)
 {
 	Z_TEST_SKIP_IFDEF(CONFIG_BUGxxxxx);
-	zassert_true(false, NULL);
+	ztest_test_fail();
 }
 
 ZTEST(framework_tests, test_skip_no_config)


### PR DESCRIPTION
Add macro Z_TEST_SKIP_IFNDEF which is used when you want to skip test
if configuration option is not enabled.