### PR TITLE
samples: espi: disable SAF testing

### DIFF
--- a/samples/drivers/espi/prj_mec15xxevb_assy6853.conf
+++ b/samples/drivers/espi/prj_mec15xxevb_assy6853.conf
@@ -8,6 +8,8 @@ CONFIG_ESPI_AUTOMATIC_WARNING_ACKNOWLEDGE=n
 # Sample code doesn't handle ACPI host communication
 CONFIG_ESPI_PERIPHERAL_HOST_IO=n
 # Test SAF flash portal read/erase/write on EVB
-CONFIG_ESPI_SAF=y
+# disabled CONFIG_ESPI_SAF since devicetree node for ESPI_SAF is
+# not currently enabled so this will fail to build
+#CONFIG_ESPI_SAF=y
 CONFIG_SPI=y
 CONFIG_SPI_XEC_QMSPI=y


### PR DESCRIPTION
espi saf node is not enabled in mec15xxevb_assy6853.dts so the sample
will fail to build.  For now disable CONFIG_ESPI_SAF to get the sample
to build.

Signed-off-by: Kumar Gala <galak@kernel.org>