### PR TITLE
Bluetooth: Audio: TBS Client optional procedures actually optional

### DIFF
--- a/include/zephyr/bluetooth/audio/tbs.h
+++ b/include/zephyr/bluetooth/audio/tbs.h
@@ -454,28 +454,65 @@ typedef void (*bt_tbs_client_call_states_cb)(struct bt_conn *conn, int err,
 
 struct bt_tbs_client_cb {
 	bt_tbs_client_discover_cb            discover;
+#if defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL)
 	bt_tbs_client_cp_cb                  originate_call;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL)
 	bt_tbs_client_cp_cb                  terminate_call;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL)
 	bt_tbs_client_cp_cb                  hold_call;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL)
 	bt_tbs_client_cp_cb                  accept_call;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL)
 	bt_tbs_client_cp_cb                  retrieve_call;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS)
 	bt_tbs_client_cp_cb                  join_calls;
-
+#endif /* defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 	bt_tbs_client_read_string_cb         bearer_provider_name;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 	bt_tbs_client_read_string_cb         bearer_uci;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 	bt_tbs_client_read_value_cb          technology;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 	bt_tbs_client_read_string_cb         uri_list;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 	bt_tbs_client_read_value_cb          signal_strength;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
+#if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL)
 	bt_tbs_client_read_value_cb          signal_interval;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 	bt_tbs_client_current_calls_cb       current_calls;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 	bt_tbs_client_read_value_cb          ccid;
-	bt_tbs_client_read_value_cb          status_flags;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
 	bt_tbs_client_read_string_cb         call_uri;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
+	bt_tbs_client_read_value_cb          status_flags;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
 	bt_tbs_client_call_states_cb         call_state;
+#if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 	bt_tbs_client_read_value_cb          optional_opcodes;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 	bt_tbs_client_termination_reason_cb  termination_reason;
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 	bt_tbs_client_read_string_cb         remote_uri;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 	bt_tbs_client_read_string_cb         friendly_name;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 };
 
 /**
@@ -509,6 +546,9 @@ int bt_tbs_client_set_outgoing_uri(struct bt_conn *conn, uint8_t inst_index,
  * @param interval      The interval to write (0-255 seconds).
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_set_signal_strength_interval(struct bt_conn *conn,
 					       uint8_t inst_index,
@@ -522,6 +562,9 @@ int bt_tbs_client_set_signal_strength_interval(struct bt_conn *conn,
  * @param uri           The URI of the callee.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_originate_call(struct bt_conn *conn, uint8_t inst_index,
 				 const char *uri);
@@ -534,6 +577,9 @@ int bt_tbs_client_originate_call(struct bt_conn *conn, uint8_t inst_index,
  * @param call_index    The call index to terminate.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_TERMINATE_CALL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_terminate_call(struct bt_conn *conn, uint8_t inst_index,
 				 uint8_t call_index);
@@ -546,6 +592,9 @@ int bt_tbs_client_terminate_call(struct bt_conn *conn, uint8_t inst_index,
  * @param call_index    The call index to place on hold.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_HOLD_CALL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_hold_call(struct bt_conn *conn, uint8_t inst_index,
 			    uint8_t call_index);
@@ -558,6 +607,9 @@ int bt_tbs_client_hold_call(struct bt_conn *conn, uint8_t inst_index,
  * @param call_index    The call index to accept.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_ACCEPT_CALL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_accept_call(struct bt_conn *conn, uint8_t inst_index,
 			      uint8_t call_index);
@@ -570,6 +622,9 @@ int bt_tbs_client_accept_call(struct bt_conn *conn, uint8_t inst_index,
  * @param call_index    The call index to retrieve.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_retrieve_call(struct bt_conn *conn, uint8_t inst_index,
 				uint8_t call_index);
@@ -583,6 +638,9 @@ int bt_tbs_client_retrieve_call(struct bt_conn *conn, uint8_t inst_index,
  * @param count         Number of call indexes in the call_indexes array.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_JOIN_CALLS} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
 			     const uint8_t *call_indexes, uint8_t count);
@@ -594,6 +652,9 @@ int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
  * @param inst_index    The index of the TBS instance.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_bearer_provider_name(struct bt_conn *conn,
 					    uint8_t inst_index);
@@ -605,6 +666,9 @@ int bt_tbs_client_read_bearer_provider_name(struct bt_conn *conn,
  * @param inst_index    The index of the TBS instance.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_UCI} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_bearer_uci(struct bt_conn *conn, uint8_t inst_index);
 
@@ -615,9 +679,11 @@ int bt_tbs_client_read_bearer_uci(struct bt_conn *conn, uint8_t inst_index);
  * @param inst_index    The index of the TBS instance.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_technology(struct bt_conn *conn, uint8_t inst_index);
-
 
 /**
  * @brief Read the URI schemes list of a TBS instance.
@@ -626,6 +692,9 @@ int bt_tbs_client_read_technology(struct bt_conn *conn, uint8_t inst_index);
  * @param inst_index    The index of the TBS instance.
  *
  * @return int          0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_uri_list(struct bt_conn *conn, uint8_t inst_index);
 
@@ -636,6 +705,9 @@ int bt_tbs_client_read_uri_list(struct bt_conn *conn, uint8_t inst_index);
  * @param inst_index    The index of the TBS instance.
  *
  * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_signal_strength(struct bt_conn *conn,
 				       uint8_t inst_index);
@@ -647,6 +719,9 @@ int bt_tbs_client_read_signal_strength(struct bt_conn *conn,
  * @param inst_index    The index of the TBS instance.
  *
  * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_signal_interval(struct bt_conn *conn,
 				       uint8_t inst_index);
@@ -658,6 +733,9 @@ int bt_tbs_client_read_signal_interval(struct bt_conn *conn,
  * @param inst_index    The index of the TBS instance.
  *
  * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_current_calls(struct bt_conn *conn, uint8_t inst_index);
 
@@ -668,18 +746,11 @@ int bt_tbs_client_read_current_calls(struct bt_conn *conn, uint8_t inst_index);
  * @param inst_index    The index of the TBS instance.
  *
  * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_CCID} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_ccid(struct bt_conn *conn, uint8_t inst_index);
-
-/**
- * @brief Read the feature and status value of a TBS instance.
- *
- * @param conn          The connection to the TBS server.
- * @param inst_index    The index of the TBS instance.
- *
- * @return              int 0 on success, errno value on fail.
- */
-int bt_tbs_client_read_status_flags(struct bt_conn *conn, uint8_t inst_index);
 
 /**
  * @brief Read the call target URI of a TBS instance.
@@ -688,8 +759,24 @@ int bt_tbs_client_read_status_flags(struct bt_conn *conn, uint8_t inst_index);
  * @param inst_index    The index of the TBS instance.
  *
  * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_INCOMING_URI} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_call_uri(struct bt_conn *conn, uint8_t inst_index);
+
+/**
+ * @brief Read the feature and status value of a TBS instance.
+ *
+ * @param conn          The connection to the TBS server.
+ * @param inst_index    The index of the TBS instance.
+ *
+ * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_STATUS_FLAGS} must be set
+ * for this function to be effective.
+ */
+int bt_tbs_client_read_status_flags(struct bt_conn *conn, uint8_t inst_index);
 
 /**
  * @brief Read the states of the current calls of a TBS instance.
@@ -708,6 +795,9 @@ int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index);
  * @param inst_index    The index of the TBS instance.
  *
  * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_INCOMING_CALL} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_remote_uri(struct bt_conn *conn, uint8_t inst_index);
 
@@ -718,6 +808,9 @@ int bt_tbs_client_read_remote_uri(struct bt_conn *conn, uint8_t inst_index);
  * @param inst_index    The index of the TBS instance.
  *
  * @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index);
 
@@ -727,6 +820,9 @@ int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index);
  *  @param inst_index    The index of the TBS instance.
  *
  *  @return              int 0 on success, errno value on fail.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES} must be set
+ * for this function to be effective.
  */
 int bt_tbs_client_read_optional_opcodes(struct bt_conn *conn,
 					uint8_t inst_index);
