### PR TITLE
Enable MPU background region for ARMv8-R AArch32

### DIFF
--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -146,8 +146,11 @@ void arm_core_mpu_enable(void)
 {
 	uint32_t val;
 
+	/* Enable MPU and use the default memory map as a
+	 * background region for privileged software access.
+	 */
 	val = __get_SCTLR();
-	val |= SCTLR_MPU_ENABLE;
+	val |= SCTLR_M_BIT | SCTLR_BR_BIT;
 	__set_SCTLR(val);
 
 	/* Make sure that all the registers are set before proceeding */
@@ -166,7 +169,7 @@ void arm_core_mpu_disable(void)
 	__DMB();
 
 	val = __get_SCTLR();
-	val &= ~SCTLR_MPU_ENABLE;
+	val &= ~SCTLR_M_BIT;
 	__set_SCTLR(val);
 
 	/* Make sure that all the registers are set before proceeding */

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -148,9 +148,10 @@ void arm_core_mpu_enable(void)
 
 	val = __get_SCTLR();
 	val |= SCTLR_MPU_ENABLE;
+	__set_SCTLR(val);
+
 	/* Make sure that all the registers are set before proceeding */
 	__DSB();
-	__set_SCTLR(val);
 	__ISB();
 }
 
@@ -161,11 +162,15 @@ void arm_core_mpu_disable(void)
 {
 	uint32_t val;
 
+	/* Force any outstanding transfers to complete before disabling MPU */
+	__DMB();
+
 	val = __get_SCTLR();
 	val &= ~SCTLR_MPU_ENABLE;
-	/* Force any outstanding transfers to complete before disabling MPU */
-	__DSB();
 	__set_SCTLR(val);
+
+	/* Make sure that all the registers are set before proceeding */
+	__DSB();
 	__ISB();
 }
 #else

--- a/include/zephyr/arch/arm/aarch32/cortex_a_r/cpu.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_a_r/cpu.h
@@ -14,8 +14,6 @@
 /*
  * SCTLR register bit assignments
  */
-#define SCTLR_MPU_ENABLE	(1 << 0)
-
 #define MODE_USR	0x10
 #define MODE_FIQ	0x11
 #define MODE_IRQ	0x12
@@ -53,6 +51,7 @@
 #define SCTLR_A_BIT		BIT(1)
 #define SCTLR_C_BIT		BIT(2)
 #define SCTLR_I_BIT		BIT(12)
+#define SCTLR_BR_BIT		BIT(17)
 
 /* Hyp System Control Register */
 #define HSCTLR_RES1		(BIT(29) | BIT(28) | BIT(23) | \


### PR DESCRIPTION
Use the default memory map as a background region for privileged software access to keep consistency with other ARM implementations. Also fix the sync barriers on MPU enable/disable operations.