### PR TITLE
boards: thingy53_nrf5340: Disable BMI270 in DTS

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -114,7 +114,6 @@
 		magn0 = &bmm150;
 		watchdog0 = &wdt0;
 		accel0 = &adxl362;
-		accel1 = &bmi270;
 	};
 };
 
@@ -189,6 +188,7 @@
 
 	bmi270: spi-dev-bmi270@1 {
 		compatible = "bosch,bmi270";
+		status = "disabled";
 		spi-max-frequency = <8000000>;
 		reg = <1>;
 		int1-gpios = <&gpio0 23 0>;


### PR DESCRIPTION
Change disables BMI270 sensor in board DTS. The BMI270 sensor driver in Zephyr does not support sensor connected over SPI.