### PR TITLE
drivers: serial: esp32c3: fix duplicated definition

### DIFF
--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -78,8 +78,6 @@ static int serial_esp32_usb_init(const struct device *dev)
 	int ret = clock_control_on(config->clock_dev, config->clock_subsys);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
-	const struct serial_esp32_usb_config *config = dev->config;
-
 	data->irq_line = esp_intr_alloc(config->irq_source, 0, (isr_handler_t)serial_esp32_usb_isr,
 					(void *)dev, NULL);
 #endif


### PR DESCRIPTION
Removes redefinition when uart interrupt is enabled.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>