### PR TITLE
drivers: pinctrl: nrf: add support for disconnecting a pin

### DIFF
--- a/drivers/pinctrl/pinctrl_nrf.c
+++ b/drivers/pinctrl/pinctrl_nrf.c
@@ -27,6 +27,9 @@ BUILD_ASSERT(((NRF_DRIVE_S0S1 == NRF_GPIO_PIN_S0S1) &&
 	      (1U)),
 	     "nRF pinctrl drive settings do not match HAL values");
 
+/* value to indicate pin level doesn't need initialization */
+#define NO_WRITE UINT32_MAX
+
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_uart)
 #define NRF_PSEL_UART(reg, line) ((NRF_UART_Type *)reg)->PSEL##line
 #elif DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_uarte)
@@ -77,103 +80,89 @@ BUILD_ASSERT(((NRF_DRIVE_S0S1 == NRF_GPIO_PIN_S0S1) &&
 #define NRF_PSEL_QSPI(reg, line) ((NRF_QSPI_Type *)reg)->PSEL.line
 #endif
 
-/**
- * @brief Configure pin settings.
- *
- * @param pin Pin configuration.
- * @param dir Pin direction.
- * @param input Pin input buffer connection.
- */
-__unused static void nrf_pin_configure(pinctrl_soc_pin_t pin,
-				       nrf_gpio_pin_dir_t dir,
-				       nrf_gpio_pin_input_t input,
-				       nrf_gpio_pin_drive_t drive)
-{
-	/* force input direction and disconnected buffer for low power */
-	if (NRF_GET_LP(pin) == NRF_LP_ENABLE) {
-		dir = NRF_GPIO_PIN_DIR_INPUT;
-		input = NRF_GPIO_PIN_INPUT_DISCONNECT;
-	}
-
-	nrf_gpio_cfg(NRF_GET_PIN(pin), dir, input, NRF_GET_PULL(pin), drive,
-		     NRF_GPIO_PIN_NOSENSE);
-}
-
 int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 			   uintptr_t reg)
 {
 	for (uint8_t i = 0U; i < pin_cnt; i++) {
-		__unused nrf_gpio_pin_drive_t drive = NRF_GET_DRIVE(pins[i]);
+		nrf_gpio_pin_drive_t drive = NRF_GET_DRIVE(pins[i]);
+		uint32_t pin = NRF_GET_PIN(pins[i]);
+		uint32_t write = NO_WRITE;
+		nrf_gpio_pin_dir_t dir;
+		nrf_gpio_pin_input_t input;
+
+		if (pin == NRF_PIN_DISCONNECTED) {
+			pin = 0xFFFFFFFFU;
+		}
 
 		switch (NRF_GET_FUN(pins[i])) {
 #if defined(NRF_PSEL_UART)
 		case NRF_FUN_UART_TX:
-			NRF_PSEL_UART(reg, TXD) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 1);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_UART(reg, TXD) = pin;
+			write = 1U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_UART_RX:
-			NRF_PSEL_UART(reg, RXD) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_UART(reg, RXD) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_UART_RTS:
-			NRF_PSEL_UART(reg, RTS) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 1);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_UART(reg, RTS) = pin;
+			write = 1U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_UART_CTS:
-			NRF_PSEL_UART(reg, CTS) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_UART(reg, CTS) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* defined(NRF_PSEL_UART) */
 #if defined(NRF_PSEL_SPIM)
 		case NRF_FUN_SPIM_SCK:
-			NRF_PSEL_SPIM(reg, SCK) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_SPIM(reg, SCK) = pin;
+			write = 0U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_SPIM_MOSI:
-			NRF_PSEL_SPIM(reg, MOSI) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_SPIM(reg, MOSI) = pin;
+			write = 0U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_SPIM_MISO:
-			NRF_PSEL_SPIM(reg, MISO) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_SPIM(reg, MISO) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* defined(NRF_PSEL_SPIM) */
 #if defined(NRF_PSEL_SPIS)
 		case NRF_FUN_SPIS_SCK:
-			NRF_PSEL_SPIS(reg, SCK) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_SPIS(reg, SCK) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_SPIS_MOSI:
-			NRF_PSEL_SPIS(reg, MOSI) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_SPIS(reg, MOSI) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_SPIS_MISO:
-			NRF_PSEL_SPIS(reg, MISO) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_SPIS(reg, MISO) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_SPIS_CSN:
-			NRF_PSEL_SPIS(reg, CSN) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_SPIS(reg, CSN) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* defined(NRF_PSEL_SPIS) */
 #if defined(NRF_PSEL_TWIM)
 		case NRF_FUN_TWIM_SCL:
-			NRF_PSEL_TWIM(reg, SCL) = NRF_GET_PIN(pins[i]);
+			NRF_PSEL_TWIM(reg, SCL) = pin;
 			if (drive == NRF_DRIVE_S0S1) {
 				/* Override the default drive setting with one
 				 * suitable for TWI/TWIM peripherals (S0D1).
@@ -183,153 +172,165 @@ int pinctrl_configure_pins(const pinctrl_soc_pin_t *pins, uint8_t pin_cnt,
 				 */
 				drive = NRF_DRIVE_S0D1;
 			}
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_TWIM_SDA:
-			NRF_PSEL_TWIM(reg, SDA) = NRF_GET_PIN(pins[i]);
+			NRF_PSEL_TWIM(reg, SDA) = pin;
 			if (drive == NRF_DRIVE_S0S1) {
 				drive = NRF_DRIVE_S0D1;
 			}
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* defined(NRF_PSEL_TWIM) */
 #if defined(NRF_PSEL_I2S)
 		case NRF_FUN_I2S_SCK_M:
-			NRF_PSEL_I2S(reg, SCK) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_I2S(reg, SCK) = pin;
+			write = 0U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_I2S_SCK_S:
-			NRF_PSEL_I2S(reg, SCK) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_I2S(reg, SCK) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_I2S_LRCK_M:
-			NRF_PSEL_I2S(reg, LRCK) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_I2S(reg, LRCK) = pin;
+			write = 0U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_I2S_LRCK_S:
-			NRF_PSEL_I2S(reg, LRCK) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_I2S(reg, LRCK) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_I2S_SDIN:
-			NRF_PSEL_I2S(reg, SDIN) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_I2S(reg, SDIN) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_I2S_SDOUT:
-			NRF_PSEL_I2S(reg, SDOUT) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_I2S(reg, SDOUT) = pin;
+			write = 0U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_I2S_MCK:
-			NRF_PSEL_I2S(reg, MCK) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_I2S(reg, MCK) = pin;
+			write = 0U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 #endif /* defined(NRF_PSEL_I2S) */
 #if defined(NRF_PSEL_PDM)
 		case NRF_FUN_PDM_CLK:
-			NRF_PSEL_PDM(reg, CLK) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]), 0);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_PDM(reg, CLK) = pin;
+			write = 0U;
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_PDM_DIN:
-			NRF_PSEL_PDM(reg, DIN) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_PDM(reg, DIN) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* defined(NRF_PSEL_PDM) */
 #if defined(NRF_PSEL_PWM)
 		case NRF_FUN_PWM_OUT0:
