### PR TITLE
Bluetooth: audio: Fix bt_pacs_context_available

### DIFF
--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -36,12 +36,6 @@ NET_BUF_SIMPLE_DEFINE_STATIC(read_buf, CONFIG_BT_L2CAP_TX_MTU);
 
 static const struct bt_audio_pacs_cb *pacs_cb;
 
-static struct bt_pacs_context available_context = {
-	/* TODO: This should reflect the ongoing channel contexts */
-	.snk = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED,
-	.src = BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED,
-};
-
 static void pac_data_add(struct net_buf_simple *buf, uint8_t num,
 			 struct bt_codec_data *data)
 {
@@ -703,6 +697,15 @@ int bt_audio_pacs_register_cb(const struct bt_audio_pacs_cb *cb)
 
 bool bt_pacs_context_available(enum bt_audio_dir dir, uint16_t context)
 {
+	struct bt_pacs_context available_context;
+	int err;
+
+	err = available_contexts_get(NULL, &available_context);
+	if (err) {
+		BT_DBG("get_available_contexts returned %d", err);
+		return false;
+	}
+
 	if (IS_ENABLED(CONFIG_BT_PAC_SRC) && dir == BT_AUDIO_DIR_SOURCE) {
 		return (context & available_context.src) == context;
 	} else if (IS_ENABLED(CONFIG_BT_PAC_SNK) && dir == BT_AUDIO_DIR_SINK) {


### PR DESCRIPTION
This fixes bt_pacs_context_available so that it gets available
contexts from capabilities that hold the value.
This removes redundant available_context that were held
(and not updated) in pacs.c.

Fixes: HAP/HA/STR/BV-01-C
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>