### PR TITLE
cbprintf: fix missing field initializer warning

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -527,7 +527,8 @@ static inline int cbprintf_package_copy(void *in_packaged,
 {
 	struct z_cbprintf_buf_desc buf_desc = {
 		.buf = packaged,
-		.size = len
+		.size = len,
+		.off = 0,
 	};
 
 	return cbprintf_package_convert(in_packaged, in_len,


### PR DESCRIPTION
When compiling with '-Werror=missing-field-initializers', the cbprintf
header causes an error since 'off' isn't initialized.

Signed-off-by: Yuval Peress <peress@google.com>