### PR TITLE
drivers: video: video_mcux_csi: Use phandle for devicetree sensor ref

### DIFF
--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -153,7 +153,7 @@ arduino_i2c: &lpi2c1 {};
 	pinctrl-0 = <&pinmux_lpi2c1>;
 	pinctrl-names = "default";
 
-	mt9m114@48 {
+	mt9m114: mt9m114@48 {
 		compatible = "aptina,mt9m114";
 		reg = <0x48>;
 		label = "MT9M114";
@@ -267,7 +267,7 @@ zephyr_udc0: &usb1 {
 
 &csi {
 	status = "okay";
-	sensor-label = "MT9M114";
+	sensor = <&mt9m114>;
 	pinctrl-0 = <&pinmux_csi>;
 	pinctrl-names = "default";
 

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -105,7 +105,7 @@
 	pinctrl-0 = <&pinmux_lpi2c3>;
 	pinctrl-names = "default";
 
-	ov7725@21 {
+	ov7725: ov7725@21 {
 		compatible = "ovti,ov7725";
 		reg = <0x21>;
 		label = "OV7725";
@@ -192,7 +192,7 @@
 
 &csi {
 	status = "okay";
-	sensor-label = "OV7725";
+	sensor = <&ov7725>;
 	pinctrl-0 = <&pinmux_csi>;
 	pinctrl-names = "default";
 

--- a/drivers/video/video_mcux_csi.c
+++ b/drivers/video/video_mcux_csi.c
@@ -19,13 +19,12 @@
 
 struct video_mcux_csi_config {
 	CSI_Type *base;
-	char *sensor_label;
+	const struct device *sensor_dev;
 	const struct pinctrl_dev_config *pincfg;
 };
 
 struct video_mcux_csi_data {
 	const struct device *dev;
-	const struct device *sensor_dev;
 	csi_config_t csi_config;
 	csi_handle_t csi_handle;
 	struct k_fifo fifo_in;
@@ -149,7 +148,7 @@ static int video_mcux_csi_set_fmt(const struct device *dev,
 		return -EIO;
 	}
 
-	if (data->sensor_dev && video_set_format(data->sensor_dev, ep, fmt)) {
+	if (config->sensor_dev && video_set_format(config->sensor_dev, ep, fmt)) {
 		return -EIO;
 	}
 
@@ -161,12 +160,13 @@ static int video_mcux_csi_get_fmt(const struct device *dev,
 				  struct video_format *fmt)
 {
 	struct video_mcux_csi_data *data = dev->data;
+	const struct video_mcux_csi_config *config = dev->config;
 
 	if (fmt == NULL || ep != VIDEO_EP_OUT) {
 		return -EINVAL;
 	}
 
-	if (data->sensor_dev && !video_get_format(data->sensor_dev, ep, fmt)) {
+	if (config->sensor_dev && !video_get_format(config->sensor_dev, ep, fmt)) {
 		/* align CSI with sensor fmt */
 		return video_mcux_csi_set_fmt(dev, ep, fmt);
 	}
@@ -190,7 +190,7 @@ static int video_mcux_csi_stream_start(const struct device *dev)
 		return -EIO;
 	}
 
-	if (data->sensor_dev && video_stream_start(data->sensor_dev)) {
+	if (config->sensor_dev && video_stream_start(config->sensor_dev)) {
 		return -EIO;
 	}
 
@@ -203,7 +203,7 @@ static int video_mcux_csi_stream_stop(const struct device *dev)
 	struct video_mcux_csi_data *data = dev->data;
 	status_t ret;
 
-	if (data->sensor_dev && video_stream_stop(data->sensor_dev)) {
+	if (config->sensor_dev && video_stream_stop(config->sensor_dev)) {
 		return -EIO;
 	}
 
@@ -301,12 +301,12 @@ static inline int video_mcux_csi_set_ctrl(const struct device *dev,
 					  unsigned int cid,
 					  void *value)
 {
-	struct video_mcux_csi_data *data = dev->data;
+	const struct video_mcux_csi_config *config = dev->config;
 	int ret = -ENOTSUP;
 
 	/* Forward to sensor dev if any */
-	if (data->sensor_dev) {
-		ret = video_set_ctrl(data->sensor_dev, cid, value);
+	if (config->sensor_dev) {
+		ret = video_set_ctrl(config->sensor_dev, cid, value);
 	}
 
 	return ret;
@@ -316,12 +316,12 @@ static inline int video_mcux_csi_get_ctrl(const struct device *dev,
 					  unsigned int cid,
 					  void *value)
 {
-	struct video_mcux_csi_data *data = dev->data;
+	const struct video_mcux_csi_config *config = dev->config;
 	int ret = -ENOTSUP;
 
 	/* Forward to sensor dev if any */
-	if (data->sensor_dev) {
-		ret = video_get_ctrl(data->sensor_dev, cid, value);
+	if (config->sensor_dev) {
+		ret = video_get_ctrl(config->sensor_dev, cid, value);
 	}
 
 	return ret;
@@ -331,7 +331,7 @@ static int video_mcux_csi_get_caps(const struct device *dev,
 				   enum video_endpoint_id ep,
 				   struct video_caps *caps)
 {
-	struct video_mcux_csi_data *data = dev->data;
+	const struct video_mcux_csi_config *config = dev->config;
 	int err = -ENODEV;
 
 	if (ep != VIDEO_EP_OUT) {
@@ -339,8 +339,8 @@ static int video_mcux_csi_get_caps(const struct device *dev,
 	}
 
 	/* Just forward to sensor dev for now */
-	if (data->sensor_dev) {
-		err = video_get_caps(data->sensor_dev, ep, caps);
+	if (config->sensor_dev) {
+		err = video_get_caps(config->sensor_dev, ep, caps);
 	}
 
 	/* NXP MCUX CSI request at least 2 buffer before starting */
@@ -369,11 +369,8 @@ static int video_mcux_csi_init(const struct device *dev)
 	CSI_GetDefaultConfig(&data->csi_config);
 
 	/* check if there is any sensor device (video ctrl device) */
-	if (config->sensor_label) {
-		data->sensor_dev = device_get_binding(config->sensor_label);
-		if (data->sensor_dev == NULL) {
-			return -ENODEV;
-		}
+	if (!device_is_ready(config->sensor_dev)) {
+		return -ENODEV;
 	}
 
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
@@ -422,7 +419,7 @@ PINCTRL_DT_INST_DEFINE(0);
 
 static const struct video_mcux_csi_config video_mcux_csi_config_0 = {
 	.base = (CSI_Type *)DT_INST_REG_ADDR(0),
-	.sensor_label = DT_INST_PROP(0, sensor_label),
+	.sensor_dev = DEVICE_DT_GET(DT_INST_PHANDLE(0, sensor)),
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 };
 

--- a/dts/bindings/video/nxp,imx-csi.yaml
+++ b/dts/bindings/video/nxp,imx-csi.yaml
@@ -17,7 +17,7 @@ properties:
     label:
       required: true
 
-    sensor-label:
+    sensor:
       required: true
-      type: string
-      description: label of connected sensor device
+      type: phandle
+      description: phandle of connected sensor device


### PR DESCRIPTION
Replace sensor_label property in devicetree with just a sensor phandle
property.  This is more generic and allows driver to use DEVICE_DT_GET
instead of device_get_binding.

Signed-off-by: Kumar Gala <galak@kernel.org>