### PR TITLE
dts: arm: Remove label property from devicetrees

### DIFF
--- a/dts/arm/acsip/s76s.dtsi
+++ b/dts/arm/acsip/s76s.dtsi
@@ -18,7 +18,6 @@
 	lora: lora@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
-		label = "sx1276";
 		/* SX1276 nRESET */
 		reset-gpios = <&gpiob 10 GPIO_ACTIVE_LOW>;
 		dio-gpios =

--- a/dts/arm/aspeed/ast10x0.dtsi
+++ b/dts/arm/aspeed/ast10x0.dtsi
@@ -34,7 +34,6 @@
 			reg = <0x7e784000 0x1000>;
 			interrupts = <8 0>;
 			status = "disabled";
-			label = "UART_5";
 			reg-shift = <2>;
 		};
 	};

--- a/dts/arm/broadcom/valkyrie.dtsi
+++ b/dts/arm/broadcom/valkyrie.dtsi
@@ -37,7 +37,6 @@
 			reg = <0x40020000 0x400>;
 			clock-frequency = <25000000>;
 			interrupts = <MCU_AON_UART_INTR 3>;
-			label = "UART_0";
 			reg-shift = <2>;
 			status = "disabled";
 		};
@@ -47,7 +46,6 @@
 			reg = <0x48100000 0x400>;
 			clock-frequency = <100000000>;
 			interrupts = <UART0_INTR 3>;
-			label = "UART_1";
 			reg-shift = <2>;
 			status = "disabled";
 		};

--- a/dts/arm/broadcom/viper-common.dtsi
+++ b/dts/arm/broadcom/viper-common.dtsi
@@ -15,7 +15,6 @@
 			compatible = "ns16550";
 			reg = <0x40020000 0x400>;
 			clock-frequency = <25000000>;
-			label = "CRMU_UART";
 			reg-shift = <2>;
 			status = "disabled";
 		};
@@ -24,7 +23,6 @@
 			compatible = "ns16550";
 			reg = <0x48100000 0x400>;
 			clock-frequency = <100000000>;
-			label = "CCG_UART0";
 			reg-shift = <2>;
 			status = "disabled";
 		};
@@ -38,7 +36,6 @@
 			microcode = <0x63b00000  0x1000>;
 			dma-channels = <8>;
 			#dma-cells = <1>;
-			label = "DMA_0";
 		};
 	};
 
@@ -53,14 +50,12 @@
 			      <0x4 0x0 0x0 0x8000000>;
 			reg-names = "iproc_pcie_regs", "map_lowmem",
 				    "map_highmem";
-			label = "PCIE_0";
 			dmas = <&pl330 0>, <&pl330 1>;
 			dma-names = "txdma", "rxdma";
 		};
 
 		paxdma: paxdma@4e100800 {
 			compatible = "brcm,iproc-pax-dma-v2";
-			label = "DMA_1";
 			reg = <0x0 0x4e100800 0x0 0x2100>,
 			      <0x0 0x4f000000 0x0 0x200000>,
 			      <0x0 0x4f200000 0x0 0x10000>;

--- a/dts/arm/cypress/psoc6.dtsi
+++ b/dts/arm/cypress/psoc6.dtsi
@@ -34,18 +34,15 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 
-			label="CYPRESS_FLASH_DRV_NAME";
 
 			flash0: flash@10000000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 				reg = <0x10000000 DT_SIZE_K(384)>;
 				write-block-size = <4>;
 			};
 
 			flash1: flash@10060000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_1";
 				reg = <0x10060000 DT_SIZE_K(640)>;
 				write-block-size = <4>;
 			};
@@ -79,7 +76,6 @@
 				compatible = "cypress,psoc6-hsiom";
 				reg = <0x40310000 0x2024>;
 				interrupts = <15 1>, <16 1>;
-				label = "HSIOM";
 				status = "disabled";
 			};
 
@@ -87,7 +83,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320000 0x80>;
 				interrupts = <0 1>;
-				label = "P0";
 				gpio-controller;
 				ngpios = <6>;
 				#gpio-cells = <2>;
@@ -98,7 +93,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320080 0x80>;
 				interrupts = <1 1>;
-				label = "P1";
 				gpio-controller;
 				ngpios = <6>;
 				#gpio-cells = <2>;
@@ -109,7 +103,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320100 0x80>;
 				interrupts = <2 1>;
-				label = "P2";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -120,7 +113,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320180 0x80>;
 				interrupts = <3 1>;
-				label = "P3";
 				gpio-controller;
 				ngpios = <6>;
 				#gpio-cells = <2>;
@@ -131,7 +123,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320200 0x80>;
 				interrupts = <4 1>;
-				label = "P4";
 				gpio-controller;
 				ngpios = <4>;
 				#gpio-cells = <2>;
@@ -142,7 +133,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320280 0x80>;
 				interrupts = <5 1>;
-				label = "P5";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -153,7 +143,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320300 0x80>;
 				interrupts = <6 1>;
-				label = "P6";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -164,7 +153,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320380 0x80>;
 				interrupts = <7 1>;
-				label = "P7";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -175,7 +163,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320400 0x80>;
 				interrupts = <8 1>;
-				label = "P8";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -186,7 +173,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320480 0x80>;
 				interrupts = <9 1>;
-				label = "P9";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -197,7 +183,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320500 0x80>;
 				interrupts = <10 1>;
-				label = "P10";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -208,7 +193,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320580 0x80>;
 				interrupts = <11 1>;
-				label = "P11";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -219,7 +203,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320600 0x80>;
 				interrupts = <12 1>;
-				label = "P12";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -230,7 +213,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320680 0x80>;
 				interrupts = <13 1>;
-				label = "P13";
 				gpio-controller;
 				ngpios = <8>;
 				#gpio-cells = <2>;
@@ -241,7 +223,6 @@
 				compatible = "cypress,psoc6-gpio";
 				reg = <0x40320700 0x80>;
 				interrupts = <14 1>;
-				label = "P14";
 				gpio-controller;
 				ngpios = <2>;
 				#gpio-cells = <2>;
@@ -256,7 +237,6 @@
 			interrupts = <41 6>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "spi_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -266,7 +246,6 @@
 			interrupts = <42 6>;
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "spi_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -276,7 +255,6 @@
 			interrupts = <43 6>;
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "spi_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -286,7 +264,6 @@
 			interrupts = <44 6>;
 			peripheral-id = <3>;
 			status = "disabled";
-			label = "spi_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -296,7 +273,6 @@
 			interrupts = <45 6>;
 			peripheral-id = <4>;
 			status = "disabled";
-			label = "spi_4";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -306,7 +282,6 @@
 			interrupts = <46 6>;
 			peripheral-id = <5>;
 			status = "disabled";
-			label = "spi_5";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -316,7 +291,6 @@
 			interrupts = <47 6>;
 			peripheral-id = <6>;
 			status = "disabled";
-			label = "spi_6";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -326,7 +300,6 @@
 			interrupts = <48 6>;
 			peripheral-id = <7>;
 			status = "disabled";
-			label = "spi_7";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -336,7 +309,6 @@
 			interrupts = <18 6>;
 			peripheral-id = <8>;
 			status = "disabled";
-			label = "spi_8";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -347,7 +319,6 @@
 			interrupts = <41 6>;
 			peripheral-id = <0>;
 			status = "disabled";
-			label = "uart_0";
 		};
 		uart1: uart@40620000 {
 			compatible = "cypress,psoc6-uart";
@@ -355,7 +326,6 @@
 			interrupts = <42 6>;
 			peripheral-id = <1>;
 			status = "disabled";
-			label = "uart_1";
 		};
 		uart2: uart@40630000 {
 			compatible = "cypress,psoc6-uart";
@@ -363,7 +333,6 @@
 			interrupts = <43 6>;
 			peripheral-id = <2>;
 			status = "disabled";
-			label = "uart_2";
 		};
 		uart3: uart@40640000 {
 			compatible = "cypress,psoc6-uart";
@@ -371,7 +340,6 @@
 			interrupts = <44 6>;
 			peripheral-id = <3>;
 			status = "disabled";
-			label = "uart_3";
 		};
 		uart4: uart@40650000 {
 			compatible = "cypress,psoc6-uart";
@@ -379,7 +347,6 @@
 			interrupts = <45 6>;
 			peripheral-id = <4>;
 			status = "disabled";
-			label = "uart_4";
 		};
 		uart5: uart@40660000 {
 			compatible = "cypress,psoc6-uart";
@@ -387,7 +354,6 @@
 			interrupts = <46 6>;
 			peripheral-id = <5>;
 			status = "disabled";
-			label = "uart_5";
 		};
 		uart6: uart@40670000 {
 			compatible = "cypress,psoc6-uart";
@@ -395,7 +361,6 @@
 			interrupts = <47 6>;
 			peripheral-id = <6>;
 			status = "disabled";
-			label = "uart_6";
 		};
 		uart7: uart@40680000 {
 			compatible = "cypress,psoc6-uart";
@@ -403,7 +368,6 @@
 			interrupts = <48 6>;
 			peripheral-id = <7>;
 			status = "disabled";
-			label = "uart_7";
 		};
 		uart8: uart@40690000 {
 			compatible = "cypress,psoc6-uart";
@@ -411,7 +375,6 @@
 			interrupts = <18 6>;
 			peripheral-id = <8>;
 			status = "disabled";
-			label = "uart_8";
 		};
 
 		uid: device_uid@16000600 {

--- a/dts/arm/cypress/psoc6_cm0.dtsi
+++ b/dts/arm/cypress/psoc6_cm0.dtsi
@@ -22,7 +22,6 @@
 			compatible = "cypress,psoc6-intmux";
 			reg = <0x40210020 0x20>;
 			ranges = <0x0 0x40210020 0x20>;
-			label = "INTMUX";
 			status = "okay";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -33,7 +32,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <0 3>;
-				label = "INTMUX_CH0";
 				status = "okay";
 			};
 			intmux_ch1: interrupt-controller@1 {
@@ -42,7 +40,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <1 3>;
-				label = "INTMUX_CH1";
 				status = "okay";
 			};
 			intmux_ch2: interrupt-controller@2 {
@@ -51,7 +48,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <2 3>;
-				label = "INTMUX_CH2";
 				status = "okay";
 			};
 			intmux_ch3: interrupt-controller@3 {
@@ -60,7 +56,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <3 3>;
-				label = "INTMUX_CH3";
 				status = "okay";
 			};
 			intmux_ch4: interrupt-controller@4 {
@@ -69,7 +64,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <4 3>;
-				label = "INTMUX_CH4";
 				status = "okay";
 			};
 			intmux_ch5: interrupt-controller@5 {
@@ -78,7 +72,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <5 3>;
-				label = "INTMUX_CH5";
 				status = "okay";
 			};
 			intmux_ch6: interrupt-controller@6 {
@@ -87,7 +80,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <6 3>;
-				label = "INTMUX_CH6";
 				status = "okay";
 			};
 			intmux_ch7: interrupt-controller@7 {
@@ -96,7 +88,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <7 3>;
-				label = "INTMUX_CH7";
 				status = "okay";
 			};
 			intmux_ch8: interrupt-controller@8 {
@@ -105,7 +96,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <8 3>;
-				label = "INTMUX_CH8";
 				status = "okay";
 			};
 			intmux_ch9: interrupt-controller@9 {
@@ -114,7 +104,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <9 3>;
-				label = "INTMUX_CH9";
 				status = "okay";
 			};
 			intmux_ch10: interrupt-controller@a {
@@ -123,7 +112,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <10 3>;
-				label = "INTMUX_CH10";
 				status = "okay";
 			};
 			intmux_ch11: interrupt-controller@b {
@@ -132,7 +120,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <11 3>;
-				label = "INTMUX_CH11";
 				status = "okay";
 			};
 			intmux_ch12: interrupt-controller@c {
@@ -141,7 +128,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <12 3>;
-				label = "INTMUX_CH12";
 				status = "okay";
 			};
 			intmux_ch13: interrupt-controller@d {
@@ -150,7 +136,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <13 3>;
-				label = "INTMUX_CH13";
 				status = "okay";
 			};
 			intmux_ch14: interrupt-controller@e {
@@ -159,7 +144,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <14 3>;
-				label = "INTMUX_CH14";
 				status = "okay";
 			};
 			intmux_ch15: interrupt-controller@f {
@@ -168,7 +152,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <15 3>;
-				label = "INTMUX_CH15";
 				status = "okay";
 			};
 			intmux_ch16: interrupt-controller@10 {
@@ -177,7 +160,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <16 3>;
-				label = "INTMUX_CH16";
 				status = "okay";
 			};
 			intmux_ch17: interrupt-controller@11 {
@@ -186,7 +168,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <17 3>;
-				label = "INTMUX_CH17";
 				status = "okay";
 			};
 			intmux_ch18: interrupt-controller@12 {
@@ -195,7 +176,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <18 3>;
-				label = "INTMUX_CH18";
 				status = "okay";
 			};
 			intmux_ch19: interrupt-controller@13 {
@@ -204,7 +184,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <19 3>;
-				label = "INTMUX_CH19";
 				status = "okay";
 			};
 			intmux_ch20: interrupt-controller@14 {
@@ -213,7 +192,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <20 3>;
-				label = "INTMUX_CH20";
 				status = "okay";
 			};
 			intmux_ch21: interrupt-controller@15 {
@@ -222,7 +200,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <21 3>;
-				label = "INTMUX_CH21";
 				status = "okay";
 			};
 			intmux_ch22: interrupt-controller@16 {
@@ -231,7 +208,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <22 3>;
-				label = "INTMUX_CH22";
 				status = "okay";
 			};
 			intmux_ch23: interrupt-controller@17 {
@@ -240,7 +216,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <23 3>;
-				label = "INTMUX_CH23";
 				status = "okay";
 			};
 			intmux_ch24: interrupt-controller@18 {
@@ -249,7 +224,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <24 3>;
-				label = "INTMUX_CH24";
 				status = "okay";
 			};
 			intmux_ch25: interrupt-controller@19 {
@@ -258,7 +232,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <25 3>;
-				label = "INTMUX_CH25";
 				status = "okay";
 			};
 			intmux_ch26: interrupt-controller@1a {
@@ -267,7 +240,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <26 3>;
-				label = "INTMUX_CH26";
 				status = "okay";
 			};
 			intmux_ch27: interrupt-controller@1b {
@@ -276,7 +248,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <27 3>;
-				label = "INTMUX_CH27";
 				status = "okay";
 			};
 			intmux_ch28: interrupt-controller@1c {
@@ -285,7 +256,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <28 3>;
-				label = "INTMUX_CH28";
 				status = "okay";
 			};
 			intmux_ch29: interrupt-controller@1d {
@@ -294,7 +264,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <29 3>;
-				label = "INTMUX_CH29";
 				status = "okay";
 			};
 			intmux_ch30: interrupt-controller@1e {
@@ -303,7 +272,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <30 3>;
-				label = "INTMUX_CH30";
 				status = "okay";
 			};
 			intmux_ch31: interrupt-controller@1f {
@@ -312,7 +280,6 @@
 				#interrupt-cells = <2>;
 				interrupt-controller;
 				interrupts = <31 3>;
-				label = "INTMUX_CH31";
 				status = "okay";
 			};
 		};

