### PR TITLE
modules: lvgl: add missing stubs for Kconfig symbols

### DIFF
--- a/modules/Kconfig.lvgl
+++ b/modules/Kconfig.lvgl
@@ -9,6 +9,15 @@ config LVGL
 
 if LVGL
 
+config LV_Z_DISPLAY_DEV_NAME
+	string
+
+config LV_Z_HOR_RES_MAX
+	int
+
+config LV_Z_VER_RES_MAX
+	int
+
 config LV_Z_POINTER_KSCAN
 	bool
 


### PR DESCRIPTION
Add missing `LV_Z_HOR_RES_MAX` and `LV_Z_VER_RES_MAX` Kconfig symbols to fix the following Kconfig warnings:

```
warning: LV_Z_HOR_RES_MAX (defined at boards/arm/mimxrt1060_evk/Kconfig.defconfig:68) defined without a type

warning: LV_Z_VER_RES_MAX (defined at boards/arm/mimxrt1060_evk/Kconfig.defconfig:71) defined without a type
Parsing /home/bartekk/Projects/zephyr-test/zephyr/Kconfig
Loaded configuration '/home/bartekk/Projects/zephyr-test/zephyr/boards/arm/mimxrt1060_evk/mimxrt1060_evkb_defconfig'
Merged configuration '/home/bartekk/Projects/zephyr-test/zephyr/samples/hello_world/prj.conf'

error: Aborting due to Kconfig warnings
```

+ fixes https://github.com/zephyrproject-rtos/zephyr/issues/48185

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>