### PR TITLE
boards: bl5340_dvk: drop the flash and partitions for the NS DTS

### DIFF
--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_ns.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_ns.dts
@@ -23,3 +23,12 @@ zephyr_udc0: &usbd {
 	compatible = "nordic,nrf-usbd";
 	status = "okay";
 };
+
+&qspi {
+	status = "disabled";
+
+	/* Drop the flash and partitions to avoid the config being used for DFU
+	 * samples.
+	 */
+	/delete-node/ mx25r6435f@0;
+};


### PR DESCRIPTION
Change the non-secure dts file to disable the qspi device and drop the
flash node. This has the effects of excluding the QSPI driver from the
build (which is supposedly not being accessible from the non-secure
core) and dropping the partitions under the external flash, skipping
this config in DFU tests.

Followup from https://github.com/zephyrproject-rtos/zephyr/pull/47782