### PR TITLE
Bluetooth: Host: Random address should be cleared in bt_disable

### DIFF
--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -3765,6 +3765,9 @@ int bt_disable(void)
 	/* Some functions rely on checking this bitfield */
 	memset(bt_dev.supported_commands, 0x00, sizeof(bt_dev.supported_commands));
 
+	/* If random address was set up - clear it */
+	bt_addr_le_copy(&bt_dev.random_addr, BT_ADDR_LE_ANY);
+
 	/* Abort TX thread */
 	k_thread_abort(&tx_thread_data);
 


### PR DESCRIPTION
This is to address such a scenario:
* bt_enable
* create a new identity (random MAC)
* setup and start advertisement with the new identity
* stop advertisement
* delete identity
* bt_disable
* bt_enable
* create a new identity (random MAC - the same as before)
* setup and start advertisement with the new identity - error

previous random MAC is cached in bt_dev and is not set up on the controller side (HCI command 0x2005 is not sent)

Signed-off-by: Adam Augustyn <adam.augustyn@hidglobal.com>