### PR TITLE
drivers: Fix coding guidelines MISRAC:2012 Rule 14.4 do-whiles/Zero checks

### DIFF
--- a/drivers/adc/adc_cc32xx.c
+++ b/drivers/adc/adc_cc32xx.c
@@ -294,7 +294,7 @@ static const struct adc_driver_api cc32xx_driver_api = {
 			    adc_cc32xx_isr_ch##chan,		       \
 			    DEVICE_DT_INST_GET(index), 0);	       \
 		irq_enable(DT_INST_IRQ_BY_IDX(index, chan, irq));      \
-	} while (0)
+	} while (false)
 
 #define cc32xx_ADC_INIT(index)							 \
 										 \

--- a/drivers/adc/adc_sam0.c
+++ b/drivers/adc/adc_sam0.c
@@ -526,7 +526,7 @@ do {									\
 	adc->CALIB.reg = ADC_SAM0_BIASCOMP(n)				\
 			 | ADC_SAM0_BIASR2R(n)				\
 			 | ADC_SAM0_BIASREFBUF(n);			\
-} while (0)
+} while (false)
 
 #else
 
@@ -551,7 +551,7 @@ do {									\
 		      ADC_FUSES_BIASCAL_Msk) >> ADC_FUSES_BIASCAL_Pos;	\
 	adc->CALIB.reg = ADC_CALIB_BIAS_CAL(bias) |			\
 			 ADC_CALIB_LINEARITY_CAL(lin);			\
-} while (0)
+} while (false)
 
 #endif
 

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -846,7 +846,7 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 		mcux_flexcan_isr,					\
 		DEVICE_DT_INST_GET(id), 0);				\
 		irq_enable(DT_INST_IRQ_BY_NAME(id, name, irq));		\
-	} while (0)
+	} while (false)
 
 #define FLEXCAN_IRQ(id, name) \
 	COND_CODE_1(DT_INST_IRQ_HAS_NAME(id, name), \

--- a/drivers/dma/dma_sam0.c
+++ b/drivers/dma/dma_sam0.c
@@ -398,7 +398,7 @@ static int dma_sam0_get_status(const struct device *dev, uint32_t channel,
 			    DT_INST_IRQ_BY_IDX(0, n, priority),		 \
 			    dma_sam0_isr, DEVICE_DT_INST_GET(0), 0);	 \
 		irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		 \
-	} while (0)
+	} while (false)
 
 static int dma_sam0_init(const struct device *dev)
 {

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -718,7 +718,7 @@ DEVICE_DT_INST_DEFINE(index,						\
 			    dma_stm32_shared_irq_handler,		\
 			    DEVICE_DT_INST_GET(dma), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(dma, chan, irq));		\
-	} while (0)
+	} while (false)
 
 
 #else /* CONFIG_DMA_STM32_SHARED_IRQS */
@@ -737,7 +737,7 @@ static void dma_stm32_irq_##dma##_##chan(const struct device *dev)	\
 			    dma_stm32_irq_##dma##_##chan,		\
 			    DEVICE_DT_INST_GET(dma), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(dma, chan, irq));		\
-	} while (0)
+	} while (false)
 
 #endif /* CONFIG_DMA_STM32_SHARED_IRQS */
 

--- a/drivers/ethernet/eth_e1000_priv.h
+++ b/drivers/ethernet/eth_e1000_priv.h
@@ -98,7 +98,7 @@ static const char *e1000_reg_to_string(enum e1000_reg_t r)
 #define iow32(_dev, _reg, _val) do {					\
 	LOG_DBG("iow32 %s 0x%08x", e1000_reg_to_string(_reg), (_val)); 	\
 	sys_write32(_val, (_dev)->address + (_reg));			\
-} while (0)
+} while (false)
 
 #define ior32(_dev, _reg)						\
 ({									\

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1447,7 +1447,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 			    DEVICE_DT_INST_GET(n),			\
 			    0);						\
 		irq_enable(DT_INST_IRQ_BY_NAME(n, name, irq));		\
-	} while (0)
+	} while (false)
 
 #define ETH_MCUX_IRQ(n, name)						\
 	COND_CODE_1(DT_INST_IRQ_HAS_NAME(n, name),			\
@@ -1465,7 +1465,7 @@ static void eth_mcux_err_isr(const struct device *dev)
 			    DEVICE_DT_INST_GET(n),					\
 			    0);								\
 		irq_enable(DT_IRQ_BY_NAME(PTP_INST_NODEID(n), ieee1588_tmr, irq));	\
