### PR TITLE
Bluetooth: Mesh: IV Index timer is not started

### DIFF
--- a/subsys/bluetooth/mesh/main.c
+++ b/subsys/bluetooth/mesh/main.c
@@ -110,6 +110,8 @@ int bt_mesh_provision(const uint8_t net_key[16], uint16_t net_idx,
 		return err;
 	}
 
+	bt_mesh_net_settings_commit();
+
 	bt_mesh.seq = 0U;
 
 	bt_mesh_comp_provision(addr);


### PR DESCRIPTION
This fixes an issue where IV index stage counting timer is not
started after the node is provisioned. This would have prevented node
from performing IV index updates.

Signed-off-by: Omkar Kulkarni <omkar.kulkarni@nordicsemi.no>