### PR TITLE
[RFC] ci: for PRs move cmake phase into test_plan.py

### DIFF
--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -229,8 +229,8 @@ jobs:
           rm -f testplan.json
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
-          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request
-          ./scripts/twister --subset ${{matrix.subset}}/${{ strategy.job-total }} --load-tests testplan.json ${TWISTER_COMMON} ${PR_OPTIONS}
+          python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request --subset ${{matrix.subset}}/${{ strategy.job-total }}
+          ./scripts/twister --load-tests testplan.json ${TWISTER_COMMON} ${PR_OPTIONS}
           if [ "${{matrix.subset}}" = "1" -a ${{needs.twister-build-prep.outputs.fullrun}} = 'True' ]; then
             ./scripts/zephyr_module.py --twister-out module_tests.args
             if [ -s module_tests.args ]; then

--- a/.github/workflows/twister.yaml
+++ b/.github/workflows/twister.yaml
@@ -133,7 +133,7 @@ jobs:
       CLANG_ROOT_DIR: /usr/lib/llvm-12
       TWISTER_COMMON: ' --force-color --inline-logs -v -N -M --retry-failed 3 '
       DAILY_OPTIONS: ' -M --build-only --all'
-      PR_OPTIONS: ' --clobber-output --integration'
+      PR_OPTIONS: ' --integration'
       PUSH_OPTIONS: ' --clobber-output -M'
       COMMIT_RANGE: ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       BASE_REF: ${{ github.base_ref }}
@@ -230,11 +230,11 @@ jobs:
           export ZEPHYR_BASE=${PWD}
           export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
           python3 ./scripts/ci/test_plan.py -c origin/${BASE_REF}.. --pull-request --subset ${{matrix.subset}}/${{ strategy.job-total }}
-          ./scripts/twister --load-tests testplan.json ${TWISTER_COMMON} ${PR_OPTIONS}
+          ./scripts/twister --load-tests testplan.json ${TWISTER_COMMON} --skip-cmake ${PR_OPTIONS}
           if [ "${{matrix.subset}}" = "1" -a ${{needs.twister-build-prep.outputs.fullrun}} = 'True' ]; then
             ./scripts/zephyr_module.py --twister-out module_tests.args
             if [ -s module_tests.args ]; then
-              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} ${PR_OPTIONS}
+              ./scripts/twister +module_tests.args --outdir module_tests ${TWISTER_COMMON} --clobber-output ${PR_OPTIONS}
             fi
           fi
 

--- a/scripts/ci/test_plan.py
+++ b/scripts/ci/test_plan.py
@@ -122,6 +122,12 @@ class Filters:
             json_data = json.load(jsonfile)
             suites = json_data.get("testsuites", [])
             self.all_tests.extend(suites)
+
+        if self.pull_request:
+            cmd = ["scripts/twister", "-n", "--load-tests", fname, "--cmake-only"]
+            logging.info(" ".join(cmd))
+            _ = subprocess.call(cmd)
+
         if os.path.exists(fname):
             os.remove(fname)
 

--- a/scripts/pylib/twister/twisterlib/environment.py
+++ b/scripts/pylib/twister/twisterlib/environment.py
@@ -241,6 +241,10 @@ structure in the main Zephyr tree: boards/<arch>/<board_name>/""")
         "--cmake-only", action="store_true",
         help="Only run cmake, do not build or run.")
 
+    parser.add_argument(
+        "--skip-cmake", action="store_true",
+        help="Skip the cmake step.")
+
     parser.add_argument("--coverage-basedir", default=ZEPHYR_BASE,
                         help="Base source directory for coverage report.")
 

--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -841,7 +841,10 @@ class TwisterRunner:
                 if test_only and instance.run:
                     pipeline.put({"op": "run", "test": instance})
                 else:
-                    pipeline.put({"op": "cmake", "test": instance})
+                    if self.options.skip_cmake:
+                        pipeline.put({"op": "build", "test": instance})
+                    else:
+                        pipeline.put({"op": "cmake", "test": instance})
 
     def pipeline_mgr(self, pipeline, done_queue, lock, results):
         while True:


### PR DESCRIPTION
This is plumbing to allow test_plan.py to do additional filtering based on `compile_commands.json` such that if we have a PR that only touches C files we can skip building any tests that don't actually build one of the files that the PR touches.