### PR TITLE
drivers: memc: mcux_flexspi_hyperram: Fix multiple log module definition

### DIFF
--- a/drivers/memc/memc_mcux_flexspi_hyperram.c
+++ b/drivers/memc/memc_mcux_flexspi_hyperram.c
@@ -23,7 +23,7 @@
 	read-while-write hazards. This configuration is not recommended."
 #endif
 
-LOG_MODULE_REGISTER(memc_flexspi, CONFIG_MEMC_LOG_LEVEL);
+LOG_MODULE_REGISTER(memc_flexspi_hyperram, CONFIG_MEMC_LOG_LEVEL);
 
 enum {
 	READ_DATA,


### PR DESCRIPTION
Enabling the FlexSPI HyperRAM results in a build error (since #40270), due to a logging module re-definition. Fixed by changing the log module name.

