### PR TITLE
 boards: nucleo_u575zi_q enable additional peripheral nodes and runners

### DIFF
--- a/boards/arm/nucleo_u575zi_q/arduino_r3_connector.dtsi
+++ b/boards/arm/nucleo_u575zi_q/arduino_r3_connector.dtsi
@@ -34,3 +34,7 @@
 			   <21 0 &gpiob 8 0>;	/* D15 */
 	};
 };
+
+arduino_i2c: &i2c1 {};
+arduino_spi: &spi1 {};
+arduino_serial: &lpuart1 {};

--- a/boards/arm/nucleo_u575zi_q/board.cmake
+++ b/boards/arm/nucleo_u575zi_q/board.cmake
@@ -5,7 +5,13 @@ board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
 board_runner_args(openocd "--no-halt")
 
+board_runner_args(pyocd "--target=stm32u575zitx")
+
+board_runner_args(jlink "--device=STM32U575ZI" "--reset-after-load")
+
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 # FIXME: openocd runner requires use of STMicro openocd fork.
 # Check board documentation for more details.
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
@@ -145,14 +145,24 @@ The Zephyr nucleo_u575zi_q board configuration supports the following hardware f
 +-----------+------------+-------------------------------------+
 | Interface | Controller | Driver/Component                    |
 +===========+============+=====================================+
+| CLOCK     | on-chip    | reset and clock control             |
++-----------+------------+-------------------------------------+
+| DAC       | on-chip    | DAC Controller                      |
++-----------+------------+-------------------------------------+
+| GPIO      | on-chip    | gpio                                |
++-----------+------------+-------------------------------------+
+| I2C       | on-chip    | i2c                                 |
++-----------+------------+-------------------------------------+
 | NVIC      | on-chip    | nested vector interrupt controller  |
++-----------+------------+-------------------------------------+
+| PINMUX    | on-chip    | pinmux                              |
++-----------+------------+-------------------------------------+
+| SPI       | on-chip    | spi                                 |
 +-----------+------------+-------------------------------------+
 | UART      | on-chip    | serial port-polling;                |
 |           |            | serial port-interrupt               |
 +-----------+------------+-------------------------------------+
-| PINMUX    | on-chip    | pinmux                              |
-+-----------+------------+-------------------------------------+
-| GPIO      | on-chip    | gpio                                |
+| WATCHDOG  | on-chip    | independent watchdog                |
 +-----------+------------+-------------------------------------+
 
 
@@ -173,12 +183,25 @@ For mode details please refer to `STM32 Nucleo-144 board User Manual`_.
 Default Zephyr Peripheral Mapping:
 ----------------------------------
 
-- UART_1_TX : PA9
-- UART_1_RX : PA10
-- USER_PB : PC13
+- DAC1_OUT1 : PA4
+- I2C_1_SCL : PB8
+- I2C_1_SDA : PB9
+- I2C_2_SCL : PF1
+- I2C_2_SDA : PF0
 - LD1 : PC7
 - LD2 : PB7
 - LD3 : PG2
+- LPUART_1_TX : PG7
+- LPUART_1_RX : PG8
+- SPI_1_NSS : PA4
+- SPI_1_SCK : PA5
+- SPI_1_MISO : PA6
+- SPI_1_MOSI : PA7
+- UART_1_TX : PA9
+- UART_1_RX : PA10
+- UART_2_TX : PD5
+- UART_2_RX : PD6
+- USER_PB : PC13
 
 System Clock
 ------------

--- a/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
+++ b/boards/arm/nucleo_u575zi_q/doc/nucleou575zi_q.rst
@@ -207,6 +207,17 @@ Flashing
 Board is configured to be flashed using west STM32CubeProgrammer runner.
 Installation of `STM32CubeProgrammer`_ is then required to flash the board.
 
+Alternatively pyocd and JLink can be used to flash and debug the board.
+JLink works out of the box if west is told to use it as runner,
+which can be done by passing ``-r jlink``.
+For pyocd (``-r pyocd``) additional target information needs to be installed.
+This can be done by executing the following commands.
+
+.. code-block:: console
+
+   $ pyocd pack --update
+   $ pyocd pack --install stm32u5
+
 
 Flashing an application to Nucleo U575ZI Q
 ------------------------------------------

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -61,3 +61,49 @@
 	apb2-prescaler = <1>;
 	apb3-prescaler = <1>;
 };
+
+&lpuart1 {
+	pinctrl-0 = <&lpuart1_tx_pg7 &lpuart1_rx_pg8>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart2 {
+	pinctrl-0 = <&usart2_tx_pd5 &usart2_rx_pd6>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb8 &i2c1_sda_pb9>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
+		     &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&dac1 {
+	/* CAUTION: DAC on PA4 may conflict with SPI1 NSS on same pin */
+	pinctrl-0 = <&dac1_out1_pa4>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&iwdg {
+	status = "okay";
+};

--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.yaml
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.yaml
@@ -6,6 +6,15 @@ toolchain:
   - zephyr
   - gnuarmemb
 supported:
+  - arduino_gpio
+  - arduino_i2c
+  - arduino_serial
+  - arduino_spi
+  - dac
   - gpio
+  - i2c
+  - spi
+  - usart
+  - watchdog
 ram: 786
 flash: 2048

--- a/samples/drivers/dac/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/dac/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,7 @@
+/ {
+	zephyr,user {
+		dac = <&dac1>;
+		dac-channel-id = <1>;
+		dac-resolution = <12>;
+	};
+};

--- a/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022 Thomas Stranger
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&rcc {
+	apb2-prescaler = <2>;
+};


### PR DESCRIPTION
This PR enables the following additional nodes on the nucleo_u575zi_q:
lpuart1, usart2, i2c1, i2c2, spi1, dac1, and iwdg.

Additionally, Jlink and pyocd runners, and overlay files for the spi loopback test as well as the DAC sample are added. 

