### PR TITLE
test: filter out picolib tests for ARC MWDT toolchain

### DIFF
--- a/lib/libc/Kconfig
+++ b/lib/libc/Kconfig
@@ -18,6 +18,7 @@ config SUPPORT_MINIMAL_LIBC
 config PICOLIBC_SUPPORTED
 	bool
 	depends on ARC || ARM || ARM64 || MIPS || RISCV
+	depends on "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "arcmwdt"
 	default y
 	help
 	  Selected when the target has support for picolibc.


### PR DESCRIPTION
Currently picolib isn't compatible with ARC MWDT toolchain, so don't try to build picolib tests in case of ARC MWDT toolchain usage.