### PR TITLE
Revert PR #48105

### DIFF
--- a/subsys/testsuite/include/zephyr/tc_util.h
+++ b/subsys/testsuite/include/zephyr/tc_util.h
@@ -121,35 +121,14 @@ static inline void test_time_ms(void)
 	} while (0)
 #endif
 
-static inline void print_nothing(const char *fmt, ...)
-{
-	ARG_UNUSED(fmt);
-}
-
 #ifndef TC_PRINT
-#if defined(CONFIG_ZTEST_VERBOSE_OUTPUT)
 #define TC_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
-#else
-#define TC_PRINT(fmt, ...) print_nothing(fmt, ##__VA_ARGS__)
-#endif
-#endif
-
-#ifndef TC_SUMMARY_PRINT
-#define TC_SUMMARY_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
-#endif
-
-#ifndef TC_START_PRINT
-#if defined(CONFIG_ZTEST_VERBOSE_OUTPUT)
-#define TC_START_PRINT(name) PRINT_DATA("START - %s\n", name);
-#else
-#define TC_START_PRINT(name)
-#endif
 #endif
 
 #ifndef TC_START
 #define TC_START(name)							\
 	do {								\
-		TC_START_PRINT(name);			\
+		PRINT_DATA("START - %s\n", name);			\
 		get_start_time_cyc();					\
 	} while (0)
 #endif
@@ -158,22 +137,15 @@ static inline void print_nothing(const char *fmt, ...)
 #define TC_END(result, fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
 #endif
 
-#ifndef TC_END_PRINT
-#if defined(CONFIG_ZTEST_VERBOSE_OUTPUT)
-#define TC_END_PRINT(result, fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__); PRINT_LINE
-#else
-#define TC_END_PRINT(result, fmt, ...)
-#endif
-#endif
-
-/* prints result and the function name */
 #ifndef Z_TC_END_RESULT
