### PR TITLE
dts: riscv: Remove label property from devicetrees

### DIFF
--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -140,7 +140,6 @@
 
 		uart0: serial@f0200020 {
 			compatible = "ns16550";
-			label = "UART_0";
 			reg = <0xf0200020 0x1000>;
 			reg-shift = <2>;
 			interrupts = <8 1>;
@@ -150,7 +149,6 @@
 
 		uart1: serial@f0300020 {
 			compatible = "ns16550";
-			label = "UART_1";
 			reg = <0xf0300020 0x1000>;
 			reg-shift = <2>;
 			interrupts = <9 1>;
@@ -160,7 +158,6 @@
 
 		pit0: pit@f0400000 {
 			compatible = "andestech,atcpit100";
-			label = "PIT_0";
 			reg = <0xf0400000 0x1000>;
 			interrupts = <3 1>;
 			interrupt-parent = <&plic0>;
@@ -179,7 +176,6 @@
 
 		gpio0: gpio@f0700000 {
 			compatible = "andestech,atcgpio100";
-			label = "GPIO_0";
 			reg = <0xf0700000 0x1000>;
 			interrupts = <7 1>;
 			interrupt-parent = <&plic0>;
@@ -191,7 +187,6 @@
 
 		i2c0: i2c@f0a00000 {
 			compatible = "andestech,atciic100";
-			label = "I2C_0";
 			reg = <0xf0a00000 0x1000>;
 			interrupts = <6 1>;
 			interrupt-parent = <&plic0>;
@@ -202,7 +197,6 @@
 
 		spi0: spi@f0b00000 {
 			compatible = "andestech,atcspi200";
-			label = "SPI_0";
 			reg = <0xf0b00000 0x1000
 			       0x80000000 DT_SIZE_K(1024)>;
 			reg-names = "control", "mem";
@@ -217,7 +211,6 @@
 
 		spi1: spi@f0f00000 {
 			compatible = "andestech,atcspi200";
-			label = "SPI_1";
 			reg = <0xf0f00000 0x1000>;
 			reg-names = "control";
 			interrupts = <5 1>;
@@ -239,7 +232,6 @@
 
 		eth0: eth@e0100000 {
 			compatible = "andestech,atfmac100";
-			label = "ETH_0";
 			reg = <0xe0100000 0x1000>;
 			interrupts = <19 2>;
 			interrupt-parent = <&plic0>;
@@ -249,7 +241,6 @@
 
 		lcd0: lcd@e0200000 {
 			compatible = "andestech,atflcdc100";
-			label = "LCD_0";
 			reg = <0xe0200000 0x1000>;
 			interrupts = <20 1>;
 			interrupt-parent = <&plic0>;

--- a/dts/riscv/espressif/esp32c3.dtsi
+++ b/dts/riscv/espressif/esp32c3.dtsi
@@ -52,7 +52,6 @@
 			#interrupt-cells = <1>;
 			interrupt-controller;
 			reg = <0x600c2000 0x198>;
-			label = "INTC_0";
 			status = "okay";
 		};
 
@@ -61,14 +60,12 @@
 			reg = <0x60023000 0x80>;
 			interrupts = <SYSTIMER_TARGET0_EDGE_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "SYSTIMER_0";
 			status = "okay";
 		};
 
 		rtc: rtc@60008000 {
 			compatible = "espressif,esp32-rtc";
 			reg = <0x60008000 0x1000>;
-			label = "RTC";
 			xtal-freq = <ESP32_CLK_XTAL_40M>;
 			#clock-cells = <1>;
 			status = "ok";
@@ -76,7 +73,6 @@
 
 		flash: flash-controller@60002000 {
 			compatible = "espressif,esp32-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x60002000 0x1000>;
 
 			#address-cells = <1>;
@@ -84,7 +80,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_ESP32C3";
 				reg = <0 0x400000>;
 				erase-block-size = <4096>;
 				write-block-size = <4>;
@@ -98,7 +93,6 @@
 			reg = <0x60004000 0x800>;
 			interrupts = <GPIO_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "GPIO_0";
 			ngpios = <32>;   /* 0..31 */
 		};
 
@@ -109,7 +103,6 @@
 			reg = <0x60013000 0x1000>;
 			interrupts = <I2C_EXT0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "I2C_0";
 			clocks = <&rtc ESP32_I2C0_MODULE>;
 			status = "disabled";
 		};
@@ -117,7 +110,6 @@
 		uart0: uart@60000000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x60000000 0x400>;
-			label = "UART_0";
 			status = "disabled";
 			interrupts = <UART0_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
@@ -127,7 +119,6 @@
 		uart1: uart@60010000 {
 			compatible = "espressif,esp32-uart";
 			reg = <0x60010000 0x400>;
-			label = "UART_1";
 			status = "disabled";
 			interrupts = <UART1_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
@@ -140,7 +131,6 @@
 			pwm-controller;
 			#pwm-cells = <3>;
 			reg = <0x60019000 0x1000>;
-			label = "LEDC_0";
 			clocks = <&rtc ESP32_LEDC_MODULE>;
 			status = "disabled";
 		};
@@ -148,7 +138,6 @@
 		usb_serial: uart@60043000 {
 			compatible = "espressif,esp32-usb-serial";
 			reg = <0x60043000 0x400>;
-			label = "USB_SERIAL";
 			status = "disabled";
 			interrupts = <USB_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
@@ -162,7 +151,6 @@
 			index = <0>;
 			interrupts = <TG0_T0_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG0_T0";
 			status = "disabled";
 		};
 
@@ -173,14 +161,12 @@
 			index = <0>;
 			interrupts = <TG1_T0_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "TIMG1_T0";
 			status = "disabled";
 		};
 
 		trng0: trng@3ff700b0 {
 			compatible = "espressif,esp32-trng";
 			reg = <0x3FF700B0 0x4>;
-			label = "TRNG_0";
 			status = "disabled";
 		};
 
@@ -189,7 +175,6 @@
 			reg = <0x60024000 DT_SIZE_K(4)>;
 			interrupts = <SPI2_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
-			label = "SPI_2";
 			clocks = <&rtc ESP32_SPI2_MODULE>;
 			status = "disabled";
 		};
@@ -200,7 +185,6 @@
 			interrupts = <TG0_WDT_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG0_MODULE>;
-			label = "WDT_0";
 			status = "disabled";
 		};
 
@@ -210,7 +194,6 @@
 			interrupts = <TG1_WDT_LEVEL_INTR_SOURCE>;
 			interrupt-parent = <&intc>;
 			clocks = <&rtc ESP32_TIMG1_MODULE>;
-			label = "WDT_1";
 			status = "disabled";
 		};
 

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -53,19 +53,16 @@
 				0xd2000004 0x0004
 				0xd200000b 0x0001
 				0xd2001000 0x1000>;
-			label = "NUCLEI_ECLIC";
 		};
 
 		fmc: flash-controller@40022000 {
 			compatible = "gd,gd32-flash-controller";
-			label = "FMC";
 			reg = <0x40022000 0x400>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH0";
 				write-block-size = <2>;
 			};
 		};
@@ -77,7 +74,6 @@
 			interrupt-parent = <&eclic>;
 			rcu-periph-clock = <0x60e>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		usart1: serial@40004400 {
@@ -87,7 +83,6 @@
 			interrupt-parent = <&eclic>;
 			rcu-periph-clock = <0x711>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		usart2: serial@40004800 {
@@ -97,7 +92,6 @@
 			interrupt-parent = <&eclic>;
 			rcu-periph-clock = <0x712>;
 			status = "disabled";
-			label = "UART_2";
 		};
 
 		adc0: adc@40012400 {
@@ -108,7 +102,6 @@
 			rcu-periph-clock = <0x609>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_0";
 			#io-channel-cells = <1>;
 		};
 
@@ -120,7 +113,6 @@
 			rcu-periph-clock = <0x60A>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_1";
 			#io-channel-cells = <1>;
 		};
 
@@ -129,7 +121,6 @@
 			reg = <0x40007400 0x400>;
 			rcu-periph-clock = <0x71d>;
 			num-channels = <2>;
-			label = "DAC";
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -145,7 +136,6 @@
 			interrupt-parent = <&eclic>;
 			rcu-periph-clock = <0x715>;
 			status = "disabled";
-			label = "I2C_0";
 		};
 
 		spi0: spi@40013000 {
@@ -155,7 +145,6 @@
 			interrupt-parent = <&eclic>;
 			rcu-periph-clock = <0x60c>;
 			status = "disabled";
-			label = "SPI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -167,7 +156,6 @@
 			interrupt-parent = <&eclic>;
 			rcu-periph-clock = <0x70e>;
 			status = "disabled";
-			label = "SPI_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -177,7 +165,6 @@
 			reg = <0x40010000 0x400>;
 			rcu-periph-clock = <0x600>;
 			status = "okay";
-			label = "AFIO";
 		};
 
 		exti: interrupt-controller@40010400 {
@@ -193,7 +180,6 @@
 			interrupt-names = "line0", "line1", "line2", "line3",
 					  "line4", "line5-9", "line10-15";
 			status = "okay";
-			label = "EXTI";
 		};
 
 		pinctrl: pin-controller@40010800 {
@@ -202,7 +188,6 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
-			label = "PINCTRL";
 
 			gpioa: gpio@40010800 {
 				compatible = "gd,gd32-gpio";
@@ -211,7 +196,6 @@
 				#gpio-cells = <2>;
 				rcu-periph-clock = <0x602>;
 				status = "disabled";
-				label = "GPIOA";
 			};
 
 			gpiob: gpio@40010c00 {
@@ -221,7 +205,6 @@
 				#gpio-cells = <2>;
 				rcu-periph-clock = <0x603>;
 				status = "disabled";
-				label = "GPIOB";
 			};
 
 			gpioc: gpio@40011000 {
@@ -231,7 +214,6 @@
 				#gpio-cells = <2>;
 				rcu-periph-clock = <0x604>;
 				status = "disabled";
-				label = "GPIOC";
 			};
 
 			gpiod: gpio@40011400 {
@@ -241,7 +223,6 @@
 				#gpio-cells = <2>;
 				rcu-periph-clock = <0x605>;
 				status = "disabled";
-				label = "GPIOD";
 			};
 
 			gpioe: gpio@40011800 {
@@ -251,7 +232,6 @@
 				#gpio-cells = <2>;
 				rcu-periph-clock = <0x606>;
 				status = "disabled";
-				label = "GPIOE";
 			};
 		};
 
