### PR TITLE
drivers: ieee802154: rf2xx: Move power table to devicetree and add Sub-Giga support

### DIFF
--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -160,6 +160,14 @@
 		slptr-gpios = <&porta 20 GPIO_ACTIVE_HIGH>;
 		dig2-gpios = <&portb 17 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		status = "okay";
+		tx-pwr-min = [01 11];	/* -17.0 dBm */
+		tx-pwr-max = [00 04];	/*   4.0 dBm */
+		tx-pwr-table = [00 01 03 04 05 05 06 06
+				07 07 07 08 08 09 09 0a
+				0a 0a 0b 0b 0b 0b 0c 0c
+				0c 0c 0d 0d 0d 0d 0d 0d
+				0d 0d 0e 0e 0e 0e 0e 0e
+				0e 0e 0e 0e 0e 0e 0f 0f];
 	};
 };
 

--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -85,6 +85,11 @@ struct rf2xx_config {
 
 	uint8_t inst;
 	uint8_t has_mac;
+
+	uint8_t const *tx_pwr_table;
+	uint8_t tx_pwr_table_size;
+	int8_t tx_pwr_min[2];
+	int8_t tx_pwr_max[2];
 };
 
 struct rf2xx_context {

--- a/drivers/ieee802154/ieee802154_rf2xx.h
+++ b/drivers/ieee802154/ieee802154_rf2xx.h
@@ -74,6 +74,12 @@ enum rf2xx_trx_model_t {
 	RF2XX_TRX_MODEL_233     = 0x0B,
 };
 
+enum rf2xx_trx_channel_page_t {
+	RF2XX_TRX_CC_PAGE_0     = 0x00,
+	RF2XX_TRX_CC_PAGE_2     = 0x02,
+	RF2XX_TRX_CC_PAGE_5     = 0x05,
+};
+
 struct rf2xx_config {
 	struct gpio_dt_spec irq_gpio;
 	struct gpio_dt_spec reset_gpio;
@@ -106,6 +112,7 @@ struct rf2xx_context {
 	struct k_sem trx_tx_sync;
 
 	enum rf2xx_trx_model_t trx_model;
+	enum rf2xx_trx_channel_page_t cc_page;
 	enum rf2xx_trx_state_trac_t trx_trac;
 
 	enum ieee802154_tx_mode tx_mode;

--- a/drivers/ieee802154/ieee802154_rf2xx_regs.h
+++ b/drivers/ieee802154/ieee802154_rf2xx_regs.h
@@ -24,6 +24,12 @@
 #define RF2XX_MAX_PSDU_LENGTH               127
 #define RX2XX_MAX_FRAME_SIZE                132
 
+#define RF2XX_RSSI_BPSK_20                  -100
+#define RF2XX_RSSI_BPSK_40                  -99
+#define RF2XX_RSSI_OQPSK_SIN_RC_100         -98
+#define RF2XX_RSSI_OQPSK_SIN_250            -97
+#define RF2XX_RSSI_OQPSK_RC_250             -97
+
 /*- Types ------------------------------------------------------------------*/
 #define RF2XX_TRX_STATUS_REG                0x01
 #define RF2XX_TRX_STATE_REG                 0x02
@@ -148,6 +154,12 @@
 #define RF2XX_BPSK_OQPSK                    3
 #define RF2XX_SUB_MODE                      2
 #define RF2XX_OQPSK_DATA_RATE               0
+#define RF2XX_SUB_CHANNEL_MASK              0x3F
+#define RF2XX_CC_BPSK_20                    0x00
+#define RF2XX_CC_BPSK_40                    0x04
+#define RF2XX_CC_OQPSK_SIN_RC_100           0x08
+#define RF2XX_CC_OQPSK_SIN_250              0x0C
+#define RF2XX_CC_OQPSK_RC_250               0x1C
 
 /* ANT_DIV */
 #define RF2XX_ANT_SEL                       7
@@ -201,6 +213,7 @@
 #define RF2XX_PA_CHIP_LT                    6
 #define RF2XX_F_SHIFT_MODE                  2
 #define RF2XX_GC_TX_OFFS                    0
+#define RF2XX_GC_TX_OFFS_MASK               3
 
 /* XAH_CTRL_1 */
 #define RF2XX_ARET_TX_TS_EN                 7

--- a/dts/bindings/ieee802154/atmel,rf2xx.yaml
+++ b/dts/bindings/ieee802154/atmel,rf2xx.yaml
@@ -38,3 +38,75 @@ properties:
       description: |
         Specifies the MAC address that was assigned to the network
         device
+
+    tx-pwr-table:
+      type: uint8-array
+      default: [ 0x00 ]
+      description: |
+        This is the Transmission Power Mapping Table array used to comply with
+        local regulations. By default this value set an output power above 0dBm
+        for all transceivers. This property must be used with tx-pwr-min and
+        tx-pwr-max for normal operations. The number of elements is defined by
+        the size of the tx-pwr-table array property. The max entry value for
+        2.4GHz is 0x0f and 0xff for Sub-Giga. See PHY_TX_PWR at datasheet for
+        more details.
+
+        The output power is determined by following formula:
+
+          linear_step = (tx-pwr-max - tx-pwr-min)
+                      / (sizeof(tx-pwr-table) - 1.0);
+          table_index = abs((value_in_dbm - tx-pwr-max) / linear_step);
+          output_power = tx-pwr-table[table_index];
+
+        Using AT86RF233 as example without external PA. By the datasheet the
+        tx-pwr-min = -17 dBm and tx-pwr-max = +4 dBm. Using 48 elements in the
+        tx-pwr-table array. The table array is filled from higher to lower power.
+
+          tx-pwr-min = [01 11];	/* -17.0 dBm */
+          tx-pwr-max = [00 04];	/*   4.0 dBm */
+          tx-pwr-table = [00 01 03 04 05 05 06 06
+                          07 07 07 08 08 09 09 0a
+                          0a 0a 0b 0b 0b 0b 0c 0c
+                          0c 0c 0d 0d 0d 0d 0d 0d
+                          0d 0d 0e 0e 0e 0e 0e 0e
+                          0e 0e 0e 0e 0e 0e 0f 0f];
+
+        The values in the table are filled based on table 9-9 [ TX Output Power ]
+        using the linear step in dBm as:
+
+          linear_step = (4 - (-17)) / (48 - 1) => ~0.45 dBm
+
+        Assuming that user wants set 0 dBm as output power:
+
+          table_index = abs((0 - 4) / 0.45) => 8.95 ( round to 9 )
+          output_power = tx-pwr-table[9] => 0x07 ( 0 dBm as table 9-9 )
+
+        Note when tx-pwr-min is [ 0x00, 0x00 ] and tx-pwr-max is [ 0x00, 0x00 ]
+        the linear step is zero. This means that table_index will be always the
+        first element of the tx-pwr-table array, which is 0x00 by default. This
+        is defined as general case when user not define any tx-pwr-* entries. It
+        sets the transceiver to use always a value above 0 dBm as output power.
+
+    tx-pwr-min:
+      type: uint8-array
+      default: [ 0x00, 0x00 ]
+      description: |
+        This value represent minimum normalized value in dBm for the transceiver
+        output power. This property must be used when tx-pwr-table is defined.
+        The value is represented by two entries where first element represents
+        the signal indication [ 0x00-positive, 0x01-negative] and second element
+        is the minimal value in dBm for the transceiver output power. By default,
+        the combination of tx-pwr-min as [ 0x00, 0x00 ] and tx-pwr-max as [ 0x00,
+        0x00 ] will create a fixed transmission power.
+
+    tx-pwr-max:
+      type: uint8-array
+      default: [ 0x00, 0x00 ]
+      description: |
+        This value represent maximum normalized value in dBm for the transceiver
+        output power. This property must be used when tx-pwr-table is defined.
+        The value is represented by two entries where first element represents
+        the signal indication [ 0x00-positive ] and second element is the maximum
+        value in dBm for the transceiver output power. By default, the
+        combination of tx-pwr-max as [ 0x00, 0x00 ] and tx-pwr-min as [ 0x00,
+        0x00 ] will create a fixed transmission power.

--- a/dts/bindings/ieee802154/atmel,rf2xx.yaml
+++ b/dts/bindings/ieee802154/atmel,rf2xx.yaml
@@ -39,6 +39,23 @@ properties:
         Specifies the MAC address that was assigned to the network
         device
 
+    channel-page:
+      type: int
+      enum:
+        - 0
+        - 2
+        - 5
+      description: |
+        Selects Channel Page accordingly with IEEE 802.15.4 standard. The Page 0
+        is used in both Sub-Giga and 2.4GHz. It allows select channels 0-10 in
+        Sub-Giga band (0: BPSK-20, 1-10: BPSK-40) and 11-26 in 2.4GHz band
+        (11-26: O-QPSK-250). Channel 2 is for Sub-Giga and selects
+        (0: OQPSK-SIN-RC-100, 1-10: OQPSK-SIN-250). Channel 5 is for Sub-Giga
+        (JAPAN) and selects (0-3: OQPSK-RC-250) .
+          0: Page 0 - BPSK-20 [0], BPSK-40 [1-10], O-QPSK-250 [11-26].
+          2: Page 2 - OQPSK-SIN-RC-100 [0], OQPSK-SIN-250 [1-10].
+          5: Page 5 - OQPSK-RC-250 [0-3].
+
     tx-pwr-table:
       type: uint8-array
       default: [ 0x00 ]


### PR DESCRIPTION
The current version of power table is hardcoded in the driver which is a problem when use devices in production. This change remove all hardcode from driver and re-implement the feature to allow people create a table which is defined in devicetree. The big advantage is that each board can define their own table based on lab tests and allows use of FEM devices inclusive.

In addition, add support to at86rf212[b] sub-giga devices. This work enables use of pages 0, 2 and 5 in accordance with IEEE-802.15.4/2003/2006/2011. The proprietary speeds can be object of future work.

CC: @markus-becker-tridonic-com @maxmclau

How to build and test with AVR-RZ600 modules on Atmel Boards

```
west build -b sam4e_xpro samples/net/sockets/echo_client -- -DSHIELD=atmel_rf2xx_legacy -DOVERLAY_CONFIG=overlay-802154-subg.conf
west build -b sam4s_xplained samples/net/sockets/echo_server -- -DSHIELD=atmel_rf2xx_xplained -DOVERLAY_CONFIG=overlay-802154-subg.conf
```

Note: Ethernet/MDIO drivers should be disabled at SAM4E-XPRO