### PR TITLE
Bluetooth: df: Add vendor specific IQ sample reports providing 16 bits integer IQ samples

### DIFF
--- a/doc/connectivity/bluetooth/api/hci.txt
+++ b/doc/connectivity/bluetooth/api/hci.txt
@@ -88,8 +88,8 @@ the controller. By default no vendor events are reported.
 	|       | 1    | Fatal Error                                |
 	|       | 2    | Trace Information Event                    |
 	|       | 3    | Scan Request Received Event                |
-	|       | 4    | Reserved                                   |
-	|       | 5    | Reserved                                   |
+	|       | 4    | Connectionless IQ Report Event             |
+	|       | 5    | Connection IQ Report Event                 |
 	|       | 6    | Reserved                                   |
 	|       | 7    | Reserved                                   |
 	+-------+------+--------------------------------------------+
@@ -1325,7 +1325,372 @@ advertising sets, this event shall not be generated.
 The event is only reported when unmasked by Set_Event_Mask command.
 
 
-Zephyr Vendor Diagnostic Channel
+Zephyr LE Connectionless IQ Report Event
+========================================
+
+This event indicates that periodic advertising PDU including Constant Tone
+Extension was received and sampled.
+
++-------------------------------+------------+-------------------------------+
+| Event                         | Event Code | Event Parameters              |
++-------------------------------+------------+-------------------------------+
+| LE_Connectionless_IQ_Report   | 0xFF       | Subevent_Code,                |
+|                               |            | Sync_Handle,                  |
+|                               |            | Channel_Index,                |
+|                               |            | RSSI,                         |
+|                               |            | RSSI_Antenna_ID,              |
+|                               |            | CTE_Type,                     |
+|                               |            | Slot_Durations,               |
+|                               |            | Packet_Status,                |
+|                               |            | Periodic_Event_Counter,       |
+|                               |            | Sample_Count,                 |
+|                               |            | I_Sample[i],                  |
+|                               |            | Q_Sample[i]                   |
++-------------------------------+------------+-------------------------------+
+
+ The event provides collected IQ samples that are stored as 16 bit signed
+ integers. It is an extension to LE Connectionless IQ Report Event provided
+ by Bluetooth Core 5.3 Vol 4, Part E section 7.7.65.21. The BT Core defined
+ counterpart provides IQ samples that are 8 bit signed integers.
+
+	Subevent_Code:                                  Size: 1 Octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x05               | Subevent code for LE Connectionless  |
+	|                    | IQ Report event                      |
+	+--------------------+--------------------------------------+
+
+	Sync_Handle:              Size: 2 octets (12 bits meaningful)
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXXXX             | Sync_Handle identifying the periodic |
+	|                    | advertising train.                   |
+	|                    | Range: 0x0000 to 0x0EFF              |
+	+--------------------+--------------------------------------+
+	| 0x0FFF             | Receiver Test.                       |
+	+--------------------+--------------------------------------+
+
+	Channel_Index:                                  Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00 to 0x27       | The index of the channel on which the|
+	|                    | packet was received. Note: 0x25 to   |
+	|                    | 0x27 can be used only for packets    |
+	|                    | generated during test modes.         |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	RSSI:                                          Size: 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXXXX             | RSSI of the packet                   |
+	|                    | Range: -1270 to +200                 |
+	|                    | Units: 0.1 dBm                       |
+	+--------------------+--------------------------------------+
+
+
+	RSSI_Antenna_ID:                                Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXX               | Antenna ID                           |
+	+--------------------+--------------------------------------+
+
+	CTE_Type:                                       Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00               | AoA Constant Tone Extension          |
+	+--------------------+--------------------------------------+
+	| 0x01               | AoD Constant Tone Extension with     |
+	|                    | 1 us slots                           |
+	+--------------------+--------------------------------------+
+	| 0x02               | AoD Constant Tone Extension with     |
+	|                    | 2 us slots                           |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+
+	Slot_Durations:                                 Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x01               | Switching and sampling slots are     |
+	|                    | 1 µs each                            |
+	+--------------------+--------------------------------------+
+	| 0x02               | Switching and sampling slots are     |
+	|                    | 2 µs each                            |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	Packet_Status:                                  Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00               | Packet_Status                        |
+	+--------------------+--------------------------------------+
+	| 0x01               | CRC was incorrect and the Length and |
+	|                    | CTETime fields of the packet were    |
+	|                    | used to determine sampling points    |
+	+--------------------+--------------------------------------+
+	| 0x02               | CRC was incorrect but the Controller |
+	|                    | has determined the position and      |
+	|                    | length of the Constant Tone Extension|
+	|                    | in some other way                    |
+	+--------------------+--------------------------------------+
+	| 0xFF               | Insufficient resources to sample     |
+	|                    | (Channel_Index, CTE_Type, and        |
+	|                    | Slot_Durations invalid).             |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	Periodic_Event_Counter:                        Size: 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXXXX             | The value of paEventCounter (see     |
+	|                    | [Vol 6] Part B, Section 4.4.2.1) for |
+	|                    | the reported AUX_SYNC_IND PDU        |
+	+--------------------+--------------------------------------+
+
+	Sample_Count:                                   Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00               | No samples provided (only permitted  |
+	|                    | if Packet_Status is 0xFF).           |
+	+--------------------+--------------------------------------+
+	| 0x09 to 0x52       | Total number of sample pairs (there  |
+	|                    | shall be the same number of I samples|
+	|                    | and Q samples).                      |
+	|                    | Note: This number is dependent on the|
+	|                    | switch and sample slot durations used|
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	I_Sample[i]:                    Size: Sample_count x 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x8000             | No valid sample available or sample  |
+	|                    | is saturated                         |
+	+--------------------+--------------------------------------+
+	| All other values   | I sample for the reported packet     |
+	|                    | (signed integer).                    |
+	|                    | The list in the order of the sampling|
+	|                    | points within the packet.            |
+	+--------------------+--------------------------------------+
+
+	Q_Sample[i]:                    Size: Sample_count x 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x8000             | No valid sample available or sample  |
+	|                    | is saturated                         |
+	+--------------------+--------------------------------------+
+	| All other values   | Q sample for the reported packet     |
+	|                    | (signed integer).                    |
+	|                    | The list in the order of the sampling|
+	|                    | points within the packet.            |
+	+--------------------+--------------------------------------+
+
+Zephyr LE Connection IQ Report Event
+====================================
+
+This event indicates that there was received and sampled a PDU including
+Constant Tone Extension associated with a given connection.
+
++-------------------------------+------------+-------------------------------+
+| Event                         | Event Code | Event Parameters              |
++-------------------------------+------------+-------------------------------+
+| LE_Connection_IQ_Report       | 0xFF       | Subevent_Code,                |
+|                               |            | Connection_Handle,            |
+|                               |            | RF_PHY,                       |
+|                               |            | Data_Channel_Index,           |
+|                               |            | RSSI,                         |
+|                               |            | RSSI_Antenna_ID,              |
+|                               |            | CTE_Type,                     |
+|                               |            | Slot_Durations,               |
+|                               |            | Packet_Status,                |
+|                               |            | Connection_Event_Counter,     |
+|                               |            | Sample_Count,                 |
+|                               |            | I_Sample[i],                  |
+|                               |            | Q_Sample[i]                   |
++-------------------------------+------------+-------------------------------+
+
+ The event provides collected IQ samples that are stored as 16 bit signed
+ integers. It is an extension to LE Connection IQ Report Event provided
+ by Bluetooth Core 5.3 Vol 4, Part E section 7.7.65.22. The BT Core defined
+ counterpart provides IQ samples that are 8 bit signed integers.
+
+	Subevent_Code:                                  Size: 1 Octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x06               | Subevent code for LE Connection IQ   |
+	|                    | Report event                         |
+	+--------------------+--------------------------------------+
+
+	Connection_Handle:        Size: 2 octets (12 bits meaningful)
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXXXX             | Connection_Handle identifying the    |
+	|                    | connection.                          |
+	|                    | Range: 0x0000 to 0x0EFF              |
+	+--------------------+--------------------------------------+
+
+	RF_PHY:                                         Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x01               | The receiver PHY for the connection  |
+	|                    | is LE 1M                             |
+	+--------------------+--------------------------------------+
+	| 0x02               | The receiver PHY for the connection  |
+	|                    | is LE 2M                             |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	Data_Channel_Index:                             Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00 to 0x24       | The index of the data channel on     |
+	|                    | which the Data Physical Channel PDU  |
+	|                    | was received.                        |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	RSSI:                                          Size: 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXXXX             | RSSI of the packet                   |
+	|                    | Range: -1270 to +200                 |
+	|                    | Units: 0.1 dBm                       |
+	+--------------------+--------------------------------------+
+
+	RSSI_Antenna_ID:                                Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXX               | Antenna ID                           |
+	+--------------------+--------------------------------------+
+
+	CTE_Type:                                       Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00               | AoA Constant Tone Extension          |
+	+--------------------+--------------------------------------+
+	| 0x01               | AoD Constant Tone Extension with     |
+	|                    | 1 us slots                           |
+	+--------------------+--------------------------------------+
+	| 0x02               | AoD Constant Tone Extension with     |
+	|                    | 2 us slots                           |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	Slot_Durations:                                 Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x01               | Switching and sampling slots are     |
+	|                    | 1 µs each                            |
+	+--------------------+--------------------------------------+
+	| 0x02               | Switching and sampling slots are     |
+	|                    | 2 µs each                            |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	Packet_Status:                                  Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00               | Packet_Status                        |
+	+--------------------+--------------------------------------+
+	| 0x01               | CRC was incorrect and the Length and |
+	|                    | CTETime fields of the packet were    |
+	|                    | used to determine sampling points    |
+	+--------------------+--------------------------------------+
+	| 0x02               | CRC was incorrect but the Controller |
+	|                    | has determined the position and      |
+	|                    | length of the Constant Tone Extension|
+	|                    | in some other way                    |
+	+--------------------+--------------------------------------+
+	| 0xFF               | Insufficient resources to sample     |
+	|                    | (Channel_Index, CTE_Type, and        |
+	|                    | Slot_Durations invalid).             |
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	Connection_Event_Counter:                      Size: 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0xXXXX             | The value of connEventCounter (see   |
+	|                    | [Vol 6] Part B, Section 4.5.1) for   |
+	|                    | the reported PDU                     |
+	+--------------------+--------------------------------------+
+
+	Sample_Count:                                   Size: 1 octet
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x00               | No samples provided (only permitted  |
+	|                    | if Packet_Status is 0xFF).           |
+	+--------------------+--------------------------------------+
+	| 0x09 to 0x52       | Total number of sample pairs (there  |
+	|                    | shall be the same number of I samples|
+	|                    | and Q samples).                      |
+	|                    | Note: This number is dependent on the|
+	|                    | switch and sample slot durations used|
+	+--------------------+--------------------------------------+
+	| All other values   | Reserved for future use              |
+	+--------------------+--------------------------------------+
+
+	I_Sample[i]:                    Size: Sample_count x 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x8000             | No valid sample available or sample  |
+	|                    | is saturated                         |
+	+--------------------+--------------------------------------+
+	| All other values   | I sample for the reported packet     |
+	|                    | (signed integer).                    |
+	|                    | The list in the order of the sampling|
+	|                    | points within the packet.            |
+	+--------------------+--------------------------------------+
+
+	Q_Sample[i]:                    Size: Sample_count x 2 octets
+	+--------------------+--------------------------------------+
+	| Value              | Parameter Description                |
+	+--------------------+--------------------------------------+
+	| 0x8000             | No valid sample available or sample  |
+	|                    | is saturated                         |
+	+--------------------+--------------------------------------+
+	| All other values   | Q sample for the reported packet     |
+	|                    | (signed integer).                    |
+	|                    | The list in the order of the sampling|
+	|                    | points within the packet.            |
+	+--------------------+--------------------------------------+
+
+ Zephyr Vendor Diagnostic Channel
 ================================
 
 The vendor diagnostic channel allows for an independent side channel to provide

