### PR TITLE
intel_adsp: fix boot errors with no_optimizations

### DIFF
--- a/include/zephyr/arch/xtensa/cache.h
+++ b/include/zephyr/arch/xtensa/cache.h
@@ -154,7 +154,7 @@ static inline void __sparse_cache *arch_xtensa_cached_ptr(void *ptr)
  * @param ptr A pointer to a valid C object
  * @return A pointer to the same object bypassing the L1 dcache
  */
-static inline void *arch_xtensa_uncached_ptr(void __sparse_cache *ptr)
+static ALWAYS_INLINE void *arch_xtensa_uncached_ptr(void __sparse_cache *ptr)
 {
 	return (void *)z_xtrpoflip((uint32_t) ptr,
 				   CONFIG_XTENSA_UNCACHED_REGION,

--- a/soc/xtensa/intel_adsp/common/multiprocessing.c
+++ b/soc/xtensa/intel_adsp/common/multiprocessing.c
@@ -62,8 +62,12 @@ bool soc_cpus_active[CONFIG_MP_NUM_CPUS];
  *
  * Note that alignment is absolutely required: the IDC protocol passes
  * only the upper 30 bits of the address to the second CPU.
+ *
+ * The .section is the same as __imr, but that can't be used for an assebly
+ * function like this
  */
-__asm__(".align 4                   \n\t"
+__asm__(".section .imr." Z_STRINGIFY(__FILE__) "." Z_STRINGIFY(__COUNTER__) "\n\t"
+	".align 4                   \n\t"
 	".global z_soc_mp_asm_entry \n\t"
 	"z_soc_mp_asm_entry:        \n\t"
 	"  movi  a0, 0x4002f        \n\t" /* WOE | UM | INTLEVEL(max) */


### PR DESCRIPTION
Certain boot functions were not stored in IMR, higher opt levels inlined
them so issues weren't noticed. Also, a power managment sys_write32
halts execution, this needs to be resolved before merging. So far, only
tested on hello_world sample, full SOF fails at the moment.

Signed-off-by: Noah Klayman <noah.klayman@intel.com>

Fixes #48390

TODO:

- [x] Determine issue with power management sys_write32 and use a better solution than commenting it out
- [ ] Verify something more complex than hello_world works (All the issues have been before application code, but other configurations could potentially cause issues)
- [ ] I'm not 100% sure I correctly implemented the effect of the `__imr` macro for `z_soc_mp_asm_entry`, can someone verify this? 