### PR TITLE
drivers: virt: ivshmem: Convert to use DEVICE_DT_GET_ONE

### DIFF
--- a/drivers/virtualization/Kconfig
+++ b/drivers/virtualization/Kconfig
@@ -22,10 +22,6 @@ config IVSHMEM
 
 if IVSHMEM
 
-config IVSHMEM_DEV_NAME
-       string
-       default "IVSHMEM"
-
 module = IVSHMEM
 module-str = ivshmem
 source "subsys/logging/Kconfig.template.log_config"

--- a/drivers/virtualization/virt_ivshmem_shell.c
+++ b/drivers/virtualization/virt_ivshmem_shell.c
@@ -49,9 +49,9 @@ static void doorbell_notification_thread(const struct shell *shell)
 static bool get_ivshmem(const struct shell *shell)
 {
 	if (ivshmem == NULL) {
-		ivshmem = device_get_binding(CONFIG_IVSHMEM_DEV_NAME);
-		if (!ivshmem) {
-			shell_error(shell, "IVshmem device cannot be found");
+		ivshmem = DEVICE_DT_GET_ONE(qemu_ivshmem);
+		if (!device_is_ready(ivshmem)) {
+			shell_error(shell, "IVshmem device is not ready");
 		}
 	}
 

--- a/tests/drivers/virtualization/ivshmem/app.overlay
+++ b/tests/drivers/virtualization/ivshmem/app.overlay
@@ -7,7 +7,6 @@
 
 / {
 	pcie0 {
-		label = "PCIE_0";
 		#address-cells = <1>;
 		#size-cells = <1>;
 		compatible = "intel,pcie";
@@ -17,7 +16,6 @@
 			compatible = "qemu,ivshmem";
 
 			reg = <PCIE_BDF_NONE PCIE_ID(0x1af4,0x1110)>;
-			label = "IVSHMEM";
 			status = "okay";
 		};
 	};

--- a/tests/drivers/virtualization/ivshmem/src/ivshmem.c
+++ b/tests/drivers/virtualization/ivshmem/src/ivshmem.c
@@ -19,8 +19,8 @@ void test_ivshmem_plain(void)
 	uint16_t vectors;
 	int ret;
 
-	ivshmem = device_get_binding(CONFIG_IVSHMEM_DEV_NAME);
-	zassert_not_null(ivshmem, "Could not get ivshmem device");
+	ivshmem = DEVICE_DT_GET_ONE(qemu_ivshmem);
+	zassert_true(device_is_ready(ivshmem), "ivshmem device is not ready");
 
 	size = ivshmem_get_mem(ivshmem, &mem);
 	zassert_not_equal(size, 0, "Size cannot not be 0");


### PR DESCRIPTION
Replace Kconfig (IVSHMEM_DEV_NAME) based named device_get_binding
with DEVICE_DT_GET_ONE.  Since there is only one driver for ivshmem
use the qemu,ivshmem for that.

Signed-off-by: Kumar Gala <galak@kernel.org>