### PR TITLE
dts: bindings: gpio: device labels are now optional

### DIFF
--- a/dts/bindings/gpio/andestech,atcgpio100.yaml
+++ b/dts/bindings/gpio/andestech,atcgpio100.yaml
@@ -13,9 +13,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/gpio/arm,cmsdk-gpio.yaml
+++ b/dts/bindings/gpio/arm,cmsdk-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/atmel,sam-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     peripheral-id:
       type: int
       description: peripheral ID

--- a/dts/bindings/gpio/atmel,sam0-gpio.yaml
+++ b/dts/bindings/gpio/atmel,sam0-gpio.yaml
@@ -8,9 +8,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/cypress,cy8c95xx-gpio-port.yaml
+++ b/dts/bindings/gpio/cypress,cy8c95xx-gpio-port.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/cypress,cy8c95xx-gpio.yaml
+++ b/dts/bindings/gpio/cypress,cy8c95xx-gpio.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/gpio/cypress,psoc6-gpio.yaml
+++ b/dts/bindings/gpio/cypress,psoc6-gpio.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/cypress,psoc6-hsiom.yaml
+++ b/dts/bindings/gpio/cypress,psoc6-hsiom.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/gpio/espressif,esp32-gpio.yaml
+++ b/dts/bindings/gpio/espressif,esp32-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
         required: true
 
-    label:
-        required: true
-
     "#gpio-cells":
         const: 2
 

--- a/dts/bindings/gpio/fcs,fxl6408.yaml
+++ b/dts/bindings/gpio/fcs,fxl6408.yaml
@@ -8,9 +8,6 @@ compatible: "fcs,fxl6408"
 include: [gpio-controller.yaml, i2c-device.yaml]
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/gd,gd32-gpio.yaml
+++ b/dts/bindings/gpio/gd,gd32-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     rcu-periph-clock:
       type: int
       description: Reset Control Unit Peripheral Clock ID

--- a/dts/bindings/gpio/intel,gpio.yaml
+++ b/dts/bindings/gpio/intel,gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     group-index:
       type: int
       description: Group number for this GPIO entry

--- a/dts/bindings/gpio/ite,it8xxx2-gpio.yaml
+++ b/dts/bindings/gpio/ite,it8xxx2-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
 gpio-cells:
   - pin
   - flags

--- a/dts/bindings/gpio/litex,gpio.yaml
+++ b/dts/bindings/gpio/litex,gpio.yaml
@@ -18,9 +18,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     ngpios:
       required: true
 

--- a/dts/bindings/gpio/microchip,mcp230xx.yaml
+++ b/dts/bindings/gpio/microchip,mcp230xx.yaml
@@ -12,9 +12,6 @@ compatible: "microchip,mcp230xx"
 include: [gpio-controller.yaml, i2c-device.yaml]
 
 properties:
-    label:
-      required: true
-
     ngpios:
       type: int
       enum:

--- a/dts/bindings/gpio/microchip,mcp23s17.yaml
+++ b/dts/bindings/gpio/microchip,mcp23s17.yaml
@@ -12,9 +12,6 @@ compatible: "microchip,mcp23s17"
 include: [gpio-controller.yaml, spi-device.yaml]
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/microchip,mcp23sxx.yaml
+++ b/dts/bindings/gpio/microchip,mcp23sxx.yaml
@@ -13,9 +13,6 @@ compatible: "microchip,mcp23sxx"
 include: [gpio-controller.yaml, spi-device.yaml]
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/microchip,xec-gpio-v2.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio-v2.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: false
 
-    label:
-      required: true
-
     port-id:
       type: int
       required: true

--- a/dts/bindings/gpio/microchip,xec-gpio.yaml
+++ b/dts/bindings/gpio/microchip,xec-gpio.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: false
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/nordic,nrf-gpio.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/nordic,nrf-gpiote.yaml
+++ b/dts/bindings/gpio/nordic,nrf-gpiote.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio-alert.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio-alert.yaml
@@ -9,7 +9,6 @@ description: |
         compatible = "nuvoton,nct38xx-gpio-alert";
         irq-gpios = <&gpiod 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
         nct38xx-dev = <&nct3808_0_P1 &nct3808_0_P2>;
