### PR TITLE
LE Audio: Unicast client read available context

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -1316,6 +1316,21 @@ struct bt_audio_unicast_client_cb {
 	 */
 	void (*location)(struct bt_conn *conn, enum bt_audio_dir dir,
 			 enum bt_audio_location loc);
+
+	/** @brief Remote Unicast Server Available Contexts
+	 *
+	 *  This callback is called whenever the available contexts are read
+	 *  from the server or otherwise notified to the client.
+	 *
+	 *  @param conn     Connection to the remote unicast server.
+	 *  @param snk_ctx  The sink context bitfield value.
+	 *  @param src_ctx  The source context bitfield value.
+	 *
+	 *  @return 0 in case of success or negative value in case of error.
+	 */
+	void (*available_contexts)(struct bt_conn *conn,
+				   enum bt_audio_context snk_ctx,
+				   enum bt_audio_context src_ctx);
 };
 
 /** @brief Register unicast client callbacks.

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -724,8 +724,16 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 	printk("dir %u loc %X\n", dir, loc);
 }
 
+static void available_contexts_cb(struct bt_conn *conn,
+				  enum bt_audio_context snk_ctx,
+				  enum bt_audio_context src_ctx)
+{
+	printk("snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+}
+
 const struct bt_audio_unicast_client_cb unicast_client_cbs = {
-	.location = unicast_client_location_cb
+	.location = unicast_client_location_cb,
+	.available_contexts = available_contexts_cb,
 };
 
 static int init(void)

--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -597,8 +597,16 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 	shell_print(ctx_shell, "dir %u loc %X\n", dir, loc);
 }
 
+static void available_contexts_cb(struct bt_conn *conn,
+				  enum bt_audio_context snk_ctx,
+				  enum bt_audio_context src_ctx)
+{
+	shell_print(ctx_shell, "snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+}
+
 const struct bt_audio_unicast_client_cb unicast_client_cbs = {
-	.location = unicast_client_location_cb
+	.location = unicast_client_location_cb,
+	.available_contexts = available_contexts_cb,
 };
 
 static int cmd_discover(const struct shell *sh, size_t argc, char *argv[])

--- a/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_audio/src/unicast_client_test.c
@@ -102,8 +102,16 @@ static void unicast_client_location_cb(struct bt_conn *conn,
 	printk("dir %u loc %X\n", dir, loc);
 }
 
+static void available_contexts_cb(struct bt_conn *conn,
+				  enum bt_audio_context snk_ctx,
+				  enum bt_audio_context src_ctx)
+{
+	printk("snk ctx %u src ctx %u\n", snk_ctx, src_ctx);
+}
+
 const struct bt_audio_unicast_client_cb unicast_client_cbs = {
-	.location = unicast_client_location_cb
+	.location = unicast_client_location_cb,
+	.available_contexts = available_contexts_cb,
 };
 
 static void add_remote_sink(struct bt_audio_ep *ep, uint8_t index)


### PR DESCRIPTION
Updates the unicast client to read the available context of the unicast server and subscribe to changes. 

depends on https://github.com/zephyrproject-rtos/zephyr/pull/46940
fixes https://github.com/zephyrproject-rtos/zephyr/issues/47409