### PR TITLE
ztest: add function-level before/after

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -134,7 +134,7 @@ static void cpu_hold(void *arg1, void *arg2, void *arg3)
 	 * logic views it as one "job") and cause other test failures.
 	 */
 	dt = k_uptime_get_32() - start_ms;
-	zassert_true(dt < 3000, "1cpu test took too long (%d ms)", dt);
+	zassert_true(dt < 10000, "1cpu test took too long (%d ms)", dt);
 	arch_irq_unlock(key);
 }
 
@@ -202,7 +202,16 @@ static void run_test_functions(struct ztest_suite_node *suite, struct ztest_unit
 			       void *data)
 {
 	phase = TEST_PHASE_TEST;
+
+	if (test->before) {
+		test->before(/*data=*/data);
+	}
+
 	test->test(data);
+
+	if (test->after) {
+		test->after(/*data=*/data);
+	}
 }
 
 enum ztest_result {


### PR DESCRIPTION
The new ztest fx stores before/after functions at test
suite level. Thus all test functions within the same
suite share the same before/after functions.

This can cause inflexibility for test suite arrangement.
A ztest suite usually tests one feature. But now we have to
group test functions based on their before/after functions
even they belong to the same suite logically. Sometimes,a
test function do need before/after operations specific to
itself. Such as the 1cpu scenario.

This patch adds function-level before/after functions.
Test writer can choose between suite-level or function-level
as appropriate.

Signed-off-by: Ming Shao <ming.shao@intel.com>


Fix: https://github.com/zephyrproject-rtos/zephyr/issues/47604