### PR TITLE
boards: lpcxpresso55s69_cpu1: Fix CI failures

### DIFF
--- a/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
+++ b/boards/arm/lpcxpresso55s69/lpcxpresso55s69_cpu1.dts
@@ -57,3 +57,7 @@
 &mailbox0 {
 	status = "okay";
 };
+
+&mma8652fc {
+	status = "disabled";
+};

--- a/drivers/flash/soc_flash_mcux.c
+++ b/drivers/flash/soc_flash_mcux.c
@@ -14,11 +14,6 @@
 #include "flash_priv.h"
 
 #include "fsl_common.h"
-#ifdef CONFIG_HAS_MCUX_IAP
-#include "fsl_iap.h"
-#else
-#include "fsl_flash.h"
-#endif
 
 #define LOG_LEVEL CONFIG_FLASH_LOG_LEVEL
 #include <zephyr/logging/log.h>
@@ -33,11 +28,20 @@ LOG_MODULE_REGISTER(flash_mcux);
 #define DT_DRV_COMPAT nxp_kinetis_ftfl
 #elif DT_NODE_HAS_STATUS(DT_INST(0, nxp_iap_fmc55), okay)
 #define DT_DRV_COMPAT nxp_iap_fmc55
+#define SOC_HAS_IAP 1
 #elif DT_NODE_HAS_STATUS(DT_INST(0, nxp_iap_fmc553), okay)
 #define DT_DRV_COMPAT nxp_iap_fmc553
+#define SOC_HAS_IAP 1
 #else
 #error No matching compatible for soc_flash_mcux.c
 #endif
+
+#ifdef SOC_HAS_IAP
+#include "fsl_iap.h"
+#else
+#include "fsl_flash.h"
+#endif /* SOC_HAS_IAP */
+
 
 #define SOC_NV_FLASH_NODE DT_INST(0, soc_nv_flash)
 
@@ -272,7 +276,7 @@ static int flash_mcux_init(const struct device *dev)
 
 	rc = FLASH_Init(&priv->config);
 
-#ifdef CONFIG_HAS_MCUX_IAP
+#ifdef SOC_HAS_IAP
 	FLASH_GetProperty(&priv->config, kFLASH_PropertyPflashBlockBaseAddr,
 			  &pflash_block_base);
 #else

--- a/tests/drivers/build_all/modem/testcase.yaml
+++ b/tests/drivers/build_all/modem/testcase.yaml
@@ -6,6 +6,7 @@ tests:
     extra_args: CONF_FILE=modem.conf
     platform_exclude: serpente particle_boron rak5010_nrf52840 litex_vexriscv ip_k66f
     min_ram: 68
+    min_flash: 115
   drivers.modem.ublox_sara.build:
     extra_args: CONF_FILE=modem_ublox_sara.conf
     platform_exclude: serpente pinnacle_100_dvk litex_vexriscv ip_k66f


### PR DESCRIPTION
This PR fixes the following CI failures for the lpcxpresso55s69_cpu1 target:
- samples/sensor/thermometer/sample/sensor.thermometer: fix pulled in from #49172
- samples/drivers/flash_shell/sample.drivers.flash.shell: remove dependency on KConfig HAS_MCUX_IAP
- tests/drivers/build_all/model/drivers.model.build: exclude test, platform does not have enough flash