### PR TITLE
Start looking at DT bindings from check_compliance

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -69,7 +69,7 @@ jobs:
         # debug
         ls -la
         git log  --pretty=oneline | head -n 10
-        ./scripts/ci/check_compliance.py -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}..
+        ./scripts/ci/check_compliance.py -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -m DevicetreeBindings -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@master

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -69,7 +69,7 @@ jobs:
         # debug
         ls -la
         git log  --pretty=oneline | head -n 10
-        ./scripts/ci/check_compliance.py -m Devicetree -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}..
+        ./scripts/ci/check_compliance.py -m Gitlint -m Identity -m Nits -m pylint -m checkpatch -m Kconfig -c origin/${BASE_REF}..
 
     - name: upload-results
       uses: actions/upload-artifact@master
@@ -84,7 +84,7 @@ jobs:
           exit 1;
         fi
 
-        for file in Nits.txt checkpatch.txt Identity.txt Gitlint.txt pylint.txt Devicetree.txt Kconfig.txt; do
+        for file in Nits.txt checkpatch.txt Identity.txt Gitlint.txt pylint.txt Kconfig.txt; do
           if [[ -s $file ]]; then
             errors=$(cat $file)
             errors="${errors//'%'/'%25'}"

--- a/boards/arc/em_starterkit/em_starterkit_r23.dtsi
+++ b/boards/arc/em_starterkit/em_starterkit_r23.dtsi
@@ -34,9 +34,9 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf0000014 0x4>;
 			ngpios = <6>;
-			bit_per_gpio = <1>;
-			off_val = <0>;
-			on_val = <1>;
+			bit-per-gpio = <1>;
+			off-val = <0>;
+			on-val = <1>;
 
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
+++ b/boards/arm/efm32gg_slwstk6121a/efm32gg_slwstk6121a.dts
@@ -120,19 +120,19 @@
 
 	/* PHY management pins */
 	location-mdio        = <GECKO_LOCATION(3)>;
-	location-phy_mdc     = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(6)>;
-	location-phy_mdio    = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(15)>;
+	location-phy-mdc     = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(6)>;
+	location-phy-mdio    = <GECKO_LOCATION(3) GECKO_PORT_A GECKO_PIN(15)>;
 
 	/* RMII interface pins */
 	location-rmii        = <GECKO_LOCATION(0)>;
-	location-rmii_refclk = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(3)>;
-	location-rmii_crs_dv = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(4)>;
-	location-rmii_txd0   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(15)>;
-	location-rmii_txd1   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(14)>;
-	location-rmii_tx_en  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
-	location-rmii_rxd0   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(2)>;
-	location-rmii_rxd1   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
-	location-rmii_rx_er  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
+	location-rmii-refclk = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(3)>;
+	location-rmii-crs-dv = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(4)>;
+	location-rmii-txd0   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(15)>;
+	location-rmii-txd1   = <GECKO_LOCATION(0) GECKO_PORT_E GECKO_PIN(14)>;
+	location-rmii-tx-en  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(0)>;
+	location-rmii-rxd0   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(2)>;
+	location-rmii-rxd1   = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(1)>;
+	location-rmii-rx-er  = <GECKO_LOCATION(0) GECKO_PORT_A GECKO_PIN(5)>;
 
 	status = "okay";
 };

--- a/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
+++ b/boards/arm/efm32gg_stk3701a/efm32gg_stk3701a.dts
@@ -140,19 +140,19 @@
 
 	/* PHY management pins */
 	location-mdio        = <GECKO_LOCATION(1)>;
-	location-phy_mdc     = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(14)>;
-	location-phy_mdio    = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(13)>;
+	location-phy-mdc     = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(14)>;
+	location-phy-mdio    = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(13)>;
 
 	/* RMII interface pins */
 	location-rmii        = <GECKO_LOCATION(1)>;