-	} while (0)
+	} while (false)
 
 #define ETH_MCUX_IRQ_PTP(n)						\
 	COND_CODE_1(DT_NODE_HAS_STATUS(PTP_INST_NODEID(n), okay),	\

--- a/drivers/flash/flash_simulator.c
+++ b/drivers/flash/flash_simulator.c
@@ -69,7 +69,7 @@
 		if (U < STATS_PAGE_COUNT_THRESHOLD) {			     \
 			(*(&flash_sim_stats.erase_cycles_unit0 + (U)) += 1); \
 		}							     \
-	} while (0)
+	} while (false)
 
 #if (CONFIG_FLASH_SIMULATOR_STAT_PAGE_COUNT > STATS_PAGE_COUNT_THRESHOLD)
        /* Limitation above is caused by used LISTIFY                        */
@@ -135,7 +135,7 @@ STATS_NAME_END(flash_sim_thresholds);
 
 #else
 
-#define ERASE_CYCLES_INC(U) do {} while (0)
+#define ERASE_CYCLES_INC(U) do {} while (false)
 #define FLASH_SIM_STATS_INC(group__, var__)
 #define FLASH_SIM_STATS_INCN(group__, var__, n__)
 #define FLASH_SIM_STATS_INIT_AND_REG(group__, size__, name__)

--- a/drivers/gpio/gpio_litex.c
+++ b/drivers/gpio/gpio_litex.c
@@ -307,7 +307,7 @@ static const struct gpio_driver_api gpio_litex_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0); \
 \
 		irq_enable(DT_INST_IRQN(n)); \
-	} while (0)
+	} while (false)
 
 #define GPIO_LITEX_INIT(n) \
 	static int gpio_litex_port_init_##n(const struct device *dev); \

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -512,7 +512,7 @@ do {							                \
 		    DT_INST_IRQ_BY_IDX(0, n, priority),			\
 		    gpio_lpc11u6x_isr, &gpio_lpc11u6x_shared, 0);	\
 	irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));			\
-} while (0)
+} while (false)
 
 static int gpio_lpc11u6x_init(const struct device *dev)
 {

--- a/drivers/gpio/gpio_mcux.c
+++ b/drivers/gpio/gpio_mcux.c
@@ -304,7 +304,7 @@ static const struct gpio_driver_api gpio_mcux_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQN(n));				\
-	} while (0)
+	} while (false)
 
 #define GPIO_PORT_BASE_ADDR(n) DT_REG_ADDR(DT_INST_PHANDLE(n, nxp_kinetis_port))
 

--- a/drivers/gpio/gpio_mcux_igpio.c
+++ b/drivers/gpio/gpio_mcux_igpio.c
@@ -384,7 +384,7 @@ static const struct gpio_driver_api mcux_igpio_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 
 #define MCUX_IGPIO_INIT(n)						\
 	MCUX_IGPIO_PIN_DECLARE(n)					\

--- a/drivers/gpio/gpio_mcux_lpc.c
+++ b/drivers/gpio/gpio_mcux_lpc.c
@@ -408,7 +408,7 @@ static const clock_ip_name_t gpio_clock_names[] = GPIO_CLOCKS;
 			    gpio_mcux_lpc_port_isr, DEVICE_DT_INST_GET(n), 0);		\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));				\
 		data->isr_list[data->isr_list_idx++] = DT_INST_IRQ_BY_IDX(n, m, irq);	\
-	} while (0)
+	} while (false)
 
 #define GPIO_MCUX_LPC_IRQ(n, m)								\
 	COND_CODE_1(DT_INST_IRQ_HAS_IDX(n, m), (GPIO_MCUX_LPC_IRQ_CONNECT(n, m)), ())

--- a/drivers/gpio/gpio_sam4l.c
+++ b/drivers/gpio/gpio_sam4l.c
@@ -243,7 +243,7 @@ int gpio_sam_init(const struct device *dev)
 			    gpio_sam_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
-	} while (0)
+	} while (false)
 
 #define GPIO_SAM_INIT(n)						\
 	static void port_##n##_sam_config_func(const struct device *dev);\

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -293,7 +293,7 @@ static int i2c_stm32_init(const struct device *dev)
 			    stm32_i2c_combined_isr,			\
 			    DEVICE_DT_GET(DT_NODELABEL(name)), 0);	\
 		irq_enable(DT_IRQN(DT_NODELABEL(name)));		\
