### PR TITLE
it8xxx2_evb: exclude it8xxx2_evb for kernel.scheduler.slice_perthread

### DIFF
--- a/tests/kernel/sched/schedule_api/testcase.yaml
+++ b/tests/kernel/sched/schedule_api/testcase.yaml
@@ -18,6 +18,7 @@ tests:
       - CONFIG_TIMESLICING=y
       - CONFIG_TIMESLICE_PER_THREAD=y
     tags: kernel threads sched userspace ignore_faults
+    platform_exclude: it8xxx2_evb
   kernel.scheduler.multiq:
     extra_args: CONF_FILE=prj_multiq.conf
     extra_configs:


### PR DESCRIPTION
it8xxx2_evb does not support CONFIG_TIMESLICE_PER_THREAD=y

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>