### PR TITLE
 [alternative] device: rework how we do struct device extern's

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -214,7 +214,6 @@ if(SUPPORTS_DTS)
   --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
   --bindings-dirs ${DTS_ROOT_BINDINGS}
   --header-out ${DEVICETREE_UNFIXED_H}.new
-  --device-header-out ${DEVICE_EXTERN_H}.new
   --dts-out ${ZEPHYR_DTS}.new # for debugging and dtc
   --edt-pickle-out ${EDT_PICKLE}
   ${EXTRA_GEN_DEFINES_ARGS}
@@ -231,11 +230,11 @@ if(SUPPORTS_DTS)
   else()
     zephyr_file_copy(${ZEPHYR_DTS}.new ${ZEPHYR_DTS} ONLY_IF_DIFFERENT)
     zephyr_file_copy(${DEVICETREE_UNFIXED_H}.new ${DEVICETREE_UNFIXED_H} ONLY_IF_DIFFERENT)
-    zephyr_file_copy(${DEVICE_EXTERN_H}.new ${DEVICE_EXTERN_H})
-    file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_UNFIXED_H}.new ${DEVICE_EXTERN_H}.new)
+    file(WRITE ${DEVICE_EXTERN_H}
+"#error The contents of this file are now implemented directly in zephyr/device.h.")
+    file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_UNFIXED_H}.new)
     message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
     message(STATUS "Generated devicetree_unfixed.h: ${DEVICETREE_UNFIXED_H}")
-    message(STATUS "Generated device_extern.h: ${DEVICE_EXTERN_H}")
   endif()
 
 
@@ -310,5 +309,4 @@ if(SUPPORTS_DTS)
 else()
   set(header_template ${ZEPHYR_BASE}/misc/generated/generated_header.template)
   zephyr_file_copy(${header_template} ${DEVICETREE_UNFIXED_H} ONLY_IF_DIFFERENT)
-  zephyr_file_copy(${header_template} ${DEVICE_EXTERN_H} ONLY_IF_DIFFERENT)
 endif(SUPPORTS_DTS)

--- a/doc/build/dts/macros.bnf
+++ b/doc/build/dts/macros.bnf
@@ -224,6 +224,10 @@ prop-suf = 1*( "_" gen-name ["_" dt-name] )
 other-macro =  %s"DT_N_" alternate-id
 ; Total count of enabled instances of a compatible.
 other-macro =/ %s"DT_N_INST_" dt-name %s"_NUM_OKAY"
+; These are used internally by DT_FOREACH_NODE and
+; DT_FOREACH_STATUS_OKAY_NODE respectively.
+other-macro =/ %s"DT_FOREACH_HELPER"
+other-macro =/ %s"DT_FOREACH_OKAY_HELPER"
 ; These are used internally by DT_FOREACH_STATUS_OKAY,
 ; which iterates over each enabled node of a compatible.
 other-macro =/ %s"DT_FOREACH_OKAY_" dt-name

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -96,13 +96,13 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_NAME_GET(name) _CONCAT(__device_, name)
 
-/* Node paths can exceed the maximum size supported by device_get_binding() in user mode,
- * so synthesize a unique dev_name from the devicetree node.
+/* Node paths can exceed the maximum size supported by
+ * device_get_binding() in user mode; this macro synthesizes a unique
+ * dev_name from a devicetree node while staying within this maximum
+ * size.
  *
  * The ordinal used in this name can be mapped to the path by
- * examining zephyr/include/generated/device_extern.h header. If the
- * format of this conversion changes, gen_defines should be updated to
- * match it.
+ * examining zephyr/include/generated/devicetree_unfixed.h.
  */
 #define Z_DEVICE_DT_DEV_NAME(node_id) _CONCAT(dts_ord_, DT_DEP_ORD(node_id))
 
@@ -951,12 +951,25 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,		\
 		(&DEVICE_NAME_GET(dev_name)), level, prio)
 
