### PR TITLE
scripts: twisterlib: Fix --short-build-path argument handling

### DIFF
--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -368,8 +368,7 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
 
     test_xor_generator.add_argument(
         "-N", "--ninja", action="store_true", default="--make" not in sys.argv,
-        help="Use the Ninja generator with CMake. (This is the default)",
-        required="--short-build-path" in sys.argv)
+        help="Use the Ninja generator with CMake. (This is the default)")
 
     test_xor_generator.add_argument(
         "-k", "--make", action="store_true",
@@ -602,6 +601,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
     options = parser.parse_args(args)
 
     # Very early error handling
+    if options.short_build_path and not options.ninja:
+        logger.error("--short-build-path requires Ninja to be enabled")
+        sys.exit(1)
+
     if options.device_serial_pty and os.name == "nt":  # OS is Windows
         logger.error("--device-serial-pty is not supported on Windows OS")
         sys.exit(1)

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -367,7 +367,8 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         help="Delete artifacts of passing tests.")
 
     test_xor_generator.add_argument(
-        "-N", "--ninja", action="store_true", default="--make" not in sys.argv,
+        "-N", "--ninja", action="store_true",
+        default=not any(a in sys.argv for a in ("-k", "--make")),
         help="Use the Ninja generator with CMake. (This is the default)")
 
     test_xor_generator.add_argument(


### PR DESCRIPTION
When `--short-build-path` argument is specified to the twister, the
following error message is displayed because the Python argparse module
does not allow specifying a mutually exclusive argument as required:

  ValueError: mutually exclusive arguments must be optional

This commit removes the `required` parameter when adding the `--ninja`
argument, which is a mutually exclusive argument, and adds a manual
check to validate this condition instead.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

This series also fixes the incorrect default value for the `--ninja` argument (see the 2nd commit).