### PR TITLE
scripts: release: list_backports: use older python dict merge method

### DIFF
--- a/scripts/release/list_backports.py
+++ b/scripts/release/list_backports.py
@@ -254,7 +254,8 @@ class Backport(object):
                 self._pulls_without_an_issue.append(p)
                 continue
 
-            issue_map = issue_map | issues_for_this_pr
+            # FIXME: when we have upgrade to python3.9+, use "issue_map | issues_for_this_pr"
+            issue_map = {**issue_map, **issues_for_this_pr}
 
         issues = list(issue_map.values())
 


### PR DESCRIPTION
In Python versions >= 3.9, dicts can be merged with the `|` operator.

This is not the case for python versions < 3.9, and the simplest way is to use `dict_c = {**dict_a, **dict_b}`.
