### PR TITLE
drivers: misc: ft8xx: Convert to DEVICE_DT_INST_DEFINE

### DIFF
--- a/drivers/misc/ft8xx/ft8xx.c
+++ b/drivers/misc/ft8xx/ft8xx.c
@@ -167,9 +167,8 @@ static int ft8xx_init(const struct device *dev)
 	return 0;
 }
 
-DEVICE_DEFINE(ft8xx_spi, "ft8xx_spi", ft8xx_init, NULL,
-		&ft8xx_data, &ft8xx_config,
-		APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
+DEVICE_DT_INST_DEFINE(0, ft8xx_init, NULL, &ft8xx_data, &ft8xx_config,
+		      APPLICATION, CONFIG_KERNEL_INIT_PRIORITY_DEVICE, NULL);
 
 int ft8xx_get_touch_tag(void)
 {


### PR DESCRIPTION
Move driver to use DEVICE_DT_INST_DEFINE.

Signed-off-by: Kumar Gala <galak@kernel.org>