### PR TITLE
tests: arch: fix arm_thread_swap on stm32 platform

### DIFF
--- a/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
+++ b/tests/arch/arm/arm_thread_swap/src/arm_syscalls.c
@@ -114,6 +114,7 @@ void arm_isr_handler(const void *args)
 		zassert_true(__get_MSPLIM() == (uint32_t)z_interrupt_stacks,
 		"MSPLIM not guarding the interrupt stack\n");
 #endif
+		NVIC_DisableIRQ((uint32_t)args);
 	}
 }
 
@@ -212,7 +213,7 @@ ZTEST(arm_thread_swap, test_arm_syscalls)
 
 	arch_irq_connect_dynamic(i, 0 /* highest priority */,
 		arm_isr_handler,
-		NULL,
+		(uint32_t *)i,
 		0);
 
 	NVIC_ClearPendingIRQ(i);


### PR DESCRIPTION
The test fails on several stm32 platforms, due to the
correlation between test_arm_syscalls and
test_arm_thread_swap, so disable the corresponding IRQ
interrupt may fix it.

Signed-off-by: Shaoan Li <shaoanx.li@intel.com>

Fixes: #47696