### PR TITLE
intel: adsp: Simplify PM

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -16,38 +16,25 @@
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <0>;
-			cpu-power-states = <&idle &suspend &off>;
+			cpu-power-states = <&off>;
 		};
 
 		cpu1: cpu@1 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <1>;
-			cpu-power-states = <&idle &suspend &off>;
+			cpu-power-states = <&off>;
 		};
 
 		cpu2: cpu@2 {
 			device_type = "cpu";
 			compatible = "cdns,tensilica-xtensa-lx7";
 			reg = <2>;
-			cpu-power-states = <&idle &suspend &off>;
+			cpu-power-states = <&off>;
 		};
 	};
 
 	power-states {
-		idle: idle {
-			compatible = "zephyr,power-state";
-			power-state-name = "runtime-idle";
-			min-residency-us = <0>;
-			exit-latency-us = <0>;
-		};
-		suspend: suspend {
-			compatible = "zephyr,power-state";
-			power-state-name = "suspend-to-idle";
-			min-residency-us = <200>;
-			exit-latency-us = <100>;
-		};
-
 		/* PM_STATE_SOFT_OFF can be entered only by calling pm_state_force.
 		 * The procedure is triggered by IPC from the HOST (SET_DX).
 		 */


### PR DESCRIPTION
Both idle and suspend states were just being used to set the cpu
idle. That is not necessary, if the pm policy does not find a suitable
power state the kernel automatically calls k_cpu_idle().

This remove unnecessary code and the weirdness of having
min-residency-us set to 0 and other arbitrary values.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>