### PR TITLE
drivers: can: Move to using select in Kconfig for SPI bus

### DIFF
--- a/drivers/can/Kconfig.mcp2515
+++ b/drivers/can/Kconfig.mcp2515
@@ -7,7 +7,7 @@ config CAN_MCP2515
 	bool "MCP2515 CAN Driver"
 	default y
 	depends on DT_HAS_MICROCHIP_MCP2515_ENABLED
-	depends on SPI
+	select SPI
 	help
 	  Enable MCP2515 CAN Driver
 


### PR DESCRIPTION
* Move to using 'select SPI' instead of 'depends on'
  (see commit df81fef94483da9f2811d48088affbcfd61ab18c for
   more details)

Signed-off-by: Kumar Gala <galak@kernel.org>