### PR TITLE
[RFC] define some boilerplate macros for device drivers

### DIFF
--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -349,7 +349,8 @@ static int uart_mcux_init(const struct device *dev)
 	return 0;
 }
 
-static const struct uart_driver_api uart_mcux_driver_api = {
+
+UART_DT_INST_API_DECLARE = {
 	.poll_in = uart_mcux_poll_in,
 	.poll_out = uart_mcux_poll_out,
 	.err_check = uart_mcux_err_check,
@@ -384,7 +385,7 @@ static const struct uart_driver_api uart_mcux_driver_api = {
 #endif
 
 #define UART_MCUX_DECLARE_CFG(n, IRQ_FUNC_INIT)				\
-static const struct uart_mcux_config uart_mcux_##n##_config = {		\
+static const struct uart_mcux_config UART_DT_INST_CONFIG_NAME(n) = {	\
 	.base = (UART_Type *)DT_INST_REG_ADDR(n),			\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
 	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
@@ -408,6 +409,7 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 									\
 		irq_enable(DT_INST_IRQ_BY_NAME(n, error, irq));		\
 	}
+
 #define UART_MCUX_IRQ_CFG_FUNC_INIT(n)					\
 	.irq_config_func = uart_mcux_config_func_##n
 #define UART_MCUX_INIT_CFG(n)						\
@@ -422,7 +424,7 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 #define UART_MCUX_INIT(n)						\
 	PINCTRL_DEFINE(n)						\
 									\
-	static struct uart_mcux_data uart_mcux_##n##_data = {		\
+	static struct uart_mcux_data UART_DT_INST_DATA_NAME(n) = {	\
 		.uart_cfg = {						\
 			.stop_bits = UART_CFG_STOP_BITS_1,		\
 			.data_bits = UART_CFG_DATA_BITS_8,		\
@@ -433,16 +435,9 @@ static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 		},							\
 	};								\
 									\
-	static const struct uart_mcux_config uart_mcux_##n##_config;	\
+	static const struct uart_mcux_config UART_DT_INST_CONFIG_NAME(n);\
 									\
-	DEVICE_DT_INST_DEFINE(n,					\
-			    &uart_mcux_init,				\
-			    NULL,					\
-			    &uart_mcux_##n##_data,			\
-			    &uart_mcux_##n##_config,			\
-			    PRE_KERNEL_1,				\
-			    CONFIG_SERIAL_INIT_PRIORITY,		\
-			    &uart_mcux_driver_api);			\
+	UART_DT_INST_DEFINE(n, &uart_mcux_init);			\
 									\
 	UART_MCUX_CONFIG_FUNC(n)					\
 									\

--- a/include/zephyr/drivers/uart.h
+++ b/include/zephyr/drivers/uart.h
@@ -1655,6 +1655,28 @@ static inline int z_impl_uart_drv_cmd(const struct device *dev, uint32_t cmd,
 #endif
 }
 
+#define UART_DT_INST_NAME_PREFIX UTIL_CAT(uart_, DT_DRV_COMPAT)
+
+#define UART_DT_INST_API_NAME(n) UTIL_CAT(UART_DT_INST_NAME_PREFIX, _api)
+
+#define UART_DT_CONFIG_NAME(node_id) UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _config)
+#define UART_DT_DATA_NAME(node_id) UTIL_CAT(Z_DEVICE_DT_DEV_NAME(node_id), _data)
+
+#define UART_DT_INST_CONFIG_NAME(inst) UART_DT_CONFIG_NAME(DT_DRV_INST(inst))
+#define UART_DT_INST_DATA_NAME(inst) UART_DT_DATA_NAME(DT_DRV_INST(inst))
+
+#define UART_DT_INST_API_DECLARE \
+	static const struct uart_driver_api UART_DT_INST_API_NAME
+
+#define UART_DT_INST_DEFINE(n, init_fn) 			\
+	DEVICE_DT_INST_DEFINE(n, init_fn, PM_DEVICE_DT_INST_GET(n),	\
+			    &UART_DT_INST_DATA_NAME(n),			\
+			    &UART_DT_INST_CONFIG_NAME(n),		\
+			    PRE_KERNEL_1,				\
+			    CONFIG_SERIAL_INIT_PRIORITY,		\
+			    &UART_DT_INST_API_NAME)
+
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The PR is meant to start a discuss around value of having some standard naming conventions towards handling boilerplate code in a common way.  Reasons for this:

* reduce code in drivers
* make it easier to make changes if its handled in boilerplate
