### PR TITLE
drivers: pwm_nrfx: Fix PWM_NRFX_CH_VALUE() macro

### DIFF
--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -18,7 +18,7 @@ LOG_MODULE_REGISTER(pwm_nrfx, CONFIG_PWM_LOG_LEVEL);
 #define PWM_NRFX_CH_POLARITY_MASK BIT(15)
 #define PWM_NRFX_CH_COMPARE_MASK  BIT_MASK(15)
 #define PWM_NRFX_CH_VALUE(compare_value, inverted) \
-	(compare_value | (inverted ? 0 : PWM_NRFX_CH_COMPARE_MASK))
+	(compare_value | (inverted ? 0 : PWM_NRFX_CH_POLARITY_MASK))
 
 struct pwm_nrfx_config {
 	nrfx_pwm_t pwm;


### PR DESCRIPTION
This is a follow-up to commit 63d6cfd65496eccc13615a7c41d3a02a91e4e398.

Revert unwanted PWM_NRFX_CH_POLARITY_MASK to PWM_NRFX_CH_COMPARE_MASK
replacement that was accidentally done in the above commit.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>