### PR TITLE
spi: Asynchronous callback API

### DIFF
--- a/drivers/spi/CMakeLists.txt
+++ b/drivers/spi/CMakeLists.txt
@@ -32,4 +32,5 @@ zephyr_library_sources_ifdef(CONFIG_SPI_GD32		spi_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_MCHP_QSPI	spi_mchp_mss_qspi.c)
 zephyr_library_sources_ifdef(CONFIG_SPI_PL022		spi_pl022.c)
 
+zephyr_library_sources_ifdef(CONFIG_SPI_ASYNC spi_signal.c)
 zephyr_library_sources_ifdef(CONFIG_USERSPACE		spi_handlers.c)

--- a/drivers/spi/spi_b91.c
+++ b/drivers/spi/spi_b91.c
@@ -233,7 +233,7 @@ static void spi_b91_txrx(const struct device *dev, uint32_t len)
 	};
 
 	/* context complete */
-	spi_context_complete(ctx, 0);
+	spi_context_complete(ctx, dev, 0);
 }
 
 /* Check for supported configuration */
@@ -393,7 +393,7 @@ static int spi_b91_transceive(const struct device *dev,
 	}
 
 	/* context setup */
-	spi_context_lock(&data->ctx, false, NULL, config);
+	spi_context_lock(&data->ctx, false, NULL, NULL, config);
 	spi_context_buffers_setup(&data->ctx, tx_bufs, rx_bufs, 1);
 
 	/* if cs is defined: software cs control, set active true */
