### PR TITLE
dts: bindings: arm: device labels are now optional

### DIFF
--- a/dts/bindings/arm/nxp,imx-epit.yaml
+++ b/dts/bindings/arm/nxp,imx-epit.yaml
@@ -14,9 +14,6 @@ properties:
   interrupts:
       required: true
 
-  label:
-      required: true
-
   prescaler:
      type: int
      required: true

--- a/dts/bindings/arm/nxp,imx-mu.yaml
+++ b/dts/bindings/arm/nxp,imx-mu.yaml
@@ -14,9 +14,6 @@ properties:
   interrupts:
       required: true
 
-  label:
-      required: true
-
   rdc:
      type: int
      required: true

--- a/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-ke1xf-sim.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     clkout-source:
       type: int
       required: false

--- a/dts/bindings/arm/nxp,kinetis-mcg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-mcg.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#clock-cells":
       const: 1
 

--- a/dts/bindings/arm/nxp,kinetis-pcc.yaml
+++ b/dts/bindings/arm/nxp,kinetis-pcc.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#clock-cells":
       const: 2
 

--- a/dts/bindings/arm/nxp,kinetis-scg.yaml
+++ b/dts/bindings/arm/nxp,kinetis-scg.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     sosc-mode:
       type: int
       description: system oscillator mode

--- a/dts/bindings/arm/nxp,kinetis-sim.yaml
+++ b/dts/bindings/arm/nxp,kinetis-sim.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     pllfll-select:
       type: int
       required: true


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>