### PR TITLE
drivers: spi: gd32: support interrupt-driven mode

### DIFF
--- a/drivers/spi/Kconfig.gd32
+++ b/drivers/spi/Kconfig.gd32
@@ -7,3 +7,13 @@ config SPI_GD32
 	depends on DT_HAS_GD_GD32_SPI_ENABLED
 	help
 	  Enables Gigadevice GD32 SPI driver.
+
+if SPI_GD32
+
+config SPI_GD32_INTERRUPT
+	bool "GD32 MCU SPI Interrupt Support"
+	default y if SPI_ASYNC
+	help
+	  Enable the interrupt driven mode for SPI instances
+
+endif # SPI_GD32


### PR DESCRIPTION
Add supporting interrupt-based asynchronous operation for GD32 SPI.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@gmail.com>