### PR TITLE
Migrate bluetooth/host/buf.c UT to use FFF

### DIFF
--- a/subsys/bluetooth/host/buf.c
+++ b/subsys/bluetooth/host/buf.c
@@ -145,3 +145,34 @@ struct net_buf *bt_buf_get_evt(uint8_t evt, bool discardable,
 		return bt_buf_get_rx(BT_BUF_EVT, timeout);
 	}
 }
+
+#ifdef ZTEST_UNITTEST
+#if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
+struct net_buf_pool *bt_buf_get_evt_pool(void)
+{
+	return &evt_pool;
+}
+
+struct net_buf_pool *bt_buf_get_acl_in_pool(void)
+{
+	return &acl_in_pool;
+}
+#else
+struct net_buf_pool *bt_buf_get_hci_rx_pool(void)
+{
+	return &hci_rx_pool;
+}
+#endif
+#if defined(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT)
+struct net_buf_pool *bt_buf_get_discardable_pool(void)
+{
+	return &discardable_pool;
+}
+#endif
+#if defined(CONFIG_BT_CONN) || defined(CONFIG_BT_ISO)
+struct net_buf_pool *bt_buf_get_num_complete_pool(void)
+{
+	return &num_complete_pool;
+}
+#endif
+#endif

--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if (NOT BOARD STREQUAL unit_testing)
+  message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")
+endif()
+
+FILE(GLOB SOURCES src/*.c)
+
+project(bluetooth_bt_buf_get_cmd_complete)
+
+find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+
+include(${ZEPHYR_BASE}/tests/bluetooth/host/cmake.txt)
+include(${ZEPHYR_BASE}/tests/bluetooth/host/buf/cmake.txt)
+
+target_sources(testbinary PRIVATE ${host_module} ${module_mocks} ${host_mocks})

--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/src/main.c
@@ -9,8 +9,9 @@
 #include <zephyr/bluetooth/buf.h>
 #include <host/hci_core.h>
 #include "kconfig.h"
-#include "net_buf.h"
-#include "buf_help_utils.h"
+#include "mocks/net_buf.h"
+#include "mocks/net_buf_expects.h"
+#include "mocks/buf_help_utils.h"
 
 /*
  *  Return value from bt_buf_get_cmd_complete() should be NULL
@@ -49,9 +50,9 @@ void test_returns_null_sent_cmd_is_null(void)
 
 	returned_buf = bt_buf_get_cmd_complete(timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_not_called_behaviour();
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_not_called_net_buf_reserve();
+	expect_not_called_net_buf_ref();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_cmd_complete() returned non-NULL value while expecting NULL");
@@ -98,9 +99,9 @@ void test_returns_not_null_sent_cmd_is_null(void)
 
 	returned_buf = bt_buf_get_cmd_complete(timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_called_behaviour(&expected_buf);
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_single_call_net_buf_reserve(&expected_buf);
+	expect_not_called_net_buf_ref();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_cmd_complete() returned incorrect buffer pointer value");
@@ -142,9 +143,9 @@ void test_returns_not_null_sent_cmd_is_not_null(void)
 
 	returned_buf = bt_buf_get_cmd_complete(timeout);
 
-	validate_net_buf_reserve_called_behaviour(bt_dev.sent_cmd);
-	validate_net_buf_ref_called_behaviour(bt_dev.sent_cmd);
-	validate_net_buf_alloc_not_called_behaviour();
+	expect_single_call_net_buf_reserve(bt_dev.sent_cmd);
+	expect_single_call_net_buf_ref(bt_dev.sent_cmd);
+	expect_not_called_net_buf_alloc();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_cmd_complete() returned incorrect buffer pointer value");
@@ -162,7 +163,7 @@ void test_returns_not_null_sent_cmd_is_not_null(void)
 static void unit_test_setup(void)
 {
 	/* Register resets */
-	FFF_FAKES_LIST(RESET_FAKE);
+	NET_BUFF_FFF_FAKES_LIST(RESET_FAKE);
 }
 
 void test_main(void)

