### PR TITLE
doc: kconfig: add option to select number of results per page

### DIFF
--- a/doc/_extensions/zephyr/kconfig/static/kconfig.css
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.css
@@ -15,8 +15,24 @@
     width: 100%;
 }
 
-#__kconfig-search .search-summary {
+#__kconfig-search select {
+    border-radius: 5px;
+    border: 1px solid rgba(149, 157, 165, 0.2);
+    box-shadow: unset;
+}
+
+#__kconfig-search .search-tools {
+    display: flex;
+    flex-direction: row;
     margin: 0.25rem 0.1rem 1.5rem;
+}
+
+#__kconfig-search .results-per-page-container {
+    margin-left: auto;
+}
+
+#__kconfig-search .results-per-page-title {
+    padding-right: 1rem;
 }
 
 #__kconfig-search .search-nav {

--- a/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
+++ b/doc/_extensions/zephyr/kconfig/static/kconfig.mjs
@@ -4,14 +4,16 @@
  */
 
 const DB_FILE = 'kconfig.json';
-const MAX_RESULTS = 10;
+const RESULTS_PER_PAGE_OPTIONS = [10, 25, 50];
 
 /* search state */
 let db;
 let searchOffset;
+let maxResults = RESULTS_PER_PAGE_OPTIONS[0];
 
 /* elements */
 let input;
+let searchTools;
 let summaryText;
 let results;
 let navigation;
@@ -282,9 +284,9 @@ function doSearch() {
 
     /* nothing to search for */
     if (!input.value) {
-        summaryText.nodeValue = '';
         results.replaceChildren();
         navigation.style.visibility = 'hidden';
+        searchTools.style.visibility = 'hidden';
         return;
     }
 
@@ -307,7 +309,7 @@ function doSearch() {
 
         if (matches === regexes.length) {
             count++;
-            if (count > searchOffset && count <= (searchOffset + MAX_RESULTS)) {
+            if (count > searchOffset && count <= (searchOffset + maxResults)) {
                 return true;
             }
         }
@@ -315,16 +317,17 @@ function doSearch() {
         return false;
     });
 
-    /* show results count */
+    /* show results count and search tools */
     summaryText.nodeValue = `${count} options match your search.`;
+    searchTools.style.visibility = 'visible';
 
     /* update navigation */
     navigation.style.visibility = 'visible';
-    navigationPrev.disabled = searchOffset - MAX_RESULTS < 0;
-    navigationNext.disabled = searchOffset + MAX_RESULTS > count;
+    navigationPrev.disabled = searchOffset - maxResults < 0;
+    navigationNext.disabled = searchOffset + maxResults > count;
 
-    const currentPage = Math.floor(searchOffset / MAX_RESULTS) + 1;
-    const totalPages = Math.floor(count / MAX_RESULTS) + 1;
+    const currentPage = Math.floor(searchOffset / maxResults) + 1;
+    const totalPages = Math.floor(count / maxResults) + 1;
     navigationPagesText.nodeValue = `Page ${currentPage} of ${totalPages}`;
 
     /* render Kconfig entries */
@@ -362,13 +365,49 @@ function setupKconfigSearch() {
     input.type = 'text';
     container.appendChild(input);
 
+    /* create search tools container */
+    searchTools = document.createElement('div');
+    searchTools.className = 'search-tools';
+    searchTools.style.visibility = 'hidden';
+    container.appendChild(searchTools);
+
     /* create search summary */
+    const searchSummaryContainer = document.createElement('div');
+    searchTools.appendChild(searchSummaryContainer);
+
     const searchSummary = document.createElement('p');
-    searchSummary.className = 'search-summary';
-    container.appendChild(searchSummary);
+    searchSummaryContainer.appendChild(searchSummary);
 
     summaryText = document.createTextNode('');
     searchSummary.appendChild(summaryText);
+
+    /* create results per page selector */
+    const resultsPerPageContainer = document.createElement('div');
+    resultsPerPageContainer.className = 'results-per-page-container';
+    searchTools.appendChild(resultsPerPageContainer);
+
+    const resultsPerPageTitle = document.createElement('span');
+    resultsPerPageTitle.className = 'results-per-page-title';
+    resultsPerPageContainer.appendChild(resultsPerPageTitle);
+
+    const resultsPerPageTitleText = document.createTextNode('Results per page:');
+    resultsPerPageTitle.appendChild(resultsPerPageTitleText);
+
+    const resultsPerPageSelect = document.createElement('select');
+    resultsPerPageSelect.onchange = (event) => {
+        maxResults = parseInt(event.target.value);
+        searchOffset = 0;
+        doSearch();
+    }
+    resultsPerPageContainer.appendChild(resultsPerPageSelect);
+
+    RESULTS_PER_PAGE_OPTIONS.forEach((value, index) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.text = value;
+        option.selected = index === 0;
+        resultsPerPageSelect.appendChild(option);
+    });
 
     /* create search results container */
     results = document.createElement('div');
@@ -384,7 +423,7 @@ function setupKconfigSearch() {
     navigationPrev.className = 'btn';
     navigationPrev.disabled = true;
     navigationPrev.onclick = () => {
-        searchOffset -= MAX_RESULTS;
+        searchOffset -= maxResults;
         doSearch();
         window.scroll(0, 0);
     }
@@ -403,7 +442,7 @@ function setupKconfigSearch() {
     navigationNext.className = 'btn';
     navigationNext.disabled = true;
     navigationNext.onclick = () => {
-        searchOffset += MAX_RESULTS;
+        searchOffset += maxResults;
         doSearch();
         window.scroll(0, 0);
     }


### PR DESCRIPTION
When searching for a certain group of Kconfig options, e.g. CONFIG_BT*
it may be useful to view more than 10 options at the same time. This
patch adds a new combo box that allows to increase the number of results
per page (10, 25 or 50).

![image](https://user-images.githubusercontent.com/25011557/184110191-db6270a8-d712-4e87-bd17-3430fbb69df4.png)

Demo: https://builds.zephyrproject.io/zephyr/pr/48923/docs/kconfig.html

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>