### PR TITLE
maintainers: Adding yvanderv, EmilioCBen, and decsny as collaborators

### DIFF
--- a/MAINTAINERS.yml
+++ b/MAINTAINERS.yml
@@ -1763,6 +1763,10 @@ NXP Platforms:
   collaborators:
     - mmahadevan108
     - danieldegrasse
+    - DerekSnell
+    - yvanderv
+    - EmilioCBen
+    - decsny
   files:
     - boards/arm/mimx*/
     - boards/arm/frdm_k*/


### PR DESCRIPTION
Adding yvanderv, EmilioCBen, and decsny as NXP Platform collaborators.

Signed-off-by: David Leach <david.leach@nxp.com>