### PR TITLE
Bluetooth: L2CAP: Add check to see if device is not disconnecting

### DIFF
--- a/subsys/bluetooth/host/l2cap.c
+++ b/subsys/bluetooth/host/l2cap.c
@@ -701,6 +701,11 @@ static void le_conn_param_update_req(struct bt_l2cap *l2cap, uint8_t ident,
 		return;
 	}
 
+	if (conn->state != BT_CONN_CONNECTED) {
+		BT_WARN("Not connected");
+		return;
+	}
+
 	if (conn->role != BT_HCI_ROLE_CENTRAL) {
 		l2cap_send_reject(conn, ident, BT_L2CAP_REJ_NOT_UNDERSTOOD,
 				  NULL, 0);


### PR DESCRIPTION
Currently, if a bluetooth peripheral sends a connection parameter update
request to a Zephyr central while the central is in the process of
disconnecting and has sent a connection terminate command in the same
connection interval, the central will try to reply, resulting in an
error being printed in the console.

This commit adds a check in le_conn_param_update_req that catches this
state before the central considers this request, preventing the unneeded
error being printed.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/48813

Signed-off-by: Ivan Herrera Olivares <ivan.herreraolivares@uantwerpen.be>