### PR TITLE
tests/kernel/context: don't do print in time-critical section

### DIFF
--- a/tests/kernel/context/src/main.c
+++ b/tests/kernel/context/src/main.c
@@ -850,17 +850,13 @@ static void busy_wait_thread(void *mseconds, void *arg2, void *arg3)
 
 	usecs = POINTER_TO_INT(mseconds) * 1000;
 
-	TC_PRINT("Thread busy waiting for %d usecs\n", usecs);
 	k_busy_wait(usecs);
-	TC_PRINT("Thread busy waiting completed\n");
 
 	/* FIXME: Broken on Nios II, see #22956 */
 #ifndef CONFIG_NIOS2
 	int key = arch_irq_lock();
 
-	TC_PRINT("Thread busy waiting for %d usecs (irqs locked)\n", usecs);
 	k_busy_wait(usecs);
-	TC_PRINT("Thread busy waiting completed (irqs locked)\n");
 	arch_irq_unlock(key);
 #endif
 
@@ -889,11 +885,9 @@ static void thread_sleep(void *delta, void *arg2, void *arg3)
 	ARG_UNUSED(arg2);
 	ARG_UNUSED(arg3);
 
-	TC_PRINT(" thread sleeping for %d milliseconds\n", timeout);
 	timestamp = k_uptime_get();
 	k_msleep(timeout);
 	timestamp = k_uptime_get() - timestamp;
-	TC_PRINT(" thread back from sleep\n");
 
 	int slop = MAX(k_ticks_to_ms_floor64(2), 1);
 


### PR DESCRIPTION
In `test_busy_wait` and `test_k_sleep` test cases of `tests/kernel/context` test we measure not only execution time of the
primitives itself (`k_busy_wait` and `k_msleep` respectively) but also the overall test thread execution time.

The issue here is that we do printing in test threads which means that we do printing in time-critical sections. That breaks test if we do printing via some device which isn't fast enough.

Fix that by removing print from time-critical section