### PR TITLE
emul: emul_sbs_gauge: Fix compile

### DIFF
--- a/subsys/emul/i2c/emul_sbs_gauge.c
+++ b/subsys/emul/i2c/emul_sbs_gauge.c
@@ -151,7 +151,7 @@ static int emul_sbs_sbs_gauge_init(const struct emul *target, const struct devic
 	static const struct sbs_gauge_emul_cfg sbs_gauge_emul_cfg_##n = {                          \
 		.addr = DT_INST_REG_ADDR(n),                                                       \
 	};                                                                                         \
-	EMUL_DEFINE(emul_sbs_sbs_gauge_init, DT_DRV_INST(n), &sbs_gauge_emul_cfg_##n,              \
-		    &sbs_gauge_emul_data_##n, &sbs_gauge_emul_api_i2c)
+	EMUL_DT_INST_DEFINE(n, emul_sbs_sbs_gauge_init, &sbs_gauge_emul_data_##n,                  \
+			    &sbs_gauge_emul_cfg_##n, &sbs_gauge_emul_api_i2c)
 
 DT_INST_FOREACH_STATUS_OKAY(SBS_GAUGE_EMUL)


### PR DESCRIPTION
EMUL_DEFINE was removed and replaced.  Update code to use new
EMUL_DT_INST_DEFINE.

Signed-off-by: Kumar Gala <galak@kernel.org>