### PR TITLE
init: specify dependencies between init entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -712,6 +712,7 @@ scripts/build/gen_image_info.py           @tejlmand
 /scripts/list_boards.py                   @mbolivar-nordic
 /scripts/build/process_gperf.py           @dcpleung @nashif
 /scripts/build/gen_relocate_app.py        @dcpleung
+/scripts/build/elf_parser.py              @JordanYates
 /scripts/requirements*.txt                @mbolivar-nordic @galak @nashif
 /scripts/tests/twister/                   @aasthagr
 /scripts/tests/build/test_subfolder_list.py @rmstoi

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -236,6 +236,18 @@ typedef int16_t device_handle_t;
 			__VA_ARGS__)
 
 /**
+ * @brief Manually specify other init entries that device object depends on
+ *
+ * @note Only dependencies not expressed in the devicetree need to be specified.
+ *
+ * @param node_id The devicetree node identifier.
+ *
+ * @param ... List of init entries that device depends on.
+ */
+#define DEVICE_DT_MANUAL_DEPS(node_id, ...) \
+	Z_DEVICE_MANUAL_DEPS(Z_DEVICE_DT_DEV_NAME(node_id), __VA_ARGS__)
+
+/**
  * @brief Like DEVICE_DT_DEFINE(), but uses an instance of a
  * DT_DRV_COMPAT compatible instead of a node identifier.
  *
@@ -246,6 +258,20 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_DT_INST_DEFINE(inst, ...) \
 	DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
+
+/**
+ * @brief Like DEVICE_DT_MANUAL_DEPS(), but uses an instance
+ * of a DT_DRV_COMPAT compatible instead of a node identifier.
+ *
+ * @note Only dependencies not expressed in the devicetree need to be specified.
+ *
+ * @param inst instance number. The @p node_id argument to
+ * DEVICE_DT_DEFINE is set to <tt>DT_DRV_INST(inst)</tt>.
+ *
+ * @param ... List of init entries that device depends on.
+ */
+#define DEVICE_DT_INST_MANUAL_DEPS(inst, ...) \
+	DEVICE_DT_MANUAL_DEPS(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
  * @brief The name of the global device object for @p node_id
@@ -922,6 +948,16 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 		     Z_STRINGIFY(DEVICE_NAME_GET(drv_name)) " too long"); \
 	Z_INIT_ENTRY_DEFINE(DEVICE_NAME_GET(dev_name), init_fn,		\
 		(&DEVICE_NAME_GET(dev_name)), level, prio)
+
+/**
+ * @brief Manually define dependencies on other init objects
+ *
+ * @param dev_name Unique token from @ref DEVICE_DEFINE
+ *
+ * @param ... List of init entries that device depends on
+ */
+#define Z_DEVICE_MANUAL_DEPS(dev_name, ...) \
+	Z_INIT_ENTRY_DEPS(DEVICE_NAME_GET(dev_name), __VA_ARGS__)
 
 #if CONFIG_HAS_DTS
 /*

--- a/include/zephyr/device.h
+++ b/include/zephyr/device.h
@@ -225,15 +225,14 @@ typedef int16_t device_handle_t;
  */
 #define DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
 			 data_ptr, cfg_ptr, level, prio,		\
-			 api_ptr, ...)					\
+			 api_ptr)					\
 	Z_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)) \
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
 			DEVICE_DT_NAME(node_id), init_fn,		\
 			pm_device,					\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr,					\
-			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)),	\
-			__VA_ARGS__)
+			&Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)))
 
 /**
  * @brief Manually specify other init entries that device object depends on
@@ -844,9 +843,6 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 			    (node_id),					\
 			    (dev_name)))
 
-#define Z_DEVICE_EXTRA_HANDLES(...)				\
-	FOR_EACH_NONEMPTY_TERM(IDENTITY, (,), __VA_ARGS__)
-
 /*
  * Utility macro to define and initialize the device state.
  *
@@ -860,8 +856,8 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
 /* Construct objects that are referenced from struct device. These
  * include power management and dependency handles.
  */
-#define Z_DEVICE_DEFINE_PRE(node_id, dev_name, ...)			\
-	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, __VA_ARGS__)
+#define Z_DEVICE_DEFINE_PRE(node_id, dev_name)			\
+	Z_DEVICE_DEFINE_HANDLES(node_id, dev_name)
 
 /* Initial build provides a record that associates the device object
  * with its devicetree ordinal, and provides the dependency ordinals.
@@ -902,7 +898,7 @@ static inline bool z_impl_device_is_ready(const struct device *dev)
  * `gen_handles.py` must be updated.
  */
 BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
