### PR TITLE
drivers: flash: sam: Fix sam flash controller support

### DIFF
--- a/dts/arm/atmel/sam3x.dtsi
+++ b/dts/arm/atmel/sam3x.dtsi
@@ -47,7 +47,14 @@
 				reg = <0x00080000 0x80000>;
 
 				write-block-size = <16>;
+				erase-block-size = <512>;
 			};
+
+			/*
+			 * SAM3X doesn't support erase pages command and must
+			 * be keeped disabled.
+			 */
+			status = "disabled";
 		};
 
 		wdt: watchdog@400e1a50 {

--- a/dts/arm/atmel/sam4e.dtsi
+++ b/dts/arm/atmel/sam4e.dtsi
@@ -41,7 +41,6 @@
 			compatible = "mmio-sram";
 		};
 
-		/* Only used for HWINFO device ID */
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
@@ -54,6 +53,7 @@
 				compatible = "soc-nv-flash";
 
 				write-block-size = <16>;
+				erase-block-size = <8192>;
 			};
 		};
 

--- a/dts/arm/atmel/sam4l.dtsi
+++ b/dts/arm/atmel/sam4l.dtsi
@@ -51,18 +51,23 @@
 
 	soc {
 		flashcalw: flash-controller@400a0000 {
-			compatible = "atmel,sam-flash-controller";
+			compatible = "atmel,sam4l-flashcalw-controller";
 			reg = <0x400a0000 0x400>;
 			interrupts = <0 0>;
-			peripheral-id = <32>;
 			#address-cells = <1>;
 			#size-cells = <1>;
 
 			flash0: flash@0 {
 				compatible = "soc-nv-flash";
 
-				write-block-size = <16>;
+				write-block-size = <8>;
+				erase-block-size = <512>;
 			};
+
+			/*
+			 * No driver implemented yet, keeped it disabled
+			 */
+			status = "disabled";
 		};
 
 		twim0: twim@40018000 {

--- a/dts/arm/atmel/sam4s.dtsi
+++ b/dts/arm/atmel/sam4s.dtsi
@@ -42,7 +42,6 @@
 			compatible = "mmio-sram";
 		};
 
-		/* Only used for HWINFO device ID */
 		eefc: flash-controller@400e0a00 {
 			compatible = "atmel,sam-flash-controller";
 			reg = <0x400e0a00 0x200>;
@@ -55,6 +54,7 @@
 				compatible = "soc-nv-flash";
 
 				write-block-size = <16>;
+				erase-block-size = <8192>;
 			};
 		};
 

--- a/dts/bindings/flash_controller/atmel,sam4l-flashcalw-controller.yaml
+++ b/dts/bindings/flash_controller/atmel,sam4l-flashcalw-controller.yaml
@@ -1,0 +1,8 @@
+# Copyright (c) 2022, Gerson Fernando Budke <nandojve@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+description: Atmel SAM4L Flash Controller Double Word (FLASHCALW)
+
+compatible: "atmel,sam4l-flashcalw-controller"
+
+include: flash-controller.yaml


### PR DESCRIPTION
The current atmel sam flash driver was develop based on the cortex-m7 version of smart arm microcontroller. The driver support write protection and cache functions which is not supported by the cortex-m4 variants. The cortex-m3 doesn't have support erase pages command and because of that it is not compatible.

Fixes #48516

Signed-off-by: Gerson Fernando Budke <nandojve@gmail.com>