### PR TITLE
modbus: remove the use of DT_INST_LABEL and DT_PROP(inst, label)

### DIFF
--- a/samples/subsys/modbus/rtu_client/app.overlay
+++ b/samples/subsys/modbus/rtu_client/app.overlay
@@ -9,7 +9,6 @@
 
 	modbus0 {
 		compatible = "zephyr,modbus-serial";
-		label = "MODBUS0";
 		status = "okay";
 		de-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
 	};

--- a/samples/subsys/modbus/rtu_client/src/main.c
+++ b/samples/subsys/modbus/rtu_client/src/main.c
@@ -24,9 +24,11 @@ const static struct modbus_iface_param client_param = {
 	},
 };
 
+#define MODBUS_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_modbus_serial)
+
 static int init_modbus_client(void)
 {
-	const char iface_name[] = {DT_PROP(DT_INST(0, zephyr_modbus_serial), label)};
+	const char iface_name[] = {DEVICE_DT_NAME(MODBUS_NODE)};
 
 	client_iface = modbus_iface_get_by_name(iface_name);
 

--- a/samples/subsys/modbus/rtu_server/app.overlay
+++ b/samples/subsys/modbus/rtu_server/app.overlay
@@ -9,7 +9,6 @@
 
 	modbus0 {
 		compatible = "zephyr,modbus-serial";
-		label = "MODBUS0";
 		status = "okay";
 		de-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
 	};

--- a/samples/subsys/modbus/rtu_server/cdc-acm.overlay
+++ b/samples/subsys/modbus/rtu_server/cdc-acm.overlay
@@ -8,11 +8,9 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 
 		modbus0 {
 			compatible = "zephyr,modbus-serial";
-			label = "MODBUS0";
 			status = "okay";
 		};
 	};

--- a/samples/subsys/modbus/rtu_server/src/main.c
+++ b/samples/subsys/modbus/rtu_server/src/main.c
@@ -109,9 +109,11 @@ const static struct modbus_iface_param server_param = {
 	},
 };
 
+#define MODBUS_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_modbus_serial)
+
 static int init_modbus_server(void)
 {
-	const char iface_name[] = {DT_PROP(DT_INST(0, zephyr_modbus_serial), label)};
+	const char iface_name[] = {DEVICE_DT_NAME(MODBUS_NODE)};
 	int iface;
 
 	iface = modbus_iface_get_by_name(iface_name);
@@ -123,8 +125,6 @@ static int init_modbus_server(void)
 
 	return modbus_init_server(iface, server_param);
 }
-
-#define MODBUS_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_modbus_serial)
 
 void main(void)
 {

--- a/samples/subsys/modbus/tcp_gateway/boards/frdm_k64f.overlay
+++ b/samples/subsys/modbus/tcp_gateway/boards/frdm_k64f.overlay
@@ -10,7 +10,6 @@
 
 	modbus0 {
 		compatible = "zephyr,modbus-serial";
-		label = "MODBUS0";
 		status = "okay";
 	};
 };

--- a/samples/subsys/modbus/tcp_gateway/src/main.c
+++ b/samples/subsys/modbus/tcp_gateway/src/main.c
@@ -27,9 +27,11 @@ const static struct modbus_iface_param backend_param = {
 	},
 };
 
+#define MODBUS_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_modbus_serial)
+
 static int init_backend_iface(void)
 {
-	const char bend_name[] = {DT_PROP(DT_INST(0, zephyr_modbus_serial), label)};
+	const char bend_name[] = {DEVICE_DT_NAME(MODBUS_NODE)};
 
 	backend = modbus_iface_get_by_name(bend_name);
 	if (backend < 0) {

--- a/subsys/modbus/modbus_core.c
+++ b/subsys/modbus/modbus_core.c
@@ -47,7 +47,7 @@ static struct modbus_serial_config modbus_serial_cfg[] = {
 #endif
 
 #define MODBUS_DT_GET_DEV(inst) {				\
-		.iface_name = DT_INST_LABEL(inst),		\
+		.iface_name = DEVICE_DT_NAME(DT_DRV_INST(inst)),\
 		.cfg = &modbus_serial_cfg[inst],		\
 	},
 

--- a/tests/subsys/modbus/boards/frdm_k64f.overlay
+++ b/tests/subsys/modbus/boards/frdm_k64f.overlay
@@ -9,7 +9,6 @@
 
 	modbus0 {
 		compatible = "zephyr,modbus-serial";
-		label = "MODBUS0";
 		status = "okay";
 		de-gpios = <&gpiob 22 GPIO_ACTIVE_LOW>;	/* red LED */
 		re-gpios = <&gpioe 26 GPIO_ACTIVE_LOW>;	/* green LED */
@@ -22,7 +21,6 @@
 
 	modbus1 {
 		compatible = "zephyr,modbus-serial";
-		label = "MODBUS1";
 		status = "okay";
 	};
 };

--- a/tests/subsys/modbus/boards/reel_board.overlay
+++ b/tests/subsys/modbus/boards/reel_board.overlay
@@ -9,7 +9,6 @@
 
 	modbus0 {
 		compatible = "zephyr,modbus-serial";
-		label = "MODBUS0";
 		status = "okay";
 	};
 };

--- a/tests/subsys/modbus/src/test_modbus_client.c
+++ b/tests/subsys/modbus/src/test_modbus_client.c
@@ -212,13 +212,24 @@ static struct modbus_iface_param client_param = {
 	},
 };
 
