### PR TITLE
manifest: Pull trusted-firmware-m for isolation level 2 fix

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -225,7 +225,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: f13209f1883232cbcb9f0c31fb4c63e7c242df0d
+      revision: 4c984817d861512edaeca27b83308e9b9915a98a
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Pull trusted-firmware-m for isolation level 2 fix needed for nRF
devices.

Fixes: #49005

Signed-off-by: Joakim Andersson <joakim.andersson@nordicsemi.no>