### PR TITLE
Bluetooth: Mesh: Flush pending settings in bt_mesh_reset/_cdb_clear

### DIFF
--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -729,6 +729,8 @@ void bt_mesh_cdb_clear(void)
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		update_cdb_net_settings();
 	}
+
+	bt_mesh_settings_store_pending();
 }
 
 void bt_mesh_cdb_iv_update(uint32_t iv_index, bool iv_update)

--- a/subsys/bluetooth/mesh/cfg_srv.c
+++ b/subsys/bluetooth/mesh/cfg_srv.c
@@ -38,6 +38,13 @@
 #include "settings.h"
 #include "cfg.h"
 
+static void node_reset_pending_handler(struct k_work *work)
+{
+	bt_mesh_reset();
+}
+
+static K_WORK_DEFINE(node_reset_pending, node_reset_pending_handler);
+
 static int comp_add_elem(struct net_buf_simple *buf, struct bt_mesh_elem *elem,
 			 bool primary)
 {
@@ -2071,13 +2078,13 @@ static void reset_send_start(uint16_t duration, int err, void *cb_data)
 {
 	if (err) {
 		BT_ERR("Sending Node Reset Status failed (err %d)", err);
-		bt_mesh_reset();
+		k_work_submit(&node_reset_pending);
 	}
 }
 
 static void reset_send_end(int err, void *cb_data)
 {
-	bt_mesh_reset();
+	k_work_submit(&node_reset_pending);
 }
 
 static int node_reset(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx,

--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -228,6 +228,10 @@ void bt_mesh_reset(void)
 
 	bt_mesh_comp_unprovision();
 
+	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
+		bt_mesh_settings_store_pending();
+	}
+
 	if (IS_ENABLED(CONFIG_BT_MESH_PROV)) {
 		bt_mesh_prov_reset();
 	}

--- a/subsys/bluetooth/mesh/settings.c
+++ b/subsys/bluetooth/mesh/settings.c
@@ -209,3 +209,10 @@ void bt_mesh_settings_init(void)
 {
 	k_work_init_delayable(&pending_store, store_pending);
 }
+
+void bt_mesh_settings_store_pending(void)
+{
+	(void)k_work_cancel_delayable(&pending_store);
+
+	store_pending(&pending_store.work);
+}

--- a/subsys/bluetooth/mesh/settings.h
+++ b/subsys/bluetooth/mesh/settings.h
@@ -39,5 +39,6 @@ enum bt_mesh_settings_flag {
 void bt_mesh_settings_init(void);
 void bt_mesh_settings_store_schedule(enum bt_mesh_settings_flag flag);
 void bt_mesh_settings_store_cancel(enum bt_mesh_settings_flag flag);
+void bt_mesh_settings_store_pending(void);
 int bt_mesh_settings_set(settings_read_cb read_cb, void *cb_arg,
 			 void *out, size_t read_len);


### PR DESCRIPTION
Upon bt_mesh_reset call, all mesh modules has to clear the privisioning
and configuration data. None of the modules store or erase in settings
subsystem immediately, but put this on the mesh settings work. After the
settings work is scheduled, all stored data will be removed and the
device will eventually be unprovisioned. Until then, the device is not
completely unprovisioned, thus calling bt_mesh_prov_enable,
bt_mesh_provision (and bt_mesh_cdb_create) should not be allowed.

Struct bt_mesh_prov has a reset callback stating that after this
callback is called, the device has been reset and can be re-provisioned
again. Also, bt_mesh_reset API description states that after calling
bt_mesh_reset API, the device needs to reenable the provisioning layer
to be provisioned again. But this is not correct since the settings has
to be cleared before the device can be reprovisionined.

This commit makes bt_mesh_reset flush pending settings so that the
device can be reprovisioned immediately and to API will behave as
written in the description.

The same applies to bt_mesh_cdb_clear.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>