### PR TITLE
drivers: i2c: esp32: Rework SDA/SDL pins as gpios in devicetree

### DIFF
--- a/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
+++ b/boards/riscv/esp32c3_devkitm/esp32c3_devkitm.dts
@@ -54,8 +54,8 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-pin = <1>;
-	scl-pin = <3>;
+	sda-gpios = <&gpio0 1 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio0 3 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/riscv/icev_wireless/icev_wireless.dts
+++ b/boards/riscv/icev_wireless/icev_wireless.dts
@@ -59,8 +59,8 @@
 
 &i2c0 {
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-pin = <2>;
-	scl-pin = <8>;
+	sda-gpios = <&gpio0 2 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio0 8 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/xtensa/esp32/esp32.dts
+++ b/boards/xtensa/esp32/esp32.dts
@@ -64,8 +64,8 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-pin = <21>;
-	scl-pin = <22>;
+	sda-gpios = <&gpio0 21 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio0 22 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -97,8 +97,8 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-pin = <21>;
-	scl-pin = <22>;
+	sda-gpios = <&gpio0 21 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio0 22 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
+++ b/boards/xtensa/heltec_wifi_lora32_v2/heltec_wifi_lora32_v2.dts
@@ -79,8 +79,8 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-pin = <4>;
-	scl-pin = <15>;
+	sda-gpios = <&gpio0 4 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio0 15 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/xtensa/odroid_go/odroid_go.dts
+++ b/boards/xtensa/odroid_go/odroid_go.dts
@@ -98,8 +98,8 @@
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	sda-pin = <4>;
-	scl-pin = <15>;
+	sda-gpios = <&gpio0 4 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio0 15 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
@@ -81,8 +81,8 @@ uext_spi: &spi2 {};
 &i2c0 {
 	status = "okay";
 	clock-frequency = <I2C_BITRATE_STANDARD>;
-	sda-pin = <16>;
-	scl-pin = <13>;
+	sda-gpios = <&gpio0 16 GPIO_OPEN_DRAIN>;
+	scl-gpios = <&gpio0 13 GPIO_OPEN_DRAIN>;
 	pinctrl-0 = <&i2c0_default>;
 	pinctrl-names = "default";
 };

--- a/dts/bindings/i2c/espressif,esp32-i2c.yaml
+++ b/dts/bindings/i2c/espressif,esp32-i2c.yaml
@@ -21,23 +21,21 @@ properties:
     pinctrl-names:
       required: true
 
-    sda-pin:
-      type: int
+    scl-gpios:
+      type: phandle-array
       required: false
       description: |
-        SDA pin information is only required if
-        the target SoC does not have support in
-        hardware for clearing the I2C bus in case
-        of communication failure
+        GPIO to which the I2C SCL signal is routed. This is only required
+        if the target SoC does not have support in hardware for clearing
+        the I2C bus in case of a communication failure
 
-    scl-pin:
-      type: int
+    sda-gpios:
+      type: phandle-array
       required: false
       description: |
-        SCL pin information is only required if
-        the target SoC does not have support in
-        hardware for clearing the I2C bus in case
-        of communication failure
+        GPIO to which the I2C SDA signal is routed. This is only required
+        if the target SoC does not have support in hardware for clearing
+        the I2C bus in case of a communication failure
 
     tx-lsb:
       type: boolean


### PR DESCRIPTION
For the !SOC_I2C_SUPPORT_HW_CLR_BUS in which we implement bus
reset via GPIOs, change the devicetree properties to be actual
gpio properties and update the code to reflect this.

Signed-off-by: Kumar Gala <galak@kernel.org>