### PR TITLE
templates: bug: ask if the bug is a regression

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -14,6 +14,8 @@ Please also mention any information which could help others to understand
 the problem you're facing:
  - What target platform are you using?
  - What have you tried to diagnose or workaround this issue?
+ - Is this a regression? If yes, have you been able to "git bisect" it to a
+   specific commit?
  - ...
 
 **To Reproduce**


### PR DESCRIPTION
Heya, when triaging bugs I often find unclear whether it's a "new" issue or a regression. Regressions are easy to bisect, but one needs the right hardware which we often don't have. Maybe asking explicitly may help a bit with both.

Let me know what you think.

-- 8< --

Add a note to the bug report GitHub template asking if the bug is a
regression, and asking for a bisected commit if available.

This should make regression bugs easier to triage, or even point the
author to the solution.