### PR TITLE
soc: ace_v1x: stoping WDT during transiotion to D3

### DIFF
--- a/soc/xtensa/intel_adsp/ace_v1x/include/ace_v1x-regs.h
+++ b/soc/xtensa/intel_adsp/ace_v1x/include/ace_v1x-regs.h
@@ -43,6 +43,9 @@ struct dfdspbrcp {
 #define DFDSPBRCP_BATTR_LPSCTL_L1_MIN_WAY		BIT(15)
 #define DFDSPBRCP_BATTR_LPSCTL_BATTR_SLAVE_CORE	BIT(16)
 
+#define DFDSPBRCP_WDT_RESUME		BIT(8)
+#define DFDSPBRCP_WDT_RESTART_COMMAND	0x76
+
 #define DFDSPBRCP (*(volatile struct dfdspbrcp *)DFDSPBRCP_REG)
 
 /* Low priority interrupt indices */

--- a/soc/xtensa/intel_adsp/ace_v1x/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/multiprocessing.c
@@ -76,6 +76,11 @@ void soc_mp_startup(uint32_t cpu)
 	/* Prevent idle from powering us off */
 	DFDSPBRCP.bootctl[cpu].bctl |=
 		DFDSPBRCP_BCTL_WAITIPCG | DFDSPBRCP_BCTL_WAITIPPG;
+	/* checking if WDT was stopped during D3 transition */
+	if (DFDSPBRCP.bootctl[cpu].wdtcs & DFDSPBRCP_WDT_RESUME) {
+		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESUME;
+		/* TODO: delete this IF when FW starts using imr restore vector */
+	}
 }
 
 void arch_sched_ipi(void)

--- a/soc/xtensa/intel_adsp/ace_v1x/power.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/power.c
@@ -37,6 +37,7 @@ __weak void pm_state_set(enum pm_state state, uint8_t substate_id)
 	if (state == PM_STATE_SOFT_OFF) {
 		uint32_t cpu = arch_proc_id();
 
+		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESTART_COMMAND;
 		DFDSPBRCP.bootctl[cpu].bctl &= ~DFDSPBRCP_BCTL_WAITIPCG;
 		soc_cpus_active[cpu] = false;
 		z_xtensa_cache_flush_inv_all();
@@ -62,6 +63,7 @@ __weak void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	if (state == PM_STATE_SOFT_OFF) {
 		uint32_t cpu = arch_proc_id();
 
+		DFDSPBRCP.bootctl[cpu].wdtcs = DFDSPBRCP_WDT_RESUME;
 		/* TODO: move clock gating prevent to imr restore vector when it will be ready. */
 		DFDSPBRCP.bootctl[cpu].bctl |= DFDSPBRCP_BCTL_WAITIPCG;
 		soc_cpus_active[cpu] = true;


### PR DESCRIPTION
During transition into D3 state, watchdog timer have to be paused. FW can
resume it when core is re-enabled.

Signed-off-by: Tomasz Leman <tomasz.m.leman@intel.com>