--- a/include/zephyr/bluetooth/direction.h
+++ b/include/zephyr/bluetooth/direction.h
@@ -101,10 +101,19 @@ struct bt_df_per_adv_sync_cte_rx_param {
 	const uint8_t *ant_ids;
 };
 
+enum bt_df_iq_sample {
+	/** Reported IQ samples have 8 bits signed integer format. Size defined in BT Core 5.3
+	 * Vol 4, Part E sections 7.7.65.21 and 7.7.65.22.
+	 */
+	BT_DF_IQ_SAMPLE_8_BITS_INT,
+	/** Reported IQ samples have 16 bits signed integer format. Vendor specific extension. */
+	BT_DF_IQ_SAMPLE_16_BITS_INT,
+};
+
 struct bt_df_per_adv_sync_iq_samples_report {
 	/** Channel index used to receive PDU with CTE that was sampled. */
 	uint8_t chan_idx;
-	/** The RSSI of the PDU with CTE (excluding CTE). */
+	/** The RSSI of the PDU with CTE (excluding CTE). Range: -1270 to +200. Units: 0.1 dBm. */
 	int16_t rssi;
 	/** Id of antenna used to measure the RSSI. */
 	uint8_t rssi_ant_id;
@@ -118,8 +127,13 @@ struct bt_df_per_adv_sync_iq_samples_report {
 	uint16_t per_evt_counter;
 	/** Number of IQ samples in report. */
 	uint8_t sample_count;
-	/** Pinter to IQ samples data. */
-	struct bt_hci_le_iq_sample const *sample;
+	/** Type of IQ samples provided in a report. */
+	enum bt_df_iq_sample sample_type;
+	/** Pointer to IQ samples data. */
+	union {
+		struct bt_hci_le_iq_sample const *sample;
+		struct bt_hci_le_iq_sample16 const *sample16;
+	};
 };
 
 struct bt_df_conn_cte_rx_param {
@@ -153,7 +167,7 @@ struct bt_df_conn_iq_samples_report {
 	uint8_t rx_phy;
 	/** Channel index used to receive PDU with CTE that was sampled. */
 	uint8_t chan_idx;
-	/** The RSSI of the PDU with CTE (excluding CTE). */
+	/** The RSSI of the PDU with CTE (excluding CTE). Range: -1270 to +200. Units: 0.1 dBm. */
 	int16_t rssi;
 	/** Id of antenna used to measure the RSSI. */
 	uint8_t rssi_ant_id;
@@ -165,10 +179,15 @@ struct bt_df_conn_iq_samples_report {
 	uint8_t packet_status;
 	/** Value of connection event counter when the CTE was received and sampled. */
 	uint16_t conn_evt_counter;
+	/** Type of IQ samples provided in a report. */
+	enum bt_df_iq_sample sample_type;
 	/** Number of IQ samples in report. */
 	uint8_t sample_count;
-	/** Pinter to IQ samples data. */
-	struct bt_hci_le_iq_sample const *sample;
+	/** Pointer to IQ samples data. */
+	union {
+		struct bt_hci_le_iq_sample const *sample;
+		struct bt_hci_le_iq_sample16 const *sample16;
+	};
 };
 /** Constant Tone Extension parameters for CTE transmission in connected mode. */
 struct bt_df_conn_cte_tx_param {

--- a/include/zephyr/bluetooth/hci_vs.h
+++ b/include/zephyr/bluetooth/hci_vs.h
@@ -263,11 +263,53 @@ struct bt_hci_evt_vs_scan_req_rx {
 	int8_t         rssi;
 } __packed;
 
+struct bt_hci_le_iq_sample16 {
+	int16_t i;
+	int16_t q;
+} __packed;
+
+#define BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT 0x5
+#define BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE   0x8000
+struct bt_hci_evt_vs_le_connectionless_iq_report {
+	uint16_t sync_handle;
+	uint8_t chan_idx;
+	int16_t rssi;
+	uint8_t rssi_ant_id;
+	uint8_t cte_type;
+	uint8_t slot_durations;
+	uint8_t packet_status;
+	uint16_t per_evt_counter;
+	uint8_t sample_count;
+	struct bt_hci_le_iq_sample16 sample[0];
+} __packed;
+
+#define BT_HCI_EVT_VS_LE_CONNECTION_IQ_REPORT 0x6
+struct bt_hci_evt_vs_le_connection_iq_report {
+	uint16_t conn_handle;
+	uint8_t rx_phy;
+	uint8_t data_chan_idx;
+	int16_t rssi;
+	uint8_t rssi_ant_id;
+	uint8_t cte_type;
+	uint8_t slot_durations;
+	uint8_t packet_status;
+	uint16_t conn_evt_counter;
+	uint8_t sample_count;
+	struct bt_hci_le_iq_sample16 sample[0];
+} __packed;
+
 /* Event mask bits */
 
 #define BT_EVT_MASK_VS_FATAL_ERROR             BT_EVT_BIT(1)
 #define BT_EVT_MASK_VS_TRACE_INFO              BT_EVT_BIT(2)
 #define BT_EVT_MASK_VS_SCAN_REQ_RX             BT_EVT_BIT(3)
+#define BT_EVT_MASK_VS_LE_CONNECTIONLESS_IQ_REPORT BT_EVT_BIT(4)
+#define BT_EVT_MASK_VS_LE_CONNECTION_IQ_REPORT	   BT_EVT_BIT(5)
+
+#define DEFAULT_VS_EVT_MASK                                                                        \
+	BT_EVT_MASK_VS_FATAL_ERROR | BT_EVT_MASK_VS_TRACE_INFO | BT_EVT_MASK_VS_SCAN_REQ_RX |      \
+		BT_EVT_MASK_VS_LE_CONNECTIONLESS_IQ_REPORT |                                       \
+		BT_EVT_MASK_VS_LE_CONNECTION_IQ_REPORT
 
 /* Mesh HCI commands */
 #define BT_HCI_MESH_REVISION                   0x01

--- a/samples/bluetooth/direction_finding_central/Kconfig
+++ b/samples/bluetooth/direction_finding_central/Kconfig
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "Direction Finding Central"
+config DF_CENTRAL_APP_IQ_REPORT_PRINT_IQ_SAMPLES
+	bool "Print IQ samples for received IQ reports"
+	help
+	  The option enables printing of IQ samples for received IQ report.
+endmenu
+
+menu "Zephyr Kernel"
+source "Kconfig.zephyr"
+endmenu

--- a/samples/bluetooth/direction_finding_connectionless_rx/Kconfig
+++ b/samples/bluetooth/direction_finding_connectionless_rx/Kconfig
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2022 Nordic Semiconductor ASA
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+menu "DF Connectionless Locator App"
+config DF_LOCATOR_APP_IQ_REPORT_PRINT_IQ_SAMPLES
+	bool "Print IQ samples for received IQ reports"
+	help
+	  The option enables printing of IQ samples for received IQ report.
+endmenu
+
+menu "Zephyr Kernel"
+source "Kconfig.zephyr"
+endmenu

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -224,10 +224,9 @@ config BT_HCI_VS_EVT
 config BT_HCI_VS_FATAL_ERROR
 	bool "Allow vendor specific HCI event Zephyr Fatal Error"
 	depends on BT_HCI_VS_EXT
-	default n
 	help
-	  Enable emiting HCI Vendor-Specific events for system and Controller error that are
-	  unrecoverable.
+	  Enable emiting HCI Vendor-Specific events for system and Controller
+	  errors that are unrecoverable.
 
 config BT_HCI_VS_EXT_DETECT
 	bool "Use heuristics to guess HCI vendor extensions support in advance"

--- a/subsys/bluetooth/common/Kconfig
+++ b/subsys/bluetooth/common/Kconfig
@@ -214,6 +214,13 @@ config BT_HCI_VS_EXT
 	  Host and/or Controller. This enables  Write BD_ADDR, Read Build Info,
 	  Read Static Addresses and Read Key Hierarchy Roots vendor commands.
 
+config BT_HCI_VS_EVT
+	bool "Zephyr HCI Vendor-Specific Events"
+	depends on BT_HCI_VS_EXT
+	help
+	  Enable support for the Zephyr HCI Vendor-Specific Events in the
+	  Host and/or Controller.
+
 config BT_HCI_VS_FATAL_ERROR
 	bool "Allow vendor specific HCI event Zephyr Fatal Error"
 	depends on BT_HCI_VS_EXT

--- a/subsys/bluetooth/controller/Kconfig.df
+++ b/subsys/bluetooth/controller/Kconfig.df
@@ -309,6 +309,30 @@ config BT_CTLR_DF_IQ_SAMPLES_CONVERT_USE_8_LSB
 
 endchoice
 
+# Vendor specifici extensions configuration
+
+config BT_CTLR_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES
+	bool "Use 16 bits signed integer IQ samples in connectionless IQ reports"
+	depends on BT_CTLR_DF_SCAN_CTE_RX && BT_HCI_VS_EXT
+	select BT_HCI_VS_EVT
+	help
+	  Direction Finging connectionless IQ reports provide a set of IQ samples collected during
+	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
+	  integer, see Vol 4, Part E section 7.7.65.21. This option enables a vendor specific
+	  extenstion to HCI layer, so that connectionless IQ reports store samples in 16 bit signed
+	  integer format.
+
+config BT_CTLR_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES
+	bool "Use 16 bits signed integer IQ samples in connection IQ reports"
+	depends on BT_CTLR_DF_CONN_CTE_RX && BT_HCI_VS_EXT
+	select BT_HCI_VS_EVT
+	help
+	  Direction Finging connection IQ reports provide a set of IQ samples collected during
+	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
+	  integer, see Vol 4, Part E section 7.7.65.22. This option enables a vendor specific
+	  extenstion to HCI layer, so that connection IQ reports store samples in 16 bit signed
+	  integer format.
+
 endif # BT_LL_SW_SPLIT
 
 endif # BT_CTLR_DF

--- a/subsys/bluetooth/controller/hci/hci.c
+++ b/subsys/bluetooth/controller/hci/hci.c
@@ -2936,11 +2936,15 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 	}
 #endif /* CONFIG_BT_CTLR_DF_SCAN_CTE_RX */
 
-	/* If there are no IQ samples due to insufficient resources
-	 * HCI event should inform about it by storing single octet with
-	 * special I_sample and Q_sample data.
+	/* If packet status does not indicate insufficient resources for IQ samples and for
+	 * some reason sample_count is zero, inform Host about lack of valid IQ samples by
+	 * storing single I_sample and Q_sample with BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE value.
 	 */
-	samples_cnt = MAX(1, iq_report->sample_count);
+	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		samples_cnt = 0U;
+	} else {
+		samples_cnt = MAX(1, iq_report->sample_count);
+	}
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_CONNECTIONLESS_IQ_REPORT,
 		       (sizeof(*sep) +
@@ -2967,18 +2971,21 @@ static void le_df_connectionless_iq_report(struct pdu_data *pdu_rx,
 
 	sep->packet_status = iq_report->packet_status;
 
-	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
-		sep->sample[0].i = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample[0].q = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample_count = 0U;
-	} else {
-		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = iq_convert_12_to_8_bits(iq_report->sample[idx].i);
-			sep->sample[idx].q = iq_convert_12_to_8_bits(iq_report->sample[idx].q);
+	if (iq_report->packet_status != BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		if (iq_report->sample_count == 0U) {
+			sep->sample[0].i = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
+			sep->sample[0].q = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
+		} else {
+			for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
+				sep->sample[idx].i =
+					iq_convert_12_to_8_bits(iq_report->sample[idx].i);
+				sep->sample[idx].q =
+					iq_convert_12_to_8_bits(iq_report->sample[idx].q);
+			}
 		}
-
-		sep->sample_count = samples_cnt;
 	}
+
+	sep->sample_count = samples_cnt;
 }
 #endif /* defined(CONFIG_BT_CTLR_DF_SCAN_CTE_RX) || defined(CONFIG_BT_CTLR_DTM_HCI_DF_IQ_REPORT) */
 
@@ -3061,10 +3068,15 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 		return;
 	}
 
-	/* If there are no IQ samples due to insufficient resources HCI event should inform about
-	 * it by store single octet with special I_sample and Q_sample data.
+	/* If packet status does not indicate insufficient resources for IQ samples and for
+	 * some reason sample_count is zero, inform Host about lack of valid IQ samples by
+	 * storing single I_sample and Q_sample with BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE value.
 	 */
-	samples_cnt = MAX(1, iq_report->sample_count);
+	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		samples_cnt = 0;
+	} else {
+		samples_cnt = MAX(1, iq_report->sample_count);
+	}
 
 	sep = meta_evt(buf, BT_HCI_EVT_LE_CONNECTION_IQ_REPORT,
 		       (sizeof(*sep) + (samples_cnt * sizeof(struct bt_hci_le_iq_sample))));
