### PR TITLE
Bluetooth: Add Periodic Advertising ADI support

### DIFF
--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -664,6 +664,13 @@ enum {
 	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
 	 */
 	BT_LE_PER_ADV_OPT_USE_TX_POWER = BIT(1),
+
+	/**
+	 * @brief Advertise with included AdvDataInfo (ADI).
+	 *
+	 * @note Requires @ref BT_LE_ADV_OPT_EXT_ADV
+	 */
+	BT_LE_PER_ADV_OPT_INCLUDE_ADI = BIT(2),
 };
 
 struct bt_le_per_adv_param {

--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -174,52 +174,66 @@ struct bt_hci_cmd_hdr {
 #define BT_LE_FEAT_TEST(feat, n)                (feat[(n) >> 3] & \
 						 BIT((n) & 7))
 
-#define BT_FEAT_LE_ENCR(feat)                   BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_ENC)
-#define BT_FEAT_LE_CONN_PARAM_REQ_PROC(feat)    BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_CONN_PARAM_REQ)
-#define BT_FEAT_LE_PER_INIT_FEAT_XCHG(feat)     BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_PER_INIT_FEAT_XCHG)
-#define BT_FEAT_LE_DLE(feat)                    BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_DLE)
-#define BT_FEAT_LE_PHY_2M(feat)                 BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_PHY_2M)
-#define BT_FEAT_LE_PHY_CODED(feat)              BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_PHY_CODED)
-#define BT_FEAT_LE_PRIVACY(feat)                BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_PRIVACY)
-#define BT_FEAT_LE_EXT_ADV(feat)                BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_EXT_ADV)
-#define BT_FEAT_LE_EXT_PER_ADV(feat)            BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_PER_ADV)
-#define BT_FEAT_LE_CONNECTION_CTE_REQ(feat)     BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_CONN_CTE_REQ)
-#define BT_FEAT_LE_CONNECTION_CTE_RESP(feat)    BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_CONN_CTE_RESP)
-#define BT_FEAT_LE_CONNECTIONLESS_CTE_TX(feat)  BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_CONNECTIONLESS_CTE_TX)
-#define BT_FEAT_LE_CONNECTIONLESS_CTE_RX(feat)  BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_CONNECTIONLESS_CTE_RX)
-#define BT_FEAT_LE_ANT_SWITCH_TX_AOD(feat)      BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_ANT_SWITCH_TX_AOD)
-#define BT_FEAT_LE_ANT_SWITCH_RX_AOA(feat)      BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_ANT_SWITCH_RX_AOA)
-#define BT_FEAT_LE_RX_CTE(feat)                 BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_RX_CTE)
-#define BT_FEAT_LE_PAST_SEND(feat)              BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_PAST_SEND)
-#define BT_FEAT_LE_PAST_RECV(feat)              BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_PAST_RECV)
-#define BT_FEAT_LE_CIS_CENTRAL(feat)            BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_CIS_CENTRAL)
-#define BT_FEAT_LE_CIS_PERIPHERAL(feat)         BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_CIS_PERIPHERAL)
-#define BT_FEAT_LE_ISO_BROADCASTER(feat)        BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_ISO_BROADCASTER)
-#define BT_FEAT_LE_SYNC_RECEIVER(feat)          BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_SYNC_RECEIVER)
-#define BT_FEAT_LE_ISO_CHANNELS(feat)           BT_LE_FEAT_TEST(feat, \
-						BT_LE_FEAT_BIT_ISO_CHANNELS)
+#define BT_FEAT_LE_ENCR(feat)                     BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_ENC)
+#define BT_FEAT_LE_CONN_PARAM_REQ_PROC(feat)      BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CONN_PARAM_REQ)
+#define BT_FEAT_LE_PER_INIT_FEAT_XCHG(feat)       BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PER_INIT_FEAT_XCHG)
+#define BT_FEAT_LE_DLE(feat)                      BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_DLE)
+#define BT_FEAT_LE_PHY_2M(feat)                   BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PHY_2M)
+#define BT_FEAT_LE_PHY_CODED(feat)                BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PHY_CODED)
+#define BT_FEAT_LE_PRIVACY(feat)                  BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PRIVACY)
+#define BT_FEAT_LE_EXT_ADV(feat)                  BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_EXT_ADV)
+#define BT_FEAT_LE_EXT_PER_ADV(feat)              BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PER_ADV)
+#define BT_FEAT_LE_CONNECTION_CTE_REQ(feat)       BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CONN_CTE_REQ)
+#define BT_FEAT_LE_CONNECTION_CTE_RESP(feat)      BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CONN_CTE_RESP)
+#define BT_FEAT_LE_CONNECTIONLESS_CTE_TX(feat)    BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CONNECTIONLESS_CTE_TX)
+#define BT_FEAT_LE_CONNECTIONLESS_CTE_RX(feat)    BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CONNECTIONLESS_CTE_RX)
+#define BT_FEAT_LE_ANT_SWITCH_TX_AOD(feat)        BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_ANT_SWITCH_TX_AOD)
+#define BT_FEAT_LE_ANT_SWITCH_RX_AOA(feat)        BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_ANT_SWITCH_RX_AOA)
+#define BT_FEAT_LE_RX_CTE(feat)                   BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_RX_CTE)
+#define BT_FEAT_LE_PAST_SEND(feat)                BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PAST_SEND)
+#define BT_FEAT_LE_PAST_RECV(feat)                BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PAST_RECV)
+#define BT_FEAT_LE_CIS_CENTRAL(feat)              BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CIS_CENTRAL)
+#define BT_FEAT_LE_CIS_PERIPHERAL(feat)           BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CIS_PERIPHERAL)
+#define BT_FEAT_LE_ISO_BROADCASTER(feat)          BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_ISO_BROADCASTER)
+#define BT_FEAT_LE_SYNC_RECEIVER(feat)            BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_SYNC_RECEIVER)
+#define BT_FEAT_LE_ISO_CHANNELS(feat)             BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_ISO_CHANNELS)
+#define BT_FEAT_LE_PWR_CTRL_REQ(feat)             BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PWR_CTRL_REQ)
+#define BT_FEAT_LE_PWR_CHG_IND(feat)              BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PWR_CHG_IND)
+#define BT_FEAT_LE_PATH_LOSS_MONITOR(feat)        BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PATH_LOSS_MONITOR)
+#define BT_FEAT_LE_PER_ADV_ADI_SUPP(feat)         BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_PER_ADV_ADI_SUPP)
+#define BT_FEAT_LE_CONN_SUBRATING(feat)           BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CONN_SUBRATING)
+#define BT_FEAT_LE_CONN_SUBRATING_HOST_SUPP(feat) BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CONN_SUBRATING_HOST_SUPP)
+#define BT_FEAT_LE_CHANNEL_CLASSIFICATION(feat)   BT_LE_FEAT_TEST(feat, \
+						  BT_LE_FEAT_BIT_CHANNEL_CLASSIFICATION)
 
 #define BT_FEAT_LE_CIS(feat)            (BT_FEAT_LE_CIS_CENTRAL(feat) | \
 					BT_FEAT_LE_CIS_PERIPHERAL(feat))

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -1748,6 +1748,11 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 		return -EINVAL;
 	}
 
