### PR TITLE
EDAC: IBECC: Refactor tests for new API

### DIFF
--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -194,7 +194,11 @@ static int inject_error_trigger(const struct device *dev)
 static int ecc_error_log_get(const struct device *dev, uint64_t *value)
 {
 	*value = ibecc_read_reg64(dev, IBECC_ECC_ERROR_LOG);
-	if (*value == 0) {
+	/**
+	 * The ECC Error log register is only valid when ECC_ERROR_CERRSTS
+	 * or ECC_ERROR_MERRSTS error status bits are set
+	 */
+	if ((*value & (ECC_ERROR_MERRSTS | ECC_ERROR_CERRSTS)) == 0) {
 		return -ENODATA;
 	}
 

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -12,13 +12,11 @@
 #include <zephyr/drivers/edac.h>
 #include <ibecc.h>
 
-#if defined(CONFIG_EDAC_ERROR_INJECT)
 #define TEST_ADDRESS1		0x1000
 #define TEST_ADDRESS2		0x2000
 #define TEST_DATA		0xface
 #define TEST_ADDRESS_MASK	INJ_ADDR_BASE_MASK_MASK
 #define DURATION		100
-#endif
 
 ZTEST(ibecc, test_ibecc_driver_initialized)
 {
@@ -91,13 +89,14 @@ ZTEST(ibecc, test_ibecc_api)
 	zassert_equal(ret, 0, "Error setting notification callback");
 }
 
-#if defined(CONFIG_EDAC_ERROR_INJECT)
 ZTEST(ibecc, test_ibecc_error_inject_api)
 {
 	const struct device *dev;
 	uint32_t test_value;
 	uint64_t val;
 	int ret;
+
+	Z_TEST_SKIP_IFNDEF(CONFIG_EDAC_ERROR_INJECT);
 
 	TC_PRINT("Test IBECC Inject API\n");
 
@@ -160,14 +159,7 @@ ZTEST(ibecc, test_ibecc_error_inject_api)
 	zassert_equal(ret, 0, "Error getting param2");
 	zassert_equal(val, 0, "Read back value differs");
 }
-#else
-ZTEST(ibecc, test_ibecc_error_inject_api)
-{
-	ztest_test_skip();
-}
-#endif
 
-#if defined(CONFIG_EDAC_ERROR_INJECT)
 static void test_inject(const struct device *dev, uint64_t addr, uint64_t mask,
 			uint8_t type)
 {
@@ -315,6 +307,8 @@ static void ibecc_error_inject_test(uint64_t addr, uint64_t mask, uint64_t type)
 
 ZTEST(ibecc, test_ibecc_error_inject_test_cor)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_EDAC_ERROR_INJECT);
+
 	TC_PRINT("Test IBECC injection correctable error\n");
 
 	ibecc_error_inject_test(TEST_ADDRESS1, TEST_ADDRESS_MASK,
@@ -323,22 +317,13 @@ ZTEST(ibecc, test_ibecc_error_inject_test_cor)
 
 ZTEST(ibecc, test_ibecc_error_inject_test_uc)
 {
+	Z_TEST_SKIP_IFNDEF(CONFIG_EDAC_ERROR_INJECT);
+
 	TC_PRINT("Test IBECC injection uncorrectable error\n");
 
 	ibecc_error_inject_test(TEST_ADDRESS2, TEST_ADDRESS_MASK,
 				EDAC_ERROR_TYPE_DRAM_UC);
 }
-#else /* CONFIG_EDAC_ERROR_INJECT */
-ZTEST(ibecc, test_ibecc_error_inject_test_cor)
-{
-	ztest_test_skip();
-}
-
-ZTEST(ibecc, test_ibecc_error_inject_test_uc)
-{
-	ztest_test_skip();
-}
-#endif
 
 static void *setup_ibecc(void)
 {

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -24,11 +24,10 @@ ZTEST(ibecc, test_ibecc_initialized)
 {
 	const struct device *dev;
 
-	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
-	zassert_true(device_is_ready(dev), "Device is not ready");
-
 	TC_PRINT("Test ibecc driver is initialized\n");
 
+	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
+	zassert_true(device_is_ready(dev), "Device is not ready");
 }
 
 K_APPMEM_PARTITION_DEFINE(default_part);
@@ -53,6 +52,8 @@ static void test_ibecc_api(void)
 	const struct device *dev;
 	uint64_t value;
 	int ret;
+
+	TC_PRINT("Test IBECC API\n");
 
 	/* Error log API */
 
@@ -92,6 +93,8 @@ static void test_ibecc_error_inject_api(void)
 	uint32_t test_value;
 	uint64_t val;
 	int ret;
+
+	TC_PRINT("Test IBECC Inject API\n");
 
 	dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 	zassert_true(device_is_ready(dev), "Device is not ready");
@@ -289,12 +292,16 @@ static void ibecc_error_inject_test(uint64_t addr, uint64_t mask, uint64_t type)
 
 static void test_ibecc_error_inject_test_cor(void)
 {
+	TC_PRINT("Test IBECC injection correctable error\n");
+
 	ibecc_error_inject_test(TEST_ADDRESS1, TEST_ADDRESS_MASK,
 				EDAC_ERROR_TYPE_DRAM_COR);
 }
 
 static void test_ibecc_error_inject_test_uc(void)
 {
+	TC_PRINT("Test IBECC injection uncorrectable error\n");
+
 	ibecc_error_inject_test(TEST_ADDRESS2, TEST_ADDRESS_MASK,
 				EDAC_ERROR_TYPE_DRAM_UC);
 }

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -323,8 +323,9 @@ static void *setup_ibecc(void)
 	int ret = k_mem_domain_add_partition(&k_mem_domain_default,
 					     &default_part);
 	if (ret != 0) {
-		TC_PRINT("Failed to add to mem domain (%d)", ret);
-		k_oops();
+		TC_PRINT("Failed to add to mem domain (%d)\n", ret);
+		TC_PRINT("Running test setup function second time?\n");
+		ztest_test_fail();
 	}
 #endif
 	return NULL;

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -20,7 +20,7 @@
 #define DURATION		100
 #endif
 
-ZTEST(ibecc, test_ibecc_initialized)
+ZTEST(ibecc, test_ibecc_driver_initialized)
 {
 	const struct device *dev;
 
@@ -50,7 +50,7 @@ static void callback(const struct device *d, void *data)
 	error_syndrome = error_data->syndrome;
 }
 
-static void test_ibecc_api(void)
+ZTEST(ibecc, test_ibecc_api)
 {
 	const struct device *dev;
 	uint64_t value;
@@ -92,7 +92,7 @@ static void test_ibecc_api(void)
 }
 
 #if defined(CONFIG_EDAC_ERROR_INJECT)
-static void test_ibecc_error_inject_api(void)
+ZTEST(ibecc, test_ibecc_error_inject_api)
 {
 	const struct device *dev;
 	uint32_t test_value;
@@ -161,7 +161,7 @@ static void test_ibecc_error_inject_api(void)
 	zassert_equal(val, 0, "Read back value differs");
 }
 #else
-static void test_ibecc_error_inject_api(void)
+ZTEST(ibecc, test_ibecc_error_inject_api)
 {
 	ztest_test_skip();
 }
@@ -299,7 +299,7 @@ static void ibecc_error_inject_test(uint64_t addr, uint64_t mask, uint64_t type)
 #endif
 }
 
-static void test_ibecc_error_inject_test_cor(void)
+ZTEST(ibecc, test_ibecc_error_inject_test_cor)
 {
 	TC_PRINT("Test IBECC injection correctable error\n");
 
@@ -307,7 +307,7 @@ static void test_ibecc_error_inject_test_cor(void)
 				EDAC_ERROR_TYPE_DRAM_COR);
 }
 
-static void test_ibecc_error_inject_test_uc(void)
+ZTEST(ibecc, test_ibecc_error_inject_test_uc)
 {
 	TC_PRINT("Test IBECC injection uncorrectable error\n");
 
@@ -315,12 +315,12 @@ static void test_ibecc_error_inject_test_uc(void)
 				EDAC_ERROR_TYPE_DRAM_UC);
 }
 #else /* CONFIG_EDAC_ERROR_INJECT */
-static void test_ibecc_error_inject_test_cor(void)
+ZTEST(ibecc, test_ibecc_error_inject_test_cor)
 {
 	ztest_test_skip();
 }
 
-static void test_ibecc_error_inject_test_uc(void)
+ZTEST(ibecc, test_ibecc_error_inject_test_uc)
 {
 	ztest_test_skip();
 }
@@ -338,14 +338,6 @@ static void *setup_ibecc(void)
 	}
 #endif
 	return NULL;
