### PR TITLE
runners: jlink: kill existing processes before use

### DIFF
--- a/scripts/west_commands/runners/jlink.py
+++ b/scripts/west_commands/runners/jlink.py
@@ -14,6 +14,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import psutil
 
 from runners.core import ZephyrBinaryRunner, RunnerCaps, depr_action
 
@@ -64,6 +65,10 @@ class JLinkBinaryRunner(ZephyrBinaryRunner):
         self.tool_opt = []
         for opts in [shlex.split(opt) for opt in tool_opt]:
             self.tool_opt += opts
+
+        for proc in psutil.process_iter():
+            if proc.name() == DEFAULT_JLINK_EXE:
+                proc.kill()
 
     @classmethod
     def name(cls):


### PR DESCRIPTION
From time to time, a case occurs when multiple JLinkExeprocesses are spawned and still active which makes `west flash` command failed. Fix that by killing every existing process to be sure that we start from scratch.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>