### PR TITLE
drivers: can: expand return values reported by the CAN timing functions

### DIFF
--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -88,9 +88,7 @@ static int can_calc_timing_int(uint32_t core_clock, struct can_timing *res,
 	int sp_err;
 	struct can_timing tmp_res;
 
-	if (bitrate == 0 || sp >= 1000 ||
-	    (!IS_ENABLED(CONFIG_CAN_FD_MODE) && bitrate > 1000000) ||
-	     (IS_ENABLED(CONFIG_CAN_FD_MODE) && bitrate > 8000000)) {
+	if (bitrate == 0 || sp >= 1000) {
 		return -EINVAL;
 	}
 
@@ -139,6 +137,10 @@ int z_impl_can_calc_timing(const struct device *dev, struct can_timing *res,
 	uint32_t core_clock;
 	int ret;
 
+	if (bitrate > 1000000) {
+		return -EINVAL;
+	}
+
 	ret = can_get_core_clock(dev, &core_clock);
 	if (ret != 0) {
 		return ret;
@@ -155,6 +157,10 @@ int z_impl_can_calc_timing_data(const struct device *dev, struct can_timing *res
 	const struct can_timing *max = can_get_timing_data_max(dev);
 	uint32_t core_clock;
 	int ret;
+
+	if (bitrate > 8000000) {
+		return -EINVAL;
+	}
 
 	ret = can_get_core_clock(dev, &core_clock);
 	if (ret != 0) {

--- a/drivers/can/can_common.c
+++ b/drivers/can/can_common.c
@@ -125,9 +125,8 @@ static int can_calc_timing_int(uint32_t core_clock, struct can_timing *res,
 		LOG_DBG("SP error: %d 1/1000", sp_err_min);
 	}
 
-	return sp_err_min == UINT16_MAX ? -EINVAL : (int)sp_err_min;
+	return sp_err_min == UINT16_MAX ? -ENOTSUP : (int)sp_err_min;
 }
-
 
 int z_impl_can_calc_timing(const struct device *dev, struct can_timing *res,
 			   uint32_t bitrate, uint16_t sample_pnt)
@@ -235,11 +234,11 @@ int z_impl_can_set_bitrate(const struct device *dev, uint32_t bitrate)
 	sample_pnt = sample_point_for_bitrate(bitrate);
 	ret = can_calc_timing(dev, &timing, bitrate, sample_pnt);
 	if (ret < 0) {
-		return -EINVAL;
+		return ret;
 	}
 
 	if (ret > SAMPLE_POINT_MARGIN) {
-		return -EINVAL;
+		return -ERANGE;
 	}
 
 	timing.sjw = CAN_SJW_NO_CHANGE;
@@ -270,11 +269,11 @@ int z_impl_can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data)
 	sample_pnt = sample_point_for_bitrate(bitrate_data);
 	ret = can_calc_timing_data(dev, &timing_data, bitrate_data, sample_pnt);
 	if (ret < 0) {
-		return -EINVAL;
+		return ret;
 	}
 
 	if (ret > SAMPLE_POINT_MARGIN) {
-		return -EINVAL;
+		return -ERANGE;
 	}
 
 	timing_data.sjw = CAN_SJW_NO_CHANGE;

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -723,7 +723,8 @@ static inline const struct can_timing *z_impl_can_get_timing_max(const struct de
  * @param sample_pnt Sampling point in permill of the entire bit time.
  *
  * @retval 0 or positive sample point error on success.
- * @retval -EINVAL if there is no solution for the desired values.
+ * @retval -EINVAL if the requested bitrate or sample point is out of range.
+ * @retval -ENOTSUP if the requested bitrate is not supported.
  * @retval -EIO if @a can_get_core_clock() is not available.
  */
 __syscall int can_calc_timing(const struct device *dev, struct can_timing *res,
@@ -792,7 +793,8 @@ static inline const struct can_timing *z_impl_can_get_timing_data_max(const stru
  * @param sample_pnt Sampling point for the data phase in permille of the entire bit time.
  *
  * @retval 0 or positive sample point error on success.
- * @retval -EINVAL if there is no solution for the desired values.
+ * @retval -EINVAL if the requested bitrate or sample point is out of range.
+ * @retval -ENOTSUP if the requested bitrate is not supported.
  * @retval -EIO if @a can_get_core_clock() is not available.
  */
 __syscall int can_calc_timing_data(const struct device *dev, struct can_timing *res,
@@ -848,8 +850,10 @@ static inline int z_impl_can_set_timing_data(const struct device *dev,
  * @param bitrate_data Desired data phase bitrate.
  *
  * @retval 0 If successful.
- * @retval -ENOTSUP bitrate not supported by CAN controller/transceiver combination
- * @retval -EINVAL bitrate/sample point cannot be met.
+ * @retval -EINVAL if the requested bitrate is out of range.
+ * @retval -ENOTSUP if the requested bitrate not supported by the CAN controller/transceiver
+ *                  combination.
+ * @retval -ERANGE if the resulting sample point is off by more than +/- 5%.
  * @retval -EIO General input/output error, failed to set bitrate.
  */
 __syscall int can_set_bitrate_data(const struct device *dev, uint32_t bitrate_data);
@@ -960,8 +964,10 @@ static inline int z_impl_can_set_mode(const struct device *dev, can_mode_t mode)
  * @param bitrate      Desired arbitration phase bitrate.
  *
  * @retval 0 If successful.
- * @retval -ENOTSUP bitrate not supported by CAN controller/transceiver combination
- * @retval -EINVAL bitrate/sample point cannot be met.
+ * @retval -EINVAL if the requested bitrate is out of range.
+ * @retval -ENOTSUP if the requested bitrate not supported by the CAN controller/transceiver
+ *                  combination.
+ * @retval -ERANGE if the resulting sample point is off by more than +/- 5%.
  * @retval -EIO General input/output error, failed to set bitrate.
  */
 __syscall int can_set_bitrate(const struct device *dev, uint32_t bitrate);


### PR DESCRIPTION
Expand the error return values reported by the CAN timing calculation functions to be able to distinguish between an out of range bitrate/sample point, an unsupported bitrate, and a resulting sample point outside the guard limit.

Move the check for the maximum allowed CAN bitrate to the corresponding can_calc_timing()/can_calc_timing_data() function.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>