### PR TITLE
drivers: sensor: shell_battery: Convert to DEVICE_DT_GET

### DIFF
--- a/drivers/sensor/shell_battery.c
+++ b/drivers/sensor/shell_battery.c
@@ -54,13 +54,12 @@ static int cmd_battery(const struct shell *shell, size_t argc, char **argv)
 	struct sensor_value temp, volt, current, i_desired, charge_remain;
 	struct sensor_value charge, v_desired, v_design, cap, nom_cap;
 	struct sensor_value full, empty;
-	const struct device *dev;
+	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(battery));
 	bool allowed;
 	int err;
 
-	dev = device_get_binding(DT_LABEL(DT_ALIAS(battery)));
-	if (!dev) {
-		shell_error(shell, "Device unknown (%s)", argv[1]);
+	if (!device_is_ready(dev)) {
+		shell_error(shell, "Device not ready (%s)", argv[1]);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Move to using DEVICE_DT_GET so we can phase out DT_LABEL.

Signed-off-by: Kumar Gala <galak@kernel.org>