### PR TITLE
dts: riscv: define riscv,machine-timer

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -3,11 +3,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
+
+#define DT_DRV_COMPAT riscv_machine_timer
+
 #include <zephyr/device.h>
+#include <zephyr/devicetree.h>
 #include <zephyr/drivers/timer/system_timer.h>
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
-#include <soc.h>
 
 #define CYC_PER_TICK ((uint32_t)((uint64_t) (sys_clock_hw_cycles_per_sec()			 \
 					     >> CONFIG_RISCV_MACHINE_TIMER_SYSTEM_CLOCK_DIVIDER) \
@@ -18,10 +21,13 @@
 
 #define TICKLESS IS_ENABLED(CONFIG_TICKLESS_KERNEL)
 
+#define RISCV_MTIME_BASE      DT_INST_REG_ADDR_BY_NAME(0, mtime)
+#define RISCV_MTIMECMP_BASE   DT_INST_REG_ADDR_BY_NAME(0, mtimecmp)
+
 static struct k_spinlock lock;
 static uint64_t last_count;
 #if defined(CONFIG_TEST)
-const int32_t z_sys_timer_irq_for_test = RISCV_MACHINE_TIMER_IRQ;
+const int32_t z_sys_timer_irq_for_test = DT_INST_IRQN(0);
 #endif
 
 static uint64_t get_hart_mtimecmp(void)
@@ -156,10 +162,11 @@ static int sys_clock_driver_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
 
-	IRQ_CONNECT(RISCV_MACHINE_TIMER_IRQ, 0, timer_isr, NULL, 0);
+	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority), timer_isr,
+		    NULL, 0);
 	last_count = mtime();
 	set_mtimecmp(last_count + CYC_PER_TICK);
-	irq_enable(RISCV_MACHINE_TIMER_IRQ);
+	irq_enable(DT_INST_IRQN(0));
 	return 0;
 }
 
@@ -167,7 +174,7 @@ static int sys_clock_driver_init(const struct device *dev)
 void smp_timer_init(void)
 {
 	set_mtimecmp(last_count + CYC_PER_TICK);
-	irq_enable(RISCV_MACHINE_TIMER_IRQ);
+	irq_enable(DT_INST_IRQN(0));
 }
 #endif
 

--- a/dts/bindings/timer/riscv,machine-timer.yaml
+++ b/dts/bindings/timer/riscv,machine-timer.yaml
@@ -1,13 +1,39 @@
 # Copyright (c) 2021 TOKITA Hiroshi <tokita.hiroshi@gmail.com>
 # SPDX-License-Identifier: Apache-2.0
 
-description: RISC-V Machine timer
+description: |
+  RISC-V Machine Timer
+
+  Privilege platforms provide a real-time counter, exposed as a 64-bit
+  memory-mapped machine-mode register named mtime. Another 64-bit register,
+  timer compare register (mtimecmp), causes a timer interrupt when the mtime
+  register contains a value greater than or equal to the value in the mtimecmp
+  register.
+
+  Example usage:
+
+    mtimer: timer@abcd1230 {
+      compatible = "riscv,machine-timer";
+      reg = <0xabcd1230 0x8,
+             0xabcd1238 0x8>;
+      reg-names = "mtime", "mtimecmp";
+      interrupts = <7 0>;
+    };
 
 compatible: "riscv,machine-timer"
 
 include: base.yaml
 
 properties:
+    reg:
+      required: true
+
+    reg-names:
+      required: true
+
+    interrupts:
+      required: true
+
     clk-divider:
       type: int
       required: false

--- a/dts/riscv/andes/andes_v5_ae350.dtsi
+++ b/dts/riscv/andes/andes_v5_ae350.dtsi
@@ -98,6 +98,15 @@
 		compatible = "andestech,ae350";
 		ranges;
 
