### PR TITLE
Bluetooth: Simplify predicate for host-based RPA resolution

### DIFF
--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2675,8 +2675,8 @@ int bt_conn_le_create(const bt_addr_le_t *peer,
 
 #if defined(CONFIG_BT_SMP)
 	if (IS_ENABLED(CONFIG_BT_PRIVACY) &&
-	    (bt_dev.le.rl_entries > 0) &&
-	    (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size)) {
+	    (bt_dev.le.rl_entries > bt_dev.le.rl_size)) {
+		/* Use host-based identity resolving. */
 		bt_conn_set_state(conn, BT_CONN_CONNECTING_SCAN);
 
 		err = bt_le_scan_update(true);


### PR DESCRIPTION
The expression for the condition for using host-based RPA resolution now
simplifies to "Use host-based when we need to resolve more identities
than the controller can handle.".

Proof:
X=((bt_dev.le.rl_entries > 0) && (!bt_dev.le.rl_size || bt_dev.le.rl_entries > bt_dev.le.rl_size))

X=(a > 0) && (!b || a > b)

a>=0, b>=0, because they are cardinal / size_t.

If a=0:
> X evaluates to false. (0 > b)=(a > b) also always evaluates to false.
> X=false=(0 > b)=(a > b)

If a>0:
> X=(!b || a > b)
> If b=0: X=true=(a > 0)=(a > b)
> If b>0: X=(false || (a > b))=(a > b)

The expression is equivalent with (a > b) for all values of (a,b).
QED.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>