### PR TITLE
dts: bindings: memory-controllers: device labels are now optional

### DIFF
--- a/dts/bindings/memory-controllers/ite,it8xxx2-bbram.yaml
+++ b/dts/bindings/memory-controllers/ite,it8xxx2-bbram.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
         required: true
-
-    label:
-        required: true

--- a/dts/bindings/memory-controllers/nuvoton,npcx-bbram.yaml
+++ b/dts/bindings/memory-controllers/nuvoton,npcx-bbram.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
         required: true
-
-    label:
-        required: true

--- a/dts/bindings/memory-controllers/nxp,imx-semc.yaml
+++ b/dts/bindings/memory-controllers/nxp,imx-semc.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/memory-controllers/st,stm32-backup-sram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-backup-sram.yaml
@@ -12,9 +12,6 @@ compatible: "st,stm32-backup-sram"
 include: base.yaml
 
 properties:
-  label:
-    required: true
-
   reg:
     required: true
 

--- a/dts/bindings/memory-controllers/st,stm32-fmc-nor-psram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc-nor-psram.yaml
@@ -40,7 +40,6 @@ description: |
     sram {
       status = "okay";
       compatible = "st,stm32-fmc-nor-psram";
-      label = "STM32_FMC_NOR_PSRAM";
 
       #address-cells = <1>;
       #size-cells = <0>;
@@ -73,9 +72,6 @@ compatible: "st,stm32-fmc-nor-psram"
 include: base.yaml
 
 properties:
-  label:
-    required: true
-
   "#address-cells":
     required: true
     const: 1

--- a/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc-sdram.yaml
@@ -78,9 +78,6 @@ compatible: "st,stm32-fmc-sdram"
 include: base.yaml
 
 properties:
-  label:
-    required: true
-
   "#address-cells":
     required: true
     const: 1

--- a/dts/bindings/memory-controllers/st,stm32-fmc.yaml
+++ b/dts/bindings/memory-controllers/st,stm32-fmc.yaml
@@ -35,9 +35,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     clocks:
       required: true
 

--- a/dts/bindings/memory-controllers/zephyr,bbram-emul.yaml
+++ b/dts/bindings/memory-controllers/zephyr,bbram-emul.yaml
@@ -12,6 +12,3 @@ properties:
         type: int
         required: true
         description: Size of the BBRAM region in bytes.
-
-    label:
-        required: true


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>