### PR TITLE
tests: net: socket: Disable unstable tests for mps2_an385

### DIFF
--- a/tests/net/socket/poll/testcase.yaml
+++ b/tests/net/socket/poll/testcase.yaml
@@ -1,5 +1,9 @@
 common:
   depends_on: netif
+  # FIXME: This test fails very frequently on mps2_an385 due to the system
+  #        timer stability issues, so keep it disabled until the root cause
+  #        is fixed (GitHub issue zephyrproject-rtos/zephyr#48608).
+  platform_exclude: mps2_an385
 tests:
   net.socket.poll:
     min_ram: 21

--- a/tests/net/socket/select/testcase.yaml
+++ b/tests/net/socket/select/testcase.yaml
@@ -3,6 +3,10 @@ common:
   min_ram: 21
   tags: net socket userspace
   filter: TOOLCHAIN_HAS_NEWLIB == 1
+  # FIXME: This test fails very frequently on mps2_an385 due to the system
+  #        timer stability issues, so keep it disabled until the root cause
+  #        is fixed (GitHub issue zephyrproject-rtos/zephyr#48608).
+  platform_exclude: mps2_an385
 tests:
   net.socket.select:
     extra_configs:

--- a/tests/net/socket/tcp/testcase.yaml
+++ b/tests/net/socket/tcp/testcase.yaml
@@ -4,6 +4,10 @@ common:
   tags: net socket userspace
   filter: TOOLCHAIN_HAS_NEWLIB == 1
   timeout: 120
+  # FIXME: This test fails very frequently on mps2_an385 due to the system
+  #        timer stability issues, so keep it disabled until the root cause
+  #        is fixed (GitHub issue zephyrproject-rtos/zephyr#48608).
+  platform_exclude: mps2_an385
 tests:
   net.socket.tcp:
     extra_configs:
@@ -12,7 +16,3 @@ tests:
     extra_configs:
       - CONFIG_NET_TC_THREAD_PREEMPTIVE=y
       - CONFIG_NET_TCP_RANDOMIZED_RTO=n
-    # FIXME: This test fails very frequently on mps2_an385 due to the system
-    #        timer stability issues, so keep it disabled until the root cause
-    #        is fixed (GitHub issue zephyrproject-rtos/zephyr#48608).
-    platform_exclude: mps2_an385


### PR DESCRIPTION
Disable unstable tests cases for mps2_an385, which fail sporadically
due to timer stability issues on that platform (see #48608).

Fixes #48779

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>