### PR TITLE
drivers: gpio: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/gpio/Kconfig.andes_atcgpio100
+++ b/drivers/gpio/Kconfig.andes_atcgpio100
@@ -7,6 +7,8 @@
 
 config GPIO_ANDES_ATCGPIO100
 	bool "Andes ATCGPIO100 GPIO driver"
+	default y
+	depends on DT_HAS_ANDESTECH_ATCGPIO100_ENABLED
 	depends on SOC_SERIES_RISCV_ANDES_V5
 	help
 	  Enable driver for the Andes ATCGPIO100 GPIO controller.

--- a/drivers/gpio/Kconfig.b91
+++ b/drivers/gpio/Kconfig.b91
@@ -5,6 +5,8 @@
 
 config GPIO_TELINK_B91
 	bool "Telink B91 GPIO driver"
+	default y
+	depends on DT_HAS_TELINK_B91_GPIO_ENABLED
 	depends on SOC_RISCV_TELINK_B91
 	help
 	  Enable the B91 GPIO driver.

--- a/drivers/gpio/Kconfig.cc13xx_cc26xx
+++ b/drivers/gpio/Kconfig.cc13xx_cc26xx
@@ -5,6 +5,8 @@
 
 config GPIO_CC13XX_CC26XX
 	bool "TI SimpleLink CC13xx / CC26xx GPIO driver"
+	default y
+	depends on DT_HAS_TI_CC13XX_CC26XX_GPIO_ENABLED
 	depends on SOC_SERIES_CC13X2_CC26X2
 	help
 	  Enable the TI SimpleLink CC13xx / CC26xx GPIO driver.

--- a/drivers/gpio/Kconfig.cc32xx
+++ b/drivers/gpio/Kconfig.cc32xx
@@ -4,6 +4,8 @@
 
 config GPIO_CC32XX
 	bool "TI CC32XX GPIO driver"
+	default y
+	depends on DT_HAS_TI_CC32XX_GPIO_ENABLED
 	depends on SOC_FAMILY_TISIMPLELINK
 	help
 	  Enable the GPIO driver on TI SimpleLink CC32xx boards

--- a/drivers/gpio/Kconfig.cmsdk_ahb
+++ b/drivers/gpio/Kconfig.cmsdk_ahb
@@ -5,6 +5,8 @@
 
 config GPIO_CMSDK_AHB
 	bool "ARM CMSDK (Cortex-M System Design Kit) AHB GPIO Controllers"
+	default y
+	depends on DT_HAS_ARM_CMSDK_GPIO_ENABLED
 	depends on SOC_FAMILY_ARM
 	help
 	  Enable config options to support the ARM CMSDK GPIO controllers.

--- a/drivers/gpio/Kconfig.creg_gpio
+++ b/drivers/gpio/Kconfig.creg_gpio
@@ -3,11 +3,9 @@
 # Copyright (c) 2021 Synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_SNPS_CREG_GPIO := snps,creg-gpio
-
 config GPIO_SNPS_CREG
 	bool "SNPS CREG GPIO"
-	default $(dt_compat_enabled,$(DT_COMPAT_SNPS_CREG_GPIO))
+	default y
+	depends on DT_HAS_SNPS_CREG_GPIO_ENABLED
 	help
 	  Enable driver for SNPS CREG GPIO.

--- a/drivers/gpio/Kconfig.cy8c95xx
+++ b/drivers/gpio/Kconfig.cy8c95xx
@@ -3,12 +3,10 @@
 # Copyright (c) 2021 Synopsys
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_CYPRESS_CY8C95XX := cypress,cy8c95xx-gpio
-
 menuconfig GPIO_CY8C95XX
 	bool "CY8C95XX I2C GPIO chip"
-	default $(dt_compat_enabled,$(DT_COMPAT_CYPRESS_CY8C95XX))
+	default y
+	depends on DT_HAS_CYPRESS_CY8C95XX_GPIO_PORT_ENABLED
 	depends on I2C
 	help
 	  Enable driver for CY8C95XX I2C GPIO chip.

--- a/drivers/gpio/Kconfig.dw
+++ b/drivers/gpio/Kconfig.dw
@@ -5,5 +5,7 @@
 
 config GPIO_DW
 	bool "Designware GPIO"
+	default y
+	depends on DT_HAS_SNPS_DESIGNWARE_GPIO_ENABLED
 	help
 	  Enable driver for Designware GPIO

