### PR TITLE
Cleanup Kconfig: test related configs should be enabled only with tests

### DIFF
--- a/samples/arch/smp/pi/src/main.c
+++ b/samples/arch/smp/pi/src/main.c
@@ -17,8 +17,7 @@
 #define DIGITS_NUM	240
 
 #define LENGTH		((DIGITS_NUM / 4) * 14)
-#define STACK_SIZE	((LENGTH * sizeof(int) + 512) + \
-			 CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACK_SIZE	((LENGTH * sizeof(int) + 1024))
 
 #ifdef CONFIG_SMP
 #define CORES_NUM	CONFIG_MP_NUM_CPUS

--- a/samples/kernel/condition_variables/condvar/src/main.c
+++ b/samples/kernel/condition_variables/condvar/src/main.c
@@ -16,7 +16,7 @@ static int count;
 K_MUTEX_DEFINE(count_mutex);
 K_CONDVAR_DEFINE(count_threshold_cv);
 
-#define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACK_SIZE (1024)
 
 K_THREAD_STACK_ARRAY_DEFINE(tstacks, NUM_THREADS, STACK_SIZE);
 

--- a/samples/kernel/condition_variables/simple/src/main.c
+++ b/samples/kernel/condition_variables/simple/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/sys/arch_interface.h>
 
 #define NUM_THREADS 20
-#define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACK_SIZE (1024)
 
 K_THREAD_STACK_ARRAY_DEFINE(tstacks, NUM_THREADS, STACK_SIZE);
 

--- a/samples/net/sockets/socketpair/src/socketpair_example.c
+++ b/samples/net/sockets/socketpair/src/socketpair_example.c
@@ -48,7 +48,7 @@ static const char *const names[] = {
 	|| defined(CONFIG_BOARD_NATIVE_POSIX_64BIT) \
 	|| defined(CONFIG_SOC_SERIES_BSIM_NRFXX))
 
-#define STACK_SIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACK_SIZE (1024)
 static pthread_attr_t attr[NUM_SOCKETPAIRS];
 K_THREAD_STACK_ARRAY_DEFINE(stack, NUM_SOCKETPAIRS, STACK_SIZE);
 

--- a/samples/philosophers/src/main.c
+++ b/samples/philosophers/src/main.c
@@ -83,7 +83,7 @@
 /* end - control behaviour of the demo */
 /***************************************/
 
-#define STACK_SIZE (768 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACK_SIZE (2048)
 
 #include "phil_obj_abstract.h"
 

--- a/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/remote/src/main.c
@@ -9,7 +9,7 @@
 
 #include <zephyr/ipc/ipc_service.h>
 
-#define STACKSIZE	(1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACKSIZE	(1024)
 #define PRIORITY	K_PRIO_PREEMPT(2)
 
 K_THREAD_STACK_DEFINE(ipc0A_stack, STACKSIZE);

--- a/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
+++ b/samples/subsys/ipc/ipc_service/static_vrings/src/main.c
@@ -9,7 +9,7 @@
 
 #include <zephyr/ipc/ipc_service.h>
 
-#define STACKSIZE	(4096 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACKSIZE	(4096)
 #define PRIORITY	K_PRIO_PREEMPT(2)
 
 K_THREAD_STACK_DEFINE(ipc0A_stack, STACKSIZE);

--- a/samples/subsys/logging/logger/src/main.c
+++ b/samples/subsys/logging/logger/src/main.c
@@ -30,7 +30,7 @@ static struct k_mem_partition *app_parts[] = {
 #endif /* CONFIG_USERSPACE */
 
 /* size of stack area used by each thread */
-#define STACKSIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACKSIZE (1024)
 
 extern void sample_module_func(void);
 

--- a/samples/subsys/tracing/src/main.c
+++ b/samples/subsys/tracing/src/main.c
@@ -19,7 +19,7 @@
 
 
 /* size of stack area used by each thread */
-#define STACKSIZE (1024 + CONFIG_TEST_EXTRA_STACK_SIZE)
+#define STACKSIZE (2048)
 
 /* scheduling priority used by each thread */
 #define PRIORITY 7

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -19,6 +19,7 @@ config TEST_EXTRA_STACK_SIZE
 	default 2048 if COVERAGE_GCOV
 	default 768 if XTENSA
 	default 0
+	depends on TEST
 	help
 	  Additional stack for tests on some platform where default is not
 	  enough.

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -87,11 +87,6 @@ config TEST_LOGGING_DEFAULTS
 	  logging configuration, or no logging at all, disable this
 	  in the project-level defconfig.
 
-config TEST_LOGGING_FLUSH_AFTER_TEST
-	bool "When enabled logs are flushed after each test case"
-	default y
-	depends on MULTITHREADING
-
 config TEST_ENABLE_USERSPACE
 	bool
 	depends on TEST_USERSPACE

--- a/subsys/testsuite/ztest/Kconfig
+++ b/subsys/testsuite/ztest/Kconfig
@@ -124,6 +124,11 @@ endif #ZTEST_SHUFFLE
 
 endif # ZTEST_NEW_API
 
+config TEST_LOGGING_FLUSH_AFTER_TEST
+	bool "When enabled logs are flushed after each test case"
+	default y
+	depends on MULTITHREADING
+
 endif # ZTEST
 
 config ZTEST_MOCKING


### PR DESCRIPTION
- tests: ztest: move TEST_LOGGING_FLUSH_AFTER_TEST under ztest
- tests: TEST_EXTRA_STACK_SIZE depend on test
