### PR TITLE
samples: sensors: Remove label property from devicetree overlays

### DIFF
--- a/samples/sensor/adt7420/boards/frdm_k64f.overlay
+++ b/samples/sensor/adt7420/boards/frdm_k64f.overlay
@@ -10,7 +10,6 @@
 	adt7420@48 {
 		compatible = "adi,adt7420";
 		reg = <0x48>;
-		label = "ADT7420";
 		int-gpios = <&gpioc 16 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/samples/sensor/adt7420/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/adt7420/boards/nrf52dk_nrf52832.overlay
@@ -10,7 +10,6 @@
 	adt7420@48 {
 		compatible = "adi,adt7420";
 		reg = <0x48>;
-		label = "ADT7420";
 		int-gpios = <&gpio0 11 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/samples/sensor/adxl362/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/adxl362/boards/nrf52dk_nrf52832.overlay
@@ -32,7 +32,6 @@
 
 	adxl362@0 {
 		compatible = "adi,adxl362";
-		label = "ADXL362";
 		spi-max-frequency = <8000000>;
 		reg = <0>;
 		int1-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;

--- a/samples/sensor/adxl372/boards/frdm_k64f.overlay
+++ b/samples/sensor/adxl372/boards/frdm_k64f.overlay
@@ -10,7 +10,6 @@
 	adxl372@11 {
 		compatible = "adi,adxl372";
 		reg = <0x11>;
-		label = "ADXL372";
 		int1-gpios = <&gpioc 6 0>;
 	};
 };

--- a/samples/sensor/adxl372/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/adxl372/boards/nrf52dk_nrf52832.overlay
@@ -10,7 +10,6 @@
 		compatible = "adi,adxl372";
 		reg = <0>;
 		spi-max-frequency = <8000000>;
-		label = "ADXL372";
 		int1-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/ams_iAQcore/iaq_core.overlay
+++ b/samples/sensor/ams_iAQcore/iaq_core.overlay
@@ -10,6 +10,5 @@
 	iaqcore: iaqcore@5a {
 		compatible = "ams,iaqcore";
 		reg = <0x5a>;
-		label = "IAQ_CORE";
 	};
 };

--- a/samples/sensor/bme280/arduino_i2c.overlay
+++ b/samples/sensor/bme280/arduino_i2c.overlay
@@ -15,6 +15,5 @@
 	bme280@77 {
 		compatible = "bosch,bme280";
 		reg = <0x77>;
-		label = "BME280_I2C";
 	};
 };

--- a/samples/sensor/bme280/arduino_spi.overlay
+++ b/samples/sensor/bme280/arduino_spi.overlay
@@ -12,7 +12,6 @@
 	bme280@0 {
 		compatible = "bosch,bme280";
 		reg = <0>;
-		label = "BME280_SPI";
 		spi-max-frequency = <1000000>; /* conservatively set to 1MHz */
 	};
 };

--- a/samples/sensor/bme280/boards/adafruit_feather_m0_basic_proto.overlay
+++ b/samples/sensor/bme280/boards/adafruit_feather_m0_basic_proto.overlay
@@ -10,6 +10,5 @@
 		/* 0x77 - SDO <-> VCC */
 		compatible = "bosch,bme280";
 		reg = <0x76>;
-		label = "ENVIRONMENTAL_SENSOR";
 	};
 };

--- a/samples/sensor/bme680/boards/adafruit_feather_nrf52840.overlay
+++ b/samples/sensor/bme680/boards/adafruit_feather_nrf52840.overlay
@@ -12,6 +12,5 @@
 	bme680: bme680@77 {
 		compatible = "bosch,bme680";
 		reg = <0x77>;
-		label = "BME680";
 	};
 };

--- a/samples/sensor/bme680/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/bme680/boards/nrf52840dk_nrf52840.overlay
@@ -8,6 +8,5 @@
 	bme680@76 {
 		compatible = "bosch,bme680";
 		reg = <0x76>;
-		label = "BME680";
 	};
 };

