### PR TITLE
devices: constify device pointers

### DIFF
--- a/arch/x86/core/intel64/irq.c
+++ b/arch/x86/core/intel64/irq.c
@@ -34,7 +34,7 @@ const void *x86_irq_args[NR_IRQ_VECTORS];
 #include <zephyr/device.h>
 #include <zephyr/drivers/interrupt_controller/intel_vtd.h>
 
-static const struct device *vtd = DEVICE_DT_GET_ONE(intel_vt_d);
+static const struct device *const vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 
 #endif /* CONFIG_INTEL_VTD_ICTL */
 

--- a/arch/x86/core/pcie.c
+++ b/arch/x86/core/pcie.c
@@ -164,7 +164,7 @@ void pcie_conf_write(pcie_bdf_t bdf, unsigned int reg, uint32_t data)
 #include <zephyr/drivers/interrupt_controller/intel_vtd.h>
 #include <zephyr/arch/x86/acpi.h>
 
-static const struct device *vtd = DEVICE_DT_GET_ONE(intel_vt_d);
+static const struct device *const vtd = DEVICE_DT_GET_ONE(intel_vt_d);
 
 #endif /* CONFIG_INTEL_VTD_ICTL */
 

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.yaml
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.yaml
@@ -23,6 +23,5 @@ supported:
   - pwm
   - watchdog
   - ps2
-  - peci
   - kscan
   - tach

--- a/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.yaml
+++ b/boards/arm/mec1501modular_assy6885/mec1501modular_assy6885.yaml
@@ -22,6 +22,5 @@ supported:
   - pinmux
   - pwm
   - watchdog
-  - ps2
   - kscan
   - tach

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.yaml
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.yaml
@@ -22,5 +22,4 @@ supported:
   - pinmux
   - pwm
   - watchdog
-  - ps2
   - kscan

--- a/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.yaml
+++ b/boards/arm/mec15xxevb_assy6853/mec15xxevb_assy6853.yaml
@@ -23,5 +23,4 @@ supported:
   - pwm
   - watchdog
   - ps2
-  - peci
   - kscan

--- a/drivers/adc/adc_gd32.c
+++ b/drivers/adc/adc_gd32.c
@@ -372,7 +372,7 @@ static int adc_gd32_init(const struct device *dev)
 }
 
 #define HANDLE_SHARED_IRQ(n, active_irq)							\
-	static const struct device *dev_##n = DEVICE_DT_INST_GET(n);				\
+	static const struct device *const dev_##n = DEVICE_DT_INST_GET(n);			\
 	const struct adc_gd32_config *cfg_##n = dev_##n->config;				\
 												\
 	if ((cfg_##n->irq_num == active_irq) &&							\

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1185,7 +1185,8 @@ bool adc_stm32_is_irq_active(ADC_TypeDef *adc)
 }
 
 #define HANDLE_IRQS(index)							\
-	static const struct device *dev_##index = DEVICE_DT_INST_GET(index);	\
+	static const struct device *const dev_##index =				\
+		DEVICE_DT_INST_GET(index);					\
 	const struct adc_stm32_cfg *cfg_##index = dev_##index->config;		\
 	ADC_TypeDef *adc_##index = (ADC_TypeDef *)(cfg_##index->base);		\
 										\

--- a/drivers/bluetooth/hci/h4.c
+++ b/drivers/bluetooth/hci/h4.c
@@ -69,7 +69,7 @@ static struct {
 	.fifo = Z_FIFO_INITIALIZER(tx.fifo),
 };
 
-static const struct device *h4_dev;
+static const struct device *const h4_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_uart));
 
 static inline void h4_get_type(void)
 {
@@ -558,9 +558,8 @@ static int bt_uart_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 
-	h4_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_uart));
 	if (!device_is_ready(h4_dev)) {
-		return -EINVAL;
+		return -ENODEV;
 	}
 
 	bt_hci_driver_register(&drv);

--- a/drivers/bluetooth/hci/h5.c
+++ b/drivers/bluetooth/hci/h5.c
@@ -127,7 +127,7 @@ static const uint8_t conf_rsp[] = { 0x04, 0x7b };
 #define SIG_BUF_SIZE (BT_BUF_RESERVE + MAX_SIG_LEN)
 NET_BUF_POOL_DEFINE(h5_pool, SIGNAL_COUNT, SIG_BUF_SIZE, 0, NULL);
 
-static const struct device *h5_dev;
+static const struct device *const h5_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_uart));
 
 static void h5_reset_rx(void)
 {
@@ -778,9 +778,8 @@ static int bt_uart_init(const struct device *unused)
 {
 	ARG_UNUSED(unused);
 
-	h5_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_uart));
 	if (!device_is_ready(h5_dev)) {
-		return -EINVAL;
+		return -ENODEV;
 	}
 
 	bt_hci_driver_register(&drv);

--- a/drivers/clock_control/nrf_clock_calibration.c
+++ b/drivers/clock_control/nrf_clock_calibration.c
@@ -13,9 +13,6 @@
 
 LOG_MODULE_DECLARE(clock_control, CONFIG_CLOCK_CONTROL_LOG_LEVEL);
 
-/** Temperature sensor DT node */
-#define TEMP_NODE DT_INST(0, nordic_nrf_temp)
-
 /**
  * Terms:
  * - calibration - overall process of LFRC clock calibration which is performed
@@ -51,7 +48,8 @@ static void cal_lf_callback(struct onoff_manager *mgr,
 static struct onoff_client cli;
 static struct onoff_manager *mgrs;
 
-static const struct device *temp_sensor;
+static const struct device *const temp_sensor =
+	DEVICE_DT_GET_OR_NULL(DT_INST(0, nordic_nrf_temp));
 
 static void measure_temperature(struct k_work *work);
 static K_WORK_DEFINE(temp_measure_work, measure_temperature);
@@ -231,7 +229,6 @@ void z_nrf_clock_calibration_init(struct onoff_manager *onoff_mgrs)
 #if CONFIG_CLOCK_CONTROL_NRF_CALIBRATION_MAX_SKIP
 static int temp_sensor_init(const struct device *arg)
 {
-	temp_sensor = DEVICE_DT_GET_OR_NULL(TEMP_NODE);
 	if ((temp_sensor != NULL) && !device_is_ready(temp_sensor)) {
 		LOG_ERR("Temperature sensor not ready");
 		return -ENODEV;

--- a/drivers/console/uart_console.c
+++ b/drivers/console/uart_console.c
@@ -35,7 +35,8 @@
 #include <zephyr/mgmt/mcumgr/serial.h>
 #endif
 
-static const struct device *uart_console_dev;
+static const struct device *const uart_console_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 #ifdef CONFIG_UART_CONSOLE_DEBUG_SERVER_HOOKS
 
@@ -589,8 +590,6 @@ static int uart_console_init(const struct device *arg)
 
 	ARG_UNUSED(arg);
 
-	/* Claim console device */
-	uart_console_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 	if (!device_is_ready(uart_console_dev)) {
 		return -ENODEV;
 	}

--- a/drivers/console/uart_mcumgr.c
+++ b/drivers/console/uart_mcumgr.c
@@ -15,7 +15,8 @@
 #include <zephyr/mgmt/mcumgr/serial.h>
 #include <zephyr/drivers/console/uart_mcumgr.h>
 
-static const struct device *uart_mcumgr_dev;
+static const struct device *const uart_mcumgr_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
 
 /** Callback to execute when a valid fragment has been received. */
 static uart_mcumgr_recv_fn *uart_mgumgr_recv_cb;
@@ -245,8 +246,6 @@ static void uart_mcumgr_setup(const struct device *uart)
 void uart_mcumgr_register(uart_mcumgr_recv_fn *cb)
 {
 	uart_mgumgr_recv_cb = cb;
-
-	uart_mcumgr_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_mcumgr));
 
 	if (device_is_ready(uart_mcumgr_dev)) {
 		uart_mcumgr_setup(uart_mcumgr_dev);

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -98,13 +98,14 @@ static void mcux_qtmr_isr(const struct device *timers[])
 	}
 }
 
-#define ADD_TIMER(node_id, n) timers_##n[DT_PROP(node_id, channel)] = DEVICE_DT_GET(node_id);
+#define INIT_TIMER(node_id) [DT_PROP(node_id, channel)] = DEVICE_DT_GET(node_id),
 
 #define QTMR_DEVICE_INIT_MCUX(n)							\
