### PR TITLE
net: ppp: Fix NULL pointer dereference in FSM module

### DIFF
--- a/subsys/net/l2/ppp/fsm.c
+++ b/subsys/net/l2/ppp/fsm.c
@@ -382,7 +382,6 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 	struct ppp_packet ppp;
 	struct net_pkt *pkt = NULL;
 	int ret;
-	struct ppp_context *ctx = ppp_fsm_ctx(fsm);
 
 	if (!iface) {
 		if (!fsm) {
@@ -397,10 +396,13 @@ int ppp_send_pkt(struct ppp_fsm *fsm, struct net_if *iface,
 	}
 
 	switch (type) {
-	case PPP_CODE_REJ:
+	case PPP_CODE_REJ: {
+		struct ppp_context *ctx = ppp_fsm_ctx(fsm);
+
 		len = net_pkt_get_len(req_pkt);
 		len = MIN(len, ctx->lcp.my_options.mru);
 		break;
+	}
 
 	case PPP_CONFIGURE_ACK:
 	case PPP_CONFIGURE_NACK:


### PR DESCRIPTION
ppp_send_pkt() function can be called with NULL fsm parameter (when
PPP_PROTOCOL_REJ packet was sent), howerver this was not taken into
consideration when ppp_context was retrieved. In result, this could lead
to NULL pointer dereference an crash.

Fix this, by moving the ppp_context extraction directly where it's
actually used (PPP_CODE_REJ packet type handling). In such case, fsm
point should not be NULL.

Fixes #48541

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>