### PR TITLE
drivers/modem helper libraries refactoring

### DIFF
--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -177,8 +177,7 @@ static void gsm_rx(struct gsm_modem *gsm)
 		modem_iface_uart_rx_wait(&gsm->context.iface, K_FOREVER);
 
 		/* The handler will listen AT channel */
-		gsm->context.cmd_handler.process(&gsm->context.cmd_handler,
-						 &gsm->context.iface);
+		modem_cmd_handler_process(&gsm->context.cmd_handler, &gsm->context.iface);
 	}
 }
 
@@ -1273,19 +1272,24 @@ static int gsm_init(const struct device *dev)
 	(void)k_mutex_init(&gsm->lock);
 	gsm->dev = dev;
 
-	gsm->cmd_handler_data.cmds[CMD_RESP] = response_cmds;
-	gsm->cmd_handler_data.cmds_len[CMD_RESP] = ARRAY_SIZE(response_cmds);
-	gsm->cmd_handler_data.match_buf = &gsm->cmd_match_buf[0];
-	gsm->cmd_handler_data.match_buf_len = sizeof(gsm->cmd_match_buf);
-	gsm->cmd_handler_data.buf_pool = &gsm_recv_pool;
-	gsm->cmd_handler_data.alloc_timeout = K_NO_WAIT;
-	gsm->cmd_handler_data.eol = "\r";
+	const struct modem_cmd_handler_config cmd_handler_config = {
+		.match_buf = &gsm->cmd_match_buf[0],
+		.match_buf_len = sizeof(gsm->cmd_match_buf),
+		.buf_pool = &gsm_recv_pool,
+		.alloc_timeout = K_NO_WAIT,
+		.eol = "\r",
+		.user_data = NULL,
+		.response_cmds = response_cmds,
+		.response_cmds_len = ARRAY_SIZE(response_cmds),
+		.unsol_cmds = NULL,
+		.unsol_cmds_len = 0,
+	};
 
 	(void)k_sem_init(&gsm->sem_response, 0, 1);
 	(void)k_sem_init(&gsm->sem_if_down, 0, 1);
 
-	ret = modem_cmd_handler_init(&gsm->context.cmd_handler,
-				   &gsm->cmd_handler_data);
+	ret = modem_cmd_handler_init(&gsm->context.cmd_handler, &gsm->cmd_handler_data,
+				     &cmd_handler_config);
 	if (ret < 0) {
 		LOG_DBG("cmd handler error %d", ret);
 		return ret;

--- a/drivers/modem/modem_iface_uart.h
+++ b/drivers/modem/modem_iface_uart.h
@@ -23,10 +23,6 @@ struct modem_iface_uart_data {
 	/* HW flow control */
 	bool hw_flow_control;
 
-	/* ring buffer char buffer */
-	char *rx_rb_buf;
-	size_t rx_rb_buf_len;
-
 	/* ring buffer */
 	struct ring_buf rx_rb;
 
@@ -55,17 +51,48 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
 			      const struct device *dev);
 
 /**
- * @brief  Init modem interface for UART
+ * @brief Modem uart interface configuration
  *
- * @param  *iface: modem interface to initialize.
- * @param  *data: modem interface data to use
- * @param  *dev_name: name of the UART device to use
- *
- * @retval 0 if ok, < 0 if error.
+ * @param rx_rb_buf Buffer used for internal ring buffer
+ * @param rx_rb_buf_len Size of buffer used for internal ring buffer
+ * @param dev UART device used for interface
+ * @param hw_flow_control Set if hardware flow control is used
  */
-int modem_iface_uart_init(struct modem_iface *iface,
-			  struct modem_iface_uart_data *data,
-			  const struct device *dev);
+struct modem_iface_uart_config {
+	char *rx_rb_buf;
+	size_t rx_rb_buf_len;
+	const struct device *dev;
+	bool hw_flow_control;
+};
+
+/**
+ * @brief Initialize modem interface for UART
+ *
+ * @param iface Interface structure to initialize
+ * @param data UART data structure used by the modem interface
+ * @param config UART configuration structure used to configure UART data structure
+ *
+ * @return -EINVAL if any argument is invalid
+ * @return 0 if successful
+ */
+int modem_iface_uart_init(struct modem_iface *iface, struct modem_iface_uart_data *data,
+			  const struct modem_iface_uart_config *config);
+
+/**
+ * @brief Wait for rx data ready from uart interface
+ *
+ * @param iface Interface to wait on
+ *
+ * @return 0 if data is ready
+ * @return -EBUSY if returned without waiting
+ * @return -EAGAIN if timeout occurred
+ */
+static inline int modem_iface_uart_rx_wait(struct modem_iface *iface, k_timeout_t timeout)
+{
+	struct modem_iface_uart_data *data = (struct modem_iface_uart_data *)iface->iface_data;
+
+	return k_sem_take(&data->rx_sem, timeout);
+}
 
 #ifdef __cplusplus
 }

