### PR TITLE
doc: gen_devicetree_rest: Fix glob to handle both .yaml and .yml

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -204,6 +204,8 @@ def load_bindings(dts_roots):
 
     binding_files = []
     for dts_root in dts_roots:
+        binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yml',
+                                       recursive=True))
         binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yaml',
                                        recursive=True))
 


### PR DESCRIPTION
The glob search was only finding .yaml files, however we do have a
few .yml bindings that got missed.

Signed-off-by: Kumar Gala <galak@kernel.org>