### PR TITLE
net: lwm2m: Remove two useless macros

### DIFF
--- a/subsys/net/lib/lwm2m/ipso_current_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_current_sensor.c
@@ -83,13 +83,13 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT]
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
 	min_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
 	max_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
 }
 
 static int reset_min_max_measured_values_cb(uint16_t obj_inst_id,

--- a/subsys/net/lib/lwm2m/ipso_filling_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_filling_sensor.c
@@ -107,14 +107,14 @@ static void update(uint16_t obj_inst_id, uint16_t res_id, int index)
 	full = actual_fill_percentage[index] > high_threshold[index];
 	if (container_full[index] != full) {
 		container_full[index] = full;
-		NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id,
+		lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id,
 				CONTAINER_FULL_FILLING_SENSOR_RID);
 	}
 
 	empty = actual_fill_percentage[index] < low_threshold[index];
 	if (container_empty[index] != empty) {
 		container_empty[index] = empty;
-		NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id,
+		lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id,
 				CONTAINER_EMPTY_FILLING_SENSOR_RID);
 	}
 }

--- a/subsys/net/lib/lwm2m/ipso_generic_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_generic_sensor.c
@@ -92,13 +92,13 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT]
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
 	min_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
 	max_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
 }
 
 static int reset_min_max_measured_values_cb(uint16_t obj_inst_id,

--- a/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_humidity_sensor.c
@@ -78,13 +78,13 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT]
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
 	min_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
 	max_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
 }
 
 static int reset_min_max_measured_values_cb(uint16_t obj_inst_id,

--- a/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_pressure_sensor.c
@@ -79,13 +79,13 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT]
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
 	min_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
 	max_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
+	lwm2m_notify_observer(IPSO_OBJECT_ID, obj_inst_id, MAX_MEASURED_VALUE_RID);
 }
 
 static int reset_min_max_measured_values_cb(uint16_t obj_inst_id,

--- a/subsys/net/lib/lwm2m/ipso_temp_sensor.c
+++ b/subsys/net/lib/lwm2m/ipso_temp_sensor.c
@@ -79,14 +79,14 @@ static struct lwm2m_engine_res_inst
 static void update_min_measured(uint16_t obj_inst_id, int index)
 {
 	min_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_TEMP_SENSOR_ID, obj_inst_id,
+	lwm2m_notify_observer(IPSO_OBJECT_TEMP_SENSOR_ID, obj_inst_id,
 			MIN_MEASURED_VALUE_RID);
 }
 
 static void update_max_measured(uint16_t obj_inst_id, int index)
 {
 	max_measured_value[index] = sensor_value[index];
-	NOTIFY_OBSERVER(IPSO_OBJECT_TEMP_SENSOR_ID, obj_inst_id,
+	lwm2m_notify_observer(IPSO_OBJECT_TEMP_SENSOR_ID, obj_inst_id,
 			MAX_MEASURED_VALUE_RID);
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_engine.h
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.h
@@ -24,10 +24,6 @@
 	STRINGIFY(LWM2M_PROTOCOL_VERSION_MAJOR)                                                    \
 	"." STRINGIFY(LWM2M_PROTOCOL_VERSION_MINOR)
 
-/* TODO: */
-#define NOTIFY_OBSERVER(o, i, r)   lwm2m_notify_observer(o, i, r)
-#define NOTIFY_OBSERVER_PATH(path) lwm2m_notify_observer_path(path)
-
 /* Use this value to generate new token */
 #define LWM2M_MSG_TOKEN_GENERATE_NEW 0xFFU
 

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -966,7 +966,7 @@ int lwm2m_write_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm2m_eng
 	res_inst->data_len = len;
 
 	if (LWM2M_HAS_PERM(obj_field, LWM2M_PERM_R)) {
-		NOTIFY_OBSERVER_PATH(&msg->path);
+		lwm2m_notify_observer_path(&msg->path);
 	}
 
 	return ret;

--- a/subsys/net/lib/lwm2m/lwm2m_obj_device.c
+++ b/subsys/net/lib/lwm2m/lwm2m_obj_device.c
@@ -201,14 +201,14 @@ int lwm2m_device_add_err(uint8_t error_code)
 
 	error_code_list[i] = error_code;
 	error_code_ri[i].res_inst_id = i;
-	NOTIFY_OBSERVER(LWM2M_OBJECT_DEVICE_ID, 0, DEVICE_ERROR_CODE_ID);
+	lwm2m_notify_observer(LWM2M_OBJECT_DEVICE_ID, 0, DEVICE_ERROR_CODE_ID);
 
 	return 0;
 }
 
 static void device_periodic_service(struct k_work *work)
 {
-	NOTIFY_OBSERVER(LWM2M_OBJECT_DEVICE_ID, 0, DEVICE_CURRENT_TIME_ID);
+	lwm2m_notify_observer(LWM2M_OBJECT_DEVICE_ID, 0, DEVICE_CURRENT_TIME_ID);
 }
 
 int lwm2m_update_device_service_period(uint32_t period_ms)

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -587,7 +587,7 @@ static int lwm2m_engine_set(const char *pathstr, void *value, uint16_t len)
 	}
 
 	if (changed && LWM2M_HAS_PERM(obj_field, LWM2M_PERM_R)) {
-		NOTIFY_OBSERVER_PATH(&path);
+		lwm2m_notify_observer_path(&path);
 	}
 
 	return ret;

--- a/subsys/net/lib/lwm2m/ucifi_battery.c
+++ b/subsys/net/lib/lwm2m/ucifi_battery.c
@@ -60,7 +60,7 @@ static struct lwm2m_engine_res_inst res_inst[MAX_INSTANCE_COUNT][RESOURCE_INSTAN
 static void clear_supply_loss_counter(uint16_t obj_inst_id, int index)
 {
 	supply_loss_counter[index] = 0;
-	NOTIFY_OBSERVER(UCIFI_OBJECT_BATTERY_ID, obj_inst_id,
+	lwm2m_notify_observer(UCIFI_OBJECT_BATTERY_ID, obj_inst_id,
 			UCIFI_BATTERY_SUPPLY_LOSS_COUNTER_RID);
 }
 


### PR DESCRIPTION
These two macros just change the name of function call
* NOTIFY_OBSERVER
* NOTIFY_OBSERVER_PATH

I don't see any benefit of those, so I dropped them.