@@ -745,6 +841,9 @@ void bt_tbs_client_register_cb(const struct bt_tbs_client_cb *cbs);
  * @param ccid  The CCID to lookup a service instance for.
  *
  * @return Pointer to a Telephone Bearer Service instance if found else NULL.
+ *
+ * @note @kconfig{CONFIG_BT_TBS_CLIENT_CCID} must be set
+ * for this function to be effective.
  */
 struct bt_tbs_instance *bt_tbs_client_get_by_ccid(const struct bt_conn *conn,
 						  uint8_t ccid);

--- a/subsys/bluetooth/audio/Kconfig.tbs
+++ b/subsys/bluetooth/audio/Kconfig.tbs
@@ -170,6 +170,151 @@ config BT_TBS_CLIENT_MAX_TBS_INSTANCES
 	  Sets the maximum number of Telephone Bearer Service (TBS)
 	  instances to setup and use.
 
+config BT_TBS_CLIENT_MINIMAL
+	bool "Minimal TBS Client without optional procedures"
+	default n
+	help
+	  This option disables all optional procedures in the TBS Client.
+
+config BT_TBS_CLIENT_BEARER_PROVIDER_NAME
+	bool "Support reading Bearer Provider Name"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Bearer Provider Name.
+
+config BT_TBS_CLIENT_BEARER_UCI
+	bool "Support reading Bearer UCI"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Bearer UCI.
+
+config BT_TBS_CLIENT_BEARER_TECHNOLOGY
+	bool "Support reading Bearer Technology"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Bearer Technology.
+
+config BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST
+	bool "Support reading Bearer URI Schemes Supported List"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Bearer URI Schemes Supported
+	  List.
+
+config BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH
+	bool "Support reading Bearer Signal Strength"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Bearer Signal Strength.
+
+config BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL
+	bool "Support reading Bearer Signal Strength Reporting Interval"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Bearer Signal Strength
+	  Reporting Interval.
+
+config BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL
+	bool "Support setting Bearer Signal Strength Reporting Interval"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for setting Bearer Signal Strength
+	  Reporting Interval.
+
+config BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS
+	bool "Support reading Bearer List Current Calls"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Bearer List Current Calls.
+
+config BT_TBS_CLIENT_CCID
+	bool "Support reading Content Control ID"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Content Control ID.
+
+config BT_TBS_CLIENT_INCOMING_URI
+	bool "Support reading Incoming Call Target Bearer URI"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Incoming Call Target Bearer
+	  URI.
+
+config BT_TBS_CLIENT_STATUS_FLAGS
+	bool "Support reading Status Flags"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Status Flags.
+
+config BT_TBS_CLIENT_CP_PROCEDURES
+	def_bool y
+	depends on (BT_TBS_CLIENT_ACCEPT_CALL || \
+		    BT_TBS_CLIENT_TERMINATE_CALL || \
+		    BT_TBS_CLIENT_HOLD_CALL || \
+		    BT_TBS_CLIENT_RETRIEVE_CALL || \
+		    BT_TBS_CLIENT_ORIGINATE_CALL || \
+		    BT_TBS_CLIENT_JOIN_CALLS)
+	help
+	  This hidden option indicates that there are at least one control
+	  point procedure available.
+	  When this option is disabled it indicates that the control point can
+	  be optimized away.
+
+config BT_TBS_CLIENT_ACCEPT_CALL
+	bool "Support Accept Call"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for answering an incoming call.
+
+config BT_TBS_CLIENT_TERMINATE_CALL
+	bool "Support Terminate Call"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for terminating a call.
+
+config BT_TBS_CLIENT_HOLD_CALL
+	bool "Support Hold Call"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for putting a call on hold.
+
+config BT_TBS_CLIENT_RETRIEVE_CALL
+	bool "Support Retrieve Call"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for retrieving a call on hold.
+
+config BT_TBS_CLIENT_ORIGINATE_CALL
+	bool "Support Originate Call"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for originating a call.
+
+config BT_TBS_CLIENT_JOIN_CALLS
+	bool "Support Join Calls"
+	depends on BT_TBS_CLIENT_MAX_CALLS > 1
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for joining calls.
+
+config BT_TBS_CLIENT_OPTIONAL_OPCODES
+	bool "Support reading Optional Opcodes"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Optional Opcodes.
+
+config BT_TBS_CLIENT_INCOMING_CALL
+	bool "Support reading Incoming Call"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Incoming Call.
+
+config BT_TBS_CLIENT_CALL_FRIENDLY_NAME
+	bool "Support reading Call Friendly Name"
+	default !BT_TBS_CLIENT_MINIMAL
+	help
+	  This option enables support for reading Call Friendly Name.
+
 ############# DEBUG #############
 
 config BT_DEBUG_TBS_CLIENT

--- a/subsys/bluetooth/audio/cap.c
+++ b/subsys/bluetooth/audio/cap.c
@@ -58,7 +58,7 @@ BT_GATT_SERVICE_DEFINE(cas_svc,
 
 bool bt_cap_acceptor_ccid_exist(const struct bt_conn *conn, uint8_t ccid)
 {
-	if (IS_ENABLED(CONFIG_BT_TBS_CLIENT) &&
+	if (IS_ENABLED(CONFIG_BT_TBS_CLIENT_CCID) &&
 	    bt_tbs_client_get_by_ccid(conn, ccid) != NULL) {
 		return true;
 	}

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -81,6 +81,7 @@ static struct bt_tbs_instance *get_inst_by_index(struct bt_conn *conn,
 	}
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL)
 static bool free_call_spot(struct bt_tbs_instance *inst)
 {
 	for (int i = 0; i < CONFIG_BT_TBS_CLIENT_MAX_CALLS; i++) {
@@ -91,6 +92,7 @@ static bool free_call_spot(struct bt_tbs_instance *inst)
 
 	return false;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL) */
 
 static struct bt_tbs_instance *lookup_inst_by_handle(struct bt_conn *conn,
 							 uint16_t handle)
@@ -129,7 +131,7 @@ static uint8_t net_buf_pull_call_state(struct net_buf_simple *buf,
 	return 0;
 }
 
-
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 static uint8_t net_buf_pull_call(struct net_buf_simple *buf,
 				 struct bt_tbs_client_call *call)
 {
@@ -173,7 +175,9 @@ static uint8_t net_buf_pull_call(struct net_buf_simple *buf,
 
 	return 0;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES)
 static void call_cp_callback_handler(struct bt_conn *conn, int err,
 				     uint8_t index, uint8_t opcode,
 				     uint8_t call_index)
@@ -188,24 +192,36 @@ static void call_cp_callback_handler(struct bt_conn *conn, int err,
 	}
 
 	switch (opcode) {
+#if defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL)
 	case BT_TBS_CALL_OPCODE_ACCEPT:
 		cp_cb = tbs_client_cbs->accept_call;
 		break;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL)
 	case BT_TBS_CALL_OPCODE_TERMINATE:
 		cp_cb = tbs_client_cbs->terminate_call;
 		break;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL)
 	case BT_TBS_CALL_OPCODE_HOLD:
 		cp_cb = tbs_client_cbs->hold_call;
 		break;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL)
 	case BT_TBS_CALL_OPCODE_RETRIEVE:
 		cp_cb = tbs_client_cbs->retrieve_call;
 		break;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL)
 	case BT_TBS_CALL_OPCODE_ORIGINATE:
 		cp_cb = tbs_client_cbs->originate_call;
 		break;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS)
 	case BT_TBS_CALL_OPCODE_JOIN:
 		cp_cb = tbs_client_cbs->join_calls;
 		break;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS) */
 	default:
 		break;
 	}
