### PR TITLE
Bluetooth: llcp: test: fix bsim test for eatt

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.c
@@ -7,6 +7,7 @@
  */
 
 #include "common.h"
+#include "argparse.h"
 
 struct bt_conn *default_conn;
 
@@ -173,4 +174,50 @@ void disconnect(void)
 	while (is_connected) {
 		k_sleep(K_MSEC(100));
 	}
+}
+
+
+#define CHANNEL_ID 0
+#define MSG_SIZE 1
+
+void backchannel_init(void)
+{
+	uint device_number = get_device_nbr();
+	uint peer_number = device_number ^ 1;
+	uint device_numbers[] = { peer_number };
+	uint channel_numbers[] = { CHANNEL_ID };
+	uint *ch;
+
+	ch = bs_open_back_channel(device_number, device_numbers, channel_numbers,
+				  ARRAY_SIZE(channel_numbers));
+	if (!ch) {
+		FAIL("Unable to open backchannel\n");
+	}
+}
+
+void backchannel_sync_send(void)
+{
+	uint8_t sync_msg[MSG_SIZE] = { get_device_nbr() };
+
+	printk("Sending sync\n");
+	bs_bc_send_msg(CHANNEL_ID, sync_msg, ARRAY_SIZE(sync_msg));
+}
+
+void backchannel_sync_wait(void)
+{
+	uint8_t sync_msg[MSG_SIZE];
+
+	while (true) {
+		if (bs_bc_is_msg_received(CHANNEL_ID) > 0) {
+			bs_bc_receive_msg(CHANNEL_ID, sync_msg, ARRAY_SIZE(sync_msg));
+			if (sync_msg[0] != get_device_nbr()) {
+				/* Received a message from another device, exit */
+				break;
+			}
+		}
+
+		k_sleep(K_MSEC(1));
+	}
+
+	printk("Sync received\n");
 }

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.h
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/common.h
@@ -20,6 +20,7 @@
 #include "bs_types.h"
 #include "bs_tracing.h"
 #include "bstests.h"
+#include "bs_pc_backchannel.h"
 
 extern enum bst_result_t bst_result;
 
@@ -51,3 +52,6 @@ void wait_for_disconnect(void);
 void disconnect(void);
 void test_init(void);
 void test_tick(bs_time_t HW_device_time);
+void backchannel_init(void);
+void backchannel_sync_send(void);
+void backchannel_sync_wait(void);

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main_collision.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main_collision.c
@@ -12,7 +12,15 @@ static void test_peripheral_main(void)
 {
 	int err;
 
+	backchannel_init();
+
 	peripheral_setup_and_connect();
+
+	/*
+	 * we need to sync with peer to ensure that we get collisions
+	 */
+	backchannel_sync_send();
+	backchannel_sync_wait();
 
 	err = bt_eatt_connect(default_conn, CONFIG_BT_EATT_MAX);
 	if (err) {
@@ -35,7 +43,12 @@ static void test_central_main(void)
 {
 	int err;
 
+	backchannel_init();
+
 	central_setup_and_connect();
+
+	backchannel_sync_wait();
+	backchannel_sync_send();
 
 	err = bt_eatt_connect(default_conn, CONFIG_BT_EATT_MAX);
 	if (err) {

--- a/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main_reconfigure.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_eatt/src/main_reconfigure.c
@@ -10,12 +10,16 @@
 
 #include <zephyr/bluetooth/gatt.h>
 
+#define NEW_MTU 100
+
 CREATE_FLAG(flag_reconfigured);
 
 void att_mtu_updated(struct bt_conn *conn, uint16_t tx, uint16_t rx)
 {
 	printk("MTU Updated: tx %d, rx %d\n", tx, rx);
-	SET_FLAG(flag_reconfigured);
+	if (rx == NEW_MTU || tx == NEW_MTU) {
+		SET_FLAG(flag_reconfigured);
+	}
 }
 
 static struct bt_gatt_cb cb = {
@@ -38,8 +42,6 @@ static void test_peripheral_main(void)
 
 	PASS("EATT Peripheral tests Passed\n");
 }
-
-#define NEW_MTU 100
 
 static void test_central_main(void)
 {


### PR DESCRIPTION
The Babblesim test for eatt for reconfiguration of MTU is not
foolproof. Central actually generates two mtu update events.
This is fixed by only setting the reconfigured flag when the MTU actually
changes to the new values

In the Babblesim test for eatt for collision the peripheral
needs to sync with central to ensure collisions occur.

Signed-off-by: Andries Kruithof <andries.kruithof@nordicsemi.no>