### PR TITLE
drivers: sensor: ms5607: move driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -322,12 +322,10 @@ static const struct sensor_driver_api ms5607_api_funcs = {
 /* Initializes a struct ms5607_config for an instance on a SPI bus. */
 #define MS5607_CONFIG_SPI(inst)						\
 	{								\
-		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
 		.tf = &ms5607_spi_transfer_function,			\
-		.bus_cfg.spi_bus =					\
-			SPI_DT_SPEC_INST_GET(inst,			\
-					   MS5607_SPI_OPERATION,	\
-					   0),				\
+		.bus_cfg.spi = SPI_DT_SPEC_INST_GET(inst,		\
+						MS5607_SPI_OPERATION,	\
+						0),			\
 	}
 
 /* Initializes a struct ms5607_config for an instance on a I2C bus. */

--- a/drivers/sensor/ms5607/ms5607.c
+++ b/drivers/sensor/ms5607/ms5607.c
@@ -333,9 +333,8 @@ static const struct sensor_driver_api ms5607_api_funcs = {
 /* Initializes a struct ms5607_config for an instance on a I2C bus. */
 #define MS5607_CONFIG_I2C(inst)						\
 	{								\
-		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		\
 		.tf = &ms5607_i2c_transfer_function,			\
-		.bus_cfg.i2c_addr = DT_INST_REG_ADDR(inst)		\
+		.bus_cfg.i2c = I2C_DT_SPEC_INST_GET(inst),		\
 	}
 
 /*

--- a/drivers/sensor/ms5607/ms5607.h
+++ b/drivers/sensor/ms5607/ms5607.h
@@ -92,7 +92,7 @@ struct ms5607_config {
 	const struct ms5607_transfer_function *tf;
 	union {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-		uint16_t i2c_addr;
+		struct i2c_dt_spec i2c;
 #endif
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 		struct spi_dt_spec spi_bus;

--- a/drivers/sensor/ms5607/ms5607.h
+++ b/drivers/sensor/ms5607/ms5607.h
@@ -88,14 +88,13 @@ extern const struct ms5607_transfer_function ms5607_spi_transfer_function;
 #endif
 
 struct ms5607_config {
-	const struct device *bus;
 	const struct ms5607_transfer_function *tf;
 	union {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 		struct i2c_dt_spec i2c;
 #endif
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-		struct spi_dt_spec spi_bus;
+		struct spi_dt_spec spi;
 #endif
 	} bus_cfg;
 };

--- a/drivers/sensor/ms5607/ms5607_i2c.c
+++ b/drivers/sensor/ms5607/ms5607_i2c.c
@@ -19,7 +19,7 @@ LOG_MODULE_DECLARE(ms5607);
 
 static int ms5607_i2c_raw_cmd(const struct ms5607_config *config, uint8_t cmd)
 {
-	return i2c_write(config->bus, &cmd, 1, config->bus_cfg.i2c_addr);
+	return i2c_write_dt(&config->bus_cfg.i2c, &cmd, 1);
 }
 
 static int ms5607_i2c_reset(const struct ms5607_config *config)
@@ -39,7 +39,7 @@ static int ms5607_i2c_read_prom(const struct ms5607_config *config, uint8_t cmd,
 	uint8_t valb[2];
 	int err;
 
-	err = i2c_burst_read(config->bus, config->bus_cfg.i2c_addr, cmd, valb, sizeof(valb));
+	err = i2c_burst_read_dt(&config->bus_cfg.i2c, cmd, valb, sizeof(valb));
 	if (err < 0) {
 		return err;
 	}
@@ -60,8 +60,7 @@ static int ms5607_i2c_read_adc(const struct ms5607_config *config, uint32_t *val
 	int err;
 	uint8_t valb[3];
 
-	err = i2c_burst_read(config->bus, config->bus_cfg.i2c_addr,
-			     MS5607_CMD_CONV_READ_ADC, valb, sizeof(valb));
+	err = i2c_burst_read_dt(&config->bus_cfg.i2c, MS5607_CMD_CONV_READ_ADC, valb, sizeof(valb));
 	if (err < 0) {
 		return err;
 	}
@@ -74,8 +73,8 @@ static int ms5607_i2c_read_adc(const struct ms5607_config *config, uint32_t *val
 
 static int ms5607_i2c_check(const struct ms5607_config *config)
 {
-	if (!device_is_ready(config->bus)) {
-		LOG_DBG("I2C bus %s not ready", config->bus->name);
+	if (!device_is_ready(config->bus_cfg.i2c.bus)) {
+		LOG_DBG("I2C bus device not ready");
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ms5607/ms5607_spi.c
+++ b/drivers/sensor/ms5607/ms5607_spi.c
@@ -29,7 +29,7 @@ static int ms5607_spi_raw_cmd(const struct ms5607_config *config, uint8_t cmd)
 		.count = 1,
 	};
 
-	return spi_write_dt(&config->bus_cfg.spi_bus, &buf_set);
+	return spi_write_dt(&config->bus_cfg.spi, &buf_set);
 }
 
 static int ms5607_spi_reset(const struct ms5607_config *config)
@@ -79,9 +79,7 @@ static int ms5607_spi_read_prom(const struct ms5607_config *config, uint8_t cmd,
 		.count = 1,
 	};
 
-	err = spi_transceive_dt(&config->bus_cfg.spi_bus,
-			     &tx_buf_set,
-			     &rx_buf_set);
+	err = spi_transceive_dt(&config->bus_cfg.spi, &tx_buf_set, &rx_buf_set);
 	if (err < 0) {
 		return err;
 	}
@@ -129,9 +127,7 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 		.count = 1,
 	};
 
-	err = spi_transceive_dt(&config->bus_cfg.spi_bus,
-			     &tx_buf_set,
-			     &rx_buf_set);
+	err = spi_transceive_dt(&config->bus_cfg.spi, &tx_buf_set, &rx_buf_set);
 	if (err < 0) {
 		return err;
 	}
@@ -143,8 +139,8 @@ static int ms5607_spi_read_adc(const struct ms5607_config *config, uint32_t *val
 
 static int ms5607_spi_check(const struct ms5607_config *config)
 {
-	if (!spi_is_ready(&config->bus_cfg.spi_bus)) {
-		LOG_DBG("SPI bus %s not ready", config->bus->name);
+	if (!spi_is_ready(&config->bus_cfg.spi)) {
+		LOG_DBG("SPI bus not ready");
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>