### PR TITLE
Bluetooth: gatt: allow the CCCD to be in any location

### DIFF
--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -3145,7 +3145,18 @@ bool bt_gatt_is_subscribed(struct bt_conn *conn,
 		__ASSERT(attr, "No more attributes\n");
 	}
 
-	/* Check if the attribute is the CCC Descriptor */
+	/* Find the CCC Descriptor */
+	while (bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CCC) &&
+	       /* Also stop if we leave the current characteristic definition */
+	       bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CHRC) &&
+	       bt_uuid_cmp(attr->uuid, BT_UUID_GATT_PRIMARY) &&
+	       bt_uuid_cmp(attr->uuid, BT_UUID_GATT_SECONDARY)) {
+		attr = bt_gatt_attr_next(attr);
+		if (!attr) {
+			return false;
+		}
+	}
+
 	if (bt_uuid_cmp(attr->uuid, BT_UUID_GATT_CCC) != 0) {
 		return false;
 	}

--- a/tests/bluetooth/bsim_bt/bsim_test_notify/src/gatt_server_test.c
+++ b/tests/bluetooth/bsim_bt/bsim_test_notify/src/gatt_server_test.c
@@ -100,6 +100,7 @@ BT_GATT_SERVICE_DEFINE(test_svc, BT_GATT_PRIMARY_SERVICE(TEST_SERVICE_UUID),
 		       BT_GATT_CHARACTERISTIC(TEST_CHRC_UUID,
 					      BT_GATT_CHRC_NOTIFY | BT_GATT_CHRC_READ,
 					      BT_GATT_PERM_READ, read_test_chrc, NULL, NULL),
+		       BT_GATT_CUD("Short test_svc format description", BT_GATT_PERM_READ),
 		       BT_GATT_CCC(short_subscribe, BT_GATT_PERM_READ | BT_GATT_PERM_WRITE),
 		       BT_GATT_CHARACTERISTIC(TEST_LONG_CHRC_UUID,
 					      BT_GATT_CHRC_NOTIFY | BT_GATT_CHRC_READ,
@@ -143,7 +144,7 @@ static inline void long_notify(void)
 {
 	static size_t length = LONG_CHRC_SIZE;
 	static struct bt_gatt_notify_params params = {
-		.attr = &attr_test_svc[4],
+		.attr = &attr_test_svc[5],
 		.data = long_chrc_data,
 		.len = LONG_CHRC_SIZE,
 		.func = notification_sent,


### PR DESCRIPTION
Per spec, the CCCD doesn't necessarily have to be located immediately after
the characteristic value. This commit fixes that assumption when checking
for subscriptions.

Fixes #48880.
