### PR TITLE
Intel ADSP Meteorlake SoC: Minor cleanups

### DIFF
--- a/include/zephyr/linker/section_tags.h
+++ b/include/zephyr/linker/section_tags.h
@@ -18,6 +18,10 @@
 #define __irq_vector_table	Z_GENERIC_SECTION(_IRQ_VECTOR_TABLE_SECTION_NAME)
 #define __sw_isr_table		Z_GENERIC_SECTION(_SW_ISR_TABLE_SECTION_NAME)
 
+/* Attribute macros to place code and data into IMR memory */
+#define __imr __in_section_unique(imr)
+#define __imrdata __in_section_unique(imrdata)
+
 #if defined(CONFIG_ARM)
 #define __kinetis_flash_config_section __in_section_unique(_KINETIS_FLASH_CONFIG_SECTION_NAME)
 #define __ti_ccfg_section Z_GENERIC_SECTION(_TI_CCFG_SECTION_NAME)

--- a/soc/xtensa/intel_adsp/ace_v1x/fw_defs.h
+++ b/soc/xtensa/intel_adsp/ace_v1x/fw_defs.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADSP_PLATFORM_DEFS_H
+#define ADSP_PLATFORM_DEFS_H
+
+#define ADSP_L1_CACHE_PREFCTL_VALUE 0x1038
+
+#endif

--- a/soc/xtensa/intel_adsp/ace_v1x/soc.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/soc.c
@@ -32,7 +32,7 @@ extern void parse_manifest(void);
 #define HOST_PAGE_SIZE 4096
 
 #define MANIFEST_SEGMENT_COUNT 3
-
+#define DELAY_COUNT 256
 #define PLATFORM_INIT_HPSRAM
 #define PLATFORM_INIT_LPSRAM
 
@@ -45,14 +45,14 @@ static __imr void hp_sram_pm_banks(void)
 	uint32_t hpsram_ebb_quantity = mtl_hpsram_get_bank_count();
 	volatile uint32_t *l2hsbpmptr = (volatile uint32_t *)MTL_L2MM->l2hsbpmptr;
 	volatile uint8_t *status = (volatile uint8_t *)l2hsbpmptr + 4;
-	int inx, delay_count = 256;
+	int inx;
 
 	for (inx = 0; inx < hpsram_ebb_quantity; ++inx) {
 		*(l2hsbpmptr + inx * 2) = 0;
 	}
 	for (inx = 0; inx < hpsram_ebb_quantity; ++inx) {
 		while (*(status + inx * 8) != 0) {
-			z_idelay(delay_count);
+			z_idelay(DELAY_COUNT);
 		}
 	}
 #endif /* PLATFORM_INIT_HPSRAM */

--- a/soc/xtensa/intel_adsp/ace_v1x/soc.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/soc.c
@@ -19,7 +19,7 @@
 extern void soc_mp_init(void);
 extern void win_setup(void);
 extern void lp_sram_init(void);
-extern void hp_sram_init(uint32_t memory_size);
+extern void hp_sram_init(void);
 extern void parse_manifest(void);
 
 #define DSP_INIT_LPGPDMA(x)		(0x71A60 + (2*x))
@@ -33,15 +33,10 @@ extern void parse_manifest(void);
 
 #define MANIFEST_SEGMENT_COUNT 3
 #define DELAY_COUNT 256
-#define PLATFORM_INIT_HPSRAM
-#define PLATFORM_INIT_LPSRAM
 
-/* function powers up a number of memory banks provided as an argument and
- * gates remaining memory banks
- */
-static __imr void hp_sram_pm_banks(void)
+
+__imr void hp_sram_init(void)
 {
-#ifdef PLATFORM_INIT_HPSRAM
 	uint32_t hpsram_ebb_quantity = mtl_hpsram_get_bank_count();
 	volatile uint32_t *l2hsbpmptr = (volatile uint32_t *)MTL_L2MM->l2hsbpmptr;
 	volatile uint8_t *status = (volatile uint8_t *)l2hsbpmptr + 4;
@@ -55,24 +50,16 @@ static __imr void hp_sram_pm_banks(void)
 			z_idelay(DELAY_COUNT);
 		}
 	}
