### PR TITLE
soc: riscv: remove usage of SOC_ERET

### DIFF
--- a/arch/riscv/core/isr.S
+++ b/arch/riscv/core/isr.S
@@ -603,5 +603,4 @@ no_fp:	/* make sure this is reflected in the restored mstatus */
 	addi sp, sp, __z_arch_esf_t_SIZEOF
 #endif
 
-	/* Call SOC_ERET to exit ISR */
-	SOC_ERET
+	mret

--- a/soc/riscv/esp32c3/soc.h
+++ b/soc/riscv/esp32c3/soc.h
@@ -28,8 +28,6 @@
 #define SOC_MCAUSE_IRQ_MASK (1 << 31)
 /* Exception code Mask */
 #define SOC_MCAUSE_EXP_MASK 0x7FFFFFFF
-/* SOC-Specific EXIT ISR command */
-#define SOC_ERET mret
 
 #ifndef _ASMLANGUAGE
 

--- a/soc/riscv/openisa_rv32m1/soc_ri5cy.h
+++ b/soc/riscv/openisa_rv32m1/soc_ri5cy.h
@@ -54,13 +54,7 @@
  * what the standard allocates (which is XLEN-1 bits).
  */
 #define SOC_MCAUSE_EXP_MASK 0x1F
-/*
- * Assembler instruction to exit from interrupt in machine mode.
- * The name "ERET" is a leftover from pre-v1.10 privileged ISA specs.
- * The "mret" mnemonic works properly with the Pulpino toolchain;
- * YMMV if using a generic toolchain.
- */
-#define SOC_ERET mret
+
 /* The ecall exception number. This is a standard value. */
 #define SOC_MCAUSE_ECALL_EXP 11
 #endif /* SOC_RISCV32_OPENISA_RV32M1_SOC_RI5CY_H_ */

--- a/soc/riscv/openisa_rv32m1/soc_zero_riscy.h
+++ b/soc/riscv/openisa_rv32m1/soc_zero_riscy.h
@@ -42,13 +42,7 @@
  * what the standard allocates (which is XLEN-1 bits).
  */
 #define SOC_MCAUSE_EXP_MASK 0x1F
-/*
- * Assembler instruction to exit from interrupt in machine mode.
- * The name "ERET" is a leftover from pre-v1.10 privileged ISA specs.
- * The "mret" mnemonic works properly with the Pulpino toolchain;
- * YMMV if using a generic toolchain.
- */
-#define SOC_ERET mret
+
 /* The ecall exception number. This is a standard value. */
 #define SOC_MCAUSE_ECALL_EXP 11
 

--- a/soc/riscv/riscv-ite/common/soc_common.h
+++ b/soc/riscv/riscv-ite/common/soc_common.h
@@ -25,9 +25,6 @@
 /* Exception code of environment call from M-mode */
 #define SOC_MCAUSE_ECALL_EXP         11
 
-/* SOC-Specific EXIT ISR command */
-#define SOC_ERET                     mret
-
 #ifndef _ASMLANGUAGE
 
 #if CONFIG_ITE_IT8XXX2_INTC

--- a/soc/riscv/riscv-privilege/common/soc_common.h
+++ b/soc/riscv/riscv-privilege/common/soc_common.h
@@ -32,9 +32,6 @@
 /* Exception code Mask */
 #define SOC_MCAUSE_EXP_MASK          CONFIG_RISCV_SOC_MCAUSE_EXCEPTION_MASK
 
-/* SOC-Specific EXIT ISR command */
-#define SOC_ERET                     mret
-
 #ifndef _ASMLANGUAGE
 
 #include <zephyr/drivers/interrupt_controller/riscv_clic.h>


### PR DESCRIPTION
All SOC_ERET definitions expand to the mret instruction (used to return
from a trap: exception or interruption). The 'eret' instruction existed
in previous RISC-V privileged specs, but it doesn't seem to be used in
Zephyr (ref. RISC-V Privileged Architectures 3.2.2).

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>