-}
-
-ZTEST(ibecc, test_ibecc_injection)
-{
-	test_ibecc_api();
-	test_ibecc_error_inject_api();
-	test_ibecc_error_inject_test_cor();
-	test_ibecc_error_inject_test_uc();
 }
 
 ZTEST_SUITE(ibecc, NULL, setup_ibecc, NULL, NULL, NULL);

--- a/tests/subsys/edac/ibecc/src/ibecc.c
+++ b/tests/subsys/edac/ibecc/src/ibecc.c
@@ -251,6 +251,20 @@ static void test_inject(const struct device *dev, uint64_t addr, uint64_t mask,
 	TC_PRINT("Uncorrectable error count %d\n", ret);
 
 	errors_uncorrectable = ret;
+
+	/* Clear */
+
+	ret = edac_inject_set_error_type(dev, 0);
+	zassert_equal(ret, 0, "Error setting inject error type");
+
+	ret = edac_inject_set_param1(dev, 0);
+	zassert_equal(ret, 0, "Error setting inject address");
+
+	ret = edac_inject_set_param2(dev, 0);
+	zassert_equal(ret, 0, "Error setting inject address mask");
+
+	ret = edac_inject_error_trigger(dev);
+	zassert_equal(ret, 0, "Error setting ctrl");
 }
 
 static int check_values(void *p1, void *p2, void *p3)

--- a/tests/subsys/edac/ibecc_cov/src/ibecc.c
+++ b/tests/subsys/edac/ibecc_cov/src/ibecc.c
@@ -34,8 +34,8 @@ static uint64_t mock_sys_read64(uint64_t addr)
 {
 #if defined(IBECC_ENABLED)
 	if (addr == IBECC_ECC_ERROR_LOG) {
-		TC_PRINT("Simulate sys_read64(IBECC_ECC_ERROR_LOG)=>1\n");
-		return 1;
+		TC_PRINT("Simulate sys_read64(IBECC_ECC_ERROR_LOG)=>CERRSTS\n");
+		return ECC_ERROR_CERRSTS;
 	}
 
 	if (addr == IBECC_PARITY_ERROR_LOG) {


### PR DESCRIPTION
Refactor tests for new ZTEST:

- Use new ZTEST API right way
- Using new helpers like `Z_TEST_SKIP_IFNDEF`. 
- Make also all tests independent, suitable for shuffle.