--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/src/main.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/buf.h>
+#include <host/hci_core.h>
+#include "kconfig.h"
+#include "buf_help_utils.h"
+
+/*
+ *  Return value from bt_buf_get_cmd_complete() should be NULL
+ *
+ *  This is to test the behaviour when memory allocation request fails
+ *
+ *  Constraints:
+ *   - bt_dev.sent_cmd value is NULL
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() returns a NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_cmd_complete()
+ *   - bt_dev.sent_cmd value isn't changed after calling bt_buf_get_cmd_complete()
+ *   - bt_buf_get_cmd_complete() returns NULL
+ */
+void test_returns_null_sent_cmd_is_null(void)
+{
+	struct net_buf *returned_buf;
+	struct net_buf *sent_cmd_not_changing_value;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	bt_dev.sent_cmd = NULL;
+	sent_cmd_not_changing_value = bt_dev.sent_cmd;
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_evt_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, NULL);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_cmd_complete(timeout);
+
+	zassert_is_null(returned_buf,
+			"bt_buf_get_cmd_complete() returned non-NULL value while expecting NULL");
+
+	zassert_equal(bt_dev.sent_cmd, sent_cmd_not_changing_value,
+		     "bt_buf_get_cmd_complete() caused bt_dev.sent_cmd value to be changed");
+}
+
+/*
+ *  Return value from bt_buf_get_cmd_complete() shouldn't be NULL
+ *
+ *  Constraints:
+ *   - bt_dev.sent_cmd value is NULL
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() return a not NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_cmd_complete()
+ *   - bt_dev.sent_cmd value isn't changed after calling bt_buf_get_cmd_complete()
+ *   - bt_buf_get_cmd_complete() returns the same value returned by net_buf_alloc_fixed()
+ *   - Return buffer type is set to BT_BUF_EVT
+ */
+void test_returns_not_null_sent_cmd_is_null(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	struct net_buf *sent_cmd_not_changing_value;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	bt_dev.sent_cmd = NULL;
+	sent_cmd_not_changing_value = bt_dev.sent_cmd;
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_evt_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_cmd_complete(timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_cmd_complete() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_EVT,
+		      "bt_buf_get_cmd_complete() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_EVT, STRINGIFY(BT_BUF_EVT));
+
+	zassert_equal(bt_dev.sent_cmd, sent_cmd_not_changing_value,
+		     "bt_buf_get_cmd_complete() caused bt_dev.sent_cmd value to be changed");
+}
+
+/*
+ *  Return value from bt_buf_get_cmd_complete() shouldn't be NULL
+ *
+ *  Constraints:
+ *   - bt_dev.sent_cmd value isn't NULL
+ *   - Timeout value is a positive non-zero value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() isn't called
+ *   - bt_dev.sent_cmd value isn't changed after calling bt_buf_get_cmd_complete()
+ *   - bt_buf_get_cmd_complete() returns the same value set to bt_dev.sent_cmd
+ *   - Return buffer type is set to BT_BUF_EVT
+ */
+void test_returns_not_null_sent_cmd_is_not_null(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	struct net_buf *sent_cmd_not_changing_value;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	bt_dev.sent_cmd = &expected_buf;
+	sent_cmd_not_changing_value = bt_dev.sent_cmd;
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &bt_dev.sent_cmd->b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+	ztest_expect_value(net_buf_ref, buf, bt_dev.sent_cmd);
+
+	returned_buf = bt_buf_get_cmd_complete(timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_cmd_complete() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_EVT,
+		      "bt_buf_get_cmd_complete() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_EVT, STRINGIFY(BT_BUF_EVT));
+
+	zassert_equal(bt_dev.sent_cmd, sent_cmd_not_changing_value,
+		     "bt_buf_get_cmd_complete() caused bt_dev.sent_cmd value to be changed");
+}
+
+void test_main(void)
+{
+	ztest_test_suite(bt_buf_get_cmd_complete_returns_not_null,
+			ztest_unit_test(test_returns_not_null_sent_cmd_is_null),
+			ztest_unit_test(test_returns_not_null_sent_cmd_is_not_null)
+			);
+
+	ztest_run_test_suite(bt_buf_get_cmd_complete_returns_not_null);
+
+	ztest_test_suite(bt_buf_get_cmd_complete_returns_null,
+			ztest_unit_test(test_returns_null_sent_cmd_is_null)
+			);
+
+	ztest_run_test_suite(bt_buf_get_cmd_complete_returns_null);
+}

--- a/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_cmd_complete/testcase.yaml
@@ -1,0 +1,14 @@
+common:
+    tags: test_framework bluetooth host
+tests:
+  bluetooth.host.bt_buf_get_cmd_complete.default:
+     type: unit
+  bluetooth.host.bt_buf_get_cmd_complete.hci_acl_flow_control:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=CONFIG_BT_HCI_ACL_FLOW_CONTROL
+  bluetooth.host.bt_buf_get_cmd_complete.iso_unicast:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_ISO_UNICAST_CONFIG_SET
+  bluetooth.host.bt_buf_get_cmd_complete.iso_sync_receiver:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_ISO_SYNC_RECEIVER_CONFIG_SET

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if (NOT BOARD STREQUAL unit_testing)
+  message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")
+endif()
+
+FILE(GLOB SOURCES src/*.c)
+
+project(bluetooth_bt_buf_get_evt)
+
+find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+
+include(${ZEPHYR_BASE}/tests/bluetooth/host/cmake.txt)
+include(${ZEPHYR_BASE}/tests/bluetooth/host/buf/cmake.txt)
+
+target_sources(testbinary PRIVATE ${host_module} ${module_mocks} ${host_mocks})

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/main.c
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+
+void test_main(void)
+{
+	uint32_t state;
+
+	ztest_run_registered_test_suites(&state);
+}

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_cmd.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_cmd.c
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/buf.h>
+#include <host/hci_core.h>
+#include "kconfig.h"
+#include "buf_help_utils.h"
+
+/* Rows count equals number of events x 2 */
+#define TEST_PARAMETERS_LUT_ROWS_COUNT		4
+
+/* LUT containing testing parameters that will be used
+ * during each iteration to cover different scenarios
+ */
+static const struct testing_params testing_params_lut[] = {
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_CMD_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_CMD_STATUS)
+};
+
+BUILD_ASSERT(ARRAY_SIZE(testing_params_lut) == TEST_PARAMETERS_LUT_ROWS_COUNT);
+
+/* Global iterator to iterate over the LUT */
+static uint8_t testing_params_it;
+
+/* Pointer to the current set of testing parameter */
+struct testing_params const *current_test_vector;
+
+/* Return the memory pool used for event memory allocation
+ * based on compilation flags
+ */
+static struct net_buf_pool *get_memory_pool(void)
+{
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_evt_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	return memory_pool;
+}
+
+/*
+ *  Return value from bt_buf_get_evt() should match the value returned
+ *  from bt_buf_get_cmd_complete() which is NULL
+ *
+ *  Constraints:
+ *   - Event type 'BT_HCI_EVT_CMD_COMPLETE' or 'BT_HCI_EVT_CMD_STATUS'
+ *   -'discardable' flag value doesn't care
+ *   - bt_buf_get_cmd_complete() returns NULL
+ *   - Timeout value is a positive non-zero value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_evt()
+ *   - bt_buf_get_evt() returns NULL
+ */
+static void test_return_value_matches_bt_buf_get_cmd_complete_null(void)
+{
+	struct net_buf *returned_buf;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+	uint8_t evt = current_test_vector->evt;
+	bool discardable = current_test_vector->discardable;
+
+	bt_dev.sent_cmd = NULL;
+
+	zassert_true((evt == BT_HCI_EVT_CMD_COMPLETE || evt == BT_HCI_EVT_CMD_STATUS),
+		     "Invalid event type %u to this test", evt);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool());
+	ztest_returns_value(net_buf_alloc_fixed, NULL);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	zassert_is_null(returned_buf,
+			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
+}
+
+/*
+ *  Return value from bt_buf_get_evt() should match the value returned
+ *  from bt_buf_get_cmd_complete() which isn't NULL
+ *
+ *  Constraints:
+ *   - Event type 'BT_HCI_EVT_CMD_COMPLETE' or 'BT_HCI_EVT_CMD_STATUS'
+ *   -'discardable' flag value doesn't care
+ *   - bt_buf_get_cmd_complete() returns a valid reference
+ *   - Timeout value is a positive non-zero value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_evt()
+ *   - bt_buf_get_evt() returns the same reference returned by net_buf_alloc_fixed()
+ */
+static void test_return_value_matches_bt_buf_get_cmd_complete_not_null(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+	uint8_t evt = current_test_vector->evt;
+	bool discardable = current_test_vector->discardable;
+
+	zassert_true((evt == BT_HCI_EVT_CMD_COMPLETE || evt == BT_HCI_EVT_CMD_STATUS),
+		     "Invalid event type %u to this test", evt);
+
+	bt_dev.sent_cmd = NULL;
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool());
+	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_evt() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_EVT,
+		      "bt_buf_get_evt() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_EVT, STRINGIFY(BT_BUF_EVT));
+}
+
+/* Initialize test variables */
+static void test_round_initialization(void)
+{
+	testing_params_it = 0;
+	current_test_vector = NULL;
+}
+
+/* Setup test variables */
+static void unit_test_setup(void)
+{
+	zassert_true((testing_params_it < (ARRAY_SIZE(testing_params_lut))),
+		     "Invalid testing parameters index %u", testing_params_it);
+	current_test_vector = &testing_params_lut[testing_params_it];
+	testing_params_it++;
+}
+
+/* Each run will use a testing parameters set from LUT
+ * This can help in identifying which parameters fails instead of using
+ * a single 'void' test function and call the parameterized function.
+ */
+ztest_register_test_suite(bt_buf_get_evt_cmd_type_returns_null, NULL,
+			  ztest_unit_test(test_round_initialization),
+			  LISTIFY(TEST_PARAMETERS_LUT_ROWS_COUNT, REGISTER_SETUP_TEARDOWN, (,),
+				  test_return_value_matches_bt_buf_get_cmd_complete_null));
+
+ztest_register_test_suite(bt_buf_get_evt_cmd_type_returns_not_null, NULL,
+			  ztest_unit_test(test_round_initialization),
+			  LISTIFY(TEST_PARAMETERS_LUT_ROWS_COUNT, REGISTER_SETUP_TEARDOWN, (,),
+				  test_return_value_matches_bt_buf_get_cmd_complete_not_null));

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_cmd.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_cmd.c
@@ -8,8 +8,9 @@
 #include <zephyr/bluetooth/buf.h>
 #include <host/hci_core.h>
 #include "kconfig.h"
-#include "net_buf.h"
-#include "buf_help_utils.h"
+#include "mocks/net_buf.h"
+#include "mocks/net_buf_expects.h"
+#include "mocks/buf_help_utils.h"
 
 /* Rows count equals number of events x 2 */
 #define TEST_PARAMETERS_LUT_ROWS_COUNT		4
@@ -77,9 +78,9 @@ static void test_return_value_matches_bt_buf_get_cmd_complete_null(void)
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
 
-	validate_net_buf_alloc_called_behaviour(get_memory_pool(), &timeout);
-	validate_net_buf_reserve_not_called_behaviour();
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(get_memory_pool(), &timeout);
+	expect_not_called_net_buf_reserve();
+	expect_not_called_net_buf_ref();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
@@ -118,9 +119,9 @@ static void test_return_value_matches_bt_buf_get_cmd_complete_not_null(void)
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
 
-	validate_net_buf_alloc_called_behaviour(get_memory_pool(), &timeout);
-	validate_net_buf_reserve_called_behaviour(&expected_buf);
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(get_memory_pool(), &timeout);
+	expect_single_call_net_buf_reserve(&expected_buf);
+	expect_not_called_net_buf_ref();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_evt() returned incorrect buffer pointer value");
@@ -147,7 +148,7 @@ static void unit_test_setup(void)
 	testing_params_it++;
 
 	/* Register resets */
-	FFF_FAKES_LIST(RESET_FAKE);
+	NET_BUFF_FFF_FAKES_LIST(RESET_FAKE);
 }
 
 /* Each run will use a testing parameters set from LUT

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_default.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_default.c
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/buf.h>
+#include "kconfig.h"
+#include "buf_help_utils.h"
+
+/* Rows count equals number of events x 2 */
+#define TEST_PARAMETERS_LUT_ROWS_COUNT		60
+
+/* LUT containing testing parameters that will be used
+ * during each iteration to cover different scenarios
+ */
+static const struct testing_params testing_params_lut[] = {
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_UNKNOWN),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_VENDOR),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_INQUIRY_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_CONN_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_CONN_REQUEST),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_DISCONN_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_AUTH_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_REMOTE_NAME_REQ_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_ENCRYPT_CHANGE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_REMOTE_FEATURES),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_REMOTE_VERSION_INFO),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_HARDWARE_ERROR),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_ROLE_CHANGE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_PIN_CODE_REQ),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_LINK_KEY_REQ),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_LINK_KEY_NOTIFY),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_DATA_BUF_OVERFLOW),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_INQUIRY_RESULT_WITH_RSSI),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_REMOTE_EXT_FEATURES),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_SYNC_CONN_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_EXTENDED_INQUIRY_RESULT),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_ENCRYPT_KEY_REFRESH_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_IO_CAPA_REQ),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_IO_CAPA_RESP),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_USER_CONFIRM_REQ),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_USER_PASSKEY_REQ),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_SSP_COMPLETE),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_USER_PASSKEY_NOTIFY),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_LE_META_EVENT),
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_AUTH_PAYLOAD_TIMEOUT_EXP)
+};
+
+BUILD_ASSERT(ARRAY_SIZE(testing_params_lut) == TEST_PARAMETERS_LUT_ROWS_COUNT);
+
+/* Global iterator to iterate over the LUT */
+static uint8_t testing_params_it;
+
+/* Pointer to the current set of testing parameter */
+struct testing_params const *current_test_vector;
+
+/* Return the memory pool used for event memory allocation
+ * based on compilation flags
+ */
+static struct net_buf_pool *get_memory_pool(bool discardable)
+{
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_evt_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	if (discardable) {
+		if ((IS_ENABLED(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT))) {
+			memory_pool = bt_buf_get_discardable_pool();
+		}
+	}
+
+	return memory_pool;
+}
+
+/*
+ *  Return value from bt_buf_get_evt() should not be NULL
+ *
+ *  Constraints:
+ *   - All events except 'BT_HCI_EVT_CMD_COMPLETE', 'BT_HCI_EVT_CMD_STATUS' or
+ *     'BT_HCI_EVT_NUM_COMPLETED_PACKETS'
+ *   - Timeout value is a positive non-zero value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_evt()
+ *   - bt_buf_get_evt() returns the same reference returned by net_buf_alloc_fixed()
+ */
+static void test_returns_not_null_default_events(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+	uint8_t evt = current_test_vector->evt;
+	bool discardable = current_test_vector->discardable;
+
+	zassert_true((evt != BT_HCI_EVT_CMD_COMPLETE && evt != BT_HCI_EVT_CMD_STATUS &&
+		      evt != BT_HCI_EVT_NUM_COMPLETED_PACKETS),
+		     "Invalid event type %u to this test", evt);
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
+	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_evt() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_EVT,
+		      "bt_buf_get_evt() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_EVT, STRINGIFY(BT_BUF_EVT));
+}
+
+/*
+ *  Return value from bt_buf_get_evt() should be NULL
+ *
+ *  Constraints:
+ *   - All events except 'BT_HCI_EVT_CMD_COMPLETE', 'BT_HCI_EVT_CMD_STATUS' or
+ *     'BT_HCI_EVT_NUM_COMPLETED_PACKETS'
+ *   - Timeout value is a positive non-zero value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_evt()
+ *   - bt_buf_get_evt() returns NULL
+ */
+static void test_returns_null_default_events(void)
+{
+	struct net_buf *returned_buf;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+	uint8_t evt = current_test_vector->evt;
+	bool discardable = current_test_vector->discardable;
+
+	zassert_true((evt != BT_HCI_EVT_CMD_COMPLETE && evt != BT_HCI_EVT_CMD_STATUS &&
+		      evt != BT_HCI_EVT_NUM_COMPLETED_PACKETS),
+		     "Invalid event type %u to this test", evt);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
+	ztest_returns_value(net_buf_alloc_fixed, NULL);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	zassert_is_null(returned_buf,
+			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
+}
+
+/* Initialize test variables */
+static void test_round_initialization(void)
+{
+	testing_params_it = 0;
+	current_test_vector = NULL;
+}
+
+/* Setup test variables */
+static void unit_test_setup(void)
+{
+	zassert_true((testing_params_it < (ARRAY_SIZE(testing_params_lut))),
+		     "Invalid testing parameters index %u", testing_params_it);
+	current_test_vector = &testing_params_lut[testing_params_it];
+	testing_params_it++;
+}
+
+/* Each run will use a testing parameters set from LUT
+ * This can help in identifying which parameters fails instead of using
+ * a single 'void' test function and call the parameterized function.
+ */
+ztest_register_test_suite(bt_buf_get_evt_default_type_returns_not_null, NULL,
+			  ztest_unit_test(test_round_initialization),
+			  LISTIFY(TEST_PARAMETERS_LUT_ROWS_COUNT, REGISTER_SETUP_TEARDOWN, (,),
+				  test_returns_not_null_default_events));
+
+ztest_register_test_suite(bt_buf_get_evt_default_type_returns_null, NULL,
+			  ztest_unit_test(test_round_initialization),
+			  LISTIFY(TEST_PARAMETERS_LUT_ROWS_COUNT, REGISTER_SETUP_TEARDOWN, (,),
+				  test_returns_null_default_events));

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_default.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_default.c
@@ -7,6 +7,7 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/bluetooth/buf.h>
 #include "kconfig.h"
+#include "net_buf.h"
 #include "buf_help_utils.h"
 
 /* Rows count equals number of events x 2 */
@@ -104,15 +105,13 @@ static void test_returns_not_null_default_events(void)
 		      evt != BT_HCI_EVT_NUM_COMPLETED_PACKETS),
 		     "Invalid event type %u to this test", evt);
 
