### PR TITLE
Bluetooth: audio: ascs: Fix bugs in metadata validation

### DIFF
--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1641,12 +1641,7 @@ static int ascs_verify_metadata(const struct net_buf_simple *buf,
 		return -EINVAL;
 	}
 
-	if (result.count >= CONFIG_BT_CODEC_MAX_METADATA_COUNT) {
-		BT_ERR("No slot available for Codec Config Metadata");
-		return -ENOMEM;
-	}
-
-	return 0;
+	return result.err;
 }
 
 int ascs_ep_set_metadata(struct bt_audio_ep *ep,

--- a/subsys/bluetooth/audio/ascs.c
+++ b/subsys/bluetooth/audio/ascs.c
@@ -1676,6 +1676,9 @@ int ascs_ep_set_metadata(struct bt_audio_ep *ep,
 		return err;
 	}
 
+	/* reset cached metadata */
+	ep->codec.meta_count = 0;
+
 	/* store data contents */
 	bt_data_parse(&meta_ltv, ascs_codec_store_metadata, codec);
 


### PR DESCRIPTION
This fixes issues found in ASCS Enable operation's metadata validation code.