### PR TITLE
drivers: sensor: adxl372: Fix default bus issue

### DIFF
--- a/drivers/sensor/adxl372/Kconfig
+++ b/drivers/sensor/adxl372/Kconfig
@@ -16,6 +16,8 @@ if ADXL372
 
 choice ADXL372_BUS_TYPE
 	prompt "Interface type"
+	default ADXL372_I2C if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL372),i2c)
+	default ADXL372_SPI if $(dt_compat_on_bus,$(DT_COMPAT_ADI_ADXL372),spi)
 	help
 	  Select interface the digital interface type for the ADXL372
 


### PR DESCRIPTION
The adxl372 device does not select the correct bus that it is on, which
causes undefined operation (usually a fault). This driver should not be
using Kconfig to determine which bus to use, that should be done by
dts, however this works as a quick fix in the interim until the driver
can be fixed properly.