### PR TITLE
Bluetooth: audio: ascs: Reject peer Release operation in Idle state

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2212,6 +2212,14 @@ static ssize_t ascs_release(struct bt_ascs *ascs, struct net_buf_simple *buf)
 			continue;
 		}
 
+		if (ase->ep.status.state == BT_AUDIO_EP_STATE_IDLE) {
+			BT_WARN("Invalid operation in state: %s",
+				bt_audio_ep_state_str(ase->ep.status.state));
+			ascs_cp_rsp_add(id, BT_ASCS_RELEASE_OP,
+					BT_ASCS_RSP_INVALID_ASE_STATE, BT_ASCS_REASON_NONE);
+			continue;
+		}
+
 		ase_release(ase, false);
 	}
 

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1719,7 +1719,7 @@ static int ase_metadata(struct bt_ascs_ase *ase, uint8_t op,
 	default:
 		BT_WARN("Invalid operation in state: %s", bt_audio_ep_state_str(state));
 		err = -EBADMSG;
-		ascs_cp_rsp_add_errno(ASE_ID(ase), op, EBADMSG,
+		ascs_cp_rsp_add_errno(ASE_ID(ase), op, err,
 				      buf->len ? *buf->data : 0x00);
 		return err;
 	}
@@ -2043,7 +2043,7 @@ static void ase_stop(struct bt_ascs_ase *ase)
 
 	if (ep->status.state != BT_AUDIO_EP_STATE_DISABLING) {
 		BT_WARN("Invalid operation in state: %s", bt_audio_ep_state_str(ep->status.state));
-		ascs_cp_rsp_add_errno(ASE_ID(ase), BT_ASCS_STOP_OP, EBADMSG,
+		ascs_cp_rsp_add_errno(ASE_ID(ase), BT_ASCS_STOP_OP, -EBADMSG,
 				      BT_ASCS_REASON_NONE);
 		return;
 	}


### PR DESCRIPTION
This fixes crash that happened when client initiated Release operation
on ASE in Idle state. In such case the operation shall be rejected with
Invalid ASE State Machine Response_Code.

Fixes: ASCS/SR/SPE/BI-10-C
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>