### PR TITLE
boards: arm: stm32: Remove label property from devicetree

### DIFF
--- a/boards/arm/96b_argonkey/96b_argonkey.dts
+++ b/boards/arm/96b_argonkey/96b_argonkey.dts
@@ -99,7 +99,6 @@
 		reg = <1>;
 		spi-max-frequency = <1000000>;
 		irq-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
-		label = "LSM6DSL_SPI";
 	};
 };
 
@@ -115,7 +114,6 @@
 	mp34dt05@0 {
 		compatible = "st,mpxxdtyy";
 		reg = <0>;
-		label = "MP34DT05";
 	};
 };
 
@@ -135,20 +133,17 @@
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 		drdy-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
 	};
 
 	lps22hb-press@5d {
 		compatible = "st,lps22hb-press";
 		reg = <0x5d>;
-		label = "LPS22HB";
 	};
 
 	vl53l0x@29 {
 		compatible = "st,vl53l0x";
 		reg = <0x29>;
-		label = "VL53L0X";
 	};
 };
 
@@ -161,7 +156,6 @@
 	lp3943@60 {
 		compatible = "ti,lp3943";
 		reg = <0x60>;
-		label = "LP3943";
 	};
 };
 

--- a/boards/arm/96b_carbon/96b_carbon.dts
+++ b/boards/arm/96b_carbon/96b_carbon.dts
@@ -124,7 +124,6 @@
 		reset-gpios = <&gpiob 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		irq-gpios = <&gpiob 1 GPIO_ACTIVE_HIGH>;
 		spi-max-frequency = <2000000>;
-		label = "BT_HCI";
 	};
 };
 

--- a/boards/arm/96b_neonkey/96b_neonkey.dts
+++ b/boards/arm/96b_neonkey/96b_neonkey.dts
@@ -106,7 +106,6 @@
 	lp3943@60 {
 		compatible = "ti,lp3943";
 		reg = <0x60>;
-		label = "LP3943";
 	};
 };
 

--- a/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
+++ b/boards/arm/96b_stm32_sensor_mez/96b_stm32_sensor_mez.dts
@@ -79,7 +79,6 @@
 	mp34dt01@0 {
 		compatible = "st,mpxxdtyy";
 		reg = <0>;
-		label = "MP34DT01";
 	};
 };
 
@@ -93,14 +92,12 @@
 	lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
-		label = "LIS3MDL";
 	};
 
 	/* ST Microelectronics LPS22HB pressure sensor */
 	lps22hb-press@5d {
 		compatible = "st,lps22hb-press";
 		reg = <0x5d>;
-		label = "LPS22HB";
 	};
 };
 

--- a/boards/arm/96b_wistrio/96b_wistrio.dts
+++ b/boards/arm/96b_wistrio/96b_wistrio.dts
@@ -48,7 +48,6 @@
 	/* regulator controlling SX oscillator enable */
 	sx-osc-enable {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "sx-osc-enable";
 		regulator-name = "sx-osc-enable";
 		enable-gpios = <&gpioh 1 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -96,7 +95,6 @@
 	lis3dh@32 {
 		compatible = "st,lis3dh";
 		reg = <0x32>;
-		label = "LIS3DH";
 	};
 };
 
@@ -109,7 +107,6 @@
 	lora: lora@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
-		label = "sx1276";
 		reset-gpios = <&gpiob 13 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 		dio-gpios = <&gpioa 11 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
 			<&gpiob 1 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,

