### PR TITLE
samples: i2s: echo: exclude litex_vexriscv

### DIFF
--- a/samples/drivers/i2s/echo/sample.yaml
+++ b/samples/drivers/i2s/echo/sample.yaml
@@ -8,6 +8,7 @@ tests:
     integration_platforms:
       - nrf52840dk_nrf52840
       - nrf5340dk_nrf5340_cpuapp
+    platform_exclude: litex_vexriscv
     harness: console
     harness_config:
       type: one_line


### PR DESCRIPTION
The litex platform has its own sample and echo sample does not
build on litex_vexriscv so exclude it.

Signed-off-by: Kumar Gala <galak@kernel.org>