### PR TITLE
Add cmock and unity support

### DIFF
--- a/subsys/testsuite/CMakeLists.txt
+++ b/subsys/testsuite/CMakeLists.txt
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 add_subdirectory_ifdef(CONFIG_ZTEST ztest)
+add_subdirectory_ifdef(CONFIG_UNITY unity)
+add_subdirectory_ifdef(CONFIG_CMOCK cmock)
 
 if(CONFIG_TEST)
   zephyr_include_directories(${ZEPHYR_BASE}/subsys/testsuite/include)

--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -4,6 +4,8 @@
 menu "Testing"
 
 source "subsys/testsuite/ztest/Kconfig"
+source "subsys/testsuite/cmock/Kconfig"
+source "subsys/testsuite/unity/Kconfig"
 
 config TEST
 	bool "Mark project as a test"

--- a/subsys/testsuite/cmock/CMakeLists.txt
+++ b/subsys/testsuite/cmock/CMakeLists.txt
@@ -1,0 +1,128 @@
+# Copyright (c) 2022 Swedish Embedded Consulting Group AB
+# Author: Martin Schröder <martin.schroder@swedishembedded.com>
+# SPDX-License-Identifier: Apache-2.0
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+zephyr_library()
+
+# set the directory where cmock has been checked out by west
+set_property(GLOBAL PROPERTY CMOCK_DIR ${ZEPHYR_BASE}/../modules/test/cmock)
+# need to also import it into current file so it can be used
+get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
+
+# locate cmock config file
+set(CMOCK_CONFIG_FILE
+    ${CMAKE_CURRENT_LIST_DIR}/cmock_cfg.yaml
+    CACHE STRING "")
+
+# check if we have ruby executable
+find_program(RUBY_PATH ruby)
+if(${RUBY_PATH} STREQUAL RUBY_PATH-NOTFOUND)
+  message(FATAL_ERROR "Ruby executable not found")
+endif()
+
+# add cmock include directories to our build
+zephyr_include_directories(${CMOCK_DIR}/src ${CMAKE_CURRENT_LIST_DIR})
+
+# add cmock sources
+zephyr_library_sources(${CMOCK_DIR}/src/cmock.c)
+
+function(cmock_gen_mocks HEADER_FILE OUTPUT_DIRECTORY)
+  get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
+  # configure prefix for mock file
+  set(MOCK_FILE_PREFIX mock_)
+  # get filename without extension
+  get_filename_component(FILE_NAME "${HEADER_FILE}" NAME_WE)
+  # compute output file name
+  set(MOCK_FILE ${OUTPUT_DIRECTORY}/${MOCK_FILE_PREFIX}${FILE_NAME}.c)
+  # create the output directory
+  file(MAKE_DIRECTORY "${OUTPUT_DIRECTORY}")
+
+  add_custom_command(
+    OUTPUT ${MOCK_FILE}
+    COMMAND
+      ${RUBY_PATH} ${CMOCK_DIR}/lib/cmock.rb --mock_prefix=${MOCK_FILE_PREFIX}
+      --mock_path=${OUTPUT_DIRECTORY} -o${CMOCK_CONFIG_FILE} ${HEADER_FILE}
+    DEPENDS ${HEADER_FILE} ${CMOCK_CONFIG_FILE}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  target_sources(app PRIVATE ${MOCK_FILE})
+endfunction()
+
+function(cmock_add_linker_wrap_functions FUNCTION_LIST_FILE)
+  file(STRINGS ${FUNCTION_LIST_FILE} CONTENT)
+  if(CONTENT)
+    set(LINKER_OPTS "-Wl")
+  endif()
+  foreach(FUNC_NAME ${CONTENT})
+    set(LINKER_OPTS "${LINKER_OPTS},--wrap=${FUNC_NAME}")
+  endforeach()
+  zephyr_link_libraries(${LINKER_OPTS})
+endfunction()
+
+function(cmock_add_linker_wraps HEADER_PATH)
+  set(FUNCTION_LIST_FILE "${HEADER_PATH}.flist")
+
+  execute_process(
+    COMMAND
+      ${PYTHON_EXECUTABLE} ${ZEPHYR_TESTING_MODULE_DIR}/cmock/gen_function_list.py
+      --input ${HEADER_PATH} --output ${FUNCTION_LIST_FILE}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE RETURN_CODE
+    OUTPUT_VARIABLE SCRIPT_OUTPUT)
+
+  if(NOT ${RETURN_CODE} EQUAL 0)
+    message(SEND_ERROR "${RETURN_CODE}")
+    message(FATAL_ERROR "Error generating function list from ${HEADER_PATH}")
+  endif()
+  cmock_add_linker_wrap_functions(${FUNCTION_LIST_FILE})
+endfunction()
+
+function(cmock_gen_headers IN_HEADER OUT_HEADER WRAP_HEADER)
+  execute_process(
+    COMMAND ${PYTHON_EXECUTABLE} ${ZEPHYR_TESTING_MODULE_DIR}/cmock/gen_headers.py
+            --input ${IN_HEADER} --output ${OUT_HEADER} --wrap ${WRAP_HEADER}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+    RESULT_VARIABLE RETURN_CODE
+    OUTPUT_VARIABLE SCRIPT_OUTPUT)
+
+  if(NOT ${op_result} EQUAL 0)
+    message(SEND_ERROR "${SCRIPT_OUTPUT}")
+    message(FATAL_ERROR "Error parsing header ${IN_HEADER}")
+  endif()
+endfunction()
+
+function(cmock_generate_mocks HEADER_PATH OUTPUT_PATH_PREFIX)
+  # get the global cmock directory
+  get_property(CMOCK_DIR GLOBAL PROPERTY CMOCK_DIR)
+
+  # specify output as build/mocks
+  set(CMOCK_OUTPUT_DIR ${APPLICATION_BINARY_DIR}/mocks)
+
+  # specify output path for headers
+  set(HEADER_OUTPUT_DIR "${CMOCK_OUTPUT_DIR}/${OUTPUT_PATH_PREFIX}")
+
+  # make <prefix>/internal
+  file(MAKE_DIRECTORY "${HEADER_OUTPUT_DIR}/internal")
+
+  # get header filename
+  get_filename_component(HEADER_FILE "${HEADER_PATH}" NAME)
+
+  # modified header path
+  set(MODIFIED_HEADER_PATH "${HEADER_OUTPUT_DIR}/${HEADER_FILE}")
+
+  # wrapper header path
+  set(WRAP_HEADER_PATH "${HEADER_OUTPUT_DIR}/internal/${HEADER_FILE}")
+
+  # prepare headers
+  cmock_gen_headers(${HEADER_PATH} ${MODIFIED_HEADER_PATH} ${WRAP_HEADER_PATH})
+  cmock_gen_mocks(${WRAP_HEADER_PATH} ${HEADER_OUTPUT_DIR})
+
+  # add linker options to wrap the functions
+  cmock_add_linker_wraps(${MODIFIED_HEADER_PATH})
+
+  # add the output directory to include path before all other paths
+  target_include_directories(app BEFORE PRIVATE ${CMOCK_OUTPUT_DIR}/)
+
+  message(STATUS "Generating mocks for ${HEADER_PATH}")
+endfunction()

--- a/subsys/testsuite/cmock/Kconfig
+++ b/subsys/testsuite/cmock/Kconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Martin Schröder <martin.schroder@swedishembedded.com>
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+config CMOCK
+	bool "Use CMock mocking framework"
+	select TEST
+	depends on UNITY
+	help
+			This option enables CMock testing.

--- a/subsys/testsuite/cmock/cmock_cfg.yaml
+++ b/subsys/testsuite/cmock/cmock_cfg.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Martin Schröder <info@swedishembedded.com>
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+:cmock:
+    :plugins:
+        - :ignore
+        - :ignore_arg
+        - :array
+        - :callback
+        - :return_thru_ptr
+        - :expect_any_args
+    :treat_externs: :include
+    :when_ptr: :compare_data
+    :callback_after_arg_check: true
+    :exclude_setjmp_h: true
+    :treat_as:
+        'int8_t': 'INT8'
+        'uint8_t': 'HEX8'
+        'int16_t': 'INT16'
+        'uint16_t': 'HEX16'
+        'int32_t': 'INT32'
+        'uint32_t': 'HEX32'
+        'int64_t': 'INT64'
+        'uint64_t': 'HEX64'

--- a/subsys/testsuite/cmock/cmock_unit.h
+++ b/subsys/testsuite/cmock/cmock_unit.h
@@ -1,0 +1,16 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright 2022 Martin Schröder <info@swedishembedded.com>
+ * This file should be included into every unit test before the unit under test!
+ * Consulting: https://swedishembedded.com/go
+ * Training: https://swedishembedded.com/tag/training
+ **/
+
+#ifndef CMOCK_UNIT_H_
+#define CMOCK_UNIT_H_
+
+/** Remove the device tree driver init macro */
+#undef DT_INST_FOREACH_STATUS_OKAY
+#define DT_INST_FOREACH_STATUS_OKAY(macro)
+
+#endif

--- a/subsys/testsuite/cmock/gen_function_list.py
+++ b/subsys/testsuite/cmock/gen_function_list.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Martin Schröder
+
+import argparse
+import clang.cindex
+from clang.cindex import CursorKind
+
+# These are blacklisted because they are used early during init
+# meaning that nothing is initialized yet - so we don't wrap them
+blacklist = [
+    "__errno_location",
+    "k_work_queue_start",
+    "z_init_static_threads",
+    "k_sched_lock",
+    "k_sched_unlock",
+]
+
+
+def dump_functions(in_file, out_file):
+    with open(out_file, "w") as f_out:
+        index = clang.cindex.Index.create()
+        tu = index.parse(in_file)
+        for c in tu.cursor.walk_preorder():
+            if c.kind == CursorKind.FUNCTION_DECL:
+                if c.spelling not in blacklist:
+                    f_out.write(c.spelling + "\n")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i", "--input", type=str, help="Input header to parse", required=True
+    )
+    parser.add_argument(
+        "-o", "--output", type=str, help="Output file for function list", required=True
+    )
+    args = parser.parse_args()
+
+    dump_functions(args.input, args.output)

