### PR TITLE
bluetooth: controller: Expose prpa cache for LLL use

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_filter.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_filter.h
@@ -80,6 +80,14 @@ struct lll_resolve_list {
 #endif /* CONFIG_BT_CTLR_SYNC_PERIODIC_ADV_LIST */
 };
 
+#if defined(CONFIG_BT_CTLR_SW_DEFERRED_PRIVACY)
+/* Cache of known unknown peer RPAs */
+struct lll_prpa_cache {
+	uint8_t   taken:1;
+	bt_addr_t rpa;
+};
+#endif
+
 extern uint8_t ull_filter_lll_fal_match(struct lll_filter const *const filter,
 					uint8_t addr_type,
 					uint8_t const *const addr,
@@ -102,6 +110,7 @@ extern bool ull_filter_lll_rl_addr_resolve(uint8_t id_addr_type,
 					   uint8_t rl_idx);
 extern bool ull_filter_lll_rl_enabled(void);
 #if defined(CONFIG_BT_CTLR_SW_DEFERRED_PRIVACY)
+extern const struct lll_prpa_cache *ull_filter_lll_prpa_cache_get(void);
 typedef void (*resolve_callback_t)(void *param);
 extern uint8_t ull_filter_deferred_resolve(bt_addr_t *rpa,
 					resolve_callback_t cb);

--- a/subsys/bluetooth/controller/ll_sw/ull_filter.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_filter.c
@@ -71,10 +71,7 @@ static uint8_t rl_enable;
 #if defined(CONFIG_BT_CTLR_SW_DEFERRED_PRIVACY)
 /* Cache of known unknown peer RPAs */
 static uint8_t newest_prpa;
-static struct prpa_cache_dev {
-	uint8_t      taken:1;
-	bt_addr_t rpa;
-} prpa_cache[CONFIG_BT_CTLR_RPA_CACHE_SIZE];
+static struct lll_prpa_cache prpa_cache[CONFIG_BT_CTLR_RPA_CACHE_SIZE];
 
 struct prpa_resolve_work {
 	struct k_work prpa_work;
@@ -1625,5 +1622,10 @@ static uint8_t prpa_cache_find(bt_addr_t *rpa)
 		}
 	}
 	return FILTER_IDX_NONE;
+}
+
+const struct lll_prpa_cache *ull_filter_lll_prpa_cache_get(void)
+{
+	return prpa_cache;
 }
 #endif /* !CONFIG_BT_CTLR_SW_DEFERRED_PRIVACY */


### PR DESCRIPTION
The prpa cache is now exposed through the ull_filter_lll_prpa_cache_get()
function (as the resolve list already is). This is needed to be
able to reply to AUX_CONNECT_REQ within the required time when
using SW-based RPA resolving

Signed-off-by: Troels Nilsson <trnn@demant.com>