### PR TITLE
subsys: modbus: Add modbus_iface_get_by_dev

### DIFF
--- a/include/zephyr/modbus/modbus.h
+++ b/include/zephyr/modbus/modbus.h
@@ -373,6 +373,18 @@ struct modbus_user_callbacks {
 int modbus_iface_get_by_name(const char *iface_name);
 
 /**
+ * @brief Get Modbus interface index according to interface dev
+ *
+ * If there is more than one interface, it can be used to clearly
+ * identify interfaces in the application.
+ *
+ * @param dev        Modbus interface struct device
+ *
+ * @retval           Modbus interface index or negative error value.
+ */
+int modbus_iface_get_by_dev(const struct device *dev);
+
+/**
  * @brief ADU raw callback function signature
  *
  * @param iface      Modbus RTU interface index

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -47,7 +47,7 @@ static struct modbus_serial_config modbus_serial_cfg[] = {
 #endif
 
 #define MODBUS_DT_GET_DEV(inst) {				\
-		.iface_name = DT_INST_LABEL(inst),		\
+		.iface_name = NULL,				\
 		.cfg = &modbus_serial_cfg[inst],		\
 	},
 
@@ -175,6 +175,20 @@ int modbus_iface_get_by_ctx(const struct modbus_context *ctx)
 	for (int i = 0; i < ARRAY_SIZE(mb_ctx_tbl); i++) {
 		if (&mb_ctx_tbl[i] == ctx) {
 			return i;
+		}
+	}
+
+	return -ENODEV;
+}
+
+int modbus_iface_get_by_dev(const struct device *dev)
+{
+	for (int i = 0; i < ARRAY_SIZE(mb_ctx_tbl); i++) {
+		if ((mb_ctx_tbl[i].mode == MODBUS_MODE_RTU) ||
+		    (mb_ctx_tbl[i].mode == MODBUS_MODE_ASCII)) {
+			if (mb_ctx_tbl[i].cfg->dev == dev) {
+				return i;
+			}
 		}
 	}
 


### PR DESCRIPTION
Add modbus_iface_get_by_dev() to get the modbus interface from a
struct device.

This is to allow removal of DT_LABEL.

Signed-off-by: Kumar Gala <galak@kernel.org>