### PR TITLE
lorawan: upgrade to LoRaMAC-node v4.6.0

### DIFF
--- a/subsys/lorawan/lorawan.c
+++ b/subsys/lorawan/lorawan.c
@@ -155,7 +155,8 @@ static void mcps_indication_handler(McpsIndication_t *mcps_indication)
 		if ((cb->port == LW_RECV_PORT_ANY) ||
 		    (cb->port == mcps_indication->Port)) {
 			cb->cb(mcps_indication->Port,
-			       !!mcps_indication->FramePending,
+			       /* IsUplinkTxPending also indicates pending downlinks */
+			       mcps_indication->IsUplinkTxPending == 1,
 			       mcps_indication->Rssi, mcps_indication->Snr,
 			       mcps_indication->BufferSize,
 			       mcps_indication->Buffer);

--- a/west.yml
+++ b/west.yml
@@ -158,7 +158,7 @@ manifest:
         - fs
       revision: 652f2c5646e79b881e6f3099686ad3b7af9e216c
     - name: loramac-node
-      revision: 12019623bbad9eb54fe51066847a7cbd4b4eac57
+      revision: 0257b50905695192d095667b1c3abb80346db1a1
       path: modules/lib/loramac-node
     - name: lvgl
       revision: 487bcde705b6f453d053f28dbba4dd9f353d1ccb


### PR DESCRIPTION
This release contains some bug fixes and improvements in the upstream repo.

See below link for details:
https://github.com/Lora-net/LoRaMac-node/releases/tag/v4.6.0

As discussed in Discord, @JordanYates and I propose to name the branches in our tracking repo based on the upstream LoRaMAC-node release instead of the Zephyr release. I've already created a branch [v4.6.0-zephyr](https://github.com/zephyrproject-rtos/loramac-node/tree/v4.6.0-zephyr) with the necessary 2 commits for Zephyr integration cherry-picked from the previous branch. If you disagree with the approach, just let me know a different way for the update to happen.