### PR TITLE
boards: bl5340_dvk: multiple CI fixes

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -13,12 +13,12 @@ config BOARD
 config FLASH
 	default y
 
-if BOARD_BL5340_DVK_CPUAPP
-
 # Enable QSPI for secondary partition maps
 
 config NORDIC_QSPI_NOR
 	default y
+
+if BOARD_BL5340_DVK_CPUAPP
 
 if DAC
 

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -192,7 +192,7 @@
 	pinctrl-0 = <&spi3_default>;
 	pinctrl-1 = <&spi3_sleep>;
 	pinctrl-names = "default", "sleep";
-	sdhc@0 {
+	sdhc0: sdhc@0 {
 		reg = <0>;
 		compatible = "zephyr,sdhc-spi-slot";
 		status = "okay";


### PR DESCRIPTION
Hi, two hotfixes for main CI breakage:

```
-- Found BOARD.dts: /__w/zephyr/zephyr/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_ns.dts
devicetree error: /aliases: undefined node label 'sdhc0'`
```

and then

```
/opt/zephyr-sdk-0.14.1/arm-zephyr-eabi/bin/../lib/gcc/arm-zephyr-eabi/10.3.0/../../../../arm-zephyr-eabi/bin/ld.bfd: zephyr/libzephyr.a(flash_map_default.c.obj):(.rodata.default_flash_map+0xc): undefined reference to `__device_dts_ord_127'
...

```
*   127 /soc/peripheral@40000000/qspi@2b000/mx25r6435f@0
```