### PR TITLE
samples: usb: dfu: Fix building of sample on a few platforms

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -13,11 +13,6 @@ config BOARD
 config FLASH
 	default y
 
-# Enable QSPI for secondary partition maps
-
-config NORDIC_QSPI_NOR
-	default y
-
 if BOARD_BL5340_DVK_CPUAPP
 
 if DAC

--- a/drivers/flash/Kconfig.nordic_qspi_nor
+++ b/drivers/flash/Kconfig.nordic_qspi_nor
@@ -7,6 +7,7 @@ menuconfig NORDIC_QSPI_NOR
 	select NRFX_QSPI
 	select FLASH_JESD216
 	depends on HAS_HW_NRF_QSPI
+	default y
 	help
 	  Enable support for nrfx QSPI driver with EasyDMA.
 

--- a/samples/subsys/usb/mass/Kconfig
+++ b/samples/subsys/usb/mass/Kconfig
@@ -67,11 +67,6 @@ config DISK_FLASH_START
 config FLASH_LOG_LEVEL
 	default 3
 
-DT_COMPAT_QSPI_NOR := nordic,qspi-nor
-
-config NORDIC_QSPI_NOR
-	default $(dt_compat_enabled,$(DT_COMPAT_QSPI_NOR))
-
 if NORDIC_QSPI_NOR
 
 config NORDIC_QSPI_NOR_FLASH_LAYOUT_PAGE_SIZE


### PR DESCRIPTION
Fix building this sample on bl5340_dvk_cpuapp_ns and
pinnacle_100_dvk.  On these boards the NORDIC_QSPI_NOR
driver needs to be enabled for the sample to build.

Signed-off-by: Kumar Gala <galak@kernel.org>