### PR TITLE
drivers: counter: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/counter/Kconfig.cmos
+++ b/drivers/counter/Kconfig.cmos
@@ -5,4 +5,5 @@
 
 config COUNTER_CMOS
 	bool "Counter driver for x86 CMOS/RTC clock"
-	depends on X86
+	default y
+	depends on DT_HAS_MOTOROLA_MC146818_ENABLED

--- a/drivers/counter/Kconfig.dtmr_cmsdk_apb
+++ b/drivers/counter/Kconfig.dtmr_cmsdk_apb
@@ -5,7 +5,8 @@
 
 config TIMER_DTMR_CMSDK_APB
 	bool "ARM CMSDK (Cortex-M System Design Kit) DTMR Timer driver"
-	depends on SOC_FAMILY_ARM
+	default y
+	depends on DT_HAS_ARM_CMSDK_DTIMER_ENABLED
 	help
 	  The dualtimer (DTMR) present in the platform is used as a timer.
 	  This option enables the support for the timer.

--- a/drivers/counter/Kconfig.esp32
+++ b/drivers/counter/Kconfig.esp32
@@ -3,11 +3,9 @@
 # Copyright (c) 2020 Espressif Systems (Shanghai) Co., Ltd.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ESP32_TIMER := espressif,esp32-timer
-
 config COUNTER_ESP32
 	bool "ESP32 Counter Driver"
-	depends on SOC_ESP32 || SOC_ESP32S2 || SOC_ESP32C3
-	default $(dt_compat_enabled,$(DT_COMPAT_ESP32_TIMER))
+	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_TIMER_ENABLED
 	help
 	  Enable Counter driver for ESP32 series devices.

--- a/drivers/counter/Kconfig.gecko
+++ b/drivers/counter/Kconfig.gecko
@@ -5,7 +5,8 @@
 
 config COUNTER_GECKO_RTCC
 	bool "Silicon Labs Gecko Counter (RTCC) driver"
-	depends on SOC_FAMILY_EXX32
+	default y
+	depends on DT_HAS_SILABS_GECKO_RTCC_ENABLED
 	select SOC_GECKO_CMU
 	select SOC_GECKO_RTCC
 	help

--- a/drivers/counter/Kconfig.imx_epit
+++ b/drivers/counter/Kconfig.imx_epit
@@ -5,6 +5,7 @@
 
 config COUNTER_IMX_EPIT
 	bool "IMX EPIT driver"
-	depends on HAS_IMX_EPIT
+	default y
+	depends on DT_HAS_NXP_IMX_EPIT_ENABLED
 	help
 	  Enable the IMX EPIT driver.

--- a/drivers/counter/Kconfig.maxim_ds3231
+++ b/drivers/counter/Kconfig.maxim_ds3231
@@ -5,6 +5,8 @@
 
 config COUNTER_MAXIM_DS3231
 	bool "Maxim DS3231 RTC/TCXO"
+	default y
+	depends on DT_HAS_MAXIM_DS3231_ENABLED
 	depends on I2C
 	select POLL
 	help

--- a/drivers/counter/Kconfig.mcp7940n
+++ b/drivers/counter/Kconfig.mcp7940n
@@ -5,6 +5,8 @@
 
 config COUNTER_MICROCHIP_MCP7940N
 	bool "Microchip MCP7940N RTC"
+	default y
+	depends on DT_HAS_MICROCHIP_MCP7940N_ENABLED
 	select I2C
 	help
 	  Enable RTC driver based on Microchip MCP7940N I2C device.

--- a/drivers/counter/Kconfig.mcux_ctimer
+++ b/drivers/counter/Kconfig.mcux_ctimer
@@ -5,7 +5,8 @@
 
 config COUNTER_MCUX_CTIMER
 	bool "MCUX CTIMER driver"
-	depends on HAS_MCUX_CTIMER
+	default y
+	depends on DT_HAS_NXP_LPC_CTIMER_ENABLED
 	help
 	  Enable support for MCUX CTIMER driver.
 

--- a/drivers/counter/Kconfig.mcux_gpt
+++ b/drivers/counter/Kconfig.mcux_gpt
@@ -5,6 +5,7 @@
 
 config COUNTER_MCUX_GPT
 	bool "MCUX GPT driver"
