### PR TITLE
drivers: w1: use select in Kconfig for serial and remove superfluous overlays in sample/test

### DIFF
--- a/drivers/w1/Kconfig.zephyr_serial
+++ b/drivers/w1/Kconfig.zephyr_serial
@@ -5,6 +5,7 @@
 
 config W1_ZEPHYR_SERIAL
 	bool "1-wire Serial"
+	select SERIAL
 	default y
 	depends on DT_HAS_ZEPHYR_W1_SERIAL_ENABLED
 	help

--- a/samples/drivers/w1/scanner/README.rst
+++ b/samples/drivers/w1/scanner/README.rst
@@ -19,7 +19,7 @@ enable and configure the drivers.
 .. zephyr-app-commands::
    :zephyr-app: samples/drivers/w1/scanner
    :board: nrf52840dk_nrf52840
-   :gen-args: -DDTC_OVERLAY_FILE=w1_serial.overlay -DOVERLAY_CONFIG=w1_serial.conf
+   :gen-args: -DDTC_OVERLAY_FILE=w1_serial.overlay
    :goals: build flash
    :compact:
 

--- a/samples/drivers/w1/scanner/ds2484.conf
+++ b/samples/drivers/w1/scanner/ds2484.conf
@@ -1,1 +1,0 @@
-CONFIG_I2C=y

--- a/samples/drivers/w1/scanner/sample.yaml
+++ b/samples/drivers/w1/scanner/sample.yaml
@@ -7,7 +7,7 @@ common:
 tests:
   samples.drivers.w1.scanner.ds2484:
     depends_on: arduino_i2c
-    extra_args: DTC_OVERLAY_FILE=ds2484.overlay OVERLAY_CONFIG=ds2484.conf
+    extra_args: DTC_OVERLAY_FILE=ds2484.overlay
     platform_allow: nrf52840dk_nrf52840
     harness_config:
       type: one_line
@@ -16,7 +16,7 @@ tests:
       fixture: w1_scanner_ds2484
   samples.drivers.w1.scanner.w1_serial:
     depends_on: arduino_serial
-    extra_args: DTC_OVERLAY_FILE=w1_serial.overlay OVERLAY_CONFIG=w1_serial.conf
+    extra_args: DTC_OVERLAY_FILE=w1_serial.overlay
     platform_allow: nrf52840dk_nrf52840
     harness_config:
       type: one_line

--- a/samples/drivers/w1/scanner/w1_serial.conf
+++ b/samples/drivers/w1/scanner/w1_serial.conf
@@ -1,1 +1,0 @@
-CONFIG_SERIAL=y

--- a/tests/drivers/w1/w1_api/i2c.conf
+++ b/tests/drivers/w1/w1_api/i2c.conf
@@ -1,1 +1,0 @@
-CONFIG_I2C=y

--- a/tests/drivers/w1/w1_api/serial.conf
+++ b/tests/drivers/w1/w1_api/serial.conf
@@ -1,1 +1,0 @@
-CONFIG_SERIAL=y

--- a/tests/drivers/w1/w1_api/testcase.yaml
+++ b/tests/drivers/w1/w1_api/testcase.yaml
@@ -5,13 +5,13 @@ common:
 tests:
   drivers.w1.w1-serial:
     depends_on: arduino_serial
-    extra_args: DTC_OVERLAY_FILE=w1_serial.overlay OVERLAY_CONFIG=serial.conf
+    extra_args: DTC_OVERLAY_FILE=w1_serial.overlay
     platform_allow: nucleo_g0b1re nrf52840dk_nrf52840
     harness_config:
       fixture: w1_serial_idle
   drivers.w1.ds2484:
     depends_on: arduino_i2c
-    extra_args: DTC_OVERLAY_FILE=ds2484.overlay OVERLAY_CONFIG=i2c.conf
+    extra_args: DTC_OVERLAY_FILE=ds2484.overlay
     platform_allow: nrf52840dk_nrf52840
     harness_config:
       fixture: w1_ds2484_idle


### PR DESCRIPTION
After Sensors have moved to selecting the bus they depend on, do this also for the zephyr-serial 1-wire driver.

As the bus dependencies are now already enabled, some overlays can be removed from the sample and the test.

Follow-up to #48980