@@ -3090,17 +3102,21 @@ static void le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct net_b
 
 	sep->packet_status = iq_report->packet_status;
 
-	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
-		sep->sample[0].i = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample[0].q = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample_count = 0U;
-	} else {
-		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = iq_convert_12_to_8_bits(iq_report->sample[idx].i);
-			sep->sample[idx].q = iq_convert_12_to_8_bits(iq_report->sample[idx].q);
+	if (iq_report->packet_status != BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		if (iq_report->sample_count == 0U) {
+			sep->sample[0].i = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
+			sep->sample[0].q = BT_HCI_LE_CTE_REPORT_NO_VALID_SAMPLE;
+		} else {
+			for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
+				sep->sample[idx].i =
+					iq_convert_12_to_8_bits(iq_report->sample[idx].i);
+				sep->sample[idx].q =
+					iq_convert_12_to_8_bits(iq_report->sample[idx].q);
+			}
 		}
-		sep->sample_count = samples_cnt;
 	}
+
+	sep->sample_count = samples_cnt;
 }
 #endif /* CONFIG_BT_CTLR_DF_CONN_CTE_RX */
 
@@ -5029,11 +5045,16 @@ static void vs_le_df_connectionless_iq_report(struct pdu_data *pdu_rx, struct no
 	sync_handle = ull_sync_handle_get(sync);
 	per_evt_counter = iq_report->event_counter;
 
-	/* If there are no IQ samples due to insufficient resources
-	 * HCI event should inform about it by storing single octet with
-	 * special I_sample and Q_sample data.
+	/* If packet status does not indicate insufficient resources for IQ samples and for
+	 * some reason sample_count is zero, inform Host about lack of valid IQ samples by
+	 * storing single I_sample and Q_sample with BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE
+	 * value.
 	 */
-	samples_cnt = MAX(1, iq_report->sample_count);
+	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		samples_cnt = 0U;
+	} else {
+		samples_cnt = MAX(1, iq_report->sample_count);
+	}
 
 	sep = vs_event(buf, BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
 		       (sizeof(*sep) + (samples_cnt * sizeof(struct bt_hci_le_iq_sample16))));
