### PR TITLE
Update EPD documentation with actual chip names

### DIFF
--- a/boards/arm/reel_board/doc/index.rst
+++ b/boards/arm/reel_board/doc/index.rst
@@ -87,7 +87,7 @@ used for building an application.
 | Good Display | HINK-E0213         | SSD1673 /            | reel_board        |
 | GDEH0213B1   |                    | ssd16xx              |                   |
 +--------------+--------------------+----------------------+-------------------+
-| Good Display | HINK-E0213A22      | IL3897 /             | reel_board_v2     |
+| Good Display | HINK-E0213A22      | SSD1675A /           | reel_board_v2     |
 | GDEH0213B72  |                    | ssd16xx              |                   |
 +--------------+--------------------+----------------------+-------------------+
 

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -56,7 +56,7 @@
 	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";
 	ssd16xx: ssd16xxfb@0 {
-		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b1";
+		compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673", "solomon,ssd16xxfb";
 		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/arm/reel_board/reel_board_v2.dts
+++ b/boards/arm/reel_board/reel_board_v2.dts
@@ -36,7 +36,7 @@
 	pinctrl-1 = <&spi1_sleep>;
 	pinctrl-names = "default", "sleep";
 	ssd16xx: ssd16xxfb@0 {
-		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b72";
+		compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a", "solomon,ssd16xxfb";
 		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/doc/index.rst
+++ b/boards/shields/waveshare_epaper/doc/index.rst
@@ -50,13 +50,13 @@ Current supported displays
 | Good Display | HINK-E0213      | SSD1673 /    | waveshare_epaper_gdeh0213b1  |
 | GDEH0213B1   |                 | ssd16xx      |                              |
 +--------------+-----------------+--------------+------------------------------+
-| Good Display | HINK-E0213A22   | IL3897 /     | waveshare_epaper_gdeh0213b72 |
+| Good Display | HINK-E0213A22   | SSD1675A /   | waveshare_epaper_gdeh0213b72 |
 | GDEH0213B72  |                 | ssd16xx      |                              |
 +--------------+-----------------+--------------+------------------------------+
-| Good Display | E029A01         | IL3820 /     | waveshare_epaper_gdeh029a1   |
+| Good Display | E029A01         | SSD1608 /    | waveshare_epaper_gdeh029a1   |
 | GDEH029A1    |                 | ssd16xx      |                              |
 +--------------+-----------------+--------------+------------------------------+
-| Good Display | WFT0583CZ61     | GD7965 /     | waveshare_epaper_gdew075t7   |
+| Good Display | WFT0583CZ61     | UC8179 /     | waveshare_epaper_gdew075t7   |
 | GDEW075T7    |                 | gd7965       |                              |
 +--------------+-----------------+--------------+------------------------------+
 | Good Display | HINK-E0154A07   | SSD1681 /    | waveshare_epaper_gdeh0154a07 |

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
@@ -14,7 +14,7 @@
 
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
-		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0154a07";
+		compatible = "gooddisplay,gdeh0154a07", "solomon,ssd1681", "solomon,ssd16xxfb";
 		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -14,7 +14,7 @@
 
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
-		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b1";
+		compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673", "solomon,ssd16xxfb";
 		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -14,7 +14,7 @@
 
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
-		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh0213b72";
+		compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a", "solomon,ssd16xxfb";
 		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -14,7 +14,7 @@
 
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
-		compatible = "solomon,ssd16xxfb", "gooddisplay,gdeh029a1";
+		compatible = "gooddisplay,gdeh029a1", "solomon,ssd1608", "solomon,ssd16xxfb";
 		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
@@ -13,8 +13,8 @@
 
 &arduino_spi {
 	gd7965: gd7965@0 {
-		compatible = "gooddisplay,gd7965","gooddisplay,gdew042t2";
-    		label = "GD7965";
+		compatible = "gooddisplay,gdew042t2", "ultrachip,uc8176", "gooddisplay,gd7965";
+		label = "GD7965";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <400>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -14,7 +14,7 @@
 
 &arduino_spi {
 	gd7965: gd7965@0 {
-		compatible = "gooddisplay,gd7965";
+		compatible = "gooddisplay,gdew075t7", "ultrachip,uc8179", "gooddisplay,gd7965";
 		label = "GD7965";
 		spi-max-frequency = <4000000>;
 		reg = <0>;


### PR DESCRIPTION
GoodDisplay used to hide the real vendor of the driver chip in some of their old data sheets. This is no longer the case and the actual chip version can be found on their official site. Update the documentation to show which chip is actually used.

This change is also reflected in the device tree overlays where the specific chip versions are now included in the compatible strings.