### PR TITLE
drivers: entropy: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/entropy/Kconfig.b91
+++ b/drivers/entropy/Kconfig.b91
@@ -5,7 +5,8 @@
 
 config ENTROPY_TELINK_B91_TRNG
 	bool "Telink B91 Entropy driver"
-	depends on SOC_RISCV_TELINK_B91
+	default y
+	depends on DT_HAS_TELINK_B91_TRNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  Enable the B91 Entropy driver.

--- a/drivers/entropy/Kconfig.bt_hci
+++ b/drivers/entropy/Kconfig.bt_hci
@@ -4,6 +4,8 @@
 
 config ENTROPY_BT_HCI
 	bool "Bluetooth HCI RNG driver"
+	default y
+	depends on DT_HAS_ZEPHYR_BT_HCI_ENTROPY_ENABLED
 	depends on BT_HCI_HOST
 	select ENTROPY_HAS_DRIVER
 	help

--- a/drivers/entropy/Kconfig.cc13xx_cc26xx
+++ b/drivers/entropy/Kconfig.cc13xx_cc26xx
@@ -5,7 +5,8 @@
 
 config ENTROPY_CC13XX_CC26XX_RNG
 	bool "TI SimpleLink CC13xx / CC26xx True Random Number Generator (TRNG)"
-	depends on SOC_SERIES_CC13X2_CC26X2
+	default y
+	depends on DT_HAS_TI_CC13XX_CC26XX_TRNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	select RING_BUFFER
 	help

--- a/drivers/entropy/Kconfig.esp32
+++ b/drivers/entropy/Kconfig.esp32
@@ -5,9 +5,9 @@
 
 config ENTROPY_ESP32_RNG
 	bool "ESP32 entropy number generator driver"
-	depends on SOC_ESP32 || SOC_ESP32C3 || SOC_ESP32S2
-	select ENTROPY_HAS_DRIVER
 	default y
+	depends on DT_HAS_ESPRESSIF_ESP32_TRNG_ENABLED
+	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the entropy number generator for ESP32 SoCs.
 

--- a/drivers/entropy/Kconfig.gecko
+++ b/drivers/entropy/Kconfig.gecko
@@ -6,16 +6,17 @@
 
 config ENTROPY_GECKO_TRNG
 	bool "GECKO TRNG driver"
-	depends on SOC_GECKO_TRNG
-	select ENTROPY_HAS_DRIVER
 	default y
+	depends on DT_HAS_SILABS_GECKO_TRNG_ENABLED
+	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the true random number generator
 	  driver based on the TRNG.
 
 config ENTROPY_GECKO_SE
 	bool "GECKO SE driver"
-	depends on SOC_GECKO_SE
+	default y
+	depends on DT_HAS_SILABS_GECKO_SEMAILBOX_ENABLED
 	select ENTROPY_HAS_DRIVER
 	default y
 	help

--- a/drivers/entropy/Kconfig.litex
+++ b/drivers/entropy/Kconfig.litex
@@ -5,7 +5,8 @@
 
 config ENTROPY_LITEX_RNG
 	bool "PRBS RNG driver"
-	depends on SOC_RISCV32_LITEX_VEXRISCV
+	default y
+	depends on DT_HAS_LITEX_PRBS_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the RNG module, which is an entropy number

--- a/drivers/entropy/Kconfig.mcux
+++ b/drivers/entropy/Kconfig.mcux
@@ -5,7 +5,8 @@
 
 config ENTROPY_MCUX_RNGA
 	bool "MCUX RNGA driver"
-	depends on HAS_MCUX_RNGA
+	default y
+	depends on DT_HAS_NXP_KINETIS_RNGA_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the random number generator accelerator (RNGA)
@@ -13,7 +14,8 @@ config ENTROPY_MCUX_RNGA
 
 config ENTROPY_MCUX_TRNG
 	bool "MCUX TRNG driver"
