### PR TITLE
Bluetooth: Correct printf format for 16-bit int architectures

### DIFF
--- a/subsys/bluetooth/host/uuid.c
+++ b/subsys/bluetooth/host/uuid.c
@@ -108,7 +108,7 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 		snprintk(str, len, "%04x", BT_UUID_16(uuid)->val);
 		break;
 	case BT_UUID_TYPE_32:
-		snprintk(str, len, "%08x", BT_UUID_32(uuid)->val);
+		snprintk(str, len, "%08"PRIx32"", BT_UUID_32(uuid)->val);
 		break;
 	case BT_UUID_TYPE_128:
 		memcpy(&tmp0, &BT_UUID_128(uuid)->val[0], sizeof(tmp0));
@@ -118,7 +118,7 @@ void bt_uuid_to_str(const struct bt_uuid *uuid, char *str, size_t len)
 		memcpy(&tmp4, &BT_UUID_128(uuid)->val[10], sizeof(tmp4));
 		memcpy(&tmp5, &BT_UUID_128(uuid)->val[12], sizeof(tmp5));
 
-		snprintk(str, len, "%08x-%04x-%04x-%04x-%08x%04x",
+		snprintk(str, len, "%08"PRIx32"-%04x-%04x-%04x-%08"PRIx32"%04x",
 			 sys_le32_to_cpu(tmp5), sys_le16_to_cpu(tmp4),
 			 sys_le16_to_cpu(tmp3), sys_le16_to_cpu(tmp2),
 			 sys_le32_to_cpu(tmp1), sys_le16_to_cpu(tmp0));


### PR DESCRIPTION
uint32_t format warning

Signed-off-by: YanBiao Hao <haoyanbiao@xiaomi.com>