### PR TITLE
dts: bindings: device labels are now optional

### DIFF
--- a/dts/bindings/adc/adc-controller.yaml
+++ b/dts/bindings/adc/adc-controller.yaml
@@ -7,9 +7,6 @@
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     "#io-channel-cells":
       type: int
       required: true

--- a/dts/bindings/dac/dac-controller.yaml
+++ b/dts/bindings/dac/dac-controller.yaml
@@ -6,9 +6,6 @@
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     "#io-channel-cells":
       type: int
       required: true

--- a/dts/bindings/display/display-controller.yaml
+++ b/dts/bindings/display/display-controller.yaml
@@ -15,6 +15,3 @@ properties:
       required: true
       description: |
         Width of the panel driven by the controller, with the units in pixels.
-
-    label:
-      required: true

--- a/dts/bindings/ethernet/ethernet.yaml
+++ b/dts/bindings/ethernet/ethernet.yaml
@@ -10,8 +10,6 @@ properties:
       type: uint8-array
       required: false
       description: Specifies the MAC address that was assigned to the network device
-    label:
-      required: true
     zephyr,random-mac-address:
       type: boolean
       required: false

--- a/dts/bindings/flash_controller/flash-controller.yaml
+++ b/dts/bindings/flash_controller/flash-controller.yaml
@@ -3,8 +3,5 @@
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true

--- a/dts/bindings/i2c/i2c-device.yaml
+++ b/dts/bindings/i2c/i2c-device.yaml
@@ -11,5 +11,3 @@ properties:
     reg:
       required: true
       description: device address on i2c bus
-    label:
-      required: true

--- a/dts/bindings/i2s/i2s-device.yaml
+++ b/dts/bindings/i2s/i2s-device.yaml
@@ -10,5 +10,3 @@ on-bus: i2s
 properties:
     reg:
       required: true
-    label:
-      required: true

--- a/dts/bindings/interrupt-controller/shared-irq.yaml
+++ b/dts/bindings/interrupt-controller/shared-irq.yaml
@@ -7,6 +7,3 @@ include: [interrupt-controller.yaml, base.yaml]
 properties:
   interrupts:
       required: true
-
-  label:
-      required: true

--- a/dts/bindings/led/led-controller.yaml
+++ b/dts/bindings/led/led-controller.yaml
@@ -3,10 +3,6 @@
 
 # Common fields for LED controllers and child LEDs
 
-properties:
-    label:
-      required: true
-
 child-binding:
     description: LED child node
     properties:

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -9,14 +9,6 @@ include:
     - name: base.yaml
       property-allowlist: [label]
 
-properties:
-    label:
-      description: |
-        Human readable string describing the device and used to set the device
-        name. It can be passed as argument to device_get_binding() to retrieve
-        the device. If this property is omitted, then the device name is set
-        from the node full name.
-
 child-binding:
     description: PWM LED child node
     properties:

--- a/dts/bindings/mtd/eeprom-base.yaml
+++ b/dts/bindings/mtd/eeprom-base.yaml
@@ -14,5 +14,3 @@ properties:
       type: boolean
       required: false
       description: Disable writes to the EEPROM
-    label:
-      required: true

--- a/dts/bindings/pwm/pwm-controller.yaml
+++ b/dts/bindings/pwm/pwm-controller.yaml
@@ -4,9 +4,6 @@
 # Common fields for PWM controllers
 
 properties:
-    label:
-      required: true
-
     "#pwm-cells":
       type: int
       required: true

--- a/dts/bindings/regulator/regulator-fixed.yaml
+++ b/dts/bindings/regulator/regulator-fixed.yaml
@@ -18,9 +18,6 @@ include: regulator.yaml
 compatible: "regulator-fixed"
 
 properties:
-  label:
-    required: true
-
   regulator-name:
     type: string
     required: true

--- a/dts/bindings/rtc/rtc.yaml
+++ b/dts/bindings/rtc/rtc.yaml
@@ -10,8 +10,6 @@ properties:
       type: int
       required: false
       description: Clock frequency information for RTC operation
-    label:
-      required: true
     interrupts:
       required: true
 

--- a/dts/bindings/serial/uart-device.yaml
+++ b/dts/bindings/serial/uart-device.yaml
@@ -6,7 +6,3 @@
 include: base.yaml
 
 on-bus: uart
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/spi/spi-device.yaml
+++ b/dts/bindings/spi/spi-device.yaml
@@ -14,8 +14,6 @@ properties:
       type: int
       required: true
       description: Maximum clock frequency of device's SPI interface in Hz
-    label:
-      required: true
     duplex:
       type: int
       default: 0


### PR DESCRIPTION
All in tree device drivers on a bus use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>