### PR TITLE
boards: shields: Remove label property from devicetrees

### DIFF
--- a/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
+++ b/boards/shields/adafruit_2_8_tft_touch_v2/dts/adafruit_2_8_tft_touch_v2.dtsi
@@ -20,7 +20,6 @@
 
 	ili9340: ili9340@0 {
 		compatible = "ilitek,ili9340";
-		label = "ILI9340";
 		spi-max-frequency = <15151515>;
 		reg = <0>;
 		cmd-data-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
@@ -52,7 +51,6 @@
 	touch_controller: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "FT5336";
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
 		/* int-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; */ /* D7 */
 	};

--- a/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
+++ b/boards/shields/adafruit_winc1500/adafruit_winc1500.overlay
@@ -12,7 +12,6 @@
 		status = "ok";
 		compatible = "atmel,winc1500";
 		reg = <0x0>;
-		label = "winc1500";
 		spi-max-frequency = <4000000>;
 		irq-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>;	/* D7 */
 		reset-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;	/* D5 */

--- a/boards/shields/amg88xx/amg88xx_eval_kit.overlay
+++ b/boards/shields/amg88xx/amg88xx_eval_kit.overlay
@@ -10,7 +10,6 @@
 	amg88xx@68 {
 		compatible = "panasonic,amg88xx";
 		reg = <0x68>;
-		label = "AMG88XX";
 		/* Pin D6 from Arduino Connector */
 		int-gpios = <&arduino_header 12 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		status = "okay";

--- a/boards/shields/arceli_eth_w5500/arceli_eth_w5500.overlay
+++ b/boards/shields/arceli_eth_w5500/arceli_eth_w5500.overlay
@@ -11,6 +11,5 @@
 		spi-max-frequency = <80000000>;
 		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
 		reset-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;	/* D8 */
-		label = "w5500";
 	};
 };

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_arduino.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_arduino.overlay
@@ -14,7 +14,6 @@
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
-		label = "RF2XX_0";
 		spi-max-frequency = <6000000>;
 		/*  D2 */
 		irq-gpios = <&arduino_header 8

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_legacy.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_legacy.overlay
@@ -6,12 +6,10 @@
 
 &ext1_spi {
 	status = "okay";
-	label = "SPI_RF2XX";
 
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
-		label = "RF2XX_0";
 		spi-max-frequency = <6000000>;
 		irq-gpios = <&ext1_header 10
 			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_mikrobus.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_mikrobus.overlay
@@ -13,7 +13,6 @@
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
-		label = "RF2XX_0";
 		spi-max-frequency = <6000000>;
 		/* INT */
 		irq-gpios = <&mikrobus_header 7

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_xplained.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_xplained.overlay
@@ -6,12 +6,10 @@
 
 &xplained1_spi {
 	status = "okay";
-	label = "SPI_RF2XX";
 
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
-		label = "RF2XX_0";
 		spi-max-frequency = <6000000>;
 		irq-gpios = <&xplained1_header 2
 			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;

--- a/boards/shields/atmel_rf2xx/atmel_rf2xx_xpro.overlay
+++ b/boards/shields/atmel_rf2xx/atmel_rf2xx_xpro.overlay
@@ -6,12 +6,10 @@
 
 &ext1_spi {
 	status = "okay";
-	label = "SPI_RF2XX";
 
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
-		label = "RF2XX_0";
 		spi-max-frequency = <6000000>;
 		irq-gpios = <&ext1_header 6
 			     (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>;

--- a/boards/shields/boostxl_ulpsense/boostxl_ulpsense.overlay
+++ b/boards/shields/boostxl_ulpsense/boostxl_ulpsense.overlay
@@ -11,7 +11,6 @@
 		reg = <0>;
 		spi-max-frequency = <8000000>;
 		int1-gpios = <&boosterpack_header 36 0>;
-		label = "ADXL362";
 	};
 
 };

--- a/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_2_8_tft_touch_arduino/buydisplay_2_8_tft_touch_arduino.overlay
@@ -18,7 +18,6 @@
 
 	ili9340: ili9340@0 {
 		compatible = "ilitek,ili9340";
-		label = "DISPLAY";
 		spi-max-frequency = <25000000>;
 		reg = <0>;
 		cmd-data-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
@@ -40,7 +39,6 @@
 	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "TOUCH";
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
 		/* int-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>; */ /* D5 */
 	};

--- a/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
+++ b/boards/shields/buydisplay_3_5_tft_touch_arduino/buydisplay_3_5_tft_touch_arduino.overlay
@@ -18,7 +18,6 @@
 
 	ili9488: ili9488@0 {
 		compatible = "ilitek,ili9488";
-		label = "DISPLAY";
 		spi-max-frequency = <25000000>;
 		reg = <0>;
 		cmd-data-gpios = <&arduino_header 13 GPIO_ACTIVE_LOW>; /* D7 */
@@ -39,7 +38,6 @@
 	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "TOUCH";
 		/* Uncomment if IRQ line is available (requires to solder jumper) */
 		/* int-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>; */ /* D5 */
 	};

--- a/boards/shields/dac80508_evm/dac80508_evm.overlay
+++ b/boards/shields/dac80508_evm/dac80508_evm.overlay
@@ -11,7 +11,6 @@
 	dac80508: dac80508@0 {
 		compatible = "ti,dac80508";
 		reg = <0x0>;
-		label = "DAC80508";
 		spi-max-frequency = <1000000>;
 		#io-channel-cells = <1>;
 	};

--- a/boards/shields/esp_8266/boards/sam4e_xpro.overlay
+++ b/boards/shields/esp_8266/boards/sam4e_xpro.overlay
@@ -22,7 +22,6 @@
 
 	esp8266 {
 		compatible = "espressif,esp-at";
-		label = "esp8266";
 		status = "okay";
 	};
 };

--- a/boards/shields/esp_8266/esp_8266_arduino.overlay
+++ b/boards/shields/esp_8266/esp_8266_arduino.overlay
@@ -10,7 +10,6 @@
 
 	esp8266 {
 		compatible = "espressif,esp-at";
-		label = "esp8266";
 		status = "okay";
 	};
 };

