### PR TITLE
drivers: ace_v1x wallclock drivers

### DIFF
--- a/drivers/counter/CMakeLists.txt
+++ b/drivers/counter/CMakeLists.txt
@@ -30,3 +30,5 @@ zephyr_library_sources_ifdef(CONFIG_COUNTER_TMR_ESP32           counter_esp32_tm
 zephyr_library_sources_ifdef(CONFIG_COUNTER_RTC_ESP32           counter_esp32_rtc.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_MICROCHIP_MCP7940N  rtc_mcp7940n.c)
 zephyr_library_sources_ifdef(CONFIG_COUNTER_ANDES_ATCPIT100     counter_andes_atcpit100.c)
+zephyr_library_sources_ifdef(CONFIG_ACE_V1X_ART_COUNTER         counter_ace_v1x_art.c)
+zephyr_library_sources_ifdef(CONFIG_ACE_V1X_RTC_COUNTER         counter_ace_v1x_rtc.c)

--- a/drivers/counter/Kconfig
+++ b/drivers/counter/Kconfig
@@ -42,6 +42,8 @@ source "drivers/counter/Kconfig.sam"
 
 source "drivers/counter/Kconfig.sam0"
 
+source "drivers/counter/Kconfig.ace"
+
 source "drivers/counter/Kconfig.cmos"
 
 source "drivers/counter/Kconfig.mcux_gpt"

--- a/drivers/counter/Kconfig.ace
+++ b/drivers/counter/Kconfig.ace
@@ -1,0 +1,17 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+config ACE_V1X_ART_COUNTER
+	bool "DSP ART Wall Clock for ACE V1X"
+	depends on DT_HAS_INTEL_ACE_ART_COUNTER_ENABLED
+	default y
+	help
+	  DSP ART Wall Clock used by ACE V1X.
+
+config ACE_V1X_RTC_COUNTER
+	bool "DSP RTC Wall Clock for ACE V1X"
+	depends on DT_HAS_INTEL_ACE_RTC_COUNTER_ENABLED
+	default y
+	help
+	  DSP RTC Wall Clock used by ACE V1X.

--- a/drivers/counter/counter_ace_v1x_art.c
+++ b/drivers/counter/counter_ace_v1x_art.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <device.h>
+#include <devicetree.h>
+#include <zephyr/drivers/counter.h>
+#include <soc.h>
+#include <ace_v1x-regs.h>
+#include <counter/counter_ace_v1x_art_regs.h>
+
+static struct k_spinlock lock;
+
+static void counter_ace_v1x_art_ionte_set(bool new_timestamp_enable)
+{
+	uint32_t val;
+
+	val = sys_read32(ACE_TSCTRL);
+	val &= ~ACE_TSCTRL_IONTE_MASK;
+	val |= FIELD_PREP(ACE_TSCTRL_IONTE_MASK, new_timestamp_enable);
+	sys_write32(val, ACE_TSCTRL);
+}
+
+static void counter_ace_v1x_art_cdmas_set(uint32_t cdmas)
+{
+	uint32_t val;
+
+	val = sys_read32(ACE_TSCTRL);
+	val &= ~ACE_TSCTRL_CDMAS_MASK;
+	val |= FIELD_PREP(ACE_TSCTRL_CDMAS_MASK, cdmas);
+	sys_write32(val, ACE_TSCTRL);
+}
+
+static void counter_ace_v1x_art_ntk_set(bool new_timestamp_taken)
+{
+	uint32_t val;
+
+	val = sys_read32(ACE_TSCTRL);
+	val &= ~ACE_TSCTRL_NTK_MASK;
+	val |= FIELD_PREP(ACE_TSCTRL_NTK_MASK, new_timestamp_taken);
+	sys_write32(val, ACE_TSCTRL);
+}
+
+static uint32_t counter_ace_v1x_art_ntk_get(void)
+{
+	return FIELD_GET(ACE_TSCTRL_NTK_MASK, sys_read32(ACE_TSCTRL));
+}
+
+static void counter_ace_v1x_art_hhtse_set(bool enable)
+{
+	uint32_t val;
+
+	val = sys_read32(ACE_TSCTRL);
+	val &= ~ACE_TSCTRL_HHTSE_MASK;
+	val |= FIELD_PREP(ACE_TSCTRL_HHTSE_MASK, enable);
+	sys_write32(val, ACE_TSCTRL);
+}
+
+static uint64_t counter_ace_v1x_art_counter_get(void)
+{
+	uint32_t hi0, lo, hi1;
+
+	do {
+		hi0 = sys_read32(ACE_ARTCS_HI);
+		lo = sys_read32(ACE_ARTCS_LO);
+		hi1 = sys_read32(ACE_ARTCS_HI);
+	} while (hi0 != hi1);
+
+	return (((uint64_t)hi1) << 32) | lo;
+}
+
+int counter_ace_v1x_art_get_value(const struct device *dev, uint64_t *value)
+{
+	ARG_UNUSED(dev);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	counter_ace_v1x_art_ionte_set(1);
+	counter_ace_v1x_art_cdmas_set(1);
+
+	if (counter_ace_v1x_art_ntk_get()) {
+		counter_ace_v1x_art_ntk_set(1);
+		while (counter_ace_v1x_art_ntk_get()) {
+			k_busy_wait(10);
+		}
+	}
+
+	counter_ace_v1x_art_hhtse_set(1);
+
+	while (!counter_ace_v1x_art_ntk_get()) {
+		k_busy_wait(10);
+	}
+
+	*value = counter_ace_v1x_art_counter_get();
+
+	counter_ace_v1x_art_ntk_set(1);
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+int counter_ace_v1x_art_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+static const struct counter_driver_api ace_v1x_art_counter_apis = {
+	.get_value_64 = counter_ace_v1x_art_get_value
+};
+
+DEVICE_DT_DEFINE(DT_NODELABEL(ace_art_counter), counter_ace_v1x_art_init, NULL, NULL, NULL,
+		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		 &ace_v1x_art_counter_apis);

--- a/drivers/counter/counter_ace_v1x_art_regs.h
+++ b/drivers/counter/counter_ace_v1x_art_regs.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __COUNTER_ACE_V1X_ART_REGS__
+#define __COUNTER_ACE_V1X_ART_REGS__
+
+#if CONFIG_ACE_V1X_ART_COUNTER
+
+#define ACE_ART_COUNTER_ID DT_NODELABEL(ace_art_counter)
+#define ACE_TIMESTAMP_ID DT_NODELABEL(ace_timestamp)
+
+#define ACE_TSCTRL	(DT_REG_ADDR(ACE_TIMESTAMP_ID))
+
+#define ACE_ARTCS	(DT_REG_ADDR(ACE_ART_COUNTER_ID))
+#define ACE_ARTCS_LO ACE_ARTCS
+#define ACE_ARTCS_HI (ACE_ARTCS_LO + 0x04)
+
+#define ACE_TSCTRL_CDMAS_MASK		GENMASK(4, 0)
+#define ACE_TSCTRL_ODTS_MASK		BIT(5)
+#define ACE_TSCTRL_LWCS_MASK		BIT(6)
+#define ACE_TSCTRL_HHTSE_MASK		BIT(7)
+#define ACE_TSCTRL_CLNKS_MASK		GENMASK(11, 10)
+#define ACE_TSCTRL_DMATS_MASK		GENMASK(13, 12)
+#define ACE_TSCTRL_IONTE_MASK		BIT(30)
+#define ACE_TSCTRL_NTK_MASK		BIT(31)
+
+#endif
+
+#endif /*__COUNTER_ACE_V1X_ART_REGS__*/

--- a/drivers/counter/counter_ace_v1x_rtc.c
+++ b/drivers/counter/counter_ace_v1x_rtc.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <device.h>
+#include <devicetree.h>
+#include <zephyr/drivers/counter.h>
+#include <soc.h>
+#include <ace_v1x-regs.h>
+#include <counter/counter_ace_v1x_rtc_regs.h>
+
+static int counter_ace_v1x_rtc_get_value(const struct device *dev,
+		int64_t *value)
+{
+	ARG_UNUSED(dev);
+
+		uint32_t hi0, lo, hi1;
+	do {
+		hi0 = sys_read32(ACE_RTCWC_HI);
+		lo = sys_read32(ACE_RTCWC_LO);
+		hi1 = sys_read32(ACE_RTCWC_HI);
+	} while (hi0 != hi1);
+
+	*value = (((uint64_t)hi0) << 32) | lo;
+}
+
+int counter_ace_v1x_rtc_init(const struct device *dev)
+{
+	ARG_UNUSED(dev);
+
+	return 0;
+}
+
+static const struct counter_driver_api ace_v1x_rtc_counter_apis = {
+	.get_value_64 = counter_ace_v1x_rtc_get_value
+};
+
+DEVICE_DT_DEFINE(DT_NODELABEL(ace_rtc_counter), counter_ace_v1x_rtc_init, NULL, NULL, NULL,
+		 PRE_KERNEL_1, CONFIG_KERNEL_INIT_PRIORITY_DEFAULT,
+		 &ace_v1x_rtc_counter_apis);

--- a/drivers/counter/counter_ace_v1x_rtc_regs.h
+++ b/drivers/counter/counter_ace_v1x_rtc_regs.h
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef __COUNTER_ACE_V1X_RTC_REGS__
+#define __COUNTER_ACE_V1X_RTC_REGS__
+
+#if CONFIG_ACE_V1X_RTC_COUNTER
+
+#define ACE_RTC_COUNTER_ID DT_NODELABEL(ace_rtc_counter)
+
+#define ACE_RTCWC	(DT_REG_ADDR(ACE_RTC_COUNTER_ID))
+#define ACE_RTCWC_LO ACE_RTCWC
+#define ACE_RTCWC_HI ACE_RTCWC + 0x04
+
+#endif
+
+#endif /*__COUNTER_ACE_V1X_RTC_REGS__*/

--- a/dts/bindings/counter/intel,ace-art-counter.yaml
+++ b/dts/bindings/counter/intel,ace-art-counter.yaml
@@ -1,0 +1,9 @@
+description: ACE wallclock ART counter controller
+
+compatible: "intel,ace-art-counter"
+
+include: base.yaml
+
+properties:
+  reg:
+      required: true

--- a/dts/bindings/counter/intel,ace-rtc-counter.yaml
+++ b/dts/bindings/counter/intel,ace-rtc-counter.yaml
@@ -1,0 +1,9 @@
+description: ACE wallclock RTC counter controller
+
+compatible: "intel,ace-rtc-counter"
+
+include: base.yaml
+
+properties:
+  reg:
+      required: true

--- a/dts/bindings/timestamp/intel,ace-timestamp.yaml
+++ b/dts/bindings/timestamp/intel,ace-timestamp.yaml
@@ -1,0 +1,9 @@
+description: ACE timestamp controller
+
+compatible: "intel,ace-timestamp"
+
+include: base.yaml
+
+properties:
+  reg:
+      required: true

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -106,6 +106,21 @@
 			interrupt-parent = <&core_intc>;
 		};
 
+		ace_timestamp: ace_timestamp@72040 {
+			compatible = "intel,ace-timestamp";
+			reg = <0x72040 0x0032>;
+		};
+
+		ace_art_counter: ace_art_counter@72058 {
+			compatible = "intel,ace-art-counter";
+			reg = <0x72058 0x0064>;
+		};
+
+		ace_rtc_counter: ace_rtc_counter@72008 {
+			compatible = "intel,ace-rtc-counter";
+			reg = <0x72008 0x0064>;
+		};
+
 		shim: shim@71f00 {
 			compatible = "intel,cavs-shim";
 			reg = <0x71f00 0x100>;


### PR DESCRIPTION
Wallclock driver with functionality required by ACE v1x base firmware.

To build properly it requires https://github.com/zephyrproject-rtos/zephyr/pull/47479 to be merged first.

Signed-off-by: Piotr Kmiecik <piotrx.kmiecik@intel.com>