### PR TITLE
drivers: clock_control: remove clock_control_subsys_t

### DIFF
--- a/drivers/adc/adc_npcx.c
+++ b/drivers/adc/adc_npcx.c
@@ -750,15 +750,14 @@ static int adc_npcx_init(const struct device *dev)
 	data->adc_dev = dev;
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
-							&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on ADC clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
-			&config->clk_cfg, &data->input_clk);
+	ret = clock_control_get_rate(clk_dev, &config->clk_cfg,
+				     &data->input_clk);
 	if (ret < 0) {
 		LOG_ERR("Get ADC clock rate error %d", ret);
 		return ret;

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -994,8 +994,7 @@ static int adc_stm32_init(const struct device *dev)
 	data->acq_time_index = -1;
 #endif
 
-	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+	if (clock_control_on(clk, &config->pclken) != 0) {
 		return -EIO;
 	}
 
@@ -1105,8 +1104,7 @@ static int adc_stm32_init(const struct device *dev)
 	 */
 	uint32_t adc_rate, wait_cycles;
 
-	if (clock_control_get_rate(clk,
-		(clock_control_subsys_t *) &config->pclken, &adc_rate) < 0) {
+	if (clock_control_get_rate(clk, &config->pclken, &adc_rate) < 0) {
 		LOG_ERR("ADC clock rate get error.");
 	}
 

--- a/drivers/audio/dmic_nrfx_pdm.c
+++ b/drivers/audio/dmic_nrfx_pdm.c
@@ -513,7 +513,7 @@ static int dmic_nrfx_pdm_read(const struct device *dev,
 static void init_clock_manager(const struct device *dev)
 {
 	struct dmic_nrfx_pdm_drv_data *drv_data = dev->data;
-	clock_control_subsys_t subsys;
+	void *subsys;
 
 #if NRF_CLOCK_HAS_HFCLKAUDIO
 	const struct dmic_nrfx_pdm_drv_cfg *drv_cfg = dev->config;

--- a/drivers/can/can_esp32_twai.c
+++ b/drivers/can/can_esp32_twai.c
@@ -22,7 +22,7 @@ struct can_esp32_twai_config {
 	mm_reg_t base;
 	const struct pinctrl_dev_config *pcfg;
 	const struct device *clock_dev;
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	int irq_source;
 };
 
@@ -125,7 +125,7 @@ const struct can_driver_api can_esp32_twai_driver_api = {
 	static const struct can_esp32_twai_config can_esp32_twai_config_##inst = {                 \
 		.base = DT_INST_REG_ADDR(inst),                                                    \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(inst)),                             \
-		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(inst, offset),         \
+		.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(inst, offset),                   \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(inst),                                      \
 		.irq_source = DT_INST_IRQN(inst),                                                  \
 	};                                                                                         \

--- a/drivers/can/can_mcux_flexcan.c
+++ b/drivers/can/can_mcux_flexcan.c
@@ -80,7 +80,7 @@ LOG_MODULE_REGISTER(can_mcux_flexcan, CONFIG_CAN_LOG_LEVEL);
 struct mcux_flexcan_config {
 	CAN_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	int clk_source;
 	uint32_t bitrate;
 	uint32_t sample_point;
@@ -867,8 +867,8 @@ static const struct can_driver_api mcux_flexcan_driver_api = {
 	static const struct mcux_flexcan_config mcux_flexcan_config_##id = { \
 		.base = (CAN_Type *)DT_INST_REG_ADDR(id),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
-		.clock_subsys = (clock_control_subsys_t)		\
-			DT_INST_CLOCKS_CELL(id, name),			\
+		.clock_subsys =						\
+			(const void *)DT_INST_CLOCKS_CELL(id, name),	\
 		.clk_source = DT_INST_PROP(id, clk_source),		\
 		.bitrate = DT_INST_PROP(id, bus_speed),			\
 		.sjw = DT_INST_PROP(id, sjw),				\

--- a/drivers/can/can_mcux_mcan.c
+++ b/drivers/can/can_mcux_mcan.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(can_mcux_mcan, CONFIG_CAN_LOG_LEVEL);
 
 struct mcux_mcan_config {
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
@@ -154,7 +154,7 @@ static const struct can_driver_api mcux_mcan_driver_api = {
 									\
 	static const struct mcux_mcan_config mcux_mcan_config_##n = {	\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys = (clock_control_subsys_t)		\
+		.clock_subsys = (const void *)				\
 			DT_INST_CLOCKS_CELL(n, name),			\
 		.irq_config_func = mcux_mcan_irq_config_##n,		\
 		MCUX_MCAN_PINCTRL_INIT(n)				\

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -953,20 +953,17 @@ static int can_rcar_init(const struct device *dev)
 	}
 
 	/* reset the registers */
-	ret = clock_control_off(config->clock_dev,
-				(clock_control_subsys_t *)&config->mod_clk);
+	ret = clock_control_off(config->clock_dev, &config->mod_clk);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->mod_clk);
+	ret = clock_control_on(config->clock_dev, &config->mod_clk);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->bus_clk);
+	ret = clock_control_on(config->clock_dev, &config->bus_clk);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -464,9 +464,7 @@ static int can_stm32_get_core_clock(const struct device *dev, uint32_t *rate)
 
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	ret = clock_control_get_rate(clock,
-				     (clock_control_subsys_t *) &cfg->pclken,
-				     rate);
+	ret = clock_control_get_rate(clock, &cfg->pclken, rate);
 	if (ret != 0) {
 		LOG_ERR("Failed call clock_control_get_rate: return [%d]", ret);
 		return -EIO;
@@ -525,7 +523,7 @@ static int can_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clock, (clock_control_subsys_t *) &cfg->pclken);
+	ret = clock_control_on(clock, &cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("HAL_CAN_Init clock control on failed: %d", ret);
 		return -EIO;

--- a/drivers/can/can_stm32fd.c
+++ b/drivers/can/can_stm32fd.c
@@ -87,7 +87,7 @@ static int can_stm32fd_clock_enable(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *)&stm32fd_cfg->pclken);
+	ret = clock_control_on(clk, &stm32fd_cfg->pclken);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/can/can_stm32h7.c
+++ b/drivers/can/can_stm32h7.c
@@ -57,7 +57,7 @@ static int can_stm32h7_clock_enable(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *)&stm32h7_cfg->pclken);
+	ret = clock_control_on(clk, &stm32h7_cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("failure enabling clock");
 		return ret;

--- a/drivers/clock_control/beetle_clock_control.c
+++ b/drivers/clock_control/beetle_clock_control.c
@@ -81,7 +81,7 @@ static inline void beetle_apb_set_clock_off(uint8_t bit,
 }
 
 static inline int beetle_clock_control_on(const struct device *dev,
-					  clock_control_subsys_t sub_system)
+					  const void *sub_system)
 {
 	struct arm_clock_control_t *beetle_cc =
 				(struct arm_clock_control_t *)(sub_system);
@@ -105,7 +105,7 @@ static inline int beetle_clock_control_on(const struct device *dev,
 }
 
 static inline int beetle_clock_control_off(const struct device *dev,
-					   clock_control_subsys_t sub_system)
+					   const void *sub_system)
 {
 	struct arm_clock_control_t *beetle_cc =
 				(struct arm_clock_control_t *)(sub_system);
@@ -128,7 +128,7 @@ static inline int beetle_clock_control_off(const struct device *dev,
 }
 
 static int beetle_clock_control_get_subsys_rate(const struct device *clock,
-						clock_control_subsys_t sub_system,
+						const void *sub_system,
 						uint32_t *rate)
 {
 #ifdef CONFIG_CLOCK_CONTROL_BEETLE_ENABLE_PLL

--- a/drivers/clock_control/clock_agilex.c
+++ b/drivers/clock_control/clock_agilex.c
@@ -20,7 +20,7 @@ static int clk_init(const struct device *dev)
 }
 
 static int clk_get_rate(const struct device *dev,
-			clock_control_subsys_t sub_system,
+			const void *sub_system,
 			uint32_t *rate)
 {
 	ARG_UNUSED(dev);

--- a/drivers/clock_control/clock_control_ast10x0.c
+++ b/drivers/clock_control/clock_control_ast10x0.c
@@ -49,7 +49,7 @@ struct clock_aspeed_config {
 
 #define DEV_CFG(dev) ((const struct clock_aspeed_config *const)(dev)->config)
 
-static int aspeed_clock_control_on(const struct device *dev, clock_control_subsys_t sub_system)
+static int aspeed_clock_control_on(const struct device *dev, const void *sub_system)
 {
 	const struct device *syscon = DEV_CFG(dev)->syscon;
 	uint32_t clk_gate = (uint32_t)sub_system;
@@ -70,7 +70,7 @@ static int aspeed_clock_control_on(const struct device *dev, clock_control_subsy
 	return 0;
 }
 
-static int aspeed_clock_control_off(const struct device *dev, clock_control_subsys_t sub_system)
+static int aspeed_clock_control_off(const struct device *dev, const void *sub_system)
 {
 	const struct device *syscon = DEV_CFG(dev)->syscon;
 	uint32_t clk_gate = (uint32_t)sub_system;
@@ -92,7 +92,7 @@ static int aspeed_clock_control_off(const struct device *dev, clock_control_subs
 }
 
 static int aspeed_clock_control_get_rate(const struct device *dev,
-					 clock_control_subsys_t sub_system, uint32_t *rate)
+					 const void *sub_system, uint32_t *rate)
 {
 	const struct device *syscon = DEV_CFG(dev)->syscon;
 	uint32_t clk_id = (uint32_t)sub_system;

--- a/drivers/clock_control/clock_control_cavs.c
+++ b/drivers/clock_control/clock_control_cavs.c
@@ -8,7 +8,7 @@
 #include <zephyr/drivers/clock_control.h>
 
 static int cavs_clock_ctrl_set_rate(const struct device *clk,
-				    clock_control_subsys_t sys,
+				    const void *sys,
 				    clock_control_subsys_rate_t rate)
 {
 	uint32_t freq_idx = (uint32_t)rate;

--- a/drivers/clock_control/clock_control_esp32.c
+++ b/drivers/clock_control/clock_control_esp32.c
@@ -60,7 +60,7 @@ static uint8_t const xtal_freq[] = {
 };
 
 static int clock_control_esp32_on(const struct device *dev,
-				  clock_control_subsys_t sys)
+				  const void *sys)
 {
 	ARG_UNUSED(dev);
 	periph_module_enable((periph_module_t)sys);
@@ -68,7 +68,7 @@ static int clock_control_esp32_on(const struct device *dev,
 }
 
 static int clock_control_esp32_off(const struct device *dev,
-				   clock_control_subsys_t sys)
+				   const void *sys)
 {
 	ARG_UNUSED(dev);
 	periph_module_disable((periph_module_t)sys);
@@ -76,7 +76,7 @@ static int clock_control_esp32_off(const struct device *dev,
 }
 
 static int clock_control_esp32_async_on(const struct device *dev,
-					clock_control_subsys_t sys,
+					const void *sys,
 					clock_control_cb_t cb,
 					void *user_data)
 {
@@ -88,7 +88,7 @@ static int clock_control_esp32_async_on(const struct device *dev,
 }
 
 static enum clock_control_status clock_control_esp32_get_status(const struct device *dev,
-								clock_control_subsys_t sys)
+								const void *sys)
 {
 	ARG_UNUSED(dev);
 	uint32_t clk_en_reg = periph_ll_get_clk_en_reg((periph_module_t)sys);
@@ -101,7 +101,7 @@ static enum clock_control_status clock_control_esp32_get_status(const struct dev
 }
 
 static int clock_control_esp32_get_rate(const struct device *dev,
-					clock_control_subsys_t sub_system,
+					const void *sub_system,
 					uint32_t *rate)
 {
 	ARG_UNUSED(sub_system);

--- a/drivers/clock_control/clock_control_litex.c
+++ b/drivers/clock_control/clock_control_litex.c
@@ -1524,9 +1524,9 @@ static int litex_clk_set_all_def_clkouts(void)
  *			all clkout parameters
  */
 static int litex_clk_get_subsys_rate(const struct device *clock,
-				     clock_control_subsys_t sys, uint32_t *rate)
+				     const void *sys, uint32_t *rate)
 {
-	struct litex_clk_setup *setup = sys;
+	const struct litex_clk_setup *setup = sys;
 	struct litex_clk_clkout *lcko;
 
 	lcko = &ldev->clkouts[setup->clkout_nr];
@@ -1536,9 +1536,9 @@ static int litex_clk_get_subsys_rate(const struct device *clock,
 }
 
 static enum clock_control_status litex_clk_get_status(const struct device *dev,
-						     clock_control_subsys_t sys)
+						     const void *sys)
 {
-	struct litex_clk_setup *setup = sys;
+	struct litex_clk_setup *setup = (struct litex_clk_setup *)sys;
 	struct clk_duty duty;
 	struct litex_clk_clkout *lcko;
 	int ret;
@@ -1556,9 +1556,9 @@ static enum clock_control_status litex_clk_get_status(const struct device *dev,
 	return CLOCK_CONTROL_STATUS_ON;
 }
 
-static inline int litex_clk_on(const struct device *dev, clock_control_subsys_t sys)
+static inline int litex_clk_on(const struct device *dev, const void *sys)
 {
-	struct litex_clk_setup *setup = sys;
+	const struct litex_clk_setup *setup = sys;
 	struct clk_duty duty;
 	struct litex_clk_clkout *lcko;
 	uint8_t duty_perc;
@@ -1591,7 +1591,7 @@ static inline int litex_clk_on(const struct device *dev, clock_control_subsys_t 
 }
 
 static inline int litex_clk_off(const struct device *dev,
-				clock_control_subsys_t sub_system)
+				const void *sub_system)
 {
 	return litex_clk_change_value(ZERO_REG, ZERO_REG, POWER_REG);
 }

--- a/drivers/clock_control/clock_control_lpc11u6x.c
+++ b/drivers/clock_control/clock_control_lpc11u6x.c
@@ -105,7 +105,7 @@ static void syscon_frg_deinit(struct lpc11u6x_syscon_regs *syscon)
 }
 
 static int lpc11u6x_clock_control_on(const struct device *dev,
-				     clock_control_subsys_t sub_system)
+				     const void *sub_system)
 {
 	const struct lpc11u6x_syscon_config *cfg = dev->config;
 	struct lpc11u6x_syscon_data *data = dev->data;
@@ -177,7 +177,7 @@ static int lpc11u6x_clock_control_on(const struct device *dev,
 }
 
 static int lpc11u6x_clock_control_off(const struct device *dev,
-				      clock_control_subsys_t sub_system)
+				      const void *sub_system)
 {
 	const struct lpc11u6x_syscon_config *cfg = dev->config;
 	struct lpc11u6x_syscon_data *data = dev->data;
@@ -251,7 +251,7 @@ static int lpc11u6x_clock_control_off(const struct device *dev,
 }
 
 static int lpc11u6x_clock_control_get_rate(const struct device *dev,
-					   clock_control_subsys_t sub_system,
+					   const void *sub_system,
 					   uint32_t *rate)
 {
 	switch ((int) sub_system) {

--- a/drivers/clock_control/clock_control_mchp_xec.c
+++ b/drivers/clock_control/clock_control_mchp_xec.c
@@ -439,7 +439,7 @@ int z_mchp_xec_pcr_periph_sleep(uint8_t slp_idx, uint8_t slp_pos,
 /* clock control driver API implementation */
 
 static int xec_cc_on(const struct device *dev,
-		     clock_control_subsys_t sub_system,
+		     const void *sub_system,
 		     bool turn_on)
 {
 	struct pcr_regs *const pcr = XEC_PCR_REGS_BASE(dev);
@@ -508,7 +508,7 @@ static int xec_cc_on(const struct device *dev,
  * to its PCR control register.
  */
 static int xec_clock_control_on(const struct device *dev,
-				clock_control_subsys_t sub_system)
+				const void *sub_system)
 {
 	return xec_cc_on(dev, sub_system, true);
 }
@@ -523,7 +523,7 @@ static int xec_clock_control_on(const struct device *dev,
  * Peripheral slow clock can be turned off by writing 0 to its control register.
  */
 static inline int xec_clock_control_off(const struct device *dev,
-					clock_control_subsys_t sub_system)
+					const void *sub_system)
 {
 	return xec_cc_on(dev, sub_system, false);
 }
@@ -549,7 +549,7 @@ static inline int xec_clock_control_off(const struct device *dev,
  *   BBLED, RPMFAN
  */
 static int xec_clock_control_get_subsys_rate(const struct device *dev,
-					     clock_control_subsys_t sub_system,
+					     const void *sub_system,
 					     uint32_t *rate)
 {
 	struct pcr_regs *const pcr = XEC_PCR_REGS_BASE(dev);

--- a/drivers/clock_control/clock_control_mcux_ccm.c
+++ b/drivers/clock_control/clock_control_mcux_ccm.c
@@ -34,19 +34,19 @@ static const clock_root_control_t uart_clk_root[] = {
 #endif
 
 static int mcux_ccm_on(const struct device *dev,
-			      clock_control_subsys_t sub_system)
+			      const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_ccm_off(const struct device *dev,
-			       clock_control_subsys_t sub_system)
+			       const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_ccm_get_subsys_rate(const struct device *dev,
-				    clock_control_subsys_t sub_system,
+				    const void *sub_system,
 				    uint32_t *rate)
 {
 #ifdef CONFIG_ARM64

--- a/drivers/clock_control/clock_control_mcux_ccm_rev2.c
+++ b/drivers/clock_control/clock_control_mcux_ccm_rev2.c
@@ -16,19 +16,19 @@
 LOG_MODULE_REGISTER(clock_control);
 
 static int mcux_ccm_on(const struct device *dev,
-				  clock_control_subsys_t sub_system)
+				  const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_ccm_off(const struct device *dev,
-				   clock_control_subsys_t sub_system)
+				   const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_ccm_get_subsys_rate(const struct device *dev,
-					clock_control_subsys_t sub_system,
+					const void *sub_system,
 					uint32_t *rate)
 {
 	uint32_t clock_name = (uint32_t) sub_system;

--- a/drivers/clock_control/clock_control_mcux_mcg.c
+++ b/drivers/clock_control/clock_control_mcux_mcg.c
@@ -19,19 +19,19 @@
 LOG_MODULE_REGISTER(clock_control_mcg);
 
 static int mcux_mcg_on(const struct device *dev,
-		       clock_control_subsys_t sub_system)
+		       const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_mcg_off(const struct device *dev,
-			clock_control_subsys_t sub_system)
+			const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_mcg_get_rate(const struct device *dev,
-			     clock_control_subsys_t sub_system,
+			     const void *sub_system,
 			     uint32_t *rate)
 {
 	clock_name_t clock_name;

--- a/drivers/clock_control/clock_control_mcux_pcc.c
+++ b/drivers/clock_control/clock_control_mcux_pcc.c
@@ -28,7 +28,7 @@ struct mcux_pcc_config {
 #endif
 
 static inline clock_ip_name_t clock_ip(const struct device *dev,
-				       clock_control_subsys_t sub_system)
+				       const void *sub_system)
 {
 	uint32_t offset = POINTER_TO_UINT(sub_system);
 
@@ -36,21 +36,21 @@ static inline clock_ip_name_t clock_ip(const struct device *dev,
 }
 
 static int mcux_pcc_on(const struct device *dev,
-		       clock_control_subsys_t sub_system)
+		       const void *sub_system)
 {
 	CLOCK_EnableClock(clock_ip(dev, sub_system));
 	return 0;
 }
 
 static int mcux_pcc_off(const struct device *dev,
-			clock_control_subsys_t sub_system)
+			const void *sub_system)
 {
 	CLOCK_DisableClock(clock_ip(dev, sub_system));
 	return 0;
 }
 
 static int mcux_pcc_get_rate(const struct device *dev,
-			       clock_control_subsys_t sub_system,
+			       const void *sub_system,
 			       uint32_t *rate)
 {
 	*rate = CLOCK_GetIpFreq(clock_ip(dev, sub_system));

--- a/drivers/clock_control/clock_control_mcux_scg.c
+++ b/drivers/clock_control/clock_control_mcux_scg.c
@@ -21,19 +21,19 @@ LOG_MODULE_REGISTER(clock_control_scg);
 #define MCUX_SCG_CLOCK_NODE(name) DT_CHILD(DT_DRV_INST(0), name)
 
 static int mcux_scg_on(const struct device *dev,
-		       clock_control_subsys_t sub_system)
+		       const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_scg_off(const struct device *dev,
-			clock_control_subsys_t sub_system)
+			const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_scg_get_rate(const struct device *dev,
-			     clock_control_subsys_t sub_system,
+			     const void *sub_system,
 			     uint32_t *rate)
 {
 	clock_name_t clock_name;

--- a/drivers/clock_control/clock_control_mcux_sim.c
+++ b/drivers/clock_control/clock_control_mcux_sim.c
@@ -16,7 +16,7 @@
 LOG_MODULE_REGISTER(clock_control);
 
 static int mcux_sim_on(const struct device *dev,
-		       clock_control_subsys_t sub_system)
+		       const void *sub_system)
 {
 	clock_ip_name_t clock_ip_name = (clock_ip_name_t) sub_system;
 
@@ -26,7 +26,7 @@ static int mcux_sim_on(const struct device *dev,
 }
 
 static int mcux_sim_off(const struct device *dev,
-			clock_control_subsys_t sub_system)
+			const void *sub_system)
 {
 	clock_ip_name_t clock_ip_name = (clock_ip_name_t) sub_system;
 
@@ -36,7 +36,7 @@ static int mcux_sim_off(const struct device *dev,
 }
 
 static int mcux_sim_get_subsys_rate(const struct device *dev,
-				    clock_control_subsys_t sub_system,
+				    const void *sub_system,
 				    uint32_t *rate)
 {
 	clock_name_t clock_name;

--- a/drivers/clock_control/clock_control_mcux_syscon.c
+++ b/drivers/clock_control/clock_control_mcux_syscon.c
@@ -16,7 +16,7 @@
 LOG_MODULE_REGISTER(clock_control);
 
 static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
-			      clock_control_subsys_t sub_system)
+			      const void *sub_system)
 {
 #if defined(CONFIG_CAN_MCUX_MCAN)
 	uint32_t clock_name = (uint32_t)sub_system;
@@ -30,14 +30,14 @@ static int mcux_lpc_syscon_clock_control_on(const struct device *dev,
 }
 
 static int mcux_lpc_syscon_clock_control_off(const struct device *dev,
-			       clock_control_subsys_t sub_system)
+			       const void *sub_system)
 {
 	return 0;
 }
 
 static int mcux_lpc_syscon_clock_control_get_subsys_rate(
 					const struct device *dev,
-				    clock_control_subsys_t sub_system,
+				    const void *sub_system,
 				    uint32_t *rate)
 {
 	uint32_t clock_name = (uint32_t) sub_system;

--- a/drivers/clock_control/clock_control_npcx.c
+++ b/drivers/clock_control/clock_control_npcx.c
@@ -30,7 +30,7 @@ struct npcx_pcc_config {
 
 /* Clock controller local functions */
 static inline int npcx_clock_control_on(const struct device *dev,
-					 clock_control_subsys_t sub_system)
+					 const void *sub_system)
 {
 	ARG_UNUSED(dev);
 	struct npcx_clk_cfg *clk_cfg = (struct npcx_clk_cfg *)(sub_system);
@@ -46,7 +46,7 @@ static inline int npcx_clock_control_on(const struct device *dev,
 }
 
 static inline int npcx_clock_control_off(const struct device *dev,
-					  clock_control_subsys_t sub_system)
+					  const void *sub_system)
 {
 	ARG_UNUSED(dev);
 	struct npcx_clk_cfg *clk_cfg = (struct npcx_clk_cfg *)(sub_system);
@@ -62,7 +62,7 @@ static inline int npcx_clock_control_off(const struct device *dev,
 }
 
 static int npcx_clock_control_get_subsys_rate(const struct device *dev,
-					      clock_control_subsys_t sub_system,
+					      const void *sub_system,
 					      uint32_t *rate)
 {
 	ARG_UNUSED(dev);

--- a/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
+++ b/drivers/clock_control/clock_control_r8a7795_cpg_mssr.c
@@ -67,7 +67,7 @@ unlock:
 	return ret;
 }
 
-int r8a7795_cpg_mssr_start_stop(const struct device *dev, clock_control_subsys_t sys, bool enable)
+int r8a7795_cpg_mssr_start_stop(const struct device *dev, const void *sys, bool enable)
 {
 	const struct r8a7795_cpg_mssr_config *config = dev->config;
 	struct rcar_cpg_clk *clk = (struct rcar_cpg_clk *)sys;
@@ -84,19 +84,19 @@ int r8a7795_cpg_mssr_start_stop(const struct device *dev, clock_control_subsys_t
 }
 
 static int r8a7795_cpg_mssr_start(const struct device *dev,
-				  clock_control_subsys_t sys)
+				  const void *sys)
 {
 	return r8a7795_cpg_mssr_start_stop(dev, sys, true);
 }
 
 static int r8a7795_cpg_mssr_stop(const struct device *dev,
-				 clock_control_subsys_t sys)
+				 const void *sys)
 {
 	return r8a7795_cpg_mssr_start_stop(dev, sys, false);
 }
 
 static int r8a7795_cpg_get_rate(const struct device *dev,
-				clock_control_subsys_t sys,
+				const void *sys,
 				uint32_t *rate)
 {
 	const struct r8a7795_cpg_mssr_config *config = dev->config;

--- a/drivers/clock_control/clock_control_rv32m1_pcc.c
+++ b/drivers/clock_control/clock_control_rv32m1_pcc.c
@@ -22,7 +22,7 @@ struct rv32m1_pcc_config {
 	(((struct rv32m1_pcc_config *)(dev->config))->base_address)
 
 static inline clock_ip_name_t clock_ip(const struct device *dev,
-				       clock_control_subsys_t sub_system)
+				       const void *sub_system)
 {
 	uint32_t offset = POINTER_TO_UINT(sub_system);
 
@@ -30,21 +30,21 @@ static inline clock_ip_name_t clock_ip(const struct device *dev,
 }
 
 static int rv32m1_pcc_on(const struct device *dev,
-			 clock_control_subsys_t sub_system)
+			 const void *sub_system)
 {
 	CLOCK_EnableClock(clock_ip(dev, sub_system));
 	return 0;
 }
 
 static int rv32m1_pcc_off(const struct device *dev,
-			  clock_control_subsys_t sub_system)
+			  const void *sub_system)
 {
 	CLOCK_DisableClock(clock_ip(dev, sub_system));
 	return 0;
 }
 
 static int rv32m1_pcc_get_rate(const struct device *dev,
-			       clock_control_subsys_t sub_system,
+			       const void *sub_system,
 			       uint32_t *rate)
 {
 	*rate = CLOCK_GetIpFreq(clock_ip(dev, sub_system));

--- a/drivers/clock_control/clock_stm32_ll_common.c
+++ b/drivers/clock_control/clock_stm32_ll_common.c
@@ -181,7 +181,7 @@ static int enabled_clock(uint32_t src_clk)
 }
 
 static inline int stm32_clock_control_on(const struct device *dev,
-					 clock_control_subsys_t sub_system)
+					 const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	volatile uint32_t *reg;
@@ -203,7 +203,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 }
 
 static inline int stm32_clock_control_off(const struct device *dev,
-					  clock_control_subsys_t sub_system)
+					  const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	volatile uint32_t *reg;
@@ -225,7 +225,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 }
 
 static inline int stm32_clock_control_configure(const struct device *dev,
-						clock_control_subsys_t sub_system,
+						const void *sub_system,
 						void *data)
 {
 #if defined(STM32_SRC_SYSCLK)
@@ -260,7 +260,7 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 }
 
 static int stm32_clock_control_get_subsys_rate(const struct device *clock,
-						clock_control_subsys_t sub_system,
+						const void *sub_system,
 						uint32_t *rate)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);

--- a/drivers/clock_control/clock_stm32_ll_h7.c
+++ b/drivers/clock_control/clock_stm32_ll_h7.c
@@ -350,7 +350,7 @@ static int enabled_clock(uint32_t src_clk)
 }
 
 static inline int stm32_clock_control_on(const struct device *dev,
-					 clock_control_subsys_t sub_system)
+					 const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	volatile uint32_t *reg;
@@ -376,7 +376,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 }
 
 static inline int stm32_clock_control_off(const struct device *dev,
-					  clock_control_subsys_t sub_system)
+					  const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	volatile uint32_t *reg;
@@ -402,7 +402,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 }
 
 static inline int stm32_clock_control_configure(const struct device *dev,
-						clock_control_subsys_t sub_system,
+						const void *sub_system,
 						void *data)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
@@ -436,7 +436,7 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 }
 
 static int stm32_clock_control_get_subsys_rate(const struct device *clock,
-					       clock_control_subsys_t sub_system,
+					       const void *sub_system,
 					       uint32_t *rate)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);

--- a/drivers/clock_control/clock_stm32_ll_mp1.c
+++ b/drivers/clock_control/clock_stm32_ll_mp1.c
@@ -15,7 +15,7 @@
  * @brief fill in AHB/APB buses configuration structure
  */
 static inline int stm32_clock_control_on(const struct device *dev,
-					 clock_control_subsys_t sub_system)
+					 const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 
@@ -66,7 +66,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 }
 
 static inline int stm32_clock_control_off(const struct device *dev,
-					  clock_control_subsys_t sub_system)
+					  const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 
@@ -117,7 +117,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 }
 
 static int stm32_clock_control_get_subsys_rate(const struct device *clock,
-					       clock_control_subsys_t sub_system,
+					       const void *sub_system,
 					       uint32_t *rate)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);

--- a/drivers/clock_control/clock_stm32_ll_u5.c
+++ b/drivers/clock_control/clock_stm32_ll_u5.c
@@ -141,7 +141,7 @@ static int enabled_clock(uint32_t src_clk)
 }
 
 static inline int stm32_clock_control_on(const struct device *dev,
-					 clock_control_subsys_t sub_system)
+					 const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	volatile uint32_t *reg;
@@ -163,7 +163,7 @@ static inline int stm32_clock_control_on(const struct device *dev,
 }
 
 static inline int stm32_clock_control_off(const struct device *dev,
-					  clock_control_subsys_t sub_system)
+					  const void *sub_system)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
 	volatile uint32_t *reg;
@@ -185,7 +185,7 @@ static inline int stm32_clock_control_off(const struct device *dev,
 }
 
 static inline int stm32_clock_control_configure(const struct device *dev,
-						clock_control_subsys_t sub_system,
+						const void *sub_system,
 						void *data)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sub_system);
@@ -214,7 +214,7 @@ static inline int stm32_clock_control_configure(const struct device *dev,
 }
 
 static int stm32_clock_control_get_subsys_rate(const struct device *dev,
-					       clock_control_subsys_t sys,
+					       const void *sys,
 					       uint32_t *rate)
 {
 	struct stm32_pclken *pclken = (struct stm32_pclken *)(sys);

--- a/drivers/clock_control/clock_stm32_mux.c
+++ b/drivers/clock_control/clock_stm32_mux.c
@@ -26,7 +26,7 @@ static int stm32_clk_mux_init(const struct device *dev)
 	const struct stm32_clk_mux_config *cfg = dev->config;
 
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			     (clock_control_subsys_t) &cfg->pclken) != 0) {
+			     &cfg->pclken) != 0) {
 		LOG_ERR("Could not enable clock mux");
 		return -EIO;
 	}

--- a/drivers/counter/counter_ll_stm32_rtc.c
+++ b/drivers/counter/counter_ll_stm32_rtc.c
@@ -289,7 +289,7 @@ static int rtc_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken) != 0) {
+	if (clock_control_on(clk, &cfg->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/counter/counter_ll_stm32_timer.c
+++ b/drivers/counter/counter_ll_stm32_timer.c
@@ -358,8 +358,7 @@ static int counter_stm32_get_tim_clk(const struct stm32_pclken *pclken, uint32_t
 		return -ENODEV;
 	}
 
-	r = clock_control_get_rate(clk, (clock_control_subsys_t *)pclken,
-				   &bus_clk);
+	r = clock_control_get_rate(clk, pclken, &bus_clk);
 	if (r < 0) {
 		return r;
 	}
@@ -444,7 +443,7 @@ static int counter_stm32_init_timer(const struct device *dev)
 
 	/* initialize clock and check its speed  */
 	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			     (clock_control_subsys_t *)&cfg->pclken);
+			     &cfg->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize clock (%d)", r);
 		return r;

--- a/drivers/counter/counter_mcux_ctimer.c
+++ b/drivers/counter/counter_mcux_ctimer.c
@@ -34,7 +34,7 @@ struct mcux_lpc_ctimer_config {
 	struct counter_config_info info;
 	CTIMER_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	ctimer_timer_mode_t mode;
 	ctimer_capture_channel_t input;
 	uint32_t prescale;
@@ -297,8 +297,8 @@ static const struct counter_driver_api mcux_ctimer_driver_api = {
 		},\
 		.base = (CTIMER_Type *)DT_INST_REG_ADDR(id),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
-		.clock_subsys =				\
-		(clock_control_subsys_t)(DT_INST_CLOCKS_CELL(id, name) + MCUX_CTIMER_CLK_OFFSET),\
+		.clock_subsys =	(const void *)				\
+		(DT_INST_CLOCKS_CELL(id, name) + MCUX_CTIMER_CLK_OFFSET),\
 		.mode = DT_INST_PROP(id, mode),						\
 		.input = DT_INST_PROP(id, input),					\
 		.prescale = DT_INST_PROP(id, prescale),				\

--- a/drivers/counter/counter_mcux_gpt.c
+++ b/drivers/counter/counter_mcux_gpt.c
@@ -17,7 +17,7 @@ struct mcux_gpt_config {
 	/* info must be first element */
 	struct counter_config_info info;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	GPT_Type *base;
 	clock_name_t clock_source;
 };
@@ -211,8 +211,8 @@ static const struct counter_driver_api mcux_gpt_driver_api = {
 	static const struct mcux_gpt_config mcux_gpt_config_ ## n = {	\
 		.base = (void *)DT_INST_REG_ADDR(n),			\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys =						\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(n, name),			\
 		.info = {						\
 			.max_top_value = UINT32_MAX,			\
 			.freq = DT_INST_PROP(n, gptfreq),           \

--- a/drivers/counter/counter_mcux_qtmr.c
+++ b/drivers/counter/counter_mcux_qtmr.c
@@ -24,7 +24,7 @@ struct mcux_qtmr_config {
 	/* info must be first element */
 	struct counter_config_info info;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	TMR_Type *base;
 	clock_name_t clock_source;
 	qtmr_channel_selection_t channel;
@@ -305,8 +305,8 @@ static const struct counter_driver_api mcux_qtmr_driver_api = {
 	static const struct mcux_qtmr_config mcux_qtmr_config_ ## n = {				\
 		.base = (void *)DT_REG_ADDR(DT_INST_PARENT(n)),					\
 		.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(DT_INST_PARENT(n))),			\
-		.clock_subsys =									\
-			(clock_control_subsys_t)DT_CLOCKS_CELL(DT_INST_PARENT(n), name),	\
+		.clock_subsys = (const void *)							\
+			DT_CLOCKS_CELL(DT_INST_PARENT(n), name),				\
 		.info = {									\
 			.max_top_value = UINT16_MAX,						\
 			.freq = DT_INST_PROP_OR(n, freq, 0),					\

--- a/drivers/counter/timer_dtmr_cmsdk_apb.c
+++ b/drivers/counter/timer_dtmr_cmsdk_apb.c
@@ -151,9 +151,9 @@ static int dtmr_cmsdk_apb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->dtimer_cc_as);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->dtimer_cc_ss);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->dtimer_cc_dss);
+	clock_control_on(clk, &cfg->dtimer_cc_as);
+	clock_control_on(clk, &cfg->dtimer_cc_ss);
+	clock_control_on(clk, &cfg->dtimer_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/counter/timer_tmr_cmsdk_apb.c
+++ b/drivers/counter/timer_tmr_cmsdk_apb.c
@@ -154,9 +154,9 @@ static int tmr_cmsdk_apb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->timer_cc_as);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->timer_cc_ss);
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->timer_cc_dss);
+	clock_control_on(clk, &cfg->timer_cc_as);
+	clock_control_on(clk, &cfg->timer_cc_ss);
+	clock_control_on(clk, &cfg->timer_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/crypto/crypto_stm32.c
+++ b/drivers/crypto/crypto_stm32.c
@@ -458,7 +458,7 @@ static int crypto_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken) != 0) {
+	if (clock_control_on(clk, &cfg->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/dac/dac_stm32.c
+++ b/drivers/dac/dac_stm32.c
@@ -126,8 +126,7 @@ static int dac_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk,
-			     (clock_control_subsys_t *) &cfg->pclken) != 0) {
+	if (clock_control_on(clk, &cfg->pclken) != 0) {
 		return -EIO;
 	}
 

--- a/drivers/disk/sdmmc_stm32.c
+++ b/drivers/disk/sdmmc_stm32.c
@@ -154,7 +154,7 @@ static int stm32_sdmmc_clock_enable(struct stm32_sdmmc_priv *priv)
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	/* Enable the APB clock for stm32_sdmmc */
-	return clock_control_on(clock, (clock_control_subsys_t *)&priv->pclken);
+	return clock_control_on(clock, &priv->pclken);
 }
 
 static int stm32_sdmmc_clock_disable(struct stm32_sdmmc_priv *priv)
@@ -163,8 +163,7 @@ static int stm32_sdmmc_clock_disable(struct stm32_sdmmc_priv *priv)
 
 	clock = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	return clock_control_off(clock,
-				 (clock_control_subsys_t *)&priv->pclken);
+	return clock_control_off(clock, &priv->pclken);
 }
 
 #if STM32_SDMMC_USE_DMA

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -245,7 +245,7 @@ static int stm32_ltdc_init(const struct device *dev)
 
 	/* Turn on LTDC peripheral clock */
 	err = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &config->pclken);
+			       &config->pclken);
 	if (err < 0) {
 		LOG_ERR("Could not enable LTDC peripheral clock");
 		return err;
@@ -328,7 +328,7 @@ static int stm32_ltdc_suspend(const struct device *dev)
 
 	/* Turn off LTDC peripheral clock */
 	err = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &config->pclken);
+				 &config->pclken);
 
 	return err;
 }

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -622,8 +622,7 @@ static int dma_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+	if (clock_control_on(clk, &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/dma/dmamux_stm32.c
+++ b/drivers/dma/dmamux_stm32.c
@@ -221,8 +221,7 @@ static int dmamux_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk,
-		(clock_control_subsys_t *) &config->pclken) != 0) {
+	if (clock_control_on(clk, &config->pclken) != 0) {
 		LOG_ERR("clock op failed\n");
 		return -EIO;
 	}

--- a/drivers/entropy/entropy_stm32.c
+++ b/drivers/entropy/entropy_stm32.c
@@ -608,8 +608,7 @@ static int entropy_stm32_rng_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	res = clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&dev_cfg->pclken);
+	res = clock_control_on(dev_data->clock, &dev_cfg->pclken);
 	__ASSERT_NO_MSG(res == 0);
 
 	/* Locking semaphore initialized to 1 (unlocked) */