-	} while (0)
+	} while (false)
 #else
 #define STM32_I2C_IRQ_CONNECT_AND_ENABLE(name)				\
 	do {								\
@@ -310,7 +310,7 @@ static int i2c_stm32_init(const struct device *dev)
 			    stm32_i2c_error_isr,			\
 			    DEVICE_DT_GET(DT_NODELABEL(name)), 0);	\
 		irq_enable(DT_IRQ_BY_NAME(DT_NODELABEL(name), error, irq));\
-	} while (0)
+	} while (false)
 #endif /* CONFIG_I2C_STM32_COMBINED_INTERRUPT */
 
 #define STM32_I2C_IRQ_HANDLER_DECL(name)				\

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -780,7 +780,7 @@ static const struct i2c_driver_api i2c_sam0_driver_api = {
 			    i2c_sam0_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
-	} while (0)
+	} while (false)
 
 #if DT_INST_IRQ_HAS_IDX(0, 3)
 #define I2C_SAM0_IRQ_HANDLER(n)						\

--- a/drivers/ieee802154/ieee802154_kw41z.c
+++ b/drivers/ieee802154/ieee802154_kw41z.c
@@ -67,7 +67,7 @@ int kw41_dbg_idx;
 		if (++kw41_dbg_idx == KW41_DBG_TRACE_SIZE) { \
 			kw41_dbg_idx = 0; \
 		} \
-	} while (0)
+	} while (false)
 
 #else
 

--- a/drivers/interrupt_controller/intc_esp32.c
+++ b/drivers/interrupt_controller/intc_esp32.c
@@ -41,7 +41,7 @@ LOG_MODULE_REGISTER(esp32_intc, CONFIG_LOG_DEFAULT_LEVEL);
 #ifdef CONFIG_INTC_ESP32_DECISIONS_LOG
 # define INTC_LOG(...) LOG_INF(__VA_ARGS__)
 #else
-# define INTC_LOG(...) do {} while (0)
+# define INTC_LOG(...) do {} while (false)
 #endif
 
 /* Typedef for C-callable interrupt handler function */

--- a/drivers/interrupt_controller/intc_loapic.c
+++ b/drivers/interrupt_controller/intc_loapic.c
@@ -323,7 +323,7 @@ int z_irq_controller_isr_vector_get(void)
 	 */
 	for (block = 7; likely(block > 0); block--) {
 		pReg = x86_read_loapic(LOAPIC_ISR + (block * 0x10));
-		if (pReg) {
+		if (pReg != 0) {
 			return (block * 32) + (find_msb_set(pReg) - 1);
 		}
 

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -329,7 +329,7 @@ uint32_t sam0_eic_interrupt_pending(int port)
 			    DT_INST_IRQ_BY_IDX(0, n, priority),		\
 			    sam0_eic_isr, DEVICE_DT_INST_GET(0), 0);	\
 		irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		\
-	} while (0)
+	} while (false)
 
 static int sam0_eic_init(const struct device *dev)
 {

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -75,7 +75,7 @@ struct ws2812_gpio_cfg {
 			DELAY_TxL			\
 			::				\
 			[r] "l" (base),		\
-			[p] "l" (pin)); } while (0)
+			[p] "l" (pin)); } while (false)
 
 /* Send out a 0 bit's pulse */
 #define ZERO_BIT(base, pin) do {			\
