### PR TITLE
intel_adsp: Cleanup shim headers and move timer driver to use syscon

### DIFF
--- a/drivers/timer/intel_adsp_timer.c
+++ b/drivers/timer/intel_adsp_timer.c
@@ -12,6 +12,8 @@
 #include <cavs-idc.h>
 #include <adsp_shim.h>
 
+#define DT_DRV_COMPAT intel_adsp_timer
+
 #ifdef CONFIG_SOC_SERIES_INTEL_ACE
 #include <ace_v1x-regs.h>
 #endif
@@ -42,15 +44,19 @@
 BUILD_ASSERT(MIN_DELAY < CYC_PER_TICK);
 BUILD_ASSERT(COMPARATOR_IDX >= 0 && COMPARATOR_IDX <= 1);
 
-#define WCTCS      (ADSP_SHIM_DSPWCTS)
-#define COUNTER_HI (ADSP_SHIM_DSPWCH)
-#define COUNTER_LO (ADSP_SHIM_DSPWCL)
-#define COMPARE_HI (ADSP_SHIM_COMPARE_HI(COMPARATOR_IDX))
-#define COMPARE_LO (ADSP_SHIM_COMPARE_LO(COMPARATOR_IDX))
-
+#define DSP_WCT_CS_TT(x)                     BIT(4 + x)
 
 static struct k_spinlock lock;
 static uint64_t last_count;
+
+/* Not using current syscon driver due to overhead due to MMU support */
+#define SYSCON_REG_ADDR	DT_REG_ADDR(DT_INST_PHANDLE(0, syscon))
+
+#define DSPWCTCS_ADDR (SYSCON_REG_ADDR + ADSP_DSPWCTCS_OFFSET)
+#define DSPWCT0C_LO_ADDR (SYSCON_REG_ADDR + ADSP_DSPWCT0C_OFFSET)
+#define DSPWCT0C_HI_ADDR (SYSCON_REG_ADDR + ADSP_DSPWCT0C_OFFSET + 4)
+#define DSPWC_LO_ADDR (SYSCON_REG_ADDR + ADSP_DSPWC_OFFSET)
+#define DSPWC_HI_ADDR (SYSCON_REG_ADDR + ADSP_DSPWC_OFFSET + 4)
 
 #if defined(CONFIG_TEST)
 const int32_t z_sys_timer_irq_for_test = TIMER_IRQ; /* See tests/kernel/context */
@@ -59,13 +65,15 @@ const int32_t z_sys_timer_irq_for_test = TIMER_IRQ; /* See tests/kernel/context 
 static void set_compare(uint64_t time)
 {
 	/* Disarm the comparator to prevent spurious triggers */
-	*WCTCS &= ~DSP_WCT_CS_TA(COMPARATOR_IDX);
+	sys_write32(sys_read32(DSPWCTCS_ADDR) & (~DSP_WCT_CS_TA(COMPARATOR_IDX)),
+			SYSCON_REG_ADDR + ADSP_DSPWCTCS_OFFSET);
 
-	*COMPARE_LO = (uint32_t)time;
-	*COMPARE_HI = (uint32_t)(time >> 32);
+	sys_write32((uint32_t)time, DSPWCT0C_LO_ADDR);
+	sys_write32((uint32_t)(time >> 32), DSPWCT0C_HI_ADDR);
 
 	/* Arm the timer */
-	*WCTCS |= DSP_WCT_CS_TA(COMPARATOR_IDX);
+	sys_write32(sys_read32(DSPWCTCS_ADDR) | (DSP_WCT_CS_TA(COMPARATOR_IDX)),
+			DSPWCTCS_ADDR);
 }
 
 static uint64_t count(void)
