### PR TITLE
tests: mec15xxevb_assy6853: Enlarge the IDLE_STACK_SIZE from 256 to 512

### DIFF
--- a/samples/boards/mec15xxevb_assy6853/power_management/prj.conf
+++ b/samples/boards/mec15xxevb_assy6853/power_management/prj.conf
@@ -13,3 +13,5 @@ CONFIG_SOC_MEC1501_TEST_CLK_OUT=y
 # Enable additional drivers to evaluate power consumption without activity
 CONFIG_PECI=y
 CONFIG_KSCAN=y
+
+CONFIG_IDLE_STACK_SIZE=512


### PR DESCRIPTION
The test case "samples/boards/mec15xxevb_assy6853/power_management" could
always pass until commit 5f60164 was merged in. This patch changes the sem
take timeout value from 50ms to forever of the log thread, it will make the
idle thread run longer and takes more stack memory. Analyzed the coredump
of the failed test case, it can be found that the test case stucks at
z_idle_stacks. The test case used default CONFIG_IDLE_STACK_SIZE = 256 in
kernel/Kconfig, now we increase the value to 512 in prj.conf for this test
only. With this change, the test case can pass with the commit of 5f60164.
Fixes #47987

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>