--- a/drivers/espi/espi_npcx.c
+++ b/drivers/espi/espi_npcx.c
@@ -866,8 +866,7 @@ static int espi_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on eSPI device clock first */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
-							&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on eSPI clock fail %d", ret);
 		return ret;

--- a/drivers/espi/host_subs_npcx.c
+++ b/drivers/espi/host_subs_npcx.c
@@ -1013,8 +1013,7 @@ int npcx_host_init_subs_core_domain(const struct device *host_bus_dev,
 			return -ENODEV;
 		}
 
-		ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
-				&host_sub_cfg.clks_list[i]);
+		ret = clock_control_on(clk_dev, &host_sub_cfg.clks_list[i]);
 		if (ret < 0) {
 			return ret;
 		}

--- a/drivers/ethernet/eth_dwmac_stm32h7x.c
+++ b/drivers/ethernet/eth_dwmac_stm32h7x.c
@@ -56,9 +56,9 @@ int dwmac_bus_init(struct dwmac_priv *p)
 		return -ENODEV;
 	}
 
-	ret  = clock_control_on(p->clock, (clock_control_subsys_t *)&pclken);
-	ret |= clock_control_on(p->clock, (clock_control_subsys_t *)&pclken_tx);
-	ret |= clock_control_on(p->clock, (clock_control_subsys_t *)&pclken_rx);
+	ret  = clock_control_on(p->clock, &pclken);
+	ret |= clock_control_on(p->clock, &pclken_tx);
+	ret |= clock_control_on(p->clock, &pclken_rx);
 	if (ret) {
 		LOG_ERR("Failed to enable ethernet clock");
 		return -EIO;

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -263,14 +263,12 @@ static int eth_mcux_device_pm_action(const struct device *dev,
 
 		ENET_Reset(eth_ctx->base);
 		ENET_Deinit(eth_ctx->base);
-		clock_control_off(eth_ctx->clock_dev,
-			(clock_control_subsys_t)eth_ctx->clock);
+		clock_control_off(eth_ctx->clock_dev, (void *)eth_ctx->clock);
 		break;
 	case PM_DEVICE_ACTION_RESUME:
 		LOG_DBG("Resuming");
 
-		clock_control_on(eth_ctx->clock_dev,
-			(clock_control_subsys_t)eth_ctx->clock);
+		clock_control_on(eth_ctx->clock_dev, (void *)eth_ctx->clock);
 		eth_mcux_init(dev);
 		net_if_resume(eth_ctx->iface);
 		break;

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -792,15 +792,11 @@ static int eth_initialize(const struct device *dev)
 	}
 
 	/* enable clock */
-	ret = clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken);
-	ret |= clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken_tx);
-	ret |= clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken_rx);
+	ret = clock_control_on(dev_data->clock, &cfg->pclken);
+	ret |= clock_control_on(dev_data->clock, &cfg->pclken_tx);
+	ret |= clock_control_on(dev_data->clock, &cfg->pclken_rx);
 #if !defined(CONFIG_SOC_SERIES_STM32H7X)
