### PR TITLE
samples: tracing: make example in readme work

### DIFF
--- a/samples/subsys/tracing/README.txt
+++ b/samples/subsys/tracing/README.txt
@@ -18,6 +18,9 @@ or:
 
     cmake -DBOARD=mps2_an521 -DCONF_FILE=prj_uart_ctf.conf ..
 
+NOTE: You may need to set 'zephyr,tracing-uart' property under the chosen
+node in your devicetree.  See boards/mps2_an521.overlay for an example.
+
 After the application has run for a while, check the trace output file.
 
 --------------------------------------------------------------------------------

--- a/samples/subsys/tracing/boards/mps2_an521.overlay
+++ b/samples/subsys/tracing/boards/mps2_an521.overlay
@@ -1,0 +1,7 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+/ {
+       chosen {
+               zephyr,tracing-uart = &uart1;
+       };
+};

--- a/samples/subsys/tracing/sample.yaml
+++ b/samples/subsys/tracing/sample.yaml
@@ -18,6 +18,7 @@ tests:
   tracing.transport.uart:
     platform_allow: qemu_x86 qemu_x86_64
     extra_args: CONF_FILE="prj_uart.conf"
+    filter: dt_chosen_enabled("zephyr,tracing-uart")
   tracing.transport.usb:
     platform_allow: sam_e70_xplained
     depends_on: usb_device
@@ -25,6 +26,7 @@ tests:
   tracing.transport.ctf:
     platform_allow: qemu_x86 qemu_x86_64
     extra_args: CONF_FILE="prj_uart_ctf.conf"
+    filter: dt_chosen_enabled("zephyr,tracing-uart")
   tracing.transport.ctf:
     platform_allow: sam_e70_xplained
     depends_on: usb_device


### PR DESCRIPTION
Add mps2_an521.overlay so that the example in the README.txt will
actually build.  Update README.txt to document needing to have
'zephyr,tracing-uart' property set under chosen node in devicetree.

Fixes #48416

Signed-off-by: Kumar Gala <galak@kernel.org>