### PR TITLE
drivers: pinctrl: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/pinctrl/Kconfig.b91
+++ b/drivers/pinctrl/Kconfig.b91
@@ -1,11 +1,9 @@
 # Copyright (c) 2022 Telink Semiconductor
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_TELINK_B91_PINCTRL := telink,b91-pinctrl
-
 config PINCTRL_TELINK_B91
 	bool "Telink B91 pin controller driver"
-	depends on SOC_RISCV_TELINK_B91
-	default $(dt_compat_enabled,$(DT_COMPAT_TELINK_B91_PINCTRL))
+	default y
+	depends on DT_HAS_TELINK_B91_PINCTRL_ENABLED
 	help
 	  Enables Telink B91 pin controller driver

--- a/drivers/pinctrl/Kconfig.cc13xx_cc26xx
+++ b/drivers/pinctrl/Kconfig.cc13xx_cc26xx
@@ -1,11 +1,9 @@
 # Copyright (c) 2022 Vaishnav Achath
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_CC13XX_CC26XX_PINCTRL := ti,cc13xx-cc26xx-pinctrl
-
 config PINCTRL_CC13XX_CC26XX
 	bool "TI SimpleLink CC13xx / CC26xx pinctrl driver"
-	depends on SOC_SERIES_CC13X2_CC26X2
-	default $(dt_compat_enabled,$(DT_COMPAT_CC13XX_CC26XX_PINCTRL))
+	default y
+	depends on DT_HAS_TI_CC13XX_CC26XX_PINCTRL_ENABLED
 	help
 	  Enable the TI SimpleLink CC13xx / CC26xx pinctrl driver

--- a/drivers/pinctrl/Kconfig.esp32
+++ b/drivers/pinctrl/Kconfig.esp32
@@ -1,11 +1,9 @@
 # Copyright (c) 2022 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ESP32_PINCTRL := espressif,esp32-pinctrl
-
 config PINCTRL_ESP32
 	bool "ESP32 pin controller"
-	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
-	default $(dt_compat_enabled,$(DT_COMPAT_ESP32_PINCTRL))
+	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_PINCTRL_ENABLED
 	help
 	  Enables ESP32 pin controller

--- a/drivers/pinctrl/Kconfig.gd32
+++ b/drivers/pinctrl/Kconfig.gd32
@@ -1,21 +1,18 @@
 # Copyright (c) 2021 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_GIGADEVICE_GD32_PINCTRL_AF := gd,gd32-pinctrl-af
-DT_COMPAT_GIGADEVICE_GD32_PINCTRL_AFIO := gd,gd32-pinctrl-afio
-
 config PINCTRL_GD32_AF
 	bool "GD32 AF pin controller driver"
-	depends on GD32_HAS_AF_PINMUX
-	default $(dt_compat_enabled,$(DT_COMPAT_GIGADEVICE_GD32_PINCTRL_AF))
+	default y
+	depends on DT_HAS_GD_GD32_PINCTRL_AF_ENABLED
 	help
 	  GD32 AF pin controller driver. This driver is used by series using the
 	  AF pin multiplexing model.
 
 config PINCTRL_GD32_AFIO
 	bool "GD32 AFIO pin controller driver"
-	depends on GD32_HAS_AFIO_PINMUX
-	default $(dt_compat_enabled,$(DT_COMPAT_GIGADEVICE_GD32_PINCTRL_AFIO))
+	default y
+	depends on DT_HAS_GD_GD32_PINCTRL_AFIO_ENABLED
 	help
 	  GD32 AFIO pin controller driver. This driver is used by series using the
 	  AFIO pin multiplexing model.

--- a/drivers/pinctrl/Kconfig.it8xxx2
+++ b/drivers/pinctrl/Kconfig.it8xxx2
@@ -1,11 +1,9 @@
 # Copyright (c) 2022 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ITE_IT8XXX2_PINCTRL := ite,it8xxx2-pinctrl
-
 config PINCTRL_ITE_IT8XXX2
 	bool "ITE IT8XXX2 pin controller driver"
-	depends on SOC_FAMILY_RISCV_ITE
-	default $(dt_compat_enabled,$(DT_COMPAT_ITE_IT8XXX2_PINCTRL))
+	default y
+	depends on DT_HAS_ITE_IT8XXX2_PINCTRL_FUNC_ENABLED
 	help
 	  Enable IT8XXX2 pin controller driver.

--- a/drivers/pinctrl/Kconfig.kinetis
+++ b/drivers/pinctrl/Kconfig.kinetis
@@ -1,11 +1,9 @@
 # Copyright (c) 2022 NXP
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_NXP_KINETIS_PINCTRL := nxp,kinetis-pinctrl
-
 config PINCTRL_NXP_KINETIS
 	bool "Pin controller driver for NXP Kinetis MCUs"
