### PR TITLE
drivers: timer: lptim: Remove deprecation warning

### DIFF
--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -28,7 +28,6 @@
 #define LPTIM (LPTIM_TypeDef *) DT_INST_REG_ADDR(0)
 
 #if DT_INST_NUM_CLOCKS(0) == 1
-#warning Kconfig for LPTIM source clock (LSI/LSE) is deprecated, use device tree.
 static const struct stm32_pclken lptim_clk[] = {
 	STM32_CLOCK_INFO(0, DT_DRV_INST(0)),
 	/* Use Kconfig to configure source clocks fields */


### PR DESCRIPTION
It appears that some in tree boards still enable lptim w/o configured
domain clocks.
Remove this deprecation message the time a clean up is done fully.

Signed-off-by: Erwan Gouriou <erwan.gouriou@linaro.org>