### PR TITLE
modules: openthread: Fix building with picolibc

### DIFF
--- a/modules/openthread/CMakeLists.txt
+++ b/modules/openthread/CMakeLists.txt
@@ -433,9 +433,11 @@ target_compile_options(ot-config INTERFACE
 # errno_private.h is generated as part of ${SYSCALL_LIST_H_TARGET} target.
 add_dependencies(ot-config ${SYSCALL_LIST_H_TARGET})
 
-# Make sure C library is linked after OpenThread libraries (to prevent linker
-# errors)
-target_link_libraries(ot-config INTERFACE -lc)
+# Make sure C library, in case of newlib, is linked after OpenThread libraries
+# (to prevent linker errors)
+if(CONFIG_NEWLIB_LIBC)
+  target_link_libraries(ot-config INTERFACE -lc)
+endif()
 
 # Include OpenThread headers
 zephyr_system_include_directories(${ZEPHYR_CURRENT_MODULE_DIR}/include)


### PR DESCRIPTION
The OpenThread module should not explicitly link with libc in case of minimal libc or picolibc.