### PR TITLE
subsys: comply to coding guidelines MISRA C:2012 Rule 14.4 for do-while violations

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -34,7 +34,7 @@
 			(void)bt_ots_obj_id_to_str(id64, t, sizeof(t)); \
 			BT_DBG(text "0x%s", t); \
 		} \
-	} while (0)
+	} while (false)
 
 
 #define BT_DBG_ENABLED IS_ENABLED(CONFIG_BT_DEBUG_MCC)

--- a/subsys/bluetooth/audio/media_proxy_internal.h
+++ b/subsys/bluetooth/audio/media_proxy_internal.h
@@ -23,7 +23,7 @@
 			(void)bt_ots_obj_id_to_str(id64, t, sizeof(t)); \
 			BT_DBG(text "0x%s", t); \
 		} \
-	} while (0)
+	} while (false)
 
 
 /* SYNCHRONOUS (CALL/RETURN) API FOR CONTROLLERS */

--- a/subsys/bluetooth/common/log.h
+++ b/subsys/bluetooth/common/log.h
@@ -63,7 +63,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 			BT_ASSERT_PRINT(cond);   \
 			BT_ASSERT_DIE();         \
 		}                                \
-	} while (0)
+	} while (false)
 
 #define BT_ASSERT_MSG(cond, fmt, ...)                              \
 	do {                                                       \
@@ -72,7 +72,7 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME, LOG_LEVEL);
 			BT_ASSERT_PRINT_MSG(fmt, ##__VA_ARGS__);   \
 			BT_ASSERT_DIE();                           \
 		}                                                  \
-	} while (0)
+	} while (false)
 #else
 #define BT_ASSERT(cond) __ASSERT_NO_MSG(cond)
 #define BT_ASSERT_MSG(cond, msg, ...) __ASSERT(cond, msg, ##__VA_ARGS__)

--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/debug.h
@@ -45,7 +45,7 @@
 		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX7, NRF_GPIO_PIN_MCUSEL_NETWORK); \
 		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX8, NRF_GPIO_PIN_MCUSEL_NETWORK); \
 		soc_secure_gpio_pin_mcu_select(32 + DEBUG_PIN_IDX9, NRF_GPIO_PIN_MCUSEL_NETWORK); \
-	} while (0)
+	} while (false)
 #endif /* CONFIG_BOARD_NRF5340DK_NRF5340_CPUAPP */
 #elif defined(CONFIG_BOARD_NRF52840DK_NRF52840) || \
 	defined(CONFIG_BOARD_NRF52833DK_NRF52833)
