### PR TITLE
dts: arm: ti: Remove label property from devicetrees

### DIFF
--- a/dts/arm/ti/cc1352r.dtsi
+++ b/dts/arm/ti/cc1352r.dtsi
@@ -24,7 +24,6 @@
 		/* CCFG registers occupy the last 88 bytes of flash */
 		ti_ccfg_partition: partition@57fa8 {
 			compatible = "zephyr,memory-region";
-			label = "ti_ccfg";
 			reg = <0x57fa8 88>;
 			zephyr,memory-region = "FLASH_CCFG";
 		};

--- a/dts/arm/ti/cc13x2_cc26x2.dtsi
+++ b/dts/arm/ti/cc13x2_cc26x2.dtsi
@@ -53,7 +53,6 @@
 			reg = <0x40022000 0x400>;
 			interrupts = <0 0>;
 			status = "disabled";
-			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -63,13 +62,11 @@
 			reg = <0x40028000 0x2000>;
 			interrupts = <33 0>;
 			status = "disabled";
-			label = "TRNG";
 		};
 
 		flash_controller: flash-controller@40030000 {
 			compatible = "ti,cc13xx-cc26xx-flash-controller";
 			reg = <0x40030000 0x4000>;
-			label="FLASH_CTRL";
 
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -87,7 +84,6 @@
 			interrupts = <5 0>;
 			clocks = <&sysclk>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: uart@4000b000 {
@@ -96,7 +92,6 @@
 			interrupts = <36 0>;
 			clocks = <&sysclk>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		i2c0: i2c@40002000 {
@@ -107,7 +102,6 @@
 			interrupts = <1 0>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			status = "disabled";
-			label = "I2C_0";
 		};
 
 		spi0: spi@40000000 {
@@ -117,7 +111,6 @@
 			reg = <0x40000000 0x1000>;
 			interrupts = <7 0>;
 			status = "disabled";
-			label = "SPI_0";
 		};
 
 		spi1: spi@40008000 {
@@ -127,7 +120,6 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <8 0>;
 			status = "disabled";
-			label = "SPI_1";
 		};
 
 		rtc: rtc@40092000 {
@@ -135,7 +127,6 @@
 			reg = <0x40092000 0x1000>;
 			interrupts = <4 0>;  /* interrupt #20 = 4 + 16 */
 			status = "disabled";
-			label = "RTC";
 		};
 	};
 };

--- a/dts/arm/ti/cc2652r.dtsi
+++ b/dts/arm/ti/cc2652r.dtsi
@@ -24,7 +24,6 @@
 		/* CCFG registers occupy the last 88 bytes of flash */
 		ti_ccfg_partition: partition@57fa8 {
 			compatible = "zephyr,memory-region";
-			label = "ti_ccfg";
 			reg = <0x57fa8 88>;
 			zephyr,memory-region = "FLASH_CCFG";
 		};

--- a/dts/arm/ti/cc3220sf.dtsi
+++ b/dts/arm/ti/cc3220sf.dtsi
@@ -18,7 +18,6 @@
 
 	flash1: flash@1000000 {
 		compatible = "soc-nv-flash";
-		label = "FLASH_1";
 		reg = <0x01000000 DT_SIZE_K(1024)>;
 	};
 };

--- a/dts/arm/ti/cc3235sf.dtsi
+++ b/dts/arm/ti/cc3235sf.dtsi
@@ -18,7 +18,6 @@
 
 	flash1: flash@1000000 {
 		compatible = "soc-nv-flash";
-		label = "FLASH_1";
 		reg = <0x01000000 DT_SIZE_K(1024)>;
 	};
 };

