### PR TITLE
Fix diagnosis for clang-tidy-14 or higher

### DIFF
--- a/include/zephyr/logging/log_core.h
+++ b/include/zephyr/logging/log_core.h
@@ -240,6 +240,7 @@ static inline char z_log_minimal_level_to_char(int level)
 	Z_LOG_MSG2_CREATE(UTIL_NOT(IS_ENABLED(CONFIG_USERSPACE)), _mode, \
 			  CONFIG_LOG_DOMAIN_ID, _src, _level, NULL,\
 			  0, __VA_ARGS__); \
+	(void)_mode; \
 	if (false) { \
 		/* Arguments checker present but never evaluated.*/ \
 		/* Placed here to ensure that __VA_ARGS__ are*/ \

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -132,8 +132,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  */
 #define zassert(cond, default_msg, msg, ...)                                                       \
 	do {                                                                                       \
-		bool _ret = z_zassert(cond, msg ? ("(" default_msg ")") : (default_msg), __FILE__, \
-				      __LINE__, __func__, msg ? msg : "", ##__VA_ARGS__);          \
+		bool _msg = (msg != NULL);                                                         \
+		bool _ret = z_zassert(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,\
+				      __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);         \
+		(void)_msg;                                                                        \
 		if (!_ret) {                                                                       \
 			/* If kernel but without multithreading return. */                         \
 			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \
@@ -143,8 +145,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 
 #define zassume(cond, default_msg, msg, ...)                                                       \
 	do {                                                                                       \
-		bool _ret = z_zassume(cond, msg ? ("(" default_msg ")") : (default_msg), __FILE__, \
-				      __LINE__, __func__, msg ? msg : "", ##__VA_ARGS__);          \
+		bool _msg = (msg != NULL);                                                         \
+		bool _ret = z_zassume(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,\
+				      __LINE__, __func__, _msg ? msg : "", ##__VA_ARGS__);         \
+		(void)_msg;                                                                        \
 		if (!_ret) {                                                                       \
 			/* If kernel but without multithreading return. */                         \
 			COND_CODE_1(KERNEL, (COND_CODE_1(CONFIG_MULTITHREADING, (), (return;))),   \


### PR DESCRIPTION
There are two issues that clang-tidy report and it makes impossible to run this software to diagnose Zephyr and these fixes current issues.