### PR TITLE
samples: drivers: led_pwm: Update sample to remove usage of DT_INST

### DIFF
--- a/samples/drivers/led_pwm/sample.yaml
+++ b/samples/drivers/led_pwm/sample.yaml
@@ -13,7 +13,6 @@ tests:
       type: multi_line
       ordered: true
       regex:
-        - "Found device \\S+"
         - "Testing LED \\d+"
         - "Turned on"
         - "Turned off"


### PR DESCRIPTION
Update sample to use DT_COMPAT_GET_ANY_STATUS_OKAY in order to remove
usage of DT_INST.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>