### PR TITLE
Bluetooth: Controller: df: Add selectable IQ samples to 8 bit conversion

### DIFF
--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -270,6 +270,45 @@ config BT_CTLR_DF_PHYEND_OFFSET_COMPENSATION_ENABLE
 	  enables workaround for the delay to maintain inter frame spacing (IFS) for connection
 	  events.
 
+choice
+	prompt "IQ samples 12 bit to 8 bit conversion approach"
+	default BT_CTLR_DF_IQ_SAMPLES_CONVERT_2_BITS_SHIFT if !SOC_NRF5340_CPUNET
+	default BT_CTLR_DF_IQ_SAMPLES_CONVERT_USE_8_LSB if SOC_NRF5340_CPUNET
+
+config BT_CTLR_DF_IQ_SAMPLES_CONVERT_4_BITS_SHIFT
+	bool "Conversion of IQ samples to 8 bits wide by 4 bits shift"
+	depends on BT_CTLR_DF_SCAN_CTE_RX || BT_CTLR_DF_CONN_CTE_RX
+	help
+	  IQ samples provided by the Radio Direction Finding Extension are 12 bit wide. The
+	  Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits wide: Vol 4, Part E
+	  sections 7.7.65.21 and 7.7.65.22. This config enables conversion of 12 bit IQ samples to
+	  8 bits by ordinary right shift operation by 4 bits. That means there is loss in accuracy
+	  since only the 8 MSB are used.
+
+config BT_CTLR_DF_IQ_SAMPLES_CONVERT_2_BITS_SHIFT
+	bool "Conversion of IQ samples to 8 bits wide by 2 bits shift"
+	depends on BT_CTLR_DF_SCAN_CTE_RX || BT_CTLR_DF_CONN_CTE_RX
+	help
+	  IQ samples provided by the Radio Direction Finding Extension are 12 bit wide. The
+	  Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits wide: Vol 4, Part E
+	  sections 7.7.65.21 and 7.7.65.22. This config enables conversion of 12 bit IQ samples to
+	  8 bits by ordinary right shift operation by 2 bits and a cast to int8_t. That means there
+	  is a loss in accuracy. This conversion may be used only if you are sure samples will not
+	  saturate.
+
+config BT_CTLR_DF_IQ_SAMPLES_CONVERT_USE_8_LSB
+	bool "Conversion of IQ samples to 8 bits wide by use of 8 LSB"
+	depends on SOC_NRF5340_CPUNET && (BT_CTLR_DF_SCAN_CTE_RX || BT_CTLR_DF_CONN_CTE_RX)
+	help
+	  IQ samples provided by the Radio Direction Finding Extension are 12 bit wide. The
+	  Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits wide: Vol 4, Part E
+	  sections 7.7.65.21 and 7.7.65.22. This config enables conversion of 12 bit IQ samples to
+	  8 bits by use of 8 least significant bits. This conversion may be used only if you are
+	  sure actual samples are not greater than 8 bits. This prevents additional accuracy loss
+	  due to shifting operation.
+
+endchoice
+
 endif # BT_LL_SW_SPLIT
 
 endif # BT_CTLR_DF

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2835,6 +2835,28 @@ static void le_df_set_cl_iq_sampling_enable(struct net_buf *buf, struct net_buf 
 }
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
 
+#if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX) || defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT) ||      \
+	defined(CONFIG_BT_CTLR_DF_CONN_CTE_RX)
+static int8_t iq_convert_12_to_8_bits(int16_t data)
+{
+	if (data == IQ_SAMPLE_SATURATED_16_BIT) {
+		return IQ_SAMPLE_SATURATED_8_BIT;
+	}
+
+#if defined(CONFIG_BT_CTLR_DF_IQ_SAMPLES_CONVERT_USE_8_LSB)
+	return (data > INT8_MAX || data < INT8_MIN) ? IQ_SAMPLE_SATURATED_8_BIT
+						    : IQ_SAMPLE_CONVERT_12_TO_8_BIT(data);
+#else  /* !CONFIG_BT_CTLR_DF_IQ_SAMPLES_CONVERT_USE_8_LSB */
+	int16_t data_conv = IQ_SAMPLE_CONVERT_12_TO_8_BIT(data);
+
+	return (data_conv > INT8_MAX || data_conv < INT8_MIN) ? IQ_SAMPLE_SATURATED_8_BIT
+							      : (int8_t)data_conv;
+#endif /* CONFIG_BT_CTLR_DF_IQ_SAMPLES_CONVERT_USE_8_LSB */
+}
+#endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX || CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT
+	* || CONFIG_BT_CTLR_DF_CONN_CTE_RX
+	*/
+
 #if defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX) || defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT)
 static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 					   struct node_rx_pdu *node_rx,
