### PR TITLE
maintainers: Add Al Semjonovs as collaborator for testing/emul

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -2652,6 +2652,7 @@ ZTest:
     - aaronemassey
     - jeremybettis
     - yperess
+    - asemjonovs
   files:
     - subsys/testsuite/
     - tests/ztest/
@@ -2668,6 +2669,7 @@ Emulation:
     - aaronemassey
     - jeremybettis
     - alevkoy
+    - asemjonovs
   files:
     - subsys/emul/
     - include/zephyr/drivers/emul.h


### PR DESCRIPTION
Al is part of the core team working on testing & emulation at Google. He should be added to reviews for changes pertaining to these.