-	location-rmii_refclk = <GECKO_LOCATION(5) GECKO_PORT_D GECKO_PIN(10)>;
-	location-rmii_crs_dv = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(11)>;
-	location-rmii_txd0   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(7)>;
-	location-rmii_txd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(6)>;
-	location-rmii_tx_en  = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(8)>;
-	location-rmii_rxd0   = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(9)>;
-	location-rmii_rxd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(9)>;
-	location-rmii_rx_er  = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(12)>;
+	location-rmii-refclk = <GECKO_LOCATION(5) GECKO_PORT_D GECKO_PIN(10)>;
+	location-rmii-crs-dv = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(11)>;
+	location-rmii-txd0   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(7)>;
+	location-rmii-txd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(6)>;
+	location-rmii-tx-en  = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(8)>;
+	location-rmii-rxd0   = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(9)>;
+	location-rmii-rxd1   = <GECKO_LOCATION(1) GECKO_PORT_F GECKO_PIN(9)>;
+	location-rmii-rx-er  = <GECKO_LOCATION(1) GECKO_PORT_D GECKO_PIN(12)>;
 
 	status = "okay";
 };

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -60,24 +60,23 @@
 };
 
 &i2c_smb_0 {
-	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 	sda-gpios = <&gpio_000_036 3 0>;
 	scl-gpios = <&gpio_000_036 4 0>;
 };
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	sda-gpios = <&gpio_100_136 24 0>;
 	scl-gpios = <&gpio_100_136 25 0>;
 };
 
 &espi0 {
 	status = "okay";
-	io_girq = <19>;
-	vw_girqs = <24 25>;
-	pc_girq = <15>;
+	io-girq = <19>;
+	vw-girqs = <24 25>;
+	pc-girq = <15>;
 };
 
 &ps2_0 {

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -89,7 +89,7 @@
 
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 	sda-gpios = <&gpio_000_036 3 0>;
 	scl-gpios = <&gpio_000_036 4 0>;
 
@@ -112,23 +112,22 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	sda-gpios = <&gpio_100_136 24 0>;
 	scl-gpios = <&gpio_100_136 25 0>;
 };
 
 &i2c_smb_2 {
-	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	sda-gpios = <&gpio_000_036 10 0>;
 	scl-gpios = <&gpio_000_036 11 0>;
 };
 
 &espi0 {
 	status = "okay";
-	io_girq = <19>;
-	vw_girqs = <24 25>;
-	pc_girq = <15>;
+	io-girq = <19>;
+	vw-girqs = <24 25>;
+	pc-girq = <15>;
 };
 
 &timer5 {
@@ -157,8 +156,8 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <1>;
 };
 

--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -137,7 +137,7 @@
 /* I2C */
 &i2c_smb_0 {
 	status = "okay";
-	port_sel = <0>;
+	port-sel = <0>;
 
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
 	pinctrl-names = "default";
@@ -171,7 +171,7 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	port_sel = <1>;
+	port-sel = <1>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
 };
@@ -188,7 +188,7 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	port_sel = <7>;
+	port-sel = <7>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";
 };
@@ -207,8 +207,8 @@
 	status = "okay";
 	clock-frequency = <4000000>;
 	lines = <4>;
-	chip_select = <0>;
-	port_sel = <0>; /* Shared SPI */
+	chip-select = <0>;
+	port-sel = <0>; /* Shared SPI */
 
 	pinctrl-0 = < &shd_cs0_n_gpio055
 		      &shd_clk_gpio056

--- a/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
+++ b/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
@@ -19,7 +19,7 @@
 		irq-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
 
 		pclk = <5>;
-		pclk_pol = <1>;
+		pclk-pol = <1>;
 		cspread = <1>;
 		swizzle = <0>;
 		vsize = <272>;

--- a/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
@@ -26,7 +26,7 @@
 		segment-remap;
 		com-invdir;
 		prechargep = <0x22>;
-		data_cmd-gpios = <&arduino_header 15 0>;
+		data-cmd-gpios = <&arduino_header 15 0>;
 		/* reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; */
 	};
 };

--- a/doc/_scripts/gen_devicetree_rest.py
+++ b/doc/_scripts/gen_devicetree_rest.py
@@ -8,7 +8,6 @@ devicetree bindings.
 
 import argparse
 from collections import defaultdict
-import glob
 import io
 import logging
 import os
@@ -202,7 +201,8 @@ def setup_logging(verbose):
 def load_relevant_bindings(dts_roots):
     # Load just the bindings we care about from dts_roots.
 
