### PR TITLE
drivers: w1: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/w1/Kconfig.test
+++ b/drivers/w1/Kconfig.test
@@ -1,8 +1,7 @@
 # Copyright (c) 2022, Thomas Stranger
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_VND_W1 := vnd,w1
-
 # Hidden option to enable the vnd,w1 1-Wire host driver used in testing.
 config W1_TEST
-	def_bool $(dt_compat_enabled,$(DT_COMPAT_VND_W1))
+	def_bool DT_HAS_VND_W1_ENABLED
+	depends on DT_HAS_VND_W1_ENABLED

--- a/drivers/w1/Kconfig.zephyr_serial
+++ b/drivers/w1/Kconfig.zephyr_serial
@@ -3,11 +3,10 @@
 # Copyright (c) 2022 Thomas Stranger
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ZEPHYR_SERIAL := zephyr,w1-serial
-
 config W1_ZEPHYR_SERIAL
 	bool "1-wire Serial"
-	default y if $(dt_compat_enabled,$(DT_COMPAT_ZEPHYR_SERIAL))
+	default y
+	depends on DT_HAS_ZEPHYR_W1_SERIAL_ENABLED
 	help
 	  This option enables the Zephyr serial 1-Wire master driver.
 


### PR DESCRIPTION
Update w1 drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

Signed-off-by: Kumar Gala <galak@kernel.org>