### PR TITLE
fix: tests: esp32: drivers: spi_loopback

### DIFF
--- a/tests/drivers/spi/spi_loopback/boards/esp32.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/esp32.overlay
@@ -1,0 +1,4 @@
+&spi3 {
+	label = "SPI_3";
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/esp32c3_devkitm.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/esp32c3_devkitm.overlay
@@ -1,0 +1,4 @@
+&spi2 {
+	label = "SPI_2";
+	status = "okay";
+};

--- a/tests/drivers/spi/spi_loopback/boards/esp32s2_saola.overlay
+++ b/tests/drivers/spi/spi_loopback/boards/esp32s2_saola.overlay
@@ -1,0 +1,4 @@
+&spi3 {
+	label = "SPI_3";
+	status = "okay";
+};


### PR DESCRIPTION
Fixes SPI loopback tests for Espressif boards.

Tests were previously relying on SPI label properties defined on `dts` files which the following PRs removed:

#48023
#48652
