### PR TITLE
Bluetooth: Don't disconnect in bt_unpair

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -31,6 +31,10 @@ Changes in this release
   release.  The :zephyr_file:`scripts/utils/migrate_includes.py` script is
   provided to automate the migration.
 
+* :c:func:`bt_unpair` would previously disconnect any connection with a matching
+  local identity and remote address. The previous behavior may be obtained by
+  explicitly calling :c:func:`bt_conn_disconnect` before :c:func:`bt_unpair`.
+
 Removed APIs in this release
 ============================
 

--- a/subsys/bluetooth/host/hci_core.c
+++ b/subsys/bluetooth/host/hci_core.c
@@ -1657,7 +1657,6 @@ static void unpair(uint8_t id, const bt_addr_le_t *addr)
 			conn->le.keys = NULL;
 		}
 
-		bt_conn_disconnect(conn, BT_HCI_ERR_REMOTE_USER_TERM_CONN);
 		bt_conn_unref(conn);
 	}
 


### PR DESCRIPTION
Allow local side to react to security failed due to remote missing keys
by bt_unpair without disconnecting for no reason. We disconnected for no
reason because we did not check if the link to be disconnected actually
"uses" the bond, i.e. is encrypted.

There is anyway no requirement to disconnect even if the connection did
use the bond. The connection is still usable, even if it is no longer
bonded.