### PR TITLE
boards: tlsr9518adk80d: Disable testing due to invalid linker script

### DIFF
--- a/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
+++ b/boards/riscv/tlsr9518adk80d/tlsr9518adk80d.yaml
@@ -4,7 +4,10 @@ type: mcu
 arch: riscv32
 toolchain:
   - cross-compile
-  - zephyr
+  # FIXME: This platform is broken due to the incorrect linker script and
+  #        cannot be compiled using the current version of the Zephyr SDK. For
+  #        more details, refer to the GitHub issue #49036.
+  # - zephyr
 ram: 128
 flash: 1024
 supported:


### PR DESCRIPTION
This commit disables testing for the `tlsr9518adk80d` platform because
it contains an invalid linker script (overlapping memory region) and
cannot be compiled using the current version of the Zephyr SDK (0.15.0
at the time of making this change).

Revert this commit to re-enable testing for this platform once the
GitHub issue #49036 is fixed.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

**NOTE: This is to be merged after the Zephyr SDK 0.15.0 is mainlined and the minimum required Zephyr SDK version is updated to 0.15.0.**
NOTE2: This PR should be closed if #49036 is fixed before the Zephyr SDK 0.15.0 is mainlined.