### PR TITLE
dma/cavs_hda: Configure DGMBS only for host DMA configuration

### DIFF
--- a/drivers/dma/dma_cavs_hda.c
+++ b/drivers/dma/dma_cavs_hda.c
@@ -55,9 +55,13 @@ int cavs_hda_dma_host_in_config(const struct device *dev,
 	res = cavs_hda_set_buffer(cfg->base, channel, buf,
 				  blk_cfg->block_size);
 
-	if (res == 0 && dma_cfg->source_data_size <= 3) {
-		/* set the sample container set bit to 16bits */
-		*DGCS(cfg->base, channel) |= DGCS_SCS;
+	if (res == 0) {
+		*DGMBS(cfg->base, channel) = blk_cfg->block_size & HDA_ALIGN_MASK;
+
+		if (dma_cfg->source_data_size <= 3) {
+			/* set the sample container set bit to 16bits */
+			*DGCS(cfg->base, channel) |= DGCS_SCS;
+		}
 	}
 
 	return res;
@@ -87,9 +91,13 @@ int cavs_hda_dma_host_out_config(const struct device *dev,
 	res = cavs_hda_set_buffer(cfg->base, channel, buf,
 				  blk_cfg->block_size);
 
-	if (res == 0 && dma_cfg->dest_data_size <= 3) {
-		/* set the sample container set bit to 16bits */
-		*DGCS(cfg->base, channel) |= DGCS_SCS;
+	if (res == 0) {
+		*DGMBS(cfg->base, channel) = blk_cfg->block_size & HDA_ALIGN_MASK;
+
+		if (dma_cfg->dest_data_size <= 3) {
+			/* set the sample container set bit to 16bits */
+			*DGCS(cfg->base, channel) |= DGCS_SCS;
+		}
 	}
 
 	return res;

--- a/soc/xtensa/intel_adsp/common/include/cavs_hda.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs_hda.h
@@ -178,7 +178,6 @@ static inline int cavs_hda_set_buffer(uint32_t base, uint32_t sid,
 
 	*DGBBA(base, sid) = aligned_addr;
 	*DGBS(base, sid) = aligned_size;
-	*DGMBS(base, sid) = aligned_size;
 
 	return 0;
 }


### PR DESCRIPTION
The DGMBS should be only set for the host side and not on the link DMA.

Fixes: #46632
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>