-			NRF_PSEL_PWM(reg, OUT[0]) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
-					   NRF_GET_INVERT(pins[i]));
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_PWM(reg, OUT[0]) = pin;
+			write = NRF_GET_INVERT(pins[i]);
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_PWM_OUT1:
-			NRF_PSEL_PWM(reg, OUT[1]) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
-					   NRF_GET_INVERT(pins[i]));
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_PWM(reg, OUT[1]) = pin;
+			write = NRF_GET_INVERT(pins[i]);
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_PWM_OUT2:
-			NRF_PSEL_PWM(reg, OUT[2]) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
-					   NRF_GET_INVERT(pins[i]));
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_PWM(reg, OUT[2]) = pin;
+			write = NRF_GET_INVERT(pins[i]);
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_PWM_OUT3:
-			NRF_PSEL_PWM(reg, OUT[3]) = NRF_GET_PIN(pins[i]);
-			nrf_gpio_pin_write(NRF_GET_PIN(pins[i]),
-					   NRF_GET_INVERT(pins[i]));
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_OUTPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_PWM(reg, OUT[3]) = pin;
+			write = NRF_GET_INVERT(pins[i]);
+			dir = NRF_GPIO_PIN_DIR_OUTPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 #endif /* defined(NRF_PSEL_PWM) */
 #if defined(NRF_PSEL_QDEC)
 		case NRF_FUN_QDEC_A:
