### PR TITLE
tests: drivers: coredump: add delay for ACRN to show the complete log

### DIFF
--- a/tests/drivers/coredump/coredump_api/boards/acrn_ehl_crb.conf
+++ b/tests/drivers/coredump/coredump_api/boards/acrn_ehl_crb.conf
@@ -1,0 +1,4 @@
+# Give 1 second delay when running on ACRN.
+# Because the zephyr's log from ACRN console
+# cannot output completedly before this time.
+CONFIG_BOOT_DELAY=1000


### PR DESCRIPTION
Give 1 second delay when running coredump tests on ACRN. Because
the zephyr's log from ACRN console cannot output completedly
before this time.

Fixes #47010.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>