### PR TITLE
drivers: gpio: Add IGPIO compatible binding

### DIFF
--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT nxp_imx_gpio
+#define DT_DRV_COMPAT nxp_imx_igpio
 
 #include <errno.h>
 #include <zephyr/device.h>

--- a/dts/arm/nxp/nxp_imx8m_m4.dtsi
+++ b/dts/arm/nxp/nxp_imx8m_m4.dtsi
@@ -62,7 +62,7 @@
 		};
 
 		gpio1: gpio@30200000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30200000 DT_SIZE_K(64)>;
 			interrupts = <64 0>, <65 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -76,7 +76,7 @@
 		};
 
 		gpio2: gpio@30210000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30210000 DT_SIZE_K(64)>;
 			interrupts = <66 0>, <67 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -90,7 +90,7 @@
 		};
 
 		gpio3: gpio@30220000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30220000 DT_SIZE_K(64)>;
 			interrupts = <68 0>, <69 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -104,7 +104,7 @@
 		};
 
 		gpio4: gpio@30230000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30230000 DT_SIZE_K(64)>;
 			interrupts = <70 0>, <71 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -118,7 +118,7 @@
 		};
 
 		gpio5: gpio@30240000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30240000 DT_SIZE_K(64)>;
 			interrupts = <72 0>, <73 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\

--- a/dts/arm/nxp/nxp_imx8ml_m7.dtsi
+++ b/dts/arm/nxp/nxp_imx8ml_m7.dtsi
@@ -98,7 +98,7 @@
 		};
 
 		gpio1: gpio@30200000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30200000 DT_SIZE_K(64)>;
 			interrupts = <64 0>, <65 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -112,7 +112,7 @@
 		};
 
 		gpio2: gpio@30210000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30210000 DT_SIZE_K(64)>;
 			interrupts = <66 0>, <67 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -126,7 +126,7 @@
 		};
 
 		gpio3: gpio@30220000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30220000 DT_SIZE_K(64)>;
 			interrupts = <68 0>, <69 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -140,7 +140,7 @@
 		};
 
 		gpio4: gpio@30230000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30230000 DT_SIZE_K(64)>;
 			interrupts = <70 0>, <71 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\
@@ -154,7 +154,7 @@
 		};
 
 		gpio5: gpio@30240000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x30240000 DT_SIZE_K(64)>;
 			interrupts = <72 0>, <73 0>;
 			rdc = <(RDC_DOMAIN_PERM(A7_DOMAIN_ID,\

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -275,7 +275,7 @@
 		};
 
 		gpio1: gpio@401b8000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x401b8000 0x4000>;
 			interrupts = <80 0>, <81 0>;
 			label = "GPIO_1";
@@ -284,7 +284,7 @@
 		};
 
 		gpio2: gpio@401bc000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x401bc000 0x4000>;
 			interrupts = <82 0>, <83 0>;
 			label = "GPIO_2";
@@ -293,7 +293,7 @@
 		};
 
 		gpio3: gpio@401c0000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x401c0000 0x4000>;
 			interrupts = <84 0>, <85 0>;
 			label = "GPIO_3";
@@ -302,7 +302,7 @@
 		};
 
 		gpio4: gpio@401c4000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x401c4000 0x4000>;
 			interrupts = <86 0>, <87 0>;
 			label = "GPIO_4";
@@ -311,7 +311,7 @@
 		};
 
 		gpio5: gpio@400c0000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x400c0000 0x4000>;
 			interrupts = <88 0>, <89 0>;
 			label = "GPIO_5";
@@ -323,7 +323,7 @@
 		 * by the gpio driver.
 		 */
 		gpio6: gpio@42000000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x42000000 0x4000>;
 			label = "GPIO_6";
 			gpio-controller;
@@ -331,7 +331,7 @@
 		};
 
 		gpio7: gpio@42004000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x42004000 0x4000>;
 			label = "GPIO_7";
 			gpio-controller;
@@ -339,7 +339,7 @@
 		};
 
 		gpio8: gpio@42008000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x42008000 0x4000>;
 			label = "GPIO_8";
 			gpio-controller;
@@ -347,7 +347,7 @@
 		};
 
 		gpio9: gpio@4200c000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x4200c000 0x4000>;
 			label = "GPIO_9";
 			gpio-controller;

--- a/dts/arm/nxp/nxp_rt1010.dtsi
+++ b/dts/arm/nxp/nxp_rt1010.dtsi
@@ -77,7 +77,7 @@
 		/delete-node/ gpio@401bc000;
 
 		gpio2: gpio@42000000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x42000000 0x4000>;
 			interrupts = <72 0>;
 			label = "GPIO_2";

--- a/dts/arm/nxp/nxp_rt1160_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm4.dtsi
@@ -38,7 +38,7 @@
 		 * GPIO3, see pg. 1364 of RT1160 ref manual for example
 		 */
 		gpio2: gpio@40130000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40130000 0x4000>;
 			interrupts = <102 0>, <103 0>;
 			label = "GPIO_2";
@@ -47,7 +47,7 @@
 		};
 
 		gpio3: gpio@40134000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40134000 0x4000>;
 			interrupts = <104 0>, <105 0>;
 			label = "GPIO_3";

