### PR TITLE
net: ipv6: use static inlines where it makes sense for stubs

### DIFF
--- a/subsys/net/ip/ipv6.h
+++ b/subsys/net/ip/ipv6.h
@@ -205,7 +205,14 @@ static inline int net_ipv6_finalize(struct net_pkt *pkt,
 #if defined(CONFIG_NET_IPV6_MLD)
 int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr);
 #else
-#define net_ipv6_mld_join(...)
+static inline int
+net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(addr);
+
+	return -ENOTSUP;
+}
 #endif /* CONFIG_NET_IPV6_MLD */
 
 /**
@@ -219,7 +226,14 @@ int net_ipv6_mld_join(struct net_if *iface, const struct in6_addr *addr);
 #if defined(CONFIG_NET_IPV6_MLD)
 int net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr);
 #else
-#define net_ipv6_mld_leave(...)
+static inline int
+net_ipv6_mld_leave(struct net_if *iface, const struct in6_addr *addr)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(addr);
+
+	return -ENOTSUP;
+}
 #endif /* CONFIG_NET_IPV6_MLD */
 
 /**


### PR DESCRIPTION
If we're disabling certain features and instead providing function stubs,
it doesn't make sense to use macros for those routines that return values
that the user may check unless we want to provide them with vague errors
like:

zephyr/samples/net/sockets/coap_server/src/coap-server.c:101:55: error: expected expression before ';' token
  101 |  ret = net_ipv6_mld_join(iface, &mcast_addr.sin6_addr);

When a function we're mocking up returns a value, use a static inline
stub.

Signed-off-by: Bartosz Golaszewski <bartosz.golaszewski@huawei.com>