### PR TITLE
dts: bindings: pwm: device labels are now optional

### DIFF
--- a/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
+++ b/dts/bindings/pwm/atmel,sam0-tcc-pwm.yaml
@@ -23,9 +23,6 @@ properties:
   clock-names:
     required: true
 
-  label:
-    required: true
-
   channels:
     type: int
     required: true

--- a/dts/bindings/pwm/espressif,esp32-ledc.yaml
+++ b/dts/bindings/pwm/espressif,esp32-ledc.yaml
@@ -77,9 +77,6 @@ compatible: "espressif,esp32-ledc"
 include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
 
 properties:
-  label:
-    required: true
-
   "#pwm-cells":
     const: 3
 

--- a/dts/bindings/pwm/espressif,esp32-mcpwm.yaml
+++ b/dts/bindings/pwm/espressif,esp32-mcpwm.yaml
@@ -81,9 +81,6 @@ compatible: "espressif,esp32-mcpwm"
 include: [pwm-controller.yaml, pinctrl-device.yaml, base.yaml]
 
 properties:
-  label:
-    required: true
-
   prescale:
     type: int
     required: true

--- a/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwm.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: false
 

--- a/dts/bindings/pwm/ite,it8xxx2-pwmprs.yaml
+++ b/dts/bindings/pwm/ite,it8xxx2-pwmprs.yaml
@@ -11,8 +11,5 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     interrupts:
       required: false

--- a/dts/bindings/pwm/microchip,xec-pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     pcrs:
       type: array
       required: true

--- a/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
+++ b/dts/bindings/pwm/nuvoton,npcx-pwm.yaml
@@ -12,8 +12,6 @@ properties:
         required: true
     clocks:
         required: true
-    label:
-        required: true
     pinctrl-0:
         required: true
     pinctrl-names:

--- a/dts/bindings/pwm/nxp,imx-pwm.yaml
+++ b/dts/bindings/pwm/nxp,imx-pwm.yaml
@@ -16,9 +16,6 @@ properties:
     interrupts:
       required: true
 
-    label:
-      required: true
-
     "#pwm-cells":
       const: 2
 

--- a/dts/bindings/pwm/st,stm32-pwm.yaml
+++ b/dts/bindings/pwm/st,stm32-pwm.yaml
@@ -5,9 +5,6 @@ compatible: "st,stm32-pwm"
 include: [pwm-controller.yaml, base.yaml, pinctrl-device.yaml]
 
 properties:
-    label:
-      required: true
-
     pinctrl-0:
       required: true
 


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>