### PR TITLE
tests: espi: Convert to use DEVICE_DT_GET

### DIFF
--- a/tests/drivers/espi/src/test_acpi.c
+++ b/tests/drivers/espi/src/test_acpi.c
@@ -10,13 +10,13 @@
 
 static void test_acpi_shared_memory(void)
 {
-	const struct device *espi_dev = device_get_binding(DT_LABEL(DT_NODELABEL(espi0)));
+	const struct device *espi_dev = DEVICE_DT_GET(DT_NODELABEL(espi0));
 	struct espi_cfg cfg = {
 		.channel_caps = ESPI_CHANNEL_VWIRE | ESPI_CHANNEL_PERIPHERAL,
 	};
 	uintptr_t host_shm, peripheral_shm;
 
-	zassert_not_null(espi_dev, NULL);
+	zassert_true(device_is_ready(espi_dev), "Device is not ready");
 
 	zassert_ok(espi_config(espi_dev, &cfg), NULL);
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>