### PR TITLE
dts: xtensa: Remove label property from devicetrees

### DIFF
--- a/dts/xtensa/espressif/esp32.dtsi
+++ b/dts/xtensa/espressif/esp32.dtsi
@@ -57,14 +57,12 @@
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x3ff00104 0x114>;
-			label = "INTC_0";
 			status = "okay";
 		};
 
 		rtc: rtc@3ff48000 {
 			compatible = "espressif,esp32-rtc";
 			reg = <0x3ff48000 0x0D8>;
-			label = "RTC";
 			xtal-freq = <ESP32_CLK_XTAL_40M>;
 			#clock-cells = <1>;
 			status = "ok";
@@ -72,7 +70,6 @@
 
 		flash: flash-controller@3ff42000 {
 			compatible = "espressif,esp32-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x3ff42000 0x1000>;
 			/* interrupts = <3 0>; */
 
@@ -81,7 +78,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_ESP32";
 				reg = <0 0x400000>;
 				erase-block-size = <4096>;
 				write-block-size = <32>;
@@ -90,7 +86,6 @@
 
 		ipi0: ipi@3f4c0058 {
 			compatible = "espressif,crosscore-interrupt";
-			label = "IPI0";
 			reg = <0x3f4c0058 0x4>;
 			interrupts = <FROM_CPU_INTR0_SOURCE>;
 			interrupt-parent = <&intc>;
@@ -98,7 +93,6 @@
 
 		ipi1: ipi@3f4c005c {
 			compatible = "espressif,crosscore-interrupt";
-			label = "IPI1";
 			reg = <0x3f4c005c 0x4>;
 			interrupts = <FROM_CPU_INTR1_SOURCE>;
 			interrupt-parent = <&intc>;
@@ -109,7 +103,6 @@
 			reg = <0x3ff40000 0x400>;
 			interrupts = <UART0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "UART_0";
 			clocks = <&rtc ESP32_UART0_MODULE>;
 			status = "disabled";
 		};
@@ -119,7 +112,6 @@
 			reg = <0x3ff50000 0x400>;
 			interrupts = <UART1_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "UART_1";
 			clocks = <&rtc ESP32_UART1_MODULE>;
 			status = "disabled";
 		};
@@ -129,7 +121,6 @@
 			reg = <0x3ff6E000 0x400>;
 			interrupts = <UART2_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "UART_2";
 			clocks = <&rtc ESP32_UART2_MODULE>;
 			status = "disabled";
 		};
@@ -138,7 +129,6 @@
 			compatible = "espressif,esp32-ledc";
 			#pwm-cells = <3>;
 			reg = <0x3ff59000 0x800>;
-			label = "LEDC_0";
 			clocks = <&rtc ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
@@ -148,7 +138,6 @@
 			reg = <0x3ff5e000 0x1000>;
 			interrupts = <PWM0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "MCPWM_0";
 			clocks = <&rtc ESP32_PWM0_MODULE>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -159,7 +148,6 @@
 			reg = <0x3ff6c000 0x1000>;
 			interrupts = <PWM1_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "MCPWM_1";
 			clocks = <&rtc ESP32_PWM1_MODULE>;
 			#pwm-cells = <3>;
 			status = "disabled";
@@ -185,7 +173,6 @@
 				reg = <0x3ff44000 0x800>;
 				interrupts = <GPIO_INTR_SOURCE>;
 				interrupt-parent = <&intc>;
-				label = "GPIO_0";
 				ngpios = <32>;   /* 0..31 */
 			};
 
@@ -196,7 +183,6 @@
 				reg = <0x3ff44800 0x800>;
 				interrupts = <GPIO_INTR_SOURCE>;
 				interrupt-parent = <&intc>;
-				label = "GPIO_1";
 				ngpios = <8>;   /* 32..39 */
 			};
 		};
@@ -208,7 +194,6 @@
 			reg = <0x3ff53000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "I2C_0";
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
@@ -220,7 +205,6 @@
 			reg = <0x3ff67000 0x1000>;
 			interrupts = <I2C_EXT1_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "I2C_1";
 			clocks = <&rtc ESP32_I2C1_MODULE>;
 			status = "disabled";
 		};
@@ -229,7 +213,6 @@
 			compatible = "espressif,esp32-trng";
 			reg = <0x3FF75144 0x4>;
 			/* interrupts = <33 0>; - FIXME: Enable interrupts when interrupt-controller got supported in device tree */
-			label = "TRNG_0";
 			status = "disabled";
 		};
 
@@ -239,7 +222,6 @@
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
-			label = "WDT_0";
 			status = "okay";
 		};
 
@@ -249,7 +231,6 @@
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
-			label = "WDT_1";
 			status = "disabled";
 		};
 