-	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
-	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
-
-	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
-	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
-
-	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+	net_buf_alloc_fixed_fake.return_val = &expected_buf;
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
+	validate_net_buf_reserve_called_behaviour(&expected_buf);
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_evt() returned incorrect buffer pointer value");
@@ -147,12 +146,13 @@ static void test_returns_null_default_events(void)
 		      evt != BT_HCI_EVT_NUM_COMPLETED_PACKETS),
 		     "Invalid event type %u to this test", evt);
 
-	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
-	ztest_returns_value(net_buf_alloc_fixed, NULL);
-
-	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+	net_buf_alloc_fixed_fake.return_val = NULL;
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
+	validate_net_buf_reserve_not_called_behaviour();
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
@@ -172,6 +172,9 @@ static void unit_test_setup(void)
 		     "Invalid testing parameters index %u", testing_params_it);
 	current_test_vector = &testing_params_lut[testing_params_it];
 	testing_params_it++;
+
+	/* Register resets */
+	FFF_FAKES_LIST(RESET_FAKE);
 }
 
 /* Each run will use a testing parameters set from LUT

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_default.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_default.c
@@ -7,8 +7,9 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/bluetooth/buf.h>
 #include "kconfig.h"
-#include "net_buf.h"
-#include "buf_help_utils.h"
+#include "mocks/net_buf.h"
+#include "mocks/net_buf_expects.h"
+#include "mocks/buf_help_utils.h"
 
 /* Rows count equals number of events x 2 */
 #define TEST_PARAMETERS_LUT_ROWS_COUNT		60
@@ -109,9 +110,9 @@ static void test_returns_not_null_default_events(void)
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
 
-	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
-	validate_net_buf_reserve_called_behaviour(&expected_buf);
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(get_memory_pool(discardable), &timeout);
+	expect_single_call_net_buf_reserve(&expected_buf);
+	expect_not_called_net_buf_ref();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_evt() returned incorrect buffer pointer value");
@@ -150,9 +151,9 @@ static void test_returns_null_default_events(void)
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
 
-	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
-	validate_net_buf_reserve_not_called_behaviour();
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(get_memory_pool(discardable), &timeout);
+	expect_not_called_net_buf_reserve();
+	expect_not_called_net_buf_ref();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
@@ -174,7 +175,7 @@ static void unit_test_setup(void)
 	testing_params_it++;
 
 	/* Register resets */
-	FFF_FAKES_LIST(RESET_FAKE);
+	NET_BUFF_FFF_FAKES_LIST(RESET_FAKE);
 }
 
 /* Each run will use a testing parameters set from LUT

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/buf.h>
+#include "kconfig.h"
+#include "buf_help_utils.h"
+
+/* Rows count equals number of events x 2 */
+#define TEST_PARAMETERS_LUT_ROWS_COUNT		2
+
+/* LUT containing testing parameters that will be used
+ * during each iteration to cover different scenarios
+ */
+static const struct testing_params testing_params_lut[] = {
+	TEST_PARAM_PAIR_DEFINE(BT_HCI_EVT_NUM_COMPLETED_PACKETS),
+};
+
+BUILD_ASSERT(ARRAY_SIZE(testing_params_lut) == TEST_PARAMETERS_LUT_ROWS_COUNT);
+
+/* Global iterator to iterate over the LUT */
+static uint8_t testing_params_it;
+
+/* Pointer to the current set of testing parameter */
+struct testing_params const *current_test_vector;
+
+/* Return the memory pool used for event memory allocation
+ * based on compilation flags
+ */
+static struct net_buf_pool *get_memory_pool(bool discardable)
+{
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_evt_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	if ((IS_ENABLED(CONFIG_BT_CONN) || IS_ENABLED(CONFIG_BT_ISO))) {
+		memory_pool = bt_buf_get_num_complete_pool();
+	} else {
+		if (discardable) {
+			if ((IS_ENABLED(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT))) {
+				memory_pool = bt_buf_get_discardable_pool();
+			}
+		}
+	}
+
+	return memory_pool;
+}
+
+/*
+ *  Return value from bt_buf_get_evt() should not be NULL
+ *
+ *  Constraints:
+ *   - Only event type 'BT_HCI_EVT_NUM_COMPLETED_PACKETS'
+ *   - Timeout value is a positive non-zero value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_evt()
+ *   - bt_buf_get_evt() returns the same reference returned by net_buf_alloc_fixed()
+ */
+static void test_returns_not_null_default_events(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+	uint8_t evt = current_test_vector->evt;
+	bool discardable = current_test_vector->discardable;
+
+	zassert_true((evt == BT_HCI_EVT_NUM_COMPLETED_PACKETS),
+		     "Invalid event type %u to this test", evt);
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
+	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_evt() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_EVT,
+		      "bt_buf_get_evt() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_EVT, STRINGIFY(BT_BUF_EVT));
+}
+
+/*
+ *  Return value from bt_buf_get_evt() should be NULL
+ *
+ *  Constraints:
+ *   - Only event type 'BT_HCI_EVT_NUM_COMPLETED_PACKETS'
+ *   - Timeout value is a positive non-zero value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_evt()
+ *   - bt_buf_get_evt() returns NULL
+ */
+static void test_returns_null_default_events(void)
+{
+	struct net_buf *returned_buf;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+	uint8_t evt = current_test_vector->evt;
+	bool discardable = current_test_vector->discardable;
+
+	zassert_true((evt == BT_HCI_EVT_NUM_COMPLETED_PACKETS),
+		     "Invalid event type %u to this test", evt);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
+	ztest_returns_value(net_buf_alloc_fixed, NULL);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	zassert_is_null(returned_buf,
+			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
+}
+
+/* Initialize test variables */
+static void test_round_initialization(void)
+{
+	testing_params_it = 0;
+	current_test_vector = NULL;
+}
+
+/* Setup test variables */
+static void unit_test_setup(void)
+{
+	zassert_true((testing_params_it < (ARRAY_SIZE(testing_params_lut))),
+		     "Invalid testing parameters index %u", testing_params_it);
+	current_test_vector = &testing_params_lut[testing_params_it];
+	testing_params_it++;
+}
+
+/* Each run will use a testing parameters set from LUT
+ * This can help in identifying which parameters fails instead of using
+ * a single 'void' test function and call the parameterized function.
+ */
+ztest_register_test_suite(bt_buf_get_evt_num_completed_packets_type_returns_not_null, NULL,
+			  ztest_unit_test(test_round_initialization),
+			  LISTIFY(TEST_PARAMETERS_LUT_ROWS_COUNT, REGISTER_SETUP_TEARDOWN, (,),
+				  test_returns_not_null_default_events));
+
+ztest_register_test_suite(bt_buf_get_evt_num_completed_packets_type_returns_null, NULL,
+			  ztest_unit_test(test_round_initialization),
+			  LISTIFY(TEST_PARAMETERS_LUT_ROWS_COUNT, REGISTER_SETUP_TEARDOWN, (,),
+				  test_returns_null_default_events));

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
@@ -7,8 +7,9 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/bluetooth/buf.h>
 #include "kconfig.h"
-#include "net_buf.h"
-#include "buf_help_utils.h"
+#include "mocks/net_buf.h"
+#include "mocks/net_buf_expects.h"
+#include "mocks/buf_help_utils.h"
 
 /* Rows count equals number of events x 2 */
 #define TEST_PARAMETERS_LUT_ROWS_COUNT		2
@@ -82,9 +83,9 @@ static void test_returns_not_null_default_events(void)
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
 
-	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
-	validate_net_buf_reserve_called_behaviour(&expected_buf);
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(get_memory_pool(discardable), &timeout);
+	expect_single_call_net_buf_reserve(&expected_buf);
+	expect_not_called_net_buf_ref();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_evt() returned incorrect buffer pointer value");
@@ -121,9 +122,9 @@ static void test_returns_null_default_events(void)
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
 
-	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
-	validate_net_buf_reserve_not_called_behaviour();
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(get_memory_pool(discardable), &timeout);
+	expect_not_called_net_buf_reserve();
+	expect_not_called_net_buf_ref();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
@@ -145,7 +146,7 @@ static void unit_test_setup(void)
 	testing_params_it++;
 
 	/* Register resets */
-	FFF_FAKES_LIST(RESET_FAKE);
+	NET_BUFF_FFF_FAKES_LIST(RESET_FAKE);
 }
 
 /* Each run will use a testing parameters set from LUT

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/src/test_suite_hci_evt_num_completed_packets.c
@@ -7,6 +7,7 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/bluetooth/buf.h>
 #include "kconfig.h"
+#include "net_buf.h"
 #include "buf_help_utils.h"
 
 /* Rows count equals number of events x 2 */
@@ -77,15 +78,13 @@ static void test_returns_not_null_default_events(void)
 	zassert_true((evt == BT_HCI_EVT_NUM_COMPLETED_PACKETS),
 		     "Invalid event type %u to this test", evt);
 
-	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
-	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
-
-	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
-	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
-
-	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+	net_buf_alloc_fixed_fake.return_val = &expected_buf;
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
+	validate_net_buf_reserve_called_behaviour(&expected_buf);
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_evt() returned incorrect buffer pointer value");
@@ -118,12 +117,13 @@ static void test_returns_null_default_events(void)
 	zassert_true((evt == BT_HCI_EVT_NUM_COMPLETED_PACKETS),
 		     "Invalid event type %u to this test", evt);
 
-	ztest_expect_value(net_buf_alloc_fixed, pool, get_memory_pool(discardable));
-	ztest_returns_value(net_buf_alloc_fixed, NULL);
-
-	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+	net_buf_alloc_fixed_fake.return_val = NULL;
 
 	returned_buf = bt_buf_get_evt(evt, discardable, timeout);
+
+	validate_net_buf_alloc_called_behaviour(get_memory_pool(discardable), &timeout);
+	validate_net_buf_reserve_not_called_behaviour();
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_evt() returned non-NULL value while expecting NULL");
@@ -143,6 +143,9 @@ static void unit_test_setup(void)
 		     "Invalid testing parameters index %u", testing_params_it);
 	current_test_vector = &testing_params_lut[testing_params_it];
 	testing_params_it++;
