### PR TITLE
Bluetooth: Controller: Fix hang on chain PDU allocation

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -52,6 +52,8 @@
 #include "common/log.h"
 #include "hal/debug.h"
 
+#define PDU_FREE_TIMEOUT K_SECONDS(5)
+
 static int init_reset(void);
 static void pdu_free_sem_give(void);
 
@@ -428,7 +430,7 @@ struct pdu_adv *lll_adv_pdu_alloc_pdu_adv(void)
 		return p;
 	}
 
-	err = k_sem_take(&sem_pdu_free, K_FOREVER);
+	err = k_sem_take(&sem_pdu_free, PDU_FREE_TIMEOUT);
 	LL_ASSERT(!err);
 
 	k_sem_reset(&sem_pdu_free);
@@ -846,7 +848,7 @@ static void *adv_extra_data_allocate(struct lll_adv_pdu *pdu, uint8_t last)
 		return extra_data;
 	}
 
-	err = k_sem_take(&sem_extra_data_free, K_FOREVER);
+	err = k_sem_take(&sem_extra_data_free, PDU_FREE_TIMEOUT);
 	LL_ASSERT(!err);
 
 	extra_data = MFIFO_DEQUEUE(extra_data_free);


### PR DESCRIPTION
Fix hang on chain PDU allocation by replacing K_FOREVER use
by a timeout. Hang occurs when configured number of
advertising data buffers is low.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>