### PR TITLE
test: Ignore the format-zero-length for sprintf

### DIFF
--- a/tests/lib/sprintf/CMakeLists.txt
+++ b/tests/lib/sprintf/CMakeLists.txt
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 cmake_minimum_required(VERSION 3.20.0)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-zero-length")
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(sprintf)
 


### PR DESCRIPTION
As printf("") will trigger a warning of format-zero-length in
build stage, and warning is treated as error by default. This
test case is failed to build. In order to test this, -Wno-format
-zero-length is added for this test case, to make it run.

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>