### PR TITLE
boards: xtensa: Remove label property from devicetree

### DIFF
--- a/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
+++ b/boards/xtensa/esp_wrover_kit/esp_wrover_kit.dts
@@ -120,7 +120,6 @@
 
 	ili9341: ili9341@0 {
 		compatible = "ilitek,ili9341";
-		label = "DISPLAY";
 		spi-max-frequency = <25000000>;
 		reg = <0>;
 		cmd-data-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;

--- a/boards/xtensa/odroid_go/odroid_go.dts
+++ b/boards/xtensa/odroid_go/odroid_go.dts
@@ -58,7 +58,6 @@
 
 	lcd_backlight_en {
 		compatible = "regulator-fixed-sync", "regulator-fixed";
-		label = "lcd_backlight_enable";
 		regulator-name = "lcd_backlight_enable";
 		enable-gpios = <&gpio0 14 GPIO_ACTIVE_HIGH>;
 		regulator-boot-on;
@@ -113,7 +112,6 @@
 
 	ili9341: ili9341@0 {
 		compatible = "ilitek,ili9341";
-		label = "DISPLAY";
 		spi-max-frequency = <25000000>;
 		reg = <0>;
 		cmd-data-gpios = <&gpio0 21 GPIO_ACTIVE_LOW>;
@@ -127,11 +125,9 @@
 		compatible = "zephyr,sdhc-spi-slot";
 		reg = <1>;
 		status = "okay";
-		label = "SDHC_0";
 		mmc {
 			compatible = "zephyr,sdmmc-disk";
 			status = "okay";
-			label = "SDMMC_0";
 		};
 		spi-max-frequency = <20000000>;
 	};

--- a/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
+++ b/boards/xtensa/olimex_esp32_evb/olimex_esp32_evb.dts
@@ -37,7 +37,6 @@
 		compatible = "regulator-fixed";
 		enable-gpios = <&gpio 32 GPIO_ACTIVE_HIGH>;
 		regulator-name = "REL1";
-		label = "REL1";
 		startup-delay-us = <10000>;
 		off-on-delay-us = <5000>;
 	};
@@ -46,7 +45,6 @@
 		compatible = "regulator-fixed";
 		enable-gpios = <&gpio 33 GPIO_ACTIVE_HIGH>;
 		regulator-name = "REL2";
-		label = "REL2";
 		startup-delay-us = <10000>;
 		off-on-delay-us = <5000>;
 	};


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>