### PR TITLE
pinctrl: remove Kconfig.defconfig setting of pinctrl drivers

### DIFF
--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.series
@@ -12,10 +12,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 128
 
-config PINCTRL_IMX
-	default y if HAS_IMX_IOMUXC
-	depends on PINCTRL
-
 source "soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4"
 
 endif # SOC_SERIES_IMX_6X_M4

--- a/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.series
@@ -12,10 +12,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 127
 
-config PINCTRL_IMX
-	default y if HAS_IMX_IOMUXC
-	depends on PINCTRL
-
 source "soc/arm/nxp_imx/mcimx7_m4/Kconfig.defconfig.mcimx7_m4"
 
 endif # SOC_SERIES_IMX7_M4

--- a/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.series
@@ -13,10 +13,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 159
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 source "soc/arm/nxp_imx/mimx8ml8_m7/Kconfig.defconfig.mimx8ml8_m7"
 
 endif # SOC_SERIES_IMX8ML_M7

--- a/soc/arm/nxp_imx/mimx8mm6_m4/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/mimx8mm6_m4/Kconfig.defconfig.series
@@ -13,10 +13,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 127
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 source "soc/arm/nxp_imx/mimx8mm6_m4/Kconfig.defconfig.mimx8mm6_m4"
 
 endif # SOC_SERIES_IMX8MM_M4

--- a/soc/arm/nxp_imx/mimx8mq6_m4/Kconfig.defconfig.mimx8mq6_m4
+++ b/soc/arm/nxp_imx/mimx8mq6_m4/Kconfig.defconfig.mimx8mq6_m4
@@ -27,8 +27,4 @@ config PINMUX_MCUX
 
 endif # PINMUX
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 endif # SOC_MIMX8MQ6

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -28,10 +28,6 @@ config DISPLAY_MCUX_ELCDIF
 	default y if HAS_MCUX_ELCDIF
 	depends on DISPLAY
 
-config PINCTRL_IMX
-	default y if HAS_MCUX_IOMUXC
-	depends on PINCTRL
-
 config ENTROPY_MCUX_TRNG
 	default y if HAS_MCUX_TRNG
 	depends on ENTROPY_GENERATOR


### PR DESCRIPTION
Now that pinctrl drivers are enabled based on devicetree
we need to remove any cases of them getting enabled by
Kconfig.defconfig* files as this can lead to errors.

Typically the Kconfig.defconfig* will blindly enable a
sensor and not respect the devicetree state of the pinctrl.
Additionally we can get problems with prj.conf/defconfig
getting incorrectly overridden.

Signed-off-by: Kumar Gala <galak@kernel.org>