### PR TITLE
Scripts: ci: testplan: check exists _test_plan_partial file before open

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 NXP
 # Copyright (c) 2021 Intel Corporation
 
 # A script to generate twister options based on modified files.
@@ -110,11 +111,11 @@ class Filters:
 
         logging.info(" ".join(cmd))
         _ = subprocess.call(cmd)
-        with open(fname, newline='') as jsonfile:
-            json_data = json.load(jsonfile)
-            suites = json_data.get("testsuites", [])
-            self.all_tests.extend(suites)
         if os.path.exists(fname):
+            with open(fname, newline='') as jsonfile:
+                json_data = json.load(jsonfile)
+                suites = json_data.get("testsuites", [])
+                self.all_tests.extend(suites)
             os.remove(fname)
 
     def find_archs(self):

--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -26,3 +26,6 @@ grpcio-tools
 
 # used by scripts/release/bug_bash.py for generating top ten bug squashers
 PyGithub
+
+# used by scripts/ci/test_plan
+GitPython


### PR DESCRIPTION
Incase _test_plan_partial.json is not generated, be error if not check exists this file. Need check file before open.
Missing module gitpython when run manually test_plan. Add module gitpython in requirements for test plan scripts.