### PR TITLE
boards: arm: nucleo_u575zi_q: Add watchdog0 alias to dts file

### DIFF
--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q.dts
@@ -24,6 +24,7 @@
 	aliases {
 		led0 = &blue_led_1;
 		sw0 = &user_button;
+		watchdog0 = &iwdg;
 	};
 };
 


### PR DESCRIPTION
Add watchdog0 alias to dts file for correctly compiling
samples/drivers/watchdog sample.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>

---

This is fix for issue #48392.

It is may be forgot to fix in the https://github.com/zephyrproject-rtos/zephyr/pull/47912.