### PR TITLE
samples: subsys: nvs: disco_l475_iot1: keep quadspi node

### DIFF
--- a/samples/subsys/nvs/boards/disco_l475_iot1.overlay
+++ b/samples/subsys/nvs/boards/disco_l475_iot1.overlay
@@ -4,8 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/delete-node/ &quadspi;
+
 /delete-node/ &scratch_partition;
+/delete-node/ &storage_partition;
 
 / {
 	chosen {


### PR DESCRIPTION
samples: subsys: nvs: disco_l475_iot1: keep quadspi node

Due to introduction of alias spi-flash0
sha1: 64fbbd9a446ce18a6a941bbbffd7572b338eb123
it is necessary to keep `quadspi `node
Instead of removing `quadspi `node, remove `storage_partition `node

This allows to pass `sample/subsys/nvs`
