### PR TITLE
west: warn that using runner args on multiple domains is experimental

### DIFF
--- a/scripts/west_commands/run_common.py
+++ b/scripts/west_commands/run_common.py
@@ -169,6 +169,11 @@ def do_run_common(command, user_args, user_runner_args, domains=None):
             # Get the user specified domains.
             domains = load_domains(build_dir).get_domains(user_args.domain)
 
+    if len(domains) > 1 and len(user_runner_args) > 1:
+        log.wrn("Specifying runner options for multiple domains is experimental.\n"
+                "If problems are experienced, please specify a single domain "
+                "using '--domain <domain>'")
+
     for d in domains:
         do_run_common_image(command, user_args, user_runner_args, d.build_dir)
 


### PR DESCRIPTION
The introduction of sysbuild and west build / flash / debug / etc.
support raises questions regarding how to handle user specified runner
arguments.

Some arguments may be acceptable for all domains, whereas others are
only valid for a single or few domains in a multi domain build.

Therefore, consider the usages of runner specific options experimental
when applied to multiple domains.

The following warning is printed to the user when using runner specific
arguments on multiple domains:
```
WARNING: Specifying runner options for multiple domains is experimental.
If problems are experienced, please specify a single domain using '--domain <domain>'
```

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>