### PR TITLE
xcc: do not call ASSERT in CODE_UNREACHABLE

### DIFF
--- a/include/zephyr/toolchain/xcc.h
+++ b/include/zephyr/toolchain/xcc.h
@@ -141,8 +141,7 @@
 
 #endif /* __GCC_LINKER_CMD__ */
 
-#define __builtin_unreachable() do { __ASSERT(false, "Unreachable code"); } \
-	while (true)
+#define __builtin_unreachable() __builtin_trap()
 
 /* Not a full barrier, just a SW barrier */
 #define __sync_synchronize() do { __asm__ __volatile__ ("" ::: "memory"); } \


### PR DESCRIPTION
230ddd9a7f91 added unreachable path hint for assertion failure. Xcc does
not support __builtin_unreachable and this was defined as a call to
ASSERT, which generated some recursion.

Replace the definition with __builtin_trap() to work around this issue.

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
