### PR TITLE
intel_adsp: cavs: Add variables used in coredump

### DIFF
--- a/soc/xtensa/intel_adsp/ace_v1x/ace-link.ld
+++ b/soc/xtensa/intel_adsp/ace_v1x/ace-link.ld
@@ -302,6 +302,7 @@ SECTIONS {
     *(.xt_except_desc_end)
     *(.dynamic)
     *(.gnu.version_d)
+    _image_ram_start = .;
     _bss_table_start = .;
     LONG(_bss_start)
     LONG(_bss_end)
@@ -439,6 +440,7 @@ SECTIONS {
     _dma_buf_start = .;
     *(.dma_buffers)
     _dma_buf_end = .;
+    _image_ram_end = .;
   } >lpram
 
   /* Non-loadable sections below.  Back to cached memory so

--- a/soc/xtensa/intel_adsp/common/include/cavs-link.ld
+++ b/soc/xtensa/intel_adsp/common/include/cavs-link.ld
@@ -302,6 +302,7 @@ SECTIONS {
     *(.xt_except_desc_end)
     *(.dynamic)
     *(.gnu.version_d)
+    _image_ram_start = .;
     _bss_table_start = .;
     LONG(_bss_start)
     LONG(_bss_end)
@@ -423,6 +424,7 @@ SECTIONS {
     _dma_buf_start = .;
     *(.dma_buffers)
     _dma_buf_end = .;
+    _image_ram_end = .;
   } >lpram
 
   /* Non-loadable sections below.  Back to cached memory so


### PR DESCRIPTION
In order to coredump dump the ram memory, it is necessary that we define
in the linker scripts two variable to indicate the start and the end of
the ram area. Adding these variables to cavs linker script.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>