### PR TITLE
drivers: nrf_rtc_timer: Add z_nrf_rtc_timer_compare_evt_publish_set

### DIFF
--- a/drivers/timer/Kconfig.nrf_rtc
+++ b/drivers/timer/Kconfig.nrf_rtc
@@ -18,7 +18,7 @@ if NRF_RTC_TIMER
 
 config NRF_RTC_TIMER_USER_CHAN_COUNT
 	int "Additional channels that can be used"
-	default 2 if NRF_802154_RADIO_DRIVER
+	default 3 if NRF_802154_RADIO_DRIVER
 	default 0
 	help
 	  Use nrf_rtc_timer.h API. Driver is not managing allocation of channels.

--- a/include/zephyr/drivers/timer/nrf_rtc_timer.h
+++ b/include/zephyr/drivers/timer/nrf_rtc_timer.h
@@ -65,6 +65,22 @@ uint64_t z_nrf_rtc_timer_read(void);
  */
 uint32_t z_nrf_rtc_timer_compare_evt_address_get(int32_t chan);
 
+/** @brief Configure publishing of the COMPARE event to (D)PPI.
+ *
+ * @param chan Channel ID between 1 and CONFIG_NRF_RTC_TIMER_USER_CHAN_COUNT.
+ *
+ * @param ppi (D)PPI channel to publish to.
+ */
+void z_nrf_rtc_timer_compare_evt_publish_set(int32_t chan, uint32_t ppi);
+
+/** @brief Clear COMPARE event publishing configuration.
+ *
+ * @param chan Channel ID that was previously configured.
+ *
+ * @param ppi (D)PPI channel to which publishing is to be cleared.
+ */
+void z_nrf_rtc_timer_compare_evt_publish_clear(int32_t chan, uint32_t ppi);
+
 /** @brief Get CAPTURE task register address.
  *
  * Address can be used for (D)PPI.


### PR DESCRIPTION
Add function for publishing the RTC compare event to (D)PPI channel.

Thanks to these extensions the user is no longer forced to use the HAL directly to create (D)PPI connections with RTC.