### PR TITLE
Bluetooth: controller: llcp: fix failing LL/CON/CEN/BV-55-C

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -301,7 +301,9 @@ static uint8_t pu_update_eff_times(struct ll_conn *conn, struct proc_ctx *ctx)
 	}
 
 	if ((eff_tx_time > lll->dle.eff.max_tx_time) ||
-	    (eff_rx_time > lll->dle.eff.max_rx_time)) {
+	    (lll->dle.eff.max_tx_time > max_tx_time) ||
+	    (eff_rx_time > lll->dle.eff.max_rx_time) ||
+	    (lll->dle.eff.max_rx_time > max_rx_time)) {
 		lll->dle.eff.max_tx_time = eff_tx_time;
 		lll->dle.eff.max_rx_time = eff_rx_time;
 		return 1U;


### PR DESCRIPTION
The mandatory minimum PDU length conformance test was failing
because the LLCP did update the effective rx/tx times (and
corresponding notification to host).
This was due to a missing test condition.

This PR adds the missing conditions.

Note that with this change the refactored controller code is
similar to the legacy code; relevant code is in ull_conn.c,
in the function event_phy_upd_ind_prep

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>