### PR TITLE
tests: posix: eventfd: make min_ram a common test parameter

### DIFF
--- a/tests/posix/eventfd/testcase.yaml
+++ b/tests/posix/eventfd/testcase.yaml
@@ -5,6 +5,7 @@ tests:
   portability.posix.eventfd:
     min_ram: 32
   portability.posix.eventfd.newlib:
+    min_ram: 32
     filter: TOOLCHAIN_HAS_NEWLIB == 1
     extra_configs:
       - CONFIG_NEWLIB_LIBC=y


### PR DESCRIPTION
Some platforms with insufficient ram were incorrectly included in this test since #47288.

Fixes #47734
