### PR TITLE
device: rework `gen_handles.py`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 \#*\#
 build*/
 !doc/build/
+!scripts/build
 !tests/drivers/build_all
 cscope.*
 .dir

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -872,6 +872,7 @@ if(CONFIG_HAS_DTS)
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/build/gen_handles.py
     --output-source dev_handles.c
+    --output-graphviz dev_graph.dot
     --num-dynamic-devices ${number_of_dynamic_devices}
     --kernel $<TARGET_FILE:${ZEPHYR_LINK_STAGE_EXECUTABLE}>
     --zephyr-base ${ZEPHYR_BASE}

--- a/include/zephyr/pm/device.h
+++ b/include/zephyr/pm/device.h
@@ -190,7 +190,7 @@ struct pm_device {
  *
  * @param dev_name Device name.
  */
-#define Z_PM_DEVICE_NAME(dev_name) _CONCAT(__pm_device__, dev_name)
+#define Z_PM_DEVICE_NAME(dev_name) _CONCAT(__pm_device_, dev_name)
 
 /**
  * @brief Define device PM slot.
@@ -205,7 +205,7 @@ struct pm_device {
  */
 #define Z_PM_DEVICE_DEFINE_SLOT(dev_name)				\
 	static const Z_DECL_ALIGN(struct device *)			\
-	_CONCAT(Z_PM_DEVICE_NAME(dev_name), _slot) __used		\
+	_CONCAT(__pm_slot_, dev_name) __used				\
 	__attribute__((__section__(".z_pm_device_slots")))
 
 #ifdef CONFIG_PM_DEVICE

--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+#
+# Copyright (c) 2022, CSIRO
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import struct
+import sys
+from packaging import version
+
+import elftools
+from elftools.elf.elffile import ELFFile
+from elftools.elf.sections import SymbolTableSection
+
+if version.parse(elftools.__version__) < version.parse('0.24'):
+    sys.exit("pyelftools is out of date, need version 0.24 or later")
+
+class _Symbol:
+    """
+    Parent class for objects derived from an elf symbol.
+    """
+    def __init__(self, elf, sym):
+        self.elf = elf
+        self.sym = sym
+        self.data = self.elf.symbol_data(sym)
+
+    def _data_native_read(self, offset):
+        (format, size) = self.elf.native_struct_format
+        return struct.unpack(format, self.data[offset:offset + size])[0]
+
+class DevicePM(_Symbol):
+    """
+    Represents information about device PM capabilities.
+    """
+    required_ld_consts = [
+        "_PM_DEVICE_STRUCT_FLAGS_OFFSET",
+        "_PM_DEVICE_FLAG_PD"
+    ]
+
+    def __init__(self, elf, sym):
+        super().__init__(elf, sym)
+        self.flags = self._data_native_read(self.elf.ld_consts['_PM_DEVICE_STRUCT_FLAGS_OFFSET'])
+
+    @property
+    def is_power_domain(self):
+        return self.flags & (1 << self.elf.ld_consts["_PM_DEVICE_FLAG_PD"])
+
+class DeviceOrdinals(_Symbol):
+    """
+    Represents information about device dependencies.
+    """
+    DEVICE_HANDLE_SEP = -32768
+    DEVICE_HANDLE_ENDS = 32767
+    DEVICE_HANDLE_NULL = 0
+
+    def __init__(self, elf, sym):
+        super().__init__(elf, sym)
+        format = "<" if self.elf.little_endian else ">"
+        format += "{:d}h".format(len(self.data) // 2)
+        self._ordinals = struct.unpack(format, self.data)
+        self._ordinals_split = []
+
+        # Split ordinals on DEVICE_HANDLE_SEP
+        prev =  1
+        for idx, val in enumerate(self._ordinals, 1):
+            if val == self.DEVICE_HANDLE_SEP:
+                self._ordinals_split.append(self._ordinals[prev:idx-1])
+                prev = idx
+        self._ordinals_split.append(self._ordinals[prev:])
+
+    @property
+    def self_ordinal(self):
+        return self._ordinals[0]
+
+    @property
+    def ordinals(self):
+        return self._ordinals_split
+
+class Device(_Symbol):
+    """
+    Represents information about a device object and its references to other objects.
+    """
+    required_ld_consts = [
+        "_DEVICE_STRUCT_HANDLES_OFFSET",
+        "_DEVICE_STRUCT_PM_OFFSET"
+    ]
+
+    def __init__(self, elf, sym):
+        super().__init__(elf, sym)
+        self.edt_node = None
+        self.handle = None
+        self.ordinals = None
+        self.pm = None
+
+        # Devicetree dependencies, injected dependencies, supported devices
+        self.devs_depends_on = set()
+        self.devs_depends_on_injected = set()
+        self.devs_supports = set()
+
+        # Point to the handles instance associated with the device;
+        # assigned by correlating the device struct handles pointer
+        # value with the addr of a Handles instance.
+        ordinal_offset = self.elf.ld_consts['_DEVICE_STRUCT_HANDLES_OFFSET']
+        self.obj_ordinals = self._data_native_read(ordinal_offset)
+        self.obj_pm = None
+        if '_DEVICE_STRUCT_PM_OFFSET' in self.elf.ld_consts:
+            pm_offset = self.elf.ld_consts['_DEVICE_STRUCT_PM_OFFSET']
+            self.obj_pm = self._data_native_read(pm_offset)
+
+    @property
+    def ordinal(self):
+        return self.ordinals.self_ordinal
+
+class ZephyrElf:
+    """
+    Represents information about devices in an elf file.
+    """
+    def __init__(self, kernel, edt, device_start_symbol):
+        self.elf = ELFFile(open(kernel, "rb"))
+        self.edt = edt
+        self.devices = []
+        self.ld_consts = self._symbols_find_value(set([device_start_symbol, *Device.required_ld_consts, *DevicePM.required_ld_consts]))
+        self._device_parse_and_link()
+
+    @property
+    def little_endian(self):
+        """
+        True if the elf file is for a little-endian architecture.
+        """
+        return self.elf.little_endian
+
+    @property
+    def native_struct_format(self):
+        """
+        Get the struct format specifier and byte size of the native machine type.
+        """
+        format = "<" if self.little_endian else ">"
+        if self.elf.elfclass == 32:
+            format += "I"
+            size = 4
+        else:
+            format += "Q"
+            size = 8
+        return (format, size)
+
+    def symbol_data(self, sym):
+        """
+        Retrieve the raw bytes associated with a symbol from the elf file.
+        """
+        addr = sym.entry.st_value
+        len = sym.entry.st_size
+        for section in self.elf.iter_sections():
+            start = section['sh_addr']
+            end = start + section['sh_size']
+
+            if (start <= addr) and (addr + len) <= end:
+                offset = addr - section['sh_addr']
+                return bytes(section.data()[offset:offset + len])
+
+    def _symbols_find_value(self, names):
+        symbols = {}
+        for section in self.elf.iter_sections():
+            if isinstance(section, SymbolTableSection):
+                for sym in section.iter_symbols():
+                    if sym.name in names:
+                        symbols[sym.name] = sym.entry.st_value
+        return symbols
+
+    def _object_find_named(self, prefix, cb):
+        for section in self.elf.iter_sections():
+            if isinstance(section, SymbolTableSection):
+                for sym in section.iter_symbols():
+                    if sym.entry.st_info.type != 'STT_OBJECT':
+                        continue
+                    if sym.name.startswith(prefix):
+                        cb(sym)
+
+    def _link_devices(self, devices):
+        # Compute the dependency graph induced from the full graph restricted to the
+        # the nodes that exist in the application.  Note that the edges in the
+        # induced graph correspond to paths in the full graph.
+        root = self.edt.dep_ord2node[0]
+
+        for ord, dev in devices.items():
+            n = self.edt.dep_ord2node[ord]
+
+            deps = set(n.depends_on)
+            while len(deps) > 0:
+                dn = deps.pop()
+                if dn.dep_ordinal in devices:
+                    # this is used
+                    dev.devs_depends_on.add(devices[dn.dep_ordinal])
+                elif dn != root:
+                    # forward the dependency up one level
+                    for ddn in dn.depends_on:
+                        deps.add(ddn)
+
+            sups = set(n.required_by)
+            while len(sups) > 0:
+                sn = sups.pop()
+                if sn.dep_ordinal in devices:
+                    dev.devs_supports.add(devices[sn.dep_ordinal])
+                else:
+                    # forward the support down one level
+                    for ssn in sn.required_by:
+                        sups.add(ssn)
+
+    def _link_injected(self, devices):
+        for dev in devices.values():
+            injected = dev.ordinals.ordinals[1]
+            for inj in injected:
+                if inj in devices:
+                    dev.devs_depends_on_injected.add(devices[inj])
+
+    def _device_parse_and_link(self):
+        # Find all PM structs
+        pm_structs = {}
+        def _on_pm(sym):
+            pm_structs[sym.entry.st_value] = DevicePM(self, sym)
+        self._object_find_named('__pm_device_', _on_pm)
+
+        # Find all ordinal arrays
+        ordinal_arrays = {}
+        def _on_ordinal(sym):
+            ordinal_arrays[sym.entry.st_value] = DeviceOrdinals(self, sym)
+        self._object_find_named('__devicehdl_', _on_ordinal)
+
+        # Find all device structs
+        def _on_device(sym):
+            self.devices.append(Device(self, sym))
+        self._object_find_named('__device_', _on_device)
+
+        # Sort the device array by address for handle calculation
+        self.devices = sorted(self.devices, key = lambda k: k.sym.entry.st_value)
+
+        # Assign handles to the devices
+        for idx, dev in enumerate(self.devices):
+            dev.handle = 1 + idx
+
+        # Link devices structs with PM and ordinals
+        for dev in self.devices:
+            if dev.obj_pm in pm_structs:
+                dev.pm = pm_structs[dev.obj_pm]
+            if dev.obj_ordinals in ordinal_arrays:
+                dev.ordinals = ordinal_arrays[dev.obj_ordinals]
+                if dev.ordinal != DeviceOrdinals.DEVICE_HANDLE_NULL:
+                    dev.edt_node = self.edt.dep_ord2node[dev.ordinal]
+
+        # Create mapping of ordinals to devices
+        devices_by_ord = {d.ordinal: d for d in self.devices if d.edt_node}
+
+        # Link devices to each other based on the EDT tree
+        self._link_devices(devices_by_ord)
+
+        # Link injected devices to each other
+        self._link_injected(devices_by_ord)

--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -211,6 +211,7 @@ class ZephyrElf:
             for inj in injected:
                 if inj in devices:
                     dev.devs_depends_on_injected.add(devices[inj])
+                    devices[inj].devs_supports.add(dev)
 
     def _device_parse_and_link(self):
         # Find all PM structs

--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -254,3 +254,25 @@ class ZephyrElf:
 
         # Link injected devices to each other
         self._link_injected(devices_by_ord)
+
+    def device_dependency_graph(self, title, comment):
+        """
+        Construct a graphviz Digraph of the relationships between devices.
+        """
+        import graphviz
+        dot = graphviz.Digraph(title, comment=comment)
+        # Split iteration so nodes and edges are grouped in source
+        for dev in self.devices:
+            if dev.ordinal == DeviceOrdinals.DEVICE_HANDLE_NULL:
+                text = '{:s}\\nHandle: {:d}'.format(dev.sym.name, dev.handle)
+            else:
+                n = self.edt.dep_ord2node[dev.ordinal]
+                label = n.labels[0] if n.labels else n.label
+                text = '{:s}\\nOrdinal: {:d} | Handle: {:d}\\n{:s}'.format(
+                    label, dev.ordinal, dev.handle, n.path
+                )
+            dot.node(str(dev.ordinal), text)
+        for dev in self.devices:
+            for sup in dev.devs_supports:
+                dot.edge(str(dev.ordinal), str(sup.ordinal))
+        return dot

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -29,29 +29,14 @@ driver-specific object file.
 import sys
 import argparse
 import os
-import struct
 import pickle
-from packaging import version
 
-import elftools
-from elftools.elf.elffile import ELFFile
-from elftools.elf.sections import SymbolTableSection
-import elftools.elf.enums
+from elf_parser import ZephyrElf
 
 # This is needed to load edt.pickle files.
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..',
                                 'dts', 'python-devicetree', 'src'))
 from devicetree import edtlib  # pylint: disable=unused-import
