### PR TITLE
drivers: sensor: ccs811: Add multi-instance support

### DIFF
--- a/drivers/sensor/ccs811/ccs811.h
+++ b/drivers/sensor/ccs811/ccs811.h
@@ -49,7 +49,6 @@
 #define CCS811_CO2_MAX_PPM              32767
 
 struct ccs811_data {
-#if DT_INST_NODE_HAS_PROP(0, irq_gpios)
 #ifdef CONFIG_CCS811_TRIGGER
 	const struct device *dev;
 
@@ -70,7 +69,6 @@ struct ccs811_data {
 	uint16_t co2_l2m;
 	uint16_t co2_m2h;
 #endif /* CONFIG_CCS811_TRIGGER */
-#endif
 	struct ccs811_result_type result;
 	uint8_t mode;
 	uint8_t app_fw_ver;
@@ -78,15 +76,9 @@ struct ccs811_data {
 
 struct ccs811_config {
 	struct i2c_dt_spec i2c;
-#if DT_INST_NODE_HAS_PROP(0, irq_gpios)
 	struct gpio_dt_spec irq_gpio;
-#endif
-#if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	struct gpio_dt_spec reset_gpio;
-#endif
-#if DT_INST_NODE_HAS_PROP(0, wake_gpios)
 	struct gpio_dt_spec wake_gpio;
-#endif
 };
 
 #ifdef CONFIG_CCS811_TRIGGER

--- a/drivers/sensor/ccs811/ccs811_trigger.c
+++ b/drivers/sensor/ccs811/ccs811_trigger.c
@@ -19,7 +19,12 @@ int ccs811_attr_set(const struct device *dev,
 		    const struct sensor_value *thr)
 {
 	struct ccs811_data *drv_data = dev->data;
+	const struct ccs811_config *config = dev->config;
 	int rc;
+
+	if (!config->irq_gpio.port) {
+		return -ENOTSUP;
+	}
 
 	if (chan != SENSOR_CHAN_CO2) {
 		rc = -ENOTSUP;
@@ -121,6 +126,10 @@ int ccs811_trigger_set(const struct device *dev,
 	const struct ccs811_config *config = dev->config;
 	uint8_t drdy_thresh = CCS811_MODE_THRESH | CCS811_MODE_DATARDY;
 	int rc;
+
+	if (!config->irq_gpio.port) {
+		return -ENOTSUP;
+	}
 
 	LOG_DBG("CCS811 trigger set");
 	setup_irq(dev, false);


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>