@@ -102,7 +102,7 @@
 	do { \
 		DEBUG_PORT->DIRSET = DEBUG_PIN_MASK; \
 		DEBUG_PORT->OUTCLR = DEBUG_PIN_MASK; \
-	} while (0)
+	} while (false)
 
 #define DEBUG_CPU_SLEEP(flag) \
 	do { \
@@ -113,7 +113,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN0; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN0; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_ISR(flag) \
 	do { \
@@ -124,7 +124,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN1; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_TASK(flag) \
 	do { \
@@ -135,7 +135,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN1; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN1; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_TICKER_JOB(flag) \
 	do { \
@@ -146,7 +146,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN2; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN2; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_ISR(flag) \
 	do { \
@@ -157,7 +157,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN7; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN7; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_XTAL(flag) \
 	do { \
@@ -168,7 +168,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN8; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN8; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_ACTIVE(flag) \
 	do { \
@@ -179,7 +179,7 @@
 			DEBUG_PORT->OUTSET = DEBUG_PIN9; \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN9; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE(flag) \
 	do { \
@@ -189,7 +189,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_CLOSE_MASK; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_A(flag) \
 	do { \
@@ -200,7 +200,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_A(flag) \
 	do { \
@@ -211,7 +211,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_A(flag) \
 	do { \
@@ -221,7 +221,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN3; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_S(flag) \
 	do { \
@@ -232,7 +232,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_S(flag) \
 	do { \
@@ -243,7 +243,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_S(flag) \
 	do { \
@@ -253,7 +253,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN4; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_O(flag) \
 	do { \
@@ -264,7 +264,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_O(flag) \
 	do { \
@@ -275,7 +275,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_O(flag) \
 	do { \
@@ -285,7 +285,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN5; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_M(flag) \
 	do { \
@@ -296,7 +296,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_START_M(flag) \
 	do { \
@@ -307,7 +307,7 @@
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 			DEBUG_PORT->OUTSET = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_CLOSE_M(flag) \
 	do { \
@@ -317,7 +317,7 @@
 		} else { \
 			DEBUG_PORT->OUTCLR = DEBUG_PIN6; \
 		} \
-	} while (0)
+	} while (false)
 
 #else
 #define DEBUG_INIT()

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_conn.c
@@ -84,7 +84,7 @@ static uint8_t force_md_cnt;
 			if (force_md_cnt) { \
 				force_md_cnt--; \
 			} \
-		} while (0)
+		} while (false)
 
 #define FORCE_MD_CNT_GET() force_md_cnt
 
@@ -94,7 +94,7 @@ static uint8_t force_md_cnt;
 			    (trx_cnt >= ((CONFIG_BT_BUF_ACL_TX_COUNT) - 1))) { \
 				force_md_cnt = BT_CTLR_FORCE_MD_COUNT; \
 			} \
-		} while (0)
+		} while (false)
 
 #else /* !CONFIG_BT_CTLR_FORCE_MD_COUNT */
 #define FORCE_MD_CNT_INIT()

--- a/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
+++ b/subsys/bluetooth/controller/ll_sw/openisa/hal/RV32M1/debug.h
@@ -87,7 +87,7 @@ extern const struct device *vega_debug_portd;
 		\
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 1); \
 		gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, 0); \
-	} while (0)
+	} while (false)
 
 #define DEBUG_CPU_SLEEP(flag) gpio_pin_set(DEBUG0_PORT, DEBUG0_PIN, flag)
 
@@ -111,7 +111,7 @@ extern const struct device *vega_debug_portd;
 			gpio_pin_set(DEBUG5_PORT, DEBUG5_PIN, flag); \
 			gpio_pin_set(DEBUG6_PORT, DEBUG6_PIN, flag); \
 		} \
-	} while (0)
+	} while (false)
 
 #define DEBUG_RADIO_PREPARE_A(flag) \
 		gpio_pin_set(DEBUG3_PORT, DEBUG3_PIN, flag)

--- a/subsys/bluetooth/mesh/shell.c
+++ b/subsys/bluetooth/mesh/shell.c
@@ -35,7 +35,7 @@ static const struct shell *ctx_shell;
 			if (ctx_shell != NULL) {                               \
 				shell_print(ctx_shell, _ft, ##__VA_ARGS__);    \
 			}                                                      \
-		} while (0)
+		} while (false)
 
 /* Default net, app & dev key values, unless otherwise specified */
 static const uint8_t default_key[16] = {

--- a/subsys/mgmt/osdp/src/osdp_common.h
+++ b/subsys/mgmt/osdp/src/osdp_common.h
@@ -35,7 +35,7 @@
 	do {                                                    \
 		TO_CP(p)->current_pd = TO_PD(p, i);             \
 		TO_CP(p)->pd_offset = i;                        \
-	} while (0)
+	} while (false)
 #define PD_MASK(ctx) \
 	(uint32_t)((1 << (TO_CP(ctx)->num_pd)) - 1)
 #define AES_PAD_LEN(x)                 ((x + 16 - 1) & (~(16 - 1)))

--- a/subsys/net/ip/ipv6_mld.c
+++ b/subsys/net/ip/ipv6_mld.c
@@ -291,7 +291,7 @@ drop:
 		NET_DBG("%s %s from %s to %s", action, pkt_str,         \
 			net_sprint_ipv6_addr(src),		\
 			net_sprint_ipv6_addr(dst));		\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv(pkt_str, src, dst)	\
 	dbg_addr("Received", pkt_str, src, dst)

--- a/subsys/net/ip/ipv6_nbr.c
+++ b/subsys/net/ip/ipv6_nbr.c
@@ -471,7 +471,7 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 			net_sprint_ipv6_addr(dst),		\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv(pkt_str, src, dst, pkt)	\
 	dbg_addr("Received", pkt_str, src, dst, pkt)
@@ -489,7 +489,7 @@ static void dbg_update_neighbor_lladdr_raw(uint8_t *new_lladdr,
 			net_sprint_ipv6_addr(target),	\
 			net_pkt_iface(pkt),				\
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
-	} while (0)
+	} while (false)
 
 #define dbg_addr_recv_tgt(pkt_str, src, dst, tgt, pkt)		\
 	dbg_addr_with_tgt("Received", pkt_str, src, dst, tgt, pkt)

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -124,7 +124,7 @@ static sys_slist_t timestamp_callbacks;
 			net_if_get_by_iface(net_pkt_iface(pkt)));	\
 									\
 		NET_ASSERT(pkt->frags);					\
-	} while (0)
+	} while (false)
 #else
 #define debug_check_packet(...)
 #endif /* CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG */

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -260,7 +260,7 @@ void net_pkt_allocs_foreach(net_pkt_allocs_cb_t cb, void *user_data)
 			NET_ERR("**ERROR** frag %p not in use (%s:%s():%d)", \
 				frag, __FILE__, __func__, __LINE__);     \
 		}                                                       \
