### PR TITLE
boards/soc: comply to coding guidelines MISRA C:2012 Rule 14.4

### DIFF
--- a/boards/posix/native_posix/board_irq.h
+++ b/boards/posix/native_posix/board_irq.h
@@ -70,14 +70,14 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio,
 	} \
 	static inline int name##_body(void)
 
-#define ARCH_ISR_DIRECT_HEADER()   do { } while (0)
-#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (0)
+#define ARCH_ISR_DIRECT_HEADER()   do { } while (false)
+#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (false)
 
 #ifdef CONFIG_PM
 extern void posix_irq_check_idle_exit(void);
 #define ARCH_ISR_DIRECT_PM() posix_irq_check_idle_exit()
 #else
-#define ARCH_ISR_DIRECT_PM() do { } while (0)
+#define ARCH_ISR_DIRECT_PM() do { } while (false)
 #endif
 
 #ifdef __cplusplus

--- a/boards/posix/nrf52_bsim/board_irq.h
+++ b/boards/posix/nrf52_bsim/board_irq.h
@@ -70,14 +70,14 @@ void posix_irq_priority_set(unsigned int irq, unsigned int prio,
 	} \
 	static inline int name##_body(void)
 
-#define ARCH_ISR_DIRECT_HEADER()   do { } while (0)
-#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (0)
+#define ARCH_ISR_DIRECT_HEADER()   do { } while (false)
+#define ARCH_ISR_DIRECT_FOOTER(a)  do { } while (false)
 
 #ifdef CONFIG_PM
 extern void posix_irq_check_idle_exit(void);
 #define ARCH_ISR_DIRECT_PM() posix_irq_check_idle_exit()
 #else
-#define ARCH_ISR_DIRECT_PM() do { } while (0)
+#define ARCH_ISR_DIRECT_PM() do { } while (false)
 #endif
 
 #ifdef __cplusplus

--- a/soc/arm/cypress/common/cypress_psoc6_dt.h
+++ b/soc/arm/cypress/common/cypress_psoc6_dt.h
@@ -100,7 +100,7 @@
 			    isr, DEVICE_DT_INST_GET(n), 0);\
 		CY_PSOC6_NVIC_MUX_MAP(n);		\
 		irq_enable(CY_PSOC6_NVIC_MUX_IRQN(n));	\
-	} while (0)
+	} while (false)
 
 /*
  * Devicetree related macros to construct pin control config data

--- a/soc/arm/nuvoton_npcx/common/soc_dt.h
+++ b/soc/arm/nuvoton_npcx/common/soc_dt.h
@@ -263,7 +263,7 @@
 			DT_PROP(child, group_mask),                            \
 			0);						       \
 		irq_enable(DT_PROP(child, irq));                               \
-	} while (0)
+	} while (false)
 
 /**
  * @brief Get a child node from path '/npcx-espi-vws-map/name'.


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 14.4 in boards and soc:
> The controlling expression of an if statement
> and the controlling expression of an iteration-statement shall have
> essentially Boolean type.

This PR is part of the enhancement issue #48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
5d02614e34a86b549c7707d3d9f0984bc3a5f22a