### PR TITLE
tests:ipc_service: Add ipc_service test of deregistered endpoint

### DIFF
--- a/tests/subsys/ipc/ipc_service/src/backend.c
+++ b/tests/subsys/ipc/ipc_service/src/backend.c
@@ -53,9 +53,19 @@ static int register_ept(const struct device *instance,
 	return 0;
 }
 
+static int deregister_ept(const struct device *instance, void *token)
+{
+	struct backend_data_t *data = instance->data;
+
+	data->cfg = NULL;
+
+	return 0;
+}
+
 const static struct ipc_service_backend backend_ops = {
 	.send = send,
 	.register_endpoint = register_ept,
+	.deregister_endpoint = deregister_ept,
 };
 
 static int backend_init(const struct device *dev)

--- a/tests/subsys/ipc/ipc_service/src/main.c
+++ b/tests/subsys/ipc/ipc_service/src/main.c
@@ -67,6 +67,16 @@ ZTEST(ipc_service, test_ipc_service)
 
 	ret = ipc_service_send(&ept_20, &msg, sizeof(msg));
 	zassert_ok(ret, "ipc_service_send() failed");
+
+	/*
+	 * Deregister the endpoint and ensure that we fail
+	 * correctly
+	 */
+	ret = ipc_service_deregister_endpoint(&ept_10);
+	zassert_ok(ret, "ipc_service_deregister_endpoint() failed");
+
+	ret = ipc_service_send(&ept_10, &msg, sizeof(msg));
+	zassert_equal(ret, -ENOENT, "ipc_service_send() should return -ENOENT");
 }
 
 ZTEST_SUITE(ipc_service, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
This adds an additional test to the ipc_service test suite whereby the
test attempts to deregister the endpoint from the ipc_service instance
and then send a message to that endpoint - this should fail with
-ENOENT.

Signed-off-by: Jackson Cooper-Driver <jackson.cooper---driver@amd.com>