### PR TITLE
boards: arm: nrf9160dk_nrf52840: Set code partition to slot0

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
+++ b/boards/arm/nrf9160dk_nrf52840/nrf9160dk_nrf52840.dts
@@ -20,6 +20,7 @@
 		zephyr,bt-mon-uart = &uart0;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
 	};
 
 	interface_to_nrf9160: gpio-interface {


### PR DESCRIPTION
Set missing code-partition to slot0 for nrf9160dk_nrf52840.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>