### PR TITLE
net: Use DEVICE_DT_NAME

### DIFF
--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -892,7 +892,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
 #define ETH_NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_action_cb, data,	\
 			       cfg, prio, api, mtu)			\
 	Z_ETH_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
-			      DT_PROP_OR(node_id, label, ""),		\
+			      DEVICE_DT_NAME(node_id),			\
 			      init_fn, pm_action_cb, data, cfg, prio,	\
 			      api, mtu)
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -2365,7 +2365,7 @@ struct net_if_api {
 #define NET_DEVICE_DT_DEFINE(node_id, init_fn, pm_action_cb, data, cfg,	\
 			   prio, api, l2, l2_ctx_type, mtu)		\
 	Z_NET_DEVICE_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id),	\
-			  DT_PROP_OR(node_id, label, ""), init_fn,	\
+			  DEVICE_DT_NAME(node_id), init_fn,		\
 			  pm_action_cb, data, cfg, prio, api, l2,	\
 			  l2_ctx_type, mtu)
 
@@ -2449,7 +2449,7 @@ struct net_if_api {
 				      api, l2, l2_ctx_type, mtu)	\
 	Z_NET_DEVICE_INIT_INSTANCE(node_id,				\
 				   Z_DEVICE_DT_DEV_NAME(node_id),	\
-				   DT_PROP_OR(node_id, label, ""),	\
+				   DEVICE_DT_NAME(node_id),		\
 				   instance, init_fn,			\
 				   pm_action_cb, data, cfg, prio, api,	\
 				   l2, l2_ctx_type, mtu)
@@ -2521,7 +2521,7 @@ struct net_if_api {
 #define NET_DEVICE_DT_OFFLOAD_DEFINE(node_id, init_fn, pm_action_cb,	\
 				   data, cfg, prio, api, mtu)		\
 	Z_NET_DEVICE_OFFLOAD_INIT(node_id, Z_DEVICE_DT_DEV_NAME(node_id), \
-				  DT_PROP_OR(node_id, label, ""),	\
+				  DEVICE_DT_NAME(node_id),		\
 				  init_fn, pm_action_cb, data, cfg,	\
 				  prio, api, mtu)
 


### PR DESCRIPTION
Make networking use DEVICE_DT_NAME so the name is consistent with
how DEVICE_DT_DEFINE works.

Signed-off-by: Kumar Gala <galak@kernel.org>