### PR TITLE
dts: x86: Remove label property from devicetrees

### DIFF
--- a/dts/x86/intel/apollo_lake.dtsi
+++ b/dts/x86/intel/apollo_lake.dtsi
@@ -36,7 +36,6 @@
 	};
 
 	pcie0 {
-		label = "PCIE_0";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";
@@ -48,7 +47,6 @@
 			reg = <PCIE_BDF(0,0x18,0) PCIE_ID(0x8086,0x5abc)>;
 			reg-shift = <2>;
 
-			label = "UART_0";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -62,7 +60,6 @@
 			reg = <PCIE_BDF(0,0x18,1) PCIE_ID(0x8086,0x5abe)>;
 			reg-shift = <2>;
 
-			label = "UART_1";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -77,7 +74,6 @@
 			reg = <PCIE_BDF(0,0x18,2) PCIE_ID(0x8086,0x5ac0)>;
 			reg-shift = <2>;
 
-			label = "UART_2";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -92,7 +88,6 @@
 			reg = <PCIE_BDF(0,0x18,3) PCIE_ID(0x8086,0x5aee)>;
 			reg-shift = <2>;
 
-			label = "UART_3";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -109,7 +104,6 @@
 			reg = <PCIE_BDF(0,0x16,0) PCIE_ID(0x8086,0x5aac)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_0";
 
 			status = "okay";
 		};
@@ -122,7 +116,6 @@
 			reg = <PCIE_BDF(0,0x16,1) PCIE_ID(0x8086,0x5aae)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_1";
 
 			status = "okay";
 		};
@@ -135,7 +128,6 @@
 			reg = <PCIE_BDF(0,0x16,2) PCIE_ID(0x8086,0x5ab0)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_2";
 
 			status = "okay";
 		};
@@ -148,7 +140,6 @@
 			reg = <PCIE_BDF(0,0x16,3) PCIE_ID(0x8086,0x5ab2)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_3";
 
 			status = "okay";
 		};
@@ -161,7 +152,6 @@
 			reg = <PCIE_BDF(0,0x17,0) PCIE_ID(0x8086,0x5ab4)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_4";
 
 			status = "okay";
 		};
@@ -174,7 +164,6 @@
 			reg = <PCIE_BDF(0,0x17,1) PCIE_ID(0x8086,0x5ab6)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_5";
 
 			status = "okay";
 		};
@@ -187,7 +176,6 @@
 			reg = <PCIE_BDF(0,0x17,2) PCIE_ID(0x8086,0x5ab8)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_6";
 
 			status = "okay";
 		};
@@ -200,7 +188,6 @@
 			reg = <PCIE_BDF(0,0x17,3) PCIE_ID(0x8086,0x5aba)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_7";
 
 			status = "okay";
 		};
