### PR TITLE
drivers: memc: mcux_flexspi: Always try to apply pinctrl state

### DIFF
--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -145,13 +145,13 @@ static int memc_flexspi_init(const struct device *dev)
 
 	/*
 	 * SOCs such as the RT1064 and RT1024 have internal flash, and no pinmux
-	 * settings, so skip pin control state.
+	 * settings, continue if no pinctrl state found.
 	 */
-#if defined(CONFIG_PINCTRL) && !(defined(CONFIG_SOC_MIMXRT1064) || defined(CONFIG_SOC_MIMXRT1024))
+#ifdef CONFIG_PINCTRL
 	int ret;
 
 	ret = pinctrl_apply_state(data->pincfg, PINCTRL_STATE_DEFAULT);
-	if (ret < 0) {
+	if (ret < 0 && ret != -ENOENT) {
 		return ret;
 	}
 #endif


### PR DESCRIPTION
This commit fixes an issue introduced in 5ee9392 where FlexSPI pinctrl states where applied based on the SoC type.
However multiple FlexSPI instances can be active, some of which are not pre-configured from ROM.