### PR TITLE
boards/shields: Remove "ultrachip,uc8176" compatible

### DIFF
--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
@@ -13,7 +13,7 @@
 
 &arduino_spi {
 	gd7965: gd7965@0 {
-		compatible = "gooddisplay,gdew042t2", "ultrachip,uc8176", "gooddisplay,gd7965";
+		compatible = "gooddisplay,gdew042t2", "gooddisplay,gd7965";
 		label = "GD7965";
 		spi-max-frequency = <4000000>;
 		reg = <0>;


### PR DESCRIPTION
The compatible string "ultrachip,uc8176" is not referenced anywhere else
in the code. This compatible string causes a failure when running the
test "scripts/twister -T samples/drivers/display".

Signed-off-by: Keith Short <keithshort@google.com>