### PR TITLE
ci: Use zephyrproject-rtos/action-s3-cache

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -83,7 +83,7 @@ jobs:
           message("::set-output name=repo::${repo2}")
       - name: use cache
         id: cache-ccache
-        uses: nashif/action-s3-cache@master
+        uses: zephyrproject-rtos/action-s3-cache@v1
         with:
           key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-clang-${{ matrix.platform }}-ccache
           path: /github/home/.ccache

--- a/.github/workflows/codecov.yaml
+++ b/.github/workflows/codecov.yaml
@@ -66,7 +66,7 @@ jobs:
 
       - name: use cache
         id: cache-ccache
-        uses: nashif/action-s3-cache@master
+        uses: zephyrproject-rtos/action-s3-cache@v1
         with:
           key: ${{ steps.ccache_cache_prop.outputs.repo }}-${{github.event_name}}-${{matrix.platform}}-codecov-ccache
           path: /github/home/.ccache

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -195,7 +195,7 @@ jobs:
 
       - name: use cache
         id: cache-ccache
-        uses: nashif/action-s3-cache@master
+        uses: zephyrproject-rtos/action-s3-cache@v1
         continue-on-error: true
         with:
           key: ${{ steps.ccache_cache_timestamp.outputs.repo }}-${{ github.ref_name }}-${{github.event_name}}-${{ matrix.subset }}-ccache


### PR DESCRIPTION
This series updates the CI workflows to use the 'action-s3-cache'
action from the zephyrproject-rtos organisation.

It also updates the action reference such that it uses a specific
version of the action instead of the latest master.