--- a/drivers/gpio/Kconfig.emul
+++ b/drivers/gpio/Kconfig.emul
@@ -3,12 +3,10 @@
 # Copyright (c) 2020 Friedt Professional Engineering Services, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_ZEPHYR_GPIO_EMUL := zephyr,gpio-emul
-
 config GPIO_EMUL
 	bool "Emulated GPIO driver"
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_GPIO_EMUL))
+	default y
+	depends on DT_HAS_ZEPHYR_GPIO_EMUL_ENABLED
 	help
 	  Enable the emulated GPIO driver. Mainly used for testing, this
 	  driver allows for an arbitrary number of emulated GPIO controllers

--- a/drivers/gpio/Kconfig.eos_s3
+++ b/drivers/gpio/Kconfig.eos_s3
@@ -5,6 +5,8 @@
 
 config GPIO_EOS_S3
 	bool "EOS_S3 GPIO driver"
+	default y
+	depends on DT_HAS_QUICKLOGIC_EOS_S3_GPIO_ENABLED
 	depends on EOS_S3_HAL
 	help
 	  Enable the EOS S3 gpio driver.

--- a/drivers/gpio/Kconfig.esp32
+++ b/drivers/gpio/Kconfig.esp32
@@ -5,6 +5,8 @@
 
 config GPIO_ESP32
 	bool "ESP32 GPIO"
+	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_GPIO_ENABLED
 	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
 	help
 	  Enables the ESP32 GPIO driver

--- a/drivers/gpio/Kconfig.fxl6408
+++ b/drivers/gpio/Kconfig.fxl6408
@@ -3,6 +3,8 @@
 
 menuconfig GPIO_FXL6408
 	bool "FXL6408 I2C-based GPIO chip"
+	default y
+	depends on DT_HAS_FCS_FXL6408_ENABLED
 	depends on I2C
 	help
 	  Enable driver for FXL6408 I2C-based GPIO chip.

--- a/drivers/gpio/Kconfig.gd32
+++ b/drivers/gpio/Kconfig.gd32
@@ -1,11 +1,10 @@
 # Copyright (c) 2021 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_GD_GD32_GPIO := gd,gd32-gpio
-
 config GPIO_GD32
 	bool "GD32 GPIO driver"
+	default y
+	depends on DT_HAS_GD_GD32_GPIO_ENABLED
 	depends on (SOC_FAMILY_GD32 || SOC_SERIES_GD32VF103)
-	default $(dt_compat_enabled,$(DT_COMPAT_GD_GD32_GPIO))
 	help
 	  Enable the GD32 GPIO driver.

--- a/drivers/gpio/Kconfig.gecko
+++ b/drivers/gpio/Kconfig.gecko
@@ -5,6 +5,8 @@
 
 menuconfig GPIO_GECKO
 	bool "Gecko GPIO driver"
+	default y
+	depends on DT_HAS_SILABS_GECKO_GPIO_PORT_ENABLED
 	depends on HAS_SILABS_GECKO
 	select SOC_GECKO_GPIO
 	help

--- a/drivers/gpio/Kconfig.imx
+++ b/drivers/gpio/Kconfig.imx
@@ -5,6 +5,8 @@
 
 config GPIO_IMX
 	bool "IMX GPIO driver"
+	default y
+	depends on DT_HAS_NXP_IMX_GPIO_ENABLED
 	depends on HAS_IMX_GPIO
 	help
 	  Enable the IMX GPIO driver.

--- a/drivers/gpio/Kconfig.intel
+++ b/drivers/gpio/Kconfig.intel
@@ -5,6 +5,8 @@
 
 config GPIO_INTEL
 	bool "Intel Soc GPIO"
+	default y
+	depends on DT_HAS_INTEL_GPIO_ENABLED
 	help
 	  Enable driver for Intel SoC GPIO
 

--- a/drivers/gpio/Kconfig.it8xxx2
+++ b/drivers/gpio/Kconfig.it8xxx2
@@ -3,5 +3,7 @@
 
 config GPIO_ITE_IT8XXX2
 	bool "ITE IT8XXX2 GPIO driver"
+	default y
+	depends on DT_HAS_ITE_IT8XXX2_GPIO_ENABLED
 	help
 	  Enable driver for the ite GPIO controller.

