### PR TITLE
drivers: spi_esp32_spim: Add support for IOMUX mode

### DIFF
--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -199,7 +199,7 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 		.clock_speed_hz = spi_cfg->frequency,
 		.duty_cycle = cfg->duty_cycle == 0 ? 128 : cfg->duty_cycle,
 		.input_delay_ns = cfg->input_delay_ns,
-		.use_gpio = true
+		.use_gpio = !cfg->use_iomux,
 	};
 
 	spi_hal_cal_clock_conf(&timing_param, &freq, &hal_dev->timing_conf);
@@ -365,6 +365,7 @@ static const struct spi_driver_api spi_api = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),	\
 		.clock_subsys =	\
 			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),	\
+		.use_iomux = DT_INST_PROP(idx, use_iomux),	\
 	};	\
 		\
 	DEVICE_DT_INST_DEFINE(idx, &spi_esp32_init,	\

--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -28,6 +28,7 @@ struct spi_esp32_config {
 	int irq_source;
 	const struct pinctrl_dev_config *pcfg;
 	clock_control_subsys_t clock_subsys;
+	bool use_iomux;
 };
 
 struct spi_esp32_data {

--- a/dts/bindings/spi/espressif,esp32-spi.yaml
+++ b/dts/bindings/spi/espressif,esp32-spi.yaml
@@ -55,3 +55,14 @@ properties:
       type: boolean
       required: false
       description: Make CS positive during a transaction instead of negative
+
+    use-iomux:
+      type: boolean
+      required: false
+      description: |
+        Some pins are allowed to bypass the GPIO Matrix and use the IO_MUX
+        routing mechanism instead, this avoids extra routing latency and makes
+        possible the use of operating frequencies higher than 20 MHz.
+
+        Refer to SoC's Technical Reference Manual to check which pins are
+        allowed to use this routing path.


### PR DESCRIPTION
In order to work on a clock speed higher than 20 MHz, IO MUX is required.

References:
* https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/peripherals/spi_master.html#c.SPICOMMON_BUSFLAG_IOMUX_PINS
* https://docs.espressif.com/projects/esp-idf/en/release-v4.4/esp32/api-reference/peripherals/gpio.html#overview
* https://github.com/espressif/esp-idf/blob/ee2029c38ac05bad3ac4c4684a9c0f37094e9246/components/driver/spi_common.c#L553