### PR TITLE
dts: arc: Remove label property from devicetrees

### DIFF
--- a/dts/arc/synopsys/arc_hsdk.dtsi
+++ b/dts/arc/synopsys/arc_hsdk.dtsi
@@ -70,7 +70,6 @@
 			compatible = "ns16550";
 			clock-frequency = <33333333>;
 			reg = <0xf0005000 0x1000>;
-			label = "UART_0";
 			interrupts = <30 1>;
 			reg-shift = <2>;
 		};
@@ -79,7 +78,6 @@
 			compatible = "ns16550";
 			clock-frequency = <33333333>;
 			reg = <0xf0026000 0x1000>;
-			label = "UART_1";
 			interrupts = <46 1>;
 			reg-shift = <2>;
 			status = "disabled";
@@ -89,7 +87,6 @@
 			compatible = "ns16550";
 			clock-frequency = <33333333>;
 			reg = <0xf0027000 0x1000>;
-			label = "UART_2";
 			interrupts = <47 1>;
 			reg-shift = <2>;
 			status = "disabled";
@@ -99,7 +96,6 @@
 			compatible = "ns16550";
 			clock-frequency = <33333333>;
 			reg = <0xf0028000 0x1000>;
-			label = "UART_3";
 			interrupts = <48 1>;
 			reg-shift = <2>;
 			status = "disabled";
@@ -109,7 +105,6 @@
 			compatible = "snps,designware-gpio";
 			reg = <0xf0003000 0x1000>;
 			ngpios = <24>;
-			label = "GPIO_0";
 			interrupt-parent = <&idu_intc>;
 
 			gpio-controller;
@@ -122,7 +117,6 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf00014b0 0x4>;
 			ngpios = <12>;
-			label = "CREG_GPIO";
 			bit_per_gpio = <2>;
 			off_val = <0>;
 			on_val = <2>;
@@ -140,7 +134,6 @@
 			#size-cells = <0>;
 			reg = <0xf0023000 0x1000>;
 			interrupts = <43 1>;
-			label = "I2C_0";
 
 			status = "disabled";
 		};
@@ -152,7 +145,6 @@
 			#size-cells = <0>;
 			reg = <0xf0024000 0x1000>;
 			interrupts = <44 1>;
-			label = "I2C_1";
 
 			status = "disabled";
 		};
@@ -164,7 +156,6 @@
 			#size-cells = <0>;
 			reg = <0xf0025000 0x1000>;
 			interrupts = <45 1>;
-			label = "I2C_2";
 
 			status = "disabled";
 		};
@@ -175,7 +166,6 @@
 			#size-cells = <0>;
 			reg = <0xf0020000 0x1000>;
 			interrupts = <40 1>;
-			label = "SPI_0";
 
 			status = "disabled";
 		};
@@ -186,7 +176,6 @@
 			#size-cells = <0>;
 			reg = <0xf0021000 0x1000>;
 			interrupts = <41 1>;
-			label = "SPI_1";
 			status = "disabled";
 		};
 
@@ -196,7 +185,6 @@
 			#size-cells = <0>;
 			reg = <0xf0022000 0x1000>;
 			interrupts = <42 1>;
-			label = "SPI_2";
 			status = "disabled";
 		};
 

--- a/dts/arc/synopsys/arc_iot.dtsi
+++ b/dts/arc/synopsys/arc_iot.dtsi
@@ -65,7 +65,6 @@
 			compatible = "ns16550";
 			clock-frequency = <16000000>;
 			reg = <0x80014000 0x100>;
-			label = "UART_0";
 			interrupts = <86 0>;
 			interrupt-parent = <&intc>;
 			dlf = <0x01>;
@@ -76,7 +75,6 @@
 			compatible = "ns16550";
 			clock-frequency = <16000000>;
 			reg = <0x80014100 0x100>;
-			label = "UART_1";
 			interrupts = <87 0>;
 			interrupt-parent = <&intc>;
 			reg-shift = <2>;
@@ -87,7 +85,6 @@
 			compatible = "ns16550";
 			clock-frequency = <16000000>;
 			reg = <0x80014200 0x1000>;
-			label = "UART_2";
 			interrupts = <88 0>;
 			interrupt-parent = <&intc>;
 			reg-shift = <2>;
@@ -98,7 +95,6 @@
 			compatible = "ns16550";
 			clock-frequency = <144000000>;
 			reg = <0x80014300 0x100>;
-			label = "UART_3";
 			interrupts = <89 0>;
 			interrupt-parent = <&intc>;
 			reg-shift = <2>;
@@ -109,7 +105,6 @@
 			reg = <0x80017800 0x100>;
 			interrupts = <54 1>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_8B_0";
 
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -121,7 +116,6 @@
 			reg = <0x80017900 0x100>;
 			interrupts = <55 1>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_8B_1";
 
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -133,7 +127,6 @@
 			reg = <0x80017a00 0x100>;
 			interrupts = <56 1>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_8B_2";
 
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -145,7 +138,6 @@
 			reg = <0x80017b00 0x100>;
 			interrupts = <57 1>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_8B_3";
 
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -157,7 +149,6 @@
 			reg = <0x80017c00 0x100>;
 			interrupts = <19 1>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_4B_0";
 
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -167,7 +158,6 @@
 			reg = <0x80017d00 0x100>;
 			interrupts = <52 1>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_4B_1";
 
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -179,7 +169,6 @@
 			reg = <0x80017e00 0x100>;
 			interrupts = <53 1>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_4B_2";
 
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -196,7 +185,6 @@
 			interrupts = <58 1>, <61 1>, <60 1>, <59 1>;
 			interrupt-names = "error", "stop", "tx", "rx";
 			interrupt-parent = <&intc>;
