### PR TITLE
samples: Bluetooth: Added multiple broadcaster and Extended Advertising chain PDU validation

### DIFF
--- a/samples/bluetooth/broadcaster_multiple/CMakeLists.txt
+++ b/samples/bluetooth/broadcaster_multiple/CMakeLists.txt
@@ -4,4 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(broadcaster_multiple)
 
-target_sources(app PRIVATE src/main.c)
+target_sources(app PRIVATE
+  src/main.c
+  src/broadcaster_multiple.c
+)

--- a/samples/bluetooth/broadcaster_multiple/CMakeLists.txt
+++ b/samples/bluetooth/broadcaster_multiple/CMakeLists.txt
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(broadcaster_multiple)
+
+target_sources(app PRIVATE src/main.c)

--- a/samples/bluetooth/broadcaster_multiple/README.rst
+++ b/samples/bluetooth/broadcaster_multiple/README.rst
@@ -1,0 +1,36 @@
+.. _bluetooth-broadcaster-multiple-sample:
+
+Bluetooth: Multiple Broadcaster
+###############################
+
+Overview
+********
+
+A simple application demonstrating the Bluetooth Low Energy Broadcaster that
+uses multiple advertising sets functionality.
+
+This sample advertises two non-connectable non-scannable advertising sets with
+two different SID. Number of advertising sets can be increased by updating the
+`CONFIG_BT_EXT_ADV_MAX_ADV_SET` value in the project configuration file.
+
+When building this sample combined with a Bluetooth LE Controller, the
+advertising data length can be increased from the default 31 bytes by updating
+the Controller's `CONFIG_BT_CTLR_ADV_DATA_LEN_MAX` value. The size of the
+manufacturer data is calculated to maximize the use of supported AD data length.
+
+Requirements
+************
+
+* A board with Bluetooth Low Energy with Extended Advertising support.
+
+Building and Running
+********************
+
+This sample can be found under
+:zephyr_file:`samples/bluetooth/broadcaster_multiple` in the Zephyr tree.
+
+To test this sample use the Observer sample with Extended Scanning enabled,
+found under
+:zephyr_file:`samples/bluetooth/observer` in the Zephyr tree.
+
+See :ref:`Bluetooth samples section <bluetooth-samples>` for details.

--- a/samples/bluetooth/broadcaster_multiple/prj.conf
+++ b/samples/bluetooth/broadcaster_multiple/prj.conf
@@ -1,0 +1,23 @@
+CONFIG_BT=y
+CONFIG_BT_BROADCASTER=y
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=2
+CONFIG_BT_DEVICE_NAME="Broadcaster Multiple"
+
+CONFIG_BT_DEBUG_LOG=y
+
+# Zephyr Bluetooth LE Controller will need to use chain PDUs when AD data
+# length > 191 bytes
+# - 31 bytes will use 22 bytes for the default name in this sample plus 9 bytes
+#   for manufacturer data
+# - 191 bytes will use 22 bytes for the default name in this sample plus 169
+#   bytes for manufacturer data
+# - 277 bytes will use 22 bytes for the default name in this sample plus 255
+#   bytes for manufacturer data
+# CONFIG_BT_CTLR_ADV_DATA_LEN_MAX=192
+
+# Increase Advertising PDU buffers to number of advertising sets times the
+# number of chain PDUs per advertising set when using Zephyr Bluetooth LE
+# Controller
+# CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+# CONFIG_BT_CTLR_ADV_DATA_BUF_MAX=2

--- a/samples/bluetooth/broadcaster_multiple/sample.yaml
+++ b/samples/bluetooth/broadcaster_multiple/sample.yaml
@@ -1,0 +1,7 @@
+sample:
+  name: Bluetooth Multiple Extended Advertising Broadcaster
+tests:
+  sample.bluetooth.multiple_broadcast:
+    harness: bluetooth
+    platform_allow: qemu_cortex_m3 qemu_x86 nrf51dk_nrf51422 nrf52_bsim nrf52dk_nrf52832
+    tags: bluetooth

--- a/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
+++ b/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/bluetooth/bluetooth.h>
+
+/* Maximum supported AD data length, use a value supported by the Controller,
+ * Bluetooth Core Specification define minimum of 31 bytes will be supported by
+ * all Controllers, can be a maximum of 1650 bytes when supported.
+ */
+#if defined(CONFIG_BT_CTLR_ADV_DATA_LEN_MAX)
+#define BT_AD_DATA_LEN_MAX CONFIG_BT_CTLR_ADV_DATA_LEN_MAX
+#else
+#define BT_AD_DATA_LEN_MAX 31U
+#endif
+
+/* Size of AD data format length field in octets */
+#define BT_AD_DATA_FORMAT_LEN_SIZE 1U
+
+/* Size of AD data format type field in octets */
+#define BT_AD_DATA_FORMAT_TYPE_SIZE 1U
+
+/* Maximum value of AD data format length field (8-bit) */
+#define BT_AD_DATA_FORMAT_LEN_MAX 255U
+
+/* Device name length, size minus one null character */
+#define BT_DEVICE_NAME_LEN (sizeof(CONFIG_BT_DEVICE_NAME) - 1U)
+
+/* Device name length in AD data format, 2 bytes for length and type overhead */
+#define BT_DEVICE_NAME_AD_DATA_LEN (BT_AD_DATA_FORMAT_LEN_SIZE + \
+				    BT_AD_DATA_FORMAT_TYPE_SIZE + \
+				    BT_DEVICE_NAME_LEN)
+
+/* Maximum manufacturer data length, considering ad data format overhead and
+ * the included device name in ad data format.
+ */
+#define BT_MFG_DATA_LEN_MAX       (MIN((BT_AD_DATA_FORMAT_LEN_MAX - \
+					BT_AD_DATA_FORMAT_TYPE_SIZE), \
+				       (BT_AD_DATA_LEN_MAX - \
+					BT_AD_DATA_FORMAT_LEN_SIZE - \
+					BT_AD_DATA_FORMAT_TYPE_SIZE)))
+#define BT_MFG_DATA_LEN           (MIN(BT_MFG_DATA_LEN_MAX, \
+				       (BT_AD_DATA_LEN_MAX - \
+					BT_AD_DATA_FORMAT_LEN_SIZE - \
+					BT_AD_DATA_FORMAT_TYPE_SIZE - \
+					BT_DEVICE_NAME_AD_DATA_LEN)))
+
+static uint8_t mfg_data[BT_MFG_DATA_LEN] = { 0xFF, 0xFF, };
+
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, sizeof(mfg_data)),
+};
+
+static struct bt_le_ext_adv *adv[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
+
+int broadcaster_multiple(void)
+{
+	struct bt_le_adv_param adv_param = {
+		.id = BT_ID_DEFAULT,
+		.sid = 0U, /* Supply unique SID when creating advertising set */
+		.secondary_max_skip = 0U,
+		.options = (BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME),
+		.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
+		.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
+		.peer = NULL,
+	};
+	int err;
+
+	/* Initialize the Bluetooth Subsystem */
+	err = bt_enable(NULL);
+	if (err) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return err;
+	}
+
+	for (int index = 0; index < CONFIG_BT_EXT_ADV_MAX_ADV_SET; index++) {
+		/* Use advertising set instance index as SID */
+		adv_param.sid = index;
+
+		/* Create a non-connectable non-scannable advertising set */
+		err = bt_le_ext_adv_create(&adv_param, NULL, &adv[index]);
+		if (err) {
+			printk("Failed to create advertising set %d (err %d)\n",
+			       index, err);
+			return err;
+		}
+
+		/* Set extended advertising data */
+		err = bt_le_ext_adv_set_data(adv[index], ad, ARRAY_SIZE(ad),
+					     NULL, 0);
+		if (err) {
+			printk("Failed to set advertising data for set %d "
+			       "(err %d)\n", index, err);
+			return err;
+		}
+
+		/* Start extended advertising set */
+		err = bt_le_ext_adv_start(adv[index],
+					  BT_LE_EXT_ADV_START_DEFAULT);
+		if (err) {
+			printk("Failed to start extended advertising set %d "
+			       "(err %d)\n", index, err);
+			return err;
+		}
+
+		printk("Started Extended Advertising Set %d.\n", index);
+	}
+
+	return 0;
+}

--- a/samples/bluetooth/broadcaster_multiple/src/main.c
+++ b/samples/bluetooth/broadcaster_multiple/src/main.c
@@ -5,111 +5,14 @@
  */
 
 #include <zephyr/sys/printk.h>
-#include <zephyr/bluetooth/bluetooth.h>
 
