### PR TITLE
twister: run tests on device with twister on windows

### DIFF
--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -36,17 +36,39 @@ These also affect the outputs of ``--testcase-report`` and
 
 To run the script in the local tree, follow the steps below:
 
-::
+.. tabs::
 
-        $ source zephyr-env.sh
-        $ ./scripts/twister
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         $ source zephyr-env.sh
+         $ ./scripts/twister
+
+   .. group-tab:: Windows
+
+      .. code-block:: bat
+
+         zephyr-env.cmd
+         python .\scripts\twister
+
 
 If you have a system with a large number of cores and plenty of free storage space,
 you can build and run all possible tests using the following options:
 
-::
+.. tabs::
 
-        $ ./scripts/twister --all --enable-slow
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         $ ./scripts/twister --all --enable-slow
+
+   .. group-tab:: Windows
+
+      .. code-block:: bat
+
+         python .\scripts\twister --all --enable-slow
 
 This will build for all available boards and run all applicable tests in
 a simulated (for example QEMU) environment.
@@ -57,10 +79,21 @@ option, test suites will only be built/run on the platforms specified.
 This option also supports different revisions of one same board,
 you can use ``--platform board@revision`` to test on a specific revision.
 
-The list of command line options supported by twister can be viewed using::
+The list of command line options supported by twister can be viewed using:
 
-        $ ./scripts/twister --help
+.. tabs::
 
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         $ ./scripts/twister --help
+
+   .. group-tab:: Windows
+
+      .. code-block:: bat
+
+         python .\scripts\twister --help
 
 
 Board Configuration
@@ -519,10 +552,23 @@ Executing tests on a single device
 ===================================
 
 To use this feature on a single connected device, run twister with
-the following new options::
+the following new options:
 
-	scripts/twister --device-testing --device-serial /dev/ttyACM0 \
-	--device-serial-baud 9600 -p frdm_k64f  -T tests/kernel
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+	      scripts/twister --device-testing --device-serial /dev/ttyACM0 \
+	      --device-serial-baud 115200 -p frdm_k64f  -T tests/kernel
+
+   .. group-tab:: Windows
+
+      .. code-block:: bat
+
+	      python .\scripts\twister --device-testing --device-serial COM1 \
+	      --device-serial-baud 115200 -p frdm_k64f  -T tests/kernel
 
 The ``--device-serial`` option denotes the serial device the board is connected to.
 This needs to be accessible by the user running twister. You can run this on
@@ -533,10 +579,22 @@ The ``--device-serial-baud`` option is only needed if your device does not run a
 
 To support devices without a physical serial port, use the ``--device-serial-pty``
 option. In this cases, log messages are captured for example using a script.
-In this case you can run twister with the following options::
+In this case you can run twister with the following options:
 
-    scripts/twister --device-testing --device-serial-pty "script.py" \
-    -p intel_adsp_cavs25 -T tests/kernel
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         scripts/twister --device-testing --device-serial-pty "script.py" \
+         -p intel_adsp_cavs25 -T tests/kernel
+
+   .. group-tab:: Windows
+
+      .. note::
+
+         Not supported on Windows OS
 
 The script is user-defined and handles delivering the messages which can be
 used by twister to determine the test execution status.
@@ -548,46 +606,106 @@ Executing tests on multiple devices
 To build and execute tests on multiple devices connected to the host PC, a
 hardware map needs to be created with all connected devices and their
 details such as the serial device, baud and their IDs if available.
-Run the following command to produce the hardware map::
+Run the following command to produce the hardware map:
 
-    ./scripts/twister --generate-hardware-map map.yml
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         ./scripts/twister --generate-hardware-map map.yml
+
+   .. group-tab:: Windows
+
+      .. code-block:: bat
+
+         python .\scripts\twister --generate-hardware-map map.yml
 
 The generated hardware map file (map.yml) will have the list of connected
-devices, for example::
+devices, for example:
 
-  - connected: true
-    id: OSHW000032254e4500128002ab98002784d1000097969900
-    platform: unknown
-    product: DAPLink CMSIS-DAP
-    runner: pyocd
-    serial: /dev/cu.usbmodem146114202
-  - connected: true
-    id: 000683759358
-    platform: unknown
-    product: J-Link
-    runner: unknown
-    serial: /dev/cu.usbmodem0006837593581
+.. tabs::
+
+   .. group-tab:: Linux
+
+    ::
+
+      - connected: true
+        id: OSHW000032254e4500128002ab98002784d1000097969900
+        platform: unknown
+        product: DAPLink CMSIS-DAP
+        runner: pyocd
+        serial: /dev/cu.usbmodem146114202
+      - connected: true
+        id: 000683759358
+        platform: unknown
+        product: J-Link
+        runner: unknown
+        serial: /dev/cu.usbmodem0006837593581
+
+   .. group-tab:: Windows
+
+    ::
+
+      - connected: true
+        id: OSHW000032254e4500128002ab98002784d1000097969900
+        platform: unknown
+        product: unknown
+        runner: unknown
+        serial: COM1
+      - connected: true
+        id: 000683759358
+        platform: unknown
+        product: unknown
+        runner: unknown
+        serial: COM2
 
 
 Any options marked as 'unknown' need to be changed and set with the correct
