### PR TITLE
RFC: shell: utilize api_type to filter 'struct devices'

### DIFF
--- a/cmake/kobj.cmake
+++ b/cmake/kobj.cmake
@@ -10,6 +10,7 @@ function(gen_kobj gen_dir_out)
   set(KOBJ_TYPES ${gen_dir}/kobj-types-enum.h)
   set(KOBJ_OTYPE ${gen_dir}/otype-to-str.h)
   set(KOBJ_SIZE ${gen_dir}/otype-to-size.h)
+  set(DRV_API_TO_KOBJ_TYPES ${gen_dir}/driver-api-to-kobj-enum.h)
 
   file(MAKE_DIRECTORY ${gen_dir})
 
@@ -19,6 +20,7 @@ function(gen_kobj gen_dir_out)
     ${PYTHON_EXECUTABLE}
     ${ZEPHYR_BASE}/scripts/build/gen_kobject_list.py
     --kobj-types-output ${KOBJ_TYPES}
+    --driver-api-to-kobj-types-output ${DRV_API_TO_KOBJ_TYPES}
     --kobj-otype-output ${KOBJ_OTYPE}
     --kobj-size-output ${KOBJ_SIZE}
     ${gen_kobject_list_include_args}

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -261,7 +261,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_lookup(idx, K_OBJ_DRIVER_FLASH);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -14,7 +14,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_shell, CONFIG_LOG_DEFAULT_LEVEL);
 
-#define I2C_DEVICE_PREFIX "I2C_"
 #define MAX_BYTES_FOR_REGISTER_INDEX	4
 #define ARGV_DEV	1
 #define ARGV_ADDR	2
@@ -277,7 +276,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, I2C_DEVICE_PREFIX);
+	const struct device *dev = shell_device_lookup(idx, K_OBJ_DRIVER_I2C);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -197,7 +197,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, NULL);
+	const struct device *dev = shell_device_lookup(idx, K_OBJ_DRIVER_SENSOR);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -7,6 +7,8 @@
 #ifndef ZEPHYR_INCLUDE_DEVICE_H_
 #define ZEPHYR_INCLUDE_DEVICE_H_
 
+#include <driver-api-to-kobj-enum.h>
+
 /**
  * @brief Device Driver APIs
  * @defgroup io_interfaces Device Driver APIs
@@ -467,6 +469,9 @@ struct device {
 	const void *config;
 	/** Address of the API structure exposed by the device instance */
 	const void *api;
+#ifdef CONFIG_HAS_API_TYPE
+	enum k_objects api_type;
+#endif
 	/** Address of the common device state */
 	struct device_state *state;
 	/** Address of the device instance private data */
@@ -940,6 +945,7 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		.name = drv_name,					\
 		.config = (cfg_ptr),					\
 		.api = (api_ptr),					\
+		IF_ENABLED(CONFIG_HAS_API_TYPE,(.api_type = api2kobjs(api_ptr),))	\
 		.state = (state_ptr),					\
 		.data = (data_ptr),					\
 		COND_CODE_1(CONFIG_PM_DEVICE, (.pm = pm_device,), ())	\

--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -17,6 +17,8 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/sys/util.h>
 
+#include <zephyr/sys/kobject.h>
+
 #if defined CONFIG_SHELL_GETOPT
 #include <getopt.h>
 #endif
@@ -122,7 +124,7 @@ struct shell_static_args {
  * start with this text.  Pass null if no prefix match is required.
  */
 const struct device *shell_device_lookup(size_t idx,
-				   const char *prefix);
+				   enum k_objects type);
 
 /**
  * @brief Shell command handler prototype.

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -943,6 +943,12 @@ config HAS_DYNAMIC_DEVICE_HANDLES
 	  Hidden option that makes possible to manipulate device handles at
 	  runtime.
 
+config HAS_API_TYPE
+	bool
+	help
+	  Hidden option that adds storage and setting of driver api type in
+          struct device.
+
 endmenu
 
 rsource "Kconfig.vm"

--- a/scripts/build/gen_kobject_list.py
+++ b/scripts/build/gen_kobject_list.py
@@ -927,6 +927,16 @@ def write_kobj_types_output(fp):
         fp.write("K_OBJ_DRIVER_%s,\n" % subsystem)
 
 
+def write_api_to_kobjs_output(fp):
+    fp.write("/* Driver subsystems */\n")
+
+    fp.write("#define api2kobjs(x) _Generic((x), \\\n")
+    for subsystem in subsystems:
+        subsys = subsystem.replace("_driver_api", "").upper()
+        fp.write("\tstruct %s *: K_OBJ_DRIVER_%s,\\\n" % (subsystem, subsys))
+        fp.write("\tconst struct %s *: K_OBJ_DRIVER_%s,\\\n" % (subsystem, subsys))
+    fp.write("\tdefault: K_OBJ_ANY)\n")
+
 def write_kobj_otype_output(fp):
     fp.write("/* Core kernel objects */\n")
     for kobj, obj_info in kobjects.items():
@@ -990,6 +1000,9 @@ def parse_args():
         "-V", "--validation-output", required=False,
         help="Output driver validation macros")
     parser.add_argument(
+        "-D", "--driver-api-to-kobj-types-output", required=False,
+        help="Output driver api to k_object macro")
+    parser.add_argument(
         "-K", "--kobj-types-output", required=False,
         help="Output k_object enum constants")
     parser.add_argument(
@@ -1040,6 +1053,10 @@ def main():
     if args.validation_output:
         with open(args.validation_output, "w") as fp:
             write_validation_output(fp)
+
+    if args.driver_api_to_kobj_types_output:
+        with open(args.driver_api_to_kobj_types_output, "w") as fp:
+            write_api_to_kobjs_output(fp)
 
     if args.kobj_types_output:
         with open(args.kobj_types_output, "w") as fp:

--- a/subsys/shell/Kconfig
+++ b/subsys/shell/Kconfig
@@ -9,6 +9,7 @@ menuconfig SHELL
 	bool "Shell"
 	imply LOG_RUNTIME_FILTERING
 	select POLL
+	select HAS_API_TYPE
 
 if SHELL
 

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -494,8 +494,7 @@ void z_shell_cmd_trim(const struct shell *shell)
 	shell->ctx->cmd_buff_pos = shell->ctx->cmd_buff_len;
 }
 
-const struct device *shell_device_lookup(size_t idx,
-				   const char *prefix)
+const struct device *shell_device_lookup(size_t idx, enum k_objects type)
 {
 	size_t match_idx = 0;
 	const struct device *dev;
@@ -506,9 +505,7 @@ const struct device *shell_device_lookup(size_t idx,
 		if (device_is_ready(dev)
 		    && (dev->name != NULL)
 		    && (strlen(dev->name) != 0)
-		    && ((prefix == NULL)
-			|| (strncmp(prefix, dev->name,
-				    strlen(prefix)) == 0))) {
+		    && (dev->api_type == type)) {
 			if (match_idx == idx) {
 				return dev;
 			}


### PR DESCRIPTION
Utilize a C11 feature (_Generic) to create a macro so we can store the a kobject_enum that encodes the `api_type`.  We can than utilize that to rework `shell_device_lookup` to filter utilizing the `api_type` data.