### PR TITLE
tests: logging: disable logging stack test

### DIFF
--- a/tests/subsys/logging/log_stack/testcase.yaml
+++ b/tests/subsys/logging/log_stack/testcase.yaml
@@ -2,6 +2,7 @@ common:
   platform_type:
     - qemu
   tags: log_api logging
+  skip: true
   integration_platforms:
     - qemu_x86
 tests:


### PR DESCRIPTION
This test keeps breaking whenever something in kernel or
architecture code changes. If we are to track footprint and stack, it
should be done in some other way.
The value of the test deminished if we have to change the boundaries
every second day.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
