### PR TITLE
Bluetooth: bugfix in applying appearance from settings

### DIFF
--- a/subsys/bluetooth/host/settings.c
+++ b/subsys/bluetooth/host/settings.c
@@ -186,7 +186,7 @@ static int set(const char *name, size_t len_rd, settings_read_cb read_cb,
 
 #if defined(CONFIG_BT_DEVICE_APPEARANCE_DYNAMIC)
 	if (!strncmp(name, "appearance", len)) {
-		if (len != sizeof(bt_dev.appearance)) {
+		if (len_rd != sizeof(bt_dev.appearance)) {
 			BT_ERR("Ignoring settings entry 'bt/appearance'. Wrong length.");
 			return -EINVAL;
 		}


### PR DESCRIPTION
The len parameter is the length of the settings name 'appearance' and not of the settings value

Signed-off-by: Matthias Hauser <Matthias.Hauser@we-online.de>