### PR TITLE
dts: bindings: sensor: device labels are now optional

### DIFF
--- a/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
+++ b/dts/bindings/sensor/atmel,sam-tc-qdec.yaml
@@ -15,9 +15,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     peripheral-id:
       type: array
       description: peripheral ID

--- a/dts/bindings/sensor/honeywell,sm351lt.yaml
+++ b/dts/bindings/sensor/honeywell,sm351lt.yaml
@@ -12,7 +12,3 @@ properties:
       type: phandle-array
       required: true
       description: GPIO connected to the sensor
-   label:
-      required: true
-      type: string
-      description: Driver label

--- a/dts/bindings/sensor/ite,it8xxx2-vcmp.yaml
+++ b/dts/bindings/sensor/ite,it8xxx2-vcmp.yaml
@@ -11,9 +11,6 @@ properties:
   reg:
     required: true
 
-  label:
-    required: true
-
   interrupts:
     required: true
 

--- a/dts/bindings/sensor/nordic,nrf-qdec.yaml
+++ b/dts/bindings/sensor/nordic,nrf-qdec.yaml
@@ -72,6 +72,3 @@ properties:
       type: int
       description: Number of steps on the rotating wheel
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/sensor/nordic,nrf-temp.yaml
+++ b/dts/bindings/sensor/nordic,nrf-temp.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/sensor/nxp,kinetis-acmp.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-acmp.yaml
@@ -11,9 +11,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     reg:
       required: true
 

--- a/dts/bindings/sensor/nxp,kinetis-temperature.yaml
+++ b/dts/bindings/sensor/nxp,kinetis-temperature.yaml
@@ -8,9 +8,6 @@ compatible: "nxp,kinetis-temperature"
 include: base.yaml
 
 properties:
-    label:
-      required: true
-
     io-channels:
       required: true
       description: ADC channels for temperature sensor and bandgap voltage

--- a/dts/bindings/sensor/st,stm32-temp-common.yaml
+++ b/dts/bindings/sensor/st,stm32-temp-common.yaml
@@ -2,9 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 properties:
-    label:
-      required: true
-
     io-channels:
       required: true
       description: ADC channel for temperature sensor


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>