### PR TITLE
soc: riscv: remove unused content from soc.h

### DIFF
--- a/drivers/pinctrl/pinctrl_sifive.c
+++ b/drivers/pinctrl/pinctrl_sifive.c
@@ -8,6 +8,8 @@
 
 #include <zephyr/devicetree.h>
 #include <zephyr/drivers/pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/sifive-pinctrl.h>
+
 #include <soc.h>
 
 #define PINCTRL_BASE_ADDR	DT_INST_REG_ADDR(0)

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.c
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.c
@@ -6,6 +6,8 @@
 
 #include <zephyr/init.h>
 
+#include <gd32vf103.h>
+
 static int gigadevice_gd32v_soc_init(const struct device *dev)
 {
 	uint32_t key;

--- a/soc/riscv/riscv-privilege/gd32vf103/soc.h
+++ b/soc/riscv/riscv-privilege/gd32vf103/soc.h
@@ -18,13 +18,4 @@
 #define RISCV_MTIME_BASE      DT_REG_ADDR_BY_IDX(DT_NODELABEL(mtimer), 0)
 #define RISCV_MTIMECMP_BASE   DT_REG_ADDR_BY_IDX(DT_NODELABEL(mtimer), 1)
 
-#ifndef _ASMLANGUAGE
-#include <zephyr/toolchain.h>
-#include <gd32vf103.h>
-
-/* The GigaDevice HAL headers define this, but it conflicts with the Zephyr can.h */
-#undef CAN_MODE_NORMAL
-
-#endif  /* !_ASMLANGUAGE */
-
 #endif  /* RISCV_GD32VF103_SOC_H */

--- a/soc/riscv/riscv-privilege/miv/soc.h
+++ b/soc/riscv/riscv-privilege/miv/soc.h
@@ -6,45 +6,8 @@
 
 #include <soc_common.h>
 
-/* GPIO Interrupts */
-#define MIV_GPIO_0_IRQ           (0)
-#define MIV_GPIO_1_IRQ           (1)
-#define MIV_GPIO_2_IRQ           (2)
-#define MIV_GPIO_3_IRQ           (3)
-#define MIV_GPIO_4_IRQ           (4)
-#define MIV_GPIO_5_IRQ           (5)
-#define MIV_GPIO_6_IRQ           (6)
-#define MIV_GPIO_7_IRQ           (7)
-#define MIV_GPIO_8_IRQ           (8)
-#define MIV_GPIO_9_IRQ           (9)
-#define MIV_GPIO_10_IRQ          (10)
-#define MIV_GPIO_11_IRQ          (11)
-#define MIV_GPIO_12_IRQ          (12)
-#define MIV_GPIO_13_IRQ          (13)
-#define MIV_GPIO_14_IRQ          (14)
-#define MIV_GPIO_15_IRQ          (15)
-#define MIV_GPIO_16_IRQ          (16)
-#define MIV_GPIO_17_IRQ          (17)
-#define MIV_GPIO_18_IRQ          (18)
-#define MIV_GPIO_19_IRQ          (19)
-#define MIV_GPIO_20_IRQ          (20)
-#define MIV_GPIO_21_IRQ          (21)
-#define MIV_GPIO_22_IRQ          (22)
-#define MIV_GPIO_23_IRQ          (23)
-#define MIV_GPIO_24_IRQ          (24)
-#define MIV_GPIO_25_IRQ          (25)
-#define MIV_GPIO_26_IRQ          (26)
-#define MIV_GPIO_27_IRQ          (27)
-#define MIV_GPIO_28_IRQ          (28)
-#define MIV_GPIO_29_IRQ          (29)
-#define MIV_GPIO_30_IRQ          (30)
-#define MIV_GPIO_31_IRQ          (31)
-
 /* UART Configuration */
 #define MIV_UART_0_LINECFG           0x1
-
-/* GPIO Configuration */
-#define MIV_GPIO_0_BASE_ADDR         0x70002000
 
 /* Clock controller. */
 #define PRCI_BASE_ADDR               0x44000000

--- a/soc/riscv/riscv-privilege/miv/soc.h
+++ b/soc/riscv/riscv-privilege/miv/soc.h
@@ -9,9 +9,6 @@
 /* UART Configuration */
 #define MIV_UART_0_LINECFG           0x1
 
-/* Clock controller. */
-#define PRCI_BASE_ADDR               0x44000000
-
 /* Timer configuration */
 #define RISCV_MTIME_BASE             0x4400bff8
 #define RISCV_MTIMECMP_BASE          0x44004000

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -20,15 +20,6 @@
 /* Clock controller. */
 #define PRCI_BASE_ADDR               0x10008000
 
-/* Always ON Domain */
-#define SIFIVE_PMUIE		     0x10000140
-#define SIFIVE_PMUCAUSE		     0x10000144
-#define SIFIVE_PMUSLEEP		     0x10000148
-#define SIFIVE_PMUKEY		     0x1000014C
-#define SIFIVE_SLEEP_KEY_VAL	     0x0051F15E
-
-#define SIFIVE_BACKUP_REG_BASE	     0x10000080
-
 #elif defined(CONFIG_SOC_RISCV_SIFIVE_FU540) || defined(CONFIG_SOC_RISCV_SIFIVE_FU740)
 
 /* Clock controller. */

--- a/soc/riscv/riscv-privilege/sifive-freedom/soc.h
+++ b/soc/riscv/riscv-privilege/sifive-freedom/soc.h
@@ -14,11 +14,6 @@
 #include <soc_common.h>
 
 #if defined(CONFIG_SOC_RISCV_SIFIVE_FREEDOM)
-
-/* PINMUX IO Hardware Functions */
-#define SIFIVE_PINMUX_IOF0            0x00
-#define SIFIVE_PINMUX_IOF1            0x01
-
 /* PINMUX MAX PINS */
 #define SIFIVE_PINMUX_PINS            32
 


### PR DESCRIPTION
Remove all unused content from soc.h. Prep-work for soc.h cleanup/removal.