### PR TITLE
soc: riscv: riscv-privilege: telink_b91: dts: riscv: telink: telink_b…

### DIFF
--- a/drivers/serial/uart_b91.c
+++ b/drivers/serial/uart_b91.c
@@ -10,7 +10,7 @@
 #include <zephyr/device.h>
 #include <zephyr/drivers/uart.h>
 #include <zephyr/drivers/pinctrl.h>
-
+#include <zephyr/pm/device.h>
 
 /* Driver dts compatibility: telink,b91_uart */
 #define DT_DRV_COMPAT telink_b91_uart
@@ -40,7 +40,7 @@
 #define UART_TX_RESET_BIT BIT(7)
 
 /* B91 UART registers structure */
-struct uart_b91_t {
+struct __packed uart_b91_t {
 	uint8_t data_buf[UART_DATA_SIZE];
 	uint16_t clk_div;
 	uint8_t ctrl0;
@@ -102,6 +102,10 @@ enum {
 	UART_RX_ERR_STATUS      = BIT(7),
 };
 
+/* txrx_status register enums */
+enum {
+	UART_TXRX_STATUS_TX_DONE = BIT(0)
+};
 
 /* Get tx fifo count */
 static inline uint8_t uart_b91_get_tx_bufcnt(volatile struct uart_b91_t *uart)
@@ -337,10 +341,13 @@ static void uart_b91_poll_out(const struct device *dev, uint8_t c)
 	struct uart_b91_data *data = dev->data;
 
 	while (uart_b91_get_tx_bufcnt(uart) >= UART_TX_BUF_CNT) {
-	};
+	}
 
 	uart->data_buf[data->tx_byte_index] = c;
 	data->tx_byte_index = (data->tx_byte_index + 1) % ARRAY_SIZE(uart->data_buf);
+
+	while (!(uart->txrx_status & UART_TXRX_STATUS_TX_DONE)) {
+	}
 }
 
 /* API implementation: poll_in */
