### PR TITLE
boards, dts: fix namespace for intel adsp cavs, ace

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
+++ b/boards/xtensa/intel_adsp_cavs15/intel_adsp_cavs15.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <intel/intel_cavs15.dtsi>
+#include <intel/intel_adsp_cavs15.dtsi>
 
 / {
 	model = "intel_adsp_cavs15";

--- a/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.dts
+++ b/boards/xtensa/intel_adsp_cavs18/intel_adsp_cavs18.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <intel/intel_cavs18.dtsi>
+#include <intel/intel_adsp_cavs18.dtsi>
 
 / {
 	model = "intel_adsp_cavs18";

--- a/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.dts
+++ b/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <intel/intel_cavs20.dtsi>
+#include <intel/intel_adsp_cavs20.dtsi>
 
 / {
 	model = "intel_adsp_cavs20";

--- a/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20_jsl.dts
+++ b/boards/xtensa/intel_adsp_cavs20/intel_adsp_cavs20_jsl.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <intel/intel_cavs20_jsl.dtsi>
+#include <intel/intel_adsp_cavs20_jsl.dtsi>
 
 / {
 	model = "intel_adsp_cavs20_jsl";

--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.dts
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <intel/intel_cavs25.dtsi>
+#include <intel/intel_adsp_cavs25.dtsi>
 
 / {
 	model = "intel_adsp_cavs25";

--- a/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_tgph.dts
+++ b/boards/xtensa/intel_adsp_cavs25/intel_adsp_cavs25_tgph.dts
@@ -6,7 +6,7 @@
 
 /dts-v1/;
 
-#include <intel/intel_cavs25_tgph.dtsi>
+#include <intel/intel_adsp_cavs25_tgph.dtsi>
 
 / {
 	model = "intel_adsp_cavs25_tgph";

--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -3,7 +3,7 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_BEETLE              beetle_clock_control.c)
-zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ADSP                clock_control_cavs.c)
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ADSP                clock_control_adsp.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ESP32               clock_control_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_GD32                clock_control_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_LITEX               clock_control_litex.c)

--- a/drivers/clock_control/CMakeLists.txt
+++ b/drivers/clock_control/CMakeLists.txt
@@ -3,7 +3,7 @@
 zephyr_library()
 
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_BEETLE              beetle_clock_control.c)
-zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_CAVS                clock_control_cavs.c)
+zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ADSP                clock_control_cavs.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_ESP32               clock_control_esp32.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_GD32                clock_control_gd32.c)
 zephyr_library_sources_ifdef(CONFIG_CLOCK_CONTROL_LITEX               clock_control_litex.c)

--- a/drivers/clock_control/Kconfig.cavs
+++ b/drivers/clock_control/Kconfig.cavs
@@ -3,11 +3,11 @@
 # Copyright (c) 2022 Intel Corporation
 # SPDX-License-Idertifier: Apache-2.0
 
-config CLOCK_CONTROL_CAVS
+config CLOCK_CONTROL_ADSP
 	bool "Intel CAVS clock control"
 	default y
-	depends on DT_HAS_INTEL_CAVS_SHIM_CLKCTL_ENABLED
-	select CAVS_CLOCK
+	depends on DT_HAS_INTEL_ADSP_SHIM_CLKCTL_ENABLED
+	select ADSP_CLOCK
 	help
 	  Driver for the CAVS clocks. Allow type of clock (and
 	  thus frequency) to be chosen.

