### PR TITLE
drivers: dma stm32 keep the channel busy if overriden

### DIFF
--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -549,6 +549,9 @@ DMA_STM32_EXPORT_API int dma_stm32_reload(const struct device *dev, uint32_t id,
 				     size / stream->dst_size);
 	}
 
+	/* When reloading the dma, the stream is busy again before enabling */
+	stream->busy = true;
+
 	stm32_dma_enable_stream(dma, id);
 
 	return 0;
@@ -558,6 +561,7 @@ DMA_STM32_EXPORT_API int dma_stm32_start(const struct device *dev, uint32_t id)
 {
 	const struct dma_stm32_config *config = dev->config;
 	DMA_TypeDef *dma = (DMA_TypeDef *)(config->base);
+	struct dma_stm32_stream *stream;
 
 	/* Give channel from index 0 */
 	id = id - STM32_DMA_STREAM_OFFSET;
@@ -567,8 +571,11 @@ DMA_STM32_EXPORT_API int dma_stm32_start(const struct device *dev, uint32_t id)
 		return -EINVAL;
 	}
 
-	dma_stm32_clear_stream_irq(dev, id);
+	/* When starting the dma, the stream is busy before enabling */
+	stream = &config->streams[id];
+	stream->busy = true;
 
+	dma_stm32_clear_stream_irq(dev, id);
 	stm32_dma_enable_stream(dma, id);
 
 	return 0;
@@ -587,10 +594,6 @@ DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
 		return -EINVAL;
 	}
 
-	dma_stm32_clear_stream_irq(dev, id);
-
-	dma_stm32_disable_stream(dma, id);
-
 #if !defined(CONFIG_DMAMUX_STM32) || defined(CONFIG_SOC_SERIES_STM32H7X)
 	LL_DMA_DisableIT_TC(dma, dma_stm32_id_to_stream(id));
 #endif /* CONFIG_DMAMUX_STM32 */
@@ -598,6 +601,9 @@ DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
 #if defined(CONFIG_DMA_STM32_V1)
 	stm32_dma_disable_fifo_irq(dma, id);
 #endif
+
+	dma_stm32_clear_stream_irq(dev, id);
+	dma_stm32_disable_stream(dma, id);
 
 	/* Finally, flag stream as free */
 	stream->busy = false;

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -93,7 +93,12 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 
 	stream = &config->streams[id];
 
-	if (stream->busy == false) {
+	/* The busy channel is pertinent if not overridden by the HAL */
+	if ((stream->hal_override != true) && (stream->busy == false)) {
+		/*
+		 * When DMA channel is not overridden by HAL,
+		 * ignore irq if the channel is not busy anymore
+		 */
 		dma_stm32_clear_stream_irq(dev, id);
 		return;
 	}


### PR DESCRIPTION
Actually the busy flag of a dma stream is no pertinent when this stream is overridden by the HAL.

After merging the https://github.com/zephyrproject-rtos/zephyr/pull/44133, 
we found that  running the tests/drivers/flash on the disco board stm32l475, fails.
This test is running on the qspi  flash with DMA transfer of the stm32l475 disco kit. This flash_stm32_qspi driver is using the HAL to control the DMA transfer with HAL_DMA_Init and HAL_DMA_IRQHandler. That's the purpose of the `hal_override` flag of the stream (channel). Both stm32l4xx_hal_dma functions do not manage the DMA  irq as the stm32l4xx_ll_dma does. This makes DMA irq triggered even when the channel is no busy anymore.

This fix is ignoring the status of a stream busy  if this one was overridden (controlled) by the HAL.

Signed-off-by: Francois Ramu <francois.ramu@st.com>