### PR TITLE
devicetree: Deprecate spi & gpio DT_LABEL based macros

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -52,6 +52,10 @@ Removed APIs in this release
 Deprecated in this release
 ==========================
 
+* :c:macro:`DT_SPI_DEV_CS_GPIOS_LABEL` and
+  :c:macro:`DT_INST_SPI_DEV_CS_GPIOS_LABEL` are deprecated in favor of
+  utilizing :c:macro:`DT_SPI_DEV_CS_GPIOS_CTLR` and variants.
+
 Stable API changes in this release
 ==================================
 

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -56,6 +56,10 @@ Deprecated in this release
   :c:macro:`DT_INST_SPI_DEV_CS_GPIOS_LABEL` are deprecated in favor of
   utilizing :c:macro:`DT_SPI_DEV_CS_GPIOS_CTLR` and variants.
 
+* :c:macro:`DT_GPIO_LABEL`, :c:macro:`DT_INST_GPIO_LABEL`,
+  :c:macro:`DT_GPIO_LABEL_BY_IDX`, and :c:macro:`DT_INST_GPIO_LABEL_BY_IDX`,
+  are deprecated in favor of utilizing :c:macro:`DT_GPIO_CTLR` and variants.
+
 Stable API changes in this release
 ==================================
 

--- a/include/zephyr/devicetree/gpio.h
+++ b/include/zephyr/devicetree/gpio.h
@@ -66,6 +66,9 @@ extern "C" {
 	DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, 0)
 
 /**
+ * @deprecated If used to obtain a device instance with device_get_binding,
+ * consider using @c DEVICE_DT_GET(DT_GPIO_CTLR_BY_IDX(node, gpio_pha, idx)).
+ *
  * @brief Get a label property from a gpio phandle-array property
  *        at an index
  *
@@ -100,9 +103,12 @@ extern "C" {
  * @see DT_PHANDLE_BY_IDX()
  */
 #define DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, idx) \
-	DT_PROP(DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, idx), label)
+	DT_PROP(DT_GPIO_CTLR_BY_IDX(node_id, gpio_pha, idx), label) __DEPRECATED_MACRO
 
 /**
+ * @deprecated If used to obtain a device instance with device_get_binding,
+ * consider using @c DEVICE_DT_GET(DT_GPIO_CTLR(node, gpio_pha)).
+ *
  * @brief Equivalent to DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, 0)
  * @param node_id node identifier
  * @param gpio_pha lowercase-and-underscores GPIO property with
@@ -111,7 +117,7 @@ extern "C" {
  * @see DT_GPIO_LABEL_BY_IDX()
  */
 #define DT_GPIO_LABEL(node_id, gpio_pha) \
-	DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, 0)
+	DT_GPIO_LABEL_BY_IDX(node_id, gpio_pha, 0) __DEPRECATED_MACRO
 
 /**
  * @brief Get a GPIO specifier's pin cell at an index
@@ -225,6 +231,9 @@ extern "C" {
 	DT_GPIO_FLAGS_BY_IDX(node_id, gpio_pha, 0)
 
 /**
+ * @deprecated If used to obtain a device instance with device_get_binding,
+ * consider using @c DEVICE_DT_GET(DT_INST_GPIO_CTLR_BY_IDX(node, gpio_pha, idx)).
+ *
  * @brief Get a label property from a DT_DRV_COMPAT instance's GPIO
  *        property at an index
  * @param inst DT_DRV_COMPAT instance number
@@ -234,9 +243,12 @@ extern "C" {
  * @return the label property of the node referenced at index "idx"
  */
 #define DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, idx) \
