### PR TITLE
mgmt/mcumgr: Fix format specifier

### DIFF
--- a/subsys/mgmt/mcumgr/smp_bt.c
+++ b/subsys/mgmt/mcumgr/smp_bt.c
@@ -236,7 +236,7 @@ static ssize_t smp_bt_chr_write(struct bt_conn *conn,
 	}
 
 	if (net_buf_tailroom(nb) < len) {
-		LOG_DBG("SMP packet len (%zu) > net_buf len (%zu)",
+		LOG_DBG("SMP packet len (%" PRIu16 ") > net_buf len (%zu)",
 			len, net_buf_tailroom(nb));
 		mcumgr_buf_free(nb);
 		return BT_GATT_ERR(BT_ATT_ERR_INSUFFICIENT_RESOURCES);


### PR DESCRIPTION
Our build reports warnings when building for native_posix and native_posix_64 therefore: Use c99 format specifier macros to remove build warnings when building for `native_posix[_64]`.

Signed-off-by: Marc Lasch <marc.lasch@husqvarnagroup.com>