### PR TITLE
Bug fix: Queue mode without TLS cache

### DIFF
--- a/subsys/net/lib/lwm2m/lwm2m_engine.c
+++ b/subsys/net/lib/lwm2m/lwm2m_engine.c
@@ -936,7 +936,6 @@ int lwm2m_engine_start(struct lwm2m_ctx *client_ctx)
 		return ret;
 	}
 
-	lwm2m_engine_context_init(client_ctx);
 	return lwm2m_socket_start(client_ctx);
 }
 

--- a/subsys/net/lib/lwm2m/lwm2m_rd_client.c
+++ b/subsys/net/lib/lwm2m/lwm2m_rd_client.c
@@ -1252,6 +1252,9 @@ int lwm2m_rd_client_start(struct lwm2m_ctx *client_ctx, const char *ep_name,
 		return -EINPROGRESS;
 	}
 
+	/* Init Context */
+	lwm2m_engine_context_init(client_ctx);
+
 	client.ctx = client_ctx;
 	client.ctx->sock_fd = -1;
 	client.ctx->fault_cb = socket_fault_cb;


### PR DESCRIPTION
Fix data message loose when message is triggered from idle state.
Handle properly Server rejected Registration update by 4.3 Forbidden.