### PR TITLE
arch: arm64: initialize IRQ stack for CONFIG_INIT_STACKS

### DIFF
--- a/arch/arm64/core/reset.S
+++ b/arch/arm64/core/reset.S
@@ -149,6 +149,23 @@ primary_core:
 	/* Prepare for calling C code */
 	bl	__reset_prep_c
 
+	/*
+	 * Initialize the interrupt stack with 0xaa so stack utilization
+	 * can be measured. This needs to be done before using the stack
+	 * so that we don't clobber any data.
+	 */
+#ifdef CONFIG_INIT_STACKS
+	ldr	x0, =(z_interrupt_stacks)
+	sub     x9, sp, #8
+	mov     x10, 0xaaaaaaaaaaaaaaaa
+stack_init_loop:
+	cmp     x0, x9
+	beq     stack_init_done
+	str     x10, [x0], #8
+	b       stack_init_loop
+stack_init_done:
+#endif
+
 	/* Platform hook for highest EL */
 	bl	z_arm64_el_highest_init
 


### PR DESCRIPTION
When CONFIG_INIT_STACKS is enabled all stacks should be filled with 0xaa
so that the thread analyzer can measure stack utilization, but the IRQ
stack was not filled and so `kernel stacks` on the shell would show that
the stack had been fully used and inferring an IRQ stack overflow
regardless of the IRQ stack size.

Fill the IRQ stack before it gets used so that we can have precise usage
reports.

Signed-off-by: Jamie Iles <quic_jiles@quicinc.com>
Signed-off-by: Dave Aldridge <quic_daldridg@quicinc.com>