@@ -85,7 +85,7 @@ struct ws2812_gpio_cfg {
 			DELAY_TxL			\
 			::				\
 			[r] "l" (base),		\
-			[p] "l" (pin)); } while (0)
+			[p] "l" (pin)); } while (false)
 
 static int send_buf(const struct device *dev, uint8_t *buf, size_t len)
 {

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -310,7 +310,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 			LOG_ERR("%s result:%d", (c), ret);                     \
 			goto error;                                            \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 #define SEND_AT_CMD_IGNORE_ERROR(c)                                            \
 	do {                                                                   \
@@ -318,7 +318,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 		if (ret < 0) {                                                 \
 			LOG_ERR("%s result:%d", (c), ret);                     \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 #define SEND_AT_CMD_EXPECT_OK(c)                                               \
 	do {                                                                   \
@@ -328,7 +328,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 			LOG_ERR("%s result:%d", (c), ret);                     \
 			goto error;                                            \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 /* Complex has "no_id_resp" set to true because the sending command
  * is the command used to process the response
@@ -341,7 +341,7 @@ static const char TIME_STRING_FORMAT[] = "\"yy/MM/dd,hh:mm:ss?zz\"";
 			LOG_ERR("%s result:%d", (c), ret);                     \
 			goto error;                                            \
 		}                                                              \
-	} while (0)
+	} while (false)
 
 NET_BUF_POOL_DEFINE(mdm_recv_pool, CONFIG_MODEM_HL7800_RECV_BUF_CNT,
 		    CONFIG_MODEM_HL7800_RECV_BUF_SIZE, 0, NULL);
@@ -2982,7 +2982,7 @@ static bool on_cmd_polte_registration(struct net_buf **buf, uint16_t len)
 			break;
 		}
 		parsed = true;
-	} while (0);
+	} while (false);
 
 	if (parsed && data.user && data.password) {
 		data.status = 0;
@@ -3027,7 +3027,7 @@ static bool on_cmd_polte_locate_cmd_rsp(struct net_buf **buf, uint16_t len)
 		rsp[out_len] = 0;
 
 		data.status = (uint32_t)strtoul(rsp, NULL, 10);
-	} while (0);
+	} while (false);
 
 	event_handler(HL7800_EVENT_POLTE_LOCATE_STATUS, &data);
 
@@ -3124,7 +3124,7 @@ static bool on_cmd_polte_location(struct net_buf **buf, uint16_t len)
 		}
 
 		parsed = true;
-	} while (0);
+	} while (false);
 
 	if (!parsed) {
 		LOG_HEXDUMP_ERR(rsp, out_len, "Unable to parse PoLTE location");

--- a/drivers/pcie/host/msi.c
+++ b/drivers/pcie/host/msi.c
@@ -248,7 +248,7 @@ static void enable_msi(pcie_bdf_t bdf,
 
 	mdr = pcie_msi_mdr(irq, vectors);
 	mcr = pcie_conf_read(bdf, base + PCIE_MSI_MCR);
-	if (mcr & PCIE_MSI_MCR_64) {
+	if ((mcr & PCIE_MSI_MCR_64) != 0U) {
 		pcie_conf_write(bdf, base + PCIE_MSI_MAP1_64, 0U);
 		pcie_conf_write(bdf, base + PCIE_MSI_MDR_64, mdr);
 	} else {

--- a/drivers/pcie/host/pcie.c
+++ b/drivers/pcie/host/pcie.c
@@ -60,12 +60,12 @@ uint32_t pcie_get_cap(pcie_bdf_t bdf, uint32_t cap_id)
 	uint32_t data;
 
 	data = pcie_conf_read(bdf, PCIE_CONF_CMDSTAT);
-	if (data & PCIE_CONF_CMDSTAT_CAPS) {
+	if ((data & PCIE_CONF_CMDSTAT_CAPS) != 0U) {
 		data = pcie_conf_read(bdf, PCIE_CONF_CAPPTR);
 		reg = PCIE_CONF_CAPPTR_FIRST(data);
 	}
 
-	while (reg) {
+	while (reg != 0U) {
 		data = pcie_conf_read(bdf, reg);
 
 		if (PCIE_CONF_CAP_ID(data) == cap_id) {
@@ -83,7 +83,7 @@ uint32_t pcie_get_ext_cap(pcie_bdf_t bdf, uint32_t cap_id)
 	unsigned int reg = PCIE_CONF_EXT_CAPPTR; /* Start at end of the PCI configuration space */
 	uint32_t data;
 
-	while (reg) {
+	while (reg != 0U) {
 		data = pcie_conf_read(bdf, reg);
 		if (!data || data == 0xffffffffU) {
 			return 0;

--- a/drivers/serial/uart_cc13xx_cc26xx.c
+++ b/drivers/serial/uart_cc13xx_cc26xx.c
@@ -510,7 +510,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		Power_registerNotify(&data->postNotify,			\
 			PowerCC26XX_AWAKE_STANDBY,			\
 			postNotifyFxn, (uintptr_t)dev);			\
-	} while (0)
+	} while (false)
 #else
 #define UART_CC13XX_CC26XX_POWER_UART(n)				\
 	do {								\
@@ -541,7 +541,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 			PRCM_DOMAIN_POWER_ON) {				     \
 			continue;					     \
 		}							     \
-	} while (0)
+	} while (false)
 #endif
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -560,7 +560,7 @@ static const struct uart_driver_api uart_cc13xx_cc26xx_driver_api = {
 		irq_enable(DT_INST_IRQN(n));				\
 		/* Causes an initial TX ready INT when TX INT enabled */\
 		UARTCharPutNonBlocking(config->reg, '\0');		\
-	} while (0)
+	} while (false)
 
 #define UART_CC13XX_CC26XX_INT_FIELDS					\
 	.callback = NULL,						\

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -281,7 +281,7 @@ static const struct uart_driver_api mcux_iuart_driver_api = {
 			    mcux_iuart_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 #define IUART_MCUX_CONFIG_FUNC(n)					\
 	static void mcux_iuart_config_func_##n(const struct device *dev) \
 	{								\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -1094,7 +1094,7 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 			    mcux_lpuart_isr, DEVICE_DT_INST_GET(n), 0);	\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 #define MCUX_LPUART_IRQ_INIT(n) .irq_config_func = mcux_lpuart_config_func_##n,
 #define MCUX_LPUART_IRQ_DEFINE(n)						\
 	static void mcux_lpuart_config_func_##n(const struct device *dev)	\

--- a/drivers/serial/uart_nrfx_uarte.c
+++ b/drivers/serial/uart_nrfx_uarte.c
@@ -2020,7 +2020,7 @@ static int uarte_nrfx_pm_action(const struct device *dev,
 		IRQ_CONNECT(DT_IRQN(UARTE(idx)), DT_IRQ(UARTE(idx), priority), \
 			    isr_handler, DEVICE_DT_GET(UARTE(idx)), 0);	       \
 		irq_enable(DT_IRQN(UARTE(idx)));			       \
-	} while (0)
+	} while (false)
 
 #ifdef CONFIG_PINCTRL
 /* Low power mode is used when disable_rx is not defined or in async mode if

--- a/drivers/serial/uart_sam0.c
+++ b/drivers/serial/uart_sam0.c
@@ -1201,7 +1201,7 @@ static const struct uart_driver_api uart_sam0_driver_api = {
 			    uart_sam0_isr,				\
 			    DEVICE_DT_INST_GET(n), 0);			\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, m, irq));		\
-	} while (0)
+	} while (false)
 
 #define UART_SAM0_IRQ_HANDLER_DECL(n)					\
 	static void uart_sam0_irq_config_##n(const struct device *dev)

--- a/drivers/serial/uart_xlnx_uartlite.c
+++ b/drivers/serial/uart_xlnx_uartlite.c
@@ -378,7 +378,7 @@ static const struct uart_driver_api xlnx_uartlite_driver_api = {
 			    DEVICE_DT_INST_GET(n), 0);			\
 									\
 		irq_enable(DT_INST_IRQ_BY_IDX(n, i, irq));		\
-	} while (0)
+	} while (false)
 #define XLNX_UARTLITE_CONFIG_FUNC(n)					\
 	static void xlnx_uartlite_config_func_##n(const struct device *dev) \
 	{								\

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -248,7 +248,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 		} else {						  \
 			Power_setDependency(PowerCC26XX_PERIPH_SSI1);	  \
 		}							  \
-	} while (0)
+	} while (false)
 #else
 #define SPI_CC13XX_CC26XX_POWER_SPI(n)					  \
 	do {								  \
@@ -281,7 +281,7 @@ static const struct spi_driver_api spi_cc13xx_cc26xx_driver_api = {
 			PRCM_DOMAIN_POWER_ON) {				  \
 			continue;					  \
 		}							  \
-	} while (0)
+	} while (false)
 #endif
 
 #define SPI_CC13XX_CC26XX_DEVICE_INIT(n)				    \

--- a/drivers/usb/device/usb_dc_sam0.c
+++ b/drivers/usb/device/usb_dc_sam0.c
@@ -210,7 +210,7 @@ static void usb_sam0_load_padcal(void)
 		    DT_INST_IRQ_BY_IDX(0, n, priority),		\
 		    usb_sam0_isr, 0, 0);			\
 	irq_enable(DT_INST_IRQ_BY_IDX(0, n, irq));		\
-	} while (0)
+	} while (false)
 
 /* Attach by initializing the device */
 int usb_dc_attach(void)


### PR DESCRIPTION
Fix coding guideline MISRA C:2012 Rule 14.4 do-while and implicitly testing integers violations in drivers:
> The controlling expression of an if statement
> and the controlling expression of an iteration-statement shall have
> essentially Boolean type.

This PR is part of the enhancement issue #48002 which port the coding guideline fixes done by BUGSENG on the https://github.com/zephyrproject-rtos/zephyr/tree/v2.7-auditable-branch back to main

The commit in this PR is a subset of the original auditable-branch commit:
5d02614e34a86b549c7707d3d9f0984bc3a5f22a