-	depends on SOC_FAMILY_KINETIS
-	default $(dt_compat_enabled,$(DT_COMPAT_NXP_KINETIS_PINCTRL))
+	default y
+	depends on DT_HAS_NXP_KINETIS_PINMUX_ENABLED
 	help
 	  Enable pin controller driver for NXP Kinetis MCUs

--- a/drivers/pinctrl/Kconfig.lpc_iocon
+++ b/drivers/pinctrl/Kconfig.lpc_iocon
@@ -1,15 +1,11 @@
 # Copyright 2022, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_NXP_LPC_PINCTRL := nxp,lpc-iocon-pinctrl
-DT_COMPAT_NXP_LPC_11U6X_PINCTRL := nxp,lpc11u6x-pinctrl
-DT_COMPAT_NXP_RT_PINCTRL := nxp,rt-iocon-pinctrl
-
 config PINCTRL_NXP_IOCON
 	bool "IOCON Pin controller driver for NXP LPC MCUs"
-	depends on SOC_FAMILY_LPC || SOC_SERIES_IMX_RT6XX || SOC_SERIES_IMX_RT5XX
-	default $(dt_compat_enabled,$(DT_COMPAT_NXP_LPC_PINCTRL)) || \
-		$(dt_compat_enabled,$(DT_COMPAT_NXP_RT_PINCTRL)) || \
-		$(dt_compat_enabled,$(DT_COMPAT_NXP_LPC_11U6X_PINCTRL))
+	default y
+	depends on DT_HAS_NXP_LPC_IOCON_PINCTRL_ENABLED || \
+		   DT_HAS_NXP_LPC11U6X_PINCTRL_ENABLED || \
+		   DT_HAS_NXP_RT_IOCON_PINCTRL_ENABLED
 	help
 	  Enable pin controller driver for NXP LPC MCUs

--- a/drivers/pinctrl/Kconfig.npcx
+++ b/drivers/pinctrl/Kconfig.npcx
@@ -3,12 +3,11 @@
 # Copyright (c) 2022 Nuvoton Technology Corporation.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_PINCTRL_NPCX := nuvoton,npcx-pinctrl
 
 config PINCTRL_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) pin controller driver"
-	depends on SOC_FAMILY_NPCX
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_PINCTRL_NPCX))
+	default y
+	depends on DT_HAS_NUVOTON_NPCX_PINCTRL_ENABLED
 	help
 	  This option enables the pin controller driver for NPCX family of
 	  processors.

--- a/drivers/pinctrl/Kconfig.nrf
+++ b/drivers/pinctrl/Kconfig.nrf
@@ -3,8 +3,8 @@
 
 config PINCTRL_NRF
 	bool "nRF pin controller driver"
-	depends on SOC_FAMILY_NRF
-	select PINCTRL_STORE_REG
 	default y
+	depends on DT_HAS_NORDIC_NRF_PINCTRL_ENABLED
+	select PINCTRL_STORE_REG
 	help
 	  nRF pin controller driver

--- a/drivers/pinctrl/Kconfig.rcar
+++ b/drivers/pinctrl/Kconfig.rcar
@@ -3,7 +3,7 @@
 
 config PINCTRL_RCAR_PFC
 	bool "Pin controller driver for Renesas RCar SoC"
-	depends on SOC_FAMILY_RCAR
 	default y
+	depends on DT_HAS_RENESAS_RCAR_PFC_ENABLED
 	help
 	  Enable pin controller driver for Renesas RCar SoC

--- a/drivers/pinctrl/Kconfig.rpi_pico
+++ b/drivers/pinctrl/Kconfig.rpi_pico
@@ -1,12 +1,10 @@
 # Copyright (c) 2021 Yonatan Schachter
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_RPI_PICO_PINCTRL := raspberrypi,pico-pinctrl
-
 config PINCTRL_RPI_PICO
 	bool "RaspberryPi Pico pin controller driver"
-	depends on SOC_FAMILY_RPI_PICO
-	default $(dt_compat_enabled,$(DT_COMPAT_RPI_PICO_PINCTRL))
+	default y
+	depends on DT_HAS_RASPBERRYPI_PICO_PINCTRL_ENABLED
 	select PICOSDK_USE_GPIO
 	help
 	  RaspberryPi Pico pinctrl driver

--- a/drivers/pinctrl/Kconfig.rv32m1
+++ b/drivers/pinctrl/Kconfig.rv32m1
@@ -1,11 +1,9 @@
 # Copyright (c) 2022 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_OPENISA_RV32M1_PINCTRL := openisa,rv32m1-pinctrl