-	DT_GPIO_LABEL_BY_IDX(DT_DRV_INST(inst), gpio_pha, idx)
+	DT_GPIO_LABEL_BY_IDX(DT_DRV_INST(inst), gpio_pha, idx) __DEPRECATED_MACRO
 
 /**
+ * @deprecated If used to obtain a device instance with device_get_binding,
+ * consider using @c DEVICE_DT_GET(DT_INST_GPIO_CTLR(node, gpio_pha)).
+ *
  * @brief Equivalent to DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, 0)
  * @param inst DT_DRV_COMPAT instance number
  * @param gpio_pha lowercase-and-underscores GPIO property with
@@ -244,7 +256,7 @@ extern "C" {
  * @return the label property of the node referenced at index 0
  */
 #define DT_INST_GPIO_LABEL(inst, gpio_pha) \
-	DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, 0)
+	DT_INST_GPIO_LABEL_BY_IDX(inst, gpio_pha, 0) __DEPRECATED_MACRO
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's GPIO specifier's pin cell value

--- a/include/zephyr/devicetree/spi.h
+++ b/include/zephyr/devicetree/spi.h
@@ -151,6 +151,9 @@ extern "C" {
 	DT_GPIO_CTLR_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
 
 /**
+ * @deprecated If used to obtain a device instance with device_get_binding,
+ * consider using @c DEVICE_DT_GET(DT_SPI_DEV_CS_GPIOS_CTLR(node)).
+ *
  * @brief Get a SPI device's chip select GPIO controller's label property
  *
  * Example devicetree fragment:
@@ -186,7 +189,7 @@ extern "C" {
  * @return label property of spi_dev's chip select GPIO controller
  */
 #define DT_SPI_DEV_CS_GPIOS_LABEL(spi_dev) \
-	DT_GPIO_LABEL_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev))
+	DT_GPIO_LABEL_BY_IDX(DT_BUS(spi_dev), cs_gpios, DT_REG_ADDR(spi_dev)) __DEPRECATED_MACRO
 
 /**
  * @brief Get a SPI device's chip select GPIO pin number
@@ -270,6 +273,9 @@ extern "C" {
 	DT_SPI_DEV_CS_GPIOS_CTLR(DT_DRV_INST(inst))
 
 /**
+ * @deprecated If used to obtain a device instance with device_get_binding,
+ * consider using @c DEVICE_DT_GET(DT_INST_SPI_DEV_CS_GPIOS_CTLR(node)).
+ *
  * @brief Get GPIO controller name for a SPI device instance
  * This is equivalent to DT_SPI_DEV_CS_GPIOS_LABEL(DT_DRV_INST(inst)).
  * @param inst DT_DRV_COMPAT instance number
@@ -277,7 +283,7 @@ extern "C" {
  * @see DT_SPI_DEV_CS_GPIOS_LABEL()
  */
 #define DT_INST_SPI_DEV_CS_GPIOS_LABEL(inst) \
-	DT_SPI_DEV_CS_GPIOS_LABEL(DT_DRV_INST(inst))
+	DT_SPI_DEV_CS_GPIOS_LABEL(DT_DRV_INST(inst)) __DEPRECATED_MACRO
 
 /**
  * @brief Equivalent to DT_SPI_DEV_CS_GPIOS_PIN(DT_DRV_INST(inst)).

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/* Override __DEPRECATED_MACRO so we don't get twister failures for
+ * deprecated macros:
+ * - DT_SPI_DEV_CS_GPIOS_LABEL
+ * - DT_INST_SPI_DEV_CS_GPIOS_LABEL
+ */
+#define __DEPRECATED_MACRO
+
 #include <ztest.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/device.h>

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -7,7 +7,11 @@
 /* Override __DEPRECATED_MACRO so we don't get twister failures for
  * deprecated macros:
  * - DT_SPI_DEV_CS_GPIOS_LABEL
+ * - DT_GPIO_LABEL
+ * - DT_GPIO_LABEL_BY_IDX
  * - DT_INST_SPI_DEV_CS_GPIOS_LABEL
+ * - DT_INST_GPIO_LABEL
+ * - DT_INST_GPIO_LABEL_BY_IDX
  */
 #define __DEPRECATED_MACRO
 


### PR DESCRIPTION
As all users of DT_LABEL based gpio access have been converted to use gpio_dt_spec or DEVICE_DT_GET we can deprecate the macros associated with GPIO label access.