### PR TITLE
Bluetooth: Mesh: Use mesh settings API only if settings are enabled

### DIFF
--- a/subsys/bluetooth/mesh/cdb.c
+++ b/subsys/bluetooth/mesh/cdb.c
@@ -728,9 +728,8 @@ void bt_mesh_cdb_clear(void)
 
 	if (IS_ENABLED(CONFIG_BT_SETTINGS)) {
 		update_cdb_net_settings();
+		bt_mesh_settings_store_pending();
 	}
-
-	bt_mesh_settings_store_pending();
 }
 
 void bt_mesh_cdb_iv_update(uint32_t iv_index, bool iv_update)


### PR DESCRIPTION
Don't call bt_mesh_settings_store_pending if CONFIG_BT_SETTINGS is not
enabled.

Signed-off-by: Pavel Vasilyev <pavel.vasilyev@nordicsemi.no>