### PR TITLE
doc: add nitpicky mode ignores

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -105,6 +105,26 @@ todo_include_todos = False
 
 numfig = True
 
+nitpick_ignore = [
+    # ignore C standard identifiers (they are not defined in Zephyr docs)
+    ("c:identifier", "FILE"),
+    ("c:identifier", "int8_t"),
+    ("c:identifier", "int16_t"),
+    ("c:identifier", "int32_t"),
+    ("c:identifier", "int64_t"),
+    ("c:identifier", "intptr_t"),
+    ("c:identifier", "off_t"),
+    ("c:identifier", "size_t"),
+    ("c:identifier", "ssize_t"),
+    ("c:identifier", "time_t"),
+    ("c:identifier", "uint8_t"),
+    ("c:identifier", "uint16_t"),
+    ("c:identifier", "uint32_t"),
+    ("c:identifier", "uint64_t"),
+    ("c:identifier", "uintptr_t"),
+    ("c:identifier", "va_list"),
+]
+
 rst_epilog = """
 .. include:: /substitutions.txt
 """


### PR DESCRIPTION
The nitpicky mode warns about any broken reference. It is useful to keep
docs in good shape, however, there are some references that will never
be resolvable. Provide an initial list to decrease the number of
warnings that are not relevant/can't be fixed.

Note that the Sphinx nitpicky mode can be enabled by either setting
`nitpicky = True` in `doc/conf.py` or by setting the `-n` flag in
`SPHINXOPTS`.

Note that this mode can't be enabled now as it generated ~2K warnings.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>