### PR TITLE
drivers: ssd16xx: Refactor busy pin handling

### DIFF
--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -61,6 +61,18 @@ struct ssd16xx_config {
 	uint8_t pp_height_bits;
 };
 
+static inline void ssd16xx_busy_wait(const struct device *dev)
+{
+	const struct ssd16xx_config *config = dev->config;
+	int pin = gpio_pin_get_dt(&config->busy_gpio);
+
+	while (pin > 0) {
+		__ASSERT(pin >= 0, "Failed to get pin level");
+		k_msleep(SSD16XX_BUSY_DELAY);
+		pin = gpio_pin_get_dt(&config->busy_gpio);
+	}
+}
+
 static inline int ssd16xx_write_cmd(const struct device *dev, uint8_t cmd,
 				    uint8_t *data, size_t len)
 {
@@ -68,6 +80,8 @@ static inline int ssd16xx_write_cmd(const struct device *dev, uint8_t cmd,
 	struct spi_buf buf = {.buf = &cmd, .len = sizeof(cmd)};
 	struct spi_buf_set buf_set = {.buffers = &buf, .count = 1};
 	int err = 0;
+
+	ssd16xx_busy_wait(dev);
 
 	err = gpio_pin_set_dt(&config->dc_gpio, 1);
 	if (err < 0) {
@@ -97,18 +111,6 @@ static inline int ssd16xx_write_cmd(const struct device *dev, uint8_t cmd,
 spi_out:
 	spi_release_dt(&config->bus);
 	return err;
-}
-
-static inline void ssd16xx_busy_wait(const struct device *dev)
-{
-	const struct ssd16xx_config *config = dev->config;
-	int pin = gpio_pin_get_dt(&config->busy_gpio);
-
-	while (pin > 0) {
-		__ASSERT(pin >= 0, "Failed to get pin level");
-		k_msleep(SSD16XX_BUSY_DELAY);
-		pin = gpio_pin_get_dt(&config->busy_gpio);
-	}
 }
 
 static inline size_t push_x_param(const struct device *dev,
@@ -289,8 +291,6 @@ static int ssd16xx_write(const struct device *dev, const uint16_t x,
 	default:
 		return -EINVAL;
 	}
-
-	ssd16xx_busy_wait(dev);
 
 	err = ssd16xx_write_cmd(dev, SSD16XX_CMD_ENTRY_MODE,
 				&data->scan_mode, sizeof(data->scan_mode));
@@ -479,8 +479,6 @@ static inline int ssd16xx_load_ws_from_otp(const struct device *dev)
 		return err;
 	}
 
-	ssd16xx_busy_wait(dev);
-
 	/* Load temperature value */
 	sys_put_be16(t, tmp);
 	err = ssd16xx_write_cmd(dev, SSD16XX_CMD_TSENS_CTRL, tmp, 2);
@@ -499,8 +497,6 @@ static inline int ssd16xx_load_ws_from_otp(const struct device *dev)
 		return err;
 	}
 
-	ssd16xx_busy_wait(dev);
-
 	data->update_cmd |= SSD16XX_CTRL2_LOAD_LUT;
 
 	return 0;
@@ -509,43 +505,31 @@ static inline int ssd16xx_load_ws_from_otp(const struct device *dev)
 static int ssd16xx_load_ws_initial(const struct device *dev)
 {
 	const struct ssd16xx_config *config = dev->config;
-	int err = 0;
 
 	if (config->lut_initial.len) {
-		err = ssd16xx_write_cmd(dev, SSD16XX_CMD_UPDATE_LUT,
-					config->lut_initial.data,
-					config->lut_initial.len);
-
-		if (err == 0) {
-			ssd16xx_busy_wait(dev);
-		}
+		return ssd16xx_write_cmd(dev, SSD16XX_CMD_UPDATE_LUT,
+					 config->lut_initial.data,
+					 config->lut_initial.len);
 	} else {
 		if (config->tssv) {
-			err = ssd16xx_load_ws_from_otp_tssv(dev);
+			return ssd16xx_load_ws_from_otp_tssv(dev);
 		} else {
-			err = ssd16xx_load_ws_from_otp(dev);
+			return ssd16xx_load_ws_from_otp(dev);
 		}
 	}
-
-	return err;
 }
 
 static int ssd16xx_load_ws_default(const struct device *dev)
 {
 	const struct ssd16xx_config *config = dev->config;
-	int err = 0;
 
 	if (config->lut_default.len) {
-		err = ssd16xx_write_cmd(dev, SSD16XX_CMD_UPDATE_LUT,
-					config->lut_default.data,
-					config->lut_default.len);
-
-		if (err == 0) {
-			ssd16xx_busy_wait(dev);
-		}
+		return ssd16xx_write_cmd(dev, SSD16XX_CMD_UPDATE_LUT,
+					 config->lut_default.data,
+					 config->lut_default.len);
 	}
 
-	return err;
+	return 0;
 }
 
 
@@ -572,13 +556,11 @@ static int ssd16xx_controller_init(const struct device *dev)
 	}
 
 	k_msleep(SSD16XX_RESET_DELAY);
-	ssd16xx_busy_wait(dev);
 
 	err = ssd16xx_write_cmd(dev, SSD16XX_CMD_SW_RESET, NULL, 0);
 	if (err < 0) {
 		return err;
 	}
-	ssd16xx_busy_wait(dev);
 
 	len = push_y_param(dev, tmp, last_gate);
 	tmp[len++] = 0U;
@@ -654,15 +636,11 @@ static int ssd16xx_controller_init(const struct device *dev)
 		return err;
 	}
 
-	ssd16xx_busy_wait(dev);
-
 	err = ssd16xx_clear_cntlr_mem(dev, SSD16XX_CMD_WRITE_RED_RAM,
 					     false);
 	if (err < 0) {
 		return err;
 	}
-
-	ssd16xx_busy_wait(dev);
 
 	err = ssd16xx_load_ws_default(dev);
 	if (err < 0) {


### PR DESCRIPTION
The SSD16xx driver needs to wait for the chip to complete commands before issuing new commands. The datasheet doesn't specify which commands cause the chip to raise the busy pin. The current driver has ssd16xx_busy_wait() calls after commands that are known to take a long time. This is very fragile and scatters a lot of boiler plate around
the driver.

Include an ssd16xx_busy_wait() call in ssd16xx_write_cmd() instead of after commands that are suspected to take a long time. This makes the driver more robust and is more in line with the expectations set out in the data sheet.

---

Note: This has only been tested on an SSD1681-based display. I can't see any reason for this not to work on other displays since the state of the busy pin will always be checked prior to sending a new command to the chip.