### PR TITLE
dts: arm: silabs: Remove label property from devicetrees

### DIFF
--- a/dts/arm/silabs/efm32_jg_pg_12b.dtsi
+++ b/dts/arm/silabs/efm32_jg_pg_12b.dtsi
@@ -31,7 +31,6 @@
 	soc {
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x104>;
 			interrupts = <25 0>;
 
@@ -40,7 +39,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};
@@ -53,7 +51,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40010400 { /* USART1 */
@@ -63,7 +60,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40010800 { /* USART2 */
@@ -73,7 +69,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		usart3: usart@40010c00 { /* USART3 */
@@ -83,7 +78,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <3>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		leuart0: leuart@4004a000 { /* LEUART0 */
@@ -92,7 +86,6 @@
 			interrupts = <22 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		i2c0: i2c@4000c000 {
@@ -102,7 +95,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c000 0x400>;
 			interrupts = <17 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -113,7 +105,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c400 0x400>;
 			interrupts = <42 0>;
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -124,7 +115,6 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
-			label = "RTCC_0";
 		};
 
 		gpio: gpio@4000a400 {
@@ -132,7 +122,6 @@
 			reg = <0x4000a400 0xf00>;
 			interrupts = <10 2 18 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -142,7 +131,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a000 0x30>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -152,7 +140,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a030 0x30>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -162,7 +149,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a060 0x30>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -172,7 +158,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a090 0x30>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -182,7 +167,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a0c0 0x30>;
 				peripheral-id = <4>;
-				label = "GPIO_E";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -192,7 +176,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a0f0 0x30>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -202,7 +185,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a180 0x30>;
 				peripheral-id = <8>;
-				label = "GPIO_I";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -212,7 +194,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a1b0 0x30>;
 				peripheral-id = <9>;
-				label = "GPIO_J";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -222,7 +203,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a1e0 0x30>;
 				peripheral-id = <10>;
-				label = "GPIO_K";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -233,7 +213,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052000 0x2C>;
 			peripheral-id = <0>;
-			label = "WDOG0";
 			interrupts = <2 0>;
 			status = "disabled";
 		};
@@ -242,7 +221,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052400 0x2C>;
 			peripheral-id = <1>;
-			label = "WDOG1";
 			interrupts = <3 0>;
 			status = "disabled";
 		};
@@ -251,20 +229,17 @@
 			compatible = "silabs,gecko-trng";
 			reg = <0x4001d000 0x400>;
 			interrupts = <49 0>;
-			label = "TRNG0";
 			status = "disabled";
 		};
 
 		timer0: timer@40018000 {
 			compatible = "silabs,gecko-timers";
 			reg = <0x40018000 0x400>;
-			label = "TIMER_0";
 			status = "disabled";
 
 			pwm {
 				compatible = "silabs,gecko-pwm";
 				status = "disabled";
-				label = "PWM_0";
 				#pwm-cells = <3>;
 			};
 		};

--- a/dts/arm/silabs/efm32_pg_1b.dtsi
+++ b/dts/arm/silabs/efm32_pg_1b.dtsi
@@ -27,7 +27,6 @@
 	soc {
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x800>;
 			interrupts = <24 0>;
 
@@ -36,7 +35,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};
@@ -49,7 +47,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40010400 { /* USART1 */
@@ -59,7 +56,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		leuart0: leuart@4004a000 { /* LEUART0 */
@@ -68,7 +64,6 @@
 			interrupts = <21 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		i2c0: i2c@4000c000 {
@@ -78,7 +73,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c000 0x400>;
 			interrupts = <16 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -89,7 +83,6 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
-			label = "RTCC_0";
 		};
 
 		gpio: gpio@4000a400 {
@@ -97,7 +90,6 @@
 			reg = <0x4000a400 0xf00>;
 			interrupts = <9 2 17 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -107,7 +99,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a000 0x30>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -117,7 +108,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a030 0x30>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -127,7 +117,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a060 0x30>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -137,7 +126,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a090 0x30>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -147,7 +135,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a0f0 0x30>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -158,7 +145,6 @@
                         compatible = "silabs,gecko-wdog";
                         reg = <0x40052000 0x400>;
                         peripheral-id = <0>;
-                        label = "WDOG0";
                         interrupts = <2 0>;
                         status = "disabled";
                 };

--- a/dts/arm/silabs/efm32gg11b.dtsi
+++ b/dts/arm/silabs/efm32gg11b.dtsi
@@ -33,7 +33,6 @@
 	soc {
 		msc: flash-controller@40000000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x40000000 0x110>;
 			interrupts = <33 0>;
 
@@ -42,7 +41,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <4096>;
 			};
@@ -55,7 +53,6 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
-			label = "RTCC_0";
 		};
 
 		uart0: uart@40014000 { /* UART0 */
@@ -65,7 +62,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: uart@40014400 { /* UART1 */
@@ -75,7 +71,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		usart0: usart@40010000 { /* USART0 */
@@ -85,7 +80,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40010400 { /* USART1 */
@@ -95,7 +89,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40010800 { /* USART2 */
@@ -105,7 +98,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		usart3: usart@40010c00 { /* USART3 */
@@ -115,7 +107,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <3>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		usart4: usart@40011000 { /* USART4 */
@@ -125,7 +116,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <4>;
 			status = "disabled";
-			label = "USART_4";
 		};
 
 		usart5: usart@40011400 { /* USART5 */
@@ -135,7 +125,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <5>;
 			status = "disabled";
-			label = "USART_5";
 		};
 
 		leuart0: leuart@4006a000 { /* LEUART0 */
@@ -144,7 +133,6 @@
 			interrupts = <25 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		leuart1: leuart@4006a400 { /* LEUART1 */
@@ -153,7 +141,6 @@
 			interrupts = <26 0>;
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "LEUART_1";
 		};
 
 		i2c0: i2c@40089000 {
@@ -163,7 +150,6 @@
 			#size-cells = <0>;
 			reg = <0x40089000 0x400>;
 			interrupts = <11 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -174,7 +160,6 @@
 			#size-cells = <0>;
 			reg = <0x40089400 0x400>;
 			interrupts = <12 0>;
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -185,7 +170,6 @@
 			#size-cells = <0>;
 			reg = <0x40089800 0x400>;
 			interrupts = <45 0>;
-			label = "I2C_2";
 			status = "disabled";
 		};
 
@@ -194,7 +178,6 @@
 			reg = <0x40088400 0xc00>;
 			interrupts = <3 2 13 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -204,7 +187,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40088000 0x30>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -214,7 +196,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40088030 0x30>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -224,7 +205,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40088060 0x30>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -234,7 +214,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40088090 0x30>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -244,7 +223,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x400880c0 0x30>;
 				peripheral-id = <4>;
-				label = "GPIO_E";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -254,7 +232,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x400880f0 0x30>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -264,7 +241,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40088120 0x30>;
 				peripheral-id = <6>;
-				label = "GPIO_G";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -274,7 +250,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40088150 0x30>;
 				peripheral-id = <7>;
-				label = "GPIO_H";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -284,7 +259,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40088180 0x30>;
 				peripheral-id = <8>;
-				label = "GPIO_I";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -295,7 +269,6 @@
 			compatible = "silabs,gecko-trng";
 			reg = <0x4001d000 0x400>;
 			interrupts = <66 0>;
-			label = "TRNG0";
 			status = "disabled";
 		};
 
@@ -303,7 +276,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052000 0x2C>;
 			peripheral-id = <0>;
-			label = "WDOG0";
 			interrupts = <1 0>;
 			status = "disabled";
 		};
@@ -312,7 +284,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052400 0x2C>;
 			peripheral-id = <1>;
-			label = "WDOG1";
 			interrupts = <64 0>;
 			status = "disabled";
 		};

--- a/dts/arm/silabs/efm32gg11b820f2048gl192.dtsi
+++ b/dts/arm/silabs/efm32gg11b820f2048gl192.dtsi
@@ -28,7 +28,6 @@
 			reg = <0x40024000 0xC14>;
 			interrupts = <59 0>;
 			status = "disabled";
-			label = "ETH_0";
 		};
 	};
 

--- a/dts/arm/silabs/efm32hg.dtsi
+++ b/dts/arm/silabs/efm32hg.dtsi
@@ -27,7 +27,6 @@
 	soc {
 		msc: flash-controller@400c0000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400c0000 0x5c>;
 			interrupts = <15 0>;
 
@@ -36,7 +35,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <1024>;
 			};
@@ -49,7 +47,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		usart1: usart@4000c400 { /* USART1 */
@@ -59,7 +56,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		leuart0: leuart@40084000 { /* LEUART0 */
@@ -68,7 +64,6 @@
 			interrupts = <10 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		i2c0: i2c@4000a000 {
@@ -78,7 +73,6 @@
 			#size-cells = <0>;
 			reg = <0x4000a000 0x400>;
 			interrupts = <5 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -87,7 +81,6 @@
 			reg = <0x40006100 0xf00>;
 			interrupts = <1 0 6 0>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -97,7 +90,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006000 0x24>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -107,7 +99,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006024 0x24>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -117,7 +108,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006048 0x24>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -127,7 +117,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000606c 0x24>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -137,7 +126,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006090 0x24>;
 				peripheral-id = <4>;
-				label = "GPIO_E";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -147,7 +135,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x400060b4 0x24>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";

--- a/dts/arm/silabs/efm32wg.dtsi
+++ b/dts/arm/silabs/efm32wg.dtsi
@@ -27,7 +27,6 @@
 	soc {
 		msc: flash-controller@400c0000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400c0000 0x78>;
 			interrupts = <35 0>;
 
@@ -36,7 +35,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};
@@ -49,7 +47,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		usart1: usart@4000c400 { /* USART1 */
@@ -59,7 +56,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		usart2: usart@4000c800 { /* USART2 */
@@ -69,7 +65,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "UART_2";
 		};
 
 		uart0: uart@4000e000 { /* UART0 */
@@ -79,7 +74,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "UART_3";
 		};
 
 		uart1: uart@4000e400 { /* UART1 */
@@ -89,7 +83,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "UART_4";
 		};
 
 		leuart0: leuart@40084000 { /* LEUART0 */
@@ -98,7 +91,6 @@
 			interrupts = <24 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		leuart1: leuart@40084400 { /* LEUART1 */
@@ -107,7 +99,6 @@
 			interrupts = <25 0>;
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "LEUART_1";
 		};
 
 		i2c0: i2c@4000a000 {
@@ -117,7 +108,6 @@
 			#size-cells = <0>;
 			reg = <0x4000a000 0x400>;
 			interrupts = <9 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -128,7 +118,6 @@
 			#size-cells = <0>;
 			reg = <0x4000a400 0x400>;
 			interrupts = <10 0>;
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -137,7 +126,6 @@
 			reg = <0x40006100 0xf00>;
 			interrupts = <1 2 11 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -147,7 +135,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006000 0x24>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -157,7 +144,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006024 0x24>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -167,7 +153,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006048 0x24>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -177,7 +162,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000606c 0x24>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -187,7 +171,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x40006090 0x24>;
 				peripheral-id = <4>;
-				label = "GPIO_E";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -197,7 +180,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x400060b4 0x24>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";

--- a/dts/arm/silabs/efr32fg1p.dtsi
+++ b/dts/arm/silabs/efr32fg1p.dtsi
@@ -28,7 +28,6 @@
 	soc {
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x78>;
 			interrupts = <24 0>;
 
@@ -37,7 +36,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};
@@ -50,7 +48,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40010400 { /* USART1 */
@@ -60,7 +57,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		leuart0: leuart@4004a000 { /* LEUART0 */
@@ -69,7 +65,6 @@
 			interrupts = <21 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		i2c0: i2c@4000c000 {
@@ -79,7 +74,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c000 0x400>;
 			interrupts = <16 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -90,7 +84,6 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
-			label = "RTCC_0";
 		};
 
 		gpio: gpio@4000a400 {
@@ -98,7 +91,6 @@
 			reg = <0x4000a400 0xc00>;
 			interrupts = <9 2 17 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -108,7 +100,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a000 0x30>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -118,7 +109,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a030 0x30>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -128,7 +118,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a060 0x30>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -138,7 +127,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a090 0x30>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -148,7 +136,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a0c0 0x30>;
 				peripheral-id = <4>;
-				label = "GPIO_E";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -158,7 +145,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a0f0 0x30>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -169,7 +155,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052000 0x2C>;
 			peripheral-id = <0>;
-			label = "WDOG0";
 			interrupts = <2 0>;
 			status = "disabled";
 		};
@@ -178,12 +163,10 @@
 			compatible = "silabs,gecko-timers";
 			reg = <0x40018000 0x400>;
 			status = "disabled";
-			label = "TIMER_0";
 
 			pwm {
 				compatible = "silabs,gecko-pwm";
 				status = "disabled";
-				label = "PWM_0";
 				#pwm-cells = <3>;
 			};
 		};

--- a/dts/arm/silabs/efr32mg.dtsi
+++ b/dts/arm/silabs/efr32mg.dtsi
@@ -29,7 +29,6 @@
 	soc {
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x104>;
 			interrupts = <25 0>;
 
@@ -38,7 +37,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};
@@ -51,7 +49,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40010400 { /* USART1 */
@@ -61,7 +58,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40010800 { /* USART2 */
@@ -71,7 +67,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		usart3: usart@40010c00 { /* USART3 */
@@ -81,7 +76,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <3>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		leuart0: leuart@4004a000 { /* LEUART0 */
@@ -90,7 +84,6 @@
 			interrupts = <22 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		i2c0: i2c@4000c000 {
@@ -100,7 +93,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c000 0x400>;
 			interrupts = <17 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -111,7 +103,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c400 0x400>;
 			interrupts = <42 0>;
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -122,7 +113,6 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
-			label = "RTCC_0";
 		};
 
 		gpio: gpio@4000a400 {
@@ -130,7 +120,6 @@
 			reg = <0x4000a400 0xc00>;
 			interrupts = <10 2 18 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -140,7 +129,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a000 0x30>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -150,7 +138,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a030 0x30>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -160,7 +147,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a060 0x30>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -170,7 +156,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a090 0x30>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -180,7 +165,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a0f0 0x30>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -190,7 +174,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a180 0x30>;
 				peripheral-id = <8>;
-				label = "GPIO_I";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -200,7 +183,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a1b0 0x30>;
 				peripheral-id = <9>;
-				label = "GPIO_J";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -210,7 +192,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a1e0 0x30>;
 				peripheral-id = <10>;
-				label = "GPIO_K";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -221,7 +202,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052000 0x2C>;
 			peripheral-id = <0>;
-			label = "WDOG0";
 			interrupts = <2 0>;
 			status = "disabled";
 		};
@@ -230,7 +210,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052400 0x2C>;
 			peripheral-id = <1>;
-			label = "WDOG1";
 			interrupts = <3 0>;
 			status = "disabled";
 		};
@@ -239,12 +218,10 @@
 			compatible = "silabs,gecko-timers";
 			reg = <0x40018000 0x400>;
 			status = "disabled";
-			label = "TIMER_0";
 
 			pwm {
 				compatible = "silabs,gecko-pwm";
 				status = "disabled";
-				label = "PWM_0";
 				#pwm-cells = <3>;
 			};
 		};
@@ -253,7 +230,6 @@
 			compatible = "silabs,gecko-trng";
 			reg = <0x4001d000 0x400>;
 			interrupts = <49 0>;
-			label = "TRNG0";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/silabs/efr32mg21.dtsi
+++ b/dts/arm/silabs/efr32mg21.dtsi
@@ -43,7 +43,6 @@
 	soc {
 		msc: flash-controller@40030000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x40030000 0x31a4>;
 			interrupts = <51 0>;
 
@@ -52,7 +51,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <8192>;
 			};
@@ -65,7 +63,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@4005c000 { /* USART1 */
@@ -75,7 +72,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40060000 { /* USART2 */
@@ -85,7 +81,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		i2c0: i2c@4a010000 {
@@ -95,7 +90,6 @@
 			#size-cells = <0>;
 			reg = <0x4a010000 0x400>;
 			interrupts = <27 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -106,7 +100,6 @@
 			#size-cells = <0>;
 			reg = <0x40068000 0x400>;
 			interrupts = <28 0>;
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -117,7 +110,6 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
-			label = "RTCC_0";
 		};
 
 		gpio: gpio@4003c300 {
@@ -125,7 +117,6 @@
 			reg = <0x4003c300 0x3c00>;
 			interrupts = <26 2>, <25 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -135,7 +126,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4003c000 0x30>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -145,7 +135,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4003c030 0x30>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -155,7 +144,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4003c060 0x30>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -165,7 +153,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4003c090 0x30>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -177,7 +164,6 @@
 			reg = <0x4c000000 0x80>;
 			interrupts = <0 3>, <1 3>, <2 3>;
 			interrupt-names = "SETAMPERHOST", "SEMBRX", "SEMBTX";
-			label = "SEMAILBOX";
 			status = "okay";
 		};
 
@@ -185,7 +171,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x4a018000 0x2C>;
 			peripheral-id = <0>;
-			label = "WDOG0";
 			interrupts = <43 0>;
 			status = "disabled";
 		};
@@ -194,7 +179,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x4a01c000 0x2C>;
 			peripheral-id = <1>;
-			label = "WDOG1";
 			interrupts = <44 0>;
 			status = "disabled";
 		};

--- a/dts/arm/silabs/efr32xg13p.dtsi
+++ b/dts/arm/silabs/efr32xg13p.dtsi
@@ -31,7 +31,6 @@
 	soc {
 		msc: flash-controller@400e0000 {
 			compatible = "silabs,gecko-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x400e0000 0x104>;
 			interrupts = <25 0>;
 
@@ -40,7 +39,6 @@
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				write-block-size = <4>;
 				erase-block-size = <2048>;
 			};
@@ -53,7 +51,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40010400 { /* USART1 */
@@ -63,7 +60,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40010800 { /* USART2 */
@@ -73,7 +69,6 @@
 			interrupt-names = "rx", "tx";
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		leuart0: leuart@4004a000 { /* LEUART0 */
@@ -82,7 +77,6 @@
 			interrupts = <22 0>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "LEUART_0";
 		};
 
 		i2c0: i2c@4000c000 {
@@ -92,7 +86,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c000 0x400>;
 			interrupts = <17 0>;
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -103,7 +96,6 @@
 			#size-cells = <0>;
 			reg = <0x4000c400 0x400>;
 			interrupts = <40 0>;
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -114,7 +106,6 @@
 			clock-frequency = <32768>;
 			prescaler = <1>;
 			status = "disabled";
-			label = "RTCC_0";
 		};
 
 		gpio: gpio@4000a400 {
@@ -122,7 +113,6 @@
 			reg = <0x4000a400 0xc00>;
 			interrupts = <10 2 18 2>;
 			interrupt-names = "GPIO_EVEN", "GPIO_ODD";
-			label = "GPIO";
 
 			ranges;
 			#address-cells = <1>;
@@ -132,7 +122,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a000 0x30>;
 				peripheral-id = <0>;
-				label = "GPIO_A";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -142,7 +131,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a030 0x30>;
 				peripheral-id = <1>;
-				label = "GPIO_B";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -152,7 +140,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a060 0x30>;
 				peripheral-id = <2>;
-				label = "GPIO_C";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -162,7 +149,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a090 0x30>;
 				peripheral-id = <3>;
-				label = "GPIO_D";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -172,7 +158,6 @@
 				compatible = "silabs,gecko-gpio-port";
 				reg = <0x4000a0f0 0x30>;
 				peripheral-id = <5>;
-				label = "GPIO_F";
 				gpio-controller;
 				#gpio-cells = <2>;
 				status = "disabled";
@@ -183,7 +168,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052000 0x2C>;
 			peripheral-id = <0>;
-			label = "WDOG0";
 			interrupts = <2 0>;
 			status = "disabled";
 		};
@@ -192,7 +176,6 @@
 			compatible = "silabs,gecko-wdog";
 			reg = <0x40052400 0x2C>;
 			peripheral-id = <1>;
-			label = "WDOG1";
 			interrupts = <3 0>;
 			status = "disabled";
 		};


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>