### PR TITLE
dts: xtensa: bring back label properties for Intel xtensa

### DIFF
--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -104,6 +104,7 @@
 			interrupts = <4 0 0>;
 			num-irqs = <28>;
 			interrupt-parent = <&core_intc>;
+			label = "ACE_0";
 		};
 
 		shim: shim@71f00 {
@@ -138,6 +139,7 @@
 			shim = <0x0007c800 0x1000>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "DMA_0";
 			status = "okay";
 		};
 
@@ -148,6 +150,7 @@
 			shim = <0x0007d800 0x1000>;
 			interrupts = <0x20 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "DMA_1";
 			status = "okay";
 		};
 
@@ -163,6 +166,7 @@
 					&lpgpdma0 3>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			label = "SSP_0";
 			status = "okay";
 		};
 
@@ -178,6 +182,7 @@
 					&lpgpdma0 5>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			label = "SSP_1";
 			status = "okay";
 		};
 
@@ -193,6 +198,7 @@
 					&lpgpdma0 7>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			label = "SSP_2";
 			status = "okay";
 		};
 
@@ -208,6 +214,7 @@
 					&lpgpdma0 9>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			label = "SSP_3";
 			status = "okay";
 		};
 
@@ -223,6 +230,7 @@
 					&lpgpdma0 11>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			label = "SSP_4";
 			status = "okay";
 		};
 
@@ -238,6 +246,7 @@
 					&lpgpdma0 13>;
 			dma-names = "tx", "rx";
 			power-domain = <&io0_domain>;
+			label = "SSP_5";
 			status = "okay";
 		};
 
@@ -247,6 +256,7 @@
 			reg = <0x00072800 0x40>;
 			dma-channels = <5>;
 			dma-buf-alignment = <128>;
+			label = "HDA_HOST_OUT";
 			status = "okay";
 		};
 
@@ -256,6 +266,7 @@
 			reg = <0x00072c00 0x40>;
 			dma-channels = <5>;
 			dma-buf-alignment = <128>;
+			label = "HDA_HOST_IN";
 			status = "okay";
 		};
 
@@ -265,6 +276,7 @@
 			reg = <0x00072400 0x40>;
 			dma-channels = <5>;
 			dma-buf-alignment = <128>;
+			label = "HDA_LINK_OUT";
 			status = "okay";
 		};
 
@@ -274,6 +286,7 @@
 			reg = <0x00072600 0x40>;
 			dma-channels = <5>;
 			dma-buf-alignment = <128>;
+			label = "HDA_LINK_IN";
 			status = "okay";
 		};
 

--- a/dts/xtensa/intel/intel_cavs.dtsi
+++ b/dts/xtensa/intel/intel_cavs.dtsi
@@ -15,6 +15,7 @@
 			shim = <0x00078400 0x100>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&cavs3>;
+			label = "DMA_0";
 
 			status = "okay";
 		};
@@ -26,6 +27,7 @@
 			shim = <0x00078500 0x100>;
 			interrupts = <0x0F 0 0>;
 			interrupt-parent = <&cavs3>;
+			label = "DMA_1";
 
 			status = "okay";
 		};
@@ -36,6 +38,7 @@
 			reg = <0x00072400 0x40>;
 			dma-channels = <4>;
 			dma-buf-alignment = <128>;
+			label = "HDA_LINK_OUT";
 
 			status = "okay";
 		};
@@ -46,6 +49,7 @@
 			reg = <0x00072600 0x40>;
 			dma-channels = <4>;
 			dma-buf-alignment = <128>;
+			label = "HDA_LINK_IN";
 
 			status = "okay";
 		};
@@ -56,6 +60,7 @@
 			reg = <0x00072800 0x40>;
 			dma-channels = <9>;
 			dma-buf-alignment = <128>;
+			label = "HDA_HOST_OUT";
 
 			status = "okay";
 		};
@@ -66,6 +71,7 @@
 			reg = <0x00072c00 0x40>;
 			dma-channels = <7>;
 			dma-buf-alignment = <128>;
+			label = "HDA_HOST_IN";
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_cavs15.dtsi
@@ -94,6 +94,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_0";
 		};
 
 		cavs1: cavs@1610  {
@@ -103,6 +104,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_1";
 		};
 
 		cavs2: cavs@1620  {
@@ -112,6 +114,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_2";
 		};
 
 		cavs3: cavs@1630  {
@@ -121,10 +124,12 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
+			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
@@ -137,6 +142,7 @@
 			shim = <0x00000c00 0x080>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&cavs3>;
+			label = "DMA_0";
 
 			status = "okay";
 		};
@@ -148,6 +154,7 @@
 			shim = <0x00000c80 0x080>;
 			interrupts = <0x0F 0 0>;
 			interrupt-parent = <&cavs3>;
+			label = "DMA_1";
 
 			status = "okay";
 		};
@@ -158,6 +165,7 @@
 			reg = <0x00002400 0x40>;
 			dma-channels = <2>;
 			dma-buf-alignment = <128>;
+			label = "HDA_LINK_OUT";
 
 			status = "okay";
 		};
