### PR TITLE
tests: subsys: pm: Remove unneccessary devicetree label prop

### DIFF
--- a/tests/subsys/pm/device_power_domains/app.overlay
+++ b/tests/subsys/pm/device_power_domains/app.overlay
@@ -1,19 +1,16 @@
 / {
 	test_reg_0: test_reg_0 {
 		compatible = "power-domain-gpio";
-		label = "test-reg-0";
 		enable-gpios = <&gpio0 0 0>;
 	};
 
 	test_reg_1: test_reg_1 {
 		compatible = "power-domain-gpio";
-		label = "test-reg-1";
 		enable-gpios = <&gpio0 1 0>;
 	};
 
 	test_reg_chained: test_reg_chained {
 		compatible = "power-domain-gpio";
-		label = "test-reg-chained";
 		enable-gpios = <&gpio0 2 0>;
 		power-domain = <&test_reg_0>;
 	};

--- a/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
+++ b/tests/subsys/pm/power_mgmt/boards/native_posix.overlay
@@ -6,17 +6,14 @@
 
 / {
 	device_a: device_a {
-		label = "device_a";
 		compatible = "test-device-pm";
 	};
 
 	device_b: device_b {
-		label = "device_b";
 		compatible = "test-device-pm";
 	};
 
 	device_c: device_c {
-		label = "device_c";
 		compatible = "test-device-pm";
 	};
 };


### PR DESCRIPTION
Remove "label" properties that are not used from devicetree
overlay files.

Signed-off-by: Kumar Gala <galak@kernel.org>