### PR TITLE
samples: Remove label property from devicetree overlays

### DIFF
--- a/samples/drivers/counter/maxim_ds3231/boards/efr32mg_sltb004a.overlay
+++ b/samples/drivers/counter/maxim_ds3231/boards/efr32mg_sltb004a.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpiof 6 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/samples/drivers/counter/maxim_ds3231/boards/frdm_k64f.overlay
+++ b/samples/drivers/counter/maxim_ds3231/boards/frdm_k64f.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpioe 26 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/samples/drivers/counter/maxim_ds3231/boards/nrf51dk_nrf51422.overlay
+++ b/samples/drivers/counter/maxim_ds3231/boards/nrf51dk_nrf51422.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpio0 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/samples/drivers/counter/maxim_ds3231/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/counter/maxim_ds3231/boards/nrf52840dk_nrf52840.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpio0 0 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/samples/drivers/counter/maxim_ds3231/boards/nucleo_l476rg.overlay
+++ b/samples/drivers/counter/maxim_ds3231/boards/nucleo_l476rg.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpioa 9 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
 };

--- a/samples/drivers/counter/maxim_ds3231/boards/particle_xenon.overlay
+++ b/samples/drivers/counter/maxim_ds3231/boards/particle_xenon.overlay
@@ -9,7 +9,6 @@
 	ds3231: ds3231@68 {
 		compatible = "maxim,ds3231";
 		reg = <0x68>;
-		label = "DS3231";
 		isw-gpios = <&gpio1 1 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		32k-gpios = <&gpio1 2 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};

--- a/samples/drivers/display/dummy_dc.overlay
+++ b/samples/drivers/display/dummy_dc.overlay
@@ -11,7 +11,6 @@
 
 	dummy_dc: dummy_dc {
 		compatible = "zephyr,dummy-dc";
-		label = "DISPLAY";
 		height = <240>;
 		width = <320>;
 	};

--- a/samples/drivers/ht16k33/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/ht16k33/boards/nrf52840dk_nrf52840.overlay
@@ -10,13 +10,11 @@
 	ht16k33@70 {
 		compatible = "holtek,ht16k33";
 		reg = <0x70>;
-		label = "HT16K33";
                 /* Uncomment to use IRQ instead of polling: */
 		/* irq-gpios = <&gpio1 8 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>; */
 
 		keyscan {
 			compatible = "holtek,ht16k33-keyscan";
-			label = "KEYSCAN";
 		};
 	};
 };

--- a/samples/drivers/i2s/echo/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/i2s/echo/boards/nrf52840dk_nrf52840.overlay
@@ -39,7 +39,6 @@
 	wm8731: wm8731@1a {
 		compatible = "wolfson,wm8731";
 		reg = <0x1a>;
-		label = "WM8731";
 	};
 };
 

--- a/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/samples/drivers/i2s/echo/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -39,7 +39,6 @@
 	wm8731: wm8731@1a {
 		compatible = "wolfson,wm8731";
 		reg = <0x1a>;
-		label = "WM8731";
 	};
 };
 

--- a/samples/drivers/led_apa102/boards/blueclover_plt_demo_v2_nrf52832.overlay
+++ b/samples/drivers/led_apa102/boards/blueclover_plt_demo_v2_nrf52832.overlay
@@ -7,7 +7,6 @@
 / {
 	led_pwr: led-pwr-ctrl {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "led-pwr-ctrl";
 		regulator-name = "led-pwr-ctrl";
 		enable-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;

--- a/samples/drivers/led_apa102/boards/nucleo_l432kc.overlay
+++ b/samples/drivers/led_apa102/boards/nucleo_l432kc.overlay
@@ -10,6 +10,5 @@
 		compatible = "apa,apa102";
 		reg = <0>;
 		spi-max-frequency = <5250000>;
-		label = "APA102";
 	};
 };

--- a/samples/drivers/led_lp503x/boards/lpcxpresso11u68.overlay
+++ b/samples/drivers/led_lp503x/boards/lpcxpresso11u68.overlay
@@ -11,7 +11,6 @@
 	lp5030@30 {
 		compatible = "ti,lp5030", "ti,lp503x";
 		reg = <0x30>;
-		label = "LP5030";
 
 		led_0 {
 			label = "LED LP5030 0";

--- a/samples/drivers/led_lp5562/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/led_lp5562/boards/nrf52840dk_nrf52840.overlay
@@ -7,6 +7,5 @@
 	lp5562@30 {
 		compatible = "ti,lp5562";
 		reg = <0x30>;
-		label = "LP5562";
 	};
 };

--- a/samples/drivers/led_lpd8806/boards/96b_carbon.overlay
+++ b/samples/drivers/led_lpd8806/boards/96b_carbon.overlay
@@ -10,6 +10,5 @@
 		compatible = "greeled,lpd8806";
 		reg = <0>;
 		spi-max-frequency = <2000000>;
-		label = "LPD8806";
 	};
 };

