### PR TITLE
samples: modules: nanopb: Limit the integration platforms

### DIFF
--- a/samples/modules/nanopb/sample.yaml
+++ b/samples/modules/nanopb/sample.yaml
@@ -13,3 +13,6 @@ common:
 tests:
   sample.modules.nanopb:
     tags: samples nanopb
+    integration_platforms:
+    - native_posix
+    - native_posix_64


### PR DESCRIPTION
Reduce the number of build tests by explicitly setting the integrations platforms.