### PR TITLE
Rewrite the k_pipe_get() and k_pipe_put() APIs

### DIFF
--- a/doc/kernel/services/data_passing/pipes.rst
+++ b/doc/kernel/services/data_passing/pipes.rst
@@ -54,8 +54,9 @@ pended writer to fill the ring buffer.
     Flushing does not in practice allocate or use additional buffers.
 
 .. note::
-    The kernel does NOT allow for an ISR to send or receive data to/from a
-    pipe or flush even if it does not attempt to wait for space/data.
+    The kernel does allow for an ISR to flush a pipe from an ISR. It also
+    allows it to send/receive data to/from one provided it does not attempt
+    to wait for space/data.
 
 Implementation
 **************

--- a/doc/kernel/services/index.rst
+++ b/doc/kernel/services/index.rst
@@ -61,7 +61,7 @@ LIFO              No                  Queue                  Arbitrary [1]      
 Stack             No                  Array                  Word                          Word   Yes [3]            Yes             Undefined behavior
 Message queue     No                  Ring buffer            Power of two          Power of two   Yes [3]            Yes             Pend thread or return -errno
 Mailbox           Yes                 Queue                  Arbitrary [1]            Arbitrary   No                 No              N/A
-Pipe              No                  Ring buffer [4]        Arbitrary                Arbitrary   No                 No              Pend thread or return -errno
+Pipe              No                  Ring buffer [4]        Arbitrary                Arbitrary   Yes [5]            No              Pend thread or return -errno
 ===============   ==============      ===================    ==============      ==============   =================  ==============  ===============================
 
 [1] Callers allocate space for queue overhead in the data
@@ -75,6 +75,9 @@ calling thread's resource pool.
 argument.
 
 [4] Optional.
+
+[5] ISRS can send and/or receive only when passing K_NO_WAIT as the
+timeout argument.
 
 .. toctree::
    :maxdepth: 1

--- a/kernel/pipes.c
+++ b/kernel/pipes.c
@@ -127,6 +127,8 @@ void z_impl_k_pipe_buffer_flush(struct k_pipe *pipe)
 	if (pipe->buffer != NULL) {
 		(void) pipe_get_internal(key, pipe, NULL, pipe->size,
 					 &bytes_read, 0, K_NO_WAIT);
+	} else {
+		k_spin_unlock(&pipe->lock, key);
 	}
 
 	SYS_PORT_TRACING_OBJ_FUNC_EXIT(k_pipe, buffer_flush, pipe);


### PR DESCRIPTION
Fixes #47061

The original pipe implementation was written using sched-lock as it was both assumed at the time that it would only be used on a single processor system AND to minimize interrupt latency in case large amounts of data needed to be copied from one buffer to another. That assumption no longer holds, and pipes as it was written is wrong for an SMP system.

The new implementation  uses spin locks to guard to the pipe even during the data copying. This may negatively impact interrupt latency while copying data, but it does ensure overall correctness. One other benefit of this is that it allows these routines to be called from within an ISR (provided that the timeout is set to K_NO_WAIT).

The new implementation is simpler in nature and on x86 also reduces the .text section of the pipe module by about 16%.

Overall strategy differences.
---------------------
Instead of duplicating code by having custom strategies for copying into/from waiting threads' buffers, or pipe buffers. The new implementation creates a list of descriptors that describe where the data is to be copied to/from (waiting thread buffers or pipe buffers). Once this is created, we then iterate over the set copying the data as described by each descriptor. This eliminates a fair bit of code duplication and simplifies everything A LOT!

The next major difference is that instead of re-purposing the thread's queuing node for creating the list of waiting threads, we simply extend the existing **k_pipe_desc** structure to add extra fields to do this. Each instance of a **k_pipe_desc** structure resides on the thread's stack. This reduces the number of times we have to traverse a list of waiting threads. Originally, the traversal was done up to three times (once for testing if there is enough room, once for creating the list and once for processing the list). Now it needs only be done twice (once for creating the list and once for processing it).

Finally, there is one other fix in this set of commits. If one attempts to call k_pipe_buffer_flush() on a pipe with no buffer, it will no longer leave the routine with a locked spin-lock.