### PR TITLE
dts: bindings: dma: device labels are now optional

### DIFF
--- a/dts/bindings/dma/arm,dma-pl330.yaml
+++ b/dts/bindings/dma/arm,dma-pl330.yaml
@@ -13,7 +13,6 @@ description: |
                   ...
                   dma-channels = <8>;
                   #dma-cells = <1>;
-                  label = "PL330";
             };
 
   If PCIe EP client uses channel 0 for Tx DMA and channel 1 for Rx DMA
@@ -22,7 +21,6 @@ description: |
                   ...
                   dmas = <&pl330 0>, <&pl330 1>;
                   dma-names = "txdma", "rxdma";
-                  label = "PCIE_0";
             };
 compatible: "arm,dma-pl330"
 
@@ -35,8 +33,6 @@ properties:
       type: array
       required: true
       description: microcode's physical memory address
-    label:
-      required: true
     "#dma-cells":
       const: 1
 

--- a/dts/bindings/dma/brcm,iproc-pax-dma-v1.yaml
+++ b/dts/bindings/dma/brcm,iproc-pax-dma-v1.yaml
@@ -14,8 +14,6 @@ properties:
         It includes data mover engine(dme), ring manager, ring manager common
         registers.
       required: true
-    label:
-      required: true
     bd-memory:
       type: array
       description: Uncached memory address to populate dma buffer descriptors

--- a/dts/bindings/dma/brcm,iproc-pax-dma-v2.yaml
+++ b/dts/bindings/dma/brcm,iproc-pax-dma-v2.yaml
@@ -14,8 +14,6 @@ properties:
         It includes data mover engine(dme), ring manager, ring manager common
         registers.
       required: true
-    label:
-      required: true
     bd-memory:
       type: array
       description: Uncached memory address to populate dma buffer descriptors

--- a/dts/bindings/dma/st,stm32-dma-v1.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v1.yaml
@@ -59,7 +59,6 @@ description: |
          st,mem2mem;
          dma-requests = <7>;
          status = "disabled";
-         label = "DMA_2";
         };
 
   For the client part, example for stm32f411 on DMA2 instance

--- a/dts/bindings/dma/st,stm32-dma-v2.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2.yaml
@@ -52,7 +52,6 @@ description: |
          ...
          dma-requests = <7>;
          status = "disabled";
-         label = "DMA_2";
         };
 
   For the client part, example for stm32l476 on DMA1 instance

--- a/dts/bindings/dma/st,stm32-dma-v2bis.yaml
+++ b/dts/bindings/dma/st,stm32-dma-v2bis.yaml
@@ -46,7 +46,6 @@ description: |
          ...
          dma-requests = <7>;
          status = "disabled";
-         label = "DMA_1";
         };
 
   For the client part, example for stm32f103 on DMA1 instance

--- a/dts/bindings/dma/st,stm32-dmamux.yaml
+++ b/dts/bindings/dma/st,stm32-dmamux.yaml
@@ -49,7 +49,6 @@ description: |
          dma-generators = <4>;
          dma-requests= <36>;
          status = "disabled";
-         label = "DMAMUX_1";
         };
     for client SPI of stm32wb55x
      spi1: spi@40013000 {


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>