### PR TITLE
soc: mimxrt1064: Add HAL clock header include

### DIFF
--- a/soc/arm/nxp_imx/rt/lpm_rt1064.c
+++ b/soc/arm/nxp_imx/rt/lpm_rt1064.c
@@ -10,6 +10,7 @@
 #include <zephyr/init.h>
 #include <power_rt10xx.h>
 #include <zephyr/zephyr.h>
+#include <fsl_clock.h>
 
 /*
  * Clock configuration structures populated at boot time. These structures are


### PR DESCRIPTION
The low power mode logic for i.MX RT1064 indirectly includes the HAL definitions, but this is fragile and depends on specific `Kconfig` options.

This fixes build issues if for example `CONFIG_ARM_MPU` is not set.