### PR TITLE
sample: usb: Change integration_platforms to platform_allow

### DIFF
--- a/samples/subsys/usb/mass/sample.yaml
+++ b/samples/subsys/usb/mass/sample.yaml
@@ -32,10 +32,7 @@ tests:
       - fatfs
     depends_on: usb_device
     filter: dt_compat_enabled("nordic,qspi-nor")
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-      - adafruit_feather_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp adafruit_feather_nrf52840
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
         - CONFIG_APP_MSC_STORAGE_FLASH_FATFS=y
@@ -66,10 +63,7 @@ tests:
     min_ram: 32
     depends_on: usb_device
     filter: dt_compat_enabled("nordic,qspi-nor")
-    integration_platforms:
-      - nrf52840dk_nrf52840
-      - nrf5340dk_nrf5340_cpuapp
-      - adafruit_feather_nrf52840
+    platform_allow: nrf52840dk_nrf52840 nrf5340dk_nrf5340_cpuapp adafruit_feather_nrf52840
     extra_configs:
         - CONFIG_LOG_DEFAULT_LEVEL=3
         - CONFIG_APP_MSC_STORAGE_FLASH_LITTLEFS=y


### PR DESCRIPTION
The sample proviades required overlays only for 3 platforms.
Therefore, flash scenarios can only work on those 3 platforms.
To reflect this, platform_allow has to be used instead of
integration_platforms, so boards without overlays are not picked up
into a scope.

Signed-off-by: Maciej Perkowski <Maciej.Perkowski@nordicsemi.no>