-/* Maximum supported AD data length, use a value supported by the Controller,
- * Bluetooth Core Specification define minimum of 31 bytes will be supported by
- * all Controllers, can be a maximum of 1650 bytes when supported.
- */
-#if defined(CONFIG_BT_CTLR_ADV_DATA_LEN_MAX)
-#define BT_AD_DATA_LEN_MAX CONFIG_BT_CTLR_ADV_DATA_LEN_MAX
-#else
-#define BT_AD_DATA_LEN_MAX 31U
-#endif
-
-/* Size of AD data format length field in octets */
-#define BT_AD_DATA_FORMAT_LEN_SIZE 1U
-
-/* Size of AD data format type field in octets */
-#define BT_AD_DATA_FORMAT_TYPE_SIZE 1U
-
-/* Maximum value of AD data format length field (8-bit) */
-#define BT_AD_DATA_FORMAT_LEN_MAX 255U
-
-/* Device name length, size minus one null character */
-#define BT_DEVICE_NAME_LEN (sizeof(CONFIG_BT_DEVICE_NAME) - 1U)
-
-/* Device name length in AD data format, 2 bytes for length and type overhead */
-#define BT_DEVICE_NAME_AD_DATA_LEN (BT_AD_DATA_FORMAT_LEN_SIZE + \
-				    BT_AD_DATA_FORMAT_TYPE_SIZE + \
-				    BT_DEVICE_NAME_LEN)
-
-/* Maximum manufacturer data length, considering ad data format overhead and
- * the included device name in ad data format.
- */
-#define BT_MFG_DATA_LEN_MAX       (MIN((BT_AD_DATA_FORMAT_LEN_MAX - \
-					BT_AD_DATA_FORMAT_TYPE_SIZE), \
-				       (BT_AD_DATA_LEN_MAX - \
-					BT_AD_DATA_FORMAT_LEN_SIZE - \
-					BT_AD_DATA_FORMAT_TYPE_SIZE)))
-#define BT_MFG_DATA_LEN           (MIN(BT_MFG_DATA_LEN_MAX, \
-				       (BT_AD_DATA_LEN_MAX - \
-					BT_AD_DATA_FORMAT_LEN_SIZE - \
-					BT_AD_DATA_FORMAT_TYPE_SIZE - \
-					BT_DEVICE_NAME_AD_DATA_LEN)))
-
-static uint8_t mfg_data[BT_MFG_DATA_LEN] = { 0xFF, 0xFF, };
-
-static const struct bt_data ad[] = {
-	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, sizeof(mfg_data)),
-};
-
-static struct bt_le_ext_adv *adv[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
+int broadcaster_multiple(void);
 
 void main(void)
 {
-	struct bt_le_adv_param adv_param = {
-		.id = BT_ID_DEFAULT,
-		.sid = 0U, /* Supply unique SID when creating advertising set */
-		.secondary_max_skip = 0U,
-		.options = (BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME),
-		.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
-		.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
-		.peer = NULL,
-	};
-	int err;
-
 	printk("Starting Multiple Broadcaster Demo\n");
 
-	/* Initialize the Bluetooth Subsystem */
-	err = bt_enable(NULL);
-	if (err) {
-		printk("Bluetooth init failed (err %d)\n", err);
-		return;
-	}
-
-	for (int index = 0; index < CONFIG_BT_EXT_ADV_MAX_ADV_SET; index++) {
-		/* Use advertising set instance index as SID */
-		adv_param.sid = index;
-
-		/* Create a non-connectable non-scannable advertising set */
-		err = bt_le_ext_adv_create(&adv_param, NULL, &adv[index]);
-		if (err) {
-			printk("Failed to create advertising set %d (err %d)\n",
-			       index, err);
-			return;
-		}
-
-		/* Set extended advertising data */
-		err = bt_le_ext_adv_set_data(adv[index], ad, ARRAY_SIZE(ad),
-					     NULL, 0);
-		if (err) {
-			printk("Failed to set advertising data for set %d "
-			       "(err %d)\n", index, err);
-			return;
-		}
-
-		/* Start extended advertising set */
-		err = bt_le_ext_adv_start(adv[index],
-					  BT_LE_EXT_ADV_START_DEFAULT);
-		if (err) {
-			printk("Failed to start extended advertising set %d "
-			       "(err %d)\n", index, err);
-			return;
-		}
-
-		printk("Started Extended Advertising Set %d.\n", index);
-	}
+	(void)broadcaster_multiple();
 
 	printk("Exiting %s thread.\n", __func__);
 }

--- a/samples/bluetooth/broadcaster_multiple/src/main.c
+++ b/samples/bluetooth/broadcaster_multiple/src/main.c
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/bluetooth/bluetooth.h>
+
+/* Maximum supported AD data length, use a value supported by the Controller,
+ * Bluetooth Core Specification define minimum of 31 bytes will be supported by
+ * all Controllers, can be a maximum of 1650 bytes when supported.
+ */
+#if defined(CONFIG_BT_CTLR_ADV_DATA_LEN_MAX)
+#define BT_AD_DATA_LEN_MAX CONFIG_BT_CTLR_ADV_DATA_LEN_MAX
+#else
+#define BT_AD_DATA_LEN_MAX 31U
+#endif
+
+/* Size of AD data format length field in octets */
+#define BT_AD_DATA_FORMAT_LEN_SIZE 1U
+
+/* Size of AD data format type field in octets */
+#define BT_AD_DATA_FORMAT_TYPE_SIZE 1U
+
+/* Maximum value of AD data format length field (8-bit) */
+#define BT_AD_DATA_FORMAT_LEN_MAX 255U
+
+/* Device name length, size minus one null character */
+#define BT_DEVICE_NAME_LEN (sizeof(CONFIG_BT_DEVICE_NAME) - 1U)
+
+/* Device name length in AD data format, 2 bytes for length and type overhead */
+#define BT_DEVICE_NAME_AD_DATA_LEN (BT_AD_DATA_FORMAT_LEN_SIZE + \
+				    BT_AD_DATA_FORMAT_TYPE_SIZE + \
+				    BT_DEVICE_NAME_LEN)
+
+/* Maximum manufacturer data length, considering ad data format overhead and
+ * the included device name in ad data format.
+ */
+#define BT_MFG_DATA_LEN_MAX       (MIN((BT_AD_DATA_FORMAT_LEN_MAX - \
+					BT_AD_DATA_FORMAT_TYPE_SIZE), \
+				       (BT_AD_DATA_LEN_MAX - \
+					BT_AD_DATA_FORMAT_LEN_SIZE - \
+					BT_AD_DATA_FORMAT_TYPE_SIZE)))
+#define BT_MFG_DATA_LEN           (MIN(BT_MFG_DATA_LEN_MAX, \
+				       (BT_AD_DATA_LEN_MAX - \
+					BT_AD_DATA_FORMAT_LEN_SIZE - \
+					BT_AD_DATA_FORMAT_TYPE_SIZE - \
+					BT_DEVICE_NAME_AD_DATA_LEN)))
+
+static uint8_t mfg_data[BT_MFG_DATA_LEN] = { 0xFF, 0xFF, };
+
+static const struct bt_data ad[] = {
+	BT_DATA(BT_DATA_MANUFACTURER_DATA, mfg_data, sizeof(mfg_data)),
+};
+
+static struct bt_le_ext_adv *adv[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
+
+void main(void)
+{
+	struct bt_le_adv_param adv_param = {
+		.id = BT_ID_DEFAULT,
+		.sid = 0U, /* Supply unique SID when creating advertising set */
+		.secondary_max_skip = 0U,
+		.options = (BT_LE_ADV_OPT_EXT_ADV | BT_LE_ADV_OPT_USE_NAME),
+		.interval_min = BT_GAP_ADV_FAST_INT_MIN_2,
+		.interval_max = BT_GAP_ADV_FAST_INT_MAX_2,
+		.peer = NULL,
+	};
+	int err;
+
+	printk("Starting Multiple Broadcaster Demo\n");
+
+	/* Initialize the Bluetooth Subsystem */
+	err = bt_enable(NULL);
+	if (err) {
+		printk("Bluetooth init failed (err %d)\n", err);
+		return;
+	}
+
+	for (int index = 0; index < CONFIG_BT_EXT_ADV_MAX_ADV_SET; index++) {
+		/* Use advertising set instance index as SID */
+		adv_param.sid = index;
+
+		/* Create a non-connectable non-scannable advertising set */
+		err = bt_le_ext_adv_create(&adv_param, NULL, &adv[index]);
+		if (err) {
+			printk("Failed to create advertising set %d (err %d)\n",
+			       index, err);
+			return;
+		}
+
+		/* Set extended advertising data */
+		err = bt_le_ext_adv_set_data(adv[index], ad, ARRAY_SIZE(ad),
+					     NULL, 0);
+		if (err) {
+			printk("Failed to set advertising data for set %d "
+			       "(err %d)\n", index, err);
+			return;
+		}
+
+		/* Start extended advertising set */
+		err = bt_le_ext_adv_start(adv[index],
+					  BT_LE_EXT_ADV_START_DEFAULT);
+		if (err) {
+			printk("Failed to start extended advertising set %d "
+			       "(err %d)\n", index, err);
+			return;
+		}
+
+		printk("Started Extended Advertising Set %d.\n", index);
+	}
+
+	printk("Exiting %s thread.\n", __func__);
+}

--- a/samples/bluetooth/observer/CMakeLists.txt
+++ b/samples/bluetooth/observer/CMakeLists.txt
@@ -4,7 +4,7 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(observer)
 
-FILE(GLOB app_sources src/*.c)
-target_sources(app PRIVATE ${app_sources})
-
-zephyr_library_include_directories(${ZEPHYR_BASE}/samples/bluetooth)
+target_sources(app PRIVATE
+  src/main.c
+  src/observer.c
+)

--- a/samples/bluetooth/observer/README.rst
+++ b/samples/bluetooth/observer/README.rst
@@ -1,20 +1,24 @@
 .. _bluetooth-observer-sample:
 
 Bluetooth: Observer
-###########################
+###################
 
 Overview
 ********
 
-A simple application demonstrating Bluetooth Low Energy Observer role functionality
-The application will periodically scan for devices nearby. If any found,
-prints the address of the device and the RSSI value to the UART terminal.
+A simple application demonstrating Bluetooth Low Energy Observer role
+functionality. The application will periodically scan for devices nearby.
+If any found, prints the address of the device, the RSSI value, the Advertising
+type, and the Advertising data length to the console.
+
+If the used Bluetooth Low Energy Controller supports Extended Scanning, you may
+enable `CONFIG_BT_EXT_ADV` in the project configuration file. Refer to the
+project configuration file for further details.
 
 Requirements
 ************
 
-* BlueZ running on the host, or
-* A board with BLE support
+* A board with Bluetooth Low Energy support
 
 Building and Running
 ********************
@@ -22,4 +26,4 @@ Building and Running
 This sample can be found under :zephyr_file:`samples/bluetooth/observer` in the
 Zephyr tree.
 
-See :ref:`bluetooth samples section <bluetooth-samples>` for details.
+See :ref:`Bluetooth samples section <bluetooth-samples>` for details.

--- a/samples/bluetooth/observer/prj_extended.conf
+++ b/samples/bluetooth/observer/prj_extended.conf
@@ -1,0 +1,17 @@
+CONFIG_BT=y
+CONFIG_BT_OBSERVER=y
+
+# Enable Extended Scanning
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_SCAN_BUF_SIZE=1650
+
+# Zephyr Bluetooth LE Controller needs 16 event buffers to generate Extended
+# Advertising Report for receiving the complete 1650 bytes of data
+CONFIG_BT_BUF_EVT_RX_COUNT=16
+
+# Set maximum scan data length for Extended Scanning in Bluetooth LE Controller
+CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=1650
+
+# Increase Zephyr Bluetooth LE Controller Rx buffer to receive complete chain
+# of PDUs
+CONFIG_BT_CTLR_RX_BUFFERS=9

--- a/samples/bluetooth/observer/sample.yaml
+++ b/samples/bluetooth/observer/sample.yaml
@@ -3,5 +3,10 @@ sample:
 tests:
   sample.bluetooth.observer:
     harness: bluetooth
-    platform_allow: qemu_cortex_m3 qemu_x86
+    platform_allow: qemu_cortex_m3 qemu_x86 nrf52840dk_nrf52840
+    tags: bluetooth
+  sample.bluetooth.observer.extended:
+    harness: bluetooth
+    extra_args: CONF_FILE="prj_extended.conf"
+    platform_allow: qemu_cortex_m3 qemu_x86 nrf52840dk_nrf52840
     tags: bluetooth

--- a/samples/bluetooth/observer/src/main.c
+++ b/samples/bluetooth/observer/src/main.c
@@ -1,107 +1,19 @@
-/* main.c - Application main entry point */
-
 /*
- * Copyright (c) 2015-2016 Intel Corporation
+ * Copyright (c) 2022 Nordic Semiconductor ASA
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <zephyr/types.h>
-#include <stddef.h>
 #include <zephyr/sys/printk.h>
-#include <zephyr/sys/util.h>
-
 #include <zephyr/bluetooth/bluetooth.h>
-#include <zephyr/bluetooth/hci.h>
 
-#define NAME_LEN 30
-
-static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
-			 struct net_buf_simple *ad)
-{
-	char addr_str[BT_ADDR_LE_STR_LEN];
-
-	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
-	printk("Device found: %s (RSSI %d), type %u, AD data len %u\n",
-	       addr_str, rssi, type, ad->len);
-}
-
-#if defined(CONFIG_BT_EXT_ADV)
-static bool data_cb(struct bt_data *data, void *user_data)
-{
-	char *name = user_data;
-	uint8_t len;
-
-	switch (data->type) {
-	case BT_DATA_NAME_SHORTENED:
-	case BT_DATA_NAME_COMPLETE:
-		len = MIN(data->data_len, NAME_LEN - 1);
-		(void)memcpy(name, data->data, len);
-		name[len] = '\0';
-		return false;
-	default:
-		return true;
-	}
-}
-
-static const char *phy2str(uint8_t phy)
-{
-	switch (phy) {
-	case BT_GAP_LE_PHY_NONE: return "No packets";
-	case BT_GAP_LE_PHY_1M: return "LE 1M";
-	case BT_GAP_LE_PHY_2M: return "LE 2M";
-	case BT_GAP_LE_PHY_CODED: return "LE Coded";
-	default: return "Unknown";
-	}
-}
-
-static void scan_recv(const struct bt_le_scan_recv_info *info,
-		      struct net_buf_simple *buf)
-{
-	char le_addr[BT_ADDR_LE_STR_LEN];
-	char name[NAME_LEN];
-	uint8_t data_status;
-	uint16_t data_len;
-
-	(void)memset(name, 0, sizeof(name));
-
-	data_len = buf->len;
-	bt_data_parse(buf, data_cb, name);
-
-	data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS(info->adv_props);
-
-	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
-	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i "
-	       "Data status: %u, AD data len: %u Name: %s "
-	       "C:%u S:%u D:%u SR:%u E:%u Pri PHY: %s, Sec PHY: %s, "
-	       "Interval: 0x%04x (%u ms), SID: %u\n",
-	       le_addr, info->adv_type, info->tx_power, info->rssi,
-	       data_status, data_len, name,
-	       (info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
-	       (info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
-	       (info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
-	       (info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
-	       (info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0,
-	       phy2str(info->primary_phy), phy2str(info->secondary_phy),
-	       info->interval, info->interval * 5 / 4, info->sid);
-}
-
-static struct bt_le_scan_cb scan_callbacks = {
-	.recv = scan_recv,
-};
-#endif /* CONFIG_BT_EXT_ADV */
+int observer_start(void);
 
 void main(void)
 {
-	struct bt_le_scan_param scan_param = {
-		.type       = BT_LE_SCAN_TYPE_PASSIVE,
-		.options    = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
-		.interval   = BT_GAP_SCAN_FAST_INTERVAL,
-		.window     = BT_GAP_SCAN_FAST_WINDOW,
-	};
 	int err;
 
-	printk("Starting Observer\n");
+	printk("Starting Observer Demo\n");
 
 	/* Initialize the Bluetooth Subsystem */
 	err = bt_enable(NULL);
@@ -109,17 +21,8 @@ void main(void)
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-	printk("Bluetooth initialized\n");
 
-#if defined(CONFIG_BT_EXT_ADV)
-	bt_le_scan_cb_register(&scan_callbacks);
-	printk("Registered scan callbacks\n");
-#endif /* CONFIG_BT_EXT_ADV */
+	(void)observer_start();
 
-	err = bt_le_scan_start(&scan_param, device_found);
-	if (err) {
-		printk("Start scanning failed (err %d)\n", err);
-		return;
-	}
-	printk("Scanning started, exiting %s thread.\n", __func__);
+	printk("Exiting %s thread.\n", __func__);
 }

--- a/samples/bluetooth/observer/src/main.c
+++ b/samples/bluetooth/observer/src/main.c
@@ -14,14 +14,82 @@
 #include <zephyr/bluetooth/bluetooth.h>
 #include <zephyr/bluetooth/hci.h>
 
+#define NAME_LEN 30
+
 static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
 			 struct net_buf_simple *ad)
 {
 	char addr_str[BT_ADDR_LE_STR_LEN];
 
 	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
-	printk("Device found: %s (RSSI %d)\n", addr_str, rssi);
+	printk("Device found: %s (RSSI %d), type %u, AD data len %u\n",
+	       addr_str, rssi, type, ad->len);
 }
+
+#if defined(CONFIG_BT_EXT_ADV)
+static bool data_cb(struct bt_data *data, void *user_data)
+{
+	char *name = user_data;
+	uint8_t len;
+
+	switch (data->type) {
+	case BT_DATA_NAME_SHORTENED:
+	case BT_DATA_NAME_COMPLETE:
+		len = MIN(data->data_len, NAME_LEN - 1);
+		(void)memcpy(name, data->data, len);
+		name[len] = '\0';
+		return false;
+	default:
+		return true;
+	}
+}
+
+static const char *phy2str(uint8_t phy)
+{
+	switch (phy) {
+	case BT_GAP_LE_PHY_NONE: return "No packets";
+	case BT_GAP_LE_PHY_1M: return "LE 1M";
+	case BT_GAP_LE_PHY_2M: return "LE 2M";
+	case BT_GAP_LE_PHY_CODED: return "LE Coded";
+	default: return "Unknown";
+	}
+}
+
+static void scan_recv(const struct bt_le_scan_recv_info *info,
+		      struct net_buf_simple *buf)
+{
+	char le_addr[BT_ADDR_LE_STR_LEN];
+	char name[NAME_LEN];
+	uint8_t data_status;
+	uint16_t data_len;
+
+	(void)memset(name, 0, sizeof(name));
+
+	data_len = buf->len;
+	bt_data_parse(buf, data_cb, name);
+
+	data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS(info->adv_props);
+
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i "
+	       "Data status: %u, AD data len: %u Name: %s "
+	       "C:%u S:%u D:%u SR:%u E:%u Pri PHY: %s, Sec PHY: %s, "
+	       "Interval: 0x%04x (%u ms), SID: %u\n",
+	       le_addr, info->adv_type, info->tx_power, info->rssi,
+	       data_status, data_len, name,
+	       (info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0,
+	       phy2str(info->primary_phy), phy2str(info->secondary_phy),
+	       info->interval, info->interval * 5 / 4, info->sid);
+}
+
+static struct bt_le_scan_cb scan_callbacks = {
+	.recv = scan_recv,
+};
+#endif /* CONFIG_BT_EXT_ADV */
 
 void main(void)
 {
@@ -41,13 +109,17 @@ void main(void)
 		printk("Bluetooth init failed (err %d)\n", err);
 		return;
 	}
-
 	printk("Bluetooth initialized\n");
 
+#if defined(CONFIG_BT_EXT_ADV)
+	bt_le_scan_cb_register(&scan_callbacks);
+	printk("Registered scan callbacks\n");
+#endif /* CONFIG_BT_EXT_ADV */
+
 	err = bt_le_scan_start(&scan_param, device_found);
-	printk("\n");
 	if (err) {
-		printk("Starting scanning failed (err %d)\n", err);
+		printk("Start scanning failed (err %d)\n", err);
 		return;
 	}
+	printk("Scanning started, exiting %s thread.\n", __func__);
 }

