### PR TITLE
doc: commit description line length limit per line added.

### DIFF
--- a/doc/contribute/guidelines.rst
+++ b/doc/contribute/guidelines.rst
@@ -655,7 +655,7 @@ Changes are submitted as Git commits. Each commit message must contain:
   previous patches of this file.)
 
 * A change description with your logic or reasoning for the changes, followed
-  by a blank line.
+  by a blank line. (Every single line has to be less than 75 characters.)
 
 * A Signed-off-by line, ``Signed-off-by: <name> <email>`` typically added
   automatically by using ``git commit -s``


### PR DESCRIPTION
https://docs.zephyrproject.org/latest/contribute/guidelines.html#commit-guidelines 

There wasn't any description for line length limit per line. Description added.

