### PR TITLE
dts: arm64: Remove label property from devicetrees

### DIFF
--- a/dts/arm64/broadcom/viper-common.dtsi
+++ b/dts/arm64/broadcom/viper-common.dtsi
@@ -16,7 +16,6 @@
 			reg = <0x40020000 0x400>;
 			reg-shift = <2>;
 			clock-frequency = <25000000>;
-			label = "CRMU_UART";
 			status = "disabled";
 		};
 
@@ -25,7 +24,6 @@
 			reg = <0x48100000 0x400>;
 			reg-shift = <2>;
 			clock-frequency = <100000000>;
-			label = "CCG_UART0";
 			status = "disabled";
 		};
 
@@ -38,7 +36,6 @@
 			microcode = <0x63b00000  0x1000>;
 			dma-channels = <8>;
 			#dma-cells = <1>;
-			label = "DMA_0";
 		};
 	};
 
@@ -53,14 +50,12 @@
 			      <0x4 0x0 0x0 0x8000000>;
 			reg-names = "iproc_pcie_regs", "map_lowmem",
 				    "map_highmem";
-			label = "PCIE_0";
 			dmas = <&pl330 0>, <&pl330 1>;
 			dma-names = "txdma", "rxdma";
 		};
 
 		paxdma: paxdma@4e100800 {
 			compatible = "brcm,iproc-pax-dma-v2";
-			label = "DMA_1";
 			reg = <0x0 0x4e100800 0x0 0x2100>,
 			      <0x0 0x4f000000 0x0 0x200000>,
 			      <0x0 0x4f200000 0x0 0x10000>;

--- a/dts/arm64/fvp/fvp-aemv8r.dtsi
+++ b/dts/arm64/fvp/fvp-aemv8r.dtsi
@@ -74,7 +74,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 5 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_5";
-			label = "UART_0";
 			clocks = <&uartclk>;
 		};
 
@@ -84,7 +83,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_6";
-			label = "UART_1";
 			clocks = <&uartclk>;
 		};
 
@@ -94,7 +92,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 7 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_7";
-			label = "UART_2";
 			clocks = <&uartclk>;
 		};
 
@@ -104,7 +101,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_8";
-			label = "UART_3";
 			clocks = <&uartclk>;
 		};
 	};

--- a/dts/arm64/intel/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex.dtsi
@@ -27,7 +27,6 @@
 		      <0xfffc2000 0x2000>;
 		interrupt-controller;
 		#interrupt-cells = <4>;
-		label = "gic";
 		status = "okay";
 	};
 
@@ -47,20 +46,17 @@
 	sysmgr: sysmgr@ffd12000 {
 		compatible = "syscon";
 		reg = <0xffd12000 0x1000>;
-		label = "sysmgr";
 	};
 
 	clock: clock@ffd10000 {
 		compatible = "intel,agilex-clock";
 		reg = <0xffd10000 0x1000>;
 		#clock-cells = <1>;
-		label = "clock";
 	};
 
 	mem0: memory@10000000 {
 		device_type = "memory";
 		reg = <0x10000000 0x40000>;
-		label = "mem_0";
 	};
 
 	uart0: uart@ffc02000 {
@@ -72,7 +68,6 @@
 			      IRQ_DEFAULT_PRIORITY>;
 		interrupt-names = "irq_0";
 		clocks = <&clock INTEL_SOCFPGA_CLOCK_UART>;
-		label = "uart_0";
 		status = "disabled";
 	};
 };

--- a/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
+++ b/dts/arm64/nxp/nxp_imx8mm_a53.dtsi
@@ -72,13 +72,11 @@
 	ana_pll: ana_pll@30360000 {
 		compatible = "nxp,imx-ana";
 		reg = <0x30360000 DT_SIZE_K(64)>;
-		label = "ANA_PLL";
 	};
 
 	ccm: ccm@30380000 {
 		compatible = "nxp,imx-ccm";
 		reg = <0x30380000 DT_SIZE_K(64)>;
-		label = "CCM";
 		#clock-cells = <3>;
 	};
 
@@ -89,7 +87,6 @@
 		interrupt-names = "irq_0";
 		interrupt-parent = <&gic>;
 		clocks = <&ccm IMX_CCM_UART2_CLK 0x6c 24>;
-		label = "UART_2";
 		status = "disabled";
 	};
 
@@ -100,7 +97,6 @@
 		interrupt-names = "irq_0";
 		interrupt-parent = <&gic>;
 		clocks = <&ccm IMX_CCM_UART4_CLK 0x6c 24>;
-		label = "UART_4";
 		status = "disabled";
 	};
 };

--- a/dts/arm64/nxp/nxp_imx8mp_a53.dtsi
+++ b/dts/arm64/nxp/nxp_imx8mp_a53.dtsi
@@ -63,13 +63,11 @@
 		ana_pll: ana_pll@30360000 {
 			compatible = "nxp,imx-ana";
 			reg = <0x30360000 DT_SIZE_K(64)>;
-			label = "ANA_PLL";
 		};
 
 		ccm: ccm@30380000 {
 			compatible = "nxp,imx-ccm";
 			reg = <0x30380000 DT_SIZE_K(64)>;
-			label = "CCM";
 			#clock-cells = <3>;
 		};
 
@@ -79,7 +77,6 @@
 			interrupts = <GIC_SPI 27 IRQ_TYPE_LEVEL 0>;
 			interrupt-names = "irq_0";
 			interrupt-parent = <&gic>;
-			label = "UART_2";
 			status = "disabled";
 		};
 
@@ -89,7 +86,6 @@
 			interrupts = <GIC_SPI 29 IRQ_TYPE_LEVEL 0>;
 			interrupt-names = "irq_0";
 			interrupt-parent = <&gic>;
-			label = "UART_4";
 			status = "disabled";
 		};
 

--- a/dts/arm64/nxp/nxp_ls1046a.dtsi
+++ b/dts/arm64/nxp/nxp_ls1046a.dtsi
@@ -49,7 +49,6 @@
 	psci: psci {
 		compatible = "arm,psci-0.2";
 		method = "smc";
-		label = "PSCI";
 	};
 
 	sram0: memory@c0000000 {
@@ -75,7 +74,6 @@
 			interrupt-parent = <&gic>;
 			interrupts = <GIC_SPI 54 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			clock-frequency = <350000000>;
-			label = "UART_1";
 			reg-shift = <2>;
 			status = "disabled";
 		};

--- a/dts/arm64/qemu/qemu-virt-a53.dtsi
+++ b/dts/arm64/qemu/qemu-virt-a53.dtsi
@@ -80,7 +80,6 @@
 			interrupts = <GIC_SPI 1 IRQ_TYPE_LEVEL 0>;
 			interrupt-names = "irq_0";
 			clocks = <&uartclk>;
-			label = "UART_0";
 		};
 
 		flash0: flash@0 {


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>