### PR TITLE
mtl: drv: Power off flow, HPSRAM memory save/restore to an external buffer

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -817,8 +817,20 @@ __imr void adsp_mm_restore_context(void *storage_buffer)
 	/* HPSRAM memory is restored */
 }
 
+static uint32_t adsp_mm_get_storage_size(void)
+{
+	/*
+	 * FIXME - currently the function returns a maximum possible size of the buffer
+	 * as L3 memory is generally a huge area its OK (and fast)
+	 * in future the function may go through the mapping and calculate a required size
+	 */
+	return	L2_SRAM_SIZE + TLB_SIZE + (L2_SRAM_PAGES_NUM * sizeof(void *))
+		+ sizeof(void *);
+}
+
 static const struct intel_adsp_tlb_api adsp_tlb_api_func = {
-	.save_context = adsp_mm_save_context
+	.save_context = adsp_mm_save_context,
+	.get_storage_size = adsp_mm_get_storage_size
 };
 
 DEVICE_DT_DEFINE(DT_INST(0, intel_adsp_mtl_tlb),

--- a/include/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h
+++ b/include/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h
@@ -27,6 +27,12 @@
 typedef void (*mm_save_context)(void *storage_buffer);
 
 /*
+ * This function will return a required size of storage buffer needed to perform context save
+ *
+ */
+typedef uint32_t (*mm_get_storage_size)(void);
+
+/*
  * This function will restore the contents and power state of the physical memory banks
  * and recreate physical to virtual mappings
  *
@@ -40,6 +46,7 @@ void adsp_mm_restore_context(void *storage_buffer);
 
 struct intel_adsp_tlb_api {
 	mm_save_context save_context;
+	mm_get_storage_size get_storage_size;
 };
 
 #endif /* ZEPHYR_INCLUDE_DRIVERS_INTEL_ADSP_MTL_TLB */

--- a/include/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h
+++ b/include/drivers/mm/mm_drv_intel_adsp_mtl_tlb.h
@@ -1,0 +1,45 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (c) 2022 Intel Corporation.
+ *
+ * Author: Marcin Szkudlinski <marcin.szkudlinski@linux.intel.com>
+ *
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_INTEL_ADSP_MTL_TLB
+#define ZEPHYR_INCLUDE_DRIVERS_INTEL_ADSP_MTL_TLB
+
+
+/*
+ * This function will save contents of the physical memory banks into a provided storage buffer
+ *
+ * the system must be almost stopped. Operation is destructive - it will change physical to
+ * virtual addresses mapping leaving the system not operational
+ * Power states of memory banks will stay not touched
+ * assuming
+ *	- the dcache memory had been invalidated before
+ *	- no remapping of addresses below unused_l2_sram_start_marker has been made
+ *	  (this is ensured by the driver itself - it rejects such remapping request)
+ *
+ * at this point the memory is still up&running so its safe to use libraries like memcpy
+ * and the procedure can be called in a zephyr driver model way
+ */
+typedef void (*mm_save_context)(void *storage_buffer);
+
+/*
+ * This function will restore the contents and power state of the physical memory banks
+ * and recreate physical to virtual mappings
+ *
+ * As the system memory is down at this point, the procedure
+ *  - MUST be located in IMR memory region
+ *  - MUST be called using a simple extern procedure call - API table is not yet loaded
+ *  - MUST NOT use libraries, like memcpy, use instead a special version bmemcpy located in IMR
+ *
+ */
+void adsp_mm_restore_context(void *storage_buffer);
+
+struct intel_adsp_tlb_api {
+	mm_save_context save_context;
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_INTEL_ADSP_MTL_TLB */

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_imr_layout.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_imr_layout.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2022 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#ifndef ZEPHYR_SOC_INTEL_ADSP_ACE_IMR_LAYOUT_H_
+#define ZEPHYR_SOC_INTEL_ADSP_ACE_IMR_LAYOUT_H_
+
+/* These structs and macros are from from the ROM code header
+ * on cAVS platforms, please keep them immutable
+ */
+
+/*
+ * A magic that tells ROM to jump to imr_restore_vector instead of normal boot
+ */
+#define ADSP_IMR_MAGIC_VALUE		0x02468ACE
+#define IMR_LAYOUT_OFFSET               0x20000
+#define IMR_LAYOUT_ADDRESS              (L3_MEM_BASE_ADDR + IMR_LAYOUT_OFFSET)
+
+struct imr_header {
+	uint32_t adsp_imr_magic;
+	uint32_t structure_version;
+	uint32_t structure_size;
+	uint32_t imr_state;
+	uint32_t imr_size;
+	void *imr_restore_vector;
+	void *imr_auth_api_vector;
+	uint8_t *imr_ram_storage;
+};
+
+struct imr_state {
+	struct imr_header header;
+	uint8_t reserved[0x1000 - sizeof(struct imr_header)];
+};
+
+struct imr_layout {
+	struct imr_state    imr_state;
+};
+
+#endif /* ZEPHYR_SOC_INTEL_ADSP_ACE_IMR_LAYOUT_H_ */

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_memory.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_memory.h
@@ -24,6 +24,13 @@
 #define RAM_BASE (L2_SRAM_BASE + CONFIG_HP_SRAM_RESERVE + VECTOR_TBL_SIZE)
 #define RAM_SIZE (L2_SRAM_SIZE - CONFIG_HP_SRAM_RESERVE - VECTOR_TBL_SIZE)
 
+
+/* L3 region (IMR), located in host memory */
+
+#define L3_MEM_BASE_ADDR (DT_REG_ADDR(DT_NODELABEL(imr1)))
+#define L3_MEM_SIZE (DT_REG_SIZE(DT_NODELABEL(imr1)))
+#define L3_MEM_PAGE_SIZE (DT_PROP(DT_NODELABEL(imr1), block_size))
+
 /* The rimage tool produces two blob addresses we need to find: one is
  * our bootloader code block which starts at its entry point, the
  * other is the "manifest" containing the HP-SRAM data to unpack,
@@ -31,13 +38,38 @@
  * memory.  There's no ability to change this offset, it's a magic
  * number from rimage we simply need to honor.
  */
+#define IMR_BOOT_LDR_MANIFEST_OFFSET	0x42000
+#define IMR_BOOT_LDR_MANIFEST_SIZE	0x6000
+#define IMR_BOOT_LDR_MANIFEST_BASE	(L3_MEM_BASE_ADDR + IMR_BOOT_LDR_MANIFEST_OFFSET)
 
-#define IMR_BOOT_LDR_DATA_BASE          (0xA1048000+0x1000)
-#define IMR_BOOT_LDR_MANIFEST_BASE      0xA1042000
-#define IMR_BOOT_LDR_TEXT_ENTRY_BASE (IMR_BOOT_LDR_MANIFEST_BASE + 0x6000)
+#define IMR_BOOT_LDR_TEXT_ENTRY_SIZE	0x180
+#define IMR_BOOT_LDR_TEXT_ENTRY_BASE	(IMR_BOOT_LDR_MANIFEST_BASE + IMR_BOOT_LDR_MANIFEST_SIZE)
+
+#define IMR_BOOT_LDR_LIT_SIZE		0x40
+#define IMR_BOOT_LDR_LIT_BASE		(IMR_BOOT_LDR_TEXT_ENTRY_BASE + \
+					IMR_BOOT_LDR_TEXT_ENTRY_SIZE)
+
+#define IMR_BOOT_LDR_TEXT_SIZE		0x1C00
+#define IMR_BOOT_LDR_TEXT_BASE		(IMR_BOOT_LDR_LIT_BASE + IMR_BOOT_LDR_LIT_SIZE)
+
+#define IMR_BOOT_LDR_DATA_OFFSET	0x49000
+#define IMR_BOOT_LDR_DATA_BASE		(L3_MEM_BASE_ADDR + IMR_BOOT_LDR_DATA_OFFSET)
+#define IMR_BOOT_LDR_DATA_SIZE		0xA8000
+
+#define IMR_BOOT_LDR_BSS_OFFSET		0x110000
+#define IMR_BOOT_LDR_BSS_BASE		(L3_MEM_BASE_ADDR + IMR_BOOT_LDR_BSS_OFFSET)
+#define IMR_BOOT_LDR_BSS_SIZE		0x10000
+
+/* stack to be used at boot, when RAM is not yet powered up */
+#define IMR_BOOT_LDR_STACK_BASE		(IMR_BOOT_LDR_BSS_BASE + IMR_BOOT_LDR_BSS_SIZE)
+#define IMR_BOOT_LDR_STACK_SIZE		0x1000
+
+/* position of L3 heap, size of L3 heap - till end of the L3 memory */
+#define IMR_L3_HEAP_BASE		(IMR_BOOT_LDR_STACK_BASE + IMR_BOOT_LDR_STACK_SIZE)
+#define IMR_L3_HEAP_SIZE		(L3_MEM_SIZE - \
+					(IMR_L3_HEAP_BASE - L3_MEM_BASE_ADDR))
 
 #define ADSP_L1_CACHE_PREFCTL_VALUE 0x1038
