### PR TITLE
doc: Update frdm_k64f doc about modbus fixtures

### DIFF
--- a/tests/subsys/modbus/src/test_modbus.h
+++ b/tests/subsys/modbus/src/test_modbus.h
@@ -19,10 +19,20 @@
 #define MB_TEST_FP_OFFSET	5000
 
 /*
+ * This test performed on hardware requires two UART controllers
+ * on the board with RX/TX lines connected crosswise.
+ *
  * Integration platform for this test is FRDM-K64F.
  * The board must be prepared accordingly:
  * UART3(PTC16)-RX <-> UART2(PTD3)-TX pins and
  * UART3(PTC17)-TX <-> UART2(PTD2)-RX pins have to be connected.
+ *
+ * If need to test this test suite by twister,
+ * should add the following fixtures to hardware map file:
+ *
+ *   fixtures:
+ *   - uart_loopback
+ *
  */
 
 uint8_t test_get_client_iface(void);


### PR DESCRIPTION
Add the modbus fixtures to frdm_k64f doc.

Signed-off-by: Shaoan Li <shaoanx.li@intel.com>