### PR TITLE
serial: uart_pipe: Get rid of redundant check in uart_pipe_isr().

### DIFF
--- a/drivers/serial/uart_pipe.c
+++ b/drivers/serial/uart_pipe.c
@@ -59,10 +59,8 @@ static void uart_pipe_isr(const struct device *dev, void *user_data)
 
 	uart_irq_update(dev);
 
-	if (uart_irq_is_pending(dev)) {
-		if (uart_irq_rx_ready(dev)) {
-			uart_pipe_rx(dev);
-		}
+	if (uart_irq_rx_ready(dev)) {
+		uart_pipe_rx(dev);
 	}
 }
 


### PR DESCRIPTION
The uart_pipe_isr() double-checks whether rx interrupt occured by
calling uart_irq_is_pending() first. Get rid of that function call since
it is redundant (i.e. nothing more is done or checked inside that
conditional).

Signed-off-by: Jan Kuliga <jtkuliga@gmail.com>