-	depends on HAS_MCUX_GPT
+	default y
+	depends on DT_HAS_NXP_IMX_GPT_ENABLED
 	help
 	  Enable support for mcux General Purpose Timer (GPT) driver.

--- a/drivers/counter/Kconfig.mcux_lpc_rtc
+++ b/drivers/counter/Kconfig.mcux_lpc_rtc
@@ -3,6 +3,7 @@
 
 config COUNTER_MCUX_LPC_RTC
 	bool "MCUX LPC RTC driver"
-	depends on HAS_MCUX_LPC_RTC
+	default y
+	depends on DT_HAS_NXP_LPC_RTC_ENABLED
 	help
 	  Enable support for LPC rtc driver.

--- a/drivers/counter/Kconfig.mcux_lptmr
+++ b/drivers/counter/Kconfig.mcux_lptmr
@@ -5,6 +5,7 @@
 
 config COUNTER_MCUX_LPTMR
 	bool "MCUX LPTMR driver"
-	depends on HAS_MCUX_LPTMR
+	default y
+	depends on DT_HAS_NXP_KINETIS_LPTMR_ENABLED
 	help
 	  Enable support for the MCUX Low Power Timer (LPTMR).

--- a/drivers/counter/Kconfig.mcux_pit
+++ b/drivers/counter/Kconfig.mcux_pit
@@ -5,6 +5,7 @@
 
 config COUNTER_MCUX_PIT
 	bool "MCUX PIT driver"
-	depends on HAS_MCUX_PIT
+	default y
+	depends on DT_HAS_NXP_KINETIS_PIT_ENABLED
 	help
 	  Enable support for the MCUX Periodic Interrupt Timer (PIT).

--- a/drivers/counter/Kconfig.mcux_qtmr
+++ b/drivers/counter/Kconfig.mcux_qtmr
@@ -5,6 +5,7 @@
 
 config COUNTER_MCUX_QTMR
 	bool "MCUX QTMR driver"
-	depends on HAS_MCUX_QTMR
+	default y
+	depends on DT_HAS_NXP_IMX_TMR_ENABLED
 	help
 	  Enable support for mcux Quad Timer (QTMR) driver.

--- a/drivers/counter/Kconfig.mcux_rtc
+++ b/drivers/counter/Kconfig.mcux_rtc
@@ -5,6 +5,7 @@
 
 config COUNTER_MCUX_RTC
 	bool "MCUX RTC driver"
-	depends on HAS_MCUX_RTC
+	default y
+	depends on DT_HAS_NXP_KINETIS_RTC_ENABLED
 	help
 	  Enable support for mcux rtc driver.

--- a/drivers/counter/Kconfig.mcux_snvs
+++ b/drivers/counter/Kconfig.mcux_snvs
@@ -5,7 +5,8 @@
 
 config COUNTER_MCUX_SNVS
 	bool "IMX SNVS RTC driver"
-	depends on HAS_MCUX_SNVS
+	default y
+	depends on DT_HAS_NXP_IMX_SNVS_RTC_ENABLED
 	help
 	  Enable support for the IMX SNVS High/Low Power clock.
 

--- a/drivers/counter/Kconfig.native_posix
+++ b/drivers/counter/Kconfig.native_posix
@@ -4,7 +4,7 @@
 config COUNTER_NATIVE_POSIX
 	bool "Counter on COUNTER_0"
 	default y
-	depends on BOARD_NATIVE_POSIX
+	depends on DT_HAS_ZEPHYR_NATIVE_POSIX_COUNTER_ENABLED
 
 config COUNTER_NATIVE_POSIX_FREQUENCY
 	int "native_posix counter frequency in Hz"

--- a/drivers/counter/Kconfig.sam
+++ b/drivers/counter/Kconfig.sam
@@ -1,12 +1,9 @@
 # Copyright (c) 2021 Piotr Mienkowski
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_ATMEL_SAM_TC := atmel,sam-tc
-
 config COUNTER_SAM_TC
 	bool "Atmel SAM MCU family counter (TC) driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_TC))
