### PR TITLE
ethernet: Add missing __subsystem tag

### DIFF
--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -1019,7 +1019,7 @@ static enum ethernet_hw_caps dsa_port_get_capabilities(const struct device *dev)
 		ETHERNET_LINK_100BASE_T;
 }
 
-const struct ethernet_api dsa_eth_api_funcs = {
+const struct ethernet_driver_api dsa_eth_api_funcs = {
 	.iface_api.init		= dsa_iface_init,
 	.get_capabilities	= dsa_port_get_capabilities,
 	.send                   = dsa_tx,

--- a/drivers/ethernet/eth_dwmac.c
+++ b/drivers/ethernet/eth_dwmac.c
@@ -615,7 +615,7 @@ int dwmac_probe(const struct device *dev)
 	return 0;
 }
 
-const struct ethernet_api dwmac_api = {
+const struct ethernet_driver_api dwmac_api = {
 	.iface_api.init		= dwmac_iface_init,
 	.get_capabilities	= dwmac_caps,
 	.set_config		= dwmac_set_config,

--- a/drivers/ethernet/eth_dwmac_priv.h
+++ b/drivers/ethernet/eth_dwmac_priv.h
@@ -84,7 +84,7 @@ int dwmac_probe(const struct device *dev);
 int dwmac_bus_init(struct dwmac_priv *p);
 void dwmac_platform_init(struct dwmac_priv *p);
 void dwmac_isr(const struct device *ddev);
-extern const struct ethernet_api dwmac_api;
+extern const struct ethernet_driver_api dwmac_api;
 
 /*
  * MAC Register Definitions

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -317,7 +317,7 @@ static void e1000_iface_init(struct net_if *iface)
 
 static struct e1000_dev e1000_dev;
 
-static const struct ethernet_api e1000_api = {
+static const struct ethernet_driver_api e1000_api = {
 	.iface_api.init		= e1000_iface_init,
 #if defined(CONFIG_ETH_E1000_PTP_CLOCK)
 	.get_ptp_clock		= e1000_get_ptp_clock,

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -721,7 +721,7 @@ static void eth_enc28j60_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static const struct ethernet_api api_funcs = {
+static const struct ethernet_driver_api api_funcs = {
 	.iface_api.init		= eth_enc28j60_iface_init,
 
 	.get_capabilities	= eth_enc28j60_get_capabilities,

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -637,7 +637,7 @@ static int enc424j600_stop_device(const struct device *dev)
 	return 0;
 }
 
-static const struct ethernet_api api_funcs = {
+static const struct ethernet_driver_api api_funcs = {
 	.iface_api.init		= enc424j600_iface_init,
 	.get_config		= enc424j600_get_config,
 	.get_capabilities	= enc424j600_get_capabilities,

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -630,7 +630,7 @@ static enum ethernet_hw_caps eth_gecko_get_capabilities(const struct device *dev
 			ETHERNET_LINK_100BASE_T | ETHERNET_DUPLEX_SET);
 }
 
-static const struct ethernet_api eth_api = {
+static const struct ethernet_driver_api eth_api = {
 	.iface_api.init = eth_iface_init,
 	.get_capabilities = eth_gecko_get_capabilities,
 	.send = eth_tx,

--- a/drivers/ethernet/eth_liteeth.c
+++ b/drivers/ethernet/eth_liteeth.c
@@ -243,7 +243,7 @@ static enum ethernet_hw_caps eth_caps(const struct device *dev)
 	       ETHERNET_LINK_1000BASE_T;
 }
 
-static const struct ethernet_api eth_api = {
+static const struct ethernet_driver_api eth_api = {
 	.iface_api.init = eth_iface_init,
 	.get_capabilities = eth_caps,
 	.send = eth_tx

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1264,7 +1264,7 @@ static const struct device *eth_mcux_get_ptp_clock(const struct device *dev)
 }
 #endif
 
-static const struct ethernet_api api_funcs = {
+static const struct ethernet_driver_api api_funcs = {
 	.iface_api.init		= eth_iface_init,
 #if defined(CONFIG_PTP_CLOCK_MCUX)
 	.get_ptp_clock		= eth_mcux_get_ptp_clock,

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -606,7 +606,7 @@ static int eth_stop_device(const struct device *dev)
 	return eth_if_down(context->if_name);
 }
 
-static const struct ethernet_api eth_if_api = {
+static const struct ethernet_driver_api eth_if_api = {
 	.iface_api.init = eth_iface_init,
 
 	.get_capabilities = eth_posix_native_get_capabilities,

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2148,7 +2148,7 @@ static const struct device *eth_sam_gmac_get_ptp_clock(const struct device *dev)
 }
 #endif
 
-static const struct ethernet_api eth_api = {
+static const struct ethernet_driver_api eth_api = {
 	.iface_api.init = eth0_iface_init,
 
 	.get_capabilities = eth_sam_gmac_get_capabilities,

--- a/drivers/ethernet/eth_smsc911x.c
+++ b/drivers/ethernet/eth_smsc911x.c
@@ -505,7 +505,7 @@ error:
 	return -1;
 }
 
-static const struct ethernet_api api_funcs = {
+static const struct ethernet_driver_api api_funcs = {
 	.iface_api.init = eth_initialize,
 
 	.get_capabilities = eth_smsc911x_get_capabilities,

--- a/drivers/ethernet/eth_smsc911x_priv.h
+++ b/drivers/ethernet/eth_smsc911x_priv.h
@@ -22,7 +22,7 @@
  * but was considerably refactored since then.
  */
 
-/* This file is the re-implementation of mps2_ethernet_api and Selftest's
+/* This file is the re-implementation of mps2_ethernet_driver_api and Selftest's
  * ETH_MPS2.
  * MPS2 Selftest:https://silver.arm.com/browse/VEI10 ->
  *     \ISCM-1-0\AN491\software\Selftest\v2m_mps2\

--- a/drivers/ethernet/eth_stellaris.c
+++ b/drivers/ethernet/eth_stellaris.c
@@ -341,7 +341,7 @@ struct eth_stellaris_runtime eth_data = {
 	.tx_pos = 0,
 };
 
-static const struct ethernet_api eth_stellaris_apis = {
+static const struct ethernet_driver_api eth_stellaris_apis = {
 	.iface_api.init	= eth_stellaris_init,
 	.send =  eth_stellaris_send,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1042,7 +1042,7 @@ static const struct device *eth_stm32_get_ptp_clock(const struct device *dev)
 }
 #endif /* CONFIG_PTP_CLOCK_STM32_HAL */
 
-static const struct ethernet_api eth_api = {
+static const struct ethernet_driver_api eth_api = {
 	.iface_api.init = eth_iface_init,
 #if defined(CONFIG_PTP_CLOCK_STM32_HAL)
 	.get_ptp_clock = eth_stm32_get_ptp_clock,

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -391,7 +391,7 @@ static int w5500_hw_stop(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api w5500_api_funcs = {
+static struct ethernet_driver_api w5500_api_funcs = {
 	.iface_api.init = w5500_iface_init,
 	.get_capabilities = w5500_get_capabilities,
 	.set_config = w5500_set_config,

--- a/drivers/ethernet/eth_xlnx_gem.c
+++ b/drivers/ethernet/eth_xlnx_gem.c
@@ -63,7 +63,7 @@ static void eth_xlnx_gem_handle_rx_pending(const struct device *dev);
 static void eth_xlnx_gem_tx_done_work(struct k_work *item);
 static void eth_xlnx_gem_handle_tx_done(const struct device *dev);
 
-static const struct ethernet_api eth_xlnx_gem_apis = {
+static const struct ethernet_driver_api eth_xlnx_gem_apis = {
 	.iface_api.init   = eth_xlnx_gem_iface_init,
 	.get_capabilities = eth_xlnx_gem_get_capabilities,
 	.send		  = eth_xlnx_gem_send,

--- a/drivers/net/slip.c
+++ b/drivers/net/slip.c
@@ -445,7 +445,7 @@ static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
 		;
 }
 
-static const struct ethernet_api slip_if_api = {
+static const struct ethernet_driver_api slip_if_api = {
 	.iface_api.init = slip_iface_init,
 
 	.get_capabilities = eth_capabilities,

--- a/drivers/wifi/esp32/src/esp_wifi_drv.c
+++ b/drivers/wifi/esp32/src/esp_wifi_drv.c
@@ -223,7 +223,7 @@ static int eth_esp32_dev_init(const struct device *dev)
 
 static struct esp32_wifi_runtime eth_data;
 
-static const struct ethernet_api eth_esp32_apis = {
+static const struct ethernet_driver_api eth_esp32_apis = {
 	.iface_api.init	= eth_esp32_init,
 	.send =  eth_esp32_send,
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)

--- a/include/zephyr/net/dsa.h
+++ b/include/zephyr/net/dsa.h
@@ -147,7 +147,7 @@ struct dsa_context {
 
 /**
  * @brief Structure to provide DSA switch api callbacks - it is an augmented
- * struct ethernet_api.
+ * struct ethernet_driver_api.
  */
 struct dsa_api {
 	/** Function to get proper LAN{123} interface */

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -397,7 +397,7 @@ struct ethernet_config {
 };
 /** @endcond */
 
-struct ethernet_api {
+__subsystem struct ethernet_api {
 	/**
 	 * The net_if_api must be placed in first position in this
 	 * struct so that we are compatible with network interface API.

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -397,7 +397,10 @@ struct ethernet_config {
 };
 /** @endcond */
 
-__subsystem struct ethernet_api {
+/* Hack to handle out of tree drivers */
+#define ethernet_api ethernet_driver_api
+
+__subsystem struct ethernet_driver_api {
 	/**
 	 * The net_if_api must be placed in first position in this
 	 * struct so that we are compatible with network interface API.
@@ -453,7 +456,7 @@ __subsystem struct ethernet_api {
 /* Make sure that the network interface API is properly setup inside
  * Ethernet API struct (it is the first one).
  */
-BUILD_ASSERT(offsetof(struct ethernet_api, iface_api) == 0);
+BUILD_ASSERT(offsetof(struct ethernet_driver_api, iface_api) == 0);
 
 /** @cond INTERNAL_HIDDEN */
 struct net_eth_hdr {
@@ -714,8 +717,8 @@ void net_eth_ipv6_mcast_to_mac_addr(const struct in6_addr *ipv6_addr,
 static inline
 enum ethernet_hw_caps net_eth_get_hw_capabilities(struct net_if *iface)
 {
-	const struct ethernet_api *eth =
-		(struct ethernet_api *)net_if_get_device(iface)->api;
+	const struct ethernet_driver_api *eth =
+		(struct ethernet_driver_api *)net_if_get_device(iface)->api;
 
 	if (!eth->get_capabilities) {
 		return (enum ethernet_hw_caps)0;

--- a/subsys/net/l2/ethernet/dsa/dsa.c
+++ b/subsys/net/l2/ethernet/dsa/dsa.c
@@ -170,7 +170,7 @@ int dsa_tx(const struct device *dev, struct net_pkt *pkt)
 
 	/*
 	 * Here packets are send via lan{123} interfaces in user program.
-	 * Those structs' ethernet_api only have .send callback set to point
+	 * Those structs' ethernet_driver_api only have .send callback set to point
 	 * to this wrapper function.
 	 *
 	 * Hence, it is necessary to get this callback from master's ethernet

--- a/subsys/net/l2/ethernet/eth_stats.h
+++ b/subsys/net/l2/ethernet/eth_stats.h
@@ -16,7 +16,7 @@
 static inline void eth_stats_update_bytes_rx(struct net_if *iface,
 					     uint32_t bytes)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -35,7 +35,7 @@ static inline void eth_stats_update_bytes_rx(struct net_if *iface,
 static inline void eth_stats_update_bytes_tx(struct net_if *iface,
 					     uint32_t bytes)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -53,7 +53,7 @@ static inline void eth_stats_update_bytes_tx(struct net_if *iface,
 
 static inline void eth_stats_update_pkts_rx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -71,7 +71,7 @@ static inline void eth_stats_update_pkts_rx(struct net_if *iface)
 
 static inline void eth_stats_update_pkts_tx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -89,7 +89,7 @@ static inline void eth_stats_update_pkts_tx(struct net_if *iface)
 
 static inline void eth_stats_update_broadcast_rx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -107,7 +107,7 @@ static inline void eth_stats_update_broadcast_rx(struct net_if *iface)
 
 static inline void eth_stats_update_broadcast_tx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -125,7 +125,7 @@ static inline void eth_stats_update_broadcast_tx(struct net_if *iface)
 
 static inline void eth_stats_update_multicast_rx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -143,7 +143,7 @@ static inline void eth_stats_update_multicast_rx(struct net_if *iface)
 
 static inline void eth_stats_update_multicast_tx(struct net_if *iface)
 {
-	const struct ethernet_api *api = (const struct ethernet_api *)
+	const struct ethernet_driver_api *api = (const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api;
 	struct net_stats_eth *stats;
 
@@ -163,13 +163,13 @@ static inline void eth_stats_update_multicast_tx(struct net_if *iface)
 static inline void eth_stats_update_errors_rx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
-	const struct ethernet_api *api;
+	const struct ethernet_driver_api *api;
 
 	if (!iface) {
 		return;
 	}
 
-	api = ((const struct ethernet_api *)
+	api = ((const struct ethernet_driver_api *)
 	       net_if_get_device(iface)->api);
 
 	if (!api->get_stats) {
@@ -187,7 +187,7 @@ static inline void eth_stats_update_errors_rx(struct net_if *iface)
 static inline void eth_stats_update_errors_tx(struct net_if *iface)
 {
 	struct net_stats_eth *stats;
-	const struct ethernet_api *api = ((const struct ethernet_api *)
+	const struct ethernet_driver_api *api = ((const struct ethernet_driver_api *)
 		net_if_get_device(iface)->api);
 
 	if (!api->get_stats) {

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -163,7 +163,7 @@ static void ethernet_update_rx_stats(struct net_if *iface,
 static inline bool eth_is_vlan_tag_stripped(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 
 	return (api->get_capabilities(dev) & ETHERNET_HW_VLAN_TAG_STRIP);
 }
@@ -596,7 +596,7 @@ static void ethernet_remove_l2_header(struct net_pkt *pkt)
 
 static int ethernet_send(struct net_if *iface, struct net_pkt *pkt)
 {
-	const struct ethernet_api *api = net_if_get_device(iface)->api;
+	const struct ethernet_driver_api *api = net_if_get_device(iface)->api;
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	uint16_t ptype;
 	int ret;
@@ -729,7 +729,7 @@ error:
 
 static inline int ethernet_enable(struct net_if *iface, bool state)
 {
-	const struct ethernet_api *eth =
+	const struct ethernet_driver_api *eth =
 		net_if_get_device(iface)->api;
 
 	if (!eth) {
@@ -924,7 +924,7 @@ static void setup_ipv6_link_local_addr(struct net_if *iface)
 int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	const struct ethernet_api *eth =
+	const struct ethernet_driver_api *eth =
 		net_if_get_device(iface)->api;
 	struct ethernet_vlan *vlan;
 	int i;
@@ -997,7 +997,7 @@ int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
 int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	const struct ethernet_api *eth =
+	const struct ethernet_driver_api *eth =
 		net_if_get_device(iface)->api;
 	struct ethernet_vlan *vlan;
 
@@ -1094,7 +1094,7 @@ void net_eth_carrier_off(struct net_if *iface)
 const struct device *net_eth_get_ptp_clock(struct net_if *iface)
 {
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 
 	if (!api) {
 		return NULL;

--- a/subsys/net/l2/ethernet/ethernet_mgmt.c
+++ b/subsys/net/l2/ethernet/ethernet_mgmt.c
@@ -16,7 +16,7 @@ LOG_MODULE_REGISTER(net_ethernet_mgmt, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 static inline bool is_hw_caps_supported(const struct device *dev,
 					enum ethernet_hw_caps caps)
 {
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 
 	if (!api) {
 		return false;
@@ -31,7 +31,7 @@ static int ethernet_set_config(uint32_t mgmt_request,
 {
 	struct ethernet_req_params *params = (struct ethernet_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 	struct ethernet_config config = { 0 };
 	enum ethernet_config_type type;
 
@@ -232,7 +232,7 @@ static int ethernet_get_config(uint32_t mgmt_request,
 {
 	struct ethernet_req_params *params = (struct ethernet_req_params *)data;
 	const struct device *dev = net_if_get_device(iface);
-	const struct ethernet_api *api = dev->api;
+	const struct ethernet_driver_api *api = dev->api;
 	struct ethernet_config config = { 0 };
 	int ret = 0;
 	enum ethernet_config_type type;

--- a/subsys/net/l2/ethernet/ethernet_stats.c
+++ b/subsys/net/l2/ethernet/ethernet_stats.c
@@ -22,7 +22,7 @@ static int eth_stats_get(uint32_t mgmt_request, struct net_if *iface,
 {
 	size_t len_chk = 0;
 	void *src = NULL;
-	const struct ethernet_api *eth;
+	const struct ethernet_driver_api *eth;
 
 	switch (NET_MGMT_GET_COMMAND(mgmt_request)) {
 	case NET_REQUEST_STATS_CMD_GET_ETHERNET:

--- a/subsys/usb/device/class/netusb/netusb.c
+++ b/subsys/usb/device/class/netusb/netusb.c
@@ -138,7 +138,7 @@ static void netusb_init(struct net_if *iface)
 	LOG_INF("netusb initialized");
 }
 
-static const struct ethernet_api netusb_api_funcs = {
+static const struct ethernet_driver_api netusb_api_funcs = {
 	.iface_api.init = netusb_init,
 
 	.get_capabilities = NULL,

--- a/tests/net/arp/src/main.c
+++ b/tests/net/arp/src/main.c
@@ -283,7 +283,7 @@ static void setup_eth_header(struct net_if *iface, struct net_pkt *pkt,
 struct net_arp_context net_arp_context_data;
 
 #if defined(CONFIG_NET_ARP) && defined(CONFIG_NET_L2_ETHERNET)
-static const struct ethernet_api net_arp_if_api = {
+static const struct ethernet_driver_api net_arp_if_api = {
 	.iface_api.init = net_arp_iface_init,
 	.send = tester_send,
 };

--- a/tests/net/bridge/src/main.c
+++ b/tests/net/bridge/src/main.c
@@ -114,7 +114,7 @@ static int eth_fake_set_config(const struct device *dev,
 	return 0;
 }
 
-static const struct ethernet_api eth_fake_api_funcs = {
+static const struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 	.get_capabilities = eth_fake_get_capabilities,
 	.set_config = eth_fake_set_config,
@@ -160,7 +160,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	DBG("Interface %p [%d]\n", iface, net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *api =
+		const struct ethernet_driver_api *api =
 			net_if_get_device(iface)->api;
 
 		/*

--- a/tests/net/checksum_offload/src/main.c
+++ b/tests/net/checksum_offload/src/main.c
@@ -256,14 +256,14 @@ static enum ethernet_hw_caps eth_offloading_disabled(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api api_funcs_offloading_disabled = {
+static struct ethernet_driver_api api_funcs_offloading_disabled = {
 	.iface_api.init = eth_iface_init,
 
 	.get_capabilities = eth_offloading_disabled,
 	.send = eth_tx_offloading_disabled,
 };
 
-static struct ethernet_api api_funcs_offloading_enabled = {
+static struct ethernet_driver_api api_funcs_offloading_enabled = {
 	.iface_api.init = eth_iface_init,
 
 	.get_capabilities = eth_offloading_enabled,

--- a/tests/net/ethernet_mgmt/src/main.c
+++ b/tests/net/ethernet_mgmt/src/main.c
@@ -501,7 +501,7 @@ static int eth_fake_get_config(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 
 	.get_capabilities = eth_fake_get_capabilities,

--- a/tests/net/hostname/src/main.c
+++ b/tests/net/hostname/src/main.c
@@ -109,7 +109,7 @@ static int sender_iface(const struct device *dev, struct net_pkt *pkt)
 
 struct net_if_test net_iface1_data;
 
-static struct ethernet_api net_iface_api = {
+static struct ethernet_driver_api net_iface_api = {
 	.iface_api.init = net_iface_init,
 	.send = sender_iface,
 };
@@ -169,7 +169,7 @@ static int eth_fake_send(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 	.send = eth_fake_send,
 };

--- a/tests/net/iface/src/main.c
+++ b/tests/net/iface/src/main.c
@@ -244,7 +244,7 @@ static int eth_fake_set_config(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 
 	.get_capabilities = eth_fake_get_capabilities,
@@ -288,7 +288,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	    net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *api =
+		const struct ethernet_driver_api *api =
 			net_if_get_device(iface)->api;
 
 		/* As native_posix board will introduce another ethernet

--- a/tests/net/ipv6/src/main.c
+++ b/tests/net/ipv6/src/main.c
@@ -284,7 +284,7 @@ out:
 /* Ethernet interface (interface under test) */
 struct net_test_ipv6 net_test_data;
 
-static const struct ethernet_api net_test_if_api = {
+static const struct ethernet_driver_api net_test_if_api = {
 	.iface_api.init = net_test_iface_init,
 	.send = tester_send,
 };

--- a/tests/net/net_pkt/src/main.c
+++ b/tests/net/net_pkt/src/main.c
@@ -56,7 +56,7 @@ int fake_dev_init(const struct device *dev)
 }
 
 #if defined(CONFIG_NET_L2_ETHERNET)
-static const struct ethernet_api fake_dev_api = {
+static const struct ethernet_driver_api fake_dev_api = {
 	.iface_api.init = fake_dev_iface_init,
 	.send = fake_dev_send,
 };

--- a/tests/net/promiscuous/src/main.c
+++ b/tests/net/promiscuous/src/main.c
@@ -125,7 +125,7 @@ static int eth_fake_set_config(const struct device *dev,
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 
 	.get_capabilities = eth_fake_get_capabilities,
@@ -175,7 +175,7 @@ static void iface_cb(struct net_if *iface, void *user_data)
 	    net_if_get_by_iface(iface));
 
 	if (net_if_l2(iface) == &NET_L2_GET_NAME(ETHERNET)) {
-		const struct ethernet_api *api =
+		const struct ethernet_driver_api *api =
 			net_if_get_device(iface)->api;
 
 		/* As native_posix board will introduce another ethernet

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -131,7 +131,7 @@ static const struct device *eth_get_ptp_clock(const struct device *dev)
 	return context->ptp_clock;
 }
 
-static struct ethernet_api api_funcs = {
+static struct ethernet_driver_api api_funcs = {
 	.iface_api.init = eth_iface_init,
 
 	.get_capabilities = eth_capabilities,

--- a/tests/net/socket/af_packet/src/main.c
+++ b/tests/net/socket/af_packet/src/main.c
@@ -78,7 +78,7 @@ static void eth_fake_iface_init(struct net_if *iface)
 	ethernet_init(iface);
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 	.send = eth_fake_send,
 };

--- a/tests/net/socket/net_mgmt/src/main.c
+++ b/tests/net/socket/net_mgmt/src/main.c
@@ -226,7 +226,7 @@ static enum ethernet_hw_caps eth_fake_get_capabilities(const struct device *dev)
 		ETHERNET_PROMISC_MODE | ETHERNET_PRIORITY_QUEUES;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 
 	.get_capabilities = eth_fake_get_capabilities,

--- a/tests/net/socket/udp/src/main.c
+++ b/tests/net/socket/udp/src/main.c
@@ -1008,7 +1008,7 @@ static int eth_fake_send(const struct device *dev, struct net_pkt *pkt)
 	return 0;
 }
 
-static struct ethernet_api eth_fake_api_funcs = {
+static struct ethernet_driver_api eth_fake_api_funcs = {
 	.iface_api.init = eth_fake_iface_init,
 	.send = eth_fake_send,
 };

--- a/tests/net/tx_timestamp/src/main.c
+++ b/tests/net/tx_timestamp/src/main.c
@@ -126,7 +126,7 @@ static enum ethernet_hw_caps eth_get_capabilities(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api api_funcs = {
+static struct ethernet_driver_api api_funcs = {
 	.iface_api.init = eth_iface_init,
 
 	.get_capabilities = eth_get_capabilities,

--- a/tests/net/virtual/src/main.c
+++ b/tests/net/virtual/src/main.c
@@ -160,7 +160,7 @@ static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
 	return 0;
 }
 
-static struct ethernet_api api_funcs = {
+static struct ethernet_driver_api api_funcs = {
 	.iface_api.init = eth_iface_init,
 
 	.get_capabilities = eth_capabilities,

--- a/tests/net/vlan/src/main.c
+++ b/tests/net/vlan/src/main.c
@@ -144,7 +144,7 @@ static enum ethernet_hw_caps eth_capabilities(const struct device *dev)
 	return ETHERNET_HW_VLAN;
 }
 
-static struct ethernet_api api_funcs = {
+static struct ethernet_driver_api api_funcs = {
 	.iface_api.init = eth_vlan_iface_init,
 
 	.get_capabilities = eth_capabilities,


### PR DESCRIPTION
The ethernet driver API was missing a __subystem tag.  This is used
by scripts/build/gen_kobject_list.py when dealing with userspace.

Signed-off-by: Kumar Gala <galak@kernel.org>