### PR TITLE
bme680: Rework setting the spi_mem_page accordingly to the datasheet

### DIFF
--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -372,10 +372,14 @@ static int bme680_init(const struct device *dev)
 
 #if BME680_BUS_SPI
 	if (bme680_is_on_spi(dev)) {
-		err = bme680_reg_read(dev, BME680_REG_MEM_PAGE, &data->mem_page, 1);
+		uint8_t mem_page;
+
+		err = bme680_reg_read(dev, BME680_REG_STATUS, &mem_page, 1);
 		if (err < 0) {
 			return err;
 		}
+
+		data->mem_page = (mem_page & BME680_SPI_MEM_PAGE_MSK) >> BME680_SPI_MEM_PAGE_POS;
 	}
 #endif
 

--- a/drivers/sensor/bme680/bme680.h
+++ b/drivers/sensor/bme680/bme680.h
@@ -74,7 +74,7 @@ struct bme680_config {
 #define BME680_REG_CTRL_HUM             0x72
 #define BME680_REG_CTRL_MEAS            0x74
 #define BME680_REG_CONFIG               0x75
-#define BME680_REG_MEM_PAGE             0x73
+#define BME680_REG_STATUS               0x73
 #define BME680_REG_UNIQUE_ID            0x83
 #define BME680_REG_COEFF1               0x8a
 #define BME680_REG_COEFF2               0xe1
@@ -87,11 +87,10 @@ struct bme680_config {
 #define BME680_MSK_RANGE_SW_ERR         0xf0
 #define BME680_MSK_HEATR_STAB           0x10
 
-#define BME680_SPI_READ_BIT		0x80
-#define BME680_SPI_WRITE_MSK		0x7f
-
-#define BME680_MEM_PAGE1		0x00
-#define BME680_MEM_PAGE0		0x10
+#define BME680_SPI_MEM_PAGE_MSK         0x10
+#define BME680_SPI_MEM_PAGE_POS         4
+#define BME680_SPI_READ_BIT             0x80
+#define BME680_SPI_WRITE_MSK            0x7f
 
 #if defined CONFIG_BME680_TEMP_OVER_1X
 #define BME680_TEMP_OVER                (1 << 5)

--- a/drivers/sensor/bme680/bme680_spi.c
+++ b/drivers/sensor/bme680/bme680_spi.c
@@ -27,30 +27,52 @@ static inline int bme680_set_mem_page(const struct device *dev, uint8_t addr)
 {
 	const struct bme680_config *config = dev->config;
 	struct bme680_data *data = dev->data;
-	uint8_t page;
+	uint8_t page = (addr > 0x7f) ? 0U : 1U;
 	int err = 0;
 
-	if (addr > 0x7f) {
-		page = BME680_MEM_PAGE1;
-	} else {
-		page = BME680_MEM_PAGE0;
-	}
-
 	if (data->mem_page != page) {
+		uint8_t buf[2];
 
-		data->mem_page = page;
-		uint8_t cmd[] = { BME680_REG_MEM_PAGE & BME680_SPI_WRITE_MSK, data->mem_page };
-		const struct spi_buf tx_buf = {
-			.buf = cmd,
-			.len = sizeof(cmd)
+		struct spi_buf tx_buf = {
+			.buf = &buf[0],
+			.len = 1,
 		};
 		const struct spi_buf_set tx = {
 			.buffers = &tx_buf,
-			.count = 1
+			.count = 1,
 		};
 
+		const struct spi_buf rx_buf[] = {
+			{ .buf = NULL, .len = 1 },
+			{ .buf = &buf[1], .len = 1 },
+		};
+		const struct spi_buf_set rx = {
+			.buffers = rx_buf,
+			.count = ARRAY_SIZE(rx_buf),
+		};
+
+		buf[0] = BME680_REG_STATUS | BME680_SPI_READ_BIT;
+		err = spi_transceive_dt(&config->bus.spi, &tx, &rx);
+		if (err < 0) {
+			return err;
+		}
+
+		if (data->mem_page == 1U) {
+			buf[1] &= ~BME680_SPI_MEM_PAGE_MSK;
+		} else {
+			buf[1] |= BME680_SPI_MEM_PAGE_MSK;
+		}
+
+		buf[0] = BME680_REG_STATUS & BME680_SPI_WRITE_MSK;
+		tx_buf.len = 2;
 		err = spi_write_dt(&config->bus.spi, &tx);
+		if (err < 0) {
+			return err;
+		}
+
+		data->mem_page = page;
 	}
+
 	return err;
 }
 


### PR DESCRIPTION
According to the BME680 datasheet, only the spi_mem_page bit can be
changed in its 8-bit register. Therefore we shouldn't just write 0s
to the remaining bits, but update the register content in read-modify-write
fashion instead.
Rework the bme680_set_mem_page(), bme680_init() and register-access
macros.

Signed-off-by: Jan Kuliga <jtkuliga@gmail.com>