@@ -266,12 +246,10 @@
 			is-advanced;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_0";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_0";
 				#pwm-cells = <3>;
 			};
 		};
@@ -286,12 +264,10 @@
 			rcu-periph-reset = <0x400>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_1";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_1";
 				#pwm-cells = <3>;
 			};
 		};
@@ -306,12 +282,10 @@
 			rcu-periph-reset = <0x401>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_2";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_2";
 				#pwm-cells = <3>;
 			};
 		};
@@ -326,12 +300,10 @@
 			rcu-periph-reset = <0x402>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_3";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_3";
 				#pwm-cells = <3>;
 			};
 		};
@@ -346,12 +318,10 @@
 			rcu-periph-reset = <0x403>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_4";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_4";
 				#pwm-cells = <3>;
 			};
 		};
@@ -366,7 +336,6 @@
 			rcu-periph-reset = <0x404>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_5";
 		};
 
 		timer6: timer@40001400 {
@@ -379,7 +348,6 @@
 			rcu-periph-reset = <0x405>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_6";
 		};
 	};
 };

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -53,12 +53,10 @@
 			compatible = "ite,it8xxx2-bbram";
 			status = "okay";
 			reg = <0x00f02200 0xc0>;
-			label = "BBRAM";
 		};
 		flashctrl: flash-controller@f01000 {
 			compatible = "ite,it8xxx2-flash-controller";
 			reg = <0x00f01000 0x100>;
-			label = "fspi";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -75,12 +73,10 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
-			label = "PINCTRL";
 
 			pinctrla: pinctrl@f01610 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01610 8>;   /* GPCR */
-				label = "PINCTRLA";
 				func3-gcr =     <NO_FUNC  NO_FUNC  NO_FUNC  NO_FUNC
 						 0xf02032 0xf02032 0xf016f0 0xf016f0>;
 				func3-en-mask = <0        0        0        0
@@ -99,7 +95,6 @@
 			pinctrlb: pinctrl@f01618 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01618 8>;   /* GPCR */
-				label = "PINCTRLB";
 				func3-gcr =     <0xf016f5 0xf016f5 NO_FUNC NO_FUNC
 						 NO_FUNC  NO_FUNC  NO_FUNC 0xf01600>;
 				func3-en-mask = <0x01     0x02     0       0
@@ -118,7 +113,6 @@
 			pinctrlc: pinctrl@f01620 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01620 8>;   /* GPCR */
-				label = "PINCTRLC";
 				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC 0xf016f0
 						 NO_FUNC 0xf016f0 NO_FUNC 0xf016f3>;
 				func3-en-mask = <0       0        0       0x10
@@ -137,7 +131,6 @@
 			pinctrld: pinctrl@f01628 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01628 8>;   /* GPCR */
-				label = "PINCTRLD";
 				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC NO_FUNC
 						 NO_FUNC 0xf016f0 NO_FUNC NO_FUNC>;
 				func3-en-mask = <0       0        0       0
@@ -156,7 +149,6 @@
 			pinctrle: pinctrl@f01630 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01630 8>;   /* GPCR */
-				label = "PINCTRLE";
 				func3-gcr =     <0xf02032 NO_FUNC  NO_FUNC NO_FUNC
 						 NO_FUNC  0xf016f0 NO_FUNC 0xf02032>;
 				func3-en-mask = <0x01     0        0       0
@@ -175,7 +167,6 @@
 			pinctrlf: pinctrl@f01638 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01638 8>;   /* GPCR */
-				label = "PINCTRLF";
 				func3-gcr =     <NO_FUNC NO_FUNC 0xf016f0 0xf016f0
 						 NO_FUNC NO_FUNC 0xf016f1 0xf016f1>;
 				func3-en-mask = <0       0       0x02     0x02
@@ -194,7 +185,6 @@
 			pinctrlg: pinctrl@f01640 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01640 8>;   /* GPCR */
-				label = "PINCTRLG";
 				func3-gcr =     <0xf016f0 0xf016f0 0xf016f0 NO_FUNC
 						 NO_FUNC  NO_FUNC  0xf016f0 NO_FUNC>;
 				func3-en-mask = <0x20     0x08     0x10     0
@@ -213,7 +203,6 @@
 			pinctrlh: pinctrl@f01648 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01648 8>;   /* GPCR */
-				label = "PINCTRLH";
 				func3-gcr =     <NO_FUNC 0xf016f1 0xf016f1 NO_FUNC
 						 NO_FUNC 0xf016f5 0xf016f5 NO_FUNC>;
 				func3-en-mask = <0       0x20     0x20     0
@@ -232,7 +221,6 @@
 			pinctrli: pinctrl@f01650 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01650 8>;   /* GPCR */
-				label = "PINCTRLI";
 				func3-gcr =     <NO_FUNC NO_FUNC  NO_FUNC  NO_FUNC
 						 NO_FUNC 0xf016f0 0xf016f0 0xf016f0>;
 				func3-en-mask = <0       0        0        0
@@ -251,7 +239,6 @@
 			pinctrlj: pinctrl@f01658 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01658 8>;   /* GPCR */
-				label = "PINCTRLJ";
 				func3-gcr =     <0xf016f4 NO_FUNC  0xf016f4 0xf016f4
 						 0xf016f0 0xf016f0 NO_FUNC  NO_FUNC>;
 				func3-en-mask = <0x01     0        0x01     0x02
@@ -270,7 +257,6 @@
 			pinctrlk: pinctrl@f01690 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01690 8>;   /* GPCR */
-				label = "PINCTRLK";
 				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 				func3-en-mask = <0       0       0       0
@@ -289,7 +275,6 @@
 			pinctrll: pinctrl@f01698 {
 			compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f01698 8>;   /* GPCR */
-				label = "PINCTRLL";
 				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 				func3-en-mask = <0       0       0       0
@@ -308,7 +293,6 @@
 			pinctrlm: pinctrl@f016a0 {
 				compatible = "ite,it8xxx2-pinctrl-func";
 				reg = <0x00f016a0 8>;   /* GPCR */
-				label = "PINCTRLM";
 				func3-gcr =     <NO_FUNC NO_FUNC NO_FUNC NO_FUNC
 						 NO_FUNC NO_FUNC NO_FUNC NO_FUNC>;
 				func3-en-mask = <0       0       0       0
@@ -335,7 +319,6 @@
 			       0x00f01b04 1   /* WUESR1 */
 			       0x00f01b08 1   /* WUENR1 */
 			       0x00f01b3c 1>; /* WUBEMR1 */
-			label = "WUC_1";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -345,7 +328,6 @@
 			       0x00f01b05             1   /* WUESR2 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR2 */
 			       0x00f01b3d             1>; /* WUBEMR2 */
-			label = "WUC_2";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -355,7 +337,6 @@
 			       0x00f01b06 1   /* WUESR3 */
 			       0x00f01b0a 1   /* WUENR3 */
 			       0x00f01b3e 1>; /* WUBEMR3 */
-			label = "WUC_3";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -365,7 +346,6 @@
 			       0x00f01b07 1   /* WUESR4 */
 			       0x00f01b0b 1   /* WUENR4 */
 			       0x00f01b3f 1>; /* WUBEMR4 */
-			label = "WUC_4";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -375,7 +355,6 @@
 			       0x00f01b0d             1   /* WUESR5 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR5 */
 			       0x00f01b0f             1>; /* WUBEMR5 */
-			label = "WUC_5";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -385,7 +364,6 @@
 			       0x00f01b11             1   /* WUESR6 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR6 */
 			       0x00f01b13             1>; /* WUBEMR6 */
-			label = "WUC_6";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -395,7 +373,6 @@
 			       0x00f01b15             1   /* WUESR7 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR7 */
 			       0x00f01b17             1>; /* WUBEMR7 */
-			label = "WUC_7";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -405,7 +382,6 @@
 			       0x00f01b19             1   /* WUESR8 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR8 */
 			       0x00f01b1b             1>; /* WUBEMR8 */
-			label = "WUC_8";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -415,7 +391,6 @@
 			       0x00f01b1d             1   /* WUESR9 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR9 */
 			       0x00f01b1f             1>; /* WUBEMR9 */
-			label = "WUC_9";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -425,7 +400,6 @@
 			       0x00f01b21             1   /* WUESR10 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR10 */
 			       0x00f01b23             1>; /* WUBEMR10 */
-			label = "WUC_10";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -435,7 +409,6 @@
 			       0x00f01b25             1   /* WUESR11 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR11 */
 			       0x00f01b27             1>; /* WUBEMR11 */
-			label = "WUC_11";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -445,7 +418,6 @@
 			       0x00f01b29             1   /* WUESR12 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR12 */
 			       0x00f01b2b             1>; /* WUBEMR12 */
-			label = "WUC_12";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -455,7 +427,6 @@
 			       0x00f01b2d             1   /* WUESR13 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR13 */
 			       0x00f01b2f             1>; /* WUBEMR13 */
-			label = "WUC_13";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -465,7 +436,6 @@
 			       0x00f01b31             1   /* WUESR14 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR14 */
 			       0x00f01b33             1>; /* WUBEMR14 */
-			label = "WUC_14";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -475,7 +445,6 @@
 			       0x00f01b35             1   /* WUESR15 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR15 */
 			       0x00f01b37             1>; /* WUBEMR15 */
-			label = "WUC_15";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -485,7 +454,6 @@
 			       0x00f01b39             1   /* WUESR16 */
 			       IT8XXX2_WUC_UNUSED_REG 1   /* WUENR16 */
 			       0x00f01b3b             1>; /* WUBEMR16 */
-			label = "WUC_16";
 			wakeup-controller;
 			#wuc-cells = <1>;
 		};
@@ -501,7 +469,6 @@
 			compatible = "ns16550";
 			reg = <0x00f02700 0x0020>;
 			status = "disabled";
-			label = "console";
 			current-speed = <115200>;
 			clock-frequency = <1804800>;
 			interrupts = <38 IRQ_TYPE_EDGE_RISING>;
@@ -512,7 +479,6 @@
 			compatible = "ns16550";
 			reg = <0x00f02800 0x0020>;
 			status = "disabled";
-			label = "UART_2";
 			current-speed = <460800>;
 			clock-frequency = <1804800>;
 			interrupts = <39 IRQ_TYPE_EDGE_RISING>;
@@ -524,7 +490,6 @@
 			compatible = "ite,it8xxx2-uart";
 			reg = <0x00f02720 0x0020>;
 			status = "disabled";
-			label = "UART1_WRAPPER";
 			port-num = <1>;
 			gpios = <&gpiob 0 0>;
 			uart-dev = <&uart1>;
@@ -534,7 +499,6 @@
 			compatible = "ite,it8xxx2-uart";
 			reg = <0x00f02820 0x0020>;
 			status = "disabled";
-			label = "UART2_WRAPPER";
 			port-num = <2>;
 			gpios = <&gpioh 1 0>;
 			uart-dev = <&uart2>;
@@ -543,7 +507,6 @@
 		twd0: watchdog@f01f00 {
 			compatible = "ite,it8xxx2-watchdog";
 			reg = <0x00f01f00 0x0062>;
-			label = "TWD_0";
 			interrupts = <IT8XXX2_IRQ_TIMER1 IRQ_TYPE_EDGE_RISING   /* Warning timer */
 				      IT8XXX2_IRQ_TIMER2 IRQ_TYPE_EDGE_RISING>; /* One shot timer */
 			interrupt-parent = <&intc>;
@@ -552,7 +515,6 @@
 		timer: timer@f01f10 {
 			compatible = "ite,it8xxx2-timer";
 			reg = <0x00f01f10 0x0052>;
-			label = "TIMER";
 			interrupts = <IT8XXX2_IRQ_TIMER3 IRQ_TYPE_EDGE_RISING   /* Event timer */
 				      IT8XXX2_IRQ_TIMER4 IRQ_TYPE_EDGE_RISING   /* Free run timer */
 				      IT8XXX2_IRQ_TIMER5 IRQ_TYPE_EDGE_RISING   /* Busy wait low */
@@ -565,7 +527,6 @@
 		gpiogcr: gpio-gcr@f01600 {
 			compatible = "ite,it8xxx2-gpiogcr";
 			reg = <0x00f01600 0x100>;
-			label = "GPIO_GCR";
 		};
 
 		gpioa: gpio@f01601 {
@@ -575,7 +536,6 @@
 			       0x00f01661 1   /* GPDMR (get) */
 			       0x00f01671 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_A";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU91 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU92 IRQ_TYPE_LEVEL_HIGH
@@ -596,7 +556,6 @@
 			       0x00f01662 1   /* GPDMR (get) */
 			       0x00f01672 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_B";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU101 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU102 IRQ_TYPE_LEVEL_HIGH
@@ -618,7 +577,6 @@
 			       0x00f01663 1   /* GPDMR (get) */
 			       0x00f01673 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_C";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU85 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU107 IRQ_TYPE_LEVEL_HIGH
@@ -639,7 +597,6 @@
 			       0x00f01664 1   /* GPDMR (get) */
 			       0x00f01674 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_D";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU20 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU21 IRQ_TYPE_LEVEL_HIGH
@@ -660,7 +617,6 @@
 			       0x00f01665 1   /* GPDMR (get) */
 			       0x00f01675 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_E";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU70 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU71 IRQ_TYPE_LEVEL_HIGH
@@ -681,7 +637,6 @@
 			       0x00f01666 1   /* GPDMR (get) */
 			       0x00f01676 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_F";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU96 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU97 IRQ_TYPE_LEVEL_HIGH
@@ -702,7 +657,6 @@
 			       0x00f01667 1   /* GPDMR (get) */
 			       0x00f01677 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_G";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU115 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU116 IRQ_TYPE_LEVEL_HIGH
@@ -723,7 +677,6 @@
 			       0x00f01668 1   /* GPDMR (get) */
 			       0x00f01678 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_H";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU60 IRQ_TYPE_LEVEL_HIGH
 				IT8XXX2_IRQ_WU61 IRQ_TYPE_LEVEL_HIGH
@@ -745,7 +698,6 @@
 			       0x00f01669 1   /* GPDMR (get) */
 			       0x00f01679 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_I";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU119 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU120 IRQ_TYPE_LEVEL_HIGH
@@ -766,7 +718,6 @@
 			       0x00f0166a 1   /* GPDMR (get) */
 			       0x00f0167a 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_J";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU128 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU129 IRQ_TYPE_LEVEL_HIGH
@@ -787,7 +738,6 @@
 			       0x00f0166b 1   /* GPDMR (get) */
 			       0x00f0167b 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_K";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU50 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU51 IRQ_TYPE_LEVEL_HIGH
@@ -808,7 +758,6 @@
 			       0x00f0166c 1   /* GPDMR (get) */
 			       0x00f0167c 1>; /* GPOTR */
 			ngpios = <8>;
-			label = "GPIO_L";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU136 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_WU137 IRQ_TYPE_LEVEL_HIGH
@@ -829,7 +778,6 @@
 			       0x00f0166d 1   /* GPDMR (get) */
 			       0x00f0167d 1>; /* GPOTR */
 			ngpios = <7>;
-			label = "GPIO_M";
 			gpio-controller;
 			interrupts = <IT8XXX2_IRQ_WU144 IRQ_TYPE_LEVEL_HIGH
 				IT8XXX2_IRQ_WU145 IRQ_TYPE_LEVEL_HIGH
@@ -861,7 +809,6 @@
 				      IT8XXX2_IRQ_PCH_P80 IRQ_TYPE_LEVEL_HIGH
 				      IT8XXX2_IRQ_PMC2_IBF IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
-			label = "ESPI_0";
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "disabled";
@@ -872,7 +819,6 @@
 			#size-cells = <0>;
 			compatible = "ite,it8xxx2-sspi";
 			reg = <0x00f02600 0x40>;
-			label = "SPI0";
 			interrupt-parent = <&intc>;
 			interrupts = <37 IRQ_TYPE_EDGE_RISING>;
 			clock-frequency = <115200>;
@@ -882,7 +828,6 @@
 			#size-cells = <0>;
 			compatible = "ite,it8xxx2-sspi";
 			reg = <0x00f02640 0x40>;
-			label = "SPI1";
 			interrupts = <37 IRQ_TYPE_EDGE_RISING>;
 			interrupt-parent = <&intc>;
 			status = "okay";
@@ -893,7 +838,6 @@
 			interrupts = <8 IRQ_TYPE_NONE>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			label = "ADC_0";
 			#io-channel-cells = <1>;
 		};
 		vcmp0: vcmp@f01946 {
@@ -905,7 +849,6 @@
 			       0xf01948 0x01   /* VCMP0THRDATL */
 			       0xf01945 0x01   /* VCMPSTS */
 			       0xf0196d 0x01>; /* VCMPSTS2 */
-			label = "VCMP_0";
 			interrupts = <IT8XXX2_IRQ_V_CMP IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			vcmp-ch = <VCMP_CHANNEL_0>;
@@ -920,7 +863,6 @@
 			       0xf0194b 0x01   /* VCMP1THRDATL */
 			       0xf01945 0x01   /* VCMPSTS */
 			       0xf0196d 0x01>; /* VCMPSTS2 */
-			label = "VCMP_1";
 			interrupts = <IT8XXX2_IRQ_V_CMP IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			vcmp-ch = <VCMP_CHANNEL_1>;
@@ -935,7 +877,6 @@
 			       0xf0194e 0x01   /* VCMP2THRDATL */
 			       0xf01945 0x01   /* VCMPSTS */
 			       0xf0196d 0x01>; /* VCMPSTS2 */
-			label = "VCMP_2";
 			interrupts = <IT8XXX2_IRQ_V_CMP IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			vcmp-ch = <VCMP_CHANNEL_2>;
@@ -950,7 +891,6 @@
 			       0xf01970 0x01   /* VCMP3THRDATL */
 			       0xf01945 0x01   /* VCMPSTS */
 			       0xf0196d 0x01>; /* VCMPSTS2 */
-			label = "VCMP_3";
 			interrupts = <IT8XXX2_IRQ_V_CMP IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			vcmp-ch = <VCMP_CHANNEL_3>;
@@ -965,7 +905,6 @@
 			       0xf01973 0x01   /* VCMP4THRDATL */
 			       0xf01945 0x01   /* VCMPSTS */
 			       0xf0196d 0x01>; /* VCMPSTS2 */
-			label = "VCMP_4";
 			interrupts = <IT8XXX2_IRQ_V_CMP IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			vcmp-ch = <VCMP_CHANNEL_4>;
@@ -980,7 +919,6 @@
 			       0xf01976 0x01   /* VCMP5THRDATL */
 			       0xf01945 0x01   /* VCMPSTS */
 			       0xf0196d 0x01>; /* VCMPSTS2 */
-			label = "VCMP_5";
 			interrupts = <IT8XXX2_IRQ_V_CMP IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			vcmp-ch = <VCMP_CHANNEL_5>;
@@ -995,7 +933,6 @@
 			interrupts = <IT8XXX2_IRQ_SMB_A IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			label = "I2C_0";
 			port-num = <0>;
 			scl-gpios = <&gpiob 3 0>;
 			sda-gpios = <&gpiob 4 0>;
@@ -1010,7 +947,6 @@
 			interrupts = <IT8XXX2_IRQ_SMB_B IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			label = "I2C_1";
 			port-num = <1>;
 			scl-gpios = <&gpioc 1 0>;
 			sda-gpios = <&gpioc 2 0>;
@@ -1025,7 +961,6 @@
 			interrupts = <IT8XXX2_IRQ_SMB_C IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			label = "I2C_2";
 			port-num = <2>;
 			scl-gpios = <&gpiof 6 0>;
 			sda-gpios = <&gpiof 7 0>;
@@ -1040,7 +975,6 @@
 			interrupts = <IT8XXX2_IRQ_SMB_D IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			label = "I2C_3";
 			port-num = <3>;
 			scl-gpios = <&gpioh 1 0>;
 			sda-gpios = <&gpioh 2 0>;
@@ -1055,7 +989,6 @@
 			interrupts = <IT8XXX2_IRQ_SMB_E IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			label = "I2C_4";
 			port-num = <4>;
 			scl-gpios = <&gpioe 0 0>;
 			sda-gpios = <&gpioe 7 0>;
@@ -1070,7 +1003,6 @@
 			interrupts = <IT8XXX2_IRQ_SMB_F IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-parent = <&intc>;
 			status = "disabled";
-			label = "I2C_5";
 			port-num = <5>;
 			scl-gpios = <&gpioa 4 0>;
 			sda-gpios = <&gpioa 5 0>;
@@ -1081,12 +1013,10 @@
 			compatible = "ite,it8xxx2-ecpm";
 			reg = <0x00f01e00 0x11>;
 			reg-names = "ecpm";
-			label = "EC_PM";
 		};
 		prs: pwmprs@f01800 {
 			compatible = "ite,it8xxx2-pwmprs";
 			reg = <0x00f01800 1>;
-			label = "prescaler";
 		};
 		pwm0: pwm@f01802 {
 			compatible = "ite,it8xxx2-pwm";
@@ -1095,7 +1025,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_0>;
-			label = "pwm_0";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1107,7 +1036,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_1>;
-			label = "pwm_1";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1119,7 +1047,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_2>;
-			label = "pwm_2";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1131,7 +1058,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_3>;
-			label = "pwm_3";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1143,7 +1069,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_4>;
-			label = "pwm_4";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1155,7 +1080,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_5>;
-			label = "pwm_5";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1167,7 +1091,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_6>;
-			label = "pwm_6";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1179,7 +1102,6 @@
 			       0x00f0180f 1   /* PCSG */
 			       0x00f0180a 1>; /* PWMPOL */
 			channel = <PWM_CHANNEL_7>;
-			label = "pwm_7";
 			status = "disabled";
 			pwmctrl = <&prs>;
 			#pwm-cells = <3>;
@@ -1191,7 +1113,6 @@
 			       0x00f01848 1>; /* TSWCTLR */
 			dvs-bit = <BIT(3)>;
 			chsel-bit = <BIT(2)>;
-			label = "TACH_0";
 			status = "disabled";
 		};
 		tach1: tach@f01820 {
@@ -1201,20 +1122,17 @@
 			       0x00f01848 1>; /* TSWCTLR */
 			dvs-bit = <BIT(1)>;
 			chsel-bit = <BIT(0)>;
-			label = "TACH_1";
 			status = "disabled";
 		};
 
 		gctrl: general-control@f02000 {
 			compatible = "ite,it8xxx2-gctrl";
 			reg = <0x00f02000 0x100>;
-			label = "GCTRL";
 		};
 
 		peci0: peci@f02c00 {
 			compatible = "ite,peci-it8xxx2";
 			reg = <0x00f02c00 15>;
-			label = "PECI_0";
 			#address-cells=<1>;
 			#size-cells = <0>;
 			interrupt-parent = <&intc>;
@@ -1225,7 +1143,6 @@
 		kscan0: kscan@f01d00 {
 			compatible = "ite,it8xxx2-kscan";
 			reg = <0x00f01d00 0x29>;
-			label = "KSCAN";
 			interrupt-parent = <&intc>;
 			interrupts = <IT8XXX2_IRQ_WKINTC IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
@@ -1244,14 +1161,12 @@
 		usbpd0: usbpd@f03700 {
 			compatible = "ite,it8xxx2-usbpd";
 			reg = <0x00f03700 0x100>;
-			label = "USB_PD_PORT0";
 			status = "disabled";
 		};
 
 		usbpd1: usbpd@f03800 {
 			compatible = "ite,it8xxx2-usbpd";
 			reg = <0x00f03800 0x100>;
-			label = "USB_PD_PORT1";
 			status = "disabled";
 		};
 	};

--- a/dts/riscv/microsemi/microsemi-miv.dtsi
+++ b/dts/riscv/microsemi/microsemi-miv.dtsi
@@ -59,7 +59,6 @@
 		uart0: uart@70001000 {
 			compatible = "microsemi,coreuart";
 			reg = <0x70001000 0x1000>;
-			label = "uart_0";
 			status = "disabled";
 			current-speed = <0>;
 			clock-frequency = <0>;

--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -78,7 +78,6 @@
 			current-speed = <115200>;
 			interrupt-parent = <&plic>;
 			interrupts = <90 1>;
-			label = "UART_0";
 			reg-shift = <2>;
 			status = "disabled";
 		};
@@ -91,7 +90,6 @@
 			interrupt-parent = <&plic>;
 			interrupts = <85 1>;
 			status = "disabled";
-			label = "QSPI_0";
 			clock-frequency = <150000000>;
 		};
 	};

--- a/dts/riscv/neorv32.dtsi
+++ b/dts/riscv/neorv32.dtsi
@@ -70,7 +70,6 @@
 			interrupts = <2>, <3>;
 			interrupt-names = "RX", "TX";
 			syscon = <&sysinfo>;
-			label = "UART_0";
 		};
 
 		trng: rng@ffffffb8 {
@@ -78,7 +77,6 @@
 			status = "disabled";
 			reg = <0xffffffb8 4>;
 			syscon = <&sysinfo>;
-			label = "TRNG";
 		};
 
 		gpio: gpio {
@@ -102,7 +100,6 @@
 				gpio-controller;
 				ngpios = <32>;
 				syscon = <&sysinfo>;
-				label = "GPIO_LO";
 				#gpio-cells = <2>;
 			};
 
@@ -114,7 +111,6 @@
 				gpio-controller;
 				ngpios = <32>;
 				syscon = <&sysinfo>;
-				label = "GPIO_HI";
 				#gpio-cells = <2>;
 			};
 		};
