### PR TITLE
dts: bindings: test: device labels are now optional

### DIFF
--- a/dts/bindings/test/vnd,adc-temp-sensor.yaml
+++ b/dts/bindings/test/vnd,adc-temp-sensor.yaml
@@ -8,9 +8,6 @@ compatible: "vnd,adc-temp-sensor"
 include: [base.yaml, reset-device.yaml]
 
 properties:
-    label:
-      required: true
-
     io-channels:
       required: true
       description: ADC conversion channels

--- a/dts/bindings/test/vnd,gpio-device.yaml
+++ b/dts/bindings/test/vnd,gpio-device.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/test/vnd,gpio-expander-common.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-common.yaml
@@ -9,9 +9,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/test/vnd,gpio-one-cell.yaml
+++ b/dts/bindings/test/vnd,gpio-one-cell.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 1
 

--- a/dts/bindings/test/vnd,gpio.yaml
+++ b/dts/bindings/test/vnd,gpio.yaml
@@ -11,9 +11,6 @@ properties:
     reg:
       required: true
 
-    label:
-      required: true
-
     "#gpio-cells":
       const: 2
 

--- a/dts/bindings/test/vnd,mbox-zero-cell.yaml
+++ b/dts/bindings/test/vnd,mbox-zero-cell.yaml
@@ -4,8 +4,3 @@
 description: VND MBOX controller (0 cell)
 
 compatible: "vnd,mbox-zero-cell"
-
-properties:
-  label:
-    type: string
-    required: true

--- a/dts/bindings/test/vnd,mbox.yaml
+++ b/dts/bindings/test/vnd,mbox.yaml
@@ -7,10 +7,5 @@ compatible: "vnd,mbox"
 
 include: mailbox-controller.yaml
 
-properties:
-  label:
-    type: string
-    required: true
-
 mbox-cells:
   - channel

--- a/tests/lib/devicetree/api/app.overlay
+++ b/tests/lib/devicetree/api/app.overlay
@@ -231,7 +231,6 @@
 		};
 
 		test_mbox: mbox {
-			label = "TEST_MBOX";
 			compatible = "vnd,mbox";
 			#mbox-cells = <1>;
 			status = "okay";


### PR DESCRIPTION
All in tree device drivers use some form of DEVICE_DT_GET
so we no longer need to require label properties.

Signed-off-by: Kumar Gala <galak@kernel.org>