### PR TITLE
drivers: nordic_nrf_temp: nrfx: Fix build warning into temp_nrf5_init

### DIFF
--- a/drivers/sensor/nrf5/temp_nrf5.c
+++ b/drivers/sensor/nrf5/temp_nrf5.c
@@ -112,8 +112,6 @@ static int temp_nrf5_init(const struct device *dev)
 {
 	struct temp_nrf5_data *data = dev->data;
 
-	LOG_DBG("");
-
 	/* A null clk_mgr indicates sensor has not been initialized */
 	data->clk_mgr =
 		z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);


### PR DESCRIPTION
Building lwm2m_client with CONFIG_NET_L2_OPENTHREAD=y leads to
following warning during build:

west build -s samples/net/lwm2m_client -b nrf52840dk_nrf52840 -- \
				-DCONFIG_NET_L2_OPENTHREAD=y

zephyr/drivers/sensor/nrf5/temp_nrf5.c:115:10:
warning: zero-length gnu_printf format string [-Wformat-zero-length]
115 |  LOG_DBG("");

Signed-off-by: Kiril Petrov <retfie@gmail.com>