### PR TITLE
drivers: i2c: esp32: fix node identification

### DIFF
--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -687,15 +687,17 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 	return i2c_esp32_configure(dev, config->default_config);
 }
 
+#define I2C(idx) DT_NODELABEL(i2c##idx)
+
 #ifndef SOC_I2C_SUPPORT_HW_CLR_BUS
 #define I2C_ESP32_GET_PIN_INFO(idx)					\
 	.scl = {							\
-		.gpio = GPIO_DT_SPEC_INST_GET(idx, scl_gpios),		\
+		.gpio = GPIO_DT_SPEC_GET(I2C(idx), scl_gpios),		\
 		.sig_out = I2CEXT##idx##_SCL_OUT_IDX,			\
 		.sig_in = I2CEXT##idx##_SCL_IN_IDX,			\
 	},								\
 	.sda = {							\
-		.gpio = GPIO_DT_SPEC_INST_GET(idx, sda_gpios),		\
+		.gpio = GPIO_DT_SPEC_GET(I2C(idx), sda_gpios),		\
 		.sig_out = I2CEXT##idx##_SDA_OUT_IDX,			\
 		.sig_in = I2CEXT##idx##_SDA_IN_IDX,			\
 	},
@@ -708,15 +710,15 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 	: bitrate == I2C_BITRATE_FAST     ? KHZ(400)	       \
 	: bitrate == I2C_BITRATE_FAST_PLUS  ? MHZ(1) : 0)
 #define I2C_FREQUENCY(idx)						       \
-	I2C_ESP32_FREQUENCY(DT_INST_PROP(idx, clock_frequency))
+	I2C_ESP32_FREQUENCY(DT_PROP(I2C(idx), clock_frequency))
 
 #define ESP32_I2C_INIT(idx)		\
 					\
-	PINCTRL_DT_INST_DEFINE(idx);	\
+	PINCTRL_DT_DEFINE(I2C(idx));	\
 					\
 	static struct i2c_esp32_data i2c_esp32_data_##idx = {		  \
 		.hal = {	\
-			.dev = (i2c_dev_t *) DT_REG_ADDR(DT_NODELABEL(i2c##idx)),	\
+			.dev = (i2c_dev_t *) DT_REG_ADDR(I2C(idx)),	\
 		},	\
 		.cmd_sem = Z_SEM_INITIALIZER(                            \
 			i2c_esp32_data_##idx.cmd_sem, 0, 1),                 \
@@ -726,47 +728,47 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 								\
 	static const struct i2c_esp32_config i2c_esp32_config_##idx = {	       \
 	.index = idx, \
-	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)), \
-	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),	\
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset), \
+	.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(I2C(idx))), \
+	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2C(idx)),	\
+	.clock_subsys = (clock_control_subsys_t)DT_CLOCKS_CELL(I2C(idx), offset), \
 	I2C_ESP32_GET_PIN_INFO(idx)	\
 	.mode = { \
-		.tx_lsb_first = DT_INST_PROP(idx, tx_lsb), \
-		.rx_lsb_first = DT_INST_PROP(idx, rx_lsb), \
+		.tx_lsb_first = DT_PROP(I2C(idx), tx_lsb), \
+		.rx_lsb_first = DT_PROP(I2C(idx), rx_lsb), \
 	}, \
 	.irq_source = ETS_I2C_EXT##idx##_INTR_SOURCE,	\
 	.bitrate = I2C_FREQUENCY(idx),	\
 	.default_config = I2C_MODE_CONTROLLER,				\
 	};								       \
-	I2C_DEVICE_DT_DEFINE(DT_NODELABEL(i2c##idx),					       \
+	I2C_DEVICE_DT_DEFINE(I2C(idx),					       \
 		      i2c_esp32_init,					       \
 		      NULL,				       \
 		      &i2c_esp32_data_##idx,				       \
 		      &i2c_esp32_config_##idx,				       \
 		      POST_KERNEL,					       \
 		      CONFIG_I2C_INIT_PRIORITY,	       \
-		      &i2c_esp32_driver_api); \
+		      &i2c_esp32_driver_api);
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c0), okay)
+#if DT_NODE_HAS_STATUS(I2C(0), okay)
 #ifndef SOC_I2C_SUPPORT_HW_CLR_BUS
-#if !DT_INST_NODE_HAS_PROP(0, sda_gpios) || !DT_INST_NODE_HAS_PROP(0, scl_gpios)
+#if !DT_NODE_HAS_PROP(I2C(0), sda_gpios) || !DT_NODE_HAS_PROP(I2C(0), scl_gpios)
 #error "Missing <sda-gpios> and <scl-gpios> properties to build for this target."
 #endif
 #else
-#if DT_INST_NODE_HAS_PROP(0, sda_gpios) || DT_INST_NODE_HAS_PROP(0, scl_gpios)
+#if DT_NODE_HAS_PROP(I2C(0), sda_gpios) || DT_NODE_HAS_PROP(I2C(0), scl_gpios)
 #error "Properties <sda-gpios> and <scl-gpios> are not required for this target."
 #endif
 #endif
 ESP32_I2C_INIT(0);
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(i2c1), okay)
+#if DT_NODE_HAS_STATUS(I2C(1), okay)
 #ifndef SOC_I2C_SUPPORT_HW_CLR_BUS
-#if !DT_INST_NODE_HAS_PROP(1, sda_gpios) || !DT_INST_NODE_HAS_PROP(1, scl_gpios)
+#if !DT_NODE_HAS_PROP(I2C(1), sda_gpios) || !DT_NODE_HAS_PROP(I2C(1), scl_gpios)
 #error "Missing <sda-gpios> and <scl-gpios> properties to build for this target."
 #endif
 #else
-#if DT_INST_NODE_HAS_PROP(1, sda_gpios) || DT_INST_NODE_HAS_PROP(1, scl_gpios)
+#if DT_NODE_HAS_PROP(I2C(1), sda_gpios) || DT_NODE_HAS_PROP(I2C(1), scl_gpios)
 #error "Properties <sda-gpios> and <scl-gpios> are not required for this target."
 #endif
 #endif


### PR DESCRIPTION
This PR fixes the instances indexing in the driver's
initialization macros.

The use of DT_INST macros along with other node identifiers
was preventing the driver from initialize correctly in some
cases.

The driver requires the signal mux number value. Hence the need
to use the SoC's peripheral number information and DT_NODELABEL
macro for node id.

Signed-off-by: Lucas Tamborrino <lucas.tamborrino@espressif.com>