### PR TITLE
MAINTAINERS: add tests/dts to pinctrl area

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -899,6 +899,8 @@ Documentation:
         - include/zephyr/drivers/pinctrl/
         - include/zephyr/drivers/pinctrl.h
         - drivers/pinctrl/
+        - tests/drivers/pinctrl/
+        - dts/bindings/pinctrl/
     labels:
         - "area: Pinctrl"
 


### PR DESCRIPTION
Add more coverage for this area to catch changes to tests and DTS
bindings.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
