### PR TITLE
ztest: fix the linker error when different suites use same func

### DIFF
--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -263,7 +263,7 @@ void ztest_test_pass(void);
 void ztest_test_skip(void);
 
 #define Z_TEST(suite, fn, t_options, use_fixture)                                                  \
-	struct ztest_unit_test_stats UTIL_CAT(z_ztest_unit_test_stats_, fn);      \
+	struct ztest_unit_test_stats z_ztest_unit_test_stats_##suite##_##fn;                       \
 	static void _##suite##_##fn##_wrapper(void *data);                                         \
 	static void suite##_##fn(                                                                  \
 		COND_CODE_1(use_fixture, (struct suite##_fixture *fixture), (void)));              \
@@ -272,7 +272,7 @@ void ztest_test_skip(void);
 		.name = STRINGIFY(fn),                                                             \
 		.test = (_##suite##_##fn##_wrapper),                                               \
 		.thread_options = t_options,                                                       \
-		.stats = &UTIL_CAT(z_ztest_unit_test_stats_, fn)                                  \
+		.stats = &z_ztest_unit_test_stats_##suite##_##fn                                   \
 	};                                                                                         \
 	static void _##suite##_##fn##_wrapper(void *data)                                          \
 	{                                                                                          \


### PR DESCRIPTION
Currently when declaring a unit test with ZTEST* macros, a stats
object is defined and associated with the unit test. This stats
object is named only after the test function. So if the same function
is used in different suites, the same stats object will be defined
multiple times, thus the duplicate symbol error. This can be avoided
by including the suite name in the stats object name because suite
name is guaranteed to be unique. And also, this can make sure test
function in different suites can have separate stats.

Signed-off-by: Ming Shao <ming.shao@intel.com>

Fix: #48480