### PR TITLE
drivers: spi: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/spi/Kconfig.b91
+++ b/drivers/spi/Kconfig.b91
@@ -3,6 +3,7 @@
 
 config SPI_TELINK_B91
 	bool "Telink Semiconductor B91 SPI driver"
-	depends on SOC_RISCV_TELINK_B91
+	default y
+	depends on DT_HAS_TELINK_B91_SPI_ENABLED
 	help
 	  Enables Telink B91 SPI driver.

--- a/drivers/spi/Kconfig.bitbang
+++ b/drivers/spi/Kconfig.bitbang
@@ -3,5 +3,7 @@
 
 config SPI_BITBANG
 	bool "Bitbang SPI controller driver"
+	default y
+	depends on DT_HAS_ZEPHYR_SPI_BITBANG_ENABLED
 	help
 	  Enable the Bitbang SPI controller

--- a/drivers/spi/Kconfig.cc13xx_cc26xx
+++ b/drivers/spi/Kconfig.cc13xx_cc26xx
@@ -5,6 +5,7 @@
 
 config SPI_CC13XX_CC26XX
 	bool "TI SimpleLink CC13xx / CC26xx SPI driver"
-	depends on SOC_SERIES_CC13X2_CC26X2
+	default y
+	depends on DT_HAS_TI_CC13XX_CC26XX_SPI_ENABLED
 	help
 	  Enable support for the TI SimpleLink CC13xx / CC26xx SPI peripheral

--- a/drivers/spi/Kconfig.dw
+++ b/drivers/spi/Kconfig.dw
@@ -10,6 +10,8 @@ config HAS_SPI_DW
 
 menuconfig SPI_DW
 	bool "Designware SPI controller driver"
+	default y
+	depends on DT_HAS_SNPS_DESIGNWARE_SPI_ENABLED
 	depends on HAS_SPI_DW
 	help
 	  Enable support for Designware's SPI controllers.

--- a/drivers/spi/Kconfig.esp32
+++ b/drivers/spi/Kconfig.esp32
@@ -5,8 +5,8 @@
 
 menuconfig ESP32_SPIM
 	bool "ESP32 SPI Master driver"
-	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
 	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_SPI_ENABLED
 	help
 	  Enables support for ESP32 SPI Master driver.
 

--- a/drivers/spi/Kconfig.gd32
+++ b/drivers/spi/Kconfig.gd32
@@ -1,12 +1,9 @@
 # Copyright (c) 2021 BrainCo Inc.
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_GD_GD32_SPI := gd,gd32-spi
-
 config SPI_GD32
 	bool "Gigadevice GD32 SPI driver"
-	depends on (SOC_FAMILY_GD32 || SOC_SERIES_GD32VF103)
-	default $(dt_compat_enabled,$(DT_COMPAT_GD_GD32_SPI))
+	default y
+	depends on DT_HAS_GD_GD32_SPI_ENABLED
 	help
 	  Enables Gigadevice GD32 SPI driver.

--- a/drivers/spi/Kconfig.gecko
+++ b/drivers/spi/Kconfig.gecko
@@ -5,8 +5,9 @@
 
 config SPI_GECKO
 	bool "Gecko SPI controller driver"
-	depends on HAS_SILABS_GECKO
-	depends on GPIO_GECKO
+	default y
+	depends on DT_HAS_SILABS_GECKO_SPI_USART_ENABLED
+	depends on GPIO
 	select SOC_GECKO_USART
 	help
 	  Enable the SPI peripherals on Gecko

--- a/drivers/spi/Kconfig.litex
+++ b/drivers/spi/Kconfig.litex
@@ -5,6 +5,7 @@
 
 config SPI_LITESPI
 	bool "LiteX SPI controller driver"
-	depends on SOC_RISCV32_LITEX_VEXRISCV
+	default y
+	depends on DT_HAS_LITEX_SPI_ENABLED
 	help
 	  Enable the SPI peripherals on LiteX

--- a/drivers/spi/Kconfig.mchp_mss_qspi
+++ b/drivers/spi/Kconfig.mchp_mss_qspi
@@ -6,6 +6,6 @@
 config SPI_MCHP_QSPI
 	bool "Microchip Polarfire SOC QSPI driver"
 	default y
