### PR TITLE
Bluetooth: audio: Fix possible compilation error

### DIFF
--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -18,6 +18,7 @@
  * @{
  */
 
+#include <zephyr/types.h>
 #include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus


### PR DESCRIPTION
This fixes possible "unknown type name 'uint16_t'" compilation error
of bt_codec_lc3_frame_len members.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>