@@ -126,14 +122,12 @@
 			interrupts = <4>, <5>;
 			interrupt-names = "RX", "TX";
 			syscon = <&sysinfo>;
-			label = "UART_1";
 		};
 
 		sysinfo: syscon@ffffffe0 {
 			compatible = "neorv-sysinfo", "syscon";
 			status = "okay";
 			reg = <0xffffffe0 32>;
-			label = "SYSINFO";
 		};
 	};
 };

--- a/dts/riscv/openisa/rv32m1.dtsi
+++ b/dts/riscv/openisa/rv32m1.dtsi
@@ -58,14 +58,12 @@
 		pcc0: clock-controller@4002b000 {
 			compatible = "openisa,rv32m1-pcc";
 			reg = <0x4002b000 0x200>;
-			label = "PCC0";
 			#clock-cells = <1>;
 		};
 
 		pcc1: clock-controller@41027000 {
 			compatible = "openisa,rv32m1-pcc";
 			reg = <0x41027000 0x200>;
-			label = "PCC1";
 			#clock-cells = <1>;
 		};
 
@@ -89,7 +87,6 @@
 			compatible = "openisa,rv32m1-intmux";
 			reg = <0x4004f000 0x200>;
 			clocks = <&pcc0 0x13c>;
-			label = "INTMUX0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -103,7 +100,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH0_IRQ>;
 				reg = <0x0 0x40>;
