### PR TITLE
drivers: memc: Update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/memc/Kconfig.mcux
+++ b/drivers/memc/Kconfig.mcux
@@ -2,10 +2,12 @@
 # Copyright (c) 2021 Basalte bv
 # SPDX-License-Identifier: Apache-2.0
 
-if HAS_MCUX_FLEXSPI
+if DT_HAS_NXP_IMX_FLEXSPI_ENABLED
 
 config MEMC_MCUX_FLEXSPI_HYPERRAM
 	bool "MCUX FlexSPI HyperRAM driver"
+	default y
+	depends on DT_HAS_NXP_IMX_FLEXSPI_HYPERRAM_ENABLED
 	select MEMC_MCUX_FLEXSPI
 
 config MEMC_MCUX_FLEXSPI

--- a/drivers/memc/Kconfig.stm32
+++ b/drivers/memc/Kconfig.stm32
@@ -1,33 +1,32 @@
 # Copyright (c) 2020 Teslabs Engineering S.L.
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_ST_STM32_FMC := st,stm32-fmc
-
 config MEMC_STM32
 	bool "STM32 Flexible Memory Controller (FMC)"
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_FMC))
+	default y
+	depends on DT_HAS_ST_STM32_FMC_ENABLED
 	help
 	  Enable STM32 Flexible Memory Controller.
 
-DT_COMPAT_ST_STM32_FMC_SDRAM := st,stm32-fmc-sdram
+if MEMC_STM32
 
 config MEMC_STM32_SDRAM
 	bool "STM32 FMC SDRAM controller"
-	depends on MEMC_STM32
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_FMC_SDRAM))
+	default y
+	depends on DT_HAS_ST_STM32_FMC_SDRAM_ENABLED
 	select USE_STM32_LL_FMC
 	select USE_STM32_HAL_SDRAM
 	help
 	  Enable STM32 FMC SDRAM controller.
 
-DT_COMPAT_ST_STM32_FMC_NOR_PSRAM := st,stm32-fmc-nor-psram
-
 config MEMC_STM32_NOR_PSRAM
 	bool "STM32 FMC NOR/PSRAM controller"
-	depends on MEMC_STM32
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_FMC_NOR_PSRAM))
+	default y
+	depends on DT_HAS_ST_STM32_FMC_NOR_PSRAM_ENABLED
 	select USE_STM32_LL_FMC
 	select USE_STM32_HAL_NOR
 	select USE_STM32_HAL_SRAM
 	help
 	  Enable STM32 FMC NOR/PSRAM controller.
+
+endif


### PR DESCRIPTION
Update memc drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol
to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by
the devicetree node existing.

Signed-off-by: Kumar Gala <galak@kernel.org>