### PR TITLE
samples: drivers: adc: fixup sam0 samples

### DIFF
--- a/samples/drivers/adc/boards/atsamd21_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamd21_xpro.overlay
@@ -23,5 +23,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
+		zephyr,input-positive = <8>;
 	};
 };

--- a/samples/drivers/adc/boards/atsame54_xpro.overlay
+++ b/samples/drivers/adc/boards/atsame54_xpro.overlay
@@ -23,5 +23,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
+		zephyr,input-positive = <6>;
 	};
 };

--- a/samples/drivers/adc/boards/atsamr21_xpro.overlay
+++ b/samples/drivers/adc/boards/atsamr21_xpro.overlay
@@ -23,5 +23,6 @@
 		zephyr,reference = "ADC_REF_INTERNAL";
 		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
 		zephyr,resolution = <12>;
+		zephyr,input-positive = <6>;
 	};
 };


### PR DESCRIPTION
The sam0 ADC driver has ADC_CONFIGURABLE_INPUTS enabled, which means that the device tree ADC nodes must include the `zephyr,input-positive` property.

The `samples/drivers/adc` sample does not build for the following boards without this patch:
- `atsamd21_xpro`
- `atsame54_xpro`
- `atsamr21_xpro`

**NOTE:** I do not have these boards, so have not been able to test the patch, please could someone verify?