### PR TITLE
console: uart_mux: uart_mux_send to return number of bytes sent

### DIFF
--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -787,6 +787,7 @@ const struct device *z_impl_uart_mux_find(int dlci_address)
 int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size)
 {
 	struct uart_mux_dev_data *dev_data = uart->data;
+	size_t remaining = size;
 
 	if (size == 0) {
 		return 0;
@@ -808,11 +809,11 @@ int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size)
 
 	do {
 		uart_poll_out(dev_data->real_uart->uart, *buf++);
-	} while (--size);
+	} while (--remaining);
 
 	k_mutex_unlock(&dev_data->real_uart->lock);
 
-	return 0;
+	return size;
 }
 
 int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,

--- a/drivers/console/uart_mux_internal.h
+++ b/drivers/console/uart_mux_internal.h
@@ -18,7 +18,7 @@ extern "C" {
  * @param buf Data to send
  * @param size Data length
  *
- * @return 0 if data was sent, <0 if error
+ * @return >=0 if data was sent (and number of bytes sent), <0 if error
  */
 int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size);
 


### PR DESCRIPTION
This changes the return value of uart_mux_send() to return
how many bytes sent instead of simply zero for any bytes sent.
This would make it consistent with other UART send commands where
they return number of bytes sent.

Fixes #48470

Signed-off-by: Daniel Leung <daniel.leung@intel.com>