### PR TITLE
Increase buffer used by settings_fcb for devices with large write size

### DIFF
--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -29,7 +29,7 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 	size_t w_size, rem, add;
 
 	bool done;
-	char w_buf[16]; /* write buff, must be aligned either to minimal */
+	char w_buf[32]; /* write buff, must be aligned either to minimal */
 			/* base64 encoding size and write-block-size */
 	int rc;
 	uint8_t wbs = settings_io_cb.rwbs;
@@ -182,7 +182,7 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 				 void *cb_arg)
 {
 	size_t rem_size, len;
-	char temp_buf[16]; /* buffer for fit read-block-size requirements */
+	char temp_buf[32]; /* buffer for fit read-block-size requirements */
 	size_t exp_size, read_size;
 	uint8_t rbs = settings_io_cb.rwbs;
 	off_t off;

--- a/tests/subsys/settings/fcb/src/settings_test_fcb.c
+++ b/tests/subsys/settings/fcb/src/settings_test_fcb.c
@@ -351,7 +351,7 @@ void *settings_config_fcb_setup(void)
 	zassume_true(rc == 0, "Can't open storage flash area");
 
 	wbs = flash_area_align(fap);
-	zassume_true(wbs <= 16,
+	zassume_true(wbs <= 32,
 		"Flash driver is not compatible with the settings fcb-backend");
 	return NULL;
 }


### PR DESCRIPTION
Increase buffer used to read/write settings for devices with write block size greater than 16 bytes (stm32h7).
Update relevant value in test.

Note that the test will not work 'as is' on a nucleo: as mentionned in https://github.com/zephyrproject-rtos/zephyr/issues/47607#issuecomment-1180333759, the `fcb_sectors` and `fcb_small_sectors` must be updated for the test suite to run on nucleo properly.