### PR TITLE
dts: bindings: watchdog: device labels are now optional

### DIFF
--- a/dts/bindings/watchdog/atmel,sam-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam-watchdog.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
+++ b/dts/bindings/watchdog/atmel,sam0-watchdog.yaml
@@ -8,8 +8,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
+++ b/dts/bindings/watchdog/espressif,esp32-watchdog.yaml
@@ -13,8 +13,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: false

--- a/dts/bindings/watchdog/ite,it8xxx2-watchdog.yaml
+++ b/dts/bindings/watchdog/ite,it8xxx2-watchdog.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
+++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/watchdog/nuvoton,npcx-watchdog.yaml
+++ b/dts/bindings/watchdog/nuvoton,npcx-watchdog.yaml
@@ -10,8 +10,6 @@ include: [base.yaml]
 properties:
     reg:
         required: true
-    label:
-        required: true
     t0-out:
         type: phandle
         required: true

--- a/dts/bindings/watchdog/nxp,imx-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,imx-wdog.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
+++ b/dts/bindings/watchdog/nxp,kinetis-wdog32.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/watchdog/nxp,lpc-wwdt.yaml
+++ b/dts/bindings/watchdog/nxp,lpc-wwdt.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/watchdog/raspberrypi,pico-watchdog.yaml
+++ b/dts/bindings/watchdog/raspberrypi,pico-watchdog.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     clocks:
       required: true
       description: Crystal oscillator source clock

--- a/dts/bindings/watchdog/sifive,wdt.yaml
+++ b/dts/bindings/watchdog/sifive,wdt.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/watchdog/silabs,gecko-wdog.yaml
+++ b/dts/bindings/watchdog/silabs,gecko-wdog.yaml
@@ -12,9 +12,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 

--- a/dts/bindings/watchdog/st,stm32-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-watchdog.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
+++ b/dts/bindings/watchdog/st,stm32-window-watchdog.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     clocks:
       required: true

--- a/dts/bindings/watchdog/ti,cc32xx-watchdog.yaml
+++ b/dts/bindings/watchdog/ti,cc32xx-watchdog.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>