### PR TITLE
Update CONFIG_ASAN et. al.

### DIFF
--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -28,15 +28,6 @@ if (CONFIG_GPROF)
   zephyr_compile_options($<TARGET_PROPERTY:compiler,gprof>)
   zephyr_link_libraries($<TARGET_PROPERTY:linker,gprof>)
 endif()
-if (CONFIG_ASAN)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,sanitize_address>)
-  zephyr_link_libraries($<TARGET_PROPERTY:linker,sanitize_address>)
-endif ()
-
-if (CONFIG_UBSAN)
-  zephyr_compile_options($<TARGET_PROPERTY:compiler,sanitize_undefined>)
-  zephyr_link_libraries($<TARGET_PROPERTY:linker,sanitize_undefined>)
-endif ()
 
 zephyr_compile_definitions(_POSIX_C_SOURCE=200809 _XOPEN_SOURCE=600 _XOPEN_SOURCE_EXTENDED)
 
@@ -52,6 +43,30 @@ zephyr_ld_options(
 # ( include/posix/pthread.h / kernel/pthread.c ) [And any future API added to
 # Zephyr which will clash with the native POSIX API] . It would also need to
 # be included in a few zephyr kernel files.
+
+#
+# Support for the LLVM Sanitizer toolchain instrumentation frameworks
+# (supported by current gcc's as well)
+#
+
+if(CONFIG_ASAN)
+  list(APPEND LLVM_SANITIZERS "address")
+endif()
+
+if(CONFIG_UBSAN)
+  list(APPEND LLVM_SANITIZERS "undefined")
+endif()
+
+if(CONFIG_ASAN_RECOVER)
+  zephyr_compile_options(-fsanitize-recover=all)
+endif()
+
+list(JOIN LLVM_SANITIZERS "," LLVM_SANITIZERS_ARG)
+if(NOT ${LLVM_SANITIZERS_ARG} STREQUAL "")
+  set(LLVM_SANITIZERS_ARG "-fsanitize=${LLVM_SANITIZERS_ARG}")
+  zephyr_compile_options("${LLVM_SANITIZERS_ARG}")
+  zephyr_link_libraries("${LLVM_SANITIZERS_ARG}")
+endif()
 
 
 add_subdirectory(core)

--- a/arch/posix/CMakeLists.txt
+++ b/arch/posix/CMakeLists.txt
@@ -53,6 +53,10 @@ if(CONFIG_ASAN)
   list(APPEND LLVM_SANITIZERS "address")
 endif()
 
+if(CONFIG_MSAN)
+  list(APPEND LLVM_SANITIZERS "memory")
+endif()
+
 if(CONFIG_UBSAN)
   list(APPEND LLVM_SANITIZERS "undefined")
 endif()

--- a/cmake/bintools/llvm/target.cmake
+++ b/cmake/bintools/llvm/target.cmake
@@ -7,12 +7,25 @@ if(DEFINED TOOLCHAIN_HOME)
   set(find_program_binutils_args PATHS ${TOOLCHAIN_HOME})
 endif()
 
-find_program(CMAKE_AR      llvm-ar      ${find_program_clang_args}   )
-find_program(CMAKE_NM      llvm-nm      ${find_program_clang_args}   )
-find_program(CMAKE_OBJDUMP llvm-objdump ${find_program_clang_args}   )
-find_program(CMAKE_RANLIB  llvm-ranlib  ${find_program_clang_args}   )
-find_program(CMAKE_STRIP   llvm-strip   ${find_program_clang_args}   )
-find_program(CMAKE_OBJCOPY objcopy      ${find_program_binutils_args})
+# Extract the clang version.  Debian (maybe other distros?) will
+# append a version to llvm-objdump/objcopy
+execute_process(COMMAND ${CMAKE_C_COMPILER} --version
+                OUTPUT_VARIABLE CLANGVER)
+string(REGEX REPLACE "[^0-9]*([0-9]+).*" "\\1" CLANGVER ${CLANGVER})
+
+find_program(CMAKE_AR      llvm-ar      ${find_program_clang_args})
+find_program(CMAKE_NM      llvm-nm      ${find_program_clang_args})
+find_program(CMAKE_OBJDUMP NAMES
+                           llvm-objdump
+                           llvm-objdump-${CLANGVER}
+                           ${find_program_clang_args})
+find_program(CMAKE_RANLIB  llvm-ranlib  ${find_program_clang_args})
+find_program(CMAKE_STRIP   llvm-strip   ${find_program_clang_args})
+find_program(CMAKE_OBJCOPY NAMES
+                           llvm-objcopy
+                           llvm-objcopy-${CLANGVER}
+                           objcopy
+                           ${find_program_binutils_args})
 find_program(CMAKE_READELF readelf      ${find_program_binutils_args})
 
 # Use the gnu binutil abstraction

--- a/cmake/compiler/arcmwdt/compiler_flags.cmake
+++ b/cmake/compiler/arcmwdt/compiler_flags.cmake
@@ -162,11 +162,6 @@ set_compiler_property(PROPERTY coverage "")
 # mwdt compiler flags for imacros. The specific header must be appended by user.
 set_compiler_property(PROPERTY imacros -imacros)
 
-#no support of -fsanitize=address and -lasan
-set_compiler_property(PROPERTY sanitize_address "")
-
-set_compiler_property(PROPERTY sanitize_undefined "")
-
 # Security canaries.
 #no support of -mstack-protector-guard=global"
 set_compiler_property(PROPERTY security_canaries -fstack-protector-all)

--- a/cmake/compiler/compiler_flags_template.cmake
+++ b/cmake/compiler/compiler_flags_template.cmake
@@ -101,11 +101,6 @@ set_compiler_property(PROPERTY no_common)
 # Flags for imacros. The specific header must be appended by user.
 set_compiler_property(PROPERTY imacros)
 
-# Compiler flags for sanitizing.
-set_compiler_property(PROPERTY sanitize_address)
-
-set_compiler_property(PROPERTY sanitize_undefined)
-
 # Compiler flag for turning off thread-safe initialization of local statics
 set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics)
 

