### PR TITLE
ADC Support for STM32U575

### DIFF
--- a/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
+++ b/boards/arm/nucleo_u575zi_q/nucleo_u575zi_q-common.dtsi
@@ -104,6 +104,12 @@
 	status = "okay";
 };
 
+&adc1 {
+	pinctrl-0 = <&adc1_in1_pc0>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
 &iwdg {
 	status = "okay";
 };

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -656,6 +656,15 @@ static int start_read(const struct device *dev,
 	 * This register controls the analog switch integrated in the IO level.
 	 */
 	LL_ADC_SetChannelPreSelection(adc, channel);
+#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+	/*
+	 * Each channel in the sequence must be previously enabled in PCSEL.
+	 * This register controls the analog switch integrated in the IO level.
+	 * Only for ADC1 instance (ADC4 has no Channel preselection capability).
+	 */
+	if (adc == ADC1) {
+		LL_ADC_SetChannelPreselection(adc, channel);
+	}
 #endif
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \

--- a/samples/drivers/adc/boards/nucleo_u575zi_q.overlay
+++ b/samples/drivers/adc/boards/nucleo_u575zi_q.overlay
@@ -1,0 +1,24 @@
+/* Copyright (c) 2022 STMicroelectronics
+   SPDX-License-Identifier: Apache-2.0 */
+
+#include <zephyr/dt-bindings/adc/adc.h>
+
+ / {
+	zephyr,user {
+		/* adjust channel number according to pinmux in board.dts */
+		io-channels = <&adc1 1>;
+	};
+};
+
+&adc1 {
+	#address-cells = <1>;
+	#size-cells = <0>;
+
+	channel@1 {
+		reg = <1>;
+		zephyr,gain = "ADC_GAIN_1";
+		zephyr,reference = "ADC_REF_INTERNAL";
+		zephyr,acquisition-time = <ADC_ACQ_TIME_DEFAULT>;
+		zephyr,resolution = <14>;
+	};
+};


### PR DESCRIPTION
For the ADC driver of the stm32u5 serie, the channel preselection was missing. It is done like the stm32H7 serie but stm32Cube/stm32U5 has its own stm32Cube function name.

Note that stm32Cube LL function is planned to be updated in a next version (1.2.0) of the HAL_LL.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48682

Signed-off-by: Francois Ramu <francois.ramu@st.com>