### PR TITLE
tests: net: lib: move coap to new ztest API

### DIFF
--- a/tests/net/lib/coap/prj.conf
+++ b/tests/net/lib/coap/prj.conf
@@ -1,6 +1,7 @@
 #Testing
 CONFIG_TEST=y
 CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
 CONFIG_NET_TEST=y
 
 # Generic networking options

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -63,7 +63,7 @@ static struct sockaddr_in6 dummy_addr = {
 
 static uint8_t data_buf[2][COAP_BUF_SIZE];
 
-static void test_build_empty_pdu(void)
+ZTEST(coap, test_build_empty_pdu)
 {
 	uint8_t result_pdu[] = { 0x40, 0x01, 0x0, 0x0 };
 	struct coap_packet cpkt;
@@ -84,7 +84,7 @@ static void test_build_empty_pdu(void)
 			  "Built packet doesn't match reference packet");
 }
 
-static void test_build_simple_pdu(void)
+ZTEST(coap, test_build_simple_pdu)
 {
 	uint8_t result_pdu[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e',
 				 'n', 0xC0, 0xFF, 'p', 'a', 'y', 'l',
@@ -130,7 +130,7 @@ static void test_build_simple_pdu(void)
 }
 
 /* No options, No payload */
-static void test_parse_empty_pdu(void)
+ZTEST(coap, test_parse_empty_pdu)
 {
 	uint8_t pdu[] = { 0x40, 0x01, 0, 0 };
 	struct coap_packet cpkt;
@@ -166,7 +166,7 @@ static void test_parse_empty_pdu(void)
 }
 
 /* 1 option, No payload (No payload marker) */
-static void test_parse_empty_pdu_1(void)
+ZTEST(coap, test_parse_empty_pdu_1)
 {
 	uint8_t pdu[] = { 0x40, 0x01, 0, 0, 0x40};
 	struct coap_packet cpkt;
@@ -201,7 +201,7 @@ static void test_parse_empty_pdu_1(void)
 	zassert_equal(id, 0U, "Packet id doesn't match reference");
 }
 
-static void test_parse_simple_pdu(void)
+ZTEST(coap, test_parse_simple_pdu)
 {
 	uint8_t pdu[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
 		       0x00, 0xc1, 0x00, 0xff, 'p', 'a', 'y', 'l', 'o',
@@ -272,7 +272,7 @@ static void test_parse_simple_pdu(void)
 		      "There shouldn't be any ETAG option in the packet");
 }
 
-static void test_parse_malformed_opt(void)
+ZTEST(coap, test_parse_malformed_opt)
 {
 	uint8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
 		       0xD0 };
@@ -286,7 +286,7 @@ static void test_parse_malformed_opt(void)
 	zassert_not_equal(r, 0, "Should've failed to parse a packet");
 }
 
-static void test_parse_malformed_opt_len(void)
+ZTEST(coap, test_parse_malformed_opt_len)
 {
 	uint8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
 		       0xC1 };
@@ -300,7 +300,7 @@ static void test_parse_malformed_opt_len(void)
 	zassert_not_equal(r, 0, "Should've failed to parse a packet");
 }
 
-static void test_parse_malformed_opt_ext(void)
+ZTEST(coap, test_parse_malformed_opt_ext)
 {
 	uint8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
 		       0xE0, 0x01 };
@@ -314,7 +314,7 @@ static void test_parse_malformed_opt_ext(void)
 	zassert_not_equal(r, 0, "Should've failed to parse a packet");
 }
 
-static void test_parse_malformed_opt_len_ext(void)
+ZTEST(coap, test_parse_malformed_opt_len_ext)
 {
 	uint8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
 		       0xEE, 0x01, 0x02, 0x01};
@@ -329,7 +329,7 @@ static void test_parse_malformed_opt_len_ext(void)
 }
 
 /* 1 option, No payload (with payload marker) */
-static void test_parse_malformed_marker(void)
+ZTEST(coap, test_parse_malformed_marker)
 {
 	uint8_t pdu[] = { 0x40, 0x01, 0, 0, 0x40, 0xFF};
 	struct coap_packet cpkt;
@@ -342,7 +342,7 @@ static void test_parse_malformed_marker(void)
 	zassert_not_equal(r, 0, "Should've failed to parse a packet");
 }
 
