### PR TITLE
samples: Add missing sample.yaml

### DIFF
--- a/samples/boards/nrf/nrf53_sync_rtc/net/sample.yaml
+++ b/samples/boards/nrf/nrf53_sync_rtc/net/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+    description: This app shows how RTCs are synchronized
+        on nrf53 cores.
+    name: nRF53 Synchronized RTC sample (net)
+common:
+    harness: remote
+tests:
+    sample.boards.nrf.nrf53_sync_rtc:
+        platform_allow: nrf5340dk_nrf5340_cpunet
+        integration_platforms:
+          - nrf5340dk_nrf5340_cpunet
+    sample.boards.nrf.nrf53_sync_rtc_mbox:
+        platform_allow: nrf5340dk_nrf5340_cpunet
+        integration_platforms:
+          - nrf5340dk_nrf5340_cpunet
+        extra_args: OVERLAY_CONFIG="boards/nrf5340dk_nrf5340_cpunet_mbox.conf"

--- a/samples/boards/nrf/nrf53_sync_rtc/sample.yaml
+++ b/samples/boards/nrf/nrf53_sync_rtc/sample.yaml
@@ -2,16 +2,16 @@ sample:
     description: This app shows how RTCs are synchronized
         on nrf53 cores.
     name: nRF53 Synchronized RTC sample
+common:
+    harness: remote
 tests:
     sample.boards.nrf.nrf53_sync_rtc:
         platform_allow: nrf5340dk_nrf5340_cpuapp
         integration_platforms:
           - nrf5340dk_nrf5340_cpuapp
-        build_only: true
     sample.boards.nrf.nrf53_sync_rtc_mbox:
         platform_allow: nrf5340dk_nrf5340_cpuapp
         integration_platforms:
           - nrf5340dk_nrf5340_cpuapp
-        build_only: true
         extra_args: OVERLAY_CONFIG="boards/nrf5340dk_nrf5340_cpuapp_mbox.conf"
           NET_OVERLAY_CONF="boards/nrf5340dk_nrf5340_cpunet_mbox.conf"

--- a/samples/drivers/ipm/ipm_mcux/remote/sample.yaml
+++ b/samples/drivers/ipm/ipm_mcux/remote/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+    description: Sample app that sends messages between the two cores on
+        the lpcxpresso54114 using a mailbox.
+    name: IPM MCUX Mailbox Sample
+tests:
+    sample.ipm.ipm_mcux:
+        platform_allow: lpcxpresso54114_m0 lpcxpresso55s69_cpu1
+        tags: ipm
+        harness: remote

--- a/samples/subsys/ipc/openamp/remote/sample.yaml
+++ b/samples/subsys/ipc/openamp/remote/sample.yaml
@@ -1,0 +1,9 @@
+sample:
+    description: This app provides an example of how to integrate OpenAMP
+        with Zephyr.
+    name: OpenAMP example integration (remote)
+tests:
+    sample.ipc.openamp.remote:
+        platform_allow: lpcxpresso54114_m0 lpcxpresso55s69_cpu1
+        tags: ipm
+        harness: remote

--- a/samples/subsys/ipc/rpmsg_service/remote/sample.yaml
+++ b/samples/subsys/ipc/rpmsg_service/remote/sample.yaml
@@ -1,0 +1,16 @@
+sample:
+    description: This app provides an example of how to integrate
+        RPMsg Service with Zephyr.
+    name: RPMsg Service example integration (remote)
+common:
+    harness: remote
+tests:
+    sample.ipc.rpmsg_service:
+        platform_allow: mps2_an521_remote v2m_musca_b1_ns
+        tags: ipm
+    sample.ipc.rpmsg_service.nrf:
+        platform_allow: nrf5340dk_nrf5340_cpunet bl5340_dvk_cpunet
+        integration_platforms:
+          - nrf5340dk_nrf5340_cpunet
+          - bl5340_dvk_cpunet
+        tags: ipm

--- a/samples/subsys/ipc/rpmsg_service/sample.yaml
+++ b/samples/subsys/ipc/rpmsg_service/sample.yaml
@@ -19,4 +19,4 @@ tests:
           - nrf5340dk_nrf5340_cpuapp
           - bl5340_dvk_cpuapp
         tags: ipm
-        build_only: true
+        harness: remote

--- a/samples/subsys/shell/devmem_load/README.md
+++ b/samples/subsys/shell/devmem_load/README.md
@@ -20,8 +20,7 @@ west flash
 
 Building for boards without UART interrupt support:
 ```bash
-west build -b quick_feather -- -DOVERLAY_CONFIG=prj_poll.conf  samples/subsys/shell/devmem_load
-west flash
+west build -b native_posix -- -DOVERLAY_CONFIG=prj_poll.conf  samples/subsys/shell/devmem_load
 ```
 ## Running
 After connecting to the UART console you should see the following output:

--- a/samples/subsys/shell/devmem_load/sample.yaml
+++ b/samples/subsys/shell/devmem_load/sample.yaml
@@ -1,0 +1,15 @@
+sample:
+  name: devmem_load
+  description: devmem load sample
+common:
+  harness: keyboard
+  tags: devmem devmem_load
+tests:
+  sample.devmem_load.polled:
+    integration_platforms:
+      - native_posix
+    extra_args: OVERLAY_CONFIG="prj_poll.conf"
+  sample.devmem_load.uart.interrupt:
+    integration_platforms:
+      - frdm_k64f
+    filter: CONFIG_SERIAL_SUPPORT_INTERRUPT


### PR DESCRIPTION
Adding the yaml files to sub-applications to avoid bitrot and
specifying the main applications with remote harness instead of
build_only.

Signed-off-by: Aastha Grover <aastha.grover@intel.com>