### PR TITLE
tests: Remove label property from devicetree overlays

### DIFF
--- a/tests/bluetooth/shell/usb.overlay
+++ b/tests/bluetooth/shell/usb.overlay
@@ -13,6 +13,5 @@
 &zephyr_udc0 {
 	cdc_acm_uart0: cdc_acm_uart0 {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/tests/drivers/gpio/gpio_api_1pin/boards/particle_xenon.overlay
+++ b/tests/drivers/gpio/gpio_api_1pin/boards/particle_xenon.overlay
@@ -24,7 +24,6 @@
 	sx1509b: sx1509b@3e {
 		compatible = "semtech,sx1509b";
 		reg = <0x3e>;
-		label = "IOX";
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <16>;

--- a/tests/drivers/gpio/gpio_basic_api/boards/particle_xenon.overlay
+++ b/tests/drivers/gpio/gpio_basic_api/boards/particle_xenon.overlay
@@ -24,7 +24,6 @@
 	sx1509b: sx1509b@3e {
 		compatible = "semtech,sx1509b";
 		reg = <0x3e>;
-		label = "IOX";
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <16>;

--- a/tests/subsys/storage/flash_map/app.overlay
+++ b/tests/subsys/storage/flash_map/app.overlay
@@ -11,7 +11,6 @@
 	disabled_flash@0 {
 		compatible = "vnd,flash";
 		reg = <0x00 0x1000>;
-		label = "DISABLED FLASH";
 		status = "disabled";
 
 		partitions {


### PR DESCRIPTION
"label" properties are not required.  Remove them from tests.

Signed-off-by: Kumar Gala <galak@kernel.org>