### PR TITLE
drivers: intc_gicv3: configuring affinity to PE

### DIFF
--- a/drivers/interrupt_controller/intc_gicv3.c
+++ b/drivers/interrupt_controller/intc_gicv3.c
@@ -103,6 +103,20 @@ static bool arm_gic_lpi_is_enabled(unsigned int intid)
 }
 #endif
 
+#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
+static inline void arm_gic_write_irouter(uint64_t val, unsigned int intid)
+{
+	mem_addr_t addr = IROUTER(GET_DIST_BASE(intid), intid);
+
+#ifdef CONFIG_ARM
+	sys_write32((uint32_t)val, addr);
+	sys_write32((uint32_t)(val >> 32U), addr + 4);
+#else
+	sys_write64(val, addr);
+#endif
+}
+#endif
+
 void arm_gic_irq_set_priority(unsigned int intid,
 			      unsigned int prio, uint32_t flags)
 {
@@ -152,15 +166,15 @@ void arm_gic_irq_enable(unsigned int intid)
 
 	sys_write32(mask, ISENABLER(GET_DIST_BASE(intid), idx));
 
-#ifdef CONFIG_ARMV8_A_NS
+#if defined(CONFIG_ARMV8_A_NS) || defined(CONFIG_GIC_SINGLE_SECURITY_STATE)
 	/*
-	 * Affinity routing is enabled for Non-secure state (GICD_CTLR.ARE_NS
-	 * is set to '1' when GIC distributor is initialized) ,so need to set
-	 * SPI's affinity, now set it to be the PE on which it is enabled.
+	 * Affinity routing is enabled for Armv8-A Non-secure state (GICD_CTLR.ARE_NS
+	 * is set to '1') and for GIC single security state (GICD_CTRL.ARE is set to '1'),
+	 * so need to set SPI's affinity, now set it to be the PE on which it is enabled.
 	 */
-	if (GIC_IS_SPI(intid))
-		sys_write64(MPIDR_TO_CORE(GET_MPIDR()),
-				IROUTER(GET_DIST_BASE(intid), intid));
+	if (GIC_IS_SPI(intid)) {
+		arm_gic_write_irouter(MPIDR_TO_CORE(GET_MPIDR()), intid);
+	}
 #endif
 }
 


### PR DESCRIPTION
For Arm Cortex-family processors that only support single
sercurity state, (GICD_CTRL.ARE is set to '1'), so need to
set SPI's affinity for the PE which it is enabled.

Signed-off-by: Dat Nguyen Duy <dat.nguyenduy@nxp.com>