### PR TITLE
boards: shields: waveshare_epaper: fix mismatch in compatible property

### DIFF
--- a/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
+++ b/boards/shields/waveshare_epaper/waveshare_epaper_gdew075t7.overlay
@@ -14,7 +14,7 @@
 
 &arduino_spi {
 	uc8179: uc8179@0 {
-		compatible = "gooddisplay,gdew042t2", "ultrachip,uc8179";
+		compatible = "gooddisplay,gdew075t7", "ultrachip,uc8179";
 		spi-max-frequency = <4000000>;
 		reg = <0>;
 		width = <800>;


### PR DESCRIPTION
renamed gooddisplay,gdew042t2 to gooddisplay,gdew075t7 as like the
shield device file name.

Signed-off-by: Dinesh Kumar K <dinesh@linumiz.com>