### PR TITLE
twister: fix the hanging up on an exception happens during west flash

### DIFF
--- a/scripts/pylib/twister/twisterlib/handlers.py
+++ b/scripts/pylib/twister/twisterlib/handlers.py
@@ -573,14 +573,25 @@ class DeviceHandler(Handler):
 
         except subprocess.CalledProcessError:
             os.write(write_pipe, b'x')  # halt the thread
+            self.instance.status = "error"
+            self.instance.reason = "Device issue (Flash error)"
+            flash_error = True
 
         if post_flash_script:
             self.run_custom_script(post_flash_script, 30)
 
         if not flash_error:
             t.join(self.timeout)
-            if t.is_alive():
-                logger.debug("Timed out while monitoring serial output on {}".format(self.instance.platform.name))
+        else:
+            # When the flash error is due exceptions,
+            # twister tell the monitor serial thread
+            # to close the serial. But it is necessary
+            # for this thread being run first and close
+            # have the change to close the serial.
+            t.join(0.1)
+
+        if t.is_alive():
+            logger.debug("Timed out while monitoring serial output on {}".format(self.instance.platform.name))
 
         if ser.isOpen():
             ser.close()


### PR DESCRIPTION
Fix the missing logic of setting the flash_error flag when
caught the exceptions. And we should let the serial thread
can be run first if flash error. Otherwise the twister will
hang up while an exception happens on closing serial, after
the https://github.com/zephyrproject-rtos/zephyr/pull/47820 got merged. This mostly happens on frdm_k64f.

Fixes #49086

Signed-off-by: Enjia Mai <enjia.mai@intel.com>