### PR TITLE
settings: API for get storage instance used

### DIFF
--- a/include/zephyr/settings/settings.h
+++ b/include/zephyr/settings/settings.h
@@ -440,6 +440,13 @@ struct settings_store_itf {
 	 * Parameters:
 	 *  - cs - Corresponding backend handler node
 	 */
+
+	/**< Get pointer to the storage instance used by the backend.
+	 *
+	 * Parameters:
+	 *  - cs - Corresponding backend handler node
+	 */
+	void *(*csi_storage_get)(struct settings_store *cs);
 };
 
 /**
@@ -585,6 +592,18 @@ int settings_runtime_commit(const char *name);
 
 #endif /* CONFIG_SETTINGS_RUNTIME */
 
+/**
+ * Get the storage instance used by zephyr.
+ *
+ * The type of storage object instance depends on the settings backend used.
+ * It might pointer to: `struct nvs_fs`, `struct fcb` or string witch file name
+ * depends on settings backend type used.
+ *
+ * @retval Pointer to which reference to the storage object can be stored.
+ *
+ * @retval 0 on success, negative error code on failure.
+ */
+int settings_storage_get(void **storage);
 
 #ifdef __cplusplus
 }

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -27,15 +27,18 @@ LOG_MODULE_DECLARE(settings, CONFIG_SETTINGS_LOG_LEVEL);
 
 int settings_backend_init(void);
 void settings_mount_fcb_backend(struct settings_fcb *cf);
+static void *settings_fcb_storage_get(struct settings_store *cs);
 
 static int settings_fcb_load(struct settings_store *cs,
 			     const struct settings_load_arg *arg);
 static int settings_fcb_save(struct settings_store *cs, const char *name,
 			     const char *value, size_t val_len);
+static void *settings_fcb_storage_get(struct settings_store *cs);
 
 static const struct settings_store_itf settings_fcb_itf = {
 	.csi_load = settings_fcb_load,
 	.csi_save = settings_fcb_save,
+	.csi_storage_get = settings_fcb_storage_get
 };
 
 int settings_fcb_src(struct settings_fcb *cf)
@@ -435,4 +438,11 @@ int settings_backend_init(void)
 	settings_mount_fcb_backend(&config_init_settings_fcb);
 
 	return rc;
+}
+
+static void *settings_fcb_storage_get(struct settings_store *cs)
+{
+	struct settings_fcb *cf = (struct settings_fcb *)cs;
+
+	return &cf->cf_fcb;
 }

--- a/subsys/settings/src/settings_file.c
+++ b/subsys/settings/src/settings_file.c
@@ -26,10 +26,12 @@ static int settings_file_load(struct settings_store *cs,
 			      const struct settings_load_arg *arg);
 static int settings_file_save(struct settings_store *cs, const char *name,
 			      const char *value, size_t val_len);
+static void *settings_fs_storage_get(struct settings_store *cs);
 
 static const struct settings_store_itf settings_file_itf = {
 	.csi_load = settings_file_load,
 	.csi_save = settings_file_save,
+	.csi_storage_get = settings_fs_storage_get
 };
 
 /*
@@ -534,4 +536,11 @@ int settings_backend_init(void)
 		rc = fs_mkdir(CONFIG_SETTINGS_FS_DIR);
 	}
 	return rc;
+}
+
+static void *settings_fs_storage_get(struct settings_store *cs)
+{
+	struct settings_file *cf = (struct settings_file *)cs;
+
+	return (void *)cf->cf_name;
 }

--- a/subsys/settings/src/settings_nvs.c
+++ b/subsys/settings/src/settings_nvs.c
@@ -31,10 +31,12 @@ static int settings_nvs_load(struct settings_store *cs,
 			     const struct settings_load_arg *arg);
 static int settings_nvs_save(struct settings_store *cs, const char *name,
 			     const char *value, size_t val_len);
+static void *settings_nvs_storage_get(struct settings_store *cs);
 
 static struct settings_store_itf settings_nvs_itf = {
 	.csi_load = settings_nvs_load,
 	.csi_save = settings_nvs_save,
+	.csi_storage_get = settings_nvs_storage_get
 };
 
 static ssize_t settings_nvs_read_fn(void *back_end, void *data, size_t len)
@@ -331,4 +333,11 @@ int settings_backend_init(void)
 	rc = settings_nvs_dst(&default_settings_nvs);
 
 	return rc;
+}
+
+static void *settings_nvs_storage_get(struct settings_store *cs)
+{
+	struct settings_nvs *cf = (struct settings_nvs *)cs;
+
+	return &cf->cf_nvs;
 }

--- a/subsys/settings/src/settings_store.c
+++ b/subsys/settings/src/settings_store.c
@@ -158,6 +158,21 @@ int settings_save(void)
 	return rc;
 }
 
+int settings_storage_get(void **storage)
+{
+	struct settings_store *cs = settings_save_dst;
+
+	if (!cs) {
+		return -ENOENT;
+	}
+
+	if (cs->cs_itf->csi_storage_get) {
+		*storage = cs->cs_itf->csi_storage_get(cs);
+	}
+
+	return 0;
+}
+
 void settings_store_init(void)
 {
 	sys_slist_init(&settings_load_srcs);

--- a/tests/subsys/settings/functional/fcb/CMakeLists.txt
+++ b/tests/subsys/settings/functional/fcb/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(functional_fcb)
 
 # The code is in the library common to several tests.
-target_sources(app PRIVATE placeholder.c)
+target_sources(app PRIVATE settings_test_fcb.c)
 
 add_subdirectory(../src func_test_bindir)
 

--- a/tests/subsys/settings/functional/fcb/placeholder.c
+++ b/tests/subsys/settings/functional/fcb/placeholder.c
@@ -1,2 +1,0 @@
-/* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/functional/fcb/settings_test_fcb.c
+++ b/tests/subsys/settings/functional/fcb/settings_test_fcb.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2022 Nordic semiconductor ASA */
+
+#include <zephyr/zephyr.h>
+#include <ztest.h>
+#include <errno.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/fs/fcb.h>
+
+void test_setting_storage_get(void)
+{
+	int rc;
+	void *storage;
+	struct fcb_entry loc;
+
+	rc = settings_storage_get(&storage);
+	zassert_equal(0, rc, "Can't fetch storage reference (err=%d)", rc);
+
+	zassert_not_null(storage, "Null reference.");
+
+	loc.fe_sector = NULL;
+	rc = fcb_getnext((struct fcb *)storage, &loc);
+
+	zassert_equal(rc, 0, "Can't read fcb (err=%d)", rc);
+}

