### PR TITLE
sd: sdmmc: wait before sending second OCR

### DIFF
--- a/subsys/sd/sdmmc.c
+++ b/subsys/sd/sdmmc.c
@@ -998,6 +998,11 @@ int sdmmc_card_init(struct sd_card *card)
 			ocr_arg |= SD_OCR_VDD29_30FLAG;
 		}
 		ocr_arg |= (SD_OCR_VDD32_33FLAG | SD_OCR_VDD33_34FLAG);
+		/* Momentary delay before initialization OCR. Some cards will
+		 * never leave busy state if init OCR is sent too soon after
+		 * probing OCR
+		 */
+		k_busy_wait(100);
 		/* Send SD OCR to card to initialize it */
 		ret = sdmmc_send_ocr(card, ocr_arg);
 	} else {


### PR DESCRIPTION
introduce a small wait between probing and initialization OCR. This
delay fixes a failure to initialize seen on some SD cards

Fixes #47238

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>