### PR TITLE
boards: mips: Remove label property from devicetree

### DIFF
--- a/boards/mips/qemu_malta/qemu_malta.dts
+++ b/boards/mips/qemu_malta/qemu_malta.dts
@@ -50,7 +50,6 @@
 		/* no matter for emulated port */
 		clock-frequency = <1843200>;
 		current-speed = <115200>;
-		label = "UART_2";
 		status = "okay";
 	};
 };


### PR DESCRIPTION
The label property isn't needed in devicetree so remove it.

Signed-off-by: Kumar Gala <galak@kernel.org>