### PR TITLE
twister: add `--coverage-formats` option for use with gcovr

### DIFF
--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -98,8 +98,16 @@ class CoverageTool:
         with open(os.path.join(outdir, "coverage.log"), "a") as coveragelog:
             ret = self._generate(outdir, coveragelog)
             if ret == 0:
-                logger.info("HTML report generated: {}".format(
-                    os.path.join(outdir, "coverage", "index.html")))
+                report_log = {
+                    "html": "HTML report generated: {}".format(os.path.join(outdir, "coverage", "index.html")),
+                    "xml": "XML report generated: {}".format(os.path.join(outdir, "coverage", "coverage.xml")),
+                    "csv": "CSV report generated: {}".format(os.path.join(outdir, "coverage", "coverage.csv")),
+                    "txt": "TXT report generated: {}".format(os.path.join(outdir, "coverage", "coverage.txt")),
+                    "coveralls": "Coveralls report generated: {}".format(os.path.join(outdir, "coverage", "coverage.coveralls.json")),
+                    "sonarqube": "Sonarqube report generated: {}".format(os.path.join(outdir, "coverage", "coverage.sonarqube.xml"))
+                }
+                for r in self.output_formats.split(','):
+                    logger.info(report_log[r])
 
 
 class Lcov(CoverageTool):
@@ -208,10 +216,6 @@ class Gcovr(CoverageTool):
 
         tracefiles = self._interleave_list("--add-tracefile", files)
 
-        # Apply gcovr output format default
-        if self.output_formats is None:
-            self.output_formats = "html"
-
         # Convert command line argument (comma-separated list) to gcovr flags
         report_options = {
             "html": ["--html", os.path.join(subdir, "index.html"), "--html-details"],
@@ -247,6 +251,9 @@ def run_coverage(testplan, options):
     coverage_tool = CoverageTool.factory(options.coverage_tool)
     coverage_tool.gcov_tool = options.gcov_tool
     coverage_tool.base_dir = os.path.abspath(options.coverage_basedir)
+    # Apply output format default
+    if options.coverage_formats is None:
+        options.coverage_formats = "html"
     coverage_tool.output_formats = options.coverage_formats
     coverage_tool.add_ignore_file('generated')
     coverage_tool.add_ignore_directory('tests')

--- a/scripts/pylib/twister/twisterlib/coverage.py
+++ b/scripts/pylib/twister/twisterlib/coverage.py
@@ -208,6 +208,10 @@ class Gcovr(CoverageTool):
 
         tracefiles = self._interleave_list("--add-tracefile", files)
 
+        # Apply gcovr output format default
+        if self.output_formats is None:
+            self.output_formats = "html"
+
         # Convert command line argument (comma-separated list) to gcovr flags
         report_options = {
             "html": ["--html", os.path.join(subdir, "index.html"), "--html-details"],

--- a/scripts/pylib/twister/twisterlib/enviornment.py
+++ b/scripts/pylib/twister/twisterlib/enviornment.py
@@ -247,9 +247,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='lcov',
                         help="Tool to use to generate coverage report.")
 
-    parser.add_argument("--coverage-formats", action="store", default='html',
+    parser.add_argument("--coverage-formats", action="store", default=None, # default behavior is set in Gcovr._generate
                         help="Output formats to use for generated coverage reports, as a comma-separated list. "
                              "Only used in conjunction with gcovr. "
+                             "Default to html. "
                              "Valid options are html, xml, csv, txt, coveralls, sonarqube.")
 
     parser.add_argument(
@@ -629,6 +630,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         logger.error("""When --device-testing is used with
                         --device-serial or --device-serial-pty,
                         only one platform is allowed""")
+        sys.exit(1)
+
+    if options.coverage_formats and (options.coverage_tool != "gcovr"):
+        logger.error("""--coverage-formats can only be used when coverage
+                        tool is set to gcovr""")
         sys.exit(1)
 
     if options.size:

--- a/scripts/pylib/twister/twisterlib/enviornment.py
+++ b/scripts/pylib/twister/twisterlib/enviornment.py
@@ -247,6 +247,11 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='lcov',
                         help="Tool to use to generate coverage report.")
 
+    parser.add_argument("--coverage-formats", action="store", default='html',
+                        help="Output formats to use for generated coverage reports, as a comma-separated list. "
+                             "Only used in conjunction with gcovr. "
+                             "Valid options are html, xml, csv, txt, coveralls, sonarqube.")
+
     parser.add_argument(
         "-D", "--all-deltas", action="store_true",
         help="Show all footprint deltas, positive or negative. Implies "

--- a/scripts/pylib/twister/twisterlib/enviornment.py
+++ b/scripts/pylib/twister/twisterlib/enviornment.py
@@ -247,7 +247,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     parser.add_argument("--coverage-tool", choices=['lcov', 'gcovr'], default='lcov',
                         help="Tool to use to generate coverage report.")
 
-    parser.add_argument("--coverage-formats", action="store", default=None, # default behavior is set in Gcovr._generate
+    parser.add_argument("--coverage-formats", action="store", default=None, # default behavior is set in run_coverage
                         help="Output formats to use for generated coverage reports, as a comma-separated list. "
                              "Only used in conjunction with gcovr. "
                              "Default to html. "


### PR DESCRIPTION
Adds an `--coverage-formats` option to twister, which (if gcovr is used as the coverage tool) allows generation of alternate report formats such as coberatura xml, gcc txt, etc.

Closes #46580.