### PR TITLE
Allow k_poll to wait on pipes

### DIFF
--- a/include/zephyr/kernel.h
+++ b/include/zephyr/kernel.h
@@ -4645,6 +4645,8 @@ struct k_pipe {
 		_wait_q_t      writers; /**< Writer wait queue */
 	} wait_q;			/** Wait queue */
 
+	_POLL_EVENT;
+
 	uint8_t	       flags;		/**< Flags */
 
 	SYS_PORT_TRACING_TRACKING_FIELD(k_pipe)
@@ -4667,7 +4669,8 @@ struct k_pipe {
 		.readers = Z_WAIT_Q_INIT(&obj.wait_q.readers),       \
 		.writers = Z_WAIT_Q_INIT(&obj.wait_q.writers)        \
 	},                                                          \
-	.flags = 0                                                  \
+	_POLL_EVENT_OBJ_INIT(obj)                                   \
+	.flags = 0,                                                 \
 	}
 
 /**
@@ -5309,6 +5312,9 @@ enum _poll_types_bits {
 	/* msgq data availability */
 	_POLL_TYPE_MSGQ_DATA_AVAILABLE,
 
+	/* pipe data availability */
+	_POLL_TYPE_PIPE_DATA_AVAILABLE,
+
 	_POLL_NUM_TYPES
 };
 
@@ -5333,6 +5339,9 @@ enum _poll_states_bits {
 
 	/* data is available to read on a message queue */
 	_POLL_STATE_MSGQ_DATA_AVAILABLE,
+
+	/* data is available to read from a pipe */
+	_POLL_STATE_PIPE_DATA_AVAILABLE,
 
 	_POLL_NUM_STATES
 };
