### PR TITLE
testsuite: ztest: fix the linker generator not working of new ztest

### DIFF
--- a/cmake/linker_script/common/common-ram.cmake
+++ b/cmake/linker_script/common/common-ram.cmake
@@ -105,4 +105,10 @@ endif()
 
 if(CONFIG_ZTEST)
   zephyr_iterable_section(NAME ztest_suite_node GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
+  zephyr_iterable_section(NAME ztest_suite_stats GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
+endif()
+
+if(CONFIG_ZTEST_NEW_API)
+  zephyr_iterable_section(NAME ztest_unit_test GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
+  zephyr_iterable_section(NAME ztest_test_rule GROUP DATA_REGION ${XIP_ALIGN_WITH_INPUT} SUBALIGN 4)
 endif()


### PR DESCRIPTION
Fix the linking error when CONFIG_CMAKE_LINKER_GENERATOR=y when
applying the new ztest API.

Fixes #47126

Signed-off-by: Enjia Mai <enjia.mai@intel.com> 