### PR TITLE
unittest: support ztest_new_api

### DIFF
--- a/cmake/modules/unittest.cmake
+++ b/cmake/modules/unittest.cmake
@@ -88,10 +88,20 @@ if(LIBS)
   message(FATAL_ERROR "This variable is not supported, see SOURCES instead")
 endif()
 
-target_sources(testbinary PRIVATE
-  ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest.c
-  ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_mock.c
-  )
+if(CONFIG_ZTEST_NEW_API)
+  add_definitions( -DCONFIG_ZTEST_NEW_API=y )
+  target_sources(testbinary PRIVATE
+      ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_new.c
+      ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_mock.c
+      ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_rules.c
+      ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_defaults.c
+      )
+else()
+  target_sources(testbinary PRIVATE
+      ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest.c
+      ${ZEPHYR_BASE}/subsys/testsuite/ztest/src/ztest_mock.c
+      )
+endif()
 
 target_compile_definitions(testbinary PRIVATE ZTEST_UNITTEST)
 

--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -165,7 +165,7 @@ static inline void test_time_ms(void)
 #ifndef TC_SUITE_END
 #define TC_SUITE_END(name, result)				\
 	do {								\
-		if (result == TC_PASS) {					\
+		if (result != TC_FAIL) {				\
 			TC_PRINT("TESTSUITE %s succeeded\n", name);	\
 		} else {						\
 			TC_PRINT("TESTSUITE %s failed.\n", name);	\

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -136,9 +136,18 @@ void ztest_run_all(const void *state);
  * @param state The current state of the machine as it relates to the test executable.
  * @return The number of tests that ran.
  */
-__syscall int ztest_run_test_suites(const void *state);
 
+#ifdef ZTEST_UNITTEST
+int z_impl_ztest_run_test_suites(const void *state);
+static inline int ztest_run_test_suites(const void *state)
+{
+	return z_impl_ztest_run_test_suites(state);
+}
+
+#else
+__syscall int ztest_run_test_suites(const void *state);
 #include <syscalls/ztest_test_new.h>
+#endif
 
 /**
  * @brief Fails the test if any of the registered tests did not run.
@@ -389,7 +398,5 @@ struct ztest_arch_api {
 #ifdef __cplusplus
 }
 #endif
-
-#include <syscalls/ztest_test_new.h>
 
 #endif /* ZEPHYR_TESTSUITE_ZTEST_TEST_H_ */

--- a/subsys/testsuite/ztest/src/ztest_defaults.c
+++ b/subsys/testsuite/ztest/src/ztest_defaults.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include "ztest_test_new.h"
+#include <ztest.h>
 
 /**
  * @brief Try to shorten a filename by removing the current directory

--- a/tests/ztest/base/CMakeLists.txt
+++ b/tests/ztest/base/CMakeLists.txt
@@ -2,7 +2,15 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 if(BOARD STREQUAL unit_testing)
-  list(APPEND SOURCES src/main_deprecated.c)
+
+  # Use the new ztest API
+  set(CONFIG_ZTEST_NEW_API TRUE CACHE BOOL "" FORCE)
+
+  # Add the sources
+  list(APPEND SOURCES src/main.c)
+
+  # This test suite depends on having this CONFIG_ value, so define it
+  add_definitions( -DCONFIG_BUGxxxxx )
 
   find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
   project(base)


### PR DESCRIPTION
Add support for the new Ztest API when using unittest.

Fixes #47420

Signed-off-by: Yuval Peress <peress@google.com>