### PR TITLE
net: tcp: Use default MSS value if no MSS option is present

### DIFF
--- a/subsys/net/ip/tcp_private.h
+++ b/subsys/net/ip/tcp_private.h
@@ -110,10 +110,12 @@
 #define conn_ack(_conn, _req) (_conn)->ack += (_req)
 #endif
 
-#define conn_mss(_conn)					\
-	((_conn)->recv_options.mss_found ?		\
-	 MIN((_conn)->recv_options.mss, \
-	 net_tcp_get_supported_mss(_conn)) : net_tcp_get_supported_mss(_conn))
+#define NET_TCP_DEFAULT_MSS 536
+
+#define conn_mss(_conn)							\
+	MIN((_conn)->recv_options.mss_found ? (_conn)->recv_options.mss	\
+					    : NET_TCP_DEFAULT_MSS,	\
+	    net_tcp_get_supported_mss(_conn))
 
 #define conn_state(_conn, _s)						\
 ({									\


### PR DESCRIPTION
In case peer does not send the MSS option, the TCP stack should assume
default peer MSS value of 536, as per RFC 1122:

    If an MSS option is not received at connection setup, TCP
    MUST assume a default send MSS of 536.

Fixes #48739

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>