### PR TITLE
Bluetooth: Controller: Fix jitter in offsets for Extended and Periodic Advertising

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -43,6 +43,9 @@ config BT_LLL_VENDOR_NORDIC
 	select BT_CTLR_TIFS_HW_SUPPORT
 	select BT_CTLR_ULL_LLL_PRIO_SUPPORT
 
+	select BT_TICKER_REMAINDER_GET if BT_BROADCASTER && BT_CTLR_ADV_EXT
+	select BT_TICKER_LAZY_GET if BT_CTLR_ADV_PERIODIC
+
 	default y
 	help
 	  Use Nordic Lower Link Layer implementation.
@@ -709,7 +712,6 @@ config BT_TICKER_LOW_LAT
 
 config BT_TICKER_REMAINDER_GET
 	bool "Ticker Next Slot Get with Remainder"
-	default y if BT_BROADCASTER && BT_CTLR_ADV_EXT
 	help
 	  This option enables ticker interface to iterate through active
 	  ticker nodes, returning tick to expire and remainder from a reference
@@ -717,7 +719,6 @@ config BT_TICKER_REMAINDER_GET
 
 config BT_TICKER_LAZY_GET
 	bool "Ticker Next Slot Get with Lazy"
-	default y if BT_CTLR_ADV_PERIODIC
 	help
 	  This option enables ticker interface to iterate through active
 	  ticker nodes, returning tick to expire and lazy count from a reference

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -198,7 +198,7 @@ config BT_CTLR_ADV_PDU_LINK
 
 config BT_CTLR_ADV_PDU_BACK2BACK
 	bool "Back-to-back transmission of extended advertising trains"
-	depends on BT_CTLR_ADV_EXT && BT_BROADCASTER
+	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
 	select BT_CTLR_ADV_PDU_LINK
 	help
 	  Enables transmission of AUX_CHAIN_IND in extended advertising train by
@@ -706,6 +706,14 @@ config BT_TICKER_LOW_LAT
 	  ticker node timeouts and thereby prevents ticker interrupts during
 	  radio RX/TX. Enabling this option disables the ticker priority- and
 	  'must expire' features.
+
+config BT_TICKER_REMAINDER_GET
+	bool "Ticker Next Slot Get with Remainder"
+	default y if BT_BROADCASTER && BT_CTLR_ADV_EXT
+	help
+	  This option enables ticker interface to iterate through active
+	  ticker nodes, returning tick to expire and remainder from a reference
+	  tick.
 
 config BT_TICKER_LAZY_GET
 	bool "Ticker Next Slot Get with Lazy"

