### PR TITLE
driver: clock_control: npcx: fix the power down of eSPI module

### DIFF
--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -222,7 +222,7 @@ static int npcx_clock_control_init(const struct device *dev)
 	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL5) = 0xFA;
 #if CONFIG_ESPI
 	/* Don't gate the clock of the eSPI module if eSPI interface is required */
-	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL6) = 0xEF;
+	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL6) = 0x7F;
 #else
 	NPCX_PWDWN_CTL(pmc_base, NPCX_PWDWN_CTL6) = 0xFF;
 #endif


### PR DESCRIPTION
This power down bit of eSPI module is loacted in the bit 7 of PWDWN_CTL6
register rather than the bit 4. This commit fixs the incorrect setting.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>