### PR TITLE
doc: lwm2m: Announces support for v.1.1

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -239,7 +239,8 @@ The Zephyr LwM2M library implements the following items:
   Device, Firmware Update, etc.
 * Extended IPSO objects such as Light Control, Temperature Sensor, and Timer
 
-The library currently implements up to `LwM2M specification 1.0.2`_.
+By default, the library implements `LwM2M specification 1.0.2`_ and can be set to
+`LwM2M specification 1.1.1`_ with a Kconfig option.
 
 For more information about LwM2M visit `OMA Specworks LwM2M`_.
 
@@ -517,3 +518,6 @@ API Reference
 
 .. _LwM2M specification 1.0.2:
    http://openmobilealliance.org/release/LightweightM2M/V1_0_2-20180209-A/OMA-TS-LightweightM2M-V1_0_2-20180209-A.pdf
+
+.. _LwM2M specification 1.1.1:
+   http://openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/

--- a/doc/connectivity/networking/overview.rst
+++ b/doc/connectivity/networking/overview.rst
@@ -81,7 +81,8 @@ can be disabled if not needed.
   (`LwM2M specification 1.0.2`_) is supported via the "Bootstrap", "Client
   Registration", "Device Management & Service Enablement" and "Information
   Reporting" interfaces.  The required core LwM2M objects are implemented as
-  well as several IPSO Smart Objects.
+  well as several IPSO Smart Objects. (`LwM2M specification 1.1.1`_) is
+  supported in similar manner when enabled with a Kconfig option.
   :ref:`lwm2m-client-sample` implements the library as an example.
 
 * **DNS** Domain Name Service
@@ -166,3 +167,6 @@ The networking stack source code tree is organized as follows:
 
 .. _LwM2M specification 1.0.2:
    http://openmobilealliance.org/release/LightweightM2M/V1_0_2-20180209-A/OMA-TS-LightweightM2M-V1_0_2-20180209-A.pdf
+
+.. _LwM2M specification 1.1.1:
+   http://openmobilealliance.org/release/LightweightM2M/V1_1_1-20190617-A/


### PR DESCRIPTION
Tells that it's possible to enable v1.1 support by using an overlay
file.

Signed-off-by: Veijo Pesonen <veijo.pesonen@nordicsemi.no>