### PR TITLE
soc: stm32: Remove direct COUNTER_RTC_STM32 to COUNTER dependency

### DIFF
--- a/soc/arm/st_stm32/common/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/common/Kconfig.defconfig.series
@@ -41,10 +41,6 @@ config USB_DC_STM32
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config COUNTER_RTC_STM32
-	default y
-	depends on COUNTER
-
 if DMA
 
 config DMA_STM32


### PR DESCRIPTION
COUNTER_RTC_STM32 used to be enabled directly based on COUNTER status.
This should not be the case anymore as we should first check
DT_HAS_ST_STM32_RTC_ENABLED status (which is already done in
drivers/counter/Kconfig.stm32_rtc).

Remove these 3 lines that are not correct anymore.

Fixes following build issues:
- 2022-07-31 12:44:15,667 - twister - ERROR - nucleo_l476rg             tests/drivers/counter/counter_basic_api/drivers.counter.basic_api FAILED: Build failure
- 2022-07-31 12:46:02,804 - twister - ERROR - stm32f4_disco          tests/drivers/counter/counter_basic_api/drivers.counter.basic_api FAILED: Build failure
- 2022-07-31 12:46:03,072 - twister - ERROR - nucleo_l433rc_p           tests/drivers/counter/counter_basic_api/drivers.counter.basic_api FAILED: Build failure
