### PR TITLE
ARC: Check that ISR and exception stacks are proper aligned

### DIFF
--- a/include/zephyr/arch/arc/arch.h
+++ b/include/zephyr/arch/arc/arch.h
@@ -89,6 +89,12 @@ extern "C" {
 #define ARCH_STACK_PTR_ALIGN	4
 #endif /* CONFIG_64BIT */
 
+BUILD_ASSERT(CONFIG_ISR_STACK_SIZE % ARCH_STACK_PTR_ALIGN == 0,
+	"CONFIG_ISR_STACK_SIZE must be a multiple of ARCH_STACK_PTR_ALIGN");
+
+BUILD_ASSERT(CONFIG_ARC_EXCEPTION_STACK_SIZE % ARCH_STACK_PTR_ALIGN == 0,
+	"CONFIG_ARC_EXCEPTION_STACK_SIZE must be a multiple of ARCH_STACK_PTR_ALIGN");
+
 /* Indicate, for a minimally sized MPU region, how large it must be and what
  * its base address must be aligned to.
  *


### PR DESCRIPTION
`CONFIG_ISR_STACK_SIZE` and `CONFIG_ARC_EXCEPTION_STACK_SIZE` are used in arc asembler code without C wrapper on them with following manner:

```
#define INIT_STACK z_interrupt_stacks
#define INIT_STACK_SIZE CONFIG_ISR_STACK_SIZE

	mov_s sp, INIT_STACK
	add sp, sp, INIT_STACK_SIZE
```

In result we can get stack unaligned if we have `CONFIG_ISR_STACK_SIZE` or `CONFIG_ARC_EXCEPTION_STACK_SIZE`
values unaligned. 

There is no point to have unaligned stack size - so let's check against such configurations in compile time.

Fixes: #37704 