### PR TITLE
Fix twister hardware map

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -485,12 +485,10 @@ class DeviceHandler(Handler):
                     elif runner == "intel_adsp":
                         command.append("--pty")
 
-                    # Receive parameters from an runner_params field
-                    # of the specified hardware map file.
-                    for d in self.duts:
-                        if (d.platform == self.instance.platform.name) and d.runner_params:
-                            for param in d.runner_params:
-                                command.append(param)
+                    # Receive parameters from runner_params field.
+                    if hardware.runner_params:
+                        for param in hardware.runner_params:
+                            command.append(param)
 
             if command_extra_args != []:
                 command.append('--')

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -224,6 +224,8 @@ class HardwareMap:
             product = dut.get('product')
             fixtures = dut.get('fixtures', [])
             connected= dut.get('connected') and ((serial or serial_pty) is not None)
+            if not connected:
+                continue
             new_dut = DUT(platform=platform,
                           product=product,
                           runner=runner,


### PR DESCRIPTION
fix runner_params parsing when running twister on multiple same platforms
using hardware map.
also if platform's connected is false in hardware map file, then don't add it
into the available duts pool.

 Signed-off-by: Chen Peng1 <peng1.chen@intel.com>