### PR TITLE
arch: comply to coding guidelines MISRA C:2012 Rule 14.4

### DIFF
--- a/arch/arm/include/aarch32/cortex_m/tz_ns.h
+++ b/arch/arm/include/aarch32/cortex_m/tz_ns.h
@@ -65,7 +65,7 @@
 			"pop {r0-r3}\n\t" \
 			load_lr "\n\t" \
 			::); \
-	} while (0)
+	} while (false)
 
 /**
  * @brief Macro for "sandwiching" a function call (@p name) in two other calls

--- a/arch/nios2/include/kernel_arch_func.h
+++ b/arch/nios2/include/kernel_arch_func.h
@@ -53,15 +53,15 @@ void z_irq_do_offload(void);
 #if ALT_CPU_ICACHE_SIZE > 0
 void z_nios2_icache_flush_all(void);
 #else
-#define z_nios2_icache_flush_all() do { } while (0)
+#define z_nios2_icache_flush_all() do { } while (false)
 #endif
 
 #if ALT_CPU_DCACHE_SIZE > 0
 void z_nios2_dcache_flush_all(void);
 void z_nios2_dcache_flush_no_writeback(void *start, uint32_t len);
 #else
-#define z_nios2_dcache_flush_all() do { } while (0)
-#define z_nios2_dcache_flush_no_writeback(x, y) do { } while (0)
+#define z_nios2_dcache_flush_all() do { } while (false)
+#define z_nios2_dcache_flush_no_writeback(x, y) do { } while (false)
 #endif
 
 #endif /* _ASMLANGUAGE */

--- a/arch/x86/core/acpi.c
+++ b/arch/x86/core/acpi.c
@@ -149,7 +149,7 @@ void *z_acpi_find_table(uint32_t signature)
 		return NULL;
 	}
 
-	if (rsdp->rsdt_ptr) {
+	if (rsdp->rsdt_ptr != 0U) {
 		z_phys_map((uint8_t **)&rsdt, rsdp->rsdt_ptr, sizeof(*rsdt), 0);
 		tbl_found = false;
 
@@ -191,7 +191,7 @@ void *z_acpi_find_table(uint32_t signature)
 		return NULL;
 	}
 
-	if (rsdp->xsdt_ptr) {
+	if (rsdp->xsdt_ptr != 0ULL) {
 		z_phys_map((uint8_t **)&xsdt, rsdp->xsdt_ptr, sizeof(*xsdt), 0);
 
 		tbl_found = false;

--- a/arch/x86/core/x86_mmu.c
+++ b/arch/x86/core/x86_mmu.c
@@ -531,7 +531,7 @@ static inline bool is_region_page_aligned(void *addr, size_t size)
 
 #define COLOR(x)	printk(_CONCAT(ANSI_, x))
 #else
-#define COLOR(x)	do { } while (0)
+#define COLOR(x)	do { } while (false)
 #endif
 
 __pinned_func
@@ -740,7 +740,7 @@ static void dump_entry(int level, void *virt, pentry_t entry)
 			if ((entry & MMU_##bit) != 0U) { \
 				str_append(&pos, &sz, #bit " "); \
 			} \
-		} while (0)
+		} while (false)
 
 	DUMP_BIT(RW);
 	DUMP_BIT(US);

--- a/arch/x86/zefi/printf.h
+++ b/arch/x86/zefi/printf.h
@@ -5,6 +5,7 @@
  */
 #include <stdarg.h>
 #include <stdbool.h>
+#include <stddef.h>
 
 /* Tiny, but not-as-primitive-as-it-looks implementation of something
  * like s/n/printf().  Handles %d, %x, %p, %c and %s only, allows a
@@ -24,7 +25,7 @@ static void (*z_putchar)(int c);
 
 static void pc(struct _pfr *r, int c)
 {
-	if (r->buf) {
+	if (r->buf != NULL) {
 		if (r->idx <= r->len) {
 			r->buf[r->idx] = c;
 		}
@@ -50,7 +51,7 @@ static void prdec(struct _pfr *r, long v)
 		v /= 10;
 	}
 
-	while (digs[++i]) {
+	while (digs[++i] != '\0') {
 		pc(r, digs[i]);
 	}
 }
@@ -64,7 +65,7 @@ static void endrec(struct _pfr *r)
 
 static int vpf(struct _pfr *r, const char *f, va_list ap)
 {
-	for (/**/; *f; f++) {
+	for (/**/; *f != '\0'; f++) {
 		bool islong = false;
 
 		if (*f != '%') {
@@ -100,7 +101,7 @@ static int vpf(struct _pfr *r, const char *f, va_list ap)
 		case 's': {
 			char *s = va_arg(ap, char *);
 
-			while (*s)
+			while (*s != '\0')
 				pc(r, *s++);
 			break;
 		}


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 14.4 in arch:
> The controlling expression of an if statement
> and the controlling expression of an iteration-statement shall have
> essentially Boolean type.

This PR is part of the enhancement issue #48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
5d02614e34a86b549c7707d3d9f0984bc3a5f22a
