### PR TITLE
samples: canopenmode exclude nvs_sector_size above 64K

### DIFF
--- a/samples/modules/canopennode/README.rst
+++ b/samples/modules/canopennode/README.rst
@@ -99,6 +99,12 @@ The sample can be built and executed for the STM32F3 Discovery as follows:
 Pressing the button labelled ``USER`` will increment the button press counter
 object at index ``0x2102`` in the object dictionary.
 
+Building and Running for other STM32 boards
+===========================================
+The sample cannot run if the <erase-block-size> of the flash-controller exceeds 0x10000.
+Typically nucleo_h743zi with erase-block-size = <DT_SIZE_K(128)>;
+
+
 Building and Running for boards without storage partition
 =========================================================
 The sample can be built for boards without a flash storage partition by using a different configuration file:

--- a/samples/modules/canopennode/sample.yaml
+++ b/samples/modules/canopennode/sample.yaml
@@ -16,6 +16,7 @@ tests:
     filter: dt_label_with_parent_compat_enabled("storage_partition", "fixed-partitions") and
             dt_chosen_enabled("zephyr,flash-controller") and
             CONFIG_FLASH_HAS_DRIVER_ENABLED
+    platform_exclude: nucleo_h723zg nucleo_h743zi nucleo_h745zi_q nucleo_h753zi
   sample.modules.canopennode.program_download:
     build_only: true
     platform_exclude: native_posix native_posix_64 rcar_h3ulcb_cr7


### PR DESCRIPTION
This commits is restricting the execution of the
samples/modules/canopennode to board configuration where
the nvs_sector_size is less than 0x10000.
When the CONFIG_CANOPENNODE_STORAGE is selected, the
settings_subsys_init do not accept
nvs_sector_size > UINT16_MAX.
Then all the stm32h723/h743/h745/h750 cannot run the
sample.modules.canopennode testcase

Signed-off-by: Francois Ramu <francois.ramu@st.com>