### PR TITLE
dma: HDA: Convert to DEVICE_DT_GET

### DIFF
--- a/subsys/logging/log_backend_cavs_hda.c
+++ b/subsys/logging/log_backend_cavs_hda.c
@@ -248,8 +248,8 @@ void cavs_hda_log_init(cavs_hda_log_hook_t fn, uint32_t channel)
 
 	int res;
 
-	hda_log_dev = device_get_binding("HDA_HOST_IN");
-	__ASSERT(hda_log_dev, "No valid DMA device found");
+	hda_log_dev = DEVICE_DT_GET(DT_NODELABEL(hda_host_in));
+	__ASSERT(device_is_ready(hda_log_dev), "DMA device is not ready");
 
 	hda_log_chan = dma_request_channel(hda_log_dev, &channel);
 	__ASSERT(hda_log_chan >= 0, "No valid DMA channel");

--- a/tests/boards/intel_adsp/hda/src/dma.c
+++ b/tests/boards/intel_adsp/hda/src/dma.c
@@ -67,8 +67,8 @@ void test_hda_host_in_dma(void)
 	z_xtensa_cache_flush(dma_buf, DMA_BUF_SIZE);
 #endif
 
-	dma = device_get_binding("HDA_HOST_IN");
-	zassert_not_null(dma, "Expected a valid DMA device pointer");
+	dma = DEVICE_DT_GET(DT_NODELABEL(hda_host_in));
+	zassert_true(device_is_ready(dma), "DMA device is not ready");
 
 	channel = dma_request_channel(dma, NULL);
 	zassert_true(channel >= 0, "Expected a valid DMA channel");
@@ -159,8 +159,8 @@ void test_hda_host_out_dma(void)
 
 	printk("Using buffer of size %d at addr %p\n", DMA_BUF_SIZE, dma_buf);
 
-	dma = device_get_binding("HDA_HOST_OUT");
-	zassert_not_null(dma, "Expected a valid DMA device pointer");
+	dma = DEVICE_DT_GET(DT_NODELABEL(hda_host_out));
+	zassert_true(device_is_ready(dma), "DMA device is not ready");
 
 	channel = dma_request_channel(dma, NULL);
 	zassert_true(channel >= 0, "Expected a valid DMA channel");


### PR DESCRIPTION
Move to using DEVICE_DT_GET so we can phase out DT_LABEL.

Signed-off-by: Kumar Gala <galak@kernel.org>