### PR TITLE
[Backport v3.0-branch] lib: libc: Initialise libc heap during POST_KERNEL phase

### DIFF
--- a/lib/libc/minimal/source/stdlib/malloc.c
+++ b/lib/libc/minimal/source/stdlib/malloc.c
@@ -94,7 +94,7 @@ void free(void *ptr)
 	(void) sys_mutex_unlock(&z_malloc_heap_mutex);
 }
 
-SYS_INIT(malloc_prepare, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(malloc_prepare, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 #else /* No malloc arena */
 void *malloc(size_t size)
 {

--- a/lib/libc/newlib/libc-hooks.c
+++ b/lib/libc/newlib/libc-hooks.c
@@ -134,7 +134,7 @@ static int malloc_prepare(const struct device *unused)
 	return 0;
 }
 
-SYS_INIT(malloc_prepare, APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
+SYS_INIT(malloc_prepare, POST_KERNEL, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT);
 
 /* Current offset from HEAP_BASE of unused memory */
 LIBC_BSS static size_t heap_sz;

--- a/tests/subsys/cpp/cxx/src/main.cpp
+++ b/tests/subsys/cpp/cxx/src/main.cpp
@@ -65,6 +65,17 @@ static void test_global_static_ctor(void)
 	zassert_equal(static_foo.get_foo(), 12345678, NULL);
 }
 
+/*
+ * Check that dynamic memory allocation (usually, the C library heap) is
+ * functional when the global static object constructors are called.
+ */
+foo_class *static_init_dynamic_foo = new foo_class(87654321);
+
+static void test_global_static_ctor_dynmem(void)
+{
+	zassert_equal(static_init_dynamic_foo->get_foo(), 87654321, NULL);
+}
+
 static void test_new_delete(void)
 {
 	foo_class *test_foo = new foo_class(10);
@@ -76,6 +87,7 @@ void test_main(void)
 {
 	ztest_test_suite(cpp_tests,
 			 ztest_unit_test(test_global_static_ctor),
+			 ztest_unit_test(test_global_static_ctor_dynmem),
 			 ztest_unit_test(test_new_delete)
 		);
 

--- a/tests/subsys/cpp/cxx/src/main.cpp
+++ b/tests/subsys/cpp/cxx/src/main.cpp
@@ -57,6 +57,13 @@ static int test_init(const struct device *dev)
 
 SYS_INIT(test_init, APPLICATION, CONFIG_APPLICATION_INIT_PRIORITY);
 
+/* Check that global static object constructors are called. */
+foo_class static_foo(12345678);
+
+static void test_global_static_ctor(void)
+{
+	zassert_equal(static_foo.get_foo(), 12345678, NULL);
+}
 
 static void test_new_delete(void)
 {
@@ -68,6 +75,7 @@ static void test_new_delete(void)
 void test_main(void)
 {
 	ztest_test_suite(cpp_tests,
+			 ztest_unit_test(test_global_static_ctor),
 			 ztest_unit_test(test_new_delete)
 		);
 

--- a/tests/subsys/cpp/cxx/testcase.yaml
+++ b/tests/subsys/cpp/cxx/testcase.yaml
@@ -1,5 +1,21 @@
-tests:
-  cpp.main:
+common:
+    tags: cpp
     integration_platforms:
       - mps2_an385
-    tags: cpp
+
+tests:
+  cpp.main.minimal:
+    extra_configs:
+      - CONFIG_MINIMAL_LIBC=y
+  cpp.main.newlib:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1
+    min_ram: 32
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+      - CONFIG_NEWLIB_LIBC_NANO=n
+  cpp.main.newlib_nano:
+    filter: TOOLCHAIN_HAS_NEWLIB == 1 and CONFIG_HAS_NEWLIB_LIBC_NANO
+    min_ram: 24
+    extra_configs:
+      - CONFIG_NEWLIB_LIBC=y
+      - CONFIG_NEWLIB_LIBC_NANO=y

--- a/tests/subsys/cpp/cxx/testcase.yaml
+++ b/tests/subsys/cpp/cxx/testcase.yaml
@@ -2,6 +2,7 @@ common:
     tags: cpp
     integration_platforms:
       - mps2_an385
+      - qemu_cortex_a53
 
 tests:
   cpp.main.minimal:


### PR DESCRIPTION
This series changes the invocation of the libc heap initialisation functions such that they are executed during the `POST_KERNEL`
phase instead of the `APPLICATION` phase, which is necessary in order to ensure that the application initialisation functions, including the C++ global static object constructors, can make use of the libc heap.

Also, this adds some additional C++ subsystem tests to ensure that this requirement is well tested.

Fixes #47356

(Backport of #47355)