-			NRF_PSEL_QDEC(reg, A) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_QDEC(reg, A) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_QDEC_B:
-			NRF_PSEL_QDEC(reg, B) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_QDEC(reg, B) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 		case NRF_FUN_QDEC_LED:
-			NRF_PSEL_QDEC(reg, LED) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_CONNECT, drive);
+			NRF_PSEL_QDEC(reg, LED) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_CONNECT;
 			break;
 #endif /* defined(NRF_PSEL_QDEC) */
 #if defined(NRF_PSEL_QSPI)
 		case NRF_FUN_QSPI_SCK:
-			NRF_PSEL_QSPI(reg, SCK) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_QSPI(reg, SCK) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_QSPI_CSN:
-			NRF_PSEL_QSPI(reg, CSN) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_QSPI(reg, CSN) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_QSPI_IO0:
-			NRF_PSEL_QSPI(reg, IO0) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_QSPI(reg, IO0) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_QSPI_IO1:
-			NRF_PSEL_QSPI(reg, IO1) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_QSPI(reg, IO1) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_QSPI_IO2:
-			NRF_PSEL_QSPI(reg, IO2) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_QSPI(reg, IO2) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 		case NRF_FUN_QSPI_IO3:
-			NRF_PSEL_QSPI(reg, IO3) = NRF_GET_PIN(pins[i]);
-			nrf_pin_configure(pins[i], NRF_GPIO_PIN_DIR_INPUT,
-					  NRF_GPIO_PIN_INPUT_DISCONNECT, drive);
+			NRF_PSEL_QSPI(reg, IO3) = pin;
+			dir = NRF_GPIO_PIN_DIR_INPUT;
+			input = NRF_GPIO_PIN_INPUT_DISCONNECT;
 			break;
 #endif /* defined(NRF_PSEL_QSPI) */
 		default:
 			return -ENOTSUP;
+		}
+
+		/* configure GPIO properties */
+		if (pin != NRF_PIN_DISCONNECTED) {
+			if (write != NO_WRITE) {
+				nrf_gpio_pin_write(pin, write);
+			}
+
+			/* force input and disconnected buffer for low power */
+			if (NRF_GET_LP(pins[i]) == NRF_LP_ENABLE) {
+				dir = NRF_GPIO_PIN_DIR_INPUT;
+				input = NRF_GPIO_PIN_INPUT_DISCONNECT;
+			}
+
+			nrf_gpio_cfg(pin, dir, input, NRF_GET_PULL(pins[i]),
+				     drive, NRF_GPIO_PIN_NOSENSE);
 		}
 	}
 

--- a/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
+++ b/dts/bindings/pinctrl/nordic,nrf-pinctrl.yaml
@@ -46,6 +46,8 @@ description: |
     As shown, pin configurations are organized in groups within each child node.
     Each group can specify a list of pin function selections in the 'psels'
     property. The NRF_PSEL macro is used to specify a pin function selection.
+    If a pin needs to be explicitly disconnected, there is also the
+    NRF_PSEL_DISCONNECTED macro.
     Available pin functions can be found in the
     include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h header file.
 
@@ -98,7 +100,8 @@ child-binding:
         description: |
           An array of pins sharing the same group properties. The pins should
           be defined using the NRF_PSEL utility macro that encodes the port,
-          pin and function.
+          pin and function. NRF_PSEL_DISCONNECTED is also available to explicitly
+          disconnect a pin.
 
       nordic,drive-mode:
         type: int

--- a/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
+++ b/include/zephyr/dt-bindings/pinctrl/nrf-pinctrl.h
@@ -11,12 +11,12 @@
  * organized as follows:
  *
  * - 31..16: Pin function.
