### PR TITLE
drivers: i2c: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -65,45 +65,53 @@ source "subsys/logging/Kconfig.template.log_config"
 
 config I2C_GECKO
 	bool "Gecko I2C driver"
-	depends on HAS_SILABS_GECKO
+	default y
+	depends on DT_HAS_SILABS_GECKO_I2C_ENABLED
 	select SOC_GECKO_I2C
 	help
 	  Enable the SiLabs Gecko I2C bus driver.
 
 config I2C_SAM_TWIHS
 	bool "Atmel SAM (TWIHS) I2C driver"
-	depends on SOC_FAMILY_SAM
+	default y
+	depends on DT_HAS_ATMEL_SAM_I2C_TWIHS_ENABLED
 	help
 	  Enable Atmel SAM MCU Family (TWIHS) I2C bus driver.
 
 config I2C_SAM_TWIM
 	bool "Atmel SAM (TWIM) I2C driver"
-	depends on SOC_SERIES_SAM4L
+	default y
+	depends on DT_HAS_ATMEL_SAM_I2C_TWIM_ENABLED
 	help
 	  Enable Atmel SAM MCU Family (TWIM) I2C bus driver.
 
 config I2C_SAM_TWI
 	bool "Atmel SAM (TWI) I2C driver"
-	depends on SOC_FAMILY_SAM
+	default y
+	depends on DT_HAS_ATMEL_SAM_I2C_TWI_ENABLED
 	help
 	  Enable Atmel SAM MCU Family (TWI) I2C bus driver.
 
 config I2C_MCUX
 	bool "MCUX I2C driver"
-	depends on HAS_MCUX
+	default y
+	depends on DT_HAS_NXP_KINETIS_I2C_ENABLED
 	select PINCTRL
 	help
 	  Enable the mcux I2C driver.
 
 config I2C_MCUX_FLEXCOMM
 	bool "MCUX FLEXCOMM I2C driver"
-	depends on HAS_MCUX_FLEXCOMM
+	default y
+	depends on DT_HAS_NXP_LPC_I2C_ENABLED
 	help
 	  Enable the mcux flexcomm i2c driver.
 
 config I2C_MCUX_LPI2C
 	bool "MCUX LPI2C driver"
-	depends on HAS_MCUX_LPI2C && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_IMX_LPI2C_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable the mcux LPI2C driver.
 
@@ -116,13 +124,15 @@ config I2C_MCUX_LPI2C_BUS_RECOVERY
 
 config I2C_IMX
 	bool "i.MX I2C driver"
-	depends on HAS_IMX_I2C
+	default y
+	depends on DT_HAS_FSL_IMX21_I2C_ENABLED
 	help
 	  Enable the i.MX I2C driver.
 
 config I2C_CC32XX
 	bool "CC32XX I2C driver"
-	depends on SOC_SERIES_CC32XX
+	default y
+	depends on DT_HAS_TI_CC32XX_I2C_ENABLED
 	help
 	  Enable the CC32XX I2C driver.
 
@@ -133,13 +143,16 @@ config I2C_BITBANG
 
 config I2C_NIOS2
 	bool "Nios-II I2C driver"
-	depends on HAS_ALTERA_HAL
+	default y
+	depends on DT_HAS_ALTR_NIOS2_I2C_ENABLED
 	help
 	  Enable the Nios-II I2C driver.
 
 config I2C_RV32M1_LPI2C
 	bool "RV32M1 LPI2C driver"
-	depends on HAS_RV32M1_LPI2C && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_OPENISA_RV32M1_LPI2C_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable the RV32M1 LPI2C driver.
 

--- a/drivers/i2c/Kconfig.b91
+++ b/drivers/i2c/Kconfig.b91
@@ -3,6 +3,7 @@
 
 config I2C_TELINK_B91
 	bool "Telink Semiconductor B91 I2C driver"
-	depends on SOC_RISCV_TELINK_B91
+	default y
+	depends on DT_HAS_TELINK_B91_I2C_ENABLED
 	help
 	  Enables Telink B91 I2C driver.

