### PR TITLE
scripts: west_commands: runners: jlink: support pylink >= 0.14

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -8,6 +8,7 @@ import argparse
 from functools import partial
 import logging
 import os
+from packaging.version import Version
 from pathlib import Path
 import shlex
 import subprocess
@@ -17,6 +18,7 @@ import tempfile
 from runners.core import ZephyrBinaryRunner, RunnerCaps, depr_action
 
 try:
+    import pylink
     from pylink.library import Library
     MISSING_REQUIREMENTS = False
 except ImportError:
@@ -150,16 +152,23 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         # to load the shared library distributed with the tools, which
         # provides an API call for getting the version.
         if not hasattr(self, '_jlink_version'):
+            # pylink >= 0.14.0 exposes JLink SDK DLL (libjlinkarm) in
+            # JLINK_SDK_STARTS_WITH, while previous versions use JLINK_SDK_NAME
+            if Version(pylink.__version__) >= Version('0.14.0'):
+                sdk = Library.JLINK_SDK_STARTS_WITH
+            else:
+                sdk = Library.JLINK_SDK_NAME
+
             plat = sys.platform
             if plat.startswith('win32'):
                 libname = Library.get_appropriate_windows_sdk_name() + '.dll'
             elif plat.startswith('linux'):
-                libname = Library.JLINK_SDK_NAME + '.so'
+                libname = sdk + '.so'
             elif plat.startswith('darwin'):
-                libname = Library.JLINK_SDK_NAME + '.dylib'
+                libname = sdk + '.dylib'
             else:
                 self.logger.warning(f'unknown platform {plat}; assuming UNIX')
-                libname = Library.JLINK_SDK_NAME + '.so'
+                libname = sdk + '.so'
 
             lib = Library(dllpath=os.fspath(Path(self.commander).parent /
                                             libname))


### PR DESCRIPTION
pylink 0.14.0 changed the class variable where JLink DLL library name
(libjlinkarm) is stored. This patch adds support for new pylink
libraries while keeping backwards compatibility.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48626