### PR TITLE
dac: remove Kconfig.defconfig setting of DAC drivers

### DIFF
--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -17,9 +17,6 @@ if BOARD_BL5340_DVK_CPUAPP
 
 if DAC
 
-config DAC_MCP4725
-	default y
-
 config I2C
 	default y
 

--- a/boards/arm/bl5340_dvk/Kconfig.defconfig
+++ b/boards/arm/bl5340_dvk/Kconfig.defconfig
@@ -20,9 +20,6 @@ if DAC
 config DAC_MCP4725
 	default y
 
-config DAC_INIT_PRIORITY
-	default 80
-
 config I2C
 	default y
 

--- a/boards/arm/bl652_dvk/Kconfig.defconfig
+++ b/boards/arm/bl652_dvk/Kconfig.defconfig
@@ -16,9 +16,6 @@ if DAC
 config DAC_MCP4725
 	default y
 
-config DAC_INIT_PRIORITY
-	default 80
-
 config I2C
 	default y
 

--- a/boards/arm/bl652_dvk/Kconfig.defconfig
+++ b/boards/arm/bl652_dvk/Kconfig.defconfig
@@ -13,9 +13,6 @@ config BT_CTLR
 
 if DAC
 
-config DAC_MCP4725
-	default y
-
 config I2C
 	default y
 

--- a/boards/arm/bl653_dvk/Kconfig.defconfig
+++ b/boards/arm/bl653_dvk/Kconfig.defconfig
@@ -17,9 +17,6 @@ config BT_CTLR
 
 if DAC
 
-config DAC_MCP4725
-	default y
-
 config I2C
 	default y
 

--- a/boards/arm/bl653_dvk/Kconfig.defconfig
+++ b/boards/arm/bl653_dvk/Kconfig.defconfig
@@ -20,9 +20,6 @@ if DAC
 config DAC_MCP4725
 	default y
 
-config DAC_INIT_PRIORITY
-	default 80
-
 config I2C
 	default y
 

--- a/boards/arm/bl654_dvk/Kconfig.defconfig
+++ b/boards/arm/bl654_dvk/Kconfig.defconfig
@@ -16,9 +16,6 @@ if DAC
 config DAC_MCP4725
 	default y
 
-config DAC_INIT_PRIORITY
-	default 80
-
 config I2C
 	default y
 

--- a/boards/arm/bl654_dvk/Kconfig.defconfig
+++ b/boards/arm/bl654_dvk/Kconfig.defconfig
@@ -13,9 +13,6 @@ config BT_CTLR
 
 if DAC
 
-config DAC_MCP4725
-	default y
-
 config I2C
 	default y
 

--- a/boards/shields/dac80508_evm/Kconfig.defconfig
+++ b/boards/shields/dac80508_evm/Kconfig.defconfig
@@ -11,9 +11,6 @@ config SPI
 config DAC_DACX0508
 	default y
 
-config DAC_INIT_PRIORITY
-	default 80
-
 endif # DAC
 
 endif # SHIELD_DAC80508_EVM

--- a/boards/shields/dac80508_evm/Kconfig.defconfig
+++ b/boards/shields/dac80508_evm/Kconfig.defconfig
@@ -8,9 +8,6 @@ if DAC
 config SPI
 	default y
 
-config DAC_DACX0508
-	default y
-
 endif # DAC
 
 endif # SHIELD_DAC80508_EVM

--- a/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
@@ -8,9 +8,6 @@ if SOC_FAMILY_SAM0
 config COUNTER_SAM0_TC32
 	default COUNTER
 
-config DAC_SAM0
-	default DAC
-
 config DMA_SAM0
 	default DMA
 

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
@@ -8,10 +8,6 @@ if SOC_MK22F51212
 config SOC
 	default "mk22f51212"
 
-config DAC_MCUX_DAC
-	default y
-	depends on DAC
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -12,10 +12,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 86
 
-config DAC_MCUX_DAC
-	default y
-	depends on DAC
-
 config CAN_MCUX_FLEXCAN
 	default y
 	depends on CAN

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
@@ -12,10 +12,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 100
 
-config DAC_MCUX_DAC
-	default y
-	depends on DAC
-
 config CAN_MCUX_FLEXCAN
 	default y
 	depends on CAN

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
@@ -54,10 +54,6 @@ config SOC_FLASH_MCUX
 	default y
 	depends on FLASH
 
-config DAC_MCUX_DAC32
-	default y
-	depends on DAC
-
 config DMA_MCUX_EDMA
 	default y
 	depends on DMA


### PR DESCRIPTION
Now that DAC drivers are enabled based on devicetree
we need to remove any cases of them getting enabled by
Kconfig.defconfig* files as this can lead to errors.

Typically the Kconfig.defconfig* will blindly enable a
sensor and not respect the devicetree state of the DAC.
Additionally we can get problems with prj.conf/defconfig
getting incorrectly overridden.

Signed-off-by: Kumar Gala <galak@kernel.org>