### PR TITLE
net: net_if.c: Fix build warning

### DIFF
--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -563,7 +563,7 @@ struct net_if *net_if_get_default(void)
 {
 	struct net_if *iface = NULL;
 
-	if (_net_if_list_start == _net_if_list_end) {
+	if (&_net_if_list_start[0] == &_net_if_list_end[0]) {
 		return NULL;
 	}
 


### PR DESCRIPTION
Fix compilation warning in GCC 12 when it's not obvious that we want to
compare the adresses of the first elements of two arrays

Signed-off-by: Hristo Mitrev <hr.mitrev@gmail.com>