+/*
+ * Declare a device for each status "okay" devicetree node. (Disabled
+ * nodes should not result in devices, so not predeclaring these keeps
+ * drivers honest.)
+ *
+ * This is only "maybe" a device because some nodes have status "okay",
+ * but don't have a corresponding struct device allocated. There's no way
+ * to figure that out until after we've built the zephyr image,
+ * though.
+ */
+#define Z_MAYBE_DEVICE_DECLARE_INTERNAL(node_id) \
+	extern const struct device DEVICE_DT_NAME_GET(node_id);
+
+DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
+
 #ifdef __cplusplus
 }
 #endif
 
-/* device_extern is generated based on devicetree nodes */
-#include <device_extern.h>
 
 #include <syscalls/device.h>
 

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -26,6 +26,7 @@
  * @{
  */
 
+#include <zephyr/devicetree.h>
 #include <zephyr/init.h>
 #include <zephyr/linker/sections.h>
 #include <zephyr/sys/device_mmio.h>

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -1891,6 +1891,30 @@
  */
 
 /**
+ * @brief Invokes "fn" for every node in the tree.
+ *
+ * The macro "fn" must take one parameter, which will be a node
+ * identifier. The macro is expanded once for each node in the tree.
+ * The order that nodes are visited in is not specified.
+ *
+ * @param fn macro to invoke
+ */
+#define DT_FOREACH_NODE(fn) DT_FOREACH_HELPER(fn)
+
+/**
+ * @brief Invokes "fn" for every status "okay" node in the tree.
+ *
+ * The macro "fn" must take one parameter, which will be a node
+ * identifier. The macro is expanded once for each node in the tree
+ * with status "okay" (as usual, a missing status property is treated
+ * as status "okay"). The order that nodes are visited in is not
+ * specified.
+ *
+ * @param fn macro to invoke
+ */
+#define DT_FOREACH_STATUS_OKAY_NODE(fn) DT_FOREACH_OKAY_HELPER(fn)
+
+/**
  * @brief Invokes "fn" for each child of "node_id"
  *
  * The macro "fn" must take one parameter, which will be the node

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -146,34 +146,8 @@ def main():
         write_chosen(edt)
         write_global_macros(edt)
 
-        write_device_extern_header(args.device_header_out, edt)
-
     if args.edt_pickle_out:
         write_pickled_edt(edt, args.edt_pickle_out)
-
-
-def write_device_extern_header(device_header_out, edt):
-    # Generate header that will extern devicetree struct device's
-
-    with open(device_header_out, "w", encoding="utf-8") as dev_header_file:
-        print("#ifndef DEVICE_EXTERN_GEN_H", file=dev_header_file)
-        print("#define DEVICE_EXTERN_GEN_H", file=dev_header_file)
-        print("", file=dev_header_file)
-        print("#ifdef __cplusplus", file=dev_header_file)
-        print('extern "C" {', file=dev_header_file)
-        print("#endif", file=dev_header_file)
-        print("", file=dev_header_file)
-
-        for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
-            print(f"extern const struct device DEVICE_DT_NAME_GET(DT_{node.z_path_id}); /* dts_ord_{node.dep_ordinal} */",
-                  file=dev_header_file)
-
-        print("", file=dev_header_file)
-        print("#ifdef __cplusplus", file=dev_header_file)
-        print("}", file=dev_header_file)
-        print("#endif", file=dev_header_file)
-        print("", file=dev_header_file)
-        print("#endif /* DEVICE_EXTERN_GEN_H */", file=dev_header_file)
 
 
 def setup_edtlib_logging():
@@ -222,8 +196,6 @@ def parse_args():
     parser.add_argument("--dts-out", required=True,
                         help="path to write merged DTS source code to (e.g. "
                              "as a debugging aid)")
