### PR TITLE
tests: drivers: gpio: gpio_basic_api: use static dev declaration

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -69,7 +69,7 @@ static int setup(void)
 	int rc;
 	gpio_port_value_t v1;
 
-	const struct device *dev = DEVICE_DT_GET(DEV);
+	dev = DEVICE_DT_GET(DEV);
 
 	TC_PRINT("Validate device %s\n", dev->name);
 	zassert_true(device_is_ready(dev), "GPIO dev is not ready");


### PR DESCRIPTION
tests: drivers: gpio: gpio_basic_api: use static dev declaration

"dev" is already defined as a static variable,
it should not be redefined locally.
Fix regression (all STM32board fails on test bench) introduced by PR #47414 


