### PR TITLE
can: remove Kconfig.defconfig setting of CAN drivers

### DIFF
--- a/boards/shields/mcp2515/Kconfig.defconfig
+++ b/boards/shields/mcp2515/Kconfig.defconfig
@@ -11,9 +11,6 @@ config GPIO
 config SPI
 	default y
 
-config CAN_MCP2515
-	default y
-
 config CAN_INIT_PRIORITY
 	default 80
 

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -12,10 +12,6 @@ config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x2000 if BOOT_FLEXSPI_NOR || BOOT_SEMC_NOR
 
-config CAN_MCUX_FLEXCAN
-	default y if HAS_MCUX_FLEXCAN
-	depends on CAN
-
 config DISPLAY_MCUX_ELCDIF
 	default y if HAS_MCUX_ELCDIF
 	depends on DISPLAY

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -12,10 +12,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 86
 
-config CAN_MCUX_FLEXCAN
-	default y
-	depends on CAN
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
@@ -12,10 +12,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 100
 
-config CAN_MCUX_FLEXCAN
-	default y
-	depends on CAN
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke16f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke16f16
@@ -8,8 +8,4 @@ if SOC_MKE16F16
 config SOC
 	default "mke16f16"
 
-config CAN_MCUX_FLEXCAN
-	default y
-	depends on CAN
-
 endif # SOC_MKE16F16

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke18f16
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.mke18f16
@@ -8,8 +8,4 @@ if SOC_MKE18F16
 config SOC
 	default "mke18f16"
 
-config CAN_MCUX_FLEXCAN
-	default y
-	depends on CAN
-
 endif # SOC_MKE18F16


### PR DESCRIPTION
Now that CAN drivers are enabled based on devicetree
we need to remove any cases of them getting enabled by
Kconfig.defconfig* files as this can lead to errors.

Typically the Kconfig.defconfig* will blindly enable a
sensor and not respect the devicetree state of the CAN.
Additionally we can get problems with prj.conf/defconfig
getting incorrectly overridden.

Signed-off-by: Kumar Gala <galak@kernel.org>