### PR TITLE
tests: devicetree: device: utilize DEVICE_DT_NAME

### DIFF
--- a/tests/lib/devicetree/devices/app.overlay
+++ b/tests/lib/devicetree/devices/app.overlay
@@ -21,7 +21,6 @@
 			compatible = "vnd,gpio-device";
 			status = "okay";
 			reg = <0x0 0x1000>;
-			label = "TEST_GPIO_0";
 		};
 
 		test_i2c: i2c@11112222 {
@@ -31,14 +30,12 @@
 			status = "okay";
 			reg = <0x11112222 0x1000>;
 			clock-frequency = <100000>;
-			label = "TEST_I2C_CTLR";
 
 			test_dev_a: test-i2c-dev@10 {
 				compatible = "vnd,i2c-device";
 				status = "okay";
 				reg = <0x10>;
 				supply-gpios = <&test_gpio_0 1 0>;
-				label = "TEST_I2C_DEV_10";
 			};
 
 			test_gpiox: test-i2c-dev@11 {
@@ -47,7 +44,6 @@
 				compatible = "vnd,gpio-expander";
 				status = "okay";
 				reg = <0x11>;
-				label = "TEST_I2C_GPIO";
 			};
 
 			test_dev_b: test-i2c-dev@12 {
@@ -55,12 +51,10 @@
 				status = "okay";
 				reg = <0x12>;
 				supply-gpios = <&test_gpiox 2 0>;
-				label = "TEST_I2C_DEV_12";
 			};
 
 			test_dev_c: test-i2c-dev@13 {
 				compatible = "vnd,i2c-device";
-				label = "TEST_I2C_DEV_13";
 				reg = <0x13>;
 				status = "disabled";
 
@@ -85,7 +79,6 @@
 				status = "okay";
 				reg = <0x14>;
 				supply-gpios = <&test_gpiox 2 0>;
-				label = "TEST_I2C_DEV_14";
 			};
 		};
 
@@ -95,7 +88,6 @@
 			compatible = "vnd,gpio-device";
 			status = "okay";
 			reg = <0x1000 0x1000>;
-			label = "TEST_GPIO_INJECTED";
 		};
 	};
 };

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -160,7 +160,7 @@ ZTEST(devicetree_devices, test_requires)
 	struct visitor_context ctx = { 0 };
 
 	/* TEST_GPIO: no req */
-	dev = device_get_binding(DT_LABEL(TEST_GPIO));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
@@ -168,7 +168,7 @@ ZTEST(devicetree_devices, test_requires)
 		      NULL);
 
 	/* TEST_GPIO_INJECTED: no req */
-	dev = device_get_binding(DT_LABEL(TEST_GPIO_INJECTED));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO_INJECTED));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
@@ -176,7 +176,7 @@ ZTEST(devicetree_devices, test_requires)
 		      NULL);
 
 	/* TEST_I2C: no req */
-	dev = device_get_binding(DT_LABEL(TEST_I2C));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_I2C));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
@@ -184,7 +184,7 @@ ZTEST(devicetree_devices, test_requires)
 		      NULL);
 
 	/* TEST_DEVA: TEST_I2C GPIO */
-	dev = device_get_binding(DT_LABEL(TEST_DEVA));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_DEVA));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVA), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 2, NULL);
@@ -212,7 +212,7 @@ ZTEST(devicetree_devices, test_requires)
 		     NULL);
 
 	/* TEST_GPIOX: TEST_I2C */
-	dev = device_get_binding(DT_LABEL(TEST_GPIOX));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIOX));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIOX), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 1, NULL);
@@ -226,7 +226,7 @@ ZTEST(devicetree_devices, test_requires)
 		     NULL);
 
 	/* TEST_DEVB: TEST_I2C TEST_GPIOX */
-	dev = device_get_binding(DT_LABEL(TEST_DEVB));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_DEVB));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVB), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 2, NULL);
@@ -234,7 +234,7 @@ ZTEST(devicetree_devices, test_requires)
 	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
 
 	/* TEST_GPIO_INJECTED: NONE */
-	dev = device_get_binding(DT_LABEL(TEST_GPIO_INJECTED));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO_INJECTED));
 	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
 	hdls = device_required_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
@@ -247,17 +247,17 @@ ZTEST(devicetree_devices, test_injected)
 	const struct device *dev;
 
 	/* TEST_GPIO: NONE */
-	dev = device_get_binding(DT_LABEL(TEST_GPIO));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO));
 	hdls = device_injected_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
 
 	/* TEST_DEVB: NONE */
-	dev = device_get_binding(DT_LABEL(TEST_DEVB));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_DEVB));
 	hdls = device_injected_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 0, NULL);
 
 	/* TEST_GPIO_INJECTED: TEST_DEVB */
-	dev = device_get_binding(DT_LABEL(TEST_GPIO_INJECTED));
+	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO_INJECTED));
 	hdls = device_injected_handles_get(dev, &nhdls);
 	zassert_equal(nhdls, 1, NULL);
 	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);

--- a/tests/lib/devicetree/devices/testcase.yaml
+++ b/tests/lib/devicetree/devices/testcase.yaml
@@ -5,4 +5,4 @@ tests:
     # will mostly likely be the fastest.
     integration_platforms:
       - native_posix
-    platform_exclude: hsdk hsdk_2cores thingy52_nrf52832
+    platform_exclude: hsdk hsdk_2cores thingy52_nrf52832 bbc_microbit bbc_microbit_v2


### PR DESCRIPTION
Convert DT_LABEL to DEVICE_DT_NAME.  This lets us drop label properties
in the app.overlay.

Signed-off-by: Kumar Gala <galak@kernel.org>