### PR TITLE
util: Cleanup some duplicated macros

### DIFF
--- a/drivers/dai/intel/alh/alh.h
+++ b/drivers/dai/intel/alh/alh.h
@@ -9,6 +9,7 @@
 
 #include <stdint.h>
 #include <zephyr/drivers/dai.h>
+#include <zephyr/sys/util_macro.h>
 
 #include "alh_map.h"
 
@@ -21,9 +22,7 @@
 
 #define ALH_GPDMA_BURST_LENGTH 4
 
-#define ALH_SET_BITS(b_hi, b_lo, x)	\
-	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
-#define ALHASCTL_OSEL(x)          ALH_SET_BITS(25, 24, x)
+#define ALHASCTL_OSEL(x)          SET_BITS(25, 24, x)
 
 #define dai_get_drvdata(dai) &dai->priv_data
 #define dai_base(dai) dai->plat_data.base

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -8,15 +8,12 @@
 #define __INTEL_DAI_DRIVER_DMIC_H__
 
 #include <zephyr/sys/util_macro.h>
-
-/* bit operations macros */
-#define MASK(b_hi, b_lo)	\
-	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
+#include <zephyr/sys/util.h>
 
 #define SET_BIT(b, x)		(((x) & 1) << (b))
 
 #define GET_BITS(b_hi, b_lo, x) \
-	(((x) & MASK(b_hi, b_lo)) >> (b_lo))
+	(((x) & GENMASK(b_hi, b_lo)) >> (b_lo))
 
 /* The microphones create a low frequecy thump sound when clock is enabled.
  * The unmute linear gain ramp chacteristic is defined here.
@@ -208,14 +205,14 @@
 #define OUTSTAT0_ASNE_BIT	BIT(29)
 #define OUTSTAT0_RFS_BIT	BIT(28)
 #define OUTSTAT0_ROR_BIT	BIT(27)
-#define OUTSTAT0_FL_MASK	MASK(6, 0)
+#define OUTSTAT0_FL_MASK	GENMASK(6, 0)
 
 /* OUTSTAT1 bits */
 #define OUTSTAT1_AFE_BIT	BIT(31)
 #define OUTSTAT1_ASNE_BIT	BIT(29)
 #define OUTSTAT1_RFS_BIT	BIT(28)
 #define OUTSTAT1_ROR_BIT	BIT(27)
-#define OUTSTAT1_FL_MASK	MASK(6, 0)
+#define OUTSTAT1_FL_MASK	GENMASK(6, 0)
 
 /* CIC_CONTROL bits */
 #define CIC_CONTROL_SOFT_RESET_BIT	BIT(16)
@@ -247,8 +244,8 @@
 #define CIC_CONFIG_COMB_COUNT(x)	SET_BITS(15, 8, x)
 
 /* CIC_CONFIG masks */
-#define CIC_CONFIG_CIC_SHIFT_MASK	MASK(27, 24)
-#define CIC_CONFIG_COMB_COUNT_MASK	MASK(15, 8)
+#define CIC_CONFIG_CIC_SHIFT_MASK	GENMASK(27, 24)
+#define CIC_CONFIG_COMB_COUNT_MASK	GENMASK(15, 8)
 
 #define CIC_CONFIG_CIC_SHIFT_GET(x)	GET_BITS(27, 24, x)
 #define CIC_CONFIG_COMB_COUNT_GET(x)	GET_BITS(15, 8, x)
@@ -263,7 +260,7 @@
 #define MIC_CONTROL_PDM_EN_A(x)		SET_BIT(0, x)
 
 /* MIC_CONTROL masks */
-#define MIC_CONTROL_PDM_CLKDIV_MASK	MASK(15, 8)
+#define MIC_CONTROL_PDM_CLKDIV_MASK	GENMASK(15, 8)
 
 #define MIC_CONTROL_PDM_CLKDIV_GET(x)	GET_BITS(15, 8, x)
 #define MIC_CONTROL_PDM_SKEW_GET(x)	GET_BITS(7, 4, x)

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -51,8 +51,6 @@
 #define TS_LOCAL_TSCTRL_HHTSE_BIT	BIT(7)
 #define TS_LOCAL_TSCTRL_ODTS_BIT	BIT(5)
 #define TS_LOCAL_TSCTRL_CDMAS(x)	SET_BITS(4, 0, x)
