### PR TITLE
dts: bindings: fix intel,dai-misc

### DIFF
--- a/dts/bindings/dai/intel,dai-misc.yaml
+++ b/dts/bindings/dai/intel,dai-misc.yaml
@@ -3,7 +3,7 @@
 
 description: Intel Digital PDM Microphone (DMIC) node
 
-compatible: "intel,dai,dmic"
+compatible: "intel,dai-dmic"
 
 include: base.yaml
 


### PR DESCRIPTION
* Fix the compatible string from "intel,dai,dmic" to "intel,dai-dmic".
* Also rename the yaml file to have vendor name first.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>