-static void test_parse_req_build_ack(void)
+ZTEST(coap, test_parse_req_build_ack)
 {
 	uint8_t pdu[] = { 0x45, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
 		       0x00, 0xc1, 0x00, 0xff, 'p', 'a', 'y', 'l', 'o',
@@ -369,7 +369,7 @@ static void test_parse_req_build_ack(void)
 			  "Built packet doesn't match reference packet");
 }
 
-static void test_parse_req_build_empty_ack(void)
+ZTEST(coap, test_parse_req_build_empty_ack)
 {
 	uint8_t pdu[] = { 0x45, 0xA5, 0xDE, 0xAD, 't', 'o', 'k', 'e', 'n',
 		       0x00, 0xc1, 0x00, 0xff, 'p', 'a', 'y', 'l', 'o',
@@ -396,7 +396,7 @@ static void test_parse_req_build_empty_ack(void)
 			  "Built packet doesn't match reference packet");
 }
 
-static void test_match_path_uri(void)
+ZTEST(coap, test_match_path_uri)
 {
 	const char * const resource_path[] = {
 		"s",
@@ -558,7 +558,7 @@ static void verify_block1_response(struct coap_block_context *rsp_ctx,
 		      "rsp:%d, Couldn't packet total size", iter);
 }
 
-static void test_block1_size(void)
+ZTEST(coap, test_block1_size)
 {
 	struct coap_block_context req_ctx;
 	struct coap_block_context rsp_ctx;
@@ -700,7 +700,7 @@ static void verify_block2_response(struct coap_block_context *rsp_ctx,
 		      "rsp:%d, Couldn't packet total size", iter);
 }
 
-static void test_block2_size(void)
+ZTEST(coap, test_block2_size)
 {
 	struct coap_block_context req_ctx;
 	struct coap_block_context rsp_ctx;
@@ -725,7 +725,7 @@ static void test_block2_size(void)
 	}
 }
 
-static void test_retransmit_second_round(void)
+ZTEST(coap, test_retransmit_second_round)
 {
 	struct coap_packet cpkt;
 	struct coap_packet rsp;
@@ -847,7 +847,7 @@ static int server_resource_1_get(struct coap_resource *resource,
 	return 0;
 }
 
-static void test_observer_server(void)
+ZTEST(coap, test_observer_server)
 {
 	uint8_t valid_request_pdu[] = {
 		0x45, 0x01, 0x12, 0x34,
@@ -904,7 +904,7 @@ static int resource_reply_cb(const struct coap_packet *response,
 	return 0;
 }
 
-static void test_observer_client(void)
+ZTEST(coap, test_observer_client)
 {
 	struct coap_packet req;
 	struct coap_packet rsp;
@@ -963,27 +963,4 @@ static void test_observer_client(void)
 	zassert_not_null(reply, "Couldn't find a matching waiting reply");
 }
 
-void test_main(void)
-{
-	ztest_test_suite(coap_tests,
-			 ztest_unit_test(test_build_empty_pdu),
-			 ztest_unit_test(test_build_simple_pdu),
-			 ztest_unit_test(test_parse_empty_pdu),
-			 ztest_unit_test(test_parse_empty_pdu_1),
-			 ztest_unit_test(test_parse_simple_pdu),
-			 ztest_unit_test(test_parse_malformed_opt),
-			 ztest_unit_test(test_parse_malformed_opt_len),
-			 ztest_unit_test(test_parse_malformed_opt_ext),
-			 ztest_unit_test(test_parse_malformed_opt_len_ext),
-			 ztest_unit_test(test_parse_malformed_marker),
-			 ztest_unit_test(test_parse_req_build_ack),
-			 ztest_unit_test(test_parse_req_build_empty_ack),
-			 ztest_unit_test(test_match_path_uri),
-			 ztest_unit_test(test_block1_size),
-			 ztest_unit_test(test_block2_size),
-			 ztest_unit_test(test_retransmit_second_round),
-			 ztest_unit_test(test_observer_server),
-			 ztest_unit_test(test_observer_client));
-
-	ztest_run_test_suite(coap_tests);
-}
+ZTEST_SUITE(coap, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
Move tests/net/lib/coap/ to use new ztest API.

Signed-off-by: Xiao Song <songx.xiao@intel.com>