### PR TITLE
samples: smp_svr requires CONFIG_MULTITHREADING=y

### DIFF
--- a/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/prj.conf
@@ -8,6 +8,9 @@ CONFIG_MAIN_STACK_SIZE=2048
 # Ensure an MCUboot-compatible binary is generated.
 CONFIG_BOOTLOADER_MCUBOOT=y
 
+# Ensure multithreading is enabled
+CONFIG_MULTITHREADING=y
+
 # Enable flash operations.
 CONFIG_FLASH=y
 


### PR DESCRIPTION
Add an explicit `CONFIG_MULTITHREADING=y` to `prj.conf`
of this sample to make the setting dependency explicit.

Verified by running
`./zephyr/scripts/twister --inline-logs -v -N -M \
  --integration --overflow-as-errors --retry-failed 2 \
  -T zephyr/samples/subsys/mgmt/mcumgr/smp_svr` on:

1. Original condition. Verified all tests passed
   and generated `.config` files already indicated
   `CONFIG_MULTITHREADING=y`.

2. Amended prj.conf with `CONFIG_MULTITHREADING=n`.
   Verified the resulting build failures were consistent
   with a single-threaded environment (no k_sleep() definition).

3. Amended prj.conf with `CONFIG_MULTITHREADING=y`.
   Verified all tests passed and generated `.config`
   files indicated `CONFIG_MULTITHREADING=y`.

4. Amended prj.conf with `CONFIG_MULTITHREADING=y` and local
   mcuboot module with the proposed zephyr port reorganization.
   Verified all tests passed.

Fix #47895

Signed-off-by: Gregory SHUE <gregory.shue@legrand.com>