### PR TITLE
modules: hal_nordic: Convert to use DEVICE_DT_GET

### DIFF
--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_gpiote_zephyr.c
@@ -56,13 +56,15 @@ void nrf_802154_gpiote_init(void)
 					GPIO_PULL_DOWN;
 
 #if DT_NODE_EXISTS(DT_NODELABEL(gpio1))
-		dev = device_get_binding(use_port_1 ?
-					 DT_LABEL(DT_NODELABEL(gpio1)) :
-					 DT_LABEL(DT_NODELABEL(gpio0)));
+		if (use_port_1) {
+			dev = DEVICE_DT_GET(DT_NODELABEL(gpio1));
+		} else {
+			dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
+		}
 #else
-		dev = device_get_binding(DT_LABEL(DT_NODELABEL(gpio0)));
+		dev = DEVICE_DT_GET(DT_NODELABEL(gpio0));
 #endif
-		__ASSERT_NO_MSG(dev != NULL);
+		__ASSERT_NO_MSG(device_is_ready(dev));
 
 		gpio_pin_configure(dev, pin_number, GPIO_INPUT | pull_up_down);
 


### PR DESCRIPTION
Move to use DEVICE_DT_GET_ONE instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Kumar Gala <galak@kernel.org>