### PR TITLE
tests: dma: fix building issues on various platforms

### DIFF
--- a/tests/drivers/dma/chan_blen_transfer/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/chan_blen_transfer/boards/frdm_k64f.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2022 Kumar Gala <galak@kernel.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+test_dma: &edma0 { };

--- a/tests/drivers/dma/chan_blen_transfer/testcase.yaml
+++ b/tests/drivers/dma/chan_blen_transfer/testcase.yaml
@@ -3,3 +3,4 @@ tests:
     min_ram: 16
     depends_on: dma
     tags: drivers dma
+    filter: dt_nodelabel_enabled("test_dma")

--- a/tests/drivers/dma/loop_transfer/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/loop_transfer/boards/frdm_k64f.overlay
@@ -1,0 +1,7 @@
+/*
+ * Copyright (c) 2022 Kumar Gala <galak@kernel.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+test_dma: &edma0 { };

--- a/tests/drivers/dma/loop_transfer/testcase.yaml
+++ b/tests/drivers/dma/loop_transfer/testcase.yaml
@@ -2,3 +2,4 @@ tests:
   drivers.dma.loop_transfer:
     depends_on: dma
     tags: drivers dma
+    filter: dt_nodelabel_enabled("test_dma")

--- a/tests/drivers/dma/scatter_gather/boards/frdm_k64f.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/frdm_k64f.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Kumar Gala <galak@kernel.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		dma0 = &edma0;
+	};
+};

--- a/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk.overlay
+++ b/tests/drivers/dma/scatter_gather/boards/mimxrt1060_evk.overlay
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Kumar Gala <galak@kernel.org>
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	aliases {
+		dma0 = &edma0;
+	};
+};

--- a/tests/drivers/dma/scatter_gather/testcase.yaml
+++ b/tests/drivers/dma/scatter_gather/testcase.yaml
@@ -4,3 +4,4 @@ tests:
     tags: drivers dma
     platform_allow: intel_adsp_cavs25 intel_adsp_cavs20 intel_adsp_cavs18 intel_adsp_cavs15
      frdm_k64f mimxrt1060_evk
+    filter: dt_alias_exists("dma0")


### PR DESCRIPTION
When test was converted to use DEVICE_DT_GET we missed the
FRDM-K64F board.  Add missing overlay to get test to build.

Signed-off-by: Kumar Gala <galak@kernel.org>