### PR TITLE
doc: porting/arch: add two funcs for MMU enabling

### DIFF
--- a/doc/hardware/porting/arch.rst
+++ b/doc/hardware/porting/arch.rst
@@ -472,7 +472,11 @@ Memory Management
 
 If the target platform enables paging and requires drivers to memory-map
 their I/O regions, :kconfig:option:`CONFIG_MMU` needs to be enabled and the
-:c:func:`arch_mem_map` API implemented.
+following API implemented:
+
+- :c:func:`arch_mem_map`
+- :c:func:`arch_mem_unmap`
+- :c:func:`arch_page_phys_get`
 
 Stack Objects
 *************


### PR DESCRIPTION
Two more functions are needed for MMU enabling on a new
architecture, so add them to the porting guide.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>