### PR TITLE
sensors: remove defconfig setting of sensor drivers

### DIFF
--- a/boards/arm/frdm_k64f/Kconfig.defconfig
+++ b/boards/arm/frdm_k64f/Kconfig.defconfig
@@ -20,10 +20,6 @@ config MCG_VDIV0
 config MCG_FCRDIV
 	default 1
 
-config TEMP_KINETIS
-	default y if "$(dt_nodelabel_enabled,adc1)"
-	depends on SENSOR && ADC
-
 config I2C
 	default y if SENSOR
 

--- a/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
+++ b/boards/arm/mec1501modular_assy6885/Kconfig.defconfig
@@ -39,8 +39,4 @@ config SYS_CLOCK_TICKS_PER_SEC
 
 endif # RTOS_TIMER
 
-config TACH_XEC
-	default y
-	depends on SENSOR
-
 endif # BOARD_MEC1501MODULAR_ASSY6885

--- a/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
+++ b/boards/arm/mec15xxevb_assy6853/Kconfig.defconfig
@@ -46,8 +46,4 @@ config SPI_XEC_QMSPI
 
 endif # SPI
 
-config TACH_XEC
-	default y
-	depends on SENSOR
-
 endif # BOARD_MEC15XXEVB_ASSY6853

--- a/boards/arm/mec172xevb_assy6906/Kconfig.defconfig
+++ b/boards/arm/mec172xevb_assy6906/Kconfig.defconfig
@@ -36,8 +36,4 @@ config SYS_CLOCK_TICKS_PER_SEC
 
 endif # RTOS_TIMER
 
-config TACH_XEC
-	default y
-	depends on SENSOR
-
 endif # BOARD_MEC172XEVB_ASSY6906

--- a/boards/arm/rddrone_fmuk66/Kconfig.defconfig
+++ b/boards/arm/rddrone_fmuk66/Kconfig.defconfig
@@ -20,10 +20,6 @@ config MCG_VDIV0
 config MCG_FCRDIV
 	default 1
 
-config TEMP_KINETIS
-	default y if "$(dt_nodelabel_enabled,adc1)"
-	depends on SENSOR && ADC
-
 if NETWORKING
 
 config NET_L2_ETHERNET

--- a/boards/arm/twr_ke18f/Kconfig.defconfig
+++ b/boards/arm/twr_ke18f/Kconfig.defconfig
@@ -8,10 +8,6 @@ if BOARD_TWR_KE18F
 config BOARD
 	default "twr_ke18f"
 
-config TEMP_KINETIS
-	default y if "$(dt_nodelabel_enabled,adc0)"
-	depends on SENSOR && ADC
-
 config I2C
 	default y if SENSOR
 

--- a/boards/shields/x_nucleo_53l0a1/Kconfig.defconfig
+++ b/boards/shields/x_nucleo_53l0a1/Kconfig.defconfig
@@ -15,9 +15,6 @@ config I2C
 config SENSOR
 	default y
 
-config VL53L0X
-	default y
-
 config VL53L0X_RECONFIGURE_ADDRESS
 	default y
 

--- a/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx7/Kconfig.defconfig.series
@@ -46,10 +46,6 @@ config I2C_NPCX
 	default y
 	depends on I2C
 
-config TACH_NPCX
-	default y
-	depends on SENSOR
-
 config SPI_NPCX_FIU
 	default y
 	depends on SPI

--- a/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series
+++ b/soc/arm/nuvoton_npcx/npcx9/Kconfig.defconfig.series
@@ -46,10 +46,6 @@ config I2C_NPCX
 	default y
 	depends on I2C
 
-config TACH_NPCX
-	default y
-	depends on SENSOR
-
 config SPI_NPCX_FIU
 	default y
 	depends on SPI

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -75,10 +75,6 @@ config PWM_ITE_IT8XXX2
 	default y
 	depends on PWM
 
-config TACH_IT8XXX2
-	default y
-	depends on SENSOR
-
 config PECI_ITE_IT8XXX2
 	default y
 	depends on PECI


### PR DESCRIPTION
Now that sensor drivers are enabled based on devicetree
we need to remove any cases of them getting enabled by
Kconfig.defconfig* files as this can lead to errors.

Typically the Kconfig.defconfig* will blindly enable a
sensor and not respect the devicetree state of the sensor.
Additionally we can get problems with prj.conf/defconfig
as well getting incorrectly overridden.

Fixes #48198

Signed-off-by: Kumar Gala <galak@kernel.org>