### PR TITLE
maintainers: espressif: add Lucas Tambor as collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1872,6 +1872,8 @@ Espressif Platforms:
     - sylvioalves
     - glaubermaroto
     - uLipe
+  collaborators:
+    - LucasTambor
   files:
     - drivers/*/*esp32*.c
     - boards/xtensa/esp32*/
@@ -2167,6 +2169,8 @@ West:
     - sylvioalves
     - glaubermaroto
     - uLipe
+  collaborators:
+    - LucasTambor
   files: []
   labels:
     - manifest-hal_espressif


### PR DESCRIPTION
Adding Lucas as Espressif project collaborator.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>