### PR TITLE
samples: subsys: Remove label property from devicetree overlays

### DIFF
--- a/boards/arm64/imx8mm_evk/imx8mm_evk.dts
+++ b/boards/arm64/imx8mm_evk/imx8mm_evk.dts
@@ -31,7 +31,6 @@
 };
 
 &uart2 {
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";

--- a/boards/arm64/imx8mm_evk/imx8mm_evk_jailhouse.dts
+++ b/boards/arm64/imx8mm_evk/imx8mm_evk_jailhouse.dts
@@ -37,7 +37,6 @@
 };
 
 &uart4 {
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;
 	pinctrl-names = "default";

--- a/boards/arm64/imx8mp_evk/imx8mp_evk.dts
+++ b/boards/arm64/imx8mp_evk/imx8mp_evk.dts
@@ -33,7 +33,6 @@
 
 &uart2 {
 	clocks = <&uartclk>;
-	status = "okay";
 	current-speed = <115200>;
 	pinctrl-0 = <&uart2_default>;
 	pinctrl-names = "default";

--- a/boards/arm64/imx8mp_evk/imx8mp_evk_jailhouse.dts
+++ b/boards/arm64/imx8mp_evk/imx8mp_evk_jailhouse.dts
@@ -38,7 +38,6 @@
 };
 
 &uart4 {
-	status = "okay";
 	clocks = <&uartclk>;
 	current-speed = <115200>;
 	pinctrl-0 = <&uart4_default>;

--- a/samples/subsys/fs/fat_fs/boards/esp_wrover_kit.overlay
+++ b/samples/subsys/fs/fat_fs/boards/esp_wrover_kit.overlay
@@ -26,7 +26,6 @@
 		compatible = "zephyr,mmc-spi-slot";
 		reg = <0>;
 		status = "okay";
-		label = "SDHC";
 		spi-max-frequency = <400000>;
         };
 };

--- a/samples/subsys/fs/fat_fs/boards/nrf52840_blip.overlay
+++ b/samples/subsys/fs/fat_fs/boards/nrf52840_blip.overlay
@@ -12,7 +12,6 @@
                 compatible = "zephyr,mmc-spi-slot";
                 reg = <0>;
                 status = "okay";
-                label = "SDHC0";
                 spi-max-frequency = <24000000>;
         };
 };

--- a/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
+++ b/samples/subsys/fs/littlefs/boards/nucleo_h743zi.overlay
@@ -25,7 +25,6 @@
 
 	mx25l25645g: qspi-nor-flash@0 {
 		compatible = "st,stm32-qspi-nor";
-		label = "MX25L25645G";
 		reg = <0>;
 		qspi-max-frequency = <50000000>;
 		size = <DT_SIZE_M(32*8)>;

--- a/samples/subsys/mgmt/mcumgr/smp_svr/usb.overlay
+++ b/samples/subsys/mgmt/mcumgr/smp_svr/usb.overlay
@@ -13,6 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/samples/subsys/mgmt/updatehub/arduino.overlay
+++ b/samples/subsys/mgmt/updatehub/arduino.overlay
@@ -9,6 +9,5 @@
 	current-speed = <115200>;
 	gsm: gsm-modem {
 		compatible = "zephyr,gsm-ppp";
-		label = "gsm_ppp";
 	};
 };

--- a/samples/subsys/rtio/sensor_batch_processing/app.overlay
+++ b/samples/subsys/rtio/sensor_batch_processing/app.overlay
@@ -12,7 +12,6 @@
 		vsensor0: sensor@0 {
 			compatible = "vnd,sensor";
 			reg = <0>;
-			label = "SENSOR_0";
 			sample-period = <100>;
 			sample-size = <16>;
 			max-msgs = <8>;
@@ -22,7 +21,6 @@
 		vsensor1: sensor@1 {
 			compatible = "vnd,sensor";
 			reg = <1>;
-			label = "SENSOR_1";
 			sample-period = <120>;
 			sample-size = <16>;
 			max-msgs = <4>;

--- a/samples/subsys/shell/shell_module/usb.overlay
+++ b/samples/subsys/shell/shell_module/usb.overlay
@@ -13,6 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/samples/subsys/usb/cdc_acm/app.overlay
+++ b/samples/subsys/usb/cdc_acm/app.overlay
@@ -7,6 +7,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/samples/subsys/usb/cdc_acm_composite/app.overlay
+++ b/samples/subsys/usb/cdc_acm_composite/app.overlay
@@ -7,11 +7,9 @@
 &zephyr_udc0 {
 	cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 
 	cdc_acm_uart1 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_1";
 	};
 };

--- a/samples/subsys/usb/console/app.overlay
+++ b/samples/subsys/usb/console/app.overlay
@@ -13,6 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/samples/subsys/usb/hid-cdc/app.overlay
+++ b/samples/subsys/usb/hid-cdc/app.overlay
@@ -7,11 +7,9 @@
 &zephyr_udc0 {
 	cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 
 	cdc_acm_uart1 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_1";
 	};
 };


### PR DESCRIPTION
"label" properties are not required.  Remove them from samples.

Signed-off-by: Kumar Gala <galak@kernel.org>