### PR TITLE
tests: use CONFIG_ZTEST_NEW_API=y for bluetooth/controller/ctrl_cte_req

### DIFF
--- a/tests/bluetooth/controller/ctrl_cte_req/testcase.yaml
+++ b/tests/bluetooth/controller/ctrl_cte_req/testcase.yaml
@@ -3,3 +3,5 @@ common:
 tests:
   bluetooth.controller.ctrl_cte_req.test:
      type: unit
+     extra_configs:
+     - CONFIG_ZTEST_NEW_API=y


### PR DESCRIPTION
The bluetooth/controller/ctrl_cte_req wrongly defaulted to old Ztest API
after the introduction of the new unit_testing board.

Enforce use of CONFIG_ZTEST_NEW_API to get test working again.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>