### PR TITLE
boards: lpcxpresso55s69_cpu1: disable iap node

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
@@ -57,3 +57,8 @@
 &mailbox0 {
 	status = "okay";
 };
+
+/* Disable flash controller access for CPU1. */
+&iap {
+	status = "disabled";
+};


### PR DESCRIPTION
Hi, this fixes the remaining point in https://github.com/zephyrproject-rtos/zephyr/issues/49073, lmk if it should be done differently.

Tested with `$ ./scripts/twister -v -n -M -p lpcxpresso55s69_cpu1 -p lpcxpresso55s69_ns -T samples/drivers/flash_shell`

-- 8< --

SOC_LPC55S69_CPU1 is configured without HAS_MCUX_IAP, but the node is
enabled in the dts (inherited from the base dtsi files), resulting in
some test combination that fails to build, such as
samples/drivers/flash_shell/sample.drivers.flash.shell.

Drop disable the iap node from lpcxpresso55s69_cpu1.dts to match the
Kconfig HAS_* config, which skips the affected tests as a side effect.
