### PR TITLE
Dai misc additions

### DIFF
--- a/drivers/dai/intel/alh/alh.c
+++ b/drivers/dai/intel/alh/alh.c
@@ -180,7 +180,11 @@ static const struct dai_driver_api dai_intel_alh_api_funcs = {
 };
 
 #define DAI_INTEL_ALH_DEVICE_INIT(n)						\
-	static struct dai_config dai_intel_alh_config_##n;			\
+	static struct dai_config dai_intel_alh_config_##n = {			\
+		.type = DAI_INTEL_ALH,						\
+		.dai_index = (n / DAI_NUM_ALH_BI_DIR_LINKS_GROUP) << 8 |	\
+			(n % DAI_NUM_ALH_BI_DIR_LINKS_GROUP),			\
+	};									\
 	static struct dai_intel_alh dai_intel_alh_data_##n = {			\
 		.index = (n / DAI_NUM_ALH_BI_DIR_LINKS_GROUP) << 8 |		\
 			(n % DAI_NUM_ALH_BI_DIR_LINKS_GROUP),			\

--- a/drivers/dai/intel/dmic/dmic.c
+++ b/drivers/dai/intel/dmic/dmic.c
@@ -631,7 +631,7 @@ static const struct dai_config *dai_dmic_get_config(const struct device *dev, en
 {
 	struct dai_intel_dmic *dmic = (struct dai_intel_dmic *)dev->data;
 
-	__ASSERT_NO_MSG(dir == DAI_DIR_CAPTURE);
+	__ASSERT_NO_MSG(dir == DAI_DIR_RX);
 	return &dmic->dai_config_params;
 }
 

--- a/drivers/dai/intel/ssp/ssp.c
+++ b/drivers/dai/intel/ssp/ssp.c
@@ -1829,6 +1829,9 @@ static const struct dai_config *dai_ssp_config_get(const struct device *dev, enu
 	struct dai_intel_ssp *dp = (struct dai_intel_ssp *)dev->data;
 	struct dai_intel_ssp_pdata *ssp = dai_get_drvdata(dp);
 
+	if (!ssp)
+		return params;
+
 	params->rate = ssp->params.fsync_rate;
 
 	if (dir == DAI_DIR_PLAYBACK) {
@@ -1991,7 +1994,10 @@ static struct dai_intel_ssp_mn ssp_mn_divider = {
 static const char irq_name_level5_z[] = "level5";
 
 #define DAI_INTEL_SSP_DEVICE_INIT(n)						\
-	static struct dai_config dai_intel_ssp_config_##n;			\
+	static struct dai_config dai_intel_ssp_config_##n = {			\
+		.type = DAI_INTEL_SSP,						\
+		.dai_index = n,							\
+	};									\
 	static struct dai_intel_ssp dai_intel_ssp_data_##n = {			\
 		.index = n,							\
 		.plat_data = {							\


### PR DESCRIPTION
Add dai indexes and types to ssp and alh configs. These can be used in app for runtime device match when dts Labels are removed. see https://github.com/thesofproject/sof/pull/6132. Also fix dmic enum.