### PR TITLE
drivers: lora: Add support for setting sync-word (public/private network) and iq-inverted in lora_modem_config

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -316,14 +316,16 @@ int sx12xx_lora_config(const struct device *dev,
 		Radio.SetTxConfig(MODEM_LORA, config->tx_power, 0,
 				  config->bandwidth, config->datarate,
 				  config->coding_rate, config->preamble_len,
-				  false, true, 0, 0, false, 4000);
+				  false, true, 0, 0, config->iq_inverted, 4000);
 	} else {
 		/* TODO: Get symbol timeout value from config parameters */
 		Radio.SetRxConfig(MODEM_LORA, config->bandwidth,
 				  config->datarate, config->coding_rate,
 				  0, config->preamble_len, 10, false, 0,
-				  false, 0, 0, false, true);
+				  false, 0, 0, config->iq_inverted, true);
 	}
+
+	Radio.SetPublicNetwork(config->public_network);
 
 	modem_release(&dev_data);
 	return 0;

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -66,6 +66,26 @@ struct lora_modem_config {
 
 	/* Set to true for transmission, false for receiving */
 	bool tx;
+
+	/**
+	 * Invert the In-Phase and Quadrature (IQ) signals. Normally this
+	 * should be set to false. In advanced use-cases where a
+	 * differentation is needed between "uplink" and "downlink" traffic,
+	 * the IQ can be inverted to create two different channels on the
+	 * same frequency
+	 */
+	bool iq_inverted;
+
+	/**
+	 * Sets the sync-byte to use:
+	 *  - false: for using the private network sync-byte
+	 *  - true:  for using the public network sync-byte
+	 * The public network sync-byte is only intended for advanced usage.
+	 * Normally the private network sync-byte should be used for peer
+	 * to peer communications and the LoRaWAN APIs should be used for
+	 * interacting with a public network.
+	 */
+	bool public_network;
 };
 
 /**

--- a/include/zephyr/drivers/lora.h
+++ b/include/zephyr/drivers/lora.h
@@ -46,12 +46,25 @@ enum lora_coding_rate {
 };
 
 struct lora_modem_config {
+	/* Frequency in Hz to use for transceiving */
 	uint32_t frequency;
+
+	/* The bandwidth to use for transceiving */
 	enum lora_signal_bandwidth bandwidth;
+
+	/* The data-rate to use for transceiving */
 	enum lora_datarate datarate;
+
+	/* The coding rate to use for transceiving */
 	enum lora_coding_rate coding_rate;
+
+	/* Length of the preamble */
 	uint16_t preamble_len;
+
+	/* TX-power in dBm to use for transmission */
 	int8_t tx_power;
+
+	/* Set to true for transmission, false for receiving */
 	bool tx;
 };
 

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -57,6 +57,8 @@ void main(void)
 	config.datarate = SF_10;
 	config.preamble_len = 8;
 	config.coding_rate = CR_4_5;
+	config.iq_inverted = false;
+	config.public_network = false;
 	config.tx_power = 14;
 	config.tx = false;
 

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -38,6 +38,8 @@ void main(void)
 	config.datarate = SF_10;
 	config.preamble_len = 8;
 	config.coding_rate = CR_4_5;
+	config.iq_inverted = false;
+	config.public_network = false;
 	config.tx_power = 4;
 	config.tx = true;
 


### PR DESCRIPTION
Some use-cases of sending LoRa packets require sending with the public-network sync-word and/or with iq-inverted.
Additionally document the lora_modem_config struct.

Signed-off-by: Tim Cooijmans <timcooijmans@gmail.com>