+		mtimer: timer@e6000000 {
+			compatible = "riscv,machine-timer";
+			reg = <0xe6000000 0x8
+			       0xe6000008 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic0>;
+		};
+
 		plic0: interrupt-controller@e4000000 {
 			compatible = "sifive,plic-1.0.0";
 			#address-cells = <1>;

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -41,6 +41,7 @@
 			compatible = "riscv,machine-timer";
 			reg = <0xd1000000 0x8
 			       0xd1000008 0x8>;
+			reg-names = "mtime", "mtimecmp";
 			clk-divider = <RISCV_MACHINE_TIMER_DIVIDER_4>;
 		};
 

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -42,6 +42,8 @@
 			reg = <0xd1000000 0x8
 			       0xd1000008 0x8>;
 			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&eclic>;
 			clk-divider = <RISCV_MACHINE_TIMER_DIVIDER_4>;
 		};
 

--- a/dts/riscv/gigadevice/gd32vf103.dtsi
+++ b/dts/riscv/gigadevice/gd32vf103.dtsi
@@ -39,8 +39,8 @@
 
 		mtimer: machine-timer@d1000000 {
 			compatible = "riscv,machine-timer";
-			reg = <0xd1000000 0x1
-			       0xd1000008 0x1>;
+			reg = <0xd1000000 0x8
+			       0xd1000008 0x8>;
 			clk-divider = <RISCV_MACHINE_TIMER_DIVIDER_4>;
 		};
 

--- a/dts/riscv/microsemi/microsemi-miv.dtsi
+++ b/dts/riscv/microsemi/microsemi-miv.dtsi
@@ -42,6 +42,15 @@
 			reg = <0x80040000 0x40000>;
 		};
 
+		mtimer: timer@4400bff8 {
+			compatible = "riscv,machine-timer";
+			reg = <0x4400bff8 0x8
+			       0x44004000 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic>;
+		};
+
 		plic: interrupt-controller@40000000 {
 			compatible = "sifive,plic-1.0.0";
 			#address-cells = <0>;

--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -56,6 +56,15 @@
 			reg = <0x80000000 0x800000>;
 		};
 
