### PR TITLE
lib: libc: minimal: Define off_t as intptr_t

### DIFF
--- a/lib/libc/minimal/include/sys/types.h
+++ b/lib/libc/minimal/include/sys/types.h
@@ -32,27 +32,8 @@ typedef __SIZE_TYPE__ ssize_t;
 
 #if !defined(__off_t_defined)
 #define __off_t_defined
-
-#if defined(__i386) || defined(__x86_64) || defined(__ARC64__)
-typedef long int off_t; /* "long" works for all of i386, X32 and true 64 bit */
-#elif defined(__ARM_ARCH)
-typedef int off_t;
-#elif defined(__arc__)
-typedef int off_t;
-#elif defined(__NIOS2__)
-typedef int off_t;
-#elif defined(__riscv)
-typedef int off_t;
-#elif defined(__XTENSA__)
-typedef int off_t;
-#elif defined(__sparc__)
-typedef int off_t;
-#elif defined(__mips)
-typedef int off_t;
-#else
-#error "The minimal libc library does not recognize the architecture!\n"
-#endif
-
+/* off_t is defined such that it matches the size of a pointer */
+typedef __INTPTR_TYPE__ off_t;
 #endif
 
 #if !defined(__time_t_defined)


### PR DESCRIPTION
The `off_t` type, which is specified by the POSIX standard as a signed
integer type representing file sizes, was defined as `long` or `int`
depending on the target architecture without a clear explanation on why
it was defined as such.

While the POSIX standard does not specify the size requirement of the
`off_t` type, it generally corresponds to the size of a pointer in
practice, mainly because the optimal file handling size is closely tied
to the native pointer size.

For this reason, this commit removes the per-architecture `off_t`
definition and defines it as `intptr_t` such that its size always
matches the native pointer size.

Note that the toolchain-defined `__INTPTR_TYPE__` macro is used instead
of the `intptr_t` typedef as per the common convention used in the C
standard library headers.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: It was a deliberate decision to not implement the support for `_FILE_OFFSET_BITS` because it is a Linux/glibc-specific construct, and neither the newlib nor the picolibc supports it. It may be desirable to implement the support for this macro (or something similar) in the future when https://github.com/zephyrproject-rtos/sdk-ng/issues/350 is implemented.