### PR TITLE
cmake: compiler: Add flag for disabling strict aliasing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,6 +141,10 @@ if(TOOLCHAIN_USE_CUSTOM)
   zephyr_compile_definitions(__TOOLCHAIN_CUSTOM__)
 endif()
 
+# @Intent: Set compiler specific flag for disabling strict aliasing rule
+zephyr_compile_options($<$<COMPILE_LANGUAGE:C>:$<TARGET_PROPERTY:compiler,no_strict_aliasing>>)
+zephyr_compile_options($<$<COMPILE_LANGUAGE:CXX>:$<TARGET_PROPERTY:compiler-cpp,no_strict_aliasing>>)
+
 # @Intent: Set compiler flags to enable buffer overflow checks in libc functions
 # @config in CONFIG_NO_OPTIMIZATIONS optional : Optimizations may affect security
 zephyr_compile_definitions($<TARGET_PROPERTY:compiler,security_fortify> )

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -132,6 +132,9 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a "")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 "")
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "")
 
+# Flag for disabling strict aliasing rule in C and C++
+set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)
+
 # Disable exceptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")
 

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -65,6 +65,9 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp2a)
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp20)
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b)
 
+# Flag for disabling strict aliasing rule in C and C++
+set_compiler_property(PROPERTY no_strict_aliasing)
+
 # Flag for disabling exceptions in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -129,6 +129,9 @@ set_property(TARGET compiler-cpp PROPERTY dialect_cpp20 "-std=c++20"
 set_property(TARGET compiler-cpp PROPERTY dialect_cpp2b "-std=c++2b"
   "-Wno-register" "-Wno-volatile")
 
+# Flag for disabling strict aliasing rule in C and C++
+set_compiler_property(PROPERTY no_strict_aliasing -fno-strict-aliasing)
+
 # Disable exceptions flag in C++
 set_property(TARGET compiler-cpp PROPERTY no_exceptions "-fno-exceptions")
 


### PR DESCRIPTION
This series adds the infrastructure for specifying the flag for disabling the strict aliasing rule.

```
This commit adds a template for specifying the C/C++ compiler flag for
disabling the strict aliasing rule.

It also enables this flag globally because the Zephyr codebase does not
strictly adhere to the aliasing rules specified by the C/C++ standards
and the optimisation strategies that assume these rules may end up
generating invalid code.

For instance, GCC 11 and above tend to optimise more aggressively
assuming the strict adherence to the standard aliasing rules and may
generate invalid code, when compiling Zephyr with `-fstrict-aliasing`,
that results in various run-time failures.

Note that the footprint and performance ramifications of disabling the
strict aliasing rule are negligible.
```

Fixes #44466
Fixes #48829

re: Motivation: https://github.com/zephyrproject-rtos/zephyr/issues/44466#issuecomment-1211012355
re: Footprint: https://github.com/zephyrproject-rtos/zephyr/issues/44466#issuecomment-1211033752

**NOTE: This is required for the Zephyr SDK 0.15.0 release, which includes the GCC 12.**