### PR TITLE
doc: extensions: kconfig: improve search capabilities

### DIFF
--- a/doc/_extensions/zephyr/kconfig/__init__.py
+++ b/doc/_extensions/zephyr/kconfig/__init__.py
@@ -253,7 +253,10 @@ def kconfig_build_resources(app: Sphinx) -> None:
         kconfig, module_paths = kconfig_load(app)
         db = list()
 
-        for sc in chain(kconfig.unique_defined_syms, kconfig.unique_choices):
+        for sc in sorted(
+            chain(kconfig.unique_defined_syms, kconfig.unique_choices),
+            key=lambda sc: sc.name if sc.name else "",
+        ):
             # skip nameless symbols
             if not sc.name:
                 continue

--- a/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
@@ -289,11 +289,23 @@ function doSearch() {
     }
 
     /* perform search */
-    let pattern = new RegExp(input.value, 'i');
+    const regexes = input.value.trim().split(/\s+/).map(
+        element => new RegExp(element.toLowerCase())
+    );
     let count = 0;
 
     const searchResults = db.filter(entry => {
-        if (entry.name.match(pattern)) {
+        let matches = 0;
+        const name = entry.name.toLowerCase();
+        const prompt = entry.prompt ? entry.prompt.toLowerCase() : "";
+
+        regexes.forEach(regex => {
+            if (name.search(regex) >= 0 || prompt.search(regex) >= 0) {
+                matches++;
+            }
+        });
+
+        if (matches === regexes.length) {
             count++;
             if (count > searchOffset && count <= (searchOffset + MAX_RESULTS)) {
                 return true;


### PR DESCRIPTION
This patch modifies the Kconfig search _algorithm_ so that it aligns
with how menuconfig search works:

- Input is split into multiple search terms (space-based split)
- Both Kconfig option name and prompt are used
- Regex search is used instead of match, it is less efficient but will
  search the whole string, leading to more results.