### PR TITLE
peci: ite_it8xxx2: A few devicetree/kconfig updates

### DIFF
--- a/drivers/peci/Kconfig.it8xxx2
+++ b/drivers/peci/Kconfig.it8xxx2
@@ -6,5 +6,6 @@
 config PECI_ITE_IT8XXX2
 	bool "ITE IT8XXX2 PECI driver"
 	depends on SOC_IT8XXX2
+	select PECI_INTERRUPT_DRIVEN
 	help
 	  Enable the ITE IT8XXX2 PECI IO driver.

--- a/drivers/peci/peci_ite_it8xxx2.c
+++ b/drivers/peci/peci_ite_it8xxx2.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#define DT_DRV_COMPAT ite_peci_it8xxx2
+#define DT_DRV_COMPAT ite_it8xxx2_peci
 
 #include <zephyr/drivers/gpio.h>
 #include <zephyr/drivers/pinctrl.h>

--- a/dts/bindings/peci/ite,it8xxx2-peci.yaml
+++ b/dts/bindings/peci/ite,it8xxx2-peci.yaml
@@ -3,7 +3,7 @@
 
 description: ITE it8xxx2 PECI
 
-compatible: "ite,peci-it8xxx2"
+compatible: "ite,it8xxx2-peci"
 
 include: [peci.yaml, pinctrl-device.yaml]
 

--- a/dts/riscv/ite/it8xxx2.dtsi
+++ b/dts/riscv/ite/it8xxx2.dtsi
@@ -1131,7 +1131,7 @@
 		};
 
 		peci0: peci@f02c00 {
-			compatible = "ite,peci-it8xxx2";
+			compatible = "ite,it8xxx2-peci";
 			reg = <0x00f02c00 15>;
 			#address-cells=<1>;
 			#size-cells = <0>;

--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.defconfig.series
@@ -46,7 +46,6 @@ config IT8XXX2_PLL_SEQUENCE_PRIORITY
 config PECI_ITE_IT8XXX2
 	default y
 	depends on PECI
-	select PECI_INTERRUPT_DRIVEN
 
 config PINCTRL
 	default y


### PR DESCRIPTION
* rename compatible to match other ite,it8xxx2 devices
* minor Kconfig cleanup for the driver.