### PR TITLE
Bluetooth: Audio: Use MEDIA_PROXY defines instead of BT_MCS defines

### DIFF
--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -235,6 +235,10 @@ struct mpl_search {
 #define MEDIA_PROXY_SEARCH_SUCCESS  0x01
 #define MEDIA_PROXY_SEARCH_FAILURE  0x02
 
+/* Group object object types */
+#define MEDIA_PROXY_GROUP_OBJECT_TRACK_TYPE 0x00
+#define MEDIA_PROXY_GROUP_OBJECT_GROUP_TYPE 0x01
+
 
 /**
  * @brief Opaque media player instance

--- a/include/zephyr/bluetooth/audio/media_proxy.h
+++ b/include/zephyr/bluetooth/audio/media_proxy.h
@@ -1335,9 +1335,8 @@ struct media_proxy_pl_calls {
 	/**
 	 * @brief Set Playing Order
 	 *
-	 * Set the media player's playing order
-	 * See the Media Control Service spec, or the
-	 * BT_MCS_PLAYING_ORDER_* defines in the mcs.h file.
+	 * Set the media player's playing order.
+	 * See the MEDIA_PROXY_PLAYING_ORDER_* defines.
 	 *
 	 * @param order	The playing order to set
 	 */
@@ -1348,9 +1347,7 @@ struct media_proxy_pl_calls {
 	 *
 	 * Read a bitmap containing the media player's supported
 	 * playing orders.
-	 * See the Media Control Service spec, or the
-	 * BT_MCS_PLAYING_ORDERS_SUPPORTED_* defines in the mcs.h
-	 * file.
+	 * See the MEDIA_PROXY_PLAYING_ORDERS_SUPPORTED_* defines.
 	 *
 	 * @return The media player's supported playing orders
 	 */
@@ -1360,8 +1357,7 @@ struct media_proxy_pl_calls {
 	 * @brief Read Media State
 	 *
 	 * Read the media player's state
-	 * See the Media Control Service spec, or the
-	 * BT_MCS_MEDIA_STATE_* defines in the mcs.h file.
+	 * See the MEDIA_PROXY_MEDIA_STATE_* defines.
 	 *
 	 * @return The media player's state
 	 */
@@ -1371,9 +1367,8 @@ struct media_proxy_pl_calls {
 	 * @brief Send Command
 	 *
 	 * Send a command to the media player.
-	 * For command opcodes (play, pause, ... - see the Media Control
-	 * Service spec, or the BT_MCS_OPC_* defines in the mcs.h
-	 * file.
+	 * For command opcodes (play, pause, ...) - see the MEDIA_PROXY_OP_*
+	 * defines.
 	 *
 	 * @param command	The command to send
 	 */
@@ -1383,9 +1378,8 @@ struct media_proxy_pl_calls {
 	 * @brief Read Commands Supported
 	 *
 	 * Read a bitmap containing the media player's supported
-	 * command opcodes..
-	 * See the Media Control Service spec, or the
-	 * BT_MCS_OPC_SUP_* defines in the mcs.h file.
+	 * command opcodes.
+	 * See the MEDIA_PROXY_OP_SUP_* defines.
 	 *
 	 * @return The media player's supported command opcodes
 	 */
@@ -1574,8 +1568,7 @@ void media_proxy_pl_media_state_cb(uint8_t state);
  *
  * To be called when a command has been sent, to notify whether the
  * command was successfully performed or not.
- * See the Media Control Service spec, or the BT_MCS_OPC_NTF_*
- * defines in the mcs.h file.
+ * See the MEDIA_PROXY_CMD_* result code defines.
  *
  * @param cmd_ntf	The result of the command
  */
@@ -1595,8 +1588,7 @@ void media_proxy_pl_commands_supported_cb(uint32_t opcodes);
  *
  * To be called when a search has been set to notify whether the
  * search was successfully performed or not.
- * See the Media Control Service spec, or the BT_MCS_SCP_NTF_*
- * defines in the mcs.h file.
+ * See the MEDIA_PROXY_SEARCH_* result code defines.
  *
  * The actual results of the search, if successful, can be found in
  * the search results object.

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -23,7 +23,7 @@
 #define TRACK_STATUS_INVALID 0x00
 #define TRACK_STATUS_VALID 0x01
 
-#define PLAYBACK_SPEED_PARAM_DEFAULT BT_MCS_PLAYBACK_SPEED_UNITY
+#define PLAYBACK_SPEED_PARAM_DEFAULT MEDIA_PROXY_PLAYBACK_SPEED_UNITY
 
 /* Temporary hardcoded setup for groups, tracks and segments */
 /* There is one parent group, which is the parent of a number of groups. */
@@ -229,12 +229,12 @@ static struct mpl_mediaplayer pl = {
 	.icon_url		  = CONFIG_BT_MPL_ICON_URL,
 	.group			  = &group_1,
 	.track_pos		  = 0,
-	.state			  = BT_MCS_MEDIA_STATE_PAUSED,
+	.state			  = MEDIA_PROXY_STATE_PAUSED,
 	.playback_speed_param	  = PLAYBACK_SPEED_PARAM_DEFAULT,
-	.seeking_speed_factor	  = BT_MCS_SEEKING_SPEED_FACTOR_ZERO,
-	.playing_order		  = BT_MCS_PLAYING_ORDER_INORDER_REPEAT,
-	.playing_orders_supported = BT_MCS_PLAYING_ORDERS_SUPPORTED_INORDER_ONCE |
-				    BT_MCS_PLAYING_ORDERS_SUPPORTED_INORDER_REPEAT,
+	.seeking_speed_factor	  = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO,
+	.playing_order		  = MEDIA_PROXY_PLAYING_ORDER_INORDER_REPEAT,
+	.playing_orders_supported = MEDIA_PROXY_PLAYING_ORDERS_SUPPORTED_INORDER_ONCE |
+				    MEDIA_PROXY_PLAYING_ORDERS_SUPPORTED_INORDER_REPEAT,
 	.opcodes_supported	  = 0x001fffff, /* All opcodes */
 #ifdef CONFIG_BT_MPL_OBJECTS
 	.search_results_id	  = 0,
@@ -1407,21 +1407,21 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 		}
 	}
 	switch (command->opcode) {
-	case BT_MCS_OPC_PLAY: /* Fall-through - handle several cases identically */
-	case BT_MCS_OPC_PAUSE:
-	case BT_MCS_OPC_FAST_REWIND:
-	case BT_MCS_OPC_FAST_FORWARD:
-	case BT_MCS_OPC_STOP:
-	case BT_MCS_OPC_MOVE_RELATIVE:
-	case BT_MCS_OPC_PREV_SEGMENT:
-	case BT_MCS_OPC_NEXT_SEGMENT:
-	case BT_MCS_OPC_FIRST_SEGMENT:
-	case BT_MCS_OPC_LAST_SEGMENT:
-	case BT_MCS_OPC_GOTO_SEGMENT:
-		ntf->result_code = BT_MCS_OPC_NTF_PLAYER_INACTIVE;
+	case MEDIA_PROXY_OP_PLAY: /* Fall-through - handle several cases identically */
+	case MEDIA_PROXY_OP_PAUSE:
+	case MEDIA_PROXY_OP_FAST_REWIND:
+	case MEDIA_PROXY_OP_FAST_FORWARD:
+	case MEDIA_PROXY_OP_STOP:
+	case MEDIA_PROXY_OP_MOVE_RELATIVE:
+	case MEDIA_PROXY_OP_PREV_SEGMENT:
+	case MEDIA_PROXY_OP_NEXT_SEGMENT:
+	case MEDIA_PROXY_OP_FIRST_SEGMENT:
+	case MEDIA_PROXY_OP_LAST_SEGMENT:
+	case MEDIA_PROXY_OP_GOTO_SEGMENT:
+		ntf->result_code = MEDIA_PROXY_CMD_PLAYER_INACTIVE;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_TRACK:
+	case MEDIA_PROXY_OP_PREV_TRACK:
 		if (do_prev_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1432,12 +1432,12 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_TRACK:
+	case MEDIA_PROXY_OP_NEXT_TRACK:
 		/* TODO:
 		 * The case where the next track has been set explicitly breaks somewhat
 		 * with the "next" order hardcoded into the group and track structure
@@ -1455,12 +1455,12 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_TRACK:
+	case MEDIA_PROXY_OP_FIRST_TRACK:
 		if (do_first_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1470,12 +1470,12 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_TRACK:
+	case MEDIA_PROXY_OP_LAST_TRACK:
 		if (do_last_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1485,12 +1485,12 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_TRACK:
+	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
 			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
@@ -1502,56 +1502,56 @@ void inactive_state_command_handler(const struct mpl_cmd *command,
 				pl.track_pos = 0;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
-			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+			pl.state = MEDIA_PROXY_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_GROUP:
+	case MEDIA_PROXY_OP_PREV_GROUP:
 		do_full_prev_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_GROUP:
+	case MEDIA_PROXY_OP_NEXT_GROUP:
 		do_full_next_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_GROUP:
+	case MEDIA_PROXY_OP_FIRST_GROUP:
 		do_full_first_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_GROUP:
+	case MEDIA_PROXY_OP_LAST_GROUP:
 		do_full_last_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_GROUP:
+	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
 			do_full_goto_group(&pl, command->param);
-			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+			pl.state = MEDIA_PROXY_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
 		BT_DBG("Invalid command: %d", command->opcode);
-		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		ntf->result_code = MEDIA_PROXY_CMD_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
@@ -1567,44 +1567,44 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		}
 	}
 	switch (command->opcode) {
-	case BT_MCS_OPC_PLAY:
+	case MEDIA_PROXY_OP_PLAY:
 		/* Continue playing - i.e. do nothing */
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PAUSE:
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+	case MEDIA_PROXY_OP_PAUSE:
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FAST_REWIND:
+	case MEDIA_PROXY_OP_FAST_REWIND:
 		/* We're in playing state, seeking speed must have been zero */
 		pl.seeking_speed_factor = -MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
+		pl.state = MEDIA_PROXY_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FAST_FORWARD:
+	case MEDIA_PROXY_OP_FAST_FORWARD:
 		/* We're in playing state, seeking speed must have been zero */
 		pl.seeking_speed_factor = MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
+		pl.state = MEDIA_PROXY_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_STOP:
+	case MEDIA_PROXY_OP_STOP:
 		pl.track_pos = 0;
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_MOVE_RELATIVE:
+	case MEDIA_PROXY_OP_MOVE_RELATIVE:
 		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
 			if (command->param >
@@ -1615,14 +1615,14 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 			} else {
 				pl.track_pos += command->param;
 			}
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_track_position_cb(pl.track_pos);
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_SEGMENT:
+	case MEDIA_PROXY_OP_PREV_SEGMENT:
 		/* Switch to previous segment if we are less than <margin> */
 		/* into the segment, otherwise go to start of segment */
 		if (pl.track_pos - PREV_MARGIN <
@@ -1631,31 +1631,31 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		}
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_SEGMENT:
+	case MEDIA_PROXY_OP_NEXT_SEGMENT:
 		do_next_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_SEGMENT:
+	case MEDIA_PROXY_OP_FIRST_SEGMENT:
 		do_first_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_SEGMENT:
+	case MEDIA_PROXY_OP_LAST_SEGMENT:
 		do_last_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_SEGMENT:
+	case MEDIA_PROXY_OP_GOTO_SEGMENT:
 		if (command->use_param) {
 			if (command->param != 0) {
 				do_goto_segment(&pl, command->param);
@@ -1665,13 +1665,13 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
 			/* track position shall not change. */
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_TRACK:
+	case MEDIA_PROXY_OP_PREV_TRACK:
 		if (do_prev_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1682,10 +1682,10 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_TRACK:
+	case MEDIA_PROXY_OP_NEXT_TRACK:
 		if (pl.next_track_set) {
 			BT_DBG("Next track set");
 			if (do_next_track_next_track_set(&pl)) {
@@ -1699,10 +1699,10 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_TRACK:
+	case MEDIA_PROXY_OP_FIRST_TRACK:
 		if (do_first_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1712,10 +1712,10 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_TRACK:
+	case MEDIA_PROXY_OP_LAST_TRACK:
 		if (do_last_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1725,10 +1725,10 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_TRACK:
+	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
 			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
@@ -1740,44 +1740,44 @@ void playing_state_command_handler(const struct mpl_cmd *command,
 				pl.track_pos = 0;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_GROUP:
+	case MEDIA_PROXY_OP_PREV_GROUP:
 		do_full_prev_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_GROUP:
+	case MEDIA_PROXY_OP_NEXT_GROUP:
 		do_full_next_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_GROUP:
+	case MEDIA_PROXY_OP_FIRST_GROUP:
 		do_full_first_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_GROUP:
+	case MEDIA_PROXY_OP_LAST_GROUP:
 		do_full_last_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_GROUP:
+	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
 			do_full_goto_group(&pl, command->param);
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
 		BT_DBG("Invalid command: %d", command->opcode);
-		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		ntf->result_code = MEDIA_PROXY_CMD_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
@@ -1793,44 +1793,44 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		}
 	}
 	switch (command->opcode) {
-	case BT_MCS_OPC_PLAY:
-		pl.state = BT_MCS_MEDIA_STATE_PLAYING;
+	case MEDIA_PROXY_OP_PLAY:
+		pl.state = MEDIA_PROXY_STATE_PLAYING;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PAUSE:
+	case MEDIA_PROXY_OP_PAUSE:
 		/* No change */
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FAST_REWIND:
+	case MEDIA_PROXY_OP_FAST_REWIND:
 		/* We're in paused state, seeking speed must have been zero */
 		pl.seeking_speed_factor = -MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
+		pl.state = MEDIA_PROXY_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FAST_FORWARD:
+	case MEDIA_PROXY_OP_FAST_FORWARD:
 		/* We're in paused state, seeking speed must have been zero */
 		pl.seeking_speed_factor = MPL_SEEKING_SPEED_FACTOR_STEP;
-		pl.state = BT_MCS_MEDIA_STATE_SEEKING;
+		pl.state = MEDIA_PROXY_STATE_SEEKING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_STOP:
+	case MEDIA_PROXY_OP_STOP:
 		pl.track_pos = 0;
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_MOVE_RELATIVE:
+	case MEDIA_PROXY_OP_MOVE_RELATIVE:
 		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
 			if (command->param >
@@ -1841,14 +1841,14 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 			} else {
 				pl.track_pos += command->param;
 			}
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_track_position_cb(pl.track_pos);
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_SEGMENT:
+	case MEDIA_PROXY_OP_PREV_SEGMENT:
 		/* Switch to previous segment if we are less than 5 seconds */
 		/* into the segment, otherwise go to start of segment */
 		if (pl.track_pos - PREV_MARGIN <
@@ -1857,31 +1857,31 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		}
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_SEGMENT:
+	case MEDIA_PROXY_OP_NEXT_SEGMENT:
 		do_next_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_SEGMENT:
+	case MEDIA_PROXY_OP_FIRST_SEGMENT:
 		do_first_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_SEGMENT:
+	case MEDIA_PROXY_OP_LAST_SEGMENT:
 		do_last_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_SEGMENT:
+	case MEDIA_PROXY_OP_GOTO_SEGMENT:
 		if (command->use_param) {
 			if (command->param != 0) {
 				do_goto_segment(&pl, command->param);
@@ -1891,13 +1891,13 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
 			/* track position shall not change. */
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_TRACK:
+	case MEDIA_PROXY_OP_PREV_TRACK:
 		if (do_prev_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1908,10 +1908,10 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_TRACK:
+	case MEDIA_PROXY_OP_NEXT_TRACK:
 		if (pl.next_track_set) {
 			BT_DBG("Next track set");
 			if (do_next_track_next_track_set(&pl)) {
@@ -1925,10 +1925,10 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_TRACK:
+	case MEDIA_PROXY_OP_FIRST_TRACK:
 		if (do_first_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1938,10 +1938,10 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_TRACK:
+	case MEDIA_PROXY_OP_LAST_TRACK:
 		if (do_last_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -1951,10 +1951,10 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_TRACK:
+	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
 			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
@@ -1966,44 +1966,44 @@ void paused_state_command_handler(const struct mpl_cmd *command,
 				pl.track_pos = 0;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_GROUP:
+	case MEDIA_PROXY_OP_PREV_GROUP:
 		do_full_prev_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_GROUP:
+	case MEDIA_PROXY_OP_NEXT_GROUP:
 		do_full_next_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_GROUP:
+	case MEDIA_PROXY_OP_FIRST_GROUP:
 		do_full_first_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_GROUP:
+	case MEDIA_PROXY_OP_LAST_GROUP:
 		do_full_last_group(&pl);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_GROUP:
+	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
 			do_full_goto_group(&pl, command->param);
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
 		BT_DBG("Invalid command: %d", command->opcode);
-		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		ntf->result_code = MEDIA_PROXY_CMD_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
@@ -2019,59 +2019,59 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 		}
 	}
 	switch (command->opcode) {
-	case BT_MCS_OPC_PLAY:
-		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = BT_MCS_MEDIA_STATE_PLAYING;
+	case MEDIA_PROXY_OP_PLAY:
+		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		pl.state = MEDIA_PROXY_STATE_PLAYING;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PAUSE:
-		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
+	case MEDIA_PROXY_OP_PAUSE:
+		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
 		/* TODO: Set track and track position */
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FAST_REWIND:
+	case MEDIA_PROXY_OP_FAST_REWIND:
 		/* TODO: Here, and for FAST_FORWARD */
 		/* Decide on algorithm for multiple presses - add step (as */
 		/* now) or double/half? */
 		/* What about FR followed by FF? */
 		/* Currently, the seeking speed may also become	 zero */
 		/* Lowest value allowed by spec is -64, notify on change only */
-		if (pl.seeking_speed_factor >= -(BT_MCS_SEEKING_SPEED_FACTOR_MAX
+		if (pl.seeking_speed_factor >= -(MEDIA_PROXY_SEEKING_SPEED_FACTOR_MAX
 						 - MPL_SEEKING_SPEED_FACTOR_STEP)) {
 			pl.seeking_speed_factor -= MPL_SEEKING_SPEED_FACTOR_STEP;
 			media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FAST_FORWARD:
+	case MEDIA_PROXY_OP_FAST_FORWARD:
 		/* Highest value allowed by spec is 64, notify on change only */
-		if (pl.seeking_speed_factor <= (BT_MCS_SEEKING_SPEED_FACTOR_MAX
+		if (pl.seeking_speed_factor <= (MEDIA_PROXY_SEEKING_SPEED_FACTOR_MAX
 						- MPL_SEEKING_SPEED_FACTOR_STEP)) {
 			pl.seeking_speed_factor += MPL_SEEKING_SPEED_FACTOR_STEP;
 			media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
 		}
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_STOP:
-		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
+	case MEDIA_PROXY_OP_STOP:
+		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
 		pl.track_pos = 0;
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
 		media_proxy_pl_seeking_speed_cb(pl.seeking_speed_factor);
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_MOVE_RELATIVE:
+	case MEDIA_PROXY_OP_MOVE_RELATIVE:
 		if (command->use_param) {
 			/* Keep within track - i.e. in the range 0 - duration */
 			if (command->param >
@@ -2082,14 +2082,14 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 			} else {
 				pl.track_pos += command->param;
 			}
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_track_position_cb(pl.track_pos);
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_SEGMENT:
+	case MEDIA_PROXY_OP_PREV_SEGMENT:
 		/* Switch to previous segment if we are less than 5 seconds */
 		/* into the segment, otherwise go to start of segment */
 		if (pl.track_pos - PREV_MARGIN <
@@ -2098,31 +2098,31 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 		}
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_SEGMENT:
+	case MEDIA_PROXY_OP_NEXT_SEGMENT:
 		do_next_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_SEGMENT:
+	case MEDIA_PROXY_OP_FIRST_SEGMENT:
 		do_first_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_SEGMENT:
+	case MEDIA_PROXY_OP_LAST_SEGMENT:
 		do_last_segment(&pl);
 		pl.track_pos = pl.group->track->segment->pos;
 		media_proxy_pl_track_position_cb(pl.track_pos);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_SEGMENT:
+	case MEDIA_PROXY_OP_GOTO_SEGMENT:
 		if (command->use_param) {
 			if (command->param != 0) {
 				do_goto_segment(&pl, command->param);
@@ -2132,13 +2132,13 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 			/* If the argument to "goto segment" is zero, */
 			/* the segment shall stay the same, and the */
 			/* track position shall not change. */
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_TRACK:
+	case MEDIA_PROXY_OP_PREV_TRACK:
 		if (do_prev_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -2149,13 +2149,13 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_TRACK:
+	case MEDIA_PROXY_OP_NEXT_TRACK:
 		if (pl.next_track_set) {
 			BT_DBG("Next track set");
 			if (do_next_track_next_track_set(&pl)) {
@@ -2169,13 +2169,13 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 		}
 		/* For next track, the position is kept if the track */
 		/* does not change */
-		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_TRACK:
+	case MEDIA_PROXY_OP_FIRST_TRACK:
 		if (do_first_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -2185,13 +2185,13 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_TRACK:
+	case MEDIA_PROXY_OP_LAST_TRACK:
 		if (do_last_track(&pl)) {
 			pl.track_pos = 0;
 			do_track_change_notifications(&pl);
@@ -2201,13 +2201,13 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 			pl.track_pos = 0;
 			media_proxy_pl_track_position_cb(pl.track_pos);
 		}
-		pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_TRACK:
+	case MEDIA_PROXY_OP_GOTO_TRACK:
 		if (command->use_param) {
 			if (do_goto_track(&pl, command->param)) {
 				pl.track_pos = 0;
@@ -2219,63 +2219,63 @@ void seeking_state_command_handler(const struct mpl_cmd *command,
 				pl.track_pos = 0;
 				media_proxy_pl_track_position_cb(pl.track_pos);
 			}
-			pl.seeking_speed_factor = BT_MCS_SEEKING_SPEED_FACTOR_ZERO;
-			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+			pl.seeking_speed_factor = MEDIA_PROXY_SEEKING_SPEED_FACTOR_ZERO;
+			pl.state = MEDIA_PROXY_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_PREV_GROUP:
+	case MEDIA_PROXY_OP_PREV_GROUP:
 		do_full_prev_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_NEXT_GROUP:
+	case MEDIA_PROXY_OP_NEXT_GROUP:
 		do_full_next_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_FIRST_GROUP:
+	case MEDIA_PROXY_OP_FIRST_GROUP:
 		do_full_first_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_LAST_GROUP:
+	case MEDIA_PROXY_OP_LAST_GROUP:
 		do_full_last_group(&pl);
-		pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+		pl.state = MEDIA_PROXY_STATE_PAUSED;
 		media_proxy_pl_media_state_cb(pl.state);
-		ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+		ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		media_proxy_pl_command_cb(ntf);
 		break;
-	case BT_MCS_OPC_GOTO_GROUP:
+	case MEDIA_PROXY_OP_GOTO_GROUP:
 		if (command->use_param) {
 			do_full_goto_group(&pl, command->param);
-			pl.state = BT_MCS_MEDIA_STATE_PAUSED;
+			pl.state = MEDIA_PROXY_STATE_PAUSED;
 			media_proxy_pl_media_state_cb(pl.state);
-			ntf->result_code = BT_MCS_OPC_NTF_SUCCESS;
+			ntf->result_code = MEDIA_PROXY_CMD_SUCCESS;
 		} else {
-			ntf->result_code = BT_MCS_OPC_NTF_CANNOT_BE_COMPLETED;
+			ntf->result_code = MEDIA_PROXY_CMD_CANNOT_BE_COMPLETED;
 		}
 		media_proxy_pl_command_cb(ntf);
 		break;
 	default:
 		BT_DBG("Invalid command: %d", command->opcode);
-		ntf->result_code = BT_MCS_OPC_NTF_NOT_SUPPORTED;
+		ntf->result_code = MEDIA_PROXY_CMD_NOT_SUPPORTED;
 		media_proxy_pl_command_cb(ntf);
 		break;
 	}
 }
 
-void (*command_handlers[BT_MCS_MEDIA_STATE_LAST])(const struct mpl_cmd *command,
+void (*command_handlers[MEDIA_PROXY_STATE_LAST])(const struct mpl_cmd *command,
 						  struct mpl_cmd_ntf *ntf) = {
 	inactive_state_command_handler,
 	playing_state_command_handler,
@@ -2592,7 +2592,7 @@ void send_command(const struct mpl_cmd *command)
 		BT_DBG("opcode: %d", command->opcode);
 	}
 
-	if (pl.state < BT_MCS_MEDIA_STATE_LAST) {
+	if (pl.state < MEDIA_PROXY_STATE_LAST) {
 		ntf.requested_opcode = command->opcode;
 		command_handlers[pl.state](command, &ntf);
 	} else {
@@ -2632,8 +2632,8 @@ static void parse_search(const struct mpl_search *search)
 				break;
 			}
 			sci.type = (uint8_t)search->search[index++];
-			if (sci.type <  BT_MCS_SEARCH_TYPE_TRACK_NAME ||
-			    sci.type > BT_MCS_SEARCH_TYPE_ONLY_GROUPS) {
+			if (sci.type <  MEDIA_PROXY_SEARCH_TYPE_TRACK_NAME ||
+			    sci.type > MEDIA_PROXY_SEARCH_TYPE_ONLY_GROUPS) {
 				search_failed = true;
 				break;
 			}
@@ -2651,11 +2651,11 @@ static void parse_search(const struct mpl_search *search)
 
 	if (search_failed) {
 		pl.search_results_id = 0;
-		media_proxy_pl_search_cb(BT_MCS_SCP_NTF_FAILURE);
+		media_proxy_pl_search_cb(MEDIA_PROXY_SEARCH_FAILURE);
 	} else {
 		/* Use current group as search result for now */
 		pl.search_results_id = pl.group->id;
-		media_proxy_pl_search_cb(BT_MCS_SCP_NTF_SUCCESS);
+		media_proxy_pl_search_cb(MEDIA_PROXY_SEARCH_SUCCESS);
 	}
 
 	media_proxy_pl_search_results_id_cb(pl.search_results_id);

--- a/subsys/bluetooth/audio/mpl.c
+++ b/subsys/bluetooth/audio/mpl.c
@@ -386,7 +386,7 @@ static uint32_t setup_parent_group_object(struct mpl_group *group)
 	/* poinbter in the other direction, so it is not possible to go from */
 	/* the parent group to a group of tracks. */
 
-	uint8_t type = BT_MCS_GROUP_OBJECT_GROUP_TYPE;
+	uint8_t type = MEDIA_PROXY_GROUP_OBJECT_GROUP_TYPE;
 	uint8_t record_size = sizeof(type) + BT_OTS_OBJ_ID_SIZE;
 	int next_size = record_size;
 
@@ -419,7 +419,7 @@ static uint32_t setup_parent_group_object(struct mpl_group *group)
 static uint32_t setup_group_object(struct mpl_group *group)
 {
 	struct mpl_track *track = group->track;
-	uint8_t type = BT_MCS_GROUP_OBJECT_TRACK_TYPE;
+	uint8_t type = MEDIA_PROXY_GROUP_OBJECT_TRACK_TYPE;
 	uint8_t record_size = sizeof(type) + BT_OTS_OBJ_ID_SIZE;
 	int next_size = record_size;
 


### PR DESCRIPTION
This PR updates the use of defines in the media_proxy and the media_player.  The purpose is to decouple the media player (which is a generic dummy media player) from the media control service (which is a Bluetooth specific interface to media players).

To avoid dependencies, the media_proxy has a set of defines corresponding to the set in the media control service.
This PR adds two missing defines ("missing" in the sense that they existed in MCS, but not in the media_proxy.)

The media_proxy header file is updated to refer to it's own defines, rather than the MCS ones.
The media player is updated to use the media proxy defines, rather than the MCS ones.

There are no functional changes in this PR, it only switches some code from one set of defines to another (corresponding) set of defines.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/41197


