### PR TITLE
ring_buffer: Introduce `RING_BUF_ITEM_SIZEOF`

### DIFF
--- a/doc/kernel/data_structures/ring_buffers.rst
+++ b/doc/kernel/data_structures/ring_buffers.rst
@@ -62,6 +62,9 @@ single static declaration exist for convenience.
 buffer with a specified byte count, where
 :c:macro:`RING_BUF_ITEM_DECLARE` will declare and statically
 initialize a buffer with a given count of 32 bit words.
+:c:macro:`RING_BUF_ITEM_SIZEOF` will compute the size in 32-bit words
+corresponding to a type or an expression.  Note: rounds up if the size is
+not a multiple of 32 bits.
 
 "Bytes" data may be copied into the ring buffer using
 :c:func:`ring_buf_put`, passing a data pointer and byte count.  These

--- a/include/zephyr/sys/ring_buffer.h
+++ b/include/zephyr/sys/ring_buffer.h
@@ -18,8 +18,6 @@
 extern "C" {
 #endif
 
-#define SIZE32_OF(x) (sizeof((x))/sizeof(uint32_t))
-
 /* The limit is used by algorithm for distinguishing between empty and full
  * state.
  */
@@ -130,6 +128,17 @@ static inline void ring_buf_internal_reset(struct ring_buf *buf, int32_t value)
  */
 #define RING_BUF_ITEM_DECLARE_POW2(name, pow) \
 	RING_BUF_ITEM_DECLARE(name, BIT(pow))
+
+/**
+ * @brief Compute the ring buffer size in 32-bit needed to store an element
+ *
+ * The argument can be a type or an expression.
+ * Note: rounds up if the size is not a multiple of 32 bits.
+ *
+ * @param expr Expression or type to compute the size of
+ */
+#define RING_BUF_ITEM_SIZEOF(expr) \
+	((sizeof(expr) + sizeof(uint32_t) - 1) / sizeof(uint32_t))
 
 /**
  * @brief Initialize a ring buffer for byte data.

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -111,7 +111,7 @@ ZTEST(ringbuffer_api, test_ring_buffer_main)
 		}
 		LOG_DBG("inserted %d chunks, %d remaining", dsize,
 			    ring_buf_space_get(&ring_buf1));
-		dsize = (dsize + 1) % SIZE32_OF(rb_data);
+		dsize = (dsize + 1) % RING_BUF_ITEM_SIZEOF(rb_data);
 		put_count++;
 	}
 
@@ -126,7 +126,7 @@ ZTEST(ringbuffer_api, test_ring_buffer_main)
 	}
 
 	for (i = 0; i < put_count; i++) {
-		getsize = SIZE32_OF(getdata);
+		getsize = RING_BUF_ITEM_SIZEOF(getdata);
 		ret = ring_buf_item_get(&ring_buf1, &gettype, &getval, getdata,
 				       &getsize);
 		zassert_true((ret == 0), "Couldn't retrieve a stored value");
@@ -140,7 +140,7 @@ ZTEST(ringbuffer_api, test_ring_buffer_main)
 		zassert_true((getval == VALUE), "value information corrupted");
 	}
 
-	getsize = SIZE32_OF(getdata);
+	getsize = RING_BUF_ITEM_SIZEOF(getdata);
 	ret = ring_buf_item_get(&ring_buf1, &gettype, &getval, getdata,
 			       &getsize);
 	zassert_true((ret == -EAGAIN), "Got data out of an empty buffer");


### PR DESCRIPTION
Current SIZE32_OF only works on variables, not types, due to an extra parenthesis pair.
Indeed, sizeof((int)) is not valid C, whereas sizeof((my_var)) is.

Remove the extra parenthesis pair.