### PR TITLE
sample: subsys: nvs: add support of some STM32 boards

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a.yaml
@@ -17,3 +17,4 @@ supported:
   - dac
   - adc
   - watchdog
+  - nvs

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.yaml
@@ -18,3 +18,4 @@ supported:
   - watchdog
   - adc
   - dma
+  - nvs

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.yaml
@@ -23,3 +23,4 @@ supported:
   - adc
   - dac
   - dma
+  - nvs

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.yaml
@@ -23,3 +23,4 @@ supported:
   - dac
   - dma
   - lptim
+  - nvs

--- a/boards/arm/nucleo_l152re/nucleo_l152re.yaml
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.yaml
@@ -20,3 +20,4 @@ supported:
   - dac
   - pwm
   - dma
+  - nvs

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.yaml
@@ -21,3 +21,4 @@ supported:
   - arduino_i2c
   - arduino_spi
   - usb_device
+  - nvs

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.yaml
@@ -20,3 +20,4 @@ supported:
   - pwm
   - dma
   - watchdog
+  - nvs

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.yaml
@@ -19,5 +19,6 @@ supported:
   - usart
   - arduino_spi
   - usb
+  - nvs
 ram: 192
 flash: 512

--- a/samples/subsys/nvs/boards/disco_l475_iot1.overlay
+++ b/samples/subsys/nvs/boards/disco_l475_iot1.overlay
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &quadspi;
+/delete-node/ &scratch_partition;
+
+/ {
+	chosen {
+		zephyr,flash-controller = &flash0;
+	};
+};
+
+&flash0 {
+	partitions {
+		/* Set 6Kb of storage at the end of the 1Mb of flash */
+		storage_partition: partition@fe800 {
+			label = "storage";
+			reg = <0x000fe800 DT_SIZE_K(6)>;
+		};
+	};
+};

--- a/samples/subsys/nvs/boards/nucleo_f103rb.overlay
+++ b/samples/subsys/nvs/boards/nucleo_f103rb.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 3KB of storage at the end of 128KB flash */
+		storage_partition: partition@1f400 {
+			label = "storage";
+			reg = <0x0001f400 DT_SIZE_K(3)>;
+		};
+	};
+};

--- a/samples/subsys/nvs/boards/nucleo_f429zi.overlay
+++ b/samples/subsys/nvs/boards/nucleo_f429zi.overlay
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 48KB of storage at the beginning of bank2 in order to have 3 sectors smaller than 32K
+		 * 	(nvs.h: uint16_t sector_size)
+		 */
+		storage_partition: partition@100000 {
+			label = "storage";
+			reg = <0x000100000 DT_SIZE_K(48)>;
+		};
+	};
+};

--- a/samples/subsys/nvs/boards/nucleo_g071rb.overlay
+++ b/samples/subsys/nvs/boards/nucleo_g071rb.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 6KB of storage at the end of 128KB flash */
+		storage_partition: partition@1e800 {
+			label = "storage";
+			reg = <0x0001e800 DT_SIZE_K(6)>;
+		};
+	};
+};

--- a/samples/subsys/nvs/boards/nucleo_l152re.overlay
+++ b/samples/subsys/nvs/boards/nucleo_l152re.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 12KB of storage at the end of 128KB flash */
+		storage_partition: partition@1d000 {
+			label = "storage";
+			reg = <0x0001d000 DT_SIZE_K(12)>;
+		};
+	};
+};

--- a/samples/subsys/nvs/boards/nucleo_wb55rg.overlay
+++ b/samples/subsys/nvs/boards/nucleo_wb55rg.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 12KB of storage at the end of 1st half of flash (dual core constraints) */
+		storage_partition: partition@7d000 {
+			label = "storage";
+			reg = <0x0007d000 DT_SIZE_K(12)>;
+		};
+	};
+};

--- a/samples/subsys/nvs/boards/stm32l562e_dk.overlay
+++ b/samples/subsys/nvs/boards/stm32l562e_dk.overlay
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/delete-node/ &storage_partition;
+
+&flash0 {
+	partitions {
+		/* Set 6KB of storage at the end of 512KB flash */
+		storage_partition: partition@7e800 {
+			label = "storage";
+			reg = <0x0007e800 DT_SIZE_K(6)>;
+		};
+	};
+};


### PR DESCRIPTION
sample: subsys: nvs: add support of some STM32 boards:
* disco_l476_iot1
* b_u585i_iot02a
* nucleo_f103rb 
* nucleo_f429zi
* nucleo_g071rb
* nucleo_l152re 
* nucleo_wb55rj
* nucleo_wl55jc 
* stm32l562e_dk

Use MCU FLASH and not QSPI, because twister needs flash erase to check this sample properly.