-#define TS_LOCAL_OFFS_FRM		GET_BITS(15, 12)
-#define TS_LOCAL_OFFS_CLK		GET_BITS(11, 0)
 
 /* Digital Mic Shim Registers */
 #define DMICLCTL_OFFSET        0x04

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -15,9 +15,6 @@
 
 #define SET_BIT(b, x)		(((x) & 1) << (b))
 
-#define GET_BIT(b, x) \
-	(((x) & (1ULL << (b))) >> (b))
-
 #define GET_BITS(b_hi, b_lo, x) \
 	(((x) & MASK(b_hi, b_lo)) >> (b_lo))
 

--- a/drivers/dai/intel/dmic/dmic.h
+++ b/drivers/dai/intel/dmic/dmic.h
@@ -15,9 +15,6 @@
 
 #define SET_BIT(b, x)		(((x) & 1) << (b))
 
-#define SET_BITS(b_hi, b_lo, x)	\
-	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
-
 #define GET_BIT(b, x) \
 	(((x) & (1ULL << (b))) >> (b))
 

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -17,8 +17,6 @@
 #define DAI_INTEL_SSP_SET_BIT(b, x)		(((x) & 1) << (b))
 #define DAI_INTEL_SSP_GET_BIT(b, x) \
 	(((x) & (1ULL << (b))) >> (b))
-#define DAI_INTEL_SSP_GET_BITS(b_hi, b_lo, x) \
-	(((x) & MASK(b_hi, b_lo)) >> (b_lo))
 
 /* ssp_freq array constants */
 #define DAI_INTEL_SSP_NUM_FREQ			3

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -15,8 +15,6 @@
 #define DAI_INTEL_SSP_MASK(b_hi, b_lo)	\
 	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
 #define DAI_INTEL_SSP_SET_BIT(b, x)		(((x) & 1) << (b))
-#define DAI_INTEL_SSP_SET_BITS(b_hi, b_lo, x)	\
-	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
 #define DAI_INTEL_SSP_GET_BIT(b, x) \
 	(((x) & (1ULL << (b))) >> (b))
 #define DAI_INTEL_SSP_GET_BITS(b_hi, b_lo, x) \
@@ -73,22 +71,22 @@
 #define SSCR2			0x40
 
 /* SSCR0 bits */
-#define SSCR0_DSIZE(x)		DAI_INTEL_SSP_SET_BITS(3, 0, (x) - 1)
+#define SSCR0_DSIZE(x)		SET_BITS(3, 0, (x) - 1)
 #define SSCR0_DSIZE_GET(x)	(((x) & DAI_INTEL_SSP_MASK(3, 0)) + 1)
 #define SSCR0_FRF		DAI_INTEL_SSP_MASK(5, 4)
-#define SSCR0_MOT		DAI_INTEL_SSP_SET_BITS(5, 4, 0)
-#define SSCR0_TI		DAI_INTEL_SSP_SET_BITS(5, 4, 1)
-#define SSCR0_NAT		DAI_INTEL_SSP_SET_BITS(5, 4, 2)
-#define SSCR0_PSP		DAI_INTEL_SSP_SET_BITS(5, 4, 3)
+#define SSCR0_MOT		SET_BITS(5, 4, 0)
+#define SSCR0_TI		SET_BITS(5, 4, 1)
+#define SSCR0_NAT		SET_BITS(5, 4, 2)
+#define SSCR0_PSP		SET_BITS(5, 4, 3)
 #define SSCR0_ECS		BIT(6)
 #define SSCR0_SSE		BIT(7)
 #define SSCR0_SCR_MASK		DAI_INTEL_SSP_MASK(19, 8)
