### PR TITLE
define PLL for USB OTG FS controller of STM32F4

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -50,8 +50,16 @@
 #define GET_CURRENT_FLASH_PRESCALER LL_RCC_GetAHBPrescaler
 #endif
 
+#if defined(RCC_PLLCFGR_PLLPEN)
 #define RCC_PLLP_ENABLE() SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLPEN)
+#else
+#define RCC_PLLP_ENABLE()
+#endif /* RCC_PLLCFGR_PLLPEN */
+#if defined(RCC_PLLCFGR_PLLQEN)
 #define RCC_PLLQ_ENABLE() SET_BIT(RCC->PLLCFGR, RCC_PLLCFGR_PLLQEN)
+#else
+#define RCC_PLLQ_ENABLE()
+#endif /* RCC_PLLCFGR_PLLQEN */
 
 /**
  * @brief Return frequency for pll with 2 dividers and a multiplier

--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -34,6 +34,22 @@ static uint32_t get_pll_source(void)
 }
 
 /**
+ * @brief get the pll source frequency
+ */
+__unused
+uint32_t get_pllsrc_frequency(void)
+{
+	if (IS_ENABLED(STM32_PLL_SRC_HSI)) {
+		return STM32_HSI_FREQ;
+	} else if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
+		return STM32_HSE_FREQ;
+	}
+
+	__ASSERT(0, "Invalid source");
+	return 0;
+}
+
+/**
  * @brief Set up pll configuration
  */
 __unused

--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -19,4 +19,21 @@
 #define STM32_PERIPH_BUS_MIN	STM32_CLOCK_BUS_AHB1
 #define STM32_PERIPH_BUS_MAX	STM32_CLOCK_BUS_APB3
 
+/** Peripheral clock sources */
+/* RM0386, 0390, 0402, 0430 § Dedicated Clock configuration register (RCC_DCKCFGRx) */
+
+/** Fixed clocks  */
+#define STM32_SRC_HSI		0x001
+#define STM32_SRC_LSE		0x002
+#define STM32_SRC_LSI		0x003
+/* #define STM32_SRC_HSI48	0x004 */
+/** System clock */
+/* #define STM32_SRC_SYSCLK	0x005 */
+/** Bus clock */
+#define STM32_SRC_PCLK		0x006
+/** PLL clock outputs */
+#define STM32_SRC_PLL_P	0x007
+#define STM32_SRC_PLL_Q	0x008
+#define STM32_SRC_PLL_R	0x009
+
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */


### PR DESCRIPTION
This PR is defining the STM32_SRC_PLL_P and STM32_SRC_PLL_Q on the stm32f4 serie. This  is required especially for the USB controller peripheral.
The stm32f4 mcu has no PLL P or Q enable bit in its PLL config. register (PLLCFGR) like other stm32 devices.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/47445

Signed-off-by: Francois Ramu <francois.ramu@st.com>