### PR TITLE
drivers: ds2484: Fix wrong early exit during suspend/resume

### DIFF
--- a/drivers/w1/w1_ds2484.c
+++ b/drivers/w1/w1_ds2484.c
@@ -91,18 +91,16 @@ static int ds2484_pm_control(const struct device *dev, enum pm_device_action act
 
 	switch (action) {
 	case PM_DEVICE_ACTION_SUSPEND:
-		if (config->slpz_spec.port) {
+		if (!config->slpz_spec.port) {
 			return -ENOTSUP;
 		}
 		return gpio_pin_set_dt(&config->slpz_spec, 1);
 	case PM_DEVICE_ACTION_RESUME:
-		if (config->slpz_spec.port) {
+		if (!config->slpz_spec.port) {
 			return -ENOTSUP;
 		}
 		return gpio_pin_set_dt(&config->slpz_spec, 0);
-	case PM_DEVICE_ACTION_TURN_OFF:
-	case PM_DEVICE_ACTION_TURN_ON:
-	case PM_DEVICE_ACTION_FORCE_SUSPEND:
+	default:
 		return -ENOTSUP;
 	};
 


### PR DESCRIPTION
The sleep pin is optional and the driver checks for availability during
runtime. Currently the logic is inverted and therefore the driver exits
early if the pin is actually available. This pr fixes this behavior.

Also: Add `fallthrough` flags to switch/case

Signed-off-by: Caspar Friedrich <c.s.w.friedrich@gmail.com>