--- a/subsys/testsuite/cmock/gen_headers.py
+++ b/subsys/testsuite/cmock/gen_headers.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Martin Schröder
+import re
+import argparse
+
+
+def gen_headers(header, output, output_wrap):
+    with open(header) as header_file:
+        content = header_file.read()
+
+    # Change static inline declarations to normal declarations
+    pattern = re.compile(
+        r"(?:__deprecated\s+|static\s+inline\s+)?(?:static\s+inline\s+|static\s+ALWAYS_INLINE\s+|__deprecated\s+)"
+        r"((?:\w+[*\s]+)+\w+?\(.*?\))\n\{.+?\n\}",
+        re.M | re.S,
+    )
+    content = pattern.sub(r"\1;", content)
+
+    # Remove externs, but only function externs (there are extern variables as well)
+    pattern = re.compile(r"extern\s+((?:\w+[*\s]+)+\w+?\(.*?\);)", re.M | re.S)
+    content = pattern.sub(r"\1", content)
+
+    # Delete anything that matches these patterns completely
+    patterns = [
+        r"/\*("  # group match for 'any number of'
+        r"[^*]|"  # any number of non '*'
+        r"[\r\n]|"  # any number of return or new lines
+        r"(\*+([^*/]|[\r\n]))"  # any number of ('*' followed by not '*/') or (newlines)
+        r")*"  # end group for any number of
+        r"\*+/",  # ending with any number of '*' followed by slash '/'
+    ]
+    for pattern in patterns:
+        pattern = re.compile(pattern, re.M | re.S)
+        content = pattern.sub(r"", content)
+
+    # Single line patterns
+    patterns = [
+        # Remove C++ comments
+        r"//.*[\r\n]",
+        # Remove syscalls because we will have duplicate declarations there
+        r"#include <syscalls/\w+?.h>",
+        # Remove attributes that mess up mock generation
+        r"__syscall\s+",
+        r"FUNC_NORETURN\s+",
+        r"static\s+inline\s+",
+        r"static\s+ALWAYS_INLINE\s+",
+        r"__STATIC_INLINE\s+",
+        r"inline\s+static\s+",
+        r"__attribute_const__\s+",
+        r"__deprecated\s+",
+        r"__printf_like\(.*\)",
+        r"BUILD_ASSERT\(.*\);",
+    ]
+    for pattern in patterns:
+        pattern = re.compile(pattern)
+        content = pattern.sub(r"", content)
+
+    # Treat as always enabled because otherwise futex mocks fail to compile
+    pattern = re.compile(r"ifdef CONFIG_USERSPACE\s+", re.M | re.S)
+    content = pattern.sub("if 1\n", content)
+
+    with open(output, "w") as output_file:
+        output_file.write(content)
+
+    # Prefix all function names with __wrap_ prefix
+    pattern = re.compile(r"^\s*((?:\w+[*\s]+)+)(\w+?\s*\([^\\{}#]*?\)\s*;)", re.M)
+    content = pattern.sub(r"\n\1__wrap_\2", content)
+
+    with open(output_wrap, "w") as output_file:
+        output_file.write(content)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i", "--input", type=str, help="Input header file", required=True
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=str,
+        help="Cleaned up header file to be included in the unit test",
+        required=True,
+    )
+    parser.add_argument(
+        "-w",
+        "--wrap",
+        type=str,
+        help="Header with __wrap_ prefixes for mock generation",
+        required=True,
+    )
+    args = parser.parse_args()
+
+    gen_headers(args.input, args.output, args.wrap)

