### PR TITLE
bluetooth: Add le power control feature host apis

### DIFF
--- a/include/zephyr/bluetooth/hci.h
+++ b/include/zephyr/bluetooth/hci.h
@@ -534,6 +534,53 @@ struct bt_hci_rp_read_tx_power_level {
 	int8_t   tx_power_level;
 } __packed;
 
+#define BT_HCI_LE_TX_POWER_PHY_1M               0x01
+#define BT_HCI_LE_TX_POWER_PHY_2M               0x02
+#define BT_HCI_LE_TX_POWER_PHY_CODED_S8         0x03
+#define BT_HCI_LE_TX_POWER_PHY_CODED_S2         0x04
+#define BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL    BT_OP(BT_OGF_LE, 0x0076)
+struct bt_hci_cp_le_read_tx_power_level {
+	uint16_t handle;
+	uint8_t  phy;
+} __packed;
+
+struct bt_hci_rp_le_read_tx_power_level {
+	uint8_t  status;
+	uint16_t handle;
+	uint8_t  phy;
+	int8_t   current_tx_power_level;
+	int8_t   max_tx_power_level;
+} __packed;
+
+#define BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL	BT_OP(BT_OGF_LE, 0x0077)
+
+#define BT_HCI_OP_LE_SET_PATH_LOSS_REPORT_PARAM BT_OP(BT_OGF_LE, 0x0078)
+struct bt_hci_cp_le_set_path_loss_report_param {
+	uint16_t handle;
+	int8_t   high_threshold;
+	int8_t   high_hysteresis;
+	int8_t   low_threshold;
+	int8_t   low_hysteresis;
+	uint16_t min_time_spent;
+} __packed;
+
+#define BT_HCI_LE_PATH_LOSS_REPORT_DISABLE       0x00
+#define BT_HCI_LE_PATH_LOSS_REPORT_ENABLE        0x01
+#define BT_HCI_OP_LE_SET_PATH_LOSS_REPORT_ENABLE BT_OP(BT_OGF_LE, 0x0079)
+struct bt_hci_cp_le_set_path_loss_report_enable {
+	uint16_t handle;
+	uint8_t  enable;
+} __packed;
+
+#define BT_HCI_LE_TX_POWER_REPORT_DISABLE       0x00
+#define BT_HCI_LE_TX_POWER_REPORT_ENABLE        0x01
+#define BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE BT_OP(BT_OGF_LE, 0x007A)
+struct bt_hci_cp_le_set_tx_power_report_enable {
+	uint16_t handle;
+	uint8_t  local_enable;
+	uint8_t  remote_enable;
+} __packed;
+
 #define BT_HCI_CTL_TO_HOST_FLOW_DISABLE         0x00
 #define BT_HCI_CTL_TO_HOST_FLOW_ENABLE          0x01
 #define BT_HCI_OP_SET_CTL_TO_HOST_FLOW          BT_OP(BT_OGF_BASEBAND, 0x0031)
@@ -2694,6 +2741,24 @@ struct bt_hci_evt_le_req_peer_sca_complete {
 	uint8_t  status;
 	uint16_t handle;
 	uint8_t  sca;
+} __packed;
+
+#define BT_HCI_EVT_LE_PATH_LOSS_THRESHOLD       0x20
+struct bt_hci_evt_le_path_loss_threshold {
+	uint16_t handle;
+	int8_t   current_path_loss;
+	uint8_t  zone_entered;
+} __packed;
+
+#define BT_HCI_EVT_LE_TRANSMIT_POWER_REPORT     0x21
+struct bt_hci_evt_le_transmit_power_report {
+	uint8_t	 status;
+	uint16_t handle;
+	uint8_t  reason;
+	uint8_t  phy;
+	int8_t   tx_power_level;
+	int8_t   tx_power_level_flag;
+	int8_t   delta;
 } __packed;
 
 #define BT_HCI_EVT_LE_BIGINFO_ADV_REPORT        0x22

--- a/subsys/bluetooth/controller/Kconfig
+++ b/subsys/bluetooth/controller/Kconfig
@@ -82,6 +82,9 @@ config BT_CTLR_READ_ISO_LINK_QUALITY_SUPPORT
 		   BT_CTLR_PERIPHERAL_ISO_SUPPORT
 	bool
 
+config BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	bool
+
 config BT_CTLR
 	bool "Bluetooth Controller"
 	help

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -557,6 +557,23 @@ config BT_CONN_PARAM_UPDATE_TIMEOUT
 	  "The Peripheral device should not perform a Connection Parameter
 	  Update procedure within 5 seconds after establishing a connection."
 
