### PR TITLE
Fix timeout for fvp_baser_aemv8r_aarch32

### DIFF
--- a/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.yaml
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.yaml
@@ -11,3 +11,5 @@ toolchain:
   - cross-compile
 ram: 2048
 flash: 64
+testing:
+  timeout_multiplier: 2

--- a/samples/subsys/rtio/sensor_batch_processing/sample.yaml
+++ b/samples/subsys/rtio/sensor_batch_processing/sample.yaml
@@ -5,7 +5,6 @@ tests:
     tags: rtio
     integration_platforms:
       - native_posix
-    timeout: 120
     harness: console
     harness_config:
       type: multi_line

--- a/tests/kernel/workq/critical/testcase.yaml
+++ b/tests/kernel/workq/critical/testcase.yaml
@@ -1,6 +1,5 @@
 common:
   tags: kernel
-  timeout: 60
 
 tests:
   kernel.workqueue.critical:

--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -2,7 +2,7 @@ common:
   arch_exclude: posix
   tags: posix
   min_ram: 64
-  timeout: 600
+  timeout: 240
 
 tests:
   portability.posix.common:


### PR DESCRIPTION
This is a follow-up patch to address https://github.com/zephyrproject-rtos/zephyr/pull/47579#discussion_r917705816 and https://github.com/zephyrproject-rtos/zephyr/pull/47579#discussion_r917580682.
Timeout for tests/posix/common must be still increased (was 120 sec).
