### PR TITLE
drivers: sensor: max17055: fix TTE and TTF time units

### DIFF
--- a/drivers/sensor/max17055/max17055.c
+++ b/drivers/sensor/max17055/max17055.c
@@ -174,12 +174,12 @@ static int max17055_channel_get(const struct device *dev,
 		set_millis(valp, tmp);
 		break;
 	case SENSOR_CHAN_GAUGE_TIME_TO_EMPTY:
-		/* Get time in ms */
 		if (priv->time_to_empty == 0xffff) {
 			valp->val1 = 0;
 			valp->val2 = 0;
 		} else {
-			tmp = priv->time_to_empty * 5625;
+			/* Get time in milli-minutes */
+			tmp = priv->time_to_empty * 5625 / 60;
 			set_millis(valp, tmp);
 		}
 		break;
@@ -188,8 +188,8 @@ static int max17055_channel_get(const struct device *dev,
 			valp->val1 = 0;
 			valp->val2 = 0;
 		} else {
-			/* Get time in ms */
-			tmp = priv->time_to_full * 5625;
+			/* Get time in milli-minutes */
+			tmp = priv->time_to_full * 5625 / 60;
 			set_millis(valp, tmp);
 		}
 		break;

--- a/drivers/sensor/max17055/max17055.h
+++ b/drivers/sensor/max17055/max17055.h
@@ -55,9 +55,9 @@ struct max17055_data {
 	uint16_t full_cap;
 	/* Remaining capacity in 5/Rsense uA */
 	uint16_t remaining_cap;
-	/* Time to empty in seconds */
+	/* Time to empty in units of 5.625s */
 	uint16_t time_to_empty;
-	/* Time to full in seconds */
+	/* Time to full in units of 5.625s */
 	uint16_t time_to_full;
 	/* Cycle count in 1/100ths (number of charge/discharge cycles) */
 	uint16_t cycle_count;


### PR DESCRIPTION
Hi, this fixes the time units for the max17055 driver, https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/drivers/sensor.h#L167 says

```c
        /** Time to empty in minutes **/
        SENSOR_CHAN_GAUGE_TIME_TO_EMPTY,
        /** Time to full in minutes **/
        SENSOR_CHAN_GAUGE_TIME_TO_FULL,
```

...but the current code reports in seconds.

-- 8< --

The unit for SENSOR_CHAN_GAUGE_TIME_TO_EMPTY and
SENSOR_CHAN_GAUGE_TIME_TO_FULL are defined in
zephyr/drivers/sensor.h as being in minutes.

Change the max17055 implementation to match the API spec, fix the
annotation for time register units.

Link: https://datasheets.maximintegrated.com/en/ds/MAX17055.pdf