--- a/drivers/i2c/Kconfig.cc13xx_cc26xx
+++ b/drivers/i2c/Kconfig.cc13xx_cc26xx
@@ -3,6 +3,7 @@
 
 config I2C_CC13XX_CC26XX
 	bool "TI SimpleLink CC13xx / CC26xx I2C driver"
-	depends on SOC_SERIES_CC13X2_CC26X2
+	default y
+	depends on DT_HAS_TI_CC13XX_CC26XX_I2C_ENABLED
 	help
 	  Enable support for I2C on the TI SimpleLink CC13xx / CC26xx series.

--- a/drivers/i2c/Kconfig.dw
+++ b/drivers/i2c/Kconfig.dw
@@ -8,6 +8,8 @@ config HAS_I2C_DW
 
 menuconfig I2C_DW
 	bool "Design Ware I2C support"
+	default y
+	depends on DT_HAS_SNPS_DESIGNWARE_I2C_ENABLED
 	depends on HAS_I2C_DW
 	help
 	  Enable the Design Ware I2C driver

--- a/drivers/i2c/Kconfig.esp32
+++ b/drivers/i2c/Kconfig.esp32
@@ -4,12 +4,10 @@
 # Copyright (c) 2021 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ESP32_I2C := espressif,esp32-i2c
-
 config I2C_ESP32
 	bool "ESP32 I2C driver"
-	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
-	default $(dt_compat_enabled,$(DT_COMPAT_ESP32_I2C))
+	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_I2C_ENABLED
 	select GPIO_ESP32
 	help
 	  Enables the ESP32 I2C driver

--- a/drivers/i2c/Kconfig.gd32
+++ b/drivers/i2c/Kconfig.gd32
@@ -1,11 +1,9 @@
 # Copyright (c) 2021 BrainCo Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_GD32_I2C := gd,gd32-i2c
-
 config I2C_GD32
 	bool "GigaDevice GD32 I2C driver"
-	depends on (SOC_FAMILY_GD32 || SOC_SERIES_GD32VF103)
-	default $(dt_compat_enabled,$(DT_COMPAT_GD32_I2C))
+	default y
+	depends on DT_HAS_GD_GD32_I2C_ENABLED
 	help
 	  Enables GigaDevice GD32 I2C driver

--- a/drivers/i2c/Kconfig.gpio
+++ b/drivers/i2c/Kconfig.gpio
@@ -3,6 +3,8 @@
 
 config I2C_GPIO
 	bool "GPIO bit banging I2C support"
+	default y
+	depends on DT_HAS_GPIO_I2C_ENABLED
 	select I2C_BITBANG
 	help
 	  Enable software driven (bit banging) I2C support using GPIO pins

--- a/drivers/i2c/Kconfig.i2c_emul
+++ b/drivers/i2c/Kconfig.i2c_emul
@@ -3,6 +3,8 @@
 
 config I2C_EMUL
 	bool "I2C emulator"
+	default y
+	depends on DT_HAS_ZEPHYR_I2C_EMUL_CONTROLLER_ENABLED
 	help
 	  Enable the I2C emulator driver. This is a fake driver in that it
 	  does not talk to real hardware. Instead it talks to emulation

--- a/drivers/i2c/Kconfig.it8xxx2
+++ b/drivers/i2c/Kconfig.it8xxx2
@@ -1,13 +1,10 @@
 # Copyright (c) 2020 ITE Corporation. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ITE_IT8XXX2_I2C := ite,it8xxx2-i2c
-DT_COMPAT_ITE_ENHANCE_I2C := ite,enhance-i2c
-
 config I2C_ITE_IT8XXX2
 	bool "ITE IT8XXX2 I2C driver"