@@ -215,7 +202,6 @@
 		vtd: vtd@fed65000 {
 			compatible = "intel,vt-d";
 
-			label = "VTD_0";
 			reg = <0xfed65000 0x1000>;
 
 			status = "okay";
@@ -227,7 +213,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_N_000";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -243,7 +228,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_N_032";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -259,7 +243,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_N_064";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -275,7 +258,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_NW_000";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -291,7 +273,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_NW_032";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -307,7 +288,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_NW_064";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -323,7 +303,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_W_000";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -339,7 +318,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_W_032";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -355,7 +333,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_SW_000";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -372,7 +349,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_SW_032";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -383,7 +359,6 @@
 		};
 
 		hpet: hpet@fed00000 {
-			label = "HPET";
 			compatible = "intel,hpet";
 			reg = <0xfed00000 0x400>;
 			interrupts = <2 IRQ_TYPE_FIXED_EDGE_RISING 4>;
@@ -393,7 +368,6 @@
 		};
 
 		counter: counter@70 {
-			label = "CMOS";
 			compatible = "motorola,mc146818";
 			reg = <0x70 0x0D 0x71 0x0D>;
 

--- a/dts/x86/intel/atom.dtsi
+++ b/dts/x86/intel/atom.dtsi
@@ -42,7 +42,6 @@
 		uart0: uart@3f8 {
 			compatible = "ns16550";
 			reg = <0x000003f8 0x100>;
-			label = "UART_0";
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
@@ -53,7 +52,6 @@
 		uart1: uart@2f8 {
 			compatible = "ns16550";
 			reg = <0x000002f8 0x100>;
-			label = "UART_1";
 			clock-frequency = <1843200>;
 			interrupts = <3 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
@@ -62,7 +60,6 @@
 		};
 
 		hpet: hpet@fed00000 {
-			label = "HPET";
 			compatible = "intel,hpet";
 			reg = <0xfed00000 0x400>;
 			interrupts = <2 IRQ_TYPE_FIXED_EDGE_RISING 4>;
@@ -72,7 +69,6 @@
 		};
 
 		counter: counter@70 {
-			label = "CMOS";
 			compatible = "motorola,mc146818";
 			reg = <0x70 0x0D 0x71 0x0D>;
 

--- a/dts/x86/intel/elkhart_lake.dtsi
+++ b/dts/x86/intel/elkhart_lake.dtsi
@@ -30,7 +30,6 @@
 
 	ibecc: ibecc {
 	       compatible = "intel,ibecc";
-	       label = "ibecc";
 	       status = "okay";
 	};
 
@@ -42,7 +41,6 @@
 	};
 
 	pcie0 {
-		label = "PCIE_0";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";
@@ -52,7 +50,6 @@
 			compatible = "ptm-root";
 
 			reg = <PCIE_BDF(0,0x1c,0) PCIE_ID(0x8086,0x4b38)>;
-			label = "PTM_ROOT_0";
 
 			status = "okay";
 		};
@@ -63,7 +60,6 @@
 			reg = <PCIE_BDF(0,0x1e,0) PCIE_ID(0x8086,0x4b28)>;
 			reg-shift = <2>;
 
-			label = "UART_0";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -77,7 +73,6 @@
 			reg = <PCIE_BDF(0,0x1e,1) PCIE_ID(0x8086,0x4b29)>;
 			reg-shift = <2>;
 
-			label = "UART_1";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -92,7 +87,6 @@
 			reg = <PCIE_BDF(0,0x19,2) PCIE_ID(0x8086,0x4b4d)>;
 			reg-shift = <2>;
 
-			label = "UART_2";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -107,7 +101,6 @@
 			reg = <PCIE_BDF(0,0x11,0) PCIE_ID(0x8086,0x4b96)>;
 			reg-shift = <2>;
 
-			label = "UART_PSE_0";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -122,7 +115,6 @@
 			reg = <PCIE_BDF(0,0x11,1) PCIE_ID(0x8086,0x4b97)>;
 			reg-shift = <2>;
 
-			label = "UART_PSE_1";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -137,7 +129,6 @@
 			reg = <PCIE_BDF(0,0x11,2) PCIE_ID(0x8086,0x4b98)>;
 			reg-shift = <2>;
 
-			label = "UART_PSE_2";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -152,7 +143,6 @@
 			reg = <PCIE_BDF(0,0x11,3) PCIE_ID(0x8086,0x4b99)>;
 			reg-shift = <2>;
 
-			label = "UART_PSE_3";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -167,7 +157,6 @@
 			reg = <PCIE_BDF(0,0x11,4) PCIE_ID(0x8086,0x4b9a)>;
 			reg-shift = <2>;
 
-			label = "UART_PSE_4";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -182,7 +171,6 @@
 			reg = <PCIE_BDF(0,0x11,5) PCIE_ID(0x8086,0x4b9b)>;
 			reg-shift = <2>;
 
-			label = "UART_PSE_5";
 			clock-frequency = <1843200>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -199,7 +187,6 @@
 			reg = <PCIE_BDF(0,0x15,0) PCIE_ID(0x8086,0x4b78)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_0";
 
 			status = "okay";
 		};
@@ -212,7 +199,6 @@
 			reg = <PCIE_BDF(0,0x15,1) PCIE_ID(0x8086,0x4b79)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_1";
 
 			status = "okay";
 		};
@@ -225,7 +211,6 @@
 			reg = <PCIE_BDF(0,0x15,2) PCIE_ID(0x8086,0x4b7a)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_2";
 
 			status = "okay";
 		};
@@ -238,7 +223,6 @@
 			reg = <PCIE_BDF(0,0x15,3) PCIE_ID(0x8086,0x4b7b)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_3";
 
 			status = "okay";
 		};
@@ -251,7 +235,6 @@
 			reg = <PCIE_BDF(0,0x19,0) PCIE_ID(0x8086,0x4b4b)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_4";
 
 			status = "okay";
 		};
@@ -264,7 +247,6 @@
 			reg = <PCIE_BDF(0,0x19,1) PCIE_ID(0x8086,0x4b4c)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_5";
 
 			status = "okay";
 		};
@@ -277,7 +259,6 @@
 			reg = <PCIE_BDF(0,0x10,0) PCIE_ID(0x8086,0x4b44)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_6";
 
 			status = "okay";
 		};
@@ -290,7 +271,6 @@
 			reg = <PCIE_BDF(0,0x10,1) PCIE_ID(0x8086,0x4b45)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_7";
 
 			status = "okay";
 		};
@@ -303,7 +283,6 @@
 			reg = <PCIE_BDF(0,0x1b,0) PCIE_ID(0x8086,0x4bb9)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_PSE_0";
 
 			status = "okay";
 		};