@@ -5365,6 +5374,7 @@ enum _poll_states_bits {
 #define K_POLL_TYPE_DATA_AVAILABLE Z_POLL_TYPE_BIT(_POLL_TYPE_DATA_AVAILABLE)
 #define K_POLL_TYPE_FIFO_DATA_AVAILABLE K_POLL_TYPE_DATA_AVAILABLE
 #define K_POLL_TYPE_MSGQ_DATA_AVAILABLE Z_POLL_TYPE_BIT(_POLL_TYPE_MSGQ_DATA_AVAILABLE)
+#define K_POLL_TYPE_PIPE_DATA_AVAILABLE Z_POLL_TYPE_BIT(_POLL_TYPE_PIPE_DATA_AVAILABLE)
 
 /* public - polling modes */
 enum k_poll_modes {
@@ -5381,6 +5391,7 @@ enum k_poll_modes {
 #define K_POLL_STATE_DATA_AVAILABLE Z_POLL_STATE_BIT(_POLL_STATE_DATA_AVAILABLE)
 #define K_POLL_STATE_FIFO_DATA_AVAILABLE K_POLL_STATE_DATA_AVAILABLE
 #define K_POLL_STATE_MSGQ_DATA_AVAILABLE Z_POLL_STATE_BIT(_POLL_STATE_MSGQ_DATA_AVAILABLE)
+#define K_POLL_STATE_PIPE_DATA_AVAILABLE Z_POLL_STATE_BIT(_POLL_STATE_PIPE_DATA_AVAILABLE)
 #define K_POLL_STATE_CANCELLED Z_POLL_STATE_BIT(_POLL_STATE_CANCELLED)
 
 /* public - poll signal object */
@@ -5438,6 +5449,9 @@ struct k_poll_event {
 		struct k_fifo *fifo;
 		struct k_queue *queue;
 		struct k_msgq *msgq;
+#ifdef CONFIG_PIPES
+		struct k_pipe *pipe;
+#endif
 	};
 };
 

--- a/kernel/poll.c
+++ b/kernel/poll.c
@@ -86,6 +86,13 @@ static inline bool is_condition_met(struct k_poll_event *event, uint32_t *state)
 			return true;
 		}
 		break;
+#ifdef CONFIG_PIPES
+	case K_POLL_TYPE_PIPE_DATA_AVAILABLE:
+		if (k_pipe_read_avail(event->pipe)) {
+			*state = K_POLL_STATE_PIPE_DATA_AVAILABLE;
+			return true;
+		}
+#endif
 	case K_POLL_TYPE_IGNORE:
 		break;
 	default:
@@ -146,6 +153,12 @@ static inline void register_event(struct k_poll_event *event,
 		__ASSERT(event->msgq != NULL, "invalid message queue\n");
 		add_event(&event->msgq->poll_events, event, poller);
 		break;
+#ifdef CONFIG_PIPES
+	case K_POLL_TYPE_PIPE_DATA_AVAILABLE:
+		__ASSERT(event->pipe != NULL, "invalid pipe\n");
+		add_event(&event->pipe->poll_events, event, poller);
+		break;
+#endif
 	case K_POLL_TYPE_IGNORE:
 		/* nothing to do */
 		break;
@@ -181,6 +194,12 @@ static inline void clear_event_registration(struct k_poll_event *event)
 		__ASSERT(event->msgq != NULL, "invalid message queue\n");
 		remove_event = true;
 		break;
+#ifdef CONFIG_PIPES
+	case K_POLL_TYPE_PIPE_DATA_AVAILABLE:
+		__ASSERT(event->pipe != NULL, "invalid pipe\n");
+		remove_event = true;
+		break;
+#endif
 	case K_POLL_TYPE_IGNORE:
 		/* nothing to do */
 		break;
@@ -397,6 +416,11 @@ static inline int z_vrfy_k_poll(struct k_poll_event *events,
 		case K_POLL_TYPE_MSGQ_DATA_AVAILABLE:
 			Z_OOPS(Z_SYSCALL_OBJ(e->msgq, K_OBJ_MSGQ));
 			break;
+#ifdef CONFIG_PIPES
+		case K_POLL_TYPE_PIPE_DATA_AVAILABLE:
+			Z_OOPS(Z_SYSCALL_OBJ(e->pipe, K_OBJ_PIPE));
+			break;
+#endif
 		default:
 			ret = -EINVAL;
 			goto out_free;


### PR DESCRIPTION
Hi,

I'd like to have the ability to poll on multiple pipes, so I had a go at adding it to the kernel myself. I have tested this code on `native_posix` and it works fine there at least. I know that tests and documentation is currently missing, but I wanted to ask a few questions first:

1. Would this kind of PR be reasonably accepted? ie am I missing something here as to why you should never poll on pipes
2. Should the tests be added to `poll` or `pipe`? I would have to change the `prj.conf` of either one to add support for the other. Or should I create a brand new folder called `poll_pipe` ?
3. I have a small sample for `k_poll` which I would like to contribute to the `samples/kernel` folder. Is this acceptable/should it be in a separate PR? I have put the sample code below as it is fairly short.

I would appreciate any feedback on any of this.

Thanks.

```
/*
 * Copyright (c) 2022 Jeremy Herbert
 *
 * SPDX-License-Identifier: Apache-2.0
 */

#include <zephyr/zephyr.h>

/* Define a semaphore with an initial value of 0 and a max value of 1
   and also start a thread to periodically give the semaphore */
K_SEM_DEFINE(my_sem, 0, 1);

void sem_give_func(void *arg1, void *arg2, void *arg3) {
	while (true) {
		k_sleep(K_MSEC(987));
		k_sem_give(&my_sem);
	}
}

K_THREAD_DEFINE(sem_give_thread, 512, sem_give_func, NULL, NULL, NULL, K_IDLE_PRIO-1, 0, 0);


/* Define a pipe with a 100 byte ringbuffer, aligned to a 4 byte boundary
   and also start a thread to periodically put a character in the pipe */
K_PIPE_DEFINE(my_pipe, 100, 4);

void pipe_put_func(void *arg1, void *arg2, void *arg3) {
	size_t bytes_written;

	while (true) {
		k_sleep(K_MSEC(733));
		k_pipe_put(&my_pipe, "a", 1, &bytes_written, 1, K_NO_WAIT);

		__ASSERT(bytes_written == 1, "pipe full\n");
	}
}

K_THREAD_DEFINE(pipe_put_thread, 512, pipe_put_func, NULL, NULL, NULL, 
				K_IDLE_PRIO-1, 0, 0);


struct k_poll_event events[2] = {
	K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_SEM_AVAILABLE,
									K_POLL_MODE_NOTIFY_ONLY,
									&my_sem, 0),
	K_POLL_EVENT_STATIC_INITIALIZER(K_POLL_TYPE_PIPE_DATA_AVAILABLE,
									K_POLL_MODE_NOTIFY_ONLY,
									&my_pipe, 0),
};

void main(void)
{
	int status;
	size_t pipe_bytes_received;
	char pipe_received_data;

	printk("Polling for events...\n");

	while (true) {
		status = k_poll(events, ARRAY_SIZE(events), K_MSEC(250));
		if (status == 0) {

			if (events[0].state == K_POLL_STATE_SEM_AVAILABLE) {
				printk("Semaphore available! Taking...\n");
				status = k_sem_take(events[0].sem, K_NO_WAIT);

				__ASSERT(status == 0, "semaphore not taken\n");
			}

			if (events[1].state == K_POLL_STATE_PIPE_DATA_AVAILABLE) {
				printk("Pipe data available! Receiving...\n");
				status = k_pipe_get(events[1].pipe, &pipe_received_data, 1, 
									&pipe_bytes_received, 1, K_NO_WAIT);

				__ASSERT(status == 0, "pipe data not available\n");
				__ASSERT(pipe_bytes_received == 1, "pipe data not received\n");
				__ASSERT(pipe_received_data == 'a', "received pipe data incorrect\n");
			}

			/* reset the state of events */
			events[0].state = K_POLL_STATE_NOT_READY;
			events[1].state = K_POLL_STATE_NOT_READY;

		} else {
			printk("Timeout waiting for events\n");
		}
	}
}
```