### PR TITLE
kernel: Prevent Wundef

### DIFF
--- a/include/zephyr/kernel/thread.h
+++ b/include/zephyr/kernel/thread.h
@@ -209,7 +209,7 @@ typedef struct k_thread_runtime_stats {
 	uint64_t idle_cycles;
 #endif
 
-#if __cplusplus && !defined(CONFIG_SCHED_THREAD_USAGE) &&                                          \
+#if defined(__cplusplus) && !defined(CONFIG_SCHED_THREAD_USAGE) &&                                 \
 	!defined(CONFIG_SCHED_THREAD_USAGE_ANALYSIS) && !defined(CONFIG_SCHED_THREAD_USAGE_ALL)
 	/* If none of the above Kconfig values are defined, this struct will have a size 0 in C
 	 * which is not allowed in C++ (it'll have a size 1). To prevent this, we add a 1 byte dummy

--- a/scripts/build/gen_syscalls.py
+++ b/scripts/build/gen_syscalls.py
@@ -122,7 +122,7 @@ uintptr_t %s(uintptr_t arg1, uintptr_t arg2, uintptr_t arg3,
 # enable/disable of syscall tracing. Used for returning functions
 # Note that the last argument to the exit macro is the return value.
 syscall_tracer_with_return_template = """
-#if (CONFIG_TRACING_SYSCALL == 1)
+#if defined(CONFIG_TRACING_SYSCALL)
 #ifndef DISABLE_SYSCALL_TRACING
 {trace_diagnostic}
 #define {func_name}({argnames}) ({{ \
@@ -140,7 +140,7 @@ syscall_tracer_with_return_template = """
 # and provides tracing enter/exit hooks while allowing per compilation unit
 # enable/disable of syscall tracing. Used for non-returning (void) functions
 syscall_tracer_void_template = """
-#if (CONFIG_TRACING_SYSCALL == 1)
+#if defined(CONFIG_TRACING_SYSCALL)
 #ifndef DISABLE_SYSCALL_TRACING
 {trace_diagnostic}
 #define {func_name}({argnames}) do {{ \


### PR DESCRIPTION
prevent `Wundef` warnings from occurring due to
missing CONFIG_ symbols and __cplusplus.

Signed-off-by: Christoph A Schnetzler <Christoph.Schnetzler@husqvarnagroup.com>