### PR TITLE
drivers: gpio: dw: Updating driver to Enable Multiple Interrupts.

### DIFF
--- a/drivers/gpio/gpio_dw.c
+++ b/drivers/gpio/gpio_dw.c
@@ -383,8 +383,6 @@ static inline int gpio_dw_manage_callback(const struct device *port,
 	return gpio_manage_callback(&context->callbacks, callback, set);
 }
 
-#define gpio_dw_unmask_int(...)
-
 static void gpio_dw_isr(const struct device *port)
 {
 	struct gpio_dw_runtime *context = port->data;
@@ -437,19 +435,17 @@ static int gpio_dw_initialize(const struct device *port)
 #define INST_IRQ_FLAGS(n) \
 	COND_CODE_1(DT_INST_IRQ_HAS_CELL(n, flags), (DT_INST_IRQ(n, flags)), (0))
 
-#define GPIO_CFG_IRQ(n)										\
-		const struct gpio_dw_config *config = port->config;				\
-												\
-		IRQ_CONNECT(DT_INST_IRQN(n),							\
+#define GPIO_CFG_IRQ(idx, n)									\
+		IRQ_CONNECT(DT_INST_IRQ_BY_IDX(n, idx, irq),					\
 			    DT_INST_IRQ(n, priority), gpio_dw_isr,				\
 			    DEVICE_DT_INST_GET(n), INST_IRQ_FLAGS(n));				\
-		irq_enable(config->irq_num);							\
-		gpio_dw_unmask_int(GPIO_DW_PORT_##n##_INT_MASK);				\
+		irq_enable(DT_INST_IRQ_BY_IDX(n, idx, irq));					\
 
 #define GPIO_DW_INIT(n)										\
 	static void gpio_config_##n##_irq(const struct device *port)				\
 	{											\
-		IF_ENABLED(DT_INST_IRQ_HAS_IDX(n, 0), (GPIO_CFG_IRQ(n)))			\
+		ARG_UNUSED(port);			                                        \
+		LISTIFY(DT_NUM_IRQS(DT_DRV_INST(n)), GPIO_CFG_IRQ, (), n)                       \
 	}											\
 												\
 	static const struct gpio_dw_config gpio_dw_config_##n = {				\


### PR DESCRIPTION
Change Summary:
- Updating GPIO_CFG_IRQ define to enable multiple interrupts to
  accomodate for IP configuration where each pin when interrupted
  can trigger CPU interrupt.

Signed-off-by: Ravik Hasija <ravikh@fb.com>