+
+	/* Register resets */
+	FFF_FAKES_LIST(RESET_FAKE);
 }
 
 /* Each run will use a testing parameters set from LUT

--- a/tests/bluetooth/host/buf/bt_buf_get_evt/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_evt/testcase.yaml
@@ -1,0 +1,23 @@
+common:
+    tags: test_framework bluetooth host
+tests:
+  bluetooth.host.bt_buf_get_evt.default:
+     type: unit
+  bluetooth.host.bt_buf_get_evt.hci_acl_flow_control:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=CONFIG_BT_HCI_ACL_FLOW_CONTROL
+  bluetooth.host.bt_buf_get_evt.bt_connect_enabled:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_CONN_CONFIG_SET
+  bluetooth.host.bt_buf_get_evt.bt_iso_enabled:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_ISO_CONFIG_SET
+  bluetooth.host.bt_buf_get_evt.buf_evt_discardable_count:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_BUF_EVT_DISCARDABLE_COUNT_CONFIG_SET
+  bluetooth.host.bt_buf_get_evt.iso_unicast:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_ISO_UNICAST_CONFIG_SET
+  bluetooth.host.bt_buf_get_evt.iso_sync_receiver:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_ISO_SYNC_RECEIVER_CONFIG_SET

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if (NOT BOARD STREQUAL unit_testing)
+  message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")
+endif()
+
+FILE(GLOB SOURCES src/*.c)
+
+project(bluetooth_bt_buf_get_rx)
+
+find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+
+include(${ZEPHYR_BASE}/tests/bluetooth/host/cmake.txt)
+include(${ZEPHYR_BASE}/tests/bluetooth/host/buf/cmake.txt)
+
+target_sources(testbinary PRIVATE ${host_module} ${module_mocks} ${host_mocks})

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
@@ -44,6 +44,7 @@ void test_returns_null_type_bt_buf_evt(void)
 
 	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
 	validate_net_buf_reserve_not_called_behaviour();
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
@@ -83,6 +84,7 @@ void test_returns_null_type_bt_buf_acl_in(void)
 
 	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
 	validate_net_buf_reserve_not_called_behaviour();
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
@@ -126,6 +128,7 @@ void test_returns_null_type_bt_buf_iso_in(void)
 
 	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
 	validate_net_buf_reserve_not_called_behaviour();
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
@@ -166,6 +169,7 @@ void test_returns_not_null_type_bt_buf_evt(void)
 
 	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
 	validate_net_buf_reserve_called_behaviour(&expected_buf);
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_rx() returned incorrect buffer pointer value");
@@ -211,6 +215,7 @@ void test_returns_not_null_type_bt_buf_acl_in(void)
 
 	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
 	validate_net_buf_reserve_called_behaviour(&expected_buf);
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_rx() returned incorrect buffer pointer value");
@@ -260,6 +265,7 @@ void test_returns_not_null_type_bt_buf_iso_in(void)
 
 	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
 	validate_net_buf_reserve_called_behaviour(&expected_buf);
+	validate_net_buf_ref_not_called_behaviour();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_rx() returned incorrect buffer pointer value");

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
@@ -1,0 +1,303 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/buf.h>
+#include "kconfig.h"
+#include "buf_help_utils.h"
+
+/*
+ *  Return value from bt_buf_get_rx() should be NULL
+ *
+ *  This is to test the behaviour when memory allocation request fails
+ *
+ *  Constraints:
+ *   - Use valid buffer type 'BT_BUF_EVT'
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() returns a NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_rx()
+ *   - bt_buf_get_rx() returns NULL
+ */
+void test_returns_null_type_bt_buf_evt(void)
+{
+	struct net_buf *returned_buf;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_evt_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, NULL);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_rx(BT_BUF_EVT, timeout);
+
+	zassert_is_null(returned_buf,
+			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
+}
+
+/*
+ *  Return value from bt_buf_get_rx() should be NULL
+ *
+ *  This is to test the behaviour when memory allocation request fails
+ *
+ *  Constraints:
+ *   - Use valid buffer type 'BT_BUF_ACL_IN'
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() returns a NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_rx()
+ *   - bt_buf_get_rx() returns NULL
+ */
+void test_returns_null_type_bt_buf_acl_in(void)
+{
+	struct net_buf *returned_buf;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_acl_in_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, NULL);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_rx(BT_BUF_ACL_IN, timeout);
+
+	zassert_is_null(returned_buf,
+			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
+}
+
+/*
+ *  Return value from bt_buf_get_rx() should be NULL
+ *
+ *  This is to test the behaviour when memory allocation request fails
+ *
+ *  Constraints:
+ *   - Use valid buffer type 'BT_BUF_ISO_IN'
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() returns a NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_rx()
+ *   - bt_buf_get_rx() returns NULL
+ */
+void test_returns_null_type_bt_buf_iso_in(void)
+{
+	struct net_buf *returned_buf;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_ISO_UNICAST) || IS_ENABLED(CONFIG_BT_ISO_SYNC_RECEIVER))) {
+		memory_pool = bt_buf_get_iso_rx_pool();
+	} else {
+		if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+			memory_pool = bt_buf_get_acl_in_pool();
+		} else {
+			memory_pool = bt_buf_get_hci_rx_pool();
+		}
+	}
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, NULL);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_rx(BT_BUF_ISO_IN, timeout);
+
+	zassert_is_null(returned_buf,
+			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
+}
+
+/*
+ *  Return value from bt_buf_get_rx() shouldn't be NULL
+ *
+ *  Constraints:
+ *   - Use valid buffer type 'BT_BUF_EVT'
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() return a not NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_rx()
+ *   - bt_buf_get_rx() returns the same value returned by net_buf_alloc_fixed()
+ *   - Return buffer matches the buffer type requested
+ */
+void test_returns_not_null_type_bt_buf_evt(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_evt_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_rx(BT_BUF_EVT, timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_rx() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_EVT,
+		      "bt_buf_get_rx() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_EVT, STRINGIFY(BT_BUF_EVT));
+}
+
+/*
+ *  Return value from bt_buf_get_rx() shouldn't be NULL
+ *
+ *  Constraints:
+ *   - Use valid buffer type 'BT_BUF_ACL_IN'
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() return a not NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_rx()
+ *   - bt_buf_get_rx() returns the same value returned by net_buf_alloc_fixed()
+ *   - Return buffer matches the buffer type requested
+ */
+void test_returns_not_null_type_bt_buf_acl_in(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+		memory_pool = bt_buf_get_acl_in_pool();
+	} else {
+		memory_pool = bt_buf_get_hci_rx_pool();
+	}
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_rx(BT_BUF_ACL_IN, timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_rx() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_ACL_IN,
+		      "bt_buf_get_rx() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_ACL_IN, STRINGIFY(BT_BUF_ACL_IN));
+}
+
+/*
+ *  Return value from bt_buf_get_rx() shouldn't be NULL
+ *
+ *  Constraints:
+ *   - Use valid buffer type 'BT_BUF_ISO_IN'
+ *   - Timeout value is a positive non-zero value
+ *   - net_buf_alloc() return a not NULL value
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called with the correct memory allocation pool
+ *     and the same timeout value passed to bt_buf_get_rx()
+ *   - bt_buf_get_rx() returns the same value returned by net_buf_alloc_fixed()
+ *   - Return buffer matches the buffer type requested
+ */
+void test_returns_not_null_type_bt_buf_iso_in(void)
+{
+	static struct net_buf expected_buf;
+	struct net_buf *returned_buf;
+	uint8_t returned_buffer_type;
+	k_timeout_t timeout = Z_TIMEOUT_TICKS(1000);
+
+	struct net_buf_pool *memory_pool;
+
+	if ((IS_ENABLED(CONFIG_BT_ISO_UNICAST) || IS_ENABLED(CONFIG_BT_ISO_SYNC_RECEIVER))) {
+		memory_pool = bt_buf_get_iso_rx_pool();
+	} else {
+		if ((IS_ENABLED(CONFIG_BT_HCI_ACL_FLOW_CONTROL))) {
+			memory_pool = bt_buf_get_acl_in_pool();
+		} else {
+			memory_pool = bt_buf_get_hci_rx_pool();
+		}
+	}
+
+	ztest_expect_value(net_buf_simple_reserve, buf, &expected_buf.b);
+	ztest_expect_value(net_buf_simple_reserve, reserve, BT_BUF_RESERVE);
+
+	ztest_expect_value(net_buf_alloc_fixed, pool, memory_pool);
+	ztest_returns_value(net_buf_alloc_fixed, &expected_buf);
+
+	ztest_expect_value(net_buf_validate_timeout_value_mock, value, timeout.ticks);
+
+	returned_buf = bt_buf_get_rx(BT_BUF_ISO_IN, timeout);
+
+	zassert_equal(returned_buf, &expected_buf,
+		      "bt_buf_get_rx() returned incorrect buffer pointer value");
+
+	returned_buffer_type = bt_buf_get_type(returned_buf);
+	zassert_equal(returned_buffer_type, BT_BUF_ISO_IN,
+		      "bt_buf_get_rx() returned incorrect buffer type %u, expected %u (%s)",
+		      returned_buffer_type, BT_BUF_ISO_IN, STRINGIFY(BT_BUF_ISO_IN));
+}
+
+void test_main(void)
+{
+	ztest_test_suite(test_bt_buf_get_rx_returns_null,
+			ztest_unit_test(test_returns_null_type_bt_buf_evt),
+			ztest_unit_test(test_returns_null_type_bt_buf_acl_in),
+			ztest_unit_test(test_returns_null_type_bt_buf_iso_in)
+			);
+
+	ztest_run_test_suite(test_bt_buf_get_rx_returns_null);
+
+	ztest_test_suite(test_bt_buf_get_rx_returns_not_null,
+			ztest_unit_test(test_returns_not_null_type_bt_buf_evt),
+			ztest_unit_test(test_returns_not_null_type_bt_buf_acl_in),
+			ztest_unit_test(test_returns_not_null_type_bt_buf_iso_in)
+			);
+
+	ztest_run_test_suite(test_bt_buf_get_rx_returns_not_null);
+
+	uint32_t state;
+
+	ztest_run_registered_test_suites(&state);
+}

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
@@ -7,8 +7,9 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/bluetooth/buf.h>
 #include "kconfig.h"
-#include "net_buf.h"
-#include "buf_help_utils.h"
+#include "mocks/net_buf.h"
+#include "mocks/net_buf_expects.h"
+#include "mocks/buf_help_utils.h"
 
 /*
  *  Return value from bt_buf_get_rx() should be NULL
@@ -42,9 +43,9 @@ void test_returns_null_type_bt_buf_evt(void)
 
 	returned_buf = bt_buf_get_rx(BT_BUF_EVT, timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_not_called_behaviour();
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_not_called_net_buf_reserve();
+	expect_not_called_net_buf_ref();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
@@ -82,9 +83,9 @@ void test_returns_null_type_bt_buf_acl_in(void)
 
 	returned_buf = bt_buf_get_rx(BT_BUF_ACL_IN, timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_not_called_behaviour();
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_not_called_net_buf_reserve();
+	expect_not_called_net_buf_ref();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
@@ -126,9 +127,9 @@ void test_returns_null_type_bt_buf_iso_in(void)
 
 	returned_buf = bt_buf_get_rx(BT_BUF_ISO_IN, timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_not_called_behaviour();
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_not_called_net_buf_reserve();
+	expect_not_called_net_buf_ref();
 
 	zassert_is_null(returned_buf,
 			"bt_buf_get_rx() returned non-NULL value while expecting NULL");
@@ -167,9 +168,9 @@ void test_returns_not_null_type_bt_buf_evt(void)
 
 	returned_buf = bt_buf_get_rx(BT_BUF_EVT, timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_called_behaviour(&expected_buf);
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_single_call_net_buf_reserve(&expected_buf);
+	expect_not_called_net_buf_ref();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_rx() returned incorrect buffer pointer value");
@@ -213,9 +214,9 @@ void test_returns_not_null_type_bt_buf_acl_in(void)
 
 	returned_buf = bt_buf_get_rx(BT_BUF_ACL_IN, timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_called_behaviour(&expected_buf);
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_single_call_net_buf_reserve(&expected_buf);
+	expect_not_called_net_buf_ref();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_rx() returned incorrect buffer pointer value");
@@ -263,9 +264,9 @@ void test_returns_not_null_type_bt_buf_iso_in(void)
 
 	returned_buf = bt_buf_get_rx(BT_BUF_ISO_IN, timeout);
 
-	validate_net_buf_alloc_called_behaviour(memory_pool, &timeout);
-	validate_net_buf_reserve_called_behaviour(&expected_buf);
-	validate_net_buf_ref_not_called_behaviour();
+	expect_single_call_net_buf_alloc(memory_pool, &timeout);
+	expect_single_call_net_buf_reserve(&expected_buf);
+	expect_not_called_net_buf_ref();
 
 	zassert_equal(returned_buf, &expected_buf,
 		      "bt_buf_get_rx() returned incorrect buffer pointer value");
@@ -280,7 +281,7 @@ void test_returns_not_null_type_bt_buf_iso_in(void)
 static void unit_test_setup(void)
 {
 	/* Register resets */
-	FFF_FAKES_LIST(RESET_FAKE);
+	NET_BUFF_FFF_FAKES_LIST(RESET_FAKE);
 }
 
 void test_main(void)

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/src/test_suite_invalid_inputs.c
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/buf.h>
+#include "kconfig.h"
+#include "buf_help_utils.h"
+#include "assert.h"
+
+/*
+ *  Test passing invalid buffer type to bt_buf_get_rx()
+ *
+ *  Constraints:
+ *   - Use invalid buffer type 'BT_BUF_CMD'
+ *
+ *  Expected behaviour:
+ *   - An assertion should be raised as an invalid parameter was used
+ */
+void test_invalid_input_type_bt_buf_cmd(void)
+{
+	expect_assert();
+	bt_buf_get_rx(BT_BUF_CMD, Z_TIMEOUT_TICKS(1000));
+}
+
+/*
+ *  Test passing invalid buffer type to bt_buf_get_rx()
+ *
+ *  Constraints:
+ *   - Use invalid buffer type 'BT_BUF_ACL_OUT'
+ *
+ *  Expected behaviour:
+ *   - An assertion should be raised as an invalid parameter was used
+ */
+void test_invalid_input_type_bt_buf_acl_out(void)
+{
+	expect_assert();
+	bt_buf_get_rx(BT_BUF_ACL_OUT, Z_TIMEOUT_TICKS(1000));
+}
+
+/*
+ *  Test passing invalid buffer type to bt_buf_get_rx()
+ *
+ *  Constraints:
+ *   - Use invalid buffer type 'BT_BUF_ISO_OUT'
+ *
+ *  Expected behaviour:
+ *   - An assertion should be raised as an invalid parameter was used
+ */
+void test_invalid_input_type_bt_buf_iso_out(void)
+{
+	expect_assert();
+	bt_buf_get_rx(BT_BUF_ISO_OUT, Z_TIMEOUT_TICKS(1000));
+}
+
+/*
+ *  Test passing invalid buffer type to bt_buf_get_rx()
+ *
+ *  Constraints:
+ *   - Use invalid buffer type 'BT_BUF_H4'
+ *
+ *  Expected behaviour:
+ *   - An assertion should be raised as an invalid parameter was used
+ */
+void test_invalid_input_type_bt_buf_h4(void)
+{
+	expect_assert();
+	bt_buf_get_rx(BT_BUF_H4, Z_TIMEOUT_TICKS(1000));
+}
+
+ztest_register_test_suite(test_bt_buf_get_rx_invalid_input, NULL,
+			  ztest_unit_test(test_invalid_input_type_bt_buf_cmd),
+			  ztest_unit_test(test_invalid_input_type_bt_buf_acl_out),
+			  ztest_unit_test(test_invalid_input_type_bt_buf_iso_out),
+			  ztest_unit_test(test_invalid_input_type_bt_buf_h4));

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/src/test_suite_invalid_inputs.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/src/test_suite_invalid_inputs.c
@@ -7,8 +7,8 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/bluetooth/buf.h>
 #include "kconfig.h"
