### PR TITLE
samples/nvs: Switch flash_area_offset to use STORAGE_NODE_LABEL

### DIFF
--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -74,14 +74,14 @@ void main(void)
 	/* define the nvs file system by settings with:
 	 *	sector_size equal to the pagesize,
 	 *	3 sectors
-	 *	starting at FLASH_AREA_OFFSET(storage)
+	 *	starting at FLASH_AREA_OFFSET(STORAGE_NODE_LABEL)
 	 */
 	fs.flash_device = FLASH_AREA_DEVICE(STORAGE_NODE_LABEL);
 	if (!device_is_ready(fs.flash_device)) {
 		printk("Flash device %s is not ready\n", fs.flash_device->name);
 		return;
 	}
-	fs.offset = FLASH_AREA_OFFSET(storage);
+	fs.offset = FLASH_AREA_OFFSET(STORAGE_NODE_LABEL);
 	rc = flash_get_page_info_by_offs(fs.flash_device, fs.offset, &info);
 	if (rc) {
 		printk("Unable to get page info\n");


### PR DESCRIPTION
The sample has been defining STORAGE_NODE_LABEL to be used
to point to storage partition, but flash_area_offset has still
been using "storage" directly.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>