### PR TITLE
drivers: syscon: Update Kconfig

### DIFF
--- a/drivers/syscon/Kconfig
+++ b/drivers/syscon/Kconfig
@@ -22,11 +22,10 @@ module = SYSCON
 module-str = syscon
 source "subsys/logging/Kconfig.template.log_config"
 
-DT_COMPAT_SYSCON := syscon
-
 config SYSCON_GENERIC
 	bool "Generic SYSCON (System Controller) driver"
-	default $(dt_compat_enabled,$(DT_COMPAT_SYSCON))
+	default y
+	depends on DT_HAS_SYSCON_ENABLED
 	help
 	  Enable generic SYSCON (System Controller) driver
 


### PR DESCRIPTION
* Utilize DT_HAS_<COMPAT>_ENABLED for devicetree based drivers

Signed-off-by: Kumar Gala <galak@kernel.org>