### PR TITLE
ipc_service: Adding functions to allow for the teardown of an IPC instance

### DIFF
--- a/include/zephyr/ipc/ipc_rpmsg.h
+++ b/include/zephyr/ipc/ipc_rpmsg.h
@@ -112,6 +112,20 @@ int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
 		   void *shb, size_t size,
 		   rpmsg_ns_bind_cb ns_bind_cb);
 
+
+/** @brief
+ *
+ * Deinit an RPMsg instance
+ *
+ * @param instance Pointer to the RPMsg instance struct.
+ * @param role Host / Remote role.
+ *
+ * @retval -EINVAL When some parameter is missing
+ * @retval 0 If successful
+ */
+int ipc_rpmsg_deinit(struct ipc_rpmsg_instance *instance,
+		   unsigned int role);
+
 /** @brief Register an endpoint.
  *
  *  Register an endpoint to a provided RPMsg instance.

--- a/include/zephyr/ipc/ipc_service.h
+++ b/include/zephyr/ipc/ipc_service.h
@@ -196,6 +196,24 @@ struct ipc_ept_cfg {
  */
 int ipc_service_open_instance(const struct device *instance);
 
+/** @brief Close an instance
+ *
+ *  Function to be used to close an instance. All endpoints must be
+ *  deregistered using ipc_service_deregister_endpoint before this
+ *  is called.
+ *
+ *  @param[in] instance Instance to close.
+ *
+ *  @retval -EINVAL when instance configuration is invalid.
+ *  @retval -EIO when no backend is registered.
+ *  @retval -EALREADY when the instance is not already opened.
+ *  @retval -EBUSY when an endpoint exists that hasn't been
+ *           deregistered
+ *
+ *  @retval 0 on success or when not implemented on the backend (not needed).
+ *  @retval other errno codes depending on the implementation of the backend.
+ */
+int ipc_service_close_instance(const struct device *instance);
 
 /** @brief Register IPC endpoint onto an instance.
  *

--- a/include/zephyr/ipc/ipc_service_backend.h
+++ b/include/zephyr/ipc/ipc_service_backend.h
@@ -37,6 +37,18 @@ struct ipc_service_backend {
 	 */
 	int (*open_instance)(const struct device *instance);
 
+	/** @brief Pointer to the function that will be used to close an instance
+	 *
+	 *  @param[in] instance Instance pointer.
+	 *
+	 *  @retval -EALREADY when the instance is not already inited.
+	 *
+	 *  @retval 0 on success
+	 *  @retval other errno codes depending on the implementation of the
+	 *	    backend.
+	 */
+	int (*close_instance)(const struct device *instance);
+
 	/** @brief Pointer to the function that will be used to send data to the endpoint.
 	 *
 	 *  @param[in] instance Instance pointer.

--- a/include/zephyr/ipc/ipc_static_vrings.h
+++ b/include/zephyr/ipc/ipc_static_vrings.h
@@ -100,6 +100,18 @@ struct ipc_static_vrings {
  */
 int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role);
 
+/** @brief Deinitialise the static VRINGs.
+ *
+ *  Deinitialise VRINGs and Virtqueues of an OpenAMP / RPMsg instance.
+ *
+ *  @param vr Pointer to the VRINGs instance struct.
+ *  @param role Host / Remote role.
+ *
+ *  @retval 0 If successful.
+ *  @retval Other errno codes depending on the OpenAMP implementation.
+ */
+int ipc_static_vrings_deinit(struct ipc_static_vrings *vr, unsigned int role);
+
 /**
  * @}
  */

--- a/subsys/ipc/ipc_service/ipc_service.c
+++ b/subsys/ipc/ipc_service/ipc_service.c
@@ -38,6 +38,30 @@ int ipc_service_open_instance(const struct device *instance)
 	return backend->open_instance(instance);
 }
 
+int ipc_service_close_instance(const struct device *instance)
+{
+	const struct ipc_service_backend *backend;
+
+	if (!instance) {
+		LOG_ERR("Invalid instance");
+		return -EINVAL;
+	}
+
+	backend = (const struct ipc_service_backend *) instance->api;
+
+	if (!backend) {
+		LOG_ERR("Invalid backend configuration");
+		return -EIO;
+	}
+
+	if (!backend->close_instance) {
+		/* maybe not needed on backend */
+		return 0;
+	}
+
+	return backend->close_instance(instance);
+}
+
 int ipc_service_register_endpoint(const struct device *instance,
 				  struct ipc_ept *ept,
 				  const struct ipc_ept_cfg *cfg)

--- a/subsys/ipc/ipc_service/lib/ipc_rpmsg.c
+++ b/subsys/ipc/ipc_service/lib/ipc_rpmsg.c
@@ -102,3 +102,19 @@ int ipc_rpmsg_init(struct ipc_rpmsg_instance *instance,
 		return rpmsg_init_vdev(&instance->rvdev, vdev, bind_cb, shm_io, NULL);
 	}
 }
+
+int ipc_rpmsg_deinit(struct ipc_rpmsg_instance *instance,
+		   unsigned int role)
+{
+	if (!instance) {
+		return -EINVAL;
+	}
+
+	rpmsg_deinit_vdev(&instance->rvdev);
+
+	if (role == RPMSG_HOST) {
+		memset(&instance->shm_pool, 0, sizeof(struct rpmsg_virtio_shm_pool));
+	}
+
+	return 0;
+}

--- a/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
+++ b/subsys/ipc/ipc_service/lib/ipc_static_vrings.c
@@ -103,6 +103,17 @@ static int libmetal_setup(struct ipc_static_vrings *vr)
 	return 0;
 }
 
+static int libmetal_teardown(struct ipc_static_vrings *vr)
+{
+	vr->shm_io = 0;
+
+	metal_device_close(&vr->shm_device);
+
+	metal_finish();
+
+	return 0;
+}
+
 static int vq_setup(struct ipc_static_vrings *vr, unsigned int role)
 {
 	vr->vq[RPMSG_VQ_0] = virtqueue_allocate(vr->vring_size);
@@ -136,6 +147,19 @@ static int vq_setup(struct ipc_static_vrings *vr, unsigned int role)
 	return 0;
 }
 
+static int vq_teardown(struct ipc_static_vrings *vr, unsigned int role)
+{
+	memset(&vr->vdev, 0, sizeof(struct virtio_device));
+
+	memset(&(vr->rvrings[RPMSG_VQ_1]), 0, sizeof(struct virtio_vring_info));
+	memset(&(vr->rvrings[RPMSG_VQ_0]), 0, sizeof(struct virtio_vring_info));
+
+	virtqueue_free(vr->vq[RPMSG_VQ_1]);
+	virtqueue_free(vr->vq[RPMSG_VQ_0]);
+
+	return 0;
+}
+
 int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role)
 {
 	int err = 0;
@@ -157,4 +181,23 @@ int ipc_static_vrings_init(struct ipc_static_vrings *vr, unsigned int role)
 	}
 
 	return vq_setup(vr, role);
+}
+
+int ipc_static_vrings_deinit(struct ipc_static_vrings *vr, unsigned int role)
+{
+	int err;
+
+	err = vq_teardown(vr, role);
+	if (err != 0) {
+		return err;
+	}
+
+	err = libmetal_teardown(vr);
+	if (err != 0) {
+		return err;
+	}
+
+	metal_io_finish(vr->shm_device.regions);
+
+	return 0;
 }


### PR DESCRIPTION
This builds upon my previous patch which allowed you to teardown an endpoint. This patch allows the whole ipc_service instance to be closed. It is intended to be used to tidy up in the case that an endpoint goes down or there is another failure in the ipc_service.