### PR TITLE
board: nrf53: Fix build error for thingy53_nrf5340 when MPU is disabled

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
+++ b/boards/arm/nrf5340dk_nrf5340/nrf5340_cpunet_reset.c
@@ -9,7 +9,6 @@
 #include <zephyr/logging/log.h>
 
 #include <soc.h>
-#include <soc_secure.h>
 
 LOG_MODULE_REGISTER(nrf5340dk_nrf5340_cpuapp, CONFIG_LOG_DEFAULT_LEVEL);
 

--- a/boards/arm/thingy53_nrf5340/board.c
+++ b/boards/arm/thingy53_nrf5340/board.c
@@ -5,8 +5,10 @@
  */
 
 #include <zephyr/device.h>
-
 #include <zephyr/logging/log.h>
+
+#include <soc.h>
+
 LOG_MODULE_REGISTER(thingy53_board_init);
 
 /* Initialization chain of Thingy:53 board requires some delays before on board sensors


### PR DESCRIPTION
Fix build error for thingy53_nrf5340 board when built CONFIG_ARM_MPU=n.
In this configuration soc.h is not included from board.c, which leaves
NRF_SPU and NRF_RESET undefined.

Remove unused header soc_secure.h from nrf5340dk_nrf5340 board.
The GPIO configuration that used soc_secure.h has been moved out of this
file.

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>