--- a/samples/bluetooth/observer/src/observer.c
+++ b/samples/bluetooth/observer/src/observer.c
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ * Copyright (c) 2015-2016 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+
+#define NAME_LEN 30
+
+static void device_found(const bt_addr_le_t *addr, int8_t rssi, uint8_t type,
+			 struct net_buf_simple *ad)
+{
+	char addr_str[BT_ADDR_LE_STR_LEN];
+
+	bt_addr_le_to_str(addr, addr_str, sizeof(addr_str));
+	printk("Device found: %s (RSSI %d), type %u, AD data len %u\n",
+	       addr_str, rssi, type, ad->len);
+}
+
+#if defined(CONFIG_BT_EXT_ADV)
+static bool data_cb(struct bt_data *data, void *user_data)
+{
+	char *name = user_data;
+	uint8_t len;
+
+	switch (data->type) {
+	case BT_DATA_NAME_SHORTENED:
+	case BT_DATA_NAME_COMPLETE:
+		len = MIN(data->data_len, NAME_LEN - 1);
+		(void)memcpy(name, data->data, len);
+		name[len] = '\0';
+		return false;
+	default:
+		return true;
+	}
+}
+
+static const char *phy2str(uint8_t phy)
+{
+	switch (phy) {
+	case BT_GAP_LE_PHY_NONE: return "No packets";
+	case BT_GAP_LE_PHY_1M: return "LE 1M";
+	case BT_GAP_LE_PHY_2M: return "LE 2M";
+	case BT_GAP_LE_PHY_CODED: return "LE Coded";
+	default: return "Unknown";
+	}
+}
+
+static void scan_recv(const struct bt_le_scan_recv_info *info,
+		      struct net_buf_simple *buf)
+{
+	char le_addr[BT_ADDR_LE_STR_LEN];
+	char name[NAME_LEN];
+	uint8_t data_status;
+	uint16_t data_len;
+
+	(void)memset(name, 0, sizeof(name));
+
+	data_len = buf->len;
+	bt_data_parse(buf, data_cb, name);
+
+	data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS(info->adv_props);
+
+	bt_addr_le_to_str(info->addr, le_addr, sizeof(le_addr));
+	printk("[DEVICE]: %s, AD evt type %u, Tx Pwr: %i, RSSI %i "
+	       "Data status: %u, AD data len: %u Name: %s "
+	       "C:%u S:%u D:%u SR:%u E:%u Pri PHY: %s, Sec PHY: %s, "
+	       "Interval: 0x%04x (%u ms), SID: %u\n",
+	       le_addr, info->adv_type, info->tx_power, info->rssi,
+	       data_status, data_len, name,
+	       (info->adv_props & BT_GAP_ADV_PROP_CONNECTABLE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_SCANNABLE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_DIRECTED) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_SCAN_RESPONSE) != 0,
+	       (info->adv_props & BT_GAP_ADV_PROP_EXT_ADV) != 0,
+	       phy2str(info->primary_phy), phy2str(info->secondary_phy),
+	       info->interval, info->interval * 5 / 4, info->sid);
+}
+
+static struct bt_le_scan_cb scan_callbacks = {
+	.recv = scan_recv,
+};
+#endif /* CONFIG_BT_EXT_ADV */
+
+int observer_start(void)
+{
+	struct bt_le_scan_param scan_param = {
+		.type       = BT_LE_SCAN_TYPE_PASSIVE,
+		.options    = BT_LE_SCAN_OPT_FILTER_DUPLICATE,
+		.interval   = BT_GAP_SCAN_FAST_INTERVAL,
+		.window     = BT_GAP_SCAN_FAST_WINDOW,
+	};
+	int err;
+
+#if defined(CONFIG_BT_EXT_ADV)
+	bt_le_scan_cb_register(&scan_callbacks);
+	printk("Registered scan callbacks\n");
+#endif /* CONFIG_BT_EXT_ADV */
+
+	err = bt_le_scan_start(&scan_param, device_found);
+	if (err) {
+		printk("Start scanning failed (err %d)\n", err);
+		return err;
+	}
+	printk("Started scanning...\n");
+
+	return 0;
+}

