### PR TITLE
include: zephyr: comply to coding guidelines MISRA C:2012 Rule 14.4

### DIFF
--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -155,7 +155,7 @@ static inline void log_backend_init(const struct log_backend *const backend)
 static inline int log_backend_is_ready(const struct log_backend *const backend)
 {
 	__ASSERT_NO_MSG(backend != NULL);
-	if (backend->api->is_ready) {
+	if (backend->api->is_ready != NULL) {
 		return backend->api->is_ready(backend);
 	}
 

--- a/include/zephyr/logging/log_msg.h
+++ b/include/zephyr/logging/log_msg.h
@@ -223,7 +223,7 @@ do { \
 	struct log_msg *_msg; \
 	Z_LOG_MSG2_ON_STACK_ALLOC(_msg, Z_LOG_MSG2_LEN(_plen, 0)); \
 	Z_LOG_ARM64_VLA_PROTECT(); \
-	if (_plen) { \
+	if (_plen != 0) { \
 		CBPRINTF_STATIC_PACKAGE(_msg->data, _plen, \
 					_plen, Z_LOG_MSG2_ALIGN_OFFSET, flags, \
 					__VA_ARGS__);\
@@ -234,7 +234,7 @@ do { \
 	LOG_MSG2_DBG("creating message on stack: package len: %d, data len: %d\n", \
 			_plen, (int)(_dlen)); \
 	z_log_msg_static_create((void *)_source, _desc, _msg->data, _data); \
-} while (0)
+} while (false)
 
 #ifdef CONFIG_LOG_SPEED
 #define Z_LOG_MSG2_SIMPLE_CREATE(_cstr_cnt, _domain_id, _source, _level, ...) do { \
@@ -255,7 +255,7 @@ do { \
 					__VA_ARGS__); \
 	} \
 	z_log_msg_finalize(_msg, (void *)_source, _desc, NULL); \
-} while (0)
+} while (false)
 #else
 /* Alternative empty macro created to speed up compilation when LOG_SPEED is
  * disabled (default).
@@ -395,7 +395,7 @@ do {\
 				   CBPRINTF_PACKAGE_ARGS_ARE_TAGGED : 0), \
 				  Z_LOG_FMT_RUNTIME_ARGS(_fmt, ##__VA_ARGS__));\
 	_mode = Z_LOG_MSG2_MODE_RUNTIME; \
-} while (0)
+} while (false)
 #else /* CONFIG_LOG_ALWAYS_RUNTIME */
 #define Z_LOG_MSG2_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			  _level, _data, _dlen, ...) \
@@ -416,7 +416,7 @@ do { \
 		_mode = Z_LOG_MSG2_MODE_FROM_STACK; \
 	} \
 	(void)_mode; \
-} while (0)
+} while (false)
 
 #if defined(__cplusplus)
 #define Z_AUTO_TYPE auto
@@ -447,7 +447,7 @@ do { \
 	Z_LOG_MSG2_CREATE3(_try_0cpy, _mode,  _cstr_cnt, _domain_id, _source,\
 			   _level, _data, _dlen, \
 			   FOR_EACH_IDX(Z_LOG_LOCAL_ARG_NAME, (,), __VA_ARGS__)); \
-} while (0)
+} while (false)
 #endif /* CONFIG_LOG_ALWAYS_RUNTIME ||
 	* (!LOG && (!TOOLCHAIN_HAS_PRAGMA_DIAG || !TOOLCHAIN_HAS_C_AUTO_TYPE))
 	*/

--- a/include/zephyr/sys/cbprintf_internal.h
+++ b/include/zephyr/sys/cbprintf_internal.h
@@ -226,7 +226,7 @@ extern "C" {
 			default : \
 				(const void **)buf) = arg; \
 	} \