-    bindings = load_bindings(dts_roots)
+    bindings = edtlib.bindings_from_dirs(f'{root}/dts/bindings' for root in
+                                         dts_roots)
     num_total = len(bindings)
 
     # Remove bindings from the 'vnd' vendor, which is not a real vendor,
@@ -215,18 +215,6 @@ def load_relevant_bindings(dts_roots):
                 len(bindings), num_total - len(bindings), dts_roots)
 
     return bindings
-
-def load_bindings(dts_roots):
-    # Get a list of edtlib.Binding objects from searching 'dts_roots'.
-
-    binding_files = []
-    for dts_root in dts_roots:
-        binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yml',
-                                       recursive=True))
-        binding_files.extend(glob.glob(f'{dts_root}/dts/bindings/**/*.yaml',
-                                       recursive=True))
-
-    return edtlib.bindings_from_paths(binding_files, ignore_errors=True)
 
 def load_base_binding():
     # Make a Binding object for base.yaml.

--- a/dts/arc/synopsys/arc_hsdk.dtsi
+++ b/dts/arc/synopsys/arc_hsdk.dtsi
@@ -135,9 +135,9 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf00014b0 0x4>;
 			ngpios = <12>;
-			bit_per_gpio = <2>;
-			off_val = <0>;
-			on_val = <2>;
+			bit-per-gpio = <2>;
+			off-val = <0>;
+			on-val = <2>;
 
 			gpio-controller;
 			#gpio-cells = <2>;

--- a/dts/arm/microchip/mec1501hsz.dtsi
+++ b/dts/arm/microchip/mec1501hsz.dtsi
@@ -434,7 +434,7 @@
 			rxdma = <11>;
 			txdma = <10>;
 			lines = <1>;
-			chip_select = <0>;
+			chip-select = <0>;
 			dcsckon = <6>;
 			dckcsoff = <4>;
 			dldh = <6>;

--- a/dts/arm/microchip/mec172xnsz.dtsi
+++ b/dts/arm/microchip/mec172xnsz.dtsi
@@ -697,7 +697,7 @@
 			pcrs = <4 8>;
 			clock-frequency = <12000000>;
 			lines = <1>;
-			chip_select = <0>;
+			chip-select = <0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
 			status = "disabled";

--- a/dts/arm/nxp/nxp_rt.dtsi
+++ b/dts/arm/nxp/nxp_rt.dtsi
@@ -773,7 +773,7 @@
 			dma-channels = <32>;
 			dma-requests = <128>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x400E8000 0x4000>,
 				<0x400EC000 0x4000>;
 			interrupts = <0 0>, <1 0>, <2 0>, <3 0>,

--- a/dts/arm/nxp/nxp_rt11xx.dtsi
+++ b/dts/arm/nxp/nxp_rt11xx.dtsi
@@ -897,7 +897,7 @@
 			dma-channels = <32>;
 			dma-requests = <208>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x40070000 0x4000>,
 				<0x40074000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_CLK 0x7C 0x000000C0>;
@@ -915,7 +915,7 @@
 			dma-channels = <32>;
 			dma-requests = <208>;
 			nxp,mem2mem;
-			nxp,a_on;
+			nxp,a-on;
 			reg = <0x40c14000 0x4000>,
 				<0x40c18000 0x4000>;
 			clocks = <&ccm IMX_CCM_EDMA_LPSR_CLK 0x7C 0x000000C0>;

--- a/dts/bindings/counter/nxp,imx-tmr.yaml
+++ b/dts/bindings/counter/nxp,imx-tmr.yaml
@@ -33,7 +33,7 @@ properties:
       - "kQTMR_SecSrcTrigPriCnt"
       - "kQTMR_CascadeCount"
 
-  primary_source:
+  primary-source:
     type: string
     required: true
     description: Primary source of the timer, see qtmr_primary_count_source_t enumerator type
@@ -56,7 +56,7 @@ properties:
       - "kQTMR_ClockDivide_64"
       - "kQTMR_ClockDivide_128"
 
-  secondary_source:
+  secondary-source:
     type: string
     required: false
     description: Secondary source of the timer, see qtmr_input_source_t enumerator type
@@ -67,12 +67,12 @@ properties:
       - "kQTMR_Counter2InputPin"
       - "kQTMR_Counter3InputPin"
 
-  filter_count:
+  filter-count:
     type: int
     required: false
     description: Fault filter count (0-255).
 
