### PR TITLE
tests: arch: arm: arm-irq-vector-table: define _vector_end

### DIFF
--- a/tests/arch/arm/arm_irq_vector_table/irq-vector-table.ld
+++ b/tests/arch/arm/arm_irq_vector_table/irq-vector-table.ld
@@ -1,3 +1,10 @@
 /* SPDX-License-Identifier: Apache-2.0 */
 
 KEEP(*(_IRQ_VECTOR_TABLE_SECTION_SYMS))
+
+/*
+ * Some ARM platforms require this symbol to be placed after the IRQ vector
+ * table (like STM32F0). The symbol defined here is overriding the one in
+ * arch/arm/core/aarch32/vector_table.ld when the IRQ vector table is enabled.
+ */
+_vector_end = .;


### PR DESCRIPTION
Following implementation of PR #46769
and to complement #47309,
it is also necessary define `_vector_end` in
test specific `arm-irq-vector-table.ld`

Fixes #47273