### PR TITLE
dt-dindings/clock: add HSE as clock source for stm32g0 and stm32g4

### DIFF
--- a/include/zephyr/dt-bindings/clock/stm32g0_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g0_clock.h
@@ -21,16 +21,17 @@
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
 #define STM32_SRC_MSI		0x002
-#define STM32_SRC_LSE		0x003
-#define STM32_SRC_LSI		0x004
+#define STM32_SRC_HSE		0x003
+#define STM32_SRC_LSE		0x004
+#define STM32_SRC_LSI		0x005
 /** System clock */
-#define STM32_SRC_SYSCLK	0x005
+#define STM32_SRC_SYSCLK	0x006
 /** Peripheral bus clock */
-#define STM32_SRC_PCLK		0x006
+#define STM32_SRC_PCLK		0x007
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P		0x007
-#define STM32_SRC_PLL_Q		0x008
-#define STM32_SRC_PLL_R		0x009
+#define STM32_SRC_PLL_P		0x008
+#define STM32_SRC_PLL_Q		0x009
+#define STM32_SRC_PLL_R		0x00a
 
 /**
  * @brief STM32 clock configuration bit field.

--- a/include/zephyr/dt-bindings/clock/stm32g4_clock.h
+++ b/include/zephyr/dt-bindings/clock/stm32g4_clock.h
@@ -23,17 +23,18 @@
 /** Fixed clocks  */
 #define STM32_SRC_HSI		0x001
 /* #define STM32_SRC_HSI48	0x002 */
-#define STM32_SRC_LSE		0x003
-#define STM32_SRC_LSI		0x004
-#define STM32_SRC_MSI		0x005
+#define STM32_SRC_HSE		0x003
+#define STM32_SRC_LSE		0x004
+#define STM32_SRC_LSI		0x005
+#define STM32_SRC_MSI		0x006
 /** System clock */
-#define STM32_SRC_SYSCLK	0x006
+#define STM32_SRC_SYSCLK	0x007
 /** Bus clock */
-#define STM32_SRC_PCLK		0x007
+#define STM32_SRC_PCLK		0x008
 /** PLL clock outputs */
-#define STM32_SRC_PLL_P		0x008
-#define STM32_SRC_PLL_Q		0x009
-#define STM32_SRC_PLL_R		0x00a
+#define STM32_SRC_PLL_P		0x009
+#define STM32_SRC_PLL_Q		0x00a
+#define STM32_SRC_PLL_R		0x00b
 /* TODO: PLLSAI clocks */
 
 /**


### PR DESCRIPTION
HSE is a valid alternate clock source for these series,
therefore STM32_SRC_HSE is added to the clock dt-bindings definitions.