### PR TITLE
kernel: Add k_event_set_masked primitive

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -2129,6 +2129,21 @@ __syscall void k_event_post(struct k_event *event, uint32_t events);
 __syscall void k_event_set(struct k_event *event, uint32_t events);
 
 /**
+ * @brief Set or clear the events in an event object
+ *
+ * This routine sets the events stored in event object to the specified value.
+ * All tasks waiting on the event object @a event whose waiting conditions
+ * become met by this immediately unpend. Unlike @ref k_event_set, this routine
+ * allows specific event bits to be set and cleared as determined by the mask.
+ *
+ * @param event Address of the event object
+ * @param events Set of events to post to @a event
+ * @param events_mask Mask to be applied to @a events
+ */
+__syscall void k_event_set_masked(struct k_event *event, uint32_t events,
+				  uint32_t events_mask);
+
+/**
  * @brief Wait for any of the specified events
  *
  * This routine waits on event object @a event until any of the specified

--- a/include/zephyr/tracing/tracing.h
+++ b/include/zephyr/tracing/tracing.h
@@ -1870,17 +1870,17 @@
  * @brief Trace posting of an Event call entry
  * @param event Event object
  * @param events Set of posted events
- * @param accumulate True if events accumulate, false otherwise
+ * @param events_mask Mask to apply against posted events
  */
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
 
 /**
  * @brief Trace posting of an Event call exit
  * @param event Event object
  * @param events Set of posted events
- * @param accumulate True if events accumulate, false otherwise
+ * @param events_mask Mask to apply against posted events
  */
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 
 /**
  * @brief Trace waiting of an Event call entry

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -174,6 +174,22 @@ void z_vrfy_k_event_set(struct k_event *event, uint32_t events)
 #include <syscalls/k_event_set_mrsh.c>
 #endif
 
+void z_impl_k_event_set_masked(struct k_event *event, uint32_t events,
+			       uint32_t events_mask)
+{
+	k_event_post_internal(event, events, events_mask);
+}
+
+#ifdef CONFIG_USERSPACE
+void z_vrfy_k_event_set_masked(struct k_event *event, uint32_t events,
+			       uint32_t events_mask)
+{
+	Z_OOPS(Z_SYSCALL_OBJ(event, K_OBJ_EVENT));
+	z_impl_k_event_set_masked(event, events, events_mask);
+}
+#include <syscalls/k_event_set_masked_mrsh.c>
+#endif
+
 static uint32_t k_event_wait_internal(struct k_event *event, uint32_t events,
 				      unsigned int options, k_timeout_t timeout)
 {

--- a/kernel/events.c
+++ b/kernel/events.c
@@ -85,7 +85,7 @@ static bool are_wait_conditions_met(uint32_t desired, uint32_t current,
 }
 
 static void k_event_post_internal(struct k_event *event, uint32_t events,
-				  bool accumulate)
+				  uint32_t events_mask)
 {
 	k_spinlock_key_t  key;
 	struct k_thread  *thread;
@@ -95,12 +95,10 @@ static void k_event_post_internal(struct k_event *event, uint32_t events,
 	key = k_spin_lock(&event->lock);
 
 	SYS_PORT_TRACING_OBJ_FUNC_ENTER(k_event, post, event, events,
-					accumulate);
+					events_mask);
 
-	if (accumulate) {
-		events |= event->events;
-	}
-
+	events = (event->events & ~events_mask) |
+		 (events & events_mask);
 	event->events = events;
 
 	/*
@@ -145,12 +143,12 @@ static void k_event_post_internal(struct k_event *event, uint32_t events,
 	z_reschedule(&event->lock, key);
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_event, post, event, events,
-				       accumulate);
+				       events_mask);
 }
 
 void z_impl_k_event_post(struct k_event *event, uint32_t events)
 {
-	k_event_post_internal(event, events, true);
+	k_event_post_internal(event, events, events);
 }
 
 #ifdef CONFIG_USERSPACE
@@ -164,7 +162,7 @@ void z_vrfy_k_event_post(struct k_event *event, uint32_t events)
 
 void z_impl_k_event_set(struct k_event *event, uint32_t events)
 {
-	k_event_post_internal(event, events, false);
+	k_event_post_internal(event, events, ~0);
 }
 
 #ifdef CONFIG_USERSPACE

--- a/subsys/tracing/ctf/tracing_ctf.h
+++ b/subsys/tracing/ctf/tracing_ctf.h
@@ -314,8 +314,8 @@ extern "C" {
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_exit(event, events, ret)

--- a/subsys/tracing/test/tracing_test.h
+++ b/subsys/tracing/test/tracing_test.h
@@ -421,10 +421,10 @@
 	sys_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event) sys_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)   \
-	sys_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)   \
-	sys_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)   \
+	sys_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)   \
+	sys_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)   \
 	sys_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout) \

--- a/subsys/tracing/user/tracing_user.h
+++ b/subsys/tracing/user/tracing_user.h
@@ -316,8 +316,8 @@ void sys_trace_idle(void);
 #define sys_port_trace_k_timer_status_sync_exit(timer, result)
 
 #define sys_port_trace_k_event_init(event)
-#define sys_port_trace_k_event_post_enter(event, events, accumulate)
-#define sys_port_trace_k_event_post_exit(event, events, accumulate)
+#define sys_port_trace_k_event_post_enter(event, events, events_mask)
+#define sys_port_trace_k_event_post_exit(event, events, events_mask)
 #define sys_port_trace_k_event_wait_enter(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_blocking(event, events, options, timeout)
 #define sys_port_trace_k_event_wait_exit(event, events, ret)

--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -340,6 +340,7 @@ ZTEST(events_api, test_event_deliver)
 {
 	static struct k_event  event;
 	uint32_t  events;
+	uint32_t  events_mask;
 
 	k_event_init(&event);
 
@@ -361,6 +362,33 @@ ZTEST(events_api, test_event_deliver)
 	events = 0xAAAA0000;
 	k_event_set(&event, events);
 	zassert_true(event.events == events, NULL);
+
+	/*
+	 * Verify k_event_set_masked() update the events
+	 * stored in the event object as expected
+	 */
+	events = 0x33333333;
+	k_event_set(&event, events);
+	zassert_true(event.events == events, NULL);
+
+	events_mask = 0x11111111;
+	k_event_set_masked(&event, 0, events_mask);
+	zassert_true(event.events == 0x22222222, NULL);
+
+	events_mask = 0x22222222;
+	k_event_set_masked(&event, 0, events_mask);
+	zassert_true(event.events == 0, NULL);
+
+	events = 0x22222222;
+	events_mask = 0x22222222;
+	k_event_set_masked(&event, events, events_mask);
+	zassert_true(event.events == events, NULL);
+
+	events = 0x11111111;
+	events_mask = 0x33333333;
+	k_event_set_masked(&event, events, events_mask);
+	zassert_true(event.events == events, NULL);
+
 }
 
 /**


### PR DESCRIPTION
This is a possible, partial fix to issue#46117 which allows a consumer of events to avoid a race with a producer (or producers).