### PR TITLE
drivers: sensor: Convert Kconfig bus 'depends on' to 'select'

### DIFF
--- a/drivers/sensor/adt7420/Kconfig
+++ b/drivers/sensor/adt7420/Kconfig
@@ -7,7 +7,7 @@ menuconfig ADT7420
 	bool "ADT7420 Temperature Sensor"
 	default y
 	depends on DT_HAS_ADI_ADT7420_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable the driver for Analog Devices ADT7420 High-Accuracy
 	  16-bit Digital I2C Temperature Sensors.

--- a/drivers/sensor/adxl345/Kconfig
+++ b/drivers/sensor/adxl345/Kconfig
@@ -7,6 +7,7 @@ config ADXL345
 	bool "ADXL345 Three Axis accelerometer"
 	default y
 	depends on DT_HAS_ADI_ADXL345_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL345),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL345),spi)
 	help
 	  Enable driver for ADXL345 Three-Axis Digital Accelerometer.

--- a/drivers/sensor/adxl362/Kconfig
+++ b/drivers/sensor/adxl362/Kconfig
@@ -7,7 +7,7 @@ menuconfig ADXL362
 	bool "ADXL362 sensor"
 	default y
 	depends on DT_HAS_ADI_ADXL362_ENABLED
-	depends on SPI
+	select SPI
 	help
 	  Enable driver for ADXL362 Three-Axis Digital Accelerometers.
 

--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -7,7 +7,8 @@ menuconfig ADXL372
 	bool "ADXL372 Three Axis High-g I2C/SPI accelerometer"
 	default y
 	depends on DT_HAS_ADI_ADXL372_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL372),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL372),spi)
 	help
 	  Enable driver for ADXL372 Three-Axis Digital Accelerometers.
 

--- a/drivers/sensor/ak8975/Kconfig
+++ b/drivers/sensor/ak8975/Kconfig
@@ -7,6 +7,6 @@ config AK8975
 	bool "AK8975 Magnetometer"
 	default y
 	depends on DT_HAS_ASAHI_KASEI_AK8975_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for AK8975 magnetometer.

--- a/drivers/sensor/amg88xx/Kconfig
+++ b/drivers/sensor/amg88xx/Kconfig
@@ -7,7 +7,7 @@ menuconfig AMG88XX
 	bool "AMG88XX Infrared Thermopile Sensor"
 	default y
 	depends on DT_HAS_PANASONIC_AMG88XX_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for AMG88XX infrared thermopile sensor.
 

--- a/drivers/sensor/ams_iAQcore/Kconfig
+++ b/drivers/sensor/ams_iAQcore/Kconfig
@@ -7,7 +7,7 @@ menuconfig AMS_IAQ_CORE
 	bool "iAQ-core Digital VOC sensor"
 	default y
 	depends on DT_HAS_AMS_IAQCORE_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for iAQ-core Digital VOC sensor.
 

--- a/drivers/sensor/apds9960/Kconfig
+++ b/drivers/sensor/apds9960/Kconfig
@@ -6,7 +6,7 @@ menuconfig APDS9960
 	bool "APDS9960 Sensor"
 	default y
 	depends on DT_HAS_AVAGO_APDS9960_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for APDS9960 sensors.
 

--- a/drivers/sensor/bma280/Kconfig
+++ b/drivers/sensor/bma280/Kconfig
@@ -7,7 +7,7 @@ menuconfig BMA280
 	bool "BMA280 Three Axis Accelerometer Family"
 	default y
 	depends on DT_HAS_BOSCH_BMA280_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for BMA280 I2C-based triaxial accelerometer sensor
 	  family.

--- a/drivers/sensor/bmc150_magn/Kconfig
+++ b/drivers/sensor/bmc150_magn/Kconfig
@@ -7,7 +7,7 @@ menuconfig BMC150_MAGN
 	bool "BMC150_MAGN I2C Magnetometer Chip"
 	default y
 	depends on DT_HAS_BOSCH_BMC150_MAGN_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for BMC150 I2C-based magnetometer sensor.
 

--- a/drivers/sensor/bme280/Kconfig
+++ b/drivers/sensor/bme280/Kconfig
@@ -8,7 +8,8 @@ menuconfig BME280
 	bool "BME280/BMP280 sensor"
 	default y
 	depends on DT_HAS_BOSCH_BME280_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME280),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME280),spi)
 	help
 	  Enable driver for BME280 I2C-based or SPI-based temperature and pressure sensor.
 

--- a/drivers/sensor/bme680/Kconfig
+++ b/drivers/sensor/bme680/Kconfig
@@ -9,7 +9,8 @@ menuconfig BME680
 	bool "BME680 sensor"
 	default y
 	depends on DT_HAS_BOSCH_BME680_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME680),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BME680),spi)
 	help
 	  Enable driver for BME680 I2C- or SPI- based temperature, pressure, humidity and gas sensor.
 

