### PR TITLE
[RFC] Multi interface devices

### DIFF
--- a/drivers/serial/CMakeLists.txt
+++ b/drivers/serial/CMakeLists.txt
@@ -49,6 +49,7 @@ zephyr_library_sources_ifdef(CONFIG_USART_GD32 usart_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XEN_HVC uart_hvc_xen.c)
 zephyr_library_sources_ifdef(CONFIG_UART_XEN_HVC_CONSOLEIO uart_hvc_xen_consoleio.c)
 zephyr_library_sources_ifdef(CONFIG_UART_PIPE uart_pipe.c)
+zephyr_library_sources_ifdef(CONFIG_NXP_SC28C94 nxp_sc28c94.c)
 
 zephyr_library_sources_ifdef(CONFIG_USERSPACE   uart_handlers.c)
 

--- a/drivers/serial/Kconfig
+++ b/drivers/serial/Kconfig
@@ -200,4 +200,6 @@ source "drivers/serial/Kconfig.neorv32"
 
 source "drivers/serial/Kconfig.xen"
 
+source "drivers/serial/Kconfig.nxp_s28c94"
+
 endif # SERIAL

--- a/drivers/serial/Kconfig.nxp_sc28c94
+++ b/drivers/serial/Kconfig.nxp_sc28c94
@@ -1,0 +1,7 @@
+# Copyright (c) 2022, Trackuit.
+# SPDX-License-Identifier: Apache-2.0
+
+config NXP_SC28C94
+	bool "NXP SC28C94 driver"
+	help
+	  Include drivers for NXP SC28C94 driver

