### PR TITLE
dts: bindings: timer: device labels are now optional

### DIFF
--- a/dts/bindings/timer/arm,cmsdk-dtimer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-dtimer.yaml
@@ -10,6 +10,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/timer/arm,cmsdk-timer.yaml
+++ b/dts/bindings/timer/arm,cmsdk-timer.yaml
@@ -10,6 +10,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/timer/atmel,sam-tc.yaml
+++ b/dts/bindings/timer/atmel,sam-tc.yaml
@@ -15,9 +15,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     peripheral-id:
       type: array
       description: peripheral ID

--- a/dts/bindings/timer/atmel,sam0-tc32.yaml
+++ b/dts/bindings/timer/atmel,sam0-tc32.yaml
@@ -22,9 +22,6 @@ properties:
   clock-names:
     required: true
 
-  label:
-    required: true
-
   prescaler:
     type: int
     required: false

--- a/dts/bindings/timer/espressif,esp32-systimer.yaml
+++ b/dts/bindings/timer/espressif,esp32-systimer.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/timer/gd,gd32-timer.yaml
+++ b/dts/bindings/timer/gd,gd32-timer.yaml
@@ -8,9 +8,6 @@ compatible: "gd,gd32-timer"
 include: base.yaml
 
 properties:
-  label:
-    required: true
-
   reg:
     required: true
 

--- a/dts/bindings/timer/ite,it8xxx2-timer.yaml
+++ b/dts/bindings/timer/ite,it8xxx2-timer.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     girqs:
       type: array
       required: true

--- a/dts/bindings/timer/nordic,nrf-timer.yaml
+++ b/dts/bindings/timer/nordic,nrf-timer.yaml
@@ -19,9 +19,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     prescaler:
       type: int
       required: true

--- a/dts/bindings/timer/nuvoton,npcx-itim-timer.yaml
+++ b/dts/bindings/timer/nuvoton,npcx-itim-timer.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
         required: true
-
-    label:
-        required: true

--- a/dts/bindings/timer/nxp,imx-gpt.yaml
+++ b/dts/bindings/timer/nxp,imx-gpt.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     gptfreq:
       type: int
       required: true

--- a/dts/bindings/timer/nxp,lpc-ctimer.yaml
+++ b/dts/bindings/timer/nxp,lpc-ctimer.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     clk-source:
       type: int
       required: true

--- a/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
+++ b/dts/bindings/timer/openisa,rv32m1-lptmr.yaml
@@ -10,6 +10,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/timer/renesas,rcar-cmt.yaml
+++ b/dts/bindings/timer/renesas,rcar-cmt.yaml
@@ -5,9 +5,6 @@ compatible: "renesas,rcar-cmt"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/dts/bindings/timer/silabs,gecko-timer.yaml
+++ b/dts/bindings/timer/silabs,gecko-timer.yaml
@@ -8,8 +8,5 @@ compatible: "silabs,gecko-timer"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true

--- a/dts/bindings/timer/st,stm32-timers.yaml
+++ b/dts/bindings/timer/st,stm32-timers.yaml
@@ -8,9 +8,6 @@ compatible: "st,stm32-timers"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/dts/bindings/timer/xlnx,ttcps.yaml
+++ b/dts/bindings/timer/xlnx,ttcps.yaml
@@ -5,9 +5,6 @@ compatible: "xlnx,ttcps"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>