--- a/drivers/sensor/bmg160/Kconfig
+++ b/drivers/sensor/bmg160/Kconfig
@@ -7,7 +7,7 @@ menuconfig BMG160
 	bool "Bosch BMG160 gyroscope support"
 	default y
 	depends on DT_HAS_BOSCH_BMG160_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable Bosch BMG160 gyroscope support.
 

--- a/drivers/sensor/bmi160/Kconfig
+++ b/drivers/sensor/bmi160/Kconfig
@@ -7,7 +7,8 @@ menuconfig BMI160
 	bool "Bosch BMI160 inertial measurement unit"
 	default y
 	depends on DT_HAS_BOSCH_BMI160_ENABLED
-	depends on SPI || I2C
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI160),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI160),spi)
 	help
 	  Enable Bosch BMI160 inertial measurement unit that provides acceleration
 	  and angular rate measurements.

--- a/drivers/sensor/bmi270/Kconfig
+++ b/drivers/sensor/bmi270/Kconfig
@@ -7,6 +7,6 @@ config BMI270
 	bool "BMI270 Inertial measurement unit"
 	default y
 	depends on DT_HAS_BOSCH_BMI270_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for BMI270 I2C-based imu sensor

--- a/drivers/sensor/bmm150/Kconfig
+++ b/drivers/sensor/bmm150/Kconfig
@@ -7,7 +7,7 @@ menuconfig BMM150
 	bool "BMM150 I2C Geomagnetic Chip"
 	default y
 	depends on DT_HAS_BOSCH_BMM150_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for BMM150 I2C-based Geomagnetic sensor.
 if BMM150

--- a/drivers/sensor/bmp388/Kconfig
+++ b/drivers/sensor/bmp388/Kconfig
@@ -5,7 +5,8 @@ menuconfig BMP388
 	bool "Bosch BMP388 pressure sensor"
 	default y
 	depends on DT_HAS_BOSCH_BMP388_ENABLED
-	depends on SPI || I2C
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP388),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMP388),spi)
 	help
 	  Enable driver for the Bosch BMP388 pressure sensor
 

--- a/drivers/sensor/bq274xx/Kconfig
+++ b/drivers/sensor/bq274xx/Kconfig
@@ -6,7 +6,7 @@ menuconfig BQ274XX
 	bool "BQ274xx Fuel Gauge"
 	default y
 	depends on DT_HAS_TI_BQ274XX_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable I2C-based driver for BQ274xx Fuel Gauge.
 

--- a/drivers/sensor/ccs811/Kconfig
+++ b/drivers/sensor/ccs811/Kconfig
@@ -9,7 +9,7 @@ menuconfig CCS811
 	bool "CCS811 Digital Gas Sensor"
 	default y
 	depends on DT_HAS_AMS_CCS811_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for CCS811 Gas sensors.
 

--- a/drivers/sensor/dps310/Kconfig
+++ b/drivers/sensor/dps310/Kconfig
@@ -7,7 +7,7 @@ menuconfig DPS310
 	bool "DPS310 sensor"
 	default y
 	depends on DT_HAS_INFINEON_DPS310_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for DPS310 I2C-based temperature and pressure sensor.
 

--- a/drivers/sensor/ens210/Kconfig
+++ b/drivers/sensor/ens210/Kconfig
@@ -7,7 +7,7 @@ menuconfig ENS210
 	bool "ENS210 Digital Temperature and Humidity sensor"
 	default y
 	depends on DT_HAS_AMS_ENS210_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for ENS210 Digital Temperature and Humidity sensor.
 if ENS210

--- a/drivers/sensor/fdc2x1x/Kconfig
+++ b/drivers/sensor/fdc2x1x/Kconfig
@@ -7,7 +7,8 @@ menuconfig FDC2X1X
 	bool "FDC2X1X Capacitance-to-Digital Converter"
 	default y
 	depends on DT_HAS_TI_FDC2X1X_ENABLED
-	depends on I2C && NEWLIB_LIBC
+	depends on NEWLIB_LIBC
+	select I2C
 	help
 	  Enable driver for FDC2X1X Capacitance-to-Digital Converter.
 

--- a/drivers/sensor/fxas21002/Kconfig
+++ b/drivers/sensor/fxas21002/Kconfig
@@ -7,7 +7,7 @@ menuconfig FXAS21002
 	bool "FXAS21002 gyroscope driver"
 	default y
 	depends on DT_HAS_NXP_FXAS21002_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for the FXAS21002 gyroscope
 

