### PR TITLE
entropy: remove Kconfig.defconfig* setting of entropy drivers

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -8,10 +8,6 @@ if  BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 config BOARD
 	default "nrf5340dk_nrf5340_cpuapp" if BOARD_NRF5340DK_NRF5340_CPUAPP || BOARD_NRF5340DK_NRF5340_CPUAPP_NS
 
-config ENTROPY_BT_HCI
-	default y if BT_HCI_HOST
-	depends on ENTROPY_GENERATOR
-
 # By default, if we build for a Non-Secure version of the board,
 # enable building with TF-M as the Secure Execution Environment.
 config BUILD_WITH_TFM

--- a/boards/posix/native_posix/Kconfig.defconfig
+++ b/boards/posix/native_posix/Kconfig.defconfig
@@ -25,10 +25,6 @@ config ETH_NATIVE_POSIX
 
 endif # NETWORKING
 
-config FAKE_ENTROPY_NATIVE_POSIX
-	default y
-	depends on ENTROPY_GENERATOR
-
 choice BT_HCI_BUS_TYPE
 	default BT_USERCHAN
 	depends on BT_HCI

--- a/boards/riscv/esp32c3_devkitm/Kconfig.defconfig
+++ b/boards/riscv/esp32c3_devkitm/Kconfig.defconfig
@@ -7,9 +7,6 @@ config BOARD
 	default "esp32c3_devkitm"
 	depends on BOARD_ESP32C3_DEVKITM
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
 if BT
 
 config HEAP_MEM_POOL_SIZE

--- a/boards/riscv/icev_wireless/Kconfig.defconfig
+++ b/boards/riscv/icev_wireless/Kconfig.defconfig
@@ -5,9 +5,6 @@ config BOARD
 	default "icev_wireless"
 	depends on BOARD_ICEV_WIRELESS
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
 if BT
 
 config HEAP_MEM_POOL_SIZE

--- a/boards/riscv/tlsr9518adk80d/Kconfig.defconfig
+++ b/boards/riscv/tlsr9518adk80d/Kconfig.defconfig
@@ -6,9 +6,6 @@ if BOARD_TLSR9518ADK80D
 config BOARD
 	default "tlsr9518adk80d"
 
-config ENTROPY_TELINK_B91_TRNG
-	default y if ENTROPY_GENERATOR
-
 config SOC_FLASH_TELINK_B91
 	default y if FLASH
 

--- a/boards/xtensa/esp32/Kconfig.defconfig
+++ b/boards/xtensa/esp32/Kconfig.defconfig
@@ -7,9 +7,6 @@ config BOARD
 	default "esp32"
 	depends on BOARD_ESP32
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
 if BT
 
 config HEAP_MEM_POOL_SIZE

--- a/boards/xtensa/esp32s2_saola/Kconfig.defconfig
+++ b/boards/xtensa/esp32s2_saola/Kconfig.defconfig
@@ -9,6 +9,3 @@ config BOARD
 
 config ENTROPY_GENERATOR
 	default y
-
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR

--- a/boards/xtensa/esp_wrover_kit/Kconfig.defconfig
+++ b/boards/xtensa/esp_wrover_kit/Kconfig.defconfig
@@ -7,9 +7,6 @@ config BOARD
 	default "esp_wrover_kit"
 	depends on BOARD_ESP_WROVER_KIT
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
 if BT
 
 config HEAP_MEM_POOL_SIZE

--- a/boards/xtensa/heltec_wifi_lora32_v2/Kconfig.defconfig
+++ b/boards/xtensa/heltec_wifi_lora32_v2/Kconfig.defconfig
@@ -6,6 +6,3 @@
 config BOARD
 	default "heltec_wifi_lora32"
 	depends on BOARD_HELTEC_WIFI_LORA32
-
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR

