### PR TITLE
drivers: gpio stm32 driver also get the pin state

### DIFF
--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -91,7 +91,7 @@ static int gpio_stm32_flags_to_conf(gpio_flags_t flags, int *pincfg)
 	return 0;
 }
 
-#ifdef CONFIG_GPIO_GET_CONFIG
+#if defined(CONFIG_GPIO_GET_CONFIG) && !defined(CONFIG_SOC_SERIES_STM32F1X)
 /**
  * @brief Custom stm32 flags to zephyr
  */
@@ -563,7 +563,7 @@ static int gpio_stm32_config(const struct device *dev,
 	return 0;
 }
 
-#ifdef CONFIG_GPIO_GET_CONFIG
+#if defined(CONFIG_GPIO_GET_CONFIG) && !defined(CONFIG_SOC_SERIES_STM32F1X)
 /**
  * @brief Get configuration of pin
  */
@@ -657,7 +657,7 @@ static int gpio_stm32_manage_callback(const struct device *dev,
 
 static const struct gpio_driver_api gpio_stm32_driver = {
 	.pin_configure = gpio_stm32_config,
-#ifdef CONFIG_GPIO_GET_CONFIG
+#if defined(CONFIG_GPIO_GET_CONFIG) && !defined(CONFIG_SOC_SERIES_STM32F1X)
 	.pin_get_config = gpio_stm32_get_config,
 #endif /* CONFIG_GPIO_GET_CONFIG */
 	.port_get_raw = gpio_stm32_port_get_raw,

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -206,7 +206,7 @@
 #define STM32_PINCFG_FLOATING           STM32_PUPDR_NO_PULL
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
-#ifdef CONFIG_GPIO_GET_CONFIG
+#if defined(CONFIG_GPIO_GET_CONFIG) && !defined(CONFIG_SOC_SERIES_STM32F1X)
 /**
  * @brief structure of a GPIO pin (stm32 LL values) use to get the configuration
  */

--- a/drivers/gpio/gpio_stm32.h
+++ b/drivers/gpio/gpio_stm32.h
@@ -206,6 +206,18 @@
 #define STM32_PINCFG_FLOATING           STM32_PUPDR_NO_PULL
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
+#ifdef CONFIG_GPIO_GET_CONFIG
+/**
+ * @brief structure of a GPIO pin (stm32 LL values) use to get the configuration
+ */
+struct gpio_stm32_pin {
+	unsigned int type; /* LL_GPIO_OUTPUT_PUSHPULL or LL_GPIO_OUTPUT_OPENDRAIN */
+	unsigned int pupd; /* LL_GPIO_PULL_NO or LL_GPIO_PULL_UP or LL_GPIO_PULL_DOWN */
+	unsigned int mode; /* LL_GPIO_MODE_INPUT or LL_GPIO_MODE_OUTPUT or other */
+	unsigned int out_state; /* 1 (high level) or 0 (low level) */
+};
+#endif /* CONFIG_GPIO_GET_CONFIG */
+
 /**
  * @brief configuration of GPIO device
  */

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -644,7 +644,7 @@ static int pin_get_config(void)
 	zassert_equal(rc, 0, "pin configure failed");
 
 	rc = gpio_pin_get_config(dev, PIN_OUT, &flags_get);
-	if (rc == -ENOTSUP) {
+	if (rc == -ENOSYS) {
 		return TC_PASS;
 	}
 


### PR DESCRIPTION
In the stm32 gpio driver, the gpio_stm32_get_config function
also returns the pin state HIGH or LOW) to match gpio_pin_get_config

The gpio_stm32_get_config function is modified to include the pin state HIGH/LOW  to the flags variable
This variable is of type gpio_flags_t.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48007

Signed-off-by: Francois Ramu <francois.ramu@st.com>