### PR TITLE
dts: bindings: clock: device labels are now optional

### DIFF
--- a/dts/bindings/clock/espressif,esp32-rtc.yaml
+++ b/dts/bindings/clock/espressif,esp32-rtc.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     xtal-freq:
       type: int
       required: true

--- a/dts/bindings/clock/fixed-clock.yaml
+++ b/dts/bindings/clock/fixed-clock.yaml
@@ -8,11 +8,6 @@ compatible: "fixed-clock"
 include: clock-controller.yaml
 
 properties:
-    label:
-      type: string
-      required: false
-      description: Human readable string describing the device (used as device_get_binding() argument)
-
     clock-frequency:
       type: int
       description: output clock frequency (Hz)

--- a/dts/bindings/clock/intel,agilex-clock.yaml
+++ b/dts/bindings/clock/intel,agilex-clock.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#clock-cells":
       const: 1
 

--- a/dts/bindings/clock/microchip,xec-pcr.yaml
+++ b/dts/bindings/clock/microchip,xec-pcr.yaml
@@ -14,9 +14,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     core-clock-div:
       type: int
       required: true

--- a/dts/bindings/clock/nordic,nrf-clock.yaml
+++ b/dts/bindings/clock/nordic,nrf-clock.yaml
@@ -8,9 +8,6 @@ compatible: "nordic,nrf-clock"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/dts/bindings/clock/nxp,imx-anatop.yaml
+++ b/dts/bindings/clock/nxp,imx-anatop.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
         required: true
 
-    label:
-        required: true
-
     "#clock-cells":
         type: int
         const: 4

--- a/dts/bindings/clock/nxp,imx-ccm-rev2.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm-rev2.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#clock-cells":
       const: 3
 

--- a/dts/bindings/clock/nxp,imx-ccm.yaml
+++ b/dts/bindings/clock/nxp,imx-ccm.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#clock-cells":
       const: 3
 

--- a/dts/bindings/clock/nxp,lpc-syscon.yaml
+++ b/dts/bindings/clock/nxp,lpc-syscon.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#clock-cells":
       const: 1
 

--- a/dts/bindings/clock/nxp,lpc11u6x-syscon.yaml
+++ b/dts/bindings/clock/nxp,lpc11u6x-syscon.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     pinctrl-0:
       required: true
 


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>