### PR TITLE
Bluetooth: conn: Extend bt_conn_info with security information

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -74,6 +74,9 @@ Bluetooth
 
 * Host
 
+  * :c:func:`bt_conn_get_security` and `bt_conn_enc_key_size` now take
+    a ``const struct bt_conn*`` argument.
+
 * Mesh
 
 * Controller

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -341,6 +341,24 @@ typedef enum __packed {
 	BT_SECURITY_FORCE_PAIR = BIT(7),
 } bt_security_t;
 
+/** Security Info Flags. */
+enum bt_security_flag {
+	/** Paired with Secure Connections. */
+	BT_SECURITY_FLAG_SC = BIT(0),
+	/** Paired with Out of Band method. */
+	BT_SECURITY_FLAG_OOB = BIT(1),
+};
+
+/** Security Info Structure. */
+struct bt_security_info {
+	/** Security Level. */
+	bt_security_t level;
+	/** Encryption Key Size. */
+	uint8_t enc_key_size;
+	/** Flags. */
+	enum bt_security_flag flags;
+};
+
 /** Connection role (central or peripheral) */
 #define BT_CONN_ROLE_MASTER __DEPRECATED_MACRO BT_CONN_ROLE_CENTRAL
 #define BT_CONN_ROLE_SLAVE __DEPRECATED_MACRO BT_CONN_ROLE_PERIPHERAL
@@ -360,8 +378,10 @@ struct bt_conn_info {
 		/** BR/EDR Connection specific Info. */
 		struct bt_conn_br_info br;
 	};
-
+	/** Connection state. */
 	enum bt_conn_state state;
+	/** Security specific info. */
+	struct bt_security_info security;
 };
 
 /** LE Connection Remote Info Structure */

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -323,6 +323,24 @@ enum bt_conn_state {
 	BT_CONN_STATE_DISCONNECTING,
 };
 
+/** Security level. */
+typedef enum __packed {
+	/** Level 0: Only for BR/EDR special cases, like SDP */
+	BT_SECURITY_L0,
+	/** Level 1: No encryption and no authentication. */
+	BT_SECURITY_L1,
+	/** Level 2: Encryption and no authentication (no MITM). */
+	BT_SECURITY_L2,
+	/** Level 3: Encryption and authentication (MITM). */
+	BT_SECURITY_L3,
+	/** Level 4: Authenticated Secure Connections and 128-bit key. */
+	BT_SECURITY_L4,
+	/** Bit to force new pairing procedure, bit-wise OR with requested
+	 *  security level.
+	 */
+	BT_SECURITY_FORCE_PAIR = BIT(7),
+} bt_security_t;
+
 /** Connection role (central or peripheral) */
 #define BT_CONN_ROLE_MASTER __DEPRECATED_MACRO BT_CONN_ROLE_CENTRAL
 #define BT_CONN_ROLE_SLAVE __DEPRECATED_MACRO BT_CONN_ROLE_PERIPHERAL
@@ -675,24 +693,6 @@ int bt_conn_create_auto_stop(void);
  */
 int bt_le_set_auto_conn(const bt_addr_le_t *addr,
 			const struct bt_le_conn_param *param);
-
-/** Security level. */
-typedef enum __packed {
-	/** Level 0: Only for BR/EDR special cases, like SDP */
-	BT_SECURITY_L0,
-	/** Level 1: No encryption and no authentication. */
-	BT_SECURITY_L1,
-	/** Level 2: Encryption and no authentication (no MITM). */
-	BT_SECURITY_L2,
-	/** Level 3: Encryption and authentication (MITM). */
-	BT_SECURITY_L3,
-	/** Level 4: Authenticated Secure Connections and 128-bit key. */
-	BT_SECURITY_L4,
-	/** Bit to force new pairing procedure, bit-wise OR with requested
-	 *  security level.
-	 */
-	BT_SECURITY_FORCE_PAIR = BIT(7),
-} bt_security_t;
 
 /** @brief Set security level for a connection.
  *

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -730,7 +730,7 @@ int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec);
  *
  *  @return Connection security level
  */
