### PR TITLE
soc: openisa_rv32m1: Update target architecture for GCC 12

### DIFF
--- a/soc/riscv/openisa_rv32m1/CMakeLists.txt
+++ b/soc/riscv/openisa_rv32m1/CMakeLists.txt
@@ -4,12 +4,12 @@
 
 if(CONFIG_SOC_OPENISA_RV32M1_RI5CY)
   if (CONFIG_RISCV_GENERIC_TOOLCHAIN)
-    zephyr_compile_options(-march=rv32imc)
+    zephyr_compile_options(-march=rv32imc_zicsr_zifencei)
   else()
     zephyr_compile_options(-march=rv32imcxpulpv2)
   endif()
 elseif(CONFIG_SOC_OPENISA_RV32M1_ZERO_RISCY)
-  zephyr_compile_options(-march=rv32imc)
+  zephyr_compile_options(-march=rv32imc_zicsr_zifencei)
 endif()
 
 zephyr_sources(


### PR DESCRIPTION
This commit updates the custom target architecture type specified for
the `SOC_OPENISA_RV32M1_RI5CY` and `SOC_OPENISA_RV32M1_ZERO_RISCY` SoC
types to be compatible with the GCC 12, which now uses the ISA spec
20191213 by default.

Note that the hack overriding the build system-default `-march` flag
for these SoCs needs to be removed and they should be properly
specified using the ISA extension Kconfigs.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

**NOTE: To be merged after Zephyr SDK 0.15.0 is mainlined.**