### PR TITLE
emul: remove name param from bus register APIs

### DIFF
--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -199,9 +199,10 @@ static int espi_emul_init(const struct device *dev)
 	return emul_init_for_bus(dev);
 }
 
-int espi_emul_register(const struct device *dev, const char *name, struct espi_emul *emul)
+int espi_emul_register(const struct device *dev, struct espi_emul *emul)
 {
 	struct espi_emul_data *data = dev->data;
+	const char *name = emul->target->dev->name;
 
 	sys_slist_append(&data->emuls, &emul->node);
 

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -118,9 +118,10 @@ static int i2c_emul_init(const struct device *dev)
 	return rc;
 }
 
-int i2c_emul_register(const struct device *dev, const char *name, struct i2c_emul *emul)
+int i2c_emul_register(const struct device *dev, struct i2c_emul *emul)
 {
 	struct i2c_emul_data *data = dev->data;
+	const char *name = emul->target->dev->name;
 
 	sys_slist_append(&data->emuls, &emul->node);
 

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -95,9 +95,10 @@ static int spi_emul_init(const struct device *dev)
 	return emul_init_for_bus(dev);
 }
 
-int spi_emul_register(const struct device *dev, const char *name, struct spi_emul *emul)
+int spi_emul_register(const struct device *dev, struct spi_emul *emul)
 {
 	struct spi_emul_data *data = dev->data;
+	const char *name = emul->target->dev->name;
 
 	sys_slist_append(&data->emuls, &emul->node);
 

--- a/include/zephyr/drivers/espi_emul.h
+++ b/include/zephyr/drivers/espi_emul.h
@@ -132,11 +132,10 @@ struct emul_espi_driver_api {
  * Register an emulated device on the controller
  *
  * @param dev Device that will use the emulator
- * @param name User-friendly name for this emulator
  * @param emul eSPI emulator to use
  * @return 0 indicating success (always)
  */
-int espi_emul_register(const struct device *dev, const char *name, struct espi_emul *emul);
+int espi_emul_register(const struct device *dev, struct espi_emul *emul);
 
 /**
  * Sets the eSPI virtual wire on the host side, which will

--- a/include/zephyr/drivers/i2c_emul.h
+++ b/include/zephyr/drivers/i2c_emul.h
@@ -65,11 +65,10 @@ typedef int (*i2c_emul_transfer_t)(const struct emul *target, struct i2c_msg *ms
  * Register an emulated device on the controller
  *
  * @param dev Device that will use the emulator
- * @param name User-friendly name for this emulator
  * @param emul I2C emulator to use
  * @return 0 indicating success (always)
  */
-int i2c_emul_register(const struct device *dev, const char *name, struct i2c_emul *emul);
+int i2c_emul_register(const struct device *dev, struct i2c_emul *emul);
 
 /** Definition of the emulator API */
 struct i2c_emul_api {

--- a/include/zephyr/drivers/spi_emul.h
+++ b/include/zephyr/drivers/spi_emul.h
@@ -69,11 +69,10 @@ typedef int (*spi_emul_io_t)(const struct emul *target, const struct spi_config 
  * Register an emulated device on the controller
  *
  * @param dev Device that will use the emulator
- * @param name User-friendly name for this emulator
  * @param emul SPI emulator to use
  * @return 0 indicating success (always)
  */
-int spi_emul_register(const struct device *dev, const char *name, struct spi_emul *emul);
+int spi_emul_register(const struct device *dev, struct spi_emul *emul);
 
 /** Definition of the emulator API */
 struct spi_emul_api {

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -64,17 +64,17 @@ int emul_init_for_bus(const struct device *dev)
 		switch (emul->bus_type) {
 #ifdef CONFIG_I2C_EMUL
 		case EMUL_BUS_TYPE_I2C:
-			rc = i2c_emul_register(dev, emul->dev->name, emul->bus.i2c);
+			rc = i2c_emul_register(dev, emul->bus.i2c);
 			break;
 #endif /* CONFIG_I2C_EMUL */
 #ifdef CONFIG_ESPI_EMUL
 		case EMUL_BUS_TYPE_ESPI:
-			rc = espi_emul_register(dev, emul->dev->name, emul->bus.espi);
+			rc = espi_emul_register(dev, emul->bus.espi);
 			break;
 #endif /* CONFIG_ESPI_EMUL */
 #ifdef CONFIG_SPI_EMUL
 		case EMUL_BUS_TYPE_SPI:
-			rc = spi_emul_register(dev, emul->dev->name, emul->bus.spi);
+			rc = spi_emul_register(dev, emul->bus.spi);
 			break;
 #endif /* CONFIG_SPI_EMUL */
 		default:


### PR DESCRIPTION
Rework the <BUS>_emul_register calls to not pass the name param.  The
name param is only used for logging and we can get it from the
struct <BUS>_emul instead.

Signed-off-by: Kumar Gala <galak@kernel.org>