### PR TITLE
tests: arch: arm: Disable l552ze in arm.swap.tz

### DIFF
--- a/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap_tz/testcase.yaml
@@ -5,9 +5,9 @@ common:
 tests:
   arch.arm.swap.tz:
     # NOTE: this platform disables FPU access in TFM.
-    platform_exclude: mps3_an547_ns
+    platform_exclude: mps3_an547_ns nucleo_l552ze_q_ns
   arch.arm.swap.tz_off:
     extra_configs:
       - CONFIG_ARM_NONSECURE_PREEMPTIBLE_SECURE_CALLS=n
     # NOTE: this platform disables FPU access in TFM.
-    platform_exclude: mps3_an547_ns
+    platform_exclude: mps3_an547_ns nucleo_l552ze_q_ns


### PR DESCRIPTION
Disabling nucleo_l552ze_q_ns from the test suite since there isn't
enough room to sign the image with the toolchain used in CI:

```
Usage: wrapper.py [OPTIONS] INFILE OUTFILE
Try 'wrapper.py --help' for help.
Error: Image size (0x8e5d) + trailer (0x1b0) exceeds requested size 0x9000
sign the payload
ninja: build stopped: subcommand failed.
```

This can be reverted if changes are made to the nucleo_l552ze_q_ns
platform to enable enough room for the signing data.

Addresses CI failures in: https://github.com/zephyrproject-rtos/zephyr/pull/47373

Signed-off-by: Kevin Townsend <kevin.townsend@linaro.org>