### PR TITLE
modules: lvgl: Remove Kconfig symbols that dont exist

### DIFF
--- a/modules/Kconfig.lvgl
+++ b/modules/Kconfig.lvgl
@@ -9,15 +9,6 @@ config LVGL
 
 if LVGL
 
-config LV_Z_DISPLAY_DEV_NAME
-	string
-
-config LV_Z_HOR_RES_MAX
-	int
-
-config LV_Z_VER_RES_MAX
-	int
-
 config LV_Z_POINTER_KSCAN
 	bool
 


### PR DESCRIPTION
LV_Z_DISPLAY_DEV_NAME, LV_Z_HOR_RES_MAX, & LV_Z_VER_RES_MAX
Kconfig symbols don't exist anymore.  They got removed in
recent devicetree update of lvgl module.  So remove them from
modules/Kconfig.lvgl.

Signed-off-by: Kumar Gala <galak@kernel.org>