### PR TITLE
adsp: gpdma: Move gpdma code to driver

### DIFF
--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -24,6 +24,10 @@
 #define SHIM_CLKCTL_LPGPDMA_SPA	BIT(0)
 #define SHIM_CLKCTL_LPGPDMA_CPA	BIT(8)
 
+# define DSP_INIT_LPGPDMA(x)	  (0x71A60 + (2*x))
+# define LPGPDMA_CTLOSEL_FLAG	  BIT(15)
+# define LPGPDMA_CHOSEL_FLAG	  0xFF
+
 #include "dma_dw_common.h"
 
 #define LOG_LEVEL CONFIG_DMA_LOG_LEVEL
@@ -233,6 +237,9 @@ int intel_adsp_gpdma_init(const struct device *dev)
 		goto out;
 	}
 #endif
+
+	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(0));
+	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(1));
 
 	/* Disable dynamic clock gating appropriately before initializing */
 	intel_adsp_gpdma_clock_enable(dev);

--- a/soc/xtensa/intel_adsp/ace_v1x/power.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/power.c
@@ -10,19 +10,11 @@
 
 #define SRAM_ALIAS_BASE         0xA0000000
 #define SRAM_ALIAS_MASK         0xF0000000
-#define DSP_INIT_LPGPDMA(x)  (0x71A60 + (2 * x))
-#define LPGPDMA_CTLOSEL_FLAG          BIT(15)
-# define LPGPDMA_CHOSEL_FLAG   0xFF
 
 __imr void power_init(void)
 {
 	/* Disable idle power gating */
 	DFDSPBRCP.bootctl[0].bctl |= DFDSPBRCP_BCTL_WAITIPCG | DFDSPBRCP_BCTL_WAITIPPG;
-
-#if CONFIG_DMA_INTEL_ADSP_GPDMA
-	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(0));
-	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(1));
-#endif
 }
 
 #ifdef CONFIG_PM

--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -29,10 +29,6 @@ LOG_MODULE_REGISTER(soc);
 # define SHIM_GPDMA_CLKCTL(x)     (SHIM_GPDMA_BASE(x) + 0x4)
 # define SHIM_CLKCTL_LPGPDMAFDCGB BIT(0)
 
-# define DSP_INIT_LPGPDMA(x)	  (0x71A60 + (2*x))
-# define LPGPDMA_CTLOSEL_FLAG	  BIT(15)
-# define LPGPDMA_CHOSEL_FLAG	  0xFF
-
 #endif
 
 
@@ -87,9 +83,6 @@ __imr void power_init(void)
 	 * though the device itself is operational.
 	 */
 	sys_write32(GENO_MDIVOSEL | GENO_DIOPTOSEL, DSP_INIT_GENO);
-	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(0));
-	sys_write32(LPGPDMA_CHOSEL_FLAG | LPGPDMA_CTLOSEL_FLAG, DSP_INIT_LPGPDMA(1));
-
 	sys_write32(IOPO_DMIC_FLAG | IOPO_I2SSEL_MASK, DSP_INIT_IOPO);
 #endif
 }


### PR DESCRIPTION
DMA controller ownership can be done in the driver
initialization, it does not need to be part of the SoC. It simplify
the code and remove duplicated definitions.

Signed-off-by: Flavio Ceolin <flavio.ceolin@intel.com>