### PR TITLE
counter: remove Kconfig.defconfig* setting of counter drivers

### DIFF
--- a/boards/arm/efm32gg_slwstk6121a/Kconfig.defconfig
+++ b/boards/arm/efm32gg_slwstk6121a/Kconfig.defconfig
@@ -19,10 +19,6 @@ config CMU_HFRCO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config COUNTER_GECKO_RTCC
-	default y
-	depends on COUNTER
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/arm/efm32gg_stk3701a/Kconfig.defconfig
+++ b/boards/arm/efm32gg_stk3701a/Kconfig.defconfig
@@ -18,10 +18,6 @@ config CMU_HFRCO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config COUNTER_GECKO_RTCC
-	default y
-	depends on COUNTER
-
 config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO

--- a/boards/arm/efm32pg_stk3401a/Kconfig.defconfig
+++ b/boards/arm/efm32pg_stk3401a/Kconfig.defconfig
@@ -14,8 +14,4 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config COUNTER_GECKO_RTCC
-	default y
-	depends on COUNTER
-
 endif # BOARD_EFM32PG_STK3401A

--- a/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
+++ b/boards/arm/efm32pg_stk3402a/Kconfig.defconfig
@@ -16,8 +16,4 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config COUNTER_GECKO_RTCC
-	default y
-	depends on COUNTER
-
 endif # BOARD_EFM32PG_STK3402A || BOARD_EFM32PG_STK3402A_JG

--- a/boards/arm/efr32_radio/Kconfig.defconfig
+++ b/boards/arm/efr32_radio/Kconfig.defconfig
@@ -22,8 +22,4 @@ config LOG_BACKEND_SWO_FREQ_HZ
 	default 875000
 	depends on LOG_BACKEND_SWO
 
-config COUNTER_GECKO_RTCC
-	default y
-	depends on COUNTER
-
 endif # BOARD_EFR32_RADIO

--- a/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
+++ b/boards/arm/efr32mg_sltb004a/Kconfig.defconfig
@@ -14,8 +14,4 @@ config CMU_HFXO_FREQ
 config CMU_LFXO_FREQ
 	default 32768
 
-config COUNTER_GECKO_RTCC
-	default y
-	depends on COUNTER
-
 endif # BOARD_EFR32MG_SLTB004A

--- a/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
+++ b/boards/arm/efr32mg_sltb004a/efr32mg_sltb004a.dts
@@ -122,6 +122,7 @@
 	/* This set selects for CCS811_I2C supporting CCS811 */
 	location-sda = <GECKO_LOCATION(6) GECKO_PORT_B GECKO_PIN(6)>;
 	location-scl = <GECKO_LOCATION(6) GECKO_PORT_B GECKO_PIN(7)>;
