### PR TITLE
boards: arm: nordic: Remove label property from devicetree

### DIFF
--- a/boards/arm/actinius_icarus/actinius_icarus_common.dts
+++ b/boards/arm/actinius_icarus/actinius_icarus_common.dts
@@ -145,7 +145,6 @@
 		reg = <0x19>;
 		irq-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>,
 			  <&gpio0 29 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12-ACCEL";
 	};
 };
 

--- a/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
+++ b/boards/arm/actinius_icarus_bee/actinius_icarus_bee_common.dts
@@ -123,7 +123,6 @@
 		reg = <0x19>;
 		irq-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>,
 			  <&gpio0 29 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12-ACCEL";
 	};
 };
 
@@ -140,7 +139,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
-		label = "W25Q64";
 		jedec-id = [ef 40 17];
 		size = <0x4000000>;
 		has-dpd;

--- a/boards/arm/actinius_icarus_som/actinius_icarus_som_common.dts
+++ b/boards/arm/actinius_icarus_som/actinius_icarus_som_common.dts
@@ -62,7 +62,6 @@
 		reg = <0x19>;
 		irq-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>,
 			  <&gpio0 29 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12-ACCEL";
 	};
 };
 

--- a/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
+++ b/boards/arm/adafruit_feather_nrf52840/adafruit_feather_nrf52840.dts
@@ -106,7 +106,6 @@
 		writeoc = "pp4o";
 		readoc = "read4io";
 		sck-frequency = <16000000>;