--- a/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
+++ b/dts/arm/gigadevice/gd32e10x/gd32e10x.dtsi
@@ -31,7 +31,6 @@
 
 		FMC: flash-controller@40022000 {
 			compatible = "gd,gd32-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			peripheral-id = <6>;
 
@@ -40,7 +39,6 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 			};
 		};
 
@@ -50,7 +48,6 @@
 			interrupts = <37 0>;
 			rcu-periph-clock = <0x60e>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40004400 {
@@ -59,7 +56,6 @@
 			interrupts = <38 0>;
 			rcu-periph-clock = <0x711>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40004800 {
@@ -68,7 +64,6 @@
 			interrupts = <39 0>;
 			rcu-periph-clock = <0x712>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		uart3: usart@40004c00 {
@@ -77,7 +72,6 @@
 			interrupts = <52 0>;
 			rcu-periph-clock = <0x713>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		uart4: usart@40005000 {
@@ -86,7 +80,6 @@
 			interrupts = <53 0>;
 			rcu-periph-clock = <0x714>;
 			status = "disabled";
-			label = "USART_4";
 		};
 
 		dac: dac@40007400 {
@@ -94,7 +87,6 @@
 			reg = <0x40007400 0x400>;
 			rcu-periph-clock = <0x71d>;
 			num-channels = <2>;
-			label = "DAC";
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -109,7 +101,6 @@
 			interrupt-names = "event", "error";
 			rcu-periph-clock = <0x715>;
 			status = "disabled";
-			label = "I2C_0";
 		};
 
 		i2c1: i2c@40005800 {
@@ -122,7 +113,6 @@
 			interrupt-names = "event", "error";
 			rcu-periph-clock = <0x716>;
 			status = "disabled";
-			label = "I2C_1";
 		};
 
 		afio: afio@40010000 {
@@ -130,7 +120,6 @@
 			reg = <0x40010000 0x400>;
 			rcu-periph-clock = <0x600>;
 			status = "okay";
-			label = "AFIO";
 		};
 
 		exti: interrupt-controller@40010400 {
@@ -144,7 +133,6 @@
 			interrupt-names = "line0", "line1", "line2", "line3",
 					  "line4", "line5-9", "line10-15";
 			status = "okay";
-			label = "EXTI";
 		};
 
 		pinctrl: pin-controller@40010800 {
@@ -153,7 +141,6 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
-			label = "PINCTRL";
 
 			gpioa: gpio@40010800 {
 				compatible = "gd,gd32-gpio";
@@ -162,7 +149,6 @@
 				reg = <0x40010800 0x400>;
 				rcu-periph-clock = <0x602>;
 				status = "disabled";
-				label = "GPIOA";
 			};
 
 			gpiob: gpio@40010c00 {
@@ -172,7 +158,6 @@
 				reg = <0x40010c00 0x400>;
 				rcu-periph-clock = <0x603>;
 				status = "disabled";
-				label = "GPIOB";
 			};
 
 			gpioc: gpio@40011000 {
@@ -182,7 +167,6 @@
 				reg = <0x40011000 0x400>;
 				rcu-periph-clock = <0x604>;
 				status = "disabled";
-				label = "GPIOC";
 			};
 
 			gpiod: gpio@40011400 {
@@ -192,7 +176,6 @@
 				reg = <0x40011400 0x400>;
 				rcu-periph-clock = <0x605>;
 				status = "disabled";
-				label = "GPIOD";
 			};
 
 			gpioe: gpio@40011800 {
@@ -202,7 +185,6 @@
 				reg = <0x40011800 0x400>;
 				rcu-periph-clock = <0x606>;
 				status = "disabled";
-				label = "GPIOE";
 			};
 		};
 
@@ -216,12 +198,10 @@
 			is-advanced;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_0";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_0";
 				#pwm-cells = <3>;
 			};
 		};
@@ -235,12 +215,10 @@
 			rcu-periph-reset = <0x400>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_1";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_1";
 				#pwm-cells = <3>;
 			};
 		};
@@ -254,12 +232,10 @@
 			rcu-periph-reset = <0x401>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_2";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_2";
 				#pwm-cells = <3>;
 			};
 		};
@@ -273,12 +249,10 @@
 			rcu-periph-reset = <0x402>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_3";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_3";
 				#pwm-cells = <3>;
 			};
 		};
@@ -292,12 +266,10 @@
 			rcu-periph-reset = <0x403>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_4";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_4";
 				#pwm-cells = <3>;
 			};
 		};
@@ -311,7 +283,6 @@
 			rcu-periph-reset = <0x404>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_5";
 		};
 
 		timer6: timer@40001400 {
@@ -323,7 +294,6 @@
 			rcu-periph-reset = <0x405>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_6";
 		};
 
 		timer7: timer@40013400 {
@@ -336,12 +306,10 @@
 			is-advanced;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_7";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_7";
 				#pwm-cells = <3>;
 			};
 		};
@@ -355,12 +323,10 @@
 			rcu-periph-reset = <0x313>;
 			channels = <2>;
 			status = "disabled";
-			label = "TIMER_8";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_8";
 				#pwm-cells = <3>;
 			};
 		};
@@ -374,12 +340,10 @@
 			rcu-periph-reset = <0x314>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_9";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_9";
 				#pwm-cells = <3>;
 			};
 		};
@@ -393,12 +357,10 @@
 			rcu-periph-reset = <0x315>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_10";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_10";
 				#pwm-cells = <3>;
 			};
 		};
@@ -412,12 +374,10 @@
 			rcu-periph-reset = <0x406>;
 			channels = <2>;
 			status = "disabled";
-			label = "TIMER_11";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_11";
 				#pwm-cells = <3>;
 			};
 		};
@@ -431,12 +391,10 @@
 			rcu-periph-reset = <0x402>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_12";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_12";
 				#pwm-cells = <3>;
 			};
 		};
@@ -450,12 +408,10 @@
 			rcu-periph-reset = <0x408>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_13";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_13";
 				#pwm-cells = <3>;
 			};
 		};

--- a/dts/arm/gigadevice/gd32f3x0/gd32f350.dtsi
+++ b/dts/arm/gigadevice/gd32f3x0/gd32f350.dtsi
@@ -14,7 +14,6 @@
 			reg = <0x40007400 0x400>;
 			rcu-periph-clock = <0x71d>;
 			num-channels = <1>;
-			label = "DAC";
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};

--- a/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
+++ b/dts/arm/gigadevice/gd32f3x0/gd32f3x0.dtsi
@@ -28,7 +28,6 @@
 
 		fmc: flash-controller@40022000 {
 			compatible = "gd,gd32-flash-controller";
-			label = "FMC";
 			reg = <0x40022000 0x400>;
 
 			#address-cells = <1>;
@@ -36,7 +35,6 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 			};
 		};
 
@@ -46,7 +44,6 @@
 			interrupts = <27 0>;
 			rcu-periph-clock = <0x060e>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40004400 {
@@ -55,7 +52,6 @@
 			interrupts = <28 0>;
 			rcu-periph-clock = <0x0711>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		adc0: adc@40012400 {
@@ -66,7 +62,6 @@
 			rcu-clock-source = <GD32_RCU_ADCCK_APB2_DIV4>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_0";
 			#io-channel-cells = <1>;
 		};
 
@@ -76,7 +71,6 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
-			label = "PINCTRL";
 
 			gpioa: gpio@48000000 {
 				compatible = "gd,gd32-gpio";
@@ -85,7 +79,6 @@
 				reg = <0x48000000 0x400>;
 				rcu-periph-clock = <0x511>;
 				status = "disabled";
-				label = "GPIOA";
 			};
 
 			gpiob: gpio@48000400 {
@@ -95,7 +88,6 @@
 				reg = <0x48000400 0x400>;
 				rcu-periph-clock = <0x512>;
 				status = "disabled";
-				label = "GPIOB";
 			};
 
 			gpioc: gpio@48000800 {
@@ -105,7 +97,6 @@
 				reg = <0x48000800 0x400>;
 				rcu-periph-clock = <0x513>;
 				status = "disabled";
-				label = "GPIOC";
 			};
 
 			gpiod: gpio@48000c00 {
@@ -115,7 +106,6 @@
 				reg = <0x48000c00 0x400>;
 				rcu-periph-clock = <0x514>;
 				status = "disabled";
-				label = "GPIOD";
 			};
 
 			gpiof: gpio@48001400 {
@@ -125,7 +115,6 @@
 				reg = <0x48001400 0x400>;
 				rcu-periph-clock = <0x516>;
 				status = "disabled";
-				label = "GPIOF";
 			};
 		};
 	};

--- a/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
+++ b/dts/arm/gigadevice/gd32f403/gd32f403.dtsi
@@ -37,7 +37,6 @@
 
 		fmc: flash-controller@40022000 {
 			compatible = "gd,gd32-flash-controller";
-			label = "FLASH_CTRL";
 			reg = <0x40022000 0x400>;
 			peripheral-id = <6>;
 
@@ -46,7 +45,6 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH_0";
 			};
 		};
 
@@ -56,7 +54,6 @@
 			interrupts = <37 0>;
 			rcu-periph-clock = <0x60e>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40004400 {
@@ -65,7 +62,6 @@
 			interrupts = <38 0>;
 			rcu-periph-clock = <0x712>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40004800 {
@@ -74,7 +70,6 @@
 			interrupts = <39 0>;
 			rcu-periph-clock = <0x713>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		uart3: usart@40004c00 {
@@ -83,7 +78,6 @@
 			interrupts = <52 0>;
 			rcu-periph-clock = <0x714>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		uart4: usart@40005000 {
@@ -92,7 +86,6 @@
 			interrupts = <53 0>;
 			rcu-periph-clock = <0x715>;
 			status = "disabled";
-			label = "USART_4";
 		};
 
 		spi0: spi@40013000 {
@@ -101,7 +94,6 @@
 			interrupts = <35 0>;
 			rcu-periph-clock = <0x60c>;
 			status = "disabled";
-			label = "SPI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -112,7 +104,6 @@
 			interrupts = <36 0>;
 			rcu-periph-clock = <0x70e>;
 			status = "disabled";
-			label = "SPI_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -123,7 +114,6 @@
 			interrupts = <51 0>;
 			rcu-periph-clock = <0x70f>;
 			status = "disabled";
-			label = "SPI_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -135,7 +125,6 @@
 			rcu-periph-clock = <0x609>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_0";
 			#io-channel-cells = <1>;
 		};
 
@@ -146,7 +135,6 @@
 			rcu-periph-clock = <0x60A>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_1";
 			#io-channel-cells = <1>;
 		};
 
@@ -157,7 +145,6 @@
 			rcu-periph-clock = <0x60F>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_2";
 			#io-channel-cells = <1>;
 		};
 
@@ -173,7 +160,6 @@
 					  "line3", "line4", "line5-9",
 					  "line10-15";
 			status = "okay";
-			label = "EXTI";
 		};
 
 		afio: afio@40010000 {
@@ -181,7 +167,6 @@
 			reg = <0x40010000 0x400>;
 			rcu-periph-clock = <0x600>;
 			status = "okay";
-			label = "AFIO";
 		};
 
 		pinctrl: pin-controller@40010800 {
@@ -190,7 +175,6 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
-			label = "PINCTRL";
 
 			gpioa: gpio@40010800 {
 				compatible = "gd,gd32-gpio";
@@ -199,7 +183,6 @@
 				reg = <0x40010800 0x400>;
 				rcu-periph-clock = <0x602>;
 				status = "disabled";
-				label = "GPIOA";
 			};
 
 			gpiob: gpio@40010c00 {
@@ -209,7 +192,6 @@
 				reg = <0x40010c00 0x400>;
 				rcu-periph-clock = <0x603>;
 				status = "disabled";
-				label = "GPIOB";
 			};
 
 			gpioc: gpio@40011000 {
@@ -219,7 +201,6 @@
 				reg = <0x40011000 0x400>;
 				rcu-periph-clock = <0x604>;
 				status = "disabled";
-				label = "GPIOC";
 			};
 
 			gpiod: gpio@40011400 {
@@ -229,7 +210,6 @@
 				reg = <0x40011400 0x400>;
 				rcu-periph-clock = <0x605>;
 				status = "disabled";
-				label = "GPIOD";
 			};
 
 			gpioe: gpio@40011800 {
@@ -239,7 +219,6 @@
 				reg = <0x40011800 0x400>;
 				rcu-periph-clock = <0x606>;
 				status = "disabled";
-				label = "GPIOE";
 			};
 
 			gpiof: gpio@40011c00 {
@@ -249,7 +228,6 @@
 				reg = <0x40011c00 0x400>;
 				rcu-periph-clock = <0x607>;
 				status = "disabled";
-				label = "GPIOF";
 			};
 
 			gpiog: gpio@40012000 {
@@ -259,7 +237,6 @@
 				reg = <0x40012000 0x400>;
 				rcu-periph-clock = <0x608>;
 				status = "disabled";
-				label = "GPIOG";
 			};
 		};
 
