### PR TITLE
Bluetooth: Mesh: Cfg_cli: Fix appkey get rsp

### DIFF
--- a/subsys/bluetooth/mesh/cfg_cli.c
+++ b/subsys/bluetooth/mesh/cfg_cli.c
@@ -456,6 +456,10 @@ static int app_key_list(struct bt_mesh_model *model,
 						&param->keys[i + 1]);
 			}
 
+			if (i < *param->key_cnt && buf->len == 2) {
+				param->keys[i++] = net_buf_simple_pull_le16(buf) & 0xfff;
+			}
+
 			if (buf->len > 0U) {
 				BT_ERR("The message size for the application opcode is incorrect.");
 				return -EMSGSIZE;


### PR DESCRIPTION
Adds missing feature so that the config client is able to receive
odd number of app index entries.

Signed-off-by: Anders Storrø <anders.storro@nordicsemi.no>