### PR TITLE
west.yml: Update hal_stm32 with recent cube packages

### DIFF
--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -35,11 +35,17 @@ static void(*const set_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *,
 };
 
 /** Channel to compare get function mapping. */
+#if !defined(CONFIG_SOC_SERIES_STM32F4X)
+static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(const TIM_TypeDef *) = {
+	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
+	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
+};
+#else
 static uint32_t(*const get_timer_compare[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_OC_GetCompareCH1, LL_TIM_OC_GetCompareCH2,
 	LL_TIM_OC_GetCompareCH3, LL_TIM_OC_GetCompareCH4,
 };
-
+#endif
 /** Channel to interrupt enable function mapping. */
 static void(*const enable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_EnableIT_CC1, LL_TIM_EnableIT_CC2,
@@ -54,10 +60,17 @@ static void(*const disable_it[TIMER_MAX_CH])(TIM_TypeDef *) = {
 
 #ifdef CONFIG_ASSERT
 /** Channel to interrupt enable check function mapping. */
+#if !defined(CONFIG_SOC_SERIES_STM32F4X)
+static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(const TIM_TypeDef *) = {
+	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,
+	LL_TIM_IsEnabledIT_CC3, LL_TIM_IsEnabledIT_CC4,
+};
+#else
 static uint32_t(*const check_it_enabled[TIMER_MAX_CH])(TIM_TypeDef *) = {
 	LL_TIM_IsEnabledIT_CC1, LL_TIM_IsEnabledIT_CC2,
 	LL_TIM_IsEnabledIT_CC3, LL_TIM_IsEnabledIT_CC4,
 };
+#endif
 #endif
 
 /** Channel to interrupt flag clear function mapping. */

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -86,8 +86,8 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
 static ETH_DMADescTypeDef dma_rx_desc_tab[ETH_RXBUFNB] __eth_stm32_desc;
 static ETH_DMADescTypeDef dma_tx_desc_tab[ETH_TXBUFNB] __eth_stm32_desc;
-static uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_RX_BUF_SIZE] __eth_stm32_buf;
-static uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_TX_BUF_SIZE] __eth_stm32_buf;
+static uint8_t dma_rx_buffer[ETH_RXBUFNB][ETH_STM32_RX_BUF_SIZE] __eth_stm32_buf;
+static uint8_t dma_tx_buffer[ETH_TXBUFNB][ETH_STM32_TX_BUF_SIZE] __eth_stm32_buf;
 
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 static ETH_TxPacketConfig tx_config;
@@ -194,7 +194,7 @@ static int eth_tx(const struct device *dev, struct net_pkt *pkt)
 	k_mutex_lock(&dev_data->tx_mutex, K_FOREVER);
 
 	total_len = net_pkt_get_len(pkt);
-	if (total_len > ETH_TX_BUF_SIZE) {
+	if (total_len > ETH_STM32_TX_BUF_SIZE) {
 		LOG_ERR("PKT too big");
 		res = -EIO;
 		goto error;
@@ -825,7 +825,7 @@ static int eth_initialize(const struct device *dev)
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
 	heth->Init.TxDesc = dma_tx_desc_tab;
 	heth->Init.RxDesc = dma_rx_desc_tab;
-	heth->Init.RxBuffLen = ETH_RX_BUF_SIZE;
+	heth->Init.RxBuffLen = ETH_STM32_RX_BUF_SIZE;
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 
 	hal_ret = HAL_ETH_Init(heth);

--- a/drivers/ethernet/eth_stm32_hal_priv.h
+++ b/drivers/ethernet/eth_stm32_hal_priv.h
@@ -17,8 +17,8 @@
 #define ETH_STM32_HAL_FRAME_SIZE_MAX (ETH_STM32_HAL_MTU + 18)
 
 /* Definition of the Ethernet driver buffers size and count */
-#define ETH_RX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for receive */
-#define ETH_TX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for transmit */
+#define ETH_STM32_RX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for receive */
+#define ETH_STM32_TX_BUF_SIZE	ETH_MAX_PACKET_SIZE /* buffer size for transmit */
 
 /* Device constant configuration parameters */
 struct eth_stm32_hal_dev_cfg {

--- a/west.yml
+++ b/west.yml
@@ -124,7 +124,7 @@ manifest:
       groups:
         - hal
     - name: hal_stm32
-      revision: 51b373cd3455b8c2b9babbf6ff41918116a442ac
+      revision: 5b1610c3cf46589d50e2634ba240b7b38bc59c53
       path: modules/hal/stm32
       groups:
         - hal


### PR DESCRIPTION
stm32cube: update stm32f4 to cube version V1.27.1.
stm32cube: update stm32f7 to cube version V1.17.0.
stm32cube: update stm32g0 to cube version V1.6.1.
stm32cube: update stm32g4 to cube version V1.5.1.
stm32cube: update stm32l4 to cube version V1.17.2.
stm32cube: update stm32mp1 to cube version 1.6.0.
stm32cube: update stm32u5 to cube version V1.1.1.
stm32cube: update stm32wb to cube version V1.14.0.
lib/stm32: update stm32wb to cube version V1.14.0


Signed-off-by: TLIG Dhaou <dhaou.tlig-ext@st.com>