### PR TITLE
net: lwm2m: Allow string and opaque data types to be empty

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -1032,8 +1032,20 @@ static int lwm2m_read_handler(struct lwm2m_engine_obj_inst *obj_inst, struct lwm
 						res->res_instances[i].res_inst_id, &data_len);
 		}
 
-		if (!data_ptr || data_len == 0) {
+		if (!data_ptr && data_len) {
 			return -ENOENT;
+		}
+
+		if (!data_len) {
+			if (obj_field->data_type != LWM2M_RES_TYPE_OPAQUE &&
+			    obj_field->data_type != LWM2M_RES_TYPE_STRING) {
+				return -ENOENT;
+			}
+			/* Only opaque and string types can be empty, and when
+			 * empty, we should not give pointer to potentially uninitialized
+			 * data to a content formatter. Give pointer to empty string instead.
+			 */
+			data_ptr = "";
 		}
 
 		switch (obj_field->data_type) {


### PR DESCRIPTION
When string and opaque types are uninitialized, we should
allow their data length to be zero. However, most content
formatters seem to calculate the string length separately
so replace the pointer of empty data into a static string
that is guaranteed to be empty.

