### PR TITLE
dts: bindings: counter: device labels are now optional

### DIFF
--- a/dts/bindings/counter/espressif,esp32-timer.yaml
+++ b/dts/bindings/counter/espressif,esp32-timer.yaml
@@ -23,9 +23,6 @@ description: |
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     group:
       description: |
         The Timer Group index to which a timer belongs.

--- a/dts/bindings/counter/motorola,mc146818.yaml
+++ b/dts/bindings/counter/motorola,mc146818.yaml
@@ -7,7 +7,3 @@ description: Motorola MC146818 compatible Real Timer Clock
 compatible: "motorola,mc146818"
 
 include: base.yaml
-
-properties:
-    label:
-      required: true

--- a/dts/bindings/counter/nxp,imx-qtmr.yaml
+++ b/dts/bindings/counter/nxp,imx-qtmr.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/counter/nxp,imx-tmr.yaml
+++ b/dts/bindings/counter/nxp,imx-tmr.yaml
@@ -9,9 +9,6 @@ compatible: "nxp,imx-tmr"
 include: base.yaml
 
 properties:
-  label:
-    required: true
-
   channel:
     type: int
     required: true

--- a/dts/bindings/counter/st,stm32-counter.yaml
+++ b/dts/bindings/counter/st,stm32-counter.yaml
@@ -6,7 +6,3 @@ description: STM32 counters
 compatible: "st,stm32-counter"
 
 include: base.yaml
-
-properties:
-    label:
-      required: true


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>