-#define SSCR0_SCR(x)		DAI_INTEL_SSP_SET_BITS(19, 8, x)
+#define SSCR0_SCR(x)		SET_BITS(19, 8, x)
 #define SSCR0_EDSS		BIT(20)
 #define SSCR0_NCS		BIT(21)
 #define SSCR0_RIM		BIT(22)
 #define SSCR0_TIM		BIT(23)
-#define SSCR0_FRDC(x)		DAI_INTEL_SSP_SET_BITS(26, 24, (x) - 1)
+#define SSCR0_FRDC(x)		SET_BITS(26, 24, (x) - 1)
 #define SSCR0_FRDC_GET(x)	((((x) & DAI_INTEL_SSP_MASK(26, 24)) >> 24) + 1)
 #define SSCR0_ACS		BIT(30)
 #define SSCR0_MOD		BIT(31)
@@ -101,9 +99,9 @@
 #define SSCR1_SPH		BIT(4)
 #define SSCR1_MWDS		BIT(5)
 #define SSCR1_TFT_MASK		DAI_INTEL_SSP_MASK(9, 6)
-#define SSCR1_TFT(x)		DAI_INTEL_SSP_SET_BITS(9, 6, (x) - 1)
+#define SSCR1_TFT(x)		SET_BITS(9, 6, (x) - 1)
 #define SSCR1_RFT_MASK		DAI_INTEL_SSP_MASK(13, 10)
-#define SSCR1_RFT(x)		DAI_INTEL_SSP_SET_BITS(13, 10, (x) - 1)
+#define SSCR1_RFT(x)		SET_BITS(13, 10, (x) - 1)
 #define SSCR1_EFWR		BIT(14)
 #define SSCR1_STRF		BIT(15)
 #define SSCR1_IFS		BIT(16)
@@ -143,18 +141,18 @@
 #define SSSR_TUR		BIT(21)
 
 /* SSPSP bits */
-#define SSPSP_SCMODE(x)		DAI_INTEL_SSP_SET_BITS(1, 0, x)
+#define SSPSP_SCMODE(x)		SET_BITS(1, 0, x)
 #define SSPSP_SFRMP(x)		DAI_INTEL_SSP_SET_BIT(2, x)
 #define SSPSP_ETDS		BIT(3)
-#define SSPSP_STRTDLY(x)	DAI_INTEL_SSP_SET_BITS(6, 4, x)
-#define SSPSP_DMYSTRT(x)	DAI_INTEL_SSP_SET_BITS(8, 7, x)
-#define SSPSP_SFRMDLY(x)	DAI_INTEL_SSP_SET_BITS(15, 9, x)
-#define SSPSP_SFRMWDTH(x)	DAI_INTEL_SSP_SET_BITS(21, 16, x)
-#define SSPSP_DMYSTOP(x)	DAI_INTEL_SSP_SET_BITS(24, 23, x)
+#define SSPSP_STRTDLY(x)	SET_BITS(6, 4, x)
+#define SSPSP_DMYSTRT(x)	SET_BITS(8, 7, x)
+#define SSPSP_SFRMDLY(x)	SET_BITS(15, 9, x)
+#define SSPSP_SFRMWDTH(x)	SET_BITS(21, 16, x)
+#define SSPSP_DMYSTOP(x)	SET_BITS(24, 23, x)
 #define SSPSP_DMYSTOP_BITS	2
 #define SSPSP_DMYSTOP_MASK	DAI_INTEL_SSP_MASK(SSPSP_DMYSTOP_BITS - 1, 0)
 #define SSPSP_FSRT		BIT(25)
-#define SSPSP_EDMYSTOP(x)	DAI_INTEL_SSP_SET_BITS(28, 26, x)
+#define SSPSP_EDMYSTOP(x)	SET_BITS(28, 26, x)
 
 #define SSPSP2			0x44
 #define SSPSP2_FEP_MASK		0xff
@@ -164,12 +162,12 @@
 #define SSP_REG_MAX		SSIOC
 
 /* SSTSA bits */
