### PR TITLE
ztest: add test summary support.

### DIFF
--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -121,14 +121,35 @@ static inline void test_time_ms(void)
 	} while (0)
 #endif
 
+static inline void print_nothing(const char *fmt, ...)
+{
+	ARG_UNUSED(fmt);
+}
+
 #ifndef TC_PRINT
+#if defined(CONFIG_ZTEST_VERBOSE_OUTPUT)
 #define TC_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
+#else
+#define TC_PRINT(fmt, ...) print_nothing(fmt, ##__VA_ARGS__)
+#endif
+#endif
+
+#ifndef TC_SUMMARY_PRINT
+#define TC_SUMMARY_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
+#endif
+
+#ifndef TC_START_PRINT
+#if defined(CONFIG_ZTEST_VERBOSE_OUTPUT)
+#define TC_START_PRINT(name) PRINT_DATA("START - %s\n", name);
+#else
+#define TC_START_PRINT(name)
+#endif
 #endif
 
 #ifndef TC_START
 #define TC_START(name)							\
 	do {								\
-		PRINT_DATA("START - %s\n", name);			\
+		TC_START_PRINT(name);			\
 		get_start_time_cyc();					\
 	} while (0)
 #endif
@@ -137,15 +158,22 @@ static inline void test_time_ms(void)
 #define TC_END(result, fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
 #endif
 
-#ifndef Z_TC_END_RESULT
+#ifndef TC_END_PRINT
+#if defined(CONFIG_ZTEST_VERBOSE_OUTPUT)
+#define TC_END_PRINT(result, fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__); PRINT_LINE
+#else
+#define TC_END_PRINT(result, fmt, ...)
+#endif
+#endif
+
 /* prints result and the function name */
+#ifndef Z_TC_END_RESULT
 #define Z_TC_END_RESULT(result, func)						\
 	do {									\
 		test_time_ms();							\
-		TC_END(result, " %s - %s in %u.%u seconds\n",			\
+		TC_END_PRINT(result, " %s - %s in %u.%u seconds\n",		\
 			TC_RESULT_TO_STR(result), func, tc_spend_time/1000,	\
 			tc_spend_time%1000);					\
-		PRINT_LINE;							\
 	} while (0)
 #endif
 
@@ -154,10 +182,14 @@ static inline void test_time_ms(void)
 	Z_TC_END_RESULT((result), __func__)
 #endif
 
+#ifndef TC_SUITE_PRINT
+#define TC_SUITE_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
+#endif
+
 #ifndef TC_SUITE_START
 #define TC_SUITE_START(name)					\
 	do {							\
-		TC_PRINT("Running TESTSUITE %s\n", name);	\
+		TC_SUITE_PRINT("Running TESTSUITE %s\n", name);	\
 		PRINT_LINE;					\
 	} while (0)
 #endif
@@ -166,9 +198,9 @@ static inline void test_time_ms(void)
 #define TC_SUITE_END(name, result)				\
 	do {								\
 		if (result != TC_FAIL) {				\
-			TC_PRINT("TESTSUITE %s succeeded\n", name);	\
+			TC_SUITE_PRINT("TESTSUITE %s succeeded\n", name);	\
 		} else {						\
-			TC_PRINT("TESTSUITE %s failed.\n", name);	\
+			TC_SUITE_PRINT("TESTSUITE %s failed.\n", name);	\
 		}							\
 	} while (0)
 #endif

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -122,6 +122,20 @@ config ZTEST_SHUFFLE_TEST_REPEAT_COUNT
 
 endif #ZTEST_SHUFFLE
 
+config ZTEST_VERBOSE_OUTPUT
+	bool "Verbose test output"
+	default y
+	help
+	  This option controls whether test output is shown verbosely or
+	  no output at all.
+
+config ZTEST_VERBOSE_SUMMARY
+	bool "Verbose test summary"
+	default y
+	help
+	  This option controls whether suite summary is shwon verbosely or
+	  just in one line.
+
 endif # ZTEST_NEW_API
 
 endif # ZTEST

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -32,6 +32,9 @@ struct ztest_unit_test {
 	const char *name;
 	void (*test)(void *data);
 	uint32_t thread_options;
+
+	/** Stats */
+	struct ztest_unit_test_stats *const stats;
 };
 
 extern struct ztest_unit_test _ztest_unit_test_list_start[];
@@ -48,6 +51,17 @@ struct ztest_suite_stats {
 	uint32_t skip_count;
 	/** The number of times that the suite failed */
 	uint32_t fail_count;
+};
+
+struct ztest_unit_test_stats {
+	/** The number of times that the test ran */
+	uint32_t run_count;
+	/** The number of times that the test was skipped */
+	uint32_t skip_count;
+	/** The number of times that the test failed */
+	uint32_t fail_count;
+	/** The number of times that the test passed */
+	uint32_t pass_count;
 };
 
 /**
@@ -133,7 +147,7 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
  * @param teardown_fn The function to call after running all the tests in this suite
  */
 #define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)             \
-	struct ztest_suite_stats UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME);                   \
+	struct ztest_suite_stats UTIL_CAT(z_ztest_suite_node_stats_, SUITE_NAME);                  \
 	static const STRUCT_SECTION_ITERABLE(ztest_suite_node,                                     \
 					     UTIL_CAT(z_ztest_test_node_, SUITE_NAME)) = {         \
 		.name = STRINGIFY(SUITE_NAME),                                                     \
@@ -142,7 +156,7 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
 		.after = (after_fn),                                                               \
 		.teardown = (teardown_fn),                                                         \
 		.predicate = PREDICATE,                                                            \
-		.stats = &UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME),                          \
+		.stats = &UTIL_CAT(z_ztest_suite_node_stats_, SUITE_NAME),             \
 	}
 /**
  * Default entry point for running or listing registered unit tests.
@@ -249,6 +263,7 @@ void ztest_test_pass(void);
 void ztest_test_skip(void);
 
 #define Z_TEST(suite, fn, t_options, use_fixture)                                                  \
+	struct ztest_unit_test_stats UTIL_CAT(z_ztest_unit_test_stats_, fn);      \
 	static void _##suite##_##fn##_wrapper(void *data);                                         \
 	static void suite##_##fn(                                                                  \
 		COND_CODE_1(use_fixture, (struct suite##_fixture *fixture), (void)));              \
@@ -257,6 +272,7 @@ void ztest_test_skip(void);
 		.name = STRINGIFY(fn),                                                             \
 		.test = (_##suite##_##fn##_wrapper),                                               \
 		.thread_options = t_options,                                                       \
+		.stats = &UTIL_CAT(z_ztest_unit_test_stats_, fn)                                  \
 	};                                                                                         \
 	static void _##suite##_##fn##_wrapper(void *data)                                          \
 	{                                                                                          \


### PR DESCRIPTION
This will be a series of commits.

**[Commit 1]**:  Add config switch for modes of test output
Support verbose or one-line summary at test suite level.
Support verbose or no output at test function level.

Totally 4 combinations configurable:
- function verbose + suite verbose
- function verbose + suite one-line
- no function output + suite verbose
- no function output + suite one-line

**[Commit 2]**:   Add test summary after all suites finish running

  Add test summary after all test suites finish running.
  The summary can be one-line or verbose, which is configured
  with CONFIG_ZTEST_VERBOSE_SUMMARY. The one-line summary covers
  overall suite stats. The verbose summary covers each test
  function within the suite besides the one-line summary.

Signed-off-by: Ming Shao <ming.shao@intel.com>