### PR TITLE
drivers: clock_control: beetle: Use devicetree for clock control

### DIFF
--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -3,7 +3,6 @@
 /dts-v1/;
 
 #include <arm/armv7-m.dtsi>
-
 / {
 	compatible = "arm,beetle";
 	#address-cells = <1>;
@@ -53,6 +52,7 @@
 			reg = <0x40000000 0x1000>;
 			interrupts = <8 3>;
 			label = "TIMER_0";
+			clocks = <&syscon>;
 		};
 
 		timer1: timer@40001000 {
@@ -60,6 +60,7 @@
 			reg = <0x40001000 0x1000>;
 			interrupts = <9 3>;
 			label = "TIMER_1";
+			clocks = <&syscon>;
 		};
 
 		dtimer0: dtimer@40002000 {
@@ -67,13 +68,14 @@
 			reg = <0x40002000 0x1000>;
 			interrupts = <10 3>;
 			label = "DTIMER_0";
+			clocks = <&syscon>;
 		};
 
 		uart0: uart@40004000 {
 			compatible = "arm,cmsdk-uart";
 			reg = <0x40004000 0x1000>;
 			interrupts = <0 3>;
-			clocks = <&sysclk>;
+			clocks = <&sysclk &syscon>;
 			current-speed = <115200>;
 			label = "UART_0";
 		};
@@ -82,7 +84,7 @@
 			compatible = "arm,cmsdk-uart";
 			reg = <0x40005000 0x1000>;
 			interrupts = <2 3>;
-			clocks = <&sysclk>;
+			clocks = <&sysclk &syscon>;
 			current-speed = <115200>;
 			label = "UART_1";
 		};
@@ -101,6 +103,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			label = "GPIO_0";
+			clocks = <&syscon>;
 		};
 
 		gpio1: gpio@40011000 {
@@ -110,6 +113,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			label = "GPIO_1";
+			clocks = <&syscon>;
 		};
 
 		gpio2: gpio@40012000 {
@@ -119,6 +123,7 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			label = "GPIO_2";
+			clocks = <&syscon>;
 		};
 
 		gpio3: gpio@40013000 {
@@ -128,6 +133,13 @@
 			gpio-controller;
 			#gpio-cells = <2>;
 			label = "GPIO_3";
+			clocks = <&syscon>;
+		};
+
+		syscon: syscon@4001f000 {
+			compatible = "arm,beetle-syscon";
+			reg = <0x4001f000 0x1000>;
+			#clock-cells = <0>;
 		};
 	};
 };

--- a/drivers/clock_control/Kconfig.beetle
+++ b/drivers/clock_control/Kconfig.beetle
@@ -13,12 +13,7 @@ menuconfig CLOCK_CONTROL_BEETLE
 	  Enable driver for Reset & Clock Control subsystem found
 	  in STM32F4 family of MCUs
 
-config ARM_CLOCK_CONTROL_DEV_NAME
-	string "Clock Config Device name"
-	default "CLOCK_CONTROL_0"
-	depends on CLOCK_CONTROL_BEETLE
-	help
-	  Configure Clock Config Device name
+if CLOCK_CONTROL_BEETLE
 
 config CLOCK_CONTROL_BEETLE_ENABLE_PLL
 	bool "PLL on Beetle"
@@ -27,5 +22,7 @@ config CLOCK_CONTROL_BEETLE_ENABLE_PLL
 	  Enable PLL on Beetle.
 
 	  Select n if not sure.
+
+endif # CLOCK_CONTROL_BEETLE
 
 endif # SOC_FAMILY_ARM

--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT arm_cortex_m3
+#define DT_DRV_COMPAT arm_beetle_syscon
 
 /**
  * @file
@@ -235,17 +235,14 @@ static int beetle_clock_control_init(const struct device *dev)
 
 static const struct beetle_clock_control_cfg_t beetle_cc_cfg = {
 	.clock_control_id = 0,
-	.freq = DT_INST_PROP(0, clock_frequency),
+	.freq = DT_PROP(DT_PATH(cpus, cpu_0), clock_frequency),
 };
 
 /**
  * @brief Clock Control device init
  *
  */
-DEVICE_DEFINE(clock_control_beetle, CONFIG_ARM_CLOCK_CONTROL_DEV_NAME,
-		    &beetle_clock_control_init,
-		    NULL,
-		    NULL, &beetle_cc_cfg,
-		    PRE_KERNEL_1,
-		    CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
-		    &beetle_clock_control_api);
+DEVICE_DT_INST_DEFINE(0, &beetle_clock_control_init, NULL,
+		      NULL, &beetle_cc_cfg, PRE_KERNEL_1,
+		      CONFIG_CLOCK_CONTROL_INIT_PRIORITY,
+		      &beetle_clock_control_api);

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -144,8 +144,11 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk =
-		device_get_binding(CONFIG_ARM_CLOCK_CONTROL_DEV_NAME);
+	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
 	clock_control_on(clk, (clock_control_subsys_t *) &cfg->dtimer_cc_as);

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -147,8 +147,11 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk =
-		device_get_binding(CONFIG_ARM_CLOCK_CONTROL_DEV_NAME);
+	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
 	clock_control_on(clk, (clock_control_subsys_t *) &cfg->timer_cc_as);

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -238,8 +238,11 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk =
-		device_get_binding(CONFIG_ARM_CLOCK_CONTROL_DEV_NAME);
+	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
 	clock_control_on(clk, (clock_control_subsys_t *) &cfg->gpio_cc_as);

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -126,10 +126,12 @@ static int uart_cmsdk_apb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk =
-		device_get_binding(CONFIG_ARM_CLOCK_CONTROL_DEV_NAME);
-
+	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_IDX(0, 1));
 	struct uart_cmsdk_apb_dev_data * const data = dev->data;
+
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
 	clock_control_on(clk, (clock_control_subsys_t *) &data->uart_cc_as);

--- a/dts/bindings/arm/arm,beetle-syscon.yaml
+++ b/dts/bindings/arm/arm,beetle-syscon.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) 2022, Kumar Gala <galak@kernel.org>
+# SPDX-License-Identifier: Apache-2.0
+
+description: ARM V2M Beetle System Control
+
+compatible: "arm,beetle-syscon"
+
+include: [clock-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    "#clock-cells":
+      required: true
+      const: 0


### PR DESCRIPTION
Add simple clock control node in devicetree for beetle to handle
relationship between drivers (uart, timers, gpio) and clock controller
device.

Signed-off-by: Kumar Gala <galak@kernel.org>