-	depends on SOC_IT8XXX2
-	default $(dt_compat_enabled,$(DT_COMPAT_ITE_IT8XXX2_I2C))
+	default y
+	depends on DT_HAS_ITE_IT8XXX2_I2C_ENABLED
 	help
 	  Enable I2C support on it8xxx2_evb.
 	  Supported Speeds: 100kHz, 400kHz and 1MHz.
@@ -15,8 +12,8 @@ config I2C_ITE_IT8XXX2
 
 config I2C_ITE_ENHANCE
 	bool "ITE IT8XXX2 I2C enhance driver"
-	depends on SOC_IT8XXX2
-	default $(dt_compat_enabled,$(DT_COMPAT_ITE_ENHANCE_I2C))
+	default y
+	depends on DT_HAS_ITE_ENHANCE_I2C_ENABLED
 	help
 	  This option can enable the enhance I2C
 	  of IT8XXX2 and support three channels.

--- a/drivers/i2c/Kconfig.litex
+++ b/drivers/i2c/Kconfig.litex
@@ -3,7 +3,8 @@
 
 config I2C_LITEX
 	bool "LiteX I2C driver"
-	depends on SOC_RISCV32_LITEX_VEXRISCV
+	default y
+	depends on DT_HAS_LITEX_I2C_ENABLED
 	select I2C_BITBANG
 	help
 	  Enable support for Litex I2C driver

--- a/drivers/i2c/Kconfig.lpc11u6x
+++ b/drivers/i2c/Kconfig.lpc11u6x
@@ -3,6 +3,7 @@
 
 config I2C_LPC11U6X
 	bool "LPC11U6X I2C driver"
-	depends on SOC_SERIES_LPC11U6X
+	default y
+	depends on DT_HAS_NXP_LPC11U6X_I2C_ENABLED
 	help
 	  Enable I2C support on the LPC11U6X SoCs

--- a/drivers/i2c/Kconfig.npcx
+++ b/drivers/i2c/Kconfig.npcx
@@ -5,7 +5,8 @@
 
 config I2C_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) I2C driver"
-	depends on SOC_FAMILY_NPCX
+	default y
+	depends on DT_HAS_NUVOTON_NPCX_I2C_PORT_ENABLED
 	help
 	  This option enables the I2C driver for NPCX family of
 	  processors.

--- a/drivers/i2c/Kconfig.rcar
+++ b/drivers/i2c/Kconfig.rcar
@@ -3,11 +3,9 @@
 # Copyright (c) 2021 IoT.bzh
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_RENESAS_RCAR_I2C := renesas,rcar-i2c
-
 config I2C_RCAR
 	bool "Renesas R-Car I2C Driver"
-	depends on SOC_FAMILY_RCAR
-	default $(dt_compat_enabled,$(DT_COMPAT_RENESAS_RCAR_I2C))
+	default y
+	depends on DT_HAS_RENESAS_RCAR_I2C_ENABLED
 	help
 	  Enable Renesas R-Car I2C Driver.

--- a/drivers/i2c/Kconfig.sam0
+++ b/drivers/i2c/Kconfig.sam0
@@ -1,12 +1,10 @@
 # Copyright (c) 2019 Derek Hageman <hageman@inthat.cloud>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ATMEL_SAM0_I2C := atmel,sam0-i2c
-
 menuconfig I2C_SAM0
 	bool "SAM0 series I2C SERCOM driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM0_I2C))
-	depends on SOC_FAMILY_SAM0
+	default y
+	depends on DT_HAS_ATMEL_SAM0_I2C_ENABLED
 	help
 	  Enable the SAM0 series SERCOM I2C driver.
 

--- a/drivers/i2c/Kconfig.sbcon
+++ b/drivers/i2c/Kconfig.sbcon
@@ -3,5 +3,6 @@
 
 config I2C_SBCON
 	bool "I2C driver for ARM's SBCon two-wire serial bus interface"
-	depends on ARM
+	default y
+	depends on DT_HAS_ARM_VERSATILE_I2C_ENABLED
 	select I2C_BITBANG

