### PR TITLE
stm32f303: Add lacking SoC-level spi dt-node description.

### DIFF
--- a/dts/arm/st/f3/stm32f303.dtsi
+++ b/dts/arm/st/f3/stm32f303.dtsi
@@ -37,6 +37,17 @@
 			label = "SPI_2";
 		};
 
+		spi3: spi@40003c00 {
+			compatible = "st,stm32-spi-fifo", "st,stm32-spi";
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0x40003c00 0x400>;
+			clocks = <&rcc STM32_CLOCK_BUS_APB1 0x00008000>;
+			interrupts = <51 5>;
+			status = "disabled";
+			label = "SPI_3";
+		};
+
 		pinctrl: pin-controller@48000000 {
 
 			gpioe: gpio@48001000 {

--- a/dts/arm/st/f3/stm32f303X8.dtsi
+++ b/dts/arm/st/f3/stm32f303X8.dtsi
@@ -35,3 +35,7 @@
 		};
 	};
 };
+
+/delete-node/ &spi2;
+
+/delete-node/ &spi3;


### PR DESCRIPTION
The stm32f303 SoC has a spi3 peripheral not listed in current dts.
Add lacking description.

Signed-off-by: Jan Kuliga <jtkuliga@gmail.com>