### PR TITLE
drivers: adc: stm32: fix int paths setup

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1074,13 +1074,6 @@ static int adc_stm32_init(const struct device *dev)
 	if (LL_ADC_IsActiveFlag_ADRDY(adc)) {
 		LL_ADC_ClearFlag_ADRDY(adc);
 	}
-
-	/*
-	 * These STM32 series has one internal voltage reference source
-	 * to be enabled.
-	 */
-	LL_ADC_SetCommonPathInternalCh(__LL_ADC_COMMON_INSTANCE(adc),
-				       LL_ADC_PATH_INTERNAL_VREFINT);
 #endif
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -537,14 +537,14 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC1) == channel_id)
 		    && (config->base == ADC1)) {
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
-			k_sleep(K_USEC(LL_ADC_DELAY_TEMPSENSOR_STAB_US));
+			k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
 		}
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc5), okay)
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC5) == channel_id)
 		   && (config->base == ADC5)) {
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
-			k_sleep(K_USEC(LL_ADC_DELAY_TEMPSENSOR_STAB_US));
+			k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
 		}
 #endif
 	}
@@ -553,7 +553,7 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR) == channel_id) {
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 #ifdef LL_ADC_DELAY_TEMPSENSOR_STAB_US
-		k_sleep(K_USEC(LL_ADC_DELAY_TEMPSENSOR_STAB_US));
+		k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
 #endif
 	}
 #endif /* CONFIG_SOC_SERIES_STM32G4X */
@@ -562,7 +562,7 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_VREFINT) == channel_id) {
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_VREFINT);
 #ifdef LL_ADC_DELAY_VREFINT_STAB_US
-		k_sleep(K_USEC(LL_ADC_DELAY_VREFINT_STAB_US));
+		k_usleep(LL_ADC_DELAY_VREFINT_STAB_US);
 #endif
 	}
 #if defined(LL_ADC_CHANNEL_VBAT)

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -531,11 +531,14 @@ static void adc_stm32_set_common_path(const struct device *dev, uint32_t PathInt
 static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_id)
 {
 	const struct adc_stm32_cfg *config = dev->config;
+	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
+
 #ifdef CONFIG_SOC_SERIES_STM32G4X
 	if (config->has_temp_channel) {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc1), okay)
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC1) == channel_id)
 		    && (config->base == ADC1)) {
+			adc_stm32_disable(adc);
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 			k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
 		}
@@ -543,6 +546,7 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(adc5), okay)
 		if ((__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR_ADC5) == channel_id)
 		   && (config->base == ADC5)) {
+			adc_stm32_disable(adc);
 			adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 			k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
 		}
@@ -551,6 +555,7 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 #else
 	if (config->has_temp_channel &&
 		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_TEMPSENSOR) == channel_id) {
+		adc_stm32_disable(adc);
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_TEMPSENSOR);
 #ifdef LL_ADC_DELAY_TEMPSENSOR_STAB_US
 		k_usleep(LL_ADC_DELAY_TEMPSENSOR_STAB_US);
@@ -560,6 +565,7 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 
 	if (config->has_vref_channel &&
 		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_VREFINT) == channel_id) {
+		adc_stm32_disable(adc);
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_VREFINT);
 #ifdef LL_ADC_DELAY_VREFINT_STAB_US
 		k_usleep(LL_ADC_DELAY_VREFINT_STAB_US);
@@ -569,6 +575,7 @@ static void adc_stm32_setup_channels(const struct device *dev, uint8_t channel_i
 	/* Enable the bridge divider only when needed for ADC conversion. */
 	if (config->has_vbat_channel &&
 		__LL_ADC_CHANNEL_TO_DECIMAL_NB(LL_ADC_CHANNEL_VBAT) == channel_id) {
+		adc_stm32_disable(adc);
 		adc_stm32_set_common_path(dev, LL_ADC_PATH_INTERNAL_VBAT);
 	}
 


### PR DESCRIPTION
1. Only setup the internal path right before the adc sampling
   1.  If VBAT internal path is setup from `adc_stm32_channel_setup` but never read, then it will be draining current for no reason
   2. To prepare for #47691 which will teardown the internal path after sampling
3. Remove setting up internal path during driver init. The internal path will be setup before sampling if necessary

pending #47758