-	depends on HAS_MCUX_TRNG
+	default y
+	depends on DT_HAS_NXP_KINETIS_TRNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the true random number generator (TRNG)
@@ -21,7 +23,8 @@ config ENTROPY_MCUX_TRNG
 
 config ENTROPY_MCUX_RNG
 	bool "MCUX RNG driver"
-	depends on HAS_MCUX_RNG
+	default y
+	depends on DT_HAS_NXP_LPC_RNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the true random number generator (TRNG)

--- a/drivers/entropy/Kconfig.native_posix
+++ b/drivers/entropy/Kconfig.native_posix
@@ -2,7 +2,8 @@
 
 config FAKE_ENTROPY_NATIVE_POSIX
 	bool "Native posix entropy driver"
-	depends on ARCH_POSIX
+	default y
+	depends on DT_HAS_ZEPHYR_NATIVE_POSIX_RNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the test random number generator for the

--- a/drivers/entropy/Kconfig.neorv32
+++ b/drivers/entropy/Kconfig.neorv32
@@ -5,8 +5,9 @@
 
 config ENTROPY_NEORV32_TRNG
 	bool "NEORV32 TRNG"
-	default $(dt_compat_enabled,neorv32-trng)
-	depends on SOC_SERIES_NEORV32 && SYSCON
+	default y
+	depends on DT_HAS_NEORV32_TRNG_ENABLED
+	depends on SYSCON
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the True Random Number Generator (TRNG) driver for

--- a/drivers/entropy/Kconfig.nrf5
+++ b/drivers/entropy/Kconfig.nrf5
@@ -13,10 +13,10 @@ config ENTROPY_NRF_FORCE_ALT
 
 menuconfig ENTROPY_NRF5_RNG
 	bool "nRF5 RNG driver"
-	depends on !ENTROPY_NRF_FORCE_ALT
-	depends on HAS_HW_NRF_RNG
-	select ENTROPY_HAS_DRIVER
 	default y
+	depends on !ENTROPY_NRF_FORCE_ALT
+	depends on DT_HAS_NORDIC_NRF_RNG_ENABLED
+	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the RNG peripheral, which is a random number
 	  generator, based on internal thermal noise, that provides a

--- a/drivers/entropy/Kconfig.rv32m1
+++ b/drivers/entropy/Kconfig.rv32m1
@@ -5,7 +5,8 @@
 
 config ENTROPY_RV32M1_TRNG
 	bool "RV32M1 TRNG driver"
-	depends on SOC_OPENISA_RV32M1_RISCV32
+	default y
+	depends on DT_HAS_OPENISA_RV32M1_TRNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  This option enables the true random number generator (TRNG)

--- a/drivers/entropy/Kconfig.sam
+++ b/drivers/entropy/Kconfig.sam
@@ -5,7 +5,8 @@
 
 config ENTROPY_SAM_RNG
 	bool "Atmel SAM MCU Family True Random Number Generator (TRNG) Driver"
-	depends on SOC_FAMILY_SAM || SOC_FAMILY_SAM0
+	default y
+	depends on DT_HAS_ATMEL_SAM_TRNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	help
 	  Enable True Random Number Generator (TRNG) driver for Atmel SAM MCUs.

--- a/drivers/entropy/Kconfig.stm32
+++ b/drivers/entropy/Kconfig.stm32
@@ -3,14 +3,12 @@
 # Copyright (c) 2017 Erwin Rol <erwin@erwinrol.com>
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_STM32_RNG := st,stm32-rng
-
 menuconfig ENTROPY_STM32_RNG
 	bool "STM32 RNG driver"
-	depends on SOC_FAMILY_STM32
+	default y
+	depends on DT_HAS_ST_STM32_RNG_ENABLED
 	select ENTROPY_HAS_DRIVER
 	select USE_STM32_LL_RNG
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_RNG))
 	help
 	  This option enables the RNG processor, which is a entropy number
 	  generator, based on a continuous analog noise, that provides


### PR DESCRIPTION
Update entropy drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>