-
-if version.parse(elftools.__version__) < version.parse('0.24'):
-    sys.exit("pyelftools is out of date, need version 0.24 or later")
-
-scr = os.path.basename(sys.argv[0])
-
-def debug(text):
-    if not args.verbose:
-        return
-    sys.stdout.write(scr + ": " + text + "\n")
 
 def parse_args():
     global args
@@ -65,24 +50,17 @@ def parse_args():
     parser.add_argument("-d", "--num-dynamic-devices", required=False, default=0,
                         type=int, help="Input number of dynamic devices allowed")
     parser.add_argument("-o", "--output-source", required=True,
-            help="Output source file")
-
-    parser.add_argument("-v", "--verbose", action="store_true",
-                        help="Print extra debugging information")
-
+                        help="Output source file")
     parser.add_argument("-z", "--zephyr-base",
                         help="Path to current Zephyr base. If this argument \
                         is not provided the environment will be checked for \
                         the ZEPHYR_BASE environment variable.")
-
     parser.add_argument("-s", "--start-symbol", required=True,
                         help="Symbol name of the section which contains the \
                         devices. The symbol name must point to the first \
                         device in that section.")
 
     args = parser.parse_args()
-    if "VERBOSE" in os.environ:
-        args.verbose = 1
 
     ZEPHYR_BASE = args.zephyr_base or os.getenv("ZEPHYR_BASE")
 