-#endif /* PLATFORM_INIT_HPSRAM */
-}
-
-__imr void hp_sram_init(uint32_t memory_size)
-{
-	hp_sram_pm_banks();
 }
 
 __imr void lp_sram_init(void)
 {
-#ifdef PLATFORM_INIT_LPSRAM
 	uint32_t lpsram_ebb_quantity = mtl_lpsram_get_bank_count();
 	volatile uint32_t *l2usbpmptr = (volatile uint32_t *)MTL_L2MM->l2usbpmptr;
 
 	for (uint32_t idx = 0; idx < lpsram_ebb_quantity; ++idx) {
 		*(l2usbpmptr + idx * 2) = 0;
 	}
-#endif /* PLATFORM_INIT_LPSRAM */
 }
 
 
@@ -87,7 +74,7 @@ __imr void boot_core0(void)
 
 	cpu_early_init();
 
-	hp_sram_init(L2_SRAM_SIZE);
+	hp_sram_init();
 	win_setup();
 	lp_sram_init();
 	parse_manifest();

--- a/soc/xtensa/intel_adsp/ace_v1x/soc.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/soc.c
@@ -7,14 +7,13 @@
 #include <zephyr/init.h>
 #include <zephyr/irq_nextlevel.h>
 
-#include <xtensa/xtruntime.h>
-#include <xtensa/hal.h>
-
 #include <ace_v1x-regs.h>
 #include <cavs-mem.h>
 #include <cavs-shim.h>
 #include <cpu_init.h>
 #include <soc.h>
+#include <xtensa/hal.h>
+#include <xtensa/xtruntime.h>
 
 extern void soc_mp_init(void);
 extern void win_setup(void);
@@ -22,18 +21,16 @@ extern void lp_sram_init(void);
 extern void hp_sram_init(void);
 extern void parse_manifest(void);
 
-#define DSP_INIT_LPGPDMA(x)		(0x71A60 + (2*x))
-#define LPGPDMA_CTLOSEL_FLAG	BIT(15)
-#define LPGPDMA_CHOSEL_FLAG		0xFF
-
+#define DSP_INIT_LPGPDMA(x)  (0x71A60 + (2 * x))
+#define LPGPDMA_CTLOSEL_FLAG BIT(15)
+#define LPGPDMA_CHOSEL_FLAG  0xFF
 
 #define LPSRAM_MASK(x) 0x00000003
 #define SRAM_BANK_SIZE (64 * 1024)
 #define HOST_PAGE_SIZE 4096
 
 #define MANIFEST_SEGMENT_COUNT 3
-#define DELAY_COUNT 256
-
+#define DELAY_COUNT	       256
 
 __imr void hp_sram_init(void)
 {
@@ -62,14 +59,13 @@ __imr void lp_sram_init(void)
 	}
 }
 
