### PR TITLE
Bluetooth: gatt: Fix potential NULL pointer dereference

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2877,7 +2877,7 @@ uint8_t bt_gatt_check_perm(struct bt_conn *conn, const struct bt_gatt_attr *attr
 	mask &= attr->perm;
 
 	if (mask & BT_GATT_PERM_LESC_MASK) {
-		if (!IS_ENABLED(CONFIG_BT_SMP) ||
+		if (!IS_ENABLED(CONFIG_BT_SMP) || !conn->le.keys ||
 		    (conn->le.keys->flags & BT_KEYS_SC) == 0) {
 			return BT_ATT_ERR_AUTHENTICATION;
 		}


### PR DESCRIPTION
If the device was not paired, the conn->le.keys is NULL, so conn->le.keys will cause NULL pointer dereference.

Authored by: Mariusz Skamra <mariusz.skamra@codecoup.pl>

Originally from https://github.com/zephyrproject-rtos/zephyr/pull/47600. I'm creating a separate PR for this bugfix since it looks like there is a discussion in the way of merging that PR.