### PR TITLE
Kconfig: fix "flag LEGACY_INCLUDE_PATH as deprecated"

### DIFF
--- a/Kconfig.zephyr
+++ b/Kconfig.zephyr
@@ -848,6 +848,7 @@ endmenu
 
 config LEGACY_INCLUDE_PATH
 	bool "Allow for the legacy include paths (without the zephyr/ prefix) (DEPRECATED)"
+	select DEPRECATED
 	help
 	  DEPRECATED: Allow applications and libraries to use the Zephyr legacy
 	  include path which does not use the zephyr/ prefix. For example, the


### PR DESCRIPTION
Commit cd7c44a152bc4469ad7da9e38d58df46655d460d
("Kconfig: flag LEGACY_INCLUDE_PATH as deprecated") forgot to select
DEPRECATED when deprecating a Kconfig option. Fix it.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>