### PR TITLE
bluetooth: common: remove Enable from BT_HCI_VS_FATAL_ERROR prompt

### DIFF
--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -215,7 +215,7 @@ config BT_HCI_VS_EXT
 	  Read Static Addresses and Read Key Hierarchy Roots vendor commands.
 
 config BT_HCI_VS_FATAL_ERROR
-	bool "Enable vendor specific HCI event Zephyr Fatal Error"
+	bool "Allow vendor specific HCI event Zephyr Fatal Error"
 	depends on BT_HCI_VS_EXT
 	default n
 	help


### PR DESCRIPTION
Boolean options are not allowed to start with "Enable...".
BT_HCI_VS_FATAL_ERROR started with "Enable..." making some PRs fail due
to compliance checks.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>