-#include "buf_help_utils.h"
-#include "assert.h"
+#include "host_mocks/assert.h"
+#include "mocks/buf_help_utils.h"
 
 /*
  *  Test passing invalid buffer type to bt_buf_get_rx()

--- a/tests/bluetooth/host/buf/bt_buf_get_rx/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_rx/testcase.yaml
@@ -1,0 +1,14 @@
+common:
+    tags: test_framework bluetooth host
+tests:
+  bluetooth.host.bt_buf_get_rx.default:
+     type: unit
+  bluetooth.host.bt_buf_get_rx.hci_acl_flow_control:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=CONFIG_BT_HCI_ACL_FLOW_CONTROL
+  bluetooth.host.bt_buf_get_rx.iso_unicast:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_ISO_UNICAST_CONFIG_SET
+  bluetooth.host.bt_buf_get_rx.iso_sync_receiver:
+     type: unit
+     extra_args: COMPILE_SWITCH_PARAM=BT_ISO_SYNC_RECEIVER_CONFIG_SET

--- a/tests/bluetooth/host/buf/bt_buf_get_type/CMakeLists.txt
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/CMakeLists.txt
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if (NOT BOARD STREQUAL unit_testing)
+  message(FATAL_ERROR "This project can only be used with '-DBOARD=unit_testing'.")
+endif()
+
+FILE(GLOB SOURCES src/*.c)
+
+project(bluetooth_bt_buf_get_type)
+
+find_package(Zephyr COMPONENTS unittest HINTS $ENV{ZEPHYR_BASE})
+
+include(${ZEPHYR_BASE}/tests/bluetooth/host/cmake.txt)
+include(${ZEPHYR_BASE}/tests/bluetooth/host/buf/cmake.txt)
+
+target_sources(testbinary PRIVATE ${host_module} ${module_mocks} ${host_mocks})

--- a/tests/bluetooth/host/buf/bt_buf_get_type/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/src/main.c
@@ -8,7 +8,7 @@
 #include <zephyr/bluetooth/hci.h>
 #include <zephyr/bluetooth/buf.h>
 #include "kconfig.h"
-#include "buf_help_utils.h"
+#include "mocks/buf_help_utils.h"
 
 /* Rows count equals number of types */
 #define TEST_PARAMETERS_LUT_ROWS_COUNT		7

--- a/tests/bluetooth/host/buf/bt_buf_get_type/src/main.c
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/src/main.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/buf.h>
+#include "kconfig.h"
+#include "buf_help_utils.h"
+
+/* Rows count equals number of types */
+#define TEST_PARAMETERS_LUT_ROWS_COUNT		7
+
+/* LUT containing testing parameters that will be used
+ * during each iteration to cover different scenarios
+ */
+static const enum bt_buf_type testing_params_lut[] = {
+	/** HCI command */
+	BT_BUF_CMD,
+	/** HCI event */
+	BT_BUF_EVT,
+	/** Outgoing ACL data */
+	BT_BUF_ACL_OUT,
+	/** Incoming ACL data */
+	BT_BUF_ACL_IN,
+	/** Outgoing ISO data */
+	BT_BUF_ISO_OUT,
+	/** Incoming ISO data */
+	BT_BUF_ISO_IN,
+	/** H:4 data */
+	BT_BUF_H4,
+};
+
+BUILD_ASSERT(ARRAY_SIZE(testing_params_lut) == TEST_PARAMETERS_LUT_ROWS_COUNT);
+
+/* Global iterator to iterate over the LUT */
+static uint8_t testing_params_it;
+
+/* Buffer type to be used during current test run */
+enum bt_buf_type current_test_buffer_type;
+
+/*
+ *  Buffer type is set and retrieved correctly
+ *
+ *  Constraints:
+ *     - Use valid buffer buffer reference
+ *     - Use valid buffer type
+ *
+ *  Expected behaviour:
+ *     - Buffer type field inside 'struct net_buf' is set correctly
+ *     - Retrieving buffer type through bt_buf_get_type() returns the correct
+ *       value
+ */
+void test_buffer_type_set_get_correctly(void)
+{
+	static struct net_buf testing_buffer;
+	struct net_buf *buf = &testing_buffer;
+	enum bt_buf_type buffer_type_set, returned_buffer_type;
+
+	bt_buf_set_type(buf, current_test_buffer_type);
+
+	returned_buffer_type = bt_buf_get_type(buf);
+	buffer_type_set = ((struct bt_buf_data *)net_buf_user_data(buf))->type;
+
+	zassert_equal(buffer_type_set, current_test_buffer_type,
+		      "Buffer type %u set by bt_buf_set_type() is incorrect, expected %u",
+		      buffer_type_set, current_test_buffer_type);
+
+	zassert_equal(returned_buffer_type, current_test_buffer_type,
+		      "Buffer type %u returned by bt_buf_get_type() is incorrect, expected %u",
+		      returned_buffer_type, current_test_buffer_type);
+}
+
+/* Setup test variables */
+static void unit_test_setup(void)
+{
+	zassert_true((testing_params_it < (ARRAY_SIZE(testing_params_lut))),
+		     "Invalid testing parameters index %u", testing_params_it);
+	current_test_buffer_type = testing_params_lut[testing_params_it];
+	testing_params_it++;
+}
+
+void test_main(void)
+{
+	/* Each run will use a testing parameters set from LUT
+	 * This can help in identifying which parameters fails instead of using
+	 * a single 'void' test function and call the parameterized function.
+	 */
+	ztest_test_suite(test_bt_buf_get_set_get_type,
+			 LISTIFY(TEST_PARAMETERS_LUT_ROWS_COUNT, REGISTER_SETUP_TEARDOWN, (,),
+				 test_buffer_type_set_get_correctly));
+
+	ztest_run_test_suite(test_bt_buf_get_set_get_type);
+}

