### PR TITLE
bluetooth: Fix bt_buf_get_rx() documentation

### DIFF
--- a/include/zephyr/bluetooth/buf.h
+++ b/include/zephyr/bluetooth/buf.h
@@ -104,8 +104,8 @@ struct bt_buf_data {
  *  This will set the buffer type so bt_buf_set_type() does not need to
  *  be explicitly called before bt_recv_prio().
  *
- *  @param type    Type of buffer. Only BT_BUF_EVT and BT_BUF_ACL_IN are
- *                 allowed.
+ *  @param type    Type of buffer. Only BT_BUF_EVT, BT_BUF_ACL_IN and BT_BUF_ISO_IN
+ *                 are allowed.
  *  @param timeout Non-negative waiting period to obtain a buffer or one of the
  *                 special values K_NO_WAIT and K_FOREVER.
  *  @return A new buffer.


### PR DESCRIPTION
Edit the 'type' parameter description that describes the
allowed input values in order to match the implementation

Signed-off-by: Ahmed Moheb <ahmed.moheb@nordicsemi.no>