### PR TITLE
boards: arm: Add Olimexino STM32F303RC board

### DIFF
--- a/boards/arm/olimexino_stm32f303rc/Kconfig.board
+++ b/boards/arm/olimexino_stm32f303rc/Kconfig.board
@@ -1,0 +1,8 @@
+# Olimexino STM32F303RC board configuration
+
+# Copyright (c) 2022 David Jablonski
+# SPDX-License-Identifier: Apache-2.0
+
+config BOARD_OLIMEXINO_STM32F303RC
+	bool "Olimexino STM32F303RC Development Board"
+	depends on SOC_STM32F303XC

--- a/boards/arm/olimexino_stm32f303rc/Kconfig.defconfig
+++ b/boards/arm/olimexino_stm32f303rc/Kconfig.defconfig
@@ -1,0 +1,11 @@
+# Olimexino STM32F303RC board configuration
+
+# Copyright (c) 2022 David Jablonski
+# SPDX-License-Identifier: Apache-2.0
+
+if BOARD_OLIMEXINO_STM32F303RC
+
+config BOARD
+	default "olimexino_stm32f303rc"
+
+endif # BOARD_OLIMEXINO_STM32F303RC

--- a/boards/arm/olimexino_stm32f303rc/board.cmake
+++ b/boards/arm/olimexino_stm32f303rc/board.cmake
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(openocd "--config=${BOARD_DIR}/support/openocd.cfg")
+board_runner_args(jlink "--device=STM32F303RC" "--speed=4000")
+
+include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/arm/olimexino_stm32f303rc/doc/index.rst
+++ b/boards/arm/olimexino_stm32f303rc/doc/index.rst
@@ -1,0 +1,126 @@
+.. _olimexino_stm32f303rc_board:
+
+Olimexino STM32F303RC
+################
+
+Overview
+********
+
+The Olimexino STM32F303RC board features an ARM Cortex-M4 based STM32F303RC
+mixed-signal MCU with FPU and DSP instructions capable of running at 72 MHz.
+Here are some highlights of the Olimexino STM32F303RC board:
+
+- STM32 microcontroller in LQFP64 package
+- LSE crystal: 32.768 kHz crystal oscillator
+- Flexible board power supply:
+
+  - 5 V from USB VBUS
+  - External power sources: 9 - 30 V
+
+- Two user LED
+- Two push-buttons: BOOT/USER and RESET
+- SIT1050T CAN transceiver
+- UEXT connector
+- SWD (2x5 1.27mm) connector
+- Arduino* Uno V3 connectors
+
+More information about the board can be found at the `Olimexino STM32F303RC website`_.
+Hardware
+********
+
+The Olimexino STM32F303RC provides the following hardware components:
+
+- STM32F303RCT6 in QFP64 package
+- ARM |reg| 32-bit Cortex |reg| -M4 CPU with FPU
+- 72 MHz max CPU frequency
+- VDD from 2.0 V to 3.6 V
+- 256 KB Flash
+- 40 KB SRAM
+- Routine booster: 8 Kbytes of SRAM on instruction and data bus
+- GPIO with external interrupt capability
+- 4x12-bit ADC with 39 channels
+- 2x12-bit D/A converters
+- RTC
+- General Purpose Timers (13)
+- USART/UART (5)
+- I2C (2)
+- SPI (3)
+- CAN
+- USB 2.0 full speed interface
+- Infrared transmitter
+- DMA Controller
+
+More information about the STM32F303RC can be found here:
+
+- `STM32F303RC on www.st.com`_
+- `STM32F303RC reference manual`_
+- `STM32F303RC datasheet`_
+
+Supported Features
+==================
+
+The default configuration can be found in the defconfig file:
+``boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc_defconfig``
+
+Connections and IOs
+===================
+
+The Olimexino STM32F303RC Board has 6 GPIO controllers. These controllers are
+responsible for pin muxing, input/output, pull-up, etc.
+
+Default Zephyr Peripheral Mapping:
+----------------------------------
+
+- UART_1_TX : PC4
+- UART_1_RX : PC5
+- UART_2_TX : PA2
+- UART_2_RX : PA3
+- UART_3_TX : PB10
+- UART_3_RX : PB11
+- I2C1_SCL : PB6
+- I2C1_SDA : PB7
+- I2C2_SCL : PF1
+- I2C2_SDA : PF0
+- SPI1_NSS : PA4
+- SPI1_SCK : PA5
+- SPI1_MISO : PA6
+- SPI1_MOSI : PA7
+- SPI2_NSS : PB12
+- SPI2_SCK : PB13
+- SPI2_MISO : PB14
+- SPI2_MOSI : PB15
+- CAN1_RX : PB8
+- CAN1_TX : PB9
+- USB_DM : PA11
+- USB_DP : PA12
+- USB_DP_PULLUP: PC12
+- LD1 : PA1
+- LD2 : PA5
+- PWM : PA8
+
+System Clock
+------------
+
+The STM32F303RC System Clock can be driven by an internal or
+external oscillator, as well as by the main PLL clock. By default the
+System Clock is driven by the PLL clock at 72 MHz. The input to the
+PLL is an 8 MHz external clock supplied by the processor of the
+on-board ST-LINK/V2-1 debugger/programmer.
+
+Serial Port
+-----------
+
+The Olimexino STM32F303RC board has 3 UARTs. The Zephyr console output is assigned
+to UART2. Default settings are 115200 8N1.
+
+.. _Olimexino STM32F303RC website:
+   https://www.olimex.com/Products/Duino/STM32/OLIMEXINO-STM32F3/open-source-hardware
+
+.. _STM32F303RC on www.st.com:
+   http://www.st.com/en/microcontrollers/stm32f303rc.html
+
+.. _STM32F303RC reference manual:
+   https://www.st.com/resource/en/reference_manual/dm00043574.pdf
+
+.. _STM32F303RC datasheet:
+   http://www.st.com/resource/en/datasheet/stm32f303rc.pdf

