### PR TITLE
drivers/apbuart: fix polling mode

### DIFF
--- a/drivers/serial/uart_apbuart.c
+++ b/drivers/serial/uart_apbuart.c
@@ -542,7 +542,8 @@ static const struct uart_driver_api apbuart_driver_api = {
 	static const struct apbuart_dev_cfg apbuart##index##_config = {	\
 		.regs           = (struct apbuart_regs *)		\
 				  DT_INST_REG_ADDR(index),		\
-		.interrupt      = DT_INST_IRQN(index),			\
+		IF_ENABLED(CONFIG_UART_INTERRUPT_DRIVEN,		\
+			(.interrupt      = DT_INST_IRQN(index),))	\
 	};								\
 									\
 	static struct apbuart_dev_data apbuart##index##_data = {	\


### PR DESCRIPTION
Header file generation from device tree was failing in pulling mode.
Restrict the interrupt node usage to interrupt mode only.