### PR TITLE
samples: usb: audio application uses static dev declaration

### DIFF
--- a/samples/subsys/usb/audio/headphones_microphone/src/main.c
+++ b/samples/subsys/usb/audio/headphones_microphone/src/main.c
@@ -65,21 +65,21 @@ static const struct usb_audio_ops mic_ops = {
 
 void main(void)
 {
-	const struct device *hp_dev = device_get_binding("HEADPHONES");
+	const struct device *hp_dev = DEVICE_DT_GET_ONE(usb_audio_hp);
 	int ret;
 
 	LOG_INF("Entered %s", __func__);
-	mic_dev = device_get_binding("MICROPHONE");
+	mic_dev = DEVICE_DT_GET_ONE(usb_audio_mic);
 
-	if (!hp_dev) {
-		LOG_ERR("Can not get USB Headphones Device");
+	if (!device_is_ready(hp_dev)) {
+		LOG_ERR("Device USB Headphones is not ready");
 		return;
 	}
 
 	LOG_INF("Found USB Headphones Device");
 
-	if (!mic_dev) {
-		LOG_ERR("Can not get USB Microphone Device");
+	if (!device_is_ready(mic_dev)) {
+		LOG_ERR("Device USB Microphone is not ready");
 		return;
 	}
 

--- a/samples/subsys/usb/audio/headset/src/main.c
+++ b/samples/subsys/usb/audio/headset/src/main.c
@@ -63,10 +63,10 @@ void main(void)
 	int ret;
 
 	LOG_INF("Entered %s", __func__);
-	hs_dev = device_get_binding("HEADSET");
+	hs_dev = DEVICE_DT_GET_ONE(usb_audio_hs);
 
-	if (!hs_dev) {
-		LOG_ERR("Can not get USB Headset Device");
+	if (!device_is_ready(hs_dev)) {
+		LOG_ERR("Device USB Headset is not ready");
 		return;
 	}
 


### PR DESCRIPTION
This change the application to get device from the
compatible of the zephyr_udc0 node.
It is defined by the DTC_OVERLAY_FILE="app.overlay"

Signed-off-by: Francois Ramu <francois.ramu@st.com>