--- a/boards/shields/esp_8266/esp_8266_mikrobus.overlay
+++ b/boards/shields/esp_8266/esp_8266_mikrobus.overlay
@@ -10,7 +10,6 @@
 
 	esp8266 {
 		compatible = "espressif,esp-at";
-		label = "esp8266";
 		status = "okay";
 	};
 };

--- a/boards/shields/frdm_cr20a/frdm_cr20a.overlay
+++ b/boards/shields/frdm_cr20a/frdm_cr20a.overlay
@@ -10,7 +10,6 @@
 	mcr20a@0 {
 		compatible = "nxp,mcr20a";
 		reg = <0x0>;
-		label = "mcr20a";
 		spi-max-frequency = <4000000>;
 		irqb-gpios = <&arduino_header 8
 				(GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;	/* D2 */

--- a/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
+++ b/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
@@ -13,7 +13,6 @@
     fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		label = "AGM01_FXOS8700";
 		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&arduino_header 10 GPIO_ACTIVE_LOW>;
     };
@@ -21,7 +20,6 @@
     fxas21002@20 {
         compatible = "nxp,fxas21002";
 		reg = <0x20>;
-		label = "AGM01_FXAS21002";
 		int1-gpios = <&arduino_header 11 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>;
     };

--- a/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
+++ b/boards/shields/ftdi_vm800c/ftdi_vm800c.overlay
@@ -14,7 +14,6 @@
 	ft800@0 {
 		compatible = "ftdi,ft800";
 		reg = <0x0>;
-		label = "FT800_0";
 		spi-max-frequency = <8000000>;
 		/*  D2 */
 		irq-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;

--- a/boards/shields/inventek_eswifi/inventek_eswifi_arduino_spi.overlay
+++ b/boards/shields/inventek_eswifi/inventek_eswifi_arduino_spi.overlay
@@ -24,7 +24,5 @@
 		resetn-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;
 		/* D5 */
 		boot0-gpios = <&arduino_header 11 GPIO_ACTIVE_HIGH>;
-
-		label = "ESWIFI0";
 	};
 };