-    parser.add_argument("--device-header-out", required=True,
-                        help="path to write device struct extern header to")
     parser.add_argument("--edt-pickle-out",
                         help="path to write pickled edtlib.EDT object to")
     parser.add_argument("--vendor-prefixes", action='append', default=[],

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -858,6 +858,14 @@ def write_global_macros(edt):
     # Global or tree-wide information, such as number of instances
     # with status "okay" for each compatible, is printed here.
 
+
+    out_comment("Macros for iterating over all nodes and enabled nodes")
+    out_dt_define("FOREACH_HELPER(fn)",
+                  " ".join(f"fn(DT_{node.z_path_id})" for node in edt.nodes))
+    out_dt_define("FOREACH_OKAY_HELPER(fn)",
+                  " ".join(f"fn(DT_{node.z_path_id})" for node in edt.nodes
+                           if node.status == "okay"))
+
     n_okay_macros = {}
     for_each_macros = {}
     compat2buses = defaultdict(list)  # just for "okay" nodes

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -144,7 +144,7 @@ def main():
             write_vanilla_props(node)
 
         write_chosen(edt)
-        write_global_compat_info(edt)
+        write_global_macros(edt)
 
         write_device_extern_header(args.device_header_out, edt)
 
@@ -854,9 +854,9 @@ def write_chosen(edt):
         out_define(macro, value, width=max_len)
 
 
-def write_global_compat_info(edt):
-    # Tree-wide information related to each compatible, such as number
-    # of instances with status "okay", is printed here.
+def write_global_macros(edt):
+    # Global or tree-wide information, such as number of instances
+    # with status "okay" for each compatible, is printed here.
 
     n_okay_macros = {}
     for_each_macros = {}

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -35,7 +35,7 @@ K_TIMER_DEFINE(ktimer, duration_expire, stop_expire);
 static ZTEST_BMEM struct timer_data tdata;
 
 #define DURATION 100
-#define LESS_DURATION 80
+#define LESS_DURATION 70
 
 /**
  * @addtogroup kernel_common_tests

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -1218,6 +1218,24 @@ ZTEST(devicetree_api, test_arrays)
 	zassert_equal(DT_PROP_LEN(TEST_ARRAYS, c), 2, "");
 }
 
+ZTEST(devicetree_api, test_foreach)
+{
+	/*
+	 * We don't know what plaform we are running on, so settle for
+	 * some basic checks related to nodes we know are in our overlay.
+	 */
+#define IS_ALIASES(node_id) + DT_SAME_NODE(DT_PATH(aliases), node_id)
+#define IS_DISABLED_GPIO(node_id) + DT_SAME_NODE(DT_NODELABEL(disabled_gpio), \
+						node_id)
+	zassert_equal(1, DT_FOREACH_NODE(IS_ALIASES), "");
+	zassert_equal(1, DT_FOREACH_NODE(IS_DISABLED_GPIO), "");
+	zassert_equal(1, DT_FOREACH_STATUS_OKAY_NODE(IS_ALIASES), "");
+	zassert_equal(0, DT_FOREACH_STATUS_OKAY_NODE(IS_DISABLED_GPIO), "");
+
+#undef IS_ALIASES
+#undef IS_DISABLED_GPIO
+}
+
 #undef DT_DRV_COMPAT
 #define DT_DRV_COMPAT vnd_gpio_device
 ZTEST(devicetree_api, test_foreach_status_okay)

--- a/tests/net/socket/select/src/main.c
+++ b/tests/net/socket/select/src/main.c
@@ -23,8 +23,8 @@ LOG_MODULE_REGISTER(net_test, CONFIG_NET_SOCKETS_LOG_LEVEL);
 #define SERVER_PORT 4242
 #define CLIENT_PORT 9898
 
-/* On QEMU, poll() which waits takes +30ms from the requested time. */
-#define FUZZ 30
+/* Fudge factor added to expected timeouts, in milliseconds. */
+#define FUZZ 60
 
 #define TIMEOUT_MS 60
 

--- a/tests/net/socket/tcp/src/main.c
+++ b/tests/net/socket/tcp/src/main.c
@@ -853,7 +853,7 @@ void test_connect_timeout(void)
 			    "net_context still in use");
 }
 
-#define TCP_CLOSE_FAILURE_TIMEOUT 60000
+#define TCP_CLOSE_FAILURE_TIMEOUT 90000
 
 void test_close_obstructed(void)
 {


### PR DESCRIPTION
This is an alternative to https://github.com/zephyrproject-rtos/zephyr/pull/47798.

Instead of introducing a new magic "DEVICE_ORD_MACRO" that callers have to override, we here add some new devicetree.h machinery for iterating over all the nodes in the tree.

That lets us replace device_extern.h with a foreach call in device.h in a way that should generalize analogously to emulators, without any tricky redefinitions.