### PR TITLE
soc: ace_v1x: check physical memory bounds on page unmap.

### DIFF
--- a/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
+++ b/drivers/mm/mm_drv_intel_adsp_mtl_tlb.c
@@ -401,12 +401,16 @@ int sys_mm_drv_unmap_page(void *virt)
 
 	pa = tlb_entry_to_pa(tlb_entries[entry_idx]);
 
-	sys_mem_blocks_free_contiguous(&L2_PHYS_SRAM_REGION,
-				       UINT_TO_POINTER(pa), 1);
+	/* Check bounds of physical address space. */
+	/* Initial TLB mappings could point to non existing physical pages. */
+	if ((pa >= L2_SRAM_BASE) && (pa < (L2_SRAM_BASE + L2_SRAM_SIZE))) {
+		sys_mem_blocks_free_contiguous(&L2_PHYS_SRAM_REGION,
+					       UINT_TO_POINTER(pa), 1);
 
-	bank_idx = get_hpsram_bank_idx(pa);
-	if (--hpsram_ref[bank_idx] == 0) {
-		sys_mm_drv_hpsram_pwr(bank_idx, false, false);
+		bank_idx = get_hpsram_bank_idx(pa);
+		if (--hpsram_ref[bank_idx] == 0) {
+			sys_mm_drv_hpsram_pwr(bank_idx, false, false);
+		}
 	}
 
 	k_spin_unlock(&tlb_lock, key);


### PR DESCRIPTION
This patch fix issue with unmapping of virtual addresses mapped
to non-existing physical memory. MTL TLB table is initialised with
1:1 mapping, however virtual space is much wider than available
physical space. We should not try to free and manage of power for
non-existing physical pages.

Signed-off-by: Jaroslaw Stelter <Jaroslaw.Stelter@intel.com>