### PR TITLE
Bluetooth: gatt: allow disabling subscription enforcement

### DIFF
--- a/subsys/bluetooth/host/Kconfig.gatt
+++ b/subsys/bluetooth/host/Kconfig.gatt
@@ -146,6 +146,14 @@ config BT_GATT_ENFORCE_CHANGE_UNAWARE
 
 endif # BT_GATT_CACHING
 
+config BT_GATT_ENFORCE_SUBSCRIPTION
+	bool "GATT Enforce characteristic subscription"
+	default y
+	help
+	  When enabled, this option will make the server block sending
+	  notifications and indications to a device which has not subscribed to
+	  the supplied characteristic.
+
 config BT_GATT_CLIENT
 	bool "GATT client support"
 	help

--- a/subsys/bluetooth/host/gatt.c
+++ b/subsys/bluetooth/host/gatt.c
@@ -2242,13 +2242,15 @@ static int gatt_notify(struct bt_conn *conn, uint16_t handle,
 		return -EPERM;
 	}
 
-	/* Check if client has subscribed before sending notifications.
-	 * This is not really required in the Bluetooth specification, but
-	 * follows its spirit.
-	 */
-	if (!bt_gatt_is_subscribed(conn, params->attr, BT_GATT_CCC_NOTIFY)) {
-		BT_WARN("Device is not subscribed to characteristic");
-		return -EINVAL;
+	if (IS_ENABLED(CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION)) {
+		/* Check if client has subscribed before sending notifications.
+		 * This is not really required in the Bluetooth specification,
+		 * but follows its spirit.
+		 */
+		if (!bt_gatt_is_subscribed(conn, params->attr, BT_GATT_CCC_NOTIFY)) {
+			BT_WARN("Device is not subscribed to characteristic");
+			return -EINVAL;
+		}
 	}
 
 #if defined(CONFIG_BT_GATT_NOTIFY_MULTIPLE) && (CONFIG_BT_GATT_NOTIFY_MULTIPLE_FLUSH_MS != 0)
@@ -2380,13 +2382,15 @@ static int gatt_indicate(struct bt_conn *conn, uint16_t handle,
 		return -EPERM;
 	}
 
-	/* Check if client has subscribed before sending notifications.
-	 * This is not really required in the Bluetooth specification, but
-	 * follows its spirit.
-	 */
-	if (!bt_gatt_is_subscribed(conn, params->attr, BT_GATT_CCC_INDICATE)) {
-		BT_WARN("Device is not subscribed to characteristic");
-		return -EINVAL;
+	if (IS_ENABLED(CONFIG_BT_GATT_ENFORCE_SUBSCRIPTION)) {
+		/* Check if client has subscribed before sending notifications.
+		 * This is not really required in the Bluetooth specification,
+		 * but follows its spirit.
+		 */
+		if (!bt_gatt_is_subscribed(conn, params->attr, BT_GATT_CCC_INDICATE)) {
+			BT_WARN("Device is not subscribed to characteristic");
+			return -EINVAL;
+		}
 	}
 
 	len = sizeof(*ind) + params->len;


### PR DESCRIPTION
This introduces a new option that allows the user to disable the
subscription checking when notifying or indicating.

Some users might have use-cases where they would like to send notifications
or indications without the peer having to go through the subscription
process, as that is allowed by the Bluetooth specification.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>