### PR TITLE
Bluetooth: controller: Add window widening for CIS/CIG

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
+++ b/subsys/bluetooth/controller/ll_sw/lll_conn_iso.h
@@ -55,6 +55,20 @@ struct lll_conn_iso_group {
 
 	/* Resumption information */
 	uint16_t resume_cis;    /* CIS handle to schedule at resume */
+
+	/* Window widening. Relies on vendor specific conversion macros, e.g.
+	 * EVENT_US_FRAC_TO_TICKS().
+	 */
+	uint32_t window_widening_periodic_us_frac; /* Widening in us fractions per
+						    * ISO interval.
+						    */
+	uint32_t window_widening_prepare_us_frac;  /* Widening in us fractions for
+						    * active prepare.
+						    */
+	uint32_t window_widening_event_us_frac;    /* Accumulated widening in us
+						    * fractions for active event.
+						    */
+	uint32_t window_widening_max_us;	   /* Maximum widening in us */
 };
 
 int lll_conn_iso_init(void);

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll_vendor.h
@@ -68,3 +68,15 @@
  * cases.
  */
 #define EVENT_RX_TX_TURNAROUND(phy)   150
+
+/* Sub-microsecond conversion macros. With current timer resolution of ~30 us
+ * per tick, conversion factor is 1, and macros map 1:1 between us_frac and us.
+ * On sub-microsecond tick resolution architectures, a number of bits may be
+ * used to represent fractions of a microsecond, to allow higher precision in
+ * window widening.
+ */
+#define EVENT_US_TO_US_FRAC(us)             (us)
+#define EVENT_US_FRAC_TO_US(us_frac)        (us_frac)
+#define EVENT_TICKS_TO_US_FRAC(ticks)       HAL_TICKER_TICKS_TO_US(ticks)
+#define EVENT_US_FRAC_TO_TICKS(us_frac)     HAL_TICKER_US_TO_TICKS(us_frac)
+#define EVENT_US_FRAC_TO_REMAINDER(us_frac) HAL_TICKER_REMAINDER(us_frac)

--- a/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_peripheral_iso.c
@@ -22,6 +22,7 @@
 #include "lll/lll_vendor.h"
 #include "lll_conn.h"
 #include "lll_conn_iso.h"
+#include "lll_clock.h"
 
 #include "isoal.h"
 #include "ull_iso_types.h"
@@ -146,6 +147,7 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 {
 	struct ll_conn_iso_group *cig;
 	struct ll_conn_iso_stream *cis;
+	uint32_t iso_interval_us;
 	uint16_t handle;
 
 	/* Get CIG by id */
@@ -160,10 +162,25 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 
 		memset(&cig->lll, 0, sizeof(cig->lll));
 
+		cig->iso_interval = sys_le16_to_cpu(req->iso_interval);
+		iso_interval_us = cig->iso_interval * CONN_INT_UNIT_US;
+
 		cig->cig_id = req->cig_id;
 		cig->lll.handle = LLL_HANDLE_INVALID;
 		cig->lll.role = acl->lll.role;
 		cig->lll.resume_cis = LLL_HANDLE_INVALID;
+
+		/* Calculate CIG default maximum window widening. NOTE: This calculation
+		 * does not take into account that leading CIS with NSE>=3 must reduce
+		 * the maximum window widening to one sub-interval. This must be applied
+		 * in LLL (BT Core 5.3, Vol 6, Part B, section 4.2.4).
+		 */
+		cig->lll.window_widening_max_us = (iso_interval_us >> 1) -
+						  EVENT_IFS_US;
+		cig->lll.window_widening_periodic_us_frac =
+			ceiling_fraction(((lll_clock_ppm_local_get() +
+					 lll_clock_ppm_get(acl->periph.sca)) *
+					 EVENT_US_TO_US_FRAC(iso_interval_us)), USEC_PER_SEC);
 
 		ull_hdr_init(&cig->ull);
 		lll_hdr_init(&cig->lll, cig);
@@ -189,7 +206,6 @@ uint8_t ull_peripheral_iso_acquire(struct ll_conn *acl,
 		return BT_HCI_ERR_INSUFFICIENT_RESOURCES;
 	}
 
-	cig->iso_interval = sys_le16_to_cpu(req->iso_interval);
 	/* Read 20-bit SDU intervals (mask away RFU bits) */
 	cig->c_sdu_interval = sys_get_le24(req->c_sdu_interval) & 0x0FFFFF;
 	cig->p_sdu_interval = sys_get_le24(req->p_sdu_interval) & 0x0FFFFF;
@@ -366,8 +382,8 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire,
 	struct ll_conn_iso_stream *cis;
 	uint32_t acl_to_cig_ref_point;
 	uint32_t cis_offs_to_cig_ref;
+	uint32_t iso_interval_us_frac;
 	uint32_t ready_delay_us;
-	uint32_t ticks_interval;
 	uint32_t ticker_status;
 	int32_t cig_offset_us;
 	uint8_t ticker_id;
@@ -389,10 +405,14 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire,
 		return;
 	}
 
-	ticker_id = TICKER_ID_CONN_ISO_BASE +
-		    ll_conn_iso_group_handle_get(cig);
-	ticks_interval = HAL_TICKER_US_TO_TICKS(cig->iso_interval *
-						CONN_INT_UNIT_US);
+	ticker_id = TICKER_ID_CONN_ISO_BASE + ll_conn_iso_group_handle_get(cig);
+
+	/* Calculate interval in fractional microseconds for highest precision when
+	 * accumulating the window widening window size. Ticker interval is set lopsided,
+	 * with natural drift towards earlier timeout.
+	 */
+	iso_interval_us_frac = EVENT_US_TO_US_FRAC(cig->iso_interval * CONN_INT_UNIT_US) -
+		cig->lll.window_widening_periodic_us_frac;
 
 	/* Establish the CIG reference point by adjusting ACL-to-CIS offset
 	 * (cis->offset) by the difference between CIG- and CIS sync delays.
@@ -408,7 +428,6 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire,
 	/* Calculate initial ticker offset - we're one ACL interval early */
 	cig_offset_us  = acl_to_cig_ref_point;
 	cig_offset_us += (acl->lll.interval * CONN_INT_UNIT_US);
-	cig_offset_us -= EVENT_OVERHEAD_START_US;
 	cig_offset_us -= EVENT_TICKER_RES_MARGIN_US;
 	cig_offset_us -= EVENT_JITTER_US;
 	cig_offset_us -= ready_delay_us;
@@ -432,8 +451,8 @@ void ull_peripheral_iso_start(struct ll_conn *acl, uint32_t ticks_at_expire,
 				     ticker_id,
 				     ticks_at_expire,
 				     HAL_TICKER_US_TO_TICKS(cig_offset_us),
-				     ticks_interval,
-				     HAL_TICKER_REMAINDER(ticks_interval),
+				     EVENT_US_FRAC_TO_TICKS(iso_interval_us_frac),
+				     EVENT_US_FRAC_TO_REMAINDER(iso_interval_us_frac),
 				     TICKER_NULL_LAZY,
 				     0,
 				     ticker_cb, cig,


### PR DESCRIPTION
Program CIG ticker with window widening drift. Introduce vendor specific
conversion macros allowing sub-microsecond resolution in the
accumulation of window widening drift per interval.

Calculation of window_widening_max_us is done for NSE<3, and must be
adjusted in the LLL before use, if the first CIS in the CIG has a
NSE>=3. In that case window_widening_max_us shall be limited to one sub
interval.

Signed-off-by: Morten Priess <mtpr@oticon.com>