### PR TITLE
drivers: flash: ospi driver erase command on 24bits in SPI mode

### DIFF
--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -819,7 +819,10 @@ static int flash_stm32_ospi_erase(const struct device *dev, off_t addr,
 						(dev_cfg->data_rate == OSPI_DTR_TRANSFER)
 						? HAL_OSPI_ADDRESS_DTR_ENABLE
 						: HAL_OSPI_ADDRESS_DTR_DISABLE;
-					cmd_erase.AddressSize = stm32_ospi_hal_address_size(dev);
+					cmd_erase.AddressSize =
+						(dev_cfg->data_mode == OSPI_OPI_MODE)
+						? stm32_ospi_hal_address_size(dev)
+						: HAL_OSPI_ADDRESS_24_BITS;
 					cmd_erase.Address = addr;
 				}
 			}


### PR DESCRIPTION
When configuring the octo-flash in SPI/STR mode, the address size
must be on 24bits (and not on 32bits).
Despite the dev_data->address_width which is always seen as 4, the
erase command must reduce the AddressSize for this transfer mode.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49100

Signed-off-by: Francois Ramu <francois.ramu@st.com>