### PR TITLE
i2c: shell: Remove prefix filtering of device list

### DIFF
--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -14,7 +14,6 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(i2c_shell, CONFIG_LOG_DEFAULT_LEVEL);
 
-#define I2C_DEVICE_PREFIX "I2C_"
 #define MAX_BYTES_FOR_REGISTER_INDEX	4
 #define ARGV_DEV	1
 #define ARGV_ADDR	2
@@ -277,7 +276,7 @@ SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
 static void device_name_get(size_t idx, struct shell_static_entry *entry)
 {
-	const struct device *dev = shell_device_lookup(idx, I2C_DEVICE_PREFIX);
+	const struct device *dev = shell_device_lookup(idx, NULL);
 
 	entry->syntax = (dev != NULL) ? dev->name : NULL;
 	entry->handler = NULL;


### PR DESCRIPTION
The I2C shell would filter the list of devices it knows about to
ones that have a device name that starts with "I2C_".  It was the
case that the majority of I2C bus controller devices happened
to be named with the "I2C_" prefix, however there is no guarantee
that is the case.  With the remove of label properties from the
devicetree this is even more true.

For now remove the prefix filter and just return the full list
of devices.

Signed-off-by: Kumar Gala <galak@kernel.org>