### PR TITLE
kernel: fix race condition in sys_clock_announce()

### DIFF
--- a/kernel/timeout.c
+++ b/kernel/timeout.c
@@ -250,7 +250,7 @@ void sys_clock_announce(int32_t ticks)
 	 * timeouts and confuse apps), just increment the tick count
 	 * and return.
 	 */
-	if (IS_ENABLED(CONFIG_SMP) && announce_remaining != 0) {
+	if (IS_ENABLED(CONFIG_SMP) && (announce_remaining != 0)) {
 		announce_remaining += ticks;
 		k_spin_unlock(&timeout_lock, key);
 		return;
@@ -263,13 +263,13 @@ void sys_clock_announce(int32_t ticks)
 		int dt = t->dticks;
 
 		curr_tick += dt;
-		announce_remaining -= dt;
 		t->dticks = 0;
 		remove_timeout(t);
 
 		k_spin_unlock(&timeout_lock, key);
 		t->fn(t);
 		key = k_spin_lock(&timeout_lock);
+		announce_remaining -= dt;
 	}
 
 	if (first() != NULL) {


### PR DESCRIPTION
Fixes a race condition in sys_clock_announce() on SMP systems by
changing how we determine whether it is safe to enter the loop or
if the tick count should be just incremented.

We can not simply rely upon the global variable *announce_remaining*
being non-zero to make that determination as it is adjusted both
before the timeout callback function is invoked and before we leave
the loop. Instead, a new variable must be used dedicated for this
purpose.

Signed-off-by: Peter Mitsis <peter.mitsis@intel.com>