### PR TITLE
drivers: entropy: cleaned up mcux code

### DIFF
--- a/drivers/entropy/entropy_mcux_rng.c
+++ b/drivers/entropy/entropy_mcux_rng.c
@@ -24,8 +24,6 @@ static int entropy_mcux_rng_get_entropy(const struct device *dev,
 	const struct mcux_entropy_config *config = dev->config;
 	status_t status;
 
-	ARG_UNUSED(dev);
-
 	status = RNG_GetRandomData(config->base, buffer, length);
 	__ASSERT_NO_MSG(!status);
 
@@ -40,14 +38,6 @@ static const struct mcux_entropy_config entropy_mcux_config = {
 	.base = (RNG_Type *)DT_INST_REG_ADDR(0)
 };
 
-static int entropy_mcux_rng_init(const struct device *);
-
-DEVICE_DT_INST_DEFINE(0,
-		    entropy_mcux_rng_init, NULL, NULL,
-		    &entropy_mcux_config,
-		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
-		    &entropy_mcux_rng_api_funcs);
-
 static int entropy_mcux_rng_init(const struct device *dev)
 {
 	ARG_UNUSED(dev);
@@ -56,3 +46,9 @@ static int entropy_mcux_rng_init(const struct device *dev)
 
 	return 0;
 }
+
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_mcux_rng_init, NULL, NULL,
+		    &entropy_mcux_config,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
+		    &entropy_mcux_rng_api_funcs);

--- a/drivers/entropy/entropy_mcux_rnga.c
+++ b/drivers/entropy/entropy_mcux_rnga.c
@@ -57,13 +57,6 @@ static const struct entropy_driver_api entropy_mcux_rnga_api_funcs = {
 	.get_entropy = entropy_mcux_rnga_get_entropy
 };
 
-static int entropy_mcux_rnga_init(const struct device *);
-
-DEVICE_DT_INST_DEFINE(0,
-		    entropy_mcux_rnga_init, NULL, NULL, NULL,
-		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
-		    &entropy_mcux_rnga_api_funcs);
-
 static int entropy_mcux_rnga_init(const struct device *dev)
 {
 	uint32_t seed = k_cycle_get_32();
@@ -82,3 +75,8 @@ static int entropy_mcux_rnga_init(const struct device *dev)
 	RNGA_SetMode(RNG, kRNGA_ModeSleep);
 	return 0;
 }
+
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_mcux_rnga_init, NULL, NULL, NULL,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
+		    &entropy_mcux_rnga_api_funcs);

--- a/drivers/entropy/entropy_mcux_trng.c
+++ b/drivers/entropy/entropy_mcux_trng.c
@@ -24,8 +24,6 @@ static int entropy_mcux_trng_get_entropy(const struct device *dev,
 	const struct mcux_entropy_config *config = dev->config;
 	status_t status;
 
-	ARG_UNUSED(dev);
-
 	status = TRNG_GetRandomData(config->base, buffer, length);
 	__ASSERT_NO_MSG(!status);
 
@@ -40,21 +38,11 @@ static struct mcux_entropy_config entropy_mcux_config = {
 	.base = (TRNG_Type *)DT_INST_REG_ADDR(0)
 };
 
-static int entropy_mcux_trng_init(const struct device *);
-
-DEVICE_DT_INST_DEFINE(0,
-		    entropy_mcux_trng_init, NULL, NULL,
-		    &entropy_mcux_config,
-		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
-		    &entropy_mcux_trng_api_funcs);
-
 static int entropy_mcux_trng_init(const struct device *dev)
 {
 	const struct mcux_entropy_config *config = dev->config;
 	trng_config_t conf;
 	status_t status;
-
-	ARG_UNUSED(dev);
 
 	status = TRNG_GetDefaultConfig(&conf);
 	__ASSERT_NO_MSG(!status);
@@ -64,3 +52,9 @@ static int entropy_mcux_trng_init(const struct device *dev)
 
 	return 0;
 }
+
+DEVICE_DT_INST_DEFINE(0,
+		    entropy_mcux_trng_init, NULL, NULL,
+		    &entropy_mcux_config,
+		    PRE_KERNEL_1, CONFIG_ENTROPY_INIT_PRIORITY,
+		    &entropy_mcux_trng_api_funcs);


### PR DESCRIPTION
cleaned up some code in 3 mcux entropy drivers,
removing unnecessary void casts and function declarations

Signed-off-by: Declan Snyder <declan.snyder@nxp.com>