### PR TITLE
scripts: Specify a version to protobuf

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -22,7 +22,7 @@ Pillow
 imgtool>=1.7.1
 
 # used by nanopb module to generate sources from .proto files
-protobuf
+protobuf==3.20.1
 
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub


### PR DESCRIPTION
The newest version of protobuf will cause build failure on
samples/modules/nanopb/ , so specify a version of 3.20.1 can
aviod that.

Signed-off-by: Shaoan Li <shaoanx.li@intel.com>