### PR TITLE
dts: arm: atmel: Remove label property from devicetrees

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -36,7 +36,6 @@
 		/* Only used for HWINFO device ID */
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0a00 0x200>;
 			peripheral-id = <6>;
 
@@ -45,7 +44,6 @@
 
 			flash0: flash@80000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				reg = <0x00080000 0x80000>;
 
 				write-block-size = <16>;
@@ -57,7 +55,6 @@
 			reg = <0x400e1a50 0xc>;
 			interrupts = <4 0>;
 			peripheral-id = <4>;
-			label = "WATCHDOG_0";
 			status = "disabled";
 		};
 
@@ -67,7 +64,6 @@
 			reg = <0x4008c000 0x128>;
 			interrupts = <22 0>;
 			peripheral-id = <22>;
-			label = "I2C_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -79,7 +75,6 @@
 			reg = <0x40090000 0x128>;
 			interrupts = <23 0>;
 			peripheral-id = <23>;
-			label = "I2C_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -91,7 +86,6 @@
 			interrupts = <8 1>;
 			peripheral-id = <8>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		usart0: usart@40098000 {
@@ -100,7 +94,6 @@
 			interrupts = <17 0>;
 			peripheral-id = <17>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@4009c000 {
@@ -109,7 +102,6 @@
 			interrupts = <18 0>;
 			peripheral-id = <18>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@400a0000 {
@@ -118,7 +110,6 @@
 			interrupts = <19 0>;
 			peripheral-id = <19>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		usart3: usart@400a4000 {
@@ -127,7 +118,6 @@
 			interrupts = <20 0>;
 			peripheral-id = <20>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		pinctrl: pinctrl@400e0e00 {
@@ -141,7 +131,6 @@
 				reg = <0x400e0e00 0x190>;
 				interrupts = <11 1>;
 				peripheral-id = <11>;
-				label = "PIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -152,7 +141,6 @@
 				reg = <0x400e1000 0x190>;
 				interrupts = <12 1>;
 				peripheral-id = <12>;
-				label = "PIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -163,7 +151,6 @@
 				reg = <0x400e1200 0x190>;
 				interrupts = <13 1>;
 				peripheral-id = <13>;
-				label = "PIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -174,7 +161,6 @@
 				reg = <0x400e1400 0x190>;
 				interrupts = <14 1>;
 				peripheral-id = <14>;
-				label = "PIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -185,7 +171,6 @@
 				reg = <0x400e1600 0x190>;
 				interrupts = <15 1>;
 				peripheral-id = <15>;
-				label = "PIO_E";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -200,7 +185,6 @@
 				      29 0>;
 			peripheral-id = <27 28 29>;
 			status = "disabled";
-			label = "TC0";
 		};
 
 		tc1: tc@40084000 {
@@ -211,7 +195,6 @@
 				      32 0>;
 			peripheral-id = <30 31 32>;
 			status = "disabled";
-			label = "TC1";
 		};
 
 		tc2: tc@40088000 {
@@ -222,7 +205,6 @@
 				      35 0>;
 			peripheral-id = <33 34 35>;
 			status = "disabled";
-			label = "TC2";
 		};
 	};
 };

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -44,7 +44,6 @@
 		/* Only used for HWINFO device ID */
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0a00 0x200>;
 			peripheral-id = <6>;
 
@@ -53,7 +52,6 @@
 
 			flash0: flash@400000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 
 				write-block-size = <16>;
 			};
@@ -64,7 +62,6 @@
 			reg = <0x400e1850 0x10>;
 			interrupts = <4 0>;
 			peripheral-id = <4>;
-			label = "WATCHDOG_0";
 			status = "disabled";
 		};
 
@@ -74,7 +71,6 @@
 			reg = <0x400a8000 0x4000>;
 			interrupts = <17 0>;
 			peripheral-id = <17>;
-			label = "I2C_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -86,7 +82,6 @@
 			reg = <0x400ac000 0x4000>;
 			interrupts = <18 0>;
 			peripheral-id = <18>;
-			label = "I2C_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -99,7 +94,6 @@
 			reg = <0x40088000 0x4000>;
 			interrupts = <19 0>;
 			peripheral-id = <19>;
-			label = "SPI_0";
 			status = "disabled";
 		};
 