-	} while (0)
+	} while (false)
 
 const char *net_pkt_slab2str(struct k_mem_slab *slab)
 {

--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -271,7 +271,7 @@ static int nbr_nexthop_put(struct net_nbr *nbr)
 			net_sprint_ipv6_addr(dst),		\
 			net_sprint_ipv6_addr(naddr),	\
 			route->iface);					\
-	} } while (0)
+	} } while (false)
 
 /* Route was accessed, so place it in front of the routes list */
 static inline void update_route_access(struct net_route_entry *route)

--- a/subsys/net/ip/tcp.c
+++ b/subsys/net/ip/tcp.c
@@ -597,7 +597,7 @@ static void tcp_send_timer_cancel(struct tcp *conn)
 static const char *tcp_state_to_str(enum tcp_state state, bool prefix)
 {
 	const char *s = NULL;
-#define _(_x) case _x: do { s = #_x; goto out; } while (0)
+#define _(_x) case _x: do { s = #_x; goto out; } while (false)
 	switch (state) {
 	_(TCP_LISTEN);
 	_(TCP_SYN_SENT);

--- a/subsys/net/ip/tp.c
+++ b/subsys/net/ip/tp.c
@@ -334,7 +334,7 @@ enum tp_type tp_msg_to_type(const char *s)
 		type = _type;		\
 		goto out;		\
 	}				\
-} while (0)
+} while (false)
 
 	is_tp(s, TP_COMMAND);
 	is_tp(s, TP_CONFIG_REQUEST);

--- a/subsys/net/ip/tp_priv.h
+++ b/subsys/net/ip/tp_priv.h
@@ -20,7 +20,7 @@ extern "C" {
 #define tp_err(fmt, args...) do {				\
 	printk("%s: Error: " fmt "\n", __func__, ## args);	\
 	k_oops();						\
-} while (0)
+} while (false)
 
 #define tp_assert(cond, fmt, args...) do {			\
 	if ((cond) == false) {					\
@@ -28,7 +28,7 @@ extern "C" {
 			__func__, #cond, ## args);		\
 		k_oops();					\
 	}							\
-} while (0)
+} while (false)
 
 #define is(_a, _b) (strcmp((_a), (_b)) == 0)
 #define ip_get(_x) ((struct net_ipv4_hdr *) net_pkt_ip_data((_x)))

--- a/subsys/net/lib/dns/mdns_responder.c
+++ b/subsys/net/lib/dns/mdns_responder.c
@@ -644,7 +644,7 @@ static int init_listener(void)
 		} else {
 			ok++;
 		}
-	} while (0);
+	} while (false);
 ipv6_out:
 #endif /* CONFIG_NET_IPV6 */
 
@@ -668,7 +668,7 @@ ipv6_out:
 		} else {
 			ok++;
 		}
-	} while (0);
+	} while (false);
 ipv4_out:
 #endif /* CONFIG_NET_IPV4 */
 