--- a/boards/shields/inventek_eswifi/inventek_eswifi_arduino_uart.overlay
+++ b/boards/shields/inventek_eswifi/inventek_eswifi_arduino_uart.overlay
@@ -15,7 +15,5 @@
 		wakeup-gpios = <&arduino_header 13 GPIO_ACTIVE_HIGH>;
 		/* D6 */
 		resetn-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;
-
-		label = "ESWIFI0";
 	};
 };

--- a/boards/shields/link_board_eth/link_board_eth.overlay
+++ b/boards/shields/link_board_eth/link_board_eth.overlay
@@ -13,7 +13,6 @@
 		spi-max-frequency = <14000000>;
 		int-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */
 		status = "okay";
-		label = "ETH_0";
 		reg = <0>;
 	};
 };

--- a/boards/shields/lmp90100_evb/lmp90100_evb.overlay
+++ b/boards/shields/lmp90100_evb/lmp90100_evb.overlay
@@ -11,7 +11,6 @@
 		compatible = "ti,lmp90100";
 		reg = <0x0>;
 		spi-max-frequency = <1000000>;
-		label = "LMP90100";
 		/* Uncomment to use IRQ instead of polling: */
 		/* drdyb-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>; */
 		#io-channel-cells = <2>;
@@ -19,7 +18,6 @@
 		lmp90100_gpio: gpio {
 			compatible = "ti,lmp90xxx-gpio";
 			gpio-controller;
-			label = "LMP90100_GPIO";
 			/* Reduce to 6 if drdyb is used */
 			ngpios = <7>;
 			#gpio-cells = <2>;
@@ -33,7 +31,6 @@
 	eeprom0: eeprom@57 {
 		compatible = "atmel,at24";
 		reg = <0x57>;
-		label = "EEPROM_LMP90100_EVB";
 		size = <256>;
 		pagesize = <8>;
 		address-width = <8>;

--- a/boards/shields/ls0xx_generic/ls013b7dh03.overlay
+++ b/boards/shields/ls0xx_generic/ls013b7dh03.overlay
@@ -16,7 +16,6 @@
 
 	ls0xx: ls0xx@0 {
 		compatible = "sharp,ls0xx";
-		label = "LS0XX";
 		spi-max-frequency = <2000000>;
 		reg = <0>;
 		width = <128>;

--- a/boards/shields/max7219/max7219_8x8.overlay
+++ b/boards/shields/max7219/max7219_8x8.overlay
@@ -14,7 +14,6 @@
 
 	max7219: max7219@0 {
 		compatible = "maxim,max7219";
-		label = "MAX7219";
 		reg = <0>;
 		spi-max-frequency = <1000000>;
 		num-cascading = <1>;

--- a/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
+++ b/boards/shields/mcp2515/dfrobot_can_bus_v2_0.overlay
@@ -13,7 +13,6 @@
 		spi-max-frequency = <1000000>;
 		int-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>; /* D2 */
 		status = "okay";
-		label = "MCP2515";
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;

--- a/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
+++ b/boards/shields/mcp2515/keyestudio_can_bus_ks0411.overlay
@@ -13,7 +13,6 @@
 		spi-max-frequency = <1000000>;
 		int-gpios = <&arduino_header 14 GPIO_ACTIVE_LOW>; /* D8 */
 		status = "okay";
-		label = "MCP2515";
 		reg = <0x0>;
 		osc-freq = <16000000>;
 		bus-speed = <125000>;

--- a/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
+++ b/boards/shields/mikroe_adc_click/boards/lpcxpresso55s16.overlay
@@ -14,7 +14,6 @@
 		compatible = "microchip,mcp3204";
 		reg = <0x1>;
 		spi-max-frequency = <100000>;
-		label = "MCP3204";
 		#io-channel-cells = <1>;
 	};
 };

--- a/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
+++ b/boards/shields/mikroe_adc_click/mikroe_adc_click.overlay
@@ -11,7 +11,6 @@
 		compatible = "microchip,mcp3204";
 		reg = <0x0>;
 		spi-max-frequency = <100000>;
-		label = "MCP3204";
 		#io-channel-cells = <1>;
 	};
 };

