### PR TITLE
drivers: sensors: fix DRDY usage

### DIFF
--- a/drivers/sensor/hts221/hts221.c
+++ b/drivers/sensor/hts221/hts221.c
@@ -116,7 +116,7 @@ static int hts221_read_conversion_data(const struct device *dev)
 }
 
 static const struct sensor_driver_api hts221_driver_api = {
-#if HTS221_TRIGGER_ENABLED
+#if CONFIG_HTS221_TRIGGER
 	.trigger_set = hts221_trigger_set,
 #endif
 	.sample_fetch = hts221_sample_fetch,
@@ -185,7 +185,7 @@ int hts221_init(const struct device *dev)
 		return status;
 	}
 
-#if HTS221_TRIGGER_ENABLED
+#if CONFIG_HTS221_TRIGGER
 	status = hts221_init_interrupt(dev);
 	if (status < 0) {
 		LOG_ERR("Failed to initialize interrupt.");


### PR DESCRIPTION
hts221_trigger.c is pulled in by the CMakeLists.txt file when
CONFIG_HTS221_TRIGGER is defined. Therefore make the source in hts221.c use
the some define.

This removes also the (wrong) warning

    <inf> HTS221: Cannot enable trigger without drdy-gpios

even when "drdy-gpios" is defined in the device-tree.