--- a/tests/subsys/settings/functional/file/CMakeLists.txt
+++ b/tests/subsys/settings/functional/file/CMakeLists.txt
@@ -6,6 +6,7 @@ project(functional_file)
 
 FILE(GLOB app_sources ../src/*.c)
 target_sources(app PRIVATE ${app_sources})
+target_sources(app PRIVATE settings_test_fs.c)
 zephyr_include_directories(
 	${ZEPHYR_BASE}/subsys/settings/include
 	${ZEPHYR_BASE}/subsys/settings/src

--- a/tests/subsys/settings/functional/file/settings_test_fs.c
+++ b/tests/subsys/settings/functional/file/settings_test_fs.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2022 Nordic semiconductor ASA */
+
+#include <zephyr/zephyr.h>
+#include <ztest.h>
+#include <errno.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/fs/fs.h>
+
+void test_setting_storage_get(void)
+{
+	int rc;
+	void *storage;
+
+	struct fs_dirent entry;
+
+	rc = settings_storage_get(&storage);
+	zassert_equal(0, rc, "Can't fetch storage reference (err=%d)", rc);
+
+	zassert_not_null(storage, "Null reference.");
+
+	rc = fs_stat((const char *)storage, &entry);
+
+	zassert_true(rc >= 0, "Can't find the file (err=%d)", rc);
+}

--- a/tests/subsys/settings/functional/nvs/CMakeLists.txt
+++ b/tests/subsys/settings/functional/nvs/CMakeLists.txt
@@ -5,7 +5,7 @@ find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(functional_nvs)
 
 # The code is in the library common to several tests.
-target_sources(app PRIVATE placeholder.c)
+target_sources(app PRIVATE settings_test_nvs.c)
 
 add_subdirectory(../src func_test_bindir)
 

--- a/tests/subsys/settings/functional/nvs/placeholder.c
+++ b/tests/subsys/settings/functional/nvs/placeholder.c
@@ -1,2 +1,0 @@
-/* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright (c) 2019 Intel Corporation */

--- a/tests/subsys/settings/functional/nvs/settings_test_nvs.c
+++ b/tests/subsys/settings/functional/nvs/settings_test_nvs.c
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright (c) 2022 Nordic semiconductor ASA */
+
+#include <zephyr/zephyr.h>
+#include <ztest.h>
+#include <errno.h>
+#include <zephyr/settings/settings.h>
+#include <zephyr/fs/nvs.h>
+
+void test_setting_storage_get(void)
+{
+	int rc;
+	void *storage;
+	uint16_t data = 0x5a5a;
+	ssize_t nvs_rc;
+
+	rc = settings_storage_get(&storage);
+	zassert_equal(0, rc, "Can't fetch storage reference (err=%d)", rc);
+
+	zassert_not_null(storage, "Null reference.");
+
+	nvs_rc = nvs_write((struct nvs_fs *)storage, 26, &data, sizeof(data));
+
+	zassert_true(nvs_rc >= 0, "Can't read nvs record (err=%d).", rc);
+}

--- a/tests/subsys/settings/functional/src/settings_basic_test.c
+++ b/tests/subsys/settings/functional/src/settings_basic_test.c
@@ -612,6 +612,7 @@ static void test_direct_loading_filter(void)
 	}
 }
 
+extern void test_setting_storage_get(void);
 
 void test_main(void)
 {
@@ -620,7 +621,8 @@ void test_main(void)
 			 ztest_unit_test(test_support_rtn),
 			 ztest_unit_test(test_register_and_loading),
 			 ztest_unit_test(test_direct_loading),
-			 ztest_unit_test(test_direct_loading_filter)
+			 ztest_unit_test(test_direct_loading_filter),
+			 ztest_unit_test(test_setting_storage_get)
 			);
 
 	ztest_run_test_suite(settings_test_suite);


### PR DESCRIPTION
Added API function +int settings_storage_get(void **storage)
which allows to get storage instance used by the
settings backed to store its records.

fixes #48328

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>