### PR TITLE
arch: sparc: Force 8-byte alignment for structs

### DIFF
--- a/arch/sparc/CMakeLists.txt
+++ b/arch/sparc/CMakeLists.txt
@@ -1,4 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
+# FIXME: Temporary workaround for the alignment-related test failure reported
+#        in the GitHub issue zephyrproject-rtos/zephyr#48992.
+zephyr_cc_option(-mfaster-structs)
+
 set_property(GLOBAL PROPERTY PROPERTY_OUTPUT_FORMAT "elf32-sparc")
 add_subdirectory(core)


### PR DESCRIPTION
This commit adds the `-mfaster-structs` flag for the SPARC
architecture, which forces all structs to have an 8-byte alignment.

This is a temporary workaround for the alignment-related test failure
reported in the GitHub issue zephyrproject-rtos/zephyr#48992, and
should be reverted once the root cause is identified and fixed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

NOTE: This is a hotfix for the issue reported in #48992.