### PR TITLE
tests: drivers: i2c_api: Convert to use DEVICE_DT_GET

### DIFF
--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -17,11 +17,11 @@
 #include <ztest.h>
 
 #if DT_NODE_HAS_STATUS(DT_ALIAS(i2c_0), okay)
-#define I2C_DEV_NAME	DT_LABEL(DT_ALIAS(i2c_0))
+#define I2C_DEV_NODE	DT_ALIAS(i2c_0)
 #elif DT_NODE_HAS_STATUS(DT_ALIAS(i2c_1), okay)
-#define I2C_DEV_NAME	DT_LABEL(DT_ALIAS(i2c_1))
+#define I2C_DEV_NODE	DT_ALIAS(i2c_1)
 #elif DT_NODE_HAS_STATUS(DT_ALIAS(i2c_2), okay)
-#define I2C_DEV_NAME	DT_LABEL(DT_ALIAS(i2c_2))
+#define I2C_DEV_NODE	DT_ALIAS(i2c_2)
 #else
 #error "Please set the correct I2C device"
 #endif
@@ -31,11 +31,11 @@ uint32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER;
 static int test_gy271(void)
 {
 	unsigned char datas[6];
-	const struct device *i2c_dev = device_get_binding(I2C_DEV_NAME);
+	const struct device *i2c_dev = DEVICE_DT_GET(I2C_DEV_NODE);
 	uint32_t i2c_cfg_tmp;
 
-	if (!i2c_dev) {
-		TC_PRINT("Cannot get I2C device\n");
+	if (!device_is_ready(i2c_dev)) {
+		TC_PRINT("I2C device is not ready\n");
 		return TC_FAIL;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>