### PR TITLE
scripts: kconfig: tweak dt_chosen_label

### DIFF
--- a/scripts/kconfig/kconfigfunctions.py
+++ b/scripts/kconfig/kconfigfunctions.py
@@ -60,7 +60,7 @@ def dt_chosen_label(kconf, _, chosen):
         return ""
 
     if "label" not in node.props:
-        return ""
+        return node.name
 
     return node.props["label"].val
 


### PR DESCRIPTION
Now that we've removed the label property from most devicetree nodes
the dt_chosen_label will end up returning "" in most cases.  For the
small handful of cases that the function is used, return the node.name
instead as this matches what DEVICE_DT_NAME will do.

Signed-off-by: Kumar Gala <galak@kernel.org>