### PR TITLE
test: flash: fix nrf52840dk_mx25l51245g test variant

### DIFF
--- a/tests/drivers/flash/boards/nrf52840dk_mx25l51245g.overlay
+++ b/tests/drivers/flash/boards/nrf52840dk_mx25l51245g.overlay
@@ -4,6 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+/ {
+	aliases {
+		spi-flash0 = &mx25l51;
+	};
+};
+
 /delete-node/ &mx25r64;
 
 &pinctrl {


### PR DESCRIPTION
The SPI flash were recently changed to use an alias to identify the
flash chip in:

64fbbd9a44 boards: Add alias to boards with spi-flash node

This caused some CI test failure for the nrf52840dk test with the
nrf52840dk_mx25l51245g overlay, as it changes the flash nodelabel of the
board dts file. Adding the correct alias to the overlay file to point tonrf52840dk_mx25l51245g
the correct one.