### PR TITLE
dts: bindings: device labels are now optional

### DIFF
--- a/boards/arm/ip_k66f/ip_k66f.dts
+++ b/boards/arm/ip_k66f/ip_k66f.dts
@@ -126,7 +126,6 @@
 		compatible = "microchip,ksz8794";
 		reg = <0>;
 
-		label = "dsa";
 		spi-max-frequency = <44000000>;
 		reset-gpios = <&gpiob 22 GPIO_ACTIVE_LOW>;
 
@@ -136,15 +135,12 @@
 		dsa-slave-ports = <3>;
 
 		lan3: lan_3 {
-			label = "lan3";
 		};
 
 		lan2: lan_2 {
-			label = "lan2";
 		};
 
 		lan1: lan_1 {
-			label = "lan1";
 		};
 	};
 };

--- a/dts/bindings/audio/intel,dmic.yaml
+++ b/dts/bindings/audio/intel,dmic.yaml
@@ -6,7 +6,3 @@ description: Intel Digital PDM Microphone (DMIC) node
 compatible: "intel,dmic"
 
 include: base.yaml
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
+++ b/dts/bindings/audio/st,mpxxdtyy-i2s.yaml
@@ -6,7 +6,3 @@ description: STMicroelectronics MPXXDTYY digital PDM microphone family
 compatible: "st,mpxxdtyy"
 
 include: i2s-device.yaml
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/coredump/zephyr,coredump.yaml
+++ b/dts/bindings/coredump/zephyr,coredump.yaml
@@ -8,9 +8,6 @@ compatible: "zephyr,coredump"
 description: Pseudo-device to help capturing desired data into core dumps
 
 properties:
-    label:
-      required: true
-
     memory-regions:
       type: array
       required: false

--- a/dts/bindings/dac/atmel,sam0-dac.yaml
+++ b/dts/bindings/dac/atmel,sam0-dac.yaml
@@ -19,9 +19,6 @@ properties:
     clock-names:
       required: true
 
-    label:
-      required: true
-
     reference:
       type: string
       required: false

--- a/dts/bindings/dai/dai,intel,dmic.yaml
+++ b/dts/bindings/dai/dai,intel,dmic.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
         required: true
 
-    label:
-       required: true
-
     shim:
       type: array
       required: true

--- a/dts/bindings/display/raydium,rm68200.yaml
+++ b/dts/bindings/display/raydium,rm68200.yaml
@@ -11,9 +11,6 @@ compatible: "raydium,rm68200"
 include: [mipi-dsi-device.yaml, display-controller.yaml]
 
 properties:
-    label:
-      required: true
-
     reset-gpios:
       type: phandle-array
       required: false

--- a/dts/bindings/dsa/microchip_dsa.yaml
+++ b/dts/bindings/dsa/microchip_dsa.yaml
@@ -35,9 +35,6 @@ properties:
 child-binding:
     description: Properties of slave port
     properties:
-        label:
-            type: string
-            required: true
         local-mac-address:
             type: uint8-array
             required: false

