### PR TITLE
drivers: adc: stm32: enable channel preselection for stm32u5

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -656,6 +656,10 @@ static int start_read(const struct device *dev,
 	 * This register controls the analog switch integrated in the IO level.
 	 */
 	LL_ADC_SetChannelPreSelection(adc, channel);
+#elif defined(CONFIG_SOC_SERIES_STM32U5X)
+	if (adc == ADC1) {
+		LL_ADC_SetChannelPreselection(adc, channel);
+	}
 #endif
 
 #if defined(CONFIG_SOC_SERIES_STM32F0X) || \


### PR DESCRIPTION
In STM32U5 ADC1 PCSEL register must be set before conversion.

Signed-off-by: Wojciech Slenska <wsl@trackunit.com>