### PR TITLE
tests: i2c_tca954x: remove dead code

### DIFF
--- a/tests/drivers/i2c/i2c_tca954x/src/main.c
+++ b/tests/drivers/i2c/i2c_tca954x/src/main.c
@@ -10,14 +10,12 @@
 
 #if DT_NODE_HAS_STATUS(DT_ALIAS(i2c_channel_0), okay)
 #define I2C_0_CTRL_NODE_ID      DT_ALIAS(i2c_channel_0)
-#define I2C_0_CTRL_DEV_NAME     DT_LABEL(I2C_0_CTRL_NODE_ID)
 #else
 #error "I2C 0 controller device not found"
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_ALIAS(i2c_channel_1), okay)
 #define I2C_1_CTRL_NODE_ID      DT_ALIAS(i2c_channel_1)
-#define I2C_1_CTRL_DEV_NAME     DT_LABEL(I2C_1_CTRL_NODE_ID)
 #else
 #error "I2C 1 controller device not found"
 #endif


### PR DESCRIPTION
I2C_x_CTRL_DEV_NAME defines are used, so remove them.

Signed-off-by: Kumar Gala <galak@kernel.org>