### PR TITLE
ztest: Fix logic for listing tests once

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_posix.c
+++ b/subsys/testsuite/ztest/src/ztest_posix.c
@@ -105,17 +105,19 @@ int z_ztest_list_tests(void)
 	struct ztest_suite_node *ptr;
 	struct ztest_unit_test *test = NULL;
 	int test_count = 0;
+	static bool list_once = true;
 
-	for (ptr = _ztest_suite_node_list_start; ptr < _ztest_suite_node_list_end; ++ptr) {
-		test = NULL;
-		while ((test = z_ztest_get_next_test(ptr->name, test)) != NULL) {
-			TC_PRINT("%s::%s\n", test->test_suite_name, test->name);
-			test_count++;
+	if (list_once) {
+		for (ptr = _ztest_suite_node_list_start; ptr < _ztest_suite_node_list_end; ++ptr) {
+			test = NULL;
+			while ((test = z_ztest_get_next_test(ptr->name, test)) != NULL) {
+				TC_PRINT("%s::%s\n", test->test_suite_name, test->name);
+				test_count++;
+			}
 		}
+		list_once = false;
 	}
 
-	/* List tests only once */
-	ztest_set_list_test(false);
 	return test_count;
 }
 


### PR DESCRIPTION
A test case may invoke run_all multiple times, causing
logic for listing tests to run tests on second call.

Signed-off-by: Al Semjonovs <asemjonovs@google.com>