### PR TITLE
twister: support board@revision in platform filter

### DIFF
--- a/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
@@ -5,7 +5,7 @@
  */
 
 &i2c1 {
-    /delete-node/ lsm303agr-magn@1e;
+    /delete-node/ lsm303agr-magn;
     /delete-node/ lsm303agr-accel@19;
 
 	lsm303dlhc_magn: lsm303dlhc-magn@1e {

--- a/doc/develop/test/twister.rst
+++ b/doc/develop/test/twister.rst
@@ -51,6 +51,12 @@ you can build and run all possible tests using the following options:
 This will build for all available boards and run all applicable tests in
 a simulated (for example QEMU) environment.
 
+If you want to run tests on one or more specific platforms, you can use
+the ``--platform`` option, it is a platform filter for testing, with this
+option, test suites will only be built/run on the platforms specified.
+This option also supports different revisions of one same board,
+you can use ``--platform board@revision`` to test on a specific revision.
+
 The list of command line options supported by twister can be viewed using::
 
         $ ./scripts/twister --help


### PR DESCRIPTION
support to use board@revision as platform filter when running
twister, like "twister -p nucleo_f030r8@1 ...".

met a build failure on stm32f411e_disco@B board when CI tested this PR, 
so added the fix in this PR too.

Signed-off-by: Chen Peng1 <peng1.chen@intel.com>

fixes: #48386 