### PR TITLE
soc: arm: nordic_nrf: include linker sections header

### DIFF
--- a/soc/arm/nordic_nrf/common/soc_nrf_common.S
+++ b/soc/arm/nordic_nrf/common/soc_nrf_common.S
@@ -10,6 +10,7 @@
  */
 
 #include <zephyr/toolchain.h>
+#include <zephyr/linker/sections.h>
 
 _ASM_FILE_PROLOGUE
 


### PR DESCRIPTION
Include linker sections header to move z_arm_platform_init to text
section. The function is now placed in the TEXT section, preceded by all other code.