@@ -273,12 +250,10 @@
 			is-advanced;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_0";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_0";
 				#pwm-cells = <3>;
 			};
 		};
@@ -292,12 +267,10 @@
 			rcu-periph-reset = <0x401>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_2";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_2";
 				#pwm-cells = <3>;
 			};
 		};
@@ -311,12 +284,10 @@
 			rcu-periph-reset = <0x402>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_3";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_3";
 				#pwm-cells = <3>;
 			};
 		};
@@ -330,7 +301,6 @@
 			rcu-periph-reset = <0x404>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_5";
 		};
 
 		timer6: timer@40001400 {
@@ -342,7 +312,6 @@
 			rcu-periph-reset = <0x405>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_6";
 		};
 
 		timer7: timer@40013400 {
@@ -355,12 +324,10 @@
 			is-advanced;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_7";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_7";
 				#pwm-cells = <3>;
 			};
 		};
@@ -374,12 +341,10 @@
 			rcu-periph-reset = <0x313>;
 			channels = <2>;
 			status = "disabled";
-			label = "TIMER_8";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_8";
 				#pwm-cells = <3>;
 			};
 		};
@@ -393,12 +358,10 @@
 			rcu-periph-reset = <0x314>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_9";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_9";
 				#pwm-cells = <3>;
 			};
 		};
@@ -412,12 +375,10 @@
 			rcu-periph-reset = <0x315>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_10";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_10";
 				#pwm-cells = <3>;
 			};
 		};
@@ -431,12 +392,10 @@
 			rcu-periph-reset = <0x406>;
 			channels = <2>;
 			status = "disabled";
-			label = "TIMER_11";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_11";
 				#pwm-cells = <3>;
 			};
 		};
@@ -450,12 +409,10 @@
 			rcu-periph-reset = <0x402>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_12";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_12";
 				#pwm-cells = <3>;
 			};
 		};
@@ -469,12 +426,10 @@
 			rcu-periph-reset = <0x408>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_13";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_13";
 				#pwm-cells = <3>;
 			};
 		};

--- a/dts/arm/gigadevice/gd32f4xx/gd32f450.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f450.dtsi
@@ -14,7 +14,6 @@
 			interrupts = <84 0>;
 			rcu-periph-clock = <0x110d>;
 			status = "disabled";
-			label = "SPI_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -25,7 +24,6 @@
 			interrupts = <85 0>;
 			rcu-periph-clock = <0x1114>;
 			status = "disabled";
-			label = "SPI_4";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -36,7 +34,6 @@
 			interrupts = <86 0>;
 			rcu-periph-clock = <0x1115>;
 			status = "disabled";
-			label = "SPI_5";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};

--- a/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
+++ b/dts/arm/gigadevice/gd32f4xx/gd32f4xx.dtsi
@@ -38,7 +38,6 @@
 
 		fmc: flash-controller@40023c00 {
 			compatible = "gd,gd32-flash-controller";
-			label = "FMC";
 			reg = <0x40023c00 0x400>;
 
 			#address-cells = <1>;
@@ -46,7 +45,6 @@
 
 			flash0: flash@8000000 {
 				compatible = "soc-nv-flash";
-				label = "FLASH0";
 			};
 		};
 
@@ -56,7 +54,6 @@
 			interrupts = <37 0>;
 			rcu-periph-clock = <0x1104>;
 			status = "disabled";
-			label = "USART_0";
 		};
 
 		usart1: usart@40004400 {
@@ -65,7 +62,6 @@
 			interrupts = <38 0>;
 			rcu-periph-clock = <0x1011>;
 			status = "disabled";
-			label = "USART_1";
 		};
 
 		usart2: usart@40004800 {
@@ -74,7 +70,6 @@
 			interrupts = <39 0>;
 			rcu-periph-clock = <0x1012>;
 			status = "disabled";
-			label = "USART_2";
 		};
 
 		uart3: usart@40004c00 {
@@ -83,7 +78,6 @@
 			interrupts = <52 0>;
 			rcu-periph-clock = <0x1013>;
 			status = "disabled";
-			label = "USART_3";
 		};
 
 		uart4: usart@40005000 {
@@ -92,7 +86,6 @@
 			interrupts = <52 0>;
 			rcu-periph-clock = <0x1014>;
 			status = "disabled";
-			label = "USART_4";
 		};
 
 		usart5: usart@40011400 {
@@ -101,7 +94,6 @@
 			interrupts = <71 0>;
 			rcu-periph-clock = <0x1105>;
 			status = "disabled";
-			label = "USART_5";
 		};
 
 		uart6: usart@40007800 {
@@ -110,7 +102,6 @@
 			interrupts = <82 0>;
 			rcu-periph-clock = <0x101e>;
 			status = "disabled";
-			label = "USART_6";
 		};
 
 		uart7: usart@40007c00 {
@@ -119,7 +110,6 @@
 			interrupts = <83 0>;
 			rcu-periph-clock = <0x101f>;
 			status = "disabled";
-			label = "USART_7";
 		};
 
 		dac: dac@40007400 {
@@ -127,7 +117,6 @@
 			reg = <0x40007400 0x400>;
 			rcu-periph-clock = <0x101d>;
 			num-channels = <2>;
-			label = "DAC";
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -142,7 +131,6 @@
 			interrupt-names = "event", "error";
 			rcu-periph-clock = <0x1015>;
 			status = "disabled";
-			label = "I2C_0";
 		};
 
 		i2c1: i2c@40005800 {
@@ -155,7 +143,6 @@
 			interrupt-names = "event", "error";
 			rcu-periph-clock = <0x1016>;
 			status = "disabled";
-			label = "I2C_1";
 		};
 
 		i2c2: i2c@40005c00 {
@@ -168,7 +155,6 @@
 			interrupt-names = "event", "error";
 			rcu-periph-clock = <0x1017>;
 			status = "disabled";
-			label = "I2C_2";
 		};
 
 		spi0: spi@40013000 {
@@ -177,7 +163,6 @@
 			interrupts = <35 0>;
 			rcu-periph-clock = <0x110c>;
 			status = "disabled";
-			label = "SPI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -188,7 +173,6 @@
 			interrupts = <36 0>;
 			rcu-periph-clock = <0x100e>;
 			status = "disabled";
-			label = "SPI_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -199,7 +183,6 @@
 			interrupts = <51 0>;
 			rcu-periph-clock = <0x100f>;
 			status = "disabled";
-			label = "SPI_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -211,7 +194,6 @@
 			rcu-periph-clock = <0x1108>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_0";
 			#io-channel-cells = <1>;
 		};
 
@@ -222,7 +204,6 @@
 			rcu-periph-clock = <0x1109>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_1";
 			#io-channel-cells = <1>;
 		};
 
@@ -233,7 +214,6 @@
 			rcu-periph-clock = <0x110A>;
 			channels = <16>;
 			status = "disabled";
-			label = "ADC_2";
 			#io-channel-cells = <1>;
 		};
 
@@ -241,7 +221,6 @@
 			compatible = "gd,gd32-syscfg";
 			reg = <0x40013800 0x400>;
 			rcu-periph-clock = <0x110e>;
-			label = "SYSCFG";
 		};
 
 		exti: interrupt-controller@40013c00 {
@@ -255,7 +234,6 @@
 			interrupt-names = "line0", "line1", "line2", "line3",
 					  "line4", "line5-9", "line10-15";
 			status = "okay";
-			label = "EXTI";
 		};
 
 		pinctrl: pin-controller@40020000 {
@@ -264,7 +242,6 @@
 			#address-cells = <1>;
 			#size-cells = <1>;
 			status = "okay";
-			label = "PINCTRL";
 
 			gpioa: gpio@40020000 {
 				compatible = "gd,gd32-gpio";
@@ -273,7 +250,6 @@
 				reg = <0x40020000 0x400>;
 				rcu-periph-clock = <0xc00>;
 				status = "disabled";
-				label = "GPIOA";
 			};
 
 			gpiob: gpio@40020400 {
@@ -283,7 +259,6 @@
 				reg = <0x40020400 0x400>;
 				rcu-periph-clock = <0xc01>;
 				status = "disabled";
-				label = "GPIOB";
 			};
 
 			gpioc: gpio@40020800 {
@@ -293,7 +268,6 @@
 				reg = <0x40020800 0x400>;
 				rcu-periph-clock = <0xc02>;
 				status = "disabled";
-				label = "GPIOC";
 			};
 
 			gpiod: gpio@40020c00 {
@@ -303,7 +277,6 @@
 				reg = <0x40020c00 0x400>;
 				rcu-periph-clock = <0xc03>;
 				status = "disabled";
-				label = "GPIOD";
 			};
 
 			gpioe: gpio@40021000 {
@@ -313,7 +286,6 @@
 				reg = <0x40021000 0x400>;
 				rcu-periph-clock = <0xc04>;
 				status = "disabled";
-				label = "GPIOE";
 			};
 
 			gpiof: gpio@40021400 {
@@ -323,7 +295,6 @@
 				reg = <0x40021400 0x400>;
 				rcu-periph-clock = <0xc05>;
 				status = "disabled";
-				label = "GPIOF";
 			};
 
 			gpiog: gpio@40021800 {
@@ -333,7 +304,6 @@
 				reg = <0x40021800 0x400>;
 				rcu-periph-clock = <0xc06>;
 				status = "disabled";
-				label = "GPIOG";
 			};
 
 			gpioh: gpio@40021c00 {
@@ -343,7 +313,6 @@
 				reg = <0x40021c00 0x400>;
 				rcu-periph-clock = <0xc07>;
 				status = "disabled";
-				label = "GPIOH";
 			};
 
 			gpioi: gpio@40022000 {
@@ -353,7 +322,6 @@
 				reg = <0x40022000 0x400>;
 				rcu-periph-clock = <0xc08>;
 				status = "disabled";
-				label = "GPIOI";
 			};
 		};
 
@@ -367,12 +335,10 @@
 			is-advanced;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_0";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_0";
 				#pwm-cells = <3>;
 			};
 		};
@@ -387,12 +353,10 @@
 			is-32bit;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_1";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_1";
 				#pwm-cells = <3>;
 			};
 		};
@@ -406,12 +370,10 @@
 			rcu-periph-reset = <0x801>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_2";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_2";
 				#pwm-cells = <3>;
 			};
 		};
@@ -425,12 +387,10 @@
 			rcu-periph-reset = <0x802>;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_3";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_3";
 				#pwm-cells = <3>;
 			};
 		};
@@ -445,12 +405,10 @@
 			is-32bit;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_4";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_4";
 				#pwm-cells = <3>;
 			};
 		};
@@ -464,7 +422,6 @@
 			rcu-periph-reset = <0x804>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_5";
 		};
 
 		timer6: timer@40001400 {
@@ -476,7 +433,6 @@
 			rcu-periph-reset = <0x805>;
 			channels = <0>;
 			status = "disabled";
-			label = "TIMER_6";
 		};
 
 		timer7: timer@40010400 {
@@ -489,12 +445,10 @@
 			is-advanced;
 			channels = <4>;
 			status = "disabled";
-			label = "TIMER_7";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_7";
 				#pwm-cells = <3>;
 			};
 		};
@@ -508,12 +462,10 @@
 			rcu-periph-reset = <0x910>;
 			channels = <2>;
 			status = "disabled";
-			label = "TIMER_8";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_8";
 				#pwm-cells = <3>;
 			};
 		};
@@ -527,12 +479,10 @@
 			rcu-periph-reset = <0x911>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_9";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_9";
 				#pwm-cells = <3>;
 			};
 		};
@@ -546,12 +496,10 @@
 			rcu-periph-reset = <0x912>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_10";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_10";
 				#pwm-cells = <3>;
 			};
 		};
@@ -565,12 +513,10 @@
 			rcu-periph-reset = <0x806>;
 			channels = <2>;
 			status = "disabled";
-			label = "TIMER_11";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_11";
 				#pwm-cells = <3>;
 			};
 		};
@@ -584,12 +530,10 @@
 			rcu-periph-reset = <0x802>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_12";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_12";
 				#pwm-cells = <3>;
 			};
 		};
@@ -603,12 +547,10 @@
 			rcu-periph-reset = <0x808>;
 			channels = <1>;
 			status = "disabled";
-			label = "TIMER_13";
 
 			pwm {
 				compatible = "gd,gd32-pwm";
 				status = "disabled";
-				label = "PWM_13";
 				#pwm-cells = <3>;
 			};
 		};

--- a/dts/arm/intel_socfpga_std/socfpga.dtsi
+++ b/dts/arm/intel_socfpga_std/socfpga.dtsi
@@ -44,7 +44,6 @@
 		interrupt-controller;
 		reg = <0xfffed000 0x1000>,
 			  <0xfffec100 0x100>;
-		label = "intc";
 	};
 
 	soc {
@@ -59,7 +58,6 @@
 			compatible = "arm,pl330-cache";
 			reg = <0xfffef000 0x1000>;
 			interrupts = <0 38 0x04 IRQ_DEFAULT_PRIORITY>;
-			label = "L2";
 			status= "okay";
 		};
 
