### PR TITLE
net: lwm2m: Allow observing of object instances and objects

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_observation.c
+++ b/subsys/net/lib/lwm2m/lwm2m_observation.c
@@ -150,11 +150,6 @@ void clear_attrs(void *ref)
 
 static bool lwm2m_observer_path_compare(struct lwm2m_obj_path *o_p, struct lwm2m_obj_path *p)
 {
-	/* updated path is deeper than obs node, skip */
-	if (p->level > o_p->level) {
-		return false;
-	}
-
 	/* check obj id matched or not */
 	if (p->obj_id != o_p->obj_id) {
 		return false;
@@ -353,7 +348,7 @@ int lwm2m_notify_observer_path(struct lwm2m_obj_path *path)
 	int i;
 	struct lwm2m_ctx **sock_ctx = lwm2m_sock_ctx();
 
-	if (path->level < LWM2M_PATH_LEVEL_RESOURCE) {
+	if (path->level < LWM2M_PATH_LEVEL_OBJECT) {
 		return 0;
 	}
 


### PR DESCRIPTION
Code was limiting observations to resources and
resource instances without any reason.
Also if resource is written, and the whole object is observer
it should trigger. Path does not have to be matching on the
same level, if parent is observed.
