### PR TITLE
lib: os: disable PRINTK_SYNC while using EFI console as log backend

### DIFF
--- a/lib/os/Kconfig
+++ b/lib/os/Kconfig
@@ -23,7 +23,7 @@ config BASE64
 
 config PRINTK_SYNC
 	bool "Serialize printk() calls"
-	default y if SMP && MP_NUM_CPUS > 1
+	default y if SMP && MP_NUM_CPUS > 1 && !(EFI_CONSOLE && LOG)
 	help
 	  When true, a spinlock will be taken around the output from a
 	  single printk() call, preventing the output data from


### PR DESCRIPTION
There is a spinlock used in the EFI console code for printing
one line string. It already made the log output being in order
under multi-cores, so it doesn't need a printk sync spinlock
again. Disable it while using EFI console as a log backend.

Fixes #47512.

Signed-off-by: Enjia Mai <enjia.mai@intel.com>