### PR TITLE
dts: bindings: bus labels are now optional

### DIFF
--- a/dts/bindings/dma/dma-controller.yaml
+++ b/dts/bindings/dma/dma-controller.yaml
@@ -8,9 +8,6 @@ include: base.yaml
 bus: dma
 
 properties:
-    label:
-      required: true
-
     "#dma-cells":
       type: int
       required: true

--- a/dts/bindings/dma/dmamux-controller.yaml
+++ b/dts/bindings/dma/dmamux-controller.yaml
@@ -8,9 +8,6 @@ include: base.yaml
 bus: dmamux
 
 properties:
-    label:
-      required: true
-
     "#dma-cells":
       type: int
       required: true

--- a/dts/bindings/espi/espi-controller.yaml
+++ b/dts/bindings/espi/espi-controller.yaml
@@ -6,7 +6,3 @@
 include: base.yaml
 
 bus: espi
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/gpio/xlnx,xps-gpio-1.00.a-gpio2.yaml
+++ b/dts/bindings/gpio/xlnx,xps-gpio-1.00.a-gpio2.yaml
@@ -7,9 +7,6 @@ include: [gpio-controller.yaml, base.yaml]
 on-bus: xlnx,xps-gpio-1.00.a
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/i2c/i2c-controller.yaml
+++ b/dts/bindings/i2c/i2c-controller.yaml
@@ -18,5 +18,3 @@ properties:
       type: int
       required: false
       description: Initial clock frequency in Hz
-    label:
-      required: true

--- a/dts/bindings/i2s/i2s-controller.yaml
+++ b/dts/bindings/i2s/i2s-controller.yaml
@@ -14,5 +14,3 @@ properties:
     "#size-cells":
       required: true
       const: 0
-    label:
-      required: true

--- a/dts/bindings/kscan/kscan.yaml
+++ b/dts/bindings/kscan/kscan.yaml
@@ -6,7 +6,3 @@
 include: base.yaml
 
 bus: kscan
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/mdio/mdio-controller.yaml
+++ b/dts/bindings/mdio/mdio-controller.yaml
@@ -8,8 +8,6 @@ include: base.yaml
 bus: mdio
 
 properties:
-    label:
-      required: true
     protocol:
       required: false
       type: string

--- a/dts/bindings/mipi-dsi/mipi-dsi-device.yaml
+++ b/dts/bindings/mipi-dsi/mipi-dsi-device.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     data-lanes:
       type: array
       required: true

--- a/dts/bindings/mipi-dsi/mipi-dsi-host.yaml
+++ b/dts/bindings/mipi-dsi/mipi-dsi-host.yaml
@@ -8,9 +8,6 @@ include: base.yaml
 bus: mipi-dsi
 
 properties:
-    label:
-      required: true
-
     "#address-cells":
       required: true
       const: 1

--- a/dts/bindings/peci/peci.yaml
+++ b/dts/bindings/peci/peci.yaml
@@ -16,5 +16,3 @@ properties:
       type: int
       required: true
       const: 0
-    label:
-      required: true

--- a/dts/bindings/ps2/ps2.yaml
+++ b/dts/bindings/ps2/ps2.yaml
@@ -16,5 +16,3 @@ properties:
       type: int
       required: true
       const: 0
-    label:
-      required: true

--- a/dts/bindings/serial/uart-controller.yaml
+++ b/dts/bindings/serial/uart-controller.yaml
@@ -13,8 +13,6 @@ properties:
       type: int
       required: false
       description: Initial baud rate setting for UART
-    label:
-      required: true
     hw-flow-control:
       type: boolean
       required: false

--- a/dts/bindings/spi/spi-controller.yaml
+++ b/dts/bindings/spi/spi-controller.yaml
@@ -19,8 +19,6 @@ properties:
     "#size-cells":
       required: true
       const: 0
-    label:
-      required: true
     cs-gpios:
       type: phandle-array
       required: false

--- a/dts/bindings/tach/tach.yaml
+++ b/dts/bindings/tach/tach.yaml
@@ -6,7 +6,3 @@
 include: base.yaml
 
 bus: tach
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/usb/usb-controller.yaml
+++ b/dts/bindings/usb/usb-controller.yaml
@@ -22,9 +22,6 @@ properties:
          - "high-speed"
          - "super-speed"
 
-    label:
-      required: true
-
     vbus-gpios:
       type: phandle-array
       required: false

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -352,9 +352,6 @@ def write_bus(node):
     if not bus:
         return
 
-    if not bus.label:
-        err(f"missing 'label' property on bus node {bus!r}")
-
     out_comment(f"Bus info (controller: '{bus.path}', type: '{node.on_bus}')")
     out_dt_define(f"{node.z_path_id}_BUS_{str2ident(node.on_bus)}", 1)
     out_dt_define(f"{node.z_path_id}_BUS", f"DT_{bus.z_path_id}")


### PR DESCRIPTION
All in tree device drivers on a bus use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>