--- a/tests/bluetooth/host/buf/bt_buf_get_type/testcase.yaml
+++ b/tests/bluetooth/host/buf/bt_buf_get_type/testcase.yaml
@@ -1,0 +1,5 @@
+common:
+    tags: test_framework bluetooth host
+tests:
+  bluetooth.host.bt_buf_get_type.default:
+     type: unit

--- a/tests/bluetooth/host/buf/cmake.txt
+++ b/tests/bluetooth/host/buf/cmake.txt
@@ -1,0 +1,22 @@
+#
+# Common include directories and source files for bluetooth/host/buf.c unit tests
+#
+
+include_directories(
+  ${ZEPHYR_BASE}/tests/bluetooth/host/buf
+  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks
+)
+
+FILE(GLOB host_module
+  ${ZEPHYR_BASE}/subsys/bluetooth/host/buf.c
+)
+
+FILE(GLOB module_mocks
+  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/net_buf.c
+  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/iso.c
+  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/hci_core.c
+)
+
+if(COMPILE_SWITCH_PARAM)
+  add_compile_definitions(${COMPILE_SWITCH_PARAM})
+endif()

--- a/tests/bluetooth/host/buf/cmake.txt
+++ b/tests/bluetooth/host/buf/cmake.txt
@@ -15,6 +15,7 @@ FILE(GLOB module_mocks
   ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/net_buf.c
   ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/iso.c
   ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/hci_core.c
+  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/buf_help_utils.c
 )
 
 if(COMPILE_SWITCH_PARAM)

--- a/tests/bluetooth/host/buf/cmake.txt
+++ b/tests/bluetooth/host/buf/cmake.txt
@@ -4,7 +4,6 @@
 
 include_directories(
   ${ZEPHYR_BASE}/tests/bluetooth/host/buf
-  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks
 )
 
 FILE(GLOB host_module
@@ -15,7 +14,7 @@ FILE(GLOB module_mocks
   ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/net_buf.c
   ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/iso.c
   ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/hci_core.c
-  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/buf_help_utils.c
+  ${ZEPHYR_BASE}/tests/bluetooth/host/buf/mocks/net_buf_expects.c
 )
 
 if(COMPILE_SWITCH_PARAM)

--- a/tests/bluetooth/host/buf/kconfig.h
+++ b/tests/bluetooth/host/buf/kconfig.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Common Kconfig settings for bluetooth/host mocks */
+
+#define CONFIG_BT_ID_MAX 2
+#define CONFIG_BT_HCI_RESERVE 1
+#define CONFIG_BT_BUF_EVT_RX_COUNT 10
+#define CONFIG_BT_BUF_ACL_RX_COUNT 6
+#define CONFIG_BT_BUF_ACL_RX_SIZE 27
+#define CONFIG_BT_BUF_EVT_RX_SIZE 68
+
+#ifdef BT_BUF_EVT_DISCARDABLE_COUNT_CONFIG_SET
+/*  Keep the value 1 in order to make IS_ENABLED(CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT) works */
+#define CONFIG_BT_BUF_EVT_DISCARDABLE_COUNT 1
+#define CONFIG_BT_BUF_EVT_DISCARDABLE_SIZE 43
+#endif
+
+#ifdef BT_ISO_CONFIG_SET
+#define CONFIG_BT_ISO 1
+#define CONFIG_BT_ID_MAX 2
+#define CONFIG_BT_ISO_MAX_CHAN 1
+#define CONFIG_BT_ISO_RX_BUF_COUNT 1
+#define CONFIG_BT_ISO_RX_MTU 251
+#endif
+
+#ifdef BT_CONN_CONFIG_SET
+/*  Keep the value 1 in order to make IS_ENABLED(CONFIG_BT_CONN) works */
+#define CONFIG_BT_CONN 1
+#define CONFIG_BT_MAX_CONN 4
+#endif
+
+#ifdef BT_ISO_UNICAST_CONFIG_SET
+#define CONFIG_BT_ISO_UNICAST 1
+#define CONFIG_BT_ISO_RX_BUF_COUNT 1
+#define CONFIG_BT_ISO_RX_MTU 251
+#endif
+
+#ifdef BT_ISO_SYNC_RECEIVER_CONFIG_SET
+#define CONFIG_BT_ISO_SYNC_RECEIVER 1
+#define CONFIG_BT_ISO_RX_BUF_COUNT 1
+#define CONFIG_BT_ISO_RX_MTU 251
+#endif
+
+/* Assertion configuration */
+
+#define CONFIG_ASSERT 1
+#define CONFIG_ASSERT_LEVEL 2
+#define CONFIG_ASSERT_VERBOSE 1

--- a/tests/bluetooth/host/buf/mocks/buf_help_utils.c
+++ b/tests/bluetooth/host/buf/mocks/buf_help_utils.c
@@ -52,3 +52,22 @@ void validate_net_buf_reserve_not_called_behaviour(void)
 	zassert_equal(net_buf_simple_reserve_fake.call_count, 0, "'%s()' was called unexpectedly",
 		      func_name);
 }
+
+void validate_net_buf_ref_called_behaviour(struct net_buf *buf)
+{
+	const char *func_name = "net_buf_ref";
+
+	zassert_equal(net_buf_ref_fake.call_count, 1, "'%s()' was called more than once",
+		      func_name);
+
+	zassert_equal_ptr(net_buf_ref_fake.arg0_val, buf,
+			  "'%s()' was called with incorrect '%s' value", func_name, "buf");
+}
+
+void validate_net_buf_ref_not_called_behaviour(void)
+{
+	const char *func_name = "net_buf_ref";
+
+	zassert_equal(net_buf_ref_fake.call_count, 0, "'%s()' was called unexpectedly",
+		      func_name);
+}

--- a/tests/bluetooth/host/buf/mocks/buf_help_utils.c
+++ b/tests/bluetooth/host/buf/mocks/buf_help_utils.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/buf.h>
+#include "net_buf.h"
+#include "buf_help_utils.h"
+
+void validate_net_buf_alloc_called_behaviour(struct net_buf_pool *pool, k_timeout_t *timeout)
+{
+	const char *func_name = "net_buf_alloc_fixed";
+
+	zassert_equal(net_buf_alloc_fixed_fake.call_count, 1, "'%s()' was called more than once",
+		      func_name);
+
+	zassert_equal_ptr(net_buf_alloc_fixed_fake.arg0_val, pool,
+			  "'%s()' was called with incorrect '%s' value", func_name, "pool");
+
+	zassert_mem_equal(&net_buf_alloc_fixed_fake.arg1_val, timeout, sizeof(k_timeout_t),
+			  "'%s()' was called with incorrect '%s' value", func_name, "timeout");
+}
+
+void validate_net_buf_alloc_not_called_behaviour(void)
+{
+	const char *func_name = "net_buf_alloc_fixed";
+
+	zassert_equal(net_buf_alloc_fixed_fake.call_count, 0, "'%s()' was called unexpectedly",
+		      func_name);
+}
+
+void validate_net_buf_reserve_called_behaviour(struct net_buf *buf)
+{
+	const char *func_name = "net_buf_simple_reserve";
+
+	zassert_equal(net_buf_simple_reserve_fake.call_count, 1, "'%s()' was called more than once",
+		      func_name);
+
+	zassert_equal_ptr(net_buf_simple_reserve_fake.arg0_val, &buf->b,
+			  "'%s()' was called with incorrect '%s' value", func_name, "buf");
+
+	zassert_equal(net_buf_simple_reserve_fake.arg1_val, BT_BUF_RESERVE,
+		      "'%s()' was called with incorrect '%s' value", func_name, "reserve");
+}
+
+void validate_net_buf_reserve_not_called_behaviour(void)
+{
+	const char *func_name = "net_buf_simple_reserve";
+
+	zassert_equal(net_buf_simple_reserve_fake.call_count, 0, "'%s()' was called unexpectedly",
+		      func_name);
+}