--- a/dts/arm/nxp/nxp_rt1160_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1160_cm7.dtsi
@@ -46,7 +46,7 @@
 		 * GPIO3, see pg. 1460 of RT1160 ref manual for example
 		 */
 		gpio2: gpio@42008000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x42008000 0x4000>;
 			interrupts = <102 0>, <103 0>;
 			label = "GPIO_2";
@@ -55,7 +55,7 @@
 		};
 
 		gpio3: gpio@4200c000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x4200c000 0x4000>;
 			interrupts = <104 0>, <105 0>;
 			label = "GPIO_3";

--- a/dts/arm/nxp/nxp_rt1170_cm4.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm4.dtsi
@@ -38,7 +38,7 @@
 		 * GPIO3, see pg. 1410 of RT1170 ref manual for example
 		 */
 		gpio2: gpio@40130000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40130000 0x4000>;
 			interrupts = <102 0>, <103 0>;
 			label = "GPIO_2";
@@ -47,7 +47,7 @@
 		};
 
 		gpio3: gpio@40134000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40134000 0x4000>;
 			interrupts = <104 0>, <105 0>;
 			label = "GPIO_3";

--- a/dts/arm/nxp/nxp_rt1170_cm7.dtsi
+++ b/dts/arm/nxp/nxp_rt1170_cm7.dtsi
@@ -46,7 +46,7 @@
 		 * GPIO3, see pg. 1460 of RT1170 ref manual for example
 		 */
 		gpio2: gpio@42008000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x42008000 0x4000>;
 			interrupts = <102 0>, <103 0>;
 			label = "GPIO_2";
@@ -55,7 +55,7 @@
 		};
 
 		gpio3: gpio@4200c000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x4200c000 0x4000>;
 			interrupts = <104 0>, <105 0>;
 			label = "GPIO_3";

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -177,7 +177,7 @@
 		};
 
 		gpio1: gpio@4012c000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x4012c000 0x4000>;
 			interrupts = <100 0>, <101 0>;
 			label = "GPIO_1";
@@ -192,7 +192,7 @@
 		 */
 
 		gpio4: gpio@40138000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40138000 0x4000>;
 			interrupts = <106 0>, <107 0>;
 			label = "GPIO_4";
@@ -201,7 +201,7 @@
 		};
 
 		gpio5: gpio@4013c000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x4013c000 0x4000>;
 			interrupts = <108 0>, <109 0>;
 			label = "GPIO_5";
@@ -210,7 +210,7 @@
 		};
 
 		gpio6: gpio@40140000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40140000 0x4000>;
 			label = "GPIO_6";
 			gpio-controller;
@@ -218,7 +218,7 @@
 		};
 
 		gpio7: gpio@40c5c000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40c5c000 0x4000>;
 			label = "GPIO_7";
 			gpio-controller;
@@ -226,7 +226,7 @@
 		};
 
 		gpio8: gpio@40c60000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40c60000 0x4000>;
 			label = "GPIO_8";
 			gpio-controller;
@@ -234,7 +234,7 @@
 		};
 
 		gpio9: gpio@40c64000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40c64000 0x4000>;
 			label = "GPIO_9";
 			gpio-controller;
@@ -242,7 +242,7 @@
 		};
 
 		gpio10: gpio@40c68000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40c68000 0x4000>;
 			label = "GPIO_10";
 			gpio-controller;
@@ -250,7 +250,7 @@
 		};
 
 		gpio11: gpio@40c6c000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40c6c000 0x4000>;
 			label = "GPIO_11";
 			gpio-controller;
@@ -258,7 +258,7 @@
 		};
 
 		gpio12: gpio@40c70000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40c70000 0x4000>;
 			label = "GPIO_12";
 			gpio-controller;
@@ -266,7 +266,7 @@
 		};
 
 		gpio13: gpio@40ca0000 {
-			compatible = "nxp,imx-gpio";
+			compatible = "nxp,imx-igpio";
 			reg = <0x40ca0000 0x4000>;
 			interrupts = <93 0>;
 			label = "GPIO_13";

--- a/dts/bindings/gpio/nxp,imx-igpio.yaml
+++ b/dts/bindings/gpio/nxp,imx-igpio.yaml
@@ -1,0 +1,37 @@
+# Copyright 2022, NXP
+# SPDX-License-Identifier: Apache-2.0
+
+description: i.MX IGPIO node
+
+compatible: "nxp,imx-igpio"
+
+include: [gpio-controller.yaml, base.yaml]
+
+properties:
+    reg:
+      required: true
+
+    interrupts:
+      required: false
+
+    rdc:
+     type: int
+     required: false
+     description: Set the RDC permission for this peripheral
+
+    pinmux:
+      type: phandles
+      required: false
+      description: |
+        IMX pin selection peripheral does not follow specific
+        pattern for which GPIO port uses which pinmux. Use this property to specify
+        pinctrl nodes to use for the gpio port when CONFIG_PINCTRL=y. Note that
+        the order of the nodes matters. The first node for gpio1 will be used
+        as the pinmux for gpio0, port 0.
+
+    "#gpio-cells":
+      const: 2
+
+gpio-cells:
+  - pin
+  - flags


### PR DESCRIPTION
Separate out GPIO and IGPIO drivers into separate compatible bindings. This would enable generating separate devicetree Kconfig symbols

