### PR TITLE
drivers: watchdog: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/watchdog/Kconfig
+++ b/drivers/watchdog/Kconfig
@@ -31,7 +31,8 @@ config WDT_MULTISTAGE
 
 config WDT_COUNTER
 	bool "Counter based watchdog"
-	def_bool $(dt_nodelabel_enabled,wdt_counter)
+	default y
+	depends on DT_HAS_ZEPHYR_COUNTER_WATCHDOG_ENABLED
 	select COUNTER
 	help
 	  Watchdog emulated with counter device. If counter device supports using

--- a/drivers/watchdog/Kconfig.cc32xx
+++ b/drivers/watchdog/Kconfig.cc32xx
@@ -1,13 +1,10 @@
 # Copyright (c) 2021 Pavlo Hamov <pasha.gamov@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_TI_CC32XX_WDG := ti,cc32xx-watchdog
-
 config WDT_CC32XX
 	bool "Watchdog Driver for cc32xx family of MCUs"
-	default $(dt_compat_enabled,$(DT_COMPAT_TI_CC32XX_WDG))
-	depends on SOC_SERIES_CC32XX
-	depends on SOC_FAMILY_TISIMPLELINK
+	default y
+	depends on DT_HAS_TI_CC32XX_WATCHDOG_ENABLED
 	help
 	  Watchdog for cc32xx family of MCUs
 

--- a/drivers/watchdog/Kconfig.cmsdk_apb
+++ b/drivers/watchdog/Kconfig.cmsdk_apb
@@ -5,6 +5,8 @@
 
 config WDOG_CMSDK_APB
 	bool "CMSDK APB Watchdog Driver for ARM family of MCUs"
+	default y
+	depends on DT_HAS_ARM_CMSDK_WATCHDOG_ENABLED
 	depends on RUNTIME_NMI
 	help
 	  Enable CMSDK APB Watchdog (WDOG_CMSDK_APB) Driver for ARM

--- a/drivers/watchdog/Kconfig.esp32
+++ b/drivers/watchdog/Kconfig.esp32
@@ -3,11 +3,9 @@
 # Copyright (C) 2017 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ESP32_WDT := espressif,esp32-watchdog
-
 config WDT_ESP32
 	bool "ESP32 Watchdog (WDT) Driver"
-	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
-	default $(dt_compat_enabled,$(DT_COMPAT_ESP32_WDT))
+	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_WATCHDOG_ENABLED
 	help
 	  Enable WDT driver for ESP32.

--- a/drivers/watchdog/Kconfig.gecko
+++ b/drivers/watchdog/Kconfig.gecko
@@ -7,7 +7,8 @@
 
 config WDT_GECKO
 	bool "Gecko series Watchdog (WDOG) Driver"
-	depends on SOC_FAMILY_EXX32
+	default y
+	depends on DT_HAS_SILABS_GECKO_WDOG_ENABLED
 	select SOC_GECKO_WDOG
 	default y
 	help

--- a/drivers/watchdog/Kconfig.it8xxx2
+++ b/drivers/watchdog/Kconfig.it8xxx2
@@ -3,8 +3,8 @@
 
 config WDT_ITE_IT8XXX2
 	bool "ITE it8xxx2 Watchdog Timer (WDT) driver"
-	depends on SOC_IT8XXX2
 	default y
+	depends on DT_HAS_ITE_IT8XXX2_WATCHDOG_ENABLED
 	help
 	  This option enables the Watchdog Timer driver for ITE it8xxx2.
 	  This driver supports only one channel that id is 0 and 16-bits

--- a/drivers/watchdog/Kconfig.mcux
+++ b/drivers/watchdog/Kconfig.mcux
@@ -5,18 +5,23 @@
 
 config WDT_MCUX_WDOG
 	bool "MCUX WDOG driver"
-	depends on HAS_MCUX && !HAS_MCUX_WDOG32 && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_KINETIS_WDOG_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable the mcux wdog driver.
 
 config WDT_MCUX_WDOG32
 	bool "MCUX WDOG32 driver"
-	depends on HAS_MCUX_WDOG32 && CLOCK_CONTROL
+	default y
+	depends on DT_HAS_NXP_KINETIS_WDOG32_ENABLED
+	depends on CLOCK_CONTROL
 	help
 	  Enable the mcux wdog32 driver.
 
 config WDT_MCUX_WWDT
 	bool "MCUX WWDT driver"
-	depends on HAS_MCUX_WWDT
+	default y
+	depends on DT_HAS_NXP_LPC_WWDT_ENABLED
 	help
 	  Enable the mcux wwdt driver.

--- a/drivers/watchdog/Kconfig.mcux_imx
+++ b/drivers/watchdog/Kconfig.mcux_imx
@@ -5,6 +5,7 @@
 
 config WDT_MCUX_IMX_WDOG
 	bool "MCUX IMX WDOG driver"
-	depends on HAS_MCUX
+	default y
+	depends on DT_HAS_NXP_IMX_WDOG_ENABLED
 	help
 	  Enable the mcux imx wdog driver.