@@ -5058,18 +5079,19 @@ static void vs_le_df_connectionless_iq_report(struct pdu_data *pdu_rx, struct no
 
 	sep->packet_status = iq_report->packet_status;
 
-	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
-		sep->sample[0].i = BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample[0].q = BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample_count = 0U;
-	} else {
-		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = sys_cpu_to_le16(iq_report->sample[idx].i);
-			sep->sample[idx].q = sys_cpu_to_le16(iq_report->sample[idx].q);
+	if (iq_report->packet_status != BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		if (iq_report->sample_count == 0U) {
+			sep->sample[0].i = sys_cpu_to_le16(BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE);
+			sep->sample[0].q = sys_cpu_to_le16(BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE);
+		} else {
+			for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
+				sep->sample[idx].i = sys_cpu_to_le16(iq_report->sample[idx].i);
+				sep->sample[idx].q = sys_cpu_to_le16(iq_report->sample[idx].q);
+			}
 		}
-
-		sep->sample_count = samples_cnt;
 	}
+
+	sep->sample_count = samples_cnt;
 }
 #endif /* CONFIG_BT_CTLR_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES */
 
@@ -5109,10 +5131,15 @@ static void vs_le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct ne
 		return;
 	}
 
-	/* If there are no IQ samples due to insufficient resources HCI event should inform about
-	 * it by store single octet with special I_sample and Q_sample data.
+	/* If packet status does not indicate insufficient resources for IQ samples and for
+	 * some reason sample_count is zero, inform Host about lack of valid IQ samples by
+	 * storing single I_sample and Q_sample with BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE value.
 	 */
