### PR TITLE
cmake: Fix linker config when using emulators

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -143,8 +143,8 @@ endif()
 zephyr_iterable_section(NAME k_p4wq_initparam KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN 4)
 
 if(CONFIG_EMUL)
-  zephyr_linker_section(NAME emulators_section GROUP RODATA_REGION)
-  zephyr_linker_section_configure(SECTION emulators_section INPUT ".emulators" KEEP SORT NAME ${XIP_ALIGN_WITH_INPUT})
+  zephyr_linker_section(NAME emulators_section GROUP RODATA_REGION ${XIP_ALIGN_WITH_INPUT})
+  zephyr_linker_section_configure(SECTION emulators_section INPUT ".emulators" KEEP SORT NAME)
 endif()
 
 if(CONFIG_DNS_SD)


### PR DESCRIPTION
XIP_ALIGN_WITH_INPUT is an argument to zephyr_linker_section, not
zephyr_linker_section_configure.

Signed-off-by: Rich Barlow <richard.barlow@gaitq.com>