@@ -168,6 +176,7 @@
 			reg = <0x00002600 0x40>;
 			dma-channels = <2>;
 			dma-buf-alignment = <128>;
+			label = "HDA_LINK_IN";
 
 			status = "okay";
 		};
@@ -178,6 +187,7 @@
 			reg = <0x00002800 0x40>;
 			dma-channels = <6>;
 			dma-buf-alignment = <128>;
+			label = "HDA_HOST_OUT";
 
 			status = "okay";
 		};
@@ -188,6 +198,7 @@
 			reg = <0x00002c00 0x40>;
 			dma-channels = <7>;
 			dma-buf-alignment = <128>;
+			label = "HDA_HOST_IN";
 
 			status = "okay";
 		};
@@ -203,6 +214,7 @@
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
+			label = "SSP_0";
 
 			status = "okay";
 		};
@@ -218,6 +230,7 @@
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
+			label = "SSP_1";
 
 			status = "okay";
 		};
@@ -233,6 +246,7 @@
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
+			label = "SSP_2";
 
 			status = "okay";
 		};
@@ -248,6 +262,7 @@
 			dmas = <&lpgpdma0 8
 				&lpgpdma0 9>;
 			dma-names = "tx", "rx";
+			label = "SSP_3";
 
 			status = "okay";
 		};
@@ -263,6 +278,7 @@
 			dmas = <&lpgpdma0 10
 				&lpgpdma0 11>;
 			dma-names = "tx", "rx";
+			label = "SSP_4";
 
 			status = "okay";
 		};
@@ -278,6 +294,7 @@
 			dmas = <&lpgpdma0 12
 				&lpgpdma0 13>;
 			dma-names = "tx", "rx";
+			label = "SSP_5";
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_cavs18.dtsi
@@ -96,6 +96,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -105,6 +106,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -114,6 +116,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -123,10 +126,12 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
+			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;

--- a/dts/xtensa/intel/intel_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_cavs20.dtsi
@@ -96,6 +96,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -105,6 +106,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -114,6 +116,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -123,10 +126,12 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
+			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;

--- a/dts/xtensa/intel/intel_cavs20_jsl.dtsi
+++ b/dts/xtensa/intel/intel_cavs20_jsl.dtsi
@@ -75,6 +75,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -84,6 +85,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -93,6 +95,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -102,10 +105,12 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
+			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;

--- a/dts/xtensa/intel/intel_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_cavs25.dtsi
@@ -121,6 +121,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -130,6 +131,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -139,6 +141,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -148,10 +151,12 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
+			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;
@@ -173,6 +178,7 @@
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
+			label = "SSP_0";
 
 			status = "okay";
 		};
@@ -188,6 +194,7 @@
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
+			label = "SSP_1";
 
 			status = "okay";
 		};
@@ -203,6 +210,7 @@
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
+			label = "SSP_2";
 
 			status = "okay";
 		};
@@ -218,6 +226,7 @@
 			dmas = <&lpgpdma0 8
 				&lpgpdma0 9>;
 			dma-names = "tx", "rx";
+			label = "SSP_3";
 
 			status = "okay";
 		};
@@ -233,6 +242,7 @@
 			dmas = <&lpgpdma0 10
 				&lpgpdma0 11>;
 			dma-names = "tx", "rx";
+			label = "SSP_4";
 
 			status = "okay";
 		};
@@ -248,6 +258,7 @@
 			dmas = <&lpgpdma0 12
 				&lpgpdma0 13>;
 			dma-names = "tx", "rx";
+			label = "SSP_5";
 
 			status = "okay";
 		};
@@ -255,6 +266,7 @@
 		alh0:alh@24400 {
 			compatible = "intel,alh-dai";
 			reg = <0x00024400 0x00024600>;
+			label = "ALH_0";
 
 			status = "okay";
 		};
@@ -262,6 +274,7 @@
 		alh1:alh@24400 {
 			compatible = "intel,alh-dai";
 			reg = <0x00024400 0x00024600>;
+			label = "ALH_1";
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_cavs25_tgph.dtsi
@@ -67,6 +67,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <6 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_0";
 		};
 
 		cavs1: cavs@78810  {
@@ -76,6 +77,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0xA 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_1";
 		};
 
 		cavs2: cavs@78820  {
@@ -85,6 +87,7 @@
 			#interrupt-cells = <3>;
 			interrupts = <0XD 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_2";
 		};
 
 		cavs3: cavs@78830  {
@@ -94,10 +97,12 @@
 			#interrupt-cells = <3>;
 			interrupts = <0x10 0 0>;
 			interrupt-parent = <&core_intc>;
+			label = "CAVS_3";
 		};
 
 		idc: idc@1200 {
 			compatible = "intel,cavs-idc";
+			label = "CAVS_IDC";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
 			interrupt-parent = <&cavs0>;


### PR DESCRIPTION
Commit 136960e0711a ('dts: xtensa: Remove label property from
devicetrees') broke Sound Open Firmware (SOF) builds with Zephyr for all
platforms when SOF is built with Zephyr native drivers. SOF code uses
labels to instantiate drivers and this completely broke when labels were
removed.

Cc: Kumar Gala <galak@kernel.org>
Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>