### PR TITLE
bluetooth: fix some soc.h usages

### DIFF
--- a/subsys/bluetooth/controller/hci/hci_driver.c
+++ b/subsys/bluetooth/controller/hci/hci_driver.c
@@ -10,7 +10,6 @@
 #include <string.h>
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/init.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/clock_control.h>

--- a/subsys/bluetooth/controller/hci/nordic/hci_vendor.c
+++ b/subsys/bluetooth/controller/hci/nordic/hci_vendor.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/addr.h>
 #include <zephyr/bluetooth/hci_vs.h>
 
-#include <soc.h>
+#include <nrf.h>
 
 uint8_t hci_vendor_read_static_addr(struct bt_hci_vs_static_addr addrs[],
 				 uint8_t size)

--- a/subsys/bluetooth/controller/ll_sw/ll_addr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_addr.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/controller.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
+++ b/subsys/bluetooth/controller/ll_sw/ll_tx_pwr.c
@@ -6,7 +6,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/hci_vs.h>
 

--- a/subsys/bluetooth/controller/ll_sw/lll.h
+++ b/subsys/bluetooth/controller/ll_sw/lll.h
@@ -4,6 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stddef.h>
+#include <stdint.h>
+
+#include <zephyr/sys_clock.h>
+
 #if defined(CONFIG_BT_CTLR_RX_PDU_META)
 #include "lll_meta.h"
 #endif /* CONFIG_BT_CTLR_RX_PDU_META */

--- a/subsys/bluetooth/controller/ll_sw/lll_chan.c
+++ b/subsys/bluetooth/controller/ll_sw/lll_chan.c
@@ -12,7 +12,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_chan
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static uint8_t chan_sel_remap(uint8_t *chan_map, uint8_t chan_index);

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/cpu.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <nrf.h>
+
 static inline void cpu_sleep(void)
 {
 #if defined(CONFIG_CPU_CORTEX_M0) || \

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/mayfly.c
@@ -5,8 +5,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <soc.h>
-
 #include "hal/nrf5/swi.h"
 
 #include "util/memq.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio.c
@@ -8,7 +8,6 @@
 #include <zephyr/sys/dlist.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/dt-bindings/gpio/gpio.h>
-#include <soc.h>
 
 #include <hal/nrf_rtc.h>
 #include <hal/nrf_timer.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -6,9 +6,9 @@
 
 #include <stdint.h>
 #include <errno.h>
-#include <soc.h>
 #include <zephyr/devicetree.h>
 #include <zephyr/sys/util_macro.h>
+
 #include <hal/nrf_radio.h>
 #include <hal/nrf_gpio.h>
 #include <hal/ccm.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_sim_nrfxx.h
@@ -6,11 +6,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/*
- * This header needs lots of types and macros, instead of relaying on
- * good inclusion order let's pull them through soc.h
- */
-#include <soc.h>
+#include <stdint.h>
+
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
+
+#include <nrf.h>
+
+#include "hal/nrf5/radio/radio_nrf5.h"
 
 /* NRF Radio HW timing constants
  * - provided in US and NS (for higher granularity)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/swi.h
@@ -4,6 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <nrf.h>
+
 /* nRF51 and nRF52 Series IRQ mapping*/
 #if defined(CONFIG_SOC_SERIES_NRF51X) || defined(CONFIG_SOC_COMPATIBLE_NRF52X)
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -9,11 +9,10 @@
 #include <errno.h>
 
 #include <zephyr/toolchain.h>
-
-#include <soc.h>
 #include <zephyr/device.h>
-
 #include <zephyr/drivers/entropy.h>
+
+#include <nrf.h>
 
 #include "hal/swi.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv.c
@@ -10,7 +10,6 @@
 
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
-#include <soc.h>
 
 #include "hal/cpu.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_aux.c
@@ -9,7 +9,6 @@
 
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci.h>
-#include <soc.h>
 
 #include "hal/cpu.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_iso.c
@@ -6,7 +6,6 @@
 
 #include <stdint.h>
 
-#include <soc.h>
 #include <zephyr/sys/byteorder.h>
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_adv_sync.c
@@ -6,8 +6,6 @@
 
 #include <stdint.h>
 
-#include <soc.h>
-
 #include <zephyr/sys/byteorder.h>
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_central.c
@@ -38,7 +38,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_central
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_clock.c
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <soc.h>
 #include <zephyr/device.h>
 
 #include <zephyr/drivers/clock_control.h>

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -9,8 +9,6 @@
 #include <stddef.h>
 
 #include <zephyr/toolchain.h>
-#include <soc.h>
-
 #include <zephyr/sys/util.h>
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn_iso.c
@@ -19,7 +19,6 @@
 
 #define LOG_MODULE_NAME bt_ctlr_lll_conn_iso
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdint.h>
-#include <soc.h>
+
 #include <zephyr/bluetooth/hci.h>
 
 #include "util/util.h"
@@ -30,7 +30,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_CTLR_DF_DEBUG_ENABLE)
 #define LOG_MODULE_NAME bt_ctlr_lll_df
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 /* Minimum number of antenna switch patterns required by Direction Finding Extension to be

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral.c
@@ -37,7 +37,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_periph
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_peripheral_iso.c
@@ -7,7 +7,6 @@
 #include <zephyr/toolchain.h>
 #include <zephyr/types.h>
 #include <zephyr/sys/byteorder.h>
-#include <soc.h>
 
 #include "hal/cpu.h"
 #include "util/memq.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan.c
@@ -7,9 +7,6 @@
 #include <stdint.h>
 
 #include <zephyr/toolchain.h>
-
-#include <soc.h>
-
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci.h>
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_scan_aux.c
@@ -47,7 +47,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_scan_aux
 #include "common/log.h"
-#include <soc.h>
 #include <ull_scan_types.h>
 #include "hal/debug.h"
 

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync.c
@@ -41,7 +41,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_lll_sync
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_sync_iso.c
@@ -6,7 +6,6 @@
 
 #include <stdint.h>
 
-#include <soc.h>
 #include <zephyr/sys/byteorder.h>
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_test.c
@@ -9,8 +9,6 @@
 
 #include <zephyr/toolchain.h>
 
-#include <soc.h>
-
 #include "hal/cpu.h"
 #include "hal/cntr.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/cpu.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <soc.h>
+
 static inline void cpu_sleep(void)
 {
 	__WFE();

--- a/subsys/bluetooth/controller/ll_sw/ull.c
+++ b/subsys/bluetooth/controller/ll_sw/ull.c
@@ -9,7 +9,6 @@
 #include <errno.h>
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/device.h>
 #include <zephyr/drivers/entropy.h>
 #include <zephyr/bluetooth/hci.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_adv.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv.c
@@ -8,7 +8,6 @@
 #include <string.h>
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_iso.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/bluetooth.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_central.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_central.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_conn.c
@@ -6,7 +6,6 @@
 
 #include <stddef.h>
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_df.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_df.c
@@ -6,7 +6,6 @@
 
 #include <stdint.h>
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/sys/util.h>
 #include <zephyr/bluetooth/hci.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -7,7 +7,6 @@
 #include <string.h>
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_iso.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 
 #include "hal/cpu.h"
 #include "hal/ccm.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -46,7 +46,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 #define LLCTRL_PDU_SIZE (offsetof(struct pdu_data, llctrl) + sizeof(struct pdu_data_llctrl))

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -48,7 +48,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_cis
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static uint16_t cc_event_counter(struct ll_conn *conn)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_chmu.c
@@ -42,7 +42,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_chmu
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 /* Hardcoded instant delta +6 */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_common.c
@@ -46,7 +46,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_common
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 /* LLCP Local Procedure FSM states */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_conn_upd.c
@@ -46,7 +46,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_conn_upd
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 /* Hardcoded instant delta +6 */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_enc.c
@@ -46,7 +46,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_enc
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 #if defined(CONFIG_BT_CENTRAL)

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_local.c
@@ -42,7 +42,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_local
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static void lr_check_done(struct ll_conn *conn, struct proc_ctx *ctx);

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_pdu.c
@@ -43,7 +43,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_pdu
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 /*

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -45,7 +45,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_phy
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 /* LLCP Local Procedure PHY Update FSM states */

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_remote.c
@@ -44,7 +44,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_llcp_remote
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static void rr_check_done(struct ll_conn *conn, struct proc_ctx *ctx);

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/sys/byteorder.h>
 

