### PR TITLE
drivers: disk: STM32 SDMMC hardware flow control for STM32F4x and STM32F1x

### DIFF
--- a/drivers/disk/Kconfig.sdmmc
+++ b/drivers/disk/Kconfig.sdmmc
@@ -47,7 +47,7 @@ config SDMMC_STM32
 config SDMMC_STM32_HWFC
 	bool "STM32 SDMMC Hardware Flow control"
 	depends on SDMMC_STM32
-	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32L4X
+	depends on SOC_SERIES_STM32H7X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32L4 || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F1X
 	help
 	  Enable SDMMC Hardware Flow Control to avoid FIFO underrun (TX mode) and
 	  overrun (RX mode) errors.

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -55,7 +55,14 @@ static void stm32_sdmmc_fc_enable(struct stm32_sdmmc_priv *priv)
 {
 	MMC_TypeDef *sdmmcx = priv->hsd.Instance;
 
+#if defined(CONFIG_SOC_SERIES_STM32F4X) \
+	|| defined(CONFIG_SOC_SERIES_STM32F1X)
+	sdmmcx->CLKCR |= SDIO_CLKCR_HWFC_EN;
+#elif defined(CONFIG_SOC_SERIES_STM32H7X) \
+	|| defined(CONFIG_SOC_SERIES_STM32F7X) \
+	|| defined(CONFIG_SOC_SERIES_STM32L4X)
 	sdmmcx->CLKCR |= SDMMC_CLKCR_HWFC_EN;
+#endif
 }
 #endif
 


### PR DESCRIPTION
`CONFIG_SDMMC_STM32_HWFC ` currently only supports the H7, F7 and L4 processor series. This PR adds support for the F4 and F1 series.

Tested on STM32F412ZGxxx