### PR TITLE
coap_packet_parse() returns different values.

### DIFF
--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -360,7 +360,11 @@ const uint8_t *coap_packet_get_payload(const struct coap_packet *cpkt,
  * @param options Parse options and cache its details.
  * @param opt_num Number of options
  *
- * @return 0 in case of success or negative in case of error.
+ * @return 0 in case of success.
+ * @return -EINVAL in case of NULL ptr for cpkt and data, and invalid
+ * len value.
+ * @return -EBADMSG in case of issues with coap packet header data.
+ * @return -EILSEQ in case of issues parsing options.
  */
 int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		      struct coap_option *options, uint8_t opt_num);

--- a/include/zephyr/net/coap.h
+++ b/include/zephyr/net/coap.h
@@ -360,11 +360,10 @@ const uint8_t *coap_packet_get_payload(const struct coap_packet *cpkt,
  * @param options Parse options and cache its details.
  * @param opt_num Number of options
  *
- * @return 0 in case of success.
- * @return -EINVAL in case of NULL ptr for cpkt and data, and invalid
- * len value.
- * @return -EBADMSG in case of issues with coap packet header data.
- * @return -EILSEQ in case of issues parsing options.
+ * @retval 0 in case of success.
+ * @retval -EINVAL in case of invalid input arguments.
+ * @retval -EBADMSG in case of malformed COAP header.
+ * @retval -EILSEQ in case of malformed COAP options.
  */
 int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		      struct coap_option *options, uint8_t opt_num);

--- a/subsys/net/lib/coap/coap.c
+++ b/subsys/net/lib/coap/coap.c
@@ -577,12 +577,12 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 	/* Token lengths 9-15 are reserved. */
 	tkl = cpkt->data[0] & 0x0f;
 	if (tkl > 8) {
-		return -EINVAL;
+		return -EBADMSG;
 	}
 
 	cpkt->hdr_len = BASIC_HEADER_SIZE + tkl;
 	if (cpkt->hdr_len > len) {
-		return -EINVAL;
+		return -EBADMSG;
 	}
 
 	if (cpkt->hdr_len == len) {
@@ -601,7 +601,7 @@ int coap_packet_parse(struct coap_packet *cpkt, uint8_t *data, uint16_t len,
 		ret = parse_option(cpkt->data, offset, &offset, cpkt->max_len,
 				   &delta, &opt_len, option);
 		if (ret < 0) {
-			return ret;
+			return -EILSEQ;
 		} else if (ret == 0) {
 			break;
 		}

--- a/tests/net/lib/coap/src/main.c
+++ b/tests/net/lib/coap/src/main.c
@@ -272,6 +272,38 @@ ZTEST(coap, test_parse_simple_pdu)
 		      "There shouldn't be any ETAG option in the packet");
 }
 
+ZTEST(coap, test_parse_malformed_pkt)
+{
+    uint8_t opt[] = { 0x55, 0xA5, 0x12 };
+
+    struct coap_packet cpkt;
+    uint8_t *data = data_buf[0];
+    int r;
+
+    r = coap_packet_parse(&cpkt, NULL, sizeof(opt), NULL, 0);
+    zassert_equal(r, -EINVAL, "Should've failed to parse a packet");
+
+    r = coap_packet_parse(&cpkt, data, 0, NULL, 0);
+    zassert_equal(r, -EINVAL, "Should've failed to parse a packet");
+
+    memcpy(data, opt, sizeof(opt));
+    r = coap_packet_parse(&cpkt, data, sizeof(opt), NULL, 0);
+    zassert_equal(r, -EINVAL, "Should've failed to parse a packet");
+}
+
+ZTEST(coap, test_parse_malformed_coap_hdr)
+{
+    uint8_t opt[] = { 0x55, 0x24, 0x49, 0x55, 0xff, 0x66, 0x77, 0x99};
+
+    struct coap_packet cpkt;
+    uint8_t *data = data_buf[0];
+    int r;
+
+    memcpy(data, opt, sizeof(opt));
+    r = coap_packet_parse(&cpkt, data, sizeof(opt), NULL, 0);
+    zassert_equal(r, -EBADMSG, "Should've failed to parse a packet");
+}
+
 ZTEST(coap, test_parse_malformed_opt)
 {
 	uint8_t opt[] = { 0x55, 0xA5, 0x12, 0x34, 't', 'o', 'k', 'e', 'n',
@@ -283,7 +315,7 @@ ZTEST(coap, test_parse_malformed_opt)
 	memcpy(data, opt, sizeof(opt));
 
 	r = coap_packet_parse(&cpkt, data, sizeof(opt), NULL, 0);
-	zassert_not_equal(r, 0, "Should've failed to parse a packet");
+	zassert_equal(r, -EILSEQ, "Should've failed to parse a packet");
 }
 
 ZTEST(coap, test_parse_malformed_opt_len)
@@ -297,7 +329,7 @@ ZTEST(coap, test_parse_malformed_opt_len)
 	memcpy(data, opt, sizeof(opt));
 
 	r = coap_packet_parse(&cpkt, data, sizeof(opt), NULL, 0);
-	zassert_not_equal(r, 0, "Should've failed to parse a packet");
+	zassert_equal(r, -EILSEQ, "Should've failed to parse a packet");
 }
 
 ZTEST(coap, test_parse_malformed_opt_ext)
@@ -311,7 +343,7 @@ ZTEST(coap, test_parse_malformed_opt_ext)
 	memcpy(data, opt, sizeof(opt));
 
 	r = coap_packet_parse(&cpkt, data, sizeof(opt), NULL, 0);
-	zassert_not_equal(r, 0, "Should've failed to parse a packet");
+	zassert_equal(r, -EILSEQ, "Should've failed to parse a packet");
 }
 
 ZTEST(coap, test_parse_malformed_opt_len_ext)
@@ -325,7 +357,7 @@ ZTEST(coap, test_parse_malformed_opt_len_ext)
 	memcpy(data, opt, sizeof(opt));
 
 	r = coap_packet_parse(&cpkt, data, sizeof(opt), NULL, 0);
-	zassert_not_equal(r, 0, "Should've failed to parse a packet");
+	zassert_equal(r, -EILSEQ, "Should've failed to parse a packet");
 }
 
 /* 1 option, No payload (with payload marker) */


### PR DESCRIPTION
coap_packet_parse() returns different values depending on the errors.
1. EINVAL for input arg related errors.
2. EBADMSG for coap packet header related errors.
3. EILSEQ for errors related to parsing.