### PR TITLE
Bluetooth: SMP: Fix min key size for LE Secure Connections Only mode

### DIFF
--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -514,8 +514,8 @@ config BT_SMP_MIN_ENC_KEY_SIZE
 	int
 	prompt "Minimum encryption key size accepted in octets" if !BT_SMP_SC_ONLY
 	range 7 16
-	default 7
 	default 16 if BT_SMP_SC_ONLY
+	default 7
 	help
 	  This option sets the minimum encryption key size accepted during pairing.
 


### PR DESCRIPTION
Secure Connection Only mode requires use of LE Security mode 1 level 4
which mandates 128 encryption key size.

Defaults in Kconfig are set from top-to-bottom and this resulted in
7 bytes key being forced. What is worse, user cannot override this
from prj.conf file since BT_SMP_MIN_ENC_KEY_SIZE is hidden config
if BT_SMP_SC_ONLY is enabled.

Signed-off-by: Szymon Janc <szymon.janc@codecoup.pl>