### PR TITLE
ci: bug_snapshot: Fix repository name resolution

### DIFF
--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -17,6 +17,7 @@ jobs:
   make_bugs_pickle:
     name: Make bugs pickle
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'zephyrproject-rtos'
 
     steps:
     - name: Checkout

--- a/.github/workflows/bug_snapshot.yaml
+++ b/.github/workflows/bug_snapshot.yaml
@@ -50,12 +50,14 @@ jobs:
 
     - name: Upload to AWS S3
       run: |
+        REPOSITORY_NAME="${GITHUB_REPOSITORY#*/}"
+
         PUBLISH_BUCKET="builds.zephyrproject.org"
         PUBLISH_DOMAIN="builds.zephyrproject.io"
         if [ "${{github.event_name}}" = "schedule" ]; then
-          PUBLISH_ROOT="${{ github.event.repository.name }}/bug-snapshot/daily"
+          PUBLISH_ROOT="${REPOSITORY_NAME}/bug-snapshot/daily"
         else
-          PUBLISH_ROOT="${{ github.event.repository.name }}/bug-snapshot"
+          PUBLISH_ROOT="${REPOSITORY_NAME}/bug-snapshot"
         fi
 
         PUBLISH_UPLOAD_URI="s3://${PUBLISH_BUCKET}/${PUBLISH_ROOT}/${BUGS_PICKLE_FILENAME}"


### PR DESCRIPTION
`github.event.repository.name` is not available for the workflow runs
triggered by the `schedule` event.

This commit updates the workflow to use the repository name extracted
from the `GITHUB_REPOSITORY` environment variable, which is always
available.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>