### PR TITLE
boards: arm: ubx_evkninab{3,4}: Update docs to use DEVICE_DT_GET

### DIFF
--- a/boards/arm/ubx_evkninab3_nrf52840/doc/index.rst
+++ b/boards/arm/ubx_evkninab3_nrf52840/doc/index.rst
@@ -302,7 +302,7 @@ more than one UART for connecting peripheral devices:
 
    In the overlay file above, pin P0.16 is used for RX and P0.14 is used for TX
 
-2. Use the UART1 as ``device_get_binding("UART_1")``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 Overlay file naming
 ===================

--- a/boards/arm/ubx_evkninab4_nrf52833/doc/index.rst
+++ b/boards/arm/ubx_evkninab4_nrf52833/doc/index.rst
@@ -197,7 +197,7 @@ more than one UART for connecting peripheral devices:
 
    In the overlay file above, pin P0.16 is used for RX and P0.14 is used for TX
 
-2. Use the UART1 as ``device_get_binding("UART_1")``
+2. Use the UART1 as ``DEVICE_DT_GET(DT_NODELABEL(uart1))``
 
 Overlay file naming
 ===================


### PR DESCRIPTION
Update docs for boards ubx_evkninab3_nrf52840 and ubx_evkninab4_nrf52833
to use DEVICE_DT_GET as we phase out "label" usage and thus the
device_get_binding() reference wouldn't work.

Signed-off-by: Kumar Gala <galak@kernel.org>