### PR TITLE
ARC: MWDT: add missing options to generate symbol file

### DIFF
--- a/cmake/bintools/arcmwdt/target_bintools.cmake
+++ b/cmake/bintools/arcmwdt/target_bintools.cmake
@@ -101,3 +101,11 @@ set_property(TARGET bintools PROPERTY strip_flag_debug -ql)
 
 set_property(TARGET bintools PROPERTY strip_flag_infile "")
 set_property(TARGET bintools PROPERTY strip_flag_outfile -o )
+
+# list symbols in a binary
+set_property(TARGET bintools PROPERTY symbols_command ${CMAKE_NM})
+# flags are set to be as close to gnu nm format as possible
+set_property(TARGET bintools PROPERTY symbols_flag "-xhpqgn")
+set_property(TARGET bintools PROPERTY symbols_final "")
+set_property(TARGET bintools PROPERTY symbols_infile "")
+set_property(TARGET bintools PROPERTY symbols_outfile ">;" )


### PR DESCRIPTION
Fix for #47353 where we add and enable symbol generation, but miss to add proper options for ARCMWDT toolchain.