--- a/samples/drivers/led_pca9633/app.overlay
+++ b/samples/drivers/led_pca9633/app.overlay
@@ -7,6 +7,5 @@
 	pca9633@62 {
 		compatible = "nxp,pca9633";
 		reg = <0x62>;
-		label = "PCA9633";
 	};
 };

--- a/samples/drivers/led_ws2812/boards/bbc_microbit.overlay
+++ b/samples/drivers/led_ws2812/boards/bbc_microbit.overlay
@@ -10,7 +10,6 @@
 / {
 	led_strip: ws2812 {
 		compatible = "worldsemi,ws2812-gpio";
-		label = "WS2812";
 
 		chain-length = <16>; /* arbitrary; change at will */
 		color-mapping = <LED_COLOR_ID_GREEN

--- a/samples/drivers/led_ws2812/boards/mimxrt1050_evk.overlay
+++ b/samples/drivers/led_ws2812/boards/mimxrt1050_evk.overlay
@@ -9,7 +9,6 @@
 &lpspi3 {
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
-		label = "WS2812";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/samples/drivers/led_ws2812/boards/mimxrt1050_evk_qspi.overlay
+++ b/samples/drivers/led_ws2812/boards/mimxrt1050_evk_qspi.overlay
@@ -9,7 +9,6 @@
 &lpspi3 {
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
-		label = "WS2812";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/samples/drivers/led_ws2812/boards/nrf51dk_nrf51422.overlay
+++ b/samples/drivers/led_ws2812/boards/nrf51dk_nrf51422.overlay
@@ -10,7 +10,6 @@
 / {
 	led_strip: ws2812 {
 		compatible = "worldsemi,ws2812-gpio";
-		label = "WS2812";
 
 		chain-length = <16>; /* arbitrary */
 		color-mapping = <LED_COLOR_ID_GREEN

--- a/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.overlay
+++ b/samples/drivers/led_ws2812/boards/nrf52dk_nrf52832.overlay
@@ -12,7 +12,6 @@
 	compatible = "nordic,nrf-spim";
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
-		label = "WS2812";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_f070rb.overlay
@@ -14,7 +14,6 @@
 
 	led_strip: b1414@0 {
 		compatible = "everlight,b1414", "worldsemi,ws2812-spi";
-		label = "B1414";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/samples/drivers/led_ws2812/boards/nucleo_g071rb.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_g071rb.overlay
@@ -9,7 +9,6 @@
 &arduino_spi {
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
-		label = "WS2812";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/samples/drivers/led_ws2812/boards/nucleo_h743zi.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_h743zi.overlay
@@ -9,7 +9,6 @@
 &arduino_spi {
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
-		label = "WS2812";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/samples/drivers/led_ws2812/boards/nucleo_l476rg.overlay
+++ b/samples/drivers/led_ws2812/boards/nucleo_l476rg.overlay
@@ -9,7 +9,6 @@
 &arduino_spi {
 	led_strip: ws2812@0 {
 		compatible = "worldsemi,ws2812-spi";
-		label = "WS2812";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */

--- a/samples/drivers/misc/grove_display/boards/serpente.overlay
+++ b/samples/drivers/misc/grove_display/boards/serpente.overlay
@@ -32,7 +32,6 @@
 
 	glcd: glcd@3e {
 		compatible = "seeed,grove-lcd-rgb";
-		label = "GLCD";
 		reg = <0x3e>;
 	};
 };

--- a/samples/drivers/spi_bitbang/boards/nrf52840dk_nrf52840.overlay
+++ b/samples/drivers/spi_bitbang/boards/nrf52840dk_nrf52840.overlay
@@ -6,7 +6,6 @@
 
 / {
 	spibb0: spibb0 {
-		label = "SPIBB";
 		compatible = "zephyr,spi-bitbang";
 		status="okay";
 		#address-cells = <1>;

--- a/samples/drivers/spi_flash_at45/boards/nrf9160dk_nrf9160.overlay
+++ b/samples/drivers/spi_flash_at45/boards/nrf9160dk_nrf9160.overlay
@@ -34,7 +34,6 @@
 		compatible = "atmel,at45";
 		reg = <0>;
 		spi-max-frequency = <15000000>;
-		label = "DATAFLASH_0";
 		jedec-id = [1f 24 00];
 		size = <4194304>;
 		sector-size = <65536>;
@@ -49,7 +48,6 @@
 		compatible = "atmel,at45";
 		reg = <1>;
 		spi-max-frequency = <15000000>;
-		label = "DATAFLASH_1";
 		jedec-id = [1f 27 01];
 		size = <33554432>;
 		sector-size = <65536>;

--- a/samples/subsys/modbus/rtu_server/cdc-acm.overlay
+++ b/samples/subsys/modbus/rtu_server/cdc-acm.overlay
@@ -8,7 +8,6 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 
 		modbus0 {
 			compatible = "zephyr,modbus-serial";


### PR DESCRIPTION
"label" properties are not required.  Remove them from samples.

Signed-off-by: Kumar Gala <galak@kernel.org>