### PR TITLE
devices: constify device pointers initialized at compile time

### DIFF
--- a/boards/arm/mec1501modular_assy6885/pinmux.c
+++ b/boards/arm/mec1501modular_assy6885/pinmux.c
@@ -130,42 +130,42 @@ static int board_pinmux_init(const struct device *dev)
 	struct pinmux_ports_t pinmux_ports;
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_000_036), okay)
-	const struct device *porta = DEVICE_DT_GET(DT_NODELABEL(pinmux_000_036));
+	const struct device *const porta = DEVICE_DT_GET(DT_NODELABEL(pinmux_000_036));
 
 	__ASSERT_NO_MSG(device_is_ready(porta));
 
 	pinmux_ports.porta = porta;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_040_076), okay)
-	const struct device *portb = DEVICE_DT_GET(DT_NODELABEL(pinmux_040_076));
+	const struct device *const portb = DEVICE_DT_GET(DT_NODELABEL(pinmux_040_076));
 
 	__ASSERT_NO_MSG(device_is_ready(portb));
 
 	pinmux_ports.portb = portb;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_100_136), okay)
-	const struct device *portc = DEVICE_DT_GET(DT_NODELABEL(pinmux_100_136));
+	const struct device *const portc = DEVICE_DT_GET(DT_NODELABEL(pinmux_100_136));
 
 	__ASSERT_NO_MSG(device_is_ready(portc));
 
 	pinmux_ports.portc = portc;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_140_176), okay)
-	const struct device *portd = DEVICE_DT_GET(DT_NODELABEL(pinmux_140_176));
+	const struct device *const portd = DEVICE_DT_GET(DT_NODELABEL(pinmux_140_176));
 
 	__ASSERT_NO_MSG(device_is_ready(portd));
 
 	pinmux_ports.portd = portd;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_200_236), okay)
-	const struct device *porte = DEVICE_DT_GET(DT_NODELABEL(pinmux_200_236));
+	const struct device *const porte = DEVICE_DT_GET(DT_NODELABEL(pinmux_200_236));
 
 	__ASSERT_NO_MSG(device_is_ready(porte));
 
 	pinmux_ports.porte = porte;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_240_276), okay)
-	const struct device *portf = DEVICE_DT_GET(DT_NODELABEL(pinmux_240_276));
+	const struct device *const portf = DEVICE_DT_GET(DT_NODELABEL(pinmux_240_276));
 
 	__ASSERT_NO_MSG(device_is_ready(portf));
 

--- a/boards/arm/mec15xxevb_assy6853/pinmux.c
+++ b/boards/arm/mec15xxevb_assy6853/pinmux.c
@@ -132,42 +132,42 @@ static int board_pinmux_init(const struct device *dev)
 	struct pinmux_ports_t pinmux_ports;
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_000_036), okay)
-	const struct device *porta = DEVICE_DT_GET(DT_NODELABEL(pinmux_000_036));
+	const struct device *const porta = DEVICE_DT_GET(DT_NODELABEL(pinmux_000_036));
 
 	__ASSERT_NO_MSG(device_is_ready(porta));
 
 	pinmux_ports.porta = porta;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_040_076), okay)
-	const struct device *portb = DEVICE_DT_GET(DT_NODELABEL(pinmux_040_076));
+	const struct device *const portb = DEVICE_DT_GET(DT_NODELABEL(pinmux_040_076));
 
 	__ASSERT_NO_MSG(device_is_ready(portb));
 
 	pinmux_ports.portb = portb;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_100_136), okay)
-	const struct device *portc = DEVICE_DT_GET(DT_NODELABEL(pinmux_100_136));
+	const struct device *const portc = DEVICE_DT_GET(DT_NODELABEL(pinmux_100_136));
 
 	__ASSERT_NO_MSG(device_is_ready(portc));
 
 	pinmux_ports.portc = portc;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_140_176), okay)
-	const struct device *portd = DEVICE_DT_GET(DT_NODELABEL(pinmux_140_176));
+	const struct device *const portd = DEVICE_DT_GET(DT_NODELABEL(pinmux_140_176));
 
 	__ASSERT_NO_MSG(device_is_ready(portd));
 
 	pinmux_ports.portd = portd;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_200_236), okay)
-	const struct device *porte = DEVICE_DT_GET(DT_NODELABEL(pinmux_200_236));
+	const struct device *const porte = DEVICE_DT_GET(DT_NODELABEL(pinmux_200_236));
 
 	__ASSERT_NO_MSG(device_is_ready(porte));
 
 	pinmux_ports.porte = porte;
 #endif
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pinmux_240_276), okay)
-	const struct device *portf = DEVICE_DT_GET(DT_NODELABEL(pinmux_240_276));
+	const struct device *const portf = DEVICE_DT_GET(DT_NODELABEL(pinmux_240_276));
 
 	__ASSERT_NO_MSG(device_is_ready(portf));
 

