### PR TITLE
dts: bindings: interrupt-controller: device labels are now optional

### DIFF
--- a/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
+++ b/dts/bindings/interrupt-controller/atmel,sam0-eic.yaml
@@ -10,6 +10,3 @@ properties:
 
   interrupts:
     required: true
-
-  label:
-    required: true

--- a/dts/bindings/interrupt-controller/cypress,psoc6-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/cypress,psoc6-intmux-ch.yaml
@@ -15,9 +15,6 @@ properties:
   reg:
       required: true
 
-  label:
-      required: true
-
   interrupts:
       required: true
 

--- a/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
+++ b/dts/bindings/interrupt-controller/cypress,psoc6-intmux.yaml
@@ -74,6 +74,3 @@ include: base.yaml
 properties:
   reg:
       required: true
-
-  label:
-      required: true

--- a/dts/bindings/interrupt-controller/gd,gd32-exti.yaml
+++ b/dts/bindings/interrupt-controller/gd,gd32-exti.yaml
@@ -8,9 +8,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   interrupts:
     required: true
 

--- a/dts/bindings/interrupt-controller/intel,ace-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,ace-intc.yaml
@@ -11,9 +11,6 @@ properties:
   interrupts:
       required: true
 
-  label:
-      required: true
-
   "#interrupt-cells":
       const: 3
 

--- a/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
+++ b/dts/bindings/interrupt-controller/intel,cavs-intc.yaml
@@ -11,9 +11,6 @@ properties:
   interrupts:
       required: true
 
-  label:
-      required: true
-
   "#interrupt-cells":
       const: 3
 

--- a/dts/bindings/interrupt-controller/intel,vt-d.yaml
+++ b/dts/bindings/interrupt-controller/intel,vt-d.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/interrupt-controller/ite,it8xxx2-wuc.yaml
+++ b/dts/bindings/interrupt-controller/ite,it8xxx2-wuc.yaml
@@ -10,9 +10,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   "wakeup-controller":
     type: boolean
     required: true

--- a/dts/bindings/interrupt-controller/microchip,xec-ecia-girq.yaml
+++ b/dts/bindings/interrupt-controller/microchip,xec-ecia-girq.yaml
@@ -11,9 +11,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     girq-id:
        type: int
        required: true

--- a/dts/bindings/interrupt-controller/microchip,xec-ecia.yaml
+++ b/dts/bindings/interrupt-controller/microchip,xec-ecia.yaml
@@ -8,9 +8,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     clocks:
       required: true
 

--- a/dts/bindings/interrupt-controller/nuvoton,npcx-miwu.yaml
+++ b/dts/bindings/interrupt-controller/nuvoton,npcx-miwu.yaml
@@ -8,9 +8,6 @@ compatible: "nuvoton,npcx-miwu"
 include: [base.yaml]
 
 properties:
-    label:
-        required: true
-
     index:
         type: int
         required: true

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux-ch.yaml
@@ -11,9 +11,6 @@ properties:
   reg:
       required: true
 
-  label:
-      required: true
-
   interrupts:
       required: true
 

--- a/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
+++ b/dts/bindings/interrupt-controller/openisa,rv32m1-intmux.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
   reg:
       required: true
-
-  label:
-      required: true


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>