### PR TITLE
drivers: pwm: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/pwm/Kconfig.b91
+++ b/drivers/pwm/Kconfig.b91
@@ -3,6 +3,7 @@
 
 config PWM_TELINK_B91
 	bool "Telink Semiconductor B91 PWM driver"
-	depends on SOC_RISCV_TELINK_B91
+	default y
+	depends on DT_HAS_TELINK_B91_PWM_ENABLED
 	help
 	  Enables Telink B91 PWM driver.

--- a/drivers/pwm/Kconfig.esp32
+++ b/drivers/pwm/Kconfig.esp32
@@ -4,21 +4,18 @@
 # Copyright (c) 2022 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ESPRESSIF_ESP32_LEDC := espressif,esp32-ledc
-DT_COMPAT_ESPRESSIF_ESP32_MCPWM := espressif,esp32-mcpwm
-
 config PWM_LED_ESP32
 	bool "ESP32 PWM LED driver"
-	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
-	default $(dt_compat_enabled,$(DT_COMPAT_ESPRESSIF_ESP32_LEDC))
+	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_LEDC_ENABLED
 	help
 	  This option enables the PWM LED driver for ESP32 family of
 	  processors.
 
 config MCPWM_ESP32
 	bool "ESP32 MCPWM driver"
-	depends on SOC_ESP32
-	default $(dt_compat_enabled,$(DT_COMPAT_ESPRESSIF_ESP32_MCPWM))
+	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_MCPWM_ENABLED
 	help
 	  This option enables the MCPWM driver for ESP32 family of
 	  processors.

--- a/drivers/pwm/Kconfig.gd32
+++ b/drivers/pwm/Kconfig.gd32
@@ -1,11 +1,9 @@
 # Copyright (c) 2021 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_GD_GD32_PWM := gd,gd32-pwm
-
 config PWM_GD32
 	bool "GigaDevice GD32 PWM driver"
-	depends on (SOC_FAMILY_GD32 || SOC_SERIES_GD32VF103)
-	default $(dt_compat_enabled,$(DT_COMPAT_GD_GD32_PWM))
+	default y
+	depends on DT_HAS_GD_GD32_PWM_ENABLED
 	help
 	  Enable the GigaDevice GD32 PWM driver.

--- a/drivers/pwm/Kconfig.gecko
+++ b/drivers/pwm/Kconfig.gecko
@@ -5,7 +5,8 @@
 
 config PWM_GECKO
 	bool "GECKO MCU PWM driver"
-	depends on SOC_FAMILY_EXX32
+	default y
+	depends on DT_HAS_SILABS_GECKO_PWM_ENABLED
 	select SOC_GECKO_TIMER
 	help
 	  This option enables the PWM driver for EXX32 GECKO family of

--- a/drivers/pwm/Kconfig.imx
+++ b/drivers/pwm/Kconfig.imx
@@ -5,6 +5,8 @@
 
 menuconfig PWM_IMX
 	bool "i.MX PWM Driver"
+	default y
+	depends on DT_HAS_FSL_IMX27_PWM_ENABLED
 	help
 	  Enable support for i.MX pwm driver.
 

--- a/drivers/pwm/Kconfig.it8xxx2
+++ b/drivers/pwm/Kconfig.it8xxx2
@@ -5,7 +5,8 @@
 
 config PWM_ITE_IT8XXX2
 	bool "ITE IT8XXX2 embedded controller (EC) PWM driver"
-	depends on SOC_IT8XXX2
+	default y
+	depends on DT_HAS_ITE_IT8XXX2_PWM_ENABLED
 	help
 	   Enable PWM driver for it8xxx2_evb.
 	   Supports three 16-bit prescalers each with 8-bit cycle timer, and

--- a/drivers/pwm/Kconfig.litex
+++ b/drivers/pwm/Kconfig.litex
@@ -6,8 +6,8 @@
 
 menuconfig PWM_LITEX
 	bool "LiteX PWM driver"
-	depends on SOC_RISCV32_LITEX_VEXRISCV
-	depends on HAS_DTS
+	default y
+	depends on DT_HAS_LITEX_PWM_ENABLED
 	help
 	  Enable support for LiteX PWM driver
 

--- a/drivers/pwm/Kconfig.mcux
+++ b/drivers/pwm/Kconfig.mcux
@@ -5,6 +5,7 @@
 
 config PWM_MCUX
 	bool "MCUX PWM driver"