--- a/cmake/compiler/gcc/compiler_flags.cmake
+++ b/cmake/compiler/gcc/compiler_flags.cmake
@@ -177,12 +177,7 @@ set_compiler_property(PROPERTY no_common -fno-common)
 # GCC compiler flags for imacros. The specific header must be appended by user.
 set_compiler_property(PROPERTY imacros -imacros)
 
-# GCC compiler flags for sanitizing.
-set_compiler_property(PROPERTY sanitize_address -fsanitize=address)
-
 set_compiler_property(PROPERTY gprof -pg)
-
-set_compiler_property(PROPERTY sanitize_undefined -fsanitize=undefined)
 
 # GCC compiler flag for turning off thread-safe initialization of local statics
 set_property(TARGET compiler-cpp PROPERTY no_threadsafe_statics "-fno-threadsafe-statics")

--- a/cmake/linker/ld/clang/linker_flags.cmake
+++ b/cmake/linker/ld/clang/linker_flags.cmake
@@ -2,8 +2,3 @@
 if (NOT CONFIG_COVERAGE_GCOV)
   set_property(TARGET linker PROPERTY coverage --coverage)
 endif()
-
-# ld/clang linker flags for sanitizing.
-check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -fsanitize=address)
-
-check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_undefined -fsanitize=undefined)

--- a/cmake/linker/ld/gcc/linker_flags.cmake
+++ b/cmake/linker/ld/gcc/linker_flags.cmake
@@ -7,9 +7,4 @@ if (NOT CONFIG_COVERAGE_GCOV)
   set_property(TARGET linker PROPERTY coverage -lgcov)
 endif()
 
-# ld/gcc linker flags for sanitizing.
-check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -lasan)
-check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address -fsanitize=address)
-check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_undefined -fsanitize=undefined)
-
 check_set_linker_property(TARGET linker APPEND PROPERTY gprof -pg)

--- a/cmake/linker/linker_flags_template.cmake
+++ b/cmake/linker/linker_flags_template.cmake
@@ -3,11 +3,6 @@
 # Set the property for the corresponding flags of the given toolchain.
 set_property(TARGET linker PROPERTY coverage)
 
-# Linker flags for sanitizing.
-check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_address)
-
-check_set_linker_property(TARGET linker APPEND PROPERTY sanitize_undefined)
-
 # Linker flag for printing of memusage.
 # Set this flag if the linker supports reporting of memusage as part of link,
 # such as ls --print-memory-usage flag.

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -91,7 +91,7 @@ void z_sys_init_run_level(int32_t level);
  */
 #define Z_INIT_ENTRY_DEFINE(_entry_name, _init_fn, _device, _level, _prio)	\
 	static const Z_DECL_ALIGN(struct init_entry)			\
