### PR TITLE
bluetooth: hci: spi: minimum reset duration

### DIFF
--- a/drivers/bluetooth/hci/spi.c
+++ b/drivers/bluetooth/hci/spi.c
@@ -490,6 +490,7 @@ static int bt_spi_open(void)
 			0, K_NO_WAIT);
 
 	/* Take BLE out of reset */
+	k_sleep(K_MSEC(DT_INST_PROP_OR(0, reset_assert_duration_ms, 0)));
 	gpio_pin_set_dt(&rst_gpio, 0);
 
 	/* Device will let us know when it's ready */

--- a/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
+++ b/dts/bindings/bluetooth/zephyr,bt-hci-spi.yaml
@@ -17,3 +17,9 @@ properties:
     reset-gpios:
       type: phandle-array
       required: true
+
+    reset-assert-duration-ms:
+      type: int
+      description:
+        Minimum duration to hold the reset-gpios pin low for.
+        If not specified no delay beyond the code path execution time is guaranteed.


### PR DESCRIPTION
Add the option to specify the minimum duration that the `reset-gpios`
pin is held low on boot. This lets devices with additional capacitance
on the reset line still reboot the Bluetooth controller.

Signed-off-by: Jordan Yates <jordan.yates@data61.csiro.au>