### PR TITLE
soc: riscv: remove unused RISCV_RAM_BASE|SIZE definitions

### DIFF
--- a/soc/riscv/litex-vexriscv/soc.h
+++ b/soc/riscv/litex-vexriscv/soc.h
@@ -11,10 +11,6 @@
 #include <zephyr/devicetree.h>
 #include <zephyr/arch/common/sys_io.h>
 
-/* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE              DT_REG_ADDR(DT_INST(0, mmio_sram))
-#define RISCV_RAM_SIZE              DT_REG_SIZE(DT_INST(0, mmio_sram))
-
 #ifndef _ASMLANGUAGE
 /* CSR access helpers */
 

--- a/soc/riscv/openisa_rv32m1/soc.h
+++ b/soc/riscv/openisa_rv32m1/soc.h
@@ -104,10 +104,6 @@ void soc_interrupt_init(void);
 #include "soc_zero_riscy.h"
 #endif
 
-/* Newlib hooks (and potentially other things) use these defines. */
-#define RISCV_RAM_SIZE KB(CONFIG_SRAM_SIZE)
-#define RISCV_RAM_BASE CONFIG_SRAM_BASE_ADDRESS
-
 /* helper macro to convert from a DT_INST to HAL clock_ip_name */
 #define INST_DT_CLOCK_IP_NAME(n) \
 	MAKE_PCC_REGADDR(DT_REG_ADDR(DT_INST_PHANDLE(n, clocks)), \

--- a/soc/riscv/riscv-ite/it8xxx2/soc.h
+++ b/soc/riscv/riscv-ite/it8xxx2/soc.h
@@ -8,10 +8,6 @@
  */
 #include <soc_common.h>
 
-/* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
-#define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)
-
 /*
  * This define gets the total number of USBPD ports available on the
  * ITE EC chip from dtsi (include status disable). Both it81202 and

--- a/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
+++ b/soc/riscv/riscv-privilege/andes_v5/ae350/soc.h
@@ -17,10 +17,6 @@
 #define RISCV_MTIME_BASE             0xE6000000
 #define RISCV_MTIMECMP_BASE          0xE6000008
 
-/* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
-#define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)
-
 /* Include CSRs available for Andes V5 SoCs */
 #include "soc_v5.h"
 

--- a/soc/riscv/riscv-privilege/miv/soc.h
+++ b/soc/riscv/riscv-privilege/miv/soc.h
@@ -53,8 +53,4 @@
 #define RISCV_MTIME_BASE             0x4400bff8
 #define RISCV_MTIMECMP_BASE          0x44004000
 
-/* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
-#define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)
-
 #endif /* __RISCV32_MIV_SOC_H_ */

--- a/soc/riscv/riscv-privilege/mpfs/soc.h
+++ b/soc/riscv/riscv-privilege/mpfs/soc.h
@@ -16,8 +16,4 @@
 #define RISCV_MTIMECMP_BY_HART(h)		(0x02004000ULL + (8ULL * (h)))
 #define RISCV_MSIP_BASE					0x02000000
 
-/* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE					CONFIG_SRAM_BASE_ADDRESS
-#define RISCV_RAM_SIZE					KB(CONFIG_SRAM_SIZE)
-
 #endif /* __RISCV64_MPFS_SOC_H_ */

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -68,8 +68,4 @@
 #define RISCV_MTIME_BASE             0x0200BFF8
 #define RISCV_MTIMECMP_BASE          0x02004000
 
-/* lib-c hooks required RAM defined variables */
-#define RISCV_RAM_BASE               CONFIG_SRAM_BASE_ADDRESS
-#define RISCV_RAM_SIZE               KB(CONFIG_SRAM_SIZE)
-
 #endif /* __RISCV_SIFIVE_FREEDOM_SOC_H_ */


### PR DESCRIPTION
The definitions are not used anywhere in Zephyr nor in modules, so
delete them.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>