### PR TITLE
soc: cavs15: disable hda link in/out

### DIFF
--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -167,7 +167,7 @@
 			dma-buf-alignment = <128>;
 			label = "HDA_LINK_OUT";
 
-			status = "okay";
+			status = "disabled";
 		};
 
 		hda_link_in: dma@2600 {
@@ -178,7 +178,7 @@
 			dma-buf-alignment = <128>;
 			label = "HDA_LINK_IN";
 
-			status = "okay";
+			status = "disabled";
 		};
 
 		hda_host_out: dma@2800 {


### PR DESCRIPTION
This seems to cause a crash when running tests/boards/intel_adsp/hda and
also causing issues downstream on SOF.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
