### PR TITLE
drivers: can: add one-shot mode flag

### DIFF
--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -20,7 +20,8 @@ static struct k_poll_event msgq_events[1] = {
 };
 
 static inline int read_config_options(const struct shell *sh, int pos,
-				      char **argv, bool *listenonly, bool *loopback)
+				      char **argv, bool *listenonly, bool *loopback,
+				      bool *oneshot)
 {
 	char *arg = argv[pos];
 
@@ -42,6 +43,13 @@ static inline int read_config_options(const struct shell *sh, int pos,
 				shell_error(sh, "Unknown option %c", *arg);
 			} else {
 				*loopback = true;
+			}
+			break;
+		case 'o':
+			if (oneshot == NULL) {
+				shell_error(sh, "Unknown option %c", *arg);
+			} else {
+				*oneshot = true;
 			}
 			break;
 		default:
@@ -231,7 +239,9 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 {
 	const struct device *can_dev;
 	int pos = 1;
-	bool listenonly = false, loopback = false;
+	bool listenonly = false;
+	bool loopback = false;
+	bool oneshot = false;
 	can_mode_t mode = CAN_MODE_NORMAL;
 	uint32_t bitrate;
 	int ret;
@@ -245,7 +255,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 
 	pos++;
 
-	pos = read_config_options(sh, pos, argv, &listenonly, &loopback);
+	pos = read_config_options(sh, pos, argv, &listenonly, &loopback, &oneshot);
 	if (pos < 0) {
 		return -EINVAL;
 	}
@@ -256,6 +266,10 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 
 	if (loopback) {
 		mode |= CAN_MODE_LOOPBACK;
+	}
+
+	if (oneshot) {
+		mode |= CAN_MODE_ONE_SHOT;
 	}
 
 	ret = can_set_mode(can_dev, mode);
@@ -444,9 +458,10 @@ static int cmd_remove_rx_filter(const struct shell *sh, size_t argc, char **argv
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_can,
 	SHELL_CMD_ARG(config, NULL,
 		      "Configure CAN controller.\n"
-		      " Usage: config device_name [-sl] bitrate\n"
+		      " Usage: config device_name [-slo] bitrate\n"
 		      " -s Listen-only mode\n"
-		      " -l Loopback mode",
+		      " -l Loopback mode\n"
+		      " -o One-shot mode",
 		      cmd_config, 3, 1),
 	SHELL_CMD_ARG(send, NULL,
 		      "Send a CAN frame.\n"

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -351,7 +351,7 @@ static int can_stm32_set_mode(const struct device *dev, can_mode_t mode)
 
 	LOG_DBG("Set mode %d", mode);
 
-	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) != 0) {
+	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_ONE_SHOT)) != 0) {
 		LOG_ERR("unsupported mode: 0x%08x", mode);
 		return -ENOTSUP;
 	}
@@ -384,6 +384,13 @@ static int can_stm32_set_mode(const struct device *dev, can_mode_t mode)
 		can->BTR |= CAN_BTR_SILM;
 	} else {
 		can->BTR &= ~CAN_BTR_SILM;
+	}
+
+	if ((mode & CAN_MODE_ONE_SHOT) != 0) {
+		/* No automatic retransmission */
+		can->MCR |= CAN_MCR_NART;
+	} else {
+		can->MCR &= ~CAN_MCR_NART;
 	}
 
 done:
@@ -534,10 +541,6 @@ static int can_stm32_init(const struct device *dev)
 #ifdef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 	can->MCR |= CAN_MCR_ABOM;
 #endif
-	if (cfg->one_shot) {
-		can->MCR |= CAN_MCR_NART;
-	}
-
 	timing.sjw = cfg->sjw;
 	if (cfg->sample_point && USE_SP_ALGO) {
 		ret = can_calc_timing(dev, &timing, cfg->bus_speed,
@@ -1202,7 +1205,6 @@ static const struct can_stm32_config can_stm32_cfg_##inst = {            \
 	.prop_ts1 = DT_INST_PROP_OR(inst, prop_seg, 0) +                 \
 		    DT_INST_PROP_OR(inst, phase_seg1, 0),                \
 	.ts2 = DT_INST_PROP_OR(inst, phase_seg2, 0),                     \
-	.one_shot = DT_INST_PROP(inst, one_shot),                        \
 	.pclken = {                                                      \
 		.enr = DT_INST_CLOCKS_CELL(inst, bits),                  \
 		.bus = DT_INST_CLOCKS_CELL(inst, bus),                   \

--- a/drivers/can/can_stm32.h
+++ b/drivers/can/can_stm32.h
@@ -74,7 +74,6 @@ struct can_stm32_config {
 	uint8_t sjw;
 	uint8_t prop_ts1;
 	uint8_t ts2;
-	bool one_shot;
 	struct stm32_pclken pclken;
 	void (*config_irq)(CAN_TypeDef *can);
 	const struct pinctrl_dev_config *pcfg;

--- a/dts/bindings/can/st,stm32-can.yaml
+++ b/dts/bindings/can/st,stm32-can.yaml
@@ -20,14 +20,6 @@ properties:
     pinctrl-names:
       required: true
 
-    one-shot:
-      type: boolean
-      required: false
-      description: |
-        Disable automatic retransmissions. A CAN frame will only be transmitted
-        once, independently of the transmission result (successful, error, or
-        arbitration lost).
-
     master-can-reg:
       type: int
       required: false

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -97,6 +97,9 @@ extern "C" {
 /** Controller allows transmitting/receiving CAN-FD frames. */
 #define CAN_MODE_FD         BIT(2)
 
+/** Controller does not retransmit in case of lost arbitration or missing ACK */
+#define CAN_MODE_ONE_SHOT   BIT(3)
+
 /** @} */
 
 /**
@@ -971,8 +974,7 @@ __syscall int can_set_bitrate(const struct device *dev, uint32_t bitrate);
  *
  * By default, the CAN controller will automatically retry transmission in case
  * of lost bus arbitration or missing acknowledge. Some CAN controllers support
- * disabling automatic retransmissions ("one-shot" mode) via a devicetree
- * property.
+ * disabling automatic retransmissions via ``CAN_MODE_ONE_SHOT``.
  *
  * @param dev       Pointer to the device structure for the driver instance.
  * @param frame     CAN frame to transmit.


### PR DESCRIPTION
-  Add CAN_MODE_ONE_SHOT flag for disabling automatic retransmissions in case of lost arbitration or missing ACK.
- Switch the STM32 bxCAN driver from using a driver-specific, compile-time devicetree one-shot property to supporting the newly added CAN_MODE_ONE_SHOT flag for enabling/disabling one-shot mode at run-time.
- Add support for setting one-shot mode in the CAN shell module.