--- a/drivers/serial/nxp_sc28c94.c
+++ b/drivers/serial/nxp_sc28c94.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2022 Trackunit
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/************************************************************************ 
+ * Dependencies
+ ************************************************************************/
+#include <zephyr/logging/log.h>
+#include <zephyr/device.h>
+#include "zephyr/drivers/spi.h"
+#include "zephyr/drivers/uart.h"
+
+/************************************************************************ 
+ * Definitions
+ ************************************************************************/
+
+/************************************************************************ 
+ * Register driver to log module
+ ************************************************************************/
+LOG_MODULE_REGISTER(nxp_sc28c94, LOG_LEVEL_INF);
+
+/************************************************************************ 
+ * Configuration structures
+ ************************************************************************/
+struct nxp_sc28c94_cfg {
+    const struct device *uart0;
+    const struct device *uart1;
+    const struct device *uart2;
+    const struct device *uart3;
+    const struct device *bus;
+};
+
+struct nxp_sc28c94_uart_cfg {
+    const struct device *parent;
+    uint32_t current_speed;
+    bool hw_flow_control;
+};
+
+/************************************************************************ 
+ * UART device API
+ ************************************************************************/
+int nxp_sc28c94_poll_in(const struct device *parent,
+        const struct device *child, unsigned char *p_char)
+{
+    /* ... */
+    /* ... */
+    /* ... */
+    return 0;
+}
+
+void nxp_sc28c94_poll_out(const struct device *parent,
+        const struct device *child, , unsigned char out_char)
+{
+    /* ... */
+    /* ... */
+    /* ... */
+    return 0;
+}
+
+/************************************************************************ 
+ * UART child device API
+ ************************************************************************/
+int nxp_sc28c94_uart_poll_in(const struct device *dev, unsigned char *p_char)
+{
+    nxp_sc28c94_uart_cfg cfg = (nxp_sc28c94_uart_cfg *)dev->cfg;
+    return nxp_sc28c94_poll_in(cfg->parent, dev, p_char);
+}
+
+void nxp_sc28c94_uart_poll_out(const struct device *parent, unsigned char out_char)
+{
+    nxp_sc28c94_uart_cfg cfg = (nxp_sc28c94_uart_cfg *)dev->cfg;
+    return nxp_sc28c94_poll_out(cfg->parent, dev, out_char);}
+
+struct uart_driver_api nxp_sc28c94_uart_api {
+    .nxp_sc28c94_uart_poll_in,
+    .nxp_sc28c94_uart_poll_out,
+};
+
+/************************************************************************ 
+ * Initialization
+ ************************************************************************/
+static int nxp_sc28c94_init(const struct device *dev)
+{
+    return 0;
+}
+
+/************************************************************************ 
+ * Instanciation macro for child device
+ ************************************************************************/
+#define NXP_SC29C94_UART_DEVICE(id)                                                             \
+    static struct nxp_sc28c94_uart_cfg nxp_sc28c94_uart_cfg_##id {                              \
+        parent = DT_PARENT(id, current_speed);                                                  \
+        current_speed = DT_PROP(id, current_speed);                                             \
+        hw_flow_control = DT_PROP(id, hw_flow_control);                                         \
+    };                                                                                          \
+                                                                                                \
+    DEVICE_DT_DEFINE(id, NULL, NULL, NULL, nxp_sc28c94_uart_cfg_##id, POST_KERNEL, 70,          \
+            nxp_sc28c94_uart_api);
+
+/************************************************************************ 
+ * Instanciation macro for parent device
+ ************************************************************************/
+#define NXP_SC29C94_DEVICE(id)                                                                  \
+    static struct nxp_sc28c94_cfg nxp_sc28c94_cfg_##id = {	                                    \
+        .uart0 = DEVICE_CHILD_DT_GET_OR_NULL(id, uart0),                                        \
+        .uart1 = DEVICE_CHILD_DT_GET_OR_NULL(id, uart1),                                        \
+        .uart2 = DEVICE_CHILD_DT_GET_OR_NULL(id, uart2),                                        \
+        .uart3 = DEVICE_CHILD_DT_GET_OR_NULL(id, uart3),                                        \
+        .bus = DEVICE_DT_GET(DT_BUS(id))                                                        \
+    };                                                                                          \
+                                                                                                \
+    DEVICE_DT_DEFINE(id, nxp_sc28c94_init, NULL, NULL,                                          \
+        quectel_bg95_modem_##id##_cfg, POST_KERNEL, 10, NULL);
+
+/************************************************************************ 
+ * Instanciation
+ ************************************************************************/
+DT_FOREACH_STATUS_OKAY(nxp_sc28c94_uart, NXP_SC29C94_UART_DEVICE)
+DT_FOREACH_STATUS_OKAY(nxp_sc28c94, NXP_SC29C94_DEVICE)

--- a/dts/bindings/gnss/quectel,bg96-gnss.yaml
+++ b/dts/bindings/gnss/quectel,bg96-gnss.yaml
@@ -1,0 +1,10 @@
+# Copyright (c) 2022 Trackunit A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: Quectel BG96 GNSS interface
+
+compatible: "quectel,bg96-gnss"
+
+include: [base.yaml]
+
+on-bus: quectel,bg96

--- a/dts/bindings/modem/quectel,bg96.yaml
+++ b/dts/bindings/modem/quectel,bg96.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2022 Trackunit
+# SPDX-License-Identifier: Apache-2.0
+
+description: Quectel BG96 modem
+
+compatible: "quectel,bg96"
+
+include: [base.yaml, uart-device.yaml]
+
+properties:
+    label:
+      required: true
+
+    power-gpios:
+      type: phandles
+      required: true
+
+    reset-gpios:
+      type: phandles
+      required: false
+
+    powerdown-gpios:
+      type: phandles
+      required: false
+
+    nmea-uart:
+      type: path
+      required: false
+      description: |
+        Used for NMEA frames from GNSS if included,
+        otherwise,the location is read from the modem
+        using AT commands.
+
+    apn-name:
+      type: string
+      required: false
+      description: APN name for network connection context
+
+    username:
+      type: string
+      required: false
+      description: Username for network connection context
+
+    password:
+      type: string
+      required: false
+      description: Password for network connection context
+
+on-bus: uart
+
+bus: quectel,bg96
+
+# Example
+#
+# / {
+#     aliases {
+#         modem = <&bg96>;
+#         gnss = <&gnss>;
+#     };
+# };
+#
+# &uart0 {
+#     bg96 {
+#         compatible = "quectel,bg96";
+#         label = "quectel,bg96";
+#
+#         power-gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
+#         reset-gpios = <&gpiod 0 GPIO_ACTIVE_HIGH>;
+#         powerdown-gpios = < &gpiof 5 GPIO_ACTIVE_HIGH>;
+#
+#         nmea-uart = &uart1;
+#
+#         apn-name = "verycoolapn.m2m";
+#
+#         gnss: gnss {
+#             compatible = "quectel,bg96-gnss";
+#             label = "bg96,gnss";
+#         };
+#     };
+# };

--- a/dts/bindings/serial/nxp,sc28c94-uart.yaml
+++ b/dts/bindings/serial/nxp,sc28c94-uart.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2022 Trackunit A/S
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP SC28C94 UART interface which is part of SC28C94
+
+compatible: "nxp,sc28c94-uart"
+
+include: [base.yaml, uart-controller.yaml]
+
+on-bus: nxp,sc28c94
+
+bus: uart

--- a/dts/bindings/serial/nxp,sc28c94.yaml
+++ b/dts/bindings/serial/nxp,sc28c94.yaml
@@ -1,0 +1,71 @@
+# Copyright (c) 2020 Analog Life LLC
+# SPDX-License-Identifier: Apache-2.0
+
+description: SC28C94 SPI to 4x UART transceiver
+
+compatible: "nxp,sc28c94"
+
+include: [base.yaml]
+
+properties:
+    label:
+      required: true
+
+    enable-gpios:
+      type: phandles
+      required: true
+
+on-bus: spi
+
+bus: nxp,sc28c94
+
+# Example
+#
+# The up to 4 supported UART devices are child devices of the
+# parent quart. The node id (serial0) of the UART devices may
+# be modified and must be referenced by the application, the
+# path to the UART devices must match the naming scheme. One
+# uart0, one uart1 etc.
+#
+# / {
+#     aliases {
+#         vcom1 = <&serial0>;
+#         vcom2 = <&serial1>;
+#         vcom3 = <&serial2>;
+#         vcom4 = <&serial3>;
+#     };
+# };
+#
+# &spi0 {
+#     quart {
+#         compatible = "nxp,sc28c94";
+#
+#         serial0: uart0 {
+#             compatible = "nxp,sc28c94-uart";
+#             label "serial0";
+#             current-speed = 115200;
+#             hw-flow-control;
+#         };
+#
+#         serial1: uart1 {
+#             compatible = "nxp,sc28c94-uart";
+#             label "serial1";
+#             current-speed = 115200;
+#             hw-flow-control;
+#         };
+#
+#         serial2: uart2 {
+#             compatible = "nxp,sc28c94-uart";
+#             label "serial2";
+#             current-speed = 115200;
+#             hw-flow-control;
+#         };
+#
+#         serial3: uart3 {
+#             compatible = "nxp,sc28c94-uart";
+#             label "serial3";
+#             current-speed = 9600;
+#             hw-flow-control;
+#         };
+#     };
+# };

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -373,6 +373,48 @@ typedef int16_t device_handle_t;
 		    (DEVICE_DT_GET(node_id)), (NULL))
 
 /**
+ * @def DEVICE_CHILD_DT_GET
+ *
+ * @brief Get a <tt>const struct device*</tt> for the child of the
+ * devicetree node identifier
+ *
+ * @details Returns a pointer to a device object created from a
+ * devicetree node, if any device was allocated by a driver.
+ *
+ * If no such device was allocated, this will fail at linker time. If
+ * you get an error that looks like <tt>undefined reference to
+ * __device_dts_ord_<N></tt>, that is what happened. Check to make
+ * sure your device driver is being compiled, usually by enabling the
+ * Kconfig options it requires.
+ *
+ * @param node_id A devicetree node identifier
+ * @param child relative path to the child
+ * @return A pointer to the device object created for that node
+ */
+
+#define DEVICE_CHILD_DT_GET(node_id, child) \
+	DEVICE_DT_GET(DT_CHILD(node_id, child))
+
+/**
+ * @def DEVICE_CHILD_DT_GET_OR_NULL
+ *
+ * @brief Utility macro to obtain an optional reference to a child device.
+ *
+ * @details If the node identifier refers to a child node with status
+ * "okay", this returns <tt>DEVICE_DT_GET(DT_CHILD(node_id, child))</tt>.
+ * Otherwise, it returns NULL.
+ *
+ * @param node_id devicetree node identifier
+ * @param child relative path to the child
+ *
+ * @return a <tt>const struct device*</tt> for the node identifier,
+ * which may be NULL.
+ */
+#define DEVICE_CHILD_DT_GET_OR_NULL(node_id, child) \
+	COND_CODE_1(DT_NODE_EXISTS(DT_CHILD(node_id, child)), \
+			(DEVICE_DT_GET_OR_NULL(DT_CHILD(node_id, child)), (NULL)))
+
+/**
  * @def DEVICE_GET
  *
  * @brief Obtain a pointer to a device object by name


### PR DESCRIPTION
The goal of this proposal is to create a standardized design
and to set a precedent for how to create drivers and models
for multi-functional-devices, which expose one or more APIs
pr device.

The formal documentation will be created based on this RFC,
in its own pull request once the design details are in place.

Some devices require more than one interface to present
all of their functionalies. This can be a SPI to 4x UART
transceiver, which presents 4 distinct uart devices. A
struct device only provides one API, so 4 devices must
be created to allow for the application to use them.
However, the IC uses a single SPI to translate the
in and outbound UART data, so they must be synchronized
within a single device.

This proposal provides a standardized simple solution to
this problem, using only what is already provided by
the zephyr build system, in a transparent and intuitive
fasion.

Summarized, the solution is to create a parent device,
which then exposes the additional interfaces through
its child devices.

To ensure that it is obvious to a developer that the
device is a composite device (single device with
multiple interfaces), these rules must be followed:

1. A composite device has the bus binding set to its 
   name, it is placed in the folder which matches its
   primary function if it has one, otherwise it is placed
   in a folder named **mfd**
2. A component device uses the on-bus binding to
   indicate that it belongs to the composite device, it
   is placed in the folder which matches its function.
3. A component (child device) has the same name as
   the composite device, followed by - and the name
   of the component
7. The composite bindings yaml file ends with a
   commented out section, which shows a detailed
   example of the composite device and its components
   in a fake device tree

Following these rules, it should be easy to spot a
composite device, and easy to figure out how to include
it in a device tree

The proposal also includes a draft implementation of the
bindings for the nxp,sc28c94 and bg96 composite devices,
alongside a draft driver for the nxp,sc28c94 to show how
the driver could be implemented.

Furthermore, the design descibed here is already in use by
the following driver:
https://github.com/zephyrproject-rtos/zephyr/blob/main/drivers/gpio/gpio_xlnx_axi.c
and in the following bindings:
https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/bindings/adc/ti%2Clmp90100.yaml
https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/bindings/gpio/ti%2Clmp90xxx-gpio.yaml

Note here that there is only one driver pr multi functional 
device, which first instanciates all child devices, then itself,
the child devices are just used for storing cfgs, data and the 
APIs.

The BG96 is a cellular modem with built in GNSS, which
requires two interfaces, and if cellular location is used,
three interfaces.

Two new functions have also been added to the device.h file
which allows for easily getting the child devices of a
composite device

Please come with any suggestions to improve this solution, or
propose a complimentary one for discussion :)

Signed-off-by: Bjarki Arge Andreasen <bjarkix123@gmail.com>