--- a/subsys/bluetooth/controller/ll_sw/ull_scan.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan.c
@@ -6,7 +6,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/bluetooth/hci.h>
 
 #include "hal/cpu.h"

--- a/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_scan_aux.c
@@ -40,7 +40,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_scan_aux
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 static int init_reset(void);

--- a/subsys/bluetooth/controller/ll_sw/ull_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_sync.c
@@ -5,7 +5,6 @@
  */
 
 #include <zephyr/zephyr.h>
-#include <soc.h>
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/bluetooth/hci.h>
 
@@ -49,7 +48,6 @@
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_HCI_DRIVER)
 #define LOG_MODULE_NAME bt_ctlr_ull_sync
 #include "common/log.h"
-#include <soc.h>
 #include "hal/debug.h"
 
 /* Check that timeout_reload member is at safe offset when ll_sync_set is

--- a/subsys/bluetooth/controller/ticker/ticker.c
+++ b/subsys/bluetooth/controller/ticker/ticker.c
@@ -7,7 +7,6 @@
 
 #include <stdbool.h>
 #include <zephyr/types.h>
-#include <soc.h>
 
 #include "hal/cntr.h"
 #include "hal/ticker.h"

--- a/subsys/bluetooth/controller/util/dbuf.c
+++ b/subsys/bluetooth/controller/util/dbuf.c
@@ -7,8 +7,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 
-#include <soc.h>
-
 #include "hal/cpu.h"
 
 #include "util/util.h"

--- a/subsys/bluetooth/controller/util/memq.c
+++ b/subsys/bluetooth/controller/util/memq.c
@@ -34,8 +34,6 @@
 
 #include <stddef.h>
 
-#include <soc.h>
-
 #include "hal/cpu.h"
 
 #include "memq.h"

--- a/subsys/bluetooth/controller/util/memq.h
+++ b/subsys/bluetooth/controller/util/memq.h
@@ -5,6 +5,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <stdint.h>
+
 /**
  * @brief   Element of a memory-queue
  * @details Elements form a linked list, and as payload carries a pointer

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -17,7 +17,6 @@
 #include <zephyr/sys/byteorder.h>
 #include <zephyr/debug/stack.h>
 #include <zephyr/sys/__assert.h>
-#include <soc.h>
 
 #include <zephyr/settings/settings.h>
 


### PR DESCRIPTION
- Remove unnecessary <soc.h> includes
- Make some headers self-contained (discovered as part of soc.h removal, there are many others that are not but things _just work_)

Briefly tested locally, will wait for CI to report any errors.