### PR TITLE
s2ram: Deal with system off failure

### DIFF
--- a/arch/arm/core/aarch32/cortex_m/pm_s2ram.S
+++ b/arch/arm/core/aarch32/cortex_m/pm_s2ram.S
@@ -27,7 +27,7 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	 *
 	 * r0: address of the system_off function
 	 */
-	push	{r4-r12, r14}
+	push	{r4-r12, lr}
 	ldr	r1, =_cpu_context
 
 	mrs	r2, msp
@@ -71,9 +71,25 @@ SECTION_FUNC(TEXT, arch_pm_s2ram_suspend)
 	str	r2, [r1]
 
 	/*
-	 * Call the system_off function passed as parameter
+	 * Call the system_off function passed as parameter. This should never
+	 * return.
 	 */
-	bx	r0
+	blx	r0
+
+	/*
+	 * The system_off function returns here only when the powering off was
+	 * not successful (in r0 the return value).
+	 */
+
+	/*
+	 * Reset the marker
+	 */
+	ldr	r1, =marker
+	mov	r2, #0x0
+	str	r2, [r1]
+
+	pop	{r4-r12, lr}
+	bx	lr
 
 GTEXT(arch_pm_s2ram_resume)
 SECTION_FUNC(TEXT, arch_pm_s2ram_resume)
@@ -134,7 +150,7 @@ resume:
 	msr	control, r1
 	isb
 
-	pop	{r4-r12, r14}
+	pop	{r4-r12, lr}
 
 	/*
 	 * Set the return value and return

--- a/include/zephyr/arch/common/pm_s2ram.h
+++ b/include/zephyr/arch/common/pm_s2ram.h
@@ -25,10 +25,17 @@ extern "C" {
  * @brief System off function
  *
  * This function is passed as argument and called by @ref arch_pm_s2ram_suspend
- * to power the system off after the CPU context has been saved. This function
- * never returns.
+ * to power the system off after the CPU context has been saved.
+ *
+ * This function never returns if the system is powered off. If the operation
+ * cannot be performed a proper value is returned and the code must take care
+ * of restoring the system in a fully operational state before returning.
+ *
+ * @retval none		The system is powered off.
+ * @retval -EBUSY	The system is busy and cannot be powered off at this time.
+ * @retval -errno	Other error codes.
  */
-typedef void (*pm_s2ram_system_off_fn_t)(void);
+typedef int (*pm_s2ram_system_off_fn_t)(void);
 
 /**
  * @brief Save CPU context on suspend
@@ -44,6 +51,7 @@ typedef void (*pm_s2ram_system_off_fn_t)(void);
  * @param system_off	Function to power off the system.
  *
  * @retval 0		The CPU context was successfully saved and restored.
+ * @retval -EBUSY	The system is busy and cannot be suspended at this time.
  * @retval -errno	Negative errno code in case of failure.
  */
 int arch_pm_s2ram_suspend(pm_s2ram_system_off_fn_t system_off);

--- a/samples/boards/nrf/s2ram/src/main.c
+++ b/samples/boards/nrf/s2ram/src/main.c
@@ -15,24 +15,34 @@
 #include <hal/nrf_regulators.h>
 #include <hal/nrf_gpio.h>
 
-static void system_off(void)
+static int system_off(void)
 {
 	nrf_regulators_system_off(NRF_REGULATORS);
+
+	/*
+	 * We should never reach this point if the system is powered off. If we
+	 * do, return -EBUSY.
+	 */
+	return -EBUSY;
 }
 
 static void do_suspend(void)
 {
-	irq_lock();
+	int ret;
 
 	/*
 	 * Save the CPU context (including the return address),set the SRAM
 	 * marker and power off the system.
 	 */
-	arch_pm_s2ram_suspend(system_off);
+	ret = arch_pm_s2ram_suspend(system_off);
 
 	/*
-	 * XXX: On resuming we return exactly *HERE*
+	 * XXX: On resuming or error we return exactly *HERE*
 	 */
+
+	if (ret != 0) {
+		printk("Something went wrong during suspend");
+	}
 }
 
 void main(void)


### PR DESCRIPTION
Some platforms have the possibility to cancel the powering off until the
very latest moment (for example if an IRQ is received). Deal with this
kind of failures.

Signed-off-by: Carlo Caione <ccaione@baylibre.com>