### PR TITLE
drivers: gpio: make gpio_utils.h a self-contained header

### DIFF
--- a/drivers/gpio/gpio_utils.h
+++ b/drivers/gpio/gpio_utils.h
@@ -11,6 +11,15 @@
 #ifndef ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_
 #define ZEPHYR_DRIVERS_GPIO_GPIO_UTILS_H_
 
+#include <stdbool.h>
+#include <stdint.h>
+#include <errno.h>
+
+#include <zephyr/devicetree.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/slist.h>
+
 #define GPIO_PORT_PIN_MASK_FROM_NGPIOS(ngpios)			\
 	((gpio_port_pins_t)(((uint64_t)1 << (ngpios)) - 1U))
 


### PR DESCRIPTION
gpio_utils.h header relied on other files including its dependencies.
This patch adds all necessary includes to make it self-contained.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>