+config BT_TRANSMIT_POWER_CONTROL
+	bool "Transmit Power Control [EXPERIMENTAL]"
+	depends on !BT_CTLR || BT_CTLR_LE_POWER_CONTROL_SUPPORT
+	select EXPERIMENTAL
+	help
+	  Enable support for controlling transmit power. The controller shall
+	  support LE Power Control Request feature that defined in the Bluetooth
+	  Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.31.
+
+config BT_PATH_LOSS_MONITORING
+	bool "Path Loss Monitoring [EXPERIMENTAL]"
+	depends on BT_TRANSMIT_POWER_CONTROL
+	select EXPERIMENTAL
+	help
+	  Enable support for Path Loss Monitoring feature that defined in the
+	  Bluetooth Core specification, Version 5.3 | Vol 6, Part B, Section 4.6.32.
+
 endif # BT_CONN
 
 if BT_OBSERVER

--- a/subsys/bluetooth/host/conn.c
+++ b/subsys/bluetooth/host/conn.c
@@ -2374,16 +2374,53 @@ static int bt_conn_get_tx_power_level(struct bt_conn *conn, uint8_t type,
 	return 0;
 }
 
+int bt_conn_le_enhanced_get_tx_power_level(struct bt_conn *conn,
+					   struct bt_conn_le_tx_power *tx_power)
+{
+	int err;
+	struct bt_hci_rp_le_read_tx_power_level *rp;
+	struct net_buf *rsp;
+	struct bt_hci_cp_le_read_tx_power_level *cp;
+	struct net_buf *buf;
+
+	if (!tx_power->phy) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->phy = tx_power->phy;
+
+	err = bt_hci_cmd_send_sync(BT_HCI_OP_LE_ENH_READ_TX_POWER_LEVEL, buf, &rsp);
+	if (err) {
+		return err;
+	}
+
+	rp = (void *) rsp->data;
+	tx_power->phy = rp->phy;
+	tx_power->current_level = rp->current_tx_power_level;
+	tx_power->max_level = rp->max_tx_power_level;
+	net_buf_unref(rsp);
+
+	return 0;
+}
+
 int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 				  struct bt_conn_le_tx_power *tx_power_level)
 {
 	int err;
 
 	if (tx_power_level->phy != 0) {
-		/* Extend the implementation when LE Enhanced Read Transmit
-		 * Power Level HCI command is available for use.
-		 */
-		return -ENOTSUP;
+		if (IS_ENABLED(CONFIG_BT_TRANSMIT_POWER_CONTROL)) {
+			return bt_conn_le_enhanced_get_tx_power_level(conn, tx_power_level);
+		} else {
+			return -ENOTSUP;
+		}
 	}
 
 	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_CURRENT,
@@ -2395,6 +2432,90 @@ int bt_conn_le_get_tx_power_level(struct bt_conn *conn,
 	err = bt_conn_get_tx_power_level(conn, BT_TX_POWER_LEVEL_MAX,
 					 &tx_power_level->max_level);
 	return err;
+}
+
+int bt_conn_le_get_remote_tx_power_level(struct bt_conn *conn,
+					 enum bt_conn_le_tx_power_phy phy)
+{
+	struct bt_hci_cp_le_read_tx_power_level *cp;
+	struct net_buf *buf;
+
+	if (!phy) {
+		return -EINVAL;
+	}
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->phy = phy;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_READ_REMOTE_TX_POWER_LEVEL, buf, NULL);
+}
+
+int bt_conn_le_set_tx_power_report_enable(struct bt_conn *conn,
+					  bool local_enable,
+					  bool remote_enable)
+{
+	struct bt_hci_cp_le_set_tx_power_report_enable *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->local_enable = local_enable ? BT_HCI_LE_TX_POWER_REPORT_ENABLE :
+		BT_HCI_LE_TX_POWER_REPORT_DISABLE;
+	cp->remote_enable = remote_enable ? BT_HCI_LE_TX_POWER_REPORT_ENABLE :
+		BT_HCI_LE_TX_POWER_REPORT_DISABLE;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_TX_POWER_REPORT_ENABLE, buf, NULL);
+}
+
+int bt_conn_le_set_path_loss_report_param(struct bt_conn *conn,
+					  const struct bt_conn_le_path_loss_report_param *param)
+{
+	struct bt_hci_cp_le_set_path_loss_report_param *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PATH_LOSS_REPORT_PARAM, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->high_threshold = param->high_threshold;
+	cp->high_hysteresis = param->high_hysteresis;
+	cp->low_threshold = param->low_threshold;
+	cp->low_hysteresis = param->low_hysteresis;
+	cp->min_time_spent = param->min_time_spent;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PATH_LOSS_REPORT_PARAM, buf, NULL);
+}
+
+int bt_conn_le_path_loss_report_enable(struct bt_conn *conn, bool enable)
+{
+	struct bt_hci_cp_le_set_path_loss_report_enable *cp;
+	struct net_buf *buf;
+
+	buf = bt_hci_cmd_create(BT_HCI_OP_LE_SET_PATH_LOSS_REPORT_ENABLE, sizeof(*cp));
+	if (!buf) {
+		return -ENOBUFS;
+	}
+
+	cp = net_buf_add(buf, sizeof(*cp));
+	cp->handle = sys_cpu_to_le16(conn->handle);
+	cp->enable = enable ? BT_HCI_LE_PATH_LOSS_REPORT_ENABLE :
+		BT_HCI_LE_PATH_LOSS_REPORT_DISABLE;
+
+	return bt_hci_cmd_send_sync(BT_HCI_OP_LE_SET_PATH_LOSS_REPORT_ENABLE, buf, NULL);
 }
 
 int bt_conn_le_param_update(struct bt_conn *conn,
@@ -3054,5 +3175,49 @@ void bt_hci_le_df_cte_req_failed(struct net_buf *buf)
 	bt_conn_unref(conn);
 }
 #endif /* CONFIG_BT_DF_CONNECTION_CTE_REQ */
