### PR TITLE
soc: rt: CAAM requires cache write-through mode

### DIFF
--- a/soc/arm/nxp_imx/rt/CMakeLists.txt
+++ b/soc/arm/nxp_imx/rt/CMakeLists.txt
@@ -41,6 +41,14 @@ endif()
 zephyr_compile_definitions(
   XIP_EXTERNAL_FLASH
 )
+
+if(CONFIG_ENTROPY_MCUX_CAAM)
+  zephyr_compile_definitions(
+    CACHE_MODE_WRITE_THROUGH
+  )
+endif()
+
+
 zephyr_linker_sources(
   RWDATA nocache.ld)
 


### PR DESCRIPTION
The use of the RT11xx CAAM requires
cache write-through mode,
otherwise some tests give a compiler warning.

Add to the soc CMake to do this

Fixes #48977