@@ -92,345 +70,60 @@ def parse_args():
 
     sys.path.insert(0, os.path.join(ZEPHYR_BASE, "scripts/dts"))
 
+def c_handle_comment(dev):
+    def dev_path_str(dev):
+        return dev.edt_node and dev.edt_node.path or dev.sym.name
+    lines = [
+        '',
+        '/* {:d} : {:s}:'.format(dev.handle, (dev_path_str(dev))),
+    ]
+    if len(dev.devs_depends_on) > 0:
+        lines.append(' * Direct Dependencies:')
+        for dep in dev.devs_depends_on:
+            lines.append(' *    - {:s}'.format(dev_path_str(dep)))
+    if len(dev.devs_depends_on_injected) > 0:
+        lines.append(' * Injected Dependencies:')
+        for dep in dev.devs_depends_on_injected:
+            lines.append(' *    - {:s}'.format(dev_path_str(dep)))
+    if len(dev.devs_supports) > 0:
+        lines.append(' * Supported:')
+        for sup in dev.devs_supports:
+            lines.append(' *    - {:s}'.format(dev_path_str(sup)))
+    lines.append(' */')
+    return lines
 
-def symbol_data(elf, sym):
-    addr = sym.entry.st_value
-    len = sym.entry.st_size
-    for section in elf.iter_sections():
-        start = section['sh_addr']
-        end = start + section['sh_size']
-
-        if (start <= addr) and (addr + len) <= end:
-            offset = addr - section['sh_addr']
-            return bytes(section.data()[offset:offset + len])
-
-def symbol_handle_data(elf, sym):
-    data = symbol_data(elf, sym)
-    if data:
-        format = "<" if elf.little_endian else ">"
-        format += "%uh" % (len(data) / 2)
-        return struct.unpack(format, data)
-
-# These match the corresponding constants in <device.h>
-DEVICE_HANDLE_SEP = -32768
-DEVICE_HANDLE_ENDS = 32767
-DEVICE_HANDLE_NULL = 0
-def handle_name(hdl):
-    if hdl == DEVICE_HANDLE_SEP:
-        return "DEVICE_HANDLE_SEP"
-    if hdl == DEVICE_HANDLE_ENDS:
-        return "DEVICE_HANDLE_ENDS"
-    if hdl == 0:
-        return "DEVICE_HANDLE_NULL"
-    return str(int(hdl))
-
-class Device:
-    """
-    Represents information about a device object and its references to other objects.
-    """
-    def __init__(self, elf, ld_constants, sym, addr):
-        self.elf = elf
-        self.ld_constants = ld_constants
-        self.sym = sym
-        self.addr = addr
-        # Point to the handles instance associated with the device;
-        # assigned by correlating the device struct handles pointer
-        # value with the addr of a Handles instance.
-        self.__handles = None
-        self.__pm = None
-
-    @property
-    def obj_handles(self):
-        """
-        Returns the value from the device struct handles field, pointing to the
-        array of handles for devices this device depends on.
-        """
-        if self.__handles is None:
-            data = symbol_data(self.elf, self.sym)
-            format = "<" if self.elf.little_endian else ">"
-            if self.elf.elfclass == 32:
-                format += "I"
-                size = 4
-            else:
-                format += "Q"
-                size = 8
-            offset = self.ld_constants["_DEVICE_STRUCT_HANDLES_OFFSET"]
-            self.__handles = struct.unpack(format, data[offset:offset + size])[0]
-        return self.__handles
-
-    @property
-    def obj_pm(self):
-        """
-        Returns the value from the device struct pm field, pointing to the
-        pm struct for this device.
-        """
-        if self.__pm is None:
-            data = symbol_data(self.elf, self.sym)
-            format = "<" if self.elf.little_endian else ">"
-            if self.elf.elfclass == 32:
-                format += "I"
-                size = 4
-            else:
-                format += "Q"
-                size = 8
-            offset = self.ld_constants["_DEVICE_STRUCT_PM_OFFSET"]
-            self.__pm = struct.unpack(format, data[offset:offset + size])[0]
-        return self.__pm
-
-class PMDevice:
-    """
-    Represents information about a pm_device object and its references to other objects.
-    """
-    def __init__(self, elf, ld_constants, sym, addr):
-        self.elf = elf
-        self.ld_constants = ld_constants
-        self.sym = sym
-        self.addr = addr
-
-        # Point to the device instance associated with the pm_device;
-        self.__flags = None
-
-    def is_domain(self):
-        """
-        Checks if the device that this pm struct belongs is a power domain.
-        """
-        if self.__flags is None:
-            data = symbol_data(self.elf, self.sym)
-            format = "<" if self.elf.little_endian else ">"
-            if self.elf.elfclass == 32:
-                format += "I"
-                size = 4
-            else:
-                format += "Q"
-                size = 8
-            offset = self.ld_constants["_PM_DEVICE_STRUCT_FLAGS_OFFSET"]
-            self.__flags = struct.unpack(format, data[offset:offset + size])[0]
-        return self.__flags & (1 << self.ld_constants["_PM_DEVICE_FLAG_PD"])
-
-class Handles:
-    def __init__(self, sym, addr, handles, node):
-        self.sym = sym
-        self.addr = addr
-        self.handles = handles
-        self.node = node
-        self.dep_ord = None
-        self.dev_deps = None
-        self.ext_deps = None
+def c_handle_array(dev, extra_support_handles=0):
+    handles = [
+        *[str(d.handle) for d in dev.devs_depends_on],
+        'DEVICE_HANDLE_SEP',
+        *[str(d.handle) for d in dev.devs_depends_on_injected],
+        'DEVICE_HANDLE_SEP',
+        *[str(d.handle) for d in dev.devs_supports],
+        *(extra_support_handles * ['DEVICE_HANDLE_NULL']),
+        'DEVICE_HANDLE_ENDS',
+    ]
+    return [
+        'const device_handle_t __aligned(2) __attribute__((__section__(".__device_handles_pass2")))',
+        '{:s}[] = {{ {:s} }};'.format(dev.ordinals.sym.name, ', '.join(handles)),
+    ]
 
 def main():
     parse_args()