-	samples_cnt = MAX(1, iq_report->sample_count);
+	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		samples_cnt = 0U;
+	} else {
+		samples_cnt = MAX(1, iq_report->sample_count);
+	}
 
 	sep = vs_event(buf, BT_HCI_EVT_VS_LE_CONNECTION_IQ_REPORT,
 			(sizeof(*sep) + (samples_cnt * sizeof(struct bt_hci_le_iq_sample16))));
@@ -5138,17 +5165,19 @@ static void vs_le_df_connection_iq_report(struct node_rx_pdu *node_rx, struct ne
 
 	sep->packet_status = iq_report->packet_status;
 
-	if (iq_report->packet_status == BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
-		sep->sample[0].i = BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample[0].q = BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE;
-		sep->sample_count = 0U;
-	} else {
-		for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
-			sep->sample[idx].i = sys_cpu_to_le16(iq_report->sample[idx].i);
-			sep->sample[idx].q = sys_cpu_to_le16(iq_report->sample[idx].q);
+	if (iq_report->packet_status != BT_HCI_LE_CTE_INSUFFICIENT_RESOURCES) {
+		if (iq_report->sample_count == 0U) {
+			sep->sample[0].i = sys_cpu_to_le16(BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE);
+			sep->sample[0].q = sys_cpu_to_le16(BT_HCI_VS_LE_CTE_REPORT_NO_VALID_SAMPLE);
+		} else {
+			for (uint8_t idx = 0U; idx < samples_cnt; ++idx) {
+				sep->sample[idx].i = sys_cpu_to_le16(iq_report->sample[idx].i);
+				sep->sample[idx].q = sys_cpu_to_le16(iq_report->sample[idx].q);
+			}
 		}
-		sep->sample_count = samples_cnt;
 	}
+
+	sep->sample_count = samples_cnt;
 }
 #endif /* CONFIG_BT_CTLR_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES */
 

--- a/subsys/bluetooth/host/Kconfig
+++ b/subsys/bluetooth/host/Kconfig
@@ -758,6 +758,28 @@ config BT_DF_CTE_TX_AOD
 	  Enable support for antenna switching during CTE transmission.
 	  Also known as Angle of Departure mode.
 
+config BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES
+	bool "Use 16 bits signed integer IQ samples in connectionless IQ reports"
+	depends on BT_DF_CONNECTIONLESS_CTE_RX && BT_HCI_VS_EXT
+	select BT_HCI_VS_EVT
+	help
+	  Direction Finging connectionless IQ reports provide a set of IQ samples collected during
+	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
+	  integer, see Vol 4, Part E section 7.7.65.21. This option enables a vendor specific Host
+	  extenstion to handle connectionless IQ reports with samples that are in 16 bit signed
+	  integer format.
+
+config BT_DF_VS_CONN_IQ_REPORT_16_BITS_IQ_SAMPLES
+	bool "Use 16 bits signed integer IQ samples in connection IQ reports"
+	depends on BT_DF_CONNECTION_CTE_RX && BT_HCI_VS_EXT
+	select BT_HCI_VS_EVT
+	help
+	  Direction Finging connection IQ reports provide a set of IQ samples collected during
+	  sampling of CTE. Bluetooth 5.3 Core Specification defines IQ samples to be 8 bits signed
+	  integer, see Vol 4, Part E sections 7.7.65.22. This option enables a vendor specific Host
+	  extenstion to handle connection IQ report with samples that are in 16 bit signed integer
+	  format.
+
 config BT_DEBUG_DF
 	bool "Bluetooth Direction Finding debug"
 	help

--- a/subsys/bluetooth/host/direction_internal.h
+++ b/subsys/bluetooth/host/direction_internal.h
@@ -10,9 +10,15 @@ int le_df_init(void);
 int hci_df_prepare_connectionless_iq_report(struct net_buf *buf,
 					    struct bt_df_per_adv_sync_iq_samples_report *report,
 					    struct bt_le_per_adv_sync **per_adv_sync_to_report);
+int hci_df_vs_prepare_connectionless_iq_report(struct net_buf *buf,
+					       struct bt_df_per_adv_sync_iq_samples_report *report,
+					       struct bt_le_per_adv_sync **per_adv_sync_to_report);
 int hci_df_prepare_connection_iq_report(struct net_buf *buf,
 					struct bt_df_conn_iq_samples_report *report,
 					struct bt_conn **conn_to_report);
+int hci_df_vs_prepare_connection_iq_report(struct net_buf *buf,
+					   struct bt_df_conn_iq_samples_report *report,
+					   struct bt_conn **conn_to_report);
 int hci_df_prepare_conn_cte_req_failed(struct net_buf *buf,
 				       struct bt_df_conn_iq_samples_report *report,
 				       struct bt_conn **conn_to_report);

--- a/subsys/bluetooth/host/hci_core.h
+++ b/subsys/bluetooth/host/hci_core.h
@@ -458,6 +458,7 @@ void bt_hci_le_per_adv_report(struct net_buf *buf);
 void bt_hci_le_per_adv_sync_lost(struct net_buf *buf);
 void bt_hci_le_biginfo_adv_report(struct net_buf *buf);
 void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf);
