### PR TITLE
drivers: gpio: gpio_cy8c95xx.c: move driver to use i2c_dt_spec

### DIFF
--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -41,8 +41,7 @@ struct cy8c95xx_drv_data {
 struct cy8c95xx_config {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
-	const struct device *i2c_master;
-	uint16_t i2c_slave_addr;
+	struct i2c_dt_spec i2c;
 	uint8_t port_num;
 };
 
@@ -54,38 +53,32 @@ struct cy8c95xx_config {
 #define CY8C95XX_REG_PULL_DOWN                  0x1E
 #define CY8C95XX_REG_ID                         0x2E
 
-static int write_pin_state(const struct cy8c95xx_config *cfg,
-			   struct cy8c95xx_drv_data *drv_data,
-			   struct cy8c95xx_pin_state *pins)
+static int write_pin_state(const struct cy8c95xx_config *cfg, struct cy8c95xx_pin_state *pins)
 {
 	int rc;
 
-	rc = i2c_reg_write_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-				CY8C95XX_REG_OUTPUT_DATA0 + cfg->port_num, pins->data_out);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, CY8C95XX_REG_OUTPUT_DATA0 + cfg->port_num,
+				   pins->data_out);
 	if (rc) {
 		return rc;
 	}
 
-	rc = i2c_reg_write_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-				CY8C95XX_REG_PORT_SELECT, cfg->port_num);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, CY8C95XX_REG_PORT_SELECT, cfg->port_num);
 	if (rc) {
 		return rc;
 	}
 
-	rc = i2c_reg_write_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-				CY8C95XX_REG_DIR, pins->dir);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, CY8C95XX_REG_DIR, pins->dir);
 	if (rc) {
 		return rc;
 	}
 
-	rc = i2c_reg_write_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-				CY8C95XX_REG_PULL_UP, pins->pull_up);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, CY8C95XX_REG_PULL_UP, pins->pull_up);
 	if (rc) {
 		return rc;
 	}
 
-	rc = i2c_reg_write_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-				CY8C95XX_REG_PULL_DOWN, pins->pull_down);
+	rc = i2c_reg_write_byte_dt(&cfg->i2c, CY8C95XX_REG_PULL_DOWN, pins->pull_down);
 
 	return rc;
 }
@@ -135,7 +128,7 @@ static int cy8c95xx_config(const struct device *dev,
 	LOG_DBG("CFG %u %x : DIR %04x ; DAT %04x",
 		pin, flags, pins->dir, pins->data_out);
 
-	rc = write_pin_state(cfg, drv_data, pins);
+	rc = write_pin_state(cfg, pins);
 
 	k_sem_give(drv_data->lock);
 	return rc;
@@ -156,8 +149,7 @@ static int port_get(const struct device *dev,
 
 	k_sem_take(drv_data->lock, K_FOREVER);
 
-	rc = i2c_reg_read_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-			       CY8C95XX_REG_INPUT_DATA0 + cfg->port_num, &pin_data);
+	rc = i2c_reg_read_byte_dt(&cfg->i2c, CY8C95XX_REG_INPUT_DATA0 + cfg->port_num, &pin_data);
 
 	if (rc == 0) {
 		*value = pin_data;
@@ -184,8 +176,7 @@ static int port_write(const struct device *dev,
 
 	k_sem_take(drv_data->lock, K_FOREVER);
 
-	int rc = i2c_reg_write_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-				    CY8C95XX_REG_OUTPUT_DATA0 + cfg->port_num, out);
+	int rc = i2c_reg_write_byte_dt(&cfg->i2c, CY8C95XX_REG_OUTPUT_DATA0 + cfg->port_num, out);
 
 	if (rc == 0) {
 		*outp = out;
@@ -246,14 +237,13 @@ static int cy8c95xx_init(const struct device *dev)
 
 	k_sem_take(drv_data->lock, K_FOREVER);
 
-	if (!device_is_ready(cfg->i2c_master)) {
-		LOG_ERR("%s is not ready", cfg->i2c_master->name);
+	if (!device_is_ready(cfg->i2c.bus)) {
+		LOG_ERR("%s is not ready", cfg->i2c.bus->name);
 		rc = -ENODEV;
 		goto out;
 	}
 
-	rc = i2c_reg_read_byte(cfg->i2c_master, cfg->i2c_slave_addr,
-			  CY8C95XX_REG_ID, &data);
+	rc = i2c_reg_read_byte_dt(&cfg->i2c, CY8C95XX_REG_ID, &data);
 	if (rc) {
 		goto out;
 	}
@@ -269,7 +259,7 @@ static int cy8c95xx_init(const struct device *dev)
 		.pull_up = 0xFF,
 		.pull_down = 0x00,
 	};
-	rc = write_pin_state(cfg, drv_data, &drv_data->pin_state);
+	rc = write_pin_state(cfg, &drv_data->pin_state);
 out:
 	if (rc != 0) {
 		LOG_ERR("%s init failed: %d", dev->name, rc);
@@ -297,8 +287,7 @@ static const struct cy8c95xx_config cy8c95xx_##idx##_cfg = { \
 	.common = { \
 		.port_pin_mask = 0xFF, \
 	}, \
-	.i2c_master = DEVICE_DT_GET(DT_BUS(DT_INST(0, cypress_cy8c95xx_gpio))), \
-	.i2c_slave_addr = DT_REG_ADDR_BY_IDX(DT_INST(0, cypress_cy8c95xx_gpio), 0), \
+	.i2c = I2C_DT_SPEC_INST_GET(idx), \
 	.port_num = DT_INST_REG_ADDR(idx), \
 }; \
 static struct cy8c95xx_drv_data cy8c95xx_##idx##_drvdata = { \


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>