### PR TITLE
boards: arm: silabs: Convert to use DEVICE_DT_GET

### DIFF
--- a/boards/arm/efm32gg_slwstk6121a/board.c
+++ b/boards/arm/efm32gg_slwstk6121a/board.c
@@ -19,9 +19,9 @@ static int efm32gg_slwstk6121a_init(const struct device *dev)
 	const struct device *cur_dev;
 
 	/* Configure ethernet reference clock */
-	cur_dev = device_get_binding(ETH_REF_CLK_GPIO_NAME);
-	if (!cur_dev) {
-		printk("Ethernet reference clock gpio port was not found!\n");
+	cur_dev = DEVICE_DT_GET(ETH_REF_CLK_GPIO_NODE);
+	if (!device_is_ready(cur_dev)) {
+		printk("Ethernet reference clock gpio port is not ready!\n");
 		return -ENODEV;
 	}
 

--- a/boards/arm/efm32gg_slwstk6121a/board.h
+++ b/boards/arm/efm32gg_slwstk6121a/board.h
@@ -10,7 +10,7 @@
 #define __INC_BOARD_H
 
 /* Ethernet specific pins */
-#define ETH_REF_CLK_GPIO_NAME           "GPIO_A"
+#define ETH_REF_CLK_GPIO_NODE           DT_NODELABEL(gpioa)
 #define ETH_REF_CLK_GPIO_PIN            DT_PROP_BY_IDX(DT_INST(0, silabs_gecko_ethernet), location_rmii_refclk, 2)
 /* The driver ties CMU_CLK2 to the refclk, and pin A3 is CMU_CLK2 #1 */
 #define ETH_REF_CLK_LOCATION            1

--- a/boards/arm/efm32gg_stk3701a/board.c
+++ b/boards/arm/efm32gg_stk3701a/board.c
@@ -18,9 +18,9 @@ static int efm32gg_stk3701a_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
-	cur_dev = device_get_binding(BC_ENABLE_GPIO_NAME);
-	if (!cur_dev) {
-		printk("Board controller gpio port was not found!\n");
+	cur_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);
+	if (!device_is_ready(cur_dev)) {
+		printk("Board controller gpio port is not ready!\n");
 		return -ENODEV;
 	}
 
@@ -29,9 +29,9 @@ static int efm32gg_stk3701a_init(const struct device *dev)
 
 #ifdef CONFIG_ETH_GECKO
 	/* Enable the ethernet PHY power */
-	cur_dev = device_get_binding(ETH_PWR_ENABLE_GPIO_NAME);
-	if (!cur_dev) {
-		printk("Ethernet PHY power gpio port was not found!\n");
+	cur_dev = DEVICE_DT_GET(ETH_PWR_ENABLE_GPIO_NODE);
+	if (!device_is_ready(cur_dev)) {
+		printk("Ethernet PHY power gpio port is not ready!\n");
 		return -ENODEV;
 	}
 
@@ -39,9 +39,9 @@ static int efm32gg_stk3701a_init(const struct device *dev)
 	gpio_pin_set(cur_dev, ETH_PWR_ENABLE_GPIO_PIN, 1);
 
 	/* Configure ethernet reference clock */
-	cur_dev = device_get_binding(ETH_REF_CLK_GPIO_NAME);
-	if (!cur_dev) {
-		printk("Ethernet reference clock gpio port was not found!\n");
+	cur_dev = DEVICE_DT_GET(ETH_REF_CLK_GPIO_NODE);
+	if (!device_is_ready(cur_dev)) {
+		printk("Ethernet reference clock gpio port is not ready!\n");
 		return -ENODEV;
 	}
 
@@ -57,9 +57,9 @@ static int efm32gg_stk3701a_init(const struct device *dev)
 	CMU->ROUTEPEN  |= CMU_ROUTEPEN_CLKOUT2PEN;
 
 	/* Release the ethernet PHY reset */
-	cur_dev = device_get_binding(ETH_RESET_GPIO_NAME);
-	if (!cur_dev) {
-		printk("Ethernet PHY reset gpio port was not found!\n");
+	cur_dev = DEVICE_DT_GET(ETH_RESET_GPIO_NODE);
+	if (!device_is_ready(cur_dev)) {
+		printk("Ethernet PHY reset gpio port is not ready!\n");
 		return -ENODEV;
 	}
 

--- a/boards/arm/efm32gg_stk3701a/board.h
+++ b/boards/arm/efm32gg_stk3701a/board.h
@@ -9,18 +9,18 @@
 #define __INC_BOARD_H
 
 /* This pin is used to enable the serial port using the board controller */
-#define BC_ENABLE_GPIO_NAME		"GPIO_E"
+#define BC_ENABLE_GPIO_NODE		DT_NODELABEL(gpioe)
 #define BC_ENABLE_GPIO_PIN		1
 
 /* Ethernet specific pins */
 #ifdef CONFIG_ETH_GECKO
-#define ETH_PWR_ENABLE_GPIO_NAME	"GPIO_I"
+#define ETH_PWR_ENABLE_GPIO_NODE	DT_NODELABEL(gpioi)
 #define ETH_PWR_ENABLE_GPIO_PIN		10
 
-#define ETH_RESET_GPIO_NAME		"GPIO_H"
+#define ETH_RESET_GPIO_NODE		DT_NODELABEL(gpioh)
 #define ETH_RESET_GPIO_PIN		7
 
-#define ETH_REF_CLK_GPIO_NAME		"GPIO_D"
+#define ETH_REF_CLK_GPIO_NODE		DT_NODELABEL(gpiod)
 #define ETH_REF_CLK_GPIO_PIN		DT_PROP_BY_IDX(DT_INST(0, silabs_gecko_ethernet), location_rmii_refclk, 2)
 #define ETH_REF_CLK_LOCATION		DT_PROP_BY_IDX(DT_INST(0, silabs_gecko_ethernet), location_rmii_refclk, 0)
 

--- a/boards/arm/efm32hg_slstk3400a/board.c
+++ b/boards/arm/efm32hg_slstk3400a/board.c
@@ -16,10 +16,10 @@ static int efm32hg_slstk3400a_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
-	bce_dev = device_get_binding(BC_ENABLE_GPIO_NAME);
+	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);
 
-	if (!bce_dev) {
-		printk("Board controller gpio port was not found!\n");
+	if (!device_is_ready(bce_dev)) {
+		printk("Board controller gpio port is not ready!\n");
 		return -ENODEV;
 	}
 

--- a/boards/arm/efm32hg_slstk3400a/board.h
+++ b/boards/arm/efm32hg_slstk3400a/board.h
@@ -8,7 +8,7 @@
 #define __INC_BOARD_H
 
 /* This pin is used to enable the serial port using the board controller */
-#define BC_ENABLE_GPIO_NAME  "GPIO_A"
+#define BC_ENABLE_GPIO_NODE  DT_NODELABEL(gpioa)
 #define BC_ENABLE_GPIO_PIN   9
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/efm32pg_stk3401a/board.c
+++ b/boards/arm/efm32pg_stk3401a/board.c
@@ -16,10 +16,10 @@ static int efm32pg_stk3401a_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
-	bce_dev = device_get_binding(BC_ENABLE_GPIO_NAME);
+	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);
 
-	if (!bce_dev) {
-		printk("Board controller gpio port was not found!\n");
+	if (!device_is_ready(bce_dev)) {
+		printk("Board controller gpio port is not ready!\n");
 		return -ENODEV;
 	}
 

--- a/boards/arm/efm32pg_stk3401a/board.h
+++ b/boards/arm/efm32pg_stk3401a/board.h
@@ -8,7 +8,7 @@
 #define __INC_BOARD_H
 
 /* This pin is used to enable the serial port using the board controller */
-#define BC_ENABLE_GPIO_NAME  "GPIO_A"
+#define BC_ENABLE_GPIO_NODE  DT_NODELABEL(gpioa)
 #define BC_ENABLE_GPIO_PIN   5
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/efm32pg_stk3402a/board.c
+++ b/boards/arm/efm32pg_stk3402a/board.c
@@ -16,10 +16,10 @@ static int efm32pg_stk3402a_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
-	bce_dev = device_get_binding(BC_ENABLE_GPIO_NAME);
+	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);
 
-	if (!bce_dev) {
-		printk("Board controller gpio port was not found!\n");
+	if (!device_is_ready(bce_dev)) {
+		printk("Board controller gpio port is not ready!\n");
 		return -ENODEV;
 	}
 

--- a/boards/arm/efm32pg_stk3402a/board.h
+++ b/boards/arm/efm32pg_stk3402a/board.h
@@ -8,7 +8,7 @@
 #define __INC_BOARD_H
 
 /* This pin is used to enable the serial port using the board controller */
-#define BC_ENABLE_GPIO_NAME  "GPIO_A"
+#define BC_ENABLE_GPIO_NODE  DT_NODELABEL(gpioa)
 #define BC_ENABLE_GPIO_PIN   5
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/efm32wg_stk3800/board.c
+++ b/boards/arm/efm32wg_stk3800/board.c
@@ -16,10 +16,10 @@ static int efm32wg_stk3800_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
-	bce_dev = device_get_binding(BC_ENABLE_GPIO_NAME);
+	bce_dev = DEVICE_DT_GET(BC_ENABLE_GPIO_NODE);
 
-	if (!bce_dev) {
-		printk("Board controller gpio port was not found!\n");
+	if (!device_is_ready(bce_dev)) {
+		printk("Board controller gpio port not ready!\n");
 		return -ENODEV;
 	}
 

--- a/boards/arm/efm32wg_stk3800/board.h
+++ b/boards/arm/efm32wg_stk3800/board.h
@@ -8,7 +8,7 @@
 #define __INC_BOARD_H
 
 /* This pin is used to enable the serial port using the board controller */
-#define BC_ENABLE_GPIO_NAME  "GPIO_F"
+#define BC_ENABLE_GPIO_NODE  DT_NODELABEL(gpiof)
 #define BC_ENABLE_GPIO_PIN   7
 
 #endif /* __INC_BOARD_H */

--- a/boards/arm/efr32_radio/board.c
+++ b/boards/arm/efr32_radio/board.c
@@ -10,10 +10,10 @@
 
 /* This pin is used to enable the serial port using the board controller */
 #ifdef CONFIG_BOARD_EFR32_RADIO_BRD4180A
-#define VCOM_ENABLE_GPIO_NAME  "GPIO_D"
+#define VCOM_ENABLE_GPIO_NODE  DT_NODELABEL(gpiod)
 #define VCOM_ENABLE_GPIO_PIN   4
 #else
-#define VCOM_ENABLE_GPIO_NAME  "GPIO_A"
+#define VCOM_ENABLE_GPIO_NODE  DT_NODELABEL(gpioa)
 #define VCOM_ENABLE_GPIO_PIN   5
 #endif /* CONFIG_BOARD_EFR32_RADIO_BRD4180A */
 
@@ -24,9 +24,9 @@ static int efr32_radio_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* Enable the board controller to be able to use the serial port */
-	vce_dev = device_get_binding(VCOM_ENABLE_GPIO_NAME);
-	if (!vce_dev) {
-		printk("Virtual COM Port Enable device was not found!\n");
+	vce_dev = DEVICE_DT_GET(VCOM_ENABLE_GPIO_NODE);
+	if (!device_is_ready(vce_dev)) {
+		printk("Virtual COM Port Enable device is not ready!\n");
 		return -ENODEV;
 	}
 


### PR DESCRIPTION
Convert board to use DEVICE_DT_GET so we don't need "label" prop
in devicetree.

Signed-off-by: Kumar Gala <galak@kernel.org>