--- a/drivers/sensor/fxos8700/Kconfig
+++ b/drivers/sensor/fxos8700/Kconfig
@@ -7,7 +7,7 @@ menuconfig FXOS8700
 	bool "FXOS8700 accelerometer/magnetometer driver"
 	default y
 	depends on DT_HAS_NXP_FXOS8700_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for the FXOS8700 accelerometer/magnetometer.
 	  The driver also supports MMA8451Q, MMA8652FC and MMA8653FC

--- a/drivers/sensor/hmc5883l/Kconfig
+++ b/drivers/sensor/hmc5883l/Kconfig
@@ -5,7 +5,7 @@ menuconfig HMC5883L
 	bool "HMC5883L magnetometer"
 	default y
 	depends on DT_HAS_HONEYWELL_HMC5883L_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for HMC5883L I2C-based magnetometer.
 

--- a/drivers/sensor/hp206c/Kconfig
+++ b/drivers/sensor/hp206c/Kconfig
@@ -8,7 +8,7 @@ menuconfig HP206C
 	bool "HopeRF HP206C precision barometer and altimeter sensor"
 	default y
 	depends on DT_HAS_HOPERF_HP206C_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable HopeRF HP206C barometer and altimeter support.
 

--- a/drivers/sensor/hts221/Kconfig
+++ b/drivers/sensor/hts221/Kconfig
@@ -5,7 +5,8 @@ menuconfig HTS221
 	bool "HTS221 temperature and humidity sensor"
 	default y
 	depends on DT_HAS_ST_HTS221_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_HTS221),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_HTS221),spi)
 	select HAS_STMEMSC
 	select USE_STDC_HTS221
 	help

--- a/drivers/sensor/i3g4250d/Kconfig
+++ b/drivers/sensor/i3g4250d/Kconfig
@@ -7,7 +7,7 @@ config I3G4250D
 	bool "I3G4250D three-axis digital output gyroscope"
 	default y
 	depends on DT_HAS_ST_I3G4250D_ENABLED
-	depends on SPI
+	select SPI
 	select HAS_STMEMSC
 	select USE_STDC_I3G4250D
 	help

--- a/drivers/sensor/icm42605/Kconfig
+++ b/drivers/sensor/icm42605/Kconfig
@@ -7,7 +7,7 @@ menuconfig ICM42605
 	bool "ICM42605 Six-Axis Motion Tracking Device"
 	default y
 	depends on DT_HAS_INVENSENSE_ICM42605_ENABLED
-	depends on SPI
+	select SPI
 	help
 	  Enable driver for ICM42605 SPI-based six-axis motion tracking device.
 

--- a/drivers/sensor/icm42670/Kconfig
+++ b/drivers/sensor/icm42670/Kconfig
@@ -9,7 +9,7 @@ menuconfig ICM42670
 	bool "ICM42670 Six-Axis Motion Tracking Device"
 	default y
 	depends on DT_HAS_INVENSENSE_ICM42670_ENABLED
-	depends on SPI
+	select SPI
 	help
 	  Enable driver for ICM42670 SPI-based six-axis motion tracking device.
 

--- a/drivers/sensor/iis2dh/Kconfig
+++ b/drivers/sensor/iis2dh/Kconfig
@@ -7,7 +7,8 @@ menuconfig IIS2DH
 	bool "IIS2DH I2C/SPI accelerometer sensor driver"
 	default y
 	depends on DT_HAS_ST_IIS2DH_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DH),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DH),spi)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2DH
 	help

--- a/drivers/sensor/iis2dlpc/Kconfig
+++ b/drivers/sensor/iis2dlpc/Kconfig
@@ -7,7 +7,8 @@ menuconfig IIS2DLPC
 	bool "IIS2DLPC I2C/SPI accelerometer sensor driver"
 	default y
 	depends on DT_HAS_ST_IIS2DLPC_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DLPC),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2DLPC),spi)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2DLPC
 	help

--- a/drivers/sensor/iis2iclx/Kconfig
+++ b/drivers/sensor/iis2iclx/Kconfig
@@ -7,7 +7,8 @@ menuconfig IIS2ICLX
 	bool "IIS2ICLX I2C/SPI accelerometer Chip"
 	default y
 	depends on DT_HAS_ST_IIS2ICLX_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2ICLX),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2ICLX),spi)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2ICLX
 	help

--- a/drivers/sensor/iis2mdc/Kconfig
+++ b/drivers/sensor/iis2mdc/Kconfig
@@ -5,7 +5,8 @@ menuconfig IIS2MDC
 	bool "IIS2MDC Magnetometer"
 	default y
 	depends on DT_HAS_ST_IIS2MDC_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2MDC),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_IIS2MDC),spi)
 	select HAS_STMEMSC
 	select USE_STDC_IIS2MDC
 	help

