### PR TITLE
Bluetooth: audio: Add HAS client support for preset switching

### DIFF
--- a/include/zephyr/bluetooth/audio/has.h
+++ b/include/zephyr/bluetooth/audio/has.h
@@ -98,15 +98,17 @@ struct bt_has_client_cb {
 	/**
 	 * @brief Callback function for Hearing Access Service active preset changes.
 	 *
-	 * Optional callback called when the value is changed by the remote server.
-	 * The callback must be set to receive active preset changes and enable support
-	 * for switching presets. If the callback is not set, the Active Index and
-	 * Control Point characteristics will not be discovered by @ref bt_has_client_discover.
+	 * Optional callback called when the active preset is changed by the remote server when the
+	 * preset switch procedure is complete. The callback must be set to receive active preset
+	 * changes and enable support for switching presets. If the callback is not set, the Active
+	 * Index and Control Point characteristics will not be discovered by
+	 * @ref bt_has_client_discover.
 	 *
 	 * @param has Pointer to the Hearing Access Service object.
+	 * @param err 0 on success, ATT error or negative errno otherwise.
 	 * @param index Active preset index.
 	 */
-	void (*preset_switch)(struct bt_has *has, uint8_t index);
+	void (*preset_switch)(struct bt_has *has, int err, uint8_t index);
 
 	/**
 	 * @brief Callback function for presets read operation.
@@ -212,6 +214,46 @@ int bt_has_client_conn_get(const struct bt_has *has, struct bt_conn **conn);
  * @return 0 in case of success or negative value in case of error.
  */
 int bt_has_client_presets_read(struct bt_has *has, uint8_t index, uint8_t max_count);
+
+/**
+ * @brief Set Active Preset.
+ *
+ * Client procedure to set preset identified by @p index as active.
+ * The status is returned in the @ref bt_has_client_cb.preset_switch callback.
+ *
+ * @param has Pointer to the Hearing Access Service object.
+ * @param index Preset index to activate.
+ * @param sync Request active preset synchronization in set.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ */
+int bt_has_client_preset_set(struct bt_has *has, uint8_t index, bool sync);
+
+/**
+ * @brief Activate Next Preset.
+ *
+ * Client procedure to set next available preset as active.
+ * The status is returned in the @ref bt_has_client_cb.preset_switch callback.
+ *
+ * @param has Pointer to the Hearing Access Service object.
+ * @param sync Request active preset synchronization in set.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ */
+int bt_has_client_preset_next(struct bt_has *has, bool sync);
+
+/**
+ * @brief Activate Previous Preset.
+ *
+ * Client procedure to set previous available preset as active.
+ * The status is returned in the @ref bt_has_client_cb.preset_switch callback.
+ *
+ * @param has Pointer to the Hearing Access Service object.
+ * @param sync Request active preset synchronization in set.
+ *
+ * @return 0 in case of success or negative value in case of error.
+ */
+int bt_has_client_preset_prev(struct bt_has *has, bool sync);
 
 /** @brief Preset operations structure. */
 struct bt_has_preset_ops {

--- a/subsys/bluetooth/shell/has_client.c
+++ b/subsys/bluetooth/shell/has_client.c
@@ -34,9 +34,13 @@ static void has_client_discover_cb(struct bt_conn *conn, int err, struct bt_has 
 	inst = has;
 }
 
-static void has_client_preset_switch_cb(struct bt_has *has, uint8_t index)
+static void has_client_preset_switch_cb(struct bt_has *has, int err, uint8_t index)
 {
-	shell_print(ctx_shell, "HAS %p preset switch index 0x%02x", has, index);
+	if (err != 0) {
+		shell_error(ctx_shell, "HAS %p preset switch error (err %d)", has, err);
+	} else {
+		shell_print(ctx_shell, "HAS %p preset switch index 0x%02x", has, index);
+	}
 }
 
 static void has_client_preset_read_rsp_cb(struct bt_has *has, int err,
@@ -127,6 +131,118 @@ static int cmd_has_client_read_presets(const struct shell *sh, size_t argc, char
 	return err;
 }
 
+static int cmd_has_client_preset_set(const struct shell *sh, size_t argc, char **argv)
+{
+	bool sync = false;
+	uint8_t index;
+	int err = 0;
+
+	index = shell_strtoul(argv[1], 16, &err);
+	if (err < 0) {
+		shell_error(sh, "Invalid command parameter (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	for (size_t argn = 2; argn < argc; argn++) {
+		const char *arg = argv[argn];
+
+		if (!strcmp(arg, "sync")) {
+			sync = true;
+		} else {
+			shell_error(sh, "Invalid argument");
+			return -ENOEXEC;
+		}
+	}
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	if (!inst) {
+		shell_error(sh, "No instance discovered");
+		return -ENOEXEC;
+	}
+
+	err = bt_has_client_preset_set(inst, index, sync);
+	if (err != 0) {
+		shell_error(sh, "bt_has_client_preset_switch (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	return 0;
+}
+
+static int cmd_has_client_preset_next(const struct shell *sh, size_t argc, char **argv)
+{
+	bool sync = false;
+	int err;
+
+	for (size_t argn = 1; argn < argc; argn++) {
+		const char *arg = argv[argn];
+
+		if (!strcmp(arg, "sync")) {
+			sync = true;
+		} else {
+			shell_error(sh, "Invalid argument");
+			return -ENOEXEC;
+		}
+	}
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	if (!inst) {
+		shell_error(sh, "No instance discovered");
+		return -ENOEXEC;
+	}
+
+	err = bt_has_client_preset_next(inst, sync);
+	if (err != 0) {
+		shell_error(sh, "bt_has_client_preset_next (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	return err;
+}
+
+static int cmd_has_client_preset_prev(const struct shell *sh, size_t argc, char **argv)
+{
+	bool sync = false;
+	int err;
+
+	for (size_t argn = 1; argn < argc; argn++) {
+		const char *arg = argv[argn];
+
+		if (!strcmp(arg, "sync")) {
+			sync = true;
+		} else {
+			shell_error(sh, "Invalid argument");
+			return -ENOEXEC;
+		}
+	}
+
+	if (default_conn == NULL) {
+		shell_error(sh, "Not connected");
+		return -ENOEXEC;
+	}
+
+	if (!inst) {
+		shell_error(sh, "No instance discovered");
+		return -ENOEXEC;
+	}
+
+	err = bt_has_client_preset_prev(inst, sync);
+	if (err != 0) {
+		shell_error(sh, "bt_has_client_preset_prev (err %d)", err);
+		return -ENOEXEC;
+	}
+
+	return err;
+}
+
 static int cmd_has_client(const struct shell *sh, size_t argc, char **argv)
 {
 	if (argc > 1) {
@@ -145,6 +261,9 @@ SHELL_STATIC_SUBCMD_SET_CREATE(has_client_cmds,
 	SHELL_CMD_ARG(discover, NULL, HELP_NONE, cmd_has_client_discover, 1, 0),
 	SHELL_CMD_ARG(presets-read, NULL, "<start_index_hex> <max_count_dec>",
 		      cmd_has_client_read_presets, 3, 0),
+	SHELL_CMD_ARG(preset-set, NULL, "<index_hex> [sync]", cmd_has_client_preset_set, 2, 1),
+	SHELL_CMD_ARG(preset-next, NULL, "[sync]", cmd_has_client_preset_next, 1, 1),
+	SHELL_CMD_ARG(preset-prev, NULL, "[sync]", cmd_has_client_preset_prev, 1, 1),
 	SHELL_SUBCMD_SET_END
 );
 


### PR DESCRIPTION
This adds client support for switching the active preset along with bsim
tests implementation.

Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>