### PR TITLE
Bluetooth: Test `bt_uuid_to_str`

### DIFF
--- a/tests/bluetooth/uuid/src/test_bt_uuid_cmp.c
+++ b/tests/bluetooth/uuid/src/test_bt_uuid_cmp.c
@@ -1,0 +1,38 @@
+/* Copyright (c) 2019 Intel Corporation
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdint.h>
+#include <zephyr/ztest.h>
+#include <zephyr/bluetooth/uuid.h>
+
+static struct bt_uuid_16 uuid_16 = BT_UUID_INIT_16(0xffff);
+
+static struct bt_uuid_128 uuid_128 = BT_UUID_INIT_128(
+	0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80,
+	0x00, 0x10, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00);
+
+ZTEST_SUITE(bt_uuid_cmp, NULL, NULL, NULL, NULL, NULL);
+
+ZTEST(bt_uuid_cmp, test_uuid_cmp)
+{
+	/* Compare UUID 16 bits */
+	zassert_false(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0xffff)),
+		     "Test UUIDs don't match");
+
+	/* Compare UUID 128 bits */
+	zassert_false(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0xffff)),
+		     "Test UUIDs don't match");
+
+	/* Compare UUID 16 bits with UUID 128 bits */
+	zassert_false(bt_uuid_cmp(&uuid_16.uuid, &uuid_128.uuid),
+		     "Test UUIDs don't match");
+
+	/* Compare different UUID 16 bits */
+	zassert_true(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0x0000)),
+		     "Test UUIDs match");
+
+	/* Compare different UUID 128 bits */
+	zassert_true(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0x000)),
+		     "Test UUIDs match");
+}