--- a/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.dts
+++ b/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.dts
@@ -1,0 +1,207 @@
+/*
+ * Copyright (c) 2022 David Jablonski
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+#include <st/f3/stm32f303Xc.dtsi>
+#include <st/f3/stm32f303r(b-c)tx-pinctrl.dtsi>
+
+/ {
+	model = "Olimex OLIMEXINO-STM32F303RC board";
+	compatible = "olimex,olimexino_stm32f303rc", "st,stm32f303rc";
+
+	chosen {
+		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,canbus = &can1;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+		green_led_1: led_1 {
+			gpios = <&gpioa 5 GPIO_ACTIVE_HIGH>;
+			label = "Green LED";
+		};
+		yellow_led_2: led_2 {
+			gpios = <&gpioa 1 GPIO_ACTIVE_HIGH>;
+			label = "Yellow LED";
+		};
+	};
+
+	gpio_keys {
+		compatible = "gpio-keys";
+		user_button: button {
+			label = "Boot/User";
+			gpios = <&gpioc 9 GPIO_ACTIVE_LOW>;
+		};
+	};
+
+	aliases {
+		led0 = &green_led_1;
+		led1 = &yellow_led_2;
+		sw0 = &user_button;
+		sdhc0 = &sdhc0;
+		watchdog0 = &iwdg;
+	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(8)>;
+	status = "okay";
+};
+
+&pll {
+	prediv = <1>;
+	mul = <9>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(72)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <2>;
+	apb2-prescaler = <1>;
+};
+
+uext_i2c: &i2c2 {};
+uext_spi: &spi1 {};
+uext_serial: &usart3 {};
+
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pc4 &usart1_rx_pc5>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart2 {
+	pinctrl-0 = <&usart2_tx_pa2 &usart2_rx_pa3>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&usart3 {
+	pinctrl-0 = <&usart3_tx_pb10 &usart3_rx_pb11>;
+	pinctrl-names = "default";
+	current-speed = <115200>;
+	status = "okay";
+};
+
+&i2c1 {
+	pinctrl-0 = <&i2c1_scl_pb6 &i2c1_sda_pb7>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&i2c2 {
+	pinctrl-0 = <&i2c2_scl_pf1 &i2c2_sda_pf0>;
+	pinctrl-names = "default";
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+};
+
+&spi1 {
+	pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5
+			  &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&spi2 {
+	pinctrl-0 = <&spi2_nss_pb12 &spi2_sck_pb13
+			  &spi2_miso_pb14 &spi2_mosi_pb15>;
+	pinctrl-names = "default";
+	status = "okay";
+	cs-gpios = <&gpiod 2 GPIO_ACTIVE_HIGH>;
+
+	sdhc0: sdhc@0 {
+		compatible = "zephyr,sdhc-spi-slot";
+		reg = <0>;
+		status = "okay";
+		spi-max-frequency = <24000000>;
+		mmc {
+			compatible = "zephyr,sdmmc-disk";
+			status = "okay";
+		};
+	};
+};
+
+zephyr_udc0: &usb {
+	pinctrl-0 = <&usb_dm_pa11 &usb_dp_pa12>;
+	pinctrl-names = "default";
+	status = "okay";
+	disconnect-gpios = <&gpioc 12 GPIO_ACTIVE_LOW>;
+	num-bidir-endpoints = <3>;
+	num-in-endpoints = <1>;
+	num-out-endpoints = <1>;
+
+	cdc_acm_uart0 {
+		compatible = "zephyr,cdc-acm-uart";
+		status = "okay";
+	};
+};
+
+&timers1 {
+	st,prescaler = <10000>;
+	status = "okay";
+
+	pwm1: pwm {
+		status = "okay";
+		pinctrl-0 = <&tim1_ch1_pa8>;
+		pinctrl-names = "default";
+	};
+};
+
+&iwdg {
+	status = "okay";
+};
+
+&can1 {
+	pinctrl-0 = <&can_rx_pb8 &can_tx_pb9>;
+	pinctrl-names = "default";
+	bus-speed = <1000000>;
+	// phys = <&transceiver0>;
+	status = "okay";
+};
+
+&flash0 {
+
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+
+		boot_partition: partition@0 {
+			label = "mcuboot";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+			read-only;
+		};
+
+		/* Set 6Kb of storage at the end of the 256Kb of flash */
+		storage_partition: partition@3e800 {
+			label = "storage";
+			reg = <0x0003e800 DT_SIZE_K(6)>;
+		};
+		slot0_partition: partition@30000 {
+			label = "image-0";
+			reg = <0x00030000 DT_SIZE_K(58)>;
+		};
+		slot1_partition: partition@20000 {
+			label = "image-1";
+			reg = <0x00020000 DT_SIZE_K(64)>;
+		};
+		scratch_partition: partition@18000 {
+			label = "image-scratch";
+			reg = <0x00018000 DT_SIZE_K(32)>;
+		};
+	};
+};
+

