### PR TITLE
twister: Don't run coverage report when --build-only is used

### DIFF
--- a/scripts/twister
+++ b/scripts/twister
@@ -377,7 +377,10 @@ def main():
     report.summary(runner.results, options.disable_unrecognized_section_test, duration)
 
     if options.coverage:
-        run_coverage(tplan, options)
+        if not options.build_only:
+            run_coverage(tplan, options)
+        else:
+            logger.info("Skipping coverage report generation due to --build-only.")
 
     if options.device_testing and not options.build_only:
         hwm.summary(tplan.selected_platforms)


### PR DESCRIPTION
When doing a split build and test with coverage enabled, (i.e.
`twister --coverage --build-only` followed by
`twister --coverage --test-only`), Twister attempts to run coverage
reports immediately after building, which fails because tests
haven't actually run yet and causes several error messages to print
in to the log.

This change causes twister to skip the call to `run_coverage()` if
`--build-only` is set and print an info message. This suppresses the
error messages from the coverage report tool complaining about missing
coverage files, but still instruments the built code for coverage data
collection. When twister is invoked again, but with `--test-only`
instead, the coverage files will be emitted and the reports
successfully generated.

 #### Testing

I ran...

```
$ zephyr/scripts/twister -T zephyr/tests/lib/cmsis_dsp/basicmath/
--coverage -p native_posix --build-only
$ zephyr/scripts/twister -T zephyr/tests/lib/cmsis_dsp/basicmath/
--coverage -p native_posix --test-only
```

... followed by a combined build and test ...

```
$ zephyr/scripts/twister -T zephyr/tests/lib/cmsis_dsp/basicmath/
--coverage -p native_posix
```

... as a control and diffed the HTML coverage reports, which were
identical other than a timestamp.