### PR TITLE
Update NET_BUF_POOL_FIXED_DEFINE: added the alignment for net_buf_data

### DIFF
--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -1134,7 +1134,7 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
  */
 #define NET_BUF_POOL_FIXED_DEFINE(_name, _count, _data_size, _ud_size, _destroy) \
 	_NET_BUF_ARRAY_DEFINE(_name, _count, _ud_size);                        \
-	static uint8_t __noinit net_buf_data_##_name[_count][_data_size];      \
+	static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_align; \
 	static const struct net_buf_pool_fixed net_buf_fixed_##_name = {       \
 		.data_size = _data_size,                                       \
 		.data_pool = (uint8_t *)net_buf_data_##_name,                  \


### PR DESCRIPTION
include/net: add the alignment for data in NET_BUF_POOL_FIXED_DEFINE
NET_BUF_POOL_FIXED_DEFINE locates net_buf_data in __noinit section,
it does not guarantees that data buffer will aligned.

There is wifi driver which required network buffers to be aligned.

Changes:
line below (from NET_BUF_POOL_FIXED_DEFINE macro):
 `static uint8_t __noinit net_buf_data_##_name[_count][_data_size];`
is updated to:
 `static uint8_t __noinit net_buf_data_##_name[_count][_data_size] __net_buf_align;`

Signed-off-by: Nazar Palamar nazar.palamar@infineon.com

Some background for this update in discord: https://discord.com/channels/720317445772017664/733037635194585148/1004652532716552273
