### PR TITLE
drivers: gpio: xlnx_ps: Fix compiler warning

### DIFF
--- a/drivers/gpio/gpio_xlnx_ps.h
+++ b/drivers/gpio/gpio_xlnx_ps.h
@@ -37,7 +37,7 @@ struct gpio_xlnx_ps_dev_cfg {
 	struct gpio_driver_config common;
 
 	uint32_t base_addr;
-	const struct device **bank_devices;
+	const struct device *const *bank_devices;
 	uint32_t num_banks;
 	gpio_xlnx_ps_config_irq_t config_func;
 };


### PR DESCRIPTION
Recent change to constify struct devices pointers introduced a
compile warning in gpio_xlnx_ps driver.  Update driver to fix a
case that got missed in the constification that fixes the warning.

Signed-off-by: Kumar Gala <galak@kernel.org>