### PR TITLE
drivers: sensor: lsm9ds0_gyro: Add multi-instance support

### DIFF
--- a/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
+++ b/drivers/sensor/lsm9ds0_gyro/lsm9ds0_gyro_trigger.c
@@ -39,6 +39,10 @@ int lsm9ds0_gyro_trigger_set(const struct device *dev,
 					 dev->config;
 	uint8_t state;
 
+	if (!config->int_gpio.port) {
+		return -ENOTSUP;
+	}
+
 	if (trig->type == SENSOR_TRIG_DATA_READY) {
 		setup_drdy(dev, false);
 


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>