-  filter_period:
+  filter-period:
     type: int
     required: false
     description: Fault filter period (0-255).

--- a/dts/bindings/dac/microchip,mcp4728.yaml
+++ b/dts/bindings/dac/microchip,mcp4728.yaml
@@ -8,7 +8,7 @@ properties:
     "#io-channel-cells":
       const: 1
 
-    voltage_reference:
+    voltage-reference:
       type: array
       required: true
       description: |
@@ -17,7 +17,7 @@ properties:
         1 - Internal voltage reference (2.048V)
         Note: array entries correspond to the successive channels
 
-    power_down_mode:
+    power-down-mode:
       type: array
       required: true
       description: |

--- a/dts/bindings/display/ftdi,ft800.yaml
+++ b/dts/bindings/display/ftdi,ft800.yaml
@@ -21,7 +21,7 @@ properties:
         typical main clock was 48MHz and this value is 5, the PCLK
         will be 9.6 MHz. Must be positive value to enable the screen
 
-    pclk_pol:
+    pclk-pol:
       type: int
       required: true
       description: |

--- a/dts/bindings/display/solomon,ssd1306fb-spi.yaml
+++ b/dts/bindings/display/solomon,ssd1306fb-spi.yaml
@@ -8,7 +8,7 @@ compatible: "solomon,ssd1306fb"
 include: ["solomon,ssd1306fb-common.yaml", "spi-device.yaml"]
 
 properties:
-    data_cmd-gpios:
+    data-cmd-gpios:
       type: phandle-array
       required: true
       description: D/C# pin.

--- a/dts/bindings/dma/nxp,mcux-edma.yaml
+++ b/dts/bindings/dma/nxp,mcux-edma.yaml
@@ -24,7 +24,7 @@ properties:
       type: boolean
       description: If the DMA controller supports memory to memory transfer
 
-    nxp,a_on:
+    nxp,a-on:
       type: boolean
       description: If the DMA controller supports always on
 

--- a/dts/bindings/espi/microchip,xec-espi-saf.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-saf.yaml
@@ -13,32 +13,32 @@ properties:
       description: mmio register space
       required: true
 
-    io_girq:
+    io-girq:
       type: int
       description: soc group irq index for eSPI I/O
       required: false
 
-    poll_timeout:
+    poll-timeout:
       type: int
       description: poll flash busy timeout in 32KHz periods
       required: false
 
-    poll_interval:
+    poll-interval:
       type: int
       description: interval between flash busy poll in 20 ns units
       required: false
 
-    consec_rd_timeout:
+    consec-rd-timeout:
       type: int
       description: timeout after last read to resume supended operations in 20 ns units
       required: false
 
-    sus_chk_delay:
+    sus-chk-delay:
       type: int
       description: hold off poll after suspend in 20 ns units
       required: false
 
-    sus_rsm_interval:
+    sus-rsm-interval:
       type: int
       description: force suspended erase or program to resume in 32KHz periods
       required: false

--- a/dts/bindings/espi/microchip,xec-espi.yaml
+++ b/dts/bindings/espi/microchip,xec-espi.yaml
@@ -12,17 +12,17 @@ properties:
       description: mmio register space
       required: true
 
-    io_girq:
+    io-girq:
       type: int
       description: soc group irq index for eSPI I/O
       required: true
 
-    vw_girqs:
+    vw-girqs:
       type: array
       description: soc group irq indexes for eSPI virtual wires channel
       required: true
 
-    pc_girq:
+    pc-girq:
       type: int
       description: soc group irq index for eSPI peripheral channel
       required: true

--- a/dts/bindings/ethernet/silabs,gecko-ethernet.yaml
+++ b/dts/bindings/ethernet/silabs,gecko-ethernet.yaml
@@ -36,66 +36,66 @@ properties:
       description: location of MDC and MDIO pins, configuration defined as <location>
 
     # PHY management pins
-    location-phy_mdc:
+    location-phy-mdc:
       type: array
       required: true
       description: PHY MDC individual pin configuration defined as <location port pin>
 
-    location-phy_mdio:
+    location-phy-mdio:
       type: array
       required: true
       description: PHY MDIO individual pin configuration defined as <location port pin>
 
     # RMII interface pins
