### PR TITLE
drivers: dac: mcp4728: kconfig improvements

### DIFF
--- a/drivers/dac/Kconfig.mcp4728
+++ b/drivers/dac/Kconfig.mcp4728
@@ -6,4 +6,4 @@ config DAC_MCP4728
 	bool "Microchip MCP4728 DAC driver"
 	depends on I2C
 	help
-	Enable driver for the Microchip MCP4728.
+	  Enable driver for the Microchip MCP4728.

--- a/drivers/dac/Kconfig.mcp4728
+++ b/drivers/dac/Kconfig.mcp4728
@@ -4,6 +4,6 @@
 
 config DAC_MCP4728
 	bool "Microchip MCP4728 DAC driver"
-	depends on I2C && DAC
+	depends on I2C
 	help
 	Enable driver for the Microchip MCP4728.


### PR DESCRIPTION
Fix indentation of the help section and remove useless DAC guard.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>