### PR TITLE
Bluetooth: audio: Fix PACS location chrc properties

### DIFF
--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -449,22 +449,21 @@ BT_GATT_SERVICE_DEFINE(pacs_svc,
 			       snk_read, NULL, NULL),
 	BT_GATT_CCC(snk_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
-#if defined(CONFIG_BT_PAC_SNK_LOC)
+#if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE)
 	BT_GATT_CHARACTERISTIC(BT_UUID_PACS_SNK_LOC,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE |
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_READ_ENCRYPT |
 			       BT_GATT_PERM_WRITE_ENCRYPT,
-			       snk_loc_read,
-#if defined(CONFIG_BT_PAC_SNK_LOC_WRITEABLE)
-			       snk_loc_write,
-#else
-			       NULL,
+			       snk_loc_read, snk_loc_write, NULL),
+#elif defined(CONFIG_BT_PAC_SNK_LOC)
+	BT_GATT_CHARACTERISTIC(BT_UUID_PACS_SNK_LOC,
+			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+			       BT_GATT_PERM_READ_ENCRYPT,
+			       snk_loc_read, NULL, NULL),
 #endif /* CONFIG_BT_PAC_SNK_LOC_WRITEABLE */
-			       NULL),
 	BT_GATT_CCC(snk_loc_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
-#endif /* CONFIG_BT_PAC_SNK_LOC */
 #endif /* CONFIG_BT_PAC_SNK */
 #if defined(CONFIG_BT_PAC_SRC)
 	BT_GATT_CHARACTERISTIC(BT_UUID_PACS_SRC,
@@ -473,23 +472,22 @@ BT_GATT_SERVICE_DEFINE(pacs_svc,
 			       src_read, NULL, NULL),
 	BT_GATT_CCC(src_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
-#if defined(CONFIG_BT_PAC_SRC_LOC)
+#if defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
 	BT_GATT_CHARACTERISTIC(BT_UUID_PACS_SRC_LOC,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_WRITE |
 			       BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_READ_ENCRYPT |
 			       BT_GATT_PERM_WRITE_ENCRYPT,
-			       src_loc_read,
-#if defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
-			       src_loc_write,
-#else
-			       NULL,
+			       src_loc_read, src_loc_write, NULL),
+#elif defined(CONFIG_BT_PAC_SRC_LOC)
+	BT_GATT_CHARACTERISTIC(BT_UUID_PACS_SRC_LOC,
+			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
+			       BT_GATT_PERM_READ_ENCRYPT,
+			       src_loc_read, NULL, NULL),
 #endif /* CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
-			       NULL),
 	BT_GATT_CCC(src_loc_cfg_changed,
 		    BT_GATT_PERM_READ | BT_GATT_PERM_WRITE_ENCRYPT),
-#endif /* CONFIG_BT_PAC_SRC_LOC */
-#endif /* CONFIG_BT_PAC_SNK */
+#endif /* CONFIG_BT_PAC_SRC */
 	BT_GATT_CHARACTERISTIC(BT_UUID_PACS_AVAILABLE_CONTEXT,
 			       BT_GATT_CHRC_READ | BT_GATT_CHRC_NOTIFY,
 			       BT_GATT_PERM_READ_ENCRYPT,


### PR DESCRIPTION
If the characteristic is non-writtable, the BT_GATT_CHRC_WRITE property
flag shall be unset. Moreover, threre is no point to set
BT_GATT_PERM_WRITE_ENCRYPT permission flag as well if the attribute has
no `write` callback set anyway.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>