### PR TITLE
samples: boards: Remove label property from devicetree overlays

### DIFF
--- a/samples/boards/bbc_microbit/line_follower_robot/boards/bbc_microbit.overlay
+++ b/samples/boards/bbc_microbit/line_follower_robot/boards/bbc_microbit.overlay
@@ -13,7 +13,6 @@
 &i2c0 {
 	motorctl: motor-controller@10 {
 		compatible = "motor-controller";
-		label = "MOTORCTL";
 		reg = <0x10>;
 	};
 };

--- a/samples/boards/sensortile_box/app.overlay
+++ b/samples/boards/sensortile_box/app.overlay
@@ -13,6 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };


### PR DESCRIPTION
"label" properties are not required.  Remove them from samples.

Signed-off-by: Kumar Gala <galak@kernel.org>