### PR TITLE
everywhere: Fix legacy include paths

### DIFF
--- a/arch/xtensa/core/timing.c
+++ b/arch/xtensa/core/timing.c
@@ -1,7 +1,7 @@
 /* Copyright (c) 2022 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 void arch_timing_init(void)
 {

--- a/boards/arm/rpi_pico/rpi_pico.dts
+++ b/boards/arm/rpi_pico/rpi_pico.dts
@@ -8,7 +8,7 @@
 
 #include <rpi_pico/rp2040.dtsi>
 #include "rpi_pico-pinctrl.dtsi"
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 #include <zephyr/dt-bindings/i2c/i2c.h>
 

--- a/boards/arm/swan_r5/board.c
+++ b/boards/arm/swan_r5/board.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/gpio.h>
-#include <init.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/init.h>
 
 static int board_swan_init(const struct device *dev)
 {

--- a/drivers/adc/adc_ads1119.c
+++ b/drivers/adc/adc_ads1119.c
@@ -4,14 +4,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/adc.h>
-#include <logging/log.h>
-#include <drivers/i2c.h>
-#include <zephyr.h>
-#include <sys/byteorder.h>
-#include <sys/util.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/i2c.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/util.h>
 
 #define ADC_CONTEXT_USES_KERNEL_TIMER 1
 #include "adc_context.h"

--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -17,7 +17,7 @@
 #define ADC_CONTEXT_USES_KERNEL_TIMER
 #include "adc_context.h"
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(adc_gd32, CONFIG_ADC_LOG_LEVEL);
 
 /**

--- a/drivers/bluetooth/hci/hci_b91.c
+++ b/drivers/bluetooth/hci/hci_b91.c
@@ -8,8 +8,8 @@
 #define LOG_MODULE_NAME bt_hci_driver_b91
 #include "common/log.h"
 
-#include <sys/byteorder.h>
-#include <drivers/bluetooth/hci_driver.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/drivers/bluetooth/hci_driver.h>
 
 #include <b91_bt.h>
 

--- a/drivers/cache/cache_aspeed.c
+++ b/drivers/cache/cache_aspeed.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #include <zephyr/drivers/syscon.h>
 
 /*

--- a/drivers/clock_control/clock_control_cavs.c
+++ b/drivers/clock_control/clock_control_cavs.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/device.h>
-#include <drivers/clock_control/clock_control_cavs.h>
+#include <zephyr/drivers/clock_control/clock_control_cavs.h>
 #include <zephyr/drivers/clock_control.h>
 
 static int cavs_clock_ctrl_set_rate(const struct device *clk,

--- a/drivers/coredump/coredump_impl.c
+++ b/drivers/coredump/coredump_impl.c
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <debug/coredump.h>
-#include <drivers/coredump.h>
+#include <zephyr/debug/coredump.h>
+#include <zephyr/drivers/coredump.h>
 
 #define DT_DRV_COMPAT zephyr_coredump
 

--- a/drivers/entropy/entropy_gecko_se.c
+++ b/drivers/entropy/entropy_gecko_se.c
@@ -6,7 +6,7 @@
 
 #define DT_DRV_COMPAT silabs_gecko_semailbox
 
- #include <drivers/entropy.h>
+ #include <zephyr/drivers/entropy.h>
  #include <soc.h>
  #include "em_cmu.h"
  #include "sl_se_manager.h"

--- a/drivers/sensor/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/stm32_vbat/stm32_vbat.c
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <devicetree.h>
-#include <drivers/sensor.h>
-#include <drivers/adc.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/sensor.h>
+#include <zephyr/drivers/adc.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(stm32_vbat, CONFIG_SENSOR_LOG_LEVEL);
 

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -8,7 +8,7 @@
 
 #include <hal/usb_serial_jtag_ll.h>
 
-#include <device.h>
+#include <zephyr/device.h>
 #include <errno.h>
 #include <soc.h>
 #include <zephyr/drivers/uart.h>

--- a/drivers/spi/spi_mchp_mss_qspi.c
+++ b/drivers/spi/spi_mchp_mss_qspi.c
@@ -6,11 +6,11 @@
 
 #define DT_DRV_COMPAT microchip_mpfs_qspi
 
-#include <device.h>
-#include <drivers/spi.h>
-#include <sys/sys_io.h>
-#include <sys/util.h>
-#include <logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(mss_qspi, CONFIG_SPI_LOG_LEVEL);
 #include "spi_context.h"

--- a/drivers/w1/w1_common.c
+++ b/drivers/w1/w1_common.c
@@ -4,10 +4,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <device.h>
-#include <sys/crc.h>
+#include <zephyr/device.h>
+#include <zephyr/sys/crc.h>
 #include <zephyr/types.h>
-#include <drivers/w1.h>
+#include <zephyr/drivers/w1.h>
 
 
 int z_impl_w1_read_block(const struct device *dev, uint8_t *buffer, size_t len)

--- a/drivers/w1/w1_net.c
+++ b/drivers/w1/w1_net.c
@@ -13,8 +13,8 @@
  * the arch_is_user_context() check.
  */
 
