### PR TITLE
arch: fix typos for arch_icache_disable

### DIFF
--- a/include/zephyr/sys/arch_interface.h
+++ b/include/zephyr/sys/arch_interface.h
@@ -1036,11 +1036,11 @@ void arch_icache_enable(void);
 
 /**
  *
- * @brief Enable i-cache
+ * @brief Disable i-cache
  *
- * @see arch_dcache_disable
+ * @see arch_icache_disable
  */
-void arch_dcache_disable(void);
+void arch_icache_disable(void);
 
 /**
  *


### PR DESCRIPTION
The arch_icache_disable function was not correctly declared in arch_interface.h due to a typo.