### PR TITLE
Bluetooth: Controller: Fix missing recv fifo reset

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -455,6 +455,8 @@ static void reset(struct net_buf *buf, struct net_buf **evt)
 		k_poll_signal_raise(hbuf_signal, 0x0);
 	}
 #endif
+
+	hci_recv_fifo_reset();
 }
 
 #if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)

--- a/subsys/bluetooth/controller/hci/hci_internal.h
+++ b/subsys/bluetooth/controller/hci/hci_internal.h
@@ -32,6 +32,7 @@ extern atomic_t hci_state_mask;
 
 
 void hci_init(struct k_poll_signal *signal_host_buf);
+void hci_recv_fifo_reset(void);
 struct net_buf *hci_cmd_handle(struct net_buf *cmd, void **node_rx);
 void hci_evt_encode(struct node_rx_pdu *node_rx, struct net_buf *buf);
 uint8_t hci_get_class(struct node_rx_pdu *node_rx);


### PR DESCRIPTION
Fix missing recv fifo reset on HCI reset. This fix handles a
scenario where in Rx Prio thread has enqueued a node rx, Tx
thread handles HCI Reset Command, and Rx thread wakes up
from call to k_fifo_get to handle invalid node rx. The
changes here ensure Rx thread does not get any invalid node
rx post HCI Reset Command handled in Tx thread.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>