--- a/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
+++ b/boards/arm/adafruit_feather_stm32f405/adafruit_feather_stm32f405.dts
@@ -81,7 +81,6 @@
 	cs-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
 	gd25q16: gd25q16c@0 {
 		compatible = "jedec,spi-nor";
-		label = "GD25Q16C";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x200000>;

--- a/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
+++ b/boards/arm/b_l072z_lrwan1/b_l072z_lrwan1.dts
@@ -122,7 +122,6 @@ arduino_i2c: &i2c1 {};
 	lora: lora@0 {
 		compatible = "semtech,sx1276";
 		reg = <0>;
-		label = "sx1276";
 		reset-gpios = <&gpioc 0 GPIO_ACTIVE_LOW>;
 		dio-gpios = <&gpiob 4 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,
 			<&gpiob 1 (GPIO_PULL_DOWN | GPIO_ACTIVE_HIGH)>,

--- a/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
+++ b/boards/arm/b_l4s5i_iot01a/b_l4s5i_iot01a.dts
@@ -97,32 +97,27 @@
 	lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
-		label = "LIS3MDL";
 	};
 
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 	};
 
 	lps22hb-press@5d {
 		compatible = "st,lps22hb-press";
 		reg = <0x5d>;
-		label = "LPS22HB";
 	};
 
 	lsm6dsl@6a {
 		compatible = "st,lsm6dsl";
 		reg = <0x6a>;
 		irq-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
-		label = "LSM6DSL";
 	};
 
 	vl53l0x@29 {
 		compatible = "st,vl53l0x";
 		reg = <0x29>;
-		label = "VL53L0X";
 		xshut-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
 	};
 };
@@ -148,7 +143,6 @@
 		reset-gpios = <&gpioa 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		irq-gpios = <&gpioe 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-max-frequency = <2000000>;
-		label = "SPBTLE-RF";
 	};
 
 	wifi0: ism43362@1 {
@@ -159,7 +153,6 @@
 		boot0-gpios = <&gpiob 12 GPIO_ACTIVE_HIGH>;
 		wakeup-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 		data-gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
-		label = "ESWIFI0";
 	};
 };
 

--- a/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
+++ b/boards/arm/b_u585i_iot02a/b_u585i_iot02a-common.dtsi
@@ -126,7 +126,6 @@
 
 	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		label = "MX25LM51245";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		size = <DT_SIZE_M(64)>;
@@ -170,7 +169,6 @@
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 	};
 };
 

--- a/boards/arm/black_f407ve/black_f407ve.dts
+++ b/boards/arm/black_f407ve/black_f407ve.dts
@@ -134,7 +134,6 @@ zephyr_udc0: &usbotg_fs {
 	cs-gpios = <&gpiob 0 GPIO_ACTIVE_LOW>;
 	w25q16cv: w25q16cv@0 {
 		compatible = "jedec,spi-nor";
-		label = "W25Q16CV";
 		reg = <0>;
 		spi-max-frequency = <40000000>;
 		size = <0x1000000>;

--- a/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
+++ b/boards/arm/disco_l475_iot1/disco_l475_iot1.dts
@@ -104,32 +104,27 @@
 	lis3mdl-magn@1e {
 		compatible = "st,lis3mdl-magn";
 		reg = <0x1e>;
-		label = "LIS3MDL";
 	};
 
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 	};
 
 	lps22hb-press@5d {
 		compatible = "st,lps22hb-press";
 		reg = <0x5d>;
-		label = "LPS22HB";
 	};
 
 	lsm6dsl@6a {
 		compatible = "st,lsm6dsl";
 		reg = <0x6a>;
 		irq-gpios = <&gpiod 11 GPIO_ACTIVE_HIGH>;
-		label = "LSM6DSL";
 	};
 
 	vl53l0x@29 {
 		compatible = "st,vl53l0x";
 		reg = <0x29>;
-		label = "VL53L0X";
 		xshut-gpios = <&gpioc 6 GPIO_ACTIVE_HIGH>;
 	};
 };
@@ -165,7 +160,6 @@
 		reset-gpios = <&gpioa 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		irq-gpios = <&gpioe 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		spi-max-frequency = <2000000>;