-} while (0)
+} while (false)
 #endif
 
 /** @brief Return alignment needed for given argument.
@@ -291,7 +291,7 @@ do { \
 			Z_CBPRINTF_IS_LONGDOUBLE(_arg) && \
 			!IS_ENABLED(CONFIG_CBPRINTF_PACKAGE_LONGDOUBLE)),\
 			"Packaging of long double not enabled in Kconfig."); \
-	while (_align_offset % Z_CBPRINTF_ALIGNMENT(_arg)) { \
+	while (_align_offset % Z_CBPRINTF_ALIGNMENT(_arg) != 0UL) { \
 		_idx += sizeof(int); \
 		_align_offset += sizeof(int); \
 	} \
@@ -321,7 +321,7 @@ do { \
 	} \
 	_idx += _arg_size; \
 	_align_offset += _arg_size; \
-} while (0)
+} while (false)
 
 /** @brief Package single argument.
  *
@@ -442,7 +442,7 @@ do { \
 	/* Append string indexes to the package. */ \
 	_total_len += _ros_cnt; \
 	_total_len += _rws_cnt; \
-	if (_pbuf) { \
+	if (_pbuf != NULL) { \
 		/* Append string locations. */ \
 		uint8_t *_pbuf_loc = &_pbuf[_pkg_len]; \
 		for (size_t i = 0; i < _ros_cnt; i++) { \
@@ -455,7 +455,7 @@ do { \
 	/* Store length */ \
 	_outlen = (_total_len > (int)_pmax) ? -ENOSPC : _total_len; \
 	/* Store length in the header, set number of dumped strings to 0 */ \
-	if (_pbuf) { \
+	if (_pbuf != NULL) { \
 		union cbprintf_package_hdr hdr = { \
 			.desc = { \
 				.len = (uint8_t)(_pkg_len / sizeof(int)), \
@@ -469,7 +469,7 @@ do { \
 		*_len_loc = hdr; \
 	} \
 	_Pragma("GCC diagnostic pop") \
-} while (0)
+} while (false)
 
 #if Z_C_GENERIC
 #define Z_CBPRINTF_STATIC_PACKAGE(packaged, inlen, outlen, align_offset, flags, \
@@ -486,7 +486,7 @@ do { \
 	} else { \
 		outlen = cbprintf_package(NULL, align_offset, flags, __VA_ARGS__); \
 	} \
-} while (0)
+} while (false)
 #endif /* Z_C_GENERIC */
 
 #ifdef __cplusplus

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -277,7 +277,7 @@ struct z_device_mmio_rom {
 		   DEVICE_MMIO_ROM_PTR(dev)->size, \
 		   (flags))
 #else
-#define DEVICE_MMIO_MAP(dev, flags) do { } while (0)
+#define DEVICE_MMIO_MAP(dev, flags) do { } while (false)
 #endif
 
 /**
@@ -525,7 +525,7 @@ struct z_device_mmio_rom {
 		   (DEVICE_MMIO_NAMED_ROM_PTR((dev), name)->size), \
 		   (flags))
 #else
-#define DEVICE_MMIO_NAMED_MAP(dev, name, flags) do { } while (0)
+#define DEVICE_MMIO_NAMED_MAP(dev, name, flags) do { } while (false)
 #endif
 
 /**
@@ -709,7 +709,7 @@ struct z_device_mmio_rom {
 		   Z_TOPLEVEL_ROM_NAME(name).phys_addr, \
 		   Z_TOPLEVEL_ROM_NAME(name).size, flags)
 #else
-#define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) do { } while (0)
+#define DEVICE_MMIO_TOPLEVEL_MAP(name, flags) do { } while (false)
 #endif
 
 /**

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -247,9 +247,8 @@ do {                                                                    \
 
 #define ARG_UNUSED(x) (void)(x)
 
-#define likely(x)   __builtin_expect((bool)!!(x), true)
-#define unlikely(x) __builtin_expect((bool)!!(x), false)
-
+#define likely(x)   (__builtin_expect((bool)!!(x), true) != 0L)
+#define unlikely(x) (__builtin_expect((bool)!!(x), false) != 0L)
 #define popcount(x) __builtin_popcount(x)
 
 #ifndef __no_optimization


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 14.4 in include/zephyr:
> The controlling expression of an if statement
> and the controlling expression of an iteration-statement shall have
> essentially Boolean type.

This PR is part of the enhancement issue #48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
5d02614e34a86b549c7707d3d9f0984bc3a5f22a