### PR TITLE
clang-format: disable regrouping and sorting of includes

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,7 +63,8 @@ ForEachMacros:
   - 'Z_GENLIST_FOR_EACH_CONTAINER_SAFE'
   - 'Z_GENLIST_FOR_EACH_NODE'
   - 'Z_GENLIST_FOR_EACH_NODE_SAFE'
-IncludeBlocks: Regroup
+# Disabled for now, see bug https://github.com/zephyrproject-rtos/zephyr/issues/48520
+#IncludeBlocks: Regroup
 IncludeCategories:
   - Regex: '^".*\.h"$'
     Priority: 0
@@ -76,6 +77,7 @@ IncludeCategories:
 IndentCaseLabels: false
 IndentWidth: 8
 # SpaceBeforeParens: ControlStatementsExceptControlMacros # clang-format >= 13.0
+SortIncludes: false
 UseTab: Always
 WhitespaceSensitiveMacros:
   - STRINGIFY


### PR DESCRIPTION
Disable regrouping and sorting of includes which can cause issues due to
order requirements in some subsystems.

Fixes #48520

Signed-off-by: Anas Nashif <anas.nashif@intel.com>
