### PR TITLE
soc: riscv: andes_v5: refine andes_v5 porting

### DIFF
--- a/soc/riscv/riscv-privilege/andes_v5/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/andes_v5/CMakeLists.txt
@@ -5,10 +5,10 @@ zephyr_include_directories(${CONFIG_SOC})
 zephyr_sources(
   start.S
   soc_irq.S
+  l2_cache.c
 )
 
 zephyr_sources_ifdef(CONFIG_SOC_ANDES_V5_PMA pma.c)
-zephyr_sources_ifdef(CONFIG_SOC_ANDES_V5_L2_CACHE l2_cache.c)
 
 # Note: AndeStar V5 DSP needs custom Andes V5 toolchain
 if(CONFIG_SOC_ANDES_V5_HWDSP)

--- a/soc/riscv/riscv-privilege/andes_v5/Kconfig.defconfig.ae350
+++ b/soc/riscv/riscv-privilege/andes_v5/Kconfig.defconfig.ae350
@@ -7,7 +7,7 @@ config SOC
 	default "ae350"
 
 config SYS_CLOCK_TICKS_PER_SEC
-	default 100 if !CACHE_ENABLE
+	default 100 if (!CACHE_ENABLE || XIP)
 
 config MAIN_STACK_SIZE
 	default 2048

--- a/soc/riscv/riscv-privilege/andes_v5/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/andes_v5/Kconfig.soc
@@ -52,11 +52,6 @@ config CACHE_ENABLE
 	bool "Cache"
 	default n
 
-config SOC_ANDES_V5_L2_CACHE
-	bool "Andes V5 L2 cache controller"
-	depends on CACHE_ENABLE
-	default y
-
 config SOC_ANDES_V5_HWDSP
 	bool "AndeStar V5 DSP ISA"
 	select RISCV_SOC_CONTEXT_SAVE

--- a/soc/riscv/riscv-privilege/andes_v5/smu.h
+++ b/soc/riscv/riscv-privilege/andes_v5/smu.h
@@ -31,6 +31,7 @@
 #define SMU_BOARDVER			0x04
 #define SMU_SYSTEMCFG			0x08
 #define SMU_SMUVER			0x0C
+#define SMU_WRSR			0x10
 
 /* Reset vectors */
 #define SMU_HARTn_RESET_VECTOR(n)	(0x50 +  0x8 * (n))
@@ -52,9 +53,17 @@
  * SMU helper constant
  */
 
-#define SMU_SYSTEMCFG_CORENUM_MASK	0xFF
+/* Configuration Register bitmask */
+#define SMU_SYSTEMCFG_CORENUM_MASK	BIT_MASK(8)
 #define SMU_SYSTEMCFG_L2C		BIT(8)
 #define SMU_SYSTEMCFG_DFS		BIT(9)
 #define SMU_SYSTEMCFG_DC_COHEN		BIT(10)
+
+/* Wake-Up and Reset Status Register bitmask */
+#define SMU_WRSR_APOR			BIT(0)
+#define SMU_WRSR_MPOR			BIT(1)
+#define SMU_WRSR_HW			BIT(2)
+#define SMU_WRSR_WDT			BIT(3)
+#define SMU_WRSR_SW			BIT(4)
 
 #endif /* SOC_RISCV_ANDES_V5_SMU_H_ */


### PR DESCRIPTION
This PR refines andes_v5 soc porting for following concept

1. adp_xc7k_ae350 board decrease tick rate to 100 for XIP overhead.
2. add SMU register macro for hwinfo driver usage in the future.
3. determine the initialization of the L2 cache at runtime rather than according to Kconfig at build time.
4. fix typo and return value of pma initialization.