### PR TITLE
drivers: dac: Update Kconfig for 'select I2C/SPI'

### DIFF
--- a/drivers/dac/Kconfig.dacx0508
+++ b/drivers/dac/Kconfig.dacx0508
@@ -7,7 +7,7 @@
 config DAC_DACX0508
 	bool "TI DACx0508 DAC driver"
 	default y
-	depends on SPI
+	select SPI
 	depends on DT_HAS_TI_DAC60508_ENABLED || DT_HAS_TI_DAC70508_ENABLED || \
 		   DT_HAS_TI_DAC80508_ENABLED
 	help

--- a/drivers/dac/Kconfig.dacx3608
+++ b/drivers/dac/Kconfig.dacx3608
@@ -7,7 +7,7 @@
 config DAC_DACX3608
 	bool "TI DACX3608 DAC driver"
 	default y
-	depends on I2C
+	select I2C
 	depends on DT_HAS_TI_DAC43608_ENABLED || DT_HAS_TI_DAC53608_ENABLED
 	help
 	  Enable the driver for the TI DACX3608.

--- a/drivers/dac/Kconfig.mcp4725
+++ b/drivers/dac/Kconfig.mcp4725
@@ -7,7 +7,7 @@
 config DAC_MCP4725
 	bool "Microchip MCP4725 DAC driver"
 	default y
-	depends on I2C
+	select I2C
 	depends on DT_HAS_MICROCHIP_MCP4725_ENABLED
 	help
 	  Enable the driver for the Microchip MCP4725.

--- a/drivers/dac/Kconfig.mcp4728
+++ b/drivers/dac/Kconfig.mcp4728
@@ -5,7 +5,7 @@
 config DAC_MCP4728
 	bool "Microchip MCP4728 DAC driver"
 	default y
-	depends on I2C
+	select I2C
 	depends on DT_HAS_MICROCHIP_MCP4728_ENABLED
 	help
 	  Enable driver for the Microchip MCP4728.

--- a/tests/drivers/build_all/dac/testcase.yaml
+++ b/tests/drivers/build_all/dac/testcase.yaml
@@ -2,14 +2,11 @@ common:
   build_only: true
   tags: drivers dac
 tests:
-  drivers.dac.spi.build:
+  drivers.dac.build:
+    # will cover I2C, SPI based drivers
     platform_allow: native_posix
-    tags: dac_dacx0508
-    extra_args: "CONFIG_GPIO=y CONFIG_SPI=y CONFIG_DAC_DACX0508=y"
-  drivers.dac.i2c.build:
-    platform_allow: native_posix
-    tags: dac_dacx3608 dac_mcp4725
-    extra_args: "CONFIG_I2C=y CONFIG_DAC_DACX3608=y CONFIG_DAC_MCP4725=y"
+    tags: dac_dacx0508 dac_dacx3608 dac_mcp4725
+    extra_args: "CONFIG_GPIO=y"
   drivers.dac.mcux.build:
     platform_allow: frdm_k22f
     tags: dac_mcux

--- a/tests/drivers/build_all/dac/testcase.yaml
+++ b/tests/drivers/build_all/dac/testcase.yaml
@@ -10,16 +10,12 @@ tests:
   drivers.dac.mcux.build:
     platform_allow: frdm_k22f
     tags: dac_mcux
-    extra_args: "CONFIG_DAC_MCUX_DAC=y"
   drivers.dac.mcux32.build:
     platform_allow: twr_ke18f
     tags: dac_mcux32
-    extra_args: "CONFIG_DAC_MCUX_DAC32=y"
   drivers.dac.sam0.build:
     platform_allow: atsamd21_xpro
     tags: dac_sam0
-    extra_args: "CONFIG_DAC_SAM0=y"
   drivers.dac.stm32.build:
     platform_allow: nucleo_f091rc
     tags: dac_stm32
-    extra_args: "CONFIG_DAC_STM32=y"


### PR DESCRIPTION
* Move to using 'select I2C/SPI' instead of 'depends on'
  (see commit df81fef94483da9f2811d48088affbcfd61ab18c for
   more details)

Signed-off-by: Kumar Gala <galak@kernel.org>