### PR TITLE
Twister: various minor fixes and one major 

### DIFF
--- a/scripts/pylib/twister/twisterlib/enviornment.py
+++ b/scripts/pylib/twister/twisterlib/enviornment.py
@@ -160,8 +160,13 @@ Artificially long but functional example:
                         """)
 
     test_or_build.add_argument(
-        "-b", "--build-only", action="store_true",
+        "-b", "--build-only", action="store_true", default="--prep-artifacts-for-testing" in sys.argv,
         help="Only build the code, do not attempt to run the code on targets.")
+
+    test_or_build.add_argument(
+        "--prep-artifacts-for-testing", action="store_true",
+        help="Generate artifacts for testing, do not attempt to run the"
+              "code on targets.")
 
     test_or_build.add_argument(
         "--test-only", action="store_true",

--- a/scripts/pylib/twister/twisterlib/enviornment.py
+++ b/scripts/pylib/twister/twisterlib/enviornment.py
@@ -57,7 +57,7 @@ Artificially long but functional example:
 
     run_group_option = parser.add_mutually_exclusive_group()
 
-    serial = parser.add_mutually_exclusive_group(required="--device-testing" in sys.argv)
+    device = parser.add_mutually_exclusive_group(required="--device-testing" in sys.argv)
 
     test_or_build = parser.add_mutually_exclusive_group()
 
@@ -140,12 +140,12 @@ Artificially long but functional example:
                         --device-testing
                         """)
 
-    serial.add_argument("--device-serial",
+    device.add_argument("--device-serial",
                         help="""Serial device for accessing the board
                         (e.g., /dev/ttyACM0)
                         """)
 
-    serial.add_argument("--device-serial-pty",
+    device.add_argument("--device-serial-pty",
                         help="""Script for controlling pseudoterminal.
                         Twister believes that it interacts with a terminal
                         when it actually interacts with the script.
@@ -154,7 +154,7 @@ Artificially long but functional example:
                         --device-serial-pty <script>
                         """)
 
-    serial.add_argument("--hardware-map",
+    device.add_argument("--hardware-map",
                         help="""Load hardware map from a file. This will be used
                         for testing on hardware that is listed in the file.
                         """)

--- a/scripts/pylib/twister/twisterlib/enviornment.py
+++ b/scripts/pylib/twister/twisterlib/enviornment.py
@@ -161,7 +161,7 @@ Artificially long but functional example:
 
     test_or_build.add_argument(
         "-b", "--build-only", action="store_true",
-        help="Only build the code, do not execute any of it in QEMU")
+        help="Only build the code, do not attempt to run the code on targets.")
 
     test_or_build.add_argument(
         "--test-only", action="store_true",

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -506,7 +506,7 @@ class ProjectBuilder(FilterBuilder):
                 })
 
         elif op == "cleanup":
-            if self.options.device_testing:
+            if self.options.device_testing or self.options.prep_artifacts_for_testing:
                 self.cleanup_device_testing_artifacts()
             else:
                 self.cleanup_artifacts()

--- a/scripts/pylib/twister/twisterlib/testsuite.py
+++ b/scripts/pylib/twister/twisterlib/testsuite.py
@@ -221,11 +221,11 @@ def _get_search_area_boundary(search_area, suite_regex_matches, is_registered_te
 
 def _find_new_ztest_testcases(search_area):
     """
-    Find regular ztest testcases like "ZTEST" or "ZTEST_F". Return
+    Find regular ztest testcases like "ZTEST", "ZTEST_F" etc. Return
     testcases' names and eventually found warnings.
     """
     testcase_regex = re.compile(
-        br"^\s*(?:ZTEST|ZTEST_F)\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,"
+        br"^\s*(?:ZTEST|ZTEST_F|ZTEST_USER|ZTEST_USER_F)\(\s*(?P<suite_name>[a-zA-Z0-9_]+)\s*,"
         br"\s*(?P<testcase_name>[a-zA-Z0-9_]+)\s*",
         re.MULTILINE)
 

--- a/scripts/twister
+++ b/scripts/twister
@@ -332,7 +332,9 @@ def main():
         return 0
 
     report = Reporting(tplan, env)
-    report.json_report(os.path.join(options.outdir, "testplan.json"))
+    plan_file = os.path.join(options.outdir, "testplan.json")
+    if not os.path.exists(plan_file):
+        report.json_report(plan_file)
 
     if options.save_tests:
         report.json_report(options.save_tests)


### PR DESCRIPTION



- twister: rename argument group: serial -> device
- twister: fix --build-only  argument help
- twister: prep for device testing
- twister: fix new ztest parsing

This one is a hotfix.

- twister: do not modify testplan on subsequent runs
