### PR TITLE
Fixed quantity of ESP32-C3 board interfaces

### DIFF
--- a/boards/riscv/esp32c3_devkitm/doc/index.rst
+++ b/boards/riscv/esp32c3_devkitm/doc/index.rst
@@ -21,13 +21,13 @@ The features include the following:
 - A Bluetooth LE subsystem that supports features of Bluetooth 5 and Bluetooth mesh
 - Various peripherals:
 
-  - 12-bit ADC with up to 18 channels
+  - 12-bit ADC with up to 6 channels
   - TWAI compatible with CAN bus 2.0
   - Temperature sensor
-  - 4x SPI
-  - 2x I2S
-  - 2x I2C
-  - 3x UART
+  - 3x SPI
+  - 1x I2S
+  - 1x I2C
+  - 2x UART
   - LED PWM with up to 6 channels
 
 - Cryptographic hardware acceleration (RNG, ECC, RSA, SHA-2, AES)


### PR DESCRIPTION
Corrected the documentation due to the quantity of interfaces different from the datasheet.

[ESP32-C3 datasheet](https://www.espressif.com/sites/default/files/documentation/esp32-c3_datasheet_en.pdf)