### PR TITLE
emul: Remove empty files

### DIFF
--- a/subsys/emul/CMakeLists.txt
+++ b/subsys/emul/CMakeLists.txt
@@ -8,5 +8,4 @@ zephyr_include_directories_ifdef(CONFIG_EMUL_BMI160 ${ZEPHYR_BASE}/drivers/senso
 zephyr_library_sources_ifdef(CONFIG_EMUL_BMI160		emul_bmi160.c)
 
 add_subdirectory(i2c)
-add_subdirectory(spi)
 add_subdirectory(espi)

--- a/subsys/emul/Kconfig
+++ b/subsys/emul/Kconfig
@@ -46,7 +46,6 @@ config EMUL_BMI160
 	  i2c/ or spi/ directories.
 
 source "subsys/emul/i2c/Kconfig"
-source "subsys/emul/spi/Kconfig"
 source "subsys/emul/espi/Kconfig"
 
 endif

--- a/subsys/emul/spi/CMakeLists.txt
+++ b/subsys/emul/spi/CMakeLists.txt
@@ -1,4 +1,0 @@
-# SPDX-License-Identifier: Apache-2.0
-
-# Once we have more than 10 devices we should consider splitting them into
-# subdirectories to match the drivers/ structure.

--- a/subsys/emul/spi/Kconfig
+++ b/subsys/emul/spi/Kconfig
@@ -1,4 +1,0 @@
-# Configuration options for I2C emulators
-
-# Copyright 2020 Google LLC
-# SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
Those files do not contain anything of relevance since
fa90b5c2434cb4a0e2ae5b324ac99cb5fad333c9 [emul: spi: bmi160: Move to
top-level directory].