--- a/drivers/modem/modem_iface_uart_async.c
+++ b/drivers/modem/modem_iface_uart_async.c
@@ -148,13 +148,12 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
 	return rc;
 }
 
-int modem_iface_uart_init(struct modem_iface *iface,
-			  struct modem_iface_uart_data *data,
-			  const struct device *dev)
+int modem_iface_uart_init(struct modem_iface *iface, struct modem_iface_uart_data *data,
+			  const struct modem_iface_uart_config *config)
 {
 	int ret;
 
-	if (!iface || !data) {
+	if (iface == NULL || data == NULL || config == NULL) {
 		return -EINVAL;
 	}
 
@@ -162,12 +161,15 @@ int modem_iface_uart_init(struct modem_iface *iface,
 	iface->read = modem_iface_uart_async_read;
 	iface->write = modem_iface_uart_async_write;
 
-	ring_buf_init(&data->rx_rb, data->rx_rb_buf_len, data->rx_rb_buf);
+	ring_buf_init(&data->rx_rb, config->rx_rb_buf_len, config->rx_rb_buf);
 	k_sem_init(&data->rx_sem, 0, 1);
 	k_sem_init(&data->tx_sem, 0, 1);
 
-	/* get UART device */
-	ret = modem_iface_uart_init_dev(iface, dev);
+	/* Configure hardware flow control */
+	data->hw_flow_control = config->hw_flow_control;
+
+	/* Get UART device */
+	ret = modem_iface_uart_init_dev(iface, config->dev);
 	if (ret < 0) {
 		iface->iface_data = NULL;
 		iface->read = NULL;

--- a/drivers/modem/modem_iface_uart_interrupt.c
+++ b/drivers/modem/modem_iface_uart_interrupt.c
@@ -198,13 +198,12 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
 	return 0;
 }
 
-int modem_iface_uart_init(struct modem_iface *iface,
-			  struct modem_iface_uart_data *data,
-			  const struct device *dev)
+int modem_iface_uart_init(struct modem_iface *iface, struct modem_iface_uart_data *data,
+			  const struct modem_iface_uart_config *config)
 {
 	int ret;
 
-	if (!iface || !data) {
+	if (iface == NULL || data == NULL || config == NULL) {
 		return -EINVAL;
 	}
 
@@ -212,11 +211,14 @@ int modem_iface_uart_init(struct modem_iface *iface,
 	iface->read = modem_iface_uart_read;
 	iface->write = modem_iface_uart_write;
 
-	ring_buf_init(&data->rx_rb, data->rx_rb_buf_len, data->rx_rb_buf);
+	ring_buf_init(&data->rx_rb, config->rx_rb_buf_len, config->rx_rb_buf);
 	k_sem_init(&data->rx_sem, 0, 1);
 
-	/* get UART device */
-	ret = modem_iface_uart_init_dev(iface, dev);
+	/* Configure hardware flow control */
+	data->hw_flow_control = config->hw_flow_control;
+
+	/* Get UART device */
+	ret = modem_iface_uart_init_dev(iface, config->dev);
 	if (ret < 0) {
 		iface->iface_data = NULL;
 		iface->read = NULL;

--- a/drivers/modem/modem_socket.h
+++ b/drivers/modem/modem_socket.h
@@ -58,7 +58,11 @@ struct modem_socket_config {
 	size_t sockets_len;
 
 	/* beginning socket id (modems can set this to 0 or 1 as needed) */
-	int base_socket_num;
+	int base_socket_id;
+
+	/* dynamically assign id when modem socket is allocated */
+	bool assign_id;
+
 	struct k_sem sem_lock;
 
 	const struct socket_op_vtable *vtable;
@@ -82,7 +86,72 @@ int modem_socket_poll_prepare(struct modem_socket_config *cfg, struct modem_sock
 			      struct k_poll_event *pev_end);
 void modem_socket_wait_data(struct modem_socket_config *cfg, struct modem_socket *sock);
 void modem_socket_data_ready(struct modem_socket_config *cfg, struct modem_socket *sock);
-int modem_socket_init(struct modem_socket_config *cfg, const struct socket_op_vtable *vtable);
+
+/**
+ * @brief Initialize modem socket config struct and associated modem sockets
+ *
+ * @param cfg The config to initialize
+ * @param sockets The array of sockets associated with the modem socket config
+ * @param sockets_len The length of the array of sockets associated with the modem socket config
+ * @param base_socket_id The lowest socket id supported by the modem
+ * @param assign_id Dynamically assign modem socket id when allocated using modem_socket_get()
+ * @param vtable Socket API implementation used by this config and associated sockets
+ *
+ * @return -EINVAL if any argument is invalid
+ * @return 0 if successful
+ */
+int modem_socket_init(struct modem_socket_config *cfg, struct modem_socket *sockets,
+		      size_t sockets_len, int base_socket_id, bool assign_id,
+		      const struct socket_op_vtable *vtable);
+
+/**
+ * @brief Check if modem socket has been allocated
+ *
+ * @details A modem socket is allocated after a successful invocation of modem_socket_get, and
+ * released after a successful invocation of modem_socket_put.
+ *
+ * @note If socket id is automatically assigned, the socket id will be a value between
+ * base_socket_id and (base_socket_id + socket_len).
+ * Otherwise, the socket id will be assigned to (base_socket_id + socket_len) when allocated.
+ *
+ * @param cfg The modem socket config which the modem socket belongs to
+ * @param sock The modem socket which is checked
+ *
+ * @return true if the socket has been allocated
+ * @return false if the socket has not been allocated
+ */
+bool modem_socket_is_allocated(const struct modem_socket_config *cfg,
+			       const struct modem_socket *sock);
+
+/**
+ * @brief Check if modem socket id has been assigned
+ *
+ * @note An assigned modem socket will have an id between base_socket_id and
+ * (base_socket_id + socket_len).
+ *
+ * @param cfg The modem socket config which the modem socket belongs to
+ * @param sock The modem socket for which the id is checked
+ *
+ * @return true if the socket id is been assigned
+ * @return false if the socket has not been assigned
+ */
+bool modem_socket_id_is_assigned(const struct modem_socket_config *cfg,
+				 const struct modem_socket *sock);
+
+/**
+ * @brief Assign id to modem socket
+ *
+ * @param cfg The modem socket config which the modem socket belongs to
+ * @param sock The modem socket for which the id will be assigned
+ * @param id The id to assign to the modem socket
+ *
+ * @return -EPERM if id has been assigned previously
+ * @return -EINVAL if id is invalid
+ * @return 0 if successful
+ */
+int modem_socket_id_assign(const struct modem_socket_config *cfg,
+			   struct modem_socket *sock,
+			   int id);
 
 #ifdef __cplusplus
 }

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -197,7 +197,7 @@ static void socket_close(struct modem_socket *sock)
 	char buf[sizeof("AT+QICLOSE=##")] = {0};
 	int  ret;
 
-	snprintk(buf, sizeof(buf), "AT+QICLOSE=%d", sock->sock_fd);
+	snprintk(buf, sizeof(buf), "AT+QICLOSE=%d", sock->id);
 
 	/* Tell the modem to close the socket. */
 	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
@@ -452,7 +452,7 @@ static ssize_t send_socket_data(struct modem_socket *sock,
 
 	/* Create a buffer with the correct params. */
 	mdata.sock_written = buf_len;
-	snprintk(send_buf, sizeof(send_buf), "AT+QISEND=%d,%ld", sock->sock_fd, (long) buf_len);
+	snprintk(send_buf, sizeof(send_buf), "AT+QISEND=%d,%ld", sock->id, (long) buf_len);
 
 	/* Setup the locks correctly. */
 	k_sem_take(&mdata.cmd_handler_data.sem_tx_lock, K_FOREVER);
@@ -594,7 +594,7 @@ static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
 		return -1;
 	}
 
-	snprintk(sendbuf, sizeof(sendbuf), "AT+QIRD=%d,%zd", sock->sock_fd, len);
+	snprintk(sendbuf, sizeof(sendbuf), "AT+QIRD=%d,%zd", sock->id, len);
 
 	/* Socket read settings */
 	(void) memset(&sock_data, 0, sizeof(sock_data));
@@ -604,7 +604,7 @@ static ssize_t offload_recvfrom(void *obj, void *buf, size_t len,
 	sock->data	       = &sock_data;
 	mdata.sock_fd	       = sock->sock_fd;
 
-	/* Tell the modem to give us data (AT+QIRD=sock_fd,data_len). */
+	/* Tell the modem to give us data (AT+QIRD=id,data_len). */
 	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
 			     data_cmd, ARRAY_SIZE(data_cmd), sendbuf, &mdata.sem_response,
 			     MDM_CMD_TIMEOUT);
@@ -695,7 +695,8 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 	int		    ret;
 	char		    ip_str[NET_IPV6_ADDR_LEN];
 
-	if (sock->id < mdata.socket_config.base_socket_num - 1) {
+	/* Verify socket has been allocated */
+	if (modem_socket_is_allocated(&mdata.socket_config, sock) == false) {
 		LOG_ERR("Invalid socket_id(%d) from fd:%d",
 			sock->id, sock->sock_fd);
 		errno = EINVAL;
@@ -734,8 +735,8 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 	}
 
 	/* Formulate the complete string. */
-	snprintk(buf, sizeof(buf), "AT+QIOPEN=%d,%d,\"%s\",\"%s\",%d,0,0", 1, sock->sock_fd, protocol,
-		ip_str, dst_port);
+	snprintk(buf, sizeof(buf), "AT+QIOPEN=%d,%d,\"%s\",\"%s\",%d,0,0", 1, sock->id, protocol,
+		 ip_str, dst_port);
 
 	/* Send out the command. */
 	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler,
@@ -792,8 +793,8 @@ static int offload_close(void *obj)
 {
 	struct modem_socket *sock = (struct modem_socket *) obj;
 
-	/* Make sure we assigned an id */
-	if (sock->id < mdata.socket_config.base_socket_num) {
+	/* Make sure socket is allocated */
+	if (modem_socket_is_allocated(&mdata.socket_config, sock) == false) {
 		return 0;
 	}
 
@@ -1145,10 +1146,8 @@ static int modem_init(const struct device *dev)
 			   K_PRIO_COOP(7), NULL);
 
 	/* socket config */
-	mdata.socket_config.sockets	    = &mdata.sockets[0];
-	mdata.socket_config.sockets_len	    = ARRAY_SIZE(mdata.sockets);
-	mdata.socket_config.base_socket_num = MDM_BASE_SOCKET_NUM;
-	ret = modem_socket_init(&mdata.socket_config, &offload_socket_fd_op_vtable);
+	ret = modem_socket_init(&mdata.socket_config, &mdata.sockets[0], ARRAY_SIZE(mdata.sockets),
+				MDM_BASE_SOCKET_NUM, true, &offload_socket_fd_op_vtable);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/quectel-bg9x.c
+++ b/drivers/modem/quectel-bg9x.c
@@ -848,7 +848,7 @@ static void modem_rx(void)
 	while (true) {
 
 		/* Wait for incoming data */
-		k_sem_take(&mdata.iface_data.rx_sem, K_FOREVER);
+		modem_iface_uart_rx_wait(&mctx.iface, K_FOREVER);
 
 		mctx.cmd_handler.process(&mctx.cmd_handler, &mctx.iface);
 	}
@@ -1169,10 +1169,14 @@ static int modem_init(const struct device *dev)
 	}
 
 	/* modem interface */
-	mdata.iface_data.rx_rb_buf     = &mdata.iface_rb_buf[0];
-	mdata.iface_data.rx_rb_buf_len = sizeof(mdata.iface_rb_buf);
-	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data,
-				    MDM_UART_DEV);
+	const struct modem_iface_uart_config uart_config = {
+		.rx_rb_buf = &mdata.iface_rb_buf[0],
+		.rx_rb_buf_len = sizeof(mdata.iface_rb_buf),
+		.dev = MDM_UART_DEV,
+		.hw_flow_control = DT_PROP(MDM_UART_NODE, hw_flow_control),
+	};
+
+	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data, &uart_config);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/quectel-bg9x.h
+++ b/drivers/modem/quectel-bg9x.h
@@ -23,7 +23,8 @@
 #include "modem_cmd_handler.h"
 #include "modem_iface_uart.h"
 
-#define MDM_UART_DEV			  DEVICE_DT_GET(DT_INST_BUS(0))
+#define MDM_UART_NODE			  DT_INST_BUS(0)
+#define MDM_UART_DEV			  DEVICE_DT_GET(MDM_UART_NODE)
 #define MDM_CMD_TIMEOUT			  K_SECONDS(10)
 #define MDM_CMD_CONN_TIMEOUT		  K_SECONDS(120)
 #define MDM_REGISTRATION_TIMEOUT	  K_SECONDS(180)

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -143,7 +143,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr, socklen_t add
 		return -EAGAIN;
 	}
 
-	if (sock->id < mdata.socket_config.base_socket_num - 1) {
+	if (modem_socket_is_allocated(&mdata.socket_config, sock) == false) {
 		LOG_ERR("Invalid socket id %d from fd %d", sock->id, sock->sock_fd);
 		errno = EINVAL;
 		return -1;
@@ -172,7 +172,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr, socklen_t add
 		return -1;
 	}
 
-	ret = snprintk(buf, sizeof(buf), "AT+CAOPEN=%d,%d,\"%s\",\"%s\",%d", 0, sock->sock_fd,
+	ret = snprintk(buf, sizeof(buf), "AT+CAOPEN=%d,%d,\"%s\",\"%s\",%d", 0, sock->id,
 		       protocol, ip_str, dst_port);
 	if (ret < 0) {
 		LOG_ERR("Failed to build connect command. ID: %d, FD: %d", sock->id, sock->sock_fd);
@@ -244,7 +244,7 @@ static ssize_t offload_sendto(void *obj, const void *buf, size_t len, int flags,
 		len = MDM_MAX_DATA_LENGTH;
 	}
 
-	ret = snprintk(send_buf, sizeof(send_buf), "AT+CASEND=%d,%ld", sock->sock_fd, (long)len);
+	ret = snprintk(send_buf, sizeof(send_buf), "AT+CASEND=%d,%ld", sock->id, (long)len);
 	if (ret < 0) {
 		LOG_ERR("Failed to build send command!!");
 		errno = ENOMEM;
@@ -409,7 +409,7 @@ static ssize_t offload_recvfrom(void *obj, void *buf, size_t max_len, int flags,
 	}
 
 	max_len = (max_len > MDM_MAX_DATA_LENGTH) ? MDM_MAX_DATA_LENGTH : max_len;
-	snprintk(sendbuf, sizeof(sendbuf), "AT+CARECV=%d,%zd", sock->sock_fd, max_len);
+	snprintk(sendbuf, sizeof(sendbuf), "AT+CARECV=%d,%zd", sock->id, max_len);
 
 	memset(&sock_data, 0, sizeof(sock_data));
 	sock_data.recv_buf = buf;
@@ -501,7 +501,7 @@ static void socket_close(struct modem_socket *sock)
 	char buf[sizeof("AT+CACLOSE=##")];
 	int ret;
 
-	snprintk(buf, sizeof(buf), "AT+CACLOSE=%d", sock->sock_fd);
+	snprintk(buf, sizeof(buf), "AT+CACLOSE=%d", sock->id);
 
 	ret = modem_cmd_send(&mctx.iface, &mctx.cmd_handler, NULL, 0U, buf, &mdata.sem_response,
 			     MDM_CMD_TIMEOUT);
@@ -541,8 +541,8 @@ static int offload_close(void *obj)
 		return -EAGAIN;
 	}
 
-	/* Make sure we assigned an id */
-	if (sock->id < mdata.socket_config.base_socket_num) {
+	/* Make sure socket is allocated */
+	if (modem_socket_is_allocated(&mdata.socket_config, sock) == false) {
 		return 0;
 	}
 
@@ -2337,10 +2337,8 @@ static int modem_init(const struct device *dev)
 	mdata.sms_buffer_pos = 0;
 
 	/* Socket config. */
-	mdata.socket_config.sockets = &mdata.sockets[0];
-	mdata.socket_config.sockets_len = ARRAY_SIZE(mdata.sockets);
-	mdata.socket_config.base_socket_num = MDM_BASE_SOCKET_NUM;
-	ret = modem_socket_init(&mdata.socket_config, &offload_socket_fd_op_vtable);
+	ret = modem_socket_init(&mdata.socket_config, &mdata.sockets[0], ARRAY_SIZE(mdata.sockets),
+				MDM_BASE_SOCKET_NUM, true, &offload_socket_fd_op_vtable);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -805,7 +805,7 @@ static void modem_rx(void)
 {
 	while (true) {
 		/* Wait for incoming data */
-		k_sem_take(&mdata.iface_data.rx_sem, K_FOREVER);
+		modem_iface_uart_rx_wait(&mctx.iface, K_FOREVER);
 
 		mctx.cmd_handler.process(&mctx.cmd_handler, &mctx.iface);
 	}
@@ -2363,9 +2363,14 @@ static int modem_init(const struct device *dev)
 	}
 
 	/* Uart handler. */
-	mdata.iface_data.rx_rb_buf = &mdata.iface_rb_buf[0];
-	mdata.iface_data.rx_rb_buf_len = sizeof(mdata.iface_rb_buf);
-	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data, MDM_UART_DEV);
+	const struct modem_iface_uart_config uart_config = {
+		.rx_rb_buf = &mdata.iface_rb_buf[0],
+		.rx_rb_buf_len = sizeof(mdata.iface_rb_buf),
+		.dev = MDM_UART_DEV,
+		.hw_flow_control = DT_PROP(MDM_UART_NODE, hw_flow_control),
+	};
+
+	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data, &uart_config);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/simcom-sim7080.c
+++ b/drivers/modem/simcom-sim7080.c
@@ -807,7 +807,7 @@ static void modem_rx(void)
 		/* Wait for incoming data */
 		modem_iface_uart_rx_wait(&mctx.iface, K_FOREVER);
 
-		mctx.cmd_handler.process(&mctx.cmd_handler, &mctx.iface);
+		modem_cmd_handler_process(&mctx.cmd_handler, &mctx.iface);
 	}
 }
 
@@ -2348,16 +2348,21 @@ static int modem_init(const struct device *dev)
 	change_state(SIM7080_STATE_INIT);
 
 	/* Command handler. */
-	mdata.cmd_handler_data.cmds[CMD_RESP] = response_cmds;
-	mdata.cmd_handler_data.cmds_len[CMD_RESP] = ARRAY_SIZE(response_cmds);
-	mdata.cmd_handler_data.cmds[CMD_UNSOL] = unsolicited_cmds;
-	mdata.cmd_handler_data.cmds_len[CMD_UNSOL] = ARRAY_SIZE(unsolicited_cmds);
-	mdata.cmd_handler_data.match_buf = &mdata.cmd_match_buf[0];
-	mdata.cmd_handler_data.match_buf_len = sizeof(mdata.cmd_match_buf);
-	mdata.cmd_handler_data.buf_pool = &mdm_recv_pool;
-	mdata.cmd_handler_data.alloc_timeout = BUF_ALLOC_TIMEOUT;
-	mdata.cmd_handler_data.eol = "\r\n";
-	ret = modem_cmd_handler_init(&mctx.cmd_handler, &mdata.cmd_handler_data);
+	const struct modem_cmd_handler_config cmd_handler_config = {
+		.match_buf = &mdata.cmd_match_buf[0],
+		.match_buf_len = sizeof(mdata.cmd_match_buf),
+		.buf_pool = &mdm_recv_pool,
+		.alloc_timeout = BUF_ALLOC_TIMEOUT,
+		.eol = "\r\n",
+		.user_data = NULL,
+		.response_cmds = response_cmds,
+		.response_cmds_len = ARRAY_SIZE(response_cmds),
+		.unsol_cmds = unsolicited_cmds,
+		.unsol_cmds_len = ARRAY_SIZE(unsolicited_cmds),
+	};
+
+	ret = modem_cmd_handler_init(&mctx.cmd_handler, &mdata.cmd_handler_data,
+				     &cmd_handler_config);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/simcom-sim7080.h
+++ b/drivers/modem/simcom-sim7080.h
@@ -27,7 +27,8 @@
 #include "modem_iface_uart.h"
 #include "modem_socket.h"
 
-#define MDM_UART_DEV DEVICE_DT_GET(DT_INST_BUS(0))
+#define MDM_UART_NODE DT_INST_BUS(0)
+#define MDM_UART_DEV DEVICE_DT_GET(MDM_UART_NODE)
 #define MDM_MAX_DATA_LENGTH 1024
 #define MDM_RECV_BUF_SIZE 1024
 #define MDM_MAX_SOCKETS 5

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -737,15 +737,15 @@ static const struct setup_cmd query_cellinfo_cmds[] = {
 MODEM_CMD_DEFINE(on_cmd_sockcreate)
 {
 	struct modem_socket *sock = NULL;
+	int id;
 
 	/* look up new socket by special id */
 	sock = modem_socket_from_newid(&mdata.socket_config);
 	if (sock) {
-		sock->id = ATOI(argv[0],
-				mdata.socket_config.base_socket_num - 1,
-				"socket_id");
+		id = ATOI(argv[0], -1, "socket_id");
+
 		/* on error give up modem socket */
-		if (sock->id == mdata.socket_config.base_socket_num - 1) {
+		if (modem_socket_id_assign(&mdata.socket_config, sock, id) < 0) {
 			modem_socket_put(&mdata.socket_config, sock->sock_fd);
 		}
 	}
@@ -1488,8 +1488,8 @@ static int offload_close(void *obj)
 	char buf[sizeof("AT+USOCL=#\r")];
 	int ret;
 
-	/* make sure we assigned an id */
-	if (sock->id < mdata.socket_config.base_socket_num) {
+	/* make sure socket is allocated and assigned an id */
+	if (modem_socket_id_is_assigned(&mdata.socket_config, sock) == false) {
 		return 0;
 	}
 
@@ -1517,7 +1517,7 @@ static int offload_bind(void *obj, const struct sockaddr *addr,
 	memcpy(&sock->src, addr, sizeof(*addr));
 
 	/* make sure we've created the socket */
-	if (sock->id == mdata.socket_config.sockets_len + 1) {
+	if (modem_socket_is_allocated(&mdata.socket_config, sock) == true) {
 		if (create_socket(sock, addr) < 0) {
 			return -1;
 		}
@@ -1540,7 +1540,8 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 		return -1;
 	}
 
-	if (sock->id < mdata.socket_config.base_socket_num - 1) {
+	/* make sure socket has been allocated */
+	if (modem_socket_is_allocated(&mdata.socket_config, sock) == false) {
 		LOG_ERR("Invalid socket_id(%d) from fd:%d",
 			sock->id, sock->sock_fd);
 		errno = EINVAL;
@@ -1548,7 +1549,7 @@ static int offload_connect(void *obj, const struct sockaddr *addr,
 	}
 
 	/* make sure we've created the socket */
-	if (sock->id == mdata.socket_config.sockets_len + 1) {
+	if (modem_socket_id_is_assigned(&mdata.socket_config, sock) == false) {
 		if (create_socket(sock, NULL) < 0) {
 			return -1;
 		}
@@ -2138,11 +2139,8 @@ static int modem_init(const struct device *dev)
 #endif
 
 	/* socket config */
-	mdata.socket_config.sockets = &mdata.sockets[0];
-	mdata.socket_config.sockets_len = ARRAY_SIZE(mdata.sockets);
-	mdata.socket_config.base_socket_num = MDM_BASE_SOCKET_NUM;
-	ret = modem_socket_init(&mdata.socket_config,
-				&offload_socket_fd_op_vtable);
+	ret = modem_socket_init(&mdata.socket_config, &mdata.sockets[0], ARRAY_SIZE(mdata.sockets),
+				MDM_BASE_SOCKET_NUM, false, &offload_socket_fd_op_vtable);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -939,7 +939,7 @@ static void modem_rx(void)
 {
 	while (true) {
 		/* wait for incoming data */
-		k_sem_take(&mdata.iface_data.rx_sem, K_FOREVER);
+		modem_iface_uart_rx_wait(&mctx.iface, K_FOREVER);
 
 		mctx.cmd_handler.process(&mctx.cmd_handler, &mctx.iface);
 
@@ -2164,12 +2164,14 @@ static int modem_init(const struct device *dev)
 	}
 
 	/* modem interface */
-	mdata.iface_data.hw_flow_control = DT_PROP(MDM_UART_NODE,
-						   hw_flow_control);
-	mdata.iface_data.rx_rb_buf = &mdata.iface_rb_buf[0];
-	mdata.iface_data.rx_rb_buf_len = sizeof(mdata.iface_rb_buf);
-	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data,
-				    MDM_UART_DEV);
+	const struct modem_iface_uart_config uart_config = {
+		.rx_rb_buf = &mdata.iface_rb_buf[0],
+		.rx_rb_buf_len = sizeof(mdata.iface_rb_buf),
+		.dev = MDM_UART_DEV,
+		.hw_flow_control = DT_PROP(MDM_UART_NODE, hw_flow_control),
+	};
+
+	ret = modem_iface_uart_init(&mctx.iface, &mdata.iface_data, &uart_config);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/modem/ublox-sara-r4.c
+++ b/drivers/modem/ublox-sara-r4.c
@@ -941,7 +941,7 @@ static void modem_rx(void)
 		/* wait for incoming data */
 		modem_iface_uart_rx_wait(&mctx.iface, K_FOREVER);
 
-		mctx.cmd_handler.process(&mctx.cmd_handler, &mctx.iface);
+		modem_cmd_handler_process(&mctx.cmd_handler, &mctx.iface);
 
 		/* give up time if we have a solid stream of data */
 		k_yield();
@@ -2148,17 +2148,21 @@ static int modem_init(const struct device *dev)
 	}
 
 	/* cmd handler */
-	mdata.cmd_handler_data.cmds[CMD_RESP] = response_cmds;
-	mdata.cmd_handler_data.cmds_len[CMD_RESP] = ARRAY_SIZE(response_cmds);
-	mdata.cmd_handler_data.cmds[CMD_UNSOL] = unsol_cmds;
-	mdata.cmd_handler_data.cmds_len[CMD_UNSOL] = ARRAY_SIZE(unsol_cmds);
-	mdata.cmd_handler_data.match_buf = &mdata.cmd_match_buf[0];
-	mdata.cmd_handler_data.match_buf_len = sizeof(mdata.cmd_match_buf);
-	mdata.cmd_handler_data.buf_pool = &mdm_recv_pool;
-	mdata.cmd_handler_data.alloc_timeout = K_NO_WAIT;
-	mdata.cmd_handler_data.eol = "\r";
-	ret = modem_cmd_handler_init(&mctx.cmd_handler,
-				     &mdata.cmd_handler_data);
+	const struct modem_cmd_handler_config cmd_handler_config = {
+		.match_buf = &mdata.cmd_match_buf[0],
+		.match_buf_len = sizeof(mdata.cmd_match_buf),
+		.buf_pool = &mdm_recv_pool,
+		.alloc_timeout = K_NO_WAIT,
+		.eol = "\r",
+		.user_data = NULL,
+		.response_cmds = response_cmds,
+		.response_cmds_len = ARRAY_SIZE(response_cmds),
+		.unsol_cmds = unsol_cmds,
+		.unsol_cmds_len = ARRAY_SIZE(unsol_cmds),
+	};
+
+	ret = modem_cmd_handler_init(&mctx.cmd_handler, &mdata.cmd_handler_data,
+				     &cmd_handler_config);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -203,7 +203,7 @@ static void esp_rx(struct esp_data *data)
 {
 	while (true) {
 		/* wait for incoming data */
-		k_sem_take(&data->iface_data.rx_sem, K_FOREVER);
+		modem_iface_uart_rx_wait(&data->mctx.iface, K_FOREVER);
 
 		data->mctx.cmd_handler.process(&data->mctx.cmd_handler,
 					       &data->mctx.iface);
@@ -1156,11 +1156,14 @@ static int esp_init(const struct device *dev)
 	}
 
 	/* modem interface */
-	data->iface_data.hw_flow_control = DT_PROP(ESP_BUS, hw_flow_control);
-	data->iface_data.rx_rb_buf = &data->iface_rb_buf[0];
-	data->iface_data.rx_rb_buf_len = sizeof(data->iface_rb_buf);
-	ret = modem_iface_uart_init(&data->mctx.iface, &data->iface_data,
-				    DEVICE_DT_GET(DT_INST_BUS(0)));
+	const struct modem_iface_uart_config uart_config = {
+		.rx_rb_buf = &data->iface_rb_buf[0],
+		.rx_rb_buf_len = sizeof(data->iface_rb_buf),
+		.dev = DEVICE_DT_GET(DT_INST_BUS(0)),
+		.hw_flow_control = DT_PROP(ESP_BUS, hw_flow_control),
+	};
+
+	ret = modem_iface_uart_init(&data->mctx.iface, &data->iface_data, &uart_config);
 	if (ret < 0) {
 		goto error;
 	}

--- a/drivers/wifi/esp_at/esp.c
+++ b/drivers/wifi/esp_at/esp.c
@@ -205,8 +205,7 @@ static void esp_rx(struct esp_data *data)
 		/* wait for incoming data */
 		modem_iface_uart_rx_wait(&data->mctx.iface, K_FOREVER);
 
-		data->mctx.cmd_handler.process(&data->mctx.cmd_handler,
-					       &data->mctx.iface);
+		modem_cmd_handler_process(&data->mctx.cmd_handler, &data->mctx.iface);
 
 		/* give up time if we have a solid stream of data */
 		k_yield();
@@ -1140,17 +1139,21 @@ static int esp_init(const struct device *dev)
 	k_thread_name_set(&data->workq.thread, "esp_workq");
 
 	/* cmd handler */
-	data->cmd_handler_data.cmds[CMD_RESP] = response_cmds;
-	data->cmd_handler_data.cmds_len[CMD_RESP] = ARRAY_SIZE(response_cmds);
-	data->cmd_handler_data.cmds[CMD_UNSOL] = unsol_cmds;
-	data->cmd_handler_data.cmds_len[CMD_UNSOL] = ARRAY_SIZE(unsol_cmds);
-	data->cmd_handler_data.match_buf = &data->cmd_match_buf[0];
-	data->cmd_handler_data.match_buf_len = sizeof(data->cmd_match_buf);
-	data->cmd_handler_data.buf_pool = &mdm_recv_pool;
-	data->cmd_handler_data.alloc_timeout = K_NO_WAIT;
-	data->cmd_handler_data.eol = "\r\n";
-	ret = modem_cmd_handler_init(&data->mctx.cmd_handler,
-				       &data->cmd_handler_data);
+	const struct modem_cmd_handler_config cmd_handler_config = {
+		.match_buf = &data->cmd_match_buf[0],
+		.match_buf_len = sizeof(data->cmd_match_buf),
+		.buf_pool = &mdm_recv_pool,
+		.alloc_timeout = K_NO_WAIT,
+		.eol = "\r\n",
+		.user_data = NULL,
+		.response_cmds = response_cmds,
+		.response_cmds_len = ARRAY_SIZE(response_cmds),
+		.unsol_cmds = unsol_cmds,
+		.unsol_cmds_len = ARRAY_SIZE(unsol_cmds),
+	};
+
+	ret = modem_cmd_handler_init(&data->mctx.cmd_handler, &data->cmd_handler_data,
+				     &cmd_handler_config);
 	if (ret < 0) {
 		goto error;
 	}


### PR DESCRIPTION
**Introduction**
The drivers/modem contains libraries which are used for generic
functionality including uart interface, modem sockets and
command handling. These libraries work as expected, yet, they
lack documentation and APIs.

**Purpose**
This pull request adds well documented APIs to the libraries
and updates the in-tree drivers which depend on the libraries
to use the new APIs. The APIs are specifically designed to
prevent the need for directly accessing members of contexts,
which is the case for most of the initialization and use
of the libraries currently.

**Added feature (auto assigning socket id)**
The refactoring does not change the functionality except for
one added feature: A configuration option has been added to
the modem_socket library, which determines if the socket id
for a given socket is automatically assigned by the library,
which is the case for the quectel and simcom modems, or if
the id must be assigned later, as is the case with the ublox
sara modem.

This new feature comes with three helpers for determining if
the id has been assigned, if the socket has been allocated,
and for safely setting the id. With this new feature, the
simcom and quectel drivers have been updated to use the id,
which now behaves correctly with the added config option,
instead of the sock_fd.

**Status**
I have verified that all of the in-tree modem drivers can
compile with the new changes, and have tested and verified
the quectel-bg9x modem driver and the PPP GSM driver with
a quectel-bg95. @warasilapm has verified the ublox-sara-r4
driver.

The simcom7070 is nearly identical to the bg9x driver, so
the changes are expected to work for both of them, no one
with the modem has been available to test the update.