### PR TITLE
Bluetooth: ISO: Add check for maximum ISO SDU size

### DIFF
--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -2031,6 +2031,11 @@ int bt_audio_stream_release(struct bt_audio_stream *stream, bool cache);
  *
  *  @param stream   Stream object.
  *  @param buf      Buffer containing data to be sent.
+ *                  The maximum size is the SDU that was
+ *                  configured, minus the header size. The header size is either
+ *                  @ref BT_HCI_ISO_DATA_HDR_SIZE or
+ *                  @ref BT_HCI_ISO_TS_DATA_HDR_SIZE depending on @p ts
+ *                  (the latter is used if @p ts is not BT_ISO_TIMESTAMP_NONE).
  *  @param seq_num  Packet Sequence number. This value shall be incremented for
  *                  each call to this function and at least once per SDU
  *                  interval for a specific channel.

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -646,6 +646,11 @@ int bt_iso_chan_disconnect(struct bt_iso_chan *chan);
  *
  *  @param chan     Channel object.
  *  @param buf      Buffer containing data to be sent.
+ *                  The maximum size is the @ref bt_iso_chan_io_qos.sdu that was
+ *                  configured, minus the header size. The header size is either
+ *                  @ref BT_HCI_ISO_DATA_HDR_SIZE or
+ *                  @ref BT_HCI_ISO_TS_DATA_HDR_SIZE depending on @p ts
+ *                  (the latter is used if @p ts is not BT_ISO_TIMESTAMP_NONE).
  *  @param seq_num  Packet Sequence number. This value shall be incremented for
  *                  each call to this function and at least once per SDU
  *                  interval for a specific channel.

--- a/samples/bluetooth/unicast_audio_client/src/main.c
+++ b/samples/bluetooth/unicast_audio_client/src/main.c
@@ -322,7 +322,7 @@ static void audio_timer_timeout(struct k_work *work)
 	k_work_schedule(&audio_send_work, K_MSEC(1000));
 
 	len_to_send++;
-	if (len_to_send > ARRAY_SIZE(buf_data)) {
+	if (len_to_send > codec_configuration.qos.sdu) {
 		len_to_send = 1;
 	}
 }


### PR DESCRIPTION
Verify that the HCI ISO data packet is smaller than
the maximum SDU size we support, based on the group
settings.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>