### PR TITLE
samples: boards: nrf: battery: Remove uneccesary if-def

### DIFF
--- a/samples/boards/nrf/battery/src/main.c
+++ b/samples/boards/nrf/battery/src/main.c
@@ -14,7 +14,6 @@
 
 /** A discharge curve specific to the power source. */
 static const struct battery_level_point levels[] = {
-#if DT_NODE_HAS_PROP(DT_INST(0, voltage_divider), io_channels)
 	/* "Curve" here eyeballed from captured data for the [Adafruit
 	 * 3.7v 2000 mAh](https://www.adafruit.com/product/2011) LIPO
 	 * under full load that started with a charge of 3.96 V and
@@ -30,11 +29,6 @@ static const struct battery_level_point levels[] = {
 	{ 10000, 3950 },
 	{ 625, 3550 },
 	{ 0, 3100 },
-#else
-	/* Linear from maximum voltage to minimum voltage. */
-	{ 10000, 3600 },
-	{ 0, 1700 },
-#endif
 };
 
 static const char *now_str(void)


### PR DESCRIPTION
Remove if-def since io-channels is a required property of
the voltage-devider compatible so the else case won't happen.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>