### PR TITLE
twister: verify all platform names

### DIFF
--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -789,7 +789,7 @@ class TestPlan:
         """
         for platform in platform_names_to_verify:
             if platform in self.platform_names:
-                break
+                continue
             else:
                 logger.error(f"{log_info} - unrecognized platform - {platform}")
                 sys.exit(2)


### PR DESCRIPTION
Fix bug in verify_platforms_existence method - make it possible to
verify all platform names from list - not only first.

Fixes: #48321

Signed-off-by: Piotr Golyzniak <piotr.golyzniak@nordicsemi.no>