--- a/boards/xtensa/odroid_go/Kconfig.defconfig
+++ b/boards/xtensa/odroid_go/Kconfig.defconfig
@@ -7,9 +7,6 @@ config BOARD
 	default "odroid_go"
 	depends on BOARD_ODROID_GO
 
-config ENTROPY_ESP32_RNG
-	default y if ENTROPY_GENERATOR
-
 config DISK_DRIVER_SDMMC
 	default y if DISK_ACCESS
 

--- a/drivers/entropy/Kconfig.gecko
+++ b/drivers/entropy/Kconfig.gecko
@@ -18,7 +18,6 @@ config ENTROPY_GECKO_SE
 	default y
 	depends on DT_HAS_SILABS_GECKO_SEMAILBOX_ENABLED
 	select ENTROPY_HAS_DRIVER
-	default y
 	help
 	  This option enables the true random number generator
 	  driver based on the Secure Element (SE) module.

--- a/soc/arm/atmel_sam/sam4l/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/sam4l/Kconfig.defconfig.series
@@ -37,10 +37,6 @@ config NUM_IRQS
 # device driver the default configuration will be placed in the board defconfig
 # file.
 
-config ENTROPY_SAM_RNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 config USART_SAM
 	default y
 	depends on SERIAL

--- a/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/same70/Kconfig.defconfig.series
@@ -53,8 +53,4 @@ config USB_DC_SAM_USBHS
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config ENTROPY_SAM_RNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 endif # SOC_SERIES_SAME70

--- a/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam/samv71/Kconfig.defconfig.series
@@ -54,8 +54,4 @@ config USB_DC_SAM_USBHS
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config ENTROPY_SAM_RNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 endif # SOC_SERIES_SAMV71

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -16,10 +16,6 @@ config PINCTRL_IMX
 	default y if HAS_MCUX_IOMUXC
 	depends on PINCTRL
 
-config ENTROPY_MCUX_TRNG
-	default y if HAS_MCUX_TRNG
-	depends on ENTROPY_GENERATOR
-
 config ADC_MCUX_12B1MSPS_SAR
 	default y if HAS_MCUX_12B1MSPS_SAR
 	depends on ADC

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.series
@@ -25,10 +25,6 @@ config ZTEST_NO_YIELD
 config FLASH_BASE_ADDRESS
 	default $(dt_node_reg_addr_hex,/soc/spi@134000,1)
 
-config ENTROPY_MCUX_TRNG
-	default y if HAS_MCUX_TRNG
-	depends on ENTROPY_GENERATOR
-
 if FLASH_MCUX_FLEXSPI_XIP
 
 # Avoid RWW hazards by defaulting logging to disabled

--- a/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
+++ b/soc/arm/nxp_kinetis/k2x/Kconfig.defconfig.mk22f12
@@ -11,10 +11,6 @@ config SOC
 config GPIO
 	default y
 
-config ENTROPY_MCUX_RNGA
-	default y
-	depends on ENTROPY_GENERATOR
-
 config USB_KINETIS
 	default y
 	depends on USB_DEVICE_DRIVER

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -22,10 +22,6 @@ config ETH_MCUX
 	default y
 	depends on NET_L2_ETHERNET
 
-config ENTROPY_MCUX_RNGA
-	default y
-	depends on ENTROPY_GENERATOR
-
 config USB_KINETIS
 	default y
 	depends on USB_DEVICE_DRIVER

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
@@ -19,10 +19,6 @@ config ETH_MCUX
 	default y
 	depends on NET_L2_ETHERNET
 
-config ENTROPY_MCUX_RNGA
-	default y
-	depends on ENTROPY_GENERATOR
-
 config USB_KINETIS
 	default y
 	depends on USB_DEVICE_DRIVER

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
@@ -19,10 +19,6 @@ config KINETIS_FLASH_CONFIG_FOPT
 	default 0x3f
 	depends on KINETIS_FLASH_CONFIG
 
-config ENTROPY_MCUX_TRNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 config GPIO
 	default y
 

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw2xd512
@@ -19,10 +19,6 @@ config NUM_IRQS
 config SPI
 	default y
 