--- a/drivers/clock_control/clock_control_adsp.c
+++ b/drivers/clock_control/clock_control_adsp.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/device.h>
-#include <zephyr/drivers/clock_control/clock_control_cavs.h>
+#include <zephyr/drivers/clock_control/clock_control_adsp.h>
 #include <zephyr/drivers/clock_control.h>
 
 static int cavs_clock_ctrl_set_rate(const struct device *clk,

--- a/drivers/ipm/ipm_cavs_idc.c
+++ b/drivers/ipm/ipm_cavs_idc.c
@@ -188,7 +188,7 @@ static int cavs_idc_set_enabled(const struct device *dev, int enable)
 		idc_write(IPC_IDCCTL, i, mask);
 
 		/* FIXME: when we have API to enable IRQ on specific core. */
-		sys_set_bit(DT_REG_ADDR(DT_NODELABEL(cavs0)) + 0x04 +
+		sys_set_bit(DT_REG_ADDR(DT_NODELABEL(cavs_intc0)) + 0x04 +
 			    CAVS_ICTL_INT_CPU_OFFSET(i),
 			    CAVS_IRQ_NUMBER(DT_INST_IRQN(0)));
 	}

--- a/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
+++ b/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
@@ -1,42 +1,42 @@
 # Copyright (c) 2022 Intel Corporation. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-description: Intel cAVS clock controlling related constants.
+description: Intel ADSP clock controlling related constants.
 
 compatible: "intel,adsp-shim-clkctl"
 
 properties:
-    cavs-clkctl-clk-wovcro:
+    adsp-clkctl-clk-wovcro:
         type: int
         required: false
         description: Index of WOVCRO clock encoding in the encoding array (if wovcro-supported is true).
 
-    cavs-clkctl-clk-lpro:
+    adsp-clkctl-clk-lpro:
         type: int
         required: false
         description: Index of LPRO clock encoding in the encoding array.
 
-    cavs-clkctl-clk-hpro:
+    adsp-clkctl-clk-hpro:
         type: int
         required: false
         description: Index of HPRO clock encoding in the encoding array.
 
-    cavs-clkctl-freq-enc:
+    adsp-clkctl-freq-enc:
         type: array
         required: true
         description: Array that encodes what is needed to enable each clock.
 
-    cavs-clkctl-freq-mask:
+    adsp-clkctl-freq-mask:
         type: array
         required: false
         description: Array that encodes needed masks to enable each clock.
 
-    cavs-clkctl-freq-default:
+    adsp-clkctl-freq-default:
         type: int
         required: true
         description: Index for the default clock.
 
-    cavs-clkctl-freq-lowest:
+    adsp-clkctl-freq-lowest:
         type: int
         required: true
         description: Index for the lowest frequency clock.

--- a/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
+++ b/dts/bindings/clock/intel,adsp-shim-clkctl.yaml
@@ -3,7 +3,7 @@
 
 description: Intel cAVS clock controlling related constants.
 
-compatible: "intel,cavs-shim-clkctl"
+compatible: "intel,adsp-shim-clkctl"
 
 properties:
     cavs-clkctl-clk-wovcro:

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -143,7 +143,7 @@
 		};
 
 		shim: shim@71f00 {
-			compatible = "intel,cavs-shim";
+			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;
 		};
 

--- a/dts/xtensa/intel/intel_adsp_cavs.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs.dtsi
@@ -14,7 +14,7 @@
 			reg = <0x0007c000 0x1000>;
 			shim = <0x00078400 0x100>;
 			interrupts = <0x10 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 
 			status = "okay";
 		};
@@ -25,7 +25,7 @@
 			reg = <0x0007d000 0x1000>;
 			shim = <0x00078500 0x100>;
 			interrupts = <0x0F 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 
 			status = "okay";
 		};

