### PR TITLE
boards: arm: Remove label property from devicetree

### DIFF
--- a/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
+++ b/boards/arm/arty/dts/arty_a7_arm_designstart.dtsi
@@ -149,7 +149,6 @@
 			compatible = "xlnx,xps-gpio-1.00.a";
 			status = "disabled";
 			reg = <0x40010000 0x10000>;
-			label = "DAPLINK_GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -168,7 +167,6 @@
 			interrupts = <4 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			label = "DAPLINK_QUAD_SPI_0";
 
 			xlnx,num-ss-bits = <0x1>;
 			xlnx,num-transfer-bits = <0x8>;
@@ -179,7 +177,6 @@
 			status = "disabled";
 			reg = <0x40030000 0x10000>;
 			interrupts = <5 0>;
-			label = "DAPLINK_SINGLE_SPI_0";
 			#address-cells = <1>;
 			#size-cells = <0>;
 
@@ -191,14 +188,12 @@
 			compatible = "xlnx,xps-uartlite-1.00.a";
 			interrupts = <0 0>;
 			reg = <0x40100000 0x10000>;
-			label = "UART_0";
 		};
 
 		gpio0: gpio@40110000 {
 			compatible = "xlnx,xps-gpio-1.00.a";
 			interrupts = <1 0>;
 			reg = <0x40110000 0x10000>;
-			label = "GPIO_0";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -216,7 +211,6 @@
 
 			gpio0_2: gpio2 {
 				compatible = "xlnx,xps-gpio-1.00.a-gpio2";
-				label = "GPIO_0_2";
 				gpio-controller;
 				#gpio-cells = <2>;
 			};
@@ -226,7 +220,6 @@
 			compatible = "xlnx,xps-gpio-1.00.a";
 			interrupts = <2 0>;
 			reg = <0x40120000 0x10000>;
-			label = "GPIO_1";
 			gpio-controller;
 			#gpio-cells = <2>;
 
@@ -244,7 +237,6 @@
 
 			gpio1_2: gpio2 {
 				compatible = "xlnx,xps-gpio-1.00.a-gpio2";
-				label = "GPIO_1_2";
 				gpio-controller;
 				#gpio-cells = <2>;
 			};
@@ -256,7 +248,6 @@
 			interrupts = <3 0>;
 			#address-cells = <1>;
 			#size-cells = <0>;
-			label = "QUAD_SPI_0";
 
 			xlnx,num-ss-bits = <0x1>;
 			xlnx,num-transfer-bits = <0x8>;
@@ -267,7 +258,6 @@
 				spi-max-frequency = <108000000>;
 				size = <DT_SIZE_M(128)>;
 				jedec-id = [20 ba 18];
-				label = "FLASH_0";
 
 				partitions {
 					compatible = "fixed-partitions";

--- a/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
+++ b/boards/arm/cc1352r_sensortag/cc1352r_sensortag.dts
@@ -108,13 +108,11 @@
 	sensor0: sensor@44 {
 		compatible = "ti,opt3001";
 		reg = <0x44>;
-		label = "OPT3001";
 	};
 
 	sensor2: sensor@41 {
 		compatible = "ti,hdc2080";
 		reg = <0x41>;
-		label = "HDC2080";
 		int-gpios = <&gpio0 25 GPIO_ACTIVE_LOW>;
 	};
 };
@@ -129,7 +127,6 @@
 	sensor1: sensor@0 {
 		compatible = "adi,adxl362";
 		reg = <0>;
-		label = "ADXL362";
 		int1-gpios = <&gpio0 30 GPIO_ACTIVE_HIGH>;
 		spi-max-frequency = <8000000>;
 	};

--- a/boards/arm/cyclonev_socdk/cyclonev_socdk.dts
+++ b/boards/arm/cyclonev_socdk/cyclonev_socdk.dts
@@ -66,13 +66,11 @@
 				address-width = <8>;
 				timeout = <25>;
 				pagesize = <32>;
-				label = "EEPROM";
 			};
 
 			ds3231: rtc@68 {
 				compatible = "maxim,ds3231";
 				reg = <0x68>;
-				label = "RTC_DS1339";
 			};
 		};
 	};

