### PR TITLE
drivers/flash: stm32g0: Prepare for unaligned accesses in flash writes

### DIFF
--- a/drivers/flash/flash_stm32g0x.c
+++ b/drivers/flash/flash_stm32g0x.c
@@ -194,7 +194,8 @@ int flash_stm32_write_range(const struct device *dev, unsigned int offset,
 	int i, rc = 0;
 
 	for (i = 0; i < len; i += 8, offset += 8) {
-		rc = write_dword(dev, offset, ((const uint64_t *) data)[i>>3]);
+		rc = write_dword(dev, offset,
+				UNALIGNED_GET((const uint64_t *) data + (i >> 3)));
 		if (rc < 0) {
 			return rc;
 		}


### PR DESCRIPTION
When using the settings subsystem, the data argument argument passed to
flash_stm32_write_range() might not be 8-bytes aligned, causing an
unaligned memory access fault.

Fix that the same way as it was done for the STM32L4 in commit
652efa530f13e1232350f8e19e78cb03f00fa991.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>