### PR TITLE
drivers: eswifi: fix spi initialization

### DIFF
--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -242,7 +242,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 	gpio_pin_configure_dt(&cfg->dr, GPIO_INPUT);
 
 	/* SPI BUS */
-	if (!spi_is_ready(&spi->cfg->bus)) {
+	if (!spi_is_ready(&cfg->bus)) {
 		LOG_ERR("SPI bus is not ready");
 		return -ENODEV;
 	};


### PR DESCRIPTION
This change reverts a portion of a prior change that results
in an uninitialized eswifi_spi_data struct to be passed to
the `is_spi_ready` function. See commit 48c87f2bf8b768f550cfe6756d3cd313f9a02c3f

Signed-off-by: Brian Dunlay <brian.dunlay@gmail.com>