### PR TITLE
samples: sensor: Fix displayed gyro units in lsm6dso sample

### DIFF
--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -36,7 +36,7 @@ static void fetch_and_display(const struct device *dev)
 	sensor_channel_get(dev, SENSOR_CHAN_GYRO_Y, &y);
 	sensor_channel_get(dev, SENSOR_CHAN_GYRO_Z, &z);
 
-	printf("gyro x:%f dps y:%f dps z:%f dps\n",
+	printf("gyro x:%f rad/s y:%f rad/s z:%f rad/s\n",
 			out_ev(&x), out_ev(&y), out_ev(&z));
 
 	printf("trig_cnt:%d\n\n", trig_cnt);


### PR DESCRIPTION
The sensor driver API specifies gyroscope units in radians/second, not
degrees/second. Fix the lsm6dso sample application printk string to
display the correct units.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #46234