-	static const struct device *timers_##n[4];					\
+	static const struct device *const timers_##n[4] = {				\
+		DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(n), INIT_TIMER)		\
+	};										\
 	static int init_irq_##n(const struct device *dev)				\
 	{										\
-		DT_FOREACH_CHILD_STATUS_OKAY_VARGS(DT_DRV_INST(n), ADD_TIMER, n)	\
 		IRQ_CONNECT(DT_INST_IRQN(n), DT_INST_IRQ(n, priority), mcux_qtmr_isr,	\
 				timers_##n, 0);						\
 		irq_enable(DT_INST_IRQN(n));						\

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -143,7 +143,8 @@ static void dma_stm32_irq_handler(const struct device *dev, uint32_t id)
 #ifdef CONFIG_DMA_STM32_SHARED_IRQS
 
 #define HANDLE_IRQS(index)						       \
-	static const struct device *dev_##index = DEVICE_DT_INST_GET(index);   \
+	static const struct device *const dev_##index =			       \
+		DEVICE_DT_INST_GET(index);				       \
 	const struct dma_stm32_config *cfg_##index = dev_##index->config;      \
 	DMA_TypeDef *dma_##index = (DMA_TypeDef *)(cfg_##index->base);	       \
 									       \

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -26,7 +26,7 @@
  */
 BUILD_ASSERT(BUF_ARRAY_CNT >= 1);
 
-static const struct device *zephyr_flash_controller =
+static const struct device *const zephyr_flash_controller =
 	DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_flash_controller));
 
 static uint8_t __aligned(4) test_arr[TEST_ARR_SIZE];

--- a/drivers/gpio/gpio_npcx.c
+++ b/drivers/gpio/gpio_npcx.c
@@ -18,9 +18,11 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(gpio_npcx, LOG_LEVEL_ERR);
 
-/* GPIO module instances declarations */
-static const struct device *gpio_devs[];
-static int gpio_devs_count;
+/* GPIO module instances */
+#define NPCX_GPIO_DEV(inst) DEVICE_DT_INST_GET(inst),
+static const struct device *const gpio_devs[] = {
+	DT_INST_FOREACH_STATUS_OKAY(NPCX_GPIO_DEV)
+};
 
 /* Driver config */
 struct gpio_npcx_config {
@@ -49,7 +51,7 @@ struct gpio_npcx_data {
 /* Platform specific GPIO functions */
 const struct device *npcx_get_gpio_dev(int port)
 {
-	if (port >= gpio_devs_count) {
+	if (port >= ARRAY_SIZE(gpio_devs)) {
 		return NULL;
 	}
 
@@ -415,11 +417,3 @@ int gpio_npcx_init(const struct device *dev)
 			    &gpio_npcx_driver);
 
 DT_INST_FOREACH_STATUS_OKAY(NPCX_GPIO_DEVICE_INIT)
-
-/* GPIO module instances */
-#define NPCX_GPIO_DEV(inst) DEVICE_DT_INST_GET(inst),
-static const struct device *gpio_devs[] = {
-	DT_INST_FOREACH_STATUS_OKAY(NPCX_GPIO_DEV)
-};
-
-static int gpio_devs_count = ARRAY_SIZE(gpio_devs);

--- a/drivers/gpio/gpio_xlnx_ps.c
+++ b/drivers/gpio/gpio_xlnx_ps.c
@@ -97,7 +97,7 @@ static void gpio_xlnx_ps_isr(const struct device *dev)
 #define GPIO_XLNX_PS_CHILD_CONCAT(idx) DEVICE_DT_GET(idx),
 
 #define GPIO_XLNX_PS_GEN_BANK_ARRAY(idx)\
-static const struct device *gpio_xlnx_ps##idx##_banks[] = {\
+static const struct device *const gpio_xlnx_ps##idx##_banks[] = {\
 	DT_FOREACH_CHILD_STATUS_OKAY(DT_DRV_INST(idx), GPIO_XLNX_PS_CHILD_CONCAT)\
 };
 

--- a/drivers/interrupt_controller/intc_ioapic.c
+++ b/drivers/interrupt_controller/intc_ioapic.c
@@ -122,7 +122,8 @@ static void IoApicRedUpdateLo(unsigned int irq, uint32_t value,
 #include <zephyr/drivers/interrupt_controller/intel_vtd.h>
 #include <zephyr/arch/x86/acpi.h>
 
-static const struct device *vtd;
+static const struct device *const vtd =
+	DEVICE_DT_GET_OR_NULL(DT_INST(0, intel_vt_d));
 static uint16_t ioapic_id;
 
 
@@ -131,14 +132,6 @@ static bool get_vtd(void)
 	if (vtd != NULL) {
 		return true;
 	}
-
-#define DRV_COMPAT_BAK DT_DRV_COMPAT
-#undef DT_DRV_COMPAT
-#define DT_DRV_COMPAT intel_vt_d
-	vtd = DEVICE_DT_GET_OR_NULL(DT_DRV_INST(0));
-#undef DT_DRV_COMPAT
-#define DT_DRV_COMPAT DRV_COMPAT_BAK
-#undef DRV_COMPAT_BAK
 
 	ioapic_id = z_acpi_get_dev_id_from_dmar(ACPI_DRHD_DEV_SCOPE_IOAPIC);
 

--- a/drivers/interrupt_controller/intc_miwu.c
+++ b/drivers/interrupt_controller/intc_miwu.c
@@ -59,8 +59,15 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(intc_miwu, LOG_LEVEL_ERR);
 
-/* MIWU module instances forward declaration */
-static const struct device *miwu_devs[];
+/* MIWU module instances */
+#define NPCX_MIWU_DEV(inst) DEVICE_DT_INST_GET(inst),
+
+static const struct device *const miwu_devs[] = {
+	DT_INST_FOREACH_STATUS_OKAY(NPCX_MIWU_DEV)
+};
+
+BUILD_ASSERT(ARRAY_SIZE(miwu_devs) == NPCX_MIWU_TABLE_COUNT,
+		"Size of miwu_devs array must equal to NPCX_MIWU_TABLE_COUNT");
 
 /* Driver config */
 struct intc_miwu_config {
@@ -390,13 +397,3 @@ int npcx_miwu_manage_dev_callback(struct miwu_dev_callback *cb, bool set)
 	NPCX_MIWU_INIT_FUNC_IMPL(inst)
 
 DT_INST_FOREACH_STATUS_OKAY(NPCX_MIWU_INIT)
-
-/* MIWU module instances */
-#define NPCX_MIWU_DEV(inst) DEVICE_DT_INST_GET(inst),
-
-static const struct device *miwu_devs[] = {
-	DT_INST_FOREACH_STATUS_OKAY(NPCX_MIWU_DEV)
-};
-
-BUILD_ASSERT(ARRAY_SIZE(miwu_devs) == NPCX_MIWU_TABLE_COUNT,
-		"Size of miwu_devs array must equal to NPCX_MIWU_TABLE_COUNT");

--- a/drivers/pinctrl/pinctrl_stm32.c
+++ b/drivers/pinctrl/pinctrl_stm32.c
@@ -19,7 +19,7 @@
  *
  * Entries will be NULL if the GPIO port is not enabled.
  */
-static const struct device * const gpio_ports[] = {
+static const struct device *const gpio_ports[] = {
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioa)),
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpiob)),
 	DEVICE_DT_GET_OR_NULL(DT_NODELABEL(gpioc)),

--- a/drivers/pinctrl/pinctrl_xlnx_zynq.c
+++ b/drivers/pinctrl/pinctrl_xlnx_zynq.c
@@ -22,7 +22,7 @@ BUILD_ASSERT(DT_NUM_INST_STATUS_OKAY(DT_DRV_COMPAT) == 1,
 #define SD0_WP_CD_SEL_OFFSET 0x0130
 #define SD1_WP_CD_SEL_OFFSET 0x0134
 
-static const struct device *slcr = DEVICE_DT_GET(DT_INST_PHANDLE(0, syscon));
+static const struct device *const slcr = DEVICE_DT_GET(DT_INST_PHANDLE(0, syscon));
 static mm_reg_t base = DT_INST_REG_ADDR(0);
 K_SEM_DEFINE(pinctrl_lock, 1, 1);
 

--- a/drivers/serial/uart_pipe.c
+++ b/drivers/serial/uart_pipe.c
@@ -21,7 +21,8 @@ LOG_MODULE_REGISTER(uart_pipe);
 #include <zephyr/drivers/uart_pipe.h>
 #include <zephyr/sys/printk.h>
 
-static const struct device *uart_pipe_dev;
+static const struct device *const uart_pipe_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_pipe));
 
 static uint8_t *recv_buf;
 static size_t recv_buf_len;
@@ -98,9 +99,7 @@ void uart_pipe_register(uint8_t *buf, size_t len, uart_pipe_recv_cb cb)
 	recv_buf_len = len;
 	app_cb = cb;
 
-	uart_pipe_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_uart_pipe));
-
-	if (uart_pipe_dev != NULL) {
+	if (device_is_ready(uart_pipe_dev)) {
 		uart_pipe_setup(uart_pipe_dev);
 	}
 }

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -42,7 +42,7 @@ static const struct stm32_pclken lptim_clk[] = {
 static const struct stm32_pclken lptim_clk[] = STM32_DT_INST_CLOCKS(0);
 #endif
 
-static const struct device *clk_ctrl = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+static const struct device *const clk_ctrl = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 /*
  * Assumptions and limitations:

--- a/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/sl_opensource/platform/nrf_802154_temperature_zephyr.c
@@ -30,7 +30,7 @@ static int8_t value = DEFAULT_TEMPERATURE;
 
 #if defined(CONFIG_NRF_802154_TEMPERATURE_UPDATE)
 
-static const struct device *device = DEVICE_DT_GET(DT_NODELABEL(temp));
+static const struct device *const device = DEVICE_DT_GET(DT_NODELABEL(temp));
 static struct k_work_delayable dwork;
 
 static void work_handler(struct k_work *work)

--- a/modules/openthread/platform/entropy.c
+++ b/modules/openthread/platform/entropy.c
@@ -19,7 +19,7 @@ LOG_MODULE_REGISTER(net_otPlat_entropy, CONFIG_OPENTHREAD_L2_LOG_LEVEL);
 #error OpenThread requires an entropy source for a TRNG
 #endif
 
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+static const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
 {

--- a/samples/arch/mpu/mpu_test/src/main.c
+++ b/samples/arch/mpu/mpu_test/src/main.c
@@ -31,7 +31,7 @@
 
 #if defined(CONFIG_SOC_FLASH_MCUX) || defined(CONFIG_SOC_FLASH_LPC) || \
 	defined(CONFIG_SOC_FLASH_STM32)
-static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+static const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 #endif
 
 static int cmd_read(const struct shell *shell, size_t argc, char *argv[])

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -83,7 +83,7 @@ const static struct spi_buf_set tx_bufs = {
  * This is the SPI bus controller device used to exchange data with
  * the SPI-based BT controller.
  */
-static const struct device *spi_hci_dev = DEVICE_DT_GET(DT_BUS(HCI_SPI_NODE));
+static const struct device *const spi_hci_dev = DEVICE_DT_GET(DT_BUS(HCI_SPI_NODE));
 static struct spi_config spi_cfg = {
 	.operation = SPI_WORD_SET(8) | SPI_OP_MODE_SLAVE,
 };

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -30,7 +30,7 @@
 #define LOG_MODULE_NAME hci_uart
 LOG_MODULE_REGISTER(LOG_MODULE_NAME);
 
-static const struct device *hci_uart_dev =
+static const struct device *const hci_uart_dev =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_c2h_uart));
 static K_THREAD_STACK_DEFINE(tx_thread_stack, CONFIG_BT_HCI_TX_STACK_SIZE);
 static struct k_thread tx_thread_data;

