### PR TITLE
soc: atmel_sam0: fix include path for SAMR35

### DIFF
--- a/soc/arm/atmel_sam0/samr35/linker.ld
+++ b/soc/arm/atmel_sam0/samr35/linker.ld
@@ -5,4 +5,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <arch/arm/aarch32/cortex_m/scripts/linker.ld>
+#include <zephyr/arch/arm/aarch32/cortex_m/scripts/linker.ld>


### PR DESCRIPTION
Add the "zephyr/" prefix... SAML21 and SAMR34 received this attention, but SAMR35 didn't