@@ -92,7 +90,6 @@
 		sysmgr: sysmgr@ffd08000 {
 			compatible = "altr,sys-mgr", "syscon";
 			reg = <0xffd08000 0x4000>;
-			label = "sysmgr";
 			status = "okay";
 		};
 		ocram: sram@ffff0000 {
@@ -124,7 +121,6 @@
 			reg-shift = <2>;
 			clock-frequency = <100000000>;
 			dma-names = "tx", "rx";
-			label = "UART_0";
 		};
 
 		uart1: serial1@ffc03000 {
@@ -134,7 +130,6 @@
 			reg-shift = <2>;
 			clock-frequency = <100000000>;
 			dma-names = "tx", "rx";
-			label = "UART_1";
 		};
 
 		gmac0: ethernet@ff700000 {
@@ -144,7 +139,6 @@
 			interrupts = <0 115 4 IRQ_DEFAULT_PRIORITY>;
 			local-mac-address = [00 00 00 00 00 00];
 			status = "disabled";
-			label = "ETH_0";
 		};
 
 		gmac1: ethernet@ff702000 {
@@ -154,7 +148,6 @@
 			interrupts = <0 120 4 IRQ_DEFAULT_PRIORITY>;
 			local-mac-address = [00 00 00 00 00 00];
 			status = "okay";
-			label = "ETH_1";
 		};
 
 		gpio0: gpio@ff708000 {
@@ -164,7 +157,6 @@
 			reg = <0xff708000 0x1000>;
 			interrupts = <0 164 4 IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
-			label = "GPIO_0";
 			ngpios = <29>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -177,7 +169,6 @@
 			reg = <0xff709000 0x1000>;
 			interrupts = <0 165 4 IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
-			label = "GPIO_1";
 			ngpios = <29>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -190,7 +181,6 @@
 			reg = <0xff70a000 0x1000>;
 			interrupts = <0 166 4 IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
-			label = "GPIO_2";
 			ngpios = <27>;
 			gpio-controller;
 			#gpio-cells = <2>;
@@ -205,7 +195,6 @@
 			interrupts = <0 158 0x4 IRQ_DEFAULT_PRIORITY>;
 			interrupt-parent = <&intc>;
 			status = "okay";
-			label = "I2C_0";
 		};
 
 		i2c1: i2c@ffc05000 {
@@ -215,7 +204,6 @@
 			reg = <0xffc05000 0x1000>;
 			interrupts = <0 159 0x4 IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
-			label = "I2C_1";
 		};
 
 		i2c2: i2c@ffc06000 {
@@ -225,7 +213,6 @@
 			reg = <0xffc06000 0x1000>;
 			interrupts = <0 160 0x4 IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
-			label = "I2C_2";
 		};
 
 		i2c3: i2c@ffc07000 {
@@ -235,7 +222,6 @@
 			reg = <0xffc07000 0x1000>;
 			interrupts = <0 161 0x4 IRQ_DEFAULT_PRIORITY>;
 			status = "disabled";
-			label = "I2C_3";
 		};
 
 		usb0: usb@ffb30000 {
@@ -244,7 +230,6 @@
 			interrupts = <0 127 4 IRQ_DEFAULT_PRIORITY>;
 			interrupt-parent = <&intc>;
 			num-bidir-endpoints = <16>;
-			label = "USB_0";
 			status = "disabled";
 			};
 
@@ -254,7 +239,6 @@
 			interrupts = <0 128 4 IRQ_DEFAULT_PRIORITY>;
 			interrupt-parent = <&intc>;
 			num-bidir-endpoints = <16>;
-			label = "USB_1";
 			status = "okay";
 			};
 
@@ -265,7 +249,6 @@
 			reg = <0xfff00000 0x1000>;
 			interrupts = <0 154 4 IRQ_DEFAULT_PRIORITY>;
 			clock-frequency = <200000000>;
-			label = "SPI_0";
 			status = "okay";
 		};
 
@@ -276,7 +259,6 @@
 			reg = <0xfff01000 0x1000>;
 			interrupts = <0 155 4 IRQ_DEFAULT_PRIORITY>;
 			clock-frequency = <200000000>;
-			label = "SPI_1";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -70,11 +70,9 @@
 		pcr: pcr@40080100 {
 			reg = <0x40080100 0x100 0x4000a400 0x100>;
 			reg-names = "pcrr", "vbatr";
-			label = "PCR";
 		};
 		ecia: ecia@4000e000 {
 			reg = <0x4000e000 0x400>;
-			label = "ECIA_0";
 			#address-cells = <1>;
 			#size-cells = <1>;
 		};
@@ -82,14 +80,12 @@
 			compatible = "microchip,xec-rtos-timer";
 			reg = <0x40007400 0x10>;
 			interrupts = <111 0>;
-			label = "RTIMER";
 			girqs = <23 10>;
 		};
 		bbram: bb-ram@4000a800 {
 			compatible = "microchip,xec-bbram";
 			reg = <0x4000a800 0x80>;
 			reg-names = "memory";
-			label = "BBRAM";
 		};
 		wdog: watchdog@40000400 {
 			compatible = "microchip,xec-watchdog";
@@ -97,7 +93,6 @@
 			interrupts = <171 0>;
 			girqs = <21 2>;
 			pcrs = <1 9>;
-			label = "WDT_0";
 		};
 		uart0: uart@400f2400 {
 			compatible = "ns16550";
@@ -105,7 +100,6 @@
 			interrupts = <40 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			label = "UART_0";
 			reg-shift = <0>;
 			status = "disabled";
 		};
@@ -115,7 +109,6 @@
 			interrupts = <41 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			label = "UART_1";
 			reg-shift = <0>;
 			status = "disabled";
 		};
@@ -125,7 +118,6 @@
 			interrupts = <44 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			label = "UART_2";
 			reg-shift = <0>;
 			status = "disabled";
 		};
@@ -134,7 +126,6 @@
 			reg = <0x40081000 0x80>;
 			interrupts = <3 2>;
 			gpio-controller;
-			label="GPIO000_036";
 			#gpio-cells=<2>;
 		};
 		gpio_040_076: gpio@40081080 {
@@ -142,7 +133,6 @@
 			reg = <0x40081080 0x80>;
 			interrupts = <2 2>;
 			gpio-controller;
-			label="GPIO040_076";
 			#gpio-cells=<2>;
 		};
 		gpio_100_136: gpio@40081100 {
@@ -150,7 +140,6 @@
 			reg = <0x40081100 0x80>;
 			gpio-controller;
 			interrupts = <1 2>;
-			label="GPIO100_136";
 			#gpio-cells=<2>;
 		};
 		gpio_140_176: gpio@40081180 {
@@ -158,7 +147,6 @@
 			reg = <0x40081180 0x80>;
 			gpio-controller;
 			interrupts = <0 2>;
-			label="GPIO140_176";
 			#gpio-cells=<2>;
 		};
 		gpio_200_236: gpio@40081200 {
@@ -166,7 +154,6 @@
 			reg = <0x40081200 0x80>;
 			gpio-controller;
 			interrupts = <4 2>;
-			label="GPIO200_236";
 			#gpio-cells=<2>;
 		};
 		gpio_240_276: gpio@40081280 {
@@ -174,7 +161,6 @@
 			reg = <0x40081280 0x80>;
 			gpio-controller;
 			interrupts = <17 2>;
-			label="GPIO240_276";
 			#gpio-cells=<2>;
 		};
 
@@ -183,7 +169,6 @@
 			reg = <0x40004000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <20 1>;
-			label = "I2C_SMB_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -196,7 +181,6 @@
 			reg = <0x40004400 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <21 1>;
-			label = "I2C_SMB_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -209,7 +193,6 @@
 			reg = <0x40004800 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <22 1>;
-			label = "I2C_SMB_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -222,7 +205,6 @@
 			reg = <0x40004C00 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <23 1>;
-			label = "I2C_SMB_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -235,7 +217,6 @@
 			reg = <0x40005000 0x80>;
 			clock-frequency = <I2C_BITRATE_STANDARD>;
 			interrupts = <158 1>;
-			label = "I2C_SMB_4";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -247,7 +228,6 @@
 			compatible = "microchip,xec-espi";
 			reg = <0x400f3400 0x400>;
 			interrupts = <11 3>, <15 3>, <7 3>, <16 3>;
-			label = "ESPI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -257,7 +237,6 @@
 			reg = < 0x40008000 0x400
 				0x40070000 0x400
 				0x40071000 0x400>;
-			label = "ESPI_SAF_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -268,7 +247,6 @@
 			clock-frequency = <48000000>;
 			reg = <0x40000c00 0x20>;
 			interrupts = <136 0>;
-			label = "TIMER_0";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -280,7 +258,6 @@
 			clock-frequency = <48000000>;
 			reg = <0x40000c20 0x20>;
 			interrupts = <137 0>;
-			label = "TIMER_1";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -298,7 +275,6 @@
 			clock-frequency = <48000000>;
 			reg = <0x40000c80 0x20>;
 			interrupts = <140 0>;
-			label = "TIMER_4";
 			max-value = <0xFFFFFFFF>;
 			prescaler = <0>;
 			girqs = <23 4>;
@@ -310,7 +286,6 @@
 			clock-frequency = <48000000>;
 			reg = <0x40000ca0 0x20>;
 			interrupts = <141 0>;
-			label = "TIMER_5";
 			max-value = <0xFFFFFFFF>;
 			prescaler = <0>;
 			girqs = <23 5>;
@@ -322,7 +297,6 @@
 			interrupts = <100 1>;
 			girqs = <18 10>;
 			pcrs = <3 5>;
-			label = "PS2_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -333,7 +307,6 @@
 			interrupts = <101 1>;
 			girqs = <18 11>;
 			pcrs = <3 6>;
-			label = "PS2_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -342,7 +315,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005800 0x20>;
 			pcrs = <1 4>;
-			label = "PWM_0";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -350,7 +322,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005810 0x20>;
 			pcrs = <1 20>;
-			label = "PWM_1";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -358,7 +329,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005820 0x20>;
 			pcrs = <1 21>;
-			label = "PWM_2";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -366,7 +336,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005830 0x20>;
 			pcrs = <1 22>;
-			label = "PWM_3";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -374,7 +343,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005840 0x20>;
 			pcrs = <1 23>;
-			label = "PWM_4";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -382,7 +350,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005850 0x20>;
 			pcrs = <1 24>;
-			label = "PWM_5";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -390,7 +357,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005860 0x20>;
 			pcrs = <1 25>;
-			label = "PWM_6";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -398,7 +364,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005870 0x20>;
 			pcrs = <1 26>;
-			label = "PWM_7";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -406,7 +371,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005880 0x20>;
 			pcrs = <1 27>;
-			label = "PWM_8";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -414,7 +378,6 @@
 			compatible = "microchip,xec-adc";
 			reg = <0x40007c00 0x90>;
 			interrupts = <78 0>, <79 0>;
-			label = "ADC_0";
 			status = "disabled";
 			#io-channel-cells = <1>;
 			clktime = <32>;
@@ -425,7 +388,6 @@
 			interrupts = <135 0>;
 			girqs = <21 25>;
 			pcrs = <3 11>;
-			label = "KSCAN";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -436,7 +398,6 @@
 			interrupts = <70 4>;
 			girqs = <17 0>;
 			pcrs = <1 1>;
-			label = "PECI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -445,7 +406,6 @@
 			reg = <0x40070000 0x400>;
 			interrupts = <91 2>;
 			clock-frequency = <12000000>;
-			label = "SPI_0";
 			rxdma = <11>;
 			txdma = <10>;
 			lines = <1>;
@@ -464,7 +424,6 @@
 			interrupts = <71 4>;
 			girqs = <17 1>;
 			pcrs = <1 2>;
-			label = "TACH_0";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -475,7 +434,6 @@
 			interrupts = <72 4>;
 			girqs = <17 2>;
 			pcrs = <1 11>;
-			label = "TACH_1";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -486,7 +444,6 @@
 			interrupts = <73 4>;
 			girqs = <17 3>;
 			pcrs = <1 12>;
-			label = "TACH_2";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -497,7 +454,6 @@
 			interrupts = <159 4>;
 			girqs = <17 4>;
 			pcrs = <1 13>;
-			label = "TACH_3";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;

--- a/dts/arm/microchip/mec1701qsz.dtsi
+++ b/dts/arm/microchip/mec1701qsz.dtsi
@@ -34,7 +34,6 @@
 			interrupts = <40 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			label = "UART_0";
 			reg-shift = <0>;
 			status = "disabled";
 		};
@@ -44,7 +43,6 @@
 			interrupts = <41 0>;
 			clock-frequency = <1843200>;
 			current-speed = <38400>;
-			label = "UART_1";
 			reg-shift = <0>;
 			status = "disabled";
 		};

--- a/dts/arm/microchip/mec1727nsz.dtsi
+++ b/dts/arm/microchip/mec1727nsz.dtsi
@@ -38,7 +38,6 @@
 		compatible ="jedec,spi-nor";
 		/* 4 Mbit Flash */
 		size = <DT_SIZE_M(4)>;
