### PR TITLE
Various documentation fixes

### DIFF
--- a/.github/workflows/doc-build.yml
+++ b/.github/workflows/doc-build.yml
@@ -36,7 +36,7 @@ jobs:
   doc-build-html:
     name: "Documentation Build (HTML)"
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     concurrency:
       group: doc-build-html-${{ github.ref }}
       cancel-in-progress: true
@@ -117,7 +117,7 @@ jobs:
     name: "Documentation Build (PDF)"
     runs-on: ubuntu-latest
     container: texlive/texlive:latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     concurrency:
       group: doc-build-pdf-${{ github.ref }}
       cancel-in-progress: true

--- a/boards/riscv/litex_vexriscv/doc/index.rst
+++ b/boards/riscv/litex_vexriscv/doc/index.rst
@@ -43,9 +43,6 @@ The implementation is optimized for FPGA chips.
 More information about the project can be found on
 `VexRiscv's website <https://github.com/SpinalHDL/VexRiscv>`_.
 
-LiteX VexRiscv
-##############
-
 To run the ZephyrOS on the VexRiscv CPU, it is necessary to prepare the
 bitstream for the FPGA on a Digilent Arty A7-35 Board. This can be achieved
 using the

--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -32,7 +32,7 @@ For example, using the :ref:`qemu_cortex_m3` board to build :ref:`hello_world`:
 
    # --cmake-only here just forces CMake to run, skipping the
    # build process to save time.
-   west build -b qemu_cortex_m3 -s samples/hello_world --cmake-only
+   west build -b qemu_cortex_m3 samples/hello_world --cmake-only
 
 You can change ``qemu_cortex_m3`` to match your board.
 

--- a/doc/develop/west/sign.rst
+++ b/doc/develop/west/sign.rst
@@ -26,8 +26,8 @@ from the :file:`zephyrproject` workspace you created in the
 
 .. code-block:: console
 
-   west build -b YOUR_BOARD -s bootloader/mcuboot/boot/zephyr -d build-mcuboot
-   west build -b YOUR_BOARD -s zephyr/samples/hello_world -d build-hello-signed -- \
+   west build -b YOUR_BOARD bootloader/mcuboot/boot/zephyr -d build-mcuboot
+   west build -b YOUR_BOARD zephyr/samples/hello_world -d build-hello-signed -- \
         -DCONFIG_BOOTLOADER_MCUBOOT=y \
         -DCONFIG_MCUBOOT_SIGNATURE_KEY_FILE=\"bootloader/mcuboot/root-rsa-2048.pem\"
 

--- a/samples/subsys/shell/shell_module/Kconfig
+++ b/samples/subsys/shell/shell_module/Kconfig
@@ -3,7 +3,7 @@
 # Copyright (c) 2018 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-mainmenu "Logger sample application"
+mainmenu "Shell module sample application"
 
 menu "Application configuration"
 


### PR DESCRIPTION
Hi, few non-functional fixes I bumped into recently:
- double title in a board document
- wrong (copypasted?) sample mainmenu title
- obsolete flag showing up in the docs
- increase documentation build timeout to 45 minutes