### PR TITLE
Restore the two commits reverted in #48858

### DIFF
--- a/cmake/modules/dts.cmake
+++ b/cmake/modules/dts.cmake
@@ -214,7 +214,6 @@ if(SUPPORTS_DTS)
   --dtc-flags '${EXTRA_DTC_FLAGS_RAW}'
   --bindings-dirs ${DTS_ROOT_BINDINGS}
   --header-out ${DEVICETREE_GENERATED_H}.new
-  --device-header-out ${DEVICE_EXTERN_H}.new
   --dts-out ${ZEPHYR_DTS}.new # for debugging and dtc
   --edt-pickle-out ${EDT_PICKLE}
   ${EXTRA_GEN_DEFINES_ARGS}
@@ -231,11 +230,11 @@ if(SUPPORTS_DTS)
   else()
     zephyr_file_copy(${ZEPHYR_DTS}.new ${ZEPHYR_DTS} ONLY_IF_DIFFERENT)
     zephyr_file_copy(${DEVICETREE_GENERATED_H}.new ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
-    zephyr_file_copy(${DEVICE_EXTERN_H}.new ${DEVICE_EXTERN_H})
-    file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_GENERATED_H}.new ${DEVICE_EXTERN_H}.new)
+    file(WRITE ${DEVICE_EXTERN_H}
+"#error The contents of this file are now implemented directly in zephyr/device.h.")
+    file(REMOVE ${ZEPHYR_DTS}.new ${DEVICETREE_GENERATED_H}.new)
     message(STATUS "Generated zephyr.dts: ${ZEPHYR_DTS}")
     message(STATUS "Generated devicetree_generated.h: ${DEVICETREE_GENERATED_H}")
-    message(STATUS "Generated device_extern.h: ${DEVICE_EXTERN_H}")
   endif()
 
 
@@ -310,5 +309,4 @@ if(SUPPORTS_DTS)
 else()
   set(header_template ${ZEPHYR_BASE}/misc/generated/generated_header.template)
   zephyr_file_copy(${header_template} ${DEVICETREE_GENERATED_H} ONLY_IF_DIFFERENT)
-  zephyr_file_copy(${header_template} ${DEVICE_EXTERN_H} ONLY_IF_DIFFERENT)
 endif(SUPPORTS_DTS)

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -94,13 +94,13 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_NAME_GET(name) _CONCAT(__device_, name)
 
-/* Node paths can exceed the maximum size supported by device_get_binding() in user mode,
- * so synthesize a unique dev_name from the devicetree node.
+/* Node paths can exceed the maximum size supported by
+ * device_get_binding() in user mode; this macro synthesizes a unique
+ * dev_name from a devicetree node while staying within this maximum
+ * size.
  *
  * The ordinal used in this name can be mapped to the path by
- * examining zephyr/include/generated/device_generated.h header. If the
- * format of this conversion changes, gen_defines should be updated to
- * match it.
+ * examining zephyr/include/generated/devicetree_generated.h.
  */
 #define Z_DEVICE_DT_DEV_NAME(node_id) _CONCAT(dts_ord_, DT_DEP_ORD(node_id))
 
@@ -923,12 +923,25 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,		\
 		(&DEVICE_NAME_GET(dev_name)), level, prio)
 
+/*
+ * Declare a device for each status "okay" devicetree node. (Disabled
+ * nodes should not result in devices, so not predeclaring these keeps
+ * drivers honest.)
+ *
+ * This is only "maybe" a device because some nodes have status "okay",
+ * but don't have a corresponding struct device allocated. There's no way
+ * to figure that out until after we've built the zephyr image,
+ * though.
+ */
+#define Z_MAYBE_DEVICE_DECLARE_INTERNAL(node_id) \
+	extern const struct device DEVICE_DT_NAME_GET(node_id);
+
+DT_FOREACH_STATUS_OKAY_NODE(Z_MAYBE_DEVICE_DECLARE_INTERNAL)
+
 #ifdef __cplusplus
 }
 #endif
 
-/* device_extern is generated based on devicetree nodes */
-#include <device_extern.h>
 
 #include <syscalls/device.h>
 

--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -146,34 +146,8 @@ def main():
         write_chosen(edt)
         write_global_macros(edt)
 
-        write_device_extern_header(args.device_header_out, edt)
-
     if args.edt_pickle_out:
         write_pickled_edt(edt, args.edt_pickle_out)
-
-
-def write_device_extern_header(device_header_out, edt):
-    # Generate header that will extern devicetree struct device's
-
-    with open(device_header_out, "w", encoding="utf-8") as dev_header_file:
-        print("#ifndef DEVICE_EXTERN_GEN_H", file=dev_header_file)
-        print("#define DEVICE_EXTERN_GEN_H", file=dev_header_file)
-        print("", file=dev_header_file)
-        print("#ifdef __cplusplus", file=dev_header_file)
-        print('extern "C" {', file=dev_header_file)
-        print("#endif", file=dev_header_file)
-        print("", file=dev_header_file)
-
-        for node in sorted(edt.nodes, key=lambda node: node.dep_ordinal):
-            print(f"extern const struct device DEVICE_DT_NAME_GET(DT_{node.z_path_id}); /* dts_ord_{node.dep_ordinal} */",
-                  file=dev_header_file)
-
-        print("", file=dev_header_file)
-        print("#ifdef __cplusplus", file=dev_header_file)
-        print("}", file=dev_header_file)
-        print("#endif", file=dev_header_file)
-        print("", file=dev_header_file)
-        print("#endif /* DEVICE_EXTERN_GEN_H */", file=dev_header_file)
 
 
 def setup_edtlib_logging():
@@ -222,8 +196,6 @@ def parse_args():
     parser.add_argument("--dts-out", required=True,
                         help="path to write merged DTS source code to (e.g. "
                              "as a debugging aid)")
-    parser.add_argument("--device-header-out", required=True,
-                        help="path to write device struct extern header to")
     parser.add_argument("--edt-pickle-out",
                         help="path to write pickled edtlib.EDT object to")
     parser.add_argument("--vendor-prefixes", action='append', default=[],


### PR DESCRIPTION
Now that the underlying issue has been fixed in https://github.com/zephyrproject-rtos/zephyr/pull/48965, restore 3b341085a2baafd96328cc9e2c38b7414f89055b and 0224f2c508df154ffc9c1ecffaf0b06608d6b623, that were reverted in https://github.com/zephyrproject-rtos/zephyr/pull/48858.