### PR TITLE
drivers: sensor: adxl345: Correct converting counts to sensor value

### DIFF
--- a/drivers/sensor/adxl345/adxl345.c
+++ b/drivers/sensor/adxl345/adxl345.c
@@ -133,8 +133,8 @@ static void adxl345_accel_convert(struct sensor_value *val, int16_t sample)
 		sample |= ADXL345_COMPLEMENT;
 	}
 
-	val->val1 = (sample * 1000) / 32;
-	val->val2 = 0;
+	val->val1 = ((sample * SENSOR_G) / 32) / 1000000;
+	val->val2 = ((sample * SENSOR_G) / 32) % 1000000;
 }
 
 static int adxl345_sample_fetch(const struct device *dev,


### PR DESCRIPTION
Sensor value unit is $m/s^2$.
Currently calcs as $mg [ 1000 * g ]$ unit.

Correcting calculation to convert $m/s^2$.
Store the integer part to val1, and the fractional part to val2.

Fixes #48220