--- a/tests/bluetooth/host/buf/mocks/buf_help_utils.h
+++ b/tests/bluetooth/host/buf/mocks/buf_help_utils.h
@@ -29,18 +29,41 @@ struct testing_params {
 #define REGISTER_SETUP_TEARDOWN(i, ...) \
 	ztest_unit_test_setup_teardown(__VA_ARGS__, unit_test_setup, unit_test_noop)
 
-/*  Validate the timeout integer value
+#define ztest_unit_test_setup(fn, setup) \
+	ztest_unit_test_setup_teardown(fn, setup, unit_test_noop)
+
+/*
+ *  Validate expected behaviour when net_buf_alloc() is called
  *
- *  A validation function that will be called with
- *  the timeout integer value as an input parameter.
- *
- *  It will check the passed input parameter to check its value if it
- *  matches the expected value using ztest_check_expected_value().
- *
- *  A typical use should call ztest_expect_value() to set the expected
- *  value before calling any function that will be required to validate
- *  a timeout value
- *
- *  @param value Input integer value to be checked
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called once with :
+ *       - correct memory allocation pool
+ *       - same timeout value passed to bt_buf_get_cmd_complete()
  */
-void net_buf_validate_timeout_value_mock(uint32_t value);
+void validate_net_buf_alloc_called_behaviour(struct net_buf_pool *pool, k_timeout_t *timeout);
+
+/*
+ *  Validate expected behaviour when net_buf_alloc() isn't called
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() not to called at all
+ */
+void validate_net_buf_alloc_not_called_behaviour(void);
+
+/*
+ *  Validate expected behaviour when net_buf_reserve() is called
+ *
+ *  Expected behaviour:
+ *   - net_buf_reserve() to be called once with :
+ *       - correct reference value
+ *       - 'reserve' argument set to 'BT_BUF_RESERVE' value
+ */
+void validate_net_buf_reserve_called_behaviour(struct net_buf *buf);
+
+/*
+ *  Validate expected behaviour when net_buf_reserve() isn't called
+ *
+ *  Expected behaviour:
+ *   - net_buf_reserve() not to called at all
+ */
+void validate_net_buf_reserve_not_called_behaviour(void);

--- a/tests/bluetooth/host/buf/mocks/buf_help_utils.h
+++ b/tests/bluetooth/host/buf/mocks/buf_help_utils.h
@@ -67,3 +67,20 @@ void validate_net_buf_reserve_called_behaviour(struct net_buf *buf);
  *   - net_buf_reserve() not to called at all
  */
 void validate_net_buf_reserve_not_called_behaviour(void);
+
+/*
+ *  Validate expected behaviour when net_buf_ref() is called
+ *
+ *  Expected behaviour:
+ *   - net_buf_ref() to be called once with :
+ *       - correct reference value
+ */
+void validate_net_buf_ref_called_behaviour(struct net_buf *buf);
+
+/*
+ *  Validate expected behaviour when net_buf_ref() isn't called
+ *
+ *  Expected behaviour:
+ *   - net_buf_ref() not to called at all
+ */
+void validate_net_buf_ref_not_called_behaviour(void);

--- a/tests/bluetooth/host/buf/mocks/buf_help_utils.h
+++ b/tests/bluetooth/host/buf/mocks/buf_help_utils.h
@@ -4,8 +4,6 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-/* Include declarations and defines related to hooks */
-
 #include <zephyr/zephyr.h>
 
 struct net_buf_pool *bt_buf_get_evt_pool(void);
@@ -31,56 +29,3 @@ struct testing_params {
 
 #define ztest_unit_test_setup(fn, setup) \
 	ztest_unit_test_setup_teardown(fn, setup, unit_test_noop)
-
-/*
- *  Validate expected behaviour when net_buf_alloc() is called
- *
- *  Expected behaviour:
- *   - net_buf_alloc() to be called once with :
- *       - correct memory allocation pool
- *       - same timeout value passed to bt_buf_get_cmd_complete()
- */
-void validate_net_buf_alloc_called_behaviour(struct net_buf_pool *pool, k_timeout_t *timeout);
-
-/*
- *  Validate expected behaviour when net_buf_alloc() isn't called
- *
- *  Expected behaviour:
- *   - net_buf_alloc() not to called at all
- */
-void validate_net_buf_alloc_not_called_behaviour(void);
-
-/*
- *  Validate expected behaviour when net_buf_reserve() is called
- *
- *  Expected behaviour:
- *   - net_buf_reserve() to be called once with :
- *       - correct reference value
- *       - 'reserve' argument set to 'BT_BUF_RESERVE' value
- */
-void validate_net_buf_reserve_called_behaviour(struct net_buf *buf);
-
-/*
- *  Validate expected behaviour when net_buf_reserve() isn't called
- *
- *  Expected behaviour:
- *   - net_buf_reserve() not to called at all
- */
-void validate_net_buf_reserve_not_called_behaviour(void);
-
-/*
- *  Validate expected behaviour when net_buf_ref() is called
- *
- *  Expected behaviour:
- *   - net_buf_ref() to be called once with :
- *       - correct reference value
- */
-void validate_net_buf_ref_called_behaviour(struct net_buf *buf);
-
-/*
- *  Validate expected behaviour when net_buf_ref() isn't called
- *
- *  Expected behaviour:
- *   - net_buf_ref() not to called at all
- */
-void validate_net_buf_ref_not_called_behaviour(void);

--- a/tests/bluetooth/host/buf/mocks/buf_help_utils.h
+++ b/tests/bluetooth/host/buf/mocks/buf_help_utils.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/* Include declarations and defines related to hooks */
+
+#include <zephyr/zephyr.h>
+
+struct net_buf_pool *bt_buf_get_evt_pool(void);
+struct net_buf_pool *bt_buf_get_acl_in_pool(void);
+struct net_buf_pool *bt_buf_get_hci_rx_pool(void);
+struct net_buf_pool *bt_buf_get_discardable_pool(void);
+struct net_buf_pool *bt_buf_get_num_complete_pool(void);
+struct net_buf_pool *bt_buf_get_discardable_pool(void);
+struct net_buf_pool *bt_buf_get_num_complete_pool(void);
+struct net_buf_pool *bt_buf_get_iso_rx_pool(void);
+
+/* LUT testing parameter item */
+struct testing_params {
+	uint8_t evt;			/*	Event type */
+	bool discardable;		/*	Discardable flag	*/
+};
+
+#define TEST_PARAM_PAIR_DEFINE(EVT) {EVT, true}, {EVT, false}
+
+/* Repeat test entries */
+#define REGISTER_SETUP_TEARDOWN(i, ...) \
+	ztest_unit_test_setup_teardown(__VA_ARGS__, unit_test_setup, unit_test_noop)
+
+/*  Validate the timeout integer value
+ *
+ *  A validation function that will be called with
+ *  the timeout integer value as an input parameter.
+ *
+ *  It will check the passed input parameter to check its value if it
+ *  matches the expected value using ztest_check_expected_value().
+ *
+ *  A typical use should call ztest_expect_value() to set the expected
+ *  value before calling any function that will be required to validate
+ *  a timeout value
+ *
+ *  @param value Input integer value to be checked
+ */
+void net_buf_validate_timeout_value_mock(uint32_t value);

--- a/tests/bluetooth/host/buf/mocks/hci_core.c
+++ b/tests/bluetooth/host/buf/mocks/hci_core.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/hci.h>
+#include <host/hci_core.h>
+
+struct bt_dev bt_dev = {
+	.manufacturer = 0x1234,
+};
+
+#if defined(CONFIG_BT_HCI_ACL_FLOW_CONTROL)
+void bt_hci_host_num_completed_packets(struct net_buf *buf)
+{
+}
+#endif

--- a/tests/bluetooth/host/buf/mocks/iso.c
+++ b/tests/bluetooth/host/buf/mocks/iso.c
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/bluetooth/iso.h>
+
+/* This file doesn't contain mocks, but rather fakes of the necessary parts of
+ * subsys/bluetooth/host/iso.c. The API implementations that are copied here
+ * should be kept in sync with the original.
+ */
+
+#if defined(CONFIG_BT_ISO_UNICAST) || defined(CONFIG_BT_ISO_SYNC_RECEIVER)
+NET_BUF_POOL_FIXED_DEFINE(iso_rx_pool, CONFIG_BT_ISO_RX_BUF_COUNT,
+			  BT_ISO_SDU_BUF_SIZE(CONFIG_BT_ISO_RX_MTU), 8, NULL);
+
+struct net_buf *bt_iso_get_rx(k_timeout_t timeout)
+{
+	struct net_buf *buf = net_buf_alloc(&iso_rx_pool, timeout);
+
+	if (buf) {
+		net_buf_reserve(buf, BT_BUF_RESERVE);
+		bt_buf_set_type(buf, BT_BUF_ISO_IN);
+	}
+
+	return buf;
+}
+
+struct net_buf_pool *bt_buf_get_iso_rx_pool(void)
+{
+	return &iso_rx_pool;
+}
+#endif

--- a/tests/bluetooth/host/buf/mocks/net_buf.c
+++ b/tests/bluetooth/host/buf/mocks/net_buf.c
@@ -7,23 +7,20 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/bluetooth/buf.h>
+#include "net_buf.h"
 #include "buf_help_utils.h"
 
 
 static uint8_t *fixed_data_alloc(struct net_buf *buf, size_t *size,
 			      k_timeout_t timeout)
 {
-	ztest_check_expected_value(buf);
-	ztest_check_expected_value(size);
-	net_buf_validate_timeout_value_mock(timeout.ticks);
-	return (uint8_t *)ztest_get_return_value_ptr();
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
+	return NULL;
 }
 
 static void fixed_data_unref(struct net_buf *buf, uint8_t *data)
 {
-	/* Nothing needed for fixed-size data pools */
-	ztest_check_expected_value(buf);
-	ztest_check_expected_value(data);
+	zassert_unreachable("Unexpected call to '%s()' occurred", __func__);
 }
 
 const struct net_buf_data_cb net_buf_fixed_cb = {
@@ -31,26 +28,11 @@ const struct net_buf_data_cb net_buf_fixed_cb = {
 	.unref = fixed_data_unref,
 };
 
-void net_buf_validate_timeout_value_mock(uint32_t value)
-{
-	ztest_check_expected_value(value);
-}
+/* struct net_buf *net_buf_alloc_fixed(struct net_buf_pool *pool, k_timeout_t timeout) mock */
+DEFINE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_alloc_fixed, struct net_buf_pool *, k_timeout_t);
 
-struct net_buf *net_buf_alloc_fixed(struct net_buf_pool *pool, k_timeout_t timeout)
-{
-	ztest_check_expected_value(pool);
-	net_buf_validate_timeout_value_mock(timeout.ticks);
-	return (struct net_buf *)ztest_get_return_value_ptr();
-}
+/* void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve) mock */
+DEFINE_FAKE_VOID_FUNC(net_buf_simple_reserve, struct net_buf_simple *, size_t);
 
-void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve)
-{
-	ztest_check_expected_value(buf);
-	ztest_check_expected_value(reserve);
-}
-
-struct net_buf *net_buf_ref(struct net_buf *buf)
-{
-	ztest_check_expected_value(buf);
-	return buf;
-}
+/* struct net_buf *net_buf_ref(struct net_buf *buf) mock */
+DEFINE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_ref, struct net_buf *);

--- a/tests/bluetooth/host/buf/mocks/net_buf.c
+++ b/tests/bluetooth/host/buf/mocks/net_buf.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/net/buf.h>
+#include <zephyr/bluetooth/buf.h>
+#include "buf_help_utils.h"
+
+
+static uint8_t *fixed_data_alloc(struct net_buf *buf, size_t *size,
+			      k_timeout_t timeout)
+{
+	ztest_check_expected_value(buf);
+	ztest_check_expected_value(size);
+	net_buf_validate_timeout_value_mock(timeout.ticks);
+	return (uint8_t *)ztest_get_return_value_ptr();
+}
+
+static void fixed_data_unref(struct net_buf *buf, uint8_t *data)
+{
+	/* Nothing needed for fixed-size data pools */
+	ztest_check_expected_value(buf);
+	ztest_check_expected_value(data);
+}
+
+const struct net_buf_data_cb net_buf_fixed_cb = {
+	.alloc = fixed_data_alloc,
+	.unref = fixed_data_unref,
+};
+
+void net_buf_validate_timeout_value_mock(uint32_t value)
+{
+	ztest_check_expected_value(value);
+}
+
+struct net_buf *net_buf_alloc_fixed(struct net_buf_pool *pool, k_timeout_t timeout)
+{
+	ztest_check_expected_value(pool);
+	net_buf_validate_timeout_value_mock(timeout.ticks);
+	return (struct net_buf *)ztest_get_return_value_ptr();
+}
+
+void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve)
+{
+	ztest_check_expected_value(buf);
+	ztest_check_expected_value(reserve);
+}
+
+struct net_buf *net_buf_ref(struct net_buf *buf)
+{
+	ztest_check_expected_value(buf);
+	return buf;
+}

--- a/tests/bluetooth/host/buf/mocks/net_buf.c
+++ b/tests/bluetooth/host/buf/mocks/net_buf.c
@@ -7,9 +7,10 @@
 #include <zephyr/zephyr.h>
 #include <zephyr/net/buf.h>
 #include <zephyr/bluetooth/buf.h>
-#include "net_buf.h"
-#include "buf_help_utils.h"
+#include <mocks/net_buf.h>
+#include <mocks/buf_help_utils.h>
 
+DEFINE_FFF_GLOBALS;
 
 static uint8_t *fixed_data_alloc(struct net_buf *buf, size_t *size,
 			      k_timeout_t timeout)