-    location-rmii_refclk:
+    location-rmii-refclk:
       type: array
       required: true
       description: Reference clock individual pin configuration defined as <location port pin>
 
-    location-rmii_crs_dv:
+    location-rmii-crs-dv:
       type: array
       required: true
       description: Receive data valid individual pin configuration defined as <location port pin>
 
-    location-rmii_txd0:
+    location-rmii-txd0:
       type: array
       required: true
       description: Transmit data 0 individual pin configuration defined as <location port pin>
 
-    location-rmii_txd1:
+    location-rmii-txd1:
       type: array
       required: true
       description: Transmit data 1 individual pin configuration defined as <location port pin>
 
-    location-rmii_tx_en:
+    location-rmii-tx-en:
       type: array
       required: true
       description: Transmit enable individual pin configuration defined as <location port pin>
 
-    location-rmii_rxd0:
+    location-rmii-rxd0:
       type: array
       required: true
       description: Receive data 0 individual pin configuration defined as <location port pin>
 
-    location-rmii_rxd1:
+    location-rmii-rxd1:
       type: array
       required: true
       description: Receive data 1 individual pin configuration defined as <location port pin>
 
-    location-rmii_rx_er:
+    location-rmii-rx-er:
       type: array
       required: true
       description: Receive error individual pin configuration defined as <location port pin>
 
     # PHY control pins
-    location-phy_pwr_enable:
+    location-phy-pwr-enable:
       type: array
       description: PHY power enable individual pin configuration defined as <port pin>
 
-    location-phy_reset:
+    location-phy-reset:
       type: array
       description: PHY reset individual pin configuration defined as <port pin>
 
-    location-phy_interrupt:
+    location-phy-interrupt:
       type: array
       description: PHY interrupt individual pin configuration defined as <port pin>

--- a/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
+++ b/dts/bindings/gpio/nuvoton,nct38xx-gpio-port.yaml
@@ -11,7 +11,7 @@ properties:
     reg:
       required: true
 
-    pin_mask:
+    pin-mask:
       type: int
       required: true
       description: |
@@ -21,7 +21,7 @@ properties:
         NCT3808: <0xdc>
         others: <0xff>
 
-    pinmux_mask:
+    pinmux-mask:
       type: int
       required: false
       description: |

--- a/dts/bindings/gpio/snps,creg-gpio.yaml
+++ b/dts/bindings/gpio/snps,creg-gpio.yaml
@@ -11,15 +11,15 @@ properties:
     reg:
       required: true
 
-    bit_per_gpio:
+    bit-per-gpio:
       type: int
       required: true
 
-    off_val:
+    off-val:
       type: int
       required: true
 
-    on_val:
+    on-val:
       type: int
       required: true
 

--- a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
@@ -11,7 +11,7 @@ properties:
     reg:
       required: true
 
-    port_sel:
+    port-sel:
       type: int
       description: soc block mapping to pin
       required: true

--- a/dts/bindings/i2c/microchip,xec-i2c.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c.yaml
@@ -11,7 +11,7 @@ properties:
     reg:
       required: true
 
-    port_sel:
+    port-sel:
       type: int
       description: soc block mapping to pin
       required: true

--- a/dts/bindings/i2s/litex,i2s.yaml
+++ b/dts/bindings/i2s/litex,i2s.yaml
@@ -13,6 +13,6 @@ properties:
     reg:
         required: true
 
-    fifo_depth:
+    fifo-depth:
         type: int
         required: true

--- a/dts/bindings/led/ti,lp503x.yaml
+++ b/dts/bindings/led/ti,lp503x.yaml
@@ -8,12 +8,12 @@ compatible: "ti,lp503x"
 include: ["i2c-device.yaml", "led-controller.yaml"]
 
 properties:
-    max_curr_opt:
+    max-curr-opt:
       type: boolean
       required: false
       description: |
         If enabled the maximum current output is set to 35 mA (25.5 mA else).
-    log_scale_en:
+    log-scale-en:
       type: boolean
       required: false
       description: |

--- a/dts/bindings/sdhc/nxp,imx-usdhc.yaml
+++ b/dts/bindings/sdhc/nxp,imx-usdhc.yaml
@@ -32,7 +32,7 @@ properties:
     description: |
       Number of words used as write watermark level in FIFO queue for USDHC
 
