### PR TITLE
samples: drivers: watchdog: Update sample to use alias

### DIFF
--- a/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
+++ b/boards/arm/96b_carbon_nrf51/96b_carbon_nrf51.dts
@@ -19,6 +19,10 @@
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &gpiote {

--- a/boards/arm/96b_nitrogen/96b_nitrogen.dts
+++ b/boards/arm/96b_nitrogen/96b_nitrogen.dts
@@ -29,6 +29,7 @@
 		led1 = &led1;
 		bt = &led1;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -76,6 +76,7 @@
 		bootloader-led0 = &green_pwm_led;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &green_pwm_led;
+		watchdog0 = &wdt0;
 	};
 
 	vbatt {

--- a/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
+++ b/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
@@ -76,6 +76,7 @@
 		bootloader-led0 = &green_pwm_led;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &green_pwm_led;
+		watchdog0 = &wdt0;
 	};
 
 	sim_select: sim-select {

--- a/boards/arm/actinius_icarus_som/actinius_icarus_som_common.dts
+++ b/boards/arm/actinius_icarus_som/actinius_icarus_som_common.dts
@@ -15,6 +15,10 @@
 		zephyr,uart-mcumgr = &uart0;
 	};
 
+	aliases {
+		watchdog0 = &wdt0;
+	};
+
 	sim_select: sim-select {
 		compatible = "sim-select";
 		sim-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -49,6 +49,7 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/arduino_due/arduino_due.dts
+++ b/boards/arm/arduino_due/arduino_due.dts
@@ -14,6 +14,7 @@
 		i2c-0 = &twi0;
 		i2c-1 = &twi1;
 		led0 = &yellow_led;
+		watchdog0 = &wdt;
 	};
 
 	chosen {

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
@@ -103,6 +103,7 @@
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
 		spi = &spi2;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
+++ b/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
@@ -34,6 +34,7 @@
 
 	aliases {
 		sw0 = &user_button;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
+++ b/boards/arm/b_g474e_dpow1/b_g474e_dpow1.dts
@@ -73,6 +73,7 @@
 		sw2 = &joystick_down;
 		sw3 = &joystick_right;
 		sw4 = &joystick_up;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -43,6 +43,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -49,6 +49,10 @@
 			min-residency-us = <900>;
 		};
 	};
+
+	aliases {
+		watchdog0 = &iwdg;
+	};
 };
 
 &clk_lse {

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -17,6 +17,7 @@
 		sw0 = &buttonA;
 		sw1 = &buttonB;
 		magn0 = &lsm303agr_magn;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -17,6 +17,7 @@
 		sw0 = &buttonA;
 		sw1 = &buttonB;
 		magn0 = &lsm303agr_magn;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -87,6 +87,7 @@
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
 		sdhc0 = &sdhc0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpunet.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpunet.dts
@@ -22,6 +22,10 @@
 		zephyr,flash = &flash1;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &gpiote {

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -55,6 +55,7 @@
 		sw1 = &button2;
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -75,6 +75,7 @@
 		sw3 = &button4;
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -75,6 +75,7 @@
 		sw3 = &button4;
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
+++ b/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
@@ -45,6 +45,7 @@
 		sw0 = &button1;
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/bl654_usb/bl654_usb.dts
+++ b/boards/arm/bl654_usb/bl654_usb.dts
@@ -42,6 +42,7 @@
 	aliases {
 		led0 = &led1;
 		led1pwm = &led1bluepwm;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
@@ -40,6 +40,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		pwm-buzzer = &pwm0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -83,6 +83,7 @@
 		sw0 = &button0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led1a;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -195,6 +195,7 @@
 		sw2 = &mag1;
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -18,6 +18,7 @@
 		/* sw0/1 alias defined for compatibility with samples */
 		sw0 = &sw2;
 		sw1 = &sw3;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -71,3 +71,7 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
+
+&wdt0 {
+	status = "okay";
+};

--- a/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
+++ b/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
@@ -75,3 +75,7 @@
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
 };
+
+&wdt0 {
+	status = "okay";
+};

--- a/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
+++ b/boards/arm/cc3235sf_launchxl/cc3235sf_launchxl.dts
@@ -22,6 +22,7 @@
 		/* sw0/1 alias defined for compatibility with samples */
 		sw0 = &sw2;
 		sw1 = &sw3;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -47,6 +47,7 @@
 		sw0 = &button0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &blue_led;
+		watchdog0 = &wdt0;
 	};
 
 	/* Used for accessing other pins */

--- a/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
+++ b/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
@@ -19,6 +19,10 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &gpiote {

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -71,6 +71,7 @@
 		led2-red   = &led2_red;
 		led3-blue  = &led3_blue;
 		pwm-led0   = &pwm_led0_red;
+		watchdog0 = &wdt0;
 	};
 
 };

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -81,6 +81,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		sw2 = &button2;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -47,6 +47,7 @@
 		led1 = &green_led_1;
 		sw0 = &user_button;
 		eswifi0 = &wifi0;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/ebyte_e73_tbb_nrf52832/ebyte_e73_tbb_nrf52832.dts
