### PR TITLE
serial: uart_pl011: Fix compile error for CONFIG_UART_INTERRUPT_DRIVEN=n

### DIFF
--- a/drivers/serial/uart_pl011.c
+++ b/drivers/serial/uart_pl011.c
@@ -467,7 +467,7 @@ void pl011_isr(const struct device *dev)
 #else
 #define PL011_CONFIG_PORT(n)								\
 	static struct pl011_config pl011_cfg_port_##n = {				\
-		.uart = (volatile struct pl011_regs *)DT_INST_REG_ADDR(n),		\
+		DEVICE_MMIO_ROM_INIT(DT_DRV_INST(n)),					\
 		.sys_clk_freq = DT_INST_PROP_BY_PHANDLE(n, clocks, clock_frequency),	\
 	};
 #endif /* CONFIG_UART_INTERRUPT_DRIVEN */


### PR DESCRIPTION
When the uart is configured in non interrupt mode, then the mmio address
should be provided via DEVICE_MMIO_ROM_INIT.

Signed-off-by: Ayan Kumar Halder <ayankuma@amd.com>