### PR TITLE
device: rework how we do struct device extern's

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -28,7 +28,7 @@ set(ZEPHYR_DTS                  ${PROJECT_BINARY_DIR}/zephyr.dts)
 # and should not be made part of the documentation.
 set(EDT_PICKLE                  ${PROJECT_BINARY_DIR}/edt.pickle)
 set(DEVICETREE_UNFIXED_H        ${PROJECT_BINARY_DIR}/include/generated/devicetree_unfixed.h)
-set(DEVICE_EXTERN_H             ${PROJECT_BINARY_DIR}/include/generated/device_extern.h)
+set(DEVICE_ORD_H             ${PROJECT_BINARY_DIR}/include/generated/device_ord.h)
 set(DTS_POST_CPP                ${PROJECT_BINARY_DIR}/zephyr.dts.pre)
 set(DTS_DEPS                    ${PROJECT_BINARY_DIR}/zephyr.dts.d)
 # The location of a list of known vendor prefixes.
@@ -209,7 +209,7 @@ if(SUPPORTS_DTS)
   --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
   --bindings-dirs ${DTS_ROOT_BINDINGS}
   --header-out ${DEVICETREE_UNFIXED_H}.new
-  --device-header-out ${DEVICE_EXTERN_H}.new
+  --device-header-out ${DEVICE_ORD_H}.new
   --dts-out ${ZEPHYR_DTS}.new # for debugging and dtc
   --edt-pickle-out ${EDT_PICKLE}
   ${EXTRA_GEN_DEFINES_ARGS}
@@ -226,11 +226,11 @@ if(SUPPORTS_DTS)
   else()
     zephyr_file_copy(${ZEPHYR_DTS}.new ${ZEPHYR_DTS} ONLY_IF_DIFFERENT)
     zephyr_file_copy(${DEVICETREE_UNFIXED_H}.new ${DEVICETREE_UNFIXED_H} ONLY_IF_DIFFERENT)
-    zephyr_file_copy(${DEVICE_EXTERN_H}.new ${DEVICE_EXTERN_H})
-    file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_UNFIXED_H}.new ${DEVICE_EXTERN_H}.new)
+    zephyr_file_copy(${DEVICE_ORD_H}.new ${DEVICE_ORD_H})
+    file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_UNFIXED_H}.new ${DEVICE_ORD_H}.new)
     message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
     message(STATUS "Generated devicetree_unfixed.h: ${DEVICETREE_UNFIXED_H}")
-    message(STATUS "Generated device_extern.h: ${DEVICE_EXTERN_H}")
+    message(STATUS "Generated device_extern.h: ${DEVICE_ORD_H}")
   endif()
 
   execute_process(
@@ -293,5 +293,5 @@ if(SUPPORTS_DTS)
 else()
   set(header_template ${ZEPHYR_BASE}/misc/generated/generated_header.template)
   zephyr_file_copy(${header_template} ${DEVICETREE_UNFIXED_H} ONLY_IF_DIFFERENT)
-  zephyr_file_copy(${header_template} ${DEVICE_EXTERN_H} ONLY_IF_DIFFERENT)
+  zephyr_file_copy(${header_template} ${DEVICE_ORD_H} ONLY_IF_DIFFERENT)
 endif(SUPPORTS_DTS)

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -950,12 +950,15 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,		\
 		(&DEVICE_NAME_GET(dev_name)), level, prio)
 
+/* device_extern is generated based on devicetree nodes */
+#undef DEVICE_ORD_MACRO
+#define DEVICE_ORD_MACRO(x) extern const struct device DEVICE_DT_NAME_GET(x)
+
+#include <device_ord.h>
+
 #ifdef __cplusplus
 }
 #endif
-
-/* device_extern is generated based on devicetree nodes */
-#include <device_extern.h>
 
 #include <syscalls/device.h>
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -146,34 +146,19 @@ def main():
         write_chosen(edt)
         write_global_compat_info(edt)
 
-        write_device_extern_header(args.device_header_out, edt)
+        write_device_ord_header(args.device_header_out, edt)
 
     if args.edt_pickle_out:
         write_pickled_edt(edt, args.edt_pickle_out)
 
 
-def write_device_extern_header(device_header_out, edt):
+def write_device_ord_header(device_ord_header_out, edt):
     # Generate header that will extern devicetree struct device's
 
-    with open(device_header_out, "w", encoding="utf-8") as dev_header_file:
-        print("#ifndef DEVICE_EXTERN_GEN_H", file=dev_header_file)
-        print("#define DEVICE_EXTERN_GEN_H", file=dev_header_file)
-        print("", file=dev_header_file)
-        print("#ifdef __cplusplus", file=dev_header_file)
-        print('extern "C" {', file=dev_header_file)
-        print("#endif", file=dev_header_file)
-        print("", file=dev_header_file)
-
+    with open(device_ord_header_out, "w", encoding="utf-8") as dev_ord_header_file:
         for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
-            print(f"extern const struct device DEVICE_DT_NAME_GET(DT_{node.z_path_id}); /* dts_ord_{node.dep_ordinal} */",
-                  file=dev_header_file)
-
-        print("", file=dev_header_file)
-        print("#ifdef __cplusplus", file=dev_header_file)
-        print("}", file=dev_header_file)
-        print("#endif", file=dev_header_file)
-        print("", file=dev_header_file)
-        print("#endif /* DEVICE_EXTERN_GEN_H */", file=dev_header_file)
+            print(f"DEVICE_ORD_MACRO(DT_{node.z_path_id}); /* dts_ord_{node.dep_ordinal} */",
+                  file=dev_ord_header_file)
 
 
 def setup_edtlib_logging():


### PR DESCRIPTION
....
This lets use define DEVICE_ORD_MACRO as needed so if we want to
do different things based on it we can.
....

Signed-off-by: Kumar Gala <galak@kernel.org>