### PR TITLE
doxygen: remove redundant usages of def

### DIFF
--- a/drivers/sensor/vl53l0x/vl53l0x_platform.h
+++ b/drivers/sensor/vl53l0x/vl53l0x_platform.h
@@ -41,7 +41,6 @@ typedef struct {
 typedef VL53L0X_Dev_t *VL53L0X_DEV;
 
 /**
- * @def PALDevDataGet
  * @brief Get ST private structure @a VL53L0X_DevData_t data access
  *
  * @param Dev       Device Handle
@@ -53,7 +52,6 @@ typedef VL53L0X_Dev_t *VL53L0X_DEV;
 #define PALDevDataGet(Dev, field) (Dev->Data.field)
 
 /**
- * @def PALDevDataSet(Dev, field, data)
  * @brief  Set ST private structure @a VL53L0X_DevData_t data field
  * @param Dev       Device Handle
  * @param field     ST structure field name

--- a/include/zephyr/bluetooth/addr.h
+++ b/include/zephyr/bluetooth/addr.h
@@ -164,8 +164,7 @@ static inline bool bt_addr_le_is_identity(const bt_addr_le_t *addr)
 	return BT_ADDR_IS_STATIC(&addr->a);
 }
 
-/** @def BT_ADDR_STR_LEN
- *
+/**
  *  @brief Recommended length of user string buffer for Bluetooth address
  *
  *  @details The recommended length guarantee the output of address
@@ -174,8 +173,7 @@ static inline bool bt_addr_le_is_identity(const bt_addr_le_t *addr)
  */
 #define BT_ADDR_STR_LEN 18
 
-/** @def BT_ADDR_LE_STR_LEN
- *
+/**
  *  @brief Recommended length of user string buffer for Bluetooth LE address
  *
  *  @details The recommended length guarantee the output of address

--- a/include/zephyr/bluetooth/audio/audio.h
+++ b/include/zephyr/bluetooth/audio/audio.h
@@ -52,8 +52,7 @@ enum bt_audio_context {
 	BT_AUDIO_CONTEXT_TYPE_EMERGENCY_ALARM = BIT(11),
 };
 
-/** @def BT_AUDIO_CONTEXT_TYPE_ANY
- *
+/**
  * Any known context.
  */
 #define BT_AUDIO_CONTEXT_TYPE_ANY	 (BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED | \
@@ -177,7 +176,7 @@ struct bt_codec_data {
 	uint8_t  value[CONFIG_BT_CODEC_MAX_DATA_LEN];
 };
 
-/** @def BT_CODEC_DATA
+/**
  *  @brief Helper to declare elements of bt_codec_data arrays
  *
  *  This macro is mainly for creating an array of struct bt_codec_data
@@ -193,7 +192,7 @@ struct bt_codec_data {
 				sizeof((uint8_t []) { _bytes })) \
 	}
 
-/** @def BT_CODEC
+/**
  *  @brief Helper to declare bt_codec structure
  *
  *  @param _id Codec ID
@@ -307,7 +306,7 @@ enum bt_audio_dir {
 	BT_AUDIO_DIR_SOURCE = 0x02,
 };
 
-/** @def BT_CODEC_QOS
+/**
  *  @brief Helper to declare elements of bt_codec_qos
  *
  *  @param _interval SDU interval (usec)
@@ -343,7 +342,7 @@ enum {
 	BT_CODEC_QOS_CODED = BIT(2),
 };
 
-/** @def BT_CODEC_QOS_UNFRAMED
+/**
  *  @brief Helper to declare Input Unframed bt_codec_qos
  *
  *  @param _interval SDU interval (usec)
@@ -356,7 +355,7 @@ enum {
 	BT_CODEC_QOS(_interval, BT_CODEC_QOS_UNFRAMED, BT_CODEC_QOS_2M, _sdu, \
 		     _rtn, _latency, _pd)
 
-/** @def BT_CODEC_QOS_FRAMED
+/**
  *  @brief Helper to declare Input Framed bt_codec_qos
  *
  *  @param _interval SDU interval (usec)
@@ -392,7 +391,7 @@ struct bt_codec_qos {
 	uint32_t pd;
 };
 
-/** @def BT_CODEC_QOS_PREF
+/**
  *  @brief Helper to declare elements of @ref bt_codec_qos_pref
  *
  *  @param _unframed_supported Unframed PDUs supported
@@ -473,7 +472,7 @@ struct bt_audio_lc3_preset {
 
 /* LC3 Unicast presets defined by table 5.2 in the BAP v1.0 specification */
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_8_1_1
+/**
  *  @brief Helper to declare LC3 Unicast 8_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -485,7 +484,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_8_2_1
+/**
  *  @brief Helper to declare LC3 Unicast 8_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -497,7 +496,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_16_1_1
+/**
  *  @brief Helper to declare LC3 Unicast 16_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -509,7 +508,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_16_2_1
+/**
  *  @brief Helper to declare LC3 Unicast 16_2_1 codec configuration
  *
  *  Mandatory to support as both unicast client and server
@@ -523,7 +522,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_24_1_1
+/**
  *  @brief Helper to declare LC3 Unicast 24_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -535,7 +534,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_24_2_1
+/**
  *  @brief Helper to declare LC3 Unicast 24_2_1 codec configuration
  *
  *  Mandatory to support as unicast server
@@ -549,7 +548,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_32_1_1
+/**
  *  @brief Helper to declare LC3 Unicast 32_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -561,7 +560,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_32_2_1
+/**
  *  @brief Helper to declare LC3 Unicast 32_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -573,7 +572,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_441_1_1
+/**
  *  @brief Helper to declare LC3 Unicast 441_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -586,7 +585,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 97u, 5u, 24u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_441_2_1
+/**
  *  @brief Helper to declare LC3 Unicast 441_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -599,7 +598,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 130u, 5u, 31u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_1_1
+/**
  *  @brief Helper to declare LC3 Unicast 48_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -611,7 +610,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 5u, 15u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_2_1
+/**
  *  @brief Helper to declare LC3 Unicast 48_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -623,7 +622,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 5u, 20u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_3_1
+/**
  *  @brief Helper to declare LC3 Unicast 48_3_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -635,7 +634,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 5u, 15u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_4_1
+/**
  *  @brief Helper to declare LC3 Unicast 48_4_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -647,7 +646,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 5u, 20u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_5_1
+/**
  *  @brief Helper to declare LC3 Unicast 8_5_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -659,7 +658,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 5u, 15u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_6_1
+/**
  *  @brief Helper to declare LC3 Unicast 48_6_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -671,7 +670,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 5u, 20u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_8_1_2
+/**
  *  @brief Helper to declare LC3 Unicast 8_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -684,7 +683,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 13u, 75u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_8_2_2
+/**
  *  @brief Helper to declare LC3 Unicast 8_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -696,7 +695,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 13u, 95u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_16_1_2
+/**
  *  @brief Helper to declare LC3 Unicast 16_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -708,7 +707,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 13u, 75u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_16_2_2
+/**
  *  @brief Helper to declare LC3 Unicast 16_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -720,7 +719,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 13u, 95u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_24_1_2
+/**
  *  @brief Helper to declare LC3 Unicast 24_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -732,7 +731,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 13u, 75u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_24_2_2
+/**
  *  @brief Helper to declare LC3 Unicast 24_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -744,7 +743,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 13u, 95u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_32_1_2
+/**
  *  @brief Helper to declare LC3 Unicast 32_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -756,7 +755,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 13u, 75u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_32_2_2
+/**
  *  @brief Helper to declare LC3 Unicast 32_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -768,7 +767,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 13u, 95u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_441_1_2
+/**
  *  @brief Helper to declare LC3 Unicast 441_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -781,7 +780,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 97u, 13u, 80u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_441_2_2
+/**
  *  @brief Helper to declare LC3 Unicast 441_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -794,7 +793,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 130u, 13u, 85u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_1_2
+/**
  *  @brief Helper to declare LC3 Unicast 48_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -806,7 +805,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 13u, 75u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_2_2
+/**
  *  @brief Helper to declare LC3 Unicast 48_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -818,7 +817,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 13u, 95u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_3_2
+/**
  *  @brief Helper to declare LC3 Unicast 48_3_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -830,7 +829,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 13u, 75u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_4_2
+/**
  *  @brief Helper to declare LC3 Unicast 48_4_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -842,7 +841,7 @@ struct bt_audio_lc3_preset {
 	BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 13u, 100u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_5_2
+/**
  *  @brief Helper to declare LC3 Unicast 48_5_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -854,7 +853,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 13u, 75u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_UNICAST_PRESET_48_6_2
+/**
  *  @brief Helper to declare LC3 Unicast 48_6_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -866,7 +865,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 13u, 100u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_8_1_1
+/**
  *  @brief Helper to declare LC3 Broadcast 8_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -879,7 +878,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_8_2_1
+/**
  *  @brief Helper to declare LC3 Broadcast 8_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -891,7 +890,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_16_1_1
+/**
  *  @brief Helper to declare LC3 Broadcast 16_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -903,7 +902,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_16_2_1
+/**
  *  @brief Helper to declare LC3 Broadcast 16_2_1 codec configuration
  *
  *  Mandatory to support as both broadcast source and sink
@@ -917,7 +916,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_24_1_1
+/**
  *  @brief Helper to declare LC3 Broadcast 24_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -929,7 +928,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_24_2_1
+/**
  *  @brief Helper to declare LC3 Broadcast 24_2_1 codec configuration
  *
  *  Mandatory to support as broadcast sink
@@ -943,7 +942,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_32_1_1
+/**
  *  @brief Helper to declare LC3 Broadcast 32_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -955,7 +954,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 2u, 8u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_32_2_1
+/**
  *  @brief Helper to declare LC3 Broadcast 32_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -967,7 +966,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 2u, 10u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_441_1_1
+/**
  *  @brief Helper to declare LC3 Broadcast 441_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -980,7 +979,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 97u, 4u, 24u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_441_2_1
+/**
  *  @brief Helper to declare LC3 Broadcast 441_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -993,7 +992,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 130u, 4u, 31u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_1_1
+/**
  *  @brief Helper to declare LC3 Broadcast 48_1_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1005,7 +1004,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 15u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_2_1
+/**
  *  @brief Helper to declare LC3 Broadcast 48_2_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1017,7 +1016,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 20u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_3_1
+/**
  *  @brief Helper to declare LC3 Broadcast 48_3_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1029,7 +1028,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 15u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_4_1
+/**
  *  @brief Helper to declare LC3 Broadcast 48_4_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1041,7 +1040,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 20u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_5_1
+/**
  *  @brief Helper to declare LC3 Broadcast 48_5_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1053,7 +1052,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 15u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_6_1
+/**
  *  @brief Helper to declare LC3 Broadcast 48_6_1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1065,7 +1064,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(155u, 4u, 20u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_8_1_2
+/**
  *  @brief Helper to declare LC3 Broadcast 8_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1078,7 +1077,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(26u, 4u, 45u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_8_2_2
+/**
  *  @brief Helper to declare LC3 Broadcast 8_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1090,7 +1089,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(30u, 4u, 60u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_16_1_2
+/**
  *  @brief Helper to declare LC3 Broadcast 16_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1102,7 +1101,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(30u, 4u, 45u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_16_2_2
+/**
  *  @brief Helper to declare LC3 Broadcast 16_2_2 codec configuration
  *
  *  Mandatory to support as both broadcast source and sink
@@ -1116,7 +1115,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(40u, 4u, 60u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_24_1_2
+/**
  *  @brief Helper to declare LC3 Broadcast 24_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1128,7 +1127,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(45u, 4u, 45u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_24_2_2
+/**
  *  @brief Helper to declare LC3 Broadcast 24_2_2 codec configuration
  *
  *  Mandatory to support as broadcast sink
@@ -1142,7 +1141,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(60u, 4u, 60u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_32_1_2
+/**
  *  @brief Helper to declare LC3 Broadcast 32_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1154,7 +1153,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(60u, 4u, 45u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_32_2_2
+/**
  *  @brief Helper to declare LC3 Broadcast 32_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1166,7 +1165,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(80u, 4u, 60u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_441_1_2
+/**
  *  @brief Helper to declare LC3 Broadcast 441_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1179,7 +1178,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 97u, 4u, 54u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_441_2_2
+/**
  *  @brief Helper to declare LC3 Broadcast 441_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1192,7 +1191,7 @@ struct bt_audio_lc3_preset {
 			     BT_CODEC_QOS_2M, 130u, 4u, 60u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_1_2
+/**
  *  @brief Helper to declare LC3 Broadcast 48_1_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1204,7 +1203,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(75u, 4u, 50u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_2_2
+/**
  *  @brief Helper to declare LC3 Broadcast 48_2_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1216,7 +1215,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(100u, 4u, 65u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_3_2
+/**
  *  @brief Helper to declare LC3 Broadcast 48_3_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1228,7 +1227,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(90u, 4u, 50u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_4_2
+/**
  *  @brief Helper to declare LC3 Broadcast 48_4_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1240,7 +1239,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_10_UNFRAMED(120u, 4u, 65u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_5_2
+/**
  *  @brief Helper to declare LC3 Broadcast 48_5_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -1252,7 +1251,7 @@ struct bt_audio_lc3_preset {
 		BT_CODEC_LC3_QOS_7_5_UNFRAMED(117u, 4u, 50u, 40000u) \
 	)
 
-/** @def BT_AUDIO_LC3_BROADCAST_PRESET_48_6_2
+/**
  *  @brief Helper to declare LC3 Broadcast 48_6_2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)

--- a/include/zephyr/bluetooth/audio/capabilities.h
+++ b/include/zephyr/bluetooth/audio/capabilities.h
@@ -26,7 +26,7 @@ enum bt_audio_capability_framing {
 	BT_AUDIO_CAPABILITY_UNFRAMED_NOT_SUPPORTED = 0x01,
 };
 
-/** @def BT_AUDIO_CAPABILITY_PREF
+/**
  *  @brief Helper to declare elements of @ref bt_audio_capability_pref
  *
  *  @param _framing Framing Support

--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -25,7 +25,7 @@
 extern "C" {
 #endif
 
-/** @def BT_CODEC_LC3_ID
+/**
  *  @brief LC3 codec ID
  */
 #define BT_CODEC_LC3_ID                  0x06
@@ -40,65 +40,65 @@ extern "C" {
  */
 enum bt_codec_capability_type {
 
-	/** @def BT_CODEC_LC3_FREQ
+	/**
 	 *  @brief LC3 sample frequency capability type
 	 */
 	BT_CODEC_LC3_FREQ                = 0x01,
 
-	/** @def BT_CODEC_LC3_DURATION
+	/**
 	 *  @brief LC3 frame duration capability type
 	 */
 	BT_CODEC_LC3_DURATION            = 0x02,
 
-	/** @def BT_CODEC_LC3_CHAN_COUNT
+	/**
 	 *  @brief LC3 channel count capability type
 	 */
 	BT_CODEC_LC3_CHAN_COUNT          = 0x03,
 
-	/** @def BT_CODEC_LC3_FRAME_LEN
+	/**
 	 *  @brief LC3 frame length capability type
 	 */
 	BT_CODEC_LC3_FRAME_LEN           = 0x04,
 
-	/** @def BT_CODEC_LC3_FRAME_COUNT
+	/**
 	 *  @brief Max codec frame count per SDU capability type
 	 */
 	BT_CODEC_LC3_FRAME_COUNT         = 0x05,
 };
 
-/** @def BT_CODEC_LC3_FREQ_8KHZ
+/**
  *  @brief LC3 8 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_8KHZ           BIT(0)
-/** @def BT_CODEC_LC3_FREQ_11KHZ
+/**
  *  @brief LC3 11.025 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_11KHZ          BIT(1)
-/** @def BT_CODEC_LC3_FREQ_16KHZ
+/**
  *  @brief LC3 16 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_16KHZ          BIT(2)
-/** @def BT_CODEC_LC3_FREQ_22KHZ
+/**
  *  @brief LC3 22.05 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_22KHZ          BIT(3)
-/** @def BT_CODEC_LC3_FREQ_24KHZ
+/**
  *  @brief LC3 24 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_24KHZ          BIT(4)
-/** @def BT_CODEC_LC3_FREQ_32KHZ
+/**
  *  @brief LC3 32 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_32KHZ          BIT(5)
-/** @def BT_CODEC_LC3_FREQ_44KHZ
+/**
  *  @brief LC3 44.1 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_44KHZ          BIT(6)
-/** @def BT_CODEC_LC3_FREQ_48KHZ
+/**
  *  @brief LC3 48 Khz frequency capability
  */
 #define BT_CODEC_LC3_FREQ_48KHZ          BIT(7)
-/** @def BT_CODEC_LC3_FREQ_ANY
+/**
  *  @brief LC3 any frequency capability
  */
 #define BT_CODEC_LC3_FREQ_ANY            (BT_CODEC_LC3_FREQ_8KHZ | \
@@ -108,37 +108,37 @@ enum bt_codec_capability_type {
 					  BT_CODEC_LC3_FREQ_44KHZ | \
 					  BT_CODEC_LC3_FREQ_48KHZ)
 
-/** @def BT_CODEC_LC3_DURATION_7_5
+/**
  *  @brief LC3 7.5 msec frame duration capability
  */
 #define BT_CODEC_LC3_DURATION_7_5        BIT(0)
-/** @def BT_CODEC_LC3_DURATION_10
+/**
  *  @brief LC3 10 msec frame duration capability
  */
 #define BT_CODEC_LC3_DURATION_10         BIT(1)
-/** @def BT_CODEC_LC3_DURATION_ANY
+/**
  *  @brief LC3 any frame duration capability
  */
 #define BT_CODEC_LC3_DURATION_ANY        (BT_CODEC_LC3_DURATION_7_5 | \
 					  BT_CODEC_LC3_DURATION_10)
-/** @def BT_CODEC_LC3_DURATION_PREFER_7_5
+/**
  *  @brief LC3 7.5 msec preferred frame duration capability
  */
 #define BT_CODEC_LC3_DURATION_PREFER_7_5 BIT(4)
-/** @def BT_CODEC_LC3_DURATION_PREFER_10
+/**
  *  @brief LC3 10 msec preferred frame duration capability
  */
 #define BT_CODEC_LC3_DURATION_PREFER_10  BIT(5)
 
-/** @def BT_CODEC_LC3_CHAN_COUNT_MIN
+/**
  *  @brief LC3 minimum supported channel counts
  */
 #define BT_CODEC_LC3_CHAN_COUNT_MIN 1
-/** @def BT_CODEC_LC3_CHAN_COUNT_MIN
+/**
  *  @brief LC3 maximum supported channel counts
  */
 #define BT_CODEC_LC3_CHAN_COUNT_MAX 8
-/** @def BT_CODEC_LC3_CHAN_COUNT_SUPPORT
+/**
  *  @brief LC3 channel count support capability
  *
  *  Macro accepts variable number of channel counts.
@@ -181,70 +181,70 @@ enum bt_codec_config_type {
 	BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU   = 0x05,
 };
 
-/** @def BT_CODEC_CONFIG_LC3_FREQ_8KHZ
+/**
  *  @brief 8 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_8KHZ    0x01
-/** @def BT_CODEC_CONFIG_LC3_FREQ_11KHZ
+/**
  *  @brief 11.025 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_11KHZ   0x02
-/** @def BT_CODEC_CONFIG_LC3_FREQ_16KHZ
+/**
  *  @brief 16 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_16KHZ   0x03
-/** @def BT_CODEC_CONFIG_LC3_FREQ_22KHZ
+/**
  *  @brief 22.05 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_22KHZ   0x04
-/** @def BT_CODEC_CONFIG_LC3_FREQ_24KHZ
+/**
  *  @brief 24 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_24KHZ   0x05
-/** @def BT_CODEC_CONFIG_LC3_FREQ_32KHZ
+/**
  *  @brief 32 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_32KHZ   0x06
-/** @def BT_CODEC_CONFIG_LC3_FREQ_44KHZ
+/**
  *  @brief 44.1 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_44KHZ   0x07
-/** @def BT_CODEC_CONFIG_LC3_FREQ_48KHZ
+/**
  *  @brief 48 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_48KHZ   0x08
-/** @def BT_CODEC_CONFIG_LC3_FREQ_88KHZ
+/**
  *  @brief 88.2 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_88KHZ   0x09
-/** @def BT_CODEC_CONFIG_LC3_FREQ_96KHZ
+/**
  *  @brief 96 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_96KHZ   0x0a
-/** @def BT_CODEC_CONFIG_LC3_FREQ_176KHZ
+/**
  *  @brief 176.4 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_176KHZ   0x0b
-/** @def BT_CODEC_CONFIG_LC3_FREQ_192KHZ
+/**
  *  @brief 192 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_192KHZ   0x0c
-/** @def BT_CODEC_CONFIG_LC3_FREQ_384KHZ
+/**
  *  @brief 384 Khz codec Sample Frequency configuration
  */
 #define BT_CODEC_CONFIG_LC3_FREQ_384KHZ   0x0d
 
-/** @def BT_CODEC_CONFIG_LC3_DURATION_7_5
+/**
  *  @brief LC3 7.5 msec Frame Duration configuration
  */
 #define BT_CODEC_CONFIG_LC3_DURATION_7_5 0x00
-/** @def BT_CODEC_CONFIG_LC3_DURATION_10
+/**
  *  @brief LC3 10 msec Frame Duration configuration
  */
 #define BT_CODEC_CONFIG_LC3_DURATION_10  0x01
 
 
-/** @def BT_CODEC_LC3_DATA
+/**
  *  @brief Helper to declare LC3 codec capability
  *
  *  _max_frames_per_sdu value is optional and will be included only if != 1
@@ -266,7 +266,7 @@ enum bt_codec_config_type {
 		     (, BT_CODEC_DATA(BT_CODEC_LC3_FRAME_COUNT, _max_frames_per_sdu))) \
 }
 
-/** @def BT_CODEC_LC3_META
+/**
  *  @brief Helper to declare LC3 codec metadata
  */
 #define BT_CODEC_LC3_META(_prefer_context) \
@@ -276,7 +276,7 @@ enum bt_codec_config_type {
 		      (_prefer_context) >> 8) \
 }
 
-/** @def BT_CODEC_LC3
+/**
  *  @brief Helper to declare LC3 codec
  */
 #define BT_CODEC_LC3(_freq, _duration, _chan_count, _len_min, _len_max, \
@@ -286,7 +286,7 @@ enum bt_codec_config_type {
 				   _len_max, _max_frames_per_sdu), \
 		 BT_CODEC_LC3_META(_prefer_context))
 
-/** @def BT_CODEC_LC3_CONFIG_DATA
+/**
  *  @brief Helper to declare LC3 codec data configuration
  *
  *  _frame_blocks_per_sdu value is optional and will be included only if != 1
@@ -308,7 +308,7 @@ enum bt_codec_config_type {
 		     (, BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU, _frames_per_sdu))) \
 }
 
-/** @def BT_CODEC_LC3_CONFIG_DATA
+/**
  *  @brief Helper to declare LC3 codec metadata configuration
  */
 #define BT_CODEC_LC3_CONFIG_META(_stream_context) \
@@ -318,7 +318,7 @@ enum bt_codec_config_type {
 		      _stream_context >> 8), \
 }
 