@@ -109,7 +103,6 @@
 			interrupts = <7 1>;
 			peripheral-id = <7>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: uart@40060600 {
@@ -118,7 +111,6 @@
 			interrupts = <45 1>;
 			peripheral-id = <45>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		usart0: usart@400a0000 {
@@ -127,7 +119,6 @@
 			interrupts = <14 1>;
 			peripheral-id = <14>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@400a4000 {
@@ -136,7 +127,6 @@
 			interrupts = <15 1>;
 			peripheral-id = <15>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		gmac: ethernet@40034000 {
@@ -147,12 +137,10 @@
 			interrupt-names = "gmac";
 			num-queues = <1>;
 			phy-connection-type = "mii";
-			label = "GMAC";
 			status = "disabled";
 
 			mdio: mdio {
 				compatible = "atmel,sam-mdio";
-				label = "MDIO";
 				status = "disabled";
 			};
 		};
@@ -163,14 +151,12 @@
 			#size-cells = <1>;
 			ranges = <0x400e0e00 0x400e0e00 0xa00>;
 			status = "okay";
-			label = "PINCTRL";
 
 			pioa: gpio@400e0e00 {
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e0e00 0x200>;
 				interrupts = <9 1>;
 				peripheral-id = <9>;
-				label = "PORTA";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -181,7 +167,6 @@
 				reg = <0x400e1000 0x200>;
 				interrupts = <10 1>;
 				peripheral-id = <10>;
-				label = "PORTB";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -192,7 +177,6 @@
 				reg = <0x400e1200 0x200>;
 				interrupts = <11 1>;
 				peripheral-id = <11>;
-				label = "PORTC";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -203,7 +187,6 @@
 				reg = <0x400e1400 0x200>;
 				interrupts = <12 1>;
 				peripheral-id = <12>;
-				label = "PORTD";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -214,7 +197,6 @@
 				reg = <0x400e1600 0x200>;
 				interrupts = <13 1>;
 				peripheral-id = <13>;
-				label = "PORTE";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -229,7 +211,6 @@
 				      23 0>;
 			peripheral-id = <21 22 23>;
 			status = "disabled";
-			label = "TC0";
 		};
 
 		tc1: tc@40094000 {
@@ -240,7 +221,6 @@
 				      26 0>;
 			peripheral-id = <24 25 26>;
 			status = "disabled";
-			label = "TC1";
 		};
 
 		tc2: tc@40098000 {
@@ -251,7 +231,6 @@
 				      29 0>;
 			peripheral-id = <27 28 29>;
 			status = "disabled";
-			label = "TC2";
 		};
 	};
 };

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -52,7 +52,6 @@
 	soc {
 		flashcalw: flash-controller@400a0000 {
 			compatible = "atmel,sam-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400a0000 0x400>;
 			interrupts = <0 0>;
 			peripheral-id = <32>;
@@ -61,7 +60,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 
 				write-block-size = <16>;
 			};
@@ -73,7 +71,6 @@
 			reg = <0x40018000 0x4000>;
 			interrupts = <61 0>;
 			peripheral-id = <4>;
-			label = "TWIM_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -84,7 +81,6 @@
 			reg = <0x4001c000 0x4000>;
 			interrupts = <63 0>;
 			peripheral-id = <6>;
-			label = "TWIM_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -95,7 +91,6 @@
 			reg = <0x40078000 0x4000>;
 			interrupts = <77 0>;
 			peripheral-id = <21>;
-			label = "TWIM_2";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -106,7 +101,6 @@
 			reg = <0x4007c000 0x4000>;
 			interrupts = <78 0>;
 			peripheral-id = <22>;
-			label = "TWIM_3";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -117,7 +111,6 @@
 			reg = <0x40008000 0x4000>;
 			interrupts = <54 0>;
 			peripheral-id = <1>;
-			label = "SPI_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -129,7 +122,6 @@
 			interrupts = <65 1>;
 			peripheral-id = <8>;
 			status = "disabled";
-			label = "USART_0";
 		};
 		usart1: usart@40028000 {
 			compatible = "atmel,sam-usart";
@@ -137,7 +129,6 @@
 			interrupts = <66 1>;
 			peripheral-id = <9>;
 			status = "disabled";
-			label = "USART_1";
 		};
 		usart2: usart@4002c000 {
 			compatible = "atmel,sam-usart";
@@ -145,7 +136,6 @@
 			interrupts = <67 1>;
 			peripheral-id = <10>;
 			status = "disabled";
-			label = "USART_2";
 		};
 		usart3: usart@40030000 {
 			compatible = "atmel,sam-usart";
@@ -153,7 +143,6 @@
 			interrupts = <68 1>;
 			peripheral-id = <11>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		usbc: usbd@400a5000 {
@@ -165,7 +154,6 @@
 			num-bidir-endpoints = <8>;
 			peripheral-id = <101>;
 			status = "disabled";
-			label = "USBC";
 		};
 
 		pinctrl: pinctrl@400e1000 {
@@ -179,7 +167,6 @@
 				reg = <0x400e1000 0x200>;
 				interrupts = <25 1>, <26 1>, <27 1>, <28 1>;
 				peripheral-id = <68>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -189,7 +176,6 @@
 				reg = <0x400e1200 0x200>;
 				interrupts = <29 1>, <30 1>, <31 1>, <32 1>;
 				peripheral-id = <68>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -199,7 +185,6 @@
 				reg = <0x400e1400 0x200>;
 				interrupts = <33 1>, <34 1>, <35 1>, <36 1>;
 				peripheral-id = <68>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -214,7 +199,6 @@
 				      57 0>;
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "TC0";
 		};
 
 		tc1: tc@40014000 {
@@ -225,7 +209,6 @@
 				      60 0>;
 			peripheral-id = <3>;
 			status = "disabled";
-			label = "TC1";
 		};
 
 		trng: random@40068000 {
@@ -234,7 +217,6 @@
 			interrupts = <73 0>;
 			peripheral-id = <17>;
 			status = "okay";
-			label = "TRNG";
 		};
 
 		uid: device_uid@80020c {

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -45,7 +45,6 @@
 		/* Only used for HWINFO device ID */
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0a00 0x200>;
 			peripheral-id = <6>;
 
@@ -54,7 +53,6 @@
 
 			flash0: flash@400000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 
 				write-block-size = <16>;
 			};
@@ -65,7 +63,6 @@
 			reg = <0x400e1450 0xc>;
 			interrupts = <4 0>;
 			peripheral-id = <4>;
-			label = "WATCHDOG_0";
 			status = "disabled";
 		};
 
@@ -75,7 +72,6 @@
 			reg = <0x40018000 0x128>;
 			interrupts = <19 0>;
 			peripheral-id = <19>;
-			label = "I2C_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -87,7 +83,6 @@
 			reg = <0x4001c000 0x128>;
 			interrupts = <20 0>;
 			peripheral-id = <20>;
-			label = "I2C_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -100,7 +95,6 @@
 			reg = <0x40008000 0x4000>;
 			interrupts = <21 0>;
 			peripheral-id = <21>;
-			label = "SPI_0";
 			status = "disabled";
 		};
 