-	depends on SOC_MPFS
+	depends on DT_HAS_MICROCHIP_MPFS_QSPI_ENABLED
 	help
 	  Enable support for the Polarfire SOC QSPI driver.

--- a/drivers/spi/Kconfig.mcux_dspi
+++ b/drivers/spi/Kconfig.mcux_dspi
@@ -6,7 +6,9 @@
 
 config SPI_MCUX_DSPI
 	bool "MCUX SPI driver"
-	depends on HAS_MCUX && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_KINETIS_DSPI_ENABLED
+	depends on CLOCK_CONTROL
 	select PINCTRL
 	help
 	  Enable support for mcux spi driver.

--- a/drivers/spi/Kconfig.mcux_flexcomm
+++ b/drivers/spi/Kconfig.mcux_flexcomm
@@ -4,7 +4,8 @@
 
 config SPI_MCUX_FLEXCOMM
 	bool "MCUX FLEXCOMM SPI driver"
-	depends on HAS_MCUX_FLEXCOMM
+	default y
+	depends on DT_HAS_NXP_LPC_SPI_ENABLED
 	help
 	  Enable support for mcux flexcomm spi driver.
 

--- a/drivers/spi/Kconfig.mcux_lpspi
+++ b/drivers/spi/Kconfig.mcux_lpspi
@@ -5,7 +5,9 @@
 
 config SPI_MCUX_LPSPI
 	bool "MCUX SPI driver"
-	depends on HAS_MCUX_LPSPI && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_IMX_LPSPI_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable support for mcux spi driver.
 

--- a/drivers/spi/Kconfig.npcx_fiu
+++ b/drivers/spi/Kconfig.npcx_fiu
@@ -5,7 +5,8 @@
 
 config SPI_NPCX_FIU
 	bool "Nuvoton NPCX embedded controller (EC) SPI driver for NOR flash"
-	depends on SOC_FAMILY_NPCX
+	default y
+	depends on DT_HAS_NUVOTON_NPCX_SPI_FIU_ENABLED
 	help
 	  Enable the SPI driver for NPCX family of processors. This driver is
 	  for the dedicated SPI controller (FIU) to access the NOR flash.

--- a/drivers/spi/Kconfig.oc_simple
+++ b/drivers/spi/Kconfig.oc_simple
@@ -5,6 +5,8 @@
 
 menuconfig SPI_OC_SIMPLE
 	bool "OpenCores Simple SPI controller driver"
+	default y
+	depends on DT_HAS_OPENCORES_SPI_SIMPLE_ENABLED
 	help
 	  Enable the Simple SPI controller
 

--- a/drivers/spi/Kconfig.psoc6
+++ b/drivers/spi/Kconfig.psoc6
@@ -5,7 +5,8 @@
 
 config SPI_PSOC6
 	bool "PSoC-6 MCU SCB spi driver"
-	depends on SOC_FAMILY_PSOC6
+	default y
+	depends on DT_HAS_CYPRESS_PSOC6_SPI_ENABLED
 	select USE_INFINEON_SPI
 	help
 	  This option enables the SCB[SPI] driver for PSoC-6 SoC family.

--- a/drivers/spi/Kconfig.rv32m1_lpspi
+++ b/drivers/spi/Kconfig.rv32m1_lpspi
@@ -5,6 +5,8 @@
 
 config SPI_RV32M1_LPSPI
 	bool "RV32M1 LPSPI driver"
-	depends on HAS_RV32M1_LPSPI && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_OPENISA_RV32M1_LPSPI_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable the RV32M1 LPSPI driver.

--- a/drivers/spi/Kconfig.sam
+++ b/drivers/spi/Kconfig.sam
@@ -4,14 +4,10 @@
 # Copyright (c) 2018 qianfan Zhao
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_ATMEL_SAM_SPI := atmel,sam-spi
-
 config SPI_SAM
 	bool "Atmel SAM series SPI driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_SPI))
-	depends on SOC_FAMILY_SAM
-	depends on SPI
+	default y
+	depends on DT_HAS_ATMEL_SAM_SPI_ENABLED
 	select GPIO
 	help
 	  Enable support for the SAM SPI driver.

