### PR TITLE
tests: lib: cmsis_nn: Initialise bias dimensions for depthwise convolve

### DIFF
--- a/tests/lib/cmsis_nn/src/main.c
+++ b/tests/lib/cmsis_nn/src/main.c
@@ -274,7 +274,7 @@ ZTEST(cmsis_nn, test_depthwise_convolve)
 	cmsis_nn_per_channel_quant_params quant_params;
 	cmsis_nn_dims input_dims;
 	cmsis_nn_dims filter_dims;
-	cmsis_nn_dims bias_dims;
+	cmsis_nn_dims bias_dims = { 0 };
 	cmsis_nn_dims output_dims;
 
 	const q31_t *bias_data = stride2pad1_biases;


### PR DESCRIPTION
This commit adds an initialisation for the `bias_dims` variable, which
is given as an input to the `arm_depthwise_conv_s8` function.

Note that the `bias_dims` parameter is currently unused by the function
implementation.

This fixes the following warning reported by the GCC 12:

  error: 'bias_dims' may be used uninitialized
  Werror=maybe-uninitialized]

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>