### PR TITLE
Shell: Bluetooth: Add shell_get_ctx() instead of global var

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -1216,6 +1216,19 @@ int shell_obscure_set(const struct shell *shell, bool obscure);
  */
 int shell_mode_delete_set(const struct shell *shell, bool val);
 
+
+/**
+ * @brief Get the shell context.
+ *
+ * This is useful for functions where the shell context is not passed as a
+ * parameter, e.g., in callbacks.
+ *
+ * The shell context is initialized in `shell_init`.
+ *
+ * @retval Pointer to the shell context.
+ */
+const struct shell *shell_get_ctx(void);
+
 /**
  * @}
  */

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -136,23 +136,23 @@ static void print_codec(const struct bt_codec *codec)
 {
 	int i;
 
-	shell_print(ctx_shell, "codec 0x%02x cid 0x%04x vid 0x%04x count %u",
+	shell_print(shell_get_ctx(), "codec 0x%02x cid 0x%04x vid 0x%04x count %u",
 		    codec->id, codec->cid, codec->vid, codec->data_count);
 
 	for (i = 0; i < codec->data_count; i++) {
-		shell_print(ctx_shell, "data #%u: type 0x%02x len %u", i,
+		shell_print(shell_get_ctx(), "data #%u: type 0x%02x len %u", i,
 			    codec->data[i].data.type,
 			    codec->data[i].data.data_len);
-		shell_hexdump(ctx_shell, codec->data[i].data.data,
+		shell_hexdump(shell_get_ctx(), codec->data[i].data.data,
 			      codec->data[i].data.data_len -
 				sizeof(codec->data[i].data.type));
 	}
 
 	for (i = 0; i < codec->meta_count; i++) {
-		shell_print(ctx_shell, "meta #%u: type 0x%02x len %u", i,
+		shell_print(shell_get_ctx(), "meta #%u: type 0x%02x len %u", i,
 			    codec->meta[i].data.type,
 			    codec->meta[i].data.data_len);
-		shell_hexdump(ctx_shell, codec->meta[i].data.data,
+		shell_hexdump(shell_get_ctx(), codec->meta[i].data.data,
 			      codec->data[i].data.data_len -
 				sizeof(codec->meta[i].data.type));
 	}
@@ -235,7 +235,7 @@ static void set_stream(struct bt_audio_stream *stream)
 
 	for (i = 0; i < ARRAY_SIZE(streams); i++) {
 		if (stream == &streams[i]) {
-			shell_print(ctx_shell, "Default stream: %u", i + 1);
+			shell_print(shell_get_ctx(), "Default stream: %u", i + 1);
 		}
 	}
 }
@@ -243,7 +243,7 @@ static void set_stream(struct bt_audio_stream *stream)
 #if defined(CONFIG_BT_AUDIO_UNICAST)
 static void print_qos(struct bt_codec_qos *qos)
 {
-	shell_print(ctx_shell, "QoS: interval %u framing 0x%02x "
+	shell_print(shell_get_ctx(), "QoS: interval %u framing 0x%02x "
 		    "phy 0x%02x sdu %u rtn %u latency %u pd %u",
 		    qos->interval, qos->framing, qos->phy, qos->sdu,
 		    qos->rtn, qos->latency, qos->pd);
@@ -280,7 +280,7 @@ static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 {
 	int i;
 
-	shell_print(ctx_shell, "ASE Codec Config: conn %p ep %p dir %u, cap %p",
+	shell_print(shell_get_ctx(), "ASE Codec Config: conn %p ep %p dir %u, cap %p",
 		    conn, ep, dir, cap);
 
 	print_codec(codec);
@@ -289,14 +289,14 @@ static struct bt_audio_stream *lc3_config(struct bt_conn *conn,
 		struct bt_audio_stream *stream = &streams[i];
 
 		if (stream->conn == NULL) {
-			shell_print(ctx_shell, "ASE Codec Config stream %p",
+			shell_print(shell_get_ctx(), "ASE Codec Config stream %p",
 				    stream);
 			set_stream(stream);
 			return stream;
 		}
 	}
 
-	shell_print(ctx_shell, "No streams available");
+	shell_print(shell_get_ctx(), "No streams available");
 
 	return NULL;
 }
@@ -305,7 +305,7 @@ static int lc3_reconfig(struct bt_audio_stream *stream,
 			struct bt_audio_capability *cap,
 			struct bt_codec *codec)
 {
-	shell_print(ctx_shell, "ASE Codec Reconfig: stream %p cap %p", stream, cap);
+	shell_print(shell_get_ctx(), "ASE Codec Reconfig: stream %p cap %p", stream, cap);
 
 	print_codec(codec);
 
@@ -318,7 +318,7 @@ static int lc3_reconfig(struct bt_audio_stream *stream,
 
 static int lc3_qos(struct bt_audio_stream *stream, struct bt_codec_qos *qos)
 {
-	shell_print(ctx_shell, "QoS: stream %p %p", stream, qos);
+	shell_print(shell_get_ctx(), "QoS: stream %p %p", stream, qos);
 
 	print_qos(qos);
 
@@ -329,7 +329,7 @@ static int lc3_enable(struct bt_audio_stream *stream,
 		      struct bt_codec_data *meta,
 		      size_t meta_count)
 {
-	shell_print(ctx_shell, "Enable: stream %p meta_count %zu", stream,
+	shell_print(shell_get_ctx(), "Enable: stream %p meta_count %zu", stream,
 		    meta_count);
 
 	return 0;
@@ -337,7 +337,7 @@ static int lc3_enable(struct bt_audio_stream *stream,
 
 static int lc3_start(struct bt_audio_stream *stream)
 {
-	shell_print(ctx_shell, "Start: stream %p", stream);
+	shell_print(shell_get_ctx(), "Start: stream %p", stream);
 
 	seq_num = 0;
 
@@ -392,12 +392,12 @@ static int lc3_metadata(struct bt_audio_stream *stream,
 			struct bt_codec_data *meta,
 			size_t meta_count)
 {
-	shell_print(ctx_shell, "Metadata: stream %p meta_count %zu", stream,
+	shell_print(shell_get_ctx(), "Metadata: stream %p meta_count %zu", stream,
 		    meta_count);
 
 	for (size_t i = 0; i < meta_count; i++) {
 		if (!valid_metadata_type(meta->data.type, meta->data.data_len)) {
-			shell_print(ctx_shell,
+			shell_print(shell_get_ctx(),
 				    "Invalid metadata type %u or length %u",
 				    meta->data.type, meta->data.data_len);
 
@@ -410,21 +410,21 @@ static int lc3_metadata(struct bt_audio_stream *stream,
 
 static int lc3_disable(struct bt_audio_stream *stream)
 {
-	shell_print(ctx_shell, "Disable: stream %p", stream);
+	shell_print(shell_get_ctx(), "Disable: stream %p", stream);
 
 	return 0;
 }
 
 static int lc3_stop(struct bt_audio_stream *stream)
 {
-	shell_print(ctx_shell, "Stop: stream %p", stream);
+	shell_print(shell_get_ctx(), "Stop: stream %p", stream);
 
 	return 0;
 }
 
 static int lc3_release(struct bt_audio_stream *stream)
 {
-	shell_print(ctx_shell, "Release: stream %p", stream);
+	shell_print(shell_get_ctx(), "Release: stream %p", stream);
 
 	if (stream == default_stream) {
 		default_stream = NULL;
@@ -503,7 +503,7 @@ static uint8_t stream_dir(const struct bt_audio_stream *stream)
 
 static void add_codec(struct bt_codec *codec, uint8_t index, enum bt_audio_dir dir)
 {
-	shell_print(ctx_shell, "#%u: codec %p dir 0x%02x", index, codec, dir);
+	shell_print(shell_get_ctx(), "#%u: codec %p dir 0x%02x", index, codec, dir);
 
 	print_codec(codec);
 
@@ -518,14 +518,14 @@ static void add_codec(struct bt_codec *codec, uint8_t index, enum bt_audio_dir d
 
 static void add_sink(struct bt_audio_ep *ep, uint8_t index)
 {
-	shell_print(ctx_shell, "Sink #%u: ep %p", index, ep);
+	shell_print(shell_get_ctx(), "Sink #%u: ep %p", index, ep);
 
 	snks[index] = ep;
 }
 
 static void add_source(struct bt_audio_ep *ep, uint8_t index)
 {
-	shell_print(ctx_shell, "Source #%u: ep %p", index, ep);
+	shell_print(shell_get_ctx(), "Source #%u: ep %p", index, ep);
 
 	srcs[index] = ep;
 }
@@ -549,7 +549,7 @@ static void discover_cb(struct bt_conn *conn, struct bt_codec *codec,
 		return;
 	}
 
-	shell_print(ctx_shell, "Discover complete: err %d", params->err);
+	shell_print(shell_get_ctx(), "Discover complete: err %d", params->err);
 
 	memset(params, 0, sizeof(*params));
 }
@@ -582,7 +582,7 @@ static void discover_all(struct bt_conn *conn, struct bt_codec *codec,
 
 		err = bt_audio_discover(default_conn, params);
 		if (err) {
-			shell_error(ctx_shell, "bt_audio_discover err %d", err);
+			shell_error(shell_get_ctx(), "bt_audio_discover err %d", err);
 			discover_cb(conn, NULL, NULL, params);
 		}
 	}
@@ -980,11 +980,11 @@ static bool sink_syncable;
 static bool scan_recv(const struct bt_le_scan_recv_info *info,
 		     uint32_t broadcast_id)
 {
-	shell_print(ctx_shell, "Found broadcaster with ID 0x%06X",
+	shell_print(shell_get_ctx(), "Found broadcaster with ID 0x%06X",
 		    broadcast_id);
 
 	if (broadcast_id == accepted_broadcast_id) {
-		shell_print(ctx_shell, "PA syncing to broadcaster");
+		shell_print(shell_get_ctx(), "PA syncing to broadcaster");
 		accepted_broadcast_id = 0;
 		return true;
 	}
@@ -996,14 +996,14 @@ static void pa_synced(struct bt_audio_broadcast_sink *sink,
 		      struct bt_le_per_adv_sync *sync,
 		      uint32_t broadcast_id)
 {
-	shell_print(ctx_shell,
+	shell_print(shell_get_ctx(),
 		    "PA synced to broadcaster with ID 0x%06X as sink %p",
 		    broadcast_id, sink);
 
 	if (default_sink == NULL) {
 		default_sink = sink;
 
-		shell_print(ctx_shell, "Sink %p is set as default", sink);
+		shell_print(shell_get_ctx(), "Sink %p is set as default", sink);
 	}
 }
 
@@ -1020,14 +1020,14 @@ static void base_recv(struct bt_audio_broadcast_sink *sink,
 		return;
 	}
 
-	shell_print(ctx_shell, "Received BASE from sink %p:", sink);
+	shell_print(shell_get_ctx(), "Received BASE from sink %p:", sink);
 
 	for (int i = 0; i < base->subgroup_count; i++) {
 		const struct bt_audio_base_subgroup *subgroup;
 
 		subgroup = &base->subgroups[i];
 
-		shell_print(ctx_shell, "Subgroup[%d]:", i);
+		shell_print(shell_get_ctx(), "Subgroup[%d]:", i);
 		print_codec(&subgroup->codec);
 
 		for (int j = 0; j < subgroup->bis_count; j++) {
@@ -1035,7 +1035,7 @@ static void base_recv(struct bt_audio_broadcast_sink *sink,
 
 			bis_data = &subgroup->bis_data[j];
 
-			shell_print(ctx_shell, "BIS[%d] index 0x%02x",
+			shell_print(shell_get_ctx(), "BIS[%d] index 0x%02x",
 				    i, bis_data->index);
 			bis_indexes[index_count++] = bis_data->index;
 
@@ -1044,11 +1044,11 @@ static void base_recv(struct bt_audio_broadcast_sink *sink,
 
 				codec_data = &bis_data->data[k];
 
-				shell_print(ctx_shell,
+				shell_print(shell_get_ctx(),
 					    "data #%u: type 0x%02x len %u",
 					    i, codec_data->data.type,
 					    codec_data->data.data_len);
-				shell_hexdump(ctx_shell, codec_data->data.data,
+				shell_hexdump(shell_get_ctx(), codec_data->data.data,
 					      codec_data->data.data_len -
 						sizeof(codec_data->data.type));
 			}
@@ -1063,10 +1063,10 @@ static void base_recv(struct bt_audio_broadcast_sink *sink,
 		sprintf(bis_index_str, "0x%02x ", bis_indexes[i]);
 
 		strcat(bis_indexes_str, bis_index_str);
-		shell_print(ctx_shell, "[%d]: %s", i, bis_index_str);
+		shell_print(shell_get_ctx(), "[%d]: %s", i, bis_index_str);
 	}
 
-	shell_print(ctx_shell, "Possible indexes: %s", bis_indexes_str);
+	shell_print(shell_get_ctx(), "Possible indexes: %s", bis_indexes_str);
 
 	(void)memcpy(&received_base, base, sizeof(received_base));
 }
@@ -1077,20 +1077,20 @@ static void syncable(struct bt_audio_broadcast_sink *sink, bool encrypted)
 		return;
 	}
 
-	shell_print(ctx_shell, "Sink %p is ready to sync %s encryption",
+	shell_print(shell_get_ctx(), "Sink %p is ready to sync %s encryption",
 		    sink, encrypted ? "with" : "without");
 	sink_syncable = true;
 }
 
 static void scan_term(int err)
 {
-	shell_print(ctx_shell, "Broadcast scan was terminated: %d", err);
+	shell_print(shell_get_ctx(), "Broadcast scan was terminated: %d", err);
 
 }
 
 static void pa_sync_lost(struct bt_audio_broadcast_sink *sink)
 {
-	shell_warn(ctx_shell, "Sink %p disconnected", sink);
+	shell_warn(shell_get_ctx(), "Sink %p disconnected", sink);
 
 	if (default_sink == sink) {
 		default_sink = NULL;
@@ -1115,7 +1115,7 @@ static void audio_recv(struct bt_audio_stream *stream,
 		       const struct bt_iso_recv_info *info,
 		       struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming audio on stream %p len %u\n", stream, buf->len);
+	shell_print(shell_get_ctx(), "Incoming audio on stream %p len %u\n", stream, buf->len);
 }
 
 static struct bt_audio_stream_ops stream_ops = {
@@ -1367,7 +1367,7 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err, i;
 
-	ctx_shell = sh;
+	shell_get_ctx() = sh;
 
 	err = bt_enable(NULL);
 	if (err && err != -EALREADY) {

--- a/subsys/bluetooth/shell/bass.c
+++ b/subsys/bluetooth/shell/bass.c
@@ -21,14 +21,14 @@
 static void pa_synced(struct bt_bass_recv_state *recv_state,
 		      const struct bt_le_per_adv_sync_synced_info *info)
 {
-	shell_print(ctx_shell, "BASS receive state %p was PA synced",
+	shell_print(shell_get_ctx(), "BASS receive state %p was PA synced",
 		    recv_state);
 }
 
 static void pa_term(struct bt_bass_recv_state *recv_state,
 		    const struct bt_le_per_adv_sync_term_info *info)
 {
-	shell_print(ctx_shell, "BASS receive state %p PA synced terminated",
+	shell_print(shell_get_ctx(), "BASS receive state %p PA synced terminated",
 		    recv_state);
 
 }
@@ -42,7 +42,7 @@ static void pa_recv(struct bt_bass_recv_state *recv_state,
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
 	bin2hex(buf->data, buf->len, hex, sizeof(hex));
-	shell_print(ctx_shell, "Receive state %p: device %s, tx_power %i, "
+	shell_print(shell_get_ctx(), "Receive state %p: device %s, tx_power %i, "
 		    "RSSI %i, CTE %u, data length %u, data %s",
 		    recv_state, le_addr, info->tx_power,
 		    info->rssi, info->cte_type, buf->len, hex);

--- a/subsys/bluetooth/shell/bass_client.c
+++ b/subsys/bluetooth/shell/bass_client.c
@@ -24,9 +24,9 @@ static void bass_client_discover_cb(struct bt_conn *conn, int err,
 				    uint8_t recv_state_count)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS discover failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS discover failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "BASS discover done with %u recv states",
+		shell_print(shell_get_ctx(), "BASS discover done with %u recv states",
 			    recv_state_count);
 	}
 
@@ -41,7 +41,7 @@ static void bass_client_scan_cb(const struct bt_le_scan_recv_info *info,
 	(void)memset(name, 0, sizeof(name));
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "[DEVICE]: %s (%s), broadcast_id %u, "
+	shell_print(shell_get_ctx(), "[DEVICE]: %s (%s), broadcast_id %u, "
 		    "interval (ms) %u), SID 0x%x, RSSI %i",
 		    le_addr, name, broadcast_id, info->interval * 5 / 4,
 		    info->sid, info->rssi);
@@ -54,7 +54,7 @@ static bool metadata_entry(struct bt_data *data, void *user_data)
 
 	bin2hex(data->data, data->data_len, metadata, sizeof(metadata));
 
-	shell_print(ctx_shell, "\t\tMetadata length %u, type %u, data: %s",
+	shell_print(shell_get_ctx(), "\t\tMetadata length %u, type %u, data: %s",
 		    data->data_len, data->type, metadata);
 
 	return true;
@@ -67,14 +67,14 @@ static void bass_client_recv_state_cb(struct bt_conn *conn, int err,
 	char bad_code[33];
 
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS recv state read failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS recv state read failed (%d)", err);
 		return;
 	}
 
 	bt_addr_le_to_str(&state->addr, le_addr, sizeof(le_addr));
 	bin2hex(state->bad_code, BT_BASS_BROADCAST_CODE_SIZE,
 		bad_code, sizeof(bad_code));
-	shell_print(ctx_shell, "BASS recv state: src_id %u, addr %s, "
+	shell_print(shell_get_ctx(), "BASS recv state: src_id %u, addr %s, "
 		    "sid %u, sync_state %u, encrypt_state %u%s%s",
 		    state->src_id, le_addr, state->adv_sid,
 		    state->pa_sync_state, state->encrypt_state,
@@ -85,7 +85,7 @@ static void bass_client_recv_state_cb(struct bt_conn *conn, int err,
 		const struct bt_bass_subgroup *subgroup = &state->subgroups[i];
 		struct net_buf_simple buf;
 
-		shell_print(ctx_shell, "\t[%d]: BIS sync %u, metadata_len %u",
+		shell_print(shell_get_ctx(), "\t[%d]: BIS sync %u, metadata_len %u",
 			    i, subgroup->bis_sync, subgroup->metadata_len);
 
 		net_buf_simple_init_with_data(&buf, (void *)subgroup->metadata,
@@ -109,14 +109,15 @@ static void bass_client_recv_state_cb(struct bt_conn *conn, int err,
 		}
 
 		if (per_adv_sync) {
-			shell_print(ctx_shell, "Sending PAST");
+			shell_print(shell_get_ctx(), "Sending PAST");
 
 			err = bt_le_per_adv_sync_transfer(per_adv_sync,
 							  conn,
 							  BT_UUID_BASS_VAL);
 
 			if (err != 0) {
-				shell_error(ctx_shell, "Could not transfer periodic adv sync: %d",
+				shell_error(shell_get_ctx(),
+					    "Could not transfer periodic adv sync: %d",
 					    err);
 			}
 
@@ -135,7 +136,7 @@ static void bass_client_recv_state_cb(struct bt_conn *conn, int err,
 							  &oob_local);
 
 			if (err != 0) {
-				shell_error(ctx_shell,
+				shell_error(shell_get_ctx(),
 					    "Could not get local OOB %d",
 					    err);
 				return;
@@ -149,18 +150,18 @@ static void bass_client_recv_state_cb(struct bt_conn *conn, int err,
 		}
 
 		if (ext_adv != NULL && IS_ENABLED(CONFIG_BT_PER_ADV)) {
-			shell_print(ctx_shell, "Sending local PAST");
+			shell_print(shell_get_ctx(), "Sending local PAST");
 
 			err = bt_le_per_adv_set_info_transfer(ext_adv, conn,
 							      BT_UUID_BASS_VAL);
 
 			if (err != 0) {
-				shell_error(ctx_shell,
+				shell_error(shell_get_ctx(),
 					    "Could not transfer per adv set info: %d",
 					    err);
 			}
 		} else {
-			shell_error(ctx_shell, "Could not send PA to BASS server");
+			shell_error(shell_get_ctx(), "Could not send PA to BASS server");
 		}
 	}
 }
@@ -169,64 +170,64 @@ static void bass_client_recv_state_removed_cb(struct bt_conn *conn, int err,
 					      uint8_t src_id)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS recv state removed failed (%d)",
+		shell_error(shell_get_ctx(), "BASS recv state removed failed (%d)",
 			    err);
 	} else {
-		shell_print(ctx_shell, "BASS recv state %u removed", src_id);
+		shell_print(shell_get_ctx(), "BASS recv state %u removed", src_id);
 	}
 }
 
 static void bass_client_scan_start_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS scan start failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS scan start failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "BASS scan start successful");
+		shell_print(shell_get_ctx(), "BASS scan start successful");
 	}
 }
 
 static void bass_client_scan_stop_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS scan stop failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS scan stop failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "BASS scan stop successful");
+		shell_print(shell_get_ctx(), "BASS scan stop successful");
 	}
 }
 
 static void bass_client_add_src_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS add source failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS add source failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "BASS add source successful");
+		shell_print(shell_get_ctx(), "BASS add source successful");
 	}
 }
 
 static void bass_client_mod_src_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS modify source failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS modify source failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "BASS modify source successful");
+		shell_print(shell_get_ctx(), "BASS modify source successful");
 	}
 }
 
 static void bass_client_broadcast_code_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS broadcast code failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS broadcast code failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "BASS broadcast code successful");
+		shell_print(shell_get_ctx(), "BASS broadcast code successful");
 	}
 }
 
 static void bass_client_rem_src_cb(struct bt_conn *conn, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "BASS remove source failed (%d)", err);
+		shell_error(shell_get_ctx(), "BASS remove source failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "BASS remove source successful");
+		shell_print(shell_get_ctx(), "BASS remove source successful");
 	}
 }
 

--- a/subsys/bluetooth/shell/bredr.c
+++ b/subsys/bluetooth/shell/bredr.c
@@ -146,7 +146,7 @@ static void br_device_found(const bt_addr_t *addr, int8_t rssi,
 
 	bt_addr_to_str(addr, br_addr, sizeof(br_addr));
 
-	shell_print(ctx_shell, "[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
+	shell_print(shell_get_ctx(), "[DEVICE]: %s, RSSI %i %s", br_addr, rssi, name);
 }
 
 static struct bt_br_discovery_result br_discovery_results[5];
@@ -156,7 +156,7 @@ static void br_discovery_complete(struct bt_br_discovery_result *results,
 {
 	size_t i;
 
-	shell_print(ctx_shell, "BR/EDR discovery complete");
+	shell_print(shell_get_ctx(), "BR/EDR discovery complete");
 
 	for (i = 0; i < count; i++) {
 		br_device_found(&results[i].addr, results[i].rssi,
@@ -207,7 +207,7 @@ static int cmd_discovery(const struct shell *sh, size_t argc, char *argv[])
 
 static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
+	shell_print(shell_get_ctx(), "Incoming data channel %p len %u", chan,
 		    buf->len);
 
 	return 0;
@@ -215,17 +215,17 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p connected", chan);
+	shell_print(shell_get_ctx(), "Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p disconnected", chan);
+	shell_print(shell_get_ctx(), "Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p requires buffer", chan);
+	shell_print(shell_get_ctx(), "Channel %p requires buffer", chan);
 
 	return net_buf_alloc(&data_pool, K_FOREVER);
 }
@@ -245,10 +245,10 @@ static struct bt_l2cap_br_chan l2cap_chan = {
 
 static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming BR/EDR conn %p", conn);
+	shell_print(shell_get_ctx(), "Incoming BR/EDR conn %p", conn);
 
 	if (l2cap_chan.chan.conn) {
-		shell_error(ctx_shell, "No channels available");
+		shell_error(shell_get_ctx(), "No channels available");
 		return -ENOMEM;
 	}
 
@@ -368,7 +368,7 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		shell_print(ctx_shell, "SDP HFPAG data@%p (len %u) hint %u from"
+		shell_print(shell_get_ctx(), "SDP HFPAG data@%p (len %u) hint %u from"
 			    " remote %s", result->resp_buf,
 			    result->resp_buf->len, result->next_record_hint,
 			    addr);
@@ -380,21 +380,21 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_RFCOMM, &param);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting Server CN, "
+			shell_error(shell_get_ctx(), "Error getting Server CN, "
 				    "err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFPAG Server CN param 0x%04x", param);
+		shell_print(shell_get_ctx(), "HFPAG Server CN param 0x%04x", param);
 
 		res = bt_sdp_get_profile_version(result->resp_buf,
 						 BT_SDP_HANDSFREE_SVCLASS,
 						 &version);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting profile version, "
+			shell_error(shell_get_ctx(), "Error getting profile version, "
 				    "err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFP version param 0x%04x", version);
+		shell_print(shell_get_ctx(), "HFP version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -402,14 +402,14 @@ static uint8_t sdp_hfp_ag_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			shell_error(ctx_shell, "Error getting HFPAG Features, "
+			shell_error(shell_get_ctx(), "Error getting HFPAG Features, "
 				    "err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "HFPAG Supported Features param 0x%04x",
+		shell_print(shell_get_ctx(), "HFPAG Supported Features param 0x%04x",
 		      features);
 	} else {
-		shell_print(ctx_shell, "No SDP HFPAG data from remote %s",
+		shell_print(shell_get_ctx(), "No SDP HFPAG data from remote %s",
 			    addr);
 	}
 done:
@@ -427,7 +427,7 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (result) {
-		shell_print(ctx_shell, "SDP A2SRC data@%p (len %u) hint %u from"
+		shell_print(shell_get_ctx(), "SDP A2SRC data@%p (len %u) hint %u from"
 			    " remote %s", result->resp_buf,
 			    result->resp_buf->len, result->next_record_hint,
 			    addr);
@@ -439,12 +439,12 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		res = bt_sdp_get_proto_param(result->resp_buf,
 					     BT_SDP_PROTO_L2CAP, &param);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC PSM Number not found, "
+			shell_error(shell_get_ctx(), "A2SRC PSM Number not found, "
 				    "err %d", res);
 			goto done;
 		}
 
-		shell_print(ctx_shell, "A2SRC Server PSM Number param 0x%04x",
+		shell_print(shell_get_ctx(), "A2SRC Server PSM Number param 0x%04x",
 			    param);
 
 		/*
@@ -455,11 +455,11 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 						 BT_SDP_ADVANCED_AUDIO_SVCLASS,
 						 &version);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC version not found, "
+			shell_error(shell_get_ctx(), "A2SRC version not found, "
 				    "err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "A2SRC version param 0x%04x", version);
+		shell_print(shell_get_ctx(), "A2SRC version param 0x%04x", version);
 
 		/*
 		 * Focus to get BT_SDP_ATTR_SUPPORTED_FEATURES attribute item to
@@ -467,14 +467,14 @@ static uint8_t sdp_a2src_user(struct bt_conn *conn,
 		 */
 		res = bt_sdp_get_features(result->resp_buf, &features);
 		if (res < 0) {
-			shell_error(ctx_shell, "A2SRC Features not found, "
+			shell_error(shell_get_ctx(), "A2SRC Features not found, "
 				    "err %d", res);
 			goto done;
 		}
-		shell_print(ctx_shell, "A2SRC Supported Features param 0x%04x",
+		shell_print(shell_get_ctx(), "A2SRC Supported Features param 0x%04x",
 		      features);
 	} else {
-		shell_print(ctx_shell, "No SDP A2SRC data from remote %s",
+		shell_print(shell_get_ctx(), "No SDP A2SRC data from remote %s",
 			    addr);
 	}
 done:

--- a/subsys/bluetooth/shell/bt.c
+++ b/subsys/bluetooth/shell/bt.c
@@ -41,7 +41,6 @@
 static bool no_settings_load;
 
 uint8_t selected_id = BT_ID_DEFAULT;
-const struct shell *ctx_shell;
 
 #if defined(CONFIG_BT_CONN)
 struct bt_conn *default_conn;
@@ -116,7 +115,7 @@ static bool is_substring(const char *substr, const char *str)
 	for (size_t pos = 0; pos < str_len; pos++) {
 		if (tolower(substr[0]) == tolower(str[pos])) {
 			if (pos + sub_str_len > str_len) {
-				shell_print(ctx_shell, "length fail");
+				shell_print(shell_get_ctx(), "length fail");
 				return false;
 			}
 
@@ -163,7 +162,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 		return;
 	}
 
-	shell_print(ctx_shell, "[DEVICE]: %s, AD evt type %u, RSSI %i %s "
+	shell_print(shell_get_ctx(), "[DEVICE]: %s, AD evt type %u, RSSI %i %s "
 		    "C:%u S:%u D:%d SR:%u E:%u Prim: %s, Secn: %s, "
 		    "Interval: 0x%04x (%u ms), SID: 0x%x",
 		    le_addr, info->adv_type, info->rssi, name,
@@ -179,7 +178,7 @@ static void scan_recv(const struct bt_le_scan_recv_info *info,
 
 static void scan_timeout(void)
 {
-	shell_print(ctx_shell, "Scan timeout");
+	shell_print(shell_get_ctx(), "Scan timeout");
 }
 #endif /* CONFIG_BT_OBSERVER */
 
@@ -188,7 +187,7 @@ static void scan_timeout(void)
 static void adv_sent(struct bt_le_ext_adv *adv,
 		     struct bt_le_ext_adv_sent_info *info)
 {
-	shell_print(ctx_shell, "Advertiser[%d] %p sent %d",
+	shell_print(shell_get_ctx(), "Advertiser[%d] %p sent %d",
 		    bt_le_ext_adv_get_index(adv), adv, info->num_sent);
 }
 
@@ -199,7 +198,7 @@ static void adv_scanned(struct bt_le_ext_adv *adv,
 
 	bt_addr_le_to_str(info->addr, str, sizeof(str));
 
-	shell_print(ctx_shell, "Advertiser[%d] %p scanned by %s",
+	shell_print(shell_get_ctx(), "Advertiser[%d] %p scanned by %s",
 		    bt_le_ext_adv_get_index(adv), adv, str);
 }
 #endif /* CONFIG_BT_BROADCASTER */
@@ -212,7 +211,7 @@ static void adv_connected(struct bt_le_ext_adv *adv,
 
 	bt_addr_le_to_str(bt_conn_get_dst(info->conn), str, sizeof(str));
 
-	shell_print(ctx_shell, "Advertiser[%d] %p connected by %s",
+	shell_print(shell_get_ctx(), "Advertiser[%d] %p connected by %s",
 		    bt_le_ext_adv_get_index(adv), adv, str);
 }
 #endif /* CONFIG_BT_PERIPHERAL */
@@ -296,12 +295,12 @@ static void connected(struct bt_conn *conn, uint8_t err)
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (err) {
-		shell_error(ctx_shell, "Failed to connect to %s (0x%02x)", addr,
+		shell_error(shell_get_ctx(), "Failed to connect to %s (0x%02x)", addr,
 			     err);
 		goto done;
 	}
 
-	shell_print(ctx_shell, "Connected: %s", addr);
+	shell_print(shell_get_ctx(), "Connected: %s", addr);
 
 	if (!default_conn) {
 		default_conn = bt_conn_ref(conn);
@@ -320,7 +319,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 	char addr[BT_ADDR_LE_STR_LEN];
 
 	conn_addr_str(conn, addr, sizeof(addr));
-	shell_print(ctx_shell, "Disconnected: %s (reason 0x%02x)", addr, reason);
+	shell_print(shell_get_ctx(), "Disconnected: %s (reason 0x%02x)", addr, reason);
 
 	if (default_conn == conn) {
 		bt_conn_unref(default_conn);
@@ -330,7 +329,7 @@ static void disconnected(struct bt_conn *conn, uint8_t reason)
 
 static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 {
-	shell_print(ctx_shell, "LE conn  param req: int (0x%04x, 0x%04x) lat %d"
+	shell_print(shell_get_ctx(), "LE conn  param req: int (0x%04x, 0x%04x) lat %d"
 		    " to %d", param->interval_min, param->interval_max,
 		    param->latency, param->timeout);
 
@@ -340,7 +339,7 @@ static bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param)
 static void le_param_updated(struct bt_conn *conn, uint16_t interval,
 			     uint16_t latency, uint16_t timeout)
 {
-	shell_print(ctx_shell, "LE conn param updated: int 0x%04x lat %d "
+	shell_print(shell_get_ctx(), "LE conn param updated: int 0x%04x lat %d "
 		     "to %d", interval, latency, timeout);
 }
 
@@ -354,7 +353,7 @@ static void identity_resolved(struct bt_conn *conn, const bt_addr_le_t *rpa,
 	bt_addr_le_to_str(identity, addr_identity, sizeof(addr_identity));
 	bt_addr_le_to_str(rpa, addr_rpa, sizeof(addr_rpa));
 
-	shell_print(ctx_shell, "Identity resolved %s -> %s", addr_rpa,
+	shell_print(shell_get_ctx(), "Identity resolved %s -> %s", addr_rpa,
 	      addr_identity);
 }
 #endif
@@ -394,10 +393,10 @@ static void security_changed(struct bt_conn *conn, bt_security_t level,
 	conn_addr_str(conn, addr, sizeof(addr));
 
 	if (!err) {
-		shell_print(ctx_shell, "Security changed: %s level %u", addr,
+		shell_print(shell_get_ctx(), "Security changed: %s level %u", addr,
 			    level);
 	} else {
-		shell_print(ctx_shell, "Security failed: %s level %u "
+		shell_print(shell_get_ctx(), "Security failed: %s level %u "
 			    "reason: %s (%d)",
 			    addr, level, security_err_str(err), err);
 	}
@@ -427,7 +426,7 @@ static void remote_info_available(struct bt_conn *conn,
 	bt_conn_get_info(conn, &info);
 
 	if (IS_ENABLED(CONFIG_BT_REMOTE_VERSION)) {
-		shell_print(ctx_shell,
+		shell_print(shell_get_ctx(),
 			    "Remote LMP version %s (0x%02x) subversion 0x%04x "
 			    "manufacturer 0x%04x", ver_str(remote_info->version),
 			    remote_info->version, remote_info->subversion,
@@ -442,7 +441,7 @@ static void remote_info_available(struct bt_conn *conn,
 				sizeof(features));
 		bin2hex(features, sizeof(features),
 			features_str, sizeof(features_str));
-		shell_print(ctx_shell, "LE Features: 0x%s ", features_str);
+		shell_print(shell_get_ctx(), "LE Features: 0x%s ", features_str);
 	}
 }
 #endif /* defined(CONFIG_BT_REMOTE_INFO) */
@@ -451,7 +450,7 @@ static void remote_info_available(struct bt_conn *conn,
 void le_data_len_updated(struct bt_conn *conn,
 			 struct bt_conn_le_data_len_info *info)
 {
-	shell_print(ctx_shell,
+	shell_print(shell_get_ctx(),
 		    "LE data len updated: TX (len: %d time: %d)"
 		    " RX (len: %d time: %d)", info->tx_max_len,
 		    info->tx_max_time, info->rx_max_len, info->rx_max_time);
@@ -462,7 +461,7 @@ void le_data_len_updated(struct bt_conn *conn,
 void le_phy_updated(struct bt_conn *conn,
 		    struct bt_conn_le_phy_info *info)
 {
-	shell_print(ctx_shell, "LE PHY updated: TX PHY %s, RX PHY %s",
+	shell_print(shell_get_ctx(), "LE PHY updated: TX PHY %s, RX PHY %s",
 		    phy2str(info->tx_phy), phy2str(info->rx_phy));
 }
 #endif
@@ -527,7 +526,7 @@ static void per_adv_sync_sync_cb(struct bt_le_per_adv_sync *sync,
 		memset(past_peer, 0, sizeof(past_peer));
 	}
 
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
+	shell_print(shell_get_ctx(), "PER_ADV_SYNC[%u]: [DEVICE]: %s synced, "
 		    "Interval 0x%04x (%u ms), PHY %s, SD 0x%04X, PAST peer %s",
 		    bt_le_per_adv_sync_get_index(sync), le_addr,
 		    info->interval, BT_CONN_INTERVAL_TO_MS(info->interval),
@@ -557,7 +556,7 @@ static void per_adv_sync_terminated_cb(
 	}
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
+	shell_print(shell_get_ctx(), "PER_ADV_SYNC[%u]: [DEVICE]: %s sync terminated",
 		    bt_le_per_adv_sync_get_index(sync), le_addr);
 }
 
@@ -569,7 +568,7 @@ static void per_adv_sync_recv_cb(
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
+	shell_print(shell_get_ctx(), "PER_ADV_SYNC[%u]: [DEVICE]: %s, tx_power %i, "
 		    "RSSI %i, CTE %u, data length %u",
 		    bt_le_per_adv_sync_get_index(sync), le_addr, info->tx_power,
 		    info->rssi, info->cte_type, buf->len);
@@ -581,7 +580,8 @@ static void per_adv_sync_biginfo_cb(struct bt_le_per_adv_sync *sync,
 	char le_addr[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(biginfo->addr, le_addr, sizeof(le_addr));
-	shell_print(ctx_shell, "BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, "
+	shell_print(shell_get_ctx(),
+		    "BIG_INFO PER_ADV_SYNC[%u]: [DEVICE]: %s, sid 0x%02x, num_bis %u, "
 		    "nse 0x%02x, interval 0x%04x (%u ms), bn 0x%02x, pto 0x%02x, irc 0x%02x, "
 		    "max_pdu 0x%04x, sdu_interval 0x%04x, max_sdu 0x%04x, phy %s, framing 0x%02x, "
 		    "%sencrypted",
@@ -604,15 +604,15 @@ static struct bt_le_per_adv_sync_cb per_adv_sync_cb = {
 static void bt_ready(int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Bluetooth init failed (err %d)", err);
+		shell_error(shell_get_ctx(), "Bluetooth init failed (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Bluetooth initialized");
+	shell_print(shell_get_ctx(), "Bluetooth initialized");
 
 	if (IS_ENABLED(CONFIG_SETTINGS) && !no_settings_load) {
 		settings_load();
-		shell_print(ctx_shell, "Settings Loaded");
+		shell_print(shell_get_ctx(), "Settings Loaded");
 	}
 
 	if (IS_ENABLED(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)) {
@@ -642,8 +642,6 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 	bool no_ready_cb = false;
-
-	ctx_shell = sh;
 
 	for (size_t argn = 1; argn < argc; argn++) {
 		const char *arg = argv[argn];
@@ -1032,7 +1030,7 @@ static int cmd_scan_filter_set_name(const struct shell *sh, size_t argc,
 	const char *name_arg = argv[1];
 
 	if (strlen(name_arg) >= sizeof(scan_filter.name)) {
-		shell_error(ctx_shell, "Name is too long (max %zu): %s\n",
+		shell_error(shell_get_ctx(), "Name is too long (max %zu): %s\n",
 			    sizeof(scan_filter.name), name_arg);
 		return -ENOEXEC;
 	}
@@ -1050,7 +1048,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 
 	/* Validate length including null terminator. */
 	if (strlen(addr_arg) >= sizeof(scan_filter.addr)) {
-		shell_error(ctx_shell, "Invalid address string: %s\n",
+		shell_error(shell_get_ctx(), "Invalid address string: %s\n",
 			    addr_arg);
 		return -ENOEXEC;
 	}
@@ -1061,7 +1059,7 @@ static int cmd_scan_filter_set_addr(const struct shell *sh, size_t argc,
 		uint8_t tmp;
 
 		if (c != ':' && char2hex(c, &tmp) < 0) {
-			shell_error(ctx_shell,
+			shell_error(shell_get_ctx(),
 					"Invalid address string: %s\n",
 					addr_arg);
 			return -ENOEXEC;
@@ -1548,7 +1546,7 @@ static int cmd_adv_delete(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_le_ext_adv_delete(adv);
 	if (err) {
-		shell_error(ctx_shell, "Failed to delete advertiser set");
+		shell_error(shell_get_ctx(), "Failed to delete advertiser set");
 		return err;
 	}
 
@@ -2165,7 +2163,7 @@ static void print_le_addr(const char *desc, const bt_addr_le_t *addr)
 
 	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
 
-	shell_print(ctx_shell, "%s address: %s (%s)", desc, addr_str,
+	shell_print(shell_get_ctx(), "%s address: %s (%s)", desc, addr_str,
 		    addr_desc);
 }
 
@@ -2211,11 +2209,11 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 
 	err = bt_conn_get_info(conn, &info);
 	if (err) {
-		shell_print(ctx_shell, "Failed to get info");
+		shell_print(shell_get_ctx(), "Failed to get info");
 		goto done;
 	}
 
-	shell_print(ctx_shell, "Type: %s, Role: %s, Id: %u",
+	shell_print(shell_get_ctx(), "Type: %s, Role: %s, Id: %u",
 		    get_conn_type_str(info.type),
 		    get_conn_role_str(info.role),
 		    info.id);
@@ -2226,21 +2224,21 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		print_le_addr("Remote on-air", info.le.remote);
 		print_le_addr("Local on-air", info.le.local);
 
-		shell_print(ctx_shell, "Interval: 0x%04x (%u ms)",
+		shell_print(shell_get_ctx(), "Interval: 0x%04x (%u ms)",
 			    info.le.interval,
 			    BT_CONN_INTERVAL_TO_MS(info.le.interval));
-		shell_print(ctx_shell, "Latency: 0x%04x (%u ms)",
+		shell_print(shell_get_ctx(), "Latency: 0x%04x (%u ms)",
 			    info.le.latency,
 			    BT_CONN_INTERVAL_TO_MS(info.le.latency));
-		shell_print(ctx_shell, "Supervision timeout: 0x%04x (%d ms)",
+		shell_print(shell_get_ctx(), "Supervision timeout: 0x%04x (%d ms)",
 			    info.le.timeout, info.le.timeout * 10);
 #if defined(CONFIG_BT_USER_PHY_UPDATE)
-		shell_print(ctx_shell, "LE PHY: TX PHY %s, RX PHY %s",
+		shell_print(shell_get_ctx(), "LE PHY: TX PHY %s, RX PHY %s",
 			    phy2str(info.le.phy->tx_phy),
 			    phy2str(info.le.phy->rx_phy));
 #endif
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
-		shell_print(ctx_shell, "LE data len: TX (len: %d time: %d)"
+		shell_print(shell_get_ctx(), "LE data len: TX (len: %d time: %d)"
 			    " RX (len: %d time: %d)",
 			    info.le.data_len->tx_max_len,
 			    info.le.data_len->tx_max_time,
@@ -2254,7 +2252,7 @@ static int cmd_info(const struct shell *sh, size_t argc, char *argv[])
 		char addr_str[BT_ADDR_STR_LEN];
 
 		bt_addr_to_str(info.br.dst, addr_str, sizeof(addr_str));
-		shell_print(ctx_shell, "Peer address %s", addr_str);
+		shell_print(shell_get_ctx(), "Peer address %s", addr_str);
 	}
 #endif /* defined(CONFIG_BT_BREDR) */
 
@@ -2586,7 +2584,7 @@ static void bond_info(const struct bt_bond_info *info, void *user_data)
 	int *bond_count = user_data;
 
 	bt_addr_le_to_str(&info->addr, addr, sizeof(addr));
-	shell_print(ctx_shell, "Remote Identity: %s", addr);
+	shell_print(shell_get_ctx(), "Remote Identity: %s", addr);
 	(*bond_count)++;
 }
 
@@ -2620,7 +2618,7 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 	struct bt_conn_info info;
 
 	if (bt_conn_get_info(conn, &info) < 0) {
-		shell_error(ctx_shell, "Unable to get info: conn %p", conn);
+		shell_error(shell_get_ctx(), "Unable to get info: conn %p", conn);
 		return;
 	}
 
@@ -2628,20 +2626,20 @@ static void connection_info(struct bt_conn *conn, void *user_data)
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_BR:
 		bt_addr_to_str(info.br.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "#%u [BR][%s] %s", info.id,
+		shell_print(shell_get_ctx(), "#%u [BR][%s] %s", info.id,
 			    role_str(info.role), addr);
 		break;
 #endif
 	case BT_CONN_TYPE_LE:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "#%u [LE][%s] %s: Interval %u latency %u"
+		shell_print(shell_get_ctx(), "#%u [LE][%s] %s: Interval %u latency %u"
 			    " timeout %u", info.id, role_str(info.role), addr,
 			    info.le.interval, info.le.latency, info.le.timeout);
 		break;
 #if defined(CONFIG_BT_ISO)
 	case BT_CONN_TYPE_ISO:
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "#%u [ISO][%s] %s", info.id,
+		shell_print(shell_get_ctx(), "#%u [ISO][%s] %s", info.id,
 			    role_str(info.role), addr);
 		break;
 #endif
@@ -2670,7 +2668,7 @@ static void auth_passkey_display(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	shell_print(ctx_shell, "Passkey for %s: %s", addr, passkey_str);
+	shell_print(shell_get_ctx(), "Passkey for %s: %s", addr, passkey_str);
 }
 
 static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
@@ -2682,7 +2680,7 @@ static void auth_passkey_confirm(struct bt_conn *conn, unsigned int passkey)
 
 	snprintk(passkey_str, 7, "%06u", passkey);
 
-	shell_print(ctx_shell, "Confirm passkey for %s: %s", addr, passkey_str);
+	shell_print(shell_get_ctx(), "Confirm passkey for %s: %s", addr, passkey_str);
 }
 
 static void auth_passkey_entry(struct bt_conn *conn)
@@ -2691,7 +2689,7 @@ static void auth_passkey_entry(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Enter passkey for %s", addr);
+	shell_print(shell_get_ctx(), "Enter passkey for %s", addr);
 }
 
 static void auth_cancel(struct bt_conn *conn)
@@ -2700,7 +2698,7 @@ static void auth_cancel(struct bt_conn *conn)
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Pairing cancelled: %s", addr);
+	shell_print(shell_get_ctx(), "Pairing cancelled: %s", addr);
 
 	/* clear connection reference for sec mode 3 pairing */
 	if (pairing_conn) {
@@ -2715,7 +2713,7 @@ static void auth_pairing_confirm(struct bt_conn *conn)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Confirm pairing for %s", addr);
+	shell_print(shell_get_ctx(), "Confirm pairing for %s", addr);
 }
 
 #if !defined(CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY)
@@ -2761,7 +2759,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		if (oobd_remote &&
 		    bt_addr_le_cmp(info.le.remote, &oob_remote.addr)) {
 			bt_addr_le_to_str(info.le.remote, addr, sizeof(addr));
-			shell_print(ctx_shell,
+			shell_print(shell_get_ctx(),
 				    "No OOB data available for remote %s",
 				    addr);
 			bt_conn_auth_cancel(conn);
@@ -2771,7 +2769,7 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		if (oobd_local &&
 		    bt_addr_le_cmp(info.le.local, &oob_local.addr)) {
 			bt_addr_le_to_str(info.le.local, addr, sizeof(addr));
-			shell_print(ctx_shell,
+			shell_print(shell_get_ctx(),
 				    "No OOB data available for local %s",
 				    addr);
 			bt_conn_auth_cancel(conn);
@@ -2781,14 +2779,14 @@ static void auth_pairing_oob_data_request(struct bt_conn *conn,
 		bt_le_oob_set_sc_data(conn, oobd_local, oobd_remote);
 
 		bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-		shell_print(ctx_shell, "Set %s OOB SC data for %s, ",
+		shell_print(shell_get_ctx(), "Set %s OOB SC data for %s, ",
 			    oob_config_str(oob_info->lesc.oob_config), addr);
 		return;
 	}
 #endif /* CONFIG_BT_SMP_OOB_LEGACY_PAIR_ONLY */
 
 	bt_addr_le_to_str(info.le.dst, addr, sizeof(addr));
-	shell_print(ctx_shell, "Legacy OOB TK requested from remote %s", addr);
+	shell_print(shell_get_ctx(), "Legacy OOB TK requested from remote %s", addr);
 }
 
 static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
@@ -2797,7 +2795,7 @@ static void auth_pairing_complete(struct bt_conn *conn, bool bonded)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "%s with %s", bonded ? "Bonded" : "Paired",
+	shell_print(shell_get_ctx(), "%s with %s", bonded ? "Bonded" : "Paired",
 		    addr);
 }
 
@@ -2807,7 +2805,7 @@ static void auth_pairing_failed(struct bt_conn *conn, enum bt_security_err err)
 
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Pairing failed with %s reason: %s (%d)", addr,
+	shell_print(shell_get_ctx(), "Pairing failed with %s reason: %s (%d)", addr,
 		    security_err_str(err), err);
 }
 
@@ -2828,10 +2826,10 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 	bt_addr_to_str(info.br.dst, addr, sizeof(addr));
 
 	if (highsec) {
-		shell_print(ctx_shell, "Enter 16 digits wide PIN code for %s",
+		shell_print(shell_get_ctx(), "Enter 16 digits wide PIN code for %s",
 			    addr);
 	} else {
-		shell_print(ctx_shell, "Enter PIN code for %s", addr);
+		shell_print(shell_get_ctx(), "Enter PIN code for %s", addr);
 	}
 
 	/*
@@ -2848,7 +2846,7 @@ static void auth_pincode_entry(struct bt_conn *conn, bool highsec)
 enum bt_security_err pairing_accept(
 	struct bt_conn *conn, const struct bt_conn_pairing_feat *const feat)
 {
-	shell_print(ctx_shell, "Remote pairing features: "
+	shell_print(shell_get_ctx(), "Remote pairing features: "
 			       "IO: 0x%02x, OOB: %d, AUTH: 0x%02x, Key: %d, "
 			       "Init Kdist: 0x%02x, Resp Kdist: 0x%02x",
 			       feat->io_capability, feat->oob_data_flag,
@@ -2864,7 +2862,7 @@ void bond_deleted(uint8_t id, const bt_addr_le_t *peer)
 	char addr[BT_ADDR_STR_LEN];
 
 	bt_addr_le_to_str(peer, addr, sizeof(addr));
-	shell_print(ctx_shell, "Bond deleted for %s, id %u", addr, id);
+	shell_print(shell_get_ctx(), "Bond deleted for %s, id %u", addr, id);
 }
 
 static struct bt_conn_auth_cb auth_cb_display = {

--- a/subsys/bluetooth/shell/csis.c
+++ b/subsys/bluetooth/shell/csis.c
@@ -19,21 +19,20 @@
 #include <zephyr/bluetooth/audio/csis.h>
 #include "bt.h"
 
-extern const struct shell *ctx_shell;
 static struct bt_csis *csis;
 static uint8_t sirk_read_rsp = BT_CSIS_READ_SIRK_REQ_RSP_ACCEPT;
 
 static void locked_cb(struct bt_conn *conn, struct bt_csis *csis, bool locked)
 {
 	if (conn == NULL) {
-		shell_error(ctx_shell, "Server %s the device",
+		shell_error(shell_get_ctx(), "Server %s the device",
 			    locked ? "locked" : "released");
 	} else {
 		char addr[BT_ADDR_LE_STR_LEN];
 
 		conn_addr_str(conn, addr, sizeof(addr));
 
-		shell_print(ctx_shell, "Client %s %s the device",
+		shell_print(shell_get_ctx(), "Client %s %s the device",
 			    addr, locked ? "locked" : "released");
 	}
 }
@@ -47,7 +46,7 @@ static uint8_t sirk_read_req_cb(struct bt_conn *conn, struct bt_csis *csis)
 
 	conn_addr_str(conn, addr, sizeof(addr));
 
-	shell_print(ctx_shell, "Client %s requested to read the sirk. "
+	shell_print(shell_get_ctx(), "Client %s requested to read the sirk. "
 		    "Responding with %s", addr, rsp_strings[sirk_read_rsp]);
 
 	return sirk_read_rsp;

--- a/subsys/bluetooth/shell/csis_client.c
+++ b/subsys/bluetooth/shell/csis_client.c
@@ -46,18 +46,18 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 	bt_addr_le_to_str(bt_conn_get_dst(conn), addr, sizeof(addr));
 
 	if (err != 0) {
-		shell_error(ctx_shell, "Failed to connect to %s (%u)",
+		shell_error(shell_get_ctx(), "Failed to connect to %s (%u)",
 			    addr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "[%u]: Connected to %s",
+	shell_print(shell_get_ctx(), "[%u]: Connected to %s",
 		    bt_conn_index(conn), addr);
 
 	/* TODO: Handle RPAs */
 
 	if (members_found == 0) {
-		shell_print(ctx_shell, "Assuming member[0] connected");
+		shell_print(shell_get_ctx(), "Assuming member[0] connected");
 		set_members[0].conn = conn;
 		bt_addr_le_copy(&addr_found[0], bt_conn_get_dst(conn));
 		members_found = 1;
@@ -68,11 +68,11 @@ static void connected_cb(struct bt_conn *conn, uint8_t err)
 		if (bt_addr_le_cmp(bt_conn_get_dst(conn),
 				   &addr_found[i]) == 0) {
 			set_members[i].conn = conn;
-			shell_print(ctx_shell, "Member[%u] connected", i);
+			shell_print(shell_get_ctx(), "Member[%u] connected", i);
 			return;
 		}
 	}
-	shell_warn(ctx_shell, "[%u] connected but was not member of set",
+	shell_warn(shell_get_ctx(), "[%u] connected but was not member of set",
 		   bt_conn_index(conn));
 }
 
@@ -84,18 +84,18 @@ static void csis_discover_cb(struct bt_csis_client_set_member *member, int err,
 			     uint8_t set_count)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "discover failed (%d)", err);
+		shell_error(shell_get_ctx(), "discover failed (%d)", err);
 		return;
 	}
 
 	if (set_count == 0) {
-		shell_warn(ctx_shell, "Device has no sets");
+		shell_warn(shell_get_ctx(), "Device has no sets");
 		return;
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(set_members); i++) {
 		if (&set_members[i] == member) {
-			shell_print(ctx_shell, "Found %u sets on member[%u]",
+			shell_print(shell_get_ctx(), "Found %u sets on member[%u]",
 				    set_count, i);
 		}
 	}
@@ -104,21 +104,21 @@ static void csis_discover_cb(struct bt_csis_client_set_member *member, int err,
 static void csis_client_lock_set_cb(int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Lock sets failed (%d)", err);
+		shell_error(shell_get_ctx(), "Lock sets failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Set locked");
+	shell_print(shell_get_ctx(), "Set locked");
 }
 
 static void csis_client_release_set_cb(int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Lock sets failed (%d)", err);
+		shell_error(shell_get_ctx(), "Lock sets failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Set released");
+	shell_print(shell_get_ctx(), "Set released");
 }
 
 static void csis_client_ordered_access_cb(const struct bt_csis_client_set_info *set_info,
@@ -160,18 +160,18 @@ static bool csis_found(struct bt_data *data, void *user_data)
 		char addr_str[BT_ADDR_LE_STR_LEN];
 
 		bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
-		shell_print(ctx_shell, "Found CSIS advertiser with address %s",
+		shell_print(shell_get_ctx(), "Found CSIS advertiser with address %s",
 			    addr_str);
 
 		if (is_discovered(addr)) {
-			shell_print(ctx_shell, "Set member already found");
+			shell_print(shell_get_ctx(), "Set member already found");
 			/* Stop parsing */
 			return false;
 		}
 
 		bt_addr_le_copy(&addr_found[members_found++], addr);
 
-		shell_print(ctx_shell, "Found member (%u / %u)",
+		shell_print(shell_get_ctx(), "Found member (%u / %u)",
 			    members_found, cur_inst->info.set_size);
 
 		if (members_found == cur_inst->info.set_size) {
@@ -181,7 +181,7 @@ static bool csis_found(struct bt_data *data, void *user_data)
 
 			err = bt_le_scan_stop();
 			if (err != 0) {
-				shell_error(ctx_shell,
+				shell_error(shell_get_ctx(),
 					    "Failed to stop scan: %d",
 					    err);
 			}
@@ -213,12 +213,12 @@ static void discover_members_timer_handler(struct k_work *work)
 {
 	int err;
 
-	shell_error(ctx_shell, "Could not find all members (%u / %u)",
+	shell_error(shell_get_ctx(), "Could not find all members (%u / %u)",
 		    members_found, cur_inst->info.set_size);
 
 	err = bt_le_scan_stop();
 	if (err != 0) {
-		shell_error(ctx_shell, "Failed to stop scan: %d", err);
+		shell_error(shell_get_ctx(), "Failed to stop scan: %d", err);
 	}
 }
 
@@ -256,10 +256,6 @@ static int cmd_csis_client_discover(const struct shell *sh, size_t argc,
 				    member_index);
 			return -ENOEXEC;
 		}
-	}
-
-	if (ctx_shell == NULL) {
-		ctx_shell = sh;
 	}
 
 	shell_print(sh, "Discovering for member[%u]", (uint8_t)member_index);

--- a/subsys/bluetooth/shell/gatt.c
+++ b/subsys/bluetooth/shell/gatt.c
@@ -68,7 +68,7 @@ static void update_write_stats(uint16_t len)
 
 static void print_write_stats(void)
 {
-	shell_print(ctx_shell, "Write #%u: %u bytes (%u bps)",
+	shell_print(shell_get_ctx(), "Write #%u: %u bytes (%u bps)",
 		    write_stats.count, write_stats.total, write_stats.rate);
 }
 #endif /* CONFIG_BT_GATT_CLIENT || CONFIG_BT_GATT_DYNAMIC_DB */
@@ -82,7 +82,7 @@ static void reset_write_stats(void)
 static void exchange_func(struct bt_conn *conn, uint8_t err,
 			  struct bt_gatt_exchange_params *params)
 {
-	shell_print(ctx_shell, "Exchange %s", err == 0U ? "successful" :
+	shell_print(shell_get_ctx(), "Exchange %s", err == 0U ? "successful" :
 		    "failed");
 
 	(void)memset(params, 0, sizeof(*params));
@@ -166,7 +166,7 @@ static uint8_t discover_func(struct bt_conn *conn,
 	char str[BT_UUID_STR_LEN];
 
 	if (!attr) {
-		shell_print(ctx_shell, "Discover complete");
+		shell_print(shell_get_ctx(), "Discover complete");
 		(void)memset(params, 0, sizeof(*params));
 		return BT_GATT_ITER_STOP;
 	}
@@ -176,28 +176,28 @@ static uint8_t discover_func(struct bt_conn *conn,
 	case BT_GATT_DISCOVER_PRIMARY:
 		gatt_service = attr->user_data;
 		bt_uuid_to_str(gatt_service->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Service %s found: start handle %x, "
+		shell_print(shell_get_ctx(), "Service %s found: start handle %x, "
 			    "end_handle %x", str, attr->handle,
 			    gatt_service->end_handle);
 		break;
 	case BT_GATT_DISCOVER_CHARACTERISTIC:
 		gatt_chrc = attr->user_data;
 		bt_uuid_to_str(gatt_chrc->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Characteristic %s found: handle %x",
+		shell_print(shell_get_ctx(), "Characteristic %s found: handle %x",
 			    str, attr->handle);
-		print_chrc_props(ctx_shell, gatt_chrc->properties);
+		print_chrc_props(shell_get_ctx(), gatt_chrc->properties);
 		break;
 	case BT_GATT_DISCOVER_INCLUDE:
 		gatt_include = attr->user_data;
 		bt_uuid_to_str(gatt_include->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Include %s found: handle %x, start %x, "
+		shell_print(shell_get_ctx(), "Include %s found: handle %x, start %x, "
 			    "end %x", str, attr->handle,
 			    gatt_include->start_handle,
 			    gatt_include->end_handle);
 		break;
 	default:
 		bt_uuid_to_str(attr->uuid, str, sizeof(str));
-		shell_print(ctx_shell, "Descriptor %s found: handle %x", str,
+		shell_print(shell_get_ctx(), "Descriptor %s found: handle %x", str,
 			    attr->handle);
 		break;
 	}
@@ -268,7 +268,7 @@ static uint8_t read_func(struct bt_conn *conn, uint8_t err,
 			 struct bt_gatt_read_params *params,
 			 const void *data, uint16_t length)
 {
-	shell_print(ctx_shell, "Read complete: err 0x%02x length %u", err, length);
+	shell_print(shell_get_ctx(), "Read complete: err 0x%02x length %u", err, length);
 
 	if (!data) {
 		(void)memset(params, 0, sizeof(*params));
@@ -401,7 +401,7 @@ static uint8_t gatt_write_buf[CHAR_SIZE_MAX];
 static void write_func(struct bt_conn *conn, uint8_t err,
 		       struct bt_gatt_write_params *params)
 {
-	shell_print(ctx_shell, "Write complete: err 0x%02x", err);
+	shell_print(shell_get_ctx(), "Write complete: err 0x%02x", err);
 
 	(void)memset(&write_params, 0, sizeof(write_params));
 }
@@ -527,12 +527,12 @@ static uint8_t notify_func(struct bt_conn *conn,
 			const void *data, uint16_t length)
 {
 	if (!data) {
-		shell_print(ctx_shell, "Unsubscribed");
+		shell_print(shell_get_ctx(), "Unsubscribed");
 		params->value_handle = 0U;
 		return BT_GATT_ITER_STOP;
 	}
 
-	shell_print(ctx_shell, "Notification: data %p length %u", data, length);
+	shell_print(shell_get_ctx(), "Notification: data %p length %u", data, length);
 
 	return BT_GATT_ITER_CONTINUE;
 }
@@ -759,7 +759,7 @@ static ssize_t write_vnd1(struct bt_conn *conn, const struct bt_gatt_attr *attr,
 			  uint8_t flags)
 {
 	if (echo_enabled) {
-		shell_print(ctx_shell, "Echo attr len %u", len);
+		shell_print(shell_get_ctx(), "Echo attr len %u", len);
 		bt_gatt_notify(conn, attr, buf, len);
 	}
 

--- a/subsys/bluetooth/shell/has.c
+++ b/subsys/bluetooth/shell/has.c
@@ -24,7 +24,7 @@ static int preset_select(uint8_t index, bool sync)
 
 static void preset_name_changed(uint8_t index, const char *name)
 {
-	shell_print(ctx_shell, "Preset name changed index %u name %s", index, name);
+	shell_print(shell_get_ctx(), "Preset name changed index %u name %s", index, name);
 }
 
 static const struct bt_has_preset_ops preset_ops = {

--- a/subsys/bluetooth/shell/has_client.c
+++ b/subsys/bluetooth/shell/has_client.c
@@ -24,11 +24,11 @@ static void has_client_discover_cb(struct bt_conn *conn, int err, struct bt_has 
 				   enum bt_has_capabilities caps)
 {
 	if (err) {
-		shell_error(ctx_shell, "HAS discovery (err %d)", err);
+		shell_error(shell_get_ctx(), "HAS discovery (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "HAS discovered %p type 0x%02x caps 0x%02x for conn %p",
+	shell_print(shell_get_ctx(), "HAS discovered %p type 0x%02x caps 0x%02x for conn %p",
 		    has, type, caps, conn);
 
 	inst = has;
@@ -36,22 +36,22 @@ static void has_client_discover_cb(struct bt_conn *conn, int err, struct bt_has 
 
 static void has_client_preset_switch_cb(struct bt_has *has, uint8_t index)
 {
-	shell_print(ctx_shell, "HAS %p preset switch index 0x%02x", has, index);
+	shell_print(shell_get_ctx(), "HAS %p preset switch index 0x%02x", has, index);
 }
 
 static void has_client_preset_read_rsp_cb(struct bt_has *has, int err,
 					  const struct bt_has_preset_record *record, bool is_last)
 {
 	if (err) {
-		shell_error(ctx_shell, "Preset Read operation failed (err %d)", err);
+		shell_error(shell_get_ctx(), "Preset Read operation failed (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Preset Index: 0x%02x\tProperties: 0x%02x\tName: %s",
+	shell_print(shell_get_ctx(), "Preset Index: 0x%02x\tProperties: 0x%02x\tName: %s",
 		    record->index, record->properties, record->name);
 
 	if (is_last) {
-		shell_print(ctx_shell, "Preset Read operation complete");
+		shell_print(shell_get_ctx(), "Preset Read operation complete");
 	}
 }
 
@@ -64,10 +64,6 @@ static const struct bt_has_client_cb has_client_cb = {
 static int cmd_has_client_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int err;
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	err = bt_has_client_cb_register(&has_client_cb);
 	if (err != 0) {
@@ -84,10 +80,6 @@ static int cmd_has_client_discover(const struct shell *sh, size_t argc, char **a
 	if (default_conn == NULL) {
 		shell_error(sh, "Not connected");
 		return -ENOEXEC;
-	}
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
 	}
 
 	err = bt_has_client_discover(default_conn);

--- a/subsys/bluetooth/shell/iso.c
+++ b/subsys/bluetooth/shell/iso.c
@@ -63,7 +63,7 @@ static uint32_t get_next_sn(uint32_t last_sn, int64_t *last_ticks,
 static void iso_recv(struct bt_iso_chan *chan, const struct bt_iso_recv_info *info,
 		struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming data channel %p len %u, seq: %d, ts: %d",
+	shell_print(shell_get_ctx(), "Incoming data channel %p len %u, seq: %d, ts: %d",
 		    chan, buf->len, info->seq_num, info->ts);
 }
 
@@ -72,7 +72,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 	struct bt_iso_info iso_info;
 	int err;
 
-	shell_print(ctx_shell, "ISO Channel %p connected", chan);
+	shell_print(shell_get_ctx(), "ISO Channel %p connected", chan);
 
 
 	err = bt_iso_chan_get_info(chan, &iso_info);
@@ -92,7 +92,7 @@ static void iso_connected(struct bt_iso_chan *chan)
 
 static void iso_disconnected(struct bt_iso_chan *chan, uint8_t reason)
 {
-	shell_print(ctx_shell, "ISO Channel %p disconnected with reason 0x%02x",
+	shell_print(shell_get_ctx(), "ISO Channel %p disconnected with reason 0x%02x",
 		    chan, reason);
 }
 
@@ -287,11 +287,12 @@ static int cmd_connect(const struct shell *sh, size_t argc, char *argv[])
 static int iso_accept(const struct bt_iso_accept_info *info,
 		      struct bt_iso_chan **chan)
 {
-	shell_print(ctx_shell, "Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X",
+	shell_print(shell_get_ctx(),
+		    "Incoming request from %p with CIG ID 0x%02X and CIS ID 0x%02X",
 		    info->acl, info->cig_id, info->cis_id);
 
 	if (iso_chan.iso) {
-		shell_print(ctx_shell, "No channels available");
+		shell_print(shell_get_ctx(), "No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/l2cap.c
+++ b/subsys/bluetooth/shell/l2cap.c
@@ -88,7 +88,7 @@ static void l2cap_recv_cb(struct k_work *work)
 	struct net_buf *buf;
 
 	while ((buf = net_buf_get(&l2cap_recv_fifo, K_NO_WAIT))) {
-		shell_print(ctx_shell, "Confirming reception");
+		shell_print(shell_get_ctx(), "Confirming reception");
 		bt_l2cap_chan_recv_complete(&c->ch.chan, buf);
 	}
 }
@@ -101,17 +101,17 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 		return l2cap_recv_metrics(chan, buf);
 	}
 
-	shell_print(ctx_shell, "Incoming data channel %p len %u", chan,
+	shell_print(shell_get_ctx(), "Incoming data channel %p len %u", chan,
 		    buf->len);
 
 	if (buf->len) {
-		shell_hexdump(ctx_shell, buf->data, buf->len);
+		shell_hexdump(shell_get_ctx(), buf->data, buf->len);
 	}
 
 	if (l2cap_recv_delay_ms > 0) {
 		/* Submit work only if queue is empty */
 		if (k_fifo_is_empty(&l2cap_recv_fifo)) {
-			shell_print(ctx_shell, "Delaying response in %u ms...",
+			shell_print(shell_get_ctx(), "Delaying response in %u ms...",
 				    l2cap_recv_delay_ms);
 		}
 
@@ -126,12 +126,12 @@ static int l2cap_recv(struct bt_l2cap_chan *chan, struct net_buf *buf)
 
 static void l2cap_sent(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Outgoing data channel %p transmitted", chan);
+	shell_print(shell_get_ctx(), "Outgoing data channel %p transmitted", chan);
 }
 
 static void l2cap_status(struct bt_l2cap_chan *chan, atomic_t *status)
 {
-	shell_print(ctx_shell, "Channel %p status %u", chan, (uint32_t)*status);
+	shell_print(shell_get_ctx(), "Channel %p status %u", chan, (uint32_t)*status);
 }
 
 static void l2cap_connected(struct bt_l2cap_chan *chan)
@@ -140,19 +140,19 @@ static void l2cap_connected(struct bt_l2cap_chan *chan)
 
 	k_work_init_delayable(&c->recv_work, l2cap_recv_cb);
 
-	shell_print(ctx_shell, "Channel %p connected", chan);
+	shell_print(shell_get_ctx(), "Channel %p connected", chan);
 }
 
 static void l2cap_disconnected(struct bt_l2cap_chan *chan)
 {
-	shell_print(ctx_shell, "Channel %p disconnected", chan);
+	shell_print(shell_get_ctx(), "Channel %p disconnected", chan);
 }
 
 static struct net_buf *l2cap_alloc_buf(struct bt_l2cap_chan *chan)
 {
 	/* print if metrics is disabled */
 	if (!metrics) {
-		shell_print(ctx_shell, "Channel %p requires buffer", chan);
+		shell_print(shell_get_ctx(), "Channel %p requires buffer", chan);
 	}
 
 	return net_buf_alloc(&data_rx_pool, K_FOREVER);
@@ -215,7 +215,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 {
 	int err;
 
-	shell_print(ctx_shell, "Incoming conn %p", conn);
+	shell_print(shell_get_ctx(), "Incoming conn %p", conn);
 
 	err = l2cap_accept_policy(conn);
 	if (err < 0) {
@@ -223,7 +223,7 @@ static int l2cap_accept(struct bt_conn *conn, struct bt_l2cap_chan **chan)
 	}
 
 	if (l2ch_chan.ch.chan.conn) {
-		shell_print(ctx_shell, "No channels available");
+		shell_print(shell_get_ctx(), "No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/mcc.c
+++ b/subsys/bluetooth/shell/mcc.c
@@ -44,21 +44,21 @@ static struct object_ids_t obj_ids;
 static void mcc_discover_mcs_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Discovery failed (%d)", err);
+		shell_error(shell_get_ctx(), "Discovery failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Discovery complete");
+	shell_print(shell_get_ctx(), "Discovery complete");
 }
 
 static void mcc_read_player_name_cb(struct bt_conn *conn, int err, const char *name)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player Name read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Player Name read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player name: %s", name);
+	shell_print(shell_get_ctx(), "Player name: %s", name);
 }
 
 #ifdef CONFIG_BT_MCC_OTS
@@ -67,12 +67,12 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Icon Object ID read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Icon Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Icon object ID: %s", str);
+	shell_print(shell_get_ctx(), "Icon object ID: %s", str);
 
 	obj_ids.icon_obj_id = id;
 }
@@ -81,93 +81,93 @@ static void mcc_read_icon_obj_id_cb(struct bt_conn *conn, int err, uint64_t id)
 static void mcc_read_icon_url_cb(struct bt_conn *conn, int err, const char *url)
 {
 	if (err) {
-		shell_error(ctx_shell, "Icon URL read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Icon URL read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Icon URL: 0x%s", url);
+	shell_print(shell_get_ctx(), "Icon URL: 0x%s", url);
 }
 
 static void mcc_read_track_title_cb(struct bt_conn *conn, int err, const char *title)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track title read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track title read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track title: %s", title);
+	shell_print(shell_get_ctx(), "Track title: %s", title);
 }
 
 static void mcc_track_changed_ntf_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track changed notification failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track changed notification failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track changed");
+	shell_print(shell_get_ctx(), "Track changed");
 }
 
 static void mcc_read_track_duration_cb(struct bt_conn *conn, int err, int32_t dur)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track duration read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track duration read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track duration: %d", dur);
+	shell_print(shell_get_ctx(), "Track duration: %d", dur);
 }
 
 static void mcc_read_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track position read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track position read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track Position: %d", pos);
+	shell_print(shell_get_ctx(), "Track Position: %d", pos);
 }
 
 static void mcc_set_track_position_cb(struct bt_conn *conn, int err, int32_t pos)
 {
 	if (err) {
-		shell_error(ctx_shell, "Track Position set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track Position set failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track Position: %d", pos);
+	shell_print(shell_get_ctx(), "Track Position: %d", pos);
 }
 
 static void mcc_read_playback_speed_cb(struct bt_conn *conn, int err,
 				       int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playback speed read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playback speed read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playback speed: %d", speed);
+	shell_print(shell_get_ctx(), "Playback speed: %d", speed);
 }
 
 static void mcc_set_playback_speed_cb(struct bt_conn *conn, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playback speed set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playback speed set failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playback speed: %d", speed);
+	shell_print(shell_get_ctx(), "Playback speed: %d", speed);
 }
 
 static void mcc_read_seeking_speed_cb(struct bt_conn *conn, int err,
 				      int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Seeking speed read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Seeking speed read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Seeking speed: %d", speed);
+	shell_print(shell_get_ctx(), "Seeking speed: %d", speed);
 }
 
 
@@ -178,13 +178,13 @@ static void mcc_read_segments_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Track Segments Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Track Segments Object ID: %s", str);
+	shell_print(shell_get_ctx(), "Track Segments Object ID: %s", str);
 
 	obj_ids.track_segments_obj_id = id;
 }
@@ -196,13 +196,13 @@ static void mcc_read_current_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Current Track Object ID read failed (%d)",
+		shell_error(shell_get_ctx(), "Current Track Object ID read failed (%d)",
 			    err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Track Object ID: %s", str);
+	shell_print(shell_get_ctx(), "Current Track Object ID: %s", str);
 
 	obj_ids.current_track_obj_id = id;
 }
@@ -214,12 +214,12 @@ static void mcc_set_current_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Current Track Object ID set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Current Track Object ID set failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Track Object ID written: %s", str);
+	shell_print(shell_get_ctx(), "Current Track Object ID written: %s", str);
 }
 
 
@@ -229,16 +229,16 @@ static void mcc_read_next_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Next Track Object ID read failed (%d)",
+		shell_error(shell_get_ctx(), "Next Track Object ID read failed (%d)",
 			    err);
 		return;
 	}
 
 	if (id == MPL_NO_TRACK_ID) {
-		shell_print(ctx_shell, "Next Track Object ID is empty");
+		shell_print(shell_get_ctx(), "Next Track Object ID is empty");
 	} else {
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Next Track Object ID: %s", str);
+		shell_print(shell_get_ctx(), "Next Track Object ID: %s", str);
 	}
 
 	obj_ids.next_track_obj_id = id;
@@ -251,12 +251,12 @@ static void mcc_set_next_track_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Next Track Object ID set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Next Track Object ID set failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Next Track Object ID written: %s", str);
+	shell_print(shell_get_ctx(), "Next Track Object ID written: %s", str);
 }
 
 
@@ -266,13 +266,13 @@ static void mcc_read_parent_group_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Parent Group Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Parent Group Object ID: %s", str);
+	shell_print(shell_get_ctx(), "Parent Group Object ID: %s", str);
 
 	obj_ids.parent_group_obj_id = id;
 }
@@ -284,13 +284,13 @@ static void mcc_read_current_group_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Current Group Object ID read failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Group Object ID: %s", str);
+	shell_print(shell_get_ctx(), "Current Group Object ID: %s", str);
 
 	obj_ids.current_group_obj_id = id;
 }
@@ -301,12 +301,12 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Current Group Object ID set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Current Group Object ID set failed (%d)", err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Current Group Object ID written: %s", str);
+	shell_print(shell_get_ctx(), "Current Group Object ID written: %s", str);
 }
 #endif /* CONFIG_BT_MCC_OTS */
 
@@ -314,68 +314,68 @@ static void mcc_set_current_group_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playing order read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playing order read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playing order: %d", order);
+	shell_print(shell_get_ctx(), "Playing order: %d", order);
 }
 
 static void mcc_set_playing_order_cb(struct bt_conn *conn, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Playing order set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playing order set failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playing order: %d", order);
+	shell_print(shell_get_ctx(), "Playing order: %d", order);
 }
 
 static void mcc_read_playing_orders_supported_cb(struct bt_conn *conn, int err,
 						 uint16_t orders)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Playing orders supported read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Playing orders supported: %d", orders);
+	shell_print(shell_get_ctx(), "Playing orders supported: %d", orders);
 }
 
 static void mcc_read_media_state_cb(struct bt_conn *conn, int err, uint8_t state)
 {
 	if (err) {
-		shell_error(ctx_shell, "Media State read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Media State read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Media State: %d", state);
+	shell_print(shell_get_ctx(), "Media State: %d", state);
 }
 
 static void mcc_send_cmd_cb(struct bt_conn *conn, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Command send failed (%d) - opcode: %d, param: %d",
 			    err, cmd->opcode, cmd->param);
 		return;
 	}
 
-	shell_print(ctx_shell, "Command opcode: %d, param: %d", cmd->opcode, cmd->param);
+	shell_print(shell_get_ctx(), "Command opcode: %d, param: %d", cmd->opcode, cmd->param);
 }
 
 static void mcc_cmd_ntf_cb(struct bt_conn *conn, int err,
 			   const struct mpl_cmd_ntf *ntf)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Command notification error (%d) - opcode: %d, result: %d",
 			    err, ntf->requested_opcode, ntf->result_code);
 		return;
 	}
 
-	shell_print(ctx_shell, "Command opcode: %d, result: %d",
+	shell_print(shell_get_ctx(), "Command opcode: %d, result: %d",
 		    ntf->requested_opcode, ntf->result_code);
 }
 
@@ -383,12 +383,12 @@ static void mcc_read_opcodes_supported_cb(struct bt_conn *conn, int err,
 					    uint32_t opcodes)
 {
 	if (err) {
-		shell_error(ctx_shell, "Opcodes supported read failed (%d)",
+		shell_error(shell_get_ctx(), "Opcodes supported read failed (%d)",
 			    err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Opcodes supported: %d", opcodes);
+	shell_print(shell_get_ctx(), "Opcodes supported: %d", opcodes);
 }
 
 #ifdef CONFIG_BT_MCC_OTS
@@ -396,24 +396,24 @@ static void mcc_send_search_cb(struct bt_conn *conn, int err,
 			       const struct mpl_search *search)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Search send failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Search sent");
+	shell_print(shell_get_ctx(), "Search sent");
 }
 
 static void mcc_search_ntf_cb(struct bt_conn *conn, int err, uint8_t result_code)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Search notification error (%d), result code: %d",
 			    err, result_code);
 		return;
 	}
 
-	shell_print(ctx_shell, "Search notification result code: %d",
+	shell_print(shell_get_ctx(), "Search notification result code: %d",
 		    result_code);
 }
 
@@ -423,16 +423,16 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Search Results Object ID read failed (%d)", err);
 		return;
 	}
 
 	if (id == 0) {
-		shell_print(ctx_shell, "Search Results Object ID: 0x000000000000");
+		shell_print(shell_get_ctx(), "Search Results Object ID: 0x000000000000");
 	} else {
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Search Results Object ID: %s", str);
+		shell_print(shell_get_ctx(), "Search Results Object ID: %s", str);
 	}
 
 	obj_ids.search_results_obj_id = id;
@@ -442,11 +442,11 @@ static void mcc_read_search_results_obj_id_cb(struct bt_conn *conn, int err,
 static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_t ccid)
 {
 	if (err) {
-		shell_error(ctx_shell, "Content Control ID read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Content Control ID read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Content Control ID: %d", ccid);
+	shell_print(shell_get_ctx(), "Content Control ID: %d", ccid);
 }
 
 #ifdef CONFIG_BT_MCC_OTS
@@ -454,36 +454,36 @@ static void mcc_read_content_control_id_cb(struct bt_conn *conn, int err, uint8_
 static void mcc_otc_obj_selected_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Error in selecting object (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Selecting object succeeded");
+	shell_print(shell_get_ctx(), "Selecting object succeeded");
 }
 
 static void mcc_otc_obj_metadata_cb(struct bt_conn *conn, int err)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Error in reading object metadata (err %d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Reading object metadata succeeded\n");
+	shell_print(shell_get_ctx(), "Reading object metadata succeeded\n");
 }
 
 static void mcc_icon_object_read_cb(struct bt_conn *conn, int err,
 				    struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Icon Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Icon content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	shell_print(shell_get_ctx(), "Icon content (%d octets)", buf->len);
+	shell_hexdump(shell_get_ctx(), buf->data, buf->len);
 }
 
 /* TODO: May want to use a parsed type, instead of the raw buf, here */
@@ -491,65 +491,65 @@ static void mcc_track_segments_object_read_cb(struct bt_conn *conn, int err,
 					      struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Track Segments Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Track Segments content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	shell_print(shell_get_ctx(), "Track Segments content (%d octets)", buf->len);
+	shell_hexdump(shell_get_ctx(), buf->data, buf->len);
 }
 
 static void mcc_otc_read_current_track_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Current Track Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Current Track content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	shell_print(shell_get_ctx(), "Current Track content (%d octets)", buf->len);
+	shell_hexdump(shell_get_ctx(), buf->data, buf->len);
 }
 
 static void mcc_otc_read_next_track_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Next Track Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Next Track content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	shell_print(shell_get_ctx(), "Next Track content (%d octets)", buf->len);
+	shell_hexdump(shell_get_ctx(), buf->data, buf->len);
 }
 
 static void mcc_otc_read_parent_group_object_cb(struct bt_conn *conn, int err,
 						struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Parent Group Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Parent Group content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	shell_print(shell_get_ctx(), "Parent Group content (%d octets)", buf->len);
+	shell_hexdump(shell_get_ctx(), buf->data, buf->len);
 }
 
 static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 						 struct net_buf_simple *buf)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Current Group Object read failed (%d)", err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Current Group content (%d octets)", buf->len);
-	shell_hexdump(ctx_shell, buf->data, buf->len);
+	shell_print(shell_get_ctx(), "Current Group content (%d octets)", buf->len);
+	shell_hexdump(shell_get_ctx(), buf->data, buf->len);
 }
 
 #endif /* CONFIG_BT_MCC_OTS */
@@ -558,10 +558,6 @@ static void mcc_otc_read_current_group_object_cb(struct bt_conn *conn, int err,
 int cmd_mcc_init(const struct shell *sh, size_t argc, char **argv)
 {
 	int result;
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	/* Set up the callbacks */
 	cb.discover_mcs                  = mcc_discover_mcs_cb;

--- a/subsys/bluetooth/shell/media_controller.c
+++ b/subsys/bluetooth/shell/media_controller.c
@@ -38,12 +38,12 @@ static struct media_player *current_player;
 static void local_player_instance_cb(struct media_player *plr, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Local player instance failed (%d)", err);
+		shell_error(shell_get_ctx(), "Local player instance failed (%d)", err);
 		return;
 	}
 
 	local_player = plr;
-	shell_print(ctx_shell, "Local player instance: %p", local_player);
+	shell_print(shell_get_ctx(), "Local player instance: %p", local_player);
 
 	if (!current_player) {
 		current_player = local_player;
@@ -54,12 +54,12 @@ static void local_player_instance_cb(struct media_player *plr, int err)
 static void discover_player_cb(struct media_player *plr, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Discover player failed (%d)", err);
+		shell_error(shell_get_ctx(), "Discover player failed (%d)", err);
 		return;
 	}
 
 	remote_player = plr;
-	shell_print(ctx_shell, "Discovered player instance: %p", remote_player);
+	shell_print(shell_get_ctx(), "Discovered player instance: %p", remote_player);
 
 	/* Assuming that since discovery was called, the remote player is wanted */
 	current_player = remote_player;
@@ -69,11 +69,11 @@ static void discover_player_cb(struct media_player *plr, int err)
 static void player_name_cb(struct media_player *plr, int err, const char *name)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Player name failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Player name failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Player name: %s", plr, name);
+	shell_print(shell_get_ctx(), "Player: %p, Player name: %s", plr, name);
 }
 
 static void icon_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -81,102 +81,110 @@ static void icon_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Icon ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Icon ID failed (%d)", plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Icon Object ID: %s", plr, str);
+	shell_print(shell_get_ctx(), "Player: %p, Icon Object ID: %s", plr, str);
 }
 
 static void icon_url_cb(struct media_player *plr, int err, const char *url)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Icon URL failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Icon URL failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Icon URL: %s", plr, url);
+	shell_print(shell_get_ctx(), "Player: %p, Icon URL: %s", plr, url);
 }
 
 static void track_changed_cb(struct media_player *plr, int err)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track change failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Track change failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track changed", plr);
+	shell_print(shell_get_ctx(), "Player: %p, Track changed", plr);
 }
 
 static void track_title_cb(struct media_player *plr, int err, const char *title)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track title failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Track title failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track title: %s", plr, title);
+	shell_print(shell_get_ctx(), "Player: %p, Track title: %s", plr, title);
 }
 
 static void track_duration_cb(struct media_player *plr, int err, int32_t duration)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track duration failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Track duration failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track duration: %d", plr, duration);
+	shell_print(shell_get_ctx(), "Player: %p, Track duration: %d", plr, duration);
 }
 
 static void track_position_recv_cb(struct media_player *plr, int err, int32_t position)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track position receive failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Track position receive failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track Position received: %d", plr, position);
+	shell_print(shell_get_ctx(), "Player: %p, Track Position received: %d", plr, position);
 }
 
 static void track_position_write_cb(struct media_player *plr, int err, int32_t position)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track position write failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Track position write failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Track Position write: %d", plr, position);
+	shell_print(shell_get_ctx(), "Player: %p, Track Position write: %d", plr, position);
 }
 
 static void playback_speed_recv_cb(struct media_player *plr, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playback speed receive failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Playback speed receive failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playback speed received: %d", plr, speed);
+	shell_print(shell_get_ctx(), "Player: %p, Playback speed received: %d", plr, speed);
 }
 
 static void playback_speed_write_cb(struct media_player *plr, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playback speed write failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Playback speed write failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playback speed write: %d", plr, speed);
+	shell_print(shell_get_ctx(), "Player: %p, Playback speed write: %d", plr, speed);
 }
 
 static void seeking_speed_cb(struct media_player *plr, int err, int8_t speed)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Seeking speed failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Seeking speed failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Seeking speed: %d", plr, speed);
+	shell_print(shell_get_ctx(), "Player: %p, Seeking speed: %d", plr, speed);
 }
 
 #ifdef CONFIG_BT_OTS
@@ -185,12 +193,12 @@ static void track_segments_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Track segments ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Track segments ID failed (%d)", plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Track Segments Object ID: %s", plr, str);
+	shell_print(shell_get_ctx(), "Player: %p, Track Segments Object ID: %s", plr, str);
 }
 
 static void current_track_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -198,12 +206,12 @@ static void current_track_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Current track ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Current track ID failed (%d)", plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Current Track Object ID: %s", plr, str);
+	shell_print(shell_get_ctx(), "Player: %p, Current Track Object ID: %s", plr, str);
 }
 
 static void next_track_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -211,15 +219,15 @@ static void next_track_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Next track ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Next track ID failed (%d)", plr, err);
 		return;
 	}
 
 	if (id == MPL_NO_TRACK_ID) {
-		shell_print(ctx_shell, "Player: %p, Next Track Object ID is empty", plr);
+		shell_print(shell_get_ctx(), "Player: %p, Next Track Object ID is empty", plr);
 	} else {
 		(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-		shell_print(ctx_shell, "Player: %p, Next Track Object ID: %s", plr, str);
+		shell_print(shell_get_ctx(), "Player: %p, Next Track Object ID: %s", plr, str);
 	}
 }
 
@@ -228,12 +236,12 @@ static void current_group_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Current group ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Current group ID failed (%d)", plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Current Group Object ID: %s", plr, str);
+	shell_print(shell_get_ctx(), "Player: %p, Current Group Object ID: %s", plr, str);
 }
 
 static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -241,87 +249,93 @@ static void parent_group_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Parent group ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Parent group ID failed (%d)", plr, err);
 		return;
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Parent Group Object ID: %s", plr, str);
+	shell_print(shell_get_ctx(), "Player: %p, Parent Group Object ID: %s", plr, str);
 }
 #endif /* CONFIG_BT_OTS */
 
 static void playing_order_recv_cb(struct media_player *plr, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playing order receive_failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Playing order receive_failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playing received: %u", plr, order);
+	shell_print(shell_get_ctx(), "Player: %p, Playing received: %u", plr, order);
 }
 
 static void playing_order_write_cb(struct media_player *plr, int err, uint8_t order)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playing order write_failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Playing order write_failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playing written: %u", plr, order);
+	shell_print(shell_get_ctx(), "Player: %p, Playing written: %u", plr, order);
 }
 
 static void playing_orders_supported_cb(struct media_player *plr, int err, uint16_t orders)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Playing orders supported failed (%d)",
+		shell_error(shell_get_ctx(), "Player: %p, Playing orders supported failed (%d)",
 			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Playing orders supported: %u", plr, orders);
+	shell_print(shell_get_ctx(), "Player: %p, Playing orders supported: %u", plr, orders);
 	/* TODO: Parse bitmap and output list of playing orders */
 }
 
 static void media_state_cb(struct media_player *plr, int err, uint8_t state)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Media state failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Media state failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Media State: %u", plr, state);
+	shell_print(shell_get_ctx(), "Player: %p, Media State: %u", plr, state);
 	/* TODO: Parse state and output state name (e.g. "Playing") */
 }
 
 static void command_send_cb(struct media_player *plr, int err, const struct mpl_cmd *cmd)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Command send failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Command send failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Command opcode sent: %u", plr, cmd->opcode);
+	shell_print(shell_get_ctx(), "Player: %p, Command opcode sent: %u", plr, cmd->opcode);
 }
 
 static void command_recv_cb(struct media_player *plr, int err, const struct mpl_cmd_ntf *cmd_ntf)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Command failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Command failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Command opcode: %u, result: %u",
+	shell_print(shell_get_ctx(), "Player: %p, Command opcode: %u, result: %u",
 		    plr, cmd_ntf->requested_opcode, cmd_ntf->result_code);
 }
 
 static void commands_supported_cb(struct media_player *plr, int err, uint32_t opcodes)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Commands supported failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Commands supported failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Command opcodes supported: %u", plr, opcodes);
+	shell_print(shell_get_ctx(), "Player: %p, Command opcodes supported: %u", plr, opcodes);
 	/* TODO: Parse bitmap and output list of opcodes */
 }
 
@@ -329,21 +343,21 @@ static void commands_supported_cb(struct media_player *plr, int err, uint32_t op
 static void search_send_cb(struct media_player *plr, int err, const struct mpl_search *search)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Search send failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Search send failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Search sent with len %u", plr, search->len);
+	shell_print(shell_get_ctx(), "Player: %p, Search sent with len %u", plr, search->len);
 }
 
 static void search_recv_cb(struct media_player *plr, int err, uint8_t result_code)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Search failed (%d)", plr, err);
+		shell_error(shell_get_ctx(), "Player: %p, Search failed (%d)", plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Search result code: %u", plr, result_code);
+	shell_print(shell_get_ctx(), "Player: %p, Search result code: %u", plr, result_code);
 }
 
 static void search_results_id_cb(struct media_player *plr, int err, uint64_t id)
@@ -351,40 +365,44 @@ static void search_results_id_cb(struct media_player *plr, int err, uint64_t id)
 	char str[BT_OTS_OBJ_ID_STR_LEN];
 
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Search results ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Search results ID failed (%d)",
+			    plr, err);
 		return;
 	}
 
 	if (id == 0) {
-		shell_print(ctx_shell, "Player: %p, Search result not avilable", plr);
+		shell_print(shell_get_ctx(), "Player: %p, Search result not avilable", plr);
 	}
 
 	(void)bt_ots_obj_id_to_str(id, str, sizeof(str));
-	shell_print(ctx_shell, "Player: %p, Search Results Object ID: %s", plr, str);
+	shell_print(shell_get_ctx(), "Player: %p, Search Results Object ID: %s", plr, str);
 }
 #endif /* CONFIG_BT_OTS */
 
 static void content_ctrl_id_cb(struct media_player *plr, int err, uint8_t ccid)
 {
 	if (err) {
-		shell_error(ctx_shell, "Player: %p, Content control ID failed (%d)", plr, err);
+		shell_error(shell_get_ctx(),
+			    "Player: %p, Content control ID failed (%d)",
+			    plr, err);
 		return;
 	}
 
-	shell_print(ctx_shell, "Player: %p, Content Control ID: %u", plr, ccid);
+	shell_print(shell_get_ctx(), "Player: %p, Content Control ID: %u", plr, ccid);
 }
 
 int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 {
 	int err;
 
-	if (!ctx_shell) {
-		ctx_shell = sh;
+	if (!shell_get_ctx()) {
+		shell_get_ctx() = sh;
 	}
 
 	err = media_proxy_pl_init();  /* TODO: Fix direct call to player */
 	if (err) {
-		shell_error(ctx_shell, "Could not init mpl");
+		shell_error(shell_get_ctx(), "Could not init mpl");
 	}
 
 	/* Set up the callback structure */
@@ -426,7 +444,7 @@ int cmd_media_init(const struct shell *sh, size_t argc, char *argv[])
 
 	err = media_proxy_ctrl_register(&cbs);
 	if (err) {
-		shell_error(ctx_shell, "Could not register media shell as controller");
+		shell_error(shell_get_ctx(), "Could not register media shell as controller");
 	}
 
 	return err;
@@ -437,46 +455,47 @@ static int cmd_media_set_player(const struct shell *sh, size_t argc, char *argv[
 	if (!strcmp(argv[1], "local")) {
 		if (local_player) {
 			current_player = local_player;
-			shell_print(ctx_shell, "Current player set to local player: %p",
+			shell_print(shell_get_ctx(), "Current player set to local player: %p",
 				    current_player);
 			return 0;
 		}
 
-		shell_print(ctx_shell, "No local player");
+		shell_print(shell_get_ctx(), "No local player");
 		return -EOPNOTSUPP;
 
 	} else if (!strcmp(argv[1], "remote")) {
 		if (remote_player) {
 			current_player = remote_player;
-			shell_print(ctx_shell, "Current player set to remote player: %p",
+			shell_print(shell_get_ctx(), "Current player set to remote player: %p",
 				    current_player);
 			return 0;
 		}
 
-		shell_print(ctx_shell, "No remote player");
+		shell_print(shell_get_ctx(), "No remote player");
 		return -EOPNOTSUPP;
 
 	} else {
-		shell_error(ctx_shell, "Input argument must be either \"local\" or \"remote\"");
+		shell_error(shell_get_ctx(),
+			    "Input argument must be either \"local\" or \"remote\"");
 		return -EINVAL;
 	}
 }
 
 static int cmd_media_show_players(const struct shell *sh, size_t argc, char *argv[])
 {
-	shell_print(ctx_shell, "Local player: %p", local_player);
-	shell_print(ctx_shell, "Remote player: %p", remote_player);
+	shell_print(shell_get_ctx(), "Local player: %p", local_player);
+	shell_print(shell_get_ctx(), "Remote player: %p", remote_player);
 
 	if (current_player == NULL) {
-		shell_print(ctx_shell, "Current player is not set");
+		shell_print(shell_get_ctx(), "Current player is not set");
 	} else if (current_player == local_player) {
-		shell_print(ctx_shell, "Current player is set to local player: %p",
+		shell_print(shell_get_ctx(), "Current player is set to local player: %p",
 			    current_player);
 	} else if (current_player == remote_player) {
-		shell_print(ctx_shell, "Current player is set to remote player: %p",
+		shell_print(shell_get_ctx(), "Current player is set to remote player: %p",
 			    current_player);
 	} else {
-		shell_print(ctx_shell, "Current player is not set to valid player");
+		shell_print(shell_get_ctx(), "Current player is not set to valid player");
 	}
 
 	return 0;
@@ -488,7 +507,7 @@ static int cmd_media_discover_player(const struct shell *sh, size_t argc, char *
 	int err = media_proxy_ctrl_discover_player(default_conn);
 
 	if (err) {
-		shell_error(ctx_shell, "Discover player failed (%d)", err);
+		shell_error(shell_get_ctx(), "Discover player failed (%d)", err);
 	}
 
 	return err;
@@ -500,7 +519,7 @@ static int cmd_media_read_player_name(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_player_name(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Player name get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Player name get failed (%d)", err);
 	}
 
 	return err;
@@ -512,7 +531,7 @@ static int cmd_media_read_icon_obj_id(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_icon_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Icon ID get failed (%d)", err);
 	}
 
 	return err;
@@ -524,7 +543,7 @@ static int cmd_media_read_icon_url(const struct shell *sh, size_t argc, char *ar
 	int err = media_proxy_ctrl_get_icon_url(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Icon URL get failed (%d)", err);
 	}
 
 	return err;
@@ -535,7 +554,7 @@ static int cmd_media_read_track_title(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_track_title(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track title get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track title get failed (%d)", err);
 	}
 
 	return err;
@@ -546,7 +565,7 @@ static int cmd_media_read_track_duration(const struct shell *sh, size_t argc, ch
 	int err = media_proxy_ctrl_get_track_duration(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track duration get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track duration get failed (%d)", err);
 	}
 
 	return err;
@@ -557,7 +576,7 @@ static int cmd_media_read_track_position(const struct shell *sh, size_t argc, ch
 	int err = media_proxy_ctrl_get_track_position(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track position get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track position get failed (%d)", err);
 	}
 
 	return err;
@@ -572,7 +591,7 @@ static int cmd_media_set_track_position(const struct shell *sh, size_t argc,
 	int err = media_proxy_ctrl_set_track_position(current_player, position);
 
 	if (err) {
-		shell_error(ctx_shell, "Track position set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track position set failed (%d)", err);
 	}
 
 	return err;
@@ -583,7 +602,7 @@ static int cmd_media_read_playback_speed(const struct shell *sh, size_t argc, ch
 	int err = media_proxy_ctrl_get_playback_speed(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Playback speed get get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playback speed get get failed (%d)", err);
 	}
 
 	return err;
@@ -596,7 +615,7 @@ static int cmd_media_set_playback_speed(const struct shell *sh, size_t argc, cha
 	int err = media_proxy_ctrl_set_playback_speed(current_player, speed);
 
 	if (err) {
-		shell_error(ctx_shell, "Playback speed set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playback speed set failed (%d)", err);
 	}
 
 	return err;
@@ -607,7 +626,7 @@ static int cmd_media_read_seeking_speed(const struct shell *sh, size_t argc, cha
 	int err = media_proxy_ctrl_get_seeking_speed(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Seeking speed get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Seeking speed get failed (%d)", err);
 	}
 
 	return err;
@@ -619,7 +638,7 @@ static int cmd_media_read_track_segments_obj_id(const struct shell *sh, size_t a
 	int err = media_proxy_ctrl_get_track_segments_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Track segments ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Track segments ID get failed (%d)", err);
 	}
 
 	return err;
@@ -630,7 +649,7 @@ static int cmd_media_read_current_track_obj_id(const struct shell *sh, size_t ar
 	int err = media_proxy_ctrl_get_current_track_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Current track ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Current track ID get failed (%d)", err);
 	}
 
 	return err;
@@ -643,7 +662,7 @@ static int cmd_media_read_next_track_obj_id(const struct shell *sh, size_t argc,
 	int err = media_proxy_ctrl_get_next_track_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Nect track ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Nect track ID get failed (%d)", err);
 	}
 
 	return err;
@@ -654,7 +673,7 @@ static int cmd_media_read_current_group_obj_id(const struct shell *sh, size_t ar
 	int err = media_proxy_ctrl_get_current_group_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Current group ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Current group ID get failed (%d)", err);
 
 	}
 
@@ -666,7 +685,7 @@ static int cmd_media_read_parent_group_obj_id(const struct shell *sh, size_t arg
 	int err = media_proxy_ctrl_get_parent_group_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Parent group ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Parent group ID get failed (%d)", err);
 	}
 
 	return err;
@@ -678,7 +697,7 @@ static int cmd_media_read_playing_order(const struct shell *sh, size_t argc, cha
 	int err = media_proxy_ctrl_get_playing_order(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Playing order get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playing order get failed (%d)", err);
 	}
 
 	return err;
@@ -691,7 +710,7 @@ static int cmd_media_set_playing_order(const struct shell *sh, size_t argc, char
 	int err = media_proxy_ctrl_set_playing_order(current_player, order);
 
 	if (err) {
-		shell_error(ctx_shell, "Playing order set failed (%d)", err);
+		shell_error(shell_get_ctx(), "Playing order set failed (%d)", err);
 	}
 
 	return err;
@@ -703,7 +722,7 @@ static int cmd_media_read_playing_orders_supported(const struct shell *sh, size_
 	int err = media_proxy_ctrl_get_playing_orders_supported(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Icon URL get failed (%d)", err);
 	}
 
 	return err;
@@ -714,7 +733,7 @@ static int cmd_media_read_media_state(const struct shell *sh, size_t argc, char 
 	int err = media_proxy_ctrl_get_media_state(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Icon URL get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Icon URL get failed (%d)", err);
 	}
 
 	return err;
@@ -738,7 +757,7 @@ static int cmd_media_send_command(const struct shell *sh, size_t argc, char *arg
 	err = media_proxy_ctrl_send_command(current_player, &cmd);
 
 	if (err) {
-		shell_error(ctx_shell, "Command send failed (%d)", err);
+		shell_error(shell_get_ctx(), "Command send failed (%d)", err);
 	}
 
 	return err;
@@ -749,7 +768,7 @@ static int cmd_media_read_commands_supported(const struct shell *sh, size_t argc
 	int err = media_proxy_ctrl_get_commands_supported(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Commands supported read failed (%d)", err);
+		shell_error(shell_get_ctx(), "Commands supported read failed (%d)", err);
 	}
 
 	return err;
@@ -771,7 +790,7 @@ int cmd_media_set_search(const struct shell *sh, size_t argc, char *argv[])
 
 	err = media_proxy_ctrl_send_search(current_player, &search);
 	if (err) {
-		shell_error(ctx_shell, "Search send failed (%d)", err);
+		shell_error(shell_get_ctx(), "Search send failed (%d)", err);
 	}
 
 	return err;
@@ -783,7 +802,7 @@ static int cmd_media_read_search_results_obj_id(const struct shell *sh, size_t a
 	int err = media_proxy_ctrl_get_search_results_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Search results ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Search results ID get failed (%d)", err);
 	}
 
 	return err;
@@ -796,7 +815,7 @@ static int cmd_media_read_content_control_id(const struct shell *sh, size_t argc
 	int err = media_proxy_ctrl_get_content_ctrl_id(current_player);
 
 	if (err) {
-		shell_error(ctx_shell, "Content control ID get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Content control ID get failed (%d)", err);
 	}
 
 	return err;
@@ -804,7 +823,7 @@ static int cmd_media_read_content_control_id(const struct shell *sh, size_t argc
 
 static int cmd_media(const struct shell *sh, size_t argc, char **argv)
 {
-	shell_error(ctx_shell, "%s unknown parameter: %s", argv[0], argv[1]);
+	shell_error(shell_get_ctx(), "%s unknown parameter: %s", argv[0], argv[1]);
 
 	return -ENOEXEC;
 }

--- a/subsys/bluetooth/shell/micp_mic_ctlr.c
+++ b/subsys/bluetooth/shell/micp_mic_ctlr.c
@@ -25,15 +25,15 @@ static void micp_mic_ctlr_discover_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 				      int err, uint8_t aics_count)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Discovery failed (%d)", err);
+		shell_error(shell_get_ctx(), "Discovery failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Discovery done with %u AICS",
+		shell_print(shell_get_ctx(), "Discovery done with %u AICS",
 			    aics_count);
 
 #if defined(CONFIG_BT_MICP_MIC_CTLR_AICS)
 		if (bt_micp_mic_ctlr_included_get(mic_ctlr,
 						  &micp_included) != 0) {
-			shell_error(ctx_shell, "Could not get included services");
+			shell_error(shell_get_ctx(), "Could not get included services");
 		}
 #endif /* CONFIG_BT_MICP_MIC_CTLR_AICS */
 	}
@@ -43,9 +43,9 @@ static void micp_mic_ctlr_mute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					  int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute write failed (%d)", err);
+		shell_error(shell_get_ctx(), "Mute write failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Mute write completed");
+		shell_print(shell_get_ctx(), "Mute write completed");
 	}
 }
 
@@ -53,9 +53,9 @@ static void micp_mic_ctlr_unmute_written_cb(struct bt_micp_mic_ctlr *mic_ctlr,
 					    int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Unmute write failed (%d)", err);
+		shell_error(shell_get_ctx(), "Unmute write failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Unmute write completed");
+		shell_print(shell_get_ctx(), "Unmute write completed");
 	}
 }
 
@@ -63,9 +63,9 @@ static void micp_mic_ctlr_mute_cb(struct bt_micp_mic_ctlr *mic_ctlr, int err,
 				  uint8_t mute)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute get failed (%d)", err);
+		shell_error(shell_get_ctx(), "Mute get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "Mute value %u", mute);
+		shell_print(shell_get_ctx(), "Mute value %u", mute);
 	}
 }
 
@@ -75,52 +75,52 @@ static struct bt_micp_included micp_included;
 static void micp_mic_ctlr_aics_set_gain_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Set gain failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "Set gain failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Gain set for inst %p", inst);
+		shell_print(shell_get_ctx(), "Gain set for inst %p", inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_unmute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Unmute failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "Unmute failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Unmuted inst %p", inst);
+		shell_print(shell_get_ctx(), "Unmuted inst %p", inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_mute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "Mute failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Muted inst %p", inst);
+		shell_print(shell_get_ctx(), "Muted inst %p", inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Set manual mode failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Manuel mode set for inst %p", inst);
+		shell_print(shell_get_ctx(), "Manuel mode set for inst %p", inst);
 	}
 }
 
 static void micp_mic_ctlr_aics_automatic_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Set automatic mode failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Automatic mode set for inst %p",
+		shell_print(shell_get_ctx(), "Automatic mode set for inst %p",
 			    inst);
 	}
 }
@@ -129,10 +129,10 @@ static void micp_mic_ctlr_aics_state_cb(struct bt_aics *inst, int err,
 					int8_t gain, uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS state get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS state get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p state gain %d, mute %u, "
+		shell_print(shell_get_ctx(), "AICS inst %p state gain %d, mute %u, "
 			    "mode %u", inst, gain, mute, mode);
 	}
 
@@ -143,10 +143,10 @@ static void micp_mic_ctlr_aics_gain_setting_cb(struct bt_aics *inst, int err,
 					       int8_t maximum)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS gain settings get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS gain settings get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p gain settings units %u, "
+		shell_print(shell_get_ctx(), "AICS inst %p gain settings units %u, "
 			    "min %d, max %d", inst, units, minimum,
 			    maximum);
 	}
@@ -157,10 +157,10 @@ static void micp_mic_ctlr_aics_input_type_cb(struct bt_aics *inst, int err,
 					     uint8_t input_type)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS input type get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS input type get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
+		shell_print(shell_get_ctx(), "AICS inst %p input type %u",
 			    inst, input_type);
 	}
 
@@ -170,10 +170,10 @@ static void micp_mic_ctlr_aics_status_cb(struct bt_aics *inst, int err,
 					 bool active)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS status get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS status get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
+		shell_print(shell_get_ctx(), "AICS inst %p status %s",
 			    inst, active ? "active" : "inactive");
 	}
 
@@ -183,10 +183,10 @@ static void micp_mic_ctlr_aics_description_cb(struct bt_aics *inst, int err,
 					      char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS description get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS description get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
+		shell_print(shell_get_ctx(), "AICS inst %p description %s",
 			    inst, description);
 	}
 }
@@ -219,10 +219,6 @@ static int cmd_micp_mic_ctlr_discover(const struct shell *sh, size_t argc,
 				    char **argv)
 {
 	int result;
-
-	if (ctx_shell == NULL) {
-		ctx_shell = sh;
-	}
 
 	result = bt_micp_mic_ctlr_cb_register(&micp_cbs);
 	if (result != 0) {

--- a/subsys/bluetooth/shell/micp_mic_dev.c
+++ b/subsys/bluetooth/shell/micp_mic_dev.c
@@ -18,7 +18,7 @@
 
 static void micp_mic_dev_mute_cb(uint8_t mute)
 {
-	shell_print(ctx_shell, "Mute value %u", mute);
+	shell_print(shell_get_ctx(), "Mute value %u", mute);
 }
 
 static struct bt_micp_mic_dev_cb micp_mic_dev_cbs = {
@@ -32,10 +32,10 @@ static void micp_mic_dev_aics_state_cb(struct bt_aics *inst, int err,
 				       int8_t gain, uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS state get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS state get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p state gain %d, mute %u, "
+		shell_print(shell_get_ctx(), "AICS inst %p state gain %d, mute %u, "
 			    "mode %u", inst, gain, mute, mode);
 	}
 
@@ -45,10 +45,10 @@ static void micp_mic_dev_aics_gain_setting_cb(struct bt_aics *inst, int err,
 					      int8_t maximum)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS gain settings get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS gain settings get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p gain settings units %u, "
+		shell_print(shell_get_ctx(), "AICS inst %p gain settings units %u, "
 			    "min %d, max %d", inst, units, minimum,
 			    maximum);
 	}
@@ -58,10 +58,10 @@ static void micp_mic_dev_aics_input_type_cb(struct bt_aics *inst, int err,
 					    uint8_t input_type)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS input type get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS input type get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
+		shell_print(shell_get_ctx(), "AICS inst %p input type %u",
 			    inst, input_type);
 	}
 
@@ -70,10 +70,10 @@ static void micp_mic_dev_aics_status_cb(struct bt_aics *inst, int err,
 					bool active)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS status get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS status get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
+		shell_print(shell_get_ctx(), "AICS inst %p status %s",
 			    inst, active ? "active" : "inactive");
 	}
 
@@ -82,10 +82,10 @@ static void micp_mic_dev_aics_description_cb(struct bt_aics *inst, int err,
 					     char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS description get failed (%d) for "
+		shell_error(shell_get_ctx(), "AICS description get failed (%d) for "
 			    "inst %p", err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
+		shell_print(shell_get_ctx(), "AICS inst %p description %s",
 			    inst, description);
 	}
 }
@@ -104,10 +104,6 @@ static int cmd_micp_mic_dev_param(const struct shell *sh, size_t argc,
 {
 	int result;
 	struct bt_micp_mic_dev_register_param micp_param;
-
-	if (ctx_shell == NULL) {
-		ctx_shell = sh;
-	}
 
 	(void)memset(&micp_param, 0, sizeof(micp_param));
 

--- a/subsys/bluetooth/shell/mpl.c
+++ b/subsys/bluetooth/shell/mpl.c
@@ -59,10 +59,6 @@ int cmd_mpl_debug_dump_state(const struct shell *sh, size_t argc,
 
 int cmd_media_proxy_pl_init(const struct shell *sh, size_t argc, char *argv[])
 {
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
-
 	int err = media_proxy_pl_init();
 
 	if (err) {

--- a/subsys/bluetooth/shell/rfcomm.c
+++ b/subsys/bluetooth/shell/rfcomm.c
@@ -101,17 +101,17 @@ static struct bt_sdp_record spp_rec = BT_SDP_RECORD(spp_attrs);
 
 static void rfcomm_recv(struct bt_rfcomm_dlc *dlci, struct net_buf *buf)
 {
-	shell_print(ctx_shell, "Incoming data dlc %p len %u", dlci, buf->len);
+	shell_print(shell_get_ctx(), "Incoming data dlc %p len %u", dlci, buf->len);
 }
 
 static void rfcomm_connected(struct bt_rfcomm_dlc *dlci)
 {
-	shell_print(ctx_shell, "Dlc %p connected", dlci);
+	shell_print(shell_get_ctx(), "Dlc %p connected", dlci);
 }
 
 static void rfcomm_disconnected(struct bt_rfcomm_dlc *dlci)
 {
-	shell_print(ctx_shell, "Dlc %p disconnected", dlci);
+	shell_print(shell_get_ctx(), "Dlc %p disconnected", dlci);
 }
 
 static struct bt_rfcomm_dlc_ops rfcomm_ops = {
@@ -127,10 +127,10 @@ static struct bt_rfcomm_dlc rfcomm_dlc = {
 
 static int rfcomm_accept(struct bt_conn *conn, struct bt_rfcomm_dlc **dlc)
 {
-	shell_print(ctx_shell, "Incoming RFCOMM conn %p", conn);
+	shell_print(shell_get_ctx(), "Incoming RFCOMM conn %p", conn);
 
 	if (rfcomm_dlc.session) {
-		shell_error(ctx_shell, "No channels available");
+		shell_error(shell_get_ctx(), "No channels available");
 		return -ENOMEM;
 	}
 

--- a/subsys/bluetooth/shell/vcs.c
+++ b/subsys/bluetooth/shell/vcs.c
@@ -23,18 +23,18 @@ static void vcs_state_cb(struct bt_vcs *vcs, int err, uint8_t volume,
 			 uint8_t mute)
 {
 	if (err) {
-		shell_error(ctx_shell, "VCS state get failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS state get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS volume %u, mute %u", volume, mute);
+		shell_print(shell_get_ctx(), "VCS volume %u, mute %u", volume, mute);
 	}
 }
 
 static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 {
 	if (err) {
-		shell_error(ctx_shell, "VCS flags get failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS flags get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS flags 0x%02X", flags);
+		shell_print(shell_get_ctx(), "VCS flags 0x%02X", flags);
 	}
 }
 
@@ -42,11 +42,11 @@ static void aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			  uint8_t mute, uint8_t mode)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS state get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell,
+		shell_print(shell_get_ctx(),
 			    "AICS inst %p state gain %d, mute %u, mode %u",
 			    inst, gain, mute, mode);
 	}
@@ -56,11 +56,11 @@ static void aics_gain_setting_cb(struct bt_aics *inst, int err, uint8_t units,
 				 int8_t minimum, int8_t maximum)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS gain settings get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell,
+		shell_print(shell_get_ctx(),
 			    "AICS inst %p gain settings units %u, min %d, max %d",
 			    inst, units, minimum, maximum);
 	}
@@ -70,11 +70,11 @@ static void aics_input_type_cb(struct bt_aics *inst, int err,
 			       uint8_t input_type)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS input type get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
+		shell_print(shell_get_ctx(), "AICS inst %p input type %u",
 			    inst, input_type);
 	}
 }
@@ -82,11 +82,11 @@ static void aics_input_type_cb(struct bt_aics *inst, int err,
 static void aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS status get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
+		shell_print(shell_get_ctx(), "AICS inst %p status %s",
 			    inst, active ? "active" : "inactive");
 	}
 
@@ -95,32 +95,32 @@ static void aics_description_cb(struct bt_aics *inst, int err,
 				char *description)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS description get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
+		shell_print(shell_get_ctx(), "AICS inst %p description %s",
 			    inst, description);
 	}
 }
 static void vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err) {
-		shell_error(ctx_shell, "VOCS state get failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "VOCS state get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p offset %d", inst, offset);
+		shell_print(shell_get_ctx(), "VOCS inst %p offset %d", inst, offset);
 	}
 }
 
 static void vocs_location_cb(struct bt_vocs *inst, int err, uint32_t location)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "VOCS location get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p location %u",
+		shell_print(shell_get_ctx(), "VOCS inst %p location %u",
 			    inst, location);
 	}
 }
@@ -129,11 +129,11 @@ static void vocs_description_cb(struct bt_vocs *inst, int err,
 				char *description)
 {
 	if (err) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "VOCS description get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p description %s",
+		shell_print(shell_get_ctx(), "VOCS inst %p description %s",
 			    inst, description);
 	}
 }
@@ -163,10 +163,6 @@ static int cmd_vcs_init(const struct shell *sh, size_t argc, char **argv)
 	struct bt_vcs_register_param vcs_param;
 	char input_desc[CONFIG_BT_VCS_AICS_INSTANCE_COUNT][16];
 	char output_desc[CONFIG_BT_VCS_VOCS_INSTANCE_COUNT][16];
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	memset(&vcs_param, 0, sizeof(vcs_param));
 

--- a/subsys/bluetooth/shell/vcs_client.c
+++ b/subsys/bluetooth/shell/vcs_client.c
@@ -22,13 +22,13 @@ static void vcs_discover_cb(struct bt_vcs *vcs, int err, uint8_t vocs_count,
 			    uint8_t aics_count)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS discover failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS discover failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS discover done with %u AICS",
+		shell_print(shell_get_ctx(), "VCS discover done with %u AICS",
 			    aics_count);
 
 		if (bt_vcs_included_get(vcs, &vcs_included)) {
-			shell_error(ctx_shell, "Could not get VCS context");
+			shell_error(shell_get_ctx(), "Could not get VCS context");
 		}
 	}
 }
@@ -36,63 +36,63 @@ static void vcs_discover_cb(struct bt_vcs *vcs, int err, uint8_t vocs_count,
 static void vcs_vol_down_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS vol_down failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS vol_down failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS vol_down done");
+		shell_print(shell_get_ctx(), "VCS vol_down done");
 	}
 }
 
 static void vcs_vol_up_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS vol_up failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS vol_up failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS vol_up done");
+		shell_print(shell_get_ctx(), "VCS vol_up done");
 	}
 }
 
 static void vcs_mute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS mute failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS mute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS mute done");
+		shell_print(shell_get_ctx(), "VCS mute done");
 	}
 }
 
 static void vcs_unmute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS unmute failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS unmute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS unmute done");
+		shell_print(shell_get_ctx(), "VCS unmute done");
 	}
 }
 
 static void vcs_vol_down_unmute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS vol_down_unmute failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS vol_down_unmute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS vol_down_unmute done");
+		shell_print(shell_get_ctx(), "VCS vol_down_unmute done");
 	}
 }
 
 static void vcs_vol_up_unmute_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS vol_up_unmute failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS vol_up_unmute failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS vol_up_unmute done");
+		shell_print(shell_get_ctx(), "VCS vol_up_unmute done");
 	}
 }
 
 static void vcs_vol_set_cb(struct bt_vcs *vcs, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS vol_set failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS vol_set failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS vol_set done");
+		shell_print(shell_get_ctx(), "VCS vol_set done");
 	}
 }
 
@@ -100,18 +100,18 @@ static void vcs_state_cb(struct bt_vcs *vcs, int err, uint8_t volume,
 			 uint8_t mute)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS state get failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS state get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS volume %u, mute %u", volume, mute);
+		shell_print(shell_get_ctx(), "VCS volume %u, mute %u", volume, mute);
 	}
 }
 
 static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VCS flags get failed (%d)", err);
+		shell_error(shell_get_ctx(), "VCS flags get failed (%d)", err);
 	} else {
-		shell_print(ctx_shell, "VCS flags 0x%02X", flags);
+		shell_print(shell_get_ctx(), "VCS flags 0x%02X", flags);
 	}
 }
 
@@ -119,52 +119,52 @@ static void vcs_flags_cb(struct bt_vcs *vcs, int err, uint8_t flags)
 static void vcs_aics_set_gain_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Set gain failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "Set gain failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Gain set for inst %p", inst);
+		shell_print(shell_get_ctx(), "Gain set for inst %p", inst);
 	}
 }
 
 static void vcs_aics_unmute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Unmute failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "Unmute failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Unmuted inst %p", inst);
+		shell_print(shell_get_ctx(), "Unmuted inst %p", inst);
 	}
 }
 
 static void vcs_aics_mute_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Mute failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "Mute failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Muted inst %p", inst);
+		shell_print(shell_get_ctx(), "Muted inst %p", inst);
 	}
 }
 
 static void vcs_aics_set_manual_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Set manual mode failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Manuel mode set for inst %p", inst);
+		shell_print(shell_get_ctx(), "Manuel mode set for inst %p", inst);
 	}
 }
 
 static void vcs_aics_automatic_mode_cb(struct bt_aics *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "Set automatic mode failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Automatic mode set for inst %p",
+		shell_print(shell_get_ctx(), "Automatic mode set for inst %p",
 			    inst);
 	}
 }
@@ -173,10 +173,10 @@ static void vcs_aics_state_cb(struct bt_aics *inst, int err, int8_t gain,
 			      uint8_t mute, uint8_t mode)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "AICS state get failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "AICS state get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell,
+		shell_print(shell_get_ctx(),
 			    "AICS inst %p state gain %d, mute %u, mode %u",
 			    inst, gain, mute, mode);
 	}
@@ -187,11 +187,11 @@ static void vcs_aics_gain_setting_cb(struct bt_aics *inst, int err,
 				     int8_t maximum)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS gain settings get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell,
+		shell_print(shell_get_ctx(),
 			    "AICS inst %p gain settings units %u, min %d, max %d",
 			    inst, units, minimum, maximum);
 	}
@@ -201,11 +201,11 @@ static void vcs_aics_input_type_cb(struct bt_aics *inst, int err,
 				   uint8_t input_type)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS input type get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p input type %u",
+		shell_print(shell_get_ctx(), "AICS inst %p input type %u",
 			    inst, input_type);
 	}
 }
@@ -213,11 +213,11 @@ static void vcs_aics_input_type_cb(struct bt_aics *inst, int err,
 static void vcs_aics_status_cb(struct bt_aics *inst, int err, bool active)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS status get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p status %s",
+		shell_print(shell_get_ctx(), "AICS inst %p status %s",
 			    inst, active ? "active" : "inactive");
 	}
 
@@ -226,11 +226,11 @@ static void vcs_aics_description_cb(struct bt_aics *inst, int err,
 				    char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "AICS description get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "AICS inst %p description %s",
+		shell_print(shell_get_ctx(), "AICS inst %p description %s",
 			    inst, description);
 	}
 }
@@ -240,20 +240,20 @@ static void vcs_aics_description_cb(struct bt_aics *inst, int err,
 static void vcs_vocs_set_offset_cb(struct bt_vocs *inst, int err)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "Set offset failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "Set offset failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "Offset set for inst %p", inst);
+		shell_print(shell_get_ctx(), "Offset set for inst %p", inst);
 	}
 }
 
 static void vcs_vocs_state_cb(struct bt_vocs *inst, int err, int16_t offset)
 {
 	if (err != 0) {
-		shell_error(ctx_shell, "VOCS state get failed (%d) for inst %p",
+		shell_error(shell_get_ctx(), "VOCS state get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p offset %d", inst, offset);
+		shell_print(shell_get_ctx(), "VOCS inst %p offset %d", inst, offset);
 	}
 }
 
@@ -261,11 +261,11 @@ static void vcs_vocs_location_cb(struct bt_vocs *inst, int err,
 				 uint32_t location)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "VOCS location get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p location %u",
+		shell_print(shell_get_ctx(), "VOCS inst %p location %u",
 			    inst, location);
 	}
 }
@@ -274,11 +274,11 @@ static void vcs_vocs_description_cb(struct bt_vocs *inst, int err,
 				    char *description)
 {
 	if (err != 0) {
-		shell_error(ctx_shell,
+		shell_error(shell_get_ctx(),
 			    "VOCS description get failed (%d) for inst %p",
 			    err, inst);
 	} else {
-		shell_print(ctx_shell, "VOCS inst %p description %s",
+		shell_print(shell_get_ctx(), "VOCS inst %p description %s",
 			    inst, description);
 	}
 }
@@ -326,10 +326,6 @@ static int cmd_vcs_client_discover(const struct shell *sh, size_t argc,
 				   char **argv)
 {
 	int result;
-
-	if (!ctx_shell) {
-		ctx_shell = sh;
-	}
 
 	result = bt_vcs_client_cb_register(&vcs_cbs);
 	if (result != 0) {

--- a/subsys/shell/shell.c
+++ b/subsys/shell/shell.c
@@ -41,6 +41,8 @@ BUILD_ASSERT(SHELL_THREAD_PRIORITY >=
 		&& SHELL_THREAD_PRIORITY <= K_LOWEST_APPLICATION_THREAD_PRIO,
 		  "Invalid range for thread priority");
 
+static const struct shell *shell_ctx;
+
 static inline void receive_state_change(const struct shell *shell,
 					enum shell_receive_state state)
 {
@@ -1345,6 +1347,11 @@ void shell_thread(void *shell_handle, void *arg_log_backend,
 	}
 }
 
+const struct shell *shell_get_ctx(void)
+{
+	return shell_ctx;
+}
+
 int shell_init(const struct shell *shell, const void *transport_config,
 	       struct shell_backend_config_flags cfg_flags,
 	       bool log_backend, uint32_t init_log_level)
@@ -1370,6 +1377,8 @@ int shell_init(const struct shell *shell, const void *transport_config,
 
 	shell->ctx->tid = tid;
 	k_thread_name_set(tid, shell->thread_name);
+
+	shell_ctx = shell;
 
 	return 0;
 }


### PR DESCRIPTION
Use a getter for the shell context, which is initialized by the shell
backend.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>