### PR TITLE
lib: os: spsc_pbuf: Fix free space calculation

### DIFF
--- a/lib/os/spsc_pbuf.c
+++ b/lib/os/spsc_pbuf.c
@@ -184,7 +184,7 @@ int spsc_pbuf_alloc(struct spsc_pbuf *pb, uint16_t len, char **buf)
 			}
 		}
 	} else {
-		free_space = rd_idx - wr_idx - 1;
+		free_space = rd_idx - wr_idx - sizeof(uint32_t);
 	}
 
 	len = MIN(len, MAX(free_space - (int32_t)LEN_SZ, 0));


### PR DESCRIPTION
Fixing bug in free space calculation which was assuming 1 byte
padding and not 32 bit word padding. Bug could result in the
data corruption in certain scenario.
    
Signed-off-by: Krzysztof Chruscinski <krzysztof.chruscinski@nordicsemi.no>