### PR TITLE
drivers: can: rename can_state enumerations

### DIFF
--- a/doc/releases/release-notes-3.0.rst
+++ b/doc/releases/release-notes-3.0.rst
@@ -466,13 +466,13 @@ Drivers and Sensors
 * CAN
 
   * Renamed ``zephyr,can-primary`` chosen property to ``zephyr,canbus``.
-  * Added :c:macro:`CAN_ERROR_WARNING` CAN controller state.
+  * Added :c:macro:`CAN_STATE_ERROR_WARNING` CAN controller state.
   * Added Atmel SAM Bosch M_CAN CAN-FD driver.
   * Added NXP LPCXpresso Bosch M_CAN CAN-FD driver.
   * Added ST STM32H7 Bosch M_CAN CAN-FD driver.
   * Rework transmission error handling the NXP FlexCAN driver to automatically
     retry transmission in case or arbitration lost or missing acknowledge and
-    to fail early in :c:func:`can_send` if in :c:macro:`CAN_BUS_OFF` state.
+    to fail early in :c:func:`can_send` if in :c:macro:`CAN_STATE_BUS_OFF`.
   * Added support for disabling automatic retransmissions ("one-shot" mode") to
     the ST STM32 bxCAN driver.
   * Converted the emulated CAN loopback driver to be configured through

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -258,7 +258,7 @@ static int can_loopback_get_state(const struct device *dev, enum can_state *stat
 	ARG_UNUSED(dev);
 
 	if (state != NULL) {
-		*state = CAN_ERROR_ACTIVE;
+		*state = CAN_STATE_ERROR_ACTIVE;
 	}
 
 	if (err_cnt) {

--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -748,13 +748,13 @@ int can_mcan_get_state(const struct device *dev, enum can_state *state,
 
 	if (state != NULL) {
 		if (can->psr & CAN_MCAN_PSR_BO) {
-			*state = CAN_BUS_OFF;
+			*state = CAN_STATE_BUS_OFF;
 		} else if (can->psr & CAN_MCAN_PSR_EP) {
-			*state = CAN_ERROR_PASSIVE;
+			*state = CAN_STATE_ERROR_PASSIVE;
 		} else if (can->psr & CAN_MCAN_PSR_EW) {
-			*state = CAN_ERROR_WARNING;
+			*state = CAN_STATE_ERROR_WARNING;
 		} else {
-			*state = CAN_ERROR_ACTIVE;
+			*state = CAN_STATE_ERROR_ACTIVE;
 		}
 	}
 

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -693,13 +693,13 @@ static int mcp2515_get_state(const struct device *dev, enum can_state *state,
 
 	if (state != NULL) {
 		if (eflg & MCP2515_EFLG_TXBO) {
-			*state = CAN_BUS_OFF;
+			*state = CAN_STATE_BUS_OFF;
 		} else if ((eflg & MCP2515_EFLG_RXEP) || (eflg & MCP2515_EFLG_TXEP)) {
-			*state = CAN_ERROR_PASSIVE;
+			*state = CAN_STATE_ERROR_PASSIVE;
 		} else if (eflg & MCP2515_EFLG_EWARN) {
-			*state = CAN_ERROR_WARNING;
+			*state = CAN_STATE_ERROR_WARNING;
 		} else {
-			*state = CAN_ERROR_ACTIVE;
+			*state = CAN_STATE_ERROR_ACTIVE;
 		}
 	}
 
@@ -934,7 +934,7 @@ static int mcp2515_init(const struct device *dev)
 
 	(void)memset(dev_data->rx_cb, 0, sizeof(dev_data->rx_cb));
 	(void)memset(dev_data->filter, 0, sizeof(dev_data->filter));
-	dev_data->old_state = CAN_ERROR_ACTIVE;
+	dev_data->old_state = CAN_STATE_ERROR_ACTIVE;
 
 	timing.sjw = dev_cfg->tq_sjw;
 	if (dev_cfg->sample_point && USE_SP_ALGO) {

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -325,14 +325,14 @@ static int mcux_flexcan_get_state(const struct device *dev, enum can_state *stat
 		status_flags = FLEXCAN_GetStatusFlags(config->base);
 
 		if ((status_flags & CAN_ESR1_FLTCONF(2)) != 0U) {
-			*state = CAN_BUS_OFF;
+			*state = CAN_STATE_BUS_OFF;
 		} else if ((status_flags & CAN_ESR1_FLTCONF(1)) != 0U) {
-			*state = CAN_ERROR_PASSIVE;
+			*state = CAN_STATE_ERROR_PASSIVE;
 		} else if ((status_flags &
 			(kFLEXCAN_TxErrorWarningFlag | kFLEXCAN_RxErrorWarningFlag)) != 0) {
-			*state = CAN_ERROR_WARNING;
+			*state = CAN_STATE_ERROR_WARNING;
 		} else {
-			*state = CAN_ERROR_ACTIVE;
+			*state = CAN_STATE_ERROR_ACTIVE;
 		}
 	}
 
@@ -362,7 +362,7 @@ static int mcux_flexcan_send(const struct device *dev,
 	}
 
 	(void)mcux_flexcan_get_state(dev, &state, NULL);
-	if (state == CAN_BUS_OFF) {
+	if (state == CAN_STATE_BUS_OFF) {
 		LOG_DBG("Transmit failed, bus-off");
 		return -ENETDOWN;
 	}
@@ -471,7 +471,7 @@ static int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 	int ret = 0;
 
 	(void)mcux_flexcan_get_state(dev, &state, NULL);
-	if (state != CAN_BUS_OFF) {
+	if (state != CAN_STATE_BUS_OFF) {
 		return 0;
 	}
 
@@ -481,7 +481,7 @@ static int mcux_flexcan_recover(const struct device *dev, k_timeout_t timeout)
 	if (!K_TIMEOUT_EQ(timeout, K_NO_WAIT)) {
 		(void)mcux_flexcan_get_state(dev, &state, NULL);
 
-		while (state == CAN_BUS_OFF) {
+		while (state == CAN_STATE_BUS_OFF) {
 			if (!K_TIMEOUT_EQ(timeout, K_FOREVER) &&
 			    k_uptime_ticks() - start_time >= timeout.ticks) {
 				ret = -EAGAIN;
@@ -571,7 +571,7 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 		}
 	}
 
-	if (state == CAN_BUS_OFF) {
+	if (state == CAN_STATE_BUS_OFF) {
 		/* Abort any pending TX frames in case of bus-off */
 		for (alloc = 0; alloc < MCUX_FLEXCAN_MAX_TX; alloc++) {
 			/* Copy callback function and argument before clearing bit */

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -322,14 +322,14 @@ static void can_rcar_error(const struct device *dev)
 		/* Clear interrupt condition */
 		sys_write8((uint8_t)~RCAR_CAN_EIFR_EWIF,
 			   config->reg_addr + RCAR_CAN_EIFR);
-		can_rcar_state_change(dev, CAN_ERROR_WARNING);
+		can_rcar_state_change(dev, CAN_STATE_ERROR_WARNING);
 	}
 	if (eifr & RCAR_CAN_EIFR_EPIF) {
 		LOG_DBG("Error passive interrupt\n");
 		/* Clear interrupt condition */
 		sys_write8((uint8_t)~RCAR_CAN_EIFR_EPIF,
 			   config->reg_addr + RCAR_CAN_EIFR);
-		can_rcar_state_change(dev, CAN_ERROR_PASSIVE);
+		can_rcar_state_change(dev, CAN_STATE_ERROR_PASSIVE);
 	}
 	if (eifr & RCAR_CAN_EIFR_BORIF) {
 		LOG_DBG("Bus-off recovery interrupt\n");
@@ -337,7 +337,7 @@ static void can_rcar_error(const struct device *dev)
 		/* Clear interrupt condition */
 		sys_write8((uint8_t)~RCAR_CAN_EIFR_BORIF,
 			   config->reg_addr + RCAR_CAN_EIFR);
-		can_rcar_state_change(dev, CAN_BUS_OFF);
+		can_rcar_state_change(dev, CAN_STATE_BUS_OFF);
 	}
 	if (eifr & RCAR_CAN_EIFR_BOEIF) {
 		LOG_DBG("Bus-off entry interrupt\n");
@@ -345,7 +345,7 @@ static void can_rcar_error(const struct device *dev)
 		/* Clear interrupt condition */
 		sys_write8((uint8_t)~RCAR_CAN_EIFR_BOEIF,
 			   config->reg_addr + RCAR_CAN_EIFR);
-		can_rcar_state_change(dev, CAN_BUS_OFF);
+		can_rcar_state_change(dev, CAN_STATE_BUS_OFF);
 	}
 	if (eifr & RCAR_CAN_EIFR_ORIF) {
 		LOG_DBG("Receive overrun error interrupt\n");
@@ -754,7 +754,7 @@ static int can_rcar_recover(const struct device *dev, k_timeout_t timeout)
 	int64_t start_time;
 	int ret;
 
-	if (data->state != CAN_BUS_OFF) {
+	if (data->state != CAN_STATE_BUS_OFF) {
 		return 0;
 	}
 
@@ -763,7 +763,7 @@ static int can_rcar_recover(const struct device *dev, k_timeout_t timeout)
 	}
 
 	start_time = k_uptime_ticks();
-	while (data->state == CAN_BUS_OFF) {
+	while (data->state == CAN_STATE_BUS_OFF) {
 		ret = can_rcar_enter_operation_mode(config);
 		if (ret != 0) {
 			goto done;
@@ -930,7 +930,7 @@ static int can_rcar_init(const struct device *dev)
 	data->tx_unsent = 0;
 
 	memset(data->rx_callback, 0, sizeof(data->rx_callback));
-	data->state = CAN_ERROR_ACTIVE;
+	data->state = CAN_STATE_ERROR_ACTIVE;
 	data->state_change_cb = NULL;
 	data->state_change_cb_data = NULL;
 

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -311,7 +311,7 @@ int can_sja1000_send(const struct device *dev, const struct can_frame *frame, k_
 		return -EINVAL;
 	}
 
-	if (data->state == CAN_BUS_OFF) {
+	if (data->state == CAN_STATE_BUS_OFF) {
 		LOG_DBG("transmit failed, bus-off");
 		return -ENETDOWN;
 	}
@@ -543,7 +543,7 @@ static void can_sja1000_handle_error_warning_irq(const struct device *dev)
 
 	sr = can_sja1000_read_reg(dev, CAN_SJA1000_SR);
 	if ((sr & CAN_SJA1000_SR_BS) != 0) {
-		data->state = CAN_BUS_OFF;
+		data->state = CAN_STATE_BUS_OFF;
 		can_sja1000_tx_done(dev, -ENETDOWN);
 #ifdef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 		/* Recover bus now unless interrupted in the middle of a MOD register change. */
@@ -554,9 +554,9 @@ static void can_sja1000_handle_error_warning_irq(const struct device *dev)
 		}
 #endif /* CONFIG_CAN_AUTO_BUS_OFF_RECOVERY */
 	} else if ((sr & CAN_SJA1000_SR_ES) != 0) {
-		data->state = CAN_ERROR_WARNING;
+		data->state = CAN_STATE_ERROR_WARNING;
 	} else {
-		data->state = CAN_ERROR_ACTIVE;
+		data->state = CAN_STATE_ERROR_ACTIVE;
 	}
 }
 
@@ -564,10 +564,10 @@ static void can_sja1000_handle_error_passive_irq(const struct device *dev)
 {
 	struct can_sja1000_data *data = dev->data;
 
-	if (data->state == CAN_ERROR_PASSIVE) {
-		data->state = CAN_ERROR_WARNING;
+	if (data->state == CAN_STATE_ERROR_PASSIVE) {
+		data->state = CAN_STATE_ERROR_WARNING;
 	} else {
-		data->state = CAN_ERROR_PASSIVE;
+		data->state = CAN_STATE_ERROR_PASSIVE;
 	}
 }
 
@@ -626,7 +626,7 @@ int can_sja1000_init(const struct device *dev)
 	k_sem_init(&data->tx_idle, 1, 1);
 	k_sem_init(&data->tx_done, 0, 1);
 
-	data->state = CAN_ERROR_ACTIVE;
+	data->state = CAN_STATE_ERROR_ACTIVE;
 
 	/* See NXP SJA1000 Application Note AN97076 (figure 12) for initialization sequence */
 

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -131,13 +131,13 @@ static int can_stm32_get_state(const struct device *dev, enum can_state *state,
 
 	if (state != NULL) {
 		if (can->ESR & CAN_ESR_BOFF) {
-			*state = CAN_BUS_OFF;
+			*state = CAN_STATE_BUS_OFF;
 		} else if (can->ESR & CAN_ESR_EPVF) {
-			*state = CAN_ERROR_PASSIVE;
+			*state = CAN_STATE_ERROR_PASSIVE;
 		} else if (can->ESR & CAN_ESR_EWGF) {
-			*state = CAN_ERROR_WARNING;
+			*state = CAN_STATE_ERROR_WARNING;
 		} else {
-			*state = CAN_ERROR_ACTIVE;
+			*state = CAN_STATE_ERROR_ACTIVE;
 		}
 	}
 

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -106,17 +106,17 @@ extern "C" {
 typedef uint32_t can_mode_t;
 
 /**
- * @brief Defines the state of the CAN bus
+ * @brief Defines the state of the CAN controller
  */
 enum can_state {
 	/** Error-active state (RX/TX error count < 96). */
-	CAN_ERROR_ACTIVE,
+	CAN_STATE_ERROR_ACTIVE,
 	/** Error-warning state (RX/TX error count < 128). */
-	CAN_ERROR_WARNING,
+	CAN_STATE_ERROR_WARNING,
 	/** Error-passive state (RX/TX error count < 256). */
-	CAN_ERROR_PASSIVE,
+	CAN_STATE_ERROR_PASSIVE,
 	/** Bus-off state (RX/TX error count >= 256). */
-	CAN_BUS_OFF,
+	CAN_STATE_BUS_OFF,
 };
 
 /**

--- a/modules/canopennode/CO_driver.c
+++ b/modules/canopennode/CO_driver.c
@@ -433,7 +433,7 @@ void CO_CANverifyErrors(CO_CANmodule_t *CANmodule)
 	if (errors != CANmodule->errors) {
 		CANmodule->errors = errors;
 
-		if (state == CAN_BUS_OFF) {
+		if (state == CAN_STATE_BUS_OFF) {
 			/* Bus off */
 			CO_errorReport(em, CO_EM_CAN_TX_BUS_OFF,
 				       CO_EMC_BUS_OFF_RECOVERED, errors);

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -109,13 +109,13 @@ void change_led_work_handler(struct k_work *work)
 char *state_to_str(enum can_state state)
 {
 	switch (state) {
-	case CAN_ERROR_ACTIVE:
+	case CAN_STATE_ERROR_ACTIVE:
 		return "error-active";
-	case CAN_ERROR_WARNING:
+	case CAN_STATE_ERROR_WARNING:
 		return "error-warning";
-	case CAN_ERROR_PASSIVE:
+	case CAN_STATE_ERROR_PASSIVE:
 		return "error-passive";
-	case CAN_BUS_OFF:
+	case CAN_STATE_BUS_OFF:
 		return "bus-off";
 	default:
 		return "unknown";
@@ -126,7 +126,7 @@ void poll_state_thread(void *unused1, void *unused2, void *unused3)
 {
 	struct can_bus_err_cnt err_cnt = {0, 0};
 	struct can_bus_err_cnt err_cnt_prev = {0, 0};
-	enum can_state state_prev = CAN_ERROR_ACTIVE;
+	enum can_state state_prev = CAN_STATE_ERROR_ACTIVE;
 	enum can_state state;
 	int err;
 
@@ -165,7 +165,7 @@ void state_change_work_handler(struct k_work *work)
 		current_err_cnt.rx_err_cnt, current_err_cnt.tx_err_cnt);
 
 #ifndef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
-	if (current_state == CAN_BUS_OFF) {
+	if (current_state == CAN_STATE_BUS_OFF) {
 		printk("Recover from bus-off\n");
 
 		if (can_recover(can_dev, K_MSEC(100)) != 0) {


### PR DESCRIPTION
Rename the can_state enumerations to contain the word STATE to make their meaning more clear:
- CAN_ERROR_ACTIVE  => CAN_STATE_ERROR_ACTIVE
- CAN_ERROR_WARNING => CAN_STATE_ERROR_WARNING
- CAN_ERROR_PASSIVE => CAN_STATE_ERROR_PASSIVE
- CAN_BUS_OFF       => CAN_STATE_BUS_OFF

This is preparation for solving #45304.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>