### PR TITLE
doc: correct path to user package registry

### DIFF
--- a/doc/build/zephyr_cmake_package.rst
+++ b/doc/build/zephyr_cmake_package.rst
@@ -28,13 +28,13 @@ CMake user package registry.
 
       In Linux, the CMake user package registry is found in:
 
-      ``~/.cmake/package/Zephyr``
+      ``~/.cmake/packages/Zephyr``
 
    .. group-tab:: macOS
 
       In macOS, the CMake user package registry is found in:
 
-      ``~/.cmake/package/Zephyr``
+      ``~/.cmake/packages/Zephyr``
 
    .. group-tab:: Windows
 


### PR DESCRIPTION
Fix typo in path. See cmake-packages(7).

Signed-off-by: Troy D. Hanson <tdh@tkhanson.net>