### PR TITLE
SPARC: Thread stack reduction

### DIFF
--- a/arch/sparc/core/switch.S
+++ b/arch/sparc/core/switch.S
@@ -150,9 +150,9 @@ SECTION_FUNC(TEXT, z_sparc_context_switch)
 
 SECTION_FUNC(TEXT, z_thread_entry_wrapper)
 	mov	%g0, %o7
-	ld	[%sp + 0x40], %o0
-	ld	[%sp + 0x44], %o1
-	ld	[%sp + 0x48], %o2
-	ld	[%sp + 0x4C], %o3
+	mov	%i0, %o0
+	mov	%i1, %o1
+	mov	%i2, %o2
+	mov	%i3, %o3
 	call	z_thread_entry
 	 nop

--- a/arch/sparc/core/thread.c
+++ b/arch/sparc/core/thread.c
@@ -20,11 +20,6 @@ void z_thread_entry_wrapper(k_thread_entry_t thread,
  */
 struct init_stack_frame {
 	uint32_t window_save_area[16];
-	k_thread_entry_t entry_point;
-	void *arg1;
-	void *arg2;
-	void *arg3;
-	uint32_t pad[8];
 };
 
 #if defined(CONFIG_FPU_SHARING)
@@ -42,12 +37,10 @@ void arch_new_thread(struct k_thread *thread, k_thread_stack_t *stack,
 	/* Initial stack frame data, stored at base of the stack */
 	iframe = Z_STACK_PTR_TO_FRAME(struct init_stack_frame, stack_ptr);
 
-	iframe->entry_point = entry;
-	iframe->arg1 = p1;
-	iframe->arg2 = p2;
-	iframe->arg3 = p3;
-
-	/* Put values for debugging purposes */
+	thread->callee_saved.i0 = (uint32_t) entry;
+	thread->callee_saved.i1 = (uint32_t) p1;
+	thread->callee_saved.i2 = (uint32_t) p2;
+	thread->callee_saved.i3 = (uint32_t) p3;
 	thread->callee_saved.i6 = 0;                    /* frame pointer */
 	thread->callee_saved.o6 = (uint32_t) iframe;    /* stack pointer */
 	thread->callee_saved.o7 = (uint32_t) z_thread_entry_wrapper - 8;

--- a/tests/kernel/fpu_sharing/generic/testcase.yaml
+++ b/tests/kernel/fpu_sharing/generic/testcase.yaml
@@ -40,11 +40,6 @@ tests:
     arch_allow: sparc
     tags: fpu kernel
     timeout: 600
-    # qemu_leon3 crashes during z_cbvprintf_impl.
-    # Workaround it by making the main stack larger.
-    # See #47477.
-    extra_configs:
-      - CONFIG_MAIN_STACK_SIZE=2048
   kernel.fpu_sharing.generic.x86.fpu:
     extra_args: CONF_FILE=prj_x86.conf
     extra_configs:


### PR DESCRIPTION
This is an architecture specific optimisation.

Transfer the thread entry point and initial parameters in the struct `callee_saved` rather than on the stack. This saves 48 byte stack per thread and simplifies the logic.

The stack reduction is enough to solve #47477, so the workaround introduced in d6995cb0508 is no longer needed.
