### PR TITLE
Bluetooth: audio: ascs: Fix sending invalid ATT_ERROR_RSP error code

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2269,7 +2269,6 @@ static ssize_t ascs_cp_write(struct bt_conn *conn,
 	default:
 		ascs_cp_rsp_add(0x00, req->op, BT_ASCS_RSP_NOT_SUPPORTED, 0);
 		BT_DBG("Unknown opcode");
-		len = BT_GATT_ERR(BT_ATT_ERR_NOT_SUPPORTED);
 		goto respond;
 	}
 


### PR DESCRIPTION
This fixes sending invalid ATT Request Not Supported error code as a
response to Control Point write request.
ATT Request Not Supported error code is used to inform that
"ATT Server does not support the request received from the client",
so it should not be sent in this case.
If the requested opcode is unsupported, ASCS mandates to send ATT
Notification from Control Point with Unsupported opcode Response_Code
only. If the request received from the client is properly formatted,
ATT Write Response can be sent to complete the ATT transaction.

Fixes: ASCS/SR/SPE/BI-01-C
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>