-
 __imr void boot_core0(void)
 {
 	int prid;
 
 	prid = arch_proc_id();
 	if (prid != 0) {
-		((void(*)(void))DFDSPBRCP.bootctl[prid].baddr)();
+		((void (*)(void))DFDSPBRCP.bootctl[prid].baddr)();
 	}
 
 	cpu_early_init();

--- a/soc/xtensa/intel_adsp/ace_v1x/soc.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/soc.c
@@ -45,13 +45,13 @@ static __imr void hp_sram_pm_banks(void)
 	uint32_t hpsram_ebb_quantity = mtl_hpsram_get_bank_count();
 	volatile uint32_t *l2hsbpmptr = (volatile uint32_t *)MTL_L2MM->l2hsbpmptr;
 	volatile uint8_t *status = (volatile uint8_t *)l2hsbpmptr + 4;
-	int inx;
+	int idx;
 
-	for (inx = 0; inx < hpsram_ebb_quantity; ++inx) {
-		*(l2hsbpmptr + inx * 2) = 0;
+	for (idx = 0; idx < hpsram_ebb_quantity; ++idx) {
+		*(l2hsbpmptr + idx * 2) = 0;
 	}
-	for (inx = 0; inx < hpsram_ebb_quantity; ++inx) {
-		while (*(status + inx * 8) != 0) {
+	for (idx = 0; idx < hpsram_ebb_quantity; ++idx) {
+		while (*(status + idx * 8) != 0) {
 			z_idelay(DELAY_COUNT);
 		}
 	}
@@ -69,8 +69,8 @@ __imr void lp_sram_init(void)
 	uint32_t lpsram_ebb_quantity = mtl_lpsram_get_bank_count();
 	volatile uint32_t *l2usbpmptr = (volatile uint32_t *)MTL_L2MM->l2usbpmptr;
 
-	for (uint32_t inx = 0; inx < lpsram_ebb_quantity; ++inx) {
-		*(l2usbpmptr + inx * 2) = 0;
+	for (uint32_t idx = 0; idx < lpsram_ebb_quantity; ++idx) {
+		*(l2usbpmptr + idx * 2) = 0;
 	}
 #endif /* PLATFORM_INIT_LPSRAM */
 }

--- a/soc/xtensa/intel_adsp/cavs_v15/fw_defs.h
+++ b/soc/xtensa/intel_adsp/cavs_v15/fw_defs.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADSP_PLATFORM_DEFS_H
+#define ADSP_PLATFORM_DEFS_H
+
+#define ADSP_L1_CACHE_PREFCTL_VALUE 0
+
+#endif

--- a/soc/xtensa/intel_adsp/cavs_v18/fw_defs.h
+++ b/soc/xtensa/intel_adsp/cavs_v18/fw_defs.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADSP_PLATFORM_DEFS_H
+#define ADSP_PLATFORM_DEFS_H
+
+#define ADSP_L1_CACHE_PREFCTL_VALUE 0
+
+#endif

--- a/soc/xtensa/intel_adsp/cavs_v20/fw_defs.h
+++ b/soc/xtensa/intel_adsp/cavs_v20/fw_defs.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADSP_PLATFORM_DEFS_H
+#define ADSP_PLATFORM_DEFS_H
+
+#define ADSP_L1_CACHE_PREFCTL_VALUE 0
+
+#endif

--- a/soc/xtensa/intel_adsp/cavs_v25/fw_defs.h
+++ b/soc/xtensa/intel_adsp/cavs_v25/fw_defs.h
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ADSP_PLATFORM_DEFS_H
+#define ADSP_PLATFORM_DEFS_H
+
+#define ADSP_L1_CACHE_PREFCTL_VALUE 0x1038
+
+#endif

--- a/soc/xtensa/intel_adsp/common/include/cpu_init.h
+++ b/soc/xtensa/intel_adsp/common/include/cpu_init.h
@@ -6,6 +6,7 @@
 
 #include <zephyr/arch/xtensa/cache.h>
 #include <xtensa/config/core-isa.h>
+#include <fw_defs.h>
 
 #define CxL1CCAP (*(volatile uint32_t *)0x9F080080)
 #define CxL1CCFG (*(volatile uint32_t *)0x9F080084)
@@ -61,7 +62,7 @@ static ALWAYS_INLINE void cpu_early_init(void)
 	 * SOF for now.  If we care about prefetch priority tuning
 	 * we're supposed to ask Cadence I guess.
 	 */
-	reg = IS_ENABLED(CONFIG_SOC_SERIES_INTEL_CAVS_V25) ? 0x1038 : 0;
+	reg = ADSP_L1_CACHE_PREFCTL_VALUE;
 	__asm__ volatile("wsr %0, PREFCTL; rsync" :: "r"(reg));
 
 	/* Finally we need to enable the cache in the Region

--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -57,9 +57,6 @@
 #define DSP_WCT_CS_TA(x)			BIT(x)
 #define DSP_WCT_CS_TT(x)			BIT(4 + x)
 
-/* Attribute macros to place code and data into IMR memory */
-#define __imr __in_section_unique(imr)
-#define __imrdata __in_section_unique(imrdata)
 
 extern char _text_start[];
 extern char _text_end[];


### PR DESCRIPTION
- intel_adsp: ace: convert delay count into a define
- intel_adsp: ace: rename inx -> idx
- intel_adsp: ace: simplify and cleanup sram init functions
- intel_adsp: ace: run soc.c through clang-format
- intel_adsp: add a header for soc specific defines
- intel_adsp: move attribute macros to dedicated linker header
