### PR TITLE
Bluetooth: Mesh: Scanner is enabled during Friendship termination

### DIFF
--- a/subsys/bluetooth/mesh/lpn.c
+++ b/subsys/bluetooth/mesh/lpn.c
@@ -170,7 +170,7 @@ static void friend_clear_sent(int err, void *user_data)
 {
 	struct bt_mesh_lpn *lpn = &bt_mesh.lpn;
 
-	/* Scanning will enable if lpn state still enabled  */
+	bt_mesh_scan_enable();
 
 	lpn->req_attempts++;
 
@@ -233,6 +233,10 @@ static void clear_friendship(bool force, bool disable)
 	lpn_set_state(BT_MESH_LPN_DISABLED);
 	/* The timer handler returns without any actions if this fails. */
 	(void)k_work_cancel_delayable(&lpn->timer);
+
+	if (IS_ENABLED(CONFIG_BT_MESH_LPN_ESTABLISHMENT) || disable) {
+		bt_mesh_scan_disable();
+	}
 
 	if (lpn->clear_success) {
 		lpn->old_friend = BT_MESH_ADDR_UNASSIGNED;


### PR DESCRIPTION
Scanner was disabled after Friend Clear command. LNP didn't have
chance to receive Friend Clear Confirmation command back.
If option BT_MESH_LPN_ESTABLISHMENT is off then scanner is left
disabled and next Friend Offer after Friend Request
cannot be received.
PR fixes this.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>