@@ -79,9 +87,9 @@ static uint64_t count(void)
 	uint32_t hi0, hi1, lo;
 
 	do {
-		hi0 = *COUNTER_HI;
-		lo = *COUNTER_LO;
-		hi1 = *COUNTER_HI;
+		hi0 = sys_read32(DSPWC_HI_ADDR);
+		lo = sys_read32(DSPWC_LO_ADDR);
+		hi1 = sys_read32(DSPWC_HI_ADDR);
 	} while (hi0 != hi1);
 
 	return (((uint64_t)hi0) << 32) | lo;
@@ -89,7 +97,10 @@ static uint64_t count(void)
 
 static uint32_t count32(void)
 {
-	return *COUNTER_LO;
+	uint32_t counter_lo;
+
+	counter_lo = sys_read32(DSPWC_LO_ADDR);
+	return counter_lo;
 }
 
 static void compare_isr(const void *arg)
@@ -104,7 +115,8 @@ static void compare_isr(const void *arg)
 	dticks = (uint32_t)((curr - last_count) / CYC_PER_TICK);
 
 	/* Clear the triggered bit */
-	*WCTCS |= DSP_WCT_CS_TT(COMPARATOR_IDX);
+	sys_write32(sys_read32(DSPWCTCS_ADDR) | DSP_WCT_CS_TT(COMPARATOR_IDX),
+			DSPWCTCS_ADDR);
 
 	last_count += dticks * CYC_PER_TICK;
 
@@ -185,13 +197,16 @@ static void irq_init(void)
 {
 	int cpu = arch_curr_cpu()->id;
 
+
 	/* These platforms have an extra layer of interrupt masking
 	 * (for per-core control) above the interrupt controller.
 	 * Drivers need to do that part.
 	 */
 #ifdef CONFIG_SOC_SERIES_INTEL_ACE
 	MTL_DINT[cpu].ie[MTL_INTL_TTS] |= BIT(COMPARATOR_IDX + 1);
-	*WCTCS |= ADSP_SHIM_DSPWCTCS_TTIE(COMPARATOR_IDX);
+
+	sys_write32(sys_read32(DSPWCTCS_ADDR) | ADSP_SHIM_DSPWCTCS_TTIE(COMPARATOR_IDX),
+			DSPWCTCS_ADDR);
 #else
 	CAVS_INTCTRL[cpu].l2.clear = CAVS_L2_DWCT0;
 #endif

--- a/dts/bindings/timer/intel,adsp-timer.yaml
+++ b/dts/bindings/timer/intel,adsp-timer.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2022 Intel Corp.
+# SPDX-License-Identifier: Apache-2.0
+
+description: Intel ADSP Timer
+
+compatible: "intel,adsp-timer"
+
+include: base.yaml
+
+properties:
+    reg:
+      required: false
+
+    interrupts:
+      required: false
+
+    syscon:
+      type: phandle
+      required: true
+      description: |
+        phandle to syscon node.

--- a/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
+++ b/dts/xtensa/intel/intel_adsp_ace15_mtpm.dtsi
@@ -147,6 +147,17 @@
 			reg = <0x71f00 0x100>;
 		};
 
