### PR TITLE
drivers: bluetooth: stm32wb: Set HCI driver compatible with HCI_RAW mode

### DIFF
--- a/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
+++ b/boards/arm/nucleo_wb55rg/nucleo_wb55rg.dts
@@ -17,6 +17,7 @@
 		zephyr,console = &usart1;
 		zephyr,shell-uart = &usart1;
 		zephyr,bt-mon-uart = &lpuart1;
+		zephyr,bt-c2h-uart = &lpuart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,code-partition = &slot0_partition;
@@ -159,7 +160,9 @@
 };
 
 &lpuart1 {
-	pinctrl-0 = <&lpuart1_tx_pa2 &lpuart1_rx_pa3>;
+	pinctrl-0 = <&lpuart1_tx_pc1 &lpuart1_rx_pc0
+			&lpuart1_cts_pa6 &lpuart1_rts_pb12>;
+	hw-flow-control;
 	pinctrl-names = "default";
 	current-speed = <115200>;
 	status = "okay";

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -63,14 +63,16 @@ struct aci_set_ble_addr {
 	uint8_t value[6];
 } __packed;
 
+#ifdef CONFIG_BT_HCI_HOST
 #define ACI_WRITE_SET_TX_POWER_LEVEL       BT_OP(BT_OGF_VS, 0xFC0F)
 #define ACI_HAL_WRITE_CONFIG_DATA	   BT_OP(BT_OGF_VS, 0xFC0C)
 #define ACI_HAL_STACK_RESET		   BT_OP(BT_OGF_VS, 0xFC3B)
 
 #define HCI_CONFIG_DATA_PUBADDR_OFFSET		0
-#define HCI_CONFIG_DATA_RANDOM_ADDRESS_OFFSET	0x2E
-
 static bt_addr_t bd_addr_udn;
+#endif /* CONFIG_BT_HCI_HOST */
+
+#define HCI_CONFIG_DATA_RANDOM_ADDRESS_OFFSET	0x2E
 
 /* Rx thread definitions */
 K_FIFO_DEFINE(ipm_rx_events_fifo);
@@ -428,6 +430,7 @@ static void start_ble_rf(void)
 	LL_RCC_SetCLK48ClockSource(LL_RCC_CLK48_CLKSOURCE_HSI48);
 }
 
+#ifdef CONFIG_BT_HCI_HOST
 bt_addr_t *bt_get_ble_addr(void)
 {
 	bt_addr_t *bd_addr;
@@ -523,6 +526,7 @@ static int bt_ipm_ble_init(void)
 
 	return 0;
 }
+#endif /* CONFIG_BT_HCI_HOST */
 
 static int c2_reset(void)
 {
@@ -569,16 +573,19 @@ static int bt_ipm_open(void)
 			K_PRIO_COOP(CONFIG_BT_DRIVER_RX_HIGH_PRIO),
 			0, K_NO_WAIT);
 
+#ifdef CONFIG_BT_HCI_HOST
 	err = bt_ipm_ble_init();
 	if (err) {
 		return err;
 	}
+#endif /* CONFIG_BT_HCI_HOST */
 
 	BT_DBG("IPM Channel Open Completed");
 
 	return 0;
 }
 
+#ifdef CONFIG_BT_HCI_HOST
 static int bt_ipm_close(void)
 {
 	int err;
@@ -603,12 +610,15 @@ static int bt_ipm_close(void)
 
 	return err;
 }
+#endif /* CONFIG_BT_HCI_HOST */
 
 static const struct bt_hci_driver drv = {
 	.name           = "BT IPM",
 	.bus            = BT_HCI_DRIVER_BUS_IPM,
 	.open           = bt_ipm_open,
+#ifdef CONFIG_BT_HCI_HOST
 	.close          = bt_ipm_close,
+#endif
 	.send           = bt_ipm_send,
 };
 

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -72,8 +72,6 @@ struct aci_set_ble_addr {
 static bt_addr_t bd_addr_udn;
 #endif /* CONFIG_BT_HCI_HOST */
 
-#define HCI_CONFIG_DATA_RANDOM_ADDRESS_OFFSET	0x2E
-
 /* Rx thread definitions */
 K_FIFO_DEFINE(ipm_rx_events_fifo);
 static K_KERNEL_STACK_DEFINE(ipm_rx_stack, CONFIG_BT_STM32_IPM_RX_STACK_SIZE);

--- a/drivers/bluetooth/hci/ipm_stm32wb.c
+++ b/drivers/bluetooth/hci/ipm_stm32wb.c
@@ -501,13 +501,6 @@ static int bt_ipm_ble_init(void)
 	struct net_buf *buf, *rsp;
 	int err;
 
-	/* Send HCI_RESET */
-	err = bt_hci_cmd_send_sync(BT_HCI_OP_RESET, NULL, &rsp);
-	if (err) {
-		return err;
-	}
-	/* TDB: Something to do on reset complete? */
-	net_buf_unref(rsp);
 	err = bt_ipm_set_addr();
 	if (err) {
 		BT_ERR("Can't set BLE UID addr");
@@ -614,7 +607,6 @@ static int bt_ipm_close(void)
 static const struct bt_hci_driver drv = {
 	.name           = "BT IPM",
 	.bus            = BT_HCI_DRIVER_BUS_IPM,
-	.quirks         = BT_QUIRK_NO_RESET,
 	.open           = bt_ipm_open,
 	.close          = bt_ipm_close,
 	.send           = bt_ipm_send,


### PR DESCRIPTION
Current implementation of stm32wb HCI driver uses functions of hci_core driver to send specific messages.
This makes the driver incompatible with BT_HCI_RAW mode.

Provide some adaptations to allow use of BT_HCI_RAW mode on STM32WB
- Remove the HCI_RESET sending as this is available in hci_core.
- Put sending of ACI_HAL_* messages under !BT_HCI_RAW as these messages are not needed for test mode.

Add a c2h chosen to allow building hci_uart sample.

Fixes #46075
