### PR TITLE
boards: arm64: Remove label property from devicetree

### DIFF
--- a/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
+++ b/boards/arm64/fvp_base_revc_2xaemv8a/fvp_base_revc_2xaemv8a.dts
@@ -79,7 +79,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 5 0 IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_5";
-			label = "UART_0";
 			clocks = <&uartclk>;
 		};
 
@@ -89,7 +88,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 6 0 IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_6";
-			label = "UART_1";
 			clocks = <&uartclk>;
 		};
 
@@ -99,7 +97,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 7 0 IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_7";
-			label = "UART_2";
 			clocks = <&uartclk>;
 		};
 
@@ -109,7 +106,6 @@
 			status = "disabled";
 			interrupts = <GIC_SPI 8 0 IRQ_TYPE_LEVEL>;
 			interrupt-names = "irq_8";
-			label = "UART_3";
 			clocks = <&uartclk>;
 		};
 

--- a/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
+++ b/boards/arm64/fvp_baser_aemv8r/fvp_baser_aemv8r.dts
@@ -24,7 +24,6 @@
 	psci {
 		compatible = "arm,psci-0.2";
 		method = "hvc";
-		label = "PSCI";
 	};
 
 	soc {

--- a/boards/arm64/imx8mm_evk/imx8mm_evk.dts
+++ b/boards/arm64/imx8mm_evk/imx8mm_evk.dts
@@ -21,7 +21,6 @@
 	psci {
 		compatible = "arm,psci-0.2";
 		method = "smc";
-		label = "PSCI";
 	};
 
 	sram0: memory@40000000 {

--- a/boards/arm64/imx8mm_evk/imx8mm_evk_jailhouse.dts
+++ b/boards/arm64/imx8mm_evk/imx8mm_evk_jailhouse.dts
@@ -27,7 +27,6 @@
 	psci {
 		compatible = "arm,psci-0.2";
 		method = "smc";
-		label = "PSCI";
 	};
 
 	sram0: memory@40000000 {

--- a/boards/arm64/imx8mp_evk/imx8mp_evk.dts
+++ b/boards/arm64/imx8mp_evk/imx8mp_evk.dts
@@ -16,7 +16,6 @@
 	psci {
 		compatible = "arm,psci-0.2";
 		method = "smc";
-		label = "PSCI";
 	};
 
 	uartclk: apb-pclk {

--- a/boards/arm64/imx8mp_evk/imx8mp_evk_jailhouse.dts
+++ b/boards/arm64/imx8mp_evk/imx8mp_evk_jailhouse.dts
@@ -28,7 +28,6 @@
 	psci {
 		compatible = "arm,psci-0.2";
 		method = "smc";
-		label = "PSCI";
 	};
 
 	sram0: memory@c0000000 {

--- a/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
+++ b/boards/arm64/qemu_cortex_a53/qemu_cortex_a53.dts
@@ -15,7 +15,6 @@
 	psci {
 		compatible = "arm,psci-0.2";
 		method = "hvc";
-		label = "PSCI";
 	};
 
 	chosen {

--- a/boards/arm64/xenvm/xenvm.dts
+++ b/boards/arm64/xenvm/xenvm.dts
@@ -44,7 +44,6 @@
 	psci {
 		compatible = "arm,psci-1.0", "arm,psci-0.2", "arm,psci";
 		method = "hvc";
-		label = "PSCI";
 	};
 
 	ram: memory@40000000 {
@@ -78,6 +77,5 @@
 	xen_hvc: hvc {
 		compatible = "xen,hvc-uart";
 		status = "okay";
-		label = "UART_HVC";
 	};
 };


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>