### PR TITLE
driver: esp32: add wifi binding

### DIFF
--- a/dts/bindings/wifi/espressif,esp32-wifi.yaml
+++ b/dts/bindings/wifi/espressif,esp32-wifi.yaml
@@ -1,0 +1,6 @@
+# Copyright (c) 2022 Espressif Systems (Shanghai) Co., Ltd.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Espressif ESP32 SoC WiFi
+
+compatible: "espressif,esp32-wifi"


### PR DESCRIPTION
Add missing espressif_esp-wifi binding file.

Signed-off-by: Sylvio Alves <sylvio.alves@espressif.com>