### PR TITLE
boards: mimxrt1160_evk_cm4: enable standalone debugging

### DIFF
--- a/boards/arm/mimxrt1160_evk/board.cmake
+++ b/boards/arm/mimxrt1160_evk/board.cmake
@@ -4,8 +4,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+if(CONFIG_SOC_MIMXRT1166_CM7)
 board_runner_args(pyocd "--target=mimxrt1160_cm7")
 board_runner_args(jlink "--device=MIMXRT1166xxx6_M7" "--reset-after-load")
+endif()
+
+if(CONFIG_SOC_MIMXRT1166_CM4)
+board_runner_args(pyocd "--target=mimxrt1160_cm4")
+# Note: Please use JLINK above V7.50 (Only support run cm4 image when debugging due to default boot core on board is cm7 core)
+board_runner_args(jlink "--device=MIMXRT1166xxx6_M4")
+endif()
 
 include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)


### PR DESCRIPTION
Enable standalone debugging of secondary CM4 core on MIMXRT1160 EVK.

Signed-off-by: Daniel DeGrasse <daniel.degrasse@nxp.com>