### PR TITLE
shell: Fix combo use of mandatory and optional raw arguments

### DIFF
--- a/tests/subsys/shell/shell/src/main.c
+++ b/tests/subsys/shell/shell/src/main.c
@@ -344,12 +344,12 @@ ZTEST(shell, test_shell_fprintf)
 }
 
 #define RAW_ARG "aaa \"\" bbb"
-#define CMD_NAME test_cmd_raw_arg
+#define CMD_MAND_1_OPT_RAW_NAME cmd_mand_1_opt_raw
 
-static int cmd_raw_arg(const struct shell *shell, size_t argc, char **argv)
+static int cmd_mand_1_opt_raw_handler(const struct shell *sh, size_t argc, char **argv)
 {
 	if (argc == 2) {
-		if (strcmp(argv[0], STRINGIFY(CMD_NAME))) {
+		if (strcmp(argv[0], STRINGIFY(CMD_MAND_1_OPT_RAW_NAME))) {
 			return -1;
 		}
 		if (strcmp(argv[1], RAW_ARG)) {
@@ -362,14 +362,53 @@ static int cmd_raw_arg(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 
-SHELL_CMD_ARG_REGISTER(CMD_NAME, NULL, NULL, cmd_raw_arg, 1, SHELL_OPT_ARG_RAW);
+SHELL_CMD_ARG_REGISTER(CMD_MAND_1_OPT_RAW_NAME, NULL, NULL, cmd_mand_1_opt_raw_handler, 1,
+		       SHELL_OPT_ARG_RAW);
 
-ZTEST(shell, test_raw_arg)
+ZTEST(shell, test_cmd_mand_1_opt_raw)
 {
-	test_shell_execute_cmd("test_cmd_raw_arg aaa \"\" bbb", 0);
-	test_shell_execute_cmd("test_cmd_raw_arg", 0);
-	test_shell_execute_cmd("select test_cmd_raw_arg", 0);
+	test_shell_execute_cmd("cmd_mand_1_opt_raw aaa \"\" bbb", 0);
+	test_shell_execute_cmd("cmd_mand_1_opt_raw", 0);
+	test_shell_execute_cmd("select cmd_mand_1_opt_raw", 0);
 	test_shell_execute_cmd("aaa \"\" bbb", 0);
+	shell_set_root_cmd(NULL);
+}
+
+#define CMD_MAND_2_OPT_RAW_NAME cmd_mand_2_opt_raw
+
+static int cmd_mand_2_opt_raw_handler(const struct shell *sh, size_t argc, char **argv)
+{
+	if (argc < 2 || argc > 3) {
+		return -1;
+	}
+
+	if (strcmp(argv[0], STRINGIFY(CMD_MAND_2_OPT_RAW_NAME))) {
+		return -1;
+	}
+
+	if (argc >= 2 && strcmp(argv[1], "mandatory")) {
+		return -1;
+	}
+
+	if (argc == 3 && strcmp(argv[2], RAW_ARG)) {
+		return -1;
+	}
+
+	return 0;
+}
+
+SHELL_CMD_ARG_REGISTER(CMD_MAND_2_OPT_RAW_NAME, NULL, NULL, cmd_mand_2_opt_raw_handler, 2,
+		       SHELL_OPT_ARG_RAW);
+
+ZTEST(shell, test_mand_2_opt_raw)
+{
+	test_shell_execute_cmd("cmd_mand_2_opt_raw", -EINVAL);
+	test_shell_execute_cmd("cmd_mand_2_opt_raw mandatory", 0);
+	test_shell_execute_cmd("cmd_mand_2_opt_raw mandatory aaa \"\" bbb", 0);
+	test_shell_execute_cmd("select cmd_mand_2_opt_raw", 0);
+	test_shell_execute_cmd("", -ENOEXEC);
+	test_shell_execute_cmd("mandatory", 0);
+	test_shell_execute_cmd("mandatory aaa \"\" bbb", 0);
 	shell_set_root_cmd(NULL);
 }
 


### PR DESCRIPTION
Fixes issue seen when using 1+ mandatory arguments with an optional argument using `SHELL_OPT_ARG_RAW`. Also adds tests to catch future issues.

Fixes #48380 