### PR TITLE
tests: drivers: gpio on nucleo_g071rb new pins

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/nucleo_g071rb.overlay
@@ -7,7 +7,7 @@
 / {
 	resources {
 		compatible = "test-gpio-basic-api";
-		out-gpios = <&arduino_header 0 0>; /* Arduino A0 */
-		in-gpios = <&arduino_header 1 0>;  /* Arduino A1 */
+		out-gpios = <&arduino_header 4 0>; /* Arduino A4 */
+		in-gpios = <&arduino_header 5 0>;  /* Arduino A5 */
 	};
 };


### PR DESCRIPTION
This commit changes the pin assignment for the gpio_basic_api
test case because A0 was conflicting with tests/drivers/dac/dac_loopback


Signed-off-by: Francois Ramu <francois.ramu@st.com>