### PR TITLE
drivers: mipi_dsi: Update Kconfig

### DIFF
--- a/drivers/mipi_dsi/Kconfig.mcux
+++ b/drivers/mipi_dsi/Kconfig.mcux
@@ -1,11 +1,9 @@
 # Copyright (c) 2022, NXP
 # SPDX-License-Identifier: Apache-2.0
 
-DT_COMPAT_MCUX_MIPI_DSI := nxp,imx-mipi-dsi
-
 config MIPI_DSI_MCUX
 	bool "NXP MCUX MIPI-DSI Host Controller"
-	depends on HAS_MCUX_MIPI_DSI
-	default $(dt_compat_enabled,$(DT_COMPAT_MCUX_MIPI_DSI))
+	default y
+	depends on DT_HAS_NXP_IMX_MIPI_DSI_ENABLED
 	help
 	  NXP MIPI DSI controller driver


### PR DESCRIPTION
* Utilize DT_HAS_<COMPAT>_ENABLED for devicetree based drivers

Signed-off-by: Kumar Gala <galak@kernel.org>