-		label = "SPBTLE-RF";
 	};
 
 	wifi0: ism43362@1 {
@@ -176,7 +170,6 @@
 		boot0-gpios = <&gpiob 12 GPIO_ACTIVE_HIGH>;
 		wakeup-gpios = <&gpiob 13 GPIO_ACTIVE_HIGH>;
 		data-gpios = <&gpioe 1 GPIO_ACTIVE_HIGH>;
-		label = "ESWIFI0";
 	};
 };
 
@@ -272,7 +265,6 @@ zephyr_udc0: &usbotg_fs {
 
 	mx25r6435f: qspi-nor-flash@0 {
 		compatible = "st,stm32-qspi-nor";
-		label = "MX25R6435F";
 		reg = <0>;
 		qspi-max-frequency = <50000000>;
 		/* 64 Megabits = 8 Megabytes */

--- a/boards/arm/legend/legend.dts
+++ b/boards/arm/legend/legend.dts
@@ -64,7 +64,6 @@
 
 	led_strip_spi: b1414@0 {
 		compatible = "everlight,b1414", "worldsemi,ws2812-spi";
-		label = "B1414";
 
 		/* SPI */
 		reg = <0>; /* ignored, but necessary for SPI bindings */
@@ -91,7 +90,6 @@
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <8000000>;
-		label = "SPI_FLASH_0";
 		size = <1048576>;
 		/*
 		 * Main flash source

--- a/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
+++ b/boards/arm/lora_e5_dev_board/lora_e5_dev_board.dts
@@ -57,7 +57,6 @@
 		 * Requires closed J15 (D9)
 		 */
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "pwr-3v3-ctrl";
 		regulator-name = "pwr-3v3-ctrl";
 		enable-gpios = <&gpioa 9 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -70,7 +69,6 @@
 		 * Requires closed J6 (D10)
 		 */
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "pwr-5v-ctrl";
 		regulator-name = "pwr-5v-ctrl";
 		enable-gpios = <&gpiob 10 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;

--- a/boards/arm/sensortile_box/sensortile_box.dts
+++ b/boards/arm/sensortile_box/sensortile_box.dts
@@ -94,14 +94,12 @@
 	hts221@5f {
 		compatible = "st,hts221";
 		reg = <0x5f>;
-		label = "HTS221";
 		drdy-gpios = <&gpiod 13 GPIO_ACTIVE_HIGH>;
 	};
 
 	lps22hh@5d {
 		compatible = "st,lps22hh";
 		reg = <0x5d>;
-		label = "LPS22HH";
 		drdy-gpios = <&gpiod 15 GPIO_ACTIVE_HIGH>;
 	};
 };
@@ -116,7 +114,6 @@
 		compatible = "st,stts751";
 		reg = <0x38>;
 		drdy-gpios = <&gpiog 5 GPIO_ACTIVE_LOW>;
-		label = "STTS751";
 	};
 };
 
@@ -133,7 +130,6 @@
 		spi-max-frequency = <1000000>;
 		reg = <0>;
 		irq-gpios = <&gpioc 5 GPIO_ACTIVE_HIGH>;
-		label = "LIS2DW12";
 	};
 
 	lsm6dso@1 {
@@ -141,7 +137,6 @@
 		spi-max-frequency = <1000000>;
 		reg = <1>;
 		irq-gpios = <&gpioa 2 GPIO_ACTIVE_HIGH>;
-		label = "LSM6DSO";
 		int-pin = <1>;
 	};
 
@@ -150,7 +145,6 @@
 		spi-max-frequency = <1000000>;
 		reg = <2>;
 		irq-gpios = <&gpioc 13 GPIO_ACTIVE_HIGH>, <&gpioe 6 GPIO_ACTIVE_HIGH>;
-		label = "IIS3DHHC";
 	};
 };
 
@@ -167,7 +161,6 @@
 		spi-max-frequency = <1000000>;
 		spi-full-duplex;
 		reg = <0>;
