### PR TITLE
dts: mm: intel: Add imr binding

### DIFF
--- a/dts/bindings/mm/intel,adsp-imr.yaml
+++ b/dts/bindings/mm/intel,adsp-imr.yaml
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Copyright (c) 2022 Intel Corporation
+
+description: INTEL Audio DSP IMR Memory
+
+compatible: "intel,adsp-imr"
+
+include: [mm_drv.yaml, "zephyr,memory-region.yaml"]
+
+properties:
+    reg:
+      required: true
+
+    block-size:
+      required: true
+      type: int


### PR DESCRIPTION
Add adsp-imr binding. This memory type is being used in intel adsp dts
but this binding was missing.

Co-authored-by: Marcin Szkudlinski <marcin.szkudlinski@intel.com>
Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>