### PR TITLE
soc: select HAS_MCUX_SRC for MIMXRT1052

### DIFF
--- a/soc/arm/nxp_imx/rt/Kconfig.soc
+++ b/soc/arm/nxp_imx/rt/Kconfig.soc
@@ -182,6 +182,7 @@ config SOC_MIMXRT1052
 	select HAS_MCUX_DCDC
 	select HAS_MCUX_PMU
 	select HAS_MCUX_IOMUXC
+	select HAS_MCUX_SRC
 	select HAS_SWO
 
 config SOC_MIMXRT1061


### PR DESCRIPTION
Select missing HAS_MCUX_SRC Kconfig symbol for MIMXRT1052, that allows using NXP i.MX mcux SRC hwinfo driver.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/47025

Signed-off-by: Jeppe Odgaard <jeppe.odgaard@prevas.dk>