### PR TITLE
AICS and VOCS cb register fix

### DIFF
--- a/subsys/bluetooth/audio/micp_mic_ctlr.c
+++ b/subsys/bluetooth/audio/micp_mic_ctlr.c
@@ -456,7 +456,9 @@ int bt_micp_mic_ctlr_cb_register(struct bt_micp_mic_ctlr_cb *cb)
 	struct bt_aics_cb *aics_cb = NULL;
 
 	if (cb != NULL) {
-		CHECKIF(cb->aics_cb.discover != NULL) {
+		/* Ensure that the cb->aics_cb.discover is the aics_discover_cb */
+		CHECKIF(cb->aics_cb.discover != NULL &&
+			cb->aics_cb.discover != aics_discover_cb) {
 			BT_ERR("AICS discover callback shall not be set");
 			return -EINVAL;
 		}

--- a/subsys/bluetooth/audio/vcs_client.c
+++ b/subsys/bluetooth/audio/vcs_client.c
@@ -813,7 +813,9 @@ int bt_vcs_client_cb_register(struct bt_vcs_cb *cb)
 	struct bt_vocs_cb *vocs_cb = NULL;
 
 	if (cb != NULL) {
-		CHECKIF(cb->vocs_cb.discover) {
+		/* Ensure that the cb->vocs_cb.discover is the vocs_discover_cb */
+		CHECKIF(cb->vocs_cb.discover != NULL &&
+			cb->vocs_cb.discover != vocs_discover_cb) {
 			BT_ERR("VOCS discover callback shall not be set");
 			return -EINVAL;
 		}

--- a/subsys/bluetooth/audio/vcs_client.c
+++ b/subsys/bluetooth/audio/vcs_client.c
@@ -837,7 +837,9 @@ int bt_vcs_client_cb_register(struct bt_vcs_cb *cb)
 	struct bt_aics_cb *aics_cb = NULL;
 
 	if (cb != NULL) {
-		CHECKIF(cb->aics_cb.discover) {
+		/* Ensure that the cb->aics_cb.discover is the aics_discover_cb */
+		CHECKIF(cb->aics_cb.discover != NULL &&
+			cb->aics_cb.discover != aics_discover_cb) {
 			BT_ERR("AICS discover callback shall not be set");
 			return -EINVAL;
 		}


### PR DESCRIPTION
Fixes issues with calling MICP and VCP callbacks multiple times with the same struct, as the struct may be modified by the stack. 