### PR TITLE
CODEOWNERS: Remove alwa-nordic from bsim_test_audio

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -793,7 +793,7 @@ scripts/gen_image_info.py                 @tejlmand
 /tests/bluetooth/                         @alwa-nordic @jhedberg @Vudentz @sjanc
 /tests/bluetooth/controller/              @cvinayak @thoh-ot @kruithofa @erbr-ot @sjanc @ppryga
 /tests/bluetooth/bsim_bt/                 @alwa-nordic @jhedberg @Vudentz @wopu-ot
-/tests/bluetooth/bsim_bt/bsim_test_audio/ @alwa-nordic @jhedberg @Vudentz @wopu-ot @Thalley @asbjornsabo
+/tests/bluetooth/bsim_bt/bsim_test_audio/ @jhedberg @Vudentz @wopu-ot @Thalley @asbjornsabo
 /tests/bluetooth/tester/                  @alwa-nordic @jhedberg @Vudentz @sjanc
 /tests/posix/                             @pfalcon
 /tests/crypto/                            @ceolin


### PR DESCRIPTION
Remove alwa-nordic from /tests/bluetooth/bsim_bt/bsim_test_audio.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>