### PR TITLE
dts: nios2: Remove label property from devicetrees

### DIFF
--- a/dts/nios2/intel/nios2-qemu.dtsi
+++ b/dts/nios2/intel/nios2-qemu.dtsi
@@ -36,7 +36,6 @@
 		jtag_uart: uart@201000 {
 			compatible = "altr,jtag-uart";
 			reg = <0x201000 0x400>;
-			label = "jtag_uart0";
 
 			status = "disabled";
 		};
@@ -46,7 +45,6 @@
 			reg = <0x440000 0x400>;
 			interrupts = <1>;
 			clock-frequency = <50000000>;
-			label = "UART_0";
 			reg-shift = <2>;
 			status = "disabled";
 		};

--- a/dts/nios2/intel/nios2f.dtsi
+++ b/dts/nios2/intel/nios2f.dtsi
@@ -39,7 +39,6 @@
 			reg = <0x100000 0x400>;
 			clock-frequency = <50000000>;
 			interrupts = <1 0>;
-			label = "UART_0";
 			reg-shift = <2>;
 			status = "disabled";
 		};
@@ -47,7 +46,6 @@
 		jtag_uart: uart@201000 {
 			compatible = "altr,jtag-uart";
 			reg = <0x201000 0x8>;
-			label = "JTAG_UART";
 
 			status = "disabled";
 		};
@@ -59,13 +57,11 @@
 			#size-cells = <0>;
 			reg = <0x100200 0x400>;
 			interrupts = <4 10>;
-			label = "I2C_0";
 		};
 
 		dma: dma@100200 {
 			compatible = "altr,msgdma";
 			reg = <0x1002c0 0x30>;
-			label = "DMA_0";
 			interrupts = <3 3>;
 			#dma-cells = <0>;
 		};


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>