### PR TITLE
drivers: ieee802154: Move to using select in Kconfig for SPI bus

### DIFF
--- a/drivers/ieee802154/Kconfig.dw1000
+++ b/drivers/ieee802154/Kconfig.dw1000
@@ -4,7 +4,8 @@
 menuconfig IEEE802154_DW1000
 	bool "Decawave DW1000 Driver support"
 	default y
-	depends on SPI && DT_HAS_DECAWAVE_DW1000_ENABLED
+	depends on DT_HAS_DECAWAVE_DW1000_ENABLED
+	select SPI
 
 if IEEE802154_DW1000
 

--- a/drivers/ieee802154/Kconfig.mcr20a
+++ b/drivers/ieee802154/Kconfig.mcr20a
@@ -6,7 +6,8 @@
 menuconfig IEEE802154_MCR20A
 	bool "NXP MCR20A Driver support"
 	default y
-	depends on SPI && DT_HAS_NXP_MCR20A_ENABLED
+	depends on DT_HAS_NXP_MCR20A_ENABLED
+	select SPI
 
 if IEEE802154_MCR20A
 


### PR DESCRIPTION
* Move to using 'select SPI' instead of 'depends on'
  (see commit df81fef94483da9f2811d48088affbcfd61ab18c for
   more details)

Signed-off-by: Kumar Gala <galak@kernel.org>