### PR TITLE
drivers: bluetooth: hci: spi: Replace DT_INST_LABEL

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -499,7 +499,7 @@ static int bt_spi_open(void)
 }
 
 static const struct bt_hci_driver drv = {
-	.name		= DT_INST_LABEL(0),
+	.name		= DEVICE_DT_NAME(DT_DRV_INST(0)),
 	.bus		= BT_HCI_DRIVER_BUS_SPI,
 #if defined(CONFIG_BT_BLUENRG_ACI)
 	.quirks		= BT_QUIRK_NO_RESET,


### PR DESCRIPTION
As we phase out label properties from devicetree the devicetree
node may not have a label so utilize DEVICE_DT_NAME instead
which will use a label if it exists and the node name if not.

Signed-off-by: Kumar Gala <galak@kernel.org>