### PR TITLE
Add addition debug Kconfigs for ISO and Audio data 

### DIFF
--- a/subsys/bluetooth/audio/Kconfig.baps
+++ b/subsys/bluetooth/audio/Kconfig.baps
@@ -193,6 +193,14 @@ config BT_AUDIO_DEBUG_STREAM
 	  Use this option to enable Bluetooth Audio Stream debug logs for the
 	  Bluetooth Audio functionality.
 
+config BT_AUDIO_DEBUG_STREAM_DATA
+	bool "Bluetooth Audio Stream data debug"
+	depends on BT_AUDIO_DEBUG_STREAM
+	help
+	  Use this option to enable Bluetooth Audio Stream data debug logs for
+	  the Bluetooth Audio functionality. This will enable debug logs for all
+	  audio data received and sent.
+
 config BT_AUDIO_DEBUG_CAPABILITIES
 	bool "Bluetooth Audio Capabilities debug"
 	depends on BT_AUDIO_CAPABILITY

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -332,7 +332,10 @@ static void ascs_iso_recv(struct bt_iso_chan *chan,
 
 	ops = ep->stream->ops;
 
-	BT_DBG("stream %p ep %p len %zu", chan, ep, net_buf_frags_len(buf));
+	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
+		BT_DBG("stream %p ep %p len %zu",
+		       chan, ep, net_buf_frags_len(buf));
+	}
 
 	if (ops != NULL && ops->recv != NULL) {
 		ops->recv(ep->stream, info, buf);

--- a/subsys/bluetooth/audio/broadcast_sink.c
+++ b/subsys/bluetooth/audio/broadcast_sink.c
@@ -128,7 +128,10 @@ static void broadcast_sink_iso_recv(struct bt_iso_chan *chan,
 
 	ops = ep->stream->ops;
 
-	BT_DBG("stream %p ep %p len %zu", chan, ep, net_buf_frags_len(buf));
+	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
+		BT_DBG("stream %p ep %p len %zu",
+		       chan, ep, net_buf_frags_len(buf));
+	}
 
 	if (ops != NULL && ops->recv != NULL) {
 		ops->recv(ep->stream, info, buf);

--- a/subsys/bluetooth/audio/unicast_client.c
+++ b/subsys/bluetooth/audio/unicast_client.c
@@ -80,7 +80,10 @@ static void unicast_client_ep_iso_recv(struct bt_iso_chan *chan,
 
 	ops = ep->stream->ops;
 
-	BT_DBG("stream %p ep %p len %zu", chan, ep, net_buf_frags_len(buf));
+	if (IS_ENABLED(CONFIG_BT_AUDIO_DEBUG_STREAM_DATA)) {
+		BT_DBG("stream %p ep %p len %zu",
+		       chan, ep, net_buf_frags_len(buf));
+	}
 
 	if (ops != NULL && ops->recv != NULL) {
 		ops->recv(ep->stream, info, buf);

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -779,6 +779,14 @@ config BT_DEBUG_ISO
 	  Use this option to enable ISO channels debug logs for the
 	  Bluetooth Audio functionality.
 
+config BT_DEBUG_ISO_DATA
+	bool "ISO channel data debug"
+	depends on BT_DEBUG_ISO
+	help
+	  Use this option to enable ISO channels data debug logs for the
+	  Bluetooth Audio functionality. This will enable debug logs for all
+	  ISO data received and sent.
+
 config BT_DEBUG_KEYS
 	bool "Bluetooth security keys debug"
 	depends on BT_HCI_HOST

--- a/subsys/bluetooth/host/iso.c
+++ b/subsys/bluetooth/host/iso.c
@@ -567,8 +567,10 @@ void bt_iso_recv(struct bt_conn *iso, struct net_buf *buf, uint8_t flags)
 	pb = bt_iso_flags_pb(flags);
 	ts = bt_iso_flags_ts(flags);
 
-	BT_DBG("handle %u len %u flags 0x%02x pb 0x%02x ts 0x%02x",
-	       iso->handle, buf->len, flags, pb, ts);
+	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
+		BT_DBG("handle %u len %u flags 0x%02x pb 0x%02x ts 0x%02x",
+		       iso->handle, buf->len, flags, pb, ts);
+	}
 
 	/* When the PB_Flag does not equal 0b00, the fields Time_Stamp,
 	 * Packet_Sequence_Number, Packet_Status_Flag and ISO_SDU_Length
@@ -713,7 +715,9 @@ int bt_iso_chan_send(struct bt_iso_chan *chan, struct net_buf *buf,
 		return -EINVAL;
 	}
 
-	BT_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+	if (IS_ENABLED(CONFIG_BT_DEBUG_ISO_DATA)) {
+		BT_DBG("chan %p len %zu", chan, net_buf_frags_len(buf));
+	}
 
 	if (chan->state != BT_ISO_STATE_CONNECTED) {
 		BT_DBG("Not connected");


### PR DESCRIPTION
Add two new Kconfigs for ISO and BT Audio data. The point of these is that the logs will get more clean when enabling ISO or BT_AUDIO_STREAM debugs, as the data being sent isn't logged as well by default. 