--- a/subsys/bluetooth/controller/Kconfig.ll_sw_split
+++ b/subsys/bluetooth/controller/Kconfig.ll_sw_split
@@ -207,6 +207,7 @@ config BT_CTLR_ADV_AUX_PDU_BACK2BACK
 	bool "Back-to-back transmission of extended advertising trains"
 	depends on BT_BROADCASTER && BT_CTLR_ADV_EXT
 	select BT_CTLR_ADV_AUX_PDU_LINK
+	default y if BT_CTLR_ADV_DATA_LEN_MAX > 191
 	help
 	  Enables transmission of AUX_CHAIN_IND in extended advertising train by
 	  sending each AUX_CHAIN_IND one after another back-to-back.
@@ -215,6 +216,7 @@ config BT_CTLR_ADV_AUX_PDU_BACK2BACK_AFS
 	int "AUX Frame Space for back-to-back transmission of extended advertising trains"
 	depends on BT_CTLR_ADV_AUX_PDU_BACK2BACK
 	range 300 1000
+	default 300
 	help
 	  Specific AUX Frame Space to be used for back-to-back transmission of
 	  extended advertising trains. Time specified in microseconds.

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -401,7 +401,7 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		struct pdu_adv_ext_hdr *hdr_chain;
 		struct pdu_adv_aux_ptr *aux_ptr;
 		struct pdu_adv *pdu_chain_prev;
-		struct pdu_adv_ext_hdr *hdr;
+		struct pdu_adv_ext_hdr hdr;
 		struct pdu_adv *pdu_chain;
 		uint8_t *dptr_chain;
 		uint32_t offs_us;
@@ -415,8 +415,12 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 
 		/* Get reference to flags in superior PDU */
 		com_hdr = &pdu->adv_ext_ind;
-		hdr = (void *)&com_hdr->ext_hdr_adv_data[0];
-		dptr = (void *)hdr;
+		if (com_hdr->ext_hdr_len) {
+			hdr = com_hdr->ext_hdr;
+		} else {
+			*(uint8_t *)&hdr = 0U;
+		}
+		dptr = com_hdr->ext_hdr.data;
 
 		/* Allocate new PDU */
 		pdu_chain = lll_adv_pdu_alloc_pdu_adv();
@@ -438,14 +442,11 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		*dptr_chain = 0U;
 
 		/* ADI flag, mandatory if superior PDU has it */