-config ENTROPY_MCUX_RNGA
-	default y
-	depends on ENTROPY_GENERATOR
-
 config USB_KINETIS
 	default y
 	depends on USB_DEVICE_DRIVER

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw40z4
@@ -10,10 +10,6 @@ config SOC
 config NUM_IRQS
 	default 32
 
-config ENTROPY_MCUX_TRNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 choice CSPRNG_GENERATOR_CHOICE
 	default CTR_DRBG_CSPRNG_GENERATOR
 endchoice

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -15,10 +15,6 @@ config COUNTER_MCUX_RTC
 	default y
 	depends on COUNTER
 
-config ENTROPY_MCUX_TRNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 if NETWORKING
 
 config NET_L2_IEEE802154

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.series
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.series
@@ -12,9 +12,6 @@ config NUM_IRQS
 	# must be >= the highest interrupt number used
 	default 60
 
-config ENTROPY_MCUX_RNG
-	default y if HAS_MCUX_RNG
-
 source "soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lp*"
 
 endif # SOC_SERIES_LPC55XXX

--- a/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f427xx
+++ b/soc/arm/st_stm32/stm32f4/Kconfig.defconfig.stm32f427xx
@@ -11,11 +11,4 @@ config SOC
 config NUM_IRQS
 	default 91
 
-if ENTROPY_GENERATOR
-
-config ENTROPY_STM32_RNG
-	default y
-
-endif # ENTROPY_GENERATOR
-
 endif # SOC_STM32F427XX

--- a/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f767xx
+++ b/soc/arm/st_stm32/stm32f7/Kconfig.defconfig.stm32f767xx
@@ -11,11 +11,4 @@ config SOC
 config NUM_IRQS
 	default 110
 
-if ENTROPY_GENERATOR
-
-config ENTROPY_STM32_RNG
-	default y
-
-endif # ENTROPY_GENERATOR
-
 endif # SOC_STM32F767XX

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
@@ -20,11 +20,4 @@ config ROM_START_OFFSET
 config STM32_LPTIM_TIMER
 	default y if PM
 
-if ENTROPY_GENERATOR
-
-config ENTROPY_STM32_RNG
-	default y
-
-endif # ENTROPY_GENERATOR
-
 endif # SOC_SERIES_STM32H7X

--- a/soc/arm/st_stm32/stm32l5/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l5/Kconfig.defconfig.series
@@ -13,11 +13,4 @@ config SOC_SERIES
 config STM32_LPTIM_TIMER
 	default y if PM
 
-if ENTROPY_GENERATOR
-
-config ENTROPY_STM32_RNG
-	default y
-
-endif # ENTROPY_GENERATOR
-
 endif # SOC_SERIES_STM32L5X

--- a/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
+++ b/soc/arm/ti_simplelink/cc13x2_cc26x2/Kconfig.defconfig.series
@@ -25,10 +25,6 @@ config NUM_IRQS
 config CC13X2_CC26X2_RTC_TIMER
 	default y
 
-config ENTROPY_CC13XX_CC26XX_RNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 if IEEE802154
 
 config IEEE802154_CC13XX_CC26XX

--- a/soc/riscv/openisa_rv32m1/Kconfig.defconfig
+++ b/soc/riscv/openisa_rv32m1/Kconfig.defconfig
@@ -132,8 +132,4 @@ config FLASH_BASE_ADDRESS
 
 endif # FLASH
 
-config ENTROPY_RV32M1_TRNG
-	default y
-	depends on ENTROPY_GENERATOR
-
 endif # SOC_OPENISA_RV32M1_RISCV32


### PR DESCRIPTION
Now that entropy drivers are enabled based on devicetree
we need to remove any cases of them getting enabled by
Kconfig.defconfig* files as this can lead to errors.

Signed-off-by: Kumar Gala <galak@kernel.org>