### PR TITLE
cmake: Fix the complier format error

### DIFF
--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -26,7 +26,7 @@ set_compiler_property(PROPERTY optimization_size  -Os)
 #######################################################
 
 # GCC Option standard warning base in Zephyr
-check_set_compiler_property(PROPERTY warning_base
+set_compiler_property(PROPERTY warning_base
     -Wall
     -Wformat
     -Wformat-security


### PR DESCRIPTION
`check_set_compiler_property` would check the specified flags 
individually, causing `warning: '-Wformat-zero-length' ignored without '-Wformat'`,
then the cmake with 3.23 version would judge the warning as error, so the error
`error: zero-length gnu_printf format string [-Werror=format-zero-length]` occurs.
In order to be compatible with different environments, revert the 
`check_set_compiler_property` to `set_compiler_property` is more reasonable.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/47588

Signed-off-by: Shaoan Li <shaoanx.li@intel.com>