### PR TITLE
net: lwm2m: Thread safety in the engine related files

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -159,6 +159,7 @@ void engine_update_tx_time(void)
 
 static void set_sm_state(uint8_t sm_state)
 {
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	enum lwm2m_rd_client_event event = LWM2M_RD_CLIENT_EVENT_NONE;
 
 	/* Determine if a callback to the app is needed */
@@ -195,7 +196,6 @@ static void set_sm_state(uint8_t sm_state)
 		}
 	}
 
-	/* TODO: add locking? */
 	client.engine_state = sm_state;
 
 	if (event > LWM2M_RD_CLIENT_EVENT_NONE && client.ctx->event_cb) {
@@ -210,13 +210,17 @@ static void set_sm_state(uint8_t sm_state)
 			lwm2m_close_socket(client.ctx);
 		}
 	}
+	k_mutex_unlock(&client.mutex);
 }
 
 static bool sm_is_bootstrap(void)
 {
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
-	return (client.engine_state >= ENGINE_DO_BOOTSTRAP_REG &&
+	k_mutex_lock(&client.mutex, K_FOREVER);
+	bool is_bootstrap = (client.engine_state >= ENGINE_DO_BOOTSTRAP_REG &&
 		client.engine_state <= ENGINE_BOOTSTRAP_TRANS_DONE);
+	k_mutex_unlock(&client.mutex);
+	return is_bootstrap;
 #else
 	return false;
 #endif
@@ -224,19 +228,27 @@ static bool sm_is_bootstrap(void)
 
 static bool sm_is_registered(void)
 {
-	return (client.engine_state >= ENGINE_REGISTRATION_DONE &&
-		client.engine_state <= ENGINE_DEREGISTER_SENT);
+	k_mutex_lock(&client.mutex, K_FOREVER);
+	bool registered = (client.engine_state >= ENGINE_REGISTRATION_DONE &&
+			   client.engine_state <= ENGINE_DEREGISTER_SENT);
+
+	k_mutex_unlock(&client.mutex);
+	return registered;
 }
 
 static uint8_t get_sm_state(void)
 {
-	/* TODO: add locking? */
-	return client.engine_state;
+	k_mutex_lock(&client.mutex, K_FOREVER);
+	uint8_t state = client.engine_state;
+
+	k_mutex_unlock(&client.mutex);
+	return state;
 }
 
 static void sm_handle_timeout_state(struct lwm2m_message *msg,
 				    enum sm_engine_state sm_state)
 {
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	enum lwm2m_rd_client_event event = LWM2M_RD_CLIENT_EVENT_NONE;
 
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
@@ -261,10 +273,12 @@ static void sm_handle_timeout_state(struct lwm2m_message *msg,
 	if (event > LWM2M_RD_CLIENT_EVENT_NONE && client.ctx->event_cb) {
 		client.ctx->event_cb(client.ctx, event);
 	}
+	k_mutex_unlock(&client.mutex);
 }
 
 static void sm_handle_failure_state(enum sm_engine_state sm_state)
 {
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	enum lwm2m_rd_client_event event = LWM2M_RD_CLIENT_EVENT_NONE;
 
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
@@ -276,6 +290,7 @@ static void sm_handle_failure_state(enum sm_engine_state sm_state)
 		event = LWM2M_RD_CLIENT_EVENT_REGISTRATION_FAILURE;
 	} else if (client.engine_state == ENGINE_UPDATE_SENT) {
 		sm_handle_registration_update_failure();
+		k_mutex_unlock(&client.mutex);
 		return;
 	} else if (client.engine_state == ENGINE_DEREGISTER_SENT) {
 		event = LWM2M_RD_CLIENT_EVENT_DEREGISTER_FAILURE;
@@ -287,6 +302,7 @@ static void sm_handle_failure_state(enum sm_engine_state sm_state)
 	if (event > LWM2M_RD_CLIENT_EVENT_NONE && client.ctx->event_cb) {
 		client.ctx->event_cb(client.ctx, event);
 	}
+	k_mutex_unlock(&client.mutex);
 }
 
 /* force state machine restart */
@@ -308,17 +324,19 @@ static void socket_fault_cb(int error)
 /* force re-update with remote peer */
 void engine_trigger_update(bool update_objects)
 {
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	if (client.engine_state < ENGINE_REGISTRATION_SENT ||
 	    client.engine_state > ENGINE_UPDATE_SENT) {
+		k_mutex_unlock(&client.mutex);
 		return;
 	}
 
-	/* TODO: add locking? */
 	client.trigger_update = true;
 
 	if (update_objects) {
 		client.update_objects = true;
 	}
+	k_mutex_unlock(&client.mutex);
 }
 
 static inline const char *code2str(uint8_t code)
@@ -384,15 +402,18 @@ static void do_bootstrap_reg_timeout_cb(struct lwm2m_message *msg)
 int engine_trigger_bootstrap(void)
 {
 #if defined(CONFIG_LWM2M_RD_CLIENT_SUPPORT_BOOTSTRAP)
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	if (!sm_is_registered()) {
 		/* Bootstrap is not possible to trig */
 		LOG_WRN("Cannot trigger bootstrap from state %u", client.engine_state);
+		k_mutex_unlock(&client.mutex);
 		return -EPERM;
 	}
 
 	LOG_INF("Server Initiated Bootstrap");
 	client.use_bootstrap = true;
 	client.engine_state = ENGINE_INIT;
+	k_mutex_unlock(&client.mutex);
 
 	return 0;
 #else
@@ -924,8 +945,10 @@ cleanup:
 
 static void sm_handle_registration_update_failure(void)
 {
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	LOG_WRN("Registration Update fail -> trigger full registration");
 	client.engine_state = ENGINE_SEND_REGISTRATION;
+	k_mutex_unlock(&client.mutex);
 }
 
 static int sm_send_registration_msg(void)
@@ -999,6 +1022,7 @@ static int sm_do_registration(void)
 
 static int sm_registration_done(void)
 {
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	int ret = 0;
 
 	/*
@@ -1018,7 +1042,7 @@ static int sm_registration_done(void)
 	     CONFIG_LWM2M_QUEUE_MODE_UPTIME)) {
 		set_sm_state(ENGINE_REGISTRATION_DONE_RX_OFF);
 	}
-
+	k_mutex_unlock(&client.mutex);
 	return ret;
 }
 
@@ -1308,11 +1332,11 @@ int lwm2m_rd_client_stop(struct lwm2m_ctx *client_ctx,
 
 	LOG_INF("Stop LWM2M Client: %s", client.ep_name);
 
-	k_mutex_unlock(&client.mutex);
 
 	while (get_sm_state() != ENGINE_IDLE) {
 		k_sleep(K_MSEC(STATE_MACHINE_UPDATE_INTERVAL_MS / 2));
 	}
+	k_mutex_unlock(&client.mutex);
 	return 0;
 }
 
@@ -1434,9 +1458,10 @@ int lwm2m_rd_client_timeout(struct lwm2m_ctx *client_ctx)
 	if (!sm_is_registered()) {
 		return 0;
 	}
-
+	k_mutex_lock(&client.mutex, K_FOREVER);
 	LOG_WRN("Confirmable Timeout -> Re-connect and register");
 	client.engine_state = ENGINE_DO_REGISTRATION;
+	k_mutex_unlock(&client.mutex);
 	return 0;
 }
 


### PR DESCRIPTION
Added mutex locks to the lwm2m_rd_client and the lwm2m_registry to  
protect the global resources in the files.

Signed-off-by: Ola Tangen Kulseng <ola.kulseng@nordicsemi.no>