### PR TITLE
Revert "dma/cavs_hda: add missing hda link files to CMakeLists"

### DIFF
--- a/drivers/dma/CMakeLists.txt
+++ b/drivers/dma/CMakeLists.txt
@@ -20,5 +20,7 @@ zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_GPDMA	dma_cavs_gpdma.c dma_dw_commo
 zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_HDA dma_cavs_hda.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_HDA_HOST_IN dma_cavs_hda_host_in.c)
 zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_HDA_HOST_OUT dma_cavs_hda_host_out.c)
-zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_HDA_LINK_IN dma_cavs_hda_link_in.c)
-zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_HDA_LINK_OUT dma_cavs_hda_link_out.c)
+
+# Temporarily disabled, see https://github.com/zephyrproject-rtos/zephyr/pull/47524
+# zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_HDA_LINK_IN dma_cavs_hda_link_in.c)
+# zephyr_library_sources_ifdef(CONFIG_DMA_CAVS_HDA_LINK_OUT dma_cavs_hda_link_out.c)


### PR DESCRIPTION
This reverts commit ef2644d40d5babe4e4f0ca28f8f3146d752e6745.

This commit broke Zephyr booting across many platforms, see
examples at https://sof-ci.01.org/linuxpr/PR3742/build343/devicetest/,
https://sof-ci.01.org/sofpr/PR5994/build850/devicetest/, every other PR
test run today and today's July 7th internal daily run 13803 with commit
2d54229f6cfa.

July 6th run 13760 with Zephyr commit e0b1d81acbc5 was all green.

I have no idea why this broke booting across so many platforms but it's
hard to argue with git bisect and not booting is obviously a top
priority blocker.