--- a/subsys/net/lib/http/http_parser.c
+++ b/subsys/net/lib/http/http_parser.c
@@ -72,7 +72,7 @@ do {                                                                       \
 	if (!FOR##_mark) {                                                 \
 		FOR##_mark = p;                                            \
 	}                                                                  \
-} while (0)
+} while (false)
 
 /* Don't allow the total size of the HTTP headers (including the status
  * line) to exceed HTTP_MAX_HEADER_SIZE.  This check is here to protect

--- a/subsys/net/lib/http/http_parser_url.c
+++ b/subsys/net/lib/http/http_parser_url.c
@@ -44,7 +44,7 @@ do {                                                                       \
 	if (!FOR##_mark) {                                                 \
 		FOR##_mark = p;                                            \
 	}                                                                  \
-} while (0)
+} while (false)
 
 
 #ifdef HTTP_PARSER_STRICT

--- a/subsys/net/lib/mqtt/mqtt_internal.h
+++ b/subsys/net/lib/mqtt/mqtt_internal.h
@@ -115,14 +115,14 @@ extern "C" {
 		if ((param) == NULL) { \
 			return -EINVAL; \
 		} \
-	} while (0)
+	} while (false)
 
 #define NULL_PARAM_CHECK_VOID(param) \
 	do { \
 		if ((param) == NULL) { \
 			return; \
 		} \
-	} while (0)
+	} while (false)
 
 /** Buffer context to iterate over buffer. */
 struct buf_ctx {

--- a/subsys/net/lib/sockets/sockets.c
+++ b/subsys/net/lib/sockets/sockets.c
@@ -58,7 +58,7 @@ LOG_MODULE_REGISTER(net_sock, CONFIG_NET_SOCKETS_LOG_LEVEL);
 		k_mutex_unlock(lock);                        \
 							     \
 		return ret;				     \
-	} while (0)
+	} while (false)
 
 const struct socket_op_vtable sock_fd_op_vtable;
 

--- a/subsys/shell/shell_ops.h
+++ b/subsys/shell/shell_ops.h
@@ -32,7 +32,7 @@ static inline void z_shell_raw_fprintf(const struct shell_fprintf *const ctx,
 		    !z_flag_use_vt100_get(_shell_))			\
 			break;						\
 		z_shell_raw_fprintf(_shell_->fprintf_ctx, __VA_ARGS__);	\
-	} while (0)
+	} while (false)
 
 #define Z_SHELL_SET_FLAG_ATOMIC(_shell_, _type_, _flag_, _val_, _ret_)		\
 	do {									\
@@ -48,7 +48,7 @@ static inline void z_shell_raw_fprintf(const struct shell_fprintf *const ctx,
 						   ~_internal_.value);		\
 		}								\
 		_ret_ = (_internal_.flags._flag_ != 0);				\
-	} while (0)
+	} while (false)
 
 static inline bool z_flag_insert_mode_get(const struct shell *sh)
 {

--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -49,7 +49,7 @@
 #ifdef TC_RUNID
 #define TC_PRINT_RUNID PRINT_DATA("RunID: " TC_STR(TC_RUNID) "\n")
 #else
-#define TC_PRINT_RUNID do {} while (0)
+#define TC_PRINT_RUNID do {} while (false)
 #endif
 
 #ifndef PRINT_LINE
@@ -112,7 +112,7 @@ static inline void get_test_duration_ms(void)
 	do {                                                 \
 		PRINT_DATA(FMT_ERROR, "FAIL", __func__, __LINE__); \
 		PRINT_DATA(fmt, ##__VA_ARGS__);                  \
-	} while (0)
+	} while (false)
 #endif
 
 static inline void print_nothing(const char *fmt, ...)
@@ -155,7 +155,7 @@ static inline void print_nothing(const char *fmt, ...)
 #define TC_START(name)							\
 	do {								\
 		TC_START_PRINT(name);			\
-	} while (0)
+	} while (false)
 #endif
 
 #ifndef TC_END
@@ -181,7 +181,7 @@ static inline void print_nothing(const char *fmt, ...)
 		TC_END_PRINT(result, " %s - %s in %u.%03u seconds\n",		\
 			TC_RESULT_TO_STR(result), func, tc_spend_time/1000,	\
 			tc_spend_time%1000);					\
-	} while (0)
+	} while (false)
 #endif
 
 #ifndef TC_END_RESULT
