### PR TITLE
Bluetooth: csis: Expose bt_csis_generate_rsi function

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -173,7 +173,9 @@ struct bt_audio_broadcast_source;
 /** @brief Codec configuration structure */
 struct bt_codec_data {
 	struct bt_data data;
+#if defined(CONFIG_BT_CODEC_MAX_DATA_LEN)
 	uint8_t  value[CONFIG_BT_CODEC_MAX_DATA_LEN];
+#endif /* CONFIG_BT_CODEC_MAX_DATA_LEN */
 };
 
 /**
@@ -255,19 +257,24 @@ struct bt_codec {
 	uint16_t cid;
 	/** Codec Company Vendor ID */
 	uint16_t vid;
+#if defined(CONFIG_BT_CODEC_MAX_DATA_COUNT)
 	/** Codec Specific Data count */
 	size_t   data_count;
 	/** Codec Specific Data */
 	struct bt_codec_data data[CONFIG_BT_CODEC_MAX_DATA_COUNT];
+#endif /* CONFIG_BT_CODEC_MAX_DATA_COUNT */
+#if defined(CONFIG_BT_CODEC_MAX_METADATA_COUNT)
 	/** Codec Specific Metadata count */
 	size_t   meta_count;
 	/** Codec Specific Metadata */
 	struct bt_codec_data meta[CONFIG_BT_CODEC_MAX_METADATA_COUNT];
