### PR TITLE
boards: arm: atmel: Remove label property from devicetree

### DIFF
--- a/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
+++ b/boards/arm/adafruit_trinket_m0/adafruit_trinket_m0.dts
@@ -85,7 +85,6 @@
 		compatible = "apa,apa102";
 		reg = <0>;
 		spi-max-frequency = <24000000>;
-		label = "LED1";
 	};
 };
 

--- a/boards/arm/arduino_mkrzero/arduino_mkrzero.dts
+++ b/boards/arm/arduino_mkrzero/arduino_mkrzero.dts
@@ -52,7 +52,6 @@
 	atecc508a@c0 {
 		compatible = "atmel,atecc508";
 		reg = <0xc0>;
-		label = "ATECC508A";
 	};
 
 };
@@ -90,7 +89,6 @@
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 	};
 };

--- a/boards/arm/atsame54_xpro/atsame54_xpro.dts
+++ b/boards/arm/atsame54_xpro/atsame54_xpro.dts
@@ -80,7 +80,6 @@
 	compatible = "atmel,sam0-spi";
 	dipo = <3>;
 	dopo = <0>;
-	label = "SPI_0";
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -92,7 +91,6 @@
 	status = "okay";
 	compatible = "atmel,sam0-i2c";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	label = "I2C_0";
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
+++ b/boards/arm/atsamr21_xpro/atsamr21_xpro.dts
@@ -126,7 +126,6 @@
 	status = "okay";
 	compatible = "atmel,sam0-i2c";
 	clock-frequency = <I2C_BITRATE_FAST>;
-	label = "I2C_0";
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -143,7 +142,6 @@
 	 */
 	dipo = <0>;
 	dopo = <1>;
-	label = "SPI_RF2XX";
 	#address-cells = <1>;
 	#size-cells = <0>;
 
@@ -155,7 +153,6 @@
 	rf2xx@0 {
 		compatible = "atmel,rf2xx";
 		reg = <0x0>;
-		label = "RF2XX_0";
 		spi-max-frequency = <6000000>;
 		irq-gpios = <&portb 0 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
 		reset-gpios = <&portb 15 GPIO_ACTIVE_LOW>;
@@ -170,7 +167,6 @@
 	compatible = "atmel,sam0-spi";
 	dipo = <0>;
 	dopo = <2>;
-	label = "SPI_0";
 	#address-cells = <1>;
 	#size-cells = <0>;
 

--- a/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
+++ b/boards/arm/sam_e70_xplained/sam_e70_xplained-common.dtsi
@@ -183,7 +183,6 @@ zephyr_udc0: &usbhs {
 
 &ssc {
 	status = "okay";
-	label = "I2S_0";
 
 	pinctrl-0 = <&ssc_default>;
 	pinctrl-names = "default";

--- a/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
+++ b/boards/arm/sam_v71_xult/sam_v71_xult-common.dtsi
@@ -311,7 +311,6 @@ zephyr_udc0: &usbhs {
 
 &ssc {
 	status = "okay";
-	label = "I2S_0";
 
 	pinctrl-0 = <&ssc_default>;
 	pinctrl-names = "default";


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>