### PR TITLE
stm32U5 enable clock for the SDMMC peripheral

### DIFF
--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -151,6 +151,12 @@ static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 	LL_RCC_SetSDMMCClockSource(LL_RCC_SDMMC1_CLKSOURCE_PLLSAI1);
 #endif
 
+#if defined(CONFIG_SOC_SERIES_STM32U5X)
+	/* By default the SDMMC clock source is set to 0 --> 48MHz, must be enabled */
+	LL_RCC_HSI48_Enable();
+	while (!LL_RCC_HSI48_IsReady()) {
+	}
+#endif /* CONFIG_SOC_SERIES_STM32U5X */
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* Enable the APB clock for stm32_sdmmc */
@@ -272,7 +278,7 @@ static int stm32_sdmmc_access_init(struct disk_info *disk)
 
 	err = HAL_SD_Init(&priv->hsd);
 	if (err != HAL_OK) {
-		LOG_ERR("failed to init stm32_sdmmc");
+		LOG_ERR("failed to init stm32_sdmmc (ErrorCode 0x%X)", priv->hsd.ErrorCode);
 		return -EIO;
 	}
 


### PR DESCRIPTION
For some stm32 devices, including the stm32U5 serie, the SDMMC clock selection is HSI 48MHz by default (reset value).
This is the bit 14 position of the RCC CCIPR2 (peripheral independent clock configuration register 2)

To access the SDMMC peripheral correctly, the HSI48 must be on an ready.

The DTS of the stm32U5 is including the sdmmc1 & sdmmc2 nodes.

The ErrorCode of the HAL_SD_Init is also reported when is fails (0x0 is for NO error), so the reason for failing is given (see [stm32u5xx_ll_sdmmc.h](https://github.com/zephyrproject-rtos/hal_stm32/blob/main/stm32cube/stm32u5xx/drivers/include/stm32u5xx_ll_sdmmc.h) for ErroCode definition).


Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49154

Signed-off-by: Francois Ramu [francois.ramu@st.com](mailto:francois.ramu@st.com)