### PR TITLE
drivers: dac: update drivers to use devicetree Kconfig symbol

### DIFF
--- a/drivers/dac/Kconfig.dacx0508
+++ b/drivers/dac/Kconfig.dacx0508
@@ -6,7 +6,10 @@
 
 config DAC_DACX0508
 	bool "TI DACx0508 DAC driver"
+	default y
 	depends on SPI
+	depends on DT_HAS_TI_DAC60508_ENABLED || DT_HAS_TI_DAC70508_ENABLED || \
+		   DT_HAS_TI_DAC80508_ENABLED
 	help
 	  Enable the driver for the TI DACx0508.
 

--- a/drivers/dac/Kconfig.dacx3608
+++ b/drivers/dac/Kconfig.dacx3608
@@ -6,7 +6,9 @@
 
 config DAC_DACX3608
 	bool "TI DACX3608 DAC driver"
+	default y
 	depends on I2C
+	depends on DT_HAS_TI_DAC43608_ENABLED || DT_HAS_TI_DAC53608_ENABLED
 	help
 	  Enable the driver for the TI DACX3608.
 

--- a/drivers/dac/Kconfig.gd32
+++ b/drivers/dac/Kconfig.gd32
@@ -4,12 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_GD_GD32_DAC := gd,gd32-dac
-
 config DAC_GD32
 	bool "GD32 DAC driver"
-	depends on (SOC_FAMILY_GD32 || SOC_SERIES_GD32VF103)
-	default $(dt_compat_enabled,$(DT_COMPAT_GD_GD32_DAC))
+	default y
+	depends on DT_HAS_GD_GD32_DAC_ENABLED
 	help
 	  Enable GigaDevice GD32 DAC driver

--- a/drivers/dac/Kconfig.mcp4725
+++ b/drivers/dac/Kconfig.mcp4725
@@ -6,7 +6,9 @@
 
 config DAC_MCP4725
 	bool "Microchip MCP4725 DAC driver"
+	default y
 	depends on I2C
+	depends on DT_HAS_MICROCHIP_MCP4725_ENABLED
 	help
 	  Enable the driver for the Microchip MCP4725.
 

--- a/drivers/dac/Kconfig.mcp4728
+++ b/drivers/dac/Kconfig.mcp4728
@@ -4,7 +4,9 @@
 
 config DAC_MCP4728
 	bool "Microchip MCP4728 DAC driver"
+	default y
 	depends on I2C
+	depends on DT_HAS_MICROCHIP_MCP4728_ENABLED
 	help
 	  Enable driver for the Microchip MCP4728.
 

--- a/drivers/dac/Kconfig.mcux
+++ b/drivers/dac/Kconfig.mcux
@@ -6,13 +6,15 @@
 
 config DAC_MCUX_DAC
 	bool "NXP Kinetis MCUX DAC driver"
-	depends on HAS_MCUX_DAC
+	default y
+	depends on DT_HAS_NXP_KINETIS_DAC_ENABLED
 	help
 	  Enable the driver for the NXP Kinetis MCUX DAC.
 
 config DAC_MCUX_DAC32
 	bool "NXP Kinetis MCUX DAC32 driver"
-	depends on HAS_MCUX_DAC32
+	default y
+	depends on DT_HAS_NXP_KINETIS_DAC32_ENABLED
 	select PINCTRL
 	help
 	  Enable the driver for the NXP Kinetis MCUX DAC32.

--- a/drivers/dac/Kconfig.sam
+++ b/drivers/dac/Kconfig.sam
@@ -2,12 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_ATMEL_SAM_DAC := atmel,sam-dac
-
 config DAC_SAM
 	bool "Atmel SAM DAC driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ATMEL_SAM_DAC))
-	depends on SOC_FAMILY_SAM
+	default y
+	depends on DT_HAS_ATMEL_SAM_DAC_ENABLED
 	help
 	  Enable Atmel SAM MCU Family Digital Audio Converter (DAC) driver.

--- a/drivers/dac/Kconfig.sam0
+++ b/drivers/dac/Kconfig.sam0
@@ -3,6 +3,7 @@
 
 config DAC_SAM0
 	bool "Atmel SAM0 series DAC Driver"
-	depends on SOC_SERIES_SAMD20 || SOC_SERIES_SAMD21
+	default y
+	depends on DT_HAS_ATMEL_SAM0_DAC_ENABLED
 	help
 	  Enables the Atmel SAM0 MCU Family Digital-to-Analog (DAC) driver.

--- a/drivers/dac/Kconfig.stm32
+++ b/drivers/dac/Kconfig.stm32
@@ -4,11 +4,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Workaround for not being able to have commas in macro arguments
-DT_COMPAT_ST_STM32_DAC := st,stm32-dac
-
 config DAC_STM32
 	bool "STM32 DAC driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_ST_STM32_DAC))
+	default y
+	depends on DT_HAS_ST_STM32_DAC_ENABLED
 	help
 	  Enable the driver implementation for the stm32xx DAC


### PR DESCRIPTION
Update dac drivers to use DT_HAS_<compat>_ENABLED Kconfig symbol to expose the driver and enable it by default based on devicetree.

We remove 'depend on' Kconfig for symbols that would be implied by the devicetree node existing.