### PR TITLE
cleanup: use DT_LABEL macro

### DIFF
--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -258,7 +258,7 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 	DT_HAS_FIXED_PARTITION_LABEL(label)
 
 #define FLASH_AREA_LABEL_STR(lbl) \
-	DT_PROP(DT_NODE_BY_FIXED_PARTITION_LABEL(lbl), label)
+	DT_LABEL(DT_NODE_BY_FIXED_PARTITION_LABEL(lbl))
 
 #define FLASH_AREA_ID(label) \
 	DT_FIXED_PARTITION_ID(DT_NODE_BY_FIXED_PARTITION_LABEL(label))

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -63,13 +63,13 @@ static bool init_buttons(void)
 	} btn_spec[] = {
 		{
 			GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios),
-			DT_PROP(DT_ALIAS(sw0), label),
+			DT_LABEL(DT_ALIAS(sw0)),
 			"trigger a transfer",
 			sw0_handler
 		},
 		{
 			GPIO_DT_SPEC_GET(DT_ALIAS(sw1), gpios),
-			DT_PROP(DT_ALIAS(sw1), label),
+			DT_LABEL(DT_ALIAS(sw1)),
 			"switch the type of peripheral",
 			sw1_handler
 		},


### PR DESCRIPTION
Cleanup a few cases that should use the DT_LABEL macro (usage is around label property for flash partitions and leds)