### PR TITLE
drivers: i2c_tca954x: Fix transfer function

### DIFF
--- a/drivers/i2c/i2c_tca954x.c
+++ b/drivers/i2c/i2c_tca954x.c
@@ -93,7 +93,7 @@ static int tca954x_transfer(const struct device *dev,
 		goto end_trans;
 	}
 
-	res = i2c_transfer_dt(&config->i2c, msgs, num_msgs);
+	res = i2c_transfer(config->i2c.bus, msgs, num_msgs, addr);
 
 end_trans:
 	k_mutex_unlock(&data->lock);


### PR DESCRIPTION
This is a follow-up to commit e1c0a494b3dc697d65a5cfab92b3bb8711ab0862.

The `tca954x_transfer()` function cannot call `i2c_transfer_dt()`,
because the I2C device address used in the transaction must be the one
passed as the `addr` parameter, not the address of the TCA954xA switch
itself. Hence, this commit restores the call to `i2c_transfer()`.

Fixes #49046.