### PR TITLE
Counter support stm32l4 series

### DIFF
--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -282,6 +282,12 @@
 				label = "PWM_2";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_2";
+			};
 		};
 
 		timers6: timers@40001000 {
@@ -293,6 +299,12 @@
 			st,prescaler = <0>;
 			status = "disabled";
 			label = "TIMERS_6";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_6";
+			};
 		};
 
 		timers15: timers@40014000 {
@@ -311,6 +323,12 @@
 				label = "PWM_15";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_15";
+			};
 		};
 
 		timers16: timers@40014400 {
@@ -328,6 +346,12 @@
 				status = "disabled";
 				label = "PWM_16";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_16";
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l432.dtsi
+++ b/dts/arm/st/l4/stm32l432.dtsi
@@ -28,6 +28,12 @@
 			st,prescaler = <0>;
 			status = "disabled";
 			label = "TIMERS_7";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_7";
+			};
 		};
 
 		can1: can@40006400 {

--- a/dts/arm/st/l4/stm32l452.dtsi
+++ b/dts/arm/st/l4/stm32l452.dtsi
@@ -124,6 +124,12 @@
 				label = "PWM_3";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_3";
+			};
 		};
 
 		dac1: dac@40007400 {

--- a/dts/arm/st/l4/stm32l471.dtsi
+++ b/dts/arm/st/l4/stm32l471.dtsi
@@ -125,6 +125,12 @@
 				label = "PWM_3";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_3";
+			};
 		};
 
 		timers4: timers@40000800 {
@@ -142,6 +148,12 @@
 				status = "disabled";
 				label = "PWM_4";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_4";
 			};
 		};
 
@@ -161,6 +173,12 @@
 				label = "PWM_5";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_5";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -172,6 +190,12 @@
 			st,prescaler = <0>;
 			status = "disabled";
 			label = "TIMERS_7";
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_7";
+			};
 		};
 
 		timers8: timers@40013400 {
@@ -207,6 +231,12 @@
 				status = "disabled";
 				label = "PWM_17";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_17";
 			};
 		};
 

--- a/dts/arm/st/l4/stm32l4r5.dtsi
+++ b/dts/arm/st/l4/stm32l4r5.dtsi
@@ -152,6 +152,12 @@
 				label = "PWM_3";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_3";
+			};
 		};
 
 		timers4: timers@40000800 {
@@ -169,6 +175,12 @@
 				status = "disabled";
 				label = "PWM_4";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_4";
 			};
 		};
 
@@ -188,6 +200,12 @@
 				label = "PWM_5";
 				#pwm-cells = <3>;
 			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_5";
+			};
 		};
 
 		timers7: timers@40001400 {
@@ -205,6 +223,12 @@
 				status = "disabled";
 				label = "PWM_7";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_7";
 			};
 		};
 
@@ -241,6 +265,12 @@
 				status = "disabled";
 				label = "PWM_17";
 				#pwm-cells = <3>;
+			};
+
+			counter {
+				compatible = "st,stm32-counter";
+				status = "disabled";
+				label = "COUNTER_17";
 			};
 		};
 

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_l433rc_p.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_l433rc_p.overlay
@@ -1,0 +1,38 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&rtc {
+	status = "disabled";
+};

--- a/tests/drivers/counter/counter_basic_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/nucleo_l476rg.overlay
@@ -1,0 +1,66 @@
+&timers2 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers3 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers4 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers5 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers6 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers7 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers15 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers16 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&timers17 {
+	st,prescaler = <79>;
+	counter {
+		status = "okay";
+	};
+};
+
+&rtc {
+	status = "disabled";
+};


### PR DESCRIPTION
The patch adds the counter API support for the STM32L4 series. 
There are no changes to the previously implemented driver for the STM32F4 series (see #39414). Only device tree and test suite extensions where necessary, to confirm the ability of the existing driver for the STM32L4 series.
The test are implemented and run on nucleo_l476rg and nucleo_l433rc_p boards.

(A previous qualification alongside of the implementation were prevented by missing test capabilities of the original author)