### PR TITLE
Thingy53 dts bme688 addition

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -169,6 +169,11 @@
 		reg = <0x38>;
 		int-gpios = <&gpio1 5 (GPIO_PULL_UP | GPIO_ACTIVE_LOW)>;
 	};
+
+	bme688@76 {
+		compatible = "bosch,bme680";
+		reg = <0x76>;
+	};
 };
 
 &spi3 {


### PR DESCRIPTION
Added the BME688 sensor to the i2c1 instance in the Thingy:53 dts.

Signed-off-by: Karl Ylvisaker karl.ylvisaker@nordicsemi.no