### PR TITLE
libc/picolibc: Place malloc heap in noinit section if possible

### DIFF
--- a/lib/libc/picolibc/libc-hooks.c
+++ b/lib/libc/picolibc/libc-hooks.c
@@ -88,7 +88,7 @@ LIBC_BSS static size_t max_heap_size;
 K_APPMEM_PARTITION_DEFINE(z_malloc_partition);
 #   define MALLOC_BSS	K_APP_BMEM(z_malloc_partition)
 #  else
-#   define MALLOC_BSS
+#   define MALLOC_BSS	__noinit
 #  endif
 
 MALLOC_BSS static unsigned char __aligned(HEAP_ALIGN)


### PR DESCRIPTION
When the heap is of a fixed size and there isn't a special malloc partition
in use, place the heap in uninitialized memory so that the application
doesn't spend time at startup erasing it. Picolibc malloc always clears
memory before returning it to applications, so this change will not be
visible to applications.

Signed-off-by: Keith Packard <keithp@keithp.com>