### PR TITLE
mbedtls: add CONFIG_MBEDTLS_HEAP_SELF_INIT

### DIFF
--- a/modules/mbedtls/Kconfig
+++ b/modules/mbedtls/Kconfig
@@ -183,8 +183,8 @@ config MBEDTLS_ENABLE_HEAP
 	  This option enables the mbedtls to use the heap. This setting must
 	  be global so that various applications and libraries in Zephyr do not
 	  try to do this themselves as there can be only one heap defined
-	  in mbedtls. If this is enabled, then the Zephyr will, during the device
-	  startup, initialize the heap automatically.
+	  in mbedtls. If this is enabled, and MBEDTLS_INIT is enabled then the
+	  Zephyr will, during the device startup, initialize the heap automatically.
 
 config MBEDTLS_HEAP_SIZE
 	int "Heap size for mbed TLS"
@@ -201,6 +201,13 @@ config MBEDTLS_HEAP_SIZE
 	  servers on the Internet, 32KB + overheads (up to another 20KB) may
 	  be needed. For some dedicated and specific usage of mbedtls API, the
 	  1000 bytes might be ok.
+
+config MBEDTLS_INIT
+	bool "Initialize mbed TLS at boot"
+	default y
+	help
+	  By default mbed TLS will be initialized at Zephyr init. Disabling this option
+	  will defer the initialization until explicitly called.
 
 config MBEDTLS_SHELL
 	bool "mbed TLS shell"

--- a/modules/mbedtls/include/mbedtls_init.h
+++ b/modules/mbedtls/include/mbedtls_init.h
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2022 Qualcomm Innovation Center, Inc.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef MBEDTLS_INIT_H
+#define MBEDTLS_INIT_H
+
+/* This should be called by platforms that do not wish to
+ * have mbedtls initialised during kernel startup
+ */
+int mbedtls_init(void);
+
+#endif /* MBEDTLS_INIT_H */

--- a/modules/mbedtls/zephyr_init.c
+++ b/modules/mbedtls/zephyr_init.c
@@ -96,4 +96,15 @@ static int _mbedtls_init(const struct device *device)
 	return 0;
 }
 
+#if defined(CONFIG_MBEDTLS_INIT)
 SYS_INIT(_mbedtls_init, POST_KERNEL, 0);
+#endif
+
+/* if CONFIG_MBEDTLS_INIT is not defined then this function
+ * should be called by the platform before any mbedtls functionality
+ * is used
+ */
+int mbedtls_init(void)
+{
+	return _mbedtls_init(NULL);
+}


### PR DESCRIPTION
Add a config flag to enable conditional mbedtls heap
initialization at startup, defaulting to enabled.

Also make the mbedtls_init() non-static so it can be
called externally.

Signed-off-by: Eugene Cohen <quic_egmc@quicinc.com>
Signed-off-by: Dave Aldridge <quic_daldridg@quicinc.com>