### PR TITLE
samples: net: gsm_modem: Update sample to remove use of DT_INST

### DIFF
--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -12,9 +12,13 @@
 #include <zephyr/net/net_event.h>
 #include <zephyr/net/net_conn_mgr.h>
 #include <zephyr/drivers/modem/gsm_ppp.h>
+#include <zephyr/devicetree.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(sample_gsm_ppp, LOG_LEVEL_DBG);
+
+#define GSM_MODEM_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_gsm_ppp)
+#define UART_NODE DT_BUS(GSM_MODEM_NODE)
 
 static const struct device *gsm_dev;
 static struct net_mgmt_event_callback mgmt_cb;
@@ -108,10 +112,9 @@ static void modem_off_cb(const struct device *dev, void *user_data)
 
 int main(void)
 {
-	const struct device *uart_dev =
-		DEVICE_DT_GET(DT_BUS(DT_INST(0, zephyr_gsm_ppp)));
+	const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
 
-	gsm_dev = DEVICE_DT_GET(DT_INST(0, zephyr_gsm_ppp));
+	gsm_dev = DEVICE_DT_GET(GSM_MODEM_NODE);
 
 	/* Optional register modem power callbacks */
 	gsm_ppp_register_modem_power_callback(gsm_dev, modem_on_cb, modem_off_cb, NULL);


### PR DESCRIPTION
Simplify sample by removing usage of DT_INST.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>