### PR TITLE
samples: boards: fix bbc_microbit pong build

### DIFF
--- a/samples/boards/bbc_microbit/pong/prj.conf
+++ b/samples/boards/bbc_microbit/pong/prj.conf
@@ -9,3 +9,7 @@ CONFIG_DISPLAY=y
 CONFIG_MICROBIT_DISPLAY=y
 CONFIG_PWM=y
 CONFIG_PWM_NRF5_SW=y
+
+# This feature isn't needed as this sample is intended to be used
+# between zephyr devices only.
+CONFIG_BT_GATT_CACHING=n


### PR DESCRIPTION
The GATT caching feature isn't needed, and was making the memory
consumption blow up because of the recent addition of `long_wq` for
deferred work.

Fixes #47428 .

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>