### PR TITLE
drivers: i2c: gd32: Use correct FAST speed

### DIFF
--- a/drivers/i2c/i2c_gd32.c
+++ b/drivers/i2c/i2c_gd32.c
@@ -597,7 +597,7 @@ static int i2c_gd32_configure(const struct device *dev,
 		I2C_RT(cfg->reg) = freq * 300U / 1000U + 1U;
 
 		/* CLKC = pclk1 / (bitrate * 25) */
-		clkc = pclk1 / (I2C_BITRATE_FAST_PLUS * 25U);
+		clkc = pclk1 / (I2C_BITRATE_FAST * 25U);
 		if (clkc == 0U) {
 			clkc = 1U;
 		}


### PR DESCRIPTION
Fixed bug where configured FAST speed causes FAST_PLUS speed to be applied.

Signed-off-by: Alex Sergeev <asergeev@carbonrobotics.com>

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202627655412777