### PR TITLE
samples: grove_temperature: Update sample to use DEVICE_DT_GET_ONE

### DIFF
--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -31,9 +31,9 @@ void main(void)
 #ifdef CONFIG_GROVE_LCD_RGB
 	const struct device *glcd;
 
-	glcd = device_get_binding(GROVE_LCD_NAME);
-	if (glcd == NULL) {
-		printf("Failed to get Grove LCD\n");
+	glcd = DEVICE_DT_GET_ONE(seeed_grove_lcd_rgb);
+	if (!device_is_ready(glcd)) {
+		printf("Grove LCD is not ready\n");
 		return;
 	}
 


### PR DESCRIPTION
Update sample to use DEVICE_DT_GET_ONE in order to remove usage of
device_get_binding.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>