### PR TITLE
devicetree: deprecate DT_LABEL

### DIFF
--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -67,6 +67,9 @@ Deprecated in this release
   :c:macro:`DT_GPIO_LABEL_BY_IDX`, and :c:macro:`DT_INST_GPIO_LABEL_BY_IDX`,
   are deprecated in favor of utilizing :c:macro:`DT_GPIO_CTLR` and variants.
 
+* :c:macro:`DT_LABEL`, and :c:macro:`DT_INST_LABEL`, are deprecated
+  in favor of utilizing :c:macro:`DT_PROP` and variants.
+
 * :c:macro:`DT_BUS_LABEL`, and :c:macro:`DT_INST_BUS_LABEL`, are deprecated
   in favor of utilizing :c:macro:`DT_BUS` and variants.
 

--- a/drivers/led/lp503x.c
+++ b/drivers/led/lp503x.c
@@ -235,7 +235,7 @@ const uint8_t color_mapping_##led_node_id[] =			\
 
 #define LED_INFO(led_node_id)					\
 {								\
-	.label		= DT_LABEL(led_node_id),		\
+	.label		= DT_PROP(led_node_id, label),		\
 	.index		= DT_PROP(led_node_id, index),		\
 	.num_colors	=					\
 		DT_PROP_LEN(led_node_id, color_mapping),	\

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -704,6 +704,7 @@
 		    (DT_PROP(node_id, prop)), (default_value))
 
 /**
+ * @deprecated Use DT_PROP(node_id, label)
  * @brief Equivalent to DT_PROP(node_id, label)
  *
  * This is a convenience for the Zephyr device API, which uses label
@@ -711,7 +712,7 @@
  * @param node_id node identifier
  * @return node's label property value
  */
-#define DT_LABEL(node_id) DT_PROP(node_id, label)
+#define DT_LABEL(node_id) DT_PROP(node_id, label) __DEPRECATED_MACRO
 
 /**
  * @brief Get a property value's index into its enumeration values
@@ -2553,11 +2554,12 @@
 	DT_PROP_OR(DT_DRV_INST(inst), prop, default_value)
 
 /**
+ * @deprecated Use DT_INST_PROP(inst, label)
  * @brief Get a DT_DRV_COMPAT instance's "label" property
  * @param inst instance number
  * @return instance's label property value
  */
-#define DT_INST_LABEL(inst) DT_INST_PROP(inst, label)
+#define DT_INST_LABEL(inst) DT_INST_PROP(inst, label) __DEPRECATED_MACRO
 
 /**
  * @brief Get a DT_DRV_COMPAT instance's string property's value as a

--- a/include/zephyr/storage/flash_map.h
+++ b/include/zephyr/storage/flash_map.h
@@ -258,7 +258,7 @@ uint8_t flash_area_erased_val(const struct flash_area *fa);
 	DT_HAS_FIXED_PARTITION_LABEL(label)
 
 #define FLASH_AREA_LABEL_STR(lbl) \
-	DT_LABEL(DT_NODE_BY_FIXED_PARTITION_LABEL(lbl))
+	DT_PROP(DT_NODE_BY_FIXED_PARTITION_LABEL(lbl), label)
 
 #define FLASH_AREA_ID(label) \
 	DT_FIXED_PARTITION_ID(DT_NODE_BY_FIXED_PARTITION_LABEL(label))

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -63,13 +63,13 @@ static bool init_buttons(void)
 	} btn_spec[] = {
 		{
 			GPIO_DT_SPEC_GET(DT_ALIAS(sw0), gpios),
-			DT_LABEL(DT_ALIAS(sw0)),
+			DT_PROP(DT_ALIAS(sw0), label),
 			"trigger a transfer",
 			sw0_handler
 		},
 		{
 			GPIO_DT_SPEC_GET(DT_ALIAS(sw1), gpios),
-			DT_LABEL(DT_ALIAS(sw1)),
+			DT_PROP(DT_ALIAS(sw1), label),
 			"switch the type of peripheral",
 			sw1_handler
 		},

--- a/tests/drivers/led/led_api/src/test_led_api.c
+++ b/tests/drivers/led/led_api/src/test_led_api.c
@@ -22,7 +22,7 @@ const uint8_t test_color_mapping_##led_node_id[] =		\
 
 #define LED_INFO_COLOR(led_node_id)				\
 {								\
-	.label		= DT_LABEL(led_node_id),		\
+	.label		= DT_PROP(led_node_id, label),		\
 	.index		= DT_PROP_OR(led_node_id, index, 0),	\
 	.num_colors	=					\
 		DT_PROP_LEN(led_node_id, color_mapping),	\
@@ -31,7 +31,7 @@ const uint8_t test_color_mapping_##led_node_id[] =		\
 
 #define LED_INFO_NO_COLOR(led_node_id)				\
 {								\
-	.label		= DT_LABEL(led_node_id),		\
+	.label		= DT_PROP(led_node_id, label),		\
 	.index		= DT_PROP_OR(led_node_id, index, 0),	\
 	.num_colors	= 0,					\
 	.color_mapping	= NULL,					\

--- a/tests/lib/devicetree/api/src/main.c
+++ b/tests/lib/devicetree/api/src/main.c
@@ -6,10 +6,12 @@
 
 /* Override __DEPRECATED_MACRO so we don't get twister failures for
  * deprecated macros:
+ * - DT_LABEL
  * - DT_BUS_LABEL
  * - DT_SPI_DEV_CS_GPIOS_LABEL
  * - DT_GPIO_LABEL
  * - DT_GPIO_LABEL_BY_IDX
+ * - DT_INST_LABEL
  * - DT_INST_BUS_LABEL
  * - DT_INST_SPI_DEV_CS_GPIOS_LABEL
  * - DT_INST_GPIO_LABEL


### PR DESCRIPTION
Deprecate DT_LABEL and DT_INST_LABEL as we have phased out
general 'label' usage and there isn't a need to keep a specific
set of macros for 'label'.  DT_PROP(node, label) works fine for
the small handful of cases that need it now.
