### PR TITLE
Driver: Sensor: sht3xd_trigger thresholds corrected

### DIFF
--- a/drivers/sensor/sht3xd/sht3xd_trigger.c
+++ b/drivers/sensor/sht3xd/sht3xd_trigger.c
@@ -228,7 +228,7 @@ int sht3xd_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
-	if (sht3xd_write_reg(dev, SHT3XD_CMD_WRITE_TH_LOW_SET, 0) < 0) {
+	if (sht3xd_write_reg(dev, SHT3XD_CMD_WRITE_TH_LOW_CLEAR, 0) < 0) {
 		LOG_DBG("Failed to write threshold low clear value!");
 		return -EIO;
 	}


### PR DESCRIPTION
SHT3XD_CMD_WRITE_TH_LOW_SET was set twice, should be SHT3XD_CMD_WRITE_TH_LOW_CLEAR once
Due to this set a wrong Clear threshold was set

Signed-off-by: Louis Creus <louis.creus@unitrongroup.com>

Fixes #48299