@@ -110,7 +104,6 @@
 			interrupts = <8 1>;
 			peripheral-id = <8>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: uart@400e0800 {
@@ -119,7 +112,6 @@
 			interrupts = <9 1>;
 			peripheral-id = <9>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		usart0: usart@40024000 {
@@ -128,7 +120,6 @@
 			interrupts = <14 1>;
 			peripheral-id = <14>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40028000 {
@@ -137,7 +128,6 @@
 			interrupts = <15 1>;
 			peripheral-id = <15>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		pinctrl: pinctrl@400e0e00 {
@@ -146,14 +136,12 @@
 			#size-cells = <1>;
 			ranges = <0x400e0e00 0x400e0e00 0x600>;
 			status = "okay";
-			label = "PINCTRL";
 
 			pioa: gpio@400e0e00 {
 				compatible = "atmel,sam-gpio";
 				reg = <0x400e0e00 0x190>;
 				interrupts = <11 1>;
 				peripheral-id = <11>;
-				label = "PORTA";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -164,7 +152,6 @@
 				reg = <0x400e1000 0x190>;
 				interrupts = <12 1>;
 				peripheral-id = <12>;
-				label = "PORTB";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -175,7 +162,6 @@
 				reg = <0x400e1200 0x190>;
 				interrupts = <13 1>;
 				peripheral-id = <13>;
-				label = "PORTC";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -190,7 +176,6 @@
 				      25 0>;
 			peripheral-id = <23 24 25>;
 			status = "disabled";
-			label = "TC0";
 		};
 
 		tc1: tc@40014000 {
@@ -201,14 +186,12 @@
 				      28 0>;
 			peripheral-id = <26 27 28>;
 			status = "disabled";
-			label = "TC1";
 		};
 
 		rstc: rstc@400e1400 {
 			compatible = "atmel,sam-rstc";
 			reg = <0x400e1400 0x10>;
 			peripheral-id = <1>;
-			label = "RSTC";
 			user-nrst;
 		};
 	};

--- a/dts/arm/atmel/samd20.dtsi
+++ b/dts/arm/atmel/samd20.dtsi
@@ -18,7 +18,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x42002000 0x20>;
 			interrupts = <13 0>;
-			label = "TIMER_0";
 			clocks = <&gclk 0x13>, <&pm 0x20 8>;
 			clock-names = "GCLK", "PM";
 		};
@@ -27,7 +26,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x42002800 0x20>;
 			interrupts = <15 0>;
-			label = "TIMER_2";
 			clocks = <&gclk 0x14>, <&pm 0x20 10>;
 			clock-names = "GCLK", "PM";
 		};
@@ -36,7 +34,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x42003800 0x20>;
 			interrupts = <19 0>;
-			label = "TIMER_6";
 			clocks = <&gclk 0x16>, <&pm 0x20 14>;
 			clock-names = "GCLK", "PM";
 		};

--- a/dts/arm/atmel/samd21.dtsi
+++ b/dts/arm/atmel/samd21.dtsi
@@ -18,14 +18,12 @@
 			reg = <0x41005000 0x1000>;
 			interrupts = <7 0>;
 			num-bidir-endpoints = <8>;
-			label = "USB0";
 		};
 
 		dmac: dmac@41004800 {
 			compatible = "atmel,sam0-dmac";
 			reg = <0x41004800 0x50>;
 			interrupts = <6 0>;
-			label = "DMA_0";
 			#dma-cells = <2>;
 		};
 
@@ -33,7 +31,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x42003800 0x20>;
 			interrupts = <21 0>;
-			label = "TIMER_6";
 			clocks = <&gclk 0x1d>, <&pm 0x20 14>;
 			clock-names = "GCLK", "PM";
 		};
@@ -42,7 +39,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42002000 0x80>;
 			interrupts = <15 0>;
-			label = "TCC_0";
 			clocks = <&gclk 26>, <&pm 0x20 8>;
 			clock-names = "GCLK", "PM";
 
@@ -54,7 +50,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42002400 0x80>;
 			interrupts = <16 0>;
-			label = "TCC_1";
 			clocks = <&gclk 26>, <&pm 0x20 9>;
 			clock-names = "GCLK", "PM";
 
@@ -66,7 +61,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42002800 0x80>;
 			interrupts = <17 0>;
-			label = "TCC_2";
 			clocks = <&gclk 27>, <&pm 0x20 10>;
 			clock-names = "GCLK", "PM";
 

