### PR TITLE
tests: lib: notify: Fix uninitialised variable warning

### DIFF
--- a/tests/lib/notify/src/main.c
+++ b/tests/lib/notify/src/main.c
@@ -45,7 +45,7 @@ ZTEST(sys_notify_api, test_spinwait)
 {
 	int rc;
 	int set_res = 423;
-	int res;
+	int res = 0;
 	sys_notify_generic_callback cb;
 	struct sys_notify notify;
 	uint32_t xflags = 0x1234;


### PR DESCRIPTION
This commit sets an initial value of 0 for the `res` variable, whose
pointer is passed to other functions and is not directly assigned
within the calling function.

Note that, when the test completes successfully, the value of the `res`
variable should be set to `423` (the value of `set_res`).

This fixes the "‘res’ may be used uninitialized" warning generated by
the GCC 12.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>