-        label = "NCT3808_ALERT_0";
       };
 
 compatible: "nuvoton,nct38xx-gpio-alert"
@@ -17,9 +16,6 @@ compatible: "nuvoton,nct38xx-gpio-alert"
 include: [base.yaml]
 
 properties:
-    label:
-      required: true
-
     irq-gpios:
       type: phandle-array
       required: true

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
@@ -8,9 +8,6 @@ compatible: "nuvoton,nct38xx-gpio-port"
 include: [gpio-controller.yaml, base.yaml]
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio.yaml
@@ -11,12 +11,10 @@ description: |
           #size-cells = <0>;
           compatible = "nuvoton,nct38xx-gpio";
           reg = <0x70>;
-          label = "NCT3807_0";
 
           gpio@0 {
             compatible = "nuvoton,nct38xx-gpio-port";
             reg = <0x0>;
-            label = "NCT3807_0_GPIO0";
             gpio-controller;
             #gpio-cells = <2>;
             ngpios = <8>;
@@ -27,7 +25,6 @@ description: |
           gpio@1 {
             compatible = "nuvoton,nct38xx-gpio-port";
             reg = <0x1>;
-            label = "NCT3807_0_GPIO1";
             gpio-controller;
             #gpio-cells = <2>;
             ngpios = <8>;
@@ -40,12 +37,10 @@ description: |
           #size-cells = <0>;
           compatible = "nuvoton,nct38xx-gpio";
           reg = <0x71>;
-          label = "NCT3808_0_P1";
 
           gpio@0 {
             compatible = "nuvoton,nct38xx-gpio-port";
             reg = <0x0>;
-            label = "NCT3808_0_P1_GPIO0";
             gpio-controller;
             #gpio-cells = <2>;
             ngpios = <8>;
@@ -59,12 +54,10 @@ description: |
           #size-cells = <0>;
           compatible = "nuvoton,nct38xx-gpio";
           reg = <0x75>;
-          label = "NCT3808_0_P2";
 
           gpio@0 {
             compatible = "nuvoton,nct38xx-gpio-port";
             reg = <0x0>;
-            label = "NCT3808_0_P2_GPIO0";
             gpio-controller;
             #gpio-cells = <2>;
             ngpios = <8>;
@@ -77,7 +70,3 @@ description: |
 compatible: "nuvoton,nct38xx-gpio"
 
 include: [i2c-device.yaml]
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
+++ b/dts/bindings/gpio/nuvoton,npcx-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
         required: true
 
-    label:
-        required: true
-
     index:
         type: int
         required: true

--- a/dts/bindings/gpio/nxp,imx-gpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-gpio.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: false
 
-    label:
-      required: true
-
     rdc:
      type: int
      required: false

--- a/dts/bindings/gpio/nxp,kinetis-gpio.yaml
+++ b/dts/bindings/gpio/nxp,kinetis-gpio.yaml
@@ -8,9 +8,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/nxp,lpc-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
+++ b/dts/bindings/gpio/nxp,lpc11u6x-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/gpio/nxp,pca95xx.yaml
+++ b/dts/bindings/gpio/nxp,pca95xx.yaml
@@ -8,9 +8,6 @@ compatible: "nxp,pca95xx"
 include: [gpio-controller.yaml, i2c-device.yaml]
 
 properties:
-    label:
-      required: true
-
     has-pud:
       type: boolean
       required: false

--- a/dts/bindings/gpio/nxp,pcal6408a.yaml
+++ b/dts/bindings/gpio/nxp,pcal6408a.yaml
@@ -8,9 +8,6 @@ compatible: "nxp,pcal6408a"
 include: [i2c-device.yaml, gpio-controller.yaml]
 
 properties:
-    label:
-      required: true
-
     ngpios:
       required: true
       const: 8

--- a/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
+++ b/dts/bindings/gpio/openisa,rv32m1-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/quicklogic,eos-s3-gpio.yaml
+++ b/dts/bindings/gpio/quicklogic,eos-s3-gpio.yaml
@@ -5,9 +5,6 @@ compatible: "quicklogic,eos-s3-gpio"
 include: [gpio-controller.yaml, base.yaml]
 
 properties:
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/gpio/raspberrypi,pico-gpio.yaml
+++ b/dts/bindings/gpio/raspberrypi,pico-gpio.yaml
@@ -11,9 +11,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   "#gpio-cells":
     const: 2
 

--- a/dts/bindings/gpio/renesas,rcar-gpio.yaml
+++ b/dts/bindings/gpio/renesas,rcar-gpio.yaml
@@ -14,9 +14,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/gpio/semtech,sx1509b.yaml
+++ b/dts/bindings/gpio/semtech,sx1509b.yaml
@@ -8,9 +8,6 @@ compatible: "semtech,sx1509b"
 include: [i2c-device.yaml, gpio-controller.yaml]
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/sifive,gpio0.yaml
+++ b/dts/bindings/gpio/sifive,gpio0.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/gpio/silabs,gecko-gpio-port.yaml
+++ b/dts/bindings/gpio/silabs,gecko-gpio-port.yaml
@@ -8,9 +8,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     peripheral-id:
       type: int
       required: true

--- a/dts/bindings/gpio/silabs,gecko-gpio.yaml
+++ b/dts/bindings/gpio/silabs,gecko-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     location-swo:
       type: int
       required: false

--- a/dts/bindings/gpio/snps,creg-gpio.yaml
+++ b/dts/bindings/gpio/snps,creg-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     bit_per_gpio:
       type: int
       required: true

--- a/dts/bindings/gpio/snps,designware-gpio.yaml
+++ b/dts/bindings/gpio/snps,designware-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/st,stm32-gpio.yaml
+++ b/dts/bindings/gpio/st,stm32-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     clocks:
       required: true
 

--- a/dts/bindings/gpio/st,stmpe1600.yaml
+++ b/dts/bindings/gpio/st,stmpe1600.yaml
@@ -8,9 +8,6 @@ compatible: "st,stmpe1600"
 include: [gpio-controller.yaml, i2c-device.yaml]
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/telink,b91-gpio.yaml
+++ b/dts/bindings/gpio/telink,b91-gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc13xx-cc26xx-gpio.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/ti,cc32xx-gpio.yaml
+++ b/dts/bindings/gpio/ti,cc32xx-gpio.yaml
@@ -12,9 +12,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/ti,lmp90xxx-gpio.yaml
+++ b/dts/bindings/gpio/ti,lmp90xxx-gpio.yaml
@@ -7,9 +7,6 @@ include: [gpio-controller.yaml, base.yaml]
 on-bus: lmp90xxx
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/ti,sn74hc595.yaml
+++ b/dts/bindings/gpio/ti,sn74hc595.yaml
@@ -8,9 +8,6 @@ compatible: "ti,sn74hc595"
 include: [gpio-controller.yaml, spi-device.yaml]
 
 properties:
-    label:
-      required: true
-
     reset-gpios:
       type: phandle-array
       required: true

--- a/dts/bindings/gpio/ti,stellaris-gpio.yaml
+++ b/dts/bindings/gpio/ti,stellaris-gpio.yaml
@@ -10,9 +10,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/gpio/ti,tca9538.yaml
+++ b/dts/bindings/gpio/ti,tca9538.yaml
@@ -9,9 +9,6 @@ compatible: "ti,tca9538"
 include: [i2c-device.yaml, gpio-controller.yaml]
 
 properties:
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/xlnx,ps-gpio-bank.yaml
+++ b/dts/bindings/gpio/xlnx,ps-gpio-bank.yaml
@@ -18,9 +18,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/gpio/xlnx,ps-gpio.yaml
+++ b/dts/bindings/gpio/xlnx,ps-gpio.yaml
@@ -41,8 +41,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/gpio/xlnx,xps-gpio-1.00.a.yaml
+++ b/dts/bindings/gpio/xlnx,xps-gpio-1.00.a.yaml
@@ -13,9 +13,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     xlnx,all-inputs:
       type: int
       description: |

--- a/dts/bindings/gpio/zephyr,gpio-emul.yaml
+++ b/dts/bindings/gpio/zephyr,gpio-emul.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     rising-edge:
       description: Enables support for rising edge interrupt detection
       type: boolean


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>