--- a/drivers/sensor/iis3dhhc/Kconfig
+++ b/drivers/sensor/iis3dhhc/Kconfig
@@ -7,7 +7,7 @@ menuconfig IIS3DHHC
 	bool "IIS3DHHC accelerometer sensor"
 	default y
 	depends on DT_HAS_ST_IIS3DHHC_ENABLED
-	depends on SPI
+	select SPI
 	select HAS_STMEMSC
 	select USE_STDC_IIS3DHHC
 	help

--- a/drivers/sensor/ina219/Kconfig
+++ b/drivers/sensor/ina219/Kconfig
@@ -7,6 +7,6 @@ config INA219
 	bool "INA219 Current/Power Monitor"
 	default y
 	depends on DT_HAS_TI_INA219_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for INA219 Bidirectional Current/Power Monitor.

--- a/drivers/sensor/ina23x/Kconfig
+++ b/drivers/sensor/ina23x/Kconfig
@@ -6,7 +6,7 @@ config INA23X
 	bool "INA23X Current and Power Monitor"
 	default y
 	depends on DT_HAS_TI_INA230_ENABLED || DT_HAS_TI_INA237_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for INA23X Current and Power Monitor.
 

--- a/drivers/sensor/isl29035/Kconfig
+++ b/drivers/sensor/isl29035/Kconfig
@@ -7,7 +7,7 @@ menuconfig ISL29035
 	bool "ISL29035 light sensor"
 	default y
 	depends on DT_HAS_ISIL_ISL29035_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for the ISL29035 light sensor.
 

--- a/drivers/sensor/ism330dhcx/Kconfig
+++ b/drivers/sensor/ism330dhcx/Kconfig
@@ -7,7 +7,8 @@ menuconfig ISM330DHCX
 	bool "ISM330DHCX I2C/SPI accelerometer and gyroscope Chip"
 	default y
 	depends on DT_HAS_ST_ISM330DHCX_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_ISM330DHCX),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_ISM330DHCX),spi)
 	select HAS_STMEMSC
 	select USE_STDC_ISM330DHCX
 	help

--- a/drivers/sensor/lis2dh/Kconfig
+++ b/drivers/sensor/lis2dh/Kconfig
@@ -7,7 +7,8 @@ menuconfig LIS2DH
 	bool "LIS2DH Three Axis Accelerometer"
 	default y
 	depends on DT_HAS_ST_LIS2DH_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DH),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DH),spi)
 	help
 	  Enable SPI/I2C-based driver for LIS2DH, LIS3DH, LSM303DLHC,
 	  LIS2DH12, LSM303AGR triaxial accelerometer sensors.

--- a/drivers/sensor/lis2ds12/Kconfig
+++ b/drivers/sensor/lis2ds12/Kconfig
@@ -7,7 +7,8 @@ menuconfig LIS2DS12
 	bool "LIS2DS12 I2C/SPI accelerometer sensor driver"
 	default y
 	depends on DT_HAS_ST_LIS2DS12_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DS12),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DS12),spi)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DS12
 	help

--- a/drivers/sensor/lis2dw12/Kconfig
+++ b/drivers/sensor/lis2dw12/Kconfig
@@ -7,7 +7,8 @@ menuconfig LIS2DW12
 	bool "LIS2DW12 I2C/SPI accelerometer sensor driver"
 	default y
 	depends on DT_HAS_ST_LIS2DW12_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DW12),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2DW12),spi)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2DW12
 	help

--- a/drivers/sensor/lis2mdl/Kconfig
+++ b/drivers/sensor/lis2mdl/Kconfig
@@ -5,7 +5,8 @@ menuconfig LIS2MDL
 	bool "LIS2MDL Magnetometer"
 	default y
 	depends on DT_HAS_ST_LIS2MDL_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2MDL),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LIS2MDL),spi)
 	select HAS_STMEMSC
 	select USE_STDC_LIS2MDL
 	help

--- a/drivers/sensor/lis3mdl/Kconfig
+++ b/drivers/sensor/lis3mdl/Kconfig
@@ -5,7 +5,7 @@ menuconfig LIS3MDL
 	bool "LIS3MDL magnetometer"
 	default y
 	depends on DT_HAS_ST_LIS3MDL_MAGN_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for LIS3MDL I2C-based magnetometer.
 

--- a/drivers/sensor/lm75/Kconfig
+++ b/drivers/sensor/lm75/Kconfig
@@ -7,7 +7,7 @@ config LM75
 	bool "LM75 Temperature Sensor"
 	default y
 	depends on DT_HAS_LM75_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable the driver for the LM75 digital temperature Sensor with 2-wire
 	  interface. Thermal Watchdog is not implemented

