### PR TITLE
ci: twister: Include module test results in report

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -263,6 +263,7 @@ jobs:
           if-no-files-found: ignore
           path: |
             twister-out/twister.xml
+            module_tests/twister.xml
             testplan.json
 
   twister-test-results:


### PR DESCRIPTION
This commit modifies the twister workflow to include the module test
results in the unit test report.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>