### PR TITLE
blobs: Document the submission process

### DIFF
--- a/.github/ISSUE_TEMPLATE/bin-blobs.md
+++ b/.github/ISSUE_TEMPLATE/bin-blobs.md
@@ -1,0 +1,41 @@
+---
+name: Binary blobs
+about: Submit a proposal to integrate binary blob(s)
+title: ''
+labels: TSC
+assignees: ''
+
+---
+
+## Origin
+
+Describe where the binary blob(s) originate from
+
+## Type
+
+- [ ] Precompiled library
+- [ ] Firmware image
+
+## Module
+
+The Zephyr module that this blob(s) will be referenced from
+
+## Purpose
+
+Brief description of what the blob(s) do. It is especially important to describe
+the functionality that the blob(s) provide, to the largest extent possible
+
+## Pull Request
+
+Link to the Pull request with the actual implementation of the integration. If
+you are submitting this as part of a new module you may link to the same Pull
+Request that introduced the new module.
+
+## Dependencies
+
+What other components do the blob(s) depend on, if any?
+
+## License
+
+Document the license the blob(s) are distributed under
+

--- a/doc/contribute/bin_blobs.rst
+++ b/doc/contribute/bin_blobs.rst
@@ -224,5 +224,29 @@ the integration of such blob for the foreseeable future.
 Submission and review process
 =============================
 
-This section will be updated once the standard format for describing binary
-blobs is agreed upon.
+For references to binary blobs to be included in the project, they must be
+reviewed and accepted by the Technical Steering Committee (TSC). This process is
+only required for new binary blobs, updates to binary blobs follow the
+:ref:`module update procedure <modules_changes>`.
+
+A request for integration with binary blobs must be made by creating a new
+issue in the Zephyr project issue tracking system on GitHub with details
+about the blobs and the functionality they provide to the project.
+
+Follow the steps below to begin the submission process:
+
+#. Make sure to read through the :ref:`bin-blobs` section in
+   detail, so that you are informed of the criteria used by the TSC in order to
+   approve or reject a request
+#. Use the :github:`New Binary Blobs Issue
+   <new?assignees=&labels=RFC&template=bin-blobs.md&title=>` to open an issue
+#. Fill out all required sections, making sure you provide enough detail for the
+   TSC to assess the merit of the request. Additionally you must also create a Pull
+   Request that demonstrates the integration of the binary blobs and then
+   link to it from the issue
+#. Wait for feedback from the TSC, respond to any additional questions added as
+   GitHub issue comments
+
+If, after consideration by the TSC, the submission of the binary blob(s) is
+approved, the submission process is complete and the binary blob(s) can be
+integrated.

--- a/doc/develop/modules.rst
+++ b/doc/develop/modules.rst
@@ -207,6 +207,7 @@ such updates in Zephyr and the module **owner**. In particular:
   have not been caught by Zephyr pull request CI runs.
 
 
+.. _modules_changes:
 
 Contributing changes to modules
 ===============================


### PR DESCRIPTION
Add the missing piece of documentation for binary blobs: the submission
process. This follows the external source code process relatively close,
but it is relatively simpler.

The proposal includes a new issue template for requesting inclusion of
blob(s) for a particular module.

Fixes #7516.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>