--- a/drivers/sensor/lm77/Kconfig
+++ b/drivers/sensor/lm77/Kconfig
@@ -8,7 +8,7 @@ menuconfig LM77
 	default y
 	depends on DT_HAS_LM77_ENABLED
 	default $(dt_compat_enabled,lm77)
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for the LM77 digital temperature sensor with 2-wire
 	  interface.

--- a/drivers/sensor/lps22hb/Kconfig
+++ b/drivers/sensor/lps22hb/Kconfig
@@ -5,7 +5,7 @@ menuconfig LPS22HB
 	bool "LPS22HB pressure and temperature"
 	default y
 	depends on DT_HAS_ST_LPS22HB_PRESS_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for LPS22HB I2C-based pressure and temperature
 	  sensor.

--- a/drivers/sensor/lps22hh/Kconfig
+++ b/drivers/sensor/lps22hh/Kconfig
@@ -7,7 +7,8 @@ menuconfig LPS22HH
 	bool "LPS22HH pressure and temperature"
 	default y
 	depends on DT_HAS_ST_LPS22HH_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LPS22HH),spi)
 	select HAS_STMEMSC
 	select USE_STDC_LPS22HH
 	help

--- a/drivers/sensor/lps25hb/Kconfig
+++ b/drivers/sensor/lps25hb/Kconfig
@@ -5,7 +5,7 @@ menuconfig LPS25HB
 	bool "LPS25HB pressure and temperature"
 	default y
 	depends on DT_HAS_ST_LPS25HB_PRESS_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for LPS25HB I2C-based pressure and temperature
 	  sensor.

--- a/drivers/sensor/lsm303dlhc_magn/Kconfig
+++ b/drivers/sensor/lsm303dlhc_magn/Kconfig
@@ -7,7 +7,7 @@ menuconfig LSM303DLHC_MAGN
 	bool "LSM303DLHC Three Axis Magnetometer"
 	default y
 	depends on DT_HAS_ST_LSM303DLHC_MAGN_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for LSM303DLHC I2C-based triaxial magnetometer sensor.
 

--- a/drivers/sensor/lsm6ds0/Kconfig
+++ b/drivers/sensor/lsm6ds0/Kconfig
@@ -8,7 +8,7 @@ menuconfig LSM6DS0
 	bool "LSM6DS0 I2C accelerometer and gyroscope Chip"
 	default y
 	depends on DT_HAS_ST_LSM6DS0_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for LSM6DS0 I2C-based accelerometer and gyroscope
 	  sensor.

--- a/drivers/sensor/lsm6dsl/Kconfig
+++ b/drivers/sensor/lsm6dsl/Kconfig
@@ -8,7 +8,8 @@ menuconfig LSM6DSL
 	bool "LSM6DSL I2C/SPI accelerometer and gyroscope Chip"
 	default y
 	depends on DT_HAS_ST_LSM6DSL_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSL),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSL),spi)
 	help
 	  Enable driver for LSM6DSL accelerometer and gyroscope
 	  sensor.

--- a/drivers/sensor/lsm6dso/Kconfig
+++ b/drivers/sensor/lsm6dso/Kconfig
@@ -7,7 +7,8 @@ menuconfig LSM6DSO
 	bool "LSM6DSO I2C/SPI accelerometer and gyroscope Chip"
 	default y
 	depends on DT_HAS_ST_LSM6DSO_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_ST_LSM6DSO),spi)
 	select HAS_STMEMSC
 	select USE_STDC_LSM6DSO
 	help

--- a/drivers/sensor/lsm9ds0_gyro/Kconfig
+++ b/drivers/sensor/lsm9ds0_gyro/Kconfig
@@ -7,7 +7,7 @@ menuconfig LSM9DS0_GYRO
 	bool "LSM9DS0 I2C gyroscope Chip"
 	default y
 	depends on DT_HAS_ST_LSM9DS0_GYRO_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for LSM9DS0 I2C-based gyroscope sensor.
 

--- a/drivers/sensor/lsm9ds0_mfd/Kconfig
+++ b/drivers/sensor/lsm9ds0_mfd/Kconfig
@@ -7,7 +7,7 @@ menuconfig LSM9DS0_MFD
 	bool "LSM9DS0 I2C accelerometer, magnetometer and temperature sensor chip"
 	default y
 	depends on DT_HAS_ST_LSM9DS0_MFD_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for LSM9DS0 I2C-based MFD sensor.
 

--- a/drivers/sensor/max17055/Kconfig
+++ b/drivers/sensor/max17055/Kconfig
@@ -6,7 +6,7 @@ config MAX17055
 	bool "MAX17055 Fuel Gauge"
 	default y
 	depends on DT_HAS_MAXIM_MAX17055_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable I2C-based driver for MAX17055 Fuel Gauge. This driver supports
 	  reading various sensor settings including charge level percentage,

