### PR TITLE
drivers: dts: Add SPI capability to bmi270 driver

### DIFF
--- a/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
+++ b/boards/arm/thingy53_nrf5340/thingy53_nrf5340_common.dts
@@ -198,7 +198,6 @@
 		status = "disabled";
 		spi-max-frequency = <8000000>;
 		reg = <1>;
-		int1-gpios = <&gpio0 23 0>;
 	};
 
 	nrf_radio_fem_spi: fem_spi@2 {

--- a/drivers/sensor/bmi270/CMakeLists.txt
+++ b/drivers/sensor/bmi270/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
 # Copyright (c) 2021 Bosch Sensortec GmbH
+# Copyright (c) 2022 Nordic Semiconductor ASA
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -7,3 +8,5 @@
 zephyr_library()
 
 zephyr_library_sources(bmi270.c)
+zephyr_library_sources_ifdef(CONFIG_BMI270_BUS_I2C bmi270_i2c.c)
+zephyr_library_sources_ifdef(CONFIG_BMI270_BUS_SPI bmi270_spi.c)

--- a/drivers/sensor/bmi270/Kconfig
+++ b/drivers/sensor/bmi270/Kconfig
@@ -1,12 +1,28 @@
 # BMI270 6 Axis IMU configuration
 
 # Copyright (c) 2021 Bosch Sensortec GmbH
+# Copyright (c) 2022 Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
-config BMI270
+menuconfig BMI270
 	bool "BMI270 Inertial measurement unit"
 	default y
 	depends on DT_HAS_BOSCH_BMI270_ENABLED
-	select I2C
+	select I2C if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),i2c)
+	select SPI if $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),spi)
 	help
 	  Enable driver for BMI270 I2C-based imu sensor
+
+if BMI270
+
+config BMI270_BUS_I2C
+	bool
+	default y
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),i2c)
+
+config BMI270_BUS_SPI
+	bool
+	default y
+	depends on $(dt_compat_on_bus,$(DT_COMPAT_BOSCH_BMI270),spi)
+
+endif # BMI270

--- a/drivers/sensor/bmi270/bmi270.c
+++ b/drivers/sensor/bmi270/bmi270.c
@@ -143,7 +143,7 @@ static uint8_t acc_odr_to_reg(const struct sensor_value *val)
 static int set_accel_odr_osr(const struct device *dev, const struct sensor_value *odr,
 			     const struct sensor_value *osr)
 {
-	struct bmi270_data *drv_dev = dev->data;
+	struct bmi270_data *data = dev->data;
 	uint8_t acc_conf, odr_bits, pwr_ctrl, osr_bits;
 	int ret = 0;
 
@@ -185,11 +185,11 @@ static int set_accel_odr_osr(const struct device *dev, const struct sensor_value
 						   BMI270_ACC_FILT_PWR_OPT);
 		}
 
