### PR TITLE
test,arch: fix few odd suffix include paths

### DIFF
--- a/arch/arm64/core/macro_priv.inc
+++ b/arch/arm64/core/macro_priv.inc
@@ -7,7 +7,7 @@
 #ifndef _MACRO_PRIV_INC_
 #define _MACRO_PRIV_INC_
 
-#include <arch/arm64/tpidrro_el0.h>
+#include <zephyr/arch/arm64/tpidrro_el0.h>
 
 #ifdef _ASMLANGUAGE
 

--- a/tests/unit/math_extras/tests.inc
+++ b/tests/unit/math_extras/tests.inc
@@ -5,7 +5,7 @@
  */
 
 #include <ztest.h>
-#include <sys/math_extras.h>
+#include <zephyr/sys/math_extras.h>
 #include <inttypes.h>
 
 static void VNAME(u32_add)(void)

--- a/tests/unit/util/maincxx.cxx
+++ b/tests/unit/util/maincxx.cxx
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
-#include <sys/util.h>
+#include <zephyr/ztest.h>
+#include <zephyr/sys/util.h>
 #include <string.h>
 
 #include "test.inc"

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -4,8 +4,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <ztest.h>
-#include <sys/util.h>
+#include <zephyr/ztest.h>
+#include <zephyr/sys/util.h>
 #include <string.h>
 
 /**


### PR DESCRIPTION
Fix some more legacy include paths found in files with unusual suffixes.