### PR TITLE
drivers: can: utils: change can_utils_filter_match() return type to bool

### DIFF
--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -75,7 +75,7 @@ static void tx_thread(void *arg1, void *arg2, void *arg3)
 		for (int i = 0; i < CONFIG_CAN_MAX_FILTER; i++) {
 			filter = &data->filters[i];
 			if (filter->rx_cb &&
-			    can_utils_filter_match(&frame.frame, &filter->filter) != 0) {
+			    can_utils_filter_match(&frame.frame, &filter->filter)) {
 				dispatch_frame(dev, &frame.frame, filter);
 			}
 		}

--- a/drivers/can/can_utils.h
+++ b/drivers/can/can_utils.h
@@ -11,22 +11,29 @@
 #ifndef ZEPHYR_DRIVERS_CAN_CAN_UTILS_H_
 #define ZEPHYR_DRIVERS_CAN_CAN_UTILS_H_
 
-static inline uint8_t can_utils_filter_match(const struct zcan_frame *frame,
-					     struct zcan_filter *filter)
+/**
+ * @brief Check if a CAN filter matches a CAN frame
+ *
+ * @param frame  CAN frame.
+ * @param filter CAN filter.
+ * @return true if the CAN filter matches the CAN frame, false otherwise
+ */
+static inline bool can_utils_filter_match(const struct zcan_frame *frame,
+					  struct zcan_filter *filter)
 {
 	if (frame->id_type != filter->id_type) {
-		return 0;
+		return false;
 	}
 
 	if ((frame->rtr ^ filter->rtr) & filter->rtr_mask) {
-		return 0;
+		return false;
 	}
 
 	if ((frame->id ^ filter->id) & filter->id_mask) {
-		return 0;
+		return false;
 	}
 
-	return 1;
+	return true;
 }
 
 #endif /* ZEPHYR_DRIVERS_CAN_CAN_UTILS_H_ */


### PR DESCRIPTION
Change the return type for can_utils_filter_match() to bool and add documentation.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>