### PR TITLE
Bluetooth: df: Fix reference antenna repeat after switch pattern exhausted

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/hal/nrf5/radio/radio_df.c
@@ -34,7 +34,7 @@
 	FOR_EACH(fn, sep, 0, 1, 2, 3, 4, 5, 6, 7)
 
 /* Index of antenna id in antenna switching pattern used for GUARD and REFERENCE period */
-#define GUARD_REF_ANTENNA_PATTERN_IDX 1U
+#define GUARD_REF_ANTENNA_PATTERN_IDX 0U
 
 /* Direction Finding antenna matrix configuration */
 struct df_ant_cfg {


### PR DESCRIPTION
Direction finding functionality does antenna switching during CTE
reception in AoA mode and CTE transmission in AoD mode. Antennas are
switched according to user provided antenna switch pattern. If a CTE
length is enough to exhaust all antenna ids in a switch pattern then
Radio should loopback to reference antenna and continue from switching
from it.

Current implementation loops back to wrong antenna due to wrong index
used in GUARD_REF_ANTENNA_PATTERN_IDX. It was set to one instead of
zero. Zero is the index of reference antenna in Host provided antenna
switching pattern array.

Signed-off-by: Piotr Pryga <piotr.pryga@nordicsemi.no>