@@ -258,7 +239,6 @@
 			reg = <0x3ff64000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "SPI_2";
 			clocks = <&rtc ESP32_HSPI_MODULE>;
 			status = "disabled";
 		};
@@ -268,7 +248,6 @@
 			reg = <0x3ff65000 DT_SIZE_K(4)>;
 			interrupts = <SPI3_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "SPI_3";
 			clocks = <&rtc ESP32_VSPI_MODULE>;
 			status = "disabled";
 		};
@@ -280,7 +259,6 @@
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG0_T0";
 			status = "disabled";
 		};
 
@@ -291,7 +269,6 @@
 			index = <1>;
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG0_T1";
 			status = "disabled";
 		};
 
@@ -302,7 +279,6 @@
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG1_T0";
 			status = "disabled";
 		};
 
@@ -313,7 +289,6 @@
 			index = <1>;
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG1_T1";
 			status = "disabled";
 		};
 	};

--- a/dts/xtensa/espressif/esp32s2.dtsi
+++ b/dts/xtensa/espressif/esp32s2.dtsi
@@ -57,14 +57,12 @@
 			compatible = "espressif,esp32-intc";
 			interrupt-controller;
 			reg = <0x3f4c2000 0x114>;
-			label = "INTC_0";
 			status = "okay";
 		};
 
 		rtc: rtc@3f408000 {
 			compatible = "espressif,esp32-rtc";
 			reg = <0x3f408000 0x0D8>;
-			label = "RTC";
 			xtal-freq = <ESP32_CLK_XTAL_40M>;
 			#clock-cells = <1>;
 			status = "ok";
@@ -72,7 +70,6 @@
 
 		flash: flash-controller@3f402000 {
 			compatible = "espressif,esp32-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x3f402000 0x1000>;
 
 			#address-cells = <1>;
@@ -80,7 +77,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_ESP32S2";
 				reg = <0 0x400000>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
@@ -90,7 +86,6 @@
 		uart0: uart@3f400000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x3f400000 0x400>;
-			label = "UART_0";
 			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
@@ -100,7 +95,6 @@
 		uart1: uart@3f410000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x3f410000 0x400>;
-			label = "UART_1";
 			status = "disabled";
 			interrupts = <UART1_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
@@ -113,7 +107,6 @@
 			pwm-controller;
 			#pwm-cells = <3>;
 			reg = <0x3f419000 0x1000>;
-			label = "LEDC_0";
 			clocks = <&rtc ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
@@ -125,7 +118,6 @@
 			reg = <0x3f404000 0x800>;
 			interrupts = <GPIO_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_0";
 			ngpios = <32>;   /* 0..31 */
 		};
 
@@ -136,7 +128,6 @@
 			reg = <0x3f404800 0x800>;
 			interrupts = <GPIO_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_1";
 			ngpios = <22>;   /* 32..53 */
 		};
 
@@ -147,7 +138,6 @@
 			reg = <0x3f413000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "I2C_0";
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
@@ -159,7 +149,6 @@
 			reg = <0x3f427000 0x1000>;
 			interrupts = <I2C_EXT1_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "I2C_1";
 			clocks = <&rtc ESP32_I2C1_MODULE>;
 			status = "disabled";
 		};
@@ -171,7 +160,6 @@
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG0_T0";
 			status = "disabled";
 		};
 
@@ -182,7 +170,6 @@
 			index = <1>;
 			interrupts = <TG0_T1_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG0_T1";
 			status = "disabled";
 		};
 
@@ -193,7 +180,6 @@
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG1_T0";
 			status = "disabled";
 		};
 
@@ -204,13 +190,11 @@
 			index = <1>;
 			interrupts = <TG1_T1_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG1_T1";
 		};
 
 		trng0: trng@3f435110 {
 			compatible = "espressif,esp32-trng";
 			reg = <0x3f435110 0x4>;
-			label = "TRNG_0";
 			status = "disabled";
 		};
 
@@ -219,7 +203,6 @@
 			reg = <0x3f424000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "SPI_2";
 			clocks = <&rtc ESP32_FSPI_MODULE>;
 			status = "disabled";
 		};
@@ -229,7 +212,6 @@
 			reg = <0x3f425000 DT_SIZE_K(4)>;
 			interrupts = <SPI3_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "SPI_3";
 			clocks = <&rtc ESP32_HSPI_MODULE>;
 			status = "disabled";
 		};
@@ -240,7 +222,6 @@
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
-			label = "WDT_0";
 			status = "disabled";
 		};
 
@@ -250,7 +231,6 @@
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
-			label = "WDT_1";
 			status = "disabled";
 		};
 	};

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -104,7 +104,6 @@
 			interrupts = <4 0 0>;
 			num-irqs = <28>;
 			interrupt-parent = <&core_intc>;
