### PR TITLE
tests: posix: common: Disable for qemu_leon3

### DIFF
--- a/tests/posix/common/testcase.yaml
+++ b/tests/posix/common/testcase.yaml
@@ -1,5 +1,8 @@
 common:
   arch_exclude: posix
+  # FIXME: qemu_leon3 is excluded because of the alignment-related failure
+  #        reported in the GitHub issue zephyrproject-rtos/zephyr#48992.
+  platform_exclude: qemu_leon3
   tags: posix
   min_ram: 64
   timeout: 600


### PR DESCRIPTION
This commit disables the `tests/posix/common` test for the `qemu_leon3`
platform because of the alignment-related failure reported in the
GitHub issue zephyrproject-rtos/zephyr#48992.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

**NOTE: This is a hotfix for the issue reported in https://github.com/zephyrproject-rtos/zephyr/issues/48992.**