--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_cpu0.overlay
@@ -22,6 +22,5 @@
 		/* Errata B7/1 specifies min 8Mhz, 20MHz max according to RM */
 		spi-max-frequency = <10000000>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;	/* INT */
-		label = "ETH_CLICK";
 	};
 };

--- a/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
+++ b/boards/shields/mikroe_eth_click/boards/lpcxpresso55s69_ns.overlay
@@ -22,6 +22,5 @@
 		/* Errata B7/1 specifies min 8Mhz, 20MHz max according to RM */
 		spi-max-frequency = <10000000>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;	/* INT */
-		label = "ETH_CLICK";
 	};
 };

--- a/boards/shields/mikroe_eth_click/mikroe_eth_click.overlay
+++ b/boards/shields/mikroe_eth_click/mikroe_eth_click.overlay
@@ -12,6 +12,5 @@
 		/* Errata B7/1 specifies min 8Mhz, 20MHz max according to RM */
 		spi-max-frequency = <10000000>;
 		int-gpios = <&mikrobus_header 7 GPIO_ACTIVE_LOW>;	/* INT */
-		label = "ETH_CLICK";
 	};
 };

--- a/boards/shields/mikroe_wifi_bt_click/mikroe_wifi_bt_click_arduino.overlay
+++ b/boards/shields/mikroe_wifi_bt_click/mikroe_wifi_bt_click_arduino.overlay
@@ -9,7 +9,6 @@
 
 	mikroe_wifi_bt_click {
 		compatible = "espressif,esp-at";
-		label = "mikroe_wifi_bt_click_arduino";
 		status = "okay";
 	};
 };

--- a/boards/shields/mikroe_wifi_bt_click/mikroe_wifi_bt_click_mikrobus.overlay
+++ b/boards/shields/mikroe_wifi_bt_click/mikroe_wifi_bt_click_mikrobus.overlay
@@ -9,7 +9,6 @@
 
 	mikroe_wifi_bt_click {
 		compatible = "espressif,esp-at";
-		label = "mikroe_wifi_bt_click_mikrobus";
 		status = "okay";
 	};
 };