-			label = "ACE_0";
 		};
 
 		shim: shim@71f00 {
@@ -134,7 +133,6 @@
 			shim = <0x0007c800 0x1000>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "DMA_0";
 			status = "okay";
 		};
 
@@ -145,7 +143,6 @@
 			shim = <0x0007d800 0x1000>;
 			interrupts = <0x20 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "DMA_1";
 			status = "okay";
 		};
 
@@ -160,7 +157,6 @@
 			dmas = <&lpgpdma0 2
 					&lpgpdma0 3>;
 			dma-names = "tx", "rx";
-			label = "SSP_0";
 			status = "okay";
 		};
 
@@ -175,7 +171,6 @@
 			dmas = <&lpgpdma0 4
 					&lpgpdma0 5>;
 			dma-names = "tx", "rx";
-			label = "SSP_1";
 			status = "okay";
 		};
 
@@ -190,7 +185,6 @@
 			dmas = <&lpgpdma0 6
 					&lpgpdma0 7>;
 			dma-names = "tx", "rx";
-			label = "SSP_2";
 			status = "okay";
 		};
 
@@ -205,7 +199,6 @@
 			dmas = <&lpgpdma0 8
 					&lpgpdma0 9>;
 			dma-names = "tx", "rx";
-			label = "SSP_3";
 			status = "okay";
 		};
 
@@ -220,7 +213,6 @@
 			dmas = <&lpgpdma0 10
 					&lpgpdma0 11>;
 			dma-names = "tx", "rx";
-			label = "SSP_4";
 			status = "okay";
 		};
 
@@ -235,7 +227,6 @@
 			dmas = <&lpgpdma0 12
 					&lpgpdma0 13>;
 			dma-names = "tx", "rx";
-			label = "SSP_5";
 			status = "okay";
 		};
 
@@ -245,7 +236,6 @@
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
 			dma-buf-alignment = <128>;
-			label = "HDA_HOST_OUT";
 			status = "okay";
 		};
 
@@ -255,7 +245,6 @@
 			reg = <0x00072c00 0x40>;
 			dma-channels = <10>;
 			dma-buf-alignment = <128>;
-			label = "HDA_HOST_IN";
 			status = "okay";
 		};
 
@@ -265,7 +254,6 @@
 			reg = <0x00072400 0x40>;
 			dma-channels = <9>;
 			dma-buf-alignment = <128>;
-			label = "HDA_LINK_OUT";
 			status = "okay";
 		};
 
@@ -275,7 +263,6 @@
 			reg = <0x00072600 0x40>;
 			dma-channels = <10>;
 			dma-buf-alignment = <128>;
-			label = "HDA_LINK_IN";
 			status = "okay";
 		};
 	};

--- a/dts/xtensa/intel/intel_cavs.dtsi
+++ b/dts/xtensa/intel/intel_cavs.dtsi
@@ -15,7 +15,6 @@
 			shim = <0x00078400 0x100>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&cavs3>;
-			label = "DMA_0";
 
 			status = "okay";
 		};
@@ -27,7 +26,6 @@
 			shim = <0x00078500 0x100>;
 			interrupts = <0x0F 0 0>;
 			interrupt-parent = <&cavs3>;
-			label = "DMA_1";
 
 			status = "okay";
 		};
@@ -38,7 +36,6 @@
 			reg = <0x00072400 0x40>;
 			dma-channels = <4>;
 			dma-buf-alignment = <128>;
-			label = "HDA_LINK_OUT";
 
 			status = "okay";
 		};
@@ -49,7 +46,6 @@
 			reg = <0x00072600 0x40>;
 			dma-channels = <4>;
 			dma-buf-alignment = <128>;
-			label = "HDA_LINK_IN";
 
 			status = "okay";
 		};
@@ -60,7 +56,6 @@
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
 			dma-buf-alignment = <128>;
-			label = "HDA_HOST_OUT";
 
 			status = "okay";
 		};
@@ -71,7 +66,6 @@
 			reg = <0x00072c00 0x40>;
 			dma-channels = <7>;
 			dma-buf-alignment = <128>;
-			label = "HDA_HOST_IN";
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -94,7 +94,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_0";
 		};
 
 		cavs1: cavs@1610  {
@@ -104,7 +103,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_1";
 		};
 
 		cavs2: cavs@1620  {
@@ -114,7 +112,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_2";
 		};
 
 		cavs3: cavs@1630  {
@@ -124,12 +121,10 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
-			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
@@ -142,7 +137,6 @@
 			shim = <0x00000c00 0x080>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&cavs3>;
-			label = "DMA_0";
 
 			status = "okay";
 		};
