### PR TITLE
A couple of toolchain TLS fixes

### DIFF
--- a/cmake/toolchain/cross-compile/Kconfig
+++ b/cmake/toolchain/cross-compile/Kconfig
@@ -1,0 +1,9 @@
+# Copyright © 2022 Keith Packard
+# SPDX-License-Identifier: Apache-2.0
+
+config TOOLCHAIN_CROSS_COMPILE_SUPPORTS_THREAD_LOCAL_STORAGE
+	bool "Cross-compile toolchain supports TLS"
+	select TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE
+	help
+	  Set this if the cross-compile toolchain being used for the build
+	  supports thread local storage.

--- a/cmake/toolchain/xtools/Kconfig
+++ b/cmake/toolchain/xtools/Kconfig
@@ -1,0 +1,6 @@
+# Copyright © 2022 Keith Packard
+# SPDX-License-Identifier: Apache-2.0
+
+config TOOLCHAIN_XTOOLS_SUPPORTS_THREAD_LOCAL_STORAGE
+	def_bool y
+	select TOOLCHAIN_SUPPORTS_THREAD_LOCAL_STORAGE


### PR DESCRIPTION
The first recognizes that crosstool-ng enables TLS by default, and so Zephyr should at least allow TLS to be enabled when building with it.

The second patch allows any toolchain used with the 'cross-compile' variant to be configured to support thread local storage (disabled by default).

With these two patches, I am able to build Zephyr projects using the 'arm-none-eabi' sample configuration provided with crosstool-ng (save for GCC 12 issues, of course), the Debian arm-none-eabi toolchain and the regular Zephyr arm-zephyr-eabi crosstools-ng toolchain.