+		tts: tts@72000 {
+			compatible = "intel,adsp-tts", "syscon";
+			reg = <0x72000 0x70>;
+			status = "okay";
+		};
+
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&tts>;
+		};
+
 		lps: lps@71ac0 {
 			compatible = "intel,adsp-lps";
 			reg = <0x00071ac0 0x100>;

--- a/dts/xtensa/intel/intel_adsp_cavs15.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs15.dtsi
@@ -64,13 +64,18 @@
 
 	soc {
 		shim: shim@1000 {
-			compatible = "intel,adsp-shim";
+			compatible = "intel,adsp-shim", "syscon";
 			reg = <0x1000 0x100>;
 		};
 
 		l2cc: l2cc@1500 {
 			compatible = "intel,cavs-l2cc";
 			reg = <0x1500 0x40>;
+		};
+
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&shim>;
 		};
 
 		win: win@1580 {

--- a/dts/xtensa/intel/intel_adsp_cavs18.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs18.dtsi
@@ -61,8 +61,12 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,adsp-shim";
+			compatible = "intel,adsp-shim", "syscon";
 			reg = <0x71f00 0x100>;
+		};
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&shim>;
 		};
 
 		win: win@71a00 {

--- a/dts/xtensa/intel/intel_adsp_cavs20.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs20.dtsi
@@ -61,8 +61,13 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,adsp-shim";
+			compatible = "intel,adsp-shim", "syscon";
 			reg = <0x71f00 0x100>;
+		};
+
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&shim>;
 		};
 
 		win: win@71a00 {

--- a/dts/xtensa/intel/intel_adsp_cavs20_jsl.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs20_jsl.dtsi
@@ -40,8 +40,13 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,adsp-shim";
+			compatible = "intel,adsp-shim", "syscon";
 			reg = <0x71f00 0x100>;
+		};
+
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&shim>;
 		};
 
 		win: win@71a00 {

--- a/dts/xtensa/intel/intel_adsp_cavs25.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25.dtsi
@@ -81,8 +81,13 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,adsp-shim";
+			compatible = "intel,adsp-shim", "syscon";
 			reg = <0x71f00 0x100>;
+		};
+
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&shim>;
 		};
 
 		win: win@71a00 {

--- a/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
+++ b/dts/xtensa/intel/intel_adsp_cavs25_tgph.dtsi
@@ -39,10 +39,14 @@
 
 	soc {
 		shim: shim@71f00 {
-			compatible = "intel,adsp-shim";
+			compatible = "intel,adsp-shim", "syscon";
 			reg = <0x71f00 0x100>;
 		};
 
+		timer: timer {
+			compatible = "intel,adsp-timer";
+			syscon = <&shim>;
+		};
 		win: win@71a00 {
 			compatible = "intel,cavs-win";
 			reg = <0x71a00 0x20>;

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
@@ -52,37 +52,24 @@ struct cavs_shim {
 #define CAVS_SHIM (*((volatile struct cavs_shim *)DT_REG_ADDR(DT_NODELABEL(shim))))
 
 
+#define ADSP_TTSCAP_OFFSET	0x00
+#define ADSP_RTCWC_OFFSET	0x08
+#define ADSP_DSPWCCTL_OFFSET	0x10
+#define ADSP_DSPWCSTS_OFFSET	0x12
+#define ADSP_DSPWCAV_OFFSET	0x18
+#define ADSP_DSPWC_OFFSET	0x20
+#define ADSP_DSPWCTCS_OFFSET	0x28
+#define ADSP_DSPWCT0C_OFFSET	0x30
+#define ADSP_DSPWCT1C_OFFSET	0x38
+#define ADSP_TSCTRL_OFFSET	0x40
+#define ADSP_ISCS_OFFSET	0x44
+#define ADSP_LSCS_OFFSET	0x48
+#define ADSP_DWCCS_OFFSET	0x50
+#define ADSP_ARTCS_OFFSET	0x58
+#define ADSP_LWCCS_OFFSET	0x60
+#define ADSP_CLTSYNC_OFFSET	0x70
 
-struct clk64 {
-	uint32_t lo;
-	uint32_t hi;
-};
 
-
-/* Timers & Time Stamping register block */
-struct adsp_tftts {
-	uint32_t		ttscap;
-	uint32_t		unused0;
-	struct clk64	rtcwc;
-	uint16_t		wcctl;
-	uint16_t		wcsts;
-	uint32_t		unused1;
-	struct clk64	wcav;
-	struct clk64	wc;
-	uint32_t		wctcs;
-	uint32_t		unused2;
-	struct			clk64 wctc[2];
-};
-
-/* These registers are for timers / time stamping usages under DSP FW management. */
-#define ADSP_DFTTS_REG			0x72000
-#define ADSP_DFTTS			(*(volatile struct adsp_tftts *)ADSP_DFTTS_REG)
-
-#define ADSP_SHIM_DSPWCTS (&ADSP_DFTTS.wctcs)
-#define ADSP_SHIM_DSPWCH  (&ADSP_DFTTS.wc.hi)
-#define ADSP_SHIM_DSPWCL  (&ADSP_DFTTS.wc.lo)
-#define ADSP_SHIM_COMPARE_HI(idx)  (&ADSP_DFTTS.wctc[idx].hi)
-#define ADSP_SHIM_COMPARE_LO(idx) (&ADSP_DFTTS.wctc[idx].lo)
 
 #define ADSP_SHIM_DSPWCTCS_TTIE(c) BIT(8 + (c))
 

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
@@ -25,43 +25,28 @@ struct cavs_shim {
 	uint32_t dspwct1c_lo;
 	uint32_t dspwct1c_hi;
 	uint32_t _unused2[14];
-	uint32_t clkctl;
-	uint32_t clksts;
-	uint32_t hspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t hsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
+	uint32_t clkctl;   /* Offset: 0x78 */
+	uint32_t clksts;   /* Offset: 0x7C */
+	uint32_t _unused3[4];
 	uint16_t pwrctl;
 	uint16_t pwrsts;
 	uint32_t lpsctl;
 	uint32_t lpsdmas0;
 	uint32_t lpsdmas1;
-	uint32_t spsreq;
-	uint32_t ldoctl;
-	uint32_t _unused3[2];
-	union {
-		/* cAVS 1.5 */
-		struct {
-			uint32_t hspgists;
-			uint32_t lspgists;
-			uint32_t _unused4[2];
-		};
-		/* cAVS 1.8+ */
-		struct {
-			uint32_t lpsalhss0;
-			uint32_t lpsalhss1;
-			uint32_t lpsalhss2;
-			uint32_t lpsalhss3;
-		};
-	};
+	uint32_t spsreq;  /* Offset: 0xA0 */
+	uint32_t _unused4[3]; /* Offset: 0xA4 */
+	uint32_t lpsalhss0;
+	uint32_t lpsalhss1;
+	uint32_t lpsalhss2;
+	uint32_t lpsalhss3;
 	uint32_t _unused5[4];
 	uint32_t l2mecs;
 	uint32_t l2mpat;
 	uint32_t _unused6[2];
-	uint32_t ltrc;
+	uint32_t ltrc;  /* Offset: 0xe0 */
 	uint32_t _unused8[3];
-	uint32_t dbgo;
-	uint32_t svcfg;
+	uint32_t dbgo; /* Offset: 0xf0 */
+	uint32_t svcfg; /* Offset: 0xf4 */
 	uint32_t _unused9[2];
 };
 #define CAVS_SHIM (*((volatile struct cavs_shim *)DT_REG_ADDR(DT_NODELABEL(shim))))

--- a/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/ace/include/intel_ace15_mtpm/adsp_shim.h
@@ -86,26 +86,6 @@ struct adsp_tftts {
 
 #define ADSP_SHIM_DSPWCTCS_TTIE(c) BIT(8 + (c))
 
-/* L2 Local Memory control (cAVS 1.8+) */
-struct cavs_l2lm {
-	uint32_t l2lmcap;
-	uint32_t l2lmpat;
-	uint32_t _unused0[2];
-	uint32_t hspgctl0;
-	uint32_t hsrmctl0;
-	uint32_t hspgists0;
-	uint32_t _unused1;
-	uint32_t hspgctl1;
-	uint32_t hsrmctl1;
-	uint32_t hspgists1;
-	uint32_t _unused2[9];
-	uint32_t lspgctl;
-	uint32_t lsrmctl;
-	uint32_t lspgists;
-};
-
-#define CAVS_L2LM (*((volatile struct cavs_l2lm *)DT_REG_ADDR(DT_NODELABEL(l2lm))))
-
 /* Host memory window control.  Not strictly part of the shim block. */
 struct cavs_win {
 	uint32_t dmwba;

--- a/soc/xtensa/intel_adsp/cavs/include/intel_apl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_apl_adsp/adsp_shim.h
@@ -55,13 +55,17 @@ struct cavs_shim {
 
 #define CAVS_SHIM (*((volatile struct cavs_shim *)DT_REG_ADDR(DT_NODELABEL(shim))))
 
-#define ADSP_SHIM_DSPWCTS (&CAVS_SHIM.dspwctcs)
-#define ADSP_SHIM_DSPWCH  (&CAVS_SHIM.dspwc_hi)
-#define ADSP_SHIM_DSPWCL  (&CAVS_SHIM.dspwc_lo)
-#define ADSP_SHIM_COMPARE_HI(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_hi))
-#define ADSP_SHIM_COMPARE_LO(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_lo))
-
 #define ADSP_SHIM_DSPWCTCS_TTIE(c) BIT(8 + (c))
+
+#define ADSP_DSPWC_OFFSET	0x20
+#define ADSP_DSPWCTCS_OFFSET	0x28
+#define ADSP_DSPWCT0C_OFFSET	0x30
+#define ADSP_DSPWCT1C_OFFSET	0x38
+#define ADSP_CLKCTL_OFFSET	0x78
+#define ADSP_CLKSTS_OFFSET	0x7C
+#define ADSP_PWRCTL_OFFSET	0x90
+#define ADSP_PWRSTS_OFFSET	0x92
+#define ADSP_LPSCTL_OFFSET	0x94
 
 /* Host memory window control.  Not strictly part of the shim block. */
 struct cavs_win {

--- a/soc/xtensa/intel_adsp/cavs/include/intel_apl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_apl_adsp/adsp_shim.h
@@ -27,10 +27,10 @@ struct cavs_shim {
 	uint32_t _unused2[14];
 	uint32_t clkctl;
 	uint32_t clksts;
-	uint32_t hspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t hsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
+	uint32_t hspgctl;
+	uint32_t lspgctl;
+	uint32_t hsrmctl;
+	uint32_t lsrmctl;
 	uint16_t pwrctl;
 	uint16_t pwrsts;
 	uint32_t lpsctl;
@@ -39,21 +39,9 @@ struct cavs_shim {
 	uint32_t spsreq;
 	uint32_t ldoctl;
 	uint32_t _unused3[2];
-	union {
-		/* cAVS 1.5 */
-		struct {
-			uint32_t hspgists;
-			uint32_t lspgists;
-			uint32_t _unused4[2];
-		};
-		/* cAVS 1.8+ */
-		struct {
-			uint32_t lpsalhss0;
-			uint32_t lpsalhss1;
-			uint32_t lpsalhss2;
-			uint32_t lpsalhss3;
-		};
-	};
+	uint32_t hspgists;
+	uint32_t lspgists;
+	uint32_t _unused4[2];
 	uint32_t _unused5[4];
 	uint32_t l2mecs;
 	uint32_t l2mpat;
@@ -74,26 +62,6 @@ struct cavs_shim {
 #define ADSP_SHIM_COMPARE_LO(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_lo))
 
 #define ADSP_SHIM_DSPWCTCS_TTIE(c) BIT(8 + (c))
-
-/* L2 Local Memory control (cAVS 1.8+) */
-struct cavs_l2lm {
-	uint32_t l2lmcap;
-	uint32_t l2lmpat;
-	uint32_t _unused0[2];
-	uint32_t hspgctl0;
-	uint32_t hsrmctl0;
-	uint32_t hspgists0;
-	uint32_t _unused1;
-	uint32_t hspgctl1;
-	uint32_t hsrmctl1;
-	uint32_t hspgists1;
-	uint32_t _unused2[9];
-	uint32_t lspgctl;
-	uint32_t lsrmctl;
-	uint32_t lspgists;
-};
-
-#define CAVS_L2LM (*((volatile struct cavs_l2lm *)DT_REG_ADDR(DT_NODELABEL(l2lm))))
 
 /* Host memory window control.  Not strictly part of the shim block. */
 struct cavs_win {

--- a/soc/xtensa/intel_adsp/cavs/include/intel_cnl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_cnl_adsp/adsp_shim.h
@@ -53,11 +53,16 @@ struct cavs_shim {
 
 #define CAVS_SHIM (*((volatile struct cavs_shim *)DT_REG_ADDR(DT_NODELABEL(shim))))
 
-#define ADSP_SHIM_DSPWCTS (&CAVS_SHIM.dspwctcs)
-#define ADSP_SHIM_DSPWCH  (&CAVS_SHIM.dspwc_hi)
-#define ADSP_SHIM_DSPWCL  (&CAVS_SHIM.dspwc_lo)
-#define ADSP_SHIM_COMPARE_HI(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_hi))
-#define ADSP_SHIM_COMPARE_LO(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_lo))
+#define ADSP_DSPWC_OFFSET	0x20
+#define ADSP_DSPWCTCS_OFFSET	0x28
+#define ADSP_DSPWCT0C_OFFSET	0x30
+#define ADSP_DSPWCT1C_OFFSET	0x38
+#define ADSP_CLKCTL_OFFSET	0x78
+#define ADSP_CLKSTS_OFFSET	0x7C
+#define ADSP_PWRCTL_OFFSET	0x90
+#define ADSP_PWRSTS_OFFSET	0x92
+#define ADSP_LPSCTL_OFFSET	0x94
+
 
 #define ADSP_SHIM_DSPWCTCS_TTIE(c) BIT(8 + (c))
 

--- a/soc/xtensa/intel_adsp/cavs/include/intel_cnl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_cnl_adsp/adsp_shim.h
@@ -27,10 +27,7 @@ struct cavs_shim {
 	uint32_t _unused2[14];
 	uint32_t clkctl;
 	uint32_t clksts;
-	uint32_t hspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t hsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
+	uint32_t _unused3[4];
 	uint16_t pwrctl;
 	uint16_t pwrsts;
 	uint32_t lpsctl;
@@ -38,22 +35,11 @@ struct cavs_shim {
 	uint32_t lpsdmas1;
 	uint32_t spsreq;
 	uint32_t ldoctl;
-	uint32_t _unused3[2];
-	union {
-		/* cAVS 1.5 */
-		struct {
-			uint32_t hspgists;
-			uint32_t lspgists;
-			uint32_t _unused4[2];
-		};
-		/* cAVS 1.8+ */
-		struct {
-			uint32_t lpsalhss0;
-			uint32_t lpsalhss1;
-			uint32_t lpsalhss2;
-			uint32_t lpsalhss3;
-		};
-	};
+	uint32_t _unused4[2];
+	uint32_t lpsalhss0;
+	uint32_t lpsalhss1;
+	uint32_t lpsalhss2;
+	uint32_t lpsalhss3;
 	uint32_t _unused5[4];
 	uint32_t l2mecs;
 	uint32_t l2mpat;

--- a/soc/xtensa/intel_adsp/cavs/include/intel_icl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_icl_adsp/adsp_shim.h
@@ -53,13 +53,18 @@ struct cavs_shim {
 
 #define CAVS_SHIM (*((volatile struct cavs_shim *)DT_REG_ADDR(DT_NODELABEL(shim))))
 
-#define ADSP_SHIM_DSPWCTS (&CAVS_SHIM.dspwctcs)
-#define ADSP_SHIM_DSPWCH  (&CAVS_SHIM.dspwc_hi)
-#define ADSP_SHIM_DSPWCL  (&CAVS_SHIM.dspwc_lo)
-#define ADSP_SHIM_COMPARE_HI(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_hi))
-#define ADSP_SHIM_COMPARE_LO(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_lo))
 
 #define ADSP_SHIM_DSPWCTCS_TTIE(c) BIT(8 + (c))
+
+#define ADSP_DSPWC_OFFSET	0x20
+#define ADSP_DSPWCTCS_OFFSET	0x28
+#define ADSP_DSPWCT0C_OFFSET	0x30
+#define ADSP_DSPWCT1C_OFFSET	0x38
+#define ADSP_CLKCTL_OFFSET	0x78
+#define ADSP_CLKSTS_OFFSET	0x7C
+#define ADSP_PWRCTL_OFFSET	0x90
+#define ADSP_PWRSTS_OFFSET	0x92
+#define ADSP_LPSCTL_OFFSET	0x94
 
 /* L2 Local Memory control (cAVS 1.8+) */
 struct cavs_l2lm {

--- a/soc/xtensa/intel_adsp/cavs/include/intel_icl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_icl_adsp/adsp_shim.h
@@ -27,10 +27,7 @@ struct cavs_shim {
 	uint32_t _unused2[14];
 	uint32_t clkctl;
 	uint32_t clksts;
-	uint32_t hspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t hsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
+	uint32_t _unused3[4];
 	uint16_t pwrctl;
 	uint16_t pwrsts;
 	uint32_t lpsctl;
@@ -38,22 +35,11 @@ struct cavs_shim {
 	uint32_t lpsdmas1;
 	uint32_t spsreq;
 	uint32_t ldoctl;
-	uint32_t _unused3[2];
-	union {
-		/* cAVS 1.5 */
-		struct {
-			uint32_t hspgists;
-			uint32_t lspgists;
-			uint32_t _unused4[2];
-		};
-		/* cAVS 1.8+ */
-		struct {
-			uint32_t lpsalhss0;
-			uint32_t lpsalhss1;
-			uint32_t lpsalhss2;
-			uint32_t lpsalhss3;
-		};
-	};
+	uint32_t _unused4[2];
+	uint32_t lpsalhss0;
+	uint32_t lpsalhss1;
+	uint32_t lpsalhss2;
+	uint32_t lpsalhss3;
 	uint32_t _unused5[4];
 	uint32_t l2mecs;
 	uint32_t l2mpat;

--- a/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_shim.h
@@ -53,13 +53,17 @@ struct cavs_shim {
 
 #define CAVS_SHIM (*((volatile struct cavs_shim *)DT_REG_ADDR(DT_NODELABEL(shim))))
 
-#define ADSP_SHIM_DSPWCTS (&CAVS_SHIM.dspwctcs)
-#define ADSP_SHIM_DSPWCH  (&CAVS_SHIM.dspwc_hi)
-#define ADSP_SHIM_DSPWCL  (&CAVS_SHIM.dspwc_lo)
-#define ADSP_SHIM_COMPARE_HI(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_hi))
-#define ADSP_SHIM_COMPARE_LO(idx) (&CAVS_SHIM.UTIL_CAT(UTIL_CAT(dspwct, idx), c_lo))
-
 #define ADSP_SHIM_DSPWCTCS_TTIE(c) BIT(8 + (c))
+
+#define ADSP_DSPWC_OFFSET	0x20
+#define ADSP_DSPWCTCS_OFFSET	0x28
+#define ADSP_DSPWCT0C_OFFSET	0x30
+#define ADSP_DSPWCT1C_OFFSET	0x38
+#define ADSP_CLKCTL_OFFSET	0x78
+#define ADSP_CLKSTS_OFFSET	0x7C
+#define ADSP_PWRCTL_OFFSET	0x90
+#define ADSP_PWRSTS_OFFSET	0x92
+#define ADSP_LPSCTL_OFFSET	0x94
 
 /* L2 Local Memory control (cAVS 1.8+) */
 struct cavs_l2lm {

--- a/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_shim.h
+++ b/soc/xtensa/intel_adsp/cavs/include/intel_tgl_adsp/adsp_shim.h
@@ -27,41 +27,27 @@ struct cavs_shim {
 	uint32_t _unused2[14];
 	uint32_t clkctl;
 	uint32_t clksts;
-	uint32_t hspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lspgctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t hsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
-	uint32_t lsrmctl; /* cAVS 1.5, see cavs_l2lm for 1.8+ */
+	uint32_t _unused3[4];
 	uint16_t pwrctl;
 	uint16_t pwrsts;
 	uint32_t lpsctl;
 	uint32_t lpsdmas0;
 	uint32_t lpsdmas1;
-	uint32_t spsreq;
-	uint32_t ldoctl;
-	uint32_t _unused3[2];
-	union {
-		/* cAVS 1.5 */
-		struct {
-			uint32_t hspgists;
-			uint32_t lspgists;
-			uint32_t _unused4[2];
-		};
-		/* cAVS 1.8+ */
-		struct {
-			uint32_t lpsalhss0;
-			uint32_t lpsalhss1;
-			uint32_t lpsalhss2;
-			uint32_t lpsalhss3;
-		};
-	};
+	uint32_t spsreq; /* Offset: 0x00A0 */
+	uint32_t ldoctl; /* Offset: 0x00A4 */
+	uint32_t _unused4[2];
+	uint32_t lpsalhss0; /* Offset: 0x00B0 */
+	uint32_t lpsalhss1; /* Offset: 0x00B4 */
+	uint32_t lpsalhss2; /* Offset: 0x00B8 */
+	uint32_t lpsalhss3; /* Offset: 0x00BC */
 	uint32_t _unused5[4];
-	uint32_t l2mecs;
-	uint32_t l2mpat;
-	uint32_t _unused6[2];
-	uint32_t ltrc;
+	uint32_t l2mecs;  /* Offset: 0x00D0 */
+	uint32_t _unused6;
+	uint32_t _unused7[2];
+	uint32_t ltrc;    /* Offset: 0x00E0 */
 	uint32_t _unused8[3];
-	uint32_t dbgo;
-	uint32_t svcfg;
+	uint32_t dbgo; /* Offset: 0x00F0 */
+	uint32_t svcfg; /* Offset: 0x00F4 */
 	uint32_t _unused9[2];
 };
 

--- a/soc/xtensa/intel_adsp/cavs/sram.c
+++ b/soc/xtensa/intel_adsp/cavs/sram.c
@@ -129,7 +129,12 @@ __imr void lp_sram_init(void)
 	/* Add some delay before writing power registers */
 	z_idelay(DELAY_COUNT);
 
+	/* FIXME */
+#if !defined(CONFIG_SOC_INTEL_CAVS_V15)
+	CAVS_L2LM.lspgctl = CAVS_L2LM.lspgists & ~LPSRAM_MASK(0);
+#else
 	CAVS_SHIM.lspgctl = CAVS_SHIM.lspgists & ~LPSRAM_MASK(0);
+#endif
 
 	/* Add some delay before checking the status */
 	z_idelay(DELAY_COUNT);
@@ -139,9 +144,16 @@ __imr void lp_sram_init(void)
 	 * to check whether it has been powered up. A few
 	 * cycles are needed for it to be powered up
 	 */
+	/* FIXME */
+#if !defined(CONFIG_SOC_INTEL_CAVS_V15)
+	while (CAVS_L2LM.lspgists && timeout_counter--) {
+		z_idelay(DELAY_COUNT);
+	}
+#else
 	while (CAVS_SHIM.lspgists && timeout_counter--) {
 		z_idelay(DELAY_COUNT);
 	}
+#endif
 
 	CAVS_SHIM.ldoctl = SHIM_LDOCTL_LPSRAM_LDO_BYPASS;
 	bbzero((void *)LP_SRAM_BASE, LP_SRAM_SIZE);


### PR DESCRIPTION
- intel_adsp: adapt shim for each platform
- intel_adsp: ace: drop l2lm defines
- timer: intel_adsp: use syscon for hardware information