--- a/samples/sensor/bmg160/boards/frdm_k64f.overlay
+++ b/samples/sensor/bmg160/boards/frdm_k64f.overlay
@@ -9,6 +9,5 @@
 		compatible = "bosch,bmg160";
 		reg = <0x68>;
 		int-gpios = <&gpioc 6 0>;
-		label = "BMG160";
 	};
 };

--- a/samples/sensor/bmi270/app.overlay
+++ b/samples/sensor/bmi270/app.overlay
@@ -10,6 +10,5 @@
 	bmi270@68 {
 		compatible = "bosch,bmi270";
 		reg = <0x68>;
-		label = "BMI270";
 	};
 };

--- a/samples/sensor/ccs811/boards/nrf51_ble400.overlay
+++ b/samples/sensor/ccs811/boards/nrf51_ble400.overlay
@@ -31,7 +31,6 @@
 	ccs811: ccs811@5b {
 		compatible = "ams,ccs811";
 		reg = <0x5b>;
-		label = "CCS811";
 		irq-gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 		wake-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;

--- a/samples/sensor/dht/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/dht/boards/nrf52dk_nrf52832.overlay
@@ -8,7 +8,6 @@
 	dht22 {
 		compatible = "aosong,dht";
 		status = "okay";
-		label = "DHT22";
 		dio-gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		dht22;
 	};

--- a/samples/sensor/dps310/app.overlay
+++ b/samples/sensor/dps310/app.overlay
@@ -13,6 +13,5 @@
 		status = "okay";
 		compatible = "infineon,dps310";
 		reg = <0x77>;
-		label = "DPS310";
 	};
 };

--- a/samples/sensor/ds18b20/arduino_serial.overlay
+++ b/samples/sensor/ds18b20/arduino_serial.overlay
@@ -16,14 +16,12 @@
 		compatible = "zephyr,w1-serial";
 		#address-cells = <1>;
 		#size-cells = <0>;
-		label = "W1_0";
 		status = "okay";
 
 		ds18b20 {
 			compatible = "maxim,ds18b20";
 			family-code = <0x28>;
 			resolution = <12>;
-			label = "DS18B20";
 			status = "okay";
 		};
 	};

--- a/samples/sensor/ds18b20/boards/serial_overlay.dtsi
+++ b/samples/sensor/ds18b20/boards/serial_overlay.dtsi
@@ -11,14 +11,12 @@
 		compatible = "zephyr,w1-serial";
 		#address-cells = <1>;
 		#size-cells = <0>;
-		label = "W1_0";
 		status = "okay";
 
 		ds18b20 {
 			compatible = "maxim,ds18b20";
 			family-code = <0x28>;
 			resolution = <12>;
-			label = "DS18B20";
 			status = "okay";
 		};
 	};

--- a/samples/sensor/ens210/ens210.overlay
+++ b/samples/sensor/ens210/ens210.overlay
@@ -10,6 +10,5 @@
 	ens210: ens210@43 {
 		compatible = "ams,ens210";
 		reg = <0x43>;
-		label = "ENS210";
 	};
 };

