### PR TITLE
dts: bindings: {gpio,pwm}-leds: device labels are now optional

### DIFF
--- a/dts/bindings/gpio/gpio-leds.yaml
+++ b/dts/bindings/gpio/gpio-leds.yaml
@@ -34,18 +34,6 @@ description: |
 
 compatible: "gpio-leds"
 
-include:
-    - name: base.yaml
-      property-allowlist: [label]
-
-properties:
-    label:
-      description: |
-        Human readable string describing the device and used to set the device
-        name. It can be passed as argument to device_get_binding() to retrieve
-        the device. If this property is omitted, then the device name is set
-        from the node full name.
-
 child-binding:
     description: GPIO LED child node
     properties:

--- a/dts/bindings/led/pwm-leds.yaml
+++ b/dts/bindings/led/pwm-leds.yaml
@@ -5,10 +5,6 @@ description: PWM LEDs parent node
 
 compatible: "pwm-leds"
 
-include:
-    - name: base.yaml
-      property-allowlist: [label]
-
 child-binding:
     description: PWM LED child node
     properties:


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>