- * - 15..14: Reserved.
- * - 13:     Pin inversion mode.
- * - 12:     Pin low power mode.
- * - 11..8:  Pin output drive configuration.
- * - 7..6:   Pin pull configuration.
- * - 5..0:   Pin number (combination of port and pin).
+ * - 15:     Reserved.
+ * - 14:     Pin inversion mode.
+ * - 13:     Pin low power mode.
+ * - 12..9:  Pin output drive configuration.
+ * - 8..7:   Pin pull configuration.
+ * - 6..0:   Pin number (combination of port and pin).
  */
 
 /**
@@ -29,25 +29,25 @@
 /** Mask for the function field. */
 #define NRF_FUN_MSK 0xFFFFU
 /** Position of the invert field. */
-#define NRF_INVERT_POS 13U
+#define NRF_INVERT_POS 14U
 /** Mask for the invert field. */
 #define NRF_INVERT_MSK 0x1U
 /** Position of the low power field. */
-#define NRF_LP_POS 12U
+#define NRF_LP_POS 13U
 /** Mask for the low power field. */
 #define NRF_LP_MSK 0x1U
 /** Position of the drive configuration field. */
-#define NRF_DRIVE_POS 8U
+#define NRF_DRIVE_POS 9U
 /** Mask for the drive configuration field. */
 #define NRF_DRIVE_MSK 0xFU
 /** Position of the pull configuration field. */
-#define NRF_PULL_POS 6U
+#define NRF_PULL_POS 7U
 /** Mask for the pull configuration field. */
 #define NRF_PULL_MSK 0x3U
 /** Position of the pin field. */
 #define NRF_PIN_POS 0U
 /** Mask for the pin field. */
-#define NRF_PIN_MSK 0x3FU
+#define NRF_PIN_MSK 0x7FU
 
 /** @} */
 
@@ -184,6 +184,16 @@
 /** @} */
 
 /**
+ * @name nRF pinctrl helpers to indicate disconnected pins.
+ * @{
+ */
+
+/** Indicates that a pin is disconnected */
+#define NRF_PIN_DISCONNECTED NRF_PIN_MSK
+
+/** @} */
+
+/**
  * @brief Utility macro to build nRF psels property entry.
  *
  * @param fun Pin function configuration (see NRF_FUNC_{name} macros).
@@ -191,7 +201,19 @@
  * @param pin Pin (0..31).
  */
 #define NRF_PSEL(fun, port, pin)						       \
-	((((((port) * 32U) + (pin)) & NRF_PIN_MSK) << NRF_PIN_POS) |	       \
+	((((((port) * 32U) + (pin)) & NRF_PIN_MSK) << NRF_PIN_POS) |		       \
+	 ((NRF_FUN_ ## fun & NRF_FUN_MSK) << NRF_FUN_POS))
+
+/**
+ * @brief Utility macro to build nRF psels property entry when a pin is disconnected.
+ *
+ * This can be useful in situations where code running before Zephyr, e.g. a bootloader
+ * configures pins that later needs to be disconnected.
+ *
+ * @param fun Pin function configuration (see NRF_FUN_{name} macros).
+ */
+#define NRF_PSEL_DISCONNECTED(fun)						       \
+	(NRF_PIN_DISCONNECTED |							       \
 	 ((NRF_FUN_ ## fun & NRF_FUN_MSK) << NRF_FUN_POS))
 
 #endif /* ZEPHYR_INCLUDE_DT_BINDINGS_PINCTRL_NRF_PINCTRL_H_ */

--- a/tests/drivers/pinctrl/nrf/app.overlay
+++ b/tests/drivers/pinctrl/nrf/app.overlay
@@ -19,7 +19,8 @@
 		   feasible combination */
 		group1 {
 			psels = <NRF_PSEL(UART_TX, 0, 1)>,
-				<NRF_PSEL(UART_RTS, 0, 2)>;
+				<NRF_PSEL(UART_RTS, 0, 2)>,
+				<NRF_PSEL_DISCONNECTED(UART_RX)>;
 		};
 		group2 {
 			psels = <NRF_PSEL(UART_RX, 0, 3)>;

--- a/tests/drivers/pinctrl/nrf/src/main.c
+++ b/tests/drivers/pinctrl/nrf/src/main.c
@@ -22,7 +22,7 @@ static void test_dt_extract(void)
 	scfg = &pcfg->states[0];
 
 	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT, NULL);
-	zassert_equal(scfg->pin_cnt, 6U, NULL);
+	zassert_equal(scfg->pin_cnt, 7U, NULL);
 
 	zassert_equal(NRF_GET_FUN(scfg->pins[0]), NRF_FUN_UART_TX, NULL);
 	zassert_equal(NRF_GET_LP(scfg->pins[0]), NRF_LP_DISABLE, NULL);
@@ -37,28 +37,31 @@ static void test_dt_extract(void)
 	zassert_equal(NRF_GET_PIN(scfg->pins[1]), 2U, NULL);
 
 	zassert_equal(NRF_GET_FUN(scfg->pins[2]), NRF_FUN_UART_RX, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[2]), NRF_LP_DISABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[2]), NRF_DRIVE_H0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[2]), NRF_PULL_NONE, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[2]), 3U, NULL);
+	zassert_equal(NRF_GET_PIN(scfg->pins[2]), NRF_PIN_DISCONNECTED, NULL);
 
 	zassert_equal(NRF_GET_FUN(scfg->pins[3]), NRF_FUN_UART_RX, NULL);
 	zassert_equal(NRF_GET_LP(scfg->pins[3]), NRF_LP_DISABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[3]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[3]), NRF_PULL_UP, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[3]), 4U, NULL);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[3]), NRF_DRIVE_H0S1, NULL);
