### PR TITLE
tests: Minor tweaks in tests timing

### DIFF
--- a/drivers/serial/Kconfig.nrfx
+++ b/drivers/serial/Kconfig.nrfx
@@ -41,13 +41,13 @@ if UART_NRF_DK_SERIAL_WORKAROUND
 
 config UART_NRF_DK_SERIAL_WORKAROUND_COUNT
 	int
-	default 32
+	default 64
 	help
 	  Number of bytes transferred after which a busy wait is added.
 
 config UART_NRF_DK_SERIAL_WORKAROUND_WAIT_MS
 	int
-	default 10
+	default 7
 	help
 	  Busy wait time (in milliseconds).
 endif

--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -11,6 +11,7 @@ tests:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
       - CONFIG_MAIN_STACK_SIZE=2048
+      - CONFIG_TEST_EXTRA_STACK_SIZE=1024
   arch.interrupt.extra_exception_info:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:

--- a/tests/subsys/portability/cmsis_rtos_v2/src/timer.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/timer.c
@@ -8,7 +8,7 @@
 #include <cmsis_os2.h>
 
 #define ONESHOT_TIME_TICKS      100
-#define PERIOD_TICKS            MAX(50, k_ms_to_ticks_ceil32(5))
+#define PERIOD_TICKS            MAX(50, k_ms_to_ticks_ceil32(10))
 #define NUM_PERIODS             5
 
 uint32_t num_oneshots_executed;


### PR DESCRIPTION
Minor tweaks since some tests are failing on Nordic DKs after #48268:
- increasing timeout in the test. Test timing is impacted by the UART speed and some nordic boards due to workaround has slower UART.
- applying UART workaround increases stack usage. It lead to stack overflow in one test. Adding extra stack size in that test
- Tweaking default values used for Nordic DK workaround.


