### PR TITLE
tests: Change the result compare method in pin_get_config()

### DIFF
--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -647,7 +647,7 @@ static int pin_get_config(void)
 	}
 
 	zassert_equal(rc, 0, "pin get config failed");
-	zassert_equal(flags_set, flags_get, "flags are different");
+	zassert_equal(flags_get & ~GPIO_VOLTAGE_MASK, flags_set, "flags are different");
 
 	return TC_PASS;
 }
@@ -670,6 +670,8 @@ void test_gpio_port(void)
 		      "bits_logical failed");
 	zassert_equal(check_pulls(), TC_PASS,
 		      "check_pulls failed");
-	zassert_equal(pin_get_config(), TC_PASS,
-		      "pin_get_config failed");
+	if (IS_ENABLED(CONFIG_GPIO_GET_CONFIG)) {
+		zassert_equal(pin_get_config(), TC_PASS,
+			      "pin_get_config failed");
+	}
 }


### PR DESCRIPTION
Fixes #47921
When setting a GPIO to certain value, and then get the GPIO value, on some
platforms, such as ITE, these two values may not be the same. For example
setting GPIO_OUTPUT | GPIO_OUTPUT_INT_HIGH, it will read back
GPIO_OUTPUT | GPIO_OUTPUT_INT_HIGH | GPIO_VOLTAGE_3P3. This is as expected,
as GPIO_VOLTAGE is a read only property. So when comparing the gpio set
and get values, it is necessary to filter the read only bits first and
then compare to the set value.

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>