### PR TITLE
tests: kernel: exception: Disable infinite recursion warning

### DIFF
--- a/tests/kernel/fatal/exception/src/main.c
+++ b/tests/kernel/fatal/exception/src/main.c
@@ -181,10 +181,21 @@ __no_optimization void blow_up_stack(void)
 #else
 /* stack sentinel doesn't catch it in time before it trashes the entire kernel
  */
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Winfinite-recursion"
+#endif
+
 __no_optimization int stack_smasher(int val)
 {
 	return stack_smasher(val * 2) + stack_smasher(val * 3);
 }
+
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
 
 void blow_up_stack(void)
 {


### PR DESCRIPTION
This commit disables the infinite recursion warning
(`-Winfinite-recursion`), which may be reported by the GCC 12 and
above, for the `stack_smasher` function because that is the intended
behaviour.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>