+void bt_hci_le_vs_df_connectionless_iq_report(struct net_buf *buf);
 void bt_hci_le_past_received(struct net_buf *buf);
 
 /* Adv HCI event handlers */
@@ -480,4 +481,5 @@ void bt_hci_role_change(struct net_buf *buf);
 void bt_hci_synchronous_conn_complete(struct net_buf *buf);
 
 void bt_hci_le_df_connection_iq_report(struct net_buf *buf);
+void bt_hci_le_vs_df_connection_iq_report(struct net_buf *buf);
 void bt_hci_le_df_cte_req_failed(struct net_buf *buf);

--- a/subsys/bluetooth/host/scan.c
+++ b/subsys/bluetooth/host/scan.c
@@ -14,6 +14,8 @@
 #include <zephyr/bluetooth/buf.h>
 #include <zephyr/bluetooth/direction.h>
 #include <zephyr/bluetooth/addr.h>
+#include <zephyr/bluetooth/hci.h>
+#include <zephyr/bluetooth/hci_vs.h>
 
 #include "hci_core.h"
 #include "conn_internal.h"
@@ -1102,7 +1104,7 @@ void bt_hci_le_biginfo_adv_report(struct net_buf *buf)
 }
 #endif /* CONFIG_BT_ISO_BROADCAST */
 #if defined(CONFIG_BT_DF_CONNECTIONLESS_CTE_RX)
