### PR TITLE
samples: nrf53_sync_rtc: net: Update sample to use DEVICE_DT_GET_ONE

### DIFF
--- a/samples/boards/nrf/nrf53_sync_rtc/net/src/main.c
+++ b/samples/boards/nrf/nrf53_sync_rtc/net/src/main.c
@@ -62,10 +62,9 @@ static int mbox_init(void)
 
 static int ipm_init(void)
 {
-	const struct device *ipm_dev;
+	const struct device *ipm_dev = DEVICE_DT_GET_ONE(nordic_mbox_nrf_ipc);
 
-	ipm_dev = device_get_binding("IPM_2");
-	if (ipm_dev == NULL) {
+	if (!device_is_ready(ipm_dev)) {
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Update sample to use DEVICE_DT_GET_ONE to remove usage of
device_get_binding.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>