### PR TITLE
drivers: timer: riscv_machine_timer: fix compatible comment

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -9,7 +9,7 @@
 #include <zephyr/sys_clock.h>
 #include <zephyr/spinlock.h>
 
-/* neorv32-machine-timer */
+/* andestech,machine-timer */
 #if DT_HAS_COMPAT_STATUS_OKAY(andestech_machine_timer)
 #define DT_DRV_COMPAT andestech_machine_timer
 


### PR DESCRIPTION
The andestech,machine-timer comment was incorrectly set to
neorv32-machine-timer.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>