--- a/drivers/spi/Kconfig.sam0
+++ b/drivers/spi/Kconfig.sam0
@@ -6,7 +6,7 @@
 config SPI_SAM0
 	bool "Atmel SAM0 series SERCOM SPI driver"
 	default y
-	depends on SOC_FAMILY_SAM0
+	depends on DT_HAS_ATMEL_SAM0_SPI_ENABLED
 	select DMA if SPI_ASYNC
 	help
 	  Enable support for the SAM0 SERCOM SPI driver.

--- a/drivers/spi/Kconfig.sifive
+++ b/drivers/spi/Kconfig.sifive
@@ -5,6 +5,7 @@
 
 config SPI_SIFIVE
 	bool "SiFive SPI controller driver"
-	depends on SOC_SERIES_RISCV_SIFIVE_FREEDOM
+	default y
+	depends on DT_HAS_SIFIVE_SPI0_ENABLED
 	help
 	  Enable the SPI peripherals on SiFive Freedom processors

--- a/drivers/spi/Kconfig.spi_emul
+++ b/drivers/spi/Kconfig.spi_emul
@@ -3,6 +3,9 @@
 
 config SPI_EMUL
 	bool "SPI emulator"
+	default y
+	depends on DT_HAS_ZEPHYR_SPI_EMUL_CONTROLLER_ENABLED
+	depends on EMUL
 	help
 	  Enable the SPI emulator driver. This is a fake driver in that it
 	  does not talk to real hardware. Instead it talks to emulation

--- a/drivers/spi/Kconfig.stm32
+++ b/drivers/spi/Kconfig.stm32
@@ -5,7 +5,8 @@
 
 menuconfig SPI_STM32
 	bool "STM32 MCU SPI controller driver"
-	depends on SOC_FAMILY_STM32
+	default y
+	depends on DT_HAS_ST_STM32_SPI_ENABLED
 	select USE_STM32_LL_SPI
 	help
 	  Enable SPI support on the STM32 family of processors.

--- a/drivers/spi/Kconfig.test
+++ b/drivers/spi/Kconfig.test
@@ -1,9 +1,8 @@
 # Copyright (c) 2021, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_VND_SPI := vnd,spi
-
 # Hidden option for turning on the dummy driver for vnd,spi devices
 # used in testing.
 config SPI_TEST
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_VND_SPI))
+	def_bool DT_HAS_VND_SPI_ENABLED
+	depends on DT_HAS_VND_SPI_ENABLED

--- a/drivers/spi/Kconfig.xec_qmspi
+++ b/drivers/spi/Kconfig.xec_qmspi
@@ -6,7 +6,7 @@
 config SPI_XEC_QMSPI
 	bool "Microchip XEC QMSPI driver"
 	default y
-	depends on SOC_SERIES_MEC1501X
+	depends on DT_HAS_MICROCHIP_XEC_QMSPI_ENABLED
 	select DMA if SPI_ASYNC
 	help
 	  Enable support for the Microchip XEC QMSPI driver.

--- a/drivers/spi/Kconfig.xec_qmspi_ldma
+++ b/drivers/spi/Kconfig.xec_qmspi_ldma
@@ -6,6 +6,6 @@
 config SPI_XEC_QMSPI_LDMA
 	bool "Microchip XEC QMSPI LDMA driver"
 	default y
-	depends on SOC_SERIES_MEC172X
+	depends on DT_HAS_MICROCHIP_XEC_QMSPI_LDMA_ENABLED
 	help
 	  Enable support for the Microchip XEC QMSPI with local DMA driver.

--- a/drivers/spi/Kconfig.xlnx
+++ b/drivers/spi/Kconfig.xlnx
@@ -5,5 +5,7 @@
 
 config SPI_XLNX_AXI_QUADSPI
 	bool "Xilinx AXI Quad SPI driver"
+	default y
+	depends on DT_HAS_XLNX_XPS_SPI_2_00_A_ENABLED
 	help
 	  Enable Xilinx AXI Quad SPI v3.2 driver.


### PR DESCRIPTION
Update spi drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>