--- a/dts/arm/atmel/samd2x.dtsi
+++ b/dts/arm/atmel/samd2x.dtsi
@@ -61,7 +61,6 @@
 	soc {
 		nvmctrl: nvmctrl@41004000  {
 			compatible = "atmel,sam0-nvmctrl";
-			label = "FLASH_CTRL";
 			reg = <0x41004000 0x22>;
 			interrupts = <5 0>;
 			lock-regions = <16>;
@@ -71,7 +70,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				reg = <0 0x40000>;
 				write-block-size = <4>;
 			};
@@ -94,7 +92,6 @@
 			compatible = "atmel,sam0-eic";
 			reg = <0x40001800 0x1C>;
 			interrupts = <4 0>;
-			label = "EIC";
 		};
 
 		pinmux_a: pinmux@41004400 {
@@ -111,55 +108,47 @@
 			compatible = "atmel,sam0-watchdog";
 			reg = <0x40001000 9>;
 			interrupts = <2 0>;
-			label = "WATCHDOG_0";
 		};
 
 		sercom0: sercom@42000800 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000800 0x40>;
 			status = "disabled";
-			label = "SERCOM0";
 		};
 
 		sercom1: sercom@42000c00 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000c00 0x40>;
 			status = "disabled";
-			label = "SERCOM1";
 		};
 
 		sercom2: sercom@42001000 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001000 0x40>;
 			status = "disabled";
-			label = "SERCOM2";
 		};
 
 		sercom3: sercom@42001400 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001400 0x40>;
 			status = "disabled";
-			label = "SERCOM3";
 		};
 
 		sercom4: sercom@42001800 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001800 0x40>;
 			status = "disabled";
-			label = "SERCOM4";
 		};
 
 		sercom5: sercom@42001c00 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001c00 0x40>;
 			status = "disabled";
