### PR TITLE
Run SX12XX callback before starting reception again

### DIFF
--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -103,10 +103,10 @@ static void sx12xx_ev_rx_done(uint8_t *payload, uint16_t size, int16_t rssi,
 
 	/* Receiving in asynchronous mode */
 	if (dev_data.async_rx_cb) {
-		/* Start receiving again */
-		Radio.Rx(0);
 		/* Run the callback */
 		dev_data.async_rx_cb(dev_data.dev, payload, size, rssi, snr);
+		/* Start receiving again */
+		Radio.Rx(0);
 		/* Don't run the synchronous code */
 		return;
 	}


### PR DESCRIPTION
For asynchronous reception on the SX1276, the callback must be run before reception is started again, or the payload memory will be zero'd.

If you look over in loramac-node sx1276.c, you can see that it calls memset on the rxtxbuffer (IE payload) when SX1276SetRx (the alias for Radio.Rx(0) in this case) is called.

This was tested on a NR52840 with a SX1276 connected (doing async reception), and a device transmitting one packet a second.

I have verified by code inspection that SX1272 has the same issue.

SX1262 does not appear to memset the buffer when RX is called.   However, even without this bug, you don't want the radio receiving again before running the callback since it still risks overwriting the payload buffer on the SX1262 when the next reception comes in.


Signed-off-by: Daniel Berlin <dberlin@dberlin.org>