@@ -316,7 +295,6 @@
 			reg = <PCIE_BDF(0,0x1b,1) PCIE_ID(0x8086,0x4bba)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_PSE_1";
 
 			status = "okay";
 		};
@@ -329,7 +307,6 @@
 			reg = <PCIE_BDF(0,0x1b,2) PCIE_ID(0x8086,0x4bbb)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_PSE_2";
 
 			status = "okay";
 		};
@@ -342,7 +319,6 @@
 			reg = <PCIE_BDF(0,0x1b,3) PCIE_ID(0x8086,0x4bbc)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_PSE_3";
 
 			status = "okay";
 		};
@@ -355,7 +331,6 @@
 			reg = <PCIE_BDF(0,0x1b,4) PCIE_ID(0x8086,0x4bbd)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_PSE_4";
 
 			status = "okay";
 		};
@@ -368,7 +343,6 @@
 			reg = <PCIE_BDF(0,0x1b,5) PCIE_ID(0x8086,0x4bbe)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_PSE_5";
 
 			status = "okay";
 		};
@@ -381,7 +355,6 @@
 			reg = <PCIE_BDF(0,0x1b,6) PCIE_ID(0x8086,0x4bbf)>;
 			interrupts = <PCIE_IRQ_DETECT IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
-			label = "I2C_PSE_6";
 
 			status = "okay";
 		};
@@ -396,7 +369,6 @@
 		vtd: vtd@fed91000 {
 			compatible = "intel,vt-d";
 
-			label = "VTD_0";
 			reg = <0xfed91000 0x1000>;
 
 			status = "okay";
@@ -409,7 +381,6 @@
 			reg = <0xfe040000 0x1000>;
 			reg-shift = <0>;
 
-			label = "UART_1_FIXED";
 			clock-frequency = <1843200>;
 			interrupts = <3 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -424,7 +395,6 @@
 			reg = <0xfe042000 0x1000>;
 			reg-shift = <0>;
 
-			label = "UART_2_FIXED";
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
@@ -439,7 +409,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_0_B";
 			group-index = <0x0>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -456,7 +425,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_0_T";
 			group-index = <0x1>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -473,7 +441,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_0_G";
 			group-index = <0x2>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -490,7 +457,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_1_V";
 			group-index = <0x0>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -507,7 +473,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_1_H";
 			group-index = <0x1>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -524,7 +489,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_1_D";
 			group-index = <0x2>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -541,7 +505,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_1_U";
 			group-index = <0x3>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -558,7 +521,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_1_vG";
 			group-index = <0x4>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -575,7 +537,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_3_S";
 			group-index = <0x1>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -592,7 +553,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_3_A";
 			group-index = <0x2>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -609,7 +569,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_3_vG";
 			group-index = <0x3>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -626,7 +585,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_4_C";
 			group-index = <0x0>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -643,7 +601,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_4_F";
 			group-index = <0x1>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -660,7 +617,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_4_E";
 			group-index = <0x3>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -677,7 +633,6 @@
 			interrupts = <14 IRQ_TYPE_LOWEST_LEVEL_LOW 3>;
 			interrupt-parent = <&intc>;
 
-			label = "GPIO_COM_5_R";
 			group-index = <0x0>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -689,7 +644,6 @@
 		};
 
 		hpet: hpet@fed00000 {
-			label = "HPET";
 			compatible = "intel,hpet";
 			reg = <0xfed00000 0x400>;
 			interrupts = <2 IRQ_TYPE_FIXED_EDGE_RISING 4>;
@@ -699,7 +653,6 @@
 		};
 
 		counter: counter@70 {
-			label = "CMOS";
 			compatible = "motorola,mc146818";
 			reg = <0x70 0x0D 0x71 0x0D>;
 

--- a/dts/x86/intel/ia32.dtsi
+++ b/dts/x86/intel/ia32.dtsi
@@ -42,7 +42,6 @@
 		uart0: uart@3f8 {
 			compatible = "ns16550";
 			reg = <0x000003f8 0x100>;
-			label = "UART_0";
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
@@ -53,7 +52,6 @@
 		uart1: uart@2f8 {
 			compatible = "ns16550";
 			reg = <0x000002f8 0x100>;
-			label = "UART_1";
 			clock-frequency = <1843200>;
 			interrupts = <3 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
@@ -62,7 +60,6 @@
 		};
 
 		hpet: hpet@fed00000 {
-			label = "HPET";
 			compatible = "intel,hpet";
 			reg = <0xfed00000 0x400>;
 			interrupts = <2 IRQ_TYPE_FIXED_EDGE_RISING 4>;
@@ -72,7 +69,6 @@
 		};
 
 		counter: counter@70 {
-			label = "CMOS";
 			compatible = "motorola,mc146818";
 			reg = <0x70 0x0D 0x71 0x0D>;
 


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>