### PR TITLE
drivers: adc: stm32: wait for internal channels stabilization

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -862,12 +862,14 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC1) == channel_id)
 		    && (config->base == ADC1)) {
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
+			k_sleep(K_USEC(LL_ADC_DELAY_TEMPSENSOR_STAB_US));
 		}
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc5), okay)
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC5) == channel_id)
 		   && (config->base == ADC5)) {
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
+			k_sleep(K_USEC(LL_ADC_DELAY_TEMPSENSOR_STAB_US));
 		}
 #endif
 	}
@@ -875,12 +877,18 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 	if (config->has_temp_channel &&
 		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR) == channel_id) {
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
+#ifdef LL_ADC_DELAY_TEMPSENSOR_STAB_US
+		k_sleep(K_USEC(LL_ADC_DELAY_TEMPSENSOR_STAB_US));
+#endif
 	}
 #endif /* CONFIG_SOC_SERIES_STM32G4X */
 
 	if (config->has_vref_channel &&
 		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_VREFINT) == channel_id) {
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_VREFINT);
+#ifdef LL_ADC_DELAY_VREFINT_STAB_US
+		k_sleep(K_USEC(LL_ADC_DELAY_VREFINT_STAB_US));
+#endif
 	}
 #if defined(LL_ADC_CHANNEL_VBAT)
 	/* Enable the bridge divider only when needed for ADC conversion. */


### PR DESCRIPTION
The VREFINT and TEMPSENSOR internal channels have a stabilization time
after they are enabled. Right now this just causes the first measure to
be a bit off, however with PR #47691 which stops the internal channels
after each readout, this is something important to respect. Fortunately
the stabilization time is available as constants in the HAL, so just
wait the time specified by the constants.

Note that the VBAT internal channel does not have any stabilization
time.

Signed-off-by: Aurelien Jarno <aurelien@aurel32.net>