-		label = "SST25PF040";
 		reg = <0>;
 		spi-max-frequency = <DT_FREQ_M(40)>;
 		status = "okay";

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -39,14 +39,12 @@
 	soc {
 		ecs: ecs@4000fc00 {
 			reg = <0x4000fc00 0x200>;
-			label = "ECS";
 		};
 		pcr: pcr@40080100 {
 			compatible = "microchip,xec-pcr";
 			reg = <0x40080100 0x100 0x4000a400 0x100>;
 			reg-names = "pcrr", "vbatr";
 			interrupts = <174 0>;
-			label = "PCR";
 			core-clock-div = <1>;
 			pll-32k-src = <MCHP_XEC_CLK32K_SRC_SIL_OSC>;
 			periph-32k-src = <MCHP_XEC_CLK32K_SRC_SIL_OSC>;
@@ -57,7 +55,6 @@
 			reg = <0x4000e000 0x400>;
 			direct-capable-girqs = <13 14 15 16 17 18 19 20 21 23>;
 			clocks = <&pcr 1 0>;
-			label = "ECIA_0";
 			#address-cells = <1>;
 			#size-cells = <1>;
 
@@ -67,7 +64,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x0 0x14>;
 				interrupts = <0 0>;
-				label = "GIRQ_8";
 				girq-id = <0>;
 				sources = <0 1 2 3 4 5 6 7
 					   8 9 10 11 12 13 14 15
@@ -79,7 +75,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x14 0x14>;
 				interrupts = <1 0>;
-				label = "GIRQ_9";
 				girq-id = <1>;
 				sources = <0 1 2 3 4 5 6 7
 					   8 9 10 11 12 13 14 15
@@ -91,7 +86,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x28 0x14>;
 				interrupts = <2 0>;
-				label = "GIRQ_10";
 				girq-id = <2>;
 				sources = <0 1 2 3 4 5 6 7
 					   8 9 10 11 12 13 14 15
@@ -103,7 +97,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x3c 0x14>;
 				interrupts = <3 0>;
-				label = "GIRQ_11";
 				girq-id = <3>;
 				sources = <0 1 2 3 4 5 6 7
 					   8 9 10 11 12 13 14 15
@@ -115,7 +108,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x50 0x14>;
 				interrupts = <4 0>;
-				label = "GIRQ_12";
 				girq-id = <4>;
 				sources = <0 1 2 3 4 5 6 7
 					   8 9 10 11 12 13 14 15
@@ -127,7 +119,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x64 0x14>;
 				interrupts = <5 0>;
-				label = "GIRQ_13";
 				girq-id = <5>;
 				sources = <0 1 2 3 4>;
 				status = "disabled";
@@ -136,7 +127,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x78 0x14>;
 				interrupts = <6 0>;
-				label = "GIRQ_14";
 				girq-id = <6>;
 				sources = <0 1 2 3 4 5 6 7
 					   8 9 10 11 12 13 14 15>;
@@ -146,7 +136,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x8c 0x14>;
 				interrupts = <7 0>;
-				label = "GIRQ_15";
 				girq-id = <7>;
 				sources = <0 1 2 3 4 5 6 7
 					   8 9 10 11 12 13 14 15
@@ -157,7 +146,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0xa0 0x14>;
 				interrupts = <8 0>;
-				label = "GIRQ_16";
 				girq-id = <8>;
 				sources = <0 2 3>;
 				status = "disabled";
@@ -166,7 +154,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0xb4 0x14>;
 				interrupts = <9 0>;
-				label = "GIRQ_17";
 				girq-id = <9>;
 				sources = <0 1 2 3 4 8 9 10 11 12 13 14 15
 					   16 17 20 21 22 23>;
@@ -176,7 +163,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0xc8 0x14>;
 				interrupts = <10 0>;
-				label = "GIRQ_18";
 				girq-id = <10>;
 				sources = <0 1 2 3 4 5 6 7
 					   10 20 21 22 23
@@ -187,7 +173,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0xdc 0x14>;
 				interrupts = <11 0>;
-				label = "GIRQ_19";
 				girq-id = <11>;
 				sources = <0 1 2 3 4 5 6 7 8 9 10>;
 				status = "disabled";
@@ -196,7 +181,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0xf0 0x14>;
 				interrupts = <12 0>;
-				label = "GIRQ_20";
 				girq-id = <12>;
 				sources = <3 9>;
 				status = "disabled";
@@ -205,7 +189,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x104 0x14>;
 				interrupts = <13 0>;
-				label = "GIRQ_21";
 				girq-id = <13>;
 				sources = <2 3 4 5 6 7 8 9 10 11 12 13 14 15
 					   18 19 25 26>;
@@ -215,7 +198,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x118 0x14>;
 				interrupts = <255 0>;
-				label = "GIRQ_22";
 				girq-id = <14>;
 				sources = <0 1 2 3 4 5 9 15>;
 				status = "disabled";
@@ -224,7 +206,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x12c 0x14>;
 				interrupts = <14 0>;
-				label = "GIRQ_23";
 				girq-id = <15>;
 				sources = <0 1 2 3 4 5 6 7 8 9 10 16 17>;
 				status = "disabled";
@@ -233,7 +214,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x140 0x14>;
 				interrupts = <15 0>;
-				label = "GIRQ_24";
 				girq-id = <16>;
 				sources = <0 1 2 3 4 5 6 7 8 9 10 11
 					   12 13 14 15 16 17 18 19
@@ -244,7 +224,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x154 0x14>;
 				interrupts = <16 0>;
-				label = "GIRQ_25";
 				girq-id = <17>;
 				sources = <0 1 2 3 4 5 6 7 8 9 10 11
 					   12 13 14 15>;
@@ -254,7 +233,6 @@
 				compatible = "microchip,xec-ecia-girq";
 				reg = <0x168 0x14>;
 				interrupts = <17 0>;
-				label = "GIRQ_26";
 				girq-id = <18>;
 				sources = <0 1 2 3 4 5 6 12 13>;
 				status = "disabled";
@@ -272,7 +250,6 @@
 					0x40081380 0x04 0x400813fc 0x04>;
 				interrupts = <3 2>;
 				gpio-controller;
-				label="GPIO000_036";
 				port-id = <0>;
 				girq-id = <11>;
 				#gpio-cells=<2>;
@@ -283,7 +260,6 @@
 					0x40081384 0x04 0x400813f8 0x4>;
 				interrupts = <2 2>;
 				gpio-controller;
-				label="GPIO040_076";
 				port-id = <1>;
 				girq-id = <10>;
 				#gpio-cells=<2>;
@@ -294,7 +270,6 @@
 					0x40081388 0x04 0x400813f4 0x04>;
 				gpio-controller;
 				interrupts = <1 2>;
-				label="GPIO100_136";
 				port-id = <2>;
 				girq-id = <9>;
 				#gpio-cells=<2>;
@@ -305,7 +280,6 @@
 					0x4008138c 0x04 0x400813f0 0x04>;
 				gpio-controller;
 				interrupts = <0 2>;
-				label="GPIO140_176";
 				port-id = <3>;
 				girq-id = <8>;
 				#gpio-cells=<2>;
@@ -316,7 +290,6 @@
 					0x40081390 0x04 0x400813ec 0x04>;
 				gpio-controller;
 				interrupts = <4 2>;
-				label="GPIO200_236";
 				port-id = <4>;
 				girq-id = <12>;
 				#gpio-cells=<2>;
@@ -327,7 +300,6 @@
 					0x40081394 0x04 0x400813e8 0x04>;
 				gpio-controller;
 				interrupts = <17 2>;
-				label="GPIO240_276";
 				port-id = <5>;
 				girq-id = <26>;
 				#gpio-cells=<2>;
@@ -339,13 +311,11 @@
 			interrupts = <171 0>;
 			girqs = <21 2>;
 			pcrs = <1 9>;
-			label = "WDT_0";
 		};
 		rtimer: timer@40007400 {
 			compatible = "microchip,xec-rtos-timer";
 			reg = <0x40007400 0x10>;
 			interrupts = <111 0>;
-			label = "RTIMER";
 			girqs = <23 10>;
 		};
 		timer0: timer@40000c00 {
@@ -355,7 +325,6 @@
 			interrupts = <136 0>;
 			girqs = <23 0>;
 			pcrs = <1 30>;
-			label = "TIMER_0";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -367,7 +336,6 @@
 			interrupts = <137 0>;
 			girqs = <23 1>;
 			pcrs = <1 31>;
-			label = "TIMER_1";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -379,7 +347,6 @@
 			interrupts = <138 0>;
 			girqs = <23 2>;
 			pcrs = <3 21>;
-			label = "TIMER_2";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -391,7 +358,6 @@
 			interrupts = <139 0>;
 			girqs = <23 3>;
 			pcrs = <3 22>;
-			label = "TIMER_3";
 			max-value = <0xFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -408,7 +374,6 @@
 			interrupts = <140 0>;
 			girqs = <23 4>;
 			pcrs = <3 23>;
-			label = "TIMER_4";
 			max-value = <0xFFFFFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -420,7 +385,6 @@
 			interrupts = <141 0>;
 			girqs = <23 5>;
 			pcrs = <3 24>;
-			label = "TIMER_5";
 			max-value = <0xFFFFFFFF>;
 			prescaler = <0>;
 			status = "disabled";
@@ -430,7 +394,6 @@
 			interrupts = <142 0>;
 			girqs = <23 6>;
 			pcrs = <4 2>;
-			label = "EVTMR_0";
 			status = "disabled";
 		};
 		cntr1: timer@40000d20 {
@@ -438,7 +401,6 @@
 			interrupts = <143 0>;
 			girqs = <23 7>;
 			pcrs = <4 3>;
-			label = "EVTMR_1";
 			status = "disabled";
 		};
 		cntr2: timer@40000d40 {
@@ -446,7 +408,6 @@
 			interrupts = <144 0>;
 			girqs = <23 8>;
 			pcrs = <4 3>;
-			label = "EVTMR_2";
 			status = "disabled";
 		};
 		cntr3: timer@40000d60 {
@@ -454,7 +415,6 @@
 			interrupts = <145 0>;
 			girqs = <23 9>;
 			pcrs = <4 4>;
-			label = "EVTMR_3";
 			status = "disabled";
 		};
 		cctmr0: timer@40001000 {
@@ -465,41 +425,35 @@
 			girqs = <18 20>, <18 21>, <18 22>, <18 23>, <18 24>,
 				<18 25>, <18 26>, <18 27>, <18 28>;
 			pcrs = <3 30>;
-			label = "CCTMR_0";
 			status = "disabled";
 		};
 		hibtimer0: timer@40009800 {
 			reg = <0x40009800 0x20>;
 			interrupts = <112 0>;
 			girqs = <23 16>;
-			label = "HIBTIMER_0";
 		};
 		hibtimer1: timer@40009820 {
 			reg = <0x40009820 0x20>;
 			interrupts = <113 0>;
 			girqs = <23 17>;
-			label = "HIBTIMER_1";
 		};
 		weektmr0: timer@4000ac80 {
 			reg = <0x4000ac80 0x80>;
 			interrupts = <114 0>, <115 0>, <116 0>,
 				     <117 0>, <118 0>;
 			girqs = <21 3>, <21 4>, <21 5>, <21 6>, <21 7>;
-			label = "WEEKTMR_0";
 			status = "disabled";
 		};
 		bbram: bb-ram@4000a800 {
 			compatible = "microchip,xec-bbram";
 			reg = <0x4000a800 0x100>;
 			reg-names = "memory";
-			label = "BBRAM";
 		};
 		vci0: vci@4000ae00 {
 			reg = <0x4000ae00 0x40>;
 			interrupts = <121 0>, <122 0>, <123 0>,
 				     <124 0>, <125 0>;
 			girqs = <21 10>, <21 11>, <21 12>, <21 13>, <21 14>;
-			label = "VCI_0";
 			status = "disabled";
 		};
 		dmac: dmac@40002400 {
@@ -513,7 +467,6 @@
 				<14 8>, <14 9>, <14 10>, <14 11>,
 				<14 12>, <14 13>, <14 14>, <14 15>;
 			pcrs = <1 6>;
-			label = "DMA_0";
 			#dma-cells = <2>;
 			status = "disabled";
 		};
@@ -524,7 +477,6 @@
 			interrupts = <20 1>;
 			girqs = <13 0>;
 			pcrs = <1 10>;
-			label = "I2C_SMB_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -536,7 +488,6 @@
 			interrupts = <21 1>;
 			girqs = <13 1>;
 			pcrs = <3 13>;
-			label = "I2C_SMB_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -548,7 +499,6 @@
 			interrupts = <22 1>;
 			girqs = <13 2>;
 			pcrs = <3 14>;
-			label = "I2C_SMB_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -560,7 +510,6 @@
 			interrupts = <23 1>;
 			girqs = <13 3>;
 			pcrs = <3 15>;
-			label = "I2C_SMB_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -572,7 +521,6 @@
 			interrupts = <158 1>;
 			girqs = <13 4>;
 			pcrs = <3 20>;
-			label = "I2C_SMB_4";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -583,7 +531,6 @@
 			interrupts = <100 1>;
 			girqs = <18 10>;
 			pcrs = <3 5>;
-			label = "PS2_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -592,7 +539,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005800 0x20>;
 			pcrs = <1 4>;
-			label = "PWM_0";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -600,7 +546,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005810 0x20>;
 			pcrs = <1 20>;
-			label = "PWM_1";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -608,7 +553,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005820 0x20>;
 			pcrs = <1 21>;
-			label = "PWM_2";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -616,7 +560,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005830 0x20>;
 			pcrs = <1 22>;
-			label = "PWM_3";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -624,7 +567,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005840 0x20>;
 			pcrs = <1 23>;
-			label = "PWM_4";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -632,7 +574,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005850 0x20>;
 			pcrs = <1 24>;
-			label = "PWM_5";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -640,7 +581,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005860 0x20>;
 			pcrs = <1 25>;
-			label = "PWM_6";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -648,7 +588,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005870 0x20>;
 			pcrs = <1 26>;
-			label = "PWM_7";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -656,7 +595,6 @@
 			compatible = "microchip,xec-pwm";
 			reg = <0x40005880 0x20>;
 			pcrs = <1 27>;
-			label = "PWM_8";
 			status = "disabled";
 			#pwm-cells = <2>;
 		};
@@ -666,7 +604,6 @@
 			interrupts = <71 4>;
 			girqs = <17 1>;
 			pcrs = <1 2>;
-			label = "TACH_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -677,7 +614,6 @@
 			interrupts = <72 4>;
 			girqs = <17 2>;
 			pcrs = <1 11>;
