### PR TITLE
[backport v2.7-branch] drivers: sensor: sm351lt: Fix global thread triggering bug

### DIFF
--- a/drivers/sensor/sm351lt/sm351lt.c
+++ b/drivers/sensor/sm351lt/sm351lt.c
@@ -209,9 +209,9 @@ static int sm351lt_init(const struct device *dev)
 	}
 
 #if defined(CONFIG_SM351LT_TRIGGER)
-#if defined(CONFIG_SM351LT_TRIGGER_OWN_THREAD)
 	data->dev = dev;
 
+#if defined(CONFIG_SM351LT_TRIGGER_OWN_THREAD)
 	k_sem_init(&data->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
 	k_thread_create(&data->thread, data->thread_stack,


### PR DESCRIPTION
This fixes a bug in the sm351lt driver whereby global triggering will
cause an MPU fault due to an unset pointer.

Fixes #46698