@@ -214,8 +230,9 @@ static void call_cp_callback_handler(struct bt_conn *conn, int err,
 		cp_cb(conn, err, index, call_index);
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 
-static const char *parse_string_value(const void *data, uint16_t length,
+const char *parse_string_value(const void *data, uint16_t length,
 				      uint16_t max_len)
 {
 	static char string_val[CONFIG_BT_TBS_MAX_URI_LENGTH + 1];
@@ -230,6 +247,7 @@ static const char *parse_string_value(const void *data, uint16_t length,
 	return string_val;
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 static void provider_name_notify_handler(struct bt_conn *conn,
 					 const struct bt_tbs_instance *tbs_inst,
 					 const void *data, uint16_t length)
@@ -243,7 +261,9 @@ static void provider_name_notify_handler(struct bt_conn *conn,
 		tbs_client_cbs->bearer_provider_name(conn, 0, tbs_inst->index, name);
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 static void technology_notify_handler(struct bt_conn *conn,
 				      const struct bt_tbs_instance *tbs_inst,
 				      const void *data, uint16_t length)
@@ -263,7 +283,9 @@ static void technology_notify_handler(struct bt_conn *conn,
 		}
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 static void signal_strength_notify_handler(struct bt_conn *conn,
 					   const struct bt_tbs_instance *tbs_inst,
 					   const void *data, uint16_t length)
@@ -282,7 +304,9 @@ static void signal_strength_notify_handler(struct bt_conn *conn,
 		}
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 static void current_calls_notify_handler(struct bt_conn *conn,
 					 const struct bt_tbs_instance *tbs_inst,
 					 const void *data, uint16_t length)
@@ -321,7 +345,9 @@ static void current_calls_notify_handler(struct bt_conn *conn,
 		tbs_client_cbs->current_calls(conn, 0, tbs_inst->index, cnt, calls);
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
 static void status_flags_notify_handler(struct bt_conn *conn,
 					const struct bt_tbs_instance *tbs_inst,
 					const void *data, uint16_t length)
@@ -339,7 +365,9 @@ static void status_flags_notify_handler(struct bt_conn *conn,
 		}
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
 static void incoming_uri_notify_handler(struct bt_conn *conn,
 					const struct bt_tbs_instance *tbs_inst,
 					const void *data, uint16_t length)
@@ -353,6 +381,7 @@ static void incoming_uri_notify_handler(struct bt_conn *conn,
 		tbs_client_cbs->call_uri(conn, 0, tbs_inst->index, uri);
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
 
 static void call_state_notify_handler(struct bt_conn *conn,
 				      const struct bt_tbs_instance *tbs_inst,
@@ -390,6 +419,7 @@ static void call_state_notify_handler(struct bt_conn *conn,
 	}
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES)
 static void call_cp_notify_handler(struct bt_conn *conn,
 				  const struct bt_tbs_instance *tbs_inst,
 				  const void *data, uint16_t length)
@@ -409,6 +439,7 @@ static void call_cp_notify_handler(struct bt_conn *conn,
 					 ind_val->opcode, ind_val->call_index);
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES) */
 
 static void termination_reason_notify_handler(struct bt_conn *conn,
 					      const struct bt_tbs_instance *tbs_inst,
@@ -432,6 +463,7 @@ static void termination_reason_notify_handler(struct bt_conn *conn,
 	}
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 static void in_call_notify_handler(struct bt_conn *conn,
 				   const struct bt_tbs_instance *tbs_inst,
 				   const void *data, uint16_t length)
@@ -445,7 +477,9 @@ static void in_call_notify_handler(struct bt_conn *conn,
 		tbs_client_cbs->remote_uri(conn, 0, tbs_inst->index, uri);
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 static void friendly_name_notify_handler(struct bt_conn *conn,
 					 const struct bt_tbs_instance *tbs_inst,
 					 const void *data, uint16_t length)
@@ -459,6 +493,7 @@ static void friendly_name_notify_handler(struct bt_conn *conn,
 		tbs_client_cbs->friendly_name(conn, 0, tbs_inst->index, name);
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 
 /** @brief Handles notifications and indications from the server */
 static uint8_t notify_handler(struct bt_conn *conn,
@@ -487,35 +522,53 @@ static uint8_t notify_handler(struct bt_conn *conn,
 
 		BT_HEXDUMP_DBG(data, length, "notify handler value");
 
-		if (handle == tbs_inst->provider_name_handle) {
+		if (handle == tbs_inst->call_state_sub_params.value_handle) {
+			call_state_notify_handler(conn, tbs_inst, data, length);
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
+		} else if (handle == tbs_inst->name_sub_params.value_handle) {
 			provider_name_notify_handler(conn, tbs_inst, data,
 						     length);
-		} else if (handle == tbs_inst->technology_handle) {
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
+		} else if (handle == tbs_inst->technology_sub_params.value_handle) {
 			technology_notify_handler(conn, tbs_inst, data, length);
-		} else if (handle == tbs_inst->signal_strength_handle) {
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
+		} else if (handle == tbs_inst->signal_strength_sub_params.value_handle) {
 			signal_strength_notify_handler(conn, tbs_inst, data,
 						       length);
-		} else if (handle == tbs_inst->status_flags_handle) {
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
+		} else if (handle == tbs_inst->status_flags_sub_params.value_handle) {
 			status_flags_notify_handler(conn, tbs_inst, data,
 						    length);
-		} else if (handle == tbs_inst->current_calls_handle) {
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
+		} else if (handle == tbs_inst->current_calls_sub_params.value_handle) {
 			current_calls_notify_handler(conn, tbs_inst, data,
 						     length);
-		} else if (handle == tbs_inst->in_uri_handle) {
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
+		} else if (handle == tbs_inst->in_target_uri_sub_params.value_handle) {
 			incoming_uri_notify_handler(conn, tbs_inst, data,
 						    length);
-		} else if (handle == tbs_inst->call_state_handle) {
-			call_state_notify_handler(conn, tbs_inst, data, length);
-		} else if (handle == tbs_inst->call_cp_handle) {
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
+#if defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES)
+		} else if (handle == tbs_inst->call_cp_sub_params.value_handle) {
 			call_cp_notify_handler(conn, tbs_inst, data, length);
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES) */
 		} else if (handle == tbs_inst->termination_reason_handle) {
 			termination_reason_notify_handler(conn, tbs_inst, data,
 							  length);
-		} else if (handle == tbs_inst->in_call_handle) {
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
+		} else if (handle == tbs_inst->incoming_call_sub_params.value_handle) {
 			in_call_notify_handler(conn, tbs_inst, data, length);
-		} else if (handle == tbs_inst->friendly_name_handle) {
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
+		} else if (handle == tbs_inst->friendly_name_sub_params.value_handle) {
 			friendly_name_notify_handler(conn, tbs_inst, data,
 						     length);
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 		}
 	} else {
 		BT_DBG("Notification/Indication on unknown TBS inst");
@@ -524,6 +577,7 @@ static uint8_t notify_handler(struct bt_conn *conn,
 	return BT_GATT_ITER_CONTINUE;
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES)
 static int tbs_client_common_call_control(struct bt_conn *conn,
 					  uint8_t inst_index,
 					  uint8_t call_index,
@@ -536,7 +590,7 @@ static int tbs_client_common_call_control(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
-	if (inst->call_cp_handle == 0) {
+	if (inst->call_cp_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
@@ -544,10 +598,12 @@ static int tbs_client_common_call_control(struct bt_conn *conn,
 	common.opcode = opcode;
 	common.call_index = call_index;
 
-	return bt_gatt_write_without_response(conn, inst->call_cp_handle,
+	return bt_gatt_write_without_response(conn, inst->call_cp_sub_params.value_handle,
 					      &common, sizeof(common), false);
 }
+#endif /* CONFIG_BT_TBS_CLIENT_CP_PROCEDURES */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 static uint8_t read_bearer_provider_name_cb(struct bt_conn *conn, uint8_t err,
 					    struct bt_gatt_read_params *params,
 					    const void *data, uint16_t length)
@@ -584,7 +640,9 @@ static uint8_t read_bearer_provider_name_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 static uint8_t read_bearer_uci_cb(struct bt_conn *conn, uint8_t err,
 				   struct bt_gatt_read_params *params,
 				   const void *data, uint16_t length)
@@ -619,7 +677,9 @@ static uint8_t read_bearer_uci_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 static uint8_t read_technology_cb(struct bt_conn *conn, uint8_t err,
 				   struct bt_gatt_read_params *params,
 				   const void *data, uint16_t length)
@@ -663,7 +723,9 @@ static uint8_t read_technology_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 static uint8_t read_uri_list_cb(struct bt_conn *conn, uint8_t err,
 				    struct bt_gatt_read_params *params,
 				    const void *data, uint16_t length)
@@ -699,7 +761,9 @@ static uint8_t read_uri_list_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 static uint8_t read_signal_strength_cb(struct bt_conn *conn, uint8_t err,
 					struct bt_gatt_read_params *params,
 					const void *data, uint16_t length)
@@ -741,7 +805,9 @@ static uint8_t read_signal_strength_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL)
 static uint8_t read_signal_interval_cb(struct bt_conn *conn, uint8_t err,
 					struct bt_gatt_read_params *params,
 					const void *data, uint16_t length)
@@ -783,7 +849,9 @@ static uint8_t read_signal_interval_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 static uint8_t read_current_calls_cb(struct bt_conn *conn, uint8_t err,
 				      struct bt_gatt_read_params *params,
 				      const void *data, uint16_t length)
@@ -876,7 +944,9 @@ static uint8_t read_current_calls_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 static uint8_t read_ccid_cb(struct bt_conn *conn, uint8_t err,
 			    struct bt_gatt_read_params *params,
 			    const void *data, uint16_t length)
@@ -917,7 +987,9 @@ static uint8_t read_ccid_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
 static uint8_t read_status_flags_cb(struct bt_conn *conn, uint8_t err,
 				    struct bt_gatt_read_params *params,
 				    const void *data, uint16_t length)
@@ -960,7 +1032,9 @@ static uint8_t read_status_flags_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
 static uint8_t read_call_uri_cb(struct bt_conn *conn, uint8_t err,
 				struct bt_gatt_read_params *params,
 				const void *data, uint16_t length)
@@ -997,6 +1071,7 @@ static uint8_t read_call_uri_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
 
 static uint8_t read_call_state_cb(struct bt_conn *conn, uint8_t err,
 				  struct bt_gatt_read_params *params,
@@ -1088,6 +1163,7 @@ static uint8_t read_call_state_cb(struct bt_conn *conn, uint8_t err,
 	return BT_GATT_ITER_STOP;
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 static uint8_t read_optional_opcodes_cb(struct bt_conn *conn, uint8_t err,
 					struct bt_gatt_read_params *params,
 					const void *data, uint16_t length)
@@ -1131,7 +1207,9 @@ static uint8_t read_optional_opcodes_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 static uint8_t read_remote_uri_cb(struct bt_conn *conn, uint8_t err,
 				  struct bt_gatt_read_params *params,
 				  const void *data, uint16_t length)
@@ -1168,7 +1246,9 @@ static uint8_t read_remote_uri_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 static uint8_t read_friendly_name_cb(struct bt_conn *conn, uint8_t err,
 					 struct bt_gatt_read_params *params,
 					 const void *data, uint16_t length)
@@ -1204,7 +1284,9 @@ static uint8_t read_friendly_name_cb(struct bt_conn *conn, uint8_t err,
 
 	return BT_GATT_ITER_STOP;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 static uint8_t disc_read_ccid_cb(struct bt_conn *conn, uint8_t err,
 				 struct bt_gatt_read_params *params,
 				 const void *data, uint16_t length)
@@ -1291,6 +1373,7 @@ static void tbs_client_disc_read_ccid(struct bt_conn *conn)
 		}
 	}
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
 
 /**
  * @brief This will discover all characteristics on the server, retrieving the
@@ -1306,8 +1389,10 @@ static uint8_t discover_func(struct bt_conn *conn,
 	struct bt_tbs_instance *current_inst = srv_inst->current_inst;
 
 	if (attr == NULL) {
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 		/* Read the CCID as the last part of discovering a TBS instance */
 		tbs_client_disc_read_ccid(conn);
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
 
 		return BT_GATT_ITER_STOP;
 	}
@@ -1319,76 +1404,108 @@ static uint8_t discover_func(struct bt_conn *conn,
 		struct bt_gatt_subscribe_params *sub_params = NULL;
 
 		chrc = (struct bt_gatt_chrc *)attr->user_data;
-		if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_PROVIDER_NAME) == 0) {
+
+		if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_CALL_STATE) == 0) {
+			BT_DBG("Call state");
+			sub_params = &current_inst->call_state_sub_params;
+			sub_params->value_handle = chrc->value_handle;
+			sub_params->disc_params = &current_inst->call_state_sub_disc_params;
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
+		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_PROVIDER_NAME) == 0) {
 			BT_DBG("Provider name");
-			current_inst->provider_name_handle = chrc->value_handle;
 			sub_params = &current_inst->name_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->name_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_UCI) == 0) {
 			BT_DBG("Bearer UCI");
 			current_inst->bearer_uci_handle = chrc->value_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_TECHNOLOGY) == 0) {
 			BT_DBG("Technology");
-			current_inst->technology_handle = chrc->value_handle;
 			sub_params = &current_inst->technology_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->technology_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_URI_LIST) == 0) {
 			BT_DBG("URI Scheme List");
 			current_inst->uri_list_handle = chrc->value_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_SIGNAL_STRENGTH) == 0) {
 			BT_DBG("Signal strength");
-			current_inst->signal_strength_handle = chrc->value_handle;
 			sub_params = &current_inst->signal_strength_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->signal_strength_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
+#if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) \
+|| defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_SIGNAL_INTERVAL) == 0) {
 			BT_DBG("Signal strength reporting interval");
 			current_inst->signal_interval_handle = chrc->value_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
+/* || defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_LIST_CURRENT_CALLS) == 0) {
 			BT_DBG("Current calls");
-			current_inst->current_calls_handle = chrc->value_handle;
 			sub_params = &current_inst->current_calls_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->current_calls_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_CCID) == 0) {
 			BT_DBG("CCID");
 			current_inst->ccid_handle = chrc->value_handle;
-		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_STATUS_FLAGS) == 0) {
-			BT_DBG("Status flags");
-			current_inst->status_flags_handle = chrc->value_handle;
-			sub_params = &current_inst->status_flags_sub_params;
-			sub_params->disc_params = &current_inst->status_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_INCOMING_URI) == 0) {
 			BT_DBG("Incoming target URI");
-			current_inst->in_uri_handle = chrc->value_handle;
 			sub_params = &current_inst->in_target_uri_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->in_target_uri_sub_disc_params;
-		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_CALL_STATE) == 0) {
-			BT_DBG("Call state");
-			current_inst->call_state_handle = chrc->value_handle;
-			sub_params = &current_inst->call_state_sub_params;
-			sub_params->disc_params = &current_inst->call_state_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
+		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_STATUS_FLAGS) == 0) {
+			BT_DBG("Status flags");
+			sub_params = &current_inst->status_flags_sub_params;
+			sub_params->value_handle = chrc->value_handle;
+			sub_params->disc_params = &current_inst->status_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
+#if defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_CALL_CONTROL_POINT) == 0) {
 			BT_DBG("Call control point");
-			current_inst->call_cp_handle = chrc->value_handle;
 			sub_params = &current_inst->call_cp_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->call_cp_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES) */
+#if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_OPTIONAL_OPCODES) == 0) {
 			BT_DBG("Supported opcodes");
 			current_inst->optional_opcodes_handle = chrc->value_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_TERMINATE_REASON) == 0) {
 			BT_DBG("Termination reason");
 			current_inst->termination_reason_handle = chrc->value_handle;
 			sub_params = &current_inst->termination_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->termination_sub_disc_params;
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_FRIENDLY_NAME) == 0) {
 			BT_DBG("Incoming friendly name");
-			current_inst->friendly_name_handle = chrc->value_handle;
 			sub_params = &current_inst->friendly_name_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->friendly_name_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 		} else if (bt_uuid_cmp(chrc->uuid, BT_UUID_TBS_INCOMING_CALL) == 0) {
 			BT_DBG("Incoming call");
-			current_inst->in_call_handle = chrc->value_handle;
 			sub_params = &current_inst->incoming_call_sub_params;
+			sub_params->value_handle = chrc->value_handle;
 			sub_params->disc_params = &current_inst->incoming_call_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
 		}
 
 		if (srv_insts[conn_index].subscribe_all && sub_params != NULL) {
@@ -1405,7 +1522,6 @@ static uint8_t discover_func(struct bt_conn *conn,
 				/* Setting ccc_handle = will use auto discovery feature */
 				sub_params->ccc_handle = 0;
 				sub_params->end_handle = current_inst->end_handle;
-				sub_params->value_handle = chrc->value_handle;
 				sub_params->notify = notify_handler;
 				err = bt_gatt_subscribe(conn, sub_params);
 				if (err != 0) {
@@ -1570,34 +1686,43 @@ static uint8_t primary_discover_func(struct bt_conn *conn,
 
 /****************************** PUBLIC API ******************************/
 
+#if defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL)
 int bt_tbs_client_hold_call(struct bt_conn *conn, uint8_t inst_index,
 			    uint8_t call_index)
 {
 	return tbs_client_common_call_control(conn, inst_index, call_index,
 					      BT_TBS_CALL_OPCODE_HOLD);
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL)
 int bt_tbs_client_accept_call(struct bt_conn *conn, uint8_t inst_index,
 			      uint8_t call_index)
 {
 	return tbs_client_common_call_control(conn, inst_index, call_index,
 					      BT_TBS_CALL_OPCODE_ACCEPT);
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL)
 int bt_tbs_client_retrieve_call(struct bt_conn *conn, uint8_t inst_index,
 				uint8_t call_index)
 {
 	return tbs_client_common_call_control(conn, inst_index, call_index,
 					      BT_TBS_CALL_OPCODE_RETRIEVE);
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL)
 int bt_tbs_client_terminate_call(struct bt_conn *conn, uint8_t inst_index,
 				 uint8_t call_index)
 {
 	return tbs_client_common_call_control(conn, inst_index, call_index,
 					      BT_TBS_CALL_OPCODE_TERMINATE);
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL)
 int bt_tbs_client_originate_call(struct bt_conn *conn, uint8_t inst_index,
 				 const char *uri)
 {
@@ -1636,12 +1761,14 @@ int bt_tbs_client_originate_call(struct bt_conn *conn, uint8_t inst_index,
 	originate->opcode = BT_TBS_CALL_OPCODE_ORIGINATE;
 	(void)memcpy(originate->uri, uri, uri_len);
 
-	return bt_gatt_write_without_response(conn, inst->call_cp_handle,
+	return bt_gatt_write_without_response(conn, inst->call_cp_sub_params.value_handle,
 					      originate,
 					      sizeof(*originate) + uri_len,
 					      false);
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS)
 int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
 			     const uint8_t *call_indexes, uint8_t count)
 {
@@ -1660,7 +1787,7 @@ int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
 		inst = get_inst_by_index(conn, inst_index);
 		if (inst == NULL) {
 			return -EINVAL;
-		} else if (inst->call_cp_handle == 0) {
+		} else if (inst->call_cp_sub_params.value_handle == 0) {
 			BT_DBG("Handle not set");
 			return -EINVAL;
 		}
@@ -1677,7 +1804,7 @@ int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
 		(void)memcpy(join->call_indexes, call_indexes, count);
 
 		return bt_gatt_write_without_response(conn,
-						      inst->call_cp_handle,
+						      inst->call_cp_sub_params.value_handle,
 						      join,
 						      sizeof(*join) + count,
 						      false);
@@ -1685,7 +1812,9 @@ int bt_tbs_client_join_calls(struct bt_conn *conn, uint8_t inst_index,
 
 	return -EINVAL;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL)
 int bt_tbs_client_set_signal_strength_interval(struct bt_conn *conn,
 					       uint8_t inst_index,
 					       uint8_t interval)
@@ -1710,7 +1839,9 @@ int bt_tbs_client_set_signal_strength_interval(struct bt_conn *conn,
 					      &interval, sizeof(interval),
 					      false);
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 int bt_tbs_client_read_bearer_provider_name(struct bt_conn *conn,
 					    uint8_t inst_index)
 {
@@ -1725,14 +1856,14 @@ int bt_tbs_client_read_bearer_provider_name(struct bt_conn *conn,
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->provider_name_handle == 0) {
+	if (inst->name_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_bearer_provider_name_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->provider_name_handle;
+	inst->read_params.single.handle = inst->name_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -1742,7 +1873,9 @@ int bt_tbs_client_read_bearer_provider_name(struct bt_conn *conn,
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 int bt_tbs_client_read_bearer_uci(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -1773,7 +1906,9 @@ int bt_tbs_client_read_bearer_uci(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 int bt_tbs_client_read_technology(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -1787,14 +1922,14 @@ int bt_tbs_client_read_technology(struct bt_conn *conn, uint8_t inst_index)
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->technology_handle == 0) {
+	if (inst->technology_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_technology_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->technology_handle;
+	inst->read_params.single.handle = inst->technology_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -1804,7 +1939,9 @@ int bt_tbs_client_read_technology(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 int bt_tbs_client_read_uri_list(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -1835,7 +1972,9 @@ int bt_tbs_client_read_uri_list(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 int bt_tbs_client_read_signal_strength(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -1849,14 +1988,14 @@ int bt_tbs_client_read_signal_strength(struct bt_conn *conn, uint8_t inst_index)
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->signal_strength_handle == 0) {
+	if (inst->signal_strength_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_signal_strength_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->signal_strength_handle;
+	inst->read_params.single.handle = inst->signal_strength_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -1866,7 +2005,9 @@ int bt_tbs_client_read_signal_strength(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL)
 int bt_tbs_client_read_signal_interval(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -1897,7 +2038,9 @@ int bt_tbs_client_read_signal_interval(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 int bt_tbs_client_read_current_calls(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -1911,14 +2054,14 @@ int bt_tbs_client_read_current_calls(struct bt_conn *conn, uint8_t inst_index)
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->current_calls_handle == 0) {
+	if (inst->current_calls_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_current_calls_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->current_calls_handle;
+	inst->read_params.single.handle = inst->current_calls_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -1928,7 +2071,9 @@ int bt_tbs_client_read_current_calls(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 int bt_tbs_client_read_ccid(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -1959,38 +2104,9 @@ int bt_tbs_client_read_ccid(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
 
-int bt_tbs_client_read_status_flags(struct bt_conn *conn, uint8_t inst_index)
-{
-	int err;
-	struct bt_tbs_instance *inst;
-
-	if (conn == NULL) {
-		return -ENOTCONN;
-	} else if (!valid_inst_index(conn, inst_index)) {
-		return -EINVAL;
-	}
-
-	inst = get_inst_by_index(conn, inst_index);
-
-	if (inst->status_flags_handle == 0) {
-		BT_DBG("Handle not set");
-		return -EINVAL;
-	}
-
-	inst->read_params.func = read_status_flags_cb;
-	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->status_flags_handle;
-	inst->read_params.single.offset = 0U;
-
-	err = bt_gatt_read(conn, &inst->read_params);
-	if (err != 0) {
-		(void)memset(&inst->read_params, 0, sizeof(inst->read_params));
-	}
-
-	return err;
-}
-
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
 int bt_tbs_client_read_call_uri(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -2004,14 +2120,14 @@ int bt_tbs_client_read_call_uri(struct bt_conn *conn, uint8_t inst_index)
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->in_uri_handle == 0) {
+	if (inst->in_target_uri_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_call_uri_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->in_uri_handle;
+	inst->read_params.single.handle = inst->in_target_uri_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -2021,6 +2137,40 @@ int bt_tbs_client_read_call_uri(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
+
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
+int bt_tbs_client_read_status_flags(struct bt_conn *conn, uint8_t inst_index)
+{
+	int err;
+	struct bt_tbs_instance *inst;
+
+	if (conn == NULL) {
+		return -ENOTCONN;
+	} else if (!valid_inst_index(conn, inst_index)) {
+		return -EINVAL;
+	}
+
+	inst = get_inst_by_index(conn, inst_index);
+
+	if (inst->status_flags_sub_params.value_handle == 0) {
+		BT_DBG("Handle not set");
+		return -EINVAL;
+	}
+
+	inst->read_params.func = read_status_flags_cb;
+	inst->read_params.handle_count = 1;
+	inst->read_params.single.handle = inst->status_flags_sub_params.value_handle;
+	inst->read_params.single.offset = 0U;
+
+	err = bt_gatt_read(conn, &inst->read_params);
+	if (err != 0) {
+		(void)memset(&inst->read_params, 0, sizeof(inst->read_params));
+	}
+
+	return err;
+}
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
 
 int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index)
 {
@@ -2035,14 +2185,14 @@ int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index)
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->call_state_handle == 0) {
+	if (inst->call_state_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_call_state_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->call_state_handle;
+	inst->read_params.single.handle = inst->call_state_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -2053,6 +2203,7 @@ int bt_tbs_client_read_call_state(struct bt_conn *conn, uint8_t inst_index)
 	return err;
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 int bt_tbs_client_read_optional_opcodes(struct bt_conn *conn,
 					uint8_t inst_index)
 {
@@ -2084,7 +2235,9 @@ int bt_tbs_client_read_optional_opcodes(struct bt_conn *conn,
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 int bt_tbs_client_read_remote_uri(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -2098,14 +2251,14 @@ int bt_tbs_client_read_remote_uri(struct bt_conn *conn, uint8_t inst_index)
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->in_call_handle == 0) {
+	if (inst->incoming_call_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_remote_uri_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->in_call_handle;
+	inst->read_params.single.handle = inst->incoming_call_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -2115,7 +2268,9 @@ int bt_tbs_client_read_remote_uri(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index)
 {
 	int err;
@@ -2129,14 +2284,14 @@ int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index)
 
 	inst = get_inst_by_index(conn, inst_index);
 
-	if (inst->friendly_name_handle == 0) {
+	if (inst->friendly_name_sub_params.value_handle == 0) {
 		BT_DBG("Handle not set");
 		return -EINVAL;
 	}
 
 	inst->read_params.func = read_friendly_name_cb;
 	inst->read_params.handle_count = 1;
-	inst->read_params.single.handle = inst->friendly_name_handle;
+	inst->read_params.single.handle = inst->friendly_name_sub_params.value_handle;
 	inst->read_params.single.offset = 0U;
 
 	err = bt_gatt_read(conn, &inst->read_params);
@@ -2146,6 +2301,7 @@ int bt_tbs_client_read_friendly_name(struct bt_conn *conn, uint8_t inst_index)
 
 	return err;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 
 int bt_tbs_client_discover(struct bt_conn *conn, bool subscribe)
 {
@@ -2188,6 +2344,7 @@ void bt_tbs_client_register_cb(const struct bt_tbs_client_cb *cbs)
 	tbs_client_cbs = cbs;
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 struct bt_tbs_instance *bt_tbs_client_get_by_ccid(const struct bt_conn *conn,
 						  uint8_t ccid)
 {
@@ -2208,3 +2365,4 @@ struct bt_tbs_instance *bt_tbs_client_get_by_ccid(const struct bt_conn *conn,
 
 	return NULL;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */

--- a/subsys/bluetooth/audio/tbs_internal.h
+++ b/subsys/bluetooth/audio/tbs_internal.h
@@ -36,6 +36,9 @@
 
 #define FIRST_PRINTABLE_ASCII_CHAR ' ' /* space */
 
+const char *parse_string_value(const void *data, uint16_t length,
+				      uint16_t max_len);
+
 static inline const char *bt_tbs_state_str(uint8_t state)
 {
 	switch (state) {
@@ -288,52 +291,73 @@ struct bt_tbs_instance {
 
 	uint16_t start_handle;
 	uint16_t end_handle;
-	uint16_t provider_name_handle;
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 	uint16_t bearer_uci_handle;
-	uint16_t technology_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 	uint16_t uri_list_handle;
-	uint16_t signal_strength_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
+#if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) \
+|| defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL)
 	uint16_t signal_interval_handle;
-	uint16_t current_calls_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
+/* || defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL) */
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 	uint16_t ccid_handle;
-	uint16_t status_flags_handle;
-	uint16_t in_uri_handle;
-	uint16_t call_state_handle;
-	uint16_t call_cp_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
+#if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 	uint16_t optional_opcodes_handle;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 	uint16_t termination_reason_handle;
-	uint16_t friendly_name_handle;
-	uint16_t in_call_handle;
 
 	bool busy;
 	uint8_t subscribe_cnt;
 	uint8_t index;
 	bool gtbs;
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 	uint8_t ccid;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 	struct bt_gatt_subscribe_params name_sub_params;
 	struct bt_gatt_discover_params name_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 	struct bt_gatt_subscribe_params technology_sub_params;
 	struct bt_gatt_discover_params technology_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 	struct bt_gatt_subscribe_params signal_strength_sub_params;
 	struct bt_gatt_discover_params signal_strength_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 	struct bt_gatt_subscribe_params current_calls_sub_params;
 	struct bt_gatt_discover_params current_calls_sub_disc_params;
-	struct bt_gatt_subscribe_params in_target_uri_sub_params;
-	struct bt_gatt_discover_params in_target_uri_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
 	struct bt_gatt_subscribe_params status_flags_sub_params;
 	struct bt_gatt_discover_params status_sub_disc_params;
-	struct bt_gatt_subscribe_params call_state_sub_params;
-	struct bt_gatt_discover_params call_state_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
+	struct bt_gatt_subscribe_params in_target_uri_sub_params;
+	struct bt_gatt_discover_params in_target_uri_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
+#if defined(CONFIG_BT_TBS_CLIENT_CP_PROCEDURES)
 	struct bt_gatt_subscribe_params call_cp_sub_params;
 	struct bt_gatt_discover_params call_cp_sub_disc_params;
-	struct bt_gatt_subscribe_params termination_sub_params;
-	struct bt_gatt_discover_params termination_sub_disc_params;
-	struct bt_gatt_subscribe_params incoming_call_sub_params;
-	struct bt_gatt_discover_params incoming_call_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 	struct bt_gatt_subscribe_params friendly_name_sub_params;
 	struct bt_gatt_discover_params friendly_name_sub_disc_params;
-
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
+	struct bt_gatt_subscribe_params incoming_call_sub_params;
+	struct bt_gatt_discover_params incoming_call_sub_disc_params;
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
+	struct bt_gatt_subscribe_params call_state_sub_params;
+	struct bt_gatt_discover_params call_state_sub_disc_params;
+	struct bt_gatt_subscribe_params termination_sub_params;
+	struct bt_gatt_discover_params termination_sub_disc_params;
 	struct bt_gatt_read_params read_params;
 	uint8_t read_buf[BT_ATT_MAX_ATTRIBUTE_LEN];
 	struct net_buf_simple net_buf;

--- a/subsys/bluetooth/shell/tbs_client.c
+++ b/subsys/bluetooth/shell/tbs_client.c
@@ -46,6 +46,7 @@ static int cmd_tbs_client_discover(const struct shell *sh, size_t argc,
 	return result;
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL)
 static int cmd_tbs_client_set_signal_strength_interval(const struct shell *sh,
 						       size_t argc,
 						       char *argv[])
@@ -83,7 +84,9 @@ static int cmd_tbs_client_set_signal_strength_interval(const struct shell *sh,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL)
 static int cmd_tbs_client_hold(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
@@ -118,7 +121,9 @@ static int cmd_tbs_client_hold(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL)
 static int cmd_tbs_client_retrieve(const struct shell *sh, size_t argc,
 				   char *argv[])
 {
@@ -154,7 +159,9 @@ static int cmd_tbs_client_retrieve(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL)
 static int cmd_tbs_client_accept(const struct shell *sh, size_t argc,
 				 char *argv[])
 {
@@ -191,8 +198,9 @@ static int cmd_tbs_client_accept(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL) */
 
-#if CONFIG_BT_TBS_CLIENT_MAX_CALLS > 1
+#if defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS)
 static int cmd_tbs_client_join(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
@@ -230,8 +238,9 @@ static int cmd_tbs_client_join(const struct shell *sh, size_t argc,
 
 	return result;
 }
-#endif /* CONFIG_BT_TBS_CLIENT_MAX_CALLS > 1 */
+#endif /* defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL)
 static int cmd_tbs_client_terminate(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
@@ -267,7 +276,9 @@ static int cmd_tbs_client_terminate(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL)
 static int cmd_tbs_client_originate(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
@@ -296,7 +307,9 @@ static int cmd_tbs_client_originate(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 static int cmd_tbs_client_read_bearer_provider_name(const struct shell *sh,
 						    size_t argc, char *argv[])
 {
@@ -325,7 +338,9 @@ static int cmd_tbs_client_read_bearer_provider_name(const struct shell *sh,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 static int cmd_tbs_client_read_bearer_uci(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
@@ -353,7 +368,9 @@ static int cmd_tbs_client_read_bearer_uci(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 static int cmd_tbs_client_read_technology(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
@@ -381,7 +398,9 @@ static int cmd_tbs_client_read_technology(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 static int cmd_tbs_client_read_uri_list(const struct shell *sh, size_t argc,
 					char *argv[])
 {
@@ -409,7 +428,9 @@ static int cmd_tbs_client_read_uri_list(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 static int cmd_tbs_client_read_signal_strength(const struct shell *sh,
 					       size_t argc, char *argv[])
 {
@@ -437,7 +458,9 @@ static int cmd_tbs_client_read_signal_strength(const struct shell *sh,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL)
 static int cmd_tbs_client_read_signal_interval(const struct shell *sh,
 					       size_t argc, char *argv[])
 {
@@ -465,7 +488,9 @@ static int cmd_tbs_client_read_signal_interval(const struct shell *sh,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 static int cmd_tbs_client_read_current_calls(const struct shell *sh,
 					     size_t argc, char *argv[])
 {
@@ -493,7 +518,9 @@ static int cmd_tbs_client_read_current_calls(const struct shell *sh,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 static int cmd_tbs_client_read_ccid(const struct shell *sh, size_t argc,
 				    char *argv[])
 {
@@ -521,7 +548,39 @@ static int cmd_tbs_client_read_ccid(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
+static int cmd_tbs_client_read_uri(const struct shell *sh, size_t argc,
+				   char *argv[])
+{
+	int result;
+	int inst_index;
+
+	if (argc > 1) {
+		if (strcmp(argv[1], "gtbs") == 0) {
+			inst_index = BT_TBS_GTBS_INDEX;
+		} else {
+			inst_index = strtol(argv[1], NULL, 0);
+			if (inst_index < 0 || inst_index > UINT8_MAX) {
+				shell_error(sh, "Invalid index");
+				return -ENOEXEC;
+			}
+		}
+	} else {
+		inst_index = 0;
+	}
+
+	result = bt_tbs_client_read_call_uri(default_conn, inst_index);
+	if (result != 0) {
+		shell_print(sh, "Fail: %d", result);
+	}
+
+	return result;
+}
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
+
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
 static int cmd_tbs_client_read_status_flags(const struct shell *sh, size_t argc,
 					    char *argv[])
 {
@@ -549,34 +608,7 @@ static int cmd_tbs_client_read_status_flags(const struct shell *sh, size_t argc,
 
 	return result;
 }
-
-static int cmd_tbs_client_read_uri(const struct shell *sh, size_t argc,
-				   char *argv[])
-{
-	int result;
-	int inst_index;
-
-	if (argc > 1) {
-		if (strcmp(argv[1], "gtbs") == 0) {
-			inst_index = BT_TBS_GTBS_INDEX;
-		} else {
-			inst_index = strtol(argv[1], NULL, 0);
-			if (inst_index < 0 || inst_index > UINT8_MAX) {
-				shell_error(sh, "Invalid index");
-				return -ENOEXEC;
-			}
-		}
-	} else {
-		inst_index = 0;
-	}
-
-	result = bt_tbs_client_read_remote_uri(default_conn, inst_index);
-	if (result != 0) {
-		shell_print(sh, "Fail: %d", result);
-	}
-
-	return result;
-}
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
 
 static int cmd_tbs_client_read_call_state(const struct shell *sh, size_t argc,
 					  char *argv[])
@@ -606,6 +638,7 @@ static int cmd_tbs_client_read_call_state(const struct shell *sh, size_t argc,
 	return result;
 }
 
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 static int cmd_tbs_client_read_remote_uri(const struct shell *sh, size_t argc,
 					  char *argv[])
 {
@@ -633,7 +666,9 @@ static int cmd_tbs_client_read_remote_uri(const struct shell *sh, size_t argc,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 static int cmd_tbs_client_read_friendly_name(const struct shell *sh,
 					     size_t argc, char *argv[])
 {
@@ -661,7 +696,9 @@ static int cmd_tbs_client_read_friendly_name(const struct shell *sh,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
 
+#if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 static int cmd_tbs_client_read_optional_opcodes(const struct shell *sh,
 						size_t argc, char *argv[])
 {
@@ -689,6 +726,7 @@ static int cmd_tbs_client_read_optional_opcodes(const struct shell *sh,
 
 	return result;
 }
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 
 static int cmd_tbs_client(const struct shell *sh, size_t argc, char **argv)
 {
@@ -706,80 +744,120 @@ SHELL_STATIC_SUBCMD_SET_CREATE(tbs_client_cmds,
 	SHELL_CMD_ARG(discover, NULL,
 		      "Discover TBS [subscribe]",
 		      cmd_tbs_client_discover, 1, 1),
+
+#if defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL)
 	SHELL_CMD_ARG(set_signal_reporting_interval, NULL,
 		      "Set the signal reporting interval "
 		      "[<{instance_index, gtbs}>] <interval>",
 		      cmd_tbs_client_set_signal_strength_interval, 2, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_SET_BEARER_SIGNAL_INTERVAL) */
+#if defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL)
 	SHELL_CMD_ARG(originate, NULL,
 		      "Originate a call [<{instance_index, gtbs}>] <uri>",
 		      cmd_tbs_client_originate, 2, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ORIGINATE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL)
 	SHELL_CMD_ARG(terminate, NULL,
 		      "terminate a call [<{instance_index, gtbs}>] <id>",
 		      cmd_tbs_client_terminate, 2, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_TERMINATE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL)
 	SHELL_CMD_ARG(accept, NULL,
 		      "Accept a call [<{instance_index, gtbs}>] <id>",
 		      cmd_tbs_client_accept, 2, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_ACCEPT_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL)
 	SHELL_CMD_ARG(hold, NULL,
 		      "Place a call on hold [<{instance_index, gtbs}>] <id>",
 		      cmd_tbs_client_hold, 2, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_HOLD_CALL) */
+
+#if defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL)
 	SHELL_CMD_ARG(retrieve, NULL,
 		      "Retrieve a held call [<{instance_index, gtbs}>] <id>",
 		      cmd_tbs_client_retrieve, 2, 1),
-#if CONFIG_BT_TBS_CLIENT_MAX_CALLS > 1
+#endif /* defined(CONFIG_BT_TBS_CLIENT_RETRIEVE_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS)
 	SHELL_CMD_ARG(join, NULL,
 		      "Join calls <{instance_index, gtbs}> "
 		      "<id> <id> [<id> [<id> [...]]]",
 		      cmd_tbs_client_join, 4,
 		      CONFIG_BT_TBS_CLIENT_MAX_CALLS - 2),
-#endif /* CONFIG_BT_TBS_CLIENT_MAX_CALLS > 1 */
+#endif /* defined(CONFIG_BT_TBS_CLIENT_JOIN_CALLS) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME)
 	SHELL_CMD_ARG(read_provider_name, NULL,
 		      "Read the bearer name [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_bearer_provider_name, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_PROVIDER_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI)
 	SHELL_CMD_ARG(read_bearer_uci, NULL,
 		      "Read the bearer UCI [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_bearer_uci, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_UCI) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY)
 	SHELL_CMD_ARG(read_technology, NULL,
 		      "Read the bearer technology [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_technology, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_TECHNOLOGY) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST)
 	SHELL_CMD_ARG(read_uri_list, NULL,
 		      "Read the bearer's supported URI list "
 		      "[<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_uri_list, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_URI_SCHEMES_SUPPORTED_LIST) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH)
 	SHELL_CMD_ARG(read_signal_strength, NULL,
 		      "Read the bearer signal strength "
 		      "[<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_signal_strength, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_SIGNAL_STRENGTH) */
+#if defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL)
 	SHELL_CMD_ARG(read_signal_interval, NULL,
 		      "Read the bearer signal strength reporting interval "
 		      "[<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_signal_interval, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_READ_BEARER_SIGNAL_INTERVAL) */
+#if defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS)
 	SHELL_CMD_ARG(read_current_calls, NULL,
 		      "Read the current calls [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_current_calls, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_BEARER_LIST_CURRENT_CALLS) */
+#if defined(CONFIG_BT_TBS_CLIENT_CCID)
 	SHELL_CMD_ARG(read_ccid, NULL,
 		      "Read the CCID [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_ccid, 1, 1),
-	SHELL_CMD_ARG(read_status_flags, NULL,
-		      "Read the in feature and status value "
-		      "[<{instance_index, gtbs}>]",
-		      cmd_tbs_client_read_status_flags, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CCID) */
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI)
 	SHELL_CMD_ARG(read_uri, NULL,
 		      "Read the incoming call target URI "
 		      "[<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_uri, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_URI) */
+#if defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS)
+	SHELL_CMD_ARG(read_status_flags, NULL,
+		      "Read the in feature and status value "
+		      "[<{instance_index, gtbs}>]",
+		      cmd_tbs_client_read_status_flags, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_STATUS_FLAGS) */
 	SHELL_CMD_ARG(read_call_state, NULL,
 		      "Read the call state [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_call_state, 1, 1),
+#if defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL)
 	SHELL_CMD_ARG(read_remote_uri, NULL,
 		      "Read the incoming remote URI [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_remote_uri, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_INCOMING_CALL) */
+#if defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME)
 	SHELL_CMD_ARG(read_friendly_name, NULL,
 		      "Read the friendly name of an incoming call "
 		      "[<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_friendly_name, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_CALL_FRIENDLY_NAME) */
+#if defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES)
 	SHELL_CMD_ARG(read_optional_opcodes, NULL,
 		      "Read the optional opcodes [<{instance_index, gtbs}>]",
 		      cmd_tbs_client_read_optional_opcodes, 1, 1),
+#endif /* defined(CONFIG_BT_TBS_CLIENT_OPTIONAL_OPCODES) */
 	SHELL_SUBCMD_SET_END
 );
 

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/tbs_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/tbs_client_test.c
@@ -102,7 +102,6 @@ static const struct bt_tbs_client_cb tbs_client_cbs = {
 	.hold_call = NULL,
 	.accept_call = NULL,
 	.retrieve_call = NULL,
-	.join_calls = NULL,
 	.bearer_provider_name = tbs_client_read_bearer_provider_name,
 	.bearer_uci = NULL,
 	.technology = NULL,


### PR DESCRIPTION
This change makes the optional procedures in the TBS Client optional
and configurable through Kconfig.

Signed-off-by: Fredrik Danebjer <fredrik@danebjer.com>