### PR TITLE
boards: nucleo_l11k4: SPI device is missing pinctrl configuration

### DIFF
--- a/boards/arm/nucleo_l011k4/nucleo_l011k4.dts
+++ b/boards/arm/nucleo_l011k4/nucleo_l011k4.dts
@@ -75,6 +75,8 @@
 };
 
 &spi1 {
+	pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+	pinctrl-names = "default";
 	status = "okay";
 };
 


### PR DESCRIPTION
Add pinctrl-0 to spi1 device.

Fixes #48642

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>