-  max_current_330:
+  max-current-330:
     type: int
     required: false
     default: 0

--- a/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
+++ b/dts/bindings/spi/microchip,xec-qmspi-ldma.yaml
@@ -42,7 +42,7 @@ properties:
         MOSI and MISO or half-duplex on MOSI only. Lines set to 2
         or 4 indicate dual or quad I/O modes. Defaults to 1.
 
-    port_sel:
+    port-sel:
       type: int
       required: false
       description: |
@@ -51,7 +51,7 @@ properties:
         chip configurations with an embedded SPI flash. Defaults
         to port 0 (shared SPI port).
 
-    chip_select:
+    chip-select:
       type: int
       required: false
       description: |

--- a/dts/bindings/spi/microchip,xec-qmspi.yaml
+++ b/dts/bindings/spi/microchip,xec-qmspi.yaml
@@ -11,7 +11,7 @@ properties:
     reg:
       required: true
 
-    port_sel:
+    port-sel:
       type: int
       required: true
       description: SPI Port 0 or 1.
@@ -31,7 +31,7 @@ properties:
       required: true
       description: QMSPI lines 1, 2, or 4
 
-    chip_select:
+    chip-select:
       type: int
       required: true
       description: Use QMSPI CS0# or CS1#

--- a/dts/riscv/riscv32-litex-vexriscv.dtsi
+++ b/dts/riscv/riscv32-litex-vexriscv.dtsi
@@ -228,7 +228,7 @@
 				"rx_stat",
 				"rx_conf",
 				"fifo";
-			fifo_depth = <256>;
+			fifo-depth = <256>;
 			status = "disabled";
 		};
 		i2s_tx: i2s_tx@e000b000 {
@@ -251,7 +251,7 @@
 				"tx_stat",
 				"tx_conf",
 				"fifo";
-			fifo_depth = <256>;
+			fifo-depth = <256>;
 			status = "disabled";
 		};
 		clock-outputs {

--- a/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
+++ b/samples/drivers/espi/boards/mec1501modular_assy6885.overlay
@@ -16,7 +16,7 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <4>;
 };

