### PR TITLE
drivers: can: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/can/Kconfig.loopback
+++ b/drivers/can/Kconfig.loopback
@@ -3,12 +3,11 @@
 # Copyright (c) 2019 Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ZEPHYR_CAN_LOOPBACK := zephyr,can-loopback
-
 config CAN_LOOPBACK
 	bool "Emulated CAN loopback driver"
+	default y
+	depends on DT_HAS_ZEPHYR_CAN_LOOPBACK_ENABLED
 	select CAN_HAS_CANFD
-	default $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_CAN_LOOPBACK))
 	help
 	  This is an emulated driver that can only loopback messages.
 

--- a/drivers/can/Kconfig.mcp2515
+++ b/drivers/can/Kconfig.mcp2515
@@ -5,6 +5,8 @@
 
 config CAN_MCP2515
 	bool "MCP2515 CAN Driver"
+	default y
+	depends on DT_HAS_MICROCHIP_MCP2515_ENABLED
 	depends on SPI
 	help
 	  Enable MCP2515 CAN Driver

--- a/drivers/can/Kconfig.mcux
+++ b/drivers/can/Kconfig.mcux
@@ -5,7 +5,9 @@
 
 config CAN_MCUX_FLEXCAN
 	bool "MCUX FlexCAN driver"
-	depends on HAS_MCUX_FLEXCAN && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_KINETIS_FLEXCAN_ENABLED
+	depends on CLOCK_CONTROL
 	select CAN_HAS_RX_TIMESTAMP
 	help
 	  Enable support for mcux flexcan driver.
@@ -21,7 +23,9 @@ config CAN_MAX_FILTER
 
 config CAN_MCUX_MCAN
 	bool "MCUX MCAN driver"
-	depends on HAS_MCUX_MCAN && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_LPC_MCAN_ENABLED
+	depends on CLOCK_CONTROL
 	select CAN_MCAN
 	help
 	  Enable support for mcux mcan driver.

--- a/drivers/can/Kconfig.rcar
+++ b/drivers/can/Kconfig.rcar
@@ -3,12 +3,10 @@
 # Copyright (c) 2021 IoT.bzh
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_RENESAS_RCAR_CAN := renesas,rcar-can
-
 config CAN_RCAR
 	bool "Renesas R-Car CAN Driver"
-	depends on SOC_FAMILY_RCAR
-	default $(dt_compat_enabled,$(DT_COMPAT_RENESAS_RCAR_CAN))
+	default y
+	depends on DT_HAS_RENESAS_RCAR_CAN_ENABLED
 	help
 	  Enable Renesas R-Car CAN Driver.
 

--- a/drivers/can/Kconfig.sam
+++ b/drivers/can/Kconfig.sam
@@ -2,9 +2,8 @@
 # Copyright (c) 2021 Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ATMEL_SAM_CAN := atmel,sam-can
-
 config CAN_SAM
 	bool "Atmel SAM CAN driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_CAN))
+	default y
+	depends on DT_HAS_ATMEL_SAM_CAN_ENABLED
 	select CAN_MCAN

--- a/drivers/can/Kconfig.stm32
+++ b/drivers/can/Kconfig.stm32
@@ -3,11 +3,10 @@
 # Copyright (c) 2018 Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_STM32_CAN := st,stm32-can
-
 config CAN_STM32
 	bool "STM32 CAN Driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_CAN))
+	default y
+	depends on DT_HAS_ST_STM32_CAN_ENABLED
 	select CAN_HAS_RX_TIMESTAMP
 	help
 	  Enable STM32 CAN Driver.

--- a/drivers/can/Kconfig.stm32fd
+++ b/drivers/can/Kconfig.stm32fd
@@ -3,11 +3,10 @@
 # Copyright (c) 2020 Alexander Wachter
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_STM32_FDCAN := st,stm32-fdcan
-
 config CAN_STM32FD
 	bool "STM32 FDCAN driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_STM32_FDCAN))
+	default y
+	depends on DT_HAS_ST_STM32_FDCAN_ENABLED
 	select CAN_MCAN
 	select USE_STM32_LL_RCC
 

--- a/drivers/can/Kconfig.stm32h7
+++ b/drivers/can/Kconfig.stm32h7
@@ -3,11 +3,10 @@
 # Copyright (c) 2022 Blue Clover
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_STM32_H7 := st,stm32h7-fdcan
-
 config CAN_STM32H7
 	bool "STM32H7 FDCAN driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_STM32_H7))
+	default y
+	depends on DT_HAS_ST_STM32H7_FDCAN_ENABLED
 	select CAN_MCAN
 	select USE_STM32_LL_RCC
 


### PR DESCRIPTION
Update CAN drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol to expose the driver and enable it by default based on devicetree.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>