-				label = "INTMUX0_CH0";
 				status = "disabled";
 			};
 
@@ -114,7 +110,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH1_IRQ>;
 				reg = <0x40 0x40>;
-				label = "INTMUX0_CH1";
 				status = "disabled";
 			};
 
@@ -125,7 +120,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH2_IRQ>;
 				reg = <0x80 0x40>;
-				label = "INTMUX0_CH2";
 				status = "disabled";
 			};
 
@@ -136,7 +130,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH3_IRQ>;
 				reg = <0xc0 0x40>;
-				label = "INTMUX0_CH3";
 				status = "disabled";
 			};
 
@@ -147,7 +140,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH4_IRQ>;
 				reg = <0x100 0x40>;
-				label = "INTMUX0_CH4";
 				status = "disabled";
 			};
 
@@ -158,7 +150,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH5_IRQ>;
 				reg = <0x140 0x40>;
-				label = "INTMUX0_CH5";
 				status = "disabled";
 			};
 
@@ -169,7 +160,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH6_IRQ>;
 				reg = <0x180 0x40>;
-				label = "INTMUX0_CH6";
 				status = "disabled";
 			};
 
@@ -180,7 +170,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH7_IRQ>;
 				reg = <0x1c0 0x40>;
-				label = "INTMUX0_CH7";
 				status = "disabled";
 			};
 		};
