### PR TITLE
drivers: mdio: mdio: Update mdio_shell to use DEVICE_DT_GET

### DIFF
--- a/drivers/mdio/mdio_shell.c
+++ b/drivers/mdio/mdio_shell.c
@@ -9,11 +9,12 @@
 #include <zephyr/drivers/mdio.h>
 #include <string.h>
 #include <zephyr/sys/util.h>
+#include <zephyr/devicetree.h>
 
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(mdio_shell, CONFIG_LOG_DEFAULT_LEVEL);
 
-#define MDIO_DEVICE "MDIO"
+#define MDIO_NODE_ID DT_COMPAT_GET_ANY_STATUS_OKAY(atmel_sam_mdio)
 
 /*
  * Scan the entire 5-bit address space of the MDIO bus
@@ -27,10 +28,9 @@ static int cmd_mdio_scan(const struct shell *sh, size_t argc, char **argv)
 	uint16_t data;
 	uint16_t dev_addr;
 
-	dev = device_get_binding(MDIO_DEVICE);
-	if (!dev) {
-		shell_error(sh, "MDIO: Device driver %s not found.",
-			    MDIO_DEVICE);
+	dev = DEVICE_DT_GET(MDIO_NODE_ID);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "MDIO: Device driver %s is not ready.", dev->name);
 
 		return -ENODEV;
 	}
@@ -59,7 +59,7 @@ static int cmd_mdio_scan(const struct shell *sh, size_t argc, char **argv)
 
 	mdio_bus_disable(dev);
 
-	shell_print(sh, "%u devices found on %s", cnt, MDIO_DEVICE);
+	shell_print(sh, "%u devices found on %s", cnt, dev->name);
 
 	return 0;
 }
@@ -72,10 +72,9 @@ static int cmd_mdio_write(const struct shell *sh, size_t argc, char **argv)
 	uint16_t dev_addr;
 	uint16_t port_addr;
 
-	dev = device_get_binding(MDIO_DEVICE);
-	if (!dev) {
-		shell_error(sh, "MDIO: Device driver %s not found.",
-			    MDIO_DEVICE);
+	dev = DEVICE_DT_GET(MDIO_NODE_ID);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "MDIO: Device driver %s is not ready.", dev->name);
 
 		return -ENODEV;
 	}
@@ -87,7 +86,7 @@ static int cmd_mdio_write(const struct shell *sh, size_t argc, char **argv)
 	mdio_bus_enable(dev);
 
 	if (mdio_write(dev, port_addr, dev_addr, data) < 0) {
-		shell_error(sh, "Failed to write to device: %s", MDIO_DEVICE);
+		shell_error(sh, "Failed to write to device: %s", dev->name);
 		mdio_bus_disable(dev);
 
 		return -EIO;
@@ -106,10 +105,9 @@ static int cmd_mdio_read(const struct shell *sh, size_t argc, char **argv)
 	uint16_t dev_addr;
 	uint16_t port_addr;
 
-	dev = device_get_binding(MDIO_DEVICE);
-	if (!dev) {
-		shell_error(sh, "MDIO: Device driver %s not found.",
-			    MDIO_DEVICE);
+	dev = DEVICE_DT_GET(MDIO_NODE_ID);
+	if (!device_is_ready(dev)) {
+		shell_error(sh, "MDIO: Device driver %s is not ready.", dev->name);
 
 		return -ENODEV;
 	}
@@ -120,7 +118,7 @@ static int cmd_mdio_read(const struct shell *sh, size_t argc, char **argv)
 	mdio_bus_enable(dev);
 
 	if (mdio_read(dev, port_addr, dev_addr, &data) < 0) {
-		shell_error(sh, "Failed to read from device: %s", MDIO_DEVICE);
+		shell_error(sh, "Failed to read from device: %s", dev->name);
 		mdio_bus_disable(dev);
 
 		return -EIO;


### PR DESCRIPTION
Update mdio_shell to use DEVICE_DT_GET to remove usage of
device_get_binding.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>