### PR TITLE
dts: bindings: rng: device labels are now optional

### DIFF
--- a/dts/bindings/rng/atmel,sam-trng.yaml
+++ b/dts/bindings/rng/atmel,sam-trng.yaml
@@ -18,6 +18,3 @@ properties:
       type: int
       description: peripheral ID
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/rng/espressif,esp32-trng.yaml
+++ b/dts/bindings/rng/espressif,esp32-trng.yaml
@@ -17,6 +17,3 @@ properties:
 
     interrupts:
       required: false
-
-    label:
-      required: true

--- a/dts/bindings/rng/nxp,kinetis-rnga.yaml
+++ b/dts/bindings/rng/nxp,kinetis-rnga.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/rng/nxp,kinetis-trng.yaml
+++ b/dts/bindings/rng/nxp,kinetis-trng.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/rng/nxp,lpc-rng.yaml
+++ b/dts/bindings/rng/nxp,lpc-rng.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: false
-
-    label:
-      required: true

--- a/dts/bindings/rng/openisa,rv32m1-trng.yaml
+++ b/dts/bindings/rng/openisa,rv32m1-trng.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/rng/silabs,gecko-trng.yaml
+++ b/dts/bindings/rng/silabs,gecko-trng.yaml
@@ -16,6 +16,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/rng/st,stm32-rng.yaml
+++ b/dts/bindings/rng/st,stm32-rng.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     clocks:
       required: true
 

--- a/dts/bindings/rng/telink,b91-trng.yaml
+++ b/dts/bindings/rng/telink,b91-trng.yaml
@@ -10,6 +10,3 @@ include: base.yaml
 properties:
     reg:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
+++ b/dts/bindings/rng/ti,cc13xx-cc26xx-trng.yaml
@@ -13,6 +13,3 @@ properties:
 
     interrupts:
       required: true
-
-    label:
-      required: true

--- a/dts/bindings/rng/zephyr,native-posix-rng.yaml
+++ b/dts/bindings/rng/zephyr,native-posix-rng.yaml
@@ -6,7 +6,3 @@ description: Native POSIX RNG/Entropy
 compatible: "zephyr,native-posix-rng"
 
 include: base.yaml
-
-properties:
-    label:
-      required: true


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>