### PR TITLE
Mark LEGACY_INCLUDE_PATH as deprecated and update release notes

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -844,12 +844,11 @@ config COMPAT_INCLUDES
 endmenu
 
 config LEGACY_INCLUDE_PATH
-	bool "Allow for the legacy include paths (without the zephyr/ prefix)"
+	bool "Allow for the legacy include paths (without the zephyr/ prefix) (DEPRECATED)"
 	help
-	  Allow applications and libraries to use the Zephyr legacy include
-	  path which does not use the zephyr/ prefix. For example, the
+	  DEPRECATED: Allow applications and libraries to use the Zephyr legacy
+	  include path which does not use the zephyr/ prefix. For example, the
 	  preferred way to include a Zephyr header is to use <zephyr/kernel.h>,
-	  but enabling CONFIG_LEGACY_INCLUDE_PATH will allow developers to
-	  use <kernel.h> instead. This (without the zephyr/ prefix) is
-	  deprecated and should be avoided. Eventually, it will not be
-	  supported.
+	  but enabling CONFIG_LEGACY_INCLUDE_PATH will allow developers to use
+	  <kernel.h> instead. This (without the zephyr/ prefix) is deprecated
+	  and should be avoided. Eventually, it will not be supported.

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -24,6 +24,13 @@ Changes in this release
   struct.  Updated :c:macro:`SPI_CS_CONTROL_PTR_DT` to reflect
   this change.
 
+* The :kconfig:option:`CONFIG_LEGACY_INCLUDE_PATH` option has been disabled by
+  default, all upstream code and modules have been converted to use
+  ``<zephyr/...>`` header paths. The option is still available to facilitate
+  the migration of external applications, but will be removed with the 3.4
+  release.  The :zephyr_file:`scripts/utils/migrate_includes.py` script is
+  provided to automate the migration.
+
 Removed APIs in this release
 ============================
 


### PR DESCRIPTION
Mark the LEGACY_INCLUDE_PATH config option as deprecated and update the release note to mention its removal in v3.4.