-
 config PINCTRL_RV32M1
 	bool "RV32M1 pin controller driver"
-	depends on SOC_OPENISA_RV32M1_RISCV32
-	default $(dt_compat_enabled,$(DT_COMPAT_OPENISA_RV32M1_PINCTRL))
+	default y
+	depends on DT_HAS_OPENISA_RV32M1_PINMUX_ENABLED
 	help
 	  Enable the RV32M1 pin controller driver.

--- a/drivers/pinctrl/Kconfig.sam
+++ b/drivers/pinctrl/Kconfig.sam
@@ -1,11 +1,9 @@
 # Copyright (c) 2022, Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ATMEL_SAM_PINCTRL := atmel,sam-pinctrl
-
 config PINCTRL_SAM
 	bool "Atmel SAM pin controller driver"
-	depends on SOC_FAMILY_SAM
-	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_PINCTRL))
+	default y
+	depends on DT_HAS_ATMEL_SAM_PINCTRL_ENABLED
 	help
 	  Atmel pin controller driver is used on SAM and SAM4L SoC series

--- a/drivers/pinctrl/Kconfig.sam0
+++ b/drivers/pinctrl/Kconfig.sam0
@@ -1,11 +1,9 @@
 # Copyright (c) 2022, Gerson Fernando Budke <nandojve@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ATMEL_SAM0_PINCTRL := atmel,sam0-pinctrl
-
 config PINCTRL_SAM0
 	bool "Atmel SAM0 pin controller driver"
-	depends on SOC_FAMILY_SAM0
-	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM0_PINCTRL))
+	default y
+	depends on DT_HAS_ATMEL_SAM0_PINCTRL_ENABLED
 	help
 	  Atmel pin controller driver is used on SAM0 SoC series

--- a/drivers/pinctrl/Kconfig.sifive
+++ b/drivers/pinctrl/Kconfig.sifive
@@ -1,11 +1,9 @@
 # Copyright (c) 2022 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_SIFIVE_PINCTRL := sifive,pinctrl
-
 config PINCTRL_SIFIVE
 	bool "SiFive Freedom SoC pinmux driver"
-	depends on SOC_SERIES_RISCV_SIFIVE_FREEDOM
-	default $(dt_compat_enabled,$(DT_COMPAT_SIFIVE_PINCTRL))
+	default y
+	depends on DT_HAS_SIFIVE_PINCTRL_ENABLED
 	help
 	  Enable driver for the SiFive Freedom SoC pinctrl driver

--- a/drivers/pinctrl/Kconfig.stm32
+++ b/drivers/pinctrl/Kconfig.stm32
@@ -3,8 +3,8 @@
 
 config PINCTRL_STM32
 	bool "Pin controller driver for STM32 MCUs"
-	depends on SOC_FAMILY_STM32
 	default y
+	depends on DT_HAS_ST_STM32_PINCTRL_ENABLED || DT_HAS_ST_STM32F1_PINCTRL_ENABLED
 	help
 	  Enable pin controller driver for STM32 MCUs
 

--- a/drivers/pinctrl/Kconfig.xec
+++ b/drivers/pinctrl/Kconfig.xec
@@ -1,11 +1,9 @@
 # Copyright (c) 2021 Microchip Technology Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_PINCTRL_XEC := microchip,xec-pinctrl
-
 config PINCTRL_MCHP_XEC
 	bool "Pin controller driver for MCHP XEC MCUs"
-	depends on SOC_SERIES_MEC172X
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_PINCTRL_XEC))
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_PINCTRL_ENABLED
 	help
 	  Enable pin controller driver for Microchip XEC MCUs

--- a/drivers/pinctrl/Kconfig.xlnx
+++ b/drivers/pinctrl/Kconfig.xlnx
@@ -1,12 +1,10 @@
 # Copyright (c) 2022 Henrik Brix Andersen <henrik@brixandersen.dk>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_XLNX_PINCTRL_ZYNQ := xlnx,pinctrl-zynq
-
 config PINCTRL_XLNX_ZYNQ
 	bool "Xilinx Zynq 7000 processor system MIO pin controller driver"
-	depends on SOC_FAMILY_XILINX_ZYNQ7000
-	default $(dt_compat_enabled,$(DT_COMPAT_XLNX_PINCTRL_ZYNQ))
+	default y
+	depends on DT_HAS_XLNX_PINCTRL_ZYNQ_ENABLED
 	select SYSCON
 	help
 	  Enable the Xilinx Zynq 7000 processor system MIO pin controller driver.


### PR DESCRIPTION
Update pinctrl drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>