### PR TITLE
tests: net: socket: tcp: Disable preempt test for mps2_an385

### DIFF
--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -12,3 +12,7 @@ tests:
     extra_configs:
       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
       - CONFIG_NET_TCP_RANDOMIZED_RTO=n
+    # FIXME: This test fails very frequently on mps2_an385 due to the system
+    #        timer stability issues, so keep it disabled until the root cause
+    #        is fixed (GitHub issue zephyrproject-rtos/zephyr#48608).
+    platform_exclude: mps2_an385


### PR DESCRIPTION
This commit disables the `net.socket.tcp.preempt` test on the
`mps2_an385` platform because it fails very frequently due to the
system timer stability issues.

For more details, refer to the issue zephyrproject-rtos/zephyr#48608.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>