### PR TITLE
boards: x86: Remove label property from devicetree

### DIFF
--- a/boards/x86/qemu_x86/qemu_x86.dts
+++ b/boards/x86/qemu_x86/qemu_x86.dts
@@ -46,7 +46,6 @@
 		eth0: eth@febc0000 {
 			compatible = "intel,e1000";
 			reg = <0xfebc0000 0x100>;
-			label = "eth0";
 			interrupts = <11 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
 
@@ -56,7 +55,6 @@
 
 	sim_flash: sim_flash {
 		compatible = "zephyr,sim-flash";
-		label = "FLASH_SIMULATOR";
 
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -74,7 +72,6 @@
 	eeprom1: eeprom1 {
 		status = "okay";
 		compatible = "zephyr,emu-eeprom";
-		label = "EEPROM_1";
 		size = <DT_SIZE_K(4)>;
 		pagesize = <DT_SIZE_K(8)>;
 		partition = <&eepromemu_partition>;
@@ -84,7 +81,6 @@
 	eeprom0: eeprom0 {
 		status = "okay";
 		compatible = "zephyr,sim-eeprom";
-		label = "EEPROM_0";
 		size = <DT_SIZE_K(4)>;
 	};
 

--- a/boards/x86/qemu_x86/qemu_x86_lakemont.dts
+++ b/boards/x86/qemu_x86/qemu_x86_lakemont.dts
@@ -40,7 +40,6 @@
 		uart0: uart@3f8 {
 			compatible = "ns16550";
 			reg = <0x000003f8 0x100>;
-			label = "UART_0";
 			clock-frequency = <1843200>;
 			interrupts = <4 IRQ_TYPE_LOWEST_EDGE_RISING 3>;
 			interrupt-parent = <&intc>;
@@ -50,7 +49,6 @@
 		};
 
 		hpet: hpet@fed00000 {
-			label = "HPET";
 			compatible = "intel,hpet";
 			reg = <0xfed00000 0x400>;
 			interrupts = <2 IRQ_TYPE_FIXED_EDGE_RISING 4>;


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>