### PR TITLE
drivers: sensor: max17055: add VFOCV support

### DIFF
--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -12,6 +12,7 @@
 LOG_MODULE_REGISTER(max17055, CONFIG_SENSOR_LOG_LEVEL);
 
 #include "max17055.h"
+#include <zephyr/drivers/sensor/max17055.h>
 
 #define DT_DRV_COMPAT maxim_max17055
 
@@ -150,6 +151,11 @@ static int max17055_channel_get(const struct device *dev,
 		valp->val1 = tmp / 1000000;
 		valp->val2 = tmp % 1000000;
 		break;
+	case SENSOR_CHAN_MAX17055_VFOCV:
+		tmp = priv->ocv * 1250 / 16;
+		valp->val1 = tmp / 1000000;
+		valp->val2 = tmp % 1000000;
+		break;
 	case SENSOR_CHAN_GAUGE_AVG_CURRENT: {
 		int current_ma;
 
@@ -228,6 +234,7 @@ static int max17055_sample_fetch(const struct device *dev,
 		int16_t *dest;
 	} regs[] = {
 		{ VCELL, &priv->voltage },
+		{ VFOCV, &priv->ocv },
 		{ AVG_CURRENT, &priv->avg_current },
 		{ REP_SOC, &priv->state_of_charge },
 		{ INT_TEMP, &priv->internal_temp },

--- a/drivers/sensor/max17055/max17055.h
+++ b/drivers/sensor/max17055/max17055.h
@@ -30,6 +30,7 @@ enum {
 	SOFT_WAKEUP     = 0x60,
 	HIB_CFG         = 0xba,
 	MODEL_CFG       = 0xdb,
+	VFOCV           = 0xfb,
 };
 
 /* Masks */
@@ -45,6 +46,8 @@ enum {
 struct max17055_data {
 	/* Current cell voltage in units of 1.25/16mV */
 	uint16_t voltage;
+	/* Current cell open circuit voltage in units of 1.25/16mV */
+	uint16_t ocv;
 	/* Average current in units of 1.5625uV / Rsense */
 	int16_t avg_current;
 	/* Remaining capacity as a %age */

--- a/include/zephyr/drivers/sensor/max17055.h
+++ b/include/zephyr/drivers/sensor/max17055.h
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_INCLUDE_DRIVERS_SENSOR_MAX17055_H_
+#define ZEPHYR_INCLUDE_DRIVERS_SENSOR_MAX17055_H_
+
+#include <zephyr/drivers/sensor.h>
+
+enum sensor_channel_max17055 {
+	/** Battery Open Circuit Voltage. */
+	SENSOR_CHAN_MAX17055_VFOCV = SENSOR_CHAN_PRIV_START,
+};
+
+#endif /* ZEPHYR_INCLUDE_DRIVERS_SENSOR_MAX17055_H_ */


### PR DESCRIPTION
Add support for reading the VFOCV register, which contains the model
estimated open circuit voltage for the cell.

Link: https://pdfserv.maximintegrated.com/en/an/AN6358.pdf