### PR TITLE
docs: Raspberry Pi Pico board page document fix for pwm

### DIFF
--- a/boards/arm/rpi_pico/doc/index.rst
+++ b/boards/arm/rpi_pico/doc/index.rst
@@ -71,8 +71,8 @@ hardware features:
      - :kconfig:option:`CONFIG_WATCHDOG`
      - :dtcompatible:`raspberrypi,pico-watchdog`
    * - PWM
-     - :kconfig: `CONFIG_PWM`
-     - :dtcompatible: `raspberrypi,pico-pwm`
+     - :kconfig:option:`CONFIG_PWM`
+     - :dtcompatible:`raspberrypi,pico-pwm`
 
 Programming and Debugging
 *************************


### PR DESCRIPTION
https://docs.zephyrproject.org/latest/boards/arm/rpi_pico/doc/index.html

There was a format problem on Supported Features table last element of pwm.

<img width="870" alt="Screen Shot 2022-07-09 at 19 33 55" src="https://user-images.githubusercontent.com/76992231/178102249-06a1c2a3-2f9e-425c-a307-8f8cf92b607b.png">

