### PR TITLE
dts: riscv: gd32vf103: Correct systimer interrupt assignment

### DIFF
--- a/drivers/timer/riscv_machine_timer.c
+++ b/drivers/timer/riscv_machine_timer.c
@@ -29,7 +29,7 @@
 
 #define MTIME_REG	DT_INST_REG_ADDR(0)
 #define MTIMECMP_REG	(DT_INST_REG_ADDR(0) + 8)
-#define TIMER_IRQN	DT_INST_IRQN(0)
+#define TIMER_IRQN	DT_INST_IRQ_BY_IDX(0, 1, irq)
 /* sifive,clint0 */
 #elif DT_HAS_COMPAT_STATUS_OKAY(sifive_clint0)
 #define DT_DRV_COMPAT sifive_clint0

--- a/soc/riscv/riscv-privilege/gd32vf103/Kconfig.defconfig.gd32vf103
+++ b/soc/riscv/riscv-privilege/gd32vf103/Kconfig.defconfig.gd32vf103
@@ -13,7 +13,7 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default $(dt_node_int_prop_int,/cpus/cpu@0,clock-frequency) if RISCV_MACHINE_TIMER
 
 config RISCV_MACHINE_TIMER_SYSTEM_CLOCK_DIVIDER
-	default $(dt_node_int_prop_int,/soc/machine-timer@d1000000,clk-divider) if RISCV_MACHINE_TIMER
+	default $(dt_node_int_prop_int,/soc/timer@d1000000,clk-divider) if RISCV_MACHINE_TIMER
 
 config RISCV_SOC_MCAUSE_EXCEPTION_MASK
 	default $(dt_node_int_prop_hex,/cpus/cpu@0,mcause-exception-mask)


### PR DESCRIPTION
Assign IRQ7 to riscv_machine_timer

Since #48429 changes to use the first elements of interrupts.
(It has been using IRQ7 as a fixed configuration before #48429)
Place the IRQ7 to the first element of the array for
use with riscv_machine_timer.

gd32vf103.dtsi set IRQ3 and IRQ7 for machine timer's interrupts.
Currently, the first element is IRQ3. So we need to use IRQ7 instead of it.

IRQ3 has not used before, so leave it as it is.

--- 

machine-timer node name changed in #48429.
but Kcondif.defconfig.gd32vf103 not followed it.
It makes misconfigures the RISCV_MACHINE_TIMER_SYSTEM_CLOCK_DIVIDER.
So the machine-timer did not count the actual time. (4 times slow...)