-			label = "SERCOM5";
 		};
 
 		tc4: tc@42003000 {
 			compatible = "atmel,sam0-tc32";
 			reg = <0x42003000 0x20>;
-			label = "TIMER_4";
 		};
 
 		pinctrl: pinctrl@41004400 {
@@ -171,7 +160,6 @@
 			porta: gpio@41004400 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x41004400 0x80>;
-				label = "PORTA";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -181,7 +169,6 @@
 			portb: gpio@41004480 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x41004480 0x80>;
-				label = "PORTB";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -194,13 +181,11 @@
 			interrupts = <3 0>;
 			clock-generator = <0>;
 			status = "disabled";
-			label = "RTC";
 		};
 
 		adc: adc@42004000 {
 			compatible = "atmel,sam0-adc";
 			reg = <0x42004000 0x2B>;
-			label = "ADC_0";
 
 			/*
 			 * 2.1 MHz max, so clock it with the
@@ -215,7 +200,6 @@
 			compatible = "atmel,sam0-dac";
 			status = "disabled";
 			reg = <0x42004800 0x10>;
-			label = "DAC_0";
 			#io-channel-cells = <0>;
 		};
 	};

--- a/dts/arm/atmel/samd5x.dtsi
+++ b/dts/arm/atmel/samd5x.dtsi
@@ -102,7 +102,6 @@
 
 		nvmctrl: nvmctrl@41004000  {
 			compatible = "atmel,sam0-nvmctrl";
-			label = "FLASH_CTRL";
 			reg = <0x41004000 0x22>;
 			interrupts = <29 0>, <30 0>;
 			lock-regions = <32>;
@@ -112,7 +111,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <8>;
 			};
 		};
@@ -121,7 +119,6 @@
 			compatible = "atmel,sam0-dmac";
 			reg = <0x4100A000 0x50>;
 			interrupts = <31 0>, <32 0>, <33 0>, <34 0>, <35 0>;
-			label = "DMA_0";
 			#dma-cells = <2>;
 		};
 
@@ -132,7 +129,6 @@
 				     <16 0>, <17 0>, <18 0>, <19 0>,
 				     <20 0>, <21 0>, <22 0>, <23 0>,
 				     <24 0>, <25 0>, <26 0>, <27 0>;
-			label = "EIC";
 		};
 
 		pinmux_a: pinmux@41008000 {
@@ -159,7 +155,6 @@
 			compatible = "atmel,sam0-watchdog";
 			reg = <0x40002000 13>;
 			interrupts = <10 0>;
-			label = "WATCHDOG_0";
 		};
 
 		sercom0: sercom@40003000 {
@@ -167,7 +162,6 @@
 			reg = <0x40003000 0x40>;
 			interrupts = <46 0>, <47 0>, <48 0>, <49 0>;
 			status = "disabled";
-			label = "SERCOM0";
 			clocks = <&gclk 7>, <&mclk 0x14 12>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -177,7 +171,6 @@
 			reg = <0x40003400 0x40>;
 			interrupts = <50 0>, <51 0>, <52 0>, <53 0>;
 			status = "disabled";
-			label = "SERCOM1";
 			clocks = <&gclk 8>, <&mclk 0x14 13>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -187,7 +180,6 @@
 			reg = <0x41012000 0x40>;
 			interrupts = <54 0>, <55 0>, <56 0>, <57 0>;
 			status = "disabled";
-			label = "SERCOM2";
 			clocks = <&gclk 23>, <&mclk 0x18 9>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -197,7 +189,6 @@
 			reg = <0x41014000 0x40>;
 			interrupts = <58 0>, <59 0>, <60 0>, <61 0>;
 			status = "disabled";
-			label = "SERCOM3";
 			clocks = <&gclk 24>, <&mclk 0x18 10>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -207,7 +198,6 @@
 			reg = <0x43000000 0x40>;
 			interrupts = <62 0>, <63 0>, <64 0>, <65 0>;
 			status = "disabled";
-			label = "SERCOM4";
 			clocks = <&gclk 34>, <&mclk 0x20 0>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -217,7 +207,6 @@
 			reg = <0x43000400 0x40>;
 			interrupts = <66 0>, <67 0>, <68 0>, <69 0>;
 			status = "disabled";
-			label = "SERCOM5";
 			clocks = <&gclk 35>, <&mclk 0x20 1>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -227,7 +216,6 @@
 			reg = <0x43000800 0x40>;
 			interrupts = <70 0>, <71 0>, <72 0>, <73 0>;
 			status = "disabled";
-			label = "SERCOM6";
 			clocks = <&gclk 36>, <&mclk 0x20 2>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -237,7 +225,6 @@
 			reg = <0x43000C00 0x40>;
 			interrupts = <74 0>, <75 0>, <76 0>, <77 0>;
 			status = "disabled";
-			label = "SERCOM7";
 			clocks = <&gclk 37>, <&mclk 0x20 3>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -251,7 +238,6 @@
 			porta: gpio@41008000 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x41008000 0x80>;
-				label = "PORTA";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -260,7 +246,6 @@
 			portb: gpio@41008080 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x41008080 0x80>;
-				label = "PORTB";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -269,7 +254,6 @@
 			portc: gpio@41008100 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x41008100 0x80>;
-				label = "PORTC";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -278,7 +262,6 @@
 			portd: gpio@41008180 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x41008180 0x80>;
-				label = "PORTD";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -291,7 +274,6 @@
 			reg = <0x41000000 0x1000>;
 			interrupts = <80 0>, <81 0>, <82 0>, <83 0>;
 			num-bidir-endpoints = <8>;
-			label = "USB0";
 		};
 
 		trng: random@42002800 {
@@ -299,7 +281,6 @@
 			reg = <0x42002800 0x1e>;
 			peripheral-id = <0>;
 			interrupts = <131 0>;
-			label = "ENTROPY_0";
 		};
 
 		rtc: rtc@40002400 {
@@ -308,7 +289,6 @@
 			interrupts = <11 0>;
 			clock-generator = <0>;
 			status = "disabled";
-			label = "RTC";
 		};
 
 		adc0: adc@43001c00 {
@@ -316,7 +296,6 @@
 			reg = <0x43001C00 0x4A>;
 			interrupts = <118 0>, <119 0>;
 			interrupt-names = "overrun", "resrdy";
-			label = "ADC_0";
 
 			/*
 			 * 16 MHz max, source clock must not exceed 100 MHz.
@@ -337,7 +316,6 @@
 			reg = <0x43002000 0x4A>;
 			interrupts = <120 0>, <121 0>;
 			interrupt-names = "overrun", "resrdy";
-			label = "ADC_1";
 
 			/*
 			 * 16 MHz max, source clock must not exceed 100 MHz.
@@ -357,7 +335,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x40003800 0x34>;
 			interrupts = <107 0>;
-			label = "TIMER_0";
 			clocks = <&gclk 9>, <&mclk 0x14 14>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -366,7 +343,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x4101A000 0x34>;
 			interrupts = <109 0>;
-			label = "TIMER_2";
 			clocks = <&gclk 26>, <&mclk 0x18 13>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -375,7 +351,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x42001400 0x34>;
 			interrupts = <111 0>;
-			label = "TIMER_4";
 			clocks = <&gclk 30>, <&mclk 0x1c 5>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -384,7 +359,6 @@
 			compatible = "atmel,sam0-tc32";
 			reg = <0x43001400 0x34>;
 			interrupts = <113 0>;
-			label = "TIMER_6";
 			clocks = <&gclk 39>, <&mclk 0x20 5>;
 			clock-names = "GCLK", "MCLK";
 		};
@@ -394,7 +368,6 @@
 			reg = <0x41016000 0x2000>;
 			interrupts = <85 0>, <86 0>, <87 0>, <88 0>, <89 0>,
 				     <90 0>, <91 0>;
-			label = "TCC_0";
 			clocks = <&gclk 25>, <&mclk 0x18 11>;
 			clock-names = "GCLK", "MCLK";
 			channels = <6>;
@@ -405,7 +378,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x41018000 0x2000>;
 			interrupts = <92 0>, <93 0>, <94 0>, <95 0>, <96 0>;
-			label = "TCC_1";
 			clocks = <&gclk 25>, <&mclk 0x18 12>;
 			clock-names = "GCLK", "MCLK";
 			channels = <4>;
@@ -416,7 +388,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42000c00 0x400>;
 			interrupts = <97 0>, <98 0>, <99 0>, <100 0>;
-			label = "TCC_2";
 			clocks = <&gclk 29>, <&mclk 0x1c 3>;
 			clock-names = "GCLK", "MCLK";
 			channels = <3>;
@@ -427,7 +398,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42001000 0x400>;
 			interrupts = <101 0>, <102 0>, <103 0>;
-			label = "TCC_3";
 			clocks = <&gclk 29>, <&mclk 0x1c 4>;
 			clock-names = "GCLK", "MCLK";
 			channels = <2>;
@@ -438,7 +408,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x43001000 0x400>;
 			interrupts = <104 0>, <105 0>, <106 0>;
-			label = "TCC_4";
 			clocks = <&gclk 38>, <&mclk 0x20 4>;
 			clock-names = "GCLK", "MCLK";
 			channels = <2>;

--- a/dts/arm/atmel/same5x.dtsi
+++ b/dts/arm/atmel/same5x.dtsi
@@ -15,12 +15,10 @@
 			interrupt-names = "gmac";
 			num-queues = <1>;
 			local-mac-address = [00 00 00 00 00 00];
-			label = "GMAC";
 			status = "disabled";
 
 			mdio: mdio {
 				compatible = "atmel,sam-mdio";
-				label = "MDIO";
 				status = "disabled";
 			};
 		};

--- a/dts/arm/atmel/same70.dtsi
+++ b/dts/arm/atmel/same70.dtsi
@@ -49,7 +49,6 @@
 	soc {
 		eefc: flash-controller@400e0c00 {
 			compatible = "atmel,sam-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0c00 0x200>;
 			interrupts = <6 0>;
 			peripheral-id = <6>;
@@ -59,7 +58,6 @@
 
 			flash0: flash@400000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_E70";
 
 				write-block-size = <16>;
 				erase-block-size = <8192>;
@@ -72,7 +70,6 @@
 			reg = <0x400e1850 0xc>;
 			interrupts = <4 0>;
 			peripheral-id = <4>;
-			label = "WATCHDOG_0";
 			status = "disabled";
 		};
 
@@ -84,7 +81,6 @@
 			reg = <0x40018000 0x12B>;
 			interrupts = <19 0>;
 			peripheral-id = <19>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -96,7 +92,6 @@
 			reg = <0x4001c000 0x12B>;
 			interrupts = <20 0>;
 			peripheral-id = <20>;
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -108,7 +103,6 @@
 			reg = <0x40060000 0x12B>;
 			interrupts = <41 0>;
 			peripheral-id = <41>;
-			label = "I2C_2";
 			status = "disabled";
 		};
 
@@ -119,7 +113,6 @@
 			reg = <0x40008000 0x4000>;
 			interrupts = <21 0>;
 			peripheral-id = <21>;
-			label = "SPI_0";
 			status = "disabled";
 		};
 
@@ -130,7 +123,6 @@
 			reg = <0x40058000 0x4000>;
 			interrupts = <42 0>;
 			peripheral-id = <42>;
-			label = "SPI_1";
 			status = "disabled";
 		};
 
@@ -140,7 +132,6 @@
 			interrupts = <7 1>;
 			peripheral-id = <7>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: uart@400e0a00 {
@@ -149,7 +140,6 @@
 			interrupts = <8 1>;
 			peripheral-id = <8>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		uart2: uart@400e1a00 {
@@ -158,7 +148,6 @@
 			interrupts = <44 1>;
 			peripheral-id = <44>;
 			status = "disabled";
-			label = "UART_2";
 		};
 
 		uart3: uart@400e1c00 {
@@ -167,7 +156,6 @@
 			interrupts = <45 1>;
 			peripheral-id = <45>;
 			status = "disabled";
-			label = "UART_3";
 		};
 
 		uart4: uart@400e1e00 {
@@ -176,7 +164,6 @@
 			interrupts = <46 1>;
 			peripheral-id = <46>;
 			status = "disabled";
-			label = "UART_4";
 		};
 
 		usart0: usart@40024000 {
@@ -185,7 +172,6 @@
 			interrupts = <13 0>;
 			peripheral-id = <13>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40028000 {
@@ -194,7 +180,6 @@
 			interrupts = <14 0>;
 			peripheral-id = <14>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@4002c000 {
@@ -203,7 +188,6 @@
 			interrupts = <15 0>;
 			peripheral-id = <15>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		afec0: adc@4003c000 {
@@ -212,7 +196,6 @@
 			interrupts = <29 0>;
 			peripheral-id = <29>;
 			status = "disabled";
-			label = "ADC_0";
 			#io-channel-cells = <1>;
 		};
 
@@ -222,7 +205,6 @@
 			interrupts = <40 0>;
 			peripheral-id = <40>;
 			status = "disabled";
-			label = "ADC_1";
 			#io-channel-cells = <1>;
 		};
 
@@ -232,7 +214,6 @@
 			interrupts = <30 0>;
 			peripheral-id = <30>;
 			status = "disabled";
-			label = "DACC";
 			#io-channel-cells = <1>;
 		};
 
@@ -247,7 +228,6 @@
 				reg = <0x400e0e00 0x190>;
 				interrupts = <10 1>;
 				peripheral-id = <10>;
-				label = "PORTA";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -258,7 +238,6 @@
 				reg = <0x400e1000 0x190>;
 				interrupts = <11 1>;
 				peripheral-id = <11>;
-				label = "PORTB";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -269,7 +248,6 @@
 				reg = <0x400e1200 0x190>;
 				interrupts = <12 1>;
 				peripheral-id = <12>;
-				label = "PORTC";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -280,7 +258,6 @@
 				reg = <0x400e1400 0x190>;
 				interrupts = <16 1>;
 				peripheral-id = <16>;
-				label = "PORTD";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -291,7 +268,6 @@
 				reg = <0x400e1600 0x190>;
 				interrupts = <17 1>;
 				peripheral-id = <17>;
-				label = "PORTE";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -304,7 +280,6 @@
 			interrupts = <31 0>;
 			peripheral-id = <31>;
 			status = "disabled";
-			label = "PWM_0";
 			prescaler = <10>;
 			divider = <1>;
 			#pwm-cells = <2>;
@@ -316,7 +291,6 @@
 			interrupts = <60 0>;
 			peripheral-id = <60>;
 			status = "disabled";
-			label = "PWM_1";
 			prescaler = <10>;
 			divider = <1>;
 			#pwm-cells = <2>;
@@ -333,7 +307,6 @@
 			num-bidir-endpoints = <10>;
 			peripheral-id = <34>;
 			status = "disabled";
-			label = "USBHS";
 		};
 
 		gmac: ethernet@40050000 {
@@ -344,12 +317,10 @@
 			interrupt-names = "gmac", "q1", "q2";
 			num-queues = <3>;
 			local-mac-address = [00 00 00 00 00 00];
-			label = "GMAC";
 			status = "disabled";
 
 			mdio: mdio {
 				compatible = "atmel,sam-mdio";
-				label = "MDIO";
 				status = "disabled";
 			};
 		};
@@ -362,7 +333,6 @@
 				      25 0>;
 			peripheral-id = <23 24 25>;
 			status = "disabled";
-			label = "TC0";
 		};
 
 		tc1: tc@40010000 {
@@ -373,7 +343,6 @@
 				      28 0>;
 			peripheral-id = <26 27 28>;
 			status = "disabled";
-			label = "TC1";
 		};
 
 		tc2: tc@40014000 {
@@ -384,7 +353,6 @@
 				      49 0>;
 			peripheral-id = <47 48 49>;
 			status = "disabled";
-			label = "TC2";
 		};
 
 		tc3: tc@40054000 {
@@ -395,7 +363,6 @@
 				      52 0>;
 			peripheral-id = <50 51 52>;
 			status = "disabled";
-			label = "TC3";
 		};
 
 		trng: random@40070000 {
@@ -404,7 +371,6 @@
 			interrupts = <57 0>;
 			peripheral-id = <57>;
 			status = "okay";
-			label = "TRNG";
 		};
 
 		xdmac: dma-controller@40078000 {
@@ -412,7 +378,6 @@
 			reg = <0x40078000 0x400>;
 			interrupts = <58 0>;
 			peripheral-id = <58>;
-			label = "DMA_0";
 			#dma-cells = <2>;
 		};
 
@@ -421,7 +386,6 @@
 			reg = <0x40004000 0x400>;
 			interrupts = <22 0>;
 			peripheral-id = <22>;
-			label = "SSC_0";
 			status = "disabled";
 		};
 
@@ -449,7 +413,6 @@
 				sjw-data = <1>;
 				sample-point-data = <875>;
 				status = "disabled";
-				label = "CAN_0";
 			};
 
 			can1: can@40034000 {
@@ -465,7 +428,6 @@
 				sjw-data = <1>;
 				sample-point-data = <875>;
 				status = "disabled";
-				label = "CAN_1";
 			};
 		};
 
@@ -473,7 +435,6 @@
 			compatible = "atmel,sam-rstc";
 			reg = <0x400e1800 0x10>;
 			peripheral-id = <1>;
-			label = "RSTC";
 			user-nrst;
 		};
 	};

--- a/dts/arm/atmel/saml21.dtsi
+++ b/dts/arm/atmel/saml21.dtsi
@@ -14,14 +14,12 @@
 			reg = <0x41000000 0x1000>;
 			interrupts = <6 0>;
 			num-bidir-endpoints = <8>;
-			label = "USB0";
 		};
 
 		dmac: dmac@44000400 {
 			compatible = "atmel,sam0-dmac";
 			reg = <0x44000400 0x50>;
 			interrupts = <5 0>;
-			label = "DMA_0";
 			#dma-cells = <2>;
 		};
 
@@ -29,7 +27,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42001400 0x80>;
 			interrupts = <14 0>;
-			label = "TCC_0";
 			clocks = <&gclk 25>, <&mclk 0x1c 5>;
 			clock-names = "GCLK", "MCLK";
 
@@ -41,7 +38,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42001800 0x80>;
 			interrupts = <15 0>;
-			label = "TCC_1";
 			clocks = <&gclk 25>, <&mclk 0x1c 6>;
 			clock-names = "GCLK", "MCLK";
 
@@ -53,7 +49,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42001C00 0x80>;
 			interrupts = <16 0>;
-			label = "TCC_2";
 			clocks = <&gclk 26>, <&mclk 0x1c 7>;
 			clock-names = "GCLK", "MCLK";
 

--- a/dts/arm/atmel/saml2x.dtsi
+++ b/dts/arm/atmel/saml2x.dtsi
@@ -47,7 +47,6 @@
 	soc {
 		nvmctrl: nvmctrl@41004000  {
 			compatible = "atmel,sam0-nvmctrl";
-			label = "FLASH_CTRL";
 			reg = <0x41004000 0x22>;
 			interrupts = <4 0>;
 			lock-regions = <16>;
@@ -57,7 +56,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				reg = <0 0x40000>;
 				write-block-size = <4>;
 			};
@@ -86,7 +84,6 @@
 			compatible = "atmel,sam0-dmac";
 			reg = <0x44000400 0x400>;
 			interrupts = <5 0>;
-			label = "DMA_0";
 			#dma-cells = <2>;
 		};
 
@@ -94,62 +91,53 @@
 			compatible = "atmel,sam0-eic";
 			reg = <0x40002400 0x24>;
 			interrupts = <3 0>;
-			label = "EIC";
 		};
 
 		wdog: watchdog@40001c00 {
 			compatible = "atmel,sam0-watchdog";
 			reg = <0x40001c00 0x0c>;
 			interrupts = <1 0>;
-			label = "WATCHDOG_0";
 		};
 
 		sercom0: sercom@42000000 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000000 0x40>;
 			status = "disabled";
-			label = "SERCOM0";
 		};
 
 		sercom1: sercom@42000400 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000400 0x40>;
 			status = "disabled";
-			label = "SERCOM1";
 		};
 
 		sercom2: sercom@42000800 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000800 0x40>;
 			status = "disabled";
-			label = "SERCOM2";
 		};
 
 		sercom3: sercom@42000c00 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42000C00 0x40>;
 			status = "disabled";
-			label = "SERCOM3";
 		};
 
 		sercom4: sercom@42001000 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x42001000 0x40>;
 			status = "disabled";
-			label = "SERCOM4";
 		};
 
 		sercom5: sercom@43000400 {
 			compatible = "atmel,sam0-sercom";
 			reg = <0x43000400 0x40>;
 			status = "disabled";
-			label = "SERCOM5";
 		};
 
 		tc4: tc@43000800 {
 			compatible = "atmel,sam0-tc32";
 			reg = <0x43000800 0x34>;
-			label = "TIMER_4";
 		};
 
 		pinctrl: pinctrl@40002800 {
@@ -161,7 +149,6 @@
 			porta: gpio@40002800 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x40002800 0x80>;
-				label = "PORTA";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -171,7 +158,6 @@
 			portb: gpio@40002880 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x40002880 0x80>;
-				label = "PORTB";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -184,13 +170,11 @@
 			interrupts = <2 0>;
 			clock-generator = <0>;
 			status = "disabled";
-			label = "RTC";
 		};
 
 		adc: adc@43000c00 {
 			compatible = "atmel,sam0-adc";
 			reg = <0x43000c00 0x30>;
-			label = "ADC_0";
 
 			/*
 			 * 16 MHz max, so clock it with the
@@ -205,7 +189,6 @@
 			compatible = "atmel,sam0-dac";
 			status = "disabled";
 			reg = <0x42003000 0x1a>;
-			label = "DAC_0";
 			#io-channel-cells = <0>;
 		};
 
@@ -214,7 +197,6 @@
 			reg = <0x42003800 0x24>;
 			peripheral-id = <0>;
 			interrupts = <27 0>;
-			label = "ENTROPY_0";
 		};
 	};
 };

--- a/dts/arm/atmel/samr21.dtsi
+++ b/dts/arm/atmel/samr21.dtsi
@@ -18,14 +18,12 @@
 			reg = <0x41005000 0x1000>;
 			interrupts = <7 0>;
 			num-bidir-endpoints = <8>;
-			label = "USB0";
 		};
 
 		dmac: dmac@41004800 {
 			compatible = "atmel,sam0-dmac";
 			reg = <0x41004800 0x50>;
 			interrupts = <6 0>;
-			label = "DMA_0";
 			#dma-cells = <2>;
 		};
 
@@ -35,7 +33,6 @@
 			portc: gpio@41004500 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x41004500 0x80>;
-				label = "PORTC";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -51,7 +48,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42002000 0x80>;
 			interrupts = <15 0>;
-			label = "TCC_0";
 			clocks = <&gclk 26>, <&pm 0x20 8>;
 			clock-names = "GCLK", "PM";
 
@@ -63,7 +59,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42002400 0x80>;
 			interrupts = <16 0>;
-			label = "TCC_1";
 			clocks = <&gclk 26>, <&pm 0x20 9>;
 			clock-names = "GCLK", "PM";
 
@@ -75,7 +70,6 @@
 			compatible = "atmel,sam0-tcc";
 			reg = <0x42002800 0x80>;
 			interrupts = <17 0>;
-			label = "TCC_2";
 			clocks = <&gclk 27>, <&pm 0x20 10>;
 			clock-names = "GCLK", "PM";
 

--- a/dts/arm/atmel/samr34.dtsi
+++ b/dts/arm/atmel/samr34.dtsi
@@ -22,7 +22,6 @@
 			portc: gpio@40002900 {
 				compatible = "atmel,sam0-gpio";
 				reg = <0x40002900 0x80>;
-				label = "PORTC";
 				gpio-controller;
 				#gpio-cells = <2>;
 				#atmel,pin-cells = <2>;
@@ -45,7 +44,6 @@
 	lora: sx1276@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
-		label = "SX1276";
 		reset-gpios = <&portb 15 GPIO_ACTIVE_LOW>;               /* nRST */
 		dio-gpios =
 			<&portb 16 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>, /* DIO0 */


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>