### PR TITLE
doc: dts: drop compatibility with linux design goal

### DIFF
--- a/doc/build/dts/design.rst
+++ b/doc/build/dts/design.rst
@@ -50,36 +50,9 @@ Source compatibility with other operating systems
 *************************************************
 
 Zephyr's devicetree tooling is based on a generic layer which is interoperable
-with other devicetree users, such as the Linux kernel.
+at a DTS syntax level with other devicetree users, such as the Linux kernel.
 
-Zephyr's binding language *semantics* can support Zephyr-specific attributes,
-but shall not express Zephyr-specific relationships.
-
-Examples
-========
-
-- Zephyr's devicetree source parser, :ref:`dtlib.py <dt-scripts>`, is
-  source-compatible with other tools like `dtc`_ in both directions:
-  :file:`dtlib.py` can parse ``dtc`` output, and ``dtc`` can parse
-  :file:`dtlib.py` output.
-
-- Zephyr's "extended dtlib" library, :file:`edtlib.py`, shall not include
-  Zephyr-specific features. Its purpose is to provide a higher-level view of the
-  devicetree for common elements like interrupts and buses.
-
-  Only the high-level :file:`gen_defines.py` script, which is built on top of
-  :file:`edtlib.py`, contains Zephyr-specific knowledge and features.
-
-.. _dtc: https://git.kernel.org/pub/scm/utils/dtc/dtc.git/about/
-
-Example remaining work
-======================
-
-- Zephyr has a custom :ref:`dt-bindings` language *syntax*. While Linux's
-  dtschema does not yet meet Zephyr's needs, we should try to follow what it is
-  capable of representing in Zephyr's own bindings.
-
-- Due to inflexibility in the bindings language, Zephyr cannot support the full
-  set of bindings supported by Linux.
-
-- Devicetree source sharing between Zephyr and Linux is not done.
+Zephyr's devicetree bindings should be compatible with Linux bindings as well
+whenever that is practical. However, the needs of the two operating systems are
+different, so Zephyr bindings can be incompatible with Linux provided there is
+a strong enough justification to convince the devicetree maintainers.


### PR DESCRIPTION
This hasn't been possible in practice. For example, we use child nodes
in multi-function devices in our devicetrees in order to create
different struct device objects for each 'function', and thus each
zephyr API. There are a litany of other differences, especially since
our bindings are often developed from scratch in our own bindings
language.

However, we do want to be compatible with Linux whenever it makes
sense. Gratuitous incompatibilities are not welcome.

Handle this by relaxing the requirement to "you can violate Linux
compatibility if you can convince the DT maintainers it's a good
idea".

Signed-off-by: Marti Bolivar <marti.bolivar@nordicsemi.no>