--- a/samples/sensor/fdc2x1x/boards/nrf9160dk_nrf9160.overlay
+++ b/samples/sensor/fdc2x1x/boards/nrf9160dk_nrf9160.overlay
@@ -9,7 +9,6 @@
 	fdc2x1x@2A {
 		compatible = "ti,fdc2x1x";
 		reg = <0x2A>;
-		label = "FDC2X1X";
 		sd-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
 		intb-gpios = <&gpio0 20 GPIO_ACTIVE_LOW>;
 

--- a/samples/sensor/grove_light/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/grove_light/boards/nrf52dk_nrf52832.overlay
@@ -6,7 +6,6 @@
 
 / {
 	ntc {
-		label = "GLS";
 		compatible = "seeed,grove-light";
 		io-channels = <&arduino_adc 0>;
 	};

--- a/samples/sensor/grove_temperature/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/grove_temperature/boards/nrf52dk_nrf52832.overlay
@@ -6,7 +6,6 @@
 
 / {
 	ntc {
-		label = "GTS";
 		compatible = "seeed,grove-temperature";
 		io-channels = <&arduino_adc 0>;
 	};

--- a/samples/sensor/icm42605/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/icm42605/boards/nrf52dk_nrf52832.overlay
@@ -34,7 +34,6 @@
 		compatible = "invensense,icm42605";
 		spi-max-frequency = <24000000>;
 		reg = <0>;
-		label = "ICM42605";
 		int-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/ina219/boards/blackpill_f411ce.overlay
+++ b/samples/sensor/ina219/boards/blackpill_f411ce.overlay
@@ -8,13 +8,11 @@
 	status = "okay";
 	compatible = "st,stm32-i2c-v1";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	label = "I2C_0";
 
 	ina219@40 {
 		status = "okay";
 		compatible = "ti,ina219";
 		reg = <0x40>;
-		label = "INA219";
 		brng = <0>;
 		pg = <0>;
 		sadc = <13>;

--- a/samples/sensor/isl29035/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/isl29035/boards/nrf52dk_nrf52832.overlay
@@ -8,7 +8,6 @@
 	isl29035@44 {
 		compatible = "isil,isl29035";
 		reg = <0x44>;
-		label = "ISL29035";
 		int-gpios = <&gpio0 11 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/samples/sensor/max17262/app.overlay
+++ b/samples/sensor/max17262/app.overlay
@@ -9,7 +9,6 @@
 
 	max17262@36 {
 		compatible = "maxim,max17262";
-		label = "MAX17262";
 		reg = <0x36>;
 		design-voltage = <3600>;
 		desired-voltage = <3600>;

--- a/samples/sensor/max44009/boards/frdm_k64f.overlay
+++ b/samples/sensor/max44009/boards/frdm_k64f.overlay
@@ -9,6 +9,5 @@
 		compatible = "maxim,max44009";
 		reg = <0x4a>;
 		int-gpios = <&gpioc 6 0>;
-		label = "MAX44009";
 	};
 };

--- a/samples/sensor/max6675/boards/nucleo_f030r8.overlay
+++ b/samples/sensor/max6675/boards/nucleo_f030r8.overlay
@@ -9,6 +9,5 @@
 		compatible = "maxim,max6675";
 		reg = <0>;
 		spi-max-frequency = <4300000>;
-		label = "MAX6675";
 	};
 };

--- a/samples/sensor/mcp9808/boards/frdm_k64f.overlay
+++ b/samples/sensor/mcp9808/boards/frdm_k64f.overlay
@@ -9,6 +9,5 @@
 		compatible = "microchip,mcp9808";
 		reg = <0x18>;
 		int-gpios = <&gpioc 16 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-		label = "MCP9808";
 	};
 };

--- a/samples/sensor/mcp9808/boards/nucleo_l031k6.overlay
+++ b/samples/sensor/mcp9808/boards/nucleo_l031k6.overlay
@@ -10,6 +10,5 @@
 		reg = <0x18>;
 		int-gpios = <&gpiob 4 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		resolution = <3>;
-		label = "MCP9808";
 	};
 };

--- a/samples/sensor/mcp9808/boards/nucleo_l053r8.overlay
+++ b/samples/sensor/mcp9808/boards/nucleo_l053r8.overlay
@@ -9,7 +9,6 @@
 		compatible = "microchip,mcp9808";
 		reg = <0x18>;
 		int-gpios = <&gpioa 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-		label = "MCP9808";
 		resolution = <3>;
 	};
 };

--- a/samples/sensor/mcp9808/boards/particle_xenon.overlay
+++ b/samples/sensor/mcp9808/boards/particle_xenon.overlay
@@ -9,6 +9,5 @@
 		compatible = "microchip,mcp9808";
 		reg = <0x18>;
 		int-gpios = <&gpio1 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
-		label = "MCP9808";
 	};
 };

--- a/samples/sensor/mhz19b/boards/nucleo_g0b1re.overlay
+++ b/samples/sensor/mhz19b/boards/nucleo_g0b1re.overlay
@@ -10,6 +10,5 @@
 		compatible = "winsen,mhz19b";
 		maximum-range = <10000>;
 		abc-on;
-		label = "MHZ19B_2";
 	};
 };

