### PR TITLE
clock_control: stm32u5: Fix some issues in driver and tests

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -42,8 +42,10 @@ static uint32_t get_bus_clock(uint32_t clock, uint32_t prescaler)
 
 static uint32_t get_msis_frequency(void)
 {
-	return __LL_RCC_CALC_MSIS_FREQ(LL_RCC_MSIRANGESEL_RUN,
-				STM32_MSIS_RANGE << RCC_ICSCR1_MSISRANGE_Pos);
+	return __LL_RCC_CALC_MSIS_FREQ(LL_RCC_MSI_IsEnabledRangeSelect(),
+				       ((LL_RCC_MSI_IsEnabledRangeSelect() == 1U) ?
+						LL_RCC_MSIS_GetRange() :
+						LL_RCC_MSIS_GetRangeAfterStandby()));
 }
 
 __unused
@@ -710,7 +712,7 @@ int stm32_clock_control_init(const struct device *dev)
 	/* Current hclk value */
 	old_hclk_freq = __LL_RCC_CALC_HCLK_FREQ(get_startup_frequency(), LL_RCC_GetAHBPrescaler());
 
-	/* Set up indiviual enabled clocks */
+	/* Set up individual enabled clocks */
 	set_up_fixed_clock_sources();
 
 	/* Set up PLLs */

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -425,7 +425,9 @@ static int set_up_plls(void)
 	 * case we're currently running from the PLL we're about to
 	 * turn off and reconfigure.)
 	 */
-	clock_switch_to_hsi();
+	if (LL_RCC_GetSysClkSource() == LL_RCC_SYS_CLKSOURCE_STATUS_PLL1) {
+		clock_switch_to_hsi();
+	}
 
 	LL_RCC_PLL1_Disable();
 

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -468,7 +468,8 @@ static int set_up_plls(void)
 	}
 
 	if (IS_ENABLED(STM32_PLL_R_ENABLED)) {
-		__ASSERT_NO_MSG(STM32_PLL_R_DIVISOR != 1);
+		__ASSERT_NO_MSG((STM32_PLL_R_DIVISOR == 1) ||
+				(STM32_PLL_R_DIVISOR % 2 == 0));
 		LL_RCC_PLL1_SetR(STM32_PLL_R_DIVISOR);
 		LL_RCC_PLL1_EnableDomain_SYS();
 	}

--- a/dts/bindings/clock/st,stm32u5-pll-clock.yaml
+++ b/dts/bindings/clock/st,stm32u5-pll-clock.yaml
@@ -70,5 +70,6 @@ properties:
       required: true
       description: |
           PLLx DIVR division factor
-          PLL1 DIVR must not be set to 1, but DIVR can be set to 1 for PLL2 and PLL3
+          On PLL1, only division by 1 and even division values are allowed.
+          No restrictions for PLL2 and PLL3
           Valid range: 1 - 128

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/boards/hse_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/boards/hse_16.overlay
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+/*
+ * Warning: HSE is not implemented on available boards, hence:
+ *          This configuration is only available for build
+ */
+
+&clk_hse {
+	status = "okay";
+	clock-frequency = <DT_FREQ_M(16)>;
+	hse-bypass;
+};
+
+&rcc {
+	clocks = <&clk_hse>;
+	clock-frequency = <DT_FREQ_M(16)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/boards/hsi_16.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/boards/hsi_16.overlay
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2021 Linaro Limited
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Warning: This overlay performs configuration from clean sheet.
+ * It is assumed that it is applied after clear_clocks.overlay file.
+ */
+
+&clk_hsi {
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&clk_hsi>;
+	clock-frequency = <DT_FREQ_M(16)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	apb3-prescaler = <1>;
+};

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/testcase.yaml
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/testcase.yaml
@@ -14,6 +14,12 @@ tests:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/msis_48.overlay"
   drivers.stm32_clock_configuration.u5.sysclksrc_msis_24:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/msis_24.overlay"
+  drivers.stm32_clock_configuration.u5.sysclksrc_hsi_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hsi_16.overlay"
+  drivers.stm32_clock_configuration.u5.sysclksrc_hse_16:
+    extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/hse_16.overlay"
+    # Build only as HSE not implemened on available boards
+    build_only: true
   drivers.stm32_clock_configuration.u5.sysclksrc_pll_hse_160:
     extra_args: DTC_OVERLAY_FILE="boards/clear_clocks.overlay;boards/pll_hse_160.overlay"
     # Build only as HSE not implemened on available boards

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/boards/spi1_msik.overlay
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/boards/spi1_msik.overlay
@@ -11,6 +11,7 @@
 
 &clk_msik {
 	msi-range = <4>;
+	msi-pll-mode;
 	status = "okay";
 };
 


### PR DESCRIPTION
Some tests are failed on stm32u5 clock_control:
```
tests/drivers/clock_control/stm32_clock_configuration/stm32u5_core/drivers.stm32_clock_configuration.u5.sysclksrc_pll_hsi_160, b_u585i_iot02a
tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/drivers.stm32_clock_configuration.dev_u5.spi1_msik, b_u585i_iot02a
```
Make necessary changes to fix these test and fix some other issues found during debug.

