### PR TITLE
drivers: can: mcux: mcan: add pinctrl support

### DIFF
--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -7,6 +7,9 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/can.h>
 #include <zephyr/drivers/clock_control.h>
+#ifdef CONFIG_PINCTRL
+#include <zephyr/drivers/pinctrl.h>
+#endif
 #include <zephyr/logging/log.h>
 
 #include "can_mcan.h"
@@ -19,6 +22,9 @@ struct mcux_mcan_config {
 	const struct device *clock_dev;
 	clock_control_subsys_t clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
+#ifdef CONFIG_PINCTRL
+	const struct pinctrl_dev_config *pincfg;
+#endif
 };
 
 struct mcux_mcan_data {
@@ -39,6 +45,13 @@ static int mcux_mcan_init(const struct device *dev)
 	const struct can_mcan_config *mcan_config = dev->config;
 	const struct mcux_mcan_config *mcux_config = mcan_config->custom;
 	int err;
+
+#ifdef CONFIG_PINCTRL
+	err = pinctrl_apply_state(mcux_config->pincfg, PINCTRL_STATE_DEFAULT);
+	if (err) {
+		return err;
+	}
+#endif /* CONFIG_PINCTRL */
 
 	err = clock_control_on(mcux_config->clock_dev, mcux_config->clock_subsys);
 	if (err) {
@@ -121,7 +134,17 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 #endif /* CONFIG_CAN_FD_MODE */
 };
 
+#ifdef CONFIG_PINCTRL
+#define MCUX_MCAN_PINCTRL_DEFINE(n) PINCTRL_DT_INST_DEFINE(n)
+#define MCUX_MCAN_PINCTRL_INIT(n) .pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),
+#else
+#define MCUX_MCAN_PINCTRL_DEFINE(n)
+#define MCUX_MCAN_PINCTRL_INIT(n)
+#endif
+
 #define MCUX_MCAN_INIT(n)						\
+	MCUX_MCAN_PINCTRL_DEFINE(n);					\
+									\
 	static void mcux_mcan_irq_config_##n(const struct device *dev); \
 									\
 	static const struct mcux_mcan_config mcux_mcan_config_##n = {	\
@@ -129,6 +152,7 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 		.clock_subsys = (clock_control_subsys_t)		\
 			DT_INST_CLOCKS_CELL(n, name),			\
 		.irq_config_func = mcux_mcan_irq_config_##n,		\
+		MCUX_MCAN_PINCTRL_INIT(n)				\
 	};								\
 									\
 	static const struct can_mcan_config can_mcan_config_##n =	\

--- a/dts/bindings/can/nxp,lpc-mcan.yaml
+++ b/dts/bindings/can/nxp,lpc-mcan.yaml
@@ -2,7 +2,7 @@ description: NXP LPC SoC series MCAN CAN-FD controller
 
 compatible: "nxp,lpc-mcan"
 
-include: [can-fd-controller.yaml, "bosch,m_can-base.yaml"]
+include: [can-fd-controller.yaml, "bosch,m_can-base.yaml", pinctrl-device.yaml]
 
 properties:
     reg:


### PR DESCRIPTION
Add pinctrl support to the NXP LPC driver front-end.

Fixes: #47742

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>