### PR TITLE
drivers: sensor: Fix apds9960 device pointer initialization

### DIFF
--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -377,9 +377,10 @@ static int apds9960_init_interrupt(const struct device *dev)
 		return -EIO;
 	}
 
+	drv_data->dev = dev;
+
 #ifdef CONFIG_APDS9960_TRIGGER
 	drv_data->work.handler = apds9960_work_cb;
-	drv_data->dev = dev;
 	if (i2c_reg_update_byte_dt(&config->i2c,
 				APDS9960_ENABLE_REG,
 				APDS9960_ENABLE_PON,
@@ -391,7 +392,7 @@ static int apds9960_init_interrupt(const struct device *dev)
 #else
 	k_sem_init(&drv_data->data_sem, 0, K_SEM_MAX_LIMIT);
 #endif
-	apds9960_setup_int(drv_data->dev->config, true);
+	apds9960_setup_int(config, true);
 
 	if (gpio_pin_get_dt(&config->int_gpio) > 0) {
 		apds9960_handle_cb(drv_data);


### PR DESCRIPTION
Fixes a bus fault observed in samples/boards/reel_board/mesh_badge
caused by dereferencing an uninitialized device pointer in the apds9960
sensor driver. The device pointer needs to be initialized regardless of
how CONFIG_APDS9960_TRIGGER is configured.

Signed-off-by: Maureen Helm <maureen.helm@intel.com>

Fixes #46962
cc: @ruscur