### PR TITLE
ci: fix pattern for skipping boards in testplan.py

### DIFF
--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -102,7 +102,7 @@ class Filters:
             self.find_boards()
 
         if self.default_run:
-            self.find_excludes(skip=["tests/*", "boards/*"])
+            self.find_excludes(skip=["tests/*", "boards/*/*/*"])
         else:
             self.find_excludes()
 


### PR DESCRIPTION
boards have their own unique pattern, use that for proper skip.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
