### PR TITLE
samples: led_sx1509b_intensity: Convert to use DEVICE_DT_GET

### DIFF
--- a/samples/drivers/led_sx1509b_intensity/src/main.c
+++ b/samples/drivers/led_sx1509b_intensity/src/main.c
@@ -71,11 +71,10 @@ void main(void)
 
 	printk("SX1509B intensity sample\n");
 
-	sx1509b_dev = device_get_binding(DT_PROP(DT_NODELABEL(sx1509b), label));
+	sx1509b_dev = DEVICE_DT_GET(DT_NODELABEL(sx1509b));
 
-	if (sx1509b_dev == NULL) {
-		printk("Error binding SX1509B device\n");
-
+	if (!device_is_ready(sx1509b_dev)) {
+		printk("sx1509b: device not ready.\n");
 		return;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>