### PR TITLE
soc: xtensa: include linker/section.h to fix the build error

### DIFF
--- a/soc/xtensa/intel_adsp/common/include/soc.h
+++ b/soc/xtensa/intel_adsp/common/include/soc.h
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <errno.h>
 #include <zephyr/arch/xtensa/cache.h>
+#include <zephyr/linker/sections.h>
 
 /* macros related to interrupt handling */
 #define XTENSA_IRQ_NUM_SHIFT			0


### PR DESCRIPTION
Some tests was built failed due to cannot find the __imr macro:
Try to fix it by including the linker/section.h in soc.h.

Fixes #47830.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>