### PR TITLE
west: zcmake.py: support UNINITIALIZED type if CMakeCache.txt file

### DIFF
--- a/scripts/west_commands/zcmake.py
+++ b/scripts/west_commands/zcmake.py
@@ -124,6 +124,7 @@ class CMakeCacheEntry:
     BOOL          bool
     INTERNAL      str OR list of str (if ';' is in the value)
     STATIC        str OR list of str (if ';' is in the value)
+    UNINITIALIZED str OR list of str (if ';' is in the value)
     ----------    -------------------------------------------
     '''
 
@@ -135,9 +136,9 @@ class CMakeCacheEntry:
     # the first colon (':'). This breaks if the variable name has a
     # colon inside, but it's good enough.
     CACHE_ENTRY = re.compile(
-        r'''(?P<name>.*?)                                      # name
-         :(?P<type>FILEPATH|PATH|STRING|BOOL|INTERNAL|STATIC)  # type
-         =(?P<value>.*)                                        # value
+        r'''(?P<name>.*?)                                                   # name
+         :(?P<type>FILEPATH|PATH|STRING|BOOL|INTERNAL|STATIC|UNINITIALIZED) # type
+         =(?P<value>.*)                                                     # value
         ''', re.X)
 
     @classmethod
@@ -188,7 +189,7 @@ class CMakeCacheEntry:
             except ValueError as exc:
                 args = exc.args + ('on line {}: {}'.format(line_no, line),)
                 raise ValueError(args) from exc
-        elif type_ in {'STRING', 'INTERNAL', 'STATIC'}:
+        elif type_ in {'STRING', 'INTERNAL', 'STATIC', 'UNINITIALIZED'}:
             # If the value is a CMake list (i.e. is a string which
             # contains a ';'), convert to a Python list.
             if ';' in value:


### PR DESCRIPTION
A variable set by the user with `-DVAR=<val>` will be given the type
UNINITIALIZED.

This results in the variable not being read into the cmake_cache.

Support reading of CMake cache variables of type UNINITIALIZED.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>