### PR TITLE
drivers: ieee802154: b91: Convert to DEVICE_DT_INST_DEFINE

### DIFF
--- a/drivers/ieee802154/Kconfig.b91
+++ b/drivers/ieee802154/Kconfig.b91
@@ -9,12 +9,6 @@ menuconfig IEEE802154_TELINK_B91
 
 if IEEE802154_TELINK_B91
 
-config IEEE802154_B91_DRV_NAME
-	string "b91 IEEE 802.15.4 Driver's name"
-	default "IEEE802154_b91"
-	help
-	  This option sets the driver name
-
 config IEEE802154_B91_INIT_PRIO
 	int "Telink B91 IEEE 802.15.4 initialization priority"
 	default 80

--- a/drivers/ieee802154/ieee802154_b91.c
+++ b/drivers/ieee802154/ieee802154_b91.c
@@ -613,14 +613,11 @@ static struct ieee802154_radio_api b91_radio_api = {
 
 /* IEEE802154 driver registration */
 #if defined(CONFIG_NET_L2_IEEE802154) || defined(CONFIG_NET_L2_OPENTHREAD)
-NET_DEVICE_INIT(b91_154_radio, CONFIG_IEEE802154_B91_DRV_NAME,
-		b91_init, NULL, &data, NULL,
-		CONFIG_IEEE802154_B91_INIT_PRIO,
-		&b91_radio_api, L2,
-		L2_CTX_TYPE, MTU);
+NET_DEVICE_DT_INST_DEFINE(0, b91_init, NULL, &data, NULL,
+			  CONFIG_IEEE802154_B91_INIT_PRIO,
+			  &b91_radio_api, L2, L2_CTX_TYPE, MTU);
 #else
-DEVICE_DEFINE(b91_154_radio, CONFIG_IEEE802154_B91_DRV_NAME,
-	      b91_init, NULL, &data, NULL,
-	      POST_KERNEL, CONFIG_IEEE802154_B91_INIT_PRIO,
-	      &b91_radio_api);
+DEVICE_DT_INST_DEFINE(0, b91_init, NULL, &data, NULL,
+		      POST_KERNEL, CONFIG_IEEE802154_B91_INIT_PRIO,
+		      &b91_radio_api);
 #endif


### PR DESCRIPTION
Move driver to use {NET_}DEVICE_DT_INST_DEFINE.  This lets us
remove the IEEE802154_B91_DRV_NAME Kconfig symobl.

Signed-off-by: Kumar Gala <galak@kernel.org>