-	depends on HAS_MCUX_PWM
+	default y
+	depends on DT_HAS_NXP_IMX_PWM_ENABLED
 	help
 	  Enable mcux pwm driver.

--- a/drivers/pwm/Kconfig.mcux_ftm
+++ b/drivers/pwm/Kconfig.mcux_ftm
@@ -5,7 +5,8 @@
 
 config PWM_MCUX_FTM
 	bool "MCUX FTM PWM driver"
-	depends on HAS_MCUX_FTM
+	default y
+	depends on DT_HAS_NXP_KINETIS_FTM_PWM_ENABLED
 	select PINCTRL
 	help
 	  Enable support for mcux ftm pwm driver.

--- a/drivers/pwm/Kconfig.mcux_pwt
+++ b/drivers/pwm/Kconfig.mcux_pwt
@@ -5,7 +5,9 @@
 
 config PWM_MCUX_PWT
 	bool "MCUX PWT PWM capture driver"
-	depends on HAS_MCUX_PWT && CLOCK_CONTROL && PWM_CAPTURE
+	default y
+	depends on DT_HAS_NXP_KINETIS_PWT_ENABLED
+	depends on CLOCK_CONTROL && PWM_CAPTURE
 	select PINCTRL
 	help
 	  Enable the MCUX Pulse Width Timer (PWT) PWM capture driver.

--- a/drivers/pwm/Kconfig.mcux_sctimer
+++ b/drivers/pwm/Kconfig.mcux_sctimer
@@ -3,6 +3,7 @@
 
 config PWM_MCUX_SCTIMER
 	bool "MCUX SCTimer PWM driver"
-	depends on HAS_MCUX_SCTIMER
+	default y
+	depends on DT_HAS_NXP_SCTIMER_PWM_ENABLED
 	help
 	  Enable sctimer based pwm driver.

--- a/drivers/pwm/Kconfig.mcux_tpm
+++ b/drivers/pwm/Kconfig.mcux_tpm
@@ -5,7 +5,9 @@
 
 config PWM_MCUX_TPM
 	bool "MCUX TPM PWM driver"
-	depends on HAS_MCUX_TPM && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_KINETIS_TPM_ENABLED
+	depends on CLOCK_CONTROL
 	select PINCTRL
 	help
 	  Enable the MCUX TPM PWM driver.

--- a/drivers/pwm/Kconfig.npcx
+++ b/drivers/pwm/Kconfig.npcx
@@ -5,7 +5,8 @@
 
 config PWM_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) PWM driver"
-	depends on SOC_FAMILY_NPCX
+	default y
+	depends on DT_HAS_NUVOTON_NPCX_PWM_ENABLED
 	help
 	  This option enables the PWM driver for NPCX family of
 	  processors.

--- a/drivers/pwm/Kconfig.nrf5_sw
+++ b/drivers/pwm/Kconfig.nrf5_sw
@@ -6,7 +6,8 @@
 config PWM_NRF5_SW
 	bool "Nordic Semiconductor nRF5x series S/W PWM"
 	default y if !PWM_NRFX
-	depends on HAS_HW_NRF_PPI
+	depends on DT_HAS_NORDIC_NRF_SW_PWM_ENABLED
+	depends on DT_HAS_NORDIC_NRF_PPI_ENABLED
 	select NRFX_GPIOTE
 	select NRFX_PPI
 	help

--- a/drivers/pwm/Kconfig.nrfx
+++ b/drivers/pwm/Kconfig.nrfx
@@ -4,10 +4,7 @@
 config PWM_NRFX
 	bool "nRF PWM nrfx driver"
 	default y
-	depends on HAS_HW_NRF_PWM0 \
-		|| HAS_HW_NRF_PWM1 \
-		|| HAS_HW_NRF_PWM2 \
-		|| HAS_HW_NRF_PWM3
+	depends on DT_HAS_NORDIC_NRF_PWM_ENABLED
 	select NRFX_PWM0 if HAS_HW_NRF_PWM0
 	select NRFX_PWM1 if HAS_HW_NRF_PWM1
 	select NRFX_PWM2 if HAS_HW_NRF_PWM2

--- a/drivers/pwm/Kconfig.rpi_pico
+++ b/drivers/pwm/Kconfig.rpi_pico
@@ -1,13 +1,10 @@
 # Copyright (c) 2022, Joep Buruma
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_RPI_PICO_PWM := raspberrypi,pico-pwm
-
 config PWM_RPI_PICO
 	bool "RPi Pico PWM"
