### PR TITLE
ztest: Handle assert failures without signal handler

### DIFF
--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -234,12 +234,6 @@ static jmp_buf test_pass;
 static jmp_buf test_skip;
 static jmp_buf stack_fail;
 
-void ztest_test_fail(void) { raise(SIGABRT); }
-
-void ztest_test_pass(void) { longjmp(test_pass, 1); }
-
-void ztest_test_skip(void) { longjmp(test_skip, 1); }
-
 /**
  * @brief Get a friendly name string for a given test phrase.
  *
@@ -266,9 +260,8 @@ static inline const char *get_friendly_phase_name(enum ztest_phase phase)
 	}
 }
 
-static void handle_signal(int sig)
+void ztest_test_fail(void)
 {
-	PRINT("    %s", strsignal(sig));
 	switch (phase) {
 	case TEST_PHASE_SETUP:
 	case TEST_PHASE_BEFORE:
@@ -283,11 +276,12 @@ static void handle_signal(int sig)
 	}
 }
 
+void ztest_test_pass(void) { longjmp(test_pass, 1); }
+
+void ztest_test_skip(void) { longjmp(test_skip, 1); }
+
 static void init_testing(void)
 {
-	signal(SIGABRT, handle_signal);
-	signal(SIGSEGV, handle_signal);
-
 	if (setjmp(stack_fail)) {
 		PRINT("TESTSUITE crashed.");
 		exit(1);


### PR DESCRIPTION
The signal handler needs to return gracefully. When multiple
tests assert, the first assert will raise SIGABRT and the signal
handler will run and the test will stop running.
The second assert will raise SIGABRT but the signal handler
will not be called, therefore the test PASS/FAIL status is not
updated correctly.

Signed-off-by: Al Semjonovs <asemjonovs@google.com>