### PR TITLE
[v2.7-branch] actions: west/devicetree: exclude python 3.6 on windows

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -25,6 +25,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: 3.6
+          - os: windows-latest
+            python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -26,6 +26,8 @@ jobs:
         exclude:
           - os: macos-latest
             python-version: 3.6
+          - os: windows-latest
+            python-version: 3.6
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2769,18 +2769,6 @@ class _BindingLoader(Loader):
 # Add legacy '!include foo.yaml' handling
 _BindingLoader.add_constructor("!include", _binding_include)
 
-# Use OrderedDict instead of plain dict for YAML mappings, to preserve
-# insertion order on Python 3.5 and earlier (plain dicts only preserve
-# insertion order on Python 3.6+). This makes testing easier and avoids
-# surprises.
-#
-# Adapted from
-# https://stackoverflow.com/questions/5121931/in-python-how-can-you-load-yaml-mappings-as-ordereddicts.
-# Hopefully this API stays stable.
-_BindingLoader.add_constructor(
-    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
-    lambda loader, node: OrderedDict(loader.construct_pairs(node)))
-
 #
 # "Default" binding for properties which are defined by the spec.
 #


### PR DESCRIPTION
This version of python is not available anymore. Excluding for now to
unblock CI.

Fixes: #49139

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>
(cherry picked from commit 773242cbb705a887ca6b7445ec79636ce7b65069)