### PR TITLE
drivers: counter: stm32u5 family compatibility

### DIFF
--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -268,6 +268,8 @@ void rtc_stm32_isr(const struct device *dev)
 	LL_C2_EXTI_ClearFlag_0_31(RTC_EXTI_LINE);
 #elif defined(CONFIG_SOC_SERIES_STM32G0X)
 	LL_EXTI_ClearRisingFlag_0_31(RTC_EXTI_LINE);
+#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+	/* in STM32U5 family RTC is not connected to EXTI */
 #else
 	LL_EXTI_ClearFlag_0_31(RTC_EXTI_LINE);
 #endif
@@ -367,10 +369,13 @@ static int rtc_stm32_init(const struct device *dev)
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X) && defined(CONFIG_CPU_CORTEX_M4)
 	LL_C2_EXTI_EnableIT_0_31(RTC_EXTI_LINE);
+	LL_EXTI_EnableRisingTrig_0_31(RTC_EXTI_LINE);
+#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+	/* in STM32U5 family RTC is not connected to EXTI */
 #else
 	LL_EXTI_EnableIT_0_31(RTC_EXTI_LINE);
-#endif
 	LL_EXTI_EnableRisingTrig_0_31(RTC_EXTI_LINE);
+#endif
 
 	rtc_stm32_irq_config(dev);
 

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -343,6 +343,15 @@
 			status = "disabled";
 		};
 
+		rtc: rtc@46007800 {
+			compatible = "st,stm32-rtc";
+			reg = <0x46007800 0x400>;
+			interrupts = <2 0>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB3 0x00200000>;
+			prescaler = <32768>;
+			status = "disabled";
+		};
+
 		octospi1: octospi@420d1400 {
 			compatible = "st,stm32-ospi";
 			reg = <0x420d1400 0x400>;


### PR DESCRIPTION
In STM32U5X family there is no EXTI line for RTC.

Signed-off-by: Wojciech Slenska <wsl@trackunit.com>