### PR TITLE
scripts: Require Python 3.8

### DIFF
--- a/.github/workflows/devicetree_checks.yml
+++ b/.github/workflows/devicetree_checks.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-20.04, macos-11, windows-2022]
         exclude:
           - os: macos-11

--- a/.github/workflows/twister_tests.yml
+++ b/.github/workflows/twister_tests.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-20.04]
     steps:
     - name: checkout

--- a/.github/workflows/west_cmds.yml
+++ b/.github/workflows/west_cmds.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.8, 3.9, '3.10']
         os: [ubuntu-20.04, macos-11, windows-2022]
         exclude:
           - os: macos-11

--- a/cmake/modules/python.cmake
+++ b/cmake/modules/python.cmake
@@ -11,7 +11,7 @@ if (WIN32)
   set(ENV{PYTHONIOENCODING} "utf-8")
 endif()
 
-set(PYTHON_MINIMUM_REQUIRED 3.6)
+set(PYTHON_MINIMUM_REQUIRED 3.8)
 
 # We are using foreach here, instead of find_program(PYTHON_EXECUTABLE_SYSTEM_DEFAULT "python" "python3")
 # cause just using find_program directly could result in a python2.7 as python, and not finding a valid python3.

--- a/doc/develop/getting_started/index.rst
+++ b/doc/develop/getting_started/index.rst
@@ -65,7 +65,7 @@ The current minimum required version for the main dependencies are:
      - 3.20.0
 
    * - `Python <https://www.python.org/>`_
-     - 3.6
+     - 3.8
 
    * - `Devicetree compiler <https://www.devicetree.org/>`_
      - 1.4.6

--- a/doc/releases/release-notes-3.2.rst
+++ b/doc/releases/release-notes-3.2.rst
@@ -19,6 +19,8 @@ API Changes
 Changes in this release
 =======================
 
+* Zephyr now requires Python 3.8 or higher
+
 * Changed :c:struct:`spi_cs_control` to remove anonymous struct.
   This causes possible breakage for static initialization of the
   struct.  Updated :c:macro:`SPI_CS_CONTROL_PTR_DT` to reflect


### PR DESCRIPTION
Given that 3.6 is now several years old and the current and previous
 Ubuntu LTS ship with 3.8 or later, upgrade the minimum required Python
version from 3.6 to 3.8.

Signed-off-by: Carles Cufi <carles.cufi@nordicsemi.no>