### PR TITLE
tests: subsys: fs: move littlefs to new ztest API

### DIFF
--- a/tests/subsys/fs/littlefs/prj.conf
+++ b/tests/subsys/fs/littlefs/prj.conf
@@ -1,6 +1,6 @@
 CONFIG_FILE_SYSTEM=y
 CONFIG_FILE_SYSTEM_LITTLEFS=y
-
+CONFIG_ZTEST_NEW_API=y
 CONFIG_MAIN_STACK_SIZE=4096
 
 # Performance tests need custom buffer allocation

--- a/tests/subsys/fs/littlefs/src/main.c
+++ b/tests/subsys/fs/littlefs/src/main.c
@@ -11,20 +11,5 @@
 #include "testfs_tests.h"
 #include "testfs_lfs.h"
 
-void test_main(void)
-{
-	ztest_test_suite(littlefs_test,
-			 ztest_unit_test(test_util_path_init_base),
-			 ztest_unit_test(test_util_path_init_overrun),
-			 ztest_unit_test(test_util_path_init_extended),
-			 ztest_unit_test(test_util_path_extend),
-			 ztest_unit_test(test_util_path_extend_up),
-			 ztest_unit_test(test_util_path_extend_overrun),
-			 ztest_unit_test(test_lfs_basic),
-			 ztest_unit_test(test_lfs_dirops),
-			 ztest_unit_test(test_lfs_perf),
-			 ztest_unit_test(test_fs_open_flags_lfs),
-			 ztest_unit_test(test_fs_mount_flags)
-			 );
-	ztest_run_test_suite(littlefs_test);
-}
+
+ZTEST_SUITE(littlefs, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/fs/littlefs/src/test_lfs_basic.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_basic.c
@@ -585,7 +585,7 @@ static int num_dirs(struct fs_mount_t *mp)
 	return TC_PASS;
 }
 
-void test_lfs_basic(void)
+ZTEST(littlefs, test_lfs_basic)
 {
 	struct fs_mount_t *mp = &testfs_small_mnt;
 

--- a/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_dirops.c
@@ -309,7 +309,7 @@ static int check_rename(struct fs_mount_t *mp)
 	return TC_PASS;
 }
 
-void test_lfs_dirops(void)
+ZTEST(littlefs, test_lfs_dirops)
 {
 	struct fs_mount_t *mp = &testfs_small_mnt;
 

--- a/tests/subsys/fs/littlefs/src/test_lfs_perf.c
+++ b/tests/subsys/fs/littlefs/src/test_lfs_perf.c
@@ -223,7 +223,7 @@ static int small_8_1K_cust(void)
 	return custom_write_test("small 8x1K bigfile", &testfs_small_mnt, &cfg, 1024, 8);
 }
 
-void test_lfs_perf(void)
+ZTEST(littlefs, test_lfs_perf)
 {
 	k_sleep(K_MSEC(100));   /* flush log messages */
 	zassert_equal(write_read("small 8x1K dflt",

--- a/tests/subsys/fs/littlefs/src/test_util.c
+++ b/tests/subsys/fs/littlefs/src/test_util.c
@@ -26,7 +26,7 @@ static inline struct testfs_path *reset_path()
 	return &path;
 }
 
-void test_util_path_init_base(void)
+ZTEST(littlefs, test_util_path_init_base)
 {
 	zassert_equal(testfs_path_init(&path, NULL, TESTFS_PATH_END),
 		      path.path,
@@ -48,7 +48,7 @@ void test_util_path_init_base(void)
 	}
 }
 
-void test_util_path_init_overrun(void)
+ZTEST(littlefs, test_util_path_init_overrun)
 {
 	char overrun[TESTFS_PATH_MAX + 2] = "/";
 	size_t overrun_max = sizeof(overrun) - 1;
@@ -74,7 +74,7 @@ void test_util_path_init_overrun(void)
 		      "missing overrun EOS");
 }
 
-void test_util_path_init_extended(void)
+ZTEST(littlefs, test_util_path_init_extended)
 {
 	zassert_equal(strcmp(testfs_path_init(&path, &mnt,
 					      ELT1,
@@ -92,7 +92,7 @@ void test_util_path_init_extended(void)
 		      "bad mnt init elt1 elt2");
 }
 
-void test_util_path_extend(void)
+ZTEST(littlefs, test_util_path_extend)
 {
 	zassert_equal(strcmp(testfs_path_extend(reset_path(),
 						TESTFS_PATH_END),
@@ -116,7 +116,7 @@ void test_util_path_extend(void)
 		      "elt1 elt2 extend failed");
 }
 
-void test_util_path_extend_up(void)
+ZTEST(littlefs, test_util_path_extend_up)
 {
 	zassert_equal(strcmp(testfs_path_extend(reset_path(),
 						ELT2,
@@ -143,7 +143,7 @@ void test_util_path_extend_up(void)
 		      "up from root failed");
 }
 
-void test_util_path_extend_overrun(void)
+ZTEST(littlefs, test_util_path_extend_overrun)
 {
 	char long_elt[TESTFS_PATH_MAX];
 

--- a/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
+++ b/tests/subsys/fs/littlefs/src/testfs_mount_flags.c
@@ -17,7 +17,7 @@ static void cleanup(struct fs_mount_t *mp)
 		      "Failed to clean partition");
 }
 
-void test_fs_mount_flags(void)
+ZTEST(littlefs, test_fs_mount_flags)
 {
 	/* Using smallest partition for this tests as they do not write
 	 * a lot of data, basically they just check flags.

--- a/tests/subsys/fs/littlefs/src/testfs_open_flags.c
+++ b/tests/subsys/fs/littlefs/src/testfs_open_flags.c
@@ -36,7 +36,8 @@ static void cleanup(struct fs_mount_t *mp)
 		      "Failed to clean partition");
 }
 
-void test_fs_open_flags_lfs(void)
+ZTEST(littlefs, test_fs_open_flags_lfs)
+
 {
 	/* Using smallest partition for this tests as they do not write
 	 * a lot of data, basically they just check flags.
@@ -44,6 +45,7 @@ void test_fs_open_flags_lfs(void)
 	struct fs_mount_t *mp = &testfs_small_mnt;
 
 	cleanup(mp);
+	mp->flags = 0;
 	mount(mp);
 
 	test_fs_open_flags();


### PR DESCRIPTION
Move test littlefs to use new ztest API.

Signed-off-by: Kun Li <kun1x.li@intel.com>