### PR TITLE
west_commands: runners: reserve -O for --tool-opt

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -70,12 +70,17 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
-                          dev_id=True, flash_addr=True, erase=True)
+                          dev_id=True, flash_addr=True, erase=True,
+                          tool_opt=True)
 
     @classmethod
     def dev_id_help(cls) -> str:
         return '''Device identifier. Use it to select the J-Link Serial Number
                   of the device connected over USB.'''
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return "Additional options for JLink Commander, e.g. '-autoconnect 1'"
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -101,9 +106,6 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         parser.add_argument('--gdb-port', default=DEFAULT_JLINK_GDB_PORT,
                             help='pyocd gdb port, defaults to {}'.format(
                                 DEFAULT_JLINK_GDB_PORT))
-        parser.add_argument('--tool-opt', default=[], action='append',
-                            help='''Additional options for JLink Commander,
-                            e.g. \'-autoconnect 1\' ''')
         parser.add_argument('--commander', default=DEFAULT_JLINK_EXE,
                             help=f'''J-Link Commander, default is
                             {DEFAULT_JLINK_EXE}''')

--- a/scripts/west_commands/runners/nrfjprog.py
+++ b/scripts/west_commands/runners/nrfjprog.py
@@ -47,13 +47,18 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={'flash'}, dev_id=True, erase=True)
+        return RunnerCaps(commands={'flash'}, dev_id=True, erase=True,
+                          tool_opt=True)
 
     @classmethod
     def dev_id_help(cls) -> str:
         return '''Device identifier. Use it to select the J-Link Serial Number
                   of the device connected over USB. '*' matches one or more
                   characters/digits'''
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return 'Additional options for nrfjprog, e.g. "--recover"'
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -68,9 +73,6 @@ class NrfJprogBinaryRunner(ZephyrBinaryRunner):
                             action=partial(depr_action,
                                            replacement='-i/--dev-id'),
                             help='Deprecated: use -i/--dev-id instead')
-        parser.add_argument('--tool-opt', default=[], action='append',
-                            help='''Additional options for nrfjprog,
-                            e.g. "--recover"''')
         parser.add_argument('--force', required=False,
                             action='store_true',
                             help='Flash even if the result cannot be guaranteed.')

--- a/scripts/west_commands/runners/pyocd.py
+++ b/scripts/west_commands/runners/pyocd.py
@@ -68,10 +68,7 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
             frequency_args = ['-f', frequency]
         self.frequency_args = frequency_args
 
-        tool_opt_args = []
-        if tool_opt is not None:
-            tool_opt_args = [tool_opt]
-        self.tool_opt_args = tool_opt_args
+        self.tool_opt_args = tool_opt or []
 
         self.flash_extra = flash_opts if flash_opts else []
 
@@ -82,7 +79,8 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
     @classmethod
     def capabilities(cls):
         return RunnerCaps(commands={'flash', 'debug', 'debugserver', 'attach'},
-                          dev_id=True, flash_addr=True, erase=True)
+                          dev_id=True, flash_addr=True, erase=True,
+                          tool_opt=True)
 
     @classmethod
     def dev_id_help(cls) -> str:
@@ -115,9 +113,11 @@ class PyOcdBinaryRunner(ZephyrBinaryRunner):
                             action=partial(depr_action,
                                            replacement='-i/--dev-id'),
                             help='Deprecated: use -i/--dev-id instead')
-        parser.add_argument('--tool-opt',
-                            help='''Additional options for pyocd Commander,
-                            e.g. \'--script=user.py\' ''')
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return """Additional options for pyocd commander,
+        e.g. '--script=user.py'"""
 
     @classmethod
     def do_create(cls, cfg, args):

--- a/scripts/west_commands/runners/stm32cubeprogrammer.py
+++ b/scripts/west_commands/runners/stm32cubeprogrammer.py
@@ -107,7 +107,7 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
 
     @classmethod
     def capabilities(cls):
-        return RunnerCaps(commands={"flash"}, erase=True)
+        return RunnerCaps(commands={"flash"}, erase=True, tool_opt=True)
 
     @classmethod
     def do_add_parser(cls, parser):
@@ -145,12 +145,10 @@ class STM32CubeProgrammerBinaryRunner(ZephyrBinaryRunner):
             required=False,
             help="Use ELF file when flashing instead of HEX file",
         )
-        parser.add_argument(
-            "--tool-opt",
-            default=[],
-            action="append",
-            help="Additional options for STM32_Programmer_CLI",
-        )
+
+    @classmethod
+    def tool_opt_help(cls) -> str:
+        return "Additional options for STM32_Programmer_CLI"
 
     @classmethod
     def do_create(

--- a/scripts/west_commands/tests/test_pyocd.py
+++ b/scripts/west_commands/tests/test_pyocd.py
@@ -37,7 +37,7 @@ TEST_ALL_KWARGS = {
     'dev_id': TEST_DEV_ID,
     'frequency': TEST_FREQUENCY,
     'daparg': TEST_DAPARG,
-    'tool_opt': TEST_TOOL_OPT,
+    'tool_opt': [TEST_TOOL_OPT],
 }
 
 TEST_DEF_KWARGS = {}
@@ -72,8 +72,8 @@ FLASH_ALL_EXPECTED_CALL = ([TEST_PYOCD,
                             '-e', 'sector',
                             '-a', hex(TEST_ADDR), '-da', TEST_DAPARG,
                             '-t', TEST_TARGET, '-u', TEST_DEV_ID,
-                            '-f', TEST_FREQUENCY,
-                            TEST_TOOL_OPT] +
+                            '-f', TEST_FREQUENCY] +
+                           [TEST_TOOL_OPT] +
                            TEST_FLASH_OPTS +
                            [RC_KERNEL_HEX])
 FLASH_DEF_EXPECTED_CALL = ['pyocd', 'flash', '-e', 'sector',
@@ -87,8 +87,7 @@ DEBUG_ALL_EXPECTED_SERVER = [TEST_PYOCD,
                              '-T', str(TEST_TELNET_PORT),
                              '-t', TEST_TARGET,
                              '-u', TEST_DEV_ID,
-                             '-f', TEST_FREQUENCY,
-                             TEST_TOOL_OPT]
+                             '-f', TEST_FREQUENCY] + [TEST_TOOL_OPT]
 DEBUG_ALL_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
                              '-ex', 'target remote :{}'.format(TEST_GDB_PORT),
                              '-ex', 'monitor halt',
@@ -113,8 +112,7 @@ DEBUGSERVER_ALL_EXPECTED_CALL = [TEST_PYOCD,
                                  '-T', str(TEST_TELNET_PORT),
                                  '-t', TEST_TARGET,
                                  '-u', TEST_DEV_ID,
-                                 '-f', TEST_FREQUENCY,
-                                 TEST_TOOL_OPT]
+                                 '-f', TEST_FREQUENCY] + [TEST_TOOL_OPT]
 DEBUGSERVER_DEF_EXPECTED_CALL = ['pyocd',
                                  'gdbserver',
                                  '-p', '3333',


### PR DESCRIPTION
The --tool-opt runner option is the recommended practice for allowing
runners to take additional arguments that are passed on to the
underlying tool. It exists because we don't want to add one runner
option for every single tool option that users might want to tweak --
that would be a nightmare.

Enough runners are using this option that it's time to promote it to a
common runner capability with consistent behavior, the same way we did
for the --dev-id option in the past. This removes boilerplate from
individual runner files and ensures consistent argument handling for
this option when it is supported.

Since --tool-opt is a bit long to type, and we've had some complaints
about that, take this as an opportunity to standardize on -O as a
short option equivalent for it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>