### PR TITLE
tests: Bluetooth: Mesh: make ble mesh tests passable on ext adv

### DIFF
--- a/subsys/bluetooth/mesh/Kconfig
+++ b/subsys/bluetooth/mesh/Kconfig
@@ -733,7 +733,7 @@ config BT_MESH_LPN_INIT_POLL_TIMEOUT
 config BT_MESH_LPN_SCAN_LATENCY
 	int "Latency for enabling scanning"
 	range 0 50
-	default 10
+	default 15
 	help
 	  Latency in milliseconds that it takes to enable scanning. This
 	  is in practice how much time in advance before the Receive Window

--- a/subsys/bluetooth/mesh/friend.c
+++ b/subsys/bluetooth/mesh/friend.c
@@ -281,16 +281,23 @@ int bt_mesh_friend_clear(struct bt_mesh_net_rx *rx, struct net_buf_simple *buf)
 
 static void friend_sub_add(struct bt_mesh_friend *frnd, uint16_t addr)
 {
-	int i;
+	int empty_idx = INT_MAX;
 
-	for (i = 0; i < ARRAY_SIZE(frnd->sub_list); i++) {
-		if (frnd->sub_list[i] == BT_MESH_ADDR_UNASSIGNED) {
-			frnd->sub_list[i] = addr;
+	for (int i = 0; i < ARRAY_SIZE(frnd->sub_list); i++) {
+		if (frnd->sub_list[i] == addr) {
 			return;
+		}
+
+		if (frnd->sub_list[i] == BT_MESH_ADDR_UNASSIGNED) {
+			empty_idx = i;
 		}
 	}
 
-	BT_WARN("No space in friend subscription list");
+	if (empty_idx != INT_MAX) {
+		frnd->sub_list[empty_idx] = addr;
+	} else {
+		BT_WARN("No space in friend subscription list");
+	}
 }
 
 static void friend_sub_rem(struct bt_mesh_friend *frnd, uint16_t addr)

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_friendship.c
@@ -388,6 +388,15 @@ static void test_lpn_est(void)
 {
 	bt_mesh_test_setup();
 
+	/* This test is used to establish friendship with single lpn as well as
+	 * with many lpn devices. If legacy advertiser is used friendship with
+	 * many lpn devices is established normally due to bad precision of advertiser.
+	 * If extended advertiser is used simultaneous lpn running causes the situation
+	 * when Friend Request from several devices collide in emulated radio channel.
+	 * This shift of start moment helps to avoid Friend Request collisions.
+	 */
+	k_sleep(K_MSEC(10 * get_device_nbr()));
+
 	bt_mesh_lpn_set(true);
 
 	ASSERT_OK(evt_wait(LPN_ESTABLISHED, K_SECONDS(5)),

--- a/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_mesh/src/test_provision.c
@@ -269,6 +269,7 @@ static void oob_auth_set(int test_step)
 	prov.input_size = oob_auth_test_vector[test_step].input_size;
 	prov.input_actions = oob_auth_test_vector[test_step].input_actions;
 }
+
 static void oob_device(bool use_oob_pk)
 {
 	int err = 0;
@@ -394,7 +395,7 @@ static void test_device_pb_adv_reprovision(void)
 	for (int i = 0; i < PROV_REPROV_COUNT; i++) {
 		/* Keep a long timeout so the prov multi case has time to finish: */
 		LOG_INF("Dev prov loop #%d, waiting for prov ...\n", i);
-		ASSERT_OK(k_sem_take(&prov_sem, K_SECONDS(5)));
+		ASSERT_OK(k_sem_take(&prov_sem, K_SECONDS(10)));
 	}
 
 	PASS();
@@ -561,18 +562,26 @@ static void test_provisioner_pb_adv_reprovision(void)
 						  &status));
 		ASSERT_EQUAL(0, status);
 
+		k_sleep(K_SECONDS(1));
+
 		ASSERT_OK(bt_mesh_cfg_mod_app_bind(0, current_dev_addr, current_dev_addr, 0x0,
 						   BT_MESH_MODEL_ID_HEALTH_SRV, &status));
 		ASSERT_EQUAL(0, status);
+
+		k_sleep(K_SECONDS(1));
 
 		ASSERT_OK(bt_mesh_cfg_mod_sub_add(0, current_dev_addr, current_dev_addr, 0xc000,
 						  BT_MESH_MODEL_ID_HEALTH_SRV, &status));
 		ASSERT_EQUAL(0, status);
 
+		k_sleep(K_SECONDS(1));
+
 		ASSERT_OK(bt_mesh_cfg_mod_pub_set(0, current_dev_addr, current_dev_addr,
 						  BT_MESH_MODEL_ID_HEALTH_SRV, &healthpub,
 						  &status));
 		ASSERT_EQUAL(0, status);
+
+		k_sleep(K_SECONDS(1));
 
 		ASSERT_OK(bt_mesh_cfg_node_reset(0, current_dev_addr, (bool *)&status));
 


### PR DESCRIPTION
mesh extended advertiser is not well tested. As the first step
the mesh babblesim tests should pass on extended advertiser as well
as on legacy advertiser. Some fixes in the tests that didn't pass for ext adv
with description of reason. Seems there is no issue in ext adv itself but 
some of tests have been designed not considering high precision of it.

Signed-off-by: Aleksandr Khromykh <aleksandr.khromykh@nordicsemi.no>