### PR TITLE
dts: Move pca95xx device from I2C0 to I2C1 on mec15xxevb

### DIFF
--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -92,6 +92,13 @@
 	port_sel = <0>;
 	sda-gpios = <&gpio_000_036 3 0>;
 	scl-gpios = <&gpio_000_036 4 0>;
+};
+
+&i2c_smb_1 {
+	status = "okay";
+	port_sel = <1>;
+	sda-gpios = <&gpio_100_136 24 0>;
+	scl-gpios = <&gpio_100_136 25 0>;
 
 	pca9555@26 {
 		compatible = "nxp,pca95xx";
@@ -108,13 +115,6 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 	};
-};
-
-&i2c_smb_1 {
-	status = "okay";
-	port_sel = <1>;
-	sda-gpios = <&gpio_100_136 24 0>;
-	scl-gpios = <&gpio_100_136 25 0>;
 };
 
 &i2c_smb_2 {


### PR DESCRIPTION
The on board device pca95xx is connected to I2C1, not I2C0

Fixes: #48071

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>