### PR TITLE
usb_dc_stm32: fix init on soft reset

### DIFF
--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -453,6 +453,16 @@ static int usb_dc_stm32_init(void)
 		return -EIO;
 	}
 
+	/* On a soft reset force USB to reset first and switch it off
+	 * so the USB connection can get re-initialized
+	 */
+	LOG_DBG("HAL_PCD_Stop");
+	status = HAL_PCD_Stop(&usb_dc_stm32_state.pcd);
+	if (status != HAL_OK) {
+		LOG_ERR("PCD_Stop failed, %d", (int)status);
+		return -EIO;
+	}
+
 	LOG_DBG("HAL_PCD_Start");
 	status = HAL_PCD_Start(&usb_dc_stm32_state.pcd);
 	if (status != HAL_OK) {


### PR DESCRIPTION
Soft resetting a STM32 device currently does not reset the USB
connection, which causes a few problems: The endpoints do not respond
anymore, and within zephyr any kind of status information like
CDC_SET_CONTROL_LINE_STATE is also missing as they are not
re-negotiated.

This is fixed by stopping the USB device from zephyr side, right after
initialising the USB device.

Tested on a custom board (Olimexino STM32F3 - looking forward to PR this as well):

```
cd samples/subsys/usb/cdc_acm
west build -p auto -b olimexino_stm32f303rc .
arm-none-eabi-gdb build/zephyr/zephyr.elf
(gdb) load
(gdb) mon reset
```

The cdc_acm sample application could be tested in another window:
```
# is necessary in my case to set the DTR:
stty -F /dev/ttyACM1 -hupcl
screen /dev/ttyACM1 921600 8N1
<typed stuff gets echoed here correctly>
```

The logger output with `CONFIG_USB_CDC_ACM_LOG_LEVEL_DBG=y` and `CONFIG_USB_DRIVER_LOG_LEVEL_DBG=y` is attached.
[usb_reset.log](https://github.com/zephyrproject-rtos/zephyr/files/9225986/usb_reset.log)

Signed-off-by: David Jablonski <dayjaby@gmail.com>