--- a/subsys/testsuite/unity/CMakeLists.txt
+++ b/subsys/testsuite/unity/CMakeLists.txt
@@ -1,0 +1,62 @@
+# Copyright (c) 2022 Swedish Embedded Consulting Group AB
+# Author: Martin Schröder <martin.schroder@swedishembedded.com>
+# SPDX-License-Identifier: Apache-2.0
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+zephyr_library()
+
+# locate unity directory
+set_property(GLOBAL PROPERTY UNITY_DIR
+                             ${ZEPHYR_BASE}/../modules/test/cmock/vendor/unity)
+# need to also import it into current file so it can be used
+get_property(UNITY_DIR GLOBAL PROPERTY UNITY_DIR)
+
+# locate unity config file
+set(UNITY_CONFIG_FILE
+    ${CMAKE_CURRENT_LIST_DIR}/unity_cfg.yaml
+    CACHE STRING "")
+
+# check if we have ruby executable
+find_program(RUBY_PATH ruby)
+if(${RUBY_PATH} STREQUAL RUBY_PATH-NOTFOUND)
+  message(FATAL_ERROR "Ruby executable not found")
+endif()
+
+# add unity include directories to our build
+zephyr_include_directories(${UNITY_DIR}/src ${CMAKE_CURRENT_LIST_DIR})
+
+# add unity sources
+zephyr_library_sources(${UNITY_DIR}/src/unity.c)
+
+# add glue source code to build
+zephyr_library_sources(teardown.c)
+zephyr_library_sources(main.c)
+
+# instruct unity to include "unity_config.h" file
+zephyr_compile_definitions(UNITY_INCLUDE_CONFIG_H)
+
+# function for generating the test runner
+function(unity_generate_test_runner TEST_FILE_PATH)
+  # get the global setting
+  get_property(UNITY_DIR GLOBAL PROPERTY UNITY_DIR)
+  # will be placed in build/runner
+  set(UNITY_OUTPUT_DIR ${APPLICATION_BINARY_DIR}/runner)
+  # create the directory
+  file(MAKE_DIRECTORY "${UNITY_OUTPUT_DIR}")
+  # get filename with extension
+  get_filename_component(TEST_FILE_NAME "${TEST_FILE_PATH}" NAME)
+  set(OUTPUT_FILE_PATH "${UNITY_OUTPUT_DIR}/runner_${TEST_FILE_NAME}")
+  # add command for building this runner file
+  add_custom_command(
+    COMMAND ${RUBY_PATH} ${UNITY_DIR}/auto/generate_test_runner.rb
+            ${UNITY_CONFIG_FILE} ${TEST_FILE_PATH} ${OUTPUT_FILE_PATH}
+    DEPENDS ${TEST_FILE_PATH} ${UNITY_CONFIG_FILE}
+    OUTPUT ${OUTPUT_FILE_PATH}
+    WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  # add the generated file to build
+  target_sources(app PRIVATE ${OUTPUT_FILE_PATH})
+
+  message(
+    STATUS "Generating test runner ${OUTPUT_FILE_PATH} for ${TEST_FILE_PATH}")
+endfunction()

--- a/subsys/testsuite/unity/Kconfig
+++ b/subsys/testsuite/unity/Kconfig
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Martin Schröder <info@swedishembedded.com>
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+config UNITY
+	bool "Use Unity unit test framework"
+	select TEST
+	depends on !ZTEST
+	help
+			This enables unity test framework which you should use instead of ZTEST.

--- a/subsys/testsuite/unity/main.c
+++ b/subsys/testsuite/unity/main.c
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright 2022 Martin Schröder <info@swedishembedded.com>
+ * Consulting: https://swedishembedded.com/go
+ * Training: https://swedishembedded.com/tag/training
+ **/
+
+#include <zephyr/sys/printk.h>
+#include <unity.h>
+#ifdef CONFIG_BOARD_NATIVE_POSIX
+#include "posix_board_if.h"
+#include "cmdline.h"
+#endif
+
+void main(void)
+{
+#ifdef CONFIG_BOARD_NATIVE_POSIX
+	printk("Parsing command line arguments\n");
+	int argc;
+	char **argv;
+
+	native_get_test_cmd_line_args(&argc, &argv);
+	posix_exit(unity_main(argc, argv));
+#else
+	printk("Ignoring command line arguments\n");
+	unity_main(0, NULL);
+#endif
+}

--- a/subsys/testsuite/unity/teardown.c
+++ b/subsys/testsuite/unity/teardown.c
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright 2022 Martin Schröder <info@swedishembedded.com>
+ * Consulting: https://swedishembedded.com/go
+ * Training: https://swedishembedded.com/tag/training
+ **/
+
+#include <zephyr/sys/printk.h>
+#ifdef CONFIG_BOARD_NATIVE_POSIX
+#include "posix_board_if.h"
+#endif
+
+int generic_test_suite_teardown(int num_failures)
+{
+	int ret = num_failures > 0 ? 1 : 0;
+
+	printk("PROJECT EXECUTION %s\n", (num_failures) ? "FAILED" : "SUCCESSFUL");
+#ifdef CONFIG_BOARD_NATIVE_POSIX
+	posix_exit(ret);
+#endif
+	return ret;
+}
+
+__weak int __unused test_suite_teardown(int num_failures)
+{
+	return generic_test_suite_teardown(num_failures);
+}

--- a/subsys/testsuite/unity/unity_cfg.yaml
+++ b/subsys/testsuite/unity/unity_cfg.yaml
@@ -1,0 +1,10 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Martin Schröder <info@swedishembedded.com>
+# Consulting: https://swedishembedded.com/go
+# Training: https://swedishembedded.com/tag/training
+
+:unity:
+    :suite_teardown: >
+       extern int test_suite_teardown(int); return test_suite_teardown(num_failures);
+    :main_name: unity_main
+    :cmdline_args: true

--- a/subsys/testsuite/unity/unity_config.h
+++ b/subsys/testsuite/unity/unity_config.h
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/**
+ * Copyright 2022 Martin Schröder <info@swedishembedded.com>
+ * Consulting: https://swedishembedded.com/go
+ * Training: https://swedishembedded.com/tag/training
+ **/
+
+#ifndef UNITY_CONFIG_H__
+#define UNITY_CONFIG_H__
+
+#define UNITY_OUTPUT_COLOR
+#define UNITY_USE_COMMAND_LINE_ARGS
+
+#ifndef CONFIG_BOARD_NATIVE_POSIX
+#include <stddef.h>
+#include <stdio.h>
+#define UNITY_EXCLUDE_SETJMP_H 1
+#define UNITY_OUTPUT_CHAR(a) printf("%c", a)
+#endif
+
+extern int unity_main(int argc, char **argv);
+
+#endif

--- a/tests/cmock/example/CMakeLists.txt
+++ b/tests/cmock/example/CMakeLists.txt
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(test)
+
+if(CONFIG_CMOCK)
+  unity_generate_test_runner(src/unit.c)
+  cmock_generate_mocks(${ZEPHYR_BASE}/include/kernel.h .)
+  target_sources(app PRIVATE src/unit.c)
+else()
+  unity_generate_test_runner(src/integration.c)
+  target_sources(app PRIVATE src/integration.c)
+endif()

--- a/tests/cmock/example/prj.conf
+++ b/tests/cmock/example/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_UNITY=y

--- a/tests/cmock/example/src/integration.c
+++ b/tests/cmock/example/src/integration.c
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2022 Martin Schröder Consulting
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <unity.h>
+
+void test_integration_example(void)
+{
+	TEST_ASSERT_EQUAL(0, 0);
+}

--- a/tests/cmock/example/src/unit.c
+++ b/tests/cmock/example/src/unit.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Martin Schröder Consulting
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <unity.h>
+#include <mock_kernel.h>
+
+/**
+ * this is a unit test so we will include the file directly
+ * this is the only place where we do this - it is the optimal solution.
+ * #include "../../../../../some/driver/we/are/unit/testing/driver.c"
+ **/
+
+void test_example_object_init_should_return_einval_on_invalid_args(void)
+{
+	/**
+	 * Here you can use mocks of any kernel functions
+	 * __wrap_k_mutex_init_ExpectAndReturn(&inst.mx, 0);
+	 * TEST_ASSERT_EQUAL(0, _some_driver_function(&inst));
+	 **/
+}

--- a/tests/cmock/example/testcase.yaml
+++ b/tests/cmock/example/testcase.yaml
@@ -1,0 +1,7 @@
+tests:
+  tests.cmock.example.unit:
+    extra_configs:
+      - CONFIG_CMOCK=y
+    platform_allow: native_posix
+  tests.cmock.example.integration:
+    platform_allow: native_posix

--- a/west.yml
+++ b/west.yml
@@ -21,7 +21,8 @@ manifest:
   remotes:
     - name: upstream
       url-base: https://github.com/zephyrproject-rtos
-
+    - name: throwtheswitch
+      url-base: https://github.com/ThrowTheSwitch
   #
   # Please add items below based on alphabetical order
   projects:
@@ -262,7 +263,14 @@ manifest:
     - name: zscilib
       path: modules/lib/zscilib
       revision: ca070ddabdaf67175a2da901d0bd62e8899371c5
-
+    - name: cmock
+      path: modules/test/cmock
+      revision: f65066f15d8248e6dcb778efb8739904a4512087
+      remote: throwtheswitch
+    - name: unity
+      path: modules/test/cmock/vendor/unity
+      revision: 1958b977019c3ac19bb83350f7b26e60cbeb6c75
+      remote: throwtheswitch
   self:
     path: zephyr
     west-commands: scripts/west-commands.yml


### PR DESCRIPTION
## What was done

This MR adds cmock and unity support including a custom python script that uses clang cindex to parse the headers that will be mocked and extract necessary data for mocking the functions within.

## Why is this important

This adds ability to do full 100% branch and line testing for ANY C file. Zephyr unit testing currently is very limited to what can be tested. But using this approach 100% line and branch coverage can be easily achieved. It is not strictly unit testing because we still need to link it with zephyr platform but it is much much better than any other approach I have used so far.

Using this approach we can test every static private method in any part of the system. 

## How good is the support

- kernel.h can be mocked in full
- gpio driver interface can be mocked in full
- spi interface can be mocked in full
- ... probably many more, but these are the ones I have tried so far.

You can do the following:

- Mock any function for which you can provide a header file
- Specify constraints for order of calls being made (if you enable strict order checking in cmock config)
- Specify expected arguments and return value for sequences of calls
- Specify custom callbacks for mocked functions where you can implement device specific logic (example: https://gitlab.com/swedishembedded/platform/sdk/-/blob/a42214fd59ecb07f3863248dd15d6b01b4e52b7e/tests/drivers/gpio/mcp23s17/src/unit.c)

See cmock documentation for more details: https://github.com/ThrowTheSwitch/CMock/blob/master/docs/CMock_Summary.md

Other kernel headers will have to be handled individually and support *may* need to be added to the cleanup script so that cleaned up headers can be provided to cmock.

## Example

Unit test and integration test are combined into one. This may seem clunky at first, but it avoids a lot of duplication. Integration test is run by default. You can configure two targets in your sample.yaml file that set CMOCK to y for one and drop it for the other. 

Build and run unit test:

`west build -p -b native_posix tests/cmock/example -- -DCONFIG_CMOCK=y`

Build and run integration test:

`west build -p -b native_posix tests/cmock/example
`
## Questions

- **Does unity work on all platforms?** Yes there are no limitations for unity. 
- **Does CMock work on all platforms?** Yes, but you need a lot of RAM because it uses large RAM buffers for setting up expectations. Thus it works best on native_posix (where you will be running majority of your tests anyway). 

## Known issues

Cmock in its current state crashes with latest zephyr repo. This needs to be addressed in the main cmock repository. This is why this MR is targeted at Zephyr 3.0.0 for now. 

Fixes #30391

Signed-off-by: Martin Schröder <mkschreder.uk@gmail.com>