-#define Z_DEVICE_DEFINE_HANDLES(node_id, dev_name, ...)			\
+#define Z_DEVICE_DEFINE_HANDLES(node_id, dev_name)			\
 	extern Z_DEVICE_HANDLES_CONST device_handle_t			\
 		Z_DEVICE_HANDLE_NAME(node_id, dev_name)[];		\
 	Z_DEVICE_HANDLES_CONST device_handle_t				\
@@ -917,7 +913,6 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
 			DEVICE_HANDLE_NULL,				\
 		))							\
 			DEVICE_HANDLE_SEP,				\
-			Z_DEVICE_EXTRA_HANDLES(__VA_ARGS__)		\
 			DEVICE_HANDLE_SEP,				\
 	COND_CODE_1(DT_NODE_EXISTS(node_id),				\
 			(DT_SUPPORTS_DEP_ORDS(node_id)), ())		\
@@ -930,8 +925,8 @@ BUILD_ASSERT(sizeof(device_handle_t) == 2, "fix the linker scripts");
  * dependency handles that come from outside devicetree.
  */
 #define Z_DEVICE_DEFINE(node_id, dev_name, drv_name, init_fn, pm_device,\
-			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr, ...)	\
-	Z_DEVICE_DEFINE_PRE(node_id, dev_name, __VA_ARGS__)		\
+			data_ptr, cfg_ptr, level, prio, api_ptr, state_ptr)	\
+	Z_DEVICE_DEFINE_PRE(node_id, dev_name)		\
 	COND_CODE_1(DT_NODE_EXISTS(node_id), (), (static))		\
 		const Z_DECL_ALIGN(struct device)			\
 		DEVICE_NAME_GET(dev_name) __used			\

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -585,7 +585,7 @@ struct can_device_state {
  */
 #define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
 			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
+			     api_ptr)				\
 	Z_CAN_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)); \
 	Z_CAN_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
@@ -594,8 +594,7 @@ struct can_device_state {
 			pm_device,					\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr,					\
-			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate), \
-			__VA_ARGS__)
+			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate))
 
 #else /* CONFIG_CAN_STATS */
 
@@ -608,10 +607,10 @@ struct can_device_state {
 
 #define CAN_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
 			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
+			     api_ptr)					\
 	DEVICE_DT_DEFINE(node_id, init_fn, pm_device,			\
 			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, __VA_ARGS__)
+			     api_ptr)
 
 #endif /* CONFIG_CAN_STATS */
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -480,7 +480,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
  */
 #define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
 			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
+			     api_ptr)				\
 	Z_I2C_DEVICE_STATE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id)); \
 	Z_I2C_INIT_FN(Z_DEVICE_DT_DEV_NAME(node_id), init_fn)		\
 	Z_DEVICE_DEFINE(node_id, Z_DEVICE_DT_DEV_NAME(node_id),		\
@@ -489,8 +489,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 			pm_device,					\
 			data_ptr, cfg_ptr, level, prio,			\
 			api_ptr,					\
-			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate), \
-			__VA_ARGS__)
+			&(Z_DEVICE_STATE_NAME(Z_DEVICE_DT_DEV_NAME(node_id)).devstate))
 
 #else /* CONFIG_I2C_STATS */
 
@@ -504,10 +503,10 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 
 #define I2C_DEVICE_DT_DEFINE(node_id, init_fn, pm_device,		\
 			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, ...)				\
+			     api_ptr)					\
 	DEVICE_DT_DEFINE(node_id, &init_fn, pm_device,			\
 			     data_ptr, cfg_ptr, level, prio,		\
-			     api_ptr, __VA_ARGS__)
+			     api_ptr)
 
 #endif /* CONFIG_I2C_STATS */
 

--- a/include/zephyr/init.h
+++ b/include/zephyr/init.h
@@ -68,6 +68,32 @@ void z_sys_init_run_level(int32_t level);
 #define Z_INIT_ENTRY_NAME(_entry_name) _CONCAT(__init_, _entry_name)
 
 /**
+ * @brief Construct a reference to a @ref init_entry instance
+ *
+ * @param _entry_name Base unique name
+ */
+#define Z_INIT_ENTRY_GET(_entry_name) &Z_INIT_ENTRY_NAME(_entry_name)
+
+/**
+ * @brief Specify init dependencies for script processing
+ *
+ * The first entry of the array is the address of the init entry being described,
+ * additional entries are the dependencies.
+ *
+ * @param _entry_name Init entry name from @ref Z_INIT_ENTRY_DEFINE
+ *
+ * @param ... List of names provided to other invocations of @ref Z_INIT_ENTRY_DEFINE
+ *            that @a _entry_name depends on
+ */
+#define Z_INIT_ENTRY_DEPS(_entry_name, ...)					   \
+	static const struct init_entry*						   \
+	_CONCAT(__initdeps, _entry_name)[] __used				   \
+	__attribute__((__section__(".__init_dependencies"))) = {		   \
+			Z_INIT_ENTRY_GET(_entry_name),				   \
+			FOR_EACH_NONEMPTY_TERM(Z_INIT_ENTRY_GET, (,), __VA_ARGS__) \
+			}
+
+/**
  * @brief Create an init entry object and set it up for boot time initialization
  *
  * @details This macro defines an init entry object that will be automatically

--- a/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
+++ b/include/zephyr/linker/common-rom/common-rom-kernel-devices.ld
@@ -83,3 +83,15 @@
 #include <zephyr/linker/device-handles.ld>
 	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
 #endif /* !CONFIG_HAS_DYNAMIC_DEVICE_HANDLES */