+/* prints result and the function name */
 #define Z_TC_END_RESULT(result, func)						\
 	do {									\
 		test_time_ms();							\
-		TC_END_PRINT(result, " %s - %s in %u.%u seconds\n",		\
+		TC_END(result, " %s - %s in %u.%u seconds\n",			\
 			TC_RESULT_TO_STR(result), func, tc_spend_time/1000,	\
 			tc_spend_time%1000);					\
+		PRINT_LINE;							\
 	} while (0)
 #endif
 
@@ -182,14 +154,10 @@ static inline void print_nothing(const char *fmt, ...)
 	Z_TC_END_RESULT((result), __func__)
 #endif
 
-#ifndef TC_SUITE_PRINT
-#define TC_SUITE_PRINT(fmt, ...) PRINT_DATA(fmt, ##__VA_ARGS__)
-#endif
-
 #ifndef TC_SUITE_START
 #define TC_SUITE_START(name)					\
 	do {							\
-		TC_SUITE_PRINT("Running TESTSUITE %s\n", name);	\
+		TC_PRINT("Running TESTSUITE %s\n", name);	\
 		PRINT_LINE;					\
 	} while (0)
 #endif
@@ -198,9 +166,9 @@ static inline void print_nothing(const char *fmt, ...)
 #define TC_SUITE_END(name, result)				\
 	do {								\
 		if (result != TC_FAIL) {				\
-			TC_SUITE_PRINT("TESTSUITE %s succeeded\n", name);	\
+			TC_PRINT("TESTSUITE %s succeeded\n", name);	\
 		} else {						\
-			TC_SUITE_PRINT("TESTSUITE %s failed.\n", name);	\
+			TC_PRINT("TESTSUITE %s failed.\n", name);	\
 		}							\
 	} while (0)
 #endif

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -122,20 +122,6 @@ config ZTEST_SHUFFLE_TEST_REPEAT_COUNT
 
 endif #ZTEST_SHUFFLE
 
-config ZTEST_VERBOSE_OUTPUT
-	bool "Verbose test output"
-	default y
-	help
-	  This option controls whether test output is shown verbosely or
-	  no output at all.
-
-config ZTEST_VERBOSE_SUMMARY
-	bool "Verbose test summary"
-	default y
-	help
-	  This option controls whether suite summary is shwon verbosely or
-	  just in one line.
-
 endif # ZTEST_NEW_API
 
 endif # ZTEST

--- a/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_test_new.h
@@ -32,9 +32,6 @@ struct ztest_unit_test {
 	const char *name;
 	void (*test)(void *data);
 	uint32_t thread_options;
-
-	/** Stats */
-	struct ztest_unit_test_stats *const stats;
 };
 
 extern struct ztest_unit_test _ztest_unit_test_list_start[];
@@ -51,17 +48,6 @@ struct ztest_suite_stats {
 	uint32_t skip_count;
 	/** The number of times that the suite failed */
 	uint32_t fail_count;
-};
-
-struct ztest_unit_test_stats {
-	/** The number of times that the test ran */
-	uint32_t run_count;
-	/** The number of times that the test was skipped */
-	uint32_t skip_count;
-	/** The number of times that the test failed */
-	uint32_t fail_count;
-	/** The number of times that the test passed */
-	uint32_t pass_count;
 };
 
 /**
@@ -147,7 +133,7 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
  * @param teardown_fn The function to call after running all the tests in this suite
  */
 #define ZTEST_SUITE(SUITE_NAME, PREDICATE, setup_fn, before_fn, after_fn, teardown_fn)             \
-	struct ztest_suite_stats UTIL_CAT(z_ztest_suite_node_stats_, SUITE_NAME);                  \
+	struct ztest_suite_stats UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME);                   \
 	static const STRUCT_SECTION_ITERABLE(ztest_suite_node,                                     \
 					     UTIL_CAT(z_ztest_test_node_, SUITE_NAME)) = {         \
 		.name = STRINGIFY(SUITE_NAME),                                                     \
@@ -156,7 +142,7 @@ extern struct ztest_suite_node _ztest_suite_node_list_end[];
 		.after = (after_fn),                                                               \
 		.teardown = (teardown_fn),                                                         \
 		.predicate = PREDICATE,                                                            \
-		.stats = &UTIL_CAT(z_ztest_suite_node_stats_, SUITE_NAME),             \
+		.stats = &UTIL_CAT(z_ztest_test_node_stats_, SUITE_NAME),                          \
 	}
 /**
  * Default entry point for running or listing registered unit tests.
@@ -263,7 +249,6 @@ void ztest_test_pass(void);
 void ztest_test_skip(void);
 
 #define Z_TEST(suite, fn, t_options, use_fixture)                                                  \
-	struct ztest_unit_test_stats UTIL_CAT(z_ztest_unit_test_stats_, fn);      \
 	static void _##suite##_##fn##_wrapper(void *data);                                         \
 	static void suite##_##fn(                                                                  \
 		COND_CODE_1(use_fixture, (struct suite##_fixture *fixture), (void)));              \
@@ -272,7 +257,6 @@ void ztest_test_skip(void);
 		.name = STRINGIFY(fn),                                                             \
 		.test = (_##suite##_##fn##_wrapper),                                               \
 		.thread_options = t_options,                                                       \
-		.stats = &UTIL_CAT(z_ztest_unit_test_stats_, fn)                                  \
 	};                                                                                         \
 	static void _##suite##_##fn##_wrapper(void *data)                                          \
 	{                                                                                          \

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -458,9 +458,8 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 		ret |= cleanup_test(test);
 	}
 
-	if (test_result == ZTEST_RESULT_SKIP || test_result == ZTEST_RESULT_SUITE_SKIP) {
+	if (test_result == ZTEST_RESULT_SKIP) {
 		Z_TC_END_RESULT(TC_SKIP, test->name);
-		ret = TC_SKIP;
 	} else {
 		Z_TC_END_RESULT(ret, test->name);
 	}
@@ -518,7 +517,6 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 	struct ztest_unit_test *test = NULL;
 	void *data = NULL;
 	int fail = 0;
-	int tc_result = TC_PASS;
 
 	if (test_status < 0) {
 		return test_status;
@@ -554,16 +552,7 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 				continue;
 			}
 			if (ztest_api.should_test_run(suite->name, test->name)) {
-				test->stats->run_count++;
-				tc_result = run_test(suite, test, data);
-				if (tc_result == TC_PASS) {
-					test->stats->pass_count++;
-				} else if (tc_result == TC_SKIP) {
-					test->stats->skip_count++;
-				} else if (tc_result == TC_FAIL) {
-					test->stats->fail_count++;
-				}
-				if (tc_result == TC_FAIL) {
+				if (run_test(suite, test, data) == TC_FAIL) {
 					fail++;
 				}
 			}
@@ -575,17 +564,7 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 #else
 		while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
 			if (ztest_api.should_test_run(suite->name, test->name)) {
-				test->stats->run_count++;
-				tc_result = run_test(suite, test, data);
-				if (tc_result == TC_PASS) {
-					test->stats->pass_count++;
-				} else if (tc_result == TC_SKIP) {
-					test->stats->skip_count++;
-				} else if (tc_result == TC_FAIL) {
-					test->stats->fail_count++;
-				}
-
-				if (tc_result == TC_FAIL) {
+				if (run_test(suite, test, data) == TC_FAIL) {
 					fail++;
 				}
 			}
@@ -626,102 +605,10 @@ void end_report(void)
 K_APPMEM_PARTITION_DEFINE(ztest_mem_partition);
 #endif
 
-static void __ztest_init_unit_test_result_for_suite(struct ztest_suite_node *suite)
-{
-	struct ztest_unit_test *test = NULL;
-
-	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
-		test->stats->run_count = 0;
-		test->stats->skip_count = 0;
-		test->stats->fail_count = 0;
-		test->stats->pass_count = 0;
-	}
-}
-
-/* Show one line summary for a test suite.
- */
-static void __ztest_show_suite_summary_oneline(struct ztest_suite_node *suite)
-{
-	int distinct_pass = 0, distinct_fail = 0, distinct_skip = 0, distinct_total = 0;
-	int passrate = 0, passrate1 = 0, passrate2 = 0;
-	int suite_result = TC_PASS;
-
-	struct ztest_unit_test *test = NULL;
-
-	/** summary of disctinct run  */
-	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
-		distinct_total++;
-		if (test->stats->skip_count == test->stats->run_count) {
-			distinct_skip++;
-		} else if (test->stats->pass_count == test->stats->run_count) {
-			distinct_pass++;
-		} else {
-			distinct_fail++;
-		}
-	}
-
-	if (distinct_skip == distinct_total) {
-		suite_result = TC_SKIP;
-		passrate1 = passrate2 = 0;
-	} else {
-		suite_result = (distinct_fail > 0) ? TC_FAIL : TC_PASS;
-		passrate = distinct_pass * 100;
-		passrate1 = passrate / (distinct_total - distinct_skip);
-		passrate2 = (passrate - passrate1 * (distinct_total - distinct_skip)) / 100;
-	}
-
-	TC_SUMMARY_PRINT("%s - %3d.%02d%% [%s]: pass = %d, fail = %d, "
-				"skip = %d, total = %d\n",
-				TC_RESULT_TO_STR(suite_result),
-				passrate1, passrate2,
-				suite->name, distinct_pass, distinct_fail,
-				distinct_skip, distinct_total);
-}
-
-#ifdef CONFIG_ZTEST_VERBOSE_SUMMARY
-static void __ztest_show_suite_summary_verbose(struct ztest_suite_node *suite)
-{
-	struct ztest_unit_test *test = NULL;
-	int tc_result = TC_PASS;
-
-	__ztest_show_suite_summary_oneline(suite);
-
-	while (((test = z_ztest_get_next_test(suite->name, test)) != NULL)) {
-		if (test->stats->skip_count == test->stats->run_count) {
-			tc_result = TC_SKIP;
-		} else if (test->stats->pass_count == test->stats->run_count) {
-			tc_result = TC_PASS;
-		} else {
-			tc_result = TC_FAIL;
-		}
-
-		TC_SUMMARY_PRINT(" - %s - [%s.%s]\n", TC_RESULT_TO_STR(tc_result),
-				 test->test_suite_name, test->name);
-	}
-	TC_SUMMARY_PRINT("\n");
-}
-#endif
-
-static void __ztest_show_suite_summary(void)
-{
-	TC_SUMMARY_PRINT("\n------ TESTSUITE SUMMARY ------\n");
-	for (struct ztest_suite_node *ptr = _ztest_suite_node_list_start;
-	     ptr < _ztest_suite_node_list_end; ++ptr) {
-
-#ifdef CONFIG_ZTEST_VERBOSE_SUMMARY
-		__ztest_show_suite_summary_verbose(ptr);
-#else
-		__ztest_show_suite_summary_oneline(ptr);
-#endif
-	}
-}
-
 static int __ztest_run_test_suite(struct ztest_suite_node *ptr, const void *state)
 {
 	struct ztest_suite_stats *stats = ptr->stats;
 	int count = 0;
-
-	__ztest_init_unit_test_result_for_suite(ptr);
 
 	for (int i = 0; i < NUM_ITER_PER_SUITE; i++) {
 		if (ztest_api.should_suite_run(state, ptr)) {
@@ -758,8 +645,6 @@ int z_impl_ztest_run_test_suites(const void *state)
 	}
 #endif
 
-	__ztest_show_suite_summary();
-
 	return count;
 }
 
@@ -787,14 +672,6 @@ void ztest_verify_all_test_suites_ran(void)
 
 	if (!all_tests_run) {
 		test_status = 1;
-	}
-
-	for (test = _ztest_unit_test_list_start; test < _ztest_unit_test_list_end; ++test) {
-		if (test->stats->fail_count + test->stats->pass_count + test->stats->skip_count !=
-		    test->stats->run_count) {
-			PRINT("Bad stats for %s.%s\n", test->test_suite_name, test->name);
-			test_status = 1;
-		}
 	}
 }
 


### PR DESCRIPTION
This reverts the commits merged as part of the PR #48105, which broke multiple tests in the CI.

See https://github.com/zephyrproject-rtos/zephyr/pull/48105#pullrequestreview-1055942751

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48469
Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48480