### PR TITLE
samples: reel_board: mesh_badge: Convert to use gpio_dt_spec

### DIFF
--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -52,7 +52,6 @@ struct font_info {
 static const struct device *epd_dev;
 static bool pressed;
 static uint8_t screen_id = SCREEN_MAIN;
-static const struct device *gpio;
 static struct k_work_delayable epd_work;
 static struct k_work_delayable long_press_work;
 static char str_buf[256];
@@ -62,6 +61,8 @@ static const struct gpio_dt_spec leds[] = {
 	GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios),
 	GPIO_DT_SPEC_GET(DT_ALIAS(led2), gpios),
 };
+
+static const struct gpio_dt_spec sw0_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios);
 
 struct k_work_delayable led_timer;
 
@@ -434,7 +435,7 @@ static void long_press(struct k_work *work)
 
 static bool button_is_pressed(void)
 {
-	return gpio_pin_get(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios)) > 0;
+	return gpio_pin_get_dt(&sw0_gpio) > 0;
 }
 
 static void button_interrupt(const struct device *dev,
@@ -465,7 +466,7 @@ static void button_interrupt(const struct device *dev,
 	case SCREEN_STATS:
 		return;
 	case SCREEN_MAIN:
-		if (pins & BIT(DT_GPIO_PIN(DT_ALIAS(sw0), gpios))) {
+		if (pins & BIT(sw0_gpio.pin)) {
 			uint32_t uptime = k_uptime_get_32();
 			static uint32_t bad_count, press_ts;
 
@@ -498,21 +499,18 @@ static int configure_button(void)
 {
 	static struct gpio_callback button_cb;
 
-	gpio = device_get_binding(DT_GPIO_LABEL(DT_ALIAS(sw0), gpios));
-	if (!gpio) {
+	if (!device_is_ready(sw0_gpio.port)) {
+		printk("%s: device not ready.\n", sw0_gpio.port->name);
 		return -ENODEV;
 	}
 
-	gpio_pin_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
-			   GPIO_INPUT | DT_GPIO_FLAGS(DT_ALIAS(sw0), gpios));
+	gpio_pin_configure_dt(&sw0_gpio, GPIO_INPUT);
 
-	gpio_pin_interrupt_configure(gpio, DT_GPIO_PIN(DT_ALIAS(sw0), gpios),
-				     GPIO_INT_EDGE_BOTH);
+	gpio_pin_interrupt_configure_dt(&sw0_gpio, GPIO_INT_EDGE_BOTH);
 
-	gpio_init_callback(&button_cb, button_interrupt,
-			   BIT(DT_GPIO_PIN(DT_ALIAS(sw0), gpios)));
+	gpio_init_callback(&button_cb, button_interrupt, BIT(sw0_gpio.pin));
 
-	gpio_add_callback(gpio, &button_cb);
+	gpio_add_callback(sw0_gpio.port, &button_cb);
 
 	return 0;
 }


### PR DESCRIPTION
Move sample to use gpio_dt_spec for GPIO access for SW0.

Signed-off-by: Kumar Gala <galak@kernel.org>