### PR TITLE
samples: drivers: espi: Convert to use DT_NODELABEL

### DIFF
--- a/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
+++ b/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
@@ -5,7 +5,7 @@
  */
 
 / {
-	resources {
+	board_power: resources {
 		compatible = "microchip,mec15xx-board-power";
 		/* MCHP_GPIO_012 */
 		pwrg-gpios = <&gpio_000_036 10 GPIO_ACTIVE_HIGH>;

--- a/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
+++ b/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
@@ -5,7 +5,7 @@
  */
 
 / {
-	resources {
+	board_power: resources {
 		compatible = "microchip,mec15xx-board-power";
 		/* MCHP_GPIO_012 */
 		pwrg-gpios = <&gpio_000_036 10 GPIO_ACTIVE_HIGH>;

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -39,7 +39,7 @@ LOG_MODULE_DECLARE(espi, CONFIG_ESPI_LOG_LEVEL);
 #define PWR_SEQ_TIMEOUT    3000u
 
 /* The devicetree node identifier for the board power rails pins. */
-#define BRD_PWR_NODE DT_INST(0, microchip_mec15xx_board_power)
+#define BRD_PWR_NODE DT_NODELABEL(board_power)
 
 #if DT_NODE_HAS_STATUS(BRD_PWR_NODE, okay)
 static const struct gpio_dt_spec pwrgd_gpio = GPIO_DT_SPEC_GET(BRD_PWR_NODE, pwrg_gpios);
@@ -65,7 +65,7 @@ static uint8_t flash_read_buf[MAX_TEST_BUF_SIZE];
 #define ESPI_SAF_NODE     DT_NODELABEL(espi_saf0)
 #define SPI_NODE          DT_NODELABEL(spi0)
 
-#define SAF_BASE_ADDR     DT_REG_ADDR(DT_INST(0, microchip_xec_espi_saf))
+#define SAF_BASE_ADDR     DT_REG_ADDR(ESPI_SAF_NODE)
 
 #define SAF_TEST_FREQ_HZ 24000000U
 #define SAF_TEST_BUF_SIZE 4096U


### PR DESCRIPTION
Convert to use DT_NODELABEL to remove usage of DT_INST in sample.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>