### PR TITLE
drivers/samples: flash: shell: fix issues

### DIFF
--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -50,12 +50,12 @@
 	pinctrl-names = "default";
 };
 
+/* disabled (used by Flash ROM by default) */
 &spi0 {
-	status = "okay";
-
 	reg = <0x10014000 0x1000 0x20400000 0xc00000>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		status = "disabled";
 		size = <134217728>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -92,12 +92,12 @@
 	current-speed = <115200>;
 };
 
+/* disabled (used by Flash ROM by default) */
 &spi0 {
-	status = "okay";
-
 	reg = <0x10014000 0x1000 0x20010000 0x3c0900>;
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
+		status = "disabled";
 		size = <134217728>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];

--- a/boards/riscv/hifive_unleashed/hifive_unleashed.dts
+++ b/boards/riscv/hifive_unleashed/hifive_unleashed.dts
@@ -46,12 +46,12 @@
 	current-speed = <115200>;
 };
 
+/* disabled (used by Flash ROM by default) */
 &spi0 {
-	status = "okay";
-
 	reg = <0x10040000 0x1000 0x20000000 0x2000000>;
 	flash0: flash@0 {
 		compatible = "issi,is25wp256d", "jedec,spi-nor";
+		status = "disabled";
 		size = <33554432>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];

--- a/boards/riscv/hifive_unmatched/hifive_unmatched.dts
+++ b/boards/riscv/hifive_unmatched/hifive_unmatched.dts
@@ -27,12 +27,12 @@
 	current-speed = <115200>;
 };
 
+/* disabled (used by Flash ROM by default) */
 &spi0 {
-	status = "okay";
-
 	reg = <0x10040000 0x1000 0x20000000 0x2000000>;
 	flash0: flash@0 {
 		compatible = "issi,is25wp256d", "jedec,spi-nor";
+		status = "disabled";
 		size = <33554432>;
 		label = "FLASH0";
 		jedec-id = [96 60 18];

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -14,7 +14,6 @@
 #include <stdlib.h>
 #include <string.h>
 #include <zephyr/drivers/flash.h>
-#include <soc.h>
 
 /* Buffer is only needed for bytes that follow command and offset */
 #define BUF_ARRAY_CNT (CONFIG_SHELL_ARGC_MAX - 2)

--- a/drivers/spi/Kconfig.sifive
+++ b/drivers/spi/Kconfig.sifive
@@ -3,20 +3,8 @@
 # Copyright (c) 2018 SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-menuconfig SPI_SIFIVE
+config SPI_SIFIVE
 	bool "SiFive SPI controller driver"
 	depends on SOC_SERIES_RISCV_SIFIVE_FREEDOM
 	help
 	  Enable the SPI peripherals on SiFive Freedom processors
-
-config SIFIVE_SPI_0_ROM
-	bool "SPI 0 is used to access SPI Flash ROM"
-	default y
-	depends on SPI_SIFIVE
-	help
-	  If enabled, SPI 0 is reserved for accessing the SPI flash ROM and a
-	  driver interface won't be instantiated for SPI 0.
-
-	  Beware disabling this option on HiFive 1! The SPI flash ROM is where the
-	  program is stored, and if this driver initializes the interface for
-	  peripheral control the FE310 will crash on boot.

--- a/drivers/spi/spi_sifive.c
+++ b/drivers/spi/spi_sifive.c
@@ -296,24 +296,6 @@ static struct spi_driver_api spi_sifive_api = {
 			&spi_sifive_cfg_##n, \
 			POST_KERNEL, \
 			CONFIG_SPI_INIT_PRIORITY, \
-			&spi_sifive_api)
+			&spi_sifive_api);
 
-#ifndef CONFIG_SIFIVE_SPI_0_ROM
-#if DT_INST_NODE_HAS_PROP(0, label)
-
-SPI_INIT(0);
-
-#endif /* DT_INST_NODE_HAS_PROP(0, label) */
-#endif /* !CONFIG_SIFIVE_SPI_0_ROM */
-
-#if DT_INST_NODE_HAS_PROP(1, label)
-
-SPI_INIT(1);
-
-#endif /* DT_INST_NODE_HAS_PROP(1, label) */
-
-#if DT_INST_NODE_HAS_PROP(2, label)
-
-SPI_INIT(2);
-
-#endif /* DT_INST_NODE_HAS_PROP(2, label) */
+DT_INST_FOREACH_STATUS_OKAY(SPI_INIT)

--- a/dts/bindings/spi/sifive,spi0.yaml
+++ b/dts/bindings/spi/sifive,spi0.yaml
@@ -1,7 +1,12 @@
 # Copyright (c) 2018, SiFive Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Sifive SPI controller
+description: |
+  Sifive SPI controller.
+
+  Note: First instance of the Sifive SPI controller (spi0) must be kept
+  disabled if used to access SPI Flash ROM. Failing to do so could result in
+  crashes during boot time.
 
 compatible: "sifive,spi0"
 

--- a/include/zephyr/arch/riscv/common/linker.ld
+++ b/include/zephyr/arch/riscv/common/linker.ld
@@ -40,7 +40,7 @@
 #define ROM_BASE DT_REG_ADDR(DT_CHOSEN(zephyr_flash))
 #endif /* CONFIG_FLASH_LOAD_OFFSET */
 #define ROM_SIZE DT_REG_SIZE(DT_CHOSEN(zephyr_flash))
-#elif DT_NODE_HAS_COMPAT_STATUS(DT_CHOSEN(zephyr_flash), jedec_spi_nor, okay)
+#elif DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_flash), jedec_spi_nor)
 /* For jedec,spi-nor we expect the spi controller to memory map the flash
  * and for that mapping to be the second register property of the spi
  * controller.

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -13,7 +13,6 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/device.h>
-#include <soc.h>
 #include <stdlib.h>
 
 LOG_MODULE_REGISTER(app);

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -13,7 +13,6 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/drivers/flash.h>
 #include <zephyr/device.h>
-#include <stdlib.h>
 
 LOG_MODULE_REGISTER(app);
 


### PR DESCRIPTION
- The flash shell/sample shell included soc.h for no reason, remove it. Also removed a duplicate include.
- Fix hifive_unmatched issues with `jedec,spi-nor` (node could not be used)

Fixes #47576

minimal libc issues discovered here are being fixed in #47612