### PR TITLE
RISCV: rework and cleanup interrupt controllers support

### DIFF
--- a/drivers/interrupt_controller/Kconfig
+++ b/drivers/interrupt_controller/Kconfig
@@ -16,20 +16,10 @@ config ARCV2_INTERRUPT_UNIT
 	  building a processor, you can configure the processor to include an
 	  interrupt unit. The ARCv2 interrupt unit is highly programmable.
 
-config PLIC
-	bool "Platform Level Interrupt Controller (PLIC)"
-	default y
-	depends on RISCV_HAS_PLIC
-	select MULTI_LEVEL_INTERRUPTS
-	select 2ND_LEVEL_INTERRUPTS
-	help
-	  Platform Level Interrupt Controller provides support
-	  for external interrupt lines defined by the RISC-V SoC;
-
 config SWERV_PIC
 	bool "SweRV EH1 Programmable Interrupt Controller (PIC)"
 	help
-	  Programmable Interrupt Controller for the SweRV EH1 RISC-V CPU;
+	  Programmable Interrupt Controller for the SweRV EH1 RISC-V CPU.
 
 config VEXRISCV_LITEX_IRQ
 	bool "VexRiscv LiteX Interrupt controller"
@@ -82,8 +72,10 @@ source "drivers/interrupt_controller/Kconfig.esp32c3"
 
 source "drivers/interrupt_controller/Kconfig.xec"
 
-source "drivers/interrupt_controller/Kconfig.eclic"
+source "drivers/interrupt_controller/Kconfig.clic"
 
 source "drivers/interrupt_controller/Kconfig.gd32_exti"
+
+source "drivers/interrupt_controller/Kconfig.plic"
 
 endmenu

--- a/drivers/interrupt_controller/Kconfig.clic
+++ b/drivers/interrupt_controller/Kconfig.clic
@@ -1,18 +1,11 @@
-# Nuclei ECLIC interrupt-controller configuration
-
 # Copyright (c) 2021 Tokita, Hiroshi <tokita.hiroshi@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
 DT_COMPAT_NUCLEI_ECLIC = nuclei,eclic
 
-config HAS_NUCLEI_ECLIC
-	bool
-	help
-	  Indicate that the platform has ECLIC.
-
 config NUCLEI_ECLIC
 	bool "Enhanced Core Local Interrupt Controller (ECLIC)"
 	default $(dt_compat_enabled,$(DT_COMPAT_NUCLEI_ECLIC))
-	depends on HAS_NUCLEI_ECLIC
+	depends on RISCV_HAS_CLIC
 	help
 	  Interrupt controller for Nuclei SoC core.

--- a/drivers/interrupt_controller/Kconfig.plic
+++ b/drivers/interrupt_controller/Kconfig.plic
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+# SPDX-License-Identifier: Apache-2.0
+
+config PLIC
+	bool "Platform Level Interrupt Controller (PLIC)"
+	default y
+	depends on RISCV_HAS_PLIC
+	select MULTI_LEVEL_INTERRUPTS
+	select 2ND_LEVEL_INTERRUPTS
+	help
+	  Platform Level Interrupt Controller provides support
+	  for external interrupt lines defined by the RISC-V SoC.

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -122,7 +122,7 @@ static inline uint8_t mask8(uint8_t len)
 /**
  * @brief Enable interrupt
  */
-void nuclei_eclic_irq_enable(uint32_t irq)
+void riscv_clic_irq_enable(uint32_t irq)
 {
 	ECLIC_CTRL[irq].INTIE.b.IE = 1;
 }
@@ -130,7 +130,7 @@ void nuclei_eclic_irq_enable(uint32_t irq)
 /**
  * @brief Disable interrupt
  */
-void nuclei_eclic_irq_disable(uint32_t irq)
+void riscv_clic_irq_disable(uint32_t irq)
 {
 	ECLIC_CTRL[irq].INTIE.b.IE = 0;
 }
@@ -138,7 +138,7 @@ void nuclei_eclic_irq_disable(uint32_t irq)
 /**
  * @brief Get enable status of interrupt
  */
