### PR TITLE
west: Fix handling of modules in the boards command

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -71,9 +71,7 @@ import kconfiglib
 def kconfig_load(app: Sphinx) -> Tuple[kconfiglib.Kconfig, Dict[str, str]]:
     """Load Kconfig"""
     with TemporaryDirectory() as td:
-        projects = zephyr_module.west_projects()
-        projects = [p.posixpath for p in projects["projects"]] if projects else None
-        modules = zephyr_module.parse_modules(ZEPHYR_BASE, projects)
+        modules = zephyr_module.parse_modules(ZEPHYR_BASE)
 
         # generate Kconfig.modules file
         kconfig = ""

--- a/scripts/pylib/twister/twisterlib/testplan.py
+++ b/scripts/pylib/twister/twisterlib/testplan.py
@@ -29,7 +29,7 @@ from twisterlib.config_parser import TwisterConfigParser
 from twisterlib.testinstance import TestInstance
 
 
-from zephyr_module import west_projects, parse_modules
+from zephyr_module import parse_modules
 
 ZEPHYR_BASE = os.getenv("ZEPHYR_BASE")
 if not ZEPHYR_BASE:
@@ -225,10 +225,7 @@ class TestPlan:
 
     def handle_modules(self):
         # get all enabled west projects
-        west_proj = west_projects()
-        modules_meta = parse_modules(ZEPHYR_BASE,
-                                    [p.posixpath for p in west_proj['projects']]
-                                    if west_proj else None, None)
+        modules_meta = parse_modules(ZEPHYR_BASE)
         self.modules = [module.meta.get('name') for module in modules_meta]
 
 

--- a/scripts/west_commands/boards.py
+++ b/scripts/west_commands/boards.py
@@ -73,7 +73,7 @@ class Boards(WestCommand):
 
         modules_board_roots = []
 
-        for module in zephyr_module.parse_modules(ZEPHYR_BASE):
+        for module in zephyr_module.parse_modules(ZEPHYR_BASE, self.manifest):
             board_root = module.meta.get('build', {}).get('settings', {}).get('board_root')
             if board_root is not None:
                 modules_board_roots.append(Path(module.project) / board_root)


### PR DESCRIPTION
The boards command was not properly using the zephyr_module
functionality to obtain the board roots of all modules. Fix that by
moving the functionality required to the core zephyr_module file and
reuse it from external scripts.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>