### PR TITLE
boards: riscv: tlsr9518adk80d: Move IMG_BLOCK_BUF_SIZE in Kconfig.def…

### DIFF
--- a/boards/riscv/tlsr9518adk80d/Kconfig.defconfig
+++ b/boards/riscv/tlsr9518adk80d/Kconfig.defconfig
@@ -55,4 +55,11 @@ DT_CHOSEN_Z_CODE_PARTITION := zephyr,code-partition
 config FLASH_LOAD_OFFSET
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_CODE_PARTITION)) if USE_DT_CODE_PARTITION
 
+# Buffer for image writter shall be less(multiple of access alignment) or
+# equal to flash page. tlsr9518adk80d boards use external P25Q16 IC as
+# flesh memory. Flash page size of the IC is 256 bytes. So that, it is
+# maximum image writer buffer size for such kind of boards.
+config IMG_BLOCK_BUF_SIZE
+	default 256 if MCUBOOT_IMG_MANAGER
+
 endif

--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_defconfig
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d_defconfig
@@ -16,9 +16,3 @@ CONFIG_UART_CONSOLE=y
 
 # HW DSP options
 CONFIG_TELINK_B91_HWDSP=n
-
-# Buffer for image writter shall be less(multiple of access alignment) or
-# equal to flash page. tlsr9518adk80d boards use external P25Q16 IC as
-# flesh memory. Flash page size of the IC is 256 bytes. So that, it is
-# maximum image writer buffer size for such kind of boards.
-CONFIG_IMG_BLOCK_BUF_SIZE=256


### PR DESCRIPTION
While build of samples or applications which does not contain
MCUBOOT_IMG_MANAGER option enabled, following warning occurs:

warning: IMG_BLOCK_BUF_SIZE was assigned the value 256 but got
the value ``.

Because of that it decided to move IMG_BLOCK_BUF_SIZE config to
Kconfig.defconfig with additional condition if MCUBOOT_IMG_MANAGER

Signed-off-by: Alexandr Kolosov <rikorsev@gmail.com>