### PR TITLE
kconfig: logging: Add LOG_MIPI_SYST_ARGS_BUFFER_SIZE option.

### DIFF
--- a/subsys/logging/Kconfig.formatting
+++ b/subsys/logging/Kconfig.formatting
@@ -52,6 +52,16 @@ config LOG_MIPI_SYST_CATALOG_ARGS_BUFFER_SIZE
 	  argument list needed for the MIPI Sys-T library for processing
 	  catalog messages.
 
+config LOG_MIPI_SYST_ARGS_BUFFER_SIZE
+	int "Buffer size in bytes"
+	default 1024
+	help
+	  This user-configurable option specifies the maximum size (in bytes) to reserve in
+	  the call stack for processing the logging format strings MIPI Sys-T library.
+	  Increasing it will allow for longer strings to be logged at the expense of used
+	  stack space. Conversely decreasing it will lessen the stack burden at the expense
+	  of shorter maximum log strings.
+
 config LOG_MIPI_SYST_OUTPUT_LOG_MSG_SRC_ID
 	bool "Output Log Message Source ID as Module ID"
 	default y if LOG_MIPI_SYST_USE_CATALOG

--- a/subsys/logging/mipi_syst/platform.h
+++ b/subsys/logging/mipi_syst/platform.h
@@ -13,6 +13,8 @@
 extern "C" {
 #endif
 
+#define MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE CONFIG_LOG_MIPI_SYST_ARGS_BUFFER_SIZE
+
 #if defined(CONFIG_MIPI_SYST_STP)
 /*
  * Structure generating STP protocol data

--- a/west.yml
+++ b/west.yml
@@ -178,7 +178,7 @@ manifest:
       path: modules/debug/mipi-sys-t
       groups:
         - debug
-      revision: a5163c1800a5243f8b05d84c942da008df4cb666
+      revision: 0d521d8055f3b2b4842f728b0365d3f0ece9c37f
     - name: nanopb
       revision: dc4deed54fd4c7e1935e3b6387eedf21bb45dc38
       path: modules/lib/nanopb


### PR DESCRIPTION
Add user configurable LOG_MIPI_SYST_ARGS_BUFFER_SIZE Kconfig
option to use it for macro MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE.
Moving macro definition of MIPI_SYST_PCFG_PRINTF_ARGBUF_SIZE
from mipi-sys-t library to platform.h which defaulted to 1kb
and resulted in stack overflow in some applications.
LOG_MIPI_SYST_ARGS_BUFFER_SIZE gives flexibilty to users when
maximum log length is known.

Fixes zephyrproject-rtos/mipi-sys-t#10

Signed-off-by: Aastha Grover <aastha.grover@intel.com>