-	default $(dt_compat_enabled,$(DT_COMPAT_RPI_PICO_PWM))
-	depends on SOC_SERIES_RP2XXX
+	default y
+	depends on DT_HAS_RASPBERRYPI_PICO_PWM_ENABLED
 	depends on RESET
 	select PICOSDK_USE_PWM
 	help

--- a/drivers/pwm/Kconfig.rv32m1_tpm
+++ b/drivers/pwm/Kconfig.rv32m1_tpm
@@ -5,6 +5,8 @@
 
 config PWM_RV32M1_TPM
 	bool "RV32M1 TPM PWM driver"
-	depends on HAS_RV32M1_TPM && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_OPENISA_RV32M1_TPM_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable the RV32M1 TPM PWM driver.

--- a/drivers/pwm/Kconfig.sam
+++ b/drivers/pwm/Kconfig.sam
@@ -5,6 +5,7 @@
 
 config PWM_SAM
 	bool "Atmel SAM MCU Family PWM Driver"
-	depends on SOC_FAMILY_SAM
+	default y
+	depends on DT_HAS_ATMEL_SAM_PWM_ENABLED
 	help
 	  Enable PWM driver for Atmel SAM MCUs.

--- a/drivers/pwm/Kconfig.sam0
+++ b/drivers/pwm/Kconfig.sam0
@@ -5,6 +5,7 @@
 
 config PWM_SAM0_TCC
 	bool "Atmel SAM0 MCU Family TCC PWM Driver"
-	depends on SOC_FAMILY_SAM0
+	default y
+	depends on DT_HAS_ATMEL_SAM0_TCC_PWM_ENABLED
 	help
 	  Enable PWM driver for Atmel SAM0 MCUs using the TCC timer/counter.

--- a/drivers/pwm/Kconfig.sifive
+++ b/drivers/pwm/Kconfig.sifive
@@ -5,8 +5,8 @@
 
 menuconfig PWM_SIFIVE
 	bool "SiFive Freedom PWM driver"
-	depends on SOC_SERIES_RISCV_SIFIVE_FREEDOM
-	depends on HAS_DTS
+	default y
+	depends on DT_HAS_SIFIVE_PWM0_ENABLED
 	help
 	  Enable the PWM driver for the SiFive Freedom platform
 

--- a/drivers/pwm/Kconfig.stm32
+++ b/drivers/pwm/Kconfig.stm32
@@ -5,7 +5,8 @@
 
 config PWM_STM32
 	bool "STM32 MCU PWM driver"
-	depends on SOC_FAMILY_STM32
+	default y
+	depends on DT_HAS_ST_STM32_PWM_ENABLED
 	select USE_STM32_LL_TIM
 	select USE_STM32_LL_RCC if SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32H7X
 	help

--- a/drivers/pwm/Kconfig.test
+++ b/drivers/pwm/Kconfig.test
@@ -2,9 +2,8 @@
 # Organisation (CSIRO) ABN 41 687 119 230.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_VND_PWM := vnd,pwm
-
 # Hidden option for turning on the dummy driver for vnd,pwm devices
 # used in testing.
 config PWM_TEST
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_VND_PWM))
+	def_bool DT_HAS_VND_PWM_ENABLED
+	depends on DT_HAS_VND_PWM_ENABLED

--- a/drivers/pwm/Kconfig.xec
+++ b/drivers/pwm/Kconfig.xec
@@ -3,11 +3,9 @@
 # Copyright (c) 2019 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_PWM_XEC := microchip,xec-pwm
-
 config PWM_XEC
 	bool "Microchip XEC PWM"
-	depends on SOC_FAMILY_MEC
-	default $(dt_compat_enabled,${DT_COMPAT_PWM_XEC})
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_PWM_ENABLED
 	help
 	  Enable driver to utilize PWM on the Microchip XEC IP block.

--- a/drivers/pwm/Kconfig.xlnx
+++ b/drivers/pwm/Kconfig.xlnx
@@ -5,5 +5,7 @@
 
 config PWM_XLNX_AXI_TIMER
 	bool "Xilinx AXI Timer driver"
+	default y
+	depends on DT_HAS_XLNX_XPS_TIMER_1_00_A_PWM_ENABLED
 	help
 	  Enable PWM support for the Xilinx AXI Timer v2.0 IP.


### PR DESCRIPTION
Update pwm drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>