-	ret |= clock_control_on(dev_data->clock,
-		(clock_control_subsys_t *)&cfg->pclken_ptp);
+	ret |= clock_control_on(dev_data->clock, &cfg->pclken_ptp);
 #endif /* !defined(CONFIG_SOC_SERIES_STM32H7X) */
 
 	if (ret) {
@@ -1331,9 +1327,9 @@ static int ptp_stm32_init(const struct device *port)
 	/* Query ethernet clock rate */
 	ret = clock_control_get_rate(eth_dev_data->clock,
 #if defined(CONFIG_SOC_SERIES_STM32H7X)
-		(clock_control_subsys_t *)&eth_cfg->pclken,
+		&eth_cfg->pclken,
 #else
-		(clock_control_subsys_t *)&eth_cfg->pclken_ptp,
+		&eth_cfg->pclken_ptp,
 #endif /* CONFIG_SOC_SERIES_STM32H7X */
 		&ptp_hclk_rate);
 	if (ret) {

--- a/drivers/flash/flash_stm32.c
+++ b/drivers/flash/flash_stm32.c
@@ -364,7 +364,7 @@ static int stm32_flash_init(const struct device *dev)
 	}
 
 	/* enable clock */
-	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {
+	if (clock_control_on(clk, &p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");
 		return -EIO;
 	}

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1590,27 +1590,26 @@ static int flash_stm32_ospi_init(const struct device *dev)
 
 	/* Clock configuration */
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			     (clock_control_subsys_t) &dev_cfg->pclken[0]) != 0) {
+			     &dev_cfg->pclken[0]) != 0) {
 		LOG_ERR("Could not enable OSPI clock");
 		return -EIO;
 	}
 	/* Alternate clock config for peripheral if any */
 	if (dev_cfg->pclk_len > 1) {
 		if (clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &dev_cfg->pclken[1],
-					NULL) != 0) {
+					    &dev_cfg->pclken[1], NULL) != 0) {
 			LOG_ERR("Could not select OSPI domain clock pclk[1]");
 			return -EIO;
 		}
 		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					   (clock_control_subsys_t) &dev_cfg->pclken[1],
+					   &dev_cfg->pclken[1],
 					   &ahb_clock_freq) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclk[1])");
 			return -EIO;
 		}
 	} else {
 		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					   (clock_control_subsys_t) &dev_cfg->pclken[0],
+					   &dev_cfg->pclken[0],
 					   &ahb_clock_freq) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclk[0])");
 			return -EIO;

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -1138,14 +1138,14 @@ static int flash_stm32_qspi_init(const struct device *dev)
 
 	/* Clock configuration */
 	if (clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			     (clock_control_subsys_t) &dev_cfg->pclken) != 0) {
+			     &dev_cfg->pclken) != 0) {
 		LOG_DBG("Could not enable QSPI clock");
 		return -EIO;
 	}
 
 	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			(clock_control_subsys_t) &dev_cfg->pclken,
-			&ahb_clock_freq) < 0) {
+				   &dev_cfg->pclken,
+				   &ahb_clock_freq) < 0) {
 		LOG_DBG("Failed to get AHB clock frequency");
 		return -EIO;
 	}

--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -672,7 +672,7 @@ static int stm32h7_flash_init(const struct device *dev)
 	}
 
 	/* enable clock */
