### PR TITLE
drivers: sensor: stts751: Add multi-instance support

### DIFF
--- a/drivers/sensor/stts751/stts751.c
+++ b/drivers/sensor/stts751/stts751.c
@@ -188,29 +188,31 @@ static int stts751_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_STTS751_TRIGGER
-	if (stts751_init_interrupt(dev) < 0) {
-		LOG_ERR("Failed to initialize interrupt.");
-		return -EIO;
+	if (config->int_gpio.port) {
+		if (stts751_init_interrupt(dev) < 0) {
+			LOG_ERR("Failed to initialize interrupt.");
+			return -EIO;
+		}
 	}
 #endif
 
 	return 0;
 }
 
-static struct stts751_data stts751_data;
+#define STTS751_DEFINE(inst)									\
+	static struct stts751_data stts751_data_##inst;						\
+												\
+	static const struct stts751_config stts751_config_##inst = {				\
+		COND_CODE_1(DT_INST_ON_BUS(inst, i2c),						\
+			    (.i2c = I2C_DT_SPEC_INST_GET(inst),					\
+			     .bus_init = stts751_i2c_init,),					\
+			    ())									\
+		IF_ENABLED(CONFIG_STTS751_TRIGGER,						\
+			   (.int_gpio = GPIO_DT_SPEC_INST_GET_OR(inst, drdy_gpios, { 0 }),))	\
+	};											\
+												\
+	DEVICE_DT_INST_DEFINE(inst, stts751_init, NULL,						\
+			      &stts751_data_##inst, &stts751_config_##inst, POST_KERNEL,	\
+			      CONFIG_SENSOR_INIT_PRIORITY, &stts751_api_funcs);			\
 
-static const struct stts751_config stts751_config = {
-	COND_CODE_1(DT_INST_ON_BUS(0, i2c), (.i2c = I2C_DT_SPEC_INST_GET(0),), ())
-#ifdef CONFIG_STTS751_TRIGGER
-	.int_gpio = GPIO_DT_SPEC_INST_GET(0, drdy_gpios),
-#endif
-#if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-	.bus_init = stts751_i2c_init,
-#else
-#error "BUS MACRO NOT DEFINED IN DTS"
-#endif
-};
-
-DEVICE_DT_INST_DEFINE(0, stts751_init, NULL,
-		    &stts751_data, &stts751_config, POST_KERNEL,
-		    CONFIG_SENSOR_INIT_PRIORITY, &stts751_api_funcs);
+DT_INST_FOREACH_STATUS_OKAY(STTS751_DEFINE)

--- a/drivers/sensor/stts751/stts751_trigger.c
+++ b/drivers/sensor/stts751/stts751_trigger.c
@@ -38,6 +38,11 @@ int stts751_trigger_set(const struct device *dev,
 			  sensor_trigger_handler_t handler)
 {
 	struct stts751_data *stts751 = dev->data;
+	const struct stts751_config *config = dev->config;
+
+	if (!config->int_gpio.port) {
+		return -ENOTSUP;
+	}
 
 	if (trig->chan == SENSOR_CHAN_ALL) {
 		stts751->thsld_handler = handler;


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>