### PR TITLE
drivers: adding soc.h to crypto_stm32.c

### DIFF
--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -12,6 +12,7 @@
 #include <zephyr/drivers/clock_control/stm32_clock_control.h>
 #include <zephyr/drivers/clock_control.h>
 #include <zephyr/sys/byteorder.h>
+#include <soc.h>
 
 #include "crypto_stm32_priv.h"
 


### PR DESCRIPTION
soc.h needs to be added to fix build issue, described in https://github.com/zephyrproject-rtos/zephyr/issues/47379
Signed-off-by: tobias-aunbol <ext-tba@trackunit.com>