--- a/boards/arm/efr32_radio/efr32_radio.dtsi
+++ b/boards/arm/efr32_radio/efr32_radio.dtsi
@@ -74,7 +74,6 @@
 
 	mx25r80: mx25r8035f@0 {
 		compatible = "jedec,spi-nor";
-		label = "MX25R8035F";
 		reg = <0>;
 		spi-max-frequency = <33000000>;
 		size = <0x800000>;

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -92,7 +92,6 @@
 
 	mx25r80: mx25r8035f@0 {
 		compatible = "jedec,spi-nor";
-		label = "MX25R8035F";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
 		size = <0x800000>;
@@ -127,7 +126,6 @@
 	ccs811: ccs811@5a {
 		compatible = "ams,ccs811";
 		reg = <0x5a>;
-		label = "CCS811";
 		supply-gpios = <&gpiof 14 GPIO_ACTIVE_HIGH>;
 		irq-gpios = <&gpiof 13 GPIO_ACTIVE_LOW>;
 		wake-gpios = <&gpiof 15 GPIO_ACTIVE_LOW>;

--- a/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.dts
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/fvp_baser_aemv8r_aarch32.dts
@@ -24,7 +24,6 @@
 	psci {
 		compatible = "arm,psci-0.2";
 		method = "hvc";
-		label = "PSCI";
 	};
 
 	soc {

--- a/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
+++ b/boards/arm/gd32e103v_eval/gd32e103v_eval.dts
@@ -120,7 +120,6 @@
 		compatible = "atmel,at24";
 		reg = <0x50>;
 		status = "okay";
-		label = "EEPROM_AT24C02";
 		size = <256>;
 		pagesize = <8>;
 		address-width = <8>;

--- a/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
+++ b/boards/arm/gd32f450i_eval/gd32f450i_eval.dts
@@ -136,7 +136,6 @@
 		compatible = "atmel,at24";
 		reg = <0x50>;
 		status = "okay";
-		label = "EEPROM_AT24C02";
 		size = <256>;
 		pagesize = <8>;
 		address-width = <8>;
@@ -153,7 +152,6 @@
 	nor_flash: gd25q16@0 {
 		compatible ="jedec,spi-nor";
 		size = <0x1000000>;
-		label = "GD25Q16";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
 		status = "okay";

--- a/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
+++ b/boards/arm/gd32f450z_eval/gd32f450z_eval.dts
@@ -122,7 +122,6 @@
 		compatible = "atmel,at24";
 		reg = <0x50>;
 		status = "okay";
-		label = "EEPROM_AT24C02";
 		size = <256>;
 		pagesize = <8>;
 		address-width = <8>;
@@ -139,7 +138,6 @@
 	nor_flash: gd25q16@0 {
 		compatible ="jedec,spi-nor";
 		size = <0x1000000>;
-		label = "GD25Q16";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
 		status = "okay";

--- a/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
+++ b/boards/arm/gd32f470i_eval/gd32f470i_eval.dts
@@ -126,7 +126,6 @@
 		compatible = "atmel,at24";
 		reg = <0x50>;
 		status = "okay";
-		label = "EEPROM_AT24C02";
 		size = <256>;
 		pagesize = <8>;
 		address-width = <8>;
@@ -143,7 +142,6 @@
 	nor_flash: gd25q16@0 {
 		compatible ="jedec,spi-nor";
 		size = <0x1000000>;
-		label = "GD25Q16";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
 		status = "okay";

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.dts
@@ -60,7 +60,6 @@
 
 &i2c_smb_0 {
 	status = "okay";
-	label = "I2C0";
 	port_sel = <0>;
 	sda-gpios = <&gpio_000_036 3 0>;
 	scl-gpios = <&gpio_000_036 4 0>;
@@ -68,7 +67,6 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	label = "I2C1";
 	port_sel = <1>;
 	sda-gpios = <&gpio_100_136 24 0>;
 	scl-gpios = <&gpio_100_136 25 0>;

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.dts
@@ -88,14 +88,12 @@
 
 &i2c_smb_0 {
 	status = "okay";
-	label = "I2C0";
 	port_sel = <0>;
 	sda-gpios = <&gpio_000_036 3 0>;
 	scl-gpios = <&gpio_000_036 4 0>;
 
 	pca9555@26 {
 		compatible = "nxp,pca95xx";
-		label = "GPIO_P0";
 
 		/* Depends on JP53 for device address.
 		 * Pin 1-2 = A0, pin 3-4 = A1, pin 5-6 = A2.
@@ -113,7 +111,6 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	label = "I2C1";
 	port_sel = <1>;
 	sda-gpios = <&gpio_100_136 24 0>;
 	scl-gpios = <&gpio_100_136 25 0>;
@@ -121,7 +118,6 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	label = "I2C7";
 	port_sel = <7>;
 	sda-gpios = <&gpio_000_036 10 0>;
 	scl-gpios = <&gpio_000_036 11 0>;

--- a/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
+++ b/boards/arm/mec172xevb_assy6906/mec172xevb_assy6906.dts
@@ -137,7 +137,6 @@
 /* I2C */
 &i2c_smb_0 {
 	status = "okay";
-	label = "I2C0";
 	port_sel = <0>;
 
 	pinctrl-0 = < &i2c00_scl_gpio004 &i2c00_sda_gpio003 >;
@@ -145,7 +144,6 @@
 
 	pca9555@26 {
 		compatible = "nxp,pca95xx";
-		label = "GPIO_P0";
 
 		/* Depends on JP53 for device address.
 		 * Pin 1-2 = A0, pin 3-4 = A1, pin 5-6 = A2.
@@ -173,7 +171,6 @@
 
 &i2c_smb_1 {
 	status = "okay";
-	label = "I2C1";
 	port_sel = <1>;
 	pinctrl-0 = <&i2c01_scl_gpio131 &i2c01_sda_gpio130>;
 	pinctrl-names = "default";
@@ -191,7 +188,6 @@
 
 &i2c_smb_2 {
 	status = "okay";
-	label = "I2C7";
 	port_sel = <7>;
 	pinctrl-0 = <&i2c07_scl_gpio013 &i2c07_sda_gpio012>;
 	pinctrl-names = "default";

--- a/boards/arm/mps2_an385/mps2_an385.dts
+++ b/boards/arm/mps2_an385/mps2_an385.dts
@@ -81,21 +81,18 @@
 			compatible = "arm,cmsdk-timer";
 			reg = <0x40000000 0x1000>;
 			interrupts = <8 3>;
-			label = "TIMER_0";
 		};
 
 		timer1: timer@40001000 {
 			compatible = "arm,cmsdk-timer";
 			reg = <0x40001000 0x1000>;
 			interrupts = <9 3>;
-			label = "TIMER_1";
 		};
 
 		dtimer0: dtimer@40002000 {
 			compatible = "arm,cmsdk-dtimer";
 			reg = <0x40002000 0x1000>;
 			interrupts = <10 3>;
-			label = "DTIMER_0";
 		};
 
 		uart0: uart@40004000 {
@@ -105,7 +102,6 @@
 			interrupt-names = "tx", "rx";
 			clocks = <&sysclk>;
 			current-speed = <115200>;
-			label = "UART_0";
 		};
 
 		uart1: uart@40005000 {
@@ -115,7 +111,6 @@
 			interrupt-names = "tx", "rx";
 			clocks = <&sysclk>;
 			current-speed = <115200>;
-			label = "UART_1";
 		};
 
 		uart2: uart@40006000 {
@@ -125,7 +120,6 @@
 			interrupt-names = "tx", "rx";
 			clocks = <&sysclk>;
 			current-speed = <115200>;
-			label = "UART_2";
 		};
 
 		uart3: uart@40007000 {
@@ -135,14 +129,12 @@
 			interrupt-names = "tx", "rx";
 			clocks = <&sysclk>;
 			current-speed = <115200>;
-			label = "UART_3";
 		};
 
 		wdog0: wdog@40008000 {
 			compatible = "arm,cmsdk-watchdog";
 			clocks = <&sysclk>;
 			reg = <0x40008000 0x1000>;
-			label = "WATCHDOG";
 		};
 
 		uart4: uart@40009000 {
@@ -152,7 +144,6 @@
 			interrupt-names = "tx", "rx";
 			clocks = <&sysclk>;
 			current-speed = <115200>;
-			label = "UART_4";
 		};
 
 		gpio0: gpio@40010000 {
@@ -161,7 +152,6 @@
 			interrupts = <6 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_0";
 		};
 
 		gpio1: gpio@40011000 {
@@ -170,7 +160,6 @@
 			interrupts = <7 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_1";
 		};
 
 		gpio2: gpio@40012000 {
@@ -179,7 +168,6 @@
 			interrupts = <16 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_2";
 		};
 
 		gpio3: gpio@40013000 {
@@ -188,7 +176,6 @@
 			interrupts = <17 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_3";
 		};
 
 		eth0: eth@40200000 {
@@ -197,7 +184,6 @@
 			/* Such a big size from memory map in AN385 */
 			/* Actual reg range is ~0x200 */
 			reg = <0x40200000 0x100000>;
-			label = "eth0";
 			interrupts = <13 3>;
 		};
 
@@ -207,7 +193,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40022000 0x1000>;
-			label = "I2C_TOUCH";
 		};
 
 		i2c_audio_conf: i2c@40023000 {
@@ -216,7 +201,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40023000 0x1000>;
-			label = "I2C_AUDIO_CONF";
 		};
 
 		i2c_shield0: i2c@40029000 {
@@ -225,7 +209,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x40029000 0x1000>;
-			label = "I2C_SHIELD0";
 		};
 
 		i2c_shield1: i2c@4002a000 {
@@ -234,7 +217,6 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0x4002a000 0x1000>;
-			label = "I2C_SHIELD1";
 		};
 
 		gpio_led0: mps2_fpgaio@40028000 {
@@ -244,7 +226,6 @@
 			gpio-controller;
 			#gpio-cells = <1>;
 			ngpios = <2>;
-			label = "FPGA_LED0";
 		};
 
 		gpio_button: mps2_fpgaio@40028008 {
@@ -254,7 +235,6 @@
 			gpio-controller;
 			#gpio-cells = <1>;
 			ngpios = <2>;
-			label = "FPGA_BUTTON";
 		};
 
 		gpio_misc: mps2_fpgaio@4002804c {
@@ -264,7 +244,6 @@
 			gpio-controller;
 			#gpio-cells = <1>;
 			ngpios = <10>;
-			label = "FPGA_MISC";
 		};
 
 	};

--- a/boards/arm/mps2_an521/mps2_an521-common.dtsi
+++ b/boards/arm/mps2_an521/mps2_an521-common.dtsi
@@ -14,35 +14,30 @@ timer0: timer@0 {
 	compatible = "arm,cmsdk-timer";
 	reg = <0x0 0x1000>;
 	interrupts = <3 3>;
-	label = "TIMER_0";
 };
 
 timer1: timer@1000 {
 	compatible = "arm,cmsdk-timer";
 	reg = <0x1000 0x1000>;
 	interrupts = <4 3>;
-	label = "TIMER_1";
 };
 
 dtimer0: dtimer@2000 {
 	compatible = "arm,cmsdk-dtimer";
 	reg = <0x2000 0x1000>;
 	interrupts = <5 3>;
-	label = "DTIMER_0";
 };
 
 mhu0: mhu@3000 {
 	compatible = "arm,mhu";
 	reg = <0x3000 0x1000>;
 	interrupts = <6 3>;
-	label = "MHU_0";
 };
 
 mhu1: mhu@4000 {
 	compatible = "arm,mhu";
 	reg = <0x4000 0x1000>;
 	interrupts = <7 3>;
-	label = "MHU_1";
 };
 
 gpio0: gpio@100000 {
@@ -51,7 +46,6 @@ gpio0: gpio@100000 {
 	interrupts = <68 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_0";
 };
 
 gpio1: gpio@101000 {
@@ -60,7 +54,6 @@ gpio1: gpio@101000 {
 	interrupts = <69 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_1";
 };
 
 gpio2: gpio@102000 {
@@ -69,7 +62,6 @@ gpio2: gpio@102000 {
 	interrupts = <70 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_2";
 };
 
 gpio3: gpio@103000 {
@@ -78,14 +70,12 @@ gpio3: gpio@103000 {
 	interrupts = <71 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_3";
 };
 
 wdog0: wdog@81000 {
 	compatible = "arm,cmsdk-watchdog";
 	reg = <0x81000 0x1000>;
 	clocks = <&sysclk>;
-	label = "WATCHDOG";
 };
 
 uart0: uart@200000 {
@@ -95,7 +85,6 @@ uart0: uart@200000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_0";
 };
 
 uart1: uart@201000 {
@@ -105,7 +94,6 @@ uart1: uart@201000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_1";
 };
 
 uart2: uart@202000 {
@@ -115,7 +103,6 @@ uart2: uart@202000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_2";
 };
 
 uart3: uart@203000 {
@@ -125,7 +112,6 @@ uart3: uart@203000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_3";
 };
 
 uart4: uart@204000 {
@@ -135,7 +121,6 @@ uart4: uart@204000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_4";
 };
 
 i2c_touch: i2c@207000 {
@@ -144,7 +129,6 @@ i2c_touch: i2c@207000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x207000 0x1000>;
-	label = "I2C_TOUCH";
 };
 
 i2c_audio_conf: i2c@208000 {
@@ -153,7 +137,6 @@ i2c_audio_conf: i2c@208000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x208000 0x1000>;
-	label = "I2C_AUDIO_CONF";
 };
 
 i2c_shield0: i2c@20c000 {
@@ -162,7 +145,6 @@ i2c_shield0: i2c@20c000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x20c000 0x1000>;
-	label = "I2C_SHIELD0";
 };
 
 i2c_shield1: i2c@20d000 {
@@ -171,7 +153,6 @@ i2c_shield1: i2c@20d000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x20d000 0x1000>;
-	label = "I2C_SHIELD1";
 };
 
 gpio_led0: mps2_fpgaio@302000 {
@@ -181,7 +162,6 @@ gpio_led0: mps2_fpgaio@302000 {
 	gpio-controller;
 	#gpio-cells = <1>;
 	ngpios = <2>;
-	label = "FPGA_LED0";
 };
 
 gpio_button: mps2_fpgaio@302008 {
@@ -191,7 +171,6 @@ gpio_button: mps2_fpgaio@302008 {
 	gpio-controller;
 	#gpio-cells = <1>;
 	ngpios = <2>;
-	label = "FPGA_BUTTON";
 };
 
 gpio_misc: mps2_fpgaio@30204c {
@@ -201,7 +180,6 @@ gpio_misc: mps2_fpgaio@30204c {
 	gpio-controller;
 	#gpio-cells = <1>;
 	ngpios = <10>;
-	label = "FPGA_MISC";
 };
 
 eth0: eth@2000000 {
@@ -209,6 +187,5 @@ eth0: eth@2000000 {
 	compatible = "smsc,lan9220";
 	/* Actual reg range is ~0x200 */
 	reg = <0x2000000 0x100000>;
-	label = "eth0";
 	interrupts = <48 3>;
 };

--- a/boards/arm/mps3_an547/mps3_an547-common.dtsi
+++ b/boards/arm/mps3_an547/mps3_an547-common.dtsi
@@ -16,7 +16,6 @@ gpio0: gpio@1100000 {
 	interrupts = <69 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_0";
 };
 
 gpio1: gpio@1101000 {
@@ -25,7 +24,6 @@ gpio1: gpio@1101000 {
 	interrupts = <70 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_1";
 };
 
 gpio2: gpio@1102000 {
@@ -34,7 +32,6 @@ gpio2: gpio@1102000 {
 	interrupts = <71 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_2";
 };
 
 gpio3: gpio@1103000 {
@@ -43,7 +40,6 @@ gpio3: gpio@1103000 {
 	interrupts = <72 3>;
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_3";
 };
 
 eth0: eth@1400000 {
@@ -51,7 +47,6 @@ eth0: eth@1400000 {
 	compatible = "smsc,lan9220";
 	/* Actual reg range is ~0x200 */
 	reg = <0x1400000 0x100000>;
-	label = "eth0";
 	interrupts = <49 3>;
 };
 
@@ -61,7 +56,6 @@ i2c_touch: i2c@9200000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9200000 0x1000>;
-	label = "I2C_TOUCH";
 };
 
 i2c_audio_conf: i2c@9201000 {
@@ -70,7 +64,6 @@ i2c_audio_conf: i2c@9201000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9201000 0x1000>;
-	label = "I2C_AUDIO_CONF";
 };
 
 i2c_shield0: i2c@9203000 {
@@ -79,7 +72,6 @@ i2c_shield0: i2c@9203000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9203000 0x1000>;
-	label = "I2C_SHIELD0";
 };
 
 i2c_shield1: i2c@9204000 {
@@ -88,7 +80,6 @@ i2c_shield1: i2c@9204000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9204000 0x1000>;
-	label = "I2C_SHIELD1";
 };
 
 i2c_ddr4_eeprom: i2c@9208000 {
@@ -97,7 +88,6 @@ i2c_ddr4_eeprom: i2c@9208000 {
 	#address-cells = <1>;
 	#size-cells = <0>;
 	reg = <0x9208000 0x1000>;
-	label = "DDR4_EEPROM";
 };
 
 gpio_led0: mps3_fpgaio@9302000 {
@@ -107,7 +97,6 @@ gpio_led0: mps3_fpgaio@9302000 {
 	gpio-controller;
 	#gpio-cells = <1>;
 	ngpios = <8>;
-	label = "FPGA_LED0";
 };
 
 gpio_button: mps3_fpgaio@9302008 {
@@ -117,7 +106,6 @@ gpio_button: mps3_fpgaio@9302008 {
 	gpio-controller;
 	#gpio-cells = <1>;
 	ngpios = <2>;
-	label = "FPGA_BUTTON";
 };
 
 gpio_misc: mps3_fpgaio@930204c {
@@ -127,7 +115,6 @@ gpio_misc: mps3_fpgaio@930204c {
 	gpio-controller;
 	#gpio-cells = <1>;
 	ngpios = <3>;
-	label = "FPGA_MISC";
 };
 
 uart0: uart@9303000 {
@@ -137,7 +124,6 @@ uart0: uart@9303000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_0";
 };
 
 uart1: uart@9304000 {
@@ -147,7 +133,6 @@ uart1: uart@9304000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_1";
 };
 
 uart2: uart@9305000 {
@@ -157,7 +142,6 @@ uart2: uart@9305000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_2";
 };
 
 uart3: uart@9306000 {
@@ -167,7 +151,6 @@ uart3: uart@9306000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_3";
 };
 
 uart4: uart@9307000 {
@@ -177,7 +160,6 @@ uart4: uart@9307000 {
 	interrupt-names = "tx", "rx";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_4";
 };
 
 uart5: uart@9308000 {
@@ -188,5 +170,4 @@ uart5: uart@9308000 {
 	interrupts = <126 3 125 3>;
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_5";
 };

--- a/boards/arm/scobc_module1/scobc_module1.dts
+++ b/boards/arm/scobc_module1/scobc_module1.dts
@@ -46,7 +46,6 @@
 			compatible = "xlnx,xps-uartlite-1.00.a";
 			interrupts = <0 0>;
 			reg = <0x50010000 0x10000>;
-			label = "UART_0";
 		};
 	};
 };

--- a/boards/arm/v2m_beetle/v2m_beetle.dts
+++ b/boards/arm/v2m_beetle/v2m_beetle.dts
@@ -51,7 +51,6 @@
 			compatible = "arm,cmsdk-timer";
 			reg = <0x40000000 0x1000>;
 			interrupts = <8 3>;
-			label = "TIMER_0";
 			clocks = <&syscon>;
 		};
 
@@ -59,7 +58,6 @@
 			compatible = "arm,cmsdk-timer";
 			reg = <0x40001000 0x1000>;
 			interrupts = <9 3>;
-			label = "TIMER_1";
 			clocks = <&syscon>;
 		};
 
@@ -67,7 +65,6 @@
 			compatible = "arm,cmsdk-dtimer";
 			reg = <0x40002000 0x1000>;
 			interrupts = <10 3>;
-			label = "DTIMER_0";
 			clocks = <&syscon>;
 		};
 
@@ -77,7 +74,6 @@
 			interrupts = <0 3>;
 			clocks = <&sysclk &syscon>;
 			current-speed = <115200>;
-			label = "UART_0";
 		};
 
 		uart1: uart@40005000 {
@@ -86,14 +82,12 @@
 			interrupts = <2 3>;
 			clocks = <&sysclk &syscon>;
 			current-speed = <115200>;
-			label = "UART_1";
 		};
 
 		wdog0: wdog@40008000 {
 			compatible = "arm,cmsdk-watchdog";
 			clocks = <&sysclk>;
 			reg = <0x40008000 0x1000>;
-			label = "WATCHDOG";
 		};
 
 		gpio0: gpio@40010000 {
@@ -102,7 +96,6 @@
 			interrupts = <6 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_0";
 			clocks = <&syscon>;
 		};
 
@@ -112,7 +105,6 @@
 			interrupts = <7 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_1";
 			clocks = <&syscon>;
 		};
 
@@ -122,7 +114,6 @@
 			interrupts = <42 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_2";
 			clocks = <&syscon>;
 		};
 
@@ -132,7 +123,6 @@
 			interrupts = <43 3>;
 			gpio-controller;
 			#gpio-cells = <2>;
-			label = "GPIO_3";
 			clocks = <&syscon>;
 		};
 

--- a/boards/arm/v2m_musca_b1/v2m_musca_b1-common.dtsi
+++ b/boards/arm/v2m_musca_b1/v2m_musca_b1-common.dtsi
@@ -8,21 +8,18 @@ mhu0: mhu@3000 {
 	compatible = "arm,mhu";
 	reg = <0x3000 0x1000>;
 	interrupts = <6 3>;
-	label = "MHU_0";
 };
 
 mhu1: mhu@4000 {
 	compatible = "arm,mhu";
 	reg = <0x4000 0x1000>;
 	interrupts = <7 3>;
-	label = "MHU_1";
 };
 
 timer: timer@10c000 {
 	compatible = "arm,cmsdk-timer";
 	reg = <0x10c000 0x1000>;
 	interrupts = <3 3>;
-	label = "TIMER_0";
 };
 
 uart0: uart@105000 {
@@ -32,7 +29,6 @@ uart0: uart@105000 {
 	interrupt-names = "rx", "tx", "rxtim", "err";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_0";
 };
 
 uart1: uart@106000 {
@@ -42,7 +38,6 @@ uart1: uart@106000 {
 	interrupt-names = "rx", "tx", "rxtim", "err";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_1";
 };
 
 gpio: gpio@1000000 {
@@ -55,5 +50,4 @@ gpio: gpio@1000000 {
 		      63 3 64 3 65 3 66 3>; /* PINS 12:15 */
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_0";
 };

--- a/boards/arm/v2m_musca_s1/v2m_musca_s1-common.dtsi
+++ b/boards/arm/v2m_musca_s1/v2m_musca_s1-common.dtsi
@@ -8,21 +8,18 @@ mhu0: mhu@3000 {
 	compatible = "arm,mhu";
 	reg = <0x3000 0x1000>;
 	interrupts = <6 3>;
-	label = "MHU_0";
 };
 
 mhu1: mhu@4000 {
 	compatible = "arm,mhu";
 	reg = <0x4000 0x1000>;
 	interrupts = <7 3>;
-	label = "MHU_1";
 };
 
 timer: timer@10b000 {
 	compatible = "arm,cmsdk-timer";
 	reg = <0x10b000 0x1000>;
 	interrupts = <33 3>;
-	label = "TIMER_0";
 };
 
 uart0: uart@101000 {
@@ -32,7 +29,6 @@ uart0: uart@101000 {
 	interrupt-names = "rx", "tx", "rxtim", "err";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_0";
 };
 
 uart1: uart@102000 {
@@ -42,7 +38,6 @@ uart1: uart@102000 {
 	interrupt-names = "rx", "tx", "rxtim", "err";
 	clocks = <&sysclk>;
 	current-speed = <115200>;
-	label = "UART_1";
 };
 
 gpio: gpio@110000 {
@@ -55,5 +50,4 @@ gpio: gpio@110000 {
 				  63 3 64 3 65 3 66 3>;	/* PINS 12:15 */
 	gpio-controller;
 	#gpio-cells = <2>;
-	label = "GPIO_0";
 };

--- a/boards/arm/xmc45_relax_kit/xmc45_relax_kit.dts
+++ b/boards/arm/xmc45_relax_kit/xmc45_relax_kit.dts
@@ -30,6 +30,5 @@
 &usic1ch1 {
 	compatible = "infineon,xmc4xxx-uart";
 	current-speed = <115200>;
-	label = "UART_0";
 	status = "okay";
 };


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>