### PR TITLE
devicetree: remove label references from header docs

### DIFF
--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -545,7 +545,7 @@
  * A property's type is usually defined by its binding. In some
  * special cases, it has an assumed type defined by the devicetree
  * specification even when no binding is available: "compatible" has
- * type string-array, "status" and "label" have type string, and
+ * type string-array, "status" has type string, and
  * "interrupt-controller" has type boolean.
  *
  * For other properties or properties with unknown type due to a
@@ -1168,11 +1168,11 @@
  * Example devicetree fragment:
  *
  *     adc1: adc@... {
- *             label = "ADC_1";
+ *             foobar = "ADC_1";
  *     };
  *
  *     adc2: adc@... {
- *             label = "ADC_2";
+ *             foobar = "ADC_2";
  *     };
  *
  *     n: node {
@@ -1189,8 +1189,8 @@
  *
  *     #define NODE DT_NODELABEL(n)
  *
- *     DT_LABEL(DT_PHANDLE_BY_NAME(NODE, io_channels, sensor))  // "ADC_1"
- *     DT_LABEL(DT_PHANDLE_BY_NAME(NODE, io_channels, bandgap)) // "ADC_2"
+ *     DT_PROP(DT_PHANDLE_BY_NAME(NODE, io_channels, sensor), foobar)  // "ADC_1"
+ *     DT_PROP(DT_PHANDLE_BY_NAME(NODE, io_channels, bandgap), foobar) // "ADC_2"
  *
  * Notice how devicetree properties and names are lowercased, and
  * non-alphanumeric characters are converted to underscores.
@@ -1926,24 +1926,24 @@
  *
  *     n: node {
  *             child-1 {
- *                     label = "foo";
+ *                     foobar = "foo";
  *             };
  *             child-2 {
- *                     label = "bar";
+ *                     foobar = "bar";
  *             };
  *     };
  *
  * Example usage:
  *
- *     #define LABEL_AND_COMMA(node_id) DT_LABEL(node_id),
+ *     #define FOOBAR_AND_COMMA(node_id) DT_PROP(node_id, foobar),
  *
- *     const char *child_labels[] = {
- *         DT_FOREACH_CHILD(DT_NODELABEL(n), LABEL_AND_COMMA)
+ *     const char *child_foobars[] = {
+ *         DT_FOREACH_CHILD(DT_NODELABEL(n), FOOBAR_AND_COMMA)
  *     };
  *
  * This expands to:
  *
- *     const char *child_labels[] = {
+ *     const char *child_foobars[] = {
  *         "foo", "bar",
  *     };
  *
@@ -2366,7 +2366,6 @@
  * Example devicetree fragment:
  *
  *     i2c@deadbeef {
- *             label = "I2C_CTLR";
  *             status = "okay";
  *             clock-frequency = < 100000 >;
  *
@@ -2891,25 +2890,25 @@
  *     a {
  *             compatible = "vnd,device";
  *             status = "okay";
- *             label = "DEV_A";
+ *             foobar = "DEV_A";
  *     };
  *
  *     b {
  *             compatible = "vnd,device";
  *             status = "okay";
- *             label = "DEV_B";
+ *             foobar = "DEV_B";
  *     };
  *
  *     c {
  *             compatible = "vnd,device";
  *             status = "disabled";
- *             label = "DEV_C";
+ *             foobar = "DEV_C";
  *     };
  *
  * Example usage:
  *
  *     #define DT_DRV_COMPAT vnd_device
- *     #define MY_FN(inst) DT_INST_LABEL(inst),
+ *     #define MY_FN(inst) DT_INST_PROP(inst, foobar),
  *
  *     DT_INST_FOREACH_STATUS_OKAY(MY_FN)
  *

--- a/include/zephyr/devicetree/pwms.h
+++ b/include/zephyr/devicetree/pwms.h
@@ -97,13 +97,11 @@ extern "C" {
  *
  *     pwm1: pwm-controller@... {
  *             compatible = "vnd,pwm";
- *             label = "PWM_1";
  *             #pwm-cells = <2>;
  *     };
  *
  *     pwm2: pwm-controller@... {
  *             compatible = "vnd,pwm";
- *             label = "PWM_2";
  *             #pwm-cells = <2>;
  *     };
  *
@@ -144,13 +142,11 @@ extern "C" {
  *
  *     pwm1: pwm-controller@... {
  *             compatible = "vnd,pwm";
- *             label = "PWM_1";
  *             #pwm-cells = <2>;
  *     };
  *
  *     pwm2: pwm-controller@... {
  *             compatible = "vnd,pwm";
- *             label = "PWM_2";
  *             #pwm-cells = <2>;
  *     };
  *


### PR DESCRIPTION
As the label property has been removed from the majority of devicetrees
replace the examples and docs that utilize label.

Signed-off-by: Kumar Gala <galak@kernel.org>