### PR TITLE
Bluetooth; GATT: don't immediately cancel CCC write request

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -4901,6 +4901,11 @@ int bt_gatt_unsubscribe(struct bt_conn *conn,
 		return -EINVAL;
 	}
 
+	/* Attempt to cancel if write is pending */
+	if (atomic_test_bit(params->flags, BT_GATT_SUBSCRIBE_FLAG_WRITE_PENDING)) {
+		bt_gatt_cancel(conn, params);
+	}
+
 	if (!has_subscription) {
 		int err;
 
@@ -4912,11 +4917,6 @@ int bt_gatt_unsubscribe(struct bt_conn *conn,
 	}
 
 	sys_slist_find_and_remove(&sub->list, &params->node);
-
-	/* Attempt to cancel if write is pending */
-	if (atomic_test_bit(params->flags, BT_GATT_SUBSCRIBE_FLAG_WRITE_PENDING)) {
-		bt_gatt_cancel(conn, params);
-	}
 
 	if (gatt_sub_is_empty(sub)) {
 		gatt_sub_free(sub);

--- a/tests/bluetooth/bsim_bt/bsim_test_notify/src/gatt_client_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_notify/src/gatt_client_test.c
@@ -234,6 +234,20 @@ static void gatt_subscribe_short(void)
 	WAIT_FOR_FLAG(flag_subscribed);
 }
 
+static void gatt_unsubscribe_short(void)
+{
+	int err;
+
+	sub_params_short.value_handle = chrc_handle;
+	err = bt_gatt_unsubscribe(g_conn, &sub_params_short);
+	if (err < 0) {
+		FAIL("Failed to unsubscribe\n");
+	} else {
+		printk("Unsubscribe request sent\n");
+	}
+	WAIT_FOR_FLAG(flag_subscribed);
+}
+
 static void gatt_subscribe_long(void)
 {
 	int err;
@@ -245,6 +259,21 @@ static void gatt_subscribe_long(void)
 		FAIL("Failed to subscribe\n");
 	} else {
 		printk("Subscribe request sent\n");
+	}
+	WAIT_FOR_FLAG(flag_subscribed);
+}
+
+static void gatt_unsubscribe_long(void)
+{
+	int err;
+
+	UNSET_FLAG(flag_subscribed);
+	sub_params_long.value_handle = long_chrc_handle;
+	err = bt_gatt_unsubscribe(g_conn, &sub_params_long);
+	if (err < 0) {
+		FAIL("Failed to unsubscribe\n");
+	} else {
+		printk("Unsubscribe request sent\n");
 	}
 	WAIT_FOR_FLAG(flag_subscribed);
 }
@@ -289,6 +318,11 @@ static void test_main(void)
 	while (num_notifications < NOTIFICATION_COUNT) {
 		k_sleep(K_MSEC(100));
 	}
+
+	gatt_unsubscribe_short();
+	gatt_unsubscribe_long();
+
+	printk("Unsubscribed\n");
 
 	PASS("GATT client Passed\n");
 }


### PR DESCRIPTION
`bt_gatt_unsubscribe` was pending a write to the CCC and then immediately
canceling it.

Fixes #47682 .

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>