-#include <logging/log.h>
-#include <drivers/w1.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/drivers/w1.h>
 
 LOG_MODULE_REGISTER(w1, CONFIG_W1_LOG_LEVEL);
 

--- a/drivers/xen/gnttab.c
+++ b/drivers/xen/gnttab.c
@@ -17,16 +17,16 @@
  *
  ****************************************************************************
  */
-#include <arch/arm64/hypercall.h>
-#include <xen/generic.h>
-#include <xen/gnttab.h>
-#include <xen/public/grant_table.h>
-#include <xen/public/memory.h>
-#include <xen/public/xen.h>
+#include <zephyr/arch/arm64/hypercall.h>
+#include <zephyr/xen/generic.h>
+#include <zephyr/xen/gnttab.h>
+#include <zephyr/xen/public/grant_table.h>
+#include <zephyr/xen/public/memory.h>
+#include <zephyr/xen/public/xen.h>
 
-#include <init.h>
-#include <kernel.h>
-#include <logging/log.h>
+#include <zephyr/init.h>
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
 
 LOG_MODULE_REGISTER(xen_gnttab);
 

--- a/dts/arm/atmel/saml2x.dtsi
+++ b/dts/arm/atmel/saml2x.dtsi
@@ -6,9 +6,9 @@
 
 #include <mem.h>
 #include <arm/armv6-m.dtsi>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/pwm/pwm.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/pwm/pwm.h>
 
 / {
 	aliases {

--- a/dts/arm/atmel/samr34.dtsi
+++ b/dts/arm/atmel/samr34.dtsi
@@ -6,7 +6,7 @@
 
 #include <freq.h>
 #include <atmel/saml21.dtsi>
-#include <dt-bindings/lora/sx126x.h>
+#include <zephyr/dt-bindings/lora/sx126x.h>
 
 #include "saml21.dtsi"
 

--- a/dts/arm/microchip/mec1727nsz.dtsi
+++ b/dts/arm/microchip/mec1727nsz.dtsi
@@ -6,10 +6,10 @@
 
 #include <arm/armv7-m.dtsi>
 
-#include <dt-bindings/i2c/i2c.h>
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/clock/mchp_xec_pcr.h>
-#include <dt-bindings/interrupt-controller/mchp-xec-ecia.h>
+#include <zephyr/dt-bindings/i2c/i2c.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/clock/mchp_xec_pcr.h>
+#include <zephyr/dt-bindings/interrupt-controller/mchp-xec-ecia.h>
 
 #include "mec172xnsz.dtsi"
 #include "mec172x/mec172x-vw-routing.dtsi"

--- a/include/zephyr/bluetooth/audio/cap.h
+++ b/include/zephyr/bluetooth/audio/cap.h
@@ -20,7 +20,7 @@
  */
 
 #include <zephyr/types.h>
-#include <bluetooth/audio/csis.h>
+#include <zephyr/bluetooth/audio/csis.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -20,7 +20,7 @@
 #include <stdbool.h>
 #include <zephyr/toolchain.h>
 #include <zephyr/tracing/tracing_macros.h>
-#include <sys/mem_stats.h>
+#include <zephyr/sys/mem_stats.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/sys/sys_heap.h
+++ b/include/zephyr/sys/sys_heap.h
@@ -9,7 +9,7 @@
 #include <stddef.h>
 #include <stdbool.h>
 #include <zephyr/types.h>
-#include <sys/mem_stats.h>
+#include <zephyr/sys/mem_stats.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/xen/gnttab.h
+++ b/include/zephyr/xen/gnttab.h
@@ -6,7 +6,7 @@
 #ifndef __XEN_GNTTAB_H__
 #define __XEN_GNTTAB_H__
 
-#include <xen/public/grant_table.h>
+#include <zephyr/xen/public/grant_table.h>
 
 /*
  * Assigns gref and permits access to 4K page for specific domain.

--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -256,7 +256,7 @@ int z_impl_zephyr_write_stdout(const void *buffer, int nbytes)
 	return nbytes;
 }
 
-#include <sys/cbprintf.h>
+#include <zephyr/sys/cbprintf.h>
 
 struct cb_bits {
 	FILE f;
@@ -528,7 +528,7 @@ int _gettimeofday(struct timeval *__tp, void *__tzp)
 }
 
 #include <stdlib.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /* Replace picolibc abort with native Zephyr one */
 void abort(void)

--- a/samples/boards/mimxrt1060_evk/system_off/src/main.c
+++ b/samples/boards/mimxrt1060_evk/system_off/src/main.c
@@ -5,12 +5,12 @@
  */
 
 #include <stdio.h>
-#include <zephyr.h>
-#include <device.h>
-#include <drivers/gpio.h>
-#include <drivers/counter.h>
-#include <pm/pm.h>
-#include <pm/policy.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/counter.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/policy.h>
 
 #define BUSY_WAIT_S 2U
 #define SLEEP_S 2U

--- a/samples/drivers/led_ws2812/boards/mimxrt1050_evk.overlay
+++ b/samples/drivers/led_ws2812/boards/mimxrt1050_evk.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 &lpspi3 {
 	led_strip: ws2812@0 {

--- a/samples/drivers/led_ws2812/boards/mimxrt1050_evk_qspi.overlay
+++ b/samples/drivers/led_ws2812/boards/mimxrt1050_evk_qspi.overlay
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/led/led.h>
+#include <zephyr/dt-bindings/led/led.h>
 
 &lpspi3 {
 	led_strip: ws2812@0 {

--- a/samples/subsys/rtio/sensor_batch_processing/src/main.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <zephyr/rtio/rtio.h>
 #include <zephyr/rtio/rtio_executor_simple.h>
 #include <zephyr/logging/log.h>

--- a/soc/arm/microchip_mec/mec172x/device_power.c
+++ b/soc/arm/microchip_mec/mec172x/device_power.c
@@ -5,10 +5,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/sys_io.h>
-#include <sys/__assert.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
 #include "device_power.h"
 

--- a/soc/arm/microchip_mec/mec172x/power.c
+++ b/soc/arm/microchip_mec/mec172x/power.c
@@ -5,13 +5,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <sys/sys_io.h>
-#include <sys/__assert.h>
-#include <pm/pm.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/sys/sys_io.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/pm/pm.h>
 #include <soc.h>
-#include <arch/cpu.h>
-#include <arch/arm/aarch32/cortex_m/cmsis.h>
+#include <zephyr/arch/cpu.h>
+#include <zephyr/arch/arm/aarch32/cortex_m/cmsis.h>
 #ifndef CONFIG_PM_DEVICE
 #include "device_power.h"
 #endif

--- a/soc/xtensa/intel_adsp/ace_v1x/_soc_inthandlers.h
+++ b/soc/xtensa/intel_adsp/ace_v1x/_soc_inthandlers.h
@@ -14,8 +14,8 @@
  */
 
 #include <xtensa/config/core-isa.h>
-#include <sys/util.h>
-#include <sw_isr_table.h>
+#include <zephyr/sys/util.h>
+#include <zephyr/sw_isr_table.h>
 
 #if !defined(XCHAL_INT0_LEVEL) || XCHAL_INT0_LEVEL != 1
 #error core-isa.h interrupt level does not match dispatcher!

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -3,7 +3,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#include <device.h>
+#include <zephyr/device.h>
 
 #include <cavs-clk.h>
 #include <cavs-shim.h>

--- a/subsys/bluetooth/audio/cap.c
+++ b/subsys/bluetooth/audio/cap.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <bluetooth/gatt.h>
-#include <bluetooth/audio/tbs.h>
-#include <bluetooth/audio/csis.h>
+#include <zephyr/bluetooth/gatt.h>
+#include <zephyr/bluetooth/audio/tbs.h>
+#include <zephyr/bluetooth/audio/csis.h>
 #include "cap_internal.h"
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_CAP)

--- a/subsys/bluetooth/audio/cap_internal.h
+++ b/subsys/bluetooth/audio/cap_internal.h
@@ -7,6 +7,6 @@
  */
 
 #include <zephyr/types.h>
-#include <bluetooth/conn.h>
+#include <zephyr/bluetooth/conn.h>
 
 bool bt_cap_acceptor_ccid_exist(const struct bt_conn *conn, uint8_t ccid);

--- a/subsys/bluetooth/audio/tbs_client.c
+++ b/subsys/bluetooth/audio/tbs_client.c
@@ -8,7 +8,7 @@
 
 #include <zephyr/zephyr.h>
 #include <zephyr/types.h>
-#include <sys/check.h>
+#include <zephyr/sys/check.h>
 
 #include <zephyr/device.h>
 #include <zephyr/init.h>

--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_cc.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/types.h>
 
-#include <bluetooth/hci.h>
-#include <sys/byteorder.h>
-#include <sys/slist.h>
-#include <sys/util.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
 
 #include "hal/ecb.h"
 #include "hal/ccm.h"

--- a/subsys/debug/coredump/coredump_core.c
+++ b/subsys/debug/coredump/coredump_core.c
@@ -30,7 +30,7 @@ static struct coredump_backend_api
 #endif
 
 #if defined(CONFIG_COREDUMP_DEVICE)
-#include <drivers/coredump.h>
+#include <zephyr/drivers/coredump.h>
 #define DT_DRV_COMPAT zephyr_coredump
 #endif
 

--- a/subsys/rtio/rtio_executor_concurrent.c
+++ b/subsys/rtio/rtio_executor_concurrent.c
@@ -5,11 +5,11 @@
  */
 
 #include "spinlock.h"
-#include <rtio/rtio_executor_concurrent.h>
-#include <rtio/rtio.h>
+#include <zephyr/rtio/rtio_executor_concurrent.h>
+#include <zephyr/rtio/rtio.h>
 #include <zephyr/kernel.h>
 
-#include <logging/log.h>
+#include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(rtio_executor_concurrent, CONFIG_RTIO_LOG_LEVEL);
 
 #define CONEX_TASK_COMPLETE BIT(0)

--- a/tests/bluetooth/controller/ctrl_cis_create/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_create/src/main.c
@@ -8,10 +8,10 @@
 #include <ztest.h>
 #include "kconfig.h"
 
-#include <bluetooth/hci.h>
-#include <sys/byteorder.h>
-#include <sys/slist.h>
-#include <sys/util.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
 #include "hal/ccm.h"
 
 #include "util/util.h"

--- a/tests/bluetooth/controller/ctrl_cis_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/src/main.c
@@ -8,10 +8,10 @@
 #include <ztest.h>
 #include "kconfig.h"
 
-#include <bluetooth/hci.h>
-#include <sys/byteorder.h>
-#include <sys/slist.h>
-#include <sys/util.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/slist.h>
+#include <zephyr/sys/util.h>
 #include "hal/ccm.h"
 
 #include "util/util.h"

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_conn_iso.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 #include "hal/ccm.h"
 #include "hal/ticker.h"

--- a/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral_iso.c
+++ b/tests/bluetooth/controller/mock_ctrl/src/ull_peripheral_iso.c
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
-#include <bluetooth/buf.h>
-#include <sys/byteorder.h>
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/buf.h>
+#include <zephyr/sys/byteorder.h>
 
 #include "util/util.h"
 #include "util/memq.h"

--- a/tests/drivers/clock_control/cavs_clock/src/main.c
+++ b/tests/drivers/clock_control/cavs_clock/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <ztest.h>
-#include <drivers/clock_control/clock_control_cavs.h>
+#include <zephyr/drivers/clock_control/clock_control_cavs.h>
 #include <zephyr/drivers/clock_control.h>
 
 static void check_clocks(struct cavs_clock_info *clocks, uint32_t freq_idx)

--- a/tests/drivers/coredump/coredump_api/src/main.c
+++ b/tests/drivers/coredump/coredump_api/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <drivers/coredump.h>
+#include <zephyr/drivers/coredump.h>
 #include <ztest.h>
 
 /* Test will verify that these values are present in the core dump */

--- a/tests/drivers/syscon/src/main.c
+++ b/tests/drivers/syscon/src/main.c
@@ -6,7 +6,7 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/syscon.h>
 #include <ztest.h>
-#include <linker/devicetree_regions.h>
+#include <zephyr/linker/devicetree_regions.h>
 
 #define RES_SECT LINKER_DT_NODE_REGION_NAME(DT_NODELABEL(res))
 

--- a/tests/drivers/w1/w1_api/src/w1_dummy_slave.c
+++ b/tests/drivers/w1/w1_api/src/w1_dummy_slave.c
@@ -6,8 +6,8 @@
 
 #define DT_DRV_COMPAT test_w1_dummy_slave
 
-#include <device.h>
-#include <drivers/w1.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/w1.h>
 
 struct w1_dummy_slave_api {
 };

--- a/tests/kernel/common/src/pow2.c
+++ b/tests/kernel/common/src/pow2.c
@@ -5,7 +5,7 @@
  */
 
 #include <ztest.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 
 /**
  * @brief Test the Z_POW2_CEIL() macro

--- a/tests/net/lib/lwm2m/content_raw_cbor/src/main.c
+++ b/tests/net/lib/lwm2m/content_raw_cbor/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <ztest.h>
 
 #include "lwm2m_util.h"

--- a/tests/net/lib/lwm2m/content_senml_cbor/src/main.c
+++ b/tests/net/lib/lwm2m/content_senml_cbor/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <ztest.h>
 
 #include "lwm2m_util.h"

--- a/tests/subsys/logging/log_backend_init/src/main.c
+++ b/tests/subsys/logging/log_backend_init/src/main.c
@@ -7,11 +7,11 @@
 
 #include <tc_util.h>
 #include <stdbool.h>
-#include <zephyr.h>
+#include <zephyr/zephyr.h>
 #include <ztest.h>
-#include <logging/log_backend.h>
-#include <logging/log_ctrl.h>
-#include <logging/log.h>
+#include <zephyr/logging/log_backend.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log.h>
 
 #define LOG_MODULE_NAME test
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);

--- a/tests/subsys/logging/log_stress/src/main.c
+++ b/tests/subsys/logging/log_stress/src/main.c
@@ -5,13 +5,13 @@
  */
 
 #include <ztest.h>
-#include <sys/util.h>
+#include <zephyr/sys/util.h>
 #include <string.h>
 #include <ztress.h>
-#include <random/rand32.h>
-#include <logging/log.h>
-#include <logging/log_ctrl.h>
-#include <logging/log_backend.h>
+#include <zephyr/random/rand32.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/logging/log_ctrl.h>
+#include <zephyr/logging/log_backend.h>
 
 #define MODULE_NAME test
 

--- a/tests/subsys/mgmt/zcbor_bulk/src/main.c
+++ b/tests/subsys/mgmt/zcbor_bulk/src/main.c
@@ -5,7 +5,7 @@
  */
 
 #include <ztest.h>
-#include <sys/byteorder.h>
+#include <zephyr/sys/byteorder.h>
 #include <zcbor_common.h>
 #include <zcbor_decode.h>
 #include <zcbor_encode.h>


### PR DESCRIPTION
Any project with Kconfig option `CONFIG_LEGACY_INCLUDE_PATH` set to `n` couldn't be built because some files were missing the `zephyr/` prefix in includes. Even the `blinky` sample couldn't be bult without legacy include paths support.

- Re-ran the `migrate_includes.py` script to fix all legacy include paths.

Maybe not using the legacy include paths could be somehow enforced in CI?