### PR TITLE
[DNM] Revert "boards: arm: nrf: Enable uart workaround for nrf9160dk and nrf5340dk"

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -99,6 +99,3 @@ config BT_CTLR
 	default y if BT
 
 endif # BOARD_NRF5340DK_NRF5340_CPUNET
-
-config UART_NRF_DK_SERIAL_WORKAROUND
-	default y if ZTEST

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -63,6 +63,3 @@ config I2C
 	default $(dt_compat_on_bus,$(DT_COMPAT_NXP_PCAL6408A),i2c)
 
 endif # BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160_NS
-
-config UART_NRF_DK_SERIAL_WORKAROUND
-	default y if ZTEST


### PR DESCRIPTION
DNM. Test to see an impact on the hw testing. 

This reverts commit 681244109946f788792d6a1e82f0a24117ed0995.