### PR TITLE
drivers: sensor: lsm6dsl: disable high performance in initialization

### DIFF
--- a/drivers/sensor/lsm6dsl/lsm6dsl.c
+++ b/drivers/sensor/lsm6dsl/lsm6dsl.c
@@ -774,6 +774,22 @@ static int lsm6dsl_init_chip(const struct device *dev)
 		return -EIO;
 	}
 
+	if (data->hw_tf->update_reg(dev,
+				    LSM6DSL_REG_CTRL6_C,
+				    LSM6DSL_MASK_CTRL6_C_XL_HM_MODE,
+				    (1 << LSM6DSL_SHIFT_CTRL6_C_XL_HM_MODE)) < 0) {
+		LOG_DBG("failed to disable accelerometer high performance mode");
+		return -EIO;
+	}
+
+	if (data->hw_tf->update_reg(dev,
+				    LSM6DSL_REG_CTRL7_G,
+				    LSM6DSL_MASK_CTRL7_G_HM_MODE,
+				    (1 << LSM6DSL_SHIFT_CTRL7_G_HM_MODE)) < 0) {
+		LOG_DBG("failed to disable gyroscope high performance mode");
+		return -EIO;
+	}
+
 	return 0;
 }
 


### PR DESCRIPTION
To reduce energy consumption for accel and gyro frequencies 52 Hz and
lower, disable high performance mode by default.
It doesn't affect for higher frequencies.

Signed-off-by: Adrian Wojak <adrian.wojak@grinn-global.com>