### PR TITLE
mgmt: osdp: Move to DTS for uart device

### DIFF
--- a/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
+++ b/boards/arm/stm32_min_dev/stm32_min_dev_black.yaml
@@ -12,3 +12,4 @@ supported:
   - pwm
   - spi
   - adc
+  - gpio

--- a/doc/build/dts/api/api.rst
+++ b/doc/build/dts/api/api.rst
@@ -421,6 +421,8 @@ device.
      - Instruction Tightly Coupled Memory node on some Arm SoCs
    * - zephyr,ocm
      - On-chip memory node on Xilinx Zynq-7000 and ZynqMP SoCs
+   * - zephyr,osdp-uart
+     - Sets UART device used by OSDP subsystem
    * - zephyr,ot-uart
      - Used by the OpenThread to specify UART device for Spinel protocol
    * - zephyr,pcie-controller

--- a/samples/subsys/mgmt/osdp/control_panel/sample.yaml
+++ b/samples/subsys/mgmt/osdp/control_panel/sample.yaml
@@ -5,7 +5,8 @@ tests:
   sample.mgmt.osdp.control_panel:
     tags: osdp
     depends_on: gpio
-    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and CONFIG_SERIAL
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
+            dt_chosen_enabled("zephyr,osdp-uart") and CONFIG_SERIAL
     harness: osdp
     integration_platforms:
-      - frdm_k64f
+      - stm32_min_dev_black

--- a/samples/subsys/mgmt/osdp/peripheral_device/sample.yaml
+++ b/samples/subsys/mgmt/osdp/peripheral_device/sample.yaml
@@ -5,7 +5,8 @@ tests:
   sample.mgmt.osdp.peripheral_device:
     tags: osdp
     depends_on: gpio
-    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and CONFIG_SERIAL
+    filter: dt_enabled_alias_with_parent_compat("led0", "gpio-leds") and
+            dt_chosen_enabled("zephyr,osdp-uart") and CONFIG_SERIAL
     harness: osdp
     integration_platforms:
-      - frdm_k64f
+      - stm32_min_dev_black

--- a/subsys/mgmt/osdp/Kconfig
+++ b/subsys/mgmt/osdp/Kconfig
@@ -26,17 +26,6 @@ choice
 		  Configure this device to operate as a CP (Control Panel)
 endchoice
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_OSDP_UART := zephyr,osdp-uart
-
-config OSDP_UART_DEV_NAME
-	string "Device name of UART device for OSDP"
-	default "$(dt_chosen_label,$(DT_CHOSEN_Z_OSDP_UART))" if HAS_DTS
-	default "UART_2"
-	help
-	  This option specifies the name of UART device to be used for
-	  OSDP
-
 config OSDP_UART_BAUD_RATE
 	int "OSDP UART baud rate"
 	default 115200

--- a/subsys/mgmt/osdp/src/osdp.c
+++ b/subsys/mgmt/osdp/src/osdp.c
@@ -199,9 +199,9 @@ static int osdp_init(const struct device *arg)
 	ring_buf_init(&p->tx_buf, sizeof(p->tx_fbuf), p->tx_fbuf);
 
 	/* init OSDP uart device */
-	p->dev = device_get_binding(CONFIG_OSDP_UART_DEV_NAME);
-	if (p->dev == NULL) {
-		LOG_ERR("Failed to get UART dev binding");
+	p->dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_osdp_uart));
+	if (!device_is_ready(p->dev)) {
+		LOG_ERR("UART dev is not ready");
 		k_panic();
 	}
 


### PR DESCRIPTION
Move from using Kconfig OSDP_UART_DEV_NAME to a devicetree
chosen property ("zephyr,osdp-uart").  This is similar to a number
of other functions like "zephyr,shell-uart" or "zephyr,bt-uart".

Signed-off-by: Kumar Gala <galak@kernel.org>