### PR TITLE
drivers: can: add triple sampling mode flag

### DIFF
--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -183,7 +183,7 @@ static int mcux_flexcan_get_capabilities(const struct device *dev, can_mode_t *c
 {
 	ARG_UNUSED(dev);
 
-	*cap = CAN_MODE_NORMAL | CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY;
+	*cap = CAN_MODE_NORMAL | CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_3_SAMPLES;
 
 	return 0;
 }
@@ -195,7 +195,7 @@ static int mcux_flexcan_set_mode(const struct device *dev, can_mode_t mode)
 	uint32_t mcr;
 	int err;
 
-	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY)) != 0) {
+	if ((mode & ~(CAN_MODE_LOOPBACK | CAN_MODE_LISTENONLY | CAN_MODE_3_SAMPLES)) != 0) {
 		LOG_ERR("unsupported mode: 0x%08x", mode);
 		return -ENOTSUP;
 	}
@@ -229,6 +229,14 @@ static int mcux_flexcan_set_mode(const struct device *dev, can_mode_t mode)
 	} else {
 		/* Disable listen-only mode */
 		ctrl1 &= ~(CAN_CTRL1_LOM_MASK);
+	}
+
+	if ((mode & CAN_MODE_3_SAMPLES) != 0) {
+		/* Enable triple sampling mode */
+		ctrl1 |= CAN_CTRL1_SMP_MASK;
+	} else {
+		/* Disable triple sampling mode */
+		ctrl1 &= ~(CAN_CTRL1_SMP_MASK);
 	}
 
 	config->base->CTRL1 = ctrl1;

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -21,7 +21,7 @@ static struct k_poll_event msgq_events[1] = {
 
 static inline int read_config_options(const struct shell *sh, int pos,
 				      char **argv, bool *listenonly, bool *loopback,
-				      bool *oneshot)
+				      bool *oneshot, bool *triple)
 {
 	char *arg = argv[pos];
 
@@ -50,6 +50,13 @@ static inline int read_config_options(const struct shell *sh, int pos,
 				shell_error(sh, "Unknown option %c", *arg);
 			} else {
 				*oneshot = true;
+			}
+			break;
+		case 't':
+			if (triple == NULL) {
+				shell_error(sh, "Unknown option %c", *arg);
+			} else {
+				*triple = true;
 			}
 			break;
 		default:
@@ -242,6 +249,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 	bool listenonly = false;
 	bool loopback = false;
 	bool oneshot = false;
+	bool triple = false;
 	can_mode_t mode = CAN_MODE_NORMAL;
 	uint32_t bitrate;
 	int ret;
@@ -255,7 +263,7 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 
 	pos++;
 
-	pos = read_config_options(sh, pos, argv, &listenonly, &loopback, &oneshot);
+	pos = read_config_options(sh, pos, argv, &listenonly, &loopback, &oneshot, &triple);
 	if (pos < 0) {
 		return -EINVAL;
 	}
@@ -270,6 +278,10 @@ static int cmd_config(const struct shell *sh, size_t argc, char **argv)
 
 	if (oneshot) {
 		mode |= CAN_MODE_ONE_SHOT;
+	}
+
+	if (triple) {
+		mode |= CAN_MODE_3_SAMPLES;
 	}
 
 	ret = can_set_mode(can_dev, mode);
@@ -461,7 +473,8 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_can,
 		      " Usage: config device_name [-slo] bitrate\n"
 		      " -s Listen-only mode\n"
 		      " -l Loopback mode\n"
-		      " -o One-shot mode",
+		      " -o One-shot mode\n"
+		      " -t Triple sampling mode",
 		      cmd_config, 3, 1),
 	SHELL_CMD_ARG(send, NULL,
 		      "Send a CAN frame.\n"

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -100,6 +100,9 @@ extern "C" {
 /** Controller does not retransmit in case of lost arbitration or missing ACK */
 #define CAN_MODE_ONE_SHOT   BIT(3)
 
+/** Controller uses triple sampling mode */
+#define CAN_MODE_3_SAMPLES  BIT(4)
+
 /** @} */
 
 /**


### PR DESCRIPTION
- Add flag for enabling triple sampling of the CAN RX signal. Normally just one sample of the RX signal is performed by the CAN controller, but in triple sampling mode the RX signal is sampled three times. These three samples are then used for determining the value of the received bit, typically by majority vote.
- Add support for setting triple sampling mode in the CAN shell module.
- Add support for triple sampling mode to the NXP FlexCAN driver.
