### PR TITLE
tests: boards: altera_max10: i2c_master: Convert to use DEVICE_DT_GET

### DIFF
--- a/tests/boards/altera_max10/i2c_master/src/i2c_master.c
+++ b/tests/boards/altera_max10/i2c_master/src/i2c_master.c
@@ -65,13 +65,12 @@ static int powerup_adv7513(const struct device *i2c_dev)
 
 static int test_i2c_adv7513(void)
 {
-	const struct device *i2c_dev =
-		device_get_binding(DT_LABEL(DT_INST(0, altr_nios2_i2c)));
+	const struct device *i2c_dev = DEVICE_DT_GET_ONE(altr_nios2_i2c);
 	uint32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER;
 	uint8_t data;
 
-	if (!i2c_dev) {
-		TC_PRINT("cannot get i2c device\n");
+	if (!device_is_ready(i2c_dev)) {
+		TC_PRINT("i2c device is not ready\n");
 		return TC_FAIL;
 	}
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>