### PR TITLE
doc: gen_devicetree_rest: Fix binding doc file name resolution

### DIFF
--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -796,9 +796,9 @@ def binding_filename(binding):
     if idx == -1:
         raise ValueError(f'binding path has no {dts_bindings}: {binding.path}')
 
-    # Cut past dts/bindings, strip off the .yaml, and replace with
-    # .rst.
-    return as_posix[idx + len(dts_bindings):-4] + 'rst'
+    # Cut past dts/bindings, strip off the extension (.yaml or .yml), and
+    # replace with .rst.
+    return os.path.splitext(as_posix[idx + len(dts_bindings):])[0] + '.rst'
 
 def binding_ref_target(binding):
     # Return the sphinx ':ref:' target name for a binding.


### PR DESCRIPTION
The `binding_filename` function, which resolves the binding
documentation file name from the binding yaml file name, made a very
crude assumption that the binding yaml file name will always have the
extension name of `yaml` -- this is no longer true after the commit
c4532200061c7bda595745a5a07b5d341158513c, which added support for both
`yaml` or `yml`.

This commit reworks the function such that its implementation is not
dependent on the extension name of the binding yaml file.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Hotfix for the scheduled documentation build failure observed here:
https://github.com/zephyrproject-rtos/zephyr/actions/workflows/doc-build.yml?query=event%3Aschedule

Note that this failure was not seen in the PR documentation builds because they build with `DT_TURBO_MODE=1`, which does not generate the devicetree binding documentations.