### PR TITLE
tests: arm: Increase main stack size with no optimizations

### DIFF
--- a/subsys/testsuite/Kconfig
+++ b/subsys/testsuite/Kconfig
@@ -139,7 +139,10 @@ config TEST_ARM_CORTEX_M
 	help
 	  ARM Cortex-M configuration required when testing.
 
-	  Currently, this option is only utilized, to force routing
+	  This option is used to select stack sizes and enable features for
+	  testing.
+
+	  This option is also used to force routing
 	  BusFault, HardFault, and NMI exceptions to Secure State,
 	  when building a Secure ARMv8-M firmware. This will allow
 	  the testing suite to utilize these exceptions, in tests.

--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -10,7 +10,7 @@ tests:
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
-      - CONFIG_MAIN_STACK_SIZE=1024
+      - CONFIG_MAIN_STACK_SIZE=2048
   arch.interrupt.extra_exception_info:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:

--- a/tests/arch/arm/arm_thread_swap/testcase.yaml
+++ b/tests/arch/arm/arm_thread_swap/testcase.yaml
@@ -10,6 +10,7 @@ tests:
     extra_configs:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
+      - CONFIG_MAIN_STACK_SIZE=2048
     min_flash: 192
   arch.arm.swap.common.fpu_sharing:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE and CONFIG_ARMV7_M_ARMV8_M_FP
@@ -23,4 +24,5 @@ tests:
       - CONFIG_FPU_SHARING=y
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
+      - CONFIG_MAIN_STACK_SIZE=2048
     min_flash: 192


### PR DESCRIPTION
If the test is run with the config NO_OPTIMIZATIONS enabled then the
stack size usage increases by around 80% for ARM platforms.
Increase the stack size used in test cases that enables building with no
optimizations for ARM.


Update description on TEST_ARM_CORTEX_M since it was outdated and said
it was only used for a single purpose.

Fixes: #47930
Fixes: #47929
Fixes: #47855

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>