### PR TITLE
samples: flash_shell: Fix flash range printing

### DIFF
--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -103,7 +103,7 @@ static void dump_buffer(const struct shell *shell, uint8_t *buf, size_t size)
 	uint8_t *p = buf;
 
 	while (size >= 16) {
-		PR_SHELL(shell, "%02x %02x %02x %02x | %02x %02x %02x %02x |" \
+		PR_SHELL(shell, "%02x %02x %02x %02x | %02x %02x %02x %02x | "
 		       "%02x %02x %02x %02x | %02x %02x %02x %02x\n",
 		       p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7],
 			   p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15]);
@@ -111,13 +111,13 @@ static void dump_buffer(const struct shell *shell, uint8_t *buf, size_t size)
 		size -= 16;
 	}
 	if (size >= 8) {
-		PR_SHELL(shell, "%02x %02x %02x %02x | %02x %02x %02x %02x\n",
+		PR_SHELL(shell, "%02x %02x %02x %02x | %02x %02x %02x %02x | ",
 		       p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7]);
 		p += 8;
 		size -= 8;
 		newline = true;
 	}
-	if (size > 4) {
+	if (size >= 4) {
 		PR_SHELL(shell, "%02x %02x %02x %02x | ",
 		       p[0], p[1], p[2], p[3]);
 		p += 4;


### PR DESCRIPTION
When running a flash read command on the flash shell, the hexdump
prints came out incorrect. There was a space missing between the
ninth element and its preceding "|", and a redundant newline.
This commit fixes this issue.

Before:
```
uart:~$ flash read 0x40000 26
ff ff ff ff | ff ff ff ff |ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff
ff ff 
```

After:
```
uart:~$ flash read 0x40000 17
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff 
uart:~$ flash read 0x40000 18
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff 
uart:~$ flash read 0x40000 19
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff 
uart:~$ flash read 0x40000 20
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | 
uart:~$ flash read 0x40000 21
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff 
uart:~$ flash read 0x40000 22
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff 
uart:~$ flash read 0x40000 23
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff 
uart:~$ flash read 0x40000 24
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | 
uart:~$ flash read 0x40000 25
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff 
uart:~$ flash read 0x40000 26
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff ff 
uart:~$ flash read 0x40000 27
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff ff ff 
uart:~$ flash read 0x40000 28
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff ff ff ff | 
uart:~$ flash read 0x40000 29
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff 
uart:~$ flash read 0x40000 30
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff 
uart:~$ flash read 0x40000 31
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff 
uart:~$ flash read 0x40000 32
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff
ff ff ff ff | ff ff ff ff | ff ff ff ff | ff ff ff ff

```

Signed-off-by: Yonatan Schachter <yonatan.schachter@gmail.com>