### PR TITLE
samples: module: Remove label property from devicetree overlays

### DIFF
--- a/samples/modules/tflite-micro/magic_wand/boards/litex_vexriscv.overlay
+++ b/samples/modules/tflite-micro/magic_wand/boards/litex_vexriscv.overlay
@@ -14,12 +14,10 @@ limitations under the License.
 ==============================================================================*/
 
 &i2c0 {
-	label = "I2C0";
 	reg = <0xe0003000 0x4 0xe0003004 0x4>;
 
 	adxl@1d {
 		compatible = "adi,adxl345";
-		label = "accel-0";
 		reg = <0x1d>;
 	};
 


### PR DESCRIPTION
"label" properties are not required.  Remove them from samples.

Signed-off-by: Kumar Gala <galak@kernel.org>