### PR TITLE
net: dns: Check query index in dns_read

### DIFF
--- a/subsys/net/lib/dns/resolve.c
+++ b/subsys/net/lib/dns/resolve.c
@@ -743,7 +743,8 @@ static int dns_read(struct dns_resolve_context *ctx,
 		goto finished;
 	}
 
-	if (ret < 0) {
+	if (ret < 0 || query_idx < 0 ||
+	    query_idx > CONFIG_DNS_NUM_CONCUR_QUERIES) {
 		goto quit;
 	}
 


### PR DESCRIPTION
This commit adds a check, in the `dns_read` function, before
dereferencing the query index returned by the `dns_validate_msg`
function.

This fixes the warnings generated by the GCC 12 such as:

  error: array subscript -1 is below array bounds of
  'struct dns_pending_query[5]' [-Werror=array-bounds]

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>