### PR TITLE
sdhc: dts: remove label property from SDHC nodes

### DIFF
--- a/boards/arm/arduino_mkrzero/arduino_mkrzero.dts
+++ b/boards/arm/arduino_mkrzero/arduino_mkrzero.dts
@@ -86,7 +86,6 @@
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		label = "SDHC_0";
 		spi-max-frequency = <1000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -196,7 +196,6 @@
 		reg = <0>;
 		compatible = "zephyr,sdhc-spi-slot";
 		status = "okay";
-		label = "SDHC_0";
 		spi-max-frequency = <8000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -115,7 +115,6 @@
 		reg = <0>;
 		compatible = "zephyr,sdhc-spi-slot";
 		spi-max-frequency = <25000000>;
-		label = "SDHC_0";
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -129,7 +129,6 @@ uext_serial: &usart1 {};
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		label = "SDHC_0";
 		spi-max-frequency = <24000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/boards/riscv/longan_nano/longan_nano-common.dtsi
+++ b/boards/riscv/longan_nano/longan_nano-common.dtsi
@@ -109,7 +109,6 @@
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		label = "SDHC_0";
 		spi-max-frequency = <24000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -40,7 +40,6 @@
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <1>;
 		status = "okay";
-		label = "SDHC_0";
 		spi-max-frequency = <24000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/boards/shields/v2c_daplink/v2c_daplink.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink.overlay
@@ -39,7 +39,6 @@
 	sdhc0: sdhc@0 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
-		label = "SDHC_0";
 		spi-max-frequency = <25000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink_cfg.overlay
@@ -30,7 +30,6 @@
 	sdhc0: sdhc@0 {
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <0>;
-		label = "SDHC_0";
 		spi-max-frequency = <25000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
+++ b/boards/shields/waveshare_epaper/dts/waveshare_epaper_common.dtsi
@@ -13,7 +13,6 @@
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <1>;
 		status = "okay";
-		label = "SDHC_0";
 		spi-max-frequency = <24000000>;
 		mmc {
 			compatible = "zephyr,sdmmc-disk";

--- a/doc/services/storage/disk/access.rst
+++ b/doc/services/storage/disk/access.rst
@@ -50,7 +50,6 @@ at 24 MHz once the SD card has been initialized:
 		    compatible = "zephyr,sdhc-spi-slot";
                     reg = <0>;
                     status = "okay";
-                    label = "SDHC_0";
 		    mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -819,7 +819,6 @@
 			status = "disabled";
 			interrupts = <110 0>;
 			clocks = <&ccm IMX_CCM_USDHC1_CLK 0 0>;
-			label = "SDHC_0";
 			max-current-330 = <1020>;
 			max-current-180 = <1020>;
 			max-bus-freq = <208000000>;
@@ -832,7 +831,6 @@
 			status = "disabled";
 			interrupts = <111 0>;
 			clocks = <&ccm IMX_CCM_USDHC2_CLK 0 0>;
-			label = "SDHC_1";
 			max-current-330 = <120>;
 			max-current-180 = <45>;
 			max-bus-freq = <198000000>;

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -794,7 +794,6 @@
 			status = "disabled";
 			interrupts = <133 0>;
 			clocks = <&ccm IMX_CCM_USDHC1_CLK 0 0>;
-			label = "SDHC_0";
 			max-current-330 = <1020>;
 			max-current-180 = <1020>;
 			max-bus-freq = <208000000>;
@@ -807,7 +806,6 @@
 			status = "disabled";
 			interrupts = <134 0>;
 			clocks = <&ccm IMX_CCM_USDHC2_CLK 0 0>;
-			label = "SDHC_1";
 			max-current-330 = <1020>;
 			max-current-180 = <1020>;
 			max-bus-freq = <208000000>;

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -393,7 +393,6 @@
 		status = "disabled";
 		interrupts = <45 0>;
 		clocks = <&clkctl1 MCUX_USDHC1_CLK>;
-		label = "SDHC_0";
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <208000000>;
@@ -406,7 +405,6 @@
 		status = "disabled";
 		interrupts = <46 0>;
 		clocks = <&clkctl1 MCUX_USDHC2_CLK>;
-		label = "SDHC_1";
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <208000000>;

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -334,7 +334,6 @@
 		status = "disabled";
 		interrupts = <45 0>;
 		clocks = <&clkctl1 MCUX_USDHC1_CLK>;
-		label = "SDHC_0";
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <208000000>;
@@ -347,7 +346,6 @@
 		status = "disabled";
 		interrupts = <46 0>;
 		clocks = <&clkctl1 MCUX_USDHC2_CLK>;
-		label = "SDHC_1";
 		max-current-330 = <1020>;
 		max-current-180 = <1020>;
 		max-bus-freq = <208000000>;

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -11,9 +11,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   data-timeout:
     type: int
     required: false


### PR DESCRIPTION
Remove 'label' property from SDHC nodes.  We can use variants of
DEVICE_DT_GET to get access to a device pointer for use in an
application.

Signed-off-by: Kumar Gala <galak@kernel.org>