--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -98,8 +98,6 @@ struct lll_adv_sync {
 	uint8_t  chm_last;
 	uint16_t chm_instant;
 
-	uint32_t ticks_offset;
-
 	struct lll_adv_pdu data;
 
 #if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)
@@ -129,10 +127,11 @@ struct lll_adv_aux {
 	 */
 	uint16_t data_chan_counter;
 
-	/* Temporary stored use by primary channel PDU event to fill the
+	/* Store used by primary channel PDU event to fill the
 	 * auxiliary offset to this auxiliary PDU event.
 	 */
 	uint32_t ticks_offset;
+	uint32_t us_offset;
 
 	struct lll_adv_pdu data;
 #if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)

--- a/subsys/bluetooth/controller/ll_sw/lll_adv.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv.h
@@ -130,8 +130,8 @@ struct lll_adv_aux {
 	/* Store used by primary channel PDU event to fill the
 	 * auxiliary offset to this auxiliary PDU event.
 	 */
-	uint32_t ticks_offset;
-	uint32_t us_offset;
+	uint32_t ticks_pri_pdu_offset;
+	uint32_t us_pri_pdu_offset;
 
 	struct lll_adv_pdu data;
 #if defined(CONFIG_BT_CTLR_ADV_PDU_LINK)

--- a/subsys/bluetooth/controller/ll_sw/lll_adv_aux.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_adv_aux.h
@@ -10,6 +10,5 @@ void lll_adv_aux_prepare(void *param);
 
 extern uint8_t ull_adv_aux_lll_handle_get(struct lll_adv_aux *lll);
 extern struct pdu_adv_aux_ptr *
-	ull_adv_aux_lll_offset_fill(struct pdu_adv *pdu,
-				    uint32_t ticks_offset,
-				    uint32_t start_us);
+	ull_adv_aux_lll_offset_fill(struct pdu_adv *pdu, uint32_t ticks_offset,
+				    uint32_t remainder_us, uint32_t start_us);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1050,11 +1050,7 @@ void radio_tmr_tifs_set(uint32_t tifs)
 
 uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder)
 {
-	if ((!(remainder / 1000000UL)) || (remainder & 0x80000000)) {
-		ticks_start--;
-		remainder += 30517578UL;
-	}
-	remainder /= 1000000UL;
+	HAL_TICKER_REMOVE_JITTER(ticks_start, remainder);
 
 	nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_CLEAR);
 	EVENT_TIMER->MODE = 0;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -1050,7 +1050,7 @@ void radio_tmr_tifs_set(uint32_t tifs)
 
 uint32_t radio_tmr_start(uint8_t trx, uint32_t ticks_start, uint32_t remainder)
 {
-	HAL_TICKER_REMOVE_JITTER(ticks_start, remainder);
+	hal_ticker_remove_jitter(&ticks_start, &remainder);
 
 	nrf_timer_task_trigger(EVENT_TIMER, NRF_TIMER_TASK_CLEAR);
 	EVENT_TIMER->MODE = 0;

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/ticker.h
@@ -13,6 +13,12 @@
 /* Macro defining the max. counter update latency in ticks */
 #define HAL_TICKER_CNTR_SET_LATENCY 0
 
+/* Macro defines the h/w supported most significant bit */
+#define HAL_TICKER_CNTR_MSBIT 23
+
+/* Macro defining the HW supported counter bits */
+#define HAL_TICKER_CNTR_MASK 0x00FFFFFF
+
 /* Macro to translate microseconds to tick units.
  * NOTE: This returns the floor value.
  */
@@ -22,7 +28,7 @@
 		& HAL_TICKER_CNTR_MASK \
 	)
 
-/* Macro returning remainder in nanoseconds */
+/* Macro returning remainder in picoseconds */
 #define HAL_TICKER_REMAINDER(x) \
 	( \
 		( \
@@ -32,15 +38,29 @@
 		/ 1000UL \
 	)
 
+/* Macro to remove ticks and return positive remainder value in microseconds */
+#define HAL_TICKER_REMOVE_JITTER(t, r) \
+	{ \
+		if ((!(r / 1000000UL)) || (r & BIT(31))) { \
+			t--; \
+			r += 30517578UL; \
+		} \
+		r /= 1000000UL; \
+	}
+
+/* Macro to add ticks and return positive remainder value in microseconds */
+#define HAL_TICKER_ADD_JITTER(t, r) \
+	{ \
+		if ((!(r / 1000000UL)) || (r & BIT(31))) { \
+			t++; \
+			r += 30517578UL; \
+		} \
+		r /= 1000000UL; \
+	}
+
 /* Macro to translate tick units to microseconds. */
 #define HAL_TICKER_TICKS_TO_US(x) \
 	((uint32_t)(((uint64_t)(x) * 30517578125UL) / 1000000000UL))
-
-/* Macro defines the h/w supported most significant bit */
-#define HAL_TICKER_CNTR_MSBIT 23
-
-/* Macro defining the HW supported counter bits */
-#define HAL_TICKER_CNTR_MASK 0x00FFFFFF
 
 /* Macro defining the remainder resolution/range
  * ~ 1000000 * HAL_TICKER_TICKS_TO_US(1)

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1315,6 +1315,7 @@ static void isr_done(void *param)
 		if (lll_aux) {
 			(void)ull_adv_aux_lll_offset_fill(pdu,
 							  lll_aux->ticks_offset,
+							  lll_aux->us_offset,
 							  start_us);
 		}
 #else /* !CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -1314,8 +1314,8 @@ static void isr_done(void *param)
 		lll_aux = lll->aux;
 		if (lll_aux) {
 			(void)ull_adv_aux_lll_offset_fill(pdu,
-							  lll_aux->ticks_offset,
-							  lll_aux->us_offset,
+							  lll_aux->ticks_pri_pdu_offset,
+							  lll_aux->us_pri_pdu_offset,
 							  start_us);
 		}
 #else /* !CONFIG_BT_CTLR_ADV_EXT */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -1503,24 +1503,24 @@ static void mfy_aux_offset_get(void *param)
 	} while (id != ticker_id);
 
 	/* Adjust ticks to expire based on remainder value */
-	HAL_TICKER_REMOVE_JITTER(ticks_to_expire, remainder);
+	hal_ticker_remove_jitter(&ticks_to_expire, &remainder);
 
 	/* Store the ticks offset for population in other advertising primary
 	 * channel PDUs.
 	 */
-	lll_aux->ticks_offset =	ticks_to_expire;
+	lll_aux->ticks_pri_pdu_offset = ticks_to_expire;
 
 	/* NOTE: as first primary channel PDU does not use remainder, the packet
 	 * timer is started one tick in advance to start the radio with
 	 * microsecond precision, hence compensate for the higher start_us value
 	 * captured at radio start of the first primary channel PDU.
 	 */
-	lll_aux->ticks_offset += 1U;
+	lll_aux->ticks_pri_pdu_offset += 1U;
 
 	/* Store the microsecond remainder offset for population in other
 	 * advertising primary channel PDUs.
 	 */
-	lll_aux->us_offset = remainder;
+	lll_aux->us_pri_pdu_offset = remainder;
 
 	/* Fill the aux offset in the first Primary channel PDU */
 	/* FIXME: we are in ULL_LOW context, fill offset in LLL context? */

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -960,7 +960,7 @@ static void mfy_iso_offset_get(void *param)
 		ret = ticker_next_slot_get_ext(TICKER_INSTANCE_ID_CTLR,
 					       TICKER_USER_ID_ULL_LOW,
 					       &id, &ticks_current,
-					       &ticks_to_expire, &lazy,
+					       &ticks_to_expire, NULL, &lazy,
 					       NULL, NULL,
 					       ticker_op_cb, (void *)&ret_cb);
 		if (ret == TICKER_STATUS_BUSY) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1809,7 +1809,7 @@ static void mfy_sync_offset_get(void *param)
 		ret = ticker_next_slot_get_ext(TICKER_INSTANCE_ID_CTLR,
 					       TICKER_USER_ID_ULL_LOW,
 					       &id, &ticks_current,
-					       &ticks_to_expire, &lazy,
+					       &ticks_to_expire, NULL, &lazy,
 					       NULL, NULL,
 					       ticker_op_cb, (void *)&ret_cb);
 		if (ret == TICKER_STATUS_BUSY) {

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -1831,11 +1831,17 @@ static void mfy_sync_offset_get(void *param)
 		LL_ASSERT(id != TICKER_NULL);
 	} while (id != ticker_id);
 
-	HAL_TICKER_REMOVE_JITTER(ticks_to_expire, remainder);
+	/* Reduced a tick for negative remainder and return positive remainder
+	 * value.
+	 */
+	hal_ticker_remove_jitter(&ticks_to_expire, &remainder);
 	sync_remainder_us = remainder;
 
+	/* Add a tick for negative remainder and return positive remainder
+	 * value.
+	 */
 	remainder = sync->aux_remainder;
-	HAL_TICKER_ADD_JITTER(ticks_to_expire, remainder);
+	hal_ticker_add_jitter(&ticks_to_expire, &remainder);
 	aux_remainder_us = remainder;
 
 	pdu = lll_adv_aux_data_latest_peek(adv->lll.aux);

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_types.h
@@ -90,6 +90,8 @@ struct ll_adv_sync_set {
 	uint8_t is_enabled:1;
 	uint8_t is_started:1;
 	uint8_t is_data_cmplt:1;
+
+	uint32_t aux_remainder;
 };
 
 struct ll_adv_iso_set {

--- a/subsys/bluetooth/controller/ll_sw/ull_sched.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sched.c
@@ -686,7 +686,7 @@ static uint8_t after_match_slot_get(uint8_t user_id, uint32_t ticks_slot_abs,
 #if defined(CONFIG_BT_TICKER_NEXT_SLOT_GET_MATCH)
 		ret = ticker_next_slot_get_ext(TICKER_INSTANCE_ID_CTLR, user_id,
 					       &ticker_id, ticks_anchor,
-					       &ticks_to_expire,
+					       &ticks_to_expire, NULL,
 					       NULL, /* lazy */
 					       ticker_match_op_cb,
 					       NULL, /* match_op_context */

--- a/subsys/bluetooth/controller/ticker/ticker.h
+++ b/subsys/bluetooth/controller/ticker/ticker.h
@@ -157,7 +157,8 @@ uint32_t ticker_next_slot_get(uint8_t instance_index, uint8_t user_id,
 			      ticker_op_func fp_op_func, void *op_context);
 uint32_t ticker_next_slot_get_ext(uint8_t instance_index, uint8_t user_id,
 				  uint8_t *ticker_id, uint32_t *ticks_current,
-				  uint32_t *ticks_to_expire, uint16_t *lazy,
+				  uint32_t *ticks_to_expire,
+				  uint32_t *remainder, uint16_t *lazy,
 				  ticker_op_match_func fp_op_match_func,
 				  void *match_op_context,
 				  ticker_op_func fp_op_func, void *op_context);


### PR DESCRIPTION
Updated ticker implementation to return remainder value for
a ticker when enumerating active tickers with time
reservations.

This is required to find offsets and to use the remainder
value to correctly calculate auxiliary offsets to the
microsecond resolution.

Use macro to adjust ticks for jitter stored in remainder
value.

Use remainder value in scheduling the periodic auxiliary
PDUs and use the ticker next slot get interface with
remainder value to fill the auxiliary offsets with
microsecond precision in the primary channel PDUs.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>