### PR TITLE
Handle macro name variation

### DIFF
--- a/soc/arm/nxp_imx/rt5xx/soc.h
+++ b/soc/arm/nxp_imx/rt5xx/soc.h
@@ -72,4 +72,9 @@
 /*!<@brief Slow mode */
 #define IOPCTL_PIO_SLEW_RATE_SLOW 0x80u
 
+/* Workaround to handle macro variation in the SDK */
+#ifndef INPUTMUX_PINTSEL_COUNT
+#define INPUTMUX_PINTSEL_COUNT INPUTMUX_PINT_SEL_COUNT
+#endif
+
 #endif /* _SOC__H_ */

--- a/soc/arm/nxp_imx/rt6xx/soc.h
+++ b/soc/arm/nxp_imx/rt6xx/soc.h
@@ -75,6 +75,11 @@
 /*!<@brief Slow mode */
 #define IOPCTL_PIO_SLEW_RATE_SLOW 0x80u
 
+/* Workaround to handle macro variation in the SDK */
+#ifndef INPUTMUX_PINTSEL_COUNT
+#define INPUTMUX_PINTSEL_COUNT INPUTMUX_PINT_SEL_COUNT
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/west.yml
+++ b/west.yml
@@ -93,7 +93,7 @@ manifest:
       groups:
         - hal
     - name: hal_nxp
-      revision: 2faea0afa206b9fc2708ec811a9b0bae2d6fd95e
+      revision: 5a065f9d20557eb6f22c69f3de576600bc1b6ac1
       path: modules/hal/nxp
       groups:
         - hal


### PR DESCRIPTION
Handle SDK macro name variation. The macro INPUTMUX_PINTSEL_COUNT is name INPUTMUX_PINT_SEL_COUNT on certain SoC's in the SDK.

This inconsistency was exposed by PR https://github.com/zephyrproject-rtos/zephyr/pull/37148 