+		mtimer: timer@0200bff8 {
+			compatible = "riscv,machine-timer";
+			reg = <0x0200bff8 0x8
+			       0x02004000 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic>;
+		};
+
 		plic: interrupt-controller@c000000 {
 			compatible = "sifive,plic-1.0.0";
 			#interrupt-cells = <2>;

--- a/dts/riscv/neorv32.dtsi
+++ b/dts/riscv/neorv32.dtsi
@@ -63,6 +63,14 @@
 		#size-cells = <1>;
 		ranges;
 
+		mtimer: timer@ffffff90 {
+			compatible = "riscv,machine-timer";
+			reg = <0xffffff90 0x8
+			       0xffffff98 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7>;
+		};
+
 		uart0: serial@ffffffa0 {
 			compatible = "neorv32-uart";
 			status = "disabled";

--- a/dts/riscv/sifive/riscv32-fe310.dtsi
+++ b/dts/riscv/sifive/riscv32-fe310.dtsi
@@ -46,6 +46,16 @@
 		compatible = "sifive,FE310G-0002-Z0-soc", "fe310-soc",
 			"sifive-soc", "simple-bus";
 		ranges;
+
+		mtimer: timer@0200bff8 {
+			compatible = "riscv,machine-timer";
+			reg = <0x0200bff8 0x8
+			       0x02004000 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic>;
+		};
+
 		wdog0: wdog@10000000 {
 			compatible = "sifive,wdt";
 			interrupt-parent = <&plic>;

--- a/dts/riscv/sifive/riscv64-fu540.dtsi
+++ b/dts/riscv/sifive/riscv64-fu540.dtsi
@@ -54,6 +54,15 @@
 		compatible = "simple-bus";
 		ranges;
 
+		mtimer: timer@0200bff8 {
+			compatible = "riscv,machine-timer";
+			reg = <0x0200bff8 0x8
+			       0x02004000 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic>;
+		};
+
 		modeselect: rom@1000 {
 			compatible = "sifive,modeselect0";
 			reg = <0x1000 0x1000>;

--- a/dts/riscv/sifive/riscv64-fu740.dtsi
+++ b/dts/riscv/sifive/riscv64-fu740.dtsi
@@ -53,6 +53,15 @@
 		compatible = "simple-bus";
 		ranges;
 
+		mtimer: timer@0200bff8 {
+			compatible = "riscv,machine-timer";
+			reg = <0x0200bff8 0x8
+			       0x02004000 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic>;
+		};
+
 		modeselect: rom@1000 {
 			compatible = "sifive,modeselect0";
 			reg = <0x1000 0x1000>;

--- a/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
+++ b/dts/riscv/starfive/starfive_jh7100_beagle_v.dtsi
@@ -89,6 +89,15 @@
 		compatible = "starfive,freedom-u74-arty", "simple-bus";
 		ranges;
 
+		mtimer: timer@0200bff8 {
+			compatible = "riscv,machine-timer";
+			reg = <0x0 0x0200bff8 0x0 0x8
+			       0x0 0x02004000 0x0 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic>;
+		};
+
 		cachectrl: cache-controller@2010000 {
 			cache-block-size = <64>;
 			cache-level = <2>;

--- a/dts/riscv/telink/telink_b91.dtsi
+++ b/dts/riscv/telink/telink_b91.dtsi
@@ -40,6 +40,15 @@
 			compatible = "mmio-sram";
 		};
 
+		mtimer: timer@e6000000 {
+			compatible = "riscv,machine-timer";
+			reg = <0xe6000000 0x8
+			       0xe6000008 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic0>;
+		};
+
 		flash_mspi: flash-controller@80140100 {
 			compatible = "telink,b91-flash-controller";
 			reg = <0x80140100 0x40>;

--- a/dts/riscv/virt.dtsi
+++ b/dts/riscv/virt.dtsi
@@ -162,6 +162,15 @@
 		compatible = "simple-bus";
 		ranges;
 
+		mtimer: timer@0200bff8 {
+			compatible = "riscv,machine-timer";
+			reg = <0x0200bff8 0x8
+			       0x02004000 0x8>;
+			reg-names = "mtime", "mtimecmp";
+			interrupts = <7 0>;
+			interrupt-parent = <&plic>;
+		};
+
 		plic: interrupt-controller@c000000 {
 			riscv,max-priority = <7>;
 			riscv,ndev = < 0x35 >;

--- a/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
+++ b/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
@@ -13,10 +13,6 @@
 
 #include <soc_common.h>
 
-/* Machine timer memory-mapped registers */
-#define RISCV_MTIME_BASE             0xE6000000
-#define RISCV_MTIMECMP_BASE          0xE6000008
-
 /* lib-c hooks required RAM defined variables */
 #define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
 #define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)

--- a/soc/riscv/riscv-privilege/common/soc_common.h
+++ b/soc/riscv/riscv-privilege/common/soc_common.h
@@ -14,7 +14,6 @@
 
 /* IRQ numbers */
 #define RISCV_MACHINE_SOFT_IRQ       3  /* Machine Software Interrupt */
-#define RISCV_MACHINE_TIMER_IRQ      7  /* Machine Timer Interrupt */
 #define RISCV_MACHINE_EXT_IRQ        11 /* Machine External Interrupt */
 
 /* ECALL Exception numbers */

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.h
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.h
@@ -12,11 +12,6 @@
 #define RISCV_GD32VF103_SOC_H_
 
 #include <soc_common.h>
-#include <zephyr/devicetree.h>
-
-/* Timer configuration */
-#define RISCV_MTIME_BASE      DT_REG_ADDR_BY_IDX(DT_NODELABEL(mtimer), 0)
-#define RISCV_MTIMECMP_BASE   DT_REG_ADDR_BY_IDX(DT_NODELABEL(mtimer), 1)
 
 #ifndef _ASMLANGUAGE
 #include <zephyr/toolchain.h>

--- a/soc/riscv/riscv-privilege/miv/soc.h
+++ b/soc/riscv/riscv-privilege/miv/soc.h
@@ -49,10 +49,6 @@
 /* Clock controller. */
 #define PRCI_BASE_ADDR               0x44000000
 
-/* Timer configuration */
-#define RISCV_MTIME_BASE             0x4400bff8
-#define RISCV_MTIMECMP_BASE          0x44004000
-
 /* lib-c hooks required RAM defined variables */
 #define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
 #define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)

--- a/soc/riscv/riscv-privilege/mpfs/soc.h
+++ b/soc/riscv/riscv-privilege/mpfs/soc.h
@@ -11,8 +11,6 @@
 
 
 /* Timer configuration */
-#define RISCV_MTIME_BASE				0x0200BFF8ULL
-#define RISCV_MTIMECMP_BASE				(0x02004000ULL + (8ULL * 0))
 #define RISCV_MTIMECMP_BY_HART(h)		(0x02004000ULL + (8ULL * (h)))
 #define RISCV_MSIP_BASE					0x02000000
 

--- a/soc/riscv/riscv-privilege/mpfs/soc.h
+++ b/soc/riscv/riscv-privilege/mpfs/soc.h
@@ -10,8 +10,6 @@
 #include <zephyr/devicetree.h>
 
 
-/* Timer configuration */
-#define RISCV_MTIMECMP_BY_HART(h)		(0x02004000ULL + (8ULL * (h)))
 #define RISCV_MSIP_BASE					0x02000000
 
 /* lib-c hooks required RAM defined variables */

--- a/soc/riscv/riscv-privilege/neorv32/soc.h
+++ b/soc/riscv/riscv-privilege/neorv32/soc.h
@@ -9,10 +9,6 @@
 
 #include <soc_common.h>
 
-/* Machine System Timer (MTIME) registers */
-#define RISCV_MTIME_BASE    0xffffff90U
-#define RISCV_MTIMECMP_BASE 0xffffff98U
-
 /* System information (SYSINFO) register offsets */
 #define NEORV32_SYSINFO_CLK         0x00U
 #define NEORV32_SYSINFO_CPU         0x04U

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -64,10 +64,6 @@
 
 #endif
 
-/* Timer configuration */
-#define RISCV_MTIME_BASE             0x0200BFF8
-#define RISCV_MTIMECMP_BASE          0x02004000
-
 /* lib-c hooks required RAM defined variables */
 #define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
 #define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)

--- a/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h
+++ b/soc/riscv/riscv-privilege/starfive_jh71xx/soc.h
@@ -9,7 +9,4 @@
 
 #include <soc_common.h>
 
-#define RISCV_MTIME_BASE 0x0200BFF8
-#define RISCV_MTIMECMP_BASE 0x02004000
-
 #endif

--- a/soc/riscv/riscv-privilege/telink_b91/soc.h
+++ b/soc/riscv/riscv-privilege/telink_b91/soc.h
@@ -9,8 +9,4 @@
 
 #include <soc_common.h>
 
-/* Machine timer memory-mapped registers */
-#define RISCV_MTIME_BASE             0xE6000000
-#define RISCV_MTIMECMP_BASE          0xE6000008
-
 #endif /* RISCV_TELINK_B91_SOC_H */

--- a/soc/riscv/riscv-privilege/virt/soc.h
+++ b/soc/riscv/riscv-privilege/virt/soc.h
@@ -10,8 +10,6 @@
 #include <soc_common.h>
 
 #define SIFIVE_SYSCON_TEST           0x00100000
-#define RISCV_MTIME_BASE             0x0200BFF8
-#define RISCV_MTIMECMP_BASE          0x02004000
 #define RISCV_MSIP_BASE              0x02000000
 
 #endif


### PR DESCRIPTION
All RISC-V platforms with machine timer, except GigaDevice, define its
base address in soc.h. Nowadays we have Devicetree to describe hardware,
so it needs to be used when appropriate. This patch defines the machine
timer for all platforms that define RISCV_MTIME_BASE and
RISCV_MTIMECMP_BASE in soc.h, re-using the same base addresses.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>