### PR TITLE
arm: aarch32: dsb after writing to SCTLR on MPU enable/disable

### DIFF
--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -148,9 +148,10 @@ void arm_core_mpu_enable(void)
 
 	val = __get_SCTLR();
 	val |= SCTLR_MPU_ENABLE;
+	__set_SCTLR(val);
+
 	/* Make sure that all the registers are set before proceeding */
 	__DSB();
-	__set_SCTLR(val);
 	__ISB();
 }
 

--- a/arch/arm/core/aarch32/mpu/arm_mpu.c
+++ b/arch/arm/core/aarch32/mpu/arm_mpu.c
@@ -162,11 +162,15 @@ void arm_core_mpu_disable(void)
 {
 	uint32_t val;
 
-	val = __get_SCTLR();
-	val &= ~SCTLR_MPU_ENABLE;
 	/* Force any outstanding transfers to complete before disabling MPU */
 	__DSB();
+
+	val = __get_SCTLR();
+	val &= ~SCTLR_MPU_ENABLE;
 	__set_SCTLR(val);
+
+	/* Make sure that all the registers are set before proceeding */
+	__DSB();
 	__ISB();
 }
 #else


### PR DESCRIPTION
This patch improves the sync barriers on Arm Aarch32 MPU enable/disable functions: move data and instructions sync barriers after writing to `SCTLR` to ensure the registers are set before proceeding and that the new changes are seen by the instructions that follow.
Tested with `fvp_baser_aemv8r_aarch32`, `qemu_cortex_r5` and in custom board.