-		label = "LIS2MDL";
 	};
 };
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco.dts
+++ b/boards/arm/stm32f3_disco/stm32f3_disco.dts
@@ -124,7 +124,6 @@
 	lsm303dlhc_magn: lsm303dlhc-magn@1e {
 		compatible = "st,lsm303dlhc-magn";
 		reg = <0x1e>;
-		label = "LSM303DLHC-MAGN";
 	};
 
 	lsm303dlhc-accel@19 {
@@ -132,7 +131,6 @@
 		reg = <0x19>;
 		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
 			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
-		label = "LSM303DLHC-ACCEL";
 	};
 };
 

--- a/boards/arm/stm32f3_disco/stm32f3_disco_E.overlay
+++ b/boards/arm/stm32f3_disco/stm32f3_disco_E.overlay
@@ -17,7 +17,6 @@
 	lsm303agr_magn: lsm303agr-magn@1e {
 		compatible = "st,lis2mdl", "st,lsm303agr-magn";
 		reg = <0x1e>;
-		label = "LSM303AGR-MAGN";
 	};
 
 	lsm303agr-accel@19 {
@@ -25,7 +24,6 @@
 		reg = <0x19>;
 		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
 			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
-		label = "LSM303AGR-ACCEL";
 	};
 };
 
@@ -35,6 +33,5 @@
 		compatible = "st,i3g4250d";
 		reg = <0>;
 		spi-max-frequency = <1000000>;
-		label = "I3G4250D";
 	};
 };

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco.dts
@@ -124,7 +124,6 @@
 		status = "okay";
 		reg = <0x1e>;
 		irq-gpios = <&gpioe 2 GPIO_ACTIVE_HIGH>;
-		label = "LSM303AGR-MAGN";
 	};
 
 	lsm303agr-accel@19 {
@@ -133,7 +132,6 @@
 		reg = <0x19>;
 		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
 			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
-		label = "LSM303AGR-ACCEL";
 	};
 };
 

--- a/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
+++ b/boards/arm/stm32f411e_disco/stm32f411e_disco_B.overlay
@@ -12,7 +12,6 @@
 		compatible = "st,lsm303dlhc-magn";
         status = "okay";
 		reg = <0x1e>;
-		label = "LSM303DLHC-MAGN";
 	};
 
 	lsm303dlhc-accel@19 {
@@ -21,6 +20,5 @@
 		reg = <0x19>;
 		irq-gpios = <&gpioe 4 GPIO_ACTIVE_HIGH>,
 			  <&gpioe 5 GPIO_ACTIVE_HIGH>;
-		label = "LSM303DLHC-ACCEL";
 	};
 };

--- a/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
+++ b/boards/arm/stm32f412g_disco/stm32f412g_disco.dts
@@ -137,7 +137,6 @@
 
 	n25q128a1: qspi-nor-flash@0 {
 		compatible = "st,stm32-qspi-nor";
-		label = "N25Q128A1";
 		reg = <0>;
 		qspi-max-frequency = <72000000>;
 		size = <DT_SIZE_M(16*8)>;

--- a/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
+++ b/boards/arm/stm32f429i_disc1/stm32f429i_disc1.dts
@@ -118,7 +118,6 @@
 	cs-gpios = <&gpioc 2 GPIO_ACTIVE_LOW>;
 	ili9341: ili9341@0 {
 		compatible = "ilitek,ili9341";
-		label = "ILI9341";
 		spi-max-frequency = <5625000>;
 		reg = <0>;
 		cmd-data-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>;

--- a/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
+++ b/boards/arm/stm32f746g_disco/stm32f746g_disco.dts
@@ -92,7 +92,6 @@
 	touch_controller: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "FT5336";
 		int-gpios = <&gpioi 13 0>;
 	};
 };
