### PR TITLE
net: sockets: Fill the address structure provided in recvfrom() 

### DIFF
--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -300,6 +300,9 @@ struct cmsghdr {
 #define PACKET_LOOPBACK     5
 #define PACKET_FASTROUTE    6
 
+/* ARP protocol HARDWARE identifiers. */
+#define ARPHRD_ETHER 1
+
 /* Note: These macros are defined in a specific order.
  * The largest sockaddr size is the last one.
  */

--- a/include/zephyr/net/net_pkt.h
+++ b/include/zephyr/net/net_pkt.h
@@ -124,6 +124,7 @@ struct net_pkt {
 	/* Filled by layer 2 when network packet is received. */
 	struct net_linkaddr lladdr_src;
 	struct net_linkaddr lladdr_dst;
+	uint16_t ll_proto_type;
 
 #if defined(CONFIG_NET_TCP)
 	/** Allow placing the packet into sys_slist_t */
@@ -1016,6 +1017,16 @@ static inline void net_pkt_lladdr_clear(struct net_pkt *pkt)
 {
 	net_pkt_lladdr_src(pkt)->addr = NULL;
 	net_pkt_lladdr_src(pkt)->len = 0U;
+}
+
+static inline uint16_t net_pkt_ll_proto_type(struct net_pkt *pkt)
+{
+	return pkt->ll_proto_type;
+}
+
+static inline void net_pkt_set_ll_proto_type(struct net_pkt *pkt, uint16_t type)
+{
+	pkt->ll_proto_type = type;
 }
 
 #if defined(CONFIG_IEEE802154) || defined(CONFIG_IEEE802154_RAW_MODE)

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1774,6 +1774,7 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_orig_iface(clone_pkt, net_pkt_orig_iface(pkt));
 	net_pkt_set_captured(clone_pkt, net_pkt_is_captured(pkt));
 	net_pkt_set_l2_bridged(clone_pkt, net_pkt_is_l2_bridged(pkt));
+	net_pkt_set_l2_processed(clone_pkt, net_pkt_is_l2_processed(pkt));
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET) {
 		net_pkt_set_ipv4_ttl(clone_pkt, net_pkt_ipv4_ttl(pkt));

--- a/subsys/net/ip/net_pkt.c
+++ b/subsys/net/ip/net_pkt.c
@@ -1775,6 +1775,7 @@ static void clone_pkt_attributes(struct net_pkt *pkt, struct net_pkt *clone_pkt)
 	net_pkt_set_captured(clone_pkt, net_pkt_is_captured(pkt));
 	net_pkt_set_l2_bridged(clone_pkt, net_pkt_is_l2_bridged(pkt));
 	net_pkt_set_l2_processed(clone_pkt, net_pkt_is_l2_processed(pkt));
+	net_pkt_set_ll_proto_type(clone_pkt, net_pkt_ll_proto_type(pkt));
 
 	if (IS_ENABLED(CONFIG_NET_IPV4) && net_pkt_family(pkt) == AF_INET) {
 		net_pkt_set_ipv4_ttl(clone_pkt, net_pkt_ipv4_ttl(pkt));

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -274,6 +274,8 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	lladdr->len = sizeof(struct net_eth_addr);
 	lladdr->type = NET_LINK_ETHERNET;
 
+	net_pkt_set_ll_proto_type(pkt, type);
+
 	if (net_eth_is_vlan_enabled(ctx, iface)) {
 		if (type == NET_ETH_PTYPE_VLAN ||
 		    (eth_is_vlan_tag_stripped(iface) &&


### PR DESCRIPTION
The packet socket implementation did not fill the address structure
provided by the application. This commit fixes this.

Note, that the implementation needs to cover two cases: SOCK_RAW and
SOCK_DGRAM. In the first case, the information is extracted directly
from the L2 header (curently only Ethernet supported). In latter case,
the header is already removed from the packet as the L2 has already
processed the packet, so the information is obtained from the net_pkt
structure.

Fixes #48089