### PR TITLE
manifest: update zscilib module

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -244,7 +244,7 @@ manifest:
       path: modules/lib/zcbor
     - name: zscilib
       path: modules/lib/zscilib
-      revision: fc979a8dcb74169c69b02835927bff8f070d6325
+      revision: a54986aa98db4082ac56b582843bb5b5435208a6
 
   group-filter:
     - -ci


### PR DESCRIPTION
update the zephyr scilib to most recent addition which fixes integral windup in the mahony filter. 