-#define SSTSA_SSTSA(x)		DAI_INTEL_SSP_SET_BITS(7, 0, x)
+#define SSTSA_SSTSA(x)		SET_BITS(7, 0, x)
 #define SSTSA_GET(x)		((x) & DAI_INTEL_SSP_MASK(7, 0))
 #define SSTSA_TXEN		BIT(8)
 
 /* SSRSA bits */
-#define SSRSA_SSRSA(x)		DAI_INTEL_SSP_SET_BITS(7, 0, x)
+#define SSRSA_SSRSA(x)		SET_BITS(7, 0, x)
 #define SSRSA_GET(x)		((x) & DAI_INTEL_SSP_MASK(7, 0))
 #define SSRSA_RXEN		BIT(8)
 
@@ -209,8 +207,8 @@
 #define SSCR3_RFL_MASK	DAI_INTEL_SSP_MASK(13, 8)
 #define SSCR3_TFL_VAL(scr3_val)	(((scr3_val) >> 0) & DAI_INTEL_SSP_MASK(5, 0))
 #define SSCR3_RFL_VAL(scr3_val)	(((scr3_val) >> 8) & DAI_INTEL_SSP_MASK(5, 0))
-#define SSCR3_TX(x)	DAI_INTEL_SSP_SET_BITS(21, 16, (x) - 1)
-#define SSCR3_RX(x)	DAI_INTEL_SSP_SET_BITS(29, 24, (x) - 1)
+#define SSCR3_TX(x)	SET_BITS(21, 16, (x) - 1)
+#define SSCR3_RX(x)	SET_BITS(29, 24, (x) - 1)
 
 #define SSIOC_TXDPDEB	BIT(1)
 #define SSIOC_SFCR	BIT(4)
@@ -245,7 +243,7 @@
 #define MN_MDIVR(x) (0x80 + (x) * 0x4)
 
 /** \brief Bits for setting MCLK source clock. */
-#define MCDSS(x)	DAI_INTEL_SSP_SET_BITS(17, 16, x)
+#define MCDSS(x)	SET_BITS(17, 16, x)
 
 /** \brief Offset of BCLK x M/N Divider M Value Register. */
 #define MN_MDIV_M_VAL(x) (0x100 + (x) * 0x8 + 0x0)
@@ -254,7 +252,7 @@
 #define MN_MDIV_N_VAL(x) (0x100 + (x) * 0x8 + 0x4)
 
 /** \brief Bits for setting M/N source clock. */
-#define MNDSS(x)	DAI_INTEL_SSP_SET_BITS(21, 20, x)
+#define MNDSS(x)	SET_BITS(21, 20, x)
 
 /** \brief Mask for clearing mclk and bclk source in MN_MDIVCTRL */
 #define MN_SOURCE_CLKS_MASK 0x3

--- a/drivers/dai/intel/ssp/ssp.h
+++ b/drivers/dai/intel/ssp/ssp.h
@@ -15,8 +15,6 @@
 #define DAI_INTEL_SSP_MASK(b_hi, b_lo)	\
 	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
 #define DAI_INTEL_SSP_SET_BIT(b, x)		(((x) & 1) << (b))
-#define DAI_INTEL_SSP_GET_BIT(b, x) \
-	(((x) & (1ULL << (b))) >> (b))
 
 /* ssp_freq array constants */
 #define DAI_INTEL_SSP_NUM_FREQ			3

--- a/drivers/dma/dma_dw_common.h
+++ b/drivers/dma/dma_dw_common.h
@@ -9,6 +9,7 @@
 
 #include <zephyr/sys/atomic.h>
 #include <zephyr/drivers/dma.h>
+#include <zephyr/sys/util_macro.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -17,8 +18,6 @@ extern "C" {
 #define MASK(b_hi, b_lo)					\
 	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
 #define SET_BIT(b, x) (((x) & 1) << (b))
