### PR TITLE
drivers/clock/rcar: Move ASSERT to module clock function

### DIFF
--- a/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
@@ -67,23 +67,17 @@ unlock:
 	return ret;
 }
 
-int r8a7795_cpg_mssr_start_stop(const struct device *dev,
-				clock_control_subsys_t sys, bool enable)
+int r8a7795_cpg_mssr_start_stop(const struct device *dev, clock_control_subsys_t sys, bool enable)
 {
 	const struct r8a7795_cpg_mssr_config *config = dev->config;
 	struct rcar_cpg_clk *clk = (struct rcar_cpg_clk *)sys;
-	uint32_t reg = clk->module / 100;
-	uint32_t bit = clk->module % 100;
 	int ret = -EINVAL;
 
-	__ASSERT((bit < 32) && reg < ARRAY_SIZE(mstpcr),
-		 "Invalid module number for cpg clock: %d", clk->module);
-
 	if (clk->domain == CPG_MOD) {
-		ret = rcar_cpg_mstp_clock_endisable(config->base_address, bit, reg, enable);
+		ret = rcar_cpg_mstp_clock_endisable(config->base_address, clk->module, enable);
 	} else if (clk->domain == CPG_CORE) {
-		ret = r8a7795_cpg_core_clock_endisable(config->base_address, clk->module,
-						       clk->rate, enable);
+		ret = r8a7795_cpg_core_clock_endisable(config->base_address, clk->module, clk->rate,
+						       enable);
 	}
 
 	return ret;

--- a/drivers/clock_control/clock_control_renesas_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_renesas_cpg_mssr.c
@@ -23,12 +23,16 @@ void rcar_cpg_write(uint32_t base_address, uint32_t reg, uint32_t val)
 	k_sleep(K_USEC(35));
 }
 
-int rcar_cpg_mstp_clock_endisable(uint32_t base_address, uint32_t bit,
-				  uint32_t reg, bool enable)
+int rcar_cpg_mstp_clock_endisable(uint32_t base_address, uint32_t module, bool enable)
 {
+	uint32_t reg = module / 100;
+	uint32_t bit = module % 100;
 	uint32_t bitmask = BIT(bit);
 	uint32_t reg_val;
 	unsigned int key;
+
+	__ASSERT((bit < 32) && reg < ARRAY_SIZE(mstpcr), "Invalid module number for cpg clock: %d",
+		 module);
 
 	key = irq_lock();
 

--- a/drivers/clock_control/clock_control_renesas_cpg_mssr.h
+++ b/drivers/clock_control/clock_control_renesas_cpg_mssr.h
@@ -44,7 +44,6 @@ static const uint16_t srcr[] = {
 
 void rcar_cpg_write(uint32_t base_address, uint32_t reg, uint32_t val);
 
-int rcar_cpg_mstp_clock_endisable(uint32_t base_address, uint32_t bit,
-				  uint32_t reg, bool enable);
+int rcar_cpg_mstp_clock_endisable(uint32_t base_address, uint32_t module, bool enable);
 
 #endif /* ZEPHYR_DRIVERS_RENESAS_RENESAS_CPG_MSSR_H_ */


### PR DESCRIPTION
This PR is fixing a bug introduced with #44418.

ASSERT was failing when `r8a7795_cpg_mssr_start_stop` was
called for a "core" clock.

This ASSERT statement and "mstpcr" table of registers are
only meant to be used when starting or stopping a "module" clock.

Moved ASSERT statement to `rcar_cpg_mstp_clock_endisable`
as well as "reg" & "bit" calculation.

Signed-off-by: Aymeric Aillet <aymeric.aillet@iot.bzh>