+	if (!BT_FEAT_LE_PER_ADV_ADI_SUPP(bt_dev.le.features) &&
+	    (param->options & BT_LE_PER_ADV_OPT_INCLUDE_ADI)) {
+		return -ENOTSUP;
+	}
+
 	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PER_ADV_PARAM, sizeof(*cp));
 	if (!buf) {
 		return -ENOBUFS;
@@ -1768,6 +1773,12 @@ int bt_le_per_adv_set_param(struct bt_le_ext_adv *adv,
 	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PER_ADV_PARAM, buf, NULL);
 	if (err) {
 		return err;
+	}
+
+	if (param->options & BT_LE_PER_ADV_OPT_INCLUDE_ADI) {
+		atomic_set_bit(adv->flags, BT_PER_ADV_INCLUDE_ADI);
+	} else {
+		atomic_clear_bit(adv->flags, BT_PER_ADV_INCLUDE_ADI);
 	}
 
 	atomic_set_bit(adv->flags, BT_PER_ADV_PARAMS_SET);
@@ -1836,7 +1847,16 @@ static int bt_le_per_adv_enable(struct bt_le_ext_adv *adv, bool enable)
 	(void)memset(cp, 0, sizeof(*cp));
 
 	cp->handle = adv->handle;
-	cp->enable = enable ? 1 : 0;
+
+	if (enable) {
+		cp->enable = BT_HCI_LE_SET_PER_ADV_ENABLE_ENABLE;
+
+		if (atomic_test_bit(adv->flags, BT_PER_ADV_INCLUDE_ADI)) {
+			cp->enable |= BT_HCI_LE_SET_PER_ADV_ENABLE_ADI;
+		}
+	} else {
+		cp->enable = 0U;
+	}
 
 	bt_hci_cmd_state_set_init(buf, &state, adv->flags,
 				  BT_PER_ADV_ENABLED, enable);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -117,6 +117,8 @@ enum {
 	BT_PER_ADV_ENABLED,
 	/* Periodic Advertising parameters has been set in the controller. */
 	BT_PER_ADV_PARAMS_SET,
+	/* Periodic Advertising to include AdvDataInfo (ADI) */
+	BT_PER_ADV_INCLUDE_ADI,
 	/* Constant Tone Extension parameters for Periodic Advertising
 	 * has been set in the controller.
 	 */


### PR DESCRIPTION
Add support in Bluetooth Host to enable Periodic Advertising
ADI support feature when supported in the Controller to
include ADI in Periodic Advertising AUX_SYNC_IND PDU.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>