### PR TITLE
i2c: NPCX Port use correct device define macro

### DIFF
--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -165,7 +165,7 @@ static const struct i2c_driver_api i2c_port_npcx_driver_api = {
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                  \
 	};                                                                     \
 									       \
-	DEVICE_DT_INST_DEFINE(inst,                                            \
+	I2C_DEVICE_DT_INST_DEFINE(inst,                                        \
 			    i2c_npcx_port_init,                                \
 			    NULL, NULL,                                        \
 			    &i2c_npcx_port_cfg_##inst,                         \


### PR DESCRIPTION
I2C has its own set of device define macro wrappers to provide
automatic stats tracking when enabled for the device class. This
particular driver happened ot be missed in the transition.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>