@@ -422,13 +422,15 @@ static int spi_b91_transceive_async(const struct device *dev,
 				    const struct spi_config *config,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs,
-				    struct k_poll_signal *async)
+				    spi_callback_t cb,
+				    void *userdata)
 {
 	ARG_UNUSED(dev);
 	ARG_UNUSED(config);
 	ARG_UNUSED(tx_bufs);
 	ARG_UNUSED(rx_bufs);
-	ARG_UNUSED(async);
+	ARG_UNUSED(cb);
+	ARG_UNUSED(userdata);
 
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_bitbang.c
+++ b/drivers/spi/spi_bitbang.c
@@ -221,7 +221,7 @@ static int spi_bitbang_transceive(const struct device *dev,
 
 	spi_context_cs_control(ctx, false);
 
-	spi_context_complete(ctx, 0);
+	spi_context_complete(ctx, dev, 0);
 
 	return 0;
 }

--- a/drivers/spi/spi_cc13xx_cc26xx.c
+++ b/drivers/spi/spi_cc13xx_cc26xx.c
@@ -140,7 +140,7 @@ static int spi_cc13xx_cc26xx_transceive(const struct device *dev,
 	uint32_t txd, rxd;
 	int err;
 
-	spi_context_lock(ctx, false, NULL, config);
+	spi_context_lock(ctx, false, NULL, NULL, config);
 	pm_policy_state_lock_get(PM_STATE_STANDBY, PM_ALL_SUBSTATES);
 
 	err = spi_cc13xx_cc26xx_configure(dev, config);

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -35,7 +35,8 @@ struct spi_context {
 	int sync_status;
 
 #ifdef CONFIG_SPI_ASYNC
-	struct k_poll_signal *signal;
+	spi_callback_t callback;
+	void *callback_data;
 	bool asynchronous;
 #endif /* CONFIG_SPI_ASYNC */
 	const struct spi_buf *current_tx;
@@ -86,7 +87,8 @@ static inline bool spi_context_is_slave(struct spi_context *ctx)
 
 static inline void spi_context_lock(struct spi_context *ctx,
 				    bool asynchronous,
-				    struct k_poll_signal *signal,
+				    spi_callback_t callback,
+				    void *callback_data,
 				    const struct spi_config *spi_cfg)
 {
 	if ((spi_cfg->operation & SPI_LOCK_ON) &&
@@ -100,7 +102,8 @@ static inline void spi_context_lock(struct spi_context *ctx,
 
 #ifdef CONFIG_SPI_ASYNC
 	ctx->asynchronous = asynchronous;
-	ctx->signal = signal;
+	ctx->callback = callback;
+	ctx->callback_data = callback_data;
 #endif /* CONFIG_SPI_ASYNC */
 }
 
@@ -171,14 +174,16 @@ static inline int spi_context_wait_for_completion(struct spi_context *ctx)
 	return status;
 }
 
-static inline void spi_context_complete(struct spi_context *ctx, int status)
+static inline void spi_context_complete(struct spi_context *ctx,
+					const struct device *dev,
+					int status)
 {
 #ifdef CONFIG_SPI_ASYNC
 	if (!ctx->asynchronous) {
 		ctx->sync_status = status;
 		k_sem_give(&ctx->sync);
 	} else {
-		if (ctx->signal) {
+		if (ctx->callback) {
 #ifdef CONFIG_SPI_SLAVE
 			if (spi_context_is_slave(ctx) && !status) {
 				/* Let's update the status so it tells
@@ -187,7 +192,7 @@ static inline void spi_context_complete(struct spi_context *ctx, int status)
 				status = ctx->recv_frames;
 			}
 #endif /* CONFIG_SPI_SLAVE */
-			k_poll_signal_raise(ctx->signal, status);
+			ctx->callback(dev, status, ctx->callback_data);
 		}
 
 		if (!(ctx->config->operation & SPI_LOCK_ON)) {

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -413,7 +413,7 @@ static void spi_stm32_complete(const struct device *dev, int status)
 	ll_func_disable_spi(spi);
 
 #ifdef CONFIG_SPI_STM32_INTERRUPT
-	spi_context_complete(&data->ctx, status);
+	spi_context_complete(&data->ctx, dev, status);
 #endif
 }
 
@@ -600,7 +600,9 @@ static int transceive(const struct device *dev,
 		      const struct spi_config *config,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
-		      bool asynchronous, struct k_poll_signal *signal)
+		      bool asynchronous,
+		      spi_callback_t cb,
+		      void *userdata)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
@@ -617,7 +619,7 @@ static int transceive(const struct device *dev,
 	}
 #endif
 
-	spi_context_lock(&data->ctx, asynchronous, signal, config);
+	spi_context_lock(&data->ctx, asynchronous, cb, userdata, config);
 
 	ret = spi_stm32_configure(dev, config);
 	if (ret) {
@@ -699,7 +701,9 @@ static int transceive_dma(const struct device *dev,
 		      const struct spi_config *config,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
-		      bool asynchronous, struct k_poll_signal *signal)
+		      bool asynchronous,
+		      spi_callback_t cb,
+		      void *userdata)
 {
 	const struct spi_stm32_config *cfg = dev->config;
 	struct spi_stm32_data *data = dev->data;
@@ -714,7 +718,7 @@ static int transceive_dma(const struct device *dev,
 		return -ENOTSUP;
 	}
 
-	spi_context_lock(&data->ctx, asynchronous, signal, config);
+	spi_context_lock(&data->ctx, asynchronous, cb, userdata, config);
 
 	k_sem_reset(&data->status_sem);
 
@@ -819,10 +823,10 @@ static int spi_stm32_transceive(const struct device *dev,
 	if ((data->dma_tx.dma_dev != NULL)
 	 && (data->dma_rx.dma_dev != NULL)) {
 		return transceive_dma(dev, config, tx_bufs, rx_bufs,
-				      false, NULL);
+				      false, NULL, NULL);
 	}
 #endif /* CONFIG_SPI_STM32_DMA */
-	return transceive(dev, config, tx_bufs, rx_bufs, false, NULL);
+	return transceive(dev, config, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -830,9 +834,10 @@ static int spi_stm32_transceive_async(const struct device *dev,
 				      const struct spi_config *config,
 				      const struct spi_buf_set *tx_bufs,
 				      const struct spi_buf_set *rx_bufs,
-				      struct k_poll_signal *async)
+				      spi_callback_t cb,
+				      void *userdata)
 {
-	return transceive(dev, config, tx_bufs, rx_bufs, true, async);
+	return transceive(dev, config, tx_bufs, rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -95,7 +95,7 @@ static int spi_mcux_transfer_next_packet(const struct device *dev)
 		/* nothing left to rx or tx, we're done! */
 		LOG_DBG("spi transceive done");
 		spi_context_cs_control(&data->ctx, false);
-		spi_context_complete(&data->ctx, 0);
+		spi_context_complete(&data->ctx, dev, 0);
 		return 0;
 	}
 
@@ -675,7 +675,8 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      spi_callback_t cb,
+		      void *userdata)
 {
 	struct spi_mcux_data *data = dev->data;
 	int ret;
@@ -684,7 +685,7 @@ static int transceive(const struct device *dev,
 	SPI_Type *base = config->base;
 #endif
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -731,7 +732,7 @@ static int spi_mcux_transceive(const struct device *dev,
 			       const struct spi_buf_set *tx_bufs,
 			       const struct spi_buf_set *rx_bufs)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -739,9 +740,10 @@ static int spi_mcux_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     spi_callback_t cb,
+				     void *userdata)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -75,7 +75,7 @@ static int spi_npcx_fiu_transceive(const struct device *dev,
 	size_t cur_xfer_len;
 	int error = 0;
 
-	spi_context_lock(ctx, false, NULL, spi_cfg);
+	spi_context_lock(ctx, false, NULL, NULL, spi_cfg);
 	ctx->config = spi_cfg;
 
 	/*

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -182,7 +182,7 @@ static void transfer_next_chunk(const struct device *dev)
 
 	LOG_DBG("Transaction finished with status %d", error);
 
-	spi_context_complete(ctx, error);
+	spi_context_complete(ctx, dev, error);
 	dev_data->busy = false;
 }
 
@@ -203,12 +203,13 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      spi_callback_t cb,
+		      void *userdata)
 {
 	struct spi_nrfx_data *dev_data = dev->data;
 	int error;
 
-	spi_context_lock(&dev_data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&dev_data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	error = configure(dev, spi_cfg);
 	if (error == 0) {
@@ -232,7 +233,7 @@ static int spi_nrfx_transceive(const struct device *dev,
 			       const struct spi_buf_set *tx_bufs,
 			       const struct spi_buf_set *rx_bufs)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -240,9 +241,10 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     spi_callback_t cb,
+				     void *userdata)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -345,7 +345,7 @@ static void transfer_next_chunk(const struct device *dev)
 
 	LOG_DBG("Transaction finished with status %d", error);
 
-	spi_context_complete(ctx, error);
+	spi_context_complete(ctx, dev, error);
 	dev_data->busy = false;
 }
 
@@ -369,12 +369,13 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      spi_callback_t cb,
+		      void *userdata)
 {
 	struct spi_nrfx_data *dev_data = dev->data;
 	int error;
 
-	spi_context_lock(&dev_data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&dev_data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	error = configure(dev, spi_cfg);
 	if (error == 0) {
@@ -398,7 +399,7 @@ static int spi_nrfx_transceive(const struct device *dev,
 			       const struct spi_buf_set *tx_bufs,
 			       const struct spi_buf_set *rx_bufs)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -406,9 +407,10 @@ static int spi_nrfx_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     spi_callback_t cb,
+				     void *userdata)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_oc_simple.c
+++ b/drivers/spi/spi_oc_simple.c
@@ -104,7 +104,7 @@ int spi_oc_simple_transceive(const struct device *dev,
 	int rc;
 
 	/* Lock the SPI Context */
-	spi_context_lock(ctx, false, NULL, config);
+	spi_context_lock(ctx, false, NULL, NULL, config);
 
 	spi_oc_simple_configure(info, spi, config);
 
@@ -153,7 +153,7 @@ int spi_oc_simple_transceive(const struct device *dev,
 		sys_write8(0 << config->slave, SPI_OC_SIMPLE_SPSS(info));
 	}
 
-	spi_context_complete(ctx, 0);
+	spi_context_complete(ctx, dev, 0);
 	rc = spi_context_wait_for_completion(ctx);
 
 	spi_context_release(ctx, rc);

--- a/drivers/spi/spi_psoc6.c
+++ b/drivers/spi/spi_psoc6.c
@@ -62,7 +62,7 @@ static void spi_psoc6_transfer_next_packet(const struct device *dev)
 		xfer->dataSize = 0U;
 
 		spi_context_cs_control(ctx, false);
-		spi_context_complete(ctx, 0U);
+		spi_context_complete(ctx, dev, 0U);
 		return;
 	}
 
@@ -124,7 +124,7 @@ err:
 	xfer->dataSize = 0U;
 
 	spi_context_cs_control(ctx, false);
-	spi_context_complete(ctx, -ENOMEM);
+	spi_context_complete(ctx, dev, -ENOMEM);
 }
 
 static void spi_psoc6_isr(const struct device *dev)
@@ -296,13 +296,14 @@ static int spi_psoc6_transceive(const struct device *dev,
 				const struct spi_buf_set *tx_bufs,
 				const struct spi_buf_set *rx_bufs,
 				bool asynchronous,
-				struct k_poll_signal *signal)
+				spi_callback_t cb,
+				void *userdata)
 {
 	const struct spi_psoc6_config *config = dev->config;
 	struct spi_psoc6_data *data = dev->data;
 	int ret;
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	LOG_DBG("\n\n");
 

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -56,7 +56,7 @@ static void spi_mcux_transfer_next_packet(const struct device *dev)
 	if ((ctx->tx_len == 0) && (ctx->rx_len == 0)) {
 		/* nothing left to rx or tx, we're done! */
 		spi_context_cs_control(&data->ctx, false);
-		spi_context_complete(&data->ctx, 0);
+		spi_context_complete(&data->ctx, dev, 0);
 		return;
 	}
 
@@ -214,12 +214,13 @@ static int transceive(const struct device *dev,
 		      const struct spi_buf_set *tx_bufs,
 		      const struct spi_buf_set *rx_bufs,
 		      bool asynchronous,
-		      struct k_poll_signal *signal)
+		      spi_callback_t cb,
+		      void *userdata)
 {
 	struct spi_mcux_data *data = dev->data;
 	int ret;
 
-	spi_context_lock(&data->ctx, asynchronous, signal, spi_cfg);
+	spi_context_lock(&data->ctx, asynchronous, cb, userdata, spi_cfg);
 
 	ret = spi_mcux_configure(dev, spi_cfg);
 	if (ret) {
@@ -244,7 +245,7 @@ static int spi_mcux_transceive(const struct device *dev,
 			       const struct spi_buf_set *tx_bufs,
 			       const struct spi_buf_set *rx_bufs)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, false, NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -252,9 +253,10 @@ static int spi_mcux_transceive_async(const struct device *dev,
 				     const struct spi_config *spi_cfg,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     spi_callback_t cb,
+				     void *userdata)
 {
-	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, async);
+	return transceive(dev, spi_cfg, tx_bufs, rx_bufs, true, cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/drivers/spi/spi_sam.c
+++ b/drivers/spi/spi_sam.c
@@ -370,7 +370,7 @@ static int spi_sam_transceive(const struct device *dev,
 	Spi *regs = cfg->regs;
 	int err;
 
-	spi_context_lock(&data->ctx, false, NULL, config);
+	spi_context_lock(&data->ctx, false, NULL, NULL, config);
 
 	err = spi_sam_configure(dev, config);
 	if (err != 0) {
@@ -414,9 +414,10 @@ static int spi_sam_transceive_async(const struct device *dev,
 				     const struct spi_config *config,
 				     const struct spi_buf_set *tx_bufs,
 				     const struct spi_buf_set *rx_bufs,
-				     struct k_poll_signal *async)
+				     spi_callback_t cb,
+				     void *userdata)
 {
-	/* TODO: implement asyc transceive */
+	/* TODO: implement async transceive */
 	return -ENOTSUP;
 }
 #endif /* CONFIG_SPI_ASYNC */

--- a/drivers/spi/spi_signal.c
+++ b/drivers/spi/spi_signal.c
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Intel Corporation
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * @file
+ * @brief Async callback used with signal notifier
+ */
+
+#include <zephyr/zephyr.h>
+#include <zephyr/device.h>
+
+#ifdef CONFIG_POLL
+
+void z_spi_transfer_signal_cb(const struct device *dev,
+			      int result,
+			      void *userdata)
+{
+	ARG_UNUSED(dev);
+
+	struct k_poll_signal *sig = userdata;
+
+	k_poll_signal_raise(sig, result);
+}
+
+#endif /* CONFIG_POLL */

--- a/drivers/spi/spi_test.c
+++ b/drivers/spi/spi_test.c
@@ -27,7 +27,8 @@ static int vnd_spi_transceive_async(const struct device *dev,
 				    const struct spi_config *spi_cfg,
 				    const struct spi_buf_set *tx_bufs,
 				    const struct spi_buf_set *rx_bufs,
-				    struct k_poll_signal *async)
+				    spi_callback_t cb,
+				    void *userdata)
 {
 	return -ENOTSUP;
 }

--- a/drivers/spi/spi_xec_qmspi.c
+++ b/drivers/spi/spi_xec_qmspi.c
@@ -522,7 +522,7 @@ static int qmspi_transceive(const struct device *dev,
 	uint32_t descr, last_didx;
 	int err;
 
-	spi_context_lock(&data->ctx, false, NULL, config);
+	spi_context_lock(&data->ctx, false, NULL, NULL, config);
 
 	err = qmspi_configure(dev, config);
 	if (err != 0) {

--- a/drivers/spi/spi_xlnx_axi_quadspi.c
+++ b/drivers/spi/spi_xlnx_axi_quadspi.c
@@ -243,7 +243,7 @@ static void xlnx_quadspi_start_tx(const struct device *dev)
 			xlnx_quadspi_write32(dev, spicr, SPICR_OFFSET);
 		}
 
-		spi_context_complete(ctx, 0);
+		spi_context_complete(ctx, dev, 0);
 		return;
 	}
 
@@ -301,7 +301,7 @@ static void xlnx_quadspi_start_tx(const struct device *dev)
 		xlnx_quadspi_write32(dev, spicr | SPICR_TX_FIFO_RESET,
 				     SPICR_OFFSET);
 
-		spi_context_complete(ctx, -ENOTSUP);
+		spi_context_complete(ctx, dev, -ENOTSUP);
 	}
 
 	if (!IS_ENABLED(CONFIG_SPI_SLAVE) || !spi_context_is_slave(ctx)) {
@@ -315,14 +315,16 @@ static int xlnx_quadspi_transceive(const struct device *dev,
 				   const struct spi_config *spi_cfg,
 				   const struct spi_buf_set *tx_bufs,
 				   const struct spi_buf_set *rx_bufs,
-				   bool async, struct k_poll_signal *signal)
+				   bool async,
+				   spi_callback_t cb,
+				   void *userdata)
 {
 	const struct xlnx_quadspi_config *config = dev->config;
 	struct xlnx_quadspi_data *data = dev->data;
 	struct spi_context *ctx = &data->ctx;
 	int ret;
 
-	spi_context_lock(ctx, async, signal, spi_cfg);
+	spi_context_lock(ctx, async, cb, userdata, spi_cfg);
 
 	ret = xlnx_quadspi_configure(dev, spi_cfg);
 	if (ret) {
@@ -349,7 +351,7 @@ static int xlnx_quadspi_transceive_blocking(const struct device *dev,
 					    const struct spi_buf_set *rx_bufs)
 {
 	return xlnx_quadspi_transceive(dev, spi_cfg, tx_bufs, rx_bufs, false,
-				       NULL);
+				       NULL, NULL);
 }
 
 #ifdef CONFIG_SPI_ASYNC
@@ -357,10 +359,11 @@ static int xlnx_quadspi_transceive_async(const struct device *dev,
 					 const struct spi_config *spi_cfg,
 					 const struct spi_buf_set *tx_bufs,
 					 const struct spi_buf_set *rx_bufs,
-					 struct k_poll_signal *signal)
+					 spi_callback_t cb,
+					 void *userdata)
 {
 	return xlnx_quadspi_transceive(dev, spi_cfg, tx_bufs, rx_bufs, true,
-				       signal);
+				       cb, userdata);
 }
 #endif /* CONFIG_SPI_ASYNC */
 

--- a/tests/drivers/spi/spi_loopback/src/spi.c
+++ b/tests/drivers/spi/spi_loopback/src/spi.c
@@ -480,7 +480,7 @@ static int spi_async_call(struct spi_dt_spec *spec)
 
 	LOG_INF("Start async call");
 
-	ret = spi_transceive_async(spec->bus, &spec->config, &tx, &rx, &async_sig);
+	ret = spi_transceive_signal(spec->bus, &spec->config, &tx, &rx, &async_sig);
 	if (ret == -ENOTSUP) {
 		LOG_DBG("Not supported");
 		return 0;


### PR DESCRIPTION
Updates the SPI API to provide an asynchronous API with callbacks. When CONFIG_POLL is enabled an additional k_poll_signal notifier and helpers are available. The SPI API should be backwards compatible for external users, for drivers some minor changes have been made to enable callbacks as the only internal notifier drivers need to concern themselves with.

Signed-off-by: Tom Burdick <thomas.burdick@intel.com>