### PR TITLE
manifest: Update hal_nordic revision to use nrfx 2.9.0

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -83,7 +83,7 @@ manifest:
       groups:
         - hal
     - name: hal_nordic
-      revision: d892b442b0c74a33ffbbff0ed2a2c2122b4d3925
+      revision: f5024df56c57794ad964956a2e163bd17f7b3b40
       path: modules/hal/nordic
       groups:
         - hal


### PR DESCRIPTION
Pull in new nrfx version that integrates MDK 8.47.0

Signed-off-by: Nikodem Kastelik <nikodem.kastelik@nordicsemi.no>