### PR TITLE
Bluetooth: tests: add bsim debug helper script

### DIFF
--- a/tests/bluetooth/bsim_bt/bsim_test_notify/test_scripts/notify-debug.sh
+++ b/tests/bluetooth/bsim_bt/bsim_test_notify/test_scripts/notify-debug.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright 2022 Nordic Semiconductor ASA
+# SPDX-License-Identifier: Apache-2.0
+
+# Basic GATT test: A central acting as a GATT client scans for and connects
+# to a peripheral acting as a GATT server. The GATT client will then attempt
+# to write and read to and from a few GATT characteristics.
+simulation_id="notify_cb"
+verbosity_level=2
+process_ids=""; exit_code=0
+
+: "${BSIM_OUT_PATH:?BSIM_OUT_PATH must be defined}"
+
+#Give a default value to BOARD if it does not have one yet:
+BOARD="${BOARD:-nrf52_bsim}"
+
+cd ${BSIM_OUT_PATH}/bin
+
+if [[ $2 == "debug" ]]; then
+  GDB_P="gdb --args "
+fi
+
+if [[ $1 == "client" ]]; then
+$GDB_P ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_notify_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=0 -testid=gatt_client
+
+elif [[ $1 == "server" ]]; then
+$GDB_P ./bs_${BOARD}_tests_bluetooth_bsim_bt_bsim_test_notify_prj_conf \
+  -v=${verbosity_level} -s=${simulation_id} -d=1 -testid=gatt_server
+
+else
+./bs_2G4_phy_v1 -v=${verbosity_level} -s=${simulation_id} \
+  -D=2 -sim_length=60e6 $@
+
+fi


### PR DESCRIPTION
Add a helper script `notify-debug.sh` that saves a bunch of time (setting
up env vars and such) when debugging a failing test with GDB.

Signed-off-by: Jonathan Rico <jonathan.rico@nordicsemi.no>