-
 
 /* L1 init */
 #define ADSP_L1CC_ADDR                       (0x1FE80080)

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -5,12 +5,15 @@
  */
 #include <zephyr/kernel.h>
 #include <zephyr/pm/pm.h>
+#include <zephyr/device.h>
 #include <cpu_init.h>
 
 #include <xtensa/corebits.h>
 #include <adsp_boot.h>
 #include <adsp_power.h>
-
+#include <adsp_memory.h>
+#include <adsp_imr_layout.h>
+#include <drivers/mm/mm_drv_intel_adsp_mtl_tlb.h>
 #define LPSRAM_MAGIC_VALUE      0x13579BDF
 #define LPSCTL_BATTR_MASK       GENMASK(16, 12)
 #define SRAM_ALIAS_BASE         0xA0000000
@@ -53,6 +56,23 @@ __aligned(XCHAL_DCACHE_LINESIZE) uint8_t d0i3_stack[CONFIG_MM_DRV_PAGE_SIZE];
  */
 extern void power_down(bool disable_lpsram, uint32_t *hpsram_pg_mask,
 			   bool response_to_ipc);
+
+/**
+ *  @brief platform specific context restore procedure
+ *
+ *  Should be called when soc context restore is completed
+ */
+extern void platform_context_restore(void);
+
+/*
+ * @brief pointer to a persistent storage space, to be set by platform code
+ */
+uint8_t *global_imr_ram_storage;
+
+/*8
+ * @biref a d3 restore boot entry point
+ */
+extern void rom_entry_d3_restore(void);
 
 /* NOTE: This struct will grow with all values that have to be stored for
  * proper cpu restore after PG.
@@ -134,6 +154,19 @@ void power_gate_exit(void)
 	_restore_core_context();
 }
 
+void ALWAYS_INLINE power_off_exit(void)
+{
+	__asm__(
+		"  movi  a0, 0\n\t"
+		"  movi  a1, 1\n\t"
+		"  movi  a2, 0x40020\n\t"/* PS_UM|PS_WOE */
+		"  wsr   a2, PS\n\t"
+		"  wsr   a1, WINDOWSTART\n\t"
+		"  wsr   a0, WINDOWBASE\n\t"
+		"  rsync\n\t");
+	_restore_core_context();
+}
+
 __asm__(".align 4\n\t"
 	"dsp_restore_vector:\n\t"
 	"  movi  a0, 0\n\t"
@@ -148,21 +181,77 @@ __asm__(".align 4\n\t"
 	"  add sp, sp, a2\n\t"
 	"  call0 power_gate_exit\n\t");
 
+__imr FUNC_NORETURN void pm_state_imr_restore(void)
+{
+	struct imr_layout *imr_layout = (struct imr_layout *)(IMR_LAYOUT_ADDRESS);
+	/* restore lpsram power and contents */
+	bmemcpy(z_soc_uncached_ptr(UINT_TO_POINTER(LP_SRAM_BASE)),
+		imr_layout->imr_state.header.imr_ram_storage,
+		LP_SRAM_SIZE);
+
+	/* restore HPSRAM contents, mapping and power states */
+	adsp_mm_restore_context(imr_layout->imr_state.header.imr_ram_storage+LP_SRAM_SIZE);
+
+	/* this function won't return, it will restore a saved state */
+	power_off_exit();
+}
+
 __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 {
 	ARG_UNUSED(substate_id);
 	uint32_t cpu = arch_proc_id();
 
 	if (state == PM_STATE_SOFT_OFF) {
+		/* save interrupt state and turn off all interrupts */
+		core_desc[cpu].intenable = XTENSA_RSR("INTENABLE");
+		z_xt_ints_off(0xffffffff);
 		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESTART_COMMAND;
 		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPCG;
 		soc_cpus_active[cpu] = false;
 		z_xtensa_cache_flush_inv_all();
 		if (cpu == 0) {
-			/* FIXME: this value should come from MM */
-			uint32_t hpsram_mask[1] = { 0x3FFFFF };
+			/* save storage and restore information to imr */
+			__ASSERT_NO_MSG(global_imr_ram_storage != NULL);
+			struct imr_layout *imr_layout = (struct imr_layout *)(IMR_LAYOUT_ADDRESS);
 
-			power_down(true, uncache_to_cache(&hpsram_mask[0]),
+			imr_layout->imr_state.header.adsp_imr_magic = ADSP_IMR_MAGIC_VALUE;
+			imr_layout->imr_state.header.imr_restore_vector =
+					(void *)rom_entry_d3_restore;
+			imr_layout->imr_state.header.imr_ram_storage = global_imr_ram_storage;
+			z_xtensa_cache_flush(imr_layout, sizeof(*imr_layout));
+
+			/* save CPU context here
+			 * when _restore_core_context() is called, it will return directly to
+			 * the caller of this procedure
+			 * any changes to CPU context after _save_core_context
+			 * will be lost when power_down is executed
+			 * Only data in the imr region survives
+			 */
+			xthal_window_spill();
+			_save_core_context(cpu);
+
+			/* save LPSRAM - a simple copy */
+			memcpy(global_imr_ram_storage, LP_SRAM_BASE, LP_SRAM_SIZE);
+
+			/* save HPSRAM - a multi step procedure, executed by a TLB driver
+			 * the TLB driver will change memory mapping
+			 * leaving the system not operational
+			 * it must be called directly here,
+			 * just before power_down
+			 */
+			const struct device *tlb_dev = DEVICE_DT_GET(DT_NODELABEL(tlb));
+
+			__ASSERT_NO_MSG(tlb_dev != NULL);
+			const struct intel_adsp_tlb_api *tlb_api =
+					(struct intel_adsp_tlb_api *)tlb_dev->api;
+
+			tlb_api->save_context(global_imr_ram_storage+LP_SRAM_SIZE);
+
+			/* turn off all HPSRAM banks - get a full bitmap */
+			uint32_t ebb_banks = ace_hpsram_get_bank_count();
+			uint32_t hpsram_mask = (1 << ebb_banks) - 1;
+			/* do power down - this function won't return */
+			power_down(true, uncache_to_cache(&hpsram_mask),
 				   true);
 		} else {
 			k_cpu_idle();
@@ -179,7 +268,6 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 			battr |= (DFDSPBRCP_BATTR_LPSCTL_RESTORE_BOOT & LPSCTL_BATTR_MASK);
 			DFDSPBRCP.bootctl[cpu].battr = battr;
 		}
-
 		power_gate_entry(cpu);
 	} else {
 		__ASSERT(false, "invalid argument - unsupported power state");
@@ -193,11 +281,25 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	uint32_t cpu = arch_proc_id();
 
 	if (state == PM_STATE_SOFT_OFF) {
-		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESUME;
-		/* TODO: move clock gating prevent to imr restore vector when it will be ready. */
-		DFDSPBRCP.bootctl[cpu].bctl |= DFDSPBRCP_BCTL_WAITIPCG;
-		soc_cpus_active[cpu] = true;
-		z_xtensa_cache_flush_inv_all();
+		if (cpu == 0) {
+			struct imr_layout *imr_layout = (struct imr_layout *)(IMR_LAYOUT_ADDRESS);
+
+			DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESUME;
+			/* restore clock gating state */
+			DFDSPBRCP.bootctl[cpu].bctl |=
+					(core_desc[0].bctl & DFDSPBRCP_BCTL_WAITIPCG);
+			soc_cpus_active[cpu] = true;
+
+			/* clean storage and restore information */
+			z_xtensa_cache_inv(imr_layout, sizeof(*imr_layout));
+			imr_layout->imr_state.header.adsp_imr_magic = 0;
+			imr_layout->imr_state.header.imr_restore_vector = NULL;
+			imr_layout->imr_state.header.imr_ram_storage = NULL;
+
+			z_xtensa_cache_flush_inv_all();
+			z_xt_ints_on(core_desc[cpu].intenable);
+		}
+
 	} else if (state == PM_STATE_RUNTIME_IDLE) {
 		if (cpu != 0) {
 			/* NOTE: HW should support dynamic power gating on secondary cores.

--- a/soc/xtensa/intel_adsp/ace/power.c
+++ b/soc/xtensa/intel_adsp/ace/power.c
@@ -85,6 +85,7 @@ struct core_state {
 	uint32_t excsave3;
 	uint32_t thread_ptr;
 	uint32_t intenable;
+	uint32_t bctl;
 };
 
 static struct core_state core_desc[CONFIG_MP_MAX_NUM_CPUS] = { 0 };
@@ -205,6 +206,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 		/* save interrupt state and turn off all interrupts */
 		core_desc[cpu].intenable = XTENSA_RSR("INTENABLE");
 		z_xt_ints_off(0xffffffff);
+		core_desc[cpu].bctl = DFDSPBRCP.bootctl[cpu].bctl;
 		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESTART_COMMAND;
 		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPCG;
 		soc_cpus_active[cpu] = false;


### PR DESCRIPTION
This PR adds a power flows to Intel MTL TLB driver
It allows the driver to save the whole Translation Table
as well as contents of memory banks to a designated address
It is designed for memory content retention in an persistent
storage during low power state