### PR TITLE
tests: build_all: Remove label property from devicetree overlays

### DIFF
--- a/tests/drivers/build_all/adc/app.overlay
+++ b/tests/drivers/build_all/adc/app.overlay
@@ -21,7 +21,6 @@
 			ref-internal-mv = <3300>;
 			ref-external1-mv = <5000>;
 			#io-channel-cells = <1>;
-			label = "ADC_EMUL_0";
 			status = "okay";
 		};
 
@@ -30,7 +29,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -39,55 +37,47 @@
 			#size-cells = <0>;
 			compatible = "vnd,i2c";
 			reg = <0x11112222 0x1000>;
-			label = "TEST_I2C_CTLR";
 			status = "okay";
 			clock-frequency = <100000>;
 
 			test_i2c_ads1013: ads1013@0 {
 				compatible = "ti,ads1013";
-				label = "ADS1013";
 				reg = <0x0>;
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_ads1014: ads1014@1 {
 				compatible = "ti,ads1014";
-				label = "ADS1014";
 				reg = <0x1>;
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_ads1015: ads1015@2 {
 				compatible = "ti,ads1015";
-				label = "ADS1015";
 				reg = <0x2>;
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_ads1113: ads1113@3 {
 				compatible = "ti,ads1113";
-				label = "ADS1113";
 				reg = <0x3>;
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_ads1114: ads1114@4 {
 				compatible = "ti,ads1114";
-				label = "ADS1114";
 				reg = <0x4>;
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_ads1115: ads1115@5 {
 				compatible = "ti,ads1115";
-				label = "ADS1115";
 				reg = <0x5>;
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_ads1119: ads1119@6 {
 				compatible = "ti,ads1119";
-				label = "ADS1119";
 				reg = <0x6>;
 				#io-channel-cells = <1>;
   			};
@@ -98,7 +88,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <2000000>;
 
@@ -117,13 +106,11 @@
 				compatible = "microchip,mcp3204";
 				reg = <0>;
 				spi-max-frequency = <0>;
-				label = "MCP3204";
 				#io-channel-cells = <1>;
 			};
 
 			test_spi_lmp90077: lmp90077@1 {
 				compatible = "ti,lmp90077";
-				label = "LMP90077";
 				reg = <0x1>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
@@ -132,7 +119,6 @@
 
 			test_spi_lmp90078: lmp90078@2 {
 				compatible = "ti,lmp90078";
-				label = "LMP90078";
 				reg = <0x2>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
@@ -141,7 +127,6 @@
 
 			test_spi_lmp90079: lmp90079@3 {
 				compatible = "ti,lmp90079";
-				label = "LMP90079";
 				reg = <0x3>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
@@ -150,7 +135,6 @@
 
 			test_spi_lmp90080: lmp90080@4 {
 				compatible = "ti,lmp90080";
-				label = "LMP90080";
 				reg = <0x4>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
@@ -159,7 +143,6 @@
 
 			test_spi_lmp90097: lmp90097@5 {
 				compatible = "ti,lmp90097";
-				label = "LMP90097";
 				reg = <0x5>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
@@ -168,7 +151,6 @@
 
 			test_spi_lmp90098: lmp90098@6 {
 				compatible = "ti,lmp90098";
-				label = "LMP90098";
 				reg = <0x6>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
@@ -177,7 +159,6 @@
 
 			test_spi_lmp90099: lmp90099@7 {
 				compatible = "ti,lmp90099";
-				label = "LMP90099";
 				reg = <0x7>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;
@@ -186,7 +167,6 @@
 
 			test_spi_lmp90100: lmp90100@8 {
 				compatible = "ti,lmp90100";
-				label = "LMP90100";
 				reg = <0x8>;
 				spi-max-frequency = <0>;
 				drdyb-gpios = <&test_gpio 0 0>;

--- a/tests/drivers/build_all/adc/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/build_all/adc/boards/qemu_cortex_m3.overlay
@@ -9,7 +9,6 @@
 	test_adc: adc@11112222 {
 		reg = <0x11112222 0x1000>;
 		compatible = "vnd,adc";
-		label = "TEST_ADC";
 		status = "okay";
 		#io-channel-cells = <1>;
 	};

--- a/tests/drivers/build_all/counter/boards/arty_a7_arm_designstart_m1.overlay
+++ b/tests/drivers/build_all/counter/boards/arty_a7_arm_designstart_m1.overlay
@@ -17,6 +17,5 @@
 		xlnx,one-timer-only = <0x0>;
 		xlnx,trig0-assert = <0x1>;
 		xlnx,trig1-assert = <0x1>;
-		label = "COUNTER_0";
 	};
 };

--- a/tests/drivers/build_all/dac/app.overlay
+++ b/tests/drivers/build_all/dac/app.overlay
@@ -20,7 +20,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -29,28 +28,24 @@
 			#size-cells = <0>;
 			compatible = "vnd,i2c";
 			reg = <0x11112222 0x1000>;
-			label = "TEST_I2C_CTLR";
 			status = "okay";
 			clock-frequency = <100000>;
 
 			test_i2c_dac43608: dac43608@1 {
 				compatible = "ti,dac43608";
 				reg = <0x1>;
-				label = "DAC43608";
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_dac53608: dac53608@2 {
 				compatible = "ti,dac53608";
 				reg = <0x2>;
-				label = "DAC53608";
 				#io-channel-cells = <1>;
 			};
 
 			test_i2c_mcp4725: mcp4725@60 {
 				compatible = "microchip,mcp4725";
 				reg = <0x60>;
-				label = "MCP4725";
 				#io-channel-cells = <1>;
 			};
 		};
@@ -60,7 +55,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <2000000>;
 
@@ -71,7 +65,6 @@
 
 			test_spi_dac60508: dac60508@0 {
 				compatible = "ti,dac60508";
-				label = "DAC60508";
 				reg = <0x0>;
 				spi-max-frequency = <0>;
 				#io-channel-cells = <1>;
@@ -88,7 +81,6 @@
 
 			test_spi_dac70508: dac70508@1 {
 				compatible = "ti,dac70508";
-				label = "DAC70508";
 				reg = <0x1>;
 				spi-max-frequency = <0>;
 				#io-channel-cells = <1>;
@@ -105,7 +97,6 @@
 
 			test_spi_dac80508: dac80508@2 {
 				compatible = "ti,dac80508";
-				label = "DAC80508";
 				reg = <0x2>;
 				spi-max-frequency = <0>;
 				#io-channel-cells = <1>;

--- a/tests/drivers/build_all/eeprom/app.overlay
+++ b/tests/drivers/build_all/eeprom/app.overlay
@@ -20,7 +20,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -29,13 +28,11 @@
 			#size-cells = <0>;
 			compatible = "vnd,i2c";
 			reg = <0x11112222 0x1000>;
-			label = "TEST_I2C_CTLR";
 			status = "okay";
 			clock-frequency = <100000>;
 
 			test_i2c_at24: at24@0 {
 				compatible = "atmel,at24";
-				label = "AT24";
 				reg = <0x0>;
 				size = <32768>;
 				pagesize = <64>;
@@ -51,7 +48,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <2000000>;
 
@@ -60,7 +56,6 @@
 
 			test_spi_at25: at25@0 {
 				compatible = "atmel,at25";
-				label = "AT25";
 				reg = <0x0>;
 				spi-max-frequency = <0>;
 				size = <32768>;

--- a/tests/drivers/build_all/ethernet/app.overlay
+++ b/tests/drivers/build_all/ethernet/app.overlay
@@ -20,7 +20,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -29,7 +28,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <2000000>;
 
@@ -40,7 +38,6 @@
 
 			test_spi_enc28j60: enc28j60@0 {
 				compatible = "microchip,enc28j60";
-				label = "ENC28J60";
 				reg = <0x0>;
 				spi-max-frequency = <0>;
 				int-gpios = <&test_gpio 0 0>;
@@ -49,7 +46,6 @@
 
 			test_spi_enc424j600: enc424j600@1 {
 				compatible = "microchip,enc424j600";
-				label = "ENC424J600";
 				reg = <0x1>;
 				spi-max-frequency = <0>;
 				int-gpios = <&test_gpio 0 0>;
@@ -58,7 +54,6 @@
 
 			test_spi_w5500: w5500@2 {
 				compatible = "wiznet,w5500";
-				label = "w5500";
 				reg = <0x2>;
 				spi-max-frequency = <0>;
 				int-gpios = <&test_gpio 0 0>;

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -20,7 +20,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -29,13 +28,11 @@
 			#size-cells = <0>;
 			compatible = "vnd,i2c";
 			reg = <0x11112222 0x1000>;
-			label = "TEST_I2C_CTLR";
 			status = "okay";
 			clock-frequency = <100000>;
 
 			test_i2c_sx1509b: sx1509b@0 {
 				compatible = "semtech,sx1509b";
-				label = "SX1509B";
 				reg = <0x0>;
 				#gpio-cells = <2>;
 				ngpios = <16>;
@@ -44,7 +41,6 @@
 
 			test_i2c_pcal6408a: pcal6408a@1 {
 				compatible = "nxp,pcal6408a";
-				label = "PCAL6408A";
 				reg = <0x1>;
 				gpio-controller;
 				#gpio-cells = <2>;
@@ -55,7 +51,6 @@
 
 			test_i2c_pca95xx: pca95xx@20 {
 				compatible = "nxp,pca95xx";
-				label = "PCA95XX";
 				reg = <0x20>;
 				gpio-controller;
 				#gpio-cells = <2>;
@@ -66,7 +61,6 @@
 			test_i2c_pca953x: pca953x@70 {
 				compatible = "ti,tca9538";
 				reg = <0x70>;
-				label = "PCA953X";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <8>;
@@ -75,7 +69,6 @@
 
 			test_i2c_mcp230xx: mcp230xx@0 {
 				compatible = "microchip,mcp230xx";
-				label = "MCP230XX";
 				reg = <0x0>;
 				gpio-controller;
 				#gpio-cells = <2>;
@@ -85,7 +78,6 @@
 			test_i2c_fxl6408: fxl6408@43 {
 				status = "okay";
 				compatible = "fcs,fxl6408";
-				label = "FXL6408";
 				reg = <0x43>;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -97,12 +89,10 @@
 				#size-cells = <0>;
 				compatible = "nuvoton,nct38xx-gpio";
 				reg = <0x72>;
-				label = "NCT3807_0";
 
 				gpio@0 {
 					compatible = "nuvoton,nct38xx-gpio-port";
 					reg = <0x0>;
-					label = "NCT3807_0_GPIO0";
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
@@ -113,7 +103,6 @@
 				gpio@1 {
 					compatible = "nuvoton,nct38xx-gpio-port";
 					reg = <0x1>;
-					label = "NCT3807_0_GPIO1";
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
@@ -126,12 +115,10 @@
 				#size-cells = <0>;
 				compatible = "nuvoton,nct38xx-gpio";
 				reg = <0x71>;
-				label = "NCT3808_0_P1";
 
 				gpio@0 {
 					compatible = "nuvoton,nct38xx-gpio-port";
 					reg = <0x0>;
-					label = "NCT3808_0_P1_GPIO0";
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
@@ -145,12 +132,10 @@
 				#size-cells = <0>;
 				compatible = "nuvoton,nct38xx-gpio";
 				reg = <0x75>;
-				label = "NCT3808_0_P2";
 
 				gpio@0 {
 					compatible = "nuvoton,nct38xx-gpio-port";
 					reg = <0x0>;
-					label = "NCT3808_0_P2_GPIO0";
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
@@ -165,7 +150,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <2000000>;
 
@@ -174,7 +158,6 @@
 
 			test_spi_mcp23s17: mcp23s17@0 {
 				compatible = "microchip,mcp23s17";
-				label = "GPIO_E0";
 				spi-max-frequency = <0>;
 				reg = <0x0>;
 				gpio-controller;
@@ -184,7 +167,6 @@
 
 			test_spi_mcp23sxx: mcp23sxx@0 {
 				compatible = "microchip,mcp23sxx";
-				label = "GPIO_E1";
 				spi-max-frequency = <0>;
 				reg = <0x0>;
 				gpio-controller;

--- a/tests/drivers/build_all/ieee802154/app.overlay
+++ b/tests/drivers/build_all/ieee802154/app.overlay
@@ -21,7 +21,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -30,7 +29,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <2000000>;
 

--- a/tests/drivers/build_all/ieee802154/spi.dtsi
+++ b/tests/drivers/build_all/ieee802154/spi.dtsi
@@ -9,7 +9,6 @@
 
 test_spi_cc1200: cc1200@0 {
 	compatible = "ti,cc1200";
-	label = "CC1200";
 	reg = <0x0>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
@@ -18,7 +17,6 @@ test_spi_cc1200: cc1200@0 {
 
 test_spi_cc2520: cc2520@1 {
 	compatible = "ti,cc2520";
-	label = "CC2520";
 	reg = <0x1>;
 	spi-max-frequency = <0>;
 	vreg-en-gpios = <&test_gpio 0 0>;
@@ -32,7 +30,6 @@ test_spi_cc2520: cc2520@1 {
 
 test_spi_dw1000: dw1000@2 {
 	compatible = "decawave,dw1000";
-	label = "DW1000";
 	reg = <0x2>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
@@ -43,7 +40,6 @@ test_spi_dw1000: dw1000@2 {
 test_spi_mcr20a: mcr20a@3 {
 	compatible = "nxp,mcr20a";
 	reg = <0x3>;
-	label = "MCR20A";
 	spi-max-frequency = <0>;
 	irqb-gpios = <&test_gpio 0 0>;
 	reset-gpios = <&test_gpio 0 0>;
@@ -53,7 +49,6 @@ test_spi_mcr20a: mcr20a@3 {
 test_spi_rf2xx: rf2xx@4 {
 	compatible = "atmel,rf2xx";
 	reg = <0x4>;
-	label = "RF2XX";
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
 	reset-gpios = <&test_gpio 0 0>;

--- a/tests/drivers/build_all/led/app.overlay
+++ b/tests/drivers/build_all/led/app.overlay
@@ -20,7 +20,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -28,7 +27,6 @@
 			compatible = "gpio-leds";
 			test_gpio_led0: test_gpio_led_0 {
 				gpios = <&test_gpio 0 0>;
-				label = "Test GPIO LED";
 			};
 		};
 	};

--- a/tests/drivers/build_all/led_strip/app.overlay
+++ b/tests/drivers/build_all/led_strip/app.overlay
@@ -24,7 +24,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -33,7 +32,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <DT_FREQ_M(2)>;
 
@@ -42,7 +40,6 @@
 			test_spi_tlc5971: tlc5971@0 {
 				status = "okay";
 				compatible = "ti,tlc59711", "ti,tlc5971";
-				label = "TLC5971";
 				spi-max-frequency = <DT_FREQ_M(1)>;
 				reg = <0x0>;
 				chain-length = <8>; // two TLC5971 devices

--- a/tests/drivers/build_all/modem/app.overlay
+++ b/tests/drivers/build_all/modem/app.overlay
@@ -20,14 +20,12 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
 		test_uart: uart@55556666 {
 			compatible = "vnd,serial";
 			reg = <0x55556666 0x1000>;
-			label = "TEST_UART_CTLR";
 			status = "okay";
 
 			#include "uart.dtsi"

--- a/tests/drivers/build_all/modem/uart.dtsi
+++ b/tests/drivers/build_all/modem/uart.dtsi
@@ -8,7 +8,6 @@
 
 test_hl7800: hl7800 {
 	compatible = "swir,hl7800";
-	label = "hl7800";
 	mdm-reset-gpios = <&test_gpio 0 0>;
 	mdm-wake-gpios = <&test_gpio 0 0>;
 	mdm-pwr-on-gpios = <&test_gpio 0 0>;
@@ -21,7 +20,6 @@ test_hl7800: hl7800 {
 
 test_wnc_m14a2a: wncm14a2a {
 	compatible = "wnc,m14a2a";
-	label = "wnc-m14a2a";
 	mdm-boot-mode-sel-gpios = <&test_gpio 0 0>;
 	mdm-power-gpios = <&test_gpio 0 0>;
 	mdm-keep-awake-gpios = <&test_gpio 0 0>;
@@ -31,7 +29,6 @@ test_wnc_m14a2a: wncm14a2a {
 
 test_sara_r4: sara_r4 {
 	compatible = "u-blox,sara-r4";
-	label = "ublox-sara-r4";
 
 	mdm-power-gpios = <&test_gpio 0 0>;
 	mdm-reset-gpios = <&test_gpio 0 0>;
@@ -39,14 +36,12 @@ test_sara_r4: sara_r4 {
 
 test_simcom_sim7080: sim7080 {
 	compatible = "simcom,sim7080";
-	label = "simcom,sim7080";
 
 	mdm-power-gpios = <&test_gpio 0 0>;
 };
 
 test_quectel_bg9x: quectel_bg9x {
 	compatible = "quectel,bg9x";
-	label = "quectel,bg9x";
 
 	mdm-power-gpios = <&test_gpio 0 0>;
 	mdm-reset-gpios = <&test_gpio 0 0>;
@@ -54,10 +49,8 @@ test_quectel_bg9x: quectel_bg9x {
 
 test_gsm_ppp: gsm_ppp {
 	compatible = "zephyr,gsm-ppp";
-	label = "gsm_ppp";
 };
 
 test_esp_at: esp_at {
 	compatible = "espressif,esp-at";
-	label = "espressif,esp-at";
 };

--- a/tests/drivers/build_all/pwm/boards/arty_a7_arm_designstart_m1.overlay
+++ b/tests/drivers/build_all/pwm/boards/arty_a7_arm_designstart_m1.overlay
@@ -17,7 +17,6 @@
 		xlnx,one-timer-only = <0x0>;
 		xlnx,trig0-assert = <0x1>;
 		xlnx,trig1-assert = <0x0>;
-		label = "PWM_0";
 		#pwm-cells = <3>;
 	};
 };

--- a/tests/drivers/build_all/pwm/boards/qemu_cortex_m3.overlay
+++ b/tests/drivers/build_all/pwm/boards/qemu_cortex_m3.overlay
@@ -10,7 +10,6 @@
 		compatible = "vnd,pwm";
 		#pwm-cells = <3>;
 		reg = <0x11112222 0x1000>;
-		label = "TEST_PWM_CTLR";
 		status = "okay";
 	};
 };

--- a/tests/drivers/build_all/sensor/app.overlay
+++ b/tests/drivers/build_all/sensor/app.overlay
@@ -20,7 +20,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 
 			#include "gpio.dtsi"
@@ -31,7 +30,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,i2c";
 			reg = <0x11112222 0x1000>;
-			label = "TEST_I2C_CTLR";
 			status = "okay";
 			clock-frequency = <100000>;
 
@@ -43,7 +41,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR";
 			status = "okay";
 			clock-frequency = <2000000>;
 
@@ -120,7 +117,6 @@
 		test_uart: uart@55556666 {
 			compatible = "vnd,serial";
 			reg = <0x55556666 0x1000>;
-			label = "TEST_UART_CTLR";
 			status = "okay";
 
 			#include "uart.dtsi"
@@ -131,7 +127,6 @@
 			reg = <0x66660000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			label = "TEST_W1_MASTER";
 			status = "okay";
 
 			#include "w1.dtsi"
@@ -140,7 +135,6 @@
 		dht22 {
 			compatible = "aosong,dht";
 			status = "okay";
-			label = "DHT22";
 			dio-gpios = <&test_gpio 0 0>;
 			/* dht22; */
 		};

--- a/tests/drivers/build_all/sensor/gpio.dtsi
+++ b/tests/drivers/build_all/sensor/gpio.dtsi
@@ -9,5 +9,4 @@
 test_gpio_sm351lt: sm351lt0 {
 	compatible = "honeywell,sm351lt";
 	gpios = <&test_gpio 0 0>;
-	label = "SM351LT0";
 };

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -8,27 +8,23 @@
 
 test_i2c_adt7420: adt7420@0 {
 	compatible = "adi,adt7420";
-	label = "ADT7420";
 	reg = <0x0>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_adxl345: adxl345@1 {
 	compatible = "adi,adxl345";
-	label = "ADXL345";
 	reg = <0x1>;
 };
 
 test_i2c_adxl372: adxl372@2 {
 	compatible = "adi,adxl372";
-	label = "ADXL372";
 	reg = <0x2>;
 	int1-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_ccs811: ccs811@3 {
 	compatible = "ams,ccs811";
-	label = "CCS811";
 	reg = <0x3>;
 	wake-gpios = <&test_gpio 0 0>;
 	reset-gpios = <&test_gpio 0 0>;
@@ -37,32 +33,27 @@ test_i2c_ccs811: ccs811@3 {
 
 test_i2c_ens210: ens210@4 {
 	compatible = "ams,ens210";
-	label = "ENS210";
 	reg = <0x4>;
 };
 
 test_i2c_iaqcore: iaqcore@5 {
 	compatible = "ams,iaqcore";
-	label = "IAQCORE";
 	reg = <0x5>;
 };
 
 test_i2c_bme280: bme280@7 {
 	compatible = "bosch,bme280";
-	label = "BME280";
 	reg = <0x7>;
 };
 
 test_i2c_apds9960: apds9960@9 {
 	compatible = "avago,apds9960";
-	label = "APDS9960";
 	reg = <0x9>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_bma280: bma280@a {
 	compatible = "bosch,bma280";
-	label = "BMA280";
 	reg = <0xa>;
 	int1-gpios = <&test_gpio 0 0>;
 	/* is-bmc150; */
@@ -70,46 +61,39 @@ test_i2c_bma280: bma280@a {
 
 test_i2c_bmc150_magn: bmc150_magn@b {
 	compatible = "bosch,bmc150_magn";
-	label = "BMC150_MAGN";
 	reg = <0xb>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_ak8975: ak8975@c {
 	compatible = "asahi-kasei,ak8975";
-	label = "AK8975";
 	reg = <0xc>;
 };
 
 test_i2c_bme680: bme680@d {
 	compatible = "bosch,bme680";
-	label = "BME680";
 	reg = <0xd>;
 };
 
 test_i2c_bmg160: bmg160@e {
 	compatible = "bosch,bmg160";
-	label = "BMG160";
 	reg = <0xe>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_bmm150: bmm150@f {
 	compatible = "bosch,bmm150";
-	label = "BMM150";
 	reg = <0xf>;
 };
 
 test_i2c_ft5336: ft5336@10 {
 	compatible = "focaltech,ft5336";
-	label = "FT5336";
 	reg = <0x10>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_ht16k33: ht16k33@11 {
 	compatible = "holtek,ht16k33";
-	label = "HT16K33";
 	reg = <0x11>;
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -118,26 +102,22 @@ test_i2c_ht16k33: ht16k33@11 {
 
 test_i2c_hmc5883l: hmc5883l@12 {
 	compatible = "honeywell,hmc5883l";
-	label = "HMC5883L";
 	reg = <0x12>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_hp206c: hp206c@13 {
 	compatible = "hoperf,hp206c";
-	label = "HP206C";
 	reg = <0x13>;
 };
 
 test_i2c_th02: th02@14 {
 	compatible = "hoperf,th02";
-	label = "TH02";
 	reg = <0x14>;
 };
 
 test_i2c_mpu6050: mpu6050@15 {
 	compatible = "invensense,mpu6050";
-	label = "MPU6050";
 	reg = <0x15>;
 	int-gpios = <&test_gpio 0 0>;
 };
@@ -151,12 +131,10 @@ test_i2c_mpu9250: mpu9250@1e {
 	gyro-fs = <250>;
 	accel-fs = <2>;
 	accel-dlpf="5.05";
-	label = "MPU9250";
 };
 
 test_i2c_ina219: ina219@40 {
 	compatible = "ti,ina219";
-	label = "INA219";
 	reg = <0x40>;
 	brng = <0>;
 	pg = <0>;
@@ -168,46 +146,39 @@ test_i2c_ina219: ina219@40 {
 
 test_i2c_isl29035: isl29035@17 {
 	compatible = "isil,isl29035";
-	label = "ISL29035";
 	reg = <0x17>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_max30101: max30101@18 {
 	compatible = "maxim,max30101";
-	label = "MAX30101";
 	reg = <0x18>;
 };
 
 test_i2c_max44009: max44009@19 {
 	compatible = "maxim,max44009";
-	label = "MAX44009";
 	reg = <0x19>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_ms5607: ms5607@76 {
 	compatible = "meas,ms5607";
-	label = "MS5607";
 	reg = <0x76>;
 };
 
 test_i2c_ms5837: ms5837@1a {
 	compatible = "meas,ms5837";
-	label = "MS5837";
 	reg = <0x1a>;
 };
 
 test_i2c_mcp9808: mcp9808@1b {
 	compatible = "microchip,mcp9808";
-	label = "MCP9808";
 	reg = <0x1b>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_fxas21002: fxas21002@1c {
 	compatible = "nxp,fxas21002";
-	label = "FXAS21002";
 	reg = <0x1c>;
 	int1-gpios = <&test_gpio 0 0>;
 	int2-gpios = <&test_gpio 0 0>;
@@ -215,7 +186,6 @@ test_i2c_fxas21002: fxas21002@1c {
 
 test_i2c_fxos8700: fxos8700@1d {
 	compatible = "nxp,fxos8700";
-	label = "FXOS8700";
 	reg = <0x1d>;
 	reset-gpios = <&test_gpio 0 0>;
 	int1-gpios = <&test_gpio 0 0>;
@@ -224,34 +194,29 @@ test_i2c_fxos8700: fxos8700@1d {
 
 test_i2c_pca9633: pca9633@1f {
 	compatible = "nxp,pca9633";
-	label = "PCA9633";
 	reg = <0x1f>;
 };
 
 test_i2c_amg88xx: amg88xx@20 {
 	compatible = "panasonic,amg88xx";
-	label = "AMG88XX";
 	reg = <0x20>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_sx9500: sx9500@22 {
 	compatible = "semtech,sx9500";
-	label = "SX9500";
 	reg = <0x22>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_sgp40: sgp40@59 {
 	compatible = "sensirion,sgp40";
-	label = "SGP40";
 	reg = <0x59>;
 	enable-selftest;
 };
 
 test_i2c_sht3xd: sht3xd@23 {
 	compatible = "sensirion,sht3xd";
-	label = "SHT3XD";
 	reg = <0x23>;
 	alert-gpios = <&test_gpio 0 0>;
 };
@@ -259,13 +224,11 @@ test_i2c_sht3xd: sht3xd@23 {
 test_i2c_sht4xd: sht4x@44 {
 	compatible = "sensirion,sht4x";
 	reg = <0x44>;
-	label = "SHT4X";
 	repeatability = <2>;
 };
 
 test_i2c_shtc3: SHTC3@70 {
 	compatible = "sensirion,shtcx";
-	label = "SHTC3";
 	reg = <0x70>;
 	chip = "shtc3";
 	measure-mode = "normal";
@@ -274,59 +237,50 @@ test_i2c_shtc3: SHTC3@70 {
 
 test_i2c_si7006: si7006@24 {
 	compatible = "silabs,si7006";
-	label = "SI7006";
 	reg = <0x24>;
 };
 
 test_i2c_si7055: si7055@40 {
 	compatible = "silabs,si7055";
-	label = "SI7055";
 	reg = <0x40>;
 };
 
 test_i2c_si7060: si7060@25 {
 	compatible = "silabs,si7060";
-	label = "SI7060";
 	reg = <0x25>;
 };
 
 test_i2c_si7210: si7010@30 {
 	compatible = "silabs,si7210";
-	label = "SI7210";
 	reg = <0x30>;
 };
 
 test_i2c_hts221: hts221@27 {
 	compatible = "st,hts221";
-	label = "HTS221";
 	reg = <0x27>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_iis2dlpc: iis2dlpc@28 {
 	compatible = "st,iis2dlpc";
-	label = "IIS2DLPC";
 	reg = <0x28>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_iis2mdc: iis2mdc@29 {
 	compatible = "st,iis2mdc";
-	label = "IIS2MDC";
 	reg = <0x29>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_ism330dhcx: ism330dhcx@2a {
 	compatible = "st,ism330dhcx";
-	label = "ISM330DHCX";
 	reg = <0x2a>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lis2dh: lis2dh@2b {
 	compatible = "st,lis2dh";
-	label = "LIS2DH";
 	reg = <0x2b>;
 	irq-gpios = <&test_gpio 0 0>;
 	/* disconnect-sdo-sa0-pull-up; */
@@ -334,68 +288,58 @@ test_i2c_lis2dh: lis2dh@2b {
 
 test_i2c_lis2dh12: lis2dh12@2c {
 	compatible = "st,lis2dh12";
-	label = "LIS2DH12";
 	reg = <0x2c>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lis2ds12: lis2ds12@2d {
 	compatible = "st,lis2ds12";
-	label = "LIS2DS12";
 	reg = <0x2d>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lis2dw12: lis2dw12@2e {
 	compatible = "st,lis2dw12";
-	label = "LIS2DW12";
 	reg = <0x2e>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lis2mdl: lis2mdl@2f {
 	compatible = "st,lis2mdl";
-	label = "LIS2MDL";
 	reg = <0x2f>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lis3dh: lis3dh@30 {
 	compatible = "st,lis3dh";
-	label = "LIS3DH";
 	reg = <0x30>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lis3mdl_magn: lis3mdl-magn@31 {
 	compatible = "st,lis3mdl-magn";
-	label = "LIS3MDL-MAGN";
 	reg = <0x31>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lps22hb_press: lps22hb-press@32 {
 	compatible = "st,lps22hb-press";
-	label = "LPS22HB-PRESS";
 	reg = <0x32>;
 };
 
 test_i2c_lps22hh: lps22hh@33 {
 	compatible = "st,lps22hh";
-	label = "LPS22HH";
 	reg = <0x33>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lps25hb_press: lps25hb-press@34 {
 	compatible = "st,lps25hb-press";
-	label = "LPS25HB-PRESS";
 	reg = <0x34>;
 };
 
 test_i2c_lsm303agr_accel: lsm303agr-accel@35 {
 	compatible = "st,lsm303agr-accel";
-	label = "LSM303AGR-ACCEL";
 	reg = <0x35>;
 	irq-gpios = <&test_gpio 0 0>;
 	/* disconnect-sdo-sa0-pull-up; */
@@ -403,7 +347,6 @@ test_i2c_lsm303agr_accel: lsm303agr-accel@35 {
 
 test_i2c_lsm303dlhc_accel: lsm303dlhc-accel@36 {
 	compatible = "st,lsm303dlhc-accel";
-	label = "LSM303DLHC-ACCEL";
 	reg = <0x36>;
 	irq-gpios = <&test_gpio 0 0>;
 	/* disconnect-sdo-sa0-pull-up; */
@@ -411,143 +354,121 @@ test_i2c_lsm303dlhc_accel: lsm303dlhc-accel@36 {
 
 test_i2c_lsm303dlhc_magn: lsm303dlhc-magn@37 {
 	compatible = "st,lsm303dlhc-magn";
-	label = "LSM303DLHC-MAGN";
 	reg = <0x37>;
 };
 
 test_i2c_lsm6ds0: lsm6ds0@38 {
 	compatible = "st,lsm6ds0";
-	label = "LSM6DS0";
 	reg = <0x38>;
 };
 
 test_i2c_lsm6dsl: lsm6dsl@39 {
 	compatible = "st,lsm6dsl";
-	label = "LSM6DSL";
 	reg = <0x39>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lsm6dso: lsm6dso@3a {
 	compatible = "st,lsm6dso";
-	label = "LSM6DSO";
 	reg = <0x3a>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lsm9ds0_gyro: lsm9ds0-gyro@3b {
 	compatible = "st,lsm9ds0-gyro";
-	label = "LSM9DS0-GYRO";
 	reg = <0x3b>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_lsm9ds0_mfd: lsm9ds0-mfd@3c {
 	compatible = "st,lsm9ds0-mfd";
-	label = "LSM9DS0-MFD";
 	reg = <0x3c>;
 	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_stts751: stts751@3d {
 	compatible = "st,stts751";
-	label = "STTS751";
 	reg = <0x3d>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_vl53l0x: vl53l0x@3e {
 	compatible = "st,vl53l0x";
-	label = "VL53L0X";
 	reg = <0x3e>;
 	xshut-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_hdc: hdc@3f {
 	compatible = "ti,hdc";
-	label = "HDC";
 	reg = <0x3f>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_hdc2010: hdc2010@40 {
 	compatible = "ti,hdc2010";
-	label = "HDC2010";
 	reg = <0x40>;
 };
 
 test_i2c_hdc2021: hdc2021@40 {
 	compatible = "ti,hdc2021";
-	label = "HDC2021";
 	reg = <0x40>;
 };
 
 test_i2c_hdc2022: hdc2022@40 {
 	compatible = "ti,hdc2022";
-	label = "HDC2022";
 	reg = <0x40>;
 };
 
 test_i2c_hdc2080: hdc2080@40 {
 	compatible = "ti,hdc2080";
-	label = "HDC2080";
 	reg = <0x40>;
 };
 
 test_i2c_lp3943: lp3943@40 {
 	compatible = "ti,lp3943";
-	label = "LP3943";
 	reg = <0x40>;
 };
 
 test_i2c_lp5562: lp5562@41 {
 	compatible = "ti,lp5562";
-	label = "LP5562";
 	reg = <0x41>;
 };
 
 test_i2c_opt3001: opt3001@42 {
 	compatible = "ti,opt3001";
-	label = "OPT3001";
 	reg = <0x42>;
 };
 
 test_i2c_tlv320dac: tlv320dac@43 {
 	compatible = "ti,tlv320dac";
-	label = "TLV320DAC";
 	reg = <0x43>;
 	reset-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_tmp007: tmp007@44 {
 	compatible = "ti,tmp007";
-	label = "TMP007";
 	reg = <0x44>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_tmp108: tmp108@48 {
 	compatible = "ti,tmp108";
-	label = "TMP108";
 	reg = <0x48>;
 	alert-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_tmp112: tmp112@45 {
 	compatible = "ti,tmp112";
-	label = "TMP112";
 	reg = <0x45>;
 };
 
 test_i2c_tmp116: tmp116@46 {
 	compatible = "ti,tmp116";
-	label = "TMP116";
 	reg = <0x46>;
 };
 
 test_i2c_bq274xx: bq27xx@47 {
 	compatible = "ti,bq274xx";
-	label = "BQ274XX";
 	reg = <0x47>;
 	design-voltage = <3700>;
 	design-capacity = <1800>;
@@ -558,26 +479,22 @@ test_i2c_bq274xx: bq27xx@47 {
 
 test_i2c_mpr: mpr@18 {
 	compatible = "honeywell,mpr";
-	label = "MPR";
 	reg = <0x18>;
 };
 
 test_i2c_dps310: dps310@48 {
 		compatible = "infineon,dps310";
-		label = "DPS310";
 		reg = <0x48>;
 };
 
 test_i2c_iis2dh: iis2dh@18 {
 	compatible = "st,iis2dh";
-	label = "IIS2DH";
 	reg = <0x18>;
 	drdy-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_iis2iclx: iis2iclx@6a {
 	compatible = "st,iis2iclx";
-	label = "IIS2ICLX";
 	reg = <0x6a>;
 	drdy-gpios = <&test_gpio 0 0>;
 	int-pin = <1>;
@@ -585,7 +502,6 @@ test_i2c_iis2iclx: iis2iclx@6a {
 
 test_i2c_itds: itds@18 {
 	compatible = "we,wsen-itds";
-	label = "WSEN-ITDS";
 	reg = <0x18>;
 	int-gpios = <&test_gpio 0 0>;
 	odr = "800";
@@ -594,7 +510,6 @@ test_i2c_itds: itds@18 {
 
 test_i2c_max17055: max17055@49 {
 	compatible = "maxim,max17055";
-	label = "max17055";
 	reg = <0x49>;
 	design-capacity = <1500>;
 	design-voltage = <3860>;
@@ -607,7 +522,6 @@ test_i2c_max17055: max17055@49 {
 
 test_i2c_max17262: max17262@36 {
 	compatible = "maxim,max17262";
-	label = "MAX17262";
 	reg = <0x36>;
 	design-voltage = <3600>;
 	desired-voltage = <3600>;
@@ -620,26 +534,22 @@ test_i2c_max17262: max17262@36 {
 
 test_i2c_vcnl4040: vcnl4040@60 {
 	compatible = "vishay,vcnl4040";
-	label = "VCNL4040";
 	reg = <0x60>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_bmi160: bmi160@4a {
 	compatible = "bosch,bmi160";
-	label = "BMI160";
 	reg = <0x4a>;
 };
 
 test_i2c_bmi270: bmi270@4a {
 	compatible = "bosch,bmi270";
-	label = "BMI270";
 	reg = <0x4a>;
 };
 
 test_i2c_fdc2x1x: fdc2x1x@2a {
 	compatible = "ti,fdc2x1x";
-	label = "FDC2X1X";
 	reg = <0x2a>;
 	intb-gpios = <&test_gpio 0 0>;
 	deglitch = <5>;
@@ -656,26 +566,22 @@ test_i2c_fdc2x1x: fdc2x1x@2a {
 
 test_i2c_bmp388: bmp388@4c {
 	compatible = "bosch,bmp388";
-	label = "BMP388";
 	reg = <0x4c>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_sbc_gauge: sbsgauge@4d {
 	compatible = "sbs,sbs-gauge";
-	label = "SBSGAUGE";
 	reg = <0x4d>;
 };
 
 test_i2c_lm75: lm75@4e {
 	compatible = "lm75";
-	label = "LM75";
 	reg = <0x4e>;
 };
 
 test_i2c_ina230: ina230@4f {
 	compatible = "ti,ina230";
-	label = "INA230";
 	reg = <0x4f>;
 	config = <0>;
 	current-lsb = <1>;
@@ -687,14 +593,12 @@ test_i2c_ina230: ina230@4f {
 
 test_i2c_lm77: lm77@50 {
 	compatible = "lm77";
-	label = "LM77";
 	reg = <0x50>;
 	int-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_ina231: ina231@51 {
 	compatible = "ti,ina230";
-	label = "INA231";
 	reg = <0x51>;
 	config = <0>;
 	current-lsb = <1>;
@@ -706,7 +610,6 @@ test_i2c_ina231: ina231@51 {
 
 test_i2c_ina237: ina237@52 {
 	compatible = "ti,ina237";
-	label = "INA237";
 	reg = <0x52>;
 	config = <0>;
 	current-lsb = <1>;
@@ -716,6 +619,5 @@ test_i2c_ina237: ina237@52 {
 
 test_i2c_max31875: max31875@53 {
 	compatible = "maxim,max31875";
-	label = "MAX31875";
 	reg = <0x53>;
 };

--- a/tests/drivers/build_all/sensor/spi.dtsi
+++ b/tests/drivers/build_all/sensor/spi.dtsi
@@ -8,7 +8,6 @@
 
 test_spi_adxl362: adxl362@0 {
 	compatible = "adi,adxl362";
-	label = "ADXL362";
 	reg = <0x0>;
 	spi-max-frequency = <0>;
 	int1-gpios = <&test_gpio 0 0>;
@@ -16,7 +15,6 @@ test_spi_adxl362: adxl362@0 {
 
 test_spi_adxl372: adxl372@1 {
 	compatible = "adi,adxl372";
-	label = "ADXL372";
 	reg = <0x1>;
 	spi-max-frequency = <0>;
 	int1-gpios = <&test_gpio 0 0>;
@@ -24,14 +22,12 @@ test_spi_adxl372: adxl372@1 {
 
 test_spi_apa102: apa102@2 {
 	compatible = "apa,apa102";
-	label = "APA102";
 	reg = <0x2>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_rf2xx: rf2xx@4 {
 	compatible = "atmel,rf2xx";
-	label = "RF2XX";
 	reg = <0x4>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -43,7 +39,6 @@ test_spi_rf2xx: rf2xx@4 {
 
 test_spi_winc1500: winc1500@5 {
 	compatible = "atmel,winc1500";
-	label = "WINC1500";
 	reg = <0x5>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -53,14 +48,12 @@ test_spi_winc1500: winc1500@5 {
 
 test_spi_bme280: bme280@6 {
 	compatible = "bosch,bme280";
-	label = "BME280";
 	reg = <0x6>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_bmi160: bmi160@7 {
 	compatible = "bosch,bmi160";
-	label = "BMI160";
 	reg = <0x7>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
@@ -68,21 +61,18 @@ test_spi_bmi160: bmi160@7 {
 
 test_spi_lpd8803: lpd8803@8 {
 	compatible = "greeled,lpd8803";
-	label = "LPD8803";
 	reg = <0x8>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_lpd8806: lpd8806@9 {
 	compatible = "greeled,lpd8806";
-	label = "LPD8806";
 	reg = <0x9>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_gd7965: gd7965@a {
 	compatible = "gooddisplay,gd7965";
-	label = "GD7965";
 	reg = <0xa>;
 	spi-max-frequency = <0>;
 	height = <0>;
@@ -98,7 +88,6 @@ test_spi_gd7965: gd7965@a {
 
 test_spi_eswifi: eswifi@c {
 	compatible = "inventek,eswifi";
-	label = "ESWIFI";
 	reg = <0xc>;
 	spi-max-frequency = <0>;
 	resetn-gpios = <&test_gpio 0 0>;
@@ -109,7 +98,6 @@ test_spi_eswifi: eswifi@c {
 
 test_spi_spi_nor: spi-nor@d {
 	compatible = "jedec,spi-nor";
-	label = "SPI-NOR";
 	reg = <0xd>;
 	spi-max-frequency = <0>;
 	wp-gpios = <&test_gpio 0 0>;
@@ -123,14 +111,12 @@ test_spi_spi_nor: spi-nor@d {
 
 test_spi_ms5607: ms5607@e {
 	compatible = "meas,ms5607";
-	label = "MS5607";
 	reg = <0xe>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_mcr20a: mcr20a@13 {
 	compatible = "nxp,mcr20a";
-	label = "MCR20A";
 	reg = <0x13>;
 	spi-max-frequency = <0>;
 	irqb-gpios = <&test_gpio 0 0>;
@@ -139,7 +125,6 @@ test_spi_mcr20a: mcr20a@13 {
 
 test_spi_sx1276: sx1276@14 {
 	compatible = "semtech,sx1276";
-	label = "SX1276";
 	reg = <0x14>;
 	spi-max-frequency = <0>;
 	reset-gpios = <&test_gpio 0 0>;
@@ -149,7 +134,6 @@ test_spi_sx1276: sx1276@14 {
 
 test_spi_iis2dlpc: iis2dlpc@17 {
 	compatible = "st,iis2dlpc";
-	label = "IIS2DLPC";
 	reg = <0x17>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
@@ -157,7 +141,6 @@ test_spi_iis2dlpc: iis2dlpc@17 {
 
 test_spi_iis2mdc: iis2mdc@18 {
 	compatible = "st,iis2mdc";
-	label = "IIS2MDC";
 	reg = <0x18>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
@@ -165,7 +148,6 @@ test_spi_iis2mdc: iis2mdc@18 {
 
 test_spi_iis3dhhc: iis3dhhc@19 {
 	compatible = "st,iis3dhhc";
-	label = "IIS3DHHC";
 	reg = <0x19>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -173,7 +155,6 @@ test_spi_iis3dhhc: iis3dhhc@19 {
 
 test_spi_ism330dhcx: ism330dhcx@1a {
 	compatible = "st,ism330dhcx";
-	label = "ISM330DHCX";
 	reg = <0x1a>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
@@ -181,7 +162,6 @@ test_spi_ism330dhcx: ism330dhcx@1a {
 
 test_spi_lis2dh: lis2dh@1b {
 	compatible = "st,lis2dh";
-	label = "LIS2DH";
 	reg = <0x1b>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -190,7 +170,6 @@ test_spi_lis2dh: lis2dh@1b {
 
 test_spi_lis2ds12: lis2ds12@1c {
 	compatible = "st,lis2ds12";
-	label = "LIS2DS12";
 	reg = <0x1c>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -198,7 +177,6 @@ test_spi_lis2ds12: lis2ds12@1c {
 
 test_spi_lis2dw12: lis2dw12@1d {
 	compatible = "st,lis2dw12";
-	label = "LIS2DW12";
 	reg = <0x1d>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -206,7 +184,6 @@ test_spi_lis2dw12: lis2dw12@1d {
 
 test_spi_lis2mdl: lis2mdl@1e {
 	compatible = "st,lis2mdl";
-	label = "LIS2MDL";
 	reg = <0x1e>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -214,7 +191,6 @@ test_spi_lis2mdl: lis2mdl@1e {
 
 test_spi_lps22hh: lps22hh@1f {
 	compatible = "st,lps22hh";
-	label = "LPS22HH";
 	reg = <0x1f>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
@@ -222,7 +198,6 @@ test_spi_lps22hh: lps22hh@1f {
 
 test_spi_lsm303agr_accel: lsm303agr-accel@20 {
 	compatible = "st,lsm303agr-accel";
-	label = "LSM303AGR-ACCEL";
 	reg = <0x20>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -231,7 +206,6 @@ test_spi_lsm303agr_accel: lsm303agr-accel@20 {
 
 test_spi_lsm6dsl: lsm6dsl@21 {
 	compatible = "st,lsm6dsl";
-	label = "LSM6DSL";
 	reg = <0x21>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -239,7 +213,6 @@ test_spi_lsm6dsl: lsm6dsl@21 {
 
 test_spi_lsm6dso: lsm6dso@22 {
 	compatible = "st,lsm6dso";
-	label = "LSM6DSO";
 	reg = <0x22>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -247,7 +220,6 @@ test_spi_lsm6dso: lsm6dso@22 {
 
 test_spi_ws2812_spi: ws2812-spi@2e {
 	compatible = "worldsemi,ws2812-spi";
-	label = "WS2812-SPI";
 	reg = <0x2e>;
 	spi-max-frequency = <0>;
 	spi-one-frame = <0>;
@@ -258,7 +230,6 @@ test_spi_ws2812_spi: ws2812-spi@2e {
 
 test_spi_bt_hci_spi: bt-hci-spi@2f {
 	compatible = "zephyr,bt-hci-spi";
-	label = "BT-HCI-SPI";
 	reg = <0x2f>;
 	spi-max-frequency = <0>;
 	irq-gpios = <&test_gpio 0 0>;
@@ -267,14 +238,12 @@ test_spi_bt_hci_spi: bt-hci-spi@2f {
 
 test_spi_mmc_spi_slot: mmc-spi-slot@30 {
 	compatible = "zephyr,mmc-spi-slot";
-	label = "MMC-SPI-SLOT";
 	reg = <0x30>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_iis2dh: iis2dh@31 {
 	compatible = "st,iis2dh";
-	label = "IIS2DH";
 	reg = <0x31>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
@@ -282,7 +251,6 @@ test_spi_iis2dh: iis2dh@31 {
 
 test_spi_iis2iclx: iis2iclx@37 {
 	compatible = "st,iis2iclx";
-	label = "IIS2ICLX";
 	reg = <0x37>;
 	spi-max-frequency = <0>;
 	drdy-gpios = <&test_gpio 0 0>;
@@ -291,7 +259,6 @@ test_spi_iis2iclx: iis2iclx@37 {
 
 test_spi_icm42605: icm42605@38 {
 	compatible = "invensense,icm42605";
-	label = "ICM42605";
 	reg = <0x38>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
@@ -299,21 +266,18 @@ test_spi_icm42605: icm42605@38 {
 
 test_spi_max6675: max6675@38 {
 	compatible = "maxim,max6675";
-	label = "MAX6675";
 	reg = <0x38>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_bmi270: bmi270@39 {
 	compatible = "bosch,bmi270";
-	label = "BMI270";
 	reg = <0x39>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_bmp388: bmp388@3a {
 	compatible = "bosch,bmp388";
-	label = "BMP388";
 	reg = <0x3a>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
@@ -321,14 +285,12 @@ test_spi_bmp388: bmp388@3a {
 
 test_spi_i3g4250d: i3g4250d@3b {
 	compatible = "st,i3g4250d";
-	label = "I3G4250D";
 	reg = <0x3b>;
 	spi-max-frequency = <0>;
 };
 
 test_spi_icm42670: icm42670@3c {
 	compatible = "invensense,icm42670";
-	label = "ICM42670";
 	reg = <0x3c>;
 	spi-max-frequency = <0>;
 	int-gpios = <&test_gpio 0 0>;
@@ -340,7 +302,6 @@ test_spi_icm42670: icm42670@3c {
 
 test_spi_bme680: bme680@3c {
 	compatible = "bosch,bme680";
-	label = "BME680";
 	reg = <0x3c>;
 	spi-max-frequency = <0>;
 };

--- a/tests/drivers/build_all/sensor/uart.dtsi
+++ b/tests/drivers/build_all/sensor/uart.dtsi
@@ -10,10 +10,8 @@ test_uart_mhz19b {
 	compatible = "winsen,mhz19b";
 	maximum-range = <10000>;
 	abc-on;
-	label = "MHZ19B";
 };
 
 test_uart_pms7003 {
 	compatible = "plantower,pms7003";
-	label = "PMS7003";
 };

--- a/tests/drivers/build_all/sensor/w1.dtsi
+++ b/tests/drivers/build_all/sensor/w1.dtsi
@@ -10,6 +10,5 @@ test-w1-ds18b20 {
 	compatible = "maxim,ds18b20";
 	family-code = <0x28>;
 	resolution = <12>;
-	label = "DS18B20";
 	status = "okay";
 };

--- a/tests/drivers/build_all/video/app.overlay
+++ b/tests/drivers/build_all/video/app.overlay
@@ -20,7 +20,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO_1";
 			status = "okay";
 		};
 
@@ -29,26 +28,22 @@
 			#size-cells = <0>;
 			compatible = "vnd,i2c";
 			reg = <0x11112222 0x1000>;
-			label = "TEST_I2C_CTLR";
 			status = "okay";
 			clock-frequency = <100000>;
 
 			test_i2c_mt9m114: mt9m114@0 {
 				compatible = "aptina,mt9m114";
-				label = "MT9M114";
 				reg = <0>;
 			};
 
 			test_i2c_ov2640: ov2640@1 {
 				compatible = "ovti,ov2640";
-				label = "OV2640";
 				reg = <0x1>;
 				reset-gpios = <&test_gpio 0 0>;
 			};
 
 			test_i2c_ov7725: ov7725@2 {
 				compatible = "ovti,ov7725";
-				label = "OV7725";
 				reg = <0x2>;
 				reset-gpios = <&test_gpio 0 0>;
 			};


### PR DESCRIPTION
"label" properties are not required.  Remove them from tests.

Signed-off-by: Kumar Gala <galak@kernel.org>