### PR TITLE
soc: samv71b: Fix CIDR for V71 Revision B Silicon

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -57,7 +57,7 @@ manifest:
       groups:
         - hal
     - name: hal_atmel
-      revision: bb4e7104132bdc22c7cc7e20057434c2979e6706
+      revision: 1d237f2e2f262751975b6da6e03af569b2b49b2b
       path: modules/hal/atmel
       groups:
         - hal


### PR DESCRIPTION
Update the 'atmel_hal' module to fix incorrect CIDR values for
revision b silicon of atsamv71 devices.

[Corresponding pull request on 'hal_atmel' repo.](https://github.com/zephyrproject-rtos/hal_atmel/pull/26)

Signed-off-by: Nick Kraus <nick@nckraus.com>