### PR TITLE
drivers: clock control: stm32U5 set regulator voltage before clocks

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -715,6 +715,12 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Set voltage regulator to comply with targeted system frequency */
 	set_regu_voltage(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
 
+	/* Set flash latency */
+	/* If freq increases, set flash latency before any clock setting */
+	if (old_hclk_freq < CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) {
+		LL_SetFlashLatency(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
+	}
+
 	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 
@@ -722,12 +728,6 @@ int stm32_clock_control_init(const struct device *dev)
 	r = set_up_plls();
 	if (r < 0) {
 		return r;
-	}
-
-	/* Set flash latency */
-	/* If freq increases, set flash latency before any clock setting */
-	if (old_hclk_freq < CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) {
-		LL_SetFlashLatency(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
 	}
 
 	/* Set peripheral busses prescalers */

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -712,6 +712,9 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Current hclk value */
 	old_hclk_freq = __LL_RCC_CALC_HCLK_FREQ(get_startup_frequency(), LL_RCC_GetAHBPrescaler());
 
+	/* Set voltage regulator to comply with targeted system frequency */
+	set_regu_voltage(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
+
 	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 
@@ -720,9 +723,6 @@ int stm32_clock_control_init(const struct device *dev)
 	if (r < 0) {
 		return r;
 	}
-
-	/* Set voltage regulator to comply with targeted system frequency */
-	set_regu_voltage(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC);
 
 	/* Set flash latency */
 	/* If freq increases, set flash latency before any clock setting */

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/testcase.yaml
@@ -4,7 +4,7 @@ common:
 tests:
   drivers.stm32_clock_configuration.u5.sysclksrc_pll_msis_160:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_msis_160.overlay"
-  drivers.stm32_clock_configuration.u5.pll_msis_hab_2_40:
+  drivers.stm32_clock_configuration.u5.pll_msis_ahb_2_40:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_msis_ahb_2_40.overlay"
   drivers.stm32_clock_configuration.u5.sysclksrc_pll_hsi_160:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_hsi_160.overlay"


### PR DESCRIPTION
The regulator voltage should be set before the clocks are enabled
This is especially the case when the MSIS at 48MHz is selected as
SYSCLK.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48081

Signed-off-by: Francois Ramu <francois.ramu@st.com>