### PR TITLE
drivers: crypto: ataes132a: Convert to devicetree

### DIFF
--- a/drivers/crypto/Kconfig.ataes132a
+++ b/drivers/crypto/Kconfig.ataes132a
@@ -11,24 +11,6 @@ menuconfig CRYPTO_ATAES132A
 
 if CRYPTO_ATAES132A
 
-config CRYPTO_ATAES132A_DRV_NAME
-	string "Driver's name"
-	default "ataes132a"
-	help
-	  Name for the ATAES132A driver which will be used for binding.
-
-config CRYPTO_ATAES132A_I2C_PORT_NAME
-	string "I2C master controller port name"
-	default "I2C_0"
-	help
-	  Master I2C port name through which ATAES132A chip is accessed.
-
-config CRYPTO_ATAES132A_I2C_ADDR
-	hex "ATAES132A I2C address"
-	default 0x50
-	help
-	  ATAES132A chip's I2C address.
-
 choice
 	prompt "ATAES132A I2C bus speed"
 	default CRYPTO_ATAES132A_I2C_SPEED_STANDARD

--- a/drivers/crypto/crypto_ataes132a_priv.h
+++ b/drivers/crypto/crypto_ataes132a_priv.h
@@ -136,11 +136,10 @@ void ataes132a_atmel_crc(uint8_t *input, uint8_t length,
 	*(uint16_t *)output = crc << 8 | crc >> 8;
 }
 
-static inline int burst_write_i2c(const struct device *dev, uint16_t dev_addr,
+static inline int burst_write_i2c(const struct i2c_dt_spec *spec,
 				  uint16_t start_addr, uint8_t *buf,
 				  uint8_t num_bytes)
 {
-	const struct i2c_driver_api *api = dev->api;
 	uint8_t addr_buffer[2];
 	struct i2c_msg msg[2];
 
@@ -154,15 +153,14 @@ static inline int burst_write_i2c(const struct device *dev, uint16_t dev_addr,
 	msg[1].len = num_bytes;
 	msg[1].flags = I2C_MSG_WRITE | I2C_MSG_STOP;
 
-	return api->transfer(dev, msg, 2, dev_addr);
+	return i2c_transfer_dt(spec, msg, 2);
 }
 
 
-static inline int burst_read_i2c(const struct device *dev, uint16_t dev_addr,
+static inline int burst_read_i2c(const struct i2c_dt_spec *spec,
 				 uint16_t start_addr, uint8_t *buf,
 				 uint8_t num_bytes)
 {
-	const struct i2c_driver_api *api = dev->api;
 	uint8_t addr_buffer[2];
 	struct i2c_msg msg[2];
 
@@ -176,25 +174,23 @@ static inline int burst_read_i2c(const struct device *dev, uint16_t dev_addr,
 	msg[1].len = num_bytes;
 	msg[1].flags = I2C_MSG_RESTART | I2C_MSG_READ | I2C_MSG_STOP;
 
-	return api->transfer(dev, msg, 2, dev_addr);
+	return i2c_transfer_dt(spec, msg, 2);
 }
 
-static inline int read_reg_i2c(const struct device *dev, uint16_t dev_addr,
+static inline int read_reg_i2c(const struct i2c_dt_spec *spec,
 			       uint16_t reg_addr, uint8_t *value)
 {
-	return burst_read_i2c(dev, dev_addr, reg_addr, value, 1);
+	return burst_read_i2c(spec, reg_addr, value, 1);
 }
 
-static inline int write_reg_i2c(const struct device *dev, uint16_t dev_addr,
+static inline int write_reg_i2c(const struct i2c_dt_spec *spec,
 				uint16_t reg_addr, uint8_t value)
 {
-	return burst_write_i2c(dev, dev_addr, reg_addr, &value, 1);
+	return burst_write_i2c(spec, reg_addr, &value, 1);
 }
 
 struct ataes132a_device_config {
-	const char *i2c_port;
-	uint16_t i2c_addr;
-	uint8_t i2c_speed;
+	struct i2c_dt_spec i2c;
 };
 
 struct ataes132a_device_data {

--- a/dts/bindings/crypto/atmel,ataes132a.yaml
+++ b/dts/bindings/crypto/atmel,ataes132a.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2022, Kumar Gala <galak@kernel.org>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel ATAES132A 32K AES Serial EEPROM
+
+compatible: "atmel,ataes132a"
+
+include: [i2c-device.yaml]


### PR DESCRIPTION
Move driver to be devicetree based and use struct i2c_dt_spec.

Signed-off-by: Kumar Gala <galak@kernel.org>