### PR TITLE
bluetooth: Fix duration endianness issues

### DIFF
--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -3420,7 +3420,7 @@ static void le_set_ext_adv_enable(struct net_buf *buf, struct net_buf **evt)
 		status = ll_adv_enable(handle, cmd->enable, 0, 0, 0, 0, 0);
 #else /* !CONFIG_BT_HCI_MESH_EXT */
 		status = ll_adv_enable(handle, cmd->enable,
-				       s->duration, s->max_ext_adv_evts);
+				       sys_le16_to_cpu(s->duration), s->max_ext_adv_evts);
 #endif /* !CONFIG_BT_HCI_MESH_EXT */
 		if (status) {
 			/* TODO: how to handle succeeded ones before this

--- a/subsys/bluetooth/host/adv.c
+++ b/subsys/bluetooth/host/adv.c
@@ -351,7 +351,7 @@ int bt_le_adv_set_enable_ext(struct bt_le_ext_adv *adv,
 	net_buf_add_u8(buf, 1);
 
 	net_buf_add_u8(buf, adv->handle);
-	net_buf_add_le16(buf, param ? sys_cpu_to_le16(param->timeout) : 0);
+	net_buf_add_le16(buf, param ? param->timeout : 0);
 	net_buf_add_u8(buf, param ? param->num_events : 0);
 
 	bt_hci_cmd_state_set_init(buf, &state, adv->flags, BT_ADV_ENABLED, enable);


### PR DESCRIPTION
Added missing endianness conversion in controller and fixed double
conversion in host

Signed-off-by: Troels Nilsson <trnn@demant.com>