### PR TITLE
kernel: Init the base.slice_ticks for dummy_thread

### DIFF
--- a/kernel/include/kswap.h
+++ b/kernel/include/kswap.h
@@ -232,6 +232,10 @@ static inline void z_dummy_thread_init(struct k_thread *dummy_thread)
 	dummy_thread->resource_pool = NULL;
 #endif
 
+#ifdef CONFIG_TIMESLICE_PER_THREAD
+	dummy_thread->base.slice_ticks = 0;
+#endif
+
 	_current_cpu->current = dummy_thread;
 }
 #endif /* ZEPHYR_KERNEL_INCLUDE_KSWAP_H_ */


### PR DESCRIPTION
Fixes #46324
Set dummy_thread->base.slice_ticks to 0 when
CONFIG_TIMESLICE_PER_THREAD is set. To avoid
_current_cpu->slice_ticks be a big number.

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>