-#define SET_BITS(b_hi, b_lo, x)	\
-	(((x) & ((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL)) << (b_lo))
 
 #define DW_MAX_CHAN		8
 #define DW_CH_SIZE		0x58

--- a/drivers/dma/dma_dw_common.h
+++ b/drivers/dma/dma_dw_common.h
@@ -15,8 +15,6 @@
 extern "C" {
 #endif
 
-#define MASK(b_hi, b_lo)					\
-	(((1ULL << ((b_hi) - (b_lo) + 1ULL)) - 1ULL) << (b_lo))
 #define SET_BIT(b, x) (((x) & 1) << (b))
 
 #define DW_MAX_CHAN		8
@@ -70,9 +68,9 @@ extern "C" {
 #define DW_FIFO_PART1_HI	0x40C
 
 /* channel bits */
-#define DW_CHAN_WRITE_EN_ALL	MASK(2 * DW_MAX_CHAN - 1, DW_MAX_CHAN)
+#define DW_CHAN_WRITE_EN_ALL	GENMASK(2 * DW_MAX_CHAN - 1, DW_MAX_CHAN)
 #define DW_CHAN_WRITE_EN(chan)	BIT((chan) + DW_MAX_CHAN)
-#define DW_CHAN_ALL		MASK(DW_MAX_CHAN - 1, 0)
+#define DW_CHAN_ALL		GENMASK(DW_MAX_CHAN - 1, 0)
 #define DW_CHAN(chan)		BIT(chan)
 #define DW_CHAN_MASK_ALL	DW_CHAN_WRITE_EN_ALL
 #define DW_CHAN_MASK(chan)	DW_CHAN_WRITE_EN(chan)
@@ -121,16 +119,16 @@ extern "C" {
 #define DW_CTLL_SRC_WIDTH(x)	SET_BITS(6, 4, x)
 #define DW_CTLL_DST_WIDTH(x)	SET_BITS(3, 1, x)
 #define DW_CTLL_INT_EN		BIT(0)
-#define DW_CTLL_SRC_WIDTH_MASK	MASK(6, 4)
+#define DW_CTLL_SRC_WIDTH_MASK	GENMASK(6, 4)
 #define DW_CTLL_SRC_WIDTH_SHIFT	4
-#define DW_CTLL_DST_WIDTH_MASK	MASK(3, 1)
+#define DW_CTLL_DST_WIDTH_MASK	GENMASK(3, 1)
 #define DW_CTLL_DST_WIDTH_SHIFT	1
 
 /* CTL_HI */
 #define DW_CTLH_CLASS(x)	SET_BITS(31, 29, x)
 #define DW_CTLH_WEIGHT(x)	SET_BITS(28, 18, x)
 #define DW_CTLH_DONE(x)		SET_BIT(17, x)
-#define DW_CTLH_BLOCK_TS_MASK	MASK(16, 0)
+#define DW_CTLH_BLOCK_TS_MASK	GENMASK(16, 0)
 
 /* DSR */
 #define DW_DSR_DSC(x)		SET_BITS(31, 20, x)

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -48,6 +48,10 @@ extern "C" {
 /** @brief 64-bit unsigned integer with bit position @p _n set. */
 #define BIT64(_n) (1ULL << (_n))
 
+/** @brief Get bit @p n from @p val. */
+#define GET_BIT(n, val)				\
+	(((val) & (1UL << (n))) >> (n))
+
 /**
  * @brief Unsigned integer with bits set in a specific range.
  *

--- a/include/zephyr/sys/util_macro.h
+++ b/include/zephyr/sys/util_macro.h
@@ -49,6 +49,19 @@ extern "C" {
 #define BIT64(_n) (1ULL << (_n))
 
 /**
+ * @brief Unsigned integer with bits set in a specific range.
+ *
+ * Set the bits value from @p val starting from bit @p bits_lo to (including)
+ * @p bits_hi.
+ *
+ * @param bits_hi Upper range limit.
+ * @param bits_lo Lower range limit.
+ * @param val Bits value to be used.
+ */
+#define SET_BITS(bits_hi, bits_lo, val)				\
+	(((val) & ((1UL << ((bits_hi) - (bits_lo) + 1UL)) - 1UL)) << (bits_lo))
+
+/**
  * @brief Set or clear a bit depending on a boolean value
  *
  * The argument @p var is a variable whose value is written to as a


### PR DESCRIPTION
Move some macros to util_macro.h to remove duplicated code.
