### PR TITLE
tests: x86: Convert to test to use use DEVICE_DT_GET_ONE

### DIFF
--- a/tests/arch/x86/info/src/timer.c
+++ b/tests/arch/x86/info/src/timer.c
@@ -48,9 +48,10 @@ void timer(void)
 		sys_clock_hw_cycles_per_sec());
 
 #if defined(CONFIG_COUNTER_CMOS)
-	const struct device *cmos = device_get_binding("CMOS");
-	if (cmos == NULL) {
-		printk("\tCan't get reference CMOS clock device.\n");
+	const struct device *cmos = DEVICE_DT_GET_ONE(motorola_mc146818);
+
+	if (!device_is_ready(cmos)) {
+		printk("\tCMOS clock device is not ready.\n");
 	} else {
 		uint64_t sum = 0;
 


### PR DESCRIPTION
Update test to use DEVICE_DT_GET_ONE to remove usage of
device_get_binding.

Signed-off-by: Kumar Gala <galak@kernel.org>