### PR TITLE
segger: Resolve circular include dependencies

### DIFF
--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -9,6 +9,8 @@
 
 #define DT_DRV_COMPAT segger_rtt_uart
 
+extern struct k_mutex rtt_term_mutex;
+
 struct uart_rtt_config {
 	void *up_buffer;
 	size_t up_size;

--- a/modules/segger/SEGGER_RTT_zephyr.c
+++ b/modules/segger/SEGGER_RTT_zephyr.c
@@ -5,6 +5,7 @@
  */
 
 #include <zephyr/kernel.h>
+#include <zephyr/irq.h>
 #include <zephyr/init.h>
 #include "SEGGER_RTT.h"
 
@@ -29,5 +30,31 @@ static int rtt_init(const struct device *unused)
 
 	return 0;
 }
+
+#ifdef CONFIG_MULTITHREADING
+
+void zephyr_rtt_mutex_lock(void)
+{
+	k_mutex_lock(&rtt_term_mutex, K_FOREVER);
+}
+
+void zephyr_rtt_mutex_unlock(void)
+{
+	k_mutex_unlock(&rtt_term_mutex);
+}
+
+#endif /* CONFIG_MULTITHREADING */
+
+unsigned int zephyr_rtt_irq_lock(void)
+{
+	return irq_lock();
+}
+
+void zephyr_rtt_irq_unlock(unsigned int key)
+{
+	irq_unlock(key);
+}
+
+
 
 SYS_INIT(rtt_init, PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_OBJECTS);

--- a/modules/segger/SEGGER_SYSVIEW_Conf.h
+++ b/modules/segger/SEGGER_SYSVIEW_Conf.h
@@ -8,7 +8,6 @@
 #define SEGGER_SEGGER_SYSVIEW_CONF_H_
 
 #include <stdint.h>
-#include <zephyr/irq.h>
 
 #define SEGGER_SYSVIEW_GET_TIMESTAMP sysview_get_timestamp
 #define SEGGER_SYSVIEW_GET_INTERRUPT_ID sysview_get_interrupt
@@ -23,13 +22,16 @@ uint32_t sysview_get_interrupt(void);
 #define SEGGER_SYSVIEW_SECTION	".dtcm_data"
 #endif
 
+extern unsigned int zephyr_rtt_irq_lock(void);
+extern void zephyr_rtt_irq_unlock(unsigned int key);
+
 /* Lock SystemView (nestable) */
 #define SEGGER_SYSVIEW_LOCK()	{					       \
 					unsigned int __sysview_irq_key =       \
-						irq_lock()
+						zephyr_rtt_irq_lock()
 
 /* Unlock SystemView (nestable) */
-#define SEGGER_SYSVIEW_UNLOCK()		irq_unlock(__sysview_irq_key);         \
+#define SEGGER_SYSVIEW_UNLOCK()		zephyr_rtt_irq_unlock(__sysview_irq_key);         \
 				}
 
 #endif  /* SEGGER_SEGGER_SYSVIEW_CONF_H_ */

--- a/west.yml
+++ b/west.yml
@@ -200,7 +200,7 @@ manifest:
       path: modules/lib/picolibc
       revision: e87b2fc37345a62361478f0a6efd140e14180ba5
     - name: segger
-      revision: 3a52ab222133193802d3c3b4d21730b9b1f1d2f6
+      revision: d4e568a920b4bd087886170a5624c167b2d0665e
       path: modules/debug/segger
       groups:
         - debug


### PR DESCRIPTION
CONFIG_SEGGER_SYSTEMVIEW=y does not compile for Cortex-M targets anymore. This is caused by circular include dependencies with the SEGGER module.

Zephyr kernel is dependend on trace.
Trace is dependend on segger rtt.
Segger rtt MUST NOT be dependend on zephyr kernel.

Move lock functions from header into c file to avoid circular
dependency.

Fixes #43887.

This fix needs an update of the segger repository (see zephyrproject-rtos/segger#13), west.yml has to be updated after this.


