### PR TITLE
Bluetooth: controller: Only allow supported feature bits to be set by host

### DIFF
--- a/subsys/bluetooth/controller/include/ll_feat.h
+++ b/subsys/bluetooth/controller/include/ll_feat.h
@@ -243,9 +243,6 @@
 /* Mask to filter away octet 0 for feature exchange */
 #define LL_FEAT_FILTER_OCTET0    (LL_FEAT_BIT_MASK & ~0xFFULL)
 
-/* Mask for host controlled features */
-#define LL_FEAT_HOST_BIT_MASK    0x4100000000ULL
-
 /* Feature bits of this controller */
 #define LL_FEAT                  (LL_FEAT_BIT_ENC | \
 				  LL_FEAT_BIT_CONN_PARAM_REQ | \
@@ -276,3 +273,17 @@
 				  LL_FEAT_BIT_ISO_BROADCASTER | \
 				  LL_FEAT_BIT_SYNC_RECEIVER | \
 				  LL_FEAT_BIT_PERIODIC_ADI_SUPPORT)
+
+/* Connected Isochronous Stream (Host Support) bit is controlled by host */
+#if defined(CONFIG_BT_CTLR_CONN_ISO)
+#define LL_FEAT_HOST_BITS_ISO_CHANNELS BIT64(BT_LE_FEAT_BIT_ISO_CHANNELS)
+#else /* !CONFIG_BT_CTLR_CONN_ISO */
+#define LL_FEAT_HOST_BITS_ISO_CHANNELS 0U
+#endif /* !CONFIG_BT_CTLR_CONN_ISO */
+
+/* Connection subrating not supported and bit thus cannot be set by host */
+#define LL_FEAT_HOST_BITS_CONN_SUBRATING 0U
+
+/* Mask for host controlled features */
+#define LL_FEAT_HOST_BIT_MASK  (LL_FEAT_HOST_BITS_ISO_CHANNELS |\
+				LL_FEAT_HOST_BITS_CONN_SUBRATING)

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -2894,10 +2894,12 @@ static int le_init_iso(void)
 	int err;
 	struct net_buf *rsp;
 
-	/* Set Isochronous Channels - Host support */
-	err = le_set_host_feature(BT_LE_FEAT_BIT_ISO_CHANNELS, 1);
-	if (err) {
-		return err;
+	if (IS_ENABLED(CONFIG_BT_ISO_UNICAST)) {
+		/* Set Connected Isochronous Streams - Host support */
+		err = le_set_host_feature(BT_LE_FEAT_BIT_ISO_CHANNELS, 1);
+		if (err) {
+			return err;
+		}
 	}
 
 	/* Octet 41, bit 5 is read buffer size V2 */


### PR DESCRIPTION
Redefine mask of host-controlled feature bits to include only features
that are supported by the controller. This fixes a conformance test
failure where setting an unsupported host-controlled feature bit was
not rejected as it should.

Fixes #54544

Signed-off-by: Wolfgang Puffitsch <wopu@demant.com>