### PR TITLE
Bluetooth: controller: llcp: fix unhandled rsp in periph phy upd proc

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_llcp_phy.c
@@ -728,6 +728,18 @@ static void lp_pu_st_wait_rx_phy_update_ind(struct ll_conn *conn, struct proc_ct
 		ctx->data.pu.ntf_pu = 1;
 		lp_pu_complete(conn, ctx, evt, param);
 		llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
+		break;
+	case LP_PU_EVT_UNKNOWN:
+		llcp_rr_set_incompat(conn, INCOMPAT_NO_COLLISION);
+		/* Unsupported in peer, so disable locally for this connection
+		 * Peer does not accept PHY UPDATE, so disable non 1M phys on current connection
+		 */
+		feature_unmask_features(conn, LL_FEAT_BIT_PHY_2M | LL_FEAT_BIT_PHY_CODED);
+		ctx->data.pu.error = BT_HCI_ERR_UNSUPP_REMOTE_FEATURE;
+		ctx->data.pu.ntf_pu = 1;
+		lp_pu_complete(conn, ctx, evt, param);
+		llcp_tx_resume_data(conn, LLCP_TX_QUEUE_PAUSE_DATA_PHY_UPDATE);
+		break;
 	default:
 		/* Ignore other evts */
 		break;


### PR DESCRIPTION
Re. peripheral phy update procedure: UNKNOWN_RSP from central was not
handled, leading to stall of procedure and subsequent procedure timeout

Proper handle and unit test for case added.

Fixes #49182

Signed-off-by: Erik Brockhoff <erbr@oticon.com>