-
-    assert args.kernel, "--kernel ELF required to extract data"
-    elf = ELFFile(open(args.kernel, "rb"))
 
     edtser = os.path.join(os.path.split(args.kernel)[0], "edt.pickle")
     with open(edtser, 'rb') as f:
         edt = pickle.load(f)
 
-    pm_devices = {}
-    devices = []
-    handles = []
-    # Leading _ are stripped from the stored constant key
-
-    want_constants = set([args.start_symbol,
-                          "_DEVICE_STRUCT_SIZEOF",
-                          "_DEVICE_STRUCT_HANDLES_OFFSET"])
-    if args.num_dynamic_devices != 0:
-        want_constants.update(["_PM_DEVICE_FLAG_PD",
-                               "_DEVICE_STRUCT_PM_OFFSET",
-                               "_PM_DEVICE_STRUCT_FLAGS_OFFSET"])
-    ld_constants = dict()
-
-    for section in elf.iter_sections():
-        if isinstance(section, SymbolTableSection):
-            for sym in section.iter_symbols():
-                if sym.name in want_constants:
-                    ld_constants[sym.name] = sym.entry.st_value
-                    continue
-                if sym.entry.st_info.type != 'STT_OBJECT':
-                    continue
-                if sym.name.startswith("__device"):
-                    addr = sym.entry.st_value
-                    if sym.name.startswith("__device_"):
-                        devices.append(Device(elf, ld_constants, sym, addr))
-                        debug("device %s" % (sym.name,))
-                    elif sym.name.startswith("__devicehdl_"):
-                        hdls = symbol_handle_data(elf, sym)
-
-                        # The first element of the hdls array is the dependency
-                        # ordinal of the device, which identifies the devicetree
-                        # node.
-                        node = edt.dep_ord2node[hdls[0]] if (hdls and hdls[0] != 0) else None
-                        handles.append(Handles(sym, addr, hdls, node))
-                        debug("handles %s %d %s" % (sym.name, hdls[0] if hdls else -1, node))
-                if sym.name.startswith("__pm_device_"):
-                    addr = sym.entry.st_value
-                    pm_devices[addr] = PMDevice(elf, ld_constants, sym, addr)
-                    debug("pm device %s" % (sym.name,))
-
-    assert len(want_constants) == len(ld_constants), "linker map data incomplete"
-
-    devices = sorted(devices, key = lambda k: k.sym.entry.st_value)
-
-    device_start_addr = ld_constants[args.start_symbol]
-    device_size = 0
-
-    assert len(devices) == len(handles), 'mismatch devices and handles'
-
-    used_nodes = set()
-    for handle in handles:
-        handle.device = None
-        for device in devices:
-            if handle.addr == device.obj_handles:
-                handle.device = device
-                break
-        device = handle.device
-        assert device, 'no device for %s' % (handle.sym.name,)
-
-        device.handle = handle
-
-        if device_size == 0:
-            device_size = device.sym.entry.st_size
-
-        # The device handle is one plus the ordinal of this device in
-        # the device table.
-        device.dev_handle = 1 + int((device.sym.entry.st_value - device_start_addr) / device_size)
-        debug("%s dev ordinal %d" % (device.sym.name, device.dev_handle))
-
-        n = handle.node
-        if n is not None:
-            debug("%s dev ordinal %d\n\t%s" % (n.path, device.dev_handle, ' ; '.join(str(_) for _ in handle.handles)))
-            used_nodes.add(n)
-            n.__device = device
-        else:
-            debug("orphan %d" % (device.dev_handle,))
-        hv = handle.handles
-        hvi = 1
-        handle.dev_deps = []
-        handle.dev_injected = []
-        handle.dev_sups = []
-        hdls = handle.dev_deps
-        while hvi < len(hv):
-            h = hv[hvi]
-            if h == DEVICE_HANDLE_ENDS:
-                break
-            if h == DEVICE_HANDLE_SEP:
-                if hdls == handle.dev_deps:
-                    hdls = handle.dev_injected
-                else:
-                    hdls = handle.dev_sups
-            else:
-                hdls.append(h)
-                n = edt
-            hvi += 1
-
-    # Compute the dependency graph induced from the full graph restricted to the
-    # the nodes that exist in the application.  Note that the edges in the
-    # induced graph correspond to paths in the full graph.
-    root = edt.dep_ord2node[0]
-    assert root not in used_nodes
-
-    for n in used_nodes:
-        # Where we're storing the final set of nodes: these are all used
-        n.__depends = set()
-        n.__supports = set()
-
-        deps = set(n.depends_on)
-        debug("\nNode: %s\nOrig deps:\n\t%s" % (n.path, "\n\t".join([dn.path for dn in deps])))
-        while len(deps) > 0:
-            dn = deps.pop()
-            if dn in used_nodes:
-                # this is used
-                n.__depends.add(dn)
-            elif dn != root:
-                # forward the dependency up one level
-                for ddn in dn.depends_on:
-                    deps.add(ddn)
-        debug("Final deps:\n\t%s\n" % ("\n\t".join([ _dn.path for _dn in n.__depends])))
-
-        sups = set(n.required_by)
-        debug("\nOrig sups:\n\t%s" % ("\n\t".join([dn.path for dn in sups])))
-        while len(sups) > 0:
-            sn = sups.pop()
-            if sn in used_nodes:
-                # this is used
-                n.__supports.add(sn)
-            else:
-                # forward the support down one level
-                for ssn in sn.required_by:
-                    sups.add(ssn)
-        debug("\nFinal sups:\n\t%s" % ("\n\t".join([_sn.path for _sn in n.__supports])))
+    parsed_elf = ZephyrElf(args.kernel, edt, args.start_symbol)
 
     with open(args.output_source, "w") as fp:
         fp.write('#include <zephyr/device.h>\n')
         fp.write('#include <zephyr/toolchain.h>\n')
