### PR TITLE
dts: riscv: telink: telink_b91.dtsi: Fix OpenThread subsystem for Telink B91

### DIFF
--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -143,6 +143,7 @@
 		ieee802154: ieee802154@80140800 {
 			compatible = "telink,b91-zb";
 			reg = <0x80140800 0x800>;
+			label = "IEEE802154_b91";
 			interrupt-parent = <&plic0>;
 			interrupts = <15 2>;
 			status = "disabled";


### PR DESCRIPTION
Telink b91 OpenThread sample projects fail due to NULL device binding.
Kconfig provides NET_CONFIG_IEEE802154_DEV_NAME equal to "IEEE802154_b91",
but device tree label was equal to "IEEE802154".

Tested manualy by execution
amples/net/sockets/echo_client & amples/net/sockets/echo_server
with openthread overlay on Telink B91 platform