+++ b/boards/arm/ebyte_e73_tbb_nrf52832/ebyte_e73_tbb_nrf52832.dts
@@ -64,6 +64,7 @@
 		sw0 = &button0;
 		sw1 = &button1;
 		bootloader-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a_common.dtsi
+++ b/boards/arm/efm32pg_stk3401a/efm32pg_stk3401a_common.dtsi
@@ -12,7 +12,6 @@
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		watchdog0 = &wdog0;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -21,6 +20,7 @@
 		led1 = &led1;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdog0;
 	};
 
 	leds {

--- a/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
+++ b/boards/arm/efm32pg_stk3402a/efm32pg_stk3402a_common.dtsi
@@ -13,8 +13,6 @@
 		zephyr,shell-uart = &usart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
-		watchdog0 = &wdog0;
-		watchdog1 = &wdog1;
 	};
 
 	/* These aliases are provided for compatibility with samples */
@@ -24,6 +22,8 @@
 		pwm-led0 = &pwm_led0;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdog0;
+		watchdog1 = &wdog1;
 	};
 
 	leds {

--- a/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
+++ b/boards/arm/holyiot_yj16019/holyiot_yj16019.dts
@@ -38,6 +38,7 @@
 	aliases {
 		sw0 = &button0;
 		led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -47,6 +47,7 @@
 		sw0 = &boot_button;
 		sw1 = &user_button;
 		lora0 = &lora;
+		watchdog0 = &iwdg;
 	};
 
 	pwr_3v3: pwr-3v3-ctrl {

--- a/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
+++ b/boards/arm/lpcxpresso55s28/lpcxpresso55s28.dts
@@ -17,6 +17,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		watchdog0 = &wwdt0;
 	};
 
 	chosen {

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -22,6 +22,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		watchdog0 = &wwdt0;
 		/* For pwm test suites */
 		pwm-0 = &sc_timer;
 		pwm-led0 = &red_pwm_led;

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_ns.dts
@@ -21,6 +21,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		watchdog0 = &wwdt0;
 	};
 
 	chosen {

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -26,6 +26,7 @@
 		i2c0 = &i2c_smb_0;
 		i2c1 = &i2c_smb_1;
 		kscan0 = &kscan0;
+		watchdog0 = &wdog;
 	};
 
 	power-states {

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -29,6 +29,7 @@
 		i2c1 = &i2c_smb_1;
 		i2c7 = &i2c_smb_2;
 		kscan0 = &kscan0;
+		watchdog0 = &wdog;
 	};
 
 	leds {

--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -27,6 +27,7 @@
 		i2c1 = &i2c_smb_1;
 		i2c7 = &i2c_smb_2;
 		pwm-0 = &pwm0;
+		watchdog0 = &wdog;
 	};
 
 	leds {

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -30,6 +30,10 @@
 		device_type = "memory";
 		reg = <0x80000000 DT_SIZE_M(64)>;
 	};
+
+	aliases {
+		watchdog0 = &wdog1;
+	};
 };
 
 &lpuart1 {

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -15,6 +15,7 @@
 
 	aliases {
 		mipi-dsi = &mipi_dsi;
+		watchdog0 = &wdog1;
 	};
 
 	chosen {

--- a/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
+++ b/boards/arm/npcx7m6fb_evb/npcx7m6fb_evb.dts
@@ -25,6 +25,7 @@
 		pwm-0 = &pwm6;
 		/* For i2c test suites */
 		i2c-0 = &i2c0_0;
+		watchdog0 = &twd0;
 	};
 
 	pwmleds {

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -135,6 +135,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf51_ble400/nrf51_ble400.dts
+++ b/boards/arm/nrf51_ble400/nrf51_ble400.dts
@@ -30,6 +30,7 @@
 		led4 = &led4;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/nrf51_blenano/nrf51_blenano.dts
+++ b/boards/arm/nrf51_blenano/nrf51_blenano.dts
@@ -23,6 +23,7 @@
 
 	aliases {
 		led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
+++ b/boards/arm/nrf51_vbluno51/nrf51_vbluno51.dts
@@ -25,6 +25,7 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
+++ b/boards/arm/nrf51dk_nrf51422/nrf51dk_nrf51422.dts
@@ -84,6 +84,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
+++ b/boards/arm/nrf51dongle_nrf51422/nrf51dongle_nrf51422.dts
@@ -52,6 +52,7 @@
 		led1 = &led0_green;
 		led2 = &led0_blue;
 		pwm-led0 = &pwm_led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
+++ b/boards/arm/nrf52832_mdk/nrf52832_mdk.dts
@@ -79,6 +79,7 @@
 		green-pwm-led = &pwm_led0_green;
 		red-pwm-led = &pwm_led1_red;
 		blue-pwm-led = &pwm_led2_blue;
+		watchdog0 = &wdt0;
 	};
 
 };

--- a/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
+++ b/boards/arm/nrf52833dk_nrf52820/nrf52833dk_nrf52820.dts
@@ -84,6 +84,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
+++ b/boards/arm/nrf52833dk_nrf52833/nrf52833dk_nrf52833.dts
@@ -113,6 +113,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52840_blip/nrf52840_blip.dts
+++ b/boards/arm/nrf52840_blip/nrf52840_blip.dts
@@ -55,6 +55,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -78,6 +78,7 @@
 		green-pwm-led = &pwm_led0_green;
 		red-pwm-led = &pwm_led1_red;
 		blue-pwm-led = &pwm_led2_blue;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
+++ b/boards/arm/nrf52840_mdk_usb_dongle/nrf52840_mdk_usb_dongle.dts
@@ -76,6 +76,7 @@
 		red-pwm-led = &red_pwm_led;
 		green-pwm-led = &green_pwm_led;
 		blue-pwm-led = &blue_pwm_led;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
+++ b/boards/arm/nrf52840_papyr/nrf52840_papyr.dts
@@ -74,6 +74,7 @@
 		blue-pwm-led = &pwm_led1;
 		red-pwm-led = &pwm_led2;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
+++ b/boards/arm/nrf52840dk_nrf52811/nrf52840dk_nrf52811.dts
@@ -84,6 +84,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -124,6 +124,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
+++ b/boards/arm/nrf52840dongle_nrf52840/nrf52840dongle_nrf52840.dts
@@ -84,6 +84,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0_green;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
+++ b/boards/arm/nrf52_adafruit_feather/nrf52_adafruit_feather.dts
@@ -34,6 +34,7 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
+++ b/boards/arm/nrf52_blenano2/nrf52_blenano2.dts
@@ -25,6 +25,7 @@
 	/* These aliases are provided for compatibility with samples */
 	aliases {
 		led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
+++ b/boards/arm/nrf52_sparkfun/nrf52_sparkfun.dts
@@ -27,6 +27,7 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
+++ b/boards/arm/nrf52_vbluno52/nrf52_vbluno52.dts
@@ -25,6 +25,7 @@
 	aliases {
 		led0 = &led0;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
+++ b/boards/arm/nrf52dk_nrf52805/nrf52dk_nrf52805.dts
@@ -76,6 +76,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
+++ b/boards/arm/nrf52dk_nrf52810/nrf52dk_nrf52810.dts
@@ -78,6 +78,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
+++ b/boards/arm/nrf52dk_nrf52832/nrf52dk_nrf52832.dts
@@ -125,6 +125,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -125,6 +125,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340dk_nrf5340_cpunet.dts
@@ -106,6 +106,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
@@ -72,6 +72,7 @@
 		sw0  = &button0;
 		rgb-pwm  = &pwm0;
 		mode-pwm = &pwm1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -63,6 +63,7 @@
 		sw0  = &button0;
 		rgb-pwm  = &pwm0;
 		mode-pwm = &pwm1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -133,6 +133,10 @@
 			status = "disabled";
 		};
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &gpiote {

--- a/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
+++ b/boards/arm/nrf9160dk_nrf9160/nrf9160dk_nrf9160_common.dts
@@ -149,6 +149,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
+++ b/boards/arm/nucleo_f030r8/nucleo_f030r8.dts
@@ -39,6 +39,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
+++ b/boards/arm/nucleo_f070rb/nucleo_f070rb.dts
@@ -39,6 +39,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
+++ b/boards/arm/nucleo_f091rc/nucleo_f091rc.dts
@@ -50,6 +50,7 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 		pwm-led0 = &green_pwm_led;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
+++ b/boards/arm/nucleo_f103rb/nucleo_f103rb.dts
@@ -39,6 +39,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
+++ b/boards/arm/nucleo_f207zg/nucleo_f207zg.dts
@@ -72,6 +72,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		red-pwm-led = &red_pwm_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
+++ b/boards/arm/nucleo_f334r8/nucleo_f334r8.dts
@@ -39,6 +39,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f401re/nucleo_f401re.dts
+++ b/boards/arm/nucleo_f401re/nucleo_f401re.dts
@@ -49,6 +49,7 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 		pwm-led0 = &green_pwm_led;
+		watchdog0 = &wwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
+++ b/boards/arm/nucleo_f429zi/nucleo_f429zi.dts
@@ -51,6 +51,7 @@
 		led1 = &blue_led_1;
 		led2 = &red_led_1;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
+++ b/boards/arm/nucleo_f746zg/nucleo_f746zg.dts
@@ -58,6 +58,7 @@
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
+++ b/boards/arm/nucleo_f767zi/nucleo_f767zi.dts
@@ -59,6 +59,7 @@
 		led1 = &blue_led;
 		led2 = &red_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
+++ b/boards/arm/nucleo_g071rb/nucleo_g071rb.dts
@@ -55,6 +55,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
+++ b/boards/arm/nucleo_g0b1re/nucleo_g0b1re.dts
@@ -56,6 +56,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
+++ b/boards/arm/nucleo_g431rb/nucleo_g431rb.dts
@@ -48,6 +48,7 @@
 		led0 = &green_led;
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_g474re/nucleo_g474re.dts
+++ b/boards/arm/nucleo_g474re/nucleo_g474re.dts
@@ -49,6 +49,7 @@
 		led0 = &green_led;
 		pwm-led0 = &green_pwm_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
+++ b/boards/arm/nucleo_h743zi/nucleo_h743zi.dts
@@ -56,6 +56,7 @@
 		led1 = &yellow_led;
 		pwm-led0 = &red_pwm_led;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -51,6 +51,7 @@
 		led0 = &green_led_2;
 		sw0 = &user_button;
 		pwm-led0 = &green_pwm_led;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_l152re/nucleo_l152re.dts
+++ b/boards/arm/nucleo_l152re/nucleo_l152re.dts
@@ -40,6 +40,7 @@
 		led0 = &green_led_0;
 		sw0 = &user_button;
 		eeprom-0 = &eeprom;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
+++ b/boards/arm/nucleo_l496zg/nucleo_l496zg.dts
@@ -58,6 +58,7 @@
 		led2 = &red_led_3;
 		pwm-led0 = &red_pwm_led;
 		sw0 = &user_button;
+		watchdog0 = &wwdg;
 	};
 };
 

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -80,6 +80,7 @@
 		sw0 = &user_button_1;
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -59,6 +59,7 @@
 		sw1 = &user_button_2;
 		sw2 = &user_button_3;
 		lora0 = &lora;
+		watchdog0 = &iwdg;
 	};
 
 	power-states {

--- a/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
+++ b/boards/arm/olimex_stm32_h103/olimex_stm32_h103.dts
@@ -37,6 +37,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/olimex_stm32_h405/olimex_stm32_h405.dts
+++ b/boards/arm/olimex_stm32_h405/olimex_stm32_h405.dts
@@ -39,6 +39,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/olimexino_stm32/olimexino_stm32.dts
+++ b/boards/arm/olimexino_stm32/olimexino_stm32.dts
@@ -52,6 +52,7 @@
 		led1 = &yellow_led_2;
 		sw0 = &user_button;
 		sdhc0 = &sdhc0;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/pan1770_evb/pan1770_evb.dts
+++ b/boards/arm/pan1770_evb/pan1770_evb.dts
@@ -123,6 +123,7 @@
 		sw2 = &evb_sw3;
 		sw3 = &evb_sw4;
 		bootloader-led0 = &evb_led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/pan1780_evb/pan1780_evb.dts
+++ b/boards/arm/pan1780_evb/pan1780_evb.dts
@@ -123,6 +123,7 @@
 		sw2 = &evb_sw3;
 		sw3 = &evb_sw4;
 		bootloader-led0 = &evb_led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/pan1781_evb/pan1781_evb.dts
+++ b/boards/arm/pan1781_evb/pan1781_evb.dts
@@ -85,6 +85,7 @@
 		pwm-led0 = &pwm_evb_led1;
 		sw0 = &evb_sw1;
 		sw1 = &evb_sw2;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/pan1782_evb/pan1782_evb.dts
+++ b/boards/arm/pan1782_evb/pan1782_evb.dts
@@ -86,6 +86,7 @@
 		sw0 = &evb_sw1;
 		sw1 = &evb_sw2;
 		bootloader-led0 = &evb_led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/particle_argon/particle_argon.dts
+++ b/boards/arm/particle_argon/particle_argon.dts
@@ -26,6 +26,10 @@
 		output-ohms = <2100000>;
 		full-ohms = <(2100000 + 806000)>;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &uart1 { /* ESP32 */

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -22,6 +22,10 @@
 		 * but is not used in board.c */
 		vctl2-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &i2c1 { /* power monitoring */

--- a/boards/arm/particle_xenon/particle_xenon.dts
+++ b/boards/arm/particle_xenon/particle_xenon.dts
@@ -26,6 +26,10 @@
 		output-ohms = <2100000>;
 		full-ohms = <(2100000 + 806000)>;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &uart1 { /* feather UART2 */

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -34,6 +34,7 @@
 		led3 = &statusled;	/* status led, may be not populated */
 		sw0 = &key_in;  /* key in */
 		kscan0 = &cst816s;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -74,6 +74,7 @@
 		sw3 = &button4;
 		mcuboot-button0 = &button1;
 		mcuboot-led0 = &led1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
+++ b/boards/arm/qemu_cortex_m0/qemu_cortex_m0.dts
@@ -22,6 +22,10 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &gpiote {

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -40,6 +40,7 @@
 	aliases {
 		led0 = &blue_led;
 		lora0 = &lora;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -34,6 +34,7 @@
 	/* Declaration of aliases */
 	aliases {
 		led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -44,6 +44,7 @@
 	aliases {
 		led3 = &back_led;
 		pwm-led3 = &back_pwm_led;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/reel_board/reel_board_v2.dts
+++ b/boards/arm/reel_board/reel_board_v2.dts
@@ -25,6 +25,10 @@
 		zephyr,code-partition = &slot0_partition;
 		zephyr,display = &ssd16xx;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &spi1 {

--- a/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
+++ b/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
@@ -34,6 +34,7 @@
 	aliases {
 		sw0 = &button2;
 		lora0 = &lora0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ronoth_lodev/ronoth_lodev.dts
+++ b/boards/arm/ronoth_lodev/ronoth_lodev.dts
@@ -103,6 +103,7 @@
 		sw0 = &user_button;
 		eeprom-0 = &eeprom;
 		lora0 = &lora;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
+++ b/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
@@ -28,6 +28,7 @@
 		led0 = &led0;
 		led1 = &led1;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/sam4e_xpro/sam4e_xpro.dts
+++ b/boards/arm/sam4e_xpro/sam4e_xpro.dts
@@ -18,6 +18,7 @@
 		led0 = &yellow_led_1;
 		sw0 = &user_button;
 		wdog = &wdt;
+		watchdog0 = &wdt;
 	};
 
 	chosen {

--- a/boards/arm/sam4s_xplained/sam4s_xplained.dts
+++ b/boards/arm/sam4s_xplained/sam4s_xplained.dts
@@ -18,6 +18,7 @@
 		led0 = &yellow_led_1;
 		led1 = &yellow_led_2;
 		sw0 = &user_button;
+		watchdog0 = &wdt;
 	};
 
 	chosen {

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -15,6 +15,7 @@
 		i2c-1 = &twihs2;
 		led0 = &green_led;
 		sw0 = &sw0_user_button;
+		watchdog0 = &wdt;
 	};
 
 	chosen {

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -18,6 +18,7 @@
 		pwm-0 = &pwm0;
 		sw0 = &sw0_user_button;
 		sw1 = &sw1_user_button;
+		watchdog0 = &wdt;
 	};
 
 	chosen {

--- a/boards/arm/segger_trb_stm32f407/segger_trb_stm32f407.dts
+++ b/boards/arm/segger_trb_stm32f407/segger_trb_stm32f407.dts
@@ -21,6 +21,7 @@
 		led0 = &led_0_green;
 		led1 = &led_1_green;
 		led2 = &led_2_green;
+		watchdog0 = &iwdg;
 	};
 
 	leds {

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160.dts
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160.dts
@@ -17,6 +17,10 @@
 		zephyr,sram-secure-partition = &sram0_s;
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &uart0 {

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
@@ -47,6 +47,7 @@
 		sw0 = &button0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &blue_led;
+		watchdog0 = &wdt0;
 	};
 
 	/* Used for accessing other pins */

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_ns.dts
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_ns.dts
@@ -15,4 +15,8 @@
 		zephyr,sram = &sram0_ns;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };

--- a/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
+++ b/boards/arm/steval_fcu001v1/steval_fcu001v1.dts
@@ -35,6 +35,7 @@
 	aliases {
 		led0 = &red_led_1;
 		led1 = &red_led_2;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm3210c_eval/stm3210c_eval.dts
+++ b/boards/arm/stm3210c_eval/stm3210c_eval.dts
@@ -38,6 +38,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32373c_eval/stm32373c_eval.dts
+++ b/boards/arm/stm32373c_eval/stm32373c_eval.dts
@@ -38,6 +38,7 @@
 	aliases {
 		led0 = &green_led_2;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32f030_demo/stm32f030_demo.dts
+++ b/boards/arm/stm32f030_demo/stm32f030_demo.dts
@@ -29,6 +29,7 @@
 
 	aliases {
 		led0 = &led;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32f072_eval/stm32f072_eval.dts
+++ b/boards/arm/stm32f072_eval/stm32f072_eval.dts
@@ -73,6 +73,7 @@
 		led2 = &red_led_3;
 		led3 = &blue_led_4;
 		sw0 = &joy_sel;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
+++ b/boards/arm/stm32f072b_disco/stm32f072b_disco.dts
@@ -54,6 +54,7 @@
 		led2 = &green_right_led_5;
 		led3 = &blue_low_led_6;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32f0_disco/stm32f0_disco.dts
+++ b/boards/arm/stm32f0_disco/stm32f0_disco.dts
@@ -44,6 +44,7 @@
 		led0 = &green_led_3;
 		led1 = &blue_led_4;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32f103_mini/stm32f103_mini.dts
+++ b/boards/arm/stm32f103_mini/stm32f103_mini.dts
@@ -29,6 +29,7 @@
 
 	aliases {
 		led0 = &green_led_1;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -69,6 +69,7 @@
 		led1 = &green_led_7;
 		sw0 = &user_button;
 		magn0 = &lsm303dlhc_magn;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32g0316_disco/stm32g0316_disco.dts
+++ b/boards/arm/stm32g0316_disco/stm32g0316_disco.dts
@@ -15,6 +15,7 @@
 	aliases {
 		led0 = &green_led_1;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 
 	chosen {

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -92,6 +92,7 @@
 		sw2 = &joy_down;
 		sw3 = &joy_right;
 		sw4 = &joy_up;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
@@ -85,6 +85,7 @@
 		sw2 = &joy_down;
 		sw3 = &joy_right;
 		sw4 = &joy_up;
+		watchdog0 = &iwdg;
 	};
 
 	vbus {

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk.dts
@@ -24,6 +24,7 @@
 	aliases {
 		led0 = &green_led_10;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -30,6 +30,7 @@
 		led1 = &led1;
 		led2 = &led2;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -115,6 +115,7 @@
 		pwm-led1 = &green_led_pwm;
 		pwm-led2 = &blue_led_pwm;
 		magn0 = &bmm150;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp.dts
@@ -19,4 +19,8 @@
 		zephyr,sram-secure-partition = &sram0_s;
 		zephyr,sram-non-secure-partition = &sram0_ns;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpuapp_ns.dts
@@ -17,4 +17,8 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_ns_partition;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_cpunet.dts
@@ -66,6 +66,7 @@
 		led0 = &red_led;
 		led1 = &green_led;
 		led2 = &blue_led;
+		watchdog0 = &wdt;
 	};
 };
 

--- a/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
+++ b/boards/arm/ubx_bmd300eval_nrf52832/ubx_bmd300eval_nrf52832.dts
@@ -128,6 +128,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
+++ b/boards/arm/ubx_bmd330eval_nrf52810/ubx_bmd330eval_nrf52810.dts
@@ -128,6 +128,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -126,6 +126,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -138,6 +138,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
+++ b/boards/arm/ubx_bmd360eval_nrf52811/ubx_bmd360eval_nrf52811.dts
@@ -128,6 +128,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -87,6 +87,7 @@
 		sw1 = &button1;
 		sw2 = &button2;
 		sw3 = &button3;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_evkannab1_nrf52832/ubx_evkannab1_nrf52832.dts
+++ b/boards/arm/ubx_evkannab1_nrf52832/ubx_evkannab1_nrf52832.dts
@@ -124,6 +124,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_evkninab1_nrf52832/ubx_evkninab1_nrf52832.dts
+++ b/boards/arm/ubx_evkninab1_nrf52832/ubx_evkninab1_nrf52832.dts
@@ -124,6 +124,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
+++ b/boards/arm/ubx_evkninab3_nrf52840/ubx_evkninab3_nrf52840.dts
@@ -119,6 +119,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
+++ b/boards/arm/ubx_evkninab4_nrf52833/ubx_evkninab4_nrf52833.dts
@@ -122,6 +122,7 @@
 		blue-pwm-led = &blue_pwm_led;
 		sw0 = &button0;
 		sw1 = &button1;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/waveshare_open103z/waveshare_open103z.dts
+++ b/boards/arm/waveshare_open103z/waveshare_open103z.dts
@@ -74,6 +74,7 @@
 		led2 = &led_3;
 		led3 = &led_4;
 		sw0 = &button;
+		watchdog0 = &iwdg;
 	};
 };
 

--- a/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
+++ b/boards/arm/we_ophelia1ev_nrf52805/we_ophelia1ev_nrf52805.dts
@@ -51,6 +51,7 @@
 		bootloader-led0 = &led0;
 		mcuboot-button0 = &button0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/we_proteus2ev_nrf52832/we_proteus2ev_nrf52832.dts
+++ b/boards/arm/we_proteus2ev_nrf52832/we_proteus2ev_nrf52832.dts
@@ -46,6 +46,7 @@
 		led1 = &led1;
 		sw0 = &button0;
 		bootloader-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/we_proteus3ev_nrf52840/we_proteus3ev_nrf52840.dts
+++ b/boards/arm/we_proteus3ev_nrf52840/we_proteus3ev_nrf52840.dts
@@ -47,6 +47,7 @@
 		led1 = &led1;
 		sw0 = &button0;
 		bootloader-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/arm/xiao_ble/xiao_ble.dts
+++ b/boards/arm/xiao_ble/xiao_ble.dts
@@ -56,6 +56,7 @@
 		pwm-led0 = &pwm_led0;
 		bootloader-led0 = &led0;
 		mcuboot-led0 = &led0;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -23,6 +23,7 @@
 	aliases {
 		sw0 = &user_button1;
 		i2c-0 = &i2c0;
+		watchdog0 = &wdt0;
 	};
 
 	gpio_keys {

--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -13,6 +13,7 @@
 		pwm-led0 = &led0;
 		pwm-led1 = &led1;
 		pwm-led2 = &led2;
+		watchdog0 = &wdog0;
 	};
 
 	chosen {

--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -15,6 +15,7 @@
 	aliases {
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
+++ b/boards/xtensa/esp32s2_saola/esp32s2_saola.dts
@@ -15,6 +15,7 @@
 
 	aliases {
 		i2c-0 = &i2c0;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -24,6 +24,7 @@
 		blue-pwm-led = &pwm_led_blue;
 		uart-0 = &uart0;
 		i2c-0 = &i2c0;
+		watchdog0 = &wdt0;
 	};
 
 	chosen {

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -17,6 +17,7 @@
 		i2c-0 = &i2c0;
 		led0 = &led0;
 		sw0 = &button0;
+		watchdog0 = &wdt0;
 	};
 
 	leds {

--- a/boards/xtensa/odroid_go/odroid_go.dts
+++ b/boards/xtensa/odroid_go/odroid_go.dts
@@ -68,6 +68,7 @@
 		uart-0 = &uart0;
 		led0 = &blue_led;
 		sw0 = &menu_button;
+		watchdog0 = &wdt0;
 	};
 };
 

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
@@ -22,6 +22,7 @@
 
 	aliases {
 		sw0 = &button1;
+		watchdog0 = &wdt0;
 	};
 
 	gpio_keys {

--- a/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/samples/application_development/out_of_tree_board/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -19,6 +19,10 @@
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
 	};
+
+	aliases {
+		watchdog0 = &wdt0;
+	};
 };
 
 &gpiote {

--- a/samples/drivers/watchdog/boards/cc3220sf_launchxl.overlay
+++ b/samples/drivers/watchdog/boards/cc3220sf_launchxl.overlay
@@ -1,3 +1,0 @@
-&wdt0 {
-	status = "okay";
-};

--- a/samples/drivers/watchdog/boards/cc3235sf_launchxl.overlay
+++ b/samples/drivers/watchdog/boards/cc3235sf_launchxl.overlay
@@ -1,3 +1,0 @@
-&wdt0 {
-	status = "okay";
-};

--- a/samples/drivers/watchdog/boards/disco_l475_iot1.overlay
+++ b/samples/drivers/watchdog/boards/disco_l475_iot1.overlay
@@ -1,3 +1,9 @@
+/ {
+	aliases {
+		watchdog0 = &wwdg;
+	};
+};
+
 &rcc {
 	apb1-prescaler = <16>;
 };

--- a/samples/drivers/watchdog/boards/esp32s2_saola.overlay
+++ b/samples/drivers/watchdog/boards/esp32s2_saola.overlay
@@ -1,3 +1,0 @@
-&wdt0 {
-	status = "okay";
-};

--- a/samples/drivers/watchdog/boards/nucleo_f091rc.overlay
+++ b/samples/drivers/watchdog/boards/nucleo_f091rc.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		watchdog0 = &wwdg;
+	};
+};
+
 &rcc {
 	apb1-prescaler = <4>;
 };

--- a/samples/drivers/watchdog/boards/nucleo_g431rb.overlay
+++ b/samples/drivers/watchdog/boards/nucleo_g431rb.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		watchdog0 = &wwdg;
+	};
+};
+
 &wwdg {
 	status = "okay";
 };

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -15,41 +15,17 @@
 #define WDT_FEED_TRIES 5
 
 /*
- * To use this sample, either the devicetree's /aliases must have a
- * 'watchdog0' property, or one of the following watchdog compatibles
- * must have an enabled node.
+ * To use this sample the devicetree's /aliases must have a 'watchdog0' property.
  */
-#if DT_NODE_HAS_STATUS(DT_ALIAS(watchdog0), okay)
-#define WDT_NODE DT_ALIAS(watchdog0)
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
-#define WDT_NODE DT_INST(0, st_stm32_window_watchdog)
+#if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_window_watchdog)
 #define WDT_MAX_WINDOW  100U
-#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_watchdog)
-#define WDT_NODE DT_INST(0, st_stm32_watchdog)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_wdt)
 /* Nordic supports a callback, but it has 61.2 us to complete before
  * the reset occurs, which is too short for this sample to do anything
  * useful.  Explicitly disallow use of the callback.
  */
 #define WDT_ALLOW_CALLBACK 0
-#define WDT_NODE DT_INST(0, nordic_nrf_wdt)
-#elif DT_HAS_COMPAT_STATUS_OKAY(espressif_esp32_watchdog)
-#define WDT_NODE DT_INST(0, espressif_esp32_watchdog)
-#elif DT_HAS_COMPAT_STATUS_OKAY(silabs_gecko_wdog)
-#define WDT_NODE DT_INST(0, silabs_gecko_wdog)
-#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_kinetis_wdog32)
-#define WDT_NODE DT_INST(0, nxp_kinetis_wdog32)
-#elif DT_HAS_COMPAT_STATUS_OKAY(microchip_xec_watchdog)
-#define WDT_NODE DT_INST(0, microchip_xec_watchdog)
-#elif DT_HAS_COMPAT_STATUS_OKAY(ti_cc32xx_watchdog)
-#define WDT_NODE DT_INST(0, ti_cc32xx_watchdog)
-#elif DT_HAS_COMPAT_STATUS_OKAY(nxp_imx_wdog)
-#define WDT_NODE DT_INST(0, nxp_imx_wdog)
-#else
-#error "Unsupported SoC and no watchdog0 alias in zephyr.dts"
-#endif
-
-#if DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_watchdog)
+#elif DT_HAS_COMPAT_STATUS_OKAY(raspberrypi_pico_watchdog)
 #define WDT_MAX_WINDOW  600000U
 #define WDT_ALLOW_CALLBACK 0
 #endif
@@ -82,7 +58,7 @@ void main(void)
 {
 	int err;
 	int wdt_channel_id;
-	const struct device *wdt = DEVICE_DT_GET(WDT_NODE);
+	const struct device *wdt = DEVICE_DT_GET(DT_ALIAS(watchdog0));
 
 	printk("Watchdog sample application\n");
 


### PR DESCRIPTION
Simplify sample by using alias for node access. Also removes
usage of DT_LABEL.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>