@@ -154,7 +148,6 @@
 			shim = <0x00000c80 0x080>;
 			interrupts = <0x0F 0 0>;
 			interrupt-parent = <&cavs3>;
-			label = "DMA_1";
 
 			status = "okay";
 		};
@@ -165,7 +158,6 @@
 			reg = <0x00002400 0x40>;
 			dma-channels = <2>;
 			dma-buf-alignment = <128>;
-			label = "HDA_LINK_OUT";
 
 			status = "okay";
 		};
@@ -176,7 +168,6 @@
 			reg = <0x00002600 0x40>;
 			dma-channels = <2>;
 			dma-buf-alignment = <128>;
-			label = "HDA_LINK_IN";
 
 			status = "okay";
 		};
@@ -187,7 +178,6 @@
 			reg = <0x00002800 0x40>;
 			dma-channels = <6>;
 			dma-buf-alignment = <128>;
-			label = "HDA_HOST_OUT";
 
 			status = "okay";
 		};
@@ -198,7 +188,6 @@
 			reg = <0x00002c00 0x40>;
 			dma-channels = <7>;
 			dma-buf-alignment = <128>;
-			label = "HDA_HOST_IN";
 
 			status = "okay";
 		};
@@ -214,7 +203,6 @@
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
-			label = "SSP_0";
 
 			status = "okay";
 		};
@@ -230,7 +218,6 @@
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
-			label = "SSP_1";
 
 			status = "okay";
 		};
@@ -246,7 +233,6 @@
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
-			label = "SSP_2";
 
 			status = "okay";
 		};
@@ -262,7 +248,6 @@
 			dmas = <&lpgpdma0 8
 				&lpgpdma0 9>;
 			dma-names = "tx", "rx";
-			label = "SSP_3";
 
 			status = "okay";
 		};
@@ -278,7 +263,6 @@
 			dmas = <&lpgpdma0 10
 				&lpgpdma0 11>;
 			dma-names = "tx", "rx";
-			label = "SSP_4";
 
 			status = "okay";
 		};
@@ -294,7 +278,6 @@
 			dmas = <&lpgpdma0 12
 				&lpgpdma0 13>;
 			dma-names = "tx", "rx";
-			label = "SSP_5";
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_cavs18.dtsi
@@ -96,7 +96,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -106,7 +105,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -116,7 +114,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -126,12 +123,10 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
-			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;

--- a/dts/xtensa/intel/intel_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_cavs20.dtsi
@@ -96,7 +96,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -106,7 +105,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -116,7 +114,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -126,12 +123,10 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
-			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;

--- a/dts/xtensa/intel/intel_cavs20_jsl.dtsi
+++ b/dts/xtensa/intel/intel_cavs20_jsl.dtsi
@@ -75,7 +75,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -85,7 +84,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -95,7 +93,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -105,12 +102,10 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
-			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;

--- a/dts/xtensa/intel/intel_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_cavs25.dtsi
@@ -120,7 +120,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -130,7 +129,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -140,7 +138,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -150,12 +147,10 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
-			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
@@ -177,7 +172,6 @@
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
-			label = "SSP_0";
 
 			status = "okay";
 		};
@@ -193,7 +187,6 @@
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
-			label = "SSP_1";
 
 			status = "okay";
 		};
@@ -209,7 +202,6 @@
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
-			label = "SSP_2";
 
 			status = "okay";
 		};
@@ -225,7 +217,6 @@
 			dmas = <&lpgpdma0 8
 				&lpgpdma0 9>;
 			dma-names = "tx", "rx";
-			label = "SSP_3";
 
 			status = "okay";
 		};
@@ -241,7 +232,6 @@
 			dmas = <&lpgpdma0 10
 				&lpgpdma0 11>;
 			dma-names = "tx", "rx";
-			label = "SSP_4";
 
 			status = "okay";
 		};
@@ -257,7 +247,6 @@
 			dmas = <&lpgpdma0 12
 				&lpgpdma0 13>;
 			dma-names = "tx", "rx";
-			label = "SSP_5";
 
 			status = "okay";
 		};
@@ -265,7 +254,6 @@
 		alh0:alh@24400 {
 			compatible = "intel,alh-dai";
 			reg = <0x00024400 0x00024600>;
-			label = "ALH_0";
 
 			status = "okay";
 		};
@@ -273,7 +261,6 @@
 		alh1:alh@24400 {
 			compatible = "intel,alh-dai";
 			reg = <0x00024400 0x00024600>;
-			label = "ALH_1";
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_cavs25_tgph.dtsi
@@ -67,7 +67,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -77,7 +76,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -87,7 +85,6 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -97,12 +94,10 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
-			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
-			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>