-		if (hdr->adi) {
+		if (hdr.adi) {
 			hdr_chain->adi = 1U;
 		}
 
 		/* Proceed to next byte if any flags present */
-		if (*dptr) {
-			dptr++;
-		}
 		if (*dptr_chain) {
 			dptr_chain++;
 		}
@@ -453,12 +454,12 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		/* Start adding fields corresponding to flags here, if any */
 
 		/* AdvA flag */
-		if (hdr->adv_addr) {
+		if (hdr.adv_addr) {
 			dptr += BDADDR_SIZE;
 		}
 
 		/* TgtA flag */
-		if (hdr->tgt_addr) {
+		if (hdr.tgt_addr) {
 			dptr += BDADDR_SIZE;
 		}
 
@@ -473,10 +474,11 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			dptr_chain += sizeof(struct pdu_adv_adi);
 		}
 
-		/* Finish Common ExtAdv Payload header */
+		/* non-connectable non-scannable chain pdu */
 		com_hdr_chain->adv_mode = 0;
-		com_hdr_chain->ext_hdr_len =
-			dptr_chain - &com_hdr_chain->ext_hdr_adv_data[0];
+
+		/* Calc current chain PDU len */
+		sec_len = ull_adv_aux_hdr_len_calc(com_hdr_chain, &dptr_chain);
 
 		/* Prefix overflowed data to chain PDU and reduce the AD data in
 		 * in the current PDU.
@@ -519,11 +521,9 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			len = ad_len_chain;
 		}
 
-		/* PDU length so far */
-		sec_len = dptr_chain - &pdu_chain->payload[0];
-
 		/* Check AdvData overflow */
-		if ((sec_len + len) > PDU_AC_PAYLOAD_SIZE_MAX) {
+		if ((sec_len + ad_len_overflow + len) >
+		    PDU_AC_PAYLOAD_SIZE_MAX) {
 			/* NOTE: latest PDU was not consumed by LLL and
 			 * as ull_adv_sync_pdu_alloc() has reverted back
 			 * the double buffer with the first PDU, and
@@ -538,11 +538,12 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			return BT_HCI_ERR_PACKET_TOO_LONG;
 		}
 
+		/* Fill the chain PDU length */
+		ull_adv_aux_hdr_len_fill(com_hdr_chain, sec_len);
+		pdu_chain->len = sec_len + ad_len_overflow + len;
+
 		/* Fill AD Data in chain PDU */
 		(void)memcpy(dptr_chain, data, len);
-
-		/* Fill the chain PDU length */
-		pdu_chain->len = sec_len + len;
 
 		/* Fill the aux offset in the previous AUX_SYNC_IND PDU */
 		offs_us = PDU_AC_US(pdu->len, adv->lll.phy_s,
@@ -1023,7 +1024,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		struct pdu_adv_ext_hdr *hdr_chain;
 		struct pdu_adv_aux_ptr *aux_ptr;
 		struct pdu_adv *pdu_chain_prev;
-		struct pdu_adv_ext_hdr *hdr;
+		struct pdu_adv_ext_hdr hdr;
 		struct pdu_adv *pdu_chain;
 		uint8_t aux_ptr_offset;
 		uint8_t *dptr_chain;
@@ -1042,8 +1043,12 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 
 		/* Get reference to flags in superior PDU */
 		com_hdr = &sr_pdu->adv_ext_ind;
-		hdr = (void *)&com_hdr->ext_hdr_adv_data[0];
-		dptr = (void *)hdr;
+		if (com_hdr->ext_hdr_len) {
+			hdr = com_hdr->ext_hdr;
+		} else {
+			*(uint8_t *)&hdr = 0U;
+		}
+		dptr = com_hdr->ext_hdr.data;
 
 		/* Allocate new PDU */
 		pdu_chain = lll_adv_pdu_alloc_pdu_adv();
@@ -1065,14 +1070,11 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		*dptr_chain = 0U;
 
 		/* ADI flag, mandatory if superior PDU has it */
-		if (hdr->adi) {
+		if (hdr.adi) {
 			hdr_chain->adi = 1U;
 		}
 
 		/* Proceed to next byte if any flags present */
-		if (*dptr) {
-			dptr++;
-		}
 		if (*dptr_chain) {
 			dptr_chain++;
 		}
@@ -1080,12 +1082,12 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		/* Start adding fields corresponding to flags here, if any */
 
 		/* AdvA flag */
-		if (hdr->adv_addr) {
+		if (hdr.adv_addr) {
 			dptr += BDADDR_SIZE;
 		}
 
 		/* TgtA flag */
-		if (hdr->tgt_addr) {
+		if (hdr.tgt_addr) {
 			dptr += BDADDR_SIZE;
 		}
 
@@ -1100,10 +1102,11 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			dptr_chain += sizeof(struct pdu_adv_adi);
 		}
 
-		/* Finish Common ExtAdv Payload header */
+		/* non-connectable non-scannable chain pdu */
 		com_hdr_chain->adv_mode = 0;
-		com_hdr_chain->ext_hdr_len =
-			dptr_chain - &com_hdr_chain->ext_hdr_adv_data[0];
+
+		/* Calc current chain PDU len */
+		sec_len = ull_adv_aux_hdr_len_calc(com_hdr_chain, &dptr_chain);
 
 		/* Prefix overflowed data to chain PDU and reduce the AD data in
 		 * in the current PDU.
@@ -1146,11 +1149,9 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			len = ad_len_chain;
 		}
 
-		/* PDU length so far */
-		sec_len = dptr_chain - &pdu_chain->payload[0];
-
 		/* Check AdvData overflow */
-		if ((sec_len + len) > PDU_AC_PAYLOAD_SIZE_MAX) {
+		if ((sec_len + ad_len_overflow + len) >
+		    PDU_AC_PAYLOAD_SIZE_MAX) {
 			/* NOTE: latest PDU was not consumed by LLL and
 			 * as ull_adv_sync_pdu_alloc() has reverted back
 			 * the double buffer with the first PDU, and
@@ -1165,11 +1166,12 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			return BT_HCI_ERR_PACKET_TOO_LONG;
 		}
 
+		/* Fill the chain PDU length */
+		ull_adv_aux_hdr_len_fill(com_hdr_chain, sec_len);
+		pdu_chain->len = sec_len + ad_len_overflow + len;
+
 		/* Fill AD Data in chain PDU */
 		(void)memcpy(dptr_chain, data, len);
-
-		/* Fill the chain PDU length */
-		pdu_chain->len = sec_len + len;
 
 		/* Fill the aux offset in the previous AUX_SYNC_IND PDU */
 		offs_us = PDU_AC_US(sr_pdu->len, adv->lll.phy_s,
@@ -1385,8 +1387,8 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 {
 	struct pdu_adv_com_ext_adv *pri_com_hdr, *pri_com_hdr_prev;
 	struct pdu_adv_com_ext_adv *sec_com_hdr, *sec_com_hdr_prev;
-	struct pdu_adv_ext_hdr *pri_hdr, pri_hdr_prev;
-	struct pdu_adv_ext_hdr *sec_hdr, sec_hdr_prev;
+	struct pdu_adv_ext_hdr *hdr, pri_hdr, pri_hdr_prev;
+	struct pdu_adv_ext_hdr sec_hdr, sec_hdr_prev;
 	struct pdu_adv *pri_pdu, *pri_pdu_prev;
 	struct pdu_adv *sec_pdu_prev, *sec_pdu;
 	struct pdu_adv_adi *pri_adi, *sec_adi;
@@ -1428,13 +1430,13 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	}
 
 	pri_com_hdr_prev = (void *)&pri_pdu_prev->adv_ext_ind;
-	pri_hdr = (void *)pri_com_hdr_prev->ext_hdr_adv_data;
+	hdr = (void *)pri_com_hdr_prev->ext_hdr_adv_data;
 	if (pri_com_hdr_prev->ext_hdr_len) {
-		pri_hdr_prev = *pri_hdr;
+		pri_hdr_prev = *hdr;
 	} else {
 		*(uint8_t *)&pri_hdr_prev = 0U;
 	}
-	pri_dptr_prev = pri_hdr->data;
+	pri_dptr_prev = hdr->data;
 
 	/* Advertising data are not supported by scannable instances */
 	if ((sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_AD_DATA) &&
@@ -1449,9 +1451,9 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	pri_pdu->chan_sel = 0U;
 	pri_com_hdr = (void *)&pri_pdu->adv_ext_ind;
 	pri_com_hdr->adv_mode = pri_com_hdr_prev->adv_mode;
-	pri_hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
-	pri_dptr = pri_hdr->data;
-	*(uint8_t *)pri_hdr = 0U;
+	hdr = (void *)pri_com_hdr->ext_hdr_adv_data;
+	pri_dptr = hdr->data;
+	*(uint8_t *)&pri_hdr = 0U;
 
 	/* Get the reference to aux instance */
 	lll_aux = lll->aux;
@@ -1474,9 +1476,9 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* Get reference to previous secondary PDU data */
 	sec_pdu_prev = lll_adv_aux_data_peek(lll_aux);
 	sec_com_hdr_prev = (void *)&sec_pdu_prev->adv_ext_ind;
-	sec_hdr = (void *)sec_com_hdr_prev->ext_hdr_adv_data;
+	hdr = (void *)sec_com_hdr_prev->ext_hdr_adv_data;
 	if (!is_aux_new) {
-		sec_hdr_prev = *sec_hdr;
+		sec_hdr_prev = *hdr;
 	} else {
 		/* Initialize only those fields used to copy into new PDU
 		 * buffer.
@@ -1484,9 +1486,10 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		sec_pdu_prev->tx_addr = 0U;
 		sec_pdu_prev->rx_addr = 0U;
 		sec_pdu_prev->len = PDU_AC_EXT_HEADER_SIZE_MIN;
+		*(uint8_t *)hdr = 0U;
 		*(uint8_t *)&sec_hdr_prev = 0U;
 	}
-	sec_dptr_prev = sec_hdr->data;
+	sec_dptr_prev = hdr->data;
 
 	/* Get reference to new secondary PDU data buffer */
 	sec_pdu = lll_adv_aux_data_alloc(lll_aux, sec_idx);
@@ -1499,9 +1502,9 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 	sec_com_hdr = (void *)&sec_pdu->adv_ext_ind;
 	sec_com_hdr->adv_mode = pri_com_hdr->adv_mode;
-	sec_hdr = (void *)sec_com_hdr->ext_hdr_adv_data;
-	sec_dptr = sec_hdr->data;
-	*(uint8_t *)sec_hdr = 0U;
+	hdr = (void *)sec_com_hdr->ext_hdr_adv_data;
+	sec_dptr = hdr->data;
+	*(uint8_t *)&sec_hdr = 0U;
 
 	/* AdvA flag */
 	/* NOTE: as we will use auxiliary packet, we remove AdvA in primary
@@ -1510,7 +1513,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	 * set), can be copied from primary PDU (i.e. adding AD to existing set)
 	 * or can be copied from previous secondary PDU.
 	 */
-	sec_hdr->adv_addr = 1;
+	sec_hdr.adv_addr = 1;
 	if (sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_ADVA) {
 		uint8_t own_addr_type = *(uint8_t *)hdr_data;
 
@@ -1540,14 +1543,14 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	 * Move from primary to secondary PDU, if present in primary PDU.
 	 */
 	if (pri_hdr_prev.tgt_addr) {
-		sec_hdr->tgt_addr = 1U;
+		sec_hdr.tgt_addr = 1U;
 		sec_pdu->rx_addr = pri_pdu_prev->rx_addr;
 		sec_dptr += BDADDR_SIZE;
 
 	/* Retain the target address if present in the previous PDU */
 	} else if (!(sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_ADVA) &&
 		   sec_hdr_prev.tgt_addr) {
-		sec_hdr->tgt_addr = 1U;
+		sec_hdr.tgt_addr = 1U;
 		sec_pdu->rx_addr = sec_pdu_prev->rx_addr;
 		sec_dptr += BDADDR_SIZE;
 	}
@@ -1567,10 +1570,10 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	if (pri_hdr_prev.adi) {
 		pri_dptr_prev += sizeof(struct pdu_adv_adi);
 	}
-	pri_hdr->adi = 1;
+	pri_hdr.adi = 1;
 	pri_dptr += sizeof(struct pdu_adv_adi);
 	if (sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_ADI) {
-		sec_hdr->adi = 1U;
+		sec_hdr.adi = 1U;
 		/* return the size of ADI structure */
 		*(uint8_t *)hdr_data = sizeof(struct pdu_adv_adi);
 		hdr_data = (uint8_t *)hdr_data + sizeof(uint8_t);
@@ -1581,7 +1584,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		hdr_data = (uint8_t *)hdr_data + sizeof(sec_dptr);
 		sec_dptr += sizeof(struct pdu_adv_adi);
 	} else {
-		sec_hdr->adi = 1;
+		sec_hdr.adi = 1;
 		adi = NULL;
 		sec_dptr += sizeof(struct pdu_adv_adi);
 	}
@@ -1593,11 +1596,11 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	if (pri_hdr_prev.aux_ptr) {
 		pri_dptr_prev += sizeof(struct pdu_adv_aux_ptr);
 	}
-	pri_hdr->aux_ptr = 1;
+	pri_hdr.aux_ptr = 1;
 	pri_dptr += sizeof(struct pdu_adv_aux_ptr);
 
 	if (sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_AUX_PTR) {
-		sec_hdr->aux_ptr = 1;
+		sec_hdr.aux_ptr = 1;
 		aux_ptr = NULL;
 
 		/* return the size of aux pointer structure */
@@ -1611,7 +1614,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		hdr_data = (uint8_t *)hdr_data + sizeof(sec_dptr);
 	} else if (!(sec_hdr_rem_fields & ULL_ADV_PDU_HDR_FIELD_AUX_PTR) &&
 		   sec_hdr_prev.aux_ptr) {
-		sec_hdr->aux_ptr = 1;
+		sec_hdr.aux_ptr = 1;
 		aux_ptr = (void *)sec_dptr_prev;
 	} else {
 		aux_ptr = NULL;
@@ -1619,7 +1622,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	if (sec_hdr_prev.aux_ptr) {
 		sec_dptr_prev += sizeof(struct pdu_adv_aux_ptr);
 	}
-	if (sec_hdr->aux_ptr) {
+	if (sec_hdr.aux_ptr) {
 		sec_dptr += sizeof(struct pdu_adv_aux_ptr);
 	}
 
@@ -1629,7 +1632,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* No SyncInfo flag in primary channel PDU */
 	/* Add/Remove SyncInfo flag in secondary channel PDU */
 	if (sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_SYNC_INFO) {
-		sec_hdr->sync_info = 1;
+		sec_hdr.sync_info = 1;
 		sync_info = NULL;
 
 		/* return the size of sync info structure */
@@ -1643,7 +1646,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		hdr_data = (uint8_t *)hdr_data + sizeof(sec_dptr);
 	} else if (!(sec_hdr_rem_fields & ULL_ADV_PDU_HDR_FIELD_SYNC_INFO) &&
 		   sec_hdr_prev.sync_info) {
-		sec_hdr->sync_info = 1;
+		sec_hdr.sync_info = 1;
 		sync_info = (void *)sec_dptr_prev;
 	} else {
 		sync_info = NULL;
@@ -1651,7 +1654,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	if (sec_hdr_prev.sync_info) {
 		sec_dptr_prev += sizeof(*sync_info);
 	}
-	if (sec_hdr->sync_info) {
+	if (sec_hdr.sync_info) {
 		sec_dptr += sizeof(*sync_info);
 	}
 #endif /* CONFIG_BT_CTLR_ADV_PERIODIC */
@@ -1664,18 +1667,18 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		 * reserved for future use on the LE Coded PHY.
 		 */
 		if (lll->phy_p != PHY_CODED) {
-			pri_hdr->tx_pwr = 1;
+			pri_hdr.tx_pwr = 1;
 			pri_dptr++;
 		} else {
-			sec_hdr->tx_pwr = 1;
+			sec_hdr.tx_pwr = 1;
 		}
 	}
 	if (sec_hdr_prev.tx_pwr) {
 		sec_dptr_prev++;
 
-		sec_hdr->tx_pwr = 1;
+		sec_hdr.tx_pwr = 1;
 	}
-	if (sec_hdr->tx_pwr) {
+	if (sec_hdr.tx_pwr) {
 		sec_dptr++;
 	}
 
@@ -1684,10 +1687,6 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 	/* Calc primary PDU len */
 	pri_len = ull_adv_aux_hdr_len_calc(pri_com_hdr, &pri_dptr);
-	ull_adv_aux_hdr_len_fill(pri_com_hdr, pri_len);
-
-	/* set the primary PDU len */
-	pri_pdu->len = pri_len;
 
 	/* Calc previous secondary PDU len */
 	sec_len_prev = ull_adv_aux_hdr_len_calc(sec_com_hdr_prev,
@@ -1702,7 +1701,6 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 
 	/* Calc current secondary PDU len */
 	sec_len = ull_adv_aux_hdr_len_calc(sec_com_hdr, &sec_dptr);
-	ull_adv_aux_hdr_len_fill(sec_com_hdr, sec_len);
 
 	/* AD Data, add or remove */
 	if (sec_hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_AD_DATA) {
@@ -1762,7 +1760,12 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		return BT_HCI_ERR_PACKET_TOO_LONG;
 	}
 
+	/* set the primary PDU len */
+	ull_adv_aux_hdr_len_fill(pri_com_hdr, pri_len);
+	pri_pdu->len = pri_len;
+
 	/* set the secondary PDU len */
+	ull_adv_aux_hdr_len_fill(sec_com_hdr, sec_len);
 	sec_pdu->len = sec_len + ad_len;
 
 	/* Start filling pri and sec PDU payload based on flags from here
@@ -1782,9 +1785,9 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* TODO: Fill ACAD in secondary channel PDU */
 
 	/* Tx Power */
-	if (pri_hdr->tx_pwr) {
+	if (pri_hdr.tx_pwr) {
 		*--pri_dptr = *--pri_dptr_prev;
-	} else if (sec_hdr->tx_pwr) {
+	} else if (sec_hdr.tx_pwr) {
 		*--sec_dptr = *--sec_dptr_prev;
 	}
 
@@ -1795,7 +1798,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		sec_dptr_prev -= sizeof(*sync_info);
 	}
 
-	if (sec_hdr->sync_info) {
+	if (sec_hdr.sync_info) {
 		sec_dptr -= sizeof(*sync_info);
 	}
 
@@ -1814,7 +1817,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	if (sec_hdr_prev.aux_ptr) {
 		sec_dptr_prev -= sizeof(struct pdu_adv_aux_ptr);
 	}
-	if (sec_hdr->aux_ptr) {
+	if (sec_hdr.aux_ptr) {
 		sec_dptr -= sizeof(struct pdu_adv_aux_ptr);
 	}
 
@@ -1855,7 +1858,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* No TargetA non-conn non-scan advertising, but present in directed
 	 * advertising.
 	 */
-	if (sec_hdr->tgt_addr) {
+	if (sec_hdr.tgt_addr) {
 		void *bdaddr;
 
 		if (sec_hdr_prev.tgt_addr) {
@@ -1876,7 +1879,7 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 	/* NOTE: AdvA in aux channel is also filled at enable and RPA
 	 * timeout
 	 */
-	if (sec_hdr->adv_addr) {
+	if (sec_hdr.adv_addr) {
 		void *bdaddr;
 
 		if (sec_hdr_prev.adv_addr) {
@@ -1890,6 +1893,20 @@ uint8_t ull_adv_aux_hdr_set_clear(struct ll_adv_set *adv,
 		sec_dptr -= BDADDR_SIZE;
 
 		(void)memcpy(sec_dptr, bdaddr, BDADDR_SIZE);
+	}
+
+	/* Set the common extended header format flags in the current primary
+	 * PDU
+	 */
+	if (pri_com_hdr->ext_hdr_len != 0) {
+		pri_com_hdr->ext_hdr = pri_hdr;
+	}
+
+	/* Set the common extended header format flags in the current secondary
+	 * PDU
+	 */
+	if (sec_com_hdr->ext_hdr_len != 0) {
+		sec_com_hdr->ext_hdr = sec_hdr;
 	}
 
 #if defined(CONFIG_BT_CTLR_ADV_AUX_PDU_LINK)

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -408,11 +408,6 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		uint16_t sec_len;
 		uint8_t *dptr;
 
-		/* Get reference to aux ptr in superior PDU */
-		(void)memcpy(&aux_ptr,
-			     &hdr_data[ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET],
-			     sizeof(aux_ptr));
-
 		/* Get reference to flags in superior PDU */
 		com_hdr = &pdu->adv_ext_ind;
 		if (com_hdr->ext_hdr_len) {
@@ -544,6 +539,11 @@ uint8_t ll_adv_aux_ad_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 
 		/* Fill AD Data in chain PDU */
 		(void)memcpy(dptr_chain, data, len);
+
+		/* Get reference to aux ptr in superior PDU */
+		(void)memcpy(&aux_ptr,
+			     &hdr_data[ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET],
+			     sizeof(aux_ptr));
 
 		/* Fill the aux offset in the previous AUX_SYNC_IND PDU */
 		offs_us = PDU_AC_US(pdu->len, adv->lll.phy_s,
@@ -1032,15 +1032,6 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 		uint16_t sec_len;
 		uint8_t *dptr;
 
-		/* Get reference to aux ptr in superior PDU */
-		aux_ptr_offset = ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET;
-		if (hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_ADI) {
-			aux_ptr_offset +=  ULL_ADV_HDR_DATA_ADI_PTR_OFFSET +
-					   ULL_ADV_HDR_DATA_ADI_PTR_SIZE;
-		}
-		(void)memcpy(&aux_ptr, &hdr_data[aux_ptr_offset],
-			     sizeof(aux_ptr));
-
 		/* Get reference to flags in superior PDU */
 		com_hdr = &sr_pdu->adv_ext_ind;
 		if (com_hdr->ext_hdr_len) {
@@ -1172,6 +1163,15 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 
 		/* Fill AD Data in chain PDU */
 		(void)memcpy(dptr_chain, data, len);
+
+		/* Get reference to aux ptr in superior PDU */
+		aux_ptr_offset = ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET;
+		if (hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_ADI) {
+			aux_ptr_offset +=  ULL_ADV_HDR_DATA_ADI_PTR_OFFSET +
+					   ULL_ADV_HDR_DATA_ADI_PTR_SIZE;
+		}
+		(void)memcpy(&aux_ptr, &hdr_data[aux_ptr_offset],
+			     sizeof(aux_ptr));
 
 		/* Fill the aux offset in the previous AUX_SYNC_IND PDU */
 		offs_us = PDU_AC_US(sr_pdu->len, adv->lll.phy_s,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -466,7 +466,7 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 		struct pdu_adv_ext_hdr *hdr_chain;
 		struct pdu_adv_aux_ptr *aux_ptr;
 		struct pdu_adv *pdu_chain_prev;
-		struct pdu_adv_ext_hdr *hdr;
+		struct pdu_adv_ext_hdr hdr;
 		struct pdu_adv *pdu_chain;
 		uint8_t *dptr_chain;
 		uint32_t offs_us;
@@ -480,8 +480,12 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 
 		/* Get reference to flags in superior PDU */
 		com_hdr = &pdu->adv_ext_ind;
-		hdr = (void *)&com_hdr->ext_hdr_adv_data[0];
-		dptr = (void *)hdr;
+		if (com_hdr->ext_hdr_len) {
+			hdr = com_hdr->ext_hdr;
+		} else {
+			*(uint8_t *)&hdr = 0U;
+		}
+		dptr = com_hdr->ext_hdr.data;
 
 		/* Allocate new PDU */
 		pdu_chain = lll_adv_pdu_alloc_pdu_adv();
@@ -509,14 +513,11 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 		 */
 
 		/* ADI flag, mandatory if superior PDU has it */
-		if (hdr->adi) {
+		if (hdr.adi) {
 			hdr_chain->adi = 1U;
 		}
 
 		/* Proceed to next byte if any flags present */
-		if (*dptr) {
-			dptr++;
-		}
 		if (*dptr_chain) {
 			dptr_chain++;
 		}
@@ -536,10 +537,11 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 			dptr_chain += sizeof(struct pdu_adv_adi);
 		}
 
-		/* Finish Common ExtAdv Payload header */
+		/* non-connectable non-scannable chain pdu */
 		com_hdr_chain->adv_mode = 0;
-		com_hdr_chain->ext_hdr_len =
-			dptr_chain - &com_hdr_chain->ext_hdr_adv_data[0];
+
+		/* Calc current chain PDU len */
+		ter_len = ull_adv_aux_hdr_len_calc(com_hdr_chain, &dptr_chain);
 
 		/* Prefix overflowed data to chain PDU and reduce the AD data in
 		 * in the current PDU.
@@ -583,19 +585,29 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 			len = ad_len_chain;
 		}
 
-		/* PDU length so far */
-		ter_len = dptr_chain - &pdu_chain->payload[0];
-
 		/* Check AdvData overflow */
-		if ((ter_len + len) > PDU_AC_PAYLOAD_SIZE_MAX) {
+		if ((ter_len + ad_len_overflow + len) >
+		    PDU_AC_PAYLOAD_SIZE_MAX) {
+			/* NOTE: latest PDU was not consumed by LLL and
+			 * as ull_adv_sync_pdu_alloc() has reverted back
+			 * the double buffer with the first PDU, and
+			 * returned the latest PDU as the new PDU, we
+			 * need to enqueue back the new PDU which is
+			 * infact the latest PDU.
+			 */
+			if (pdu_prev == pdu) {
+				lll_adv_sync_data_enqueue(lll_sync, ter_idx);
+			}
+
 			return BT_HCI_ERR_PACKET_TOO_LONG;
 		}
 
+		/* Fill the chain PDU length */
+		ull_adv_aux_hdr_len_fill(com_hdr_chain, ter_len);
+		pdu_chain->len = ter_len + ad_len_overflow + len;
+
 		/* Fill AD Data in chain PDU */
 		(void)memcpy(dptr_chain, data, len);
-
-		/* Fill the chain PDU length */
-		pdu_chain->len = ter_len + len;
 
 		/* Fill the aux offset in the previous AUX_SYNC_IND PDU */
 		offs_us = PDU_AC_US(pdu->len, adv->lll.phy_s,

--- a/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_sync.c
@@ -473,11 +473,6 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 		uint16_t ter_len;
 		uint8_t *dptr;
 
-		/* Get reference to aux ptr in superior PDU */
-		(void)memcpy(&aux_ptr,
-			     &hdr_data[ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET],
-			     sizeof(aux_ptr));
-
 		/* Get reference to flags in superior PDU */
 		com_hdr = &pdu->adv_ext_ind;
 		if (com_hdr->ext_hdr_len) {
@@ -608,6 +603,11 @@ uint8_t ll_adv_sync_ad_data_set(uint8_t handle, uint8_t op, uint8_t len,
 
 		/* Fill AD Data in chain PDU */
 		(void)memcpy(dptr_chain, data, len);
+
+		/* Get reference to aux ptr in superior PDU */
+		(void)memcpy(&aux_ptr,
+			     &hdr_data[ULL_ADV_HDR_DATA_AUX_PTR_PTR_OFFSET],
+			     sizeof(aux_ptr));
 
 		/* Fill the aux offset in the previous AUX_SYNC_IND PDU */
 		offs_us = PDU_AC_US(pdu->len, adv->lll.phy_s,

--- a/tests/bluetooth/bsim_bt/bsim_test_adv_chain/CMakeLists.txt
+++ b/tests/bluetooth/bsim_bt/bsim_test_adv_chain/CMakeLists.txt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+if (NOT DEFINED ENV{BSIM_COMPONENTS_PATH})
+  message(FATAL_ERROR "This test requires the BabbleSim simulator. Please set  \
+          the  environment variable BSIM_COMPONENTS_PATH to point to its       \
+          components folder. More information can be found in                  \
+          https://babblesim.github.io/folder_structure_and_env.html")
+endif()
+
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
+project(bsim_test_adv_chain)
+
+target_sources(app PRIVATE
+  src/main.c
+  ${ZEPHYR_BASE}/samples/bluetooth/broadcaster_multiple/src/broadcaster_multiple.c
+  ${ZEPHYR_BASE}/samples/bluetooth/observer/src/observer.c
+)
+
+zephyr_include_directories(
+  $ENV{BSIM_COMPONENTS_PATH}/libUtilv1/src/
+  $ENV{BSIM_COMPONENTS_PATH}/libPhyComv1/src/
+)

--- a/tests/bluetooth/bsim_bt/bsim_test_adv_chain/prj.conf
+++ b/tests/bluetooth/bsim_bt/bsim_test_adv_chain/prj.conf
@@ -1,0 +1,36 @@
+CONFIG_BT=y
+CONFIG_BT_BROADCASTER=y
+CONFIG_BT_OBSERVER=y
+CONFIG_BT_EXT_ADV=y
+CONFIG_BT_EXT_ADV_MAX_ADV_SET=2
+CONFIG_BT_DEVICE_NAME="Broadcaster Multiple"
+
+# Zephyr Bluetooth LE Controller will need to use chain PDUs when AD data
+# length > 191 bytes
+# - 31 bytes will use 22 bytes for the default name in this sample plus 9 bytes
+#   for manufacturer data
+# - 191 bytes will use 22 bytes for the default name in this sample plus 169
+#   bytes for manufacturer data
+# - 277 bytes will use 22 bytes for the default name in this sample plus 255
+#   bytes for manufacturer data
+CONFIG_BT_CTLR_ADV_DATA_LEN_MAX=1650
+
+# Increase Advertising PDU buffers to number of advertising sets times the
+# number of chain PDUs per advertising set when using Zephyr Bluetooth LE
+# Controller
+CONFIG_BT_CTLR_ADVANCED_FEATURES=y
+CONFIG_BT_CTLR_ADV_DATA_BUF_MAX=2
+
+# Maximum Extended Scanning buffer size
+CONFIG_BT_EXT_SCAN_BUF_SIZE=1650
+
+# Set maximum scan data length for Extended Scanning in Bluetooth LE Controller
+CONFIG_BT_CTLR_SCAN_DATA_LEN_MAX=1650
+
+# Zephyr Bluetooth LE Controller needs 16 event buffers to generate Extended
+# Advertising Report for receiving the complete 1650 bytes of data
+CONFIG_BT_BUF_EVT_RX_COUNT=16
+
+# Increase Zephyr Bluetooth LE Controller Rx buffer to receive complete chain
+# of PDUs
+CONFIG_BT_CTLR_RX_BUFFERS=9

--- a/tests/bluetooth/bsim_bt/bsim_test_adv_chain/src/main.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_adv_chain/src/main.c
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <stddef.h>
+
+#include <zephyr/zephyr.h>
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/util.h>
+
+#include <zephyr/bluetooth/bluetooth.h>
+#include <zephyr/bluetooth/hci.h>
+
+#include "bs_types.h"
+#include "bs_tracing.h"
+#include "time_machine.h"
+#include "bstests.h"
+
+#define FAIL(...)					\
+	do {						\
+		bst_result = Failed;			\
+		bs_trace_error_time_line(__VA_ARGS__);	\
+	} while (0)
+
+#define PASS(...)					\
+	do {						\
+		bst_result = Passed;			\
+		bs_trace_info_time(1, __VA_ARGS__);	\
+	} while (0)
+
+#define NAME_LEN 30
+#define BT_AD_DATA_NAME_SIZE     (sizeof(CONFIG_BT_DEVICE_NAME) - 1U + 2U)
+#define BT_AD_DATA_MFG_DATA_SIZE (254U + 2U)
+#define DATA_LEN                 MIN((BT_AD_DATA_NAME_SIZE + \
+				      BT_AD_DATA_MFG_DATA_SIZE), \
+				     CONFIG_BT_CTLR_ADV_DATA_LEN_MAX)
+
+static K_SEM_DEFINE(sem_recv, 0, 1);
+
+extern enum bst_result_t bst_result;
+
+static void test_adv_main(void)
+{
+	extern int broadcaster_multiple(void);
+	int err;
+
+	err = broadcaster_multiple();
+	if (err) {
+		FAIL("Adv tests failed\n");
+		bs_trace_silent_exit(err);
+		return;
+	}
+
+	/* Successfully started advertising multiple sets */
+	PASS("Adv tests passed\n");
+
+	/* Let the scanner receive the reports */
+	k_sleep(K_SECONDS(10));
+}
+
+static bool data_cb(struct bt_data *data, void *user_data)
+{
+	char *name = user_data;
+	uint8_t len;
+
+	switch (data->type) {
+	case BT_DATA_NAME_SHORTENED:
+	case BT_DATA_NAME_COMPLETE:
+		len = MIN(data->data_len, NAME_LEN - 1);
+		(void)memcpy(name, data->data, len);
+		name[len] = '\0';
+		return false;
+	default:
+		return true;
+	}
+}
+
+static void scan_recv(const struct bt_le_scan_recv_info *info,
+		      struct net_buf_simple *buf)
+{
+	static uint8_t sid[CONFIG_BT_EXT_ADV_MAX_ADV_SET];
+	static uint8_t sid_count;
+	char name[NAME_LEN];
+	uint8_t data_status;
+	uint16_t data_len;
+
+	data_status = BT_HCI_LE_ADV_EVT_TYPE_DATA_STATUS(info->adv_props);
+	if (data_status) {
+		return;
+	}
+
+	data_len = buf->len;
+	if (data_len != DATA_LEN) {
+		return;
+	}
+
+	(void)memset(name, 0, sizeof(name));
+	bt_data_parse(buf, data_cb, name);
+
+	if (strcmp(name, CONFIG_BT_DEVICE_NAME)) {
+		return;
+	}
+
+	for (uint8_t i = 0; i < sid_count; i++) {
+		if (sid[i] == info->sid) {
+			return;
+		}
+	}
+
+	sid[sid_count++] = info->sid;
+
+	if (sid_count < CONFIG_BT_EXT_ADV_MAX_ADV_SET) {
+		return;
+	}
+
+	k_sem_give(&sem_recv);
+}
+
+static struct bt_le_scan_cb scan_callbacks = {
+	.recv = scan_recv,
+};
+
+static void test_scan_main(void)
+{
+	extern int observer_start(void);
+	int err;
+
+	err = bt_enable(NULL);
+	if (err) {
+		FAIL("Bluetooth init failed\n");
+
+		bs_trace_silent_exit(err);
+		return;
+	}
+
+	bt_le_scan_cb_register(&scan_callbacks);
+
+	err = observer_start();
+	if (err) {
+		FAIL("Observer start failed\n");
+
+		bs_trace_silent_exit(err);
+		return;
+	}
+
+	/* Let the recv callback verify the reports */
+	k_sleep(K_SECONDS(10));
+
+	err = k_sem_take(&sem_recv, K_NO_WAIT);
+	if (err) {
+		FAIL("Scan receive failed\n");
+
+		bs_trace_silent_exit(err);
+		return;
+	}
+
+	PASS("Scan tests passed\n");
+
+	bs_trace_silent_exit(0);
+}
+
+static void test_adv_chain_init(void)
+{
+	bst_ticker_set_next_tick_absolute(60e6);
+	bst_result = In_progress;
+}
+
+static void test_adv_chain_tick(bs_time_t HW_device_time)
+{
+	bst_result = Failed;
+	bs_trace_error_line("Test GATT Write finished.\n");
+}
+
+static const struct bst_test_instance test_def[] = {
+	{
+		.test_id = "adv",
+		.test_descr = "Central GATT Write",
+		.test_post_init_f = test_adv_chain_init,
+		.test_tick_f = test_adv_chain_tick,
+		.test_main_f = test_adv_main
+	},
+	{
+		.test_id = "scan",
+		.test_descr = "Peripheral GATT Write",
+		.test_post_init_f = test_adv_chain_init,
+		.test_tick_f = test_adv_chain_tick,
+		.test_main_f = test_scan_main
+	},
+	BSTEST_END_MARKER
+};
+
+struct bst_test_list *test_adv_chain_install(struct bst_test_list *tests)
+{
+	return bst_add_tests(tests, test_def);
+}
+
+bst_test_install_t test_installers[] = {
+	test_adv_chain_install,
+	NULL
+};
+
+void main(void)
+{
+	bst_main();
+}

--- a/tests/bluetooth/bsim_bt/bsim_test_adv_chain/tests_scripts/adv_chain.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_adv_chain/tests_scripts/adv_chain.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Copyright 2018 Oticon A/S
+# SPDX-License-Identifier: Apache-2.0
+
+# Validate Extended Advertising AD Data fragment operation, PDU chaining and
+# Extended Scanning of chain PDUs
+simulation_id="adv_chain"
+verbosity_level=2
+process_ids=""; exit_code=0
+
+function Execute(){
+  if [ ! -f $1 ]; then
+    echo -e "  \e[91m`pwd`/`basename $1` cannot be found (did you forget to\
+ compile it?)\e[39m"
+    exit 1
+  fi
+  timeout 10 $@ & process_ids="$process_ids $!"
+}
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+#Give a default value to BOARD if it does not have one yet:
+BOARD="${BOARD:-nrf52_bsim}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_adv_chain_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=adv
+
+Execute ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_adv_chain_prj_conf\
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=scan
+
+Execute ./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=10e6 $@
+
+for process_id in $process_ids; do
+  wait $process_id || let "exit_code=$?"
+done
+exit $exit_code #the last exit code != 0

--- a/tests/bluetooth/bsim_bt/compile.sh
+++ b/tests/bluetooth/bsim_bt/compile.sh
@@ -34,6 +34,7 @@ app=tests/bluetooth/bsim_bt/bsim_test_app conf_file=prj_split_low_lat.conf \
   compile
 app=tests/bluetooth/bsim_bt/bsim_test_multiple compile
 app=tests/bluetooth/bsim_bt/bsim_test_advx compile
+app=tests/bluetooth/bsim_bt/bsim_test_adv_chain compile
 app=tests/bluetooth/bsim_bt/bsim_test_gatt compile
 app=tests/bluetooth/bsim_bt/bsim_test_gatt_write compile
 app=tests/bluetooth/bsim_bt/bsim_test_l2cap compile


### PR DESCRIPTION
Added Extended Advertising multiple advertising set
broadcaster sample. Which is used to manually verify that
AD data PDU chaining is functional.

Added implementation to Observer sample so that when
Extended Advertising feature is enabled, it can receive
Extended Advertising Reports, and hence receive long AD
data from peer Extended Advertising Broadcaster Multiple
sample.

Fix Extended Advertising and Periodic Advertising's parent
PDU's aux ptr field to contain correct aux offset value to
its chain PDU.

Uninitialized pointer reference to aux ptr in the parent PDU
was used before the pointer reference was returned by the
function adding the aux ptr fields in the parent PDU.

Use local variable to update current PDU's Common Extended
Header Format flags instead of updating it directly in the
PDU buffer. This is required to be able to non-destructively
be able to manipulate the PDU's header flags and contents
many time before a final commit of the updated PDU.

In order to calculate overflowed AD data length, PDU is
manipulated couple of times to determine the overflow length
and next to be able to add aux ptr field when chain PDU is
appended.

The changes are now consistent with how Periodic Advertising
PDU's Common Extended Header Format is manipulated.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>