### PR TITLE
tests: boards: mec15xxevb_assy6853: i2c: Convert to use i2c_dt_spec

### DIFF
--- a/tests/boards/mec15xxevb_assy6853/i2c_api/src/main.c
+++ b/tests/boards/mec15xxevb_assy6853/i2c_api/src/main.c
@@ -8,8 +8,6 @@
 #include <zephyr/zephyr.h>
 #include <ztest.h>
 
-#define I2C_DEV_NAME DT_LABEL(DT_ALIAS(i2c1))
-
 /* command to configure port direction of NXP PCA95xx */
 #define REG_CONF_PORT0 0x06U
 
@@ -31,12 +29,12 @@ void test_i2c_pca95xx(void)
 	uint32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER;
 
 	/* get i2c device */
-	const struct device *i2c_dev = device_get_binding(I2C_DEV_NAME);
+	const struct i2c_dt_spec i2c = I2C_DT_SPEC_GET(DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_pca95xx));
 
-	zassert_true(i2c_dev, "Cannot get i2c device");
+	zassert_true(device_is_ready(i2c.bus), "I2C controller device is not ready");
 
 	/* configure i2c device */
-	ret = i2c_configure(i2c_dev, i2c_cfg);
+	ret = i2c_configure(i2c.bus, i2c_cfg);
 	zassert_true(ret == 0, "Failed to configure i2c device");
 
 	/* write configuration to register 6 and 7 of PCA95XX*/
@@ -44,17 +42,17 @@ void test_i2c_pca95xx(void)
 	datas[0] = REG_CONF_PORT0;
 	datas[1] = test_data[0];
 	datas[2] = test_data[1];
-	ret = i2c_write(i2c_dev, datas, 3, 0x26);
+	ret = i2c_write_dt(&i2c, datas, 3);
 	zassert_true(ret == 0, "Failed to write data to i2c device");
 
 	/* read configuration from register 6 and 7 */
 	(void)memset(datas, 0, 3);
 	datas[0] = REG_CONF_PORT0;
-	ret = i2c_write(i2c_dev, datas, 1, 0x26);
+	ret = i2c_write_dt(&i2c, datas, 1);
 	zassert_true(ret == 0, "Failed to write data to i2c device");
 
 	(void)memset(datas, 0, 3);
-	ret = i2c_read(i2c_dev, datas, 2, 0x26);
+	ret = i2c_read_dt(&i2c, datas, 2);
 	zassert_true(ret == 0, "Failed to read data from i2c device");
 
 	/* check read data whether correct */


### PR DESCRIPTION
Move to use test to use i2c_dt_spec.

Signed-off-by: Kumar Gala <galak@kernel.org>