### PR TITLE
boards: nrf: Activate pull-up on QSPI CSN line in "sleep" state

### DIFF
--- a/boards/arm/nrf52840_mdk/nrf52840_mdk-pinctrl.dtsi
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk-pinctrl.dtsi
@@ -88,9 +88,13 @@
 				<NRF_PSEL(QSPI_IO0, 1, 5)>,
 				<NRF_PSEL(QSPI_IO1, 1, 4)>,
 				<NRF_PSEL(QSPI_IO2, 1, 2)>,
-				<NRF_PSEL(QSPI_IO3, 1, 1)>,
-				<NRF_PSEL(QSPI_CSN, 1, 6)>;
+				<NRF_PSEL(QSPI_IO3, 1, 1)>;
 			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 1, 6)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840-pinctrl.dtsi
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840-pinctrl.dtsi
@@ -156,9 +156,13 @@
 				<NRF_PSEL(QSPI_IO0, 0, 20)>,
 				<NRF_PSEL(QSPI_IO1, 0, 21)>,
 				<NRF_PSEL(QSPI_IO2, 0, 22)>,
-				<NRF_PSEL(QSPI_IO3, 0, 23)>,
-				<NRF_PSEL(QSPI_CSN, 0, 17)>;
+				<NRF_PSEL(QSPI_IO3, 0, 23)>;
 			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 17)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common-pinctrl.dtsi
@@ -71,9 +71,13 @@
 				<NRF_PSEL(QSPI_IO0, 0, 13)>,
 				<NRF_PSEL(QSPI_IO1, 0, 14)>,
 				<NRF_PSEL(QSPI_IO2, 0, 15)>,
-				<NRF_PSEL(QSPI_IO3, 0, 16)>,
-				<NRF_PSEL(QSPI_CSN, 0, 18)>;
+				<NRF_PSEL(QSPI_IO3, 0, 16)>;
 			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common-pinctrl.dtsi
@@ -98,9 +98,13 @@
 		group1 {
 			psels = <NRF_PSEL(QSPI_SCK, 0, 17)>,
 				<NRF_PSEL(QSPI_IO0, 0, 13)>,
-				<NRF_PSEL(QSPI_IO1, 0, 14)>,
-				<NRF_PSEL(QSPI_CSN, 0, 18)>;
+				<NRF_PSEL(QSPI_IO1, 0, 14)>;
 			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 18)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 

--- a/tests/drivers/flash/boards/nrf52840dk_mx25l51245g.overlay
+++ b/tests/drivers/flash/boards/nrf52840dk_mx25l51245g.overlay
@@ -29,9 +29,13 @@
 				<NRF_PSEL(QSPI_IO0, 0, 29)>,
 				<NRF_PSEL(QSPI_IO1, 0, 28)>,
 				<NRF_PSEL(QSPI_IO2, 0, 04)>,
-				<NRF_PSEL(QSPI_IO3, 0, 03)>,
-				<NRF_PSEL(QSPI_CSN, 0, 31)>;
+				<NRF_PSEL(QSPI_IO3, 0, 03)>;
 			low-power-enable;
+		};
+		group2 {
+			psels = <NRF_PSEL(QSPI_CSN, 0, 31)>;
+			low-power-enable;
+			bias-pull-up;
 		};
 	};
 };


### PR DESCRIPTION
When there is no external pull-up on the CSN line and the line
is put into the low-power mode (input direction and disconnected
buffer), after some time its level falls to low and some flash
chips, like for example MX25R64, exit the Deep Power-down mode
when that happens. To prevent this, activate the GPIO internal
pull-up for this line in boards that do not have the external
pull-up on it.

Signed-off-by: Andrzej Głąbek <andrzej.glabek@nordicsemi.no>