### PR TITLE
drivers: clock_control: avoid calling device_is_ready() in API calls

### DIFF
--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -741,6 +741,11 @@ static int adc_npcx_init(const struct device *dev)
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int prescaler = 0, ret;
 
+	if (!device_is_ready(clk_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Save ADC device in data */
 	data->adc_dev = dev;
 

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -975,6 +975,11 @@ static int adc_stm32_init(const struct device *dev)
 
 	LOG_DBG("Initializing....");
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	data->dev = dev;
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \
 	defined(CONFIG_SOC_SERIES_STM32G0X) || \

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -46,6 +46,11 @@ static int mcux_mcan_init(const struct device *dev)
 	const struct mcux_mcan_config *mcux_config = mcan_config->custom;
 	int err;
 
+	if (!device_is_ready(mcux_config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 #ifdef CONFIG_PINCTRL
 	err = pinctrl_apply_state(mcux_config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err) {

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -941,6 +941,11 @@ static int can_rcar_init(const struct device *dev)
 		}
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Configure dt provided device signals when available */
 	ret = pinctrl_apply_state(config->pcfg, PINCTRL_STATE_DEFAULT);
 	if (ret < 0) {

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -520,6 +520,10 @@ static int can_stm32_init(const struct device *dev)
 	}
 
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	if (!device_is_ready(clock)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
 
 	ret = clock_control_on(clock, (clock_control_subsys_t *) &cfg->pclken);
 	if (ret != 0) {

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -72,6 +72,7 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 	int ret;
 	const struct can_mcan_config *mcan_cfg = dev->config;
 	const struct can_stm32fd_config *stm32fd_cfg = mcan_cfg->custom;
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	LL_RCC_SetFDCANClockSource(CAN_STM32FD_CLOCK_SOURCE);
 
@@ -82,8 +83,11 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 	LL_RCC_PLL2_EnableDomain_SAI();
 #endif
 
-	ret = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			       (clock_control_subsys_t *)&stm32fd_cfg->pclken);
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
+
+	ret = clock_control_on(clk, (clock_control_subsys_t *)&stm32fd_cfg->pclken);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -52,6 +52,11 @@ static int can_stm32h7_clock_enable(const struct device *dev)
 
 	LL_RCC_SetFDCANClockSource(LL_RCC_FDCAN_CLKSOURCE_PLL1Q);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	ret = clock_control_on(clk, (clock_control_subsys_t *)&stm32h7_cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("failure enabling clock");

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -282,6 +282,11 @@ static int rtc_stm32_init(const struct device *dev)
 
 	data->callback = NULL;
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -354,6 +354,10 @@ static int counter_stm32_get_tim_clk(const struct stm32_pclken *pclken, uint32_t
 
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		return -ENODEV;
+	}
+
 	r = clock_control_get_rate(clk, (clock_control_subsys_t *)pclken,
 				   &bus_clk);
 	if (r < 0) {

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -250,8 +250,12 @@ static int mcux_lpc_ctimer_init(const struct device *dev)
 {
 	const struct mcux_lpc_ctimer_config *config = dev->config;
 	struct mcux_lpc_ctimer_data *data = dev->data;
-
 	ctimer_config_t ctimer_config;
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
 
 	for (uint8_t chan = 0; chan < NUM_CHANNELS; chan++) {
 		data->channels[chan].alarm_callback = NULL;

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -168,6 +168,11 @@ static int mcux_gpt_init(const struct device *dev)
 	gpt_config_t gptConfig;
 	uint32_t clock_freq;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -267,6 +267,11 @@ static int mcux_qtmr_init(const struct device *dev)
 		data->freq = config->info.freq;
 	} else {
 		/* bus clock with divider */
+		if (!device_is_ready(config->clock_dev)) {
+			LOG_ERR("clock control device not ready");
+			return -ENODEV;
+		}
+
 		if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 					&data->freq)) {
 			return -EINVAL;

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -453,6 +453,11 @@ static int crypto_stm32_init(const struct device *dev)
 	struct crypto_stm32_data *data = CRYPTO_STM32_DATA(dev);
 	const struct crypto_stm32_config *cfg = CRYPTO_STM32_CFG(dev);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -121,6 +121,11 @@ static int dac_stm32_init(const struct device *dev)
 	/* enable clock for subsystem */
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(clk,
 			     (clock_control_subsys_t *) &cfg->pclken) != 0) {
 		return -EIO;

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -432,7 +432,13 @@ static int stm32_sdmmc_pwr_uninit(struct stm32_sdmmc_priv *priv)
 static int disk_stm32_sdmmc_init(const struct device *dev)
 {
 	struct stm32_sdmmc_priv *priv = dev->data;
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int err;
+
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
 
 	k_work_init(&priv->work, stm32_sdmmc_cd_handler);
 

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -238,6 +238,11 @@ static int stm32_ltdc_init(const struct device *dev)
 		return err;
 	}
 
+	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Turn on LTDC peripheral clock */
 	err = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 				(clock_control_subsys_t) &config->pclken);

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -616,6 +616,11 @@ static int dma_stm32_init(const struct device *dev)
 	const struct dma_stm32_config *config = dev->config;
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(clk,
 		(clock_control_subsys_t *) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -216,6 +216,11 @@ static int dmamux_stm32_init(const struct device *dev)
 	const struct dmamux_stm32_config *config = dev->config;
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(clk,
 		(clock_control_subsys_t *) &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -604,6 +604,10 @@ static int entropy_stm32_rng_init(const struct device *dev)
 
 	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(dev_data->clock)) {
+		return -ENODEV;
+	}
+
 	res = clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&dev_cfg->pclken);
 	__ASSERT_NO_MSG(res == 0);

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -860,6 +860,11 @@ static int espi_npcx_init(const struct device *dev)
 		npcx_host_interface_sel(NPCX_HIF_TYPE_ESPI_SHI);
 	}
 
+	if (!device_is_ready(clk_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Turn on eSPI device clock first */
 	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
 							&config->clk_cfg);

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -1009,6 +1009,10 @@ int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 	for (i = 0; i < host_sub_cfg.clks_size; i++) {
 		int ret;
 
+		if (!device_is_ready(clk_dev)) {
+			return -ENODEV;
+		}
+
 		ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
 				&host_sub_cfg.clks_list[i]);
 		if (ret < 0) {

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -50,6 +50,12 @@ int dwmac_bus_init(struct dwmac_priv *p)
 	int ret;
 
 	p->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+
+	if (!device_is_ready(p->clock)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	ret  = clock_control_on(p->clock, (clock_control_subsys_t *)&pclken);
 	ret |= clock_control_on(p->clock, (clock_control_subsys_t *)&pclken_tx);
 	ret |= clock_control_on(p->clock, (clock_control_subsys_t *)&pclken_rx);

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -246,7 +246,7 @@ static int eth_mcux_device_pm_action(const struct device *dev,
 	struct eth_context *eth_ctx = dev->data;
 	int ret = 0;
 
-	if (!eth_ctx->clock_dev) {
+	if (!device_is_ready(eth_ctx->clock_dev)) {
 		LOG_ERR("No CLOCK dev");
 
 		ret = -EIO;

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -786,6 +786,11 @@ static int eth_initialize(const struct device *dev)
 
 	dev_data->clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(dev_data->clock)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* enable clock */
 	ret = clock_control_on(dev_data->clock,
 		(clock_control_subsys_t *)&cfg->pclken);

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -358,6 +358,11 @@ static int stm32_flash_init(const struct device *dev)
 	}
 #endif
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* enable clock */
 	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1570,6 +1570,11 @@ static int flash_stm32_ospi_init(const struct device *dev)
 		return ret;
 	}
 
+	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Clock configuration */
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			     (clock_control_subsys_t) &dev_cfg->pclken[0]) != 0) {

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -666,6 +666,11 @@ static int stm32h7_flash_init(const struct device *dev)
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* enable clock */
 	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -525,6 +525,10 @@ static int gpio_lpc11u6x_init(const struct device *dev)
 		return 0;
 	}
 
+	if (!device_is_ready(config->shared->clock_dev)) {
+		return -ENODEV;
+	}
+
 	/* Enable GPIO and PINT clocks. */
 	ret = clock_control_on(config->shared->clock_dev, config->shared->clock_subsys);
 	if (ret < 0) {

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -247,6 +247,10 @@ static int gpio_rcar_init(const struct device *dev)
 	const struct gpio_rcar_cfg *config = dev->config;
 	int ret;
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	ret = clock_control_on(config->clock_dev,
 			       (clock_control_subsys_t *) &config->mod_clk);
 

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -270,8 +270,11 @@ static int gpio_rv32m1_init(const struct device *dev)
 	int ret;
 
 	if (config->clock_dev) {
-		ret = clock_control_on(config->clock_dev, config->clock_subsys);
+		if (!device_is_ready(config->clock_dev)) {
+			return -ENODEV;
+		}
 
+		ret = clock_control_on(config->clock_dev, config->clock_subsys);
 		if (ret < 0) {
 			return ret;
 		}

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -697,6 +697,10 @@ static int gpio_stm32_init(const struct device *dev)
 
 	data->dev = dev;
 
+	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
+		return -ENODEV;
+	}
+
 #if defined(PWR_CR2_IOSV) && DT_NODE_HAS_STATUS(DT_NODELABEL(gpiog), okay)
 	z_stm32_hsem_lock(CFG_HW_RCC_SEMID, HSEM_LOCK_DEFAULT_RETRY);
 	/* Port G[15:2] requires external power supply */

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -680,6 +680,11 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
 	esp_intr_alloc(config->irq_source, 0, i2c_esp32_isr, (void *)dev, NULL);

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -223,6 +223,11 @@ static int i2c_stm32_init(const struct device *dev)
 	 */
 	k_sem_init(&data->bus_mutex, 1, 1);
 
+	if (!device_is_ready(clock)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(clock,
 		(clock_control_subsys_t *) &cfg->pclken) != 0) {
 		LOG_ERR("i2c: failure enabling clock");

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -314,6 +314,10 @@ static int lpc11u6x_i2c_init(const struct device *dev)
 		return err;
 	}
 
+	if (!device_is_ready(cfg->clock_dev)) {
+		return -ENODEV;
+	}
+
 	/* Configure clock and de-assert reset for I2Cx */
 	clock_control_on(cfg->clock_dev, (clock_control_subsys_t) cfg->clkid);
 

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -335,6 +335,11 @@ static int mcux_flexcomm_init(const struct device *dev)
 
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Get the clock frequency */
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -315,6 +315,12 @@ static int mcux_lpi2c_init(const struct device *dev)
 
 	k_sem_init(&data->lock, 1, 1);
 	k_sem_init(&data->device_sync_sem, 0, K_SEM_MAX_LIMIT);
+
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -909,6 +909,11 @@ static int i2c_ctrl_init(const struct device *dev)
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	uint32_t i2c_rate;
 
+	if (!device_is_ready(clk_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Turn on device clock first and get source clock freq. */
 	if (clock_control_on(clk_dev,
 		(clock_control_subsys_t *) &config->clk_cfg) != 0) {

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -321,6 +321,10 @@ static int i2c_rcar_init(const struct device *dev)
 
 	k_sem_init(&data->int_sem, 0, 1);
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	ret = clock_control_on(config->clock_dev,
 			       (clock_control_subsys_t *)&config->mod_clk);
 

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -217,6 +217,11 @@ static int rv32m1_lpi2c_init(const struct device *dev)
 
 	CLOCK_SetIpSrc(config->clock_ip_name, config->clock_ip_src);
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	err = clock_control_on(config->clock_dev, config->clock_subsys);
 	if (err) {
 		LOG_ERR("Could not turn on clock (err %d)", err);

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -102,6 +102,11 @@ static int i2s_stm32_enable_clock(const struct device *dev)
 
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	ret = clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("Could not enable I2S clock");

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -221,6 +221,11 @@ static int i2s_mcux_configure(const struct device *dev, enum i2s_dir dir,
 		return -ENOTSUP;
 	}
 
+	if (!device_is_ready(cfg->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Figure out function base clock */
 	if (clock_control_get_rate(cfg->clock_dev,
 				   cfg->clock_subsys, &base_frequency)) {

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -452,7 +452,7 @@ static void get_mclk_rate(const struct device *dev, uint32_t *mclk)
 	clock_control_subsys_t clk_sub_sys = dev_cfg->clk_sub_sys;
 	uint32_t rate = 0;
 
-	if (ccm_dev != NULL) {
+	if (device_is_ready(ccm_dev)) {
 		clock_control_get_rate(ccm_dev, clk_sub_sys, &rate);
 	} else {
 		LOG_ERR("CCM driver is not installed");

--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -515,6 +515,10 @@ static int xec_ecia_init(const struct device *dev)
 	uint32_t n = 0, nr = 0;
 	int ret;
 
+	if (!device_is_ready(clk_dev)) {
+		return -ENODEV;
+	}
+
 	ret = clock_control_on(clk_dev,
 			       (clock_control_subsys_t *)&cfg->clk_ctrl);
 	if (ret < 0) {

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -154,6 +154,10 @@ static int rv32m1_intmux_init(const struct device *dev)
 	INTMUX_Type *regs = DEV_REGS(dev);
 	size_t i;
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	/* Enable INTMUX clock. */
 	clock_control_on(config->clock_dev, config->clock_subsys);
 

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -157,6 +157,11 @@ static int stm32_hsem_mailbox_init(const struct device *dev)
 	/* Config transfer semaphore */
 	switch (CONFIG_IPM_STM32_HSEM_CPU) {
 	case HSEM_CPU1:
+		if (!device_is_ready(clk)) {
+			LOG_ERR("clock control device not ready");
+			return -ENODEV;
+		}
+
 		/* Enable clock */
 		if (clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken) != 0) {
 			LOG_WRN("Failed to enable clock");

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -245,6 +245,11 @@ static int stm32_ipcc_mailbox_init(const struct device *dev)
 
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* enable clock */
 	if (clock_control_on(clk,
 			     (clock_control_subsys_t *)&cfg->pclken) != 0) {

--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -44,6 +44,11 @@ static int memc_stm32_init(const struct device *dev)
 	/* enable FMC peripheral clock */
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	r = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize FMC clock (%d)", r);

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -303,6 +303,11 @@ int pwm_led_esp32_init(const struct device *dev)
 	const struct pwm_ledc_esp32_config *config = dev->config;
 	struct pwm_ledc_esp32_data *data = (struct pwm_ledc_esp32_data *const)(dev)->data;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Enable peripheral */
 	clock_control_on(config->clock_dev, config->clock_subsys);
 

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -413,6 +413,11 @@ int mcpwm_esp32_init(const struct device *dev)
 	struct mcpwm_esp32_data *data = (struct mcpwm_esp32_data *const)(dev)->data;
 	struct mcpwm_esp32_channel_config *channel;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Enable peripheral */
 	ret = clock_control_on(config->clock_dev, config->clock_subsys);
 	if (ret < 0) {

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -137,6 +137,11 @@ static int pwm_mcux_init(const struct device *dev)
 	status_t status;
 	int i, err;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	err = pinctrl_apply_state(config->pincfg, PINCTRL_STATE_DEFAULT);
 	if (err < 0) {
 		return err;

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -404,6 +404,11 @@ static int mcux_ftm_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &data->clock_freq)) {
 		LOG_ERR("Could not get clock frequency");

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -283,6 +283,11 @@ static int mcux_pwt_init(const struct device *dev)
 	pwt_config_t *pwt_config = &data->pwt_config;
 	int err;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &data->clock_freq)) {
 		LOG_ERR("could not get clock frequency");

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -142,6 +142,11 @@ static int mcux_tpm_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(config->clock_dev, config->clock_subsys)) {
 		LOG_ERR("Could not turn on clock");
 		return -EINVAL;

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -183,6 +183,11 @@ static int pwm_npcx_init(const struct device *dev)
 	NPCX_REG_WORD_ACCESS_CHECK(inst->PRSC, 0xA55A);
 
 
+	if (!device_is_ready(clk_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Turn on device clock first and get source clock freq. */
 	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
 							&config->clk_cfg);

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -147,6 +147,11 @@ static int rv32m1_tpm_init(const struct device *dev)
 		return -EINVAL;
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(config->clock_dev, config->clock_subsys)) {
 		LOG_ERR("Could not turn on clock");
 		return -EINVAL;

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -636,6 +636,11 @@ static int pwm_stm32_init(const struct device *dev)
 	/* enable clock and store its speed */
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	r = clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize clock (%d)", r);

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -785,6 +785,10 @@ static int imx_usdhc_init(const struct device *dev)
 		.TransferComplete = transfer_complete_cb,
 	};
 
+	if (!device_is_ready(cfg->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
 
 #ifdef CONFIG_PINCTRL
 	ret = pinctrl_apply_state(cfg->pincfg, PINCTRL_STATE_DEFAULT);

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -314,6 +314,11 @@ static int tach_npcx_init(const struct device *dev)
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
 
+	if (!device_is_ready(clk_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Turn on device clock first and get source clock freq. */
 	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
 							&config->clk_cfg);

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -75,6 +75,10 @@ static int serial_esp32_usb_init(const struct device *dev)
 	const struct serial_esp32_usb_config *config = dev->config;
 	struct serial_esp32_usb_data *data = dev->data;
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	int ret = clock_control_on(config->clock_dev, config->clock_subsys);
 
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -201,6 +201,10 @@ static int uart_esp32_configure(const struct device *dev, const struct uart_conf
 		return ret;
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
 	uart_hal_set_sclk(&data->hal, UART_SCLK_APB);

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -347,6 +347,10 @@ static int lpc11u6x_uart0_init(const struct device *dev)
 		return err;
 	}
 
+	if (!device_is_ready(cfg->clock_dev)) {
+		return -ENODEV;
+	}
+
 	clock_control_on(cfg->clock_dev, (clock_control_subsys_t) cfg->clkid);
 
 	/* Configure baudrate, parity and stop bits */

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -46,6 +46,10 @@ static int uart_mcux_configure(const struct device *dev,
 	uint32_t clock_freq;
 	status_t retval;
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -265,6 +265,10 @@ static int mcux_flexcomm_init(const struct device *dev)
 	}
 #endif /* CONFIG_PINCTRL */
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	/* Get the clock frequency */
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -227,6 +227,10 @@ static int mcux_iuart_init(const struct device *dev)
 	uint32_t clock_freq;
 	int err;
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -241,6 +241,10 @@ static int mcux_lpsci_init(const struct device *dev)
 	uint32_t clock_freq;
 	int err;
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -883,6 +883,10 @@ static int mcux_lpuart_configure_init(const struct device *dev, const struct uar
 	struct mcux_lpuart_data *data = dev->data;
 	uint32_t clock_freq;
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -434,6 +434,11 @@ static int uart_npcx_init(const struct device *dev)
 	uint32_t uart_rate;
 	int ret;
 
+	if (!device_is_ready(clk_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Turn on device clock first and get source clock freq. */
 	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
 	if (ret < 0) {

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -377,7 +377,7 @@ static int uart_ns16550_configure(const struct device *dev,
 	if (dev_cfg->sys_clk_freq != 0U) {
 		pclk = dev_cfg->sys_clk_freq;
 	} else {
-		if (dev_cfg->clock_dev == NULL) {
+		if (!device_is_ready(dev_cfg->clock_dev)) {
 			ret = -EINVAL;
 			goto out;
 		}

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -273,6 +273,10 @@ static int uart_rcar_init(const struct device *dev)
 		return ret;
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	ret = clock_control_on(config->clock_dev,
 			       (clock_control_subsys_t *)&config->mod_clk);
 	if (ret < 0) {

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -254,6 +254,10 @@ static int rv32m1_lpuart_init(const struct device *dev)
 	/* TODO: Don't change if another core has configured */
 	CLOCK_SetIpSrc(config->clock_ip_name, config->clock_ip_src);
 
+	if (!device_is_ready(config->clock_dev)) {
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -1563,6 +1563,12 @@ static int uart_stm32_init(const struct device *dev)
 	int err;
 
 	__uart_stm32_get_clock(dev);
+
+	if (!device_is_ready(data->clock)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* enable clock */
 	err = clock_control_on(data->clock, (clock_control_subsys_t)&config->pclken[0]);
 	if (err != 0) {

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -164,6 +164,11 @@ static int IRAM_ATTR spi_esp32_configure(const struct device *dev,
 		return 0;
 	}
 
+	if (!device_is_ready(cfg->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* enables SPI peripheral */
 	if (clock_control_on(cfg->clock_dev, cfg->clock_subsys)) {
 		LOG_ERR("Could not enable SPI clock");

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -862,6 +862,11 @@ static int spi_stm32_init(const struct device *dev)
 	const struct spi_stm32_config *cfg = dev->config;
 	int err;
 
+	if (!device_is_ready(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE))) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	err = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
 			       (clock_control_subsys_t) &cfg->pclken[0]);
 	if (err < 0) {

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -632,6 +632,11 @@ static int spi_mcux_configure(const struct device *dev,
 	ctar_config->lastSckToPcsDelayInNanoSec = config->sck_pcs_delay;
 	ctar_config->betweenTransferDelayInNanoSec = config->transfer_delay;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -202,6 +202,11 @@ static int spi_mcux_configure(const struct device *dev,
 
 		SPI_MasterGetDefaultConfig(&master_config);
 
+		if (!device_is_ready(config->clock_dev)) {
+			LOG_ERR("clock control device not ready");
+			return -ENODEV;
+		}
+
 		/* Get the clock frequency */
 		if (clock_control_get_rate(config->clock_dev,
 					   config->clock_subsys, &clock_freq)) {

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -215,6 +215,11 @@ static int spi_mcux_configure(const struct device *dev,
 	master_config.lastSckToPcsDelayInNanoSec = config->sck_pcs_delay;
 	master_config.betweenTransferDelayInNanoSec = config->transfer_delay;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -186,6 +186,11 @@ static int spi_mcux_configure(const struct device *dev,
 
 	master_config.baudRate = spi_cfg->frequency;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -308,6 +308,11 @@ static int sys_clock_driver_init(const struct device *dev)
 	uint32_t sys_tmr_rate;
 	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 
+	if (!device_is_ready(clk_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	/* Turn on all itim module clocks used for counting */
 	for (int i = 0; i < ARRAY_SIZE(itim_clk_cfg); i++) {
 		ret = clock_control_on(clk_dev, (clock_control_subsys_t *)

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -95,7 +95,7 @@ static int sys_clock_driver_init(const struct device *dev)
 
 	ARG_UNUSED(dev);
 	clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
-	if (clk == NULL) {
+	if (!device_is_ready(clk)) {
 		return -ENODEV;
 	}
 

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -316,6 +316,11 @@ static int usb_dc_stm32_clock_enable(void)
 	}
 #endif /* RCC_HSI48_SUPPORT / LL_RCC_USB_CLKSOURCE_NONE / RCC_CFGR_OTGFSPRE / RCC_CFGR_USBPRE */
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_on(clk, (clock_control_subsys_t *)&pclken) != 0) {
 		LOG_ERR("Unable to enable USB clock");
 		return -EIO;

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -153,6 +153,11 @@ static int wdt_esp32_init(const struct device *dev)
 	const struct wdt_esp32_config *const config = dev->config;
 	struct wdt_esp32_data *data = dev->data;
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	clock_control_on(config->clock_dev, config->clock_subsys);
 
 	wdt_hal_init(&data->hal, config->wdt_inst, MWDT_TICK_PRESCALER, true);

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -78,6 +78,11 @@ static int mcux_wdog_install_timeout(const struct device *dev,
 		return -ENOMEM;
 	}
 
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -93,6 +93,11 @@ static int mcux_wdog32_install_timeout(const struct device *dev,
 #if DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency)
 	clock_freq = config->clock_frequency;
 #else /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
+	if (!device_is_ready(config->clock_dev)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	if (clock_control_get_rate(config->clock_dev, config->clock_subsys,
 				   &clock_freq)) {
 		return -EINVAL;

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -282,6 +282,11 @@ static int wwdg_stm32_init(const struct device *dev)
 
 	wwdg_stm32_irq_config(dev);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	return clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
 }
 

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -43,7 +43,6 @@ enum clock_control_status {
 	CLOCK_CONTROL_STATUS_STARTING,
 	CLOCK_CONTROL_STATUS_OFF,
 	CLOCK_CONTROL_STATUS_ON,
-	CLOCK_CONTROL_STATUS_UNAVAILABLE,
 	CLOCK_CONTROL_STATUS_UNKNOWN
 };
 
@@ -122,10 +121,6 @@ struct clock_control_driver_api {
 static inline int clock_control_on(const struct device *dev,
 				   clock_control_subsys_t sys)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
-	}
-
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 
@@ -145,10 +140,6 @@ static inline int clock_control_on(const struct device *dev,
 static inline int clock_control_off(const struct device *dev,
 				    clock_control_subsys_t sys)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
-	}
-
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 
@@ -184,10 +175,6 @@ static inline int clock_control_async_on(const struct device *dev,
 		return -ENOSYS;
 	}
 
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
-	}
-
 	return api->async_on(dev, sys, cb, user_data);
 }
 
@@ -209,10 +196,6 @@ static inline enum clock_control_status clock_control_get_status(const struct de
 		return CLOCK_CONTROL_STATUS_UNKNOWN;
 	}
 
-	if (!device_is_ready(dev)) {
-		return CLOCK_CONTROL_STATUS_UNAVAILABLE;
-	}
-
 	return api->get_status(dev, sys);
 }
 
@@ -227,10 +210,6 @@ static inline int clock_control_get_rate(const struct device *dev,
 					 clock_control_subsys_t sys,
 					 uint32_t *rate)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
-	}
-
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 
@@ -261,10 +240,6 @@ static inline int clock_control_set_rate(const struct device *dev,
 		clock_control_subsys_t sys,
 		clock_control_subsys_rate_t rate)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
-	}
-
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 
@@ -301,10 +276,6 @@ static inline int clock_control_configure(const struct device *dev,
 					  clock_control_subsys_t sys,
 					  void *data)
 {
-	if (!device_is_ready(dev)) {
-		return -ENODEV;
-	}
-
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
 

--- a/soc/arm/st_stm32/common/stm32_backup_sram.c
+++ b/soc/arm/st_stm32/common/stm32_backup_sram.c
@@ -27,6 +27,11 @@ static int stm32_backup_sram_init(const struct device *dev)
 	/* enable clock for subsystem */
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
+	if (!device_is_ready(clk)) {
+		LOG_ERR("clock control device not ready");
+		return -ENODEV;
+	}
+
 	ret = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
 	if (ret < 0) {
 		LOG_ERR("Could not initialize backup SRAM clock (%d)", ret);


### PR DESCRIPTION
Change the clock control driver API to not call device_is_ready() in every API call. It is up to the caller to ensure that the clock control device is ready before calling a clock control API function.
    
Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>
