### PR TITLE
device: minor doc/include tweaks

### DIFF
--- a/doc/_doxygen/groups.dox
+++ b/doc/_doxygen/groups.dox
@@ -1,5 +1,16 @@
 /**
 
+@brief Device Driver APIs
+@defgroup io_interfaces Device Driver APIs
+@{
+@}
+
+@brief Miscellaneous Drivers APIs
+@defgroup misc_interfaces Miscellaneous Drivers APIs
+@ingroup io_interfaces
+@{
+@}
+
 @defgroup subsys Subsystems
 @brief Zephyr Subsystems
 @{

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -13,11 +13,14 @@
  * @{
  */
 
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/devicetree.h>
 #include <zephyr/init.h>
-#include <zephyr/linker/sections.h>
-#include <zephyr/sys/device_mmio.h>
-#include <zephyr/sys/util.h>
+#include <zephyr/sys/util_macro.h>
+#include <zephyr/toolchain.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -8,19 +8,6 @@
 #define ZEPHYR_INCLUDE_DEVICE_H_
 
 /**
- * @brief Device Driver APIs
- * @defgroup io_interfaces Device Driver APIs
- * @{
- * @}
- */
-/**
- * @brief Miscellaneous Drivers APIs
- * @defgroup misc_interfaces Miscellaneous Drivers APIs
- * @ingroup io_interfaces
- * @{
- * @}
- */
-/**
  * @brief Device Model APIs
  * @defgroup device_model Device Model APIs
  * @{


### PR DESCRIPTION
```
It is sometimes necessary to define a Doxygen group that is not
associated to any particular header file. Instead of picking a random
header, one can use groups.dox.
```

```
Include what is necessary, no more no less.
```