### PR TITLE
drivers: eeprom: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/eeprom/Kconfig
+++ b/drivers/eeprom/Kconfig
@@ -43,6 +43,8 @@ config EEPROM_AT2X
 
 config EEPROM_AT24
 	bool "Atmel AT24 (and compatible) I2C EEPROM support"
+	default y
+	depends on DT_HAS_ATMEL_AT24_ENABLED
 	depends on I2C
 	select EEPROM_AT2X
 	help
@@ -50,6 +52,8 @@ config EEPROM_AT24
 
 config EEPROM_AT25
 	bool "Atmel AT25 (and compatible) SPI EEPROM support"
+	default y
+	depends on DT_HAS_ATMEL_AT25_ENABLED
 	depends on SPI
 	select EEPROM_AT2X
 	help
@@ -62,6 +66,8 @@ source "drivers/eeprom/Kconfig.tmp116"
 
 config EEPROM_SIMULATOR
 	bool "Simulated EEPROM driver"
+	default y
+	depends on DT_HAS_ZEPHYR_SIM_EEPROM_ENABLED
 	select STATS
 	select STATS_NAMES
 	help

--- a/drivers/eeprom/Kconfig.eeprom_emu
+++ b/drivers/eeprom/Kconfig.eeprom_emu
@@ -3,6 +3,8 @@
 
 config EEPROM_EMULATOR
 	bool "Emulated EEPROM driver"
+	default y
+	depends on DT_HAS_ZEPHYR_EMU_EEPROM_ENABLED
 	select FLASH
 	help
 	  Enable emulated (on flash) EEPROM support. This mimics an external

--- a/drivers/eeprom/Kconfig.lpc11u6x
+++ b/drivers/eeprom/Kconfig.lpc11u6x
@@ -3,7 +3,7 @@
 
 config EEPROM_LPC11U6X
 	bool "LPC11U6x EEPROM driver"
-	depends on SOC_SERIES_LPC11U6X
 	default y
+	depends on DT_HAS_NXP_LPC11U6X_EEPROM_ENABLED
 	help
 	  Enable support for the on-chip EEPROM found on NXP LPC11U6x MCUs.

--- a/drivers/eeprom/Kconfig.stm32
+++ b/drivers/eeprom/Kconfig.stm32
@@ -3,8 +3,8 @@
 
 config EEPROM_STM32
 	bool "STM32 EEPROM driver"
-	depends on SOC_SERIES_STM32L0X || SOC_SERIES_STM32L1X
 	default y
+	depends on DT_HAS_ST_STM32_EEPROM_ENABLED
 	select USE_STM32_HAL_FLASH
 	select USE_STM32_HAL_FLASH_EX
 	help

--- a/drivers/eeprom/Kconfig.tmp116
+++ b/drivers/eeprom/Kconfig.tmp116
@@ -3,8 +3,9 @@
 
 config EEPROM_TMP116
 	bool "TMP116 EEPROM driver"
-	depends on TMP116
 	default y
+	depends on DT_HAS_TI_TMP116_EEPROM_ENABLED
+	depends on TMP116
 	help
 	  Enable support for the on-chip EEPROM found on
 	  Texas instrument TMP116 temperature sensor


### PR DESCRIPTION
Update EEPROM drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol to expose the driver and enable it by default based on devicetree.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>