### PR TITLE
samples: sensor: accel_polling: Correct integration platform name

### DIFF
--- a/samples/sensor/accel_polling/sample.yaml
+++ b/samples/sensor/accel_polling/sample.yaml
@@ -20,7 +20,7 @@ tests:
       - thingy52_nrf52832               # lis2dh12
       - stm32f411e_disco                # lsm303agr_accel
       - stm32f3_disco                   # lsm303dlhc_accel
-      - bl5340_dvk                      # lis3dh
+      - bl5340_dvk_cpuapp               # lis3dh
       - b_l4s5i_iot01a                  # lsm6dsl
       - sensortile_box                  # lis2dw12, lsm6dso, iisdhhc
       - thingy53_nrf5340_cpuapp         # adxl362, bmi270


### PR DESCRIPTION
bl5340_dvk is a non-exists target.
I fix it to bl5340_dvk_cpuapp to fix the CI error.

Signed-off-by: TOKITA Hiroshi <tokita.hiroshi@fujitsu.com>