### PR TITLE
drivers: entropy: fail mcux CAAM init on error

### DIFF
--- a/drivers/entropy/entropy_mcux_caam.c
+++ b/drivers/entropy/entropy_mcux_caam.c
@@ -57,6 +57,10 @@ static int entropy_mcux_caam_init(const struct device *dev)
 	status = CAAM_Init(config->base, &conf);
 	__ASSERT_NO_MSG(!status);
 
+	if (status != 0) {
+		return -ENODEV;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
Commit d556a0c8a6699cc430ff2464b612a1ea9d25e948
("drivers: entropy: Add entropy driver for MCUX CAAM")
added a shim entropy driver whose initialization function
always returns 0, even when the underlying HAL API fails.

This is wrong; if the device initialization function fails, it
must return nonzero by contract. Papering this over with an
assert is not enough. Fix it by returning -ENODEV on error.

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>