### PR TITLE
dts: bindings: Remove compatible from nxp,imx-flexspi-device.yaml

### DIFF
--- a/dts/bindings/mtd/nxp,imx-flexspi-device.yaml
+++ b/dts/bindings/mtd/nxp,imx-flexspi-device.yaml
@@ -3,8 +3,6 @@
 
 description: NXP FlexSPI device
 
-compatible: "nxp,imx-flexspi-device"
-
 include: [spi-device.yaml, "jedec,jesd216.yaml"]
 
 properties:


### PR DESCRIPTION
The 'nxp,imx-flexspi-device' compatible that was specified in
the YAML file is not an actual compatible that is intented to be
used.  Instead the YAML file is included in other YAML files
that set specific compatible.

If the 'nxp,imx-flexspi-device' was used we'd actually get an error
from edtlib because of having the same compatible specified by
two different YAML files.

Signed-off-by: Kumar Gala <galak@kernel.org>