### PR TITLE
Improve ztest macros

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp.c
@@ -1767,7 +1767,7 @@ void test_int_mem_proc_ctx(void)
 	}
 
 	nr_of_free_ctx = local_ctx_buffers_free();
-	zassert_equal(nr_of_free_ctx, 0, NULL);
+	zassert_equal(nr_of_free_ctx, 0);
 
 	ctx2 = proc_ctx_acquire(&mem_local_ctx);
 
@@ -1776,7 +1776,7 @@ void test_int_mem_proc_ctx(void)
 
 	llcp_proc_ctx_release(ctx1);
 	nr_of_free_ctx = local_ctx_buffers_free();
-	zassert_equal(nr_of_free_ctx, 1, NULL);
+	zassert_equal(nr_of_free_ctx, 1);
 
 	ctx1 = proc_ctx_acquire(&mem_local_ctx);
 
@@ -1858,8 +1858,8 @@ void test_int_create_proc(void)
 	ctx = create_procedure(PROC_VERSION_EXCHANGE, &mem_local_ctx);
 	zassert_not_null(ctx, NULL);
 
-	zassert_equal(ctx->proc, PROC_VERSION_EXCHANGE, NULL);
-	zassert_equal(ctx->collision, 0, NULL);
+	zassert_equal(ctx->proc, PROC_VERSION_EXCHANGE);
+	zassert_equal(ctx->collision, 0);
 
 	for (int i = 0U; i < CONFIG_BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM; i++) {
 		zassert_not_null(ctx, NULL);
@@ -1881,8 +1881,8 @@ void test_int_llcp_init(void)
 
 	ull_llcp_init(&conn);
 
-	zassert_equal(conn.llcp.local.pause, 0, NULL);
-	zassert_equal(conn.llcp.remote.pause, 0, NULL);
+	zassert_equal(conn.llcp.local.pause, 0);
+	zassert_equal(conn.llcp.remote.pause, 0);
 }
 
 #endif

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -127,8 +127,8 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * context of the test function.
  *
  * @param cond Condition to check
- * @param msg Optional, can be NULL. Message to print if @a cond is false.
  * @param default_msg Message to print if @a cond is false
+ * @param msg Optional, can be NULL. Message to print if @a cond is false.
  */
 #define zassert(cond, default_msg, msg, ...)                                                       \
 	do {                                                                                       \
@@ -158,8 +158,8 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * failures only.
  *
  * @param cond Condition to check
- * @param msg Optional, can be NULL. Message to print if @a cond is false.
  * @param default_msg Message to print if @a cond is false
+ * @param msg Optional, can be NULL. Message to print if @a cond is false.
  */
 #define zassume(cond, default_msg, msg, ...)                                                       \
 	do {                                                                                       \

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -130,7 +130,7 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param default_msg Message to print if @a cond is false
  * @param msg Optional, can be NULL. Message to print if @a cond is false.
  */
-#define zassert(cond, default_msg, msg, ...)                                                       \
+#define _zassert_base(cond, default_msg, msg, ...)                                                 \
 	do {                                                                                       \
 		bool _msg = (msg != NULL);                                                         \
 		bool _ret = z_zassert(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,\
@@ -142,6 +142,12 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 				    ())                                                            \
 		}                                                                                  \
 	} while (0)
+
+#define _zassert_va(cond, default_msg, msg, ...)                                                   \
+	_zassert_base(cond, default_msg, msg, ##__VA_ARGS__)
+
+#define zassert(cond, default_msg, ...)                                                            \
+	_zassert_va(cond, default_msg, COND_CODE_1(__VA_OPT__(1), (__VA_ARGS__), (NULL)))
 
 /**
  * @brief Skip the test, if @a cond is false
@@ -161,7 +167,7 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param default_msg Message to print if @a cond is false
  * @param msg Optional, can be NULL. Message to print if @a cond is false.
  */
-#define zassume(cond, default_msg, msg, ...)                                                       \
+#define _zassume_base(cond, default_msg, msg, ...)                                                 \
 	do {                                                                                       \
 		bool _msg = (msg != NULL);                                                         \
 		bool _ret = z_zassume(cond, _msg ? ("(" default_msg ")") : (default_msg), __FILE__,\
@@ -173,6 +179,13 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 				    ())                                                            \
 		}                                                                                  \
 	} while (0)
+
+#define _zassume_va(cond, default_msg, msg, ...)                                                   \
+	_zassume_base(cond, default_msg, msg, ##__VA_ARGS__)
+
+#define zassume(cond, default_msg, ...)                                                            \
+	_zassume_va(cond, default_msg, COND_CODE_1(__VA_OPT__(1), (__VA_ARGS__), (NULL)))
+
 /**
  * @brief Assert that this function call won't be reached
  * @param msg Optional message to print if the assertion fails

--- a/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
+++ b/subsys/testsuite/ztest/include/zephyr/ztest_assert.h
@@ -188,45 +188,44 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
 
 /**
  * @brief Assert that this function call won't be reached
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_unreachable(msg, ...) zassert(0, "Reached unreachable code", msg, ##__VA_ARGS__)
+#define zassert_unreachable(...) zassert(0, "Reached unreachable code", ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a cond is true
  * @param cond Condition to check
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_true(cond, msg, ...) zassert(cond, #cond " is false", msg, ##__VA_ARGS__)
+#define zassert_true(cond, ...) zassert(cond, #cond " is false", ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a cond is false
  * @param cond Condition to check
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_false(cond, msg, ...) zassert(!(cond), #cond " is true", msg, ##__VA_ARGS__)
+#define zassert_false(cond, ...) zassert(!(cond), #cond " is true", ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a cond is 0 (success)
  * @param cond Condition to check
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_ok(cond, msg, ...) zassert(!(cond), #cond " is non-zero", msg, ##__VA_ARGS__)
+#define zassert_ok(cond, ...) zassert(!(cond), #cond " is non-zero", ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a ptr is NULL
  * @param ptr Pointer to compare
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_is_null(ptr, msg, ...)                                                             \
-	zassert((ptr) == NULL, #ptr " is not NULL", msg, ##__VA_ARGS__)
+#define zassert_is_null(ptr, ...) zassert((ptr) == NULL, #ptr " is not NULL", ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a ptr is not NULL
  * @param ptr Pointer to compare
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_not_null(ptr, msg, ...) zassert((ptr) != NULL, #ptr " is NULL", msg, ##__VA_ARGS__)
+#define zassert_not_null(ptr, ...) zassert((ptr) != NULL, #ptr " is NULL", ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a a equals @a b
@@ -235,10 +234,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  *
  * @param a Value to compare
  * @param b Value to compare
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_equal(a, b, msg, ...)                                                              \
-	zassert((a) == (b), #a " not equal to " #b, msg, ##__VA_ARGS__)
+#define zassert_equal(a, b, ...) zassert((a) == (b), #a " not equal to " #b, ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a a does not equal @a b
@@ -247,10 +245,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  *
  * @param a Value to compare
  * @param b Value to compare
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_not_equal(a, b, msg, ...)                                                          \
-	zassert((a) != (b), #a " equal to " #b, msg, ##__VA_ARGS__)
+#define zassert_not_equal(a, b, ...) zassert((a) != (b), #a " equal to " #b, ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a a equals @a b
@@ -259,10 +256,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  *
  * @param a Value to compare
  * @param b Value to compare
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_equal_ptr(a, b, msg, ...)                                                          \
-	zassert((void *)(a) == (void *)(b), #a " not equal to " #b, msg, ##__VA_ARGS__)
+#define zassert_equal_ptr(a, b, ...)                                                               \
+	zassert((void *)(a) == (void *)(b), #a " not equal to " #b, ##__VA_ARGS__)
 
 /**
  * @brief Assert that @a a is within @a b with delta @a d
@@ -270,11 +267,11 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param a Value to compare
  * @param b Value to compare
  * @param d Delta
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_within(a, b, d, msg, ...)                                                          \
+#define zassert_within(a, b, d, ...)                                                               \
 	zassert(((a) >= ((b) - (d))) && ((a) <= ((b) + (d))), #a " not within " #b " +/- " #d,     \
-		msg, ##__VA_ARGS__)
+		##__VA_ARGS__)
 
 /**
  * @brief Assert that @a a is greater than or equal to @a l and less
@@ -283,10 +280,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param a Value to compare
  * @param l Lower limit
  * @param u Upper limit
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_between_inclusive(a, l, u, msg, ...)                                               \
-	zassert(((a) >= (l)) && ((a) <= (u)), #a " not between " #l " and " #u " inclusive", msg,  \
+#define zassert_between_inclusive(a, l, u, ...)                                                    \
+	zassert(((a) >= (l)) && ((a) <= (u)), #a " not between " #l " and " #u " inclusive",       \
 		##__VA_ARGS__)
 
 /**
@@ -311,10 +308,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param buf Buffer to compare
  * @param exp Buffer with expected contents
  * @param size Size of buffers
- * @param msg Optional message to print if the assertion fails
+ * @param ... Optional message and variables to print if the assertion fails
  */
-#define zassert_mem_equal__(buf, exp, size, msg, ...)                                              \
-	zassert(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, msg, ##__VA_ARGS__)
+#define zassert_mem_equal__(buf, exp, size, ...)                                                   \
+	zassert(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, ##__VA_ARGS__)
 
 /**
  * @}
@@ -335,9 +332,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * If the assumption fails, the test will be marked as "skipped".
  *
  * @param cond Condition to check
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_true(cond, msg, ...) zassume(cond, #cond " is false", msg, ##__VA_ARGS__)
+#define zassume_true(cond, ...) zassume(cond, #cond " is false", ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a cond is false
@@ -345,9 +342,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * If the assumption fails, the test will be marked as "skipped".
  *
  * @param cond Condition to check
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_false(cond, msg, ...) zassume(!(cond), #cond " is true", msg, ##__VA_ARGS__)
+#define zassume_false(cond, ...) zassume(!(cond), #cond " is true", ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a cond is 0 (success)
@@ -355,9 +352,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * If the assumption fails, the test will be marked as "skipped".
  *
  * @param cond Condition to check
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_ok(cond, msg, ...) zassume(!(cond), #cond " is non-zero", msg, ##__VA_ARGS__)
+#define zassume_ok(cond, ...) zassume(!(cond), #cond " is non-zero", ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a ptr is NULL
@@ -365,10 +362,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * If the assumption fails, the test will be marked as "skipped".
  *
  * @param ptr Pointer to compare
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_is_null(ptr, msg, ...)                                                             \
-	zassume((ptr) == NULL, #ptr " is not NULL", msg, ##__VA_ARGS__)
+#define zassume_is_null(ptr, ...) zassume((ptr) == NULL, #ptr " is not NULL", ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a ptr is not NULL
@@ -376,9 +372,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * If the assumption fails, the test will be marked as "skipped".
  *
  * @param ptr Pointer to compare
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_not_null(ptr, msg, ...) zassume((ptr) != NULL, #ptr " is NULL", msg, ##__VA_ARGS__)
+#define zassume_not_null(ptr, ...) zassume((ptr) != NULL, #ptr " is NULL", ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a a equals @a b
@@ -388,10 +384,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  *
  * @param a Value to compare
  * @param b Value to compare
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_equal(a, b, msg, ...)                                                              \
-	zassume((a) == (b), #a " not equal to " #b, msg, ##__VA_ARGS__)
+#define zassume_equal(a, b, ...) zassume((a) == (b), #a " not equal to " #b, ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a a does not equal @a b
@@ -401,10 +396,9 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  *
  * @param a Value to compare
  * @param b Value to compare
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_not_equal(a, b, msg, ...)                                                          \
-	zassume((a) != (b), #a " equal to " #b, msg, ##__VA_ARGS__)
+#define zassume_not_equal(a, b, ...) zassume((a) != (b), #a " equal to " #b, ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a a equals @a b
@@ -414,10 +408,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  *
  * @param a Value to compare
  * @param b Value to compare
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_equal_ptr(a, b, msg, ...)                                                          \
-	zassume((void *)(a) == (void *)(b), #a " not equal to " #b, msg, ##__VA_ARGS__)
+#define zassume_equal_ptr(a, b, ...)                                                               \
+	zassume((void *)(a) == (void *)(b), #a " not equal to " #b, ##__VA_ARGS__)
 
 /**
  * @brief Assume that @a a is within @a b with delta @a d
@@ -427,11 +421,11 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param a Value to compare
  * @param b Value to compare
  * @param d Delta
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_within(a, b, d, msg, ...)                                                          \
+#define zassume_within(a, b, d, ...)                                                               \
 	zassume(((a) >= ((b) - (d))) && ((a) <= ((b) + (d))), #a " not within " #b " +/- " #d,     \
-		msg, ##__VA_ARGS__)
+		##__VA_ARGS__)
 
 /**
  * @brief Assume that @a a is greater than or equal to @a l and less
@@ -442,10 +436,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param a Value to compare
  * @param l Lower limit
  * @param u Upper limit
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_between_inclusive(a, l, u, msg, ...)                                               \
-	zassume(((a) >= (l)) && ((a) <= (u)), #a " not between " #l " and " #u " inclusive", msg,  \
+#define zassume_between_inclusive(a, l, u, ...)                                                    \
+	zassume(((a) >= (l)) && ((a) <= (u)), #a " not between " #l " and " #u " inclusive",       \
 		##__VA_ARGS__)
 
 /**
@@ -472,10 +466,10 @@ static inline bool z_zassume(bool cond, const char *default_msg, const char *fil
  * @param buf Buffer to compare
  * @param exp Buffer with expected contents
  * @param size Size of buffers
- * @param msg Optional message to print if the assumption fails
+ * @param ... Optional message and variables to print if the assumption fails
  */
-#define zassume_mem_equal__(buf, exp, size, msg, ...)                                              \
-	zassume(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, msg, ##__VA_ARGS__)
+#define zassume_mem_equal__(buf, exp, size, ...)                                                   \
+	zassume(memcmp(buf, exp, size) == 0, #buf " not equal to " #exp, ##__VA_ARGS__)
 
 /**
  * @}

--- a/tests/arch/arm/arm_thread_swap_tz/src/main.c
+++ b/tests/arch/arm/arm_thread_swap_tz/src/main.c
@@ -89,7 +89,7 @@ ZTEST(thread_swap_tz, test_thread_swap_tz)
 	main_thread = (struct k_thread *)curr;
 
 	status = psa_crypto_init();
-	zassert_equal(PSA_SUCCESS, status, NULL);
+	zassert_equal(PSA_SUCCESS, status);
 
 	/* Calculate correct hash. */
 	do_hash(dummy_digest_correct);

--- a/tests/arch/arm/arm_tz_wrap_func/src/main.c
+++ b/tests/arch/arm/arm_tz_wrap_func/src/main.c
@@ -48,9 +48,9 @@ uint32_t foo1(uint32_t arg1, uint32_t arg2, uint32_t arg3, uint32_t arg4)
 	zassert_true(expect_foo1, "%s unexpectedly called", __func__);
 	zassert_equal(arg1, foo1_arg1, "Was 0x%"PRIx32", expected 0x%"PRIx32,
 		arg1, foo1_arg1);
-	zassert_equal(arg2, foo1_arg2, NULL);
-	zassert_equal(arg3, foo1_arg3, NULL);
-	zassert_equal(arg4, foo1_arg4, NULL);
+	zassert_equal(arg2, foo1_arg2);
+	zassert_equal(arg3, foo1_arg3);
+	zassert_equal(arg4, foo1_arg4);
 	expect_foo1 = false;
 	foo1_called = true;
 	expect_postface = true;
@@ -89,15 +89,15 @@ ZTEST(tz_wrap_func, test_tz_wrap_func)
 	zassert_equal(foo1_retval,
 		wrap_foo1(foo1_arg1, foo1_arg2, foo1_arg3, foo1_arg4), NULL);
 
-	zassert_equal(msp1, __get_MSP(), NULL);
-	zassert_equal(psp1, __get_PSP(), NULL);
+	zassert_equal(msp1, __get_MSP());
+	zassert_equal(psp1, __get_PSP());
 
-	zassert_true(preface_called, NULL);
-	zassert_true(foo1_called, NULL);
-	zassert_true(postface_called, NULL);
-	zassert_false(expect_preface, NULL);
-	zassert_false(expect_foo1, NULL);
-	zassert_false(expect_postface, NULL);
+	zassert_true(preface_called);
+	zassert_true(foo1_called);
+	zassert_true(postface_called);
+	zassert_false(expect_preface);
+	zassert_false(expect_foo1);
+	zassert_false(expect_postface);
 }
 
 ZTEST_SUITE(tz_wrap_func, NULL, NULL, NULL, NULL, NULL);

--- a/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
+++ b/tests/benchmarks/data_structure_perf/rbtree_perf/src/rbtree_perf.c
@@ -136,7 +136,7 @@ static void verify_rbtree_perf(struct rbnode *root, struct rbnode *test)
 	uint32_t node_height = 0;
 
 	node_height = search_height_recurse(root, test, node_height);
-	zassert_true(node_height <= dlog_N, NULL);
+	zassert_true(node_height <= dlog_N);
 }
 
 /**

--- a/tests/bluetooth/controller/common/src/helper_pdu.c
+++ b/tests/bluetooth/controller/common/src/helper_pdu.c
@@ -518,7 +518,7 @@ void helper_pdu_verify_feature_req(const char *file, uint32_t line, struct pdu_d
 {
 	struct pdu_data_llctrl_feature_req *feature_req = param;
 
-	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, NULL);
+	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_FEATURE_REQ,
 		      "Wrong opcode.\nCalled at %s:%d\n", file, line);
 
@@ -535,8 +535,8 @@ void helper_pdu_verify_peripheral_feature_req(const char *file, uint32_t line, s
 {
 	struct pdu_data_llctrl_feature_req *feature_req = param;
 
-	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, NULL);
-	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_PER_INIT_FEAT_XCHG, NULL);
+	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL);
+	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_PER_INIT_FEAT_XCHG);
 
 	for (int counter = 0; counter < 8; counter++) {
 		uint8_t expected_value = feature_req->features[counter];
@@ -551,7 +551,7 @@ void helper_pdu_verify_feature_rsp(const char *file, uint32_t line, struct pdu_d
 {
 	struct pdu_data_llctrl_feature_rsp *feature_rsp = param;
 
-	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL, NULL);
+	zassert_equal(pdu->ll_id, PDU_DATA_LLID_CTRL);
 	zassert_equal(pdu->llctrl.opcode, PDU_DATA_LLCTRL_TYPE_FEATURE_RSP,
 		      "Response: %d Expected: %d\n", pdu->llctrl.opcode,
 		      PDU_DATA_LLCTRL_TYPE_FEATURE_RSP);

--- a/tests/bluetooth/controller/ctrl_api/src/main.c
+++ b/tests/bluetooth/controller/ctrl_api/src/main.c
@@ -54,8 +54,8 @@ void test_api_init(void)
 
 	ull_llcp_init(&conn);
 
-	zassert_true(lr_is_disconnected(&conn), NULL);
-	zassert_true(rr_is_disconnected(&conn), NULL);
+	zassert_true(lr_is_disconnected(&conn));
+	zassert_true(rr_is_disconnected(&conn));
 }
 
 extern void test_int_mem_proc_ctx(void);
@@ -72,8 +72,8 @@ void test_api_connect(void)
 	ull_llcp_init(&conn);
 
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
-	zassert_true(lr_is_idle(&conn), NULL);
-	zassert_true(rr_is_idle(&conn), NULL);
+	zassert_true(lr_is_idle(&conn));
+	zassert_true(rr_is_idle(&conn));
 }
 
 void test_api_disconnect(void)
@@ -83,16 +83,16 @@ void test_api_disconnect(void)
 	ull_llcp_init(&conn);
 
 	ull_cp_state_set(&conn, ULL_CP_DISCONNECTED);
-	zassert_true(lr_is_disconnected(&conn), NULL);
-	zassert_true(rr_is_disconnected(&conn), NULL);
+	zassert_true(lr_is_disconnected(&conn));
+	zassert_true(rr_is_disconnected(&conn));
 
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
-	zassert_true(lr_is_idle(&conn), NULL);
-	zassert_true(rr_is_idle(&conn), NULL);
+	zassert_true(lr_is_idle(&conn));
+	zassert_true(rr_is_idle(&conn));
 
 	ull_cp_state_set(&conn, ULL_CP_DISCONNECTED);
-	zassert_true(lr_is_disconnected(&conn), NULL);
-	zassert_true(rr_is_disconnected(&conn), NULL);
+	zassert_true(lr_is_disconnected(&conn));
+	zassert_true(rr_is_disconnected(&conn));
 }
 
 void test_int_disconnect_loc(void)
@@ -113,13 +113,13 @@ void test_int_disconnect_loc(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	nr_free_ctx = ctx_buffers_free();
-	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt(), NULL);
+	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt());
 
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	nr_free_ctx = ctx_buffers_free();
-	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt() - 1, NULL);
+	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt() - 1);
 
 	event_prepare(&conn);
 	lt_rx(LL_VERSION_IND, &conn, &tx, &local_version_ind);
@@ -132,7 +132,7 @@ void test_int_disconnect_loc(void)
 	ull_cp_state_set(&conn, ULL_CP_DISCONNECTED);
 
 	nr_free_ctx = ctx_buffers_free();
-	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt(), NULL);
+	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt());
 
 	ut_rx_q_is_empty();
 
@@ -143,7 +143,7 @@ void test_int_disconnect_loc(void)
 	event_done(&conn);
 
 	nr_free_ctx = ctx_buffers_free();
-	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt(), NULL);
+	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt());
 
 	/*
 	 * all buffers should still be empty
@@ -171,7 +171,7 @@ void test_int_disconnect_rem(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	nr_free_ctx = ctx_buffers_free();
-	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt(), NULL);
+	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt());
 	/* Prepare */
 	event_prepare(&conn);
 
@@ -179,7 +179,7 @@ void test_int_disconnect_rem(void)
 	lt_tx(LL_VERSION_IND, &conn, &remote_version_ind);
 
 	nr_free_ctx = ctx_buffers_free();
-	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt(), NULL);
+	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt());
 
 	/* Disconnect before we reply */
 
@@ -195,7 +195,7 @@ void test_int_disconnect_rem(void)
 	event_done(&conn);
 
 	nr_free_ctx = ctx_buffers_free();
-	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt(), NULL);
+	zassert_equal(nr_free_ctx, test_ctx_buffers_cnt());
 
 	/* There should not be a host notifications */
 	ut_rx_q_is_empty();

--- a/tests/bluetooth/controller/ctrl_chmu/src/main.c
+++ b/tests/bluetooth/controller/ctrl_chmu/src/main.c
@@ -78,7 +78,7 @@ void test_channel_map_update_central_loc(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	err = ull_cp_chan_map_update(&conn, chm);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -157,7 +157,7 @@ void test_channel_map_update_central_invalid(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	err = ull_cp_chan_map_update(&conn, chm);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -350,7 +350,7 @@ void test_channel_map_update_periph_loc(void)
 	ull_cp_state_set(&conn, ULL_CP_CONNECTED);
 
 	err = ull_cp_chan_map_update(&conn, chm);
-	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED, NULL);
+	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED);
 
 	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
 				  "Free CTX buffers %d", ctx_buffers_free());

--- a/tests/bluetooth/controller/ctrl_cis_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cis_terminate/src/main.c
@@ -111,7 +111,7 @@ void test_cis_terminate_loc(uint8_t role)
 
 	/* Initiate an CIS Terminate Procedure */
 	err = ull_cp_cis_terminate(&conn, &cis, local_cis_terminate_ind.error_code);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_collision/src/main.c
+++ b/tests/bluetooth/controller/ctrl_collision/src/main.c
@@ -178,7 +178,7 @@ void test_phy_update_central_loc_collision(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/*** ***/
 
@@ -356,7 +356,7 @@ void test_phy_update_central_rem_collision(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/*** ***/
 
@@ -517,7 +517,7 @@ void test_phy_update_periph_loc_collision(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -644,7 +644,7 @@ void test_phy_conn_update_central_loc_collision(void)
 	/* (A) Initiate a PHY update procedure */
 
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, 1);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_conn_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_conn_update/src/main.c
@@ -239,7 +239,7 @@ void test_conn_update_central_loc_accept(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -391,7 +391,7 @@ void test_conn_update_central_loc_accept_reject_2nd_cpr(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -474,7 +474,7 @@ void test_conn_update_central_loc_accept_reject_2nd_cpr(void)
 
 	/* Initiate a parallel Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn_3rd, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn_3rd);
@@ -612,7 +612,7 @@ void test_conn_update_central_loc_invalid_param_rsp(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -681,7 +681,7 @@ void test_conn_update_central_loc_invalid_rsp(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -754,7 +754,7 @@ void test_conn_update_central_loc_reject(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -833,7 +833,7 @@ void test_conn_update_central_loc_remote_legacy(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -958,7 +958,7 @@ void test_conn_update_central_loc_unsupp_wo_feat_exch(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1075,7 +1075,7 @@ void test_conn_update_central_loc_unsupp_w_feat_exch(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1198,7 +1198,7 @@ void test_conn_update_central_loc_collision(void)
 
 	/* (A) Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1649,7 +1649,7 @@ void test_conn_update_central_rem_collision(void)
 	/* (B) Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, req_B->interval_min, req_B->interval_max, req_B->latency,
 				 req_B->timeout);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1831,7 +1831,7 @@ void test_conn_update_periph_loc_accept(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1936,7 +1936,7 @@ void test_conn_update_periph_loc_reject(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2015,7 +2015,7 @@ void test_conn_update_periph_loc_unsupp_feat_wo_feat_exch(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2082,7 +2082,7 @@ void test_conn_update_periph_loc_unsupp_feat_w_feat_exch(void)
 
 	/* Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE, NULL);
+	zassert_equal(err, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2176,7 +2176,7 @@ void test_conn_update_periph_loc_collision(void)
 
 	/* (A) Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2528,7 +2528,7 @@ void test_conn_update_periph_loc_collision_reject_2nd_cpr(void)
 
 	/* (A) Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2655,7 +2655,7 @@ void test_conn_update_periph_loc_collision_reject_2nd_cpr(void)
 	{
 		/* Initiate a parallel local Connection Parameter Request Procedure */
 		err = ull_cp_conn_update(&conn_2nd, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-		zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 		/* Prepare */
 		event_prepare(&conn_2nd);
@@ -2905,7 +2905,7 @@ void test_conn_update_periph_rem_accept_reject_2nd_cpr(void)
 	{
 		/* Initiate a parallel local Connection Parameter Request Procedure */
 		err = ull_cp_conn_update(&conn_2nd, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-		zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 		/* Prepare */
 		event_prepare(&conn_2nd);
@@ -3471,7 +3471,7 @@ void test_conn_update_periph_rem_collision(void)
 	/* (B) Initiate a Connection Parameter Request Procedure */
 	err = ull_cp_conn_update(&conn, req_B->interval_min, req_B->interval_max, req_B->latency,
 				 req_B->timeout);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/*******************/
 
@@ -3650,7 +3650,7 @@ void test_conn_update_central_loc_accept_no_param_req(void)
 	do {
 		/* Initiate a Connection Update Procedure */
 		err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-		zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 		/* Prepare */
 		event_prepare(&conn);
@@ -3981,7 +3981,7 @@ void test_conn_update_periph_loc_disallowed_no_param_req(void)
 
 	/* Initiate a Connection Update Procedure */
 	err = ull_cp_conn_update(&conn, INTVL_MIN, INTVL_MAX, LATENCY, TIMEOUT);
-	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED, NULL);
+	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED);
 
 	/* Prepare */
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_cte_req/src/main.c
+++ b/tests/bluetooth/controller/ctrl_cte_req/src/main.c
@@ -110,7 +110,7 @@ ZTEST(cte_req_after_fex, test_cte_req_central_local)
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -185,7 +185,7 @@ ZTEST(cte_req_after_fex, test_cte_req_peripheral_local)
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -404,7 +404,7 @@ ZTEST(cte_req_after_fex, test_cte_req_rejected_inv_ll_param_central_local)
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -483,7 +483,7 @@ ZTEST(cte_req_after_fex, test_cte_req_rejected_inv_ll_param_peripheral_local)
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -700,7 +700,7 @@ static void test_cte_req_ll_unknown_rsp_local(uint8_t role)
 
 	/* Initiate an CTE Request Procedure */
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -735,7 +735,7 @@ static void test_cte_req_ll_unknown_rsp_local(uint8_t role)
 
 	/* Verify that CTE response feature is marked as not supported by peer device */
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE, NULL);
+	zassert_equal(err, BT_HCI_ERR_UNSUPP_REMOTE_FEATURE);
 }
 
 ZTEST(cte_req, test_cte_req_ll_unknown_rsp_central_local)
@@ -1114,13 +1114,13 @@ static void test_local_cte_req_wait_for_phy_update_complete_and_disable(uint8_t 
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_CODED, PREFER_S2_CODING, PHY_CODED, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Initiate an CTE Request Procedure */
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	if (role == BT_HCI_ROLE_CENTRAL) {
 		run_phy_update_central(true, &phy_req, pu_event_counter(&conn),
@@ -1181,13 +1181,13 @@ static void test_local_cte_req_wait_for_phy_update_complete(uint8_t role)
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, phy_req.rx_phys, PREFER_S2_CODING, phy_req.tx_phys,
 				HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Initiate an CTE Request Procedure */
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	if (role == BT_HCI_ROLE_CENTRAL) {
 		run_phy_update_central(true, &phy_req, pu_event_counter(&conn),
@@ -1235,11 +1235,11 @@ static void test_local_phy_update_wait_for_cte_req_complete(uint8_t role)
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_CODED, PREFER_S2_CODING, PHY_CODED, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Handle CTE request */
 	run_local_cte_req(&local_cte_req);
@@ -1327,7 +1327,7 @@ static void test_phy_update_wait_for_remote_cte_req_complete(uint8_t role)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_CODED, PREFER_S2_CODING, PHY_CODED, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	run_remote_cte_req(&local_cte_req);
 
@@ -1387,7 +1387,7 @@ static void test_cte_req_wait_for_remote_phy_update_complete_and_disable(uint8_t
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	if (role == BT_HCI_ROLE_CENTRAL) {
 		run_phy_update_central(false, &phy_req, pu_event_counter(&conn),
@@ -1443,7 +1443,7 @@ static void test_cte_req_wait_for_remote_phy_update_complete(uint8_t role)
 	conn.llcp.cte_req.is_enabled = 1U;
 
 	err = ull_cp_cte_req(&conn, local_cte_req.min_cte_len_req, local_cte_req.cte_type_req);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	if (role == BT_HCI_ROLE_CENTRAL) {
 		run_phy_update_central(false, &phy_req, pu_event_counter(&conn),

--- a/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_data_length_update/src/main.c
@@ -104,7 +104,7 @@ void test_data_length_update_central_loc(void)
 
 	/* Initiate a Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -177,7 +177,7 @@ void test_data_length_update_central_loc_unknown_rsp(void)
 
 	/* Initiate a Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -250,7 +250,7 @@ void test_data_length_update_central_loc_invalid_rsp(void)
 
 	/* Initiate a Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -288,7 +288,7 @@ void test_data_length_update_central_loc_invalid_rsp(void)
 
 	/* Initiate another Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -353,7 +353,7 @@ void test_data_length_update_central_loc_no_eff_change(void)
 
 	/* Initiate a Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -429,7 +429,7 @@ void test_data_length_update_central_loc_no_eff_change2(void)
 
 	/* Initiate a Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -454,7 +454,7 @@ void test_data_length_update_central_loc_no_eff_change2(void)
 	 * change to effective numbers, thus not generate NTF
 	 */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -495,7 +495,7 @@ void test_data_length_update_periph_loc(void)
 
 	/* Initiate a Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -714,7 +714,7 @@ void test_data_length_update_periph_rem_and_loc(void)
 
 	/* Initiate a Data Length Update Procedure */
 	err = ull_cp_data_length_update(&conn, 211, 1800);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_done(&conn);
 

--- a/tests/bluetooth/controller/ctrl_encrypt/src/main.c
+++ b/tests/bluetooth/controller/ctrl_encrypt/src/main.c
@@ -223,7 +223,7 @@ void test_encryption_start_central_loc(void)
 
 	/* Initiate an Encryption Start Procedure */
 	err = ull_cp_encryption_start(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -400,7 +400,7 @@ void test_encryption_start_central_loc_limited_memory(void)
 
 	/* Initiate an Encryption Start Procedure */
 	err = ull_cp_encryption_start(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -512,10 +512,10 @@ void test_encryption_start_central_loc_limited_memory(void)
 	ull_cp_release_ntf(ntf);
 
 	/* Tx Encryption should be enabled */
-	zassert_equal(conn.lll.enc_tx, 1U, NULL);
+	zassert_equal(conn.lll.enc_tx, 1U);
 
 	/* Rx Decryption should be enabled */
-	zassert_equal(conn.lll.enc_rx, 1U, NULL);
+	zassert_equal(conn.lll.enc_rx, 1U);
 
 	/* Release dummy procedure */
 	llcp_proc_ctx_release(ctx);
@@ -589,7 +589,7 @@ void test_encryption_start_central_loc_reject_ext(void)
 
 	/* Initiate an Encryption Start Procedure */
 	err = ull_cp_encryption_start(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -686,7 +686,7 @@ void test_encryption_start_central_loc_reject(void)
 
 	/* Initiate an Encryption Start Procedure */
 	err = ull_cp_encryption_start(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -794,7 +794,7 @@ void test_encryption_start_central_loc_no_ltk(void)
 
 	/* Initiate an Encryption Start Procedure */
 	err = ull_cp_encryption_start(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -900,7 +900,7 @@ void test_encryption_start_central_loc_no_ltk_2(void)
 
 	/* Initiate an Encryption Start Procedure */
 	err = ull_cp_encryption_start(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1008,7 +1008,7 @@ void test_encryption_start_central_loc_mic(void)
 
 	/* Initiate an Encryption Start Procedure */
 	err = ull_cp_encryption_start(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1925,7 +1925,7 @@ void test_encryption_pause_central_loc(void)
 
 	/* Initiate an Encryption Pause Procedure */
 	err = ull_cp_encryption_pause(&conn, rand, ediv, ltk);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1953,10 +1953,10 @@ void test_encryption_pause_central_loc(void)
 	ull_cp_release_tx(&conn, tx);
 
 	/* Tx Encryption should be disabled */
-	zassert_equal(conn.lll.enc_tx, 0U, NULL);
+	zassert_equal(conn.lll.enc_tx, 0U);
 
 	/* Rx Decryption should be disabled */
-	zassert_equal(conn.lll.enc_rx, 0U, NULL);
+	zassert_equal(conn.lll.enc_rx, 0U);
 
 	/**** UNENCRYPTED ****/
 
@@ -1992,10 +1992,10 @@ void test_encryption_pause_central_loc(void)
 	CHECK_TX_CCM_STATE(conn, sk_be, iv, 0U, CCM_DIR_M_TO_S);
 
 	/* Tx Encryption should be enabled */
-	zassert_equal(conn.lll.enc_tx, 1U, NULL);
+	zassert_equal(conn.lll.enc_tx, 1U);
 
 	/* Rx Decryption should be enabled */
-	zassert_equal(conn.lll.enc_rx, 1U, NULL);
+	zassert_equal(conn.lll.enc_rx, 1U);
 
 	/* Release Tx */
 	ull_cp_release_tx(&conn, tx);
@@ -2014,10 +2014,10 @@ void test_encryption_pause_central_loc(void)
 	ull_cp_release_ntf(ntf);
 
 	/* Tx Encryption should be enabled */
-	zassert_equal(conn.lll.enc_tx, 1U, NULL);
+	zassert_equal(conn.lll.enc_tx, 1U);
 
 	/* Rx Decryption should be enabled */
-	zassert_equal(conn.lll.enc_rx, 1U, NULL);
+	zassert_equal(conn.lll.enc_rx, 1U);
 
 	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
 				  "Free CTX buffers %d", ctx_buffers_free());
@@ -2085,7 +2085,7 @@ void test_encryption_pause_periph_rem(void)
 	lt_rx_q_is_empty(&conn);
 
 	/* Rx Decryption should be disabled */
-	zassert_equal(conn.lll.enc_rx, 0U, NULL);
+	zassert_equal(conn.lll.enc_rx, 0U);
 
 	/* Rx */
 	lt_tx(LL_PAUSE_ENC_RSP, &conn, NULL);
@@ -2097,7 +2097,7 @@ void test_encryption_pause_periph_rem(void)
 	ull_cp_release_tx(&conn, tx);
 
 	/* Tx Encryption should be disabled */
-	zassert_equal(conn.lll.enc_tx, 0U, NULL);
+	zassert_equal(conn.lll.enc_tx, 0U);
 
 	/**** UNENCRYPTED ****/
 
@@ -2153,7 +2153,7 @@ void test_encryption_pause_periph_rem(void)
 	CHECK_RX_CCM_STATE(conn, sk_be, iv, 0U, CCM_DIR_M_TO_S);
 
 	/* Rx Decryption should be enabled */
-	zassert_equal(conn.lll.enc_rx, 1U, NULL);
+	zassert_equal(conn.lll.enc_rx, 1U);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -2188,7 +2188,7 @@ void test_encryption_pause_periph_rem(void)
 	CHECK_TX_CCM_STATE(conn, sk_be, iv, 0U, CCM_DIR_S_TO_M);
 
 	/* Tx Encryption should be enabled */
-	zassert_equal(conn.lll.enc_tx, 1U, NULL);
+	zassert_equal(conn.lll.enc_tx, 1U);
 
 	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
 				  "Free CTX buffers %d", ctx_buffers_free());

--- a/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
+++ b/tests/bluetooth/controller/ctrl_feature_exchange/src/main.c
@@ -110,7 +110,7 @@ void test_feat_exchange_central_loc(void)
 
 		/* Initiate a Feature Exchange Procedure */
 		err = ull_cp_feature_exchange(&conn);
-		zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 		event_prepare(&conn);
 		/* Tx Queue should have one LL Control PDU */
@@ -176,7 +176,7 @@ void test_feat_exchange_central_loc_invalid_rsp(void)
 
 	/* Initiate a Feature Exchange Procedure */
 	err = ull_cp_feature_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -210,7 +210,7 @@ void test_feat_exchange_central_loc_invalid_rsp(void)
 
 	/* Initiate another Feature Exchange Procedure */
 	err = ull_cp_feature_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -245,7 +245,7 @@ void test_feat_exchange_central_loc_2(void)
 
 	err = ull_cp_feature_exchange(&conn);
 	for (int i = 0U; i < CONFIG_BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM; i++) {
-		zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 		err = ull_cp_feature_exchange(&conn);
 	}
 
@@ -372,7 +372,7 @@ void test_feat_exchange_central_rem_2(void)
 		sys_put_le64(ut_exp_featureset[feat_count], ut_feature_rsp.features);
 
 		err = ull_cp_feature_exchange(&conn);
-		zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 		event_prepare(&conn);
 		lt_tx(LL_PERIPH_FEAT_XCHG, &conn, &remote_feature_req);
@@ -435,7 +435,7 @@ void test_peripheral_feat_exchange_periph_loc(void)
 
 	/* Initiate a Feature Exchange Procedure */
 	err = ull_cp_feature_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	event_prepare(&conn);
 	/* Tx Queue should have one LL Control PDU */
@@ -496,7 +496,7 @@ void test_feat_exchange_periph_loc_unknown_rsp(void)
 
 	event_prepare(&conn);
 	err = ull_cp_feature_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 	event_done(&conn);
 
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_hci/src/main.c
+++ b/tests/bluetooth/controller/ctrl_hci/src/main.c
@@ -229,19 +229,19 @@ void test_hci_apto(void)
 	conn_from_pool->apto_reload = 100;
 	conn_from_pool->lll.interval = 10;
 	err = ll_apto_get(conn_handle, &apto);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 	zassert_equal(apto, 125, "Apto is %d", apto);
 
 	err = ll_apto_get(conn_handle + 1, &apto);
-	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID, NULL);
+	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID);
 
 	err = ll_apto_set(conn_handle, 1000);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 	zassert_equal(conn_from_pool->apto_reload, 800, "Apto reload is %d",
 		      conn_from_pool->apto_reload);
 
 	err = ll_apto_get(conn_handle + 1, 0x00);
-	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID, NULL);
+	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID);
 }
 
 void test_hci_phy(void)
@@ -258,7 +258,7 @@ void test_hci_phy(void)
 	ull_cp_state_set(conn_from_pool, ULL_CP_CONNECTED);
 
 	err = ll_phy_req_send(conn_handle + 1, 0x00, 0x00, 0x00);
-	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID, NULL);
+	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID);
 	conn_from_pool->llcp.fex.features_used = 0x00;
 	conn_from_pool->llcp.fex.valid = 1;
 	err = ll_phy_req_send(conn_handle, 0x03, 0xFF, 0x03);
@@ -268,27 +268,27 @@ void test_hci_phy(void)
 	err = ll_phy_req_send(conn_handle, 0x03, 0xFF, 0x03);
 	zassert_equal(err, BT_HCI_ERR_SUCCESS, "Errorcode %d", err);
 	err = ll_phy_get(conn_handle + 1, &phy_tx, &phy_rx);
-	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID, NULL);
+	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID);
 
 	conn_from_pool->lll.phy_rx = 0x3;
 	conn_from_pool->lll.phy_tx = 0x7;
 	err = ll_phy_get(conn_handle, &phy_tx, &phy_rx);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
-	zassert_equal(phy_tx, 0x07, NULL);
-	zassert_equal(phy_rx, 0x03, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
+	zassert_equal(phy_tx, 0x07);
+	zassert_equal(phy_rx, 0x03);
 
 	err = ll_phy_default_set(0x00, 0x00);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 	phy_tx = ull_conn_default_phy_tx_get();
 	phy_rx = ull_conn_default_phy_rx_get();
-	zassert_equal(phy_tx, 0x00, NULL);
-	zassert_equal(phy_rx, 0x00, NULL);
+	zassert_equal(phy_tx, 0x00);
+	zassert_equal(phy_rx, 0x00);
 	err = ll_phy_default_set(0x01, 0x03);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 	phy_tx = ull_conn_default_phy_tx_get();
 	phy_rx = ull_conn_default_phy_rx_get();
-	zassert_equal(phy_tx, 0x01, NULL);
-	zassert_equal(phy_rx, 0x03, NULL);
+	zassert_equal(phy_tx, 0x01);
+	zassert_equal(phy_rx, 0x03);
 }
 
 void test_hci_dle(void)
@@ -317,25 +317,25 @@ void test_hci_dle(void)
 	zassert_equal(err, BT_HCI_ERR_UNKNOWN_CONN_ID, "Errorcode %d", err);
 
 	ll_length_max_get(&max_tx_octets, &max_tx_time, &max_rx_octets, &max_rx_time);
-	zassert_equal(max_tx_octets, LL_LENGTH_OCTETS_RX_MAX, NULL);
-	zassert_equal(max_rx_octets, LL_LENGTH_OCTETS_RX_MAX, NULL);
+	zassert_equal(max_tx_octets, LL_LENGTH_OCTETS_RX_MAX);
+	zassert_equal(max_rx_octets, LL_LENGTH_OCTETS_RX_MAX);
 	zassert_equal(max_tx_time, 17040, "Actual time is %d", max_tx_time);
 	zassert_equal(max_rx_time, 17040, "Actual time is %d", max_rx_time);
 
 	err = ll_length_default_set(0x00, 0x00);
 	ll_length_default_get(&max_tx_octets, &max_tx_time);
-	zassert_equal(err, 00, NULL);
-	zassert_equal(max_tx_octets, 0x00, NULL);
-	zassert_equal(max_tx_time, 0x00, NULL);
+	zassert_equal(err, 00);
+	zassert_equal(max_tx_octets, 0x00);
+	zassert_equal(max_tx_time, 0x00);
 	err = ll_length_default_set(0x10, 0x3FF);
 	ll_length_default_get(&max_tx_octets, &max_tx_time);
-	zassert_equal(err, 00, NULL);
-	zassert_equal(max_tx_octets, 0x10, NULL);
-	zassert_equal(max_tx_time, 0x3FF, NULL);
+	zassert_equal(err, 00);
+	zassert_equal(max_tx_octets, 0x10);
+	zassert_equal(max_tx_time, 0x3FF);
 	max_tx_octets = ull_conn_default_tx_octets_get();
 	max_tx_time = ull_conn_default_tx_time_get();
-	zassert_equal(max_tx_octets, 0x10, NULL);
-	zassert_equal(max_tx_time, 0x3FF, NULL);
+	zassert_equal(max_tx_octets, 0x10);
+	zassert_equal(max_tx_time, 0x3FF);
 }
 
 void test_hci_terminate(void)

--- a/tests/bluetooth/controller/ctrl_le_ping/src/main.c
+++ b/tests/bluetooth/controller/ctrl_le_ping/src/main.c
@@ -94,7 +94,7 @@ void test_ping_central_loc(void)
 
 	/* Initiate an LE Ping Procedure */
 	err = ull_cp_le_ping(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -120,7 +120,7 @@ void test_ping_central_loc(void)
 
 	/* Initiate another LE Ping Procedure */
 	err = ull_cp_le_ping(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -185,7 +185,7 @@ void test_ping_central_loc_invalid_rsp(void)
 
 	/* Initiate an LE Ping Procedure */
 	err = ull_cp_le_ping(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -218,7 +218,7 @@ void test_ping_central_loc_invalid_rsp(void)
 
 	/* Initiate another LE Ping Procedure */
 	err = ull_cp_le_ping(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -281,7 +281,7 @@ void test_ping_periph_loc(void)
 
 	/* Initiate an LE Ping Procedure */
 	err = ull_cp_le_ping(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
+++ b/tests/bluetooth/controller/ctrl_min_used_chans/src/main.c
@@ -81,7 +81,7 @@ void test_min_used_chans_periph_loc(void)
 
 	/* Initiate a Min number of Used Channels Procedure */
 	err = ull_cp_min_used_chans(&conn, 1, 2);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -121,7 +121,7 @@ void test_min_used_chans_central_loc(void)
 
 	/* Initiate a Min number of Used Channels Procedure */
 	err = ull_cp_min_used_chans(&conn, 1, 2);
-	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED, NULL);
+	zassert_equal(err, BT_HCI_ERR_CMD_DISALLOWED);
 
 	zassert_equal(ctx_buffers_free(), test_ctx_buffers_cnt(),
 		      "Free CTX buffers %d", ctx_buffers_free());

--- a/tests/bluetooth/controller/ctrl_phy_update/src/main.c
+++ b/tests/bluetooth/controller/ctrl_phy_update/src/main.c
@@ -141,7 +141,7 @@ void test_phy_update_central_loc(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -245,7 +245,7 @@ void test_phy_update_central_loc_invalid(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -296,7 +296,7 @@ void test_phy_update_central_loc_unsupp_feat(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -443,7 +443,7 @@ void test_phy_update_periph_loc(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -749,7 +749,7 @@ void test_phy_update_central_loc_collision(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/*** ***/
 
@@ -926,7 +926,7 @@ void test_phy_update_central_rem_collision(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/*** ***/
 
@@ -1093,7 +1093,7 @@ void test_phy_update_periph_loc_collision(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_2M, PREFER_S8_CODING, PHY_2M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1209,7 +1209,7 @@ void test_phy_update_central_loc_no_act_change(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_1M, PREFER_S8_CODING, PHY_1M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -1357,7 +1357,7 @@ void test_phy_update_periph_loc_no_actual_change(void)
 
 	/* Initiate an PHY Update Procedure */
 	err = ull_cp_phy_update(&conn, PHY_1M, PREFER_S8_CODING, PHY_1M, HOST_INITIATED);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_terminate/src/main.c
+++ b/tests/bluetooth/controller/ctrl_terminate/src/main.c
@@ -112,7 +112,7 @@ void test_terminate_loc(uint8_t role)
 
 	/* Initiate an LE Ping Procedure */
 	err = ull_cp_terminate(&conn, 0x06);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);

--- a/tests/bluetooth/controller/ctrl_tx_buffer_alloc/src/main.c
+++ b/tests/bluetooth/controller/ctrl_tx_buffer_alloc/src/main.c
@@ -71,39 +71,39 @@ void test_tx_buffer_alloc(void)
 #if defined(LLCP_TX_CTRL_BUF_QUEUE_ENABLE)
 	/* Check alloc flow */
 	for (i = 0; i < CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM; i++) {
-		zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]), NULL);
+		zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]));
 		tx[tx_alloc_idx] = llcp_tx_alloc(&conn[0], ctxs[0]);
-		zassert_equal(conn[0].llcp.tx_buffer_alloc, i + 1, NULL);
-		zassert_equal(common_tx_buffer_alloc_count(), 0, NULL);
+		zassert_equal(conn[0].llcp.tx_buffer_alloc, i + 1);
+		zassert_equal(common_tx_buffer_alloc_count(), 0);
 		zassert_not_null(tx[tx_alloc_idx], NULL);
 		tx_alloc_idx++;
 	}
 	for (i = 0; i < CONFIG_BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM; i++) {
-		zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]), NULL);
+		zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]));
 		tx[tx_alloc_idx] = llcp_tx_alloc(&conn[0], ctxs[0]);
 		zassert_equal(conn[0].llcp.tx_buffer_alloc,
 			      CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM + i + 1, NULL);
-		zassert_equal(common_tx_buffer_alloc_count(), i+1, NULL);
+		zassert_equal(common_tx_buffer_alloc_count(), i+1);
 		zassert_not_null(tx[tx_alloc_idx], NULL);
 		tx_alloc_idx++;
 	}
-	zassert_false(llcp_tx_alloc_peek(&conn[0], ctxs[0]), NULL);
-	zassert_equal(ctxs[0]->wait_reason, WAITING_FOR_TX_BUFFER, NULL);
+	zassert_false(llcp_tx_alloc_peek(&conn[0], ctxs[0]));
+	zassert_equal(ctxs[0]->wait_reason, WAITING_FOR_TX_BUFFER);
 
 	for (int j = 1; j < CONFIG_BT_CTLR_LLCP_CONN; j++) {
 		/* Now global pool is exausted, but conn pool is not */
 		for (i = 0; i < CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM; i++) {
-			zassert_true(llcp_tx_alloc_peek(&conn[j], ctxs[j]), NULL);
+			zassert_true(llcp_tx_alloc_peek(&conn[j], ctxs[j]));
 			tx[tx_alloc_idx] = llcp_tx_alloc(&conn[j], ctxs[j]);
 			zassert_not_null(tx[tx_alloc_idx], NULL);
 			zassert_equal(common_tx_buffer_alloc_count(),
 				      CONFIG_BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM, NULL);
-			zassert_equal(conn[j].llcp.tx_buffer_alloc, i + 1, NULL);
+			zassert_equal(conn[j].llcp.tx_buffer_alloc, i + 1);
 			tx_alloc_idx++;
 		}
 
-		zassert_false(llcp_tx_alloc_peek(&conn[j], ctxs[j]), NULL);
-		zassert_equal(ctxs[j]->wait_reason, WAITING_FOR_TX_BUFFER, NULL);
+		zassert_false(llcp_tx_alloc_peek(&conn[j], ctxs[j]));
+		zassert_equal(ctxs[j]->wait_reason, WAITING_FOR_TX_BUFFER);
 	}
 
 	ull_cp_release_tx(&conn[0], tx[1]);
@@ -113,10 +113,10 @@ void test_tx_buffer_alloc(void)
 		      CONFIG_BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM - 1, NULL);
 
 	/* global pool is now 'open' again, but ctxs[1] is NOT next in line */
-	zassert_false(llcp_tx_alloc_peek(&conn[1], ctxs[1]), NULL);
+	zassert_false(llcp_tx_alloc_peek(&conn[1], ctxs[1]));
 
 	/* ... ctxs[0] is */
-	zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]), NULL);
+	zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]));
 	tx[tx_alloc_idx] = llcp_tx_alloc(&conn[0], ctxs[0]);
 	zassert_equal(common_tx_buffer_alloc_count(), CONFIG_BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM,
 		      NULL);
@@ -132,7 +132,7 @@ void test_tx_buffer_alloc(void)
 		      CONFIG_BT_CTLR_LLCP_COMMON_TX_CTRL_BUF_NUM - 1, NULL);
 
 	/* global pool does not allow as ctxs[2] is NOT next up */
-	zassert_false(llcp_tx_alloc_peek(&conn[2], ctxs[2]), NULL);
+	zassert_false(llcp_tx_alloc_peek(&conn[2], ctxs[2]));
 
 #if (CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM > 0)
 	/* Release conn[2] held tx, to confirm alloc is allowed after releasing pre-alloted buf */
@@ -145,20 +145,20 @@ void test_tx_buffer_alloc(void)
 		       CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM), NULL);
 
 	/* global pool does not allow as ctxs[2] is not next up, but pre alloted is now avail */
-	zassert_equal(ctxs[2]->wait_reason, WAITING_FOR_TX_BUFFER, NULL);
+	zassert_equal(ctxs[2]->wait_reason, WAITING_FOR_TX_BUFFER);
 	zassert_not_null(ctxs[2]->wait_node.next, NULL);
-	zassert_true(llcp_tx_alloc_peek(&conn[2], ctxs[2]), NULL);
+	zassert_true(llcp_tx_alloc_peek(&conn[2], ctxs[2]));
 	tx[tx_alloc_idx] = llcp_tx_alloc(&conn[2], ctxs[2]);
 	zassert_not_null(tx[tx_alloc_idx], NULL);
 	tx_alloc_idx++;
 
 	/* No longer waiting in line */
-	zassert_equal(ctxs[2]->wait_reason, WAITING_FOR_NOTHING, NULL);
+	zassert_equal(ctxs[2]->wait_reason, WAITING_FOR_NOTHING);
 	zassert_is_null(ctxs[2]->wait_node.next, NULL);
 #endif /* (CONFIG_BT_CTLR_LLCP_PER_CONN_TX_CTRL_BUF_NUM > 0) */
 
 	/* now ctxs[1] is next up */
-	zassert_true(llcp_tx_alloc_peek(&conn[1], ctxs[1]), NULL);
+	zassert_true(llcp_tx_alloc_peek(&conn[1], ctxs[1]));
 	tx[tx_alloc_idx] = llcp_tx_alloc(&conn[0], ctxs[0]);
 	zassert_not_null(tx[tx_alloc_idx], NULL);
 	tx_alloc_idx++;
@@ -170,12 +170,12 @@ void test_tx_buffer_alloc(void)
 	for (i = 0;
 	     i < CONFIG_BT_CTLR_LLCP_TX_PER_CONN_TX_CTRL_BUF_NUM_MAX * CONFIG_BT_CTLR_LLCP_CONN;
 	     i++) {
-		zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]), NULL);
+		zassert_true(llcp_tx_alloc_peek(&conn[0], ctxs[0]));
 		tx[tx_alloc_idx] = llcp_tx_alloc(&conn[0], ctxs[0]);
 		zassert_not_null(tx[tx_alloc_idx], NULL);
 		tx_alloc_idx++;
 	}
-	zassert_false(llcp_tx_alloc_peek(&conn[0], ctxs[0]), NULL);
+	zassert_false(llcp_tx_alloc_peek(&conn[0], ctxs[0]));
 #endif /* LLCP_TX_CTRL_BUF_QUEUE_ENABLE */
 }
 

--- a/tests/bluetooth/controller/ctrl_version/src/main.c
+++ b/tests/bluetooth/controller/ctrl_version/src/main.c
@@ -94,7 +94,7 @@ void test_version_exchange_central_loc(void)
 
 	/* Initiate a Version Exchange Procedure */
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -166,7 +166,7 @@ void test_version_exchange_central_loc_invalid_rsp(void)
 
 	/* Initiate a Version Exchange Procedure */
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -202,7 +202,7 @@ void test_version_exchange_central_loc_invalid_rsp(void)
 
 	/* Initiate another Version Exchange Procedure */
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -238,7 +238,7 @@ void test_version_exchange_central_loc_invalid_rsp(void)
 
 	/* Initiate yet another Version Exchange Procedure */
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -278,7 +278,7 @@ void test_version_exchange_central_loc_2(void)
 	err = ull_cp_version_exchange(&conn);
 
 	for (int i = 0U; i < CONFIG_BT_CTLR_LLCP_LOCAL_PROC_CTX_BUF_NUM; i++) {
-		zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+		zassert_equal(err, BT_HCI_ERR_SUCCESS);
 		err = ull_cp_version_exchange(&conn);
 	}
 
@@ -396,7 +396,7 @@ void test_version_exchange_central_rem_2(void)
 
 	/* Initiate a Version Exchange Procedure */
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);
@@ -468,11 +468,11 @@ void test_version_exchange_central_loc_twice(void)
 
 	/* Initiate a Version Exchange Procedure */
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Initiate a Version Exchange Procedure */
 	err = ull_cp_version_exchange(&conn);
-	zassert_equal(err, BT_HCI_ERR_SUCCESS, NULL);
+	zassert_equal(err, BT_HCI_ERR_SUCCESS);
 
 	/* Prepare */
 	event_prepare(&conn);

--- a/tests/bluetooth/ctrl_isoal/src/main.c
+++ b/tests/bluetooth/ctrl_isoal/src/main.c
@@ -928,7 +928,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_single_pdu)
 
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
 	zassert_equal(BT_ISO_SINGLE,
@@ -937,8 +937,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_single_pdu)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1034,7 +1034,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu)
 		      FSM_TO_STR(ISOAL_CONTINUE));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -1071,7 +1071,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
 	zassert_equal(BT_ISO_SINGLE,
@@ -1080,8 +1080,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1178,7 +1178,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* SDU 1 - PDU 2 -----------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -1211,7 +1211,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 		      FSM_TO_STR(ISOAL_START));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
 	zassert_equal(BT_ISO_SINGLE,
@@ -1220,8 +1220,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1264,7 +1264,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* SDU 2 - PDU 4 */
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -1297,7 +1297,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 		      FSM_TO_STR(ISOAL_START));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
 	zassert_equal(BT_ISO_SINGLE,
@@ -1306,8 +1306,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1351,7 +1351,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
 	zassert_equal(BT_ISO_SINGLE,
@@ -1360,8 +1360,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_split)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1458,7 +1458,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_multi_split)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -1490,7 +1490,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_multi_split)
 		      FSM_TO_STR(ISOAL_CONTINUE));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 3 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -1522,7 +1522,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_multi_split)
 		      FSM_TO_STR(ISOAL_CONTINUE));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 4 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -1554,7 +1554,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_multi_split)
 		      FSM_TO_STR(ISOAL_CONTINUE));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 5 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -1586,7 +1586,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_multi_split)
 		      FSM_TO_STR(ISOAL_START));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -1596,8 +1596,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_multi_split)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1706,11 +1706,11 @@ ZTEST(test_rx_unframed, test_rx_unframed_long_pdu_short_sdu)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_history[0], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_history[0], NULL);
-	zassert_equal(20, sink_sdu_write_test_fake.arg2_history[0], NULL);
+	zassert_equal(20, sink_sdu_write_test_fake.arg2_history[0]);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_history[1], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + 20], sink_sdu_write_test_fake.arg1_history[1],
 			  NULL);
-	zassert_equal(20, sink_sdu_write_test_fake.arg2_history[1], NULL);
+	zassert_equal(20, sink_sdu_write_test_fake.arg2_history[1]);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl],
 			  sink_sdu_emit_test_fake.arg0_history[0], NULL);
@@ -1724,7 +1724,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_long_pdu_short_sdu)
 		      sink_sdu_emit_test_handler_fake.arg1_history[0].status, NULL);
 	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_history[0].timestamp,
 		      NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_history[0].seqn, NULL);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_history[0].seqn);
 	zassert_equal(sdu_buffer.dbuf,
 		      sink_sdu_emit_test_handler_fake.arg1_history[0].contents.dbuf, NULL);
 	zassert_equal(sdu_buffer.size,
@@ -1742,7 +1742,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_long_pdu_short_sdu)
 		      sink_sdu_emit_test_handler_fake.arg1_history[1].status, NULL);
 	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_history[1].timestamp,
 		      NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_history[1].seqn, NULL);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_history[1].seqn);
 	zassert_equal(sdu_buffer.dbuf,
 		      sink_sdu_emit_test_handler_fake.arg1_history[1].contents.dbuf, NULL);
 	zassert_equal(sdu_buffer.size,
@@ -1838,7 +1838,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_prem)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -1848,8 +1848,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_prem)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1891,7 +1891,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_prem)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -1901,8 +1901,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_prem)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -1998,7 +1998,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_single_pdu_err)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -2008,8 +2008,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_single_pdu_err)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -2051,7 +2051,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_single_pdu_err)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -2061,8 +2061,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_single_pdu_err)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -2159,7 +2159,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_err)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 Not transferred to ISO-AL ------------------------------------*/
 	payload_number++;
@@ -2201,7 +2201,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_err)
 		      FSM_TO_STR(ISOAL_ERR_SPOOL));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -2211,8 +2211,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_err)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -2260,7 +2260,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_err)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 }
 
 /**
@@ -2354,7 +2354,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_pdu_err)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 Not transferred to ISO-AL ------------------------------------*/
 	payload_number++;
@@ -2398,7 +2398,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_pdu_err)
 		      FSM_TO_STR(ISOAL_ERR_SPOOL));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -2408,8 +2408,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_pdu_err)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -2457,7 +2457,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_pdu_err)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 5 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -2489,7 +2489,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_pdu_err)
 		      FSM_TO_STR(ISOAL_ERR_SPOOL));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -2499,8 +2499,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_seq_pdu_err)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -2597,7 +2597,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -2629,7 +2629,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding)
 		      FSM_TO_STR(ISOAL_ERR_SPOOL));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -2639,8 +2639,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -2792,7 +2792,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_no_end)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -2857,8 +2857,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_no_end)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -2955,7 +2955,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_error1)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -2965,8 +2965,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_error1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -3119,7 +3119,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_error2)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -3156,8 +3156,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_error2)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -3281,7 +3281,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_error3)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -3312,7 +3312,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_error3)
 		      FSM_TO_STR(ISOAL_ERR_SPOOL));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -3322,8 +3322,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_padding_error3)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -3454,8 +3454,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_zero_len_packet)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -3553,7 +3553,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_no_end)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -3584,7 +3584,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_no_end)
 		      FSM_TO_STR(ISOAL_START));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -3594,8 +3594,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_no_end)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -3771,7 +3771,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_invalid_llid2)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -3886,7 +3886,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_invalid_llid2_pdu_err)
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu_meta, sink_sdu_alloc_test_fake.arg1_val, NULL);
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -3920,7 +3920,7 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_invalid_llid2_pdu_err)
 		      FSM_TO_STR(ISOAL_START));
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2], sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
 	zassert_equal(BT_ISO_SINGLE,
@@ -3929,8 +3929,8 @@ ZTEST(test_rx_unframed, test_rx_unframed_dbl_pdu_invalid_llid2_pdu_err)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -4034,7 +4034,7 @@ ZTEST(test_rx_framed, test_rx_framed_single_pdu_single_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -4044,8 +4044,8 @@ ZTEST(test_rx_framed, test_rx_framed_single_pdu_single_sdu)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -4150,7 +4150,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -4186,7 +4186,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 3 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -4221,7 +4221,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[2]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -4231,8 +4231,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -4340,7 +4340,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -4399,7 +4399,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_history[1], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_history[1], NULL);
-	zassert_equal(10, sink_sdu_write_test_fake.arg2_history[1], NULL);
+	zassert_equal(10, sink_sdu_write_test_fake.arg2_history[1]);
 	zassert_equal_ptr(&rx_sdu_frag_buf[1], sink_sdu_write_test_fake.arg0_history[2], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[2]],
 			  sink_sdu_write_test_fake.arg1_history[2], NULL);
@@ -4414,8 +4414,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -4454,7 +4454,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf[1], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -4464,8 +4464,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[1], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[1], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[1].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[1].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -4576,7 +4576,7 @@ ZTEST(test_rx_framed, test_rx_framed_zero_length_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -4658,7 +4658,7 @@ ZTEST(test_rx_framed, test_rx_framed_zero_length_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_history[1], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_history[1], NULL);
-	zassert_equal(10, sink_sdu_write_test_fake.arg2_history[1], NULL);
+	zassert_equal(10, sink_sdu_write_test_fake.arg2_history[1]);
 	zassert_equal_ptr(&rx_sdu_frag_buf[2], sink_sdu_write_test_fake.arg0_history[2], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_history[2], NULL);
@@ -4677,7 +4677,7 @@ ZTEST(test_rx_framed, test_rx_framed_zero_length_sdu)
 		      sink_sdu_emit_test_handler_fake.arg1_history[0].status, NULL);
 	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_history[0].timestamp,
 		      NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_history[0].seqn, NULL);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_history[0].seqn);
 	zassert_equal(sdu_buffer[0].dbuf,
 		      sink_sdu_emit_test_handler_fake.arg1_history[0].contents.dbuf, NULL);
 	zassert_equal(sdu_buffer[0].size,
@@ -4695,7 +4695,7 @@ ZTEST(test_rx_framed, test_rx_framed_zero_length_sdu)
 		      sink_sdu_emit_test_handler_fake.arg1_history[1].status, NULL);
 	zassert_equal(sdu_timestamp[1], sink_sdu_emit_test_handler_fake.arg1_history[1].timestamp,
 		      NULL);
-	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_history[1].seqn, NULL);
+	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_history[1].seqn);
 	zassert_equal(sdu_buffer[1].dbuf,
 		      sink_sdu_emit_test_handler_fake.arg1_history[1].contents.dbuf, NULL);
 	zassert_equal(sdu_buffer[1].size,
@@ -4734,7 +4734,7 @@ ZTEST(test_rx_framed, test_rx_framed_zero_length_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf[2], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -4744,8 +4744,8 @@ ZTEST(test_rx_framed, test_rx_framed_zero_length_sdu)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[2], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[2], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[2], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[2], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[2].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[2].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -4850,7 +4850,7 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_padding)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -4860,8 +4860,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_padding)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -4941,7 +4941,7 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_padding)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -4951,8 +4951,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_padding)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5064,8 +5064,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_pdu_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5116,7 +5116,7 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_pdu_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -5126,8 +5126,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_pdu_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5239,8 +5239,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_pdu_err2)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5291,7 +5291,7 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_pdu_err2)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -5301,8 +5301,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_pdu_err2)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5407,7 +5407,7 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -5417,8 +5417,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_seq_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5489,7 +5489,7 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -5499,8 +5499,8 @@ ZTEST(test_rx_framed, test_rx_framed_dbl_pdu_dbl_sdu_seq_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5611,8 +5611,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5725,7 +5725,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -5735,8 +5735,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5842,7 +5842,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err2)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -5882,8 +5882,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err2)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -5965,7 +5965,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err2)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -5975,8 +5975,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err2)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6082,7 +6082,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err3)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -6118,7 +6118,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err3)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 3 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -6158,8 +6158,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err3)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6210,7 +6210,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err3)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -6220,8 +6220,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_err3)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6327,7 +6327,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	/* PDU not transferred to the ISO-AL */
@@ -6376,8 +6376,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_seq_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6428,7 +6428,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -6438,8 +6438,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_seq_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6545,7 +6545,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	/* PDU not transferred to the ISO-AL */
@@ -6594,8 +6594,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_seq_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6646,7 +6646,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -6656,8 +6656,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_single_sdu_pdu_seq_err1)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6771,8 +6771,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err1)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6836,7 +6836,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf[1], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[2]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 3 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -6871,7 +6871,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf[1], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[3]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -6881,8 +6881,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err1)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[1], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[1], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[1].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[1].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -6933,7 +6933,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[4]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -6943,8 +6943,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err1)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7052,7 +7052,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err2)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -7111,8 +7111,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err2)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7194,7 +7194,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err2)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[4]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -7204,8 +7204,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err2)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7313,7 +7313,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err3)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -7372,7 +7372,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err3)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_history[1], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_history[1], NULL);
-	zassert_equal(10, sink_sdu_write_test_fake.arg2_history[1], NULL);
+	zassert_equal(10, sink_sdu_write_test_fake.arg2_history[1]);
 	zassert_equal_ptr(&rx_sdu_frag_buf[1], sink_sdu_write_test_fake.arg0_history[2], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[2]],
 			  sink_sdu_write_test_fake.arg1_history[2], NULL);
@@ -7387,8 +7387,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err3)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7433,8 +7433,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err3)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_ERRORS, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[1], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[1], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[1], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[1].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[1].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7485,7 +7485,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err3)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[4]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -7495,8 +7495,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_err3)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7604,7 +7604,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -7668,8 +7668,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_seq_err1)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7720,7 +7720,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[4]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -7730,8 +7730,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_seq_err1)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7839,7 +7839,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf[0], sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	/* PDU 2 -------------------------------------------------------------*/
 	init_rx_pdu_buffer(&rx_pdu_meta_buf);
@@ -7903,8 +7903,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_seq_err1)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_LOST_DATA, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -7955,7 +7955,7 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_seq_err1)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_val, NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[4]],
 			  sink_sdu_write_test_fake.arg1_val, NULL);
-	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val, NULL);
+	zassert_equal((testdata_size - testdata_indx), sink_sdu_write_test_fake.arg2_val);
 
 	zassert_equal_ptr(&isoal_global.sink_state[sink_hdl], sink_sdu_emit_test_fake.arg0_val,
 			  NULL);
@@ -7965,8 +7965,8 @@ ZTEST(test_rx_framed, test_rx_framed_trppl_pdu_dbl_sdu_pdu_seq_err1)
 		      sink_sdu_emit_test_handler_fake.arg0_val.sdu_production.sdu_written, NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp[0], sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn[0], sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer[0].dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer[0].size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,
@@ -8088,12 +8088,12 @@ ZTEST(test_rx_framed, test_rx_framed_single_invalid_pdu_single_sdu)
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_history[0], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[0]],
 			  sink_sdu_write_test_fake.arg1_history[0], NULL);
-	zassert_equal(13, sink_sdu_write_test_fake.arg2_history[0], NULL);
+	zassert_equal(13, sink_sdu_write_test_fake.arg2_history[0]);
 
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_history[1], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[1]],
 			  sink_sdu_write_test_fake.arg1_history[1], NULL);
-	zassert_equal(5, sink_sdu_write_test_fake.arg2_history[1], NULL);
+	zassert_equal(5, sink_sdu_write_test_fake.arg2_history[1]);
 
 	zassert_equal_ptr(&rx_sdu_frag_buf, sink_sdu_write_test_fake.arg0_history[2], NULL);
 	zassert_equal_ptr(&rx_pdu_meta_buf.pdu[2 + pdu_data_loc[2]],
@@ -8109,8 +8109,8 @@ ZTEST(test_rx_framed, test_rx_framed_single_invalid_pdu_single_sdu)
 		      NULL);
 	zassert_equal(ISOAL_SDU_STATUS_VALID, sink_sdu_emit_test_handler_fake.arg1_val.status,
 		      NULL);
-	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp, NULL);
-	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn, NULL);
+	zassert_equal(sdu_timestamp, sink_sdu_emit_test_handler_fake.arg1_val.timestamp);
+	zassert_equal(seqn, sink_sdu_emit_test_handler_fake.arg1_val.seqn);
 	zassert_equal(sdu_buffer.dbuf, sink_sdu_emit_test_handler_fake.arg1_val.contents.dbuf,
 		      NULL);
 	zassert_equal(sdu_buffer.size, sink_sdu_emit_test_handler_fake.arg1_val.contents.size,

--- a/tests/bluetooth/host_long_adv_recv/src/main.c
+++ b/tests/bluetooth/host_long_adv_recv/src/main.c
@@ -430,7 +430,7 @@ ZTEST(long_adv_rx_tests, test_host_long_adv_recv)
 	send_adv_report(&report_a_2);
 	send_adv_report(&report_b_1);
 	send_adv_report(&report_b_2);
-	zassert_equal(2, get_expected_report_fake.call_count, NULL);
+	zassert_equal(2, get_expected_report_fake.call_count);
 	RESET_FAKE(get_expected_report);
 	FFF_RESET_HISTORY();
 
@@ -441,7 +441,7 @@ ZTEST(long_adv_rx_tests, test_host_long_adv_recv)
 	send_adv_report(&report_a_1);
 	send_adv_report(&report_c); /* Interleaved legacy adv report */
 	send_adv_report(&report_a_2);
-	zassert_equal(2, get_expected_report_fake.call_count, NULL);
+	zassert_equal(2, get_expected_report_fake.call_count);
 	RESET_FAKE(get_expected_report);
 	FFF_RESET_HISTORY();
 
@@ -452,7 +452,7 @@ ZTEST(long_adv_rx_tests, test_host_long_adv_recv)
 	send_adv_report(&report_a_1);
 	send_adv_report(&report_b_2); /* Interleaved short extended adv report */
 	send_adv_report(&report_a_2);
-	zassert_equal(2, get_expected_report_fake.call_count, NULL);
+	zassert_equal(2, get_expected_report_fake.call_count);
 	RESET_FAKE(get_expected_report);
 	FFF_RESET_HISTORY();
 
@@ -466,7 +466,7 @@ ZTEST(long_adv_rx_tests, test_host_long_adv_recv)
 	send_adv_report(&report_b_1); /* Interleaved fragmented adv report, NOT SUPPORTED */
 	send_adv_report(&report_a_2);
 	send_adv_report(&report_b_2);
-	zassert_equal(2, get_expected_report_fake.call_count, NULL);
+	zassert_equal(2, get_expected_report_fake.call_count);
 	RESET_FAKE(get_expected_report);
 	FFF_RESET_HISTORY();
 
@@ -486,5 +486,5 @@ ZTEST(long_adv_rx_tests, test_host_long_adv_recv)
 	/* Check that reports from a different advertiser works after truncation */
 	send_adv_report(&report_b_1);
 	send_adv_report(&report_b_2);
-	zassert_equal(1, get_expected_report_fake.call_count, NULL);
+	zassert_equal(1, get_expected_report_fake.call_count);
 }

--- a/tests/boards/altera_max10/i2c_master/src/i2c_master.c
+++ b/tests/boards/altera_max10/i2c_master/src/i2c_master.c
@@ -123,7 +123,7 @@ static int test_i2c_adv7513(void)
 
 ZTEST(nios2_i2c_master, test_i2c_master)
 {
-	zassert_true(test_i2c_adv7513() == TC_PASS, NULL);
+	zassert_true(test_i2c_adv7513() == TC_PASS);
 }
 
 ZTEST_SUITE(nios2_i2c_master, NULL, NULL, NULL, NULL, NULL);

--- a/tests/boards/intel_adsp/ssp/src/main.c
+++ b/tests/boards/intel_adsp/ssp/src/main.c
@@ -383,7 +383,7 @@ ZTEST(adsp_ssp, test_adsp_ssp_config_set)
 
 	ret = dai_config_set(dev_dai_ssp, &config, &ssp_config);
 
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 static void test_adsp_ssp_probe(void)
@@ -392,7 +392,7 @@ static void test_adsp_ssp_probe(void)
 
 	ret = dai_probe(dev_dai_ssp);
 
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 static void *adsp_ssp_setup(void)

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -492,7 +492,7 @@ static int test_task_one_channel(void)
 
 ZTEST_USER(adc_basic, test_adc_sample_one_channel)
 {
-	zassert_true(test_task_one_channel() == TC_PASS, NULL);
+	zassert_true(test_task_one_channel() == TC_PASS);
 }
 
 /*
@@ -528,7 +528,7 @@ static int test_task_two_channels(void)
 ZTEST_USER(adc_basic, test_adc_sample_two_channels)
 {
 #if defined(ADC_2ND_CHANNEL_ID)
-	zassert_true(test_task_two_channels() == TC_PASS, NULL);
+	zassert_true(test_task_two_channels() == TC_PASS);
 #else
 	ztest_test_skip();
 #endif /* defined(ADC_2ND_CHANNEL_ID) */
@@ -580,7 +580,7 @@ static int test_task_asynchronous_call(void)
 ZTEST_USER(adc_basic, test_adc_asynchronous_call)
 {
 #if defined(CONFIG_ADC_ASYNC)
-	zassert_true(test_task_asynchronous_call() == TC_PASS, NULL);
+	zassert_true(test_task_asynchronous_call() == TC_PASS);
 #else
 	ztest_test_skip();
 #endif /* defined(CONFIG_ADC_ASYNC) */
@@ -642,7 +642,7 @@ static int test_task_with_interval(void)
 
 ZTEST(adc_basic, test_adc_sample_with_interval)
 {
-	zassert_true(test_task_with_interval() == TC_PASS, NULL);
+	zassert_true(test_task_with_interval() == TC_PASS);
 }
 
 /*
@@ -727,7 +727,7 @@ static int test_task_repeated_samplings(void)
 
 ZTEST(adc_basic, test_adc_repeated_samplings)
 {
-	zassert_true(test_task_repeated_samplings() == TC_PASS, NULL);
+	zassert_true(test_task_repeated_samplings() == TC_PASS);
 }
 
 /*
@@ -772,5 +772,5 @@ static int test_task_invalid_request(void)
 
 ZTEST_USER(adc_basic, test_adc_invalid_request)
 {
-	zassert_true(test_task_invalid_request() == TC_PASS, NULL);
+	zassert_true(test_task_invalid_request() == TC_PASS);
 }

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -190,7 +190,7 @@ static int test_task_one_channel(void)
 
 ZTEST_USER(adc_dma, test_adc_sample_one_channel)
 {
-	zassert_true(test_task_one_channel() == TC_PASS, NULL);
+	zassert_true(test_task_one_channel() == TC_PASS);
 }
 
 /*
@@ -225,7 +225,7 @@ static int test_task_two_channels(void)
 ZTEST_USER(adc_dma, test_adc_sample_two_channels)
 {
 #if defined(ADC_2ND_CHANNEL_ID)
-	zassert_true(test_task_two_channels() == TC_PASS, NULL);
+	zassert_true(test_task_two_channels() == TC_PASS);
 #else
 	ztest_test_skip();
 #endif /* defined(ADC_2ND_CHANNEL_ID) */
@@ -275,7 +275,7 @@ static int test_task_asynchronous_call(void)
 ZTEST_USER(adc_dma, test_adc_asynchronous_call)
 {
 #if defined(CONFIG_ADC_ASYNC)
-	zassert_true(test_task_asynchronous_call() == TC_PASS, NULL);
+	zassert_true(test_task_asynchronous_call() == TC_PASS);
 #else
 	ztest_test_skip();
 #endif /* defined(CONFIG_ADC_ASYNC) */
@@ -340,7 +340,7 @@ static int test_task_with_interval(void)
 
 ZTEST(adc_dma, test_adc_sample_with_interval)
 {
-	zassert_true(test_task_with_interval() == TC_PASS, NULL);
+	zassert_true(test_task_with_interval() == TC_PASS);
 }
 
 /*
@@ -426,7 +426,7 @@ static int test_task_repeated_samplings(void)
 
 ZTEST(adc_dma, test_adc_repeated_samplings)
 {
-	zassert_true(test_task_repeated_samplings() == TC_PASS, NULL);
+	zassert_true(test_task_repeated_samplings() == TC_PASS);
 }
 
 /*
@@ -471,5 +471,5 @@ static int test_task_invalid_request(void)
 
 ZTEST_USER(adc_dma, test_adc_invalid_request)
 {
-	zassert_true(test_task_invalid_request() == TC_PASS, NULL);
+	zassert_true(test_task_invalid_request() == TC_PASS);
 }

--- a/tests/drivers/bbram/emul/src/main.c
+++ b/tests/drivers/bbram/emul/src/main.c
@@ -18,8 +18,8 @@ ZTEST(bbram, test_get_size)
 
 	zassert_true(device_is_ready(dev), "Device is not ready");
 
-	zassert_ok(bbram_get_size(dev, &size), NULL);
-	zassert_equal(size, BBRAM_SIZE, NULL);
+	zassert_ok(bbram_get_size(dev, &size));
+	zassert_equal(size, BBRAM_SIZE);
 }
 
 ZTEST(bbram, test_bbram_out_of_bounds)
@@ -27,12 +27,12 @@ ZTEST(bbram, test_bbram_out_of_bounds)
 	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	uint8_t buffer[BBRAM_SIZE];
 
-	zassert_equal(bbram_read(dev, 0, 0, buffer), -EFAULT, NULL);
-	zassert_equal(bbram_read(dev, 0, BBRAM_SIZE + 1, buffer), -EFAULT, NULL);
-	zassert_equal(bbram_read(dev, BBRAM_SIZE - 1, 2, buffer), -EFAULT, NULL);
-	zassert_equal(bbram_write(dev, 0, 0, buffer), -EFAULT, NULL);
-	zassert_equal(bbram_write(dev, 0, BBRAM_SIZE + 1, buffer), -EFAULT, NULL);
-	zassert_equal(bbram_write(dev, BBRAM_SIZE - 1, 2, buffer), -EFAULT, NULL);
+	zassert_equal(bbram_read(dev, 0, 0, buffer), -EFAULT);
+	zassert_equal(bbram_read(dev, 0, BBRAM_SIZE + 1, buffer), -EFAULT);
+	zassert_equal(bbram_read(dev, BBRAM_SIZE - 1, 2, buffer), -EFAULT);
+	zassert_equal(bbram_write(dev, 0, 0, buffer), -EFAULT);
+	zassert_equal(bbram_write(dev, 0, BBRAM_SIZE + 1, buffer), -EFAULT);
+	zassert_equal(bbram_write(dev, BBRAM_SIZE - 1, 2, buffer), -EFAULT);
 }
 
 ZTEST(bbram, test_read_write)
@@ -45,8 +45,8 @@ ZTEST(bbram, test_read_write)
 		expected[i] = i;
 	}
 	/* Set and verify content. */
-	zassert_ok(bbram_write(dev, 0, BBRAM_SIZE, expected), NULL);
-	zassert_ok(bbram_read(dev, 0, BBRAM_SIZE, buffer), NULL);
+	zassert_ok(bbram_write(dev, 0, BBRAM_SIZE, expected));
+	zassert_ok(bbram_read(dev, 0, BBRAM_SIZE, buffer));
 	zassert_mem_equal(buffer, expected, BBRAM_SIZE, NULL);
 }
 
@@ -54,30 +54,30 @@ ZTEST(bbram, test_set_invalid)
 {
 	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 
-	zassert_equal(bbram_check_invalid(dev), 0, NULL);
-	zassert_ok(bbram_emul_set_invalid(dev, true), NULL);
-	zassert_equal(bbram_check_invalid(dev), 1, NULL);
-	zassert_equal(bbram_check_invalid(dev), 0, NULL);
+	zassert_equal(bbram_check_invalid(dev), 0);
+	zassert_ok(bbram_emul_set_invalid(dev, true));
+	zassert_equal(bbram_check_invalid(dev), 1);
+	zassert_equal(bbram_check_invalid(dev), 0);
 }
 
 ZTEST(bbram, test_set_standby)
 {
 	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 
-	zassert_equal(bbram_check_standby_power(dev), 0, NULL);
-	zassert_ok(bbram_emul_set_standby_power_state(dev, true), NULL);
-	zassert_equal(bbram_check_standby_power(dev), 1, NULL);
-	zassert_equal(bbram_check_standby_power(dev), 0, NULL);
+	zassert_equal(bbram_check_standby_power(dev), 0);
+	zassert_ok(bbram_emul_set_standby_power_state(dev, true));
+	zassert_equal(bbram_check_standby_power(dev), 1);
+	zassert_equal(bbram_check_standby_power(dev), 0);
 }
 
 ZTEST(bbram, test_set_power)
 {
 	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 
-	zassert_equal(bbram_check_power(dev), 0, NULL);
-	zassert_ok(bbram_emul_set_power_state(dev, true), NULL);
-	zassert_equal(bbram_check_power(dev), 1, NULL);
-	zassert_equal(bbram_check_power(dev), 0, NULL);
+	zassert_equal(bbram_check_power(dev), 0);
+	zassert_ok(bbram_emul_set_power_state(dev, true));
+	zassert_equal(bbram_check_power(dev), 1);
+	zassert_equal(bbram_check_power(dev), 0);
 }
 
 ZTEST(bbram, test_reset_invalid_on_read)
@@ -85,9 +85,9 @@ ZTEST(bbram, test_reset_invalid_on_read)
 	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	uint8_t buffer[BBRAM_SIZE];
 
-	zassert_ok(bbram_emul_set_invalid(dev, true), NULL);
-	zassert_equal(bbram_read(dev, 0, BBRAM_SIZE, buffer), -EFAULT, NULL);
-	zassert_equal(bbram_check_invalid(dev), 0, NULL);
+	zassert_ok(bbram_emul_set_invalid(dev, true));
+	zassert_equal(bbram_read(dev, 0, BBRAM_SIZE, buffer), -EFAULT);
+	zassert_equal(bbram_check_invalid(dev), 0);
 }
 
 ZTEST(bbram, test_reset_invalid_on_write)
@@ -95,9 +95,9 @@ ZTEST(bbram, test_reset_invalid_on_write)
 	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	uint8_t buffer[BBRAM_SIZE];
 
-	zassert_ok(bbram_emul_set_invalid(dev, true), NULL);
-	zassert_equal(bbram_write(dev, 0, BBRAM_SIZE, buffer), -EFAULT, NULL);
-	zassert_equal(bbram_check_invalid(dev), 0, NULL);
+	zassert_ok(bbram_emul_set_invalid(dev, true));
+	zassert_equal(bbram_write(dev, 0, BBRAM_SIZE, buffer), -EFAULT);
+	zassert_equal(bbram_check_invalid(dev), 0);
 }
 
 static void before(void *data)

--- a/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
+++ b/tests/drivers/clock_control/nrf_lf_clock_start/src/main.c
@@ -22,7 +22,7 @@ static void xtal_check(bool on, nrf_clock_lfclk_t type)
 		zassert_true(is_running, "Clock should be on");
 	} else {
 		zassert_true(on, "Clock should be on");
-		zassert_equal(type, NRF_CLOCK_LFCLK_Xtal, NULL);
+		zassert_equal(type, NRF_CLOCK_LFCLK_Xtal);
 	}
 }
 
@@ -32,7 +32,7 @@ static void rc_check(bool on, nrf_clock_lfclk_t type)
 		zassert_false(on, "Clock should be off");
 	} else {
 		zassert_true(on, "Clock should be on");
-		zassert_equal(type, NRF_CLOCK_LFCLK_RC, NULL);
+		zassert_equal(type, NRF_CLOCK_LFCLK_RC);
 	}
 }
 
@@ -45,7 +45,7 @@ static void synth_check(bool on, nrf_clock_lfclk_t type)
 
 	if (!IS_ENABLED(CONFIG_SYSTEM_CLOCK_NO_WAIT)) {
 		zassert_true(on, "Clock should be on");
-		zassert_equal(type, NRF_CLOCK_LFCLK_Synth, NULL);
+		zassert_equal(type, NRF_CLOCK_LFCLK_Synth);
 	}
 }
 
@@ -78,13 +78,13 @@ ZTEST(nrf_lf_clock_start, test_wait_in_thread)
 
 	z_nrf_clock_control_lf_on(CLOCK_CONTROL_NRF_LF_START_AVAILABLE);
 	o = nrf_clock_is_running(NRF_CLOCK, NRF_CLOCK_DOMAIN_LFCLK, &t);
-	zassert_false((t == NRF_CLOCK_LFCLK_Xtal) && o, NULL);
+	zassert_false((t == NRF_CLOCK_LFCLK_Xtal) && o);
 	k_busy_wait(35);
-	zassert_true(k_cycle_get_32() > 0, NULL);
+	zassert_true(k_cycle_get_32() > 0);
 
 	z_nrf_clock_control_lf_on(CLOCK_CONTROL_NRF_LF_START_STABLE);
 	o = nrf_clock_is_running(NRF_CLOCK, NRF_CLOCK_DOMAIN_LFCLK, &t);
-	zassert_true((t == NRF_CLOCK_LFCLK_Xtal) && o, NULL);
+	zassert_true((t == NRF_CLOCK_LFCLK_Xtal) && o);
 }
 
 void *test_init(void)

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -27,10 +27,10 @@ static uint32_t iteration;
 static void before(void *data)
 {
 	ARG_UNUSED(data);
-	zassert_true(device_is_ready(entropy), NULL);
+	zassert_true(device_is_ready(entropy));
 
 	hf_mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_HF);
-	zassert_true(hf_mgr, NULL);
+	zassert_true(hf_mgr);
 
 	iteration = 0;
 }
@@ -115,12 +115,12 @@ ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 		iteration++;
 
 		err = entropy_get_entropy(entropy, &rand, 1);
-		zassert_equal(err, 0, NULL);
+		zassert_equal(err, 0);
 		backoff = 3 * rand;
 
 		sys_notify_init_spinwait(&cli.notify);
 		err = onoff_request(hf_mgr, &cli);
-		zassert_true(err >= 0, NULL);
+		zassert_true(err >= 0);
 
 		k_busy_wait(backoff);
 
@@ -129,7 +129,7 @@ ZTEST(nrf_onoff_and_bt, test_onoff_interrupted)
 		}
 
 		err = onoff_cancel_or_release(hf_mgr, &cli);
-		zassert_true(err >= 0, NULL);
+		zassert_true(err >= 0);
 
 		elapsed = k_uptime_get() - start_time;
 		if (elapsed > checkpoint) {
@@ -158,7 +158,7 @@ static void onoff_timeout_handler(struct k_timer *timer)
 	if (on) {
 		on = false;
 		err = onoff_cancel_or_release(hf_mgr, &cli);
-		zassert_true(err >= 0, NULL);
+		zassert_true(err >= 0);
 	} else {
 		on = true;
 		sys_notify_init_spinwait(&cli.notify);
@@ -208,7 +208,7 @@ ZTEST(nrf_onoff_and_bt, test_bt_interrupted)
 		iteration++;
 
 		err = entropy_get_entropy(entropy, &rand, 1);
-		zassert_equal(err, 0, NULL);
+		zassert_equal(err, 0);
 		backoff = 3 * rand;
 
 		z_nrf_clock_bt_ctlr_hf_request();

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -236,7 +236,7 @@ static int test_task_loopback(void)
 
 ZTEST(dac_loopback, test_dac_loopback)
 {
-	zassert_true(test_task_loopback() == TC_PASS, NULL);
+	zassert_true(test_task_loopback() == TC_PASS);
 }
 
 ZTEST_SUITE(dac_loopback, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -101,20 +101,20 @@ static int test_task(uint32_t chan_id, uint32_t blen)
 /* export test cases */
 ZTEST(dma_m2m, test_dma_m2m_chan0_burst8)
 {
-	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8) == TC_PASS), NULL);
+	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 8) == TC_PASS));
 }
 
 ZTEST(dma_m2m, test_dma_m2m_chan1_burst8)
 {
-	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8) == TC_PASS), NULL);
+	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 8) == TC_PASS));
 }
 
 ZTEST(dma_m2m, test_dma_m2m_chan0_burst16)
 {
-	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16) == TC_PASS), NULL);
+	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_0, 16) == TC_PASS));
 }
 
 ZTEST(dma_m2m, test_dma_m2m_chan1_burst16)
 {
-	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16) == TC_PASS), NULL);
+	zassert_true((test_task(CONFIG_DMA_TRANSFER_CHANNEL_NR_1, 16) == TC_PASS));
 }

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -141,15 +141,15 @@ static int test_task(int minor, int major)
 /* export test cases */
 ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_major_link)
 {
-	zassert_true((test_task(0, 1) == TC_PASS), NULL);
+	zassert_true((test_task(0, 1) == TC_PASS));
 }
 
 ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_link)
 {
-	zassert_true((test_task(1, 0) == TC_PASS), NULL);
+	zassert_true((test_task(1, 0) == TC_PASS));
 }
 
 ZTEST(dma_m2m_link, test_dma_m2m_chan0_1_minor_major_link)
 {
-	zassert_true((test_task(1, 1) == TC_PASS), NULL);
+	zassert_true((test_task(1, 1) == TC_PASS));
 }

--- a/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
+++ b/tests/drivers/dma/loop_transfer/src/test_dma_loop.c
@@ -342,11 +342,11 @@ static int test_loop_suspend_resume(void)
 /* export test cases */
 ZTEST(dma_m2m_loop, test_dma_m2m_loop)
 {
-	zassert_true((test_loop() == TC_PASS), NULL);
+	zassert_true((test_loop() == TC_PASS));
 }
 
 /* export test cases */
 ZTEST(dma_m2m_loop, test_dma_m2m_loop_suspend_resume)
 {
-	zassert_true((test_loop_suspend_resume() == TC_PASS), NULL);
+	zassert_true((test_loop_suspend_resume() == TC_PASS));
 }

--- a/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
+++ b/tests/drivers/dma/scatter_gather/src/test_dma_sg.c
@@ -148,5 +148,5 @@ static int test_sg(void)
 /* export test cases */
 ZTEST(dma_m2m_sg, test_dma_m2m_sg)
 {
-	zassert_true((test_sg() == TC_PASS), NULL);
+	zassert_true((test_sg() == TC_PASS));
 }

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -100,7 +100,7 @@ static int get_entropy(void)
 
 ZTEST(entropy_api, test_entropy_get_entropy)
 {
-	zassert_true(get_entropy() == TC_PASS, NULL);
+	zassert_true(get_entropy() == TC_PASS);
 }
 
 void *entropy_api_setup(void)

--- a/tests/drivers/espi/src/test_acpi.c
+++ b/tests/drivers/espi/src/test_acpi.c
@@ -18,7 +18,7 @@ static void test_acpi_shared_memory(void)
 
 	zassert_true(device_is_ready(espi_dev), "Device is not ready");
 
-	zassert_ok(espi_config(espi_dev, &cfg), NULL);
+	zassert_ok(espi_config(espi_dev, &cfg));
 
 	host_shm = emul_espi_host_get_acpi_shm(espi_dev);
 	zassert_not_equal(host_shm, 0, NULL);
@@ -27,7 +27,7 @@ static void test_acpi_shared_memory(void)
 					 (uint32_t *)&peripheral_shm),
 		   NULL);
 
-	zassert_equal(host_shm, peripheral_shm, NULL);
+	zassert_equal(host_shm, peripheral_shm);
 }
 
 ztest_test_suite(acpi, ztest_unit_test(test_acpi_shared_memory));

--- a/tests/drivers/flash/src/main.c
+++ b/tests/drivers/flash/src/main.c
@@ -55,7 +55,7 @@ static void *flash_driver_setup(void)
 {
 	int rc;
 
-	zassert_true(device_is_ready(flash_dev), NULL);
+	zassert_true(device_is_ready(flash_dev));
 
 	const struct flash_parameters *flash_params =
 			flash_get_parameters(flash_dev);

--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -151,12 +151,12 @@ static int test_burst_gy271(void)
 
 ZTEST(i2c_gy271, test_i2c_gy271)
 {
-	zassert_true(test_gy271() == TC_PASS, NULL);
+	zassert_true(test_gy271() == TC_PASS);
 }
 
 ZTEST(i2c_gy271, test_i2c_burst_gy271)
 {
-	zassert_true(test_burst_gy271() == TC_PASS, NULL);
+	zassert_true(test_burst_gy271() == TC_PASS);
 }
 
 ZTEST_SUITE(i2c_gy271, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_dir_both_loopback.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_dir_both_loopback.c
@@ -26,7 +26,7 @@ void test_i2s_dir_both_transfer_configure_0(void)
 	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME_RX " not found");
 
 	ret = configure_stream(dev_i2s, I2S_DIR_BOTH);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Check if the tested driver supports the I2S_DIR_BOTH value.
 	 * Use the DROP trigger for this, as in the current state of the driver
@@ -59,22 +59,22 @@ void test_i2s_dir_both_transfer_short(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 1);
 
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 2);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = tx_block_write(dev_i2s, 2, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 3);
 
 	/* All data written, drain TX queue and stop both streams. */
@@ -82,11 +82,11 @@ void test_i2s_dir_both_transfer_short(void)
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 2);
 
 	ret = rx_block_read(dev_i2s, 2);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 3);
 
 	/* TODO: Verify the interface is in READY state when i2s_state_get
@@ -114,17 +114,17 @@ void test_i2s_dir_both_transfer_long(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	for (int i = 0; i < TEST_I2S_TRANSFER_LONG_REPEAT_COUNT; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 
 		ret = rx_block_read(dev_i2s, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 	}
 
 	/* All data written, all but one data block read, flush TX queue
@@ -134,7 +134,7 @@ void test_i2s_dir_both_transfer_long(void)
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* TODO: Verify the interface is in READY state when i2s_state_get
 	 * function is available.
@@ -159,11 +159,11 @@ void test_i2s_dir_both_transfer_restart(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 1);
 
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 2);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
@@ -173,7 +173,7 @@ void test_i2s_dir_both_transfer_restart(void)
 	zassert_equal(ret, 0, "RX/TX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 1);
 
 	TC_PRINT("Stop transmission\n");
@@ -185,7 +185,7 @@ void test_i2s_dir_both_transfer_restart(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 2, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 3);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
@@ -195,11 +195,11 @@ void test_i2s_dir_both_transfer_restart(void)
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 2);
 
 	ret = rx_block_read(dev_i2s, 2);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 3);
 }
 
@@ -226,14 +226,14 @@ void test_i2s_dir_both_transfer_rx_overrun(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
@@ -247,7 +247,7 @@ void test_i2s_dir_both_transfer_rx_overrun(void)
 	 * the error state.
 	 */
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Attempt to read more data blocks than are available in the RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
@@ -263,13 +263,13 @@ void test_i2s_dir_both_transfer_rx_overrun(void)
 
 	/* Transmit and receive one more data block */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_DRAIN);
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 }
@@ -293,19 +293,19 @@ void test_i2s_dir_both_transfer_tx_underrun(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 
 	/* Write one more TX data block, expect an error */
 	ret = tx_block_write(dev_i2s, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_PREPARE);
 	zassert_equal(ret, 0, "RX/TX PREPARE trigger failed");
@@ -314,17 +314,17 @@ void test_i2s_dir_both_transfer_tx_underrun(void)
 
 	/* Transmit and receive two more data blocks */
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = tx_block_write(dev_i2s, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_DRAIN);
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 	ret = rx_block_read(dev_i2s, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 }

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_dir_both_states.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_dir_both_states.c
@@ -26,7 +26,7 @@ void test_i2s_dir_both_transfer_configure_1(void)
 	zassert_not_null(dev_i2s, "device " I2S_DEV_NAME_RX " not found");
 
 	ret = configure_stream(dev_i2s, I2S_DIR_BOTH);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Check if the tested driver supports the I2S_DIR_BOTH value.
 	 * Use the DROP trigger for this, as in the current state of the driver
@@ -59,23 +59,23 @@ void test_i2s_dir_both_state_running_neg(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	for (int i = 0; i < TEST_I2S_STATE_RUNNING_NEG_REPEAT_COUNT; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 
 		ret = rx_block_read(dev_i2s, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 
 		/* Send invalid triggers, expect failure */
 		ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
-		zassert_equal(ret, -EIO, NULL);
+		zassert_equal(ret, -EIO);
 		ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_PREPARE);
-		zassert_equal(ret, -EIO, NULL);
+		zassert_equal(ret, -EIO);
 	}
 
 	/* All data written, drain TX queue and stop both streams. */
@@ -83,7 +83,7 @@ void test_i2s_dir_both_state_running_neg(void)
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** @brief Verify all failure cases in STOPPING state.
@@ -103,16 +103,16 @@ void test_i2s_dir_both_state_stopping_neg(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* All data written, all but one data block read, flush TX queue and
 	 * stop both streams.
@@ -122,16 +122,16 @@ void test_i2s_dir_both_state_stopping_neg(void)
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* This is incase the RX channel is stuck in STOPPING state.
 	 * Clear out the state before running the next test.
@@ -158,14 +158,14 @@ void test_i2s_dir_both_state_error_neg(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = tx_block_write(dev_i2s, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 	}
 
 	/* Wait for transmission to finish */
@@ -175,7 +175,7 @@ void test_i2s_dir_both_state_error_neg(void)
 	 * the error state.
 	 */
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Attempt to read more data blocks than are available in the RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
@@ -188,15 +188,15 @@ void test_i2s_dir_both_state_error_neg(void)
 
 	/* Write one more TX data block, expect an error */
 	ret = tx_block_write(dev_i2s, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	/* Recover from ERROR state */
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_PREPARE);
@@ -204,13 +204,13 @@ void test_i2s_dir_both_state_error_neg(void)
 
 	/* Transmit and receive one more data block */
 	ret = tx_block_write(dev_i2s, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed");
 	ret = i2s_trigger(dev_i2s, I2S_DIR_BOTH, I2S_TRIGGER_DRAIN);
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 	ret = rx_block_read(dev_i2s, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 }

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_loopback.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_loopback.c
@@ -22,7 +22,7 @@ void test_i2s_tx_transfer_configure_0(void)
 	zassert_not_null(dev_i2s_tx, "device " I2S_DEV_NAME_TX " not found");
 
 	ret = configure_stream(dev_i2s_tx, I2S_DIR_TX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** Configure I2S RX transfer. */
@@ -34,7 +34,7 @@ void test_i2s_rx_transfer_configure_0(void)
 	zassert_not_null(dev_i2s_rx, "device " I2S_DEV_NAME_RX " not found");
 
 	ret = configure_stream(dev_i2s_rx, I2S_DIR_RX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** @brief Short I2S transfer.
@@ -57,11 +57,11 @@ void test_i2s_transfer_short(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 1);
 
 	ret = tx_block_write(dev_i2s_tx, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 2);
 
 	/* Start reception */
@@ -73,11 +73,11 @@ void test_i2s_transfer_short(void)
 	zassert_equal(ret, 0, "TX START trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = tx_block_write(dev_i2s_tx, 2, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 3);
 
 	/* All data written, drain TX queue and stop the transmission */
@@ -85,7 +85,7 @@ void test_i2s_transfer_short(void)
 	zassert_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 2);
 
 	/* All but one data block read, stop reception */
@@ -93,7 +93,7 @@ void test_i2s_transfer_short(void)
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 2);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 3);
 
 	/* TODO: Verify the interface is in READY state when i2s_state_get
@@ -123,7 +123,7 @@ void test_i2s_transfer_long(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
@@ -135,10 +135,10 @@ void test_i2s_transfer_long(void)
 
 	for (int i = 0; i < TEST_I2S_TRANSFER_LONG_REPEAT_COUNT; i++) {
 		ret = tx_block_write(dev_i2s_tx, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 
 		ret = rx_block_read(dev_i2s_rx, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
@@ -150,7 +150,7 @@ void test_i2s_transfer_long(void)
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* TODO: Verify the interface is in READY state when i2s_state_get
 	 * function is available.
@@ -181,7 +181,7 @@ void test_i2s_rx_sync_start(void)
 	for (int n = 0; n < NUM_TX_BLOCKS; n++) {
 		fill_buf_const((uint16_t *)buf, 1, 2);
 		ret = i2s_buf_write(dev_i2s_tx, buf, BLOCK_SIZE);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 		TC_PRINT("%d->OK\n", n);
 	}
 
@@ -195,10 +195,10 @@ void test_i2s_rx_sync_start(void)
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_buf_read(dev_i2s_rx, buf, &rx_size);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = verify_buf_const((uint16_t *)buf, 1, 2);
 
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 1);
 
 	/* All data written, drop TX, RX queue and stop the transmission */
@@ -245,11 +245,11 @@ void test_i2s_transfer_restart(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 1);
 
 	ret = tx_block_write(dev_i2s_tx, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 2);
 
 	/* Start reception */
@@ -269,7 +269,7 @@ void test_i2s_transfer_restart(void)
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 1);
 
 	TC_PRINT("Stop transmission\n");
@@ -281,7 +281,7 @@ void test_i2s_transfer_restart(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 2, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d->OK\n", 3);
 
 	/* Start reception */
@@ -297,7 +297,7 @@ void test_i2s_transfer_restart(void)
 	zassert_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 2);
 
 	/* All but one data block read, stop reception */
@@ -305,7 +305,7 @@ void test_i2s_transfer_restart(void)
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 2);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	TC_PRINT("%d<-OK\n", 3);
 }
 
@@ -332,7 +332,7 @@ void test_i2s_transfer_rx_overrun(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
@@ -344,7 +344,7 @@ void test_i2s_transfer_rx_overrun(void)
 
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = tx_block_write(dev_i2s_tx, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
@@ -358,7 +358,7 @@ void test_i2s_transfer_rx_overrun(void)
 	 * the error state.
 	 */
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Attempt to read more data blocks than are available in the RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
@@ -374,7 +374,7 @@ void test_i2s_transfer_rx_overrun(void)
 
 	/* Transmit and receive one more data block */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_START);
@@ -384,7 +384,7 @@ void test_i2s_transfer_rx_overrun(void)
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 }
@@ -408,7 +408,7 @@ void test_i2s_transfer_tx_underrun(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
@@ -423,13 +423,13 @@ void test_i2s_transfer_tx_underrun(void)
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 
 	/* Write one more TX data block, expect an error */
 	ret = tx_block_write(dev_i2s_tx, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
 	zassert_equal(ret, 0, "TX PREPARE trigger failed");
@@ -438,21 +438,21 @@ void test_i2s_transfer_tx_underrun(void)
 
 	/* Transmit and receive two more data blocks */
 	ret = tx_block_write(dev_i2s_tx, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = tx_block_write(dev_i2s_tx, 1, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "TX START trigger failed");
 	ret = rx_block_read(dev_i2s_rx, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
 	zassert_equal(ret, 0, "TX DRAIN trigger failed");
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 	ret = rx_block_read(dev_i2s_rx, 1);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 }

--- a/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
+++ b/tests/drivers/i2s/i2s_api/src/test_i2s_states.c
@@ -21,7 +21,7 @@ void test_i2s_tx_transfer_configure_1(void)
 	zassert_not_null(dev_i2s_tx, "device " I2S_DEV_NAME_TX " not found");
 
 	ret = configure_stream(dev_i2s_tx, I2S_DIR_TX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** Configure I2S RX transfer. */
@@ -33,7 +33,7 @@ void test_i2s_rx_transfer_configure_1(void)
 	zassert_not_null(dev_i2s_rx, "device " I2S_DEV_NAME_RX " not found");
 
 	ret = configure_stream(dev_i2s_rx, I2S_DIR_RX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** @brief Verify all failure cases in NOT_READY state.
@@ -57,22 +57,22 @@ void test_i2s_state_not_ready_neg(void)
 	zassert_equal(ret, 0, "Failed to configure I2S RX stream");
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_DROP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_buf_read(dev_i2s_rx, rx_buf, &rx_size);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	i2s_cfg.frame_clk_freq = 0U;
 	i2s_cfg.mem_slab = &tx_mem_slab;
@@ -81,22 +81,22 @@ void test_i2s_state_not_ready_neg(void)
 	zassert_equal(ret, 0, "Failed to configure I2S TX stream");
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_DROP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = tx_block_write(dev_i2s_tx, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** @brief Verify all failure cases in READY state.
@@ -109,33 +109,33 @@ void test_i2s_state_ready_neg(void)
 
 	/* Configure RX stream changing its state to READY */
 	ret = configure_stream(dev_i2s_rx, I2S_DIR_RX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Send RX stream triggers */
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	/* Configure TX stream changing its state to READY */
 	ret = configure_stream(dev_i2s_tx, I2S_DIR_TX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Send TX stream triggers */
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 }
 
 #define TEST_I2S_STATE_RUNNING_NEG_REPEAT_COUNT  5
@@ -156,7 +156,7 @@ void test_i2s_state_running_neg(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
@@ -168,20 +168,20 @@ void test_i2s_state_running_neg(void)
 
 	for (int i = 0; i < TEST_I2S_STATE_RUNNING_NEG_REPEAT_COUNT; i++) {
 		ret = tx_block_write(dev_i2s_tx, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 
 		ret = rx_block_read(dev_i2s_rx, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 
 		/* Send invalid triggers, expect failure */
 		ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_START);
-		zassert_equal(ret, -EIO, NULL);
+		zassert_equal(ret, -EIO);
 		ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-		zassert_equal(ret, -EIO, NULL);
+		zassert_equal(ret, -EIO);
 		ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
-		zassert_equal(ret, -EIO, NULL);
+		zassert_equal(ret, -EIO);
 		ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-		zassert_equal(ret, -EIO, NULL);
+		zassert_equal(ret, -EIO);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
@@ -193,7 +193,7 @@ void test_i2s_state_running_neg(void)
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** @brief Verify all failure cases in STOPPING state.
@@ -213,7 +213,7 @@ void test_i2s_state_stopping_neg(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
@@ -224,10 +224,10 @@ void test_i2s_state_stopping_neg(void)
 	zassert_equal(ret, 0, "TX START trigger failed");
 
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* All data written, flush TX queue and stop the transmission */
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
@@ -235,13 +235,13 @@ void test_i2s_state_stopping_neg(void)
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
@@ -249,16 +249,16 @@ void test_i2s_state_stopping_neg(void)
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* This is incase the RX channel is stuck in STOPPING state.
 	 * Clear out the state before running the next test.
@@ -285,7 +285,7 @@ void test_i2s_state_error_neg(void)
 
 	/* Prefill TX queue */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
@@ -297,7 +297,7 @@ void test_i2s_state_error_neg(void)
 
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
 		ret = tx_block_write(dev_i2s_tx, 0, 0);
-		zassert_equal(ret, TC_PASS, NULL);
+		zassert_equal(ret, TC_PASS);
 	}
 
 	/* Wait for transmission to finish */
@@ -307,7 +307,7 @@ void test_i2s_state_error_neg(void)
 	 * the error state.
 	 */
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Attempt to read more data blocks than are available in the RX queue */
 	for (int i = 0; i < NUM_RX_BLOCKS; i++) {
@@ -320,11 +320,11 @@ void test_i2s_state_error_neg(void)
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	/* Recover from ERROR state */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_PREPARE);
@@ -332,15 +332,15 @@ void test_i2s_state_error_neg(void)
 
 	/* Write one more TX data block, expect an error */
 	ret = tx_block_write(dev_i2s_tx, 2, -EIO);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Send invalid triggers, expect failure */
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_START);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_STOP);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_DRAIN);
-	zassert_equal(ret, -EIO, NULL);
+	zassert_equal(ret, -EIO);
 
 	/* Recover from ERROR state */
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_PREPARE);
@@ -348,7 +348,7 @@ void test_i2s_state_error_neg(void)
 
 	/* Transmit and receive one more data block */
 	ret = tx_block_write(dev_i2s_tx, 0, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX START trigger failed");
 	ret = i2s_trigger(dev_i2s_tx, I2S_DIR_TX, I2S_TRIGGER_START);
@@ -358,7 +358,7 @@ void test_i2s_state_error_neg(void)
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 	ret = rx_block_read(dev_i2s_rx, 0);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	k_sleep(K_MSEC(200));
 }

--- a/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
+++ b/tests/drivers/i2s/i2s_speed/src/test_i2s_speed.c
@@ -187,7 +187,7 @@ void test_i2s_tx_transfer_configure(void)
 	zassert_not_null(dev_i2s_tx, "device " I2S_DEV_NAME_TX " not found");
 
 	ret = configure_stream(dev_i2s_tx, I2S_DIR_TX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** Configure I2S RX transfer. */
@@ -199,7 +199,7 @@ void test_i2s_rx_transfer_configure(void)
 	zassert_not_null(dev_i2s_rx, "device " I2S_DEV_NAME_RX " not found");
 
 	ret = configure_stream(dev_i2s_rx, I2S_DIR_RX);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 }
 
 /** @brief Short I2S transfer.
@@ -226,11 +226,11 @@ void test_i2s_transfer_short(void)
 	/* Prefill TX queue */
 	for (int i = 0; i < 3; i++) {
 		ret = k_mem_slab_alloc(&tx_0_mem_slab, &tx_block, K_FOREVER);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 		fill_buf((uint16_t *)tx_block, i);
 
 		ret = i2s_write(dev_i2s_tx, tx_block, BLOCK_SIZE);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 
 		TC_PRINT("%d->OK\n", i);
 	}
@@ -248,34 +248,34 @@ void test_i2s_transfer_short(void)
 	zassert_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = i2s_read(dev_i2s_rx, &rx_block[0], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	ret = i2s_read(dev_i2s_rx, &rx_block[1], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = i2s_read(dev_i2s_rx, &rx_block[2], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	/* Verify received data */
 	ret = verify_buf((uint16_t *)rx_block[0], 0);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[0]);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = verify_buf((uint16_t *)rx_block[1], 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[1]);
 	TC_PRINT("%d<-OK\n", 2);
 
 	ret = verify_buf((uint16_t *)rx_block[2], 2);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[2]);
 	TC_PRINT("%d<-OK\n", 3);
 }
@@ -308,7 +308,7 @@ void test_i2s_transfer_long(void)
 	for (tx_idx = 0; tx_idx < NUM_BLOCKS; tx_idx++) {
 		ret = k_mem_slab_alloc(&tx_0_mem_slab, &tx_block[tx_idx],
 				       K_FOREVER);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 		fill_buf((uint16_t *)tx_block[tx_idx], tx_idx % 3);
 	}
 
@@ -316,10 +316,10 @@ void test_i2s_transfer_long(void)
 
 	/* Prefill TX queue */
 	ret = i2s_write(dev_i2s_tx, tx_block[tx_idx++], BLOCK_SIZE);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = i2s_write(dev_i2s_tx, tx_block[tx_idx++], BLOCK_SIZE);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	/* Start reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_START);
@@ -331,11 +331,11 @@ void test_i2s_transfer_long(void)
 
 	for (; tx_idx < NUM_BLOCKS; ) {
 		ret = i2s_write(dev_i2s_tx, tx_block[tx_idx++], BLOCK_SIZE);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 
 		ret = i2s_read(dev_i2s_rx, &rx_block[rx_idx++], &rx_size);
-		zassert_equal(ret, 0, NULL);
-		zassert_equal(rx_size, BLOCK_SIZE, NULL);
+		zassert_equal(ret, 0);
+		zassert_equal(rx_size, BLOCK_SIZE);
 	}
 
 	/* All data written, flush TX queue and stop the transmission */
@@ -343,16 +343,16 @@ void test_i2s_transfer_long(void)
 	zassert_equal(ret, 0, "TX DRAIN trigger failed");
 
 	ret = i2s_read(dev_i2s_rx, &rx_block[rx_idx++], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	/* All but one data block read, stop reception */
 	ret = i2s_trigger(dev_i2s_rx, I2S_DIR_RX, I2S_TRIGGER_STOP);
 	zassert_equal(ret, 0, "RX STOP trigger failed");
 
 	ret = i2s_read(dev_i2s_rx, &rx_block[rx_idx++], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	TC_PRINT("%d TX blocks sent\n", tx_idx);
 	TC_PRINT("%d RX blocks received\n", rx_idx);
@@ -379,7 +379,7 @@ void test_i2s_dir_both_transfer_configure(void)
 	zassert_not_null(dev_i2s_rxtx, "device " I2S_DEV_NAME_RX " not found");
 
 	ret = configure_stream(dev_i2s_rxtx, I2S_DIR_BOTH);
-	zassert_equal(ret, TC_PASS, NULL);
+	zassert_equal(ret, TC_PASS);
 
 	/* Check if the tested driver supports the I2S_DIR_BOTH value.
 	 * Use the DROP trigger for this, as in the current state of the driver
@@ -416,11 +416,11 @@ void test_i2s_dir_both_transfer_short(void)
 	/* Prefill TX queue */
 	for (int i = 0; i < 3; i++) {
 		ret = k_mem_slab_alloc(&tx_0_mem_slab, &tx_block, K_FOREVER);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 		fill_buf((uint16_t *)tx_block, i);
 
 		ret = i2s_write(dev_i2s_rxtx, tx_block, BLOCK_SIZE);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 
 		TC_PRINT("%d->OK\n", i);
 	}
@@ -433,30 +433,30 @@ void test_i2s_dir_both_transfer_short(void)
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 
 	ret = i2s_read(dev_i2s_rxtx, &rx_block[0], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	ret = i2s_read(dev_i2s_rxtx, &rx_block[1], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	ret = i2s_read(dev_i2s_rxtx, &rx_block[2], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	/* Verify received data */
 	ret = verify_buf((uint16_t *)rx_block[0], 0);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[0]);
 	TC_PRINT("%d<-OK\n", 1);
 
 	ret = verify_buf((uint16_t *)rx_block[1], 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[1]);
 	TC_PRINT("%d<-OK\n", 2);
 
 	ret = verify_buf((uint16_t *)rx_block[2], 2);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	k_mem_slab_free(&rx_0_mem_slab, &rx_block[2]);
 	TC_PRINT("%d<-OK\n", 3);
 }
@@ -487,7 +487,7 @@ void test_i2s_dir_both_transfer_long(void)
 	for (tx_idx = 0; tx_idx < NUM_BLOCKS; tx_idx++) {
 		ret = k_mem_slab_alloc(&tx_0_mem_slab, &tx_block[tx_idx],
 				       K_FOREVER);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 		fill_buf((uint16_t *)tx_block[tx_idx], tx_idx % 3);
 	}
 
@@ -495,21 +495,21 @@ void test_i2s_dir_both_transfer_long(void)
 
 	/* Prefill TX queue */
 	ret = i2s_write(dev_i2s_rxtx, tx_block[tx_idx++], BLOCK_SIZE);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = i2s_write(dev_i2s_rxtx, tx_block[tx_idx++], BLOCK_SIZE);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = i2s_trigger(dev_i2s_rxtx, I2S_DIR_BOTH, I2S_TRIGGER_START);
 	zassert_equal(ret, 0, "RX/TX START trigger failed\n");
 
 	for (; tx_idx < NUM_BLOCKS; ) {
 		ret = i2s_write(dev_i2s_rxtx, tx_block[tx_idx++], BLOCK_SIZE);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 
 		ret = i2s_read(dev_i2s_rxtx, &rx_block[rx_idx++], &rx_size);
-		zassert_equal(ret, 0, NULL);
-		zassert_equal(rx_size, BLOCK_SIZE, NULL);
+		zassert_equal(ret, 0);
+		zassert_equal(rx_size, BLOCK_SIZE);
 	}
 
 	/* All data written, drain TX queue and stop both streams. */
@@ -517,12 +517,12 @@ void test_i2s_dir_both_transfer_long(void)
 	zassert_equal(ret, 0, "RX/TX DRAIN trigger failed");
 
 	ret = i2s_read(dev_i2s_rxtx, &rx_block[rx_idx++], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	ret = i2s_read(dev_i2s_rxtx, &rx_block[rx_idx++], &rx_size);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(rx_size, BLOCK_SIZE, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(rx_size, BLOCK_SIZE);
 
 	TC_PRINT("%d TX blocks sent\n", tx_idx);
 	TC_PRINT("%d RX blocks received\n", rx_idx);

--- a/tests/drivers/kscan/kscan_api/src/test_kscan.c
+++ b/tests/drivers/kscan/kscan_api/src/test_kscan.c
@@ -83,16 +83,16 @@ static int test_disable_enable_callback(void)
 void test_init_callback(void)
 {
 	/* Configure kscan matrix with an appropriate callback */
-	zassert_true(test_kb_callback() == TC_PASS, NULL);
+	zassert_true(test_kb_callback() == TC_PASS);
 	k_sleep(K_MSEC(1000));
 
 	/* Configure kscan with a null callback */
-	zassert_true(test_null_callback() == TC_PASS, NULL);
+	zassert_true(test_null_callback() == TC_PASS);
 }
 
 void test_control_callback(void)
 {
 	/* Disable/enable notifications to user */
-	zassert_true(test_disable_enable_callback() == TC_PASS, NULL);
+	zassert_true(test_disable_enable_callback() == TC_PASS);
 	k_sleep(K_MSEC(1000));
 }

--- a/tests/drivers/pinctrl/api/src/main.c
+++ b/tests/drivers/pinctrl/api/src/main.c
@@ -38,17 +38,17 @@ ZTEST(pinctrl_api, test_config_dev0)
 {
 	const struct pinctrl_state *scfg;
 
-	zassert_equal(pcfg0->state_cnt, 1, NULL);
+	zassert_equal(pcfg0->state_cnt, 1);
 #ifdef CONFIG_PINCTRL_STORE_REG
-	zassert_equal(pcfg0->reg, 0, NULL);
+	zassert_equal(pcfg0->reg, 0);
 #endif
 
 	scfg = &pcfg0->states[0];
-	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 0, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_UP, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 1, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_DOWN, NULL);
+	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT);
+	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 0);
+	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_UP);
+	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 1);
+	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_DOWN);
 }
 
 /**
@@ -62,30 +62,30 @@ ZTEST(pinctrl_api, test_config_dev1)
 {
 	const struct pinctrl_state *scfg;
 
-	zassert_equal(pcfg1->state_cnt, 2, NULL);
+	zassert_equal(pcfg1->state_cnt, 2);
 #ifdef CONFIG_PINCTRL_STORE_REG
-	zassert_equal(pcfg1->reg, 1, NULL);
+	zassert_equal(pcfg1->reg, 1);
 #endif
 
 	scfg = &pcfg1->states[0];
-	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT, NULL);
-	zassert_equal(scfg->pin_cnt, 3, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 10, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_DISABLE, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 11, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_DISABLE, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[2]), 12, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[2]), TEST_PULL_DISABLE, NULL);
+	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT);
+	zassert_equal(scfg->pin_cnt, 3);
+	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 10);
+	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_DISABLE);
+	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 11);
+	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_DISABLE);
+	zassert_equal(TEST_GET_PIN(scfg->pins[2]), 12);
+	zassert_equal(TEST_GET_PULL(scfg->pins[2]), TEST_PULL_DISABLE);
 
 	scfg = &pcfg1->states[1];
-	zassert_equal(scfg->id, PINCTRL_STATE_MYSTATE, NULL);
-	zassert_equal(scfg->pin_cnt, 3, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 10, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_DISABLE, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 11, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_UP, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[2]), 12, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[2]), TEST_PULL_DOWN, NULL);
+	zassert_equal(scfg->id, PINCTRL_STATE_MYSTATE);
+	zassert_equal(scfg->pin_cnt, 3);
+	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 10);
+	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_DISABLE);
+	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 11);
+	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_UP);
+	zassert_equal(TEST_GET_PIN(scfg->pins[2]), 12);
+	zassert_equal(TEST_GET_PULL(scfg->pins[2]), TEST_PULL_DOWN);
 }
 
 /**
@@ -97,11 +97,11 @@ ZTEST(pinctrl_api, test_lookup_state)
 	const struct pinctrl_state *scfg;
 
 	ret = pinctrl_lookup_state(pcfg0, PINCTRL_STATE_DEFAULT, &scfg);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	zassert_equal_ptr(scfg, &pcfg0->states[0], NULL);
 
 	ret = pinctrl_lookup_state(pcfg0, PINCTRL_STATE_SLEEP, &scfg);
-	zassert_equal(ret, -ENOENT, NULL);
+	zassert_equal(ret, -ENOENT);
 }
 
 /**
@@ -109,14 +109,14 @@ ZTEST(pinctrl_api, test_lookup_state)
  */
 ZTEST(pinctrl_api, test_apply_state)
 {
-	zassert_ok(pinctrl_apply_state(pcfg0, PINCTRL_STATE_DEFAULT), NULL);
-	zassert_equal(1, pinctrl_configure_pins_fake.call_count, NULL);
-	zassert_equal(pcfg0->states[0].pins, pinctrl_configure_pins_fake.arg0_val, NULL);
-	zassert_equal(pcfg0->states[0].pin_cnt, pinctrl_configure_pins_fake.arg1_val, NULL);
+	zassert_ok(pinctrl_apply_state(pcfg0, PINCTRL_STATE_DEFAULT));
+	zassert_equal(1, pinctrl_configure_pins_fake.call_count);
+	zassert_equal(pcfg0->states[0].pins, pinctrl_configure_pins_fake.arg0_val);
+	zassert_equal(pcfg0->states[0].pin_cnt, pinctrl_configure_pins_fake.arg1_val);
 #ifdef CONFIG_PINCTRL_STORE_REG
-	zassert_equal(0, pinctrl_configure_pins_fake.arg2_val, NULL);
+	zassert_equal(0, pinctrl_configure_pins_fake.arg2_val);
 #else
-	zassert_equal(PINCTRL_REG_NONE, pinctrl_configure_pins_fake.arg2_val, NULL);
+	zassert_equal(PINCTRL_REG_NONE, pinctrl_configure_pins_fake.arg2_val);
 #endif
 }
 
@@ -146,17 +146,17 @@ ZTEST(pinctrl_api, test_update_states)
 	const struct pinctrl_state *scfg;
 
 	ret = pinctrl_update_states(pcfg0, test_device0_alt, ARRAY_SIZE(test_device0_alt));
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	scfg = &pcfg0->states[0];
-	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 2, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_DOWN, NULL);
-	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 3, NULL);
-	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_UP, NULL);
+	zassert_equal(TEST_GET_PIN(scfg->pins[0]), 2);
+	zassert_equal(TEST_GET_PULL(scfg->pins[0]), TEST_PULL_DOWN);
+	zassert_equal(TEST_GET_PIN(scfg->pins[1]), 3);
+	zassert_equal(TEST_GET_PULL(scfg->pins[1]), TEST_PULL_UP);
 
 	ret = pinctrl_update_states(pcfg0, test_device0_alt_invalid,
 				    ARRAY_SIZE(test_device0_alt_invalid));
-	zassert_equal(ret, -EINVAL, NULL);
+	zassert_equal(ret, -EINVAL);
 }
 
 static void pinctrl_api_before(void *f)

--- a/tests/drivers/pinctrl/gd32/src/main_af.c
+++ b/tests/drivers/pinctrl/gd32/src/main_af.c
@@ -16,108 +16,108 @@ ZTEST(pinctrl_gd32, test_dt_extract)
 	const struct pinctrl_state *scfg;
 	pinctrl_soc_pin_t pin;
 
-	zassert_equal(pcfg->state_cnt, 1U, NULL);
+	zassert_equal(pcfg->state_cnt, 1U);
 
 	scfg = &pcfg->states[0];
 
-	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT, NULL);
-	zassert_equal(scfg->pin_cnt, 12U, NULL);
+	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT);
+	zassert_equal(scfg->pin_cnt, 12U);
 
 	pin = scfg->pins[0];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 0, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF0, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 0);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF0);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[1];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 1, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF1, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 1);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF1);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[2];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 2, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF2, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 2);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF2);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[3];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 3, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF3, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_OD, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 3);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF3);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_OD);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[4];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 4, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF4, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 4);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF4);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[5];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 5, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF5, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLUP, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 5);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF5);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLUP);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[6];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 6, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF6, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLDOWN, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 6);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF6);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLDOWN);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[7];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 7, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF7, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 7);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF7);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[8];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 8, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF8, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_25MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 8);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF8);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_25MHZ);
 
 	pin = scfg->pins[9];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 9, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF9, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_50MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 9);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF9);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_50MHZ);
 
 	pin = scfg->pins[10];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 10, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_AF10, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_MAX, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 10);
+	zassert_equal(GD32_AF_GET(pin), GD32_AF10);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_MAX);
 
 	pin = scfg->pins[11];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 11, NULL);
-	zassert_equal(GD32_AF_GET(pin), GD32_ANALOG, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 11);
+	zassert_equal(GD32_AF_GET(pin), GD32_ANALOG);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 }
 
 ZTEST_SUITE(pinctrl_gd32, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/pinctrl/gd32/src/main_afio.c
+++ b/tests/drivers/pinctrl/gd32/src/main_afio.c
@@ -16,122 +16,122 @@ ZTEST(pinctrl_gd32, test_dt_extract)
 	const struct pinctrl_state *scfg;
 	pinctrl_soc_pin_t pin;
 
-	zassert_equal(pcfg->state_cnt, 1U, NULL);
+	zassert_equal(pcfg->state_cnt, 1U);
 
 	scfg = &pcfg->states[0];
 
-	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT, NULL);
-	zassert_equal(scfg->pin_cnt, 14U, NULL);
+	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT);
+	zassert_equal(scfg->pin_cnt, 14U);
 
 	pin = scfg->pins[0];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 0, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ANALOG, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 0);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ANALOG);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
 
 	pin = scfg->pins[1];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 1, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 1);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[2];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 2, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 2);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
 
 	pin = scfg->pins[3];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 3, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN, NULL);
-	zassert_equal(GD32_REMAP_REG_GET(GD32_REMAP_GET(pin)), 0, NULL);
-	zassert_equal(GD32_REMAP_POS_GET(GD32_REMAP_GET(pin)), 0, NULL);
-	zassert_equal(GD32_REMAP_MSK_GET(GD32_REMAP_GET(pin)), 0x1, NULL);
-	zassert_equal(GD32_REMAP_VAL_GET(GD32_REMAP_GET(pin)), 1, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 3);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN);
+	zassert_equal(GD32_REMAP_REG_GET(GD32_REMAP_GET(pin)), 0);
+	zassert_equal(GD32_REMAP_POS_GET(GD32_REMAP_GET(pin)), 0);
+	zassert_equal(GD32_REMAP_MSK_GET(GD32_REMAP_GET(pin)), 0x1);
+	zassert_equal(GD32_REMAP_VAL_GET(GD32_REMAP_GET(pin)), 1);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
 
 	pin = scfg->pins[4];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 4, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE, NULL);
-	zassert_equal(GD32_REMAP_REG_GET(GD32_REMAP_GET(pin)), 0, NULL);
-	zassert_equal(GD32_REMAP_POS_GET(GD32_REMAP_GET(pin)), 0, NULL);
-	zassert_equal(GD32_REMAP_MSK_GET(GD32_REMAP_GET(pin)), 0x1, NULL);
-	zassert_equal(GD32_REMAP_VAL_GET(GD32_REMAP_GET(pin)), 1, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 4);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE);
+	zassert_equal(GD32_REMAP_REG_GET(GD32_REMAP_GET(pin)), 0);
+	zassert_equal(GD32_REMAP_POS_GET(GD32_REMAP_GET(pin)), 0);
+	zassert_equal(GD32_REMAP_MSK_GET(GD32_REMAP_GET(pin)), 0x1);
+	zassert_equal(GD32_REMAP_VAL_GET(GD32_REMAP_GET(pin)), 1);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[5];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 5, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 5);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
 
 	pin = scfg->pins[6];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 6, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_OD, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 6);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_OD);
 
 	pin = scfg->pins[7];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 7, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 7);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_NONE);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
 
 	pin = scfg->pins[8];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 8, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLUP, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 8);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLUP);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
 
 	pin = scfg->pins[9];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 9, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLDOWN, NULL);
-	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 9);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_GPIO_IN);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_PUPD_GET(pin), GD32_PUPD_PULLDOWN);
+	zassert_equal(GD32_OTYPE_GET(pin), GD32_OTYPE_PP);
 
 	pin = scfg->pins[10];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 10, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 10);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_2MHZ);
 
 	pin = scfg->pins[11];
-	zassert_equal(GD32_PORT_GET(pin), 2, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 11, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_10MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 2);
+	zassert_equal(GD32_PIN_GET(pin), 11);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_10MHZ);
 
 	pin = scfg->pins[12];
-	zassert_equal(GD32_PORT_GET(pin), 0, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 12, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_50MHZ, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 0);
+	zassert_equal(GD32_PIN_GET(pin), 12);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_50MHZ);
 
 	pin = scfg->pins[13];
-	zassert_equal(GD32_PORT_GET(pin), 1, NULL);
-	zassert_equal(GD32_PIN_GET(pin), 13, NULL);
-	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE, NULL);
-	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP, NULL);
-	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_MAX, NULL);
+	zassert_equal(GD32_PORT_GET(pin), 1);
+	zassert_equal(GD32_PIN_GET(pin), 13);
+	zassert_equal(GD32_MODE_GET(pin), GD32_MODE_ALTERNATE);
+	zassert_equal(GD32_REMAP_GET(pin), GD32_NORMP);
+	zassert_equal(GD32_OSPEED_GET(pin), GD32_OSPEED_MAX);
 }
 
 ZTEST_SUITE(pinctrl_gd32, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/pinctrl/nrf/src/main.c
+++ b/tests/drivers/pinctrl/nrf/src/main.c
@@ -16,52 +16,52 @@ ZTEST(pinctrl_nrf, test_dt_extract)
 {
 	const struct pinctrl_state *scfg;
 
-	zassert_equal(pcfg->reg, 0x0U, NULL);
-	zassert_equal(pcfg->state_cnt, 1U, NULL);
+	zassert_equal(pcfg->reg, 0x0U);
+	zassert_equal(pcfg->state_cnt, 1U);
 
 	scfg = &pcfg->states[0];
 
-	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT, NULL);
-	zassert_equal(scfg->pin_cnt, 7U, NULL);
+	zassert_equal(scfg->id, PINCTRL_STATE_DEFAULT);
+	zassert_equal(scfg->pin_cnt, 7U);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[0]), NRF_FUN_UART_TX, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[0]), NRF_LP_DISABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[0]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[0]), NRF_PULL_NONE, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[0]), 1U, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[0]), NRF_FUN_UART_TX);
+	zassert_equal(NRF_GET_LP(scfg->pins[0]), NRF_LP_DISABLE);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[0]), NRF_DRIVE_S0S1);
+	zassert_equal(NRF_GET_PULL(scfg->pins[0]), NRF_PULL_NONE);
+	zassert_equal(NRF_GET_PIN(scfg->pins[0]), 1U);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[1]), NRF_FUN_UART_RTS, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[1]), NRF_LP_DISABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[1]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[1]), NRF_PULL_NONE, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[1]), 2U, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[1]), NRF_FUN_UART_RTS);
+	zassert_equal(NRF_GET_LP(scfg->pins[1]), NRF_LP_DISABLE);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[1]), NRF_DRIVE_S0S1);
+	zassert_equal(NRF_GET_PULL(scfg->pins[1]), NRF_PULL_NONE);
+	zassert_equal(NRF_GET_PIN(scfg->pins[1]), 2U);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[2]), NRF_FUN_UART_RX, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[2]), NRF_PIN_DISCONNECTED, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[2]), NRF_FUN_UART_RX);
+	zassert_equal(NRF_GET_PIN(scfg->pins[2]), NRF_PIN_DISCONNECTED);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[3]), NRF_FUN_UART_RX, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[3]), NRF_LP_DISABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[3]), NRF_DRIVE_H0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[3]), NRF_PULL_NONE, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[3]), 3U, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[3]), NRF_FUN_UART_RX);
+	zassert_equal(NRF_GET_LP(scfg->pins[3]), NRF_LP_DISABLE);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[3]), NRF_DRIVE_H0S1);
+	zassert_equal(NRF_GET_PULL(scfg->pins[3]), NRF_PULL_NONE);
+	zassert_equal(NRF_GET_PIN(scfg->pins[3]), 3U);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[4]), NRF_FUN_UART_RX, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[4]), NRF_LP_DISABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[4]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[4]), NRF_PULL_UP, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[4]), 4U, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[4]), NRF_FUN_UART_RX);
+	zassert_equal(NRF_GET_LP(scfg->pins[4]), NRF_LP_DISABLE);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[4]), NRF_DRIVE_S0S1);
+	zassert_equal(NRF_GET_PULL(scfg->pins[4]), NRF_PULL_UP);
+	zassert_equal(NRF_GET_PIN(scfg->pins[4]), 4U);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[5]), NRF_FUN_UART_RX, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[5]), NRF_LP_DISABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[5]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[5]), NRF_PULL_DOWN, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[5]), 5U, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[5]), NRF_FUN_UART_RX);
+	zassert_equal(NRF_GET_LP(scfg->pins[5]), NRF_LP_DISABLE);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[5]), NRF_DRIVE_S0S1);
+	zassert_equal(NRF_GET_PULL(scfg->pins[5]), NRF_PULL_DOWN);
+	zassert_equal(NRF_GET_PIN(scfg->pins[5]), 5U);
 
-	zassert_equal(NRF_GET_FUN(scfg->pins[6]), NRF_FUN_UART_CTS, NULL);
-	zassert_equal(NRF_GET_LP(scfg->pins[6]), NRF_LP_ENABLE, NULL);
-	zassert_equal(NRF_GET_DRIVE(scfg->pins[6]), NRF_DRIVE_S0S1, NULL);
-	zassert_equal(NRF_GET_PULL(scfg->pins[6]), NRF_PULL_NONE, NULL);
-	zassert_equal(NRF_GET_PIN(scfg->pins[6]), 38U, NULL);
+	zassert_equal(NRF_GET_FUN(scfg->pins[6]), NRF_FUN_UART_CTS);
+	zassert_equal(NRF_GET_LP(scfg->pins[6]), NRF_LP_ENABLE);
+	zassert_equal(NRF_GET_DRIVE(scfg->pins[6]), NRF_DRIVE_S0S1);
+	zassert_equal(NRF_GET_PULL(scfg->pins[6]), NRF_PULL_NONE);
+	zassert_equal(NRF_GET_PIN(scfg->pins[6]), 38U);
 }
 
 ZTEST_SUITE(pinctrl_nrf, NULL, NULL, NULL, NULL, NULL);

--- a/tests/drivers/sensor/generic/src/dummy_sensor.c
+++ b/tests/drivers/sensor/generic/src/dummy_sensor.c
@@ -80,8 +80,8 @@ static int dummy_sensor_init(const struct device *dev)
 	const struct device *i2c = device_get_binding(config->i2c_name);
 
 	/* Bus and address should be configured. */
-	zassert_equal(strcmp(config->i2c_name, "dummy I2C"), 0, NULL);
-	zassert_equal(config->i2c_address, 123, NULL);
+	zassert_equal(strcmp(config->i2c_name, "dummy I2C"), 0);
+	zassert_equal(config->i2c_address, 123);
 
 	if (i2c != NULL) {
 		LOG_ERR("Should be Null for %s device!", config->i2c_name);

--- a/tests/drivers/syscon/src/main.c
+++ b/tests/drivers/syscon/src/main.c
@@ -19,7 +19,7 @@ ZTEST(syscon, test_size)
 	size_t size;
 
 	zassert_not_null(dev, NULL);
-	zassert_ok(syscon_get_size(dev, &size), NULL);
+	zassert_ok(syscon_get_size(dev, &size));
 	zassert_equal(size, expected_size, "size(0x%x) != expected_size(0x%x)", size,
 		      expected_size);
 }
@@ -29,8 +29,8 @@ ZTEST(syscon, test_out_of_bounds)
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uint32_t val;
 
-	zassert_equal(syscon_read_reg(dev, DT_REG_SIZE(DT_NODELABEL(syscon)), &val), -EINVAL, NULL);
-	zassert_equal(syscon_write_reg(dev, DT_REG_SIZE(DT_NODELABEL(syscon)), val), -EINVAL, NULL);
+	zassert_equal(syscon_read_reg(dev, DT_REG_SIZE(DT_NODELABEL(syscon)), &val), -EINVAL);
+	zassert_equal(syscon_write_reg(dev, DT_REG_SIZE(DT_NODELABEL(syscon)), val), -EINVAL);
 }
 
 ZTEST(syscon, test_read)
@@ -39,11 +39,11 @@ ZTEST(syscon, test_read)
 	uintptr_t base_addr;
 	uint32_t val;
 
-	zassert_ok(syscon_get_base(dev, &base_addr), NULL);
+	zassert_ok(syscon_get_base(dev, &base_addr));
 	for (size_t i = 0; i < ARRAY_SIZE(var_in_res0); ++i) {
 		((uint8_t *)base_addr)[i] = i;
-		zassert_ok(syscon_read_reg(dev, i, &val), NULL);
-		zassert_equal(i, val, NULL);
+		zassert_ok(syscon_read_reg(dev, i, &val));
+		zassert_equal(i, val);
 	}
 }
 
@@ -52,10 +52,10 @@ ZTEST(syscon, test_write)
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uintptr_t base_addr;
 
-	zassert_ok(syscon_get_base(dev, &base_addr), NULL);
+	zassert_ok(syscon_get_base(dev, &base_addr));
 	for (uint32_t i = 0; i < ARRAY_SIZE(var_in_res0); ++i) {
-		zassert_ok(syscon_write_reg(dev, i, i), NULL);
-		zassert_equal(((uint8_t *)base_addr)[i], i, NULL);
+		zassert_ok(syscon_write_reg(dev, i, i));
+		zassert_equal(((uint8_t *)base_addr)[i], i);
 	}
 }
 

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
@@ -99,7 +99,7 @@ ZTEST(uart_basic_api, test_uart_configure)
 {
 	int ret = test_configure();
 
-	zassert_true((ret == TC_PASS) || (ret == TC_SKIP), NULL);
+	zassert_true((ret == TC_PASS) || (ret == TC_SKIP));
 }
 
 #if CONFIG_SHELL
@@ -110,5 +110,5 @@ ZTEST(uart_basic_api, test_uart_config_get)
 {
 	int ret = test_config_get();
 
-	zassert_true((ret == TC_PASS) || (ret == TC_SKIP), NULL);
+	zassert_true((ret == TC_PASS) || (ret == TC_SKIP));
 }

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
@@ -164,7 +164,7 @@ ZTEST(uart_basic_api, test_uart_fifo_fill)
 #ifndef CONFIG_UART_INTERRUPT_DRIVEN
 	ztest_test_skip();
 #endif
-	zassert_true(test_fifo_fill() == TC_PASS, NULL);
+	zassert_true(test_fifo_fill() == TC_PASS);
 }
 
 #if CONFIG_SHELL
@@ -176,5 +176,5 @@ ZTEST(uart_basic_api, test_uart_fifo_read)
 #ifndef CONFIG_UART_INTERRUPT_DRIVEN
 	ztest_test_skip();
 #endif
-	zassert_true(test_fifo_read() == TC_PASS, NULL);
+	zassert_true(test_fifo_read() == TC_PASS);
 }

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_pending.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_pending.c
@@ -150,5 +150,5 @@ ZTEST(uart_basic_api_pending, test_uart_pending)
 #ifndef CONFIG_UART_INTERRUPT_DRIVEN
 	ztest_test_skip();
 #endif
-	zassert_true(test_pending() == TC_PASS, NULL);
+	zassert_true(test_pending() == TC_PASS);
 }

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -61,7 +61,7 @@ void test_uart_poll_out(void)
 ZTEST(uart_basic_api, test_uart_poll_out)
 #endif
 {
-	zassert_true(test_poll_out() == TC_PASS, NULL);
+	zassert_true(test_poll_out() == TC_PASS);
 }
 
 #if CONFIG_SHELL
@@ -70,5 +70,5 @@ void test_uart_poll_in(void)
 ZTEST(uart_basic_api, test_uart_poll_in)
 #endif
 {
-	zassert_true(test_poll_in() == TC_PASS, NULL);
+	zassert_true(test_poll_in() == TC_PASS);
 }

--- a/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
+++ b/tests/drivers/uart/uart_mix_fifo_poll/src/main.c
@@ -105,7 +105,7 @@ static void counter_top_handler(const struct device *dev, void *user_data)
 
 		err = uart_rx_enable(uart_dev, async_rx_buf,
 				     sizeof(async_rx_buf), 1 * USEC_PER_MSEC);
-		zassert_true(err >= 0, NULL);
+		zassert_true(err >= 0);
 		async_rx_enabled = true;
 	} else if (int_driven) {
 		if (enable) {
@@ -148,15 +148,15 @@ static void init_test(void)
 	/* Setup counter which will periodically enable/disable UART RX,
 	 * Disabling RX should lead to flow control being activated.
 	 */
-	zassert_true(device_is_ready(counter_dev), NULL);
+	zassert_true(device_is_ready(counter_dev));
 
 	top_cfg.ticks = counter_us_to_ticks(counter_dev, 1000);
 
 	err = counter_set_top_value(counter_dev, &top_cfg);
-	zassert_true(err >= 0, NULL);
+	zassert_true(err >= 0);
 
 	err = counter_start(counter_dev);
-	zassert_true(err >= 0, NULL);
+	zassert_true(err >= 0);
 }
 
 static void rx_isr(void)
@@ -256,7 +256,7 @@ static void int_async_thread_func(void *p_data, void *base, void *range)
 			int err;
 
 			err = k_sem_take(&async_tx_sem, K_MSEC(1000));
-			zassert_true(err >= 0, NULL);
+			zassert_true(err >= 0);
 
 			int idx = data->cnt & 0xF;
 			size_t len = (idx < BUF_SIZE / 2) ? 5 : 1; /* Try various lengths */
@@ -345,12 +345,12 @@ ZTEST(uart_mix_fifo_poll, test_mixed_uart_access)
 
 	for (int i = 0; i < num_of_contexts; i++) {
 		err = k_sem_take(&test_data[i].sem, K_MSEC(10000));
-		zassert_equal(err, 0, NULL);
+		zassert_equal(err, 0);
 	}
 
 	if (async || int_driven) {
 		err = k_sem_take(&int_async_data.sem, K_MSEC(10000));
-		zassert_equal(err, 0, NULL);
+		zassert_equal(err, 0);
 	}
 
 	k_msleep(10);

--- a/tests/drivers/uart/uart_pm/src/main.c
+++ b/tests/drivers/uart/uart_pm/src/main.c
@@ -34,7 +34,7 @@ static void polling_verify(const struct device *dev, bool is_async, bool active)
 	}
 
 	err = uart_poll_in(dev, &c);
-	zassert_equal(err, -1, NULL);
+	zassert_equal(err, -1);
 
 	for (int i = 0; i < ARRAY_SIZE(outs); i++) {
 		uart_poll_out(dev, outs[i]);
@@ -43,11 +43,11 @@ static void polling_verify(const struct device *dev, bool is_async, bool active)
 		if (active) {
 			err = uart_poll_in(dev, &c);
 			zassert_equal(err, 0, "Unexpected err: %d", err);
-			zassert_equal(c, outs[i], NULL);
+			zassert_equal(c, outs[i]);
 		}
 
 		err = uart_poll_in(dev, &c);
-		zassert_equal(err, -1, NULL);
+		zassert_equal(err, -1);
 	}
 }
 
@@ -102,7 +102,7 @@ static bool async_verify(const struct device *dev, bool active)
 		zassert_equal(err, 0, "Unexpected err: %d", err);
 	}
 
-	zassert_true(tx_done, NULL);
+	zassert_true(tx_done);
 
 	return true;
 }
@@ -118,7 +118,7 @@ static void communication_verify(const struct device *dev, bool active)
 	enum pm_device_state power_state; \
 	int err = pm_device_state_get(dev, &power_state); \
 	zassert_equal(err, 0, "Unexpected err: %d", err); \
-	zassert_equal(power_state, exp_state, NULL); \
+	zassert_equal(power_state, exp_state); \
 } while (0)
 
 static void action_run(const struct device *dev, enum pm_device_action action,

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -355,24 +355,24 @@ static int test_wdt_bad_window_max(void)
 ZTEST(wdt_basic_test_suite, test_wdt)
 {
 	if ((m_testcase_index != 1U) && (m_testcase_index != 2U)) {
-		zassert_true(test_wdt_no_callback() == TC_PASS, NULL);
+		zassert_true(test_wdt_no_callback() == TC_PASS);
 	}
 	if (m_testcase_index == 1U) {
 #if TEST_WDT_CALLBACK_1
-		zassert_true(test_wdt_callback_1() == TC_PASS, NULL);
+		zassert_true(test_wdt_callback_1() == TC_PASS);
 #else
 		m_testcase_index++;
 #endif
 	}
 	if (m_testcase_index == 2U) {
 #if TEST_WDT_CALLBACK_2
-		zassert_true(test_wdt_callback_2() == TC_PASS, NULL);
+		zassert_true(test_wdt_callback_2() == TC_PASS);
 #else
 		m_testcase_index++;
 #endif
 	}
 	if (m_testcase_index == 3U) {
-		zassert_true(test_wdt_bad_window_max() == TC_PASS, NULL);
+		zassert_true(test_wdt_bad_window_max() == TC_PASS);
 		m_testcase_index++;
 	}
 	if (m_testcase_index > 3) {

--- a/tests/kernel/common/src/bitarray.c
+++ b/tests/kernel/common/src/bitarray.c
@@ -521,37 +521,37 @@ ZTEST(bitarray, test_bitarray_region_set_clear)
 	ba.bundles[0] = 0xFF0F0F0F;
 	ba.bundles[1] = 0x0F0F0FFF;
 
-	zassert_true(sys_bitarray_is_region_set(&ba,  4,  0), NULL);
-	zassert_true(sys_bitarray_is_region_set(&ba, 12, 32), NULL);
-	zassert_true(sys_bitarray_is_region_set(&ba,  8, 32), NULL);
-	zassert_true(sys_bitarray_is_region_set(&ba, 14, 30), NULL);
-	zassert_true(sys_bitarray_is_region_set(&ba, 20, 24), NULL);
+	zassert_true(sys_bitarray_is_region_set(&ba,  4,  0));
+	zassert_true(sys_bitarray_is_region_set(&ba, 12, 32));
+	zassert_true(sys_bitarray_is_region_set(&ba,  8, 32));
+	zassert_true(sys_bitarray_is_region_set(&ba, 14, 30));
+	zassert_true(sys_bitarray_is_region_set(&ba, 20, 24));
 
-	zassert_false(sys_bitarray_is_region_cleared(&ba,  4,  0), NULL);
-	zassert_false(sys_bitarray_is_region_cleared(&ba, 12, 32), NULL);
-	zassert_false(sys_bitarray_is_region_cleared(&ba,  8, 32), NULL);
-	zassert_false(sys_bitarray_is_region_cleared(&ba, 14, 30), NULL);
-	zassert_false(sys_bitarray_is_region_cleared(&ba, 20, 24), NULL);
+	zassert_false(sys_bitarray_is_region_cleared(&ba,  4,  0));
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 12, 32));
+	zassert_false(sys_bitarray_is_region_cleared(&ba,  8, 32));
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 14, 30));
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 20, 24));
 
 	ba.bundles[0] = ~ba.bundles[0];
 	ba.bundles[1] = ~ba.bundles[1];
 
-	zassert_true(sys_bitarray_is_region_cleared(&ba,  4,  0), NULL);
-	zassert_true(sys_bitarray_is_region_cleared(&ba, 12, 32), NULL);
-	zassert_true(sys_bitarray_is_region_cleared(&ba,  8, 32), NULL);
-	zassert_true(sys_bitarray_is_region_cleared(&ba, 14, 30), NULL);
-	zassert_true(sys_bitarray_is_region_cleared(&ba, 20, 24), NULL);
+	zassert_true(sys_bitarray_is_region_cleared(&ba,  4,  0));
+	zassert_true(sys_bitarray_is_region_cleared(&ba, 12, 32));
+	zassert_true(sys_bitarray_is_region_cleared(&ba,  8, 32));
+	zassert_true(sys_bitarray_is_region_cleared(&ba, 14, 30));
+	zassert_true(sys_bitarray_is_region_cleared(&ba, 20, 24));
 
-	zassert_false(sys_bitarray_is_region_set(&ba,  4,  0), NULL);
-	zassert_false(sys_bitarray_is_region_set(&ba, 12, 32), NULL);
-	zassert_false(sys_bitarray_is_region_set(&ba,  8, 32), NULL);
-	zassert_false(sys_bitarray_is_region_set(&ba, 14, 30), NULL);
-	zassert_false(sys_bitarray_is_region_set(&ba, 20, 24), NULL);
+	zassert_false(sys_bitarray_is_region_set(&ba,  4,  0));
+	zassert_false(sys_bitarray_is_region_set(&ba, 12, 32));
+	zassert_false(sys_bitarray_is_region_set(&ba,  8, 32));
+	zassert_false(sys_bitarray_is_region_set(&ba, 14, 30));
+	zassert_false(sys_bitarray_is_region_set(&ba, 20, 24));
 
-	zassert_false(sys_bitarray_is_region_set(&ba, 10, 60), NULL);
-	zassert_false(sys_bitarray_is_region_cleared(&ba, 10, 60), NULL);
-	zassert_false(sys_bitarray_is_region_set(&ba, 8, 120), NULL);
-	zassert_false(sys_bitarray_is_region_cleared(&ba, 8, 120), NULL);
+	zassert_false(sys_bitarray_is_region_set(&ba, 10, 60));
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 10, 60));
+	zassert_false(sys_bitarray_is_region_set(&ba, 8, 120));
+	zassert_false(sys_bitarray_is_region_cleared(&ba, 8, 120));
 
 	printk("Testing bit array region bit manipulations\n");
 

--- a/tests/kernel/common/src/clock.c
+++ b/tests/kernel/common/src/clock.c
@@ -71,7 +71,7 @@ ZTEST_USER(clock, test_clock_uptime)
 	/**TESTPOINT: uptime straddled ms boundary*/
 	t32 = k_uptime_get_32();
 	ALIGN_MS_BOUNDARY;
-	zassert_true(k_uptime_get_32() > t32, NULL);
+	zassert_true(k_uptime_get_32() > t32);
 
 	/**TESTPOINT: uptime delta*/
 	d64 = k_uptime_delta(&d64);
@@ -231,8 +231,8 @@ ZTEST(clock, test_ms_time_duration)
 
 	/** TESTPOINT: waiting time less than duration and check the count*/
 	k_busy_wait(LESS_DURATION * 1000);
-	zassert_true(tdata.duration_count == 0, NULL);
-	zassert_true(tdata.stop_count == 0, NULL);
+	zassert_true(tdata.duration_count == 0);
+	zassert_true(tdata.stop_count == 0);
 
 	/** TESTPOINT: proving duration in millisecond */
 	init_data_count();

--- a/tests/kernel/common/src/errno.c
+++ b/tests/kernel/common/src/errno.c
@@ -55,7 +55,7 @@ static void errno_thread(void *_n, void *_my_errno, void *_unused)
 		result[n].pass = TC_PASS;
 	}
 
-	zassert_equal(errno, my_errno, NULL);
+	zassert_equal(errno, my_errno);
 
 	k_fifo_put(&fifo, &result[n]);
 }
@@ -97,7 +97,7 @@ ZTEST(common_errno, test_thread_context)
 		}
 	}
 
-	zassert_equal(errno, test_errno, NULL);
+	zassert_equal(errno, test_errno);
 
 	if (errno != errno_values[N_THREADS]) {
 		rv = TC_FAIL;

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -54,17 +54,17 @@ ZTEST(device, test_dummy_device)
 
 	/* Validates device binding for a non-existing device object */
 	dev = device_get_binding(DUMMY_PORT_1);
-	zassert_equal(dev, NULL);
+	zassert_is_null(dev);
 
 	/* Validates device binding for an existing device object */
 	dev = device_get_binding(DUMMY_PORT_2);
-	zassert_false((dev == NULL));
+	zassert_not_null(dev);
 
 	/* device_get_binding() returns false for device object
 	 * with failed init.
 	 */
 	dev = device_get_binding(BAD_DRIVER);
-	zassert_true((dev == NULL));
+	zassert_is_null(dev);
 }
 
 /**

--- a/tests/kernel/device/src/main.c
+++ b/tests/kernel/device/src/main.c
@@ -54,17 +54,17 @@ ZTEST(device, test_dummy_device)
 
 	/* Validates device binding for a non-existing device object */
 	dev = device_get_binding(DUMMY_PORT_1);
-	zassert_equal(dev, NULL, NULL);
+	zassert_equal(dev, NULL);
 
 	/* Validates device binding for an existing device object */
 	dev = device_get_binding(DUMMY_PORT_2);
-	zassert_false((dev == NULL), NULL);
+	zassert_false((dev == NULL));
 
 	/* device_get_binding() returns false for device object
 	 * with failed init.
 	 */
 	dev = device_get_binding(BAD_DRIVER);
-	zassert_true((dev == NULL), NULL);
+	zassert_true((dev == NULL));
 }
 
 /**
@@ -81,7 +81,7 @@ ZTEST_USER(device, test_dynamic_name)
 
 	snprintk(name, sizeof(name), "%s", DUMMY_PORT_2);
 	mux = device_get_binding(name);
-	zassert_true(mux != NULL, NULL);
+	zassert_true(mux != NULL);
 }
 
 /**
@@ -99,7 +99,7 @@ ZTEST_USER(device, test_bogus_dynamic_name)
 
 	snprintk(name, sizeof(name), "ANOTHER_BOGUS_NAME");
 	mux = device_get_binding(name);
-	zassert_true(mux == NULL, NULL);
+	zassert_true(mux == NULL);
 }
 
 /**
@@ -119,7 +119,7 @@ ZTEST_USER(device, test_null_dynamic_name)
 	char *drv_name = NULL;
 
 	mux = device_get_binding(drv_name);
-	zassert_equal(mux, 0,  NULL);
+	zassert_equal(mux, 0);
 #else
 	ztest_test_skip();
 #endif
@@ -233,7 +233,7 @@ ZTEST(device, test_device_list)
 	struct device const *devices;
 	size_t devcount = z_device_get_all_static(&devices);
 
-	zassert_false((devcount == 0), NULL);
+	zassert_false((devcount == 0));
 }
 
 static int sys_init_counter;
@@ -340,7 +340,7 @@ ZTEST(device, test_abstraction_driver_common)
 
 	/* verify driver A API has called */
 	dev = device_get_binding(MY_DRIVER_A);
-	zassert_false((dev == NULL), NULL);
+	zassert_false((dev == NULL));
 
 	ret = subsystem_do_this(dev, foo, bar);
 	zassert_true(ret == (foo + bar), "common API do_this fail");
@@ -350,7 +350,7 @@ ZTEST(device, test_abstraction_driver_common)
 
 	/* verify driver B API has called */
 	dev = device_get_binding(MY_DRIVER_B);
-	zassert_false((dev == NULL), NULL);
+	zassert_false((dev == NULL));
 
 	ret = subsystem_do_this(dev, foo, bar);
 	zassert_true(ret == (foo - bar), "common API do_this fail");

--- a/tests/kernel/events/event_api/src/test_event_apis.c
+++ b/tests/kernel/events/event_api/src/test_event_apis.c
@@ -71,7 +71,7 @@ ZTEST(events_api, test_k_event_init)
 	thread = z_waitq_head(&event.wait_q);
 
 	zassert_is_null(thread, NULL);
-	zassert_true(event.events == 0, NULL);
+	zassert_true(event.events == 0);
 }
 
 static void receive_existing_events(void)
@@ -189,8 +189,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-2.
@@ -199,8 +199,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-3.
@@ -209,8 +209,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-4.
@@ -219,8 +219,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-5.
@@ -229,8 +229,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x234, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x234);
 
 	/*
 	 * Sync point 1-6.
@@ -239,8 +239,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x1234, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x1234);
 }
 
 /**
@@ -261,9 +261,9 @@ static void test_reset_on_wait(void)
 	k_sleep(DELAY);           /* Give receiver thread time to run */
 	k_event_post(&test_event, 0x123);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
-	zassert_true(test_event.events == 0x123, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
+	zassert_true(test_event.events == 0x123);
 
 	/*
 	 * Sync point 2-2. Reset events before receive.
@@ -274,9 +274,9 @@ static void test_reset_on_wait(void)
 	k_sleep(DELAY);
 	k_event_post(&test_event, 0x248);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
-	zassert_true(test_event.events == 0x248, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
+	zassert_true(test_event.events == 0x248);
 
 	/*
 	 * Sync point 2-3. Reset events before receive.
@@ -287,9 +287,9 @@ static void test_reset_on_wait(void)
 	k_sleep(DELAY);
 	k_event_post(&test_event, 0x248021);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x248001, NULL);
-	zassert_true(test_event.events  == 0x248021, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x248001);
+	zassert_true(test_event.events  == 0x248021);
 
 	/*
 	 * Sync point 2-4. Reset events before receive.
@@ -300,9 +300,9 @@ static void test_reset_on_wait(void)
 	k_sleep(DELAY);
 	k_event_post(&test_event, 0x123456);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x123450, NULL);
-	zassert_true(test_event.events  == 0x123456, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x123450);
+	zassert_true(test_event.events  == 0x123456);
 
 	k_event_set(&test_event, 0x0);  /* Reset events */
 	k_sem_give(&sync_sem);
@@ -326,7 +326,7 @@ void test_wake_multiple_threads(void)
 
 	events = k_event_wait_all(&test_event, 0x333, false, SHORT_TIMEOUT);
 
-	zassert_true(events == 0x333, NULL);
+	zassert_true(events == 0x333);
 }
 
 /**
@@ -344,7 +344,7 @@ ZTEST(events_api, test_event_deliver)
 
 	k_event_init(&event);
 
-	zassert_true(event.events == 0, NULL);
+	zassert_true(event.events == 0);
 
 	/*
 	 * Verify k_event_post()  and k_event_set() update the
@@ -353,15 +353,15 @@ ZTEST(events_api, test_event_deliver)
 
 	events = 0xAAAA;
 	k_event_post(&event, events);
-	zassert_true(event.events == events, NULL);
+	zassert_true(event.events == events);
 
 	events |= 0x55555ABC;
 	k_event_post(&event, events);
-	zassert_true(event.events == events, NULL);
+	zassert_true(event.events == events);
 
 	events = 0xAAAA0000;
 	k_event_set(&event, events);
-	zassert_true(event.events == events, NULL);
+	zassert_true(event.events == events);
 
 	/*
 	 * Verify k_event_set_masked() update the events
@@ -369,25 +369,25 @@ ZTEST(events_api, test_event_deliver)
 	 */
 	events = 0x33333333;
 	k_event_set(&event, events);
-	zassert_true(event.events == events, NULL);
+	zassert_true(event.events == events);
 
 	events_mask = 0x11111111;
 	k_event_set_masked(&event, 0, events_mask);
-	zassert_true(event.events == 0x22222222, NULL);
+	zassert_true(event.events == 0x22222222);
 
 	events_mask = 0x22222222;
 	k_event_set_masked(&event, 0, events_mask);
-	zassert_true(event.events == 0, NULL);
+	zassert_true(event.events == 0);
 
 	events = 0x22222222;
 	events_mask = 0x22222222;
 	k_event_set_masked(&event, events, events_mask);
-	zassert_true(event.events == events, NULL);
+	zassert_true(event.events == events);
 
 	events = 0x11111111;
 	events_mask = 0x33333333;
 	k_event_set_masked(&event, events, events_mask);
-	zassert_true(event.events == events, NULL);
+	zassert_true(event.events == events);
 
 }
 

--- a/tests/kernel/events/sys_event/src/main.c
+++ b/tests/kernel/events/sys_event/src/main.c
@@ -69,7 +69,7 @@ ZTEST(sys_events, test_k_event_init)
 {
 	k_event_init(&init_event);
 
-	zassert_true(init_event.events == 0, NULL);
+	zassert_true(init_event.events == 0);
 }
 
 static void receive_existing_events(void)
@@ -186,8 +186,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-2.
@@ -196,8 +196,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-3.
@@ -206,8 +206,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-4.
@@ -216,8 +216,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
 
 	/*
 	 * Sync point 1-5.
@@ -226,8 +226,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x234, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x234);
 
 	/*
 	 * Sync point 1-6.
@@ -236,8 +236,8 @@ static void test_receive_existing_events(void)
 
 	k_sem_give(&sync_sem);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x1234, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x1234);
 }
 
 /**
@@ -258,9 +258,9 @@ static void test_reset_on_receive(void)
 	k_sleep(DELAY);           /* Give receiver thread time to run */
 	k_event_post(&test_event, 0x123);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
-	zassert_true(test_event.events == 0x123, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
+	zassert_true(test_event.events == 0x123);
 
 	/*
 	 * Sync point 2-2. Clear events before receive.
@@ -271,9 +271,9 @@ static void test_reset_on_receive(void)
 	k_sleep(DELAY);
 	k_event_post(&test_event, 0x248);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0, NULL);
-	zassert_true(test_event.events == 0x248, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0);
+	zassert_true(test_event.events == 0x248);
 
 	/*
 	 * Sync point 2-3. Clear events before receive.
@@ -284,9 +284,9 @@ static void test_reset_on_receive(void)
 	k_sleep(DELAY);
 	k_event_post(&test_event, 0x248021);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x248001, NULL);
-	zassert_true(test_event.events  == 0x248021, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x248001);
+	zassert_true(test_event.events  == 0x248021);
 
 	/*
 	 * Sync point 2-4. Clear events before receive.
@@ -297,9 +297,9 @@ static void test_reset_on_receive(void)
 	k_sleep(DELAY);
 	k_event_post(&test_event, 0x123456);
 	rv = k_sem_take(&receiver_sem, LONG_TIMEOUT);
-	zassert_true(rv == 0, NULL);
-	zassert_true(test_events == 0x123450, NULL);
-	zassert_true(test_event.events  == 0x123456, NULL);
+	zassert_true(rv == 0);
+	zassert_true(test_events == 0x123450);
+	zassert_true(test_event.events  == 0x123456);
 
 	k_event_set(&test_event, 0x0);  /* Clear events */
 
@@ -324,7 +324,7 @@ void test_wake_multiple_threads(void)
 
 	events = k_event_wait_all(&test_event, 0x333, false, SHORT_TIMEOUT);
 
-	zassert_true(events == 0x333, NULL);
+	zassert_true(events == 0x333);
 }
 
 /**
@@ -340,7 +340,7 @@ ZTEST(sys_events, test_event_deliver)
 
 	k_event_init(&deliver_event);
 
-	zassert_true(deliver_event.events == 0, NULL);
+	zassert_true(deliver_event.events == 0);
 
 	/*
 	 * Verify k_event_post() and k_event_set() update the
@@ -349,15 +349,15 @@ ZTEST(sys_events, test_event_deliver)
 
 	events = 0xAAAA;
 	k_event_post(&deliver_event, events);
-	zassert_true(deliver_event.events == events, NULL);
+	zassert_true(deliver_event.events == events);
 
 	events |= 0x55555ABC;
 	k_event_post(&deliver_event, events);
-	zassert_true(deliver_event.events == events, NULL);
+	zassert_true(deliver_event.events == events);
 
 	events = 0xAAAA0000;
 	k_event_set(&deliver_event, events);
-	zassert_true(deliver_event.events == events, NULL);
+	zassert_true(deliver_event.events == events);
 }
 
 /**

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_contexts.c
@@ -51,17 +51,17 @@ static void tfifo_get(struct k_fifo *pfifo)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: fifo get*/
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		zassert_equal(rx_data, (void *)&data[i]);
 	}
 	/*get fifo data from "fifo_put_list"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_l[i], NULL);
+		zassert_equal(rx_data, (void *)&data_l[i]);
 	}
 	/*get fifo data from "fifo_put_slist"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_sl[i], NULL);
+		zassert_equal(rx_data, (void *)&data_sl[i]);
 	}
 }
 
@@ -69,13 +69,13 @@ static void tfifo_get(struct k_fifo *pfifo)
 static void tIsr_entry_put(const void *p)
 {
 	tfifo_put((struct k_fifo *)p);
-	zassert_false(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	zassert_false(k_fifo_is_empty((struct k_fifo *)p));
 }
 
 static void tIsr_entry_get(const void *p)
 {
 	tfifo_get((struct k_fifo *)p);
-	zassert_true(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	zassert_true(k_fifo_is_empty((struct k_fifo *)p));
 }
 
 static void tThread_entry(void *p1, void *p2, void *p3)
@@ -118,11 +118,11 @@ static void tfifo_is_empty(void *p)
 
 	tfifo_put(&fifo);
 	/**TESTPOINT: return false when data available*/
-	zassert_false(k_fifo_is_empty(pfifo), NULL);
+	zassert_false(k_fifo_is_empty(pfifo));
 
 	tfifo_get(&fifo);
 	/**TESTPOINT: return true with data unavailable*/
-	zassert_true(k_fifo_is_empty(pfifo), NULL);
+	zassert_true(k_fifo_is_empty(pfifo));
 }
 
 /**
@@ -180,7 +180,7 @@ ZTEST(fifo_api, test_fifo_is_empty_thread)
 {
 	k_fifo_init(&fifo);
 	/**TESTPOINT: k_fifo_is_empty after init*/
-	zassert_true(k_fifo_is_empty(&fifo), NULL);
+	zassert_true(k_fifo_is_empty(&fifo));
 
 	/**TESTPONT: check fifo is empty from thread*/
 	tfifo_is_empty(&fifo);

--- a/tests/kernel/fifo/fifo_api/src/test_fifo_loop.c
+++ b/tests/kernel/fifo/fifo_api/src/test_fifo_loop.c
@@ -32,7 +32,7 @@ static void tfifo_get(struct k_fifo *pfifo)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: fifo get*/
 		rx_data = k_fifo_get(pfifo, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		zassert_equal(rx_data, (void *)&data[i]);
 	}
 }
 

--- a/tests/kernel/fifo/fifo_timeout/src/main.c
+++ b/tests/kernel/fifo/fifo_timeout/src/main.c
@@ -87,7 +87,7 @@ static void *get_scratch_packet(void)
 {
 	void *packet = k_fifo_get(&scratch_fifo_packets_fifo, K_NO_WAIT);
 
-	zassert_true(packet != NULL, NULL);
+	zassert_true(packet != NULL);
 	return packet;
 }
 
@@ -127,8 +127,8 @@ static void test_thread_pend_and_timeout(void *p1, void *p2, void *p3)
 
 	start_time = k_cycle_get_32();
 	packet = k_fifo_get(d->fifo, K_MSEC(d->timeout));
-	zassert_true(packet == NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, d->timeout), NULL);
+	zassert_true(packet == NULL);
+	zassert_true(is_timeout_in_range(start_time, d->timeout));
 
 	k_fifo_put(&timeout_order_fifo, d);
 }
@@ -201,7 +201,7 @@ static void test_thread_pend_and_get_data(void *p1, void *p2, void *p3)
 	void *packet;
 
 	packet = k_fifo_get(d->fifo, K_MSEC(d->timeout));
-	zassert_true(packet != NULL, NULL);
+	zassert_true(packet != NULL);
 
 	put_scratch_packet(packet);
 	k_fifo_put(&timeout_order_fifo, d);
@@ -306,12 +306,12 @@ ZTEST(fifo_timeout_1cpu, test_timeout_empty_fifo)
 	timeout = 10U;
 	start_time = k_cycle_get_32();
 	packet = k_fifo_get(&fifo_timeout[0], K_MSEC(timeout));
-	zassert_true(packet == NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	zassert_true(packet == NULL);
+	zassert_true(is_timeout_in_range(start_time, timeout));
 
 	/* Test empty fifo with timeout of K_NO_WAIT */
 	packet = k_fifo_get(&fifo_timeout[0], K_NO_WAIT);
-	zassert_true(packet == NULL, NULL);
+	zassert_true(packet == NULL);
 }
 
 /**
@@ -326,14 +326,14 @@ ZTEST(fifo_timeout, test_timeout_non_empty_fifo)
 	scratch_packet = get_scratch_packet();
 	k_fifo_put(&fifo_timeout[0], scratch_packet);
 	packet = k_fifo_get(&fifo_timeout[0], K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
+	zassert_true(packet != NULL);
 	put_scratch_packet(scratch_packet);
 
 	 /* Test k_fifo_get with K_FOREVER */
 	scratch_packet = get_scratch_packet();
 	k_fifo_put(&fifo_timeout[0], scratch_packet);
 	packet = k_fifo_get(&fifo_timeout[0], K_FOREVER);
-	zassert_true(packet != NULL, NULL);
+	zassert_true(packet != NULL);
 	put_scratch_packet(scratch_packet);
 }
 
@@ -368,8 +368,8 @@ ZTEST(fifo_timeout_1cpu, test_timeout_fifo_thread)
 				FIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_fifo_get(&fifo_timeout[0], K_MSEC(timeout + 10));
-	zassert_true(packet != NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	zassert_true(packet != NULL);
+	zassert_true(is_timeout_in_range(start_time, timeout));
 	put_scratch_packet(packet);
 
 	/*
@@ -385,8 +385,8 @@ ZTEST(fifo_timeout_1cpu, test_timeout_fifo_thread)
 
 	k_yield();
 	packet = k_fifo_get(&timeout_order_fifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_false(reply_packet.reply, NULL);
+	zassert_true(packet != NULL);
+	zassert_false(reply_packet.reply);
 
 	/*
 	 * Test k_fifo_get with timeout of K_NO_WAIT and the fifo
@@ -404,8 +404,8 @@ ZTEST(fifo_timeout_1cpu, test_timeout_fifo_thread)
 
 	k_yield();
 	packet = k_fifo_get(&timeout_order_fifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	zassert_true(packet != NULL);
+	zassert_true(reply_packet.reply);
 	put_scratch_packet(scratch_packet);
 
 	/*
@@ -423,8 +423,8 @@ ZTEST(fifo_timeout_1cpu, test_timeout_fifo_thread)
 				FIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_fifo_get(&timeout_order_fifo, K_FOREVER);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	zassert_true(packet != NULL);
+	zassert_true(reply_packet.reply);
 	put_scratch_packet(scratch_packet);
 }
 
@@ -444,7 +444,7 @@ ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_on_fifo)
 	 */
 	test_data_size = ARRAY_SIZE(timeout_order_data);
 	rv = test_multiple_threads_pending(timeout_order_data, test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	zassert_equal(rv, TC_PASS);
 }
 
 /**
@@ -464,7 +464,7 @@ ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_on_dual_fifos)
 	test_data_size = ARRAY_SIZE(timeout_order_data_mult_fifo);
 	rv = test_multiple_threads_pending(timeout_order_data_mult_fifo,
 							test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	zassert_equal(rv, TC_PASS);
 
 }
 
@@ -485,7 +485,7 @@ ZTEST(fifo_timeout_1cpu, test_timeout_threads_pend_fail_on_fifo)
 	 */
 	test_data_size = ARRAY_SIZE(timeout_order_data);
 	rv = test_multiple_threads_get_data(timeout_order_data, test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	zassert_equal(rv, TC_PASS);
 }
 
 /**

--- a/tests/kernel/fifo/fifo_usage/src/main.c
+++ b/tests/kernel/fifo/fifo_usage/src/main.c
@@ -64,7 +64,7 @@ static void tIsr_entry_put(const void *p)
 	for (i = 0U; i < LIST_LEN; i++) {
 		k_fifo_put((struct k_fifo *)p, (void *)&data_isr[i]);
 	}
-	zassert_false(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	zassert_false(k_fifo_is_empty((struct k_fifo *)p));
 }
 
 static void tIsr_entry_get(const void *p)
@@ -75,9 +75,9 @@ static void tIsr_entry_get(const void *p)
 	/* Get items from fifo */
 	for (i = 0U; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get((struct k_fifo *)p, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_isr[i], NULL);
+		zassert_equal(rx_data, (void *)&data_isr[i]);
 	}
-	zassert_true(k_fifo_is_empty((struct k_fifo *)p), NULL);
+	zassert_true(k_fifo_is_empty((struct k_fifo *)p));
 }
 
 static void thread_entry_fn_single(void *p1, void *p2, void *p3)
@@ -88,7 +88,7 @@ static void thread_entry_fn_single(void *p1, void *p2, void *p3)
 	/* Get items from fifo */
 	for (i = 0U; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get((struct k_fifo *)p1, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data1[i], NULL);
+		zassert_equal(rx_data, (void *)&data1[i]);
 	}
 
 	/* Put items into fifo */
@@ -108,7 +108,7 @@ static void thread_entry_fn_dual(void *p1, void *p2, void *p3)
 	for (i = 0U; i < LIST_LEN; i++) {
 		/* Get items from fifo2 */
 		rx_data = k_fifo_get((struct k_fifo *)p2, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data2[i], NULL);
+		zassert_equal(rx_data, (void *)&data2[i]);
 
 		/* Put items into fifo1 */
 		k_fifo_put((struct k_fifo *)p1, (void *)&data1[i]);
@@ -164,7 +164,7 @@ ZTEST(fifo_usage, test_single_fifo_play)
 	/* Get items from fifo */
 	for (i = 0U; i < LIST_LEN; i++) {
 		rx_data = k_fifo_get(&fifo1, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data2[i], NULL);
+		zassert_equal(rx_data, (void *)&data2[i]);
 	}
 
 	/* Clear the spawn thread to avoid side effect */
@@ -195,7 +195,7 @@ ZTEST(fifo_usage, test_dual_fifo_play)
 
 		/* Get item from fifo */
 		rx_data = k_fifo_get(&fifo1, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data1[i], NULL);
+		zassert_equal(rx_data, (void *)&data1[i]);
 	}
 
 	/* Clear the spawn thread to avoid side effect */

--- a/tests/kernel/fpu_sharing/generic/src/load_store.c
+++ b/tests/kernel/fpu_sharing/generic/src/load_store.c
@@ -184,7 +184,7 @@ static void load_store_low(void)
 		}
 
 		/* Terminate if a test error has been reported */
-		zassert_false(error, NULL);
+		zassert_false(error);
 
 		/*
 		 * After every 1000 iterations (arbitrarily chosen), explicitly

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_contexts.c
@@ -34,7 +34,7 @@ static void tlifo_get(struct k_lifo *plifo)
 	for (int i = LIST_LEN-1; i >= 0; i--) {
 		/**TESTPOINT: lifo get*/
 		rx_data = k_lifo_get(plifo, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		zassert_equal(rx_data, (void *)&data[i]);
 	}
 }
 

--- a/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
+++ b/tests/kernel/lifo/lifo_api/src/test_lifo_loop.c
@@ -32,7 +32,7 @@ static void tlifo_get(struct k_lifo *plifo)
 	for (int i = LIST_LEN-1; i >= 0; i--) {
 		/**TESTPOINT: lifo get*/
 		rx_data = k_lifo_get(plifo, K_FOREVER);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		zassert_equal(rx_data, (void *)&data[i]);
 	}
 }
 

--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -277,13 +277,13 @@ ZTEST(lifo_usage_1cpu, test_timeout_empty_lifo)
 
 	packet = k_lifo_get(&lifo_timeout[0], K_MSEC(timeout));
 
-	zassert_equal(packet, NULL);
+	zassert_is_null(packet);
 
 	zassert_true(is_timeout_in_range(start_time, timeout));
 
 	/* Test empty lifo with timeout of K_NO_WAIT */
 	packet = k_lifo_get(&lifo_timeout[0], K_NO_WAIT);
-	zassert_equal(packet, NULL);
+	zassert_is_null(packet);
 }
 
 /**

--- a/tests/kernel/lifo/lifo_usage/src/main.c
+++ b/tests/kernel/lifo/lifo_usage/src/main.c
@@ -80,7 +80,7 @@ static void *get_scratch_packet(void)
 {
 	void *packet = k_lifo_get(&scratch_lifo_packets_lifo, K_NO_WAIT);
 
-	zassert_true(packet != NULL, NULL);
+	zassert_true(packet != NULL);
 	return packet;
 }
 
@@ -96,11 +96,11 @@ static void thread_entry_nowait(void *p1, void *p2, void *p3)
 	ret = k_lifo_get((struct k_lifo *)p1, K_FOREVER);
 
 	/* data pushed at last should be read first */
-	zassert_equal(ret, (void *)&data[1], NULL);
+	zassert_equal(ret, (void *)&data[1]);
 
 	ret = k_lifo_get((struct k_lifo *)p1, K_FOREVER);
 
-	zassert_equal(ret, (void *)&data[0], NULL);
+	zassert_equal(ret, (void *)&data[0]);
 
 	k_sem_give(&start_sema);
 }
@@ -250,13 +250,13 @@ ZTEST(lifo_usage_1cpu, test_lifo_wait)
 
 	ret = k_lifo_get(&plifo, K_FOREVER);
 
-	zassert_equal(ret, (void *)&data[0], NULL);
+	zassert_equal(ret, (void *)&data[0]);
 
 	k_sem_take(&wait_sema, K_FOREVER);
 
 	ret = k_lifo_get(&plifo, K_FOREVER);
 
-	zassert_equal(ret, (void *)&data[1], NULL);
+	zassert_equal(ret, (void *)&data[1]);
 
 	k_thread_abort(tid);
 }
@@ -277,13 +277,13 @@ ZTEST(lifo_usage_1cpu, test_timeout_empty_lifo)
 
 	packet = k_lifo_get(&lifo_timeout[0], K_MSEC(timeout));
 
-	zassert_equal(packet, NULL, NULL);
+	zassert_equal(packet, NULL);
 
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	zassert_true(is_timeout_in_range(start_time, timeout));
 
 	/* Test empty lifo with timeout of K_NO_WAIT */
 	packet = k_lifo_get(&lifo_timeout[0], K_NO_WAIT);
-	zassert_equal(packet, NULL, NULL);
+	zassert_equal(packet, NULL);
 }
 
 /**
@@ -298,14 +298,14 @@ ZTEST(lifo_usage, test_timeout_non_empty_lifo)
 	scratch_packet = get_scratch_packet();
 	k_lifo_put(&lifo_timeout[0], scratch_packet);
 	packet = k_lifo_get(&lifo_timeout[0], K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
+	zassert_true(packet != NULL);
 	put_scratch_packet(scratch_packet);
 
 	 /* Test k_lifo_get with K_FOREVER */
 	scratch_packet = get_scratch_packet();
 	k_lifo_put(&lifo_timeout[0], scratch_packet);
 	packet = k_lifo_get(&lifo_timeout[0], K_FOREVER);
-	zassert_true(packet != NULL, NULL);
+	zassert_true(packet != NULL);
 }
 
 /**
@@ -331,8 +331,8 @@ ZTEST(lifo_usage_1cpu, test_timeout_lifo_thread)
 				LIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_lifo_get(&lifo_timeout[0], K_MSEC(timeout + 10));
-	zassert_true(packet != NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, timeout), NULL);
+	zassert_true(packet != NULL);
+	zassert_true(is_timeout_in_range(start_time, timeout));
 	put_scratch_packet(packet);
 
 	/*
@@ -348,8 +348,8 @@ ZTEST(lifo_usage_1cpu, test_timeout_lifo_thread)
 
 	k_yield();
 	packet = k_lifo_get(&timeout_order_lifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_false(reply_packet.reply, NULL);
+	zassert_true(packet != NULL);
+	zassert_false(reply_packet.reply);
 
 	/*
 	 * Test k_lifo_get with timeout of K_NO_WAIT and the lifo
@@ -367,8 +367,8 @@ ZTEST(lifo_usage_1cpu, test_timeout_lifo_thread)
 
 	k_yield();
 	packet = k_lifo_get(&timeout_order_lifo, K_NO_WAIT);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	zassert_true(packet != NULL);
+	zassert_true(reply_packet.reply);
 	put_scratch_packet(scratch_packet);
 
 	/*
@@ -386,8 +386,8 @@ ZTEST(lifo_usage_1cpu, test_timeout_lifo_thread)
 				LIFO_THREAD_PRIO, K_INHERIT_PERMS, K_NO_WAIT);
 
 	packet = k_lifo_get(&timeout_order_lifo, K_FOREVER);
-	zassert_true(packet != NULL, NULL);
-	zassert_true(reply_packet.reply, NULL);
+	zassert_true(packet != NULL);
+	zassert_true(reply_packet.reply);
 	put_scratch_packet(scratch_packet);
 }
 
@@ -403,8 +403,8 @@ void test_thread_pend_and_timeout(void *p1, void *p2, void *p3)
 
 	start_time = k_cycle_get_32();
 	packet = k_lifo_get(d->klifo, K_MSEC(d->timeout));
-	zassert_true(packet == NULL, NULL);
-	zassert_true(is_timeout_in_range(start_time, d->timeout), NULL);
+	zassert_true(packet == NULL);
+	zassert_true(is_timeout_in_range(start_time, d->timeout));
 
 	k_lifo_put(&timeout_order_lifo, d);
 }
@@ -426,7 +426,7 @@ ZTEST(lifo_usage_1cpu, test_timeout_threads_pend_on_lifo)
 	 */
 	test_data_size = ARRAY_SIZE(timeout_order_data);
 	rv = test_multiple_threads_pending(timeout_order_data, test_data_size);
-	zassert_equal(rv, TC_PASS, NULL);
+	zassert_equal(rv, TC_PASS);
 }
 
 /**

--- a/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
+++ b/tests/kernel/mbox/mbox_api/src/test_mbox_api.c
@@ -166,7 +166,7 @@ static void tmbox_put(struct k_mbox *pmbox)
 		mmsg.tx_data = data[1];
 		mmsg.tx_block.data = NULL;
 		mmsg.tx_target_thread = K_ANY;
-		zassert_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0, NULL);
+		zassert_true(k_mbox_put(pmbox, &mmsg, K_FOREVER) == 0);
 		break;
 
 	case ASYNC_PUT_TO_WAITING_GET:
@@ -252,9 +252,9 @@ static void tmbox_get(struct k_mbox *pmbox)
 		zassert_true(k_mbox_get(pmbox, &mmsg, rxdata, K_FOREVER) == 0,
 			     NULL);
 		/*verify .info*/
-		zassert_equal(mmsg.info, PUT_GET_NULL, NULL);
+		zassert_equal(mmsg.info, PUT_GET_NULL);
 		/*verify .size*/
-		zassert_equal(mmsg.size, 0, NULL);
+		zassert_equal(mmsg.size, 0);
 		break;
 	case PUT_GET_BUFFER:
 		__fallthrough;
@@ -268,8 +268,8 @@ static void tmbox_get(struct k_mbox *pmbox)
 		}
 		zassert_true(k_mbox_get(pmbox, &mmsg, rxdata, K_FOREVER) == 0,
 			     NULL);
-		zassert_equal(mmsg.info, PUT_GET_BUFFER, NULL);
-		zassert_equal(mmsg.size, sizeof(data[info_type]), NULL);
+		zassert_equal(mmsg.info, PUT_GET_BUFFER);
+		zassert_equal(mmsg.size, sizeof(data[info_type]));
 		/*verify rxdata*/
 		zassert_true(memcmp(rxdata, data[info_type], MAIL_LEN) == 0,
 			     NULL);
@@ -280,8 +280,8 @@ static void tmbox_get(struct k_mbox *pmbox)
 		mmsg.rx_source_thread = K_ANY;
 		zassert_true(k_mbox_get(pmbox, &mmsg, NULL, K_FOREVER) == 0,
 			     NULL);
-		zassert_equal(mmsg.info, ASYNC_PUT_GET_BUFFER, NULL);
-		zassert_equal(mmsg.size, sizeof(data[info_type]), NULL);
+		zassert_equal(mmsg.info, ASYNC_PUT_GET_BUFFER);
+		zassert_equal(mmsg.size, sizeof(data[info_type]));
 		k_mbox_data_get(&mmsg, rxdata);
 		zassert_true(memcmp(rxdata, data[info_type], MAIL_LEN) == 0,
 			     NULL);

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_api.c
@@ -133,7 +133,7 @@ ZTEST(mheap_api, test_mheap_calloc)
 
 	/* Memory should be zeroed and not crash us if we read/write to it */
 	for (int i = 0; i < BOUNDS; i++) {
-		zassert_equal(mem[i], 0, NULL);
+		zassert_equal(mem[i], 0);
 		mem[i] = 1;
 	}
 

--- a/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
+++ b/tests/kernel/mem_heap/mheap_api_concept/src/test_mheap_concept.c
@@ -42,7 +42,7 @@ ZTEST(mheap_api, test_mheap_malloc_align4)
 	for (int i = 0; i < BLK_NUM_MAX; i++) {
 		block[i] = k_malloc(i);
 		zassert_not_null(block[i], NULL);
-		zassert_false((uintptr_t)block[i] % sizeof(void *), NULL);
+		zassert_false((uintptr_t)block[i] % sizeof(void *));
 	}
 
 	/* test case tear down*/

--- a/tests/kernel/mem_protect/futex/src/main.c
+++ b/tests/kernel/mem_protect/futex/src/main.c
@@ -460,14 +460,14 @@ static void futex_wait_wake(void *p1, void *p2, void *p3)
 	 * Use assertion to verify k_futex_wait() returns 0
 	 */
 	ret_value = k_futex_wait(&simple_futex, 13, K_FOREVER);
-	zassert_equal(ret_value, 0, NULL);
+	zassert_equal(ret_value, 0);
 
 	/* Test user thread can make wake without error
 	 * Use assertion to verify k_futex_wake() returns 1,
 	 * because only 1 thread wakes
 	 */
 	ret_value = k_futex_wake(&simple_futex, false);
-	zassert_equal(ret_value, 1, NULL);
+	zassert_equal(ret_value, 1);
 }
 
 static void futex_wake(void *p1, void *p2, void *p3)
@@ -478,7 +478,7 @@ static void futex_wake(void *p1, void *p2, void *p3)
 	k_futex_wake(&simple_futex, false);
 
 	ret_value = k_futex_wait(&simple_futex, 13, K_FOREVER);
-	zassert_equal(ret_value, 0, NULL);
+	zassert_equal(ret_value, 0);
 
 	/* Test user can write to the futex value
 	 * Use assertion to verify subtraction correctness
@@ -486,7 +486,7 @@ static void futex_wake(void *p1, void *p2, void *p3)
 	 */
 	atomic_sub(&simple_futex.val, 1);
 	atomic_ret_val = atomic_get(&simple_futex.val);
-	zassert_equal(atomic_ret_val, 12, NULL);
+	zassert_equal(atomic_ret_val, 12);
 }
 
 /**

--- a/tests/kernel/mem_protect/mem_protect/src/kobject.c
+++ b/tests/kernel/mem_protect/mem_protect/src/kobject.c
@@ -1040,12 +1040,12 @@ static void thread_stack_init_objects(void *p1, void *p2, void *p3)
 	/* check that thread is initialized when running */
 	ko = z_object_find(&child_thread);
 	ret = z_object_validate(ko, K_OBJ_ANY, _OBJ_INIT_TRUE);
-	zassert_equal(ret, _OBJ_INIT_TRUE, NULL);
+	zassert_equal(ret, _OBJ_INIT_TRUE);
 
 	/* check that stack is initialized when running */
 	ko = z_object_find(child_stack);
 	ret = z_object_validate(ko, K_OBJ_ANY, _OBJ_INIT_TRUE);
-	zassert_equal(ret, _OBJ_INIT_TRUE, NULL);
+	zassert_equal(ret, _OBJ_INIT_TRUE);
 }
 
 /**
@@ -1078,12 +1078,12 @@ ZTEST(mem_protect_kobj, test_mark_thread_exit_uninitialized)
 	/* check thread is uninitialized after its exit */
 	ko = z_object_find(&child_thread);
 	ret = z_object_validate(ko, K_OBJ_ANY, _OBJ_INIT_FALSE);
-	zassert_equal(ret, _OBJ_INIT_FALSE, NULL);
+	zassert_equal(ret, _OBJ_INIT_FALSE);
 
 	/* check stack is uninitialized after thread exit */
 	ko = z_object_find(child_stack);
 	ret = z_object_validate(ko, K_OBJ_ANY, _OBJ_INIT_FALSE);
-	zassert_equal(ret, _OBJ_INIT_FALSE, NULL);
+	zassert_equal(ret, _OBJ_INIT_FALSE);
 }
 
 /****************************************************************************/

--- a/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
+++ b/tests/kernel/mem_protect/mem_protect/src/mem_partition.c
@@ -27,19 +27,19 @@ ZTEST_USER(mem_protect_part, test_mem_part_assign_bss_vars_zero)
 	/* The global variable var will be inside the bounds of
 	 * ztest_mem_partition and be initialized with 1356 at boot.
 	 */
-	zassert_true(var == 1356, NULL);
+	zassert_true(var == 1356);
 
 	/* The global variable zeroed_var will be inside the bounds of
 	 * ztest_mem_partition and must be zeroed at boot size K_APP_BMEM() was
 	 * used, indicating a BSS variable.
 	 */
-	zassert_true(zeroed_var == 0, NULL);
+	zassert_true(zeroed_var == 0);
 
 	/* The global variable var will be inside the bounds of
 	 * ztest_mem_partition and must be zeroed at boot size K_APP_BMEM() was
 	 * used, indicating a BSS variable.
 	 */
-	zassert_true(bss_var == 0, NULL);
+	zassert_true(bss_var == 0);
 }
 
 K_APPMEM_PARTITION_DEFINE(part_arch);
@@ -59,7 +59,7 @@ K_APP_BMEM(part_arch) uint8_t __aligned(MEM_REGION_ALLOC)
  */
 ZTEST(mem_protect_part, test_mem_part_auto_determ_size)
 {
-	zassert_true(part_arch.size == MEM_REGION_ALLOC, NULL);
+	zassert_true(part_arch.size == MEM_REGION_ALLOC);
 	zassert_true(part_arch.start == (uintptr_t)buf_arc,
 	   "Base address of memory partition not determined at build time");
 }

--- a/tests/kernel/mem_protect/obj_validation/src/main.c
+++ b/tests/kernel/mem_protect/obj_validation/src/main.c
@@ -86,9 +86,9 @@ ZTEST(object_validation, test_generic_object)
 	struct k_sem stack_sem;
 
 	/* None of these should be even in the table */
-	zassert_false(test_object(&stack_sem, -EBADF), NULL);
-	zassert_false(test_object((struct k_sem *)&bad_sem, -EBADF), NULL);
-	zassert_false(test_object((struct k_sem *)0xFFFFFFFF, -EBADF), NULL);
+	zassert_false(test_object(&stack_sem, -EBADF));
+	zassert_false(test_object((struct k_sem *)&bad_sem, -EBADF));
+	zassert_false(test_object((struct k_sem *)0xFFFFFFFF, -EBADF));
 	object_permission_checks(&sem3, false);
 	object_permission_checks(&sem1, true);
 	object_permission_checks(&sem2, false);
@@ -106,11 +106,11 @@ ZTEST(object_validation, test_generic_object)
 	/* dynamic object table well-populated with semaphores at this point */
 	for (int i = 0; i < SEM_ARRAY_SIZE; i++) {
 		/* Should have permission granted but be uninitialized */
-		zassert_false(test_object(dyn_sem[i], -EINVAL), NULL);
+		zassert_false(test_object(dyn_sem[i], -EINVAL));
 		k_object_access_revoke(dyn_sem[i], k_current_get());
 		object_permission_checks(dyn_sem[i], false);
 		k_object_free(dyn_sem[i]);
-		zassert_false(test_object(dyn_sem[i], -EBADF), NULL);
+		zassert_false(test_object(dyn_sem[i], -EBADF));
 	}
 }
 

--- a/tests/kernel/mem_protect/stackprot/src/main.c
+++ b/tests/kernel/mem_protect/stackprot/src/main.c
@@ -112,7 +112,7 @@ static struct k_thread alt_thread_data;
  */
 ZTEST_USER(stackprot, test_stackprot)
 {
-	zassert_true(ret == TC_PASS, NULL);
+	zassert_true(ret == TC_PASS);
 	print_loop(__func__);
 }
 

--- a/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
+++ b/tests/kernel/mem_slab/mslab_api/src/test_mslab_api.c
@@ -62,7 +62,7 @@ static void tmslab_alloc_align(void *data)
 		 * TESTPOINT: To ensure that each memory block is similarly
 		 * aligned to this boundary
 		 */
-		zassert_true((uintptr_t)block[i] % BLK_ALIGN == 0U, NULL);
+		zassert_true((uintptr_t)block[i] % BLK_ALIGN == 0U);
 	}
 	for (int i = 0; i < BLK_NUM; i++) {
 		k_mem_slab_free(pslab, &block[i]);
@@ -89,16 +89,16 @@ static void tmslab_alloc_timeout(void *data)
 	err = k_mem_slab_alloc(pslab, &block_fail, K_MSEC(TIMEOUT));
 	if (IS_ENABLED(CONFIG_MULTITHREADING)) {
 		/* TESTPOINT: -EAGAIN Waiting period timed out*/
-		zassert_equal(err, -EAGAIN, NULL);
+		zassert_equal(err, -EAGAIN);
 		/*
 		 * TESTPOINT: timeout Maximum time to wait for operation to
 		 * complete (in milliseconds)
 		 */
-		zassert_true(k_uptime_delta(&tms) >= TIMEOUT, NULL);
+		zassert_true(k_uptime_delta(&tms) >= TIMEOUT);
 	} else {
 		/* If no multithreading any timeout is treated as K_NO_WAIT */
-		zassert_equal(err, -ENOMEM, NULL);
-		zassert_true(k_uptime_delta(&tms) < TIMEOUT, NULL);
+		zassert_equal(err, -ENOMEM);
+		zassert_true(k_uptime_delta(&tms) < TIMEOUT);
 	}
 
 	for (int i = 0; i < BLK_NUM; i++) {
@@ -115,30 +115,30 @@ static void tmslab_used_get(void *data)
 		zassert_true(k_mem_slab_alloc(pslab, &block[i], K_NO_WAIT) == 0,
 			     NULL);
 		/* TESTPOINT: Get the number of used blocks in a memory slab.*/
-		zassert_equal(k_mem_slab_num_used_get(pslab), i + 1, NULL);
+		zassert_equal(k_mem_slab_num_used_get(pslab), i + 1);
 		/*
 		 * TESTPOINT: Get the number of unused blocks in a memory slab.
 		 */
-		zassert_equal(k_mem_slab_num_free_get(pslab), BLK_NUM - 1 - i, NULL);
+		zassert_equal(k_mem_slab_num_free_get(pslab), BLK_NUM - 1 - i);
 	}
 
 	zassert_equal(k_mem_slab_alloc(pslab, &block_fail, K_NO_WAIT), -ENOMEM,
 		      NULL);
 	/* free get on allocation failure*/
-	zassert_equal(k_mem_slab_num_free_get(pslab), 0, NULL);
+	zassert_equal(k_mem_slab_num_free_get(pslab), 0);
 	/* used get on allocation failure*/
-	zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM, NULL);
+	zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM);
 
 	zassert_equal(k_mem_slab_alloc(pslab, &block_fail, K_MSEC(TIMEOUT)),
 		      IS_ENABLED(CONFIG_MULTITHREADING) ? -EAGAIN : -ENOMEM,
 		      NULL);
-	zassert_equal(k_mem_slab_num_free_get(pslab), 0, NULL);
-	zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM, NULL);
+	zassert_equal(k_mem_slab_num_free_get(pslab), 0);
+	zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM);
 
 	for (int i = 0; i < BLK_NUM; i++) {
 		k_mem_slab_free(pslab, &block[i]);
-		zassert_equal(k_mem_slab_num_free_get(pslab), i + 1, NULL);
-		zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM - 1 - i, NULL);
+		zassert_equal(k_mem_slab_num_free_get(pslab), i + 1);
+		zassert_equal(k_mem_slab_num_used_get(pslab), BLK_NUM - 1 - i);
 	}
 }
 
@@ -199,8 +199,8 @@ ZTEST(mslab_api, test_mslab_kinit)
 	zassert_equal(k_mem_slab_init(&mslab, tslab, BLK_SIZE + 1, BLK_NUM),
 				-EINVAL, NULL);
 	k_mem_slab_init(&mslab, tslab, BLK_SIZE, BLK_NUM);
-	zassert_equal(k_mem_slab_num_used_get(&mslab), 0, NULL);
-	zassert_equal(k_mem_slab_num_free_get(&mslab), BLK_NUM, NULL);
+	zassert_equal(k_mem_slab_num_used_get(&mslab), 0);
+	zassert_equal(k_mem_slab_num_free_get(&mslab), BLK_NUM);
 }
 
 /**
@@ -214,8 +214,8 @@ ZTEST(mslab_api, test_mslab_kinit)
  */
 ZTEST(mslab_api, test_mslab_kdefine)
 {
-	zassert_equal(k_mem_slab_num_used_get(&kmslab), 0, NULL);
-	zassert_equal(k_mem_slab_num_free_get(&kmslab), BLK_NUM, NULL);
+	zassert_equal(k_mem_slab_num_used_get(&kmslab), 0);
+	zassert_equal(k_mem_slab_num_free_get(&kmslab), BLK_NUM);
 }
 
 /**

--- a/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
+++ b/tests/kernel/mem_slab/mslab_concept/src/test_mslab_alloc_wait.c
@@ -29,7 +29,7 @@ void tmslab_alloc_wait_timeout(void *p1, void *p2, void *p3)
 
 void tmslab_alloc_wait_ok(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_mem_slab_alloc(&mslab1, &block_ok, TIMEOUT) == 0, NULL);
+	zassert_true(k_mem_slab_alloc(&mslab1, &block_ok, TIMEOUT) == 0);
 	k_sem_give(&sync_sema);
 }
 

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_attrs.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_attrs.c
@@ -16,24 +16,24 @@ static void attrs_get(struct k_msgq *q)
 	struct k_msgq_attrs attrs;
 
 	k_msgq_get_attrs(q, &attrs);
-	zassert_equal(attrs.used_msgs, 0, NULL);
+	zassert_equal(attrs.used_msgs, 0);
 
 	/*fill the queue to full*/
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(q, (void *)&send_buf[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 	}
 
 	k_msgq_get_attrs(q, &attrs);
-	zassert_equal(attrs.used_msgs, MSGQ_LEN, NULL);
+	zassert_equal(attrs.used_msgs, MSGQ_LEN);
 
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_get(q, (void *)&rec_buf[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 	}
 
 	k_msgq_get_attrs(q, &attrs);
-	zassert_equal(attrs.used_msgs, 0, NULL);
+	zassert_equal(attrs.used_msgs, 0);
 }
 
 /**
@@ -65,7 +65,7 @@ ZTEST_USER(msgq_api, test_msgq_user_attrs_get)
 
 	q = k_object_alloc(K_OBJ_MSGQ);
 	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN));
 	attrs_get(q);
 }
 #endif

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_contexts.c
@@ -29,21 +29,21 @@ static void put_msgq(struct k_msgq *pmsgq)
 
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(pmsgq, (void *)&data[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 
 		/**TESTPOINT: Check if k_msgq_peek reads msgq
 		 * in FIFO manner.
 		 * Everytime msg is enqueued, msg read should
 		 * always be the first message
 		 */
-		zassert_equal(k_msgq_peek(pmsgq, &read_data), 0, NULL);
-		zassert_equal(read_data, data[0], NULL);
+		zassert_equal(k_msgq_peek(pmsgq, &read_data), 0);
+		zassert_equal(read_data, data[0]);
 
 		/**TESTPOINT: msgq free get*/
 		zassert_equal(k_msgq_num_free_get(pmsgq),
 				MSGQ_LEN - 1 - i, NULL);
 		/**TESTPOINT: msgq used get*/
-		zassert_equal(k_msgq_num_used_get(pmsgq), i + 1, NULL);
+		zassert_equal(k_msgq_num_used_get(pmsgq), i + 1);
 	}
 }
 
@@ -53,16 +53,16 @@ static void get_msgq(struct k_msgq *pmsgq)
 	int ret;
 
 	for (int i = 0; i < MSGQ_LEN; i++) {
-		zassert_equal(k_msgq_peek(pmsgq, &read_data), 0, NULL);
+		zassert_equal(k_msgq_peek(pmsgq, &read_data), 0);
 
 		ret = k_msgq_get(pmsgq, &rx_data, K_FOREVER);
-		zassert_equal(ret, 0, NULL);
-		zassert_equal(rx_data, data[i], NULL);
+		zassert_equal(ret, 0);
+		zassert_equal(rx_data, data[i]);
 
 		/**TESTPOINT: Check if msg read is the msg deleted*/
-		zassert_equal(read_data, rx_data, NULL);
+		zassert_equal(read_data, rx_data);
 		/**TESTPOINT: msgq free get*/
-		zassert_equal(k_msgq_num_free_get(pmsgq), i + 1, NULL);
+		zassert_equal(k_msgq_num_free_get(pmsgq), i + 1);
 		/**TESTPOINT: msgq used get*/
 		zassert_equal(k_msgq_num_used_get(pmsgq),
 				MSGQ_LEN - 1 - i, NULL);
@@ -74,9 +74,9 @@ static void purge_msgq(struct k_msgq *pmsgq)
 	uint32_t read_data;
 
 	k_msgq_purge(pmsgq);
-	zassert_equal(k_msgq_num_free_get(pmsgq), MSGQ_LEN, NULL);
-	zassert_equal(k_msgq_num_used_get(pmsgq), 0, NULL);
-	zassert_equal(k_msgq_peek(pmsgq, &read_data), -ENOMSG, NULL);
+	zassert_equal(k_msgq_num_free_get(pmsgq), MSGQ_LEN);
+	zassert_equal(k_msgq_num_used_get(pmsgq), 0);
+	zassert_equal(k_msgq_peek(pmsgq, &read_data), -ENOMSG);
 }
 
 static void tisr_entry(const void *p)
@@ -113,11 +113,11 @@ static void thread_entry_overflow(void *p1, void *p2, void *p3)
 
 	ret = k_msgq_get(p1, &rx_buf[0], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = k_msgq_get(p1, &rx_buf[1], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	k_sem_give(&end_sema);
 }
@@ -128,7 +128,7 @@ static void msgq_thread_overflow(struct k_msgq *pmsgq)
 
 	ret = k_msgq_put(pmsgq, (void *)&data[0], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	/**TESTPOINT: thread-thread data passing via message queue*/
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
@@ -138,7 +138,7 @@ static void msgq_thread_overflow(struct k_msgq *pmsgq)
 
 	ret = k_msgq_put(pmsgq, (void *)&data[1], K_FOREVER);
 
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	k_sem_take(&end_sema, K_FOREVER);
 	k_thread_abort(tid);
@@ -174,7 +174,7 @@ static void pend_thread_entry(void *p1, void *p2, void *p3)
 	int ret;
 
 	ret = k_msgq_put(p1, &data[1], TIMEOUT);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 static void msgq_thread_data_passing(struct k_msgq *pmsgq)
@@ -217,7 +217,7 @@ static void get_empty_entry(void *p1, void *p2, void *p3)
 	k_sem_give(&end_sema);
 	/* blocked forever */
 	ret = k_msgq_get(p1, rx_buf, K_FOREVER);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 static void put_full_entry(void *p1, void *p2, void *p3)
@@ -225,8 +225,8 @@ static void put_full_entry(void *p1, void *p2, void *p3)
 	int ret;
 
 	/* make sure the queue is full */
-	zassert_equal(k_msgq_num_free_get(p1), 0, NULL);
-	zassert_equal(k_msgq_num_used_get(p1), 1, NULL);
+	zassert_equal(k_msgq_num_free_get(p1), 0);
+	zassert_equal(k_msgq_num_used_get(p1), 1);
 
 	ret = k_msgq_put(p1, &data[1], K_NO_WAIT);
 	zassert_equal(ret, -ENOMSG, "Put message to full queue");
@@ -238,7 +238,7 @@ static void put_full_entry(void *p1, void *p2, void *p3)
 	k_sem_give(&end_sema);
 	/* blocked forever */
 	ret = k_msgq_put(p1, &data[1], K_FOREVER);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 /**
@@ -257,7 +257,7 @@ ZTEST(msgq_api_1cpu, test_msgq_thread)
 	/**TESTPOINT: init via k_msgq_init*/
 	k_msgq_init(&msgq, tbuffer, MSG_SIZE, MSGQ_LEN);
 	ret = k_sem_init(&end_sema, 0, 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	msgq_thread(&msgq);
 	msgq_thread(&kmsgq);
@@ -274,10 +274,10 @@ ZTEST(msgq_api, test_msgq_thread_overflow)
 	/**TESTPOINT: init via k_msgq_init*/
 	k_msgq_init(&msgq, tbuffer, MSG_SIZE, 2);
 	ret = k_sem_init(&end_sema, 0, 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = k_msgq_put(&msgq, (void *)&data[0], K_FOREVER);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	msgq_thread_overflow(&msgq);
 	msgq_thread_overflow(&kmsgq);
@@ -299,9 +299,9 @@ ZTEST_USER(msgq_api, test_msgq_user_thread)
 
 	q = k_object_alloc(K_OBJ_MSGQ);
 	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN));
 	ret = k_sem_init(&end_sema, 0, 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	msgq_thread(q);
 }
@@ -317,9 +317,9 @@ ZTEST_USER(msgq_api, test_msgq_user_thread_overflow)
 
 	q = k_object_alloc(K_OBJ_MSGQ);
 	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, 1), NULL);
+	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, 1));
 	ret = k_sem_init(&end_sema, 0, 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	msgq_thread_overflow(q);
 }
@@ -350,7 +350,7 @@ ZTEST(msgq_api_1cpu, test_msgq_pend_thread)
 
 	k_msgq_init(&msgq1, tbuffer1, MSG_SIZE, 1);
 	ret = k_sem_init(&end_sema, 0, 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	msgq_thread_data_passing(&msgq1);
 }
@@ -397,7 +397,7 @@ ZTEST(msgq_api_1cpu, test_msgq_empty)
 
 	k_msgq_init(&msgq1, tbuffer1, MSG_SIZE, 1);
 	ret = k_sem_init(&end_sema, 0, 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	k_tid_t tid = k_thread_create(&tdata2, tstack2, STACK_SIZE,
 				      get_empty_entry, &msgq1, NULL,
@@ -405,16 +405,16 @@ ZTEST(msgq_api_1cpu, test_msgq_empty)
 
 	k_sem_take(&end_sema, K_FOREVER);
 	/* that getting thread is being blocked now */
-	zassert_equal(tid->base.thread_state, _THREAD_PENDING, NULL);
+	zassert_equal(tid->base.thread_state, _THREAD_PENDING);
 	/* since there is a thread is waiting for message, this queue
 	 * can't be cleanup
 	 */
 	ret = k_msgq_cleanup(&msgq1);
-	zassert_equal(ret, -EBUSY, NULL);
+	zassert_equal(ret, -EBUSY);
 
 	/* put a message to wake that getting thread */
 	ret = k_msgq_put(&msgq1, &data[0], K_NO_WAIT);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	k_thread_abort(tid);
 }
@@ -437,17 +437,17 @@ ZTEST(msgq_api_1cpu, test_msgq_full)
 
 	k_msgq_init(&msgq1, tbuffer1, MSG_SIZE, 1);
 	ret = k_sem_init(&end_sema, 0, 1);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = k_msgq_put(&msgq1, &data[0], K_NO_WAIT);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	k_tid_t tid = k_thread_create(&tdata2, tstack2, STACK_SIZE,
 					put_full_entry, &msgq1, NULL,
 					NULL, pri, 0, K_NO_WAIT);
 	k_sem_take(&end_sema, K_FOREVER);
 	/* that putting thread is being blocked now */
-	zassert_equal(tid->base.thread_state, _THREAD_PENDING, NULL);
+	zassert_equal(tid->base.thread_state, _THREAD_PENDING);
 	k_thread_abort(tid);
 }
 

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_fail.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_fail.c
@@ -13,15 +13,15 @@ static void put_fail(struct k_msgq *q)
 {
 	int ret = k_msgq_put(q, (void *)&data[0], K_NO_WAIT);
 
-	zassert_false(ret, NULL);
+	zassert_false(ret);
 	ret = k_msgq_put(q, (void *)&data[0], K_NO_WAIT);
-	zassert_false(ret, NULL);
+	zassert_false(ret);
 	/**TESTPOINT: msgq put returns -ENOMSG*/
 	ret = k_msgq_put(q, (void *)&data[1], K_NO_WAIT);
-	zassert_equal(ret, -ENOMSG, NULL);
+	zassert_equal(ret, -ENOMSG);
 	/**TESTPOINT: msgq put returns -EAGAIN*/
 	ret = k_msgq_put(q, (void *)&data[0], TIMEOUT);
-	zassert_equal(ret, -EAGAIN, NULL);
+	zassert_equal(ret, -EAGAIN);
 
 	k_msgq_purge(q);
 }
@@ -33,10 +33,10 @@ static void get_fail(struct k_msgq *q)
 	/**TESTPOINT: msgq get returns -ENOMSG*/
 	int ret = k_msgq_get(q, &rx_data, K_NO_WAIT);
 
-	zassert_equal(ret, -ENOMSG, NULL);
+	zassert_equal(ret, -ENOMSG);
 	/**TESTPOINT: msgq get returns -EAGAIN*/
 	ret = k_msgq_get(q, &rx_data, TIMEOUT);
-	zassert_equal(ret, -EAGAIN, NULL);
+	zassert_equal(ret, -EAGAIN);
 }
 
 /**
@@ -65,7 +65,7 @@ ZTEST_USER(msgq_api, test_msgq_user_put_fail)
 
 	q = k_object_alloc(K_OBJ_MSGQ);
 	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN));
 	put_fail(q);
 }
 #endif /* CONFIG_USERSPACE */
@@ -91,7 +91,7 @@ ZTEST_USER(msgq_api, test_msgq_user_get_fail)
 
 	q = k_object_alloc(K_OBJ_MSGQ);
 	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN));
 	get_fail(q);
 }
 #endif /* CONFIG_USERSPACE */

--- a/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
+++ b/tests/kernel/msgq/msgq_api/src/test_msgq_purge.c
@@ -16,7 +16,7 @@ static void tThread_entry(void *p1, void *p2, void *p3)
 {
 	int ret = k_msgq_put((struct k_msgq *)p1, (void *)&data[0], TIMEOUT);
 
-	zassert_equal(ret, -ENOMSG, NULL);
+	zassert_equal(ret, -ENOMSG);
 }
 
 static void purge_when_put(struct k_msgq *q)
@@ -26,7 +26,7 @@ static void purge_when_put(struct k_msgq *q)
 	/*fill the queue to full*/
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(q, (void *)&data[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 	}
 	/*create another thread waiting to put msg*/
 	k_thread_create(&tdata, tstack, STACK_SIZE,
@@ -40,7 +40,7 @@ static void purge_when_put(struct k_msgq *q)
 	/*verify msg put after purge*/
 	for (int i = 0; i < MSGQ_LEN; i++) {
 		ret = k_msgq_put(q, (void *)&data[i], K_NO_WAIT);
-		zassert_equal(ret, 0, NULL);
+		zassert_equal(ret, 0);
 	}
 
 	k_thread_abort(&tdata);
@@ -73,7 +73,7 @@ ZTEST_USER(msgq_api, test_msgq_user_purge_when_put)
 
 	q = k_object_alloc(K_OBJ_MSGQ);
 	zassert_not_null(q, "couldn't alloc message queue");
-	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN), NULL);
+	zassert_false(k_msgq_alloc_init(q, MSG_SIZE, MSGQ_LEN));
 
 	purge_when_put(q);
 }

--- a/tests/kernel/msgq/msgq_usage/src/main.c
+++ b/tests/kernel/msgq/msgq_usage/src/main.c
@@ -194,13 +194,13 @@ static void client_entry(void *p1, void *p2, void *p3)
 	/* query services */
 	k_msgq_put(&manager_q, client_data, K_NO_WAIT);
 	ret = k_msgq_get(&client_msgq, service_data, K_FOREVER);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	service1q = (struct k_msgq *)service_data[0];
 	service2q = (struct k_msgq *)service_data[1];
 	/* all services should be running */
-	zassert_equal(service1q, &service1_msgq, NULL);
-	zassert_equal(service2q, &service2_msgq, NULL);
+	zassert_equal(service1q, &service1_msgq);
+	zassert_equal(service2q, &service2_msgq);
 	/* let the test thread continue */
 	k_sem_give(&test_continue);
 

--- a/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
+++ b/tests/kernel/mutex/mutex_api/src/test_mutex_apis.c
@@ -35,7 +35,7 @@ static void tThread_entry_lock_forever(void *p1, void *p2, void *p3)
 
 static void tThread_entry_lock_no_wait(void *p1, void *p2, void *p3)
 {
-	zassert_true(k_mutex_lock((struct k_mutex *)p1, K_NO_WAIT) != 0, NULL);
+	zassert_true(k_mutex_lock((struct k_mutex *)p1, K_NO_WAIT) != 0);
 	TC_PRINT("bypass locked resource from spawn thread\n");
 }
 
@@ -62,7 +62,7 @@ static void tmutex_test_lock(struct k_mutex *pmutex,
 			entry_fn, pmutex, NULL, NULL,
 			K_PRIO_PREEMPT(0),
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
-	zassert_true(k_mutex_lock(pmutex, K_FOREVER) == 0, NULL);
+	zassert_true(k_mutex_lock(pmutex, K_FOREVER) == 0);
 	TC_PRINT("access resource from main thread\n");
 
 	/* wait for spawn thread to take action */
@@ -78,7 +78,7 @@ static void tmutex_test_lock_timeout(struct k_mutex *pmutex,
 			entry_fn, pmutex, NULL, NULL,
 			K_PRIO_PREEMPT(0),
 			K_USER | K_INHERIT_PERMS, K_NO_WAIT);
-	zassert_true(k_mutex_lock(pmutex, K_FOREVER) == 0, NULL);
+	zassert_true(k_mutex_lock(pmutex, K_FOREVER) == 0);
 	TC_PRINT("access resource from main thread\n");
 
 	/* wait for spawn thread to take action */

--- a/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
+++ b/tests/kernel/mutex/mutex_error_case/src/test_mutex_error.c
@@ -42,7 +42,7 @@ void ztest_post_fatal_error_hook(unsigned int reason,
 
 {
 	/* check if expected error */
-	zassert_equal(reason, K_ERR_KERNEL_OOPS, NULL);
+	zassert_equal(reason, K_ERR_KERNEL_OOPS);
 }
 
 static void tThread_entry_negative(void *p1, void *p2, void *p3)

--- a/tests/kernel/mutex/sys_mutex/src/main.c
+++ b/tests/kernel/mutex/sys_mutex/src/main.c
@@ -343,7 +343,7 @@ ZTEST_USER_OR_NOT(mutex_complex, test_mutex)
 			      priority[i], rv);
 
 		/* Catch any errors from other threads */
-		zassert_equal(tc_rc, TC_PASS, NULL);
+		zassert_equal(tc_rc, TC_PASS);
 	}
 
 	/* ~ 4 seconds have passed */
@@ -375,7 +375,7 @@ ZTEST_USER_OR_NOT(mutex_complex, test_mutex)
 			      droppri[i], rv);
 		sys_mutex_unlock(givemutex[i]);
 
-		zassert_equal(tc_rc, TC_PASS, NULL);
+		zassert_equal(tc_rc, TC_PASS);
 	}
 
 	rv = k_thread_priority_get(k_current_get());
@@ -383,7 +383,7 @@ ZTEST_USER_OR_NOT(mutex_complex, test_mutex)
 
 	k_sleep(K_SECONDS(1));     /* Give thread_11 time to run */
 
-	zassert_equal(tc_rc, TC_PASS, NULL);
+	zassert_equal(tc_rc, TC_PASS);
 
 	/* test recursive locking using a private mutex */
 

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_contexts.c
@@ -54,7 +54,7 @@ static void tpipe_put(struct k_pipe *ppipe, k_timeout_t timeout)
 			BYTES_TO_WRITE : (PIPE_LEN - i);
 		zassert_false(k_pipe_put(ppipe, &data[i], to_wt,
 					 &wt_byte, 1, timeout), NULL);
-		zassert_true(wt_byte == to_wt || wt_byte == 1, NULL);
+		zassert_true(wt_byte == to_wt || wt_byte == 1);
 	}
 }
 
@@ -70,10 +70,10 @@ static void tpipe_get(struct k_pipe *ppipe, k_timeout_t timeout)
 			BYTES_TO_READ : (PIPE_LEN - i);
 		zassert_false(k_pipe_get(ppipe, &rx_data[i], to_rd,
 					 &rd_byte, 1, timeout), NULL);
-		zassert_true(rd_byte == to_rd || rd_byte == 1, NULL);
+		zassert_true(rd_byte == to_rd || rd_byte == 1);
 	}
 	for (int i = 0; i < PIPE_LEN; i++) {
-		zassert_equal(rx_data[i], data[i], NULL);
+		zassert_equal(rx_data[i], data[i]);
 	}
 }
 
@@ -131,7 +131,7 @@ static void tpipe_put_no_wait(struct k_pipe *ppipe)
 			BYTES_TO_WRITE : (PIPE_LEN - i);
 		zassert_false(k_pipe_put(ppipe, &data[i], to_wt,
 					&wt_byte, 1, K_NO_WAIT), NULL);
-		zassert_true(wt_byte == to_wt || wt_byte == 1, NULL);
+		zassert_true(wt_byte == to_wt || wt_byte == 1);
 	}
 }
 
@@ -188,12 +188,12 @@ ZTEST(pipe_api_1cpu, test_pipe_alloc)
 {
 	int ret;
 
-	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN), NULL);
+	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN));
 
 	tpipe_kthread_to_kthread(&pipe_test_alloc);
 	k_pipe_cleanup(&pipe_test_alloc);
 
-	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, 0), NULL);
+	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, 0));
 	k_pipe_cleanup(&pipe_test_alloc);
 
 	ret = k_pipe_alloc_init(&pipe_test_alloc, 2048);
@@ -210,7 +210,7 @@ ZTEST(pipe_api, test_pipe_cleanup)
 {
 	int ret;
 
-	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN), NULL);
+	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN));
 
 	/**TESTPOINT: test if a dynamically allocated buffer can be freed*/
 	ret = k_pipe_cleanup(&pipe_test_alloc);
@@ -222,7 +222,7 @@ ZTEST(pipe_api, test_pipe_cleanup)
 	zassert_true((ret == 0) && (kpipe.buffer != NULL),
 			"Static buffer should not be freed.");
 
-	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN), NULL);
+	zassert_false(k_pipe_alloc_init(&pipe_test_alloc, PIPE_LEN));
 
 	k_tid_t tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 			thread_for_get_forever, &pipe_test_alloc, NULL,
@@ -309,10 +309,10 @@ ZTEST_USER(pipe_api_1cpu, test_pipe_user_thread2thread)
 	/**TESTPOINT: test k_object_alloc pipe*/
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 
-	zassert_true(p != NULL, NULL);
+	zassert_true(p != NULL);
 
 	/**TESTPOINT: test k_pipe_alloc_init*/
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	zassert_false(k_pipe_alloc_init(p, PIPE_LEN));
 	tpipe_thread_thread(p);
 
 }
@@ -328,8 +328,8 @@ ZTEST(pipe_api, test_resource_pool_auto_free)
 	/* Pool has 2 blocks, both should succeed if kernel object and pipe
 	 * buffer are auto-freed when the allocating threads exit
 	 */
-	zassert_true(k_heap_alloc(&test_pool, 64, K_NO_WAIT) != NULL, NULL);
-	zassert_true(k_heap_alloc(&test_pool, 64, K_NO_WAIT) != NULL, NULL);
+	zassert_true(k_heap_alloc(&test_pool, 64, K_NO_WAIT) != NULL);
+	zassert_true(k_heap_alloc(&test_pool, 64, K_NO_WAIT) != NULL);
 }
 #endif
 
@@ -355,9 +355,9 @@ ZTEST(pipe_api, test_half_pipe_put_get)
 
 	/* TESTPOINT: min_xfer > bytes_to_read */
 	ret = k_pipe_put(&kpipe, &rx_data[0], 1, &rd_byte, 24, K_NO_WAIT);
-	zassert_true(ret == -EINVAL, NULL);
+	zassert_true(ret == -EINVAL);
 	ret = k_pipe_put(&kpipe, &rx_data[0], 24, NULL, 1, K_NO_WAIT);
-	zassert_true(ret == -EINVAL, NULL);
+	zassert_true(ret == -EINVAL);
 
 	/**TESTPOINT: thread-thread data passing via pipe*/
 	k_tid_t tid1 = k_thread_create(&tdata1, tstack1, STACK_SIZE,
@@ -386,9 +386,9 @@ ZTEST(pipe_api, test_pipe_get_put)
 
 	/* TESTPOINT: min_xfer > bytes_to_read */
 	ret = k_pipe_get(&kpipe, &rx_data[0], 1, &rd_byte, 24, K_NO_WAIT);
-	zassert_true(ret == -EINVAL, NULL);
+	zassert_true(ret == -EINVAL);
 	ret = k_pipe_get(&kpipe, &rx_data[0], 24, NULL, 1, K_NO_WAIT);
-	zassert_true(ret == -EINVAL, NULL);
+	zassert_true(ret == -EINVAL);
 
 	/**TESTPOINT: thread-thread data passing via pipe*/
 	k_tid_t tid1 = k_thread_create(&tdata1, tstack1, STACK_SIZE,

--- a/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
+++ b/tests/kernel/pipe/pipe_api/src/test_pipe_fail.c
@@ -23,11 +23,11 @@ static void put_fail(struct k_pipe *p)
 	/**TESTPOINT: pipe put returns -EIO*/
 	zassert_equal(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
 				 1, K_NO_WAIT), -EIO, NULL);
-	zassert_false(wt_byte, NULL);
+	zassert_false(wt_byte);
 	/**TESTPOINT: pipe put returns -EAGAIN*/
 	zassert_equal(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
 				 1, TIMEOUT), -EAGAIN, NULL);
-	zassert_true(wt_byte < 1, NULL);
+	zassert_true(wt_byte < 1);
 	zassert_equal(k_pipe_put(p, data, PIPE_LEN, &wt_byte,
 				 PIPE_LEN + 1, TIMEOUT), -EINVAL, NULL);
 
@@ -54,12 +54,12 @@ ZTEST_USER(pipe_api_1cpu, test_pipe_user_put_fail)
 {
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	zassert_true(p != NULL);
+	zassert_false(k_pipe_alloc_init(p, PIPE_LEN));
 	/* check the number of bytes that may be read from pipe. */
-	zassert_equal(k_pipe_read_avail(p), 0, NULL);
+	zassert_equal(k_pipe_read_avail(p), 0);
 	/* check the number of bytes that may be written to pipe.*/
-	zassert_equal(k_pipe_write_avail(p), PIPE_LEN, NULL);
+	zassert_equal(k_pipe_write_avail(p), PIPE_LEN);
 
 	put_fail(p);
 }
@@ -73,11 +73,11 @@ static void get_fail(struct k_pipe *p)
 	/**TESTPOINT: pipe put returns -EIO*/
 	zassert_equal(k_pipe_get(p, rx_data, PIPE_LEN, &rd_byte, 1,
 				 K_NO_WAIT), -EIO, NULL);
-	zassert_false(rd_byte, NULL);
+	zassert_false(rd_byte);
 	/**TESTPOINT: pipe put returns -EAGAIN*/
 	zassert_equal(k_pipe_get(p, rx_data, PIPE_LEN, &rd_byte, 1,
 				 TIMEOUT), -EAGAIN, NULL);
-	zassert_true(rd_byte < 1, NULL);
+	zassert_true(rd_byte < 1);
 	zassert_equal(k_pipe_get(p, rx_data, PIPE_LEN, &rd_byte, 1,
 				 TIMEOUT), -EAGAIN, NULL);
 }
@@ -107,8 +107,8 @@ ZTEST_USER(pipe_api, test_pipe_user_get_fail)
 {
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	zassert_true(p != NULL);
+	zassert_false(k_pipe_alloc_init(p, PIPE_LEN));
 
 	get_fail(p);
 }
@@ -166,8 +166,8 @@ ZTEST_USER(pipe_api, test_pipe_get_unreach_data)
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 	size_t rd_byte = 0;
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	zassert_true(p != NULL);
+	zassert_false(k_pipe_alloc_init(p, PIPE_LEN));
 
 	ztest_set_fault_valid(true);
 	k_pipe_get(p, user_unreach, PIPE_LEN,
@@ -190,8 +190,8 @@ ZTEST_USER(pipe_api, test_pipe_get_unreach_size)
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 	unsigned char rx_data[PIPE_LEN];
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	zassert_true(p != NULL);
+	zassert_false(k_pipe_alloc_init(p, PIPE_LEN));
 
 	ztest_set_fault_valid(true);
 	k_pipe_get(p, rx_data, PIPE_LEN,
@@ -234,8 +234,8 @@ ZTEST_USER(pipe_api, test_pipe_put_unreach_data)
 	struct k_pipe *p = k_object_alloc(K_OBJ_PIPE);
 	size_t to_wt = 0, wt_byte = 0;
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	zassert_true(p != NULL);
+	zassert_false(k_pipe_alloc_init(p, PIPE_LEN));
 
 	ztest_set_fault_valid(true);
 	k_pipe_put(p, &user_unreach[0], to_wt,
@@ -259,8 +259,8 @@ ZTEST_USER(pipe_api, test_pipe_put_unreach_size)
 	unsigned char tx_data = 0xa;
 	size_t to_wt = 0;
 
-	zassert_true(p != NULL, NULL);
-	zassert_false(k_pipe_alloc_init(p, PIPE_LEN), NULL);
+	zassert_true(p != NULL);
+	zassert_false(k_pipe_alloc_init(p, PIPE_LEN));
 
 	ztest_set_fault_valid(true);
 	k_pipe_put(p, &tx_data, to_wt,

--- a/tests/kernel/poll/src/test_poll.c
+++ b/tests/kernel/poll/src/test_poll.c
@@ -100,11 +100,11 @@ ZTEST_USER(poll_api_1cpu, test_poll_no_wait)
 	 * implementation
 	 */
 
-	zassert_equal(k_poll(events, INT_MAX, K_NO_WAIT), -EINVAL, NULL);
-	zassert_equal(k_poll(events, 4096, K_NO_WAIT), -ENOMEM, NULL);
+	zassert_equal(k_poll(events, INT_MAX, K_NO_WAIT), -EINVAL);
+	zassert_equal(k_poll(events, 4096, K_NO_WAIT), -ENOMEM);
 
 	/* Allow zero events */
-	zassert_equal(k_poll(events, 0, K_NO_WAIT), -EAGAIN, NULL);
+	zassert_equal(k_poll(events, 0, K_NO_WAIT), -EAGAIN);
 
 	struct k_poll_event bad_events[] = {
 		K_POLL_EVENT_INITIALIZER(K_POLL_TYPE_SEM_AVAILABLE,
@@ -126,9 +126,9 @@ ZTEST_USER(poll_api_1cpu, test_poll_no_wait)
 #endif /* CONFIG_USERSPACE */
 
 	/* test polling events that are already ready */
-	zassert_false(k_fifo_alloc_put(&no_wait_fifo, &msg), NULL);
+	zassert_false(k_fifo_alloc_put(&no_wait_fifo, &msg));
 	k_poll_signal_raise(&no_wait_signal, SIGNAL_RESULT);
-	zassert_false(k_msgq_put(mq, msgq_msg, K_NO_WAIT), NULL);
+	zassert_false(k_msgq_put(mq, msgq_msg, K_NO_WAIT));
 
 	zassert_equal(k_poll(events, ARRAY_SIZE(events), K_NO_WAIT), 0, "");
 
@@ -149,7 +149,7 @@ ZTEST_USER(poll_api_1cpu, test_poll_no_wait)
 	zassert_equal(events[3].state, K_POLL_STATE_NOT_READY, "");
 
 	zassert_equal(events[4].state, K_POLL_STATE_MSGQ_DATA_AVAILABLE, "");
-	zassert_false(k_msgq_get(mq, msgq_recv_buf, K_NO_WAIT), NULL);
+	zassert_false(k_msgq_get(mq, msgq_recv_buf, K_NO_WAIT));
 	zassert_false(memcmp(msgq_msg, msgq_recv_buf, MSGQ_MSG_SIZE), "");
 
 	/* verify events are not ready anymore (user has to clear them first) */
@@ -785,7 +785,7 @@ ZTEST(poll_api_1cpu, test_poll_zero_events)
 	k_poll_event_init(&event, K_POLL_TYPE_SEM_AVAILABLE,
 			  K_POLL_MODE_NOTIFY_ONLY, &zero_events_sem);
 
-	zassert_equal(k_poll(&event, 0, K_MSEC(50)), -EAGAIN, NULL);
+	zassert_equal(k_poll(&event, 0, K_MSEC(50)), -EAGAIN);
 }
 
 /* subthread entry */

--- a/tests/kernel/queue/src/test_queue_contexts.c
+++ b/tests/kernel/queue/src/test_queue_contexts.c
@@ -70,23 +70,23 @@ static void tqueue_get(struct k_queue *pqueue)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_p[i], NULL);
+		zassert_equal(rx_data, (void *)&data_p[i]);
 	}
 	/*get queue data from "queue_append"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		zassert_equal(rx_data, (void *)&data[i]);
 	}
 	/*get queue data from "queue_append_list"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_l[i], NULL);
+		zassert_equal(rx_data, (void *)&data_l[i]);
 	}
 	/*get queue data from "queue_merge_slist"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_sl[i], NULL);
+		zassert_equal(rx_data, (void *)&data_sl[i]);
 	}
 }
 
@@ -260,7 +260,7 @@ static void tqueue_alloc(struct k_queue *pqueue)
 	k_queue_alloc_append(pqueue, (void *)&data_append);
 
 	/* Insertion fails and alloc returns NOMEM */
-	zassert_false(k_queue_remove(pqueue, &data_append), NULL);
+	zassert_false(k_queue_remove(pqueue, &data_append));
 
 	/* Assign resource pool of lower size */
 	k_thread_heap_assign(k_current_get(), &mem_pool_fail);
@@ -270,12 +270,12 @@ static void tqueue_alloc(struct k_queue *pqueue)
 	 */
 	k_queue_alloc_prepend(pqueue, (void *)&data_prepend);
 
-	zassert_false(k_queue_remove(pqueue, &data_prepend), NULL);
+	zassert_false(k_queue_remove(pqueue, &data_prepend));
 
 	/* No element must be present in the queue, as all
 	 * operations failed
 	 */
-	zassert_true(k_queue_is_empty(pqueue), NULL);
+	zassert_true(k_queue_is_empty(pqueue));
 
 	/* Assign resource pool of sufficient size */
 	k_thread_heap_assign(k_current_get(), &mem_pool_pass);
@@ -284,7 +284,7 @@ static void tqueue_alloc(struct k_queue *pqueue)
 		      NULL);
 
 	/* Now queue shouldn't be empty */
-	zassert_false(k_queue_is_empty(pqueue), NULL);
+	zassert_false(k_queue_is_empty(pqueue));
 
 	zassert_true(k_queue_get(pqueue, K_FOREVER) != NULL,
 		     NULL);
@@ -322,7 +322,7 @@ static void queue_poll_race_consume(void *p1, void *p2, void *p3)
 	int *count = p2;
 
 	while (true) {
-		zassert_true(k_queue_get(q, K_FOREVER) != NULL, NULL);
+		zassert_true(k_queue_get(q, K_FOREVER) != NULL);
 		*count += 1;
 	}
 }
@@ -361,12 +361,12 @@ ZTEST(queue_api_1cpu, test_queue_poll_race)
 	k_queue_append(&queue, &data[0]);
 	k_queue_append(&queue, &data[1]);
 
-	zassert_true(low_count == 0, NULL);
-	zassert_true(mid_count == 0, NULL);
+	zassert_true(low_count == 0);
+	zassert_true(mid_count == 0);
 
 	k_sleep(K_MSEC(10));
 
-	zassert_true(low_count + mid_count == 2, NULL);
+	zassert_true(low_count + mid_count == 2);
 
 	k_thread_abort(&tdata);
 	k_thread_abort(&tdata1);

--- a/tests/kernel/queue/src/test_queue_loop.c
+++ b/tests/kernel/queue/src/test_queue_loop.c
@@ -44,14 +44,14 @@ static void tqueue_get(struct k_queue *pqueue)
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data_p[i], NULL);
+		zassert_equal(rx_data, (void *)&data_p[i]);
 	}
 
 	/*get queue data from "queue_append"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue get*/
 		rx_data = k_queue_get(pqueue, K_NO_WAIT);
-		zassert_equal(rx_data, (void *)&data[i], NULL);
+		zassert_equal(rx_data, (void *)&data[i]);
 	}
 }
 
@@ -60,7 +60,7 @@ static void tqueue_find_and_remove(struct k_queue *pqueue)
 	/*remove queue data from "queue_find_and_remove"*/
 	for (int i = 0; i < LIST_LEN; i++) {
 		/**TESTPOINT: queue find and remove*/
-		zassert_true(k_queue_remove(pqueue, &data_r[i]), NULL);
+		zassert_true(k_queue_remove(pqueue, &data_r[i]));
 	}
 }
 

--- a/tests/kernel/queue/src/test_queue_user.c
+++ b/tests/kernel/queue/src/test_queue_user.c
@@ -30,9 +30,9 @@ void child_thread_get(void *p1, void *p2, void *p3)
 	struct k_queue *q = p1;
 	struct k_sem *sem = p2;
 
-	zassert_false(k_queue_is_empty(q), NULL);
+	zassert_false(k_queue_is_empty(q));
 	qd = k_queue_peek_head(q);
-	zassert_equal(qd->data, 0, NULL);
+	zassert_equal(qd->data, 0);
 	qd = k_queue_peek_tail(q);
 	zassert_equal(qd->data, (LIST_LEN * 2) - 1,
 		      "got %d expected %d", qd->data, (LIST_LEN * 2) - 1);
@@ -40,7 +40,7 @@ void child_thread_get(void *p1, void *p2, void *p3)
 	for (int i = 0; i < (LIST_LEN * 2); i++) {
 		qd = k_queue_get(q, K_FOREVER);
 
-		zassert_equal(qd->data, i, NULL);
+		zassert_equal(qd->data, i);
 		if (qd->allocated) {
 			/* snode should never have been touched */
 			zassert_is_null(qd->snode.next, NULL);
@@ -48,7 +48,7 @@ void child_thread_get(void *p1, void *p2, void *p3)
 	}
 
 
-	zassert_true(k_queue_is_empty(q), NULL);
+	zassert_true(k_queue_is_empty(q));
 
 	/* This one gets canceled */
 	qd = k_queue_get(q, K_FOREVER);
@@ -104,7 +104,7 @@ ZTEST(queue_api_1cpu, test_queue_supv_to_user)
 		qdata[i + 1].data = i + 1;
 		qdata[i + 1].allocated = true;
 		qdata[i + 1].snode.next = NULL;
-		zassert_false(k_queue_alloc_append(q, &qdata[i + 1]), NULL);
+		zassert_false(k_queue_alloc_append(q, &qdata[i + 1]));
 	}
 
 	k_thread_create(&child_thread, child_stack, STACK_SIZE,
@@ -140,15 +140,15 @@ ZTEST_USER(queue_api, test_queue_alloc_prepend_user)
 
 	for (int i = 0; i < LIST_LEN * 2; i++) {
 		qdata[i].data = i;
-		zassert_false(k_queue_alloc_prepend(q, &qdata[i]), NULL);
+		zassert_false(k_queue_alloc_prepend(q, &qdata[i]));
 	}
 
 	for (int i = (LIST_LEN * 2) - 1; i >= 0; i--) {
 		struct qdata *qd;
 
 		qd = k_queue_get(q, K_NO_WAIT);
-		zassert_true(qd != NULL, NULL);
-		zassert_equal(qd->data, i, NULL);
+		zassert_true(qd != NULL);
+		zassert_equal(qd->data, i);
 	}
 }
 
@@ -174,15 +174,15 @@ ZTEST_USER(queue_api, test_queue_alloc_append_user)
 
 	for (int i = 0; i < LIST_LEN * 2; i++) {
 		qdata[i].data = i;
-		zassert_false(k_queue_alloc_append(q, &qdata[i]), NULL);
+		zassert_false(k_queue_alloc_append(q, &qdata[i]));
 	}
 
 	for (int i = 0; i < LIST_LEN * 2; i++) {
 		struct qdata *qd;
 
 		qd = k_queue_get(q, K_NO_WAIT);
-		zassert_true(qd != NULL, NULL);
-		zassert_equal(qd->data, i, NULL);
+		zassert_true(qd != NULL);
+		zassert_equal(qd->data, i);
 	}
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
+++ b/tests/kernel/sched/schedule_api/src/test_priority_scheduling.c
@@ -43,7 +43,7 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		/* Printing alphabet corresponding to thread */
 		TC_PRINT("%c", thread_parameter);
 		/* Testing if threads are executed as per priority */
-		zassert_true((idx == thread_idx), NULL);
+		zassert_true((idx == thread_idx));
 		thread_idx = (thread_idx + 1) % (NUM_THREAD);
 
 		/* Release CPU and give chance to Ztest thread to run */

--- a/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_is_preempt_thread.c
@@ -15,38 +15,38 @@ static struct k_sem end_sema;
 static void tIsr(const void *data)
 {
 	/** TESTPOINT: The code is running at ISR. */
-	zassert_false(k_is_preempt_thread(), NULL);
+	zassert_false(k_is_preempt_thread());
 }
 
 static void tpreempt_ctx(void *p1, void *p2, void *p3)
 {
 	/** TESTPOINT: The thread's priority is in the preemptible range. */
-	zassert_true(k_is_preempt_thread(), NULL);
+	zassert_true(k_is_preempt_thread());
 	k_sched_lock();
 	/** TESTPOINT: The thread has locked the scheduler. */
-	zassert_false(k_is_preempt_thread(), NULL);
+	zassert_false(k_is_preempt_thread());
 	k_sched_unlock();
 	/** TESTPOINT: The thread has not locked the scheduler. */
-	zassert_true(k_is_preempt_thread(), NULL);
+	zassert_true(k_is_preempt_thread());
 	k_thread_priority_set(k_current_get(), K_PRIO_COOP(1));
 	/** TESTPOINT: The thread's priority is in the cooperative range. */
-	zassert_false(k_is_preempt_thread(), NULL);
+	zassert_false(k_is_preempt_thread());
 	k_sem_give(&end_sema);
 }
 
 static void tcoop_ctx(void *p1, void *p2, void *p3)
 {
 	/** TESTPOINT: The thread's priority is in the cooperative range. */
-	zassert_false(k_is_preempt_thread(), NULL);
+	zassert_false(k_is_preempt_thread());
 	k_thread_priority_set(k_current_get(), K_PRIO_PREEMPT(1));
 	/** TESTPOINT: The thread's priority is in the preemptible range. */
-	zassert_true(k_is_preempt_thread(), NULL);
+	zassert_true(k_is_preempt_thread());
 	k_sched_lock();
 	/** TESTPOINT: The thread has locked the scheduler. */
-	zassert_false(k_is_preempt_thread(), NULL);
+	zassert_false(k_is_preempt_thread());
 	k_sched_unlock();
 	/** TESTPOINT: The thread has not locked the scheduler. */
-	zassert_true(k_is_preempt_thread(), NULL);
+	zassert_true(k_is_preempt_thread());
 	k_sem_give(&end_sema);
 }
 

--- a/tests/kernel/sched/schedule_api/src/test_sched_priority.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_priority.c
@@ -59,10 +59,10 @@ ZTEST(threads_scheduling, test_priority_cooperative)
 				      thread_entry, NULL, NULL, NULL,
 				      spawn_prio, 0, K_NO_WAIT);
 	/* checkpoint: current thread shouldn't preempted by higher thread */
-	zassert_true(last_prio == k_thread_priority_get(k_current_get()), NULL);
+	zassert_true(last_prio == k_thread_priority_get(k_current_get()));
 	k_sleep(K_MSEC(100));
 	/* checkpoint: spawned thread get executed */
-	zassert_true(last_prio == spawn_prio, NULL);
+	zassert_true(last_prio == spawn_prio);
 	k_thread_abort(tid);
 
 	/* restore environment */
@@ -94,7 +94,7 @@ ZTEST(threads_scheduling, test_priority_preemptible)
 				      thread_entry, NULL, NULL, NULL,
 				      spawn_prio, 0, K_NO_WAIT);
 	/* checkpoint: thread is preempted by higher thread */
-	zassert_true(last_prio == spawn_prio, NULL);
+	zassert_true(last_prio == spawn_prio);
 
 	k_sleep(K_MSEC(100));
 	k_thread_abort(tid);
@@ -104,7 +104,7 @@ ZTEST(threads_scheduling, test_priority_preemptible)
 			      thread_entry, NULL, NULL, NULL,
 			      spawn_prio, 0, K_NO_WAIT);
 	/* checkpoint: thread is not preempted by lower thread */
-	zassert_false(last_prio == spawn_prio, NULL);
+	zassert_false(last_prio == spawn_prio);
 	k_thread_abort(tid);
 
 	/* restore environment */

--- a/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
+++ b/tests/kernel/sched/schedule_api/src/test_sched_timeslice_and_lock.c
@@ -106,10 +106,10 @@ ZTEST(threads_scheduling, test_yield_cooperative)
 	spawn_threads(0);
 	/* checkpoint: only higher priority thread get executed when yield */
 	k_yield();
-	zassert_true(tdata[0].executed == 1, NULL);
-	zassert_true(tdata[1].executed == 1, NULL);
+	zassert_true(tdata[0].executed == 1);
+	zassert_true(tdata[1].executed == 1);
 	for (int i = 2; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		zassert_true(tdata[i].executed == 0);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -133,7 +133,7 @@ ZTEST(threads_scheduling, test_sleep_cooperative)
 	/* checkpoint: all ready threads get executed when k_sleep */
 	k_sleep(K_MSEC(100));
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 1, NULL);
+		zassert_true(tdata[i].executed == 1);
 	}
 
 	/* restore environment */
@@ -150,7 +150,7 @@ ZTEST(threads_scheduling, test_busy_wait_cooperative)
 	k_busy_wait(100000); /* 100 ms */
 	/* checkpoint: No other threads get executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		zassert_true(tdata[i].executed == 0);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -178,10 +178,10 @@ ZTEST(threads_scheduling, test_sleep_wakeup_preemptible)
 	spawn_threads(10 * 1000); /* 10 second */
 	/* checkpoint: lower threads not executed, high threads are in sleep */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		zassert_true(tdata[i].executed == 0);
 	}
 	k_wakeup(tdata[0].tid);
-	zassert_true(tdata[0].executed == 1, NULL);
+	zassert_true(tdata[0].executed == 1);
 	/* restore environment */
 	teardown_threads();
 }
@@ -249,12 +249,12 @@ ZTEST(threads_scheduling, test_time_slicing_preemptible)
 	k_sched_time_slice_set(200, 0); /* 200 ms */
 	spawn_threads(0);
 	/* checkpoint: higher priority threads get executed immediately */
-	zassert_true(tdata[0].executed == 1, NULL);
+	zassert_true(tdata[0].executed == 1);
 	k_busy_wait(500000); /* 500 ms */
 	/* checkpoint: equal priority threads get executed every time slice */
-	zassert_true(tdata[1].executed == 1, NULL);
+	zassert_true(tdata[1].executed == 1);
 	for (int i = 2; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		zassert_true(tdata[i].executed == 0);
 	}
 
 	/* restore environment */
@@ -287,12 +287,12 @@ ZTEST(threads_scheduling, test_time_slicing_disable_preemptible)
 
 	spawn_threads(0);
 	/* checkpoint: higher priority threads get executed immediately */
-	zassert_true(tdata[0].executed == 1, NULL);
+	zassert_true(tdata[0].executed == 1);
 	k_busy_wait(500000); /* 500 ms */
 	/* checkpoint: equal priority threads get executed every time slice */
-	zassert_true(tdata[1].executed == 0, NULL);
+	zassert_true(tdata[1].executed == 0);
 	for (int i = 2; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		zassert_true(tdata[i].executed == 0);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -322,13 +322,13 @@ ZTEST(threads_scheduling, test_lock_preemptible)
 	k_busy_wait(100000);
 	/* checkpoint: all other threads not been executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		zassert_true(tdata[i].executed == 0);
 	}
 	/* make current thread unready */
 	k_sleep(K_MSEC(100));
 	/* checkpoint: all other threads get executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 1, NULL);
+		zassert_true(tdata[i].executed == 1);
 	}
 	/* restore environment */
 	teardown_threads();
@@ -362,9 +362,9 @@ ZTEST(threads_scheduling, test_unlock_preemptible)
 	k_yield();
 
 	/* checkpoint: higher and equal threads get executed */
-	zassert_true(tdata[0].executed == 1, NULL);
-	zassert_true(tdata[1].executed == 1, NULL);
-	zassert_true(tdata[2].executed == 0, NULL);
+	zassert_true(tdata[0].executed == 1);
+	zassert_true(tdata[1].executed == 1);
+	zassert_true(tdata[2].executed == 0);
 
 	/* restore environment */
 	teardown_threads();
@@ -403,7 +403,7 @@ ZTEST(threads_scheduling, test_unlock_nested_sched_lock)
 
 	/* checkpoint: no threads get executed */
 	for (int i = 0; i < THREADS_NUM; i++) {
-		zassert_true(tdata[i].executed == 0, NULL);
+		zassert_true(tdata[i].executed == 0);
 	}
 
 	/* unlock another; this let the higher thread to run */
@@ -413,9 +413,9 @@ ZTEST(threads_scheduling, test_unlock_nested_sched_lock)
 	k_yield();
 
 	/* checkpoint: higher threads NOT get executed */
-	zassert_true(tdata[0].executed == 1, NULL);
-	zassert_true(tdata[1].executed == 1, NULL);
-	zassert_true(tdata[2].executed == 0, NULL);
+	zassert_true(tdata[0].executed == 1);
+	zassert_true(tdata[1].executed == 1);
+	zassert_true(tdata[2].executed == 0);
 
 	/* restore environment */
 	teardown_threads();

--- a/tests/kernel/semaphore/semaphore/src/main.c
+++ b/tests/kernel/semaphore/semaphore/src/main.c
@@ -94,7 +94,7 @@ void sem_give_task(void *p1, void *p2, void *p3)
 void sem_reset_take_task(void *p1, void *p2, void *p3)
 {
 	k_sem_reset((struct k_sem *)p1);
-	zassert_false(k_sem_take((struct k_sem *)p1, K_FOREVER), NULL);
+	zassert_false(k_sem_take((struct k_sem *)p1, K_FOREVER));
 }
 
 void isr_sem_give(const void *semaphore)
@@ -186,7 +186,7 @@ void sem_queue_mutual_exclusion1(void *p1, void *p2, void *p3)
 		 * when semaphore is taken by current thread, and no other
 		 * thread can enter the critical section
 		 */
-		zassert_true(critical_var == tmp + 1, NULL);
+		zassert_true(critical_var == tmp + 1);
 		k_sem_give(&mut_sem);
 	}
 }
@@ -205,7 +205,7 @@ void sem_queue_mutual_exclusion2(void *p1, void *p2, void *p3)
 		 * when semaphore is taken by current thread, and no other
 		 * thread can enter the critical section
 		 */
-		zassert_true(critical_var == tmp - 1, NULL);
+		zassert_true(critical_var == tmp - 1);
 		k_sem_give(&mut_sem);
 	}
 }

--- a/tests/kernel/smp/src/main.c
+++ b/tests/kernel/smp/src/main.c
@@ -720,7 +720,7 @@ ZTEST(smp, test_workq_on_smp)
 	k_busy_wait(DELAY_US);
 
 	/* check work have finished */
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
 
 	main_thread_id = curr_cpu();
 

--- a/tests/kernel/stack/stack/src/test_stack_contexts.c
+++ b/tests/kernel/stack/stack/src/test_stack_contexts.c
@@ -40,8 +40,8 @@ static void tstack_pop(struct k_stack *pstack)
 
 	for (int i = STACK_LEN - 1; i >= 0; i--) {
 		/**TESTPOINT: stack pop*/
-		zassert_false(k_stack_pop(pstack, &rx_data, K_NO_WAIT), NULL);
-		zassert_equal(rx_data, data[i], NULL);
+		zassert_false(k_stack_pop(pstack, &rx_data, K_NO_WAIT));
+		zassert_equal(rx_data, data[i]);
 	}
 }
 

--- a/tests/kernel/stack/stack/src/test_stack_fail.c
+++ b/tests/kernel/stack/stack/src/test_stack_fail.c
@@ -22,9 +22,9 @@ static void stack_pop_fail(struct k_stack *stack)
 	stack_data_t rx_data;
 
 	/**TESTPOINT: stack pop returns -EBUSY*/
-	zassert_equal(k_stack_pop(stack, &rx_data, K_NO_WAIT), -EBUSY, NULL);
+	zassert_equal(k_stack_pop(stack, &rx_data, K_NO_WAIT), -EBUSY);
 	/**TESTPOINT: stack pop returns -EAGAIN*/
-	zassert_equal(k_stack_pop(stack, &rx_data, TIMEOUT), -EAGAIN, NULL);
+	zassert_equal(k_stack_pop(stack, &rx_data, TIMEOUT), -EAGAIN);
 }
 
 /**

--- a/tests/kernel/threads/no-multithreading/src/main.c
+++ b/tests/kernel/threads/no-multithreading/src/main.c
@@ -27,7 +27,7 @@ ZTEST(no_multithreading, test_k_busy_wait)
 
 	int64_t diff = k_uptime_get() - now;
 
-	zassert_within(diff, 10, 2, NULL);
+	zassert_within(diff, 10, 2);
 }
 
 static void timeout_handler(struct k_timer *timer)

--- a/tests/kernel/threads/thread_apis/src/main.c
+++ b/tests/kernel/threads/thread_apis/src/main.c
@@ -40,7 +40,7 @@ static ZTEST_DMEM int tp = 10;
  */
 ZTEST(threads_lifecycle, test_systhreads_main)
 {
-	zassert_true(main_prio == CONFIG_MAIN_THREAD_PRIORITY, NULL);
+	zassert_true(main_prio == CONFIG_MAIN_THREAD_PRIORITY);
 }
 
 /**
@@ -65,7 +65,7 @@ static void customdata_entry(void *p1, void *p2, void *p3)
 		/* relinquish cpu for a while */
 		k_msleep(50);
 		/** TESTPOINT: custom data comparison */
-		zassert_equal(data, (long)k_thread_custom_data_get(), NULL);
+		zassert_equal(data, (long)k_thread_custom_data_get());
 		data++;
 	}
 }
@@ -309,7 +309,7 @@ void do_join_from_isr(const void *arg)
 {
 	int *ret = (int *)arg;
 
-	zassert_true(k_is_in_isr(), NULL);
+	zassert_true(k_is_in_isr());
 	printk("isr: joining join_thread\n");
 	*ret = k_thread_join(&join_thread, K_NO_WAIT);
 	printk("isr: k_thread_join() returned with %d\n", *ret);
@@ -486,16 +486,16 @@ ZTEST_USER(threads_lifecycle, test_thread_timeout_remaining_expires)
 	e = k_thread_timeout_expires_ticks(tid);
 	TC_PRINT("thread_expires_ticks: %d, expect: %d\n", (int)e,
 		(int)expected_expires_ticks);
-	zassert_true(e >= expected_expires_ticks, NULL);
+	zassert_true(e >= expected_expires_ticks);
 
 	k_msleep(10);
 	r = k_thread_timeout_remaining_ticks(tid);
-	zassert_true(r < ticks, NULL);
+	zassert_true(r < ticks);
 	r1 = r;
 
 	k_msleep(10);
 	r = k_thread_timeout_remaining_ticks(tid);
-	zassert_true(r < r1, NULL);
+	zassert_true(r < r1);
 
 	k_thread_abort(tid);
 }
@@ -512,9 +512,9 @@ static void foreach_callback(const struct k_thread *thread, void *user_data)
 
 	/* Check NULL parameters */
 	ret = k_thread_runtime_stats_get(NULL, &stats);
-	zassert_true(ret == -EINVAL, NULL);
+	zassert_true(ret == -EINVAL);
 	ret = k_thread_runtime_stats_get((k_tid_t)thread, NULL);
-	zassert_true(ret == -EINVAL, NULL);
+	zassert_true(ret == -EINVAL);
 
 	k_thread_runtime_stats_get((k_tid_t)thread, &stats);
 	((k_thread_runtime_stats_t *)user_data)->execution_cycles +=
@@ -536,11 +536,11 @@ ZTEST(threads_lifecycle, test_thread_runtime_stats_get)
 
 	/* Check NULL parameters */
 	ret = k_thread_runtime_stats_all_get(NULL);
-	zassert_true(ret == -EINVAL, NULL);
+	zassert_true(ret == -EINVAL);
 
 	k_thread_runtime_stats_all_get(&stats_all);
 
-	zassert_true(stats.execution_cycles <= stats_all.execution_cycles, NULL);
+	zassert_true(stats.execution_cycles <= stats_all.execution_cycles);
 }
 
 ZTEST(threads_lifecycle, test_k_busy_wait)
@@ -559,7 +559,7 @@ ZTEST(threads_lifecycle, test_k_busy_wait)
 	 * their cycle rate)
 	 */
 	dt = test_stats.execution_cycles - cycles;
-	zassert_true(dt < k_ms_to_cyc_ceil64(10), NULL);
+	zassert_true(dt < k_ms_to_cyc_ceil64(10));
 
 	cycles = test_stats.execution_cycles;
 	k_busy_wait(100);
@@ -567,7 +567,7 @@ ZTEST(threads_lifecycle, test_k_busy_wait)
 
 	/* execution_cycles increases correctly */
 	dt = test_stats.execution_cycles - cycles;
-	zassert_true(dt >= k_us_to_cyc_floor64(100), NULL);
+	zassert_true(dt >= k_us_to_cyc_floor64(100));
 }
 
 static void tp_entry(void *p1, void *p2, void *p3)
@@ -585,11 +585,11 @@ ZTEST_USER(threads_lifecycle_1cpu, test_k_busy_wait_user)
 	/* this is a 1cpu test case, the new thread has no chance to be
 	 * scheduled and value of tp not changed
 	 */
-	zassert_false(tp == 100, NULL);
+	zassert_false(tp == 100);
 
 	/* give up cpu, the new thread will change value of tp to 100 */
 	k_msleep(100);
-	zassert_true(tp == 100, NULL);
+	zassert_true(tp == 100);
 	k_thread_abort(tid);
 }
 
@@ -625,7 +625,7 @@ ZTEST_USER(threads_lifecycle, test_k_thread_stack_space_get_user)
 	 * but it is not the case in native_posix, qemu_leon3 and
 	 * qemu_cortex_a53. Relax check condition here
 	 */
-	zassert_true(b <= a, NULL);
+	zassert_true(b <= a);
 }
 
 void *thread_test_setup(void)

--- a/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
+++ b/tests/kernel/threads/thread_apis/src/test_kthread_for_each.c
@@ -224,44 +224,44 @@ ZTEST(threads_lifecycle_1cpu, test_k_thread_state_str)
 
 	tid->base.thread_state = 0;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "") == 0, NULL);
+	zassert_true(strcmp(str, "") == 0);
 
 	tid->base.thread_state = _THREAD_DUMMY;
 
 	str = k_thread_state_str(tid, NULL, sizeof(state_str));
-	zassert_true(strcmp(str, "") == 0, NULL);
+	zassert_true(strcmp(str, "") == 0);
 
 	str = k_thread_state_str(tid, state_str, 0);
-	zassert_true(strcmp(str, "") == 0, NULL);
+	zassert_true(strcmp(str, "") == 0);
 
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "dummy") == 0, NULL);
+	zassert_true(strcmp(str, "dummy") == 0);
 
 	tid->base.thread_state = _THREAD_PENDING;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "pending") == 0, NULL);
+	zassert_true(strcmp(str, "pending") == 0);
 
 	tid->base.thread_state = _THREAD_PRESTART;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "prestart") == 0, NULL);
+	zassert_true(strcmp(str, "prestart") == 0);
 
 	tid->base.thread_state = _THREAD_DEAD;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "dead") == 0, NULL);
+	zassert_true(strcmp(str, "dead") == 0);
 
 	tid->base.thread_state = _THREAD_SUSPENDED;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "suspended") == 0, NULL);
+	zassert_true(strcmp(str, "suspended") == 0);
 
 	tid->base.thread_state = _THREAD_ABORTING;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "aborting") == 0, NULL);
+	zassert_true(strcmp(str, "aborting") == 0);
 
 	tid->base.thread_state = _THREAD_QUEUED;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "queued") == 0, NULL);
+	zassert_true(strcmp(str, "queued") == 0);
 
 	tid->base.thread_state = _THREAD_PENDING | _THREAD_SUSPENDED;
 	str = k_thread_state_str(tid, state_str, sizeof(state_str));
-	zassert_true(strcmp(str, "pending+suspended") == 0, NULL);
+	zassert_true(strcmp(str, "pending+suspended") == 0);
 }

--- a/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_cancel_abort.c
@@ -27,7 +27,7 @@ static void thread_entry_abort(void *p1, void *p2, void *p3)
 	k_thread_abort(k_current_get());
 	/*unreachable*/
 	execute_flag = 2;
-	zassert_true(1 == 0, NULL);
+	zassert_true(1 == 0);
 }
 /**
  * @ingroup kernel_thread_tests
@@ -46,7 +46,7 @@ ZTEST_USER(threads_lifecycle, test_threads_abort_self)
 			NULL, NULL, NULL, 0, K_USER, K_NO_WAIT);
 	k_msleep(100);
 	/**TESTPOINT: spawned thread executed but abort itself*/
-	zassert_true(execute_flag == 1, NULL);
+	zassert_true(execute_flag == 1);
 }
 
 /**
@@ -69,7 +69,7 @@ ZTEST_USER(threads_lifecycle, test_threads_abort_others)
 	k_thread_abort(tid);
 	k_msleep(100);
 	/**TESTPOINT: check not-started thread is aborted*/
-	zassert_true(execute_flag == 0, NULL);
+	zassert_true(execute_flag == 0);
 
 	tid = k_thread_create(&tdata, tstack, STACK_SIZE,
 			      thread_entry, NULL, NULL, NULL,
@@ -77,9 +77,9 @@ ZTEST_USER(threads_lifecycle, test_threads_abort_others)
 	k_msleep(50);
 	k_thread_abort(tid);
 	/**TESTPOINT: check running thread is aborted*/
-	zassert_true(execute_flag == 1, NULL);
+	zassert_true(execute_flag == 1);
 	k_msleep(1000);
-	zassert_true(execute_flag == 1, NULL);
+	zassert_true(execute_flag == 1);
 }
 
 /**

--- a/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_spawn.c
@@ -17,15 +17,15 @@ static ZTEST_BMEM int spawn_prio;
 static void thread_entry_params(void *p1, void *p2, void *p3)
 {
 	/* checkpoint: check parameter 1, 2, 3 */
-	zassert_equal(p1, tp1, NULL);
-	zassert_equal(POINTER_TO_INT(p2), tp2, NULL);
-	zassert_equal(p3, tp3, NULL);
+	zassert_equal(p1, tp1);
+	zassert_equal(POINTER_TO_INT(p2), tp2);
+	zassert_equal(p3, tp3);
 }
 
 static void thread_entry_priority(void *p1, void *p2, void *p3)
 {
 	/* checkpoint: check priority */
-	zassert_equal(k_thread_priority_get(k_current_get()), spawn_prio, NULL);
+	zassert_equal(k_thread_priority_get(k_current_get()), spawn_prio);
 }
 
 static void thread_entry_delay(void *p1, void *p2, void *p3)
@@ -89,10 +89,10 @@ ZTEST_USER(threads_lifecycle, test_threads_spawn_delay)
 	/* 100 < 120 ensure spawn thread not start */
 	k_msleep(100);
 	/* checkpoint: check spawn thread not execute */
-	zassert_true(tp2 == 10, NULL);
+	zassert_true(tp2 == 10);
 	/* checkpoint: check spawn thread executed */
 	k_msleep(100);
-	zassert_true(tp2 == 100, NULL);
+	zassert_true(tp2 == 100);
 }
 
 /**
@@ -119,11 +119,11 @@ ZTEST(threads_lifecycle, test_threads_spawn_forever)
 				      K_USER, K_FOREVER);
 	k_yield();
 	/* checkpoint: check spawn thread not execute */
-	zassert_true(tp2 == 10, NULL);
+	zassert_true(tp2 == 10);
 	/* checkpoint: check spawn thread executed */
 	k_thread_start(tid);
 	k_yield();
-	zassert_true(tp2 == 100, NULL);
+	zassert_true(tp2 == 100);
 	k_thread_abort(tid);
 }
 
@@ -146,7 +146,7 @@ ZTEST(threads_lifecycle, test_thread_start)
 
 	k_thread_start(tid);
 	k_yield();
-	zassert_true(tp2 == 100, NULL);
+	zassert_true(tp2 == 100);
 
 	/* checkpoint: k_thread_start() should not start the
 	 * terminated thread
@@ -155,7 +155,7 @@ ZTEST(threads_lifecycle, test_thread_start)
 	tp2 = 50;
 	k_thread_start(tid);
 	k_yield();
-	zassert_false(tp2 == 100, NULL);
+	zassert_false(tp2 == 100);
 }
 
 static void user_start_thread(void *p1, void *p2, void *p3)
@@ -173,6 +173,6 @@ ZTEST_USER(threads_lifecycle, test_thread_start_user)
 
 	k_thread_start(tid);
 	k_msleep(100);
-	zassert_true(tp2 == 100, NULL);
+	zassert_true(tp2 == 100);
 	k_thread_abort(tid);
 }

--- a/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
+++ b/tests/kernel/threads/thread_apis/src/test_threads_suspend_resume.c
@@ -31,11 +31,11 @@ static void threads_suspend_resume(int prio)
 	k_thread_suspend(tid);
 	k_msleep(100);
 	/* checkpoint: created thread shouldn't be executed after suspend */
-	zassert_false(last_prio == create_prio, NULL);
+	zassert_false(last_prio == create_prio);
 	k_thread_resume(tid);
 	k_msleep(100);
 	/* checkpoint: created thread should be executed after resume */
-	zassert_true(last_prio == create_prio, NULL);
+	zassert_true(last_prio == create_prio);
 }
 
 /*test cases*/
@@ -165,19 +165,19 @@ ZTEST(threads_lifecycle, test_resume_unsuspend_thread)
 
 	/* Resume an unsuspend thread will not change the thread state. */
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "queued") == 0, NULL);
+	zassert_true(strcmp(str, "queued") == 0);
 	k_thread_resume(tid);
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "queued") == 0, NULL);
+	zassert_true(strcmp(str, "queued") == 0);
 
 	/* suspend created thread */
 	k_thread_suspend(tid);
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "suspended") == 0, NULL);
+	zassert_true(strcmp(str, "suspended") == 0);
 
 	/* Resume an suspend thread will make it to be next eligible.*/
 	k_thread_resume(tid);
 	str = k_thread_state_str(tid, buffer, sizeof(buffer));
-	zassert_true(strcmp(str, "queued") == 0, NULL);
+	zassert_true(strcmp(str, "queued") == 0);
 	k_thread_abort(tid);
 }

--- a/tests/kernel/threads/thread_init/src/main.c
+++ b/tests/kernel/threads/thread_init/src/main.c
@@ -73,10 +73,10 @@ static void thread_entry(void *p1, void *p2, void *p3)
 
 	k_tid_t tid = k_current_get();
 	/**TESTPOINT: check priority and params*/
-	zassert_equal(k_thread_priority_get(tid), expected.init_prio, NULL);
-	zassert_equal(p1, expected.init_p1, NULL);
-	zassert_equal(p2, expected.init_p2, NULL);
-	zassert_equal(p3, expected.init_p3, NULL);
+	zassert_equal(k_thread_priority_get(tid), expected.init_prio);
+	zassert_equal(p1, expected.init_p1);
+	zassert_equal(p2, expected.init_p2);
+	zassert_equal(p3, expected.init_p3);
 	/*option, stack size, not checked, no public API to get these values*/
 
 	k_sem_give(&end_sema);

--- a/tests/kernel/tickless/tickless_concept/src/main.c
+++ b/tests/kernel/tickless/tickless_concept/src/main.c
@@ -53,9 +53,9 @@ static void thread_tslice(void *p1, void *p2, void *p3)
 		t, SLICE_SIZE, SLICE_SIZE_LIMIT);
 
 	/**TESTPOINT: verify slicing scheduler behaves as expected*/
-	zassert_true(t >= SLICE_SIZE, NULL);
+	zassert_true(t >= SLICE_SIZE);
 	/*less than one tick delay*/
-	zassert_true(t <= SLICE_SIZE_LIMIT, NULL);
+	zassert_true(t <= SLICE_SIZE_LIMIT);
 
 	/*keep the current thread busy for more than one slice*/
 	k_busy_wait(1000 * SLEEP_TICKLESS);
@@ -84,7 +84,7 @@ ZTEST(tickless_concept, test_tickless_sysclock)
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickless idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKLESS, NULL);
+	zassert_true((t1 - t0) >= SLEEP_TICKLESS);
 
 	ALIGN_MS_BOUNDARY();
 	t0 = k_uptime_get_32();
@@ -92,7 +92,7 @@ ZTEST(tickless_concept, test_tickless_sysclock)
 	t1 = k_uptime_get_32();
 	TC_PRINT("time %d, %d\n", t0, t1);
 	/**TESTPOINT: verify system clock recovery after exiting tickful idle*/
-	zassert_true((t1 - t0) >= SLEEP_TICKFUL, NULL);
+	zassert_true((t1 - t0) >= SLEEP_TICKFUL);
 }
 
 /**

--- a/tests/kernel/timer/timer_api/src/main.c
+++ b/tests/kernel/timer/timer_api/src/main.c
@@ -71,7 +71,7 @@ static ZTEST_BMEM struct timer_data tdata;
 	do {					 \
 		if (!(exp)) {			 \
 			k_timer_stop(tmr);	 \
-			zassert_true(exp, NULL); \
+			zassert_true(exp); \
 		}				 \
 	} while (0)
 
@@ -516,11 +516,11 @@ ZTEST_USER(timer_api, test_timer_status_sync)
 	init_timer_data();
 	k_timer_start(&status_sync_timer, K_MSEC(DURATION), K_MSEC(PERIOD));
 	busy_wait_ms(PERIOD*2);
-	zassert_true(k_timer_status_sync(&status_sync_timer), NULL);
+	zassert_true(k_timer_status_sync(&status_sync_timer));
 
 	/* cleanup environment */
 	k_timer_stop(&status_sync_timer);
-	zassert_false(k_timer_status_sync(&status_sync_timer), NULL);
+	zassert_false(k_timer_status_sync(&status_sync_timer));
 }
 
 /**
@@ -633,7 +633,7 @@ ZTEST_USER(timer_api, test_timer_user_data)
 				      (void *)user_data[ii]);
 		check = (intptr_t)k_timer_user_data_get(user_data_timer[ii]);
 
-		zassert_true(check == user_data[ii], NULL);
+		zassert_true(check == user_data[ii]);
 	}
 
 	for (ii = 0; ii < 5; ii++) {
@@ -656,7 +656,7 @@ ZTEST_USER(timer_api, test_timer_user_data)
 	}
 
 	for (ii = 0; ii < 5; ii++) {
-		zassert_true(user_data_correct[ii], NULL);
+		zassert_true(user_data_correct[ii]);
 	}
 }
 
@@ -741,16 +741,16 @@ ZTEST_USER(timer_api, test_timeout_abs)
 	 * the same (whiteboxed) converted values
 	 */
 	t2 = K_TIMEOUT_ABS_MS(exp_ms);
-	zassert_true(t2.ticks == t.ticks, NULL);
+	zassert_true(t2.ticks == t.ticks);
 
 	t2 = K_TIMEOUT_ABS_US(1000 * exp_ms);
-	zassert_true(t2.ticks == t.ticks, NULL);
+	zassert_true(t2.ticks == t.ticks);
 
 	t2 = K_TIMEOUT_ABS_NS(1000 * 1000 * exp_ms);
-	zassert_true(t2.ticks == t.ticks, NULL);
+	zassert_true(t2.ticks == t.ticks);
 
 	t2 = K_TIMEOUT_ABS_CYC(k_ms_to_cyc_ceil64(exp_ms));
-	zassert_true(t2.ticks == t.ticks, NULL);
+	zassert_true(t2.ticks == t.ticks);
 
 	/* Now set the timeout and make sure the expiration time is
 	 * correct vs. current time.  Tick units and tick alignment

--- a/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
+++ b/tests/kernel/usage/thread_runtime_stats/src/test_thread_runtime_stats.c
@@ -103,14 +103,14 @@ ZTEST(usage_api, test_all_stats_usage)
 	 * system has been idle yet.
 	 */
 
-	zassert_true(stats2.execution_cycles > stats1.execution_cycles, NULL);
-	zassert_true(stats3.execution_cycles > stats2.execution_cycles, NULL);
-	zassert_true(stats1.execution_cycles == stats1.total_cycles, NULL);
-	zassert_true(stats2.execution_cycles == stats2.total_cycles, NULL);
-	zassert_true(stats3.execution_cycles == stats3.total_cycles, NULL);
+	zassert_true(stats2.execution_cycles > stats1.execution_cycles);
+	zassert_true(stats3.execution_cycles > stats2.execution_cycles);
+	zassert_true(stats1.execution_cycles == stats1.total_cycles);
+	zassert_true(stats2.execution_cycles == stats2.total_cycles);
+	zassert_true(stats3.execution_cycles == stats3.total_cycles);
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-	zassert_true(stats1.idle_cycles == stats2.idle_cycles, NULL);
-	zassert_true(stats1.idle_cycles == stats3.idle_cycles, NULL);
+	zassert_true(stats1.idle_cycles == stats2.idle_cycles);
+	zassert_true(stats1.idle_cycles == stats3.idle_cycles);
 #endif
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
@@ -124,20 +124,20 @@ ZTEST(usage_api, test_all_stats_usage)
 	 * 4. [current_cycles] matches [execution_cycles].
 	 */
 
-	zassert_true(stats2.current_cycles > stats1.current_cycles, NULL);
-	zassert_true(stats3.current_cycles > stats2.current_cycles, NULL);
+	zassert_true(stats2.current_cycles > stats1.current_cycles);
+	zassert_true(stats3.current_cycles > stats2.current_cycles);
 
-	zassert_true(stats1.peak_cycles == stats1.current_cycles, NULL);
-	zassert_true(stats2.peak_cycles == stats2.current_cycles, NULL);
-	zassert_true(stats3.peak_cycles == stats3.current_cycles, NULL);
+	zassert_true(stats1.peak_cycles == stats1.current_cycles);
+	zassert_true(stats2.peak_cycles == stats2.current_cycles);
+	zassert_true(stats3.peak_cycles == stats3.current_cycles);
 
-	zassert_true(stats1.average_cycles == 0, NULL);
-	zassert_true(stats2.average_cycles == 0, NULL);
-	zassert_true(stats3.average_cycles == 0, NULL);
+	zassert_true(stats1.average_cycles == 0);
+	zassert_true(stats2.average_cycles == 0);
+	zassert_true(stats3.average_cycles == 0);
 
-	zassert_true(stats1.current_cycles == stats1.execution_cycles, NULL);
-	zassert_true(stats2.current_cycles == stats2.execution_cycles, NULL);
-	zassert_true(stats3.current_cycles == stats3.execution_cycles, NULL);
+	zassert_true(stats1.current_cycles == stats1.execution_cycles);
+	zassert_true(stats2.current_cycles == stats2.execution_cycles);
+	zassert_true(stats3.current_cycles == stats3.execution_cycles);
 #endif
 
 	/*
@@ -151,32 +151,32 @@ ZTEST(usage_api, test_all_stats_usage)
 	 * 6. [idle_cycles] increased once.
 	 */
 
-	zassert_true(stats4.execution_cycles > stats3.execution_cycles, NULL);
-	zassert_true(stats5.execution_cycles > stats4.execution_cycles, NULL);
+	zassert_true(stats4.execution_cycles > stats3.execution_cycles);
+	zassert_true(stats5.execution_cycles > stats4.execution_cycles);
 
 	/*
 	 * If the frequency is low enough, the [total_cycles] might not
 	 * increase between sample points 3 and 4. Count this as acceptable.
 	 */
 
-	zassert_true(stats4.total_cycles >= stats3.total_cycles, NULL);
-	zassert_true(stats5.total_cycles > stats4.total_cycles, NULL);
+	zassert_true(stats4.total_cycles >= stats3.total_cycles);
+	zassert_true(stats5.total_cycles > stats4.total_cycles);
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
-	zassert_true(stats4.current_cycles <= stats1.current_cycles, NULL);
-	zassert_true(stats5.current_cycles > stats4.current_cycles, NULL);
+	zassert_true(stats4.current_cycles <= stats1.current_cycles);
+	zassert_true(stats5.current_cycles > stats4.current_cycles);
 
 	zassert_true(TEST_WITHIN_X_PERCENT(stats4.peak_cycles,
 					   stats3.peak_cycles, IDLE_EVENT_STATS_PRECISION), NULL);
-	zassert_true(stats4.peak_cycles == stats5.peak_cycles, NULL);
+	zassert_true(stats4.peak_cycles == stats5.peak_cycles);
 
-	zassert_true(stats4.average_cycles > stats3.average_cycles, NULL);
-	zassert_true(stats5.average_cycles > stats4.average_cycles, NULL);
+	zassert_true(stats4.average_cycles > stats3.average_cycles);
+	zassert_true(stats5.average_cycles > stats4.average_cycles);
 #endif
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-	zassert_true(stats4.idle_cycles > stats3.idle_cycles, NULL);
-	zassert_true(stats4.idle_cycles == stats5.idle_cycles, NULL);
+	zassert_true(stats4.idle_cycles > stats3.idle_cycles);
+	zassert_true(stats4.idle_cycles == stats5.idle_cycles);
 #endif
 }
 
@@ -240,7 +240,7 @@ ZTEST(usage_api, test_thread_stats_enable_disable)
 
 	zassert_true(helper_stats1.execution_cycles ==
 		     helper_stats2.execution_cycles, NULL);
-	zassert_true(stats1.execution_cycles < stats2.execution_cycles, NULL);
+	zassert_true(stats1.execution_cycles < stats2.execution_cycles);
 
 	/*
 	 * Verify that between sample sets 2 and 3 that additional stats were
@@ -307,18 +307,18 @@ ZTEST(usage_api, test_sys_stats_enable_disable)
 
 	zassert_true(sys_stats1.execution_cycles == sys_stats2.execution_cycles,
 		     NULL);
-	zassert_true(sys_stats1.total_cycles == sys_stats2.total_cycles, NULL);
+	zassert_true(sys_stats1.total_cycles == sys_stats2.total_cycles);
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
 	zassert_true(sys_stats1.current_cycles == sys_stats2.current_cycles,
 		     NULL);
-	zassert_true(sys_stats1.peak_cycles == sys_stats2.peak_cycles, NULL);
+	zassert_true(sys_stats1.peak_cycles == sys_stats2.peak_cycles);
 	zassert_true(sys_stats1.average_cycles == sys_stats2.average_cycles,
 		     NULL);
 #endif
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-	zassert_true(sys_stats1.idle_cycles == sys_stats2.idle_cycles, NULL);
+	zassert_true(sys_stats1.idle_cycles == sys_stats2.idle_cycles);
 #endif
 
 	/*
@@ -343,7 +343,7 @@ ZTEST(usage_api, test_sys_stats_enable_disable)
 
 	zassert_true(sys_stats2.execution_cycles < sys_stats3.execution_cycles,
 		     NULL);
-	zassert_true(sys_stats2.total_cycles < sys_stats3.total_cycles, NULL);
+	zassert_true(sys_stats2.total_cycles < sys_stats3.total_cycles);
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
 
@@ -355,14 +355,14 @@ ZTEST(usage_api, test_sys_stats_enable_disable)
 
 	zassert_true(sys_stats2.current_cycles != sys_stats3.current_cycles,
 		     NULL);
-	zassert_true(sys_stats2.current_cycles != 0, NULL);
-	zassert_true(sys_stats2.peak_cycles == sys_stats3.peak_cycles, NULL);
+	zassert_true(sys_stats2.current_cycles != 0);
+	zassert_true(sys_stats2.peak_cycles == sys_stats3.peak_cycles);
 	zassert_true(sys_stats2.average_cycles > sys_stats3.average_cycles,
 		     NULL);
 #endif
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-	zassert_true(sys_stats2.idle_cycles == sys_stats3.idle_cycles, NULL);
+	zassert_true(sys_stats2.idle_cycles == sys_stats3.idle_cycles);
 #endif
 }
 #else
@@ -404,10 +404,10 @@ ZTEST(usage_api, test_thread_stats_usage)
 	 */
 
 	status = k_thread_runtime_stats_get(NULL, &stats1);
-	zassert_true(status == -EINVAL, NULL);
+	zassert_true(status == -EINVAL);
 
 	status = k_thread_runtime_stats_get(_current, NULL);
-	zassert_true(status == -EINVAL, NULL);
+	zassert_true(status == -EINVAL);
 
 	/* Align to the next tick */
 
@@ -426,12 +426,12 @@ ZTEST(usage_api, test_thread_stats_usage)
 
 	/* Verify thread creation succeeded */
 
-	zassert_true(tid == &helper_thread, NULL);
+	zassert_true(tid == &helper_thread);
 
 	/* Get a valid set of thread runtime stats */
 
 	status = k_thread_runtime_stats_get(tid, &stats1);
-	zassert_true(status == 0, NULL);
+	zassert_true(status == 0);
 
 	/*
 	 * Suspend main thread. Timer will wake it 1 tick to sample
@@ -492,11 +492,11 @@ ZTEST(usage_api, test_thread_stats_usage)
 
 	/* Verify execution_cycles are identical to total_cycles */
 
-	zassert_true(stats1.execution_cycles == stats1.total_cycles, NULL);
-	zassert_true(stats2.execution_cycles == stats2.total_cycles, NULL);
+	zassert_true(stats1.execution_cycles == stats1.total_cycles);
+	zassert_true(stats2.execution_cycles == stats2.total_cycles);
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ALL
-	zassert_true(stats3.idle_cycles == 0, NULL);
+	zassert_true(stats3.idle_cycles == 0);
 #endif
 
 	/*
@@ -511,27 +511,27 @@ ZTEST(usage_api, test_thread_stats_usage)
 	diff12 = stats2.execution_cycles - stats1.execution_cycles;
 	diff23 = stats3.execution_cycles - stats2.execution_cycles;
 
-	zassert_true(diff12 > diff23, NULL);
+	zassert_true(diff12 > diff23);
 
 #ifdef CONFIG_SCHED_THREAD_USAGE_ANALYSIS
 
 	/* Verify that [current_cycles] change as expected. */
 
-	zassert_true(stats4.current_cycles >= stats5.current_cycles, NULL);
-	zassert_true(stats4.current_cycles > stats3.current_cycles, NULL);
-	zassert_true(stats5.current_cycles < stats3.current_cycles, NULL);
+	zassert_true(stats4.current_cycles >= stats5.current_cycles);
+	zassert_true(stats4.current_cycles > stats3.current_cycles);
+	zassert_true(stats5.current_cycles < stats3.current_cycles);
 
 	/* Verify that [peak_cycles] change as expected */
 
-	zassert_true(stats4.peak_cycles > stats2.peak_cycles, NULL);
-	zassert_true(stats4.peak_cycles == stats5.peak_cycles, NULL);
-	zassert_true(stats4.peak_cycles == stats4.current_cycles, NULL);
+	zassert_true(stats4.peak_cycles > stats2.peak_cycles);
+	zassert_true(stats4.peak_cycles == stats5.peak_cycles);
+	zassert_true(stats4.peak_cycles == stats4.current_cycles);
 
 	/* Verify that [average_cycles] change as expected */
 
-	zassert_true(stats4.average_cycles > stats3.average_cycles, NULL);
-	zassert_true(stats4.average_cycles > stats5.average_cycles, NULL);
-	zassert_true(stats5.average_cycles >= stats3.average_cycles, NULL);
+	zassert_true(stats4.average_cycles > stats3.average_cycles);
+	zassert_true(stats4.average_cycles > stats5.average_cycles);
+	zassert_true(stats5.average_cycles >= stats3.average_cycles);
 #endif
 
 	/* Abort the helper thread */

--- a/tests/kernel/workq/user_work/src/main.c
+++ b/tests/kernel/workq/user_work/src/main.c
@@ -41,8 +41,8 @@ static void common_work_handler(struct k_work_user *unused)
 static void test_k_work_user_init(void)
 {
 	K_WORK_USER_DEFINE(local, common_work_handler);
-	zassert_equal(local.handler, common_work_handler, NULL);
-	zassert_equal(local.flags, 0, NULL);
+	zassert_equal(local.handler, common_work_handler);
+	zassert_equal(local.flags, 0);
 }
 
 /**
@@ -69,13 +69,13 @@ static void test_k_work_user_submit_to_queue_fail(void)
 	 * be append to a workqueue another time.
 	 */
 	k_work_user_submit_to_queue(&user_workq, &work[0]);
-	zassert_true(k_work_user_is_pending(&work[0]), NULL);
+	zassert_true(k_work_user_is_pending(&work[0]));
 	k_work_user_submit_to_queue(&user_workq, &work[0]);
 
 	/* Test the work item's callback function can only be invoked once */
 	k_sem_take(&sync_sema, K_FOREVER);
-	zassert_true(k_queue_is_empty(&user_workq.queue), NULL);
-	zassert_false(k_work_user_is_pending(&work[0]), NULL);
+	zassert_true(k_queue_is_empty(&user_workq.queue));
+	zassert_false(k_work_user_is_pending(&work[0]));
 
 	/* use up the memory in resource pool */
 	for (int i = 0; i < 100; i++) {
@@ -87,7 +87,7 @@ static void test_k_work_user_submit_to_queue_fail(void)
 
 	k_work_user_submit_to_queue(&user_workq, &work[0]);
 	/* if memory is used up, the work cannot be append into the workqueue */
-	zassert_false(k_work_user_is_pending(&work[0]), NULL);
+	zassert_false(k_work_user_is_pending(&work[0]));
 }
 
 
@@ -105,7 +105,7 @@ static void twork_submit_1(struct k_work_user_q *work_q, struct k_work_user *w,
 	/**TESTPOINT: init via k_work_init*/
 	k_work_user_init(w, handler);
 	/**TESTPOINT: check pending after work init*/
-	zassert_false(k_work_user_is_pending(w), NULL);
+	zassert_false(k_work_user_is_pending(w));
 
 	/**TESTPOINT: work submit to queue*/
 	zassert_false(k_work_user_submit_to_queue(work_q, w),

--- a/tests/kernel/workq/work/src/main.c
+++ b/tests/kernel/workq/work/src/main.c
@@ -129,7 +129,7 @@ static inline int system_counter(void)
 static inline void reset_counters(void)
 {
 	/* If this fails the previous test didn't clean up */
-	zassert_equal(k_sem_take(&sync_sem, K_NO_WAIT), -EBUSY, NULL);
+	zassert_equal(k_sem_take(&sync_sem, K_NO_WAIT), -EBUSY);
 	last_handle_ms = UINT32_MAX;
 	atomic_set(&resubmits_left, 0);
 	atomic_set(&coophi_ctr, 0);
@@ -215,10 +215,10 @@ ZTEST(work, test_unstarted)
 	int rc;
 
 	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
 
 	rc = k_work_submit_to_queue(&not_start_queue, &work);
-	zassert_equal(rc, -ENODEV, NULL);
+	zassert_equal(rc, -ENODEV);
 }
 
 static void test_queue_start(void)
@@ -227,31 +227,31 @@ static void test_queue_start(void)
 		.name = "wq.preempt",
 	};
 	k_work_queue_init(&preempt_queue);
-	zassert_equal(preempt_queue.flags, 0, NULL);
+	zassert_equal(preempt_queue.flags, 0);
 	k_work_queue_start(&preempt_queue, preempt_stack, STACK_SIZE,
 			    PREEMPT_PRIORITY, &cfg);
-	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_STARTED, NULL);
+	zassert_equal(preempt_queue.flags, K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 		const char *tn = k_thread_name_get(&preempt_queue.thread);
 
-		zassert_true(tn != cfg.name, NULL);
-		zassert_true(tn != NULL, NULL);
-		zassert_equal(strcmp(tn, cfg.name), 0, NULL);
+		zassert_true(tn != cfg.name);
+		zassert_true(tn != NULL);
+		zassert_equal(strcmp(tn, cfg.name), 0);
 	}
 
 	cfg.name = NULL;
-	zassert_equal(invalid_test_queue.flags, 0, NULL);
+	zassert_equal(invalid_test_queue.flags, 0);
 	k_work_queue_start(&invalid_test_queue, invalid_test_stack, STACK_SIZE,
 			    PREEMPT_PRIORITY, &cfg);
-	zassert_equal(invalid_test_queue.flags, K_WORK_QUEUE_STARTED, NULL);
+	zassert_equal(invalid_test_queue.flags, K_WORK_QUEUE_STARTED);
 
 	if (IS_ENABLED(CONFIG_THREAD_NAME)) {
 		const char *tn = k_thread_name_get(&invalid_test_queue.thread);
 
-		zassert_true(tn != cfg.name, NULL);
-		zassert_true(tn != NULL, NULL);
-		zassert_equal(strcmp(tn, ""), 0, NULL);
+		zassert_true(tn != cfg.name);
+		zassert_true(tn != NULL);
+		zassert_equal(strcmp(tn, ""), 0);
 	}
 
 	cfg.name = "wq.coophi";
@@ -275,10 +275,10 @@ ZTEST(work, test_null_queue)
 	int rc;
 
 	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
 
 	rc = k_work_submit_to_queue(NULL, &work);
-	zassert_equal(rc, -EINVAL, NULL);
+	zassert_equal(rc, -EINVAL);
 }
 
 /* Basic single-CPU check submitting with a non-blocking handler. */
@@ -289,28 +289,28 @@ ZTEST(work_1cpu, test_1cpu_simple_queue)
 	/* Reset state and use the non-blocking handler */
 	reset_counters();
 	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
-	zassert_equal(k_work_is_pending(&work), false, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
+	zassert_equal(k_work_is_pending(&work), false);
 
 	/* Submit to the cooperative queue */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED, NULL);
-	zassert_equal(k_work_is_pending(&work), true, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
+	zassert_equal(k_work_is_pending(&work), true);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
 	 */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Let it run, then check it finished. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 1, NULL);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
+	zassert_equal(coophi_counter(), 1);
+	zassert_equal(k_work_busy_get(&work), 0);
 
 	/* Flush the sync state from completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 /* Basic SMP check submitting with a non-blocking handler. */
@@ -326,12 +326,12 @@ ZTEST(work, test_smp_simple_queue)
 	/* Reset state and use the non-blocking handler */
 	reset_counters();
 	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
-	zassert_equal(k_work_is_pending(&work), false, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
+	zassert_equal(k_work_is_pending(&work), false);
 
 	/* Submit to the cooperative queue */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
 	/* It should run and finish without this thread yielding. */
 	int64_t ts0 = k_uptime_ticks();
@@ -341,12 +341,12 @@ ZTEST(work, test_smp_simple_queue)
 		delay = k_ticks_to_ms_floor32(k_uptime_ticks() - ts0);
 	} while (k_work_is_pending(&work) && (delay < DELAY_MS));
 
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
+	zassert_equal(coophi_counter(), 1);
 
 	/* Flush the sync state from completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 /* Basic single-CPU check submitting with a blocking handler */
@@ -357,31 +357,31 @@ ZTEST(work_1cpu, test_1cpu_sync_queue)
 	/* Reset state and use the blocking handler */
 	reset_counters();
 	k_work_init(&work, rel_handler);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
 
 	/* Submit to the cooperative queue */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
 	 */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Let it run, then check it didn't finish. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 0, NULL);
-	zassert_equal(k_work_busy_get(&work), K_WORK_RUNNING, NULL);
+	zassert_equal(coophi_counter(), 0);
+	zassert_equal(k_work_busy_get(&work), K_WORK_RUNNING);
 
 	/* Make it ready so it can finish when this thread yields. */
 	handler_release();
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Wait for then verify finish */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(rc, 0);
+	zassert_equal(coophi_counter(), 1);
 }
 
 /* Verify that if a work item is submitted while it is being run by a
@@ -398,30 +398,30 @@ ZTEST(work_1cpu, test_1cpu_reentrant_queue)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Release it so it's running and can be rescheduled. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Resubmit to a different queue. */
 	rc = k_work_submit_to_queue(&preempt_queue, &work);
-	zassert_equal(rc, 2, NULL);
+	zassert_equal(rc, 2);
 
 	/* Release the first submission. */
 	handler_release();
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(rc, 0);
+	zassert_equal(coophi_counter(), 1);
 
 	/* Confirm the second submission was redirected to the running
 	 * queue to avoid re-entrancy problems.
 	 */
 	handler_release();
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
-	zassert_equal(coophi_counter(), 2, NULL);
+	zassert_equal(rc, 0);
+	zassert_equal(coophi_counter(), 2);
 }
 
 /* Single CPU submit two work items and wait for flush in order
@@ -438,29 +438,29 @@ ZTEST(work_1cpu, test_1cpu_queued_flush)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, &work1);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Confirm that it's still in the queue, then wait for completion.
 	 * This should wait.
 	 */
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED, NULL);
-	zassert_equal(k_work_busy_get(&work1), K_WORK_QUEUED, NULL);
-	zassert_true(k_work_flush(&work, &work_sync), NULL);
-	zassert_false(k_work_flush(&work1, &work_sync), NULL);
+	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
+	zassert_equal(k_work_busy_get(&work1), K_WORK_QUEUED);
+	zassert_true(k_work_flush(&work, &work_sync));
+	zassert_false(k_work_flush(&work1, &work_sync));
 
 	/* Verify completion. */
-	zassert_equal(coophi_counter(), 2, NULL);
-	zassert_true(!k_work_is_pending(&work), NULL);
-	zassert_true(!k_work_is_pending(&work1), NULL);
+	zassert_equal(coophi_counter(), 2);
+	zassert_true(!k_work_is_pending(&work));
+	zassert_true(!k_work_is_pending(&work1));
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* After completion flush should be a no-op */
-	zassert_false(k_work_flush(&work, &work_sync), NULL);
-	zassert_false(k_work_flush(&work1, &work_sync), NULL);
+	zassert_false(k_work_flush(&work, &work_sync));
+	zassert_false(k_work_flush(&work1, &work_sync));
 }
 
 /* Single CPU submit a work item and wait for flush after it's started.
@@ -475,24 +475,24 @@ ZTEST(work_1cpu, test_1cpu_running_flush)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
+	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
 
 	/* Release it so it's running. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(k_work_busy_get(&work), K_WORK_RUNNING, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(k_work_busy_get(&work), K_WORK_RUNNING);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Wait for completion.  This should be released by the delay
 	 * handler.
 	 */
-	zassert_true(k_work_flush(&work, &work_sync), NULL);
+	zassert_true(k_work_flush(&work, &work_sync));
 
 	/* Verify completion. */
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(coophi_counter(), 1);
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 /* Single CPU schedule a work item and wait for flush. */
@@ -507,24 +507,24 @@ ZTEST(work_1cpu, test_1cpu_delayed_flush)
 	k_work_init_delayable(&dwork, counter_handler);
 
 	/* Unscheduled completes immediately. */
-	zassert_false(k_work_flush_delayable(&dwork, &work_sync), NULL);
+	zassert_false(k_work_flush_delayable(&dwork, &work_sync));
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Align to tick then flush. */
 	k_sleep(K_TICKS(1));
 	flush_ms = k_uptime_get_32();
-	zassert_true(k_work_flush_delayable(&dwork, &work_sync), NULL);
+	zassert_true(k_work_flush_delayable(&dwork, &work_sync));
 	wait_ms = last_handle_ms - flush_ms;
 	zassert_true(wait_ms <= 1, "waited %u", wait_ms);
 
 	/* Verify completion. */
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(coophi_counter(), 1);
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 /* Single CPU cancel before work item is unqueued should complete
@@ -540,14 +540,14 @@ ZTEST(work_1cpu, test_1cpu_queued_cancel)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Cancellation should complete immediately. */
-	zassert_equal(k_work_cancel(&work), 0, NULL);
+	zassert_equal(k_work_cancel(&work), 0);
 
 	/* Shouldn't have run. */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 }
 
 /* Single CPU cancel before work item is unqueued should not wait. */
@@ -562,20 +562,20 @@ ZTEST(work_1cpu, test_1cpu_queued_cancel_sync)
 	/* Cancel an unqueued work item should not affect the work
 	 * and return false.
 	 */
-	zassert_false(k_work_cancel_sync(&work, &work_sync), NULL);
+	zassert_false(k_work_cancel_sync(&work, &work_sync));
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Cancellation should complete immediately, indicating that
 	 * work was pending.
 	 */
-	zassert_true(k_work_cancel_sync(&work, &work_sync), NULL);
+	zassert_true(k_work_cancel_sync(&work, &work_sync));
 
 	/* Shouldn't have run. */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 }
 
 /* Single CPU cancel before scheduled work item is queued should
@@ -591,14 +591,14 @@ ZTEST(work_1cpu, test_1cpu_delayed_cancel)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Cancellation should complete immediately. */
-	zassert_equal(k_work_cancel_delayable(&dwork), 0, NULL);
+	zassert_equal(k_work_cancel_delayable(&dwork), 0);
 
 	/* Shouldn't have run. */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 }
 
 
@@ -614,20 +614,20 @@ ZTEST(work_1cpu, test_1cpu_delayed_cancel_sync)
 	/* Cancel an unqueued delayable work item should not affect the work
 	 * and return false.
 	 */
-	zassert_false(k_work_cancel_delayable_sync(&dwork, &work_sync), NULL);
+	zassert_false(k_work_cancel_delayable_sync(&dwork, &work_sync));
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Cancellation should complete immediately, indicating that
 	 * work was pending.
 	 */
-	zassert_true(k_work_cancel_delayable_sync(&dwork, &work_sync), NULL);
+	zassert_true(k_work_cancel_delayable_sync(&dwork, &work_sync));
 
 	/* Shouldn't have run. */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 }
 
 /* Single CPU cancel after delayable item starts should wait. */
@@ -641,22 +641,22 @@ ZTEST(work_1cpu, test_1cpu_delayed_cancel_sync_wait)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_NO_WAIT);
-	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_QUEUED, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_QUEUED);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Get it to running, where it will block. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 0, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_RUNNING, NULL);
+	zassert_equal(coophi_counter(), 0);
+	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_RUNNING);
 
 	/* Schedule to release, then cancel should delay. */
 	async_release();
-	zassert_true(k_work_cancel_delayable_sync(&dwork, &work_sync), NULL);
+	zassert_true(k_work_cancel_delayable_sync(&dwork, &work_sync));
 
 	/* Verify completion. */
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(coophi_counter(), 1);
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 /* Infrastructure to capture behavior of work item that's being
@@ -695,12 +695,12 @@ ZTEST(work_1cpu, test_1cpu_running_cancel)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, wp);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Release it so it's running. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Schedule the async process to capture state and release work. */
 	ctx->submit_rc = INT_MAX;
@@ -713,29 +713,29 @@ ZTEST(work_1cpu, test_1cpu_running_cancel)
 		      NULL);
 
 	/* Handler should not have run. */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Busy wait until timer expires. Thread context is blocked so cancelling
 	 * of work won't be completed.
 	 */
 	k_busy_wait(1000 * (ms_timeout + 1));
 
-	zassert_equal(k_timer_status_get(&ctx->timer), 1, NULL);
+	zassert_equal(k_timer_status_get(&ctx->timer), 1);
 
 	/* Wait for cancellation to complete. */
-	zassert_true(k_work_cancel_sync(wp, &work_sync), NULL);
+	zassert_true(k_work_cancel_sync(wp, &work_sync));
 
 	/* Verify completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Handler should have detected running and canceling. */
-	zassert_equal(ctx->busy_rc, K_WORK_RUNNING | K_WORK_CANCELING, NULL);
+	zassert_equal(ctx->busy_rc, K_WORK_RUNNING | K_WORK_CANCELING);
 
 	/* Attempt to submit while cancelling should have been
 	 * rejected.
 	 */
-	zassert_equal(ctx->submit_rc, -EBUSY, NULL);
+	zassert_equal(ctx->submit_rc, -EBUSY);
 
 	/* Post-cancellation should have no flags. */
 	rc = k_work_busy_get(wp);
@@ -758,12 +758,12 @@ ZTEST(work_1cpu, test_1cpu_running_cancel_sync)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, wp);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Release it so it's running. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Schedule the async process to capture state and release work. */
 	ctx->submit_rc = INT_MAX;
@@ -772,21 +772,21 @@ ZTEST(work_1cpu, test_1cpu_running_cancel_sync)
 	k_timer_start(&ctx->timer, K_MSEC(ms_timeout), K_NO_WAIT);
 
 	/* Cancellation should wait. */
-	zassert_true(k_work_cancel_sync(wp, &work_sync), NULL);
+	zassert_true(k_work_cancel_sync(wp, &work_sync));
 
 	/* Handler should have run. */
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(coophi_counter(), 1);
 
 	/* Busy wait until timer expires. Thread context is blocked so cancelling
 	 * of work won't be completed.
 	 */
 	k_busy_wait(1000 * (ms_timeout + 1));
 
-	zassert_equal(k_timer_status_get(&ctx->timer), 1, NULL);
+	zassert_equal(k_timer_status_get(&ctx->timer), 1);
 
 	/* Verify completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Handler should have detected running and canceling. */
 	zassert_equal(ctx->busy_rc, K_WORK_RUNNING | K_WORK_CANCELING,
@@ -795,7 +795,7 @@ ZTEST(work_1cpu, test_1cpu_running_cancel_sync)
 	/* Attempt to submit while cancelling should have been
 	 * rejected.
 	 */
-	zassert_equal(ctx->submit_rc, -EBUSY, NULL);
+	zassert_equal(ctx->submit_rc, -EBUSY);
 
 	/* Post-cancellation should have no flags. */
 	rc = k_work_busy_get(wp);
@@ -820,7 +820,7 @@ ZTEST(work, test_smp_running_cancel)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
 	/* It should advance to running without this thread yielding. */
 	int64_t ts0 = k_uptime_ticks();
@@ -838,12 +838,12 @@ ZTEST(work, test_smp_running_cancel)
 	zassert_equal(rc, K_WORK_RUNNING | K_WORK_CANCELING, "rc %x", rc);
 
 	/* Sync should wait. */
-	zassert_equal(k_work_cancel_sync(&work, &work_sync), true, NULL);
+	zassert_equal(k_work_cancel_sync(&work, &work_sync), true);
 
 	/* Should have completed. */
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(coophi_counter(), 1);
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 /* Drain with no active workers completes immediately. */
@@ -852,7 +852,7 @@ ZTEST(work, test_drain_empty)
 	int rc;
 
 	rc = k_work_queue_drain(&coophi_queue, false);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 struct test_drain_wait_timer {
@@ -886,8 +886,8 @@ ZTEST(work_1cpu, test_1cpu_drain_wait)
 
 	/* Submit to the cooperative queue. */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Schedule the async process to capture submission state
 	 * while draining.
@@ -898,17 +898,17 @@ ZTEST(work_1cpu, test_1cpu_drain_wait)
 
 	/* Wait to drain */
 	rc = k_work_queue_drain(&coophi_queue, false);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
 	/* Verify completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Confirm that chained submission worked, and non-chained
 	 * submission failed.
 	 */
-	zassert_equal(coophi_counter(), 2, NULL);
-	zassert_equal(ctx->submit_rc, -EBUSY, NULL);
+	zassert_equal(coophi_counter(), 2);
+	zassert_equal(ctx->submit_rc, -EBUSY);
 }
 
 /* Single CPU submit item, drain with plug, test, then unplug. */
@@ -922,16 +922,16 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 
 	/* Submit to the cooperative queue */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
 	/* Wait to drain, and plug. */
 	rc = k_work_queue_drain(&coophi_queue, true);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
 	/* Verify completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(rc, 0);
+	zassert_equal(coophi_counter(), 1);
 
 	/* Queue should be plugged */
 	zassert_equal(coophi_queue.flags,
@@ -945,27 +945,27 @@ ZTEST(work_1cpu, test_1cpu_plugged_drain)
 
 	/* Resubmission should fail because queue is plugged */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, -EBUSY, NULL);
+	zassert_equal(rc, -EBUSY);
 
 	/* Unplug the queue */
 	rc = k_work_queue_unplug(&coophi_queue);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Unplug the unplugged queue should not affect the queue */
 	rc = k_work_queue_unplug(&coophi_queue);
-	zassert_equal(rc, -EALREADY, NULL);
+	zassert_equal(rc, -EALREADY);
 	zassert_equal(coophi_queue.flags,
 		      K_WORK_QUEUE_STARTED | K_WORK_QUEUE_NO_YIELD,
 		      NULL);
 
 	/* Resubmission should succeed and complete */
 	rc = k_work_submit_to_queue(&coophi_queue, &work);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
 	/* Flush the sync state and verify completion */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
-	zassert_equal(coophi_counter(), 2, NULL);
+	zassert_equal(rc, 0);
+	zassert_equal(coophi_counter(), 2);
 }
 
 /* Single CPU test delayed submission */
@@ -983,7 +983,7 @@ ZTEST(work_1cpu, test_1cpu_basic_schedule)
 	k_work_init_delayable(&dwork, counter_handler);
 
 	/* Verify that work is idle and marked delayable. */
-	zassert_equal(k_work_busy_get(wp), 0, NULL);
+	zassert_equal(k_work_busy_get(wp), 0);
 	zassert_equal(wp->flags & K_WORK_DELAYABLE, K_WORK_DELAYABLE,
 		       NULL);
 
@@ -991,23 +991,23 @@ ZTEST(work_1cpu, test_1cpu_basic_schedule)
 	k_sleep(K_TICKS(1));
 	sched_ms = k_uptime_get_32();
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 	rc = k_work_busy_get(wp);
-	zassert_equal(rc, K_WORK_DELAYED, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), rc, NULL);
-	zassert_equal(k_work_delayable_is_pending(&dwork), true, NULL);
+	zassert_equal(rc, K_WORK_DELAYED);
+	zassert_equal(k_work_delayable_busy_get(&dwork), rc);
+	zassert_equal(k_work_delayable_is_pending(&dwork), true);
 
 	/* Scheduling again does nothing. */
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Wait for completion */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Make sure it ran and is now idle */
-	zassert_equal(coophi_counter(), 1, NULL);
-	zassert_equal(k_work_busy_get(wp), 0, NULL);
+	zassert_equal(coophi_counter(), 1);
+	zassert_equal(k_work_busy_get(wp), 0);
 
 	/* Check that the delay is within the expected range. */
 	elapsed_ms = last_handle_ms - sched_ms;
@@ -1059,25 +1059,25 @@ ZTEST(work_1cpu, test_1cpu_basic_schedule_running)
 	atomic_set(&resubmits_left, 1);
 	k_work_init_delayable(&state.dwork, handle_1cpu_basic_schedule_running);
 
-	zassert_equal(state.schedule_res, -1, NULL);
+	zassert_equal(state.schedule_res, -1);
 
 	rc = k_work_schedule_for_queue(&coophi_queue, &state.dwork,
 				       K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
-	zassert_equal(coop_counter(&coophi_queue), 0, NULL);
-
-	/* Wait for completion */
-	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
-	zassert_equal(state.schedule_res, 1, NULL);
-	zassert_equal(coop_counter(&coophi_queue), 1, NULL);
+	zassert_equal(coop_counter(&coophi_queue), 0);
 
 	/* Wait for completion */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
-	zassert_equal(state.schedule_res, -EALREADY, NULL);
-	zassert_equal(coop_counter(&coophi_queue), 2, NULL);
+	zassert_equal(rc, 0);
+	zassert_equal(state.schedule_res, 1);
+	zassert_equal(coop_counter(&coophi_queue), 1);
+
+	/* Wait for completion */
+	rc = k_sem_take(&sync_sem, K_FOREVER);
+	zassert_equal(rc, 0);
+	zassert_equal(state.schedule_res, -EALREADY);
+	zassert_equal(coop_counter(&coophi_queue), 2);
 }
 
 /* Single CPU test schedule without delay is queued immediately. */
@@ -1089,33 +1089,33 @@ ZTEST(work_1cpu, test_1cpu_immed_schedule)
 	/* Reset state and use the non-blocking handler */
 	reset_counters();
 	k_work_init_delayable(&dwork, counter_handler);
-	zassert_equal(k_work_busy_get(wp), 0, NULL);
+	zassert_equal(k_work_busy_get(wp), 0);
 
 	/* Submit to the cooperative queue */
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_NO_WAIT);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 	rc = k_work_busy_get(wp);
-	zassert_equal(rc, K_WORK_QUEUED, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), rc, NULL);
-	zassert_equal(k_work_delayable_is_pending(&dwork), true, NULL);
+	zassert_equal(rc, K_WORK_QUEUED);
+	zassert_equal(k_work_delayable_busy_get(&dwork), rc);
+	zassert_equal(k_work_delayable_is_pending(&dwork), true);
 
 	/* Scheduling again does nothing. */
 	rc = k_work_schedule_for_queue(&coophi_queue, &dwork, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
 	 */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Let it run, then check it didn't finish. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 1, NULL);
-	zassert_equal(k_work_busy_get(wp), 0, NULL);
+	zassert_equal(coophi_counter(), 1);
+	zassert_equal(k_work_busy_get(wp), 0);
 
 	/* Flush the sync state from completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 /* Single CPU test that delayed work can be rescheduled. */
@@ -1133,7 +1133,7 @@ ZTEST(work_1cpu, test_1cpu_basic_reschedule)
 	k_work_init_delayable(&dwork, counter_handler);
 
 	/* Verify that work is idle and marked delayable. */
-	zassert_equal(k_work_busy_get(wp), 0, NULL);
+	zassert_equal(k_work_busy_get(wp), 0);
 	zassert_equal(wp->flags & K_WORK_DELAYABLE, K_WORK_DELAYABLE,
 		       NULL);
 
@@ -1142,8 +1142,8 @@ ZTEST(work_1cpu, test_1cpu_basic_reschedule)
 	 */
 	rc = k_work_reschedule_for_queue(&preempt_queue, &dwork,
 					  K_MSEC(2U * DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_busy_get(wp), K_WORK_DELAYED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(wp), K_WORK_DELAYED);
 
 	/* Align to tick then reschedule on the cooperative queue for
 	 * the standard delay.
@@ -1152,16 +1152,16 @@ ZTEST(work_1cpu, test_1cpu_basic_reschedule)
 	sched_ms = k_uptime_get_32();
 	rc = k_work_reschedule_for_queue(&coophi_queue, &dwork,
 					  K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_busy_get(wp), K_WORK_DELAYED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(wp), K_WORK_DELAYED);
 
 	/* Wait for completion */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Make sure it ran on the coop queue and is now idle */
-	zassert_equal(coophi_counter(), 1, NULL);
-	zassert_equal(k_work_busy_get(wp), 0, NULL);
+	zassert_equal(coophi_counter(), 1);
+	zassert_equal(k_work_busy_get(wp), 0);
 
 	/* Check that the delay is within the expected range. */
 	elapsed_ms = last_handle_ms - sched_ms;
@@ -1182,28 +1182,28 @@ ZTEST(work_1cpu, test_1cpu_immed_reschedule)
 	/* Reset state and use the delay handler */
 	reset_counters();
 	k_work_init_delayable(&dwork, delay_handler);
-	zassert_equal(k_work_busy_get(wp), 0, NULL);
+	zassert_equal(k_work_busy_get(wp), 0);
 
 	/* Schedule immediately to the cooperative queue */
 	rc = k_work_reschedule_for_queue(&coophi_queue, &dwork, K_NO_WAIT);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_busy_get(wp), K_WORK_QUEUED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(wp), K_WORK_QUEUED);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
 	 */
-	zassert_equal(coophi_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 0);
 
 	/* Let it run, then check it didn't finish. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(coophi_counter(), 0, NULL);
-	zassert_equal(k_work_busy_get(wp), K_WORK_RUNNING, NULL);
+	zassert_equal(coophi_counter(), 0);
+	zassert_equal(k_work_busy_get(wp), K_WORK_RUNNING);
 
 	/* Schedule immediately to the preemptive queue (will divert
 	 * to coop since running).
 	 */
 	rc = k_work_reschedule_for_queue(&preempt_queue, &dwork, K_NO_WAIT);
-	zassert_equal(rc, 2, NULL);
+	zassert_equal(rc, 2);
 	zassert_equal(k_work_busy_get(wp), K_WORK_QUEUED | K_WORK_RUNNING,
 		      NULL);
 
@@ -1213,50 +1213,50 @@ ZTEST(work_1cpu, test_1cpu_immed_reschedule)
 	 */
 	rc = k_work_reschedule_for_queue(&preempt_queue, &dwork,
 					  K_MSEC(3 * DELAY_MS));
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 	zassert_equal(k_work_busy_get(wp),
 		      K_WORK_DELAYED | K_WORK_QUEUED | K_WORK_RUNNING,
 		      NULL);
 
 	/* Wait for the original no-wait submission (total 1 delay)) */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Check that coop ran once, and work is still delayed and
 	 * also running.
 	 */
-	zassert_equal(coophi_counter(), 1, NULL);
+	zassert_equal(coophi_counter(), 1);
 	zassert_equal(k_work_busy_get(wp), K_WORK_DELAYED | K_WORK_RUNNING,
 		      NULL);
 
 	/* Wait for the queued no-wait submission (total 2 delay) */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Check that got diverted to coop and ran, and work is still
 	 * delayed.
 	 */
-	zassert_equal(coophi_counter(), 2, NULL);
-	zassert_equal(preempt_counter(), 0, NULL);
+	zassert_equal(coophi_counter(), 2);
+	zassert_equal(preempt_counter(), 0);
 	zassert_equal(k_work_busy_get(wp), K_WORK_DELAYED,
 		      NULL);
 
 	/* Wait for the delayed submission (total 3 delay) */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Check that ran on preempt.  In fact we're here because the
 	 * test thread is higher priority, so the work will still be
 	 * marked running.
 	 */
-	zassert_equal(coophi_counter(), 2, NULL);
-	zassert_equal(preempt_counter(), 1, NULL);
+	zassert_equal(coophi_counter(), 2);
+	zassert_equal(preempt_counter(), 1);
 	zassert_equal(k_work_busy_get(wp), K_WORK_RUNNING,
 		      NULL);
 
 	/* Wait for preempt to drain */
 	rc = k_work_queue_drain(&preempt_queue, false);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 }
 
 /* Test no-yield behavior, returns true iff work queue priority is
@@ -1278,29 +1278,29 @@ static bool try_queue_no_yield(struct k_work_q *wq)
 	k_work_init_delayable(&dwork, counter_handler);
 
 	rc = k_work_submit_to_queue(wq, &work);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 	rc = k_work_schedule_for_queue(wq, &dwork, K_NO_WAIT);
-	zassert_equal(rc, 1, NULL);
+	zassert_equal(rc, 1);
 
 	/* Wait for completion */
-	zassert_equal(k_work_is_pending(&work), true, NULL);
-	zassert_equal(k_work_delayable_is_pending(&dwork), true, NULL);
+	zassert_equal(k_work_is_pending(&work), true);
+	zassert_equal(k_work_delayable_is_pending(&dwork), true);
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Because there was no yield both should have run, and
 	 * another yield won't cause anything to happen.
 	 */
-	zassert_equal(coop_counter(wq), 2, NULL);
-	zassert_equal(k_work_is_pending(&work), false, NULL);
-	zassert_equal(k_work_delayable_is_pending(&dwork), false, NULL);
+	zassert_equal(coop_counter(wq), 2);
+	zassert_equal(k_work_is_pending(&work), false);
+	zassert_equal(k_work_delayable_is_pending(&dwork), false);
 
 	/* The first give unblocked this thread; we need to consume
 	 * the give from the second work task.
 	 */
-	zassert_equal(k_sem_take(&sync_sem, K_NO_WAIT), 0, NULL);
+	zassert_equal(k_sem_take(&sync_sem, K_NO_WAIT), 0);
 
-	zassert_equal(k_sem_take(&sync_sem, K_NO_WAIT), -EBUSY, NULL);
+	zassert_equal(k_sem_take(&sync_sem, K_NO_WAIT), -EBUSY);
 
 	return is_high;
 }
@@ -1308,8 +1308,8 @@ static bool try_queue_no_yield(struct k_work_q *wq)
 /* Verify that no-yield policy works */
 ZTEST(work_1cpu, test_1cpu_queue_no_yield)
 {
-	zassert_equal(try_queue_no_yield(&coophi_queue), true, NULL);
-	zassert_equal(try_queue_no_yield(&cooplo_queue), false, NULL);
+	zassert_equal(try_queue_no_yield(&coophi_queue), true);
+	zassert_equal(try_queue_no_yield(&cooplo_queue), false);
 }
 
 /* Basic functionality with the system work queue. */
@@ -1320,26 +1320,26 @@ ZTEST(work_1cpu, test_1cpu_system_queue)
 	/* Reset state and use the non-blocking handler */
 	reset_counters();
 	k_work_init(&work, counter_handler);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
+	zassert_equal(k_work_busy_get(&work), 0);
 
 	/* Submit to the system queue */
 	rc = k_work_submit(&work);
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_busy_get(&work), K_WORK_QUEUED);
 
 	/* Shouldn't have been started since test thread is
 	 * cooperative.
 	 */
-	zassert_equal(system_counter(), 0, NULL);
+	zassert_equal(system_counter(), 0);
 
 	/* Let it run, then check it didn't finish. */
 	k_sleep(K_TICKS(1));
-	zassert_equal(system_counter(), 1, NULL);
-	zassert_equal(k_work_busy_get(&work), 0, NULL);
+	zassert_equal(system_counter(), 1);
+	zassert_equal(k_work_busy_get(&work), 0);
 
 	/* Flush the sync state from completion */
 	rc = k_sem_take(&sync_sem, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 }
 
 ZTEST(work_1cpu, test_1cpu_system_schedule)
@@ -1355,7 +1355,7 @@ ZTEST(work_1cpu, test_1cpu_system_schedule)
 	k_work_init_delayable(&dwork, counter_handler);
 
 	/* Verify that work is idle and marked delayable. */
-	zassert_equal(k_work_delayable_busy_get(&dwork), 0, NULL);
+	zassert_equal(k_work_delayable_busy_get(&dwork), 0);
 	zassert_equal(dwork.work.flags & K_WORK_DELAYABLE, K_WORK_DELAYABLE,
 		       NULL);
 
@@ -1363,20 +1363,20 @@ ZTEST(work_1cpu, test_1cpu_system_schedule)
 	k_sleep(K_TICKS(1));
 	sched_ms = k_uptime_get_32();
 	rc = k_work_schedule(&dwork, K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_DELAYED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_DELAYED);
 
 	/* Scheduling again does nothing. */
 	rc = k_work_schedule(&dwork, K_NO_WAIT);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Wait for completion */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Make sure it ran and is now idle */
-	zassert_equal(system_counter(), 1, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), 0, NULL);
+	zassert_equal(system_counter(), 1);
+	zassert_equal(k_work_delayable_busy_get(&dwork), 0);
 
 	/* Check that the delay is within the expected range. */
 	elapsed_ms = last_handle_ms - sched_ms;
@@ -1399,7 +1399,7 @@ ZTEST(work_1cpu, test_1cpu_system_reschedule)
 	k_work_init_delayable(&dwork, counter_handler);
 
 	/* Verify that work is idle and marked delayable. */
-	zassert_equal(k_work_delayable_busy_get(&dwork), 0, NULL);
+	zassert_equal(k_work_delayable_busy_get(&dwork), 0);
 	zassert_equal(dwork.work.flags & K_WORK_DELAYABLE, K_WORK_DELAYABLE,
 		       NULL);
 
@@ -1407,8 +1407,8 @@ ZTEST(work_1cpu, test_1cpu_system_reschedule)
 	 * delay.
 	 */
 	rc = k_work_reschedule(&dwork, K_MSEC(2U * DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_DELAYED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_DELAYED);
 
 	/* Align to tick then reschedule on the system queue for
 	 * the standard delay.
@@ -1416,16 +1416,16 @@ ZTEST(work_1cpu, test_1cpu_system_reschedule)
 	k_sleep(K_TICKS(1));
 	sched_ms = k_uptime_get_32();
 	rc = k_work_reschedule(&dwork, K_MSEC(DELAY_MS));
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_DELAYED, NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(k_work_delayable_busy_get(&dwork), K_WORK_DELAYED);
 
 	/* Wait for completion */
 	rc = k_sem_take(&sync_sem, K_FOREVER);
-	zassert_equal(rc, 0, NULL);
+	zassert_equal(rc, 0);
 
 	/* Make sure it ran on the system queue and is now idle */
-	zassert_equal(system_counter(), 1, NULL);
-	zassert_equal(k_work_delayable_busy_get(&dwork), 0, NULL);
+	zassert_equal(system_counter(), 1);
+	zassert_equal(k_work_delayable_busy_get(&dwork), 0);
 
 	/* Check that the delay is within the expected range. */
 	elapsed_ms = last_handle_ms - sched_ms;

--- a/tests/kernel/workq/work_queue/src/main.c
+++ b/tests/kernel/workq/work_queue/src/main.c
@@ -354,14 +354,14 @@ ZTEST(workqueue_delayed, test_delayed_pending)
 
 	k_work_init_delayable(&delayed_tests[0].work, delayed_work_handler);
 
-	zassert_false(k_work_delayable_is_pending(&delayed_tests[0].work), NULL);
+	zassert_false(k_work_delayable_is_pending(&delayed_tests[0].work));
 
 	TC_PRINT(" - Check pending delayed work when in workqueue\n");
 	k_work_schedule(&delayed_tests[0].work, K_NO_WAIT);
-	zassert_true(k_work_delayable_is_pending(&delayed_tests[0].work), NULL);
+	zassert_true(k_work_delayable_is_pending(&delayed_tests[0].work));
 
 	k_msleep(1);
-	zassert_false(k_work_delayable_is_pending(&delayed_tests[0].work), NULL);
+	zassert_false(k_work_delayable_is_pending(&delayed_tests[0].work));
 
 	TC_PRINT(" - Checking results\n");
 	check_results(1);
@@ -369,10 +369,10 @@ ZTEST(workqueue_delayed, test_delayed_pending)
 
 	TC_PRINT(" - Check pending delayed work with timeout\n");
 	k_work_schedule(&delayed_tests[0].work, K_MSEC(WORK_ITEM_WAIT));
-	zassert_true(k_work_delayable_is_pending(&delayed_tests[0].work), NULL);
+	zassert_true(k_work_delayable_is_pending(&delayed_tests[0].work));
 
 	k_msleep(WORK_ITEM_WAIT_ALIGNED);
-	zassert_false(k_work_delayable_is_pending(&delayed_tests[0].work), NULL);
+	zassert_false(k_work_delayable_is_pending(&delayed_tests[0].work));
 
 	TC_PRINT(" - Checking results\n");
 	check_results(1);

--- a/tests/lib/c_lib/src/main.c
+++ b/tests/lib/c_lib/src/main.c
@@ -73,7 +73,7 @@ volatile long long_one = 1L;
 ZTEST(test_c_lib, test_limits)
 {
 
-	zassert_true((long_max + long_one == LONG_MIN), NULL);
+	zassert_true((long_max + long_one == LONG_MIN));
 }
 
 static ssize_t foobar(void)
@@ -83,7 +83,7 @@ static ssize_t foobar(void)
 
 ZTEST(test_c_lib, test_ssize_t)
 {
-	zassert_true(foobar() < 0, NULL);
+	zassert_true(foobar() < 0);
 }
 
 /**
@@ -135,7 +135,7 @@ volatile uint32_t unsigned_int = 0xffffff00;
  */
 ZTEST(test_c_lib, test_stdint)
 {
-	zassert_true((unsigned_int + unsigned_byte + 1u == 0U), NULL);
+	zassert_true((unsigned_int + unsigned_byte + 1u == 0U));
 
 #if (UINT8_C(1) == 1)			\
 	&& (INT8_C(-1) == -1)		\
@@ -147,7 +147,7 @@ ZTEST(test_c_lib, test_stdint)
 	&& (INT64_C(-8) == -8)		\
 	&& (UINTMAX_C(11) == 11)	\
 	&& (INTMAX_C(-11) == -11)
-	zassert_true(true, NULL);
+	zassert_true(true);
 #else
 	zassert_true(false, "const int expr values ...");
 #endif

--- a/tests/lib/cbprintf_package/src/main.c
+++ b/tests/lib/cbprintf_package/src/main.c
@@ -59,7 +59,7 @@ static void unpack(const char *desc, struct out_buffer *buf,
 
 #define TEST_PACKAGING(flags, fmt, ...) do { \
 	int must_runtime = CBPRINTF_MUST_RUNTIME_PACKAGE(flags, fmt, __VA_ARGS__); \
-	zassert_equal(must_runtime, !Z_C_GENERIC, NULL); \
+	zassert_equal(must_runtime, !Z_C_GENERIC); \
 	snprintfcb(compare_buf, sizeof(compare_buf), fmt, __VA_ARGS__); \
 	printk("-----------------------------------------\n"); \
 	printk("%s\n", compare_buf); \
@@ -90,7 +90,7 @@ static void unpack(const char *desc, struct out_buffer *buf,
 	int outlen; \
 	pkg = &package[ALIGN_OFFSET]; \
 	CBPRINTF_STATIC_PACKAGE(pkg, len, outlen, ALIGN_OFFSET, flags, fmt, __VA_ARGS__);\
-	zassert_equal(len, outlen, NULL); \
+	zassert_equal(len, outlen); \
 	dump("static", pkg, len); \
 	unpack("static", &st_buf, pkg, len); \
 } while (0)
@@ -169,21 +169,21 @@ ZTEST(cbprintf_package, test_cbprintf_rw_str_indexes)
 		ztest_test_skip();
 	}
 
-	zassert_true(len0 > 0, NULL);
+	zassert_true(len0 > 0);
 	len1 = cbprintf_package(NULL, 0, CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
-	zassert_true(len1 > 0, NULL);
+	zassert_true(len1 > 0);
 
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, len2, 0,
 				CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
-	zassert_true(len2 > 0, NULL);
+	zassert_true(len2 > 0);
 
 	/* package with string indexes will contain two more bytes holding indexes
 	 * of string parameter locations.
 	 */
-	zassert_equal(len0 + 2, len1, NULL);
-	zassert_equal(len0 + 2, len2, NULL);
+	zassert_equal(len0 + 2, len1);
+	zassert_equal(len0 + 2, len2);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package0[len0];
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package1[len1];
@@ -195,49 +195,49 @@ ZTEST(cbprintf_package, test_cbprintf_rw_str_indexes)
 	len1 = cbprintf_package(package1, sizeof(package1) - 1,
 				CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
-	zassert_equal(-ENOSPC, len1, NULL);
+	zassert_equal(-ENOSPC, len1);
 
 	CBPRINTF_STATIC_PACKAGE(package2, sizeof(package2) - 1, len2, 0,
 				CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
-	zassert_equal(-ENOSPC, len2, NULL);
+	zassert_equal(-ENOSPC, len2);
 
 	len1 = cbprintf_package(package1, sizeof(package1),
 				CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
-	zassert_equal(len0 + 2, len1, NULL);
+	zassert_equal(len0 + 2, len1);
 
 	CBPRINTF_STATIC_PACKAGE(package2, sizeof(package2), len2, 0,
 				CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
-	zassert_equal(len0 + 2, len2, NULL);
+	zassert_equal(len0 + 2, len2);
 
 	union cbprintf_package_hdr *desc0 = (union cbprintf_package_hdr *)package0;
 	union cbprintf_package_hdr *desc1 = (union cbprintf_package_hdr *)package1;
 	union cbprintf_package_hdr *desc2 = (union cbprintf_package_hdr *)package2;
 
 	/* Compare descriptor content. Second package has one ro string index. */
-	zassert_equal(desc0->desc.ro_str_cnt, 0, NULL);
-	zassert_equal(desc1->desc.ro_str_cnt, 2, NULL);
-	zassert_equal(desc2->desc.ro_str_cnt, 2, NULL);
+	zassert_equal(desc0->desc.ro_str_cnt, 0);
+	zassert_equal(desc1->desc.ro_str_cnt, 2);
+	zassert_equal(desc2->desc.ro_str_cnt, 2);
 
 	int *p = (int *)package1;
 
 	str_idx = package1[len0];
 	addr = *(char **)&p[str_idx];
-	zassert_equal(addr, test_str, NULL);
+	zassert_equal(addr, test_str);
 
 	str_idx = package2[len0];
 	addr = *(char **)&p[str_idx];
-	zassert_equal(addr, test_str, NULL);
+	zassert_equal(addr, test_str);
 
 	str_idx = package1[len0 + 1];
 	addr = *(char **)&p[str_idx];
-	zassert_equal(addr, test_str1, NULL);
+	zassert_equal(addr, test_str1);
 
 	str_idx = package2[len0 + 1];
 	addr = *(char **)&p[str_idx];
-	zassert_equal(addr, test_str1, NULL);
+	zassert_equal(addr, test_str1);
 }
 
 ZTEST(cbprintf_package, test_cbprintf_fsc_package)
@@ -263,37 +263,37 @@ ZTEST(cbprintf_package, test_cbprintf_fsc_package)
 
 	union cbprintf_package_hdr *desc = (union cbprintf_package_hdr *)package;
 
-	zassert_equal(desc->desc.ro_str_cnt, 2, NULL);
-	zassert_equal(desc->desc.str_cnt, 0, NULL);
+	zassert_equal(desc->desc.ro_str_cnt, 2);
+	zassert_equal(desc->desc.str_cnt, 0);
 
 	/* Get length of fsc package. */
 	fsc_len = cbprintf_fsc_package(package, len, NULL, 0);
 
 	int exp_len = len + (int)strlen(test_str) + 1 + (int)strlen(test_str1) + 1;
 
-	zassert_equal(exp_len, fsc_len, NULL);
+	zassert_equal(exp_len, fsc_len);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) fsc_package[fsc_len];
 
 	fsc_len = cbprintf_fsc_package(package, len, fsc_package, sizeof(fsc_package) - 1);
-	zassert_equal(fsc_len, -ENOSPC, NULL);
+	zassert_equal(fsc_len, -ENOSPC);
 
 	fsc_len = cbprintf_fsc_package(package, len, fsc_package, sizeof(fsc_package));
-	zassert_equal((int)sizeof(fsc_package), fsc_len, NULL);
+	zassert_equal((int)sizeof(fsc_package), fsc_len);
 
 	/* New package has no RO string locations, only copied one. */
 	desc = (union cbprintf_package_hdr *)fsc_package;
-	zassert_equal(desc->desc.ro_str_cnt, 0, NULL);
-	zassert_equal(desc->desc.str_cnt, 2, NULL);
+	zassert_equal(desc->desc.ro_str_cnt, 0);
+	zassert_equal(desc->desc.str_cnt, 2);
 
 	/* Get pointer to the first string in the package. */
 	addr = (char *)&fsc_package[desc->desc.len * sizeof(int) + 1];
 
-	zassert_equal(strcmp(test_str, addr), 0, NULL);
+	zassert_equal(strcmp(test_str, addr), 0);
 
 	/* Get address of the second string. */
 	addr += strlen(addr) + 2;
-	zassert_equal(strcmp(test_str1, addr), 0, NULL);
+	zassert_equal(strcmp(test_str1, addr), 0);
 }
 
 static void check_package(void *package, size_t len, const char *exp_str)
@@ -327,7 +327,7 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc)
 
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, slen, ALIGN_OFFSET, flags, TEST_FMT);
 
-	zassert_true(len > 0, NULL);
+	zassert_true(len > 0);
 	zassert_equal(len, slen, "Runtime length: %d, static length: %d", len, slen);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package[len];
@@ -345,17 +345,17 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc)
 	len = cbprintf_package(package, sizeof(package), flags, TEST_FMT);
 	CBPRINTF_STATIC_PACKAGE(spackage, sizeof(spackage), slen, ALIGN_OFFSET, flags, TEST_FMT);
 
-	zassert_true(len > 0, NULL);
+	zassert_true(len > 0);
 	zassert_equal(len, slen, "Runtime length: %d, static length: %d", len, slen);
 
-	zassert_equal(memcmp(package, spackage, len), 0, NULL);
+	zassert_equal(memcmp(package, spackage, len), 0);
 
 	uint8_t *hdr = package;
 
 	/* Check that only read-only string location array size is non zero */
-	zassert_equal(hdr[1], 0, NULL);
-	zassert_equal(hdr[2], 1, NULL);
-	zassert_equal(hdr[3], 0, NULL);
+	zassert_equal(hdr[1], 0);
+	zassert_equal(hdr[2], 1);
+	zassert_equal(hdr[3], 0);
 
 	int clen;
 
@@ -364,26 +364,26 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc)
 				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	/* Length will be increased by string length + null terminator. */
-	zassert_equal(clen, len + (int)strlen(test_str) + 1, NULL);
+	zassert_equal(clen, len + (int)strlen(test_str) + 1);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
 				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
-	zassert_equal(clen, clen2, NULL);
+	zassert_equal(clen, clen2);
 
 	/* Length will be increased by string length + null terminator. */
-	zassert_equal(clen, len + (int)strlen(test_str) + 1, NULL);
+	zassert_equal(clen, len + (int)strlen(test_str) + 1);
 
 	uint8_t *chdr = cpackage;
 
 	/* Check that only package after copying has no locations but has
 	 * appended string.
 	 */
-	zassert_equal(chdr[1], 1, NULL);
-	zassert_equal(chdr[2], 0, NULL);
-	zassert_equal(chdr[3], 0, NULL);
+	zassert_equal(chdr[1], 1);
+	zassert_equal(chdr[2], 0);
+	zassert_equal(chdr[3], 0);
 
 	check_package(package, len, exp_str);
 	check_package(cpackage, clen, exp_str);
@@ -407,19 +407,19 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc_rw_present)
 
 	int len = cbprintf_package(NULL, 0, flags, TEST_FMT);
 
-	zassert_true(len > 0, NULL);
+	zassert_true(len > 0);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package[len];
 
 	len = cbprintf_package(package, sizeof(package), flags, TEST_FMT);
-	zassert_true(len > 0, NULL);
+	zassert_true(len > 0);
 
 	uint8_t *hdr = package;
 
 	/* Check that only read-only string location array size is non zero */
-	zassert_equal(hdr[1], 1, NULL);
-	zassert_equal(hdr[2], 1, NULL);
-	zassert_equal(hdr[3], 0, NULL);
+	zassert_equal(hdr[1], 1);
+	zassert_equal(hdr[2], 1);
+	zassert_equal(hdr[3], 0);
 
 	int clen;
 
@@ -428,26 +428,26 @@ ZTEST(cbprintf_package, test_cbprintf_ro_loc_rw_present)
 				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
 	/* Length will be increased by string length + null terminator. */
-	zassert_equal(clen, len + (int)strlen(test_str) + 1, NULL);
+	zassert_equal(clen, len + (int)strlen(test_str) + 1);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
 				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
-	zassert_equal(clen, clen2, NULL);
+	zassert_equal(clen, clen2);
 
 	/* Length will be increased by string length + null terminator. */
-	zassert_equal(clen, len + (int)strlen(test_str) + 1, NULL);
+	zassert_equal(clen, len + (int)strlen(test_str) + 1);
 
 	uint8_t *chdr = cpackage;
 
 	/* Check that only package after copying has no locations but has
 	 * appended string.
 	 */
-	zassert_equal(chdr[1], 2, NULL);
-	zassert_equal(chdr[2], 0, NULL);
-	zassert_equal(chdr[3], 0, NULL);
+	zassert_equal(chdr[1], 2);
+	zassert_equal(chdr[2], 0);
+	zassert_equal(chdr[3], 0);
 
 	check_package(package, clen, exp_str);
 	check_package(cpackage, clen, exp_str);
@@ -479,8 +479,8 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc)
 	int slen;
 
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, slen, ALIGN_OFFSET, flags, TEST_FMT);
-	zassert_true(len > 0, NULL);
-	zassert_equal(len, slen, NULL);
+	zassert_true(len > 0);
+	zassert_equal(len, slen);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package[len];
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) spackage[len];
@@ -491,18 +491,18 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc)
 	int len2 = cbprintf_package(package, sizeof(package), flags, TEST_FMT);
 
 	CBPRINTF_STATIC_PACKAGE(spackage, sizeof(spackage), slen, ALIGN_OFFSET, flags, TEST_FMT);
-	zassert_equal(len, len2, NULL);
-	zassert_equal(slen, len2, NULL);
-	zassert_equal(memcmp(package, spackage, len), 0, NULL);
+	zassert_equal(len, len2);
+	zassert_equal(slen, len2);
+	zassert_equal(memcmp(package, spackage, len), 0);
 
 	uint8_t *hdr = package;
 
 	/* Check that expected number of ro and rw locations are present and no
 	 * strings appended.
 	 */
-	zassert_equal(hdr[1], 0, NULL);
-	zassert_equal(hdr[2], 2, NULL);
-	zassert_equal(hdr[3], 2, NULL);
+	zassert_equal(hdr[1], 0);
+	zassert_equal(hdr[2], 2);
+	zassert_equal(hdr[3], 2);
 
 	int clen;
 
@@ -513,23 +513,23 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc)
 				     CBPRINTF_PACKAGE_CONVERT_RO_STR, strl, ARRAY_SIZE(strl));
 
 	/* Length will be increased by 2 string lengths + null terminators. */
-	zassert_equal(clen, len + (int)strlen(test_str) + (int)strlen(cstr) + 2, NULL);
-	zassert_equal(strl[0], strlen(test_str) + 1, NULL);
-	zassert_equal(strl[1], strlen(cstr) + 1, NULL);
+	zassert_equal(clen, len + (int)strlen(test_str) + (int)strlen(cstr) + 2);
+	zassert_equal(strl[0], strlen(test_str) + 1);
+	zassert_equal(strl[1], strlen(cstr) + 1);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
 				     CBPRINTF_PACKAGE_CONVERT_RO_STR, strl, ARRAY_SIZE(strl));
 
-	zassert_equal(clen, clen2, NULL);
+	zassert_equal(clen, clen2);
 
 	uint8_t *chdr = cpackage;
 
 	/* Check that read only strings have been appended. */
-	zassert_equal(chdr[1], 2, NULL);
-	zassert_equal(chdr[2], 0, NULL);
-	zassert_equal(chdr[3], 2, NULL);
+	zassert_equal(chdr[1], 2);
+	zassert_equal(chdr[2], 0);
+	zassert_equal(chdr[3], 2);
 
 	check_package(package, len, exp_str);
 	check_package(cpackage, clen, exp_str);
@@ -542,21 +542,21 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc)
 				     cpy_flags, NULL, 0);
 
 	/* Length will be increased by 2 string lengths + null terminators. */
-	zassert_equal(clen, len + (int)strlen(test_str1) + (int)strlen(test_str2) + 2, NULL);
+	zassert_equal(clen, len + (int)strlen(test_str1) + (int)strlen(test_str2) + 2);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage2[clen];
 
 	clen2 = cbprintf_package_copy(package, sizeof(package), cpackage2, sizeof(cpackage2),
 				      cpy_flags, NULL, 0);
 
-	zassert_equal(clen, clen2, NULL);
+	zassert_equal(clen, clen2);
 
 	chdr = cpackage2;
 
 	/* Check that read write strings have been appended. */
-	zassert_equal(chdr[1], 2, NULL);
-	zassert_equal(chdr[2], 2, NULL);
-	zassert_equal(chdr[3], 0, NULL);
+	zassert_equal(chdr[1], 2);
+	zassert_equal(chdr[2], 2);
+	zassert_equal(chdr[3], 0);
 
 	check_package(package, len, exp_str);
 	check_package(cpackage2, clen, exp_str);
@@ -599,8 +599,8 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 	int slen;
 
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, slen, ALIGN_OFFSET, flags, TEST_FMT);
-	zassert_true(len > 0, NULL);
-	zassert_equal(len, slen, NULL);
+	zassert_true(len > 0);
+	zassert_equal(len, slen);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package[len];
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) spackage[len];
@@ -611,18 +611,18 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 	int len2 = cbprintf_package(package, sizeof(package), flags, TEST_FMT);
 
 	CBPRINTF_STATIC_PACKAGE(spackage, sizeof(spackage), slen, ALIGN_OFFSET, flags, TEST_FMT);
-	zassert_equal(len, len2, NULL);
-	zassert_equal(slen, len2, NULL);
-	zassert_equal(memcmp(package, spackage, len), 0, NULL);
+	zassert_equal(len, len2);
+	zassert_equal(slen, len2);
+	zassert_equal(memcmp(package, spackage, len), 0);
 
 	uint8_t *hdr = package;
 
 	/* Check that expected number of ro and rw locations are present and no
 	 * strings appended.
 	 */
-	zassert_equal(hdr[1], 0, NULL);
-	zassert_equal(hdr[2], 3, NULL);
-	zassert_equal(hdr[3], 1, NULL);
+	zassert_equal(hdr[1], 0);
+	zassert_equal(hdr[2], 3);
+	zassert_equal(hdr[3], 1);
 
 	int clen;
 
@@ -634,21 +634,21 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 	size_t str_append_len = (int)strlen(test_str) +
 				(int)strlen(cstr) +
 				(int)strlen(test_str2) + 3;
-	zassert_equal(clen, len + (int)str_append_len, NULL);
+	zassert_equal(clen, len + (int)str_append_len);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	int clen2 = cbprintf_package_copy(package, sizeof(package), cpackage, sizeof(cpackage),
 				     CBPRINTF_PACKAGE_CONVERT_RO_STR, NULL, 0);
 
-	zassert_equal(clen, clen2, NULL);
+	zassert_equal(clen, clen2);
 
 	uint8_t *chdr = cpackage;
 
 	/* Check that read only strings have been appended. */
-	zassert_equal(chdr[1], 3, NULL);
-	zassert_equal(chdr[2], 0, NULL);
-	zassert_equal(chdr[3], 1, NULL);
+	zassert_equal(chdr[1], 3);
+	zassert_equal(chdr[2], 0);
+	zassert_equal(chdr[3], 1);
 
 	check_package(package, len, exp_str);
 	check_package(cpackage, clen, exp_str);
@@ -658,21 +658,21 @@ ZTEST(cbprintf_package, test_cbprintf_ro_rw_loc_const_char_ptr)
 				     CBPRINTF_PACKAGE_CONVERT_RW_STR, NULL, 0);
 
 	/* Length will be increased by 1 string length + null terminator. */
-	zassert_equal(clen, len + (int)strlen(test_str1) + 1, NULL);
+	zassert_equal(clen, len + (int)strlen(test_str1) + 1);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage2[clen];
 
 	clen2 = cbprintf_package_copy(package, sizeof(package), cpackage2, sizeof(cpackage2),
 				     CBPRINTF_PACKAGE_CONVERT_RW_STR, NULL, 0);
 
-	zassert_equal(clen, clen2, NULL);
+	zassert_equal(clen, clen2);
 
 	chdr = cpackage2;
 
 	/* Check that read write strings have been appended. */
-	zassert_equal(chdr[1], 1, NULL);
-	zassert_equal(chdr[2], 3, NULL);
-	zassert_equal(chdr[3], 0, NULL);
+	zassert_equal(chdr[1], 1);
+	zassert_equal(chdr[2], 3);
+	zassert_equal(chdr[3], 0);
 
 	check_package(package, len, exp_str);
 	check_package(cpackage2, clen, exp_str);
@@ -711,23 +711,23 @@ static void cbprintf_rw_loc_const_char_ptr(bool keep_ro_str)
 	snprintfcb(exp_str, sizeof(exp_str), TEST_FMT);
 
 	CBPRINTF_STATIC_PACKAGE(NULL, 0, slen, ALIGN_OFFSET, flags, TEST_FMT);
-	zassert_true(slen > 0, NULL);
+	zassert_true(slen > 0);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) spackage[slen];
 
 	memset(spackage, 0, slen);
 
 	CBPRINTF_STATIC_PACKAGE(spackage, sizeof(spackage), slen2, ALIGN_OFFSET, flags, TEST_FMT);
-	zassert_equal(slen, slen2, NULL);
+	zassert_equal(slen, slen2);
 
 	hdr = spackage;
 
 	/* Check that expected number of ro and rw locations are present and no
 	 * strings appended.
 	 */
-	zassert_equal(hdr[1], 0, NULL);
-	zassert_equal(hdr[2], 0, NULL);
-	zassert_equal(hdr[3], 2, NULL);
+	zassert_equal(hdr[1], 0);
+	zassert_equal(hdr[2], 0);
+	zassert_equal(hdr[3], 2);
 
 	uint32_t copy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
 			 (keep_ro_str ? CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR : 0);
@@ -739,21 +739,21 @@ static void cbprintf_rw_loc_const_char_ptr(bool keep_ro_str)
 	int exp_len = slen + (int)strlen(test_str1) + 1 - (keep_ro_str ? 0 : 1);
 
 	/* Length will be increased by string length + null terminator. */
-	zassert_equal(clen, exp_len, NULL);
+	zassert_equal(clen, exp_len);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) cpackage[clen];
 
 	clen2 = cbprintf_package_copy(spackage, sizeof(spackage), cpackage, sizeof(cpackage),
 				      copy_flags, NULL, 0);
 
-	zassert_equal(clen, clen2, NULL);
+	zassert_equal(clen, clen2);
 
 	hdr = cpackage;
 
 	/* Check that one string has been appended. Second is detected to be RO */
-	zassert_equal(hdr[1], 1, NULL);
-	zassert_equal(hdr[2], keep_ro_str ? 1 : 0, NULL);
-	zassert_equal(hdr[3], 0, NULL);
+	zassert_equal(hdr[1], 1);
+	zassert_equal(hdr[2], keep_ro_str ? 1 : 0);
+	zassert_equal(hdr[3], 0);
 
 	check_package(spackage, slen, exp_str);
 	test_str1[0] = '\0';
@@ -776,46 +776,46 @@ ZTEST(cbprintf_package, test_cbprintf_must_runtime_package)
 	}
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(0, "test");
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(0, "test %x", 100);
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(0, "test %x %s", 100, "");
-	zassert_equal(rv, 1, NULL);
+	zassert_equal(rv, 1);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_CONST_CHAR_RO, "test %x", 100);
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_CONST_CHAR_RO,
 					   "test %x %s", 100, (const char *)"s");
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_CONST_CHAR_RO,
 					   "test %x %s %s", 100, (char *)"s", (const char *)"foo");
-	zassert_equal(rv, 1, NULL);
+	zassert_equal(rv, 1);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_FIRST_RO_STR_CNT(1),
 					   "test %s", (char *)"s");
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_FIRST_RO_STR_CNT(2),
 					   "test %s %s %d", (const char *)"s", (char *)"s", 10);
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_FIRST_RO_STR_CNT(2),
 					   "test %s %s %s", (const char *)"s", (char *)"s", "s");
-	zassert_equal(rv, 1, NULL);
+	zassert_equal(rv, 1);
 
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_FIRST_RO_STR_CNT(1) |
 					   CBPRINTF_PACKAGE_CONST_CHAR_RO,
 					   "test %s %s %d", (char *)"s", (const char *)"s", 10);
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 
 	/* When RW str positions are stored static packaging can always be used */
 	rv = CBPRINTF_MUST_RUNTIME_PACKAGE(CBPRINTF_PACKAGE_ADD_RW_STR_POS,
 					   "test %s %s %d", (char *)"s", (const char *)"s", 10);
-	zassert_equal(rv, 0, NULL);
+	zassert_equal(rv, 0);
 }
 
 struct test_cbprintf_covert_ctx {
@@ -828,10 +828,10 @@ static int convert_cb(const void *buf, size_t len, void *context)
 {
 	struct test_cbprintf_covert_ctx *ctx = (struct test_cbprintf_covert_ctx *)context;
 
-	zassert_false(ctx->null, NULL);
+	zassert_false(ctx->null);
 	if (buf) {
-		zassert_false(ctx->null, NULL);
-		zassert_true(ctx->offset + len <= sizeof(ctx->buf), NULL);
+		zassert_false(ctx->null);
+		zassert_true(ctx->offset + len <= sizeof(ctx->buf));
 		memcpy(&ctx->buf[ctx->offset], buf, len);
 		ctx->offset += len;
 		return len;
@@ -860,7 +860,7 @@ ZTEST(cbprintf_package, test_cbprintf_package_convert)
 	snprintfcb(exp_str, sizeof(exp_str), TEST_FMT);
 
 	slen = cbprintf_package(NULL, 0, flags, TEST_FMT);
-	zassert_true(slen > 0, NULL);
+	zassert_true(slen > 0);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) spackage[slen];
 
@@ -868,18 +868,18 @@ ZTEST(cbprintf_package, test_cbprintf_package_convert)
 	memset(spackage, 0, slen);
 
 	slen = cbprintf_package(spackage, slen, flags, TEST_FMT);
-	zassert_true(slen > 0, NULL);
+	zassert_true(slen > 0);
 
 	uint32_t copy_flags = CBPRINTF_PACKAGE_CONVERT_RW_STR |
 			      CBPRINTF_PACKAGE_CONVERT_KEEP_RO_STR;
 
 	clen = cbprintf_package_convert(spackage, slen, NULL, 0, copy_flags, NULL, 0);
-	zassert_true(clen > 0, NULL);
+	zassert_true(clen > 0);
 
 	clen = cbprintf_package_convert(spackage, slen, convert_cb, &ctx, copy_flags, NULL, 0);
-	zassert_true(clen > 0, NULL);
-	zassert_true(ctx.null, NULL);
-	zassert_equal(ctx.offset, clen, NULL);
+	zassert_true(clen > 0);
+	zassert_true(ctx.null);
+	zassert_equal(ctx.offset, clen);
 
 	check_package(ctx.buf, ctx.offset, exp_str);
 #undef TEST_FMT

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -387,11 +387,11 @@ ZTEST(devicetree_api, test_bus)
 	 * Make sure the underlying DT_COMPAT_ON_BUS_INTERNAL used by
 	 * DT_ANY_INST_ON_BUS works without DT_DRV_COMPAT defined.
 	 */
-	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_spi_device, spi), 1, NULL);
-	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_spi_device, i2c), 0, NULL);
+	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_spi_device, spi), 1);
+	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_spi_device, i2c), 0);
 
-	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_i2c_device, i2c), 1, NULL);
-	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_i2c_device, spi), 0, NULL);
+	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_i2c_device, i2c), 1);
+	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_i2c_device, spi), 0);
 
 	zassert_equal(DT_COMPAT_ON_BUS_INTERNAL(vnd_gpio_expander, i2c), 1,
 		      NULL);

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -271,7 +271,7 @@ ZTEST(devicetree_devices, test_get_or_null)
 	zassert_not_equal(dev, NULL, NULL);
 
 	dev = DEVICE_DT_GET_OR_NULL(non_existing_node);
-	zassert_equal(dev, NULL);
+	zassert_is_null(dev);
 }
 
 ZTEST(devicetree_devices, test_supports)

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -87,30 +87,30 @@ ZTEST(devicetree_devices, test_init_get)
 		      DEVICE_DT_GET(TEST_NOLABEL), NULL);
 
 	/* Check init functions */
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_GET(manual_dev)->init, dev_init, NULL);
-	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init, dev_init, NULL);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_I2C)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVA)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVB)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIOX)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_DEVC)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_PARTITION)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_GPIO_INJECTED)->init, dev_init);
+	zassert_equal(DEVICE_INIT_GET(manual_dev)->init, dev_init);
+	zassert_equal(DEVICE_INIT_DT_GET(TEST_NOLABEL)->init, dev_init);
 }
 
 ZTEST(devicetree_devices, test_init_order)
 {
-	zassert_equal(init_order[0], DEV_HDL(TEST_GPIO), NULL);
-	zassert_equal(init_order[1], DEV_HDL(TEST_I2C), NULL);
-	zassert_equal(init_order[2], DEV_HDL(TEST_DEVA), NULL);
-	zassert_equal(init_order[3], DEV_HDL(TEST_DEVB), NULL);
-	zassert_equal(init_order[4], DEV_HDL(TEST_GPIOX), NULL);
-	zassert_equal(init_order[5], DEV_HDL(TEST_DEVC), NULL);
-	zassert_equal(init_order[6], DEV_HDL(TEST_PARTITION), NULL);
-	zassert_equal(init_order[7], DEV_HDL(TEST_GPIO_INJECTED), NULL);
-	zassert_equal(init_order[8], DEV_HDL_NAME(manual_dev), NULL);
-	zassert_equal(init_order[9], DEV_HDL(TEST_NOLABEL), NULL);
+	zassert_equal(init_order[0], DEV_HDL(TEST_GPIO));
+	zassert_equal(init_order[1], DEV_HDL(TEST_I2C));
+	zassert_equal(init_order[2], DEV_HDL(TEST_DEVA));
+	zassert_equal(init_order[3], DEV_HDL(TEST_DEVB));
+	zassert_equal(init_order[4], DEV_HDL(TEST_GPIOX));
+	zassert_equal(init_order[5], DEV_HDL(TEST_DEVC));
+	zassert_equal(init_order[6], DEV_HDL(TEST_PARTITION));
+	zassert_equal(init_order[7], DEV_HDL(TEST_GPIO_INJECTED));
+	zassert_equal(init_order[8], DEV_HDL_NAME(manual_dev));
+	zassert_equal(init_order[9], DEV_HDL(TEST_NOLABEL));
 }
 
 static bool check_handle(device_handle_t hdl,
@@ -161,35 +161,35 @@ ZTEST(devicetree_devices, test_requires)
 
 	/* TEST_GPIO: no req */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO));
-	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO), NULL);
+	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO));
 	hdls = device_required_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 0);
 	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 
 	/* TEST_GPIO_INJECTED: no req */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO_INJECTED));
-	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
+	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED));
 	hdls = device_required_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 0);
 	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 
 	/* TEST_I2C: no req */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_I2C));
-	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C), NULL);
+	zassert_equal(dev, DEVICE_DT_GET(TEST_I2C));
 	hdls = device_required_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 0);
 	zassert_equal(0, device_required_foreach(dev, device_visitor, &ctx),
 		      NULL);
 
 	/* TEST_DEVA: TEST_I2C GPIO */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_DEVA));
-	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVA), NULL);
+	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVA));
 	hdls = device_required_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 2, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_GPIO), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 2);
+	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls));
+	zassert_true(check_handle(DEV_HDL(TEST_GPIO), hdls, nhdls));
 
 	/* Visit fails if not enough space */
 	ctx = (struct visitor_context){
@@ -213,10 +213,10 @@ ZTEST(devicetree_devices, test_requires)
 
 	/* TEST_GPIOX: TEST_I2C */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIOX));
-	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIOX), NULL);
+	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIOX));
 	hdls = device_required_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 1, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 1);
+	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls));
 	ctx = (struct visitor_context){
 		.ndevs = 3,
 	};
@@ -227,17 +227,17 @@ ZTEST(devicetree_devices, test_requires)
 
 	/* TEST_DEVB: TEST_I2C TEST_GPIOX */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_DEVB));
-	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVB), NULL);
+	zassert_equal(dev, DEVICE_DT_GET(TEST_DEVB));
 	hdls = device_required_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 2, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 2);
+	zassert_true(check_handle(DEV_HDL(TEST_I2C), hdls, nhdls));
+	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls));
 
 	/* TEST_GPIO_INJECTED: NONE */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO_INJECTED));
-	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED), NULL);
+	zassert_equal(dev, DEVICE_DT_GET(TEST_GPIO_INJECTED));
 	hdls = device_required_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 0);
 }
 
 ZTEST(devicetree_devices, test_injected)
@@ -249,18 +249,18 @@ ZTEST(devicetree_devices, test_injected)
 	/* TEST_GPIO: NONE */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO));
 	hdls = device_injected_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 0);
 
 	/* TEST_DEVB: NONE */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_DEVB));
 	hdls = device_injected_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 0);
 
 	/* TEST_GPIO_INJECTED: TEST_DEVB */
 	dev = device_get_binding(DEVICE_DT_NAME(TEST_GPIO_INJECTED));
 	hdls = device_injected_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 1, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 1);
+	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls));
 }
 
 ZTEST(devicetree_devices, test_get_or_null)
@@ -271,7 +271,7 @@ ZTEST(devicetree_devices, test_get_or_null)
 	zassert_not_equal(dev, NULL, NULL);
 
 	dev = DEVICE_DT_GET_OR_NULL(non_existing_node);
-	zassert_equal(dev, NULL, NULL);
+	zassert_equal(dev, NULL);
 }
 
 ZTEST(devicetree_devices, test_supports)
@@ -284,50 +284,50 @@ ZTEST(devicetree_devices, test_supports)
 	/* TEST_DEVB: None */
 	dev = DEVICE_DT_GET(TEST_DEVB);
 	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 1, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_GPIO_INJECTED), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 1);
+	zassert_true(check_handle(DEV_HDL(TEST_GPIO_INJECTED), hdls, nhdls));
 
 	/* TEST_GPIO_INJECTED: None */
 	dev = DEVICE_DT_GET(TEST_GPIO_INJECTED);
 	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 0, NULL);
+	zassert_equal(nhdls, 0);
 
 	/* TEST_GPIO: TEST_DEVA */
 	dev = DEVICE_DT_GET(TEST_GPIO);
 	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 1, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 1);
+	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls));
 
 	/* Visit fails if not enough space */
 	ctx = (struct visitor_context){
 		.ndevs = 0,
 	};
-	zassert_equal(-ENOSPC, device_supported_foreach(dev, device_visitor, &ctx), NULL);
+	zassert_equal(-ENOSPC, device_supported_foreach(dev, device_visitor, &ctx));
 
 	/* Visit succeeds if enough space. */
 	ctx = (struct visitor_context){
 		.ndevs = 1,
 	};
-	zassert_equal(1, device_supported_foreach(dev, device_visitor, &ctx), NULL);
-	zassert_true(ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_DEVA)), NULL);
+	zassert_equal(1, device_supported_foreach(dev, device_visitor, &ctx));
+	zassert_true(ctx.rdevs[0] == device_from_handle(DEV_HDL(TEST_DEVA)));
 
 	/* TEST_I2C: TEST_DEVA TEST_GPIOX TEST_DEVB TEST_DEVC */
 	dev = DEVICE_DT_GET(TEST_I2C);
 	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 5, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_DEVC), hdls, nhdls), NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_NOLABEL), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 5);
+	zassert_true(check_handle(DEV_HDL(TEST_DEVA), hdls, nhdls));
+	zassert_true(check_handle(DEV_HDL(TEST_GPIOX), hdls, nhdls));
+	zassert_true(check_handle(DEV_HDL(TEST_DEVB), hdls, nhdls));
+	zassert_true(check_handle(DEV_HDL(TEST_DEVC), hdls, nhdls));
+	zassert_true(check_handle(DEV_HDL(TEST_NOLABEL), hdls, nhdls));
 
 	/* Support forwarding (intermediate missing devicetree node)
 	 * TEST_DEVC: TEST_PARTITION
 	 */
 	dev = DEVICE_DT_GET(TEST_DEVC);
 	hdls = device_supported_handles_get(dev, &nhdls);
-	zassert_equal(nhdls, 1, NULL);
-	zassert_true(check_handle(DEV_HDL(TEST_PARTITION), hdls, nhdls), NULL);
+	zassert_equal(nhdls, 1);
+	zassert_true(check_handle(DEV_HDL(TEST_PARTITION), hdls, nhdls));
 }
 
 void *devicetree_devices_setup(void)

--- a/tests/lib/fdtable/src/main.c
+++ b/tests/lib/fdtable/src/main.c
@@ -86,7 +86,7 @@ ZTEST(fdtable, test_z_finalize_fd)
 	const struct fd_op_vtable *vtable;
 
 	int fd = z_reserve_fd();
-	zassert_true(fd >= 0, NULL);
+	zassert_true(fd >= 0);
 
 	int *obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 
@@ -109,7 +109,7 @@ ZTEST(fdtable, test_z_alloc_fd)
 	int *obj = NULL;
 
 	int fd = z_alloc_fd(obj, vtable); /* function being tested */
-	zassert_true(fd >= 0, NULL);
+	zassert_true(fd >= 0);
 
 	obj = z_get_fd_obj_and_vtable(fd, &vtable, NULL);
 
@@ -124,7 +124,7 @@ ZTEST(fdtable, test_z_free_fd)
 	const struct fd_op_vtable *vtable = NULL;
 
 	int fd = z_reserve_fd();
-	zassert_true(fd >= 0, NULL);
+	zassert_true(fd >= 0);
 
 	z_free_fd(fd); /* function being tested */
 

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -59,13 +59,13 @@ static void drop(const struct mpsc_pbuf_buffer *buffer, const union mpsc_pbuf_ge
 {
 	struct test_data_var *packet = (struct test_data_var *)item;
 
-	zassert_equal(packet->hdr.data, exp_dropped_data[drop_cnt], NULL);
-	zassert_equal(packet->hdr.len, exp_dropped_len[drop_cnt], NULL);
+	zassert_equal(packet->hdr.data, exp_dropped_data[drop_cnt]);
+	zassert_equal(packet->hdr.len, exp_dropped_len[drop_cnt]);
 	for (int i = 0; i < exp_dropped_len[drop_cnt] - 1; i++) {
 		int err = memcmp(packet->data, &exp_dropped_data[drop_cnt],
 				 sizeof(uint32_t));
 
-		zassert_equal(err, 0, NULL);
+		zassert_equal(err, 0);
 	}
 
 	drop_cnt++;
@@ -119,13 +119,13 @@ void item_put_no_overwrite(bool pow2)
 		mpsc_pbuf_put_word(&buffer, test_1word.item);
 
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL, NULL);
+	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
 }
 
 ZTEST(log_buffer, test_item_put_no_overwrite)
@@ -170,17 +170,17 @@ void item_put_saturate(bool pow2)
 	union test_item test_1word = {.data = {.valid = 1, .len = 1 }};
 	union test_item *t;
 
-	zassert_false(mpsc_pbuf_is_pending(&buffer), NULL);
+	zassert_false(mpsc_pbuf_is_pending(&buffer));
 
 	for (int i = 0; i < repeat/2; i++) {
 		test_1word.data.data = i;
 		mpsc_pbuf_put_word(&buffer, test_1word.item);
 
-		zassert_true(mpsc_pbuf_is_pending(&buffer), NULL);
+		zassert_true(mpsc_pbuf_is_pending(&buffer));
 
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
@@ -191,12 +191,12 @@ void item_put_saturate(bool pow2)
 
 	for (int i = 0; i < (repeat-1); i++) {
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL, NULL);
+	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
 }
 
 ZTEST(log_buffer, test_item_put_saturate)
@@ -229,15 +229,15 @@ void benchmark_item_put(bool pow2)
 		union test_item *t;
 
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
 	t = get_cyc() - t;
 	PRINT("single word item claim,free: %d cycles\n", t/repeat);
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL, NULL);
+	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
 }
 
 ZTEST(log_buffer, test_benchmark_item_put)
@@ -269,13 +269,13 @@ void item_put_ext_no_overwrite(bool pow2)
 		mpsc_pbuf_put_word_ext(&buffer, test_ext_item.item, data);
 
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data_ext.hdr.data, i, NULL);
-		zassert_equal(t->data_ext.data, (void *)i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data_ext.hdr.data, i);
+		zassert_equal(t->data_ext.data, (void *)i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL, NULL);
+	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
 }
 
 ZTEST(log_buffer, test_item_put_ext_no_overwrite)
@@ -344,8 +344,8 @@ void item_put_ext_saturate(bool pow2)
 		mpsc_pbuf_put_word_ext(&buffer, test_ext_item.item, data);
 
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
@@ -357,13 +357,13 @@ void item_put_ext_saturate(bool pow2)
 
 	for (uintptr_t i = 0; i < (repeat-1); i++) {
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data_ext.data, (void *)i, NULL);
-		zassert_equal(t->data_ext.hdr.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data_ext.data, (void *)i);
+		zassert_equal(t->data_ext.hdr.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL, NULL);
+	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
 }
 
 ZTEST(log_buffer, test_item_put_ext_saturate)
@@ -402,15 +402,15 @@ void benchmark_item_put_ext(bool pow2)
 		union test_item *t;
 
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
 	t = get_cyc() - t;
 	PRINT("ext item claim,free: %d cycles\n", t/repeat);
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL, NULL);
+	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
 }
 
 ZTEST(log_buffer, test_benchmark_item_put_ext)
@@ -453,15 +453,15 @@ void benchmark_item_put_data(bool pow2)
 		union test_item *t;
 
 		t = (union test_item *)mpsc_pbuf_claim(&buffer);
-		zassert_true(t, NULL);
-		zassert_equal(t->data.data, i, NULL);
+		zassert_true(t);
+		zassert_equal(t->data.data, i);
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
 	t = get_cyc() - t;
 	PRINT("ext item claim,free: %d cycles\n", t/repeat);
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL, NULL);
+	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
 }
 
 ZTEST(log_buffer, test_benchmark_item_put_data)
@@ -534,11 +534,11 @@ void item_alloc_commit(bool pow2)
 		mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)packet);
 
 		packet = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-		zassert_true(packet, NULL);
-		zassert_equal(packet->hdr.len, len, NULL);
+		zassert_true(packet);
+		zassert_equal(packet->hdr.len, len);
 
 		for (int j = 0; j < len - 1; j++) {
-			zassert_equal(packet->data[j], i + j, NULL);
+			zassert_equal(packet->data[j], i + j);
 		}
 
 		mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)packet);
@@ -563,7 +563,7 @@ void item_max_alloc(bool overwrite)
 		packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer,
 								 buffer.size - 1,
 								 K_NO_WAIT);
-		zassert_true(packet != NULL, NULL);
+		zassert_true(packet != NULL);
 		packet->hdr.len = buffer.size - 1;
 		mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)packet);
 
@@ -575,7 +575,7 @@ void item_max_alloc(bool overwrite)
 	packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer,
 							 buffer.size,
 							 K_NO_WAIT);
-	zassert_true(packet == NULL, NULL);
+	zassert_true(packet == NULL);
 }
 
 ZTEST(log_buffer, test_item_max_alloc)
@@ -601,14 +601,14 @@ static uint32_t saturate_buffer_uneven(struct mpsc_pbuf_buffer *buffer,
 		mpsc_pbuf_commit(buffer, (union mpsc_pbuf_generic *)packet);
 
 		packet = (struct test_data_var *)mpsc_pbuf_claim(buffer);
-		zassert_true(packet, NULL);
+		zassert_true(packet);
 		mpsc_pbuf_free(buffer, (union mpsc_pbuf_generic *)packet);
 	}
 
 	for (int i = 0; i < repeat; i++) {
 		packet = (struct test_data_var *)mpsc_pbuf_alloc(buffer, len,
 								 K_NO_WAIT);
-		zassert_true(packet, NULL);
+		zassert_true(packet);
 		packet->hdr.len = len;
 		packet->hdr.data = i;
 		for (int j = 0; j < len - 1; j++) {
@@ -635,17 +635,17 @@ void item_alloc_commit_saturate(bool pow2)
 
 	packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len,
 							 K_NO_WAIT);
-	zassert_equal(packet, NULL, NULL);
+	zassert_equal(packet, NULL);
 
 	/* Get one packet from the buffer. */
 	packet = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(packet, NULL);
+	zassert_true(packet);
 	mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)packet);
 
 	/* and try to allocate one more time, this time with success. */
 	packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len,
 							 K_NO_WAIT);
-	zassert_true(packet, NULL);
+	zassert_true(packet);
 }
 
 ZTEST(log_buffer, test_item_alloc_commit_saturate)
@@ -665,15 +665,15 @@ void item_alloc_preemption(bool pow2)
 	struct test_data_var *p;
 
 	p0 = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, 10, K_NO_WAIT);
-	zassert_true(p0, NULL);
+	zassert_true(p0);
 	p0->hdr.len = 10;
 
 	/* Check that no packet is yet available */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL, NULL);
+	zassert_equal(p, NULL);
 
 	p1 = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, 20, K_NO_WAIT);
-	zassert_true(p1, NULL);
+	zassert_true(p1);
 	p1->hdr.len = 20;
 
 	/* Commit p1, p0 is still not committed, there should be no packets
@@ -683,25 +683,25 @@ void item_alloc_preemption(bool pow2)
 
 	/* Check that no packet is yet available */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL, NULL);
+	zassert_equal(p, NULL);
 
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p0);
 
 	/* Validate that p0 is the first one. */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p, NULL);
-	zassert_equal(p->hdr.len, 10, NULL);
+	zassert_true(p);
+	zassert_equal(p->hdr.len, 10);
 	mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p);
 
 	/* Validate that p1 is the next one. */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p, NULL);
-	zassert_equal(p->hdr.len, 20, NULL);
+	zassert_true(p);
+	zassert_equal(p->hdr.len, 20);
 	mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p);
 
 	/* No more packets. */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL, NULL);
+	zassert_equal(p, NULL);
 }
 
 ZTEST(log_buffer, test_item_alloc_preemption)
@@ -727,7 +727,7 @@ void overwrite(bool pow2)
 
 	p->hdr.len = len0;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p);
-	zassert_equal(drop_cnt, 1, NULL);
+	zassert_equal(drop_cnt, 1);
 
 	/* Request allocation which will require dropping 2 packets. */
 	len1 = 9;
@@ -740,32 +740,32 @@ void overwrite(bool pow2)
 
 	p->hdr.len = len1;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p);
-	zassert_equal(drop_cnt, 3, NULL);
+	zassert_equal(drop_cnt, 3);
 
 	for (int i = 0; i < (packet_cnt - drop_cnt); i++) {
 		p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-		zassert_true(p, NULL);
-		zassert_equal(p->hdr.len, fill_len, NULL);
-		zassert_equal(p->hdr.data, i + drop_cnt, NULL);
+		zassert_true(p);
+		zassert_equal(p->hdr.len, fill_len);
+		zassert_equal(p->hdr.data, i + drop_cnt);
 		for (int j = 0; j < fill_len - 1; j++) {
-			zassert_equal(p->data[j], p->hdr.data + j, NULL);
+			zassert_equal(p->data[j], p->hdr.data + j);
 		}
 
 		mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p);
 	}
 
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p, NULL);
-	zassert_equal(p->hdr.len, len0, NULL);
+	zassert_true(p);
+	zassert_equal(p->hdr.len, len0);
 	mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p);
 
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p, NULL);
-	zassert_equal(p->hdr.len, len1, NULL);
+	zassert_true(p);
+	zassert_equal(p->hdr.len, len1);
 	mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p);
 
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL, NULL);
+	zassert_equal(p, NULL);
 }
 
 ZTEST(log_buffer, test_overwrite)
@@ -790,8 +790,8 @@ void overwrite_while_claimed(bool pow2)
 	 * skip claimed packed and drop the next one.
 	 */
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p0, NULL);
-	zassert_equal(p0->hdr.len, fill_len, NULL);
+	zassert_true(p0);
+	zassert_equal(p0->hdr.len, fill_len);
 
 	exp_dropped_data[0] = p0->hdr.data + 1; /* next packet is dropped */
 	exp_dropped_len[0] = fill_len;
@@ -799,7 +799,7 @@ void overwrite_while_claimed(bool pow2)
 	exp_dropped_len[1] = fill_len;
 	p1 = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, 6, K_NO_WAIT);
 
-	zassert_equal(drop_cnt, 2, NULL);
+	zassert_equal(drop_cnt, 2);
 	p1->hdr.len = len;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p1);
 
@@ -807,18 +807,18 @@ void overwrite_while_claimed(bool pow2)
 
 	for (int i = 0; i < packet_cnt - drop_cnt - 1; i++) {
 		p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-		zassert_true(p0, NULL);
-		zassert_equal(p0->hdr.len, fill_len, NULL);
-		zassert_equal(p0->hdr.data, i + drop_cnt + 1, NULL);
+		zassert_true(p0);
+		zassert_equal(p0->hdr.len, fill_len);
+		zassert_equal(p0->hdr.data, i + drop_cnt + 1);
 		mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p0);
 	}
 
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p0, NULL);
-	zassert_equal(p0->hdr.len, len, NULL);
+	zassert_true(p0);
+	zassert_equal(p0->hdr.len, len);
 
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p0, NULL, NULL);
+	zassert_equal(p0, NULL);
 }
 
 ZTEST(log_buffer, test_overwrite_while_claimed)
@@ -843,8 +843,8 @@ void overwrite_while_claimed2(bool pow2)
 	 * skip claimed packed and drop the next one.
 	 */
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p0, NULL);
-	zassert_equal(p0->hdr.len, fill_len, NULL);
+	zassert_true(p0);
+	zassert_equal(p0->hdr.len, fill_len);
 
 	exp_dropped_data[0] = p0->hdr.data + 1; /* next packet is dropped */
 	exp_dropped_len[0] = fill_len;
@@ -856,7 +856,7 @@ void overwrite_while_claimed2(bool pow2)
 	exp_dropped_len[3] = fill_len;
 	p1 = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len, K_NO_WAIT);
 
-	zassert_equal(drop_cnt, 4, NULL);
+	zassert_equal(drop_cnt, 4);
 	p1->hdr.len = len;
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p1);
 
@@ -864,18 +864,18 @@ void overwrite_while_claimed2(bool pow2)
 
 	for (int i = 0; i < packet_cnt - drop_cnt - 1; i++) {
 		p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-		zassert_true(p0, NULL);
-		zassert_equal(p0->hdr.len, fill_len, NULL);
-		zassert_equal(p0->hdr.data, i + drop_cnt + 1, NULL);
+		zassert_true(p0);
+		zassert_equal(p0->hdr.len, fill_len);
+		zassert_equal(p0->hdr.data, i + drop_cnt + 1);
 		mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p0);
 	}
 
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_true(p0, NULL);
-	zassert_equal(p0->hdr.len, len, NULL);
+	zassert_true(p0);
+	zassert_equal(p0->hdr.len, len);
 
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p0, NULL, NULL);
+	zassert_equal(p0, NULL);
 }
 
 ZTEST(log_buffer, test_overwrite_while_claimed2)
@@ -986,7 +986,7 @@ void t_entry(void *p0, void *p1, void *p2)
 	t = (struct test_data_ext *)mpsc_pbuf_alloc(buffer,
 						    sizeof(*t) / sizeof(uint32_t),
 						    K_MSEC(1));
-	zassert_equal(t, NULL, NULL);
+	zassert_equal(t, NULL);
 
 	t = (struct test_data_ext *)mpsc_pbuf_alloc(buffer,
 						    sizeof(*t) / sizeof(uint32_t),
@@ -1021,7 +1021,7 @@ void start_threads(struct mpsc_pbuf_buffer *buffer)
 		k_ticks_t exp_wait = k_ms_to_ticks_ceil32(wait_ms);
 
 		/* Threads shall be blocked, waiting for available space. */
-		zassert_within(t, exp_wait, k_ms_to_ticks_ceil32(2), NULL);
+		zassert_within(t, exp_wait, k_ms_to_ticks_ceil32(2));
 	}
 }
 
@@ -1057,8 +1057,8 @@ ZTEST(log_buffer, test_pending_alloc)
 		struct test_data_ext *t =
 			(struct test_data_ext *)mpsc_pbuf_claim(&buffer);
 
-		zassert_true(t, NULL);
-		zassert_equal(t->data, tids[ARRAY_SIZE(tids) - 1 - i], NULL);
+		zassert_true(t);
+		zassert_equal(t->data, tids[ARRAY_SIZE(tids) - 1 - i]);
 		vt = t;
 		zassert_true(IS_PTR_ALIGNED(vt, union mpsc_pbuf_generic), "unaligned ptr");
 		mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)vt);
@@ -1081,7 +1081,7 @@ static void check_usage(struct mpsc_pbuf_buffer *buffer,
 	zassert_equal(usage, now, "%d: got:%d, exp:%d", line, usage, now);
 
 	err = mpsc_pbuf_get_max_utilization(buffer, &usage);
-	zassert_equal(err, exp_err, NULL);
+	zassert_equal(err, exp_err);
 	if (err == 0) {
 		zassert_equal(usage, max, "%d: got:%d, exp:%d", line, usage, max);
 	}
@@ -1137,12 +1137,12 @@ ZTEST(log_buffer, test_utilization)
 
 	t = (union test_item *)mpsc_pbuf_claim(&buffer);
 
-	zassert_true(t != NULL, NULL);
+	zassert_true(t != NULL);
 	CHECK_USAGE(&buffer, 1 + PUT_EXT_LEN, 1 + PUT_EXT_LEN);
 	mpsc_pbuf_free(&buffer, &t->item);
 
 	t = (union test_item *)mpsc_pbuf_claim(&buffer);
-	zassert_true(t != NULL, NULL);
+	zassert_true(t != NULL);
 
 	CHECK_USAGE(&buffer, PUT_EXT_LEN, 1 + PUT_EXT_LEN);
 
@@ -1165,7 +1165,7 @@ ZTEST(log_buffer, test_utilization)
 	CHECK_USAGE(&buffer, PUT_EXT_LEN, 1 + PUT_EXT_LEN);
 
 	t = (union test_item *)mpsc_pbuf_claim(&buffer);
-	zassert_true(t != NULL, NULL);
+	zassert_true(t != NULL);
 	mpsc_pbuf_free(&buffer, &t->item);
 
 	CHECK_USAGE(&buffer, 0, 1 + PUT_EXT_LEN);
@@ -1188,7 +1188,7 @@ ZTEST(log_buffer, test_utilization)
 
 	packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len, K_NO_WAIT);
 
-	zassert_true(packet == NULL, NULL);
+	zassert_true(packet == NULL);
 }
 
 /*test case main entry*/

--- a/tests/lib/mpsc_pbuf/src/main.c
+++ b/tests/lib/mpsc_pbuf/src/main.c
@@ -125,7 +125,7 @@ void item_put_no_overwrite(bool pow2)
 
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
+	zassert_is_null(mpsc_pbuf_claim(&buffer));
 }
 
 ZTEST(log_buffer, test_item_put_no_overwrite)
@@ -196,7 +196,7 @@ void item_put_saturate(bool pow2)
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
+	zassert_is_null(mpsc_pbuf_claim(&buffer));
 }
 
 ZTEST(log_buffer, test_item_put_saturate)
@@ -237,7 +237,7 @@ void benchmark_item_put(bool pow2)
 	t = get_cyc() - t;
 	PRINT("single word item claim,free: %d cycles\n", t/repeat);
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
+	zassert_is_null(mpsc_pbuf_claim(&buffer));
 }
 
 ZTEST(log_buffer, test_benchmark_item_put)
@@ -275,7 +275,7 @@ void item_put_ext_no_overwrite(bool pow2)
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
+	zassert_is_null(mpsc_pbuf_claim(&buffer));
 }
 
 ZTEST(log_buffer, test_item_put_ext_no_overwrite)
@@ -363,7 +363,7 @@ void item_put_ext_saturate(bool pow2)
 		mpsc_pbuf_free(&buffer, &t->item);
 	}
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
+	zassert_is_null(mpsc_pbuf_claim(&buffer));
 }
 
 ZTEST(log_buffer, test_item_put_ext_saturate)
@@ -410,7 +410,7 @@ void benchmark_item_put_ext(bool pow2)
 	t = get_cyc() - t;
 	PRINT("ext item claim,free: %d cycles\n", t/repeat);
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
+	zassert_is_null(mpsc_pbuf_claim(&buffer));
 }
 
 ZTEST(log_buffer, test_benchmark_item_put_ext)
@@ -461,7 +461,7 @@ void benchmark_item_put_data(bool pow2)
 	t = get_cyc() - t;
 	PRINT("ext item claim,free: %d cycles\n", t/repeat);
 
-	zassert_equal(mpsc_pbuf_claim(&buffer), NULL);
+	zassert_is_null(mpsc_pbuf_claim(&buffer));
 }
 
 ZTEST(log_buffer, test_benchmark_item_put_data)
@@ -635,7 +635,7 @@ void item_alloc_commit_saturate(bool pow2)
 
 	packet = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, len,
 							 K_NO_WAIT);
-	zassert_equal(packet, NULL);
+	zassert_is_null(packet);
 
 	/* Get one packet from the buffer. */
 	packet = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
@@ -670,7 +670,7 @@ void item_alloc_preemption(bool pow2)
 
 	/* Check that no packet is yet available */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL);
+	zassert_is_null(p);
 
 	p1 = (struct test_data_var *)mpsc_pbuf_alloc(&buffer, 20, K_NO_WAIT);
 	zassert_true(p1);
@@ -683,7 +683,7 @@ void item_alloc_preemption(bool pow2)
 
 	/* Check that no packet is yet available */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL);
+	zassert_is_null(p);
 
 	mpsc_pbuf_commit(&buffer, (union mpsc_pbuf_generic *)p0);
 
@@ -701,7 +701,7 @@ void item_alloc_preemption(bool pow2)
 
 	/* No more packets. */
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL);
+	zassert_is_null(p);
 }
 
 ZTEST(log_buffer, test_item_alloc_preemption)
@@ -765,7 +765,7 @@ void overwrite(bool pow2)
 	mpsc_pbuf_free(&buffer, (union mpsc_pbuf_generic *)p);
 
 	p = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p, NULL);
+	zassert_is_null(p);
 }
 
 ZTEST(log_buffer, test_overwrite)
@@ -818,7 +818,7 @@ void overwrite_while_claimed(bool pow2)
 	zassert_equal(p0->hdr.len, len);
 
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p0, NULL);
+	zassert_is_null(p0);
 }
 
 ZTEST(log_buffer, test_overwrite_while_claimed)
@@ -875,7 +875,7 @@ void overwrite_while_claimed2(bool pow2)
 	zassert_equal(p0->hdr.len, len);
 
 	p0 = (struct test_data_var *)mpsc_pbuf_claim(&buffer);
-	zassert_equal(p0, NULL);
+	zassert_is_null(p0);
 }
 
 ZTEST(log_buffer, test_overwrite_while_claimed2)
@@ -986,7 +986,7 @@ void t_entry(void *p0, void *p1, void *p2)
 	t = (struct test_data_ext *)mpsc_pbuf_alloc(buffer,
 						    sizeof(*t) / sizeof(uint32_t),
 						    K_MSEC(1));
-	zassert_equal(t, NULL);
+	zassert_is_null(t);
 
 	t = (struct test_data_ext *)mpsc_pbuf_alloc(buffer,
 						    sizeof(*t) / sizeof(uint32_t),

--- a/tests/lib/ringbuffer/src/concurrent.c
+++ b/tests/lib/ringbuffer/src/concurrent.c
@@ -35,7 +35,7 @@ static void data_write(uint32_t *input)
 	sys_mutex_lock(&mutex, K_FOREVER);
 	int ret = ring_buf_item_put(&ringbuf, TYPE, VALUE,
 				   input, LENGTH);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	sys_mutex_unlock(&mutex);
 }
 
@@ -49,14 +49,14 @@ static void data_read(uint32_t *output)
 	ret = ring_buf_item_get(&ringbuf, &type, &value, output, &size32);
 	sys_mutex_unlock(&mutex);
 
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(type, TYPE, NULL);
-	zassert_equal(value, VALUE, NULL);
-	zassert_equal(size32, LENGTH, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(type, TYPE);
+	zassert_equal(value, VALUE);
+	zassert_equal(size32, LENGTH);
 	if (output[0] == 1) {
-		zassert_equal(memcmp(output, databuffer1, size32), 0, NULL);
+		zassert_equal(memcmp(output, databuffer1, size32), 0);
 	} else {
-		zassert_equal(memcmp(output, databuffer2, size32), 0, NULL);
+		zassert_equal(memcmp(output, databuffer2, size32), 0);
 	}
 }
 
@@ -129,7 +129,7 @@ static bool consume_cpy(void *user_data, uint32_t iter_cnt, bool last, int prio)
 
 	len = ring_buf_get(&ringbuf, buf, sizeof(buf));
 	for (int i = 0; i < len; i++) {
-		zassert_equal(buf[i], (uint8_t)cnt, NULL);
+		zassert_equal(buf[i], (uint8_t)cnt);
 		cnt++;
 	}
 
@@ -169,11 +169,11 @@ static bool consume_item(void *user_data, uint32_t cnt, bool last, int prio)
 
 	err = ring_buf_item_get(&ringbuf, &type, &value, data, &size32);
 	if (err == 0) {
-		zassert_equal(value, VALUE, NULL);
-		zassert_equal(type, (uint16_t)pcnt, NULL);
+		zassert_equal(value, VALUE);
+		zassert_equal(type, (uint16_t)pcnt);
 		pcnt++;
 	} else if (err == -EMSGSIZE) {
-		zassert_true(false, NULL);
+		zassert_true(false);
 	}
 
 	return true;
@@ -248,7 +248,7 @@ static bool consume(void *user_data, uint32_t iter_cnt, bool last, int prio)
 
 	int err = ring_buf_get_finish(&ringbuf, len);
 
-	zassert_equal(err, 0, NULL);
+	zassert_equal(err, 0);
 
 	return true;
 }

--- a/tests/lib/ringbuffer/src/main.c
+++ b/tests/lib/ringbuffer/src/main.c
@@ -182,7 +182,7 @@ static void tringbuf_put(const void *p)
 	int ret = ring_buf_item_put(pbuf, data[index].type, data[index].value,
 				   data[index].buffer, data[index].length);
 
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 static void tringbuf_get(const void *p)
@@ -194,11 +194,11 @@ static void tringbuf_get(const void *p)
 
 	/**TESTPOINT: ring buffer get*/
 	ret = ring_buf_item_get(pbuf, &type, &value, rx_data, &size32);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(type, data[index].type, NULL);
-	zassert_equal(value, data[index].value, NULL);
-	zassert_equal(size32, data[index].length, NULL);
-	zassert_equal(memcmp(rx_data, data[index].buffer, size32), 0, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(type, data[index].type);
+	zassert_equal(value, data[index].value);
+	zassert_equal(size32, data[index].length);
+	zassert_equal(memcmp(rx_data, data[index].buffer, size32), 0);
 }
 
 static void tringbuf_get_discard(const void *p)
@@ -209,10 +209,10 @@ static void tringbuf_get_discard(const void *p)
 
 	/**TESTPOINT: ring buffer get*/
 	ret = ring_buf_item_get(pbuf, &type, &value, NULL, &size32);
-	zassert_equal(ret, 0, NULL);
-	zassert_equal(type, data[index].type, NULL);
-	zassert_equal(value, data[index].value, NULL);
-	zassert_equal(size32, data[index].length, NULL);
+	zassert_equal(ret, 0);
+	zassert_equal(type, data[index].type);
+	zassert_equal(value, data[index].value);
+	zassert_equal(size32, data[index].length);
 }
 
 /*test cases*/
@@ -220,19 +220,19 @@ ZTEST(ringbuffer_api, test_ringbuffer_init)
 {
 	/**TESTPOINT: init via ring_buf_item_init*/
 	ring_buf_item_init(&ringbuf, RINGBUFFER_SIZE, buffer);
-	zassert_true(ring_buf_is_empty(&ringbuf), NULL);
-	zassert_equal(ring_buf_item_space_get(&ringbuf), RINGBUFFER_SIZE, NULL);
+	zassert_true(ring_buf_is_empty(&ringbuf));
+	zassert_equal(ring_buf_item_space_get(&ringbuf), RINGBUFFER_SIZE);
 }
 
 ZTEST(ringbuffer_api, test_ringbuffer_declare_pow2)
 {
-	zassert_true(ring_buf_is_empty(&ringbuf_pow2), NULL);
-	zassert_equal(ring_buf_item_space_get(&ringbuf_pow2), (1 << POW), NULL);
+	zassert_true(ring_buf_is_empty(&ringbuf_pow2));
+	zassert_equal(ring_buf_item_space_get(&ringbuf_pow2), (1 << POW));
 }
 
 ZTEST(ringbuffer_api, test_ringbuffer_declare_size)
 {
-	zassert_true(ring_buf_is_empty(&ringbuf_size), NULL);
+	zassert_true(ring_buf_is_empty(&ringbuf_size));
 	zassert_equal(ring_buf_item_space_get(&ringbuf_size), RINGBUFFER_SIZE,
 		      NULL);
 }
@@ -286,9 +286,9 @@ ZTEST(ringbuffer_api, test_ringbuffer_put_get_thread)
 		tringbuf_get((const void *)0);
 		tringbuf_get((const void *)1);
 		tringbuf_put((const void *)2);
-		zassert_false(ring_buf_is_empty(pbuf), NULL);
+		zassert_false(ring_buf_is_empty(pbuf));
 		tringbuf_get((const void *)2);
-		zassert_true(ring_buf_is_empty(pbuf), NULL);
+		zassert_true(ring_buf_is_empty(pbuf));
 	}
 }
 
@@ -300,9 +300,9 @@ ZTEST(ringbuffer_api, test_ringbuffer_put_get_isr)
 	irq_offload(tringbuf_get, (const void *)0);
 	irq_offload(tringbuf_get, (const void *)1);
 	irq_offload(tringbuf_put, (const void *)2);
-	zassert_false(ring_buf_is_empty(pbuf), NULL);
+	zassert_false(ring_buf_is_empty(pbuf));
 	irq_offload(tringbuf_get, (const void *)2);
-	zassert_true(ring_buf_is_empty(pbuf), NULL);
+	zassert_true(ring_buf_is_empty(pbuf));
 }
 
 ZTEST(ringbuffer_api, test_ringbuffer_put_get_thread_isr)
@@ -321,10 +321,10 @@ ZTEST(ringbuffer_api, test_ringbuffer_put_get_discard)
 	pbuf = &ringbuf;
 	tringbuf_put((const void *)0);
 	tringbuf_put((const void *)1);
-	zassert_false(ring_buf_is_empty(pbuf), NULL);
+	zassert_false(ring_buf_is_empty(pbuf));
 	tringbuf_get_discard((const void *)0);
 	tringbuf_get_discard((const void *)1);
-	zassert_true(ring_buf_is_empty(pbuf), NULL);
+	zassert_true(ring_buf_is_empty(pbuf));
 }
 
 /**
@@ -499,8 +499,8 @@ ZTEST(ringbuffer_api, test_ringbuffer_raw)
 		out_size = ring_buf_get(&ringbuf_raw, outbuf,
 						RINGBUFFER_SIZE - 2);
 
-		zassert_true(in_size == RINGBUFFER_SIZE - 2, NULL);
-		zassert_true(in_size == out_size, NULL);
+		zassert_true(in_size == RINGBUFFER_SIZE - 2);
+		zassert_true(in_size == out_size);
 		zassert_true(memcmp(inbuf, outbuf, RINGBUFFER_SIZE - 2) == 0,
 			     NULL);
 	}
@@ -508,35 +508,35 @@ ZTEST(ringbuffer_api, test_ringbuffer_raw)
 	memset(outbuf, 0, sizeof(outbuf));
 	in_size = ring_buf_put(&ringbuf_raw, inbuf,
 				       RINGBUFFER_SIZE);
-	zassert_equal(in_size, RINGBUFFER_SIZE, NULL);
+	zassert_equal(in_size, RINGBUFFER_SIZE);
 
 	in_size = ring_buf_put(&ringbuf_raw, inbuf,
 				       1);
-	zassert_equal(in_size, 0, NULL);
+	zassert_equal(in_size, 0);
 
 	out_size = ring_buf_get(&ringbuf_raw, outbuf,
 					RINGBUFFER_SIZE);
 
-	zassert_true(out_size == RINGBUFFER_SIZE, NULL);
+	zassert_true(out_size == RINGBUFFER_SIZE);
 
 	out_size = ring_buf_get(&ringbuf_raw, outbuf,
 					RINGBUFFER_SIZE + 1);
-	zassert_true(out_size == 0, NULL);
-	zassert_true(ring_buf_is_empty(&ringbuf_raw), NULL);
+	zassert_true(out_size == 0);
+	zassert_true(ring_buf_is_empty(&ringbuf_raw));
 
 	/* Validate that raw bytes can be discarded */
 	in_size = ring_buf_put(&ringbuf_raw, inbuf,
 				       RINGBUFFER_SIZE);
-	zassert_equal(in_size, RINGBUFFER_SIZE, NULL);
+	zassert_equal(in_size, RINGBUFFER_SIZE);
 
 	out_size = ring_buf_get(&ringbuf_raw, NULL,
 					RINGBUFFER_SIZE);
-	zassert_true(out_size == RINGBUFFER_SIZE, NULL);
+	zassert_true(out_size == RINGBUFFER_SIZE);
 
 	out_size = ring_buf_get(&ringbuf_raw, NULL,
 					RINGBUFFER_SIZE + 1);
-	zassert_true(out_size == 0, NULL);
-	zassert_true(ring_buf_is_empty(&ringbuf_raw), NULL);
+	zassert_true(out_size == 0);
+	zassert_true(ring_buf_is_empty(&ringbuf_raw));
 }
 
 ZTEST(ringbuffer_api, test_ringbuffer_alloc_put)
@@ -551,26 +551,26 @@ ZTEST(ringbuffer_api, test_ringbuffer_alloc_put)
 	ring_buf_init(&ringbuf_raw, RINGBUFFER_SIZE, ringbuf_raw.buffer);
 
 	allocated = ring_buf_put_claim(&ringbuf_raw, &data, 1);
-	zassert_true(allocated == 1U, NULL);
+	zassert_true(allocated == 1U);
 
 
 	allocated = ring_buf_put_claim(&ringbuf_raw, &data,
 					   RINGBUFFER_SIZE - 1);
-	zassert_true(allocated == RINGBUFFER_SIZE - 1, NULL);
+	zassert_true(allocated == RINGBUFFER_SIZE - 1);
 
 	/* Putting too much returns error */
 	err = ring_buf_put_finish(&ringbuf_raw, RINGBUFFER_SIZE + 1);
-	zassert_true(err != 0, NULL);
+	zassert_true(err != 0);
 
 	err = ring_buf_put_finish(&ringbuf_raw, 1);
-	zassert_true(err == 0, NULL);
+	zassert_true(err == 0);
 
 	err = ring_buf_put_finish(&ringbuf_raw, RINGBUFFER_SIZE - 1);
-	zassert_true(err == -EINVAL, NULL);
+	zassert_true(err == -EINVAL);
 
 	read_size = ring_buf_get(&ringbuf_raw, outputbuf,
 					     RINGBUFFER_SIZE);
-	zassert_true(read_size == 1, NULL);
+	zassert_true(read_size == 1);
 
 	for (int i = 0; i < 10; i++) {
 		allocated = ring_buf_put_claim(&ringbuf_raw, &data, 2);
@@ -594,13 +594,13 @@ ZTEST(ringbuffer_api, test_ringbuffer_alloc_put)
 		}
 
 		err = ring_buf_put_finish(&ringbuf_raw, 4);
-		zassert_true(err == 0, NULL);
+		zassert_true(err == 0);
 
 		read_size = ring_buf_get(&ringbuf_raw,
 						     outputbuf, 4);
-		zassert_true(read_size == 4U, NULL);
+		zassert_true(read_size == 4U);
 
-		zassert_true(memcmp(outputbuf, inputbuf, 4) == 0, NULL);
+		zassert_true(memcmp(outputbuf, inputbuf, 4) == 0);
 	}
 }
 
@@ -615,7 +615,7 @@ ZTEST(ringbuffer_api, test_byte_put_free)
 
 	/* Ring buffer is empty */
 	granted = ring_buf_get_claim(&ringbuf_raw, &data, RINGBUFFER_SIZE);
-	zassert_true(granted == 0U, NULL);
+	zassert_true(granted == 0U);
 
 	for (int i = 0; i < 10; i++) {
 		ring_buf_put(&ringbuf_raw, indata,
@@ -625,12 +625,12 @@ ZTEST(ringbuffer_api, test_byte_put_free)
 					       RINGBUFFER_SIZE);
 
 		if (granted == (RINGBUFFER_SIZE-2)) {
-			zassert_true(memcmp(indata, data, granted) == 0, NULL);
+			zassert_true(memcmp(indata, data, granted) == 0);
 		} else if (granted < (RINGBUFFER_SIZE-2)) {
 			/* When buffer wraps, operation is split. */
 			uint32_t granted_1 = granted;
 
-			zassert_true(memcmp(indata, data, granted) == 0, NULL);
+			zassert_true(memcmp(indata, data, granted) == 0);
 			granted = ring_buf_get_claim(&ringbuf_raw, &data,
 						       RINGBUFFER_SIZE);
 
@@ -639,15 +639,15 @@ ZTEST(ringbuffer_api, test_byte_put_free)
 			zassert_true(memcmp(&indata[granted_1], data, granted)
 					== 0, NULL);
 		} else {
-			zassert_true(false, NULL);
+			zassert_true(false);
 		}
 
 		/* Freeing more than possible case. */
 		err = ring_buf_get_finish(&ringbuf_raw, RINGBUFFER_SIZE-1);
-		zassert_true(err != 0, NULL);
+		zassert_true(err != 0);
 
 		err = ring_buf_get_finish(&ringbuf_raw, RINGBUFFER_SIZE-2);
-		zassert_true(err == 0, NULL);
+		zassert_true(err == 0);
 	}
 }
 
@@ -751,24 +751,24 @@ ZTEST(ringbuffer_api, test_reset)
 
 	len = 3;
 	out_len = ring_buf_put(&ringbuf_raw, indata, len);
-	zassert_equal(out_len, len, NULL);
+	zassert_equal(out_len, len);
 
 	out_len = ring_buf_get(&ringbuf_raw, outdata, len);
-	zassert_equal(out_len, len, NULL);
+	zassert_equal(out_len, len);
 
 	space = ring_buf_space_get(&ringbuf_raw);
-	zassert_equal(space, RINGBUFFER_SIZE, NULL);
+	zassert_equal(space, RINGBUFFER_SIZE);
 
 	/* Even though ringbuffer is empty, full buffer cannot be allocated
 	 * because internal pointers are not at the beginning.
 	 */
 	granted = ring_buf_put_claim(&ringbuf_raw, &outbuf, RINGBUFFER_SIZE);
-	zassert_false(granted == RINGBUFFER_SIZE, NULL);
+	zassert_false(granted == RINGBUFFER_SIZE);
 
 	/* After reset full buffer can be allocated. */
 	ring_buf_reset(&ringbuf_raw);
 	granted = ring_buf_put_claim(&ringbuf_raw, &outbuf, RINGBUFFER_SIZE);
-	zassert_true(granted == RINGBUFFER_SIZE, NULL);
+	zassert_true(granted == RINGBUFFER_SIZE);
 }
 
 static uint32_t ringbuf_stored[RINGBUFFER_SIZE];
@@ -825,13 +825,13 @@ ZTEST(ringbuffer_api, test_ringbuffer_array_perf)
 	ring_buf_item_init(&buf_ii, RINGBUFFER_SIZE, ringbuf_stored);
 
 	/*Data from the beginning of the array can be copied into the ringbuf*/
-	zassert_true(ring_buf_item_put(&buf_ii, 1, 2, input, 3) == 0, NULL);
+	zassert_true(ring_buf_item_put(&buf_ii, 1, 2, input, 3) == 0);
 
 	/*Verify the address stored by ringbuf is contiguous*/
 	for (int i = 0; i < 3; i++) {
 		uint32_t *buf32 = (uint32_t *)buf_ii.buffer;
 
-		zassert_equal(input[i], buf32[i+1], NULL);
+		zassert_equal(input[i], buf32[i+1]);
 	}
 
 	/*Data from the end of the ringbuf can be copied into the array*/
@@ -840,7 +840,7 @@ ZTEST(ringbuffer_api, test_ringbuffer_array_perf)
 
 	/*Verify the ringbuf defined is working*/
 	for (int i = 0; i < 3; i++) {
-		zassert_equal(input[i], output[i], NULL);
+		zassert_equal(input[i], output[i]);
 	}
 }
 
@@ -858,24 +858,24 @@ ZTEST(ringbuffer_api, test_ringbuffer_partial_putting)
 	for (int i = 0; i < 100; i++) {
 		req_len = (i % RINGBUFFER_SIZE) + 1;
 		len = ring_buf_put(&ringbuf_raw, indata, req_len);
-		zassert_equal(req_len, len, NULL);
+		zassert_equal(req_len, len);
 
 		len = ring_buf_get(&ringbuf_raw, outdata, req_len);
-		zassert_equal(req_len, len, NULL);
+		zassert_equal(req_len, len);
 
 		req_len = 2;
 		len = ring_buf_put_claim(&ringbuf_raw, &ptr, req_len);
-		zassert_equal(len, req_len, NULL);
+		zassert_equal(len, req_len);
 
 		req_len = RINGBUFFER_SIZE;
 		len = ring_buf_put_claim(&ringbuf_raw, &ptr, req_len);
 		len2 = ring_buf_put_claim(&ringbuf_raw, &ptr, req_len);
-		zassert_equal(len + len2, req_len - 2, NULL);
+		zassert_equal(len + len2, req_len - 2);
 
 		ring_buf_put_finish(&ringbuf_raw, req_len);
 
 		len = ring_buf_get(&ringbuf_raw, indata, req_len);
-		zassert_equal(len, req_len, NULL);
+		zassert_equal(len, req_len);
 	}
 }
 
@@ -893,21 +893,21 @@ ZTEST(ringbuffer_api, test_ringbuffer_partial_getting)
 	for (int i = 0; i < 100; i++) {
 		req_len = (i % RINGBUFFER_SIZE) + 1;
 		len = ring_buf_put(&ringbuf_raw, indata, req_len);
-		zassert_equal(req_len, len, NULL);
+		zassert_equal(req_len, len);
 
 		len = ring_buf_get(&ringbuf_raw, outdata, req_len);
-		zassert_equal(req_len, len, NULL);
+		zassert_equal(req_len, len);
 
 		req_len = sizeof(indata);
 		len = ring_buf_put(&ringbuf_raw, indata, req_len);
-		zassert_equal(req_len, len, NULL);
+		zassert_equal(req_len, len);
 
 		len = ring_buf_get_claim(&ringbuf_raw, &ptr, 2);
-		zassert_equal(len, 2, NULL);
+		zassert_equal(len, 2);
 
 		len = ring_buf_get_claim(&ringbuf_raw, &ptr, RINGBUFFER_SIZE);
 		len2 = ring_buf_get_claim(&ringbuf_raw, &ptr, RINGBUFFER_SIZE);
-		zassert_equal(len + len2, RINGBUFFER_SIZE - 2, NULL);
+		zassert_equal(len + len2, RINGBUFFER_SIZE - 2);
 
 		ring_buf_get_finish(&ringbuf_raw, RINGBUFFER_SIZE);
 	}
@@ -925,11 +925,11 @@ ZTEST(ringbuffer_api, test_ringbuffer_equal_bufs)
 
 	for (int i = 0; i < 100; i++) {
 		claimed = ring_buf_put_claim(&buf_ii, &data, halfsize);
-		zassert_equal(claimed, halfsize, NULL);
+		zassert_equal(claimed, halfsize);
 		ring_buf_put_finish(&buf_ii, claimed);
 
 		claimed = ring_buf_get_claim(&buf_ii, &data, halfsize);
-		zassert_equal(claimed, halfsize, NULL);
+		zassert_equal(claimed, halfsize);
 		ring_buf_get_finish(&buf_ii, claimed);
 	}
 }

--- a/tests/lib/spsc_pbuf/src/main.c
+++ b/tests/lib/spsc_pbuf/src/main.c
@@ -39,28 +39,28 @@ static void test_spsc_pbuf_flags(uint32_t flags)
 	memset(memory_area, 0, sizeof(memory_area));
 	ib = spsc_pbuf_init(memory_area, sizeof(memory_area), flags);
 	zassert_equal_ptr(ib, memory_area, NULL);
-	zassert_equal(spsc_pbuf_capacity(ib), capacity, NULL);
+	zassert_equal(spsc_pbuf_capacity(ib), capacity);
 
 	/* Try writing invalid value. */
 	rlen = spsc_pbuf_write(ib, rbuf, 0);
-	zassert_equal(rlen, -EINVAL, NULL);
+	zassert_equal(rlen, -EINVAL);
 	rlen = spsc_pbuf_write(ib, rbuf, SPSC_PBUF_MAX_LEN);
-	zassert_equal(rlen, -EINVAL, NULL);
+	zassert_equal(rlen, -EINVAL);
 
 	/* Try to write more than buffer can store. */
 	rlen = spsc_pbuf_write(ib, rbuf, sizeof(rbuf));
-	zassert_equal(rlen, -ENOMEM, NULL);
+	zassert_equal(rlen, -ENOMEM);
 
 	/* Read empty buffer. */
 	rlen = spsc_pbuf_read(ib, rbuf, sizeof(rbuf));
-	zassert_equal(rlen, 0, NULL);
+	zassert_equal(rlen, 0);
 
 	/* Single write and read. */
 	wlen = spsc_pbuf_write(ib, message, sizeof(message));
-	zassert_equal(wlen, sizeof(message), NULL);
+	zassert_equal(wlen, sizeof(message));
 
 	rlen = spsc_pbuf_read(ib, rbuf, sizeof(rbuf));
-	zassert_equal(rlen, sizeof(message), NULL);
+	zassert_equal(rlen, sizeof(message));
 
 	ib = spsc_pbuf_init(memory_area, sizeof(memory_area), flags);
 	zassert_equal_ptr(ib, memory_area, NULL);
@@ -69,38 +69,38 @@ static void test_spsc_pbuf_flags(uint32_t flags)
 
 	for (int i = 0; i < repeat; i++) {
 		wlen = spsc_pbuf_write(ib, message, sizeof(message));
-		zassert_equal(wlen, sizeof(message), NULL);
+		zassert_equal(wlen, sizeof(message));
 	}
 
 	wlen = spsc_pbuf_write(ib, message, sizeof(message));
-	zassert_equal(wlen, -ENOMEM, NULL);
+	zassert_equal(wlen, -ENOMEM);
 
 	/* Test reading with buf == NULL, should return len of the next message to read. */
 	rlen = spsc_pbuf_read(ib, NULL, 0);
-	zassert_equal(rlen, sizeof(message), NULL);
+	zassert_equal(rlen, sizeof(message));
 
 	/* Read with len == 0 and correct buf pointer. */
 	rlen = spsc_pbuf_read(ib, rbuf, 0);
-	zassert_equal(rlen, -ENOMEM, NULL);
+	zassert_equal(rlen, -ENOMEM);
 
 	/* Read whole data from the buffer. */
 	for (size_t i = 0; i < repeat; i++) {
 		wlen = spsc_pbuf_read(ib, rbuf, sizeof(rbuf));
-		zassert_equal(wlen, sizeof(message), NULL);
+		zassert_equal(wlen, sizeof(message));
 	}
 
 	/* Buffer is empty */
 	rlen = spsc_pbuf_read(ib, NULL, 0);
-	zassert_equal(rlen, 0, NULL);
+	zassert_equal(rlen, 0);
 
 	/* Write message that would be wrapped around. */
 	wlen = spsc_pbuf_write(ib, message, sizeof(message));
-	zassert_equal(wlen, sizeof(message), NULL);
+	zassert_equal(wlen, sizeof(message));
 
 	/* Read wrapped message. */
 	rlen = spsc_pbuf_read(ib, rbuf, sizeof(rbuf));
-	zassert_equal(rlen, sizeof(message), NULL);
-	zassert_equal(message[0], 'a', NULL);
+	zassert_equal(rlen, sizeof(message));
+	zassert_equal(message[0], 'a');
 }
 
 ZTEST(test_spsc_pbuf, test_spsc_pbuf_ut)
@@ -285,13 +285,13 @@ ZTEST(test_spsc_pbuf, test_0cpy_corner1)
 	zassert_equal(len2, exp_len2, "got %d, exp: %d", len2, exp_len2);
 
 	len = spsc_pbuf_claim(pb, &buf);
-	zassert_equal(len1, len, NULL);
+	zassert_equal(len1, len);
 	spsc_pbuf_free(pb, len);
 
 	spsc_pbuf_commit(pb, len2);
 
 	len = spsc_pbuf_claim(pb, &buf);
-	zassert_equal(len2, len, NULL);
+	zassert_equal(len2, len);
 	spsc_pbuf_free(pb, len);
 }
 
@@ -381,7 +381,7 @@ ZTEST(test_spsc_pbuf, test_utilization)
 	pb = spsc_pbuf_init(buffer, sizeof(buffer), 0);
 
 	if (!IS_ENABLED(CONFIG_SPSC_PBUF_UTILIZATION)) {
-		zassert_equal(spsc_pbuf_get_utilization(pb), -ENOTSUP, NULL);
+		zassert_equal(spsc_pbuf_get_utilization(pb), -ENOTSUP);
 		return;
 	}
 	capacity = spsc_pbuf_capacity(pb);
@@ -389,17 +389,17 @@ ZTEST(test_spsc_pbuf, test_utilization)
 	len1 = 10;
 	PACKET_WRITE(pb, len1, len1, 0, len1);
 	u = spsc_pbuf_get_utilization(pb);
-	zassert_equal(u, 0, NULL);
+	zassert_equal(u, 0);
 
 	PACKET_CONSUME(pb, len1, 0);
 	u = spsc_pbuf_get_utilization(pb);
-	zassert_equal(u, TLEN(len1), NULL);
+	zassert_equal(u, TLEN(len1));
 
 	len2 = 11;
 	PACKET_WRITE(pb, len2, len2, 1, len2);
 	PACKET_CONSUME(pb, len2, 1);
 	u = spsc_pbuf_get_utilization(pb);
-	zassert_equal(u, TLEN(len2), NULL);
+	zassert_equal(u, TLEN(len2));
 
 	len3 = capacity - TLEN(len1) - TLEN(len2);
 	PACKET_WRITE(pb, SPSC_PBUF_MAX_LEN, len3, 2, len3);
@@ -408,7 +408,7 @@ ZTEST(test_spsc_pbuf, test_utilization)
 	u = spsc_pbuf_get_utilization(pb);
 	int exp_u = TLEN(len3);
 
-	zassert_equal(u, exp_u, NULL);
+	zassert_equal(u, exp_u);
 }
 
 struct stress_data {
@@ -520,7 +520,7 @@ bool stress_alloc_commit(void *user_data, uint32_t cnt, bool last, int prio)
 
 	for (int i = 0; i < rpt; i++) {
 		err = spsc_pbuf_alloc(ctx->pbuf, len, &buf);
-		zassert_true(err >= 0, NULL);
+		zassert_true(err >= 0);
 		if (err != len) {
 			return true;
 		}

--- a/tests/net/6lo/src/main.c
+++ b/tests/net/6lo/src/main.c
@@ -1100,7 +1100,7 @@ static void test_6lo(struct net_6lo_data *data)
 	net_pkt_hexdump(pkt, "after-uncompression");
 #endif
 
-	zassert_true(compare_pkt(pkt, data), NULL);
+	zassert_true(compare_pkt(pkt, data));
 
 	net_pkt_unref(pkt);
 }

--- a/tests/net/context/src/main.c
+++ b/tests/net/context/src/main.c
@@ -861,7 +861,7 @@ ZTEST(net_context, test_net_ctx_recv_v6_timeout)
 	expecting_cb_failure = false;
 	recv_cb_timeout_called = false;
 
-	zassert_true(!cb_failure, NULL);
+	zassert_true(!cb_failure);
 
 	net_ctx_put();
 }
@@ -894,7 +894,7 @@ ZTEST(net_context, test_net_ctx_recv_v4_timeout)
 	expecting_cb_failure = false;
 	recv_cb_timeout_called = false;
 
-	zassert_true(!cb_failure, NULL);
+	zassert_true(!cb_failure);
 
 	net_ctx_put();
 }

--- a/tests/net/ieee802154/6lo_fragment/src/main.c
+++ b/tests/net/ieee802154/6lo_fragment/src/main.c
@@ -579,56 +579,56 @@ ZTEST(ieee802154_6lo_fragment, test_fragment_sam00_dam00)
 {
 	bool ret = test_fragment(&test_data_1);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 ZTEST(ieee802154_6lo_fragment, test_fragment_sam01_dam01)
 {
 	bool ret = test_fragment(&test_data_2);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 ZTEST(ieee802154_6lo_fragment, test_fragment_sam10_dam10)
 {
 	bool ret = test_fragment(&test_data_3);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 ZTEST(ieee802154_6lo_fragment, test_fragment_sam00_m1_dam00)
 {
 	bool ret = test_fragment(&test_data_4);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 ZTEST(ieee802154_6lo_fragment, test_fragment_sam01_m1_dam01)
 {
 	bool ret = test_fragment(&test_data_5);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 ZTEST(ieee802154_6lo_fragment, test_fragment_sam10_m1_dam10)
 {
 	bool ret = test_fragment(&test_data_6);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 ZTEST(ieee802154_6lo_fragment, test_fragment_ipv6_dispatch_small)
 {
 	bool ret = test_fragment(&test_data_7);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 ZTEST(ieee802154_6lo_fragment, test_fragment_ipv6_dispatch_big)
 {
 	bool ret = test_fragment(&test_data_8);
 
-	zassert_true(ret, NULL);
+	zassert_true(ret);
 }
 
 

--- a/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
+++ b/tests/net/lib/mqtt_publisher/src/test_mqtt_publish.c
@@ -296,22 +296,22 @@ static int test_disconnect(void)
 
 void test_mqtt_connect(void)
 {
-	zassert_true(test_connect() == TC_PASS, NULL);
+	zassert_true(test_connect() == TC_PASS);
 }
 
 void test_mqtt_pingreq(void)
 {
-	zassert_true(test_pingreq() == TC_PASS, NULL);
+	zassert_true(test_pingreq() == TC_PASS);
 }
 
 void test_mqtt_publish(void)
 {
-	zassert_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS, NULL);
-	zassert_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS, NULL);
-	zassert_true(test_publish(MQTT_QOS_2_EXACTLY_ONCE) == TC_PASS, NULL);
+	zassert_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS);
+	zassert_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS);
+	zassert_true(test_publish(MQTT_QOS_2_EXACTLY_ONCE) == TC_PASS);
 }
 
 void test_mqtt_disconnect(void)
 {
-	zassert_true(test_disconnect() == TC_PASS, NULL);
+	zassert_true(test_disconnect() == TC_PASS);
 }

--- a/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
+++ b/tests/net/lib/mqtt_pubsub/src/test_mqtt_pubsub.c
@@ -424,32 +424,32 @@ static int test_disconnect(void)
 
 void test_mqtt_connect(void)
 {
-	zassert_true(test_connect() == TC_PASS, NULL);
+	zassert_true(test_connect() == TC_PASS);
 }
 
 void test_mqtt_subscribe(void)
 {
-	zassert_true(test_subscribe() == TC_PASS, NULL);
+	zassert_true(test_subscribe() == TC_PASS);
 }
 
 void test_mqtt_publish_short(void)
 {
 	payload = payload_short;
-	zassert_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS, NULL);
+	zassert_true(test_publish(MQTT_QOS_0_AT_MOST_ONCE) == TC_PASS);
 }
 
 void test_mqtt_publish_long(void)
 {
 	payload = payload_long;
-	zassert_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS, NULL);
+	zassert_true(test_publish(MQTT_QOS_1_AT_LEAST_ONCE) == TC_PASS);
 }
 
 void test_mqtt_unsubscribe(void)
 {
-	zassert_true(test_unsubscribe() == TC_PASS, NULL);
+	zassert_true(test_unsubscribe() == TC_PASS);
 }
 
 void test_mqtt_disconnect(void)
 {
-	zassert_true(test_disconnect() == TC_PASS, NULL);
+	zassert_true(test_disconnect() == TC_PASS);
 }

--- a/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
+++ b/tests/net/lib/mqtt_subscriber/src/test_mqtt_subscribe.c
@@ -303,20 +303,20 @@ static int test_disconnect(void)
 
 void test_mqtt_connect(void)
 {
-	zassert_true(test_connect() == TC_PASS, NULL);
+	zassert_true(test_connect() == TC_PASS);
 }
 
 void test_mqtt_subscribe(void)
 {
-	zassert_true(test_subscribe() == TC_PASS, NULL);
+	zassert_true(test_subscribe() == TC_PASS);
 }
 
 void test_mqtt_unsubscribe(void)
 {
-	zassert_true(test_unsubscribe() == TC_PASS, NULL);
+	zassert_true(test_unsubscribe() == TC_PASS);
 }
 
 void test_mqtt_disconnect(void)
 {
-	zassert_true(test_disconnect() == TC_PASS, NULL);
+	zassert_true(test_disconnect() == TC_PASS);
 }

--- a/tests/net/route/src/main.c
+++ b/tests/net/route/src/main.c
@@ -343,7 +343,7 @@ static void test_populate_nbr_cache(void)
 
 	recipient = my_iface;
 
-	zassert_true(net_test_send_ns(peer_iface, &peer_addr), NULL);
+	zassert_true(net_test_send_ns(peer_iface, &peer_addr));
 
 	nbr = net_ipv6_nbr_add(net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY)),
 			       &peer_addr,
@@ -352,7 +352,7 @@ static void test_populate_nbr_cache(void)
 			       NET_IPV6_NBR_STATE_REACHABLE);
 	zassert_not_null(nbr, "Cannot add peer to neighbor cache");
 
-	zassert_true(net_test_send_ns(peer_iface, &peer_addr_alt), NULL);
+	zassert_true(net_test_send_ns(peer_iface, &peer_addr_alt));
 
 	nbr = net_ipv6_nbr_add(net_if_get_first_by_type(&NET_L2_GET_NAME(DUMMY)),
 			       &peer_addr_alt,
@@ -369,7 +369,7 @@ static void test_populate_nbr_cache(void)
 
 	data_failure = false;
 
-	zassert_true(net_test_nbr_lookup_ok(my_iface, &peer_addr), NULL);
+	zassert_true(net_test_nbr_lookup_ok(my_iface, &peer_addr));
 }
 
 static void test_route_add(void)

--- a/tests/posix/common/src/clock.c
+++ b/tests/posix/common/src/clock.c
@@ -21,7 +21,7 @@ ZTEST(posix_apis, test_posix_clock)
 	/* TESTPOINT: Pass invalid clock type */
 	zassert_equal(clock_gettime(CLOCK_INVALID, &ts), -1,
 			NULL);
-	zassert_equal(errno, EINVAL, NULL);
+	zassert_equal(errno, EINVAL);
 
 	clock_gettime(CLOCK_MONOTONIC, &ts);
 	/* 2 Sec Delay */
@@ -66,7 +66,7 @@ ZTEST(posix_apis, test_posix_realtime)
 	/* TESTPOINT: Pass invalid clock type */
 	zassert_equal(clock_settime(CLOCK_INVALID, &nts), -1,
 			NULL);
-	zassert_equal(errno, EINVAL, NULL);
+	zassert_equal(errno, EINVAL);
 
 	ret = clock_settime(CLOCK_MONOTONIC, &nts);
 	zassert_not_equal(ret, 0, "Should not be able to set monotonic time");
@@ -110,10 +110,10 @@ ZTEST(posix_apis, test_posix_realtime)
 
 	/* Validate gettimeofday API */
 	ret = gettimeofday(&tv, NULL);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = clock_gettime(CLOCK_REALTIME, &rts);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	/* TESTPOINT: Check if time obtained from
 	 * gettimeofday is same or more than obtained

--- a/tests/posix/common/src/mqueue.c
+++ b/tests/posix/common/src/mqueue.c
@@ -77,7 +77,7 @@ ZTEST(posix_apis, test_posix_mqueue)
 	for (i = 0; i < N_THR; i++) {
 		/* Creating threads */
 		if (pthread_attr_init(&attr[i]) != 0) {
-			zassert_equal(pthread_attr_destroy(&attr[i]), 0, NULL);
+			zassert_equal(pthread_attr_destroy(&attr[i]), 0);
 			zassert_false(pthread_attr_init(&attr[i]),
 				      "pthread attr init failed");
 		}
@@ -94,7 +94,7 @@ ZTEST(posix_apis, test_posix_mqueue)
 		}
 
 		zassert_false(ret, "Not enough space to create new thread");
-		zassert_equal(pthread_attr_destroy(&attr[i]), 0, NULL);
+		zassert_equal(pthread_attr_destroy(&attr[i]), 0);
 	}
 
 	usleep(USEC_PER_MSEC * 10U);

--- a/tests/posix/common/src/posix_rwlock.c
+++ b/tests/posix/common/src/posix_rwlock.c
@@ -65,14 +65,14 @@ ZTEST(posix_apis, test_posix_rw_lock)
 	time.tv_sec = 1;
 	time.tv_nsec = 0;
 
-	zassert_equal(pthread_rwlock_destroy(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_rdlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_wrlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_trywrlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_tryrdlock(&rwlock), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_timedwrlock(&rwlock, &time), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_timedrdlock(&rwlock, &time), EINVAL, NULL);
-	zassert_equal(pthread_rwlock_unlock(&rwlock), EINVAL, NULL);
+	zassert_equal(pthread_rwlock_destroy(&rwlock), EINVAL);
+	zassert_equal(pthread_rwlock_rdlock(&rwlock), EINVAL);
+	zassert_equal(pthread_rwlock_wrlock(&rwlock), EINVAL);
+	zassert_equal(pthread_rwlock_trywrlock(&rwlock), EINVAL);
+	zassert_equal(pthread_rwlock_tryrdlock(&rwlock), EINVAL);
+	zassert_equal(pthread_rwlock_timedwrlock(&rwlock, &time), EINVAL);
+	zassert_equal(pthread_rwlock_timedrdlock(&rwlock, &time), EINVAL);
+	zassert_equal(pthread_rwlock_unlock(&rwlock), EINVAL);
 
 	zassert_false(pthread_rwlock_init(&rwlock, NULL),
 		      "Failed to create rwlock");

--- a/tests/posix/common/src/pthread.c
+++ b/tests/posix/common/src/pthread.c
@@ -589,8 +589,8 @@ ZTEST(posix_apis, test_pthread_descriptor_leak)
 	pthread_t pthread1;
 	pthread_attr_t attr;
 
-	zassert_ok(pthread_attr_init(&attr), NULL);
-	zassert_ok(pthread_attr_setstack(&attr, &stack_e[0][0], STACKS), NULL);
+	zassert_ok(pthread_attr_init(&attr));
+	zassert_ok(pthread_attr_setstack(&attr, &stack_e[0][0], STACKS));
 
 	/* If we are leaking descriptors, then this loop will never complete */
 	for (size_t i = 0; i < CONFIG_MAX_PTHREAD_COUNT * 2; ++i) {

--- a/tests/posix/common/src/semaphore.c
+++ b/tests/posix/common/src/semaphore.c
@@ -58,24 +58,24 @@ ZTEST(posix_apis, test_posix_semaphore)
 	 */
 	zassert_equal(sem_init(&sema, 0, (CONFIG_SEM_VALUE_MAX + 1)), -1,
 		      "value larger than %d\n", CONFIG_SEM_VALUE_MAX);
-	zassert_equal(errno, EINVAL, NULL);
+	zassert_equal(errno, EINVAL);
 
 	zassert_equal(sem_init(&sema, 0, 0), 0, "sem_init failed");
 
 	/* TESTPOINT: Call sem_post with invalid kobject */
 	zassert_equal(sem_post(dummy_sem), -1, "sem_post of"
 		      " invalid semaphore object didn't fail");
-	zassert_equal(errno, EINVAL, NULL);
+	zassert_equal(errno, EINVAL);
 
 	/* TESTPOINT: Check if semaphore value is as set */
-	zassert_equal(sem_getvalue(&sema, &val), 0, NULL);
-	zassert_equal(val, 0, NULL);
+	zassert_equal(sem_getvalue(&sema, &val), 0);
+	zassert_equal(val, 0);
 
 	/* TESTPOINT: Check if sema is acquired when it
 	 * is not available
 	 */
-	zassert_equal(sem_trywait(&sema), -1, NULL);
-	zassert_equal(errno, EAGAIN, NULL);
+	zassert_equal(sem_trywait(&sema), -1);
+	zassert_equal(errno, EAGAIN);
 
 	ret = pthread_create(&thread1, &attr1, child_func, NULL);
 	zassert_equal(ret, 0, "Thread creation failed");
@@ -88,18 +88,18 @@ ZTEST(posix_apis, test_posix_semaphore)
 	/* TESPOINT: Wait for 5 seconds and acquire sema given
 	 * by thread1
 	 */
-	zassert_equal(sem_timedwait(&sema, &abstime), 0, NULL);
+	zassert_equal(sem_timedwait(&sema, &abstime), 0);
 
 	/* TESTPOINT: Semaphore is already acquired, check if
 	 * no semaphore is available
 	 */
-	zassert_equal(sem_timedwait(&sema, &abstime), -1, NULL);
-	zassert_equal(errno, ETIMEDOUT, NULL);
+	zassert_equal(sem_timedwait(&sema, &abstime), -1);
+	zassert_equal(errno, ETIMEDOUT);
 
 	/* TESTPOINT: sem_destroy with invalid kobject */
 	zassert_equal(sem_destroy(dummy_sem), -1, "invalid"
 		      " semaphore is destroyed");
-	zassert_equal(errno, EINVAL, NULL);
+	zassert_equal(errno, EINVAL);
 
 	zassert_equal(sem_destroy(&sema), 0, "semaphore is not destroyed");
 
@@ -108,15 +108,15 @@ ZTEST(posix_apis, test_posix_semaphore)
 
 	/* TESTPOINT: Initialize sema with 1 */
 	zassert_equal(sem_init(&sema, 0, 1), 0, "sem_init failed");
-	zassert_equal(sem_getvalue(&sema, &val), 0, NULL);
-	zassert_equal(val, 1, NULL);
+	zassert_equal(sem_getvalue(&sema, &val), 0);
+	zassert_equal(val, 1);
 
 	zassert_equal(sem_destroy(&sema), -1, "acquired semaphore"
 		      " is destroyed");
-	zassert_equal(errno, EBUSY, NULL);
+	zassert_equal(errno, EBUSY);
 
 	/* TESTPOINT: take semaphore which is initialized with 1 */
-	zassert_equal(sem_trywait(&sema), 0, NULL);
+	zassert_equal(sem_trywait(&sema), 0);
 
 	initialize_thread_attr(&attr2);
 

--- a/tests/posix/fs/src/test_fat_mount.c
+++ b/tests/posix/fs/src/test_fat_mount.c
@@ -54,5 +54,5 @@ void test_unmount(void *unused)
 ZTEST(posix_fs_test, test_fs_mount)
 {
 	/* FIXME: restructure tests as per #46897 */
-	zassert_equal(fatfs_mnt.flags, FS_MOUNT_FLAG_USE_DISK_ACCESS, NULL);
+	zassert_equal(fatfs_mnt.flags, FS_MOUNT_FLAG_USE_DISK_ACCESS);
 }

--- a/tests/posix/fs/src/test_fs_dir.c
+++ b/tests/posix/fs/src/test_fs_dir.c
@@ -110,7 +110,7 @@ ZTEST_SUITE(posix_fs_dir_test, NULL, test_mount, NULL, after_fn,
 ZTEST(posix_fs_dir_test, test_fs_mkdir)
 {
 	/* FIXME: restructure tests as per #46897 */
-	zassert_true(test_mkdir() == TC_PASS, NULL);
+	zassert_true(test_mkdir() == TC_PASS);
 }
 
 /**
@@ -123,6 +123,6 @@ ZTEST(posix_fs_dir_test, test_fs_mkdir)
 ZTEST(posix_fs_dir_test, test_fs_readdir)
 {
 	/* FIXME: restructure tests as per #46897 */
-	zassert_true(test_mkdir() == TC_PASS, NULL);
-	zassert_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
+	zassert_true(test_mkdir() == TC_PASS);
+	zassert_true(test_lsdir(TEST_DIR) == TC_PASS);
 }

--- a/tests/posix/fs/src/test_fs_file.c
+++ b/tests/posix/fs/src/test_fs_file.c
@@ -173,7 +173,7 @@ ZTEST_SUITE(posix_fs_file_test, NULL, test_mount, NULL, after_fn,
 ZTEST(posix_fs_file_test, test_fs_open)
 {
 	/* FIXME: restructure tests as per #46897 */
-	zassert_true(test_file_open() == TC_PASS, NULL);
+	zassert_true(test_file_open() == TC_PASS);
 }
 
 /**
@@ -184,8 +184,8 @@ ZTEST(posix_fs_file_test, test_fs_open)
 ZTEST(posix_fs_file_test, test_fs_write)
 {
 	/* FIXME: restructure tests as per #46897 */
-	zassert_true(test_file_open() == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
+	zassert_true(test_file_open() == TC_PASS);
+	zassert_true(test_file_write() == TC_PASS);
 }
 
 /**
@@ -196,9 +196,9 @@ ZTEST(posix_fs_file_test, test_fs_write)
 ZTEST(posix_fs_file_test, test_fs_read)
 {
 	/* FIXME: restructure tests as per #46897 */
-	zassert_true(test_file_open() == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
-	zassert_true(test_file_read() == TC_PASS, NULL);
+	zassert_true(test_file_open() == TC_PASS);
+	zassert_true(test_file_write() == TC_PASS);
+	zassert_true(test_file_read() == TC_PASS);
 }
 
 /**
@@ -209,8 +209,8 @@ ZTEST(posix_fs_file_test, test_fs_read)
 ZTEST(posix_fs_file_test, test_fs_close)
 {
 	/* FIXME: restructure tests as per #46897 */
-	zassert_true(test_file_open() == TC_PASS, NULL);
-	zassert_true(test_file_close() == TC_PASS, NULL);
+	zassert_true(test_file_open() == TC_PASS);
+	zassert_true(test_file_close() == TC_PASS);
 }
 
 /**
@@ -220,8 +220,8 @@ ZTEST(posix_fs_file_test, test_fs_close)
  */
 ZTEST(posix_fs_file_test, test_fs_unlink)
 {
-	zassert_true(test_file_open() == TC_PASS, NULL);
-	zassert_true(test_file_delete() == TC_PASS, NULL);
+	zassert_true(test_file_open() == TC_PASS);
+	zassert_true(test_file_delete() == TC_PASS);
 }
 
 ZTEST(posix_fs_file_test, test_fs_fd_leak)
@@ -231,11 +231,11 @@ ZTEST(posix_fs_file_test, test_fs_fd_leak)
 
 	for (int i = 0; i < reps; i++) {
 		if (i > 0) {
-			zassert_true(test_file_open() == TC_PASS, NULL);
+			zassert_true(test_file_open() == TC_PASS);
 		}
 
 		if (i < reps - 1) {
-			zassert_true(test_file_close() == TC_PASS, NULL);
+			zassert_true(test_file_close() == TC_PASS);
 		}
 	}
 }

--- a/tests/posix/fs/src/test_fs_open_flags.c
+++ b/tests/posix/fs/src/test_fs_open_flags.c
@@ -282,5 +282,5 @@ static int test_file_open_flags(void)
  */
 ZTEST(posix_fs_test, test_fs_open_flags)
 {
-	zassert_true(test_file_open_flags() == TC_PASS, NULL);
+	zassert_true(test_file_open_flags() == TC_PASS);
 }

--- a/tests/subsys/cpp/cxx/src/main.cpp
+++ b/tests/subsys/cpp/cxx/src/main.cpp
@@ -107,7 +107,7 @@ foo_class static_foo(12345678);
 
 ZTEST(cxx_tests, test_global_static_ctor)
 {
-	zassert_equal(static_foo.get_foo(), 12345678, NULL);
+	zassert_equal(static_foo.get_foo(), 12345678);
 }
 
 /*
@@ -118,13 +118,13 @@ foo_class *static_init_dynamic_foo = new foo_class(87654321);
 
 ZTEST(cxx_tests, test_global_static_ctor_dynmem)
 {
-	zassert_equal(static_init_dynamic_foo->get_foo(), 87654321, NULL);
+	zassert_equal(static_init_dynamic_foo->get_foo(), 87654321);
 }
 
 ZTEST(cxx_tests, test_new_delete)
 {
 	foo_class *test_foo = new foo_class(10);
-	zassert_equal(test_foo->get_foo(), 10, NULL);
+	zassert_equal(test_foo->get_foo(), 10);
 	delete test_foo;
 }
 ZTEST_SUITE(cxx_tests, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_dir.c
@@ -157,9 +157,9 @@ static int test_rmdir(void)
 
 void test_fat_dir(void)
 {
-	zassert_true(test_mkdir() == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
-	zassert_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
-	zassert_true(test_rmdir() == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
+	zassert_true(test_mkdir() == TC_PASS);
+	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS);
+	zassert_true(test_lsdir(TEST_DIR) == TC_PASS);
+	zassert_true(test_rmdir() == TC_PASS);
+	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_file.c
@@ -271,11 +271,11 @@ static int test_file_delete(void)
 
 void test_fat_file(void)
 {
-	zassert_true(test_file_open() == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
-	zassert_true(test_file_sync() == TC_PASS, NULL);
-	zassert_true(test_file_read() == TC_PASS, NULL);
-	zassert_true(test_file_truncate() == TC_PASS, NULL);
-	zassert_true(test_file_close() == TC_PASS, NULL);
-	zassert_true(test_file_delete() == TC_PASS, NULL);
+	zassert_true(test_file_open() == TC_PASS);
+	zassert_true(test_file_write() == TC_PASS);
+	zassert_true(test_file_sync() == TC_PASS);
+	zassert_true(test_file_read() == TC_PASS);
+	zassert_true(test_file_truncate() == TC_PASS);
+	zassert_true(test_file_close() == TC_PASS);
+	zassert_true(test_file_delete() == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_fs.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_fs.c
@@ -29,5 +29,5 @@ static int test_statvfs(void)
 
 void test_fat_fs(void)
 {
-	zassert_true(test_statvfs() == TC_PASS, NULL);
+	zassert_true(test_statvfs() == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_mount.c
@@ -84,16 +84,16 @@ static int test_unmount(void)
 
 void test_fat_unmount(void)
 {
-	zassert_true(test_unmount() == TC_PASS, NULL);
+	zassert_true(test_unmount() == TC_PASS);
 }
 
 void test_fat_mount(void)
 {
-	zassert_false(test_unmount() == TC_PASS, NULL);
-	zassert_true(test_mount_no_format() == TC_PASS, NULL);
-	zassert_true(test_mount_rd_only_no_sys() == TC_PASS, NULL);
-	zassert_true(test_mount_use_disk_access() == TC_PASS, NULL);
-	zassert_true(test_unmount() == TC_PASS, NULL);
-	zassert_true(test_mount() == TC_PASS, NULL);
-	zassert_false(test_mount() == TC_PASS, NULL);
+	zassert_false(test_unmount() == TC_PASS);
+	zassert_true(test_mount_no_format() == TC_PASS);
+	zassert_true(test_mount_rd_only_no_sys() == TC_PASS);
+	zassert_true(test_mount_use_disk_access() == TC_PASS);
+	zassert_true(test_unmount() == TC_PASS);
+	zassert_true(test_mount() == TC_PASS);
+	zassert_false(test_mount() == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_rd_only_mount.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_rd_only_mount.c
@@ -23,16 +23,16 @@ static void test_prepare(void)
 	struct fs_file_t fs;
 
 	fs_file_t_init(&fs);
-	zassert_equal(fs_mount(&fatfs_mnt), 0, NULL);
+	zassert_equal(fs_mount(&fatfs_mnt), 0);
 	zassert_equal(fs_open(&fs, "/NAND:/testfile.txt", FS_O_CREATE),
 		      0, NULL);
-	zassert_equal(fs_close(&fs), 0, NULL);
-	zassert_equal(fs_unmount(&fatfs_mnt), 0, NULL);
+	zassert_equal(fs_close(&fs), 0);
+	zassert_equal(fs_unmount(&fatfs_mnt), 0);
 }
 
 static void test_unmount(void)
 {
-	zassert_true(fs_unmount(&fatfs_mnt) >= 0, NULL);
+	zassert_true(fs_unmount(&fatfs_mnt) >= 0);
 }
 
 static void test_ops_on_rd(void)

--- a/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
+++ b/tests/subsys/fs/fat_fs_api/src/test_fat_rename.c
@@ -161,6 +161,6 @@ cleanup:
 
 void test_fat_rename(void)
 {
-	zassert_true(test_rename_file() == TC_PASS, NULL);
-	zassert_true(test_rename_dir() == TC_PASS, NULL);
+	zassert_true(test_rename_file() == TC_PASS);
+	zassert_true(test_rename_dir() == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_dir.c
@@ -163,16 +163,16 @@ static int test_rmdir(const char *dir)
 ZTEST(fat_fs_dual_drive, test_fat_dir)
 {
 	TC_PRINT("\nTesting directory operations on %s\n", FATFS_MNTP);
-	zassert_true(test_mkdir(TEST_DIR, TEST_DIR_FILE) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
-	zassert_true(test_lsdir(TEST_DIR) == TC_PASS, NULL);
-	zassert_true(test_rmdir(TEST_DIR) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS, NULL);
+	zassert_true(test_mkdir(TEST_DIR, TEST_DIR_FILE) == TC_PASS);
+	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS);
+	zassert_true(test_lsdir(TEST_DIR) == TC_PASS);
+	zassert_true(test_rmdir(TEST_DIR) == TC_PASS);
+	zassert_true(test_lsdir(FATFS_MNTP) == TC_PASS);
 
 	TC_PRINT("\nTesting directory operations on %s\n", FATFS_MNTP1);
-	zassert_true(test_mkdir(TEST_DIR1, TEST_DIR_FILE1) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP1) == TC_PASS, NULL);
-	zassert_true(test_lsdir(TEST_DIR1) == TC_PASS, NULL);
-	zassert_true(test_rmdir(TEST_DIR1) == TC_PASS, NULL);
-	zassert_true(test_lsdir(FATFS_MNTP1) == TC_PASS, NULL);
+	zassert_true(test_mkdir(TEST_DIR1, TEST_DIR_FILE1) == TC_PASS);
+	zassert_true(test_lsdir(FATFS_MNTP1) == TC_PASS);
+	zassert_true(test_lsdir(TEST_DIR1) == TC_PASS);
+	zassert_true(test_rmdir(TEST_DIR1) == TC_PASS);
+	zassert_true(test_lsdir(FATFS_MNTP1) == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_file.c
@@ -306,20 +306,20 @@ static int test_file_delete(const char *path)
 ZTEST(fat_fs_dual_drive, test_fat_file)
 {
 	TC_PRINT("Testing file operations on %s\n", FATFS_MNTP);
-	zassert_true(test_file_open(TEST_FILE) == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
-	zassert_true(test_file_sync() == TC_PASS, NULL);
-	zassert_true(test_file_read() == TC_PASS, NULL);
-	zassert_true(test_file_truncate() == TC_PASS, NULL);
-	zassert_true(test_file_close() == TC_PASS, NULL);
-	zassert_true(test_file_delete(TEST_FILE) == TC_PASS, NULL);
+	zassert_true(test_file_open(TEST_FILE) == TC_PASS);
+	zassert_true(test_file_write() == TC_PASS);
+	zassert_true(test_file_sync() == TC_PASS);
+	zassert_true(test_file_read() == TC_PASS);
+	zassert_true(test_file_truncate() == TC_PASS);
+	zassert_true(test_file_close() == TC_PASS);
+	zassert_true(test_file_delete(TEST_FILE) == TC_PASS);
 
 	TC_PRINT("Testing file operations on %s\n", FATFS_MNTP1);
-	zassert_true(test_file_open(TEST_FILE1) == TC_PASS, NULL);
-	zassert_true(test_file_write() == TC_PASS, NULL);
-	zassert_true(test_file_sync() == TC_PASS, NULL);
-	zassert_true(test_file_read() == TC_PASS, NULL);
-	zassert_true(test_file_truncate() == TC_PASS, NULL);
-	zassert_true(test_file_close() == TC_PASS, NULL);
-	zassert_true(test_file_delete(TEST_FILE1) == TC_PASS, NULL);
+	zassert_true(test_file_open(TEST_FILE1) == TC_PASS);
+	zassert_true(test_file_write() == TC_PASS);
+	zassert_true(test_file_sync() == TC_PASS);
+	zassert_true(test_file_read() == TC_PASS);
+	zassert_true(test_file_truncate() == TC_PASS);
+	zassert_true(test_file_close() == TC_PASS);
+	zassert_true(test_file_delete(TEST_FILE1) == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_fs.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_fs.c
@@ -35,8 +35,8 @@ static int test_statvfs(const char *path)
 ZTEST(fat_fs_dual_drive, test_fat_fs)
 {
 	TC_PRINT("\nTesting statvfs operation on %s\n", FATFS_MNTP);
-	zassert_true(test_statvfs(FATFS_MNTP) == TC_PASS, NULL);
+	zassert_true(test_statvfs(FATFS_MNTP) == TC_PASS);
 
 	TC_PRINT("\nTesting statvfs operation on %s\n", FATFS_MNTP1);
-	zassert_true(test_statvfs(FATFS_MNTP1) == TC_PASS, NULL);
+	zassert_true(test_statvfs(FATFS_MNTP1) == TC_PASS);
 }

--- a/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_mount.c
+++ b/tests/subsys/fs/fat_fs_dual_drive/src/test_fat_mount.c
@@ -47,8 +47,8 @@ static int test_mount(struct fs_mount_t *mnt)
 void test_fat_mount(void)
 {
 	TC_PRINT("Mounting %s\n", FATFS_MNTP);
-	zassert_true(test_mount(&fatfs_mnt) == TC_PASS, NULL);
+	zassert_true(test_mount(&fatfs_mnt) == TC_PASS);
 
 	TC_PRINT("Mounting %s\n", FATFS_MNTP1);
-	zassert_true(test_mount(&fatfs_mnt1) == TC_PASS, NULL);
+	zassert_true(test_mount(&fatfs_mnt1) == TC_PASS);
 }

--- a/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
+++ b/tests/subsys/fs/fs_api/src/test_fs_dir_file.c
@@ -460,10 +460,10 @@ static int _test_lsdir(const char *path)
  */
 void test_lsdir(void)
 {
-	zassert_true(_test_lsdir(NULL) == TC_FAIL, NULL);
-	zassert_true(_test_lsdir("/") == TC_PASS, NULL);
-	zassert_true(_test_lsdir("/test") == TC_FAIL, NULL);
-	zassert_true(_test_lsdir(TEST_DIR) == TC_PASS, NULL);
+	zassert_true(_test_lsdir(NULL) == TC_FAIL);
+	zassert_true(_test_lsdir("/") == TC_PASS);
+	zassert_true(_test_lsdir("/test") == TC_FAIL);
+	zassert_true(_test_lsdir(TEST_DIR) == TC_PASS);
 }
 
 /**
@@ -574,7 +574,7 @@ static int _test_file_write(void)
  */
 void test_file_write(void)
 {
-	zassert_true(_test_file_write() == TC_PASS, NULL);
+	zassert_true(_test_file_write() == TC_PASS);
 }
 
 static int _test_file_sync(void)
@@ -647,7 +647,7 @@ static int _test_file_sync(void)
  */
 ZTEST(fs_api_dir_file, test_file_sync)
 {
-	zassert_true(_test_file_sync() == TC_PASS, NULL);
+	zassert_true(_test_file_sync() == TC_PASS);
 }
 
 /**
@@ -869,7 +869,7 @@ static int _test_file_truncate(void)
  */
 void test_file_truncate(void)
 {
-	zassert_true(_test_file_truncate() == TC_PASS, NULL);
+	zassert_true(_test_file_truncate() == TC_PASS);
 }
 
 /**

--- a/tests/subsys/fs/multi-fs/src/test_fat_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_dir.c
@@ -13,15 +13,15 @@
 
 void test_fat_mkdir(void)
 {
-	zassert_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS, NULL);
+	zassert_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS);
 }
 
 void test_fat_readdir(void)
 {
-	zassert_true(test_lsdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	zassert_true(test_lsdir(TEST_DIR_PATH) == TC_PASS);
 }
 
 void test_fat_rmdir(void)
 {
-	zassert_true(test_rmdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	zassert_true(test_rmdir(TEST_DIR_PATH) == TC_PASS);
 }

--- a/tests/subsys/fs/multi-fs/src/test_fat_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_file.c
@@ -28,14 +28,14 @@ void test_fat_write(void)
 
 void test_fat_read(void)
 {
-	zassert_true(test_file_read(&test_file, test_str) == TC_PASS, NULL);
+	zassert_true(test_file_read(&test_file, test_str) == TC_PASS);
 }
 
 void test_fat_close(void)
 {
-	zassert_true(test_file_close(&test_file) == TC_PASS, NULL);
+	zassert_true(test_file_close(&test_file) == TC_PASS);
 }
 void test_fat_unlink(void)
 {
-	zassert_true(test_file_delete(TEST_FILE_PATH) == TC_PASS, NULL);
+	zassert_true(test_file_delete(TEST_FILE_PATH) == TC_PASS);
 }

--- a/tests/subsys/fs/multi-fs/src/test_fat_mount.c
+++ b/tests/subsys/fs/multi-fs/src/test_fat_mount.c
@@ -42,6 +42,6 @@ void test_fat_mount(void)
 #ifdef CONFIG_FILE_SYSTEM_SHELL
 	test_fs_fat_mount();
 #else
-	zassert_true(test_mount() == TC_PASS, NULL);
+	zassert_true(test_mount() == TC_PASS);
 #endif
 }

--- a/tests/subsys/fs/multi-fs/src/test_littlefs_dir.c
+++ b/tests/subsys/fs/multi-fs/src/test_littlefs_dir.c
@@ -13,15 +13,15 @@
 
 void test_littlefs_mkdir(void)
 {
-	zassert_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS, NULL);
+	zassert_true(test_mkdir(TEST_DIR_PATH, TEST_FILE) == TC_PASS);
 }
 
 void test_littlefs_readdir(void)
 {
-	zassert_true(test_lsdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	zassert_true(test_lsdir(TEST_DIR_PATH) == TC_PASS);
 }
 
 void test_littlefs_rmdir(void)
 {
-	zassert_true(test_rmdir(TEST_DIR_PATH) == TC_PASS, NULL);
+	zassert_true(test_rmdir(TEST_DIR_PATH) == TC_PASS);
 }

--- a/tests/subsys/fs/multi-fs/src/test_littlefs_file.c
+++ b/tests/subsys/fs/multi-fs/src/test_littlefs_file.c
@@ -28,14 +28,14 @@ void test_littlefs_write(void)
 
 void test_littlefs_read(void)
 {
-	zassert_true(test_file_read(&test_file, test_str) == TC_PASS, NULL);
+	zassert_true(test_file_read(&test_file, test_str) == TC_PASS);
 }
 
 void test_littlefs_close(void)
 {
-	zassert_true(test_file_close(&test_file) == TC_PASS, NULL);
+	zassert_true(test_file_close(&test_file) == TC_PASS);
 }
 void test_littlefs_unlink(void)
 {
-	zassert_true(test_file_delete(TEST_FILE_PATH) == TC_PASS, NULL);
+	zassert_true(test_file_delete(TEST_FILE_PATH) == TC_PASS);
 }

--- a/tests/subsys/fs/multi-fs/src/test_littlefs_mount.c
+++ b/tests/subsys/fs/multi-fs/src/test_littlefs_mount.c
@@ -44,6 +44,6 @@ void test_littlefs_mount(void)
 #ifdef CONFIG_FILE_SYSTEM_SHELL
 	test_fs_littlefs_mount();
 #else
-	zassert_true(test_mount() == TC_PASS, NULL);
+	zassert_true(test_mount() == TC_PASS);
 #endif
 }

--- a/tests/subsys/ipc/ipc_service/src/main.c
+++ b/tests/subsys/ipc/ipc_service/src/main.c
@@ -47,10 +47,10 @@ ZTEST(ipc_service, test_ipc_service)
 	ept_cfg.priv = (void *) 20;
 
 	ret = ipc_service_register_endpoint(dev_10, &ept_10, &ept_cfg);
-	zassert_ok(ret, "ipc_service_register_endpoint() failed", NULL);
+	zassert_ok(ret, "ipc_service_register_endpoint() failed");
 
 	ret = ipc_service_send(&ept_10, &msg, sizeof(msg));
-	zassert_ok(ret, "ipc_service_send() failed", NULL);
+	zassert_ok(ret, "ipc_service_send() failed");
 
 	/*
 	 * We send 10 again this time through the ipc20 instance so we expect
@@ -63,10 +63,10 @@ ZTEST(ipc_service, test_ipc_service)
 	ept_cfg.priv = (void *) 30;
 
 	ret = ipc_service_register_endpoint(dev_20, &ept_20, &ept_cfg);
-	zassert_ok(ret, "ipc_service_register_endpoint() failed", NULL);
+	zassert_ok(ret, "ipc_service_register_endpoint() failed");
 
 	ret = ipc_service_send(&ept_20, &msg, sizeof(msg));
-	zassert_ok(ret, "ipc_service_send() failed", NULL);
+	zassert_ok(ret, "ipc_service_send() failed");
 }
 
 ZTEST_SUITE(ipc_service, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/logging/log_api/src/main.c
+++ b/tests/subsys/logging/log_api/src/main.c
@@ -127,7 +127,7 @@ static void process_and_validate(bool backend2_enable, bool panic)
 	mock_log_frontend_validate(panic);
 
 	if (NO_BACKENDS) {
-		zassert_equal(log_backend_count_get(), 0, NULL);
+		zassert_equal(log_backend_count_get(), 0);
 		return;
 	}
 

--- a/tests/subsys/logging/log_api/src/mock_backend.c
+++ b/tests/subsys/logging/log_api/src/mock_backend.c
@@ -101,11 +101,11 @@ void mock_log_backend_validate(const struct log_backend *backend, bool panic)
 		      "Got: %u, Expected: %u", mock->drop_cnt, mock->exp_drop_cnt);
 	zassert_equal(mock->msg_rec_idx, mock->msg_proc_idx,
 			"%p Recored:%d, Got: %d", mock, mock->msg_rec_idx, mock->msg_proc_idx);
-	zassert_equal(mock->panic, panic, NULL);
+	zassert_equal(mock->panic, panic);
 
 #if defined(CONFIG_LOG_MODE_DEFERRED) && \
 	defined(CONFIG_LOG_PROCESS_THREAD)
-	zassert_true(mock->evt_notified, NULL);
+	zassert_true(mock->evt_notified);
 #endif
 }
 
@@ -146,8 +146,8 @@ static void process(const struct log_backend *const backend,
 		      "Got: %u, expected: %u",
 #endif
 		      msg->log.hdr.timestamp, exp->timestamp);
-	zassert_equal(msg->log.hdr.desc.level, exp->level, NULL);
-	zassert_equal(msg->log.hdr.desc.domain, exp->domain_id, NULL);
+	zassert_equal(msg->log.hdr.desc.level, exp->level);
+	zassert_equal(msg->log.hdr.desc.domain, exp->domain_id);
 
 	uint32_t source_id;
 	const void *source = msg->log.hdr.source;
@@ -169,9 +169,9 @@ static void process(const struct log_backend *const backend,
 	uint8_t *data;
 
 	data = log_msg_get_data(&msg->log, &len);
-	zassert_equal(exp->data_len, len, NULL);
+	zassert_equal(exp->data_len, len);
 	if (exp->data_len <= sizeof(exp->data)) {
-		zassert_equal(memcmp(data, exp->data, len), 0, NULL);
+		zassert_equal(memcmp(data, exp->data, len), 0);
 	}
 
 	char str[128];

--- a/tests/subsys/logging/log_api/src/mock_frontend.c
+++ b/tests/subsys/logging/log_api/src/mock_frontend.c
@@ -99,8 +99,8 @@ void log_frontend_msg(const void *source,
 		return;
 	}
 
-	zassert_equal(desc.level, exp_msg->level, NULL);
-	zassert_equal(desc.domain, exp_msg->domain_id, NULL);
+	zassert_equal(desc.level, exp_msg->level);
+	zassert_equal(desc.domain, exp_msg->domain_id);
 
 	uint32_t source_id;
 
@@ -115,9 +115,9 @@ void log_frontend_msg(const void *source,
 	zassert_equal(source_id, exp_msg->source_id, "got: %d, exp: %d",
 			source_id, exp_msg->source_id);
 
-	zassert_equal(exp_msg->data_len, desc.data_len, NULL);
+	zassert_equal(exp_msg->data_len, desc.data_len);
 	if (exp_msg->data_len <= sizeof(exp_msg->data)) {
-		zassert_equal(memcmp(data, exp_msg->data, desc.data_len), 0, NULL);
+		zassert_equal(memcmp(data, exp_msg->data, desc.data_len), 0);
 	}
 
 	char str[128];

--- a/tests/subsys/logging/log_backend_init/src/main.c
+++ b/tests/subsys/logging/log_backend_init/src/main.c
@@ -127,13 +127,13 @@ ZTEST(log_backend_init, test_log_backends_initialization)
 	LOG_INF("test1");
 
 	/* Backends are not yet active. */
-	zassert_false(context1.active, NULL);
-	zassert_false(context2.active, NULL);
+	zassert_false(context1.active);
+	zassert_false(context2.active);
 
 	k_msleep(context2.delay + 100);
 
-	zassert_true(context1.active, NULL);
-	zassert_true(context2.active, NULL);
+	zassert_true(context1.active);
+	zassert_true(context2.active);
 
 	LOG_INF("test2");
 
@@ -143,7 +143,7 @@ ZTEST(log_backend_init, test_log_backends_initialization)
 	 * because when first was processed it was not yet active.
 	 */
 	zassert_equal(context1.cnt, 2, "Unexpected value:%d (exp: %d)", context1.cnt, 2);
-	zassert_equal(context2.cnt, 1, NULL);
+	zassert_equal(context2.cnt, 1);
 }
 
 ZTEST_SUITE(log_backend_init, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/logging/log_core_additional/src/log_test.c
+++ b/tests/subsys/logging/log_core_additional/src/log_test.c
@@ -399,22 +399,22 @@ ZTEST(test_log_core_additional, test_log_thread)
 	slabs_free = log_msg_mem_get_free();
 	used = log_msg_mem_get_used();
 	max = log_msg_mem_get_max_used();
-	zassert_equal(used, 0, NULL);
+	zassert_equal(used, 0);
 
 	LOG_INF("log info to log thread");
 	LOG_WRN("log warning to log thread");
 	LOG_ERR("log error to log thread");
 
-	zassert_equal(log_msg_mem_get_used(), 3, NULL);
-	zassert_equal(log_msg_mem_get_free(), slabs_free - 3, NULL);
-	zassert_equal(log_msg_mem_get_max_used(), max, NULL);
+	zassert_equal(log_msg_mem_get_used(), 3);
+	zassert_equal(log_msg_mem_get_free(), slabs_free - 3);
+	zassert_equal(log_msg_mem_get_max_used(), max);
 
 	TC_PRINT("after log, free: %d, used: %d, max: %d\n", slabs_free, used, max);
 	/* wait 2 seconds for logging thread to handle this log message*/
 	k_sleep(K_MSEC(2000));
 	zassert_equal(3, backend1_cb.counter,
 		      "Unexpected amount of messages received by the backend.");
-	zassert_equal(log_msg_mem_get_used(), 0, NULL);
+	zassert_equal(log_msg_mem_get_used(), 0);
 }
 #else
 ZTEST(test_log_core_additional, test_log_thread)

--- a/tests/subsys/logging/log_msg/src/main.c
+++ b/tests/subsys/logging/log_msg/src/main.c
@@ -83,22 +83,22 @@ static void basic_validate(struct log_msg *msg,
 	char buf[256];
 	struct test_buf tbuf = { .buf = buf, .idx = 0 };
 
-	zassert_equal(log_msg_get_source(msg), (void *)source, NULL);
-	zassert_equal(log_msg_get_domain(msg), domain, NULL);
-	zassert_equal(log_msg_get_level(msg), level, NULL);
-	zassert_equal(log_msg_get_timestamp(msg), t, NULL);
+	zassert_equal(log_msg_get_source(msg), (void *)source);
+	zassert_equal(log_msg_get_domain(msg), domain);
+	zassert_equal(log_msg_get_level(msg), level);
+	zassert_equal(log_msg_get_timestamp(msg), t);
 
 	d = log_msg_get_data(msg, &len);
-	zassert_equal(len, data_len, NULL);
+	zassert_equal(len, data_len);
 	if (len) {
 		rv = memcmp(d, data, data_len);
-		zassert_equal(rv, 0, NULL);
+		zassert_equal(rv, 0);
 	}
 
 	d = log_msg_get_package(msg, &len);
 	if (str) {
 		rv = cbpprintf(out, &tbuf, d);
-		zassert_true(rv > 0, NULL);
+		zassert_true(rv > 0);
 		buf[rv] = '\0';
 
 		rv = strncmp(buf, str, sizeof(buf));
@@ -112,7 +112,7 @@ union log_msg_generic *msg_copy_and_free(union log_msg_generic *msg,
 	size_t len = sizeof(int) *
 		     log_msg_generic_get_wlen((union mpsc_pbuf_generic *)msg);
 
-	zassert_true(len < buf_len, NULL);
+	zassert_true(len < buf_len);
 
 	memcpy(buf, msg, len);
 
@@ -184,7 +184,7 @@ void validate_base_message_set(const struct log_source_const_data *source,
 	 * Runtime created message (msg2) may have strings copied in and thus
 	 * different length.
 	 */
-	zassert_equal(len0, len1, NULL);
+	zassert_equal(len0, len1);
 
 	int rv = memcmp(msg0, msg1, sizeof(int) * len0);
 
@@ -211,11 +211,11 @@ ZTEST(log_msg, test_log_msg_0_args_msg)
 
 	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level,
 			  NULL, 0, TEST_MSG);
-	zassert_equal(mode, EXP_MODE(ZERO_COPY), NULL);
+	zassert_equal(mode, EXP_MODE(ZERO_COPY));
 
 	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level,
 			  NULL, 0, TEST_MSG);
-	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
+	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
 	z_log_msg_runtime_create(domain, source,
 				  level, NULL, 0, 0, TEST_MSG);
@@ -244,11 +244,11 @@ ZTEST(log_msg, test_log_msg_various_args)
 
 	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, s8, u, lld, (void *)str, lld, (void *)iarray);
-	zassert_equal(mode, EXP_MODE(ZERO_COPY), NULL);
+	zassert_equal(mode, EXP_MODE(ZERO_COPY));
 
 	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, s8, u, lld, (void *)str, lld, (void *)iarray);
-	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
+	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
 	z_log_msg_runtime_create(domain, (void *)source, level, NULL,
 				  0, 0, TEST_MSG, s8, u, lld, str, lld, iarray);
@@ -271,11 +271,11 @@ ZTEST(log_msg, test_log_msg_only_data)
 
 	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, array,
 			   sizeof(array));
-	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
+	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
 	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, array,
 			   sizeof(array));
-	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
+	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
 	z_log_msg_runtime_create(domain, (void *)source, level, array,
 				  sizeof(array), 0, NULL);
@@ -300,11 +300,11 @@ ZTEST(log_msg, test_log_msg_string_and_data)
 
 	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, array,
 			   sizeof(array), TEST_MSG);
-	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
+	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
 	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, array,
 			   sizeof(array), TEST_MSG);
-	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
+	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
 	z_log_msg_runtime_create(domain, (void *)source, level, array,
 				  sizeof(array), 0, TEST_MSG);
@@ -337,11 +337,11 @@ ZTEST(log_msg, test_log_msg_fp)
 
 	Z_LOG_MSG2_CREATE3(1, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, i, lli, (double)f, &i, d, source);
-	zassert_equal(mode, EXP_MODE(ZERO_COPY), NULL);
+	zassert_equal(mode, EXP_MODE(ZERO_COPY));
 
 	Z_LOG_MSG2_CREATE3(0, mode, 0, domain, source, level, NULL, 0,
 			TEST_MSG, i, lli, (double)f, &i, d, source);
-	zassert_equal(mode, EXP_MODE(FROM_STACK), NULL);
+	zassert_equal(mode, EXP_MODE(FROM_STACK));
 
 	z_log_msg_runtime_create(domain, (void *)source, level, NULL, 0, 0,
 				  TEST_MSG, i, lli, (double)f, &i, d, source);

--- a/tests/subsys/logging/log_output/src/log_output_test.c
+++ b/tests/subsys/logging/log_output/src/log_output_test.c
@@ -52,12 +52,12 @@ ZTEST(test_log_output, test_no_flags)
 	int err;
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	log_output_process(&log_output, 0, NULL, SNAME, LOG_LEVEL_INF, package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0, NULL);
+	zassert_equal(strcmp(exp_str, mock_buffer), 0);
 }
 
 ZTEST(test_log_output, test_raw)
@@ -67,13 +67,13 @@ ZTEST(test_log_output, test_raw)
 	int err;
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	log_output_process(&log_output, 0, NULL, SNAME, LOG_LEVEL_INTERNAL_RAW_STRING,
 			   package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0, NULL);
+	zassert_equal(strcmp(exp_str, mock_buffer), 0);
 }
 
 ZTEST(test_log_output, test_no_flags_dname)
@@ -83,12 +83,12 @@ ZTEST(test_log_output, test_no_flags_dname)
 	int err;
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	log_output_process(&log_output, 0, DNAME, SNAME, LOG_LEVEL_INF, package, NULL, 0, 0);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0, NULL);
+	zassert_equal(strcmp(exp_str, mock_buffer), 0);
 }
 
 ZTEST(test_log_output, test_level_flag)
@@ -99,13 +99,13 @@ ZTEST(test_log_output, test_level_flag)
 	int err;
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	log_output_process(&log_output, 0, DNAME, SNAME, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0, NULL);
+	zassert_equal(strcmp(exp_str, mock_buffer), 0);
 }
 
 ZTEST(test_log_output, test_ts_flag)
@@ -118,13 +118,13 @@ ZTEST(test_log_output, test_ts_flag)
 	int err;
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	log_output_process(&log_output, 0, DNAME, SNAME, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
-	zassert_equal(strcmp(exp_str, mock_buffer), 0, NULL);
+	zassert_equal(strcmp(exp_str, mock_buffer), 0);
 }
 
 ZTEST(test_log_output, test_format_ts)
@@ -138,25 +138,25 @@ ZTEST(test_log_output, test_format_ts)
 	log_output_timestamp_freq_set(1000000);
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	log_output_process(&log_output, 1000000, DNAME, SNAME, LOG_LEVEL_INF,
 			   package, NULL, 0, flags);
 
 	mock_buffer[mock_len] = '\0';
 	printk("%s", mock_buffer);
-	zassert_equal(strcmp(exp_str, mock_buffer), 0, NULL);
+	zassert_equal(strcmp(exp_str, mock_buffer), 0);
 }
 
 ZTEST(test_log_output, test_ts_to_us)
 {
 	log_output_timestamp_freq_set(1000000);
 
-	zassert_equal(log_output_timestamp_to_us(1000), 1000, NULL);
+	zassert_equal(log_output_timestamp_to_us(1000), 1000);
 
 	log_output_timestamp_freq_set(32768);
 
-	zassert_equal(log_output_timestamp_to_us(10), 305, NULL);
+	zassert_equal(log_output_timestamp_to_us(10), 305);
 }
 
 ZTEST(test_log_output, test_levels)
@@ -173,7 +173,7 @@ ZTEST(test_log_output, test_levels)
 	int err;
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	for (int i = 0; i < ARRAY_SIZE(exp_strs); i++) {
 		reset_mock_buffer();
@@ -182,7 +182,7 @@ ZTEST(test_log_output, test_levels)
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
-		zassert_equal(strcmp(exp_strs[i], mock_buffer), 0, NULL);
+		zassert_equal(strcmp(exp_strs[i], mock_buffer), 0);
 	}
 }
 
@@ -205,7 +205,7 @@ ZTEST(test_log_output, test_colors)
 	int err;
 
 	err = cbprintf_package(package, sizeof(package), 0, TEST_STR);
-	zassert_true(err > 0, NULL);
+	zassert_true(err > 0);
 
 	for (int i = 0; i < ARRAY_SIZE(exp_strs); i++) {
 		reset_mock_buffer();
@@ -214,7 +214,7 @@ ZTEST(test_log_output, test_colors)
 				   package, NULL, 0, flags);
 
 		mock_buffer[mock_len] = '\0';
-		zassert_equal(strcmp(exp_strs[i], mock_buffer), 0, NULL);
+		zassert_equal(strcmp(exp_strs[i], mock_buffer), 0);
 	}
 }
 

--- a/tests/subsys/logging/log_stack/src/main.c
+++ b/tests/subsys/logging/log_stack/src/main.c
@@ -50,13 +50,13 @@ ZTEST_SUITE(test_log_stack, NULL, NULL, NULL, NULL, after);
 	\
 	k_msleep(100); \
 	err = k_thread_stack_space_get(k_current_get(), &unused); \
-	zassert_equal(err, 0, NULL); \
+	zassert_equal(err, 0); \
 	__DEBRACKET log_msg; \
 	\
 	k_msleep(100); \
 	\
 	err = k_thread_stack_space_get(k_current_get(), &unused2); \
-	zassert_equal(err, 0, NULL); \
+	zassert_equal(err, 0); \
 	\
 	usage = unused - unused2; \
 	PRINT("Stack increase due to log usage: %zu\n", usage); \

--- a/tests/subsys/logging/log_stress/src/main.c
+++ b/tests/subsys/logging/log_stress/src/main.c
@@ -66,7 +66,7 @@ static void mock_init(struct log_backend const *const backend)
 
 static void panic(struct log_backend const *const backend)
 {
-	zassert_true(false, NULL);
+	zassert_true(false);
 }
 
 static void dropped(const struct log_backend *const backend, uint32_t cnt)
@@ -102,7 +102,7 @@ static void validate(int ctx_cnt)
 	zassert_equal(mock_backend.dropped, mock_backend.missing,
 			"dropped:%u missing:%u",
 			mock_backend.dropped, mock_backend.missing);
-	zassert_equal(in_cnt, out_cnt, NULL);
+	zassert_equal(in_cnt, out_cnt);
 }
 
 static bool context_handler(void *user_data, uint32_t cnt, bool last, int prio)

--- a/tests/subsys/openthread/radio_test.c
+++ b/tests/subsys/openthread/radio_test.c
@@ -118,11 +118,11 @@ static otError otPlatRadioReceiveDone_expected_error;
 void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
 	zassert_equal(aInstance, ot, "Incorrect instance.");
-	zassert_equal(otPlatRadioReceiveDone_expected_aframe.mChannel, aFrame->mChannel, NULL);
-	zassert_equal(otPlatRadioReceiveDone_expected_aframe.mLength, aFrame->mLength, NULL);
+	zassert_equal(otPlatRadioReceiveDone_expected_aframe.mChannel, aFrame->mChannel);
+	zassert_equal(otPlatRadioReceiveDone_expected_aframe.mLength, aFrame->mLength);
 	zassert_mem_equal(otPlatRadioReceiveDone_expected_aframe.mPsdu, aFrame->mPsdu,
 			  aFrame->mLength, NULL);
-	zassert_equal(otPlatRadioReceiveDone_expected_error, aError, NULL);
+	zassert_equal(otPlatRadioReceiveDone_expected_error, aError);
 }
 
 FAKE_VOID_FUNC(otPlatRadioTxDone, otInstance *, otRadioFrame *, otRadioFrame *, otError);
@@ -171,19 +171,19 @@ ZTEST(openthread_radio, test_energy_scan_immediate_test)
 	scan_mock_fake.return_val = 0;
 	zassert_equal(otPlatRadioEnergyScan(ot, chan, dur), OT_ERROR_NONE,
 		      "Energy scan returned error.");
-	zassert_equal(1, scan_mock_fake.call_count, NULL);
-	zassert_equal(dur, scan_mock_fake.arg1_val, NULL);
+	zassert_equal(1, scan_mock_fake.call_count);
+	zassert_equal(dur, scan_mock_fake.arg1_val);
 	zassert_not_null(scan_mock_fake.arg2_val, "Scan callback not specified.");
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(chan, set_channel_mock_fake.arg1_val, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(chan, set_channel_mock_fake.arg1_val);
 
 	scan_mock_fake.arg2_val(radio, energy);
 	make_sure_sem_set(K_NO_WAIT);
 
 	platformRadioProcess(ot);
-	zassert_equal(1, otPlatRadioEnergyScanDone_fake.call_count, NULL);
+	zassert_equal(1, otPlatRadioEnergyScanDone_fake.call_count);
 	zassert_equal_ptr(ot, otPlatRadioEnergyScanDone_fake.arg0_val, NULL);
-	zassert_equal(energy, otPlatRadioEnergyScanDone_fake.arg1_val, NULL);
+	zassert_equal(energy, otPlatRadioEnergyScanDone_fake.arg1_val);
 }
 
 /**
@@ -204,11 +204,11 @@ ZTEST(openthread_radio, test_energy_scan_delayed_test)
 
 	zassert_equal(otPlatRadioEnergyScan(ot, chan, dur), OT_ERROR_NONE,
 		      "Energy scan returned error.");
-	zassert_equal(1, scan_mock_fake.call_count, NULL);
-	zassert_equal(dur, scan_mock_fake.arg1_val, NULL);
+	zassert_equal(1, scan_mock_fake.call_count);
+	zassert_equal(dur, scan_mock_fake.arg1_val);
 	zassert_not_null(scan_mock_fake.arg2_val, "Scan callback not specified.");
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(chan, set_channel_mock_fake.arg1_val, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(chan, set_channel_mock_fake.arg1_val);
 	make_sure_sem_set(K_NO_WAIT);
 
 	/* process reported event */
@@ -220,20 +220,20 @@ ZTEST(openthread_radio, test_energy_scan_delayed_test)
 	set_channel_mock_fake.return_val = 0;
 
 	platformRadioProcess(ot);
-	zassert_equal(1, scan_mock_fake.call_count, NULL);
-	zassert_equal(dur, scan_mock_fake.arg1_val, NULL);
+	zassert_equal(1, scan_mock_fake.call_count);
+	zassert_equal(dur, scan_mock_fake.arg1_val);
 	zassert_not_null(scan_mock_fake.arg2_val, "Scan callback not specified.");
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(chan, set_channel_mock_fake.arg1_val, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(chan, set_channel_mock_fake.arg1_val);
 
 	/* invoke scan done */
 	scan_mock_fake.arg2_val(radio, energy);
 	make_sure_sem_set(K_NO_WAIT);
 
 	platformRadioProcess(ot);
-	zassert_equal(1, otPlatRadioEnergyScanDone_fake.call_count, NULL);
+	zassert_equal(1, otPlatRadioEnergyScanDone_fake.call_count);
 	zassert_equal_ptr(ot, otPlatRadioEnergyScanDone_fake.arg0_val, NULL);
-	zassert_equal(energy, otPlatRadioEnergyScanDone_fake.arg1_val, NULL);
+	zassert_equal(energy, otPlatRadioEnergyScanDone_fake.arg1_val);
 }
 
 static void create_ack_frame(void)
@@ -277,11 +277,11 @@ ZTEST(openthread_radio, test_tx_test)
 
 	set_channel_mock_fake.return_val = 0;
 	zassert_equal(otPlatRadioReceive(ot, chan), OT_ERROR_NONE, "Failed to receive.");
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(chan, set_channel_mock_fake.arg1_val, NULL);
-	zassert_equal(1, set_txpower_mock_fake.call_count, NULL);
-	zassert_equal(power, set_txpower_mock_fake.arg1_val, NULL);
-	zassert_equal(1, start_mock_fake.call_count, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(chan, set_channel_mock_fake.arg1_val);
+	zassert_equal(1, set_txpower_mock_fake.call_count);
+	zassert_equal(power, set_txpower_mock_fake.arg1_val);
+	zassert_equal(1, start_mock_fake.call_count);
 	zassert_equal_ptr(radio, start_mock_fake.arg0_val, NULL);
 	RESET_FAKE(set_channel_mock);
 	RESET_FAKE(set_txpower_mock);
@@ -299,17 +299,17 @@ ZTEST(openthread_radio, test_tx_test)
 	make_sure_sem_set(Z_TIMEOUT_MS(100));
 
 	platformRadioProcess(ot);
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(chan2, set_channel_mock_fake.arg1_val, NULL);
-	zassert_equal(1, cca_mock_fake.call_count, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(chan2, set_channel_mock_fake.arg1_val);
+	zassert_equal(1, cca_mock_fake.call_count);
 	zassert_equal_ptr(radio, cca_mock_fake.arg0_val, NULL);
-	zassert_equal(1, set_txpower_mock_fake.call_count, NULL);
-	zassert_equal(power, set_txpower_mock_fake.arg1_val, NULL);
-	zassert_equal(1, tx_mock_fake.call_count, NULL);
+	zassert_equal(1, set_txpower_mock_fake.call_count);
+	zassert_equal(power, set_txpower_mock_fake.arg1_val);
+	zassert_equal(1, tx_mock_fake.call_count);
 	zassert_equal_ptr(frm->mPsdu, tx_mock_fake.arg3_val->data, NULL);
-	zassert_equal(1, otPlatRadioTxDone_fake.call_count, NULL);
+	zassert_equal(1, otPlatRadioTxDone_fake.call_count);
 	zassert_equal_ptr(ot, otPlatRadioTxDone_fake.arg0_val, NULL);
-	zassert_equal(OT_ERROR_NONE, otPlatRadioTxDone_fake.arg3_val, NULL);
+	zassert_equal(OT_ERROR_NONE, otPlatRadioTxDone_fake.arg3_val);
 	RESET_FAKE(set_channel_mock);
 	RESET_FAKE(set_txpower_mock);
 	RESET_FAKE(tx_mock);
@@ -325,15 +325,15 @@ ZTEST(openthread_radio, test_tx_test)
 	zassert_equal(otPlatRadioTransmit(ot, frm), OT_ERROR_NONE, "Transmit failed.");
 	make_sure_sem_set(Z_TIMEOUT_MS(100));
 	platformRadioProcess(ot);
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(chan2, set_channel_mock_fake.arg1_val, NULL);
-	zassert_equal(1, set_txpower_mock_fake.call_count, NULL);
-	zassert_equal(power, set_txpower_mock_fake.arg1_val, NULL);
-	zassert_equal(1, tx_mock_fake.call_count, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(chan2, set_channel_mock_fake.arg1_val);
+	zassert_equal(1, set_txpower_mock_fake.call_count);
+	zassert_equal(power, set_txpower_mock_fake.arg1_val);
+	zassert_equal(1, tx_mock_fake.call_count);
 	zassert_equal_ptr(frm->mPsdu, tx_mock_fake.arg3_val->data, NULL);
-	zassert_equal(1, otPlatRadioTxDone_fake.call_count, NULL);
+	zassert_equal(1, otPlatRadioTxDone_fake.call_count);
 	zassert_equal_ptr(ot, otPlatRadioTxDone_fake.arg0_val, NULL);
-	zassert_equal(OT_ERROR_NONE, otPlatRadioTxDone_fake.arg3_val, NULL);
+	zassert_equal(OT_ERROR_NONE, otPlatRadioTxDone_fake.arg3_val);
 }
 
 /**
@@ -381,7 +381,7 @@ static int custom_configure_match_mock(const struct device *dev, enum ieee802154
 				       const struct ieee802154_config *config)
 {
 	zassert_equal_ptr(dev, radio, "Device handle incorrect.");
-	zassert_equal(custom_configure_match_mock_expected_type, type, NULL);
+	zassert_equal(custom_configure_match_mock_expected_type, type);
 	switch (type) {
 	case IEEE802154_CONFIG_AUTO_ACK_FPB:
 		zassert_equal(custom_configure_match_mock_expected_config.auto_ack_fpb.mode,
@@ -510,8 +510,8 @@ ZTEST(openthread_radio, test_promiscuous_mode_set_test)
 	configure_promiscuous_mock_fake.custom_fake = custom_configure_promiscuous_mock;
 	otPlatRadioSetPromiscuous(ot, true);
 	zassert_true(otPlatRadioGetPromiscuous(ot), "Mode not enabled.");
-	zassert_equal(1, configure_promiscuous_mock_fake.call_count, NULL);
-	zassert_true(custom_configure_promiscuous_mock_promiscuous, NULL);
+	zassert_equal(1, configure_promiscuous_mock_fake.call_count);
+	zassert_true(custom_configure_promiscuous_mock_promiscuous);
 
 	RESET_FAKE(configure_promiscuous_mock);
 	FFF_RESET_HISTORY();
@@ -519,8 +519,8 @@ ZTEST(openthread_radio, test_promiscuous_mode_set_test)
 	configure_promiscuous_mock_fake.custom_fake = custom_configure_promiscuous_mock;
 	otPlatRadioSetPromiscuous(ot, false);
 	zassert_false(otPlatRadioGetPromiscuous(ot), "Mode still enabled.");
-	zassert_equal(1, configure_promiscuous_mock_fake.call_count, NULL);
-	zassert_false(custom_configure_promiscuous_mock_promiscuous, NULL);
+	zassert_equal(1, configure_promiscuous_mock_fake.call_count);
+	zassert_false(custom_configure_promiscuous_mock_promiscuous);
 
 	rapi.configure = configure_mock;
 }
@@ -640,13 +640,13 @@ ZTEST(openthread_radio, test_radio_state_test)
 	zassert_equal(platformRadioChannelGet(ot), channel, "Channel number not remembered.");
 
 	zassert_true(otPlatRadioIsEnabled(ot), "Radio reports as disabled.");
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(channel, set_channel_mock_fake.arg1_val, NULL);
-	zassert_equal(1, set_txpower_mock_fake.call_count, NULL);
-	zassert_equal(power, set_txpower_mock_fake.arg1_val, NULL);
-	zassert_equal(1, start_mock_fake.call_count, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(channel, set_channel_mock_fake.arg1_val);
+	zassert_equal(1, set_txpower_mock_fake.call_count);
+	zassert_equal(power, set_txpower_mock_fake.arg1_val);
+	zassert_equal(1, start_mock_fake.call_count);
 	zassert_equal_ptr(radio, start_mock_fake.arg0_val, NULL);
-	zassert_equal(1, stop_mock_fake.call_count, NULL);
+	zassert_equal(1, stop_mock_fake.call_count);
 	zassert_equal_ptr(radio, stop_mock_fake.arg0_val, NULL);
 }
 
@@ -691,27 +691,27 @@ ZTEST(openthread_radio, test_address_test)
 
 	filter_mock_fake.custom_fake = custom_filter_mock;
 	otPlatRadioSetPanId(ot, pan_id);
-	zassert_equal(1, filter_mock_fake.call_count, NULL);
-	zassert_true(filter_mock_fake.arg1_val, NULL);
-	zassert_equal(IEEE802154_FILTER_TYPE_PAN_ID, filter_mock_fake.arg2_val, NULL);
-	zassert_equal(pan_id, custom_filter_mock_pan_id, NULL);
+	zassert_equal(1, filter_mock_fake.call_count);
+	zassert_true(filter_mock_fake.arg1_val);
+	zassert_equal(IEEE802154_FILTER_TYPE_PAN_ID, filter_mock_fake.arg2_val);
+	zassert_equal(pan_id, custom_filter_mock_pan_id);
 	RESET_FAKE(filter_mock);
 	FFF_RESET_HISTORY();
 
 	filter_mock_fake.custom_fake = custom_filter_mock;
 	otPlatRadioSetShortAddress(ot, short_add);
-	zassert_equal(1, filter_mock_fake.call_count, NULL);
-	zassert_true(filter_mock_fake.arg1_val, NULL);
-	zassert_equal(IEEE802154_FILTER_TYPE_SHORT_ADDR, filter_mock_fake.arg2_val, NULL);
-	zassert_equal(short_add, custom_filter_mock_short_addr, NULL);
+	zassert_equal(1, filter_mock_fake.call_count);
+	zassert_true(filter_mock_fake.arg1_val);
+	zassert_equal(IEEE802154_FILTER_TYPE_SHORT_ADDR, filter_mock_fake.arg2_val);
+	zassert_equal(short_add, custom_filter_mock_short_addr);
 	RESET_FAKE(filter_mock);
 	FFF_RESET_HISTORY();
 
 	filter_mock_fake.custom_fake = custom_filter_mock;
 	otPlatRadioSetExtendedAddress(ot, &ieee_addr);
-	zassert_equal(1, filter_mock_fake.call_count, NULL);
-	zassert_true(filter_mock_fake.arg1_val, NULL);
-	zassert_equal(IEEE802154_FILTER_TYPE_IEEE_ADDR, filter_mock_fake.arg2_val, NULL);
+	zassert_equal(1, filter_mock_fake.call_count);
+	zassert_true(filter_mock_fake.arg1_val);
+	zassert_equal(IEEE802154_FILTER_TYPE_IEEE_ADDR, filter_mock_fake.arg2_val);
 	zassert_mem_equal(ieee_addr.m8, custom_filter_mock_ieee_addr, OT_EXT_ADDRESS_SIZE, NULL);
 }
 
@@ -765,11 +765,11 @@ ZTEST(openthread_radio, test_receive_test)
 
 	set_channel_mock_fake.return_val = 0;
 	zassert_equal(otPlatRadioReceive(ot, channel), OT_ERROR_NONE, "Failed to receive.");
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(channel, set_channel_mock_fake.arg1_val, NULL);
-	zassert_equal(1, set_txpower_mock_fake.call_count, NULL);
-	zassert_equal(power, set_txpower_mock_fake.arg1_val, NULL);
-	zassert_equal(1, start_mock_fake.call_count, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(channel, set_channel_mock_fake.arg1_val);
+	zassert_equal(1, set_txpower_mock_fake.call_count);
+	zassert_equal(power, set_txpower_mock_fake.arg1_val);
+	zassert_equal(1, start_mock_fake.call_count);
 	zassert_equal_ptr(radio, start_mock_fake.arg0_val, NULL);
 
 	/*
@@ -809,11 +809,11 @@ ZTEST(openthread_radio, test_net_pkt_transmit)
 
 	set_channel_mock_fake.return_val = 0;
 	zassert_equal(otPlatRadioReceive(ot, channel), OT_ERROR_NONE, "Failed to receive.");
-	zassert_equal(1, set_channel_mock_fake.call_count, NULL);
-	zassert_equal(channel, set_channel_mock_fake.arg1_val, NULL);
-	zassert_equal(1, set_txpower_mock_fake.call_count, NULL);
-	zassert_equal(power, set_txpower_mock_fake.arg1_val, NULL);
-	zassert_equal(1, start_mock_fake.call_count, NULL);
+	zassert_equal(1, set_channel_mock_fake.call_count);
+	zassert_equal(channel, set_channel_mock_fake.arg1_val);
+	zassert_equal(1, set_txpower_mock_fake.call_count);
+	zassert_equal(power, set_txpower_mock_fake.arg1_val);
+	zassert_equal(1, start_mock_fake.call_count);
 	zassert_equal_ptr(radio, start_mock_fake.arg0_val, NULL);
 
 	notify_new_tx_frame(packet);
@@ -828,14 +828,14 @@ ZTEST(openthread_radio, test_net_pkt_transmit)
 	expected_data_ptrs[0] = buf->data;
 	expected_data_ptrs[1] = buf->frags->data;
 	platformRadioProcess(ot);
-	zassert_equal(2, otMessageAppend_fake.call_count, NULL);
+	zassert_equal(2, otMessageAppend_fake.call_count);
 	zassert_equal_ptr(ip_msg, otMessageAppend_fake.arg0_history[0], NULL);
 	zassert_equal_ptr(ip_msg, otMessageAppend_fake.arg0_history[1], NULL);
 	zassert_equal_ptr(expected_data_ptrs[0], otMessageAppend_fake.arg1_history[0], NULL);
 	zassert_equal_ptr(expected_data_ptrs[1], otMessageAppend_fake.arg1_history[1], NULL);
-	zassert_equal(len, otMessageAppend_fake.arg2_history[0], NULL);
-	zassert_equal(len, otMessageAppend_fake.arg2_history[1], NULL);
-	zassert_equal(1, otIp6Send_fake.call_count, NULL);
+	zassert_equal(len, otMessageAppend_fake.arg2_history[0]);
+	zassert_equal(len, otMessageAppend_fake.arg2_history[1]);
+	zassert_equal(1, otIp6Send_fake.call_count);
 	zassert_equal_ptr(ot, otIp6Send_fake.arg0_val, NULL);
 	zassert_equal_ptr(ip_msg, otIp6Send_fake.arg1_val, NULL);
 
@@ -855,10 +855,10 @@ ZTEST(openthread_radio, test_net_pkt_transmit)
 	expected_data_ptrs[0] = buf->data;
 
 	platformRadioProcess(ot);
-	zassert_equal(1, otMessageAppend_fake.call_count, NULL);
+	zassert_equal(1, otMessageAppend_fake.call_count);
 	zassert_equal_ptr(ip_msg, otMessageAppend_fake.arg0_val, NULL);
 	zassert_equal_ptr(expected_data_ptrs[0], otMessageAppend_fake.arg1_val, NULL);
-	zassert_equal(len, otMessageAppend_fake.arg2_val, NULL);
+	zassert_equal(len, otMessageAppend_fake.arg2_val);
 	zassert_equal_ptr(ip_msg, otMessageFree_fake.arg0_val, NULL);
 
 	RESET_FAKE(otMessageAppend);
@@ -879,11 +879,11 @@ ZTEST(openthread_radio, test_net_pkt_transmit)
 	/* Do not expect free in case of failure in send */
 
 	platformRadioProcess(ot);
-	zassert_equal(1, otMessageAppend_fake.call_count, NULL);
+	zassert_equal(1, otMessageAppend_fake.call_count);
 	zassert_equal_ptr(ip_msg, otMessageAppend_fake.arg0_val, NULL);
 	zassert_equal_ptr(expected_data_ptrs[0], otMessageAppend_fake.arg1_val, NULL);
-	zassert_equal(len, otMessageAppend_fake.arg2_val, NULL);
-	zassert_equal(1, otIp6Send_fake.call_count, NULL);
+	zassert_equal(len, otMessageAppend_fake.arg2_val);
+	zassert_equal(1, otIp6Send_fake.call_count);
 	zassert_equal_ptr(ot, otIp6Send_fake.arg0_val, NULL);
 	zassert_equal_ptr(ip_msg, otIp6Send_fake.arg1_val, NULL);
 }

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -25,11 +25,11 @@ static void get_runner(void *arg1, void *arg2, void *arg3)
 
 	/* make sure we test blocking path (suspend is ongoing) */
 	ongoing = test_driver_pm_ongoing(dev);
-	zassert_equal(ongoing, true, NULL);
+	zassert_equal(ongoing, true);
 
 	/* usage: 0, +1, resume: yes */
 	ret = pm_device_runtime_get(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 void test_api_setup(void *data)
@@ -39,22 +39,22 @@ void test_api_setup(void *data)
 
 	/* check API always returns 0 when runtime PM is disabled */
 	ret = pm_device_runtime_get(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	ret = pm_device_runtime_put(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 	ret = pm_device_runtime_put_async(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	/* enable runtime PM */
 	ret = pm_device_runtime_enable(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/* enabling again should succeed (no-op) */
 	ret = pm_device_runtime_enable(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 static void test_api_teardown(void *data)
@@ -71,10 +71,10 @@ static void test_api_teardown(void *data)
 
 	/* disable runtime PM, make sure device is left into active state */
 	ret = pm_device_runtime_disable(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 }
 
 /**
@@ -93,89 +93,89 @@ ZTEST(device_runtime_api, test_api)
 
 	/* device is initially suspended */
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/*** get + put ***/
 
 	/* usage: 0, +1, resume: yes */
 	ret = pm_device_runtime_get(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	/* usage: 1, +1, resume: no */
 	ret = pm_device_runtime_get(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	/* usage: 2, -1, suspend: no */
 	ret = pm_device_runtime_put(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	/* usage: 1, -1, suspend: yes */
 	ret = pm_device_runtime_put(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/* usage: 0, -1, suspend: no (unbalanced call) */
 	ret = pm_device_runtime_put(dev);
-	zassert_equal(ret, -EALREADY, NULL);
+	zassert_equal(ret, -EALREADY);
 
 	/*** get + asynchronous put until suspended ***/
 
 	/* usage: 0, +1, resume: yes */
 	ret = pm_device_runtime_get(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	test_driver_pm_async(dev);
 
 	/* usage: 1, -1, suspend: yes (queued) */
 	ret = pm_device_runtime_put_async(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
 	/* usage: 0, -1, suspend: no (unbalanced call) */
 	ret = pm_device_runtime_put(dev);
-	zassert_equal(ret, -EALREADY, NULL);
+	zassert_equal(ret, -EALREADY);
 
 	/* usage: 0, -1, suspend: no (unbalanced call) */
 	ret = pm_device_runtime_put_async(dev);
-	zassert_equal(ret, -EALREADY, NULL);
+	zassert_equal(ret, -EALREADY);
 
 	/* unblock test driver and let it finish */
 	test_driver_pm_done(dev);
 	k_yield();
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/*** get + asynchronous put + get (while suspend still ongoing) ***/
 
 	/* usage: 0, +1, resume: yes */
 	ret = pm_device_runtime_get(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	test_driver_pm_async(dev);
 
 	/* usage: 1, -1, suspend: yes (queued) */
 	ret = pm_device_runtime_put_async(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDING);
 
 	/* let suspension start */
 	k_yield();
@@ -198,23 +198,23 @@ ZTEST(device_runtime_api, test_api)
 	k_thread_join(&get_runner_td, K_FOREVER);
 
 	(void)pm_device_state_get(dev, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	/* Put operation should fail due the state be locked. */
 	ret = pm_device_runtime_disable(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	pm_device_state_lock(dev);
 
 	/* This operation should not succeed.  */
 	ret = pm_device_runtime_enable(dev);
-	zassert_equal(ret, -EPERM, NULL);
+	zassert_equal(ret, -EPERM);
 
 	/* After unlock the state, enable runtime should work. */
 	pm_device_state_unlock(dev);
 
 	ret = pm_device_runtime_enable(dev);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 static int pm_unsupported_init(const struct device *dev)

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -20,10 +20,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default)
 
 	/* cpu 0 */
 	next = pm_policy_next_state(0U, 0);
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(10999));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
 	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
@@ -43,10 +43,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default)
 
 	/* cpu 1 */
 	next = pm_policy_next_state(1U, 0);
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	next = pm_policy_next_state(1U, k_us_to_ticks_floor32(549999));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	next = pm_policy_next_state(1U, k_us_to_ticks_floor32(550000));
 	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM);
@@ -84,7 +84,7 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 	zassert_true(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	/* allow PM_STATE_RUNTIME_IDLE again
 	 * next state: PM_STATE_RUNTIME_IDLE
@@ -115,7 +115,7 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 	zassert_true(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	/* allow PM_STATE_RUNTIME_IDLE and substate 1 again
 	 * next state: PM_STATE_RUNTIME_IDLE
@@ -162,10 +162,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	pm_policy_latency_request_add(&req1, 9000);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	/* update latency requirement to a value between latencies for
 	 * PM_STATE_RUNTIME_IDLE and PM_STATE_SUSPEND_TO_RAM, so we should
@@ -186,10 +186,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	pm_policy_latency_request_add(&req2, 8000);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next, NULL);
+	zassert_is_null(next);
 
 	/* remove previous request, so we should recover behavior given by
 	 * first request.

--- a/tests/subsys/pm/policy_api/src/main.c
+++ b/tests/subsys/pm/policy_api/src/main.c
@@ -20,41 +20,41 @@ ZTEST(policy_api, test_pm_policy_next_state_default)
 
 	/* cpu 0 */
 	next = pm_policy_next_state(0U, 0);
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(10999));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
-	zassert_equal(next->min_residency_us, 100000, NULL);
-	zassert_equal(next->exit_latency_us, 10000, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
+	zassert_equal(next->min_residency_us, 100000);
+	zassert_equal(next->exit_latency_us, 10000);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1099999));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
-	zassert_equal(next->min_residency_us, 1000000, NULL);
-	zassert_equal(next->exit_latency_us, 100000, NULL);
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM);
+	zassert_equal(next->min_residency_us, 1000000);
+	zassert_equal(next->exit_latency_us, 100000);
 
 	next = pm_policy_next_state(0U, K_TICKS_FOREVER);
-	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM);
 
 	/* cpu 1 */
 	next = pm_policy_next_state(1U, 0);
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	next = pm_policy_next_state(1U, k_us_to_ticks_floor32(549999));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	next = pm_policy_next_state(1U, k_us_to_ticks_floor32(550000));
-	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
-	zassert_equal(next->min_residency_us, 500000, NULL);
-	zassert_equal(next->exit_latency_us, 50000, NULL);
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM);
+	zassert_equal(next->min_residency_us, 500000);
+	zassert_equal(next->exit_latency_us, 50000);
 
 	next = pm_policy_next_state(1U, K_TICKS_FOREVER);
-	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM);
 }
 
 /**
@@ -70,10 +70,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 	 * next state: PM_STATE_RUNTIME_IDLE
 	 */
 	active = pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
-	zassert_false(active, NULL);
+	zassert_false(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	/* disallow PM_STATE_RUNTIME_IDLE
 	 * next state: NULL (active)
@@ -81,10 +81,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 	pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 
 	active = pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
-	zassert_true(active, NULL);
+	zassert_true(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	/* allow PM_STATE_RUNTIME_IDLE again
 	 * next state: PM_STATE_RUNTIME_IDLE
@@ -92,19 +92,19 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 	pm_policy_state_lock_put(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
 
 	active = pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, PM_ALL_SUBSTATES);
-	zassert_false(active, NULL);
+	zassert_false(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	/* initial state: PM_STATE_RUNTIME_IDLE and substate 1 allowed
 	 * next state: PM_STATE_RUNTIME_IDLE
 	 */
 	pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1);
-	zassert_false(active, NULL);
+	zassert_false(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	/* disallow PM_STATE_RUNTIME_IDLE and substate 1
 	 * next state: NULL (active)
@@ -112,10 +112,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 	pm_policy_state_lock_get(PM_STATE_RUNTIME_IDLE, 1);
 
 	active = pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1);
-	zassert_true(active, NULL);
+	zassert_true(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	/* allow PM_STATE_RUNTIME_IDLE and substate 1 again
 	 * next state: PM_STATE_RUNTIME_IDLE
@@ -123,10 +123,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_allowed)
 	pm_policy_state_lock_put(PM_STATE_RUNTIME_IDLE, 1);
 
 	active = pm_policy_state_lock_is_active(PM_STATE_RUNTIME_IDLE, 1);
-	zassert_false(active, NULL);
+	zassert_false(active);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 }
 
 /** Flag to indicate number of times callback has been called */
@@ -141,7 +141,7 @@ static void on_pm_policy_latency_changed(int32_t latency)
 {
 	TC_PRINT("Latency changed to %d\n", latency);
 
-	zassert_equal(latency, expected_latency, NULL);
+	zassert_equal(latency, expected_latency);
 
 	latency_cb_call_cnt++;
 }
@@ -162,10 +162,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	pm_policy_latency_request_add(&req1, 9000);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	/* update latency requirement to a value between latencies for
 	 * PM_STATE_RUNTIME_IDLE and PM_STATE_SUSPEND_TO_RAM, so we should
@@ -174,10 +174,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	pm_policy_latency_request_update(&req1, 50000);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	/* add a new latency requirement with a maximum value below the
 	 * latency given by any state, so we should stay active all the time
@@ -186,10 +186,10 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	pm_policy_latency_request_add(&req2, 8000);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next, NULL, NULL);
+	zassert_equal(next, NULL);
 
 	/* remove previous request, so we should recover behavior given by
 	 * first request.
@@ -197,19 +197,19 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	pm_policy_latency_request_remove(&req2);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	/* remove first request, so we should observe regular behavior again */
 	pm_policy_latency_request_remove(&req1);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(110000));
-	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE, NULL);
+	zassert_equal(next->state, PM_STATE_RUNTIME_IDLE);
 
 	next = pm_policy_next_state(0U, k_us_to_ticks_floor32(1100000));
-	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM, NULL);
+	zassert_equal(next->state, PM_STATE_SUSPEND_TO_RAM);
 
 	/* get notified when latency requirement changes */
 	pm_policy_latency_changed_subscribe(&sreq1, on_pm_policy_latency_changed);
@@ -219,7 +219,7 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	latency_cb_call_cnt = 0;
 	expected_latency = 10000;
 	pm_policy_latency_request_add(&req1, 10000);
-	zassert_equal(latency_cb_call_cnt, 2, NULL);
+	zassert_equal(latency_cb_call_cnt, 2);
 
 	/* update request (expected notification, but only sreq1) */
 	pm_policy_latency_changed_unsubscribe(&sreq2);
@@ -227,22 +227,22 @@ ZTEST(policy_api, test_pm_policy_next_state_default_latency)
 	latency_cb_call_cnt = 0;
 	expected_latency = 50000;
 	pm_policy_latency_request_update(&req1, 50000);
-	zassert_equal(latency_cb_call_cnt, 1, NULL);
+	zassert_equal(latency_cb_call_cnt, 1);
 
 	/* add a new request, with higher value (no notification, previous
 	 * prevails)
 	 */
 	latency_cb_call_cnt = 0;
 	pm_policy_latency_request_add(&req2, 60000);
-	zassert_equal(latency_cb_call_cnt, 0, NULL);
+	zassert_equal(latency_cb_call_cnt, 0);
 
 	pm_policy_latency_request_remove(&req2);
-	zassert_equal(latency_cb_call_cnt, 0, NULL);
+	zassert_equal(latency_cb_call_cnt, 0);
 
 	/* remove first request, we no longer have latency requirements */
 	expected_latency = SYS_FOREVER_US;
 	pm_policy_latency_request_remove(&req1);
-	zassert_equal(latency_cb_call_cnt, 1, NULL);
+	zassert_equal(latency_cb_call_cnt, 1);
 }
 #else
 ZTEST(policy_api, test_pm_policy_next_state_default)
@@ -281,7 +281,7 @@ ZTEST(policy_api, test_pm_policy_next_state_custom)
 	const struct pm_state_info *next;
 
 	next = pm_policy_next_state(0U, 0);
-	zassert_equal(next->state, PM_STATE_SOFT_OFF, NULL);
+	zassert_equal(next->state, PM_STATE_SOFT_OFF);
 }
 #else
 ZTEST(policy_api, test_pm_policy_next_state_custom)

--- a/tests/subsys/pm/power_domain/src/main.c
+++ b/tests/subsys/pm/power_domain/src/main.c
@@ -141,72 +141,72 @@ ZTEST(power_domain_1cpu, test_power_domain_device_runtime)
 	pm_device_runtime_enable(devc);
 
 	ret = pm_device_power_domain_remove(devc, domain);
-	zassert_equal(ret, -ENOENT, NULL);
+	zassert_equal(ret, -ENOENT);
 
 	ret = pm_device_power_domain_add(devc, domain);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	/* At this point all devices should be SUSPENDED */
 	pm_device_state_get(domain, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	pm_device_state_get(deva, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	pm_device_state_get(devb, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	pm_device_state_get(devc, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/* Now test if "get" a device will resume the domain */
 	ret = pm_device_runtime_get(deva);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	pm_device_state_get(deva, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	pm_device_state_get(domain, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	ret = pm_device_runtime_get(devc);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = pm_device_runtime_get(devb);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = pm_device_runtime_put(deva);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	/*
 	 * The domain has to still be active since device B
 	 * is still in use.
 	 */
 	pm_device_state_get(domain, &state);
-	zassert_equal(state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_ACTIVE);
 
 	/*
 	 * Now the domain should be suspended since there is no
 	 * one using it.
 	 */
 	ret = pm_device_runtime_put(devb);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	ret = pm_device_runtime_put(devc);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
 	pm_device_state_get(domain, &state);
-	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_SUSPENDED);
 
 	/*
 	 * With the domain suspended the device state should be OFF, since
 	 * the power was completely cut.
 	 */
 	pm_device_state_get(devb, &state);
-	zassert_equal(state, PM_DEVICE_STATE_OFF, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_OFF);
 
 	pm_device_state_get(deva, &state);
-	zassert_equal(state, PM_DEVICE_STATE_OFF, NULL);
+	zassert_equal(state, PM_DEVICE_STATE_OFF);
 
 	/*
 	 * Now lets test that devices are notified when the domain
@@ -216,18 +216,18 @@ ZTEST(power_domain_1cpu, test_power_domain_device_runtime)
 	/* Three devices has to get the notification */
 	testing_domain_on_notitication = NUMBER_OF_DEVICES;
 	ret = pm_device_runtime_get(domain);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
-	zassert_equal(testing_domain_on_notitication, 0, NULL);
+	zassert_equal(testing_domain_on_notitication, 0);
 
 	testing_domain_off_notitication = NUMBER_OF_DEVICES;
 	ret = pm_device_runtime_put(domain);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 
-	zassert_equal(testing_domain_off_notitication, 0, NULL);
+	zassert_equal(testing_domain_off_notitication, 0);
 
 	ret = pm_device_power_domain_remove(devc, domain);
-	zassert_equal(ret, 0, NULL);
+	zassert_equal(ret, 0);
 }
 
 ZTEST_SUITE(power_domain_1cpu, NULL, NULL, ztest_simple_1cpu_before,

--- a/tests/subsys/pm/power_mgmt/src/main.c
+++ b/tests/subsys/pm/power_mgmt/src/main.c
@@ -179,10 +179,10 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 		/* If device runtime is enable, the device should still be
 		 * active
 		 */
-		zassert_true(device_power_state == PM_DEVICE_STATE_ACTIVE, NULL);
+		zassert_true(device_power_state == PM_DEVICE_STATE_ACTIVE);
 	} else {
 		/* at this point, devices have been deactivated */
-		zassert_false(device_power_state == PM_DEVICE_STATE_ACTIVE, NULL);
+		zassert_false(device_power_state == PM_DEVICE_STATE_ACTIVE);
 	}
 
 	/* this function is called when system entering low power state, so
@@ -211,9 +211,9 @@ const struct pm_state_info *pm_policy_next_state(uint8_t cpu, int32_t ticks)
 	ARG_UNUSED(cpu);
 
 	/* make sure this is idle thread */
-	zassert_true(z_is_idle_thread_object(_current), NULL);
-	zassert_true(ticks == _kernel.idle, NULL);
-	zassert_false(k_can_yield(), NULL);
+	zassert_true(z_is_idle_thread_object(_current));
+	zassert_true(ticks == _kernel.idle);
+	zassert_false(k_can_yield());
 	idle_entered = true;
 
 	if (enter_low_power) {
@@ -237,18 +237,18 @@ static void notify_pm_state_entry(enum pm_state state)
 	/* enter suspend */
 	zassert_true(notify_app_entry == true,
 		     "Notification to enter suspend was not sent to the App");
-	zassert_true(z_is_idle_thread_object(_current), NULL);
-	zassert_equal(state, PM_STATE_SUSPEND_TO_IDLE, NULL);
+	zassert_true(z_is_idle_thread_object(_current));
+	zassert_equal(state, PM_STATE_SUSPEND_TO_IDLE);
 
 	pm_device_state_get(device_dummy, &device_power_state);
 	if (testing_device_runtime) {
 		/* If device runtime is enable, the device should still be
 		 * active
 		 */
-		zassert_true(device_power_state == PM_DEVICE_STATE_ACTIVE, NULL);
+		zassert_true(device_power_state == PM_DEVICE_STATE_ACTIVE);
 	} else {
 		/* at this point, devices should not be active */
-		zassert_false(device_power_state == PM_DEVICE_STATE_ACTIVE, NULL);
+		zassert_false(device_power_state == PM_DEVICE_STATE_ACTIVE);
 	}
 	set_pm = true;
 	notify_app_exit = true;
@@ -262,12 +262,12 @@ static void notify_pm_state_exit(enum pm_state state)
 	/* leave suspend */
 	zassert_true(notify_app_exit == true,
 		     "Notification to leave suspend was not sent to the App");
-	zassert_true(z_is_idle_thread_object(_current), NULL);
-	zassert_equal(state, PM_STATE_SUSPEND_TO_IDLE, NULL);
+	zassert_true(z_is_idle_thread_object(_current));
+	zassert_equal(state, PM_STATE_SUSPEND_TO_IDLE);
 
 	/* at this point, devices are active again*/
 	pm_device_state_get(device_dummy, &device_power_state);
-	zassert_equal(device_power_state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(device_power_state, PM_DEVICE_STATE_ACTIVE);
 	leave_idle = true;
 
 }
@@ -324,7 +324,7 @@ ZTEST(power_management_1cpu, test_power_state_trans)
 
 	/* give way to idle thread */
 	k_sleep(SLEEP_TIMEOUT);
-	zassert_true(leave_idle, NULL);
+	zassert_true(leave_idle);
 
 	ret = pm_device_runtime_enable(device_dummy);
 	zassert_true(ret == 0, "Failed to enable device runtime PM");
@@ -358,18 +358,18 @@ ZTEST(power_management_1cpu, test_power_state_notification)
 	zassert_true(ret == 0, "Fail to open device");
 
 	pm_device_state_get(device_dummy, &device_power_state);
-	zassert_equal(device_power_state, PM_DEVICE_STATE_ACTIVE, NULL);
+	zassert_equal(device_power_state, PM_DEVICE_STATE_ACTIVE);
 
 
 	/* The device should be kept active even when the system goes idle */
 	testing_device_runtime = true;
 
 	k_sleep(SLEEP_TIMEOUT);
-	zassert_true(leave_idle, NULL);
+	zassert_true(leave_idle);
 
 	api->close(device_dummy);
 	pm_device_state_get(device_dummy, &device_power_state);
-	zassert_equal(device_power_state, PM_DEVICE_STATE_SUSPENDED, NULL);
+	zassert_equal(device_power_state, PM_DEVICE_STATE_SUSPENDED);
 	pm_notifier_unregister(&notifier);
 	testing_device_runtime = false;
 }
@@ -395,29 +395,29 @@ ZTEST(power_management_1cpu, test_busy)
 	bool busy;
 
 	busy = pm_device_is_any_busy();
-	zassert_false(busy, NULL);
+	zassert_false(busy);
 
 	pm_device_busy_set(device_dummy);
 
 	busy = pm_device_is_any_busy();
-	zassert_true(busy, NULL);
+	zassert_true(busy);
 
 	busy = pm_device_is_busy(device_dummy);
-	zassert_true(busy, NULL);
+	zassert_true(busy);
 
 	pm_device_busy_clear(device_dummy);
 
 	busy = pm_device_is_any_busy();
-	zassert_false(busy, NULL);
+	zassert_false(busy);
 
 	busy = pm_device_is_busy(device_dummy);
-	zassert_false(busy, NULL);
+	zassert_false(busy);
 }
 
 ZTEST(power_management_1cpu, test_device_state_lock)
 {
 	pm_device_state_lock(device_a);
-	zassert_true(pm_device_state_is_locked(device_a), NULL);
+	zassert_true(pm_device_state_is_locked(device_a));
 
 	testing_device_lock = true;
 	enter_low_power = true;

--- a/tests/subsys/pm/power_mgmt_multicore/src/main.c
+++ b/tests/subsys/pm/power_mgmt_multicore/src/main.c
@@ -35,17 +35,17 @@ void pm_state_set(enum pm_state state, uint8_t substate_id)
 
 	switch (state_testing[_current_cpu->id]) {
 	case PM_STATE_ACTIVE:
-		zassert_equal(PM_STATE_ACTIVE, state, NULL);
+		zassert_equal(PM_STATE_ACTIVE, state);
 		break;
 	case  PM_STATE_RUNTIME_IDLE:
-		zassert_equal(PM_STATE_RUNTIME_IDLE, state, NULL);
+		zassert_equal(PM_STATE_RUNTIME_IDLE, state);
 		break;
 	case  PM_STATE_SUSPEND_TO_IDLE:
-		zassert_equal(PM_STATE_SUSPEND_TO_IDLE, state, NULL);
+		zassert_equal(PM_STATE_SUSPEND_TO_IDLE, state);
 		break;
 	case  PM_STATE_STANDBY:
-		zassert_equal(_current_cpu->id, 1U, NULL);
-		zassert_equal(PM_STATE_STANDBY, state, NULL);
+		zassert_equal(_current_cpu->id, 1U);
+		zassert_equal(PM_STATE_STANDBY, state);
 		break;
 	default:
 		zassert_unreachable(NULL);

--- a/tests/subsys/portability/cmsis_rtos_v1/src/kernel_apis.c
+++ b/tests/subsys/portability/cmsis_rtos_v1/src/kernel_apis.c
@@ -43,7 +43,7 @@ ZTEST(kernel_apis, test_kernel_start)
 		/* When osFeature_MainThread is 0 the kernel requires
 		 * explicit start with osKernelStart.
 		 */
-		zassert_false(osKernelRunning(), NULL);
+		zassert_false(osKernelRunning());
 	}
 }
 

--- a/tests/subsys/portability/cmsis_rtos_v1/src/mailq.c
+++ b/tests/subsys/portability/cmsis_rtos_v1/src/mailq.c
@@ -127,9 +127,9 @@ void mail_recv(void)
 	zassert_true(evt.status == osEventMail, "osMailGet failure");
 
 	rx_ptr = evt.value.p;
-	zassert_equal(rx_ptr->data1, MAIL1_DATA1, NULL);
-	zassert_equal(rx_ptr->data2, MAIL1_DATA2, NULL);
-	zassert_equal(rx_ptr->data3, MAIL1_DATA3, NULL);
+	zassert_equal(rx_ptr->data1, MAIL1_DATA1);
+	zassert_equal(rx_ptr->data2, MAIL1_DATA2);
+	zassert_equal(rx_ptr->data3, MAIL1_DATA3);
 
 	status = osMailFree(mail_id, rx_ptr);
 	zassert_true(status == osOK, "osMailFree failure");
@@ -143,9 +143,9 @@ void mail_recv(void)
 		zassert_true(evt.status == osEventMail, "osMailGet failure");
 
 		rx_ptr = evt.value.p;
-		zassert_equal(rx_ptr->data1, i, NULL);
-		zassert_equal(rx_ptr->data2, i + 1, NULL);
-		zassert_equal(rx_ptr->data3, i + 2, NULL);
+		zassert_equal(rx_ptr->data1, i);
+		zassert_equal(rx_ptr->data2, i + 1);
+		zassert_equal(rx_ptr->data3, i + 2);
 
 		status = osMailFree(mail_id, rx_ptr);
 		zassert_true(status == osOK, "osMailFree failure");
@@ -156,9 +156,9 @@ void mail_recv(void)
 	zassert_true(evt.status == osEventMail, "osMailGet failure");
 
 	rx_ptr = evt.value.p;
-	zassert_equal(rx_ptr->data1, MAIL2_DATA1, NULL);
-	zassert_equal(rx_ptr->data2, MAIL2_DATA2, NULL);
-	zassert_equal(rx_ptr->data3, MAIL2_DATA3, NULL);
+	zassert_equal(rx_ptr->data1, MAIL2_DATA1);
+	zassert_equal(rx_ptr->data2, MAIL2_DATA2);
+	zassert_equal(rx_ptr->data3, MAIL2_DATA3);
 
 	status = osMailFree(mail_id, rx_ptr);
 	zassert_true(status == osOK, "osMailFree failure");

--- a/tests/subsys/portability/cmsis_rtos_v1/src/msgq.c
+++ b/tests/subsys/portability/cmsis_rtos_v1/src/msgq.c
@@ -82,7 +82,7 @@ void message_recv(void)
 	zassert_true(evt.status == osEventMessage, "osMessageGet failure");
 
 	data = evt.value.v;
-	zassert_equal(data, MESSAGE1, NULL);
+	zassert_equal(data, MESSAGE1);
 
 	/* Wait for queue to get filled */
 	osDelay(TIMEOUT);
@@ -94,7 +94,7 @@ void message_recv(void)
 				"osMessageGet failure");
 
 		data = evt.value.v;
-		zassert_equal(data, i, NULL);
+		zassert_equal(data, i);
 	}
 
 	/* Receive the next message */
@@ -102,7 +102,7 @@ void message_recv(void)
 	zassert_true(evt.status == osEventMessage, "osMessageGet failure");
 
 	data = evt.value.v;
-	zassert_equal(data, MESSAGE2, NULL);
+	zassert_equal(data, MESSAGE2);
 }
 
 osThreadDef(send_msg_thread, osPriorityNormal, 1, 0);

--- a/tests/subsys/portability/cmsis_rtos_v1/src/mutex.c
+++ b/tests/subsys/portability/cmsis_rtos_v1/src/mutex.c
@@ -96,10 +96,10 @@ void tThread_entry_lock_timeout(void const *arg)
 	 * other thread. Try with and without timeout.
 	 */
 	status = osMutexWait((osMutexId)arg, 0);
-	zassert_true(status == osErrorResource, NULL);
+	zassert_true(status == osErrorResource);
 
 	status = osMutexWait((osMutexId)arg, TIMEOUT - 100);
-	zassert_true(status == osErrorTimeoutResource, NULL);
+	zassert_true(status == osErrorTimeoutResource);
 
 	/* At this point, mutex is held by the other thread.
 	 * Trying to release it here should fail.
@@ -116,7 +116,7 @@ void tThread_entry_lock_timeout(void const *arg)
 	 * and release it.
 	 */
 	status = osMutexWait((osMutexId)arg, TIMEOUT);
-	zassert_true(status == osOK, NULL);
+	zassert_true(status == osOK);
 	osMutexRelease((osMutexId)arg);
 }
 

--- a/tests/subsys/portability/cmsis_rtos_v1/src/semaphore.c
+++ b/tests/subsys/portability/cmsis_rtos_v1/src/semaphore.c
@@ -35,7 +35,7 @@ void thread_sema(void const *arg)
 	 * and release it.
 	 */
 	tokens_available = osSemaphoreWait((osSemaphoreId)arg, 0);
-	zassert_true(tokens_available > 0, NULL);
+	zassert_true(tokens_available > 0);
 
 	zassert_true(osSemaphoreRelease((osSemaphoreId)arg) == osOK,
 			"Semaphore release failure");

--- a/tests/subsys/portability/cmsis_rtos_v1/src/thread_apis.c
+++ b/tests/subsys/portability/cmsis_rtos_v1/src/thread_apis.c
@@ -27,7 +27,7 @@ void thread1(void const *argument)
 
 	/* This thread starts off at a high priority (same as thread2) */
 	thread_yield_check++;
-	zassert_equal(thread_yield_check, 1, NULL);
+	zassert_equal(thread_yield_check, 1);
 
 	/* Yield to thread2 which is of same priority */
 	status = osThreadYield();
@@ -36,7 +36,7 @@ void thread1(void const *argument)
 	/* thread_yield_check should now be 2 as it was incremented
 	 * in thread2.
 	 */
-	zassert_equal(thread_yield_check, 2, NULL);
+	zassert_equal(thread_yield_check, 2);
 }
 
 void thread2(void const *argument)

--- a/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/kernel.c
@@ -40,20 +40,20 @@ void lock_unlock_check(const void *arg)
 
 	state_before_lock = osKernelLock();
 	if (k_is_in_isr()) {
-		zassert_true(state_before_lock == osErrorISR, NULL);
+		zassert_true(state_before_lock == osErrorISR);
 	}
 
 	state_after_lock = osKernelUnlock();
 	if (k_is_in_isr()) {
-		zassert_true(state_after_lock == osErrorISR, NULL);
+		zassert_true(state_after_lock == osErrorISR);
 	} else {
-		zassert_true(state_before_lock == !state_after_lock, NULL);
+		zassert_true(state_before_lock == !state_after_lock);
 	}
 	current_state = osKernelRestoreLock(state_before_lock);
 	if (k_is_in_isr()) {
-		zassert_true(current_state == osErrorISR, NULL);
+		zassert_true(current_state == osErrorISR);
 	} else {
-		zassert_equal(current_state, state_before_lock, NULL);
+		zassert_equal(current_state, state_before_lock);
 	}
 }
 
@@ -78,9 +78,9 @@ ZTEST(cmsis_kernel, test_kernel_apis)
 	irq_offload(get_version_check, (const void *)&version_irq);
 
 	/* Check if the version value retrieved in ISR and thread is same */
-	zassert_equal(strcmp(version.info, version_irq.info), 0, NULL);
-	zassert_equal(version.os_info.api, version_irq.os_info.api, NULL);
-	zassert_equal(version.os_info.kernel, version_irq.os_info.kernel, NULL);
+	zassert_equal(strcmp(version.info, version_irq.info), 0);
+	zassert_equal(version.os_info.api, version_irq.os_info.api);
+	zassert_equal(version.os_info.kernel, version_irq.os_info.kernel);
 
 	lock_unlock_check(NULL);
 
@@ -100,10 +100,10 @@ void delay_until(const void *param)
 ZTEST(cmsis_kernel, test_delay)
 {
 	delay_until(NULL);
-	zassert_true(tick <= osKernelGetTickCount(), NULL);
-	zassert_equal(status_val, osOK, NULL);
+	zassert_true(tick <= osKernelGetTickCount());
+	zassert_equal(status_val, osOK);
 
 	irq_offload(delay_until, NULL);
-	zassert_equal(status_val, osErrorISR, NULL);
+	zassert_equal(status_val, osErrorISR);
 }
 ZTEST_SUITE(cmsis_kernel, NULL, NULL, NULL, NULL, NULL);

--- a/tests/subsys/portability/cmsis_rtos_v2/src/msgq.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/msgq.c
@@ -111,7 +111,7 @@ void message_recv(void)
 	status = osMessageQueueGet(message_id, (void *)&recv_data,
 				   NULL, osWaitForever);
 	zassert_true(status == osOK, "osMessageQueueGet failure");
-	zassert_equal(recv_data.data1, MESSAGE1, NULL);
+	zassert_equal(recv_data.data1, MESSAGE1);
 
 	/* Wait for queue to get filled */
 	osDelay(TIMEOUT_TICKS);
@@ -122,16 +122,16 @@ void message_recv(void)
 					   osWaitForever);
 		zassert_true(status == osOK, "osMessageQueueGet failure");
 
-		zassert_equal(recv_data.data1, i * 3, NULL);
-		zassert_equal(recv_data.data2, i * 3 + 1, NULL);
-		zassert_equal(recv_data.data3, i * 3 + 2, NULL);
+		zassert_equal(recv_data.data1, i * 3);
+		zassert_equal(recv_data.data2, i * 3 + 1);
+		zassert_equal(recv_data.data3, i * 3 + 2);
 	}
 
 	/* Receive the next message */
 	status = osMessageQueueGet(message_id, (void *)&recv_data,
 				   NULL, osWaitForever);
 	zassert_true(status == osOK, "osMessageQueueGet failure");
-	zassert_equal(recv_data.data1, MESSAGE2, NULL);
+	zassert_equal(recv_data.data1, MESSAGE2);
 }
 
 static K_THREAD_STACK_DEFINE(test_stack, STACKSZ);

--- a/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/mutex.c
@@ -115,10 +115,10 @@ void tThread_entry_lock_timeout(void *arg)
 	 * by the other thread. Try with and without timeout.
 	 */
 	status = osMutexAcquire((osMutexId_t)arg, 0);
-	zassert_true(status == osErrorResource, NULL);
+	zassert_true(status == osErrorResource);
 
 	status = osMutexAcquire((osMutexId_t)arg, TIMEOUT_TICKS - 5);
-	zassert_true(status == osErrorTimeout, NULL);
+	zassert_true(status == osErrorTimeout);
 
 	status = osMutexRelease((osMutexId_t)arg);
 	zassert_true(status == osErrorResource, "Mutex unexpectedly released");
@@ -136,7 +136,7 @@ void tThread_entry_lock_timeout(void *arg)
 	 * and release it.
 	 */
 	status = osMutexAcquire((osMutexId_t)arg, TIMEOUT_TICKS);
-	zassert_true(status == osOK, NULL);
+	zassert_true(status == osOK);
 	osMutexRelease((osMutexId_t)arg);
 }
 

--- a/tests/subsys/portability/cmsis_rtos_v2/src/semaphore.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/semaphore.c
@@ -83,7 +83,7 @@ ZTEST(cmsis_semaphore, test_semaphore)
 	id = osThreadNew(thread_sema, semaphore_id, &thread_attr);
 	zassert_true(id != NULL, "Thread creation failed");
 
-	zassert_true(osSemaphoreGetCount(semaphore_id) == 1, NULL);
+	zassert_true(osSemaphoreGetCount(semaphore_id) == 1);
 
 	/* Acquire invalid semaphore */
 	zassert_equal(osSemaphoreAcquire(dummy_sem_id, osWaitForever),
@@ -92,7 +92,7 @@ ZTEST(cmsis_semaphore, test_semaphore)
 	status = osSemaphoreAcquire(semaphore_id, osWaitForever);
 	zassert_true(status == osOK, "Semaphore wait failure");
 
-	zassert_true(osSemaphoreGetCount(semaphore_id) == 0, NULL);
+	zassert_true(osSemaphoreGetCount(semaphore_id) == 0);
 
 	/* wait for spawn thread to take action */
 	osDelay(TIMEOUT_TICKS);

--- a/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
+++ b/tests/subsys/portability/cmsis_rtos_v2/src/thread_apis.c
@@ -51,7 +51,7 @@ static void thread1(void *argument)
 
 	/* This thread starts off at a high priority (same as thread2) */
 	(*args->yield_check)++;
-	zassert_equal(*args->yield_check, 1, NULL);
+	zassert_equal(*args->yield_check, 1);
 
 	/* Yield to thread2 which is of same priority */
 	status = osThreadYield();
@@ -60,7 +60,7 @@ static void thread1(void *argument)
 	/* thread_yield_check should now be 2 as it was incremented
 	 * in thread2.
 	 */
-	zassert_equal(*args->yield_check, 2, NULL);
+	zassert_equal(*args->yield_check, 2);
 
 	osThreadExit();
 }

--- a/tests/subsys/settings/functional/src/settings_basic_test.c
+++ b/tests/subsys/settings/functional/src/settings_basic_test.c
@@ -406,15 +406,15 @@ int direct_loader(
 	int rc;
 	uint8_t val;
 
-	zassert_equal(0x1234, (size_t)param, NULL);
+	zassert_equal(0x1234, (size_t)param);
 
-	zassert_equal(1, len, NULL);
+	zassert_equal(1, len);
 	zassert_is_null(key, "Unexpected key: %s", key);
 
 
 	zassert_not_null(cb_arg, NULL);
 	rc = read_cb(cb_arg, &val, sizeof(val));
-	zassert_equal(sizeof(val), rc, NULL);
+	zassert_equal(sizeof(val), rc);
 
 	val_directly_loaded = val;
 	direct_load_cnt += 1;
@@ -436,25 +436,25 @@ ZTEST(settings_functional, test_direct_loading)
 	settings_save_one("val/3", &val, sizeof(uint8_t));
 
 	rc = settings_register(&val123_settings);
-	zassert_true(rc == 0, NULL);
+	zassert_true(rc == 0);
 	memset(&data, 0, sizeof(data));
 
 	rc = settings_load();
-	zassert_true(rc == 0, NULL);
+	zassert_true(rc == 0);
 
-	zassert_equal(11, data.val1, NULL);
-	zassert_equal(23, data.val2, NULL);
-	zassert_equal(35, data.val3, NULL);
+	zassert_equal(11, data.val1);
+	zassert_equal(23, data.val2);
+	zassert_equal(35, data.val3);
 
 	/* Load subtree */
 	memset(&data, 0, sizeof(data));
 
 	rc = settings_load_subtree("val/2");
-	zassert_true(rc == 0, NULL);
+	zassert_true(rc == 0);
 
-	zassert_equal(0,  data.val1, NULL);
-	zassert_equal(23, data.val2, NULL);
-	zassert_equal(0,  data.val3, NULL);
+	zassert_equal(0,  data.val1);
+	zassert_equal(23, data.val2);
+	zassert_equal(0,  data.val3);
 
 	/* Direct loading now */
 	memset(&data, 0, sizeof(data));
@@ -464,13 +464,13 @@ ZTEST(settings_functional, test_direct_loading)
 		"val/2",
 		direct_loader,
 		(void *)0x1234);
-	zassert_true(rc == 0, NULL);
-	zassert_equal(0, data.val1, NULL);
-	zassert_equal(0, data.val2, NULL);
-	zassert_equal(0, data.val3, NULL);
+	zassert_true(rc == 0);
+	zassert_equal(0, data.val1);
+	zassert_equal(0, data.val2);
+	zassert_equal(0, data.val3);
 
-	zassert_equal(1, direct_load_cnt, NULL);
-	zassert_equal(23, val_directly_loaded, NULL);
+	zassert_equal(1, direct_load_cnt);
+	zassert_equal(23, val_directly_loaded);
 	settings_deregister(&val123_settings);
 }
 
@@ -514,10 +514,10 @@ static int filtered_loader(
 	zassert_not_null(ldata->n, "Unexpected data name: %s", key);
 	zassert_is_null(next, NULL);
 	zassert_equal(strlen(ldata->v) + 1, len, "e: \"%s\", a:\"%s\"", ldata->v, buf);
-	zassert_true(len <= sizeof(buf), NULL);
+	zassert_true(len <= sizeof(buf));
 
 	rc = read_cb(cb_arg, buf, len);
-	zassert_equal(len, rc, NULL);
+	zassert_equal(len, rc);
 
 	zassert_false(strcmp(ldata->v, buf), "e: \"%s\", a:\"%s\"", ldata->v, buf);
 
@@ -540,7 +540,7 @@ static int direct_filtered_loader(
 	void *cb_arg,
 	void *param)
 {
-	zassert_equal(0x3456, (size_t)param, NULL);
+	zassert_equal(0x3456, (size_t)param);
 	return filtered_loader(key, len, read_cb, cb_arg);
 }
 
@@ -596,7 +596,7 @@ ZTEST(settings_functional, test_direct_loading_filter)
 		prefix,
 		direct_filtered_loader,
 		(void *)0x3456);
-	zassert_equal(0, rc, NULL);
+	zassert_equal(0, rc);
 
 	/* Check if all the data was called */
 	for (n = 0; data_final[n].n; ++n) {
@@ -606,10 +606,10 @@ ZTEST(settings_functional, test_direct_loading_filter)
 	}
 
 	rc = settings_register(&filtered_loader_settings);
-	zassert_true(rc == 0, NULL);
+	zassert_true(rc == 0);
 
 	rc = settings_load_subtree(prefix);
-	zassert_equal(0, rc, NULL);
+	zassert_equal(0, rc);
 
 	/* Check if all the data was called */
 	for (n = 0; data_final[n].n; ++n) {

--- a/tests/unit/cbprintf/main.c
+++ b/tests/unit/cbprintf/main.c
@@ -225,7 +225,7 @@ static int rawprf(const char *format, ...)
 
 	if (IS_ENABLED(CONFIG_CBPRINTF_NANO)
 	    && !IS_ENABLED(CONFIG_CBPRINTF_LIBC_SUBSTS)) {
-		zassert_equal(rv, 0, NULL);
+		zassert_equal(rv, 0);
 		rv = outbuf.idx;
 	}
 	return rv;
@@ -248,11 +248,11 @@ static int rawprf(const char *format, ...)
 		CBPRINTF_STATIC_PACKAGE(&package[PKG_ALIGN_OFFSET], _len - 1, \
 					st_pkg_rv, PKG_ALIGN_OFFSET, \
 					PACKAGE_FLAGS, _fmt, __VA_ARGS__); \
-		zassert_equal(st_pkg_rv, -ENOSPC, NULL); \
+		zassert_equal(st_pkg_rv, -ENOSPC); \
 		CBPRINTF_STATIC_PACKAGE(&package[PKG_ALIGN_OFFSET], _len, \
 					st_pkg_rv, PKG_ALIGN_OFFSET, \
 					PACKAGE_FLAGS, _fmt, __VA_ARGS__); \
-		zassert_equal(st_pkg_rv, _len, NULL); \
+		zassert_equal(st_pkg_rv, _len); \
 		rv = cbpprintf(out, &package_buf, &package[PKG_ALIGN_OFFSET]); \
 		if (rv >= 0) { \
 			sp_buf = _buf; \
@@ -379,15 +379,15 @@ ZTEST(prf, test_c)
 	size_t spaces = 255;
 
 	zassert_equal(rc, 258, "len %d", rc);
-	zassert_equal(*bp, '/', NULL);
+	zassert_equal(*bp, '/');
 	++bp;
 	while (spaces-- > 0) {
-		zassert_equal(*bp, ' ', NULL);
+		zassert_equal(*bp, ' ');
 		++bp;
 	}
-	zassert_equal(*bp, 'a', NULL);
+	zassert_equal(*bp, 'a');
 	++bp;
-	zassert_equal(*bp, '/', NULL);
+	zassert_equal(*bp, '/');
 
 	if (IS_ENABLED(CONFIG_CBPRINTF_NANO)) {
 		TC_PRINT("short test for nano\n");
@@ -437,8 +437,8 @@ ZTEST(prf, test_v_c)
 	reset_out();
 	buf[1] = 'b';
 	rc = rawprf("%c", 'a');
-	zassert_equal(rc, 1, NULL);
-	zassert_equal(buf[0], 'a', NULL);
+	zassert_equal(rc, 1);
+	zassert_equal(buf[0], 'a');
 	if (!ENABLED_USE_LIBC) {
 		zassert_equal(buf[1], 'b', "wth %x", buf[1]);
 	}
@@ -524,7 +524,7 @@ ZTEST(prf, test_d_length)
 	reset_out();
 	rc = rawprf("/%Ld/", max);
 	zassert_equal(rc, 5, "len %d", rc);
-	zassert_equal(strncmp("/%Ld/", buf, rc), 0, NULL);
+	zassert_equal(strncmp("/%Ld/", buf, rc), 0);
 }
 
 ZTEST(prf, test_d_flags)
@@ -663,7 +663,7 @@ ZTEST(prf, test_x_flags)
 	reset_out();
 	rc = rawprf("/%+x/% x/", sv, sv);
 	zassert_equal(rc, 9, "rc %d", rc);
-	zassert_equal(strncmp("/123/123/", buf, rc), 0, NULL);
+	zassert_equal(strncmp("/123/123/", buf, rc), 0);
 }
 
 ZTEST(prf, test_o)
@@ -913,7 +913,7 @@ ZTEST(prf, test_fp_length)
 	reset_out();
 	rc = rawprf("/%hf/", dv);
 	zassert_equal(rc, 5, "len %d", rc);
-	zassert_equal(strncmp("/%hf/", buf, rc), 0, NULL);
+	zassert_equal(strncmp("/%hf/", buf, rc), 0);
 }
 
 ZTEST(prf, test_fp_flags)
@@ -944,9 +944,9 @@ ZTEST(prf, test_fp_flags)
 	PRF_CHECK("/23/23.0000/23/23./", rc);
 
 	rc = prf(NULL, "% .380f", 0x1p-400);
-	zassert_equal(rc, 383, NULL);
-	zassert_equal(strncmp(buf, " 0.000", 6), 0, NULL);
-	zassert_equal(strncmp(&buf[119], "00003872", 8), 0, NULL);
+	zassert_equal(rc, 383);
+	zassert_equal(strncmp(buf, " 0.000", 6), 0);
+	zassert_equal(strncmp(&buf[119], "00003872", 8), 0);
 }
 
 ZTEST(prf, test_star_width)
@@ -1012,29 +1012,29 @@ ZTEST(prf, test_n)
 
 	rc = prf(NULL, "12345%n", &l);
 	zassert_equal(l, rc, "%d != %d", l, rc);
-	zassert_equal(rc, 5, NULL);
+	zassert_equal(rc, 5);
 
 
 	rc = prf(NULL, "12345%hn", &l_h);
-	zassert_equal(l_h, rc, NULL);
+	zassert_equal(l_h, rc);
 
 	rc = prf(NULL, "12345%hhn", &l_hh);
-	zassert_equal(l_hh, rc, NULL);
+	zassert_equal(l_hh, rc);
 
 	rc = prf(NULL, "12345%ln", &l_l);
-	zassert_equal(l_l, rc, NULL);
+	zassert_equal(l_l, rc);
 
 	rc = prf(NULL, "12345%lln", &l_ll);
-	zassert_equal(l_ll, rc, NULL);
+	zassert_equal(l_ll, rc);
 
 	rc = prf(NULL, "12345%jn", &l_j);
-	zassert_equal(l_j, rc, NULL);
+	zassert_equal(l_j, rc);
 
 	rc = prf(NULL, "12345%zn", &l_z);
-	zassert_equal(l_z, rc, NULL);
+	zassert_equal(l_z, rc);
 
 	rc = prf(NULL, "12345%tn", &l_t);
-	zassert_equal(l_t, rc, NULL);
+	zassert_equal(l_t, rc);
 }
 
 #define EXPECTED_1ARG(_t) (IS_ENABLED(CONFIG_CBPRINTF_NANO) \
@@ -1058,28 +1058,28 @@ ZTEST(prf, test_p)
 
 	reset_out();
 	rc = rawprf("/%12p/", ptr);
-	zassert_equal(rc, 14, NULL);
-	zassert_equal(strncmp("/    0xcafe21/", buf, rc), 0, NULL);
+	zassert_equal(rc, 14);
+	zassert_equal(strncmp("/    0xcafe21/", buf, rc), 0);
 
 	reset_out();
 	rc = rawprf("/%12p/", NULL);
-	zassert_equal(rc, 14, NULL);
-	zassert_equal(strncmp("/       (nil)/", buf, rc), 0, NULL);
+	zassert_equal(rc, 14);
+	zassert_equal(strncmp("/       (nil)/", buf, rc), 0);
 
 	reset_out();
 	rc = rawprf("/%-12p/", ptr);
-	zassert_equal(rc, 14, NULL);
-	zassert_equal(strncmp("/0xcafe21    /", buf, rc), 0, NULL);
+	zassert_equal(rc, 14);
+	zassert_equal(strncmp("/0xcafe21    /", buf, rc), 0);
 
 	reset_out();
 	rc = rawprf("/%-12p/", NULL);
-	zassert_equal(rc, 14, NULL);
-	zassert_equal(strncmp("/(nil)       /", buf, rc), 0, NULL);
+	zassert_equal(rc, 14);
+	zassert_equal(strncmp("/(nil)       /", buf, rc), 0);
 
 	reset_out();
 	rc = rawprf("/%.8p/", ptr);
-	zassert_equal(rc, 12, NULL);
-	zassert_equal(strncmp("/0x00cafe21/", buf, rc), 0, NULL);
+	zassert_equal(rc, 12);
+	zassert_equal(strncmp("/0x00cafe21/", buf, rc), 0);
 }
 
 static int out_counter(int c,
@@ -1113,23 +1113,23 @@ ZTEST(prf, test_libc_substs)
 	lbuf[len] = full_flag;
 
 	rc = snprintfcb(lbuf, len, "%06d", 1);
-	zassert_equal(rc, 6, NULL);
-	zassert_equal(strncmp("000001", lbuf, rc), 0, NULL);
-	zassert_equal(lbuf[7], full_flag, NULL);
+	zassert_equal(rc, 6);
+	zassert_equal(strncmp("000001", lbuf, rc), 0);
+	zassert_equal(lbuf[7], full_flag);
 
 	rc = snprintfcb(lbuf, len, "%07d", 1);
-	zassert_equal(rc, 7, NULL);
-	zassert_equal(strncmp("000000", lbuf, rc), 0, NULL);
-	zassert_equal(lbuf[7], full_flag, NULL);
+	zassert_equal(rc, 7);
+	zassert_equal(strncmp("000000", lbuf, rc), 0);
+	zassert_equal(lbuf[7], full_flag);
 
 	rc = snprintfcb(lbuf, len, "%020d", 1);
 	zassert_equal(rc, 20, "rc %d", rc);
-	zassert_equal(lbuf[7], full_flag, NULL);
-	zassert_equal(strncmp("000000", lbuf, rc), 0, NULL);
+	zassert_equal(lbuf[7], full_flag);
+	zassert_equal(strncmp("000000", lbuf, rc), 0);
 
 	rc = cbprintf(out_counter, &count, "%020d", 1);
 	zassert_equal(rc, 20, "rc %d", rc);
-	zassert_equal(count, 20, NULL);
+	zassert_equal(count, 20);
 
 	if (!IS_ENABLED(CONFIG_CBPRINTF_NANO)) {
 		rc = cbprintf(out_e42, NULL, "%020d", 1);
@@ -1149,7 +1149,7 @@ ZTEST(prf, test_cbprintf_package)
 
 	/* Verify we can calculate length without storing */
 	rc = cbprintf_package(NULL, PKG_ALIGN_OFFSET, PACKAGE_FLAGS, fmt, 3);
-	zassert_true(rc > sizeof(int), NULL);
+	zassert_true(rc > sizeof(int));
 
 	/* Capture the base package information for future tests. */
 	size_t len = rc;
@@ -1160,12 +1160,12 @@ ZTEST(prf, test_cbprintf_package)
 	 * unaligned. Same alignment offset was used for space calculation.
 	 */
 	rc = cbprintf_package(&buf[PKG_ALIGN_OFFSET], len, PACKAGE_FLAGS, fmt, 3);
-	zassert_equal(rc, len, NULL);
+	zassert_equal(rc, len);
 
 	/* Verify we get an error if can't store */
 	len -= 1;
 	rc = cbprintf_package(&buf[PKG_ALIGN_OFFSET], len, PACKAGE_FLAGS, fmt, 3);
-	zassert_equal(rc, -ENOSPC, NULL);
+	zassert_equal(rc, -ENOSPC);
 }
 
 /* Test using @ref CBPRINTF_PACKAGE_ADD_STRING_IDXS flag.
@@ -1198,7 +1198,7 @@ ZTEST(prf, test_cbprintf_package_rw_string_indexes)
 	/* package with string indexes will contain two more bytes holding indexes
 	 * of string parameter locations.
 	 */
-	zassert_equal(len0 + 2, len1, NULL);
+	zassert_equal(len0 + 2, len1);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package0[len0];
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package1[len1];
@@ -1214,19 +1214,19 @@ ZTEST(prf, test_cbprintf_package_rw_string_indexes)
 	union cbprintf_package_hdr *desc1 = (union cbprintf_package_hdr *)package1;
 
 	/* Compare descriptor content. Second package has one ro string index. */
-	zassert_equal(desc0->desc.ro_str_cnt, 0, NULL);
-	zassert_equal(desc1->desc.ro_str_cnt, 2, NULL);
-	zassert_equal(len0 + 2, len1, NULL);
+	zassert_equal(desc0->desc.ro_str_cnt, 0);
+	zassert_equal(desc1->desc.ro_str_cnt, 2);
+	zassert_equal(len0 + 2, len1);
 
 	int *p = (int *)package1;
 
 	str_idx = package1[len0];
 	addr = *(char **)&p[str_idx];
-	zassert_equal(addr, test_str, NULL);
+	zassert_equal(addr, test_str);
 
 	str_idx = package1[len0 + 1];
 	addr = *(char **)&p[str_idx];
-	zassert_equal(addr, test_str1, NULL);
+	zassert_equal(addr, test_str1);
 }
 
 static int fsc_package_cb(int c, void *ctx)
@@ -1268,7 +1268,7 @@ ZTEST(prf, test_cbprintf_fsc_package)
 				CBPRINTF_PACKAGE_ADD_STRING_IDXS,
 				test_str, 100, test_str1);
 
-	zassert_true(len > 0, NULL);
+	zassert_true(len > 0);
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) package[len];
 
 	CBPRINTF_STATIC_PACKAGE(package, sizeof(package), len, 0,
@@ -1280,15 +1280,15 @@ ZTEST(prf, test_cbprintf_fsc_package)
 
 	int exp_len = len + (int)strlen(test_str) + 1 + (int)strlen(test_str1) + 1;
 
-	zassert_equal(exp_len, fsc_len, NULL);
+	zassert_equal(exp_len, fsc_len);
 
 	uint8_t __aligned(CBPRINTF_PACKAGE_ALIGNMENT) fsc_package[fsc_len];
 
 	err = cbprintf_fsc_package(package, len, fsc_package, fsc_len - 1);
-	zassert_equal(err, -ENOSPC, NULL);
+	zassert_equal(err, -ENOSPC);
 
 	err = cbprintf_fsc_package(package, len, fsc_package, fsc_len);
-	zassert_equal(err, fsc_len, NULL);
+	zassert_equal(err, fsc_len);
 
 	/* Now overwrite a char in original string, confirm that fsc package
 	 * contains string without that change because ro string is copied into
@@ -1301,14 +1301,14 @@ ZTEST(prf, test_cbprintf_fsc_package)
 	cbpprintf(fsc_package_cb, &pout, package);
 	*pout = '\0';
 
-	zassert_equal(strcmp(out_str, exp_str1), 0, NULL);
-	zassert_true(strcmp(exp_str0, exp_str1) != 0, NULL);
+	zassert_equal(strcmp(out_str, exp_str1), 0);
+	zassert_true(strcmp(exp_str0, exp_str1) != 0);
 
 	/* FSC package contains original content. */
 	pout = out_str;
 	cbpprintf(fsc_package_cb, &pout, fsc_package);
 	*pout = '\0';
-	zassert_equal(strcmp(out_str, exp_str0), 0, NULL);
+	zassert_equal(strcmp(out_str, exp_str0), 0);
 }
 
 ZTEST(prf, test_cbpprintf)
@@ -1326,7 +1326,7 @@ ZTEST(prf, test_cbpprintf)
 	 */
 	reset_out();
 	rc = cbpprintf(out, &outbuf, NULL);
-	zassert_equal(rc, -EINVAL, NULL);
+	zassert_equal(rc, -EINVAL);
 }
 
 ZTEST(prf, test_nop)

--- a/tests/unit/crc/main.c
+++ b/tests/unit/crc/main.c
@@ -45,9 +45,9 @@ ZTEST(crc, test_crc32_ieee)
 	uint8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 	uint8_t test3[] = { 'Z', 'e', 'p', 'h', 'y', 'r' };
 
-	zassert_equal(crc32_ieee(test1, sizeof(test1)), 0xD3D99E8B, NULL);
-	zassert_equal(crc32_ieee(test2, sizeof(test2)), 0xCBF43926, NULL);
-	zassert_equal(crc32_ieee(test3, sizeof(test3)), 0x20089AA4, NULL);
+	zassert_equal(crc32_ieee(test1, sizeof(test1)), 0xD3D99E8B);
+	zassert_equal(crc32_ieee(test2, sizeof(test2)), 0xCBF43926);
+	zassert_equal(crc32_ieee(test3, sizeof(test3)), 0x20089AA4);
 }
 
 ZTEST(crc, test_crc16)
@@ -59,13 +59,13 @@ ZTEST(crc, test_crc16)
 	 * check=0x2189
 	 * poly is 0x1021, reflected 0x8408
 	 */
-	zassert_equal(crc16_reflect(0x8408, 0x0, test, sizeof(test)), 0x2189, NULL);
+	zassert_equal(crc16_reflect(0x8408, 0x0, test, sizeof(test)), 0x2189);
 
 	/* CRC-16/DECT-X
 	 * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-dect-x
 	 * check=0x007f
 	 */
-	zassert_equal(crc16(0x0589, 0x0, test, sizeof(test)), 0x007f, NULL);
+	zassert_equal(crc16(0x0589, 0x0, test, sizeof(test)), 0x007f);
 }
 
 ZTEST(crc, test_crc16_ansi)
@@ -79,8 +79,8 @@ ZTEST(crc, test_crc16_ansi)
 	 * check=0x4b37
 	 * poly is 0x1021, reflected 0xA001
 	 */
-	zassert_equal(crc16_c, 0x4b37, NULL);
-	zassert_equal(crc16_reflect(0xA001, 0xffff, test, sizeof(test)), crc16_c, NULL);
+	zassert_equal(crc16_c, 0x4b37);
+	zassert_equal(crc16_reflect(0xA001, 0xffff, test, sizeof(test)), crc16_c);
 }
 
 ZTEST(crc, test_crc16_ccitt)
@@ -91,13 +91,13 @@ ZTEST(crc, test_crc16_ccitt)
 	uint8_t test3[] = { 'Z', 'e', 'p', 'h', 'y', 'r', 0, 0 };
 	uint16_t crc;
 
-	zassert_equal(crc16_ccitt(0, test0, sizeof(test0)), 0x0, NULL);
-	zassert_equal(crc16_ccitt(0, test1, sizeof(test1)), 0x538d, NULL);
+	zassert_equal(crc16_ccitt(0, test0, sizeof(test0)), 0x0);
+	zassert_equal(crc16_ccitt(0, test1, sizeof(test1)), 0x538d);
 	/* CRC-16/CCITT, CRC-16/CCITT-TRUE, CRC-16/KERMIT
 	 * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-kermit
 	 * check=0x2189
 	 */
-	zassert_equal(crc16_ccitt(0, test2, sizeof(test2)), 0x2189, NULL);
+	zassert_equal(crc16_ccitt(0, test2, sizeof(test2)), 0x2189);
 	/* CRC-16/X-25, CRC-16/IBM-SDLC, CRC-16/ISO-HDLC
 	 * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-ibm-sdlc
 	 * check=0x906e
@@ -112,7 +112,7 @@ ZTEST(crc, test_crc16_ccitt)
 	test3[sizeof(test3)-2] = (uint8_t)(crc >> 0);
 	test3[sizeof(test3)-1] = (uint8_t)(crc >> 8);
 
-	zassert_equal(crc16_ccitt(0, test3, sizeof(test3)), 0, NULL);
+	zassert_equal(crc16_ccitt(0, test3, sizeof(test3)), 0);
 }
 
 ZTEST(crc, test_crc16_ccitt_for_ppp)
@@ -142,17 +142,17 @@ ZTEST(crc, test_crc16_itu_t)
 	 * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-xmodem
 	 * check=0x31c3
 	 */
-	zassert_equal(crc16_itu_t(0, test2, sizeof(test2)), 0x31c3, NULL);
+	zassert_equal(crc16_itu_t(0, test2, sizeof(test2)), 0x31c3);
 	/* CRC16/CCITT-FALSE, CRC-16/IBM-3740, CRC-16/AUTOSAR
 	 * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-ibm-3740
 	 * check=0x29b1
 	 */
-	zassert_equal(crc16_itu_t(0xffff, test2, sizeof(test2)), 0x29b1, NULL);
+	zassert_equal(crc16_itu_t(0xffff, test2, sizeof(test2)), 0x29b1);
 	/* CRC-16/GSM
 	 * https://reveng.sourceforge.io/crc-catalogue/16.htm#crc.cat.crc-16-gsm
 	 * check=0xce3c
 	 */
-	zassert_equal(crc16_itu_t(0, test2, sizeof(test2)) ^ 0xffff, 0xce3c, NULL);
+	zassert_equal(crc16_itu_t(0, test2, sizeof(test2)) ^ 0xffff, 0xce3c);
 
 }
 
@@ -176,9 +176,9 @@ ZTEST(crc, test_crc7_be)
 	uint8_t test1[] = { 'A' };
 	uint8_t test2[] = { '1', '2', '3', '4', '5', '6', '7', '8', '9' };
 
-	zassert_equal(crc7_be(0, test0, sizeof(test0)), 0, NULL);
-	zassert_equal(crc7_be(0, test1, sizeof(test1)), 0xDA, NULL);
-	zassert_equal(crc7_be(0, test2, sizeof(test2)), 0xEA, NULL);
+	zassert_equal(crc7_be(0, test0, sizeof(test0)), 0);
+	zassert_equal(crc7_be(0, test1, sizeof(test1)), 0xDA);
+	zassert_equal(crc7_be(0, test2, sizeof(test2)), 0xEA);
 }
 
 ZTEST(crc, test_crc8)

--- a/tests/unit/math_extras/tests.inc
+++ b/tests/unit/math_extras/tests.inc
@@ -12,168 +12,168 @@ static void VNAME(u32_add)(void)
 {
 	uint32_t result = 42;
 
-	zassert_false(u32_add_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 5, NULL);
+	zassert_false(u32_add_overflow(2, 3, &result));
+	zassert_equal(result, 5);
 
-	zassert_false(u32_add_overflow(2, 0, &result), NULL);
-	zassert_equal(result, 2, NULL);
+	zassert_false(u32_add_overflow(2, 0, &result));
+	zassert_equal(result, 2);
 
-	zassert_false(u32_add_overflow(0, 3, &result), NULL);
-	zassert_equal(result, 3, NULL);
+	zassert_false(u32_add_overflow(0, 3, &result));
+	zassert_equal(result, 3);
 
-	zassert_false(u32_add_overflow(0, UINT32_MAX, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_add_overflow(1, UINT32_MAX, &result), NULL);
-	zassert_equal(result, 0, NULL);
+	zassert_false(u32_add_overflow(0, UINT32_MAX, &result));
+	zassert_equal(result, UINT32_MAX);
+	zassert_true(u32_add_overflow(1, UINT32_MAX, &result));
+	zassert_equal(result, 0);
 
-	zassert_false(u32_add_overflow(UINT32_MAX, 0, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_add_overflow(UINT32_MAX, 2, &result), NULL);
-	zassert_equal(result, 1, NULL);
+	zassert_false(u32_add_overflow(UINT32_MAX, 0, &result));
+	zassert_equal(result, UINT32_MAX);
+	zassert_true(u32_add_overflow(UINT32_MAX, 2, &result));
+	zassert_equal(result, 1);
 }
 
 static void VNAME(u32_mul)(void)
 {
 	uint32_t result = 42;
 
-	zassert_false(u32_mul_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 6, NULL);
+	zassert_false(u32_mul_overflow(2, 3, &result));
+	zassert_equal(result, 6);
 
-	zassert_false(u32_mul_overflow(UINT32_MAX, 1, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_mul_overflow(UINT32_MAX, 2, &result), NULL);
-	zassert_equal(result, UINT32_MAX * 2, NULL);
+	zassert_false(u32_mul_overflow(UINT32_MAX, 1, &result));
+	zassert_equal(result, UINT32_MAX);
+	zassert_true(u32_mul_overflow(UINT32_MAX, 2, &result));
+	zassert_equal(result, UINT32_MAX * 2);
 
-	zassert_false(u32_mul_overflow(1, UINT32_MAX, &result), NULL);
-	zassert_equal(result, UINT32_MAX, NULL);
-	zassert_true(u32_mul_overflow(2, UINT32_MAX, &result), NULL);
-	zassert_equal(result, UINT32_MAX * 2, NULL);
+	zassert_false(u32_mul_overflow(1, UINT32_MAX, &result));
+	zassert_equal(result, UINT32_MAX);
+	zassert_true(u32_mul_overflow(2, UINT32_MAX, &result));
+	zassert_equal(result, UINT32_MAX * 2);
 }
 
 static void VNAME(u64_add)(void)
 {
 	uint64_t result = 42;
 
-	zassert_false(u64_add_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 5, NULL);
+	zassert_false(u64_add_overflow(2, 3, &result));
+	zassert_equal(result, 5);
 
-	zassert_false(u64_add_overflow(2, 0, &result), NULL);
-	zassert_equal(result, 2, NULL);
+	zassert_false(u64_add_overflow(2, 0, &result));
+	zassert_equal(result, 2);
 
-	zassert_false(u64_add_overflow(0, 3, &result), NULL);
-	zassert_equal(result, 3, NULL);
+	zassert_false(u64_add_overflow(0, 3, &result));
+	zassert_equal(result, 3);
 
-	zassert_false(u64_add_overflow(0, UINT64_MAX, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_add_overflow(1, UINT64_MAX, &result), NULL);
-	zassert_equal(result, 0, NULL);
+	zassert_false(u64_add_overflow(0, UINT64_MAX, &result));
+	zassert_equal(result, UINT64_MAX);
+	zassert_true(u64_add_overflow(1, UINT64_MAX, &result));
+	zassert_equal(result, 0);
 
-	zassert_false(u64_add_overflow(UINT64_MAX, 0, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_add_overflow(UINT64_MAX, 2, &result), NULL);
-	zassert_equal(result, 1, NULL);
+	zassert_false(u64_add_overflow(UINT64_MAX, 0, &result));
+	zassert_equal(result, UINT64_MAX);
+	zassert_true(u64_add_overflow(UINT64_MAX, 2, &result));
+	zassert_equal(result, 1);
 }
 
 static void VNAME(u64_mul)(void)
 {
 	uint64_t result = 42;
 
-	zassert_false(u64_mul_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 6, NULL);
+	zassert_false(u64_mul_overflow(2, 3, &result));
+	zassert_equal(result, 6);
 
-	zassert_false(u64_mul_overflow(UINT64_MAX, 1, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_mul_overflow(UINT64_MAX, 2, &result), NULL);
-	zassert_equal(result, UINT64_MAX * 2, NULL);
+	zassert_false(u64_mul_overflow(UINT64_MAX, 1, &result));
+	zassert_equal(result, UINT64_MAX);
+	zassert_true(u64_mul_overflow(UINT64_MAX, 2, &result));
+	zassert_equal(result, UINT64_MAX * 2);
 
-	zassert_false(u64_mul_overflow(1, UINT64_MAX, &result), NULL);
-	zassert_equal(result, UINT64_MAX, NULL);
-	zassert_true(u64_mul_overflow(2, UINT64_MAX, &result), NULL);
-	zassert_equal(result, UINT64_MAX * 2, NULL);
+	zassert_false(u64_mul_overflow(1, UINT64_MAX, &result));
+	zassert_equal(result, UINT64_MAX);
+	zassert_true(u64_mul_overflow(2, UINT64_MAX, &result));
+	zassert_equal(result, UINT64_MAX * 2);
 }
 
 static void VNAME(size_add)(void)
 {
 	size_t result = 42;
 
-	zassert_false(size_add_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 5, NULL);
+	zassert_false(size_add_overflow(2, 3, &result));
+	zassert_equal(result, 5);
 
-	zassert_false(size_add_overflow(2, 0, &result), NULL);
-	zassert_equal(result, 2, NULL);
+	zassert_false(size_add_overflow(2, 0, &result));
+	zassert_equal(result, 2);
 
-	zassert_false(size_add_overflow(0, 3, &result), NULL);
-	zassert_equal(result, 3, NULL);
+	zassert_false(size_add_overflow(0, 3, &result));
+	zassert_equal(result, 3);
 
-	zassert_false(size_add_overflow(0, SIZE_MAX, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_add_overflow(1, SIZE_MAX, &result), NULL);
-	zassert_equal(result, 0, NULL);
+	zassert_false(size_add_overflow(0, SIZE_MAX, &result));
+	zassert_equal(result, SIZE_MAX);
+	zassert_true(size_add_overflow(1, SIZE_MAX, &result));
+	zassert_equal(result, 0);
 
-	zassert_false(size_add_overflow(SIZE_MAX, 0, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_add_overflow(SIZE_MAX, 2, &result), NULL);
-	zassert_equal(result, 1, NULL);
+	zassert_false(size_add_overflow(SIZE_MAX, 0, &result));
+	zassert_equal(result, SIZE_MAX);
+	zassert_true(size_add_overflow(SIZE_MAX, 2, &result));
+	zassert_equal(result, 1);
 }
 
 static void VNAME(size_mul)(void)
 {
 	size_t result = 42;
 
-	zassert_false(size_mul_overflow(2, 3, &result), NULL);
-	zassert_equal(result, 6, NULL);
+	zassert_false(size_mul_overflow(2, 3, &result));
+	zassert_equal(result, 6);
 
-	zassert_false(size_mul_overflow(SIZE_MAX, 1, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_mul_overflow(SIZE_MAX, 2, &result), NULL);
-	zassert_equal(result, SIZE_MAX * 2, NULL);
+	zassert_false(size_mul_overflow(SIZE_MAX, 1, &result));
+	zassert_equal(result, SIZE_MAX);
+	zassert_true(size_mul_overflow(SIZE_MAX, 2, &result));
+	zassert_equal(result, SIZE_MAX * 2);
 
-	zassert_false(size_mul_overflow(1, SIZE_MAX, &result), NULL);
-	zassert_equal(result, SIZE_MAX, NULL);
-	zassert_true(size_mul_overflow(2, SIZE_MAX, &result), NULL);
-	zassert_equal(result, SIZE_MAX * 2, NULL);
+	zassert_false(size_mul_overflow(1, SIZE_MAX, &result));
+	zassert_equal(result, SIZE_MAX);
+	zassert_true(size_mul_overflow(2, SIZE_MAX, &result));
+	zassert_equal(result, SIZE_MAX * 2);
 }
 
 static void VNAME(u32_clz)(void)
 {
-	zassert_equal(u32_count_leading_zeros(0), 32, NULL);
-	zassert_equal(u32_count_leading_zeros(1), 31, NULL);
-	zassert_equal(u32_count_leading_zeros(0xf00f), 16, NULL);
-	zassert_equal(u32_count_leading_zeros(0xf00ff00f), 0, NULL);
-	zassert_equal(u32_count_leading_zeros(0xffffffff), 0, NULL);
+	zassert_equal(u32_count_leading_zeros(0), 32);
+	zassert_equal(u32_count_leading_zeros(1), 31);
+	zassert_equal(u32_count_leading_zeros(0xf00f), 16);
+	zassert_equal(u32_count_leading_zeros(0xf00ff00f), 0);
+	zassert_equal(u32_count_leading_zeros(0xffffffff), 0);
 }
 
 static void VNAME(u64_clz)(void)
 {
-	zassert_equal(u64_count_leading_zeros(0), 64, NULL);
-	zassert_equal(u64_count_leading_zeros(1), 63, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00f), 48, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00ff00f), 32, NULL);
-	zassert_equal(u64_count_leading_zeros(0xffffffff), 32, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00f00000000ull), 16, NULL);
-	zassert_equal(u64_count_leading_zeros(0xf00ff00f00000000ull), 0, NULL);
-	zassert_equal(u64_count_leading_zeros(0xffffffff00000000ull), 0, NULL);
+	zassert_equal(u64_count_leading_zeros(0), 64);
+	zassert_equal(u64_count_leading_zeros(1), 63);
+	zassert_equal(u64_count_leading_zeros(0xf00f), 48);
+	zassert_equal(u64_count_leading_zeros(0xf00ff00f), 32);
+	zassert_equal(u64_count_leading_zeros(0xffffffff), 32);
+	zassert_equal(u64_count_leading_zeros(0xf00f00000000ull), 16);
+	zassert_equal(u64_count_leading_zeros(0xf00ff00f00000000ull), 0);
+	zassert_equal(u64_count_leading_zeros(0xffffffff00000000ull), 0);
 }
 
 static void VNAME(u32_ctz)(void)
 {
-	zassert_equal(u32_count_trailing_zeros(0), 32, NULL);
-	zassert_equal(u32_count_trailing_zeros(1), 0, NULL);
-	zassert_equal(u32_count_trailing_zeros(6), 1, NULL);
-	zassert_equal(u32_count_trailing_zeros(0x00f00f00), 8, NULL);
-	zassert_equal(u32_count_trailing_zeros(0xf00ffc00), 10, NULL);
-	zassert_equal(u32_count_trailing_zeros(0xffffffff), 0, NULL);
-	zassert_equal(u32_count_trailing_zeros(0x80000000), 31, NULL);
+	zassert_equal(u32_count_trailing_zeros(0), 32);
+	zassert_equal(u32_count_trailing_zeros(1), 0);
+	zassert_equal(u32_count_trailing_zeros(6), 1);
+	zassert_equal(u32_count_trailing_zeros(0x00f00f00), 8);
+	zassert_equal(u32_count_trailing_zeros(0xf00ffc00), 10);
+	zassert_equal(u32_count_trailing_zeros(0xffffffff), 0);
+	zassert_equal(u32_count_trailing_zeros(0x80000000), 31);
 }
 
 static void VNAME(u64_ctz)(void)
 {
-	zassert_equal(u64_count_trailing_zeros(0), 64, NULL);
-	zassert_equal(u64_count_trailing_zeros(1), 0, NULL);
-	zassert_equal(u64_count_trailing_zeros(6), 1, NULL);
-	zassert_equal(u64_count_trailing_zeros(0x00f00f00), 8, NULL);
-	zassert_equal(u64_count_trailing_zeros(0xf00ffc00), 10, NULL);
-	zassert_equal(u64_count_trailing_zeros(0xffffffffffffffffull), 0, NULL);
+	zassert_equal(u64_count_trailing_zeros(0), 64);
+	zassert_equal(u64_count_trailing_zeros(1), 0);
+	zassert_equal(u64_count_trailing_zeros(6), 1);
+	zassert_equal(u64_count_trailing_zeros(0x00f00f00), 8);
+	zassert_equal(u64_count_trailing_zeros(0xf00ffc00), 10);
+	zassert_equal(u64_count_trailing_zeros(0xffffffffffffffffull), 0);
 	zassert_equal(u64_count_trailing_zeros(0x8000000080000000ull), 31,
 		      NULL);
 	zassert_equal(u64_count_trailing_zeros(0xc000000000000000ull), 62,

--- a/tests/unit/net_timeout/main.c
+++ b/tests/unit/net_timeout/main.c
@@ -52,17 +52,17 @@ ZTEST(net_timeout, test_set)
 	/* Zero is a special case. */
 	memset(&nto, 0xa5, sizeof(nto));
 	net_timeout_set(&nto, 0, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, 0, NULL);
-	zassert_equal(nto.timer_timeout, 0, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, 0);
+	zassert_equal(nto.timer_timeout, 0);
 
 	/* Less than the max is straightforward. */
 	lifetime = NTO_MAX_S / 2;
 	++now;
 	memset(&nto, 0xa5, sizeof(nto));
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, 0);
 	zassert_equal(nto.timer_timeout, lifetime * MSEC_PER_SEC,
 		      NULL);
 
@@ -71,8 +71,8 @@ ZTEST(net_timeout, test_set)
 	++now;
 	memset(&nto, 0xa5, sizeof(nto));
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, 0);
 	zassert_equal(nto.timer_timeout, lifetime * MSEC_PER_SEC,
 		      NULL);
 
@@ -81,8 +81,8 @@ ZTEST(net_timeout, test_set)
 	++now;
 	memset(&nto, 0xa5, sizeof(nto));
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, 1U, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, 1U);
 	zassert_equal(nto.timer_timeout,
 		      (lifetime * MSEC_PER_SEC) % NET_TIMEOUT_MAX_VALUE,
 		      NULL);
@@ -92,8 +92,8 @@ ZTEST(net_timeout, test_set)
 	++now;
 	memset(&nto, 0xa5, sizeof(nto));
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, 1U, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, 1U);
 	zassert_equal(nto.timer_timeout,
 		      (lifetime * (uint64_t)MSEC_PER_SEC) % NET_TIMEOUT_MAX_VALUE,
 		      NULL);
@@ -103,9 +103,9 @@ ZTEST(net_timeout, test_set)
 	++now;
 	memset(&nto, 0xa5, sizeof(nto));
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, MSEC_PER_SEC - 1, NULL);
-	zassert_equal(nto.timer_timeout, NET_TIMEOUT_MAX_VALUE, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, MSEC_PER_SEC - 1);
+	zassert_equal(nto.timer_timeout, NET_TIMEOUT_MAX_VALUE);
 }
 
 ZTEST(net_timeout, test_deadline)
@@ -163,7 +163,7 @@ ZTEST(net_timeout, test_remaining)
 	lifetime = NTO_MAX_S / 2;
 	memset(&nto, 0xa5, sizeof(nto));
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.wrap_counter, 0, NULL);
+	zassert_equal(nto.wrap_counter, 0);
 	zassert_equal(net_timeout_remaining(&nto, now), lifetime,
 		      NULL);
 
@@ -184,7 +184,7 @@ ZTEST(net_timeout, test_remaining)
 	/* Works when wrap is involved */
 	lifetime = 4 * FULLMAX_S;
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.wrap_counter, 7, NULL);
+	zassert_equal(nto.wrap_counter, 7);
 	zassert_equal(net_timeout_remaining(&nto, now), lifetime,
 		      NULL);
 }
@@ -307,15 +307,15 @@ ZTEST(net_timeout, test_evaluate_whitebox)
 	uint32_t lifetime = 3 * HALFMAX_S + 2;
 
 	net_timeout_set(&nto, lifetime, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, 3, NULL);
-	zassert_equal(nto.timer_timeout, 59, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, 3);
+	zassert_equal(nto.timer_timeout, 59);
 
 	/* Preserve the deadline for validation */
 	uint64_t deadline = net_timeout_deadline(&nto, now);
 
 	uint32_t delay = net_timeout_evaluate(&nto, now);
-	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE, NULL);
+	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE);
 	zassert_equal(net_timeout_deadline(&nto, now),
 		      deadline, NULL);
 
@@ -324,30 +324,30 @@ ZTEST(net_timeout, test_evaluate_whitebox)
 	 */
 	now += delay + 100U;
 	delay = net_timeout_evaluate(&nto, now);
-	zassert_equal(nto.timer_start, now, NULL);
-	zassert_equal(nto.wrap_counter, 1, NULL);
-	zassert_equal(nto.timer_timeout, 2147483606, NULL);
+	zassert_equal(nto.timer_start, now);
+	zassert_equal(nto.wrap_counter, 1);
+	zassert_equal(nto.timer_timeout, 2147483606);
 	zassert_equal(net_timeout_deadline(&nto, now),
 		      deadline, NULL);
-	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE, NULL);
+	zassert_equal(delay, NET_TIMEOUT_MAX_VALUE);
 
 	/* Another late evaluation finishes the wrap leaving some extra.
 	 */
 	now += delay + 123U;
 	delay = net_timeout_evaluate(&nto, now);
-	zassert_equal(nto.timer_start, (uint32_t)now, NULL);
-	zassert_equal(nto.wrap_counter, 0, NULL);
-	zassert_equal(nto.timer_timeout, 2147483483, NULL);
+	zassert_equal(nto.timer_start, (uint32_t)now);
+	zassert_equal(nto.wrap_counter, 0);
+	zassert_equal(nto.timer_timeout, 2147483483);
 	zassert_equal(net_timeout_deadline(&nto, now),
 		      deadline, NULL);
-	zassert_equal(delay, nto.timer_timeout, NULL);
+	zassert_equal(delay, nto.timer_timeout);
 
 	/* Complete the timeout.  This does *not* adjust the internal
 	 * state.
 	 */
 	now += delay + 234U;
 	delay = net_timeout_evaluate(&nto, now);
-	zassert_equal(delay, 0, NULL);
+	zassert_equal(delay, 0);
 	zassert_equal(net_timeout_deadline(&nto, now),
 		      deadline, NULL);
 }

--- a/tests/unit/util/test.inc
+++ b/tests/unit/util/test.inc
@@ -80,16 +80,16 @@ void test_COND_CODE_1(void)
 	 * be seen in compilation (lack of variable or ununsed variable.
 	 */
 	COND_CODE_1(1, (uint32_t x0 = 1;), (uint32_t y0;))
-	zassert_true((x0 == 1), NULL);
+	zassert_true((x0 == 1));
 
 	COND_CODE_1(NOT_EXISTING_DEFINE, (uint32_t x1 = 1;), (uint32_t y1 = 1;))
-	zassert_true((y1 == 1), NULL);
+	zassert_true((y1 == 1));
 
 	COND_CODE_1(TEST_DEFINE_1, (uint32_t x2 = 1;), (uint32_t y2 = 1;))
-	zassert_true((x2 == 1), NULL);
+	zassert_true((x2 == 1));
 
 	COND_CODE_1(2, (uint32_t x3 = 1;), (uint32_t y3 = 1;))
-	zassert_true((y3 == 1), NULL);
+	zassert_true((y3 == 1));
 }
 
 void test_COND_CODE_0(void)
@@ -98,16 +98,16 @@ void test_COND_CODE_0(void)
 	 * be seen in compilation (lack of variable or ununsed variable.
 	 */
 	COND_CODE_0(0, (uint32_t x0 = 1;), (uint32_t y0;))
-	zassert_true((x0 == 1), NULL);
+	zassert_true((x0 == 1));
 
 	COND_CODE_0(NOT_EXISTING_DEFINE, (uint32_t x1 = 1;), (uint32_t y1 = 1;))
-	zassert_true((y1 == 1), NULL);
+	zassert_true((y1 == 1));
 
 	COND_CODE_0(TEST_DEFINE_0, (uint32_t x2 = 1;), (uint32_t y2 = 1;))
-	zassert_true((x2 == 1), NULL);
+	zassert_true((x2 == 1));
 
 	COND_CODE_0(2, (uint32_t x3 = 1;), (uint32_t y3 = 1;))
-	zassert_true((y3 == 1), NULL);
+	zassert_true((y3 == 1));
 }
 
 #undef ZERO
@@ -119,28 +119,28 @@ void test_COND_CODE_0(void)
 
 void test_UTIL_OR(void)
 {
-	zassert_equal(UTIL_OR(SEVEN, A_BUILD_ERROR), 7, NULL);
-	zassert_equal(UTIL_OR(7, 0), 7, NULL);
-	zassert_equal(UTIL_OR(SEVEN, ZERO), 7, NULL);
-	zassert_equal(UTIL_OR(0, 7), 7, NULL);
-	zassert_equal(UTIL_OR(ZERO, SEVEN), 7, NULL);
-	zassert_equal(UTIL_OR(0, 0), 0, NULL);
-	zassert_equal(UTIL_OR(ZERO, ZERO), 0, NULL);
+	zassert_equal(UTIL_OR(SEVEN, A_BUILD_ERROR), 7);
+	zassert_equal(UTIL_OR(7, 0), 7);
+	zassert_equal(UTIL_OR(SEVEN, ZERO), 7);
+	zassert_equal(UTIL_OR(0, 7), 7);
+	zassert_equal(UTIL_OR(ZERO, SEVEN), 7);
+	zassert_equal(UTIL_OR(0, 0), 0);
+	zassert_equal(UTIL_OR(ZERO, ZERO), 0);
 }
 
 void test_UTIL_AND(void)
 {
-	zassert_equal(UTIL_AND(ZERO, A_BUILD_ERROR), 0, NULL);
-	zassert_equal(UTIL_AND(7, 0), 0, NULL);
-	zassert_equal(UTIL_AND(SEVEN, ZERO), 0, NULL);
-	zassert_equal(UTIL_AND(0, 7), 0, NULL);
-	zassert_equal(UTIL_AND(ZERO, SEVEN), 0, NULL);
-	zassert_equal(UTIL_AND(0, 0), 0, NULL);
-	zassert_equal(UTIL_AND(ZERO, ZERO), 0, NULL);
-	zassert_equal(UTIL_AND(7, 7), 7, NULL);
-	zassert_equal(UTIL_AND(7, SEVEN), 7, NULL);
-	zassert_equal(UTIL_AND(SEVEN, 7), 7, NULL);
-	zassert_equal(UTIL_AND(SEVEN, SEVEN), 7, NULL);
+	zassert_equal(UTIL_AND(ZERO, A_BUILD_ERROR), 0);
+	zassert_equal(UTIL_AND(7, 0), 0);
+	zassert_equal(UTIL_AND(SEVEN, ZERO), 0);
+	zassert_equal(UTIL_AND(0, 7), 0);
+	zassert_equal(UTIL_AND(ZERO, SEVEN), 0);
+	zassert_equal(UTIL_AND(0, 0), 0);
+	zassert_equal(UTIL_AND(ZERO, ZERO), 0);
+	zassert_equal(UTIL_AND(7, 7), 7);
+	zassert_equal(UTIL_AND(7, SEVEN), 7);
+	zassert_equal(UTIL_AND(SEVEN, 7), 7);
+	zassert_equal(UTIL_AND(SEVEN, SEVEN), 7);
 }
 
 void test_IF_ENABLED(void)
@@ -170,9 +170,9 @@ void test_LISTIFY(void)
 
 	int *a[] = { LISTIFY(2, A_PTR, (,), a, b) };
 
-	zassert_equal(ARRAY_SIZE(a), 2, NULL);
-	zassert_equal(a[0], &ab0, NULL);
-	zassert_equal(a[1], &ab1, NULL);
+	zassert_equal(ARRAY_SIZE(a), 2);
+	zassert_equal(a[0], &ab0);
+	zassert_equal(a[1], &ab1);
 }
 
 void test_MACRO_MAP_CAT(void)
@@ -404,9 +404,9 @@ static void test_nested_FOR_EACH(void)
 
 	FOR_EACH(FOO_2, (;), FOR_EACH(FOO_1, (,), 0, 1, 2));
 
-	zassert_equal(a0, 0, NULL);
-	zassert_equal(a1, 1, NULL);
-	zassert_equal(a2, 2, NULL);
+	zassert_equal(a0, 0);
+	zassert_equal(a1, 1);
+	zassert_equal(a2, 2);
 }
 
 static void test_GET_ARG_N(void)
@@ -415,9 +415,9 @@ static void test_GET_ARG_N(void)
 	int b = GET_ARG_N(2, 10, 100, 1000);
 	int c = GET_ARG_N(3, 10, 100, 1000);
 
-	zassert_equal(a, 10, NULL);
-	zassert_equal(b, 100, NULL);
-	zassert_equal(c, 1000, NULL);
+	zassert_equal(a, 10);
+	zassert_equal(b, 100);
+	zassert_equal(c, 1000);
 }
 
 static void test_GET_ARGS_LESS_N(void)
@@ -426,14 +426,14 @@ static void test_GET_ARGS_LESS_N(void)
 	uint8_t b[] = { GET_ARGS_LESS_N(1, 1, 2, 3) };
 	uint8_t c[] = { GET_ARGS_LESS_N(2, 1, 2, 3) };
 
-	zassert_equal(sizeof(a), 3, NULL);
+	zassert_equal(sizeof(a), 3);
 
-	zassert_equal(sizeof(b), 2, NULL);
-	zassert_equal(b[0], 2, NULL);
-	zassert_equal(b[1], 3, NULL);
+	zassert_equal(sizeof(b), 2);
+	zassert_equal(b[0], 2);
+	zassert_equal(b[1], 3);
 
-	zassert_equal(sizeof(c), 1, NULL);
-	zassert_equal(c[0], 3, NULL);
+	zassert_equal(sizeof(c), 1);
+	zassert_equal(c[0], 3);
 }
 
 static void test_mixing_GET_ARG_and_FOR_EACH(void)
@@ -443,10 +443,10 @@ static void test_mixing_GET_ARG_and_FOR_EACH(void)
 	int i;
 
 	i = GET_ARG_N(3, FOR_EACH(TEST_MACRO, (), 1, 2, 3, 4, 5));
-	zassert_equal(i, 3, NULL);
+	zassert_equal(i, 3);
 
 	i = GET_ARG_N(2, 1, GET_ARGS_LESS_N(2, 1, 2, 3, 4, 5));
-	zassert_equal(i, 3, NULL);
+	zassert_equal(i, 3);
 
 	#undef TEST_MACRO
 	#undef TEST_MACRO2
@@ -456,12 +456,12 @@ static void test_mixing_GET_ARG_and_FOR_EACH(void)
 		LIST_DROP_EMPTY(TEST_MACRO2(1, 2, 3, 4)), 5
 	};
 
-	zassert_equal(ARRAY_SIZE(a), 5, NULL);
-	zassert_equal(a[0], 1, NULL);
-	zassert_equal(a[1], 2, NULL);
-	zassert_equal(a[2], 3, NULL);
-	zassert_equal(a[3], 4, NULL);
-	zassert_equal(a[4], 5, NULL);
+	zassert_equal(ARRAY_SIZE(a), 5);
+	zassert_equal(a[0], 1);
+	zassert_equal(a[1], 2);
+	zassert_equal(a[2], 3);
+	zassert_equal(a[3], 4);
+	zassert_equal(a[4], 5);
 }
 
 #if __cplusplus

--- a/tests/ztest/base/src/main.c
+++ b/tests/ztest/base/src/main.c
@@ -14,11 +14,11 @@ ZTEST(framework_tests, test_empty_test)
 
 ZTEST(framework_tests, test_assert_tests)
 {
-	zassert_true(1, NULL);
-	zassert_false(0, NULL);
+	zassert_true(1);
+	zassert_false(0);
 	zassert_is_null(NULL, NULL);
 	zassert_not_null("foo", NULL);
-	zassert_equal(1, 1, NULL);
+	zassert_equal(1, 1);
 	zassert_equal_ptr(NULL, NULL, NULL);
 }
 
@@ -136,7 +136,7 @@ static void rule_test_teardown(void *data)
 	 */
 	zassert_equal(fixture->state, RULE_STATE_AFTER_EACH, "Unexpected state");
 #ifdef CONFIG_ZTEST_SHUFFLE
-	zassert_equal(fixture->run_count, CONFIG_ZTEST_SHUFFLE_TEST_REPEAT_COUNT, NULL);
+	zassert_equal(fixture->run_count, CONFIG_ZTEST_SHUFFLE_TEST_REPEAT_COUNT);
 #endif
 }
 
@@ -154,7 +154,7 @@ ZTEST_F(rules_tests, test_rules_before_after)
 
 static void *fail_in_setup_setup(void)
 {
-	zassert_true(false, NULL);
+	zassert_true(false);
 	return NULL;
 }
 
@@ -162,7 +162,7 @@ ZTEST_EXPECT_FAIL(fail_in_setup, test_should_never_run);
 ZTEST(fail_in_setup, test_should_never_run)
 {
 	/* The following should pass, but the setup function will cause it to fail */
-	zassert_true(true, NULL);
+	zassert_true(true);
 }
 
 ZTEST_SUITE(fail_in_setup, NULL, fail_in_setup_setup, NULL, NULL, NULL);

--- a/tests/ztest/base/src/main.cpp
+++ b/tests/ztest/base/src/main.cpp
@@ -27,5 +27,5 @@ ZTEST_SUITE(cpp, NULL, cpp_setup, NULL, NULL, cpp_teardown);
 
 ZTEST_F(cpp, test_fixture_created_and_initialized)
 {
-	zassert_equal(5, fixture->x, NULL);
+	zassert_equal(5, fixture->x);
 }

--- a/tests/ztest/base/src/main_deprecated.c
+++ b/tests/ztest/base/src/main_deprecated.c
@@ -12,11 +12,11 @@ static void test_empty_test(void)
 
 static void test_assert_tests(void)
 {
-	zassert_true(1, NULL);
-	zassert_false(0, NULL);
+	zassert_true(1);
+	zassert_false(0);
 	zassert_is_null(NULL, NULL);
 	zassert_not_null("foo", NULL);
-	zassert_equal(1, 1, NULL);
+	zassert_equal(1, 1);
 	zassert_equal_ptr(NULL, NULL, NULL);
 }
 

--- a/tests/ztest/base/src/main_userspace.c
+++ b/tests/ztest/base/src/main_userspace.c
@@ -9,5 +9,5 @@
 
 ZTEST_USER(framework_tests, test_userspace_is_user)
 {
-	zassert_true(k_is_user_context(), NULL);
+	zassert_true(k_is_user_context());
 }

--- a/tests/ztest/busy_sim/src/main.c
+++ b/tests/ztest/busy_sim/src/main.c
@@ -17,7 +17,7 @@ static void test_busy_sim(void)
 	k_busy_wait(1000 * ms);
 	t = k_uptime_get_32() - t;
 
-	zassert_true((t > (ms - delta)) && (t < (ms + delta)), NULL);
+	zassert_true((t > (ms - delta)) && (t < (ms + delta)));
 
 	/* Start busy simulator and check that k_busy_wait last longer */
 	t = k_uptime_get_32();
@@ -38,7 +38,7 @@ static void test_busy_sim(void)
 	t = k_uptime_get_32();
 	k_busy_wait(1000 * ms);
 	t = k_uptime_get_32() - t;
-	zassert_true((t > (ms - delta)) && (t < (ms + delta)), NULL);
+	zassert_true((t > (ms - delta)) && (t < (ms + delta)));
 }
 
 void test_main(void)

--- a/tests/ztest/error_hook/src/main.c
+++ b/tests/ztest/error_hook/src/main.c
@@ -160,7 +160,7 @@ void ztest_post_fatal_error_hook(unsigned int reason,
 	case ZTEST_CATCH_FATAL_K_PANIC:
 	case ZTEST_CATCH_FATAL_K_OOPS:
 	case ZTEST_CATCH_USER_FATAL_Z_OOPS:
-		zassert_true(true, NULL);
+		zassert_true(true);
 		break;
 
 	/* Unfortunately, the case of trigger a fatal error
@@ -168,10 +168,10 @@ void ztest_post_fatal_error_hook(unsigned int reason,
 	 * So please don't use it this way.
 	 */
 	case ZTEST_CATCH_FATAL_IN_ISR:
-		zassert_true(false, NULL);
+		zassert_true(false);
 		break;
 	default:
-		zassert_true(false, NULL);
+		zassert_true(false);
 		break;
 	}
 }
@@ -366,7 +366,7 @@ ZTEST_SUITE(error_hook_tests, NULL, error_hook_tests_setup, NULL, NULL, NULL);
 static void *fail_assume_in_setup_setup(void)
 {
 	/* Fail the assume, will skip all the tests */
-	zassume_true(false, NULL);
+	zassume_true(false);
 	return NULL;
 }
 
@@ -387,7 +387,7 @@ ZTEST(fail_assume_in_setup, test_to_skip1)
 static void fail_assume_in_before_before(void *unused)
 {
 	ARG_UNUSED(unused);
-	zassume_true(false, NULL);
+	zassume_true(false);
 }
 
 ZTEST_SUITE(fail_assume_in_before, NULL, NULL, fail_assume_in_before_before, NULL, NULL);
@@ -408,7 +408,7 @@ ZTEST_SUITE(fail_assume_in_test, NULL, NULL, NULL, NULL, NULL);
 
 ZTEST(fail_assume_in_test, test_to_skip)
 {
-	zassume_true(false, NULL);
+	zassume_true(false);
 	ztest_test_fail();
 }
 

--- a/tests/ztest/register/src/main.c
+++ b/tests/ztest/register/src/main.c
@@ -106,50 +106,50 @@ static void test_verify_execution(void)
 	case PHASE_NULL_PREDICATE_0:
 		/* Verify that only remove_first_node suite was run and removed. */
 		stats = find_snapshot("run_null_predicate_once");
-		zassert_equal(1, execution_results.test_run_count, NULL);
-		zassert_equal(1, stats->run_count, NULL);
-		zassert_equal(0, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(1, execution_results.test_run_count);
+		zassert_equal(1, stats->run_count);
+		zassert_equal(0, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		break;
 	case PHASE_NULL_PREDICATE_1:
 		/* Verify that only remove_first_two_nodes_* were run. */
-		zassert_equal(0, execution_results.test_run_count, NULL);
+		zassert_equal(0, execution_results.test_run_count);
 		stats = find_snapshot("run_null_predicate_once");
-		zassert_equal(0, stats->run_count, NULL);
-		zassert_equal(1, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(0, stats->run_count);
+		zassert_equal(1, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		break;
 	case PHASE_STEPS_0:
 		/* Verify that steps_0 and steps_all suites were run. */
-		zassert_equal(2, execution_results.test_run_count, NULL);
+		zassert_equal(2, execution_results.test_run_count);
 		stats = find_snapshot("test_step_0");
-		zassert_equal(1, stats->run_count, NULL);
-		zassert_equal(0, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(1, stats->run_count);
+		zassert_equal(0, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		stats = find_snapshot("test_step_1");
-		zassert_equal(0, stats->run_count, NULL);
-		zassert_equal(1, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(0, stats->run_count);
+		zassert_equal(1, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		stats = find_snapshot("test_step_all");
-		zassert_equal(1, stats->run_count, NULL);
-		zassert_equal(0, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(1, stats->run_count);
+		zassert_equal(0, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		break;
 	case PHASE_STEPS_1:
 		/* Verify that steps_1 and steps_all suites were run. */
-		zassert_equal(2, execution_results.test_run_count, NULL);
+		zassert_equal(2, execution_results.test_run_count);
 		stats = find_snapshot("test_step_0");
-		zassert_equal(0, stats->run_count, NULL);
-		zassert_equal(1, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(0, stats->run_count);
+		zassert_equal(1, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		stats = find_snapshot("test_step_1");
-		zassert_equal(1, stats->run_count, NULL);
-		zassert_equal(0, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(1, stats->run_count);
+		zassert_equal(0, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		stats = find_snapshot("test_step_all");
-		zassert_equal(1, stats->run_count, NULL);
-		zassert_equal(0, stats->skip_count, NULL);
-		zassert_equal(0, stats->fail_count, NULL);
+		zassert_equal(1, stats->run_count);
+		zassert_equal(0, stats->skip_count);
+		zassert_equal(0, stats->fail_count);
 		break;
 	default:
 		ztest_test_fail();

--- a/tests/ztest/ztress/src/main.c
+++ b/tests/ztest/ztress/src/main.c
@@ -40,7 +40,7 @@ static void test_timeout(void)
 		       ZTRESS_THREAD(ztress_handler_busy, NULL, repeat, 1000, t));
 
 	d = k_uptime_get() - d;
-	zassert_within(d, 1000, 200, NULL);
+	zassert_within(d, 1000, 200);
 
 	/* Set of two threads and timer. Test is setup manually, without helper macro. */
 	struct ztress_context_data timer_data =
@@ -53,7 +53,7 @@ static void test_timeout(void)
 	d = k_uptime_get();
 	err = ztress_execute(&timer_data, thread_data, ARRAY_SIZE(thread_data));
 	d = k_uptime_get() - d;
-	zassert_within(d, timeout + 500, 500, NULL);
+	zassert_within(d, timeout + 500, 500);
 
 	ztress_set_timeout(K_NO_WAIT);
 }
@@ -74,8 +74,8 @@ static void test_abort(void)
 	ZTRESS_EXECUTE(ZTRESS_THREAD(ztress_handler_busy, NULL, repeat, 0, K_MSEC(1)),
 		       ZTRESS_THREAD(ztress_handler_busy, NULL, repeat, 0, K_MSEC(1)));
 
-	zassert_true(ztress_exec_count(0) < repeat, NULL);
-	zassert_true(ztress_exec_count(1) < repeat, NULL);
+	zassert_true(ztress_exec_count(0) < repeat);
+	zassert_true(ztress_exec_count(1) < repeat);
 }
 
 static void test_repeat_completion(void)
@@ -89,7 +89,7 @@ static void test_repeat_completion(void)
 	for (int i = 0; i < 2; i++) {
 		uint32_t exec_cnt = ztress_exec_count(i);
 
-		zassert_true(exec_cnt >= repeat && exec_cnt < repeat + 10, NULL);
+		zassert_true(exec_cnt >= repeat && exec_cnt < repeat + 10);
 	}
 
 	/* Set of two threads and timer */
@@ -100,7 +100,7 @@ static void test_repeat_completion(void)
 	for (int i = 0; i < 3; i++) {
 		uint32_t exec_cnt = ztress_exec_count(i);
 
-		zassert_true(exec_cnt >= repeat && exec_cnt < repeat + 10, NULL);
+		zassert_true(exec_cnt >= repeat && exec_cnt < repeat + 10);
 	}
 }
 
@@ -126,7 +126,7 @@ static void test_no_context_requirements(void)
 		       ZTRESS_THREAD(ztress_handler_busy, NULL, 0, 0, Z_TIMEOUT_TICKS(30)));
 
 	exec_cnt = ztress_exec_count(1);
-	zassert_true(exec_cnt >= repeat && exec_cnt < repeat + 10, NULL);
+	zassert_true(exec_cnt >= repeat && exec_cnt < repeat + 10);
 }
 
 void test_main(void)


### PR DESCRIPTION
These changes removes the requirement for sending the NULL as last parameter if the message is not used in zassert_* and zassume_* macros.

If the default message is descriptive enough, there's no need to provide the additional one, but it was required to send NULL as parameter to the macros. It will no longer be needed after this change.