### PR TITLE
driver: i2c: npcx: add recover_bus API support

### DIFF
--- a/drivers/i2c/i2c_npcx_controller.h
+++ b/drivers/i2c/i2c_npcx_controller.h
@@ -69,6 +69,17 @@ int npcx_i2c_ctrl_get_speed(const struct device *i2c_dev, uint32_t *speed);
 int npcx_i2c_ctrl_transfer(const struct device *i2c_dev, struct i2c_msg *msgs,
 			      uint8_t num_msgs, uint16_t addr, uint8_t port);
 
+/**
+ * @brief Toggle the SCL to generate maxmium 9 clocks until the target release
+ * the SDA line and send a STOP condition.
+ *
+ * @param i2c_dev Pointer to the device structure for i2c controller instance.
+ *
+ * @retval 0 If successful.
+ * @retval -EBUSY fail to recover the bus.
+ */
+int npcx_i2c_ctrl_recover_bus(const struct device *dev);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/i2c/i2c_npcx_port.c
+++ b/drivers/i2c/i2c_npcx_port.c
@@ -122,6 +122,26 @@ static int i2c_npcx_port_transfer(const struct device *dev,
 
 	return ret;
 }
+static int i2c_npcx_port_recover_bus(const struct device *dev)
+{
+	const struct i2c_npcx_port_config *const config = dev->config;
+	int ret;
+
+	if (config->i2c_ctrl == NULL) {
+		LOG_ERR("Cannot find i2c controller on port%02x!", config->port);
+		return -EIO;
+	}
+
+	/* Lock mutex of i2c/smb controller */
+	npcx_i2c_ctrl_mutex_lock(config->i2c_ctrl);
+
+	ret = npcx_i2c_ctrl_recover_bus(config->i2c_ctrl);
+
+	/* Unlock mutex of i2c/smb controller */
+	npcx_i2c_ctrl_mutex_unlock(config->i2c_ctrl);
+
+	return ret;
+}
 
 /* I2C driver registration */
 static int i2c_npcx_port_init(const struct device *dev)
@@ -152,6 +172,7 @@ static const struct i2c_driver_api i2c_port_npcx_driver_api = {
 	.configure = i2c_npcx_port_configure,
 	.get_config = i2c_npcx_port_get_config,
 	.transfer = i2c_npcx_port_transfer,
+	.recover_bus = i2c_npcx_port_recover_bus,
 };
 
 /* I2C port init macro functions */


### PR DESCRIPTION
Add I2C bus recovery support by emitting 9 SCL clock pulses.
It implements the equivalent logic of the i2c_unwedge function in the
ChromiumOS legacy-EC.

Signed-off-by: Jun Lin <CHLin56@nuvoton.com>
