### PR TITLE
tests: clock_control: on_off: Convert to use DEVICE_DT_GET

### DIFF
--- a/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
+++ b/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
@@ -17,8 +17,9 @@ static struct onoff_manager *get_mgr(void)
 
 static bool clock_is_off(void)
 {
-	const struct device *clk =
-		device_get_binding(DT_LABEL(DT_INST(0, nordic_nrf_clock)));
+	const struct device *clk = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+
+	zassert_true(device_is_ready(clk), "Device is not ready");
 
 	return clock_control_get_status(clk, CLOCK_CONTROL_NRF_SUBSYS_HF) ==
 			CLOCK_CONTROL_STATUS_OFF;


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>