### PR TITLE
drivers: spi: Set spi context for mcux flexcomm spi slave configuration

### DIFF
--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -280,6 +280,8 @@ static int spi_mcux_configure(const struct device *dev,
 
 		SPI_SlaveTransferCreateHandle(base, &data->handle,
 					      spi_mcux_transfer_callback, data);
+
+		data->ctx.config = spi_cfg;
 	}
 
 	return 0;


### PR DESCRIPTION
This is a bug fix. A pointer to the spi configuration is not saved when
the spi driver is configured for slave operation and it can lead to
runtime errors.

The problem covered by #40939 and specifically mentioned in https://github.com/zephyrproject-rtos/zephyr/issues/40939#issuecomment-1083299523

Signed-off-by: Bryce Wilkins <bryce.wilkins@gmail.com>