### PR TITLE
lib: os: Fix warning on XCC

### DIFF
--- a/lib/os/fdtable.c
+++ b/lib/os/fdtable.c
@@ -53,7 +53,9 @@ static struct fd_entry fdtable[CONFIG_POSIX_MAX_FDS] = {
 		.refcount = ATOMIC_INIT(1)
 	},
 #else
+	{
 	0
+	},
 #endif
 };
 


### PR DESCRIPTION
xcc compiler complains about how fdtable variable is initialized:
"""
warning: missing braces around initialize
"""

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>