### PR TITLE
use unsigned int for irq_lock() key

### DIFF
--- a/arch/x86/core/ia32/irq_manage.c
+++ b/arch/x86/core/ia32/irq_manage.c
@@ -193,7 +193,7 @@ extern const struct pseudo_descriptor z_x86_idt;
 
 static void idt_vector_install(int vector, void *irq_handler)
 {
-	int key;
+	unsigned int key;
 
 	key = irq_lock();
 	z_init_irq_gate(&z_x86_idt.entries[vector], CODE_SEG,

--- a/drivers/clock_control/clock_control_nrf.c
+++ b/drivers/clock_control/clock_control_nrf.c
@@ -126,7 +126,7 @@ static enum clock_control_status get_status(const struct device *dev,
 static int set_off_state(uint32_t *flags, uint32_t ctx)
 {
 	int err = 0;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	uint32_t current_ctx = GET_CTX(*flags);
 
 	if ((current_ctx != 0) && (current_ctx != ctx)) {
@@ -143,7 +143,7 @@ static int set_off_state(uint32_t *flags, uint32_t ctx)
 static int set_starting_state(uint32_t *flags, uint32_t ctx)
 {
 	int err = 0;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	uint32_t current_ctx = GET_CTX(*flags);
 
 	if ((*flags & (STATUS_MASK)) == CLOCK_CONTROL_STATUS_OFF) {
@@ -161,7 +161,7 @@ static int set_starting_state(uint32_t *flags, uint32_t ctx)
 
 static void set_on_state(uint32_t *flags)
 {
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	*flags = CLOCK_CONTROL_STATUS_ON | GET_CTX(*flags);
 	irq_unlock(key);
@@ -266,7 +266,7 @@ static void generic_hfclk_start(void)
 {
 	nrf_clock_hfclk_t type;
 	bool already_started = false;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	hfclk_users |= HF_USER_GENERIC;
 	if (hfclk_users & HF_USER_BT) {
@@ -731,7 +731,7 @@ static int cmd_status(const struct shell *shell, size_t argc, char **argv)
 				get_onoff_manager(CLOCK_DEVICE,
 						  CLOCK_CONTROL_NRF_TYPE_LFCLK);
 	uint32_t abs_start, abs_stop;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	uint64_t now = k_uptime_get();
 
 	(void)nrfx_clock_is_running(NRF_CLOCK_DOMAIN_HFCLK, (void *)&hfclk_src);

--- a/drivers/counter/counter_sam0_tc32.c
+++ b/drivers/counter/counter_sam0_tc32.c
@@ -191,7 +191,7 @@ static int counter_sam0_tc32_set_alarm(const struct device *dev,
 		return -EINVAL;
 	}
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (data->ch.callback) {
 		irq_unlock(key);
@@ -222,7 +222,7 @@ static int counter_sam0_tc32_cancel_alarm(const struct device *dev,
 	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	ARG_UNUSED(chan_id);
 
@@ -241,7 +241,7 @@ static int counter_sam0_tc32_set_top_value(const struct device *dev,
 	const struct counter_sam0_tc32_config *const cfg = dev->config;
 	TcCount32 *tc = cfg->regs;
 	int err = 0;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (data->ch.callback) {
 		irq_unlock(key);

--- a/drivers/dma/dma_mcux_edma.c
+++ b/drivers/dma/dma_mcux_edma.c
@@ -188,7 +188,7 @@ static int dma_mcux_edma_configure(const struct device *dev, uint32_t channel,
 	struct dma_block_config *block_config = config->head_block;
 	uint32_t slot = config->dma_slot;
 	edma_transfer_type_t transfer_type;
-	int key;
+	unsigned int key;
 	int ret = 0;
 
 	if (slot > DT_INST_PROP(0, dma_requests)) {
@@ -400,7 +400,7 @@ static int dma_mcux_edma_reload(const struct device *dev, uint32_t channel,
 	struct call_back *data = DEV_CHANNEL_DATA(dev, channel);
 
 	/* Lock the channel configuration */
-	const int key = irq_lock();
+	const unsigned int key = irq_lock();
 	int ret = 0;
 
 	if (!data->transfer_settings.valid) {

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -66,7 +66,7 @@ static int dma_sam0_config(const struct device *dev, uint32_t channel,
 	struct dma_block_config *block = config->head_block;
 	struct dma_sam0_channel *channel_control;
 	DMAC_BTCTRL_Type btctrl = { .reg = 0 };
-	int key;
+	unsigned int key;
 
 	if (channel >= DMAC_CH_NUM) {
 		LOG_ERR("Unsupported channel");
@@ -262,7 +262,7 @@ inval:
 
 static int dma_sam0_start(const struct device *dev, uint32_t channel)
 {
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	ARG_UNUSED(dev);
 
@@ -293,7 +293,7 @@ static int dma_sam0_start(const struct device *dev, uint32_t channel)
 
 static int dma_sam0_stop(const struct device *dev, uint32_t channel)
 {
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	ARG_UNUSED(dev);
 
@@ -316,7 +316,7 @@ static int dma_sam0_reload(const struct device *dev, uint32_t channel,
 {
 	struct dma_sam0_data *data = dev->data;
 	DmacDescriptor *desc = &data->descriptors[channel];
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	switch (desc->BTCTRL.bit.BEATSIZE) {
 	case DMAC_BTCTRL_BEATSIZE_BYTE_Val:

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -245,7 +245,7 @@ static int notify_callback_set(const struct device *dev,
 			       edac_notify_callback_f cb)
 {
 	struct ibecc_data *data = dev->data;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	data->cb = cb;
 	irq_unlock(key);

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -631,7 +631,7 @@ void host_c2h_write_io_cfg_reg(uint8_t reg_index, uint8_t reg_data)
 	struct c2h_reg *const inst_c2h = host_sub_cfg.inst_c2h;
 
 	/* Disable interrupts */
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	/* Lock host access EC configuration registers (0x4E/0x4F) */
 	inst_c2h->LKSIOHA |= BIT(NPCX_LKSIOHA_LKCFG);
@@ -675,7 +675,7 @@ uint8_t host_c2h_read_io_cfg_reg(uint8_t reg_index)
 	uint8_t data_val;
 
 	/* Disable interrupts */
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	/* Lock host access EC configuration registers (0x4E/0x4F) */
 	inst_c2h->LKSIOHA |= BIT(NPCX_LKSIOHA_LKCFG);

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -80,7 +80,7 @@ static int eth_initialize(const struct device *dev)
 
 static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 {
-	int key;
+	unsigned int key;
 	uint16_t len;
 	struct eth_liteeth_dev_data *context = dev->data;
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1320,7 +1320,7 @@ static const struct ethernet_api api_funcs = {
 static void eth_mcux_ptp_isr(const struct device *dev)
 {
 	struct eth_context *context = dev->data;
-	int irq_lock_key = irq_lock();
+	unsigned int irq_lock_key = irq_lock();
 	enet_ptp_timer_channel_t channel;
 
 	/* clear channel */
@@ -1339,7 +1339,7 @@ static void eth_mcux_common_isr(const struct device *dev)
 {
 	struct eth_context *context = dev->data;
 	uint32_t EIR = ENET_GetInterruptStatus(context->base);
-	int irq_lock_key = irq_lock();
+	unsigned int irq_lock_key = irq_lock();
 
 	if (EIR & (kENET_RxBufferInterrupt | kENET_RxFrameInterrupt)) {
 		/* disable the IRQ for RX */

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1132,7 +1132,7 @@ static int ptp_clock_stm32_set(const struct device *dev,
 	struct ptp_context *ptp_context = dev->data;
 	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
-	int key;
+	unsigned int key;
 
 	key = irq_lock();
 
@@ -1163,7 +1163,7 @@ static int ptp_clock_stm32_get(const struct device *dev,
 	struct ptp_context *ptp_context = dev->data;
 	struct eth_stm32_hal_dev_data *eth_dev_data = ptp_context->eth_dev_data;
 	ETH_HandleTypeDef *heth = &eth_dev_data->heth;
-	int key;
+	unsigned int key;
 	uint32_t second_2;
 
 	key = irq_lock();

--- a/drivers/hwinfo/hwinfo_sam.c
+++ b/drivers/hwinfo/hwinfo_sam.c
@@ -66,7 +66,7 @@ static int hwinfo_sam_init(const struct device *arg)
 {
 	Efc *efc = (Efc *)DT_REG_ADDR(DT_INST(0, atmel_sam_flash_controller));
 	uint32_t fmr;
-	int key;
+	unsigned int key;
 
 	/* Disable interrupts. */
 	key = irq_lock();

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -202,7 +202,7 @@ static void i2c_sam0_dma_write_done(const struct device *dma_dev, void *arg,
 	ARG_UNUSED(dma_dev);
 	ARG_UNUSED(id);
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (i2c_sam0_terminate_on_error(dev)) {
 		irq_unlock(key);
@@ -293,7 +293,7 @@ static void i2c_sam0_dma_read_done(const struct device *dma_dev, void *arg,
 	ARG_UNUSED(dma_dev);
 	ARG_UNUSED(id);
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (i2c_sam0_terminate_on_error(dev)) {
 		irq_unlock(key);
@@ -435,7 +435,7 @@ static int i2c_sam0_transfer(const struct device *dev, struct i2c_msg *msgs,
 #endif
 		}
 
-		int key = irq_lock();
+		unsigned int key = irq_lock();
 
 		/*
 		 * Writing the address starts the transaction, issuing

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -203,7 +203,7 @@ static inline void kw41z_wait_for_idle(void)
 
 static void kw41z_phy_abort(void)
 {
-	int key;
+	unsigned int key;
 
 	key = irq_lock();
 
@@ -619,7 +619,7 @@ static int kw41z_tx(const struct device *dev, enum ieee802154_tx_mode mode,
 	uint8_t payload_len = frag->len;
 	uint32_t tx_timeout;
 	uint8_t xcvseq;
-	int key;
+	unsigned int key;
 
 	if (mode != IEEE802154_TX_MODE_DIRECT) {
 		NET_ERR("TX mode %d not supported", mode);

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -103,7 +103,7 @@ int sam0_eic_acquire(int port, int pin, enum sam0_eic_trigger trigger,
 	int line_index;
 	int config_index;
 	int config_shift;
-	int key;
+	unsigned int key;
 	uint32_t config;
 
 	line_index = sam0_eic_map_to_line(port, pin);
@@ -210,7 +210,7 @@ int sam0_eic_release(int port, int pin)
 	int line_index;
 	int config_index;
 	int config_shift;
-	int key;
+	unsigned int key;
 
 	line_index = sam0_eic_map_to_line(port, pin);
 	if (line_index < 0) {

--- a/drivers/serial/uart_liteuart.c
+++ b/drivers/serial/uart_liteuart.c
@@ -267,7 +267,7 @@ static void uart_liteuart_irq_callback_set(const struct device *dev,
 static void liteuart_uart_irq_handler(const struct device *dev)
 {
 	struct uart_liteuart_data *data = dev->data;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (data->callback) {
 		data->callback(dev, data->cb_data);

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -137,7 +137,7 @@ static int mcux_lpuart_poll_in(const struct device *dev, unsigned char *c)
 static void mcux_lpuart_poll_out(const struct device *dev, unsigned char c)
 {
 	const struct mcux_lpuart_config *config = dev->config;
-	int key;
+	unsigned int key;
 #ifdef CONFIG_PM
 	struct mcux_lpuart_data *data = dev->data;
 #endif
@@ -232,7 +232,7 @@ static void mcux_lpuart_irq_tx_enable(const struct device *dev)
 	uint32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 #ifdef CONFIG_PM
 	struct mcux_lpuart_data *data = dev->data;
-	int key;
+	unsigned int key;
 #endif
 
 #ifdef CONFIG_PM
@@ -254,7 +254,7 @@ static void mcux_lpuart_irq_tx_disable(const struct device *dev)
 	uint32_t mask = kLPUART_TxDataRegEmptyInterruptEnable;
 #ifdef CONFIG_PM
 	struct mcux_lpuart_data *data = dev->data;
-	int key;
+	unsigned int key;
 
 	key = irq_lock();
 #endif
@@ -481,7 +481,7 @@ static int mcux_lpuart_rx_disable(const struct device *dev)
 	const struct mcux_lpuart_config *config = dev->config;
 	struct mcux_lpuart_data *data = (struct mcux_lpuart_data *)dev->data;
 	LPUART_Type *lpuart = config->base;
-	const int key = irq_lock();
+	const unsigned int key = irq_lock();
 
 	LPUART_EnableRx(lpuart, false);
 	(void)k_work_cancel_delayable(&data->async.rx_dma_params.timeout_work);
@@ -662,7 +662,7 @@ static int mcux_lpuart_tx(const struct device *dev, const uint8_t *buf, size_t l
 	const struct mcux_lpuart_config *config = dev->config;
 	LPUART_Type *lpuart = config->base;
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	/* Check for an ongiong transfer and abort if it is pending */
 	struct dma_status status;
@@ -753,7 +753,7 @@ static int mcux_lpuart_rx_enable(const struct device *dev, uint8_t *buf, const s
 
 	struct mcux_lpuart_rx_dma_params *rx_dma_params = &data->async.rx_dma_params;
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	struct dma_status status;
 	const int get_status_result = dma_get_status(config->rx_dma_config.dma_dev,
 						     config->rx_dma_config.dma_channel,

--- a/drivers/serial/uart_nrfx_uart.c
+++ b/drivers/serial/uart_nrfx_uart.c
@@ -559,7 +559,7 @@ static int uart_nrfx_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 				size_t len)
 {
 	int err;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (!uart0_cb.rx_enabled) {
 		err = -EACCES;
@@ -668,7 +668,7 @@ static void rx_isr(const struct device *dev)
 		}
 		rx_rdy_evt(dev);
 
-		int key = irq_lock();
+		unsigned int key = irq_lock();
 
 		if (uart0_cb.rx_secondary_buffer_length == 0) {
 			uart0_cb.rx_enabled = 0;

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -249,7 +249,7 @@ static void endtx_isr(const struct device *dev)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_ENDTX)) {
 		nrf_uarte_event_clear(uarte, NRF_UARTE_EVENT_ENDTX);
@@ -283,7 +283,7 @@ static void uarte_nrfx_isr_int(void *arg)
 	}
 
 	if (config->flags & UARTE_CFG_FLAG_LOW_POWER) {
-		int key = irq_lock();
+		unsigned int key = irq_lock();
 
 		if (nrf_uarte_event_check(uarte, NRF_UARTE_EVENT_TXSTOPPED)) {
 			nrf_uarte_disable(uarte);
@@ -527,7 +527,7 @@ static bool is_tx_ready(const struct device *dev)
  */
 static int wait_tx_ready(const struct device *dev)
 {
-	int key;
+	unsigned int key;
 
 	do {
 		/* wait arbitrary time before back off. */
@@ -793,7 +793,7 @@ static int uarte_nrfx_tx(const struct device *dev, const uint8_t *buf,
 	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (data->async->tx_size) {
 		irq_unlock(key);
@@ -946,7 +946,7 @@ static int uarte_nrfx_rx_enable(const struct device *dev, uint8_t *buf,
 
 	data->async->rx_enabled = true;
 	if (cfg->flags & UARTE_CFG_FLAG_LOW_POWER) {
-		int key = irq_lock();
+		unsigned int key = irq_lock();
 
 		uarte_enable(dev, UARTE_LOW_POWER_RX);
 		irq_unlock(key);
@@ -963,7 +963,7 @@ static int uarte_nrfx_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 	struct uarte_nrfx_data *data = dev->data;
 	int err;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (data->async->rx_buf == NULL) {
 		err = -EACCES;
@@ -1205,7 +1205,7 @@ static void endrx_isr(const struct device *dev)
 	 * and here we just do the swap of which buffer the driver is following,
 	 * the next rx_timeout() will update the rx_offset.
 	 */
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (data->async->rx_next_buf) {
 		data->async->rx_buf = data->async->rx_next_buf;
@@ -1307,7 +1307,7 @@ static uint8_t rx_flush(const struct device *dev, uint8_t *buf, uint32_t len)
 static void async_uart_release(const struct device *dev, uint32_t dir_mask)
 {
 	struct uarte_nrfx_data *data = dev->data;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	data->async->low_power_mask &= ~dir_mask;
 	if (!data->async->low_power_mask) {
@@ -1359,7 +1359,7 @@ static void txstopped_isr(const struct device *dev)
 	const struct uarte_nrfx_config *config = dev->config;
 	struct uarte_nrfx_data *data = dev->data;
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
-	int key;
+	unsigned int key;
 
 	if (config->flags & UARTE_CFG_FLAG_LOW_POWER) {
 		nrf_uarte_int_disable(uarte, NRF_UARTE_INT_TXSTOPPED_MASK);
@@ -1537,7 +1537,7 @@ static void uarte_nrfx_poll_out(const struct device *dev, unsigned char c)
 {
 	struct uarte_nrfx_data *data = dev->data;
 	bool isr_mode = k_is_in_isr() || k_is_pre_kernel();
-	int key;
+	unsigned int key;
 
 	if (isr_mode) {
 		while (1) {
@@ -1583,7 +1583,7 @@ static int uarte_nrfx_fifo_fill(const struct device *dev,
 	/* Copy data to RAM buffer for EasyDMA transfer */
 	memcpy(data->int_driven->tx_buffer, tx_data, len);
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (!is_tx_ready(dev)) {
 		data->int_driven->fifo_fill_lock = 0;
@@ -1624,7 +1624,7 @@ static void uarte_nrfx_irq_tx_enable(const struct device *dev)
 {
 	NRF_UARTE_Type *uarte = get_uarte_instance(dev);
 	struct uarte_nrfx_data *data = dev->data;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	data->int_driven->disable_tx_irq = false;
 	nrf_uarte_int_enable(uarte, NRF_UARTE_INT_TXSTOPPED_MASK);

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -145,7 +145,7 @@ static void uart_sam0_dma_tx_done(const struct device *dma_dev, void *arg,
 static int uart_sam0_tx_halt(struct uart_sam0_dev_data *dev_data)
 {
 	const struct uart_sam0_dev_cfg *const cfg = dev_data->cfg;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	size_t tx_active = dev_data->tx_len;
 	struct dma_status st;
 
@@ -227,7 +227,7 @@ static void uart_sam0_dma_rx_done(const struct device *dma_dev, void *arg,
 	const struct device *dev = dev_data->dev;
 	const struct uart_sam0_dev_cfg *const cfg = dev_data->cfg;
 	SercomUsart * const regs = cfg->regs;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (dev_data->rx_len == 0U) {
 		irq_unlock(key);
@@ -306,7 +306,7 @@ static void uart_sam0_rx_timeout(struct k_work *work)
 	const struct uart_sam0_dev_cfg *const cfg = dev_data->cfg;
 	SercomUsart * const regs = cfg->regs;
 	struct dma_status st;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (dev_data->rx_len == 0U) {
 		irq_unlock(key);
@@ -724,7 +724,7 @@ static void uart_sam0_isr(const struct device *dev)
 
 		k_work_cancel_delayable(&dev_data->tx_timeout_work);
 
-		int key = irq_lock();
+		unsigned int key = irq_lock();
 
 		struct uart_event evt = {
 			.type = UART_TX_DONE,
@@ -956,7 +956,7 @@ static int uart_sam0_tx(const struct device *dev, const uint8_t *buf,
 		return -EINVAL;
 	}
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (dev_data->tx_len != 0U) {
 		retval = -EBUSY;
@@ -1016,7 +1016,7 @@ static int uart_sam0_rx_enable(const struct device *dev, uint8_t *buf,
 		return -EINVAL;
 	}
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (dev_data->rx_len != 0U) {
 		retval = -EBUSY;
@@ -1063,7 +1063,7 @@ static int uart_sam0_rx_buf_rsp(const struct device *dev, uint8_t *buf,
 	}
 
 	struct uart_sam0_dev_data *const dev_data = dev->data;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	int retval = 0;
 
 	if (dev_data->rx_len == 0U) {
@@ -1096,7 +1096,7 @@ static int uart_sam0_rx_disable(const struct device *dev)
 
 	k_work_cancel_delayable(&dev_data->rx_timeout_work);
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	if (dev_data->rx_len == 0U) {
 		irq_unlock(key);

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -537,7 +537,7 @@ static void uart_stm32_poll_out(const struct device *dev,
 #ifdef CONFIG_PM
 	struct uart_stm32_data *data = dev->data;
 #endif
-	int key;
+	unsigned int key;
 
 	/* Wait for TXE flag to be raised
 	 * When TXE flag is raised, we lock interrupts to prevent interrupts (notably that of usart)
@@ -649,7 +649,7 @@ static int uart_stm32_fifo_fill(const struct device *dev,
 {
 	const struct uart_stm32_config *config = dev->config;
 	uint8_t num_tx = 0U;
-	int key;
+	unsigned int key;
 
 	if (!LL_USART_IsActiveFlag_TXE(config->usart)) {
 		return num_tx;
@@ -702,7 +702,7 @@ static void uart_stm32_irq_tx_enable(const struct device *dev)
 	const struct uart_stm32_config *config = dev->config;
 #ifdef CONFIG_PM
 	struct uart_stm32_data *data = dev->data;
-	int key;
+	unsigned int key;
 #endif
 
 #ifdef CONFIG_PM
@@ -723,7 +723,7 @@ static void uart_stm32_irq_tx_disable(const struct device *dev)
 	const struct uart_stm32_config *config = dev->config;
 #ifdef CONFIG_PM
 	struct uart_stm32_data *data = dev->data;
-	int key;
+	unsigned int key;
 
 	key = irq_lock();
 #endif

--- a/drivers/timer/litex_timer.c
+++ b/drivers/timer/litex_timer.c
@@ -35,7 +35,7 @@ const int32_t z_sys_timer_irq_for_test = TIMER_IRQ;
 
 static void litex_timer_irq_handler(const void *device)
 {
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	litex_write8(TIMER_EV, TIMER_EV_PENDING_ADDR);
 	sys_clock_announce(1);

--- a/drivers/timer/sam0_rtc_timer.c
+++ b/drivers/timer/sam0_rtc_timer.c
@@ -221,7 +221,7 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	/* Avoid race condition between reading counter and ISR incrementing
 	 * it.
 	 */
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	rtc_timeout = rtc_counter + ticks;
 	irq_unlock(key);

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -1482,7 +1482,7 @@ bool z_page_fault(void *addr)
 static void do_mem_unpin(void *addr)
 {
 	struct z_page_frame *pf;
-	int key;
+	unsigned int key;
 	uintptr_t flags, phys;
 
 	key = irq_lock();

--- a/kernel/paging/statistics.c
+++ b/kernel/paging/statistics.c
@@ -79,7 +79,7 @@ k_mem_paging_backing_store_histogram_bounds[
 unsigned long z_num_pagefaults_get(void)
 {
 	unsigned long ret;
-	int key;
+	unsigned int key;
 
 	key = irq_lock();
 	ret = paging_stats.pagefaults.cnt;

--- a/samples/userspace/prod_consumer/src/sample_driver_foo.c
+++ b/samples/userspace/prod_consumer/src/sample_driver_foo.c
@@ -40,7 +40,7 @@ static int sample_driver_foo_set_callback(const struct device *dev,
 					  void *context)
 {
 	struct sample_driver_foo_dev_data *data = dev->data;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	data->cb_context = context;
 	data->cb = cb;

--- a/soc/arm/nxp_lpc/lpc11u6x/iap.h
+++ b/soc/arm/nxp_lpc/lpc11u6x/iap.h
@@ -53,7 +53,7 @@
  */
 static inline int iap_cmd(unsigned int cmd[5])
 {
-	int key;
+	unsigned int key;
 	int status[5];
 
 	/*

--- a/subsys/demand_paging/eviction/nru.c
+++ b/subsys/demand_paging/eviction/nru.c
@@ -26,7 +26,7 @@ static void nru_periodic_update(struct k_timer *timer)
 {
 	uintptr_t phys;
 	struct z_page_frame *pf;
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	Z_PAGE_FRAME_FOREACH(phys, pf) {
 		if (!z_page_frame_is_evictable(pf)) {

--- a/subsys/net/l2/ethernet/gptp/gptp_mi.c
+++ b/subsys/net/l2/ethernet/gptp/gptp_mi.c
@@ -740,7 +740,7 @@ static void gptp_update_local_port_clock(void)
 	int64_t second_diff;
 	const struct device *clk;
 	struct net_ptp_time tm;
-	int key;
+	unsigned int key;
 
 	state = &GPTP_STATE()->clk_slave_sync;
 	global_ds = GPTP_GLOBAL_DS();

--- a/subsys/portability/cmsis_rtos_v2/event_flags.c
+++ b/subsys/portability/cmsis_rtos_v2/event_flags.c
@@ -63,7 +63,7 @@ osEventFlagsId_t osEventFlagsNew(const osEventFlagsAttr_t *attr)
 uint32_t osEventFlagsSet(osEventFlagsId_t ef_id, uint32_t flags)
 {
 	struct cv2_event_flags *events = (struct cv2_event_flags *)ef_id;
-	int key;
+	unsigned int key;
 
 	if ((ef_id == NULL) || (flags & osFlagsError)) {
 		return osFlagsErrorParameter;
@@ -84,7 +84,7 @@ uint32_t osEventFlagsSet(osEventFlagsId_t ef_id, uint32_t flags)
 uint32_t osEventFlagsClear(osEventFlagsId_t ef_id, uint32_t flags)
 {
 	struct cv2_event_flags *events = (struct cv2_event_flags *)ef_id;
-	int key;
+	unsigned int key;
 	uint32_t sig;
 
 	if ((ef_id == NULL) || (flags & osFlagsError)) {

--- a/subsys/portability/cmsis_rtos_v2/thread_flags.c
+++ b/subsys/portability/cmsis_rtos_v2/thread_flags.c
@@ -15,7 +15,7 @@
  */
 uint32_t osThreadFlagsSet(osThreadId_t thread_id, uint32_t flags)
 {
-	int key;
+	unsigned int key;
 	struct cv2_thread *tid = (struct cv2_thread *)thread_id;
 
 	if ((thread_id == NULL) || (is_cmsis_rtos_v2_thread(thread_id) == NULL)

--- a/subsys/tracing/user/tracing_user.c
+++ b/subsys/tracing/user/tracing_user.c
@@ -57,7 +57,7 @@ void sys_trace_k_thread_switched_in(void)
 /* FIXME: Limitation of the current x86 EFI cosnole implementation. */
 #if !defined(CONFIG_X86_EFI_CONSOLE) && !defined(CONFIG_UART_CONSOLE)
 
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
 	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
@@ -70,7 +70,7 @@ void sys_trace_k_thread_switched_in(void)
 void sys_trace_k_thread_switched_out(void)
 {
 #if !defined(CONFIG_X86_EFI_CONSOLE) && !defined(CONFIG_UART_CONSOLE)
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	__ASSERT_NO_MSG(nested_interrupts[_current_cpu->id] == 0);
 	/* Can't use k_current_get as thread base and z_tls_current might be incorrect */
@@ -102,7 +102,7 @@ void sys_trace_thread_pend(struct k_thread *thread)
 
 void sys_trace_isr_enter(void)
 {
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	_cpu_t *curr_cpu = _current_cpu;
 
 	sys_trace_isr_enter_user(nested_interrupts[curr_cpu->id]);
@@ -113,7 +113,7 @@ void sys_trace_isr_enter(void)
 
 void sys_trace_isr_exit(void)
 {
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 	_cpu_t *curr_cpu = _current_cpu;
 
 	nested_interrupts[curr_cpu->id]--;

--- a/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
+++ b/tests/arch/arm/arm_interrupt/src/arm_interrupt.c
@@ -395,7 +395,7 @@ void z_impl_test_arm_user_interrupt_syscall(void)
 		first_call = 0;
 
 		/* Lock IRQs in supervisor mode */
-		int key = irq_lock();
+		unsigned int key = irq_lock();
 
 		/* Verify that IRQs were not already locked */
 		zassert_false(key, "IRQs locked in system call\n");

--- a/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
+++ b/tests/arch/arm/arm_irq_zero_latency_levels/src/main.c
@@ -176,7 +176,7 @@ ZTEST(arm_irq_zero_latency_levels, test_arm_zero_latency_levels)
 	NVIC_EnableIRQ(irq_b);
 
 	/* Lock interrupts */
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	execution_trace_add(STEP_MAIN_BEGIN);
 

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -265,7 +265,7 @@ static void test_async_on_stopped_on_instance(const struct device *dev,
 {
 	enum clock_control_status status;
 	int err;
-	int key;
+	unsigned int key;
 	bool executed = false;
 
 	status = clock_control_get_status(dev, subsys);

--- a/tests/kernel/mem_protect/demand_paging/src/main.c
+++ b/tests/kernel/mem_protect/demand_paging/src/main.c
@@ -249,7 +249,7 @@ void test_k_mem_page_in(void)
 void test_k_mem_pin(void)
 {
 	unsigned long faults;
-	int key;
+	unsigned int key;
 
 	k_mem_pin(arena, HALF_BYTES);
 
@@ -293,7 +293,7 @@ void test_k_mem_unpin(void)
 void test_backing_store_capacity(void)
 {
 	char *mem, *ret;
-	int key;
+	unsigned int key;
 	unsigned long faults;
 	size_t size = (((CONFIG_BACKING_STORE_RAM_PAGES - 1) - HALF_PAGES) *
 		       CONFIG_MMU_PAGE_SIZE);

--- a/tests/kernel/mem_protect/userspace/src/main.c
+++ b/tests/kernel/mem_protect/userspace/src/main.c
@@ -923,7 +923,7 @@ void test_oops_stackcheck(void)
 
 void z_impl_check_syscall_context(void)
 {
-	int key = irq_lock();
+	unsigned int key = irq_lock();
 
 	irq_unlock(key);
 


### PR DESCRIPTION
irq_lock() returns an unsigned integer key.
Generated by spatch using semantic patch
scripts/coccinelle/irq_lock.cocci