--- a/drivers/i2c/Kconfig.sifive
+++ b/drivers/i2c/Kconfig.sifive
@@ -3,6 +3,7 @@
 
 config I2C_SIFIVE
 	bool "Sifive I2C driver"
-	depends on SOC_SERIES_RISCV_SIFIVE_FREEDOM
+	default y
+	depends on DT_HAS_SIFIVE_I2C0_ENABLED
 	help
 	  Enable I2C support on SiFive Freedom

--- a/drivers/i2c/Kconfig.stm32
+++ b/drivers/i2c/Kconfig.stm32
@@ -1,13 +1,10 @@
 # Copyright (c) 2018 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_STM32_I2C_V1 := st,stm32-i2c-v1
-DT_COMPAT_ST_STM32_I2C_V2 := st,stm32-i2c-v2
-
 menuconfig I2C_STM32
 	bool "STM32 I2C driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_I2C_V1)) || $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_I2C_V2))
-	depends on SOC_FAMILY_STM32
+	default y
+	depends on DT_HAS_ST_STM32_I2C_V1_ENABLED || DT_HAS_ST_STM32_I2C_V2_ENABLED
 	help
 	  Enable I2C support on the STM32 SoCs
 
@@ -15,7 +12,8 @@ if I2C_STM32
 
 config I2C_STM32_V1
 	bool
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_I2C_V1))
+	default y
+	depends on DT_HAS_ST_STM32_I2C_V1_ENABLED
 	select USE_STM32_LL_I2C
 	select I2C_STM32_INTERRUPT if I2C_TARGET
 	help
@@ -23,7 +21,8 @@ config I2C_STM32_V1
 
 config I2C_STM32_V2
 	bool
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_I2C_V2))
+	default y
+	depends on DT_HAS_ST_STM32_I2C_V2_ENABLED
 	select USE_STM32_LL_I2C
 	select USE_STM32_LL_RCC if SOC_SERIES_STM32F0X || SOC_SERIES_STM32F3X
 	select I2C_STM32_INTERRUPT if I2C_TARGET

--- a/drivers/i2c/Kconfig.tca954x
+++ b/drivers/i2c/Kconfig.tca954x
@@ -1,13 +1,10 @@
 # Copyright (c) 2020 Innoseis BV
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_TI_TCA9546A := ti,tca9546a
-DT_COMPAT_TI_TCA9548A := ti,tca9548a
-
 menuconfig I2C_TCA954X
 	bool "I2C addressable switch"
-	default $(dt_compat_enabled,$(DT_COMPAT_TI_TCA9546A)) || \
-		$(dt_compat_enabled,$(DT_COMPAT_TI_TCA9548A))
+	default y
+	depends on DT_HAS_TI_TCA9546A_ENABLED || DT_HAS_TI_TCA9548A_ENABLED
 	help
 	  Enable TCA954x series I2C bus switch
 

--- a/drivers/i2c/Kconfig.test
+++ b/drivers/i2c/Kconfig.test
@@ -1,9 +1,8 @@
 # Copyright (c) 2021, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_VND_I2C := vnd,i2c
-
 # Hidden option for turning on the dummy driver for vnd,i2c devices
 # used in testing.
 config I2C_TEST
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_VND_I2C))
+	def_bool DT_HAS_VND_I2C_ENABLED
+	depends on DT_HAS_VND_I2C_ENABLED

--- a/drivers/i2c/Kconfig.xec
+++ b/drivers/i2c/Kconfig.xec
@@ -5,12 +5,14 @@
 
 config I2C_XEC
 	bool "XEC Microchip I2C driver"
-	depends on SOC_SERIES_MEC1501X
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_I2C_ENABLED
 	help
 	  Enable the Microchip XEC I2C driver.
 
 config I2C_XEC_V2
 	bool "XEC Microchip I2C driver"
-	depends on SOC_SERIES_MEC172X
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_I2C_V2_ENABLED
 	help
 	  Enable the Microchip XEC I2C V2 driver.


### PR DESCRIPTION
Update i2c drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>