### PR TITLE
boards: riscv: Remove label property from devicetree

### DIFF
--- a/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.dts
+++ b/boards/riscv/adp_xc7k_ae350/adp_xc7k_ae350.dts
@@ -144,7 +144,6 @@
 	status = "okay";
 	flash0: flash@0 {
 		compatible = "jedec,spi-nor";
-		label = "JEDEC SPI-NOR";
 		reg = <0>;
 		size = <16777216>;
 		spi-max-frequency = <1000000>;

--- a/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
+++ b/boards/riscv/gd32vf103v_eval/gd32vf103v_eval.dts
@@ -131,7 +131,6 @@
 	nor_flash: gd25q16@0 {
 		compatible ="jedec,spi-nor";
 		size = <0x1000000>;
-		label = "GD25Q16";
 		reg = <0>;
 		spi-max-frequency = <4000000>;
 		status = "okay";

--- a/boards/riscv/hifive1/hifive1.dts
+++ b/boards/riscv/hifive1/hifive1.dts
@@ -58,7 +58,6 @@
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		status = "disabled";
 		size = <134217728>;
-		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/riscv/hifive1_revb/hifive1_revb.dts
+++ b/boards/riscv/hifive1_revb/hifive1_revb.dts
@@ -99,7 +99,6 @@
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		status = "disabled";
 		size = <134217728>;
-		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;
 		spi-max-frequency = <133000000>;
@@ -138,7 +137,6 @@
 
 arduino_i2c: &i2c0 {
 	status = "okay";
-	label = "I2C_0";
 	clock-frequency = <100000>;
 	pinctrl-0 = <&i2c0_0_default &i2c0_1_default>;
 	pinctrl-names = "default";

--- a/boards/riscv/hifive_unleashed/hifive_unleashed.dts
+++ b/boards/riscv/hifive_unleashed/hifive_unleashed.dts
@@ -53,7 +53,6 @@
 		compatible = "issi,is25wp256d", "jedec,spi-nor";
 		status = "disabled";
 		size = <33554432>;
-		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/riscv/hifive_unmatched/hifive_unmatched.dts
+++ b/boards/riscv/hifive_unmatched/hifive_unmatched.dts
@@ -34,7 +34,6 @@
 		compatible = "issi,is25wp256d", "jedec,spi-nor";
 		status = "disabled";
 		size = <33554432>;
-		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;
 		spi-max-frequency = <133000000>;

--- a/boards/riscv/litex_vexriscv/litex_vexriscv.dts
+++ b/boards/riscv/litex_vexriscv/litex_vexriscv.dts
@@ -50,7 +50,6 @@
 
 &i2c0 {
 	status = "okay";
-	label = "I2C_0";
 };
 
 &pwm0 {

--- a/boards/riscv/mpfs_icicle/mpfs_icicle.dts
+++ b/boards/riscv/mpfs_icicle/mpfs_icicle.dts
@@ -54,7 +54,6 @@
 		spi-max-frequency = <5000000>;
 		size = <DT_SIZE_M(256)>;
 		jedec-id = [20 ba 19];
-		label = "FLASH0";
 	};
 };
 

--- a/boards/riscv/qemu_riscv32/qemu_riscv32_xip.dts
+++ b/boards/riscv/qemu_riscv32/qemu_riscv32_xip.dts
@@ -42,7 +42,6 @@
 	flash0: flash@0 {
 		compatible = "issi,is25lp128", "jedec,spi-nor";
 		size = <134217728>;
-		label = "FLASH0";
 		jedec-id = [96 60 18];
 		reg = <0>;
 		// Dummy entry

--- a/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
+++ b/boards/riscv/rv32m1_vega/rv32m1_vega.dtsi
@@ -136,7 +136,6 @@ arduino_i2c: &lpi2c0 {
 	fxos8700: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
-		label = "FXOS8700";
 		reset-gpios = <&gpioe 27 GPIO_ACTIVE_HIGH>;
 		int1-gpios = <&gpioe 1 GPIO_ACTIVE_LOW>;
 		int2-gpios = <&gpioe 22 GPIO_ACTIVE_LOW>;
@@ -159,7 +158,6 @@ arduino_spi: &lpspi0 {
 		compatible = "jedec,spi-nor";
 		reg = <0>;
 		spi-max-frequency = <80000000>;
-		label = "MX25R32";
 		jedec-id = [c2 28 16];
 		size = <33554432>;
 	};


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>