-
-        for dev in devices:
-            hs = dev.handle
-            assert hs, "no hs for %s" % (dev.sym.name,)
-            dep_paths = []
-            inj_paths = []
-            sup_paths = []
-            hdls = []
-
-            sn = hs.node
-            if sn:
-                hdls.extend(dn.__device.dev_handle for dn in sn.__depends)
-                for dn in sn.depends_on:
-                    if dn in sn.__depends:
-                        dep_paths.append(dn.path)
-                    else:
-                        dep_paths.append('(%s)' % dn.path)
-            # Force separator to signal start of injected dependencies
-            hdls.append(DEVICE_HANDLE_SEP)
-            for inj in hs.dev_injected:
-                if inj not in edt.dep_ord2node:
-                    continue
-                expected = edt.dep_ord2node[inj]
-                if expected in used_nodes:
-                    inj_paths.append(expected.path)
-                    hdls.append(expected.__device.dev_handle)
-
-            # Force separator to signal start of supported devices
-            hdls.append(DEVICE_HANDLE_SEP)
-            if len(hs.dev_sups) > 0:
-                for dn in sn.required_by:
-                    if dn in sn.__supports:
-                        sup_paths.append(dn.path)
-                    else:
-                        sup_paths.append('(%s)' % dn.path)
-                hdls.extend(dn.__device.dev_handle for dn in sn.__supports)
-
-            if args.num_dynamic_devices != 0:
-                pm = pm_devices.get(dev.obj_pm)
-                if pm and pm.is_domain():
-                    hdls.extend(DEVICE_HANDLE_NULL for dn in range(args.num_dynamic_devices))
-
-            # Terminate the array with the end symbol
-            hdls.append(DEVICE_HANDLE_ENDS)
-
-            lines = [
-                '',
-                '/* %d : %s:' % (dev.dev_handle, (sn and sn.path) or "sysinit"),
-            ]
-
-            if len(dep_paths) > 0:
-                lines.append(' * Direct Dependencies:')
-                lines.append(' *   - %s' % ('\n *   - '.join(dep_paths)))
-            if len(inj_paths) > 0:
-                lines.append(' * Injected Dependencies:')
-                lines.append(' *   - %s' % ('\n *   - '.join(inj_paths)))
-            if len(sup_paths) > 0:
-                lines.append(' * Supported:')
-                lines.append(' *   - %s' % ('\n *   - '.join(sup_paths)))
-
-            lines.extend([
-                ' */',
-                'const device_handle_t __aligned(2) __attribute__((__section__(".__device_handles_pass2")))',
-                '%s[] = { %s };' % (hs.sym.name, ', '.join([handle_name(_h) for _h in hdls])),
-                '',
-            ])
-
+        for dev in parsed_elf.devices:
+            extra_sups = args.num_dynamic_devices if dev.pm and dev.pm.is_power_domain else 0
+            lines = c_handle_comment(dev)
+            lines.extend(c_handle_array(dev, extra_sups))
+            lines.extend([''])
             fp.write('\n'.join(lines))
 
 if __name__ == "__main__":

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -51,6 +51,8 @@ def parse_args():
                         type=int, help="Input number of dynamic devices allowed")
     parser.add_argument("-o", "--output-source", required=True,
                         help="Output source file")
