### PR TITLE
drivers: dai: intel: reduce log clutter in ssp_trigger

### DIFF
--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1796,7 +1796,7 @@ static int dai_ssp_trigger(const struct device *dev, enum dai_dir dir,
 	struct dai_intel_ssp_pdata *ssp = dai_get_drvdata(dp);
 	int array_index = SSP_ARRAY_INDEX(dir);
 
-	LOG_INF("%s cmd %d", __func__, cmd);
+	LOG_DBG("%s cmd %d", __func__, cmd);
 
 	switch (cmd) {
 	case DAI_TRIGGER_START:


### PR DESCRIPTION
With addition of DAI_TRIGGER_COPY, the trigger callback may
be called at a very high rate.

Reduce the logging level from INF to DBG for the logs in
dai_ssp_trigger().

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>