### PR TITLE
include: dt-bindings: clocks: stm32f4: Source clocks cleanup

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32f4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32f4_clock.h
@@ -22,18 +22,9 @@
 /** Peripheral clock sources */
 /* RM0386, 0390, 0402, 0430 § Dedicated Clock configuration register (RCC_DCKCFGRx) */
 
-/** Fixed clocks  */
-#define STM32_SRC_HSI		0x001
-#define STM32_SRC_LSE		0x002
-#define STM32_SRC_LSI		0x003
-/* #define STM32_SRC_HSI48	0x004 */
-/** System clock */
-/* #define STM32_SRC_SYSCLK	0x005 */
-/** Bus clock */
-#define STM32_SRC_PCLK		0x006
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P	0x007
-#define STM32_SRC_PLL_Q	0x008
-#define STM32_SRC_PLL_R	0x009
+#define STM32_SRC_PLL_P	0x001
+#define STM32_SRC_PLL_Q	0x002
+#define STM32_SRC_PLL_R	0x003
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_CLOCK_STM32F4_CLOCK_H_ */


### PR DESCRIPTION
For now, on stm32f4 series, we only define PLL_P, PLL_Q and PLL_R
source clocks are they are required by the driver to allow configuration
of respective PLL outputs.
No other source clock are supported yet.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>