+    parser.add_argument("-g", "--output-graphviz",
+                        help="Output file for graphviz dependency graph")
     parser.add_argument("-z", "--zephyr-base",
                         help="Path to current Zephyr base. If this argument \
                         is not provided the environment will be checked for \
@@ -115,6 +117,15 @@ def main():
         edt = pickle.load(f)
 
     parsed_elf = ZephyrElf(args.kernel, edt, args.start_symbol)
+
+    if args.output_graphviz:
+        # Try and output the dependency tree
+        try:
+            dot = parsed_elf.device_dependency_graph('Device dependency graph', args.kernel)
+            with open(args.output_graphviz, 'w') as f:
+                f.write(dot.source)
+        except ImportError:
+            pass
 
     with open(args.output_source, "w") as fp:
         fp.write('#include <zephyr/device.h>\n')

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -263,7 +263,7 @@ def main():
                         node = edt.dep_ord2node[hdls[0]] if (hdls and hdls[0] != 0) else None
                         handles.append(Handles(sym, addr, hdls, node))
                         debug("handles %s %d %s" % (sym.name, hdls[0] if hdls else -1, node))
-                if sym.name.startswith("__pm_device__") and not sym.name.endswith("_slot"):
+                if sym.name.startswith("__pm_device_"):
                     addr = sym.entry.st_value
                     pm_devices[addr] = PMDevice(elf, ld_constants, sym, addr)
                     debug("pm device %s" % (sym.name,))

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -26,3 +26,6 @@ grpcio-tools
 
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub
+
+# used to generate devicetree dependency graphs
+graphviz

--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -60,7 +60,7 @@
 
 			test_dev_c: test-i2c-dev@13 {
 				compatible = "vnd,i2c-device";
-				label = "TEST_SPI_DEV_0";
+				label = "TEST_I2C_DEV_13";
 				reg = <0x13>;
 				status = "disabled";
 
@@ -78,6 +78,14 @@
 						reg = <0x0000C000 0x00067000>;
 					};
 				};
