### PR TITLE
doc: release-notes: Re-instanciate Devicetree section

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -165,8 +165,15 @@ Networking
 USB
 ***
 
-Build and Infrastructure
-************************
+Build System
+************
+
+Devicetree
+**********
+
+* API
+
+* Bindings
 
 Libraries / Subsystems
 **********************


### PR DESCRIPTION
A Devicetree section was added in release-notes-3.1 document,
but not reported in release-notes-3.2.rst.

Add it back, as this topic deserves its own section.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>