### PR TITLE
arch: riscv: Align semihost_exec function at 16-byte boundary

### DIFF
--- a/arch/riscv/core/semihost.c
+++ b/arch/riscv/core/semihost.c
@@ -5,9 +5,20 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+#include <zephyr/toolchain.h>
 #include <zephyr/arch/common/semihost.h>
 
-long semihost_exec(enum semihost_instr instr, void *args)
+/*
+ * QEMU requires that the semihosting trap instruction sequence, consisting of
+ * three uncompressed instructions, lie in the same page, and refuses to
+ * interpret the trap sequence if these instructions are placed across two
+ * different pages.
+ *
+ * The `semihost_exec` function, which occupies 12 bytes, is aligned at a
+ * 16-byte boundary to ensure that the three trap sequence instructions are
+ * never placed across two different pages.
+ */
+long __aligned(16) semihost_exec(enum semihost_instr instr, void *args)
 {
 	register unsigned long a0 __asm__ ("a0") = instr;
 	register void *a1 __asm__ ("a1") = args;


### PR DESCRIPTION
QEMU requires that the semihosting trap instruction sequence, which
consists of three uncompressed instructions, lie in the same page, and
refuses to interpret the trap sequence if these instructions are placed
across two different pages.

This commit adds 16-byte alignment requirement to the `semihost_exec`
function, which occupies 12 bytes, to ensure that the three trap
sequence instructions in this function are never placed across two
different pages.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

Re: QEMU requiring the trap instructions to lie in the same page, see below:

[target/riscv/insn_trans/trans_privileged.c.inc#L55-L59](https://github.com/qemu/qemu/blob/09ed077d7fae5f825e18ff9a2004dcdd1b165edb/target/riscv/insn_trans/trans_privileged.c.inc#L55-L59)
```c
    if ((pre_addr & TARGET_PAGE_MASK) == (post_addr & TARGET_PAGE_MASK)) {
        pre    = opcode_at(&ctx->base, pre_addr);
        ebreak = opcode_at(&ctx->base, ebreak_addr);
        post   = opcode_at(&ctx->base, post_addr);
    }
```