--- a/drivers/sensor/max17262/Kconfig
+++ b/drivers/sensor/max17262/Kconfig
@@ -6,7 +6,7 @@ config MAX17262
 	bool "MAX17262 Fuel Gauge"
 	default y
 	depends on DT_HAS_MAXIM_MAX17262_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable I2C-based driver for MAX17262 Fuel Gauge. This driver supports
 	  reading various sensor settings including voltage, current, temperature,

--- a/drivers/sensor/max30101/Kconfig
+++ b/drivers/sensor/max30101/Kconfig
@@ -7,7 +7,7 @@ menuconfig MAX30101
 	bool "MAX30101 Pulse Oximeter and Heart Rate Sensor"
 	default y
 	depends on DT_HAS_MAXIM_MAX30101_ENABLED
-	depends on I2C
+	select I2C
 
 if MAX30101
 

--- a/drivers/sensor/max31875/Kconfig
+++ b/drivers/sensor/max31875/Kconfig
@@ -7,6 +7,6 @@ config MAX31875
 	bool "MAX31875 Temperature Sensor"
 	default y
 	depends on DT_HAS_MAXIM_MAX31875_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable the driver for Maxim MAX31875 Low-Power I2C Temperature Sensors.

--- a/drivers/sensor/max44009/Kconfig
+++ b/drivers/sensor/max44009/Kconfig
@@ -7,6 +7,6 @@ config MAX44009
 	bool "MAX44009 Light Sensor"
 	default y
 	depends on DT_HAS_MAXIM_MAX44009_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for MAX44009 light sensors.

--- a/drivers/sensor/max6675/Kconfig
+++ b/drivers/sensor/max6675/Kconfig
@@ -5,7 +5,7 @@ config MAX6675
 	bool "MAX6675 K-thermocouple to digital converter"
 	default y
 	depends on DT_HAS_MAXIM_MAX6675_ENABLED
-	depends on SPI
+	select SPI
 	help
 	  Enable MAX6675 cold-junction-compensated K-thermocouple to digital
 	  converter.

--- a/drivers/sensor/mcp9808/Kconfig
+++ b/drivers/sensor/mcp9808/Kconfig
@@ -7,7 +7,7 @@ menuconfig MCP9808
 	bool "MCP9808 temperature sensor"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP9808_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for MCP9808 temperature sensor.
 

--- a/drivers/sensor/mpr/Kconfig
+++ b/drivers/sensor/mpr/Kconfig
@@ -7,7 +7,7 @@ menuconfig MPR
 	bool "MPR pressure sensor"
 	default y
 	depends on DT_HAS_HONEYWELL_MPR_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for MPR pressure sensor.
 

--- a/drivers/sensor/mpu6050/Kconfig
+++ b/drivers/sensor/mpu6050/Kconfig
@@ -7,7 +7,7 @@ menuconfig MPU6050
 	bool "MPU6050 Six-Axis Motion Tracking Device"
 	default y
 	depends on DT_HAS_INVENSENSE_MPU6050_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for MPU6050 I2C-based six-axis motion tracking device.
 

--- a/drivers/sensor/mpu9250/Kconfig
+++ b/drivers/sensor/mpu9250/Kconfig
@@ -7,7 +7,7 @@ menuconfig MPU9250
 	bool "MPU9250 Nine-Axis Motion Tracking Device"
 	default y
 	depends on DT_HAS_INVENSENSE_MPU9250_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for MPU9250 I2C-based nine-axis motion tracking device.
 

--- a/drivers/sensor/ms5607/Kconfig
+++ b/drivers/sensor/ms5607/Kconfig
@@ -7,7 +7,8 @@ menuconfig MS5607
 	bool "MS5607 pressure and temperature sensor"
 	default y
 	depends on DT_HAS_MEAS_MS5607_ENABLED
-	depends on I2C || SPI
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_MEAS_MS5607),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_MEAS_MS5607),spi)
 	help
 	  Enable driver for MS5607 pressure and temperature sensor.
 

--- a/drivers/sensor/ms5837/Kconfig
+++ b/drivers/sensor/ms5837/Kconfig
@@ -7,6 +7,6 @@ config MS5837
 	bool "MS5837 pressure and temperature sensor"
 	default y
 	depends on DT_HAS_MEAS_MS5837_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for MS5837 pressure and temperature sensor.

--- a/drivers/sensor/opt3001/Kconfig
+++ b/drivers/sensor/opt3001/Kconfig
@@ -7,6 +7,6 @@ config OPT3001
 	bool "OPT3001 Light Sensor"
 	default y
 	depends on DT_HAS_TI_OPT3001_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for OPT3001 light sensors.

