### PR TITLE
net: lwm2m: API for multiple resource writing

### DIFF
--- a/doc/connectivity/networking/api/lwm2m.rst
+++ b/doc/connectivity/networking/api/lwm2m.rst
@@ -411,6 +411,24 @@ value of 1 is ok here).
 
 For a more detailed LwM2M client sample see: :ref:`lwm2m-client-sample`.
 
+Multi-thread usage
+******************
+Writing a value to a resource can be done using functions like lwm2m_engine_set_u8. When writing
+to multiple resources, the function lwm2m_registry_lock will ensure that the
+client halts until all writing operations are finished:
+
+.. code-block:: c
+
+  lwm2m_registry_lock();
+  lwm2m_engine_set_u32("1/0/1", 60);
+  lwm2m_engine_set_u8("5/0/3", 0);
+  lwm2m_engine_set_float("3303/0/5700", &value);
+  lwm2m_registry_unlock();
+
+This is especially useful if the server is composite-observing the resources being
+written to. Locking will then ensure that the client only updates and sends notifications
+to the server after all operations are done, resulting in fewer messages in general.
+
 LwM2M engine and application events
 ***********************************
 

--- a/include/zephyr/net/lwm2m.h
+++ b/include/zephyr/net/lwm2m.h
@@ -646,6 +646,21 @@ int lwm2m_engine_create_obj_inst(const char *pathstr);
 int lwm2m_engine_delete_obj_inst(const char *pathstr);
 
 /**
+ * @brief Locks the registry for this thread.
+ *
+ * Use this function before writing to multiple resources. This halts the
+ * lwm2m main thread until all the write-operations are finished.
+ *
+ */
+void lwm2m_registry_lock(void);
+
+/**
+ * @brief Unlocks the registry previously locked by lwm2m_registry_lock().
+ *
+ */
+void lwm2m_registry_unlock(void);
+
+/**
  * @brief Set resource (instance) value (opaque buffer)
  *
  * @param[in] pathstr LwM2M path string "obj/obj-inst/res(/res-inst)"

--- a/subsys/net/lib/lwm2m/lwm2m_message_handling.c
+++ b/subsys/net/lib/lwm2m/lwm2m_message_handling.c
@@ -2254,8 +2254,10 @@ void lwm2m_udp_receive(struct lwm2m_ctx *client_ctx, uint8_t *buf, uint16_t buf_
 
 		client_ctx->processed_req = msg;
 
+		lwm2m_registry_lock();
 		/* process the response to this request */
 		r = udp_request_handler(&response, msg);
+		lwm2m_registry_unlock();
 		if (r < 0) {
 			return;
 		}

--- a/subsys/net/lib/lwm2m/lwm2m_registry.c
+++ b/subsys/net/lib/lwm2m/lwm2m_registry.c
@@ -40,7 +40,18 @@ LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 #define BINDING_OPT_MAX_LEN 3 /* "UQ" */
 #define QUEUE_OPT_MAX_LEN   2 /* "Q" */
 
+/* Thread safety */
 static K_MUTEX_DEFINE(registry_lock);
+
+void lwm2m_registry_lock(void)
+{
+	(void)k_mutex_lock(&registry_lock, K_FOREVER);
+}
+
+void lwm2m_registry_unlock(void)
+{
+	(void)k_mutex_unlock(&registry_lock);
+}
 /* Resources */
 static sys_slist_t engine_obj_list;
 static sys_slist_t engine_obj_inst_list;


### PR DESCRIPTION
Used the registry lock in the functions lwm2m_registry_lock() and
lwm2m_registry_unlock() to make the registry lockable through a public
API. If writing to multiple resources that are composite-observed,
locking will halt the main thread until every resource is written to,
ensuring that only one notify message will be sent. Updated
the documentation in lwm2m to include this addition.

Signed-off-by: Ola Tangen Kulseng <ola.kulseng@nordicsemi.no>