--- a/dts/xtensa/intel/intel_adsp_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs15.dtsi
@@ -55,11 +55,11 @@
 
 	clkctl: clkctl {
 		compatible = "intel,adsp-shim-clkctl";
-		cavs-clkctl-clk-lpro = <0>;
-		cavs-clkctl-clk-hpro = <2>;
-		cavs-clkctl-freq-enc = <0x3 0x1 0x0>;
-		cavs-clkctl-freq-default = <1>;
-		cavs-clkctl-freq-lowest = <0>;
+		adsp-clkctl-clk-lpro = <0>;
+		adsp-clkctl-clk-hpro = <2>;
+		adsp-clkctl-freq-enc = <0x3 0x1 0x0>;
+		adsp-clkctl-freq-default = <1>;
+		adsp-clkctl-freq-lowest = <0>;
 	};
 
 	soc {

--- a/dts/xtensa/intel/intel_adsp_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs15.dtsi
@@ -54,7 +54,7 @@
 	};
 
 	clkctl: clkctl {
-		compatible = "intel,cavs-shim-clkctl";
+		compatible = "intel,adsp-shim-clkctl";
 		cavs-clkctl-clk-lpro = <0>;
 		cavs-clkctl-clk-hpro = <2>;
 		cavs-clkctl-freq-enc = <0x3 0x1 0x0>;
@@ -64,7 +64,7 @@
 
 	soc {
 		shim: shim@1000 {
-			compatible = "intel,cavs-shim";
+			compatible = "intel,adsp-shim";
 			reg = <0x1000 0x100>;
 		};
 
@@ -89,10 +89,10 @@
 			compatible = "intel,adsp-host-ipc";
 			reg = <0x1180 0x30>;
 			interrupts = <7 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
-		cavs0: cavs@1600  {
+		cavs_intc0: cavs@1600  {
 			compatible = "intel,cavs-intc";
 			reg = <0x1600 0x10>;
 			interrupt-controller;
@@ -101,7 +101,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs1: cavs@1610  {
+		cavs_intc1: cavs@1610  {
 			compatible = "intel,cavs-intc";
 			reg = <0x1610 0x10>;
 			interrupt-controller;
@@ -110,7 +110,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs2: cavs@1620  {
+		cavs_intc2: cavs@1620  {
 			compatible = "intel,cavs-intc";
 			reg = <0x1620 0x10>;
 			interrupt-controller;
@@ -119,7 +119,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs3: cavs@1630  {
+		cavs_intc3: cavs@1630  {
 			compatible = "intel,cavs-intc";
 			reg = <0x1630 0x10>;
 			interrupt-controller;
@@ -132,7 +132,7 @@
 			compatible = "intel,adsp-idc";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
 		lpgpdma0: dma@c000 {
@@ -141,7 +141,7 @@
 			reg = <0x0000c000 0x1000>;
 			shim = <0x00000c00 0x080>;
 			interrupts = <0x10 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 
 			status = "okay";
 		};
@@ -152,7 +152,7 @@
 			reg = <0x0000d000 0x1000>;
 			shim = <0x00000c80 0x080>;
 			interrupts = <0x0F 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 
 			status = "okay";
 		};
@@ -204,7 +204,7 @@
 			reg = <0x00008000 0x200
 			       0x00008E00 0x008>;
 			interrupts = <0x01 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
@@ -219,7 +219,7 @@
 			reg = <0x00008200 0x200
 			       0x00008E00 0x008>;
 			interrupts = <0x01 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
@@ -234,7 +234,7 @@
 			reg = <0x00008400 0x200
 			       0x00008E00 0x008>;
 			interrupts = <0x02 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
@@ -249,7 +249,7 @@
 			reg = <0x00008600 0x200
 			       0x00008E00 0x008>;
 			interrupts = <0x03 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 8
 				&lpgpdma0 9>;
 			dma-names = "tx", "rx";
@@ -264,7 +264,7 @@
 			reg = <0x00008800 0x200
 			       0x00008E00 0x008>;
 			interrupts = <0x03 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 10
 				&lpgpdma0 11>;
 			dma-names = "tx", "rx";
@@ -279,7 +279,7 @@
 			reg = <0x00008A00 0x200
 			       0x00008E00 0x008>;
 			interrupts = <0x03 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 12
 				&lpgpdma0 13>;
 			dma-names = "tx", "rx";

--- a/dts/xtensa/intel/intel_adsp_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs18.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/intel/intel_cavs.dtsi>
+#include <xtensa/intel/intel_adsp_cavs.dtsi>
 #include <mem.h>
 
 / {
@@ -50,7 +50,7 @@
 	};
 
 	clkctl: clkctl {
-		compatible = "intel,cavs-shim-clkctl";
+		compatible = "intel,adsp-shim-clkctl";
 		cavs-clkctl-clk-lpro = <0>;
 		cavs-clkctl-clk-hpro = <1>;
 		cavs-clkctl-freq-enc = <0x20000002 0x80000006>;
@@ -61,7 +61,7 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,cavs-shim";
+			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;
 		};
 
@@ -86,10 +86,10 @@
 			compatible = "intel,adsp-host-ipc";
 			reg = <0x71e00 0x30>;
 			interrupts = <7 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
-		cavs0: cavs@78800  {
+		cavs_intc0: cavs@78800  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78800 0x10>;
 			interrupt-controller;
@@ -98,7 +98,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs1: cavs@78810  {
+		cavs_intc1: cavs@78810  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78810 0x10>;
 			interrupt-controller;
@@ -107,7 +107,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs2: cavs@78820  {
+		cavs_intc2: cavs@78820  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78820 0x10>;
 			interrupt-controller;
@@ -116,7 +116,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs3: cavs@78830  {
+		cavs_intc3: cavs@78830  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78830 0x10>;
 			interrupt-controller;
@@ -129,7 +129,7 @@
 			compatible = "intel,adsp-idc";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 	};
 };

--- a/dts/xtensa/intel/intel_adsp_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs18.dtsi
@@ -51,12 +51,12 @@
 
 	clkctl: clkctl {
 		compatible = "intel,adsp-shim-clkctl";
-		cavs-clkctl-clk-lpro = <0>;
-		cavs-clkctl-clk-hpro = <1>;
-		cavs-clkctl-freq-enc = <0x20000002 0x80000006>;
-		cavs-clkctl-freq-mask = <0x20000000 0x80000000>;
-		cavs-clkctl-freq-default = <1>;
-		cavs-clkctl-freq-lowest = <0>;
+		adsp-clkctl-clk-lpro = <0>;
+		adsp-clkctl-clk-hpro = <1>;
+		adsp-clkctl-freq-enc = <0x20000002 0x80000006>;
+		adsp-clkctl-freq-mask = <0x20000000 0x80000000>;
+		adsp-clkctl-freq-default = <1>;
+		adsp-clkctl-freq-lowest = <0>;
 	};
 
 	soc {

--- a/dts/xtensa/intel/intel_adsp_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs20.dtsi
@@ -51,12 +51,12 @@
 
 	clkctl: clkctl {
 		compatible = "intel,adsp-shim-clkctl";
-		cavs-clkctl-clk-lpro = <0>;
-		cavs-clkctl-clk-hpro = <1>;
-		cavs-clkctl-freq-enc = <0x20000002 0x80000006>;
-		cavs-clkctl-freq-mask = <0x20000000 0x80000000>;
-		cavs-clkctl-freq-default = <1>;
-		cavs-clkctl-freq-lowest = <0>;
+		adsp-clkctl-clk-lpro = <0>;
+		adsp-clkctl-clk-hpro = <1>;
+		adsp-clkctl-freq-enc = <0x20000002 0x80000006>;
+		adsp-clkctl-freq-mask = <0x20000000 0x80000000>;
+		adsp-clkctl-freq-default = <1>;
+		adsp-clkctl-freq-lowest = <0>;
 	};
 
 	soc {

--- a/dts/xtensa/intel/intel_adsp_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs20.dtsi
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2019,2022 Intel Corporation
+ * Copyright (c) 2019 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/intel/intel_cavs.dtsi>
+#include <xtensa/intel/intel_adsp_cavs.dtsi>
 #include <mem.h>
 
 / {
@@ -23,12 +23,24 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 		};
+
+		cpu2: cpu@2 {
+			device_type = "cpu";
+			compatible = "cdns,tensilica-xtensa-lx6";
+			reg = <2>;
+		};
+
+		cpu3: cpu@3 {
+			device_type = "cpu";
+			compatible = "cdns,tensilica-xtensa-lx6";
+			reg = <3>;
+		};
 	};
 
 	sram0: memory@be000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0xbe000000 DT_SIZE_K(1920)>;
+		reg = <0xbe000000 DT_SIZE_K(3008)>;
 	};
 
 	sram1: memory@be800000 {
@@ -37,9 +49,19 @@
 		reg = <0xbe800000 DT_SIZE_K(64)>;
 	};
 
+	clkctl: clkctl {
+		compatible = "intel,adsp-shim-clkctl";
+		cavs-clkctl-clk-lpro = <0>;
+		cavs-clkctl-clk-hpro = <1>;
+		cavs-clkctl-freq-enc = <0x20000002 0x80000006>;
+		cavs-clkctl-freq-mask = <0x20000000 0x80000000>;
+		cavs-clkctl-freq-default = <1>;
+		cavs-clkctl-freq-lowest = <0>;
+	};
+
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,cavs-shim";
+			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;
 		};
 
@@ -60,7 +82,14 @@
 			#interrupt-cells = <3>;
 		};
 
-		cavs0: cavs@78800  {
+		adsp_host_ipc: cavs_host_ipc@71e00 {
+			compatible = "intel,adsp-host-ipc";
+			reg = <0x71e00 0x30>;
+			interrupts = <7 0 0>;
+			interrupt-parent = <&cavs_intc0>;
+		};
+
+		cavs_intc0: cavs@78800  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78800 0x10>;
 			interrupt-controller;
@@ -69,7 +98,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs1: cavs@78810  {
+		cavs_intc1: cavs@78810  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78810 0x10>;
 			interrupt-controller;
@@ -78,7 +107,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs2: cavs@78820  {
+		cavs_intc2: cavs@78820  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78820 0x10>;
 			interrupt-controller;
@@ -87,7 +116,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs3: cavs@78830  {
+		cavs_intc3: cavs@78830  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78830 0x10>;
 			interrupt-controller;
@@ -100,13 +129,8 @@
 			compatible = "intel,adsp-idc";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
-		tlb: tlb@3000 {
-			compatible = "intel,adsp-tlb";
-			reg = <0x3000 0x1000>;
-			paddr-size = <11>;
-		};
 	};
 };

--- a/dts/xtensa/intel/intel_adsp_cavs20_jsl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs20_jsl.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/intel/intel_cavs.dtsi>
+#include <xtensa/intel/intel_adsp_cavs.dtsi>
 #include <mem.h>
 
 / {
@@ -24,23 +24,12 @@
 			reg = <1>;
 		};
 
-		cpu2: cpu@2 {
-			device_type = "cpu";
-			compatible = "cdns,tensilica-xtensa-lx6";
-			reg = <2>;
-		};
-
-		cpu3: cpu@3 {
-			device_type = "cpu";
-			compatible = "cdns,tensilica-xtensa-lx6";
-			reg = <3>;
-		};
 	};
 
 	sram0: memory@be000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0xbe000000 DT_SIZE_K(3008)>;
+		reg = <0xbe000000 DT_SIZE_K(1024)>;
 	};
 
 	sram1: memory@be800000 {
@@ -49,19 +38,9 @@
 		reg = <0xbe800000 DT_SIZE_K(64)>;
 	};
 
-	clkctl: clkctl {
-		compatible = "intel,cavs-shim-clkctl";
-		cavs-clkctl-clk-lpro = <0>;
-		cavs-clkctl-clk-hpro = <1>;
-		cavs-clkctl-freq-enc = <0x20000002 0x80000006>;
-		cavs-clkctl-freq-mask = <0x20000000 0x80000000>;
-		cavs-clkctl-freq-default = <1>;
-		cavs-clkctl-freq-lowest = <0>;
-	};
-
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,cavs-shim";
+			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;
 		};
 
@@ -86,10 +65,10 @@
 			compatible = "intel,adsp-host-ipc";
 			reg = <0x71e00 0x30>;
 			interrupts = <7 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
-		cavs0: cavs@78800  {
+		cavs_intc0: cavs@78800  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78800 0x10>;
 			interrupt-controller;
@@ -98,7 +77,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs1: cavs@78810  {
+		cavs_intc1: cavs@78810  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78810 0x10>;
 			interrupt-controller;
@@ -107,7 +86,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs2: cavs@78820  {
+		cavs_intc2: cavs@78820  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78820 0x10>;
 			interrupt-controller;
@@ -116,7 +95,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs3: cavs@78830  {
+		cavs_intc3: cavs@78830  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78830 0x10>;
 			interrupt-controller;
@@ -129,7 +108,7 @@
 			compatible = "intel,adsp-idc";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
 	};

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -69,13 +69,13 @@
 
 	clkctl: clkctl {
 		compatible = "intel,adsp-shim-clkctl";
-		cavs-clkctl-clk-wovcro = <0>;
-		cavs-clkctl-clk-lpro = <1>;
-		cavs-clkctl-clk-hpro = <2>;
-		cavs-clkctl-freq-enc = <0x1a 0x20000002 0x80000002>;
-		cavs-clkctl-freq-mask = <0x10 0x20000000 0x80000000>;
-		cavs-clkctl-freq-default = <2>;
-		cavs-clkctl-freq-lowest = <0>;
+		adsp-clkctl-clk-wovcro = <0>;
+		adsp-clkctl-clk-lpro = <1>;
+		adsp-clkctl-clk-hpro = <2>;
+		adsp-clkctl-freq-enc = <0x1a 0x20000002 0x80000002>;
+		adsp-clkctl-freq-mask = <0x10 0x20000000 0x80000000>;
+		adsp-clkctl-freq-default = <2>;
+		adsp-clkctl-freq-lowest = <0>;
 		wovcro-supported;
 	};
 

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/intel/intel_cavs.dtsi>
+#include <xtensa/intel/intel_adsp_cavs.dtsi>
 #include <mem.h>
 
 / {
@@ -68,7 +68,7 @@
 	};
 
 	clkctl: clkctl {
-		compatible = "intel,cavs-shim-clkctl";
+		compatible = "intel,adsp-shim-clkctl";
 		cavs-clkctl-clk-wovcro = <0>;
 		cavs-clkctl-clk-lpro = <1>;
 		cavs-clkctl-clk-hpro = <2>;
@@ -81,7 +81,7 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,cavs-shim";
+			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;
 		};
 
@@ -111,10 +111,10 @@
 			compatible = "intel,adsp-host-ipc";
 			reg = <0x71e00 0x30>;
 			interrupts = <7 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
-		cavs0: cavs@78800  {
+		cavs_intc0: cavs@78800  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78800 0x10>;
 			interrupt-controller;
@@ -123,7 +123,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs1: cavs@78810  {
+		cavs_intc1: cavs@78810  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78810 0x10>;
 			interrupt-controller;
@@ -132,7 +132,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs2: cavs@78820  {
+		cavs_intc2: cavs@78820  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78820 0x10>;
 			interrupt-controller;
@@ -141,7 +141,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs3: cavs@78830  {
+		cavs_intc3: cavs@78830  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78830 0x10>;
 			interrupt-controller;
@@ -154,7 +154,7 @@
 			compatible = "intel,adsp-idc";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
 		tlb: tlb@3000 {
@@ -170,7 +170,7 @@
 			reg = <0x00077000 0x200
 			       0x00078C00 0x008>;
 			interrupts = <0x01 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 2
 				&lpgpdma0 3>;
 			dma-names = "tx", "rx";
@@ -185,7 +185,7 @@
 			reg = <0x00077200 0x200
 			       0x00078C00 0x008>;
 			interrupts = <0x01 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 4
 				&lpgpdma0 5>;
 			dma-names = "tx", "rx";
@@ -200,7 +200,7 @@
 			reg = <0x00077400 0x200
 			       0x00078C00 0x008>;
 			interrupts = <0x02 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 6
 				&lpgpdma0 7>;
 			dma-names = "tx", "rx";
@@ -215,7 +215,7 @@
 			reg = <0x00077600 0x200
 			       0x00078C00 0x008>;
 			interrupts = <0x03 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 8
 				&lpgpdma0 9>;
 			dma-names = "tx", "rx";
@@ -230,7 +230,7 @@
 			reg = <0x00077800 0x200
 			       0x00078C00 0x008>;
 			interrupts = <0x03 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 10
 				&lpgpdma0 11>;
 			dma-names = "tx", "rx";
@@ -245,7 +245,7 @@
 			reg = <0x00077A00 0x200
 			       0x00078C00 0x008>;
 			interrupts = <0x03 0 0>;
-			interrupt-parent = <&cavs3>;
+			interrupt-parent = <&cavs_intc3>;
 			dmas = <&lpgpdma0 12
 				&lpgpdma0 13>;
 			dma-names = "tx", "rx";

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -1,10 +1,10 @@
 /*
- * Copyright (c) 2019 Intel Corporation
+ * Copyright (c) 2019,2022 Intel Corporation
  *
  * SPDX-License-Identifier: Apache-2.0
  */
 
-#include <xtensa/intel/intel_cavs.dtsi>
+#include <xtensa/intel/intel_adsp_cavs.dtsi>
 #include <mem.h>
 
 / {
@@ -23,13 +23,12 @@
 			compatible = "cdns,tensilica-xtensa-lx6";
 			reg = <1>;
 		};
-
 	};
 
 	sram0: memory@be000000 {
 		device_type = "memory";
 		compatible = "mmio-sram";
-		reg = <0xbe000000 DT_SIZE_K(1024)>;
+		reg = <0xbe000000 DT_SIZE_K(1920)>;
 	};
 
 	sram1: memory@be800000 {
@@ -40,7 +39,7 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,cavs-shim";
+			compatible = "intel,adsp-shim";
 			reg = <0x71f00 0x100>;
 		};
 
@@ -61,14 +60,7 @@
 			#interrupt-cells = <3>;
 		};
 
-		adsp_host_ipc: cavs_host_ipc@71e00 {
-			compatible = "intel,adsp-host-ipc";
-			reg = <0x71e00 0x30>;
-			interrupts = <7 0 0>;
-			interrupt-parent = <&cavs0>;
-		};
-
-		cavs0: cavs@78800  {
+		cavs_intc0: cavs@78800  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78800 0x10>;
 			interrupt-controller;
@@ -77,7 +69,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs1: cavs@78810  {
+		cavs_intc1: cavs@78810  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78810 0x10>;
 			interrupt-controller;
@@ -86,7 +78,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs2: cavs@78820  {
+		cavs_intc2: cavs@78820  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78820 0x10>;
 			interrupt-controller;
@@ -95,7 +87,7 @@
 			interrupt-parent = <&core_intc>;
 		};
 
-		cavs3: cavs@78830  {
+		cavs_intc3: cavs@78830  {
 			compatible = "intel,cavs-intc";
 			reg = <0x78830 0x10>;
 			interrupt-controller;
@@ -108,8 +100,13 @@
 			compatible = "intel,adsp-idc";
 			reg = <0x1200 0x80>;
 			interrupts = <8 0 0>;
-			interrupt-parent = <&cavs0>;
+			interrupt-parent = <&cavs_intc0>;
 		};
 
+		tlb: tlb@3000 {
+			compatible = "intel,adsp-tlb";
+			reg = <0x3000 0x1000>;
+			paddr-size = <11>;
+		};
 	};
 };

--- a/include/zephyr/drivers/clock_control/clock_control_adsp.h
+++ b/include/zephyr/drivers/clock_control/clock_control_adsp.h
@@ -6,6 +6,6 @@
 #ifndef CLOCK_CONTROL_ADSP_H_
 #define CLOCK_CONTROL_ADSP_H_
 
-#include <cavs-clk.h>
+#include <adsp-clk.h>
 
 #endif /* CLOCK_CONTROL_ADSP_H_ */

--- a/include/zephyr/drivers/clock_control/clock_control_cavs.h
+++ b/include/zephyr/drivers/clock_control/clock_control_cavs.h
@@ -3,9 +3,9 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-#ifndef CLOCK_CONTROL_CAVS_H_
-#define CLOCK_CONTROL_CAVS_H_
+#ifndef CLOCK_CONTROL_ADSP_H_
+#define CLOCK_CONTROL_ADSP_H_
 
 #include <cavs-clk.h>
 
-#endif /* CLOCK_CONTROL_CAVS_H_ */
+#endif /* CLOCK_CONTROL_ADSP_H_ */

--- a/soc/xtensa/intel_adsp/Kconfig
+++ b/soc/xtensa/intel_adsp/Kconfig
@@ -28,7 +28,7 @@ config INTEL_ADSP_IPC
 	  Driver for the host IPC interrupt delivery mechanism.
 	  Currently SOF has its own driver for this hardware.
 
-config CAVS_CLOCK
+config ADSP_CLOCK
 	bool
 	help
 	  Driver for the CAVS clocks. Allow type of clock (and

--- a/soc/xtensa/intel_adsp/cavs/power.c
+++ b/soc/xtensa/intel_adsp/cavs/power.c
@@ -11,7 +11,7 @@
 #include <zephyr/init.h>
 
 #include <adsp_shim.h>
-#include <cavs-clk.h>
+#include <adsp-clk.h>
 #include <cavs-idc.h>
 #include "soc.h"
 

--- a/soc/xtensa/intel_adsp/common/CMakeLists.txt
+++ b/soc/xtensa/intel_adsp/common/CMakeLists.txt
@@ -18,7 +18,7 @@ zephyr_library_sources(
     soc.c
     )
 
-zephyr_library_sources_ifdef(CONFIG_CAVS_CLOCK clk.c)
+zephyr_library_sources_ifdef(CONFIG_ADSP_CLOCK clk.c)
 
 if(CONFIG_SMP OR CONFIG_MP_NUM_CPUS GREATER 1)
   zephyr_library_sources(multiprocessing.c)

--- a/soc/xtensa/intel_adsp/common/clk.c
+++ b/soc/xtensa/intel_adsp/common/clk.c
@@ -5,7 +5,7 @@
  */
 #include <zephyr/device.h>
 
-#include <cavs-clk.h>
+#include <adsp-clk.h>
 #include <adsp_shim.h>
 
 static struct cavs_clock_info platform_clocks[CONFIG_MP_NUM_CPUS];

--- a/soc/xtensa/intel_adsp/common/include/adsp-clk.h
+++ b/soc/xtensa/intel_adsp/common/include/adsp-clk.h
@@ -38,14 +38,14 @@ struct cavs_clock_info *cavs_clocks_get(void);
 #define CAVS_SHIM_BASE          DT_REG_ADDR(DT_NODELABEL(shim))
 #define CAVS_SHIM_CLKCTL        (*((volatile uint32_t *)(CAVS_SHIM_BASE + 0x78)))
 
-#define CAVS_CLOCK_FREQ_ENC     DT_PROP(DT_NODELABEL(clkctl), cavs_clkctl_freq_enc)
-#define CAVS_CLOCK_FREQ_MASK    DT_PROP(DT_NODELABEL(clkctl), cavs_clkctl_freq_mask)
-#define CAVS_CLOCK_FREQ_LEN     DT_PROP_LEN(DT_NODELABEL(clkctl), cavs_clkctl_freq_enc)
+#define CAVS_CLOCK_FREQ_ENC     DT_PROP(DT_NODELABEL(clkctl), adsp_clkctl_freq_enc)
+#define CAVS_CLOCK_FREQ_MASK    DT_PROP(DT_NODELABEL(clkctl), adsp_clkctl_freq_mask)
+#define CAVS_CLOCK_FREQ_LEN     DT_PROP_LEN(DT_NODELABEL(clkctl), adsp_clkctl_freq_enc)
 
-#define CAVS_CLOCK_FREQ_DEFAULT DT_PROP(DT_NODELABEL(clkctl), cavs_clkctl_freq_default)
-#define CAVS_CLOCK_FREQ_LOWEST  DT_PROP(DT_NODELABEL(clkctl), cavs_clkctl_freq_lowest)
+#define CAVS_CLOCK_FREQ_DEFAULT DT_PROP(DT_NODELABEL(clkctl), adsp_clkctl_freq_default)
+#define CAVS_CLOCK_FREQ_LOWEST  DT_PROP(DT_NODELABEL(clkctl), adsp_clkctl_freq_lowest)
 
-#define CAVS_CLOCK_FREQ(name)   DT_PROP(DT_NODELABEL(clkctl), cavs_clkctl_clk_##name)
+#define CAVS_CLOCK_FREQ(name)   DT_PROP(DT_NODELABEL(clkctl), adsp_clkctl_clk_##name)
 
 #if DT_PROP(DT_NODELABEL(clkctl), wovcro_supported)
 #define CAVS_CLOCK_HAS_WOVCRO

--- a/soc/xtensa/intel_adsp/common/include/cavs-idc.h
+++ b/soc/xtensa/intel_adsp/common/include/cavs-idc.h
@@ -145,6 +145,6 @@ struct cavs_intctrl {
 #define CAVS_L5_I2S(n)     BIT(n)	/* I2S */
 
 #define CAVS_INTCTRL \
-	((volatile struct cavs_intctrl *)DT_REG_ADDR(DT_NODELABEL(cavs0)))
+	((volatile struct cavs_intctrl *)DT_REG_ADDR(DT_NODELABEL(cavs_intc0)))
 
 #endif /* ZEPHYR_SOC_INTEL_ADSP_CAVS_IDC_H_ */

--- a/soc/xtensa/intel_adsp/common/soc.c
+++ b/soc/xtensa/intel_adsp/common/soc.c
@@ -16,7 +16,7 @@ static __imr int soc_init(const struct device *dev)
 {
 	power_init();
 
-#ifdef CONFIG_CAVS_CLOCK
+#ifdef CONFIG_ADSP_CLOCK
 	cavs_clock_init();
 #endif
 

--- a/tests/drivers/clock_control/cavs_clock/src/main.c
+++ b/tests/drivers/clock_control/cavs_clock/src/main.c
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 #include <zephyr/ztest.h>
-#include <zephyr/drivers/clock_control/clock_control_cavs.h>
+#include <zephyr/drivers/clock_control/clock_control_adsp.h>
 #include <zephyr/drivers/clock_control.h>
 
 static void check_clocks(struct cavs_clock_info *clocks, uint32_t freq_idx)


### PR DESCRIPTION
Fixes namespace for Intel ADSP CAVS and ACE boards.

(First PR in series of cleanups, trying to keep it modular)