### PR TITLE
logging: Fix redundant logging thread wakeups

### DIFF
--- a/subsys/logging/log_core.c
+++ b/subsys/logging/log_core.c
@@ -236,7 +236,7 @@ static uint32_t activate_foreach_backend(uint32_t mask)
 		const struct log_backend *backend = log_backend_get(i);
 
 		mask_cpy &= ~BIT(i);
-		if (log_backend_is_ready(backend) == 0) {
+		if (backend->autostart && (log_backend_is_ready(backend) == 0)) {
 			mask &= ~BIT(i);
 			log_backend_enable(backend,
 					   backend->cb->ctx,


### PR DESCRIPTION
Fix a bug introduced by 658123bb21 where if all backends were ready prior to logging thread loop, thread was periodically waken up for no reason. Fix is setting timeout to K_FOREVER if all backends are ready after the initialization.

Additionally, added check which ensures that only backends with autostart flag set are enabled automatically by the logging.