-void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf)
+static void bt_hci_le_df_connectionless_iq_report_common(uint8_t event, struct net_buf *buf)
 {
 	int err;
 
@@ -1110,9 +1112,21 @@ void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf)
 	struct bt_le_per_adv_sync *per_adv_sync;
 	struct bt_le_per_adv_sync_cb *listener;
 
-	err = hci_df_prepare_connectionless_iq_report(buf, &cte_report, &per_adv_sync);
-	if (err) {
-		BT_ERR("Prepare CTE conn IQ report failed %d", err);
+	if (event == BT_HCI_EVT_LE_CONNECTIONLESS_IQ_REPORT) {
+		err = hci_df_prepare_connectionless_iq_report(buf, &cte_report, &per_adv_sync);
+		if (err) {
+			BT_ERR("Prepare CTE conn IQ report failed %d", err);
+			return;
+		}
+	} else if (IS_ENABLED(CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES) &&
+		   event == BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT) {
+		err = hci_df_vs_prepare_connectionless_iq_report(buf, &cte_report, &per_adv_sync);
+		if (err) {
+			BT_ERR("Prepare CTE conn IQ report failed %d", err);
+			return;
+		}
+	} else {
+		BT_ERR("Unhandled VS connectionless IQ report");
 		return;
 	}
 
@@ -1122,6 +1136,19 @@ void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf)
 		}
 	}
 }
