### PR TITLE
samples: cc13x2_cc26x2: system_off: Convert to use gpio_dt_spec

### DIFF
--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/ext_flash.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/ext_flash.c
@@ -11,7 +11,7 @@
 
 #include <driverlib/cpu.h>
 
-#define GPIO_PORT DT_LABEL(DT_NODELABEL(gpio0))
+#define GPIO_PORT DT_NODELABEL(gpio0)
 #define DIO8_PIN  8
 #define DIO9_PIN  9
 #define DIO10_PIN 10
@@ -81,7 +81,13 @@ void CC1352R1_LAUNCHXL_shutDownExtFlash(void)
 	const struct device *dev;
 	uint8_t extFlashShutdown = 0xB9;
 
-	dev = device_get_binding(GPIO_PORT);
+	dev = DEVICE_DT_GET(GPIO_PORT);
+
+	if (!device_is_ready(dev)) {
+		printk("%s: device not ready.\n", dev->name);
+		return;
+	}
+
 	/* Set SPI Flash CS pin as output */
 	gpio_pin_configure(dev, DIO20_PIN, GPIO_OUTPUT);
 	/* Set SPI Flash CLK pin as output */


### PR DESCRIPTION
Move sample to use gpio_dt_spec for GPIO access.

Signed-off-by: Kumar Gala <galak@kernel.org>