### PR TITLE
logging: cavs_hda: Allow format timestamp

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -143,7 +143,7 @@ config LOG_BACKEND_FORMAT_TIMESTAMP
 	bool "Timestamp formatting in the backend"
 	depends on LOG_BACKEND_UART || LOG_BACKEND_NATIVE_POSIX || LOG_BACKEND_RTT \
 	           || LOG_BACKEND_SWO || LOG_BACKEND_XTENSA_SIM || LOG_BACKEND_FS \
-	           || LOG_BACKEND_ADSP
+	           || LOG_BACKEND_ADSP || LOG_BACKEND_CAVS_HDA
 	default y
 	help
 	  When enabled timestamp is formatted to hh:mm:ss:ms,us.


### PR DESCRIPTION
LOG_BACKEND_CAVS_HDA supports LOG_BACKEND_FORMAT_TIMESTAMP