### PR TITLE
gpio: Move to using select in Kconfig for I2C & SPI busses

### DIFF
--- a/drivers/gpio/Kconfig.cy8c95xx
+++ b/drivers/gpio/Kconfig.cy8c95xx
@@ -7,7 +7,7 @@ menuconfig GPIO_CY8C95XX
 	bool "CY8C95XX I2C GPIO chip"
 	default y
 	depends on DT_HAS_CYPRESS_CY8C95XX_GPIO_PORT_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for CY8C95XX I2C GPIO chip.
 

--- a/drivers/gpio/Kconfig.fxl6408
+++ b/drivers/gpio/Kconfig.fxl6408
@@ -5,7 +5,7 @@ menuconfig GPIO_FXL6408
 	bool "FXL6408 I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_FCS_FXL6408_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for FXL6408 I2C-based GPIO chip.
 

--- a/drivers/gpio/Kconfig.mcp23s17
+++ b/drivers/gpio/Kconfig.mcp23s17
@@ -7,7 +7,7 @@ menuconfig GPIO_MCP23S17
 	bool "MCP23S17 SPI-based GPIO chip"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP23S17_ENABLED
-	depends on SPI
+	select SPI
 	help
 	  Enable driver for MCP23S17 SPI-based GPIO chip.
 

--- a/drivers/gpio/Kconfig.mcp23xxx
+++ b/drivers/gpio/Kconfig.mcp23xxx
@@ -13,7 +13,7 @@ menuconfig GPIO_MCP230XX
 	bool "MCP230XX I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP230XX_ENABLED
-	depends on I2C
+	select I2C
 	select GPIO_MCP23XXX
 	help
 	  Enable driver for MCP230XX I2C-based GPIO chip.
@@ -32,7 +32,7 @@ menuconfig GPIO_MCP23SXX
 	bool "MCP23SXX SPI-based GPIO chip"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP23SXX_ENABLED
-	depends on SPI
+	select SPI
 	select GPIO_MCP23XXX
 	help
 	  Enable driver for MCP23SXX SPI-based GPIO chip.

--- a/drivers/gpio/Kconfig.nct38xx
+++ b/drivers/gpio/Kconfig.nct38xx
@@ -7,7 +7,7 @@ config GPIO_NCT38XX
 	bool "NCT38XX I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_NUVOTON_NCT38XX_GPIO_PORT_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for NCT38XX I2C-based GPIO chip.
 

--- a/drivers/gpio/Kconfig.pca953x
+++ b/drivers/gpio/Kconfig.pca953x
@@ -8,7 +8,7 @@ menuconfig GPIO_PCA953X
 	bool "PCA953X I2C GPIO chip"
 	default y
 	depends on DT_HAS_TI_TCA9538_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for PCA953X I2C GPIO chip.
 

--- a/drivers/gpio/Kconfig.pca95xx
+++ b/drivers/gpio/Kconfig.pca95xx
@@ -7,7 +7,7 @@ menuconfig GPIO_PCA95XX
 	bool "PCA95XX I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_NXP_PCA95XX_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for PCA95XX I2C-based GPIO chip.
 

--- a/drivers/gpio/Kconfig.pcal6408a
+++ b/drivers/gpio/Kconfig.pcal6408a
@@ -7,7 +7,7 @@ menuconfig GPIO_PCAL6408A
 	bool "PCAL6408A I2C GPIO chip"
 	default y
 	depends on DT_HAS_NXP_PCAL6408A_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for PCAL6408A I2C GPIO chip.
 

--- a/drivers/gpio/Kconfig.sn74hc595
+++ b/drivers/gpio/Kconfig.sn74hc595
@@ -5,7 +5,7 @@ config GPIO_SN74HC595
 	bool "SN74HC595 shift register as GPIO extender"
 	default y
 	depends on DT_HAS_TI_SN74HC595_ENABLED
-	depends on SPI
+	select SPI
 	help
 	  Use SN74HC595 as GPIO extender
 

--- a/drivers/gpio/Kconfig.stmpe1600
+++ b/drivers/gpio/Kconfig.stmpe1600
@@ -7,7 +7,7 @@ menuconfig GPIO_STMPE1600
 	bool "STMPE1600 I2C-based GPIO chip"
 	default y
 	depends on DT_HAS_ST_STMPE1600_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for STMPE1600 I2C-based GPIO chip.
 

--- a/drivers/gpio/Kconfig.sx1509b
+++ b/drivers/gpio/Kconfig.sx1509b
@@ -7,7 +7,7 @@ menuconfig GPIO_SX1509B
 	bool "SX1509B I2C GPIO chip"
 	default y
 	depends on DT_HAS_SEMTECH_SX1509B_ENABLED
-	depends on I2C
+	select I2C
 	help
 	  Enable driver for SX1509B I2C GPIO chip.
 


### PR DESCRIPTION
Move to using 'select SPI'/'select I2C' instead of 'depends on'
(see commit df81fef94483da9f2811d48088affbcfd61ab18c for more
 details)

Signed-off-by: Kumar Gala <galak@kernel.org>