### PR TITLE
devicetree: Add base property "model"

### DIFF
--- a/dts/bindings/base/base.yaml
+++ b/dts/bindings/base/base.yaml
@@ -59,6 +59,11 @@ properties:
         deprecated: true
         description: Human readable string describing the device (used as device_get_binding() argument)
 
+    model:
+        type: string
+        required: false
+        description: specifies the manufacturer’s model number of the device
+
     clocks:
         type: phandle-array
         required: false

--- a/include/zephyr/devicetree.h
+++ b/include/zephyr/devicetree.h
@@ -545,7 +545,7 @@
  * A property's type is usually defined by its binding. In some
  * special cases, it has an assumed type defined by the devicetree
  * specification even when no binding is available: "compatible" has
- * type string-array, "status" and "label" have type string, and
+ * type string-array, "status", "model", and "label" have type string, and
  * "interrupt-controller" has type boolean.
  *
  * For other properties or properties with unknown type due to a

--- a/scripts/dts/python-devicetree/src/devicetree/edtlib.py
+++ b/scripts/dts/python-devicetree/src/devicetree/edtlib.py
@@ -2964,7 +2964,7 @@ _BindingLoader.add_constructor(
 #
 # Zephyr: do not change the _DEFAULT_PROP_TYPES keys without
 # updating the documentation for the DT_PROP() macro in
-# include/devicetree.h.
+# include/zephyr/devicetree.h.
 #
 
 _DEFAULT_PROP_TYPES = {
@@ -2973,6 +2973,7 @@ _DEFAULT_PROP_TYPES = {
     "reg": "array",
     "reg-names": "string-array",
     "label": "string",
+    "model": "string",
     "interrupts": "array",
     "interrupts-extended": "compound",
     "interrupt-names": "string-array",


### PR DESCRIPTION
Add "model" property to base.yaml as its a standard property defined
by the devicetree spec.  Being a simple standard property, add it to
the list of properties that are automatically handled.

Signed-off-by: Kumar Gala <galak@kernel.org>