+	status = "okay";
 
 	ccs811: ccs811@5a {
 		compatible = "ams,ccs811";

--- a/boards/arm/mps2_an385/Kconfig.defconfig
+++ b/boards/arm/mps2_an385/Kconfig.defconfig
@@ -13,16 +13,6 @@ config UART_INTERRUPT_DRIVEN
 
 endif # SERIAL
 
-if COUNTER
-
-config TIMER_TMR_CMSDK_APB
-	default y
-
-config TIMER_DTMR_CMSDK_APB
-	default y
-
-endif # COUNTER
-
 config ZTEST_STACK_SIZE
 	default 4096 if ZTEST
 

--- a/boards/arm/v2m_beetle/Kconfig.defconfig
+++ b/boards/arm/v2m_beetle/Kconfig.defconfig
@@ -19,14 +19,4 @@ config UART_INTERRUPT_DRIVEN
 
 endif # SERIAL
 
-if COUNTER
-
-config TIMER_TMR_CMSDK_APB
-	default y
-
-config TIMER_DTMR_CMSDK_APB
-	default y
-
-endif # COUNTER
-
 endif # BOARD_V2M_BEETLE

--- a/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
+++ b/soc/arm/atmel_sam0/common/Kconfig.defconfig.series
@@ -5,9 +5,6 @@
 
 if SOC_FAMILY_SAM0
 
-config COUNTER_SAM0_TC32
-	default COUNTER
-
 config DMA_SAM0
 	default DMA
 

--- a/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
+++ b/soc/arm/microchip_mec/mec1501/Kconfig.defconfig.mec1501hsz
@@ -19,10 +19,6 @@ config ESPI_XEC
 	default y
 	depends on ESPI
 
-config COUNTER_XEC
-	default y
-	depends on COUNTER
-
 config PS2_XEC
 	default y
 	depends on PS2

--- a/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
+++ b/soc/arm/nxp_imx/mcimx6x_m4/Kconfig.defconfig.mcimx6x_m4
@@ -15,8 +15,4 @@ config IPM_IMX
 	default y
 	depends on IPM
 
-config COUNTER_IMX_EPIT
-	default y
-	depends on COUNTER
-
 endif # SOC_MCIMX6X_M4

--- a/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
+++ b/soc/arm/nxp_imx/rt/Kconfig.defconfig.series
@@ -51,13 +51,6 @@ config SYS_CLOCK_TICKS_PER_SEC
 config SYS_CLOCK_HW_CYCLES_PER_SEC
 	default 32768 if MCUX_GPT_TIMER
 
-if COUNTER
-
-config COUNTER_MCUX_GPT
-	default y if HAS_MCUX_GPT
-
-endif # COUNTER
-
 config PM_MCUX_GPC
 	default y if HAS_MCUX_GPC
 	depends on SOC_SERIES_IMX_RT11XX && PM

--- a/soc/arm/nxp_imx/rt5xx/Kconfig.defconfig.mimxrt595_cm33
+++ b/soc/arm/nxp_imx/rt5xx/Kconfig.defconfig.mimxrt595_cm33
@@ -16,10 +16,6 @@ config DMA_MCUX_LPC
 	default y
 	depends on DMA
 
-config COUNTER_MCUX_CTIMER
-	default y
-	depends on COUNTER
-
 if MCUX_OS_TIMER
 
 config SYS_CLOCK_HW_CYCLES_PER_SEC

--- a/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.mimxrt685_cm33
+++ b/soc/arm/nxp_imx/rt6xx/Kconfig.defconfig.mimxrt685_cm33
@@ -39,10 +39,6 @@ config SYS_CLOCK_HW_CYCLES_PER_SEC
 
 endif # CORTEX_M_SYSTICK
 
-config COUNTER_MCUX_LPC_RTC
-	default y
-	depends on COUNTER
-
 config USB_MCUX
 	default y
 	depends on USB_DEVICE_DRIVER
@@ -50,9 +46,5 @@ config USB_MCUX
 choice USB_MCUX_CONTROLLER_TYPE
 	default USB_DC_NXP_LPCIP3511
 endchoice
-
-config COUNTER_MCUX_CTIMER
-	default y
-	depends on COUNTER
 
 endif # SOC_MIMXRT685S_CM33

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk64f12
@@ -26,8 +26,4 @@ config USB_KINETIS
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config COUNTER_MCUX_RTC
-	default y
-	depends on COUNTER
-
 endif # SOC_MK64F12

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk66f18
@@ -23,8 +23,4 @@ config USB_KINETIS
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config COUNTER_MCUX_RTC
-	default y
-	depends on COUNTER
-
 endif # SOC_MK66F18

--- a/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.series
@@ -15,10 +15,6 @@ config DMA_MCUX_EDMA
 	default y if HAS_MCUX_EDMA
 	depends on DMA
 
-config COUNTER_MCUX_PIT
-	default y if HAS_MCUX_PIT
-    depends on COUNTER
-
 source "soc/arm/nxp_kinetis/k6x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_K6X

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.series
@@ -26,10 +26,6 @@ config USB_KINETIS
 	default y
 	depends on USB_DEVICE_DRIVER
 
-config COUNTER_MCUX_PIT
-	default y if HAS_MCUX_PIT
-	depends on COUNTER
-
 source "soc/arm/nxp_kinetis/k8x/Kconfig.defconfig.mk*"
 
 endif # SOC_SERIES_KINETIS_K8X

--- a/soc/arm/nxp_kinetis/k8x/Kconfig.soc
+++ b/soc/arm/nxp_kinetis/k8x/Kconfig.soc
@@ -73,8 +73,4 @@ config DMA_MCUX_EDMA
 	default y if HAS_MCUX_EDMA
 	depends on DMA
 
-config COUNTER_MCUX_PIT
-	default y if HAS_MCUX_PIT
-	depends on COUNTER
-
 endif # SOC_SERIES_KINETIS_K8X

--- a/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
+++ b/soc/arm/nxp_kinetis/ke1xf/Kconfig.defconfig.series
@@ -29,16 +29,6 @@ config KINETIS_FLASH_CONFIG_FOPT
 	default 0x7d
 	depends on KINETIS_FLASH_CONFIG
 
-if COUNTER
-
-config COUNTER_MCUX_RTC
-	default y
-
-config COUNTER_MCUX_LPTMR
-	default y
-
-endif # COUNTER
-
 config PWM_MCUX_PWT
 	default y
 	depends on PWM_CAPTURE

--- a/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
+++ b/soc/arm/nxp_kinetis/kwx/Kconfig.defconfig.mkw41z4
@@ -11,10 +11,6 @@ config SOC
 config NUM_IRQS
 	default 32
 
-config COUNTER_MCUX_RTC
-	default y
-	depends on COUNTER
-
 if NETWORKING
 
 config NET_L2_IEEE802154

--- a/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
+++ b/soc/arm/nxp_lpc/lpc55xxx/Kconfig.defconfig.lpc55S69_cpu0
@@ -29,10 +29,6 @@ choice USB_MCUX_CONTROLLER_TYPE
 	default USB_DC_NXP_LPCIP3511
 endchoice
 
-config COUNTER_MCUX_CTIMER
-	default y
-	depends on COUNTER
-
 config I2S_MCUX_FLEXCOMM
 	default y if HAS_MCUX_FLEXCOMM
 	depends on I2S


### PR DESCRIPTION
Now that counter drivers are enabled based on devicetree
we need to remove any cases of them getting enabled by
Kconfig.defconfig* files as this can lead to errors.

Signed-off-by: Kumar Gala <galak@kernel.org>