### PR TITLE
net: ethernet: Add EAPoL ether type support

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -66,6 +66,7 @@ struct net_eth_addr {
 #define NET_ETH_PTYPE_LLDP		0x88cc
 #define NET_ETH_PTYPE_ALL               0x0003 /* from linux/if_ether.h */
 #define NET_ETH_PTYPE_ECAT		0x88a4
+#define NET_ETH_PTYPE_EAPOL		0x888e
 
 #if !defined(ETH_P_ALL)
 #define ETH_P_ALL	NET_ETH_PTYPE_ALL

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -240,6 +240,9 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		net_pkt_set_family(pkt, AF_INET6);
 		family = AF_INET6;
 		break;
+	case NET_ETH_PTYPE_EAPOL:
+		family = AF_UNSPEC;
+		break;
 #if defined(CONFIG_NET_L2_PTP)
 	case NET_ETH_PTYPE_PTP:
 		family = AF_UNSPEC;


### PR DESCRIPTION
Wi-Fi protocol uses EAPoL ether type frames for authentication, so, add
support for that ether type so that they are not dropped.

Though we have NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE to allow
unknown frames to be passed up the stack, but this might cause
performance penalty.