--- a/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
+++ b/boards/shields/semtech_sx1272mb2das/semtech_sx1272mb2das.overlay
@@ -18,7 +18,6 @@
 	lora: lora@0 {
 		compatible = "semtech,sx1272";
 		reg = <0x0>;
-		label = "sx1272";
 		spi-max-frequency = <3000000>;
 
 		reset-gpios = <&arduino_header 0 GPIO_ACTIVE_HIGH>;   /* A0 */

--- a/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
+++ b/boards/shields/sparkfun_sara_r4/sparkfun_sara_r4.overlay
@@ -10,7 +10,6 @@
 
 	sara_r4 {
 		compatible = "u-blox,sara-r4";
-		label = "ublox-sara-r4";
 		mdm-power-gpios = <&arduino_header 11 0>; /* D5 */
 		mdm-reset-gpios = <&arduino_header 12 0>; /* D6 */
 		status = "okay";

--- a/boards/shields/ssd1306/sh1106_128x64.overlay
+++ b/boards/shields/ssd1306/sh1106_128x64.overlay
@@ -16,7 +16,6 @@
 	sh1106: ssd1306@3c {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
-		label = "SSD1306";
 		width = <128>;
 		height = <64>;
 		segment-offset = <2>;

--- a/boards/shields/ssd1306/ssd1306_128x32.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x32.overlay
@@ -16,7 +16,6 @@
 	ssd1306: ssd1306@3c {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
-		label = "SSD1306";
 		width = <128>;
 		height = <32>;
 		segment-offset = <0>;

--- a/boards/shields/ssd1306/ssd1306_128x64.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64.overlay
@@ -16,7 +16,6 @@
 	ssd1306: ssd1306@3c {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x3c>;
-		label = "SSD1306";
 		width = <128>;
 		height = <64>;
 		segment-offset = <0>;

--- a/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
+++ b/boards/shields/ssd1306/ssd1306_128x64_spi.overlay
@@ -16,7 +16,6 @@
 	ssd1306: ssd1306@0 {
 		compatible = "solomon,ssd1306fb";
 		reg = <0x0>;
-		label = "SSD1306";
 		spi-max-frequency = <10000000>;
 		width = <128>;
 		height = <64>;

--- a/boards/shields/st7735r/st7735r_ada_160x128.overlay
+++ b/boards/shields/st7735r/st7735r_ada_160x128.overlay
@@ -16,7 +16,6 @@
 
 	st7735r: st7735r@0 {
 		compatible = "sitronix,st7735r";
-		label = "ST7735R";
 		spi-max-frequency = <20000000>;
 		reg = <0>;
 		cmd-data-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */

--- a/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
+++ b/boards/shields/st7789v_generic/st7789v_tl019fqv01.overlay
@@ -16,7 +16,6 @@
 
 	st7789v: st7789v@0 {
 		compatible = "sitronix,st7789v";
-		label = "ST7789V";
 		spi-max-frequency = <20000000>;
 		reg = <0>;
 		cmd-data-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */

--- a/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
+++ b/boards/shields/st7789v_generic/st7789v_waveshare_240x240.overlay
@@ -17,7 +17,6 @@
 
 	st7789v: st7789v@0 {
 		compatible = "sitronix,st7789v";
-		label = "ST7789V";
 		spi-max-frequency = <20000000>;
 		reg = <0>;
 		cmd-data-gpios = <&arduino_header 15 GPIO_ACTIVE_LOW>;	/* D9 */

--- a/boards/shields/v2c_daplink/v2c_daplink.overlay
+++ b/boards/shields/v2c_daplink/v2c_daplink.overlay
@@ -29,7 +29,6 @@
 		spi-max-frequency = <80000000>;
 		size = <DT_SIZE_M(128)>;
 		jedec-id = [01 20 18];
-		label = "DAPLINK_FLASH_0";
 	};
 };
 

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0154a07.overlay
@@ -15,7 +15,6 @@
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0154a07", "solomon,ssd1681", "solomon,ssd16xxfb";
-		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <200>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b1.overlay
@@ -15,7 +15,6 @@
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673", "solomon,ssd16xxfb";
-		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <250>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh0213b72.overlay
@@ -15,7 +15,6 @@
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a", "solomon,ssd16xxfb";
-		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <250>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdeh029a1.overlay
@@ -15,7 +15,6 @@
 &arduino_spi {
 	ssd16xx: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh029a1", "solomon,ssd1608", "solomon,ssd16xxfb";
-		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <296>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew042t2.overlay
@@ -14,7 +14,6 @@
 &arduino_spi {
 	uc8176: uc8176@0 {
 		compatible = "gooddisplay,gdew042t2", "ultrachip,uc8176";
-		label = "UC8176";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <400>;

--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -15,7 +15,6 @@
 &arduino_spi {
 	uc8179: uc8179@0 {
 		compatible = "gooddisplay,gdew042t2", "ultrachip,uc8179";
-		label = "UC8179";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <800>;

--- a/boards/shields/wnc_m14a2a/boards/frdm_k64f.overlay
+++ b/boards/shields/wnc_m14a2a/boards/frdm_k64f.overlay
@@ -16,7 +16,6 @@
 	wnc_m14a2a: wncm14a2a {
 		status = "okay";
 		compatible = "wnc,m14a2a";
-		label = "wnc-m14a2a";
 		mdm-boot-mode-sel-gpios = <&arduino_header 7 GPIO_ACTIVE_HIGH>;   /* D1 */
 		mdm-power-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;	          /* D2 */
 		mdm-keep-awake-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;	  /* D6 */

--- a/boards/shields/wnc_m14a2a/boards/nrf52840dk_nrf52840.overlay
+++ b/boards/shields/wnc_m14a2a/boards/nrf52840dk_nrf52840.overlay
@@ -41,7 +41,6 @@
 	wnc_m14a2a: wncm14a2a {
 		status = "okay";
 		compatible = "wnc,m14a2a";
-		label = "wnc-m14a2a";
 		mdm-boot-mode-sel-gpios = <&arduino_header 7 GPIO_ACTIVE_HIGH>;   /* D1 */
 		mdm-power-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;	          /* D2 */
 		mdm-keep-awake-gpios = <&arduino_header 12 GPIO_ACTIVE_HIGH>;	  /* D6 */

--- a/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
+++ b/boards/shields/x_nucleo_53l0a1/x_nucleo_53l0a1.overlay
@@ -6,7 +6,6 @@
 &arduino_i2c {
 	expander1: stmpe1600@42 {
 		compatible = "st,stmpe1600";
-		label = "EXPANDER1";
 		reg = <0x42>;
 		ngpios = <16>;
 		gpio-controller;
@@ -14,7 +13,6 @@
 	};
 	expander2: stmpe1600@43 {
 		compatible = "st,stmpe1600";
-		label = "EXPANDER2";
 		reg = <0x43>;
 		ngpios = <16>;
 		gpio-controller;
@@ -24,7 +22,6 @@
 	/* Center sensor soldered on the shield */
 	vl53l0x_c: vl53l0x@30 {
 		compatible = "st,vl53l0x";
-		label = "VL53L0X_C";
 		reg = <0x30>;
 		xshut-gpios = <&expander1 15 0>;
 	};
@@ -32,13 +29,11 @@
 	/* Satellites optional sensors */
 	vl53l0x_l: vl53l0x@31 {
 		compatible = "st,vl53l0x";
-		label = "VL53L0X_L";
 		reg = <0x31>;
 		xshut-gpios = <&expander2 14 0>;
 	};
 	vl53l0x_r: vl53l0x@32 {
 		compatible = "st,vl53l0x";
-		label = "VL53L0X_R";
 		reg = <0x32>;
 		xshut-gpios = <&expander2 15 0>;
 	};

--- a/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
+++ b/boards/shields/x_nucleo_eeprma2/x_nucleo_eeprma2.overlay
@@ -22,7 +22,6 @@
 		/* M24C02-FMC6TG aka U1 (2 kbit eeprom in DFN8 package) */
 		compatible = "st,m24xxx", "atmel,at24";
 		reg = <0x54>;
-		label = "EEPROM_M24C02";
 		size = <256>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -36,7 +35,6 @@
 		/* M24256-DFDW6TP aka U2 (256 kbit eeprom in TSSOP package) */
 		compatible = "st,m24xxx", "atmel,at24";
 		reg = <0x55>;
-		label = "EEPROM_M24256";
 		size = <DT_SIZE_K(32)>;
 		pagesize = <64>;
 		address-width = <16>;
@@ -50,7 +48,6 @@
 		/* M24M01-DFMN6TP aka U3 (1 Mbit eeprom in SO8N package) */
 		compatible = "st,m24xxx", "atmel,at24";
 		reg = <0x56>;
-		label = "EEPROM_M24M01";
 		size = <DT_SIZE_K(128)>;
 		pagesize = <256>;
 		address-width = <16>;
@@ -87,7 +84,6 @@
 		/* M95040-RMC6TG aka U5 (4 kbit eeprom in DFN8 package) */
 		compatible = "st,m95xxx", "atmel,at25";
 		reg = <0x00>;
-		label = "EEPROM_M95040";
 		size = <512>;
 		pagesize = <16>;
 		address-width = <8>;
@@ -102,7 +98,6 @@
 		/* M95256-DFDW6TP aka U6 (256 kbit eeprom in TSSOP package) */
 		compatible = "st,m95xxx", "atmel,at25";
 		reg = <0x01>;
-		label = "EEPROM_M95256";
 		size = <DT_SIZE_K(32)>;
 		pagesize = <64>;
 		address-width = <16>;
@@ -117,7 +112,6 @@
 		/* M95M04-DRMN6TP aka U7 (4 Mbit eeprom in SON8 package) */
 		compatible = "st,m95xxx", "atmel,at25";
 		reg = <0x02>;
-		label = "EEPROM_M95M04";
 		size = <DT_SIZE_K(512)>;
 		pagesize = <512>;
 		address-width = <24>;

--- a/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
+++ b/boards/shields/x_nucleo_idb05a1/x_nucleo_idb05a1.overlay
@@ -13,6 +13,5 @@
 		reset-gpios = <&arduino_header 13 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>; /* D7 */
 		irq-gpios = <&arduino_header 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;  /* A0 */
 		spi-max-frequency = <2000000>;
-		label = "SPBTLE-RF";
 	};
 };

--- a/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
+++ b/boards/shields/x_nucleo_iks01a1/x_nucleo_iks01a1.overlay
@@ -10,25 +10,21 @@
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 	};
 
 	lps25hb-press@5d {
 		compatible = "st,lps25hb-press";
 		reg = <0x5d>;
-		label = "LPS25HB";
 	};
 
 	lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
 		irq-gpios = <&arduino_header 5 GPIO_ACTIVE_HIGH>; /* DRDY on A5 */
-		label = "LIS3MDL";
 	};
 
 	lsm6ds0@6b {
 		compatible = "st,lsm6ds0";
 		reg = <0x6b>;
-		label = "LSM6DS0";
 	};
 };

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -16,33 +16,28 @@
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 	};
 
 	lps22hb-press@5d {
 		compatible = "st,lps22hb-press";
 		reg = <0x5d>;
-		label = "LPS22HB";
 	};
 
 	lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
-		label = "LSM6DSL";
 		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
 	};
 
 	lsm303agr_magn: lsm303agr-magn@1e {
 		compatible = "st,lis2mdl","st,lsm303agr-magn";
 		reg = <0x1e>;
-		label = "LSM303AGR-MAGN";
 		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */
 	};
 
 	lsm303agr-accel@19 {
 		compatible = "st,lis2dh", "st,lsm303agr-accel";
 		reg = <0x19>;
-		label = "LSM303AGR-ACCEL";
 		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */
 	};
 };

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2_shub.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2_shub.overlay
@@ -9,7 +9,6 @@
 	lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
-		label = "LSM6DSL";
 		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
 	};
 };

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
@@ -15,42 +15,36 @@
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 	};
 
 	lps22hh@5d {
 		compatible = "st,lps22hh";
 		reg = <0x5d>;
 		drdy-gpios =  <&arduino_header 12 GPIO_ACTIVE_HIGH>; /* D6 */
-		label = "LPS22HH";
 	};
 
 	stts751@4a {
 		compatible = "st,stts751";
 		reg = <0x4a>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_LOW>; /* A4 */
-		label = "STTS751";
 	};
 
 	lis2mdl: lis2mdl@1e {
 		compatible = "st,lis2mdl";
 		reg = <0x1e>;
 		irq-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
-		label = "LIS2MDL";
 	};
 
 	lis2dw12@19 {
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
 		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
-		label = "LIS2DW12";
 	};
 
 	lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
 		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */
-		label = "LSM6DSO";
 		int-pin = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
@@ -10,14 +10,12 @@
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
 		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
-		label = "LIS2DW12";
 	};
 
 	lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
 		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */
-		label = "LSM6DSO";
 		int-pin = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
@@ -20,21 +20,18 @@
 		reg = <0x19>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
 		drdy-int =  <2>;
-		label = "IIS2DLPC";
 	};
 
 	iis2mdc@1e {
 		compatible = "st,iis2mdc";
 		reg = <0x1e>;
 		drdy-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
-		label = "IIS2MDC";
 	};
 
 	ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
 		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */
-		label = "ISM330DHCX";
 		int-pin = <2>;
 	};
 };

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_mic.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_mic.overlay
@@ -10,6 +10,5 @@
 	mp34dt05@0 {
 		compatible = "st,mpxxdtyy";
 		reg = <0>;
-		label = "MP34DT05";
 	};
 };

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
@@ -22,14 +22,12 @@
 		reg = <0x19>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
 		drdy-int =  <2>;
-		label = "IIS2DLPC";
 	};
 
 	ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
 		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */
-		label = "ISM330DHCX";
 		int-pin = <2>;
 	};
 };


### PR DESCRIPTION
Label properties are not required.

Signed-off-by: Kumar Gala <galak@kernel.org>