--- a/drivers/gpio/Kconfig.litex
+++ b/drivers/gpio/Kconfig.litex
@@ -5,6 +5,8 @@
 
 config GPIO_LITEX
 	bool "Litex GPIO driver"
+	default y
+	depends on DT_HAS_LITEX_GPIO_ENABLED
 	depends on SOC_RISCV32_LITEX_VEXRISCV
 	help
 	  Enable Litex GPIO driver.

--- a/drivers/gpio/Kconfig.lmp90xxx
+++ b/drivers/gpio/Kconfig.lmp90xxx
@@ -5,6 +5,8 @@
 
 menuconfig GPIO_LMP90XXX
 	bool "LMP90xxx GPIO driver"
+	default y
+	depends on DT_HAS_TI_LMP90XXX_GPIO_ENABLED
 	depends on ADC_LMP90XXX_GPIO
 	help
 	  Enable GPIO driver for LMP90xxx.

--- a/drivers/gpio/Kconfig.lpc11u6x
+++ b/drivers/gpio/Kconfig.lpc11u6x
@@ -5,6 +5,8 @@
 
 config GPIO_LPC11U6X
 	bool "LPC11U6x GPIO driver"
+	default y
+	depends on DT_HAS_NXP_LPC11U6X_GPIO_ENABLED
 	depends on SOC_SERIES_LPC11U6X
 	depends on CLOCK_CONTROL_LPC11U6X
 	depends on PINMUX_LPC11U6X

--- a/drivers/gpio/Kconfig.mcp23s17
+++ b/drivers/gpio/Kconfig.mcp23s17
@@ -5,6 +5,8 @@
 
 menuconfig GPIO_MCP23S17
 	bool "MCP23S17 SPI-based GPIO chip"
+	default y
+	depends on DT_HAS_MICROCHIP_MCP23S17_ENABLED
 	depends on SPI
 	help
 	  Enable driver for MCP23S17 SPI-based GPIO chip.

--- a/drivers/gpio/Kconfig.mcp23xxx
+++ b/drivers/gpio/Kconfig.mcp23xxx
@@ -3,10 +3,6 @@
 # Copyright (c) 2021 metraTec GmbH
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_MICROCHIP_MCP230xx := microchip,mcp230xx
-DT_COMPAT_MICROCHIP_MCP23Sxx := microchip,mcp23sxx
-
 config GPIO_MCP23XXX
 	bool
 	help
@@ -15,7 +11,8 @@ config GPIO_MCP23XXX
 
 menuconfig GPIO_MCP230XX
 	bool "MCP230XX I2C-based GPIO chip"
-	default $(dt_compat_enabled,$(DT_COMPAT_MICROCHIP_MCP230xx))
+	default y
+	depends on DT_HAS_MICROCHIP_MCP230XX_ENABLED
 	depends on I2C
 	select GPIO_MCP23XXX
 	help
@@ -33,7 +30,8 @@ endif #GPIO_MCP230XX
 
 menuconfig GPIO_MCP23SXX
 	bool "MCP23SXX SPI-based GPIO chip"
-	default $(dt_compat_enabled,$(DT_COMPAT_MICROCHIP_MCP23Sxx))
+	default y
+	depends on DT_HAS_MICROCHIP_MCP23SXX_ENABLED
 	depends on SPI
 	select GPIO_MCP23XXX
 	help

--- a/drivers/gpio/Kconfig.mcux
+++ b/drivers/gpio/Kconfig.mcux
@@ -6,5 +6,7 @@
 
 config GPIO_MCUX
 	bool "MCUX GPIO driver"
+	default y
+	depends on DT_HAS_NXP_KINETIS_GPIO_ENABLED
 	help
 	  Enable the MCUX pinmux driver.

--- a/drivers/gpio/Kconfig.mcux_igpio
+++ b/drivers/gpio/Kconfig.mcux_igpio
@@ -5,6 +5,8 @@
 
 config GPIO_MCUX_IGPIO
 	bool "MCUX IGPIO driver"
+	default y
+	depends on DT_HAS_NXP_IMX_GPIO_ENABLED
 	depends on HAS_MCUX_IGPIO
 	help
 	  Enable the MCUX IGPIO driver.

--- a/drivers/gpio/Kconfig.mcux_lpc
+++ b/drivers/gpio/Kconfig.mcux_lpc
@@ -5,6 +5,8 @@
 
 config GPIO_MCUX_LPC
 	bool "MCUX LPC GPIO driver"
