### PR TITLE
scripts: build: elf_parser: use node name for Graphviz diagrams

### DIFF
--- a/scripts/build/elf_parser.py
+++ b/scripts/build/elf_parser.py
@@ -268,9 +268,8 @@ class ZephyrElf:
                 text = '{:s}\\nHandle: {:d}'.format(dev.sym.name, dev.handle)
             else:
                 n = self.edt.dep_ord2node[dev.ordinal]
-                label = n.labels[0] if n.labels else n.label
                 text = '{:s}\\nOrdinal: {:d} | Handle: {:d}\\n{:s}'.format(
-                    label, dev.ordinal, dev.handle, n.path
+                    n.name, dev.ordinal, dev.handle, n.path
                 )
             dot.node(str(dev.ordinal), text)
         for dev in self.devices:


### PR DESCRIPTION
The elf_parser library now generates a dot file with device dependencies
that can be later rendered using Graphviz. Each node in the diagram
contains the device label (taken from DT node). In some cases the label
property can be None, leading to build failures like:

```
line 273, in device_dependency_graph
text = '{:s}\\nOrdinal: {:d} | Handle: {:d}\\n{:s}'.format(
TypeError: unsupported format string passed to NoneType.__format__
```

This patch switches to node name instead, which will always be set to
some value. This value is actually what devices get now as a name if
they do not have a label set.

Example:
![image](https://user-images.githubusercontent.com/25011557/182857018-03ee051e-e5c1-4529-9e2c-887f2b6b788a.png)

Note: I have not observed this issue on CI, meaning that it may be caused by some dependency being updated (I recently configured a new workstation, so I have fresh deps)

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>