### PR TITLE
dts: Renamed NXP usdhc in imxrt6xx

### DIFF
--- a/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
+++ b/boards/arm/mimxrt685_evk/mimxrt685_evk_cm33.dts
@@ -32,6 +32,7 @@
 		watchdog0 = &wwdt0;
 		magn0 = &fxos8700;
 		accel0 = &fxos8700;
+		sdhc0 = &usdhc0;
 	};
 
 	chosen {
@@ -399,7 +400,7 @@ i2s1: &flexcomm3 {
 	pinctrl-names = "default";
 };
 
-&usdhc1 {
+&usdhc0 {
 	status = "okay";
 	/* Quick fix for 1.8V SD cards on RT600- disable 1.8V negotiation */
 	no-1-8-v;

--- a/dts/arm/nxp/nxp_rt6xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt6xx_common.dtsi
@@ -301,7 +301,7 @@
 		clk-divider = <1>;
 	};
 
-	usdhc1: usdhc@136000 {
+	usdhc0: usdhc@136000 {
 		compatible = "nxp,imx-usdhc";
 		reg = <0x136000 0x1000>;
 		status = "disabled";
@@ -313,7 +313,7 @@
 		min-bus-freq = <400000>;
 	};
 
-	usdhc2: usdhc@137000 {
+	usdhc1: usdhc@137000 {
 		compatible = "nxp,imx-usdhc";
 		reg = <0x137000 0x1000>;
 		status = "disabled";

--- a/soc/arm/nxp_imx/rt6xx/soc.c
+++ b/soc/arm/nxp_imx/rt6xx/soc.c
@@ -135,7 +135,7 @@ static void usb_device_clock_init(void)
 	RESET_PeripheralReset(kUSBHS_DEVICE_RST_SHIFT_RSTn);
 	RESET_PeripheralReset(kUSBHS_HOST_RST_SHIFT_RSTn);
 	RESET_PeripheralReset(kUSBHS_SRAM_RST_SHIFT_RSTn);
-	/*Make sure USDHC ram buffer has power up*/
+	/*Make sure USBHS ram buffer has power up*/
 	POWER_DisablePD(kPDRUNCFG_APD_USBHS_SRAM);
 	POWER_DisablePD(kPDRUNCFG_PPD_USBHS_SRAM);
 	POWER_ApplyPD();
@@ -263,7 +263,7 @@ static ALWAYS_INLINE void clock_init(void)
 	CLOCK_AttachClk(kNONE_to_WDT0_CLK);
 #endif
 
-#if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_IMX_USDHC
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc0), okay) && CONFIG_IMX_USDHC
 	/* Make sure USDHC ram buffer has been power up*/
 	POWER_DisablePD(kPDRUNCFG_APD_USDHC0_SRAM);
 	POWER_DisablePD(kPDRUNCFG_PPD_USDHC0_SRAM);
@@ -283,7 +283,7 @@ static ALWAYS_INLINE void clock_init(void)
 #endif /* CONFIG_SOC_MIMXRT685S_CM33 */
 }
 
-#if (DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) && CONFIG_IMX_USDHC)
+#if (DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc0), okay) && CONFIG_IMX_USDHC)
 
 void imxrt_usdhc_pinmux(uint16_t nusdhc, bool init,
 	uint32_t speed, uint32_t strength)

--- a/soc/arm/nxp_imx/rt6xx/soc.h
+++ b/soc/arm/nxp_imx/rt6xx/soc.h
@@ -80,8 +80,8 @@ extern "C" {
 #endif
 
 #if CONFIG_IMX_USDHC &&					\
-	(DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay) ||	\
-	 DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc2), okay))
+	(DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc0), okay) ||	\
+	 DT_NODE_HAS_STATUS(DT_NODELABEL(usdhc1), okay))
 
 void imxrt_usdhc_pinmux(uint16_t nusdhc,
 	bool init, uint32_t speed, uint32_t strength);


### PR DESCRIPTION
The names of these peripherals in the device tree
did not match the Reference Manual for the RT600.

Added alias for usdhc0 to be able to use SDHC test.

Also fixed a typo in a comment referring to USDHC which should have been
about USB.

Signed-off-by: Declan Snyder <declan.snyder@nxp.com>