### PR TITLE
drivers: hwinfo: shell: Add missing reset cause strings

### DIFF
--- a/drivers/hwinfo/hwinfo_shell.c
+++ b/drivers/hwinfo/hwinfo_shell.c
@@ -77,6 +77,15 @@ static inline const char *cause_to_string(uint32_t cause)
 	case RESET_CLOCK:
 		return "clock";
 
+	case RESET_HARDWARE:
+		return "hardware";
+
+	case RESET_USER:
+		return "user";
+
+	case RESET_TEMPERATURE:
+		return "temperature";
+
 	default:
 		return "unknown";
 	}


### PR DESCRIPTION
The `hwinfo` shell commands were missing human readable names for
* RESET_HARDWARE
* RESET_USER
* RESET_TEMPERATURE