### PR TITLE
MAINTAINERS: Add stephanosio as MAINTAINERS file collaborator

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1262,6 +1262,7 @@ MAINTAINERS file:
         - MaureenHelm
     collaborators:
         - nashif
+        - stephanosio
     files:
         - MAINTAINERS.yml
     labels:


### PR DESCRIPTION
This commit adds @stephanosio as a collaborator for the MAINTAINERS
file area so that he is automatically notified of any changes to the
maintainer and collaborator list and can update the GitHub permissions
accordingly.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

p.s. the "update the GitHub permissions accordingly" part will eventually be automated in the future via the "Zephyr Infrastructure Manager" utility; but, for now, this should do.