--- a/tests/bluetooth/uuid/src/test_bt_uuid_create.c
+++ b/tests/bluetooth/uuid/src/test_bt_uuid_create.c
@@ -1,53 +1,18 @@
-/* main.c - Application main entry point */
-
-/*
- * Copyright (c) 2019 Intel Corporation
- *
+/* Copyright (c) 2019 Intel Corporation
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/zephyr.h>
-#include <stddef.h>
-#include <ztest.h>
-
+#include <stdint.h>
+#include <zephyr/ztest.h>
 #include <zephyr/bluetooth/uuid.h>
-
-static struct bt_uuid_16 uuid_16 = BT_UUID_INIT_16(0xffff);
-
-static struct bt_uuid_128 uuid_128 = BT_UUID_INIT_128(
-	0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80,
-	0x00, 0x10, 0x00, 0x00, 0xff, 0xff, 0x00, 0x00);
 
 static struct bt_uuid_128 le_128 = BT_UUID_INIT_128(
 	0xfb, 0x34, 0x9b, 0x5f, 0x80, 0x00, 0x00, 0x80,
 	0x00, 0x10, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00);
 
-ZTEST_SUITE(uuid_tests, NULL, NULL, NULL, NULL, NULL);
+ZTEST_SUITE(bt_uuid_create, NULL, NULL, NULL, NULL, NULL);
 
-ZTEST(uuid_tests, test_uuid_cmp)
-{
-	/* Compare UUID 16 bits */
-	zassert_false(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0xffff)),
-		     "Test UUIDs don't match");
-
-	/* Compare UUID 128 bits */
-	zassert_false(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0xffff)),
-		     "Test UUIDs don't match");
-
-	/* Compare UUID 16 bits with UUID 128 bits */
-	zassert_false(bt_uuid_cmp(&uuid_16.uuid, &uuid_128.uuid),
-		     "Test UUIDs don't match");
-
-	/* Compare different UUID 16 bits */
-	zassert_true(bt_uuid_cmp(&uuid_16.uuid, BT_UUID_DECLARE_16(0x0000)),
-		     "Test UUIDs match");
-
-	/* Compare different UUID 128 bits */
-	zassert_true(bt_uuid_cmp(&uuid_128.uuid, BT_UUID_DECLARE_16(0x000)),
-		     "Test UUIDs match");
-}
-
-ZTEST(uuid_tests, test_uuid_create)
+ZTEST(bt_uuid_create, test_uuid_create)
 {
 	uint8_t le16[] = { 0x01, 0x00 };
 	uint8_t be16[] = { 0x00, 0x01 };

--- a/tests/bluetooth/uuid/src/test_bt_uuid_to_str.c
+++ b/tests/bluetooth/uuid/src/test_bt_uuid_to_str.c
@@ -1,0 +1,93 @@
+/* Copyright (c) 2022 Nordic Semiconductor ASA
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stdbool.h>
+#include <string.h>
+
+#include <zephyr/ztest.h>
+
+#include <zephyr/bluetooth/uuid.h>
+
+ZTEST_SUITE(bt_uuid_to_str, NULL, NULL, NULL, NULL, NULL);
+
+static bool is_null_terminated(char *str, size_t size)
+{
+	return strnlen(str, size) < size;
+}
+
+static void result_is_null_terminated(const struct bt_uuid *uuid)
+{
+	char str[BT_UUID_STR_LEN];
+
+	memset(str, 1, sizeof(str));
+	bt_uuid_to_str(uuid, str, sizeof(str));
+	zassert_true(is_null_terminated(str, sizeof(str)), "Result is not null-terminated.");
+}
+
+static void result_str_is(const struct bt_uuid *uuid, const char *expected_str)
+{
+	char str[BT_UUID_STR_LEN] = {};
+
+	bt_uuid_to_str(uuid, str, sizeof(str));
+	zassume_true(is_null_terminated(str, sizeof(str)), "Result is not a string.");
+	zassert_true((strcmp(str, expected_str) == 0),
+		     "Unexpected result.\n   Found: %s\nExpected: %s", str, expected_str);
+}
+
+ZTEST(bt_uuid_to_str, test_null_terminated_type_16)
+{
+	result_is_null_terminated(BT_UUID_DECLARE_16(0));
+}
+
+ZTEST(bt_uuid_to_str, test_null_terminated_type_32)
+{
+	result_is_null_terminated(BT_UUID_DECLARE_32(0));
+}
+
+ZTEST(bt_uuid_to_str, test_null_terminated_type_128)
+{
+	result_is_null_terminated(BT_UUID_DECLARE_128(BT_UUID_128_ENCODE(0l, 0, 0, 0, 0ll)));
+}
+
+ZTEST(bt_uuid_to_str, test_padding_type_16)
+{
+	result_str_is(BT_UUID_DECLARE_16(0), "0000");
+}
+
+ZTEST(bt_uuid_to_str, test_padding_type_32)
+{
+	result_str_is(BT_UUID_DECLARE_32(0), "00000000");
+}
+
+ZTEST(bt_uuid_to_str, test_padding_type_128)
+{
+	result_str_is(BT_UUID_DECLARE_128(BT_UUID_128_ENCODE(0l, 0, 0, 0, 0ll)),
+		      "00000000-0000-0000-0000-000000000000");
+}
+
+ZTEST(bt_uuid_to_str, test_ordering_type_16)
+{
+	result_str_is(BT_UUID_DECLARE_16(0xabcd), "abcd");
+}
+
+
+ZTEST(bt_uuid_to_str, test_ordering_type_32)
+{
+	result_str_is(BT_UUID_DECLARE_32(0xabcdef12), "abcdef12");
+}
+
+ZTEST(bt_uuid_to_str, test_ordering_type_128)
+{
+	result_str_is(BT_UUID_DECLARE_128(BT_UUID_128_ENCODE(
+		0xabcdef12, 0x3456, 0x9999, 0x9999, 0x999999999999)),
+		"abcdef12-3456-9999-9999-999999999999");
+
+	result_str_is(BT_UUID_DECLARE_128(BT_UUID_128_ENCODE(
+		0x99999999, 0x9999, 0xabcd, 0xef12, 0x999999999999)),
+		"99999999-9999-abcd-ef12-999999999999");
+
+	result_str_is(BT_UUID_DECLARE_128(BT_UUID_128_ENCODE(
+		0x99999999, 0x9999, 0x9999, 0x9999, 0xabcdef123456)),
+		"99999999-9999-9999-9999-abcdef123456");
+}


### PR DESCRIPTION
Add missing unit tests for `bt_uuid_to_str`.

Signed-off-by: Aleksander Wasaznik <aleksander.wasaznik@nordicsemi.no>