### PR TITLE
maintainers: add entry for emulation

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2567,6 +2567,23 @@ ZTest:
     labels:
         - "area: Testsuite"
 
+Emulation:
+    status: maintained
+    maintainers:
+        - yperess
+    collaborators:
+        - aaronemassey
+        - jeremybettis
+        - alevkoy
+    files:
+        - subsys/emul/
+        - include/zephyr/drivers/emul.h
+        - include/zephyr/drivers/espi_emul.h
+        - include/zephyr/drivers/i2c_emul.h
+        - include/zephyr/drivers/spi_emul.h
+    labels:
+        - "area: HW Emulation"
+
 Random:
     status: odd fixes
     collaborators:


### PR DESCRIPTION
The team listed here will be adding a lot of emulation changes and
improvements in the coming months. Since emulation is not yet
officially maintain, we'd like to take ownership.

Signed-off-by: Yuval Peress <peress@google.com>