### PR TITLE
Bluetooth: audio: check MCS characteristic properties before subscribe

### DIFF
--- a/subsys/bluetooth/audio/mcc.c
+++ b/subsys/bluetooth/audio/mcc.c
@@ -1245,7 +1245,6 @@ static int do_subscribe(struct bt_conn *conn, uint16_t handle,
 	/* With ccc_handle == 0 it will use auto discovery */
 	sub_params->ccc_handle = 0;
 	sub_params->end_handle = cur_mcs_inst->end_handle;
-	sub_params->value = BT_GATT_CCC_NOTIFY;
 	sub_params->value_handle = handle;
 	sub_params->notify = mcs_notify_handler;
 	sub_params->subscribe = subscribe_mcs_char_func;
@@ -1273,6 +1272,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	 */
 
 	if (cur_mcs_inst->player_name_handle &&
+	    cur_mcs_inst->player_name_sub_params.value &&
 	    cur_mcs_inst->player_name_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->player_name_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->player_name_handle, sub_params);
@@ -1284,6 +1284,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->track_changed_handle &&
+	    cur_mcs_inst->track_changed_sub_params.value &&
 	    cur_mcs_inst->track_changed_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->track_changed_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->track_changed_handle, sub_params);
@@ -1294,6 +1295,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 		return false;
 	}
 	if (cur_mcs_inst->track_title_handle &&
+	    cur_mcs_inst->track_title_sub_params.value &&
 	    cur_mcs_inst->track_title_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->track_title_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->track_title_handle, sub_params);
@@ -1305,6 +1307,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->track_duration_handle &&
+	    cur_mcs_inst->track_duration_sub_params.value &&
 	    cur_mcs_inst->track_duration_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->track_duration_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->track_duration_handle, sub_params);
@@ -1316,6 +1319,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->track_position_handle &&
+	    cur_mcs_inst->track_position_sub_params.value &&
 	    cur_mcs_inst->track_position_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->track_position_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->track_position_handle, sub_params);
@@ -1327,6 +1331,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->playback_speed_handle &&
+	    cur_mcs_inst->playback_speed_sub_params.value &&
 	    cur_mcs_inst->playback_speed_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->playback_speed_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->playback_speed_handle, sub_params);
@@ -1338,6 +1343,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->seeking_speed_handle &&
+	    cur_mcs_inst->seeking_speed_sub_params.value &&
 	    cur_mcs_inst->seeking_speed_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->seeking_speed_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->seeking_speed_handle, sub_params);
@@ -1350,6 +1356,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 
 #ifdef CONFIG_BT_MCC_OTS
 	if (cur_mcs_inst->current_track_obj_id_handle &&
+	    cur_mcs_inst->current_track_obj_sub_params.value &&
 	    cur_mcs_inst->current_track_obj_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->current_track_obj_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->current_track_obj_id_handle, sub_params);
@@ -1361,6 +1368,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->next_track_obj_id_handle &&
+	    cur_mcs_inst->next_track_obj_sub_params.value &&
 	    cur_mcs_inst->next_track_obj_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->next_track_obj_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->next_track_obj_id_handle, sub_params);
@@ -1372,6 +1380,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->parent_group_obj_id_handle &&
+	    cur_mcs_inst->parent_group_obj_sub_params.value &&
 	    cur_mcs_inst->parent_group_obj_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->parent_group_obj_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->parent_group_obj_id_handle, sub_params);
@@ -1383,7 +1392,8 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->current_group_obj_id_handle &&
-	    cur_mcs_inst->parent_group_obj_sub_params.disc_params == NULL) {
+	    cur_mcs_inst->current_group_obj_sub_params.value &&
+	    cur_mcs_inst->current_group_obj_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->current_group_obj_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->current_group_obj_id_handle, sub_params);
 		if (err) {
@@ -1396,6 +1406,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 #endif /* CONFIG_BT_MCC_OTS */
 
 	if (cur_mcs_inst->playing_order_handle &&
+	    cur_mcs_inst->playing_order_sub_params.value &&
 	    cur_mcs_inst->playing_order_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->playing_order_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->playing_order_handle, sub_params);
@@ -1407,6 +1418,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->media_state_handle &&
+	    cur_mcs_inst->media_state_sub_params.value &&
 	    cur_mcs_inst->media_state_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->media_state_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->media_state_handle, sub_params);
@@ -1418,6 +1430,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->cp_handle &&
+	    cur_mcs_inst->cp_sub_params.value &&
 	    cur_mcs_inst->cp_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->cp_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->cp_handle, sub_params);
@@ -1429,6 +1442,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->opcodes_supported_handle &&
+	    cur_mcs_inst->opcodes_supported_sub_params.value &&
 	    cur_mcs_inst->opcodes_supported_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->opcodes_supported_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->opcodes_supported_handle, sub_params);
@@ -1441,6 +1455,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 
 #ifdef CONFIG_BT_MCC_OTS
 	if (cur_mcs_inst->scp_handle &&
+	    cur_mcs_inst->scp_sub_params.value &&
 	    cur_mcs_inst->scp_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->scp_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->scp_handle, sub_params);
