### PR TITLE
kernel: init: option to zero noinit memory

### DIFF
--- a/include/zephyr/linker/common-noinit.ld
+++ b/include/zephyr/linker/common-noinit.ld
@@ -10,6 +10,7 @@ SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
          * This section is used for non-initialized objects that
          * will not be cleared during the boot process.
          */
+        _noinit_start = .;
         *(.noinit)
         *(".noinit.*")
 #ifdef CONFIG_USERSPACE
@@ -22,6 +23,8 @@ SECTION_PROLOGUE(_NOINIT_SECTION_NAME,(NOLOAD),)
  * zephyr_linker_sources() Cmake function.
  */
 #include <snippets-noinit.ld>
+
+        _noinit_end = .;
 
 } GROUP_NOLOAD_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 

--- a/include/zephyr/linker/linker-defs.h
+++ b/include/zephyr/linker/linker-defs.h
@@ -245,6 +245,9 @@ extern char __rodata_region_size[];
 extern char _vector_start[];
 extern char _vector_end[];
 
+extern char _noinit_start[];
+extern char _noinit_end[];
+
 #ifdef CONFIG_SW_VECTOR_RELAY
 extern char __vector_relay_table[];
 #endif

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -943,6 +943,19 @@ config HAS_DYNAMIC_DEVICE_HANDLES
 	  Hidden option that makes possible to manipulate device handles at
 	  runtime.
 
+config ZERO_NOINIT_MEMORY
+	bool "Zero memory regions marked __noinit"
+	help
+	  Normally, the __noinit attribute is used to hand-off a payload in
+	  memory, to save time or power, handle tasks sooner, or enter a
+	  low-power state sooner.
+
+	  However, in most systems with ECC memory, this can cause a fault
+	  that typically occurs soon after boot or at a potentially non-
+	  deterministic point in time.
+
+	  Say Y here to initialize memory even if it is marked __noinit.
+
 endmenu
 
 rsource "Kconfig.vm"

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -133,6 +133,10 @@ void z_bss_zero(void)
 	z_early_memset(&__gcov_bss_start, 0,
 		       ((uintptr_t) &__gcov_bss_end - (uintptr_t) &__gcov_bss_start));
 #endif
+#ifdef CONFIG_ZERO_NOINIT_MEMORY
+	z_early_memset(&_noinit_start, 0,
+		       ((uintptr_t)&_noinit_end - (uintptr_t)&_noinit_start));
+#endif /* CONFIG_ZERO_NOINIT_MEMORY */
 }
 
 #ifdef CONFIG_LINKER_USE_BOOT_SECTION


### PR DESCRIPTION
Add `CONFIG_ZERO_NOINIT_MEMORY` to explicitly zero memory regions marked `__noinit` at startup.

This is useful for systems with ECC memory.

Fixes #39598
