### PR TITLE
dts: riscv: andes: andes_v5_ae350.dtsi: Refined the dts for ae350 series.

### DIFF
--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -84,6 +84,74 @@
 				interrupt-controller;
 			};
 		};
+		CPU4: cpu@4 {
+			compatible = "riscv";
+			device_type = "cpu";
+			reg = <4>;
+			status = "okay";
+			riscv,isa = "rv32imafdcxandes";
+			mmu-type = "riscv,sv32";
+			clock-frequency = <60000000>;
+			i-cache-line-size = <32>;
+			d-cache-line-size = <32>;
+			CPU4_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		CPU5: cpu@5 {
+			compatible = "riscv";
+			device_type = "cpu";
+			reg = <5>;
+			status = "okay";
+			riscv,isa = "rv32imafdcxandes";
+			mmu-type = "riscv,sv32";
+			clock-frequency = <60000000>;
+			i-cache-line-size = <32>;
+			d-cache-line-size = <32>;
+			CPU5_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		CPU6: cpu@6 {
+			compatible = "riscv";
+			device_type = "cpu";
+			reg = <6>;
+			status = "okay";
+			riscv,isa = "rv32imafdcxandes";
+			mmu-type = "riscv,sv32";
+			clock-frequency = <60000000>;
+			i-cache-line-size = <32>;
+			d-cache-line-size = <32>;
+			CPU6_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
+		CPU7: cpu@7 {
+			compatible = "riscv";
+			device_type = "cpu";
+			reg = <7>;
+			status = "okay";
+			riscv,isa = "rv32imafdcxandes";
+			mmu-type = "riscv,sv32";
+			clock-frequency = <60000000>;
+			i-cache-line-size = <32>;
+			d-cache-line-size = <32>;
+			CPU7_intc: interrupt-controller {
+				compatible = "riscv,cpu-intc";
+				#address-cells = <0>;
+				#interrupt-cells = <1>;
+				interrupt-controller;
+			};
+		};
 	};
 
 	dram: memory@0 {
@@ -110,7 +178,9 @@
 			riscv,max-priority = <255>;
 			riscv,ndev = <1023>;
 			interrupts-extended = <&CPU0_intc 11 &CPU1_intc 11
-					       &CPU2_intc 11 &CPU3_intc 11>;
+					       &CPU2_intc 11 &CPU3_intc 11
+					       &CPU4_intc 11 &CPU5_intc 11
+					       &CPU6_intc 11 &CPU7_intc 11>;
 		};
 
 		plic_sw0: interrupt-controller@e6400000 {
@@ -122,7 +192,9 @@
 			riscv,max-priority = <255>;
 			riscv,ndev = <1023>;
 			interrupts-extended = <&CPU0_intc 3 &CPU1_intc 3
-					       &CPU2_intc 3 &CPU3_intc 3>;
+					       &CPU2_intc 3 &CPU3_intc 3
+					       &CPU4_intc 3 &CPU5_intc 3
+					       &CPU6_intc 3 &CPU7_intc 3>;
 		};
 
 		smu: smu@f0100000 {

--- a/soc/riscv/riscv-privilege/andes_v5/Kconfig.defconfig.ae350
+++ b/soc/riscv/riscv-privilege/andes_v5/Kconfig.defconfig.ae350
@@ -18,4 +18,8 @@ config IDLE_STACK_SIZE
 config TEST_EXTRA_STACK_SIZE
 	default 1024
 
+config MP_NUM_CPUS
+	default 1
+	range 1 8
+
 endif # SOC_RISCV_ANDES_AE350


### PR DESCRIPTION
This PR is for updating the soc dtsi and defconfig to support 8 processing cores in FPGA-based platform adp_xc7k_ae350. Because the adp_xc7k_ae350 has been supporting up to 8 processing cores now.

In andes_v5_ae350.dtsi:
1. Adding CPU4~CPU7 node.
2. Updating the interrupt property information for cpu in interrupt-controller node.

In Kconfig.defconfig.ae350:
1. Overwrite the range of MP_NUM_CPUS Kconfig to 1 <-> 8 , because the MP_NUM_CPUS declaration in kernel/Kconfig only support 1 <-> 4.