### PR TITLE
subsys:ipc:ipc_service: Add endpoint registered check

### DIFF
--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -230,6 +230,7 @@ int ipc_service_register_endpoint(const struct device *instance,
  *  @retval -EIO when no backend is registered or send hook is missing from
  *               backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
  *  @retval -EBADMSG when the data is invalid (i.e. invalid data format,
  *		     invalid length, ...)
  *  @retval -EBUSY when the instance is busy.
@@ -250,6 +251,7 @@ int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len);
  *  @retval -EIO when no backend is registered or send hook is missing from
  *		 backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
  *  @retval -ENOTSUP when the operation is not supported by backend.
  *
  *  @retval size TX buffer size on success.
@@ -294,6 +296,7 @@ int ipc_service_get_tx_buffer_size(struct ipc_ept *ept);
  *  @retval -EIO when no backend is registered or send hook is missing from
  *		 backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
  *  @retval -ENOTSUP when the operation or the timeout is not supported by backend.
  *  @retval -ENOBUFS when there are no TX buffers available.
  *  @retval -EALREADY when a buffer was already claimed and not yet released.
@@ -316,6 +319,7 @@ int ipc_service_get_tx_buffer(struct ipc_ept *ept, void **data, uint32_t *size, 
  *  @retval -EIO when no backend is registered or send hook is missing from
  *		 backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
  *  @retval -ENOTSUP when this is not supported by backend.
  *  @retval -EALREADY when the buffer was already dropped.
  *  @retval -ENXIO when the buffer was not obtained using @ref
@@ -350,6 +354,7 @@ int ipc_service_drop_tx_buffer(struct ipc_ept *ept, const void *data);
  *  @retval -EIO when no backend is registered or send hook is missing from
  *		 backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
  *  @retval -EBADMSG when the data is invalid (i.e. invalid data format,
  *		     invalid length, ...)
  *  @retval -EBUSY when the instance is busy.
@@ -375,6 +380,7 @@ int ipc_service_send_nocopy(struct ipc_ept *ept, const void *data, size_t len);
  *  @retval -EIO when no backend is registered or release hook is missing from
  *		 backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
  *  @retval -EALREADY when the buffer data has been hold already.
  *  @retval -ENOTSUP when this is not supported by backend.
  *
@@ -398,6 +404,7 @@ int ipc_service_hold_rx_buffer(struct ipc_ept *ept, void *data);
  *  @retval -EIO when no backend is registered or release hook is missing from
  *		 backend.
  *  @retval -EINVAL when instance or endpoint is invalid.
+ *  @retval -ENOENT when the endpoint is not registered with the instance.
  *  @retval -EALREADY when the buffer data has been already released.
  *  @retval -ENOTSUP when this is not supported by backend.
  *  @retval -ENXIO when the buffer was not hold before using @ref

--- a/include/zephyr/ipc/ipc_service_backend.h
+++ b/include/zephyr/ipc/ipc_service_backend.h
@@ -45,6 +45,7 @@ struct ipc_service_backend {
 	 *  @param[in] len Number of bytes to send.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
 	 *  @retval -EBADMSG when the message is invalid.
 	 *  @retval -EBUSY when the instance is busy or not ready.
 	 *  @retval -ENOMEM when no memory / buffers are available.
@@ -79,6 +80,7 @@ struct ipc_service_backend {
 	 *  @param[in] token Backend-specific token.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
 	 *  @retval -ENOTSUP when the operation is not supported.
 	 *
 	 *  @retval size TX buffer size on success.
@@ -96,6 +98,7 @@ struct ipc_service_backend {
 	 *  @param[in] wait Timeout waiting for an available TX buffer.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
 	 *  @retval -ENOTSUP when the operation or the timeout is not supported.
 	 *  @retval -ENOBUFS when there are no TX buffers available.
 	 *  @retval -EALREADY when a buffer was already claimed and not yet released.
@@ -116,6 +119,7 @@ struct ipc_service_backend {
 	 *  @param[in] data Pointer to the TX buffer.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
 	 *  @retval -ENOTSUP when this function is not supported.
 	 *  @retval -EALREADY when the buffer was already dropped.
 	 *
@@ -136,6 +140,7 @@ struct ipc_service_backend {
 	 *  @param[in] len Number of bytes to send.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
 	 *  @retval -EBADMSG when the data is invalid (i.e. invalid data format,
 	 *		     invalid length, ...)
 	 *  @retval -EBUSY when the instance is busy or not ready.
@@ -154,6 +159,7 @@ struct ipc_service_backend {
 	 *  @param[in] data Pointer to the RX buffer to hold.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
 	 *  @retval -EALREADY when the buffer data has been already hold.
 	 *  @retval -ENOTSUP when this function is not supported.
 	 *
@@ -171,6 +177,7 @@ struct ipc_service_backend {
 	 *  @param[in] data Pointer to the RX buffer to release.
 	 *
 	 *  @retval -EINVAL when instance is invalid.
+	 *  @retval -ENOENT when the endpoint is not registered with the instance.
 	 *  @retval -EALREADY when the buffer data has been already released.
 	 *  @retval -ENOTSUP when this function is not supported.
 	 *

--- a/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
+++ b/subsys/ipc/ipc_service/backends/ipc_rpmsg_static_vrings.c
@@ -413,6 +413,11 @@ static int send(const struct device *instance, void *token,
 
 	rpmsg_ept = (struct ipc_rpmsg_ept *) token;
 
+	/* Endpoint is not registered with instance */
+	if (!rpmsg_ept) {
+		return -ENOENT;
+	}
+
 	ret = rpmsg_send(&rpmsg_ept->ep, msg, len);
 
 	/* No buffers available */
@@ -440,6 +445,11 @@ static int send_nocopy(const struct device *instance, void *token,
 	}
 
 	rpmsg_ept = (struct ipc_rpmsg_ept *) token;
+
+	/* Endpoint is not registered with instance */
+	if (!rpmsg_ept) {
+		return -ENOENT;
+	}
 
 	return rpmsg_send_nocopy(&rpmsg_ept->ep, msg, len);
 }
@@ -521,6 +531,11 @@ static int get_tx_buffer(const struct device *instance, void *token,
 
 	rpmsg_ept = (struct ipc_rpmsg_ept *) token;
 
+	/* Endpoint is not registered with instance */
+	if (!rpmsg_ept) {
+		return -ENOENT;
+	}
+
 	if (!r_data || !size) {
 		return -EINVAL;
 	}
@@ -563,6 +578,11 @@ static int hold_rx_buffer(const struct device *instance, void *token,
 
 	rpmsg_ept = (struct ipc_rpmsg_ept *) token;
 
+	/* Endpoint is not registered with instance */
+	if (!rpmsg_ept) {
+		return -ENOENT;
+	}
+
 	rpmsg_hold_rx_buffer(&rpmsg_ept->ep, data);
 
 	return 0;
@@ -574,6 +594,11 @@ static int release_rx_buffer(const struct device *instance, void *token,
 	struct ipc_rpmsg_ept *rpmsg_ept;
 
 	rpmsg_ept = (struct ipc_rpmsg_ept *) token;
+
+	/* Endpoint is not registered with instance */
+	if (!rpmsg_ept) {
+		return -ENOENT;
+	}
 
 	rpmsg_release_rx_buffer(&rpmsg_ept->ep, data);
 

--- a/subsys/ipc/ipc_service/ipc_service.c
+++ b/subsys/ipc/ipc_service/ipc_service.c
@@ -72,6 +72,11 @@ int ipc_service_send(struct ipc_ept *ept, const void *data, size_t len)
 		return -EINVAL;
 	}
 
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
+	}
+
 	backend = ept->instance->api;
 
 	if (!backend || !backend->send) {
@@ -89,6 +94,11 @@ int ipc_service_get_tx_buffer_size(struct ipc_ept *ept)
 	if (!ept) {
 		LOG_ERR("Invalid endpoint");
 		return -EINVAL;
+	}
+
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
 	}
 
 	backend = ept->instance->api;
@@ -115,6 +125,11 @@ int ipc_service_get_tx_buffer(struct ipc_ept *ept, void **data, uint32_t *len, k
 		return -EINVAL;
 	}
 
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
+	}
+
 	backend = ept->instance->api;
 
 	if (!backend) {
@@ -137,6 +152,11 @@ int ipc_service_drop_tx_buffer(struct ipc_ept *ept, const void *data)
 	if (!ept || !data) {
 		LOG_ERR("Invalid endpoint or data pointer");
 		return -EINVAL;
+	}
+
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
 	}
 
 	backend = ept->instance->api;
@@ -163,6 +183,11 @@ int ipc_service_send_nocopy(struct ipc_ept *ept, const void *data, size_t len)
 		return -EINVAL;
 	}
 
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
+	}
+
 	backend = ept->instance->api;
 
 	if (!backend) {
@@ -187,6 +212,11 @@ int ipc_service_hold_rx_buffer(struct ipc_ept *ept, void *data)
 		return -EINVAL;
 	}
 
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
+	}
+
 	backend = ept->instance->api;
 
 	if (!backend) {
@@ -209,6 +239,11 @@ int ipc_service_release_rx_buffer(struct ipc_ept *ept, void *data)
 	if (!ept) {
 		LOG_ERR("Invalid endpoint");
 		return -EINVAL;
+	}
+
+	if (!ept->instance) {
+		LOG_ERR("Endpoint not registered\n");
+		return -ENOENT;
 	}
 
 	backend = ept->instance->api;


### PR DESCRIPTION
Currently, it is possible to call various ipc_service functions
which take in an endpoint pointer (such as send, get_tx_buffer)
with an endpoint which has not been registered with the instance.
This leads to dereferencing a NULL pointer when the function tries
to access the api field of ept->instance.
This patch adds in multiple checks to ensure that the endpoint is
registered before continuing, one in the frontend, when ensures
that the ept->instance pointer is not NULL and one in the backend
which checks the value of the token pointer. If either of these fail,
we return -ENOENT.

Signed-off-by: Jackson Cooper-Driver <jackson.cooper---driver@amd.com>