### PR TITLE
arch: arm: Allow enabling FPU hard ABI with TF-M

### DIFF
--- a/arch/arm/core/aarch32/Kconfig
+++ b/arch/arm/core/aarch32/Kconfig
@@ -255,14 +255,16 @@ choice
 
 config FP_HARDABI
 	bool "Floating point Hard ABI"
-	depends on !BUILD_WITH_TFM
+	# TF-M build system does not build the NS app and libraries correctly with Hard ABI.
+	# This limitation should be removed in the next TF-M synchronization.
+	depends on !TFM_BUILD_NS
+	depends on !(BUILD_WITH_TFM && !TFM_IPC)
 	help
 	  This option selects the Floating point ABI in which hardware floating
 	  point instructions are generated and uses FPU-specific calling
 	  conventions.
-	  Note: the option is disabled for Zephyr builds with TF-M, as TF-M
-	  does not currently support building with Hard ABI, hence linking
-	  Zephyr with TF-M libraries would not be possible.
+
+	  Note: When building with TF-M enabled only the IPC mode is supported.
 
 config FP_SOFTABI
 	bool "Floating point Soft ABI"


### PR DESCRIPTION
Allow enabling FPU with TF-M with the following limitations:
- Only IPC mode is supported by TF-M.
- Disallow FPU hard ABI when building the NS application, the TF-M build
system does not pass the flags correctly to all dependencies.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>

~~Blocked: https://github.com/zephyrproject-rtos/zephyr/pull/43599~~

~~DNM: The original PR to enable FPU hard ABI caused a lot of CI issues after it was merged. Need to investigate that we have resolved these issues. now.~~