### PR TITLE
tests: i2c: Remove label property from devicetree overlays

### DIFF
--- a/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/mec1501modular_assy6885.overlay
@@ -8,7 +8,6 @@
 	eeprom0: eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
-		label = "EEPROM_0";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -21,7 +20,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
-		label = "EEPROM_1";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_f091rc.overlay
@@ -4,7 +4,6 @@
 	eeprom0: eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
-		label = "EEPROM_0";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -17,7 +16,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
-		label = "EEPROM_1";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_g071rb.overlay
@@ -17,7 +17,6 @@
 	eeprom0: eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
-		label = "EEPROM_0";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -29,7 +28,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
-		label = "EEPROM_1";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;

--- a/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/nucleo_l476rg.overlay
@@ -17,7 +17,6 @@
 	eeprom0: eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
-		label = "EEPROM_0";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -29,7 +28,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
-		label = "EEPROM_1";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;

--- a/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/rpi_pico.overlay
@@ -8,7 +8,6 @@
 	eeprom0: eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
-		label = "EEPROM_0";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -20,7 +19,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
-		label = "EEPROM_1";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;

--- a/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
+++ b/tests/drivers/i2c/i2c_target_api/boards/stm32f072b_disco.overlay
@@ -4,7 +4,6 @@
 	eeprom0: eeprom@54 {
 		compatible = "atmel,at24";
 		reg = <0x54>;
-		label = "EEPROM_0";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -17,7 +16,6 @@
 	eeprom1: eeprom@56 {
 		compatible = "atmel,at24";
 		reg = <0x56>;
-		label = "EEPROM_1";
 		size = <1024>;
 		pagesize = <16>;
 		address-width = <8>;

--- a/tests/drivers/i2c/i2c_tca954x/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/i2c/i2c_tca954x/boards/nrf52840dk_nrf52840.overlay
@@ -10,13 +10,11 @@
 		compatible = "ti,tca9546a";
 		reg = <0x77>;
 		status = "okay";
-		label = "i2c_mux";
 		#address-cells = <1>;
 		#size-cells = <0>;
 
 		ch0: mux_i2c@0 {
 			compatible = "ti,tca9546a-channel";
-			label = "mux_dw_0";
 			reg = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -24,7 +22,6 @@
 
 		ch1: mux_i2c@1 {
 			compatible = "ti,tca9546a-channel";
-			label = "mux_dw_1";
 			reg = <1>;
 			#address-cells = <1>;
 			#size-cells = <0>;


### PR DESCRIPTION
"label" properties are not required.  Remove them from tests.

Signed-off-by: Kumar Gala <galak@kernel.org>