### PR TITLE
ADC: STM32: Add device tree config for clock and prescaler

### DIFF
--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1325,6 +1325,19 @@ static const struct adc_driver_api api_stm32_driver_api = {
 	_CONCAT(prescaler_default, 4))
 #endif /* CONFIG_SOC_SERIES_STM32F1X */
 
+/*
+ * Macro to check the properties are valid with two elements:
+ * type : is SYNC or ASYNC if prescaler exists
+ * divider : is in range  if prescaler_type exists
+ */
+#define ADC_STM32_CHECK_PRESC(x)							\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(x, st_adc_prescaler),				\
+			(BUILD_ASSERT((DT_INST_NODE_HAS_PROP(x, st_adc_prescaler_type)),\
+				"Invalid ADC st_adc_prescaler_type property");))	\
+	IF_ENABLED(DT_INST_NODE_HAS_PROP(x, st_adc_prescaler_type),			\
+			(BUILD_ASSERT((DT_INST_NODE_HAS_PROP(x, st_adc_prescaler)),	\
+				"Invalid ADC st_adc_prescaler property");))
+
 #ifdef CONFIG_ADC_STM32_SHARED_IRQS
 
 bool adc_stm32_is_irq_active(ADC_TypeDef *adc)

--- a/dts/arm/st/f0/stm32f0.dtsi
+++ b/dts/arm/st/f0/stm32f0.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f1/stm32f1.dtsi
+++ b/dts/arm/st/f1/stm32f1.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f2/stm32f2.dtsi
+++ b/dts/arm/st/f2/stm32f2.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f3/stm32f3.dtsi
+++ b/dts/arm/st/f3/stm32f3.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f4/stm32f4.dtsi
+++ b/dts/arm/st/f4/stm32f4.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/sensor/qdec_stm32.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/f7/stm32f7.dtsi
+++ b/dts/arm/st/f7/stm32f7.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/g0/stm32g0.dtsi
+++ b/dts/arm/st/g0/stm32g0.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/g4/stm32g4.dtsi
+++ b/dts/arm/st/g4/stm32g4.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/h7/stm32h7.dtsi
+++ b/dts/arm/st/h7/stm32h7.dtsi
@@ -13,6 +13,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/memory-controller/stm32-fmc-sdram.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l0/stm32l0.dtsi
+++ b/dts/arm/st/l0/stm32l0.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l1/stm32l1.dtsi
+++ b/dts/arm/st/l1/stm32l1.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l4/stm32l4.dtsi
+++ b/dts/arm/st/l4/stm32l4.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/l5/stm32l5.dtsi
+++ b/dts/arm/st/l5/stm32l5.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
 #include <freq.h>
 

