### PR TITLE
boards: riscv: litex_vexriscv: doc: add arty-a7-100t support

### DIFF
--- a/boards/riscv/litex_vexriscv/doc/index.rst
+++ b/boards/riscv/litex_vexriscv/doc/index.rst
@@ -16,7 +16,7 @@ vendor-specific and open-source tools, including the
 
 The ``litex_vexriscv`` board configuration in Zephyr is meant for the
 LiteX VexRiscv SoC implementation generated for the
-`Digilent Arty A7-35T Development Board
+`Digilent Arty A7-35T or A7-100T Development Boards
 <https://store.digilentinc.com/arty-a7-artix-7-fpga-development-board-for-makers-and-hobbyists>`_.
 
 .. image:: img/litex_vexriscv.jpg
@@ -77,18 +77,28 @@ proceed with the following instruction:
       apt-get install build-essential bzip2 python3 python3-dev python3-pip
       ./install.sh
 
-#. Generate the bitstream:
+#. Set up the Arty F4PGA environment:
 
    .. code-block:: bash
 
       source ./init
-      export INSTALL_DIR="path/to/f4pga"
-      FPGA_FAM="xc7"
-      export PATH="$INSTALL_DIR/$FPGA_FAM/install/bin:$PATH";
-      source "$INSTALL_DIR/$FPGA_FAM/conda/etc/profile.d/conda.sh"
+      export F4PGA_INSTALL_DIR=~/opt/f4pga
+      export FPGA_FAM="xc7"
+      export PATH="$F4PGA_INSTALL_DIR/$FPGA_FAM/install/bin:$PATH";
+      source "$F4PGA_INSTALL_DIR/$FPGA_FAM/conda/etc/profile.d/conda.sh"
       conda activate $FPGA_FAM
-      ./make.py --board=arty --build --toolchain=symbiflow
 
+#. Generate the bitstream for the Arty 35T:
+
+   .. code-block:: bash
+
+      ./make.py --board=arty --variant=a7-35 --build --toolchain=symbiflow
+
+#. Generate the bitstream for the Arty 100T:
+
+   .. code-block:: bash
+
+      ./make.py --board=arty --variant=a7-100 --build --toolchain=symbiflow
 
 Official LiteX SoC builder
 ==========================
@@ -142,11 +152,16 @@ If you were generating bitstream with the official LiteX SoC builder you need to
 Booting
 =======
 
-To upload bitstream you can use `xc3sprog <https://github.com/matrix-io/xc3sprog>`_:
+To upload the bitstream you can use `xc3sprog <https://github.com/matrix-io/xc3sprog>`_ or
+`openFPGALoader <https://github.com/trabucayre/openFPGALoader>`_:
 
 .. code-block:: bash
 
    xc3sprog -c nexys4 digilent_arty.bit
+
+.. code-block:: bash
+
+   openFPGALoader -b arty_a7_100t digilent_arty.bit
 
 You can boot from a serial port using litex_term (replace `ttyUSBX` with your device) , e.g.:
 


### PR DESCRIPTION
Add documentation for the arty-a7-100t variant of the popular Arty board.

Fixes #49044

Depends on https://github.com/litex-hub/zephyr-on-litex-vexriscv/pull/10