+	zassert_equal(NRF_GET_PULL(scfg->pins[3]), NRF_PULL_NONE, NULL);
+	zassert_equal(NRF_GET_PIN(scfg->pins[3]), 3U, NULL);
 
 	zassert_equal(NRF_GET_FUN(scfg->pins[4]), NRF_FUN_UART_RX, NULL);
 	zassert_equal(NRF_GET_LP(scfg->pins[4]), NRF_LP_DISABLE, NULL);
 	zassert_equal(NRF_GET_DRIVE(scfg->pins[4]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[4]), NRF_PULL_DOWN, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[4]), 5U, NULL);
+	zassert_equal(NRF_GET_PULL(scfg->pins[4]), NRF_PULL_UP, NULL);
+	zassert_equal(NRF_GET_PIN(scfg->pins[4]), 4U, NULL);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[5]), NRF_FUN_UART_CTS, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[5]), NRF_LP_ENABLE, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[5]), NRF_FUN_UART_RX, NULL);
+	zassert_equal(NRF_GET_LP(scfg->pins[5]), NRF_LP_DISABLE, NULL);
 	zassert_equal(NRF_GET_DRIVE(scfg->pins[5]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[5]), NRF_PULL_NONE, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[5]), 38U, NULL);
+	zassert_equal(NRF_GET_PULL(scfg->pins[5]), NRF_PULL_DOWN, NULL);
+	zassert_equal(NRF_GET_PIN(scfg->pins[5]), 5U, NULL);
+
+	zassert_equal(NRF_GET_FUN(scfg->pins[6]), NRF_FUN_UART_CTS, NULL);
+	zassert_equal(NRF_GET_LP(scfg->pins[6]), NRF_LP_ENABLE, NULL);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[6]), NRF_DRIVE_S0S1, NULL);
+	zassert_equal(NRF_GET_PULL(scfg->pins[6]), NRF_PULL_NONE, NULL);
+	zassert_equal(NRF_GET_PIN(scfg->pins[6]), 38U, NULL);
 }
 
 void test_main(void)


### PR DESCRIPTION
It was not possible to disconnect a pin using the nRF pinctrl driver.
That is, it was not possible to set PSEL to 0xFFFFFFFF (indicating pin
is not connected). This can be useful in certain scenarios, e.g. a
bootloader configures all signals of a certain peripheral but
application then needs to disconnect certain signals.

A new DT macro has been introduced to accomplish this:
NRF_PSEL_DISCONNECTED. It can be used like this to explicitely disconnect
a peripheral signal:

```
&pinctrl {
	uart0_default: uart0_default {
		group1 {
			psels = <NRF_PSEL(UART_TX, 0, 1)>,
				<NRF_PSEL_DISCONNECTED(UART_RX)>;
		};
	};
};
```

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>