### PR TITLE
drivers: console: ipm_console: Update driver to use DEVICE_DT_GET

### DIFF
--- a/drivers/console/Kconfig
+++ b/drivers/console/Kconfig
@@ -179,17 +179,6 @@ config IPM_CONSOLE
 	help
 	  Enable console over Inter-processor Mailbox.
 
-# Workaround for not being able to have commas in macro arguments
-DT_CHOSEN_Z_IPM_CONSOLE := zephyr,console
-
-config IPM_CONSOLE_ON_DEV_NAME
-	string "IPM device name used by console"
-	default "$(dt_chosen_label,$(DT_CHOSEN_Z_IPM_CONSOLE))" if HAS_DTS
-	default "IPM_0"
-	depends on IPM_CONSOLE
-	help
-	  IPM device name used by IPM console driver.
-
 config IPM_CONSOLE_LINE_BUF_LEN
 	int "IPM console line buffer length"
 	default 128

--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -70,9 +70,9 @@ static int ipm_console_init(const struct device *dev)
 
 	LOG_DBG("IPM console initialization");
 
-	ipm_dev = device_get_binding(CONFIG_IPM_CONSOLE_ON_DEV_NAME);
-	if (!ipm_dev) {
-		LOG_ERR("Cannot get %s", CONFIG_IPM_CONSOLE_ON_DEV_NAME);
+	ipm_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	if (!device_is_ready(ipm_dev)) {
+		LOG_ERR("%s is not ready", ipm_dev->name);
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Update driver to use DEVICE_DT_GET to remove usage of device_get_binding.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>