### PR TITLE
Bluetooth: audio: Handle Receiver Stop Ready on non-connected stream

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -2062,7 +2062,7 @@ static void ase_stop(struct bt_ascs_ase *ase)
 	 * procedure defined in Volume 3, Part C, Section 9.3.15.
 	 */
 	err = bt_audio_stream_disconnect(stream);
-	if (err != 0) {
+	if (err != -ENOTCONN && err != 0) {
 		BT_ERR("Could not disconnect the CIS: %d", err);
 		return;
 	}


### PR DESCRIPTION
This fixes state transition to QoS Configured state triggered by
client-initiated Receiver Stop Ready operation on ASE that has no ISO
attached.

Fixes: ASCS/SR/ACP/BV-12-C
Signed-off-by: Mariusz Skamra <mariusz.skamra@codecoup.pl>