### PR TITLE
dts: bindings: vendor-prefixes: Add ultrachip prefix

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -622,6 +622,7 @@ ucrobotics	uCRobotics
 ubnt	Ubiquiti Networks
 udoo	Udoo
 ugoos	Ugoos Industrial Co., Ltd.
+ultrachip	UltraChip Inc.
 uniwest	United Western Technologies Corp (UniWest)
 upisemi	uPI Semiconductor Corp.
 urt	United Radiant Technology Corporation


### PR DESCRIPTION
Add UltraChip nuclei manufacturer binding prefix.

Signed-off-by: Kumar Gala <galak@kernel.org>