### PR TITLE
arch: Use a common place for z_irq_spurious

### DIFF
--- a/include/zephyr/arch/arc/v2/irq.h
+++ b/include/zephyr/arch/arc/v2/irq.h
@@ -37,7 +37,6 @@ extern void sys_trace_isr_exit(void);
 
 extern void z_irq_priority_set(unsigned int irq, unsigned int prio,
 			      uint32_t flags);
-extern void z_irq_spurious(const void *unused);
 
 /* Z_ISR_DECLARE will populate the .intList section with the interrupt's
  * parameters, which will then be used by gen_irq_tables.py to create

--- a/include/zephyr/arch/arm/aarch32/irq.h
+++ b/include/zephyr/arch/arm/aarch32/irq.h
@@ -243,9 +243,6 @@ extern void z_arm_irq_direct_dynamic_dispatch_no_reschedule(void);
 
 #endif /* CONFIG_DYNAMIC_DIRECT_INTERRUPTS */
 
-/* Spurious interrupt handler. Throws an error if called */
-extern void z_irq_spurious(const void *unused);
-
 #if defined(CONFIG_ARM_SECURE_FIRMWARE)
 /* Architecture-specific definition for the target security
  * state of an NVIC IRQ line.

--- a/include/zephyr/arch/arm64/irq.h
+++ b/include/zephyr/arch/arm64/irq.h
@@ -94,9 +94,6 @@ extern void z_arm64_interrupt_init(void);
 	z_arm64_irq_priority_set(irq_p, priority_p, flags_p); \
 }
 
-/* Spurious interrupt handler. Throws an error if called */
-extern void z_irq_spurious(const void *unused);
-
 #endif /* _ASMLANGUAGE */
 
 #ifdef __cplusplus

--- a/include/zephyr/arch/nios2/arch.h
+++ b/include/zephyr/arch/nios2/arch.h
@@ -44,8 +44,6 @@ extern "C" {
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
 }
 
-extern void z_irq_spurious(const void *unused);
-
 static ALWAYS_INLINE unsigned int arch_irq_lock(void)
 {
 	unsigned int key, tmp;

--- a/include/zephyr/arch/xtensa/arch.h
+++ b/include/zephyr/arch/xtensa/arch.h
@@ -58,9 +58,6 @@ extern void z_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
 	Z_ISR_DECLARE(irq_p, flags_p, isr_p, isr_param_p); \
 }
 
-/* Spurious interrupt handler. Throws an error if called */
-extern void z_irq_spurious(const void *unused);
-
 #define XTENSA_ERR_NORET
 
 extern uint32_t sys_clock_cycle_get_32(void);

--- a/include/zephyr/sw_isr_table.h
+++ b/include/zephyr/sw_isr_table.h
@@ -25,6 +25,9 @@ extern "C" {
 /* Default vector for the IRQ vector table */
 extern void _isr_wrapper(void);
 
+/* Spurious interrupt handler. Throws an error if called */
+extern void z_irq_spurious(const void *unused);
+
 /*
  * Note the order: arg first, then ISR. This allows a table entry to be
  * loaded arg -> r0, isr -> r3 in _isr_wrapper with one ldmia instruction,

--- a/tests/kernel/interrupt/src/dynamic_isr.c
+++ b/tests/kernel/interrupt/src/dynamic_isr.c
@@ -23,7 +23,6 @@ static void dyn_isr(const void *arg)
 
 #if defined(CONFIG_GEN_SW_ISR_TABLE)
 extern struct _isr_table_entry __sw_isr_table _sw_isr_table[];
-extern void z_irq_spurious(const void *unused);
 
 /**
  * @brief Test dynamic ISR installation


### PR DESCRIPTION
Every architecture must export the z_irq_spurious definition. Just unify
that in one single header file.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>