### PR TITLE
display: ssd1306: Use segment/page offset props.

### DIFF
--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -227,15 +227,16 @@ static int ssd1306_write(const struct device *dev, const uint16_t x, const uint1
 		x, y, desc->pitch, desc->width, desc->height, buf_len);
 
 #if defined(CONFIG_SSD1306_DEFAULT)
+	uint8_t x_offset = x + DT_INST_PROP(0, segment_offset);
 	uint8_t cmd_buf[] = {
 		SSD1306_SET_MEM_ADDRESSING_MODE,
 		SSD1306_ADDRESSING_MODE,
 		SSD1306_SET_COLUMN_ADDRESS,
-		x,
-		(x + desc->width - 1),
+		x_offset,
+		(x_offset + desc->width - 1),
 		SSD1306_SET_PAGE_ADDRESS,
-		y/8,
-		((y + desc->height)/8 - 1)
+		((y)/8) + DT_INST_PROP(0, page_offset),
+		(((y + desc->height)/8 - 1)) + DT_INST_PROP(0, page_offset)
 	};
 
 	if (ssd1306_write_bus(dev, cmd_buf, sizeof(cmd_buf), true)) {


### PR DESCRIPTION
Leverage the DT segment and page offset properties for
sending data to ssd1306 devices. Needed for displays
like the 72x20 OLED that don't use the "top left corner"
of the page/segments for the display.

Signed-off-by: Peter Johanson <peter@peterjohanson.com>

I encountered this when getting a tiny 72x40 ssd1306 display working (https://twitter.com/petejohanson/status/1547336662895689728?s=20&t=bBMrBsGDnKkqRwL2v79y_Q) w/ Zephyr. 

In particular, with these code changes, the display works with:

```
        ssd1306: ssd1306@3c {
                compatible = "solomon,ssd1306fb";
                reg = <0x3c>;                                                                
                label = "SSD1306";
                width = <72>;
                height = <40>;
                segment-offset = <28>;
                page-offset = <1>;
                display-offset = <28>;
                multiplex-ratio = <31>;
                segment-remap;                                                               
                com-invdir;
                com-sequential;                                                               
                prechargep = <0x22>;                                                         
        };
```

You can see this requires the segment offset of `28` to shift the X axis in to range, and a page offset of `1` to actually start the Y axis data on the second page.