+			};
+
+			test-i2c-dev@14 {
+				compatible = "vnd,i2c-device";
+				status = "okay";
+				reg = <0x14>;
+				supply-gpios = <&test_gpiox 2 0>;
+				label = "TEST_I2C_DEV_14";
 			};
 		};
 

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -17,6 +17,7 @@
 #define TEST_DEVC DT_NODELABEL(test_dev_c)
 #define TEST_PARTITION DT_NODELABEL(test_p0)
 #define TEST_GPIO_INJECTED DT_NODELABEL(test_gpio_injected)
+#define TEST_NOLABEL DT_PATH(test, i2c_11112222, test_i2c_dev_14)
 
 static const struct device *devlist;
 static const struct device *devlist_end;
@@ -54,6 +55,9 @@ DEVICE_DT_DEFINE(TEST_GPIO_INJECTED, dev_init, NULL,
 /* Manually specified device */
 DEVICE_DEFINE(manual_dev, "Manual Device", dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 80, NULL);
+/* Device with no nodelabel */
+DEVICE_DT_DEFINE(TEST_NOLABEL, dev_init, NULL,
+		 NULL, NULL, POST_KERNEL, 90, NULL);
 
 #define DEV_HDL(node_id) device_handle_get(DEVICE_DT_GET(node_id))
 #define DEV_HDL_NAME(name) device_handle_get(DEVICE_GET(name))
@@ -79,6 +83,8 @@ ZTEST(devicetree_devices, test_init_get)
 		      DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
 	zassert_equal(DEVICE_INIT_GET(manual_dev)->dev,
 		      DEVICE_GET(manual_dev), NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->dev,
+		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
 
 	/* Check init functions */
 	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init, dev_init, NULL);
@@ -90,6 +96,7 @@ ZTEST(devicetree_devices, test_init_get)
 	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init, dev_init, NULL);
 	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init, dev_init, NULL);
 	zassert_equal(DEVICE_INIT_GET(manual_dev)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init, dev_init, NULL);
 }
 
 ZTEST(devicetree_devices, test_init_order)
