### PR TITLE
GD7965 refactor and optional overrides

### DIFF
--- a/drivers/display/Kconfig.gd7965
+++ b/drivers/display/Kconfig.gd7965
@@ -6,6 +6,5 @@
 config GD7965
 	bool "GD7965 compatible display controller driver"
 	depends on SPI
-	depends on HEAP_MEM_POOL_SIZE != 0
 	help
 	  Enable driver for GD7965 compatible controller.

--- a/drivers/display/gd7965_regs.h
+++ b/drivers/display/gd7965_regs.h
@@ -72,16 +72,25 @@
 #define GD7965_CDI_DDX1				BIT(1)
 #define GD7965_CDI_DDX0				BIT(0)
 
-#define GD7965_TRES_REG_LENGTH			4U
-#define GD7965_TRES_HRES_IDX			0
-#define GD7965_TRES_VRES_IDX			2
+struct gd7965_tres {
+	uint16_t hres;
+	uint16_t vres;
+} __packed;
 
-#define GD7965_PTL_REG_LENGTH			9U
-#define GD7965_PTL_HRST_IDX			0
-#define GD7965_PTL_HRED_IDX			2
-#define GD7965_PTL_VRST_IDX			4
-#define GD7965_PTL_VRED_IDX			6
-#define GD7965_PTL_PT_SCAN			BIT(0)
+BUILD_ASSERT(sizeof(struct gd7965_tres) == 4);
+
+struct gd7965_ptl {
+	uint16_t hrst;
+	uint16_t hred;
+	uint16_t vrst;
+	uint16_t vred;
+	uint8_t flags;
+} __packed;
+
+BUILD_ASSERT(sizeof(struct gd7965_ptl) == 9);
+
+#define GD7965_PTL_FLAG_PT_SCAN			BIT(0)
+
 
 /* Time constants in ms */
 #define GD7965_RESET_DELAY			10U

--- a/dts/bindings/display/gooddisplay,gd7965.yaml
+++ b/dts/bindings/display/gooddisplay,gd7965.yaml
@@ -37,20 +37,22 @@ properties:
 
     pwr:
       type: uint8-array
-      required: true
+      required: false
       description: Power Setting (PWR) values
 
     softstart:
       type: uint8-array
-      required: true
+      required: false
       description: Booster Soft Start (BTST) values
 
     cdi:
       type: int
-      required: true
-      description: VCOM and data interval value
+      required: false
+      description: |
+        VCOM and data interval value. This value is optional but must
+        be provided to enable border refresh control.
 
     tcon:
       type: int
-      required: true
+      required: false
       description: TCON setting value


### PR DESCRIPTION
This pull request aims to achieve make the GD7965 driver usable for more devices by doing the following:

* Remove the dependency on kernel heap. This can be achieved by implementing a special type of SPI command helper that writes a pattern of an arbitrary size to the controller's SRAM. This both more efficient than the current implementation and avoids using heap memory.
* Add support for multiple devices by embedding all configuration and runtime data in config/data structs.
* Make overrides that are sometimes sometimes missing from datasheets / example code optional.

---

There are still a few more changes that need to be made to this driver. The driver should be renamed to something like `epd_uc` since the GD7965 seems to be an UC8179c from Ultra Chip. We also need to make better use of compatible strings to distinguish between different chip variants since they have subtly different register layouts. For example, the UC8176 has a completely different CDI layout.