### PR TITLE
Bluetooth: Controller: Fix regression in adding ADI in scan rsp PDU

### DIFF
--- a/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
+++ b/subsys/bluetooth/controller/ll_sw/ull_adv_aux.c
@@ -818,7 +818,7 @@ uint8_t ll_adv_aux_sr_data_set(uint8_t handle, uint8_t op, uint8_t frag_pref,
 			ad_len_offset = ULL_ADV_HDR_DATA_DATA_PTR_OFFSET +
 					ULL_ADV_HDR_DATA_DATA_PTR_SIZE;
 			if (hdr_add_fields & ULL_ADV_PDU_HDR_FIELD_ADI) {
-				ad_len_offset =
+				ad_len_offset +=
 					ULL_ADV_HDR_DATA_ADI_PTR_OFFSET +
 					ULL_ADV_HDR_DATA_ADI_PTR_SIZE;
 			}


### PR DESCRIPTION
Fix regression in adding ADI in scan response PDU introduced
in implementation adding support for AD data fragment
operation.

Setting scan response data with ADI failed with too long
data error. This was caused by a bug in calculating the
offset to the overflow length returned back by the call
to set_clear function.

Signed-off-by: Vinayak Kariappa Chettimada <vich@nordicsemi.no>