@@ -189,7 +178,6 @@
 			compatible = "openisa,rv32m1-intmux";
 			reg = <0x41022000 0x20>;
 			clocks = <&pcc1 0x88>;
-			label = "INTMUX1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -203,7 +191,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH0_IRQ>;
 				reg = <0x0 0x40>;
-				label = "INTMUX1_CH0";
 				status = "disabled";
 			};
 
@@ -214,7 +201,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH1_IRQ>;
 				reg = <0x40 0x40>;
-				label = "INTMUX1_CH1";
 				status = "disabled";
 			};
 
@@ -225,7 +211,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH2_IRQ>;
 				reg = <0x80 0x40>;
-				label = "INTMUX1_CH2";
 				status = "disabled";
 			};
 
@@ -236,7 +221,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH3_IRQ>;
 				reg = <0xc0 0x40>;
-				label = "INTMUX1_CH3";
 				status = "disabled";
 			};
 
@@ -247,7 +231,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH4_IRQ>;
 				reg = <0x100 0x40>;
-				label = "INTMUX1_CH4";
 				status = "disabled";
 			};
 
@@ -258,7 +241,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH5_IRQ>;
 				reg = <0x140 0x40>;
-				label = "INTMUX1_CH5";
 				status = "disabled";
 			};
 
@@ -269,7 +251,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH6_IRQ>;
 				reg = <0x180 0x40>;