-	if (clock_control_on(clk, (clock_control_subsys_t *)&p->pclken) != 0) {
+	if (clock_control_on(clk, &p->pclken) != 0) {
 		LOG_ERR("Failed to enable clock");
 		return -EIO;
 	}

--- a/drivers/gpio/gpio_cmsdk_ahb.c
+++ b/drivers/gpio/gpio_cmsdk_ahb.c
@@ -245,9 +245,9 @@ static int gpio_cmsdk_ahb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &cfg->gpio_cc_as);
-	clock_control_off(clk, (clock_control_subsys_t *) &cfg->gpio_cc_ss);
-	clock_control_off(clk, (clock_control_subsys_t *) &cfg->gpio_cc_dss);
+	clock_control_on(clk, &cfg->gpio_cc_as);
+	clock_control_off(clk, &cfg->gpio_cc_ss);
+	clock_control_off(clk, &cfg->gpio_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/gpio/gpio_lpc11u6x.c
+++ b/drivers/gpio/gpio_lpc11u6x.c
@@ -80,7 +80,7 @@ struct lpc11u6x_pint_regs {
  */
 struct gpio_lpc11u6x_shared {
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	uint32_t gpio_base;
 	uint32_t syscon_base;
 	uint8_t nirqs;
@@ -500,7 +500,7 @@ static const struct gpio_driver_api gpio_lpc11u6x_driver_api = {
 
 static const struct gpio_lpc11u6x_shared gpio_lpc11u6x_shared = {
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = (clock_control_subsys_t) DT_INST_PHA(0, clocks, clkid),
+	.clock_subsys = (const void *)DT_INST_PHA(0, clocks, clkid),
 	.gpio_base = DT_INST_REG_ADDR_BY_IDX(0, 0),
 	.syscon_base = DT_INST_REG_ADDR_BY_IDX(0, 1),
 	.nirqs = DT_NUM_IRQS(DT_DRV_INST(0)),

--- a/drivers/gpio/gpio_rcar.c
+++ b/drivers/gpio/gpio_rcar.c
@@ -251,8 +251,7 @@ static int gpio_rcar_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *) &config->mod_clk);
+	ret = clock_control_on(config->clock_dev, &config->mod_clk);
 
 	if (ret < 0) {
 		return ret;

--- a/drivers/gpio/gpio_rv32m1.c
+++ b/drivers/gpio/gpio_rv32m1.c
@@ -25,7 +25,7 @@ struct gpio_rv32m1_config {
 	PORT_Type *port_base;
 	unsigned int flags;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	int (*irq_config_func)(const struct device *dev);
 };
 
@@ -313,8 +313,7 @@ static const struct gpio_driver_api gpio_rv32m1_driver_api = {
 		.flags = GPIO_INT_ENABLE,				\
 		.irq_config_func = gpio_rv32m1_##n##_init,		\
 		.clock_dev = INST_DT_CLK_CTRL_DEV(n),			\
-		.clock_subsys = (clock_control_subsys_t)		\
-				INST_DT_CLK_CELL_NAME(n)		\
+		.clock_subsys = (const void *)INST_DT_CLK_CELL_NAME(n)	\
 	};								\
 									\
 	static struct gpio_rv32m1_data gpio_rv32m1_##n##_data;		\

--- a/drivers/gpio/gpio_stm32.c
+++ b/drivers/gpio/gpio_stm32.c
@@ -278,11 +278,9 @@ static int gpio_stm32_clock_request(const struct device *dev, bool on)
 	const struct device *clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
 	if (on) {
-		ret = clock_control_on(clk,
-					(clock_control_subsys_t *)&cfg->pclken);
+		ret = clock_control_on(clk, &cfg->pclken);
 	} else {
-		ret = clock_control_off(clk,
-					(clock_control_subsys_t *)&cfg->pclken);
+		ret = clock_control_off(clk, &cfg->pclken);
 	}
 
 	if (ret != 0) {
@@ -396,7 +394,7 @@ static int gpio_stm32_enable_int(int port, int pin)
 	int ret;
 
 	/* Enable SYSCFG clock */
-	ret = clock_control_on(clk, (clock_control_subsys_t *) &pclken);
+	ret = clock_control_on(clk, &pclken);
 	if (ret != 0) {
 		return ret;
 	}

--- a/drivers/i2c/i2c_esp32.c
+++ b/drivers/i2c/i2c_esp32.c
@@ -80,7 +80,7 @@ struct i2c_esp32_config {
 #endif
 	const struct pinctrl_dev_config *pcfg;
 
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 
 	const struct {
 		bool tx_lsb_first;
@@ -735,7 +735,7 @@ static int IRAM_ATTR i2c_esp32_init(const struct device *dev)
 	.index = idx, \
 	.clock_dev = DEVICE_DT_GET(DT_CLOCKS_CTLR(I2C(idx))), \
 	.pcfg = PINCTRL_DT_DEV_CONFIG_GET(I2C(idx)),	\
-	.clock_subsys = (clock_control_subsys_t)DT_CLOCKS_CELL(I2C(idx), offset), \
+	.clock_subsys = (const void *)DT_CLOCKS_CELL(I2C(idx), offset), \
 	I2C_ESP32_GET_PIN_INFO(idx)	\
 	.mode = { \
 		.tx_lsb_first = DT_PROP(I2C(idx), tx_lsb), \

--- a/drivers/i2c/i2c_ll_stm32.c
+++ b/drivers/i2c/i2c_ll_stm32.c
@@ -43,7 +43,7 @@ int i2c_stm32_runtime_configure(const struct device *dev, uint32_t config)
 	clock = rcc_clocks.SYSCLK_Frequency;
 #else
 	if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			(clock_control_subsys_t *) &cfg->pclken, &clock) < 0) {
+				   &cfg->pclken, &clock) < 0) {
 		LOG_ERR("Failed call clock_control_get_rate");
 		return -EIO;
 	}
@@ -228,8 +228,7 @@ static int i2c_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clock,
-		(clock_control_subsys_t *) &cfg->pclken) != 0) {
+	if (clock_control_on(clock, &cfg->pclken) != 0) {
 		LOG_ERR("i2c: failure enabling clock");
 		return -EIO;
 	}

--- a/drivers/i2c/i2c_lpc11u6x.c
+++ b/drivers/i2c/i2c_lpc11u6x.c
@@ -19,8 +19,7 @@ static void lpc11u6x_i2c_set_bus_speed(const struct lpc11u6x_i2c_config *cfg,
 {
 	uint32_t clk, div;
 
-	clock_control_get_rate(clk_dev, (clock_control_subsys_t) cfg->clkid,
-			       &clk);
+	clock_control_get_rate(clk_dev, cfg->clkid, &clk);
 	div = clk / speed;
 
 	cfg->base->sclh = div / 2;
@@ -319,7 +318,7 @@ static int lpc11u6x_i2c_init(const struct device *dev)
 	}
 
 	/* Configure clock and de-assert reset for I2Cx */
-	clock_control_on(cfg->clock_dev, (clock_control_subsys_t) cfg->clkid);
+	clock_control_on(cfg->clock_dev, cfg->clkid);
 
 	/* Configure bus speed. Default is 100KHz */
 	lpc11u6x_i2c_set_bus_speed(cfg, cfg->clock_dev, 100000);

--- a/drivers/i2c/i2c_mcux_flexcomm.c
+++ b/drivers/i2c/i2c_mcux_flexcomm.c
@@ -23,7 +23,7 @@ LOG_MODULE_REGISTER(mcux_flexcomm);
 struct mcux_flexcomm_config {
 	I2C_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t bitrate;
 #ifdef CONFIG_PINCTRL
@@ -388,8 +388,8 @@ static const struct i2c_driver_api mcux_flexcomm_driver_api = {
 	static const struct mcux_flexcomm_config mcux_flexcomm_config_##id = {	\
 		.base = (I2C_Type *) DT_INST_REG_ADDR(id),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
-		.clock_subsys =				\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(id, name),			\
 		.irq_config_func = mcux_flexcomm_config_func_##id,	\
 		.bitrate = DT_INST_PROP(id, clock_frequency),		\
 		I2C_MCUX_FLEXCOMM_PINCTRL_INIT(id)			\

--- a/drivers/i2c/i2c_mcux_lpi2c.c
+++ b/drivers/i2c/i2c_mcux_lpi2c.c
@@ -35,7 +35,7 @@ LOG_MODULE_REGISTER(mcux_lpi2c);
 struct mcux_lpi2c_config {
 	LPI2C_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t bitrate;
 	uint32_t bus_idle_timeout_ns;
@@ -384,8 +384,8 @@ static const struct i2c_driver_api mcux_lpi2c_driver_api = {
 	static const struct mcux_lpi2c_config mcux_lpi2c_config_##n = {	\
 		.base = (LPI2C_Type *)DT_INST_REG_ADDR(n),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys =						\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(n, name),			\
 		.irq_config_func = mcux_lpi2c_config_func_##n,		\
 		.bitrate = DT_INST_PROP(n, clock_frequency),		\
 		I2C_MCUX_LPI2C_PINCTRL_INIT(n)				\

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -915,8 +915,7 @@ static int i2c_ctrl_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	if (clock_control_on(clk_dev,
-		(clock_control_subsys_t *) &config->clk_cfg) != 0) {
+	if (clock_control_on(clk_dev, &config->clk_cfg) != 0) {
 		LOG_ERR("Turn on %s clock fail.", dev->name);
 		return -EIO;
 	}
@@ -926,8 +925,7 @@ static int i2c_ctrl_init(const struct device *dev)
 	 * configuration of the device to meet SMBus timing spec. Please refer
 	 * Table 21/22/23 and section 7.5.9 SMBus Timing for more detail.
 	 */
-	if (clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
-			&config->clk_cfg, &i2c_rate) != 0) {
+	if (clock_control_get_rate(clk_dev, &config->clk_cfg, &i2c_rate) != 0) {
 		LOG_ERR("Get %s clock rate error.", dev->name);
 		return -EIO;
 	}

--- a/drivers/i2c/i2c_rcar.c
+++ b/drivers/i2c/i2c_rcar.c
@@ -325,8 +325,7 @@ static int i2c_rcar_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->mod_clk);
+	ret = clock_control_on(config->clock_dev, &config->mod_clk);
 
 	if (ret != 0) {
 		return ret;

--- a/drivers/i2c/i2c_rv32m1_lpi2c.c
+++ b/drivers/i2c/i2c_rv32m1_lpi2c.c
@@ -25,7 +25,7 @@ LOG_MODULE_REGISTER(rv32m1_lpi2c);
 struct rv32m1_lpi2c_config {
 	LPI2C_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	clock_ip_name_t clock_ip_name;
 	uint32_t clock_ip_src;
 	uint32_t bitrate;
@@ -278,8 +278,7 @@ static const struct i2c_driver_api rv32m1_lpi2c_driver_api = {
 		.base =                                                        \
 		(LPI2C_Type *)DT_INST_REG_ADDR(id),                            \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	       \
-		.clock_subsys =                                                \
-			(clock_control_subsys_t) DT_INST_CLOCKS_CELL(id, name),\
+		.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(id, name),   \
 		.clock_ip_name = INST_DT_CLOCK_IP_NAME(id),                    \
 		.clock_ip_src  = kCLOCK_IpSrcFircAsync,                        \
 		.bitrate = DT_INST_PROP(id, clock_frequency),                  \

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -107,7 +107,7 @@ static int i2s_stm32_enable_clock(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
+	ret = clock_control_on(clk, &cfg->pclken);
 	if (ret != 0) {
 		LOG_ERR("Could not enable I2S clock");
 		return -EIO;

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -26,7 +26,7 @@ LOG_MODULE_REGISTER(i2s_mcux_flexcomm);
 struct i2s_mcux_config {
 	I2S_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config)(const struct device *dev);
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
@@ -924,8 +924,8 @@ static int i2s_mcux_init(const struct device *dev)
 		.base =							\
 		(I2S_Type *)DT_INST_REG_ADDR(id),			\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)), \
-		.clock_subsys =				\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(id, name),			\
 		.irq_config = i2s_mcux_config_func_##id,		\
 		I2S_MCUX_FLEXCOMM_PINCTRL_INIT(id)			\
 	};								\

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -91,7 +91,7 @@ struct i2s_mcux_config {
 	uint32_t mclk_pin_mask;
 	uint32_t mclk_pin_offset;
 	uint32_t tx_channel;
-	clock_control_subsys_t clk_sub_sys;
+	void *clk_sub_sys;
 	const struct device *ccm_dev;
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pinctrl;
@@ -449,7 +449,7 @@ static void get_mclk_rate(const struct device *dev, uint32_t *mclk)
 {
 	const struct i2s_mcux_config *dev_cfg = dev->config;
 	const struct device *ccm_dev = dev_cfg->ccm_dev;
-	clock_control_subsys_t clk_sub_sys = dev_cfg->clk_sub_sys;
+	void *clk_sub_sys = dev_cfg->clk_sub_sys;
 	uint32_t rate = 0;
 
 	if (device_is_ready(ccm_dev)) {
@@ -1275,7 +1275,7 @@ static const struct i2s_driver_api i2s_mcux_driver_api = {
 		.mclk_pin_offset =					\
 			DT_PHA_BY_IDX(DT_DRV_INST(i2s_id),		\
 				pinmuxes, 0, pin),			\
-		.clk_sub_sys =	(clock_control_subsys_t)		\
+		.clk_sub_sys =						\
 			DT_INST_CLOCKS_CELL_BY_IDX(i2s_id, 0, name),	\
 		.ccm_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(i2s_id)),	\
 		.irq_connect = i2s_irq_connect_##i2s_id,		\

--- a/drivers/i2s/i2s_nrfx.c
+++ b/drivers/i2s/i2s_nrfx.c
@@ -852,7 +852,7 @@ static int i2s_nrfx_trigger(const struct device *dev,
 static void init_clock_manager(const struct device *dev)
 {
 	struct i2s_nrfx_drv_data *drv_data = dev->data;
-	clock_control_subsys_t subsys;
+	void *subsys;
 
 #if NRF_CLOCK_HAS_HFCLKAUDIO
 	const struct i2s_nrfx_drv_cfg *drv_cfg = dev->config;

--- a/drivers/interrupt_controller/intc_mchp_ecia_xec.c
+++ b/drivers/interrupt_controller/intc_mchp_ecia_xec.c
@@ -519,8 +519,7 @@ static int xec_ecia_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk_dev,
-			       (clock_control_subsys_t *)&cfg->clk_ctrl);
+	ret = clock_control_on(clk_dev, &cfg->clk_ctrl);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/interrupt_controller/intc_rv32m1_intmux.c
+++ b/drivers/interrupt_controller/intc_rv32m1_intmux.c
@@ -41,7 +41,7 @@
 struct rv32m1_intmux_config {
 	INTMUX_Type *regs;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	struct _isr_table_entry *isr_base;
 };
 
@@ -144,7 +144,7 @@ static const struct irq_next_level_api rv32m1_intmux_apis = {
 static const struct rv32m1_intmux_config rv32m1_intmux_cfg = {
 	.regs = (INTMUX_Type *)DT_INST_REG_ADDR(0),
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = UINT_TO_POINTER(DT_INST_CLOCKS_CELL(0, name)),
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(0, name),
 	.isr_base = &_sw_isr_table[CONFIG_2ND_LVL_ISR_TBL_OFFSET],
 };
 

--- a/drivers/ipm/ipm_stm32_hsem.c
+++ b/drivers/ipm/ipm_stm32_hsem.c
@@ -163,7 +163,7 @@ static int stm32_hsem_mailbox_init(const struct device *dev)
 		}
 
 		/* Enable clock */
-		if (clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken) != 0) {
+		if (clock_control_on(clk, &cfg->pclken) != 0) {
 			LOG_WRN("Failed to enable clock");
 			return -EIO;
 		}

--- a/drivers/ipm/ipm_stm32_ipcc.c
+++ b/drivers/ipm/ipm_stm32_ipcc.c
@@ -251,8 +251,7 @@ static int stm32_ipcc_mailbox_init(const struct device *dev)
 	}
 
 	/* enable clock */
-	if (clock_control_on(clk,
-			     (clock_control_subsys_t *)&cfg->pclken) != 0) {
+	if (clock_control_on(clk, &cfg->pclken) != 0) {
 		return -EIO;
 	}
 

--- a/drivers/memc/memc_stm32.c
+++ b/drivers/memc/memc_stm32.c
@@ -49,7 +49,7 @@ static int memc_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	r = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
+	r = clock_control_on(clk, &config->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize FMC clock (%d)", r);
 		return r;

--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -242,13 +242,13 @@ static int peci_npcx_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on PECI clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)&config->clk_cfg,
+	ret = clock_control_get_rate(clk_dev, &config->clk_cfg,
 				     &data->peci_src_clk_freq);
 	if (ret < 0) {
 		LOG_ERR("Get PECI source clock rate error %d", ret);

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -336,8 +336,7 @@ static int ps2_npcx_ctrl_init(const struct device *dev)
 	}
 
 	/* Turn on PS/2 controller device clock */
-	ret = clock_control_on(clk_dev,
-			       (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on PS/2 clock fail %d", ret);
 		return ret;

--- a/drivers/pwm/pwm_led_esp32.c
+++ b/drivers/pwm/pwm_led_esp32.c
@@ -41,7 +41,7 @@ struct pwm_ledc_esp32_channel_config {
 struct pwm_ledc_esp32_config {
 	const struct pinctrl_dev_config *pincfg;
 	const struct device *clock_dev;
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	struct pwm_ledc_esp32_channel_config *channel_config;
 	const int channel_len;
 };
@@ -339,7 +339,7 @@ static struct pwm_ledc_esp32_channel_config channel_config[] = {
 static struct pwm_ledc_esp32_config pwm_ledc_esp32_config = {
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(0, offset),
 	.channel_config = channel_config,
 	.channel_len = ARRAY_SIZE(channel_config),
 };

--- a/drivers/pwm/pwm_mc_esp32.c
+++ b/drivers/pwm/pwm_mc_esp32.c
@@ -78,7 +78,7 @@ struct mcpwm_esp32_config {
 	const uint8_t index;
 	const struct pinctrl_dev_config *pincfg;
 	const struct device *clock_dev;
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	uint8_t prescale;
 	uint8_t prescale_timer0;
 	uint8_t prescale_timer1;
@@ -558,7 +558,7 @@ static const struct pwm_driver_api mcpwm_esp32_api = {
 		.index = idx,                                                                      \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),                                     \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),                              \
-		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),          \
+		.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(idx, offset),                    \
 		.prescale = DT_INST_PROP(idx, prescale),                                           \
 		.prescale_timer0 = DT_INST_PROP_OR(idx, prescale_timer0, 0),                       \
 		.prescale_timer1 = DT_INST_PROP_OR(idx, prescale_timer1, 0),                       \

--- a/drivers/pwm/pwm_mcux.c
+++ b/drivers/pwm/pwm_mcux.c
@@ -23,7 +23,7 @@ struct pwm_mcux_config {
 	PWM_Type *base;
 	uint8_t index;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	pwm_clock_prescale_t prescale;
 	pwm_mode_t mode;
 	const struct pinctrl_dev_config *pincfg;
@@ -185,8 +185,9 @@ static const struct pwm_driver_api pwm_mcux_driver_api = {
 		.index = DT_INST_PROP(n, index),			  \
 		.mode = kPWM_EdgeAligned,				  \
 		.prescale = kPWM_Prescale_Divide_128,			  \
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	  \
+		.clock_subsys = (const void *)				  \
+			DT_INST_CLOCKS_CELL(n, name),			  \
 		.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),		  \
 	};								  \
 									  \

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -29,7 +29,7 @@ LOG_MODULE_REGISTER(pwm_mcux_ftm, CONFIG_PWM_LOG_LEVEL);
 struct mcux_ftm_config {
 	FTM_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	ftm_clock_source_t ftm_clock_source;
 	ftm_clock_prescale_t prescale;
 	uint8_t channel_count;
@@ -475,8 +475,7 @@ static void mcux_ftm_config_func_##n(const struct device *dev) \
 static const struct mcux_ftm_config mcux_ftm_config_##n = { \
 	.base = (FTM_Type *)DT_INST_REG_ADDR(n),\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)), \
-	.clock_subsys = (clock_control_subsys_t) \
-		DT_INST_CLOCKS_CELL(n, name), \
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name), \
 	.ftm_clock_source = kFTM_FixedClock, \
 	.prescale = TO_FTM_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),\
 	.channel_count = FSL_FEATURE_FTM_CHANNEL_COUNTn((FTM_Type *) \

--- a/drivers/pwm/pwm_mcux_pwt.c
+++ b/drivers/pwm/pwm_mcux_pwt.c
@@ -24,7 +24,7 @@ LOG_MODULE_REGISTER(pwm_mcux_pwt, CONFIG_PWM_LOG_LEVEL);
 struct mcux_pwt_config {
 	PWT_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	pwt_clock_source_t pwt_clock_source;
 	pwt_clock_prescale_t prescale;
 	void (*irq_config_func)(const struct device *dev);
@@ -328,8 +328,8 @@ static const struct pwm_driver_api mcux_pwt_driver_api = {
 	static const struct mcux_pwt_config mcux_pwt_config_##n = {	\
 		.base = (PWT_Type *)DT_INST_REG_ADDR(n),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys =						\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(n, name),			\
 		.pwt_clock_source = kPWT_BusClock,			\
 		.prescale =						\
 		TO_PWT_PRESCALE_DIVIDE(DT_INST_PROP(n, prescaler)),	\

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -27,7 +27,7 @@ LOG_MODULE_REGISTER(pwm_mcux_tpm, CONFIG_PWM_LOG_LEVEL);
 struct mcux_tpm_config {
 	TPM_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	tpm_clock_source_t tpm_clock_source;
 	tpm_clock_prescale_t prescale;
 	uint8_t channel_count;
@@ -190,8 +190,7 @@ static const struct pwm_driver_api mcux_tpm_driver_api = {
 		.base =	(TPM_Type *) \
 			DT_INST_REG_ADDR(n), \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)), \
-		.clock_subsys = (clock_control_subsys_t) \
-			DT_INST_CLOCKS_CELL(n, name), \
+		.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name), \
 		.tpm_clock_source = kTPM_SystemClock, \
 		.prescale = kTPM_Prescale_Divide_16, \
 		.channel_count = FSL_FEATURE_TPM_CHANNEL_COUNTn((TPM_Type *) \

--- a/drivers/pwm/pwm_npcx.c
+++ b/drivers/pwm/pwm_npcx.c
@@ -189,15 +189,14 @@ static int pwm_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
-							&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on PWM clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
-			&config->clk_cfg, &data->cycles_per_sec);
+	ret = clock_control_get_rate(clk_dev, &config->clk_cfg,
+				     &data->cycles_per_sec);
 	if (ret < 0) {
 		LOG_ERR("Get PWM clock rate error %d", ret);
 		return ret;

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(pwm_rv32m1_tpm, CONFIG_PWM_LOG_LEVEL);
 struct rv32m1_tpm_config {
 	TPM_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	tpm_clock_source_t tpm_clock_source;
 	tpm_clock_prescale_t prescale;
 	uint8_t channel_count;
@@ -205,8 +205,7 @@ static const struct pwm_driver_api rv32m1_tpm_driver_api = {
 		.base =	(TPM_Type *) \
 			DT_INST_REG_ADDR(n), \
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)), \
-		.clock_subsys = (clock_control_subsys_t) \
-			DT_INST_CLOCKS_CELL(n, name), \
+		.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name), \
 		.tpm_clock_source = kTPM_SystemClock, \
 		.prescale = kTPM_Prescale_Divide_16, \
 		.channel_count = FSL_FEATURE_TPM_CHANNEL_COUNTn((TPM_Type *) \

--- a/drivers/pwm/pwm_stm32.c
+++ b/drivers/pwm/pwm_stm32.c
@@ -157,8 +157,7 @@ static int get_tim_clk(const struct stm32_pclken *pclken, uint32_t *tim_clk)
 
 	clk = DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE);
 
-	r = clock_control_get_rate(clk, (clock_control_subsys_t *)pclken,
-				   &bus_clk);
+	r = clock_control_get_rate(clk, pclken, &bus_clk);
 	if (r < 0) {
 		return r;
 	}
@@ -641,7 +640,7 @@ static int pwm_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	r = clock_control_on(clk, (clock_control_subsys_t *)&cfg->pclken);
+	r = clock_control_on(clk, &cfg->pclken);
 	if (r < 0) {
 		LOG_ERR("Could not initialize clock (%d)", r);
 		return r;

--- a/drivers/sdhc/imx_usdhc.c
+++ b/drivers/sdhc/imx_usdhc.c
@@ -54,7 +54,7 @@ struct usdhc_host_transfer {
 struct usdhc_config {
 	USDHC_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	uint8_t nusdhc;
 	const struct gpio_dt_spec pwr_gpio;
 	const struct gpio_dt_spec detect_gpio;
@@ -875,8 +875,7 @@ static const struct sdhc_driver_api usdhc_api = {
 	static const struct usdhc_config usdhc_##n##_config = {			\
 		.base = (USDHC_Type *) DT_INST_REG_ADDR(n),			\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-		.clock_subsys =							\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+		.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name),	\
 		.nusdhc = n,							\
 		.pwr_gpio = GPIO_DT_SPEC_INST_GET_OR(n, pwr_gpios, {0}),	\
 		.detect_gpio = GPIO_DT_SPEC_INST_GET_OR(n, cd_gpios, {0}),	\

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -320,15 +320,14 @@ static int tach_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
-							&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on tachometer clock fail %d", ret);
 		return ret;
 	}
 
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
-					&config->clk_cfg, &data->input_clk);
+	ret = clock_control_get_rate(clk_dev, &config->clk_cfg,
+				     &data->input_clk);
 	if (ret < 0) {
 		LOG_ERR("Get tachometer clock rate error %d", ret);
 		return ret;

--- a/drivers/sensor/pcnt_esp32/pcnt_esp32.c
+++ b/drivers/sensor/pcnt_esp32/pcnt_esp32.c
@@ -69,7 +69,7 @@ struct pcnt_esp32_unit_config {
 struct pcnt_esp32_config {
 	const struct pinctrl_dev_config *pincfg;
 	const struct device *clock_dev;
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	const int irq_src;
 	struct pcnt_esp32_unit_config *unit_config;
 	const int unit_len;
@@ -399,7 +399,7 @@ static struct pcnt_esp32_unit_config unit_config[] = {DT_INST_FOREACH_CHILD(0, U
 static struct pcnt_esp32_config pcnt_esp32_config = {
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(0),
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(0, offset),
 	.irq_src = DT_INST_IRQN(0),
 	.unit_config = unit_config,
 	.unit_len = ARRAY_SIZE(unit_config),

--- a/drivers/serial/serial_esp32_usb.c
+++ b/drivers/serial/serial_esp32_usb.c
@@ -19,7 +19,7 @@
 
 struct serial_esp32_usb_config {
 	const struct device *clock_dev;
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	int irq_source;
 };
 
@@ -236,7 +236,7 @@ static const DRAM_ATTR struct uart_driver_api serial_esp32_usb_api = {
 
 static const DRAM_ATTR struct serial_esp32_usb_config serial_esp32_usb_cfg = {
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(0, offset),
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(0, offset),
 	.irq_source = DT_INST_IRQN(0)
 };
 

--- a/drivers/serial/uart_cmsdk_apb.c
+++ b/drivers/serial/uart_cmsdk_apb.c
@@ -134,9 +134,9 @@ static int uart_cmsdk_apb_init(const struct device *dev)
 	}
 
 #ifdef CONFIG_SOC_SERIES_BEETLE
-	clock_control_on(clk, (clock_control_subsys_t *) &data->uart_cc_as);
-	clock_control_on(clk, (clock_control_subsys_t *) &data->uart_cc_ss);
-	clock_control_on(clk, (clock_control_subsys_t *) &data->uart_cc_dss);
+	clock_control_on(clk, &data->uart_cc_as);
+	clock_control_on(clk, &data->uart_cc_ss);
+	clock_control_on(clk, &data->uart_cc_dss);
 #endif /* CONFIG_SOC_SERIES_BEETLE */
 #endif /* CONFIG_CLOCK_CONTROL */
 

--- a/drivers/serial/uart_esp32.c
+++ b/drivers/serial/uart_esp32.c
@@ -53,7 +53,7 @@ struct uart_esp32_config {
 
 	const struct pinctrl_dev_config *pcfg;
 
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 
 	int irq_source;
 };
@@ -475,7 +475,7 @@ PINCTRL_DT_INST_DEFINE(idx);							\
 static const DRAM_ATTR struct uart_esp32_config uart_esp32_cfg_port_##idx = {	       \
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),		       \
 	.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),				\
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset), \
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(idx, offset),	       \
 	.irq_source = DT_INST_IRQN(idx)			       \
 };									       \
 									       \

--- a/drivers/serial/uart_lpc11u6x.c
+++ b/drivers/serial/uart_lpc11u6x.c
@@ -85,8 +85,7 @@ static void lpc11u6x_uart0_config_baudrate(const struct device *clk_drv,
 	 * LPC11U6X_UART0_CLK so that we can have every baudrate that is
 	 * a multiple of 9600
 	 */
-	clock_control_get_rate(clk_drv, (clock_control_subsys_t) cfg->clkid,
-			       &pclk);
+	clock_control_get_rate(clk_drv, &cfg->clkid, &pclk);
 	mul = pclk / (pclk % LPC11U6X_UART0_CLK);
 
 	dl = pclk / (16 * baudrate + 16 * baudrate / mul);
@@ -351,7 +350,7 @@ static int lpc11u6x_uart0_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	clock_control_on(cfg->clock_dev, (clock_control_subsys_t) cfg->clkid);
+	clock_control_on(cfg->clock_dev, &cfg->clkid);
 
 	/* Configure baudrate, parity and stop bits */
 	lpc11u6x_uart0_config_baudrate(cfg->clock_dev, cfg, cfg->baudrate);
@@ -489,8 +488,7 @@ static void lpc11u6x_uartx_config_baud(const struct lpc11u6x_uartx_config *cfg,
 	uint32_t div;
 	const struct device *clk_drv = cfg->clock_dev;
 
-	clock_control_get_rate(clk_drv, (clock_control_subsys_t) cfg->clkid,
-			       &clk_rate);
+	clock_control_get_rate(clk_drv, &cfg->clkid, &clk_rate);
 
 	div = clk_rate / (16 * baudrate);
 	if (div != 0) {
@@ -773,7 +771,7 @@ static int lpc11u6x_uartx_init(const struct device *dev)
 		return err;
 	}
 
-	clock_control_on(cfg->clock_dev, (clock_control_subsys_t) cfg->clkid);
+	clock_control_on(cfg->clock_dev, &cfg->clkid);
 
 	/* Configure baudrate, parity and stop bits */
 	lpc11u6x_uartx_config_baud(cfg, cfg->baudrate);

--- a/drivers/serial/uart_mcux.c
+++ b/drivers/serial/uart_mcux.c
@@ -20,7 +20,7 @@
 struct uart_mcux_config {
 	UART_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
 #endif
@@ -387,7 +387,7 @@ static const struct uart_driver_api uart_mcux_driver_api = {
 static const struct uart_mcux_config uart_mcux_##n##_config = {		\
 	.base = (UART_Type *)DT_INST_REG_ADDR(n),			\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name),	\
 	PINCTRL_INIT(n)							\
 	IRQ_FUNC_INIT							\
 }

--- a/drivers/serial/uart_mcux_flexcomm.c
+++ b/drivers/serial/uart_mcux_flexcomm.c
@@ -28,7 +28,7 @@
 struct mcux_flexcomm_config {
 	USART_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	uint32_t baud_rate;
 	uint8_t parity;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -356,8 +356,7 @@ static const struct uart_driver_api mcux_flexcomm_driver_api = {
 static const struct mcux_flexcomm_config mcux_flexcomm_##n##_config = {	\
 	.base = (USART_Type *)DT_INST_REG_ADDR(n),			\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-	.clock_subsys =				\
-	(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name),	\
 	.baud_rate = DT_INST_PROP(n, current_speed),			\
 	.parity = DT_INST_ENUM_IDX_OR(n, parity, UART_CFG_PARITY_NONE), \
 	UART_MCUX_FLEXCOMM_PINCTRL_INIT(n)				\

--- a/drivers/serial/uart_mcux_iuart.c
+++ b/drivers/serial/uart_mcux_iuart.c
@@ -17,7 +17,7 @@
 struct mcux_iuart_config {
 	UART_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	uint32_t baud_rate;
 	const struct pinctrl_dev_config *pincfg;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
@@ -309,7 +309,7 @@ static const struct uart_driver_api mcux_iuart_driver_api = {
 static const struct mcux_iuart_config mcux_iuart_##n##_config = {	\
 	.base = (UART_Type *) DT_INST_REG_ADDR(n),			\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name),	\
 	.baud_rate = DT_INST_PROP(n, current_speed),			\
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	IRQ_FUNC_INIT							\

--- a/drivers/serial/uart_mcux_lpsci.c
+++ b/drivers/serial/uart_mcux_lpsci.c
@@ -17,7 +17,7 @@
 struct mcux_lpsci_config {
 	UART0_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	uint32_t baud_rate;
 #ifdef CONFIG_UART_INTERRUPT_DRIVEN
 	void (*irq_config_func)(const struct device *dev);
@@ -316,7 +316,7 @@ static const struct uart_driver_api mcux_lpsci_driver_api = {
 static const struct mcux_lpsci_config mcux_lpsci_##n##_config = {	\
 	.base = (UART0_Type *)DT_INST_REG_ADDR(n),			\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),		\
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name),	\
 	.baud_rate = DT_INST_PROP(n, current_speed),			\
 	.pincfg = PINCTRL_DT_INST_DEV_CONFIG_GET(n),			\
 	IRQ_FUNC_INIT							\

--- a/drivers/serial/uart_mcux_lpuart.c
+++ b/drivers/serial/uart_mcux_lpuart.c
@@ -39,7 +39,7 @@ struct mcux_lpuart_config {
 #ifdef CONFIG_PINCTRL
 	const struct pinctrl_dev_config *pincfg;
 #endif
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	uint32_t baud_rate;
 	uint8_t flow_ctrl;
 	bool loopback_en;
@@ -1177,7 +1177,7 @@ static const struct uart_driver_api mcux_lpuart_driver_api = {
 static const struct mcux_lpuart_config mcux_lpuart_##n##_config = {		\
 	.base = (LPUART_Type *) DT_INST_REG_ADDR(n),				\
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),			\
-	.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(n, name),		\
 	.baud_rate = DT_INST_PROP(n, current_speed),				\
 	.flow_ctrl = DT_INST_PROP(n, hw_flow_control) ?				\
 		UART_CFG_FLOW_CTRL_RTS_CTS : UART_CFG_FLOW_CTRL_NONE,		\

--- a/drivers/serial/uart_npcx.c
+++ b/drivers/serial/uart_npcx.c
@@ -440,7 +440,7 @@ static int uart_npcx_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev, (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on UART clock fail %d", ret);
 		return ret;
@@ -450,7 +450,7 @@ static int uart_npcx_init(const struct device *dev)
 	 * If apb2's clock is not 15MHz, we need to find the other optimized
 	 * values of UPSR and UBAUD for baud rate 115200.
 	 */
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)&config->clk_cfg,
+	ret = clock_control_get_rate(clk_dev, &config->clk_cfg,
 				     &uart_rate);
 	if (ret < 0) {
 		LOG_ERR("Get UART clock rate error %d", ret);

--- a/drivers/serial/uart_ns16550.c
+++ b/drivers/serial/uart_ns16550.c
@@ -227,7 +227,7 @@ struct uart_ns16550_device_config {
 #endif
 	uint32_t sys_clk_freq;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 #if defined(CONFIG_UART_INTERRUPT_DRIVEN) || defined(CONFIG_UART_ASYNC_API)
 	uart_irq_config_func_t	irq_config_func;
 #endif
@@ -1137,8 +1137,8 @@ static const struct uart_driver_api uart_ns16550_driver_api = {
 			), (                                                         \
 				.sys_clk_freq = 0,                                   \
 				.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),  \
-				.clock_subsys = (clock_control_subsys_t) DT_INST_PHA(\
-								0, clocks, clkid),   \
+				.clock_subsys = (const void *)                       \
+					DT_INST_PHA(0, clocks, clkid),               \
 			)                                                            \
 		)                                                                    \
 		DEV_CONFIG_IRQ_FUNC_INIT(n)                                          \

--- a/drivers/serial/uart_rcar.c
+++ b/drivers/serial/uart_rcar.c
@@ -277,14 +277,12 @@ static int uart_rcar_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(config->clock_dev,
-			       (clock_control_subsys_t *)&config->mod_clk);
+	ret = clock_control_on(config->clock_dev, &config->mod_clk);
 	if (ret < 0) {
 		return ret;
 	}
 
-	ret = clock_control_get_rate(config->clock_dev,
-				     (clock_control_subsys_t *)&config->bus_clk,
+	ret = clock_control_get_rate(config->clock_dev, &config->bus_clk,
 				     &data->clk_rate);
 	if (ret < 0) {
 		return ret;

--- a/drivers/serial/uart_rv32m1_lpuart.c
+++ b/drivers/serial/uart_rv32m1_lpuart.c
@@ -20,7 +20,7 @@
 struct rv32m1_lpuart_config {
 	LPUART_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	clock_ip_name_t clock_ip_name;
 	uint32_t clock_ip_src;
 	uint32_t baud_rate;
@@ -322,8 +322,8 @@ static const struct uart_driver_api rv32m1_lpuart_driver_api = {
 	static const struct rv32m1_lpuart_config rv32m1_lpuart_##n##_cfg = {\
 		.base = (LPUART_Type *)DT_INST_REG_ADDR(n),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys =						\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(n, name),			\
 		.clock_ip_name = INST_DT_CLOCK_IP_NAME(n),		\
 		.clock_ip_src = kCLOCK_IpSrcFircAsync,			\
 		.baud_rate = DT_INST_PROP(n, current_speed),		\

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -109,15 +109,13 @@ static inline void uart_stm32_set_baudrate(const struct device *dev, uint32_t ba
 
 	/* Get clock rate */
 	if (IS_ENABLED(STM32_UART_DOMAIN_CLOCK_SUPPORT) && (config->pclk_len > 1)) {
-		if (clock_control_get_rate(data->clock,
-					   (clock_control_subsys_t)&config->pclken[1],
+		if (clock_control_get_rate(data->clock, &config->pclken[1],
 					   &clock_rate) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclken[1])");
 			return;
 		}
 	} else {
-		if (clock_control_get_rate(data->clock,
-					   (clock_control_subsys_t)&config->pclken[0],
+		if (clock_control_get_rate(data->clock, &config->pclken[0],
 					   &clock_rate) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclken[0])");
 			return;
@@ -1571,7 +1569,7 @@ static int uart_stm32_init(const struct device *dev)
 	}
 
 	/* enable clock */
-	err = clock_control_on(data->clock, (clock_control_subsys_t)&config->pclken[0]);
+	err = clock_control_on(data->clock, &config->pclken[0]);
 	if (err != 0) {
 		LOG_ERR("Could not enable (LP)UART clock");
 		return err;
@@ -1579,7 +1577,7 @@ static int uart_stm32_init(const struct device *dev)
 
 	if (IS_ENABLED(STM32_UART_DOMAIN_CLOCK_SUPPORT) && (config->pclk_len > 1)) {
 		err = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					      (clock_control_subsys_t) &config->pclken[1],
+					       &config->pclken[1],
 					      NULL);
 		if (err != 0) {
 			LOG_ERR("Could not select UART domain clock");
@@ -1732,7 +1730,7 @@ static int uart_stm32_pm_action(const struct device *dev,
 		}
 
 		/* enable clock */
-		err = clock_control_on(data->clock, (clock_control_subsys_t)&config->pclken[0]);
+		err = clock_control_on(data->clock, &config->pclken[0]);
 		if (err != 0) {
 			LOG_ERR("Could not enable (LP)UART clock");
 			return err;
@@ -1741,7 +1739,7 @@ static int uart_stm32_pm_action(const struct device *dev,
 	case PM_DEVICE_ACTION_SUSPEND:
 		uart_stm32_suspend_setup(dev);
 		/* Stop device clock. Note: fixed clocks are not handled yet. */
-		err = clock_control_off(data->clock, (clock_control_subsys_t)&config->pclken[0]);
+		err = clock_control_off(data->clock, &config->pclken[0]);
 		if (err != 0) {
 			LOG_ERR("Could not enable (LP)UART clock");
 			return err;

--- a/drivers/spi/spi_esp32_spim.c
+++ b/drivers/spi/spi_esp32_spim.c
@@ -368,8 +368,8 @@ static const struct spi_driver_api spi_api = {
 		.input_delay_ns = 0, \
 		.irq_source = DT_INST_IRQN(idx), \
 		.pcfg = PINCTRL_DT_INST_DEV_CONFIG_GET(idx),	\
-		.clock_subsys =	\
-			(clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset),	\
+		.clock_subsys = (const void *)			\
+			DT_INST_CLOCKS_CELL(idx, offset),	\
 		.use_iomux = DT_INST_PROP(idx, use_iomux),	\
 	};	\
 		\

--- a/drivers/spi/spi_esp32_spim.h
+++ b/drivers/spi/spi_esp32_spim.h
@@ -27,7 +27,7 @@ struct spi_esp32_config {
 	int input_delay_ns;
 	int irq_source;
 	const struct pinctrl_dev_config *pcfg;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	bool use_iomux;
 };
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -487,13 +487,13 @@ static int spi_stm32_configure(const struct device *dev,
 
 	if (IS_ENABLED(STM32_SPI_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {
 		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					   (clock_control_subsys_t) &cfg->pclken[1], &clock) < 0) {
+					   &cfg->pclken[1], &clock) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclk[1])");
 			return -EIO;
 		}
 	} else {
 		if (clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					   (clock_control_subsys_t) &cfg->pclken[0], &clock) < 0) {
+					   &cfg->pclken[0], &clock) < 0) {
 			LOG_ERR("Failed call clock_control_get_rate(pclk[0])");
 			return -EIO;
 		}
@@ -868,7 +868,7 @@ static int spi_stm32_init(const struct device *dev)
 	}
 
 	err = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-			       (clock_control_subsys_t) &cfg->pclken[0]);
+			       &cfg->pclken[0]);
 	if (err < 0) {
 		LOG_ERR("Could not enable SPI clock");
 		return err;
@@ -876,7 +876,7 @@ static int spi_stm32_init(const struct device *dev)
 
 	if (IS_ENABLED(STM32_SPI_DOMAIN_CLOCK_SUPPORT) && (cfg->pclk_len > 1)) {
 		err = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					      (clock_control_subsys_t) &cfg->pclken[1],
+					       &cfg->pclken[1],
 					      NULL);
 		if (err < 0) {
 			LOG_ERR("Could not select SPI domain clock");

--- a/drivers/spi/spi_mcux_dspi.c
+++ b/drivers/spi/spi_mcux_dspi.c
@@ -37,7 +37,7 @@ struct spi_edma_config {
 struct spi_mcux_config {
 	SPI_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t pcs_sck_delay;
 	uint32_t sck_pcs_delay;
@@ -886,8 +886,8 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	static const struct spi_mcux_config spi_mcux_config_##id = {	\
 		.base = (SPI_Type *)DT_INST_REG_ADDR(id),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
-		.clock_subsys = 					\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),	\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(id, name),			\
 		.irq_config_func = spi_mcux_config_func_##id,		\
 		.pcs_sck_delay =					\
 		    DT_INST_PROP_OR(id, pcs_sck_delay, 0),		\

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(spi_mcux_flexcomm, CONFIG_SPI_LOG_LEVEL);
 struct spi_mcux_config {
 	SPI_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t pre_delay;
 	uint32_t post_delay;
@@ -827,8 +827,8 @@ static void spi_mcux_config_func_##id(const struct device *dev) \
 		.base =							\
 		(SPI_Type *)DT_INST_REG_ADDR(id),			\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(id)),	\
-		.clock_subsys =					\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(id, name),\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(id, name),			\
 		SPI_MCUX_FLEXCOMM_IRQ_HANDLER_FUNC(id)			\
 		.pre_delay = DT_INST_PROP_OR(id, pre_delay, 0),		\
 		.post_delay = DT_INST_PROP_OR(id, post_delay, 0),		\

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(spi_mcux_lpspi, CONFIG_SPI_LOG_LEVEL);
 struct spi_mcux_config {
 	LPSPI_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 	uint32_t pcs_sck_delay;
 	uint32_t sck_pcs_delay;
@@ -623,8 +623,8 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	static const struct spi_mcux_config spi_mcux_config_##n = {	\
 		.base = (LPSPI_Type *) DT_INST_REG_ADDR(n),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys =						\
-		(clock_control_subsys_t)DT_INST_CLOCKS_CELL(n, name),	\
+		.clock_subsys = (const void *)				\
+			DT_INST_CLOCKS_CELL(n, name),			\
 		.irq_config_func = spi_mcux_config_func_##n,		\
 		.pcs_sck_delay = UTIL_AND(				\
 			DT_INST_NODE_HAS_PROP(n, pcs_sck_delay),	\

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -151,8 +151,7 @@ static int spi_npcx_fiu_init(const struct device *dev)
 	}
 
 	/* Turn on device clock first and get source clock freq. */
-	ret = clock_control_on(clk_dev,
-			       (clock_control_subsys_t *)&config->clk_cfg);
+	ret = clock_control_on(clk_dev, &config->clk_cfg);
 	if (ret < 0) {
 		LOG_ERR("Turn on FIU clock fail %d", ret);
 		return ret;

--- a/drivers/spi/spi_rv32m1_lpspi.c
+++ b/drivers/spi/spi_rv32m1_lpspi.c
@@ -28,7 +28,7 @@ LOG_MODULE_REGISTER(spi_rv32m1_lpspi);
 struct spi_mcux_config {
 	LPSPI_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	clock_ip_name_t clock_ip_name;
 	uint32_t clock_ip_src;
 	void (*irq_config_func)(const struct device *dev);
@@ -321,7 +321,7 @@ static const struct spi_driver_api spi_mcux_driver_api = {
 	static const struct spi_mcux_config spi_mcux_config_##n = {	\
 		.base = (LPSPI_Type *) DT_INST_REG_ADDR(n),		\
 		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(n)),	\
-		.clock_subsys = (clock_control_subsys_t)		\
+		.clock_subsys = (const void *)				\
 			DT_INST_CLOCKS_CELL(n, name),			\
 		.irq_config_func = spi_mcux_config_func_##n,		\
 		.clock_ip_name = INST_DT_CLOCK_IP_NAME(n),		\

--- a/drivers/timer/npcx_itim_timer.c
+++ b/drivers/timer/npcx_itim_timer.c
@@ -315,8 +315,7 @@ static int sys_clock_driver_init(const struct device *dev)
 
 	/* Turn on all itim module clocks used for counting */
 	for (int i = 0; i < ARRAY_SIZE(itim_clk_cfg); i++) {
-		ret = clock_control_on(clk_dev, (clock_control_subsys_t *)
-				&itim_clk_cfg[i]);
+		ret = clock_control_on(clk_dev, &itim_clk_cfg[i]);
 		if (ret < 0) {
 			LOG_ERR("Turn on timer %d clock failed.", i);
 			return ret;
@@ -327,8 +326,7 @@ static int sys_clock_driver_init(const struct device *dev)
 	 * In npcx series, we use ITIM64 as system kernel timer. Its source
 	 * clock frequency must equal to CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC.
 	 */
-	ret = clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
-			&itim_clk_cfg[1], &sys_tmr_rate);
+	ret = clock_control_get_rate(clk_dev, &itim_clk_cfg[1], &sys_tmr_rate);
 	if (ret < 0) {
 		LOG_ERR("Get ITIM64 clock rate failed %d", ret);
 		return ret;

--- a/drivers/timer/rcar_cmt_timer.c
+++ b/drivers/timer/rcar_cmt_timer.c
@@ -99,7 +99,7 @@ static int sys_clock_driver_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *)&mod_clk);
+	ret = clock_control_on(clk, &mod_clk);
 	if (ret < 0) {
 		return ret;
 	}

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -165,12 +165,12 @@ void sys_clock_set_timeout(int32_t ticks, bool idle)
 	}
 
 	if (ticks == K_TICKS_FOREVER) {
-		clock_control_off(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[0]);
+		clock_control_off(clk_ctrl, &lptim_clk[0]);
 		return;
 	}
 
 	/* if LPTIM clock was previously stopped, it must now be restored */
-	clock_control_on(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[0]);
+	clock_control_on(clk_ctrl, &lptim_clk[0]);
 
 	/* passing ticks==1 means "announce the next tick",
 	 * ticks value of zero (or even negative) is legal and
@@ -289,7 +289,7 @@ static int sys_clock_driver_init(const struct device *dev)
 	}
 
 	/* Enable LPTIM bus clock */
-	clock_control_on(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[0]);
+	clock_control_on(clk_ctrl, &lptim_clk[0]);
 
 #if defined(LL_APB1_GRP1_PERIPH_LPTIM1)
 	LL_APB1_GRP1_ReleaseReset(LL_APB1_GRP1_PERIPH_LPTIM1);
@@ -298,12 +298,10 @@ static int sys_clock_driver_init(const struct device *dev)
 #endif
 
 	/* Enable LPTIM clock source */
-	clock_control_configure(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[1],
-				NULL);
+	clock_control_configure(clk_ctrl, &lptim_clk[1], NULL);
 
 	/* Get LPTIM clock freq */
-	clock_control_get_rate(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[1],
-			       &lptim_clock_freq);
+	clock_control_get_rate(clk_ctrl, &lptim_clk[1], &lptim_clock_freq);
 
 	/* Set LPTIM time base based on clck source freq
 	 * Time base = (2s * freq) - 1

--- a/drivers/usb/device/usb_dc_stm32.c
+++ b/drivers/usb/device/usb_dc_stm32.c
@@ -321,7 +321,7 @@ static int usb_dc_stm32_clock_enable(void)
 		return -ENODEV;
 	}
 
-	if (clock_control_on(clk, (clock_control_subsys_t *)&pclken) != 0) {
+	if (clock_control_on(clk, &pclken) != 0) {
 		LOG_ERR("Unable to enable USB clock");
 		return -EIO;
 	}

--- a/drivers/watchdog/wdt_esp32.c
+++ b/drivers/watchdog/wdt_esp32.c
@@ -44,7 +44,7 @@ struct wdt_esp32_data {
 struct wdt_esp32_config {
 	wdt_inst_t wdt_inst;
 	const struct device *clock_dev;
-	const clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*connect_irq)(void);
 	int irq_source;
 };
@@ -187,8 +187,8 @@ static const struct wdt_driver_api wdt_api = {
 	static struct wdt_esp32_config wdt_esp32_config##idx = {		   \
 		.wdt_inst = WDT_MWDT##idx,	\
 		.irq_source = DT_IRQN(DT_NODELABEL(wdt##idx)),			   \
-		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)), \
-		.clock_subsys = (clock_control_subsys_t)DT_INST_CLOCKS_CELL(idx, offset), \
+		.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(idx)),		   \
+		.clock_subsys = DT_INST_CLOCKS_CELL(idx, offset),		   \
 	};									   \
 										   \
 	DEVICE_DT_INST_DEFINE(idx,						   \

--- a/drivers/watchdog/wdt_mcux_wdog.c
+++ b/drivers/watchdog/wdt_mcux_wdog.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(wdt_mcux_wdog);
 struct mcux_wdog_config {
 	WDOG_Type *base;
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 	void (*irq_config_func)(const struct device *dev);
 };
 
@@ -167,8 +167,7 @@ static void mcux_wdog_config_func_0(const struct device *dev);
 static const struct mcux_wdog_config mcux_wdog_config_0 = {
 	.base = (WDOG_Type *) DT_INST_REG_ADDR(0),
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = (clock_control_subsys_t)
-		DT_INST_CLOCKS_CELL(0, name),
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(0, name),
 	.irq_config_func = mcux_wdog_config_func_0,
 };
 

--- a/drivers/watchdog/wdt_mcux_wdog32.c
+++ b/drivers/watchdog/wdt_mcux_wdog32.c
@@ -25,7 +25,7 @@ struct mcux_wdog32_config {
 	uint32_t clock_frequency;
 #else /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
 	const struct device *clock_dev;
-	clock_control_subsys_t clock_subsys;
+	const void *clock_subsys;
 #endif /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
 	wdog32_clock_source_t clk_source;
 	wdog32_clock_prescaler_t clk_divider;
@@ -195,8 +195,7 @@ static const struct mcux_wdog32_config mcux_wdog32_config_0 = {
 	.clock_frequency = DT_INST_PROP_BY_PHANDLE(0, clocks, clock_frequency),
 #else /* !DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
 	.clock_dev = DEVICE_DT_GET(DT_INST_CLOCKS_CTLR(0)),
-	.clock_subsys = (clock_control_subsys_t)
-		DT_INST_CLOCKS_CELL(0, name),
+	.clock_subsys = (const void *)DT_INST_CLOCKS_CELL(0, name),
 #endif /* DT_NODE_HAS_PROP(DT_INST_PHANDLE(0, clocks), clock_frequency) */
 	.clk_source =
 		TO_WDOG32_CLK_SRC(DT_INST_PROP(0, clk_source)),

--- a/drivers/watchdog/wdt_wwdg_stm32.c
+++ b/drivers/watchdog/wdt_wwdg_stm32.c
@@ -91,8 +91,7 @@ static uint32_t wwdg_stm32_get_pclk(const struct device *dev)
 	const struct wwdg_stm32_config *cfg = WWDG_STM32_CFG(dev);
 	uint32_t pclk_rate;
 
-	if (clock_control_get_rate(clk, (clock_control_subsys_t *) &cfg->pclken,
-			       &pclk_rate) < 0) {
+	if (clock_control_get_rate(clk, &cfg->pclken, &pclk_rate) < 0) {
 		LOG_ERR("Failed call clock_control_get_rate");
 		return -EIO;
 	}
@@ -287,7 +286,7 @@ static int wwdg_stm32_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	return clock_control_on(clk, (clock_control_subsys_t *) &cfg->pclken);
+	return clock_control_on(clk, &cfg->pclken);
 }
 
 static struct wwdg_stm32_data wwdg_stm32_dev_data = {

--- a/include/zephyr/drivers/clock_control.h
+++ b/include/zephyr/drivers/clock_control.h
@@ -47,13 +47,6 @@ enum clock_control_status {
 };
 
 /**
- * clock_control_subsys_t is a type to identify a clock controller sub-system.
- * Such data pointed is opaque and relevant only to the clock controller
- * driver instance being used.
- */
-typedef void *clock_control_subsys_t;
-
-/**
  * clock_control_subsys_rate_t is a type to identify a clock
  * controller sub-system rate.  Such data pointed is opaque and
  * relevant only to set the clock controller rate of the driver
@@ -68,31 +61,31 @@ typedef void *clock_control_subsys_rate_t;
  * @param user_data	User data.
  */
 typedef void (*clock_control_cb_t)(const struct device *dev,
-				   clock_control_subsys_t subsys,
+				   const void *subsys,
 				   void *user_data);
 
 typedef int (*clock_control)(const struct device *dev,
-			     clock_control_subsys_t sys);
+			     const void *sys);
 
 typedef int (*clock_control_get)(const struct device *dev,
-				 clock_control_subsys_t sys,
+				 const void *sys,
 				 uint32_t *rate);
 
 typedef int (*clock_control_async_on_fn)(const struct device *dev,
-					 clock_control_subsys_t sys,
+					 const void *sys,
 					 clock_control_cb_t cb,
 					 void *user_data);
 
 typedef enum clock_control_status (*clock_control_get_status_fn)(
 						    const struct device *dev,
-						    clock_control_subsys_t sys);
+						    const void *sys);
 
 typedef int (*clock_control_set)(const struct device *dev,
-				 clock_control_subsys_t sys,
+				 const void *sys,
 				 clock_control_subsys_rate_t rate);
 
 typedef int (*clock_control_configure_fn)(const struct device *dev,
-					  clock_control_subsys_t sys,
+					  const void *sys,
 					  void *data);
 
 struct clock_control_driver_api {
@@ -119,7 +112,7 @@ struct clock_control_driver_api {
  * @return 0 on success, negative errno on failure.
  */
 static inline int clock_control_on(const struct device *dev,
-				   clock_control_subsys_t sys)
+				   const void *sys)
 {
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
@@ -138,7 +131,7 @@ static inline int clock_control_on(const struct device *dev,
  * @return 0 on success, negative errno on failure.
  */
 static inline int clock_control_off(const struct device *dev,
-				    clock_control_subsys_t sys)
+				    const void *sys)
 {
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
@@ -164,7 +157,7 @@ static inline int clock_control_off(const struct device *dev,
  * @retval other negative errno on vendor specific error.
  */
 static inline int clock_control_async_on(const struct device *dev,
-					 clock_control_subsys_t sys,
+					 const void *sys,
 					 clock_control_cb_t cb,
 					 void *user_data)
 {
@@ -187,7 +180,7 @@ static inline int clock_control_async_on(const struct device *dev,
  * @return Status.
  */
 static inline enum clock_control_status clock_control_get_status(const struct device *dev,
-								 clock_control_subsys_t sys)
+								 const void *sys)
 {
 	const struct clock_control_driver_api *api =
 		(const struct clock_control_driver_api *)dev->api;
@@ -212,7 +205,7 @@ static inline enum clock_control_status clock_control_get_status(const struct de
  * @retval -ENOSYS if the interface is not implemented.
  */
 static inline int clock_control_get_rate(const struct device *dev,
-					 clock_control_subsys_t sys,
+					 const void *sys,
 					 uint32_t *rate)
 {
 	const struct clock_control_driver_api *api =
@@ -242,7 +235,7 @@ static inline int clock_control_get_rate(const struct device *dev,
  * @retval other negative errno on vendor specific error.
  */
 static inline int clock_control_set_rate(const struct device *dev,
-		clock_control_subsys_t sys,
+		const void *sys,
 		clock_control_subsys_rate_t rate)
 {
 	const struct clock_control_driver_api *api =
@@ -278,7 +271,7 @@ static inline int clock_control_set_rate(const struct device *dev,
  * @retval -errno Other negative errno on failure.
  */
 static inline int clock_control_configure(const struct device *dev,
-					  clock_control_subsys_t sys,
+					  const void *sys,
 					  void *data)
 {
 	const struct clock_control_driver_api *api =

--- a/include/zephyr/drivers/clock_control/nrf_clock_control.h
+++ b/include/zephyr/drivers/clock_control/nrf_clock_control.h
@@ -36,13 +36,13 @@ enum clock_control_nrf_type {
  * increase code readability.
  */
 #define CLOCK_CONTROL_NRF_SUBSYS_HF \
-	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK)
+	((void *)CLOCK_CONTROL_NRF_TYPE_HFCLK)
 #define CLOCK_CONTROL_NRF_SUBSYS_LF \
-	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_LFCLK)
+	((void *)CLOCK_CONTROL_NRF_TYPE_LFCLK)
 #define CLOCK_CONTROL_NRF_SUBSYS_HF192M \
-	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLK192M)
+	((void *)CLOCK_CONTROL_NRF_TYPE_HFCLK192M)
 #define CLOCK_CONTROL_NRF_SUBSYS_HFAUDIO \
-	((clock_control_subsys_t)CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO)
+	((void *)CLOCK_CONTROL_NRF_TYPE_HFCLKAUDIO)
 
 /** @brief LF clock start modes. */
 enum nrf_lfclk_start_mode {
@@ -119,7 +119,7 @@ int z_nrf_clock_calibration_skips_count(void);
  *
  * @return Service handler or NULL.
  */
-struct onoff_manager *z_nrf_clock_control_get_onoff(clock_control_subsys_t sys);
+struct onoff_manager *z_nrf_clock_control_get_onoff(const void *sys);
 
 /** @brief Permanently enable low frequency clock.
  *

--- a/samples/drivers/clock_control_litex/README.rst
+++ b/samples/drivers/clock_control_litex/README.rst
@@ -43,7 +43,6 @@ The driver is interfaced with the :ref:`Clock Control API <clock_control_api>` f
 .. doxygenstruct:: litex_clk_setup
    :project: Zephyr
 
-| To change clock parameter it is needed to cast a pointer to structure ``litex_clk_setup`` onto ``clock_control_subsys_t`` and use it with ``clock_control_on()``.
 | This code will try to set on ``clk0`` frequency 50MHz, 90 degrees of phase offset and 75% duty cycle.
 
 .. code-block:: c
@@ -57,8 +56,7 @@ The driver is interfaced with the :ref:`Clock Control API <clock_control_api>` f
 		.phase = 90
 	};
 	dev = DEVICE_DT_GET(MMCM);
-	clock_control_subsys_t sub_system = (clock_control_subsys_t*)&setup;
-	if ((ret = clock_control_on(dev, sub_system)) != 0) {
+	if ((ret = clock_control_on(dev, &setup)) != 0) {
 		LOG_ERR("Set CLKOUT%d param error!", setup.clkout_nr);
 		return ret;
 	}

--- a/samples/drivers/clock_control_litex/src/main.c
+++ b/samples/drivers/clock_control_litex/src/main.c
@@ -66,15 +66,13 @@ int litex_clk_test_getters(const struct device *dev)
 	uint32_t rate;
 	int i;
 
-	clock_control_subsys_t sub_system = (clock_control_subsys_t *)&setup;
-
 	printf("Getters test\n");
 	for (i = 0; i < NCLKOUT; i++) {
 		setup.clkout_nr = i;
-		clock_control_get_status(dev, sub_system);
+		clock_control_get_status(dev, &setup);
 		printf("CLKOUT%d: get_status: rate:%d phase:%d duty:%d\n",
 			i, setup.rate, setup.phase, setup.duty);
-		clock_control_get_rate(dev, sub_system, &rate);
+		clock_control_get_rate(dev, &setup, &rate);
 		printf("CLKOUT%d: get_rate:%d\n", i, rate);
 	}
 
@@ -96,15 +94,13 @@ int litex_clk_test_single(const struct device *dev)
 		.phase = LITEX_TEST_SINGLE_PHASE_VAL2,
 	};
 	uint32_t ret = 0;
-	clock_control_subsys_t sub_system1 = (clock_control_subsys_t *)&setup1;
-	clock_control_subsys_t sub_system2 = (clock_control_subsys_t *)&setup2;
 
 	printf("Single test\n");
-	ret = clock_control_on(dev, sub_system1);
+	ret = clock_control_on(dev, &setup1);
 	if (ret != 0) {
 		return ret;
 	}
-	ret = clock_control_on(dev, sub_system2);
+	ret = clock_control_on(dev, &setup2);
 	if (ret != 0) {
 		return ret;
 	}
@@ -121,7 +117,6 @@ int litex_clk_test_freq(const struct device *dev)
 		.duty = LITEX_TEST_FREQUENCY_DUTY_VAL,
 		.phase = LITEX_TEST_FREQUENCY_PHASE_VAL
 	};
-	clock_control_subsys_t sub_system = (clock_control_subsys_t *)&setup;
 	uint32_t i, ret = 0;
 
 	printf("Frequency test\n");
@@ -131,7 +126,6 @@ int litex_clk_test_freq(const struct device *dev)
 				i += LITEX_TEST_FREQUENCY_STEP) {
 			setup.clkout_nr = LITEX_CLK_TEST_CLK1;
 			setup.rate = i;
-			sub_system = (clock_control_subsys_t *)&setup;
 			/*
 			 * Don't check for ENOTSUP here because it is expected.
 			 * The reason is that set of possible frequencies for
@@ -144,12 +138,12 @@ int litex_clk_test_freq(const struct device *dev)
 			 * test will be finished
 			 *
 			 */
-			ret = clock_control_on(dev, sub_system);
+			ret = clock_control_on(dev, &setup);
 			if (ret != 0 && ret != -ENOTSUP) {
 				return ret;
 			}
 			setup.clkout_nr = LITEX_CLK_TEST_CLK2;
-			ret = clock_control_on(dev, sub_system);
+			ret = clock_control_on(dev, &setup);
 			if (ret != 0) {
 				return ret;
 			}
@@ -159,13 +153,12 @@ int litex_clk_test_freq(const struct device *dev)
 				i -= LITEX_TEST_FREQUENCY_STEP) {
 			setup.clkout_nr = LITEX_CLK_TEST_CLK1;
 			setup.rate = i;
-			sub_system = (clock_control_subsys_t *)&setup;
-			ret = clock_control_on(dev, sub_system);
+			ret = clock_control_on(dev, &setup);
 			if (ret != 0 && ret != -ENOTSUP) {
 				return ret;
 			}
 			setup.clkout_nr = LITEX_CLK_TEST_CLK2;
-			ret = clock_control_on(dev, sub_system);
+			ret = clock_control_on(dev, &setup);
 			if (ret != 0) {
 				return ret;
 			}
@@ -189,14 +182,12 @@ int litex_clk_test_phase(const struct device *dev)
 		.rate = LITEX_TEST_PHASE_FREQ_VAL,
 		.duty = LITEX_TEST_PHASE_DUTY_VAL
 	};
-	clock_control_subsys_t sub_system1 = (clock_control_subsys_t *)&setup1;
-	clock_control_subsys_t sub_system2 = (clock_control_subsys_t *)&setup2;
 	uint32_t ret = 0;
 	int i;
 
 	printf("Phase test\n");
 
-	ret = clock_control_on(dev, sub_system1);
+	ret = clock_control_on(dev, &setup1);
 	if (ret != 0 && ret != -ENOTSUP) {
 		return ret;
 	}
@@ -205,8 +196,7 @@ int litex_clk_test_phase(const struct device *dev)
 		for (i = LITEX_TEST_PHASE_MIN; i <= LITEX_TEST_PHASE_MAX;
 				i += LITEX_TEST_PHASE_STEP) {
 			setup2.phase = i;
-			sub_system2 = (clock_control_subsys_t *)&setup2;
-			ret = clock_control_on(dev, sub_system2);
+			ret = clock_control_on(dev, &setup2);
 			if (ret != 0) {
 				return ret;
 			}
@@ -232,14 +222,12 @@ int litex_clk_test_duty(const struct device *dev)
 		.duty = 0
 	};
 	uint32_t ret = 0, i;
-	clock_control_subsys_t sub_system1 = (clock_control_subsys_t *)&setup1;
-	clock_control_subsys_t sub_system2 = (clock_control_subsys_t *)&setup2;
 
-	ret = clock_control_on(dev, sub_system1);
+	ret = clock_control_on(dev, &setup1);
 	if (ret != 0 && ret != -ENOTSUP) {
 		return ret;
 	}
-	ret = clock_control_on(dev, sub_system2);
+	ret = clock_control_on(dev, &setup2);
 	if (ret != 0 && ret != -ENOTSUP) {
 		return ret;
 	}
@@ -250,14 +238,12 @@ int litex_clk_test_duty(const struct device *dev)
 		for (i = LITEX_TEST_DUTY_MIN; i <= LITEX_TEST_DUTY_MAX;
 				i += LITEX_TEST_DUTY_STEP) {
 			setup1.duty = i;
-			sub_system1 = (clock_control_subsys_t *)&setup1;
-			ret = clock_control_on(dev, sub_system1);
+			ret = clock_control_on(dev, &setup1);
 			if (ret != 0) {
 				return ret;
 			}
 			setup2.duty = 100 - i;
-			sub_system2 = (clock_control_subsys_t *)&setup2;
-			ret = clock_control_on(dev, sub_system2);
+			ret = clock_control_on(dev, &setup2);
 			if (ret != 0) {
 				return ret;
 			}
@@ -266,14 +252,12 @@ int litex_clk_test_duty(const struct device *dev)
 		for (i = LITEX_TEST_DUTY_MAX; i > LITEX_TEST_DUTY_MIN;
 				i -= LITEX_TEST_DUTY_STEP) {
 			setup1.duty = i;
-			sub_system1 = (clock_control_subsys_t *)&setup1;
-			ret = clock_control_on(dev, sub_system1);
+			ret = clock_control_on(dev, &setup1);
 			if (ret != 0) {
 				return ret;
 			}
 			setup2.duty = 100 - i;
-			sub_system2 = (clock_control_subsys_t *)&setup2;
-			ret = clock_control_on(dev, sub_system2);
+			ret = clock_control_on(dev, &setup2);
 			if (ret != 0) {
 				return ret;
 			}

--- a/soc/arm/st_stm32/common/stm32_backup_sram.c
+++ b/soc/arm/st_stm32/common/stm32_backup_sram.c
@@ -32,7 +32,7 @@ static int stm32_backup_sram_init(const struct device *dev)
 		return -ENODEV;
 	}
 
-	ret = clock_control_on(clk, (clock_control_subsys_t *)&config->pclken);
+	ret = clock_control_on(clk, &config->pclken);
 	if (ret < 0) {
 		LOG_ERR("Could not initialize backup SRAM clock (%d)", ret);
 		return ret;

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -13,7 +13,7 @@ LOG_MODULE_REGISTER(test);
 #endif
 
 struct device_subsys_data {
-	clock_control_subsys_t subsys;
+	void *subsys;
 	uint32_t startup_us;
 };
 
@@ -57,13 +57,13 @@ static const struct device_data devices[] = {
 
 
 typedef void (*test_func_t)(const struct device *dev,
-			    clock_control_subsys_t subsys,
+			    void *subsys,
 			    uint32_t startup_us);
 
 typedef bool (*test_capability_check_t)(const struct device *dev,
-					clock_control_subsys_t subsys);
+					void *subsys);
 
-static void setup_instance(const struct device *dev, clock_control_subsys_t subsys)
+static void setup_instance(const struct device *dev, void *subsys)
 {
 	int err;
 	k_busy_wait(1000);
@@ -87,7 +87,7 @@ static void setup_instance(const struct device *dev, clock_control_subsys_t subs
 }
 
 static void tear_down_instance(const struct device *dev,
-				clock_control_subsys_t subsys)
+				void *subsys)
 {
 #if DT_HAS_COMPAT_STATUS_OKAY(nordic_nrf_clock)
 	/* Turn on LF clock using onoff service if it is disabled. */
@@ -115,7 +115,7 @@ static void tear_down_instance(const struct device *dev,
 }
 
 static void test_with_single_instance(const struct device *dev,
-				      clock_control_subsys_t subsys,
+				      void *subsys,
 				      uint32_t startup_time,
 				      test_func_t func,
 				      test_capability_check_t capability_check)
@@ -151,7 +151,7 @@ static void test_all_instances(test_func_t func,
  * Basic test for checking correctness of getting clock status.
  */
 static void test_on_off_status_instance(const struct device *dev,
-					clock_control_subsys_t subsys,
+					void *subsys,
 					uint32_t startup_us)
 {
 	enum clock_control_status status;
@@ -182,14 +182,14 @@ static void test_on_off_status(void)
 }
 
 static void async_capable_callback(const struct device *dev,
-				   clock_control_subsys_t subsys,
+				   const void *subsys,
 				   void *user_data)
 {
 	/* empty */
 }
 
 /* Function checks if clock supports asynchronous starting. */
-static bool async_capable(const struct device *dev, clock_control_subsys_t subsys)
+static bool async_capable(const struct device *dev, void *subsys)
 {
 	int err;
 
@@ -217,7 +217,7 @@ static bool async_capable(const struct device *dev, clock_control_subsys_t subsy
  * Test checks that callbacks are called after clock is started.
  */
 static void clock_on_callback(const struct device *dev,
-				clock_control_subsys_t subsys,
+				const void *subsys,
 				void *user_data)
 {
 	bool *executed = (bool *)user_data;
@@ -226,7 +226,7 @@ static void clock_on_callback(const struct device *dev,
 }
 
 static void test_async_on_instance(const struct device *dev,
-				   clock_control_subsys_t subsys,
+				   void *subsys,
 				   uint32_t startup_us)
 {
 	enum clock_control_status status;
@@ -260,7 +260,7 @@ static void test_async_on(void)
  * is reported.
  */
 static void test_async_on_stopped_on_instance(const struct device *dev,
-					      clock_control_subsys_t subsys,
+					      void *subsys,
 					      uint32_t startup_us)
 {
 	enum clock_control_status status;
@@ -297,7 +297,7 @@ static void test_async_on_stopped(void)
  * Test checks that that second start returns error.
  */
 static void test_double_start_on_instance(const struct device *dev,
-						clock_control_subsys_t subsys,
+						void *subsys,
 						uint32_t startup_us)
 {
 	enum clock_control_status status;
@@ -324,7 +324,7 @@ static void test_double_start(void)
  * Test precondition: clock is stopped.
  */
 static void test_double_stop_on_instance(const struct device *dev,
-						clock_control_subsys_t subsys,
+						void *subsys,
 						uint32_t startup_us)
 {
 	enum clock_control_status status;

--- a/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
+++ b/tests/drivers/clock_control/nrf_clock_calibration/src/test_nrf_clock_calibration.c
@@ -20,7 +20,7 @@ LOG_MODULE_REGISTER(test);
 extern void mock_temp_nrf5_value_set(struct sensor_value *val);
 
 static void turn_on_clock(const struct device *dev,
-			  clock_control_subsys_t subsys)
+			  void *subsys)
 {
 	int err;
 	int res;
@@ -37,7 +37,7 @@ static void turn_on_clock(const struct device *dev,
 }
 
 static void turn_off_clock(const struct device *dev,
-			   clock_control_subsys_t subsys)
+			   void *subsys)
 {
 	int err;
 	struct onoff_manager *mgr = z_nrf_clock_control_get_onoff(subsys);

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32_common_devices/src/test_stm32_clock_configuration.c
@@ -49,7 +49,7 @@ static void test_i2c_clk_config(void)
 
 	/* Test clock_on(gating clock) */
 	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			     &pclken[0]);
 	zassert_true((r == 0), "Could not enable I2C gating clock");
 
 	zassert_true(__HAL_RCC_I2C1_IS_CLK_ENABLED(), "I2C1 gating clock should be on");
@@ -58,8 +58,7 @@ static void test_i2c_clk_config(void)
 	if (IS_ENABLED(STM32_I2C_DOMAIN_CLOCK_SUPPORT) && DT_NUM_CLOCKS(DT_NODELABEL(i2c1)) > 1) {
 		/* Test clock_on(domain_clk) */
 		r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					    (clock_control_subsys_t) &pclken[1],
-					    NULL);
+					    &pclken[1], NULL);
 		zassert_true((r == 0), "Could not enable I2C domain clock");
 		TC_PRINT("I2C1 domain clock configured\n");
 
@@ -80,8 +79,7 @@ static void test_i2c_clk_config(void)
 
 		/* Test get_rate(srce clk) */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[1],
-					&dev_dt_clk_freq);
+					   &pclken[1], &dev_dt_clk_freq);
 		zassert_true((r == 0), "Could not get I2C clk srce freq");
 
 		dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C1);
@@ -96,8 +94,7 @@ static void test_i2c_clk_config(void)
 
 		/* Test get_rate */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[0],
-					&dev_dt_clk_freq);
+					   &pclken[0], &dev_dt_clk_freq);
 		zassert_true((r == 0), "Could not get I2C clk freq");
 
 		dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_I2C1);
@@ -110,7 +107,7 @@ static void test_i2c_clk_config(void)
 
 	/* Test clock_off(gating clk) */
 	r = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			      &pclken[0]);
 	zassert_true((r == 0), "Could not disable I2C gating clk");
 
 	zassert_true(!__HAL_RCC_I2C1_IS_CLK_ENABLED(), "I2C1 gating clk should be off");
@@ -144,7 +141,7 @@ static void test_lptim_clk_config(void)
 
 	/* Test clock_on(gating clock) */
 	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			     &pclken[0]);
 	zassert_true((r == 0), "Could not enable LPTIM gating clock");
 
 	zassert_true(__HAL_RCC_LPTIM1_IS_CLK_ENABLED(), "LPTIM1 gating clock should be on");
@@ -153,8 +150,7 @@ static void test_lptim_clk_config(void)
 	if (IS_ENABLED(STM32_LPTIM_OPT_CLOCK_SUPPORT) && DT_NUM_CLOCKS(DT_NODELABEL(lptim1)) > 1) {
 		/* Test clock_on(domain_clk) */
 		r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					    (clock_control_subsys_t) &pclken[1],
-					    NULL);
+					    &pclken[1], NULL);
 		zassert_true((r == 0), "Could not enable LPTIM1 domain clock");
 		TC_PRINT("LPTIM1 source clock configured\n");
 
@@ -175,8 +171,7 @@ static void test_lptim_clk_config(void)
 
 		/* Test get_rate(srce clk) */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[1],
-					&dev_dt_clk_freq);
+					   &pclken[1], &dev_dt_clk_freq);
 		zassert_true((r == 0), "Could not get LPTIM1 clk srce freq");
 
 		dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_LPTIM1);
@@ -191,8 +186,7 @@ static void test_lptim_clk_config(void)
 
 		/* Test get_rate */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[0],
-					&dev_dt_clk_freq);
+					   &pclken[0], &dev_dt_clk_freq);
 		zassert_true((r == 0), "Could not get LPTIM1 clk freq");
 
 		dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_LPTIM1);
@@ -205,7 +199,7 @@ static void test_lptim_clk_config(void)
 
 	/* Test clock_off(reg_clk) */
 	r = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			      &pclken[0]);
 	zassert_true((r == 0), "Could not disable LPTIM1 gating clk");
 
 	zassert_true(!__HAL_RCC_LPTIM1_IS_CLK_ENABLED(), "LPTIM1 gating clk should be off");
@@ -265,7 +259,7 @@ static void test_adc_clk_config(void)
 
 	/* Test clock_on(gating clock) */
 	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			     &pclken[0]);
 	zassert_true((r == 0), "Could not enable ADC1 gating clock");
 
 	zassert_true(ADC_IS_CLK_ENABLED(), "ADC1 gating clock should be on");
@@ -274,8 +268,7 @@ static void test_adc_clk_config(void)
 	if (IS_ENABLED(STM32_ADC_DOMAIN_CLOCK_SUPPORT) && DT_NUM_CLOCKS(DT_NODELABEL(adc1)) > 1) {
 		/* Test clock_on(domain_clk) */
 		r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					    (clock_control_subsys_t) &pclken[1],
-					    NULL);
+					    &pclken[1], NULL);
 		zassert_true((r == 0), "Could not enable ADC1 domain clock");
 		TC_PRINT("ADC1 source clock configured\n");
 
@@ -297,8 +290,7 @@ static void test_adc_clk_config(void)
 
 		/* Test get_rate(srce clk) */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[1],
-					&dev_dt_clk_freq);
+					   &pclken[1], &dev_dt_clk_freq);
 		zassert_true((r == 0), "Could not get ADC1 clk srce freq");
 
 		dev_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(PERIPHCLK_ADC);
@@ -317,7 +309,7 @@ static void test_adc_clk_config(void)
 
 	/* Test clock_off(reg_clk) */
 	r = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			      &pclken[0]);
 	zassert_true((r == 0), "Could not disable ADC1 gating clk");
 
 	zassert_true(!ADC_IS_CLK_ENABLED(), "ADC1 gating clk should be off");

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32h7_devices/src/test_stm32_clock_configuration.c
@@ -44,7 +44,7 @@ static void test_spi_clk_config(void)
 
 	/* Test clock_on(reg_clk) */
 	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &spi1_reg_clk_cfg);
+			     &spi1_reg_clk_cfg);
 	zassert_true((r == 0), "Could not enable SPI reg_clk");
 
 	zassert_true(__HAL_RCC_SPI1_IS_CLK_ENABLED(), "SPI1 reg_clk should be on");
@@ -55,8 +55,7 @@ static void test_spi_clk_config(void)
 
 		/* Select domain_clk as device source clock */
 		r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					    (clock_control_subsys_t) &spi1_domain_clk_cfg,
-					    NULL);
+					    &spi1_domain_clk_cfg, NULL);
 		zassert_true((r == 0), "Could not enable SPI domain_clk");
 		TC_PRINT("SPI1 domain_clk on\n");
 
@@ -85,8 +84,7 @@ static void test_spi_clk_config(void)
 
 		/* Test get_rate(domain_clk) */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &spi1_domain_clk_cfg,
-					&spi1_dt_clk_freq);
+					   &spi1_domain_clk_cfg, &spi1_dt_clk_freq);
 		zassert_true((r == 0), "Could not get SPI clk freq");
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
@@ -98,8 +96,7 @@ static void test_spi_clk_config(void)
 
 		/* Test get_rate(reg_clk) */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &spi1_reg_clk_cfg,
-					&spi1_dt_clk_freq);
+					   &spi1_reg_clk_cfg, &spi1_dt_clk_freq);
 		zassert_true((r == 0), "Could not get SPI clk freq");
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
@@ -112,7 +109,7 @@ static void test_spi_clk_config(void)
 
 	/* Test clock_off(reg_clk) */
 	r = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &spi1_reg_clk_cfg);
+			      &spi1_reg_clk_cfg);
 	zassert_true((r == 0), "Could not disable SPI reg_clk");
 
 	zassert_true(!__HAL_RCC_SPI1_IS_CLK_ENABLED(), "SPI1 reg_clk should be off");

--- a/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/src/test_stm32_clock_configuration.c
+++ b/tests/drivers/clock_control/stm32_clock_configuration/stm32u5_devices/src/test_stm32_clock_configuration.c
@@ -43,7 +43,7 @@ static void test_spi_clk_config(void)
 
 	/* Test clock_on(reg_clk) */
 	r = clock_control_on(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			     &pclken[0]);
 	zassert_true((r == 0), "Could not enable SPI gating clock");
 
 	zassert_true(__HAL_RCC_SPI1_IS_CLK_ENABLED(), "SPI1 gating clock should be on");
@@ -52,8 +52,7 @@ static void test_spi_clk_config(void)
 	if (IS_ENABLED(STM32_SPI_DOMAIN_CLOCK_SUPPORT) && DT_NUM_CLOCKS(DT_NODELABEL(spi1)) > 1) {
 		/* Test clock_on(domain source) */
 		r = clock_control_configure(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					    (clock_control_subsys_t) &pclken[1],
-					    NULL);
+					    &pclken[1], NULL);
 		zassert_true((r == 0), "Could not configure SPI domain clk");
 		TC_PRINT("SPI1 domain clk configured\n");
 
@@ -74,8 +73,7 @@ static void test_spi_clk_config(void)
 
 		/* Test get_rate(source clk) */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[1],
-					&spi1_dt_clk_freq);
+					   &pclken[1], &spi1_dt_clk_freq);
 		zassert_true((r == 0), "Could not get SPI clk freq");
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
@@ -87,8 +85,7 @@ static void test_spi_clk_config(void)
 
 		/* Test get_rate(gating clock) */
 		r = clock_control_get_rate(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-					(clock_control_subsys_t) &pclken[0],
-					&spi1_dt_clk_freq);
+					   &pclken[0], &spi1_dt_clk_freq);
 		zassert_true((r == 0), "Could not get SPI pclk freq");
 
 		spi1_actual_clk_freq = HAL_RCCEx_GetPeriphCLKFreq(RCC_PERIPHCLK_SPI1);
@@ -99,7 +96,7 @@ static void test_spi_clk_config(void)
 
 	/* Test clock_off(gating clock) */
 	r = clock_control_off(DEVICE_DT_GET(STM32_CLOCK_CONTROL_NODE),
-				(clock_control_subsys_t) &pclken[0]);
+			      &pclken[0]);
 	zassert_true((r == 0), "Could not disable SPI reg_clk");
 
 	zassert_true(!__HAL_RCC_SPI1_IS_CLK_ENABLED(), "SPI1 gating clock should be off");


### PR DESCRIPTION
As of today, one can have N clock controllers in Zephyr. The API accepts
an opaque type that is instance dependent, meaning each instance in the
system can require its own type. This isn't a great API design provided
Zephyr aims to offer portable APIs, but what doesn't make much sense is
to add a typedef to a void * for such cases. The naming is also weird
(subsys?), as it doesn't match the reality (what is a subsys here?).

This patch drops the clock_control_subsys_t typedef in favor of using
just void *. It also treats the argument as an input only parameter
(const). The previous typedef added no value other than noise in drivers
using the API, as they had to cast to such _opaque_ void *. In practice
there are no functional changes, so impact should be low.

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>