### PR TITLE
drivers: sensor: ina237: add support for triggered mode

### DIFF
--- a/drivers/sensor/ina23x/CMakeLists.txt
+++ b/drivers/sensor/ina23x/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 zephyr_library()
 
-zephyr_library_sources(ina23x_common.c)
+zephyr_library_sources(ina23x_common.c ina23x_trigger.c)
 zephyr_library_sources_ifdef(CONFIG_INA230 ina230.c)
 zephyr_library_sources_ifdef(CONFIG_INA237 ina237.c)
 zephyr_library_sources_ifdef(CONFIG_INA230_TRIGGER ina230_trigger.c)

--- a/drivers/sensor/ina23x/ina237.h
+++ b/drivers/sensor/ina23x/ina237.h
@@ -8,6 +8,7 @@
 #define ZEPHYR_DRIVERS_SENSOR_INA23X_INA237_H_
 
 #include <zephyr/drivers/i2c.h>
+#include "ina23x_trigger.h"
 
 #define INA237_REG_CONFIG     0x00
 #define INA237_REG_ADC_CONFIG 0x01
@@ -29,9 +30,12 @@
 #define INA237_MANUFACTURER_ID 0x5449
 
 struct ina237_data {
+	const struct device *dev;
 	uint16_t current;
 	uint16_t bus_voltage;
 	uint32_t power;
+	enum sensor_channel chan;
+	struct ina23x_trigger trigger;
 };
 
 struct ina237_config {
@@ -40,6 +44,8 @@ struct ina237_config {
 	uint16_t adc_config;
 	uint16_t current_lsb;
 	uint16_t rshunt;
+	const struct gpio_dt_spec gpio_alert;
+	uint16_t alert_config;
 };
 
 #endif /* ZEPHYR_DRIVERS_SENSOR_INA23X_INA237_H_ */

--- a/drivers/sensor/ina23x/ina23x_trigger.c
+++ b/drivers/sensor/ina23x/ina23x_trigger.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2022 Grinn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#include <zephyr/logging/log.h>
+#include "ina23x_trigger.h"
+
+LOG_MODULE_REGISTER(INA23X_TRIGGER, CONFIG_SENSOR_LOG_LEVEL);
+
+static void ina23x_gpio_callback(const struct device *port,
+				 struct gpio_callback *cb, uint32_t pin)
+{
+	ARG_UNUSED(pin);
+
+	struct ina23x_trigger *trigg = CONTAINER_OF(cb, struct ina23x_trigger, gpio_cb);
+
+	k_work_submit(&trigg->conversion_work);
+}
+
+int ina23x_trigger_mode_init(struct ina23x_trigger *trigg, const struct gpio_dt_spec *gpio_alert)
+{
+	int ret;
+
+	if (!device_is_ready(gpio_alert->port)) {
+		LOG_ERR("Alert GPIO device not ready");
+		return -ENODEV;
+	}
+
+	ret = gpio_pin_configure_dt(gpio_alert, GPIO_INPUT);
+	if (ret < 0) {
+		LOG_ERR("Could not configure gpio");
+		return ret;
+	}
+
+	gpio_init_callback(&trigg->gpio_cb,
+			   ina23x_gpio_callback,
+			   BIT(gpio_alert->pin));
+
+	ret = gpio_add_callback(gpio_alert->port, &trigg->gpio_cb);
+	if (ret < 0) {
+		LOG_ERR("Could not set gpio callback");
+		return ret;
+	}
+
+	return gpio_pin_interrupt_configure_dt(gpio_alert,
+					       GPIO_INT_EDGE_FALLING);
+}

--- a/drivers/sensor/ina23x/ina23x_trigger.h
+++ b/drivers/sensor/ina23x/ina23x_trigger.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022  Grinn
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+#ifndef ZEPHYR_DRIVERS_SENSOR_INA23X_TRIGGER_H_
+#define ZEPHYR_DRIVERS_SENSOR_INA23X_TRIGGER_H_
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/sensor.h>
+
+struct ina23x_trigger {
+	struct gpio_callback gpio_cb;
+	struct k_work conversion_work;
+	sensor_trigger_handler_t handler_alert;
+};
+
+int ina23x_trigger_mode_init(struct ina23x_trigger *trigg,
+			     const struct gpio_dt_spec *gpio_alert);
+
+#endif /* ZEPHYR_DRIVERS_SENSOR_INA23X_TRIGGER_H_ */

--- a/dts/bindings/sensor/ti,ina237.yaml
+++ b/dts/bindings/sensor/ti,ina237.yaml
@@ -21,3 +21,13 @@ properties:
       description: |
         Value of the ADC configuration register (ADC conversion times,
         averaging, operating mode and etc).
+
+    alert-config:
+      type: int
+      required: false
+      description: Diag alert register, default matches the power-on reset value
+
+    irq-gpios:
+      type: phandle-array
+      required: false
+      description: IRQ Alert pin

--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -615,6 +615,8 @@ test_i2c_ina237: ina237@52 {
 	current-lsb = <1>;
 	adc-config = <0>;
 	rshunt = <0>;
+	alert-config = <0>;
+	irq-gpios = <&test_gpio 0 0>;
 };
 
 test_i2c_max31875: max31875@53 {


### PR DESCRIPTION
Add missing support for the triggered mode using GPIO interrupt alert pin. It uses mode detection at runtime which allows working multiple sensors with different modes simultaneously.

Fixes and cleanup related to the INA230 will be done in the follow-up PRs.

Signed-off-by: Bartosz Bilas <b.bilas@grinn-global.com>