### PR TITLE
drivers: i2c: restore explicit init priority

### DIFF
--- a/drivers/i2c/Kconfig
+++ b/drivers/i2c/Kconfig
@@ -54,7 +54,7 @@ source "drivers/i2c/Kconfig.gd32"
 
 config I2C_INIT_PRIORITY
 	int "Init priority"
-	default KERNEL_INIT_PRIORITY_DEVICE
+	default 60
 	help
 	  I2C device driver initialization priority.
 


### PR DESCRIPTION
Restore the previous init level priority in order to fix a case where the FLASH driver contains the same init
priority value which causes `Unaligned memory access` due to the fact that I2C drivers tried to access
the members that were stored in the flash memory which has not been initialized yet.

This is a follow-up to commit:
c8f9f53322f1faa5a4d13f0dfcee12c596196188

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>