### PR TITLE
[WIP][RFC] HAS_SECURITY_RISK Kconfig option for risky features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1879,6 +1879,13 @@ if(CONFIG_SOC_DEPRECATED_RELEASE)
   )
 endif()
 
+if (CONFIG_HAS_SECURITY_RISK AND (NOT CONFIG_SUPPRESS_SECURITY_RISK_WARNING))
+  message(WARNING "
+      WARNING: One or more of enabled Kconfig options selects HAS_SECURITY_RISK option
+      to warn you about introduced security risks."
+  )
+endif()
+
 # In CMake projects, 'CMAKE_BUILD_TYPE' usually determines the
 # optimization flag, but in Zephyr it is determined through
 # Kconfig. Here we give a warning when there is a mismatch between the

--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -969,3 +969,22 @@ config COMPAT_INCLUDES
 	  deprecated header files.
 
 endmenu
+
+config HAS_SECURITY_RISK
+	bool
+	help
+	  Option or combination options introduce security risk into application.
+
+if HAS_SECURITY_RISK
+
+config SUPPRESS_SECURITY_RISK_WARNING
+	bool "Suppress cmake security risk warning"
+	default n if HAS_SECURITY_RISK
+	default y
+	help
+	  Allows to suppress security risk warning during build.
+
+	  To find out which Kconfig options cause the warning, check which items
+	  select HAS_SECURITY_RISK.
+
+endif

--- a/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
+++ b/subsys/mgmt/mcumgr/grp/fs_mgmt/Kconfig
@@ -16,6 +16,7 @@ menuconfig MCUMGR_GRP_FS
 	bool "Mcumgr handlers for file management (insecure)"
 	depends on FILE_SYSTEM
 	select MCUMGR_SMP_CBOR_MIN_DECODING_LEVEL_2
+	select HAS_SECURITY_RISK
 	help
 	  Enables mcumgr handlers for file management
 

--- a/subsys/usb/device/class/dfu/Kconfig
+++ b/subsys/usb/device/class/dfu/Kconfig
@@ -41,6 +41,7 @@ config USB_DFU_DEFAULT_POLLTIMEOUT
 
 config USB_DFU_ENABLE_UPLOAD
 	bool "Firmware uploading to the host"
+	select HAS_SECURITY_RISK
 	help
 	  Enabling this option allows to upload firmware image to the host.
 	  Be aware that upload capability can be a security risk because


### PR DESCRIPTION
The PR adds Kconfig option HAS_SECURITY_RISK that allows to indicate that some of selected Kconig options introduce security risks into application.