### PR TITLE
boards: arm: rak4631_nrf52840: sx1262 dio1-gpios setup change

### DIFF
--- a/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
+++ b/boards/arm/rak4631_nrf52840/rak4631_nrf52840.dts
@@ -110,7 +110,7 @@
 		busy-gpios = <&gpio1 14 GPIO_ACTIVE_HIGH>;
 		tx-enable-gpios = <&gpio1 7 GPIO_ACTIVE_LOW>;
 		rx-enable-gpios = <&gpio1 5 GPIO_ACTIVE_LOW>;
-		dio1-gpios = <&gpio1 15 GPIO_ACTIVE_LOW>;
+		dio1-gpios = <&gpio1 15 GPIO_ACTIVE_HIGH>;
 		dio2-tx-enable;
 		dio3-tcxo-voltage = <SX126X_DIO3_TCXO_3V3>;
 		tcxo-power-startup-delay-ms = <5>;


### PR DESCRIPTION
Change on rak4631_nrf52840 devicetree dio1-gpios definition to properly interface with sx1262 lorawan chipset.
Fixes: #49047