-		label = "GD25Q16";
 		jedec-id = [c8 40 15];
 		size = <16777216>;
 		has-dpd;

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble-common.dtsi
@@ -75,7 +75,6 @@
 
 	vdd_env: vdd-env {
 		compatible = "regulator-fixed";
-		label = "vdd_env";
 		regulator-name = "vdd_env";
 		enable-gpios = <&gpio0 22 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;

--- a/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble_sense.dts
+++ b/boards/arm/arduino_nano_33_ble/arduino_nano_33_ble_sense.dts
@@ -15,7 +15,6 @@
 
 	mic_pwr: mic_pwr {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "mic_pwr";
 		regulator-name = "mic_pwr";
 		enable-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -27,21 +26,18 @@
 		compatible = "st,hts221";
 		status = "okay";
 		reg = <0x5f>;
-		label = "HTS221";
 	};
 
 	lps22hb: lps22hb-press@5c {
 		compatible = "st,lps22hb-press";
 		status = "okay";
 		reg = <0x5c>;
-		label = "LPS22HB";
 	};
 
 	apds9960: apds9960@39 {
 		compatible = "avago,apds9960";
 		status = "okay";
 		reg = <0x39>;
-		label = "APDS9960";
 		int-gpios = <&gpio0 19 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 };

--- a/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
+++ b/boards/arm/arduino_nano_33_iot/arduino_nano_33_iot.dts
@@ -62,7 +62,6 @@
 &sercom2 {
 	status = "okay";
 	compatible = "atmel,sam0-spi";
-	label = "NINA_SPI";
 	dipo = <1>;
 	dopo = <3>;
 	#address-cells = <1>;
@@ -76,7 +75,6 @@
 	nina_w102@0 {
 		compatible = "u-blox,nina";
 		reg = <0>;
-		label = "NINA_W102";
 		spi-max-frequency = <8000000>;
 		ready-gpios = <&porta 28 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		reset-gpios = <&porta 8 GPIO_ACTIVE_LOW>;
@@ -96,7 +94,6 @@
 
 	nina_prog {
 		compatible = "espressif,esp-at";
-		label = "NINA_PROG";
 		reset-gpios = <&porta 8 GPIO_ACTIVE_LOW>;
 	};
 };
@@ -114,13 +111,11 @@
 	lsm6ds3@6a {
 		compatible = "st,lsm6ds3";
 		reg = <0x6a>;
-		label = "LSM6DS3";
 	};
 
 	atecc608a@15 {
 		compatible = "atmel,atecc608";
 		reg = <0x6a>;
-		label = "ATECC608A";
 	};
 };
 

--- a/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
+++ b/boards/arm/arduino_nicla_sense_me/arduino_nicla_sense_me.dts
@@ -102,7 +102,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
-		label = "MX25R16";
 		jedec-id = [c2 28 15];
 		size = <DT_SIZE_M(16)>;
 		has-dpd;

--- a/boards/arm/bbc_microbit/bbc_microbit.dts
+++ b/boards/arm/bbc_microbit/bbc_microbit.dts
@@ -48,7 +48,6 @@
 	led_matrix: led_matrix {
 		compatible = "nordic,nrf-led-matrix";
 		status = "okay";
-		label = "LED_MATRIX";
 		width = <5>;
 		height = <5>;
 		pixel-mapping = [00 13 01 14 02
@@ -136,7 +135,6 @@
 		compatible = "nxp,fxos8700", "nxp,mma8653fc";
 		status = "okay";
 		reg = <0x1d>;
-		label = "MMA8653FC";
 		int1-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpio0 27 GPIO_ACTIVE_LOW>;
 	};
@@ -146,7 +144,6 @@
 		compatible = "st,lis2mdl", "st,lsm303agr-magn";
 		status = "disabled";
 		reg = <0x1e>;
-		label = "LSM303AGR-MAGN";
 		irq-gpios = <&gpio0 27 GPIO_ACTIVE_HIGH>;	/* A3 */
 	};
 
@@ -154,7 +151,6 @@
 		compatible = "st,lis2dh", "st,lsm303agr-accel";
 		status = "disabled";
 		reg = <0x19>;
-		label = "LSM303AGR-ACCEL";
 		irq-gpios = <&gpio0 28 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
+++ b/boards/arm/bbc_microbit_v2/bbc_microbit_v2.dts
@@ -48,7 +48,6 @@
 	led_matrix: led_matrix {
 		compatible = "nordic,nrf-led-matrix";
 		status = "okay";
-		label = "LED_MATRIX";
 		width = <5>;
 		height = <5>;
 		pixel-mapping = [00 01 02 03 04
@@ -134,7 +133,6 @@
 		compatible = "st,lis2mdl", "st,lsm303agr-magn";
 		status = "okay";
 		reg = <0x1e>;
-		label = "LSM303AGR-MAGN";
 		irq-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;	/* A3 */
 	};
 
@@ -142,7 +140,6 @@
 		compatible = "st,lis2dh", "st,lsm303agr-accel";
 		status = "okay";
 		reg = <0x19>;
-		label = "LSM303AGR-ACCEL";
 		irq-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
+++ b/boards/arm/bl5340_dvk/bl5340_dvk_cpuapp_common.dts
@@ -118,7 +118,6 @@
 	at24c256@50 {
 		compatible = "atmel,at24";
 		reg = <0x50>;
-		label = "EEPROM";
 		size = <32768>;
 		pagesize = <64>;
 		address-width = <16>;
@@ -127,7 +126,6 @@
 
 	lis3dh: lis3dh@18 {
 		compatible = "st,lis2dh";
-		label = "LIS3DH";
 		reg = <0x18>;
 		irq-gpios = <&gpio0 23 GPIO_ACTIVE_HIGH>, <&gpio0 24 GPIO_ACTIVE_HIGH>;
 	};
@@ -135,33 +133,28 @@
 	ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "TOUCH";
 		int-gpios = <&gpio0 5 GPIO_ACTIVE_LOW>;
 	};
 
 	bme680@76 {
 		compatible = "bosch,bme680";
 		reg = <0x76>;
-		label = "BME680";
 	};
 
 	dac0: mcp4725@60 {
 		compatible = "microchip,mcp4725";
 		reg = <0x60>;
-		label = "dac0";
 		#io-channel-cells = <1>;
 	};
 
 	extrtc0: mcp7940n@6f {
 		compatible = "microchip,mcp7940n";
 		reg = <0x6f>;
-		label = "mcp7940n";
 	};
 
 	gpio_exp0: tca9538@70 {
 		compatible = "ti,tca9538";
 		reg = <0x70>;
-		label = "tca9538";
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <8>;
@@ -181,7 +174,6 @@
 		compatible = "microchip,enc424j600";
 		reg = <0>;
 		spi-max-frequency = <8000000>;
-		label = "ETHERNET";
 		int-gpios = <&gpio0 7 GPIO_ACTIVE_LOW>;
 	};
 };
@@ -218,7 +210,6 @@
 		compatible = "ilitek,ili9340";
 		reg = <0>;
 		spi-max-frequency = <32000000>;
-		label = "DISPLAY";
 		reset-gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
 		cmd-data-gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
 		rotation = <270>;
@@ -267,7 +258,6 @@
 		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb

--- a/boards/arm/bl652_dvk/bl652_dvk.dts
+++ b/boards/arm/bl652_dvk/bl652_dvk.dts
@@ -91,7 +91,6 @@
 		/* MCP4725 not populated at factory */
 		compatible = "microchip,mcp4725";
 		reg = <0x60>;
-		label = "MCP4725";
 		#io-channel-cells = <1>;
 		status = "disabled";
 	};