--- a/samples/sensor/mpr/boards/arduino_due.overlay
+++ b/samples/sensor/mpr/boards/arduino_due.overlay
@@ -8,6 +8,5 @@
     mpr@18 {
         compatible = "honeywell,mpr";
         reg = <0x18>;
-        label = "MPR";
     };
 };

--- a/samples/sensor/mpu6050/boards/nrf52dk_nrf52832.overlay
+++ b/samples/sensor/mpu6050/boards/nrf52dk_nrf52832.overlay
@@ -9,7 +9,6 @@
 		compatible = "invensense,mpu6050";
 		reg = <0x68>;
 		status = "okay";
-		label = "MPU6050";
 		int-gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/ms5837/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/ms5837/boards/nrf52840dk_nrf52840.overlay
@@ -10,6 +10,5 @@
     ms5837@76 {
         compatible = "meas,ms5837";
         reg = <0x76>;
-        label = "MS5837";
     };
 };

--- a/samples/sensor/sgp40_sht4x/boards/blackpill_f411ce.overlay
+++ b/samples/sensor/sgp40_sht4x/boards/blackpill_f411ce.overlay
@@ -11,14 +11,12 @@
 		status = "okay";
 		compatible = "sensirion,sht4x";
 		reg = <0x44>;
-		label = "SHT4X";
 		repeatability = <2>;
 	};
 	sgp40@59 {
 		status = "okay";
 		compatible = "sensirion,sgp40";
 		reg = <0x59>;
-		label = "SGP40";
 		enable-selftest;
 	};
 };

--- a/samples/sensor/sht3xd/boards/efr32mg_sltb004a.overlay
+++ b/samples/sensor/sht3xd/boards/efr32mg_sltb004a.overlay
@@ -8,7 +8,6 @@
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
-		label = "SHT3XD";
 		alert-gpios = <&gpiof 6 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/sht3xd/boards/frdm_k64f.overlay
+++ b/samples/sensor/sht3xd/boards/frdm_k64f.overlay
@@ -8,7 +8,6 @@
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
-		label = "SHT3XD";
 		alert-gpios = <&gpioe 26 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/sht3xd/boards/nrf51_ble400.overlay
+++ b/samples/sensor/sht3xd/boards/nrf51_ble400.overlay
@@ -8,7 +8,6 @@
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
-		label = "SHT3XD";
 		alert-gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/sht3xd/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/sensor/sht3xd/boards/nrf52840dk_nrf52840.overlay
@@ -8,7 +8,6 @@
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
-		label = "SHT3XD";
 		alert-gpios = <&gpio1 10 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/sht3xd/boards/nucleo_l476rg.overlay
+++ b/samples/sensor/sht3xd/boards/nucleo_l476rg.overlay
@@ -9,7 +9,6 @@
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
-		label = "SHT3XD";
 		alert-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/samples/sensor/stm32_temp_sensor/boards/nucleo_f401re.overlay
+++ b/samples/sensor/stm32_temp_sensor/boards/nucleo_f401re.overlay
@@ -8,7 +8,6 @@
 
 / {
 	stm-temp {
-		label = "DIE_TEMP";
 		compatible = "st,stm32-temp";
 		io-channels = <&adc1 16>;
 		status = "okay";

--- a/samples/sensor/stm32_temp_sensor/boards/stm32f103_mini.overlay
+++ b/samples/sensor/stm32_temp_sensor/boards/stm32f103_mini.overlay
@@ -8,7 +8,6 @@
 
 / {
 	stm-temp {
-		label = "DIE_TEMP";
 		compatible = "st,stm32-temp";
 		io-channels = <&adc1 16>;
 		avgslope = <43>;

--- a/samples/sensor/stm32_vbat_sensor/README.rst
+++ b/samples/sensor/stm32_vbat_sensor/README.rst
@@ -20,7 +20,6 @@ board DT file or with a board overlay in the samples/sensor/stm32_temp_sensor/bo
 
     stm32_vbat: stm32vbat {
         compatible = "st,stm32-vbat";
-        label = "VBAT";
         io-channels = <&adc1 14>;
         ratio = <3>;
         status = "okay";

--- a/samples/sensor/stm32_vbat_sensor/boards/nucleo_g071rb.overlay
+++ b/samples/sensor/stm32_vbat_sensor/boards/nucleo_g071rb.overlay
@@ -12,6 +12,5 @@
 		ratio = <3>;
 		io-channels = <&adc1 14>;
 		status = "okay";
-		label = "VBAT";
 	};
 };

--- a/samples/sensor/stm32_vbat_sensor/boards/nucleo_wb55rg.overlay
+++ b/samples/sensor/stm32_vbat_sensor/boards/nucleo_wb55rg.overlay
@@ -12,7 +12,6 @@
 		ratio = <3>;
 		io-channels = <&adc1 18>;
 		status = "okay";
-		label = "VBAT";
 	};
 };
 

--- a/samples/sensor/sx9500/boards/frdm_k64f.overlay
+++ b/samples/sensor/sx9500/boards/frdm_k64f.overlay
@@ -9,6 +9,5 @@
 		compatible = "semtech,sx9500";
 		reg = <0x28>;
 		int-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
-		label = "SX9500";
 	};
 };

