### PR TITLE
MAINTAINERS: point "Drivers: Audio" and "Intel (Xtensa)" at each other

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -483,6 +483,7 @@ Documentation:
     labels:
         - "area: ADC"
 
+# See also "Intel Platforms (Xtensa)"
 "Drivers: Audio":
     status: maintained
     maintainers:
@@ -1703,6 +1704,7 @@ Intel Platforms (X86):
     labels:
         - "platform: X86"
 
+# See also "Drivers: Audio"
 Intel Platforms (Xtensa):
     status: maintained
     maintainers:


### PR DESCRIPTION
Right now these two sections largely duplicate each other which proves
there is a good chance that someone adding themselves to one will likely
want to add themselves to the other section too.

Signed-off-by: Marc Herbert <marc.herbert@intel.com>