-		drv_dev->acc_odr = odr_bits;
+		data->acc_odr = odr_bits;
 	}
 
 	if (osr) {
-		if (drv_dev->acc_odr >= BMI270_ACC_ODR_100_HZ) {
+		if (data->acc_odr >= BMI270_ACC_ODR_100_HZ) {
 			/* Performance mode */
 			/* osr->val2 should be unused */
 			switch (osr->val1) {
@@ -263,7 +263,7 @@ static int set_accel_odr_osr(const struct device *dev, const struct sensor_value
 
 static int set_accel_range(const struct device *dev, const struct sensor_value *range)
 {
-	struct bmi270_data *drv_dev = dev->data;
+	struct bmi270_data *data = dev->data;
 	int ret = 0;
 	uint8_t acc_range, reg;
 
@@ -276,19 +276,19 @@ static int set_accel_range(const struct device *dev, const struct sensor_value *
 	switch (range->val1) {
 	case 2:
 		reg = BMI270_ACC_RANGE_2G;
-		drv_dev->acc_range = 2;
+		data->acc_range = 2;
 		break;
 	case 4:
 		reg = BMI270_ACC_RANGE_4G;
-		drv_dev->acc_range = 4;
+		data->acc_range = 4;
 		break;
 	case 8:
 		reg = BMI270_ACC_RANGE_8G;
-		drv_dev->acc_range = 8;
+		data->acc_range = 8;
 		break;
 	case 16:
 		reg = BMI270_ACC_RANGE_16G;
-		drv_dev->acc_range = 16;
+		data->acc_range = 16;
 		break;
 	default:
 		return -ENOTSUP;
@@ -331,7 +331,7 @@ static uint8_t gyr_odr_to_reg(const struct sensor_value *val)
 static int set_gyro_odr_osr(const struct device *dev, const struct sensor_value *odr,
 			    const struct sensor_value *osr)
 {
-	struct bmi270_data *drv_dev = dev->data;
+	struct bmi270_data *data = dev->data;
 	uint8_t gyr_conf, odr_bits, pwr_ctrl, osr_bits;
 	int ret = 0;
 
@@ -381,7 +381,7 @@ static int set_gyro_odr_osr(const struct device *dev, const struct sensor_value 
 						   BMI270_GYR_FILT_NOISE_PWR);
 		}
 
-		drv_dev->gyr_odr = odr_bits;
+		data->gyr_odr = odr_bits;
 	}
 
 	if (osr) {
@@ -422,7 +422,7 @@ static int set_gyro_odr_osr(const struct device *dev, const struct sensor_value 
 
 static int set_gyro_range(const struct device *dev, const struct sensor_value *range)
 {
-	struct bmi270_data *drv_dev = dev->data;
+	struct bmi270_data *data = dev->data;
 	int ret = 0;
 	uint8_t gyr_range, reg;
 
@@ -435,23 +435,23 @@ static int set_gyro_range(const struct device *dev, const struct sensor_value *r
 	switch (range->val1) {
 	case 125:
 		reg = BMI270_GYR_RANGE_125DPS;
-		drv_dev->gyr_range = 125;
+		data->gyr_range = 125;
 		break;
 	case 250:
 		reg = BMI270_GYR_RANGE_250DPS;
-		drv_dev->gyr_range = 250;
+		data->gyr_range = 250;
 		break;
 	case 500:
 		reg = BMI270_GYR_RANGE_500DPS;
-		drv_dev->gyr_range = 500;
+		data->gyr_range = 500;
 		break;
 	case 1000:
 		reg = BMI270_GYR_RANGE_1000DPS;
-		drv_dev->gyr_range = 1000;
+		data->gyr_range = 1000;
 		break;
 	case 2000:
 		reg = BMI270_GYR_RANGE_2000DPS;
-		drv_dev->gyr_range = 2000;
+		data->gyr_range = 2000;
 		break;
 	default:
 		return -ENOTSUP;
@@ -497,29 +497,29 @@ static int8_t write_config_file(const struct device *dev)
 
 static int bmi270_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
-	struct bmi270_data *drv_dev = dev->data;
-	uint8_t data[12];
+	struct bmi270_data *data = dev->data;
+	uint8_t buf[12];
 	int ret;
 
 	if (chan != SENSOR_CHAN_ALL) {
 		return -ENOTSUP;
 	}
 
-	ret = bmi270_reg_read(dev, BMI270_REG_ACC_X_LSB, data, 12);
+	ret = bmi270_reg_read(dev, BMI270_REG_ACC_X_LSB, buf, 12);
 	if (ret == 0) {
-		drv_dev->ax = (int16_t)sys_get_le16(&data[0]);
-		drv_dev->ay = (int16_t)sys_get_le16(&data[2]);
-		drv_dev->az = (int16_t)sys_get_le16(&data[4]);
-		drv_dev->gx = (int16_t)sys_get_le16(&data[6]);
-		drv_dev->gy = (int16_t)sys_get_le16(&data[8]);
-		drv_dev->gz = (int16_t)sys_get_le16(&data[10]);
+		data->ax = (int16_t)sys_get_le16(&buf[0]);
+		data->ay = (int16_t)sys_get_le16(&buf[2]);
+		data->az = (int16_t)sys_get_le16(&buf[4]);
+		data->gx = (int16_t)sys_get_le16(&buf[6]);
+		data->gy = (int16_t)sys_get_le16(&buf[8]);
+		data->gz = (int16_t)sys_get_le16(&buf[10]);
 	} else {
-		drv_dev->ax = 0;
-		drv_dev->ay = 0;
-		drv_dev->az = 0;
-		drv_dev->gx = 0;
-		drv_dev->gy = 0;
-		drv_dev->gz = 0;
+		data->ax = 0;
+		data->ay = 0;
+		data->az = 0;
+		data->gx = 0;
+		data->gy = 0;
+		data->gz = 0;
 	}
 
 	return ret;
@@ -528,34 +528,34 @@ static int bmi270_sample_fetch(const struct device *dev, enum sensor_channel cha
 static int bmi270_channel_get(const struct device *dev, enum sensor_channel chan,
 			      struct sensor_value *val)
 {
-	struct bmi270_data *drv_dev = dev->data;
+	struct bmi270_data *data = dev->data;
 
 	if (chan == SENSOR_CHAN_ACCEL_X) {
-		channel_accel_convert(val, drv_dev->ax, drv_dev->acc_range);
+		channel_accel_convert(val, data->ax, data->acc_range);
 	} else if (chan == SENSOR_CHAN_ACCEL_Y) {
-		channel_accel_convert(val, drv_dev->ay, drv_dev->acc_range);
+		channel_accel_convert(val, data->ay, data->acc_range);
 	} else if (chan == SENSOR_CHAN_ACCEL_Z) {
-		channel_accel_convert(val, drv_dev->az, drv_dev->acc_range);
+		channel_accel_convert(val, data->az, data->acc_range);
 	} else if (chan == SENSOR_CHAN_ACCEL_XYZ) {
-		channel_accel_convert(&val[0], drv_dev->ax,
-				      drv_dev->acc_range);
-		channel_accel_convert(&val[1], drv_dev->ay,
-				      drv_dev->acc_range);
-		channel_accel_convert(&val[2], drv_dev->az,
-				      drv_dev->acc_range);
+		channel_accel_convert(&val[0], data->ax,
+				      data->acc_range);
+		channel_accel_convert(&val[1], data->ay,
+				      data->acc_range);
+		channel_accel_convert(&val[2], data->az,
+				      data->acc_range);
 	} else if (chan == SENSOR_CHAN_GYRO_X) {
-		channel_gyro_convert(val, drv_dev->gx, drv_dev->gyr_range);
+		channel_gyro_convert(val, data->gx, data->gyr_range);
 	} else if (chan == SENSOR_CHAN_GYRO_Y) {
-		channel_gyro_convert(val, drv_dev->gy, drv_dev->gyr_range);
+		channel_gyro_convert(val, data->gy, data->gyr_range);
 	} else if (chan == SENSOR_CHAN_GYRO_Z) {
-		channel_gyro_convert(val, drv_dev->gz, drv_dev->gyr_range);
+		channel_gyro_convert(val, data->gz, data->gyr_range);
 	} else if (chan == SENSOR_CHAN_GYRO_XYZ) {
-		channel_gyro_convert(&val[0], drv_dev->gx,
-				     drv_dev->gyr_range);
-		channel_gyro_convert(&val[1], drv_dev->gy,
-				     drv_dev->gyr_range);
-		channel_gyro_convert(&val[2], drv_dev->gz,
-				     drv_dev->gyr_range);
+		channel_gyro_convert(&val[0], data->gx,
+				     data->gyr_range);
+		channel_gyro_convert(&val[1], data->gy,
+				     data->gyr_range);
+		channel_gyro_convert(&val[2], data->gz,
+				     data->gyr_range);
 	} else {
 		return -ENOTSUP;
 	}
@@ -611,7 +611,7 @@ static int bmi270_attr_set(const struct device *dev, enum sensor_channel chan,
 static int bmi270_init(const struct device *dev)
 {
 	int ret;
-	struct bmi270_data *drv_dev = dev->data;
+	struct bmi270_data *data = dev->data;
 	uint8_t chip_id;
 	uint8_t soft_reset_cmd;
 	uint8_t init_ctrl;
@@ -625,10 +625,10 @@ static int bmi270_init(const struct device *dev)
 		return ret;
 	}
 
-	drv_dev->acc_odr = BMI270_ACC_ODR_100_HZ;
-	drv_dev->acc_range = 8;
-	drv_dev->gyr_odr = BMI270_GYR_ODR_200_HZ;
-	drv_dev->gyr_range = 2000;
+	data->acc_odr = BMI270_ACC_ODR_100_HZ;
+	data->acc_range = 8;
+	data->gyr_odr = BMI270_GYR_ODR_200_HZ;
+	data->gyr_range = 2000;
 
 	k_usleep(BMI270_POWER_ON_TIME);
 

--- a/drivers/sensor/bmi270/bmi270_i2c.c
+++ b/drivers/sensor/bmi270/bmi270_i2c.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Bus-specific functionality for BMI270s accessed via I2C.
+ */
+
+#include "bmi270.h"
+
+static int bmi270_bus_check_i2c(const union bmi270_bus *bus)
+{
+	return device_is_ready(bus->i2c.bus) ? 0 : -ENODEV;
+}
+
+static int bmi270_reg_read_i2c(const union bmi270_bus *bus,
+			       uint8_t start, uint8_t *data, uint16_t len)
+{
+	return i2c_burst_read_dt(&bus->i2c, start, data, len);
+}
+
+static int bmi270_reg_write_i2c(const union bmi270_bus *bus, uint8_t start,
+				const uint8_t *data, uint16_t len)
+{
+	return i2c_burst_write_dt(&bus->i2c, start, data, len);
+}
+
+static int bmi270_bus_init_i2c(const union bmi270_bus *bus)
+{
+	/* I2C is used by default
+	 */
+	return 0;
+}
+
+const struct bmi270_bus_io bmi270_bus_io_i2c = {
+	.check = bmi270_bus_check_i2c,
+	.read = bmi270_reg_read_i2c,
+	.write = bmi270_reg_write_i2c,
+	.init = bmi270_bus_init_i2c,
+};

--- a/drivers/sensor/bmi270/bmi270_spi.c
+++ b/drivers/sensor/bmi270/bmi270_spi.c
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2022 Nordic Semiconductor ASA
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/*
+ * Bus-specific functionality for BMI270s accessed via SPI.
+ */
+
+#include <zephyr/logging/log.h>
+#include "bmi270.h"
+
+LOG_MODULE_DECLARE(bmi270, CONFIG_SENSOR_LOG_LEVEL);
+
+static int bmi270_bus_check_spi(const union bmi270_bus *bus)
+{
+	return spi_is_ready(&bus->spi) ? 0 : -ENODEV;
+}
+
+static int bmi270_reg_read_spi(const union bmi270_bus *bus,
+			       uint8_t start, uint8_t *data, uint16_t len)
+{
+	int ret;
+	uint8_t addr;
+	uint8_t tmp[2];
+	int i;
+	const struct spi_buf tx_buf = {
+		.buf = &addr,
+		.len = 1
+	};
+	const struct spi_buf_set tx = {
+		.buffers = &tx_buf,
+		.count = 1
+	};
+	struct spi_buf rx_buf[2];
+	const struct spi_buf_set rx = {
+		.buffers = rx_buf,
+		.count = ARRAY_SIZE(rx_buf)
+	};
+
+	rx_buf[0].buf = &tmp[0];
+	rx_buf[0].len = 2;
+	rx_buf[1].len = 1;
+
+	for (i = 0; i < len; i++) {
+		addr = (start + i) | 0x80;
+		rx_buf[1].buf = &data[i];
+
+		ret = spi_transceive_dt(&bus->spi, &tx, &rx);
+		if (ret < 0) {
+			LOG_DBG("spi_transceive failed %i", ret);
+			return ret;
+		}
+	}
+
+	k_usleep(BMI270_SPI_ACC_DELAY_US);
+	return 0;
+}
+
+static int bmi270_reg_write_spi(const union bmi270_bus *bus, uint8_t start,
+				const uint8_t *data, uint16_t len)
+{
+	int ret;
+	uint8_t addr;
+	const struct spi_buf tx_buf[2] = {
+		{.buf = &addr, .len = sizeof(addr)},
+		{.buf = (uint8_t *)data, .len = len}
+	};
+	const struct spi_buf_set tx = {
+		.buffers = tx_buf,
+		.count = ARRAY_SIZE(tx_buf)
+	};
+
+	addr = start & BMI270_REG_MASK;
+
+	ret = spi_write_dt(&bus->spi, &tx);
+	if (ret < 0) {
+		LOG_ERR("spi_write_dt failed %i", ret);
+		return ret;
+	}
+
+	k_usleep(BMI270_SPI_ACC_DELAY_US);
+	return 0;
+}
+
+static int bmi270_bus_init_spi(const union bmi270_bus *bus)
+{
+	uint8_t tmp;
+
+	/* Single read of SPI initializes the chip to SPI mode
+	 */
+	return bmi270_reg_read_spi(bus, BMI270_REG_CHIP_ID, &tmp, 1);
+}
+
+const struct bmi270_bus_io bmi270_bus_io_spi = {
+	.check = bmi270_bus_check_spi,
+	.read = bmi270_reg_read_spi,
+	.write = bmi270_reg_write_spi,
+	.init = bmi270_bus_init_spi,
+};

--- a/dts/bindings/sensor/bosch,bmi270-spi.yaml
+++ b/dts/bindings/sensor/bosch,bmi270-spi.yaml
@@ -1,7 +1,6 @@
-# Copyright (c) 2021, Bosch Sensortec GmbH
 # Copyright (c) 2022, Nordic Semiconductor ASA
 # SPDX-License-Identifier: Apache-2.0
 
 compatible: "bosch,bmi270"
 
-include: [i2c-device.yaml, "bosch,bmi270.yaml"]
+include: ["spi-device.yaml", "bosch,bmi270.yaml"]

--- a/dts/bindings/sensor/bosch,bmi270.yaml
+++ b/dts/bindings/sensor/bosch,bmi270.yaml
@@ -1,0 +1,9 @@
+# Copyright (c) 2021, Bosch Sensortec GmbH
+# Copyright (c) 2022, Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+description: |
+    The BMI270 is an inertial measurement unit. See more info at:
+    https://www.bosch-sensortec.com/products/motion-sensors/imus/bmi270.html
+
+compatible: "bosch,bmi270"


### PR DESCRIPTION
Added SPI bus support for BMI270 gyroscope driver.

Signed-off-by: Dominik Chat <dominik.chat@nordicsemi.no>