### PR TITLE
west: runners: improve pyocd runner test coverage

### DIFF
--- a/scripts/west_commands/tests/test_pyocd.py
+++ b/scripts/west_commands/tests/test_pyocd.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import itertools
 from unittest.mock import patch
 
 import pytest
@@ -25,7 +26,7 @@ TEST_TARGET = 'test-target'
 TEST_FLASH_OPTS = ['--test-flash', 'args']
 TEST_GDB_PORT = 1
 TEST_TELNET_PORT = 2
-TEST_TOOL_OPT = 'test-opt'
+TEST_TOOL_OPTS = ['test-opt-1', 'test-opt-2']
 
 TEST_ALL_KWARGS = {
     'pyocd': TEST_PYOCD,
@@ -37,21 +38,21 @@ TEST_ALL_KWARGS = {
     'dev_id': TEST_DEV_ID,
     'frequency': TEST_FREQUENCY,
     'daparg': TEST_DAPARG,
-    'tool_opt': [TEST_TOOL_OPT],
+    'tool_opt': TEST_TOOL_OPTS
 }
 
 TEST_DEF_KWARGS = {}
 
-TEST_ALL_PARAMS = (['--target', TEST_TARGET,
-                    '--daparg', TEST_DAPARG,
-                    '--pyocd', TEST_PYOCD] +
-                   ['--flash-opt={}'.format(o) for o in
-                    TEST_FLASH_OPTS] +
-                   ['--gdb-port', str(TEST_GDB_PORT),
-                    '--telnet-port', str(TEST_TELNET_PORT),
-                    '--dev-id', TEST_DEV_ID,
-                    '--frequency', str(TEST_FREQUENCY),
-                    '--tool-opt', TEST_TOOL_OPT])
+TEST_ALL_PARAMS = list(itertools.chain(
+    ['--target', TEST_TARGET,
+     '--daparg', TEST_DAPARG,
+     '--pyocd', TEST_PYOCD],
+    [f'--flash-opt={o}' for o in TEST_FLASH_OPTS],
+    ['--gdb-port', str(TEST_GDB_PORT),
+     '--telnet-port', str(TEST_TELNET_PORT),
+     '--dev-id', TEST_DEV_ID,
+     '--frequency', str(TEST_FREQUENCY)],
+    [f'--tool-opt={o}' for o in TEST_TOOL_OPTS]))
 
 TEST_DEF_PARAMS = ['--target', TEST_TARGET]
 
@@ -73,7 +74,7 @@ FLASH_ALL_EXPECTED_CALL = ([TEST_PYOCD,
                             '-a', hex(TEST_ADDR), '-da', TEST_DAPARG,
                             '-t', TEST_TARGET, '-u', TEST_DEV_ID,
                             '-f', TEST_FREQUENCY] +
-                           [TEST_TOOL_OPT] +
+                           TEST_TOOL_OPTS +
                            TEST_FLASH_OPTS +
                            [RC_KERNEL_HEX])
 FLASH_DEF_EXPECTED_CALL = ['pyocd', 'flash', '-e', 'sector',
@@ -87,7 +88,7 @@ DEBUG_ALL_EXPECTED_SERVER = [TEST_PYOCD,
                              '-T', str(TEST_TELNET_PORT),
                              '-t', TEST_TARGET,
                              '-u', TEST_DEV_ID,
-                             '-f', TEST_FREQUENCY] + [TEST_TOOL_OPT]
+                             '-f', TEST_FREQUENCY] + TEST_TOOL_OPTS
 DEBUG_ALL_EXPECTED_CLIENT = [RC_GDB, RC_KERNEL_ELF,
                              '-ex', 'target remote :{}'.format(TEST_GDB_PORT),
                              '-ex', 'monitor halt',
@@ -112,7 +113,7 @@ DEBUGSERVER_ALL_EXPECTED_CALL = [TEST_PYOCD,
                                  '-T', str(TEST_TELNET_PORT),
                                  '-t', TEST_TARGET,
                                  '-u', TEST_DEV_ID,
-                                 '-f', TEST_FREQUENCY] + [TEST_TOOL_OPT]
+                                 '-f', TEST_FREQUENCY] + TEST_TOOL_OPTS
 DEBUGSERVER_DEF_EXPECTED_CALL = ['pyocd',
                                  'gdbserver',
                                  '-p', '3333',


### PR DESCRIPTION
Make sure that this runner can handle multiple --tool-opt arguments,
and that the options specified for pyocd are passed to that tool in
order.
