### PR TITLE
boards: shields: Append accel/magn sensor nodelabels with bus address

### DIFF
--- a/boards/shields/boostxl_ulpsense/boostxl_ulpsense.overlay
+++ b/boards/shields/boostxl_ulpsense/boostxl_ulpsense.overlay
@@ -6,13 +6,13 @@
 
 / {
 	aliases {
-		accel0 = &adxl362;
+		accel0 = &adxl362_0;
 	};
 };
 
 &boosterpack_spi {
 
-	adxl362: adxl362@0 {
+	adxl362_0: adxl362@0 {
 		compatible = "adi,adxl362";
 		reg = <0>;
 		spi-max-frequency = <8000000>;

--- a/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
+++ b/boards/shields/frdm_stbc_agm01/frdm_stbc_agm01.overlay
@@ -5,13 +5,13 @@
 
 / {
 	aliases {
-		magn0 = &fxos8700;
-		accel0 = &fxos8700;
+		magn0 = &fxos8700_1e;
+		accel0 = &fxos8700_1e;
 	};
 };
 
 &arduino_i2c {
-    fxos8700: fxos8700@1e {
+    fxos8700_1e: fxos8700@1e {
 		compatible = "nxp,fxos8700";
 		reg = <0x1e>;
 		int1-gpios = <&arduino_header 8 GPIO_ACTIVE_LOW>;

--- a/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
+++ b/boards/shields/x_nucleo_iks01a2/x_nucleo_iks01a2.overlay
@@ -7,9 +7,9 @@
 
 / {
 	aliases {
-		magn0 = &lsm303agr_magn;
-		accel0 = &lsm303agr_accel;
-		accel1 = &lsm6dsl;
+		magn0 = &lsm303agr_magn_1e;
+		accel0 = &lsm303agr_accel_19;
+		accel1 = &lsm6dsl_6b;
 	};
 };
 
@@ -25,19 +25,19 @@
 		reg = <0x5d>;
 	};
 
-	lsm6dsl: lsm6dsl@6b {
+	lsm6dsl_6b: lsm6dsl@6b {
 		compatible = "st,lsm6dsl";
 		reg = <0x6b>;
 		irq-gpios = <&arduino_header 10 GPIO_ACTIVE_HIGH>;	/* D4 */
 	};
 
-	lsm303agr_magn: lsm303agr-magn@1e {
+	lsm303agr_magn_1e: lsm303agr-magn@1e {
 		compatible = "st,lis2mdl","st,lsm303agr-magn";
 		reg = <0x1e>;
 		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */
 	};
 
-	lsm303agr_accel: lsm303agr-accel@19 {
+	lsm303agr_accel_19: lsm303agr-accel@19 {
 		compatible = "st,lis2dh", "st,lsm303agr-accel";
 		reg = <0x19>;
 		irq-gpios = <&arduino_header 3 GPIO_ACTIVE_HIGH>;	/* A3 */

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3.overlay
@@ -6,9 +6,9 @@
 
 / {
 	aliases {
-		magn0 = &lis2mdl;
-		accel0 = &lis2dw12;
-		accel1 = &lsm6dso;
+		magn0 = &lis2mdl_1e;
+		accel0 = &lis2dw12_19;
+		accel1 = &lsm6dso_6b;
 	};
 };
 
@@ -31,19 +31,19 @@
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_LOW>; /* A4 */
 	};
 
-	lis2mdl: lis2mdl@1e {
+	lis2mdl_1e: lis2mdl@1e {
 		compatible = "st,lis2mdl";
 		reg = <0x1e>;
 		irq-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
 	};
 
-	lis2dw12: lis2dw12@19 {
+	lis2dw12_19: lis2dw12@19 {
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
 		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
 	};
 
-	lsm6dso: lsm6dso@6b {
+	lsm6dso_6b: lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
 		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */

--- a/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
+++ b/boards/shields/x_nucleo_iks01a3/x_nucleo_iks01a3_shub.overlay
@@ -6,20 +6,20 @@
 
 / {
 	aliases {
-		accel0 = &lis2dw12;
-		accel1 = &lsm6dso;
+		accel0 = &lis2dw12_19;
+		accel1 = &lsm6dso_6b;
 	};
 };
 
 &arduino_i2c {
 
-	lis2dw12: lis2dw12@19 {
+	lis2dw12_19: lis2dw12@19 {
 		compatible = "st,lis2dw12";
 		reg = <0x19>;
 		irq-gpios =  <&arduino_header 3 GPIO_ACTIVE_HIGH>; /* A3 */
 	};
 
-	lsm6dso: lsm6dso@6b {
+	lsm6dso_6b: lsm6dso@6b {
 		compatible = "st,lsm6dso";
 		reg = <0x6b>;
 		irq-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 */

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1.overlay
@@ -15,14 +15,14 @@
 
 / {
 	aliases {
-		accel0 = &iis2dlpc;
-		accel1 = &ism330dhcx;
+		accel0 = &iis2dlpc_19;
+		accel1 = &ism330dhcx_6b;
 	};
 };
 
 &arduino_i2c {
 
-	iis2dlpc: iis2dlpc@19 {
+	iis2dlpc_19: iis2dlpc@19 {
 		compatible = "st,iis2dlpc";
 		reg = <0x19>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
@@ -35,7 +35,7 @@
 		drdy-gpios =  <&arduino_header 2 GPIO_ACTIVE_HIGH>; /* A2 */
 	};
 
-	ism330dhcx: ism330dhcx@6b {
+	ism330dhcx_6b: ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
 		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */

--- a/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
+++ b/boards/shields/x_nucleo_iks02a1/x_nucleo_iks02a1_shub.overlay
@@ -17,21 +17,21 @@
 
 / {
 	aliases {
-		accel0 = &iis2dlpc;
-		accel1 = &ism330dhcx;
+		accel0 = &iis2dlpc_19;
+		accel1 = &ism330dhcx_6b;
 	};
 };
 
 &arduino_i2c {
 
-	iis2dlpc: iis2dlpc@19 {
+	iis2dlpc_19: iis2dlpc@19 {
 		compatible = "st,iis2dlpc";
 		reg = <0x19>;
 		drdy-gpios =  <&arduino_header 4 GPIO_ACTIVE_HIGH>; /* A4 - INT2 */
 		drdy-int =  <2>;
 	};
 
-	ism330dhcx: ism330dhcx@6b {
+	ism330dhcx_6b: ism330dhcx@6b {
 		compatible = "st,ism330dhcx";
 		reg = <0x6b>;
 		drdy-gpios =  <&arduino_header 11 GPIO_ACTIVE_HIGH>; /* D5 - INT2 */


### PR DESCRIPTION
Devicetree aliases, accel0 and magn0, were recently introduced to enable
sensor sample applications to support multiple sensor drivers of the
same type and thereby reduce the number of driver-specific sensor sample
applications.

This was implemented by adding devicetree nodelabels to accelerometer
and magnetometer sensor nodes, which unfortunately can suffer from
naming conflicts when using shield boards. Fix the problem by appending
the I2C bus address or SPI chip select to the devicetree nodelabel for
sensor nodes on shield boards only. Base boards are left alone to keep
their nodelabels as short as possible.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #48780