### PR TITLE
Set empty string for None type labels

### DIFF
--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -269,6 +269,8 @@ class ZephyrElf:
             else:
                 n = self.edt.dep_ord2node[dev.ordinal]
                 label = n.labels[0] if n.labels else n.label
+                if label is None:
+                    label = ''
                 text = '{:s}\\nOrdinal: {:d} | Handle: {:d}\\n{:s}'.format(
                     label, dev.ordinal, dev.handle, n.path
                 )


### PR DESCRIPTION
This PR  fixes an error when the device tree dot graph dependency is generated. Sometimes, both the node's 'label' and 'labels' properties are empty. In the case they are both "None" then it should be set to an empty string to be passed into the format string. Otherwise an error is thrown.

I encountered this error when trying to build the hid-cdc demo for the atsamd21_xpro. Before the fix it failed on generating dev_handles.c.obj.