### PR TITLE
Bluetooth: host: Fix scan info dangling pointer

### DIFF
--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -460,8 +460,6 @@ static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 				bt_lookup_id_addr(BT_ID_DEFAULT, addr));
 	}
 
-	info->addr = &id_addr;
-
 	if (scan_dev_found_cb) {
 		net_buf_simple_save(buf, &state);
 
@@ -470,6 +468,8 @@ static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 
 		net_buf_simple_restore(buf, &state);
 	}
+
+	info->addr = &id_addr;
 
 	SYS_SLIST_FOR_EACH_CONTAINER_SAFE(&scan_cbs, listener, next, node) {
 		if (listener->recv) {
@@ -481,6 +481,9 @@ static void le_adv_recv(bt_addr_le_t *addr, struct bt_le_scan_recv_info *info,
 			net_buf_simple_restore(buf, &state);
 		}
 	}
+
+	/* Clear pointer to this stack frame before returning to calling function */
+	info->addr = NULL;
 
 #if defined(CONFIG_BT_CENTRAL)
 	check_pending_conn(&id_addr, addr, info->adv_props);


### PR DESCRIPTION
Clear pointer to the le_adv_recv() stack frame before returning to the
calling function. This fixes a potential compiler warning newer gcc
versions.

zephyr/subsys/bluetooth/host/scan.c: In function ‘le_adv_recv’:
zephyr/subsys/bluetooth/host/scan.c:463:20: error: storing the address
of local variable ‘id_addr’ in ‘*info.addr’ [-Werror=dangling-pointer=]
  463 |         info->addr = &id_addr;
      |         ~~~~~~~~~~~^~~~~~~~~~
zephyr/subsys/bluetooth/host/scan.c:439:22: note: ‘id_addr’ declared here
  439 |         bt_addr_le_t id_addr;
      |                      ^~~~~~~

Fixes #48459

Signed-off-by: Johan Hedberg <johan.hedberg@intel.com>