### PR TITLE
Bluetooth: Host: Disable host-based RPA resolution in `bt_conn_le_create` when !CONFIG_BT_PRIVACY

### DIFF
--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -623,6 +623,11 @@ struct bt_conn_le_create_param {
  *  The application must disable explicit scanning before initiating
  *  a new LE connection.
  *
+ *  When @kconfig{CONFIG_BT_PRIVACY} enabled and @p peer is an identity address
+ *  from a local bond, this API will connect to an advertisement with either:
+ *    - the address being an RPA resolved from the IRK obtained during bonding.
+ *    - the passed identity address, if the local identity is not in Network Privacy Mode.
+ *
  *  @param[in]  peer         Remote address.
  *  @param[in]  create_param Create connection parameters.
  *  @param[in]  conn_param   Initial connection parameters.

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -338,8 +338,10 @@ if BT_SMP
 config BT_PRIVACY
 	bool "Privacy Feature"
 	help
-	  Enable local Privacy Feature support. This makes it possible
-	  to use Resolvable Private Addresses (RPAs).
+	  Enable Privacy Feature support. This makes it possible to generate and use
+	  Resolvable Private Addresses (RPAs).
+
+	  Disabling this will remove the capability to resolve private addresses.
 
 config BT_RPA_TIMEOUT
 	int "Resolvable Private Address timeout"

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2671,7 +2671,8 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 	create_param_setup(create_param);
 
 #if defined(CONFIG_BT_SMP)
-	if (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size) {
+	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size)) {
 		bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 
 		err = bt_le_scan_update(true);

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -592,7 +592,7 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_EXT_CREATE_CONN, buf, NULL);
 }
 
-int bt_le_create_conn_legacy(const struct bt_conn *conn)
+static int bt_le_create_conn_legacy(const struct bt_conn *conn)
 {
 	struct bt_hci_cp_le_create_conn *cp;
 	struct bt_hci_cmd_state_set state;

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -552,13 +552,12 @@ int bt_le_create_conn_ext(const struct bt_conn *conn)
 	} else {
 		const bt_addr_le_t *peer_addr = &conn->le.dst;
 
-#if defined(CONFIG_BT_SMP)
-		if (!bt_dev.le.rl_size ||
-		    bt_dev.le.rl_entries > bt_dev.le.rl_size) {
+		if (bt_addr_le_cmp(&conn->le.resp_addr, BT_ADDR_LE_ANY)) {
 			/* Host resolving is used, use the RPA directly. */
 			peer_addr = &conn->le.resp_addr;
+			BT_DBG("Using resp_addr %s", bt_addr_le_str(peer_addr));
 		}
-#endif
+
 		bt_addr_le_copy(&cp->peer_addr, peer_addr);
 		cp->filter_policy = BT_HCI_LE_CREATE_CONN_FP_NO_FILTER;
 	}
@@ -626,13 +625,12 @@ static int bt_le_create_conn_legacy(const struct bt_conn *conn)
 	} else {
 		const bt_addr_le_t *peer_addr = &conn->le.dst;
 
-#if defined(CONFIG_BT_SMP)
-		if (!bt_dev.le.rl_size ||
-		    bt_dev.le.rl_entries > bt_dev.le.rl_size) {
+		if (bt_addr_le_cmp(&conn->le.resp_addr, BT_ADDR_LE_ANY)) {
 			/* Host resolving is used, use the RPA directly. */
 			peer_addr = &conn->le.resp_addr;
+			BT_DBG("Using resp_addr %s", bt_addr_le_str(peer_addr));
 		}
-#endif
+
 		bt_addr_le_copy(&cp->peer_addr, peer_addr);
 		cp->filter_policy = BT_HCI_LE_CREATE_CONN_FP_NO_FILTER;
 	}


### PR DESCRIPTION
Change doc of CONFIG_BT_PRIVACY to explicitly say it's needed for both
generating and resolving RPAs.

Disable host-based RPA resolution in `bt_conn_le_create` when
!CONFIG_BT_PRIVACY.

Update doc of `bt_conn_le_create` to document that CONFIG_BT_PRIVACY is
a requirement for resolving RPAs. Also explictly say that this function
will resolve private identities. Also explain the expected effect of
Network Privacy on this function.

Reduce coupling to `bt_le_create_conn_ext` and
`bt_le_create_conn_legacy` in `bt_conn_le_create` by just use
`resp_addr` when it's set, instead of "knowing" when it had been set.
The alternative would be to also update `bt_le_create_conn_ext` and
`bt_le_create_conn_legacy` to have `(IS_ENABLED(CONFIG_BT_PRIVACY) &&
(!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size))`