### PR TITLE
arch: arm: cortex_r: Use spsr_cxsf instead of spsr_hyp

### DIFF
--- a/arch/arm/core/aarch32/cortex_a_r/reset.S
+++ b/arch/arm/core/aarch32/cortex_a_r/reset.S
@@ -65,7 +65,7 @@ SECTION_SUBSEC_FUNC(TEXT, _reset_section, __start)
     mrs r0, cpsr
     bic r0, #MODE_MASK
     orr r0, #MODE_SVC
-    msr spsr_hyp, r0
+    msr spsr_cxsf, r0
 
     ldr r0, =EL1_Reset_Handler
     msr elr_hyp, r0


### PR DESCRIPTION
The use of spsr_hyp is undefined for the ARM Cortex-R52.
Some implements choose to implement the behavior, but it
should not be assumed.
Fixes #47330

Signed-off-by: Tobias Röhmel <tobias.roehmel@rwth-aachen.de>