### PR TITLE
subsys: usb: Increase mass storage stack size when SD stack is enabled

### DIFF
--- a/subsys/usb/device/class/Kconfig.msc
+++ b/subsys/usb/device/class/Kconfig.msc
@@ -45,6 +45,7 @@ config MASS_STORAGE_BULK_EP_MPS
 
 config MASS_STORAGE_STACK_SIZE
 	int "Set stack size for mass storage thread"
+	default 786 if SD_STACK
 	default 512
 	help
 	  Stack size for mass storage disk operations thread


### PR DESCRIPTION
SD stack requires a larger stack size than the default value for the
mass storage stack thread. Increase the default stack size to 768 when
the SD stack is enabled.

Fixes #49057

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>