+	default y
+	depends on DT_HAS_NXP_LPC_GPIO_ENABLED
 	depends on HAS_MCUX
 	help
 	  Enable the MCUX LPC pinmux driver.

--- a/drivers/gpio/Kconfig.nct38xx
+++ b/drivers/gpio/Kconfig.nct38xx
@@ -5,6 +5,8 @@
 
 config GPIO_NCT38XX
 	bool "NCT38XX I2C-based GPIO chip"
+	default y
+	depends on DT_HAS_NUVOTON_NCT38XX_GPIO_PORT_ENABLED
 	depends on I2C
 	help
 	  Enable driver for NCT38XX I2C-based GPIO chip.

--- a/drivers/gpio/Kconfig.neorv32
+++ b/drivers/gpio/Kconfig.neorv32
@@ -5,7 +5,8 @@
 
 config GPIO_NEORV32
 	bool "NEORV32 GPIO driver"
-	default $(dt_compat_enabled,neorv32-gpio)
+	default y
+	depends on DT_HAS_NEORV32_GPIO_ENABLED
 	depends on SOC_SERIES_NEORV32 && SYSCON
 	help
 	  Enable NEORV32 GPIO driver.

--- a/drivers/gpio/Kconfig.npcx
+++ b/drivers/gpio/Kconfig.npcx
@@ -5,6 +5,8 @@
 
 config GPIO_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) gpio driver"
+	default y
+	depends on DT_HAS_NUVOTON_NPCX_GPIO_ENABLED
 	depends on SOC_FAMILY_NPCX
 	help
 	  This option enables the GPIO driver for NPCX family of

--- a/drivers/gpio/Kconfig.nrfx
+++ b/drivers/gpio/Kconfig.nrfx
@@ -4,6 +4,7 @@
 config GPIO_NRFX
 	bool "nRF GPIO driver"
 	default y
+	depends on DT_HAS_NORDIC_NRF_GPIO_ENABLED
 	depends on SOC_FAMILY_NRF
 	select NRFX_GPIOTE
 	help

--- a/drivers/gpio/Kconfig.pca953x
+++ b/drivers/gpio/Kconfig.pca953x
@@ -4,12 +4,10 @@
 # Copyright (c) 2021 Laird Connectivity
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_TI_TCA9538 := ti,tca9538
-
 menuconfig GPIO_PCA953X
 	bool "PCA953X I2C GPIO chip"
-	default $(dt_compat_enabled,$(DT_COMPAT_TI_TCA9538))
+	default y
+	depends on DT_HAS_TI_TCA9538_ENABLED
 	depends on I2C
 	help
 	  Enable driver for PCA953X I2C GPIO chip.

--- a/drivers/gpio/Kconfig.pca95xx
+++ b/drivers/gpio/Kconfig.pca95xx
@@ -5,6 +5,8 @@
 
 menuconfig GPIO_PCA95XX
 	bool "PCA95XX I2C-based GPIO chip"
+	default y
+	depends on DT_HAS_NXP_PCA95XX_ENABLED
 	depends on I2C
 	help
 	  Enable driver for PCA95XX I2C-based GPIO chip.

--- a/drivers/gpio/Kconfig.pcal6408a
+++ b/drivers/gpio/Kconfig.pcal6408a
@@ -3,12 +3,10 @@
 # Copyright (c) 2021 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_NXP_PCAL6408A := nxp,pcal6408a
-
 menuconfig GPIO_PCAL6408A
 	bool "PCAL6408A I2C GPIO chip"
-	default $(dt_compat_enabled,$(DT_COMPAT_NXP_PCAL6408A))
+	default y
+	depends on DT_HAS_NXP_PCAL6408A_ENABLED
 	depends on I2C
 	help
 	  Enable driver for PCAL6408A I2C GPIO chip.

--- a/drivers/gpio/Kconfig.psoc6
+++ b/drivers/gpio/Kconfig.psoc6
@@ -1,12 +1,10 @@
 # Copyright (c) 2020 ATL Electronics
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_CYPRESS_PSOC6_GPIO := cypress,psoc6-gpio
-
 config GPIO_PSOC6
 	bool "Cypress PSoC-6 GPIO driver"
