### PR TITLE
drivers: sensor: npcx_tach: Remove underflow LOG_INF

### DIFF
--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -259,8 +259,6 @@ int tach_npcx_sample_fetch(const struct device *dev, enum sensor_channel chan)
 	if (tach_npcx_is_underflow(dev)) {
 		/* Clear pending flags */
 		tach_npcx_clear_underflow_flag(dev);
-
-		LOG_INF("%s is underflow!", dev->name);
 		data->capture = 0;
 
 		return 0;


### PR DESCRIPTION
A LOG_DBG already exists for the underflow check,
and given that reading 0 edges is a valid case, remove
the noisy underflow log.