### PR TITLE
net: l2: ieee802154: Fix removing short src address filter

### DIFF
--- a/subsys/net/l2/ieee802154/ieee802154_utils.h
+++ b/subsys/net/l2/ieee802154/ieee802154_utils.h
@@ -234,7 +234,7 @@ static inline void ieee802154_remove_src_short_addr(struct net_if *iface,
 
 		filter.short_addr = short_addr;
 
-		if (radio->filter(net_if_get_device(iface), true,
+		if (radio->filter(net_if_get_device(iface), false,
 				  IEEE802154_FILTER_TYPE_SRC_SHORT_ADDR,
 				  &filter) != 0) {
 			NET_WARN("Could not remove SRC short address filter");


### PR DESCRIPTION
Driver function was called with wrong parameter (`true` instead of `false`), which resulted in filter being added instead of being removed

Signed-off-by: Tomislav Milkovic <milkovic@byte-lab.com>