### PR TITLE
include: Add __ASSERT_OR, (__ASSERT w/ fallback)

### DIFF
--- a/include/zephyr/sys/__assert.h
+++ b/include/zephyr/sys/__assert.h
@@ -114,6 +114,8 @@ void assert_post_action(const char *file, unsigned int line);
 		__ASSERT(test, fmt, ##__VA_ARGS__);                \
 	} while (false)
 
+#define __ASSERT_OR(test, expr, fmt, ...) __ASSERT(test, fmt, ##__VA_ARGS__)
+
 #if (__ASSERT_ON == 1)
 #warning "__ASSERT() statements are ENABLED"
 #endif
@@ -121,11 +123,13 @@ void assert_post_action(const char *file, unsigned int line);
 #define __ASSERT(test, fmt, ...) { }
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_OR(test, expr, fmt, ...) expr
 #endif
 #else
 #define __ASSERT(test, fmt, ...) { }
 #define __ASSERT_EVAL(expr1, expr2, test, fmt, ...) expr1
 #define __ASSERT_NO_MSG(test) { }
+#define __ASSERT_OR(test, expr, fmt, ...) expr
 #endif
 
 #endif /* ZEPHYR_INCLUDE_SYS___ASSERT_H_ */


### PR DESCRIPTION
Sometimes a variable is used only in an assertion statement.  When
assertions are disabled, this can generate a compiler warning, such as
"unused variable" or "variable is set but not used".

__ASSERT_OR allows a fallback expression to ignore the unused variable
with a void statement when assertions are disabled.

__ASSERT_OR is more lightweight then __ASSERT_EVAL, as it does not
require an extra expression to be evaluated during the assertion path.

Signed-off-by: thomas <thomas.chiantia@gmail.com>