### PR TITLE
drivers: regulator: Update Kconfig

### DIFF
--- a/drivers/regulator/Kconfig.fixed
+++ b/drivers/regulator/Kconfig.fixed
@@ -1,11 +1,10 @@
 # Copyright 2020 Peter Bigot Consulting, LLC
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_REGULATOR_FIXED := regulator-fixed
-
 config REGULATOR_FIXED
 	bool "GPIO-controlled regulators"
-	default $(dt_compat_enabled,$(DT_COMPAT_REGULATOR_FIXED))
+	default y
+	depends on DT_HAS_REGULATOR_FIXED_ENABLED
 	depends on GPIO
 	help
 	  Enable the driver for GPIO-controlled regulators

--- a/drivers/regulator/Kconfig.pmic
+++ b/drivers/regulator/Kconfig.pmic
@@ -1,12 +1,10 @@
 # Copyright (c) 2021, NXP
 # SPDX -License-Identifier: Apache-2.0
 
-DT_COMPAT_PMIC_REG := regulator-pmic
-
 config REGULATOR_PMIC
 	bool "PMIC Regulator Driver"
-	depends on $(dt_compat_enabled,$(DT_COMPAT_PMIC_REG))
-	default $(dt_compat_enabled,$(DT_COMPAT_PMIC_REG))
+	default y
+	depends on DT_HAS_REGULATOR_PMIC_ENABLED
 	select I2C
 	help
 	  Enable the pmic regulator driver


### PR DESCRIPTION
* Utilize DT_HAS_<COMPAT>_ENABLED for devicetree based drivers

Signed-off-by: Kumar Gala <galak@kernel.org>