### PR TITLE
doc: mec15xxevb_assy6853: Add notes for testing I2C

### DIFF
--- a/boards/arm/mec15xxevb_assy6853/doc/index.rst
+++ b/boards/arm/mec15xxevb_assy6853/doc/index.rst
@@ -426,6 +426,24 @@ Troubleshooting
 
 #. If Dediprog can't detect the onboard flash, press the board's Reset button and try again.
 
+Notes
+=====
+#. To enable PCA9555PW and test the I2C on mec15xxevb_assy6853, additional works are needed:
+
+   As the I2C slave device NXP pca95xx on mec15xxevb_assy6853 is connected to I2C00 port,
+   however, I2C00 port is shared with UART2 RS232 to TTL converter used to catch serial log,
+   so it's not possible to use UART2 and I2C00 port simultaneously. We need to change to use
+   I2C01 port by making some jumpers setting as below:
+
+ * JP99         1-2     Connected       Connect I2C01_SDA from CPU to header J5
+ * JP99         13-14   Connected       Connect I2C01_SCL from CPU to header J5
+ * JP25         21-22   Connected       External pull-up for I2C01_SDA
+ * JP25         23-24   Connected       External pull-up for I2C01_SCL
+ *
+ * JP44.1       J5.1    Connected       Connect NXP PCA95xx to I2C01
+ * JP44.3       J5.3    Connected       Connect NXP PCA95xx to I2C01
+
+
 References
 **********
 .. target-notes::


### PR DESCRIPTION
Describes the Connectors/Jumpers of testing the PCA9555 on I2C1

Signed-off-by: Hu Zhenyu <zhenyu.hu@intel.com>