### PR TITLE
manifest: tfm: Update TF-M for musca_s1/nrf fixes

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -225,7 +225,7 @@ manifest:
       groups:
         - debug
     - name: trusted-firmware-m
-      revision: f13209f1883232cbcb9f0c31fb4c63e7c242df0d
+      revision: 4c984817d861512edaeca27b83308e9b9915a98a
       path: modules/tee/tf-m/trusted-firmware-m
       groups:
         - tee


### PR DESCRIPTION
Updates the TF-M repo to include the following fixes:

- platform: musca_s1: only declare tfm_ns if NS is enabled
  d9522eb0d16ea5cb21d52b0ab65cfcba62830fc9
- platform: nordic_nrf: Make psa_call/svc unpriv
  4c984817d861512edaeca27b83308e9b9915a98a

Fixes:  #49169