### PR TITLE
clang-format: do not merge blocks/functions into single line

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -12,7 +12,12 @@
 ---
 BasedOnStyle: LLVM
 AlignConsecutiveMacros: AcrossComments
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
 AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
 AttributeMacros:
   - __aligned
   - __deprecated


### PR DESCRIPTION
Align clang-format a bit closer to established coding style
of the project. Similar to commit 51f9f7ca3019
("clang-format: do not put enums in single line")'