### PR TITLE
Bluetooth: doc: Add warning for bt_data_parse

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -2049,6 +2049,9 @@ int bt_le_set_rpa_timeout(uint16_t new_rpa_timeout);
  * common scenario is to call this helper on the advertising data
  * received in the callback that was given to bt_le_scan_start().
  *
+ * @warning This helper function will consume `ad` when parsing. The user should
+ *          make a copy if the original data is to be used afterwards
+ *
  * @param ad        Advertising data as given to the bt_le_scan_cb_t callback.
  * @param func      Callback function which will be called for each element
  *                  that's found in the data. The callback should return


### PR DESCRIPTION
The fact that the function consumed its argument was not clear previously.

Fixes #47676.

The alternative is to change the API to not consume the data, but as it's
an API change, I suggest we only add the warning.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>