-values, in the above example both the platform names and the runners need to be
-replaced with the correct values corresponding to the connected hardware. In
-this example we are using a reel_board and an nrf52840dk_nrf52840::
+values, in the above example the platform names, the products and the runners need
+to be replaced with the correct values corresponding to the connected hardware.
+In this example we are using a reel_board and an nrf52840dk_nrf52840:
 
-  - connected: true
-    id: OSHW000032254e4500128002ab98002784d1000097969900
-    platform: reel_board
-    product: DAPLink CMSIS-DAP
-    runner: pyocd
-    serial: /dev/cu.usbmodem146114202
-    baud: 9600
-  - connected: true
-    id: 000683759358
-    platform: nrf52840dk_nrf52840
-    product: J-Link
-    runner: nrfjprog
-    serial: /dev/cu.usbmodem0006837593581
-    baud: 9600
+.. tabs::
+
+   .. group-tab:: Linux
+
+    ::
+
+      - connected: true
+        id: OSHW000032254e4500128002ab98002784d1000097969900
+        platform: reel_board
+        product: DAPLink CMSIS-DAP
+        runner: pyocd
+        serial: /dev/cu.usbmodem146114202
+        baud: 9600
+      - connected: true
+        id: 000683759358
+        platform: nrf52840dk_nrf52840
+        product: J-Link
+        runner: nrfjprog
+        serial: /dev/cu.usbmodem0006837593581
+        baud: 9600
+
+   .. group-tab:: Windows
+
+    ::
+
+      - connected: true
+        id: OSHW000032254e4500128002ab98002784d1000097969900
+        platform: reel_board
+        product: DAPLink CMSIS-DAP
+        runner: pyocd
+        serial: COM1
+        baud: 9600
+      - connected: true
+        id: 000683759358
+        platform: nrf52840dk_nrf52840
+        product: J-Link
+        runner: nrfjprog
+        serial: COM2
+        baud: 9600
 
 The baud entry is only needed if not running at 115200.
 
@@ -596,9 +714,20 @@ will be updated. This way you can use one single master hardware map and update
 it for every run to get the correct serial devices and status of the devices.
 
 With the hardware map ready, you can run any tests by pointing to the map
-file::
 
-  ./scripts/twister --device-testing --hardware-map map.yml -T samples/hello_world/
+.. tabs::
+
+   .. group-tab:: Linux
+
+      .. code-block:: bash
+
+         ./scripts/twister --device-testing --hardware-map map.yml -T samples/hello_world/
+
+   .. group-tab:: Windows
+
+      .. code-block:: bat
+
+         python .\scripts\twister --device-testing --hardware-map map.yml -T samples\hello_world
 
 The above command will result in twister building tests for the platforms
 defined in the hardware map and subsequently flashing and running the tests
@@ -635,13 +764,24 @@ hardware map::
 
 The runner_params field indicates the parameters you want to pass to the
 west runner. For some boards the west runner needs some extra parameters to
-work. It is equivalent to following west and twister commands::
+work. It is equivalent to following west and twister commands.
 
-   west flash --remote-host remote_host_ip_addr --key /path/to/key.pem
+.. tabs::
 
-   twister -p intel_adsp_cavs18 --device-testing --device-serial-pty script.py
-   --west-flash="--remote-host=remote_host_ip_addr,--key=/path/to/key.pem"
+   .. group-tab:: Linux
 
+      .. code-block:: bash
+
+         west flash --remote-host remote_host_ip_addr --key /path/to/key.pem
+
+         twister -p intel_adsp_cavs18 --device-testing --device-serial-pty script.py
+         --west-flash="--remote-host=remote_host_ip_addr,--key=/path/to/key.pem"
+
+   .. group-tab:: Windows
+
+      .. note::
+
+         Not supported on Windows OS
 
 .. note::
 

--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -2,6 +2,7 @@
 # vim: set syntax=python ts=4 :
 #
 # Copyright (c) 20180-2022 Intel Corporation
+# Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 import math
@@ -317,15 +318,12 @@ class DeviceHandler(Handler):
         """
         super().__init__(instance, type_str)
 
-    def monitor_serial(self, ser, halt_fileno, harness):
+    def monitor_serial(self, ser, halt_event, harness):
         if harness.is_pytest:
             harness.handle(None)
             return
 
         log_out_fp = open(self.log, "wt")
-
-        ser_fileno = ser.fileno()
-        readlist = [halt_fileno, ser_fileno]
 
         if self.options.coverage:
             # Set capture_coverage to True to indicate that right after
@@ -336,14 +334,16 @@ class DeviceHandler(Handler):
         ser.flush()
 
         while ser.isOpen():
-            readable, _, _ = select.select(readlist, [], [], self.timeout)
-
-            if halt_fileno in readable:
+            if halt_event.is_set():
                 logger.debug('halted')
                 ser.close()
                 break
-            if ser_fileno not in readable:
-                continue  # Timeout.
+
+            if not ser.in_waiting:
+                # no incoming bytes are waiting to be read from the serial
+                # input buffer, let other threads run
+                time.sleep(0.001)
+                continue
 
             serial_line = None
             try:
@@ -529,12 +529,12 @@ class DeviceHandler(Handler):
         harness_import = HarnessImporter(harness_name)
         harness = harness_import.instance
         harness.configure(self.instance)
-        read_pipe, write_pipe = os.pipe()
-        start_time = time.time()
+        halt_monitor_evt = threading.Event()
 
         t = threading.Thread(target=self.monitor_serial, daemon=True,
-                             args=(ser, read_pipe, harness))
+                             args=(ser, halt_monitor_evt, harness))
         t.start()
+        start_time = time.time()
 
         d_log = "{}/device.log".format(self.instance.build_dir)
         logger.debug('Flash command: %s', command)
@@ -553,10 +553,10 @@ class DeviceHandler(Handler):
                         flash_error = True
                         with open(d_log, "w") as dlog_fp:
                             dlog_fp.write(stderr.decode())
-                        os.write(write_pipe, b'x')  # halt the thread
+                        halt_monitor_evt.set()
                 except subprocess.TimeoutExpired:
                     logger.warning("Flash operation timed out.")
-                    proc.kill()
+                    self.terminate(proc)
                     (stdout, stderr) = proc.communicate()
                     self.instance.status = "error"
                     self.instance.reason = "Device issue (Timeout)"
@@ -566,7 +566,7 @@ class DeviceHandler(Handler):
                 dlog_fp.write(stderr.decode())
 
         except subprocess.CalledProcessError:
-            os.write(write_pipe, b'x')  # halt the thread
+            halt_monitor_evt.set()
             self.instance.status = "error"
             self.instance.reason = "Device issue (Flash error)"
             flash_error = True
@@ -594,9 +594,6 @@ class DeviceHandler(Handler):
             ser_pty_process.terminate()
             outs, errs = ser_pty_process.communicate()
             logger.debug("Process {} terminated outs: {} errs {}".format(serial_pty, outs, errs))
-
-        os.close(write_pipe)
-        os.close(read_pipe)
 
         handler_time = time.time() - start_time
 

--- a/scripts/pylib/twister/twisterlib/hardwaremap.py
+++ b/scripts/pylib/twister/twisterlib/hardwaremap.py
@@ -117,7 +117,8 @@ class HardwareMap:
         'NXP Semiconductors',
         'Microchip Technology Inc.',
         'FTDI',
-        'Digilent'
+        'Digilent',
+        'Microsoft'
     ]
 
     runner_mapping = {
@@ -276,6 +277,10 @@ class HardwareMap:
                 # assume endpoint 0 is the serial, skip all others
                 if d.manufacturer == 'Texas Instruments' and not d.location.endswith('0'):
                     continue
+
+                if d.product is None:
+                    d.product = 'unknown'
+
                 s_dev = DUT(platform="unknown",
                                         id=d.serial_number,
                                         serial=persistent_map.get(d.device, d.device),

--- a/scripts/pylib/twister/twisterlib/testinstance.py
+++ b/scripts/pylib/twister/twisterlib/testinstance.py
@@ -1,6 +1,7 @@
 # vim: set syntax=python ts=4 :
 #
 # Copyright (c) 2018-2022 Intel Corporation
+# Copyright 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
 import os
@@ -183,9 +184,8 @@ class TestInstance:
     # Global testsuite parameters
     def check_runnable(self, enable_slow=False, filter='buildable', fixtures=[]):
 
-        # right now we only support building on windows. running is still work
-        # in progress.
-        if os.name == 'nt':
+        # running on simulators is currently not supported on Windows
+        if os.name == 'nt' and self.platform.simulation != 'na':
             return False
 
         # we asked for build-only on the command line


### PR DESCRIPTION
Currently, support for Twister on Windows is only build.
The only thing that needs to be ported is that select()
cannot wait on file descriptors on Windows. Therefore
the serial monitor function needs to be reworked to
support both OSes.