### PR TITLE
boards: tlsr9518adk80d: remove list of supported samples

### DIFF
--- a/boards/riscv/tlsr9518adk80d/doc/index.rst
+++ b/boards/riscv/tlsr9518adk80d/doc/index.rst
@@ -79,48 +79,6 @@ The Zephyr TLSR9518ADK80D board configuration supports the following hardware fe
 | ADC            | on-chip    | adc                          |
 +----------------+------------+------------------------------+
 
-The following example projects are supported:
-
-- samples/hello_world
-- samples/synchronization
-- samples/philosophers
-- samples/basic/threads
-- samples/basic/blinky
-- samples/basic/blinky_pwm
-- samples/basic/fade_led
-- samples/basic/button
-- samples/subsys/nvs
-- samples/subsys/console/echo
-- samples/subsys/console/getchar
-- samples/subsys/console/getline
-- samples/subsys/shell/shell_module
-- samples/subsys/cpp/cpp_synchronization
-- samples/drivers/flash_shell
-- samples/net/sockets/echo_client (OpenThread and IEEE802154)
-- samples/net/sockets/echo_server (OpenThread and IEEE802154)
-- samples/net/openthread/coprocessor
-- samples/bluetooth/beacon
-- samples/bluetooth/broadcaster
-- samples/bluetooth/central
-- samples/bluetooth/central_hr
-- samples/bluetooth/central_ht
-- samples/bluetooth/central_multilink
-- samples/bluetooth/eddystone
-- samples/bluetooth/observer
-- samples/bluetooth/peripheral
-- samples/bluetooth/peripheral_csc
-- samples/bluetooth/peripheral_dis
-- samples/bluetooth/peripheral_esp
-- samples/bluetooth/peripheral_hids
-- samples/bluetooth/peripheral_hr
-- samples/bluetooth/peripheral_ht
-- samples/bluetooth/peripheral_identity
-- samples/bluetooth/peripheral_ots
-- samples/bluetooth/peripheral_sc_only
-- samples/bluetooth/scan_adv
-- samples/subsys/mgmt/mcumgr/smp_svr/
-- samples/drivers/adc
-
 .. note::
    To support "button" example project PC3-KEY3 (J20-19, J20-20) jumper needs to be removed and KEY3 (J20-19) should be connected to VDD3_DCDC (J51-13) externally.
 


### PR DESCRIPTION
Sample compatibility should be determined by the sample.yaml in each
sample directory. Keeping a list in board documentation isn't a good
idea: easy to get outdated, it doesn't cover all compatible samples,
etc.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>