### PR TITLE
drivers: spi: Add default char to mcux flexcomm spi driver

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -36,6 +36,7 @@ struct spi_mcux_config {
 	uint32_t post_delay;
 	uint32_t frame_delay;
 	uint32_t transfer_delay;
+	uint32_t def_char;
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
 #endif
@@ -247,9 +248,10 @@ static int spi_mcux_configure(const struct device *dev,
 
 		SPI_MasterInit(base, &master_config, clock_freq);
 
+		SPI_SetDummyData(base, (uint8_t)config->def_char);
+
 		SPI_MasterTransferCreateHandle(base, &data->handle,
 					     spi_mcux_transfer_callback, data);
-		SPI_SetDummyData(base, 0);
 
 		data->ctx.config = spi_cfg;
 	} else {
@@ -277,6 +279,8 @@ static int spi_mcux_configure(const struct device *dev,
 		slave_config.dataWidth = word_size - 1;
 
 		SPI_SlaveInit(base, &slave_config);
+
+		SPI_SetDummyData(base, (uint8_t)config->def_char);
 
 		SPI_SlaveTransferCreateHandle(base, &data->handle,
 					      spi_mcux_transfer_callback, data);
@@ -823,6 +827,7 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 		.post_delay = DT_INST_PROP_OR(id, post_delay, 0),		\
 		.frame_delay = DT_INST_PROP_OR(id, frame_delay, 0),		\
 		.transfer_delay = DT_INST_PROP_OR(id, transfer_delay, 0),		\
+		.def_char = DT_INST_PROP_OR(id, def_char, 0),		\
 		SPI_MCUX_FLEXCOMM_PINCTRL_INIT(id)			\
 	};								\
 	static struct spi_mcux_data spi_mcux_data_##id = {		\

--- a/dts/bindings/spi/nxp,lpc-spi.yaml
+++ b/dts/bindings/spi/nxp,lpc-spi.yaml
@@ -36,3 +36,10 @@ properties:
       description: |
         Delay in nanoseconds inserted between transfers when chip select is
         deasserted. If not set, no additional delay is inserted.
+
+    def-char:
+      type: int
+      required: false
+      description: |
+          Default character clocked out when the TX buffer pointer is NULL.
+          Applies to SPI master and slave configurations.


### PR DESCRIPTION
Adds optional device tree property to specify a default character
to clock out when the TX buffer pointer is NULL. If the property is
not set the existing behavior (default char of 0x00) is used.

I verified the expected behavior using an i.MX RT685 board and
logic analyzer that the def-char character is transmitted when
TX buffer pointer is NULL.

Signed-off-by: Bryce Wilkins <bryce.wilkins@gmail.com>