+
+#if defined(CONFIG_BT_TRANSMIT_POWER_CONTROL)
+void notify_tx_power_report(struct bt_conn *conn,
+			    struct bt_conn_le_tx_power_report report)
+{
+	struct bt_conn_cb *cb;
+
+	for (cb = callback_list; cb; cb = cb->_next) {
+		if (cb->tx_power_report) {
+			cb->tx_power_report(conn, &report);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb)
+	{
+		if (cb->tx_power_report) {
+			cb->tx_power_report(conn, &report);
+		}
+	}
+
+	bt_conn_unref(conn);
+}
+#endif /* CONFIG_BT_TRANSMIT_POWER_CONTROL */
+
+#if defined(CONFIG_BT_PATH_LOSS_MONITORING)
+void notify_path_loss_report(struct bt_conn *conn,
+			     struct bt_conn_le_path_loss_report report)
+{
+	struct bt_conn_cb *cb;
+
+	for (cb = callback_list; cb; cb = cb->_next) {
+		if (cb->path_loss_report) {
+			cb->path_loss_report(conn, &report);
+		}
+	}
+
+	STRUCT_SECTION_FOREACH(bt_conn_cb, cb)
+	{
+		if (cb->path_loss_report) {
+			cb->path_loss_report(conn, &report);
+		}
+	}
+}
+#endif /* CONFIG_BT_PATH_LOSS_MONITORING */
 
 #endif /* CONFIG_BT_CONN */

--- a/subsys/bluetooth/host/conn_internal.h
+++ b/subsys/bluetooth/host/conn_internal.h
@@ -360,6 +360,12 @@ void notify_le_phy_updated(struct bt_conn *conn);
 
 bool le_param_req(struct bt_conn *conn, struct bt_le_conn_param *param);
 
+void notify_tx_power_report(struct bt_conn *conn,
+			    struct bt_conn_le_tx_power_report report);
+
+void notify_path_loss_report(struct bt_conn *conn,
+			     struct bt_conn_le_path_loss_report report);
+
 #if defined(CONFIG_BT_SMP)
 /* rand and ediv should be in BT order */
 int bt_conn_le_start_encryption(struct bt_conn *conn, uint8_t rand[8],


### PR DESCRIPTION
This PR aims to define host APIs, events and configs for LE Power Control Feature which is under development in controller side. The support of feature is provided with controller-based feature selection with `BT_CTLR_LE_POWER_CONTROL_SUPPORT`. So it wont be visible until a controller selects it. 
If the feature is supported, then `BT_TRANSMIT_POWER_CONTROL` feature and its sub-feature(it uses same LLCPs) `BT_PATH_LOSS_MONITORING` will be selectable.

**With the new APIs, the applications will:**
- get improved reading of local and remote tx power
- be aware of changes in remote or local tx power
- be aware of path losses to adjust tx power further.

**Defined HCI commands in Core Spec v5.3:**
- 7.8.117 LE Enhanced Read Transmit Power Level command: _improvement to existing local tx power reading._
- 7.8.118 LE Read Remote Transmit Power Level command: _Remote tx power is read through an event (LE Transmit Power Reporting)_

- 7.8.121 LE Set Transmit Power Reporting Enable command:  _Enables local or remote tx power reporting to monitor changes in tx power_
- 7.7.65.33 LE Transmit Power Reporting event:

- 7.8.119 LE Set Path Loss Reporting Parameters command: _Sets path loss parameters that is used to trigger path loss threshold event when reporting is enabled._
- 7.8.120 LE Set Path Loss Reporting Enable command
- 7.7.65.32 LE Path Loss Threshold event

**Note**
 there will be further vendor specific HCI commands to use the feature more effective