@@ -28,11 +29,8 @@ const struct net_buf_data_cb net_buf_fixed_cb = {
 	.unref = fixed_data_unref,
 };
 
-/* struct net_buf *net_buf_alloc_fixed(struct net_buf_pool *pool, k_timeout_t timeout) mock */
 DEFINE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_alloc_fixed, struct net_buf_pool *, k_timeout_t);
 
-/* void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve) mock */
 DEFINE_FAKE_VOID_FUNC(net_buf_simple_reserve, struct net_buf_simple *, size_t);
 
-/* struct net_buf *net_buf_ref(struct net_buf *buf) mock */
 DEFINE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_ref, struct net_buf *);

--- a/tests/bluetooth/host/buf/mocks/net_buf.h
+++ b/tests/bluetooth/host/buf/mocks/net_buf.h
@@ -7,19 +7,14 @@
 #include <zephyr/fff.h>
 #include <zephyr/zephyr.h>
 
-DEFINE_FFF_GLOBALS;
-
 /* List of fakes used by this unit tester */
-#define FFF_FAKES_LIST(FAKE)         \
-	FAKE(net_buf_alloc_fixed)          \
-	FAKE(net_buf_simple_reserve)       \
-	FAKE(net_buf_ref)
+#define NET_BUFF_FFF_FAKES_LIST(FAKE)  \
+		FAKE(net_buf_alloc_fixed)      \
+		FAKE(net_buf_simple_reserve)   \
+		FAKE(net_buf_ref)
 
-/* struct net_buf *net_buf_alloc_fixed(struct net_buf_pool *pool, k_timeout_t timeout) mock */
 DECLARE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_alloc_fixed, struct net_buf_pool *, k_timeout_t);
 
-/* void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve) mock */
 DECLARE_FAKE_VOID_FUNC(net_buf_simple_reserve, struct net_buf_simple *, size_t);
 
-/* struct net_buf *net_buf_ref(struct net_buf *buf) mock */
 DECLARE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_ref, struct net_buf *);

--- a/tests/bluetooth/host/buf/mocks/net_buf.h
+++ b/tests/bluetooth/host/buf/mocks/net_buf.h
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/fff.h>
+#include <zephyr/zephyr.h>
+
+DEFINE_FFF_GLOBALS;
+
+/* List of fakes used by this unit tester */
+#define FFF_FAKES_LIST(FAKE)         \
+	FAKE(net_buf_alloc_fixed)          \
+	FAKE(net_buf_simple_reserve)       \
+	FAKE(net_buf_ref)
+
+/* struct net_buf *net_buf_alloc_fixed(struct net_buf_pool *pool, k_timeout_t timeout) mock */
+DECLARE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_alloc_fixed, struct net_buf_pool *, k_timeout_t);
+
+/* void net_buf_simple_reserve(struct net_buf_simple *buf, size_t reserve) mock */
+DECLARE_FAKE_VOID_FUNC(net_buf_simple_reserve, struct net_buf_simple *, size_t);
+
+/* struct net_buf *net_buf_ref(struct net_buf *buf) mock */
+DECLARE_FAKE_VALUE_FUNC(struct net_buf *, net_buf_ref, struct net_buf *);

--- a/tests/bluetooth/host/buf/mocks/net_buf_expects.c
+++ b/tests/bluetooth/host/buf/mocks/net_buf_expects.c
@@ -6,10 +6,10 @@
 
 #include <zephyr/zephyr.h>
 #include <zephyr/bluetooth/buf.h>
-#include "net_buf.h"
-#include "buf_help_utils.h"
+#include "mocks/net_buf.h"
+#include "mocks/net_buf_expects.h"
 
-void validate_net_buf_alloc_called_behaviour(struct net_buf_pool *pool, k_timeout_t *timeout)
+void expect_single_call_net_buf_alloc(struct net_buf_pool *pool, k_timeout_t *timeout)
 {
 	const char *func_name = "net_buf_alloc_fixed";
 
@@ -23,7 +23,7 @@ void validate_net_buf_alloc_called_behaviour(struct net_buf_pool *pool, k_timeou
 			  "'%s()' was called with incorrect '%s' value", func_name, "timeout");
 }
 
-void validate_net_buf_alloc_not_called_behaviour(void)
+void expect_not_called_net_buf_alloc(void)
 {
 	const char *func_name = "net_buf_alloc_fixed";
 
@@ -31,7 +31,7 @@ void validate_net_buf_alloc_not_called_behaviour(void)
 		      func_name);
 }
 
-void validate_net_buf_reserve_called_behaviour(struct net_buf *buf)
+void expect_single_call_net_buf_reserve(struct net_buf *buf)
 {
 	const char *func_name = "net_buf_simple_reserve";
 
@@ -45,7 +45,7 @@ void validate_net_buf_reserve_called_behaviour(struct net_buf *buf)
 		      "'%s()' was called with incorrect '%s' value", func_name, "reserve");
 }
 
-void validate_net_buf_reserve_not_called_behaviour(void)
+void expect_not_called_net_buf_reserve(void)
 {
 	const char *func_name = "net_buf_simple_reserve";
 
@@ -53,7 +53,7 @@ void validate_net_buf_reserve_not_called_behaviour(void)
 		      func_name);
 }
 
-void validate_net_buf_ref_called_behaviour(struct net_buf *buf)
+void expect_single_call_net_buf_ref(struct net_buf *buf)
 {
 	const char *func_name = "net_buf_ref";
 
@@ -64,7 +64,7 @@ void validate_net_buf_ref_called_behaviour(struct net_buf *buf)
 			  "'%s()' was called with incorrect '%s' value", func_name, "buf");
 }
 
-void validate_net_buf_ref_not_called_behaviour(void)
+void expect_not_called_net_buf_ref(void)
 {
 	const char *func_name = "net_buf_ref";
 

--- a/tests/bluetooth/host/buf/mocks/net_buf_expects.h
+++ b/tests/bluetooth/host/buf/mocks/net_buf_expects.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+
+/*
+ *  Validate expected behaviour when net_buf_alloc() is called
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() to be called once with :
+ *       - correct memory allocation pool
+ *       - same timeout value passed to bt_buf_get_cmd_complete()
+ */
+void expect_single_call_net_buf_alloc(struct net_buf_pool *pool, k_timeout_t *timeout);
+
+/*
+ *  Validate expected behaviour when net_buf_alloc() isn't called
+ *
+ *  Expected behaviour:
+ *   - net_buf_alloc() not to called at all
+ */
+void expect_not_called_net_buf_alloc(void);
+
+/*
+ *  Validate expected behaviour when net_buf_reserve() is called
+ *
+ *  Expected behaviour:
+ *   - net_buf_reserve() to be called once with :
+ *       - correct reference value
+ *       - 'reserve' argument set to 'BT_BUF_RESERVE' value
+ */
+void expect_single_call_net_buf_reserve(struct net_buf *buf);
+
+/*
+ *  Validate expected behaviour when net_buf_reserve() isn't called
+ *
+ *  Expected behaviour:
+ *   - net_buf_reserve() not to called at all
+ */
+void expect_not_called_net_buf_reserve(void);
+
+/*
+ *  Validate expected behaviour when net_buf_ref() is called
+ *
+ *  Expected behaviour:
+ *   - net_buf_ref() to be called once with correct reference value
+ */
+void expect_single_call_net_buf_ref(struct net_buf *buf);
+
+/*
+ *  Validate expected behaviour when net_buf_ref() isn't called
+ *
+ *  Expected behaviour:
+ *   - net_buf_ref() not to called at all
+ */
+void expect_not_called_net_buf_ref(void);

--- a/tests/bluetooth/host/cmake.txt
+++ b/tests/bluetooth/host/cmake.txt
@@ -1,0 +1,15 @@
+#
+# Common include directories and source files for bluetooth/host unit tests
+#
+
+include_directories(
+  ${ZEPHYR_BASE}/subsys/bluetooth
+  ${ZEPHYR_BASE}/tests/bluetooth/host/host_mocks
+)
+
+FILE(GLOB host_mocks
+  ${ZEPHYR_BASE}/tests/bluetooth/host/host_mocks/assert.c
+)
+
+add_definitions(-include kconfig.h)
+add_definitions(-include ztest.h)

--- a/tests/bluetooth/host/cmake.txt
+++ b/tests/bluetooth/host/cmake.txt
@@ -4,7 +4,7 @@
 
 include_directories(
   ${ZEPHYR_BASE}/subsys/bluetooth
-  ${ZEPHYR_BASE}/tests/bluetooth/host/host_mocks
+  ${ZEPHYR_BASE}/tests/bluetooth/host
 )
 
 FILE(GLOB host_mocks

--- a/tests/bluetooth/host/host_mocks/assert.c
+++ b/tests/bluetooth/host/host_mocks/assert.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+#include "assert.h"
+
+void assert_print(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vprintk(fmt, ap);
+	va_end(ap);
+}
+
+bool mock_check_if_assert_expected(void)
+{
+	/* This will fail the test run if ztest_returns_value() hasn't been
+	 * called (i.e. the test doesn't expect an assert).
+	 */
+	return ztest_get_return_value();
+}
+
+void assert_post_action(const char *file, unsigned int line)
+{
+	/* If this is an unexpected assert (i.e. not following expect_assert())
+	 * calling mock_check_if_assert_expected() will terminate the test and
+	 * mark it as failed.
+	 */
+	if (mock_check_if_assert_expected() == true) {
+		printk("Assertion expected as part of a test case.\n");
+		/* This will mark the test as passed and stop execution:
+		 * Needed in the passing scenario to prevent undefined behavior after hitting the
+		 * assert. In real builds (non-UT), the system will be halted by the assert.
+		 */
+		ztest_test_pass();
+	}
+}

--- a/tests/bluetooth/host/host_mocks/assert.h
+++ b/tests/bluetooth/host/host_mocks/assert.h
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/zephyr.h>
+
+#define expect_assert() ztest_returns_value(mock_check_if_assert_expected, true)

--- a/tests/bluetooth/host/host_mocks/assert.h
+++ b/tests/bluetooth/host/host_mocks/assert.h
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/fff.h>
 #include <zephyr/zephyr.h>
 
-#define expect_assert() ztest_returns_value(mock_check_if_assert_expected, true)
+DECLARE_FAKE_VALUE_FUNC(bool, mock_check_if_assert_expected);
+
+#define expect_assert()     (mock_check_if_assert_expected_fake.return_val = 1)


### PR DESCRIPTION
WIP: Please check the modifications for the following files

- tests/bluetooth/host/buf/bt_buf_get_rx/src/main.c
- tests/bluetooth/host/buf/bt_buf_get_cmd_complete/src/main.c

I added some behavior verification functions at tests/bluetooth/host/buf/mocks/buf_help_utils.c