### PR TITLE
drivers: can: remove option for configuring CAN-FD max DLC

### DIFF
--- a/drivers/can/Kconfig
+++ b/drivers/can/Kconfig
@@ -54,18 +54,6 @@ config CAN_FD_MODE
 	help
 	  Enable CAN-FD compatible API
 
-if CAN_FD_MODE
-
-config CANFD_MAX_DLC
-	int "Max data length code in CAN frames"
-	range 8 15
-	default 15
-	help
-	  Maximum allowed DLC in a CAN frame. This parameter sets the
-	  data buffer size in a CAN frame and is therefore only used to
-	  optimize memory consumption.
-endif # CAN_FD_MODE
-
 config CAN_RX_TIMESTAMP
 	bool "Receiving timestamps"
 	depends on CAN_HAS_RX_TIMESTAMP

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -52,27 +52,17 @@ extern "C" {
 /**
  * @brief Maximum data length code for CAN-FD.
  */
-#define CANFD_MAX_DLC   CONFIG_CANFD_MAX_DLC
+#define CANFD_MAX_DLC   15U
 
 /**
  * @cond INTERNAL_HIDDEN
  * Internally calculated maximum data length
  */
-#ifndef CONFIG_CANFD_MAX_DLC
+#ifndef CONFIG_CAN_FD_MODE
 #define CAN_MAX_DLEN    8U
 #else
-#if CONFIG_CANFD_MAX_DLC <= 8
-#define CAN_MAX_DLEN    CONFIG_CANFD_MAX_DLC
-#elif CONFIG_CANFD_MAX_DLC <= 12
-#define CAN_MAX_DLEN    (CONFIG_CANFD_MAX_DLC + (CONFIG_CANFD_MAX_DLC - 8U) * 4U)
-#elif CONFIG_CANFD_MAX_DLC == 13
-#define CAN_MAX_DLEN    32U
-#elif CONFIG_CANFD_MAX_DLC == 14
-#define CAN_MAX_DLEN    48U
-#elif CONFIG_CANFD_MAX_DLC == 15
 #define CAN_MAX_DLEN    64U
-#endif
-#endif /* CONFIG_CANFD_MAX_DLC */
+#endif /* CONFIG_CAN_FD_MODE */
 
 /** @endcond */
 


### PR DESCRIPTION
Remove the Kconfig option for configuring the maximum value of the CAN-FD Data Length Code in order to ensure standard compliance.

Allowing users to configure the max DLC allows the user to save a number of bytes per CAN frame in RAM, but it also renders the Zephyr CAN-FD implementation non-compliant with the CAN-FD standard.

There are no guarantees that a Zephyr CAN-FD node will not receive a CAN frame with a DLC higher than the Kconfig limit, which opens up for all sorts of bugs when trying to handle received CAN-FD frames.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>