### PR TITLE
tests: bluetooth: bttester: Update test to use DEVICE_DT_GET

### DIFF
--- a/tests/bluetooth/tester/src/bttester.c
+++ b/tests/bluetooth/tester/src/bttester.c
@@ -273,7 +273,6 @@ static void uart_send(uint8_t *data, size_t len)
 	uart_pipe_send(data, len);
 }
 #else /* !CONFIG_UART_PIPE */
-#define UART_DEV	"UART_0"
 static uint8_t *recv_buf;
 static size_t recv_off;
 static const struct device *dev;
@@ -293,8 +292,8 @@ K_TIMER_DEFINE(timer, timer_expiry_cb, NULL);
 /* Uart Poll */
 static void uart_init(uint8_t *data)
 {
-	dev = device_get_binding(UART_DEV);
-	__ASSERT_NO_MSG((void *)dev);
+	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	__ASSERT_NO_MSG(device_is_ready(dev));
 
 	recv_buf = data;
 


### PR DESCRIPTION
Update test to use DEVICE_DT_GET in order to remove usage of
device_get_binding.

Signed-off-by: Benjamin Björnsson <benjamin.bjornsson@gmail.com>