### PR TITLE
tests: kernel: sleep: Fix uninitialised variable warning

### DIFF
--- a/tests/kernel/sleep/src/usleep.c
+++ b/tests/kernel/sleep/src/usleep.c
@@ -65,7 +65,7 @@
 ZTEST_USER(sleep, test_usleep)
 {
 	int retries = 0;
-	int64_t elapsed_ms;
+	int64_t elapsed_ms = 0;
 
 	while (retries < RETRIES) {
 		int64_t start_ms;


### PR DESCRIPTION
This commit sets an initial value of 0 for the `elapsed_ms` variable,
which may be used uninitialised when the while loop below does not
execute.

This fixes the "‘elapsed_ms’ may be used uninitialized" warning
generated by the GCC 12.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>