--- a/samples/sensor/th02/boards/frdm_k64f.overlay
+++ b/samples/sensor/th02/boards/frdm_k64f.overlay
@@ -8,12 +8,10 @@
 	th02@40 {
 		compatible = "hoperf,th02";
 		reg = <0x40>;
-		label = "TH02";
 	};
 
 	glcd: glcd@3e {
 		compatible = "seeed,grove-lcd-rgb";
-		label = "GLCD";
 		reg = <0x3e>;
 	};
 };

--- a/samples/sensor/ti_hdc/boards/nucleo_l496zg.overlay
+++ b/samples/sensor/ti_hdc/boards/nucleo_l496zg.overlay
@@ -9,7 +9,6 @@
 	ti_hdc: ti_hdc@40 {
 		compatible = "ti,hdc","ti,hdc1080";
 		reg = <0x40>;
-		label = "HDC1080";
 	};
 
 };

--- a/samples/sensor/tmp112/boards/frdm_k64f.overlay
+++ b/samples/sensor/tmp112/boards/frdm_k64f.overlay
@@ -8,6 +8,5 @@
 	tmp112@4a {
 		compatible = "ti,tmp112";
 		reg = <0x4a>;
-		label = "TMP112";
 	};
 };

--- a/samples/sensor/tmp116/boards/nucleo_f401re.overlay
+++ b/samples/sensor/tmp116/boards/nucleo_f401re.overlay
@@ -9,14 +9,12 @@
 	ti_tmp116: ti_tmp116@4b {
 		compatible = "ti,tmp116";
 		reg = <0x4B>;
-		label = "TMP116";
 		#address-cells = <1>;
 		#size-cells = <0>;
 
 		eeprom: ti_tmp116_eeprom@0 {
 			compatible = "ti,tmp116-eeprom";
 			reg = <0x0>;
-			label = "TMP116_EEPROM";
 			read-only;
 		};
 	};

--- a/samples/sensor/vcnl4040/boards/adafruit_feather_stm32f405.overlay
+++ b/samples/sensor/vcnl4040/boards/adafruit_feather_stm32f405.overlay
@@ -8,7 +8,6 @@
 	vcnl4040@60 {
 		compatible = "vishay,vcnl4040";
 		reg = <0x60>;
-		label = "VCNL4040";
 		int-gpios = <&feather_header 14 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		led-current = <200>;
 		led-duty-cycle = <320>;

--- a/samples/sensor/wsen_itds/boards/disco_l475_iot1.overlay
+++ b/samples/sensor/wsen_itds/boards/disco_l475_iot1.overlay
@@ -8,7 +8,6 @@
 	itds@18 {
 		compatible = "we,wsen-itds";
 		reg = <0x18>;
-		label = "WSEN-ITDS";
 		int-gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
 		odr = "800";
 		op-mode = "high-perf";


### PR DESCRIPTION
Label properties are not required

Signed-off-by: Kumar Gala <galak@kernel.org>