### PR TITLE
Bluetooth: ISO: Add check for pending ISO connections

### DIFF
--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -618,7 +618,26 @@ int bt_iso_cig_terminate(struct bt_iso_cig *cig);
  *  @param param Pointer to a connect parameter array with the ISO and ACL pointers.
  *  @param count Number of connect parameters.
  *
- *  @return 0 in case of success or negative value in case of error.
+ *  @retval 0 Successfully started the connecting procedure.
+ *
+ *  @retval -EINVAL Invalid parameters were supplied.
+ *
+ *  @retval -EBUSY Some ISO channels are already being connected.
+ *          It is not possible to have multiple outstanding connection requests.
+ *          May also be returned if @kconfig{CONFIG_BT_SMP} is enabled and a
+ *          pairing procedure is already in progress.
+ *
+ *  @retval -ENOBUFS Not buffers available to send request to controller or if
+ *          @kconfig{CONFIG_BT_SMP} is enabled and no more keys could be stored.
+ *
+ *  @retval -ENOMEM If @kconfig{CONFIG_BT_SMP} is enabled and no more keys
+ *          could be stored.
+ *
+ *  @retval -EIO Controller rejected the request or if @kconfig{CONFIG_BT_SMP}
+ *          is enabled and pairing has timed out.
+ *
+ *  @retval -ENOTCONN If @kconfig{CONFIG_BT_SMP} is enabled the ACL is not
+ *          connected.
  */
 int bt_iso_chan_connect(const struct bt_iso_connect_param *param, size_t count);
 


### PR DESCRIPTION
Per the HCI spec it is not possible to send the
HCI_LE_Create_CIS command while an outstanding request
is pending. To avoid failing the command we can
check and verify if any ISO connections are in the
pending state.
    
Since multiple ISO channels can be connected
in a single request, the solution implemented was
to iterate over all ISO connections and see if there was
any unicast ISO channels in the connecting state.
    
It also checks for the encryption pending state, as
we should not start the encryption procedure if we know
that the connect ISO command cannot be completed afterwards.

This adds a new return value to bt_iso_chan_connect,
and decided to properly document the return values the
function can return.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>

fixes https://github.com/zephyrproject-rtos/zephyr/issues/46829