### PR TITLE
drivers: ethernet: mcux: Increase available RX buffers

### DIFF
--- a/drivers/ethernet/Kconfig.mcux
+++ b/drivers/ethernet/Kconfig.mcux
@@ -50,8 +50,8 @@ config ETH_MCUX_PHY_EXTRA_DEBUG
 
 config ETH_MCUX_RX_BUFFERS
 	int "Number of MCUX RX buffers"
-	default 1
-	range 1 16
+	default 6
+	range 6 16
 	help
 	  Set the number of RX buffers provided to the MCUX driver.
 


### PR DESCRIPTION
increase available RX buffers to MCUX ethernet driver.
improves measured performance on RT1050 EVK zperf download
from 500Kbps to 22Mbps.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>