-			label = "I2C_0";
 
 			status = "disabled";
 		};
@@ -209,7 +197,6 @@
 			interrupts = <62 1>, <65 1>, <64 1>, <63 1>;
 			interrupt-names = "error", "stop", "tx", "rx";
 			interrupt-parent = <&intc>;
-			label = "I2C_1";
 
 			status = "disabled";
 		};
@@ -222,7 +209,6 @@
 			interrupts = <66 1>, <69 1>, <68 1>, <67 1>;
 			interrupt-names = "error", "stop", "tx", "rx";
 			interrupt-parent = <&intc>;
-			label = "I2C_2";
 
 			status = "disabled";
 		};
@@ -236,7 +222,6 @@
 			interrupts = <70 2>, <71 2>, <72 2>;
 			interrupt-names = "err-int", "rx-avail", "tx-req";
 			interrupt-parent = <&intc>;
-			label = "SPI_0";
 			status = "disabled";
 		};
 
@@ -249,7 +234,6 @@
 			interrupts = <74 2>, <75 2>, <76 2>;
 			interrupt-names = "err-int", "rx-avail", "tx-req";
 			interrupt-parent = <&intc>;
-			label = "SPI_1";
 			status = "disabled";
 		};
 
@@ -262,7 +246,6 @@
 			interrupts = <78 2>, <79 2>, <80 2>;
 			interrupt-names = "err-int", "rx-avail", "tx-req";
 			interrupt-parent = <&intc>;
-			label = "SPI_2";
 			status = "disabled";
 		};
 

--- a/dts/arc/synopsys/emsdp.dtsi
+++ b/dts/arc/synopsys/emsdp.dtsi
@@ -57,7 +57,6 @@
 			compatible = "ns16550";
 			clock-frequency = <DT_APB_CLK_HZ>;
 			reg = <0xf0004000 0x1000>;
-			label = "UART_0";
 			interrupt-parent = <&intc>;
 			reg-shift = <2>;
 		};
@@ -66,7 +65,6 @@
 			compatible = "snps,designware-gpio";
 			reg = <0xf0002000 0xc>;
 			ngpios = <4>;
-			label = "GPIO_0";
 			interrupt-parent = <&intc>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -76,7 +74,6 @@
 			compatible = "snps,designware-gpio";
 			reg = <0xf000200c 0xc>;
 			ngpios = <8>;
-			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};

--- a/dts/arc/synopsys/emsk.dtsi
+++ b/dts/arc/synopsys/emsk.dtsi
@@ -52,7 +52,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0xf0004000 0x1000>;
-			label = "I2C_0";
 			interrupt-parent = <&intc>;
 		};
 
@@ -62,7 +61,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0xf0005000 0x1000>;
-			label = "I2C_1";
 			interrupt-parent = <&intc>;
 		};
 
@@ -70,7 +68,6 @@
 			compatible = "ns16550";
 			clock-frequency = <DT_APB_CLK_HZ>;
 			reg = <0xf0008000 0x1000>;
-			label = "UART_0";
 			interrupt-parent = <&intc>;
 			reg-shift = <2>;
 		};
@@ -79,7 +76,6 @@
 			compatible = "ns16550";
 			clock-frequency = <DT_APB_CLK_HZ>;
 			reg = <0xf0009000 0x1000>;
-			label = "UART_1";
 			interrupt-parent = <&intc>;
 			reg-shift = <2>;
 		};
@@ -88,7 +84,6 @@
 			compatible = "ns16550";
 			clock-frequency = <DT_APB_CLK_HZ>;
 			reg = <0xf000a000 0x1000>;
-			label = "UART_2";
 			interrupt-parent = <&intc>;
 			reg-shift = <2>;
 		};
@@ -97,7 +92,6 @@
 			compatible = "snps,designware-gpio";
 			reg = <0xf0002000 0xc>;
 			ngpios = <32>;
-			label = "GPIO_0";
 			interrupt-parent = <&intc>;
 
 			gpio-controller;
@@ -108,7 +102,6 @@
 			compatible = "snps,designware-gpio";
 			reg = <0xf000200c 0xc>;
 			ngpios = <9>;
-			label = "GPIO_1";
 			interrupt-parent = <&intc>;
 
 			gpio-controller;
@@ -119,7 +112,6 @@
 			compatible = "snps,designware-gpio";
 			reg = <0xF0002018 0xc>;
 			ngpios = <32>;
-			label = "GPIO_2";
 
 			interrupt-parent = <&intc>;
 
@@ -131,7 +123,6 @@
 			compatible = "snps,designware-gpio";
 			reg = <0xF0002024 0xc>;
 			ngpios = <12>;
-			label = "GPIO_3";
 
 			interrupt-parent = <&intc>;
 
@@ -142,7 +133,6 @@
 		spi0: spi@f0006000 {
 			compatible = "snps,designware-spi";
 			reg = <0xf0006000 0x1000>;
-			label = "SPI_0";
 			clocks = <&sysclk>;
 			interrupt-parent = <&intc>;
 
@@ -154,7 +144,6 @@
 		spi1: spi@f0007000 {
 			compatible = "snps,designware-spi";
 			reg = <0xf0007000 0x1000>;
-			label = "SPI_1";
 			clocks = <&sysclk>;
 			interrupt-parent = <&intc>;
 


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>