### PR TITLE
stm32 ospi supporting sfdp JESD216

### DIFF
--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -150,18 +150,11 @@
 		compatible = "st,stm32-ospi-nor";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(64)>;
+		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
-		sfdp-bfp = [
-			53 46 44 50 06 01 02 ff
-			00 06 01 10 30 00 00 ff
-			C2 00 01 04 10 01 00 ff
-			84 00 01 02 C0 00 00 ff
-			00 00 00 00
-		];
 
 		partitions {
 			   compatible = "fixed-partitions";

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -133,17 +133,10 @@
 		compatible = "st,stm32-ospi-nor";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(64)>;
+		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		status = "okay";
-		sfdp-bfp = [
-			53 46 44 50 06 01 02 ff
-			00 06 01 10 30 00 00 ff
-			C2 00 01 04 10 01 00 ff
-			84 00 01 02 C0 00 00 ff
-			00 00 00 00
-		];
 
 		partitions {
 			   compatible = "fixed-partitions";

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -154,18 +154,11 @@
 		compatible = "st,stm32-ospi-nor";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
-		size = <DT_SIZE_M(64)>;
+		size = <DT_SIZE_M(512)>; /* 64 MBytes */
 		spi-bus-width = <OSPI_OPI_MODE>;
 		data-rate = <OSPI_DTR_TRANSFER>;
 		four-byte-opcodes;
 		status = "okay";
-		sfdp-bfp = [
-			53 46 44 50 06 01 02 ff
-			00 06 01 10 30 00 00 ff
-			C2 00 01 04 10 01 00 ff
-			84 00 01 02 C0 00 00 ff
-			00 00 00 00
-		];
 
 		partitions {
 			   compatible = "fixed-partitions";

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1459,7 +1459,8 @@ static void spi_nor_process_bfp_addrbytes(const struct device *dev,
 {
 	struct flash_stm32_ospi_data *data = dev->data;
 
-	if (jesd216_bfp_addrbytes == JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_4B) {
+	if ((jesd216_bfp_addrbytes == JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_4B) ||
+	    (jesd216_bfp_addrbytes == JESD216_SFDP_BFP_DW1_ADDRBYTES_VAL_3B4B)) {
 		data->address_width = 4U;
 	} else {
 		data->address_width = 3U;

--- a/drivers/flash/jesd216.h
+++ b/drivers/flash/jesd216.h
@@ -12,6 +12,11 @@
 #include <zephyr/sys/util.h>
 #include <zephyr/types.h>
 
+/* JEDEC Read identification */
+#define JESD216_CMD_READ_ID   SPI_NOR_CMD_RDID
+#define JESD216_OCMD_READ_ID  0x9F60
+#define JESD216_READ_ID_LEN   3
+
 /* Following are structures and constants supporting the JEDEC Serial
  * Flash Discoverable Parameters standard, JESD216 and its successors,
  * available at

--- a/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
+++ b/dts/bindings/flash_controller/st,stm32-ospi-nor.yaml
@@ -12,7 +12,7 @@ description: |
                 data-mode = <OSPI_OPI_MODE>; /* access on 8 data lines */
                 data-rate = <OSPI_DTR_TRANSFER>; /* access in DTR */
                 ospi-max-frequency = <DT_FREQ_M(50)>;
-                size = <DT_SIZE_M(4)>;
+                size = <DT_SIZE_M(64*8)>; /* 512 Mbit */
                 status = "okay";
         };
 

--- a/samples/drivers/jesd216/boards/b_u585i_iot02a.conf
+++ b/samples/drivers/jesd216/boards/b_u585i_iot02a.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_FLASH_STM32_OSPI=y
+CONFIG_SPI_NOR_SFDP_RUNTIME=y
+CONFIG_SPI_NOR=n

--- a/samples/drivers/jesd216/boards/stm32h735g_disco.conf
+++ b/samples/drivers/jesd216/boards/stm32h735g_disco.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_FLASH_STM32_OSPI=y
+CONFIG_SPI_NOR_SFDP_RUNTIME=y
+CONFIG_SPI_NOR=n

--- a/samples/drivers/jesd216/boards/stm32l562e_dk.conf
+++ b/samples/drivers/jesd216/boards/stm32l562e_dk.conf
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2022 STMicroelectronics
+#
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_FLASH_STM32_OSPI=y
+CONFIG_SPI_NOR_SFDP_RUNTIME=y
+CONFIG_SPI_NOR=n

--- a/samples/drivers/jesd216/boards/stm32l562e_dk.overlay
+++ b/samples/drivers/jesd216/boards/stm32l562e_dk.overlay
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2022, STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&mx25lm51245 {
+	/* example of sfdp-bfp table Version 1.6 */
+	sfdp-bfp = [
+		53 46 44 50 06 01 02 ff
+		00 06 01 10 30 00 00 ff
+		c2 00 01 04 10 01 00 ff
+		84 00 01 02 c0 00 00 ff
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		e5 20 fb ff ff ff ff 1f
+		44 eb 08 6b 08 3b 04 bb
+		fe ff ff ff ff ff 00 ff
+		ff ff 44 eb 0c 20 0f 52
+		10 d8 00 ff d6 49 c5 00
+		81 df 04 e3 44 03 67 38
+		30 b0 30 b0 f7 bd d5 5c
+		4a 9e 29 ff f0 50 f9 85
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		00 00 00 00 00 00 00 00
+		7f ef ff ff 21 5c dc ff
+	];
+};

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -16,6 +16,10 @@
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(jedec_spi_nor)
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_qspi_nor)
 #define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(nordic_qspi_nor)
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_qspi_nor)
+#define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(st_stm32_qspi_nor)
+#elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_ospi_nor)
+#define FLASH_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(st_stm32_ospi_nor)
 #else
 #error Unsupported flash driver
 #define FLASH_NODE DT_INVALID_NODE


### PR DESCRIPTION
This PR is adding the support of the read_sfdp and read jedec ID to the stm32 ospi driver.

- The **sdfp-bfp** table is given by the octoFlash controller answering to the READ-SFDP command **or** by the DeviceTree.
If the device-tree of the octoFlash controller has a `sfdp-bfp` table as a property of its DeviceTree, NO read SFDP command is issued to the octoFlash on the bus. The drivers is processing the sdfp table coming from the DeviceTree. 
If NO table is defined as a  `sfdp-bfp` property, the drivers is issuing the  READ-SFDP command to the octoFlash controller.
(in case the READ-SFDP command fails the device cannot be initialized correcly)

The content of the `sfdp-bfp` property of the mx25lm51245 node is copied from the [macronix MX25L51245G datasheet](https://media.digikey.com/pdf/Data%20Sheets/Macronix/MX25L51245G.pdf)  (see 9-46. Read SFDP Mode (RDSFDP))

- The **jedec-id** is given by the octoFlash controller, but is overwritten by the `jedec-id` propery of the device tree (if defined).

The octo-flash of the board is able to display its description with the samples/drivers/jesd216/

According to the zephyr/dts/bindings/mtd/jedec,jesd216.yaml,  if the jedec-id or sfdp table properties are defined by the DTS, it is not read from the octoFlash.: "_This allows encoding the entire BFP block in devicetree to avoid
 reading at runtime, while still allowing the driver to pull out extra data of interest, such as erase sizes._"

Warning :  sfdp-bfp table is given as example in the device tree.

This PR follows the https://github.com/zephyrproject-rtos/zephyr/pull/47744

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/47731

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)