### PR TITLE
tests: drivers: Remove label property from devicetree overlays

### DIFF
--- a/tests/drivers/adc/adc_api/boards/native_posix.overlay
+++ b/tests/drivers/adc/adc_api/boards/native_posix.overlay
@@ -11,7 +11,6 @@
 		ref-internal-mv = <3300>;
 		ref-external1-mv = <5000>;
 		#io-channel-cells = <1>;
-		label = "ADC_0";
 		status = "okay";
 	};
 };

--- a/tests/drivers/adc/adc_emul/app.overlay
+++ b/tests/drivers/adc/adc_emul/app.overlay
@@ -11,7 +11,6 @@
 		ref-internal-mv = <3300>;
 		ref-external1-mv = <5000>;
 		#io-channel-cells = <1>;
-		label = "ADC_0";
 		status = "okay";
 	};
 };

--- a/tests/drivers/bbram/boards/qemu_riscv32.overlay
+++ b/tests/drivers/bbram/boards/qemu_riscv32.overlay
@@ -9,6 +9,5 @@
 		compatible = "ite,it8xxx2-bbram";
 		status = "okay";
 		reg = <0x80 0xff>;
-		label = "BBRAM";
 	};
 };

--- a/tests/drivers/bbram/emul/boards/native_posix.overlay
+++ b/tests/drivers/bbram/emul/boards/native_posix.overlay
@@ -9,6 +9,5 @@
 		compatible = "zephyr,bbram-emul";
 		status = "okay";
 		size = <0xff>;
-		label = "BBRAM";
 	};
 };

--- a/tests/drivers/coredump/coredump_api/app.overlay
+++ b/tests/drivers/coredump/coredump_api/app.overlay
@@ -7,14 +7,12 @@
 / {
 	coredump_device0: coredump-device0 {
 		compatible = "zephyr,coredump";
-		label = "coredump_device_0";
 		coredump-type = "COREDUMP_TYPE_MEMCPY";
 		status = "okay";
 	};
 
 	coredump_devicecb: coredump-device-cb {
 		compatible = "zephyr,coredump";
-		label = "coredump_device_cb";
 		coredump-type = "COREDUMP_TYPE_CALLBACK";
 		status = "okay";
 		memory-regions = <0x0 0x4>;

--- a/tests/drivers/coredump/coredump_api/boards/qemu_riscv32.overlay
+++ b/tests/drivers/coredump/coredump_api/boards/qemu_riscv32.overlay
@@ -7,7 +7,6 @@
 / {
 	coredump_device0: coredump-device0 {
 		compatible = "zephyr,coredump";
-		label = "coredump_device_0";
 		coredump-type = "COREDUMP_TYPE_MEMCPY";
 		status = "okay";
 
@@ -17,7 +16,6 @@
 
 	coredump_device1: coredump-device1 {
 		compatible = "zephyr,coredump";
-		label = "coredump_device_1";
 		coredump-type = "COREDUMP_TYPE_MEMCPY";
 		status = "okay";
 
@@ -26,7 +24,6 @@
 
 	coredump_devicecb: coredump-device-cb {
 		compatible = "zephyr,coredump";
-		label = "coredump_device_cb";
 		coredump-type = "COREDUMP_TYPE_CALLBACK";
 		status = "okay";
 		memory-regions = <0x0 0x4>;

--- a/tests/drivers/eeprom/boards/native_posix.overlay
+++ b/tests/drivers/eeprom/boards/native_posix.overlay
@@ -12,7 +12,6 @@
 	i2c_eeprom: eeprom@57 {
 		compatible = "atmel,at24";
 		reg = <0x57>;
-		label = "eeprom";
 		size = <256>;
 		pagesize = <8>;
 		address-width = <8>;

--- a/tests/drivers/entropy/api/entropy_bt_hci.overlay
+++ b/tests/drivers/entropy/api/entropy_bt_hci.overlay
@@ -12,7 +12,6 @@
 
 	rng_hci: entropy_bt_hci {
 		compatible = "zephyr,bt-hci-entropy";
-		label = "bt_hci_entropy";
 		status = "okay";
 	};
 };

--- a/tests/drivers/espi/boards/native_posix.overlay
+++ b/tests/drivers/espi/boards/native_posix.overlay
@@ -9,6 +9,5 @@
 		status = "okay";
 		compatible = "zephyr,espi-emul-espi-host";
 		reg = <0x0>;
-		label = "ESPI_HOST";
 	};
 };

--- a/tests/drivers/flash/boards/nrf52840dk_mx25l51245g.overlay
+++ b/tests/drivers/flash/boards/nrf52840dk_mx25l51245g.overlay
@@ -43,7 +43,6 @@
 		/* MX25L5145G supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <2000000>;
-		label = "MX25L51245G";
 		jedec-id = [c2 20 1A];
 		sfdp-bfp = [
 			e5 20 fb ff  1f ff ff ff  44 eb 08 6b  08 3b 04 bb

--- a/tests/drivers/i2s/i2s_speed/boards/mimxrt1170_evk_cm7.overlay
+++ b/tests/drivers/i2s/i2s_speed/boards/mimxrt1170_evk_cm7.overlay
@@ -1,16 +1,10 @@
 /* i2s_speed with CONFIG_I2S_TEST_SEPARATE_DEVICES=y uses two I2S peripherals:
  *	I2S_0 is the receiver    - uses SAI1 peripheral on RT1170
  *	I2S_1 is the transmitter - uses SAI4 peripheral
- * Therefore, change labels from SoC defaults to SAI4 as I2S_1,
- * and SAI2 becomes I2S_3
  */
-&sai2 {
-	label = "I2S_3";
-};
 
 /* Enable SAI4, and set clocks to match SAI1 */
 &sai4 {
-	label = "I2S_1";
 	status = "okay";
 	clocks = < &ccm 0x2003 0x2184 0x6 >;
 	podf = < 0x4 >;

--- a/tests/drivers/sensor/accel/boards/native_posix.overlay
+++ b/tests/drivers/sensor/accel/boards/native_posix.overlay
@@ -14,7 +14,6 @@
 		compatible = "bosch,bmi160";
 		spi-max-frequency = <50000000>;
 		reg = <3>;
-		label = "accel-spi";
 	};
 };
 
@@ -22,6 +21,5 @@
 	bmi_i2c: bmi@68 {
 		compatible = "bosch,bmi160";
 		reg = <0x68>;
-		label = "accel-i2c";
 	};
 };

--- a/tests/drivers/sensor/sbs_gauge/boards/nucleo_f070rb.overlay
+++ b/tests/drivers/sensor/sbs_gauge/boards/nucleo_f070rb.overlay
@@ -10,7 +10,6 @@
 	smartbattery0: smartbattery@b {
 		compatible = "sbs,sbs-gauge";
 		reg = <0x0B>;
-		label = "SMARTBATTERY";
 		status = "okay";
 	};
 };

--- a/tests/drivers/spi/dt_spec/app.overlay
+++ b/tests/drivers/spi/dt_spec/app.overlay
@@ -16,7 +16,6 @@
 			gpio-controller;
 			reg = <0xdeadbeef 0x1000>;
 			#gpio-cells = <0x2>;
-			label = "TEST_GPIO";
 			status = "okay";
 		};
 
