### PR TITLE
samples: subsys: mgmt: updatehub: Update sample to use DEVICE_DT_GET_ONE

### DIFF
--- a/samples/subsys/mgmt/updatehub/src/main.c
+++ b/samples/subsys/mgmt/updatehub/src/main.c
@@ -17,6 +17,11 @@
 #include "c_certificates.h"
 #endif
 
+#if defined(CONFIG_MODEM_GSM_PPP)
+#define GSM_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_gsm_ppp)
+#define UART_NODE DT_BUS(GSM_NODE)
+#endif
+
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(main);
 
@@ -138,8 +143,7 @@ void main(void)
 	}
 
 #elif defined(CONFIG_MODEM_GSM_PPP)
-	const struct device *uart_dev =
-		DEVICE_DT_GET(DT_BUS(DT_INST(0, zephyr_gsm_ppp)));
+	const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
 
 	LOG_INF("APN '%s' UART '%s' device %p", CONFIG_MODEM_GSM_APN,
 		uart_dev->name, uart_dev);


### PR DESCRIPTION
Update sample to use DEVICE_DT_GET_ONE in order to remove DT_INST
usage.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>