### PR TITLE
dts: bindings: crypto: device labels are now optional

### DIFF
--- a/dts/bindings/crypto/arm,cryptocell-310.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-310.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/crypto/arm,cryptocell-312.yaml
+++ b/dts/bindings/crypto/arm,cryptocell-312.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/crypto/nordic,nrf-cc310.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc310.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/crypto/nordic,nrf-cc312.yaml
+++ b/dts/bindings/crypto/nordic,nrf-cc312.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/crypto/silabs,gecko-semailbox.yaml
+++ b/dts/bindings/crypto/silabs,gecko-semailbox.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true

--- a/dts/bindings/crypto/st,stm32-crypto-common.yaml
+++ b/dts/bindings/crypto/st,stm32-crypto-common.yaml
@@ -7,9 +7,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: true
 


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>