+/*
+ * This test performed on hardware requires two UART controllers
+ * on the board (with RX/TX lines connected crosswise).
+ * The exact mapping is not required, we assume that both controllers
+ * have similar capabilities and use the instance with index 0
+ * as interface for the client.
+ */
+#if DT_NODE_EXISTS(DT_INST(0, zephyr_modbus_serial))
+static const char rtu_iface_name[] = {DEVICE_DT_NAME(DT_INST(0, zephyr_modbus_serial))};
+#else
+static const char rtu_iface_name[] = "";
+#endif
+
 void test_client_setup_low_none(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(0, zephyr_modbus_serial),
-					      label, "")};
 
-	client_iface = modbus_iface_get_by_name(iface_name);
+	client_iface = modbus_iface_get_by_name(rtu_iface_name);
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	client_param.serial.parity = UART_CFG_PARITY_NONE;
@@ -231,10 +242,8 @@ void test_client_setup_low_none(void)
 void test_client_setup_low_odd(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(0, zephyr_modbus_serial),
-					      label, "")};
 
-	client_iface = modbus_iface_get_by_name(iface_name);
+	client_iface = modbus_iface_get_by_name(rtu_iface_name);
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	client_param.serial.parity = UART_CFG_PARITY_ODD;
@@ -247,10 +256,8 @@ void test_client_setup_low_odd(void)
 void test_client_setup_high_even(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(0, zephyr_modbus_serial),
-					      label, "")};
 
-	client_iface = modbus_iface_get_by_name(iface_name);
+	client_iface = modbus_iface_get_by_name(rtu_iface_name);
 	client_param.mode = MODBUS_MODE_RTU;
 	client_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	client_param.serial.parity = UART_CFG_PARITY_EVEN;
@@ -263,10 +270,8 @@ void test_client_setup_high_even(void)
 void test_client_setup_ascii(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(0, zephyr_modbus_serial),
-					      label, "")};
 
-	client_iface = modbus_iface_get_by_name(iface_name);
+	client_iface = modbus_iface_get_by_name(rtu_iface_name);
 	client_param.mode = MODBUS_MODE_ASCII;
 	client_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	client_param.serial.parity = UART_CFG_PARITY_EVEN;

--- a/tests/subsys/modbus/src/test_modbus_server.c
+++ b/tests/subsys/modbus/src/test_modbus_server.c
@@ -183,13 +183,24 @@ static struct modbus_iface_param server_param = {
 	},
 };
 
+/*
+ * This test performed on hardware requires two UART controllers
+ * on the board (with RX/TX lines connected crosswise).
+ * The exact mapping is not required, we assume that both controllers
+ * have similar capabilities and use the instance with index 1
+ * as interface for the server.
+ */
+#if DT_NODE_EXISTS(DT_INST(1, zephyr_modbus_serial))
+static const char rtu_iface_name[] = {DEVICE_DT_NAME(DT_INST(1, zephyr_modbus_serial))};
+#else
+static const char rtu_iface_name[] = "";
+#endif
+
 void test_server_setup_low_odd(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(1, zephyr_modbus_serial),
-					      label, "")};
 
-	server_iface = modbus_iface_get_by_name(iface_name);
+	server_iface = modbus_iface_get_by_name(rtu_iface_name);
 	server_param.mode = MODBUS_MODE_RTU;
 	server_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	server_param.serial.parity = UART_CFG_PARITY_ODD;
@@ -205,10 +216,8 @@ void test_server_setup_low_odd(void)
 void test_server_setup_low_none(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(1, zephyr_modbus_serial),
-					      label, "")};
 
-	server_iface = modbus_iface_get_by_name(iface_name);
+	server_iface = modbus_iface_get_by_name(rtu_iface_name);
 	server_param.mode = MODBUS_MODE_RTU;
 	server_param.serial.baud = MB_TEST_BAUDRATE_LOW;
 	server_param.serial.parity = UART_CFG_PARITY_NONE;
@@ -224,10 +233,8 @@ void test_server_setup_low_none(void)
 void test_server_setup_high_even(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(1, zephyr_modbus_serial),
-					      label, "")};
 
-	server_iface = modbus_iface_get_by_name(iface_name);
+	server_iface = modbus_iface_get_by_name(rtu_iface_name);
 	server_param.mode = MODBUS_MODE_RTU;
 	server_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	server_param.serial.parity = UART_CFG_PARITY_EVEN;
@@ -243,10 +250,8 @@ void test_server_setup_high_even(void)
 void test_server_setup_ascii(void)
 {
 	int err;
-	const char iface_name[] = {DT_PROP_OR(DT_INST(1, zephyr_modbus_serial),
-					      label, "")};
 
-	server_iface = modbus_iface_get_by_name(iface_name);
+	server_iface = modbus_iface_get_by_name(rtu_iface_name);
 	server_param.mode = MODBUS_MODE_ASCII;
 	server_param.serial.baud = MB_TEST_BAUDRATE_HIGH;
 	server_param.serial.parity = UART_CFG_PARITY_EVEN;


### PR DESCRIPTION
Remove the use of DT_INST_LABEL and DT_PROP(inst, label).
Although it is possible to simply use the interface number,
it has proven convenient to use the names for the interfaces
in the samples. Migrate to DEVICE_DT_NAME().