-			label = "TACH_1";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -688,7 +624,6 @@
 			interrupts = <73 4>;
 			girqs = <17 3>;
 			pcrs = <1 12>;
-			label = "TACH_2";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -699,7 +634,6 @@
 			interrupts = <159 4>;
 			girqs = <17 4>;
 			pcrs = <1 13>;
-			label = "TACH_3";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -709,7 +643,6 @@
 			interrupts = <74 1>, <75 1>;
 			girqs = <17 20>, <17 21>;
 			pcrs = <3 12>;
-			label = "RPMFAN_0";
 			status = "disabled";
 		};
 		rpmfan1: rpmfan@4000a080 {
@@ -717,7 +650,6 @@
 			interrupts = <76 1>, <77 1>;
 			girqs = <17 22>, <17 23>;
 			pcrs = <4 7>;
-			label = "RPMFAN_1";
 			status = "disabled";
 		};
 		adc0: adc@40007c00 {
@@ -726,7 +658,6 @@
 			interrupts = <78 0>, <79 0>;
 			girqs = <17 8>, <17 9>;
 			pcrs = <3 3>;
-			label = "ADC_0";
 			status = "disabled";
 			#io-channel-cells = <1>;
 		};
@@ -736,7 +667,6 @@
 			interrupts = <135 0>;
 			girqs = <21 25>;
 			pcrs = <3 11>;
-			label = "KSCAN";
 			status = "disabled";
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -747,7 +677,6 @@
 			interrupts = <70 4>;
 			girqs = <17 0>;
 			pcrs = <1 1>;
-			label = "PECI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 		};
@@ -758,7 +687,6 @@
 			girqs = < MCHP_XEC_ECIA(18, 1, 10, 91) >;
 			pcrs = <4 8>;
 			clock-frequency = <12000000>;
-			label = "SPI_0";
 			lines = <1>;
 			chip_select = <0>;
 			#address-cells = <1>;
@@ -770,7 +698,6 @@
 			interrupts = <92 2>, <93 2>;
 			girqs = <18 2>, <18 3>;
 			pcrs = <3 9>;
-			label = "SPI_1";
 			status = "disabled";
 		};
 		spi2: spi@40009480 {
@@ -778,7 +705,6 @@
 			interrupts = <94 2>, <95 2>;
 			girqs = <18 4>, <18 5>;
 			pcrs = <4 22>;
-			label = "SPI_2";
 			status = "disabled";
 		};
 		prochot0: prochot@40003400 {
@@ -786,7 +712,6 @@
 			interrupts = <87 0>;
 			girqs = <17 17>;
 			pcrs = <4 13>;
-			label = "PROCHOT_0";
 			status = "disabled";
 		};
 		rcid0: rcid@40001400 {
@@ -794,7 +719,6 @@
 			interrupts = <80 0>;
 			girqs = <17 10>;
 			pcrs = <4 10>;
-			label = "RCID_0";
 			status = "disabled";
 		};
 		rcid1: rcid@40001480 {
@@ -802,7 +726,6 @@
 			interrupts = <81 0>;
 			girqs = <17 11>;
 			pcrs = <4 11>;
-			label = "RCID_1";
 			status = "disabled";
 		};
 		rcid2: rcid@40001500 {
@@ -810,7 +733,6 @@
 			interrupts = <82 0>;
 			girqs = <17 12>;
 			pcrs = <4 12>;
-			label = "RCID_2";
 			status = "disabled";
 		};
 		spip0: spip@40007000 {
@@ -818,7 +740,6 @@
 			interrupts = <90 0>;
 			girqs = <18 0>;
 			pcrs = <4 16>;
-			label = "SPIP_0";
 			status = "disabled";
 		};
 		bbled0: bbled@4000b800 {
@@ -826,7 +747,6 @@
 			interrupts = <83 0>;
 			girqs = <17 13>;
 			pcrs = <3 16>;
-			label = "BBLED_0";
 			status = "disabled";
 		};
 		bbled1: bbled@4000b900 {
@@ -834,7 +754,6 @@
 			interrupts = <84 0>;
 			girqs = <17 14>;
 			pcrs = <3 17>;
-			label = "BBLED_1";
 			status = "disabled";
 		};
 		bbled2: bbled@4000ba00 {
@@ -842,7 +761,6 @@
 			interrupts = <85 0>;
 			girqs = <17 15>;
 			pcrs = <3 18>;
-			label = "BBLED_2";
 			status = "disabled";
 		};
 		bbled3: bbled@4000bb00 {
@@ -850,7 +768,6 @@
 			interrupts = <86 0>;
 			girqs = <17 16>;
 			pcrs = <3 25>;
-			label = "BBLED_3";
 			status = "disabled";
 		};
 		bclink0: bclink@4000cd00 {
@@ -858,19 +775,16 @@
 			interrupts = <96 0>, <97 0>;
 			girqs = <18 7>, <18 6>;
 			pcrs = <3 19>;
-			label = "BCLINK_0";
 			status = "disabled";
 		};
 		tfdp0: tfdp@40008c00 {
 			reg = <0x40008c00 0x10>;
 			pcrs = <1 7>;
-			label = "TFDP_0";
 			status = "disabled";
 		};
 		glblcfg0: glblcfg@400fff00 {
 			reg = <0x400fff00 0x40>;
 			pcrs = <2 12>;
-			label = "GLBLCFG_0";
 			status = "disabled";
 		};
 		espi0: espi@400f3400 {
@@ -894,7 +808,6 @@
 				  MCHP_XEC_ECIA(19, 7, 11, 110)
 				  MCHP_XEC_ECIA(19, 8, 11, 156) >;
 			pcrs = <2 19>;
-			label = "ESPI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";
@@ -906,7 +819,6 @@
 				girqs = < MCHP_XEC_ECIA(15, 20, 7, 60) >;
 				pcrs = <2 17>;
 				ldn = <0>;
-				label = "MBOX_0";
 				status = "disabled";
 			};
 			kbc0: kbc@400f0400 {
@@ -917,7 +829,6 @@
 				girqs = < MCHP_XEC_ECIA(15, 18, 7, 58)
 					  MCHP_XEC_ECIA(15, 19, 7, 59) >;
 				ldn = <1>;
-				label = "KBC_0";
 				status = "disabled";
 			};
 			acpi_ec0: acpi_ec@400f0800 {
@@ -928,7 +839,6 @@
 				girqs = < MCHP_XEC_ECIA(15, 5, 7, 45)
 					  MCHP_XEC_ECIA(15, 6, 7, 46) >;
 				ldn = <2>;
-				label = "ACPI_EC_0";
 				status = "disabled";
 			};
 			acpi_ec1: acpi_ec@400f0c00 {
@@ -939,7 +849,6 @@
 				girqs = < MCHP_XEC_ECIA(15, 7, 7, 47)
 					  MCHP_XEC_ECIA(15, 8, 7, 48) >;
 				ldn = <3>;
-				label = "ACPI_EC_1";
 				status = "disabled";
 			};
 			acpi_ec2: acpi_ec@400f1000 {
@@ -950,7 +859,6 @@
 				girqs = < MCHP_XEC_ECIA(15, 9, 7, 49)
 					  MCHP_XEC_ECIA(15, 10, 7, 50) >;
 				ldn = <4>;
-				label = "ACPI_EC_2";
 				status = "disabled";
 			};
 			acpi_ec3: acpi_ec@400f1400 {
@@ -961,7 +869,6 @@
 				girqs = < MCHP_XEC_ECIA(15, 11, 7, 51)
 					  MCHP_XEC_ECIA(15, 12, 7, 52) >;
 				ldn = <5>;
-				label = "ACPI_EC_3";
 				status = "disabled";
 			};
 			acpi_ec4: acpi_ec@400f1800 {
@@ -972,7 +879,6 @@
 				girqs = < MCHP_XEC_ECIA(15, 13, 7, 53)
 					  MCHP_XEC_ECIA(15, 14, 7, 54) >;
 				ldn = <6>;
-				label = "ACPI_EC_4";
 				status = "disabled";
 			};
 			acpi_pm1: acpi_pm1@400f1c00 {
@@ -984,13 +890,11 @@
 					  MCHP_XEC_ECIA(15, 16, 7, 56)
 					  MCHP_XEC_ECIA(15, 17, 7, 57) >;
 				ldn = <7>;
-				label = "ACPI_PM1";
 				status = "disabled";
 			};
 			port92: port92@400f2000 {
 				compatible = "microchip,xec-espi-host-dev";
 				reg = <0x400f2000 0x400>;
-				label = "PORT92";
 				ldn = <8>;
 				status = "disabled";
 			};
@@ -1000,7 +904,6 @@
 				interrupts = <40 0>;
 				clock-frequency = <1843200>;
 				current-speed = <38400>;
-				label = "UART_0";
 				girqs = <15 0>;
 				pcrs = <2 1>;
 				ldn = <9>;
@@ -1012,7 +915,6 @@
 				interrupts = <41 0>;
 				clock-frequency = <1843200>;
 				current-speed = <38400>;
-				label = "UART_1";
 				girqs = <15 1>;
 				pcrs = <2 2>;
 				ldn = <10>;
@@ -1023,7 +925,6 @@
 				reg = <0x400f4000 0x400>;
 				interrupts = <42 0>;
 				girqs = < MCHP_XEC_ECIA(15, 2, 7, 42) >;
-				label = "EMI_0";
 				ldn = <16>;
 				status = "disabled";
 			};
@@ -1032,7 +933,6 @@
 				reg = <0x400f4400 0x400>;
 				interrupts = <43 0>;
 				girqs = < MCHP_XEC_ECIA(15, 3, 7, 43) >;
-				label = "EMI_1";
 				ldn = <17>;
 				status = "disabled";
 			};
@@ -1041,7 +941,6 @@
 				reg = <0x400f4800 0x400>;
 				interrupts = <44 0>;
 				girqs = < MCHP_XEC_ECIA(15, 4, 7, 44) >;
-				label = "EMI_2";
 				ldn = <18>;
 				status = "disabled";
 			};
@@ -1052,7 +951,6 @@
 				girqs = < MCHP_XEC_ECIA(21, 8, 13, 119)
 					  MCHP_XEC_ECIA(21, 9, 13, 120) >;
 				pcrs = <2 18>;
-				label = "RTC_0";
 				ldn = <20>;
 				status = "disabled";
 			};
@@ -1064,14 +962,12 @@
 				girqs = < MCHP_XEC_ECIA(15, 22, 7, 62) >;
 				pcrs = <2 25>;
 				ldn = <32>;
-				label = "P80BD_0";
 				status = "disabled";
 			};
 			/* Capture writes to an 8-bit I/O and map to one of 0x80 to 0x83 */
 			p80bd0_alias: p80bd@400f8400 {
 				compatible = "microchip,xec-espi-host-dev";
 				reg = <0x400f8400 0x400>;
-				label = "P80BD_0_ALIAS";
 				ldn = <33>;
 				host-io = <0x90>;
 				/* map 0x90 to 0x80 */

--- a/dts/arm/nuvoton/m48x.dtsi
+++ b/dts/arm/nuvoton/m48x.dtsi
@@ -25,7 +25,6 @@
 
 	flash0: flash@0 {
 		compatible = "serial-flash";
-		label = "FLASH_NUMICRO";
 		erase-block-size = <4096>;
 		write-block-size = <1>;
 	};
@@ -41,56 +40,48 @@
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40070000 0x1000>;
 			status = "disabled";
-			label = "UART_0";
 		};
 
 		uart1: serial@40071000 {
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40071000 0x1000>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		uart2: serial@40072000 {
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40072000 0x1000>;
 			status = "disabled";
-			label = "UART_2";
 		};
 
 		uart3: serial@40073000 {
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40073000 0x1000>;
 			status = "disabled";
-			label = "UART_3";
 		};
 
 		uart4: serial@40074000 {
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40074000 0x1000>;
 			status = "disabled";
-			label = "UART_4";
 		};
 
 		uart5: serial@40075000 {
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40075000 0x1000>;
 			status = "disabled";
-			label = "UART_5";
 		};
 
 		uart6: serial@40076000 {
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40076000 0x1000>;
 			status = "disabled";
-			label = "UART_6";
 		};
 
 		uart7: serial@40077000 {
 			compatible = "nuvoton,numicro-uart";
 			reg = <0x40077000 0x1000>;
 			status = "disabled";
-			label = "UART_7";
 		};
 
 	};

--- a/dts/arm/nuvoton/npcx.dtsi
+++ b/dts/arm/nuvoton/npcx.dtsi
@@ -66,7 +66,6 @@
 			reg = <0x400af000 0x80
 			       0x400af100 0x1>;
 			reg-names = "memory", "status";
