### PR TITLE
intel_adsp: meteorlake: Initialize stack flush pointer SR

### DIFF
--- a/arch/xtensa/include/kernel_arch_func.h
+++ b/arch/xtensa/include/kernel_arch_func.h
@@ -34,6 +34,11 @@ static ALWAYS_INLINE void arch_kernel_init(void)
 	 * regions due to boot firmware
 	 */
 	z_xtensa_cache_flush_inv_all();
+
+	/* Our cache top stash location might have junk in it from a
+	 * pre-boot environment.  Must be zero or valid!
+	 */
+	WSR(ZSR_FLUSH_STR, 0);
 #endif
 
 	cpu0->nested = 0;
@@ -74,6 +79,10 @@ static ALWAYS_INLINE void arch_cohere_stacks(struct k_thread *old_thread,
 	size_t nstack = new_thread->stack_info.start;
 	size_t nsz    = new_thread->stack_info.size;
 	size_t nsp    = (size_t) new_thread->switch_handle;
+
+	int zero = 0;
+
+	__asm__ volatile("wsr %0, " ZSR_FLUSH_STR :: "r"(zero));
 
 	if (old_switch_handle != NULL) {
 		int32_t a0save;


### PR DESCRIPTION
The simulator seems to drop garbage addresses (somewhere in the ROM it
looks like) into this SR at arbitrary times.  I don't know if this is
a hardware exception handler that we can't turn off, or a simulator
bug, or what.  But our code that assumes it will be cleared to zero or
valid is breaking.  Set it every time in every context switch for now
pending someone figuring out what's going wrong.

Signed-off-by: Andy Ross <andrew.j.ross@intel.com>
Signed-off-by: Anas Nashif <anas.nashif@intel.com>
