### PR TITLE
doc: remove BUILD_ALWAYS True from sysbuild documentation

### DIFF
--- a/doc/build/sysbuild/index.rst
+++ b/doc/build/sysbuild/index.rst
@@ -406,7 +406,6 @@ as the main image, use this example:
    ExternalZephyrProject_Add(
      APPLICATION my_sample
      SOURCE_DIR <path-to>/my_sample
-     BUILD_ALWAYS True
    )
 
 This could be useful, for example, if your board requires you to build and flash an
@@ -433,7 +432,6 @@ a CMake function call that is structured as follows:
      APPLICATION my_sample
      SOURCE_DIR <path-to>/my_sample
      BOARD mps2_an521_remote
-     BUILD_ALWAYS True
    )
 
 This could be useful, for example, if your main application requires another
@@ -467,7 +465,6 @@ In the previous example, :file:`sysbuild.cmake` would be structured as follows:
      ExternalZephyrProject_Add(
        APPLICATION second_sample
        SOURCE_DIR <path-to>/second_sample
-       BUILD_ALWAYS True
      )
    endif()
 


### PR DESCRIPTION
The examples showing how to include an extra Zephyr project into the
build wrongly used `BUILD_ALWAYS True`.

The `ExternalZephyrProject_Add()` already adds this flag implicit to
ensure Zephyr based projects are always built correctly.

Thus remove the flag in the doc example as it is wrong and causes CMake
error if users tries to pass on this flag.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>