### PR TITLE
MAINTAINERS: Add kconfigfunctions.py under devicetree

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -421,6 +421,7 @@ Devicetree:
     - dts/bindings/test/
     - doc/build/dts/
     - include/zephyr/devicetree/
+    - scripts/kconfig/kconfigfunctions.py
   labels:
     - "area: Devicetree"
 


### PR DESCRIPTION
The majority of functions in scripts/kconfig/kconfigfunctions.py are
related to devicetree so I think its resonable to list it under
the devicetree maintained files.

Signed-off-by: Kumar Gala <galak@kernel.org>