### PR TITLE
dts: nxp: kw41z: Fix typo in 802.15.4 device compatible

### DIFF
--- a/dts/arm/nxp/nxp_kw41z.dtsi
+++ b/dts/arm/nxp/nxp_kw41z.dtsi
@@ -242,9 +242,8 @@
 		};
 
 		ieee802154: ieee802154@4005d000 {
-			compatible = "nxp,kw41z-ieee802514";
+			compatible = "nxp,kw41z-ieee802154";
 			reg = <0x4005d000 0x1000>;
-			label = "KW41Z";
 			status = "disabled";
 		};
 	};


### PR DESCRIPTION
The ieee802.15.4 node had a typo in the compatible.  Also remove
the label property as its not needed.

Signed-off-by: Kumar Gala <galak@kernel.org>