--- a/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.yaml
+++ b/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc.yaml
@@ -1,0 +1,19 @@
+identifier: olimexino_stm32f303rc
+name: Olimexino STM32F303RC
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmemb
+  - xtools
+ram: 40
+flash: 256
+supported:
+  - gpio
+  - i2c
+  - pwm
+  - sdhc
+  - spi
+  - usb_device
+  - watchdog
+  - can

--- a/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc_defconfig
+++ b/boards/arm/olimexino_stm32f303rc/olimexino_stm32f303rc_defconfig
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_SOC_SERIES_STM32F3X=y
+CONFIG_SOC_STM32F303XC=y
+
+CONFIG_SERIAL=y
+
+# Enable MPU
+CONFIG_ARM_MPU=y
+
+# Enable HW stack protection
+# CONFIG_HW_STACK_PROTECTION=y
+
+# console
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+
+# enable pinmux
+CONFIG_PINMUX=y
+
+# enable GPIO
+CONFIG_GPIO=y
+
+# Enable Clocks
+CONFIG_CLOCK_CONTROL=y
+
+# enable pin controller
+CONFIG_PINCTRL=y

--- a/boards/arm/olimexino_stm32f303rc/support/openocd.cfg
+++ b/boards/arm/olimexino_stm32f303rc/support/openocd.cfg
@@ -1,0 +1,2 @@
+source [find interface/stlink-v2-1.cfg]
+source [find target/stm32f3x.cfg]


### PR DESCRIPTION
Add Olimexino STM32F303RC board device tree and configuration files.

Tested features on this board are UART, USB CDC ACM and CAN communication between two boards.

How to build/use:
```
cd samples/subsys/usb/cdc_acm
west build -p auto -b olimexino_stm32f303rc .
west flash
```

Signed-off-by: David Jablonski <dayjaby@gmail.com>