### PR TITLE
soc: arm: infineon: 4xxx: Fix UART comms during sleep

### DIFF
--- a/soc/arm/infineon_xmc/4xxx/soc.c
+++ b/soc/arm/infineon_xmc/4xxx/soc.c
@@ -6,6 +6,7 @@
  *
  */
 
+#include <xmc_scu.h>
 #include <zephyr/kernel.h>
 #include <zephyr/init.h>
 #include <soc.h>
@@ -21,6 +22,8 @@ void z_arm_platform_init(void)
 	temp &= ~FLASH_FCON_WSPFLASH_Msk;
 	temp |= PMU_FLASH_WS;
 	FLASH0->FCON = temp;
+
+	XMC_SCU_CLOCK_SetSleepConfig(XMC_SCU_CLOCK_SLEEP_MODE_CONFIG_SYSCLK_FPLL);
 
 	/* configure PLL & system clock */
 	SystemCoreClockSetup();


### PR DESCRIPTION
In normal operation the clock for peripheral devices is derived from
the PLL clock.
During sleep, the xmc4xxx can switch its system clock source (f_sys)
from the PLL clock to an f_ofi clock. Switching to the f_ofi clock
is the default behaviour which breaks UART comms.

Use the PLL clock source during sleep instead to fix the issue.

Signed-off-by: Andriy Gelman <andriy.gelman@gmail.com>