### PR TITLE
boards: cc3220sf: add connector.dtsi for use in DTOs

### DIFF
--- a/boards/arm/cc3220sf_launchxl/boosterpack_connector.dtsi
+++ b/boards/arm/cc3220sf_launchxl/boosterpack_connector.dtsi
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2022 Dhruva Gole
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/ {
+	boosterpack_header: connector {
+		compatible = "ti,boosterpack-header";
+		#gpio-cells = <2>;
+		gpio-map = <4 0 &gpioa1 4 0>,	/* GPIO_12 */
+				<5 0 &gpioa0 6 0>,	/* GPIO_06 */
+				<7 0 &gpioa1 6 0>,	/* GPIO_14 */
+				<9 0 &gpioa1 2 0>,	/* I2C_SCL | YELLOW_LED */
+				<10 0 &gpioa1 3 0>,	/* I2C_SDA | GREEN_LED  */
+				<11 0 &gpioa2 6 0>,	/* GPIO_22 */
+				<12 0 &gpioa0 1 0>,	/* GPIO_01 */
+				<13 0 &gpioa3 1 0>,	/* GPIO_25 */
+				<14 0 &gpioa1 7 0>,	/* GPIO_15 */
+				<15 0 &gpioa1 3 0>,	/* GPIO_16 */
+				<17 0 &gpioa3 7 0>,	/* GPIO_31 */
+				<18 0 &gpioa2 3 0>,	/* GPIO_17 */
+				<19 0 &gpioa3 4 0>,	/* GPIO_28 */
+				<23 0 &gpioa0 2 0>,	/* GPIO_02 | AIN0 */
+				<24 0 &gpioa0 5 0>,	/* GPIO_05 | AIN3 */
+				<25 0 &gpioa1 3 0>,	/* GPIO_03 | AIN1 */
+				<26 0 &gpioa0 4 0>,	/* GPIO_04 | AIN2 */
+				<27 0 &gpioa1 0 0>,	/* GPIO_08 */
+				<28 0 &gpioa3 6 0>,	/* GPIO_30 */
+				<29 0 &gpioa1 1 0>,	/* GPIO_09 | RED_LED | I2S_DOUT*/
+				<30 0 &gpioa0 0 0>,	/* GPIO_00 */
+				<31 0 &gpioa3 0 0>,	/* GPIO_24 */
+				<32 0 &gpioa2 7 0>;	/* GPIO_23 */
+	};
+};
+
+boosterpack_i2c: &i2c0 {};
+boosterpack_serial: &uart0 {};

--- a/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
+++ b/boards/arm/cc3220sf_launchxl/cc3220sf_launchxl.dts
@@ -3,6 +3,7 @@
 /dts-v1/;
 
 #include <ti/cc3220sf.dtsi>
+#include "boosterpack_connector.dtsi"
 
 / {
 	model = "TI CC3220SF LaunchXL";
@@ -63,6 +64,21 @@
 	status = "okay";
 };
 
+&gpioa0 {
+	status = "okay";
+};
+
+&gpioa1 {
+	status = "okay";
+};
+
+&gpioa2 {
+	status = "okay";
+};
+
+&gpioa3 {
+	status = "okay";
+};
 &uart0 {
 	status = "okay";
 	current-speed = <115200>;


### PR DESCRIPTION
The launchxl_connector.dtsi is an attempt to add something similar to the
arduino_r3_connectors that make using DT overlays with these boards far easier
and cleaner.
This can probably also be expanded to other TI launchpads having similar layouts
as well.

Closes https://github.com/zephyrproject-rtos/zephyr/issues/49298

Signed-off-by: Dhruva Gole <goledhruva@gmail.com>