### PR TITLE
Fix minor C++ compiler issues with certain macros

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -5443,7 +5443,9 @@ struct k_poll_event {
 
 #define K_POLL_EVENT_INITIALIZER(_event_type, _event_mode, _event_obj) \
 	{ \
+	._node = {}, \
 	.poller = NULL, \
+	.tag = 0, \
 	.type = _event_type, \
 	.state = K_POLL_STATE_NOT_READY, \
 	.mode = _event_mode, \
@@ -5456,6 +5458,8 @@ struct k_poll_event {
 #define K_POLL_EVENT_STATIC_INITIALIZER(_event_type, _event_mode, _event_obj, \
 					event_tag) \
 	{ \
+	._node = {}, \
+	.poller = NULL, \
 	.tag = event_tag, \
 	.type = _event_type, \
 	.state = K_POLL_STATE_NOT_READY, \

--- a/include/zephyr/logging/log_backend.h
+++ b/include/zephyr/logging/log_backend.h
@@ -110,7 +110,7 @@ extern const struct log_backend __log_backends_end[];
 	static struct log_backend_control_block UTIL_CAT(backend_cb_, _name) = \
 	{								       \
 		COND_CODE_0(NUM_VA_ARGS_LESS_1(_, ##__VA_ARGS__),	       \
-				(), (.ctx = __VA_ARGS__,))		       \
+				(.ctx = NULL,), (.ctx = __VA_ARGS__,))	       \
 		.id = 0,						       \
 		.active = false,					       \
 	};								       \


### PR DESCRIPTION
Some C++ compilers complain if a struct is initialized with missing fields.