### PR TITLE
dts: bindings: microchip: Remove unused cell related bits

### DIFF
--- a/dts/bindings/adc/microchip,xec-adc-v2.yaml
+++ b/dts/bindings/adc/microchip,xec-adc-v2.yaml
@@ -34,21 +34,5 @@ properties:
     pinctrl-names:
       required: true
 
-    "#girq-cells":
-      type: int
-      const: 2
-
-    "#pcr-cells":
-      type: int
-      const: 2
-
 io-channel-cells:
     - input
-
-girq-cells:
-    - girqnum
-    - bitpos
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/espi/microchip,xec-espi-host-dev.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-host-dev.yaml
@@ -74,22 +74,7 @@ properties:
       type: int
       const: 3
 
-    "#girq-cells":
-      type: int
-      const: 1
-
-    "#pcr-cells":
-      type: int
-      const: 2
-
 emi-mem-cells:
     - base
     - rdlimit
     - wrlimit
-
-girq-cells:
-    - girqinfo
-
-pcr-cells:
-    - reg_idx
-    - bitpos

--- a/dts/bindings/espi/microchip,xec-espi-v2.yaml
+++ b/dts/bindings/espi/microchip,xec-espi-v2.yaml
@@ -33,18 +33,3 @@ properties:
 
     pinctrl-names:
       required: true
-
-    "#girq-cells":
-      type: int
-      const: 1
-
-    "#pcr-cells":
-      type: int
-      const: 2
-
-girq-cells:
-    - girqinfo
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
+++ b/dts/bindings/i2c/microchip,xec-i2c-v2.yaml
@@ -31,19 +31,3 @@ properties:
 
     pinctrl-names:
       required: true
-
-    "#girq-cells":
-      type: int
-      const: 2
-
-    "pcr-cells":
-      type: int
-      const: 2
-
-girq-cells:
-    - girq_num
-    - bitpos
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/kscan/microchip,xec-kscan.yaml
+++ b/dts/bindings/kscan/microchip,xec-kscan.yaml
@@ -36,11 +36,3 @@ properties:
       type: array
       required: true
       description: ADC PCR register index and bit position
-
-girq-cells:
-    - girqnum
-    - bitpos
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/mtd/microchip,xec-eeprom.yaml
+++ b/dts/bindings/mtd/microchip,xec-eeprom.yaml
@@ -22,11 +22,3 @@ properties:
       type: array
       required: true
       description: PS2 PCR register index and bit position
-
-girq-cells:
-    - girqnum
-    - bitpos
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/peci/microchip,xec-peci.yaml
+++ b/dts/bindings/peci/microchip,xec-peci.yaml
@@ -23,11 +23,3 @@ properties:
       type: array
       required: true
       description: ADC PCR register index and bit position
-
-girq-cells:
-    - girqnum
-    - bitpos
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/ps2/microchip,xec-ps2.yaml
+++ b/dts/bindings/ps2/microchip,xec-ps2.yaml
@@ -25,11 +25,3 @@ properties:
       type: array
       required: true
       description: PS2 PCR register index and bit position
-
-girq-cells:
-    - girqnum
-    - bitpos
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/pwm/microchip,xec-pwm.yaml
+++ b/dts/bindings/pwm/microchip,xec-pwm.yaml
@@ -19,10 +19,6 @@ properties:
     "#pwm-cells":
       const: 2
 
-pcr-cells:
-    - regidx
-    - bitpos
-
 pwm-cells:
     - channel
     - period

--- a/dts/bindings/rtc/microchip,xec-timer.yaml
+++ b/dts/bindings/rtc/microchip,xec-timer.yaml
@@ -36,19 +36,3 @@ properties:
       type: array
       required: true
       description: PCR sleep enable register index and bit position.
-
-    "#girq-cells":
-      type: int
-      const: 2
-
-    "#pcr-cells":
-      type: int
-      const: 2
-
-girq-cells:
-    - girq_num
-    - bitpos
-
-pcr-cells:
-    - reg_index
-    - bitpos

--- a/dts/bindings/serial/microchip,xec-uart.yaml
+++ b/dts/bindings/serial/microchip,xec-uart.yaml
@@ -31,19 +31,3 @@ properties:
 
     pinctrl-names:
       required: true
-
-    "#girq-cells":
-      type: int
-      const: 2
-
-    "#pcr-cells":
-      type: int
-      const: 2
-
-girq-cells:
-    - girq_num
-    - bitpos
-
-pcr-cells:
-    - reg_idx
-    - bitpos

--- a/dts/bindings/tach/microchip,xec-tach.yaml
+++ b/dts/bindings/tach/microchip,xec-tach.yaml
@@ -31,11 +31,3 @@ properties:
       type: array
       required: true
       description: PCR sleep register index and bit position
-
-girq-cells:
-    - girqnum
-    - bitpos
-
-pcr-cells:
-    - regidx
-    - bitpos

--- a/dts/bindings/timer/microchip,xec-rtos-timer.yaml
+++ b/dts/bindings/timer/microchip,xec-rtos-timer.yaml
@@ -18,11 +18,3 @@ properties:
       type: array
       required: true
       description: Array of GIRQ numbers [8:26] and bit positions [0:31].
-
-    "#girq-cells":
-      type: int
-      const: 2
-
-girq-cells:
-    - girq_num
-    - bitpos

--- a/dts/bindings/watchdog/microchip,xec-watchdog.yaml
+++ b/dts/bindings/watchdog/microchip,xec-watchdog.yaml
@@ -23,19 +23,3 @@ properties:
       type: array
       required: true
       description: PCR sleep enable register index and bit position.
-
-    "#girq-cells":
-      type: int
-      const: 2
-
-    "#pcr-cells":
-      type: int
-      const: 2
-
-girq-cells:
-    - girq_num
-    - bitpos
-
-pcr-cells:
-    - reg_index
-    - bitpos


### PR DESCRIPTION
various microchip bindings set 'girq-cells' and 'pcr-cells'
sections in the bindings.  However the bindings where for the
client nodes and thus do not need to set these.

Signed-off-by: Kumar Gala <galak@kernel.org>