--- a/boards/arm/bl653_dvk/bl653_dvk.dts
+++ b/boards/arm/bl653_dvk/bl653_dvk.dts
@@ -115,7 +115,6 @@
 		/* MCP4725 not populated at factory */
 		compatible = "microchip,mcp4725";
 		reg = <0x60>;
-		label = "MCP4725";
 		#io-channel-cells = <1>;
 		status = "disabled";
 	};

--- a/boards/arm/bl654_dvk/bl654_dvk.dts
+++ b/boards/arm/bl654_dvk/bl654_dvk.dts
@@ -115,7 +115,6 @@
 		/* MCP4725 not populated at factory */
 		compatible = "microchip,mcp4725";
 		reg = <0x60>;
-		label = "MCP4725";
 		#io-channel-cells = <1>;
 		status = "disabled";
 	};
@@ -149,7 +148,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		size = <67108864>;
 		wp-gpios = <&gpio0 22 0>;

--- a/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
+++ b/boards/arm/bl654_sensor_board/bl654_sensor_board.dts
@@ -84,7 +84,6 @@
 	bme280@76 {
 		compatible = "bosch,bme280";
 		status = "okay";
-		label = "BME280";
 		reg = <0x76>;
 	};
 };

--- a/boards/arm/bl654_usb/bl654_usb.dts
+++ b/boards/arm/bl654_usb/bl654_usb.dts
@@ -107,6 +107,5 @@ zephyr_udc0: &usbd {
 
 	bl654_cdc_acm_uart: bl654_cdc_acm_uart {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
+++ b/boards/arm/blueclover_plt_demo_v2_nrf52832/blueclover_plt_demo_v2_nrf52832.dts
@@ -72,13 +72,11 @@
 	sht3xd@44 {
 		compatible = "sensirion,sht3xd";
 		reg = <0x44>;
-		label = "SHT3XD";
 	};
 
 	bmi270: bmi270@68 {
 		compatible = "bosch,bmi270";
 		reg = <0x68>;
-		label = "BMI270";
 	};
 };
 
@@ -101,7 +99,6 @@
 		compatible = "apa,apa102";
 		reg = <0>;
 		spi-max-frequency = <5250000>;
-		label = "APA102";
 	};
 };
 

--- a/boards/arm/bt510/bt510.dts
+++ b/boards/arm/bt510/bt510.dts
@@ -72,7 +72,6 @@
 		mag0: mag_0 {
 			compatible = "honeywell,sm351lt";
 			gpios = <&gpio1 14 0>;
-			label = "SM351LT_0";
 		};
 	};
 
@@ -125,14 +124,12 @@
 		reg = <0x18>;
 		irq-gpios = <&gpio1 5 GPIO_ACTIVE_HIGH>,
 				<&gpio1 12 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12";
 		disconnect-sdo-sa0-pull-up;
 	};
 
 	si7055@40 {
 		compatible = "silabs,si7055";
 		reg = <0x40>;
-		label = "SI7055";
 	};
 };
 

--- a/boards/arm/bt610/bt610.dts
+++ b/boards/arm/bt610/bt610.dts
@@ -62,7 +62,6 @@
 		mag1: mag_1 {
 			compatible = "honeywell,sm351lt";
 			gpios = <&gpio1 15 0>;
-			label = "SM3531LT_0";
 		};
 	};
 