-				label = "INTMUX1_CH6";
 				status = "disabled";
 			};
 
@@ -280,7 +261,6 @@
 				interrupt-controller;
 				interrupts = <INTMUX_CH7_IRQ>;
 				reg = <0x1c0 0x40>;
-				label = "INTMUX1_CH7";
 				status = "disabled";
 			};
 		};
@@ -288,19 +268,16 @@
 		lptmr0: timer@40032000 {
 			compatible = "openisa,rv32m1-lptmr";
 			reg = <0x40032000 0x10>;
-			label = "LPTMR_0";
 		};
 
 		lptmr1: timer@40033000 {
 			compatible = "openisa,rv32m1-lptmr";
 			reg = <0x40033000 0x10>;
-			label = "LPTMR_1";
 		};
 
 		lptmr2: timer@4102b000 {
 			compatible = "openisa,rv32m1-lptmr";
 			reg = <0x4102b000 0x10>;
-			label = "LPTMR_2";
 		};
 
 		porta: pinmux@40046000 {
@@ -336,7 +313,6 @@
 		gpioa: gpio@48020000 {
 			compatible = "openisa,rv32m1-gpio";
 			reg = <0x48020000 0x14>;
-			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 			openisa,rv32m1-port = <&porta>;
@@ -345,7 +321,6 @@
 		gpiob: gpio@48020040 {
 			compatible = "openisa,rv32m1-gpio";
 			reg = <0x48020040 0x14>;
-			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
 			openisa,rv32m1-port = <&portb>;
@@ -354,7 +329,6 @@
 		gpioc: gpio@48020080 {
 			compatible = "openisa,rv32m1-gpio";
 			reg = <0x48020080 0x14>;
-			label = "GPIO_2";
 			gpio-controller;
 			#gpio-cells = <2>;
 			openisa,rv32m1-port = <&portc>;
@@ -363,7 +337,6 @@
 		gpiod: gpio@480200c0 {
 			compatible = "openisa,rv32m1-gpio";
 			reg = <0x480200c0 0x14>;
-			label = "GPIO_3";
 			gpio-controller;
 			#gpio-cells = <2>;
 			openisa,rv32m1-port = <&portd>;
@@ -372,7 +345,6 @@
 		gpioe: gpio@4100f000 {
 			compatible = "openisa,rv32m1-gpio";
 			reg = <0x4100f000 0x14>;
-			label = "GPIO_4";
 			gpio-controller;
 			#gpio-cells = <2>;
 			clocks = <&pcc1 0x3c>;
@@ -383,7 +355,6 @@
 			compatible = "openisa,rv32m1-lpuart";
 			reg = <0x40042000 0x2c>;
 			clocks = <&pcc0 0x108>;
-			label = "UART_0";
 			status = "disabled";
 		};
 
@@ -391,7 +362,6 @@
 			compatible = "openisa,rv32m1-lpuart";
 			reg = <0x40043000 0x2c>;
 			clocks = <&pcc0 0x10c>;
-			label = "UART_1";
 			status = "disabled";
 		};
 
@@ -399,7 +369,6 @@
 			compatible = "openisa,rv32m1-lpuart";
 			reg = <0x40044000 0x2c>;
 			clocks = <&pcc0 0x110>;
-			label = "UART_2";
 			status = "disabled";
 		};
 
@@ -407,7 +376,6 @@
 			compatible = "openisa,rv32m1-lpuart";
 			reg = <0x41036000 0x2c>;
 			clocks = <&pcc0 0xd8>;
-			label = "UART_3";
 			status = "disabled";
 		};
 
@@ -415,7 +383,6 @@
 			compatible = "openisa,rv32m1-lpi2c";
 			reg = <0x4003a000 0x170>;
 			clocks = <&pcc0 0xe8>;
-			label = "I2C_0";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -426,7 +393,6 @@
 			compatible = "openisa,rv32m1-lpi2c";
 			reg = <0x4003b000 0x170>;
 			clocks = <&pcc0 0xec>;
-			label = "I2C_1";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -437,7 +403,6 @@
 			compatible = "openisa,rv32m1-lpi2c";
 			reg = <0x4003c000 0x170>;
 			clocks = <&pcc0 0xf0>;
-			label = "I2C_2";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -448,7 +413,6 @@
 			compatible = "openisa,rv32m1-lpi2c";
 			reg = <0x4102e000 0x170>;
 			clocks = <&pcc1 0xb8>;
-			label = "I2C_3";
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -458,7 +422,6 @@
 		lpspi0: spi@4003f000 {
 			compatible = "openisa,rv32m1-lpspi";
 			reg = <0x4003f000 0x78>;
-			label = "SPI_0";
 			status = "disabled";
 			clocks = <&pcc0 0xfc>;
 			#address-cells = <1>;
@@ -468,7 +431,6 @@
 		lpspi1: spi@40040000 {
 			compatible = "openisa,rv32m1-lpspi";
 			reg = <0x40040000 0x78>;
-			label = "SPI_1";
 			status = "disabled";
 			clocks = <&pcc0 0x100>;
 			#address-cells = <1>;
@@ -478,7 +440,6 @@
 		lpspi2: spi@40041000 {
 			compatible = "openisa,rv32m1-lpspi";
 			reg = <0x40041000 0x78>;
-			label = "SPI_2";
 			status = "disabled";
 			clocks = <&pcc0 0x104>;
 			#address-cells = <1>;
@@ -488,7 +449,6 @@
 		lpspi3: spi@41035000 {
 			compatible = "openisa,rv32m1-lpspi";
 			reg = <0x41035000 0x78>;
-			label = "SPI_3";
 			status = "disabled";
 			clocks = <&pcc1 0xd4>;
 			#address-cells = <1>;
@@ -506,7 +466,6 @@
 			compatible = "openisa,rv32m1-tpm";
 			reg = <0x40035000 0x88>;
 			clocks = <&pcc0 0xd4>;
-			label = "PWM_0";
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -515,7 +474,6 @@
 			compatible = "openisa,rv32m1-tpm";
 			reg = <0x40036000 0x88>;
 			clocks = <&pcc0 0xd8>;
-			label = "PWM_1";
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -524,7 +482,6 @@
 			compatible = "openisa,rv32m1-tpm";
 			reg = <0x40037000 0x88>;
 			clocks = <&pcc0 0xdc>;
-			label = "PWM_2";
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
@@ -534,21 +491,18 @@
 			reg = <0x41029000 0x1000>;
 			status = "okay";
 			interrupts = <13 0>;
-			label = "TRNG";
 		};
 
 		tpm3: pwm@4102d000 {
 			compatible = "openisa,rv32m1-tpm";
 			reg = <0x4102d000 0x88>;
 			clocks = <&pcc1 0xb4>;
-			label = "PWM_3";
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
 
 		ftfe: flash-controller@40023000 {
 			compatible = "openisa,rv32m1-ftfe";
-			label = "FLASH_CTRL";
 			reg = <0x40023000 0x18>;
 
 			#address-cells = <1>;
@@ -556,7 +510,6 @@
 
 			m4_flash: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "M4_FLASH";
 				reg = <0 0x100000>;
 				erase-block-size = <4096>;
 				write-block-size = <8>;
@@ -564,7 +517,6 @@
 
 			m0_flash: flash@1000000 {
 				compatible = "soc-nv-flash";
-				label = "M0_FLASH";
 				reg = <0x01000000 0x40000>;
 				erase-block-size = <4096>;
 				write-block-size = <8>;

--- a/dts/riscv/openisa/rv32m1_ri5cy.dtsi
+++ b/dts/riscv/openisa/rv32m1_ri5cy.dtsi
@@ -28,12 +28,10 @@
 		 */
 
 		ri5cy_code_partition: partition@0 {
-			label = "ri5cy-code";
 			reg = <0x00000000 0x000fff00>;
 		};
 
 		ri5cy_vector_partition: partition@fff00 {
-			label = "ri5cy-vector";
 			reg = <0x000fff00 0x100>;
 		};
 	};

--- a/dts/riscv/openisa/rv32m1_zero_riscy.dtsi
+++ b/dts/riscv/openisa/rv32m1_zero_riscy.dtsi
@@ -28,12 +28,10 @@
 		 */
 
 		zero_riscy_code_partition: partition@1000000 {
-			label = "zero-riscy-code";
 			reg = <0x01000000 0x0003ff00>;
 		};
 
 		zero_riscy_vector_partition: partition@3ff00 {
-			label = "zero-riscy-vector";
 			reg = <0x0003ff00 0x100>;
 		};
 	};

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -63,7 +63,6 @@
 				"ev_enable",
 				"txempty",
 				"rxfull";
-			label = "uart0";
 			status = "disabled";
 		};
 		spi0: spi@e0002000 {
@@ -80,7 +79,6 @@
 				"miso",
 				"cs",
 				"loopback";
-			label = "spi0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -110,7 +108,6 @@
 				"ev_enable",
 				"uptime_latch",
 				"uptime_cycles";
-			label = "timer0";
 			status = "disabled";
 		};
 		eth0: ethernet@e0009800 {
@@ -148,7 +145,6 @@
 				"tx_ev_pending",
 				"tx_ev_enable",
 				"buffers";
-			label = "eth0";
 			status = "disabled";
 		};
 		dna0: dna@e0003800 {
@@ -160,14 +156,12 @@
 			hence 8 registers. */
 			reg = <0xe0003800 0x20>;
 			reg-names = "mem";
-			label = "dna0";
 			status = "disabled";
 		};
 		i2c0: i2c@e0005000 {
 			compatible = "litex,i2c";
 			reg = <0xe0005000 0x4 0xe0005004 0x4>;
 			reg-names = "write", "read";
-			label = "i2c0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -177,7 +171,6 @@
 			reg = <0xe0005800 0x4>;
 			reg-names = "control";
 			ngpios = <4>;
-			label = "gpio_out";
 			port-is-output;
 			status = "disabled";
 			gpio-controller;
@@ -198,7 +191,6 @@
 				"irq_pend",
 				"irq_en";
 			ngpios = <4>;
-			label = "gpio_in";
 			status = "disabled";
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -207,14 +199,12 @@
 			compatible = "litex,prbs";
 			reg = <0xe0006800 0x4>;
 			reg-names = "status";
-			label = "prbs0";
 			status = "disabled";
 		};
 		pwm0: pwm@e0007000 {
 			compatible = "litex,pwm";
 			reg = <0xe0007000 0x4 0xe0007004 0x10 0xe0007014 0x10>;
 			reg-names = "enable", "width", "period";
-			label = "pwm0";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -239,7 +229,6 @@
 				"rx_conf",
 				"fifo";
 			fifo_depth = <256>;
-			label = "i2s_rx";
 			status = "disabled";
 		};
 		i2s_tx: i2s_tx@e000b000 {
@@ -263,7 +252,6 @@
 				"tx_conf",
 				"fifo";
 			fifo_depth = <256>;
-			label = "i2s_tx";
 			status = "disabled";
 		};
 		clock-outputs {
@@ -298,7 +286,6 @@
 		};
 		clock0: clock@e0004800 {
 			compatible = "litex,clk";
-			label = "clock0";
 			reg = <0xe0004800 0x4
 				0xe0004804 0x4
 				0xe0004808 0x4

--- a/dts/riscv/sifive/riscv32-fe310.dtsi
+++ b/dts/riscv/sifive/riscv32-fe310.dtsi
@@ -52,7 +52,6 @@
 			interrupts = <1 1>;
 			reg = <0x10000000 0x40>;
 			reg-names = "control";
-			label = "WDOG0";
 		};
 		aon: aon@10000040 {
 			compatible = "sifive,aon0";
@@ -100,7 +99,6 @@
 				<36 1>, <37 1>, <38 1>, <39 1>;
 			reg = <0x10012000 0x1000>;
 			reg-names = "control";
-			label = "gpio_0";
 			status = "disabled";
 			#gpio-cells = <2>;
 
@@ -119,7 +117,6 @@
 			interrupts = <52 1>;
 			reg = <0x10016000 0x1000>;
 			reg-names = "control";
-			label = "i2c_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -158,7 +155,6 @@
 			interrupts = <40 1>, <41 1>, <42 1>, <43 1>;
 			reg = <0x10015000 0x1000>;
 			reg-names = "control";
-			label = "pwm_0";
 			status = "disabled";
 			sifive,compare-width = <8>;
 			#pwm-cells = <2>;
@@ -169,7 +165,6 @@
 			interrupts = <44 1>, <45 1>, <46 1>, <47 1>;
 			reg = <0x10025000 0x1000>;
 			reg-names = "control";
-			label = "pwm_1";
 			status = "disabled";
 			sifive,compare-width = <16>;
 			#pwm-cells = <2>;
@@ -180,7 +175,6 @@
 			interrupts = <48 1>, <49 1>, <50 1>, <51 1>;
 			reg = <0x10035000 0x1000>;
 			reg-names = "control";
-			label = "pwm_2";
 			status = "disabled";
 			sifive,compare-width = <16>;
 			#pwm-cells = <2>;
@@ -201,7 +195,6 @@
 			interrupts = <3 1>;
 			reg = <0x10013000 0x1000>;
 			reg-names = "control";
-			label = "uart_0";
 			status = "disabled";
 		};
 		uart1: serial@10023000 {
@@ -210,7 +203,6 @@
 			interrupts = <4 1>;
 			reg = <0x10023000 0x1000>;
 			reg-names = "control";
-			label = "uart_1";
 			status = "disabled";
 		};
 		spi0: spi@10014000 {
@@ -219,7 +211,6 @@
 			interrupts = <5 1>;
 			reg = <0x10014000 0x1000 0x20000000 0x20000000>;
 			reg-names = "control", "mem";
-			label = "spi_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -230,7 +221,6 @@
 			interrupts = <6 1>;
 			reg = <0x10024000 0x1000>;
 			reg-names = "control";
-			label = "spi_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -241,7 +231,6 @@
 			interrupts = <7 1>;
 			reg = <0x10034000 0x1000>;
 			reg-names = "control";
-			label = "spi_2";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/sifive/riscv64-fu540.dtsi
+++ b/dts/riscv/sifive/riscv64-fu540.dtsi
@@ -138,7 +138,6 @@
 			interrupts = <4 1>;
 			reg = <0x10010000 0x1000>;
 			reg-names = "control";
-			label = "uart_0";
 			status = "disabled";
 		};
 
@@ -148,7 +147,6 @@
 			interrupts = <5 1>;
 			reg = <0x10011000 0x1000>;
 			reg-names = "control";
-			label = "uart_1";
 			status = "disabled";
 		};
 
@@ -158,7 +156,6 @@
 			interrupts = <51 1>;
 			reg = <0x10040000 0x1000 0x20000000 0x10000000>;
 			reg-names = "control", "mem";
-			label = "spi_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -170,7 +167,6 @@
 			interrupts = <52 1>;
 			reg = <0x10041000 0x1000>;
 			reg-names = "control";
-			label = "spi_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -182,7 +178,6 @@
 			interrupts = <6 1>;
 			reg = <0x10050000 0x1000>;
 			reg-names = "control";
-			label = "spi_2";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -198,7 +193,6 @@
 				<19 1>, <20 1>, <21 1>, <22 1>;
 			reg = <0x10060000 0x1000>;
 			reg-names = "control";
-			label = "gpio_0";
 			status = "disabled";
 			#gpio-cells = <2>;
 

--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -108,7 +108,6 @@
 			interrupts = <39 1>;
 			reg = <0x10010000 0x1000>;
 			reg-names = "control";
-			label = "uart_0";
 			status = "disabled";
 		};
 
@@ -118,7 +117,6 @@
 			interrupts = <40 1>;
 			reg = <0x10011000 0x1000>;
 			reg-names = "control";
-			label = "uart_1";
 			status = "disabled";
 		};
 
@@ -128,7 +126,6 @@
 			interrupts = <41 1>;
 			reg = <0x10040000 0x1000 0x20000000 0x10000000>;
 			reg-names = "control", "mem";
-			label = "spi_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -140,7 +137,6 @@
 			interrupts = <42 1>;
 			reg = <0x10041000 0x1000>;
 			reg-names = "control";
-			label = "spi_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -152,7 +148,6 @@
 			interrupts = <43 1>;
 			reg = <0x10050000 0x1000>;
 			reg-names = "control";
-			label = "spi_2";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
+++ b/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
@@ -145,7 +145,6 @@
 			compatible = "ns16550", "snps,dw-apb-uart";
 			interrupt-parent = <&plic>;
 			interrupts = <73 1>;
-			label = "UART_3";
 			reg = <0x0 0x12440000 0x0 0x10000>;
 			reg-shift = <2>;
 			clocks = <&uartclk>, <&apb2clk>;
@@ -159,7 +158,6 @@
 			compatible = "ns16550", "snps,dw-apb-uart";
 			interrupt-parent = <&plic>;
 			interrupts = <72 1>;
-			label = "UART_2";
 			reg = <0x0 0x12430000 0x0 0x10000>;
 			reg-shift = <2>;
 			clocks = <&uartclk>, <&apb2clk>;
@@ -173,7 +171,6 @@
 			compatible = "ns16550", "snps,dw-apb-uart";
 			interrupt-parent = <&plic>;
 			interrupts = <93 1>;
-			label = "UART_1";
 			reg = <0x0 0x11880000 0x0 0x10000>;
 			reg-shift = <2>;
 			clocks = <&hs_uartclk>, <&apb1clk>;
@@ -187,7 +184,6 @@
 			compatible = "ns16550", "snps,dw-apb-uart";
 			interrupt-parent = <&plic>;
 			interrupts = <92 1>;
-			label = "UART_0";
 			reg = <0x0 0x11870000 0x0 0x10000>;
 			reg-shift = <2>;
 			clocks = <&hs_uartclk>, <&apb1clk>;

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -42,7 +42,6 @@
 
 		flash_mspi: flash-controller@80140100 {
 			compatible = "telink,b91-flash-controller";
-			label = "FLASH_MSPI";
 			reg = <0x80140100 0x40>;
 
 			#address-cells = <1>;
@@ -68,7 +67,6 @@
 			interrupt-parent = <&plic0>;
 			interrupts = <25 1>, <26 1>, <27 1>;
 			reg = <0x80140300 0x08>;
-			label = "GPIO_A";
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
@@ -79,7 +77,6 @@
 			interrupt-parent = <&plic0>;
 			interrupts = <25 1>, <26 1>, <27 1>;
 			reg = <0x80140308 0x08>;
-			label = "GPIO_B";
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
@@ -90,7 +87,6 @@
 			interrupt-parent = <&plic0>;
 			interrupts = <25 1>, <26 1>, <27 1>;
 			reg = <0x80140310 0x08>;
-			label = "GPIO_C";
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
@@ -101,7 +97,6 @@
 			interrupt-parent = <&plic0>;
 			interrupts = <25 1>, <26 1>, <27 1>;
 			reg = <0x80140318 0x08>;
-			label = "GPIO_D";
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
@@ -112,7 +107,6 @@
 			interrupt-parent = <&plic0>;
 			interrupts = <25 1>, <26 1>, <27 1>;
 			reg = <0x80140320 0x08>;
-			label = "GPIO_E";
 			status = "disabled";
 			#gpio-cells = <2>;
 		};
@@ -132,7 +126,6 @@
 
 		uart0: serial@80140080 {
 			compatible = "telink,b91-uart";
-			label = "UART_0";
 			reg = <0x80140080 0x40>;
 			interrupts = <19 1>;
 			interrupt-parent = <&plic0>;
@@ -141,7 +134,6 @@
 
 		uart1: serial@801400C0 {
 			compatible = "telink,b91-uart";
-			label = "UART_1";
 			reg = <0x801400C0 0x40>;
 			interrupts = <18 1>;
 			interrupt-parent = <&plic0>;
@@ -151,7 +143,6 @@
 		ieee802154: ieee802154@80140800 {
 			compatible = "telink,b91-zb";
 			reg = <0x80140800 0x800>;
-			label = "IEEE802154";
 			interrupt-parent = <&plic0>;
 			interrupts = <15 2>;
 			status = "disabled";
@@ -160,7 +151,6 @@
 		trng0: trng@80101800 {
 			compatible = "telink,b91-trng";
 			reg = <0x80101800 0x20>;
-			label = "TRNG";
 			status = "disabled";
 		};
 
@@ -168,14 +158,12 @@
 			compatible = "telink,b91-pwm";
 			reg = <0x80140400 0x80>;
 			channels = <6>;
-			label = "PWM";
 			status = "disabled";
 			#pwm-cells = <3>;
 		};
 
 		hspi: spi@81FFFFC0 {
 			compatible = "telink,b91-spi";
-			label = "HSPI";
 			reg = <0x81FFFFC0 0x40>;
 			peripheral-id = "HSPI_MODULE";
 			cs0-pin = "0";
@@ -188,7 +176,6 @@
 
 		pspi: spi@80140040 {
 			compatible = "telink,b91-spi";
-			label = "PSPI";
 			reg = <0x80140040 0x40>;
 			peripheral-id = "PSPI_MODULE";
 			cs0-pin = "0";
@@ -201,7 +188,6 @@
 
 		i2c: i2c@80140280 {
 			compatible = "telink,b91-i2c";
-			label = "I2C";
 			reg = <0x80140280 0x40>;
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -211,7 +197,6 @@
 
 		adc: adc@ea {
 			compatible = "telink,b91-adc";
-			label = "ADC";
 			reg = <0xea 0x18>;
 			status = "disabled";
 			#io-channel-cells = <1>;
@@ -225,7 +210,6 @@
 			reg-names = "pin_mux",
 						"gpio_en",
 						"pull_up_en";
-			label = "PINCTRL";
 			status = "okay";
 		};
 	};

--- a/dts/riscv/virt.dtsi
+++ b/dts/riscv/virt.dtsi
@@ -31,7 +31,6 @@
 		reg = < 0x10000000 0x100 >;
 		compatible = "ns16550";
 		reg-shift = < 0 >;
-		label = "UART_0";
 	};
 
 	cpus {


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>