### PR TITLE
drivers: clock_control: stm32h7: Fix frequency calculation overflow

### DIFF
--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -176,8 +176,7 @@ static uint32_t get_pllout_frequency(uint32_t pllsrc_freq,
 {
 	__ASSERT_NO_MSG(pllm_div && pllout_div);
 
-	return (pllsrc_freq * plln_mul) /
-		(pllm_div * pllout_div);
+	return (pllsrc_freq / pllm_div) * plln_mul / pllout_div;
 }
 
 __unused

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -92,8 +92,7 @@ static uint32_t get_pllout_frequency(uint32_t pllsrc_freq,
 {
 	__ASSERT_NO_MSG(pllm_div && pllout_div);
 
-	return (pllsrc_freq * plln_mul) /
-		(pllm_div * pllout_div);
+	return (pllsrc_freq / pllm_div) * plln_mul / pllout_div;
 }
 
 static uint32_t get_sysclk_frequency(void)


### PR DESCRIPTION
STM32h7 pllout frequency calculation overflows. In the
worst case pllsrc_freq can be 50Mhz and plln_mul 512 which will cause
an overflow of the intermediate result which leads to wrong frequency
returned. As no intermediate result can be bigger than 960MHz only the
order of operations is changed.

Signed-off-by: Benjamin Bigler <benjamin.bigler@securiton.ch>