### PR TITLE
drivers: can: return -ENETUNREACH from can_send() if in bus off state

### DIFF
--- a/drivers/can/can_mcan.c
+++ b/drivers/can/can_mcan.c
@@ -825,7 +825,7 @@ int can_mcan_send(const struct device *dev,
 	}
 
 	if (can->psr & CAN_MCAN_PSR_BO) {
-		return -ENETDOWN;
+		return -ENETUNREACH;
 	}
 
 	ret = k_sem_take(&data->tx_sem, timeout);

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -364,7 +364,7 @@ static int mcux_flexcan_send(const struct device *dev,
 	(void)mcux_flexcan_get_state(dev, &state, NULL);
 	if (state == CAN_STATE_BUS_OFF) {
 		LOG_DBG("Transmit failed, bus-off");
-		return -ENETDOWN;
+		return -ENETUNREACH;
 	}
 
 	if (k_sem_take(&data->tx_allocs_sem, timeout) != 0) {
@@ -582,9 +582,9 @@ static inline void mcux_flexcan_transfer_error_status(const struct device *dev,
 				FLEXCAN_TransferAbortSend(config->base, &data->handle,
 							  ALLOC_IDX_TO_TXMB_IDX(alloc));
 				if (function != NULL) {
-					function(dev, -ENETDOWN, arg);
+					function(dev, -ENETUNREACH, arg);
 				} else {
-					data->tx_cbs[alloc].status = -ENETDOWN;
+					data->tx_cbs[alloc].status = -ENETUNREACH;
 					k_sem_give(&data->tx_cbs[alloc].done);
 				}
 

--- a/drivers/can/can_sja1000.c
+++ b/drivers/can/can_sja1000.c
@@ -313,7 +313,7 @@ int can_sja1000_send(const struct device *dev, const struct can_frame *frame, k_
 
 	if (data->state == CAN_STATE_BUS_OFF) {
 		LOG_DBG("transmit failed, bus-off");
-		return -ENETDOWN;
+		return -ENETUNREACH;
 	}
 
 	if (k_sem_take(&data->tx_idle, timeout) != 0) {
@@ -544,7 +544,7 @@ static void can_sja1000_handle_error_warning_irq(const struct device *dev)
 	sr = can_sja1000_read_reg(dev, CAN_SJA1000_SR);
 	if ((sr & CAN_SJA1000_SR_BS) != 0) {
 		data->state = CAN_STATE_BUS_OFF;
-		can_sja1000_tx_done(dev, -ENETDOWN);
+		can_sja1000_tx_done(dev, -ENETUNREACH);
 #ifdef CONFIG_CAN_AUTO_BUS_OFF_RECOVERY
 		/* Recover bus now unless interrupted in the middle of a MOD register change. */
 		err = k_mutex_lock(&data->mod_lock, K_NO_WAIT);

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -215,7 +215,7 @@ static inline void can_stm32_tx_isr_handler(const struct device *dev)
 				can->TSR & CAN_TSR_TXOK0 ? 0  :
 				can->TSR & CAN_TSR_TERR0 ? -EIO :
 				can->TSR & CAN_TSR_ALST0 ? -EBUSY :
-						 bus_off ? -ENETDOWN :
+						 bus_off ? -ENETUNREACH :
 							   -EIO;
 		/* clear the request. */
 		can->TSR |= CAN_TSR_RQCP0;
@@ -227,7 +227,7 @@ static inline void can_stm32_tx_isr_handler(const struct device *dev)
 				can->TSR & CAN_TSR_TXOK1 ? 0  :
 				can->TSR & CAN_TSR_TERR1 ? -EIO :
 				can->TSR & CAN_TSR_ALST1 ? -EBUSY :
-				bus_off                  ? -ENETDOWN :
+				bus_off                  ? -ENETUNREACH :
 							   -EIO;
 		/* clear the request. */
 		can->TSR |= CAN_TSR_RQCP1;
@@ -239,7 +239,7 @@ static inline void can_stm32_tx_isr_handler(const struct device *dev)
 				can->TSR & CAN_TSR_TXOK2 ? 0  :
 				can->TSR & CAN_TSR_TERR2 ? -EIO :
 				can->TSR & CAN_TSR_ALST2 ? -EBUSY :
-				bus_off                  ? -ENETDOWN :
+				bus_off                  ? -ENETUNREACH :
 							   -EIO;
 		/* clear the request. */
 		can->TSR |= CAN_TSR_RQCP2;
@@ -692,7 +692,7 @@ static int can_stm32_send(const struct device *dev, const struct can_frame *fram
 	}
 
 	if (can->ESR & CAN_ESR_BOFF) {
-		return -ENETDOWN;
+		return -ENETUNREACH;
 	}
 
 	k_mutex_lock(&data->inst_mutex, K_FOREVER);

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -1015,7 +1015,7 @@ __syscall int can_set_bitrate(const struct device *dev, uint32_t bitrate);
  *
  * @retval 0 if successful.
  * @retval -EINVAL if an invalid parameter was passed to the function.
- * @retval -ENETDOWN if the CAN controller is in bus-off state.
+ * @retval -ENETUNREACH if the CAN controller is in bus-off state.
  * @retval -EBUSY if CAN bus arbitration was lost (only applicable if automatic
  *                retransmissions are disabled).
  * @retval -EIO if a general transmit error occurred (e.g. missing ACK if


### PR DESCRIPTION
Change the error code for can_send() when the CAN controller is in bus off state from `-ENETDOWN` to `-ENETUNREACH`.

This is preparation for solving #45304, where `-ENETDOWN`  will be used as error code when the CAN controller is in stopped state.

Signed-off-by: Henrik Brix Andersen <hebad@vestas.com>