### PR TITLE
tests: drivers: i2c_api: Convert to use DEVICE_DT_GET

### DIFF
--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -97,11 +97,11 @@ static int test_gy271(void)
 static int test_burst_gy271(void)
 {
 	unsigned char datas[6];
-	const struct device *i2c_dev = device_get_binding(I2C_DEV_NAME);
+	const struct device *i2c_dev = DEVICE_DT_GET(I2C_DEV_NODE);
 	uint32_t i2c_cfg_tmp;
 
-	if (!i2c_dev) {
-		TC_PRINT("Cannot get I2C device\n");
+	if (!device_is_ready(i2c_dev)) {
+		TC_PRINT("I2C device is not ready\n");
 		return TC_FAIL;
 	}
 


### PR DESCRIPTION
This PR is related to #47464, missing the fix of device_get_binding
in the test_burst_gy271 function.

Move to use DEVICE_DT_GET instead of device_get_binding as
we work on phasing out use of DTS 'label' property.

Signed-off-by: Tim Lin <tim2.lin@ite.corp-partner.google.com>