-	default y if $(dt_compat_enabled,$(DT_COMPAT_CYPRESS_PSOC6_GPIO))
+	default y
+	depends on DT_HAS_CYPRESS_PSOC6_GPIO_ENABLED
 	depends on SOC_FAMILY_PSOC6
 	help
 	  Enable support for the Cypress PSoC-6 GPIO controllers.

--- a/drivers/gpio/Kconfig.rcar
+++ b/drivers/gpio/Kconfig.rcar
@@ -3,11 +3,10 @@
 # Copyright (c) 2020 IoT.bzh
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_RENESAS_RCAR_GPIO := renesas,rcar-gpio
-
 config GPIO_RCAR
 	bool "Renesas R-Car GPIO"
+	default y
+	depends on DT_HAS_RENESAS_RCAR_GPIO_ENABLED
 	depends on SOC_FAMILY_RCAR
-	default $(dt_compat_enabled,$(DT_COMPAT_RENESAS_RCAR_GPIO))
 	help
 	  Enable Renesas RCAR GPIO driver.

--- a/drivers/gpio/Kconfig.rpi_pico
+++ b/drivers/gpio/Kconfig.rpi_pico
@@ -1,10 +1,8 @@
 # Copyright (c) 2021 Yonatan Schachter
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_RPI_PICO_GPIO := raspberrypi,pico-gpio
-
 config GPIO_RPI_PICO
-	default $(dt_compat_enabled,$(DT_COMPAT_RPI_PICO_GPIO))
+	default y
+	depends on DT_HAS_RASPBERRYPI_PICO_GPIO_ENABLED
 	select PICOSDK_USE_GPIO
 	bool "Raspberry Pi Pico GPIO driver"

--- a/drivers/gpio/Kconfig.rv32m1
+++ b/drivers/gpio/Kconfig.rv32m1
@@ -5,6 +5,8 @@
 
 config GPIO_RV32M1
 	bool "RV32M1 GPIO driver"
+	default y
+	depends on DT_HAS_OPENISA_RV32M1_GPIO_ENABLED
 	depends on SOC_OPENISA_RV32M1_RISCV32
 	help
 	  Enable the RV32M1 GPIO driver.

--- a/drivers/gpio/Kconfig.sam
+++ b/drivers/gpio/Kconfig.sam
@@ -4,12 +4,10 @@
 # Copyright (c) 2020 Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_ATMEL_SAM_GPIO := atmel,sam-gpio
-
 config GPIO_SAM
 	bool "Atmel SAM GPIO (PORT) driver"
-	default y if $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_GPIO))
+	default y
+	depends on DT_HAS_ATMEL_SAM_GPIO_ENABLED
 	depends on SOC_FAMILY_SAM && !SOC_SERIES_SAM4L
 	depends on GPIO
 	help
@@ -17,7 +15,7 @@ config GPIO_SAM
 
 config GPIO_SAM4L
 	bool "Atmel SAM4L GPIO (PORT) driver"
-	default y if $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_GPIO))
+	depends on DT_HAS_ATMEL_SAM4L_GPIO_ENABLED
 	depends on SOC_SERIES_SAM4L
 	depends on GPIO
 	help

--- a/drivers/gpio/Kconfig.sam0
+++ b/drivers/gpio/Kconfig.sam0
@@ -6,6 +6,7 @@
 config GPIO_SAM0
 	bool "Atmel SAM0 GPIO (PORT) driver"
 	default y
+	depends on DT_HAS_ATMEL_SAM0_GPIO_ENABLED
 	depends on SOC_FAMILY_SAM0
 	help
 	  Enable support for the Atmel SAM0 'PORT' GPIO controllers.

--- a/drivers/gpio/Kconfig.sifive
+++ b/drivers/gpio/Kconfig.sifive
@@ -5,6 +5,8 @@
 
 config GPIO_SIFIVE
 	bool "SiFive Freedom Processor GPIO driver"
+	default y
+	depends on DT_HAS_SIFIVE_GPIO0_ENABLED
 	depends on SOC_SERIES_RISCV_SIFIVE_FREEDOM
 	help
 	  Enable driver for the SiFive Freedom GPIO controller.

--- a/drivers/gpio/Kconfig.sn74hc595
+++ b/drivers/gpio/Kconfig.sn74hc595
@@ -3,6 +3,8 @@
 
 config GPIO_SN74HC595
 	bool "SN74HC595 shift register as GPIO extender"
