### PR TITLE
 posix: pthread: consider PTHREAD_EXITED state in pthread_create

### DIFF
--- a/lib/posix/pthread.c
+++ b/lib/posix/pthread.c
@@ -150,7 +150,7 @@ int pthread_create(pthread_t *newthread, const pthread_attr_t *attr,
 	for (pthread_num = 0;
 	    pthread_num < CONFIG_MAX_PTHREAD_COUNT; pthread_num++) {
 		thread = &posix_thread_pool[pthread_num];
-		if (thread->state == PTHREAD_TERMINATED) {
+		if (thread->state == PTHREAD_EXITED || thread->state == PTHREAD_TERMINATED) {
 			thread->state = PTHREAD_JOINABLE;
 			break;
 		}


### PR DESCRIPTION
If a thread is joined using `pthread_join()`, then the internal state would be set to `PTHREAD_EXITED`.

Previously, `pthread_create()` would only consider pthreads with internal state `PTHREAD_TERMINATED` as candidates for new threads. An unwanted side-effect of that was, if old threads were only ever terminated with `pthread_join()`, then the internal pthread pool (of size `CONFIG_MAX_PTHREAD_COUNT`) would quickly become exhausted.

We should be able to reuse `CONFIG_MAX_PTHREAD_COUNT` threads an infinite number of times without exhausting the internal pthread pool.

* Allow pthread pool items with state `PTHREAD_EXITED` as candidates for new pthreads in `pthread_create()`
* Add a simple test to detect "pthread leaks" by respawning 1 thread `2 * CONFIG_MAX_PTHREAD_COUNT` times

Fixes #47609