### PR TITLE
samples: boards: pm on stm32 boards with serial wakeup

### DIFF
--- a/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
@@ -7,7 +7,6 @@ tests:
     harness_config:
       type: multi_line
       regex:
-        - "Device ready"
         - "Device is wakeup capable"
         - "Wakeup source enable ok"
         - "Wakeup source enabled"

--- a/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
+++ b/samples/boards/stm32/power_mgmt/serial_wakeup/sample.yaml
@@ -15,3 +15,4 @@ tests:
       - nucleo_wb55rg
     filter: dt_compat_enabled("zephyr,power-state")
     extra_args: "CONFIG_DEBUG=y"
+    platform_allow: nucleo_wb55rg stm32l562e_dk


### PR DESCRIPTION
This commit retrains the power management testcase
tests/samples/boards/stm32/power_mgmt/serial_wakeup
to bun on stm32 boards only.
Limiting first to nucleo_wg55 and stm32l562dk targets,
more to be added.

Fixes https://github.com/zephyrproject-rtos/zephyr/issues/49268

Signed-off-by: Francois Ramu <francois.ramu@st.com>