### PR TITLE
samples: bluetooth: set available contexts for unicast audio server

### DIFF
--- a/samples/bluetooth/unicast_audio_server/src/main.c
+++ b/samples/bluetooth/unicast_audio_server/src/main.c
@@ -586,6 +586,32 @@ static int set_location(void)
 	return 0;
 }
 
+static int set_available_contexts(void)
+{
+	int err;
+
+	if (IS_ENABLED(CONFIG_BT_PAC_SNK)) {
+		err = bt_audio_capability_set_available_contexts(BT_AUDIO_DIR_SINK,
+							AVAILABLE_SINK_CONTEXT);
+		if (err != 0) {
+			printk("Failed to set sink available contexts (err %d)\n", err);
+			return err;
+		}
+	}
+
+	if (IS_ENABLED(CONFIG_BT_PAC_SRC)) {
+		err = bt_audio_capability_set_available_contexts(BT_AUDIO_DIR_SOURCE,
+							AVAILABLE_SOURCE_CONTEXT);
+		if (err != 0) {
+			printk("Failed to set source available contexts (err %d)\n", err);
+			return err;
+		}
+	}
+
+	printk("Available contexts successfully set\n");
+	return 0;
+}
+
 void main(void)
 {
 	struct bt_le_ext_adv *adv;
@@ -608,6 +634,11 @@ void main(void)
 	}
 
 	err = set_location();
+	if (err != 0) {
+		return;
+	}
+
+	err = set_available_contexts();
 	if (err != 0) {
 		return;
 	}


### PR DESCRIPTION
set available contexts for unicast audio server

Signed-off-by: Hang Fan <fanhang@xiaomi.com>