### PR TITLE
drivers: sensor: fxas21002: Add multi-instance support

### DIFF
--- a/drivers/sensor/fxas21002/fxas21002_trigger.c
+++ b/drivers/sensor/fxas21002/fxas21002_trigger.c
@@ -101,6 +101,10 @@ int fxas21002_trigger_set(const struct device *dev,
 	uint8_t mask;
 	int ret = 0;
 
+	if (!config->int_gpio.port) {
+		return -ENOTSUP;
+	}
+
 	k_sem_take(&data->sem, K_FOREVER);
 
 	switch (trig->type) {


### PR DESCRIPTION
Move driver to use DT_INST_FOREACH_STATUS_OKAY to add
multi-instance support.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>