### PR TITLE
net: sockets: Fix potential deadlock during TCP send

### DIFF
--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -693,6 +693,10 @@ static int send_check_and_wait(struct net_context *ctx, int status,
 		goto out;
 	}
 
+	if (ctx->cond.lock) {
+		(void)k_mutex_unlock(ctx->cond.lock);
+	}
+
 	if (status == -ENOBUFS) {
 		/* We can monitor net_pkt/net_buf avaialbility, so just wait. */
 		k_sleep(K_MSEC(*retry_timeout));
@@ -717,6 +721,10 @@ static int send_check_and_wait(struct net_context *ctx, int status,
 	 * Cap the value to WAIT_BUFS_MAX_MS
 	 */
 	*retry_timeout = MIN(WAIT_BUFS_MAX_MS, *retry_timeout << 1);
+
+	if (ctx->cond.lock) {
+		(void)k_mutex_lock(ctx->cond.lock, K_FOREVER);
+	}
 
 	return 0;
 


### PR DESCRIPTION
There is a potential, corner case scenario, where a deadlock can occur
between TCP and socket layers, when both ends of the connection transmit
data.

The scenario is as follows:
 * Both ends of the connection transmit data,
 * Zephyr side send() call gets blocked due to filing the TX window
 * The next incoming packet is data packet, not updating the RX window
   on the peer side or acknowledging new data. The TCP layer will
   attepmt to notify the new data to the socket layer, by calling the
   registered callback. This will block the RX thread processing the TCP
   layer, as the socket mutex is already acquired by the blocked send()
   call.
 * No further packets are processed until the socket mutex is freed,
   which does not happen as the only way to unblock send() is process
   a new ACK, either updating window size or a acknowledging data.
   The connection stalls until send() times out.

The deadlock is not permament, as both threads get unlocked once send()
times out. It effectively breaks the active connection though.

Fix this, by unlocking the socket mutex for the time the send() call is
idle. Once the TCP layer notifies that the window is available again,
the mutex is acquired back.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>