### PR TITLE
drivers: sensor: bmp388: move driver to use i2c_dt_spec

### DIFF
--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -53,7 +53,7 @@ static int bmp388_transceive(const struct device *dev,
 	const struct spi_buf buf = { .buf = data, .len = length };
 	const struct spi_buf_set s = { .buffers = &buf, .count = 1 };
 
-	return spi_transceive_dt(&cfg->spi_bus, &s, &s);
+	return spi_transceive_dt(&cfg->spi, &s, &s);
 }
 
 static int bmp388_read_spi(const struct device *dev,
@@ -72,7 +72,7 @@ static int bmp388_read_spi(const struct device *dev,
 	const struct spi_buf_set tx = { .buffers = buf, .count = 1 };
 	const struct spi_buf_set rx = { .buffers = buf, .count = 2 };
 
-	return spi_transceive_dt(&cfg->spi_bus, &tx, &rx);
+	return spi_transceive_dt(&cfg->spi, &tx, &rx);
 }
 
 static int bmp388_byte_read_spi(const struct device *dev,
@@ -605,7 +605,7 @@ static int bmp388_init(const struct device *dev)
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 	/* Verify the SPI bus */
 	if (is_spi) {
-		if (!spi_is_ready(&cfg->spi_bus)) {
+		if (!spi_is_ready(&cfg->spi)) {
 			LOG_ERR("SPI bus is not ready");
 			return -ENODEV;
 		}
@@ -695,7 +695,7 @@ static int bmp388_init(const struct device *dev)
 
 #define BMP388_BUS_CFG_SPI(inst) \
 	.ops = &bmp388_spi_ops,	 \
-	.spi_bus = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0)
+	.spi = SPI_DT_SPEC_INST_GET(inst, SPI_OP_MODE_MASTER | SPI_WORD_SET(8), 0)
 
 #define BMP388_BUS_CFG(inst)			\
 	COND_CODE_1(DT_INST_ON_BUS(inst, i2c),	\

--- a/drivers/sensor/bmp388/bmp388.c
+++ b/drivers/sensor/bmp388/bmp388.c
@@ -129,7 +129,7 @@ static int bmp388_read_i2c(const struct device *dev,
 {
 	const struct bmp388_config *cfg = dev->config;
 
-	return i2c_burst_read(cfg->bus, cfg->bus_addr, reg, data, length);
+	return i2c_burst_read_dt(&cfg->i2c, reg, data, length);
 }
 
 static int bmp388_byte_read_i2c(const struct device *dev,
@@ -138,7 +138,7 @@ static int bmp388_byte_read_i2c(const struct device *dev,
 {
 	const struct bmp388_config *cfg = dev->config;
 
-	return i2c_reg_read_byte(cfg->bus, cfg->bus_addr, reg, byte);
+	return i2c_reg_read_byte_dt(&cfg->i2c, reg, byte);
 }
 
 static int bmp388_byte_write_i2c(const struct device *dev,
@@ -147,7 +147,7 @@ static int bmp388_byte_write_i2c(const struct device *dev,
 {
 	const struct bmp388_config *cfg = dev->config;
 
-	return i2c_reg_write_byte(cfg->bus, cfg->bus_addr, reg, byte);
+	return i2c_reg_write_byte_dt(&cfg->i2c, reg, byte);
 }
 
 int bmp388_reg_field_update_i2c(const struct device *dev,
@@ -157,7 +157,7 @@ int bmp388_reg_field_update_i2c(const struct device *dev,
 {
 	const struct bmp388_config *cfg = dev->config;
 
-	return i2c_reg_update_byte(cfg->bus, cfg->bus_addr, reg, mask, val);
+	return i2c_reg_update_byte_dt(&cfg->i2c, reg, mask, val);
 }
 
 static const struct bmp388_io_ops bmp388_i2c_ops = {
@@ -597,8 +597,8 @@ static int bmp388_init(const struct device *dev)
 	bool is_spi = (cfg->ops == &bmp388_spi_ops);
 #endif
 
-	if (!device_is_ready(cfg->bus)) {
-		LOG_ERR("Bus device is not ready");
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("I2C bus device is not ready");
 		return -EINVAL;
 	}
 
@@ -691,7 +691,7 @@ static int bmp388_init(const struct device *dev)
 
 #define BMP388_BUS_CFG_I2C(inst) \
 	.ops = &bmp388_i2c_ops,	 \
-	.bus_addr = DT_INST_REG_ADDR(inst)
+	.i2c = I2C_DT_SPEC_INST_GET(inst)
 
 #define BMP388_BUS_CFG_SPI(inst) \
 	.ops = &bmp388_spi_ops,	 \
@@ -716,7 +716,6 @@ static int bmp388_init(const struct device *dev)
 		.osr_temp = DT_INST_ENUM_IDX(inst, osr_temp),		   \
 	};								   \
 	static const struct bmp388_config bmp388_config_##inst = {	   \
-		.bus = DEVICE_DT_GET(DT_INST_BUS(inst)),		   \
 		BMP388_BUS_CFG(inst),					   \
 		BMP388_INT_CFG(inst)					   \
 		.iir_filter = DT_INST_ENUM_IDX(inst, iir_filter),	   \

--- a/drivers/sensor/bmp388/bmp388.h
+++ b/drivers/sensor/bmp388/bmp388.h
@@ -13,6 +13,7 @@
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/spi.h>
+#include <zephyr/drivers/i2c.h>
 #include <zephyr/sys/util.h>
 
 /* registers */
@@ -139,14 +140,13 @@ struct bmp388_io_ops {
 };
 
 struct bmp388_config {
-	const struct device *bus;
 	const struct bmp388_io_ops *ops;
 	union {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
 		struct spi_dt_spec spi_bus;
 #endif
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
-		uint16_t bus_addr;
+		struct i2c_dt_spec i2c;
 #endif
 	};
 

--- a/drivers/sensor/bmp388/bmp388.h
+++ b/drivers/sensor/bmp388/bmp388.h
@@ -143,7 +143,7 @@ struct bmp388_config {
 	const struct bmp388_io_ops *ops;
 	union {
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(spi)
-		struct spi_dt_spec spi_bus;
+		struct spi_dt_spec spi;
 #endif
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i2c)
 		struct i2c_dt_spec i2c;


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>