-bt_security_t bt_conn_get_security(struct bt_conn *conn);
+bt_security_t bt_conn_get_security(const struct bt_conn *conn);
 
 /** @brief Get encryption key size.
  *
@@ -741,7 +741,7 @@ bt_security_t bt_conn_get_security(struct bt_conn *conn);
  *
  *  @return Encryption key size.
  */
-uint8_t bt_conn_enc_key_size(struct bt_conn *conn);
+uint8_t bt_conn_enc_key_size(const struct bt_conn *conn);
 
 enum bt_security_err {
 	/** Security procedure successful. */

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2262,6 +2262,9 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 	info->role = conn->role;
 	info->id = conn->id;
 	info->state = conn_internal_to_public_state(conn->state);
+	info->security.flags = 0;
+	info->security.level = bt_conn_get_security(conn);
+	info->security.enc_key_size = bt_conn_enc_key_size(conn);
 
 	switch (conn->type) {
 	case BT_CONN_TYPE_LE:
@@ -2283,6 +2286,12 @@ int bt_conn_get_info(const struct bt_conn *conn, struct bt_conn_info *info)
 #if defined(CONFIG_BT_USER_DATA_LEN_UPDATE)
 		info->le.data_len = &conn->le.data_len;
 #endif
+		if (conn->le.keys && (conn->le.keys->flags & BT_KEYS_SC)) {
+			info->security.flags |= BT_SECURITY_FLAG_SC;
+		}
+		if (conn->le.keys && (conn->le.keys->flags & BT_KEYS_OOB)) {
+			info->security.flags |= BT_SECURITY_FLAG_OOB;
+		}
 		return 0;
 #if defined(CONFIG_BT_BREDR)
 	case BT_CONN_TYPE_BR:

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -1945,7 +1945,7 @@ int bt_conn_le_start_encryption(struct bt_conn *conn, uint8_t rand[8],
 #endif /* CONFIG_BT_SMP */
 
 #if defined(CONFIG_BT_SMP) || defined(CONFIG_BT_BREDR)
-uint8_t bt_conn_enc_key_size(struct bt_conn *conn)
+uint8_t bt_conn_enc_key_size(const struct bt_conn *conn)
 {
 	if (!conn->encrypt) {
 		return 0;
@@ -2090,7 +2090,7 @@ int bt_conn_set_security(struct bt_conn *conn, bt_security_t sec)
 	return err;
 }
 
-bt_security_t bt_conn_get_security(struct bt_conn *conn)
+bt_security_t bt_conn_get_security(const struct bt_conn *conn)
 {
 	return conn->sec_level;
 }

--- a/subsys/bluetooth/host/keys.h
+++ b/subsys/bluetooth/host/keys.h
@@ -30,6 +30,7 @@ enum {
 	BT_KEYS_DEBUG           = BIT(1),
 	/* Bit 2 and 3 might accidentally exist in old stored keys */
 	BT_KEYS_SC              = BIT(4),
+	BT_KEYS_OOB             = BIT(5),
 };
 
 struct bt_ltk {

--- a/subsys/bluetooth/host/smp.c
+++ b/subsys/bluetooth/host/smp.c
@@ -5750,16 +5750,19 @@ void bt_smp_update_keys(struct bt_conn *conn)
 	 * security level upon encryption
 	 */
 	switch (smp->method) {
+	case LE_SC_OOB:
+	case LEGACY_OOB:
+		conn->le.keys->flags |= BT_KEYS_OOB;
+		/* fallthrough */
 	case PASSKEY_DISPLAY:
 	case PASSKEY_INPUT:
 	case PASSKEY_CONFIRM:
-	case LE_SC_OOB:
-	case LEGACY_OOB:
 		conn->le.keys->flags |= BT_KEYS_AUTHENTICATED;
 		break;
 	case JUST_WORKS:
 	default:
 		/* unauthenticated key, clear it */
+		conn->le.keys->flags &= ~BT_KEYS_OOB;
 		conn->le.keys->flags &= ~BT_KEYS_AUTHENTICATED;
 		break;
 	}


### PR DESCRIPTION
This extends the bt_conn_info with security level information and flags
including Secure Connections and OOB flags. This information is needed
by LE Audio profiles to check if security requirements are met.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>