### PR TITLE
pm: policy: improve resolution and allow for multiple subscribers

### DIFF
--- a/include/zephyr/pm/policy.h
+++ b/include/zephyr/pm/policy.h
@@ -33,6 +33,13 @@ extern "C" {
  */
 typedef void (*pm_policy_latency_changed_cb_t)(int32_t latency);
 
+/** @brief Latency change subscription. */
+struct pm_policy_latency_subscription {
+	sys_snode_t node;
+	/** Notification callback. */
+	pm_policy_latency_changed_cb_t cb;
+};
+
 /** @brief Latency request. */
 struct pm_policy_latency_request {
 	sys_snode_t node;
@@ -135,11 +142,21 @@ void pm_policy_latency_request_update(struct pm_policy_latency_request *req,
 void pm_policy_latency_request_remove(struct pm_policy_latency_request *req);
 
 /**
- * @brief Set the callback to be called when maximum latency changes.
+ * @brief Subscribe to maximum latency changes.
  *
+ * @param req Subscription request.
  * @param cb Callback function (NULL to disable).
  */
-void pm_policy_latency_changed(pm_policy_latency_changed_cb_t cb);
+void pm_policy_latency_changed_subscribe(struct pm_policy_latency_subscription *req,
+					 pm_policy_latency_changed_cb_t cb);
+
+/**
+ * @brief Unsubscribe to maximum latency changes.
+ *
+ * @param req Subscription request.
+ */
+void pm_policy_latency_changed_unsubscribe(struct pm_policy_latency_subscription *req);
+
 #else
 static inline void pm_policy_state_lock_get(enum pm_state state, uint8_t substate_id)
 {

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -129,8 +129,8 @@ static void test_pm_policy_next_state_default_allowed(void)
 	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
 }
 
-/** Flag to indicate if latency callback has been called */
-static bool latency_cb_called;
+/** Flag to indicate number of times callback has been called */
+static uint8_t latency_cb_call_cnt;
 /** Flag to indicate expected latency */
 static int32_t expected_latency;
 
@@ -143,7 +143,7 @@ static void on_pm_policy_latency_changed(int32_t latency)
 
 	zassert_equal(latency, expected_latency, NULL);
 
-	latency_cb_called = true;
+	latency_cb_call_cnt++;
 }
 
 /**
@@ -153,6 +153,7 @@ static void on_pm_policy_latency_changed(int32_t latency)
 static void test_pm_policy_next_state_default_latency(void)
 {
 	struct pm_policy_latency_request req1, req2;
+	struct pm_policy_latency_subscription sreq1, sreq2;
 	const struct pm_state_info *next;
 
 	/* add a latency requirement with a maximum value below the
@@ -211,34 +212,37 @@ static void test_pm_policy_next_state_default_latency(void)
 	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
 
 	/* get notified when latency requirement changes */
-	pm_policy_latency_changed(on_pm_policy_latency_changed);
+	pm_policy_latency_changed_subscribe(&sreq1, on_pm_policy_latency_changed);
+	pm_policy_latency_changed_subscribe(&sreq2, on_pm_policy_latency_changed);
 
 	/* add new request (expected notification) */
-	latency_cb_called = false;
+	latency_cb_call_cnt = 0;
 	expected_latency = 10000;
 	pm_policy_latency_request_add(&req1, 10000);
-	zassert_true(latency_cb_called, NULL);
+	zassert_equal(latency_cb_call_cnt, 2, NULL);
 
-	/* update request (expected notification) */
-	latency_cb_called = false;
+	/* update request (expected notification, but only sreq1) */
+	pm_policy_latency_changed_unsubscribe(&sreq2);
+
+	latency_cb_call_cnt = 0;
 	expected_latency = 50000;
 	pm_policy_latency_request_update(&req1, 50000);
-	zassert_true(latency_cb_called, NULL);
+	zassert_equal(latency_cb_call_cnt, 1, NULL);
 
 	/* add a new request, with higher value (no notification, previous
 	 * prevails)
 	 */
-	latency_cb_called = false;
+	latency_cb_call_cnt = 0;
 	pm_policy_latency_request_add(&req2, 60000);
-	zassert_false(latency_cb_called, NULL);
+	zassert_equal(latency_cb_call_cnt, 0, NULL);
 
 	pm_policy_latency_request_remove(&req2);
-	zassert_false(latency_cb_called, NULL);
+	zassert_equal(latency_cb_call_cnt, 0, NULL);
 
 	/* remove first request, we no longer have latency requirements */
 	expected_latency = SYS_FOREVER_US;
 	pm_policy_latency_request_remove(&req1);
-	zassert_true(latency_cb_called, NULL);
+	zassert_equal(latency_cb_call_cnt, 1, NULL);
 }
 #else
 static void test_pm_policy_next_state_default(void)


### PR DESCRIPTION
```
When new latency requirements are introduced/updated, the microseconds
value gets converted down to ticks. Ticks usually have a coarse
resolution compared to the microseconds scale. This is fine for making
PM state change decisions, however, when getting notified about latency
changes, we may want to know the real value in microseconds, even if the
system rounds to ticks internally. This patch stores the value in both
us and ticks (in ticks to cache the conversion, really), so that the
user will get notified with precise latency values.
```
```
Current API allowed to get notified when the maximum system latency
changes, however, a single callback was allowed. The design was intended
for SoC specific actions when latency changes. However, in some cases
drivers may also want to know the current maximum latency to perform
local actions if other parts of the system modify it.

This patch updates the API with a pair of subscribe/unsubscribe calls to
achieve such goal. Tests have been updated to show how the API can be
used.
```