### PR TITLE
drivers: can: stm32: list one-shot capability

### DIFF
--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -346,7 +346,7 @@ static int can_stm32_get_capabilities(const struct device *dev, can_mode_t *cap)
 {
 	ARG_UNUSED(dev);
 
-	*cap = CAN_MODE_NORMAL | CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY;
+	*cap = CAN_MODE_NORMAL | CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_ONE_SHOT;
 
 	return 0;
 }


### PR DESCRIPTION
List the one-shot capability as supported. PRs  #47708 and #47695 crossed each other, so this flags was not listed as a supported capability in #47695.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>