--- a/dts/arm/ti/cc32xx.dtsi
+++ b/dts/arm/ti/cc32xx.dtsi
@@ -62,7 +62,6 @@
 			interrupts = <EXP_UARTA0 3>;
 			clocks = <&sysclk>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: uart@4000d000 {
@@ -71,7 +70,6 @@
 			interrupts = <EXP_UARTA1 3>;
 			clocks = <&sysclk>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		i2c0: i2c@40020000 {
@@ -83,14 +81,12 @@
 			reg = <0x40020000 0xfc8>;
 			interrupts = <EXP_I2CA0 3>;
 			status = "disabled";
-			label= "I2C_0";
 		};
 
 		gpioa0: gpio@40004000 {
 			compatible = "ti,cc32xx-gpio";
 			reg = <0x40004000 0x1000>;
 			interrupts = <0 1>;
-			label = "GPIO_A0";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -99,7 +95,6 @@
 			compatible = "ti,cc32xx-gpio";
 			reg = <0x40005000 0x1000>;
 			interrupts = <1 1>;
-			label = "GPIO_A1";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -108,7 +103,6 @@
 			compatible = "ti,cc32xx-gpio";
 			reg = <0x40006000 0x1000>;
 			interrupts = <2 1>;
-			label = "GPIO_A2";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -117,7 +111,6 @@
 			compatible = "ti,cc32xx-gpio";
 			reg = <0x40007000 0x1000>;
 			interrupts = <3 1>;
-			label = "GPIO_A3";
 			gpio-controller;
 			#gpio-cells = <2>;
 		};
@@ -127,7 +120,6 @@
 			reg = <0x4402E800 0x100>;
 			interrupts = <EXP_ADCCH0 3>, <EXP_ADCCH1 3>, <EXP_ADCCH2 3>, <EXP_ADCCH3 3>;
 			status = "disabled";
-			label = "ADC_0";
 			#io-channel-cells = <1>;
 		};
 
@@ -135,7 +127,6 @@
 			compatible = "ti,cc32xx-watchdog";
 			reg = <0x40000000 0x1000>;
 			interrupts = <EXP_WDT 0>;
-			label = "WDT_0";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/ti/lm3s6965.dtsi
+++ b/dts/arm/ti/lm3s6965.dtsi
@@ -32,7 +32,6 @@
 			reg = <0x400fd000 0x1000>;
 			#address-cells = <1>;
 			#size-cells = <1>;
-			label = "FLASH_CTRL";
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
@@ -46,7 +45,6 @@
 			clocks = <&sysclk>;
 			interrupts = <5 3>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: uart@4000d000 {
@@ -55,7 +53,6 @@
 			clocks = <&sysclk>;
 			interrupts = <6 3>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		uart2: uart@4000e000 {
@@ -64,7 +61,6 @@
 			clocks = <&sysclk>;
 			interrupts = <33 3>;
 			status = "disabled";
-			label = "UART_2";
 		};
 
 		eth: ethernet@40048000 {
@@ -73,14 +69,12 @@
 			interrupts = <42 0>;
 			status = "disabled";
 			local-mac-address = [00 00 94 00 83 00];
-			label = "ETH";
 		};
 
 		gpio0: gpio@40004000 {
 			compatible = "ti,stellaris-gpio";
 			reg = <0x40004000 0x1000>;
 			interrupts = <0 3>;
-			label = "GPIO_A";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <8>;
@@ -90,7 +84,6 @@
 			compatible = "ti,stellaris-gpio";
 			reg = <0x40005000 0x1000>;
 			interrupts = <1 3>;
-			label = "GPIO_B";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <8>;
@@ -100,7 +93,6 @@
 			compatible = "ti,stellaris-gpio";
 			reg = <0x40006000 0x1000>;
 			interrupts = <2 3>;
-			label = "GPIO_C";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <8>;
@@ -110,7 +102,6 @@
 			compatible = "ti,stellaris-gpio";
 			reg = <0x40007000 0x1000>;
 			interrupts = <3 3>;
-			label = "GPIO_D";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <8>;
@@ -120,7 +111,6 @@
 			compatible = "ti,stellaris-gpio";
 			reg = <0x40024000 0x1000>;
 			interrupts = <4 3>;
-			label = "GPIO_E";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <4>;
@@ -130,7 +120,6 @@
 			compatible = "ti,stellaris-gpio";
 			reg = <0x40025000 0x1000>;
 			interrupts = <30 3>;
-			label = "GPIO_F";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <4>;
@@ -140,7 +129,6 @@
 			compatible = "ti,stellaris-gpio";
 			reg = <0x40026000 0x1000>;
 			interrupts = <31 3>;
-			label = "GPIO_G";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <2>;

--- a/dts/arm/ti/msp432p4xx.dtsi
+++ b/dts/arm/ti/msp432p4xx.dtsi
@@ -34,7 +34,6 @@
 			interrupts = <32 0>;
 			clocks = <&sysclk>;
 			status = "disabled";
-			label = "UART_0";
 		};
 	};
 };


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>