### PR TITLE
Safely handle asserts/assumptions in invalid test states

### DIFF
--- a/scripts/ci/check_compliance.py
+++ b/scripts/ci/check_compliance.py
@@ -607,6 +607,7 @@ UNDEF_KCONFIG_WHITELIST = {
     "MODVERSIONS",        # Linux, in boards/xtensa/intel_adsp_cavs25/doc
     "SECURITY_LOADPIN",   # Linux, in boards/xtensa/intel_adsp_cavs25/doc
     "ZEPHYR_TRY_MASS_ERASE", # MCUBoot setting described in sysbuild documentation
+    "ZTEST_FAIL_TEST_",  # regex in tests/ztest/fail/CMakeLists.txt
 }
 
 class KconfigBasicCheck(KconfigCheck, ComplianceTest):

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -55,6 +55,15 @@ static ZTEST_BMEM int test_status;
 
 extern ZTEST_DMEM const struct ztest_arch_api ztest_api;
 
+void end_report(void)
+{
+	if (test_status) {
+		TC_END_REPORT(TC_FAIL);
+	} else {
+		TC_END_REPORT(TC_PASS);
+	}
+}
+
 static int cleanup_test(struct ztest_unit_test *test)
 {
 	int ret = TC_PASS;
@@ -663,15 +672,6 @@ static int z_ztest_run_test_suite_ptr(struct ztest_suite_node *suite)
 int z_ztest_run_test_suite(const char *name)
 {
 	return z_ztest_run_test_suite_ptr(ztest_find_test_suite(name));
-}
-
-void end_report(void)
-{
-	if (test_status) {
-		TC_END_REPORT(TC_FAIL);
-	} else {
-		TC_END_REPORT(TC_PASS);
-	}
 }
 
 #ifdef CONFIG_USERSPACE

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -330,6 +330,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	int ret = TC_PASS;
 
 	TC_START(test->name);
+	phase = TEST_PHASE_BEFORE;
 
 	if (test_result == ZTEST_RESULT_SUITE_FAIL) {
 		ret = TC_FAIL;
@@ -358,6 +359,7 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	run_test_functions(suite, test, data);
 out:
 	ret |= cleanup_test(test);
+	phase = TEST_PHASE_AFTER;
 	if (test_result != ZTEST_RESULT_SUITE_FAIL) {
 		if (suite->after != NULL) {
 			suite->after(data);

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -387,8 +387,6 @@ static int run_test(struct ztest_suite_node *suite, struct ztest_unit_test *test
 	}
 	run_test_functions(suite, test, data);
 out:
-	phase = TEST_PHASE_FRAMEWORK;
-	ret |= cleanup_test(test);
 	phase = TEST_PHASE_AFTER;
 	if (test_result != ZTEST_RESULT_SUITE_FAIL) {
 		if (suite->after != NULL) {
@@ -396,6 +394,8 @@ out:
 		}
 		run_test_rules(/*is_before=*/false, test, data);
 	}
+	phase = TEST_PHASE_FRAMEWORK;
+	ret |= cleanup_test(test);
 
 	ret = get_final_test_result(test, ret);
 	Z_TC_END_RESULT(ret, test->name);

--- a/subsys/testsuite/ztest/src/ztest_new.c
+++ b/subsys/testsuite/ztest/src/ztest_new.c
@@ -256,27 +256,6 @@ static int get_final_test_result(const struct ztest_unit_test *test, int ret)
 	return ret;
 }
 
-#ifndef KERNEL
-
-/* Static code analysis tool can raise a violation that the standard header
- * <setjmp.h> shall not be used.
- *
- * setjmp is using in a test code, not in a runtime code, it is acceptable.
- * It is a deliberate deviation.
- */
-#include <setjmp.h> /* parasoft-suppress MISRAC2012-RULE_21_4-a MISRAC2012-RULE_21_4-b*/
-#include <signal.h>
-#include <stdlib.h>
-#include <string.h>
-
-#define FAIL_FAST 0
-
-static jmp_buf test_fail;
-static jmp_buf test_pass;
-static jmp_buf test_skip;
-static jmp_buf stack_fail;
-static jmp_buf test_suite_fail;
-
 /**
  * @brief Get a friendly name string for a given test phrase.
  *
@@ -302,6 +281,27 @@ static inline const char *get_friendly_phase_name(enum ztest_phase phase)
 		return "(unknown)";
 	}
 }
+
+#ifndef KERNEL
+
+/* Static code analysis tool can raise a violation that the standard header
+ * <setjmp.h> shall not be used.
+ *
+ * setjmp is using in a test code, not in a runtime code, it is acceptable.
+ * It is a deliberate deviation.
+ */
+#include <setjmp.h> /* parasoft-suppress MISRAC2012-RULE_21_4-a MISRAC2012-RULE_21_4-b*/
+#include <signal.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define FAIL_FAST 0
+
+static jmp_buf test_fail;
+static jmp_buf test_pass;
+static jmp_buf test_skip;
+static jmp_buf stack_fail;
+static jmp_buf test_suite_fail;
 
 void ztest_test_fail(void)
 {

--- a/tests/ztest/fail/CMakeLists.txt
+++ b/tests/ztest/fail/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+include(ExternalProject)
+
+# Add the sources and set up the build for either unit testing or native_posix
+list(APPEND SOURCES src/main.cpp)
+if(BOARD STREQUAL unit_testing)
+  find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  set(target testbinary)
+  # Set the target binary for the 'core' external project. The path to this must match the one set
+  # below in ExternalProject_Add's CMAKE_INSTALL_PREFIX
+  add_compile_definitions(FAIL_TARGET_BINARY="${CMAKE_BINARY_DIR}/core/bin/testbinary")
+else()
+  find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  set(target app)
+  # Set the target binary for the 'core' external project. The path to this must match the one set
+  # below in ExternalProject_Add's CMAKE_INSTALL_PREFIX
+  add_compile_definitions(FAIL_TARGET_BINARY="${CMAKE_BINARY_DIR}/core/bin/zephyr.elf")
+endif()
+
+# Create the project and set the sources for the target
+project(fail)
+target_sources(${target} PRIVATE ${SOURCES})
+
+# Find which CONFIG_ZTEST_FAIL_TEST_* choice was set so we can pass it to the external project
+# Once we find the config, we'll need to prepend a '-D' and append '=y' so we can pass it to the
+# 'core' project as a cmake argument.
+get_cmake_property(_vars VARIABLES)
+string(REGEX MATCHALL "(^|;)CONFIG_ZTEST_FAIL_TEST_[A-Za-z0-9_]+" fail_test_config "${_vars}")
+list(FILTER fail_test_config EXCLUDE REGEX "^$")
+list(TRANSFORM fail_test_config PREPEND "-D")
+list(TRANSFORM fail_test_config APPEND "=y")
+string(REPLACE ";" " " fail_test_config "${fail_test_config}")
+
+# Add the 'core' external project which will mirror the configs of this project.
+ExternalProject_Add(core
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/core
+    CMAKE_ARGS
+      -DBOARD:STRING=${BOARD}
+      -DCMAKE_INSTALL_PREFIX:PATH=${CMAKE_BINARY_DIR}/core
+      ${fail_test_config}
+)
+add_dependencies(${target} core)

--- a/tests/ztest/fail/Kconfig
+++ b/tests/ztest/fail/Kconfig
@@ -1,0 +1,36 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+choice ZTEST_FAIL_TEST
+	prompt "Select the type of failure to test"
+
+config ZTEST_FAIL_TEST_ASSERT_AFTER
+	bool "Add a failed assert in the after phase"
+
+config ZTEST_FAIL_TEST_ASSERT_TEARDOWN
+	bool "Add a failed assert in the teardown phase"
+
+config ZTEST_FAIL_TEST_ASSUME_AFTER
+	bool "Add a failed assume in the after phase"
+
+config ZTEST_FAIL_TEST_ASSUME_TEARDOWN
+	bool "Add a failed assume in the teardown phase"
+
+config ZTEST_FAIL_TEST_PASS_AFTER
+	bool "Add a call to ztest_test_pass() in the after phase"
+
+config ZTEST_FAIL_TEST_PASS_TEARDOWN
+	bool "Add a call to ztest_test_pass() in the teardown phase"
+
+endchoice
+
+config TEST_ERROR_STRING
+	string
+	default "ERROR: cannot fail in test 'after()', bailing" if ZTEST_FAIL_TEST_ASSERT_AFTER
+	default "ERROR: cannot fail in test 'teardown()', bailing" if ZTEST_FAIL_TEST_ASSERT_TEARDOWN
+	default "ERROR: cannot skip in test 'after()', bailing" if ZTEST_FAIL_TEST_ASSUME_AFTER
+	default "ERROR: cannot skip in test 'teardown()', bailing" if ZTEST_FAIL_TEST_ASSUME_TEARDOWN
+	default "ERROR: cannot pass in test 'after()', bailing" if ZTEST_FAIL_TEST_PASS_AFTER
+	default "ERROR: cannot pass in test 'teardown()', bailing" if ZTEST_FAIL_TEST_PASS_TEARDOWN
+
+source "Kconfig.zephyr"

--- a/tests/ztest/fail/README.rst
+++ b/tests/ztest/fail/README.rst
@@ -1,0 +1,21 @@
+.. _ztest_framework_failure_tests:
+
+Ztest framework failure tests
+#############################
+
+Overview
+********
+
+In order to test the actual framework's failure cases, this test suite has to do something unique.
+There's a subdirectory to this test called 'core'. This project builds a sample ``native_posix`` or
+``unit_testing`` binary which is expected to fail by calling one of the following:
+- ``ztest_test_fail()`` during either the ``after`` or ``teardown`` phase of the test suite
+- ``ztest_test_skip()`` during either the ``after`` or ``teardown`` phase of the test suite
+- ``ztest_test_pass()`` during either the ``after`` or ``teardown`` phase of the test suite
+
+Note that these can be called indirectly through failed asserts or assumptions.
+
+The binary by itself, when executed, will fail to run and return a code of ``1``. The main test
+binary will use ``popen()`` to run the failing test binary and will assert both the return code and
+the output. The output itself cannot be printed to the log as it will confuse ``twister`` by
+reporting a failure.

--- a/tests/ztest/fail/core/CMakeLists.txt
+++ b/tests/ztest/fail/core/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+
+set(KCONFIG_ROOT ${CMAKE_CURRENT_LIST_DIR}/../Kconfig)
+
+# Add the sources
+list(APPEND SOURCES src/main.cpp)
+if(CONFIG_ZTEST_FAIL_TEST_ASSERT_AFTER)
+  list(APPEND SOURCES src/assert_after.cpp)
+elseif(CONFIG_ZTEST_FAIL_TEST_ASSERT_TEARDOWN)
+  list(APPEND SOURCES src/assert_teardown.cpp)
+elseif(CONFIG_ZTEST_FAIL_TEST_ASSUME_AFTER)
+  list(APPEND SOURCES src/assume_after.cpp)
+elseif(CONFIG_ZTEST_FAIL_TEST_ASSUME_TEARDOWN)
+  list(APPEND SOURCES src/assume_teardown.cpp)
+elseif(CONFIG_ZTEST_FAIL_TEST_PASS_AFTER)
+  list(APPEND SOURCES src/pass_after.cpp)
+elseif(CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN)
+  list(APPEND SOURCES src/pass_teardown.cpp)
+endif()
+
+if(BOARD STREQUAL unit_testing)
+  find_package(Zephyr COMPONENTS unittest REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  project(base)
+
+  target_include_directories(testbinary PRIVATE include)
+  install(TARGETS testbinary)
+else()
+  find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+  project(base)
+
+  target_sources(app PRIVATE ${SOURCES})
+  target_include_directories(app PRIVATE include)
+  install(TARGETS ${logical_target_for_zephyr_elf})
+endif()

--- a/tests/ztest/fail/core/include/fail_test.hpp
+++ b/tests/ztest/fail/core/include/fail_test.hpp
@@ -1,0 +1,9 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#pragma once
+
+void fail_test_after_impl(void);
+
+void fail_test_teardown_impl(void);

--- a/tests/ztest/fail/core/prj.conf
+++ b/tests/ztest/fail/core/prj.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+
+CONFIG_CPLUSPLUS=y
+CONFIG_LIB_CPLUSPLUS=y

--- a/tests/ztest/fail/core/src/assert_after.cpp
+++ b/tests/ztest/fail/core/src/assert_after.cpp
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+void fail_test_after_impl(void)
+{
+	zassert_true(false, nullptr);
+}
+
+void fail_test_teardown_impl(void) {}

--- a/tests/ztest/fail/core/src/assert_teardown.cpp
+++ b/tests/ztest/fail/core/src/assert_teardown.cpp
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+void fail_test_after_impl(void) {}
+
+void fail_test_teardown_impl(void)
+{
+	zassert_true(false, nullptr);
+}

--- a/tests/ztest/fail/core/src/assume_after.cpp
+++ b/tests/ztest/fail/core/src/assume_after.cpp
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+void fail_test_after_impl(void)
+{
+	zassume_true(false, nullptr);
+}
+
+void fail_test_teardown_impl(void) {}

--- a/tests/ztest/fail/core/src/assume_teardown.cpp
+++ b/tests/ztest/fail/core/src/assume_teardown.cpp
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+void fail_test_after_impl(void) {}
+
+void fail_test_teardown_impl(void)
+{
+	zassume_true(false, nullptr);
+}

--- a/tests/ztest/fail/core/src/main.cpp
+++ b/tests/ztest/fail/core/src/main.cpp
@@ -1,0 +1,19 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+static void fail_after(void *) {
+	fail_test_after_impl();
+}
+
+static void fail_teardown(void *) {
+	fail_test_teardown_impl();
+}
+
+ZTEST_SUITE(fail, nullptr, nullptr, nullptr, fail_after, fail_teardown);
+
+ZTEST(fail, test_framework) {}

--- a/tests/ztest/fail/core/src/pass_after.cpp
+++ b/tests/ztest/fail/core/src/pass_after.cpp
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+void fail_test_after_impl(void)
+{
+	ztest_test_pass();
+}
+
+void fail_test_teardown_impl(void) {}

--- a/tests/ztest/fail/core/src/pass_teardown.cpp
+++ b/tests/ztest/fail/core/src/pass_teardown.cpp
@@ -1,0 +1,14 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/ztest.h>
+
+#include "fail_test.hpp"
+
+void fail_test_after_impl(void) {}
+
+void fail_test_teardown_impl(void)
+{
+	ztest_test_pass();
+}

--- a/tests/ztest/fail/prj.conf
+++ b/tests/ztest/fail/prj.conf
@@ -1,0 +1,8 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+CONFIG_ZTEST=y
+CONFIG_ZTEST_NEW_API=y
+
+CONFIG_CPLUSPLUS=y
+CONFIG_LIB_CPLUSPLUS=y

--- a/tests/ztest/fail/src/main.cpp
+++ b/tests/ztest/fail/src/main.cpp
@@ -1,0 +1,56 @@
+/* Copyright (c) 2022 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <array>
+#include <iostream>
+#include <regex>
+#include <string>
+#include <zephyr/ztest.h>
+
+ZTEST_SUITE(fail, nullptr, nullptr, nullptr, nullptr, nullptr);
+
+ZTEST(fail, test_framework)
+{
+	auto found_error_string = false;
+	char buffer[sizeof(CONFIG_TEST_ERROR_STRING)] = {0};
+	std::string result;
+
+	/* Start running the target binary. This binary is expected to fail. */
+	auto pipe = popen(FAIL_TARGET_BINARY, "r");
+
+	zassert_not_null(pipe, "Failed to execute '" FAIL_TARGET_BINARY "'");
+
+	/* Wait for the binary to finish running and grab the output */
+	while (!feof(pipe)) {
+		if (fgets(buffer, ARRAY_SIZE(buffer), pipe) != nullptr) {
+			if (found_error_string) {
+				/* Already found the error string, no need to do any more string
+				 * manipulation.
+				 */
+				continue;
+			}
+
+			/* Append the buffer to the result string */
+			result += buffer;
+
+			/* Check if result contains the right error string */
+			found_error_string |=
+				(result.find(CONFIG_TEST_ERROR_STRING) != std::string::npos);
+
+			/* If the result string is longer than the expected string,
+			 * we can prune it
+			 */
+			auto prune_length = static_cast<int>(result.length()) -
+					    static_cast<int>(sizeof(CONFIG_TEST_ERROR_STRING));
+			if (prune_length > 0) {
+				result.erase(0, prune_length);
+			}
+		}
+	}
+	auto rc = WEXITSTATUS(pclose(pipe));
+
+	zassert_equal(1, rc, "Test binary expected to fail with return code 1, but got %d", rc);
+	zassert_true(found_error_string, "Test binary did not produce the expected error string \""
+		     CONFIG_TEST_ERROR_STRING "\"");
+}

--- a/tests/ztest/fail/testcase.yaml
+++ b/tests/ztest/fail/testcase.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+tests:
+  testing.fail.unit.assert_after:
+    type: unit
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSERT_AFTER=y
+  testing.fail.unit.assert_teardown:
+    type: unit
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSERT_TEARDOWN=y
+  testing.fail.unit.assume_after:
+    type: unit
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSUME_AFTER=y
+  testing.fail.unit.assume_teardown:
+    type: unit
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSUME_TEARDOWN=y
+  testing.fail.unit.pass_after:
+    type: unit
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_PASS_AFTER=y
+  testing.fail.unit.pass_teardown:
+    type: unit
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN=y
+  testing.fail.zephyr.assert_after:
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSERT_AFTER=y
+  testing.fail.zephyr.assert_teardown:
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSERT_TEARDOWN=y
+  testing.fail.zephyr.assume_after:
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSUME_AFTER=y
+  testing.fail.zephyr.assume_teardown:
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_ASSUME_TEARDOWN=y
+  testing.fail.zephyr.pass_after:
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_PASS_AFTER=y
+  testing.fail.zephyr.pass_teardown:
+    platform_allow: native_posix
+    extra_configs:
+      - CONFIG_ZTEST_FAIL_TEST_PASS_TEARDOWN=y


### PR DESCRIPTION
If a developer calls a failed `zassert` or `zassume` in the `after` or `teardown` functions, the test should be considered failed as the binary cannot be considered valid. This stems from the fact that at that point, the test was already marked as passing.

This change was validated using a sample test that verified the following:

native_posix:
- Called `zassert_true(false, NULL)` during a suite's `after` function
- Called `zassert_true(false, NULL)` during a suite's `teardown` function
- Called `zassume_true(false, NULL)` during a suite's `after` function
- Called `zassume_true(false, NULL)` during a suite's `teardown` function
- Called `ztest_test_pass()` during a suite's `after` function
- Called `ztest_test_pass()` during a suite's `teardown` function
unit_testing:
- Called `zassert_true(false, NULL)` during a suite's `after` function
- Called `zassert_true(false, NULL)` during a suite's `teardown` function
- Called `zassume_true(false, NULL)` during a suite's `after` function
- Called `zassume_true(false, NULL)` during a suite's `teardown` function
- Called `ztest_test_pass()` during a suite's `after` function
- Called `ztest_test_pass()` during a suite's `teardown` function

In all cases, the final test result was a failure.