### PR TITLE
ESP32 serial driver clean-up

### DIFF
--- a/drivers/serial/Kconfig.esp32
+++ b/drivers/serial/Kconfig.esp32
@@ -16,11 +16,17 @@ config UART_ESP32
 DT_COMPAT_ESP32_USB_SERIAL := espressif,esp32-usb-serial
 
 config SERIAL_ESP32_USB
-	bool "ESP32 USB serial driver"
+	bool "ESP32 built-in USB serial driver"
 	default $(dt_compat_enabled,$(DT_COMPAT_ESP32_USB_SERIAL))
 	select SERIAL_HAS_DRIVER
 	select SERIAL_SUPPORT_INTERRUPT
 	depends on SOC_ESP32C3
 	help
-	  Enable the ESP32 USB serial driver integrated in the JTAG
-	  interface.
+	  Enable the built-in USB serial interface present in some Espressif
+	  MCUs like the ESP32-C3.
+
+	  This driver uses the peripheral called USB Serial/JTAG Controller
+	  (USB_SERIAL_JTAG), which acts as a CDC-ACM interface towards the
+	  USB host. The USB stack is built into the chip and accessed
+	  by the firmware through a simplified API similar to a "normal"
+	  UART peripheral.

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -8,22 +8,14 @@
 
 #include <hal/usb_serial_jtag_ll.h>
 
-#include <soc/uart_reg.h>
 #include <device.h>
+#include <errno.h>
 #include <soc.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/interrupt_controller/intc_esp32c3.h>
 #include <zephyr/drivers/clock_control.h>
-#include <errno.h>
 #include <zephyr/sys/util.h>
 #include <esp_attr.h>
-
-#define ISR_HANDLER isr_handler_t
-
-struct serial_esp32_usb_pin {
-	const char *gpio_name;
-	int pin;
-};
 
 struct serial_esp32_usb_config {
 	const struct device *clock_dev;
@@ -39,8 +31,6 @@ struct serial_esp32_usb_data {
 #endif
 	int irq_line;
 };
-
-#define SERIAL_FIFO_LIMIT (USB_SERIAL_JTAG_PACKET_SZ_BYTES)
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 static void serial_esp32_usb_isr(void *arg);
@@ -106,7 +96,7 @@ static int serial_esp32_usb_init(const struct device *dev)
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	const struct serial_esp32_usb_config *config = dev->config;
 
-	data->irq_line = esp_intr_alloc(config->irq_source, 0, (ISR_HANDLER)serial_esp32_usb_isr,
+	data->irq_line = esp_intr_alloc(config->irq_source, 0, (isr_handler_t)serial_esp32_usb_isr,
 					(void *)dev, NULL);
 #endif
 	return ret;

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -6,7 +6,6 @@
 
 #define DT_DRV_COMPAT espressif_esp32_usb_serial
 
-#include "stubs.h"
 #include <hal/usb_serial_jtag_ll.h>
 
 #include <soc/uart_reg.h>

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -28,7 +28,6 @@ struct serial_esp32_usb_pin {
 struct serial_esp32_usb_config {
 	const struct device *clock_dev;
 	const clock_control_subsys_t clock_subsys;
-	uint8_t uart_num;
 	int irq_source;
 };
 
@@ -265,7 +264,6 @@ static const DRAM_ATTR struct uart_driver_api serial_esp32_usb_api = {
 
 #define ESP32_UART_INIT(idx)                                                                       \
 	static const DRAM_ATTR struct serial_esp32_usb_config serial_esp32_usb_cfg_port_##idx = {  \
-		.uart_num = DT_INST_PROP(idx, peripheral),                                         \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                              \
 		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),          \
 		.irq_source = DT_INST_IRQN(idx)                                                    \

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -21,7 +21,6 @@
 #include <esp32c3/rom/gpio.h>
 #endif
 #include <soc/uart_struct.h>
-#include "stubs.h"
 #include <hal/uart_ll.h>
 #include <hal/uart_hal.h>
 #include <hal/uart_types.h>

--- a/dts/bindings/serial/espressif,esp32-usb-serial.yaml
+++ b/dts/bindings/serial/espressif,esp32-usb-serial.yaml
@@ -10,9 +10,3 @@ properties:
 
   interrupts:
     required: false
-
-  peripheral:
-    type: int
-    required: true
-    description: |
-      The UART peripheral number

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -153,7 +153,6 @@
 			interrupts = <USB_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_USB_MODULE>;
-			current-speed = <115200>;
 		};
 
 		timer0: counter@6001f000 {

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -154,7 +154,6 @@
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_USB_MODULE>;
 			current-speed = <115200>;
-			peripheral = <0>;
 		};
 
 		timer0: counter@6001f000 {


### PR DESCRIPTION
This PR contains some clean-up of the ESP32 UART and USB serial driver based on comments from @gmarull in #44045.

While implementing these fixes I found some more possibilities for simplification / cleaning up of the code.

See commit messages for details.