### PR TITLE
tests: Increase stack size when nRF DK serial workaround is enabled

### DIFF
--- a/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
+++ b/boards/arm/nrf5340dk_nrf5340/Kconfig.defconfig
@@ -102,3 +102,10 @@ endif # BOARD_NRF5340DK_NRF5340_CPUNET
 
 config UART_NRF_DK_SERIAL_WORKAROUND
 	default y if ZTEST
+
+# When the nRF DK serial workaround is enabled, increase the stack size in
+# tests built with no optimizations, as the standard size may be insufficient
+# then. Use 512 to align with the FPU_SHARING case, where the default value
+# is also modified.
+config TEST_EXTRA_STACK_SIZE
+	default 512 if UART_NRF_DK_SERIAL_WORKAROUND && NO_OPTIMIZATIONS

--- a/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
+++ b/boards/arm/nrf9160dk_nrf9160/Kconfig.defconfig
@@ -66,3 +66,10 @@ endif # BOARD_NRF9160DK_NRF9160 || BOARD_NRF9160DK_NRF9160_NS
 
 config UART_NRF_DK_SERIAL_WORKAROUND
 	default y if ZTEST
+
+# When the nRF DK serial workaround is enabled, increase the stack size in
+# tests built with no optimizations, as the standard size may be insufficient
+# then. Use 512 to align with the FPU_SHARING case, where the default value
+# is also modified.
+config TEST_EXTRA_STACK_SIZE
+	default 512 if UART_NRF_DK_SERIAL_WORKAROUND && NO_OPTIMIZATIONS

--- a/tests/arch/arm/arm_interrupt/testcase.yaml
+++ b/tests/arch/arm/arm_interrupt/testcase.yaml
@@ -11,7 +11,6 @@ tests:
       - CONFIG_NO_OPTIMIZATIONS=y
       - CONFIG_IDLE_STACK_SIZE=512
       - CONFIG_MAIN_STACK_SIZE=2048
-      - CONFIG_TEST_EXTRA_STACK_SIZE=1024
   arch.interrupt.extra_exception_info:
     filter: not CONFIG_TRUSTED_EXECUTION_NONSECURE
     extra_configs:


### PR DESCRIPTION
... and tests are built with no optimizations. The standard size may
not be sufficient in such circumstances.

Commit 4b1103547cb8c3acd622ea8c1540e592eeb49c02 addressed the same
issue in a single test and used a higher value (1024) that turns out
to be not necessary, so revert also that change to make the cleanup
easier when the workaround will no longer be needed.

Fixes #49000.