-			label = "BBRAM";
 		};
 
 		pcc: clock-controller@4000d000 {
@@ -78,7 +77,6 @@
 			reg = <0x4000d000 0x2000
 			       0x400b5000 0x2000>;
 			reg-names = "pmc", "cdcg";
-			label = "PMC_CDCG";
 		};
 
 		scfg: scfg@400c3000 {
@@ -90,7 +88,6 @@
 			reg-names = "scfg", "glue";
 			#alt-cells = <3>;
 			#lvol-cells = <2>;
-			label = "SCFG";
 		};
 
 		mdc: mdc@4000c000 {
@@ -110,7 +107,6 @@
 			reg = <0x400bb000 0x2000>;
 			index = <0>;
 			#miwu-cells = <2>;
-			label="MIWU_0";
 		};
 
 		miwu1: miwu@400bd000 {
@@ -118,7 +114,6 @@
 			reg = <0x400bd000 0x2000>;
 			index = <1>;
 			#miwu-cells = <2>;
-			label="MIWU_1";
 		};
 
 		miwu2: miwu@400bf000 {
@@ -126,7 +121,6 @@
 			reg = <0x400bf000 0x2000>;
 			index = <2>;
 			#miwu-cells = <2>;
-			label="MIWU_2";
 		};
 
 		gpio0: gpio@40081000 {
@@ -135,7 +129,6 @@
 			gpio-controller;
 			index = <0x0>;
 			#gpio-cells=<2>;
-			label="GPIO_0";
 		};
 
 		gpio1: gpio@40083000 {
@@ -144,7 +137,6 @@
 			gpio-controller;
 			index = <0x1>;
 			#gpio-cells=<2>;
-			label="GPIO_1";
 		};
 
 		gpio2: gpio@40085000 {
@@ -153,7 +145,6 @@
 			gpio-controller;
 			index = <0x2>;
 			#gpio-cells=<2>;
-			label="GPIO_2";
 		};
 
 		gpio3: gpio@40087000 {
@@ -162,7 +153,6 @@
 			gpio-controller;
 			index = <0x3>;
 			#gpio-cells=<2>;
-			label="GPIO_3";
 		};
 
 		gpio4: gpio@40089000 {
@@ -171,7 +161,6 @@
 			gpio-controller;
 			index = <0x4>;
 			#gpio-cells=<2>;
-			label="GPIO_4";
 		};
 
 		gpio5: gpio@4008b000 {
@@ -180,7 +169,6 @@
 			gpio-controller;
 			index = <0x5>;
 			#gpio-cells=<2>;
-			label="GPIO_5";
 		};
 
 		gpio6: gpio@4008d000 {
@@ -189,7 +177,6 @@
 			gpio-controller;
 			index = <0x6>;
 			#gpio-cells=<2>;
-			label="GPIO_6";
 		};
 
 		gpio7: gpio@4008f000 {
@@ -198,7 +185,6 @@
 			gpio-controller;
 			index = <0x7>;
 			#gpio-cells=<2>;
-			label="GPIO_7";
 		};
 
 		gpio8: gpio@40091000 {
@@ -207,7 +193,6 @@
 			gpio-controller;
 			index = <0x8>;
 			#gpio-cells=<2>;
-			label="GPIO_8";
 		};
 
 		gpio9: gpio@40093000 {
@@ -216,7 +201,6 @@
 			gpio-controller;
 			index = <0x9>;
 			#gpio-cells=<2>;
-			label="GPIO_9";
 		};
 
 		gpioa: gpio@40095000 {
@@ -225,7 +209,6 @@
 			gpio-controller;
 			index = <0xA>;
 			#gpio-cells=<2>;
-			label="GPIO_A";
 		};
 
 		gpiob: gpio@40097000 {
@@ -234,7 +217,6 @@
 			gpio-controller;
 			index = <0xB>;
 			#gpio-cells=<2>;
-			label="GPIO_B";
 		};
 
 		gpioc: gpio@40099000 {
@@ -243,7 +225,6 @@
 			gpio-controller;
 			index = <0xC>;
 			#gpio-cells=<2>;
-			label="GPIO_C";
 		};
 
 		gpiod: gpio@4009b000 {
@@ -252,7 +233,6 @@
 			gpio-controller;
 			index = <0xD>;
 			#gpio-cells=<2>;
-			label="GPIO_D";
 		};
 
 		gpioe: gpio@4009d000 {
@@ -261,7 +241,6 @@
 			gpio-controller;
 			index = <0xE>;
 			#gpio-cells=<2>;
-			label="GPIO_E";
 		};
 
 		gpiof: gpio@4009f000 {
@@ -270,7 +249,6 @@
 			gpio-controller;
 			index = <0xF>;
 			#gpio-cells=<2>;
-			label="GPIO_F";
 		};
 
 		pwm0: pwm@40080000 {
@@ -280,7 +258,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 0>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_0";
 		};
 
 		pwm1: pwm@40082000 {
@@ -290,7 +267,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 1>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_1";
 		};
 
 		pwm2: pwm@40084000 {
@@ -300,7 +276,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 2>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_2";
 		};
 
 		pwm3: pwm@40086000 {
@@ -310,7 +285,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 3>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_3";
 		};
 
 		pwm4: pwm@40088000 {
@@ -320,7 +294,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 4>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_4";
 		};
 
 		pwm5: pwm@4008a000 {
@@ -330,7 +303,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 5>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_5";
 		};
 
 		pwm6: pwm@4008c000 {
@@ -340,7 +312,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 6>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_6";
 		};
 
 		pwm7: pwm@4008e000 {
@@ -350,7 +321,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL2 7>;
 			#pwm-cells = <3>;
 			status = "disabled";
-			label = "PWM_7";
 		};
 
 		adc0: adc@400d1000 {
@@ -360,14 +330,12 @@
 			interrupts = <10 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB1 NPCX_PWDWN_CTL4 4>;
 			status = "disabled";
-			label = "ADC_0";
 		};
 
 		twd0: watchdog@400d8000 {
 			compatible = "nuvoton,npcx-watchdog";
 			reg = <0x400d8000 0x2000>;
 			t0-out = <&wui_t0out>;
-			label = "TWD_0";
 		};
 
 		espi0: espi@4000a000 {
@@ -379,7 +347,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL6 7>;
 			/* WUI maps for eSPI signals */
 			espi-rst-wui = <&wui_espi_rst>;
-			label = "ESPI_0";
 
 			#address-cells = <1>;
 			#size-cells = <0>;
@@ -417,7 +384,6 @@
 				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 5>,
 				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 6>,
 				<&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL5 7>;
-			label = "HOST_SUBS";
 		};
 
 		/* I2c Controllers - Do not use them as i2c node directly */
@@ -426,7 +392,6 @@
 			reg = <0x40009000 0x1000>;
 			interrupts = <13 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 0>;
-			label = "I2CCTRL_0";
 			status = "disabled";
 		};
 
@@ -435,7 +400,6 @@
 			reg = <0x4000b000 0x1000>;
 			interrupts = <14 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 1>;
-			label = "I2CCTRL_1";
 			status = "disabled";
 		};
 
@@ -444,7 +408,6 @@
 			reg = <0x400c0000 0x1000>;
 			interrupts = <36 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 2>;
-			label = "I2CCTRL_2";
 			status = "disabled";
 		};
 
@@ -453,7 +416,6 @@
 			reg = <0x400c2000 0x1000>;
 			interrupts = <37 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL3 3>;
-			label = "I2CCTRL_3";
 			status = "disabled";
 		};
 
@@ -462,7 +424,6 @@
 			reg = <0x40008000 0x1000>;
 			interrupts = <19 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL3 4>;
-			label = "I2CCTRL_4";
 			status = "disabled";
 		};
 
@@ -471,7 +432,6 @@
 			reg = <0x40017000 0x1000>;
 			interrupts = <20 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 0>;
-			label = "I2CCTRL_5";
 			status = "disabled";
 		};
 
@@ -480,7 +440,6 @@
 			reg = <0x40018000 0x1000>;
 			interrupts = <16 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 1>;
-			label = "I2CCTRL_6";
 			status = "disabled";
 		};
 
@@ -489,7 +448,6 @@
 			reg = <0x40019000 0x1000>;
 			interrupts = <8 3>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL7 2>;
-			label = "I2CCTRL_7";
 			status = "disabled";
 		};
 
@@ -497,7 +455,6 @@
 			compatible = "nuvoton,npcx-tach";
 			reg = <0x400e1000 0x2000>;
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL1 5>;
-			label = "TACH_1";
 			status = "disabled";
 		};
 
@@ -505,7 +462,6 @@
 			compatible = "nuvoton,npcx-tach";
 			reg = <0x400e3000 0x2000>;
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL1 6>;
-			label = "TACH_2";
 			status = "disabled";
 		};
 
@@ -514,34 +470,29 @@
 			reg = <0x400b1000 0x1000>;
 			interrupts = <21 4>;
 			clocks = <&pcc NPCX_CLOCK_BUS_FREERUN NPCX_PWDWN_CTL1 3>;
-			label = "PS2_CTRL_0";
 
 			/* PS2 Channels - Please use them as PS2 node */
 			ps2_channel0: io_ps2_channel0 {
 				compatible = "nuvoton,npcx-ps2-channel";
 				channel = <0x00>;
-				label = "PS2_CHANNEL_0";
 				status = "disabled";
 			};
 
 			ps2_channel1: io_ps2_channel1 {
 				compatible = "nuvoton,npcx-ps2-channel";
 				channel = <0x01>;
-				label = "PS2_CHANNEL_1";
 				status = "disabled";
 			};
 
 			ps2_channel2: io_ps2_channel2 {
 				compatible = "nuvoton,npcx-ps2-channel";
 				channel = <0x02>;
-				label = "PS2_CHANNEL_2";
 				status = "disabled";
 			};
 
 			ps2_channel3: io_ps2_channel3 {
 				compatible = "nuvoton,npcx-ps2-channel";
 				channel = <0x03>;
-				label = "PS2_CHANNEL_3";
 				status = "disabled";
 			};
 		};
@@ -553,7 +504,6 @@
 			#size-cells = <0>;
 			reg = <0x40020000 0x2000>;
 			clocks = <&pcc NPCX_CLOCK_BUS_APB3 NPCX_PWDWN_CTL1 2>;
-			label = "SPI_FIU";
 		};
 	};
 
@@ -564,7 +514,6 @@
 		 */
 		host_uart: io_host_uart {
 			compatible = "nuvoton,npcx-host-uart";
-			label = "HOST_UART_IO";
 			status = "disabled";
 		};
 
@@ -574,7 +523,6 @@
 			#size-cells = <0>;
 			port = <0x00>;
 			controller = <&i2c_ctrl0>;
-			label = "I2C_0_PORT_0";
 			status = "disabled";
 		};
 
@@ -584,7 +532,6 @@
 			#size-cells = <0>;
 			port = <0x10>;
 			controller = <&i2c_ctrl1>;
-			label = "I2C_1_PORT_0";
 			status = "disabled";
 		};
 
@@ -594,7 +541,6 @@
 			#size-cells = <0>;
 			port = <0x20>;
 			controller = <&i2c_ctrl2>;
-			label = "I2C_2_PORT_0";
 			status = "disabled";
 		};
 
@@ -604,7 +550,6 @@
 			#size-cells = <0>;
 			port = <0x30>;
 			controller = <&i2c_ctrl3>;
-			label = "I2C_3_PORT_0";
 			status = "disabled";
 		};
 
@@ -614,7 +559,6 @@
 			#size-cells = <0>;
 			port = <0x41>;
 			controller = <&i2c_ctrl4>;
-			label = "I2C_4_PORT_1";
 			status = "disabled";
 		};
 
@@ -624,7 +568,6 @@
 			#size-cells = <0>;
 			port = <0x50>;
 			controller = <&i2c_ctrl5>;
-			label = "I2C_5_PORT_0";
 			status = "disabled";
 		};
 
@@ -634,7 +577,6 @@
 			#size-cells = <0>;
 			port = <0x51>;
 			controller = <&i2c_ctrl5>;
-			label = "I2C_5_PORT_1";
 			status = "disabled";
 		};
 
@@ -644,7 +586,6 @@
 			#size-cells = <0>;
 			port = <0x60>;
 			controller = <&i2c_ctrl6>;
-			label = "I2C_6_PORT_0";
 			status = "disabled";
 		};
 
@@ -654,7 +595,6 @@
 			#size-cells = <0>;
 			port = <0x61>;
 			controller = <&i2c_ctrl6>;
-			label = "I2C_6_PORT_1";
 			status = "disabled";
 		};
 
@@ -664,13 +604,11 @@
 			#size-cells = <0>;
 			port = <0x70>;
 			controller = <&i2c_ctrl7>;
-			label = "I2C_7_PORT_0";
 			status = "disabled";
 		};
 
 		power_ctrl_psl: power-ctrl-psl {
 			compatible = "nuvoton,npcx-power-psl";
-			label = "POWER_CONTROL_PSL";
 			status = "disabled";
 		};
 	};

--- a/dts/arm/nuvoton/npcx/npcx-miwus-wui-map.dtsi
+++ b/dts/arm/nuvoton/npcx/npcx-miwus-wui-map.dtsi
@@ -504,7 +504,6 @@
 		compatible = "nuvoton,npcx-miwu";
 		index = <3>;
 		#miwu-cells = <2>;
-		label="MIWU_NONE";
 		status = "disabled";
 	};
 };

--- a/dts/arm/nuvoton/npcx7.dtsi
+++ b/dts/arm/nuvoton/npcx7.dtsi
@@ -66,7 +66,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL4 3
 				  &pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 5>;
 			interrupts = <46 1>; /* Event timer interrupt */
