### PR TITLE
tests: maxim_ds3231_api: Remove label property from devicetree overlays

### DIFF
--- a/tests/drivers/counter/maxim_ds3231_api/boards/efr32mg_sltb004a.overlay
+++ b/tests/drivers/counter/maxim_ds3231_api/boards/efr32mg_sltb004a.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpiof 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/tests/drivers/counter/maxim_ds3231_api/boards/frdm_k64f.overlay
+++ b/tests/drivers/counter/maxim_ds3231_api/boards/frdm_k64f.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpioe 26 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/tests/drivers/counter/maxim_ds3231_api/boards/nrf51dk_nrf51422.overlay
+++ b/tests/drivers/counter/maxim_ds3231_api/boards/nrf51dk_nrf51422.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpio0 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/tests/drivers/counter/maxim_ds3231_api/boards/nrf52840dk_nrf52840.overlay
+++ b/tests/drivers/counter/maxim_ds3231_api/boards/nrf52840dk_nrf52840.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpio0 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/tests/drivers/counter/maxim_ds3231_api/boards/nucleo_l476rg.overlay
+++ b/tests/drivers/counter/maxim_ds3231_api/boards/nucleo_l476rg.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpioa 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/tests/drivers/counter/maxim_ds3231_api/boards/particle_xenon.overlay
+++ b/tests/drivers/counter/maxim_ds3231_api/boards/particle_xenon.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpio1 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		32k-gpios = <&gpio1 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};


### PR DESCRIPTION
"label" properties are not required.  Remove them from tests.

Signed-off-by: Kumar Gala <galak@kernel.org>