### PR TITLE
samples: net: Remove label property from devicetree overlays

### DIFF
--- a/samples/net/cloud/tagoio_http_post/arduino.overlay
+++ b/samples/net/cloud/tagoio_http_post/arduino.overlay
@@ -10,6 +10,5 @@
 
 	gsm: gsm-modem {
 		compatible = "zephyr,gsm-ppp";
-		label = "gsm_ppp";
 	};
 };

--- a/samples/net/cloud/tagoio_http_post/boards/sam4e_xpro.overlay
+++ b/samples/net/cloud/tagoio_http_post/boards/sam4e_xpro.overlay
@@ -10,6 +10,5 @@
 
 	gsm: gsm-modem {
 		compatible = "zephyr,gsm-ppp";
-		label = "gsm_ppp";
 	};
 };

--- a/samples/net/gsm_modem/boards/frdm_uart2_dts.overlay
+++ b/samples/net/gsm_modem/boards/frdm_uart2_dts.overlay
@@ -8,6 +8,5 @@
 	current-speed = <115200>;
 	gsm: gsm-modem {
 		compatible = "zephyr,gsm-ppp";
-		label = "gsm_ppp";
 	};
 };

--- a/samples/net/openthread/coprocessor/usb.overlay
+++ b/samples/net/openthread/coprocessor/usb.overlay
@@ -13,6 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/samples/net/wifi/boards/reel_board.overlay
+++ b/samples/net/wifi/boards/reel_board.overlay
@@ -34,7 +34,6 @@
 		status = "ok";
 		compatible = "atmel,winc1500";
 		reg = <0x0>;
-		label = "winc1500";
 		spi-max-frequency = <4000000>;
 		irq-gpios = <&gpio1 7 1>;
 		reset-gpios = <&gpio1 8 1>;

--- a/samples/net/wpan_serial/app.overlay
+++ b/samples/net/wpan_serial/app.overlay
@@ -7,6 +7,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };


### PR DESCRIPTION
"label" properties are not required.  Remove them from samples.

Signed-off-by: Kumar Gala <galak@kernel.org>