### PR TITLE
boards: arm: nxp: Remove label property from devicetree

### DIFF
--- a/boards/arm/faze/faze.dts
+++ b/boards/arm/faze/faze.dts
@@ -80,7 +80,6 @@
 	led_controller_0: lp5030@30 {
 		compatible = "ti,lp5030", "ti,lp503x";
 		reg = <0x30>;
-		label = "LP5030";
 
 		led0: led_0 {
 			label = "LED LP5030 0";

--- a/boards/arm/frdm_k22f/frdm_k22f.dts
+++ b/boards/arm/frdm_k22f/frdm_k22f.dts
@@ -132,7 +132,6 @@ arduino_i2c: &i2c0 {
 	fxos8700: fxos8700@1c {
 		compatible = "nxp,fxos8700";
 		reg = <0x1c>;
-		label = "FXOS8700";
 		int1-gpios = <&gpiod 0 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpiod 1 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/arm/frdm_k64f/frdm_k64f.dts
+++ b/boards/arm/frdm_k64f/frdm_k64f.dts
@@ -134,7 +134,6 @@ arduino_i2c: &i2c0 {
 	fxos8700: fxos8700@1d {
 		compatible = "nxp,fxos8700";
 		reg = <0x1d>;
-		label = "FXOS8700";
 		int1-gpios = <&gpioc 6 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/arm/frdm_k82f/frdm_k82f.dts
+++ b/boards/arm/frdm_k82f/frdm_k82f.dts
@@ -184,7 +184,6 @@
 	fxos8700: fxos8700@1c {
 		compatible = "nxp,fxos8700";
 		reg = <0x1c>;
-		label = "FXOS8700";
 		int1-gpios = <&gpioc 13 GPIO_ACTIVE_LOW>;
 	};
 };
@@ -217,7 +216,6 @@
 
 	mx25u32: mx25u3235f@0 {
 		compatible = "jedec,spi-nor";
-		label = "MX25U3235F";
 		reg = <0>;
 		spi-max-frequency = <104000000>;
 		wp-gpios = <&gpioe 3 0>;

--- a/boards/arm/frdm_kl25z/frdm_kl25z.dts
+++ b/boards/arm/frdm_kl25z/frdm_kl25z.dts
@@ -105,7 +105,6 @@
 	mma8451q@1d {
 		compatible = "nxp,fxos8700","nxp,mma8451q";
 		reg = <0x1d>;
-		label = "MMA8451Q";
 		int1-gpios = <&gpioa 14 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpioa 15 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/arm/frdm_kw41z/frdm_kw41z.dts
+++ b/boards/arm/frdm_kw41z/frdm_kw41z.dts
@@ -123,7 +123,6 @@
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";
 		reg = <0x1f>;
-		label = "FXOS8700";
 		int1-gpios = <&gpioc 1 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/arm/hexiwear_k64/hexiwear_k64.dts
+++ b/boards/arm/hexiwear_k64/hexiwear_k64.dts
@@ -62,7 +62,6 @@
 
 	en_bat_sens: enable-battery-sense {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "en_bat_sens";
 		regulator-name = "en_bat_sens";
 		enable-gpios = <&gpioc 14 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
@@ -70,7 +69,6 @@
 
 	en_ldo: enable-ldo {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "en_ldo";
 		regulator-name = "en_ldo";
 		enable-gpios = <&gpioa 29 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -78,7 +76,6 @@
 
 	en_3v3b: enable-3v3b {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "en_3v3b";
 		regulator-name = "en_3v3b";
 		enable-gpios = <&gpiob 12 GPIO_ACTIVE_LOW>;
 		regulator-boot-on;
@@ -119,7 +116,6 @@
 		status = "disabled";
 		compatible = "maxim,max30101";
 		reg = <0x57>;
-		label = "MAX30101";
 	};
 };
 
@@ -131,7 +127,6 @@
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		label = "FXOS8700";
 		int1-gpios = <&gpioc 1 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpiod 13 GPIO_ACTIVE_LOW>;
 	};
@@ -139,7 +134,6 @@
 	fxas21002@20 {
 		compatible = "nxp,fxas21002";
 		reg = <0x20>;
-		label = "FXAS21002";
 		int1-gpios = <&gpiod 1 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpioc 18 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
+++ b/boards/arm/lpcxpresso55s16/lpcxpresso55s16_common.dtsi
@@ -134,7 +134,6 @@
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		label = "FXOS8700";
 		int1-gpios = <&gpio1 26 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 };

--- a/boards/arm/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
+++ b/boards/arm/lpcxpresso55s28/lpcxpresso55s28_common.dtsi
@@ -105,7 +105,6 @@ arduino_i2c: &flexcomm4 {
 	mma8652fc@1d {
 		compatible = "nxp,fxos8700","nxp,mma8652fc";
 		reg = <0x1d>;
-		label = "MMA8652FC";
 		int1-gpios = <&gpio1 19 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;
 	};
 };

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69.dtsi
@@ -158,7 +158,6 @@ arduino_i2c: &flexcomm4 {
 	mma8652fc@1d {
 		compatible = "nxp,fxos8700","nxp,mma8652fc";
 		reg = <0x1d>;
-		label = "MMA8652FC";
 		int1-gpios = <&gpio1 19 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu0.dts
@@ -178,7 +178,6 @@ zephyr_udc0: &usbhs {
 i2s0: &flexcomm6 {
 	status = "okay";
 	compatible = "nxp,lpc-i2s";
-	label = "I2S_0";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dmas = <&dma0 16>;
@@ -189,7 +188,6 @@ i2s0: &flexcomm6 {
 i2s1: &flexcomm7 {
 	status = "okay";
 	compatible = "nxp,lpc-i2s";
-	label = "I2S_1";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dmas = <&dma0 19>;

--- a/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
+++ b/boards/arm/mimxrt1010_evk/mimxrt1010_evk.dts
@@ -55,7 +55,6 @@ arduino_serial: &lpuart1 {};
 	at25sf128a: at25sf128a@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
-		label = "AT25SF128A";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
+++ b/boards/arm/mimxrt1015_evk/mimxrt1015_evk.dts
@@ -82,7 +82,6 @@ arduino_serial: &lpuart4 {
 	at25sf128a: at25sf128a@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
-		label = "AT25SF128A";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
+++ b/boards/arm/mimxrt1020_evk/mimxrt1020_evk.dts
@@ -94,7 +94,6 @@ arduino_serial: &lpuart2 {
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
-		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
+++ b/boards/arm/mimxrt1024_evk/mimxrt1024_evk.dts
@@ -137,7 +137,6 @@
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";
 		reg = <0x1f>;
-		label = "FXOS8700";
 	};
 };
 

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk.dts
@@ -122,7 +122,6 @@ arduino_serial: &lpuart3 {
 	s26ks512s0: s26ks512s@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
-		label = "S26KS512S";
 		reg = <0>;
 		spi-max-frequency = <166000000>;
 		word-addressable;
@@ -198,7 +197,6 @@ arduino_serial: &lpuart3 {
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";
 		reg = <0x1f>;
-		label = "FXOS8700";
 
 		/* Two zero ohm resistors (R263 and R264) isolate sensor
 		 * interrupt gpios from the soc and are unpopulated by default.
@@ -212,7 +210,6 @@ arduino_serial: &lpuart3 {
 	touch_controller: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "FT5336";
 		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
+++ b/boards/arm/mimxrt1050_evk/mimxrt1050_evk_qspi.dts
@@ -25,7 +25,6 @@
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
-		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk.dts
@@ -112,7 +112,6 @@ arduino_serial: &lpuart3 {
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
-		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
@@ -180,7 +179,6 @@ arduino_serial: &lpuart3 {
 	touch_controller: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "FT5336";
 		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };

--- a/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
+++ b/boards/arm/mimxrt1060_evk/mimxrt1060_evk_hyperflash.dts
@@ -29,7 +29,6 @@
 	s26ks512s0: s26ks512s@0 {
 		compatible = "nxp,imx-flexspi-hyperflash";
 		size = <DT_SIZE_M(64*8)>;
-		label = "S26KS512S";
 		reg = <0>;
 		spi-max-frequency = <166000000>;
 		word-addressable;

--- a/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
+++ b/boards/arm/mimxrt1064_evk/mimxrt1064_evk.dts
@@ -157,7 +157,6 @@ arduino_i2c: &lpi2c1 {};
 	mt9m114: mt9m114@48 {
 		compatible = "aptina,mt9m114";
 		reg = <0x48>;
-		label = "MT9M114";
 		status = "okay";
 
 		port {
@@ -170,7 +169,6 @@ arduino_i2c: &lpi2c1 {};
 	touch_controller: ft5336@38 {
 		compatible = "focaltech,ft5336";
 		reg = <0x38>;
-		label = "FT5336";
 		int-gpios = <&gpio1 11 GPIO_ACTIVE_LOW>;
 	};
 };
@@ -186,7 +184,6 @@ arduino_i2c: &lpi2c1 {};
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
-		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk.dtsi
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk.dtsi
@@ -69,7 +69,6 @@
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";
 		reg = <0x1f>;
-		label = "FXOS8700";
 
 		/* Two zero ohm resistors (R256 and R270) isolate sensor
 		 * interrupt gpios from the soc and are unpopulated by default.

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm4.dts
@@ -54,7 +54,6 @@
 	is25wp128: is25wp128@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
-		label = "IS25WP128";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
+++ b/boards/arm/mimxrt1160_evk/mimxrt1160_evk_cm7.dts
@@ -67,7 +67,6 @@
 	is25wp128: is25wp128@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
-		label = "IS25WP128";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk.dtsi
@@ -47,7 +47,6 @@
 	fxos8700: fxos8700@1f {
 		compatible = "nxp,fxos8700";
 		reg = <0x1f>;
-		label = "FXOS8700";
 
 		/* Two zero ohm resistors (R256 and R270) isolate sensor
 		 * interrupt gpios from the soc and are unpopulated by default.

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm4.dts
@@ -54,7 +54,6 @@
 	is25wp128: is25wp128@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
-		label = "IS25WP128";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
+++ b/boards/arm/mimxrt1170_evk/mimxrt1170_evk_cm7.dts
@@ -39,7 +39,6 @@
 
 	en_mipi_display: enable-mipi-display {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "en_mipi_display";
 		regulator-name = "en_mipi_display";
 		enable-gpios = <&gpio11 16 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -76,7 +75,6 @@
 		status = "okay";
 		compatible = "raydium,rm68200";
 		reg = <0x0>;
-		label = "RM68200";
 		reset-gpios = <&gpio9 1 GPIO_ACTIVE_HIGH>;
 		data-lanes = <2>;
 		width = <720>;
@@ -116,7 +114,6 @@
 	is25wp128: is25wp128@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <134217728>;
-		label = "IS25WP128";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -121,7 +121,6 @@ arduino_i2c: &flexcomm4 {
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		label = "FXOS8700";
 		int1-gpios = <&gpio0 22 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 	};
@@ -233,7 +232,6 @@ arduino_serial: &flexcomm12 {
 	mx25um51345g: mx25um51345g@0 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
 		size = <DT_SIZE_M(64)>;
-		label = "MX25UM51345G";
 		reg = <0>;
 		spi-max-frequency = <200000000>;
 		status = "okay";

--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -169,7 +169,6 @@ arduino_i2c: &flexcomm2 {
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		label = "FXOS8700";
 		int1-gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
 		reset-gpios = <&gpio1 7 GPIO_ACTIVE_HIGH>;
 	};
@@ -197,7 +196,6 @@ arduino_spi: &flexcomm5 {
 i2s0: &flexcomm1 {
 	status = "okay";
 	compatible = "nxp,lpc-i2s";
-	label = "I2S_0";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dmas = <&dma0 2>;
@@ -210,7 +208,6 @@ i2s0: &flexcomm1 {
 i2s1: &flexcomm3 {
 	status = "okay";
 	compatible = "nxp,lpc-i2s";
-	label = "I2S_1";
 	#address-cells = <1>;
 	#size-cells = <0>;
 	dmas = <&dma0 7>;
@@ -223,7 +220,6 @@ i2s1: &flexcomm3 {
 &pmic_i2c {
 	status = "okay";
 	compatible = "nxp,lpc-i2c";
-	label = "PMIC_I2C";
 	clock-frequency = <I2C_BITRATE_FAST>;
 	#address-cells = <1>;
 	#size-cells = <0>;
@@ -231,11 +227,9 @@ i2s1: &flexcomm3 {
 	pinctrl-names = "default";
 
 	pca9420: pca9420@61 {
-		label = "PCA9420_PMIC";
 		reg = <0x61>;
 
 		pca9420_sw1: sw1_buck {
-			label = "SW1_BUCK_REG";
 			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_SW1_VOLTAGE_RANGE>;
 			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
@@ -253,7 +247,6 @@ i2s1: &flexcomm3 {
 		};
 
 		pca9420_sw2: sw2_buck {
-			label = "SW2_BUCK_REG";
 			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_SW2_VOLTAGE_RANGE>;
 			num-voltages = <50>;
@@ -271,7 +264,6 @@ i2s1: &flexcomm3 {
 		};
 
 		pca9420_ldo1: ldo1_reg {
-			label = "LDO1_REG";
 			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_LDO1_VOLTAGE_RANGE>;
 			num-voltages = <9>;
@@ -289,7 +281,6 @@ i2s1: &flexcomm3 {
 		};
 
 		pca9420_ldo2: ldo2_reg {
-			label = "LDO2_REG";
 			compatible = "regulator-pmic";
 			voltage-range = <PCA9420_LDO2_VOLTAGE_RANGE>;
 			num-voltages = <50>;
@@ -316,7 +307,6 @@ i2s1: &flexcomm3 {
 	mx25um51345g: mx25um51345g@2 {
 		compatible = "nxp,imx-flexspi-mx25um51345g";
 		size = <DT_SIZE_M(64)>;
-		label = "MX25UM51345G";
 		reg = <2>;
 		spi-max-frequency = <200000000>;
 		status = "okay";

--- a/boards/arm/mm_feather/mm_feather.dts
+++ b/boards/arm/mm_feather/mm_feather.dts
@@ -59,7 +59,6 @@
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
-		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/mm_swiftio/mm_swiftio.dts
+++ b/boards/arm/mm_swiftio/mm_swiftio.dts
@@ -59,7 +59,6 @@
 	is25wp064: is25wp064@0 {
 		compatible = "nxp,imx-flexspi-nor";
 		size = <67108864>;
-		label = "IS25WP064";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";
@@ -109,7 +108,6 @@
 	ov7725: ov7725@21 {
 		compatible = "ovti,ov7725";
 		reg = <0x21>;
-		label = "OV7725";
 		status = "okay";
 
 		reset-gpios = <&gpio2 20 GPIO_ACTIVE_HIGH>;

--- a/boards/arm/teensy4/teensy40.dts
+++ b/boards/arm/teensy4/teensy40.dts
@@ -40,7 +40,6 @@
 	w25q16jvuxim: w25q16jvuxim@0 {
 		compatible = "winbond,w25q16jvuxim", "jedec,spi-nor";
 		size = <16777208>;
-		label = "W25Q16JVUXIM";
 		reg = <0>;
 		spi-max-frequency = <133000000>;
 		status = "okay";

--- a/boards/arm/teensy4/teensy41.dts
+++ b/boards/arm/teensy4/teensy41.dts
@@ -13,7 +13,6 @@
 	w25q64jvxgim: w25q64jvxgim@0 {
 		compatible = "winbond,w25q64jvxgim", "jedec,spi-nor";
 		size = < 8388607 >;
-		label = "W25Q64JVXGIM";
 		reg = < 0 >;
 		spi-max-frequency = < 133000000 >;
 		status = "okay";

--- a/boards/arm/twr_ke18f/twr_ke18f.dts
+++ b/boards/arm/twr_ke18f/twr_ke18f.dts
@@ -250,7 +250,6 @@
 	fxos8700: fxos8700@1d {
 		compatible = "nxp,fxos8700";
 		reg = <0x1d>;
-		label = "FXOS8700";
 		reset-gpios = <&gpioc 15 GPIO_ACTIVE_HIGH>;
 	};
 };

--- a/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
+++ b/boards/arm/twr_kv58f220m/twr_kv58f220m.dts
@@ -139,7 +139,6 @@
 	fxos8700: fxos8700@1c {
 		compatible = "nxp,fxos8700";
 		reg = <0x1c>;
-		label = "FXOS8700";
 		int1-gpios = <&gpioc 18 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpioc 19 GPIO_ACTIVE_LOW>;
 	};

--- a/boards/arm/warp7_m4/warp7_m4.dts
+++ b/boards/arm/warp7_m4/warp7_m4.dts
@@ -77,14 +77,12 @@
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		label = "FXOS8700";
 		int1-gpios = <&gpio7 0 GPIO_ACTIVE_LOW>;
 	};
 
 	fxas21002@20 {
 		compatible = "nxp,fxas21002";
 		reg = <0x20>;
-		label = "FXAS21002";
 		int1-gpios = <&gpio7 0 GPIO_ACTIVE_LOW>;
 	};
 


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>