### PR TITLE
fcb_settings: Use weak function to get storage flash area

### DIFF
--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -38,6 +38,21 @@ static const struct settings_store_itf settings_fcb_itf = {
 	.csi_save = settings_fcb_save,
 };
 
+/**
+ * @brief Get the flash area id of the storage partition
+ *
+ * The implementation of this function provided is weak to let user defines its own function.
+ * This may prove useful for devices using bank swap, in that case the flash area id changes based
+ * on the bank swap state.
+ * See #47732
+ *
+ * @return Flash area id
+ */
+__weak int settings_fcb_get_flash_area(void)
+{
+	return SETTINGS_PARTITION;
+}
+
 int settings_fcb_src(struct settings_fcb *cf)
 {
 	int rc;
@@ -46,7 +61,7 @@ int settings_fcb_src(struct settings_fcb *cf)
 	cf->cf_fcb.f_scratch_cnt = 1;
 
 	while (1) {
-		rc = fcb_init(SETTINGS_PARTITION, &cf->cf_fcb);
+		rc = fcb_init(settings_fcb_get_flash_area(), &cf->cf_fcb);
 		if (rc) {
 			return -EINVAL;
 		}
@@ -395,7 +410,7 @@ int settings_backend_init(void)
 	int rc;
 	const struct flash_area *fap;
 
-	rc = flash_area_get_sectors(SETTINGS_PARTITION, &cnt,
+	rc = flash_area_get_sectors(settings_fcb_get_flash_area(), &cnt,
 				    settings_fcb_area);
 	if (rc == -ENODEV) {
 		return rc;
@@ -408,7 +423,7 @@ int settings_backend_init(void)
 	rc = settings_fcb_src(&config_init_settings_fcb);
 
 	if (rc != 0) {
-		rc = flash_area_open(SETTINGS_PARTITION, &fap);
+		rc = flash_area_open(settings_fcb_get_flash_area(), &fap);
 
 		if (rc == 0) {
 			rc = flash_area_erase(fap, 0, fap->fa_size);


### PR DESCRIPTION
On MCU with bank swap capabilities, the offset of the storage area is
not the same before and after a bank swap. This commit introduce a weak
function which returns the default flash area of the storage partition.
On MCU with the bank swap capability the user can define its own
function to get the proper flash area depending on which bank the fw is
run from.

Signed-off-by: Nicolas VINCENT <nicolas.vincent@vossloh.com>

I've tested this on nucleo_h743zi with `SETTINGS_SHELL` enabled and swapping bank with `STM32_Programmer_CLI -c port=SWD 0023003E3538511133363730 reset=HWrst -ob SWAP_BANK=1`

I used the following implementation to overide `settings_fcb_get_flash_area`:

```c
int settings_fcb_get_flash_area(void)
{
        int f_area_id;

        if (READ_BIT(FLASH->OPTCR, FLASH_OPTCR_SWAP_BANK)
                        != FLASH_OPTCR_SWAP_BANK) {
                /* Not swapped */
                f_area_id = FLASH_AREA_ID(storage);
                LOG_INF("not swapped");
        } else {
                /* Swapped */
                f_area_id = FLASH_AREA_ID(storage_mirror);
                LOG_INF("swapped");
        }

        return f_area_id;
}
```

and the following board overlay:
```
&flash0 {
        partitions {
                compatible = "fixed-partitions";
                #address-cells = <1>;
                #size-cells = <1>;
                /delete-node/ partition@0;
                /delete-node/ partition@20000;
                /delete-node/ partition@40000;
                /delete-node/ partition@80000;
                /delete-node/ partition@c0000;

                slot0_partition: partition@0{
                        label = "image-0";
                        reg = <0x00000000 DT_SIZE_K(512)>;
                };
                storage0_partition: partition@c0000 {
                        label = "storage";
                        reg = <0x000C0000 DT_SIZE_K(256)>;
                };
                storage1_partition: partition@1c0000 {
                        label = "storage-mirror";
                        reg = <0x001C0000 DT_SIZE_K(256)>;
                };

        };
};
```

This PR depends on #47632 in order to work on stm32h7.