### PR TITLE
boards: fvp_baser_aemv8r_aarch32: Fix the board type

### DIFF
--- a/boards/arm/fvp_baser_aemv8r_aarch32/doc/index.rst
+++ b/boards/arm/fvp_baser_aemv8r_aarch32/doc/index.rst
@@ -69,7 +69,7 @@ Arm FVP emulated environment, for example, with the :ref:`synchronization_sample
 .. zephyr-app-commands::
    :zephyr-app: samples/synchronization
    :host-os: unix
-   :board: fvp_baser_aemv8r
+   :board: fvp_baser_aemv8r_aarch32
    :goals: build
 
 This will build an image with the synchronization sample app. To run with FVP,


### PR DESCRIPTION
The board type should be "fvp_baser_aemv8r_aarch32". This will build
zephyr binary for aarch32.

Signed-off-by: Ayan Kumar Halder <ayankuma@amd.com>