--- a/dts/bindings/ec_host_cmd_perhip/zephyr,sim-ec-host-cmd-periph.yaml
+++ b/dts/bindings/ec_host_cmd_perhip/zephyr,sim-ec-host-cmd-periph.yaml
@@ -5,7 +5,3 @@ description: Simulated Host Command Peripheral
 compatible: "zephyr,sim-ec-host-cmd-periph"
 
 include: base.yaml
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -8,7 +8,6 @@ description: |
 
         mx25lm51245: ospi-nor-flash@0 {
                 compatible = "st,stm32-ospi-nor";
-                label = "MX25LM512";
                 reg = <0>;
                 data-mode = <OSPI_OPI_MODE>; /* access on 8 data lines */
                 data-rate = <OSPI_DTR_TRANSFER>; /* access in DTR */
@@ -30,8 +29,6 @@ properties:
       type: int
       required: true
       description: Maximum clock frequency of device's OSPI interface in Hz
-    label:
-      required: true
     size:
       required: true
       description: Flash Memory size in bits

--- a/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-qspi-nor.yaml
@@ -8,7 +8,6 @@ description: |
 
         mx25r6435f: qspi-nor-flash@0 {
                 compatible = "st,stm32-qspi-nor";
-                label = "MX25R6435F";
                 reg = <0>;
                 qspi-max-frequency = <80000000>;
                 size = <0x4000000>;
@@ -31,8 +30,6 @@ properties:
       type: int
       required: true
       description: Maximum clock frequency of device's QSPI interface in Hz
-    label:
-      required: true
     size:
       required: true
       description: Flash Memory size in bits

--- a/dts/bindings/flash_controller/zephyr,sim-flash.yaml
+++ b/dts/bindings/flash_controller/zephyr,sim-flash.yaml
@@ -7,9 +7,6 @@ compatible: "zephyr,sim-flash"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     erase-value:
       type: int
       description: Value of erased flash cell

--- a/dts/bindings/i2c/nuvoton,npcx-i2c-ctrl.yaml
+++ b/dts/bindings/i2c/nuvoton,npcx-i2c-ctrl.yaml
@@ -12,5 +12,3 @@ properties:
         required: true
     clocks:
         required: true
-    label:
-        required: true

--- a/dts/bindings/i2c/ti,tca954x-base.yaml
+++ b/dts/bindings/i2c/ti,tca954x-base.yaml
@@ -15,7 +15,6 @@ description: |
           compatible = "ti,tca9546a";
           reg = <0x77>;
           status = "okay";
-          label = "i2c_mux";
           #address-cells = <1>;
           #size-cells = <0>;
           reset-gpios = <&gpio5 3 GPIO_ACTIVE_LOW>;

--- a/dts/bindings/ieee802154/telink,b91-zb.yaml
+++ b/dts/bindings/ieee802154/telink,b91-zb.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/iio/adc/nuvoton,npcx-adc.yaml
+++ b/dts/bindings/iio/adc/nuvoton,npcx-adc.yaml
@@ -12,8 +12,6 @@ properties:
         required: true
     clocks:
         required: true
-    label:
-        required: true
     pinctrl-0:
         required: true
     pinctrl-names:

--- a/dts/bindings/ipm/nxp,lpc-mailbox.yaml
+++ b/dts/bindings/ipm/nxp,lpc-mailbox.yaml
@@ -13,6 +13,3 @@ properties:
 
   interrupts:
       required: true
-
-  label:
-      required: true

--- a/dts/bindings/kscan/holtek,ht16k33-keyscan.yaml
+++ b/dts/bindings/kscan/holtek,ht16k33-keyscan.yaml
@@ -5,7 +5,3 @@ compatible: "holtek,ht16k33-keyscan"
 include: base.yaml
 
 on-bus: ht16k33
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/led/holtek,ht16k33.yaml
+++ b/dts/bindings/led/holtek,ht16k33.yaml
@@ -7,8 +7,6 @@ include: i2c-device.yaml
 bus: ht16k33
 
 properties:
-    label:
-      required: true
     irq-gpios:
       type: phandle-array
       required: false

--- a/dts/bindings/led_strip/ti,tlc5971.yaml
+++ b/dts/bindings/led_strip/ti,tlc5971.yaml
@@ -17,7 +17,6 @@ description: |
       led_controller: led_controller@0 {
         status = "okay";
         compatible = "ti,tlc59711", "ti,tlc5971";
-        label = "led controller";
         spi-max-frequency = <DT_FREQ_M(1)>;
         reg = <0x0>;
         chain-length = <24>;

--- a/dts/bindings/led_strip/worldsemi,ws2812-gpio.yaml
+++ b/dts/bindings/led_strip/worldsemi,ws2812-gpio.yaml
@@ -14,9 +14,6 @@ compatible: "worldsemi,ws2812-gpio"
 include: [base.yaml, ws2812.yaml]
 
 properties:
-  label:
-    required: true
-
   in-gpios:
     type: phandle-array
     required: true

--- a/dts/bindings/mhu/arm,mhu.yaml
+++ b/dts/bindings/mhu/arm,mhu.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/misc/gd,gd32-syscfg.yaml
+++ b/dts/bindings/misc/gd,gd32-syscfg.yaml
@@ -11,9 +11,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   rcu-periph-clock:
     type: int
     description: Reset Control Unit Peripheral Clock ID

--- a/dts/bindings/mmc/st,stm32-sdmmc.yaml
+++ b/dts/bindings/mmc/st,stm32-sdmmc.yaml
@@ -8,9 +8,6 @@ properties:
     clocks:
         required: true
 
-    label:
-        required: true
-
     reg:
         required: true
 

--- a/dts/bindings/mtd/nordic,qspi-nor.yaml
+++ b/dts/bindings/mtd/nordic,qspi-nor.yaml
@@ -14,9 +14,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   jedec-id:
     required: true
 

--- a/dts/bindings/mtd/soc-nv-flash.yaml
+++ b/dts/bindings/mtd/soc-nv-flash.yaml
@@ -5,9 +5,6 @@ compatible: "soc-nv-flash"
 include: base.yaml
 
 properties:
-    label:
-      required: false
-
     erase-block-size:
      type: int
      description: address alignment required by flash erase operations

--- a/dts/bindings/pcie/endpoint/brcm,iproc-pcie-ep.yaml
+++ b/dts/bindings/pcie/endpoint/brcm,iproc-pcie-ep.yaml
@@ -14,6 +14,3 @@ properties:
         Register space for the memory mapped PAX(PCIe to AXI bridge) registers,
         It includes registers to access EP configuration space
         and to map Host PCIe address to PCIe Outbound memory.
-
-    label:
-      required: true

--- a/dts/bindings/pinctrl/gd,gd32-afio.yaml
+++ b/dts/bindings/pinctrl/gd,gd32-afio.yaml
@@ -13,9 +13,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   rcu-periph-clock:
     type: int
     description: Reset Control Unit Peripheral Clock ID

--- a/dts/bindings/pinctrl/nxp,imx-gpr.yaml
+++ b/dts/bindings/pinctrl/nxp,imx-gpr.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
 pinmux-cells:
   - pin
   - function

--- a/dts/bindings/pinctrl/telink,b91-pinctrl.yaml
+++ b/dts/bindings/pinctrl/telink,b91-pinctrl.yaml
@@ -76,9 +76,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     pad-mul-sel:
       type: int
       required: true

--- a/dts/bindings/pm_cpu_ops/arm,psci-0.2.yaml
+++ b/dts/bindings/pm_cpu_ops/arm,psci-0.2.yaml
@@ -8,9 +8,6 @@ compatible: "arm,psci-0.2"
 include: base.yaml
 
 properties:
-  label:
-    required: true
-
   method:
     type: string
     required: true

--- a/dts/bindings/regulator/regulator-pmic.yaml
+++ b/dts/bindings/regulator/regulator-pmic.yaml
@@ -8,8 +8,6 @@ include: regulator.yaml
 compatible: "regulator-pmic"
 
 properties:
-    label:
-        required: false
     voltage-range:
         type: array
         required: true

--- a/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
+++ b/dts/bindings/riscv/openisa,rv32m1-pcc.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#clock-cells":
       const: 1
 

--- a/dts/bindings/spi/nuvoton,npcx-spi-fiu.yaml
+++ b/dts/bindings/spi/nuvoton,npcx-spi-fiu.yaml
@@ -12,5 +12,3 @@ properties:
         required: true
     clocks:
         required: true
-    label:
-        required: true

--- a/dts/bindings/sram/mmio-sram.yaml
+++ b/dts/bindings/sram/mmio-sram.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: false

--- a/dts/bindings/tcpc/st,stm32-ucpd.yaml
+++ b/dts/bindings/tcpc/st,stm32-ucpd.yaml
@@ -10,9 +10,6 @@ compatible: "st,stm32-ucpd"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/dts/bindings/usb/usb-audio.yaml
+++ b/dts/bindings/usb/usb-audio.yaml
@@ -5,9 +5,3 @@
 
 description: Common fields for USB audio devices
 compatible: "usb-audio"
-
-properties:
-  label:
-    required: true
-    type: string
-    description: Human readable string describing the device (used as device_get_binding() argument)

--- a/dts/bindings/video/nxp,imx-csi.yaml
+++ b/dts/bindings/video/nxp,imx-csi.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     sensor:
       required: true
       type: phandle

--- a/dts/bindings/wifi/espressif,esp-at.yaml
+++ b/dts/bindings/wifi/espressif,esp-at.yaml
@@ -8,9 +8,6 @@ compatible: "espressif,esp-at"
 include: uart-device.yaml
 
 properties:
-    label:
-      required: true
-
     power-gpios:
       type: phandle-array
       required: false

--- a/samples/subsys/usb/audio/headphones_microphone/app.overlay
+++ b/samples/subsys/usb/audio/headphones_microphone/app.overlay
@@ -6,14 +6,12 @@
 
 &zephyr_udc0 {
 	hp_0 {
-		label = "HEADPHONES";
 		compatible = "usb-audio-hp";
 		feature-mute;
 		channel-l;
 		channel-r;
 	};
 	mic_0 {
-		label = "MICROPHONE";
 		compatible = "usb-audio-mic";
 		feature-mute;
 		channel-l;

--- a/samples/subsys/usb/audio/headset/app.overlay
+++ b/samples/subsys/usb/audio/headset/app.overlay
@@ -6,7 +6,6 @@
 
 &zephyr_udc0 {
 	hs_0 {
-		label = "HEADSET";
 		compatible = "usb-audio-hs";
 		mic-feature-mute;
 		mic-channel-l;


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>