### PR TITLE
manifest: update MCUboot

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -172,7 +172,7 @@ manifest:
       groups:
         - crypto
     - name: mcuboot
-      revision: 1d4404116a9a6b54d54ea9aa3dd2575286e666cd
+      revision: 9c737361d59d21709a57b1dbec18711e89d9d6aa
       path: bootloader/mcuboot
     - name: mipi-sys-t
       path: modules/debug/mipi-sys-t


### PR DESCRIPTION
Synchronized up to: b03c098

- add support for generic watchdog alias
- direct inclusion of the hooks file

Signed-off-by: Andrzej Puzdrowski <andrzej.puzdrowski@nordicsemi.no>