### PR TITLE
boards: arc: Remove label property from devicetree

### DIFF
--- a/boards/arc/em_starterkit/em_starterkit_r23.dtsi
+++ b/boards/arc/em_starterkit/em_starterkit_r23.dtsi
@@ -34,7 +34,6 @@
 			compatible = "snps,creg-gpio";
 			reg = <0xf0000014 0x4>;
 			ngpios = <6>;
-			label = "CREG_GPIO";
 			bit_per_gpio = <1>;
 			off_val = <0>;
 			on_val = <1>;

--- a/boards/arc/hsdk/hsdk.dtsi
+++ b/boards/arc/hsdk/hsdk.dtsi
@@ -122,8 +122,6 @@ arduino_spi: &spi2 {};
 	cy8c95xx: cy8c95xx@20 {
 		compatible = "cypress,cy8c95xx-gpio";
 		reg = <0x20>;
-		label = "cy8c95xx_gpio";
-
 		ranges;
 		#address-cells = <1>;
 		#size-cells = <0>;
@@ -131,7 +129,6 @@ arduino_spi: &spi2 {};
 		cy8c95xx_port0: cy8c95xx_port@0 {
 			compatible = "cypress,cy8c95xx-gpio-port";
 			reg = <0x00>;
-			label = "cy8c95xx_port0";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <8>;
@@ -141,7 +138,6 @@ arduino_spi: &spi2 {};
 		cy8c95xx_port1: cy8c95xx_port@1 {
 			compatible = "cypress,cy8c95xx-gpio-port";
 			reg = <0x01>;
-			label = "cy8c95xx_port1";
 			gpio-controller;
 			#gpio-cells = <2>;
 			ngpios = <8>;

--- a/boards/arc/nsim/nsim.dtsi
+++ b/boards/arc/nsim/nsim.dtsi
@@ -38,7 +38,6 @@
 		clock-frequency = <50000000>;
 		reg = <0xf0000000 0x400>;
 		current-speed = <115200>;
-		label = "UART_0";
 		interrupt-parent = <&intc>;
 		interrupts = <24 1>;
 		reg-shift = <2>;

--- a/boards/arc/qemu_arc/qemu_arc.dtsi
+++ b/boards/arc/qemu_arc/qemu_arc.dtsi
@@ -52,7 +52,6 @@
 		clock-frequency = <10000000>;
 		reg = <0xf0000000 0x400>;
 		current-speed = <115200>;
-		label = "UART_0";
 		interrupt-parent = <&intc>;
 		interrupts = <24 1>;
 		reg-shift = <2>;
@@ -63,7 +62,6 @@
 		clock-frequency = <10000000>;
 		reg = <0xf0002000 0x400>;
 		current-speed = <115200>;
-		label = "UART_1";
 		interrupt-parent = <&intc>;
 		interrupts = <25 1>;
 		reg-shift = <2>;


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>