### PR TITLE
soc/xtensa/intel_adsp: WOVCRO clock support fixes

### DIFF
--- a/dts/bindings/clock/intel,cavs-shim-clkctl.yaml
+++ b/dts/bindings/clock/intel,cavs-shim-clkctl.yaml
@@ -9,7 +9,7 @@ properties:
     cavs-clkctl-clk-wovcro:
         type: int
         required: false
-        description: Index of WOVCRO clock encoding in the encoding array (cAVS 2.5 only).
+        description: Index of WOVCRO clock encoding in the encoding array (if wovcro-supported is true).
 
     cavs-clkctl-clk-lpro:
         type: int
@@ -40,3 +40,8 @@ properties:
         type: int
         required: true
         description: Index for the lowest frequency clock.
+
+    wovcro-supported:
+        type: boolean
+        description: |
+          If WoV clock ring oscillator is supported.

--- a/dts/xtensa/intel/intel_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_cavs25.dtsi
@@ -76,6 +76,7 @@
 		cavs-clkctl-freq-mask = <0x10 0x20000000 0x80000000>;
 		cavs-clkctl-freq-default = <2>;
 		cavs-clkctl-freq-lowest = <0>;
+		wovcro-supported;
 	};
 
 	soc {

--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -63,6 +63,4 @@ config ADSP_TRACE_SIMCALL
 	  of an enclosing simulator process.  All window contents will
 	  remain identical.
 
-
-
 endif # SOC_FAMILY_INTEL_ADSP

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -83,7 +83,7 @@ void cavs_clock_init(void)
 	if (CAVS_SHIM.clkctl & CAVS_CLKCTL_WOVCRO)
 		CAVS_SHIM.clkctl = CAVS_SHIM.clkctl & ~CAVS_CLKCTL_WOVCRO;
 	else
-		platform_lowest_freq_idx = CAVS_CLOCK_FREQ_WOVCRO;
+		platform_lowest_freq_idx = CAVS_CLOCK_FREQ_LPRO;
 #endif
 
 	for (i = 0; i < CONFIG_MP_NUM_CPUS; i++) {

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -78,7 +78,7 @@ void cavs_clock_init(void)
 	uint32_t platform_lowest_freq_idx = CAVS_CLOCK_FREQ_LOWEST;
 	int i;
 
-#ifdef CONFIG_SOC_INTEL_CAVS_V25
+#ifdef CAVS_CLOCK_HAS_WOVCRO
 	CAVS_SHIM.clkctl |= CAVS_CLKCTL_WOVCRO;
 	if (CAVS_SHIM.clkctl & CAVS_CLKCTL_WOVCRO)
 		CAVS_SHIM.clkctl = CAVS_SHIM.clkctl & ~CAVS_CLKCTL_WOVCRO;

--- a/soc/xtensa/intel_adsp/common/include/cavs-clk.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-clk.h
@@ -47,9 +47,13 @@ struct cavs_clock_info *cavs_clocks_get(void);
 
 #define CAVS_CLOCK_FREQ(name)   DT_PROP(DT_NODELABEL(clkctl), cavs_clkctl_clk_##name)
 
+#if DT_PROP(DT_NODELABEL(clkctl), wovcro_supported)
+#define CAVS_CLOCK_HAS_WOVCRO
+#endif
+
 #define CAVS_CLOCK_FREQ_LPRO  CAVS_CLOCK_FREQ(lpro)
 #define CAVS_CLOCK_FREQ_HPRO  CAVS_CLOCK_FREQ(hpro)
-#ifdef CONFIG_SOC_INTEL_CAVS_V25
+#ifdef CAVS_CLOCK_HAS_WOVCRO
 #define CAVS_CLOCK_FREQ_WOVCRO  CAVS_CLOCK_FREQ(wovcro)
 #endif
 

--- a/tests/drivers/clock_control/cavs_clock/src/main.c
+++ b/tests/drivers/clock_control/cavs_clock/src/main.c
@@ -28,7 +28,7 @@ static void test_cavs_clock_driver(void)
 	cavs_clock_set_freq(CAVS_CLOCK_FREQ_HPRO);
 	check_clocks(clocks, CAVS_CLOCK_FREQ_HPRO);
 
-#ifdef CONFIG_SOC_INTEL_CAVS_V25
+#ifdef CAVS_CLOCK_HAS_WOVCRO
 	cavs_clock_set_freq(CAVS_CLOCK_FREQ_WOVCRO);
 	check_clocks(clocks, CAVS_CLOCK_FREQ_WOVCRO);
 #endif
@@ -49,7 +49,7 @@ static void test_cavs_clock_control(void)
 					   CAVS_CLOCK_FREQ_HPRO);
 	check_clocks(clocks, CAVS_CLOCK_FREQ_HPRO);
 
-#ifdef CONFIG_SOC_INTEL_CAVS_V25
+#ifdef CAVS_CLOCK_HAS_WOVCRO
 	clock_control_set_rate(dev, NULL, (clock_control_subsys_rate_t)
 					   CAVS_CLOCK_FREQ_WOVCRO);
 	check_clocks(clocks, CAVS_CLOCK_FREQ_WOVCRO);


### PR DESCRIPTION
- Fix clock selection when obtaining WOVCRO clock fails;
- Enable WOVCRO based on feature support instead of SOC version.