### PR TITLE
Bluetooth: Audio: Update audio shell with location in cmd_init

### DIFF
--- a/subsys/bluetooth/shell/audio.c
+++ b/subsys/bluetooth/shell/audio.c
@@ -1421,14 +1421,25 @@ static int cmd_init(const struct shell *sh, size_t argc, char *argv[])
 #endif /* CONFIG_BT_AUDIO_UNICAST || CONFIG_BT_AUDIO_BROADCAST_SOURCE */
 
 	if (IS_ENABLED(CONFIG_BT_AUDIO_CAPABILITY)) {
-		/* Mark mandatory context as available */
-		err = bt_audio_capability_set_available_contexts(
-					BT_AUDIO_DIR_SINK, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
-		__ASSERT(err == 0, "Failed to set sink available contexts");
+		if (IS_ENABLED(CONFIG_BT_PAC_SNK_LOC)) {
+			err = bt_audio_capability_set_location(BT_AUDIO_DIR_SINK,
+							       LOCATION);
+			__ASSERT(err == 0, "Failed to set sink location");
 
-		err = bt_audio_capability_set_available_contexts(
-					BT_AUDIO_DIR_SOURCE, BT_AUDIO_CONTEXT_TYPE_UNSPECIFIED);
-		__ASSERT(err == 0, "Failed to set source available contexts");
+			err = bt_audio_capability_set_available_contexts(BT_AUDIO_DIR_SINK,
+									 CONTEXT);
+			__ASSERT(err == 0, "Failed to set sink available contexts");
+		}
+
+		if (IS_ENABLED(CONFIG_BT_PAC_SRC_LOC)) {
+			err = bt_audio_capability_set_location(BT_AUDIO_DIR_SOURCE,
+							       LOCATION);
+			__ASSERT(err == 0, "Failed to set source location");
+
+			err = bt_audio_capability_set_available_contexts(BT_AUDIO_DIR_SOURCE,
+									 CONTEXT);
+			__ASSERT(err == 0, "Failed to set source available contexts");
+		}
 	}
 
 #if defined(CONFIG_BT_AUDIO_UNICAST)


### PR DESCRIPTION
Set the location in the init command. Also updates the
available context to the CONTEXT macro value.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>