### PR TITLE
drivers: pinctrl: stm32: Kconfig: add missing dependency

### DIFF
--- a/drivers/pinctrl/Kconfig.stm32
+++ b/drivers/pinctrl/Kconfig.stm32
@@ -11,6 +11,7 @@ config PINCTRL_STM32
 config PINCTRL_STM32_REMAP_INIT_PRIORITY
 	int "Remap initialization priority"
 	default 2
+	depends on PINCTRL_STM32
 	help
 	  Initialization priority for the routine in charge of configuring the
 	  remap for pins PA11/12.


### PR DESCRIPTION
Add a missing `PINCTRL_STM32` dependency for `PINCTRL_STM32_REMAP_INIT_PRIORITY` option to use that option only when STM32 pinctrl driver is being used. Currently, that option is being set even when a different SOC is used which is a bit confusing.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>