-int nuclei_eclic_irq_is_enabled(uint32_t irq)
+int riscv_clic_irq_is_enabled(uint32_t irq)
 {
 	return ECLIC_CTRL[irq].INTIE.b.IE;
 }
@@ -146,7 +146,7 @@ int nuclei_eclic_irq_is_enabled(uint32_t irq)
 /**
  * @brief Set priority and level of interrupt
  */
-void nuclei_eclic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags)
+void riscv_clic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags)
 {
 	const uint8_t prio = leftalign8(MIN(pri, max_prio), intctlbits);
 	const uint8_t level =  leftalign8(MIN((irq_get_level(irq) - 1), max_level), nlbits);

--- a/drivers/interrupt_controller/intc_nuclei_eclic.c
+++ b/drivers/interrupt_controller/intc_nuclei_eclic.c
@@ -15,6 +15,7 @@
 #include <soc.h>
 
 #include <zephyr/sw_isr_table.h>
+#include <zephyr/drivers/interrupt_controller/riscv_clic.h>
 
 union CLICCFG {
 	struct {

--- a/drivers/interrupt_controller/intc_plic.c
+++ b/drivers/interrupt_controller/intc_plic.c
@@ -18,6 +18,7 @@
 #include <soc.h>
 
 #include <zephyr/sw_isr_table.h>
+#include <zephyr/drivers/interrupt_controller/riscv_plic.h>
 
 #define PLIC_MAX_PRIO	DT_INST_PROP(0, riscv_max_priority)
 #define PLIC_PRIO	DT_INST_REG_ADDR_BY_NAME(0, prio)

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -17,6 +17,7 @@
 
 #include <zephyr/arch/riscv/thread.h>
 #include <zephyr/arch/riscv/exp.h>
+#include <zephyr/arch/riscv/irq.h>
 #include <zephyr/arch/common/sys_bitops.h>
 #include <zephyr/arch/common/sys_io.h>
 #include <zephyr/arch/common/ffs.h>
@@ -212,75 +213,6 @@ struct arch_mem_domain {
 };
 
 extern void z_irq_spurious(const void *unused);
-
-extern void arch_irq_enable(unsigned int irq);
-extern void arch_irq_disable(unsigned int irq);
-extern int arch_irq_is_enabled(unsigned int irq);
-
-extern void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio,
-				     uint32_t flags);
-
-#define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-{ \
-	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	z_riscv_irq_priority_set(irq_p, priority_p, flags_p); \
-}
-
-#define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
-{ \
-	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
-}
-
-#define ARCH_ISR_DIRECT_HEADER() arch_isr_direct_header()
-#define ARCH_ISR_DIRECT_FOOTER(swap) arch_isr_direct_footer(swap)
-
-#ifdef CONFIG_TRACING_ISR
-extern void sys_trace_isr_enter(void);
-extern void sys_trace_isr_exit(void);
-#endif
-
-static inline void arch_isr_direct_header(void)
-{
-#ifdef CONFIG_TRACING_ISR
-	sys_trace_isr_enter();
-#endif
-	/* We need to increment this so that arch_is_in_isr() keeps working */
-	++(arch_curr_cpu()->nested);
-}
-
-extern void __soc_handle_irq(ulong_t mcause);
-
-static inline void arch_isr_direct_footer(int swap)
-{
-	ulong_t mcause;
-
-	/* Get the IRQ number */
-	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
-	mcause &= SOC_MCAUSE_EXP_MASK;
-
-	/* Clear the pending IRQ */
-	__soc_handle_irq(mcause);
-
-	/* We are not in the ISR anymore */
-	--(arch_curr_cpu()->nested);
-
-#ifdef CONFIG_TRACING_ISR
-	sys_trace_isr_exit();
-#endif
-}
-
-/*
- * TODO: Add support for rescheduling
- */
-#define ARCH_ISR_DIRECT_DECLARE(name) \
-	static inline int name##_body(void); \
-	__attribute__ ((interrupt)) void name(void) \
-	{ \
-		ISR_DIRECT_HEADER(); \
-		name##_body(); \
-		ISR_DIRECT_FOOTER(0); \
-	} \
-	static inline int name##_body(void)
 
 /*
  * use atomic instruction csrrc to lock global irq

--- a/include/zephyr/arch/riscv/arch.h
+++ b/include/zephyr/arch/riscv/arch.h
@@ -211,31 +211,20 @@ struct arch_mem_domain {
 	unsigned int pmp_update_nr;
 };
 
-void arch_irq_enable(unsigned int irq);
-void arch_irq_disable(unsigned int irq);
-int arch_irq_is_enabled(unsigned int irq);
-void arch_irq_priority_set(unsigned int irq, unsigned int prio);
-void z_irq_spurious(const void *unused);
+extern void z_irq_spurious(const void *unused);
 
-#if defined(CONFIG_RISCV_HAS_PLIC)
+extern void arch_irq_enable(unsigned int irq);
+extern void arch_irq_disable(unsigned int irq);
+extern int arch_irq_is_enabled(unsigned int irq);
+
+extern void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio,
+				     uint32_t flags);
+
 #define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
 { \
 	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	arch_irq_priority_set(irq_p, priority_p); \
+	z_riscv_irq_priority_set(irq_p, priority_p, flags_p); \
 }
-#elif defined(CONFIG_NUCLEI_ECLIC)
-void nuclei_eclic_irq_priority_set(unsigned int irq, unsigned int prio, unsigned int flags);
-#define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-{ \
-	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-	nuclei_eclic_irq_priority_set(irq_p, priority_p, flags_p); \
-}
-#else
-#define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
-{ \
-	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
-}
-#endif
 
 #define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
 { \

--- a/include/zephyr/arch/riscv/irq.h
+++ b/include/zephyr/arch/riscv/irq.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief RISC-V public interrupt handling
+ *
+ * RISC-V-specific kernel interrupt handling interface.
+ */
+
+#ifndef ZEPHYR_INCLUDE_ARCH_RISCV_IRQ_H_
+#define ZEPHYR_INCLUDE_ARCH_RISCV_IRQ_H_
+
+#ifndef _ASMLANGUAGE
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <zephyr/irq.h>
+#include <zephyr/sw_isr_table.h>
+#include <stdbool.h>
+#include <soc.h>
+
+extern void arch_irq_enable(unsigned int irq);
+extern void arch_irq_disable(unsigned int irq);
+extern int arch_irq_is_enabled(unsigned int irq);
+
+#if defined(CONFIG_RISCV_HAS_PLIC) || defined(CONFIG_RISCV_HAS_CLIC)
+extern void z_riscv_irq_priority_set(unsigned int irq,
+				     unsigned int prio,
+				     uint32_t flags);
+#else
+#define z_riscv_irq_priority_set(i, p, f) /* Nothing */
+#endif /* CONFIG_RISCV_HAS_PLIC || CONFIG_RISCV_HAS_CLIC */
+
+#define ARCH_IRQ_CONNECT(irq_p, priority_p, isr_p, isr_param_p, flags_p) \
+{ \
+	Z_ISR_DECLARE(irq_p, 0, isr_p, isr_param_p); \
+	z_riscv_irq_priority_set(irq_p, priority_p, flags_p); \
+}
+
+#define ARCH_IRQ_DIRECT_CONNECT(irq_p, priority_p, isr_p, flags_p) \
+{ \
+	Z_ISR_DECLARE(irq_p, ISR_FLAG_DIRECT, isr_p, NULL); \
+}
+
+#define ARCH_ISR_DIRECT_HEADER() arch_isr_direct_header()
+#define ARCH_ISR_DIRECT_FOOTER(swap) arch_isr_direct_footer(swap)
+
+#ifdef CONFIG_TRACING_ISR
+extern void sys_trace_isr_enter(void);
+extern void sys_trace_isr_exit(void);
+#endif
+
+static inline void arch_isr_direct_header(void)
+{
+#ifdef CONFIG_TRACING_ISR
+	sys_trace_isr_enter();
+#endif
+	/* We need to increment this so that arch_is_in_isr() keeps working */
+	++(arch_curr_cpu()->nested);
+}
+
+extern void __soc_handle_irq(ulong_t mcause);
+
+static inline void arch_isr_direct_footer(int swap)
+{
+	ulong_t mcause;
+
+	/* Get the IRQ number */
+	__asm__ volatile("csrr %0, mcause" : "=r" (mcause));
+	mcause &= SOC_MCAUSE_EXP_MASK;
+
+	/* Clear the pending IRQ */
+	__soc_handle_irq(mcause);
+
+	/* We are not in the ISR anymore */
+	--(arch_curr_cpu()->nested);
+
+#ifdef CONFIG_TRACING_ISR
+	sys_trace_isr_exit();
+#endif
+}
+
+/*
+ * TODO: Add support for rescheduling
+ */
+#define ARCH_ISR_DIRECT_DECLARE(name) \
+	static inline int name##_body(void); \
+	__attribute__ ((interrupt)) void name(void) \
+	{ \
+		ISR_DIRECT_HEADER(); \
+		name##_body(); \
+		ISR_DIRECT_FOOTER(0); \
+	} \
+	static inline int name##_body(void)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ASMLANGUAGE */
+#endif /* ZEPHYR_INCLUDE_ARCH_RISCV_IRQ_H_ */

--- a/include/zephyr/drivers/interrupt_controller/riscv_clic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_clic.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Driver for Core-Local Interrupt Controller (CLIC)
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RISCV_CLIC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RISCV_CLIC_H_
+
+/**
+ * @brief Enable interrupt
+ *
+ * @param irq interrupt ID
+ */
+void riscv_clic_irq_enable(uint32_t irq);
+
+/**
+ * @brief Disable interrupt
+ *
+ * @param irq interrupt ID
+ */
+void riscv_clic_irq_disable(uint32_t irq);
+
+/**
+ * @brief Check if an interrupt is enabled
+ *
+ * @param irq interrupt ID
+ * @return Returns true if interrupt is enabled, false otherwise
+ */
+int riscv_clic_irq_is_enabled(uint32_t irq);
+
+/**
+ * @brief Set interrupt priority
+ *
+ * @param irq interrupt ID
+ * @param prio interrupt priority
+ * @param flags interrupt flags
+ */
+void riscv_clic_irq_priority_set(uint32_t irq, uint32_t prio, uint32_t flags);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RISCV_CLIC_H_ */

--- a/include/zephyr/drivers/interrupt_controller/riscv_plic.h
+++ b/include/zephyr/drivers/interrupt_controller/riscv_plic.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Carlo Caione <ccaione@baylibre.com>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Driver for Platform Level Interrupt Controller (PLIC)
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
+#define ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_
+
+/**
+ * @brief Enable interrupt
+ *
+ * @param irq interrupt ID
+ */
+void riscv_plic_irq_enable(uint32_t irq);
+
+/**
+ * @brief Disable interrupt
+ *
+ * @param irq interrupt ID
+ */
+void riscv_plic_irq_disable(uint32_t irq);
+
+/**
+ * @brief Check if an interrupt is enabled
+ *
+ * @param irq interrupt ID
+ * @return Returns true if interrupt is enabled, false otherwise
+ */
+int riscv_plic_irq_is_enabled(uint32_t irq);
+
+/**
+ * @brief Set interrupt priority
+ *
+ * @param irq interrupt ID
+ * @param prio interrupt priority
+ */
+void riscv_plic_set_priority(uint32_t irq, uint32_t prio);
+
+/**
+ * @brief Get active interrupt ID
+ *
+ * @return Returns the ID of an active interrupt
+ */
+int riscv_plic_get_irq(void);
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_RISCV_PLIC_H_ */

--- a/soc/riscv/litex-vexriscv/soc.h
+++ b/soc/riscv/litex-vexriscv/soc.h
@@ -9,6 +9,7 @@
 
 #include "../riscv-privilege/common/soc_common.h"
 #include <zephyr/devicetree.h>
+#include <zephyr/arch/common/sys_io.h>
 
 /* lib-c hooks required RAM defined variables */
 #define RISCV_RAM_BASE              DT_REG_ADDR(DT_INST(0, mmio_sram))

--- a/soc/riscv/riscv-privilege/Kconfig
+++ b/soc/riscv/riscv-privilege/Kconfig
@@ -13,10 +13,16 @@ config SOC_FAMILY
 	depends on SOC_FAMILY_RISCV_PRIVILEGE
 
 config RISCV_HAS_PLIC
-	bool "Does the SOC provide support for a Platform Level Interrupt Controller"
+	bool "Does the SOC provide support for a Platform Level Interrupt Controller (PLIC)"
 	depends on SOC_FAMILY_RISCV_PRIVILEGE
 	help
-	  Does the SOC provide support for a Platform Level Interrupt Controller
+	  Does the SOC provide support for a Platform Level Interrupt Controller (PLIC).
+
+config RISCV_HAS_CLIC
+	bool "Does the SOC provide support for a Core-Local Interrupt Controller (CLIC)"
+	depends on SOC_FAMILY_RISCV_PRIVILEGE
+	help
+	  Does the SOC provide support for a Core-Local Interrupt Controller (CLIC).
 
 config RISCV_MTVEC_VECTORED_MODE
 	bool "Should the SOC use mtvec in vectored mode"

--- a/soc/riscv/riscv-privilege/common/soc_common.h
+++ b/soc/riscv/riscv-privilege/common/soc_common.h
@@ -50,11 +50,11 @@ void riscv_plic_set_priority(uint32_t irq, uint32_t priority);
 int riscv_plic_get_irq(void);
 #endif
 
-#if defined(CONFIG_NUCLEI_ECLIC)
-void nuclei_eclic_irq_enable(uint32_t irq);
-void nuclei_eclic_irq_disable(uint32_t irq);
-int nuclei_eclic_irq_is_enabled(uint32_t irq);
-void nuclei_eclic_set_priority(uint32_t irq, uint32_t priority);
+#if defined(CONFIG_RISCV_HAS_CLIC)
+int riscv_clic_irq_is_enabled(uint32_t irq);
+void riscv_clic_irq_disable(uint32_t irq);
+void riscv_clic_irq_enable(uint32_t irq);
+void riscv_clic_irq_priority_set(uint32_t irq, uint32_t pri, uint32_t flags);
 #endif
 
 #endif /* !_ASMLANGUAGE */

--- a/soc/riscv/riscv-privilege/common/soc_common_irq.c
+++ b/soc/riscv/riscv-privilege/common/soc_common_irq.c
@@ -11,6 +11,9 @@
  */
 #include <zephyr/irq.h>
 
+#include <zephyr/drivers/interrupt_controller/riscv_clic.h>
+#include <zephyr/drivers/interrupt_controller/riscv_plic.h>
+
 #if defined(CONFIG_RISCV_HAS_CLIC)
 
 void arch_irq_enable(unsigned int irq)

--- a/soc/riscv/riscv-privilege/common/soc_common_irq.c
+++ b/soc/riscv/riscv-privilege/common/soc_common_irq.c
@@ -11,6 +11,30 @@
  */
 #include <zephyr/irq.h>
 
+#if defined(CONFIG_RISCV_HAS_CLIC)
+
+void arch_irq_enable(unsigned int irq)
+{
+	riscv_clic_irq_enable(irq);
+}
+
+void arch_irq_disable(unsigned int irq)
+{
+	riscv_clic_irq_disable(irq);
+}
+
+int arch_irq_is_enabled(unsigned int irq)
+{
+	return riscv_clic_irq_is_enabled(irq);
+}
+
+void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+{
+	riscv_clic_irq_priority_set(irq, prio, flags);
+}
+
+#else /* PLIC + HLINT/CLINT or HLINT/CLINT only */
+
 void arch_irq_enable(unsigned int irq)
 {
 	uint32_t mie;
@@ -23,10 +47,6 @@ void arch_irq_enable(unsigned int irq)
 		riscv_plic_irq_enable(irq);
 		return;
 	}
-#endif
-#if defined(CONFIG_NUCLEI_ECLIC)
-	nuclei_eclic_irq_enable(irq);
-	return;
 #endif
 
 	/*
@@ -51,10 +71,6 @@ void arch_irq_disable(unsigned int irq)
 		return;
 	}
 #endif
-#if defined(CONFIG_NUCLEI_ECLIC)
-	nuclei_eclic_irq_disable(irq);
-	return;
-#endif
 
 	/*
 	 * Use atomic instruction csrrc to disable device interrupt in mie CSR.
@@ -63,23 +79,6 @@ void arch_irq_disable(unsigned int irq)
 	__asm__ volatile ("csrrc %0, mie, %1\n"
 			  : "=r" (mie)
 			  : "r" (1 << irq));
-};
-
-void arch_irq_priority_set(unsigned int irq, unsigned int prio)
-{
-#if defined(CONFIG_RISCV_HAS_PLIC)
-	unsigned int level = irq_get_level(irq);
-
-	if (level == 2) {
-		irq = irq_from_level_2(irq);
-		riscv_plic_set_priority(irq, prio);
-	}
-#endif
-#if defined(CONFIG_NUCLEI_ECLIC)
-	nuclei_eclic_set_priority(irq, prio);
-#endif
-
-	return ;
 }
 
 int arch_irq_is_enabled(unsigned int irq)
@@ -94,14 +93,24 @@ int arch_irq_is_enabled(unsigned int irq)
 		return riscv_plic_irq_is_enabled(irq);
 	}
 #endif
-#if defined(CONFIG_NUCLEI_ECLIC)
-	return nuclei_eclic_irq_is_enabled(irq);
-#endif
 
 	__asm__ volatile ("csrr %0, mie" : "=r" (mie));
 
 	return !!(mie & (1 << irq));
 }
+
+#if defined(CONFIG_RISCV_HAS_PLIC)
+void z_riscv_irq_priority_set(unsigned int irq, unsigned int prio, uint32_t flags)
+{
+	unsigned int level = irq_get_level(irq);
+
+	if (level == 2) {
+		irq = irq_from_level_2(irq);
+		riscv_plic_set_priority(irq, prio);
+	}
+}
+#endif /* CONFIG_RISCV_HAS_PLIC */
+#endif /* CONFIG_RISCV_HAS_CLIC */
 
 #if defined(CONFIG_RISCV_SOC_INTERRUPT_INIT)
 __weak void soc_interrupt_init(void)

--- a/soc/riscv/riscv-privilege/gd32vf103/Kconfig.series
+++ b/soc/riscv/riscv-privilege/gd32vf103/Kconfig.series
@@ -13,7 +13,7 @@ config SOC_SERIES_GD32VF103
 	select XIP
 	select GD32_HAS_AFIO_PINMUX
 	select HAS_GD32_HAL
-	select HAS_NUCLEI_ECLIC
+	select RISCV_HAS_CLIC
 
 	help
 	  Enable support for GigaDevice GD32VF1 series SoC


### PR DESCRIPTION
The RISCV code regarding the interrupt controllers is messy and confusing and it is currently almost impossible to add new interrupt controller drivers for RISCV without spaghettifying the code even more.

There are several problems:
- We have a `RISCV_HAS_PLIC` symbol for platform supporting PLIC but there is no `RISCV_HAS_CLIC` symbol for CLIC support
- We have instead a `HAS_NUCLEI_ECLIC` for no reason whatsoever
- There is no standard interface for PLIC or CLIC drivers
- The arch code is directly calling a specific driver code without any wrapper or interface
- There is no possibility to add new PLIC or CLIC drivers without directly modifying the arch code and its ifdef madness
- The arch code is assuming that the only CLIC driver is the Nuclei one

This PR is trying to cleanup a bit the mess.