### PR TITLE
cmake: Set GCC min-pagesize parameter to 0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,13 @@ if(NOT CMAKE_C_COMPILER_ID STREQUAL "Clang")
   # GCC assumed
   zephyr_cc_option(-fno-reorder-functions)
 
+  # GCC 11 and above may generate a warning when dereferencing a constant
+  # address pointer whose address is below the value specified by the
+  # `min-pagesize` parameter (defaults to 0x1000). The `min-pagesize` parameter
+  # is set to 0 such that GCC never generates any warnings for the constant
+  # address pointers. For more details, refer to the GCC PR99578.
+  zephyr_cc_option(--param=min-pagesize=0)
+
   if(NOT ${ZEPHYR_TOOLCHAIN_VARIANT} STREQUAL "xcc")
     zephyr_cc_option(-fno-defer-pop)
   endif()


### PR DESCRIPTION
GCC 11 and above may generate a warning when dereferencing a constant
address pointer whose address is below the value specified by the
`min-pagesize` parameter.

This commit sets the `min-pagesize` parameter to 0 such that GCC never
generates the warnings for any constant address pointers.

For more details, refer to the GCC PR99578.

Signed-off-by: Stephanos Ioannidis <root@stephanos.io>

GCC PR99578: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578

p.s. This is a no-op for GCC versions < 11 because `min-pagesize` parameter is not supported by them and will be automatically omitted.