### PR TITLE
net: route: Fix pkt leak if net_send_data() fails

### DIFF
--- a/subsys/net/ip/route.c
+++ b/subsys/net/ip/route.c
@@ -849,6 +849,7 @@ int net_route_mcast_forward_packet(struct net_pkt *pkt,
 		if (net_send_data(pkt_cpy) >= 0) {
 			++ret;
 		} else {
+			net_pkt_unref(pkt_cpy);
 			--err;
 		}
 	}


### PR DESCRIPTION
If the call to net_send_data() fails, for example if the forwading
interface is down, then the pkt will leak. The reference taken by
net_pkt_shallow_clone() will never be released. Fix the problem
by dropping the rerefence count in the error path.

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>