### PR TITLE
drivers: ethernet: sam_gmac: Convert to using dts for I2C EEPROM

### DIFF
--- a/boards/arm/sam_e70_xplained/Kconfig.defconfig
+++ b/boards/arm/sam_e70_xplained/Kconfig.defconfig
@@ -12,17 +12,11 @@ if ETH_SAM_GMAC
 
 # Read MAC address from AT24MAC402 EEPROM
 
-config ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS
-	default 0x5F
-
 config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS
 	default 0x9A
 
 config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE
 	default 1
-
-config ETH_SAM_GMAC_MAC_I2C_DEV_NAME
-	default "I2C_0"
 
 config ETH_SAM_GMAC_MAC_I2C_EEPROM
 	default y

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -75,6 +75,11 @@
 
 	pinctrl-0 = <&twihs0_default>;
 	pinctrl-names = "default";
+
+	eeprom: eeprom@5f {
+		compatible = "atmel,24mac402";
+		reg = <0x5f>;
+	};
 };
 
 &twihs2 {
@@ -115,6 +120,8 @@ zephyr_udc0: &usbhs {
 
 	pinctrl-0 = <&gmac_rmii>;
 	pinctrl-names = "default";
+
+	mac-eeprom = <&eeprom>;
 
 	phy: phy {
 		compatible = "ethernet-phy";

--- a/boards/arm/sam_v71_xult/Kconfig.defconfig
+++ b/boards/arm/sam_v71_xult/Kconfig.defconfig
@@ -15,21 +15,13 @@ if ETH_SAM_GMAC
 
 config ETH_SAM_GMAC_MAC_I2C_EEPROM
 	default y
-
-config ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS
-	default 0x5F
+	select I2C
 
 config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS
 	default 0x9A
 
 config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE
 	default 1
-
-config ETH_SAM_GMAC_MAC_I2C_DEV_NAME
-	default "I2C_0"
-
-config ETH_SAM_GMAC_MAC_I2C_EEPROM
-	select I2C
 
 endif # ETH_SAM_GMAC
 

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -174,6 +174,11 @@
 
 	pinctrl-0 = <&twihs0_default>;
 	pinctrl-names = "default";
+
+	eeprom: eeprom@5f {
+		compatible = "atmel,24mac402";
+		reg = <0x5f>;
+	};
 };
 
 &twihs2 {
@@ -223,6 +228,8 @@ zephyr_udc0: &usbhs {
 
 	pinctrl-0 = <&gmac_rmii>;
 	pinctrl-names = "default";
+
+	mac-eeprom = <&eeprom>;
 
 	phy: phy {
 		compatible = "ethernet-phy";

--- a/drivers/ethernet/Kconfig.sam_gmac
+++ b/drivers/ethernet/Kconfig.sam_gmac
@@ -76,12 +76,6 @@ config ETH_SAM_GMAC_MAC_I2C_EEPROM
 
 if ETH_SAM_GMAC_MAC_I2C_EEPROM
 
-config ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS
-	hex "I2C 7-bit EEPROM chip address"
-	range 0 0xff
-	help
-	  I2C 7-bit address of the EEPROM chip.
-
 config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS
 	hex "I2C EEPROM internal address"
 	range 0 0xffffffff
@@ -96,12 +90,6 @@ config ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE
 	range 1 4
 	help
 	  Size (in bytes) of the internal EEPROM address.
-
-config ETH_SAM_GMAC_MAC_I2C_DEV_NAME
-	string "I2C bus driver device name"
-	help
-	  Device name, e.g. I2C_0, of an I2C bus driver device. It is required to
-	  obtain handle to the I2C device object.
 
 endif # ETH_SAM_GMAC_MAC_I2C_EEPROM
 

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -1787,20 +1787,19 @@ static int eth_initialize(const struct device *dev)
 	return retval;
 }
 
-#ifdef CONFIG_ETH_SAM_GMAC_MAC_I2C_EEPROM
+#if DT_INST_NODE_HAS_PROP(0, mac_eeprom)
 static void get_mac_addr_from_i2c_eeprom(uint8_t mac_addr[6])
 {
-	const struct device *dev;
 	uint32_t iaddr = CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS;
 	int ret;
+	const struct i2c_dt_spec i2c = I2C_DT_SPEC_GET(DT_INST_PHANDLE(0, mac_eeprom));
 
-	dev = device_get_binding(CONFIG_ETH_SAM_GMAC_MAC_I2C_DEV_NAME);
-	if (!dev) {
-		LOG_ERR("I2C: Device not found");
+	if (!device_is_ready(i2c.bus)) {
+		LOG_ERR("Bus device is not ready");
 		return;
 	}
 
-	ret = i2c_write_read(dev, CONFIG_ETH_SAM_GMAC_MAC_I2C_SLAVE_ADDRESS,
+	ret = i2c_write_read_dt(&i2c,
 			   &iaddr, CONFIG_ETH_SAM_GMAC_MAC_I2C_INT_ADDRESS_SIZE,
 			   mac_addr, 6);
 
@@ -1813,7 +1812,7 @@ static void get_mac_addr_from_i2c_eeprom(uint8_t mac_addr[6])
 
 static void generate_mac(uint8_t mac_addr[6])
 {
-#if defined(CONFIG_ETH_SAM_GMAC_MAC_I2C_EEPROM)
+#if DT_INST_NODE_HAS_PROP(0, mac_eeprom)
 	get_mac_addr_from_i2c_eeprom(mac_addr);
 #elif DT_INST_PROP(0, zephyr_random_mac_address)
 	gen_random_mac(mac_addr, ATMEL_OUI_B0, ATMEL_OUI_B1, ATMEL_OUI_B2);

--- a/dts/bindings/ethernet/atmel,gmac-common.yaml
+++ b/dts/bindings/ethernet/atmel,gmac-common.yaml
@@ -52,3 +52,7 @@ properties:
         represents Reduced Media-Independent Interface (RMII) mode.
 
         This property must be used with pinctrl-0.
+
+    mac-eeprom:
+      type: phandle
+      description: phandle to I2C eeprom device node.

--- a/dts/bindings/mtd/atmel,24mac402.yaml
+++ b/dts/bindings/mtd/atmel,24mac402.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Kumar Gala <galak@kernel.org>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel AT24 (or compatible) I2C EEPROM
+
+compatible: "atmel,at24mac402"
+
+include: [i2c-device.yaml]


### PR DESCRIPTION
Introduce a simple binding for atmel,24mac402 EEPROM that the SAM
GMAC ethernet driver can utilize to get MAC address out of.  We
introduce a 'mac-eeprom' phandle into GMAC ethernet devicetree
node that will provide a pointer to the MAC eeprom to utilize.

Signed-off-by: Kumar Gala <galak@kernel.org>