### PR TITLE
samples: reel_board: mesh_badge: Select flash controller by area

### DIFF
--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -562,7 +562,7 @@ static int configure_leds(void)
 
 static int erase_storage(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+	const struct device *dev = FLASH_AREA_DEVICE(storage);
 
 	if (!device_is_ready(dev)) {
 		printk("Flash device not ready\n");


### PR DESCRIPTION
Flash controller has been specified by `zephyr,flash-controller`
chosen DTS, which does not have to be the same controller as
a flash area exists on.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>