-		Z_INIT_ENTRY_NAME(_entry_name) __used			\
+		Z_INIT_ENTRY_NAME(_entry_name) __used __noasan			\
 	__attribute__((__section__(".z_init_" #_level STRINGIFY(_prio)"_"))) = { \
 		.init = (_init_fn),					\
 		.dev = (_device),					\

--- a/include/zephyr/toolchain.h
+++ b/include/zephyr/toolchain.h
@@ -53,6 +53,21 @@
 #endif
 
 /**
+ * @def __noasan
+ * @brief Disable address sanitizer
+ *
+ * When used in the definiton of a symbol, prevents that symbol (be it
+ * a function or data) from being instrumented by the address
+ * sanitizer feature of the compiler.  Most commonly, this is used to
+ * prevent padding around data that will be treated specially by the
+ * Zephyr link (c.f. SYS_INIT records, STRUCT_SECTION_ITERABLE
+ * definitions) in ways that don't understand the guard padding.
+ */
+#ifndef __noasan
+#define __noasan /**/
+#endif
+
+/**
  * @def GCC_VERSION
  * @brief GCC version in xxyyzz for xx.yy.zz. Zero if not GCC compatible.
  */

--- a/include/zephyr/toolchain/common.h
+++ b/include/zephyr/toolchain/common.h
@@ -209,7 +209,7 @@
  */
 #define STRUCT_SECTION_ITERABLE(struct_type, name) \
 	Z_DECL_ALIGN(struct struct_type) name \
-	__in_section(_##struct_type, static, name) __used
+	__in_section(_##struct_type, static, name) __used __noasan
 
 /**
  * @brief Defines an alternate data type iterable section.
@@ -221,7 +221,7 @@
  */
 #define STRUCT_SECTION_ITERABLE_ALTERNATE(out_type, struct_type, name) \
 	Z_DECL_ALIGN(struct struct_type) name \
-	__in_section(_##out_type, static, name) __used
+	__in_section(_##out_type, static, name) __used __noasan
 
 /**
  * @brief Iterate over a specified iterable section.

--- a/include/zephyr/toolchain/gcc.h
+++ b/include/zephyr/toolchain/gcc.h
@@ -618,5 +618,11 @@ do {                                                                    \
  */
 #define Z_IS_POW2(x) (((x) != 0) && (((x) & ((x)-1)) == 0))
 
+#ifdef CONFIG_ASAN
+#define __noasan __attribute__((no_sanitize("address")))
+#else
+#define __noasan /**/
+#endif
+
 #endif /* !_LINKER */
 #endif /* ZEPHYR_INCLUDE_TOOLCHAIN_GCC_H_ */

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -108,6 +108,15 @@ void __weak z_early_memcpy(void *dst, const void *src, size_t n)
 __boot_func
 void z_bss_zero(void)
 {
+	if (IS_ENABLED(CONFIG_ARCH_POSIX)) {
+		/* native_posix gets its memory cleared on entry by
+		 * the host OS, and in any case the host clang/lld
+		 * doesn't emit the __bss_end symbol this code expects
+		 * to see
+		 */
+		return;
+	}
+
 	z_early_memset(__bss_start, 0, __bss_end - __bss_start);
 #if DT_NODE_HAS_STATUS(DT_CHOSEN(zephyr_ccm), okay)
 	z_early_memset(&__ccm_bss_start, 0,

--- a/soc/posix/inf_clock/soc.h
+++ b/soc/posix/inf_clock/soc.h
@@ -43,7 +43,7 @@ void posix_soc_clean_up(void);
  * any Zephyr thread are running.
  */
 #define NATIVE_TASK(fn, level, prio)	\
-	static void (*_CONCAT(__native_task_, fn)) __used	\
+	static const void (*_CONCAT(__native_task_, fn)) __used	__noasan \
 	__attribute__((__section__(".native_" #level STRINGIFY(prio) "_task")))\
 	= fn
 

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -154,6 +154,18 @@ config UBSAN
 	  architecture, and requires a recent-ish compiler with the
 	  ``-fsanitize=undefined`` command line option.
 
+config MSAN
+	bool "Build with memory sanitizer"
+	depends on ARCH_POSIX
+	help
+	  Builds Zephyr with the LLVM MemorySanitizer enabled.  Works
+	  only on the posix architecture currently, and only with host
+	  compilers recent enough to support the feature (currently
+	  clang on x86_64 only).  It cannot be used in tandem with
+	  CONFIG_ASAN due to clang limitations.  You must choose one
+	  or the other (but can combine it with CONFIG_UBSAN if you
+	  like)
+
 config STACK_USAGE
 	bool "Generate stack usage information"
 	help

--- a/subsys/debug/Kconfig
+++ b/subsys/debug/Kconfig
@@ -120,6 +120,18 @@ config ASAN
 	  This behavior can be changes by adding leak_check_at_exit=1 to the
 	  environment variable ASAN_OPTIONS.
 
+config ASAN_RECOVER
+	bool "Continue after sanitizer errors"
+	depends on ASAN
+	default y
+	help
+	  The default behavior of compiler sanitizers is to exit after
+	  the first error.  Set this to y to enable the code to
+	  continue, which can be useful if a code base has known
+	  unsuppressed errors.  You will also need to set
+	  "halt_on_error=0" in your ASAN_OPTIONS environment variable
+	  at runtime.
+
 config ASAN_NOP_DLCLOSE
 	bool "Override host OS dlclose() with a NOP"
 	default y if HAS_SDL


### PR DESCRIPTION
Sanitizer support had bitrotten.  Update it so that it works.  Also includes some patches for building native_posix against clang.

Now you can build with either the host gcc or ZEPHYR_TOOLCHAIN_VARIANT=llvm (which gets you the host clang) and with any combination of CONFIG_{ASAN,UBSAN} and get sanitizer validation.

Working on MSAN currently, though that requires instrumenting the sys_heap code for uninitialized memory detection.   That should arrive along with libfuzzer support sometime within a week or so, ideally.