### PR TITLE
include: add missing zephyr/ prefixes

### DIFF
--- a/dts/arm/aspeed/ast10x0.dtsi
+++ b/dts/arm/aspeed/ast10x0.dtsi
@@ -6,7 +6,7 @@
 
 #include <arm/armv7-m.dtsi>
 #include <mem.h>
-#include <dt-bindings/clock/ast10x0_clock.h>
+#include <zephyr/dt-bindings/clock/ast10x0_clock.h>
 
 / {
 	cpus {

--- a/dts/arm/microchip/mec152x/mec152xhsz-pinctrl.dtsi
+++ b/dts/arm/microchip/mec152x/mec152xhsz-pinctrl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <dt-bindings/pinctrl/mchp-xec-pinctrl.h>
+#include <zephyr/dt-bindings/pinctrl/mchp-xec-pinctrl.h>
 
 &pinctrl {
 	/* ADC */

--- a/dts/riscv/mpfs-icicle.dtsi
+++ b/dts/riscv/mpfs-icicle.dtsi
@@ -5,7 +5,7 @@
  */
 
 #include <skeleton.dtsi>
-#include <dt-bindings/gpio/gpio.h>
+#include <zephyr/dt-bindings/gpio/gpio.h>
 
 / {
 	#address-cells = <1>;

--- a/tests/subsys/settings/functional/fcb/settings_test_fcb.c
+++ b/tests/subsys/settings/functional/fcb/settings_test_fcb.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2022 Nordic semiconductor ASA */
 
 #include <zephyr/zephyr.h>
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <errno.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/fs/fcb.h>

--- a/tests/subsys/settings/functional/file/settings_test_fs.c
+++ b/tests/subsys/settings/functional/file/settings_test_fs.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2022 Nordic semiconductor ASA */
 
 #include <zephyr/zephyr.h>
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <errno.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/fs/fs.h>

--- a/tests/subsys/settings/functional/nvs/settings_test_nvs.c
+++ b/tests/subsys/settings/functional/nvs/settings_test_nvs.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2022 Nordic semiconductor ASA */
 
 #include <zephyr/zephyr.h>
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <errno.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/fs/nvs.h>


### PR DESCRIPTION
Some files were missed during the migration. This patch adds the prefix
where missing.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>