@@ -257,7 +256,6 @@
 	gpio_exp0: tca9538@70 {
 		compatible = "ti,tca9538";
 		reg = <0x70>;
-		label = "tca9538";
 		gpio-controller;
 		#gpio-cells = <2>;
 		ngpios = <8>;
@@ -286,7 +284,6 @@
 		writeoc = "pp4io";
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb

--- a/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
+++ b/boards/arm/circuitdojo_feather_nrf9160/circuitdojo_feather_nrf9160_common.dts
@@ -83,7 +83,6 @@
 
 	nrf-ps-en {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "nrf_ps_en";
 		regulator-name = "nrf_ps_en";
 		enable-gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -132,13 +131,11 @@
 	pinctrl-names = "default", "sleep";
 	pcf85063a@51 {
 		compatible = "nxp,pcf85063a";
-		label = "PCF85063A";
 		reg = <0x51>;
 	};
 
 	lis2dh: lis2dh@18 {
 		compatible = "st,lis2dh";
-		label = "LIS2DH";
 		reg = <0x18>;
 		irq-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 		disconnect-sdo-sa0-pull-up;
@@ -162,7 +159,6 @@
 	pinctrl-names = "default", "sleep";
 	w25q32jv: w25q32jv@0 {
 		compatible = "jedec,spi-nor";
-		label = "W25Q32JV";
 		reg = < 0 >;
 		spi-max-frequency = < 40000000 >;
 		wp-gpios = < &gpio0 8 GPIO_ACTIVE_LOW >;

--- a/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
+++ b/boards/arm/contextualelectronics_abc/contextualelectronics_abc.dts
@@ -62,7 +62,6 @@ arduino_serial: &uart1 {
 	pinctrl-names = "default", "sleep";
 	quectel_bg9x {
 		compatible = "quectel,bg9x";
-		label      = "quectel-bg9x";
 		status     = "okay";
 
 		mdm-power-gpios = <&gpio1 5  0>;

--- a/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
+++ b/boards/arm/decawave_dwm1001_dev/decawave_dwm1001_dev.dts
@@ -110,7 +110,6 @@
 		compatible = "st,lis2dh12", "st,lis2dh";
 		reg = <0x19>;
 		irq-gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12-ACCEL";
 	};
 };
 
@@ -137,7 +136,6 @@
 		int-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;	/* P0.19 */
 		reset-gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;	/* P0.24 */
 		status = "okay";
-		label = "DW1000";
 		reg = <0>;
 	};
 };

--- a/boards/arm/degu_evk/degu_evk.dts
+++ b/boards/arm/degu_evk/degu_evk.dts
@@ -58,7 +58,6 @@
 
 	en-3v3-switch {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "en_3v3_switch";
 		regulator-name = "en_3v3_switch";
 		enable-gpios = <&gpio0 26 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -66,7 +65,6 @@
 
 	en-vin1-moni {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "en_vin1_moni";
 		regulator-name = "en_vin1_moni";
 		enable-gpios = <&gpio1 6 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -161,6 +159,5 @@ zephyr_udc0: &usbd {
 
 	degu_cdc_acm_uart: degu_cdc_acm_uart {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };

--- a/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
+++ b/boards/arm/nrf21540dk_nrf52840/nrf21540dk_nrf52840.dts
@@ -232,7 +232,6 @@ fem_spi: &spi3 {
 		compatible = "nordic,nrf21540-fem-spi";
 		status = "okay";
 		reg = <0>;
-		label = "FEM_SPI_IF";
 		spi-max-frequency = <8000000>;
 	};
 };

--- a/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
+++ b/boards/arm/nrf52840_mdk/nrf52840_mdk.dts
@@ -142,7 +142,6 @@
 		writeoc = "pp4io";
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb

--- a/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
+++ b/boards/arm/nrf52840dk_nrf52840/nrf52840dk_nrf52840.dts
@@ -224,7 +224,6 @@ arduino_i2c: &i2c0 {
 		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb

--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpuapp_common.dts
@@ -182,7 +182,6 @@
 		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb

--- a/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
+++ b/boards/arm/nrf9160_innblue21/nrf9160_innblue21_common.dts
@@ -47,7 +47,6 @@
 
 	en_3v3_sensor: enable-3v3-sensor {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "ENABLE_3V3_SENSOR";
 		regulator-name = "en_3v3_sensor";
 		enable-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
 		startup-delay-us = <10000>;
@@ -56,7 +55,6 @@
 
 	en_5v0_boost: enable-5v0-boost {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "ENABLE_5V0_BOOST";
 		regulator-name = "en_5v0_boost";
 		enable-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		startup-delay-us = <10000>;
@@ -121,31 +119,26 @@
 		compatible = "st,lis2dh";
 		reg = <0x19>;
 		irq-gpios = <&gpio0 0 0>, <&gpio0 1 0>;
-		label = "LIS2DH12-ACCEL";
 	};
 
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
 		drdy-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
-		label = "HTS221";
 	};
 
 	lps22hb-press@5c {
 		compatible = "st,lps22hb-press";
 		reg = <0x5c>;
-		label = "LPS22HB";
 	};
 
 	ccs811: ccs811@5a {
 		compatible = "ams,ccs811";
 		reg = <0x5a>;
-		label = "CCS811";
 	};
 
 	bme680@76 {
 		compatible = "bosch,bme680";
-		label = "BME680";
 		reg = <0x76>;
 	};
 };

--- a/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
+++ b/boards/arm/nrf9160_innblue22/nrf9160_innblue22_common.dts
@@ -47,7 +47,6 @@
 
 	en_5v0_boost: enable-5v0-boost {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "ENABLE_5V0_BOOST";
 		regulator-name = "en_5v0_boost";
 		enable-gpios = <&gpio0 21 GPIO_ACTIVE_HIGH>;
 		startup-delay-us = <10000>;
@@ -112,7 +111,6 @@
 	pinctrl-names = "default", "sleep";
 	bq27421@55 {
 		compatible = "ti,bq274xx";
-		label = "BQ274XX";
 		reg = <0x55>;
 		design-voltage = <3700>;
 		design-capacity = <1800>;
@@ -124,31 +122,26 @@
 		compatible = "st,lis2dh";
 		reg = <0x19>;
 		irq-gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>, <&gpio0 1 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12-ACCEL";
 	};
 
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
 		drdy-gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
-		label = "HTS221";
 	};
 
 	lps22hb-press@5c {
 		compatible = "st,lps22hb-press";
 		reg = <0x5c>;
-		label = "LPS22HB";
 	};
 
 	ccs811: ccs811@5a {
 		compatible = "ams,ccs811";
 		reg = <0x5a>;
-		label = "CCS811";
 	};
 
 	bme680@76 {
 		compatible = "bosch,bme680";
-		label = "BME680";
 		reg = <0x76>;
 	};
 };

--- a/boards/arm/particle_argon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_argon/dts/mesh_feather.dtsi
@@ -199,7 +199,6 @@ feather_i2c: &i2c0 { };
 	pinctrl-names = "default", "sleep";
 	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
-		label = "MX25L3233F";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;

--- a/boards/arm/particle_boron/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_boron/dts/mesh_feather.dtsi
@@ -199,7 +199,6 @@ feather_i2c: &i2c0 { };
 	pinctrl-names = "default", "sleep";
 	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
-		label = "MX25L3233F";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;

--- a/boards/arm/particle_boron/particle_boron.dts
+++ b/boards/arm/particle_boron/particle_boron.dts
@@ -49,7 +49,6 @@
 	pinctrl-names = "default", "sleep";
 	sara_r4 {
 		compatible = "u-blox,sara-r4";
-		label = "ublox-sara-r4";
 		status = "okay";
 
 		mdm-power-gpios = <&gpio0 16 0>;

--- a/boards/arm/particle_xenon/dts/mesh_feather.dtsi
+++ b/boards/arm/particle_xenon/dts/mesh_feather.dtsi
@@ -198,7 +198,6 @@ feather_i2c: &i2c0 { };
 	pinctrl-names = "default", "sleep";
 	mx25l32: mx25l3233f@0 {
 		compatible = "jedec,spi-nor";
-		label = "MX25L3233F";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;

--- a/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
+++ b/boards/arm/pinetime_devkit0/pinetime_devkit0.dts
@@ -67,7 +67,6 @@
 	key_out {
 		compatible = "pine64,pinetime-key-out";
 		gpios = <&gpio0 15 GPIO_ACTIVE_HIGH>;
-		label = "Key out";
 	};
 
 	vbatt {
@@ -111,7 +110,6 @@
 	bma421: bma421@18 {
 		compatible = "bosch,bma4xx";
 		reg = <0x18>;
-		label = "BMA421";
 		int1-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
 	};
 
@@ -119,14 +117,12 @@
 	hrs3300: hrs3300@44 {
 		compatible = "tian-yi-he-xin-hrs3300";
 		reg = <0x44>;
-		label = "HRS3300";
 	};
 
 	/* Hynitron CST816S Capacitive Touch Controller (400KHz) */
 	cst816s: cst816s@15 {
 		compatible = "hynitron,cst816s";
 		reg = <0x15>;
-		label = "CST816S";
 		irq-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 		rst-gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
 	};
@@ -145,7 +141,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <8000000>; /* 8MHz */
-		label = "XT25FB32";
 		jedec-id = [0b 40 16];
 		size = <DT_SIZE_M(32)>;
 
@@ -173,7 +168,6 @@
 		compatible = "sitronix,st7789v";
 		reg = <1>;
 		spi-max-frequency = <8000000>; /* 8MHz */
-		label = "ST7789V";
 		cmd-data-gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;	/* DET */
 		reset-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;	/* RESX reset */
 		width = <240>;

--- a/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
+++ b/boards/arm/pinnacle_100_dvk/pinnacle_100_dvk.dts
@@ -113,7 +113,6 @@
 	hl7800 {
 		compatible = "swir,hl7800";
 		status = "okay";
-		label = "hl7800";
 		mdm-reset-gpios = <&gpio1 15 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
 		mdm-wake-gpios = <&gpio1 13 (GPIO_OPEN_SOURCE | GPIO_ACTIVE_HIGH)>;
 		mdm-pwr-on-gpios = <&gpio1 2 (GPIO_OPEN_DRAIN | GPIO_ACTIVE_LOW)>;
@@ -135,7 +134,6 @@
 	bme680@76 {
 		compatible = "bosch,bme680";
 		status = "okay";
-		label = "BME680";
 		reg = <0x76>;
 	};
 };
@@ -168,7 +166,6 @@
 		writeoc = "pp4io";
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		size = <67108864>;
 		has-dpd;

--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -106,7 +106,6 @@
 	lora: lora@0 {
 		compatible = "semtech,sx1262";
 		reg = <0>;
-		label = "sx1262";
 		reset-gpios = <&gpio1 6 GPIO_ACTIVE_LOW>;
 		busy-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
 		tx-enable-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;

--- a/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
+++ b/boards/arm/rak5010_nrf52840/rak5010_nrf52840.dts
@@ -66,7 +66,6 @@
 	pinctrl-names = "default", "sleep";
 	quectel_bg9x: quectel_bg9x {
 		compatible = "quectel,bg9x";
-		label = "quectel,bg9x";
 		mdm-power-gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;
 		mdm-reset-gpios = <&gpio0 28 GPIO_ACTIVE_LOW>;
 		mdm-dtr-gpios = <&gpio0 26 GPIO_ACTIVE_LOW>;
@@ -93,14 +92,12 @@
 	pinctrl-names = "default", "sleep";
 	opt3001@44 {
 		compatible = "ti,opt3001";
-		label = "OPT3001";
 		reg = <0x44>;
 	};
 
 	/* ST Microelectronics LIS3DH motion sensor */
 	lis3dh: lis3dh@19 {
 		compatible = "st,lis3dh", "st,lis2dh";
-		label = "LIS3DH";
 		reg = <0x19>;
 		irq-gpios = <&gpio0 15 0>;
 	};
@@ -109,7 +106,6 @@
 	lps22hb-press@5c {
 		compatible = "st,lps22hb-press";
 		reg = <0x5c>;
-		label = "LPS22HB";
 	};
 };
 
@@ -124,7 +120,6 @@
 		writeoc = "pp4io";
 		readoc = "read4io";
 		sck-frequency = <16000000>;
-		label = "IS25WP064A";
 		jedec-id = [9d 70 17];
 		size = <67108864>;
 		has-dpd;

--- a/boards/arm/reel_board/dts/reel_board.dtsi
+++ b/boards/arm/reel_board/dts/reel_board.dtsi
@@ -128,7 +128,6 @@ arduino_i2c: &i2c0 {
 	mma8642fc: mma8652fc@1d {
 		compatible = "nxp,fxos8700","nxp,mma8652fc";
 		reg = <0x1d>;
-		label = "MMA8652FC";
 		int1-gpios = <&gpio0 24 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
 	};
@@ -136,14 +135,12 @@ arduino_i2c: &i2c0 {
 	ti_hdc@43 {
 		compatible = "ti,hdc","ti,hdc1010";
 		reg = <0x43>;
-		label = "HDC1010";
 		drdy-gpios = <&gpio0 22 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 
 	apds9960@39 {
 		compatible = "avago,apds9960";
 		reg = <0x39>;
-		label = "APDS9960";
 		int-gpios = <&gpio0 23 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 };

--- a/boards/arm/reel_board/reel_board.dts
+++ b/boards/arm/reel_board/reel_board.dts
@@ -58,7 +58,6 @@
 	pinctrl-names = "default", "sleep";
 	ssd16xx: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0213b1", "solomon,ssd1673", "solomon,ssd16xxfb";
-		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <250>;

--- a/boards/arm/reel_board/reel_board_v2.dts
+++ b/boards/arm/reel_board/reel_board_v2.dts
@@ -41,7 +41,6 @@
 	pinctrl-names = "default", "sleep";
 	ssd16xx: ssd16xxfb@0 {
 		compatible = "gooddisplay,gdeh0213b72", "solomon,ssd1675a", "solomon,ssd16xxfb";
-		label = "SSD16XX";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <250>;

--- a/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
+++ b/boards/arm/rm1xx_dvk/rm1xx_dvk.dts
@@ -78,7 +78,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <1000000>;
-		label = "at25df04";
 		jedec-id = [1f 44 02];
 		size = <0x400000>;
 		has-lock = <0xbc>;
@@ -90,7 +89,6 @@
 	lora0: lora@1 {
 		compatible = "semtech,sx1272";
 		reg = <1>;
-		label = "sx1272";
 		reset-gpios = <&gpio0 7 GPIO_ACTIVE_HIGH>;
 		dio-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>,
 			    <&gpio0 13 GPIO_ACTIVE_HIGH>,

--- a/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
+++ b/boards/arm/ruuvi_ruuvitag/ruuvi_ruuvitag.dts
@@ -86,7 +86,6 @@
 		compatible = "bosch,bme280";
 		reg = <0>;
 		spi-max-frequency = <10000000>;
-		label= "BME280";
 	};
 
 	lis2dh12: lis2dh12@1 {
@@ -94,7 +93,6 @@
 		reg = <1>;
 		spi-max-frequency = <10000000>;
 		irq-gpios =  <&gpio0 2 GPIO_ACTIVE_HIGH>, <&gpio0 6 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12-ACCEL";
 	};
 };
 

--- a/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/sparkfun_thing_plus_nrf9160_common.dts
@@ -123,13 +123,11 @@
 	pinctrl-names = "default", "sleep";
 	pcf85063a@51 {
 		compatible = "nxp,pcf85063a";
-		label = "PCF85063A";
 		reg = <0x51>;
 	};
 
 	lis2dh: lis2dh@18 {
 		compatible = "st,lis2dh";
-		label = "LIS2DH";
 		reg = <0x18>;
 		irq-gpios = <&gpio0 29 0>;
 	};
@@ -152,7 +150,6 @@
 	pinctrl-names = "default", "sleep";
 	w25q32jv: w25q32jv@0 {
 		compatible = "jedec,spi-nor";
-		label = "W25Q32JV";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 		wp-gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;

--- a/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
+++ b/boards/arm/thingy52_nrf52832/thingy52_nrf52832.dts
@@ -73,7 +73,6 @@
 
 	vdd_pwr: vdd-pwr-ctrl {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "vdd-pwr-ctrl";
 		regulator-name = "vdd-pwr-ctrl";
 		enable-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -81,28 +80,24 @@
 
 	spk_pwr: spk-pwr-ctrl {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "spk-pwr-ctrl";
 		regulator-name = "spk-pwr-ctrl";
 		enable-gpios = <&gpio0 29 GPIO_ACTIVE_HIGH>;
 	};
 
 	mpu_pwr: mpu-pwr-ctrl {
 		compatible = "regulator-fixed";
-		label = "mpu-pwr-ctrl";
 		regulator-name = "mpu-pwr-ctrl";
 		enable-gpios = <&sx1509b 8 GPIO_ACTIVE_HIGH>;
 	};
 
 	mic_pwr: mic-pwr-ctrl {
 		compatible = "regulator-fixed";
-		label = "mic-pwr-ctrl";
 		regulator-name = "mic-pwr-ctrl";
 		enable-gpios = <&sx1509b 9 GPIO_ACTIVE_HIGH>;
 	};
 
 	ccs_pwr: ccs-pwr-ctrl {
 		compatible = "regulator-fixed";
-		label = "ccs-pwr-ctrl";
 		regulator-name = "ccs-pwr-ctrl";
 		enable-gpios = <&sx1509b 10 GPIO_ACTIVE_HIGH>;
 	};
@@ -140,7 +135,6 @@
 	sx1509b: sx1509b@3e {
 		compatible = "semtech,sx1509b";
 		reg = <0x3e>;
-		label = "GPIO_P0";
 		vin-supply = <&vdd_pwr>;
 		gpio-controller;
 		#gpio-cells = <2>;
@@ -153,14 +147,12 @@
 	lps22hb_press: lps22hb_press@5c {
 		compatible = "st,lps22hb-press";
 		reg = <0x5c>;
-		label = "LPS22HB";
 		vin-supply = <&vdd_pwr>;
 	};
 
 	hts221: hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 		vin-supply = <&vdd_pwr>;
 		drdy-gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
 	};
@@ -168,7 +160,6 @@
 	ccs811: ccs811@5a {
 		compatible = "ams,ccs811";
 		reg = <0x5a>;
-		label = "CCS811";
 		vin-supply = <&ccs_pwr>;
 		irq-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&sx1509b 11 GPIO_ACTIVE_LOW>;
@@ -188,7 +179,6 @@
 		compatible = "st,lis2dh12", "st,lis2dh";
 		reg = <0x19>;
 		irq-gpios = <&gpio0 12 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DH12-ACCEL";
 	};
 };
 

--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -63,7 +63,6 @@
 
 	npm1100_force_pwm_mode: npm1100_force_pwm_mode {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "npm1100_force_pwm_mode";
 		regulator-name = "npm1100_force_pwm_mode";
 		enable-gpios = <&gpio0 8 GPIO_ACTIVE_HIGH>;
 		status = "disabled";
@@ -80,7 +79,6 @@
 
 	regulator_3v3: regulator-3v3-ctrl {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "vsys-3v3-ctrl";
 		regulator-name = "ncp114";
 		enable-gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
@@ -88,7 +86,6 @@
 
 	sensor_pwr_ctrl: sensor-pwr-ctrl {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "sens-pwr-ctrl";
 		regulator-name = "tck106ag";
 		enable-gpios = <&gpio0 31 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -163,13 +160,11 @@
 	pinctrl-names = "default", "sleep";
 	bmm150: bmm150@10 {
 		compatible = "bosch,bmm150";
-		label = "BMM150";
 		reg = <0x10>;
 	};
 
 	bh1749@38 {
 		compatible = "rohm,bh1749";
-		label = "BH1749";
 		reg = <0x38>;
 		int-gpios = <&gpio1 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
@@ -187,7 +182,6 @@
 	pinctrl-names = "default", "sleep";
 	adxl362: spi-dev-adxl362@0 {
 		compatible = "adi,adxl362";
-		label = "ADXL362";
 		spi-max-frequency = <8000000>;
 		reg = <0>;
 		int1-gpios = <&gpio0 19 0>;
@@ -195,7 +189,6 @@
 
 	bmi270: spi-dev-bmi270@1 {
 		compatible = "bosch,bmi270";
-		label = "BMI270";
 		spi-max-frequency = <8000000>;
 		reg = <1>;
 		int1-gpios = <&gpio0 23 0>;
@@ -205,7 +198,6 @@
 		compatible = "nordic,nrf21540-fem-spi";
 		status = "disabled";
 		reg = <2>;
-		label = "FEM_SPI_IF";
 		spi-max-frequency = <8000000>;
 	};
 };
@@ -234,7 +226,6 @@
 		/* Thingy:53 supports only fastread and read2io options */
 		readoc = "read2io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03  44 eb 08 6b  08 3b 04 bb

--- a/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd340eval_nrf52840/ubx_bmd340eval_nrf52840.dts
@@ -225,7 +225,6 @@ arduino_i2c: &i2c0 {
 		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03

--- a/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd345eval_nrf52840/ubx_bmd345eval_nrf52840.dts
@@ -241,7 +241,6 @@ arduino_spi: &spi3 {
 		/* MX25R64 supports all readoc options */
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03

--- a/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
+++ b/boards/arm/ubx_bmd380eval_nrf52840/ubx_bmd380eval_nrf52840.dts
@@ -168,7 +168,6 @@
 		writeoc = "pp4io";
 		readoc = "read4io";
 		sck-frequency = <8000000>;
-		label = "MX25R64";
 		jedec-id = [c2 28 17];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 03

--- a/boards/arm/xiao_ble/xiao_ble.dts
+++ b/boards/arm/xiao_ble/xiao_ble.dts
@@ -123,7 +123,6 @@
 		wp-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		hold-gpios = <&gpio0 23 GPIO_ACTIVE_LOW>;
 		spi-max-frequency = <104000000>;
-		label = "P25Q16H";
 		jedec-id = [85 60 15];
 		sfdp-bfp = [
 			e5 20 f1 ff  ff ff ff 00  44 eb 08 6b  08 3b 80 bb
@@ -178,6 +177,5 @@ zephyr_udc0: &usbd {
 
 	usb_cdc_acm_uart: cdc-acm-uart {
 		compatible = "zephyr,cdc-acm-uart";
-		label = "CDC_ACM_0";
 	};
 };


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>