+
+void bt_hci_le_df_connectionless_iq_report(struct net_buf *buf)
+{
+	bt_hci_le_df_connectionless_iq_report_common(BT_HCI_EVT_LE_CONNECTIONLESS_IQ_REPORT, buf);
+}
+
+#if defined(CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES)
+void bt_hci_le_vs_df_connectionless_iq_report(struct net_buf *buf)
+{
+	bt_hci_le_df_connectionless_iq_report_common(BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT,
+						     buf);
+}
+#endif /* CONFIG_BT_DF_VS_CL_IQ_REPORT_16_BITS_IQ_SAMPLES */
 #endif /* CONFIG_BT_DF_CONNECTIONLESS_CTE_RX */
 #endif /* defined(CONFIG_BT_PER_ADV_SYNC) */
 #endif /* defined(CONFIG_BT_EXT_ADV) */


### PR DESCRIPTION
Add vendor specific IQ samples report that holds IQ data in 16 bits
signed integer format. Thanks to that we preserve complete accuracy of
IQ samples provided by Nordic Direction Finding Extension in Radio
peripheral. That helps to maintain better accuracy of evaluated
angles with use of reported IQ samples.

Bluetooth Controller has a vendor specific extensions that allows it
to send IQ report events with IQ samples that are 8 bits or 16 bits
signed integer. To use that functionality, there is added common
handler of vendor specific events.

Vendor specific events handling is prioritized to be done by user
provided event handler. If that is not available, then Host generic
implementation enters.

Added vendor specific events that are handled by common Host code
are BT_HCI_EVT_VS_LE_CONNECTIONLESS_IQ_REPORT and BT_HCI_EVT_VS_LE-
_CONNECTION_IQ_REPORT.

The only difference between regular IQ report events is size of
IQ samples, hence implementation of IQ report events is changed to
use the same user callback. To avoid differentiation of user callbacks
new member sample_type was added to bt_df_per_adv_sync_iq_samples-
_report. Also sample member is changed to be a union, to allow easy
access to IQ samples without type casting.

Change implementation of cte_recv_cb to print information about IQ
samples type. The changed code is ready for use of 8 bits and 16 bits
signed integer IQ samples. User has sample level option to enable
printing IQ samples.