-			label = "ITIM";
 		};
 
 		uart1: serial@400c4000 {
@@ -76,7 +75,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL1 4>;
 			uart-rx = <&wui_cr_sin1>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		uart2: serial@400c6000 {
@@ -86,7 +84,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 6>;
 			uart-rx = <&wui_cr_sin2>;
 			status = "disabled";
-			label = "UART_2";
 		};
 
 		/* Default clock and power settings in npcx9 series */

--- a/dts/arm/nuvoton/npcx7m6fb.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fb.dtsi
@@ -37,7 +37,6 @@
 		compatible ="jedec,spi-nor";
 		/* 8388608 bits = 1 Mbytes */
 		size = <0x800000>;
-		label = "W25Q80";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		status = "okay";

--- a/dts/arm/nuvoton/npcx7m6fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m6fc.dtsi
@@ -37,7 +37,6 @@
 		compatible ="jedec,spi-nor";
 		/*  4194304 bits = 512K Bytes */
 		size = <0x400000>;
-		label = "W25Q40";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		status = "okay";

--- a/dts/arm/nuvoton/npcx7m7fc.dtsi
+++ b/dts/arm/nuvoton/npcx7m7fc.dtsi
@@ -41,7 +41,6 @@
 		compatible ="jedec,spi-nor";
 		/*  4194304 bits = 512K Bytes */
 		size = <0x400000>;
-		label = "W25Q40";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		status = "okay";

--- a/dts/arm/nuvoton/npcx9.dtsi
+++ b/dts/arm/nuvoton/npcx9.dtsi
@@ -67,7 +67,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_LFCLK NPCX_PWDWN_CTL4 0
 				  &pcc NPCX_CLOCK_BUS_APB2 NPCX_PWDWN_CTL7 5>;
 			interrupts = <28 1>; /* Event timer interrupt */
-			label = "ITIM";
 		};
 
 		uart1: serial@400e0000 {
@@ -77,7 +76,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL1 4>;
 			uart-rx = <&wui_cr_sin1>;
 			status = "disabled";
-			label = "UART_1";
 		};
 
 		uart2: serial@400e2000 {
@@ -87,7 +85,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 6>;
 			uart-rx = <&wui_cr_sin2>;
 			status = "disabled";
-			label = "UART_2";
 		};
 
 		uart3: serial@400e4000 {
@@ -97,7 +94,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 4>;
 			uart-rx = <&wui_cr_sin3>;
 			status = "disabled";
-			label = "UART_3";
 		};
 
 		uart4: serial@400e6000 {
@@ -107,7 +103,6 @@
 			clocks = <&pcc NPCX_CLOCK_BUS_APB4 NPCX_PWDWN_CTL7 3>;
 			uart-rx = <&wui_cr_sin4>;
 			status = "disabled";
-			label = "UART_4";
 		};
 
 		/* Default clock and power settings in npcx9 series */

--- a/dts/arm/nuvoton/npcx9m3f.dtsi
+++ b/dts/arm/nuvoton/npcx9m3f.dtsi
@@ -31,7 +31,6 @@
 		compatible ="jedec,spi-nor";
 		/*  4194304 bits = 512K Bytes */
 		size = <0x400000>;
-		label = "W25Q40";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		status = "okay";

--- a/dts/arm/nuvoton/npcx9m6f.dtsi
+++ b/dts/arm/nuvoton/npcx9m6f.dtsi
@@ -31,7 +31,6 @@
 		compatible ="jedec,spi-nor";
 		/*  4194304 bits = 512K Bytes */
 		size = <0x400000>;
-		label = "W25Q40";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		status = "okay";

--- a/dts/arm/nuvoton/npcx9m7f.dtsi
+++ b/dts/arm/nuvoton/npcx9m7f.dtsi
@@ -31,7 +31,6 @@
 		compatible ="jedec,spi-nor";
 		/* 8388608 bits = 1 Mbytes */
 		size = <0x800000>;
-		label = "W25Q80";
 		reg = <0>;
 		spi-max-frequency = <50000000>;
 		status = "okay";

--- a/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
+++ b/dts/arm/quicklogic/quicklogic_eos_s3.dtsi
@@ -46,7 +46,6 @@
 			clocks = <&uartclk>;
 			interrupts = <7 3>;
 			interrupt-names = "rx";
-			label = "UART_0";
 		};
 
 		gpio: gpio {
@@ -57,7 +56,6 @@
 			ngpios = <8>;
 			pin-secondary-config = <0x00>;
 			gpio-controller;
-			label = "GPIO";
 		};
 	};
 };

--- a/dts/arm/renesas/gen3/r8a77951.dtsi
+++ b/dts/arm/renesas/gen3/r8a77951.dtsi
@@ -13,7 +13,6 @@
 			compatible = "renesas,r8a7795-cpg-mssr";
 			reg = <0xe6150000 0x1000>;
 			#clock-cells = <2>;
-			label = "cpg";
 		};
 
 		can0: can@e6c30000 {

--- a/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
+++ b/dts/arm/renesas/gen3/rcar_gen3_cr7.dtsi
@@ -49,7 +49,6 @@
 			interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			clocks = <&cpg CPG_MOD 907>;
 			status = "disabled";
-			label = "gpio5";
 		};
 
 		gpio6: gpio@e6055400 {
@@ -61,7 +60,6 @@
 			interrupts = <GIC_SPI 10 IRQ_TYPE_LEVEL IRQ_DEFAULT_PRIORITY>;
 			clocks = <&cpg CPG_MOD 906>;
 			status = "disabled";
-			label = "gpio6";
 		};
 
 		pfc: pin-controller@e6060000 {
@@ -80,7 +78,6 @@
 			reg = <0xe60f0500 0x1004>;
 			clocks = <&cpg CPG_MOD 303>;
 			status = "disabled";
-			label = "cmt0";
 		};
 
 		can0: can@e6c30000 {
@@ -92,7 +89,6 @@
 			sjw = <1>;
 			sample-point = <875>;
 			status = "disabled";
-			label = "can0";
 		};
 
 		i2c2: i2c@e6510000 {
@@ -106,7 +102,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			clocks = <&cpg CPG_MOD 929>;
 			status = "disabled";
-			label = "i2c2";
 		};
 
 		i2c4: i2c@e66d8000 {
@@ -120,7 +115,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			clocks = <&cpg CPG_MOD 927>;
 			status = "disabled";
-			label = "i2c4";
 		};
 
 		scif1: serial@e6e68000 {
@@ -131,7 +125,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			current-speed = <115200>;
 			status = "disabled";
-			label = "scif1";
 		};
 
 		scif2: serial@e6e88000 {
@@ -142,7 +135,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			current-speed = <115200>;
 			status = "disabled";
-			label = "scif2";
 		};
 	};
 };

--- a/dts/arm/rpi_pico/rp2040.dtsi
+++ b/dts/arm/rpi_pico/rp2040.dtsi
@@ -35,7 +35,6 @@
 
 		flash0: flash@10000000 {
 			compatible = "soc-nv-flash";
-			label = "FLASH_RP2";
 
 			write-block-size = <1>;
 		};
@@ -58,14 +57,12 @@
 			reg-width = <4>;
 			active-low = <0>;
 			#reset-cells = <1>;
-			label = "RESET";
 		};
 
 		pinctrl: pin-controller@40014000 {
 			compatible = "raspberrypi,pico-pinctrl";
 			reg = <0x40014000 DT_SIZE_K(4)>;
 			status = "okay";
-			label = "PINCTRL";
 		};
 
 		gpio0: gpio@40014000 {
@@ -74,7 +71,6 @@
 			interrupts = <13 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_0";
 			status = "disabled";
 			ngpios = <30>;
 		};
@@ -86,7 +82,6 @@
 			resets = <&reset RPI_PICO_RESETS_RESET_UART0>;
 			interrupts = <20 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "uart0";
-			label = "UART_0";
 			status = "disabled";
 		};
 
@@ -97,7 +92,6 @@
 			resets = <&reset RPI_PICO_RESETS_RESET_UART1>;
 			interrupts = <21 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "uart1";
-			label = "UART_1";
 			status = "disabled";
 		};
 
@@ -109,7 +103,6 @@
 			clocks = <&system_clk>;
 			interrupts = <23 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "i2c0";
-			label = "I2C_0";
 			status = "disabled";
 		};
 
@@ -121,7 +114,6 @@
 			clocks = <&system_clk>;
 			interrupts = <24 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "i2c1";
-			label = "I2C_1";
 			status = "disabled";
 		};
 
@@ -129,7 +121,6 @@
 			compatible = "raspberrypi,pico-watchdog";
 			reg = <0x40058000 DT_SIZE_K(4)>;
 			clocks = <&xtal_clk>;
-			label = "WDT_0";
 			status = "disabled";
 		};
 
@@ -140,7 +131,6 @@
 			interrupts = <5 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "usbctrl";
 			num-bidir-endpoints = <16>;
-			label = "USBD";
 			status = "disabled";
 		};
 
@@ -151,7 +141,6 @@
 			clocks = <&system_clk>;
 			interrupts = <4 RPI_PICO_DEFAULT_IRQ_PRIORITY>;
 			interrupt-names = "PWM_IRQ_WRAP";
-			label = "PWM_0";
 			status = "disabled";
 			#pwm-cells = <3>;
 		};

--- a/dts/arm/xilinx/zynq7000.dtsi
+++ b/dts/arm/xilinx/zynq7000.dtsi
@@ -46,7 +46,6 @@
 				<0xf8f00100 0x100>;
 			interrupt-controller;
 			#interrupt-cells = <4>;
-			label = "gic";
 		};
 
 		gem0: ethernet@e000b000 {
@@ -59,7 +58,6 @@
 				     <GIC_SPI 23 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1";
-			label = "gem0";
 			mdio-phy-address = <XLNX_GEM_PHY_AUTO_DETECT>;
 			phy-poll-interval = <1000>;
 			link-speed = <XLNX_GEM_LINK_SPEED_100MBIT>;
@@ -87,7 +85,6 @@
 				     <GIC_SPI 46 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1";
-			label = "gem1";
 			mdio-phy-address = <XLNX_GEM_PHY_AUTO_DETECT>;
 			phy-poll-interval = <1000>;
 			link-speed = <XLNX_GEM_LINK_SPEED_100MBIT>;
@@ -112,7 +109,6 @@
 			interrupts = <GIC_SPI 27 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
-			label = "uart0";
 		};
 
 		uart1: uart@e0001000 {
@@ -122,7 +118,6 @@
 			interrupts = <GIC_SPI 50 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
-			label = "uart1";
 		};
 
 		psgpio: gpio@e000a000 {
@@ -132,7 +127,6 @@
 			interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
-			label = "psgpio";
 
 			ranges;
 			#address-cells = <1>;
@@ -141,7 +135,6 @@
 			psgpio_bank0: psgpio_bank@0 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x0>;
-				label = "psgpio_bank0_mio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <32>;
@@ -151,7 +144,6 @@
 			psgpio_bank1: psgpio_bank@1 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x1>;
-				label = "psgpio_bank1_mio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <22>;
@@ -161,7 +153,6 @@
 			psgpio_bank2: psgpio_bank@2 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x2>;
-				label = "psgpio_bank2_emio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <32>;
@@ -171,7 +162,6 @@
 			psgpio_bank3: psgpio_bank@3 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x3>;
-				label = "psgpio_bank3_emio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <32>;

--- a/dts/arm/xilinx/zynqmp.dtsi
+++ b/dts/arm/xilinx/zynqmp.dtsi
@@ -34,7 +34,6 @@
 			interrupts = <GIC_SPI 21 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
-			label = "UART_0";
 		};
 
 		uart1: uart@ff010000 {
@@ -44,7 +43,6 @@
 			interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
-			label = "UART_1";
 		};
 
 		ttc0: timer@ff110000 {
@@ -58,7 +56,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff110000 0x1000>;
-			label = "ttc0";
 		};
 
 		ttc1: timer@ff120000 {
@@ -72,7 +69,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff120000 0x1000>;
-			label = "ttc1";
 		};
 
 		ttc2: timer@ff130000 {
@@ -86,7 +82,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff130000 0x1000>;
-			label = "ttc2";
 		};
 
 		ttc3: timer@ff140000 {
@@ -100,7 +95,6 @@
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1", "irq_2";
 			reg = <0xff140000 0x1000>;
-			label = "ttc3";
 		};
 
 		gem0: ethernet@ff0b0000 {
@@ -113,7 +107,6 @@
 				     <GIC_SPI 58 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1";
-			label = "gem0";
 			mdio-phy-address = <XLNX_GEM_PHY_AUTO_DETECT>;
 			phy-poll-interval = <1000>;
 			link-speed = <XLNX_GEM_LINK_SPEED_100MBIT>;
@@ -141,7 +134,6 @@
 				     <GIC_SPI 60 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1";
-			label = "gem1";
 			mdio-phy-address = <XLNX_GEM_PHY_AUTO_DETECT>;
 			phy-poll-interval = <1000>;
 			link-speed = <XLNX_GEM_LINK_SPEED_100MBIT>;
@@ -169,7 +161,6 @@
 				     <GIC_SPI 62 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1";
-			label = "gem2";
 			mdio-phy-address = <XLNX_GEM_PHY_AUTO_DETECT>;
 			phy-poll-interval = <1000>;
 			link-speed = <XLNX_GEM_LINK_SPEED_100MBIT>;
@@ -197,7 +188,6 @@
 				     <GIC_SPI 64 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0", "irq_1";
-			label = "gem3";
 			mdio-phy-address = <XLNX_GEM_PHY_AUTO_DETECT>;
 			phy-poll-interval = <1000>;
 			link-speed = <XLNX_GEM_LINK_SPEED_100MBIT>;
@@ -222,7 +212,6 @@
 			interrupts = <GIC_SPI 16 IRQ_TYPE_LEVEL
 					IRQ_DEFAULT_PRIORITY>;
 			interrupt-names = "irq_0";
-			label = "psgpio";
 
 			ranges;
 			#address-cells = <1>;
@@ -231,7 +220,6 @@
 			psgpio_bank0: psgpio_bank@0 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x0>;
-				label = "psgpio_bank0_mio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <26>;
@@ -241,7 +229,6 @@
 			psgpio_bank1: psgpio_bank@1 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x1>;
-				label = "psgpio_bank1_mio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <26>;
@@ -251,7 +238,6 @@
 			psgpio_bank2: psgpio_bank@2 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x2>;
-				label = "psgpio_bank2_mio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <26>;
@@ -261,7 +247,6 @@
 			psgpio_bank3: psgpio_bank@3 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x3>;
-				label = "psgpio_bank3_emio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <32>;
@@ -271,7 +256,6 @@
 			psgpio_bank4: psgpio_bank@4 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x4>;
-				label = "psgpio_bank4_emio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <32>;
@@ -281,7 +265,6 @@
 			psgpio_bank5: psgpio_bank@5 {
 				compatible = "xlnx,ps-gpio-bank";
 				reg = <0x5>;
-				label = "psgpio_bank5_emio";
 				gpio-controller;
 				#gpio-cells = <2>;
 				ngpios = <32>;


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>