### PR TITLE
deprecate devicetree `label` prop

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -74,6 +74,10 @@ Deprecated in this release
   Related Kconfig :kconfig:option:`CONFIG_STM32_LPTIM_CLOCK` option is now
   deprecated.
 
+* 'label' property from devicetree as a base property.  The property is still
+   valid for specific bindings to specify like :dtcompatible:`gpio-leds` and
+   :dtcompatible:`fixed-partitions`.
+
 Stable API changes in this release
 ==================================
 

--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -56,6 +56,7 @@ properties:
     label:
         type: string
         required: false
+        deprecated: true
         description: Human readable string describing the device (used as device_get_binding() argument)
 
     clocks:

--- a/dts/bindings/test/vnd,gpio-device.yaml
+++ b/dts/bindings/test/vnd,gpio-device.yaml
@@ -5,11 +5,19 @@ description: Test GPIO node
 
 compatible: "vnd,gpio-device"
 
-include: [gpio-controller.yaml, base.yaml]
+include:
+  - name: gpio-controller.yaml
+  - name: base.yaml
+    property-blocklist:
+      - label
 
 properties:
     reg:
       required: true
+
+    label:
+        type: string
+        required: false
 
     "#gpio-cells":
       const: 2

--- a/dts/bindings/test/vnd,gpio-expander-i2c.yaml
+++ b/dts/bindings/test/vnd,gpio-expander-i2c.yaml
@@ -5,4 +5,15 @@ description: GPIO expander via I2C
 
 compatible: "vnd,gpio-expander"
 
-include: ["vnd,gpio-expander-common.yaml", i2c-device.yaml]
+include:
+  - name: "vnd,gpio-expander-common.yaml"
+    property-blocklist:
+      - label
+  - name: i2c-device.yaml
+    property-blocklist:
+      - label
+
+properties:
+    label:
+        type: string
+        required: false

--- a/dts/bindings/test/vnd,i2c-device.yaml
+++ b/dts/bindings/test/vnd,i2c-device.yaml
@@ -5,4 +5,12 @@ description: Test I2C device
 
 compatible: "vnd,i2c-device"
 
-include: i2c-device.yaml
+include:
+  - name: i2c-device.yaml
+    property-blocklist:
+      - label
+
+properties:
+    label:
+        type: string
+        required: false

--- a/dts/bindings/test/vnd,i2c.yaml
+++ b/dts/bindings/test/vnd,i2c.yaml
@@ -5,4 +5,12 @@ description: Test I2C node
 
 compatible: "vnd,i2c"
 
-include: [i2c-controller.yaml, base.yaml]
+include:
+  - name: i2c-controller.yaml
+    property-blocklist:
+      - label
+
+properties:
+    label:
+        type: string
+        required: false

--- a/dts/bindings/test/vnd,spi-device.yaml
+++ b/dts/bindings/test/vnd,spi-device.yaml
@@ -5,4 +5,12 @@ description: Test SPI device
 
 compatible: "vnd,spi-device"
 
-include: spi-device.yaml
+include:
+  - name: spi-device.yaml
+    property-blocklist:
+      - label
+
+properties:
+    label:
+        type: string
+        required: false

--- a/dts/bindings/test/vnd,spi.yaml
+++ b/dts/bindings/test/vnd,spi.yaml
@@ -5,4 +5,12 @@ description: Test SPI node
 
 compatible: "vnd,spi"
 
-include: [spi-controller.yaml, base.yaml]
+include:
+  - name: spi-controller.yaml
+    property-blocklist:
+      - label
+
+properties:
+    label:
+        type: string
+        required: false

--- a/tests/drivers/sensor/sbs_gauge/boards/native_posix.overlay
+++ b/tests/drivers/sensor/sbs_gauge/boards/native_posix.overlay
@@ -9,7 +9,6 @@
 	smartbattery: sbs_gauge@b {
 		compatible = "sbs,sbs-gauge";
 		reg = <0x0B>;
-		label = "sbs-gauge";
 		status = "okay";
 	};
 };

--- a/tests/drivers/sensor/sbs_gauge/boards/qemu_cortex_a9.overlay
+++ b/tests/drivers/sensor/sbs_gauge/boards/qemu_cortex_a9.overlay
@@ -15,7 +15,6 @@
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reg = <0x100 4>;
-		label = "FAKE_I2C_BUS";
 	};
 };
 
@@ -25,7 +24,6 @@
 	smartbattery0: smartbattery@b {
 		compatible = "sbs,sbs-gauge";
 		reg = <0x0B>;
-		label = "SMARTBATTERY";
 		status = "okay";
 	};
 };


### PR DESCRIPTION
Mark 'label' property as deprecated in base.yaml.  'label' is still
defined and valid for specific bindings to specify like gpio-keys.yaml
or fixed-partitions.yaml.
