### PR TITLE
dts: arm: st: g4: add missing fdcan2 clock

### DIFF
--- a/dts/arm/st/g4/stm32g491.dtsi
+++ b/dts/arm/st/g4/stm32g491.dtsi
@@ -15,6 +15,7 @@
 				reg-names = "m_can", "message_ram";
 				interrupts = <86 0>, <87 0>;
 				interrupt-names = "LINE_0", "LINE_1";
+				clocks = <&rcc STM32_CLOCK_BUS_APB1 0x02000000>;
 				status = "disabled";
 				sjw = <1>;
 				sample-point = <875>;


### PR DESCRIPTION
Commit 783bc9db26382a466f8ad4b8b20e635d2e550195 made
the clocks propery required, but forgot to add the property
for can instance 2.

Signed-off-by: Pete Dietl <petedietl@gmail.com>