### PR TITLE
boards: nrf5340dk_nrf5340_cpuapp: Add BT_HCI_VS explicit enable.

### DIFF
--- a/drivers/bluetooth/hci/Kconfig
+++ b/drivers/bluetooth/hci/Kconfig
@@ -32,6 +32,7 @@ config BT_H5
 
 config BT_RPMSG
 	bool "HCI using RPMsg"
+	select BT_HAS_HCI_VS
 	select IPC_SERVICE
 	select MBOX
 	help


### PR DESCRIPTION
Add explicit BT_HCI_VS enable for nRF5340 application core.
It does not have Bluetooth Controller so dependecies will
not be solved automatically.