### PR TITLE
drivers: hwinfo: Fix mcux device id

### DIFF
--- a/drivers/hwinfo/hwinfo_mcux_syscon.c
+++ b/drivers/hwinfo/hwinfo_mcux_syscon.c
@@ -10,19 +10,30 @@
 #include <string.h>
 #include <zephyr/sys/byteorder.h>
 
+#define UID_WORD_COUNT (DT_INST_REG_SIZE(0) / sizeof(uint32_t))
+
+struct uid {
+	uint32_t id[UID_WORD_COUNT];
+};
+
 ssize_t z_impl_hwinfo_get_device_id(uint8_t *buffer, size_t length)
 {
-	uint8_t *uid_addr = (uint8_t *) DT_INST_REG_ADDR(0);
+	volatile const uint32_t * const uid_addr = (uint32_t *) DT_INST_REG_ADDR(0);
+	struct uid dev_id;
 
 	if (buffer == NULL) {
 		return 0;
 	}
 
-	if (length > DT_INST_REG_SIZE(0)) {
-		length = DT_INST_REG_SIZE(0);
+	for (size_t i = 0 ; i < UID_WORD_COUNT ; i++) {
+		dev_id.id[i] = sys_cpu_to_be32(uid_addr[i]);
 	}
 
-	memcpy(buffer, uid_addr, length);
+	if (length > sizeof(dev_id.id)) {
+		length = sizeof(dev_id.id);
+	}
+
+	memcpy(buffer, dev_id.id, length);
 
 	return length;
 }


### PR DESCRIPTION
This fixes an issue where the unique device identifier is incorrectly
copied from an address on the AHB bus to memory using memcpy.

I verified corrected behavior by comparing `hwinfo devid` command
output to memory view of the SoC using the debugger.

Fixes #48447

Signed-off-by: Bryce Wilkins <bryce.wilkins@gmail.com>