--- a/samples/bluetooth/mesh/src/board.c
+++ b/samples/bluetooth/mesh/src/board.c
@@ -37,7 +37,7 @@
 #define LED0_PIN DT_PHA(LED0, gpios, pin)
 #define LED0_FLAGS DT_PHA(LED0, gpios, flags)
 
-static const struct device *led_dev = DEVICE_DT_GET(LED0_DEV);
+static const struct device *const led_dev = DEVICE_DT_GET(LED0_DEV);
 #endif /* LED0 */
 
 #if DT_NODE_EXISTS(BUTTON0)
@@ -45,7 +45,7 @@ static const struct device *led_dev = DEVICE_DT_GET(LED0_DEV);
 #define BUTTON0_PIN DT_PHA(BUTTON0, gpios, pin)
 #define BUTTON0_FLAGS DT_PHA(BUTTON0, gpios, flags)
 
-static const struct device *button_dev = DEVICE_DT_GET(BUTTON0_DEV);
+static const struct device *const button_dev = DEVICE_DT_GET(BUTTON0_DEV);
 static struct k_work *button_work;
 
 static void button_cb(const struct device *port, struct gpio_callback *cb,

--- a/samples/bluetooth/mesh_demo/src/microbit.c
+++ b/samples/bluetooth/mesh_demo/src/microbit.c
@@ -32,9 +32,10 @@ static const struct gpio_dt_spec button_a =
 	GPIO_DT_SPEC_GET(DT_NODELABEL(buttona), gpios);
 static const struct gpio_dt_spec button_b =
 	GPIO_DT_SPEC_GET(DT_NODELABEL(buttonb), gpios);
-static const struct device *nvm =
+static const struct device *const nvm =
 	DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
-static const struct device *pwm = DEVICE_DT_GET_ANY(nordic_nrf_sw_pwm);
+static const struct device *const pwm =
+	DEVICE_DT_GET_ANY(nordic_nrf_sw_pwm);
 
 static struct k_work button_work;
 

--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -86,7 +86,7 @@ void main(void)
 	}
 
 #ifdef CONFIG_LP3943
