### PR TITLE
arch: arm: aarch32: Disable FPU with TF-M

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -254,10 +254,14 @@ choice
 
 config FP_HARDABI
 	bool "Floating point Hard ABI"
+	depends on !BUILD_WITH_TFM
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling
 	  conventions.
+	  Note: the option is disabled for Zephyr builds with TF-M, as TF-M
+	  does not currently support building with Hard ABI, hence linking
+	  Zephyr with TF-M libraries would not be possible.
 
 config FP_SOFTABI
 	bool "Floating point Soft ABI"


### PR DESCRIPTION
Removes the ability to enable the FPU with TF-M -- added in
PR #45906, and which is causing CI failures -- until a more
robust solution can be implemented for FPU support w/TF-M.

Should resolve CI issues described in:

- https://github.com/zephyrproject-rtos/zephyr/issues/47407
- https://github.com/zephyrproject-rtos/zephyr/pull/47369
- https://github.com/zephyrproject-rtos/zephyr/pull/47373