### PR TITLE
boards: arm: lpcxpresso55s69: Fix build of lpcxpresso55s69_cpu1

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
@@ -57,3 +57,7 @@
 &mailbox0 {
 	status = "okay";
 };
+
+&mma8652fc {
+	status = "disabled";
+};


### PR DESCRIPTION
The samples/sensor/thermometer fails to build on lpcxpresso55s69_cpu1
due to the fact that we try and build the fxos8700 driver however the
bus that this driver is on is not enabled.  Disable the sensor in the
devicetree since the bus is not enabled.

Signed-off-by: Kumar Gala <galak@kernel.org>