### PR TITLE
soc: ace_v1x: l2 mm driver corrections

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -681,9 +681,10 @@ static int sys_mm_drv_mm_init(const struct device *dev)
 	}
 
 	/*
-	 * Unmap unused physical pages from the TLB to save power
+	 * Unmap all unused physical pages from the entire
+	 * virtual address space to save power
 	 */
-	size_t unused_size = L2_SRAM_BASE + L2_SRAM_SIZE -
+	size_t unused_size = CONFIG_KERNEL_VM_BASE + CONFIG_KERNEL_VM_SIZE -
 			     unused_l2_start_aligned;
 
 	ret = sys_mm_drv_unmap_region(UINT_TO_POINTER(unused_l2_start_aligned),


### PR DESCRIPTION
This PR introduces 2 corrections to the MTL TLB driver:
1. on driver init unmaps the entire unused virtual address space instead of remaining physical memory space
2. replaces the sys_mm_drv_move_region implementation to query TLB for physical address for each virtual page to be remapped instead of assuming linear mapping as it is done in sys_mm_drv_simple_move_region