### PR TITLE
tests: pm: device_wakeup_api: Fix comment on wakeup capable assert

### DIFF
--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -84,7 +84,7 @@ void test_wakeup_device_api(void)
 	zassert_not_null(dev, "Failed to get device");
 
 	ret = pm_device_wakeup_is_capable(dev);
-	zassert_true(ret, "Device marked as capable");
+	zassert_true(ret, "Device not marked as capable");
 
 	ret = pm_device_wakeup_enable(dev, true);
 	zassert_true(ret, "Could not enable wakeup source");


### PR DESCRIPTION
If assert triggers, display the current state in order not
to confuse assert message reader.
Same logic is used for following asserts.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>