### PR TITLE
modem: hl7800 fix runtime log level control

### DIFF
--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -8,7 +8,8 @@
 
 #include <zephyr/logging/log.h>
 #include <zephyr/logging/log_ctrl.h>
-LOG_MODULE_REGISTER(modem_hl7800, CONFIG_MODEM_LOG_LEVEL);
+#define LOG_MODULE_NAME modem_hl7800
+LOG_MODULE_REGISTER(LOG_MODULE_NAME, CONFIG_MODEM_LOG_LEVEL);
 
 #include <zephyr/types.h>
 #include <stddef.h>


### PR DESCRIPTION
mdm_hl7800_log_filter_set uses LOG_MODULE_NAME which
is undefined.
log_source_id_get() will fail to get the correct source id.

fixes #48967