### PR TITLE
tests: subsys/edac: Remove test_trigger_nmi_handler testing.

### DIFF
--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -310,18 +310,6 @@ static void test_ibecc_error_inject_test_uc(void)
 }
 #endif
 
-/* Used only for code coverage */
-
-bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf);
-
-static void test_trigger_nmi_handler(void)
-{
-	bool ret;
-
-	ret = z_x86_do_kernel_nmi(NULL);
-	zassert_false(ret, "Test that NMI handling fails");
-}
-
 void test_edac_dummy_api(void);
 
 void test_main(void)
@@ -336,7 +324,6 @@ void test_main(void)
 #endif
 
 	ztest_test_suite(ibecc,
-			 ztest_unit_test(test_trigger_nmi_handler),
 			 ztest_unit_test(test_ibecc_initialized),
 			 ztest_unit_test(test_ibecc_api),
 			 ztest_unit_test(test_edac_dummy_api),


### PR DESCRIPTION
Remove the unrelated testing test_trigger_nmi_handler of edac.

Signed-off-by: Yinfang Wang <yinfang.wang@intel.com>