### PR TITLE
drivers: sensor: bq274xx: fix lazy loading

### DIFF
--- a/drivers/sensor/bq274xx/Kconfig
+++ b/drivers/sensor/bq274xx/Kconfig
@@ -2,19 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig BQ274XX
+config BQ274XX
 	bool "BQ274xx Fuel Gauge"
 	depends on I2C
 	help
 	  Enable I2C-based driver for BQ274xx Fuel Gauge.
-
-if BQ274XX
-
-config BQ274XX_LAZY_CONFIGURE
-	bool "Configure on first usage instead of init"
-	help
-	  Configuring the sensor can take a long time, which
-	  we can delay till the first sample request and keep
-	  the boot time as short as possible.
-
-endif # BQ274XX

--- a/drivers/sensor/bq274xx/bq274xx.h
+++ b/drivers/sensor/bq274xx/bq274xx.h
@@ -81,9 +81,7 @@ LOG_MODULE_REGISTER(bq274xx, CONFIG_SENSOR_LOG_LEVEL);
 #define BQ274XX_DELAY 1000
 
 struct bq274xx_data {
-#ifdef CONFIG_BQ274XX_LAZY_CONFIGURE
-	bool lazy_loaded;
-#endif
+	bool configured;
 	uint16_t voltage;
 	int16_t avg_current;
 	int16_t stdby_current;
@@ -107,6 +105,7 @@ struct bq274xx_config {
 #ifdef CONFIG_PM_DEVICE
 	struct gpio_dt_spec int_gpios;
 #endif
+	bool lazy_loading;
 };
 
 #endif

--- a/dts/bindings/sensor/ti,bq274xx.yaml
+++ b/dts/bindings/sensor/ti,bq274xx.yaml
@@ -40,3 +40,9 @@ properties:
         specific events happening (e.g. change in State of Charge). While in
         shutdown mode it acts as an input and toggling it will make the sensor
         exit the mode.
+
+    zephyr,lazy-load:
+      type: boolean
+      description: |
+        Configuring the sensor can take a long time, using lazy loading we can delay
+        until the first sample request and keep the boot time as short as possible.


### PR DESCRIPTION
This change allows per-instance configuration of lazy loading and fixes build issue.

Fixes #47458