### PR TITLE
arch: introduce config DCLS

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -591,7 +591,7 @@ config CPU_HAS_TEE
 config CPU_HAS_DCLS
 	bool
 	help
-	  This option is enabled when the processor hardware is configured in
+	  This option is enabled when the processor hardware has support for
 	  Dual-redundant Core Lock-step (DCLS) topology.
 
 config CPU_HAS_FPU
@@ -651,6 +651,16 @@ config ARCH_MAPS_ALL_RAM
 	  virtual address space. The kernel's page frame ontology will not consider
 	  this mapping at all; non-kernel pages will be considered free (unless marked
 	  as reserved) and Z_PAGE_FRAME_MAPPED will not be set.
+
+config DCLS
+	bool "Processor is configured in DCLS mode"
+	depends on CPU_HAS_DCLS
+	default y
+	help
+	  This option is enabled when the processor hardware is configured in
+	  Dual-redundant Core Lock-step (DCLS) topology. For the processor that
+	  supports DCLS, but is configured in split-lock mode (by default or
+	  changed at flash time), this option should be disabled.
 
 menuconfig MPU
 	bool "MPU features"

--- a/arch/arm/core/aarch32/cortex_a_r/reset.S
+++ b/arch/arm/core/aarch32/cortex_a_r/reset.S
@@ -76,7 +76,7 @@ SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start)
 EL1_Reset_Handler:
 
 #endif
-#if defined(CONFIG_CPU_HAS_DCLS)
+#if defined(CONFIG_DCLS)
     /*
      * Initialise CPU registers to a defined state if the processor is
      * configured as Dual-redundant Core Lock-step (DCLS). This is required
@@ -194,7 +194,7 @@ EL1_Reset_Handler:
     vmsr fpexc, r1
 #endif /* CONFIG_FPU && CONFIG_CPU_HAS_VFP */
 
-#endif /* CONFIG_CPU_HAS_DCLS */
+#endif /* CONFIG_DCLS */
 
     /*
      * Configure stack.

--- a/cmake/compiler/gcc/target_arm.cmake
+++ b/cmake/compiler/gcc/target_arm.cmake
@@ -14,7 +14,7 @@ if(CONFIG_FPU)
   list(APPEND TOOLCHAIN_C_FLAGS   -mfpu=${GCC_M_FPU})
   list(APPEND TOOLCHAIN_LD_FLAGS  -mfpu=${GCC_M_FPU})
 
-  if(CONFIG_CPU_HAS_DCLS AND NOT CONFIG_FP_HARDABI)
+  if(CONFIG_DCLS AND NOT CONFIG_FP_HARDABI)
     # If the processor is equipped with VFP and configured in DCLS topology,
     # the FP "hard" ABI must be used in order to facilitate the FP register
     # initialisation and synchronisation.


### PR DESCRIPTION
Some processors support Dual-redundant Core Lock-step
(DCLS) topology but the processor still can be ran in
split-lock mode (by default or changed at flash time).
So, introduce config DCLS that is enabled by default if
config CPU_HAS_DCLS is set, it should be disabled if
processor is used in split-lock mode.

Signed-off-by: Dat Nguyen Duy <dat.nguyenduy@nxp.com>