@@ -171,7 +170,6 @@ zephyr_udc0: &usbotg_fs {
 
 	n25q128a1: qspi-nor-flash@0 {
 		compatible = "st,stm32-qspi-nor";
-		label = "N25Q128A1";
 		reg = <0>;
 		qspi-max-frequency = <72000000>;
 		size = <DT_SIZE_M(16*8)>;

--- a/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
+++ b/boards/arm/stm32f7508_dk/stm32f7508_dk.dts
@@ -93,7 +93,6 @@
 	touch_controller: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "FT5336";
 		int-gpios = <&gpioi 13 0>;
 	};
 };
@@ -172,7 +171,6 @@ zephyr_udc0: &usbotg_fs {
 
 	n25q128a1: qspi-nor-flash@0 {
 		compatible = "st,stm32-qspi-nor";
-		label = "N25Q128A1";
 		reg = <0>;
 		qspi-max-frequency = <72000000>;
 		size = <DT_SIZE_M(16*8)>;

--- a/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
+++ b/boards/arm/stm32f769i_disco/stm32f769i_disco.dts
@@ -124,7 +124,6 @@ arduino_serial: &usart6 {};
 	touch_controller: ft6202@2a {
 		compatible = "focaltech,ft5336";
 		reg = <0x2a>;
-		label = "FT6202";
 		int-gpios = <&gpioi 13 0>;
 	};
 };
@@ -167,7 +166,6 @@ arduino_serial: &usart6 {};
 
 	mx25l51245g: qspi-nor-flash@0 {
 		compatible = "st,stm32-qspi-nor";
-		label = "MX25L51245G";
 		reg = <0>;
 		qspi-max-frequency = <72000000>;
 		size = <DT_SIZE_M(64*8)>;

--- a/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
+++ b/boards/arm/stm32g071b_disco/stm32g071b_disco.dts
@@ -137,7 +137,6 @@
 	vbus_meas: ina230@40 {
 		status = "okay";
 		compatible = "ti,ina230";
-		label = "VBUS";
 		reg = <0x40>;
 		config = <INA230_CONFIG(
 			INA230_OPER_MODE_BUS_VOLTAGE_CONT,

--- a/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
+++ b/boards/arm/stm32g081b_eval/stm32g081b_eval.dts
@@ -71,7 +71,6 @@
 		 */
 		discharge_vbus2 {
 			gpios = <&gpiob 14 GPIO_ACTIVE_HIGH>;
-			label = "DISCHARGE_VBUS2";
 		};
 	};
 

--- a/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
+++ b/boards/arm/stm32h735g_disco/stm32h735g_disco.dts
@@ -131,7 +131,6 @@
 
 	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		label = "MX25LM51245";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		size = <DT_SIZE_M(64)>;

--- a/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
+++ b/boards/arm/stm32h7b3i_dk/stm32h7b3i_dk.dts
@@ -126,7 +126,6 @@
 	touch_controller: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "FT5336";
 		int-gpios = <&gpioh 2 0>;
 	};
 };
@@ -238,7 +237,6 @@
 
 	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		label = "MX25LM51245";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		size = <DT_SIZE_M(64)>;

--- a/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
+++ b/boards/arm/stm32l562e_dk/stm32l562e_dk_common.dtsi
@@ -107,7 +107,6 @@
 		compatible = "st,lsm6dso";
 		reg = <0x6a>;
 		irq-gpios = <&gpiof 3 GPIO_ACTIVE_HIGH>;
-		label = "LSM6DSO";
 	};
 };
 
@@ -127,7 +126,6 @@
 		irq-gpios = <&gpiog 6 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		reset-gpios = <&gpiog 8 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 		spi-max-frequency = <2000000>;
-		label = "SPBTLE-RF";
 	};
 };
 
@@ -144,7 +142,6 @@
 
 	mx25lm51245: ospi-nor-flash@0 {
 		compatible = "st,stm32-ospi-nor";
-		label = "MX25LM51245";
 		reg = <0>;
 		ospi-max-frequency = <DT_FREQ_M(50)>;
 		size = <DT_SIZE_M(64)>;


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>