### PR TITLE
intel_adsp: ace: Fix function return

### DIFF
--- a/soc/xtensa/intel_adsp/ace_v1x/irq.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/irq.c
@@ -44,7 +44,7 @@ int z_soc_irq_is_enabled(unsigned int irq)
 
 	if (!device_is_ready(dev)) {
 		LOG_DBG("board: ACE V1X device is not ready");
-		return;
+		return -ENODEV;
 	}
 
 	api = (const struct dw_ace_v1_ictl_driver_api *)dev->api;


### PR DESCRIPTION
zephyr/soc/xtensa/intel_adsp/ace_v1x/irq.c: In function
'z_soc_irq_is_enabled':

zephyr/soc/xtensa/intel_adsp/ace_v1x/irq.c:47:3: warning: 'return'
with no value, in function returning non-void [-Wreturn-type]

   47 |   return;

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>