-/** @def BT_CODEC_LC3_CONFIG
+/**
  *  @brief Helper to declare LC3 codec configuration.
  *
  *  @param _freq            Sampling frequency (BT_CODEC_CONFIG_LC3_FREQ_*)
@@ -334,7 +334,7 @@ enum bt_codec_config_type {
 		 BT_CODEC_LC3_CONFIG_DATA(_freq, _duration, _loc, _len, _frames_per_sdu), \
 		 BT_CODEC_LC3_CONFIG_META(_stream_context))
 
-/** @def BT_CODEC_LC3_CONFIG_8_1
+/**
  *  @brief Helper to declare LC3 8.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -344,7 +344,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_8KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 26u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_8_2
+/**
  *  @brief Helper to declare LC3 8.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -354,7 +354,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_8KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 30u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_16_1
+/**
  *  @brief Helper to declare LC3 16.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -364,7 +364,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_16KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 30u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_16_2
+/**
  *  @brief Helper to declare LC3 16.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -375,7 +375,7 @@ enum bt_codec_config_type {
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 40u, \
 			    1, _stream_context)
 
-/** @def BT_CODEC_LC3_CONFIG_24_1
+/**
  *  @brief Helper to declare LC3 24.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -385,7 +385,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_24KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 45u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_24_2
+/**
  *  @brief Helper to declare LC3 24.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -395,7 +395,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_24KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 60u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_32_1
+/**
  *  @brief Helper to declare LC3 32.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -405,7 +405,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_32KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 60u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_32_2
+/**
  *  @brief Helper to declare LC3 32.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -415,7 +415,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_32KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 80u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_441_1
+/**
  *  @brief Helper to declare LC3 441.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -425,7 +425,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_44KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 98u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_441_2
+/**
  *  @brief Helper to declare LC3 441.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -435,7 +435,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_44KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 130u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_48_1
+/**
  *  @brief Helper to declare LC3 48.1 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -445,7 +445,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 75u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_48_2
+/**
  *  @brief Helper to declare LC3 48.2 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -455,7 +455,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 100u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_48_3
+/**
  *  @brief Helper to declare LC3 48.3 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -465,7 +465,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 90u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_48_4
+/**
  *  @brief Helper to declare LC3 48.4 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -475,7 +475,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 120u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_48_5
+/**
  *  @brief Helper to declare LC3 48.5 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -485,7 +485,7 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_7_5, _loc, 117u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_CONFIG_48_6
+/**
  *  @brief Helper to declare LC3 48.6 codec configuration
  *
  *  @param _loc             Audio channel location bitfield (@ref bt_audio_location)
@@ -495,24 +495,24 @@ enum bt_codec_config_type {
 	BT_CODEC_LC3_CONFIG(BT_CODEC_CONFIG_LC3_FREQ_48KHZ, \
 			    BT_CODEC_CONFIG_LC3_DURATION_10, _loc, 155u, \
 			    1, _stream_context)
-/** @def BT_CODEC_LC3_QOS_7_5
+/**
  *  @brief Helper to declare LC3 codec QoS for 7.5ms interval
  */
 #define BT_CODEC_LC3_QOS_7_5(_framing, _sdu, _rtn, _latency, _pd) \
 	BT_CODEC_QOS(7500u, _framing, BT_CODEC_QOS_2M, _sdu, _rtn, \
 		     _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_7_5_UNFRAMED
+/**
  *  @brief Helper to declare LC3 codec QoS for 7.5ms interval unframed input
  */
 #define BT_CODEC_LC3_QOS_7_5_UNFRAMED(_sdu, _rtn, _latency, _pd) \
 	BT_CODEC_QOS_UNFRAMED(7500u, _sdu, _rtn, _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_10
+/**
  *  @brief Helper to declare LC3 codec QoS for 10ms frame internal
  */
 #define BT_CODEC_LC3_QOS_10(_framing, _sdu, _rtn, _latency, _pd) \
 	BT_CODEC_QOS(10000u, _framing, BT_CODEC_QOS_2M, _sdu, _rtn, \
 		     _latency, _pd)
-/** @def BT_CODEC_LC3_QOS_10_UNFRAMED
+/**
  *  @brief Helper to declare LC3 codec QoS for 10ms interval unframed input
  */
 #define BT_CODEC_LC3_QOS_10_UNFRAMED(_sdu, _rtn, _latency, _pd) \

--- a/include/zephyr/bluetooth/bluetooth.h
+++ b/include/zephyr/bluetooth/bluetooth.h
@@ -37,8 +37,6 @@ extern "C" {
  */
 
 /**
- * @def BT_ID_DEFAULT
- *
  * Convenience macro for specifying the default identity. This helps
  * make the code more readable, especially when only one identity is
  * supported.

--- a/include/zephyr/bluetooth/conn.h
+++ b/include/zephyr/bluetooth/conn.h
@@ -971,8 +971,7 @@ struct bt_conn_cb {
  */
 void bt_conn_cb_register(struct bt_conn_cb *cb);
 
-/** @def BT_CONN_CB_DEFINE
- *
+/**
  *  @brief Register a callback structure for connection events.
  *
  *  @param _name Name of callback structure.
@@ -1058,8 +1057,7 @@ int bt_le_oob_get_sc_data(struct bt_conn *conn,
 			  const struct bt_le_oob_sc_data **oobd_local,
 			  const struct bt_le_oob_sc_data **oobd_remote);
 
-/** @def BT_PASSKEY_INVALID
- *
+/**
  *  Special passkey value that can be used to disable a previously
  *  set fixed passkey.
  */

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -86,7 +86,7 @@ enum bt_gatt_perm {
 	BT_GATT_PERM_WRITE_LESC = BIT(8),
 };
 
-/** @def BT_GATT_ERR
+/**
  *  @brief Construct error return value for attribute read and write callbacks.
  *
  *  @param _att_err ATT error code
@@ -230,51 +230,51 @@ struct bt_gatt_cb {
 
 /** Characteristic Properties Bit field values */
 
-/** @def BT_GATT_CHRC_BROADCAST
+/**
  *  @brief Characteristic broadcast property.
  *
  *  If set, permits broadcasts of the Characteristic Value using Server
  *  Characteristic Configuration Descriptor.
  */
 #define BT_GATT_CHRC_BROADCAST			0x01
-/** @def BT_GATT_CHRC_READ
+/**
  *  @brief Characteristic read property.
  *
  *  If set, permits reads of the Characteristic Value.
  */
 #define BT_GATT_CHRC_READ			0x02
-/** @def BT_GATT_CHRC_WRITE_WITHOUT_RESP
+/**
  *  @brief Characteristic write without response property.
  *
  *  If set, permits write of the Characteristic Value without response.
  */
 #define BT_GATT_CHRC_WRITE_WITHOUT_RESP		0x04
-/** @def BT_GATT_CHRC_WRITE
+/**
  *  @brief Characteristic write with response property.
  *
  *  If set, permits write of the Characteristic Value with response.
  */
 #define BT_GATT_CHRC_WRITE			0x08
-/** @def BT_GATT_CHRC_NOTIFY
+/**
  *  @brief Characteristic notify property.
  *
  *  If set, permits notifications of a Characteristic Value without
  *  acknowledgment.
  */
 #define BT_GATT_CHRC_NOTIFY			0x10
-/** @def BT_GATT_CHRC_INDICATE
+/**
  *  @brief Characteristic indicate property.
  *
  * If set, permits indications of a Characteristic Value with acknowledgment.
  */
 #define BT_GATT_CHRC_INDICATE			0x20
-/** @def BT_GATT_CHRC_AUTH
+/**
  *  @brief Characteristic Authenticated Signed Writes property.
  *
  *  If set, permits signed writes to the Characteristic Value.
  */
 #define BT_GATT_CHRC_AUTH			0x40
-/** @def BT_GATT_CHRC_EXT_PROP
+/**
  *  @brief Characteristic Extended Properties property.
  *
  * If set, additional characteristic properties are defined in the
@@ -304,13 +304,13 @@ struct bt_gatt_cep {
 
 /** Client Characteristic Configuration Values */
 
-/** @def BT_GATT_CCC_NOTIFY
+/**
  *  @brief Client Characteristic Configuration Notification.
  *
  *  If set, changes to Characteristic Value shall be notified.
  */
 #define BT_GATT_CCC_NOTIFY			0x0001
-/** @def BT_GATT_CCC_INDICATE
+/**
  *  @brief Client Characteristic Configuration Indication.
  *
  *  If set, changes to Characteristic Value shall be indicated.
@@ -325,7 +325,7 @@ struct bt_gatt_ccc {
 
 /** Server Characteristic Configuration Values */
 
-/** @def BT_GATT_SCC_BROADCAST
+/**
  *  @brief Server Characteristic Configuration Broadcast
  *
  *  If set, the characteristic value shall be broadcast in the advertising data
@@ -548,7 +548,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 				  const struct bt_gatt_attr *attr,
 				  void *buf, uint16_t len, uint16_t offset);
 
-/** @def BT_GATT_SERVICE_DEFINE
+/**
  *  @brief Statically define and register a service.
  *
  *  Helper macro to statically define and register a service.
@@ -565,7 +565,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 
 #define _BT_GATT_SERVICE_ARRAY_ITEM(_n, _) BT_GATT_SERVICE(attrs_##_n)
 
-/** @def BT_GATT_SERVICE_INSTANCE_DEFINE
+/**
  *  @brief Statically define service structure array.
  *
  *  Helper macro to statically define service structure array. Each element
@@ -590,7 +590,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 		LISTIFY(_instance_num, _BT_GATT_SERVICE_ARRAY_ITEM, (,)) \
 	}
 
-/** @def BT_GATT_SERVICE
+/**
  *  @brief Service Structure Declaration Macro.
  *
  *  Helper macro to declare a service structure.
@@ -603,7 +603,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 	.attr_count = ARRAY_SIZE(_attrs),				\
 }
 
-/** @def BT_GATT_PRIMARY_SERVICE
+/**
  *  @brief Primary Service Declaration Macro.
  *
  *  Helper macro to declare a primary service attribute.
@@ -614,7 +614,7 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
 	BT_GATT_ATTRIBUTE(BT_UUID_GATT_PRIMARY, BT_GATT_PERM_READ,	\
 			 bt_gatt_attr_read_service, NULL, _service)
 
-/** @def BT_GATT_SECONDARY_SERVICE
+/**
  *  @brief Secondary Service Declaration Macro.
  *
  *  Helper macro to declare a secondary service attribute.
@@ -644,7 +644,7 @@ ssize_t bt_gatt_attr_read_included(struct bt_conn *conn,
 				   const struct bt_gatt_attr *attr,
 				   void *buf, uint16_t len, uint16_t offset);
 
-/** @def BT_GATT_INCLUDE_SERVICE
+/**
  *  @brief Include Service Declaration Macro.
  *
  *  Helper macro to declare database internal include service attribute.
@@ -681,7 +681,7 @@ ssize_t bt_gatt_attr_read_chrc(struct bt_conn *conn,
 	.properties = _props,                     \
 }
 
-/** @def BT_GATT_CHARACTERISTIC
+/**
  *  @brief Characteristic and Value Declaration Macro.
  *
  *  Helper macro to declare a characteristic attribute along with its
@@ -807,7 +807,7 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 			       uint16_t len, uint16_t offset, uint8_t flags);
 
 
-/** @def BT_GATT_CCC_INITIALIZER
+/**
  *  @brief Initialize Client Characteristic Configuration Declaration Macro.
  *
  *  Helper macro to initialize a Managed CCC attribute value.
@@ -824,7 +824,7 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 		.cfg_match = _match,                 \
 	}
 
-/** @def BT_GATT_CCC_MANAGED
+/**
  *  @brief Managed Client Characteristic Configuration Declaration Macro.
  *
  *  Helper macro to declare a Managed CCC attribute.
@@ -838,7 +838,7 @@ ssize_t bt_gatt_attr_write_ccc(struct bt_conn *conn,
 			bt_gatt_attr_read_ccc, bt_gatt_attr_write_ccc,  \
 			_ccc)
 
-/** @def BT_GATT_CCC
+/**
  *  @brief Client Characteristic Configuration Declaration Macro.
  *
  *  Helper macro to declare a CCC attribute.
@@ -871,7 +871,7 @@ ssize_t bt_gatt_attr_read_cep(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset);
 
-/** @def BT_GATT_CEP
+/**
  *  @brief Characteristic Extended Properties Declaration Macro.
  *
  *  Helper macro to declare a CEP attribute.
@@ -903,7 +903,7 @@ ssize_t bt_gatt_attr_read_cud(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset);
 
-/** @def BT_GATT_CUD
+/**
  *  @brief Characteristic User Format Descriptor Declaration Macro.
  *
  *  Helper macro to declare a CUD attribute.
@@ -936,7 +936,7 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
 			      const struct bt_gatt_attr *attr, void *buf,
 			      uint16_t len, uint16_t offset);
 
-/** @def BT_GATT_CPF
+/**
  *  @brief Characteristic Presentation Format Descriptor Declaration Macro.
  *
  *  Helper macro to declare a CPF attribute.
@@ -947,7 +947,7 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
 	BT_GATT_DESCRIPTOR(BT_UUID_GATT_CPF, BT_GATT_PERM_READ,		\
 			  bt_gatt_attr_read_cpf, NULL, (void *)_value)
 
-/** @def BT_GATT_DESCRIPTOR
+/**
  *  @brief Descriptor Declaration Macro.
  *
  *  Helper macro to declare a descriptor attribute.
@@ -964,7 +964,7 @@ ssize_t bt_gatt_attr_read_cpf(struct bt_conn *conn,
 #define BT_GATT_DESCRIPTOR(_uuid, _perm, _read, _write, _user_data)	\
 	BT_GATT_ATTRIBUTE(_uuid, _perm, _read, _write, _user_data)
 
-/** @def BT_GATT_ATTRIBUTE
+/**
  *  @brief Attribute Declaration Macro.
  *
  *  Helper macro to declare an attribute.

--- a/include/zephyr/bluetooth/iso.h
+++ b/include/zephyr/bluetooth/iso.h
@@ -27,13 +27,12 @@ extern "C" {
 #include <zephyr/bluetooth/conn.h>
 #include <zephyr/bluetooth/hci.h>
 
-/** @def BT_ISO_CHAN_SEND_RESERVE
+/**
  *  @brief Headroom needed for outgoing ISO SDUs
  */
 #define BT_ISO_CHAN_SEND_RESERVE BT_BUF_ISO_SIZE(0)
 
-/** @def BT_ISO_SDU_BUF_SIZE
- *
+/**
  *  @brief Helper to calculate needed buffer size for ISO SDUs.
  *         Useful for creating buffer pools.
  *

--- a/include/zephyr/bluetooth/l2cap.h
+++ b/include/zephyr/bluetooth/l2cap.h
@@ -69,7 +69,7 @@ extern "C" {
  */
 #define BT_L2CAP_SDU_RX_MTU (BT_L2CAP_RX_MTU - BT_L2CAP_SDU_HDR_SIZE)
 
-/** @def BT_L2CAP_SDU_BUF_SIZE
+/**
  *
  *  @brief Helper to calculate needed buffer size for L2CAP SDUs.
  *         Useful for creating buffer pools.
@@ -199,7 +199,7 @@ struct bt_l2cap_le_chan {
 #endif
 };
 
-/** @def BT_L2CAP_LE_CHAN(_ch)
+/**
  *  @brief Helper macro getting container object of type bt_l2cap_le_chan
  *  address having the same container chan member address as object in question.
  *
@@ -345,12 +345,12 @@ struct bt_l2cap_chan_ops {
 	void (*reconfigured)(struct bt_l2cap_chan *chan);
 };
 
-/** @def BT_L2CAP_CHAN_SEND_RESERVE
+/**
  *  @brief Headroom needed for outgoing L2CAP PDUs.
  */
 #define BT_L2CAP_CHAN_SEND_RESERVE (BT_L2CAP_BUF_SIZE(0))
 
-/** @def BT_L2CAP_SDU_CHAN_SEND_RESERVE
+/**
  * @brief Headroom needed for outgoing L2CAP SDUs.
  */
 #define BT_L2CAP_SDU_CHAN_SEND_RESERVE (BT_L2CAP_SDU_BUF_SIZE(0))

--- a/include/zephyr/bluetooth/mesh/access.h
+++ b/include/zephyr/bluetooth/mesh/access.h
@@ -228,8 +228,7 @@ struct bt_mesh_model_op {
 /** Helper to define an empty model array */
 #define BT_MESH_MODEL_NONE ((struct bt_mesh_model []){})
 
-/** @def BT_MESH_MODEL_CB
- *
+/**
  *  @brief Composition data SIG model entry with callback functions.
  *
  *  @param _id        Model ID.
@@ -249,8 +248,7 @@ struct bt_mesh_model_op {
 	.user_data = _user_data,                                             \
 }
 
-/** @def BT_MESH_MODEL_VND_CB
- *
+/**
  *  @brief Composition data vendor model entry with callback functions.
  *
  *  @param _company   Company ID.
@@ -273,8 +271,7 @@ struct bt_mesh_model_op {
 }
 
 
-/** @def BT_MESH_MODEL
- *
+/**
  *  @brief Composition data SIG model entry.
  *
  *  @param _id        Model ID.
@@ -285,8 +282,7 @@ struct bt_mesh_model_op {
 #define BT_MESH_MODEL(_id, _op, _pub, _user_data)                              \
 	BT_MESH_MODEL_CB(_id, _op, _pub, _user_data, NULL)
 
-/** @def BT_MESH_MODEL_VND
- *
+/**
  *  @brief Composition data vendor model entry.
  *
  *  @param _company   Company ID.
@@ -298,8 +294,7 @@ struct bt_mesh_model_op {
 #define BT_MESH_MODEL_VND(_company, _id, _op, _pub, _user_data)                \
 	BT_MESH_MODEL_VND_CB(_company, _id, _op, _pub, _user_data, NULL)
 
-/** @def BT_MESH_TRANSMIT
- *
+/**
  *  @brief Encode transmission count & interval steps.
  *
  *  @param count   Number of retransmissions (first transmission is excluded).
@@ -311,8 +306,7 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_TRANSMIT(count, int_ms) ((count) | (((int_ms / 10) - 1) << 3))
 
-/** @def BT_MESH_TRANSMIT_COUNT
- *
+/**
  *  @brief Decode transmit count from a transmit value.
  *
  *  @param transmit Encoded transmit count & interval value.
@@ -321,8 +315,7 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_TRANSMIT_COUNT(transmit) (((transmit) & (uint8_t)BIT_MASK(3)))
 
-/** @def BT_MESH_TRANSMIT_INT
- *
+/**
  *  @brief Decode transmit interval from a transmit value.
  *
  *  @param transmit Encoded transmit count & interval value.
@@ -331,8 +324,7 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_TRANSMIT_INT(transmit) ((((transmit) >> 3) + 1) * 10)
 
-/** @def BT_MESH_PUB_TRANSMIT
- *
+/**
  *  @brief Encode Publish Retransmit count & interval steps.
  *
  *  @param count  Number of retransmissions (first transmission is excluded).
@@ -345,8 +337,7 @@ struct bt_mesh_model_op {
 #define BT_MESH_PUB_TRANSMIT(count, int_ms) BT_MESH_TRANSMIT(count,           \
 							     (int_ms) / 5)
 
-/** @def BT_MESH_PUB_TRANSMIT_COUNT
- *
+/**
  *  @brief Decode Publish Retransmit count from a given value.
  *
  *  @param transmit Encoded Publish Retransmit count & interval value.
@@ -355,8 +346,7 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_PUB_TRANSMIT_COUNT(transmit) BT_MESH_TRANSMIT_COUNT(transmit)
 
-/** @def BT_MESH_PUB_TRANSMIT_INT
- *
+/**
  *  @brief Decode Publish Retransmit interval from a given value.
  *
  *  @param transmit Encoded Publish Retransmit count & interval value.
@@ -365,8 +355,7 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_PUB_TRANSMIT_INT(transmit) ((((transmit) >> 3) + 1) * 50)
 
-/** @def BT_MESH_PUB_MSG_TOTAL
- *
+/**
  * @brief Get total number of messages within one publication interval including initial
  * publication.
  *
@@ -376,8 +365,7 @@ struct bt_mesh_model_op {
  */
 #define BT_MESH_PUB_MSG_TOTAL(pub) (BT_MESH_PUB_TRANSMIT_COUNT((pub)->retransmit) + 1)
 
-/** @def BT_MESH_PUB_MSG_NUM
- *
+/**
  * @brief Get message number within one publication interval.
  *
  * Meant to be used inside @ref bt_mesh_model_pub.update.
@@ -445,8 +433,7 @@ struct bt_mesh_model_pub {
 	struct k_work_delayable timer;
 };
 
-/** @def BT_MESH_MODEL_PUB_DEFINE
- *
+/**
  *  Define a model publication context.
  *
  *  @param _name Variable name given to the context.

--- a/include/zephyr/bluetooth/mesh/cfg_cli.h
+++ b/include/zephyr/bluetooth/mesh/cfg_cli.h
@@ -196,8 +196,7 @@ struct bt_mesh_cfg_cli {
 	struct bt_mesh_msg_ack_ctx ack_ctx;
 };
 
-/** @def BT_MESH_MODEL_CFG_CLI
- *
+/**
  *  @brief Generic Configuration Client model composition data entry.
  *
  *  @param cli_data Pointer to a @ref bt_mesh_cfg_cli instance.
@@ -731,7 +730,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
 				uint16_t mod_id, uint16_t cid, uint8_t *status,
 				uint16_t *apps, size_t *app_cnt);
 
-/** @def BT_MESH_PUB_PERIOD_100MS
+/**
  *
  *  @brief Helper macro to encode model publication period in units of 100ms
  *
@@ -741,8 +740,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  */
 #define BT_MESH_PUB_PERIOD_100MS(steps)  ((steps) & BIT_MASK(6))
 
-/** @def BT_MESH_PUB_PERIOD_SEC
- *
+/**
  *  @brief Helper macro to encode model publication period in units of 1 second
  *
  *  @param steps Number of 1 second steps.
@@ -751,7 +749,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  */
 #define BT_MESH_PUB_PERIOD_SEC(steps)   (((steps) & BIT_MASK(6)) | (1 << 6))
 
-/** @def BT_MESH_PUB_PERIOD_10SEC
+/**
  *
  *  @brief Helper macro to encode model publication period in units of 10
  *  seconds
@@ -762,7 +760,7 @@ int bt_mesh_cfg_mod_app_get_vnd(uint16_t net_idx, uint16_t addr, uint16_t elem_a
  */
 #define BT_MESH_PUB_PERIOD_10SEC(steps) (((steps) & BIT_MASK(6)) | (2 << 6))
 
-/** @def BT_MESH_PUB_PERIOD_10MIN
+/**
  *
  *  @brief Helper macro to encode model publication period in units of 10
  *  minutes

--- a/include/zephyr/bluetooth/mesh/cfg_srv.h
+++ b/include/zephyr/bluetooth/mesh/cfg_srv.h
@@ -21,8 +21,7 @@
 extern "C" {
 #endif
 
-/** @def BT_MESH_MODEL_CFG_SRV
- *
+/**
  *  @brief Generic Configuration Server model composition data entry.
  */
 #define BT_MESH_MODEL_CFG_SRV                                                  \

--- a/include/zephyr/bluetooth/mesh/health_cli.h
+++ b/include/zephyr/bluetooth/mesh/health_cli.h
@@ -101,8 +101,7 @@ struct bt_mesh_health_cli {
 	struct bt_mesh_msg_ack_ctx ack_ctx;
 };
 
-/** @def BT_MESH_MODEL_HEALTH_CLI
- *
+/**
  *  @brief Generic Health Client model composition data entry.
  *
  *  @param cli_data Pointer to a @ref bt_mesh_health_cli instance.

--- a/include/zephyr/bluetooth/mesh/health_srv.h
+++ b/include/zephyr/bluetooth/mesh/health_srv.h
@@ -134,8 +134,7 @@ struct bt_mesh_health_srv_cb {
 	void (*attn_off)(struct bt_mesh_model *model);
 };
 
-/** @def BT_MESH_HEALTH_PUB_DEFINE
- *
+/**
  *  A helper to define a health publication context
  *
  *  @param _name       Name given to the publication context variable.
@@ -156,8 +155,7 @@ struct bt_mesh_health_srv {
 	struct k_work_delayable attn_timer;
 };
 
-/** @def BT_MESH_MODEL_HEALTH_SRV
- *
+/**
  *  Define a new health server model. Note that this API needs to be
  *  repeated for each element that the application wants to have a
  *  health server model on. Each instance also needs a unique

--- a/include/zephyr/bluetooth/mesh/heartbeat.h
+++ b/include/zephyr/bluetooth/mesh/heartbeat.h
@@ -109,8 +109,7 @@ struct bt_mesh_hb_cb {
 	void (*pub_sent)(const struct bt_mesh_hb_pub *pub);
 };
 
-/** @def BT_MESH_HB_CB_DEFINE
- *
+/**
  *  @brief Register a callback structure for Heartbeat events.
  *
  *  Registers a callback structure that will be called whenever Heartbeat

--- a/include/zephyr/bluetooth/mesh/main.h
+++ b/include/zephyr/bluetooth/mesh/main.h
@@ -616,8 +616,7 @@ struct bt_mesh_lpn_cb {
 	void (*polled)(uint16_t net_idx, uint16_t friend_addr, bool retry);
 };
 
-/** @def BT_MESH_LPN_CB_DEFINE
- *
+/**
  *  @brief Register a callback structure for Friendship events.
  *
  *  @param _name Name of callback structure.
@@ -666,8 +665,7 @@ struct bt_mesh_friend_cb {
 	void (*polled)(uint16_t net_idx, uint16_t lpn_addr);
 };
 
-/** @def BT_MESH_FRIEND_CB_DEFINE
- *
+/**
  *  @brief Register a callback structure for Friendship events.
  *
  *  Registers a callback structure that will be called whenever Friendship

--- a/include/zephyr/bluetooth/mesh/msg.h
+++ b/include/zephyr/bluetooth/mesh/msg.h
@@ -29,16 +29,14 @@ extern "C" {
 /** Length of a long Mesh MIC. */
 #define BT_MESH_MIC_LONG 8
 
-/** @def BT_MESH_MODEL_OP_LEN
- *
+/**
  *  @brief Helper to determine the length of an opcode.
  *
  *  @param _op Opcode.
  */
 #define BT_MESH_MODEL_OP_LEN(_op) ((_op) <= 0xff ? 1 : (_op) <= 0xffff ? 2 : 3)
 
-/** @def BT_MESH_MODEL_BUF_LEN
- *
+/**
  *  @brief Helper for model message buffer length.
  *
  *  Returns the length of a Mesh model message buffer, including the opcode
@@ -50,8 +48,7 @@ extern "C" {
 #define BT_MESH_MODEL_BUF_LEN(_op, _payload_len)                               \
 	(BT_MESH_MODEL_OP_LEN(_op) + (_payload_len) + BT_MESH_MIC_SHORT)
 
-/** @def BT_MESH_MODEL_BUF_LEN_LONG_MIC
- *
+/**
  *  @brief Helper for model message buffer length.
  *
  *  Returns the length of a Mesh model message buffer, including the opcode
@@ -63,8 +60,7 @@ extern "C" {
 #define BT_MESH_MODEL_BUF_LEN_LONG_MIC(_op, _payload_len)                      \
 	(BT_MESH_MODEL_OP_LEN(_op) + (_payload_len) + BT_MESH_MIC_LONG)
 
-/** @def BT_MESH_MODEL_BUF_DEFINE
- *
+/**
  *  @brief Define a Mesh model message buffer using @ref NET_BUF_SIMPLE_DEFINE.
  *
  *  @param _buf         Buffer name.

--- a/include/zephyr/bluetooth/mesh/proxy.h
+++ b/include/zephyr/bluetooth/mesh/proxy.h
@@ -40,8 +40,7 @@ struct bt_mesh_proxy_cb {
 	void (*identity_disabled)(uint16_t net_idx);
 };
 
-/** @def BT_MESH_PROXY_CB_DEFINE
- *
+/**
  *  @brief Register a callback structure for Proxy events.
  *
  *  Registers a structure with callback functions that gets called on various

--- a/include/zephyr/bluetooth/mesh/shell.h
+++ b/include/zephyr/bluetooth/mesh/shell.h
@@ -15,8 +15,7 @@ extern "C" {
 /** Maximum number of faults the health server can have. */
 #define BT_MESH_SHELL_CUR_FAULTS_MAX 4
 
-/** @def BT_MESH_SHELL_HEALTH_PUB_DEFINE
- *
+/**
  *  A helper to define a health publication context for shell with the shell's
  *  maximum number of faults the element can have.
  *

--- a/include/zephyr/bluetooth/sdp.h
+++ b/include/zephyr/bluetooth/sdp.h
@@ -298,22 +298,22 @@ struct bt_sdp_record {
  * ---------------------------------------------------    ------------------
  */
 
-/** @def BT_SDP_ARRAY_8
+/**
  *  @brief Declare an array of 8-bit elements in an attribute.
  */
 #define BT_SDP_ARRAY_8(...) ((uint8_t[]) {__VA_ARGS__})
 
-/** @def BT_SDP_ARRAY_16
+/**
  *  @brief Declare an array of 16-bit elements in an attribute.
  */
 #define BT_SDP_ARRAY_16(...) ((uint16_t[]) {__VA_ARGS__})
 
-/** @def BT_SDP_ARRAY_32
+/**
  *  @brief Declare an array of 32-bit elements in an attribute.
  */
 #define BT_SDP_ARRAY_32(...) ((uint32_t[]) {__VA_ARGS__})
 
-/** @def BT_SDP_TYPE_SIZE
+/**
  *  @brief Declare a fixed-size data element header.
  *
  *  @param _type Data element header containing type and size descriptors.
@@ -322,7 +322,7 @@ struct bt_sdp_record {
 			.data_size = BIT(_type & BT_SDP_SIZE_DESC_MASK), \
 			.total_size = BIT(_type & BT_SDP_SIZE_DESC_MASK) + 1
 
-/** @def BT_SDP_TYPE_SIZE_VAR
+/**
  *  @brief Declare a variable-size data element header.
  *
  *  @param _type Data element header containing type and size descriptors.
@@ -333,13 +333,13 @@ struct bt_sdp_record {
 			.total_size = BIT((_type & BT_SDP_SIZE_DESC_MASK) - \
 					  BT_SDP_SIZE_INDEX_OFFSET) + _size + 1
 
-/** @def BT_SDP_DATA_ELEM_LIST
+/**
  *  @brief Declare a list of data elements.
  */
 #define BT_SDP_DATA_ELEM_LIST(...) ((struct bt_sdp_data_elem[]) {__VA_ARGS__})
 
 
-/** @def BT_SDP_NEW_SERVICE
+/**
  *  @brief SDP New Service Record Declaration Macro.
  *
  *  Helper macro to declare a new service record.
@@ -378,7 +378,7 @@ struct bt_sdp_record {
 }
 
 
-/** @def BT_SDP_LIST
+/**
  *  @brief Generic SDP List Attribute Declaration Macro.
  *
  *  Helper macro to declare a list attribute.
@@ -392,7 +392,7 @@ struct bt_sdp_record {
 	_att_id, { _type_size, _data_elem_seq } \
 }
 
-/** @def BT_SDP_SERVICE_ID
+/**
  *  @brief SDP Service ID Attribute Declaration Macro.
  *
  *  Helper macro to declare a service ID attribute.
@@ -405,7 +405,7 @@ struct bt_sdp_record {
 	{ BT_SDP_TYPE_SIZE(BT_SDP_UUID16), &((struct bt_uuid_16) _uuid) } \
 }
 
-/** @def BT_SDP_SERVICE_NAME
+/**
  *  @brief SDP Name Attribute Declaration Macro.
  *
  *  Helper macro to declare a service name attribute.
@@ -418,7 +418,7 @@ struct bt_sdp_record {
 	{ BT_SDP_TYPE_SIZE_VAR(BT_SDP_TEXT_STR8, (sizeof(_name)-1)), _name } \
 }
 
-/** @def BT_SDP_SUPPORTED_FEATURES
+/**
  *  @brief SDP Supported Features Attribute Declaration Macro.
  *
  *  Helper macro to declare supported features of a profile/protocol.
@@ -431,7 +431,7 @@ struct bt_sdp_record {
 	{ BT_SDP_TYPE_SIZE(BT_SDP_UINT16), BT_SDP_ARRAY_16(_features) } \
 }
 
-/** @def BT_SDP_RECORD
+/**
  *  @brief SDP Service Declaration Macro.
  *
  *  Helper macro to declare a service.

--- a/include/zephyr/bluetooth/services/ias.h
+++ b/include/zephyr/bluetooth/services/ias.h
@@ -51,8 +51,7 @@ struct bt_ias_cb {
  */
 int bt_ias_local_alert_stop(void);
 
-/** @def BT_IAS_CB_DEFINE
- *
+/**
  *  @brief Register a callback structure for immediate alert events.
  *
  *  @param _name Name of callback structure.

--- a/include/zephyr/bluetooth/uuid.h
+++ b/include/zephyr/bluetooth/uuid.h
@@ -229,8 +229,7 @@ struct bt_uuid_128 {
 	(((w32) >> 16) & 0xFF), \
 	(((w32) >> 24) & 0xFF)
 
-/** @def BT_UUID_STR_LEN
- *
+/**
  *  @brief Recommended length of user string buffer for Bluetooth UUID.
  *
  *  @details The recommended length guarantee the output of UUID
@@ -239,1805 +238,1805 @@ struct bt_uuid_128 {
  */
 #define BT_UUID_STR_LEN 37
 
-/** @def BT_UUID_GAP_VAL
+/**
  *  @brief Generic Access UUID value
  */
 #define BT_UUID_GAP_VAL 0x1800
-/** @def BT_UUID_GAP
+/**
  *  @brief Generic Access
  */
 #define BT_UUID_GAP \
 	BT_UUID_DECLARE_16(BT_UUID_GAP_VAL)
-/** @def BT_UUID_GATT_VAL
+/**
  *  @brief Generic attribute UUID value
  */
 #define BT_UUID_GATT_VAL 0x1801
-/** @def BT_UUID_GATT
+/**
  *  @brief Generic Attribute
  */
 #define BT_UUID_GATT \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_VAL)
-/** @def BT_UUID_IAS_VAL
+/**
  *  @brief Immediate Alert Service UUID value
  */
 #define BT_UUID_IAS_VAL 0x1802
-/** @def BT_UUID_IAS
+/**
  *  @brief Immediate Alert Service
  */
 #define BT_UUID_IAS \
 	BT_UUID_DECLARE_16(BT_UUID_IAS_VAL)
-/** @def BT_UUID_LLS_VAL
+/**
  *  @brief Link Loss Service UUID value
  */
 #define BT_UUID_LLS_VAL 0x1803
-/** @def BT_UUID_LLS
+/**
  *  @brief Link Loss Service
  */
 #define BT_UUID_LLS \
 	BT_UUID_DECLARE_16(BT_UUID_LLS_VAL)
-/** @def BT_UUID_TPS_VAL
+/**
  *  @brief Tx Power Service UUID value
  */
 #define BT_UUID_TPS_VAL 0x1804
-/** @def BT_UUID_TPS
+/**
  *  @brief Tx Power Service
  */
 #define BT_UUID_TPS \
 	BT_UUID_DECLARE_16(BT_UUID_TPS_VAL)
-/** @def BT_UUID_CTS_VAL
+/**
  *  @brief Current Time Service UUID value
  */
 #define BT_UUID_CTS_VAL 0x1805
-/** @def BT_UUID_CTS
+/**
  *  @brief Current Time Service
  */
 #define BT_UUID_CTS \
 	BT_UUID_DECLARE_16(BT_UUID_CTS_VAL)
-/** @def BT_UUID_HTS_VAL
+/**
  *  @brief Health Thermometer Service UUID value
  */
 #define BT_UUID_HTS_VAL 0x1809
-/** @def BT_UUID_HTS
+/**
  *  @brief Health Thermometer Service
  */
 #define BT_UUID_HTS \
 	BT_UUID_DECLARE_16(BT_UUID_HTS_VAL)
-/** @def BT_UUID_DIS_VAL
+/**
  *  @brief Device Information Service UUID value
  */
 #define BT_UUID_DIS_VAL 0x180a
-/** @def BT_UUID_DIS
+/**
  *  @brief Device Information Service
  */
 #define BT_UUID_DIS \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_VAL)
-/** @def BT_UUID_HRS_VAL
+/**
  *  @brief Heart Rate Service UUID value
  */
 #define BT_UUID_HRS_VAL 0x180d
-/** @def BT_UUID_HRS
+/**
  *  @brief Heart Rate Service
  */
 #define BT_UUID_HRS \
 	BT_UUID_DECLARE_16(BT_UUID_HRS_VAL)
-/** @def BT_UUID_BAS_VAL
+/**
  *  @brief Battery Service UUID value
  */
 #define BT_UUID_BAS_VAL 0x180f
-/** @def BT_UUID_BAS
+/**
  *  @brief Battery Service
  */
 #define BT_UUID_BAS \
 	BT_UUID_DECLARE_16(BT_UUID_BAS_VAL)
-/** @def BT_UUID_HIDS_VAL
+/**
  *  @brief HID Service UUID value
  */
 #define BT_UUID_HIDS_VAL 0x1812
-/** @def BT_UUID_HIDS
+/**
  *  @brief HID Service
  */
 #define BT_UUID_HIDS \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_VAL)
-/** @def BT_UUID_RSCS_VAL
+/**
  *  @brief Running Speed and Cadence Service UUID value
  */
 #define BT_UUID_RSCS_VAL 0x1814
-/** @def BT_UUID_RSCS
+/**
  *  @brief Running Speed and Cadence Service
  */
 #define BT_UUID_RSCS \
 	BT_UUID_DECLARE_16(BT_UUID_RSCS_VAL)
-/** @def BT_UUID_CSC_VAL
+/**
  *  @brief Cycling Speed and Cadence Service UUID value
  */
 #define BT_UUID_CSC_VAL 0x1816
-/** @def BT_UUID_CSC
+/**
  *  @brief Cycling Speed and Cadence Service
  */
 #define BT_UUID_CSC \
 	BT_UUID_DECLARE_16(BT_UUID_CSC_VAL)
-/** @def BT_UUID_ESS_VAL
+/**
  *  @brief Environmental Sensing Service UUID value
  */
 #define BT_UUID_ESS_VAL 0x181a
-/** @def BT_UUID_ESS
+/**
  *  @brief Environmental Sensing Service
  */
 #define BT_UUID_ESS \
 	BT_UUID_DECLARE_16(BT_UUID_ESS_VAL)
-/** @def BT_UUID_BMS_VAL
+/**
  *  @brief Bond Management Service UUID value
  */
 #define BT_UUID_BMS_VAL 0x181e
-/** @def BT_UUID_BMS
+/**
  *  @brief Bond Management Service
  */
 #define BT_UUID_BMS \
 	BT_UUID_DECLARE_16(BT_UUID_BMS_VAL)
-/** @def BT_UUID_CGMS_VAL
+/**
  *  @brief Continuous Glucose Monitoring Service UUID value
  */
 #define BT_UUID_CGMS_VAL 0x181f
-/** @def BT_UUID_CGMS
+/**
  *  @brief Continuous Glucose Monitoring Service
  */
 #define BT_UUID_CGMS \
 	BT_UUID_DECLARE_16(BT_UUID_CGMS_VAL)
-/** @def BT_UUID_IPSS_VAL
+/**
  *  @brief IP Support Service UUID value
  */
 #define BT_UUID_IPSS_VAL 0x1820
-/** @def BT_UUID_IPSS
+/**
  *  @brief IP Support Service
  */
 #define BT_UUID_IPSS \
 	BT_UUID_DECLARE_16(BT_UUID_IPSS_VAL)
-/** @def BT_UUID_HPS_VAL
+/**
  *  @brief HTTP Proxy Service UUID value
  */
 #define BT_UUID_HPS_VAL 0x1823
-/** @def BT_UUID_HPS
+/**
  *  @brief HTTP Proxy Service
  */
 #define BT_UUID_HPS \
 	BT_UUID_DECLARE_16(BT_UUID_HPS_VAL)
-/** @def BT_UUID_OTS_VAL
+/**
  *  @brief Object Transfer Service UUID value
  */
 #define BT_UUID_OTS_VAL 0x1825
-/** @def BT_UUID_OTS
+/**
  *  @brief Object Transfer Service
  */
 #define BT_UUID_OTS \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_VAL)
-/** @def BT_UUID_MESH_PROV_VAL
+/**
  *  @brief Mesh Provisioning Service UUID value
  */
 #define BT_UUID_MESH_PROV_VAL 0x1827
-/** @def BT_UUID_MESH_PROV
+/**
  *  @brief Mesh Provisioning Service
  */
 #define BT_UUID_MESH_PROV \
 	BT_UUID_DECLARE_16(BT_UUID_MESH_PROV_VAL)
-/** @def BT_UUID_MESH_PROXY_VAL
+/**
  *  @brief Mesh Proxy Service UUID value
  */
 #define BT_UUID_MESH_PROXY_VAL 0x1828
-/** @def BT_UUID_MESH_PROXY
+/**
  *  @brief Mesh Proxy Service
  */
 #define BT_UUID_MESH_PROXY \
 	BT_UUID_DECLARE_16(BT_UUID_MESH_PROXY_VAL)
-/** @def BT_UUID_AICS_VAL
+/**
  *  @brief Audio Input Control Service value
  */
 #define BT_UUID_AICS_VAL 0x1843
-/** @def BT_UUID_AICS
+/**
  *  @brief Audio Input Control Service
  */
 #define BT_UUID_AICS \
 	BT_UUID_DECLARE_16(BT_UUID_AICS_VAL)
-/** @def BT_UUID_VCS_VAL
+/**
  *  @brief Volume Control Service value
  */
 #define BT_UUID_VCS_VAL 0x1844
-/** @def BT_UUID_VCS
+/**
  *  @brief Volume Control Service
  */
 #define BT_UUID_VCS \
 	BT_UUID_DECLARE_16(BT_UUID_VCS_VAL)
-/** @def BT_UUID_VOCS_VAL
+/**
  *  @brief Volume Offset Control Service value
  */
 #define BT_UUID_VOCS_VAL 0x1845
-/** @def BT_UUID_VOCS
+/**
  *  @brief Volume Offset Control Service
  */
 #define BT_UUID_VOCS \
 	BT_UUID_DECLARE_16(BT_UUID_VOCS_VAL)
-/** @def BT_UUID_CSIS_VAL
+/**
  *  @brief Coordinated Set Identification Service value
  */
 #define BT_UUID_CSIS_VAL 0x1846
-/** @def BT_UUID_CSIS
+/**
  *  @brief Coordinated Set Identification Service
  */
 #define BT_UUID_CSIS \
 	BT_UUID_DECLARE_16(BT_UUID_CSIS_VAL)
-/** @def BT_UUID_MCS_VAL
+/**
  *  @brief Media Control Service value
  */
 #define BT_UUID_MCS_VAL 0x1848
-/** @def BT_UUID_MCS
+/**
  *  @brief Media Control Service
  */
 #define BT_UUID_MCS \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_VAL)
-/** @def BT_UUID_GMCS_VAL
+/**
  *  @brief Generic Media Control Service value
  */
 #define BT_UUID_GMCS_VAL 0x1849
-/** @def BT_UUID_GMCS
+/**
  *  @brief Generic Media Control Service
  */
 #define BT_UUID_GMCS \
 	BT_UUID_DECLARE_16(BT_UUID_GMCS_VAL)
-/** @def BT_UUID_TBS_VAL
+/**
  *  @brief Telephone Bearer Service value
  */
 #define BT_UUID_TBS_VAL 0x184B
-/** @def BT_UUID_TBS
+/**
  *  @brief Telephone Bearer Service
  */
 #define BT_UUID_TBS \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_VAL)
-/** @def BT_UUID_GTBS_VAL
+/**
  *  @brief Generic Telephone Bearer Service value
  */
 #define BT_UUID_GTBS_VAL 0x184C
-/** @def BT_UUID_GTBS
+/**
  *  @brief Generic Telephone Bearer Service
  */
 #define BT_UUID_GTBS \
 	BT_UUID_DECLARE_16(BT_UUID_GTBS_VAL)
-/** @def BT_UUID_MICS_VAL
+/**
  *  @brief Microphone Input Control Service value
  */
 #define BT_UUID_MICS_VAL 0x184D
-/** @def BT_UUID_MICS
+/**
  *  @brief Microphone Input Control Service
  */
 #define BT_UUID_MICS \
 	BT_UUID_DECLARE_16(BT_UUID_MICS_VAL)
-/** @def BT_UUID_ASCS_VAL
+/**
  *  @brief Audio Stream Control Service value
  */
 #define BT_UUID_ASCS_VAL 0x184E
-/** @def BT_UUID_ASCS
+/**
  *  @brief Audio Stream Control Service
  */
 #define BT_UUID_ASCS \
 	BT_UUID_DECLARE_16(BT_UUID_ASCS_VAL)
-/** @def BT_UUID_BASS_VAL
+/**
  *  @brief Broadcast Audio Scan Service value
  */
 #define BT_UUID_BASS_VAL 0x184F
-/** @def BT_UUID_BASS
+/**
  *  @brief Broadcast Audio Scan Service
  */
 #define BT_UUID_BASS \
 	BT_UUID_DECLARE_16(BT_UUID_BASS_VAL)
-/** @def BT_UUID_PACS_VAL
+/**
  *  @brief Published Audio Capabilities Service value
  */
 #define BT_UUID_PACS_VAL 0x1850
-/** @def BT_UUID_PACS
+/**
  *  @brief Published Audio Capabilities Service
  */
 #define BT_UUID_PACS \
 	BT_UUID_DECLARE_16(BT_UUID_PACS_VAL)
-/** @def BT_UUID_BASIC_AUDIO_VAL
+/**
  *  @brief Basic Audio Announcement Service value
  */
 #define BT_UUID_BASIC_AUDIO_VAL 0x1851
-/** @def BT_UUID_BASIC_AUDIO
+/**
  *  @brief Basic Audio Announcement Service
  */
 #define BT_UUID_BASIC_AUDIO \
 	BT_UUID_DECLARE_16(BT_UUID_BASIC_AUDIO_VAL)
-/** @def BT_UUID_BROADCAST_AUDIO_VAL
+/**
  *  @brief Broadcast Audio Announcement Service value
  */
 #define BT_UUID_BROADCAST_AUDIO_VAL 0x1852
-/** @def BT_UUID_BROADCAST_AUDIO
+/**
  *  @brief Broadcast Audio Announcement Service
  */
 #define BT_UUID_BROADCAST_AUDIO \
 	BT_UUID_DECLARE_16(BT_UUID_BROADCAST_AUDIO_VAL)
-/** @def BT_UUID_CAS_VAL
+/**
  *  @brief Common Audio Service value
  */
 #define BT_UUID_CAS_VAL 0x1853
-/** @def BT_UUID_CAS
+/**
  *  @brief Common Audio Service
  */
 #define BT_UUID_CAS \
 	BT_UUID_DECLARE_16(BT_UUID_CAS_VAL)
-/** @def BT_UUID_HAS_VAL
+/**
  *  @brief Hearing Access Service value
  */
 #define BT_UUID_HAS_VAL 0x1854
-/** @def BT_UUID_HAS
+/**
  *  @brief Hearing Access Service
  */
 #define BT_UUID_HAS \
 	BT_UUID_DECLARE_16(BT_UUID_HAS_VAL)
-/** @def BT_UUID_GATT_PRIMARY_VAL
+/**
  *  @brief GATT Primary Service UUID value
  */
 #define BT_UUID_GATT_PRIMARY_VAL 0x2800
-/** @def BT_UUID_GATT_PRIMARY
+/**
  *  @brief GATT Primary Service
  */
 #define BT_UUID_GATT_PRIMARY \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_PRIMARY_VAL)
-/** @def BT_UUID_GATT_SECONDARY_VAL
+/**
  *  @brief GATT Secondary Service UUID value
  */
 #define BT_UUID_GATT_SECONDARY_VAL 0x2801
-/** @def BT_UUID_GATT_SECONDARY
+/**
  *  @brief GATT Secondary Service
  */
 #define BT_UUID_GATT_SECONDARY \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_SECONDARY_VAL)
-/** @def BT_UUID_GATT_INCLUDE_VAL
+/**
  *  @brief GATT Include Service UUID value
  */
 #define BT_UUID_GATT_INCLUDE_VAL 0x2802
-/** @def BT_UUID_GATT_INCLUDE
+/**
  *  @brief GATT Include Service
  */
 #define BT_UUID_GATT_INCLUDE \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_INCLUDE_VAL)
-/** @def BT_UUID_GATT_CHRC_VAL
+/**
  *  @brief GATT Characteristic UUID value
  */
 #define BT_UUID_GATT_CHRC_VAL 0x2803
-/** @def BT_UUID_GATT_CHRC
+/**
  *  @brief GATT Characteristic
  */
 #define BT_UUID_GATT_CHRC \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_CHRC_VAL)
-/** @def BT_UUID_GATT_CEP_VAL
+/**
  *  @brief GATT Characteristic Extended Properties UUID value
  */
 #define BT_UUID_GATT_CEP_VAL 0x2900
-/** @def BT_UUID_GATT_CEP
+/**
  *  @brief GATT Characteristic Extended Properties
  */
 #define BT_UUID_GATT_CEP \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_CEP_VAL)
-/** @def BT_UUID_GATT_CUD_VAL
+/**
  *  @brief GATT Characteristic User Description UUID value
  */
 #define BT_UUID_GATT_CUD_VAL 0x2901
-/** @def BT_UUID_GATT_CUD
+/**
  *  @brief GATT Characteristic User Description
  */
 #define BT_UUID_GATT_CUD \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_CUD_VAL)
-/** @def BT_UUID_GATT_CCC_VAL
+/**
  *  @brief GATT Client Characteristic Configuration UUID value
  */
 #define BT_UUID_GATT_CCC_VAL 0x2902
-/** @def BT_UUID_GATT_CCC
+/**
  *  @brief GATT Client Characteristic Configuration
  */
 #define BT_UUID_GATT_CCC \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_CCC_VAL)
-/** @def BT_UUID_GATT_SCC_VAL
+/**
  *  @brief GATT Server Characteristic Configuration UUID value
  */
 #define BT_UUID_GATT_SCC_VAL 0x2903
-/** @def BT_UUID_GATT_SCC
+/**
  *  @brief GATT Server Characteristic Configuration
  */
 #define BT_UUID_GATT_SCC \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_SCC_VAL)
-/** @def BT_UUID_GATT_CPF_VAL
+/**
  *  @brief GATT Characteristic Presentation Format UUID value
  */
 #define BT_UUID_GATT_CPF_VAL 0x2904
-/** @def BT_UUID_GATT_CPF
+/**
  *  @brief GATT Characteristic Presentation Format
  */
 #define BT_UUID_GATT_CPF \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_CPF_VAL)
-/** @def BT_UUID_GATT_CAF_VAL
+/**
  *  @brief GATT Characteristic Aggregated Format UUID value
  */
 #define BT_UUID_GATT_CAF_VAL 0x2905
-/** @def BT_UUID_GATT_CAF
+/**
  *  @brief GATT Characteristic Aggregated Format
  */
 #define BT_UUID_GATT_CAF \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_CAF_VAL)
-/** @def BT_UUID_VALID_RANGE_VAL
+/**
  *  @brief Valid Range Descriptor UUID value
  */
 #define BT_UUID_VALID_RANGE_VAL 0x2906
-/** @def BT_UUID_VALID_RANGE
+/**
  *  @brief Valid Range Descriptor
  */
 #define BT_UUID_VALID_RANGE \
 	BT_UUID_DECLARE_16(BT_UUID_VALID_RANGE_VAL)
-/** @def BT_UUID_HIDS_EXT_REPORT_VAL
+/**
  *  @brief HID External Report Descriptor UUID value
  */
 #define BT_UUID_HIDS_EXT_REPORT_VAL 0x2907
-/** @def BT_UUID_HIDS_EXT_REPORT
+/**
  *  @brief HID External Report Descriptor
  */
 #define BT_UUID_HIDS_EXT_REPORT \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_EXT_REPORT_VAL)
-/** @def BT_UUID_HIDS_REPORT_REF_VAL
+/**
  *  @brief HID Report Reference Descriptor UUID value
  */
 #define BT_UUID_HIDS_REPORT_REF_VAL 0x2908
-/** @def BT_UUID_HIDS_REPORT_REF
+/**
  *  @brief HID Report Reference Descriptor
  */
 #define BT_UUID_HIDS_REPORT_REF \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_REPORT_REF_VAL)
-/** @def BT_UUID_ES_CONFIGURATION_VAL
+/**
  *  @brief Environmental Sensing Configuration Descriptor UUID value
  */
 #define BT_UUID_ES_CONFIGURATION_VAL 0x290b
-/** @def BT_UUID_ES_CONFIGURATION
+/**
  *  @brief Environmental Sensing Configuration Descriptor
  */
 #define BT_UUID_ES_CONFIGURATION \
 	BT_UUID_DECLARE_16(BT_UUID_ES_CONFIGURATION_VAL)
-/** @def BT_UUID_ES_MEASUREMENT_VAL
+/**
  *  @brief Environmental Sensing Measurement Descriptor UUID value
  */
 #define BT_UUID_ES_MEASUREMENT_VAL 0x290c
-/** @def BT_UUID_ES_MEASUREMENT
+/**
  *  @brief Environmental Sensing Measurement Descriptor
  */
 #define BT_UUID_ES_MEASUREMENT \
 	BT_UUID_DECLARE_16(BT_UUID_ES_MEASUREMENT_VAL)
-/** @def BT_UUID_ES_TRIGGER_SETTING_VAL
+/**
  *  @brief Environmental Sensing Trigger Setting Descriptor UUID value
  */
 #define BT_UUID_ES_TRIGGER_SETTING_VAL 0x290d
-/** @def BT_UUID_ES_TRIGGER_SETTING
+/**
  *  @brief Environmental Sensing Trigger Setting Descriptor
  */
 #define BT_UUID_ES_TRIGGER_SETTING \
 	BT_UUID_DECLARE_16(BT_UUID_ES_TRIGGER_SETTING_VAL)
-/** @def BT_UUID_GAP_DEVICE_NAME_VAL
+/**
  *  @brief GAP Characteristic Device Name UUID value
  */
 #define BT_UUID_GAP_DEVICE_NAME_VAL 0x2a00
-/** @def BT_UUID_GAP_DEVICE_NAME
+/**
  *  @brief GAP Characteristic Device Name
  */
 #define BT_UUID_GAP_DEVICE_NAME \
 	BT_UUID_DECLARE_16(BT_UUID_GAP_DEVICE_NAME_VAL)
-/** @def BT_UUID_GAP_APPEARANCE_VAL
+/**
  *  @brief GAP Characteristic Appearance UUID value
  */
 #define BT_UUID_GAP_APPEARANCE_VAL 0x2a01
-/** @def BT_UUID_GAP_APPEARANCE
+/**
  *  @brief GAP Characteristic Appearance
  */
 #define BT_UUID_GAP_APPEARANCE \
 	BT_UUID_DECLARE_16(BT_UUID_GAP_APPEARANCE_VAL)
-/** @def BT_UUID_GAP_PPCP_VAL
+/**
  *  @brief GAP Characteristic Peripheral Preferred Connection Parameters UUID
  *         value
  */
 #define BT_UUID_GAP_PPCP_VAL 0x2a04
-/** @def BT_UUID_GAP_PPCP
+/**
  *  @brief GAP Characteristic Peripheral Preferred Connection Parameters
  */
 #define BT_UUID_GAP_PPCP \
 	BT_UUID_DECLARE_16(BT_UUID_GAP_PPCP_VAL)
-/** @def BT_UUID_GATT_SC_VAL
+/**
  *  @brief GATT Characteristic Service Changed UUID value
  */
 #define BT_UUID_GATT_SC_VAL 0x2a05
-/** @def BT_UUID_GATT_SC
+/**
  *  @brief GATT Characteristic Service Changed
  */
 #define BT_UUID_GATT_SC \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_SC_VAL)
-/** @def BT_UUID_ALERT_LEVEL_VAL
+/**
  *  @brief Alert Level UUID value
  */
 #define BT_UUID_ALERT_LEVEL_VAL  0x2a06
-/** @def BT_UUID_ALERT_LEVEL
+/**
  *  @brief Alert Level
  */
 #define BT_UUID_ALERT_LEVEL \
 	BT_UUID_DECLARE_16(BT_UUID_ALERT_LEVEL_VAL)
-/** @def BT_UUID_TPS_TX_POWER_LEVEL_VAL
+/**
  *  @brief TPS Characteristic Tx Power Level UUID value
  */
 #define BT_UUID_TPS_TX_POWER_LEVEL_VAL 0x2a07
-/** @def BT_UUID_TPS_TX_POWER_LEVEL
+/**
  *  @brief TPS Characteristic Tx Power Level
  */
 #define BT_UUID_TPS_TX_POWER_LEVEL \
 	BT_UUID_DECLARE_16(BT_UUID_TPS_TX_POWER_LEVEL_VAL)
-/** @def BT_UUID_BAS_BATTERY_LEVEL_VAL
+/**
  *  @brief BAS Characteristic Battery Level UUID value
  */
 #define BT_UUID_BAS_BATTERY_LEVEL_VAL 0x2a19
-/** @def BT_UUID_BAS_BATTERY_LEVEL
+/**
  *  @brief BAS Characteristic Battery Level
  */
 #define BT_UUID_BAS_BATTERY_LEVEL \
 	BT_UUID_DECLARE_16(BT_UUID_BAS_BATTERY_LEVEL_VAL)
-/** @def BT_UUID_HTS_MEASUREMENT_VAL
+/**
  *  @brief HTS Characteristic Measurement Value UUID value
  */
 #define BT_UUID_HTS_MEASUREMENT_VAL 0x2a1c
-/** @def BT_UUID_HTS_MEASUREMENT
+/**
  *  @brief HTS Characteristic Measurement Value
  */
 #define BT_UUID_HTS_MEASUREMENT \
 	BT_UUID_DECLARE_16(BT_UUID_HTS_MEASUREMENT_VAL)
-/** @def BT_UUID_HIDS_BOOT_KB_IN_REPORT_VAL
+/**
  *  @brief HID Characteristic Boot Keyboard Input Report UUID value
  */
 #define BT_UUID_HIDS_BOOT_KB_IN_REPORT_VAL 0x2a22
-/** @def BT_UUID_HIDS_BOOT_KB_IN_REPORT
+/**
  *  @brief HID Characteristic Boot Keyboard Input Report
  */
 #define BT_UUID_HIDS_BOOT_KB_IN_REPORT \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_BOOT_KB_IN_REPORT_VAL)
-/** @def BT_UUID_DIS_SYSTEM_ID_VAL
+/**
  *  @brief DIS Characteristic System ID UUID value
  */
 #define BT_UUID_DIS_SYSTEM_ID_VAL 0x2a23
-/** @def BT_UUID_DIS_SYSTEM_ID
+/**
  *  @brief DIS Characteristic System ID
  */
 #define BT_UUID_DIS_SYSTEM_ID \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_SYSTEM_ID_VAL)
-/** @def BT_UUID_DIS_MODEL_NUMBER_VAL
+/**
  *  @brief DIS Characteristic Model Number String UUID value
  */
 #define BT_UUID_DIS_MODEL_NUMBER_VAL 0x2a24
-/** @def BT_UUID_DIS_MODEL_NUMBER
+/**
  *  @brief DIS Characteristic Model Number String
  */
 #define BT_UUID_DIS_MODEL_NUMBER \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_MODEL_NUMBER_VAL)
-/** @def BT_UUID_DIS_SERIAL_NUMBER_VAL
+/**
  *  @brief DIS Characteristic Serial Number String UUID value
  */
 #define BT_UUID_DIS_SERIAL_NUMBER_VAL 0x2a25
-/** @def BT_UUID_DIS_SERIAL_NUMBER
+/**
  *  @brief DIS Characteristic Serial Number String
  */
 #define BT_UUID_DIS_SERIAL_NUMBER \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_SERIAL_NUMBER_VAL)
-/** @def BT_UUID_DIS_FIRMWARE_REVISION_VAL
+/**
  *  @brief DIS Characteristic Firmware Revision String UUID value
  */
 #define BT_UUID_DIS_FIRMWARE_REVISION_VAL 0x2a26
-/** @def BT_UUID_DIS_FIRMWARE_REVISION
+/**
  *  @brief DIS Characteristic Firmware Revision String
  */
 #define BT_UUID_DIS_FIRMWARE_REVISION \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_FIRMWARE_REVISION_VAL)
-/** @def BT_UUID_DIS_HARDWARE_REVISION_VAL
+/**
  *  @brief DIS Characteristic Hardware Revision String UUID value
  */
 #define BT_UUID_DIS_HARDWARE_REVISION_VAL 0x2a27
-/** @def BT_UUID_DIS_HARDWARE_REVISION
+/**
  *  @brief DIS Characteristic Hardware Revision String
  */
 #define BT_UUID_DIS_HARDWARE_REVISION \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_HARDWARE_REVISION_VAL)
-/** @def BT_UUID_DIS_SOFTWARE_REVISION_VAL
+/**
  *  @brief DIS Characteristic Software Revision String UUID value
  */
 #define BT_UUID_DIS_SOFTWARE_REVISION_VAL 0x2a28
-/** @def BT_UUID_DIS_SOFTWARE_REVISION
+/**
  *  @brief DIS Characteristic Software Revision String
  */
 #define BT_UUID_DIS_SOFTWARE_REVISION \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_SOFTWARE_REVISION_VAL)
-/** @def BT_UUID_DIS_MANUFACTURER_NAME_VAL
+/**
  *  @brief DIS Characteristic Manufacturer Name String UUID Value
  */
 #define BT_UUID_DIS_MANUFACTURER_NAME_VAL 0x2a29
-/** @def BT_UUID_DIS_MANUFACTURER_NAME
+/**
  *  @brief DIS Characteristic Manufacturer Name String
  */
 #define BT_UUID_DIS_MANUFACTURER_NAME \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_MANUFACTURER_NAME_VAL)
-/** @def BT_UUID_DIS_PNP_ID_VAL
+/**
  *  @brief DIS Characteristic PnP ID UUID value
  */
 #define BT_UUID_DIS_PNP_ID_VAL 0x2a50
-/** @def BT_UUID_DIS_PNP_ID
+/**
  *  @brief DIS Characteristic PnP ID
  */
 #define BT_UUID_DIS_PNP_ID \
 	BT_UUID_DECLARE_16(BT_UUID_DIS_PNP_ID_VAL)
-/** @def BT_UUID_CTS_CURRENT_TIME_VAL
+/**
  *  @brief CTS Characteristic Current Time UUID value
  */
 #define BT_UUID_CTS_CURRENT_TIME_VAL 0x2a2b
-/** @def BT_UUID_CTS_CURRENT_TIME
+/**
  *  @brief CTS Characteristic Current Time
  */
 #define BT_UUID_CTS_CURRENT_TIME \
 	BT_UUID_DECLARE_16(BT_UUID_CTS_CURRENT_TIME_VAL)
-/** @def BT_UUID_MAGN_DECLINATION_VAL
+/**
  *  @brief Magnetic Declination Characteristic UUID value
  */
 #define BT_UUID_MAGN_DECLINATION_VAL 0x2a2c
-/** @def BT_UUID_MAGN_DECLINATION
+/**
  *  @brief Magnetic Declination Characteristic
  */
 #define BT_UUID_MAGN_DECLINATION \
 	BT_UUID_DECLARE_16(BT_UUID_MAGN_DECLINATION_VAL)
-/** @def BT_UUID_HIDS_BOOT_KB_OUT_REPORT_VAL
+/**
  *  @brief HID Boot Keyboard Output Report Characteristic UUID value
  */
 #define BT_UUID_HIDS_BOOT_KB_OUT_REPORT_VAL 0x2a32
-/** @def BT_UUID_HIDS_BOOT_KB_OUT_REPORT
+/**
  *  @brief HID Boot Keyboard Output Report Characteristic
  */
 #define BT_UUID_HIDS_BOOT_KB_OUT_REPORT \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_BOOT_KB_OUT_REPORT_VAL)
-/** @def BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT_VAL
+/**
  *  @brief HID Boot Mouse Input Report Characteristic UUID value
  */
 #define BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT_VAL 0x2a33
-/** @def BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT
+/**
  *  @brief HID Boot Mouse Input Report Characteristic
  */
 #define BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_BOOT_MOUSE_IN_REPORT_VAL)
-/** @def BT_UUID_HRS_MEASUREMENT_VAL
+/**
  *  @brief HRS Characteristic Measurement Interval UUID value
  */
 #define BT_UUID_HRS_MEASUREMENT_VAL 0x2a37
-/** @def BT_UUID_HRS_MEASUREMENT
+/**
  *  @brief HRS Characteristic Measurement Interval
  */
 #define BT_UUID_HRS_MEASUREMENT \
 	BT_UUID_DECLARE_16(BT_UUID_HRS_MEASUREMENT_VAL)
-/** @def BT_UUID_HRS_BODY_SENSOR
+/**
  *  @brief HRS Characteristic Body Sensor Location
  */
 #define BT_UUID_HRS_BODY_SENSOR_VAL 0x2a38
-/** @def BT_UUID_HRS_CONTROL_POINT
+/**
  *  @brief HRS Characteristic Control Point
  */
 #define BT_UUID_HRS_BODY_SENSOR \
 	BT_UUID_DECLARE_16(BT_UUID_HRS_BODY_SENSOR_VAL)
-/** @def BT_UUID_HRS_CONTROL_POINT_VAL
+/**
  *  @brief HRS Characteristic Control Point UUID value
  */
 #define BT_UUID_HRS_CONTROL_POINT_VAL 0x2a39
-/** @def BT_UUID_HRS_CONTROL_POINT
+/**
  *  @brief HRS Characteristic Control Point
  */
 #define BT_UUID_HRS_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_HRS_CONTROL_POINT_VAL)
-/** @def BT_UUID_HIDS_INFO_VAL
+/**
  *  @brief HID Information Characteristic UUID value
  */
 #define BT_UUID_HIDS_INFO_VAL 0x2a4a
-/** @def BT_UUID_HIDS_INFO
+/**
  *  @brief HID Information Characteristic
  */
 #define BT_UUID_HIDS_INFO \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_INFO_VAL)
-/** @def BT_UUID_HIDS_REPORT_MAP_VAL
+/**
  *  @brief HID Report Map Characteristic UUID value
  */
 #define BT_UUID_HIDS_REPORT_MAP_VAL 0x2a4b
-/** @def BT_UUID_HIDS_REPORT_MAP
+/**
  *  @brief HID Report Map Characteristic
  */
 #define BT_UUID_HIDS_REPORT_MAP \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_REPORT_MAP_VAL)
-/** @def BT_UUID_HIDS_CTRL_POINT_VAL
+/**
  *  @brief HID Control Point Characteristic UUID value
  */
 #define BT_UUID_HIDS_CTRL_POINT_VAL 0x2a4c
-/** @def BT_UUID_HIDS_CTRL_POINT
+/**
  *  @brief HID Control Point Characteristic
  */
 #define BT_UUID_HIDS_CTRL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_CTRL_POINT_VAL)
-/** @def BT_UUID_HIDS_REPORT_VAL
+/**
  *  @brief HID Report Characteristic UUID value
  */
 #define BT_UUID_HIDS_REPORT_VAL 0x2a4d
-/** @def BT_UUID_HIDS_REPORT
+/**
  *  @brief HID Report Characteristic
  */
 #define BT_UUID_HIDS_REPORT \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_REPORT_VAL)
-/** @def BT_UUID_HIDS_PROTOCOL_MODE_VAL
+/**
  *  @brief HID Protocol Mode Characteristic UUID value
  */
 #define BT_UUID_HIDS_PROTOCOL_MODE_VAL 0x2a4e
-/** @def BT_UUID_HIDS_PROTOCOL_MODE
+/**
  *  @brief HID Protocol Mode Characteristic
  */
 #define BT_UUID_HIDS_PROTOCOL_MODE \
 	BT_UUID_DECLARE_16(BT_UUID_HIDS_PROTOCOL_MODE_VAL)
-/** @def BT_UUID_RECORD_ACCESS_CONTROL_POINT_VAL
+/**
  *  @brief Record Access Control Point Characteristic value
  */
 #define BT_UUID_RECORD_ACCESS_CONTROL_POINT_VAL 0x2a52
-/** @def BT_UUID_RECORD_ACCESS_CONTROL_POINT
+/**
  *  @brief Record Access Control Point
  */
 #define BT_UUID_RECORD_ACCESS_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_RECORD_ACCESS_CONTROL_POINT_VAL)
-/** @def BT_UUID_RSC_MEASUREMENT_VAL
+/**
  *  @brief RSC Measurement Characteristic UUID value
  */
 #define BT_UUID_RSC_MEASUREMENT_VAL 0x2a53
-/** @def BT_UUID_RSC_MEASUREMENT
+/**
  *  @brief RSC Measurement Characteristic
  */
 #define BT_UUID_RSC_MEASUREMENT \
 	BT_UUID_DECLARE_16(BT_UUID_RSC_MEASUREMENT_VAL)
-/** @def BT_UUID_RSC_FEATURE_VAL
+/**
  *  @brief RSC Feature Characteristic UUID value
  */
 #define BT_UUID_RSC_FEATURE_VAL 0x2a54
-/** @def BT_UUID_RSC_FEATURE
+/**
  *  @brief RSC Feature Characteristic
  */
 #define BT_UUID_RSC_FEATURE \
 	BT_UUID_DECLARE_16(BT_UUID_RSC_FEATURE_VAL)
-/** @def BT_UUID_CSC_MEASUREMENT_VAL
+/**
  *  @brief CSC Measurement Characteristic UUID value
  */
 #define BT_UUID_CSC_MEASUREMENT_VAL 0x2a5b
-/** @def BT_UUID_CSC_MEASUREMENT
+/**
  *  @brief CSC Measurement Characteristic
  */
 #define BT_UUID_CSC_MEASUREMENT \
 	BT_UUID_DECLARE_16(BT_UUID_CSC_MEASUREMENT_VAL)
-/** @def BT_UUID_CSC_FEATURE_VAL
+/**
  *  @brief CSC Feature Characteristic UUID value
  */
 #define BT_UUID_CSC_FEATURE_VAL 0x2a5c
-/** @def BT_UUID_CSC_FEATURE
+/**
  *  @brief CSC Feature Characteristic
  */
 #define BT_UUID_CSC_FEATURE \
 	BT_UUID_DECLARE_16(BT_UUID_CSC_FEATURE_VAL)
-/** @def BT_UUID_SENSOR_LOCATION_VAL
+/**
  *  @brief Sensor Location Characteristic UUID value
  */
 #define BT_UUID_SENSOR_LOCATION_VAL 0x2a5d
-/** @def BT_UUID_SENSOR_LOCATION
+/**
  *  @brief Sensor Location Characteristic
  */
 #define BT_UUID_SENSOR_LOCATION \
 	BT_UUID_DECLARE_16(BT_UUID_SENSOR_LOCATION_VAL)
-/** @def BT_UUID_SC_CONTROL_POINT_VAL
+/**
  *  @brief SC Control Point Characteristic UUID value
  */
 #define BT_UUID_SC_CONTROL_POINT_VAL 0x2a55
-/** @def BT_UUID_SC_CONTROL_POINT
+/**
  *  @brief SC Control Point Characteristic
  */
 #define BT_UUID_SC_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_SC_CONTROL_POINT_VAL)
-/** @def BT_UUID_ELEVATION_VAL
+/**
  *  @brief Elevation Characteristic UUID value
  */
 #define BT_UUID_ELEVATION_VAL 0x2a6c
-/** @def BT_UUID_ELEVATION
+/**
  *  @brief Elevation Characteristic
  */
 #define BT_UUID_ELEVATION \
 	BT_UUID_DECLARE_16(BT_UUID_ELEVATION_VAL)
-/** @def BT_UUID_PRESSURE_VAL
+/**
  *  @brief Pressure Characteristic UUID value
  */
 #define BT_UUID_PRESSURE_VAL 0x2a6d
-/** @def BT_UUID_PRESSURE
+/**
  *  @brief Pressure Characteristic
  */
 #define BT_UUID_PRESSURE \
 	BT_UUID_DECLARE_16(BT_UUID_PRESSURE_VAL)
-/** @def BT_UUID_TEMPERATURE_VAL
+/**
  *  @brief Temperature Characteristic UUID value
  */
 #define BT_UUID_TEMPERATURE_VAL 0x2a6e
-/** @def BT_UUID_TEMPERATURE
+/**
  *  @brief Temperature Characteristic
  */
 #define BT_UUID_TEMPERATURE \
 	BT_UUID_DECLARE_16(BT_UUID_TEMPERATURE_VAL)
-/** @def BT_UUID_HUMIDITY_VAL
+/**
  *  @brief Humidity Characteristic UUID value
  */
 #define BT_UUID_HUMIDITY_VAL 0x2a6f
-/** @def BT_UUID_HUMIDITY
+/**
  *  @brief Humidity Characteristic
  */
 #define BT_UUID_HUMIDITY \
 	BT_UUID_DECLARE_16(BT_UUID_HUMIDITY_VAL)
-/** @def BT_UUID_TRUE_WIND_SPEED_VAL
+/**
  *  @brief True Wind Speed Characteristic UUID value
  */
 #define BT_UUID_TRUE_WIND_SPEED_VAL 0x2a70
-/** @def BT_UUID_TRUE_WIND_SPEED
+/**
  *  @brief True Wind Speed Characteristic
  */
 #define BT_UUID_TRUE_WIND_SPEED \
 	BT_UUID_DECLARE_16(BT_UUID_TRUE_WIND_SPEED_VAL)
-/** @def BT_UUID_TRUE_WIND_DIR_VAL
+/**
  *  @brief True Wind Direction Characteristic UUID value
  */
 #define BT_UUID_TRUE_WIND_DIR_VAL 0x2a71
-/** @def BT_UUID_TRUE_WIND_DIR
+/**
  *  @brief True Wind Direction Characteristic
  */
 #define BT_UUID_TRUE_WIND_DIR \
 	BT_UUID_DECLARE_16(BT_UUID_TRUE_WIND_DIR_VAL)
-/** @def BT_UUID_APPARENT_WIND_SPEED_VAL
+/**
  *  @brief Apparent Wind Speed Characteristic UUID value
  */
 #define BT_UUID_APPARENT_WIND_SPEED_VAL 0x2a72
-/** @def BT_UUID_APPARENT_WIND_SPEED
+/**
  *  @brief Apparent Wind Speed Characteristic
  */
 #define BT_UUID_APPARENT_WIND_SPEED \
 	BT_UUID_DECLARE_16(BT_UUID_APPARENT_WIND_SPEED_VAL)
-/** @def BT_UUID_APPARENT_WIND_DIR_VAL
+/**
  *  @brief Apparent Wind Direction Characteristic UUID value
  */
 #define BT_UUID_APPARENT_WIND_DIR_VAL 0x2a73
-/** @def BT_UUID_APPARENT_WIND_DIR
+/**
  *  @brief Apparent Wind Direction Characteristic
  */
 #define BT_UUID_APPARENT_WIND_DIR \
 	BT_UUID_DECLARE_16(BT_UUID_APPARENT_WIND_DIR_VAL)
-/** @def BT_UUID_GUST_FACTOR_VAL
+/**
  *  @brief Gust Factor Characteristic UUID value
  */
 #define BT_UUID_GUST_FACTOR_VAL 0x2a74
-/** @def BT_UUID_GUST_FACTOR
+/**
  *  @brief Gust Factor Characteristic
  */
 #define BT_UUID_GUST_FACTOR \
 	BT_UUID_DECLARE_16(BT_UUID_GUST_FACTOR_VAL)
-/** @def BT_UUID_POLLEN_CONCENTRATION_VAL
+/**
  *  @brief Pollen Concentration Characteristic UUID value
  */
 #define BT_UUID_POLLEN_CONCENTRATION_VAL 0x2a75
-/** @def BT_UUID_POLLEN_CONCENTRATION
+/**
  *  @brief Pollen Concentration Characteristic
  */
 #define BT_UUID_POLLEN_CONCENTRATION \
 	BT_UUID_DECLARE_16(BT_UUID_POLLEN_CONCENTRATION_VAL)
-/** @def BT_UUID_UV_INDEX_VAL
+/**
  *  @brief UV Index Characteristic UUID value
  */
 #define BT_UUID_UV_INDEX_VAL 0x2a76
-/** @def BT_UUID_UV_INDEX
+/**
  *  @brief UV Index Characteristic
  */
 #define BT_UUID_UV_INDEX \
 	BT_UUID_DECLARE_16(BT_UUID_UV_INDEX_VAL)
-/** @def BT_UUID_IRRADIANCE_VAL
+/**
  *  @brief Irradiance Characteristic UUID value
  */
 #define BT_UUID_IRRADIANCE_VAL 0x2a77
-/** @def BT_UUID_IRRADIANCE
+/**
  *  @brief Irradiance Characteristic
  */
 #define BT_UUID_IRRADIANCE \
 	BT_UUID_DECLARE_16(BT_UUID_IRRADIANCE_VAL)
-/** @def BT_UUID_RAINFALL_VAL
+/**
  *  @brief Rainfall Characteristic UUID value
  */
 #define BT_UUID_RAINFALL_VAL 0x2a78
-/** @def BT_UUID_RAINFALL
+/**
  *  @brief Rainfall Characteristic
  */
 #define BT_UUID_RAINFALL \
 	BT_UUID_DECLARE_16(BT_UUID_RAINFALL_VAL)
-/** @def BT_UUID_WIND_CHILL_VAL
+/**
  *  @brief Wind Chill Characteristic UUID value
  */
 #define BT_UUID_WIND_CHILL_VAL 0x2a79
-/** @def BT_UUID_WIND_CHILL
+/**
  *  @brief Wind Chill Characteristic
  */
 #define BT_UUID_WIND_CHILL \
 	BT_UUID_DECLARE_16(BT_UUID_WIND_CHILL_VAL)
-/** @def BT_UUID_HEAT_INDEX_VAL
+/**
  *  @brief Heat Index Characteristic UUID value
  */
 #define BT_UUID_HEAT_INDEX_VAL 0x2a7a
-/** @def BT_UUID_HEAT_INDEX
+/**
  *  @brief Heat Index Characteristic
  */
 #define BT_UUID_HEAT_INDEX \
 	BT_UUID_DECLARE_16(BT_UUID_HEAT_INDEX_VAL)
-/** @def BT_UUID_DEW_POINT_VAL
+/**
  *  @brief Dew Point Characteristic UUID value
  */
 #define BT_UUID_DEW_POINT_VAL 0x2a7b
-/** @def BT_UUID_DEW_POINT
+/**
  *  @brief Dew Point Characteristic
  */
 #define BT_UUID_DEW_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_DEW_POINT_VAL)
-/** @def BT_UUID_DESC_VALUE_CHANGED_VAL
+/**
  *  @brief Descriptor Value Changed Characteristic UUID value
  */
 #define BT_UUID_DESC_VALUE_CHANGED_VAL 0x2a7d
-/** @def BT_UUID_DESC_VALUE_CHANGED
+/**
  *  @brief Descriptor Value Changed Characteristic
  */
 #define BT_UUID_DESC_VALUE_CHANGED \
 	BT_UUID_DECLARE_16(BT_UUID_DESC_VALUE_CHANGED_VAL)
-/** @def BT_UUID_MAGN_FLUX_DENSITY_2D_VAL
+/**
  *  @brief Magnetic Flux Density - 2D Characteristic UUID value
  */
 #define BT_UUID_MAGN_FLUX_DENSITY_2D_VAL 0x2aa0
-/** @def BT_UUID_MAGN_FLUX_DENSITY_2D
+/**
  *  @brief Magnetic Flux Density - 2D Characteristic
  */
 #define BT_UUID_MAGN_FLUX_DENSITY_2D \
 	BT_UUID_DECLARE_16(BT_UUID_MAGN_FLUX_DENSITY_2D_VAL)
-/** @def BT_UUID_MAGN_FLUX_DENSITY_3D_VAL
+/**
  *  @brief Magnetic Flux Density - 3D Characteristic UUID value
  */
 #define BT_UUID_MAGN_FLUX_DENSITY_3D_VAL 0x2aa1
-/** @def BT_UUID_MAGN_FLUX_DENSITY_3D
+/**
  *  @brief Magnetic Flux Density - 3D Characteristic
  */
 #define BT_UUID_MAGN_FLUX_DENSITY_3D \
 	BT_UUID_DECLARE_16(BT_UUID_MAGN_FLUX_DENSITY_3D_VAL)
-/** @def BT_UUID_BAR_PRESSURE_TREND_VAL
+/**
  *  @brief Barometric Pressure Trend Characteristic UUID value
  */
 #define BT_UUID_BAR_PRESSURE_TREND_VAL 0x2aa3
-/** @def BT_UUID_BAR_PRESSURE_TREND
+/**
  *  @brief Barometric Pressure Trend Characteristic
  */
 #define BT_UUID_BAR_PRESSURE_TREND \
 	BT_UUID_DECLARE_16(BT_UUID_BAR_PRESSURE_TREND_VAL)
-/** @def BT_UUID_BMS_CONTROL_POINT_VAL
+/**
  *  @brief Bond Management Control Point UUID value
  */
 #define BT_UUID_BMS_CONTROL_POINT_VAL 0x2aa4
-/** @def BT_UUID_BMS_CONTROL_POINT
+/**
  *  @brief Bond Management Control Point
  */
 #define BT_UUID_BMS_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_BMS_CONTROL_POINT_VAL)
-/** @def BT_UUID_BMS_FEATURE_VAL
+/**
  *  @brief Bond Management Feature UUID value
  */
 #define BT_UUID_BMS_FEATURE_VAL 0x2aa5
-/** @def BT_UUID_BMS_FEATURE
+/**
  *  @brief Bond Management Feature
  */
 #define BT_UUID_BMS_FEATURE \
 	BT_UUID_DECLARE_16(BT_UUID_BMS_FEATURE_VAL)
-/** @def BT_UUID_CENTRAL_ADDR_RES_VAL
+/**
  *  @brief Central Address Resolution Characteristic UUID value
  */
 #define BT_UUID_CENTRAL_ADDR_RES_VAL 0x2aa6
-/** @def BT_UUID_CENTRAL_ADDR_RES
+/**
  *  @brief Central Address Resolution Characteristic
  */
 #define BT_UUID_CENTRAL_ADDR_RES \
 	BT_UUID_DECLARE_16(BT_UUID_CENTRAL_ADDR_RES_VAL)
-/** @def BT_UUID_CGM_MEASUREMENT_VAL
+/**
  *  @brief CGM Measurement Characteristic value
  */
 #define BT_UUID_CGM_MEASUREMENT_VAL 0x2aa7
-/** @def BT_UUID_CGM_MEASUREMENT
+/**
  *  @brief CGM Measurement Characteristic
  */
 #define BT_UUID_CGM_MEASUREMENT \
 	BT_UUID_DECLARE_16(BT_UUID_CGM_MEASUREMENT_VAL)
-/** @def BT_UUID_CGM_FEATURE_VAL
+/**
  *  @brief CGM Feature Characteristic value
  */
 #define BT_UUID_CGM_FEATURE_VAL 0x2aa8
-/** @def BT_UUID_CGM_FEATURE
+/**
  *  @brief CGM Feature Characteristic
  */
 #define BT_UUID_CGM_FEATURE \
 	BT_UUID_DECLARE_16(BT_UUID_CGM_FEATURE_VAL)
-/** @def BT_UUID_CGM_STATUS_VAL
+/**
  *  @brief CGM Status Characteristic value
  */
 #define BT_UUID_CGM_STATUS_VAL 0x2aa9
-/** @def BT_UUID_CGM_STATUS
+/**
  *  @brief CGM Status Characteristic
  */
 #define BT_UUID_CGM_STATUS \
 	BT_UUID_DECLARE_16(BT_UUID_CGM_STATUS_VAL)
-/** @def BT_UUID_CGM_SESSION_START_TIME_VAL
+/**
  *  @brief CGM Session Start Time Characteristic value
  */
 #define BT_UUID_CGM_SESSION_START_TIME_VAL 0x2aaa
-/** @def BT_UUID_CGM_SESSION_START_TIME
+/**
  *  @brief CGM Session Start Time
  */
 #define BT_UUID_CGM_SESSION_START_TIME \
 	BT_UUID_DECLARE_16(BT_UUID_CGM_SESSION_START_TIME_VAL)
-/** @def BT_UUID_CGM_SESSION_RUN_TIME_VAL
+/**
  *  @brief CGM Session Run Time Characteristic value
  */
 #define BT_UUID_CGM_SESSION_RUN_TIME_VAL 0x2aab
-/** @def BT_UUID_CGM_SESSION_RUN_TIME
+/**
  *  @brief CGM Session Run Time
  */
 #define BT_UUID_CGM_SESSION_RUN_TIME \
 	BT_UUID_DECLARE_16(BT_UUID_CGM_SESSION_RUN_TIME_VAL)
-/** @def BT_UUID_CGM_SPECIFIC_OPS_CONTROL_POINT_VAL
+/**
  *  @brief CGM Specific Ops Control Point Characteristic value
  */
 #define BT_UUID_CGM_SPECIFIC_OPS_CONTROL_POINT_VAL 0x2aac
-/** @def BT_UUID_CGM_SPECIFIC_OPS_CONTROL_POINT
+/**
  *  @brief CGM Specific Ops Control Point
  */
 #define BT_UUID_CGM_SPECIFIC_OPS_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_CGM_SPECIFIC_OPS_CONTROL_POINT_VAL)
-/** @def BT_UUID_URI_VAL
+/**
  *  @brief URI UUID value
  */
 #define BT_UUID_URI_VAL 0x2ab6
-/** @def BT_UUID_URI
+/**
  *  @brief URI
  */
 #define BT_UUID_URI \
 	BT_UUID_DECLARE_16(BT_UUID_URI_VAL)
-/** @def BT_UUID_HTTP_HEADERS_VAL
+/**
  *  @brief HTTP Headers UUID value
  */
 #define BT_UUID_HTTP_HEADERS_VAL 0x2ab7
-/** @def BT_UUID_HTTP_HEADERS
+/**
  *  @brief HTTP Headers
  */
 #define BT_UUID_HTTP_HEADERS \
 	BT_UUID_DECLARE_16(BT_UUID_HTTP_HEADERS_VAL)
-/** @def BT_UUID_HTTP_STATUS_CODE_VAL
+/**
  *  @brief HTTP Status Code UUID value
  */
 #define BT_UUID_HTTP_STATUS_CODE_VAL 0x2ab8
-/** @def BT_UUID_HTTP_STATUS_CODE
+/**
  *  @brief HTTP Status Code
  */
 #define BT_UUID_HTTP_STATUS_CODE \
 	BT_UUID_DECLARE_16(BT_UUID_HTTP_STATUS_CODE_VAL)
-/** @def BT_UUID_HTTP_ENTITY_BODY_VAL
+/**
  *  @brief HTTP Entity Body UUID value
  */
 #define BT_UUID_HTTP_ENTITY_BODY_VAL 0x2ab9
-/** @def BT_UUID_HTTP_ENTITY_BODY
+/**
  *  @brief HTTP Entity Body
  */
 #define BT_UUID_HTTP_ENTITY_BODY \
 	BT_UUID_DECLARE_16(BT_UUID_HTTP_ENTITY_BODY_VAL)
-/** @def BT_UUID_HTTP_CONTROL_POINT_VAL
+/**
  *  @brief HTTP Control Point UUID value
  */
 #define BT_UUID_HTTP_CONTROL_POINT_VAL 0x2aba
-/** @def BT_UUID_HTTP_CONTROL_POINT
+/**
  *  @brief HTTP Control Point
  */
 #define BT_UUID_HTTP_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_HTTP_CONTROL_POINT_VAL)
-/** @def BT_UUID_HTTPS_SECURITY_VAL
+/**
  *  @brief HTTPS Security UUID value
  */
 #define BT_UUID_HTTPS_SECURITY_VAL 0x2abb
-/** @def BT_UUID_HTTPS_SECURITY
+/**
  *  @brief HTTPS Security
  */
 #define BT_UUID_HTTPS_SECURITY \
 	BT_UUID_DECLARE_16(BT_UUID_HTTPS_SECURITY_VAL)
-/** @def BT_UUID_OTS_FEATURE_VAL
+/**
  *  @brief OTS Feature Characteristic UUID value
  */
 #define BT_UUID_OTS_FEATURE_VAL 0x2abd
-/** @def BT_UUID_OTS_FEATURE
+/**
  *  @brief OTS Feature Characteristic
  */
 #define BT_UUID_OTS_FEATURE \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_FEATURE_VAL)
-/** @def BT_UUID_OTS_NAME_VAL
+/**
  *  @brief OTS Object Name Characteristic UUID value
  */
 #define BT_UUID_OTS_NAME_VAL 0x2abe
-/** @def BT_UUID_OTS_NAME
+/**
  *  @brief OTS Object Name Characteristic
  */
 #define BT_UUID_OTS_NAME \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_NAME_VAL)
-/** @def BT_UUID_OTS_TYPE_VAL
+/**
  *  @brief OTS Object Type Characteristic UUID value
  */
 #define BT_UUID_OTS_TYPE_VAL 0x2abf
-/** @def BT_UUID_OTS_TYPE
+/**
  *  @brief OTS Object Type Characteristic
  */
 #define BT_UUID_OTS_TYPE \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_TYPE_VAL)
-/** @def BT_UUID_OTS_SIZE_VAL
+/**
  *  @brief OTS Object Size Characteristic UUID value
  */
 #define BT_UUID_OTS_SIZE_VAL 0x2ac0
-/** @def BT_UUID_OTS_SIZE
+/**
  *  @brief OTS Object Size Characteristic
  */
 #define BT_UUID_OTS_SIZE \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_SIZE_VAL)
-/** @def BT_UUID_OTS_FIRST_CREATED_VAL
+/**
  *  @brief OTS Object First-Created Characteristic UUID value
  */
 #define BT_UUID_OTS_FIRST_CREATED_VAL 0x2ac1
-/** @def BT_UUID_OTS_FIRST_CREATED
+/**
  *  @brief OTS Object First-Created Characteristic
  */
 #define BT_UUID_OTS_FIRST_CREATED \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_FIRST_CREATED_VAL)
-/** @def BT_UUID_OTS_LAST_MODIFIED_VAL
+/**
  *  @brief OTS Object Last-Modified Characteristic UUI value
  */
 #define BT_UUID_OTS_LAST_MODIFIED_VAL 0x2ac2
-/** @def BT_UUID_OTS_LAST_MODIFIED
+/**
  *  @brief OTS Object Last-Modified Characteristic
  */
 #define BT_UUID_OTS_LAST_MODIFIED \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_LAST_MODIFIED_VAL)
-/** @def BT_UUID_OTS_ID_VAL
+/**
  *  @brief OTS Object ID Characteristic UUID value
  */
 #define BT_UUID_OTS_ID_VAL 0x2ac3
-/** @def BT_UUID_OTS_ID
+/**
  *  @brief OTS Object ID Characteristic
  */
 #define BT_UUID_OTS_ID \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_ID_VAL)
-/** @def BT_UUID_OTS_PROPERTIES_VAL
+/**
  *  @brief OTS Object Properties Characteristic UUID value
  */
 #define BT_UUID_OTS_PROPERTIES_VAL 0x2ac4
-/** @def BT_UUID_OTS_PROPERTIES
+/**
  *  @brief OTS Object Properties Characteristic
  */
 #define BT_UUID_OTS_PROPERTIES \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_PROPERTIES_VAL)
-/** @def BT_UUID_OTS_ACTION_CP_VAL
+/**
  *  @brief OTS Object Action Control Point Characteristic UUID value
  */
 #define BT_UUID_OTS_ACTION_CP_VAL 0x2ac5
-/** @def BT_UUID_OTS_ACTION_CP
+/**
  *  @brief OTS Object Action Control Point Characteristic
  */
 #define BT_UUID_OTS_ACTION_CP \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_ACTION_CP_VAL)
-/** @def BT_UUID_OTS_LIST_CP_VAL
+/**
  *  @brief OTS Object List Control Point Characteristic UUID value
  */
 #define BT_UUID_OTS_LIST_CP_VAL 0x2ac6
-/** @def BT_UUID_OTS_LIST_CP
+/**
  *  @brief OTS Object List Control Point Characteristic
  */
 #define BT_UUID_OTS_LIST_CP \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_LIST_CP_VAL)
-/** @def BT_UUID_OTS_LIST_FILTER_VAL
+/**
  *  @brief OTS Object List Filter Characteristic UUID value
  */
 #define BT_UUID_OTS_LIST_FILTER_VAL 0x2ac7
-/** @def BT_UUID_OTS_LIST_FILTER
+/**
  *  @brief OTS Object List Filter Characteristic
  */
 #define BT_UUID_OTS_LIST_FILTER \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_LIST_FILTER_VAL)
-/** @def BT_UUID_OTS_CHANGED_VAL
+/**
  *  @brief OTS Object Changed Characteristic UUID value
  */
 #define BT_UUID_OTS_CHANGED_VAL 0x2ac8
-/** @def BT_UUID_OTS_CHANGED
+/**
  *  @brief OTS Object Changed Characteristic
  */
 #define BT_UUID_OTS_CHANGED \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_CHANGED_VAL)
-/** @def BT_UUID_OTS_TYPE_UNSPECIFIED_VAL
+/**
  *  @brief OTS Unspecified Object Type UUID value
  */
 #define BT_UUID_OTS_TYPE_UNSPECIFIED_VAL 0x2aca
-/** @def BT_UUID_OTS_TYPE_UNSPECIFIED
+/**
  *  @brief OTS Unspecified Object Type
  */
 #define BT_UUID_OTS_TYPE_UNSPECIFIED \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_TYPE_UNSPECIFIED_VAL)
-/** @def BT_UUID_OTS_DIRECTORY_LISTING_VAL
+/**
  *  @brief OTS Directory Listing UUID value
  */
 #define BT_UUID_OTS_DIRECTORY_LISTING_VAL 0x2acb
-/** @def BT_UUID_OTS_DIRECTORY_LISTING
+/**
  *  @brief OTS Directory Listing
  */
 #define BT_UUID_OTS_DIRECTORY_LISTING \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_DIRECTORY_LISTING_VAL)
-/** @def BT_UUID_MESH_PROV_DATA_IN_VAL
+/**
  *  @brief Mesh Provisioning Data In UUID value
  */
 #define BT_UUID_MESH_PROV_DATA_IN_VAL 0x2adb
-/** @def BT_UUID_MESH_PROV_DATA_IN
+/**
  *  @brief Mesh Provisioning Data In
  */
 #define BT_UUID_MESH_PROV_DATA_IN \
 	BT_UUID_DECLARE_16(BT_UUID_MESH_PROV_DATA_IN_VAL)
-/** @def BT_UUID_MESH_PROV_DATA_OUT_VAL
+/**
  *  @brief Mesh Provisioning Data Out UUID value
  */
 #define BT_UUID_MESH_PROV_DATA_OUT_VAL 0x2adc
-/** @def BT_UUID_MESH_PROV_DATA_OUT
+/**
  *  @brief Mesh Provisioning Data Out
  */
 #define BT_UUID_MESH_PROV_DATA_OUT \
 	BT_UUID_DECLARE_16(BT_UUID_MESH_PROV_DATA_OUT_VAL)
-/** @def BT_UUID_MESH_PROXY_DATA_IN_VAL
+/**
  *  @brief Mesh Proxy Data In UUID value
  */
 #define BT_UUID_MESH_PROXY_DATA_IN_VAL 0x2add
-/** @def BT_UUID_MESH_PROXY_DATA_IN
+/**
  *  @brief Mesh Proxy Data In
  */
 #define BT_UUID_MESH_PROXY_DATA_IN \
 	BT_UUID_DECLARE_16(BT_UUID_MESH_PROXY_DATA_IN_VAL)
-/** @def BT_UUID_MESH_PROXY_DATA_OUT_VAL
+/**
  *  @brief Mesh Proxy Data Out UUID value
  */
 #define BT_UUID_MESH_PROXY_DATA_OUT_VAL 0x2ade
-/** @def BT_UUID_MESH_PROXY_DATA_OUT
+/**
  *  @brief Mesh Proxy Data Out
  */
 #define BT_UUID_MESH_PROXY_DATA_OUT \
 	BT_UUID_DECLARE_16(BT_UUID_MESH_PROXY_DATA_OUT_VAL)
-/** @def BT_UUID_GATT_CLIENT_FEATURES_VAL
+/**
  *  @brief Client Supported Features UUID value
  */
 #define BT_UUID_GATT_CLIENT_FEATURES_VAL 0x2b29
-/** @def BT_UUID_GATT_CLIENT_FEATURES
+/**
  *  @brief Client Supported Features
  */
 #define BT_UUID_GATT_CLIENT_FEATURES \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_CLIENT_FEATURES_VAL)
-/** @def BT_UUID_GATT_DB_HASH_VAL
+/**
  *  @brief Database Hash UUID value
  */
 #define BT_UUID_GATT_DB_HASH_VAL 0x2b2a
-/** @def BT_UUID_GATT_DB_HASH
+/**
  *  @brief Database Hash
  */
 #define BT_UUID_GATT_DB_HASH \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_DB_HASH_VAL)
 
-/** @def BT_UUID_GATT_SERVER_FEATURES_VAL
+/**
  *  @brief Server Supported Features UUID value
  */
 #define BT_UUID_GATT_SERVER_FEATURES_VAL  0x2b3a
-/** @def BT_UUID_GATT_SERVER_FEATURES
+/**
  *  @brief Server Supported Features
  */
 #define BT_UUID_GATT_SERVER_FEATURES      \
 	BT_UUID_DECLARE_16(BT_UUID_GATT_SERVER_FEATURES_VAL)
 
-/** @def BT_UUID_AICS_STATE_VAL
+/**
  *  @brief Audio Input Control Service State value
  */
 #define BT_UUID_AICS_STATE_VAL 0x2B77
-/** @def BT_UUID_AICS_STATE
+/**
  *  @brief Audio Input Control Service State
  */
 #define BT_UUID_AICS_STATE \
 	BT_UUID_DECLARE_16(BT_UUID_AICS_STATE_VAL)
-/** @def BT_UUID_AICS_GAIN_SETTINGS_VAL
+/**
  *  @brief Audio Input Control Service Gain Settings Properties value
  */
 #define BT_UUID_AICS_GAIN_SETTINGS_VAL 0x2B78
-/** @def BT_UUID_AICS_GAIN_SETTINGS
+/**
  *  @brief Audio Input Control Service Gain Settings Properties
  */
 #define BT_UUID_AICS_GAIN_SETTINGS \
 	BT_UUID_DECLARE_16(BT_UUID_AICS_GAIN_SETTINGS_VAL)
-/** @def BT_UUID_AICS_INPUT_TYPE_VAL
+/**
  *  @brief Audio Input Control Service Input Type value
  */
 #define BT_UUID_AICS_INPUT_TYPE_VAL 0x2B79
-/** @def BT_UUID_AICS_INPUT_TYPE
+/**
  *  @brief Audio Input Control Service Input Type
  */
 #define BT_UUID_AICS_INPUT_TYPE \
 	BT_UUID_DECLARE_16(BT_UUID_AICS_INPUT_TYPE_VAL)
-/** @def BT_UUID_AICS_INPUT_STATUS_VAL
+/**
  *  @brief Audio Input Control Service Input Status value
  */
 #define BT_UUID_AICS_INPUT_STATUS_VAL 0x2B7A
-/** @def BT_UUID_AICS_INPUT_STATUS
+/**
  *  @brief Audio Input Control Service Input Status
  */
 #define BT_UUID_AICS_INPUT_STATUS \
 	BT_UUID_DECLARE_16(BT_UUID_AICS_INPUT_STATUS_VAL)
-/** @def BT_UUID_AICS_CONTROL_VAL
+/**
  *  @brief Audio Input Control Service Control Point value
  */
 #define BT_UUID_AICS_CONTROL_VAL 0x2B7B
-/** @def BT_UUID_AICS_CONTROL
+/**
  *  @brief Audio Input Control Service Control Point
  */
 #define BT_UUID_AICS_CONTROL \
 	BT_UUID_DECLARE_16(BT_UUID_AICS_CONTROL_VAL)
-/** @def BT_UUID_AICS_DESCRIPTION_VAL
+/**
  *  @brief Audio Input Control Service Input Description value
  */
 #define BT_UUID_AICS_DESCRIPTION_VAL 0x2B7C
-/** @def BT_UUID_AICS_DESCRIPTION
+/**
  *  @brief Audio Input Control Service Input Description
  */
 #define BT_UUID_AICS_DESCRIPTION \
 	BT_UUID_DECLARE_16(BT_UUID_AICS_DESCRIPTION_VAL)
-/** @def BT_UUID_VCS_STATE_VAL
+/**
  *  @brief Volume Control Setting value
  */
 #define BT_UUID_VCS_STATE_VAL 0x2B7D
-/** @def BT_UUID_VCS_STATE
+/**
  *  @brief Volume Control Setting
  */
 #define BT_UUID_VCS_STATE \
 	BT_UUID_DECLARE_16(BT_UUID_VCS_STATE_VAL)
-/** @def BT_UUID_VCS_CONTROL_VAL
+/**
  *  @brief Volume Control Control point value
  */
 #define BT_UUID_VCS_CONTROL_VAL 0x2B7E
-/** @def BT_UUID_VCS_CONTROL
+/**
  *  @brief Volume Control Control point
  */
 #define BT_UUID_VCS_CONTROL \
 	BT_UUID_DECLARE_16(BT_UUID_VCS_CONTROL_VAL)
-/** @def BT_UUID_VCS_FLAGS_VAL
+/**
  *  @brief Volume Control Flags value
  */
 #define BT_UUID_VCS_FLAGS_VAL 0x2B7F
-/** @def BT_UUID_VCS_FLAGS
+/**
  *  @brief Volume Control Flags
  */
 #define BT_UUID_VCS_FLAGS \
 	BT_UUID_DECLARE_16(BT_UUID_VCS_FLAGS_VAL)
-/** @def BT_UUID_VOCS_STATE_VAL
+/**
  *  @brief Volume Offset State value
  */
 #define BT_UUID_VOCS_STATE_VAL 0x2B80
-/** @def BT_UUID_VOCS_STATE
+/**
  *  @brief Volume Offset State
  */
 #define BT_UUID_VOCS_STATE \
 	BT_UUID_DECLARE_16(BT_UUID_VOCS_STATE_VAL)
-/** @def BT_UUID_VOCS_LOCATION_VAL
+/**
  *  @brief Audio Location value
  */
 #define BT_UUID_VOCS_LOCATION_VAL 0x2B81
-/** @def BT_UUID_VOCS_LOCATION
+/**
  *  @brief Audio Location
  */
 #define BT_UUID_VOCS_LOCATION \
 	BT_UUID_DECLARE_16(BT_UUID_VOCS_LOCATION_VAL)
-/** @def BT_UUID_VOCS_CONTROL_VAL
+/**
  *  @brief Volume Offset Control Point value
  */
 #define BT_UUID_VOCS_CONTROL_VAL 0x2B82
-/** @def BT_UUID_VOCS_CONTROL
+/**
  *  @brief Volume Offset Control Point
  */
 #define BT_UUID_VOCS_CONTROL \
 	BT_UUID_DECLARE_16(BT_UUID_VOCS_CONTROL_VAL)
-/** @def BT_UUID_VOCS_DESCRIPTION_VAL
+/**
  *  @brief Volume Offset Audio Output Description value
  */
 #define BT_UUID_VOCS_DESCRIPTION_VAL 0x2B83
-/** @def BT_UUID_VOCS_DESCRIPTION
+/**
  *  @brief Volume Offset Audio Output Description
  */
 #define BT_UUID_VOCS_DESCRIPTION \
 	BT_UUID_DECLARE_16(BT_UUID_VOCS_DESCRIPTION_VAL)
-/** @def BT_UUID_CSIS_SET_SIRK_VAL
+/**
  *  @brief Set Identity Resolving Key value
  */
 #define BT_UUID_CSIS_SET_SIRK_VAL 0x2B84
-/** @def BT_UUID_CSIS_SET_SIRK
+/**
  *  @brief Set Identity Resolving Key
  */
 #define BT_UUID_CSIS_SET_SIRK \
 	BT_UUID_DECLARE_16(BT_UUID_CSIS_SET_SIRK_VAL)
-/** @def BT_UUID_CSIS_SET_SIZE_VAL
+/**
  *  @brief Set size value
  */
 #define BT_UUID_CSIS_SET_SIZE_VAL 0x2B85
-/** @def BT_UUID_CSIS_SET_SIZE
+/**
  *  @brief Set size
  */
 #define BT_UUID_CSIS_SET_SIZE \
 	BT_UUID_DECLARE_16(BT_UUID_CSIS_SET_SIZE_VAL)
-/** @def BT_UUID_CSIS_SET_LOCK_VAL
+/**
  *  @brief Set lock value
  */
 #define BT_UUID_CSIS_SET_LOCK_VAL 0x2B86
-/** @def BT_UUID_CSIS_SET_LOCK
+/**
  *  @brief Set lock
  */
 #define BT_UUID_CSIS_SET_LOCK \
 	BT_UUID_DECLARE_16(BT_UUID_CSIS_SET_LOCK_VAL)
-/** @def BT_UUID_CSIS_RANK_VAL
+/**
  *  @brief Rank value
  */
 #define BT_UUID_CSIS_RANK_VAL 0x2B87
-/** @def BT_UUID_CSIS_RANK
+/**
  *  @brief Rank
  */
 #define BT_UUID_CSIS_RANK \
 	BT_UUID_DECLARE_16(BT_UUID_CSIS_RANK_VAL)
-/** @def BT_UUID_MCS_PLAYER_NAME_VAL
+/**
  *  @brief Media player name value
  */
 #define BT_UUID_MCS_PLAYER_NAME_VAL 0x2B93
-/** @def BT_UUID_MCS_PLAYER_NAME
+/**
  *  @brief Media player name
  */
 #define BT_UUID_MCS_PLAYER_NAME \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_PLAYER_NAME_VAL)
-/** @def BT_UUID_MCS_ICON_OBJ_ID_VAL
+/**
  *  @brief Media Icon Object ID value
  */
 #define BT_UUID_MCS_ICON_OBJ_ID_VAL 0x2B94
-/** @def BT_UUID_MCS_ICON_OBJ_ID
+/**
  *  @brief Media Icon Object ID
  */
 #define BT_UUID_MCS_ICON_OBJ_ID \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_ICON_OBJ_ID_VAL)
-/** @def BT_UUID_MCS_ICON_URL_VAL
+/**
  *  @brief Media Icon URL value
  */
 #define BT_UUID_MCS_ICON_URL_VAL 0x2B95
-/** @def BT_UUID_MCS_ICON_URL
+/**
  *  @brief Media Icon URL
  */
 #define BT_UUID_MCS_ICON_URL \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_ICON_URL_VAL)
-/** @def BT_UUID_MCS_TRACK_CHANGED_VAL
+/**
  *  @brief Track Changed value
  */
 #define BT_UUID_MCS_TRACK_CHANGED_VAL 0x2B96
-/** @def BT_UUID_MCS_TRACK_CHANGED
+/**
  *  @brief Track Changed
  */
 #define BT_UUID_MCS_TRACK_CHANGED \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_TRACK_CHANGED_VAL)
-/** @def BT_UUID_MCS_TRACK_TITLE_VAL
+/**
  *  @brief Track Title value
  */
 #define BT_UUID_MCS_TRACK_TITLE_VAL 0x2B97
-/** @def BT_UUID_MCS_TRACK_TITLE
+/**
  *  @brief Track Title
  */
 #define BT_UUID_MCS_TRACK_TITLE \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_TRACK_TITLE_VAL)
-/** @def BT_UUID_MCS_TRACK_DURATION_VAL
+/**
  *  @brief Track Duration value
  */
 #define BT_UUID_MCS_TRACK_DURATION_VAL 0x2B98
-/** @def BT_UUID_MCS_TRACK_DURATION
+/**
  *  @brief Track Duration
  */
 #define BT_UUID_MCS_TRACK_DURATION \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_TRACK_DURATION_VAL)
-/** @def BT_UUID_MCS_TRACK_POSITION_VAL
+/**
  *  @brief Track Position value
  */
 #define BT_UUID_MCS_TRACK_POSITION_VAL 0x2B99
-/** @def BT_UUID_MCS_TRACK_POSITION
+/**
  *  @brief Track Position
  */
 #define BT_UUID_MCS_TRACK_POSITION \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_TRACK_POSITION_VAL)
-/** @def BT_UUID_MCS_PLAYBACK_SPEED_VAL
+/**
  *  @brief Playback Speed value
  */
 #define BT_UUID_MCS_PLAYBACK_SPEED_VAL 0x2B9A
-/** @def BT_UUID_MCS_PLAYBACK_SPEED
+/**
  *  @brief Playback Speed
  */
 #define BT_UUID_MCS_PLAYBACK_SPEED \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_PLAYBACK_SPEED_VAL)
-/** @def BT_UUID_MCS_SEEKING_SPEED_VAL
+/**
  *  @brief Seeking Speed value
  */
 #define BT_UUID_MCS_SEEKING_SPEED_VAL 0x2B9B
-/** @def BT_UUID_MCS_SEEKING_SPEED
+/**
  *  @brief Seeking Speed
  */
 #define BT_UUID_MCS_SEEKING_SPEED \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_SEEKING_SPEED_VAL)
-/** @def BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID_VAL
+/**
  *  @brief Track Segments Object ID value
  */
 #define BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID_VAL 0x2B9C
-/** @def BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID
+/**
  *  @brief Track Segments Object ID
  */
 #define BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID_VAL)
-/** @def BT_UUID_MCS_CURRENT_TRACK_OBJ_ID_VAL
+/**
  *  @brief Current Track Object ID value
  */
 #define BT_UUID_MCS_CURRENT_TRACK_OBJ_ID_VAL 0x2B9D
-/** @def BT_UUID_MCS_CURRENT_TRACK_OBJ_ID
+/**
  *  @brief Current Track Object ID
  */
 #define BT_UUID_MCS_CURRENT_TRACK_OBJ_ID \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_CURRENT_TRACK_OBJ_ID_VAL)
-/** @def BT_UUID_MCS_NEXT_TRACK_OBJ_ID_VAL
+/**
  *  @brief Next Track Object ID value
  */
 #define BT_UUID_MCS_NEXT_TRACK_OBJ_ID_VAL 0x2B9E
-/** @def BT_UUID_MCS_NEXT_TRACK_OBJ_ID
+/**
  *  @brief Next Track Object ID
  */
 #define BT_UUID_MCS_NEXT_TRACK_OBJ_ID \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_NEXT_TRACK_OBJ_ID_VAL)
-/** @def BT_UUID_MCS_PARENT_GROUP_OBJ_ID_VAL
+/**
  *  @brief Parent Group Object ID value
  */
 #define BT_UUID_MCS_PARENT_GROUP_OBJ_ID_VAL 0x2B9F
-/** @def BT_UUID_MCS_PARENT_GROUP_OBJ_ID
+/**
  *  @brief Parent Group Object ID
  */
 #define BT_UUID_MCS_PARENT_GROUP_OBJ_ID \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_PARENT_GROUP_OBJ_ID_VAL)
-/** @def BT_UUID_MCS_CURRENT_GROUP_OBJ_ID_VAL
+/**
  *  @brief Group Object ID value
  */
 #define BT_UUID_MCS_CURRENT_GROUP_OBJ_ID_VAL 0x2BA0
-/** @def BT_UUID_MCS_CURRENT_GROUP_OBJ_ID
+/**
  *  @brief Group Object ID
  */
 #define BT_UUID_MCS_CURRENT_GROUP_OBJ_ID \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_CURRENT_GROUP_OBJ_ID_VAL)
-/** @def BT_UUID_MCS_PLAYING_ORDER_VAL
+/**
  *  @brief Playing Order value
  */
 #define BT_UUID_MCS_PLAYING_ORDER_VAL 0x2BA1
-/** @def BT_UUID_MCS_PLAYING_ORDER
+/**
  *  @brief Playing Order
  */
 #define BT_UUID_MCS_PLAYING_ORDER \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_PLAYING_ORDER_VAL)
-/** @def BT_UUID_MCS_PLAYING_ORDERS_VAL
+/**
  *  @brief Playing Orders supported value
  */
 #define BT_UUID_MCS_PLAYING_ORDERS_VAL 0x2BA2
-/** @def BT_UUID_MCS_PLAYING_ORDERS
+/**
  *  @brief Playing Orders supported
  */
 #define BT_UUID_MCS_PLAYING_ORDERS \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_PLAYING_ORDERS_VAL)
-/** @def BT_UUID_MCS_MEDIA_STATE_VAL
+/**
  *  @brief Media State value
  */
 #define BT_UUID_MCS_MEDIA_STATE_VAL 0x2BA3
-/** @def BT_UUID_MCS_MEDIA_STATE
+/**
  *  @brief Media State
  */
 #define BT_UUID_MCS_MEDIA_STATE \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_MEDIA_STATE_VAL)
-/** @def BT_UUID_MCS_MEDIA_CONTROL_POINT_VAL
+/**
  *  @brief Media Control Point value
  */
 #define BT_UUID_MCS_MEDIA_CONTROL_POINT_VAL 0x2BA4
-/** @def BT_UUID_MCS_MEDIA_CONTROL_POINT
+/**
  *  @brief Media Control Point
  */
 #define BT_UUID_MCS_MEDIA_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_MEDIA_CONTROL_POINT_VAL)
-/** @def BT_UUID_MCS_MEDIA_CONTROL_OPCODES_VAL
+/**
  *  @brief Media control opcodes supported value
  */
 #define BT_UUID_MCS_MEDIA_CONTROL_OPCODES_VAL 0x2BA5
-/** @def BT_UUID_MCS_MEDIA_CONTROL_OPCODES
+/**
  *  @brief Media control opcodes supported
  */
 #define BT_UUID_MCS_MEDIA_CONTROL_OPCODES \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_MEDIA_CONTROL_OPCODES_VAL)
-/** @def BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID_VAL
+/**
  *  @brief Search result object ID value
  */
 #define BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID_VAL 0x2BA6
-/** @def BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID
+/**
  *  @brief Search result object ID
  */
 #define BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID_VAL)
-/** @def BT_UUID_MCS_SEARCH_CONTROL_POINT_VAL
+/**
  *  @brief Search control point value
  */
 #define BT_UUID_MCS_SEARCH_CONTROL_POINT_VAL 0x2BA7
-/** @def BT_UUID_MCS_SEARCH_CONTROL_POINT
+/**
  *  @brief Search control point
  */
 #define BT_UUID_MCS_SEARCH_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_MCS_SEARCH_CONTROL_POINT_VAL)
-/** @def BT_UUID_OTS_TYPE_MPL_ICON_VAL
+/**
  *  @brief Media Player Icon Object Type value
  */
 #define BT_UUID_OTS_TYPE_MPL_ICON_VAL 0x2BA9
-/** @def BT_UUID_OTS_TYPE_MPL_ICON
+/**
  *  @brief Media Player Icon Object Type
  */
 #define BT_UUID_OTS_TYPE_MPL_ICON \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_TYPE_MPL_ICON_VAL)
-/** @def BT_UUID_OTS_TYPE_TRACK_SEGMENT_VAL
+/**
  *  @brief Track Segments Object Type value
  */
 #define BT_UUID_OTS_TYPE_TRACK_SEGMENT_VAL 0x2BAA
-/** @def BT_UUID_OTS_TYPE_TRACK_SEGMENT
+/**
  *  @brief Track Segments Object Type
  */
 #define BT_UUID_OTS_TYPE_TRACK_SEGMENT \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_TYPE_TRACK_SEGMENT_VAL)
-/** @def BT_UUID_OTS_TYPE_TRACK_VAL
+/**
  *  @brief Track Object Type value
  */
 #define BT_UUID_OTS_TYPE_TRACK_VAL 0x2BAB
-/** @def BT_UUID_OTS_TYPE_TRACK
+/**
  *  @brief Track Object Type
  */
 #define BT_UUID_OTS_TYPE_TRACK \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_TYPE_TRACK_VAL)
-/** @def BT_UUID_OTS_TYPE_GROUP_VAL
+/**
  *  @brief Group Object Type value
  */
 #define BT_UUID_OTS_TYPE_GROUP_VAL 0x2BAC
-/** @def BT_UUID_OTS_TYPE_GROUP
+/**
  *  @brief Group Object Type
  */
 #define BT_UUID_OTS_TYPE_GROUP \
 	BT_UUID_DECLARE_16(BT_UUID_OTS_TYPE_GROUP_VAL)
-/** @def BT_UUID_TBS_PROVIDER_NAME_VAL
+/**
  *  @brief Bearer Provider Name value
  */
 #define BT_UUID_TBS_PROVIDER_NAME_VAL 0x2BB3
-/** @def BT_UUID_TBS_PROVIDER_NAME
+/**
  *  @brief Bearer Provider Name
  */
 #define BT_UUID_TBS_PROVIDER_NAME \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_PROVIDER_NAME_VAL)
-/** @def BT_UUID_TBS_UCI_VAL
+/**
  *  @brief Bearer UCI value
  */
 #define BT_UUID_TBS_UCI_VAL 0x2BB4
-/** @def BT_UUID_TBS_UCI
+/**
  *  @brief Bearer UCI
  */
 #define BT_UUID_TBS_UCI \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_UCI_VAL)
-/** @def BT_UUID_TBS_TECHNOLOGY_VAL
+/**
  *  @brief Bearer Technology value
  */
 #define BT_UUID_TBS_TECHNOLOGY_VAL 0x2BB5
-/** @def BT_UUID_TBS_TECHNOLOGY
+/**
  *  @brief Bearer Technology
  */
 #define BT_UUID_TBS_TECHNOLOGY \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_TECHNOLOGY_VAL)
-/** @def BT_UUID_TBS_URI_LIST_VAL
+/**
  *  @brief Bearer URI Prefixes Supported List value
  */
 #define BT_UUID_TBS_URI_LIST_VAL 0x2BB6
-/** @def BT_UUID_TBS_URI_LIST
+/**
  *  @brief Bearer URI Prefixes Supported List
  */
 #define BT_UUID_TBS_URI_LIST \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_URI_LIST_VAL)
-/** @def BT_UUID_TBS_SIGNAL_STRENGTH_VAL
+/**
  *  @brief Bearer Signal Strength value
  */
 #define BT_UUID_TBS_SIGNAL_STRENGTH_VAL 0x2BB7
-/** @def BT_UUID_TBS_SIGNAL_STRENGTH
+/**
  *  @brief Bearer Signal Strength
  */
 #define BT_UUID_TBS_SIGNAL_STRENGTH \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_SIGNAL_STRENGTH_VAL)
-/** @def BT_UUID_TBS_SIGNAL_INTERVAL_VAL
+/**
  *  @brief Bearer Signal Strength Reporting Interval value
  */
 #define BT_UUID_TBS_SIGNAL_INTERVAL_VAL 0x2BB8
-/** @def BT_UUID_TBS_SIGNAL_INTERVAL
+/**
  *  @brief Bearer Signal Strength Reporting Interval
  */
 #define BT_UUID_TBS_SIGNAL_INTERVAL \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_SIGNAL_INTERVAL_VAL)
-/** @def BT_UUID_TBS_LIST_CURRENT_CALLS_VAL
+/**
  *  @brief Bearer List Current Calls value
  */
 #define BT_UUID_TBS_LIST_CURRENT_CALLS_VAL 0x2BB9
-/** @def BT_UUID_TBS_LIST_CURRENT_CALLS
+/**
  *  @brief Bearer List Current Calls
  */
 #define BT_UUID_TBS_LIST_CURRENT_CALLS \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_LIST_CURRENT_CALLS_VAL)
-/** @def BT_UUID_CCID_VAL
+/**
  *  @brief Content Control ID value
  */
 #define BT_UUID_CCID_VAL 0x2BBA
-/** @def BT_UUID_CCID
+/**
  *  @brief Content Control ID
  */
 #define BT_UUID_CCID \
 	BT_UUID_DECLARE_16(BT_UUID_CCID_VAL)
-/** @def BT_UUID_TBS_STATUS_FLAGS_VAL
+/**
  *  @brief Status flags value
  */
 #define BT_UUID_TBS_STATUS_FLAGS_VAL 0x2BBB
-/** @def BT_UUID_TBS_STATUS_FLAGS
+/**
  *  @brief Status flags
  */
 #define BT_UUID_TBS_STATUS_FLAGS \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_STATUS_FLAGS_VAL)
-/** @def BT_UUID_TBS_INCOMING_URI_VAL
+/**
  *  @brief Incoming Call Target Caller ID value
  */
 #define BT_UUID_TBS_INCOMING_URI_VAL 0x2BBC
-/** @def BT_UUID_TBS_INCOMING_URI
+/**
  *  @brief Incoming Call Target Caller ID
  */
 #define BT_UUID_TBS_INCOMING_URI \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_INCOMING_URI_VAL)
-/** @def BT_UUID_TBS_CALL_STATE_VAL
+/**
  *  @brief Call State value
  */
 #define BT_UUID_TBS_CALL_STATE_VAL 0x2BBD
-/** @def BT_UUID_TBS_CALL_STATE
+/**
  *  @brief Call State
  */
 #define BT_UUID_TBS_CALL_STATE \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_CALL_STATE_VAL)
-/** @def BT_UUID_TBS_CALL_CONTROL_POINT_VAL
+/**
  *  @brief Call Control Point value
  */
 #define BT_UUID_TBS_CALL_CONTROL_POINT_VAL 0x2BBE
-/** @def BT_UUID_TBS_CALL_CONTROL_POINT
+/**
  *  @brief Call Control Point
  */
 #define BT_UUID_TBS_CALL_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_CALL_CONTROL_POINT_VAL)
-/** @def BT_UUID_TBS_OPTIONAL_OPCODES_VAL
+/**
  *  @brief Optional Opcodes value
  */
 #define BT_UUID_TBS_OPTIONAL_OPCODES_VAL 0x2BBF
-/** @def BT_UUID_TBS_OPTIONAL_OPCODES
+/**
  *  @brief Optional Opcodes
  */
 #define BT_UUID_TBS_OPTIONAL_OPCODES \
@@ -2051,155 +2050,155 @@ struct bt_uuid_128 {
  */
 #define BT_UUID_TBS_TERMINATE_REASON \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_TERMINATE_REASON_VAL)
-/** @def BT_UUID_TBS_INCOMING_CALL_VAL
+/**
  *  @brief Incoming Call value
  */
 #define BT_UUID_TBS_INCOMING_CALL_VAL 0x2BC1
-/** @def BT_UUID_TBS_INCOMING_CALL
+/**
  *  @brief Incoming Call
  */
 #define BT_UUID_TBS_INCOMING_CALL \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_INCOMING_CALL_VAL)
-/** @def BT_UUID_TBS_FRIENDLY_NAME_VAL
+/**
  *  @brief Incoming Call Friendly name value
  */
 #define BT_UUID_TBS_FRIENDLY_NAME_VAL 0x2BC2
-/** @def BT_UUID_TBS_FRIENDLY_NAME
+/**
  *  @brief Incoming Call Friendly name
  */
 #define BT_UUID_TBS_FRIENDLY_NAME \
 	BT_UUID_DECLARE_16(BT_UUID_TBS_FRIENDLY_NAME_VAL)
-/** @def BT_UUID_MICS_MUTE_VAL
+/**
  *  @brief Microphone Input Control Service Mute value
  */
 #define BT_UUID_MICS_MUTE_VAL 0x2BC3
-/** @def BT_UUID_MICS_MUTE
+/**
  *  @brief Microphone Input Control Service Mute
  */
 #define BT_UUID_MICS_MUTE \
 	BT_UUID_DECLARE_16(BT_UUID_MICS_MUTE_VAL)
-/** @def BT_UUID_ASCS_ASE_SNK_VAL
+/**
  *  @brief Audio Stream Endpoint Sink Characteristic value
  */
 #define BT_UUID_ASCS_ASE_SNK_VAL 0x2BC4
-/** @def BT_UUID_ASCS_ASE_SNK
+/**
  *  @brief Audio Stream Endpoint Sink Characteristic
  */
 #define BT_UUID_ASCS_ASE_SNK \
 	BT_UUID_DECLARE_16(BT_UUID_ASCS_ASE_SNK_VAL)
-/** @def BT_UUID_ASCS_ASE_SRC_VAL
+/**
  *  @brief Audio Stream Endpoint Source Characteristic value
  */
 #define BT_UUID_ASCS_ASE_SRC_VAL 0x2BC5
-/** @def BT_UUID_ASCS_ASE_SNK
+/**
  *  @brief Audio Stream Endpoint Source Characteristic
  */
 #define BT_UUID_ASCS_ASE_SRC \
 	BT_UUID_DECLARE_16(BT_UUID_ASCS_ASE_SRC_VAL)
-/** @def BT_UUID_ASCS_ASE_CP_VAL
+/**
  *  @brief Audio Stream Endpoint Control Point Characteristic value
  */
 #define BT_UUID_ASCS_ASE_CP_VAL 0x2BC6
-/** @def BT_UUID_ASCS_ASE_CP
+/**
  *  @brief Audio Stream Endpoint Control Point Characteristic
  */
 #define BT_UUID_ASCS_ASE_CP \
 	BT_UUID_DECLARE_16(BT_UUID_ASCS_ASE_CP_VAL)
-/** @def BT_UUID_BASS_CONTROL_POINT_VAL
+/**
  *  @brief Broadcast Audio Scan Service Scan State value
  */
 #define BT_UUID_BASS_CONTROL_POINT_VAL 0x2BC7
-/** @def BT_UUID_BASS_CONTROL_POINT
+/**
  *  @brief Broadcast Audio Scan Service Scan State
  */
 #define BT_UUID_BASS_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_BASS_CONTROL_POINT_VAL)
-/** @def BT_UUID_BASS_RECV_STATE_VAL
+/**
  *  @brief Broadcast Audio Scan Service Receive State value
  */
 #define BT_UUID_BASS_RECV_STATE_VAL 0x2BC8
-/** @def BT_UUID_BASS_RECV_STATE
+/**
  *  @brief Broadcast Audio Scan Service Receive State
  */
 #define BT_UUID_BASS_RECV_STATE \
 	BT_UUID_DECLARE_16(BT_UUID_BASS_RECV_STATE_VAL)
-/** @def BT_UUID_PACS_SNK_VAL
+/**
  *  @brief Sink PAC Characteristic value
  */
 #define BT_UUID_PACS_SNK_VAL 0x2BC9
-/** @def BT_UUID_PACS_SNK
+/**
  *  @brief Sink PAC Characteristic
  */
 #define BT_UUID_PACS_SNK \
 	BT_UUID_DECLARE_16(BT_UUID_PACS_SNK_VAL)
-/** @def BT_UUID_PACS_SNK_LOC_VAL
+/**
  *  @brief Sink PAC Locations Characteristic value
  */
 #define BT_UUID_PACS_SNK_LOC_VAL 0x2BCA
-/** @def BT_UUID_PACS_SNK_LOC
+/**
  *  @brief Sink PAC Locations Characteristic
  */
 #define BT_UUID_PACS_SNK_LOC \
 	BT_UUID_DECLARE_16(BT_UUID_PACS_SNK_LOC_VAL)
-/** @def BT_UUID_PACS_SRC_VAL
+/**
  *  @brief Source PAC Characteristic value
  */
 #define BT_UUID_PACS_SRC_VAL 0x2BCB
-/** @def BT_UUID_PACS_SRC
+/**
  *  @brief Source PAC Characteristic
  */
 #define BT_UUID_PACS_SRC \
 	BT_UUID_DECLARE_16(BT_UUID_PACS_SRC_VAL)
-/** @def BT_UUID_PACS_SRC_LOC_VAL
+/**
  *  @brief Source PAC Locations Characteristic value
  */
 #define BT_UUID_PACS_SRC_LOC_VAL 0x2BCC
-/** @def BT_UUID_PACS_SRC_LOC
+/**
  *  @brief Source PAC Locations Characteristic
  */
 #define BT_UUID_PACS_SRC_LOC \
 	BT_UUID_DECLARE_16(BT_UUID_PACS_SRC_LOC_VAL)
-/** @def BT_UUID_PACS_AVAILABLE_CONTEXT_VAL
+/**
  *  @brief Available Audio Contexts Characteristic value
  */
 #define BT_UUID_PACS_AVAILABLE_CONTEXT_VAL 0x2BCD
-/** @def BT_UUID_PACS_AVAILABLE_CONTEXT
+/**
  *  @brief Available Audio Contexts Characteristic
  */
 #define BT_UUID_PACS_AVAILABLE_CONTEXT \
 	BT_UUID_DECLARE_16(BT_UUID_PACS_AVAILABLE_CONTEXT_VAL)
-/** @def BT_UUID_PACS_SUPPORTED_CONTEXT_VAL
+/**
  *  @brief Supported Audio Context Characteristic value
  */
 #define BT_UUID_PACS_SUPPORTED_CONTEXT_VAL 0x2BCE
-/** @def BT_UUID_PACS_SUPPORTED_CONTEXT
+/**
  *  @brief Supported Audio Context Characteristic
  */
 #define BT_UUID_PACS_SUPPORTED_CONTEXT \
 	BT_UUID_DECLARE_16(BT_UUID_PACS_SUPPORTED_CONTEXT_VAL)
-/** @def BT_UUID_HAS_HEARING_AID_FEATURES_VAL
+/**
  *  @brief Hearing Aid Features Characteristic value
  */
 #define BT_UUID_HAS_HEARING_AID_FEATURES_VAL 0x2BDA
-/** @def BT_UUID_HAS_HEARING_AID_FEATURES
+/**
  *  @brief Hearing Aid Features Characteristic
  */
 #define BT_UUID_HAS_HEARING_AID_FEATURES \
 	BT_UUID_DECLARE_16(BT_UUID_HAS_HEARING_AID_FEATURES_VAL)
-/** @def BT_UUID_HAS_PRESET_CONTROL_POINT_VAL
+/**
  *  @brief Hearing Aid Preset Control Point Characteristic value
  */
 #define BT_UUID_HAS_PRESET_CONTROL_POINT_VAL 0x2BDB
-/** @def BT_UUID_HAS_PRESET_CONTROL_POINT
+/**
  *  @brief Hearing Aid Preset Control Point Characteristic
  */
 #define BT_UUID_HAS_PRESET_CONTROL_POINT \
 	BT_UUID_DECLARE_16(BT_UUID_HAS_PRESET_CONTROL_POINT_VAL)
-/** @def BT_UUID_HAS_ACTIVE_PRESET_INDEX_VAL
+/**
  *  @brief Active Preset Index Characteristic value
  */
 #define BT_UUID_HAS_ACTIVE_PRESET_INDEX_VAL 0x2BDC
-/** @def BT_UUID_HAS_ACTIVE_PRESET_INDEX
+/**
  *  @brief Active Preset Index Characteristic
  */
 #define BT_UUID_HAS_ACTIVE_PRESET_INDEX \

--- a/include/zephyr/debug/object_tracing.h
+++ b/include/zephyr/debug/object_tracing.h
@@ -11,8 +11,6 @@
 #include <zephyr/kernel_structs.h>
 
 /**
- * @def SYS_THREAD_MONITOR_HEAD
- *
  * @brief Head element of the thread monitor list.
  *
  * @details Access the head element of the thread monitor list.
@@ -21,8 +19,6 @@
 #define SYS_THREAD_MONITOR_HEAD ((struct k_thread *)(_kernel.threads))
 
 /**
- * @def SYS_THREAD_MONITOR_NEXT
- *
  * @brief Gets a thread node's next element.
  *
  * @details Given a node in a thread monitor list, gets the next

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -72,8 +72,6 @@ typedef int16_t device_handle_t;
 #define Z_DEVICE_MAX_NAME_LEN	48
 
 /**
- * @def DEVICE_NAME_GET
- *
  * @brief Expands to the name of a global device object.
  *
  * @details Return the full name of a device object symbol created by
@@ -121,8 +119,6 @@ typedef int16_t device_handle_t;
 	__attribute__((__section__(".z_devstate")));
 
 /**
- * @def DEVICE_DEFINE
- *
  * @brief Create a device object and set it up for boot time initialization.
  *
  * @details This macro defines a <tt>struct device</tt> that is
@@ -172,8 +168,6 @@ typedef int16_t device_handle_t;
 			&Z_DEVICE_STATE_NAME(dev_name))
 
 /**
- * @def DEVICE_DT_NAME
- *
  * @brief Return a string name for a devicetree node.
  *
  * @details This macro returns a string literal usable as a device's
@@ -188,8 +182,6 @@ typedef int16_t device_handle_t;
 	DT_PROP_OR(node_id, label, DT_NODE_FULL_NAME(node_id))
 
 /**
- * @def DEVICE_DT_DEFINE
- *
  * @brief Create a device object from a devicetree node identifier and
  * set it up for boot time initialization.
  *
@@ -243,8 +235,6 @@ typedef int16_t device_handle_t;
 			__VA_ARGS__)
 
 /**
- * @def DEVICE_DT_INST_DEFINE
- *
  * @brief Like DEVICE_DT_DEFINE(), but uses an instance of a
  * DT_DRV_COMPAT compatible instead of a node identifier.
  *
@@ -257,8 +247,6 @@ typedef int16_t device_handle_t;
 	DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
- * @def DEVICE_DT_NAME_GET
- *
  * @brief The name of the global device object for @p node_id
  *
  * @details Returns the name of the global device structure as a C
@@ -276,8 +264,6 @@ typedef int16_t device_handle_t;
 #define DEVICE_DT_NAME_GET(node_id) DEVICE_NAME_GET(Z_DEVICE_DT_DEV_NAME(node_id))
 
 /**
- * @def DEVICE_DT_GET
- *
  * @brief Get a <tt>const struct device*</tt> from a devicetree node
  * identifier
  *
@@ -295,8 +281,7 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_DT_GET(node_id) (&DEVICE_DT_NAME_GET(node_id))
 
-/** @def DEVICE_DT_INST_GET
- *
+/**
  * @brief Get a <tt>const struct device*</tt> for an instance of a
  *        DT_DRV_COMPAT compatible
  *
@@ -308,8 +293,6 @@ typedef int16_t device_handle_t;
 #define DEVICE_DT_INST_GET(inst) DEVICE_DT_GET(DT_DRV_INST(inst))
 
 /**
- * @def DEVICE_DT_GET_ANY
- *
  * @brief Get a <tt>const struct device*</tt> from a devicetree compatible
  *
  * If an enabled devicetree node has the given compatible and a device
@@ -331,8 +314,6 @@ typedef int16_t device_handle_t;
 		    (NULL))
 
 /**
- * @def DEVICE_DT_GET_ONE
- *
  * @brief Get a <tt>const struct device*</tt> from a devicetree compatible
  *
  * @details If an enabled devicetree node has the given compatible and
@@ -355,8 +336,6 @@ typedef int16_t device_handle_t;
 		    (ZERO_OR_COMPILE_ERROR(0)))
 
 /**
- * @def DEVICE_DT_GET_OR_NULL
- *
  * @brief Utility macro to obtain an optional reference to a device.
  *
  * @details If the node identifier refers to a node with status
@@ -373,8 +352,6 @@ typedef int16_t device_handle_t;
 		    (DEVICE_DT_GET(node_id)), (NULL))
 
 /**
- * @def DEVICE_GET
- *
  * @brief Obtain a pointer to a device object by name
  *
  * @details Return the address of a device object created by
@@ -386,8 +363,7 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_GET(name) (&DEVICE_NAME_GET(name))
 
-/** @def DEVICE_DECLARE
- *
+/**
  * @brief Declare a static device object
  *
  * This macro can be used at the top-level to declare a device, such
@@ -404,8 +380,6 @@ typedef int16_t device_handle_t;
 #define DEVICE_DECLARE(name) static const struct device DEVICE_NAME_GET(name)
 
 /**
- * @def DEVICE_INIT_DT_GET
- *
  * @brief Get a <tt>const struct init_entry*</tt> from a devicetree node
  *
  * @param node_id A devicetree node identifier
@@ -415,8 +389,6 @@ typedef int16_t device_handle_t;
 #define DEVICE_INIT_DT_GET(node_id) (&Z_INIT_ENTRY_NAME(DEVICE_DT_NAME_GET(node_id)))
 
 /**
- * @def DEVICE_INIT_GET
- *
  * @brief Get a <tt>const struct init_entry*</tt> from a device by name
  *
  * @param name The same as dev_name provided to DEVICE_DEFINE()

--- a/include/zephyr/devicetree/zephyr.h
+++ b/include/zephyr/devicetree/zephyr.h
@@ -32,8 +32,6 @@
 
 #ifdef DT_DOXYGEN
 /**
- * @def DT_CHOSEN_ZEPHYR_ENTROPY_LABEL
- *
  * @deprecated Use @c DT_LABEL(DT_CHOSEN(zephyr_entropy)) instead. If used to
  * to obtain a device instance with device_get_binding(), consider using
  * @c DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy)).
@@ -44,8 +42,6 @@
 #define DT_CHOSEN_ZEPHYR_ENTROPY_LABEL ""
 
 /**
- * @def DT_CHOSEN_ZEPHYR_FLASH_CONTROLLER_LABEL
- *
  * @deprecated Use @c DT_LABEL(DT_CHOSEN(zephyr_flash_controller)) instead. If
  * used to to obtain a device instance with device_get_binding(), consider using
  * @c DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller)).

--- a/include/zephyr/display/mb_display.h
+++ b/include/zephyr/display/mb_display.h
@@ -69,7 +69,7 @@ enum mb_display_mode {
 };
 
 /**
- * @def MB_IMAGE
+ *
  * @brief Generate an image object from a given array rows/columns.
  *
  * This helper takes an array of 5 rows, each consisting of 5 0/1 values which

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -54,8 +54,6 @@ struct init_entry {
 void z_sys_init_run_level(int32_t level);
 
 /**
- * @def Z_SYS_NAME
- *
  * @brief Construct a namespaced identifier for SYS_INIT instance
  *
  * @param _name Base unique name
@@ -63,8 +61,6 @@ void z_sys_init_run_level(int32_t level);
 #define Z_SYS_NAME(_name) _CONCAT(sys_init_, _name)
 
 /**
- * @def Z_INIT_ENTRY_NAME
- *
  * @brief Construct a namespaced identifier for @ref init_entry instance
  *
  * @param _entry_name Base unique name
@@ -72,8 +68,6 @@ void z_sys_init_run_level(int32_t level);
 #define Z_INIT_ENTRY_NAME(_entry_name) _CONCAT(__init_, _entry_name)
 
 /**
- * @def Z_INIT_ENTRY_DEFINE
- *
  * @brief Create an init entry object and set it up for boot time initialization
  *
  * @details This macro defines an init entry object that will be automatically
@@ -104,8 +98,6 @@ void z_sys_init_run_level(int32_t level);
 	}
 
 /**
- * @def SYS_INIT
- *
  * @ingroup device_model
  *
  * @brief Run an initialization function at boot at specified priority
@@ -149,8 +141,6 @@ void z_sys_init_run_level(int32_t level);
 	SYS_INIT_NAMED(_init_fn, _init_fn, _level, _prio)
 
 /**
- * @def SYS_INIT_NAMED
- *
  * @ingroup device_model
  *
  * @brief Run an initialization function at boot at specified priority

--- a/include/zephyr/irq.h
+++ b/include/zephyr/irq.h
@@ -257,8 +257,6 @@ void z_smp_global_unlock(unsigned int key);
 
 /**
  * @brief Return IRQ level
- * @def irq_get_level()
- *
  * This routine returns the interrupt level number of the provided interrupt.
  *
  * @param irq IRQ number in its zephyr format
@@ -282,7 +280,7 @@ static inline unsigned int irq_get_level(unsigned int irq)
 #ifdef CONFIG_2ND_LEVEL_INTERRUPTS
 /**
  * @brief Return the 2nd level interrupt number
- * @def irq_from_level_2()
+ *
  *
  * This routine returns the second level irq number of the zephyr irq
  * number passed in
@@ -302,7 +300,7 @@ static inline unsigned int irq_from_level_2(unsigned int irq)
 
 /**
  * @brief Converts irq from level 1 to level 2 format
- * @def irq_to_level_2()
+ *
  *
  * This routine converts the input into the level 2 irq number format
  *
@@ -319,7 +317,7 @@ static inline unsigned int irq_to_level_2(unsigned int irq)
 
 /**
  * @brief Returns the parent IRQ of the level 2 raw IRQ number
- * @def irq_parent_level_2()
+ *
  *
  * The parent of a 2nd level interrupt is in the 1st byte
  *
@@ -336,7 +334,7 @@ static inline unsigned int irq_parent_level_2(unsigned int irq)
 #ifdef CONFIG_3RD_LEVEL_INTERRUPTS
 /**
  * @brief Return the 3rd level interrupt number
- * @def irq_from_level_3()
+ *
  *
  * This routine returns the third level irq number of the zephyr irq
  * number passed in
@@ -352,7 +350,7 @@ static inline unsigned int irq_from_level_3(unsigned int irq)
 
 /**
  * @brief Converts irq from level 1 to level 3 format
- * @def irq_to_level_3()
+ *
  *
  * This routine converts the input into the level 3 irq number format
  *
@@ -369,7 +367,7 @@ static inline unsigned int irq_to_level_3(unsigned int irq)
 
 /**
  * @brief Returns the parent IRQ of the level 3 raw IRQ number
- * @def irq_parent_level_3()
+ *
  *
  * The parent of a 3rd level interrupt is in the 2nd byte
  *

--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -95,7 +95,7 @@ extern "C" {
 #define _LOG_ZZZZ4U _LOG_YYYY,
 
 /**
- * @def LOG_CURRENT_MODULE_ID
+ *
  * @brief Macro for getting ID of current module.
  */
 #define LOG_CURRENT_MODULE_ID() (__log_level != 0 ? \

--- a/include/zephyr/math/ilog2.h
+++ b/include/zephyr/math/ilog2.h
@@ -19,7 +19,7 @@
  */
 
 /**
- * @def ilog2_compile_time_const_u32(n)
+ *
  * @brief Calculate the floor of log2 for compile time constant
  *
  * This calculates the floor of log2 (integer log2) for 32-bit
@@ -73,7 +73,7 @@
 	)
 
 /**
- * @def ilog2(n)
+ *
  * @brief Calculate integer log2
  *
  * This calculates the floor of log2 (integer of log2).

--- a/include/zephyr/mgmt/ec_host_cmd.h
+++ b/include/zephyr/mgmt/ec_host_cmd.h
@@ -63,7 +63,7 @@ struct ec_host_cmd_handler {
 };
 
 /**
- * @def EC_HOST_CMD_HANDLER
+ *
  * @brief Statically define and register a host command handler.
  *
  * Helper macro to statically define and register a host command handler that
@@ -88,7 +88,7 @@ struct ec_host_cmd_handler {
 	}
 
 /**
- * @def EC_HOST_CMD_HANDLER_UNBOUND
+ *
  * @brief Statically define and register a host command handler without sizes.
  *
  * Helper macro to statically define and register a host command handler whose

--- a/include/zephyr/net/buf.h
+++ b/include/zephyr/net/buf.h
@@ -30,7 +30,6 @@ extern "C" {
 #define __net_buf_align __aligned(sizeof(void *))
 
 /**
- *  @def NET_BUF_SIMPLE_DEFINE
  *  @brief Define a net_buf_simple stack variable.
  *
  *  This is a helper macro which is used to define a net_buf_simple object
@@ -49,7 +48,7 @@ extern "C" {
 	}
 
 /**
- * @def NET_BUF_SIMPLE_DEFINE_STATIC
+ *
  * @brief Define a static net_buf_simple variable.
  *
  * This is a helper macro which is used to define a static net_buf_simple
@@ -101,7 +100,7 @@ struct net_buf_simple {
 };
 
 /**
- * @def NET_BUF_SIMPLE
+ *
  * @brief Define a net_buf_simple stack variable and get a pointer to it.
  *
  * This is a helper macro which is used to define a net_buf_simple object on
@@ -1062,7 +1061,7 @@ extern const struct net_buf_data_alloc net_buf_heap_alloc;
 /** @endcond */
 
 /**
- * @def NET_BUF_POOL_HEAP_DEFINE
+ *
  * @brief Define a new pool for buffers using the heap for the data.
  *
  * Defines a net_buf_pool struct and the necessary memory storage (array of
@@ -1105,7 +1104,7 @@ extern const struct net_buf_data_cb net_buf_fixed_cb;
 /** @endcond */
 
 /**
- * @def NET_BUF_POOL_FIXED_DEFINE
+ *
  * @brief Define a new pool for buffers based on fixed-size data
  *
  * Defines a net_buf_pool struct and the necessary memory storage (array of
@@ -1153,7 +1152,7 @@ extern const struct net_buf_data_cb net_buf_var_cb;
 /** @endcond */
 
 /**
- * @def NET_BUF_POOL_VAR_DEFINE
+ *
  * @brief Define a new pool for buffers with variable size payloads
  *
  * Defines a net_buf_pool struct and the necessary memory storage (array of
@@ -1189,7 +1188,7 @@ extern const struct net_buf_data_cb net_buf_var_cb;
 					 _destroy)
 
 /**
- * @def NET_BUF_POOL_DEFINE
+ *
  * @brief Define a new pool for buffers
  *
  * Defines a net_buf_pool struct and the necessary memory storage (array of

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -850,8 +850,6 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #endif /* CONFIG_NET_VLAN */
 
 /**
- * @def ETH_NET_DEVICE_INIT
- *
  * @brief Create an Ethernet network interface and bind it to network device.
  *
  * @param dev_name Network device name.
@@ -875,8 +873,6 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 			      api, mtu)
 
 /**
- * @def ETH_NET_DEVICE_DT_DEFINE
- *
  * @brief Like ETH_NET_DEVICE_INIT but taking metadata from a devicetree.
  * Create an Ethernet network interface and bind it to network device.
  *
@@ -900,8 +896,6 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 			      api, mtu)
 
 /**
- * @def ETH_NET_DEVICE_DT_INST_DEFINE
- *
  * @brief Like ETH_NET_DEVICE_DT_DEFINE for an instance of a DT_DRV_COMPAT
  * compatible
  *

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2319,8 +2319,6 @@ struct net_if_api {
 	NET_IF_INIT(dev_name, 0, l2, mtu, NET_IF_MAX_CONFIGS)
 
 /**
- * @def NET_DEVICE_INIT
- *
  * @brief Create a network interface and bind it to network device.
  *
  * @param dev_name Network device name.
@@ -2347,8 +2345,6 @@ struct net_if_api {
 			l2_ctx_type, mtu)
 
 /**
- * @def NET_DEVICE_DT_DEFINE
- *
  * @brief Like NET_DEVICE_INIT but taking metadata from a devicetree node.
  * Create a network interface and bind it to network device.
  *
@@ -2374,8 +2370,6 @@ struct net_if_api {
 			  l2_ctx_type, mtu)
 
 /**
- * @def NET_DEVICE_DT_INST_DEFINE
- *
  * @brief Like NET_DEVICE_DT_DEFINE for an instance of a DT_DRV_COMPAT compatible
  *
  * @param inst instance number.  This is replaced by
@@ -2398,8 +2392,6 @@ struct net_if_api {
 	NET_IF_INIT(dev_name, instance, l2, mtu, NET_IF_MAX_CONFIGS)
 
 /**
- * @def NET_DEVICE_INIT_INSTANCE
- *
  * @brief Create multiple network interfaces and bind them to network device.
  * If your network device needs more than one instance of a network interface,
  * use this macro below and provide a different instance suffix each time
@@ -2431,8 +2423,6 @@ struct net_if_api {
 				   l2_ctx_type, mtu)
 
 /**
- * @def NET_DEVICE_DT_DEFINE_INSTANCE
- *
  * @brief Like NET_DEVICE_OFFLOAD_INIT but taking metadata from a devicetree.
  * Create multiple network interfaces and bind them to network device.
  * If your network device needs more than one instance of a network interface,
@@ -2465,8 +2455,6 @@ struct net_if_api {
 				   l2, l2_ctx_type, mtu)
 
 /**
- * @def NET_DEVICE_DT_INST_DEFINE_INSTANCE
- *
  * @brief Like NET_DEVICE_DT_DEFINE_INSTANCE for an instance of a DT_DRV_COMPAT
  * compatible
  *
@@ -2488,8 +2476,6 @@ struct net_if_api {
 	NET_IF_OFFLOAD_INIT(dev_name, 0, mtu)
 
 /**
- * @def NET_DEVICE_OFFLOAD_INIT
- *
  * @brief Create a offloaded network interface and bind it to network device.
  * The offloaded network interface is implemented by a device vendor HAL or
  * similar.
@@ -2515,8 +2501,6 @@ struct net_if_api {
 				api, mtu)
 
 /**
- * @def NET_DEVICE_DT_OFFLOAD_DEFINE
- *
  * @brief Like NET_DEVICE_OFFLOAD_INIT but taking metadata from a devicetree
  * node. Create a offloaded network interface and bind it to network device.
  * The offloaded network interface is implemented by a device vendor HAL or
@@ -2542,8 +2526,6 @@ struct net_if_api {
 				  prio, api, mtu)
 
 /**
- * @def NET_DEVICE_DT_INST_OFFLOAD_DEFINE
- *
  * @brief Like NET_DEVICE_DT_OFFLOAD_DEFINE for an instance of a DT_DRV_COMPAT
  * compatible
  *

--- a/include/zephyr/net/net_ip.h
+++ b/include/zephyr/net/net_ip.h
@@ -731,7 +731,6 @@ static inline bool net_ipv4_is_ll_addr(const struct in_addr *addr)
 }
 
 /**
- *  @def net_ipaddr_copy
  *  @brief Copy an IPv4 or IPv6 address
  *
  *  @param dest Destination IP address.

--- a/include/zephyr/net/virtual.h
+++ b/include/zephyr/net/virtual.h
@@ -283,8 +283,6 @@ net_virtual_get_iface_capabilities(struct net_if *iface)
 /** @endcond */
 
 /**
- * @def NET_VIRTUAL_INTERFACE_INIT
- *
  * @brief Create a virtual network interface. Binding to another interface
  *        is done at runtime by calling net_virtual_interface_attach().
  *        The attaching is done automatically when setting up tunneling

--- a/include/zephyr/sys/bitarray.h
+++ b/include/zephyr/sys/bitarray.h
@@ -33,8 +33,6 @@ struct sys_bitarray {
 typedef struct sys_bitarray sys_bitarray_t;
 
 /**
- * @def _SYS_BITARRAY_DEFINE
- *
  * @brief Create a bitarray object.
  *
  * @param name Name of the bitarray object.
@@ -54,8 +52,6 @@ typedef struct sys_bitarray sys_bitarray_t;
 	}
 
 /**
- * @def SYS_BITARRAY_DEFINE
- *
  * @brief Create a bitarray object.
  *
  * @param name Name of the bitarray object.
@@ -65,8 +61,6 @@ typedef struct sys_bitarray sys_bitarray_t;
 	_SYS_BITARRAY_DEFINE(name, total_bits,)
 
 /**
- * @def SYS_BITARRAY_DEFINE_STATIC
- *
  * @brief Create a static bitarray object.
  *
  * @param name Name of the bitarray object.

--- a/include/zephyr/sys/device_mmio.h
+++ b/include/zephyr/sys/device_mmio.h
@@ -173,8 +173,6 @@ struct z_device_mmio_rom {
 
 #ifdef DEVICE_MMIO_IS_IN_RAM
 /**
- * @def DEVICE_MMIO_RAM_PTR(device)
- *
  * Return a pointer to the RAM-based storage area for a device's MMIO
  * address.
  *
@@ -188,8 +186,6 @@ struct z_device_mmio_rom {
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 /**
- * @def DEVICE_MMIO_ROM
- *
  * @brief Declare storage for MMIO data within a device's config struct
  *
  * This gets accessed by DEVICE_MMIO_MAP() and DEVICE_MMIO_GET() macros.
@@ -218,8 +214,6 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_ROM		struct z_device_mmio_rom _mmio
 
 /**
- * @def DEVICE_MMIO_ROM_PTR(dev)
- *
  * Return a pointer to the ROM-based storage area for a device's MMIO
  * information. This macro will not work properly if the ROM storage
  * was omitted from the config struct declaration, and should not
@@ -232,8 +226,6 @@ struct z_device_mmio_rom {
 	((struct z_device_mmio_rom *)((dev)->config))
 
 /**
- * @def DEVICE_MMIO_ROM_INIT(node_id)
- *
  * @brief Initialize a DEVICE_MMIO_ROM member
  *
  * Initialize MMIO-related information within a specific instance of
@@ -354,8 +346,6 @@ struct z_device_mmio_rom {
 
 #ifdef DEVICE_MMIO_IS_IN_RAM
 /**
- * @def DEVICE_MMIO_NAMED_RAM_PTR(dev, name)
- *
  * @brief Return a pointer to the RAM storage for a device's named MMIO address
  *
  * This macro requires that the macro DEV_DATA is locally defined and returns
@@ -370,8 +360,6 @@ struct z_device_mmio_rom {
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 /**
- * @def DEVICE_MMIO_NAMED_ROM(name)
- *
  * @brief Declare storage for MMIO data within a device's config struct.
  *
  * This gets accessed by DEVICE_MMIO_NAMED_MAP() and
@@ -405,8 +393,6 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_NAMED_ROM(name) struct z_device_mmio_rom name
 
 /**
- * @def DEVICE_MMIO_NAMED_ROM_PTR(dev, name)
- *
  * Return a pointer to the ROM-based storage area for a device's MMIO
  * information.
  *
@@ -421,8 +407,6 @@ struct z_device_mmio_rom {
 #define DEVICE_MMIO_NAMED_ROM_PTR(dev, name) (&(DEV_CFG(dev)->name))
 
 /**
- * @def DEVICE_MMIO_NAMED_ROM_INIT(name, node_id)
- *
  * @brief Initialize a named DEVICE_MMIO_NAMED_ROM member
  *
  * Initialize MMIO-related information within a specific instance of
@@ -448,8 +432,6 @@ struct z_device_mmio_rom {
 	.name = Z_DEVICE_MMIO_ROM_INITIALIZER(node_id)
 
 /**
- * @def DEVICE_MMIO_NAMED_ROM_INIT_BY_NAME(name, node_id)
- *
  * @brief Initialize a named DEVICE_MMIO_NAMED_ROM member using a named DT
  *        reg property.
  *
@@ -491,8 +473,6 @@ struct z_device_mmio_rom {
 	.name = Z_DEVICE_MMIO_NAMED_ROM_INITIALIZER(name, node_id)
 
 /**
- * @def DEVICE_MMIO_NAMED_MAP(dev, name, flags)
- *
  * @brief Set up memory for a named MMIO region
  *
  * This performs the necessary PCI probing and/or MMU virtual memory mapping
@@ -661,8 +641,6 @@ struct z_device_mmio_rom {
 
 #ifdef DEVICE_MMIO_IS_IN_RAM
 /**
- * @def DEVICE_MMIO_TOPLEVEL_RAM_PTR(name)
- *
  * @brief Return a pointer to the RAM storage for a device's toplevel MMIO
  * address.
  *
@@ -673,8 +651,6 @@ struct z_device_mmio_rom {
 #endif /* DEVICE_MMIO_IS_IN_RAM */
 
 /**
- * @def DEVICE_MMIO_TOPLEVEL_ROM_PTR(name)
- *
  * Return a pointer to the ROM-based storage area for a toplevel MMIO region.
  *
  * @param name MMIO region name

--- a/include/zephyr/sys/mem_blocks.h
+++ b/include/zephyr/sys/mem_blocks.h
@@ -112,8 +112,6 @@ struct sys_multi_mem_blocks {
 };
 
 /**
- * @def _SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF
- *
  * @brief Create a memory block object with a providing backing buffer.
  *
  * @param name     Name of the memory block object.
@@ -133,8 +131,6 @@ struct sys_multi_mem_blocks {
 	}
 
 /**
- * @def _SYS_MEM_BLOCKS_DEFINE
- *
  * @brief Create a memory block object with a new backing buffer.
  *
  * @param name     Name of the memory block object.
@@ -156,8 +152,6 @@ struct sys_multi_mem_blocks {
  */
 
 /**
- * @def SYS_MEM_BLOCKS_DEFINE
- *
  * @brief Create a memory block object with a new backing buffer.
  *
  * @param name      Name of the memory block object.
@@ -169,8 +163,6 @@ struct sys_multi_mem_blocks {
 	_SYS_MEM_BLOCKS_DEFINE(name, blk_sz, num_blks, buf_align,)
 
 /**
- * @def SYS_MEM_BLOCKS_DEFINE_STATIC
- *
  * @brief Create a static memory block object with a new backing buffer.
  *
  * @param name      Name of the memory block object.
@@ -183,8 +175,6 @@ struct sys_multi_mem_blocks {
 
 
 /**
- * @def SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF
- *
  * @brief Create a memory block object with a providing backing buffer.
  *
  * @param name     Name of the memory block object.
@@ -196,8 +186,6 @@ struct sys_multi_mem_blocks {
 	_SYS_MEM_BLOCKS_DEFINE_WITH_EXT_BUF(name, blk_sz, num_blks, buf,)
 
 /**
- * @def SYS_MEM_BLOCKS_DEFINE_STATIC_WITH_EXT_BUF
- *
  * @brief Create a static memory block object with a providing backing buffer.
  *
  * @param name     Name of the memory block object.

--- a/include/zephyr/sys/mem_manage.h
+++ b/include/zephyr/sys/mem_manage.h
@@ -251,8 +251,6 @@ void z_phys_unmap(uint8_t *virt, size_t size);
  */
 
 /**
- * @def K_MEM_MAP_UNINIT
- *
  * @brief The mapped region is not guaranteed to be zeroed.
  *
  * This may improve performance. The associated page frames may contain
@@ -264,8 +262,6 @@ void z_phys_unmap(uint8_t *virt, size_t size);
 #define K_MEM_MAP_UNINIT	BIT(16)
 
 /**
- * @def K_MEM_MAP_LOCK
- *
  * Region will be pinned in memory and never paged
  *
  * Such memory is guaranteed to never produce a page fault due to page-outs
@@ -275,8 +271,6 @@ void z_phys_unmap(uint8_t *virt, size_t size);
 #define K_MEM_MAP_LOCK		BIT(17)
 
 /**
- * @def K_MEM_MAP_GUARD
- *
  * A un-mapped virtual guard page will be placed in memory immediately preceding
  * the mapped region. This page will still be noted as being used by the
  * virtual memory manager. The total size of the allocation will be the

--- a/include/zephyr/tracing/tracing_macros.h
+++ b/include/zephyr/tracing/tracing_macros.h
@@ -185,8 +185,6 @@
 	_SYS_PORT_TRACING_TYPE_MASK(type)(trace_call)
 
 /**
- * @def SYS_PORT_TRACING_FUNC
- *
  * @brief Tracing macro for function calls which are not directly
  * associated with a specific type of object.
  *
@@ -202,8 +200,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_FUNC_ENTER
- *
  * @brief Tracing macro for the entry into a function that might or might not return
  * a value.
  *
@@ -219,8 +215,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_FUNC_BLOCKING
- *
  * @brief Tracing macro for when a function blocks during its execution.
  *
  * @param type Type of tracing event or object type
@@ -235,8 +229,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_FUNC_EXIT
- *
  * @brief Tracing macro for when a function ends its execution. Potential return values
  * can be given as additional arguments.
  *
@@ -252,8 +244,6 @@
 	} while (false)
 
 /**
- * @def SYS_PORT_TRACING_OBJ_INIT
- *
  * @brief Tracing macro for the initialization of an object.
  *
  * @param obj_type The type of object associated with the call (k_thread, k_sem, k_mutex etc.)

--- a/subsys/bluetooth/mesh/mesh.h
+++ b/subsys/bluetooth/mesh/mesh.h
@@ -20,8 +20,7 @@ struct bt_mesh_app_key_cb {
 			    enum bt_mesh_key_evt evt);
 };
 
-/** @def BT_MESH_APP_KEY_CB
- *
+/**
  *  @brief Register an AppKey event callback.
  *
  *  @param _handler Handler function, see @ref bt_mesh_app_key_cb::evt_handler.

--- a/subsys/bluetooth/mesh/subnet.h
+++ b/subsys/bluetooth/mesh/subnet.h
@@ -73,8 +73,7 @@ struct bt_mesh_subnet_cb {
 			    enum bt_mesh_key_evt evt);
 };
 
-/** @def BT_MESH_SUBNET_CB
- *
+/**
  *  @brief Register a subnet event callback.
  *
  *  @param _name Handler name.

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/gatt_macs.h
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/gatt_macs.h
@@ -22,7 +22,7 @@ extern "C" {
 
 #include <zephyr/bluetooth/gatt.h>
 
-/** @def BT_GATT_H_ATTRIBUTE
+/**
  *  @brief Attribute Declaration Macro.
  *
  *  Helper macro to declare an attribute.
@@ -44,7 +44,7 @@ extern "C" {
 	.handle = _handle \
 	}
 
-/** @def BT_GATT_H_CHARACTERISTIC
+/**
  *  @brief Characteristic and Value Declaration Macro.
  *
  *  Helper macro to declare a characteristic attribute along with its attribute
@@ -70,7 +70,7 @@ extern "C" {
 			  _handle), \
 	BT_GATT_H_ATTRIBUTE(_uuid, _perm, _read, _write, _value, _handle + 1)
 
-/** @def BT_GATT_H_PRIMARY_SERVICE
+/**
  *  @brief Primary Service Declaration Macro.
  *
  *  Helper macro to declare a primary service attribute.
@@ -86,7 +86,7 @@ extern "C" {
 				_service, \
 				_handle)
 
-/** @def BT_GATT_H_SECONDARY_SERVICE
+/**
  *  @brief Secondary Service Declaration Macro.
  *
  *  Helper macro to declare a secondary service attribute.
@@ -102,7 +102,7 @@ extern "C" {
 				_service, \
 				_handle)
 
-/** @def BT_GATT_H_INCLUDE_SERVICE
+/**
  *  @brief Include Service Declaration Macro.
  *
  *  Helper macro to declare database internal include service attribute.
@@ -118,7 +118,7 @@ extern "C" {
 				_service_incl, \
 				_handle)
 
-/** @def BT_GATT_H_DESCRIPTOR
+/**
  *  @brief Descriptor Declaration Macro.
  *
  *  Helper macro to declare a descriptor attribute.
@@ -133,7 +133,7 @@ extern "C" {
 #define BT_GATT_H_DESCRIPTOR(_uuid, _perm, _read, _write, _value, _handle) \
 	       BT_GATT_H_ATTRIBUTE(_uuid, _perm, _read, _write, _value, _handle)
 
-/** @def BT_GATT_H_MANAGED
+/**
  *  @brief Managed Client Characteristic Configuration Declaration Macro.
  *
  *  Helper macro to declare a Managed CCC attribute.
@@ -146,7 +146,7 @@ extern "C" {
 		BT_GATT_H_ATTRIBUTE(BT_UUID_GATT_CCC, _perm,\
 		bt_gatt_attr_read_ccc, bt_gatt_attr_write_ccc, _ccc, _handle)
 
-/** @def BT_GATT_H_CCC
+/**
  *  @brief Client Characteristic Configuration Change Declaration Macro.
  *
  *  Helper macro to declare a CCC attribute.
@@ -168,7 +168,7 @@ extern "C" {
  *         } ), \
  *         _handle)
  */
-/** @def BT_GATT_H_CCC
+/**
  *  @brief Client Characteristic Configuration Change Declaration Macro.
  *
  *  Helper macro to declare a CCC attribute.
@@ -182,7 +182,7 @@ extern "C" {
 			BT_GATT_CCC_INITIALIZER(_cfg_changed, NULL, NULL)),\
 			BT_GATT_PERM_READ | BT_GATT_PERM_WRITE, _handle)
 
-/** @def BT_GATT_H_CEP
+/**
  *  @brief Characteristic Extended Properties Declaration Macro.
  *
  *  Helper macro to declare a CEP attribute.
@@ -198,7 +198,7 @@ extern "C" {
 				(void *)_value, \
 				_handle)
 
-/** @def BT_GATT_H_CUD
+/**
  *  @brief Characteristic User Format Descriptor Declaration Macro.
  *
  *  Helper macro to declare a CUD attribute.
@@ -215,7 +215,7 @@ extern "C" {
 				(void *)_value, \
 				_handle)
 
-/** @def BT_GATT_H_CPF
+/**
  *  @brief Characteristic Presentation Format Descriptor Declaration Macro.
  *
  *  Helper macro to declare a CPF attribute.

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_a_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_a_1.c
@@ -18,22 +18,22 @@
 
 extern struct bt_gatt_attr service_d_1_attrs[];
 
-/** @def BT_UUID_SERVICE_A
+/**
  *  @brief UUID for the Service A
  */
 #define BT_UUID_SERVICE_A               BT_UUID_DECLARE_16(0xa00a)
 
-/** @def BT_UUID_VALUE_V1
+/**
  *  @brief UUID for the Value V1 Characteristic
  */
 #define BT_UUID_VALUE_V1                BT_UUID_DECLARE_16(0xb001)
 
-/** @def BT_UUID_VALUE_V2
+/**
  *  @brief UUID for the Value V2 Characteristic
  */
 #define BT_UUID_VALUE_V2                BT_UUID_DECLARE_16(0xb002)
 
-/** @def BT_UUID_VALUE_V3
+/**
  *  @brief UUID for the Value V3 Characteristic
  */
 #define BT_UUID_VALUE_V3                BT_UUID_DECLARE_16(0xb003)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_a_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_a_2.c
@@ -19,22 +19,22 @@
 extern struct bt_gatt_attr service_d_2_attrs[];
 extern struct bt_gatt_attr service_c_1_2_attrs[];
 
-/** @def BT_UUID_SERVICE_A
+/**
  *  @brief UUID for the Service A
  */
 #define BT_UUID_SERVICE_A               BT_UUID_DECLARE_16(0xa00a)
 
-/** @def BT_UUID_VALUE_V1
+/**
  *  @brief UUID for the Value V1 Characteristic
  */
 #define BT_UUID_VALUE_V1                BT_UUID_DECLARE_16(0xb001)
 
-/** @def BT_UUID_VALUE_V2
+/**
  *  @brief UUID for the Value V2 Characteristic
  */
 #define BT_UUID_VALUE_V2                BT_UUID_DECLARE_16(0xb002)
 
-/** @def BT_UUID_VALUE_V3
+/**
  *  @brief UUID for the Value V3 Characteristic
  */
 #define BT_UUID_VALUE_V3                BT_UUID_DECLARE_16(0xb003)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_a_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_a_3.c
@@ -19,22 +19,22 @@
 extern struct bt_gatt_attr service_d_3_attrs[];
 extern struct bt_gatt_attr service_c_1_3_attrs[];
 
-/** @def BT_UUID_SERVICE_A
+/**
  *  @brief UUID for the Service A
  */
 #define BT_UUID_SERVICE_A               BT_UUID_DECLARE_16(0xa00a)
 
-/** @def BT_UUID_VALUE_V1
+/**
  *  @brief UUID for the Value V1 Characteristic
  */
 #define BT_UUID_VALUE_V1                BT_UUID_DECLARE_16(0xb001)
 
-/** @def BT_UUID_VALUE_V2
+/**
  *  @brief UUID for the Value V2 Characteristic
  */
 #define BT_UUID_VALUE_V2                BT_UUID_DECLARE_16(0xb002)
 
-/** @def BT_UUID_VALUE_V3
+/**
  *  @brief UUID for the Value V3 Characteristic
  */
 #define BT_UUID_VALUE_V3                BT_UUID_DECLARE_16(0xb003)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_1_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_1_1.c
@@ -16,17 +16,17 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_1
+/**
  *  @brief UUID for the Service B.1
  */
 #define BT_UUID_SERVICE_B_1             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V4
+/**
  *  @brief UUID for the Value V4 Characteristic
  */
 #define BT_UUID_VALUE_V4                BT_UUID_DECLARE_16(0xb004)
 
-/** @def BT_UUID_LONG_DES_V2D1
+/**
  *  @brief UUID for the Long descriptor V2D1 Characteristic
  */
 #define BT_UUID_LONG_DES_V2D1           BT_UUID_DECLARE_16(0xb012)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_1_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_1_2.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_1
+/**
  *  @brief UUID for the Service B.1
  */
 #define BT_UUID_SERVICE_B_1             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V4
+/**
  *  @brief UUID for the Value V4 Characteristic
  */
 #define BT_UUID_VALUE_V4                BT_UUID_DECLARE_16(0xb004)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_1_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_1_3.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_1
+/**
  *  @brief UUID for the Service B.1
  */
 #define BT_UUID_SERVICE_B_1             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V4
+/**
  *  @brief UUID for the Value V4 Characteristic
  */
 #define BT_UUID_VALUE_V4                BT_UUID_DECLARE_16(0xb004)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_2_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_2_1.c
@@ -16,17 +16,17 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_2
+/**
  *  @brief UUID for the Service B.2
  */
 #define BT_UUID_SERVICE_B_2             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V5
+/**
  *  @brief UUID for the Value V5 Characteristic
  */
 #define BT_UUID_VALUE_V5                BT_UUID_DECLARE_16(0xb005)
 
-/** @def BT_UUID_DES_V5D4__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V5D4 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V5D4__128_BIT_UUID  BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_2_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_2_2.c
@@ -16,17 +16,17 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_2
+/**
  *  @brief UUID for the Service B.2
  */
 #define BT_UUID_SERVICE_B_2             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V5
+/**
  *  @brief UUID for the Value V5 Characteristic
  */
 #define BT_UUID_VALUE_V5                BT_UUID_DECLARE_16(0xb005)
 
-/** @def BT_UUID_DES_V5D4__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V5D4 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V5D4__128_BIT_UUID  BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_2_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_2_3.c
@@ -16,17 +16,17 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_2
+/**
  *  @brief UUID for the Service B.2
  */
 #define BT_UUID_SERVICE_B_2             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V5
+/**
  *  @brief UUID for the Value V5 Characteristic
  */
 #define BT_UUID_VALUE_V5                BT_UUID_DECLARE_16(0xb005)
 
-/** @def BT_UUID_DES_V5D4__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V5D4 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V5D4__128_BIT_UUID  BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_1.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_3
+/**
  *  @brief UUID for the Service B.3
  */
 #define BT_UUID_SERVICE_B_3             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V6
+/**
  *  @brief UUID for the Value V6 Characteristic
  */
 #define BT_UUID_VALUE_V6                BT_UUID_DECLARE_16(0xb006)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_2.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_3
+/**
  *  @brief UUID for the Service B.3
  */
 #define BT_UUID_SERVICE_B_3             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V6
+/**
  *  @brief UUID for the Value V6 Characteristic
  */
 #define BT_UUID_VALUE_V6                BT_UUID_DECLARE_16(0xb006)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_3_3.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_3
+/**
  *  @brief UUID for the Service B.3
  */
 #define BT_UUID_SERVICE_B_3             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V6
+/**
  *  @brief UUID for the Value V6 Characteristic
  */
 #define BT_UUID_VALUE_V6                BT_UUID_DECLARE_16(0xb006)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_4_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_4_1.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_4
+/**
  *  @brief UUID for the Service B.4
  */
 #define BT_UUID_SERVICE_B_4             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V7
+/**
  *  @brief UUID for the Value V7 Characteristic
  */
 #define BT_UUID_VALUE_V7                BT_UUID_DECLARE_16(0xb007)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_4_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_4_2.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_4
+/**
  *  @brief UUID for the Service B.4
  */
 #define BT_UUID_SERVICE_B_4             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V7
+/**
  *  @brief UUID for the Value V7 Characteristic
  */
 #define BT_UUID_VALUE_V7                BT_UUID_DECLARE_16(0xb007)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_4_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_4_3.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_4
+/**
  *  @brief UUID for the Service B.4
  */
 #define BT_UUID_SERVICE_B_4             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V7
+/**
  *  @brief UUID for the Value V7 Characteristic
  */
 #define BT_UUID_VALUE_V7                BT_UUID_DECLARE_16(0xb007)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_5_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_5_1.c
@@ -16,27 +16,27 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_5
+/**
  *  @brief UUID for the Service B.5
  */
 #define BT_UUID_SERVICE_B_5             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V8
+/**
  *  @brief UUID for the Value V8 Characteristic
  */
 #define BT_UUID_VALUE_V8                BT_UUID_DECLARE_16(0xb008)
 
-/** @def BT_UUID_DES_V8D1
+/**
  *  @brief UUID for the Descriptor V8D1 Characteristic
  */
 #define BT_UUID_DES_V8D1                BT_UUID_DECLARE_16(0xb015)
 
-/** @def BT_UUID_DES_V8D2
+/**
  *  @brief UUID for the Descriptor V8D2 Characteristic
  */
 #define BT_UUID_DES_V8D2                BT_UUID_DECLARE_16(0xb016)
 
-/** @def BT_UUID_DES_V8D3
+/**
  *  @brief UUID for the Descriptor V8D3 Characteristic
  */
 #define BT_UUID_DES_V8D3                BT_UUID_DECLARE_16(0xb017)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_5_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_5_2.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_5
+/**
  *  @brief UUID for the Service B.5
  */
 #define BT_UUID_SERVICE_B_5             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V8
+/**
  *  @brief UUID for the Value V8 Characteristic
  */
 #define BT_UUID_VALUE_V8                BT_UUID_DECLARE_16(0xb008)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_5_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_b_5_3.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_B_5
+/**
  *  @brief UUID for the Service B.5
  */
 #define BT_UUID_SERVICE_B_5             BT_UUID_DECLARE_16(0xa00b)
 
-/** @def BT_UUID_VALUE_V8
+/**
  *  @brief UUID for the Value V8 Characteristic
  */
 #define BT_UUID_VALUE_V8                BT_UUID_DECLARE_16(0xb008)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_1_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_1_1.c
@@ -18,28 +18,28 @@
 
 extern struct bt_gatt_attr service_d_1_attrs[];
 
-/** @def BT_UUID_SERVICE_C_1
+/**
  *  @brief UUID for the Service C.1
  */
 #define BT_UUID_SERVICE_C_1             BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x0c, 0xa0, 0x00, 0x00)
 
-/** @def BT_UUID_VALUE_V9__128_BIT_UUID
+/**
  *  @brief UUID for the Value V9 (128-bit UUID) Characteristic
  */
 #define BT_UUID_VALUE_V9__128_BIT_UUID  BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x09, 0xb0, 0x00, 0x00)
 
-/** @def BT_UUID_DES_V9D2__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V9D2 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V9D2__128_BIT_UUID  BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0xd2, 0xd9, 0x00, 0x00)
 
-/** @def BT_UUID_DES_V9D3__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V9D3 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V9D3__128_BIT_UUID  BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_1_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_1_2.c
@@ -18,28 +18,28 @@
 
 extern struct bt_gatt_attr service_d_2_attrs[];
 
-/** @def BT_UUID_SERVICE_C_1
+/**
  *  @brief UUID for the Service C.1
  */
 #define BT_UUID_SERVICE_C_1             BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x0c, 0xa0, 0x00, 0x00)
 
-/** @def BT_UUID_VALUE_V9__128_BIT_UUID
+/**
  *  @brief UUID for the Value V9 (128-bit UUID) Characteristic
  */
 #define BT_UUID_VALUE_V9__128_BIT_UUID  BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x09, 0xb0, 0x00, 0x00)
 
-/** @def BT_UUID_DES_V9D2__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V9D2 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V9D2__128_BIT_UUID  BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0xd2, 0xd9, 0x00, 0x00)
 
-/** @def BT_UUID_DES_V9D3__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V9D3 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V9D3__128_BIT_UUID  BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_1_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_1_3.c
@@ -16,28 +16,28 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_C_1
+/**
  *  @brief UUID for the Service C.1
  */
 #define BT_UUID_SERVICE_C_1             BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x0c, 0xa0, 0x00, 0x00)
 
-/** @def BT_UUID_VALUE_V9__128_BIT_UUID
+/**
  *  @brief UUID for the Value V9 (128-bit UUID) Characteristic
  */
 #define BT_UUID_VALUE_V9__128_BIT_UUID  BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x09, 0xb0, 0x00, 0x00)
 
-/** @def BT_UUID_DES_V9D2__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V9D2 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V9D2__128_BIT_UUID  BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0xd2, 0xd9, 0x00, 0x00)
 
-/** @def BT_UUID_DES_V9D3__128_BIT_UUID
+/**
  *  @brief UUID for the Descriptor V9D3 (128-bit UUID) Characteristic
  */
 #define BT_UUID_DES_V9D3__128_BIT_UUID  BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_2_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_2_1.c
@@ -16,34 +16,34 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_C_2
+/**
  *  @brief UUID for the Service C.2
  */
 #define BT_UUID_SERVICE_C_2             BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x0c, 0xa0, 0x00, 0x00)
 
-/** @def BT_UUID_VALUE_V10
+/**
  *  @brief UUID for the Value V10 Characteristic
  */
 #define BT_UUID_VALUE_V10               BT_UUID_DECLARE_16(0xb00a)
 
-/** @def BT_UUID_VALUE_V2
+/**
  *  @brief UUID for the Value V2 Characteristic
  */
 #define BT_UUID_VALUE_V2                BT_UUID_DECLARE_16(0xb002)
 
-/** @def BT_UUID_LONG_DES_V2D1
+/**
  *  @brief UUID for the Long descriptor V2D1 Characteristic
  */
 #define BT_UUID_LONG_DES_V2D1           BT_UUID_DECLARE_16(0xb012)
 
-/** @def BT_UUID_LONG_DES_V2D2
+/**
  *  @brief UUID for the Long descriptor V2D2 Characteristic
  */
 #define BT_UUID_LONG_DES_V2D2           BT_UUID_DECLARE_16(0xb013)
 
-/** @def BT_UUID_LONG_DES_V2D3
+/**
  *  @brief UUID for the Long descriptor V2D3 Characteristic
  */
 #define BT_UUID_LONG_DES_V2D3           BT_UUID_DECLARE_16(0xb014)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_2_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_2_2.c
@@ -16,19 +16,19 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_C_2
+/**
  *  @brief UUID for the Service C.2
  */
 #define BT_UUID_SERVICE_C_2             BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x0c, 0xa0, 0x00, 0x00)
 
-/** @def BT_UUID_VALUE_V10
+/**
  *  @brief UUID for the Value V10 Characteristic
  */
 #define BT_UUID_VALUE_V10               BT_UUID_DECLARE_16(0xb00a)
 
-/** @def BT_UUID_VALUE_V2
+/**
  *  @brief UUID for the Value V2 Characteristic
  */
 #define BT_UUID_VALUE_V2                BT_UUID_DECLARE_16(0xb002)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_2_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_c_2_3.c
@@ -16,19 +16,19 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_C_2
+/**
  *  @brief UUID for the Service C.2
  */
 #define BT_UUID_SERVICE_C_2             BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x0c, 0xa0, 0x00, 0x00)
 
-/** @def BT_UUID_VALUE_V10
+/**
  *  @brief UUID for the Value V10 Characteristic
  */
 #define BT_UUID_VALUE_V10               BT_UUID_DECLARE_16(0xb00a)
 
-/** @def BT_UUID_VALUE_V2
+/**
  *  @brief UUID for the Value V2 Characteristic
  */
 #define BT_UUID_VALUE_V2                BT_UUID_DECLARE_16(0xb002)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_d_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_d_1.c
@@ -18,17 +18,17 @@
 
 extern struct bt_gatt_attr service_b_5_1_attrs[];
 
-/** @def BT_UUID_SERVICE_D
+/**
  *  @brief UUID for the Service D
  */
 #define BT_UUID_SERVICE_D               BT_UUID_DECLARE_16(0xa00d)
 
-/** @def BT_UUID_VALUE_V12
+/**
  *  @brief UUID for the Value V12 Characteristic
  */
 #define BT_UUID_VALUE_V12               BT_UUID_DECLARE_16(0xb00c)
 
-/** @def BT_UUID_VALUE_V11__128_BIT_UUID
+/**
  *  @brief UUID for the Value V11 (128-bit UUID) Characteristic
  */
 #define BT_UUID_VALUE_V11__128_BIT_UUID BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_d_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_d_2.c
@@ -18,19 +18,19 @@
 
 extern struct bt_gatt_attr service_b_1_2_attrs[];
 
-/** @def BT_UUID_SERVICE_D
+/**
  *  @brief UUID for the Service D
  */
 #define BT_UUID_SERVICE_D               BT_UUID_DECLARE_16(0xa00d)
 
-/** @def BT_UUID_VALUE_V11__128_BIT_UUID
+/**
  *  @brief UUID for the Value V11 (128-bit UUID) Characteristic
  */
 #define BT_UUID_VALUE_V11__128_BIT_UUID BT_UUID_DECLARE_128( \
 		0xef, 0xcd, 0xab, 0x89, 0x67, 0x45, 0x23, 0x01, \
 		0x00, 0x00, 0x00, 0x00, 0x0b, 0xb0, 0x00, 0x00)
 
-/** @def BT_UUID_VALUE_V12
+/**
  *  @brief UUID for the Value V12 Characteristic
  */
 #define BT_UUID_VALUE_V12               BT_UUID_DECLARE_16(0xb00c)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_d_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_d_3.c
@@ -18,17 +18,17 @@
 
 extern struct bt_gatt_attr service_c_1_3_attrs[];
 
-/** @def BT_UUID_SERVICE_D
+/**
  *  @brief UUID for the Service D
  */
 #define BT_UUID_SERVICE_D               BT_UUID_DECLARE_16(0xa00d)
 
-/** @def BT_UUID_VALUE_V12
+/**
  *  @brief UUID for the Value V12 Characteristic
  */
 #define BT_UUID_VALUE_V12               BT_UUID_DECLARE_16(0xb00c)
 
-/** @def BT_UUID_VALUE_V11__128_BIT_UUID
+/**
  *  @brief UUID for the Value V11 (128-bit UUID) Characteristic
  */
 #define BT_UUID_VALUE_V11__128_BIT_UUID BT_UUID_DECLARE_128( \

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_e_2.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_e_2.c
@@ -16,12 +16,12 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_E
+/**
  *  @brief UUID for the Service E
  */
 #define BT_UUID_SERVICE_E               BT_UUID_DECLARE_16(0xa00e)
 
-/** @def BT_UUID_VALUE_V13
+/**
  *  @brief UUID for the Value V13 Characteristic
  */
 #define BT_UUID_VALUE_V13               BT_UUID_DECLARE_16(0xb00d)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_e_3.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_e_3.c
@@ -16,7 +16,7 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_E
+/**
  *  @brief UUID for the Service E
  */
 #define BT_UUID_SERVICE_E               BT_UUID_DECLARE_16(0xa00e)

--- a/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_f_1.c
+++ b/tests/bluetooth/bsim_bt/edtt_ble_test_app/gatt_test_app/src/gatt/service_f_1.c
@@ -16,42 +16,42 @@
 
 #include "gatt_macs.h"
 
-/** @def BT_UUID_SERVICE_F
+/**
  *  @brief UUID for the Service F
  */
 #define BT_UUID_SERVICE_F               BT_UUID_DECLARE_16(0xa00f)
 
-/** @def BT_UUID_VALUE_V14
+/**
  *  @brief UUID for the Value V14 Characteristic
  */
 #define BT_UUID_VALUE_V14               BT_UUID_DECLARE_16(0xb00e)
 
-/** @def BT_UUID_VALUE_V15
+/**
  *  @brief UUID for the Value V15 Characteristic
  */
 #define BT_UUID_VALUE_V15               BT_UUID_DECLARE_16(0xb00f)
 
-/** @def BT_UUID_VALUE_V6
+/**
  *  @brief UUID for the Value V6 Characteristic
  */
 #define BT_UUID_VALUE_V6                BT_UUID_DECLARE_16(0xb006)
 
-/** @def BT_UUID_VALUE_V7
+/**
  *  @brief UUID for the Value V7 Characteristic
  */
 #define BT_UUID_VALUE_V7                BT_UUID_DECLARE_16(0xb007)
 
-/** @def BT_UUID_VALUE_V16
+/**
  *  @brief UUID for the Value V16 Characteristic
  */
 #define BT_UUID_VALUE_V16               BT_UUID_DECLARE_16(0xb010)
 
-/** @def BT_UUID_AGG_FORMAT
+/**
  *  @brief UUID for the Aggregate Format Characteristic
  */
 #define BT_UUID_AGG_FORMAT              BT_UUID_DECLARE_16(0x2905)
 
-/** @def BT_UUID_VALUE_V17
+/**
  *  @brief UUID for the Value V17 Characteristic
  */
 #define BT_UUID_VALUE_V17               BT_UUID_DECLARE_16(0xb011)


### PR DESCRIPTION
The `def` command Indicates that a comment block contains documentation
for a #define macro. This is useful if the comment block documents a
macro not adjacent to it, e.g.

```c
/**
 * @def MAX(x,y)
 * @brief Computes the maximum of @a x and @a y.
 */
#ifdef XXX
#define MAX(x, y) ...
#endif
```

However, it is not necessary if the comment is adjacent to the
definition, e.g.

```c
/**
 * @brief Computes the maximum of @a x and @a y.
 */
#define MAX(x, y) ...
```

This patch removes all unnecessary def entries in-tree.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>