### PR TITLE
drivers: i2c: sam0: Lock bus before referencing messages

### DIFF
--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -389,10 +389,11 @@ static int i2c_sam0_transfer(const struct device *dev, struct i2c_msg *msgs,
 	if (!num_msgs) {
 		return 0;
 	}
-	data->num_msgs = num_msgs;
-	data->msgs = msgs;
 
 	k_sem_take(&data->lock, K_FOREVER);
+
+	data->num_msgs = num_msgs;
+	data->msgs = msgs;
 
 	for (; data->num_msgs > 0;) {
 		if (!data->msgs->len) {


### PR DESCRIPTION
The I2C bus lock did not previously enclose the referencing of the transfers to conduct. If two attempts are made to use the bus at a similar time, then one set of messages may have been transferred twice.

This patch resolves this error.