--- a/drivers/sensor/sbs_gauge/Kconfig
+++ b/drivers/sensor/sbs_gauge/Kconfig
@@ -5,6 +5,6 @@ config SBS_GAUGE
 	bool "Smart Battery Fuel Gauge"
 	default y
 	depends on DT_HAS_SBS_SBS_GAUGE_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable I2C-based/SMBus-based driver for a Smart Battery Fuel Gauge.

--- a/drivers/sensor/sgp40/Kconfig
+++ b/drivers/sensor/sgp40/Kconfig
@@ -7,6 +7,6 @@ config SGP40
 	bool "SGP40 Multipixel Gas Sensor"
 	default y
 	depends on DT_HAS_SENSIRION_SGP40_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SGP40 Multipixel Gas Sensor.

--- a/drivers/sensor/sht3xd/Kconfig
+++ b/drivers/sensor/sht3xd/Kconfig
@@ -7,7 +7,7 @@ menuconfig SHT3XD
 	bool "SHT3xD Temperature and Humidity Sensor"
 	default y
 	depends on DT_HAS_SENSIRION_SHT3XD_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SHT3xD temperature and humidity sensors.
 

--- a/drivers/sensor/sht4x/Kconfig
+++ b/drivers/sensor/sht4x/Kconfig
@@ -7,6 +7,6 @@ config SHT4X
 	bool "SHT4x Temperature and Humidity Sensor"
 	default y
 	depends on DT_HAS_SENSIRION_SHT4X_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SHT4x temperature and humidity sensors.

--- a/drivers/sensor/shtcx/Kconfig
+++ b/drivers/sensor/shtcx/Kconfig
@@ -7,6 +7,6 @@ config SHTCX
 	bool "SHTCX: SHTC1 and SHTC3 Temperature and Humidity Sensor"
 	default y
 	depends on DT_HAS_SENSIRION_SHTCX_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SHTC1 and SHTC3 temperature and humidity sensors.

--- a/drivers/sensor/si7006/Kconfig
+++ b/drivers/sensor/si7006/Kconfig
@@ -5,6 +5,6 @@ config SI7006
 	bool "Si7006 Temperature and Humidity Sensor"
 	default y
 	depends on DT_HAS_SILABS_SI7006_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable I2C-based driver for Si7006 Temperature and Humidity Sensor.

--- a/drivers/sensor/si7055/Kconfig
+++ b/drivers/sensor/si7055/Kconfig
@@ -6,7 +6,7 @@ menuconfig SI7055
 	bool "Si7055 Temperature Sensor"
 	default y
 	depends on DT_HAS_SILABS_SI7055_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable I2C-based driver for Si7055 Temperature Sensor.
 

--- a/drivers/sensor/si7060/Kconfig
+++ b/drivers/sensor/si7060/Kconfig
@@ -7,6 +7,6 @@ config SI7060
 	bool "SI7060 Temperature Sensor"
 	default y
 	depends on DT_HAS_SILABS_SI7060_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SI7060 temperature sensors.

--- a/drivers/sensor/si7210/Kconfig
+++ b/drivers/sensor/si7210/Kconfig
@@ -6,6 +6,6 @@ config SI7210
 	bool "Si7210 Hall Effect Magnetic Position and Temperature Sensor"
 	default y
 	depends on DT_HAS_SILABS_SI7210_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for Si7210 Hall Effect Magnetic Position and Temperature Sensor.

--- a/drivers/sensor/stts751/Kconfig
+++ b/drivers/sensor/stts751/Kconfig
@@ -7,7 +7,7 @@ menuconfig STTS751
 	bool "STTS751 temperature sensor"
 	default y
 	depends on DT_HAS_ST_STTS751_ENABLED
-	depends on I2C
+	select I2C
 	select HAS_STMEMSC
 	select USE_STDC_STTS751
 	help

--- a/drivers/sensor/sx9500/Kconfig
+++ b/drivers/sensor/sx9500/Kconfig
@@ -7,7 +7,7 @@ menuconfig SX9500
 	bool "SX9500 I2C SAR Proximity Chip"
 	default y
 	depends on DT_HAS_SEMTECH_SX9500_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SX9500 I2C-based SAR proximity sensor.
 

--- a/drivers/sensor/th02/Kconfig
+++ b/drivers/sensor/th02/Kconfig
@@ -5,6 +5,6 @@ config TH02
 	bool "TH02 Temperature Sensor"
 	default y
 	depends on DT_HAS_HOPERF_TH02_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for the TH02 temperature sensor.

--- a/drivers/sensor/ti_hdc/Kconfig
+++ b/drivers/sensor/ti_hdc/Kconfig
@@ -7,6 +7,6 @@ config TI_HDC
 	bool "Texas Instruments Temperature and Humidity Sensor (e.g. HDC1008)"
 	default y
 	depends on DT_HAS_TI_HDC_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for TI temperature and humidity sensors.