--- a/drivers/watchdog/Kconfig.npcx
+++ b/drivers/watchdog/Kconfig.npcx
@@ -5,7 +5,8 @@
 
 config WDT_NPCX
 	bool "Nuvoton NPCX embedded controller (EC) Watchdog Timer driver"
-	depends on SOC_FAMILY_NPCX
+	default y
+	depends on DT_HAS_NUVOTON_NPCX_WATCHDOG_ENABLED
 	help
 	  This option enables the Watchdog Timer driver for NPCX family of
 	  processors.

--- a/drivers/watchdog/Kconfig.nrfx
+++ b/drivers/watchdog/Kconfig.nrfx
@@ -6,7 +6,7 @@
 config WDT_NRFX
 	bool "nRF WDT nrfx driver"
 	default y
-	depends on SOC_FAMILY_NRF
+	depends on DT_HAS_NORDIC_NRF_WDT_ENABLED
 	select NRFX_WDT0 if HAS_HW_NRF_WDT0
 	select NRFX_WDT1 if HAS_HW_NRF_WDT1
 	help

--- a/drivers/watchdog/Kconfig.rpi_pico
+++ b/drivers/watchdog/Kconfig.rpi_pico
@@ -1,12 +1,10 @@
 # Copyright (c) 2022, Jamie McCrae
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_RASPBERRYPI_PICO_WATCHDOG := raspberrypi,pico-watchdog
-
 config WDT_RPI_PICO
 	bool "Raspberry Pi Pico Watchdog driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_RASPBERRYPI_PICO_WATCHDOG))
-	depends on SOC_FAMILY_RPI_PICO
+	default y
+	depends on DT_HAS_RASPBERRYPI_PICO_WATCHDOG_ENABLED
 
 config WDT_RPI_PICO_INITIAL_TIMEOUT
 	int "Default watchdog timeout in us"

--- a/drivers/watchdog/Kconfig.sam
+++ b/drivers/watchdog/Kconfig.sam
@@ -5,7 +5,7 @@
 
 config WDT_SAM
 	bool "Atmel SAM MCU Family Watchdog (WDT) Driver"
-	depends on SOC_FAMILY_SAM
 	default y
+	depends on DT_HAS_ATMEL_SAM_WATCHDOG_ENABLED
 	help
 	  Enable WDT driver for Atmel SAM MCUs.

--- a/drivers/watchdog/Kconfig.sam0
+++ b/drivers/watchdog/Kconfig.sam0
@@ -5,7 +5,7 @@
 
 config WDT_SAM0
 	bool "Atmel SAM0 series Watchdog (WDT) Driver"
-	depends on SOC_FAMILY_SAM0
 	default y
+	depends on DT_HAS_ATMEL_SAM0_WATCHDOG_ENABLED
 	help
 	  Enable WDT driver for Atmel SAM0 MCUs.

--- a/drivers/watchdog/Kconfig.sifive
+++ b/drivers/watchdog/Kconfig.sifive
@@ -5,7 +5,7 @@
 
 config WDT_SIFIVE
 	bool "SiFive Watchdog (WDT) Driver"
-	depends on SOC_RISCV_SIFIVE_FREEDOM
 	default y
+	depends on DT_HAS_SIFIVE_WDT_ENABLED
 	help
 	  This option enables WDT driver for SiFive Freedom.

--- a/drivers/watchdog/Kconfig.stm32
+++ b/drivers/watchdog/Kconfig.stm32
@@ -5,13 +5,10 @@
 # Copyright (c) 2019 Centaur Analytics, Inc
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_STM32_IWDG := st,stm32-watchdog
-DT_COMPAT_ST_STM32_WWDG := st,stm32-window-watchdog
-
 config IWDG_STM32
 	bool "Independent Watchdog (IWDG) Driver for STM32 family of MCUs"
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_IWDG))
-	depends on SOC_FAMILY_STM32
+	default y
+	depends on DT_HAS_ST_STM32_WATCHDOG_ENABLED
 	help
 	  Enable IWDG driver for STM32 line of MCUs
 
@@ -33,7 +30,7 @@ config IWDG_STM32_INITIAL_TIMEOUT
 
 config WWDG_STM32
 	bool "System Window Watchdog (WWDG) Driver for STM32 family of MCUs"
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_WWDG))
-	depends on SOC_FAMILY_STM32
+	default y
+	depends on DT_HAS_ST_STM32_WINDOW_WATCHDOG_ENABLED
 	help
 	  Enable WWDG driver for STM32 line of MCUs

--- a/drivers/watchdog/Kconfig.xec
+++ b/drivers/watchdog/Kconfig.xec
@@ -5,7 +5,7 @@
 
 config WDT_XEC
 	bool "Microchip XEC series Watchdog Timer (WDT) driver"
-	depends on SOC_FAMILY_MEC
 	default y
+	depends on DT_HAS_MICROCHIP_XEC_WATCHDOG_ENABLED
 	help
 	  Enable WDT driver for Microchip XEC MCU series.


### PR DESCRIPTION
Update watchdog drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>