### PR TITLE
Bluetooth: Audio: Fix typo

### DIFF
--- a/subsys/bluetooth/audio/pacs.c
+++ b/subsys/bluetooth/audio/pacs.c
@@ -389,7 +389,7 @@ static ssize_t src_loc_read(struct bt_conn *conn,
 				 &location_32_le, sizeof(location_32_le));
 }
 
-#if defined(BT_PAC_SRC_LOC_WRITEABLE)
+#if defined(CONFIG_BT_PAC_SRC_LOC_WRITEABLE)
 static ssize_t src_loc_write(struct bt_conn *conn,
 			     const struct bt_gatt_attr *attr, const void *data,
 			     uint16_t len, uint16_t offset, uint8_t flags)
@@ -425,7 +425,7 @@ static ssize_t src_loc_write(struct bt_conn *conn,
 
 	return len;
 }
-#endif /* BT_PAC_SRC_LOC_WRITEABLE */
+#endif /* CONFIG_BT_PAC_SRC_LOC_WRITEABLE */
 
 static void src_loc_cfg_changed(const struct bt_gatt_attr *attr, uint16_t value)
 {


### PR DESCRIPTION
Fix typo for CONFIG_BT_PAC_SRC_LOC_WRITEABLE

Signed-off-by: Hang Fan <fanhang@xiaomi.com>