### PR TITLE
twister: also parse cpp files in app root

### DIFF
--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -280,7 +280,7 @@ def scan_testsuite_path(testsuite_path):
         except ValueError as e:
             logger.error("%s: can't find: %s" % (filename, e))
 
-    for filename in glob.glob(os.path.join(testsuite_path, "*.c")):
+    for filename in glob.glob(os.path.join(testsuite_path, "*.c*")):
         try:
             result: ScanPathResult = scan_file(filename)
             if result.warnings:


### PR DESCRIPTION
Fix wildcard to also scan cpp files in root folder of test application.

Fixes #47220

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
