### PR TITLE
driver: timer: stm32_lptim: only set LSE drive if supported

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -279,7 +279,9 @@ static int sys_clock_driver_init(const struct device *dev)
 
 	/* enable LSE clock */
 	LL_RCC_LSE_DisableBypass();
+#ifdef RCC_BDCR_LSEDRV_Pos
 	LL_RCC_LSE_SetDriveCapability(STM32_LSE_DRIVING << RCC_BDCR_LSEDRV_Pos);
+#endif
 	LL_RCC_LSE_Enable();
 	while (!LL_RCC_LSE_IsReady()) {
 		/* Wait for LSE ready */


### PR DESCRIPTION
Hi, bumped this on a custom board based on the Murata module with the L072, fails to build if compiled with LSE for LPTIM, can be reproduced with:

`west build -p -b b_l072z_lrwan1 samples/boards/stm32/power_mgmt/blinky -DCONFIG_STM32_LPTIM_CLOCK_LSE=y`

Let me know if you think there's a better way around this, went for the obvious one...

-- 8< --

Not all platforms support setting the LSE driving capability, causing
the build to fail for platform such as the STM32L072 if compiled with
CONFIG_STM32_LPTIM_CLOCK_LSE=y.

Adding an #ifdef guard around the call to skip it if not defined in the
HAL.