--- a/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
+++ b/samples/drivers/espi/boards/mec15xxevb_assy6853.overlay
@@ -16,7 +16,7 @@
 
 &spi0 {
 	status = "okay";
-	port_sel = <0>;
-	chip_select = <0>;
+	port-sel = <0>;
+	chip-select = <0>;
 	lines = <4>;
 };

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -1037,6 +1037,8 @@ def parse_args():
     parser.add_argument("-v", "--loglevel", help="python logging level")
 
     parser.add_argument('-m', '--module', action="append", default=[],
+                        choices=[testcase.name for testcase in
+                                 ComplianceTest.__subclasses__()],
                         help="Checks to run. All checks by default.")
 
     parser.add_argument('-e', '--exclude-module', action="append", default=[],

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -23,10 +23,14 @@ EDIT_TIP = "\n\n*Tip: The bot edits this comment instead of posting a new " \
            "one, so you can check the comment's history to see earlier " \
            "messages.*"
 
+HERE = Path(__file__).parent
+
 logger = None
 
-# This ends up as None when we're not running in a Zephyr tree
-ZEPHYR_BASE = os.environ.get('ZEPHYR_BASE')
+# This ends up using the current repository if ZEPHYR_BASE is unset.
+ZEPHYR_BASE = (os.environ.get('ZEPHYR_BASE') or
+               str((HERE / '..' / '..').resolve()))
+os.environ['ZEPHYR_BASE'] = ZEPHYR_BASE
 
 
 def git(*args, cwd=None):

--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -611,7 +611,7 @@ UNDEF_KCONFIG_WHITELIST = {
 
 class KconfigBasicCheck(KconfigCheck, ComplianceTest):
     """
-    Checks is we are introducing any new warnings/errors with Kconfig,
+    Checks if we are introducing any new warnings/errors with Kconfig,
     for example using undefined Kconfig variables.
     This runs the basic Kconfig test, which is checking only for undefined
     references inside the Kconfig tree.

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -69,6 +69,7 @@ bindings_from_paths() helper function.
 
 from collections import OrderedDict, defaultdict
 from copy import deepcopy
+import glob
 import logging
 import os
 import re
@@ -2006,6 +2007,35 @@ class Binding:
                                                      (int, str)):
                 _err(f"const in {self.path} for property '{prop_name}' "
                      "is not a scalar")
+
+
+def bindings_from_dirs(dirs):
+    """
+    Get a list of Binding objects from any yaml files discovered
+    under 'dirs', an iterable of os.PathLike.
+
+    All subdirectories of 'dirs' are searched for valid YAML files.
+    YAML files that do not result in complete bindings are ignored;
+    this handles 'include' files like base.yaml.
+
+    Note: *ALL* subdirectories, *NOT* just dts/bindings/ subdirectories!
+    This is meant as a general purpose helper for loading bindings that
+    that doesn't care about zephyr file system conventions.
+
+    If 'ignore_errors' is True, YAML files that cause an EDTError when
+    loaded are ignored. (No other exception types are silenced.)
+    """
+    if isinstance(dirs, str):
+        raise TypeError('expected iterable of os.PathLike, not str')
+
+    yaml_files = []
+
+    for path in dirs:
+        fspath = os.fspath(path)
+        yaml_files.extend(glob.glob(f'{fspath}/**/*.yml', recursive=True))
+        yaml_files.extend(glob.glob(f'{fspath}/**/*.yaml', recursive=True))
+
+    return bindings_from_paths(yaml_files, ignore_errors=True)
 
 
 def bindings_from_paths(yaml_paths, ignore_errors=False):

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -528,15 +528,17 @@ class EDT:
             if node.path != '/' and \
                    vendor not in self._vendor_prefixes and \
                    vendor not in _VENDOR_PREFIX_ALLOWED:
-                if self._werror:
-                    handler_fn = _err
-                else:
-                    handler_fn = _LOG.warning
-                handler_fn(
+                self._warning(
                     f"node '{node.path}' compatible '{compat}' "
                     f"has unknown vendor prefix '{vendor}'")
 
         self._checked_compatibles.add(compat)
+
+    def _warning(self, msg):
+        if self._werror:
+            _err(msg)
+        else:
+            _LOG.warning(msg)
 
 class Node:
     """

--- a/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
+++ b/tests/boards/mec15xxevb_assy6853/qspi/boards/mec15xxevb_assy6853.overlay
@@ -6,7 +6,7 @@
 
 &spi0 {
         status = "okay";
-        port_sel = <0>;
-        chip_select = <0>;
+        port-sel = <0>;
+        chip-select = <0>;
         lines = <4>;
 };

--- a/tests/drivers/build_all/gpio/app.overlay
+++ b/tests/drivers/build_all/gpio/app.overlay
@@ -96,8 +96,8 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xff>;
-					pinmux_mask = <0xf7>;
+					pin-mask = <0xff>;
+					pinmux-mask = <0xf7>;
 				};
 
 				gpio@1 {
@@ -106,7 +106,7 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xff>;
+					pin-mask = <0xff>;
 				};
 			};
 
@@ -122,8 +122,8 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xdc>;
-					pinmux_mask = <0xff>;
+					pin-mask = <0xdc>;
+					pinmux-mask = <0xff>;
 				};
 			};
 
@@ -139,8 +139,8 @@
 					gpio-controller;
 					#gpio-cells = <2>;
 					ngpios = <8>;
-					pin_mask = <0xdc>;
-					pinmux_mask = <0xff>;
+					pin-mask = <0xdc>;
+					pinmux-mask = <0xff>;
 				};
 			};
 		};

--- a/tests/drivers/counter/counter_basic_api/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/counter/counter_basic_api/boards/mimxrt1060_evk.overlay
@@ -1,5 +1,5 @@
 &qtmr1_timer0 {
 	status = "okay";
-	primary_source = "kQTMR_ClockDivide_128";
+	primary-source = "kQTMR_ClockDivide_128";
 	mode = "kQTMR_PriSrcRiseEdge";
 };


### PR DESCRIPTION
The main point of this PR is to add a new compliance check for devicetree bindings. This happens in the final two patches.The initial check enforces that we use `-` as a separator in property names instead of `_`, which is a common mistake.

The beginning of the PR is clean up, prep work, and miscellaneous fixes along the way.