### PR TITLE
tests: add extra delay between test functions

### DIFF
--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -2410,4 +2410,16 @@ ZTEST(devicetree_api, test_reset)
 	zassert_equal(DT_INST_RESET_ID(0), 10, "");
 }
 
+#if defined(CONFIG_BOARD_INTEL_ADSP_CAVS15) ||		\
+	defined(CONFIG_BOARD_INTEL_ADSP_CAVS18) ||	\
+	defined(CONFIG_BOARD_INTEL_ADSP_CAVS25)
+void delay(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	k_sleep(K_MSEC(300));
+}
+
+ZTEST_SUITE(devicetree_api, NULL, NULL, delay, NULL, NULL);
+#else
 ZTEST_SUITE(devicetree_api, NULL, NULL, NULL, NULL, NULL);
+#endif

--- a/tests/lib/mem_blocks/src/main.c
+++ b/tests/lib/mem_blocks/src/main.c
@@ -808,4 +808,16 @@ static void *lib_mem_block_setup(void)
 	return NULL;
 }
 
+#if defined(CONFIG_BOARD_INTEL_ADSP_CAVS15) ||		\
+	defined(CONFIG_BOARD_INTEL_ADSP_CAVS18) ||	\
+	defined(CONFIG_BOARD_INTEL_ADSP_CAVS25)
+void delay(void *fixture)
+{
+	ARG_UNUSED(fixture);
+	k_sleep(K_MSEC(300));
+}
+
+ZTEST_SUITE(lib_mem_block, NULL, lib_mem_block_setup, delay, NULL, NULL);
+#else
 ZTEST_SUITE(lib_mem_block, NULL, lib_mem_block_setup, NULL, NULL, NULL);
+#endif


### PR DESCRIPTION
Currently, Intel CAVS platforms will lose logs if
the log output is too frequent, which causes some
unrelated tests to fail only because of missing
logs.

This patch fixes such unrelated cases by adding some
extra delay between each test function to allow pending
logs to be extracted in time.

The log performance issue on Intel CAVS platforms is
verified by another dedicated case (https://github.com/zephyrproject-rtos/zephyr/pull/49007).

Signed-off-by: Ming Shao <ming.shao@intel.com>

(This PR can be merged only if https://github.com/zephyrproject-rtos/zephyr/pull/49007 is merged.)