+#endif /* CONFIG_BT_CODEC_MAX_METADATA_COUNT */
 };
 
 struct bt_audio_base_bis_data {
 	/* Unique index of the BIS */
 	uint8_t index;
+#if defined(CONFIG_BT_CODEC_MAX_DATA_COUNT)
 	/** Codec Specific Data count.
 	 *
 	 *  Only valid if the data_count of struct bt_codec in the subgroup is 0
@@ -278,6 +285,7 @@ struct bt_audio_base_bis_data {
 	 *  Only valid if the data_count of struct bt_codec in the subgroup is 0
 	 */
 	struct bt_codec_data data[CONFIG_BT_CODEC_MAX_DATA_COUNT];
+#endif /* CONFIG_BT_CODEC_MAX_DATA_COUNT */
 };
 
 struct bt_audio_base_subgroup {

--- a/include/zephyr/bluetooth/audio/csis.h
+++ b/include/zephyr/bluetooth/audio/csis.h
@@ -62,6 +62,16 @@ extern "C" {
 /** Client is already owner of the lock */
 #define BT_CSIS_ERROR_LOCK_ALREADY_GRANTED      0x84
 
+/**
+ * @brief Helper to declare bt_data array including RSI
+ *
+ * This macro is mainly for creating an array of struct bt_data
+ * elements which is then passed to e.g. @ref bt_le_ext_adv_start().
+ *
+ * @param _rsi Pointer to the RSI value
+ */
+#define BT_CSIS_DATA_RSI(_rsi) BT_DATA(BT_DATA_CSIS_RSI, _rsi, BT_CSIS_RSI_SIZE)
+
 /** @brief Opaque Coordinated Set Identification Service instance. */
 struct bt_csis;
 
@@ -93,15 +103,6 @@ struct bt_csis_cb {
 	 * @return A BT_CSIS_READ_SIRK_REQ_RSP_* response code.
 	 */
 	uint8_t (*sirk_read_req)(struct bt_conn *conn, struct bt_csis *csis);
-
-	/**
-	 * @brief Callback whenever the RSI changes.
-	 *
-	 * If this callback is not set, the stack will handle advertising of the RSI.
-	 *
-	 * @param rsi Pointer to the new 6-octet RSI data to be advertised.
-	 */
-	void (*rsi_changed)(const uint8_t rsi[BT_CSIS_RSI_SIZE]);
 };
 
 /** Register structure for Coordinated Set Identification Service */
@@ -190,16 +191,16 @@ int bt_csis_register(const struct bt_csis_register_param *param,
 void bt_csis_print_sirk(const struct bt_csis *csis);
 
 /**
- * @brief Starts advertising the Resolvable Set Identifier value.
+ * @brief Generate the Resolvable Set Identifier (RSI) value.
  *
- * This cannot be used with other connectable advertising sets.
+ * This will generate RSI for given @p csis instance.
  *
  * @param csis          Pointer to the Coordinated Set Identification Service.
- * @param enable	If true start advertising, if false stop advertising
+ * @param rsi           Pointer to the 6-octet newly generated RSI data.
  *
  * @return int		0 if on success, errno on error.
  */
-int bt_csis_advertise(struct bt_csis *csis, bool enable);
+int bt_csis_generate_rsi(const struct bt_csis *csis, uint8_t rsi[BT_CSIS_RSI_SIZE]);
 
 /**
  * @brief Locks a specific Coordinated Set Identification Service instance on the server.

--- a/samples/bluetooth/hap_ha/src/csip_set_member.c
+++ b/samples/bluetooth/hap_ha/src/csip_set_member.c
@@ -32,7 +32,7 @@ static struct bt_csis_cb csis_cb = {
 	.sirk_read_req = sirk_read_req_cb,
 };
 
-int csip_set_member_init(void (*rsi_changed)(const uint8_t *rsi))
+int csip_set_member_init(void)
 {
 	struct bt_csis_register_param param = {
 		.set_size = 2,
@@ -42,7 +42,22 @@ int csip_set_member_init(void (*rsi_changed)(const uint8_t *rsi))
 		.cb = &csis_cb,
 	};
 
-	csis_cb.rsi_changed = rsi_changed;
-
 	return bt_cap_acceptor_register(&param, &csis);
+}
+
+int csip_generate_rsi(uint8_t *rsi)
+{
+	int err;
+
+	if (csis == NULL) {
+		return -ENODEV;
+	}
+
+	err = bt_csis_generate_rsi(csis, rsi);
+	if (err) {
+		printk("Failed to generate RSI (err %d)\n", err);
+		return err;
+	}
+
+	return 0;
 }

--- a/samples/bluetooth/hap_ha/src/hap_ha.h
+++ b/samples/bluetooth/hap_ha/src/hap_ha.h
@@ -18,7 +18,18 @@ int bap_unicast_sr_init(void);
  *
  * @return 0 if success, errno on failure.
  */
-int csip_set_member_init(void (*rsi_changed)(const uint8_t *rsi));
+int csip_set_member_init(void);
+
+/**
+ * @brief Generate the Resolvable Set Identifier (RSI) value.
+ *
+ * This will generate RSI for given @p csis instance.
+ *
+ * @param rsi Pointer to place the 6-octet newly generated RSI data.
+ *
+ * @return 0 if on success, errno on error.
+ */
+int csip_generate_rsi(uint8_t *rsi);
 
 /**
  * @brief Initialize the VCP Volume Renderer role

--- a/subsys/bluetooth/audio/csis_internal.h
+++ b/subsys/bluetooth/audio/csis_internal.h
@@ -61,12 +61,10 @@ struct bt_csis_client_svc_inst {
 /* TODO: Rename to bt_csis_svc_inst */
 struct bt_csis_server {
 	struct bt_csis_set_sirk set_sirk;
-	uint8_t rsi[BT_CSIS_RSI_SIZE];
 	uint8_t set_size;
 	uint8_t set_lock;
 	uint8_t rank;
 	struct bt_csis_cb *cb;
-	bool adv_enabled;
 	struct k_work_delayable set_lock_timer;
 	bt_addr_le_t lock_client_addr;
 	struct bt_gatt_service *service_p;
@@ -74,12 +72,6 @@ struct bt_csis_server {
 #if IS_ENABLED(CONFIG_BT_KEYS_OVERWRITE_OLDEST)
 	uint32_t age_counter;
 #endif /* CONFIG_BT_KEYS_OVERWRITE_OLDEST */
-#if defined(CONFIG_BT_EXT_ADV)
-	uint8_t conn_cnt;
-	struct bt_le_ext_adv *adv;
-	struct bt_le_ext_adv_cb adv_cb;
-	struct k_work work;
-#endif /* CONFIG_BT_EXT_ADV */
 };
 
 struct bt_csis {

--- a/subsys/bluetooth/shell/bt.h
+++ b/subsys/bluetooth/shell/bt.h
@@ -13,8 +13,12 @@
 #ifndef __BT_H
 #define __BT_H
 
+#include <zephyr/bluetooth/bluetooth.h>
+#include <sys/types.h>
+
 extern const struct shell *ctx_shell;
 extern struct bt_conn *default_conn;
+extern struct bt_csis *csis;
 
 #if defined(CONFIG_BT_ISO)
 extern struct bt_iso_chan iso_chan;
@@ -29,5 +33,8 @@ extern struct bt_le_per_adv_sync *per_adv_syncs[CONFIG_BT_PER_ADV_SYNC_MAX];
 #endif /* CONFIG_BT_EXT_ADV */
 
 void conn_addr_str(struct bt_conn *conn, char *addr, size_t len);
+ssize_t audio_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable,
+			  const bool connectable);
+ssize_t csis_ad_data_add(struct bt_data *data, const size_t data_size, const bool discoverable);
 
 #endif /* __BT_H */

--- a/subsys/bluetooth/shell/csis.c
+++ b/subsys/bluetooth/shell/csis.c
@@ -105,55 +105,6 @@ static int cmd_csis_register(const struct shell *sh, size_t argc, char **argv)
 	return 0;
 }
 
-static int cmd_csis_advertise(const struct shell *sh, size_t argc,
-			      char *argv[])
-{
-	int err;
-
-	if (strcmp(argv[1], "off") == 0) {
-		err = bt_csis_advertise(csis, false);
-		if (err != 0) {
-			shell_error(sh, "Failed to stop advertising %d", err);
-			return -ENOEXEC;
-		}
-		shell_print(sh, "Advertising stopped");
-	} else if (strcmp(argv[1], "on") == 0) {
-		err = bt_csis_advertise(csis, true);
-		if (err != 0) {
-			shell_error(sh, "Failed to start advertising %d", err);
-			return -ENOEXEC;
-		}
-		shell_print(sh, "Advertising started");
-	} else {
-		shell_error(sh, "Invalid argument: %s", argv[1]);
-		return -ENOEXEC;
-	}
-
-	return 0;
-}
-
-static int cmd_csis_update_rsi(const struct shell *sh, size_t argc,
-				char *argv[])
-{
-	int err;
-
-	if (bt_csis_advertise(csis, false) != 0) {
-		shell_error(sh,
-			    "Failed to stop advertising - rsi not updated");
-		return -ENOEXEC;
-	}
-	err = bt_csis_advertise(csis, true);
-	if (err != 0) {
-		shell_error(sh,
-			    "Failed to start advertising  - rsi not updated");
-		return -ENOEXEC;
-	}
-
-	shell_print(sh, "RSI and optionally RPA updated");
-
-	return 0;
-}
-
 static int cmd_csis_print_sirk(const struct shell *sh, size_t argc,
 			       char *argv[])
 {
@@ -234,12 +185,6 @@ SHELL_STATIC_SUBCMD_SET_CREATE(csis_cmds,
 		      "Initialize the service and register callbacks "
 		      "[size <int>] [rank <int>] [not-lockable] [sirk <data>]",
 		      cmd_csis_register, 1, 4),
-	SHELL_CMD_ARG(advertise, NULL,
-		      "Start/stop advertising CSIS RSIs <on/off>",
-		      cmd_csis_advertise, 2, 0),
-	SHELL_CMD_ARG(update_rsi, NULL,
-		      "Update the advertised RSI",
-		      cmd_csis_update_rsi, 1, 0),
 	SHELL_CMD_ARG(lock, NULL,
 		      "Lock the set",
 		      cmd_csis_lock, 1, 0),


### PR DESCRIPTION
The function will be used to update the RSI value. The returned value
can be later used in advertisement data for set identification. This
removes the need of specific bt_csis_advertise function so that the user
can call the API to generate new RSI once needed (e.g. on RPA change).
This allows the user to manage the advertisement data to fit it's needs.

< HCI Command: LE Set Extended Advertising Enable (0x08|0x0039) plen 6
        Extended advertising: Disabled (0x00)
        Number of sets: 1 (0x01)
        Entry 0
          Handle: 0x00
          Duration: 0 ms (0x00)
          Max ext adv events: 0
> HCI Event: Command Complete (0x0e) plen 4
      LE Set Extended Advertising Enable (0x08|0x0039) ncmd 1
        Status: Success (0x00)
< HCI Command: LE Set Extended Advertising Data (0x08|0x0037) plen 33
        Handle: 0x00
        Operation: Complete extended advertising data (0x03)
        Fragment preference: Minimize fragmentation (0x01)
        Data length: 0x1d
        Flags: 0x06
          LE General Discoverable Mode
          BR/EDR Not Supported
        Unknown EIR field 0x2e: 16e61d64dc45
        Name (complete): audio test shell
> HCI Event: Command Complete (0x0e) plen 4
      LE Set Extended Advertising Data (0x08|0x0037) ncmd 1
	Status: Success (0x00)
< HCI Command: LE Set Advertising Set Random Address (0x08|0x0035) plen 7
        Advertising handle: 0x00
        Advertising random address: 4E:21:29:F8:94:93 (Resolvable)
> HCI Event: Command Complete (0x0e) plen 4
      LE Set Advertising Set Random Address (0x08|0x0035) ncmd 1
        Status: Success (0x00)
< HCI Command: LE Set Extended Advertising Enable (0x08|0x0039) plen 6
        Extended advertising: Enabled (0x01)
        Number of sets: 1 (0x01)
        Entry 0
          Handle: 0x00
          Duration: 0 ms (0x00)
          Max ext adv events: 0
> HCI Event: Command Complete (0x0e) plen 4
      LE Set Extended Advertising Enable (0x08|0x0039) ncmd 1
        Status: Success (0x00)

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>