### PR TITLE
drivers: w1: Move to using select in Kconfig for I2C bus

### DIFF
--- a/drivers/w1/Kconfig.ds2484
+++ b/drivers/w1/Kconfig.ds2484
@@ -3,6 +3,6 @@
 
 config W1_DS2484
 	bool "DS2484 Single-Channel 1-Wire Master"
-	depends on I2C
+	select I2C
 	depends on DT_HAS_MAXIM_DS2484_ENABLED
 	default y


### PR DESCRIPTION
Move to using select I2C' instead of 'depends on'
(see commit df81fef94483da9f2811d48088affbcfd61ab18c for more
 details)

Signed-off-by: Kumar Gala <galak@kernel.org>