### PR TITLE
net: lwm2m: Pass client_ctx to observe callback

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -458,7 +458,7 @@ static void engine_observe_node_init(struct observe_node *obs, const uint8_t *to
 			tmp->path.res_id, tmp->path.res_inst_id, tmp->path.level);
 
 		if (ctx->observe_cb) {
-			ctx->observe_cb(LWM2M_OBSERVE_EVENT_OBSERVER_ADDED, &tmp->path, NULL);
+			ctx->observe_cb(LWM2M_OBSERVE_EVENT_OBSERVER_ADDED, &tmp->path, ctx);
 		}
 	}
 


### PR DESCRIPTION
In case LWM2M cient wants to change attrs of observed obj it needs pointer to client_ctx.

For example on observer add, wants to change pmin for some obj path to 1s:
```
static void observe_cb(enum lwm2m_observe_event event,
		struct lwm2m_obj_path *path, void *user_data)
{
	struct lwm2m_ctx *ctx = (struct lwm2m_ctx *) user_data;

	switch (event) {
	case LWM2M_OBSERVE_EVENT_OBSERVER_ADDED:
		lwm2m_engine_update_observer_min_period(ctx, "3347", 1);
	...
}
```
Signed-off-by: Kiril Petrov <retfie@gmail.com>