--- a/drivers/sensor/ti_hdc20xx/Kconfig
+++ b/drivers/sensor/ti_hdc20xx/Kconfig
@@ -8,7 +8,7 @@ config TI_HDC20XX
 	default y
 	depends on DT_HAS_TI_HDC2010_ENABLED || DT_HAS_TI_HDC2021_ENABLED || \
 		   DT_HAS_TI_HDC2022_ENABLED || DT_HAS_TI_HDC2080_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for TI HDC20XX temperature and humidity sensors
 	  (e.g. HDC2010, HDC2021, HDC2022, HDC2080).

--- a/drivers/sensor/tmp007/Kconfig
+++ b/drivers/sensor/tmp007/Kconfig
@@ -7,7 +7,7 @@ menuconfig TMP007
 	bool "TMP007 Infrared Thermopile Sensor"
 	default y
 	depends on DT_HAS_TI_TMP007_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for TMP007 infrared thermopile sensors.
 

--- a/drivers/sensor/tmp108/Kconfig
+++ b/drivers/sensor/tmp108/Kconfig
@@ -7,7 +7,7 @@ menuconfig TMP108
 	bool "TMP108 Temperature Sensor"
 	default y
 	depends on DT_HAS_TI_TMP108_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for the TMP108 temperature sensor.
 

--- a/drivers/sensor/tmp112/Kconfig
+++ b/drivers/sensor/tmp112/Kconfig
@@ -7,7 +7,7 @@ config TMP112
 	bool "TMP112 Temperature Sensor"
 	default y
 	depends on DT_HAS_TI_TMP112_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable the driver for Texas Instruments TMP112 High-Accuracy Digital
 	  Temperature Sensors.

--- a/drivers/sensor/tmp116/Kconfig
+++ b/drivers/sensor/tmp116/Kconfig
@@ -7,6 +7,6 @@ config TMP116
 	bool "TMP116 and TMP117 Temperature Sensors"
 	default y
 	depends on DT_HAS_TI_TMP116_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for TMP116 and TMP117 temperature sensors.

--- a/drivers/sensor/vcnl4040/Kconfig
+++ b/drivers/sensor/vcnl4040/Kconfig
@@ -7,7 +7,7 @@ menuconfig VCNL4040
 	bool "VCNL4040 Proximity and Ambient Light Sensor"
 	default y
 	depends on DT_HAS_VISHAY_VCNL4040_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for VCNL4040 sensors.
 

--- a/drivers/sensor/vl53l0x/Kconfig
+++ b/drivers/sensor/vl53l0x/Kconfig
@@ -7,7 +7,7 @@ menuconfig VL53L0X
 	bool "VL53L0X time of flight sensor"
 	default y
 	depends on DT_HAS_ST_VL53L0X_ENABLED
-	depends on I2C
+	select I2C
 	select HAS_STLIB
 	help
 	  Enable driver for VL53L0X I2C-based time of flight sensor.

--- a/drivers/sensor/wsen_itds/Kconfig
+++ b/drivers/sensor/wsen_itds/Kconfig
@@ -6,7 +6,7 @@ config ITDS
 	bool "WSEN-ITDS 3-axis accel sensor"
 	default y
 	depends on DT_HAS_WE_WSEN_ITDS_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable Wurth Elektronik WSEN-ITDS 3-axis acceleration sensor
 	  provides acceleration and die temperature measurement.


### PR DESCRIPTION
    drivers: sensor: Convert Kconfig bus 'depends on' to 'select'
    
    This change in pattern is meant to address a misconfiguration issue
    that can occur for sensors that support being on multiple busses
    like I2C & SPI.
    
    For example, you can have a configuration in which such a sensor is
    on the I2C bus in the devicetree and the sensor is enabled.  However
    the application configuration enables CONFIG_SPI=y and CONFIG_I2C=n
    and this will cause the sensor driver to be built by default, however
    since we don't have the I2C bus enabled the driver will not compile
    correctly.
    
    Previously we had been adding to board Kconfig.defconfig something
    like:
    
            config I2C
                    default y if SENSOR
    
    This pattern doesn't scale well and may differ from what an application
    specific need/use is.
    
    So instead move to a pattern in which we leave the default enablement
    up to the devicetree "status" property for the sensor.  We then have
    the Kconfig move from 'depends on <BUS>' to 'select <BUS>' and in
    the case of drivers that support multiple busses we have the Kconfig
    be: 'select <BUS> if $(dt_compat_on_bus,$(<DT_COMPAT>),<BUS>) for
    each bus type the sensor supports.
    
    This removes the need to add Kconfig logic to each board and enables
    the bus subsystem and bus controller driver if the sensor requires
    it by default in the build system.

Fixes: #48518

Signed-off-by: Kumar Gala <galak@kernel.org>