### PR TITLE
drivers: gpio: gpio_pcal6408a: move driver to use i2c_dt_spec

### DIFF
--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -59,8 +59,7 @@ struct pcal6408a_drv_cfg {
 	/* gpio_driver_config needs to be first */
 	struct gpio_driver_config common;
 
-	const struct device *i2c;
-	uint16_t i2c_addr;
+	struct i2c_dt_spec i2c;
 	const struct device *int_gpio_dev;
 	gpio_pin_t int_gpio_pin;
 	gpio_dt_flags_t int_gpio_flags;
@@ -75,36 +74,31 @@ static int pcal6408a_pins_cfg_apply(const struct device *dev,
 	const struct pcal6408a_drv_cfg *drv_cfg = dev->config;
 	int rc;
 
-	rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-				PCAL6408A_REG_PULL_UP_DOWN_SELECT,
-				pins_cfg.pull_ups_selected);
+	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_PULL_UP_DOWN_SELECT,
+				   pins_cfg.pull_ups_selected);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to select pull-up/pull-down resistors: %d",
 			dev->name, rc);
 		return -EIO;
 	}
 
-	rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-				PCAL6408A_REG_PULL_UP_DOWN_ENABLE,
-				pins_cfg.pulls_enabled);
+	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_PULL_UP_DOWN_ENABLE,
+				   pins_cfg.pulls_enabled);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to enable pull-up/pull-down resistors: %d",
 			dev->name, rc);
 		return -EIO;
 	}
 
-	rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-				PCAL6408A_REG_OUTPUT_PORT,
-				pins_cfg.outputs_high);
+	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_OUTPUT_PORT, pins_cfg.outputs_high);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to set outputs: %d",
 			dev->name, rc);
 		return -EIO;
 	}
 
-	rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-				PCAL6408A_REG_CONFIGURATION,
-				pins_cfg.configured_as_inputs);
+	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_CONFIGURATION,
+				   pins_cfg.configured_as_inputs);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to configure pins: %d",
 			dev->name, rc);
@@ -190,9 +184,7 @@ static int pcal6408a_process_input(const struct device *dev,
 	uint8_t int_sources;
 	uint8_t input_port;
 
-	rc = i2c_reg_read_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-			       PCAL6408A_REG_INTERRUPT_STATUS,
-			       &int_sources);
+	rc = i2c_reg_read_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INTERRUPT_STATUS, &int_sources);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to read interrupt sources: %d",
 			dev->name, rc);
@@ -200,9 +192,7 @@ static int pcal6408a_process_input(const struct device *dev,
 	}
 
 	/* This read also clears the generated interrupt if any. */
-	rc = i2c_reg_read_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-			       PCAL6408A_REG_INPUT_PORT,
-			       &input_port);
+	rc = i2c_reg_read_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INPUT_PORT, &input_port);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to read input port: %d",
 			dev->name, rc);
@@ -316,8 +306,7 @@ static int pcal6408a_port_set_raw(const struct device *dev,
 	 * No need to limit `out` to only pins configured as outputs,
 	 * as the chip anyway ignores all other bits in the register.
 	 */
-	rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-				PCAL6408A_REG_OUTPUT_PORT, output);
+	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_OUTPUT_PORT, output);
 	if (rc == 0) {
 		drv_data->pins_cfg.outputs_high = output;
 	}
@@ -363,18 +352,14 @@ static int pcal6408a_triggers_apply(const struct device *dev,
 	const struct pcal6408a_drv_cfg *drv_cfg = dev->config;
 	int rc;
 
-	rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-				PCAL6408A_REG_INPUT_LATCH,
-				~(triggers.masked));
+	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INPUT_LATCH, ~(triggers.masked));
 	if (rc != 0) {
 		LOG_ERR("%s: failed to configure input latch: %d",
 			dev->name, rc);
 		return -EIO;
 	}
 
-	rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-				PCAL6408A_REG_INTERRUPT_MASK,
-				triggers.masked);
+	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INTERRUPT_MASK, triggers.masked);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to configure interrupt mask: %d",
 			dev->name, rc);
@@ -463,8 +448,8 @@ static int pcal6408a_init(const struct device *dev)
 	};
 	int rc;
 
-	if (!device_is_ready(drv_cfg->i2c)) {
-		LOG_ERR("%s is not ready", drv_cfg->i2c->name);
+	if (!device_is_ready(drv_cfg->i2c.bus)) {
+		LOG_ERR("%s is not ready", drv_cfg->i2c.bus->name);
 		return -ENODEV;
 	}
 
@@ -511,9 +496,8 @@ static int pcal6408a_init(const struct device *dev)
 		};
 
 		for (int i = 0; i < ARRAY_SIZE(reset_state); ++i) {
-			rc = i2c_reg_write_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-						reset_state[i][0],
-						reset_state[i][1]);
+			rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, reset_state[i][0],
+						   reset_state[i][1]);
 			if (rc != 0) {
 				LOG_ERR("%s: failed to reset register %02x: %d",
 					dev->name, reset_state[i][0], rc);
@@ -531,9 +515,8 @@ static int pcal6408a_init(const struct device *dev)
 	drv_data->pins_cfg = initial_pins_cfg;
 
 	/* Read initial state of the input port register. */
-	rc = i2c_reg_read_byte(drv_cfg->i2c, drv_cfg->i2c_addr,
-			       PCAL6408A_REG_INPUT_PORT,
-			       &drv_data->input_port_last);
+	rc = i2c_reg_read_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INPUT_PORT,
+				  &drv_data->input_port_last);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to initially read input port: %d",
 			dev->name, rc);
@@ -628,8 +611,7 @@ static const struct gpio_driver_api pcal6408a_drv_api = {
 			.port_pin_mask =				   \
 				GPIO_PORT_PIN_MASK_FROM_DT_INST(idx),	   \
 		},							   \
-		.i2c = DEVICE_DT_GET(DT_INST_BUS(idx)),			   \
-		.i2c_addr = DT_INST_REG_ADDR(idx),			   \
+		.i2c = I2C_DT_SPEC_INST_GET(idx),			   \
 		INIT_INT_GPIO_FIELDS(idx)				   \
 		INIT_RESET_GPIO_FIELDS(idx)				   \
 	};								   \


### PR DESCRIPTION
Simplify driver by using i2c_dt_spec for bus access.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>