### PR TITLE
doc: zephyr_cmake_package: fix obsolete text

### DIFF
--- a/doc/build/zephyr_cmake_package.rst
+++ b/doc/build/zephyr_cmake_package.rst
@@ -55,6 +55,7 @@ Zephyr CMake package export (west)
 When installing Zephyr using :ref:`west <get_the_code>` then it is recommended
 to export Zephyr using ``west zephyr-export``.
 
+.. _zephyr_cmake_package_export:
 
 Zephyr CMake package export (without west)
 ******************************************
@@ -422,16 +423,13 @@ Zephyr CMake package source code
 ********************************
 
 The Zephyr CMake package source code in
-``<PATH-TO-ZEPHYR>/share/zephyr-package/cmake`` contains the CMake config package
-which is used by CMake ``find_package`` function.
+:zephyr_file:`share/zephyr-package/cmake` and
+:zephyr_file:`share/zephyrunittest-package/cmake` contains the CMake config
+package which is used by the CMake ``find_package`` function.
 
 It also contains code for exporting Zephyr as a CMake config package.
 
-The following is an overview of those files
-
-:file:`CMakeLists.txt`
-    The CMakeLists.txt file for the CMake build system which is responsible for
-    exporting Zephyr as a package to the CMake user package registry.
+The following is an overview of the files in these directories:
 
 :file:`ZephyrConfigVersion.cmake`
     The Zephyr package version file. This file is called by CMake to determine
@@ -457,9 +455,8 @@ The following is an overview of those files
    Common file used for detection of Zephyr repository and workspace candidates.
    Used by ``ZephyrConfigVersion.cmake`` and ``ZephyrConfig.cmake`` for common code.
 
-:file:`pristine.cmake`
-   Pristine file for removing all files created by CMake during configure and generator time when
-   exporting Zephyr CMake package. Running pristine keeps all package related files mentioned above.
+:file:`zephyr_export.cmake`
+   See :ref:`zephyr_cmake_package_export`.
 
 .. _CMake package: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html
 .. _CMake user package registry: https://cmake.org/cmake/help/latest/manual/cmake-packages.7.html#user-package-registry


### PR DESCRIPTION
Update the documentation on the files in the two zephyr cmake packages
we have in tree to remove references to obsolete files, and add
references to missing files.

Fixes: #48047

Signed-off-by: Martí Bolívar <marti.bolivar@nordicsemi.no>