### PR TITLE
ITE: enable CPU_HAS_FPU for IT8xxx2

### DIFF
--- a/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
+++ b/soc/riscv/riscv-ite/it8xxx2/Kconfig.series
@@ -4,10 +4,9 @@
 config SOC_SERIES_RISCV32_IT8XXX2
 	bool "ITE IT8XXX2 implementation"
 	#depends on RISCV
-	# TODO:
-	# Error of can't link soft-float modules with single-float modules.
-	# No library built with -mabi=ilp32f -march=rv32iafc?
-	select CPU_HAS_FPU if RISCV_ISA_EXT_M
+	# RV32IAFC is an uncommon configuration which is not supported by
+	# default in most toolchains, causing link-time errors.
+	select CPU_HAS_FPU if "$(ZEPHYR_TOOLCHAIN_VARIANT)" != "zephyr" || RISCV_ISA_EXT_M
 	select SOC_FAMILY_RISCV_ITE
 	help
 	    Enable support for ITE IT8XXX2


### PR DESCRIPTION
This option was previously enabled only if the M extension was
available, because typical compilers do not provide internal libraries
for RV32IAFC so builds fail at link-time. An appropriately-configured
compiler (such as GCC configured with
`--with-multilib-generator=rv32iac-ilp32--f`) can support such a build
however, so don't lie about the presence of an FPU.

This doesn't affect existing builds because CONFIG_FPU gates use of the
FPU, and is off by default. Enabling CONFIG_FPU will require an
appropriately-configured compiler, possibly also requiring careful
choice of CONFIG_FLOAT_HARD.

Signed-off-by: Peter Marheine <pmarheine@chromium.org>