### PR TITLE
maintainers: Add ceolin as xtensa collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1686,6 +1686,7 @@ Intel Platforms (Xtensa):
     files:
         - boards/xtensa/intel_*/
         - soc/xtensa/intel_*/
+        - dts/xtensa/intel/
     labels:
         - "platform: Intel CAVS"
 

--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1682,6 +1682,7 @@ Intel Platforms (Xtensa):
         - marc-hb
         - kv2019i
         - MaureenHelm
+        - ceolin
     files:
         - boards/xtensa/intel_*/
         - soc/xtensa/intel_*/


### PR DESCRIPTION
Add myself as collaborator of Intel xtensa platforms.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>