### PR TITLE
arch: arm: aarch32: cortex_m: minor cleanups

### DIFF
--- a/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
@@ -22,23 +22,6 @@
 extern "C" {
 #endif
 
-
-/* CP10 Access Bits */
-#define CPACR_CP10_Pos          20U
-#define CPACR_CP10_Msk          (3UL << CPACR_CP10_Pos)
-#define CPACR_CP10_NO_ACCESS    (0UL << CPACR_CP10_Pos)
-#define CPACR_CP10_PRIV_ACCESS  (1UL << CPACR_CP10_Pos)
-#define CPACR_CP10_RESERVED     (2UL << CPACR_CP10_Pos)
-#define CPACR_CP10_FULL_ACCESS  (3UL << CPACR_CP10_Pos)
-
-/* CP11 Access Bits */
-#define CPACR_CP11_Pos          22U
-#define CPACR_CP11_Msk          (3UL << CPACR_CP11_Pos)
-#define CPACR_CP11_NO_ACCESS    (0UL << CPACR_CP11_Pos)
-#define CPACR_CP11_PRIV_ACCESS  (1UL << CPACR_CP11_Pos)
-#define CPACR_CP11_RESERVED     (2UL << CPACR_CP11_Pos)
-#define CPACR_CP11_FULL_ACCESS  (3UL << CPACR_CP11_Pos)
-
 #define SCB_UFSR  (*((__IOM uint16_t *) &SCB->CFSR + 1))
 #define SCB_BFSR  (*((__IOM uint8_t *) &SCB->CFSR + 1))
 #define SCB_MMFSR (*((__IOM uint8_t *) &SCB->CFSR))

--- a/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/cmsis.h
@@ -22,10 +22,6 @@
 extern "C" {
 #endif
 
-#define SCB_UFSR  (*((__IOM uint16_t *) &SCB->CFSR + 1))
-#define SCB_BFSR  (*((__IOM uint8_t *) &SCB->CFSR + 1))
-#define SCB_MMFSR (*((__IOM uint8_t *) &SCB->CFSR))
-
 /* Fill in CMSIS required values for non-CMSIS compliant SoCs.
  * Use __NVIC_PRIO_BITS as it is required and simple to check, but
  * ultimately all SoCs will define their own CMSIS types and constants.

--- a/include/zephyr/arch/arm/aarch32/cortex_m/cpu.h
+++ b/include/zephyr/arch/arm/aarch32/cortex_m/cpu.h
@@ -33,6 +33,22 @@
 extern "C" {
 #endif
 
+/* CP10 Access Bits */
+#define CPACR_CP10_Pos          20U
+#define CPACR_CP10_Msk          (3UL << CPACR_CP10_Pos)
+#define CPACR_CP10_NO_ACCESS    (0UL << CPACR_CP10_Pos)
+#define CPACR_CP10_PRIV_ACCESS  (1UL << CPACR_CP10_Pos)
+#define CPACR_CP10_RESERVED     (2UL << CPACR_CP10_Pos)
+#define CPACR_CP10_FULL_ACCESS  (3UL << CPACR_CP10_Pos)
+
+/* CP11 Access Bits */
+#define CPACR_CP11_Pos          22U
+#define CPACR_CP11_Msk          (3UL << CPACR_CP11_Pos)
+#define CPACR_CP11_NO_ACCESS    (0UL << CPACR_CP11_Pos)
+#define CPACR_CP11_PRIV_ACCESS  (1UL << CPACR_CP11_Pos)
+#define CPACR_CP11_RESERVED     (2UL << CPACR_CP11_Pos)
+#define CPACR_CP11_FULL_ACCESS  (3UL << CPACR_CP11_Pos)
+
 #ifdef CONFIG_PM_S2RAM
 
 struct __cpu_context {


### PR DESCRIPTION
```
arch: arm: aarch32: cortex_m: move CPACR definitions to cpu.h 

Equivalent CPACR definitions for Cortex-A/R and ARM64 are all placed in
the architecture cpu.h header, do the same for Cortex-M.
```

```
arch: arm: aarch32: cortex_m: fault: use CMSIS CFSR defines 

We can use definitions provided by "standard CMSIS" to access
MEMFAULT/BUSFAULT/USGFAULT fields in CFSR.
```

This PR contains some minor prep-work for ARM soc.h cleanup.