### PR TITLE
include: fix few more missing zephyr/ prefixes

### DIFF
--- a/tests/subsys/settings/functional/fcb/settings_test_fcb.c
+++ b/tests/subsys/settings/functional/fcb/settings_test_fcb.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2022 Nordic semiconductor ASA */
 
 #include <zephyr/zephyr.h>
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <errno.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/fs/fcb.h>

--- a/tests/subsys/settings/functional/file/settings_test_fs.c
+++ b/tests/subsys/settings/functional/file/settings_test_fs.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2022 Nordic semiconductor ASA */
 
 #include <zephyr/zephyr.h>
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <errno.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/fs/fs.h>

--- a/tests/subsys/settings/functional/nvs/settings_test_nvs.c
+++ b/tests/subsys/settings/functional/nvs/settings_test_nvs.c
@@ -2,7 +2,7 @@
 /* Copyright (c) 2022 Nordic semiconductor ASA */
 
 #include <zephyr/zephyr.h>
-#include <ztest.h>
+#include <zephyr/ztest.h>
 #include <errno.h>
 #include <zephyr/settings/settings.h>
 #include <zephyr/fs/nvs.h>


### PR DESCRIPTION
Fix few more missing "zephyr/" prefixes that got merged just before
switching off the legacy include path.