@@ -2933,8 +2955,8 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 		sep->sample_count = 0U;
 	} else {
 		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].i);
-			sep->sample[idx].q = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].q);
+			sep->sample[idx].i = iq_convert_12_to_8_bits(iq_report->sample[idx].i);
+			sep->sample[idx].q = iq_convert_12_to_8_bits(iq_report->sample[idx].q);
 		}
 
 		sep->sample_count = samples_cnt;
@@ -3056,8 +3078,8 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 		sep->sample_count = 0U;
 	} else {
 		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].i);
-			sep->sample[idx].q = IQ_CONVERT_12_TO_8_BIT(iq_report->sample[idx].q);
+			sep->sample[idx].i = iq_convert_12_to_8_bits(iq_report->sample[idx].i);
+			sep->sample[idx].q = iq_convert_12_to_8_bits(iq_report->sample[idx].q);
 		}
 		sep->sample_count = samples_cnt;
 	}

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_df_types.h
@@ -75,13 +75,19 @@ struct lll_df_adv_cfg {
  * To mitigate the limited accuracy and losing information about saturated IQ samples a 0x80 value
  * is selected to serve the purpose.
  */
-#define IQ_SAMPLE_STATURATED_16_BIT ((int16_t)0x8000)
-#define IQ_SAMPLE_STATURATED_8_BIT ((int8_t)0x80)
+#define IQ_SAMPLE_SATURATED_16_BIT ((int16_t)0x8000)
+#define IQ_SAMPLE_SATURATED_8_BIT ((int8_t)0x80)
 
-#define IQ_SHIFT_12_TO_8_BIT(x) ((int8_t)((x) >> 4))
-#define IQ_CONVERT_12_TO_8_BIT(x)                                                                  \
-	(((x) == IQ_SAMPLE_STATURATED_16_BIT) ? IQ_SAMPLE_STATURATED_8_BIT :                       \
-						      IQ_SHIFT_12_TO_8_BIT((x)))
+#if defined(CONFIG_BT_CTLR_DF_IQ_SAMPLES_CONVERT_4_BITS_SHIFT)
+#define IQ_SAMPLE_CONVERT_12_TO_8_BIT(x) ((int16_t)((x) >> 4))
+#elif defined(CONFIG_BT_CTLR_DF_IQ_SAMPLES_CONVERT_2_BITS_SHIFT)
+#define IQ_SAMPLE_CONVERT_12_TO_8_BIT(x) ((int16_t)((x) >> 2))
+#elif defined(CONFIG_BT_CTLR_DF_IQ_SAMPLES_CONVERT_USE_8_LSB)
+#define IQ_SAMPLE_CONVERT_12_TO_8_BIT(x) ((int8_t)(x))
+#elif defined(CODNFIG_BT_CTLR_DF)
+#error "Unsupported IQ samples conversion"
+#endif
+
 /* Structure to store an single IQ sample */
 struct iq_sample {
 	int16_t i;


### PR DESCRIPTION
Nordic Radio Direction Finding Extension provides 12 bits wide IQ
samples. The Bluetooth Core Specification 5.3 Vol 4, Part E sections
7.7.65.21 and 7.7.65.22 limits IQ samples to be 8 bits wide.

There are other way to conver 12 bits IQ samples into Bluetooth Core
specification compliant 8 bits IQ samples than ordinary 4 bits right
shift. If one is sure that samples will never go over 10 bits or 8
bits then, it is allowed to use 2 bits right shift or even 8 least
significant bits of 12 bits IQ samples.

The commit introduces a possibility to choice which approach is used
for IQ samples conversion in HCI layer while Host IQ report events
are created.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>