@@ -198,7 +198,7 @@ static inline void print_nothing(const char *fmt, ...)
 	do {							\
 		TC_SUITE_PRINT("Running TESTSUITE %s\n", name);	\
 		PRINT_LINE;					\
-	} while (0)
+	} while (false)
 #endif
 
 #ifndef TC_SUITE_END
@@ -209,7 +209,7 @@ static inline void print_nothing(const char *fmt, ...)
 		} else {						\
 			TC_SUITE_PRINT("TESTSUITE %s failed.\n", name);	\
 		}							\
-	} while (0)
+	} while (false)
 #endif
 
 #if defined(CONFIG_ARCH_POSIX)
@@ -217,7 +217,7 @@ static inline void print_nothing(const char *fmt, ...)
 #define TC_END_POST(result) do { \
 	LOG_PANIC(); \
 	posix_exit(result); \
-} while (0)
+} while (false)
 #else
 #define TC_END_POST(result)
 #endif /* CONFIG_ARCH_POSIX */
@@ -231,7 +231,7 @@ static inline void print_nothing(const char *fmt, ...)
 		       "PROJECT EXECUTION %s\n",               \
 		       (result) == TC_PASS ? "SUCCESSFUL" : "FAILED");	\
 		TC_END_POST(result);                                    \
-	} while (0)
+	} while (false)
 #endif
 
 #if defined(CONFIG_SHELL)

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -141,7 +141,7 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \
 				    ())                                                            \
 		}                                                                                  \
-	} while (0)
+	} while (false)
 
 /**
  * @brief Skip the test, if @a cond is false
@@ -172,7 +172,7 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \
 				    ())                                                            \
 		}                                                                                  \
-	} while (0)
+	} while (false)
 /**
  * @brief Assert that this function call won't be reached
  * @param msg Optional message to print if the assertion fails

--- a/subsys/testsuite/ztest/include/zephyr/ztress.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztress.h
@@ -166,7 +166,7 @@ struct ztress_context_data {
 	int err = ztress_execute(has_timer ? &data[0] : NULL, &data[has_timer], cnt);	\
 											\
 	zassert_equal(err, 0, "ztress_execute failed (err: %d)", err);			\
-} while (0)
+} while (false)
 
 /** Execute contexts.
  *

--- a/subsys/testsuite/ztest/src/ztress.c
+++ b/subsys/testsuite/ztest/src/ztress.c
@@ -275,7 +275,7 @@ static void thread_cb(const struct k_thread *cthread, void *user_data)
 	if (strcmp(tname, (CONFIG_MP_NUM_CPUS == 1) ? "idle" : "idle 0" STRINGIFY(i)) == 0) { \
 		idle_tid[i] = tid; \
 	} \
-} while (0)
+} while (false)
 
 	const char *tname = k_thread_name_get((struct k_thread *)cthread);
 

--- a/subsys/tracing/sysview/tracing_sysview.h
+++ b/subsys/tracing/sysview/tracing_sysview.h
@@ -32,7 +32,7 @@ void sys_trace_thread_info(struct k_thread *thread);
 	do {                                                                                       \
 		SEGGER_SYSVIEW_OnTaskCreate((uint32_t)(uintptr_t)new_thread);                      \
 		sys_trace_thread_info(new_thread);                                                 \
-	} while (0)
+	} while (false)
 
 #define sys_port_trace_k_thread_user_mode_enter()                                                  \
 	SEGGER_SYSVIEW_RecordVoid(TID_THREAD_USERMODE_ENTER)
@@ -96,7 +96,7 @@ void sys_trace_thread_info(struct k_thread *thread);
 #define sys_port_trace_k_thread_name_set(thread, ret) do { \
 		SEGGER_SYSVIEW_RecordU32(TID_THREAD_NAME_SET, (uint32_t)(uintptr_t)thread); \
 		sys_trace_thread_info(thread);	\
-	} while (0)
+	} while (false)
 
 #define sys_port_trace_k_thread_switched_out() sys_trace_k_thread_switched_out()
 


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 14.4 do-while violations in subsys:
> The controlling expression of an if statement
> and the controlling expression of an iteration-statement shall have
> essentially Boolean type.

Use `do { ... } while (false)' instead of `do { ... } while (0)'.

This PR is part of the enhancement issue #48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
5d02614e34a86b549c7707d3d9f0984bc3a5f22a