### PR TITLE
drivers/clock_control: stm32 L0,L1 fix STM32_SRC_PLLCLK calculation

### DIFF
--- a/drivers/clock_control/clock_stm32f2_f4_f7.c
+++ b/drivers/clock_control/clock_stm32f2_f4_f7.c
@@ -61,18 +61,6 @@ void config_pll_sysclock(void)
 				    pllp(STM32_PLL_P_DIVISOR));
 }
 
-/**
- * @brief Return pllout frequency
- */
-__unused
-uint32_t get_pllout_frequency(void)
-{
-	return __LL_RCC_CALC_PLLCLK_FREQ(get_pll_source(),
-					 pllm(STM32_PLL_M_DIVISOR),
-					 STM32_PLL_N_MULTIPLIER,
-					 pllp(STM32_PLL_P_DIVISOR));
-}
-
 #endif /* defined(STM32_PLL_ENABLED) */
 
 /**

--- a/drivers/clock_control/clock_stm32l0_l1.c
+++ b/drivers/clock_control/clock_stm32l0_l1.c
@@ -42,6 +42,22 @@ static uint32_t get_pll_source(void)
 }
 
 /**
+ * @brief get the pll source frequency
+ */
+__unused
+uint32_t get_pllsrc_frequency(void)
+{
+	if (IS_ENABLED(STM32_PLL_SRC_HSI)) {
+		return STM32_HSI_FREQ;
+	} else if (IS_ENABLED(STM32_PLL_SRC_HSE)) {
+		return STM32_HSE_FREQ;
+	}
+
+	__ASSERT(0, "Invalid source");
+	return 0;
+}
+
+/**
  * @brief Set up pll configuration
  */
 __unused
@@ -58,7 +74,7 @@ void config_pll_sysclock(void)
 __unused
 uint32_t get_pllout_frequency(void)
 {
-	return __LL_RCC_CALC_PLLCLK_FREQ(get_pll_source(),
+	return __LL_RCC_CALC_PLLCLK_FREQ(get_pllsrc_frequency(),
 					 pll_mul(STM32_PLL_MULTIPLIER),
 					 pll_div(STM32_PLL_DIVISOR));
 }


### PR DESCRIPTION
Some Series were calculating the pll output frequency from an
clock source index instead of the clock source frequency.

This commit resolves this issue for l0, l1 and removes an unused function for f2, f4, f7.

fixes #47105