### PR TITLE
sample: s2ram: Use harness remote

### DIFF
--- a/samples/boards/nrf/s2ram/sample.yaml
+++ b/samples/boards/nrf/s2ram/sample.yaml
@@ -5,3 +5,4 @@ common:
 tests:
   sample.boards.nrf.s2ram:
     platform_allow: nrf5340dk_nrf5340_cpuapp
+    harness: remote


### PR DESCRIPTION
The sample requires a manual user interaction. Make CI skipping that by
requiring a remote harness (the user).

Signed-off-by: Carlo Caione <ccaione@baylibre.com>

Fixes: #47852