--- a/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
+++ b/boards/arm/nrf9160dk_nrf9160/nrf52840_reset.c
@@ -21,7 +21,7 @@ int bt_hci_transport_setup(const struct device *h4)
 {
 	int err;
 	char c;
-	const struct device *port = DEVICE_DT_GET(RESET_GPIO_CTRL);
+	const struct device *const port = DEVICE_DT_GET(RESET_GPIO_CTRL);
 
 	if (!device_is_ready(port)) {
 		return -EIO;

--- a/boards/arm/sparkfun_thing_plus_nrf9160/board.c
+++ b/boards/arm/sparkfun_thing_plus_nrf9160/board.c
@@ -15,7 +15,7 @@ static int board_sparkfun_thing_plus_nrf9160_init(const struct device *dev)
 	ARG_UNUSED(dev);
 
 	/* Get handle of the GPIO device. */
-	const struct device *gpio = DEVICE_DT_GET(GPIO0);
+	const struct device *const gpio = DEVICE_DT_GET(GPIO0);
 
 	if (!device_is_ready(gpio)) {
 		return -ENODEV;

--- a/boards/riscv/rv32m1_vega/board.c
+++ b/boards/riscv/rv32m1_vega/board.c
@@ -10,9 +10,9 @@
 
 static int rv32m1_vega_board_init(const struct device *dev)
 {
-	const struct device *gpiob = DEVICE_DT_GET(DT_NODELABEL(gpiob));
-	const struct device *gpioc = DEVICE_DT_GET(DT_NODELABEL(gpioc));
-	const struct device *gpiod = DEVICE_DT_GET(DT_NODELABEL(gpiod));
+	const struct device *const gpiob = DEVICE_DT_GET(DT_NODELABEL(gpiob));
+	const struct device *const gpioc = DEVICE_DT_GET(DT_NODELABEL(gpioc));
+	const struct device *const gpiod = DEVICE_DT_GET(DT_NODELABEL(gpiod));
 
 	ARG_UNUSED(dev);
 

--- a/doc/build/dts/howtos.rst
+++ b/doc/build/dts/howtos.rst
@@ -104,7 +104,7 @@ device is to use :c:func:`DEVICE_DT_GET`:
 
 .. code-block:: c
 
-   const struct device *uart_dev = DEVICE_DT_GET(MY_SERIAL);
+   const struct device *const uart_dev = DEVICE_DT_GET(MY_SERIAL);
 
    if (!device_is_ready(uart_dev)) {
            /* Not ready, do not use */
@@ -142,7 +142,7 @@ that the node has ``status = "okay"``, like this:
    #define MY_SERIAL DT_NODELABEL(my_serial)
 
    #if DT_NODE_HAS_STATUS(MY_SERIAL, okay)
-   const struct device *uart_dev = DEVICE_DT_GET(MY_SERIAL);
+   const struct device *const uart_dev = DEVICE_DT_GET(MY_SERIAL);
    #else
    #error "Node is disabled"
    #endif

--- a/doc/hardware/peripherals/canbus/controller.rst
+++ b/doc/hardware/peripherals/canbus/controller.rst
@@ -158,7 +158,7 @@ a mailbox. When a transmitting mailbox is assigned, sending cannot be canceled.
           .dlc = 8,
           .data = {1,2,3,4,5,6,7,8}
   };
-  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+  const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
   int ret;
 
   ret = can_send(can_dev, &frame, K_MSEC(100), NULL, NULL);
@@ -234,7 +234,7 @@ The filter for this example is configured to match the identifier 0x123 exactly.
           .id_mask = CAN_STD_ID_MASK
   };
   int filter_id;
-  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+  const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
   filter_id = can_add_rx_filter(can_dev, rx_callback_function, callback_arg, &my_filter);
   if (filter_id < 0) {
@@ -261,7 +261,7 @@ The filter for this example is configured to match the extended identifier
   CAN_MSGQ_DEFINE(my_can_msgq, 2);
   struct can_frame rx_frame;
   int filter_id;
-  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+  const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
   filter_id = can_add_rx_filter_msgq(can_dev, &my_can_msgq, &my_filter);
   if (filter_id < 0) {
@@ -292,7 +292,7 @@ The following example sets the bitrate to 250k baud with the sampling point at
 .. code-block:: C
 
   struct can_timing timing;
-  const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+  const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
   int ret;
 
   ret = can_calc_timing(can_dev, &timing, 250000, 875);

--- a/doc/services/usb/uds_cdc_acm.rst
+++ b/doc/services/usb/uds_cdc_acm.rst
@@ -72,7 +72,7 @@ the DTR signal:
 
 .. code-block:: c
 
-    const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+    const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
     uint32_t dtr = 0;
 
     if (usb_enable(NULL)) {

--- a/drivers/adc/adc_ite_it8xxx2.c
+++ b/drivers/adc/adc_ite_it8xxx2.c
@@ -176,7 +176,7 @@ static void adc_it8xxx2_get_sample(const struct device *dev)
 
 static void adc_poll_valid_data(void)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	int valid = 0;
 
 	/*
@@ -205,7 +205,7 @@ static void adc_poll_valid_data(void)
 static void adc_enable_measurement(uint32_t ch)
 {
 	struct adc_it8xxx2_regs *const adc_regs = ADC_IT8XXX2_REG_BASE;
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct adc_it8xxx2_data *data = dev->data;
 
 	if (ch <= CHIP_ADC_CH7) {

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -253,7 +253,7 @@ static int adc_nrfx_read_async(const struct device *dev,
 
 static void event_handler(const nrfx_adc_evt_t *p_event)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 
 	if (p_event->type == NRFX_ADC_EVT_DONE) {
 		adc_context_on_sampling_done(&m_data.ctx, dev);

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -969,7 +969,7 @@ static int adc_stm32_init(const struct device *dev)
 {
 	struct adc_stm32_data *data = dev->data;
 	const struct adc_stm32_cfg *config = dev->config;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	ADC_TypeDef *adc = (ADC_TypeDef *)config->base;
 	int err;
 

--- a/drivers/cache/cache_aspeed.c
+++ b/drivers/cache/cache_aspeed.c
@@ -49,7 +49,7 @@
 
 static void aspeed_cache_init(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uint32_t start_bit, end_bit, max_bit;
 
 	/* set all cache areas to no-cache by default */
@@ -112,7 +112,7 @@ void cache_data_enable(void)
 
 void cache_data_disable(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 
 	syscon_write_reg(dev, CACHE_FUNC_CTRL_REG, 0);
 }
@@ -124,14 +124,14 @@ void cache_instr_enable(void)
 
 void cache_instr_disable(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 
 	syscon_write_reg(dev, CACHE_FUNC_CTRL_REG, 0);
 }
 
 int cache_data_all(int op)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uint32_t ctrl;
 	unsigned int key = 0;
 
@@ -162,7 +162,7 @@ int cache_data_all(int op)
 int cache_data_range(void *addr, size_t size, int op)
 {
 	uint32_t aligned_addr, i, n;
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	unsigned int key = 0;
 
 	ARG_UNUSED(op);
@@ -196,7 +196,7 @@ int cache_data_range(void *addr, size_t size, int op)
 
 int cache_instr_all(int op)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uint32_t ctrl;
 	unsigned int key = 0;
 
@@ -227,7 +227,7 @@ int cache_instr_all(int op)
 int cache_instr_range(void *addr, size_t size, int op)
 {
 	uint32_t aligned_addr, i, n;
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	unsigned int key = 0;
 
 	ARG_UNUSED(op);
@@ -262,7 +262,7 @@ int cache_instr_range(void *addr, size_t size, int op)
 #ifdef CONFIG_DCACHE_LINE_SIZE_DETECT
 size_t cache_data_line_size_get(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uint32_t ctrl;
 
 	syscon_read_reg(dev, CACHE_FUNC_CTRL_REG, &ctrl);
@@ -274,7 +274,7 @@ size_t cache_data_line_size_get(void)
 #ifdef CONFIG_ICACHE_LINE_SIZE_DETECT
 size_t cache_instr_line_size_get(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uint32_t ctrl;
 
 	syscon_read_reg(dev, CACHE_FUNC_CTRL_REG, &ctrl);

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -72,7 +72,7 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 	int ret;
 	const struct can_mcan_config *mcan_cfg = dev->config;
 	const struct can_stm32fd_config *stm32fd_cfg = mcan_cfg->custom;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	LL_RCC_SetFDCANClockSource(CAN_STM32FD_CLOCK_SOURCE);
 

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -47,7 +47,7 @@ static int can_stm32h7_clock_enable(const struct device *dev)
 {
 	const struct can_mcan_config *mcan_cfg = dev->config;
 	const struct can_stm32h7_config *stm32h7_cfg = mcan_cfg->custom;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int ret;
 
 	LL_RCC_SetFDCANClockSource(LL_RCC_FDCAN_CLKSOURCE_PLL1Q);

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -320,7 +320,7 @@ static const struct counter_driver_api counter_gecko_driver_api = {
 
 ISR_DIRECT_DECLARE(counter_gecko_isr_0)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct counter_gecko_data *const dev_data = dev->data;
 	counter_alarm_callback_t alarm_callback;
 	uint32_t count = RTCC_CounterGet();

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -278,7 +278,7 @@ void rtc_stm32_isr(const struct device *dev)
 
 static int rtc_stm32_init(const struct device *dev)
 {
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct rtc_stm32_config *cfg = dev->config;
 	struct rtc_stm32_data *data = dev->data;
 

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -144,7 +144,7 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+	const struct device *const clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
 
 	if (!device_is_ready(clk)) {
 		return -ENODEV;

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -147,7 +147,7 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+	const struct device *const clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
 
 	if (!device_is_ready(clk)) {
 		return -ENODEV;

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -449,7 +449,7 @@ static int crypto_stm32_query_caps(const struct device *dev)
 
 static int crypto_stm32_init(const struct device *dev)
 {
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	struct crypto_stm32_data *data = CRYPTO_STM32_DATA(dev);
 	const struct crypto_stm32_config *cfg = CRYPTO_STM32_CFG(dev);
 

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -119,7 +119,7 @@ static int dac_stm32_init(const struct device *dev)
 	int err;
 
 	/* enable clock for subsystem */
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (!device_is_ready(clk)) {
 		LOG_ERR("clock control device not ready");

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -556,7 +556,7 @@ static int stm32_sdmmc_pwr_uninit(struct stm32_sdmmc_priv *priv)
 static int disk_stm32_sdmmc_init(const struct device *dev)
 {
 	struct stm32_sdmmc_priv *priv = dev->data;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	int err;
 
 	if (!device_is_ready(clk)) {

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -615,7 +615,7 @@ DMA_STM32_EXPORT_API int dma_stm32_stop(const struct device *dev, uint32_t id)
 static int dma_stm32_init(const struct device *dev)
 {
 	const struct dma_stm32_config *config = dev->config;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (!device_is_ready(clk)) {
 		LOG_ERR("clock control device not ready");

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -214,7 +214,7 @@ static int dmamux_stm32_init(const struct device *dev)
 {
 #if DT_INST_NODE_HAS_PROP(0, clocks)
 	const struct dmamux_stm32_config *config = dev->config;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (!device_is_ready(clk)) {
 		LOG_ERR("clock control device not ready");

--- a/drivers/edac/edac_ibecc.c
+++ b/drivers/edac/edac_ibecc.c
@@ -385,7 +385,7 @@ static bool handle_nmi(void)
 
 bool z_x86_do_kernel_nmi(const z_arch_esf_t *esf)
 {
-	const struct device *dev = DEVICE_DT_GET(DEVICE_NODE);
+	const struct device *const dev = DEVICE_DT_GET(DEVICE_NODE);
 	struct ibecc_data *data = dev->data;
 	struct ibecc_error error_data;
 	k_spinlock_key_t key;

--- a/drivers/ethernet/eth_e1000.c
+++ b/drivers/ethernet/eth_e1000.c
@@ -439,7 +439,7 @@ static const struct ptp_clock_driver_api api = {
 
 static int ptp_e1000_init(const struct device *port)
 {
-	const struct device *eth_dev = DEVICE_DT_INST_GET(0);
+	const struct device *const eth_dev = DEVICE_DT_INST_GET(0);
 	struct e1000_dev *context = eth_dev->data;
 	struct ptp_context *ptp_context = port->data;
 

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1767,7 +1767,7 @@ static const struct ptp_clock_driver_api api = {
 
 static int ptp_mcux_init(const struct device *port)
 {
-	const struct device *eth_dev = DEVICE_DT_GET(DT_NODELABEL(enet));
+	const struct device *const eth_dev = DEVICE_DT_GET(DT_NODELABEL(enet));
 	struct eth_context *context = eth_dev->data;
 	struct ptp_context *ptp_context = port->data;
 #if defined(CONFIG_PINCTRL)

--- a/drivers/ethernet/eth_native_posix.c
+++ b/drivers/ethernet/eth_native_posix.c
@@ -722,7 +722,7 @@ static const struct ptp_clock_driver_api api = {
 #define PTP_INIT_FUNC(x, _)						\
 	static int ptp_init_##x(const struct device *port)			\
 	{								\
-		const struct device *eth_dev = DEVICE_GET(eth_native_posix_##x); \
+		const struct device *const eth_dev = DEVICE_GET(eth_native_posix_##x); \
 		struct eth_context *context = eth_dev->data;	\
 		struct ptp_context *ptp_context = port->data;	\
 									\

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2460,7 +2460,7 @@ static const struct ptp_clock_driver_api ptp_api = {
 
 static int ptp_gmac_init(const struct device *port)
 {
-	const struct device *eth_dev = DEVICE_DT_INST_GET(0);
+	const struct device *const eth_dev = DEVICE_DT_INST_GET(0);
 	struct eth_sam_dev_data *dev_data = eth_dev->data;
 	struct ptp_context *ptp_context = port->data;
 

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1301,7 +1301,7 @@ static const struct ptp_clock_driver_api api = {
 
 static int ptp_stm32_init(const struct device *port)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(mac));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(mac));
 	struct eth_stm32_hal_dev_data *eth_dev_data = dev->data;
 	const struct eth_stm32_hal_dev_cfg *eth_cfg = dev->config;
 	struct ptp_context *ptp_context = port->data;

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -342,7 +342,7 @@ static int stm32_flash_init(const struct device *dev)
 	 */
 #if DT_INST_NODE_HAS_PROP(0, clocks)
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/*
 	 * On STM32 F0, F1, F3 & L1 series, flash interface clock source is

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -664,7 +664,7 @@ static const struct flash_driver_api flash_stm32h7_api = {
 static int stm32h7_flash_init(const struct device *dev)
 {
 	struct flash_stm32_priv *p = FLASH_STM32_PRIV(dev);
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (!device_is_ready(clk)) {
 		LOG_ERR("clock control device not ready");

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -238,7 +238,7 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
+	const struct device *const clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0));
 
 	if (!device_is_ready(clk)) {
 		return -ENODEV;

--- a/drivers/gpio/gpio_ite_it8xxx2.c
+++ b/drivers/gpio/gpio_ite_it8xxx2.c
@@ -684,8 +684,8 @@ static int gpio_it8xxx2_init_set(const struct device *arg)
 	ARG_UNUSED(arg);
 
 	if (IS_ENABLED(CONFIG_SOC_IT8XXX2_GPIO_GROUP_K_L_DEFAULT_PULL_DOWN)) {
-		const struct device *gpiok = DEVICE_DT_GET(DT_NODELABEL(gpiok));
-		const struct device *gpiol = DEVICE_DT_GET(DT_NODELABEL(gpiol));
+		const struct device *const gpiok = DEVICE_DT_GET(DT_NODELABEL(gpiok));
+		const struct device *const gpiol = DEVICE_DT_GET(DT_NODELABEL(gpiol));
 
 		for (int i = 0; i < 8; i++) {
 			gpio_pin_configure(gpiok, i, GPIO_INPUT | GPIO_PULL_DOWN);
@@ -694,7 +694,7 @@ static int gpio_it8xxx2_init_set(const struct device *arg)
 	}
 
 	if (IS_ENABLED(CONFIG_SOC_IT8XXX2_GPIO_H7_DEFAULT_OUTPUT_LOW)) {
-		const struct device *gpioh = DEVICE_DT_GET(DT_NODELABEL(gpioh));
+		const struct device *const gpioh = DEVICE_DT_GET(DT_NODELABEL(gpioh));
 
 		gpio_pin_configure(gpioh, 7, GPIO_OUTPUT_LOW);
 	}

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -275,7 +275,7 @@ static int gpio_stm32_clock_request(const struct device *dev, bool on)
 	__ASSERT_NO_MSG(dev != NULL);
 
 	/* enable clock for subsystem */
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (on) {
 		ret = clock_control_on(clk,
@@ -383,7 +383,7 @@ static int gpio_stm32_enable_int(int port, int pin)
 	defined(CONFIG_SOC_SERIES_STM32L1X) || \
 	defined(CONFIG_SOC_SERIES_STM32L4X) || \
 	defined(CONFIG_SOC_SERIES_STM32G4X)
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	struct stm32_pclken pclken = {
 #ifdef CONFIG_SOC_SERIES_STM32H7X
 		.bus = STM32_CLOCK_BUS_APB4,

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -199,7 +199,7 @@ static const struct i2c_driver_api api_funcs = {
 
 static int i2c_stm32_init(const struct device *dev)
 {
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct i2c_stm32_config *cfg = dev->config;
 	uint32_t bitrate_cfg;
 	int ret;

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -199,7 +199,7 @@ static const struct i2c_driver_api api_funcs = {
 
 static int i2c_stm32_init(const struct device *dev)
 {
-	const struct device *clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct i2c_stm32_config *cfg = dev->config;
 	uint32_t bitrate_cfg;
 	int ret;
@@ -223,12 +223,12 @@ static int i2c_stm32_init(const struct device *dev)
 	 */
 	k_sem_init(&data->bus_mutex, 1, 1);
 
-	if (!device_is_ready(clock)) {
+	if (!device_is_ready(clk)) {
 		LOG_ERR("clock control device not ready");
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clock,
+	if (clock_control_on(clk,
 		(clock_control_subsys_t *) &cfg->pclken) != 0) {
 		LOG_ERR("i2c: failure enabling clock");
 		return -EIO;

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx.c
@@ -70,7 +70,7 @@ static void cmd_ieee_csma_callback(RF_Handle h, RF_CmdHandle ch, RF_EventMask e)
 {
 	ARG_UNUSED(h);
 
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	update_saved_cmdhandle(ch, (RF_CmdHandle *) &drv_data->saved_cmdhandle);
@@ -86,7 +86,7 @@ static void cmd_ieee_rx_callback(RF_Handle h, RF_CmdHandle ch, RF_EventMask e)
 {
 	ARG_UNUSED(h);
 
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct ieee802154_cc13xx_cc26xx_data *drv_data = dev->data;
 
 	update_saved_cmdhandle(ch, (RF_CmdHandle *) &drv_data->saved_cmdhandle);

--- a/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
+++ b/drivers/ieee802154/ieee802154_cc13xx_cc26xx_subg.c
@@ -135,7 +135,7 @@ static inline bool is_subghz(uint16_t channel)
 static void cmd_prop_tx_adv_callback(RF_Handle h, RF_CmdHandle ch,
 	RF_EventMask e)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_Op *op = RF_getCmdOp(h, ch);
 
@@ -146,7 +146,7 @@ static void cmd_prop_tx_adv_callback(RF_Handle h, RF_CmdHandle ch,
 static void cmd_prop_rx_adv_callback(RF_Handle h, RF_CmdHandle ch,
 	RF_EventMask e)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct ieee802154_cc13xx_cc26xx_subg_data *drv_data = dev->data;
 	RF_Op *op = RF_getCmdOp(h, ch);
 

--- a/drivers/interrupt_controller/intc_exti_stm32.c
+++ b/drivers/interrupt_controller/intc_exti_stm32.c
@@ -431,7 +431,7 @@ DEVICE_DT_DEFINE(EXTI_NODE, &stm32_exti_init,
  */
 int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 {
-	const struct device *dev = DEVICE_DT_GET(EXTI_NODE);
+	const struct device *const dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 
 	if (data->cb[line].cb) {
@@ -446,7 +446,7 @@ int stm32_exti_set_callback(int line, stm32_exti_callback_t cb, void *arg)
 
 void stm32_exti_unset_callback(int line)
 {
-	const struct device *dev = DEVICE_DT_GET(EXTI_NODE);
+	const struct device *const dev = DEVICE_DT_GET(EXTI_NODE);
 	struct stm32_exti_data *data = dev->data;
 
 	data->cb[line].cb = NULL;

--- a/drivers/interrupt_controller/intc_gd32_exti.c
+++ b/drivers/interrupt_controller/intc_gd32_exti.c
@@ -85,7 +85,7 @@ static const uint8_t line2irq[NUM_EXTI_LINES] = {
 
 __unused static void gd32_exti_isr(const void *isr_data)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct gd32_exti_data *data = dev->data;
 	const struct gd32_exti_range *range = isr_data;
 
@@ -138,7 +138,7 @@ void gd32_exti_trigger(uint8_t line, uint8_t trigger)
 
 int gd32_exti_configure(uint8_t line, gd32_exti_cb_t cb, void *user)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct gd32_exti_data *data = dev->data;
 
 	__ASSERT_NO_MSG(line < NUM_EXTI_LINES);

--- a/drivers/interrupt_controller/intc_gicv3_its.c
+++ b/drivers/interrupt_controller/intc_gicv3_its.c
@@ -570,7 +570,7 @@ static uint32_t gicv3_its_get_msi_addr(const struct device *dev)
 
 #define ITS_RDIST_MAP(n)									  \
 	{											  \
-		const struct device *dev = DEVICE_DT_INST_GET(n);				  \
+		const struct device *const dev = DEVICE_DT_INST_GET(n);				  \
 		struct gicv3_its_data *data;							  \
 		int ret;									  \
 												  \
@@ -593,7 +593,7 @@ void its_rdist_map(void)
 
 #define ITS_RDIST_INVALL(n)									\
 	{											\
-		const struct device *dev = DEVICE_DT_INST_GET(n);				\
+		const struct device *const dev = DEVICE_DT_INST_GET(n);				\
 		struct gicv3_its_data *data;							\
 		int ret;									\
 												\

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -106,7 +106,7 @@ static int rv32m1_intmux_get_line_state(const struct device *dev,
 
 static void rv32m1_intmux_isr(const void *arg)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	const struct rv32m1_intmux_config *config = dev->config;
 	INTMUX_Type *regs = DEV_REGS(dev);
 	uint32_t channel = POINTER_TO_UINT(arg);

--- a/drivers/interrupt_controller/intc_sam0_eic.c
+++ b/drivers/interrupt_controller/intc_sam0_eic.c
@@ -95,7 +95,7 @@ static void sam0_eic_isr(const struct device *dev)
 int sam0_eic_acquire(int port, int pin, enum sam0_eic_trigger trigger,
 		     bool filter, sam0_eic_callback_t cb, void *data)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	struct sam0_eic_port_data *port_data;
 	struct sam0_eic_line_assignment *line_assignment;
@@ -185,7 +185,7 @@ err_in_use:
 
 static bool sam0_eic_check_ownership(int port, int pin, int line_index)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	struct sam0_eic_line_assignment *line_assignment =
 		&dev_data->lines[line_index];
@@ -204,7 +204,7 @@ static bool sam0_eic_check_ownership(int port, int pin, int line_index)
 
 int sam0_eic_release(int port, int pin)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	uint32_t mask;
 	int line_index;
@@ -295,7 +295,7 @@ int sam0_eic_disable_interrupt(int port, int pin)
 
 uint32_t sam0_eic_interrupt_pending(int port)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	struct sam0_eic_data *dev_data = dev->data;
 	struct sam0_eic_line_assignment *line_assignment;
 	uint32_t set = EIC->INTFLAG.reg;

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -152,7 +152,7 @@ static int stm32_hsem_mailbox_init(const struct device *dev)
 {
 	struct stm32_hsem_mailbox_data *data = dev->data;
 	const struct stm32_hsem_mailbox_config *cfg = dev->config;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* Config transfer semaphore */
 	switch (CONFIG_IPM_STM32_HSEM_CPU) {

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -985,7 +985,7 @@ static void mux_setup(struct k_work *work)
 	struct k_work_delayable *dwork = k_work_delayable_from_work(work);
 	struct gsm_modem *gsm = CONTAINER_OF(dwork, struct gsm_modem,
 					     gsm_configure_work);
-	const struct device *uart = DEVICE_DT_GET(GSM_UART_NODE);
+	const struct device *const uart = DEVICE_DT_GET(GSM_UART_NODE);
 	int ret;
 
 	gsm_ppp_lock(gsm);

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -327,7 +327,7 @@ static int ps2_npcx_ctrl_init(const struct device *dev)
 	const struct ps2_npcx_ctrl_config *const config = dev->config;
 	struct ps2_npcx_ctrl_data *const data = dev->data;
 	struct ps2_reg *const inst = HAL_PS2_INSTANCE(dev);
-	const struct device *clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
 
 	if (!device_is_ready(clk_dev)) {

--- a/drivers/sensor/shell_battery.c
+++ b/drivers/sensor/shell_battery.c
@@ -54,7 +54,7 @@ static int cmd_battery(const struct shell *shell, size_t argc, char **argv)
 	struct sensor_value temp, volt, current, i_desired, charge_remain;
 	struct sensor_value charge, v_desired, v_design, cap, nom_cap;
 	struct sensor_value full, empty;
-	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(battery));
+	const struct device *const dev = DEVICE_DT_GET(DT_ALIAS(battery));
 	bool allowed;
 	int err;
 

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -126,7 +126,7 @@ static int uart_cmsdk_apb_init(const struct device *dev)
 
 #ifdef CONFIG_CLOCK_CONTROL
 	/* Enable clock for subsystem */
-	const struct device *clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_IDX(0, 1));
+	const struct device *const clk = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR_BY_IDX(0, 1));
 	struct uart_cmsdk_apb_dev_data * const data = dev->data;
 
 	if (!device_is_ready(clk)) {

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -637,7 +637,7 @@ static int uart_stm32_err_check(const struct device *dev)
 static inline void __uart_stm32_get_clock(const struct device *dev)
 {
 	struct uart_stm32_data *data = dev->data;
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	data->clock = clk;
 }

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -142,7 +142,7 @@ int spi_npcx_fiu_release(const struct device *dev,
 static int spi_npcx_fiu_init(const struct device *dev)
 {
 	const struct npcx_spi_fiu_config *const config = dev->config;
-	const struct device *clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
+	const struct device *const clk_dev = DEVICE_DT_GET(NPCX_CLK_CTRL_NODE);
 	int ret;
 
 	if (!device_is_ready(clk_dev)) {

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -188,7 +188,7 @@ void HAL_PCD_SOFCallback(PCD_HandleTypeDef *hpcd)
 
 static int usb_dc_stm32_clock_enable(void)
 {
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	struct stm32_pclken pclken = {
 		.bus = USB_CLOCK_BUS,
 		.enr = USB_CLOCK_BITS,

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -87,7 +87,7 @@ static void wwdg_stm32_irq_config(const struct device *dev);
 
 static uint32_t wwdg_stm32_get_pclk(const struct device *dev)
 {
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
 	uint32_t pclk_rate;
 
@@ -277,7 +277,7 @@ static const struct wdt_driver_api wwdg_stm32_api = {
 
 static int wwdg_stm32_init(const struct device *dev)
 {
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
 
 	wwdg_stm32_irq_config(dev);

--- a/kernel/init.c
+++ b/kernel/init.c
@@ -375,7 +375,7 @@ __boot_func
 void z_early_boot_rand_get(uint8_t *buf, size_t length)
 {
 #ifdef CONFIG_ENTROPY_HAS_DRIVER
-	const struct device *entropy = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
+	const struct device *const entropy = DEVICE_DT_GET_OR_NULL(DT_CHOSEN(zephyr_entropy));
 	int rc;
 
 	if (!device_is_ready(entropy)) {

--- a/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
+++ b/modules/hal_nordic/nrf_802154/radio/platform/nrf_802154_random_zephyr.c
@@ -20,7 +20,7 @@ static uint32_t next(void)
 
 void nrf_802154_random_init(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 	int err;
 
 	__ASSERT_NO_MSG(device_is_ready(dev));

--- a/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
+++ b/modules/hal_nordic/nrf_802154/serialization/platform/nrf_802154_spinel_backend_ipc.c
@@ -45,7 +45,7 @@ static struct ipc_ept_cfg ept_cfg = {
 
 nrf_802154_ser_err_t nrf_802154_backend_init(void)
 {
-	const struct device *ipc_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
+	const struct device *const ipc_instance = DEVICE_DT_GET(DT_NODELABEL(ipc0));
 	int err;
 
 	err = ipc_service_open_instance(ipc_instance);

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -26,7 +26,7 @@
 #include <zephyr/bluetooth/gatt.h>
 
 #ifdef CONFIG_TEMP_NRF5
-static const struct device *temp_dev = DEVICE_DT_GET_ANY(nordic_nrf_temp);
+static const struct device *const temp_dev = DEVICE_DT_GET_ANY(nordic_nrf_temp);
 #else
 static const struct device *temp_dev;
 #endif

--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -111,7 +111,7 @@ void main(void)
 
 	int ret;
 
-	const struct device *mic_dev = DEVICE_DT_GET_ONE(st_mpxxdtyy);
+	const struct device *const mic_dev = DEVICE_DT_GET_ONE(st_mpxxdtyy);
 
 	if (!device_is_ready(mic_dev)) {
 		printk("Device %s is not ready\n", mic_dev->name);

--- a/samples/boards/96b_argonkey/sensors/src/main.c
+++ b/samples/boards/96b_argonkey/sensors/src/main.c
@@ -155,7 +155,7 @@ void main(void)
 	printk("ArgonKey test!!\n");
 
 #ifdef CONFIG_LPS22HB
-	const struct device *baro_dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
+	const struct device *const baro_dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
 
 	if (!device_is_ready(baro_dev)) {
 		printk("%s: device not ready.\n", baro_dev->name);
@@ -164,7 +164,7 @@ void main(void)
 #endif
 
 #ifdef CONFIG_HTS221
-	const struct device *hum_dev = DEVICE_DT_GET_ONE(st_hts221);
+	const struct device *const hum_dev = DEVICE_DT_GET_ONE(st_hts221);
 
 	if (!device_is_ready(hum_dev)) {
 		printk("%s: device not ready.\n", hum_dev->name);
@@ -173,7 +173,7 @@ void main(void)
 #endif
 
 #ifdef CONFIG_LSM6DSL
-	const struct device *accel_dev = DEVICE_DT_GET_ONE(st_lsm6dsl);
+	const struct device *const accel_dev = DEVICE_DT_GET_ONE(st_lsm6dsl);
 
 	if (!device_is_ready(accel_dev)) {
 		printk("%s: device not ready.\n", accel_dev->name);
@@ -237,7 +237,7 @@ void main(void)
 #endif
 
 #ifdef CONFIG_VL53L0X
-	const struct device *tof_dev = DEVICE_DT_GET_ONE(st_vl53l0x);
+	const struct device *const tof_dev = DEVICE_DT_GET_ONE(st_vl53l0x);
 
 	if (!device_is_ready(tof_dev)) {
 		printk("%s: device not ready.\n", tof_dev->name);

--- a/samples/boards/nrf/nrf_led_matrix/src/main.c
+++ b/samples/boards/nrf/nrf_led_matrix/src/main.c
@@ -185,7 +185,7 @@ void main(void)
 	printk("nRF LED matrix sample on %s\n", CONFIG_BOARD);
 
 	int ret;
-	const struct device *dev = DEVICE_DT_GET_ONE(nordic_nrf_led_matrix);
+	const struct device *const dev = DEVICE_DT_GET_ONE(nordic_nrf_led_matrix);
 
 	if (!dev) {
 		printk("Display device not ready\n");

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -336,7 +336,7 @@ void main(void)
 	static uint8_t tx_buffer[TRANSFER_LENGTH];
 	static uint8_t rx_buffer[sizeof(tx_buffer)];
 	uint8_t fill_value = 0;
-	const struct device *spi_dev = DEVICE_DT_GET(SPI_DEV_NODE);
+	const struct device *const spi_dev = DEVICE_DT_GET(SPI_DEV_NODE);
 
 	if (!device_is_ready(spi_dev)) {
 		printk("%s is not ready\n", spi_dev->name);

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -38,7 +38,7 @@ SYS_INIT(disable_ds_1, PRE_KERNEL_2, 0);
 void main(void)
 {
 	int rc;
-	const struct device *cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(cons)) {
 		printk("%s: device not ready.\n", cons->name);

--- a/samples/boards/sensortile_box/src/main.c
+++ b/samples/boards/sensortile_box/src/main.c
@@ -251,7 +251,7 @@ void main(void)
 {
 	static const struct gpio_dt_spec led0_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
 	static const struct gpio_dt_spec led1_gpio = GPIO_DT_SPEC_GET(DT_ALIAS(led1), gpios);
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 	int i, on = 1;
 	int cnt = 1;
 	uint32_t dtr = 0;
@@ -290,13 +290,13 @@ void main(void)
 
 	printk("SensorTile.box test!!\n");
 
-	const struct device *hts221 = DEVICE_DT_GET_ONE(st_hts221);
-	const struct device *lis2dw12 = DEVICE_DT_GET_ONE(st_lis2dw12);
-	const struct device *lps22hh = DEVICE_DT_GET_ONE(st_lps22hh);
-	const struct device *lsm6dso = DEVICE_DT_GET_ONE(st_lsm6dso);
-	const struct device *stts751 = DEVICE_DT_GET_ONE(st_stts751);
-	const struct device *iis3dhhc = DEVICE_DT_GET_ONE(st_iis3dhhc);
-	const struct device *lis2mdl = DEVICE_DT_GET_ONE(st_lis2mdl);
+	const struct device *const hts221 = DEVICE_DT_GET_ONE(st_hts221);
+	const struct device *const lis2dw12 = DEVICE_DT_GET_ONE(st_lis2dw12);
+	const struct device *const lps22hh = DEVICE_DT_GET_ONE(st_lps22hh);
+	const struct device *const lsm6dso = DEVICE_DT_GET_ONE(st_lsm6dso);
+	const struct device *const stts751 = DEVICE_DT_GET_ONE(st_stts751);
+	const struct device *const iis3dhhc = DEVICE_DT_GET_ONE(st_iis3dhhc);
+	const struct device *const lis2mdl = DEVICE_DT_GET_ONE(st_lis2mdl);
 
 	if (!device_is_ready(hts221)) {
 		printk("%s: device not ready.\n", hts221->name);

--- a/samples/boards/stm32/h7_dual_core/src/main.c
+++ b/samples/boards/stm32/h7_dual_core/src/main.c
@@ -34,7 +34,7 @@ void new_message_callback(const struct device *dev, void *user_data,
 
 void main(void)
 {
-	const struct device *ipm = DEVICE_DT_GET(DT_NODELABEL(mailbox));
+	const struct device *const ipm = DEVICE_DT_GET(DT_NODELABEL(mailbox));
 
 	printk("STM32 h7_dual_core application\n");
 

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -76,7 +76,7 @@ static int do_pdm_transfer(const struct device *dmic_dev,
 
 void main(void)
 {
-	const struct device *dmic_dev = DEVICE_DT_GET(DT_NODELABEL(dmic_dev));
+	const struct device *const dmic_dev = DEVICE_DT_GET(DT_NODELABEL(dmic_dev));
 	int ret;
 
 	LOG_INF("DMIC sample");

--- a/samples/drivers/can/src/main.c
+++ b/samples/drivers/can/src/main.c
@@ -24,7 +24,7 @@
 K_THREAD_STACK_DEFINE(rx_thread_stack, RX_THREAD_STACK_SIZE);
 K_THREAD_STACK_DEFINE(poll_state_stack, STATE_POLL_THREAD_STACK_SIZE);
 
-const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 struct gpio_dt_spec led = GPIO_DT_SPEC_GET_OR(DT_ALIAS(led0), gpios, {0});
 
 struct k_thread rx_thread_data;

--- a/samples/drivers/clock_control_litex/src/main.c
+++ b/samples/drivers/clock_control_litex/src/main.c
@@ -311,7 +311,7 @@ int litex_clk_test(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(MMCM);
+	const struct device *const dev = DEVICE_DT_GET(MMCM);
 
 	printf("Clock Control Example! %s\n", CONFIG_ARCH);
 

--- a/samples/drivers/counter/alarm/src/main.c
+++ b/samples/drivers/counter/alarm/src/main.c
@@ -74,7 +74,7 @@ static void test_counter_interrupt_fn(const struct device *counter_dev,
 
 void main(void)
 {
-	const struct device *counter_dev = DEVICE_DT_GET(TIMER);
+	const struct device *const counter_dev = DEVICE_DT_GET(TIMER);
 	int err;
 
 	printk("Counter alarm sample\n\n");

--- a/samples/drivers/counter/maxim_ds3231/src/main.c
+++ b/samples/drivers/counter/maxim_ds3231/src/main.c
@@ -229,7 +229,7 @@ static void set_aligned_clock(const struct device *ds3231)
 
 void main(void)
 {
-	const struct device *ds3231 = DEVICE_DT_GET_ONE(maxim_ds3231);
+	const struct device *const ds3231 = DEVICE_DT_GET_ONE(maxim_ds3231);
 
 	if (!device_is_ready(ds3231)) {
 		printk("%s: device not ready.\n", ds3231->name);

--- a/samples/drivers/crypto/src/main.c
+++ b/samples/drivers/crypto/src/main.c
@@ -613,7 +613,7 @@ void main(void)
 		return;
 	}
 #else
-	const struct device *dev = DEVICE_DT_GET_ONE(CRYPTO_DEV_COMPAT);
+	const struct device *const dev = DEVICE_DT_GET_ONE(CRYPTO_DEV_COMPAT);
 
 	if (!device_is_ready(dev)) {
 		LOG_ERR("Crypto device is not ready\n");

--- a/samples/drivers/eeprom/src/main.c
+++ b/samples/drivers/eeprom/src/main.c
@@ -22,7 +22,7 @@ struct perisistant_values {
  */
 static const struct device *get_eeprom_device(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(eeprom_0));
+	const struct device *const dev = DEVICE_DT_GET(DT_ALIAS(eeprom_0));
 
 	if (!device_is_ready(dev)) {
 		printk("\nError: Device \"%s\" is not ready; "

--- a/samples/drivers/fpga/fpga_controller/src/main.c
+++ b/samples/drivers/fpga/fpga_controller/src/main.c
@@ -13,7 +13,7 @@
 #include "greenled.h"
 #include <eoss3_dev.h>
 
-const struct device *fpga = DEVICE_DT_GET(DT_NODELABEL(fpga0));
+const struct device *const fpga = DEVICE_DT_GET(DT_NODELABEL(fpga0));
 
 void main(void)
 {

--- a/samples/drivers/ht16k33/src/main.c
+++ b/samples/drivers/ht16k33/src/main.c
@@ -23,8 +23,8 @@ static void keyscan_callback(const struct device *dev, uint32_t row,
 
 void main(void)
 {
-	const struct device *led = DEVICE_DT_GET(LED_NODE);
-	const struct device *key = DEVICE_DT_GET(KEY_NODE);
+	const struct device *const led = DEVICE_DT_GET(LED_NODE);
+	const struct device *const key = DEVICE_DT_GET(KEY_NODE);
 	int err;
 	int i;
 

--- a/samples/drivers/i2c_fujitsu_fram/src/main.c
+++ b/samples/drivers/i2c_fujitsu_fram/src/main.c
@@ -70,7 +70,7 @@ static int read_bytes(const struct device *i2c_dev, uint16_t addr,
 
 void main(void)
 {
-	const struct device *i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c0));
+	const struct device *const i2c_dev = DEVICE_DT_GET(DT_NODELABEL(i2c0));
 	uint8_t cmp_data[16];
 	uint8_t data[16];
 	int i, ret;

--- a/samples/drivers/i2s/echo/src/codec.c
+++ b/samples/drivers/i2s/echo/src/codec.c
@@ -16,7 +16,7 @@
 
 bool init_wm8731_i2c(void)
 {
-	const struct device *i2c_dev = DEVICE_DT_GET(WM8731_I2C_NODE);
+	const struct device *const i2c_dev = DEVICE_DT_GET(WM8731_I2C_NODE);
 
 	/* Initialization data for WM8731 registers. */
 	static const uint8_t init[][2] = {

--- a/samples/drivers/i2s/echo/src/main.c
+++ b/samples/drivers/i2s/echo/src/main.c
@@ -246,8 +246,8 @@ static bool trigger_command(const struct device *i2s_dev_rx,
 
 void main(void)
 {
-	const struct device *i2s_dev_rx = DEVICE_DT_GET(I2S_RX_NODE);
-	const struct device *i2s_dev_tx = DEVICE_DT_GET(I2S_TX_NODE);
+	const struct device *const i2s_dev_rx = DEVICE_DT_GET(I2S_RX_NODE);
+	const struct device *const i2s_dev_tx = DEVICE_DT_GET(I2S_TX_NODE);
 	struct i2s_config config;
 
 	printk("I2S echo sample\n");

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -274,7 +274,7 @@ static void dump_bytes(const struct jesd216_param_header *php,
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(FLASH_NODE);
+	const struct device *const dev = DEVICE_DT_GET(FLASH_NODE);
 
 	if (!device_is_ready(dev)) {
 		printf("%s: device not ready\n", dev->name);

--- a/samples/drivers/kscan/src/main.c
+++ b/samples/drivers/kscan/src/main.c
@@ -15,7 +15,7 @@
 
 LOG_MODULE_REGISTER(main);
 
-const struct device *kscan_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_keyboard_scan));
+const struct device *const kscan_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_keyboard_scan));
 static struct k_timer typematic_timer;
 static struct k_timer block_matrix_timer;
 

--- a/samples/drivers/kscan_touch/src/main.c
+++ b/samples/drivers/kscan_touch/src/main.c
@@ -15,7 +15,7 @@
 
 LOG_MODULE_REGISTER(main);
 
-const struct device *kscan_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_keyboard_scan));
+const struct device *const kscan_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_keyboard_scan));
 
 static void k_callback(const struct device *dev, uint32_t row, uint32_t col,
 		       bool pressed)

--- a/samples/drivers/lcd_cyclonev_socdk/src/main.c
+++ b/samples/drivers/lcd_cyclonev_socdk/src/main.c
@@ -14,7 +14,7 @@
 #define I2C_INST DT_NODELABEL(i2c0)
 #define LCD_ADDRESS 0x28
 
-const struct device *i2c = DEVICE_DT_GET(I2C_INST);
+const struct device *const i2c = DEVICE_DT_GET(I2C_INST);
 
 void send_ascii(char c)
 {

--- a/samples/drivers/lcd_hd44780/src/main.c
+++ b/samples/drivers/lcd_hd44780/src/main.c
@@ -527,7 +527,7 @@ void pi_lcd_init(const struct device *gpio_dev, uint8_t cols, uint8_t rows,
 
 void main(void)
 {
-	const struct device *gpio_dev = DEVICE_DT_GET(GPIO_NODE);
+	const struct device *const gpio_dev = DEVICE_DT_GET(GPIO_NODE);
 
 	if (!device_is_ready(gpio_dev)) {
 		printk("Device %s not ready!\n", gpio_dev->name);

--- a/samples/drivers/led_lp3943/src/main.c
+++ b/samples/drivers/led_lp3943/src/main.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(app);
 
 void main(void)
 {
-	const struct device *led_dev = DEVICE_DT_GET_ANY(ti_lp3943);
+	const struct device *const led_dev = DEVICE_DT_GET_ANY(ti_lp3943);
 	int i, ret;
 
 	if (!led_dev) {

--- a/samples/drivers/led_lp503x/src/main.c
+++ b/samples/drivers/led_lp503x/src/main.c
@@ -211,7 +211,7 @@ static int run_channel_test(const struct device *lp503x_dev)
 
 void main(void)
 {
-	const struct device *lp503x_dev = DEVICE_DT_GET_ANY(ti_lp503x);
+	const struct device *const lp503x_dev = DEVICE_DT_GET_ANY(ti_lp503x);
 
 	int err;
 	uint8_t led;

--- a/samples/drivers/led_lp5562/src/main.c
+++ b/samples/drivers/led_lp5562/src/main.c
@@ -164,7 +164,7 @@ static int turn_off_all_leds(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ANY(ti_lp5562);
+	const struct device *const dev = DEVICE_DT_GET_ANY(ti_lp5562);
 	int i, ret;
 
 	if (!dev) {

--- a/samples/drivers/led_pca9633/src/main.c
+++ b/samples/drivers/led_pca9633/src/main.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(main);
 
 void main(void)
 {
-	const struct device *led_dev = DEVICE_DT_GET_ANY(nxp_pca9633);
+	const struct device *const led_dev = DEVICE_DT_GET_ANY(nxp_pca9633);
 	int i, ret;
 
 	if (!led_dev) {

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -40,7 +40,7 @@ void lora_receive_cb(const struct device *dev, uint8_t *data, uint16_t size,
 
 void main(void)
 {
-	const struct device *lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
+	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
 	struct lora_modem_config config;
 	int ret, len;
 	uint8_t data[MAX_DATA_LEN] = {0};

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -24,7 +24,7 @@ char data[MAX_DATA_LEN] = {'h', 'e', 'l', 'l', 'o', 'w', 'o', 'r', 'l', 'd'};
 
 void main(void)
 {
-	const struct device *lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
+	const struct device *const lora_dev = DEVICE_DT_GET(DEFAULT_RADIO_NODE);
 	struct lora_modem_config config;
 	int ret;
 

--- a/samples/drivers/misc/grove_display/src/main.c
+++ b/samples/drivers/misc/grove_display/src/main.c
@@ -33,7 +33,7 @@ uint8_t clamp_rgb(int val)
 
 void main(void)
 {
-	const struct device *glcd = DEVICE_DT_GET(DT_NODELABEL(glcd));
+	const struct device *const glcd = DEVICE_DT_GET(DT_NODELABEL(glcd));
 	char str[20];
 	int rgb[] = { 0x0, 0x0, 0x0 };
 	uint8_t rgb_chg[3];

--- a/samples/drivers/spi_bitbang/src/main.c
+++ b/samples/drivers/spi_bitbang/src/main.c
@@ -120,7 +120,7 @@ void test_8bit_xfer(const struct device *dev, struct spi_cs_control *cs)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(SPIBB_NODE);
+	const struct device *const dev = DEVICE_DT_GET(SPIBB_NODE);
 
 	if (!device_is_ready(dev)) {
 		printk("%s: device not ready.\n", dev->name);

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -27,7 +27,7 @@ void main(void)
 {
 	printk("DataFlash sample on %s\n", CONFIG_BOARD);
 
-	const struct device *flash_dev = DEVICE_DT_GET_ONE(atmel_at45);
+	const struct device *const flash_dev = DEVICE_DT_GET_ONE(atmel_at45);
 	int i;
 	int err;
 	uint8_t data;

--- a/samples/drivers/uart/stm32/single_wire/src/main.c
+++ b/samples/drivers/uart/stm32/single_wire/src/main.c
@@ -12,8 +12,8 @@
 #define UART_NODE1 DT_ALIAS(single_line_uart1)
 #define UART_NODE2 DT_ALIAS(single_line_uart2)
 
-const struct device *sl_uart1 = DEVICE_DT_GET(UART_NODE1);
-const struct device *sl_uart2 = DEVICE_DT_GET(UART_NODE2);
+const struct device *const sl_uart1 = DEVICE_DT_GET(UART_NODE1);
+const struct device *const sl_uart2 = DEVICE_DT_GET(UART_NODE2);
 
 void main(void)
 {

--- a/samples/drivers/w1/scanner/src/main.c
+++ b/samples/drivers/w1/scanner/src/main.c
@@ -20,7 +20,7 @@ void w1_search_callback(struct w1_rom rom, void *user_data)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(w1));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(w1));
 
 	if (!device_is_ready(dev)) {
 		LOG_ERR("Device not ready");

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -58,7 +58,7 @@ void main(void)
 {
 	int err;
 	int wdt_channel_id;
-	const struct device *wdt = DEVICE_DT_GET(DT_ALIAS(watchdog0));
+	const struct device *const wdt = DEVICE_DT_GET(DT_ALIAS(watchdog0));
 
 	printk("Watchdog sample application\n");
 

--- a/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
+++ b/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
@@ -24,7 +24,7 @@
 
 #define BUFLEN 300
 int begin_index = 0;
-const struct device *sensor = DEVICE_DT_GET_ONE(adi_adxl345);
+const struct device *const sensor = DEVICE_DT_GET_ONE(adi_adxl345);
 int current_index = 0;
 
 float bufx[BUFLEN] = { 0.0f };

--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -112,7 +112,7 @@ static void modem_off_cb(const struct device *dev, void *user_data)
 
 int main(void)
 {
-	const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
+	const struct device *const uart_dev = DEVICE_DT_GET(UART_NODE);
 
 	/* Optional register modem power callbacks */
 	gsm_ppp_register_modem_power_callback(gsm_dev, modem_on_cb, modem_off_cb, NULL);

--- a/samples/sensor/adc_cmp_npcx/src/main.c
+++ b/samples/sensor/adc_cmp_npcx/src/main.c
@@ -99,7 +99,7 @@ void threshold_trigger_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *adc_cmp = DEVICE_DT_GET(ADC_CMP_NODE);
+	const struct device *const adc_cmp = DEVICE_DT_GET(ADC_CMP_NODE);
 	int err;
 
 	if (!device_is_ready(adc_cmp)) {

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -171,7 +171,7 @@ static void process(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(adi_adt7420);
+	const struct device *const dev = DEVICE_DT_GET_ONE(adi_adt7420);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -51,7 +51,7 @@ void print_buffer(void *ptr, size_t l)
 void main(void)
 {
 	int ret;
-	const struct device *dev = DEVICE_DT_GET_ONE(panasonic_amg88xx);
+	const struct device *const dev = DEVICE_DT_GET_ONE(panasonic_amg88xx);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -16,7 +16,7 @@
  */
 static const struct device *get_bme280_device(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ANY(bosch_bme280);
+	const struct device *const dev = DEVICE_DT_GET_ANY(bosch_bme280);
 
 	if (dev == NULL) {
 		/* No such node, or the node does not have status "okay". */

--- a/samples/sensor/bme680/src/main.c
+++ b/samples/sensor/bme680/src/main.c
@@ -11,7 +11,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(bosch_bme680);
+	const struct device *const dev = DEVICE_DT_GET_ONE(bosch_bme680);
 	struct sensor_value temp, press, humidity, gas_res;
 
 	if (!device_is_ready(dev)) {

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -172,7 +172,7 @@ static void test_trigger_mode(const struct device *bmg160)
 
 void main(void)
 {
-	const struct device *bmg160 = DEVICE_DT_GET_ANY(bosch_bmg160);
+	const struct device *const bmg160 = DEVICE_DT_GET_ANY(bosch_bmg160);
 #if defined(CONFIG_BMG160_RANGE_RUNTIME)
 	struct sensor_value attr;
 #endif

--- a/samples/sensor/bmi270/src/main.c
+++ b/samples/sensor/bmi270/src/main.c
@@ -11,7 +11,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(bosch_bmi270);
+	const struct device *const dev = DEVICE_DT_GET_ONE(bosch_bmi270);
 	struct sensor_value acc[3], gyr[3];
 	struct sensor_value full_scale, sampling_freq, oversampling;
 

--- a/samples/sensor/bq274xx/src/main.c
+++ b/samples/sensor/bq274xx/src/main.c
@@ -208,7 +208,7 @@ static void do_main(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(ti_bq274xx);
+	const struct device *const dev = DEVICE_DT_GET_ONE(ti_bq274xx);
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -113,7 +113,7 @@ static void do_main(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(ams_ccs811);
+	const struct device *const dev = DEVICE_DT_GET_ONE(ams_ccs811);
 	struct ccs811_configver_type cfgver;
 	int rc;
 

--- a/samples/sensor/dht/src/main.c
+++ b/samples/sensor/dht/src/main.c
@@ -32,7 +32,7 @@ static const char *now_str(void)
 
 void main(void)
 {
-	const struct device *dht22 = DEVICE_DT_GET_ONE(aosong_dht);
+	const struct device *const dht22 = DEVICE_DT_GET_ONE(aosong_dht);
 
 	if (!device_is_ready(dht22)) {
 		printf("Device %s is not ready\n", dht22->name);

--- a/samples/sensor/dps310/src/main.c
+++ b/samples/sensor/dps310/src/main.c
@@ -12,7 +12,7 @@
 void main(void)
 {
 	printk("Hello DPS310\n");
-	const struct device *dev = DEVICE_DT_GET_ONE(infineon_dps310);
+	const struct device *const dev = DEVICE_DT_GET_ONE(infineon_dps310);
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);

--- a/samples/sensor/ds18b20/src/main.c
+++ b/samples/sensor/ds18b20/src/main.c
@@ -15,7 +15,7 @@
  */
 static const struct device *get_ds18b20_device(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ANY(maxim_ds18b20);
+	const struct device *const dev = DEVICE_DT_GET_ANY(maxim_ds18b20);
 
 	if (dev == NULL) {
 		/* No such node, or the node does not have status "okay". */

--- a/samples/sensor/ens210/src/main.c
+++ b/samples/sensor/ens210/src/main.c
@@ -11,7 +11,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(ams_ens210);
+	const struct device *const dev = DEVICE_DT_GET_ONE(ams_ens210);
 	struct sensor_value temperature, humidity;
 
 	if (!device_is_ready(dev)) {

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -70,7 +70,7 @@ void main(void)
 	enum sensor_channel base;
 	int i;
 
-	const struct device *dev = DEVICE_DT_GET(DEVICE_NODE);
+	const struct device *const dev = DEVICE_DT_GET(DEVICE_NODE);
 
 	if (!device_is_ready(dev)) {
 		printk("Device %s is not ready\n", dev->name);

--- a/samples/sensor/fxas21002/src/main.c
+++ b/samples/sensor/fxas21002/src/main.c
@@ -19,7 +19,7 @@ static void trigger_handler(const struct device *dev,
 void main(void)
 {
 	struct sensor_value gyro[3];
-	const struct device *dev = DEVICE_DT_GET_ANY(nxp_fxas21002);
+	const struct device *const dev = DEVICE_DT_GET_ANY(nxp_fxas21002);
 
 	if (dev == NULL || !device_is_ready(dev)) {
 		printf("Could not get fxas21002 device\n");

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -32,7 +32,7 @@ static void trigger_handler(const struct device *dev,
 void main(void)
 {
 	struct sensor_value accel[3];
-	const struct device *dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
+	const struct device *const dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);

--- a/samples/sensor/grove_light/src/main.c
+++ b/samples/sensor/grove_light/src/main.c
@@ -13,7 +13,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(seeed_grove_light);
+	const struct device *const dev = DEVICE_DT_GET_ONE(seeed_grove_light);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/grove_temperature/src/main.c
+++ b/samples/sensor/grove_temperature/src/main.c
@@ -19,7 +19,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(seeed_grove_temperature);
+	const struct device *const dev = DEVICE_DT_GET_ONE(seeed_grove_temperature);
 	struct sensor_value temp;
 	int read;
 

--- a/samples/sensor/hts221/src/main.c
+++ b/samples/sensor/hts221/src/main.c
@@ -48,7 +48,7 @@ static void hts221_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(st_hts221);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_hts221);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/i3g4250d/src/main.c
+++ b/samples/sensor/i3g4250d/src/main.c
@@ -52,7 +52,7 @@ static void fetch_and_display(const struct device *sensor)
 void main(void)
 {
 	const double sampling_frequency = 1000.0 / SAMPLING_INTERVAL_MS;
-	const struct device *sensor = DEVICE_DT_GET_ONE(st_i3g4250d);
+	const struct device *const sensor = DEVICE_DT_GET_ONE(st_i3g4250d);
 
 	if (!device_is_ready(sensor)) {
 		printf("Sensor %s is not ready\n", sensor->name);

--- a/samples/sensor/icm42605/src/main.c
+++ b/samples/sensor/icm42605/src/main.c
@@ -98,7 +98,7 @@ static void handle_icm42605_double_tap(const struct device *dev,
 
 void main(void)
 {
-	const struct device *icm42605 = DEVICE_DT_GET_ONE(invensense_icm42605);
+	const struct device *const icm42605 = DEVICE_DT_GET_ONE(invensense_icm42605);
 
 	if (!device_is_ready(icm42605)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/ina219/src/main.c
+++ b/samples/sensor/ina219/src/main.c
@@ -11,7 +11,7 @@
 
 void main(void)
 {
-	const struct device *ina = DEVICE_DT_GET_ONE(ti_ina219);
+	const struct device *const ina = DEVICE_DT_GET_ONE(ti_ina219);
 	struct sensor_value v_bus, power, current;
 	int rc;
 

--- a/samples/sensor/isl29035/src/main.c
+++ b/samples/sensor/isl29035/src/main.c
@@ -102,7 +102,7 @@ static void process_sample(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(isil_isl29035);
+	const struct device *const dev = DEVICE_DT_GET_ONE(isil_isl29035);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/lis2dh/src/main.c
+++ b/samples/sensor/lis2dh/src/main.c
@@ -65,7 +65,7 @@ static void trigger_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *sensor = DEVICE_DT_GET_ANY(st_lis2dh);
+	const struct device *const sensor = DEVICE_DT_GET_ANY(st_lis2dh);
 
 	if (sensor == NULL) {
 		printf("No device found\n");

--- a/samples/sensor/lps22hb/src/main.c
+++ b/samples/sensor/lps22hb/src/main.c
@@ -43,7 +43,7 @@ static void process_sample(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
 
 	if (!device_is_ready(dev)) {
 		printf("Device %s is not ready\n", dev->name);

--- a/samples/sensor/lps22hh/src/main.c
+++ b/samples/sensor/lps22hh/src/main.c
@@ -50,7 +50,7 @@ static void lps22hh_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(st_lps22hh);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_lps22hh);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/lsm303dlhc/src/main.c
+++ b/samples/sensor/lsm303dlhc/src/main.c
@@ -38,8 +38,8 @@ end:
 
 void main(void)
 {
-	const struct device *accelerometer = DEVICE_DT_GET_ONE(st_lis2dh);
-	const struct device *magnetometer = DEVICE_DT_GET_ONE(st_lsm303dlhc_magn);
+	const struct device *const accelerometer = DEVICE_DT_GET_ONE(st_lis2dh);
+	const struct device *const magnetometer = DEVICE_DT_GET_ONE(st_lsm303dlhc_magn);
 
 	if (!device_is_ready(accelerometer)) {
 		printf("Device %s is not ready\n", accelerometer->name);

--- a/samples/sensor/lsm6dsl/src/main.c
+++ b/samples/sensor/lsm6dsl/src/main.c
@@ -100,7 +100,7 @@ void main(void)
 	int cnt = 0;
 	char out_str[64];
 	struct sensor_value odr_attr;
-	const struct device *lsm6dsl_dev = DEVICE_DT_GET_ONE(st_lsm6dsl);
+	const struct device *const lsm6dsl_dev = DEVICE_DT_GET_ONE(st_lsm6dsl);
 
 	if (!device_is_ready(lsm6dsl_dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -107,7 +107,7 @@ static void test_polling_mode(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(st_lsm6dso);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_lsm6dso);
 
 	if (!device_is_ready(dev)) {
 		printk("%s: device not ready.\n", dev->name);

--- a/samples/sensor/magn_polling/src/main.c
+++ b/samples/sensor/magn_polling/src/main.c
@@ -12,7 +12,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_ALIAS(magn0));
+	const struct device *const dev = DEVICE_DT_GET(DT_ALIAS(magn0));
 	struct sensor_value value_x, value_y, value_z;
 	int ret;
 

--- a/samples/sensor/max17262/src/main.c
+++ b/samples/sensor/max17262/src/main.c
@@ -11,7 +11,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(maxim_max17262);
+	const struct device *const dev = DEVICE_DT_GET_ONE(maxim_max17262);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/max30101/src/main.c
+++ b/samples/sensor/max30101/src/main.c
@@ -11,7 +11,7 @@
 void main(void)
 {
 	struct sensor_value green;
-	const struct device *dev = DEVICE_DT_GET_ANY(maxim_max30101);
+	const struct device *const dev = DEVICE_DT_GET_ANY(maxim_max30101);
 
 	if (dev == NULL) {
 		printf("Could not get max30101 device\n");

--- a/samples/sensor/max44009/src/main.c
+++ b/samples/sensor/max44009/src/main.c
@@ -17,7 +17,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(maxim_max44009);
+	const struct device *const dev = DEVICE_DT_GET_ONE(maxim_max44009);
 	struct sensor_value val;
 	uint32_t lum = 0U;
 

--- a/samples/sensor/max6675/src/main.c
+++ b/samples/sensor/max6675/src/main.c
@@ -19,7 +19,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(maxim_max6675);
+	const struct device *const dev = DEVICE_DT_GET_ONE(maxim_max6675);
 	struct sensor_value val;
 
 	if (!device_is_ready(dev)) {

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -106,7 +106,7 @@ static void trigger_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ANY(microchip_mcp9808);
+	const struct device *const dev = DEVICE_DT_GET_ANY(microchip_mcp9808);
 	int rc;
 
 	if (dev == NULL) {

--- a/samples/sensor/mcux_acmp/src/main.c
+++ b/samples/sensor/mcux_acmp/src/main.c
@@ -91,7 +91,7 @@ static void acmp_trigger_handler(const struct device *dev,
 void main(void)
 {
 	struct sensor_trigger trigger;
-	const struct device *acmp = DEVICE_DT_GET(ACMP_NODE);
+	const struct device *const acmp = DEVICE_DT_GET(ACMP_NODE);
 	struct sensor_value val;
 	int err;
 	int i;

--- a/samples/sensor/mpr/src/main.c
+++ b/samples/sensor/mpr/src/main.c
@@ -11,7 +11,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(honeywell_mpr);
+	const struct device *const dev = DEVICE_DT_GET_ONE(honeywell_mpr);
 	int rc;
 
 	if (!device_is_ready(dev)) {

--- a/samples/sensor/mpu6050/src/main.c
+++ b/samples/sensor/mpu6050/src/main.c
@@ -86,7 +86,7 @@ static void handle_mpu6050_drdy(const struct device *dev,
 
 void main(void)
 {
-	const struct device *mpu6050 = DEVICE_DT_GET_ONE(invensense_mpu6050);
+	const struct device *const mpu6050 = DEVICE_DT_GET_ONE(invensense_mpu6050);
 
 	if (!device_is_ready(mpu6050)) {
 		printf("Device %s is not ready\n", mpu6050->name);

--- a/samples/sensor/ms5837/src/main.c
+++ b/samples/sensor/ms5837/src/main.c
@@ -15,7 +15,7 @@ LOG_MODULE_REGISTER(main);
 void main(void)
 {
 	struct sensor_value oversampling_rate = { 8192, 0 };
-	const struct device *dev = DEVICE_DT_GET_ANY(meas_ms5837);
+	const struct device *const dev = DEVICE_DT_GET_ANY(meas_ms5837);
 
 	if (dev == NULL) {
 		LOG_ERR("Could not find MS5837 device, aborting test.");

--- a/samples/sensor/sgp40_sht4x/src/main.c
+++ b/samples/sensor/sgp40_sht4x/src/main.c
@@ -27,8 +27,8 @@ void main(void)
 	struct sensor_value comp_t;
 	struct sensor_value comp_rh;
 #endif
-	const struct device *sht = DEVICE_DT_GET_ANY(sensirion_sht4x);
-	const struct device *sgp = DEVICE_DT_GET_ANY(sensirion_sgp40);
+	const struct device *const sht = DEVICE_DT_GET_ANY(sensirion_sht4x);
+	const struct device *const sgp = DEVICE_DT_GET_ANY(sensirion_sgp40);
 	struct sensor_value temp, hum, gas;
 
 	if (!device_is_ready(sht)) {

--- a/samples/sensor/sht3xd/src/main.c
+++ b/samples/sensor/sht3xd/src/main.c
@@ -25,7 +25,7 @@ static void trigger_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(sensirion_sht3xd);
+	const struct device *const dev = DEVICE_DT_GET_ONE(sensirion_sht3xd);
 	int rc;
 
 	if (!device_is_ready(dev)) {

--- a/samples/sensor/sm351lt/src/main.c
+++ b/samples/sensor/sm351lt/src/main.c
@@ -41,7 +41,7 @@ static void trigger_handler(const struct device *dev,
 
 void main(void)
 {
-	const struct device *sensor = DEVICE_DT_GET_ONE(honeywell_sm351lt);
+	const struct device *const sensor = DEVICE_DT_GET_ONE(honeywell_sm351lt);
 
 	if (!device_is_ready(sensor)) {
 		printk("Device %s is not ready\n", sensor->name);

--- a/samples/sensor/stm32_temp_sensor/src/main.c
+++ b/samples/sensor/stm32_temp_sensor/src/main.c
@@ -12,9 +12,9 @@
 void main(void)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp)
-	const struct device *dev = DEVICE_DT_GET_ONE(st_stm32_temp);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_stm32_temp);
 #elif DT_HAS_COMPAT_STATUS_OKAY(st_stm32_temp_cal)
-	const struct device *dev = DEVICE_DT_GET_ONE(st_stm32_temp_cal);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_stm32_temp_cal);
 #endif
 	struct sensor_value val;
 	int rc;

--- a/samples/sensor/stm32_vbat_sensor/src/main.c
+++ b/samples/sensor/stm32_vbat_sensor/src/main.c
@@ -13,7 +13,7 @@ void main(void)
 {
 	struct sensor_value val;
 	int rc;
-	const struct device *dev = DEVICE_DT_GET_ONE(st_stm32_vbat);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_stm32_vbat);
 
 	if (!device_is_ready(dev)) {
 		printk("VBAT sensor is not ready\n");

--- a/samples/sensor/sx9500/src/main.c
+++ b/samples/sensor/sx9500/src/main.c
@@ -74,7 +74,7 @@ static void do_main(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(semtech_sx9500);
+	const struct device *const dev = DEVICE_DT_GET_ONE(semtech_sx9500);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/th02/src/main.c
+++ b/samples/sensor/th02/src/main.c
@@ -25,8 +25,8 @@ static struct channel_info info[] = {
 
 void main(void)
 {
-	const struct device *glcd = DEVICE_DT_GET(DT_NODELABEL(glcd));
-	const struct device *th02 = DEVICE_DT_GET_ONE(hoperf_th02);
+	const struct device *const glcd = DEVICE_DT_GET(DT_NODELABEL(glcd));
+	const struct device *const th02 = DEVICE_DT_GET_ONE(hoperf_th02);
 	struct sensor_value val[ARRAY_SIZE(info)];
 	unsigned int i;
 	int rc;

--- a/samples/sensor/ti_hdc/src/main.c
+++ b/samples/sensor/ti_hdc/src/main.c
@@ -15,7 +15,7 @@
 void main(void)
 {
 	printk("Running on %s!\n", CONFIG_ARCH);
-	const struct device *dev = DEVICE_DT_GET_ONE(ti_hdc);
+	const struct device *const dev = DEVICE_DT_GET_ONE(ti_hdc);
 
 	if (!device_is_ready(dev)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/tmp112/src/main.c
+++ b/samples/sensor/tmp112/src/main.c
@@ -56,7 +56,7 @@ static void do_main(const struct device *dev)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ANY(ti_tmp112);
+	const struct device *const dev = DEVICE_DT_GET_ANY(ti_tmp112);
 
 	__ASSERT(dev != NULL, "Failed to get device binding");
 	__ASSERT(device_is_ready(dev), "Device %s is not ready", dev->name);

--- a/samples/sensor/tmp116/src/main.c
+++ b/samples/sensor/tmp116/src/main.c
@@ -19,8 +19,8 @@ static uint8_t eeprom_content[EEPROM_TMP116_SIZE];
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(TMP116_NODE);
-	const struct device *eeprom = DEVICE_DT_GET(TMP116_EEPROM_NODE);
+	const struct device *const dev = DEVICE_DT_GET(TMP116_NODE);
+	const struct device *const eeprom = DEVICE_DT_GET(TMP116_EEPROM_NODE);
 	struct sensor_value temp_value;
 
 	/* offset to be added to the temperature

--- a/samples/sensor/vcnl4040/src/main.c
+++ b/samples/sensor/vcnl4040/src/main.c
@@ -130,7 +130,7 @@ static void test_trigger_mode(const struct device *dev)
 
 void main(void)
 {
-	const struct device *vcnl = DEVICE_DT_GET_ONE(vishay_vcnl4040);
+	const struct device *const vcnl = DEVICE_DT_GET_ONE(vishay_vcnl4040);
 
 	if (!device_is_ready(vcnl)) {
 		printk("sensor: device not ready.\n");

--- a/samples/sensor/vl53l0x/src/main.c
+++ b/samples/sensor/vl53l0x/src/main.c
@@ -12,7 +12,7 @@
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ONE(st_vl53l0x);
+	const struct device *const dev = DEVICE_DT_GET_ONE(st_vl53l0x);
 	struct sensor_value value;
 	int ret;
 

--- a/samples/sensor/wsen_itds/src/main.c
+++ b/samples/sensor/wsen_itds/src/main.c
@@ -127,7 +127,7 @@ static void test_trigger_mode(const struct device *itds)
 
 void main(void)
 {
-	const struct device *itds = DEVICE_DT_GET_ONE(we_wsen_itds);
+	const struct device *const itds = DEVICE_DT_GET_ONE(we_wsen_itds);
 	struct sensor_value attr;
 
 	printf("get device wsen-itds\n");

--- a/samples/shields/lmp90100_evb/rtd/src/main.c
+++ b/samples/shields/lmp90100_evb/rtd/src/main.c
@@ -42,7 +42,7 @@ static double rtd_temperature(int nom, double resistance)
 
 void main(void)
 {
-	const struct device *lmp90100 = DEVICE_DT_GET_ONE(ti_lmp90100);
+	const struct device *const lmp90100 = DEVICE_DT_GET_ONE(ti_lmp90100);
 	double resistance;
 	int32_t buffer;
 	int err;

--- a/samples/shields/x_nucleo_iks01a1/src/main.c
+++ b/samples/shields/x_nucleo_iks01a1/src/main.c
@@ -25,10 +25,10 @@ void main(void)
 {
 	struct sensor_value temp, hum, press;
 	struct sensor_value magn_xyz[3], accel_xyz[3];
-	const struct device *hts221 = DEVICE_DT_GET_ONE(st_hts221);
-	const struct device *lis3mdl = DEVICE_DT_GET_ONE(st_lis3mdl_magn);
-	const struct device *lsm6ds0 = DEVICE_DT_GET_ONE(st_lsm6ds0);
-	const struct device *lps25hb = DEVICE_DT_GET_ONE(st_lps25hb_press);
+	const struct device *const hts221 = DEVICE_DT_GET_ONE(st_hts221);
+	const struct device *const lis3mdl = DEVICE_DT_GET_ONE(st_lis3mdl_magn);
+	const struct device *const lsm6ds0 = DEVICE_DT_GET_ONE(st_lsm6ds0);
+	const struct device *const lps25hb = DEVICE_DT_GET_ONE(st_lps25hb_press);
 #if defined(CONFIG_LIS3MDL_TRIGGER)
 	struct sensor_trigger trig;
 	int cnt = 1;

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
@@ -34,7 +34,7 @@ void main(void)
 #endif
 	struct sensor_value accel[3];
 	struct sensor_value gyro[3];
-	const struct device *lsm6dsl = DEVICE_DT_GET_ONE(st_lsm6dsl);
+	const struct device *const lsm6dsl = DEVICE_DT_GET_ONE(st_lsm6dsl);
 
 	if (!device_is_ready(lsm6dsl)) {
 		printk("%s: device not ready.\n", lsm6dsl->name);

--- a/samples/shields/x_nucleo_iks01a2/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/standard/src/main.c
@@ -27,11 +27,11 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	const struct device *hts221 = DEVICE_DT_GET_ONE(st_hts221);
-	const struct device *lps22hb = DEVICE_DT_GET_ONE(st_lps22hb_press);
-	const struct device *lsm6dsl = DEVICE_DT_GET_ONE(st_lsm6dsl);
-	const struct device *lsm303agr_a = DEVICE_DT_GET_ONE(st_lis2dh);
-	const struct device *lsm303agr_m = DEVICE_DT_GET_ONE(st_lis2mdl);
+	const struct device *const hts221 = DEVICE_DT_GET_ONE(st_hts221);
+	const struct device *const lps22hb = DEVICE_DT_GET_ONE(st_lps22hb_press);
+	const struct device *const lsm6dsl = DEVICE_DT_GET_ONE(st_lsm6dsl);
+	const struct device *const lsm303agr_a = DEVICE_DT_GET_ONE(st_lis2dh);
+	const struct device *const lsm303agr_m = DEVICE_DT_GET_ONE(st_lis2mdl);
 #ifdef CONFIG_LSM6DSL_TRIGGER
 	int cnt = 1;
 #endif

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -179,8 +179,8 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	const struct device *lis2dw12 = DEVICE_DT_GET_ONE(st_lis2dw12);
-	const struct device *lsm6dso = DEVICE_DT_GET_ONE(st_lsm6dso);
+	const struct device *const lis2dw12 = DEVICE_DT_GET_ONE(st_lis2dw12);
+	const struct device *const lsm6dso = DEVICE_DT_GET_ONE(st_lsm6dso);
 	int cnt = 1;
 
 	if (!device_is_ready(lis2dw12)) {

--- a/samples/shields/x_nucleo_iks01a3/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/standard/src/main.c
@@ -247,12 +247,12 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	const struct device *hts221 = DEVICE_DT_GET_ONE(st_hts221);
-	const struct device *lps22hh = DEVICE_DT_GET_ONE(st_lps22hh);
-	const struct device *stts751 = DEVICE_DT_GET_ONE(st_stts751);
-	const struct device *lis2mdl = DEVICE_DT_GET_ONE(st_lis2mdl);
-	const struct device *lis2dw12 = DEVICE_DT_GET_ONE(st_lis2dw12);
-	const struct device *lsm6dso = DEVICE_DT_GET_ONE(st_lsm6dso);
+	const struct device *const hts221 = DEVICE_DT_GET_ONE(st_hts221);
+	const struct device *const lps22hh = DEVICE_DT_GET_ONE(st_lps22hh);
+	const struct device *const stts751 = DEVICE_DT_GET_ONE(st_stts751);
+	const struct device *const lis2mdl = DEVICE_DT_GET_ONE(st_lis2mdl);
+	const struct device *const lis2dw12 = DEVICE_DT_GET_ONE(st_lis2dw12);
+	const struct device *const lsm6dso = DEVICE_DT_GET_ONE(st_lsm6dso);
 	int cnt = 1;
 
 	if (!device_is_ready(hts221)) {

--- a/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
@@ -49,7 +49,7 @@ void main(void)
 	uint32_t ms;
 	int ret;
 
-	const struct device *mic_dev = DEVICE_DT_GET_ONE(st_mpxxdtyy);
+	const struct device *const mic_dev = DEVICE_DT_GET_ONE(st_mpxxdtyy);
 
 	if (!device_is_ready(mic_dev)) {
 		printk("%s: device not ready.\n", mic_dev->name);

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
@@ -156,8 +156,8 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	const struct device *iis2dlpc = DEVICE_DT_GET_ONE(st_iis2dlpc);
-	const struct device *ism330dhcx = DEVICE_DT_GET_ONE(st_ism330dhcx);
+	const struct device *const iis2dlpc = DEVICE_DT_GET_ONE(st_iis2dlpc);
+	const struct device *const ism330dhcx = DEVICE_DT_GET_ONE(st_ism330dhcx);
 	int cnt = 1;
 
 	if (!device_is_ready(iis2dlpc)) {

--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -167,9 +167,9 @@ void main(void)
 	struct sensor_value accel1[3], accel2[3];
 	struct sensor_value gyro[3];
 	struct sensor_value magn[3];
-	const struct device *iis2dlpc = DEVICE_DT_GET_ONE(st_iis2dlpc);
-	const struct device *iis2mdc = DEVICE_DT_GET_ONE(st_iis2mdc);
-	const struct device *ism330dhcx = DEVICE_DT_GET_ONE(st_ism330dhcx);
+	const struct device *const iis2dlpc = DEVICE_DT_GET_ONE(st_iis2dlpc);
+	const struct device *const iis2mdc = DEVICE_DT_GET_ONE(st_iis2mdc);
+	const struct device *const ism330dhcx = DEVICE_DT_GET_ONE(st_ism330dhcx);
 	int cnt = 1;
 
 	if (!device_is_ready(iis2dlpc)) {

--- a/samples/subsys/display/cfb_custom_font/src/main.c
+++ b/samples/subsys/display/cfb_custom_font/src/main.c
@@ -13,7 +13,7 @@
 
 void main(void)
 {
-	const struct device *display = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
+	const struct device *const display = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	int err;
 
 	if (!device_is_ready(display)) {

--- a/samples/subsys/edac/src/main.c
+++ b/samples/subsys/edac/src/main.c
@@ -32,7 +32,7 @@ static void notification_callback(const struct device *dev, void *data)
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 
 	if (!device_is_ready(dev)) {
 		printk("%s: device not ready.\n", dev->name);

--- a/samples/subsys/mgmt/updatehub/src/main.c
+++ b/samples/subsys/mgmt/updatehub/src/main.c
@@ -143,7 +143,7 @@ void main(void)
 	}
 
 #elif defined(CONFIG_MODEM_GSM_PPP)
-	const struct device *uart_dev = DEVICE_DT_GET(UART_NODE);
+	const struct device *const uart_dev = DEVICE_DT_GET(UART_NODE);
 
 	LOG_INF("APN '%s' UART '%s' device %p", CONFIG_MODEM_GSM_APN,
 		uart_dev->name, uart_dev);

--- a/samples/subsys/modbus/rtu_server/src/main.c
+++ b/samples/subsys/modbus/rtu_server/src/main.c
@@ -144,7 +144,7 @@ void main(void)
 	}
 
 #if DT_NODE_HAS_COMPAT(DT_PARENT(MODBUS_NODE), zephyr_cdc_acm_uart)
-	const struct device *dev = DEVICE_DT_GET(DT_PARENT(MODBUS_NODE));
+	const struct device *const dev = DEVICE_DT_GET(DT_PARENT(MODBUS_NODE));
 	uint32_t dtr = 0;
 
 	if (!device_is_ready(dev) || usb_enable(NULL)) {

--- a/samples/subsys/rtio/sensor_batch_processing/src/main.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/main.c
@@ -28,7 +28,7 @@ static uint8_t bufs[N][SAMPLE_SIZE];
 
 void main(void)
 {
-	const struct device *vnd_sensor = DEVICE_DT_GET(NODE_ID);
+	const struct device *const vnd_sensor = DEVICE_DT_GET(NODE_ID);
 	struct rtio_iodev *iodev = vnd_sensor->data;
 
 	/* Fill the entire submission queue. */

--- a/samples/subsys/shell/shell_module/src/uart_reinit.c
+++ b/samples/subsys/shell/shell_module/src/uart_reinit.c
@@ -10,7 +10,7 @@
 
 void shell_init_from_work(struct k_work *work)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
 	uint32_t level =
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?
@@ -87,7 +87,7 @@ K_TIMER_DEFINE(uart_poll_timer, uart_poll_timeout, uart_poll_timer_stopped);
 static void shell_uninit_cb(const struct shell *shell, int res)
 {
 	__ASSERT_NO_MSG(res >= 0);
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 
 	if (IS_ENABLED(CONFIG_SHELL_BACKEND_SERIAL_INTERRUPT_DRIVEN)) {
 		/* connect uart to my handler */

--- a/samples/subsys/task_wdt/src/main.c
+++ b/samples/subsys/task_wdt/src/main.c
@@ -37,6 +37,8 @@
 #define WDT_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(nxp_kinetis_wdog32)
 #elif DT_HAS_COMPAT_STATUS_OKAY(microchip_xec_watchdog)
 #define WDT_NODE DT_COMPAT_GET_ANY_STATUS_OKAY(microchip_xec_watchdog)
+#else
+#define WDT_NODE DT_INVALID_NODE
 #endif
 
 static void task_wdt_callback(int channel_id, void *user_data)
@@ -59,18 +61,12 @@ static void task_wdt_callback(int channel_id, void *user_data)
 void main(void)
 {
 	int ret;
-#ifdef WDT_NODE
-	const struct device *hw_wdt_dev = DEVICE_DT_GET(WDT_NODE);
-#else
-	const struct device *hw_wdt_dev = NULL;
-#endif
+	const struct device *const hw_wdt_dev = DEVICE_DT_GET_OR_NULL(WDT_NODE);
 
 	printk("Task watchdog sample application.\n");
 
 	if (!device_is_ready(hw_wdt_dev)) {
-		printk("Hardware watchdog %s is not ready; ignoring it.\n",
-		       hw_wdt_dev->name);
-		hw_wdt_dev = NULL;
+		printk("Hardware watchdog not ready; ignoring it.\n");
 	}
 
 	ret = task_wdt_init(hw_wdt_dev);

--- a/samples/subsys/usb/audio/headphones_microphone/src/main.c
+++ b/samples/subsys/usb/audio/headphones_microphone/src/main.c
@@ -65,7 +65,7 @@ static const struct usb_audio_ops mic_ops = {
 
 void main(void)
 {
-	const struct device *hp_dev = DEVICE_DT_GET_ONE(usb_audio_hp);
+	const struct device *const hp_dev = DEVICE_DT_GET_ONE(usb_audio_hp);
 	int ret;
 
 	LOG_INF("Entered %s", __func__);

--- a/samples/subsys/usb/console/src/main.c
+++ b/samples/subsys/usb/console/src/main.c
@@ -14,7 +14,7 @@ BUILD_ASSERT(DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart),
 
 void main(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 	uint32_t dtr = 0;
 
 	if (usb_enable(NULL)) {

--- a/samples/subsys/video/capture/src/main.c
+++ b/samples/subsys/video/capture/src/main.c
@@ -34,7 +34,7 @@ void main(void)
 
 	/* But would be better to use a real video device if any */
 #if defined(CONFIG_VIDEO_MCUX_CSI)
-	const struct device *dev = DEVICE_DT_GET_ONE(nxp_imx_csi);
+	const struct device *const dev = DEVICE_DT_GET_ONE(nxp_imx_csi);
 
 	if (!device_is_ready(dev)) {
 		LOG_ERR("%s: device not ready.\n", dev->name);

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -40,7 +40,7 @@ void main(void)
 	struct video_buffer *buffers[2], *vbuf;
 	int i, ret, sock, client;
 	struct video_format fmt;
-	const struct device *video = DEVICE_DT_GET_ONE(nxp_imx_csi);
+	const struct device *const video = DEVICE_DT_GET_ONE(nxp_imx_csi);
 
 	/* Prepare Network */
 	(void)memset(&addr, 0, sizeof(addr));

--- a/soc/arm/atmel_sam0/common/soc_samr34.c
+++ b/soc/arm/atmel_sam0/common/soc_samr34.c
@@ -15,7 +15,7 @@
  */
 static int soc_pinconf_init(const struct device *dev)
 {
-	const struct device *portb = DEVICE_DT_GET(DT_NODELABEL(portb));
+	const struct device *const portb = DEVICE_DT_GET(DT_NODELABEL(portb));
 
 	ARG_UNUSED(dev);
 

--- a/soc/arm/st_stm32/common/stm32_backup_sram.c
+++ b/soc/arm/st_stm32/common/stm32_backup_sram.c
@@ -25,7 +25,7 @@ static int stm32_backup_sram_init(const struct device *dev)
 	int ret;
 
 	/* enable clock for subsystem */
-	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
+	const struct device *const clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (!device_is_ready(clk)) {
 		LOG_ERR("clock control device not ready");

--- a/soc/xtensa/intel_adsp/ace_v1x/irq.c
+++ b/soc/xtensa/intel_adsp/ace_v1x/irq.c
@@ -11,7 +11,7 @@ LOG_MODULE_REGISTER(ace_v1x_soc, CONFIG_SOC_LOG_LEVEL);
 
 void z_soc_irq_enable(uint32_t irq)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(ace_intc));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(ace_intc));
 	const struct dw_ace_v1_ictl_driver_api *api;
 
 	if (!device_is_ready(dev)) {
@@ -25,7 +25,7 @@ void z_soc_irq_enable(uint32_t irq)
 
 void z_soc_irq_disable(uint32_t irq)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(ace_intc));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(ace_intc));
 	const struct dw_ace_v1_ictl_driver_api *api;
 
 	if (!device_is_ready(dev)) {
@@ -39,7 +39,7 @@ void z_soc_irq_disable(uint32_t irq)
 
 int z_soc_irq_is_enabled(unsigned int irq)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(ace_intc));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(ace_intc));
 	const struct dw_ace_v1_ictl_driver_api *api;
 
 	if (!device_is_ready(dev)) {

--- a/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
+++ b/subsys/mgmt/ec_host_cmd/ec_host_cmd_handler.c
@@ -55,7 +55,7 @@ static void handle_host_cmds_entry(void *arg1, void *arg2, void *arg3)
 	ARG_UNUSED(arg1);
 	ARG_UNUSED(arg2);
 	ARG_UNUSED(arg3);
-	const struct device *ec_host_cmd_dev = DEVICE_DT_GET(DT_HOST_CMD_DEV);
+	const struct device *const ec_host_cmd_dev = DEVICE_DT_GET(DT_HOST_CMD_DEV);
 	struct ec_host_cmd_periph_rx_ctx rx;
 
 	if (!device_is_ready(ec_host_cmd_dev)) {

--- a/subsys/net/lib/config/ieee802154_settings.c
+++ b/subsys/net/lib/config/ieee802154_settings.c
@@ -33,7 +33,7 @@ int z_net_config_ieee802154_setup(void)
 #endif /* CONFIG_NET_L2_IEEE802154_SECURITY */
 
 	struct net_if *iface;
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_ieee802154));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_ieee802154));
 
 	if (!device_is_ready(dev)) {
 		return -ENODEV;

--- a/subsys/shell/backends/shell_uart.c
+++ b/subsys/shell/backends/shell_uart.c
@@ -316,7 +316,7 @@ const struct shell_transport_api shell_uart_transport_api = {
 static int enable_shell_uart(const struct device *arg)
 {
 	ARG_UNUSED(arg);
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_shell_uart));
 	bool log_backend = CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > 0;
 	uint32_t level =
 		(CONFIG_SHELL_BACKEND_SERIAL_LOG_LEVEL > LOG_LEVEL_DBG) ?

--- a/tests/arch/arm64/arm64_gicv3_its/src/main.c
+++ b/tests/arch/arm64/arm64_gicv3_its/src/main.c
@@ -37,7 +37,7 @@ unsigned int vectors[ITS_TEST_NUM_DEVS][ITS_TEST_NUM_ITES];
 ZTEST(arm64_gicv3_its, test_gicv3_its_alloc)
 {
 	int devn, event_id;
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 
 	zassert_false(dev == NULL, "");
 
@@ -60,7 +60,7 @@ ZTEST(arm64_gicv3_its, test_gicv3_its_alloc)
 ZTEST(arm64_gicv3_its, test_gicv3_its_connect)
 {
 	int devn, event_id;
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	unsigned int remain = 0;
 
 	zassert_false(dev == NULL, "");
@@ -80,7 +80,7 @@ ZTEST(arm64_gicv3_its, test_gicv3_its_connect)
 
 ZTEST(arm64_gicv3_its, test_gicv3_its_irq_simple)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	unsigned int irqn = vectors[0][0];
 	unsigned int timeout;
 	int device_id = ITS_TEST_DEV(0);
@@ -103,7 +103,7 @@ ZTEST(arm64_gicv3_its, test_gicv3_its_irq_simple)
 
 ZTEST(arm64_gicv3_its, test_gicv3_its_irq_disable)
 {
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	unsigned int irqn = vectors[0][0];
 	unsigned int timeout;
 	int device_id = ITS_TEST_DEV(0);
@@ -143,7 +143,7 @@ ZTEST(arm64_gicv3_its, test_gicv3_its_irq_disable)
 ZTEST(arm64_gicv3_its, test_gicv3_its_irq)
 {
 	int devn, event_id;
-	const struct device *dev = DEVICE_DT_INST_GET(0);
+	const struct device *const dev = DEVICE_DT_INST_GET(0);
 	unsigned int timeout;
 	unsigned int remain = 0;
 

--- a/tests/arch/x86/info/src/timer.c
+++ b/tests/arch/x86/info/src/timer.c
@@ -48,7 +48,7 @@ void timer(void)
 		sys_clock_hw_cycles_per_sec());
 
 #if defined(CONFIG_COUNTER_CMOS)
-	const struct device *cmos = DEVICE_DT_GET_ONE(motorola_mc146818);
+	const struct device *const cmos = DEVICE_DT_GET_ONE(motorola_mc146818);
 
 	if (!device_is_ready(cmos)) {
 		printk("\tCMOS clock device is not ready.\n");

--- a/tests/boards/altera_max10/i2c_master/src/i2c_master.c
+++ b/tests/boards/altera_max10/i2c_master/src/i2c_master.c
@@ -65,7 +65,7 @@ static int powerup_adv7513(const struct device *i2c_dev)
 
 static int test_i2c_adv7513(void)
 {
-	const struct device *i2c_dev = DEVICE_DT_GET_ONE(altr_nios2_i2c);
+	const struct device *const i2c_dev = DEVICE_DT_GET_ONE(altr_nios2_i2c);
 	uint32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER;
 	uint8_t data;
 

--- a/tests/drivers/adc/adc_api/src/test_adc.c
+++ b/tests/drivers/adc/adc_api/src/test_adc.c
@@ -400,7 +400,7 @@ static const struct adc_channel_cfg m_2nd_channel_cfg = {
 
 const struct device *get_adc_device(void)
 {
-	const struct device *dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const struct device *const dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
 
 	if (!device_is_ready(dev)) {
 		printk("ADC device is not ready\n");
@@ -413,7 +413,7 @@ const struct device *get_adc_device(void)
 static const struct device *init_adc(void)
 {
 	int i, ret;
-	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const struct device *const adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
 
 	zassert_true(device_is_ready(adc_dev), "ADC device is not ready");
 

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -64,7 +64,7 @@ static const struct adc_channel_cfg m_2nd_channel_cfg = {
 
 const struct device *get_adc_device(void)
 {
-	const struct device *dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const struct device *const dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
 
 	if (!device_is_ready(dev)) {
 		printk("ADC device is not ready\n");
@@ -76,7 +76,7 @@ const struct device *get_adc_device(void)
 
 const struct device *get_count_device(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(pit0));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(pit0));
 
 	if (!device_is_ready(dev)) {
 		printk("count device is not ready\n");
@@ -89,7 +89,7 @@ const struct device *get_count_device(void)
 static void init_pit(void)
 {
 	int err;
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(pit0));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(pit0));
 	struct counter_top_cfg top_cfg = { .callback = NULL,
 					   .user_data = NULL,
 					   .flags = 0 };
@@ -106,7 +106,7 @@ static void init_pit(void)
 static const struct device *init_adc(void)
 {
 	int ret;
-	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const struct device *const adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
 
 	zassert_true(device_is_ready(adc_dev), "ADC device is not ready");
 

--- a/tests/drivers/adc/adc_emul/src/main.c
+++ b/tests/drivers/adc/adc_emul/src/main.c
@@ -32,7 +32,7 @@ static ZTEST_BMEM int16_t m_sample_buffer[BUFFER_SIZE];
  */
 const struct device *get_adc_device(void)
 {
-	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const struct device *const adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
 
 	zassert_true(device_is_ready(adc_dev), "ADC device is not ready");
 

--- a/tests/drivers/bbram/emul/src/main.c
+++ b/tests/drivers/bbram/emul/src/main.c
@@ -13,7 +13,7 @@
 
 ZTEST(bbram, test_get_size)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	size_t size;
 
 	zassert_true(device_is_ready(dev), "Device is not ready");
@@ -24,7 +24,7 @@ ZTEST(bbram, test_get_size)
 
 ZTEST(bbram, test_bbram_out_of_bounds)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	uint8_t buffer[BBRAM_SIZE];
 
 	zassert_equal(bbram_read(dev, 0, 0, buffer), -EFAULT, NULL);
@@ -37,7 +37,7 @@ ZTEST(bbram, test_bbram_out_of_bounds)
 
 ZTEST(bbram, test_read_write)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	uint8_t buffer[BBRAM_SIZE];
 	uint8_t expected[BBRAM_SIZE];
 
@@ -52,7 +52,7 @@ ZTEST(bbram, test_read_write)
 
 ZTEST(bbram, test_set_invalid)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 
 	zassert_equal(bbram_check_invalid(dev), 0, NULL);
 	zassert_ok(bbram_emul_set_invalid(dev, true), NULL);
@@ -62,7 +62,7 @@ ZTEST(bbram, test_set_invalid)
 
 ZTEST(bbram, test_set_standby)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 
 	zassert_equal(bbram_check_standby_power(dev), 0, NULL);
 	zassert_ok(bbram_emul_set_standby_power_state(dev, true), NULL);
@@ -72,7 +72,7 @@ ZTEST(bbram, test_set_standby)
 
 ZTEST(bbram, test_set_power)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 
 	zassert_equal(bbram_check_power(dev), 0, NULL);
 	zassert_ok(bbram_emul_set_power_state(dev, true), NULL);
@@ -82,7 +82,7 @@ ZTEST(bbram, test_set_power)
 
 ZTEST(bbram, test_reset_invalid_on_read)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	uint8_t buffer[BBRAM_SIZE];
 
 	zassert_ok(bbram_emul_set_invalid(dev, true), NULL);
@@ -92,7 +92,7 @@ ZTEST(bbram, test_reset_invalid_on_read)
 
 ZTEST(bbram, test_reset_invalid_on_write)
 {
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 	uint8_t buffer[BBRAM_SIZE];
 
 	zassert_ok(bbram_emul_set_invalid(dev, true), NULL);
@@ -103,7 +103,7 @@ ZTEST(bbram, test_reset_invalid_on_write)
 static void before(void *data)
 {
 	ARG_UNUSED(data);
-	const struct device *dev = DEVICE_DT_GET(BBRAM_NODELABEL);
+	const struct device *const dev = DEVICE_DT_GET(BBRAM_NODELABEL);
 
 	bbram_emul_set_invalid(dev, false);
 	bbram_emul_set_standby_power_state(dev, false);

--- a/tests/drivers/can/api/src/main.c
+++ b/tests/drivers/can/api/src/main.c
@@ -50,7 +50,7 @@
 /**
  * @brief Global variables.
  */
-static ZTEST_DMEM const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+static ZTEST_DMEM const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 static struct k_sem rx_callback_sem;
 static struct k_sem tx_callback_sem;
 

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -221,7 +221,7 @@ static void test_timing_values(const struct device *dev, const struct can_timing
  */
 ZTEST_USER(can_timing, test_timing)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(can_timing_tests); i++) {
@@ -235,7 +235,7 @@ ZTEST_USER(can_timing, test_timing)
 #ifdef CONFIG_CAN_FD_MODE
 ZTEST_USER(can_timing, test_timing_data)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(can_timing_data_tests); i++) {
@@ -254,7 +254,7 @@ ZTEST_USER(can_timing, test_timing_data)
  */
 ZTEST_USER(can_timing, test_set_timing_min)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	int err;
 
 	err = can_set_timing(dev, can_get_timing_min(dev));
@@ -271,7 +271,7 @@ ZTEST_USER(can_timing, test_set_timing_min)
  */
 ZTEST_USER(can_timing, test_set_timing_max)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	int err;
 
 	err = can_set_timing(dev, can_get_timing_max(dev));
@@ -285,7 +285,7 @@ ZTEST_USER(can_timing, test_set_timing_max)
 
 void *can_timing_setup(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 	uint32_t core_clock;
 	int err;
 

--- a/tests/drivers/clock_control/cavs_clock/src/main.c
+++ b/tests/drivers/clock_control/cavs_clock/src/main.c
@@ -37,7 +37,7 @@ static void test_cavs_clock_driver(void)
 static void test_cavs_clock_control(void)
 {
 	struct cavs_clock_info *clocks = cavs_clocks_get();
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(clkctl));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(clkctl));
 
 	zassert_not_null(clocks, "");
 

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -91,7 +91,7 @@ static void tear_down_instance(const struct device *dev,
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_clock)
 	/* Turn on LF clock using onoff service if it is disabled. */
-	const struct device *clk = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+	const struct device *const clk = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 	struct onoff_client cli;
 	struct onoff_manager *mgr = z_nrf_clock_control_get_onoff(CLOCK_CONTROL_NRF_SUBSYS_LF);
 	int err;

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
@@ -120,7 +120,7 @@ static void test_calibration_after_enabling_lfclk(void)
 		ztest_test_skip();
 	}
 
-	const struct device *clk_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+	const struct device *const clk_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 	struct sensor_value value = { .val1 = 0, .val2 = 0 };
 
 	zassert_true(device_is_ready(clk_dev), "Device is not ready");

--- a/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
+++ b/tests/drivers/clock_control/nrf_onoff_and_bt/src/main.c
@@ -102,7 +102,7 @@ static void check_hf_status(const struct device *dev, bool exp_on,
  */
 static void test_onoff_interrupted(void)
 {
-	const struct device *clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+	const struct device *const clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 	struct onoff_client cli;
 	uint64_t start_time = k_uptime_get();
 	uint64_t elapsed;
@@ -196,7 +196,7 @@ K_TIMER_DEFINE(timer2, onoff_timeout_handler, NULL);
  */
 static void test_bt_interrupted(void)
 {
-	const struct device *clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+	const struct device *const clock_dev = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 	uint64_t start_time = k_uptime_get();
 	uint64_t elapsed;
 	uint64_t checkpoint = 1000;

--- a/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
+++ b/tests/drivers/clock_control/onoff/src/test_clock_control_onoff.c
@@ -17,7 +17,7 @@ static struct onoff_manager *get_mgr(void)
 
 static bool clock_is_off(void)
 {
-	const struct device *clk = DEVICE_DT_GET_ONE(nordic_nrf_clock);
+	const struct device *const clk = DEVICE_DT_GET_ONE(nordic_nrf_clock);
 
 	zassert_true(device_is_ready(clk), "Device is not ready");
 

--- a/tests/drivers/coredump/coredump_api/src/main.c
+++ b/tests/drivers/coredump/coredump_api/src/main.c
@@ -64,8 +64,8 @@ ZTEST_SUITE(coredump_tests, NULL, coredump_tests_suite_setup, NULL, NULL, NULL);
 
 ZTEST(coredump_tests, test_register_memory)
 {
-	const struct device *coredump_dev = DEVICE_DT_GET(DT_NODELABEL(coredump_device0));
-	const struct device *coredump_cb_dev = DEVICE_DT_GET(DT_NODELABEL(coredump_devicecb));
+	const struct device *const coredump_dev = DEVICE_DT_GET(DT_NODELABEL(coredump_device0));
+	const struct device *const coredump_cb_dev = DEVICE_DT_GET(DT_NODELABEL(coredump_devicecb));
 
 	zassert_not_null(coredump_dev, "Cannot get coredump device");
 

--- a/tests/drivers/counter/counter_seconds/src/main.c
+++ b/tests/drivers/counter/counter_seconds/src/main.c
@@ -23,7 +23,7 @@
 
 void test_seconds_rate(void)
 {
-	const struct device *dev = DEVICE_DT_GET(CTR_DEV);
+	const struct device *const dev = DEVICE_DT_GET(CTR_DEV);
 	uint32_t start, elapsed;
 	int err;
 

--- a/tests/drivers/dac/dac_api/src/test_dac.c
+++ b/tests/drivers/dac/dac_api/src/test_dac.c
@@ -77,7 +77,7 @@ const struct device *get_dac_device(void)
 static const struct device *init_dac(void)
 {
 	int ret;
-	const struct device *dac_dev = DEVICE_DT_GET(DAC_DEVICE_NODE);
+	const struct device *const dac_dev = DEVICE_DT_GET(DAC_DEVICE_NODE);
 
 	zassert_true(device_is_ready(dac_dev), "DAC device is not ready");
 

--- a/tests/drivers/dac/dac_loopback/src/test_dac.c
+++ b/tests/drivers/dac/dac_loopback/src/test_dac.c
@@ -168,7 +168,7 @@ static const struct adc_channel_cfg adc_ch_cfg = {
 static const struct device *init_dac(void)
 {
 	int ret;
-	const struct device *dac_dev = DEVICE_DT_GET(DAC_DEVICE_NODE);
+	const struct device *const dac_dev = DEVICE_DT_GET(DAC_DEVICE_NODE);
 
 	zassert_true(device_is_ready(dac_dev), "DAC device is not ready");
 
@@ -183,7 +183,7 @@ static const struct device *init_dac(void)
 static const struct device *init_adc(void)
 {
 	int ret;
-	const struct device *adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
+	const struct device *const adc_dev = DEVICE_DT_GET(ADC_DEVICE_NODE);
 
 	zassert_true(device_is_ready(adc_dev), "ADC device is not ready");
 

--- a/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_blen_transfer/src/test_dma.c
@@ -47,7 +47,7 @@ static int test_task(uint32_t chan_id, uint32_t blen)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
-	const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(test_dma));
+	const struct device *const dma = DEVICE_DT_GET(DT_NODELABEL(test_dma));
 
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");

--- a/tests/drivers/dma/chan_link_transfer/src/test_dma.c
+++ b/tests/drivers/dma/chan_link_transfer/src/test_dma.c
@@ -53,7 +53,7 @@ static int test_task(int minor, int major)
 {
 	struct dma_config dma_cfg = { 0 };
 	struct dma_block_config dma_block_cfg = { 0 };
-	const struct device *dma = DEVICE_DT_GET(DT_NODELABEL(dma0));
+	const struct device *const dma = DEVICE_DT_GET(DT_NODELABEL(dma0));
 
 	if (!device_is_ready(dma)) {
 		TC_PRINT("dma controller device is not ready\n");

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -68,7 +68,7 @@ static int random_entropy(const struct device *dev, char *buffer, char num)
  */
 static int get_entropy(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
+	const struct device *const dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 	uint8_t buffer[BUFFER_LENGTH] = { 0 };
 	int ret;
 

--- a/tests/drivers/espi/src/test_acpi.c
+++ b/tests/drivers/espi/src/test_acpi.c
@@ -10,7 +10,7 @@
 
 static void test_acpi_shared_memory(void)
 {
-	const struct device *espi_dev = DEVICE_DT_GET(DT_NODELABEL(espi0));
+	const struct device *const espi_dev = DEVICE_DT_GET(DT_NODELABEL(espi0));
 	struct espi_cfg cfg = {
 		.channel_caps = ESPI_CHANNEL_VWIRE | ESPI_CHANNEL_PERIPHERAL,
 	};

--- a/tests/drivers/gpio/gpio_basic_api/src/main.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/main.c
@@ -21,8 +21,8 @@ static void board_setup(void)
 {
 #if DT_NODE_HAS_STATUS(DT_INST(0, test_gpio_basic_api), okay)
 	/* PIN_IN and PIN_OUT must be on same controller. */
-	const struct device *in_dev = DEVICE_DT_GET(DEV_OUT);
-	const struct device *out_dev = DEVICE_DT_GET(DEV_IN);
+	const struct device *const in_dev = DEVICE_DT_GET(DEV_OUT);
+	const struct device *const out_dev = DEVICE_DT_GET(DEV_IN);
 
 	if (in_dev != out_dev) {
 		printk("FATAL: output controller %s != input controller %s\n",
@@ -83,7 +83,7 @@ static void board_setup(void)
 			    IOMUXC_SW_PAD_CTL_PAD_DSE(6));
 #elif defined(CONFIG_GPIO_EMUL)
 	extern struct gpio_callback gpio_emul_callback;
-	const struct device *dev = DEVICE_DT_GET(DEV);
+	const struct device *const dev = DEVICE_DT_GET(DEV);
 
 	zassert_true(device_is_ready(dev), "GPIO dev is not ready");
 	int rc = gpio_add_callback(dev, &gpio_emul_callback);

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_manage.c
@@ -83,7 +83,7 @@ static void trigger_callback(const struct device *dev, int enable_cb)
 
 static int test_callback_add_remove(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DEV);
+	const struct device *const dev = DEVICE_DT_GET(DEV);
 
 	/* SetUp: initialize environment */
 	int rc = init_callback(dev, callback_1, callback_2);
@@ -132,7 +132,7 @@ err_exit:
 static int test_callback_self_remove(void)
 {
 	int res = TC_FAIL;
-	const struct device *dev = DEVICE_DT_GET(DEV);
+	const struct device *const dev = DEVICE_DT_GET(DEV);
 
 	/* SetUp: initialize environment */
 	int rc = init_callback(dev, callback_1, callback_remove_self);
@@ -184,7 +184,7 @@ err_exit:
 
 static int test_callback_enable_disable(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DEV);
+	const struct device *const dev = DEVICE_DT_GET(DEV);
 
 	/* SetUp: initialize environment */
 	int rc = init_callback(dev, callback_1, callback_2);

--- a/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_callback_trigger.c
@@ -33,7 +33,7 @@ static void callback(const struct device *dev,
 
 static int test_callback(int mode)
 {
-	const struct device *dev = DEVICE_DT_GET(DEV);
+	const struct device *const dev = DEVICE_DT_GET(DEV);
 	struct drv_data *drv_data = &data;
 
 	gpio_pin_interrupt_configure(dev, PIN_IN, GPIO_INT_DISABLE);

--- a/tests/drivers/i2c/i2c_api/src/test_i2c.c
+++ b/tests/drivers/i2c/i2c_api/src/test_i2c.c
@@ -31,7 +31,7 @@ uint32_t i2c_cfg = I2C_SPEED_SET(I2C_SPEED_STANDARD) | I2C_MODE_CONTROLLER;
 static int test_gy271(void)
 {
 	unsigned char datas[6];
-	const struct device *i2c_dev = DEVICE_DT_GET(I2C_DEV_NODE);
+	const struct device *const i2c_dev = DEVICE_DT_GET(I2C_DEV_NODE);
 	uint32_t i2c_cfg_tmp;
 
 	if (!device_is_ready(i2c_dev)) {
@@ -97,7 +97,7 @@ static int test_gy271(void)
 static int test_burst_gy271(void)
 {
 	unsigned char datas[6];
-	const struct device *i2c_dev = DEVICE_DT_GET(I2C_DEV_NODE);
+	const struct device *const i2c_dev = DEVICE_DT_GET(I2C_DEV_NODE);
 	uint32_t i2c_cfg_tmp;
 
 	if (!device_is_ready(i2c_dev)) {

--- a/tests/drivers/i2c/i2c_target_api/src/main.c
+++ b/tests/drivers/i2c/i2c_target_api/src/main.c
@@ -134,11 +134,11 @@ static int run_program_read(const struct device *i2c, uint8_t addr,
 
 void test_eeprom_target(void)
 {
-	const struct device *eeprom_0 = DEVICE_DT_GET(NODE_EP0);
-	const struct device *i2c_0 = DEVICE_DT_GET(DT_BUS(NODE_EP0));
+	const struct device *const eeprom_0 = DEVICE_DT_GET(NODE_EP0);
+	const struct device *const i2c_0 = DEVICE_DT_GET(DT_BUS(NODE_EP0));
 	int addr_0 = DT_REG_ADDR(NODE_EP0);
-	const struct device *eeprom_1 = DEVICE_DT_GET(NODE_EP1);
-	const struct device *i2c_1 = DEVICE_DT_GET(DT_BUS(NODE_EP1));
+	const struct device *const eeprom_1 = DEVICE_DT_GET(NODE_EP1);
+	const struct device *const i2c_1 = DEVICE_DT_GET(DT_BUS(NODE_EP1));
 	int addr_1 = DT_REG_ADDR(NODE_EP1);
 	int ret, offset;
 

--- a/tests/drivers/i2c/i2c_tca954x/src/main.c
+++ b/tests/drivers/i2c/i2c_tca954x/src/main.c
@@ -33,8 +33,8 @@ static void test_tca954x(void)
 {
 	uint8_t buff[1];
 
-	const struct device *i2c0 = DEVICE_DT_GET(I2C_0_CTRL_NODE_ID);
-	const struct device *i2c1 = DEVICE_DT_GET(I2C_1_CTRL_NODE_ID);
+	const struct device *const i2c0 = DEVICE_DT_GET(I2C_0_CTRL_NODE_ID);
+	const struct device *const i2c1 = DEVICE_DT_GET(I2C_1_CTRL_NODE_ID);
 
 	zassert_true(device_is_ready(i2c0), "I2C 0 not ready");
 	zassert_true(device_is_ready(i2c1), "I2C 1 not ready");

--- a/tests/drivers/kscan/kscan_api/src/test_kscan.c
+++ b/tests/drivers/kscan/kscan_api/src/test_kscan.c
@@ -21,7 +21,7 @@ static void kb_callback(const struct device *dev, uint32_t row, uint32_t col,
 
 static int test_kb_callback(void)
 {
-	const struct device *kscan_dev = DEVICE_DT_GET(DT_ALIAS(kscan0));
+	const struct device *const kscan_dev = DEVICE_DT_GET(DT_ALIAS(kscan0));
 
 	if (!device_is_ready(kscan_dev)) {
 		TC_PRINT("KBSCAN device is not ready\n");
@@ -38,7 +38,7 @@ static int test_kb_callback(void)
 
 static int test_null_callback(void)
 {
-	const struct device *kscan_dev = DEVICE_DT_GET(DT_ALIAS(kscan0));
+	const struct device *const kscan_dev = DEVICE_DT_GET(DT_ALIAS(kscan0));
 
 	if (!device_is_ready(kscan_dev)) {
 		TC_PRINT("KBSCAN device is not ready\n");
@@ -55,7 +55,7 @@ static int test_null_callback(void)
 
 static int test_disable_enable_callback(void)
 {
-	const struct device *kscan_dev = DEVICE_DT_GET(DT_ALIAS(kscan0));
+	const struct device *const kscan_dev = DEVICE_DT_GET(DT_ALIAS(kscan0));
 
 	if (!device_is_ready(kscan_dev)) {
 		TC_PRINT("KBSCAN device is not ready\n");

--- a/tests/drivers/led/led_api/src/test_led_api.c
+++ b/tests/drivers/led/led_api/src/test_led_api.c
@@ -54,7 +54,7 @@ static ZTEST_DMEM int num_leds = ARRAY_SIZE(test_led_info)
 
 LED_CONTROLLER_INFO(DT_ALIAS(led_controller_0));
 
-static ZTEST_BMEM const struct device *led_ctrl = DEVICE_DT_GET(DT_ALIAS(led_controller_0));
+static ZTEST_BMEM const struct device *const led_ctrl = DEVICE_DT_GET(DT_ALIAS(led_controller_0));
 
 void test_led_setup(void)
 {

--- a/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.c
+++ b/tests/drivers/sensor/sbs_gauge/src/test_sbs_gauge.c
@@ -10,7 +10,7 @@
 
 const struct device *get_fuel_gauge_device(void)
 {
-	const struct device *dev = DEVICE_DT_GET_ANY(sbs_sbs_gauge);
+	const struct device *const dev = DEVICE_DT_GET_ANY(sbs_sbs_gauge);
 
 	zassert_true(device_is_ready(dev), "Fuel Gauge not found");
 

--- a/tests/drivers/syscon/src/main.c
+++ b/tests/drivers/syscon/src/main.c
@@ -14,7 +14,7 @@ uint8_t var_in_res0[DT_REG_SIZE(DT_NODELABEL(syscon))] __attribute((__section__(
 
 static void test_size(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	const size_t expected_size = DT_REG_SIZE(DT_NODELABEL(syscon));
 	size_t size;
 
@@ -26,7 +26,7 @@ static void test_size(void)
 
 static void test_out_of_bounds(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uint32_t val;
 
 	zassert_equal(syscon_read_reg(dev, DT_REG_SIZE(DT_NODELABEL(syscon)), &val), -EINVAL, NULL);
@@ -35,7 +35,7 @@ static void test_out_of_bounds(void)
 
 static void test_read(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uintptr_t base_addr;
 	uint32_t val;
 
@@ -49,7 +49,7 @@ static void test_read(void)
 
 static void test_write(void)
 {
-	const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
+	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(syscon));
 	uintptr_t base_addr;
 
 	zassert_ok(syscon_get_base(dev, &base_addr), NULL);

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_config.c
@@ -36,7 +36,7 @@ const struct uart_config uart_cfg = {
 
 static int test_configure(void)
 {
-	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {
 		TC_PRINT("UART device not ready\n");
@@ -58,7 +58,7 @@ static int test_configure(void)
 /* test UART configure get (retrieve configuration) */
 static int test_config_get(void)
 {
-	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {
 		TC_PRINT("UART device not ready\n");

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_fifo.c
@@ -92,7 +92,7 @@ static void uart_fifo_callback(const struct device *dev, void *user_data)
 
 static int test_fifo_read(void)
 {
-	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {
 		TC_PRINT("UART device not ready\n");
@@ -122,7 +122,7 @@ static int test_fifo_read(void)
 
 static int test_fifo_fill(void)
 {
-	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {
 		TC_PRINT("UART device not ready\n");

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_pending.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_pending.c
@@ -93,7 +93,7 @@ static void uart_pending_callback(const struct device *dev, void *user_data)
 
 static int test_pending(void)
 {
-	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {
 		TC_PRINT("UART device not ready\n");

--- a/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
+++ b/tests/drivers/uart/uart_basic_api/src/test_uart_poll.c
@@ -11,7 +11,7 @@ static const char *poll_data = "This is a POLL test.\r\n";
 static int test_poll_in(void)
 {
 	unsigned char recv_char;
-	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {
 		TC_PRINT("UART device not ready\n");
@@ -40,7 +40,7 @@ static int test_poll_in(void)
 static int test_poll_out(void)
 {
 	int i;
-	const struct device *uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
+	const struct device *const uart_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(uart_dev)) {
 		TC_PRINT("UART device not ready\n");

--- a/tests/drivers/w1/w1_api/src/main.c
+++ b/tests/drivers/w1/w1_api/src/main.c
@@ -16,7 +16,7 @@
 
 const struct device *get_w1_master_dev(void)
 {
-	const struct device *master_dev = DEVICE_DT_GET(W1_MASTER);
+	const struct device *const master_dev = DEVICE_DT_GET(W1_MASTER);
 
 	zassert_true(device_is_ready(master_dev), "W1 master not found");
 

--- a/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
+++ b/tests/drivers/watchdog/wdt_basic_api/src/test_wdt.c
@@ -175,7 +175,7 @@ static void wdt_int_cb1(const struct device *wdt_dev, int channel_id)
 static int test_wdt_no_callback(void)
 {
 	int err;
-	const struct device *wdt = DEVICE_DT_GET(WDT_NODE);
+	const struct device *const wdt = DEVICE_DT_GET(WDT_NODE);
 
 	if (!device_is_ready(wdt)) {
 		TC_PRINT("WDT device is not ready\n");
@@ -216,7 +216,7 @@ static int test_wdt_no_callback(void)
 static int test_wdt_callback_1(void)
 {
 	int err;
-	const struct device *wdt = DEVICE_DT_GET(WDT_NODE);
+	const struct device *const wdt = DEVICE_DT_GET(WDT_NODE);
 
 	if (!device_is_ready(wdt)) {
 		TC_PRINT("WDT device is not ready\n");
@@ -271,7 +271,7 @@ static int test_wdt_callback_1(void)
 static int test_wdt_callback_2(void)
 {
 	int err;
-	const struct device *wdt = DEVICE_DT_GET(WDT_NODE);
+	const struct device *const wdt = DEVICE_DT_GET(WDT_NODE);
 
 	if (!device_is_ready(wdt)) {
 		TC_PRINT("WDT device is not ready\n");
@@ -332,7 +332,7 @@ static int test_wdt_callback_2(void)
 static int test_wdt_bad_window_max(void)
 {
 	int err;
-	const struct device *wdt = DEVICE_DT_GET(WDT_NODE);
+	const struct device *const wdt = DEVICE_DT_GET(WDT_NODE);
 
 	if (!device_is_ready(wdt)) {
 		TC_PRINT("WDT device is not ready\n");

--- a/tests/net/ptp/clock/src/main.c
+++ b/tests/net/ptp/clock/src/main.c
@@ -235,7 +235,7 @@ static const struct ptp_clock_driver_api api = {
 
 static int ptp_test_1_init(const struct device *port)
 {
-	const struct device *eth_dev = DEVICE_GET(eth3_test);
+	const struct device *const eth_dev = DEVICE_GET(eth3_test);
 	struct eth_context *context = eth_dev->data;
 	struct ptp_context *ptp_context = port->data;
 
@@ -251,7 +251,7 @@ DEVICE_DEFINE(ptp_clock_1, PTP_VIRT_CLOCK_NAME, ptp_test_1_init,
 
 static int ptp_test_2_init(const struct device *port)
 {
-	const struct device *eth_dev = DEVICE_GET(eth2_test);
+	const struct device *const eth_dev = DEVICE_GET(eth2_test);
 	struct eth_context *context = eth_dev->data;
 	struct ptp_context *ptp_context = port->data;
 

--- a/tests/subsys/canbus/isotp/conformance/src/main.c
+++ b/tests/subsys/canbus/isotp/conformance/src/main.c
@@ -118,7 +118,7 @@ const struct isotp_msg_id tx_addr_fixed = {
 	.use_fixed_addr = 1
 };
 
-const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 struct isotp_recv_ctx recv_ctx;
 struct isotp_send_ctx send_ctx;
 uint8_t data_buf[128];

--- a/tests/subsys/canbus/isotp/implementation/src/main.c
+++ b/tests/subsys/canbus/isotp/implementation/src/main.c
@@ -25,7 +25,7 @@
  * @}
  */
 
-const struct device *can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
+const struct device *const can_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_canbus));
 
 const struct isotp_fc_opts fc_opts = {
 	.bs = 8,

--- a/tests/subsys/edac/ibecc_cov/src/ibecc.c
+++ b/tests/subsys/edac/ibecc_cov/src/ibecc.c
@@ -97,7 +97,7 @@ static uint32_t mock_conf_read(pcie_bdf_t bdf, unsigned int reg)
 
 ZTEST(ibecc_cov, test_static_functions)
 {
-	const struct device *dev = DEVICE_DT_GET(DEVICE_NODE);
+	const struct device *const dev = DEVICE_DT_GET(DEVICE_NODE);
 	struct ibecc_error error_data;
 	uint64_t log_data;
 	int ret;

--- a/tests/subsys/pm/device_power_domains/src/main.c
+++ b/tests/subsys/pm/device_power_domains/src/main.c
@@ -11,9 +11,9 @@
 
 ZTEST(device_power_domain, test_demo)
 {
-	const struct device *reg_0 = DEVICE_DT_GET(DT_NODELABEL(test_reg_0));
-	const struct device *reg_1 = DEVICE_DT_GET(DT_NODELABEL(test_reg_1));
-	const struct device *reg_chained = DEVICE_DT_GET(DT_NODELABEL(test_reg_chained));
+	const struct device *const reg_0 = DEVICE_DT_GET(DT_NODELABEL(test_reg_0));
+	const struct device *const reg_1 = DEVICE_DT_GET(DT_NODELABEL(test_reg_1));
+	const struct device *const reg_chained = DEVICE_DT_GET(DT_NODELABEL(test_reg_chained));
 
 	/* Initial power state */
 	zassert_true(pm_device_is_powered(reg_0), "");

--- a/tests/subsys/pm/device_runtime_api/src/main.c
+++ b/tests/subsys/pm/device_runtime_api/src/main.c
@@ -227,7 +227,7 @@ DEVICE_DEFINE(pm_unsupported_device, "PM Unsupported", pm_unsupported_init,
 
 ZTEST(device_runtime_api, test_unsupported)
 {
-	const struct device *dev = DEVICE_GET(pm_unsupported_device);
+	const struct device *const dev = DEVICE_GET(pm_unsupported_device);
 
 	zassert_false(pm_device_runtime_is_enabled(dev), "");
 	zassert_equal(pm_device_runtime_enable(dev), -ENOTSUP, "");

--- a/tests/subsys/shell/shell_flash/src/shell_flash_test.c
+++ b/tests/subsys/shell/shell_flash/src/shell_flash_test.c
@@ -35,7 +35,7 @@ ZTEST(shell_flash, test_flash_read)
 		"00000020: 61 62 63                                         |abc              |",
 	};
 	const struct shell *shell = shell_backend_dummy_get_ptr();
-	const struct device *flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
+	const struct device *const flash_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	const char *buf;
 	const int test_base = FLASH_SIMULATOR_BASE_OFFSET;
 	const int test_size = 0x24;  /* 32-alignment required */


### PR DESCRIPTION
Many device pointers are initialized at compile and never changed. This
means that the device pointer can be constified (immutable).

Automated using:

```
perl -i -pe 's/const struct device \*(?!const)(.*)= DEVICE/const struct device *const $1= DEVICE/g' **/*.c
```

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>