### PR TITLE
cpp: Create utility stub header with std::move

### DIFF
--- a/subsys/cpp/include/type_traits
+++ b/subsys/cpp/include/type_traits
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Stub header allowing compilation of `#include <type_traits>`
+ */
+
+#ifndef ZEPHYR_SUBSYS_CPP_INCLUDE_TYPE_TRAITS_
+#define ZEPHYR_SUBSYS_CPP_INCLUDE_TYPE_TRAITS_
+
+namespace std {
+
+template<class T> struct remove_reference      { typedef T type; };
+template<class T> struct remove_reference<T&>  { typedef T type; };
+template<class T> struct remove_reference<T&&> { typedef T type; };
+
+}
+
+#endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_TYPE_TRAITS_ */

--- a/subsys/cpp/include/utility
+++ b/subsys/cpp/include/utility
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ *
+ * @brief Stub header allowing compilation of `#include <utility>`
+ */
+
+#ifndef ZEPHYR_SUBSYS_CPP_INCLUDE_UTILITY_
+#define ZEPHYR_SUBSYS_CPP_INCLUDE_UTILITY_
+
+#include <type_traits>
+
+namespace std {
+
+template <typename T>
+static inline constexpr typename remove_reference<T>::type &&move(T &&arg)
+{
+	return static_cast<typename remove_reference<T>::type&&>(arg);
+}
+
+}
+
+#endif /* ZEPHYR_SUBSYS_CPP_INCLUDE_UTILITY_ */


### PR DESCRIPTION
This enables C++ programs to use std::move.

Signed-off-by: Moritz Fischer <moritzf@google.com>