### PR TITLE
intel_adsp: ace: reduce hda dma channels

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -234,7 +234,7 @@
 			compatible = "intel,adsp-hda-host-out";
 			#dma-cells = <1>;
 			reg = <0x00072800 0x40>;
-			dma-channels = <9>;
+			dma-channels = <5>;
 			dma-buf-alignment = <128>;
 			status = "okay";
 		};
@@ -243,7 +243,7 @@
 			compatible = "intel,adsp-hda-host-in";
 			#dma-cells = <1>;
 			reg = <0x00072c00 0x40>;
-			dma-channels = <10>;
+			dma-channels = <5>;
 			dma-buf-alignment = <128>;
 			status = "okay";
 		};
@@ -252,7 +252,7 @@
 			compatible = "intel,adsp-hda-link-out";
 			#dma-cells = <1>;
 			reg = <0x00072400 0x40>;
-			dma-channels = <9>;
+			dma-channels = <5>;
 			dma-buf-alignment = <128>;
 			status = "okay";
 		};
@@ -261,7 +261,7 @@
 			compatible = "intel,adsp-hda-link-in";
 			#dma-cells = <1>;
 			reg = <0x00072600 0x40>;
-			dma-channels = <10>;
+			dma-channels = <5>;
 			dma-buf-alignment = <128>;
 			status = "okay";
 		};


### PR DESCRIPTION
This configuration does not work on some variants (simulator), reduce
the number to something that work on all variants.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
