### PR TITLE
drivers: sensor: mpu9250: Fix initialization routine

### DIFF
--- a/drivers/sensor/mpu9250/mpu9250.c
+++ b/drivers/sensor/mpu9250/mpu9250.c
@@ -309,7 +309,7 @@ static int mpu9250_init(const struct device *dev)
 	}
 
 	ret = i2c_reg_write_byte_dt(&cfg->i2c, MPU9250_REG_ACCEL_CFG2,
-				    cfg->gyro_dlpf);
+				    cfg->accel_dlpf);
 	if (ret < 0) {
 		LOG_ERR("Failed to write accel digital LPF settings.");
 		return ret;


### PR DESCRIPTION
Fix a call that writes Register 29 - Accelerometer Configuration 2.
Due to an obvious copy-paste mistake in the code, this register was
written with a DLPF setting from devicetree intended for gyroscope,
not for accelerometer (and the latter was effectively ignored).

Fixes #48724.