@@ -25,7 +24,6 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x33334444 0x1000>;
-			label = "TEST_SPI_CTLR_CS";
 			status = "okay";
 			clock-frequency = <2000000>;
 
@@ -33,7 +31,6 @@
 
 			test_spi_dev_cs: test-spi-dev@0 {
 				compatible = "vnd,spi-device";
-				label = "TEST_SPI_DEV_0";
 				reg = <0>;
 				spi-max-frequency = <2000000>;
 			};
@@ -44,13 +41,11 @@
 			#size-cells = <0>;
 			compatible = "vnd,spi";
 			reg = <0x55556666 0x1000>;
-			label = "TEST_SPI_CTLR_NO_CS";
 			status = "okay";
 			clock-frequency = <2000000>;
 
 			test_spi_dev_no_cs: test-spi-dev@0 {
 				compatible = "vnd,spi-device";
-				label = "TEST_SPI_DEV_NO_CS";
 				reg = <0>;
 				spi-max-frequency = <2000000>;
 			};

--- a/tests/drivers/uart/uart_async_api/boards/segger_rtt.overlay
+++ b/tests/drivers/uart/uart_async_api/boards/segger_rtt.overlay
@@ -7,25 +7,21 @@
 
 	rtt0: rtt_chan0 {
 		compatible = "segger,rtt-uart";
-		label = "rtt_chan0";
 		status = "okay";
 	};
 
 	rtt1: rtt_chan1 {
 		compatible = "segger,rtt-uart";
-		label = "rtt_chan1";
 		status = "okay";
 	};
 
 	rtt2: rtt_chan2 {
 		compatible = "segger,rtt-uart";
-		label = "rtt_chan2";
 		status = "okay";
 	};
 
 	rtt3: rtt_chan3 {
 		compatible = "segger,rtt-uart";
-		label = "rtt_chan3";
 		status = "okay";
 	};
 };

--- a/tests/drivers/uart/uart_basic_api/usb.overlay
+++ b/tests/drivers/uart/uart_basic_api/usb.overlay
@@ -13,6 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/tests/drivers/virtualization/ivshmem/app.overlay
+++ b/tests/drivers/virtualization/ivshmem/app.overlay
@@ -7,7 +7,6 @@
 
 / {
 	pcie0 {
-		label = "PCIE_0";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";
@@ -17,7 +16,6 @@
 			compatible = "qemu,ivshmem";
 
 			reg = <PCIE_BDF_NONE PCIE_ID(0x1af4,0x1110)>;
-			label = "IVSHMEM";
 			status = "okay";
 		};
 	};

--- a/tests/drivers/w1/w1_api/boards/serial_overlay.dtsi
+++ b/tests/drivers/w1/w1_api/boards/serial_overlay.dtsi
@@ -11,13 +11,11 @@
 		compatible = "zephyr,w1-serial";
 		#address-cells = <1>;
 		#size-cells = <0>;
-		label = "W1_0";
 		status = "okay";
 
 		slave_1: dummy-slave-1 {
 			compatible = "test-w1-dummy-slave";
 			family-code = <0x28>;
-			label = "DUMMY_DEVICE_1";
 			overdrive-speed;
 			status = "okay";
 		};

--- a/tests/drivers/watchdog/wdt_basic_api/boards/nrf52840dk_nrf52840_counter.overlay
+++ b/tests/drivers/watchdog/wdt_basic_api/boards/nrf52840dk_nrf52840_counter.overlay
@@ -18,6 +18,5 @@
 		compatible = "zephyr,counter-watchdog";
 		status = "okay";
 		counter = <&timer0>;
-		label = "WDT_COUNTER";
 	};
 };


### PR DESCRIPTION
"label" properties are not required.  Remove them from tests.

Signed-off-by: Kumar Gala <galak@kernel.org>