### PR TITLE
boards: arc: hsdk: Fix building of LED build_all test

### DIFF
--- a/boards/arc/hsdk/Kconfig.defconfig
+++ b/boards/arc/hsdk/Kconfig.defconfig
@@ -11,6 +11,9 @@ if GPIO
 config GPIO_INIT_PRIORITY
 	default 60
 
+config I2C
+	default y
+
 endif # GPIO
 
 if SPI_DW


### PR DESCRIPTION
tests/drivers/build_all/led/drivers.led.build fails to build
since the GPIO driver for the cypress,cy8c95xx-gpio is not
enabled.  This is because the I2C bus is not enabled.  Add
enabling the I2C bus if GPIO is enabled to address the issue.

Signed-off-by: Kumar Gala <galak@kernel.org>