### PR TITLE
dma: hda link driver fixups

### DIFF
--- a/drivers/dma/dma_cavs_hda_link_in.c
+++ b/drivers/dma/dma_cavs_hda_link_in.c
@@ -26,7 +26,7 @@ static const struct dma_driver_api cavs_hda_dma_link_in_api = {
 	static const struct cavs_hda_dma_cfg cavs_hda_dma##inst##_config = {                       \
 		.base = DT_INST_REG_ADDR(inst),                                                    \
 		.dma_channels = DT_INST_PROP(inst, dma_channels),                                  \
-		.direction = MEMORY_TO_HOST                                                        \
+		.direction = PERIPHERAL_TO_MEMORY						   \
 	};                                                                                         \
 												   \
 	static struct cavs_hda_dma_data cavs_hda_dma##inst##_data = {};                            \

--- a/drivers/dma/dma_cavs_hda_link_out.c
+++ b/drivers/dma/dma_cavs_hda_link_out.c
@@ -26,8 +26,8 @@ static const struct dma_driver_api cavs_hda_dma_link_out_api = {
 	static const struct cavs_hda_dma_cfg cavs_hda_dma##inst##_config = {                       \
 		.base = DT_INST_REG_ADDR(inst),                                                    \
 		.dma_channels = DT_INST_PROP(inst, dma_channels),                                  \
-		.direction = MEMORY_TO_HOST                                                        \
-	};                                                                                         \
+		.direction = MEMORY_TO_PERIPHERAL						   \
+	};											   \
 												   \
 	static struct cavs_hda_dma_data cavs_hda_dma##inst##_data = {};                            \
 												   \

--- a/dts/xtensa/intel/intel_cavs.dtsi
+++ b/dts/xtensa/intel/intel_cavs.dtsi
@@ -36,22 +36,22 @@
 			compatible = "intel,cavs-hda-link-out";
 			#dma-cells = <1>;
 			reg = <0x00072400 0x40>;
-			dma-channels = <9>;
+			dma-channels = <4>;
 			dma-buf-alignment = <128>;
 			label = "HDA_LINK_OUT";
 
-			status = "disabled";
+			status = "okay";
 		};
 
 		hda_link_in: dma@72600 {
 			compatible = "intel,cavs-hda-link-in";
 			#dma-cells = <1>;
 			reg = <0x00072600 0x40>;
-			dma-channels = <7>;
+			dma-channels = <4>;
 			dma-buf-alignment = <128>;
 			label = "HDA_LINK_IN";
 
-			status = "disabled";
+			status = "okay";
 		};
 
 		hda_host_out: dma@72800 {

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -163,22 +163,22 @@
 			compatible = "intel,cavs-hda-link-out";
 			#dma-cells = <1>;
 			reg = <0x00002400 0x40>;
-			dma-channels = <6>;
+			dma-channels = <2>;
 			dma-buf-alignment = <128>;
 			label = "HDA_LINK_OUT";
 
-			status = "disabled";
+			status = "okay";
 		};
 
 		hda_link_in: dma@2600 {
 			compatible = "intel,cavs-hda-link-in";
 			#dma-cells = <1>;
 			reg = <0x00002600 0x40>;
-			dma-channels = <7>;
+			dma-channels = <2>;
 			dma-buf-alignment = <128>;
 			label = "HDA_LINK_IN";
 
-			status = "disabled";
+			status = "okay";
 		};
 
 		hda_host_out: dma@2800 {


### PR DESCRIPTION
Fixes configured DMA direction for HDA link in/out drivers.

Adjusts the number of channels for link in/link out to safe value
that seems to work on all tested parts.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>