-	static const struct device *ledc = DEVICE_DT_GET_ONE(ti_lp3943);
+	static const struct device *const ledc = DEVICE_DT_GET_ONE(ti_lp3943);
 
 	if (!device_is_ready(ledc)) {
 		printk("Device %s is not ready\n", ledc->name);

--- a/samples/boards/96b_argonkey/sensors/src/main.c
+++ b/samples/boards/96b_argonkey/sensors/src/main.c
@@ -20,6 +20,10 @@
 #define WHOAMI_REG      0x0F
 #define WHOAMI_ALT_REG  0x4F
 
+#ifdef CONFIG_LP3943
+static const struct device *const ledc = DEVICE_DT_GET_ONE(ti_lp3943);
+#endif
+
 static inline float out_ev(struct sensor_value *val)
 {
 	return (val->val1 + (float)val->val2 / 1000000);
@@ -112,9 +116,6 @@ void main(void)
 	int i, on = 1;
 
 #ifdef CONFIG_LP3943
-	static const struct device *ledc;
-
-	ledc = DEVICE_DT_GET_ONE(ti_lp3943);
 	if (!device_is_ready(ledc)) {
 		printk("%s: device not ready.\n", ledc->name);
 		return;

--- a/samples/boards/mimxrt1060_evk/system_off/src/main.c
+++ b/samples/boards/mimxrt1060_evk/system_off/src/main.c
@@ -29,7 +29,7 @@
 #define SNVS_LP_RTC_ALARM_ID 1
 
 static const struct gpio_dt_spec button = GPIO_DT_SPEC_GET_OR(SW0_NODE, gpios, { 0 });
-static const struct device *snvs_rtc_dev = DEVICE_DT_GET(SNVS_RTC_NODE);
+static const struct device *const snvs_rtc_dev = DEVICE_DT_GET(SNVS_RTC_NODE);
 
 void main(void)
 {

--- a/samples/boards/nrf/clock_skew/src/main.c
+++ b/samples/boards/nrf/clock_skew/src/main.c
@@ -14,8 +14,8 @@
 
 #define UPDATE_INTERVAL_S 10
 
-static const struct device *clock0 = DEVICE_DT_GET_ONE(nordic_nrf_clock);
-static const struct device *timer0 = DEVICE_DT_GET(DT_NODELABEL(timer0));
+static const struct device *const clock0 = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+static const struct device *const timer0 = DEVICE_DT_GET(DT_NODELABEL(timer0));
 static struct timeutil_sync_config sync_config;
 static uint64_t counter_ref;
 static struct timeutil_sync_state sync_state;

--- a/samples/boards/reel_board/mesh_badge/src/periphs.c
+++ b/samples/boards/reel_board/mesh_badge/src/periphs.c
@@ -12,7 +12,7 @@
 
 #include <zephyr/bluetooth/mesh.h>
 
-static const struct device *dev_info[] = {
+static const struct device *const dev_info[] = {
 	DEVICE_DT_GET_ONE(ti_hdc1010),
 	DEVICE_DT_GET_ONE(nxp_mma8652fc),
 	DEVICE_DT_GET_ONE(avago_apds9960),

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -49,7 +49,7 @@ struct font_info {
 
 #define STAT_COUNT 128
 
-static const struct device *epd_dev;
+static const struct device *const epd_dev = DEVICE_DT_GET_ONE(solomon_ssd16xxfb);
 static bool pressed;
 static uint8_t screen_id = SCREEN_MAIN;
 static struct k_work_delayable epd_work;
@@ -580,7 +580,6 @@ void board_refresh_display(void)
 
 int board_init(void)
 {
-	epd_dev = DEVICE_DT_GET_ONE(solomon_ssd16xxfb);
 	if (!device_is_ready(epd_dev)) {
 		printk("%s: device not ready.\n", epd_dev->name);
 		return -ENODEV;

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/src/main.c
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/src/main.c
@@ -11,18 +11,15 @@
 #include <zephyr/sys/printk.h>
 #include <zephyr/sys/__assert.h>
 
-#define DEV_NAME DT_CHOSEN(zephyr_console)
-
 void main(void)
 {
-	static const struct device *dev;
+	const struct device *const dev =
+		DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
-	dev = DEVICE_DT_GET(DEV_NAME);
-	if (dev < 0) {
-		printk("Failed to get device");
+	if (!device_is_ready(dev)) {
+		printk("Console device not ready");
+		return;
 	}
-
-	printk("Device ready\n");
 
 #if CONFIG_PM_DEVICE
 	/* In PM_DEVICE modes, enable device as a wakeup source will prevent

--- a/samples/boards/stm32/usbc/sink/src/stm32g081b_eval_board.c
+++ b/samples/boards/stm32/usbc/sink/src/stm32g081b_eval_board.c
@@ -27,7 +27,8 @@ static const struct gpio_dt_spec discharge_vbus = GPIO_DT_SPEC_GET(DISCHARGE_VBU
 #define ADC_ACQUISITION_TIME    ADC_ACQ_TIME_DEFAULT
 #define ADC_REF_MV              3300
 
-static const struct device *dev_adc;
+static const struct device *const dev_adc =
+	DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(VBUS));
 static int16_t sample_buffer;
 
 static const uint32_t output_ohm = DT_PROP(VBUS, output_ohms);
@@ -94,7 +95,6 @@ int board_config(void)
 {
 	int ret;
 
-	dev_adc = DEVICE_DT_GET(DT_IO_CHANNELS_CTLR(VBUS));
 	if (!device_is_ready(dev_adc)) {
 		printk("ADC device not found\n");
 		return -ENODEV;

--- a/samples/drivers/dac/src/main.c
+++ b/samples/drivers/dac/src/main.c
@@ -23,7 +23,7 @@
 #define DAC_RESOLUTION 0
 #endif
 
-static const struct device *dac_dev = DEVICE_DT_GET(DAC_NODE);
+static const struct device *const dac_dev = DEVICE_DT_GET(DAC_NODE);
 
 static const struct dac_channel_cfg dac_ch_cfg = {
 	.channel_id  = DAC_CHANNEL_ID,

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -46,7 +46,7 @@ static const struct gpio_dt_spec pwrgd_gpio = GPIO_DT_SPEC_GET(BRD_PWR_NODE, pwr
 static const struct gpio_dt_spec rsm_gpio = GPIO_DT_SPEC_GET(BRD_PWR_NODE, rsm_gpios);
 #endif
 
-static const struct device *espi_dev = DEVICE_DT_GET(DT_NODELABEL(espi0));
+static const struct device *const espi_dev = DEVICE_DT_GET(DT_NODELABEL(espi0));
 static struct espi_callback espi_bus_cb;
 static struct espi_callback vw_rdy_cb;
 static struct espi_callback vw_cb;
@@ -62,9 +62,6 @@ static uint8_t flash_read_buf[MAX_TEST_BUF_SIZE];
 #endif
 
 #ifdef CONFIG_ESPI_SAF
-#define ESPI_SAF_NODE     DT_NODELABEL(espi_saf0)
-#define SPI_NODE          DT_NODELABEL(spi0)
-
 #define SAF_BASE_ADDR     DT_REG_ADDR(ESPI_SAF_NODE)
 
 #define SAF_TEST_FREQ_HZ 24000000U
@@ -98,8 +95,10 @@ struct saf_addr_info {
 	uintptr_t saf_struct_addr;
 	uintptr_t saf_exp_addr;
 };
-static const struct device *qspi_dev;
-static const struct device *espi_saf_dev;
+static const struct device *const qspi_dev =
+	DEVICE_DT_GET(DT_NODELABEL(spi0));
+static const struct device *const espi_saf_dev =
+	DEVICE_DT_GET(DT_NODELABEL(espi_saf0));
 static uint8_t safbuf[SAF_TEST_BUF_SIZE] __aligned(4);
 static uint8_t safbuf2[SAF_TEST_BUF_SIZE] __aligned(4);
 
@@ -1218,13 +1217,11 @@ int espi_test(void)
 	}
 
 #ifdef CONFIG_ESPI_SAF
-	qspi_dev = DEVICE_DT_GET(SPI_NODE);
 	if (!device_is_ready(qspi_dev)) {
 		LOG_ERR("%s: device not ready.", qspi_dev->name);
 		return -ENODEV;
 	}
 
-	espi_saf_dev = DEVICE_DT_GET(ESPI_SAF_NODE);
 	if (!device_is_ready(espi_saf_dev)) {
 		LOG_ERR("%s: device not ready.", espi_saf_dev->name);
 		return -ENODEV;

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -38,7 +38,7 @@ static const struct led_rgb black = {
 
 struct led_rgb strip_colors[STRIP_NUM_LEDS];
 
-static const struct device *strip = DEVICE_DT_GET_ANY(greeled_lpd8806);
+static const struct device *const strip = DEVICE_DT_GET_ANY(greeled_lpd8806);
 
 const struct led_rgb *color_at(size_t time, size_t i)
 {

--- a/samples/drivers/led_ws2812/src/main.c
+++ b/samples/drivers/led_ws2812/src/main.c
@@ -33,7 +33,7 @@ static const struct led_rgb colors[] = {
 
 struct led_rgb pixels[STRIP_NUM_PIXELS];
 
-static const struct device *strip = DEVICE_DT_GET(STRIP_NODE);
+static const struct device *const strip = DEVICE_DT_GET(STRIP_NODE);
 
 void main(void)
 {

--- a/samples/drivers/peci/sample.yaml
+++ b/samples/drivers/peci/sample.yaml
@@ -5,6 +5,7 @@ tests:
     # theoretically EVB can be connected to Intel RVP as well,
     # but HW setup is not documented, hence qualifying as unsupported.
     platform_exclude: mec15xxevb_assy6853
+    filter: dt_alias_exists("peci-0")
     tags: drivers
     harness: console
     harness_config:
@@ -12,4 +13,3 @@ tests:
         ordered: true
         regex:
             - "mb data(.*)"
-    depends_on: peci

--- a/samples/drivers/peci/src/main.c
+++ b/samples/drivers/peci/src/main.c
@@ -23,7 +23,7 @@
 
 #define PECI_SAFE_TEMP          72
 
-static const struct device *peci_dev;
+static const struct device *const peci_dev = DEVICE_DT_GET(DT_ALIAS(peci_0));
 static bool peci_initialized;
 static uint8_t tjmax;
 static uint8_t rx_fcs;
@@ -176,9 +176,7 @@ static void monitor_temperature_func(void *dummy1, void *dummy2, void *dummy3)
 
 void main(void)
 {
-#if DT_NODE_HAS_STATUS(DT_ALIAS(peci_0), okay)
 	int ret;
-#endif
 
 	printk("PECI sample test\n");
 
@@ -186,8 +184,6 @@ void main(void)
 		monitor_temperature_func, NULL, NULL, NULL, PRIORITY,
 		K_INHERIT_PERMS, K_FOREVER);
 
-#if DT_NODE_HAS_STATUS(DT_ALIAS(peci_0), okay)
-	peci_dev = DEVICE_DT_GET(DT_ALIAS(peci_0));
 	if (!device_is_ready(peci_dev)) {
 		printk("Err: PECI device is not ready\n");
 		return;
@@ -208,5 +204,4 @@ void main(void)
 	k_thread_start(&temp_id);
 
 	peci_initialized = true;
-#endif
 }

--- a/samples/drivers/ps2/sample.yaml
+++ b/samples/drivers/ps2/sample.yaml
@@ -10,4 +10,4 @@ tests:
         regex:
             - "mb data(.*)"
         fixture: fixture_connect_mouse
-    depends_on: ps2
+    filter: dt_compat_enabled("microchip,xec-ps2")

--- a/samples/drivers/ps2/src/main.c
+++ b/samples/drivers/ps2/src/main.c
@@ -33,7 +33,8 @@ K_MSGQ_DEFINE(aux_to_host_queue, sizeof(uint8_t), 8, 4);
 /* We use a timer to saturate the queue */
 K_TIMER_DEFINE(block_ps2_timer, saturate_ps2, NULL);
 
-static const struct device *ps2_0_dev;
+static const struct device *const ps2_0_dev =
+	DEVICE_DT_GET_ONE(microchip_xec_ps2);
 
 static void saturate_ps2(struct k_timer *timer)
 {
@@ -175,8 +176,6 @@ void main(void)
 	/* The ps2 blocks are generic, therefore, it is allowed to swap
 	 * keyboard and mouse as desired
 	 */
-#if DT_HAS_COMPAT_STATUS_OKAY(microchip_xec_ps2)
-	ps2_0_dev = DEVICE_DT_GET_ONE(microchip_xec_ps2);
 	if (!device_is_ready(ps2_0_dev)) {
 		printk("%s: device not ready.\n", ps2_0_dev->name);
 		return;
@@ -184,6 +183,6 @@ void main(void)
 	ps2_config(ps2_0_dev, mb_callback);
 	/*Make sure there is a PS/2 device connected */
 	initialize_mouse();
-#endif
+
 	k_timer_start(&block_ps2_timer, K_SECONDS(2), K_SECONDS(1));
 }

--- a/samples/drivers/uart/echo_bot/src/main.c
+++ b/samples/drivers/uart/echo_bot/src/main.c
@@ -18,7 +18,7 @@
 /* queue to store up to 10 messages (aligned to 4-byte boundary) */
 K_MSGQ_DEFINE(uart_msgq, MSG_SIZE, 10, 4);
 
-static const struct device *uart_dev = DEVICE_DT_GET(UART_DEVICE_NODE);
+static const struct device *const uart_dev = DEVICE_DT_GET(UART_DEVICE_NODE);
 
 /* receive buffer used in UART ISR callback */
 static char rx_buf[MSG_SIZE];

--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(sample_gsm_ppp, LOG_LEVEL_DBG);
 #define GSM_MODEM_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(zephyr_gsm_ppp)
 #define UART_NODE DT_BUS(GSM_MODEM_NODE)
 
-static const struct device *gsm_dev;
+static const struct device *const gsm_dev = DEVICE_DT_GET(GSM_MODEM_NODE);
 static struct net_mgmt_event_callback mgmt_cb;
 static bool starting = IS_ENABLED(CONFIG_GSM_PPP_AUTOSTART);
 
@@ -113,8 +113,6 @@ static void modem_off_cb(const struct device *dev, void *user_data)
 int main(void)
 {
 	const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
-
-	gsm_dev = DEVICE_DT_GET(GSM_MODEM_NODE);
 
 	/* Optional register modem power callbacks */
 	gsm_ppp_register_modem_power_callback(gsm_dev, modem_on_cb, modem_off_cb, NULL);

--- a/samples/net/wpan_serial/src/main.c
+++ b/samples/net/wpan_serial/src/main.c
@@ -61,7 +61,8 @@ static const struct device *const ieee802154_dev =
 uint8_t mac_addr[8];
 
 /* UART device */
-static const struct device *uart_dev;
+static const struct device *const uart_dev =
+	DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
 
 /* SLIP state machine */
 static uint8_t slip_state = STATE_OK;
@@ -527,14 +528,12 @@ enum net_verdict ieee802154_radio_handle_ack(struct net_if *iface, struct net_pk
 
 void main(void)
 {
-	const struct device *dev;
 	uint32_t baudrate, dtr = 0U;
 	int ret;
 
 	LOG_INF("Starting wpan_serial application");
 
-	dev = DEVICE_DT_GET_ONE(zephyr_cdc_acm_uart);
-	if (!device_is_ready(dev)) {
+	if (!device_is_ready(uart_dev)) {
 		LOG_ERR("CDC ACM device not ready");
 		return;
 	}
@@ -548,7 +547,7 @@ void main(void)
 	LOG_DBG("Wait for DTR");
 
 	while (1) {
-		uart_line_ctrl_get(dev, UART_LINE_CTRL_DTR, &dtr);
+		uart_line_ctrl_get(uart_dev, UART_LINE_CTRL_DTR, &dtr);
 		if (dtr) {
 			break;
 		} else {
@@ -557,11 +556,9 @@ void main(void)
 		}
 	}
 
-	uart_dev = dev;
-
 	LOG_DBG("DTR set, continue");
 
-	ret = uart_line_ctrl_get(dev, UART_LINE_CTRL_BAUD_RATE, &baudrate);
+	ret = uart_line_ctrl_get(uart_dev, UART_LINE_CTRL_BAUD_RATE, &baudrate);
 	if (ret) {
 		LOG_WRN("Failed to get baudrate, ret code %d", ret);
 	} else {
@@ -585,8 +582,8 @@ void main(void)
 		return;
 	}
 
-	uart_irq_callback_set(dev, interrupt_handler);
+	uart_irq_callback_set(uart_dev, interrupt_handler);
 
 	/* Enable rx interrupts */
-	uart_irq_rx_enable(dev);
+	uart_irq_rx_enable(uart_dev);
 }

--- a/samples/sensor/accel_polling/src/main.c
+++ b/samples/sensor/accel_polling/src/main.c
@@ -17,7 +17,7 @@
 	IF_ENABLED(DT_NODE_EXISTS(ACCEL_ALIAS(i)), (DEVICE_DT_GET(ACCEL_ALIAS(i)),))
 
 /* support up to 10 accelerometer sensors */
-static const struct device *sensors[] = {LISTIFY(10, ACCELEROMETER_DEVICE, ())};
+static const struct device *const sensors[] = {LISTIFY(10, ACCELEROMETER_DEVICE, ())};
 
 static const enum sensor_channel channels[] = {
 	SENSOR_CHAN_ACCEL_X,

--- a/samples/shields/x_nucleo_53l0a1/src/display_7seg.c
+++ b/samples/shields/x_nucleo_53l0a1/src/display_7seg.c
@@ -13,8 +13,8 @@ const uint8_t DISPLAY_OFF[4] = { CHAR_OFF, CHAR_OFF, CHAR_OFF, CHAR_OFF };
 const uint8_t TEXT_Err[4] = { CHAR_E, CHAR_r, CHAR_r, CHAR_OFF };
 
 static bool initialized;
-static const struct device *expander1 = DEVICE_DT_GET(DT_NODELABEL(expander1));
-static const struct device *expander2 = DEVICE_DT_GET(DT_NODELABEL(expander2));
+static const struct device *const expander1 = DEVICE_DT_GET(DT_NODELABEL(expander1));
+static const struct device *const expander2 = DEVICE_DT_GET(DT_NODELABEL(expander2));
 static const uint8_t digits[16] = {
 	CHAR_0,
 	CHAR_1,

--- a/samples/shields/x_nucleo_53l0a1/src/main.c
+++ b/samples/shields/x_nucleo_53l0a1/src/main.c
@@ -29,7 +29,7 @@ typedef void (*fsm_state)(void);
 
 static int64_t last_mode_change;
 
-static const struct device *sensors[] = {
+static const struct device *const sensors[] = {
 	DEVICE_DT_GET(DT_NODELABEL(vl53l0x_l)),
 	DEVICE_DT_GET(DT_NODELABEL(vl53l0x_c)),
 	DEVICE_DT_GET(DT_NODELABEL(vl53l0x_r)),

--- a/samples/subsys/ipc/openamp/remote/src/main.c
+++ b/samples/subsys/ipc/openamp/remote/src/main.c
@@ -23,7 +23,8 @@
 K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);
 static struct k_thread thread_data;
 
-static const struct device *ipm_handle;
+static const struct device *const ipm_handle =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 
 static metal_phys_addr_t shm_physmap[] = { SHM_START_ADDR };
 static struct metal_device shm_device = {
@@ -176,7 +177,6 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	}
 
 	/* setup IPM */
-	ipm_handle = DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 	if (!device_is_ready(ipm_handle)) {
 		printk("IPM device is not ready\n");
 		return;

--- a/samples/subsys/ipc/openamp/src/main.c
+++ b/samples/subsys/ipc/openamp/src/main.c
@@ -24,7 +24,8 @@
 K_THREAD_STACK_DEFINE(thread_stack, APP_TASK_STACK_SIZE);
 static struct k_thread thread_data;
 
-static const struct device *ipm_handle;
+static const struct device *const ipm_handle =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 
 static metal_phys_addr_t shm_physmap[] = { SHM_START_ADDR };
 static struct metal_device shm_device = {
@@ -200,7 +201,6 @@ void app_task(void *arg1, void *arg2, void *arg3)
 	}
 
 	/* setup IPM */
-	ipm_handle = DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 	if (!device_is_ready(ipm_handle)) {
 		printk("IPM device is not ready\n");
 		return;

--- a/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
+++ b/samples/subsys/ipc/openamp_rsc_table/src/main_remote.c
@@ -44,7 +44,8 @@ static struct k_thread thread_mng_data;
 static struct k_thread thread_rp__client_data;
 static struct k_thread thread_tty_data;
 
-static const struct device *ipm_handle;
+static const struct device *const ipm_handle =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 
 static metal_phys_addr_t shm_physmap = SHM_START_ADDR;
 
@@ -191,7 +192,6 @@ int platform_init(void)
 	}
 
 	/* setup IPM */
-	ipm_handle = DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 	if (!device_is_ready(ipm_handle)) {
 		LOG_DBG("IPM device is not ready\n");
 		return -1;

--- a/samples/subsys/usb/audio/headphones_microphone/src/main.c
+++ b/samples/subsys/usb/audio/headphones_microphone/src/main.c
@@ -16,7 +16,7 @@
 
 LOG_MODULE_REGISTER(main, LOG_LEVEL_INF);
 
-static const struct device *mic_dev;
+static const struct device *const mic_dev = DEVICE_DT_GET_ONE(usb_audio_mic);
 
 static void data_received(const struct device *dev,
 			  struct net_buf *buffer,
@@ -69,7 +69,6 @@ void main(void)
 	int ret;
 
 	LOG_INF("Entered %s", __func__);
-	mic_dev = DEVICE_DT_GET_ONE(usb_audio_mic);
 
 	if (!device_is_ready(hp_dev)) {
 		LOG_ERR("Device USB Headphones is not ready");

--- a/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/nordic/lll/lll.c
@@ -59,7 +59,7 @@ static struct {
 } event;
 
 /* Entropy device */
-static const struct device *dev_entropy = DEVICE_DT_GET(DT_NODELABEL(rng));
+static const struct device *const dev_entropy = DEVICE_DT_GET(DT_NODELABEL(rng));
 
 static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)

--- a/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
+++ b/subsys/bluetooth/controller/ll_sw/openisa/lll/lll.c
@@ -52,7 +52,7 @@ static struct {
 } event;
 
 /* Entropy device */
-static const struct device *dev_entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+static const struct device *const dev_entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 static int init_reset(void);
 #if defined(CONFIG_BT_CTLR_LOW_LAT_ULL_DONE)

--- a/subsys/bluetooth/host/monitor.c
+++ b/subsys/bluetooth/host/monitor.c
@@ -141,7 +141,8 @@ static void poll_out(char c)
 	monitor_send(&c, sizeof(c));
 }
 #elif defined(CONFIG_BT_DEBUG_MONITOR_UART)
-static const struct device *monitor_dev;
+static const struct device *const monitor_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_mon_uart));
 
 static void poll_out(char c)
 {
@@ -376,8 +377,6 @@ static int bt_monitor_init(const struct device *d)
 				  RTT_BUFFER_NAME, rtt_up_buf, RTT_BUF_SIZE,
 				  SEGGER_RTT_MODE_NO_BLOCK_SKIP);
 #elif defined(CONFIG_BT_DEBUG_MONITOR_UART)
-	monitor_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_bt_mon_uart));
-
 	__ASSERT_NO_MSG(device_is_ready(monitor_dev));
 
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN)

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -19,7 +19,8 @@
 #define HELP_INIT "call \"cfb init\" first"
 #define HELP_PRINT "<col: pos> <row: pos> \"<text>\""
 
-static const struct device *dev;
+static const struct device *const dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 static const char * const param_name[] = {
 	"height", "width", "ppt", "rows", "cols"};
 
@@ -410,7 +411,6 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 {
 	int err;
 
-	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(dev)) {
 		shell_error(shell, "Display device not ready");
 		return -ENODEV;

--- a/subsys/ipc/rpmsg_service/rpmsg_backend.c
+++ b/subsys/ipc/rpmsg_service/rpmsg_backend.c
@@ -50,10 +50,13 @@ struct k_work_q ipm_work_q;
 /* End of configuration defines */
 
 #if defined(CONFIG_RPMSG_SERVICE_DUAL_IPM_SUPPORT)
-static const struct device *ipm_tx_handle;
-static const struct device *ipm_rx_handle;
+static const struct device *const ipm_tx_handle =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc_tx));
+static const struct device *const ipm_rx_handle =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc_rx));
 #elif defined(CONFIG_RPMSG_SERVICE_SINGLE_IPM_SUPPORT)
-static const struct device *ipm_handle;
+static const struct device *const ipm_handle =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 #endif
 
 static metal_phys_addr_t shm_physmap[] = { SHM_START_ADDR };
@@ -210,9 +213,6 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 
 	/* IPM setup */
 #if defined(CONFIG_RPMSG_SERVICE_DUAL_IPM_SUPPORT)
-	ipm_tx_handle = DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc_tx));
-	ipm_rx_handle = DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc_rx));
-
 	if (!device_is_ready(ipm_tx_handle)) {
 		LOG_ERR("IPM TX device is not ready");
 		return -ENODEV;
@@ -232,7 +232,6 @@ int rpmsg_backend_init(struct metal_io_region **io, struct virtio_device *vdev)
 	}
 
 #elif defined(CONFIG_RPMSG_SERVICE_SINGLE_IPM_SUPPORT)
-	ipm_handle = DEVICE_DT_GET(DT_CHOSEN(zephyr_ipc));
 	if (!device_is_ready(ipm_handle)) {
 		LOG_ERR("IPM device is not ready");
 		return -ENODEV;

--- a/subsys/logging/log_backend_adsp_hda.c
+++ b/subsys/logging/log_backend_adsp_hda.c
@@ -15,7 +15,8 @@
 #include <zephyr/kernel.h>
 
 static uint32_t log_format_current = CONFIG_LOG_BACKEND_ADSP_HDA_OUTPUT_DEFAULT;
-static const struct device *hda_log_dev;
+static const struct device *const hda_log_dev =
+	DEVICE_DT_GET(DT_NODELABEL(hda_host_in));
 static uint32_t hda_log_chan;
 
 /*
@@ -248,7 +249,6 @@ void adsp_hda_log_init(adsp_hda_log_hook_t fn, uint32_t channel)
 
 	int res;
 
-	hda_log_dev = DEVICE_DT_GET(DT_NODELABEL(hda_host_in));
 	__ASSERT(device_is_ready(hda_log_dev), "DMA device is not ready");
 
 	hda_log_chan = dma_request_channel(hda_log_dev, &channel);

--- a/subsys/logging/log_backend_uart.c
+++ b/subsys/logging/log_backend_uart.c
@@ -20,7 +20,8 @@ LOG_MODULE_REGISTER(log_uart);
  */
 static const char LOG_HEX_SEP[10] = "##ZLOGV1##";
 
-static const struct device *uart_dev;
+static const struct device *const uart_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 static struct k_sem sem;
 static volatile bool in_panic;
 static bool use_async;
@@ -107,7 +108,6 @@ static int format_set(const struct log_backend *const backend, uint32_t log_type
 
 static void log_backend_uart_init(struct log_backend const *const backend)
 {
-	uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 	__ASSERT_NO_MSG(device_is_ready(uart_dev));
 
 	if (IS_ENABLED(CONFIG_LOG_BACKEND_UART_OUTPUT_DICTIONARY_HEX)) {

--- a/subsys/logging/log_frontend_dict_uart.c
+++ b/subsys/logging/log_frontend_dict_uart.c
@@ -64,7 +64,7 @@ static const struct mpsc_pbuf_buffer_config config = {
 	.get_wlen = get_wlen,
 	.flags = 0
 };
-static const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+static const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 static struct mpsc_pbuf_buffer buf;
 static atomic_t active_cnt; /* Counts number of buffered messages. */

--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -9,7 +9,8 @@
 #include <zephyr/drivers/entropy.h>
 #include <string.h>
 
-static const struct device *entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+static const struct device *const entropy_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 #if defined(CONFIG_ENTROPY_DEVICE_RANDOM_GENERATOR)
 uint32_t z_impl_sys_rand32_get(void)

--- a/subsys/random/rand32_xoshiro128.c
+++ b/subsys/random/rand32_xoshiro128.c
@@ -32,7 +32,8 @@
 #include <zephyr/kernel.h>
 #include <string.h>
 
-static const struct device *entropy_driver;
+static const struct device *const entropy_driver =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 static uint32_t state[4];
 static bool initialized;
 
@@ -43,7 +44,6 @@ static inline uint32_t rotl(const uint32_t x, int k)
 
 static int xoshiro128_initialize(const struct device *dev)
 {
-	entropy_driver = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 	if (!device_is_ready(entropy_driver)) {
 		return -ENODEV;
 	}

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -23,7 +23,7 @@ extern const struct device __device_end[];
 extern const struct device __device_SMP_start[];
 #endif
 
-static const struct device *levels[] = {
+static const struct device *const levels[] = {
 	__device_PRE_KERNEL_1_start,
 	__device_PRE_KERNEL_2_start,
 	__device_POST_KERNEL_start,

--- a/subsys/testsuite/busy_sim/busy_sim.c
+++ b/subsys/testsuite/busy_sim/busy_sim.c
@@ -46,7 +46,7 @@ static const struct busy_sim_config sim_config = {
 };
 
 static struct busy_sim_data sim_data;
-static const struct device *busy_sim_dev = DEVICE_DT_GET_ONE(vnd_busy_sim);
+static const struct device *const busy_sim_dev = DEVICE_DT_GET_ONE(vnd_busy_sim);
 
 static void rng_pool_work_handler(struct k_work *work)
 {

--- a/subsys/tracing/tracing_backend_uart.c
+++ b/subsys/tracing/tracing_backend_uart.c
@@ -20,7 +20,8 @@
 #include <tracing_backend.h>
 
 
-static const struct device *tracing_uart_dev;
+static const struct device *const tracing_uart_dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_tracing_uart));
 
 #ifdef CONFIG_TRACING_HANDLE_HOST_CMD
 static void uart_isr(const struct device *dev, void *user_data)
@@ -76,7 +77,6 @@ static void tracing_backend_uart_output(
 
 static void tracing_backend_uart_init(void)
 {
-	tracing_uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_tracing_uart));
 	__ASSERT(device_is_ready(tracing_uart_dev), "uart backend is not ready");
 
 #ifdef CONFIG_TRACING_HANDLE_HOST_CMD

--- a/tests/bluetooth/tester/src/bttester.c
+++ b/tests/bluetooth/tester/src/bttester.c
@@ -275,7 +275,8 @@ static void uart_send(uint8_t *data, size_t len)
 #else /* !CONFIG_UART_PIPE */
 static uint8_t *recv_buf;
 static size_t recv_off;
-static const struct device *dev;
+static const struct device *const dev =
+	DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 static void timer_expiry_cb(struct k_timer *timer)
 {
@@ -292,7 +293,6 @@ K_TIMER_DEFINE(timer, timer_expiry_cb, NULL);
 /* Uart Poll */
 static void uart_init(uint8_t *data)
 {
-	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 	__ASSERT_NO_MSG(device_is_ready(dev));
 
 	recv_buf = data;

--- a/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
+++ b/tests/boards/espressif_esp32/cache_coex/src/cache_coex.c
@@ -25,7 +25,7 @@
 #define STACKSIZE 1024
 #define PRIORITY 7
 
-static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+static const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static struct flash_pages_info page_info;
 static int *mem;
 uint8_t flash_fill_buff[FLASH_READBACK_LEN];

--- a/tests/boards/frdm_k64f/i2c/src/i2c.c
+++ b/tests/boards/frdm_k64f/i2c/src/i2c.c
@@ -25,7 +25,7 @@
 #define FXOS8700_CTRLREG2_RST_MASK		0x40
 
 
-static const struct device *i2c_bus = DEVICE_DT_GET(DT_NODELABEL(i2c0));
+static const struct device *const i2c_bus = DEVICE_DT_GET(DT_NODELABEL(i2c0));
 
 /**
  * Setup and enable the fxos8700 with its max sample rate and

--- a/tests/boards/intel_adsp/ssp/src/main.c
+++ b/tests/boards/intel_adsp/ssp/src/main.c
@@ -43,8 +43,11 @@ struct sof_dai_ssp_params {
 	uint32_t bclk_delay;
 } __packed;
 
-static const struct device *dev_dai_ssp;
-static const struct device *dev_dma_dw;
+static const struct device *const dev_dai_ssp =
+	DEVICE_DT_GET(DT_NODELABEL(ssp0));
+static const struct device *const dev_dma_dw =
+	DEVICE_DT_GET(DT_NODELABEL(lpgpdma0));
+
 static struct dai_config config;
 static struct sof_dai_ssp_params ssp_config;
 
@@ -394,14 +397,9 @@ void test_adsp_ssp_probe(void)
 
 void test_main(void)
 {
-	dev_dai_ssp = DEVICE_DT_GET(DT_NODELABEL(ssp0));
-
 	k_object_access_grant(dev_dai_ssp, k_current_get());
 
 	zassert_true(device_is_ready(dev_dai_ssp), "device SSP_0 is not ready");
-
-	dev_dma_dw = DEVICE_DT_GET(DT_NODELABEL(lpgpdma0));
-
 	zassert_true(device_is_ready(dev_dma_dw), "device DMA 0 is not ready");
 
 	ztest_test_suite(adsp_ssp,

--- a/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
+++ b/tests/boards/mec15xxevb_assy6853/qspi/src/main.c
@@ -9,7 +9,6 @@
 
 #define TEST_FREQ_HZ 24000000U
 #define W25Q128_JEDEC_ID 0x001840efU
-#define SPI_NODE DT_NODELABEL(spi0)
 
 #define TEST_BUF_SIZE 4096U
 #define MAX_TX_BUF 2
@@ -42,7 +41,7 @@ uint8_t buffer_tx_2[] = "abcdef\0";
 
 static uint8_t safbuf[TEST_BUF_SIZE] __aligned(4);
 static uint8_t safbuf2[TEST_BUF_SIZE] __aligned(4);
-static const struct device *spi_dev;
+static const struct device *const spi_dev = DEVICE_DT_GET(DT_NODELABEL(spi0));
 struct spi_buf_set tx_bufs, rx_bufs;
 struct spi_buf txb[MAX_TX_BUF], rxb;
 struct spi_config spi_cfg_single, spi_cfg_dual, spi_cfg_quad;
@@ -65,8 +64,6 @@ void test_spi_device(void)
 	spi_cfg_single.slave = 0;
 	spi_cfg_single.cs = NULL;
 
-	/* find spi device */
-	spi_dev = DEVICE_DT_GET(SPI_NODE);
 	zassert_true(device_is_ready(spi_dev), "SPI controller device is not ready");
 
 	/* read jedec id */

--- a/tests/drivers/can/canfd/src/main.c
+++ b/tests/drivers/can/canfd/src/main.c
@@ -31,7 +31,7 @@
 /**
  * @brief Global variables.
  */
-static const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+static const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 static struct k_sem rx_callback_sem;
 static struct k_sem tx_callback_sem;
 

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -20,7 +20,7 @@ static bool test_end;
 
 #include <hal/nrf_gpio.h>
 
-static const struct device *entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+static const struct device *const entropy = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 static struct onoff_manager *hf_mgr;
 static uint32_t iteration;
 

--- a/tests/drivers/counter/counter_basic_api/src/test_counter.c
+++ b/tests/drivers/counter/counter_basic_api/src/test_counter.c
@@ -27,7 +27,7 @@ struct counter_alarm_cfg alarm_cfg2;
 #define DEVS_FOR_DT_COMPAT(compat) \
 	DT_FOREACH_STATUS_OKAY(compat, DEVICE_DT_GET_AND_COMMA)
 
-static const struct device *devices[] = {
+static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_TIMER0
 	/* Nordic TIMER0 may be reserved for Bluetooth */
 	DEVICE_DT_GET(DT_NODELABEL(timer0)),
@@ -93,7 +93,7 @@ static const struct device *devices[] = {
 #endif
 };
 
-static const struct device *period_devs[] = {
+static const struct device *const period_devs[] = {
 #ifdef CONFIG_COUNTER_MCUX_RTC
 	DEVS_FOR_DT_COMPAT(nxp_kinetis_rtc)
 #endif

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(test);
 
 static volatile uint32_t top_cnt;
 
-static const struct device *devices[] = {
+static const struct device *const devices[] = {
 #ifdef CONFIG_COUNTER_RTC0
 	/* Nordic RTC0 may be reserved for Bluetooth */
 	DEVICE_DT_GET(DT_NODELABEL(rtc0)),

--- a/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
+++ b/tests/drivers/counter/maxim_ds3231_api/src/test_counter.c
@@ -24,7 +24,7 @@ void *exp_user_data = (void *)199;
 struct counter_alarm_cfg alarm_cfg;
 struct counter_alarm_cfg alarm_cfg2;
 
-static const struct device *devices[] = {
+static const struct device *const devices[] = {
 	DEVICE_DT_GET(DT_NODELABEL(ds3231)),
 };
 typedef void (*counter_test_func_t)(const struct device *dev);

--- a/tests/drivers/flash/src/main.c
+++ b/tests/drivers/flash/src/main.c
@@ -47,7 +47,7 @@
 #define EXPECTED_SIZE	256
 #define CANARY		0xff
 
-static const struct device *flash_dev = TEST_AREA_DEVICE;
+static const struct device *const flash_dev = TEST_AREA_DEVICE;
 static struct flash_pages_info page_info;
 static uint8_t __aligned(4) expected[EXPECTED_SIZE];
 

--- a/tests/drivers/flash_simulator/src/main.c
+++ b/tests/drivers/flash_simulator/src/main.c
@@ -32,7 +32,7 @@
 		(((((((0xff & pat) << 8) | (0xff & pat)) << 8) | \
 		   (0xff & pat)) << 8) | (0xff & pat))
 
-static const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+static const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static uint8_t test_read_buf[TEST_SIM_FLASH_SIZE];
 
 static uint32_t p32_inc;

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -9,7 +9,7 @@
 
 #define ALL_BITS ((gpio_port_value_t)-1)
 
-static const struct device *dev;
+static const struct device *const dev = DEVICE_DT_GET(DEV);
 
 /* Short-hand for a checked read of PIN_IN raw state */
 static bool raw_in(void)
@@ -68,8 +68,6 @@ static int setup(void)
 {
 	int rc;
 	gpio_port_value_t v1;
-
-	dev = DEVICE_DT_GET(DEV);
 
 	TC_PRINT("Validate device %s\n", dev->name);
 	zassert_true(device_is_ready(dev), "GPIO dev is not ready");

--- a/tests/drivers/mipi_dsi/api/src/main.c
+++ b/tests/drivers/mipi_dsi/api/src/main.c
@@ -14,7 +14,7 @@
  * @}
  */
 
-static const struct device *mipi_dev = DEVICE_DT_GET(DT_ALIAS(mipi_dsi));
+static const struct device *const mipi_dev = DEVICE_DT_GET(DT_ALIAS(mipi_dsi));
 
 /**
  * Test the MIPI generic APIs to test read and write API functionality

--- a/tests/drivers/regulator/fixed/src/main.c
+++ b/tests/drivers/regulator/fixed/src/main.c
@@ -23,7 +23,7 @@ BUILD_ASSERT(DT_NODE_HAS_COMPAT_STATUS(CHECK_NODE, test_regulator_fixed, okay));
 static const struct gpio_dt_spec reg_gpio = GPIO_DT_SPEC_GET(REGULATOR_NODE, enable_gpios);
 static const struct gpio_dt_spec check_gpio = GPIO_DT_SPEC_GET(CHECK_NODE, check_gpios);
 
-static const struct device *reg_dev = DEVICE_DT_GET(REGULATOR_NODE);
+static const struct device *const reg_dev = DEVICE_DT_GET(REGULATOR_NODE);
 
 static enum {
 	PC_UNCHECKED,

--- a/tests/drivers/sdhc/src/main.c
+++ b/tests/drivers/sdhc/src/main.c
@@ -9,7 +9,7 @@
 #include <zephyr/device.h>
 #include <zephyr/ztest.h>
 
-static const struct device *sdhc_dev = DEVICE_DT_GET(DT_ALIAS(sdhc0));
+static const struct device *const sdhc_dev = DEVICE_DT_GET(DT_ALIAS(sdhc0));
 static struct sdhc_host_props props;
 static struct sdhc_io io;
 

--- a/tests/drivers/uart/uart_async_api/src/test_uart_async.c
+++ b/tests/drivers/uart/uart_async_api/src/test_uart_async.c
@@ -13,7 +13,8 @@ K_SEM_DEFINE(rx_buf_released, 0, 1);
 K_SEM_DEFINE(rx_disabled, 0, 1);
 
 ZTEST_BMEM volatile bool failed_in_isr;
-ZTEST_BMEM static const struct device *uart_dev;
+ZTEST_BMEM static const struct device *const uart_dev =
+	DEVICE_DT_GET(UART_DEVICE_DEV);
 
 static void read_abort_timeout(struct k_timer *timer);
 K_TIMER_DEFINE(read_abort_timer, read_abort_timeout, NULL);
@@ -21,11 +22,7 @@ K_TIMER_DEFINE(read_abort_timer, read_abort_timeout, NULL);
 
 void init_test(void)
 {
-	uart_dev = DEVICE_DT_GET(UART_DEVICE_DEV);
-	if (!device_is_ready(uart_dev)) {
-		printk("UART device is not ready\n");
-		return;
-	}
+	__ASSERT_NO_MSG(device_is_ready(uart_dev));
 }
 
 #ifdef CONFIG_USERSPACE

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -60,8 +60,10 @@ static struct rx_source source[4];
 static struct test_data test_data[3];
 static struct test_data int_async_data;
 
-static const struct device *counter_dev;
-static const struct device *uart_dev;
+static const struct device *const counter_dev =
+	DEVICE_DT_GET(DT_NODELABEL(timer0));
+static const struct device *const uart_dev =
+	DEVICE_DT_GET(UART_DEVICE_DEV);
 
 static bool async;
 static bool int_driven;
@@ -131,7 +133,6 @@ static void init_test(void)
 		.flags = 0
 	};
 
-	uart_dev = DEVICE_DT_GET(UART_DEVICE_DEV);
 	zassert_true(device_is_ready(uart_dev), "uart device is not ready");
 
 	if (uart_callback_set(uart_dev, async_callback, NULL) == 0) {
@@ -147,7 +148,6 @@ static void init_test(void)
 	/* Setup counter which will periodically enable/disable UART RX,
 	 * Disabling RX should lead to flow control being activated.
 	 */
-	counter_dev = DEVICE_DT_GET(DT_NODELABEL(timer0));
 	zassert_true(device_is_ready(counter_dev), NULL);
 
 	top_cfg.ticks = counter_us_to_ticks(counter_dev, 1000);

--- a/tests/subsys/fs/nvs/src/main.c
+++ b/tests/subsys/fs/nvs/src/main.c
@@ -33,7 +33,7 @@
 #define TEST_DATA_ID			1
 #define TEST_SECTOR_COUNT		5U
 
-static const struct device *flash_dev = DEVICE_DT_GET(TEST_NVS_FLASH_DEV_NODE);
+static const struct device *const flash_dev = DEVICE_DT_GET(TEST_NVS_FLASH_DEV_NODE);
 
 struct nvs_fixture {
 	struct nvs_fs fs;

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -83,7 +83,7 @@ static int init_mock(const struct device *dev)
 #define DT_DRV_COMPAT vnd_ieee802154
 DEVICE_DT_INST_DEFINE(0, init_mock, NULL, NULL, NULL, POST_KERNEL, 0, &rapi);
 
-static const struct device *radio = DEVICE_DT_INST_GET(0);
+static const struct device *const radio = DEVICE_DT_INST_GET(0);
 
 static int16_t rssi_scan_mock_max_ed;
 static int rssi_scan_mock(const struct device *dev, uint16_t duration,

--- a/tests/subsys/pm/device_wakeup_api/src/main.c
+++ b/tests/subsys/pm/device_wakeup_api/src/main.c
@@ -9,10 +9,8 @@
 #include <zephyr/pm/pm.h>
 #include <zephyr/pm/device.h>
 
-#define DEV_NAME DT_NODELABEL(gpio0)
-
-
-static const struct device *dev;
+static const struct device *const dev =
+	DEVICE_DT_GET(DT_NODELABEL(gpio0));
 static uint8_t sleep_count;
 
 
@@ -80,8 +78,7 @@ ZTEST(wakeup_device_1cpu, test_wakeup_device_api)
 {
 	bool ret = false;
 
-	dev = DEVICE_DT_GET(DEV_NAME);
-	zassert_not_null(dev, "Failed to get device");
+	zassert_true(device_is_ready(dev), "Device not ready");
 
 	ret = pm_device_wakeup_is_capable(dev);
 	zassert_true(ret, "Device not marked as capable");

--- a/tests/subsys/pm/power_domain/src/main.c
+++ b/tests/subsys/pm/power_domain/src/main.c
@@ -14,7 +14,10 @@
 #define TEST_DEVA DT_NODELABEL(test_dev_a)
 #define TEST_DEVB DT_NODELABEL(test_dev_b)
 
-static const struct device *domain, *deva, *devb, *devc;
+static const struct device *const domain = DEVICE_DT_GET(TEST_DOMAIN);
+static const struct device *const deva = DEVICE_DT_GET(TEST_DEVA);
+static const struct device *const devb = DEVICE_DT_GET(TEST_DEVB);
+static const struct device *devc;
 static int testing_domain_on_notitication;
 static int testing_domain_off_notitication;
 
@@ -125,9 +128,6 @@ ZTEST(power_domain_1cpu, test_power_domain_device_runtime)
 	int ret;
 	enum pm_device_state state;
 
-	domain = DEVICE_DT_GET(TEST_DOMAIN);
-	deva = DEVICE_DT_GET(TEST_DEVA);
-	devb = DEVICE_DT_GET(TEST_DEVB);
 	devc = DEVICE_GET(devc);
 
 	pm_device_init_suspended(domain);

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -31,9 +31,10 @@ static bool testing_device_lock;
 static const struct device *device_dummy;
 static struct dummy_driver_api *api;
 
-static const struct device *device_a;
-static const struct device *device_c;
-
+static const struct device *const device_a =
+	DEVICE_DT_GET(DT_INST(0, test_device_pm));
+static const struct device *const device_c =
+	DEVICE_DT_GET(DT_INST(2, test_device_pm));
 
 /*
  * According with the initialization level, devices A, B and C are
@@ -375,11 +376,8 @@ ZTEST(power_management_1cpu, test_power_state_notification)
 
 ZTEST(power_management_1cpu, test_device_order)
 {
-	device_a = DEVICE_DT_GET(DT_INST(0, test_device_pm));
-	zassert_not_null(device_a, "Failed to get device");
-
-	device_c = DEVICE_DT_GET(DT_INST(2, test_device_pm));
-	zassert_not_null(device_c, "Failed to get device");
+	zassert_true(device_is_ready(device_a), "device a not ready");
+	zassert_true(device_is_ready(device_c), "device c not ready");
 
 	testing_device_order = true;
 	enter_low_power = true;

--- a/tests/subsys/sd/sdmmc/src/main.c
+++ b/tests/subsys/sd/sdmmc/src/main.c
@@ -14,7 +14,7 @@
 #define SECTOR_COUNT 32
 #define SECTOR_SIZE 512 /* subsystem should set all cards to 512 byte blocks */
 #define BUF_SIZE SECTOR_SIZE * SECTOR_COUNT
-static const struct device *sdhc_dev = DEVICE_DT_GET(DT_ALIAS(sdhc0));
+static const struct device *const sdhc_dev = DEVICE_DT_GET(DT_ALIAS(sdhc0));
 static struct sd_card card;
 static uint8_t buf[BUF_SIZE] __aligned(CONFIG_SDHC_BUFFER_ALIGNMENT);
 static uint8_t check_buf[BUF_SIZE] __aligned(CONFIG_SDHC_BUFFER_ALIGNMENT);

--- a/tests/subsys/storage/stream/stream_flash/src/main.c
+++ b/tests/subsys/storage/stream/stream_flash/src/main.c
@@ -24,7 +24,7 @@
 #define FLASH_BASE (128*1024)
 #define FLASH_AVAILABLE (FLASH_SIZE-FLASH_BASE)
 
-static const struct device *fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+static const struct device *const fdev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 static const struct flash_driver_api *api;
 static const struct flash_pages_layout *layout;
 static size_t layout_size;


### PR DESCRIPTION
It is frequent to find variable definitions like this:

```c
static const struct device *dev = DEVICE_DT_GET(...);
```

That is, module level variables that are statically initialized with a
device reference. Such value is, in most cases, never changed meaning
the variable can also be declared as const (immutable):

```c
static const struct device *const dev = DEVICE_DT_GET(...);
```

This PR constifies device pointers and initializes devices at compile time when possible (allowing constification).