### PR TITLE
Bluetooth: Host: Don't start scanner bt_conn_le_create

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2675,6 +2675,7 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 
 #if defined(CONFIG_BT_SMP)
 	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
+	    (bt_dev.le.rl_entries > 0) &&
 	    (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size)) {
 		bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 


### PR DESCRIPTION
Unless I have misunderstood something, I think this change makes a lot of sense.
When nothing has been added to the resolving list, we should not enable the feature where we start a scanner so that the host can resolve addresses before connecting.

This had me confused for a while when I expected the controller to connect directly with the configured window/interval parameters, but because of this if being taken, the host actually started a scanner with different parameters first.

But another reason not to scan first and then connect is that it is less effective. Takes more time, and you also need to receive at least two adv packets on the air. Which might be hard in an environment with a lot of rf-noise. 

One argument against this change can be that the application might add something to the resolving list after the scanner has been started. But that is already broken even without this change, in the case where we go to connect state directly (because all the resoling list fits in the controller) and then the application adds more items to the resolving list, expecting it use those new items too.