### PR TITLE
drivers/timer/apic_tsc: Select the 64-bit cycle counter in deadline mode

### DIFF
--- a/drivers/timer/Kconfig.apic
+++ b/drivers/timer/Kconfig.apic
@@ -56,6 +56,7 @@ config APIC_TSC_DEADLINE_TIMER
 	depends on X86
 	select LOAPIC
 	select TICKLESS_CAPABLE
+	select TIMER_HAS_64BIT_CYCLE_COUNTER
 	help
 	  Extremely simple timer driver based the local APIC TSC
 	  deadline capability.  The use of a free-running 64 bit


### PR DESCRIPTION
When using the APIC imer in TSC deadline mode, also enable reading the
full 64-bit cycle counter value (via the k_cycle_get_64() call).

Signed-off-by: Bruno Achauer <bruno.achauer@intel.com>