### PR TITLE
boards: nucleo_wb55rg: Update regarding supported M0 BLE f/w

### DIFF
--- a/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
+++ b/boards/arm/nucleo_wb55rg/doc/nucleo_wb55rg.rst
@@ -189,6 +189,9 @@ Projects/STM32WB_Copro_Wireless_Binaries/STM32WB5x/
 For compatibility information with the various versions of these binaries,
 please check `modules/hal/stm32/lib/stm32wb/hci/README <https://github.com/zephyrproject-rtos/hal_stm32/blob/main/lib/stm32wb/hci/README>`__
 in the hal_stm32 repo.
+Note that since STM32WB Cube package V1.13.2, "full stack" binaries are not compatible
+anymore for a use in Zephyr and only "HCI Only" versions should be used on the M0
+side.
 
 Connections and IOs
 ===================

--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -197,10 +197,9 @@ zephyr_udc0: &usb {
 
 		/*
 		 * Configure partitions while leaving space for M0 BLE f/w
-		 * First 794K are configured for Zephyr to run on M4 core
-		 * Last 232K are left for BLE f/w on the M0 core
-		 * This partition set up is compatible with use of
-		 * stm32wb5x_BLE_Stack_full_fw.bin v1.13.x
+		 * Since STM32WBCube release V1.13.2, only _HCIOnly_ f/w are supported.
+		 * These FW are expected to be located not before 0x080DB000
+		 * Current partition is using the first 876K of the flash for M4
 		 */
 
 		boot_partition: partition@0 {
@@ -209,19 +208,19 @@ zephyr_udc0: &usb {
 		};
 		slot0_partition: partition@c000 {
 			label = "image-0";
-			reg = <0x0000c000 DT_SIZE_K(360)>;
+			reg = <0x0000c000 DT_SIZE_K(400)>;
 		};
-		slot1_partition: partition@66000 {
+		slot1_partition: partition@70000 {
 			label = "image-1";
-			reg = <0x00066000 DT_SIZE_K(360)>;
+			reg = <0x00070000 DT_SIZE_K(400)>;
 		};
-		scratch_partition: partition@c0000 {
+		scratch_partition: partition@d4000 {
 			label = "image-scratch";
-			reg = <0x000c0000 DT_SIZE_K(16)>;
+			reg = <0x000d4000 DT_SIZE_K(16)>;
 		};
-		storage_partition: partition@c4000 {
+		storage_partition: partition@d8000 {
 			label = "storage";
-			reg = <0x000c4000 DT_SIZE_K(8)>;
+			reg = <0x000d8000 DT_SIZE_K(8)>;
 		};
 
 	};


### PR DESCRIPTION
Since STM32WBCube release V1.13.2, only "HCI Only" f/w are now compatible
for a use with Zephyr.
"Full stack" f/w which used to be supported are not compatible anymore.

Update board documentation to mention this restriction.

Additionally, update flash partition to reflect the gain implied
by the use of this smaller f/w.

Fixes #47991

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>