+	default y
+	depends on DT_HAS_TI_SN74HC595_ENABLED
 	depends on SPI
 	help
 	  Use SN74HC595 as GPIO extender

--- a/drivers/gpio/Kconfig.stellaris
+++ b/drivers/gpio/Kconfig.stellaris
@@ -5,6 +5,8 @@
 
 config GPIO_STELLARIS
 	bool "TI Stellaris GPIO Driver"
+	default y
+	depends on DT_HAS_TI_STELLARIS_GPIO_ENABLED
 	depends on SOC_TI_LM3S6965
 	help
 	  Enable support for the Stellaris GPIO controllers.

--- a/drivers/gpio/Kconfig.stm32
+++ b/drivers/gpio/Kconfig.stm32
@@ -5,6 +5,8 @@
 
 config GPIO_STM32
 	bool "GPIO Driver for STM32 family of MCUs"
+	default y
+	depends on DT_HAS_ST_STM32_GPIO_ENABLED
 	depends on SOC_FAMILY_STM32
 	help
 	  Enable GPIO driver for STM32 line of MCUs

--- a/drivers/gpio/Kconfig.stmpe1600
+++ b/drivers/gpio/Kconfig.stmpe1600
@@ -5,6 +5,8 @@
 
 menuconfig GPIO_STMPE1600
 	bool "STMPE1600 I2C-based GPIO chip"
+	default y
+	depends on DT_HAS_ST_STMPE1600_ENABLED
 	depends on I2C
 	help
 	  Enable driver for STMPE1600 I2C-based GPIO chip.

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -3,12 +3,10 @@
 # Copyright (c) 2018 Aapo Vienamo
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_SEMTECH_SX1509B := semtech,sx1509b
-
 menuconfig GPIO_SX1509B
 	bool "SX1509B I2C GPIO chip"
-	default $(dt_compat_enabled,$(DT_COMPAT_SEMTECH_SX1509B))
+	default y
+	depends on DT_HAS_SEMTECH_SX1509B_ENABLED
 	depends on I2C
 	help
 	  Enable driver for SX1509B I2C GPIO chip.

--- a/drivers/gpio/Kconfig.test
+++ b/drivers/gpio/Kconfig.test
@@ -8,3 +8,5 @@ DT_COMPAT_VND_GPIO := vnd,gpio
 # used in testing.
 config GPIO_TEST
 	def_bool $(dt_compat_enabled,$(DT_COMPAT_VND_GPIO))
+	default y
+	depends on DT_HAS_VND_GPIO_ENABLED

--- a/drivers/gpio/Kconfig.xec
+++ b/drivers/gpio/Kconfig.xec
@@ -5,12 +5,16 @@
 
 config GPIO_XEC
 	bool "XEC Microchip GPIO driver"
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_GPIO_ENABLED
 	depends on SOC_SERIES_MEC1501X
 	help
 	  Enable the Microchip XEC gpio driver.
 
 config GPIO_XEC_V2
 	bool "XEC Microchip GPIO driver V2"
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_GPIO_V2_ENABLED
 	depends on SOC_SERIES_MEC172X
 	help
 	  Enable the Microchip XEC gpio V2 driver.

--- a/drivers/gpio/Kconfig.xlnx
+++ b/drivers/gpio/Kconfig.xlnx
@@ -5,5 +5,7 @@
 
 config GPIO_XLNX_AXI
 	bool "Xilinx AXI GPIO driver"
+	default y
+	depends on DT_HAS_XLNX_XPS_GPIO_1_00_A_ENABLED
 	help
 	  Enable Xilinx AXI GPIO v2 driver.

--- a/drivers/gpio/Kconfig.xlnx_ps
+++ b/drivers/gpio/Kconfig.xlnx_ps
@@ -6,11 +6,10 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-DT_COMPAT_XLNX_PS_GPIO := xlnx,ps-gpio
-
 config GPIO_XLNX_PS
 	bool "Xilinx Processor System MIO / EMIO GPIO controller driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_XLNX_PS_GPIO))
+	default y
+	depends on DT_HAS_XLNX_PS_GPIO_ENABLED
 	depends on SOC_XILINX_ZYNQMP_RPU || SOC_FAMILY_XILINX_ZYNQ7000
 	depends on !QEMU_TARGET
 	help


### PR DESCRIPTION
Update gpio drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

Signed-off-by: Kumar Gala <galak@kernel.org>