@@ -376,6 +383,7 @@ static int uart_b91_fifo_fill(const struct device *dev,
 {
 	int i = 0;
 	volatile struct uart_b91_t *uart = GET_UART(dev);
+	struct uart_b91_data *data = dev->data;
 
 	if (size > UART_DATA_SIZE) {
 		size = UART_DATA_SIZE;
@@ -386,7 +394,11 @@ static int uart_b91_fifo_fill(const struct device *dev,
 			break;
 		}
 
-		uart_b91_poll_out(dev, tx_data[i]);
+		while (uart_b91_get_tx_bufcnt(uart) >= UART_TX_BUF_CNT) {
+		}
+
+		uart->data_buf[data->tx_byte_index] = tx_data[i];
+		data->tx_byte_index = (data->tx_byte_index + 1) % ARRAY_SIZE(uart->data_buf);
 	}
 
 	return i;
@@ -399,13 +411,15 @@ static int uart_b91_fifo_read(const struct device *dev,
 {
 	int rx_count;
 	volatile struct uart_b91_t *uart = GET_UART(dev);
+	struct uart_b91_data *data = dev->data;
 
 	for (rx_count = 0; rx_count < size; rx_count++) {
 		if (uart_b91_get_rx_bufcnt(uart) == 0) {
 			break;
 		}
 
-		uart_b91_poll_in(dev, &rx_data[rx_count]);
+		rx_data[rx_count] = uart->data_buf[data->rx_byte_index];
+		data->rx_byte_index = (data->rx_byte_index + 1) % ARRAY_SIZE(uart->data_buf);
 	}
 
 	return rx_count;
@@ -518,6 +532,33 @@ static void uart_b91_irq_callback_set(const struct device *dev,
 
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */
 
+#ifdef CONFIG_PM_DEVICE
+
+static int uart_b91_pm_action(const struct device *dev, enum pm_device_action action)
+{
+	volatile struct uart_b91_t *uart = GET_UART(dev);
+	struct uart_b91_data *data = dev->data;
+
+	switch (action) {
+	case PM_DEVICE_ACTION_RESUME:
+		/* reset TX/RX byte index */
+		data->tx_byte_index = 0;
+		data->rx_byte_index = 0;
+		uart->status |= UART_RX_RESET_BIT | UART_TX_RESET_BIT;
+		break;
+
+	case PM_DEVICE_ACTION_SUSPEND:
+		break;
+
+	default:
+		return -ENOTSUP;
+	}
+
+	return 0;
+}
+
+#endif /* CONFIG_PM_DEVICE */
+
 static const struct uart_driver_api uart_b91_driver_api = {
 	.poll_in = uart_b91_poll_in,
 	.poll_out = uart_b91_poll_out,
@@ -545,6 +586,8 @@ static const struct uart_driver_api uart_b91_driver_api = {
 
 #define UART_B91_INIT(n)							    \
 										    \
+	PM_DEVICE_DT_INST_DEFINE(n, uart_b91_pm_action);			    \
+										    \
 	static void uart_b91_irq_connect_##n(void);				    \
 										    \
 	PINCTRL_DT_INST_DEFINE(n);						    \
@@ -560,7 +603,7 @@ static const struct uart_driver_api uart_b91_driver_api = {
 	static struct uart_b91_data uart_b91_data_##n;				    \
 										    \
 	DEVICE_DT_INST_DEFINE(n, uart_b91_driver_init,				    \
-			      NULL,						    \
+			      PM_DEVICE_DT_INST_GET(n),				    \
 			      &uart_b91_data_##n,				    \
 			      &uart_b91_cfg_##n,				    \
 			      PRE_KERNEL_1,					    \

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -23,6 +23,16 @@
 			reg = <0>;
 			clock-frequency = <24000000>;
 			compatible ="telink,b91", "riscv";
+			cpu-power-states = <&state0>;
+		};
+	};
+
+	power-states {
+		state0: state0 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <3000>;
+			exit-latency-us = <1000>;
 		};
 	};
 

--- a/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
+++ b/soc/riscv/riscv-privilege/telink_b91/CMakeLists.txt
@@ -7,6 +7,10 @@ zephyr_sources(
 	soc.c
 )
 
+zephyr_sources_ifdef(CONFIG_PM
+	power.c
+)
+
 # Force using BFD-LD
 zephyr_ld_options(-fuse-ld=bfd)
 

--- a/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
+++ b/soc/riscv/riscv-privilege/telink_b91/Kconfig.soc
@@ -40,3 +40,6 @@ endchoice
 config FLASH_BASE_ADDRESS
 	hex
 	default $(dt_chosen_reg_addr_hex,$(DT_CHOSEN_Z_FLASH))
+
+config PM_DEVICE
+	default y if PM

--- a/soc/riscv/riscv-privilege/telink_b91/power.c
+++ b/soc/riscv/riscv-privilege/telink_b91/power.c
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2022 Telink Semiconductor
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <ext_driver/ext_pm.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/pm/pm.h>
+#include <zephyr/pm/device.h>
+#include <stimer.h>
+#include <zephyr/zephyr.h>
+
+LOG_MODULE_DECLARE(soc, CONFIG_SOC_LOG_LEVEL);
+
+#define DT_DRV_COMPAT telink_machine_timer
+
+#define MTIME_REG	DT_INST_REG_ADDR(0)
+#define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 8)
+
+#define mticks_to_systicks(mticks)                                                                 \
+	(((uint64_t)(mticks)*SYSTEM_TIMER_TICK_1S) / CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)
+#define systicks_to_mticks(sticks)                                                                 \
+	(((uint64_t)(sticks)*CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC) / SYSTEM_TIMER_TICK_1S)
+
+#define SYSTICKS_MAX_SLEEP 0xe0000000
+#define SYSTICKS_MIN_SLEEP 18352
+
+/**
+ * @brief This define converts Machine Timer ticks to B91 System Timer ticks.
+ */
+#define MTIME_TO_STIME_SCALE (SYSTEM_TIMER_TICK_1S / CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)
+
+/**
+ * @brief Get Machine Timer Compare value.
+ */
+static uint64_t get_mtime_compare(void)
+{
+	return *(const volatile uint64_t *const)((uint32_t)(MTIMECMP_REG +
+						 (_current_cpu->id * sizeof(uint64_t))));
+}
+
+/**
+ * @brief Get Machine Timer value.
+ */
+static uint64_t get_mtime(void)
+{
+	const volatile uint32_t *const rl = (const volatile uint32_t *const)MTIME_REG;
+	const volatile uint32_t *const rh =
+		(const volatile uint32_t *const)(MTIME_REG + sizeof(uint32_t));
+	uint32_t mtime_l, mtime_h;
+
+	do {
+		mtime_h = *rh;
+		mtime_l = *rl;
+	} while (mtime_h != *rh);
+	return (((uint64_t)mtime_h) << 32) | mtime_l;
+}
+
+/**
+ * @brief Set Machine Timer value.
+ */
+static void set_mtime(uint64_t time)
+{
+	volatile uint32_t *const rl = (volatile uint32_t *const)MTIME_REG;
+	volatile uint32_t *const rh =
+		(volatile uint32_t *const)(MTIME_REG + sizeof(uint32_t));
+
+	*rl = 0;
+	*rh = (uint32_t)(time >> 32);
+	*rl = (uint32_t)time;
+}
+
+/**
+ * @brief PM state set API implementation.
+ */
+__weak void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	uint32_t tl_sleep_tick = stimer_get_tick();
+	uint64_t current_time = get_mtime();
+	uint64_t wakeup_time = get_mtime_compare();
+
+	if (wakeup_time <= current_time) {
+		LOG_DBG("Sleep Time = 0 or less\n");
+		return;
+	}
+#ifdef CONFIG_PM_DEVICE
+	if (pm_device_is_any_busy()) {
+		return;
+	}
+#endif /* CONFIG_PM_DEVICE */
+
+	uint64_t stimer_sleep_ticks = mticks_to_systicks(wakeup_time - current_time);
+
+	switch (state) {
+	case PM_STATE_SUSPEND_TO_IDLE:
+		if (stimer_sleep_ticks < SYSTICKS_MIN_SLEEP) {
+			k_cpu_idle();
+		} else {
+			if (stimer_sleep_ticks > SYSTICKS_MAX_SLEEP) {
+				stimer_sleep_ticks = SYSTICKS_MAX_SLEEP;
+			}
+			cpu_sleep_wakeup_32k_rc(SUSPEND_MODE, PM_WAKEUP_TIMER,
+						tl_sleep_tick + stimer_sleep_ticks);
+			current_time += systicks_to_mticks(stimer_get_tick() - tl_sleep_tick);
+			set_mtime(current_time);
+		}
+		break;
+
+	default:
+		LOG_DBG("Unsupported power state %u", state);
+		k_cpu_idle();
+		break;
+	}
+}
+
+/**
+ * @brief PM state exit post operations API implementation.
+ */
+__weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
+	/*
+	 * System is now in active mode. Enabling interrupts which were
+	 * disabled when OS started idle code.
+	 */
+	arch_irq_unlock(MSTATUS_IEN);
+}

--- a/west.yml
+++ b/west.yml
@@ -129,7 +129,7 @@ manifest:
       groups:
         - hal
     - name: hal_telink
-      revision: 38573af589173259801ae6c2b34b7d4c9e626746
+      revision: pull/6/head
       path: modules/hal/telink
       submodules: true
       groups:


### PR DESCRIPTION
…91: drivers: serial: uart_b91.c: Implement Telink B91 suspend mode

To reduce power consumption Telink B91 supports suspend mode.
This mode is involved when OS kernel enter idle process.

Co-authored-by: Andrii Bilynskyi <andrii.bilynskyi@telink-semi.com>

Signed-off-by: Misha Tkachenko <misha.tkachenko@telink-semi.com>

Tested manually using TLSR9518ADK80D by running sample projects with config PM.