### PR TITLE
net: coap: Remove resource pointer NULL check

### DIFF
--- a/subsys/net/lib/coap/coap_link_format.c
+++ b/subsys/net/lib/coap/coap_link_format.c
@@ -687,7 +687,7 @@ int coap_well_known_core_get(struct coap_resource *resource,
 			return r;
 		}
 
-		if ((resource + 1) && (resource + 1)->path) {
+		if ((resource + 1)->path) {
 			r = append_u8(response, (uint8_t) ',');
 			if (!r) {
 				return -ENOMEM;


### PR DESCRIPTION
This commit removes the resource pointer NULL check inside the resource
enumeration loop of the `coap_well_known_core_get` function because the
expression `(resource + 1)` will never evaluate to NULL (aka. 0).

This fixes the "comparison will always evaluate as ‘true’ for the
pointer operand" warning generated by the GCC 12.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

p.s. In general, this function does not seem very sane to me (e.g. doing NULL check on an incremented pointer, potentially dereferencing beyond the resource array bounds), but fixing this is beyond the scope of this PR.