### PR TITLE
Bluetooth: Mesh: Fix unable iv recovery 0 0 -> 1 0

### DIFF
--- a/subsys/bluetooth/mesh/net.c
+++ b/subsys/bluetooth/mesh/net.c
@@ -242,8 +242,9 @@ bool bt_mesh_iv_update(void)
 }
 #endif /* CONFIG_BT_MESH_IV_UPDATE_TEST */
 
-static bool is_iv_recovery(uint32_t iv_index, bool iv_update)
+bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
 {
+	/* Check if IV index should to be recovered. */
 	if (iv_index < bt_mesh.iv_index ||
 	    iv_index > bt_mesh.iv_index + 42) {
 		BT_ERR("IV Index out of sync: 0x%08x != 0x%08x",
@@ -278,46 +279,12 @@ static bool is_iv_recovery(uint32_t iv_index, bool iv_update)
 		bt_mesh.iv_index = iv_index;
 		bt_mesh.seq = 0U;
 
-		return true;
+		goto do_update;
 	}
 
-	return false;
-}
-
-bool bt_mesh_net_iv_update(uint32_t iv_index, bool iv_update)
-{
-	if (atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS)) {
-		/* We're currently in IV Update mode */
-
-		if (iv_index != bt_mesh.iv_index) {
-			if (is_iv_recovery(iv_index, iv_update)) {
-				goto do_update;
-			}
-
-			return false;
-		}
-
-		if (iv_update) {
-			/* Nothing to do */
-			BT_DBG("Already in IV Update in Progress state");
-			return false;
-		}
-	} else {
-		/* We're currently in Normal mode */
-
-		if (iv_index != bt_mesh.iv_index + 1) {
-			if (is_iv_recovery(iv_index, iv_update)) {
-				goto do_update;
-			}
-
-			return false;
-		}
-
-		if (!iv_update) {
-			/* Nothing to do */
-			BT_DBG("Already in IV normal mode");
-			return false;
-		}
+	if (atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS) == iv_update) {
+		BT_DBG("No change for IV Update procedure");
+		return false;
 	}
 
 	if (!(IS_ENABLED(CONFIG_BT_MESH_IV_UPDATE_TEST) &&

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_iv_index.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_iv_index.c
@@ -78,15 +78,15 @@ static void test_ivu_recovery(void)
 	atomic_clear_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS);
 
 	/* Already in IV normal mode */
-	ASSERT_FALSE(bt_mesh_net_iv_update(TEST_IV_IDX + 1, BCN_IV_IN_IDLE));
+	ASSERT_FALSE(bt_mesh_net_iv_update(TEST_IV_IDX, BCN_IV_IN_IDLE));
 
 	/* Out of sync */
 	ASSERT_FALSE(bt_mesh_net_iv_update(TEST_IV_IDX - 1, BCN_IV_IN_IDLE));
 	ASSERT_FALSE(bt_mesh_net_iv_update(TEST_IV_IDX + 43, BCN_IV_IN_IDLE));
 
 	/* Start recovery */
-	ASSERT_TRUE(bt_mesh_net_iv_update(TEST_IV_IDX + 2, BCN_IV_IN_IDLE));
-	ASSERT_EQUAL(TEST_IV_IDX + 2, bt_mesh.iv_index);
+	ASSERT_TRUE(bt_mesh_net_iv_update(TEST_IV_IDX + 1, BCN_IV_IN_IDLE));
+	ASSERT_EQUAL(TEST_IV_IDX + 1, bt_mesh.iv_index);
 	ASSERT_FALSE(atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS));
 
 	/* Start recovery before minimum delay */
@@ -99,6 +99,7 @@ static void test_ivu_normal(void)
 {
 	bt_mesh_test_setup();
 	bt_mesh.iv_index = TEST_IV_IDX;
+	bt_mesh.seq = 100;
 	atomic_set_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS);
 
 	/* update before minimum duration */
@@ -109,8 +110,6 @@ static void test_ivu_normal(void)
 	ASSERT_FALSE(atomic_test_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS));
 	ASSERT_EQUAL(TEST_IV_IDX, bt_mesh.iv_index);
 	ASSERT_EQUAL(0, bt_mesh.seq);
-
-	atomic_clear_bit(bt_mesh.flags, BT_MESH_IVU_IN_PROGRESS);
 
 	bt_mesh.seq = 100;
 	/* update before minimum duration */


### PR DESCRIPTION
According Mesh Spec 1.0.1:

Upon receiving and successfully authenticating to
Secure Network beacon for a primary subnet whose
IV Index is 1 or more higher than the current known IV
Index, the node shall set its current IV Index and its
current IV Update procedure state from the values in
this Secure Network beacon.

Look like test_iv_index.c:81
``` C

(bt_mesh_net_iv_update(TEST_IV_IDX + 1, BCN_IV_IN_IDLE));

```

This test case already exists, but the wrong testcase
to test wrong code.

Move `is_iv_recovery` into `bt_mesh_net_iv_update`.
First check whether it is IV recovery, and then carry out
the subsequent IV normal update procedure.

Signed-off-by: Lingao Meng <menglingao@xiaomi.com>