--- a/dts/arm/st/mp1/stm32mp157.dtsi
+++ b/dts/arm/st/mp1/stm32mp157.dtsi
@@ -14,6 +14,7 @@
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
 #include <zephyr/dt-bindings/display/stm32_ltdc.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 
 / {
 	cpus {

--- a/dts/arm/st/u5/stm32u5.dtsi
+++ b/dts/arm/st/u5/stm32u5.dtsi
@@ -12,6 +12,7 @@
 #include <zephyr/dt-bindings/gpio/gpio.h>
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/flash_controller/ospi.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/wb/stm32wb.dtsi
+++ b/dts/arm/st/wb/stm32wb.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/i2c/i2c.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/arm/st/wl/stm32wl.dtsi
+++ b/dts/arm/st/wl/stm32wl.dtsi
@@ -11,6 +11,7 @@
 #include <zephyr/dt-bindings/lora/sx126x.h>
 #include <zephyr/dt-bindings/pwm/pwm.h>
 #include <zephyr/dt-bindings/pwm/stm32_pwm.h>
+#include <zephyr/dt-bindings/adc/stm32_adc.h>
 #include <freq.h>
 
 / {

--- a/dts/bindings/adc/st,stm32-adc.yaml
+++ b/dts/bindings/adc/st,stm32-adc.yaml
@@ -27,6 +27,38 @@ properties:
     pinctrl-names:
       required: true
 
+    st,adc-prescaler-type:
+      type: int
+      required: false
+      enum:
+        - 1 # SYNC for synchronous ADC clock source
+        - 2 # ASYNC for asynchronous ADC clock source
+      description: |
+        type of ADC Clock source :
+        - <ASYNC> : independent and asynchronous with the bus clock
+        - <SYNC>: derived from the bus clock.
+
+    st,adc-prescaler:
+      type: int
+      required: false
+      enum:
+        - 1 # not divided
+        - 2
+        - 4
+        - 6
+        - 8
+        - 10
+        - 12
+        - 16
+        - 32
+        - 64
+        - 128
+        - 256
+      description: |
+        Clock prescaler at the input of the adc:
+        can be LL_ADC_CLOCK_SYNC_PCLK_DIVx or LL_ADC_CLOCK_ASYNC_DIVx
+        depending on the stm32 st,prescaler-type. Refer to the RefMan
+
     vref-mv:
       type: int
       required: false

--- a/include/zephyr/dt-bindings/adc/stm32_adc.h
+++ b/include/zephyr/dt-bindings/adc/stm32_adc.h
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright (c) 2022 STMicroelectronics
+ */
+
+#ifndef ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32_H_
+#define ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32_H_
+
+/**
+ * @name custom ADC clock scheme
+ * This value is to check <st,prescaler> (1st element)
+ * and decide if the ADC clock is either SYNC_PCLK or ASYNC specific
+ * Only Some stm32 have both possible ADC clocks : refer to the RefMan.
+ * @{
+ */
+#define SYNC  1
+#define ASYNC 2
+/** @} */
+
+/**
+ * @cond INTERNAL_HIDDEN
+ *
+ * Internal documentation. Skip in public documentation
+ */
+
+/**
+ * @brief Macro from the LL private for stm32 families
+ * to identify if the CLOCK is common to several ADC instances or not.
+ *
+ * @param clock_pre Clock prescaler value to check.
+ */
+#define IS_LL_ADC_COMMON_CLOCK(clock_pre)		\
+	(((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV1)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV2)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV4)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV6)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV8)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV10)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV12)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV16)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV32)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV64)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV128)	\
+	|| ((clock_pre) == LL_ADC_CLOCK_ASYNC_DIV256)	\
+	)
+
+/** @endcond */
+
+#endif /* ZEPHYR_INCLUDE_DT_BINDINGS_ADC_STM32_H_ */

--- a/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
+++ b/tests/drivers/adc/adc_api/boards/b_u585i_iot02a.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&adc1 {
+	st,adc-prescaler-type = <ASYNC>;
+	st,adc-prescaler = <64>;
+};

--- a/tests/drivers/adc/adc_api/boards/nucleo_l4r5zi.overlay
+++ b/tests/drivers/adc/adc_api/boards/nucleo_l4r5zi.overlay
@@ -1,0 +1,10 @@
+/*
+ * Copyright 2022 STMicroelectronics
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+&adc1 {
+	st,adc-prescaler-type = <SYNC>;
+	st,adc-prescaler = <2>;
+};


### PR DESCRIPTION
This PR adds a ADC clock plus a prescaler to the ADC of the stm32 mcus.

With a `st,adc-prescaler` property in the ADC node, it is now possible to select the exact ADC clock scheme to be SYNC or ASYNC and its divider. By combining both information into one property, as follows : 
          `st,adc-prescaler = <ASYNC 16>;`
the clock prescaler is matching the LL_ADC_CLOCK_ASYNC_DIV16

Note that the **#include <zephyr/dt-bindings/adc/stm32_adc.h>** is required when setting the `st,adc-prescaler`.

It depends on the stm32 serie (refer to the RefMan) and if property is not set, a default config is applied by the LL_ADC_SetClock or LL_ADC_SetCommonClock at ADC driver init

It is increasing and replacing the https://github.com/zephyrproject-rtos/zephyr/pull/44130


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/40955


Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)