-	depends on SOC_FAMILY_SAM
+	default y
+	depends on DT_HAS_ATMEL_SAM_TC_ENABLED
 	help
 	  Enable the Atmel SAM MCU family counter (TC) driver.

--- a/drivers/counter/Kconfig.sam0
+++ b/drivers/counter/Kconfig.sam0
@@ -4,7 +4,7 @@
 config COUNTER_SAM0_TC32
 	bool "SAM0 series 32-bit basic timer driver"
 	default y
-	depends on SOC_FAMILY_SAM0
+	depends on DT_HAS_ATMEL_SAM0_TC32_ENABLED
 	help
 	  Enable the SAM0 series timer counter (TC) driver in 32-bit wide
 	  mode.

--- a/drivers/counter/Kconfig.stm32_rtc
+++ b/drivers/counter/Kconfig.stm32_rtc
@@ -5,7 +5,8 @@
 
 menuconfig COUNTER_RTC_STM32
 	bool "STM32 Counter RTC driver"
-	depends on SOC_FAMILY_STM32
+	default y
+	depends on DT_HAS_ST_STM32_RTC_ENABLED
 	select USE_STM32_LL_RTC
 	select USE_STM32_LL_PWR
 	select USE_STM32_LL_RCC

--- a/drivers/counter/Kconfig.stm32_timer
+++ b/drivers/counter/Kconfig.stm32_timer
@@ -1,11 +1,10 @@
 # Copyright (c) 2021 Kent Hall
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_STM32_COUNTER := st,stm32-counter
-
 config COUNTER_TIMER_STM32
 	bool "STM32 counter driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_COUNTER))
+	default y
+	depends on DT_HAS_ST_STM32_COUNTER_ENABLED
 	select USE_STM32_LL_TIM
 	help
 	  Enable the counter driver for STM32 family of processors.

--- a/drivers/counter/Kconfig.tmr_cmsdk_apb
+++ b/drivers/counter/Kconfig.tmr_cmsdk_apb
@@ -5,7 +5,8 @@
 
 config TIMER_TMR_CMSDK_APB
 	bool "ARM CMSDK (Cortex-M System Design Kit) Timer driver"
-	depends on SOC_FAMILY_ARM
+	default y
+	depends on DT_HAS_ARM_CMSDK_TIMER_ENABLED
 	help
 	  The timers (TMR) present in the platform are used as timers.
 	  This option enables the support for the timers.

--- a/drivers/counter/Kconfig.xec
+++ b/drivers/counter/Kconfig.xec
@@ -5,7 +5,8 @@
 
 config COUNTER_XEC
 	bool "Microchip XEC series counter driver"
-	depends on SOC_FAMILY_MEC
+	default y
+	depends on DT_HAS_MICROCHIP_XEC_TIMER_ENABLED
 	help
 	  Enable counter driver for Microchip XEC MCU series. Such driver
 	  will expose the basic timer devices present on the MCU.

--- a/drivers/counter/Kconfig.xlnx
+++ b/drivers/counter/Kconfig.xlnx
@@ -5,5 +5,7 @@
 
 config COUNTER_XLNX_AXI_TIMER
 	bool "Xilinx AXI Timer driver"
+	default y
+	depends on DT_HAS_XLNX_XPS_TIMER_1_00_A_ENABLED
 	help
 	  Enable counter support for the Xilinx AXI Timer v2.0 IP.

--- a/dts/bindings/counter/zephyr,native-posix-counter.yaml
+++ b/dts/bindings/counter/zephyr,native-posix-counter.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Kumar Gala <galak@kernel.org>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Native POSIX Counter
+
+compatible: "zephyr,native-posix-counter"
+
+include: base.yaml

--- a/dts/bindings/rtc/nxp,lpc-rtc.yaml
+++ b/dts/bindings/rtc/nxp,lpc-rtc.yaml
@@ -1,0 +1,12 @@
+# Copyright (c) 2022, Kumar Gala <galak@kernel.org>
+# SPDX-License-Identifier: Apache-2.0
+
+description: NXP LPC RTC
+
+compatible: "nxp,lpc-rtc"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: true


### PR DESCRIPTION
Update counter drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>