### PR TITLE
ci: testplan: still run default tests with global changes

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -92,15 +92,19 @@ class Filters:
         self.tag_options = []
         self.pull_request = pull_request
         self.platforms = platforms
-
+        self.default_run = False
 
     def process(self):
         self.find_tags()
-        self.find_excludes()
         self.find_tests()
         if not self.platforms:
             self.find_archs()
             self.find_boards()
+
+        if self.default_run:
+            self.find_excludes(skip=["tests/*", "boards/*"])
+        else:
+            self.find_excludes()
 
     def get_plan(self, options, integration=False):
         fname = "_test_plan_partial.json"
@@ -171,7 +175,8 @@ class Filters:
 
         _options = []
         if len(all_boards) > 20:
-            logging.warning(f"{len(boards)} boards changed, this looks like a global change, skipping test handling")
+            logging.warning(f"{len(boards)} boards changed, this looks like a global change, skipping test handling, revert to default.")
+            self.default_run = True
             return
 
         for board in all_boards:
@@ -200,7 +205,8 @@ class Filters:
             _options.extend(["-T", t ])
 
         if len(tests) > 20:
-            logging.warning(f"{len(tests)} tests changed, this looks like a global change, skipping test handling")
+            logging.warning(f"{len(tests)} tests changed, this looks like a global change, skipping test handling, revert to default")
+            self.default_run = True
             return
 
         if _options:
@@ -251,7 +257,7 @@ class Filters:
         if exclude_tags:
             logging.info(f'Potential tag based filters...')
 
-    def find_excludes(self):
+    def find_excludes(self, skip=[]):
         with open("scripts/ci/twister_ignore.txt", "r") as twister_ignore:
             ignores = twister_ignore.read().splitlines()
             ignores = filter(lambda x: not x.startswith("#"), ignores)
@@ -260,6 +266,8 @@ class Filters:
         files = list(filter(lambda x: x, self.modified_files))
 
         for pattern in ignores:
+            if pattern in skip:
+                continue
             if pattern:
                 found.update(fnmatch.filter(files, pattern))
 


### PR DESCRIPTION
In cases of global changes where 100s of nodes are launched, i.e. on
samples and tests (more than 20 tests/samples changed), do a full
covrage run.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
