### PR TITLE
dts: bindings: modem: device labels are now optional

### DIFF
--- a/dts/bindings/modem/quectel,bg9x.yaml
+++ b/dts/bindings/modem/quectel,bg9x.yaml
@@ -8,9 +8,6 @@ compatible: "quectel,bg9x"
 include: uart-device.yaml
 
 properties:
-    label:
-      required: true
-
     mdm-power-gpios:
       type: phandle-array
       required: true

--- a/dts/bindings/modem/simcom,sim7080.yaml
+++ b/dts/bindings/modem/simcom,sim7080.yaml
@@ -8,9 +8,6 @@ compatible: "simcom,sim7080"
 include: uart-device.yaml
 
 properties:
-  label:
-    required: true
-
   mdm-power-gpios:
     type: phandle-array
     required: true

--- a/dts/bindings/modem/swir,hl7800.yaml
+++ b/dts/bindings/modem/swir,hl7800.yaml
@@ -11,9 +11,6 @@ compatible: "swir,hl7800"
 include: uart-device.yaml
 
 properties:
-    label:
-      required: true
-
     mdm-wake-gpios:
         type: phandle-array
         required: true

--- a/dts/bindings/modem/u-blox,sara-r4.yaml
+++ b/dts/bindings/modem/u-blox,sara-r4.yaml
@@ -8,9 +8,6 @@ compatible: "u-blox,sara-r4"
 include: uart-device.yaml
 
 properties:
-    label:
-      required: true
-
     mdm-power-gpios:
       type: phandle-array
       required: true

--- a/dts/bindings/modem/wnc,m14a2a.yaml
+++ b/dts/bindings/modem/wnc,m14a2a.yaml
@@ -8,9 +8,6 @@ compatible: "wnc,m14a2a"
 include: uart-device.yaml
 
 properties:
-    label:
-      required: true
-
     mdm-boot-mode-sel-gpios:
       type: phandle-array
       required: true


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>