### PR TITLE
drivers: dac: set explicitly init priority for external DACs

### DIFF
--- a/drivers/dac/Kconfig.dacx0508
+++ b/drivers/dac/Kconfig.dacx0508
@@ -9,3 +9,13 @@ config DAC_DACX0508
 	depends on SPI
 	help
 	  Enable the driver for the TI DACx0508.
+
+if DAC_DACX0508
+
+config DAC_DACX0508_INIT_PRIORITY
+	int "Init priority"
+	default 80
+	help
+	  TI DACx0508 DAC device driver initialization priority.
+
+endif # DAC_DACX0508

--- a/drivers/dac/Kconfig.dacx3608
+++ b/drivers/dac/Kconfig.dacx3608
@@ -9,3 +9,13 @@ config DAC_DACX3608
 	depends on I2C
 	help
 	  Enable the driver for the TI DACX3608.
+
+if DAC_DACX3608
+
+config DAC_DACX3608_INIT_PRIORITY
+	int "Init priority"
+	default 80
+	help
+	  TI DACX3608 DAC device driver initialization priority.
+
+endif # DAC_DACX3608

--- a/drivers/dac/Kconfig.mcp4725
+++ b/drivers/dac/Kconfig.mcp4725
@@ -9,3 +9,13 @@ config DAC_MCP4725
 	depends on I2C
 	help
 	  Enable the driver for the Microchip MCP4725.
+
+if DAC_MCP4725
+
+config DAC_MCP4725_INIT_PRIORITY
+	int "Init priority"
+	default 80
+	help
+	  Microchip MCP4725 DAC device driver initialization priority.
+
+endif # DAC_MCP4725

--- a/drivers/dac/Kconfig.mcp4728
+++ b/drivers/dac/Kconfig.mcp4728
@@ -7,3 +7,13 @@ config DAC_MCP4728
 	depends on I2C
 	help
 	  Enable driver for the Microchip MCP4728.
+
+if DAC_MCP4728
+
+config DAC_MCP4728_INIT_PRIORITY
+	int "Init priority"
+	default 80
+	help
+	  Microchip MCP4728 device driver initialization priority.
+
+endif # DAC_MCP4728

--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -385,7 +385,7 @@ static const struct dac_driver_api dacx0508_driver_api = {
 			    &dacx0508_init, NULL, \
 			    &dac##t##_data_##n, \
 			    &dac##t##_config_##n, POST_KERNEL, \
-			    CONFIG_DAC_INIT_PRIORITY, \
+			    CONFIG_DAC_DACX0508_INIT_PRIORITY, \
 			    &dacx0508_driver_api)
 
 /*

--- a/drivers/dac/dac_dacx3608.c
+++ b/drivers/dac/dac_dacx3608.c
@@ -250,7 +250,7 @@ static const struct dac_driver_api dacx3608_driver_api = {
 				&dacx3608_init, NULL, \
 				&dac##t##_data_##n, \
 				&dac##t##_config_##n, POST_KERNEL, \
-				CONFIG_DAC_INIT_PRIORITY, \
+				CONFIG_DAC_DACX3608_INIT_PRIORITY, \
 				&dacx3608_driver_api)
 
 /*

--- a/drivers/dac/dac_mcp4725.c
+++ b/drivers/dac/dac_mcp4725.c
@@ -142,7 +142,7 @@ static const struct dac_driver_api mcp4725_driver_api = {
 			    NULL,					\
 			    NULL,					\
 			    &mcp4725_config_##index, POST_KERNEL,	\
-			    CONFIG_DAC_INIT_PRIORITY,			\
+			    CONFIG_DAC_MCP4725_INIT_PRIORITY,		\
 			    &mcp4725_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INST_DT_MCP4725);

--- a/drivers/dac/dac_mcp4728.c
+++ b/drivers/dac/dac_mcp4728.c
@@ -104,7 +104,7 @@ static const struct dac_driver_api mcp4728_driver_api = {
 	DEVICE_DT_INST_DEFINE(index, dac_mcp4728_init, NULL, NULL,		\
 				&mcp4728_config_##index,			\
 				POST_KERNEL,					\
-				CONFIG_DAC_INIT_PRIORITY,			\
+				CONFIG_DAC_MCP4728_INIT_PRIORITY,		\
 				&mcp4728_driver_api);
 
 DT_INST_FOREACH_STATUS_OKAY(INST_DT_MCP4728);


### PR DESCRIPTION
Since the external DACs are connected via either I2C or SPI bus the init priority value must be higher than the default 50 so it can be initialized later than the bus itself so add a dedicated init config symbol for that.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>