### PR TITLE
ADXL372: add names for KConfig choices

### DIFF
--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -26,7 +26,7 @@ config ADXL372_SPI
 
 endchoice
 
-choice
+choice ADXL372_OP_MODE
 	prompt "Operating mode"
 	default ADXL372_PEAK_DETECT_MODE
 
@@ -47,7 +47,7 @@ config ADXL372_MEASUREMENT_MODE
 
 endchoice
 
-choice
+choice ADXL372_ODR_FREQ
 	prompt "Accelerometer sampling frequency (ODR)"
 	default ADXL372_ODR_6400HZ if ADXL372_PEAK_DETECT_MODE
 	default ADXL372_ODR_400HZ if ADXL372_MEASUREMENT_MODE
@@ -69,7 +69,7 @@ config ADXL372_ODR_6400HZ
 
 endchoice
 
-choice
+choice ADXL372_BW_FREQ
 	prompt "Low-Pass (Antialiasing) Filter corner frequency"
 	default ADXL372_BW_200HZ if ADXL372_ODR_400HZ
 	default ADXL372_BW_400HZ if ADXL372_ODR_800HZ
@@ -104,7 +104,7 @@ config ADXL372_BW_3200HZ
 
 endchoice
 
-choice
+choice ADXL372_HPF_CORNER
 	prompt "High-Pass Filter corner frequency"
 	default ADXL372_HPF_CORNER0
 	help
@@ -180,7 +180,7 @@ config ADXL372_REFERENCED_ACTIVITY_DETECTION_MODE
 	  activity detection to be based not on an absolute threshold,
 	  but on a deviation from a reference point or orientation.
 
-choice
+choice ADXL372_TRIGGER_MODE
 	prompt "Trigger mode"
 	default ADXL372_TRIGGER_NONE
 	help


### PR DESCRIPTION
This patch adds names to the KConfig choices of the ADXL372 driver.

Signed-off-by: Maximilian Deubel <maximilian.deubel@nordicsemi.no>