### PR TITLE
Bluetooth: audio: Fix server ASE Release in Codec Configured state

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -176,9 +176,6 @@ void ascs_ep_set_state(struct bt_audio_ep *ep, uint8_t state)
 	if (state == BT_AUDIO_EP_STATE_CODEC_CONFIGURED &&
 	    old_state != BT_AUDIO_EP_STATE_IDLE) {
 		ascs_ep_unbind_audio_iso(ep);
-	} else if (state == BT_AUDIO_EP_STATE_RELEASING) {
-		ascs_ep_unbind_audio_iso(ep);
-		bt_audio_stream_detach(ep->stream);
 	}
 }
 
@@ -932,8 +929,11 @@ static void ase_process(struct k_work *work)
 
 	bt_gatt_notify(ase->ascs->conn, &attr, ase_buf.data, ase_buf.len);
 
-	if (ase->ep.status.state == BT_AUDIO_EP_STATE_RELEASING &&
-	    ase->ep.stream == NULL) {
+	if (ase->ep.status.state == BT_AUDIO_EP_STATE_RELEASING) {
+		__ASSERT(ase->ep.stream, "stream is NULL");
+
+		ascs_ep_unbind_audio_iso(&ase->ep);
+		bt_audio_stream_detach(ase->ep.stream);
 		ascs_ep_set_state(&ase->ep, BT_AUDIO_EP_STATE_IDLE);
 	}
 }


### PR DESCRIPTION
This fixes issue where the ASE state stuck in Releasing state instead of
going to Idle/Codec Configured as test requires.

Fixes: ASCS/SR/ACP/BV-24-C
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>