@@ -103,6 +110,7 @@ ZTEST(devicetree_devices, test_init_order)
 	zassert_equal(init_order[6], DEV_HDL(TEST_PARTITION), NULL);
 	zassert_equal(init_order[7], DEV_HDL(TEST_GPIO_INJECTED), NULL);
 	zassert_equal(init_order[8], DEV_HDL_NAME(manual_dev), NULL);
+	zassert_equal(init_order[9], DEV_HDL(TEST_NOLABEL), NULL);
 }
 
 static bool check_handle(device_handle_t hdl,
@@ -305,11 +313,12 @@ ZTEST(devicetree_devices, test_supports)
 	/* TEST_I2C: TEST_DEVA TEST_GPIOX TEST_DEVB TEST_DEVC */
 	dev = DEVICE_DT_GET(TEST_I2C);
 	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 4, NULL);
+	zassert_equal(nhdls, 5, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls), NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_DEVC), hdls, nhdls), NULL);
+	zassert_true(check_handle(DEV_HDL(TEST_NOLABEL), hdls, nhdls), NULL);
 
 	/* Support forwarding (intermediate missing devicetree node)
 	 * TEST_DEVC: TEST_PARTITION

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -284,7 +284,8 @@ ZTEST(devicetree_devices, test_supports)
 	/* TEST_DEVB: None */
 	dev = DEVICE_DT_GET(TEST_DEVB);
 	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 1, NULL);
+	zassert_true(check_handle(DEV_HDL(TEST_GPIO_INJECTED), hdls, nhdls), NULL);
 
 	/* TEST_GPIO_INJECTED: None */
 	dev = DEVICE_DT_GET(TEST_GPIO_INJECTED);


### PR DESCRIPTION
Rework the `gen_handles.py` script by pulling out all the elf parsing and dependency calculations into a dedicated file. This parent class will be used to progress #22545, as well as just making it simpler to add/change functionality in the future.

As an example of how this simplifies new features, the build system now attempts to generate a `.dot` file of the final device hierarchy. An example `dev_graph.dot` from `zephyr/tests/lib/devicetree/devices`:
![graph](https://user-images.githubusercontent.com/8476715/178131389-07d44425-34cf-4a07-b95a-9e6215e38cc3.png)

