### PR TITLE
bt_gatt_discover API: Documentation Changes

### DIFF
--- a/doc/connectivity/bluetooth/api/gatt.rst
+++ b/doc/connectivity/bluetooth/api/gatt.rst
@@ -48,6 +48,10 @@ callbacks can be set to NULL if the attribute permission don't allow their
 respective operations.
 
 .. note::
+   32-bit UUIDs are not supported in GATT. All 32-bit UUIDs shall be converted
+   to 128-bit UUIDs when the UUID is contained in an ATT PDU.
+
+.. note::
   Attribute ``read`` and ``write`` callbacks are called directly from RX Thread
   thus it is not recommended to block for long periods of time in them.
 

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -1455,8 +1455,9 @@ struct bt_gatt_discover_params {
  *
  *  This procedure is used by a client to discover attributes on a server.
  *
- *  Primary Service Discovery: Procedure allows to discover specific Primary
- *                             Service based on UUID.
+ *  Primary Service Discovery: Procedure allows to discover primary services
+ *                             either by Discover All Primary Services or
+ *                             Discover Primary Services by Service UUID.
  *  Include Service Discovery: Procedure allows to discover all Include Services
  *                             within specified range.
  *  Characteristic Discovery:  Procedure allows to discover all characteristics

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -622,6 +622,9 @@ ssize_t bt_gatt_attr_read_service(struct bt_conn *conn,
  *
  *  Helper macro to declare a secondary service attribute.
  *
+ *  @note A secondary service is only intended to be included from a primary
+ *  service or another secondary service or other higher layer specification.
+ *
  *  @param _service Service attribute value.
  */
 #define BT_GATT_SECONDARY_SERVICE(_service)				\

--- a/include/zephyr/bluetooth/gatt.h
+++ b/include/zephyr/bluetooth/gatt.h
@@ -172,7 +172,10 @@ struct bt_gatt_attr {
 	void *user_data;
 	/** Attribute handle */
 	uint16_t handle;
-	/** Attribute permissions */
+	/** @brief Attribute permissions.
+	 *
+	 * Will be 0 if returned from bt_gatt_discover().
+	 */
 	uint16_t perm;
 };
 


### PR DESCRIPTION
Added documentation to be clearer about some aspects of the bt_gatt_discover() API.

Signed-off-by: Pierce Lowe <pierce.lowe@nordicsemi.no>