### PR TITLE
lib: os: cbprintf: fix typo exteral -> external

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -278,8 +278,8 @@ typedef int (*cbprintf_convert_cb)(const void *buf, size_t len, void *ctx);
  * @return vprintf like return values: the number of characters printed,
  * or a negative error value returned from external formatter.
  */
-typedef int (*cbvprintf_exteral_formatter_func)(cbprintf_cb out, void *ctx,
-						const char *fmt, va_list ap);
+typedef int (*cbvprintf_external_formatter_func)(cbprintf_cb out, void *ctx,
+						 const char *fmt, va_list ap);
 
 /** @brief Determine if string must be packaged in run time.
  *
@@ -596,7 +596,7 @@ static inline int cbprintf_fsc_package(void *in_packaged,
  * or a negative error value returned from external formatter.
  */
 int cbpprintf_external(cbprintf_cb out,
-		       cbvprintf_exteral_formatter_func formatter,
+		       cbvprintf_external_formatter_func formatter,
 		       void *ctx,
 		       void *packaged);
 

--- a/lib/os/cbprintf_packaged.c
+++ b/lib/os/cbprintf_packaged.c
@@ -46,7 +46,7 @@ static inline bool ptr_in_rodata(const char *addr)
 
 #if defined(__CHECKER__)
 static int cbprintf_via_va_list(cbprintf_cb out,
-				cbvprintf_exteral_formatter_func formatter,
+				cbvprintf_external_formatter_func formatter,
 				void *ctx,
 				const char *fmt, void *buf)
 {
@@ -71,7 +71,7 @@ BUILD_ASSERT(sizeof(va_list) == sizeof(struct __va_list),
 	     "architecture specific support is wrong");
 
 static int cbprintf_via_va_list(cbprintf_cb out,
-				cbvprintf_exteral_formatter_func formatter,
+				cbvprintf_external_formatter_func formatter,
 				void *ctx,
 				const char *fmt, void *buf)
 {
@@ -109,7 +109,7 @@ BUILD_ASSERT(sizeof(va_list) == sizeof(struct __va_list),
 	     "architecture specific support is wrong");
 
 static int cbprintf_via_va_list(cbprintf_cb out,
-				cbvprintf_exteral_formatter_func formatter,
+				cbvprintf_external_formatter_func formatter,
 				void *ctx,
 				const char *fmt, void *buf)
 {
@@ -146,7 +146,7 @@ BUILD_ASSERT(sizeof(va_list) == sizeof(struct __va_list),
 	     "architecture specific support is wrong");
 
 static int cbprintf_via_va_list(cbprintf_cb out,
-				cbvprintf_exteral_formatter_func formatter,
+				cbvprintf_external_formatter_func formatter,
 				void *ctx,
 				const char *fmt, void *buf)
 {
@@ -175,7 +175,7 @@ BUILD_ASSERT(sizeof(va_list) == sizeof(void *),
 	     "architecture specific support is needed");
 
 static int cbprintf_via_va_list(cbprintf_cb out,
-				cbvprintf_exteral_formatter_func formatter,
+				cbvprintf_external_formatter_func formatter,
 				void *ctx,
 				const char *fmt, void *buf)
 {
@@ -811,7 +811,7 @@ int cbprintf_package(void *packaged, size_t len, uint32_t flags,
 }
 
 int cbpprintf_external(cbprintf_cb out,
-		       cbvprintf_exteral_formatter_func formatter,
+		       cbvprintf_external_formatter_func formatter,
 		       void *ctx, void *packaged)
 {
 	uint8_t *buf = packaged;


### PR DESCRIPTION
The cbprintf formatter cbvprintf_exteral_formatter_func has a typo
in it with a missing 'n'. So add it.

Signed-off-by: Daniel Leung <daniel.leung@intel.com>