+
+#ifdef LINKER_DEVICE_HANDLES_PASS1
+	SECTION_DATA_PROLOGUE(init_dependencies,,)
+	{
+		KEEP(*(SORT(.__init_dependencies*)));
+	} GROUP_ROM_LINK_IN(RAMABLE_REGION, ROMABLE_REGION)
+#else
+	/DISCARD/ :
+	{
+		*(.__init_dependencies*)
+	}
+#endif /* LINKER_DEVICE_HANDLES_PASS1 */

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -135,10 +135,12 @@ def main():
             # specified order.  Sort each sub-category of device handle types
             # separately, so that the generated C array is reproducible across
             # builds.
+            injected_devices = [dep.dev for dep in dev.init.dependencies if dep.is_device]
+            supported_devices = dev.devs_supports.union({sup.dev for sup in dev.init.supports if sup.is_device})
             sorted_handles = {
                 "depends": sorted(dev.devs_depends_on, key=lambda d: d.handle),
-                "injected": sorted(dev.devs_depends_on_injected, key=lambda d: d.handle),
-                "supports": sorted(dev.devs_supports, key=lambda d: d.handle),
+                "injected": sorted(injected_devices, key=lambda d: d.handle),
+                "supports": sorted(supported_devices, key=lambda d: d.handle),
             }
             extra_sups = args.num_dynamic_devices if dev.pm and dev.pm.is_power_domain else 0
             lines = c_handle_comment(dev, sorted_handles)

--- a/scripts/build/gen_handles.py
+++ b/scripts/build/gen_handles.py
@@ -130,7 +130,7 @@ def main():
     with open(args.output_source, "w") as fp:
         fp.write('#include <zephyr/device.h>\n')
         fp.write('#include <zephyr/toolchain.h>\n')
-        for dev in parsed_elf.devices:
+        for dev in parsed_elf.devices.values():
             # The device handle are collected up in a set, which has no
             # specified order.  Sort each sub-category of device handle types
             # separately, so that the generated C array is reproducible across

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -52,6 +52,8 @@ DEVICE_DT_DEFINE(TEST_PARTITION, dev_init, NULL,
 /* Device with both an existing and missing injected dependency */
 DEVICE_DT_DEFINE(TEST_GPIO_INJECTED, dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 70, NULL, DT_DEP_ORD(TEST_DEVB), 999);
+DEVICE_DT_MANUAL_DEPS(TEST_GPIO_INJECTED, DEVICE_DT_NAME_GET(TEST_DEVB));
+
 /* Manually specified device */
 DEVICE_DEFINE(manual_dev, "Manual Device", dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 80, NULL);

--- a/tests/lib/devicetree/devices/src/main.c
+++ b/tests/lib/devicetree/devices/src/main.c
@@ -49,9 +49,9 @@ DEVICE_DT_DEFINE(TEST_DEVC, dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 50, NULL);
 DEVICE_DT_DEFINE(TEST_PARTITION, dev_init, NULL,
 		 NULL, NULL, POST_KERNEL, 60, NULL);
-/* Device with both an existing and missing injected dependency */
+/* Device with an additional device dependency */
 DEVICE_DT_DEFINE(TEST_GPIO_INJECTED, dev_init, NULL,
-		 NULL, NULL, POST_KERNEL, 70, NULL, DT_DEP_ORD(TEST_DEVB), 999);
+		 NULL, NULL, POST_KERNEL, 70, NULL);
 DEVICE_DT_MANUAL_DEPS(TEST_GPIO_INJECTED, DEVICE_DT_NAME_GET(TEST_DEVB));
 
 /* Manually specified device */


### PR DESCRIPTION
Introduce a mechanism to specify dependencies between `struct init_entry` instances, which includes both `SYS_INIT` macros and `struct device` instances. This allows code to specify that devices depend on a certain `SYS_INIT` instance, or vice-versa.

Removes the old, undocumented, unused mechanism of injecting dependencies to devices via devicetree ordinals.

Being able to specify dependencies between all init entries is progress towards https://github.com/zephyrproject-rtos/zephyr/issues/22545 and https://github.com/zephyrproject-rtos/zephyr/issues/34518