@@ -1452,6 +1467,7 @@ static bool subscribe_next_mcs_char(struct bt_conn *conn)
 	}
 
 	if (cur_mcs_inst->search_results_obj_id_handle &&
+	    cur_mcs_inst->search_results_obj_sub_params.value &&
 	    cur_mcs_inst->search_results_obj_sub_params.disc_params == NULL) {
 		sub_params = &cur_mcs_inst->search_results_obj_sub_params;
 		err = do_subscribe(conn, cur_mcs_inst->search_results_obj_id_handle, sub_params);
@@ -1498,6 +1514,9 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			cur_mcs_inst->player_name_handle = chrc->value_handle;
 			/* Use discovery params pointer as subscription flag */
 			cur_mcs_inst->player_name_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->player_name_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_ICON_OBJ_ID)) {
 			BT_DBG("Icon Object, UUID: %s", bt_uuid_str(chrc->uuid));
@@ -1510,26 +1529,44 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			BT_DBG("Track Changed, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->track_changed_handle = chrc->value_handle;
 			cur_mcs_inst->track_changed_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->track_changed_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_TITLE)) {
 			BT_DBG("Track Title, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->track_title_handle = chrc->value_handle;
 			cur_mcs_inst->track_title_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->track_title_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_DURATION)) {
 			BT_DBG("Track Duration, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->track_duration_handle = chrc->value_handle;
 			cur_mcs_inst->track_duration_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->track_duration_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_POSITION)) {
 			BT_DBG("Track Position, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->track_position_handle = chrc->value_handle;
 			cur_mcs_inst->track_position_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->track_position_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYBACK_SPEED)) {
 			BT_DBG("Playback Speed, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->playback_speed_handle = chrc->value_handle;
 			cur_mcs_inst->playback_speed_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->playback_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEEKING_SPEED)) {
 			BT_DBG("Seeking Speed, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->seeking_speed_handle = chrc->value_handle;
 			cur_mcs_inst->seeking_speed_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->seeking_speed_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_TRACK_SEGMENTS_OBJ_ID)) {
 			BT_DBG("Track Segments Object, UUID: %s", bt_uuid_str(chrc->uuid));
@@ -1538,23 +1575,41 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			BT_DBG("Current Track Object, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->current_track_obj_id_handle = chrc->value_handle;
 			cur_mcs_inst->current_track_obj_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->current_track_obj_sub_params.value =
+					BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_NEXT_TRACK_OBJ_ID)) {
 			BT_DBG("Next Track Object, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->next_track_obj_id_handle = chrc->value_handle;
 			cur_mcs_inst->next_track_obj_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->next_track_obj_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PARENT_GROUP_OBJ_ID)) {
 			BT_DBG("Parent Group Object, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->parent_group_obj_id_handle = chrc->value_handle;
 			cur_mcs_inst->parent_group_obj_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->parent_group_obj_sub_params.value =
+					BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_CURRENT_GROUP_OBJ_ID)) {
 			BT_DBG("Group Object, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->current_group_obj_id_handle = chrc->value_handle;
 			cur_mcs_inst->current_group_obj_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->current_group_obj_sub_params.value =
+					BT_GATT_CCC_NOTIFY;
+			}
 #endif /* CONFIG_BT_MCC_OTS */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDER)) {
 			BT_DBG("Playing Order, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->playing_order_handle = chrc->value_handle;
 			cur_mcs_inst->playing_order_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->playing_order_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_PLAYING_ORDERS)) {
 			BT_DBG("Playing Orders supported, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->playing_orders_supported_handle = chrc->value_handle;
@@ -1562,24 +1617,41 @@ static uint8_t discover_mcs_char_func(struct bt_conn *conn,
 			BT_DBG("Media State, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->media_state_handle = chrc->value_handle;
 			cur_mcs_inst->media_state_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->media_state_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_POINT)) {
 			BT_DBG("Media Control Point, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->cp_handle = chrc->value_handle;
 			cur_mcs_inst->cp_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->cp_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_MEDIA_CONTROL_OPCODES)) {
 			BT_DBG("Media control opcodes supported, UUID: %s",
 			       bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->opcodes_supported_handle = chrc->value_handle;
 			cur_mcs_inst->opcodes_supported_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->opcodes_supported_sub_params.value =
+					BT_GATT_CCC_NOTIFY;
+			}
 #ifdef CONFIG_BT_MCC_OTS
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEARCH_CONTROL_POINT)) {
 			BT_DBG("Search control point, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->scp_handle = chrc->value_handle;
 			cur_mcs_inst->scp_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->scp_sub_params.value = BT_GATT_CCC_NOTIFY;
+			}
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_MCS_SEARCH_RESULTS_OBJ_ID)) {
 			BT_DBG("Search Results object, UUID: %s", bt_uuid_str(chrc->uuid));
 			cur_mcs_inst->search_results_obj_id_handle = chrc->value_handle;
 			cur_mcs_inst->search_results_obj_sub_params.disc_params = NULL;
+			if (chrc->properties & BT_GATT_CHRC_NOTIFY) {
+				cur_mcs_inst->search_results_obj_sub_params.value =
+					BT_GATT_CCC_NOTIFY;
+			}
 #endif /* CONFIG_BT_MCC_OTS */
 		} else if (!bt_uuid_cmp(chrc->uuid, BT_UUID_CCID)) {
 			BT_DBG("Content Control ID, UUID: %s", bt_uuid_str(chrc->uuid));


### PR DESCRIPTION
MCC need to check characteristic properties before subscribe as not all
MCS characteristics support notify.

Signed-off-by: Hang Fan <fanhang@xiaomi.com>

Fix: #49142