### PR TITLE
drivers: modem: gsm: Add optional pin control

### DIFF
--- a/dts/bindings/modem/zephyr,gsm-ppp.yaml
+++ b/dts/bindings/modem/zephyr,gsm-ppp.yaml
@@ -6,3 +6,30 @@ description: GSM PPP modem
 compatible: "zephyr,gsm-ppp"
 
 include: uart-device.yaml
+
+properties:
+    label:
+      required: true
+
+    mdm-restart-gpios:
+      type: phandle-array
+      required: false
+      description: Pin to restart modem can be a reset or a power pin.
+
+    mdm-off-delay:
+      type: int
+      required: false
+      description: Delay in ms after disabling modem.
+
+    mdm-on-delay:
+      type: int
+      required: false
+      description: Delay in ms after enabling modem.
+
+    mdm-dtr-gpios:
+      type: phandle-array
+      required: false
+
+    mdm-wdisable-gpios:
+      type: phandle-array
+      required: false


### PR DESCRIPTION
Add restart (can be reset or power) and on/off timing, drt,
and wdisable pins to improve start or restart of modem.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/47324

Signed-off-by: Jeppe Odgaard <jeppe.odgaard@prevas.dk>