### PR TITLE
Shell: bluetooth: don't refer to commit message text

### DIFF
--- a/tests/bluetooth/shell/prj.conf
+++ b/tests/bluetooth/shell/prj.conf
@@ -53,5 +53,11 @@ CONFIG_BT_ISO_SYNC_RECEIVER=y
 CONFIG_BT_ISO_CENTRAL=y
 CONFIG_BT_ISO_PERIPHERAL=y
 
-# See commit message for usage
+# Usage:
+# `kernel log-level modulename severity`
+# e.g.,
+#
+# kernel log-level bt_hci_core 0
+# kernel log-level bt_l2cap 2
+# kernel log-level bt_att 4
 CONFIG_LOG_RUNTIME_FILTERING=y


### PR DESCRIPTION
One sometimes forgets files can be distributed outside of git..

Added a concise usage example of the command above the config.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>