### PR TITLE
scripts: requirements: extras: Suitable clang-format version

### DIFF
--- a/scripts/requirements-extras.txt
+++ b/scripts/requirements-extras.txt
@@ -10,7 +10,7 @@ gitlint
 junit2html
 
 # helper for developers - code formatter
-clang-format>=1.12x
+clang-format>=1.13x
 
 # Script used to build firmware images for NXP LPC MCUs.
 lpc_checksum


### PR DESCRIPTION
Even when BreakBeforeBraces is set to Linux, implying BraceWrapping for
AfterEnum to be true, clang-format version 12 puts the opening brace of
an enum declaration on a new line. [1]

One possible workaround would be to change AllowShortEnumsOnASingleLine
from false to true, but that would yield a different kind of unwanted
formatting.

clang-format version 13 and newer have this issue fixed, therefore
bumping the minimal version.

[1] https://github.com/llvm/llvm-project/issues/48983