### PR TITLE
kernel: comply to coding guidelines MISRA C:2012 Rule 14.4

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -60,7 +60,7 @@ static inline void wait_for_switch(struct k_thread *thread)
  */
 static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 					  struct k_spinlock *lock,
-					  int is_spinlock)
+					  bool is_spinlock)
 {
 	ARG_UNUSED(lock);
 	struct k_thread *new_thread, *old_thread;
@@ -161,17 +161,17 @@ static ALWAYS_INLINE unsigned int do_swap(unsigned int key,
 
 static inline int z_swap_irqlock(unsigned int key)
 {
-	return do_swap(key, NULL, 0);
+	return do_swap(key, NULL, false);
 }
 
 static inline int z_swap(struct k_spinlock *lock, k_spinlock_key_t key)
 {
-	return do_swap(key.key, lock, 1);
+	return do_swap(key.key, lock, true);
 }
 
 static inline void z_swap_unlocked(void)
 {
-	(void) do_swap(arch_irq_lock(), NULL, 1);
+	(void) do_swap(arch_irq_lock(), NULL, true);
 }
 
 #else /* !CONFIG_USE_SWITCH */

--- a/kernel/mmu.c
+++ b/kernel/mmu.c
@@ -69,7 +69,7 @@ static bool page_frames_initialized;
 
 #define COLOR(x)	printk(_CONCAT(ANSI_, x))
 #else
-#define COLOR(x)	do { } while (0)
+#define COLOR(x)	do { } while (false)
 #endif
 
 /* LCOV_EXCL_START */

--- a/kernel/sched.c
+++ b/kernel/sched.c
@@ -354,8 +354,8 @@ static ALWAYS_INLINE struct k_thread *next_up(void)
 		end_thread(_current);
 	}
 
-	int queued = z_is_thread_queued(_current);
-	int active = !z_is_thread_prevented_from_running(_current);
+	bool queued = z_is_thread_queued(_current);
+	bool active = !z_is_thread_prevented_from_running(_current);
 
 	if (thread == NULL) {
 		thread = _current_cpu->idle_thread;

--- a/kernel/smp.c
+++ b/kernel/smp.c
@@ -28,7 +28,7 @@ unsigned int z_smp_global_lock(void)
 
 void z_smp_global_unlock(unsigned int key)
 {
-	if (_current->base.global_lock_count) {
+	if (_current->base.global_lock_count != 0U) {
 		_current->base.global_lock_count--;
 
 		if (!_current->base.global_lock_count) {

--- a/kernel/timer.c
+++ b/kernel/timer.c
@@ -161,7 +161,7 @@ void z_impl_k_timer_stop(struct k_timer *timer)
 {
 	SYS_PORT_TRACING_OBJ_FUNC(k_timer, stop, timer);
 
-	int inactive = z_abort_timeout(&timer->timeout) != 0;
+	bool inactive = (z_abort_timeout(&timer->timeout) != 0);
 
 	if (inactive) {
 		return;


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 14.4 in kernel:
> The controlling expression of an if statement
> and the controlling expression of an iteration-statement shall have
> essentially Boolean type.

This PR is part of the enhancement issue #48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
5d02614e34a86b549c7707d3d9f0984bc3a5f22a