### PR TITLE
Bluetooth: Mark Extended Adv as stable

### DIFF
--- a/subsys/bluetooth/Kconfig.adv
+++ b/subsys/bluetooth/Kconfig.adv
@@ -5,9 +5,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 config BT_EXT_ADV
-	bool "Extended Advertising and Scanning support [EXPERIMENTAL]"
+	bool "Extended Advertising and Scanning support"
 	depends on !BT_CTLR || BT_CTLR_ADV_EXT_SUPPORT
-	select EXPERIMENTAL
 	help
 	  Select this to enable Extended Advertising API support.
 	  This enables support for advertising with multiple advertising sets,


### PR DESCRIPTION
Extended Advertising is no longer experimental, it has been now
extensively tested and is fully qualifiable and usable in production.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>