### PR TITLE
devices: make device name field optional

### DIFF
--- a/boards/arm/nrf9160dk_nrf52840/board.c
+++ b/boards/arm/nrf9160dk_nrf52840/board.c
@@ -124,7 +124,7 @@ static int reset_pin_configure(void)
 	gpio_dt_flags_t flags = GET_FLAGS(reset_input, gpios, 0);
 
 	if (!device_is_ready(gpio)) {
-		LOG_ERR("%s is not ready", gpio->name);
+		LOG_ERR("%s is not ready", device_name_get(gpio));
 		return -ENODEV;
 	}
 
@@ -168,7 +168,7 @@ static int init(const struct device *dev)
 		gpio_flags_t flags = cfg->flags;
 
 		if (!device_is_ready(cfg->gpio)) {
-			LOG_ERR("%s is not ready", cfg->gpio->name);
+			LOG_ERR("%s is not ready", device_name_get(cfg->gpio));
 			return -ENODEV;
 		}
 

--- a/boards/arm/pinetime_devkit0/key_out.c
+++ b/boards/arm/pinetime_devkit0/key_out.c
@@ -22,14 +22,14 @@ static int pinetime_key_out_init(const struct device *arg)
 
 	if (!device_is_ready(key_out.port)) {
 		LOG_ERR("key out gpio device %s is not ready",
-			key_out.port->name);
+			device_name_get(key_out.port));
 		return -ENODEV;
 	}
 
 	ret = gpio_pin_configure_dt(&key_out, GPIO_OUTPUT_ACTIVE);
 	if (ret != 0) {
 		LOG_ERR("failed to configure %s pin %d (err %d)",
-			key_out.port->name, key_out.pin, ret);
+			device_name_get(key_out.port), key_out.pin, ret);
 		return ret;
 	}
 

--- a/doc/develop/optimizations/footprint.rst
+++ b/doc/develop/optimizations/footprint.rst
@@ -49,6 +49,15 @@ the running application and to provide means for debugging and error handling:
 :kconfig:option:`CONFIG_DEBUG`
   This option can be disabled for production builds
 
+Others
+******
+
+:kconfig:option:`CONFIG_DEVICE_STORE_NAME`
+  When this option is disabled, devices will not have a unique human readable
+  name (:c:member:`device.name`). If you set this option to ``n``, you will no
+  longer be able to use :c:func:`device_get_binding`, because it looks up
+  devices by name. Use :c:macro:`DEVICE_DT_GET` or another related macro
+  instead.
 
 MPU/MMU Support
 ***************

--- a/doc/kernel/services/threads/workqueue.rst
+++ b/doc/kernel/services/threads/workqueue.rst
@@ -301,7 +301,7 @@ unchanged and the associated error message will not be printed.
     {
         struct device_info *the_device =
             CONTAINER_OF(item, struct device_info, work);
-        printk("Got error on device %s\n", the_device->name);
+        printk("Got error on device %s\n", device_name_get(the_device));
     }
 
     /* initialize name info for a device */

--- a/doc/services/smf/index.rst
+++ b/doc/services/smf/index.rst
@@ -422,14 +422,14 @@ Code::
 
 		if (!device_is_ready(button.port)) {
 			printk("Error: button device %s is not ready\n",
-				button.port->name);
+				device_name_get(button.port));
 			return;
 		}
 
 		ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 		if (ret != 0) {
 			printk("Error %d: failed to configure %s pin %d\n",
-				ret, button.port->name, button.pin);
+				ret, device_name_get(button.port), button.pin);
 			return;
 		}
 
@@ -437,7 +437,7 @@ Code::
 			GPIO_INT_EDGE_TO_ACTIVE);
 		if (ret != 0) {
 			printk("Error %d: failed to configure interrupt on %s pin %d\n",
-				ret, button.port->name, button.pin);
+				ret, device_name_get(button.port), button.pin);
 			return;
 		}
 

--- a/drivers/adc/adc_ads1119.c
+++ b/drivers/adc/adc_ads1119.c
@@ -458,7 +458,7 @@ static int ads1119_init(const struct device *dev)
 
 	rc = ads1119_read_reg(dev, ADS1119_REG_STATUS, &status);
 	if (rc) {
-		LOG_ERR("Could not get %s status", dev->name);
+		LOG_ERR("Could not get %s status", device_name_get(dev));
 		return rc;
 	}
 

--- a/drivers/adc/adc_ads1x1x.c
+++ b/drivers/adc/adc_ads1x1x.c
@@ -554,7 +554,7 @@ static int ads1x1x_init(const struct device *dev)
 	k_sem_init(&data->acq_sem, 0, 1);
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s not ready", config->bus.bus->name);
+		LOG_ERR("I2C bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/adc/adc_lmp90xxx.c
+++ b/drivers/adc/adc_lmp90xxx.c
@@ -941,7 +941,7 @@ static int lmp90xxx_init(const struct device *dev)
 	data->ura = LMP90XXX_INVALID_URA;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/adc/adc_nrfx_adc.c
+++ b/drivers/adc/adc_nrfx_adc.c
@@ -268,7 +268,7 @@ static int init_adc(const struct device *dev)
 
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			    dev->name);
+			    device_name_get(dev));
 		return -EBUSY;
 	}
 

--- a/drivers/adc/adc_shell.c
+++ b/drivers/adc/adc_shell.c
@@ -112,7 +112,7 @@ static struct adc_hdl {
 static struct adc_hdl *get_adc(const char *device_label)
 {
 	for (int i = 0; i < ARRAY_SIZE(adc_list); i++) {
-		if (!strcmp(device_label, adc_list[i].dev->name)) {
+		if (!strcmp(device_label, device_name_get(adc_list[i].dev))) {
 			return &adc_list[i];
 		}
 	}
@@ -347,7 +347,7 @@ static int cmd_adc_print(const struct shell *shell, size_t argc, char **argv)
 			   "Acquisition Time: %u\n"
 			   "Channel ID: %u\n"
 			   "Resolution: %u",
-			   adc->dev->name,
+			   device_name_get(adc->dev),
 			   chosen_gain,
 			   chosen_reference,
 			   adc->channel_config.acquisition_time,
@@ -408,7 +408,7 @@ static void cmd_adc_dev_get(size_t idx, struct shell_static_entry *entry)
 {
 	/* -1 because the last element in the list is a "list terminator" */
 	if (idx < ARRAY_SIZE(adc_list) - 1) {
-		entry->syntax  = adc_list[idx].dev->name;
+		entry->syntax  = device_name_get(adc_list[idx].dev);
 		entry->handler = NULL;
 		entry->subcmd  = &sub_adc_cmds;
 		entry->help    = "Select subcommand for ADC property label.\n";

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -939,7 +939,7 @@ static void adc_stm32_isr(const struct device *dev)
 
 	adc_context_on_sampling_done(&data->ctx, dev);
 
-	LOG_DBG("%s ISR triggered.", dev->name);
+	LOG_DBG("%s ISR triggered.", device_name_get(dev));
 }
 
 static int adc_stm32_read(const struct device *dev,

--- a/drivers/can/can_loopback.c
+++ b/drivers/can/can_loopback.c
@@ -103,7 +103,7 @@ static int can_loopback_send(const struct device *dev,
 	int ret;
 
 	LOG_DBG("Sending %d bytes on %s. Id: 0x%x, ID type: %s %s",
-		frame->dlc, dev->name, frame->id,
+		frame->dlc, device_name_get(dev), frame->id,
 		frame->id_type == CAN_STANDARD_IDENTIFIER ?
 				  "standard" : "extended",
 		frame->rtr == CAN_DATAFRAME ? "" : ", RTR frame");
@@ -429,7 +429,7 @@ static int can_loopback_init(const struct device *dev)
 		return -1;
 	}
 
-	LOG_INF("Init of %s done", dev->name);
+	LOG_INF("Init of %s done", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/can/can_mcp2515.c
+++ b/drivers/can/can_mcp2515.c
@@ -920,7 +920,7 @@ static int mcp2515_init(const struct device *dev)
 	}
 
 	if (!spi_is_ready(&dev_cfg->bus)) {
-		LOG_ERR("SPI bus %s not ready", dev_cfg->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(dev_cfg->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/can/can_native_posix_linux.c
+++ b/drivers/can/can_native_posix_linux.c
@@ -137,7 +137,7 @@ static int can_npl_send(const struct device *dev, const struct can_frame *frame,
 	int ret = -EIO;
 
 	LOG_DBG("Sending %d bytes on %s. Id: 0x%x, ID type: %s %s",
-		frame->dlc, dev->name, frame->id,
+		frame->dlc, device_name_get(dev), frame->id,
 		frame->id_type == CAN_STANDARD_IDENTIFIER ?
 				  "standard" : "extended",
 		frame->rtr == CAN_DATAFRAME ? "" : ", RTR frame");
@@ -469,7 +469,7 @@ static int can_npl_init(const struct device *dev)
 			CONFIG_CAN_NATIVE_POSIX_LINUX_RX_THREAD_PRIORITY,
 			0, K_NO_WAIT);
 
-	LOG_DBG("Init of %s done", dev->name);
+	LOG_DBG("Init of %s done", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/can/can_rcar.c
+++ b/drivers/can/can_rcar.c
@@ -858,7 +858,7 @@ static int can_rcar_send(const struct device *dev, const struct can_frame *frame
 		"Id: 0x%x, "
 		"ID type: %s, "
 		"Remote Frame: %s"
-		, frame->dlc, dev->name
+		, frame->dlc, device_name_get(dev)
 		, frame->id
 		, frame->id_type == CAN_STANDARD_IDENTIFIER ?
 		"standard" : "extended"

--- a/drivers/can/can_shell.c
+++ b/drivers/can/can_shell.c
@@ -798,7 +798,7 @@ static void cmd_can_device_name(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 
-	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->syntax = (dev != NULL) ? device_name_get(dev) : NULL;
 	entry->handler = NULL;
 	entry->help = NULL;
 	entry->subcmd = NULL;
@@ -828,7 +828,7 @@ static void cmd_can_device_name_mode(size_t idx, struct shell_static_entry *entr
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 
-	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->syntax = (dev != NULL) ? device_name_get(dev) : NULL;
 	entry->handler = NULL;
 	entry->help = NULL;
 	entry->subcmd = &dsub_can_mode;

--- a/drivers/can/can_stm32.c
+++ b/drivers/can/can_stm32.c
@@ -735,7 +735,7 @@ static int can_stm32_send(const struct device *dev, const struct can_frame *fram
 		    "Id: 0x%x, "
 		    "ID type: %s, "
 		    "Remote Frame: %s"
-		    , frame->dlc, dev->name
+		    , frame->dlc, device_name_get(dev)
 		    , frame->id
 		    , frame->id_type == CAN_STANDARD_IDENTIFIER ?
 		    "standard" : "extended"

--- a/drivers/console/ipm_console.c
+++ b/drivers/console/ipm_console.c
@@ -72,7 +72,7 @@ static int ipm_console_init(const struct device *dev)
 
 	ipm_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 	if (!device_is_ready(ipm_dev)) {
-		LOG_ERR("%s is not ready", ipm_dev->name);
+		LOG_ERR("%s is not ready", device_name_get(ipm_dev));
 		return -ENODEV;
 	}
 

--- a/drivers/console/uart_mux.c
+++ b/drivers/console/uart_mux.c
@@ -169,7 +169,7 @@ static int uart_mux_consume_ringbuf(struct uart_mux *uart_mux)
 		char tmp[sizeof("RECV muxed ") + 10];
 
 		snprintk(tmp, sizeof(tmp), "RECV muxed %s",
-			 uart_mux->uart->name);
+			 device_name_get(uart_mux->uart));
 		LOG_HEXDUMP_DBG(data, len, tmp);
 	}
 
@@ -216,7 +216,7 @@ static void uart_mux_tx_work(struct k_work *work)
 			 sizeof(CONFIG_UART_MUX_DEVICE_NAME)];
 
 		snprintk(tmp, sizeof(tmp), "SEND %s",
-			 dev_data->dev->name);
+			 device_name_get(dev_data->dev));
 		LOG_HEXDUMP_DBG(data, len, tmp);
 	}
 
@@ -241,7 +241,7 @@ static int uart_mux_init(const struct device *dev)
 	k_work_init(&dev_data->cb_work, uart_mux_cb_work);
 
 	LOG_DBG("Device %s dev %p dev_data %p cfg %p created",
-		dev->name, dev, dev_data, dev->config);
+		device_name_get(dev), dev, dev_data, dev->config);
 
 	return 0;
 }
@@ -324,7 +324,7 @@ static void dlci_created_cb(struct gsm_dlci *dlci, bool connected,
 		dev_data->status = UART_MUX_DISCONNECTED;
 	}
 
-	LOG_DBG("%s %s", dev_data->dev->name,
+	LOG_DBG("%s %s", device_name_get(dev_data->dev),
 		dev_data->status == UART_MUX_CONNECTED ? "connected" :
 							 "disconnected");
 
@@ -370,7 +370,7 @@ static int init_real_uart(const struct device *mux, const struct device *uart,
 		real_uart->mux = gsm_mux_create(mux);
 
 		LOG_DBG("Initializing UART %s and GSM mux %p",
-			real_uart->uart->name, (void *)real_uart->mux);
+			device_name_get(real_uart->uart), (void *)real_uart->mux);
 
 		if (!real_uart->mux) {
 			real_uart->uart = NULL;
@@ -410,7 +410,7 @@ static int attach(const struct device *mux_uart, const struct device *uart,
 	}
 
 	LOG_DBG("Attach DLCI %d (%s) to %s", dlci_address,
-		mux_uart->name, uart->name);
+		device_name_get(mux_uart), device_name_get(uart));
 
 	SYS_SLIST_FOR_EACH_NODE_SAFE(&uart_mux_data_devlist, sn, sns) {
 		struct uart_mux_dev_data *dev_data =
@@ -557,7 +557,7 @@ static int uart_mux_fifo_read(const struct device *dev, uint8_t *rx_data,
 	}
 
 	LOG_DBG("%s size %d rx_ringbuf space %u",
-		dev->name, size,
+		device_name_get(dev), size,
 		ring_buf_space_get(dev_data->rx_ringbuf));
 
 	len = ring_buf_get(dev_data->rx_ringbuf, rx_data, size);
@@ -801,7 +801,7 @@ int uart_mux_send(const struct device *uart, const uint8_t *buf, size_t size)
 		char tmp[sizeof("SEND muxed ") + 10];
 
 		snprintk(tmp, sizeof(tmp), "SEND muxed %s",
-			 dev_data->real_uart->uart->name);
+			 device_name_get(dev_data->real_uart->uart));
 		LOG_HEXDUMP_DBG(buf, size, tmp);
 	}
 
@@ -823,15 +823,15 @@ int uart_mux_recv(const struct device *mux, struct gsm_dlci *dlci,
 	struct uart_mux_dev_data *dev_data = mux->data;
 	size_t wrote = 0;
 
-	LOG_DBG("%s: dlci %p data %p len %zd", mux->name, (void *)dlci,
-		data, len);
+	LOG_DBG("%s: dlci %p data %p len %zd", device_name_get(mux),
+		(void *)dlci, data, len);
 
 	if (IS_ENABLED(CONFIG_UART_MUX_VERBOSE_DEBUG)) {
 		char tmp[sizeof("RECV _x") +
 			 sizeof(CONFIG_UART_MUX_DEVICE_NAME)];
 
 		snprintk(tmp, sizeof(tmp), "RECV %s",
-			 dev_data->dev->name);
+			 device_name_get(dev_data->dev));
 		LOG_HEXDUMP_DBG(data, len, tmp);
 	}
 

--- a/drivers/counter/counter_gecko_rtcc.c
+++ b/drivers/counter/counter_gecko_rtcc.c
@@ -300,7 +300,7 @@ static int counter_gecko_init(const struct device *dev)
 	/* Configure & enable module interrupts */
 	dev_cfg->irq_config();
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/counter/counter_sam_tc.c
+++ b/drivers/counter/counter_sam_tc.c
@@ -334,7 +334,7 @@ static int counter_sam_initialize(const struct device *dev)
 #endif
 	dev_cfg->irq_config_func(dev);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/counter/rtc_mcp7940n.c
+++ b/drivers/counter/rtc_mcp7940n.c
@@ -665,7 +665,7 @@ static int mcp7940n_init(const struct device *dev)
 	k_sem_init(&data->lock, 0, 1);
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C device %s is not ready", cfg->i2c.bus->name);
+		LOG_ERR("I2C device %s is not ready", device_name_get(cfg->i2c.bus));
 		rc = -ENODEV;
 		goto out;
 	}
@@ -693,7 +693,7 @@ static int mcp7940n_init(const struct device *dev)
 
 		if (!device_is_ready(cfg->int_gpios.port)) {
 			LOG_ERR("Port device %s is not ready",
-				cfg->int_gpios.port->name);
+				device_name_get(cfg->int_gpios.port));
 			rc = -ENODEV;
 			goto out;
 		}

--- a/drivers/dac/dac_dacx0508.c
+++ b/drivers/dac/dac_dacx0508.c
@@ -331,7 +331,7 @@ static int dacx0508_init(const struct device *dev)
 	int ret;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/dac/dac_mcp4728.c
+++ b/drivers/dac/dac_mcp4728.c
@@ -82,7 +82,7 @@ static int dac_mcp4728_init(const struct device *dev)
 	const struct mcp4728_config *config = dev->config;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("%s device not found", config->bus.bus->name);
+		LOG_ERR("%s device not found", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 	return 0;

--- a/drivers/dac/dac_sam.c
+++ b/drivers/dac/dac_sam.c
@@ -145,7 +145,7 @@ static int dac_sam_init(const struct device *dev)
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/display/display_st7735r.c
+++ b/drivers/display/display_st7735r.c
@@ -440,7 +440,7 @@ static int st7735r_init(const struct device *dev)
 	int ret;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/display/display_stm32_ltdc.c
+++ b/drivers/display/display_stm32_ltdc.c
@@ -350,7 +350,7 @@ static int stm32_ltdc_pm_action(const struct device *dev,
 	}
 
 	if (err < 0) {
-		LOG_ERR("%s: failed to set power mode", dev->name);
+		LOG_ERR("%s: failed to set power mode", device_name_get(dev));
 	}
 
 	return err;

--- a/drivers/display/ls0xx.c
+++ b/drivers/display/ls0xx.c
@@ -265,7 +265,7 @@ static int ls0xx_init(const struct device *dev)
 	const struct ls0xx_config *config = dev->config;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/display/ssd1306.c
+++ b/drivers/display/ssd1306.c
@@ -403,7 +403,7 @@ static int ssd1306_init(const struct device *dev)
 	LOG_DBG("");
 
 	if (!ssd1306_bus_ready(dev)) {
-		LOG_ERR("Bus device %s not ready!", config->bus.bus->name);
+		LOG_ERR("Bus device %s not ready!", device_name_get(config->bus.bus));
 		return -EINVAL;
 	}
 

--- a/drivers/display/ssd16xx.c
+++ b/drivers/display/ssd16xx.c
@@ -845,7 +845,7 @@ static int ssd16xx_init(const struct device *dev)
 	LOG_DBG("");
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/display/uc81xx.c
+++ b/drivers/display/uc81xx.c
@@ -619,7 +619,7 @@ static int uc81xx_init(const struct device *dev)
 	LOG_DBG("");
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/dma/dma_dw.c
+++ b/drivers/dma/dma_dw.c
@@ -34,14 +34,14 @@ static int dw_dma_init(const struct device *dev)
 	int ret = dw_dma_setup(dev);
 
 	if (ret != 0) {
-		LOG_ERR("failed to initialize DW DMA %s", dev->name);
+		LOG_ERR("failed to initialize DW DMA %s", device_name_get(dev));
 		goto out;
 	}
 
 	/* Configure interrupts */
 	dev_cfg->irq_config();
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 out:
 	return ret;

--- a/drivers/dma/dma_dw_common.c
+++ b/drivers/dma/dma_dw_common.c
@@ -141,14 +141,14 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 
 	if (chan_data->state != DW_DMA_IDLE && chan_data->state != DW_DMA_PREPARED) {
 		LOG_ERR("%s: dma %s channel %d must be inactive to "
-			"reconfigure, currently %d", __func__, dev->name,
+			"reconfigure, currently %d", __func__, device_name_get(dev),
 			channel, chan_data->state);
 		ret = -EBUSY;
 		goto out;
 	}
 
 	LOG_DBG("%s: dma %s channel %d config",
-	       __func__, dev->name, channel);
+	       __func__, device_name_get(dev), channel);
 
 	__ASSERT_NO_MSG(cfg->source_data_size == cfg->dest_data_size);
 	__ASSERT_NO_MSG(cfg->source_burst_length == cfg->dest_burst_length);
@@ -159,7 +159,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 	    cfg->source_data_size != 4 && cfg->source_data_size != 8 &&
 	    cfg->source_data_size != 16) {
 		LOG_ERR("%s: dma %s channel %d 'invalid source_data_size' value %d",
-			__func__, dev->name, channel, cfg->source_data_size);
+			__func__, device_name_get(dev), channel, cfg->source_data_size);
 		ret = -EINVAL;
 		goto out;
 	}
@@ -167,14 +167,14 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 	if (cfg->block_count > CONFIG_DMA_DW_LLI_POOL_SIZE) {
 		LOG_ERR("%s: dma %s channel %d scatter gather list larger than"
 			" descriptors in pool, consider increasing CONFIG_DMA_DW_LLI_POOL_SIZE",
-			__func__, dev->name, channel);
+			__func__, device_name_get(dev), channel);
 		ret = -EINVAL;
 		goto out;
 	}
 
 	/* burst_size = (2 ^ msize) */
 	msize = find_msb_set(cfg->source_burst_length) - 1;
-	LOG_DBG("%s: dma %s channel %d m_size=%d", __func__, dev->name, channel, msize);
+	LOG_DBG("%s: dma %s channel %d m_size=%d", __func__, device_name_get(dev), channel, msize);
 	__ASSERT_NO_MSG(msize < 5);
 
 	/* default channel config */
@@ -223,7 +223,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 			break;
 		default:
 			LOG_ERR("%s: dma %s channel %d invalid src width %d",
-			       __func__, dev->name, channel, cfg->source_data_size);
+			       __func__, device_name_get(dev), channel, cfg->source_data_size);
 			ret = -EINVAL;
 			goto out;
 		}
@@ -254,7 +254,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 			break;
 		default:
 			LOG_ERR("%s: dma %s channel %d invalid dest width %d",
-				__func__, dev->name, channel, cfg->dest_data_size);
+				__func__, device_name_get(dev), channel, cfg->dest_data_size);
 			ret = -EINVAL;
 			goto out;
 		}
@@ -315,7 +315,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 			break;
 		default:
 			LOG_ERR("%s: dma %s channel %d invalid direction %d",
-			       __func__, dev->name, channel, cfg->channel_direction);
+			       __func__, device_name_get(dev), channel, cfg->channel_direction);
 			ret = -EINVAL;
 			goto out;
 		}
@@ -330,7 +330,7 @@ int dw_dma_config(const struct device *dev, uint32_t channel,
 
 		if (block_cfg->block_size > DW_CTLH_BLOCK_TS_MASK) {
 			LOG_ERR("%s: dma %s channel %d block size too big %d",
-			       __func__, dev->name, channel, block_cfg->block_size);
+			       __func__, device_name_get(dev), channel, block_cfg->block_size);
 			ret = -EINVAL;
 			goto out;
 		}
@@ -430,7 +430,7 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	/* validate channel state */
 	if (chan_data->state != DW_DMA_PREPARED) {
 		LOG_ERR("%s: dma %s channel %d not ready ena 0x%x status 0x%x",
-		       __func__, dev->name, channel,
+		       __func__, device_name_get(dev), channel,
 		       dw_read(dev_cfg->base, DW_DMA_CHAN_EN),
 		       chan_data->state);
 		ret = -EBUSY;
@@ -440,7 +440,7 @@ int dw_dma_start(const struct device *dev, uint32_t channel)
 	/* is valid stream */
 	if (!chan_data->lli) {
 		LOG_ERR("%s: dma %s channel %d invalid stream",
-		       __func__, dev->name, channel);
+		       __func__, device_name_get(dev), channel);
 		ret = -EINVAL;
 		goto out;
 	}
@@ -519,7 +519,7 @@ int dw_dma_stop(const struct device *dev, uint32_t channel)
 #endif
 
 	LOG_DBG("%s: dma %s channel %d stop",
-		__func__, dev->name, channel);
+		__func__, device_name_get(dev), channel);
 
 	/* Validate the channel state */
 	if (chan_data->state != DW_DMA_ACTIVE &&
@@ -578,7 +578,7 @@ int dw_dma_resume(const struct device *dev, uint32_t channel)
 	}
 
 	LOG_DBG("%s: dma %s channel %d resume",
-		__func__, dev->name, channel);
+		__func__, device_name_get(dev), channel);
 
 	dw_write(dev_cfg->base, DW_CFG_LOW(channel), chan_data->cfg_lo);
 
@@ -611,7 +611,7 @@ int dw_dma_suspend(const struct device *dev, uint32_t channel)
 
 
 	LOG_DBG("%s: dma %s channel %d suspend",
-		__func__, dev->name, channel);
+		__func__, device_name_get(dev), channel);
 
 	dw_write(dev_cfg->base, DW_CFG_LOW(channel),
 		      chan_data->cfg_lo | DW_CFGL_SUSPEND);
@@ -645,12 +645,12 @@ int dw_dma_setup(const struct device *dev)
 
 	if (!i) {
 		LOG_ERR("%s: dma %s setup failed",
-			__func__, dev->name);
+			__func__, device_name_get(dev));
 		ret = -EIO;
 		goto out;
 	}
 
-	LOG_DBG("%s: dma %s", __func__, dev->name);
+	LOG_DBG("%s: dma %s", __func__, device_name_get(dev));
 
 	for (i = 0; i <  DW_MAX_CHAN; i++) {
 		dw_read(dev_cfg->base, DW_DMA_CHAN_EN);

--- a/drivers/dma/dma_intel_adsp_gpdma.c
+++ b/drivers/dma/dma_intel_adsp_gpdma.c
@@ -113,13 +113,13 @@ static int intel_adsp_gpdma_config(const struct device *dev, uint32_t channel,
 	switch (cfg->channel_direction) {
 	case MEMORY_TO_PERIPHERAL:
 		LOG_DBG("%s: dma %s configuring llp for destination %x",
-			__func__, dev->name, block_cfg->dest_address);
+			__func__, device_name_get(dev), block_cfg->dest_address);
 		intel_adsp_gpdma_llp_config(dev, channel,
 					    block_cfg->dest_address);
 		break;
 	case PERIPHERAL_TO_MEMORY:
 		LOG_DBG("%s: dma %s configuring llp for source %x",
-			__func__, dev->name, block_cfg->source_address);
+			__func__, device_name_get(dev), block_cfg->source_address);
 		intel_adsp_gpdma_llp_config(dev, channel,
 					    block_cfg->source_address);
 		break;
@@ -233,7 +233,7 @@ int intel_adsp_gpdma_init(const struct device *dev)
 	ret = intel_adsp_gpdma_enable(dev);
 	if (ret != 0) {
 		LOG_ERR("%s: dma %s failed to initialize", __func__,
-			dev->name);
+			device_name_get(dev));
 		goto out;
 	}
 #endif
@@ -255,7 +255,7 @@ int intel_adsp_gpdma_init(const struct device *dev)
 	ret = dw_dma_setup(dev);
 	if (ret != 0) {
 		LOG_ERR("%s: dma %s failed to initialize", __func__,
-			dev->name);
+			device_name_get(dev));
 		goto out;
 	}
 
@@ -263,7 +263,7 @@ int intel_adsp_gpdma_init(const struct device *dev)
 	dev_cfg->dw_cfg.irq_config();
 
 	LOG_INF("%s: dma %s initialized", __func__,
-		dev->name);
+		device_name_get(dev));
 
 out:
 	return 0;

--- a/drivers/dma/dma_iproc_pax_v1.c
+++ b/drivers/dma/dma_iproc_pax_v1.c
@@ -675,9 +675,9 @@ static int dma_iproc_pax_init(const struct device *dev)
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 #else
-	LOG_INF("%s PAX DMA rings in poll mode!\n", dev->name);
+	LOG_INF("%s PAX DMA rings in poll mode!\n", device_name_get(dev));
 #endif
-	LOG_INF("%s RM setup %d rings\n", dev->name, pd->used_rings);
+	LOG_INF("%s RM setup %d rings\n", device_name_get(dev), pd->used_rings);
 
 	return 0;
 }

--- a/drivers/dma/dma_iproc_pax_v2.c
+++ b/drivers/dma/dma_iproc_pax_v2.c
@@ -754,9 +754,9 @@ static int dma_iproc_pax_init(const struct device *dev)
 		    0);
 	irq_enable(DT_INST_IRQN(0));
 #else
-	LOG_INF("%s PAX DMA rings in poll mode!\n", dev->name);
+	LOG_INF("%s PAX DMA rings in poll mode!\n", device_name_get(dev));
 #endif
-	LOG_INF("%s RM setup %d rings\n", dev->name, pd->used_rings);
+	LOG_INF("%s RM setup %d rings\n", device_name_get(dev), pd->used_rings);
 
 	return 0;
 }

--- a/drivers/dma/dma_pl330.c
+++ b/drivers/dma/dma_pl330.c
@@ -561,7 +561,7 @@ static int dma_pl330_initialize(const struct device *dev)
 		k_mutex_init(&channel_cfg->ch_mutex);
 	}
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 	return 0;
 }
 

--- a/drivers/dma/dma_sam_xdmac.c
+++ b/drivers/dma/dma_sam_xdmac.c
@@ -351,7 +351,7 @@ static int sam_xdmac_initialize(const struct device *dev)
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/dma/dma_stm32.c
+++ b/drivers/dma/dma_stm32.c
@@ -322,7 +322,7 @@ DMA_STM32_EXPORT_API int dma_stm32_configure(const struct device *dev,
 	if ((config->channel_direction == MEMORY_TO_MEMORY) &&
 		(!dev_config->support_m2m)) {
 		LOG_ERR("Memcopy not supported for device %s",
-			dev->name);
+			device_name_get(dev));
 		return -ENOTSUP;
 	}
 #endif /* CONFIG_DMA_STM32_V1 */

--- a/drivers/espi/espi_emul.c
+++ b/drivers/espi/espi_emul.c
@@ -202,7 +202,7 @@ static int espi_emul_init(const struct device *dev)
 int espi_emul_register(const struct device *dev, struct espi_emul *emul)
 {
 	struct espi_emul_data *data = dev->data;
-	const char *name = emul->target->dev->name;
+	const char *name = device_name_get(emul->target->dev);
 
 	sys_slist_append(&data->emuls, &emul->node);
 

--- a/drivers/ethernet/dsa_ksz8xxx.c
+++ b/drivers/ethernet/dsa_ksz8xxx.c
@@ -677,7 +677,7 @@ int dsa_hw_init(struct ksz8xxx_data *pdev)
 #if defined(CONFIG_DSA_SPI)
 	if (!spi_is_ready(&pdev->spi)) {
 		LOG_ERR("SPI bus %s is not ready",
-			pdev->spi.bus->name);
+			device_name_get(pdev->spi.bus));
 		return -ENODEV;
 	}
 #endif

--- a/drivers/ethernet/eth_enc28j60.c
+++ b/drivers/ethernet/eth_enc28j60.c
@@ -735,13 +735,13 @@ static int eth_enc28j60_init(const struct device *dev)
 
 	/* SPI config */
 	if (!spi_is_ready(&config->spi)) {
-		LOG_ERR("SPI master port %s not ready", config->spi.bus->name);
+		LOG_ERR("SPI master port %s not ready", device_name_get(config->spi.bus));
 		return -EINVAL;
 	}
 
 	/* Initialize GPIO */
 	if (!device_is_ready(config->interrupt.port)) {
-		LOG_ERR("GPIO port %s not ready", config->interrupt.port->name);
+		LOG_ERR("GPIO port %s not ready", device_name_get(config->interrupt.port));
 		return -EINVAL;
 	}
 

--- a/drivers/ethernet/eth_enc424j600.c
+++ b/drivers/ethernet/eth_enc424j600.c
@@ -657,13 +657,13 @@ static int enc424j600_init(const struct device *dev)
 
 	/* SPI config */
 	if (!spi_is_ready(&config->spi)) {
-		LOG_ERR("SPI master port %s not ready", config->spi.bus->name);
+		LOG_ERR("SPI master port %s not ready", device_name_get(config->spi.bus));
 		return -EINVAL;
 	}
 
 	/* Initialize GPIO */
 	if (!device_is_ready(config->interrupt.port)) {
-		LOG_ERR("GPIO port %s not ready", config->interrupt.port->name);
+		LOG_ERR("GPIO port %s not ready", device_name_get(config->interrupt.port));
 		return -EINVAL;
 	}
 

--- a/drivers/ethernet/eth_gecko.c
+++ b/drivers/ethernet/eth_gecko.c
@@ -481,7 +481,7 @@ static int eth_init(const struct device *dev)
 	/* Connect and enable IRQ */
 	cfg->config_func();
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/ethernet/eth_mcux.c
+++ b/drivers/ethernet/eth_mcux.c
@@ -1145,7 +1145,7 @@ static int eth_init(const struct device *dev)
 	eth_mcux_init(dev);
 
 	LOG_DBG("%s MAC %02x:%02x:%02x:%02x:%02x:%02x",
-		dev->name,
+		device_name_get(dev),
 		context->mac_addr[0], context->mac_addr[1],
 		context->mac_addr[2], context->mac_addr[3],
 		context->mac_addr[4], context->mac_addr[5]);
@@ -1243,7 +1243,7 @@ static int eth_mcux_set_config(const struct device *dev,
 				     sizeof(context->mac_addr),
 				     NET_LINK_ETHERNET);
 		LOG_DBG("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x",
-			dev->name,
+			device_name_get(dev),
 			context->mac_addr[0], context->mac_addr[1],
 			context->mac_addr[2], context->mac_addr[3],
 			context->mac_addr[4], context->mac_addr[5]);

--- a/drivers/ethernet/eth_sam_gmac.c
+++ b/drivers/ethernet/eth_sam_gmac.c
@@ -2051,7 +2051,7 @@ static int eth_sam_gmac_set_config(const struct device *dev,
 		mac_addr_set(cfg->regs, 0, dev_data->mac_addr);
 
 		LOG_INF("%s MAC set to %02x:%02x:%02x:%02x:%02x:%02x",
-			dev->name,
+			device_name_get(dev),
 			dev_data->mac_addr[0], dev_data->mac_addr[1],
 			dev_data->mac_addr[2], dev_data->mac_addr[3],
 			dev_data->mac_addr[4], dev_data->mac_addr[5]);

--- a/drivers/ethernet/eth_w5500.c
+++ b/drivers/ethernet/eth_w5500.c
@@ -474,12 +474,12 @@ static int w5500_init(const struct device *dev)
 	struct w5500_runtime *ctx = dev->data;
 
 	if (!spi_is_ready(&config->spi)) {
-		LOG_ERR("SPI master port %s not ready", config->spi.bus->name);
+		LOG_ERR("SPI master port %s not ready", device_name_get(config->spi.bus));
 		return -EINVAL;
 	}
 
 	if (!device_is_ready(config->interrupt.port)) {
-		LOG_ERR("GPIO port %s not ready", config->interrupt.port->name);
+		LOG_ERR("GPIO port %s not ready", device_name_get(config->interrupt.port));
 		return -EINVAL;
 	}
 
@@ -500,7 +500,7 @@ static int w5500_init(const struct device *dev)
 
 	if (config->reset.port) {
 		if (!device_is_ready(config->reset.port)) {
-			LOG_ERR("GPIO port %s not ready", config->reset.port->name);
+			LOG_ERR("GPIO port %s not ready", device_name_get(config->reset.port));
 			return -EINVAL;
 		}
 		if (gpio_pin_configure_dt(&config->reset, GPIO_OUTPUT)) {

--- a/drivers/ethernet/phy_xlnx_gem.c
+++ b/drivers/ethernet/phy_xlnx_gem.c
@@ -219,7 +219,7 @@ static void phy_xlnx_gem_marvell_alaska_reset(const struct device *dev)
 	}
 	if (retries == 10) {
 		LOG_ERR("%s reset PHY address %hhu (Marvell Alaska) timed out",
-			dev->name, dev_data->phy_addr);
+			device_name_get(dev), dev_data->phy_addr);
 	}
 }
 
@@ -293,7 +293,7 @@ static void phy_xlnx_gem_marvell_alaska_cfg(const struct device *dev)
 		}
 		if (retries == 10) {
 			LOG_ERR("%s configure PHY address %hhu (Marvell Alaska) timed out",
-				dev->name, dev_data->phy_addr);
+				device_name_get(dev), dev_data->phy_addr);
 			return;
 		}
 
@@ -631,7 +631,7 @@ static void phy_xlnx_gem_ti_dp83822_reset(const struct device *dev)
 	}
 	if (retries == 10) {
 		LOG_ERR("%s reset PHY address %hhu (TI TLK105/DP83822) timed out",
-			dev->name, dev_data->phy_addr);
+			device_name_get(dev), dev_data->phy_addr);
 	}
 }
 
@@ -942,7 +942,7 @@ int phy_xlnx_gem_detect(const struct device *dev)
 		if (phy_id != 0x00000000 && phy_id != 0xFFFFFFFF) {
 			LOG_DBG("%s detected PHY at address %hhu: "
 				"ID 0x%08X",
-				dev->name,
+				device_name_get(dev),
 				phy_curr_addr, phy_id);
 
 			/*
@@ -956,7 +956,7 @@ int phy_xlnx_gem_detect(const struct device *dev)
 					(phy_xlnx_gem_supported_devs[list_iter].phy_id_mask
 					& phy_id)) {
 					LOG_DBG("%s identified supported PHY: %s",
-						dev->name,
+						device_name_get(dev),
 						phy_xlnx_gem_supported_devs[list_iter].identifier);
 
 					/*
@@ -975,6 +975,6 @@ int phy_xlnx_gem_detect(const struct device *dev)
 		}
 	}
 
-	LOG_ERR("%s PHY detection failed", dev->name);
+	LOG_ERR("%s PHY detection failed", device_name_get(dev));
 	return -EIO;
 }

--- a/drivers/flash/flash_gecko.c
+++ b/drivers/flash/flash_gecko.c
@@ -202,7 +202,7 @@ static int flash_gecko_init(const struct device *dev)
 	/* Lock the MSC module. */
 	MSC->LOCK = 0;
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -255,11 +255,11 @@ static int cmd_test(const struct shell *shell, size_t argc, char *argv[])
 	return result;
 }
 
-static void device_name_get(size_t idx, struct shell_static_entry *entry);
+static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry);
 
-SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, cmd_device_name_get);
 
-static void device_name_get(size_t idx, struct shell_static_entry *entry)
+static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 

--- a/drivers/flash/flash_shell.c
+++ b/drivers/flash/flash_shell.c
@@ -263,7 +263,7 @@ static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 
-	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->syntax = (dev != NULL) ? device_name_get(dev) : NULL;
 	entry->handler = NULL;
 	entry->help  = NULL;
 	entry->subcmd = &dsub_device_name;

--- a/drivers/flash/flash_stm32_ospi.c
+++ b/drivers/flash/flash_stm32_ospi.c
@@ -1520,7 +1520,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 		LOG_DBG("Unexpected flash size: %u", flash_size);
 	}
 
-	LOG_DBG("%s: %u MiBy flash", dev->name, (uint32_t)(flash_size >> 20));
+	LOG_DBG("%s: %u MiBy flash", device_name_get(dev), (uint32_t)(flash_size >> 20));
 
 	/* Copy over the erase types, preserving their order.  (The
 	 * Sector Map Parameter table references them by index.)
@@ -1668,7 +1668,7 @@ static int flash_stm32_ospi_init(const struct device *dev)
 	static DMA_HandleTypeDef hdma;
 
 	if (!device_is_ready(dev_data->dma.dev)) {
-		LOG_ERR("%s device not ready", dev_data->dma.dev->name);
+		LOG_ERR("%s device not ready", device_name_get(dev_data->dma.dev));
 		return -ENODEV;
 	}
 
@@ -1868,7 +1868,7 @@ static int flash_stm32_ospi_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	LOG_DBG("%s: SFDP v %u.%u AP %x with %u PH", dev->name,
+	LOG_DBG("%s: SFDP v %u.%u AP %x with %u PH", device_name_get(dev),
 		hp->rev_major, hp->rev_minor, hp->access, 1 + hp->nph);
 
 	const struct jesd216_param_header *php = hp->phdr;

--- a/drivers/flash/flash_stm32_qspi.c
+++ b/drivers/flash/flash_stm32_qspi.c
@@ -936,7 +936,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 		LOG_ERR("Unexpected flash size: %u", flash_size);
 	}
 
-	LOG_INF("%s: %u MiBy flash", dev->name, (uint32_t)(flash_size >> 20));
+	LOG_INF("%s: %u MiBy flash", device_name_get(dev), (uint32_t)(flash_size >> 20));
 
 	/* Copy over the erase types, preserving their order.  (The
 	 * Sector Map Parameter table references them by index.)
@@ -1085,7 +1085,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 	static DMA_HandleTypeDef hdma;
 
 	if (!device_is_ready(dev_data->dma.dev)) {
-		LOG_ERR("%s device not ready", dev_data->dma.dev->name);
+		LOG_ERR("%s device not ready", device_name_get(dev_data->dma.dev));
 		return -ENODEV;
 	}
 
@@ -1199,7 +1199,7 @@ static int flash_stm32_qspi_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	LOG_INF("%s: SFDP v %u.%u AP %x with %u PH", dev->name,
+	LOG_INF("%s: SFDP v %u.%u AP %x with %u PH", device_name_get(dev),
 		hp->rev_major, hp->rev_minor, hp->access, 1 + hp->nph);
 
 	const struct jesd216_param_header *php = hp->phdr;

--- a/drivers/flash/spi_flash_at45.c
+++ b/drivers/flash/spi_flash_at45.c
@@ -543,7 +543,7 @@ static int spi_flash_at45_init(const struct device *dev)
 	int err;
 
 	if (!spi_is_ready(&dev_config->bus)) {
-		LOG_ERR("SPI bus %s not ready", dev_config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(dev_config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/flash/spi_nor.c
+++ b/drivers/flash/spi_nor.c
@@ -819,7 +819,7 @@ static int spi_nor_process_bfp(const struct device *dev,
 	struct jesd216_erase_type *etp = data->erase_types;
 	const size_t flash_size = jesd216_bfp_density(bfp) / 8U;
 
-	LOG_INF("%s: %u MiBy flash", dev->name, (uint32_t)(flash_size >> 20));
+	LOG_INF("%s: %u MiBy flash", device_name_get(dev), (uint32_t)(flash_size >> 20));
 
 	/* Copy over the erase types, preserving their order.  (The
 	 * Sector Map Parameter table references them by index.)
@@ -890,7 +890,7 @@ static int spi_nor_process_sfdp(const struct device *dev)
 		return -EINVAL;
 	}
 
-	LOG_INF("%s: SFDP v %u.%u AP %x with %u PH", dev->name,
+	LOG_INF("%s: SFDP v %u.%u AP %x with %u PH", device_name_get(dev),
 		hp->rev_major, hp->rev_minor, hp->access, 1 + hp->nph);
 
 	const struct jesd216_param_header *php = hp->phdr;

--- a/drivers/fpga/fpga_shell.c
+++ b/drivers/fpga/fpga_shell.c
@@ -31,7 +31,7 @@ static int cmd_on(const struct shell *sh, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(sh, "%s: turning on", dev->name);
+	shell_print(sh, "%s: turning on", device_name_get(dev));
 
 	err = fpga_on(dev);
 	if (err) {
@@ -51,7 +51,7 @@ static int cmd_off(const struct shell *sh, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(sh, "%s: turning off", dev->name);
+	shell_print(sh, "%s: turning off", device_name_get(dev));
 
 	err = fpga_off(dev);
 	if (err) {
@@ -71,7 +71,7 @@ static int cmd_reset(const struct shell *sh, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(sh, "%s: resetting FPGA", dev->name);
+	shell_print(sh, "%s: resetting FPGA", device_name_get(dev));
 
 	err = fpga_reset(dev);
 	if (err) {
@@ -91,7 +91,7 @@ static int cmd_load(const struct shell *sh, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(sh, "%s: loading bitstream", dev->name);
+	shell_print(sh, "%s: loading bitstream", device_name_get(dev));
 
 	fpga_load(dev, (uint32_t *)strtol(argv[2], NULL, 0),
 		  (uint32_t)atoi(argv[3]));
@@ -109,7 +109,7 @@ static int cmd_get_status(const struct shell *sh, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(sh, "%s status: %d", dev->name, fpga_get_status(dev));
+	shell_print(sh, "%s status: %d", device_name_get(dev), fpga_get_status(dev));
 
 	return err;
 }

--- a/drivers/gpio/gpio_cy8c95xx.c
+++ b/drivers/gpio/gpio_cy8c95xx.c
@@ -238,7 +238,7 @@ static int cy8c95xx_init(const struct device *dev)
 	k_sem_take(drv_data->lock, K_FOREVER);
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("%s is not ready", cfg->i2c.bus->name);
+		LOG_ERR("%s is not ready", device_name_get(cfg->i2c.bus));
 		rc = -ENODEV;
 		goto out;
 	}
@@ -262,9 +262,9 @@ static int cy8c95xx_init(const struct device *dev)
 	rc = write_pin_state(cfg, &drv_data->pin_state);
 out:
 	if (rc != 0) {
-		LOG_ERR("%s init failed: %d", dev->name, rc);
+		LOG_ERR("%s init failed: %d", device_name_get(dev), rc);
 	} else {
-		LOG_DBG("%s init ok", dev->name);
+		LOG_DBG("%s init ok", device_name_get(dev));
 	}
 	k_sem_give(drv_data->lock);
 	return rc;

--- a/drivers/gpio/gpio_fxl6408.c
+++ b/drivers/gpio/gpio_fxl6408.c
@@ -392,7 +392,7 @@ int gpio_fxl6408_init(const struct device *dev)
 	const struct gpio_fxl6408_config *const config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("%s is not ready", config->i2c.bus->name);
+		LOG_ERR("%s is not ready", device_name_get(config->i2c.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_lmp90xxx.c
+++ b/drivers/gpio/gpio_lmp90xxx.c
@@ -141,7 +141,7 @@ static int gpio_lmp90xxx_init(const struct device *dev)
 
 	if (!device_is_ready(config->parent)) {
 		LOG_ERR("parent LMP90xxx device '%s' not ready",
-			config->parent->name);
+			device_name_get(config->parent));
 		return -EINVAL;
 	}
 

--- a/drivers/gpio/gpio_mcp230xx.c
+++ b/drivers/gpio/gpio_mcp230xx.c
@@ -68,7 +68,7 @@ static int mcp230xx_bus_is_ready(const struct device *dev)
 	const struct mcp23xxx_config *config = dev->config;
 
 	if (!device_is_ready(config->bus.i2c.bus)) {
-		LOG_ERR("I2C bus %s not ready", config->bus.i2c.bus->name);
+		LOG_ERR("I2C bus %s not ready", device_name_get(config->bus.i2c.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_mcp23s17.c
+++ b/drivers/gpio/gpio_mcp23s17.c
@@ -360,7 +360,7 @@ static int mcp23s17_init(const struct device *dev)
 	struct mcp23s17_drv_data *drv_data = dev->data;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_mcp23sxx.c
+++ b/drivers/gpio/gpio_mcp23sxx.c
@@ -103,7 +103,7 @@ static int mcp23sxx_bus_is_ready(const struct device *dev)
 	const struct mcp23xxx_config *config = dev->config;
 
 	if (!spi_is_ready(&config->bus.spi)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.spi.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.spi.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_nct38xx.c
+++ b/drivers/gpio/gpio_nct38xx.c
@@ -65,7 +65,7 @@ static int nct38xx_gpio_init(const struct device *dev)
 
 	/* Check I2C is ready  */
 	if (!device_is_ready(config->i2c_dev.bus)) {
-		LOG_ERR("%s device not ready", config->i2c_dev.bus->name);
+		LOG_ERR("%s device not ready", device_name_get(config->i2c_dev.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_nct38xx_alert.c
+++ b/drivers/gpio/gpio_nct38xx_alert.c
@@ -95,7 +95,8 @@ static int nct38xx_alert_init(const struct device *dev)
 	/* Check NCT38XX devices are all ready. */
 	for (int i = 0; i < config->nct38xx_num; i++) {
 		if (!device_is_ready(config->nct38xx_dev[i])) {
-			LOG_ERR("%s device not ready", config->nct38xx_dev[i]->name);
+			LOG_ERR("%s device not ready",
+				device_name_get(config->nct38xx_dev[i]));
 			return -ENODEV;
 		}
 	}
@@ -104,7 +105,7 @@ static int nct38xx_alert_init(const struct device *dev)
 	k_work_init(&data->alert_worker, nct38xx_alert_worker);
 
 	if (!device_is_ready(config->irq_gpio.port)) {
-		LOG_ERR("%s device not ready", config->irq_gpio.port->name);
+		LOG_ERR("%s device not ready", device_name_get(config->irq_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_nct38xx_port.c
+++ b/drivers/gpio/gpio_nct38xx_port.c
@@ -445,7 +445,7 @@ static int gpio_nct38xx_port_init(const struct device *dev)
 	struct gpio_nct38xx_port_data *const data = dev->data;
 
 	if (!device_is_ready(config->nct38xx_dev)) {
-		LOG_ERR("%s is not ready", config->nct38xx_dev->name);
+		LOG_ERR("%s is not ready", device_name_get(config->nct38xx_dev));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_pca953x.c
+++ b/drivers/gpio/gpio_pca953x.c
@@ -442,9 +442,9 @@ static int gpio_pca953x_init(const struct device *dev)
 	}
 out:
 	if (rc) {
-		LOG_ERR("%s init failed: %d", dev->name, rc);
+		LOG_ERR("%s init failed: %d", device_name_get(dev), rc);
 	} else {
-		LOG_INF("%s init ok", dev->name);
+		LOG_INF("%s init ok", device_name_get(dev));
 	}
 	return rc;
 }

--- a/drivers/gpio/gpio_pcal6408a.c
+++ b/drivers/gpio/gpio_pcal6408a.c
@@ -78,7 +78,7 @@ static int pcal6408a_pins_cfg_apply(const struct device *dev,
 				   pins_cfg.pull_ups_selected);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to select pull-up/pull-down resistors: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -86,14 +86,14 @@ static int pcal6408a_pins_cfg_apply(const struct device *dev,
 				   pins_cfg.pulls_enabled);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to enable pull-up/pull-down resistors: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
 	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_OUTPUT_PORT, pins_cfg.outputs_high);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to set outputs: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -101,7 +101,7 @@ static int pcal6408a_pins_cfg_apply(const struct device *dev,
 				   pins_cfg.configured_as_inputs);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to configure pins: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -187,7 +187,7 @@ static int pcal6408a_process_input(const struct device *dev,
 	rc = i2c_reg_read_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INTERRUPT_STATUS, &int_sources);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to read interrupt sources: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -195,7 +195,7 @@ static int pcal6408a_process_input(const struct device *dev,
 	rc = i2c_reg_read_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INPUT_PORT, &input_port);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to read input port: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -314,7 +314,7 @@ static int pcal6408a_port_set_raw(const struct device *dev,
 	k_sem_give(&drv_data->lock);
 
 	if (rc != 0) {
-		LOG_ERR("%s: failed to write output port: %d", dev->name, rc);
+		LOG_ERR("%s: failed to write output port: %d", device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -355,14 +355,14 @@ static int pcal6408a_triggers_apply(const struct device *dev,
 	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INPUT_LATCH, ~(triggers.masked));
 	if (rc != 0) {
 		LOG_ERR("%s: failed to configure input latch: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
 	rc = i2c_reg_write_byte_dt(&drv_cfg->i2c, PCAL6408A_REG_INTERRUPT_MASK, triggers.masked);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to configure interrupt mask: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -449,7 +449,7 @@ static int pcal6408a_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(drv_cfg->i2c.bus)) {
-		LOG_ERR("%s is not ready", drv_cfg->i2c.bus->name);
+		LOG_ERR("%s is not ready", device_name_get(drv_cfg->i2c.bus));
 		return -ENODEV;
 	}
 
@@ -460,7 +460,7 @@ static int pcal6408a_init(const struct device *dev)
 	if (drv_cfg->reset_gpio_dev) {
 		if (!device_is_ready(drv_cfg->reset_gpio_dev)) {
 			LOG_ERR("%s is not ready",
-				drv_cfg->reset_gpio_dev->name);
+				device_name_get(drv_cfg->reset_gpio_dev));
 			return -ENODEV;
 		}
 
@@ -470,7 +470,7 @@ static int pcal6408a_init(const struct device *dev)
 						GPIO_OUTPUT_ACTIVE);
 		if (rc != 0) {
 			LOG_ERR("%s: failed to configure RESET line: %d",
-				dev->name, rc);
+				device_name_get(dev), rc);
 			return -EIO;
 		}
 
@@ -481,7 +481,7 @@ static int pcal6408a_init(const struct device *dev)
 				  drv_cfg->reset_gpio_pin, 0);
 		if (rc != 0) {
 			LOG_ERR("%s: failed to deactivate RESET line: %d",
-				dev->name, rc);
+				device_name_get(dev), rc);
 			return -EIO;
 		}
 
@@ -500,7 +500,7 @@ static int pcal6408a_init(const struct device *dev)
 						   reset_state[i][1]);
 			if (rc != 0) {
 				LOG_ERR("%s: failed to reset register %02x: %d",
-					dev->name, reset_state[i][0], rc);
+					device_name_get(dev), reset_state[i][0], rc);
 				return -EIO;
 			}
 		}
@@ -519,7 +519,7 @@ static int pcal6408a_init(const struct device *dev)
 				  &drv_data->input_port_last);
 	if (rc != 0) {
 		LOG_ERR("%s: failed to initially read input port: %d",
-			dev->name, rc);
+			device_name_get(dev), rc);
 		return -EIO;
 	}
 
@@ -535,7 +535,7 @@ static int pcal6408a_init(const struct device *dev)
 	if (drv_cfg->int_gpio_dev) {
 		if (!device_is_ready(drv_cfg->int_gpio_dev)) {
 			LOG_ERR("%s is not ready",
-				drv_cfg->int_gpio_dev->name);
+				device_name_get(drv_cfg->int_gpio_dev));
 			return -ENODEV;
 		}
 
@@ -544,7 +544,7 @@ static int pcal6408a_init(const struct device *dev)
 					drv_cfg->int_gpio_flags | GPIO_INPUT);
 		if (rc != 0) {
 			LOG_ERR("%s: failed to configure INT line: %d",
-				dev->name, rc);
+				device_name_get(dev), rc);
 			return -EIO;
 		}
 
@@ -553,7 +553,7 @@ static int pcal6408a_init(const struct device *dev)
 						  GPIO_INT_EDGE_TO_ACTIVE);
 		if (rc != 0) {
 			LOG_ERR("%s: failed to configure INT interrupt: %d",
-				dev->name, rc);
+				device_name_get(dev), rc);
 			return -EIO;
 		}
 
@@ -564,7 +564,7 @@ static int pcal6408a_init(const struct device *dev)
 				       &drv_data->int_gpio_cb);
 		if (rc != 0) {
 			LOG_ERR("%s: failed to add INT callback: %d",
-				dev->name, rc);
+				device_name_get(dev), rc);
 			return -EIO;
 		}
 	}

--- a/drivers/gpio/gpio_sn74hc595.c
+++ b/drivers/gpio/gpio_sn74hc595.c
@@ -166,12 +166,12 @@ static int gpio_sn74hc595_init(const struct device *dev)
 	struct gpio_sn74hc595_drv_data *drv_data = dev->data;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(config->reset_gpio.port)) {
-		LOG_ERR("GPIO port %s not ready", config->reset_gpio.port->name);
+		LOG_ERR("GPIO port %s not ready", device_name_get(config->reset_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/gpio/gpio_sx1509b.c
+++ b/drivers/gpio/gpio_sx1509b.c
@@ -579,7 +579,7 @@ static int sx1509b_init(const struct device *dev)
 	rc = i2c_reg_write_byte_dt(&cfg->bus, SX1509B_REG_RESET,
 				   SX1509B_REG_RESET_MAGIC0);
 	if (rc != 0) {
-		LOG_ERR("%s: reset m0 failed: %d\n", dev->name, rc);
+		LOG_ERR("%s: reset m0 failed: %d\n", device_name_get(dev), rc);
 		goto out;
 	}
 	rc = i2c_reg_write_byte_dt(&cfg->bus, SX1509B_REG_RESET,
@@ -621,9 +621,9 @@ static int sx1509b_init(const struct device *dev)
 
 out:
 	if (rc != 0) {
-		LOG_ERR("%s init failed: %d", dev->name, rc);
+		LOG_ERR("%s init failed: %d", device_name_get(dev), rc);
 	} else {
-		LOG_INF("%s init ok", dev->name);
+		LOG_INF("%s init ok", device_name_get(dev));
 	}
 	k_sem_give(&drv_data->lock);
 	return rc;

--- a/drivers/i2c/i2c_emul.c
+++ b/drivers/i2c/i2c_emul.c
@@ -121,7 +121,7 @@ static int i2c_emul_init(const struct device *dev)
 int i2c_emul_register(const struct device *dev, struct i2c_emul *emul)
 {
 	struct i2c_emul_data *data = dev->data;
-	const char *name = emul->target->dev->name;
+	const char *name = device_name_get(emul->target->dev);
 
 	sys_slist_append(&data->emuls, &emul->node);
 

--- a/drivers/i2c/i2c_mchp_xec.c
+++ b/drivers/i2c/i2c_mchp_xec.c
@@ -298,7 +298,7 @@ static bool check_lines_high(const struct device *dev)
 	gpio_port_value_t sda = 0, scl = 0;
 
 	if (gpio_port_get_raw(config->sda_gpio.port, &sda)) {
-		LOG_ERR("gpio_port_get_raw for %s SDA failed", dev->name);
+		LOG_ERR("gpio_port_get_raw for %s SDA failed", device_name_get(dev));
 		return false;
 	}
 
@@ -308,7 +308,7 @@ static bool check_lines_high(const struct device *dev)
 	} else {
 		if (gpio_port_get_raw(config->scl_gpio.port, &scl)) {
 			LOG_ERR("gpio_port_get_raw for %s SCL failed",
-				dev->name);
+				device_name_get(dev));
 			return false;
 		}
 	}
@@ -367,7 +367,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 		if (ret) {
 			data->timeout_seen = 1;
 			LOG_ERR("%s: %s wait_completion failure %d\n",
-				__func__, dev->name, ret);
+				__func__, device_name_get(dev), ret);
 			return ret;
 		}
 		data->timeout_seen = 0;
@@ -376,7 +376,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 		 * the CLK. The master needs to end that transaction
 		 * gracefully by sending a STOP on the bus.
 		 */
-		LOG_DBG("%s: %s Force Stop", __func__, dev->name);
+		LOG_DBG("%s: %s Force Stop", __func__, device_name_get(dev));
 		MCHP_I2C_SMB_CTRL_WO(ba) =
 					MCHP_I2C_SMB_CTRL_PIN |
 					MCHP_I2C_SMB_CTRL_ESO |
@@ -401,7 +401,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 		while (check_lines_high(dev) == false) {
 			if (i2c_timer >= WAIT_LINE_HIGH_COUNT) {
 				LOG_DBG("%s: %s not high",
-					__func__, dev->name);
+					__func__, device_name_get(dev));
 				data->error_seen = 1;
 				return -EBUSY;
 			}
@@ -411,7 +411,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 
 		if (data->error_seen) {
 			LOG_DBG("%s: Recovering %s previously in error",
-				__func__, dev->name);
+				__func__, device_name_get(dev));
 			data->error_seen = 0;
 			recover_from_error(dev);
 		}
@@ -421,7 +421,7 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 		if (ret) {
 			data->error_seen = 1;
 			LOG_DBG("%s: %s wait_bus_free failure %d",
-				__func__, dev->name, ret);
+				__func__, device_name_get(dev), ret);
 			return ret;
 		}
 
@@ -440,13 +440,13 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 
 		case -EIO:
 			LOG_WRN("%s: No Addr ACK from Slave 0x%x on %s",
-				__func__, addr >> 1, dev->name);
+				__func__, addr >> 1, device_name_get(dev));
 			return ret;
 
 		default:
 			data->error_seen = 1;
 			LOG_ERR("%s: %s wait_comp error %d for addr send",
-				__func__, dev->name, ret);
+				__func__, device_name_get(dev), ret);
 			return ret;
 		}
 	}
@@ -462,19 +462,19 @@ static int i2c_xec_poll_write(const struct device *dev, struct i2c_msg msg,
 
 		case -EIO:
 			LOG_ERR("%s: No Data ACK from Slave 0x%x on %s",
-				__func__, addr >> 1, dev->name);
+				__func__, addr >> 1, device_name_get(dev));
 			return ret;
 
 		case -ETIMEDOUT:
 			data->timeout_seen = 1;
 			LOG_ERR("%s: Clk stretch Timeout - Slave 0x%x on %s",
-				__func__, addr >> 1, dev->name);
+				__func__, addr >> 1, device_name_get(dev));
 			return ret;
 
 		default:
 			data->error_seen = 1;
 			LOG_ERR("%s: %s wait_completion error %d for data send",
-				__func__, dev->name, ret);
+				__func__, device_name_get(dev), ret);
 			return ret;
 		}
 	}
@@ -512,7 +512,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 		if (ret) {
 			data->timeout_seen = 1;
 			LOG_ERR("%s: %s wait_completion failure %d\n",
-				__func__, dev->name, ret);
+				__func__, device_name_get(dev), ret);
 			return ret;
 		}
 		data->timeout_seen = 0;
@@ -521,7 +521,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 		 * the CLK. The master needs to end that transaction
 		 * gracefully by sending a STOP on the bus.
 		 */
-		LOG_DBG("%s: %s Force Stop", __func__, dev->name);
+		LOG_DBG("%s: %s Force Stop", __func__, device_name_get(dev));
 		MCHP_I2C_SMB_CTRL_WO(ba) =
 					MCHP_I2C_SMB_CTRL_PIN |
 					MCHP_I2C_SMB_CTRL_ESO |
@@ -536,7 +536,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 		while (check_lines_high(dev) == false) {
 			if (i2c_timer >= WAIT_LINE_HIGH_COUNT) {
 				LOG_DBG("%s: %s not high",
-					__func__, dev->name);
+					__func__, device_name_get(dev));
 				data->error_seen = 1;
 				return -EBUSY;
 			}
@@ -546,7 +546,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 
 		if (data->error_seen) {
 			LOG_DBG("%s: Recovering %s previously in error",
-				__func__, dev->name);
+				__func__, device_name_get(dev));
 			data->error_seen = 0;
 			recover_from_error(dev);
 		}
@@ -556,7 +556,7 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 		if (ret) {
 			data->error_seen = 1;
 			LOG_DBG("%s: %s wait_bus_free failure %d",
-				__func__, dev->name, ret);
+				__func__, device_name_get(dev), ret);
 			return ret;
 		}
 	}
@@ -578,20 +578,20 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 	case -EIO:
 		data->error_seen = 1;
 		LOG_WRN("%s: No Addr ACK from Slave 0x%x on %s",
-			__func__, addr >> 1, dev->name);
+			__func__, addr >> 1, device_name_get(dev));
 		return ret;
 
 	case -ETIMEDOUT:
 		data->previously_in_read = 1;
 		data->timeout_seen = 1;
 		LOG_ERR("%s: Clk stretch Timeout - Slave 0x%x on %s",
-			__func__, addr >> 1, dev->name);
+			__func__, addr >> 1, device_name_get(dev));
 		return ret;
 
 	default:
 		data->error_seen = 1;
 		LOG_ERR("%s: %s wait_completion error %d for address send",
-			__func__, dev->name, ret);
+			__func__, device_name_get(dev), ret);
 		return ret;
 	}
 
@@ -611,20 +611,20 @@ static int i2c_xec_poll_read(const struct device *dev, struct i2c_msg msg,
 
 		case -EIO:
 			LOG_ERR("%s: No Data ACK from Slave 0x%x on %s",
-				__func__, addr >> 1, dev->name);
+				__func__, addr >> 1, device_name_get(dev));
 			return ret;
 
 		case -ETIMEDOUT:
 			data->previously_in_read = 1;
 			data->timeout_seen = 1;
 			LOG_ERR("%s: Clk stretch Timeout - Slave 0x%x on %s",
-				__func__, addr >> 1, dev->name);
+				__func__, addr >> 1, device_name_get(dev));
 			return ret;
 
 		default:
 			data->error_seen = 1;
 			LOG_ERR("%s: %s wait_completion error %d for data send",
-				__func__, dev->name, ret);
+				__func__, device_name_get(dev), ret);
 			return ret;
 		}
 
@@ -657,7 +657,7 @@ static int i2c_xec_transfer(const struct device *dev, struct i2c_msg *msgs,
 	struct i2c_xec_data *data = dev->data;
 
 	if (data->slave_attached) {
-		LOG_ERR("%s Device is registered as slave", dev->name);
+		LOG_ERR("%s Device is registered as slave", device_name_get(dev));
 		return -EBUSY;
 	}
 #endif
@@ -667,13 +667,13 @@ static int i2c_xec_transfer(const struct device *dev, struct i2c_msg *msgs,
 		if ((msgs[i].flags & I2C_MSG_RW_MASK) == I2C_MSG_WRITE) {
 			ret = i2c_xec_poll_write(dev, msgs[i], addr);
 			if (ret) {
-				LOG_ERR("%s Write error: %d", dev->name, ret);
+				LOG_ERR("%s Write error: %d", device_name_get(dev), ret);
 				return ret;
 			}
 		} else {
 			ret = i2c_xec_poll_read(dev, msgs[i], addr);
 			if (ret) {
-				LOG_ERR("%s Read error: %d", dev->name, ret);
+				LOG_ERR("%s Read error: %d", device_name_get(dev), ret);
 				return ret;
 			}
 		}
@@ -850,12 +850,12 @@ static int i2c_xec_init(const struct device *dev)
 	data->slave_attached = false;
 
 	if (!device_is_ready(cfg->sda_gpio.port)) {
-		LOG_ERR("%s GPIO device is not ready for SDA GPIO", dev->name);
+		LOG_ERR("%s GPIO device is not ready for SDA GPIO", device_name_get(dev));
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(cfg->scl_gpio.port)) {
-		LOG_ERR("%s GPIO device is not ready for SCL GPIO", dev->name);
+		LOG_ERR("%s GPIO device is not ready for SCL GPIO", device_name_get(dev));
 		return -ENODEV;
 	}
 
@@ -864,7 +864,7 @@ static int i2c_xec_init(const struct device *dev)
 				I2C_MODE_CONTROLLER |
 				I2C_SPEED_SET(I2C_SPEED_STANDARD));
 	if (ret) {
-		LOG_ERR("%s configure failed %d", dev->name, ret);
+		LOG_ERR("%s configure failed %d", device_name_get(dev), ret);
 		return ret;
 	}
 

--- a/drivers/i2c/i2c_npcx_controller.c
+++ b/drivers/i2c/i2c_npcx_controller.c
@@ -1041,7 +1041,7 @@ static int i2c_ctrl_init(const struct device *dev)
 	/* Turn on device clock first and get source clock freq. */
 	if (clock_control_on(clk_dev,
 		(clock_control_subsys_t *) &config->clk_cfg) != 0) {
-		LOG_ERR("Turn on %s clock fail.", dev->name);
+		LOG_ERR("Turn on %s clock fail.", device_name_get(dev));
 		return -EIO;
 	}
 
@@ -1052,7 +1052,7 @@ static int i2c_ctrl_init(const struct device *dev)
 	 */
 	if (clock_control_get_rate(clk_dev, (clock_control_subsys_t *)
 			&config->clk_cfg, &i2c_rate) != 0) {
-		LOG_ERR("Get %s clock rate error.", dev->name);
+		LOG_ERR("Get %s clock rate error.", device_name_get(dev));
 		return -EIO;
 	}
 
@@ -1061,7 +1061,7 @@ static int i2c_ctrl_init(const struct device *dev)
 	} else if (i2c_rate == 20000000) {
 		data->ptr_speed_confs = npcx_20m_speed_confs;
 	} else {
-		LOG_ERR("Unsupported apb2/3 freq for %s.", dev->name);
+		LOG_ERR("Unsupported apb2/3 freq for %s.", device_name_get(dev));
 		return -EIO;
 	}
 

--- a/drivers/i2c/i2c_nrfx_twi.c
+++ b/drivers/i2c/i2c_nrfx_twi.c
@@ -226,7 +226,7 @@ static int init_twi(const struct device *dev)
 					  event_handler, dev_data);
 	if (result != NRFX_SUCCESS) {
 		LOG_ERR("Failed to initialize device: %s",
-			    dev->name);
+			    device_name_get(dev));
 		return -EBUSY;
 	}
 

--- a/drivers/i2c/i2c_nrfx_twim.c
+++ b/drivers/i2c/i2c_nrfx_twim.c
@@ -90,7 +90,7 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 					"Adjust the zephyr,concat-buf-size "
 					"property in the \"%s\" node.",
 					msg_buf_used, msgs[i].len,
-					concat_buf_size, dev->name);
+					concat_buf_size, device_name_get(dev));
 				ret = -ENOSPC;
 				break;
 			}
@@ -112,7 +112,7 @@ static int i2c_nrfx_twim_transfer(const struct device *dev,
 				LOG_ERR("Cannot copy flash buffer of size: %u. "
 					"Adjust the zephyr,flash-buf-max-size "
 					"property in the \"%s\" node.",
-					msgs[i].len, dev->name);
+					msgs[i].len, device_name_get(dev));
 				ret = -EINVAL;
 				break;
 			}
@@ -363,7 +363,7 @@ static int i2c_nrfx_twim_init(const struct device *dev)
 
 	if (nrfx_twim_init(&dev_config->twim, &dev_config->twim_config,
 			   event_handler, dev_data) != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize device: %s", dev->name);
+		LOG_ERR("Failed to initialize device: %s", device_name_get(dev));
 		return -EIO;
 	}
 

--- a/drivers/i2c/i2c_sam0.c
+++ b/drivers/i2c/i2c_sam0.c
@@ -210,7 +210,7 @@ static void i2c_sam0_dma_write_done(const struct device *dma_dev, void *arg,
 	}
 
 	if (error_code < 0) {
-		LOG_ERR("DMA write error on %s: %d", dev->name, error_code);
+		LOG_ERR("DMA write error on %s: %d", device_name_get(dev), error_code);
 		i2c->INTENCLR.reg = SERCOM_I2CM_INTENCLR_MASK;
 		irq_unlock(key);
 
@@ -268,14 +268,14 @@ static bool i2c_sam0_dma_write_start(const struct device *dev)
 	retval = dma_config(cfg->dma_dev, cfg->dma_channel, &dma_cfg);
 	if (retval != 0) {
 		LOG_ERR("Write DMA configure on %s failed: %d",
-			dev->name, retval);
+			device_name_get(dev), retval);
 		return false;
 	}
 
 	retval = dma_start(cfg->dma_dev, cfg->dma_channel);
 	if (retval != 0) {
 		LOG_ERR("Write DMA start on %s failed: %d",
-			dev->name, retval);
+			device_name_get(dev), retval);
 		return false;
 	}
 
@@ -301,7 +301,7 @@ static void i2c_sam0_dma_read_done(const struct device *dma_dev, void *arg,
 	}
 
 	if (error_code < 0) {
-		LOG_ERR("DMA read error on %s: %d", dev->name, error_code);
+		LOG_ERR("DMA read error on %s: %d", device_name_get(dev), error_code);
 		i2c->INTENCLR.reg = SERCOM_I2CM_INTENCLR_MASK;
 		irq_unlock(key);
 
@@ -361,14 +361,14 @@ static bool i2c_sam0_dma_read_start(const struct device *dev)
 	retval = dma_config(cfg->dma_dev, cfg->dma_channel, &dma_cfg);
 	if (retval != 0) {
 		LOG_ERR("Read DMA configure on %s failed: %d",
-			dev->name, retval);
+			device_name_get(dev), retval);
 		return false;
 	}
 
 	retval = dma_start(cfg->dma_dev, cfg->dma_channel);
 	if (retval != 0) {
 		LOG_ERR("Read DMA start on %s failed: %d",
-			dev->name, retval);
+			device_name_get(dev), retval);
 		return false;
 	}
 
@@ -489,13 +489,13 @@ static int i2c_sam0_transfer(const struct device *dev, struct i2c_msg *msgs,
 
 			if (data->msg.status & SERCOM_I2CM_STATUS_ARBLOST) {
 				LOG_DBG("Arbitration lost on %s",
-					dev->name);
+					device_name_get(dev));
 				ret = -EAGAIN;
 				goto unlock;
 			}
 
 			LOG_ERR("Transaction error on %s: %08X",
-				dev->name, data->msg.status);
+				device_name_get(dev), data->msg.status);
 			ret = -EIO;
 			goto unlock;
 		}
@@ -560,7 +560,7 @@ static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 		}
 
 		LOG_DBG("Setting %s to standard mode with divisor %u",
-			dev->name, baud);
+			device_name_get(dev), baud);
 
 		i2c->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(baud);
 		break;
@@ -577,7 +577,7 @@ static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 		}
 
 		LOG_DBG("Setting %s to fast mode with divisor %u",
-			dev->name, baud);
+			device_name_get(dev), baud);
 
 		i2c->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(baud);
 		break;
@@ -608,7 +608,7 @@ static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 		}
 
 		LOG_DBG("Setting %s to fast mode plus with divisors %u/%u",
-			dev->name, baud_high, baud_low);
+			device_name_get(dev), baud_high, baud_low);
 
 		i2c->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(baud_high) |
 				SERCOM_I2CM_BAUD_BAUDLOW(baud_low);
@@ -640,7 +640,7 @@ static int i2c_sam0_set_apply_bitrate(const struct device *dev,
 
 #ifdef SERCOM_I2CM_BAUD_HSBAUD
 		LOG_DBG("Setting %s to high speed with divisors %u/%u",
-			dev->name, baud_high, baud_low);
+			device_name_get(dev), baud_high, baud_low);
 
 		/*
 		 * 48 is just from the app notes, but the datasheet says

--- a/drivers/i2c/i2c_sam4l_twim.c
+++ b/drivers/i2c/i2c_sam4l_twim.c
@@ -573,14 +573,14 @@ static int i2c_sam_twim_initialize(const struct device *dev)
 
 	ret = i2c_sam_twim_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
 	if (ret < 0) {
-		LOG_ERR("Failed to initialize %s device", dev->name);
+		LOG_ERR("Failed to initialize %s device", device_name_get(dev));
 		return ret;
 	}
 
 	/* Enable module's IRQ */
 	irq_enable(cfg->irq_id);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/i2c/i2c_sam_twi.c
+++ b/drivers/i2c/i2c_sam_twi.c
@@ -334,14 +334,14 @@ static int i2c_sam_twi_initialize(const struct device *dev)
 
 	ret = i2c_sam_twi_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
 	if (ret < 0) {
-		LOG_ERR("Failed to initialize %s device", dev->name);
+		LOG_ERR("Failed to initialize %s device", device_name_get(dev));
 		return ret;
 	}
 
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/i2c/i2c_sam_twihs.c
+++ b/drivers/i2c/i2c_sam_twihs.c
@@ -305,14 +305,14 @@ static int i2c_sam_twihs_initialize(const struct device *dev)
 
 	ret = i2c_sam_twihs_configure(dev, I2C_MODE_CONTROLLER | bitrate_cfg);
 	if (ret < 0) {
-		LOG_ERR("Failed to initialize %s device", dev->name);
+		LOG_ERR("Failed to initialize %s device", device_name_get(dev));
 		return ret;
 	}
 
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -270,7 +270,7 @@ static int cmd_i2c_read(const struct shell *shell_ctx, size_t argc, char **argv)
 	return ret;
 }
 
-static void device_name_get(size_t idx, struct shell_static_entry *entry)
+static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 
@@ -280,7 +280,7 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 	entry->subcmd = NULL;
 }
 
-SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, cmd_device_name_get);
 
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_i2c_cmds,
 	SHELL_CMD_ARG(scan, &dsub_device_name,

--- a/drivers/i2c/i2c_shell.c
+++ b/drivers/i2c/i2c_shell.c
@@ -274,7 +274,7 @@ static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 
-	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->syntax = (dev != NULL) ? device_name_get(dev) : NULL;
 	entry->handler = NULL;
 	entry->help = NULL;
 	entry->subcmd = NULL;

--- a/drivers/i2c/i2c_tca954x.c
+++ b/drivers/i2c/i2c_tca954x.c
@@ -106,7 +106,7 @@ static int tca954x_root_init(const struct device *dev)
 	const struct tca954x_root_config *config = dev->config;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus %s not ready", config->i2c.bus->name);
+		LOG_ERR("I2C bus %s not ready", device_name_get(config->i2c.bus));
 		return -ENODEV;
 	}
 
@@ -114,12 +114,12 @@ static int tca954x_root_init(const struct device *dev)
 	if (config->reset_gpios.port) {
 		if (!device_is_ready(config->reset_gpios.port)) {
 			LOG_ERR("%s is not ready",
-				config->reset_gpios.port->name);
+				device_name_get(config->reset_gpios.port));
 			return -ENODEV;
 		}
 
 		if (gpio_pin_configure_dt(&config->reset_gpios, GPIO_OUTPUT)) {
-			LOG_ERR("%s: failed to configure RESET line", dev->name);
+			LOG_ERR("%s: failed to configure RESET line", device_name_get(dev));
 			return -EIO;
 		}
 
@@ -139,12 +139,13 @@ static int tca954x_channel_init(const struct device *dev)
 			get_root_config_from_channel(dev);
 
 	if (!device_is_ready(chan_cfg->root)) {
-		LOG_ERR("I2C mux root %s not ready", chan_cfg->root->name);
+		LOG_ERR("I2C mux root %s not ready",
+			device_name_get(chan_cfg->root));
 		return -ENODEV;
 	}
 
 	if (chan_cfg->chan_mask >= BIT(root_cfg->nchans)) {
-		LOG_ERR("Wrong DTS address provided for %s", dev->name);
+		LOG_ERR("Wrong DTS address provided for %s", device_name_get(dev));
 		return -EINVAL;
 	}
 

--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -693,15 +693,17 @@ static int i2s_stm32_initialize(const struct device *dev)
 
 	/* Get the binding to the DMA device */
 	if (!device_is_ready(dev_data->tx.dev_dma)) {
-		LOG_ERR("%s device not ready", dev_data->tx.dev_dma->name);
+		LOG_ERR("%s device not ready",
+			device_name_get(dev_data->tx.dev_dma));
 		return -ENODEV;
 	}
 	if (!device_is_ready(dev_data->rx.dev_dma)) {
-		LOG_ERR("%s device not ready", dev_data->rx.dev_dma->name);
+		LOG_ERR("%s device not ready",
+			device_name_get(dev_data->rx.dev_dma));
 		return -ENODEV;
 	}
 
-	LOG_INF("%s inited", dev->name);
+	LOG_INF("%s inited", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/i2s/i2s_mcux_flexcomm.c
+++ b/drivers/i2s/i2s_mcux_flexcomm.c
@@ -858,14 +858,16 @@ static int i2s_mcux_init(const struct device *dev)
 
 	if (data->tx.dev_dma != NULL) {
 		if (!device_is_ready(data->tx.dev_dma)) {
-			LOG_ERR("%s device not ready", data->tx.dev_dma->name);
+			LOG_ERR("%s device not ready",
+				device_name_get(data->tx.dev_dma));
 			return -ENODEV;
 		}
 	}
 
 	if (data->rx.dev_dma != NULL) {
 		if (!device_is_ready(data->rx.dev_dma)) {
-			LOG_ERR("%s device not ready", data->rx.dev_dma->name);
+			LOG_ERR("%s device not ready",
+				device_name_get(data->rx.dev_dma));
 			return -ENODEV;
 		}
 	}
@@ -873,7 +875,7 @@ static int i2s_mcux_init(const struct device *dev)
 	data->tx.state = I2S_STATE_NOT_READY;
 	data->rx.state = I2S_STATE_NOT_READY;
 
-	LOG_INF("Device %s inited", dev->name);
+	LOG_INF("Device %s inited", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/i2s/i2s_mcux_sai.c
+++ b/drivers/i2s/i2s_mcux_sai.c
@@ -1221,7 +1221,7 @@ static int i2s_mcux_initialize(const struct device *dev)
 	SAI_SetMasterClockConfig(base, &mclkConfig);
 #endif
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/i2s/i2s_sam_ssc.c
+++ b/drivers/i2s/i2s_sam_ssc.c
@@ -963,7 +963,8 @@ static int i2s_sam_initialize(const struct device *dev)
 		   CONFIG_I2S_SAM_SSC_TX_BLOCK_COUNT);
 
 	if (!device_is_ready(dev_cfg->dev_dma)) {
-		LOG_ERR("%s device not ready", dev_cfg->dev_dma->name);
+		LOG_ERR("%s device not ready",
+			device_name_get(dev_cfg->dev_dma));
 		return -ENODEV;
 	}
 
@@ -982,7 +983,7 @@ static int i2s_sam_initialize(const struct device *dev)
 	/* Enable module's IRQ */
 	irq_enable(dev_cfg->irq_id);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/ieee802154/ieee802154_cc1200.c
+++ b/drivers/ieee802154/ieee802154_cc1200.c
@@ -739,13 +739,13 @@ static int cc1200_init(const struct device *dev)
 	/* Configure GPIOs */
 	if (!device_is_ready(config->interrupt.port)) {
 		LOG_ERR("GPIO port %s is not ready",
-			config->interrupt.port->name);
+			device_name_get(config->interrupt.port));
 		return -ENODEV;
 	}
 	gpio_pin_configure_dt(&config->interrupt, GPIO_INPUT);
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI bus %s is not ready", config->bus.bus->name);
+		LOG_ERR("SPI bus %s is not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/ieee802154/ieee802154_cc2520.c
+++ b/drivers/ieee802154/ieee802154_cc2520.c
@@ -990,7 +990,7 @@ static int cc2520_init(const struct device *dev)
 	}
 
 	if (!spi_is_ready(&cfg->bus)) {
-		LOG_ERR("SPI bus %s not ready", cfg->bus.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(cfg->bus.bus));
 		return -EIO;
 	}
 

--- a/drivers/ieee802154/ieee802154_rf2xx.c
+++ b/drivers/ieee802154/ieee802154_rf2xx.c
@@ -938,7 +938,7 @@ static inline int configure_gpios(const struct device *dev)
 			return -ENODEV;
 		}
 		LOG_INF("Optional instance of %s device activated",
-			conf->dig2_gpio.port->name);
+			device_name_get(conf->dig2_gpio.port));
 		gpio_pin_configure_dt(&conf->dig2_gpio, GPIO_INPUT);
 		gpio_pin_interrupt_configure_dt(&conf->dig2_gpio,
 						GPIO_INT_EDGE_TO_ACTIVE);
@@ -951,7 +951,7 @@ static inline int configure_gpios(const struct device *dev)
 			return -ENODEV;
 		}
 		LOG_INF("Optional instance of %s device activated",
-			conf->clkm_gpio.port->name);
+			device_name_get(conf->clkm_gpio.port));
 		gpio_pin_configure_dt(&conf->clkm_gpio, GPIO_INPUT);
 	}
 
@@ -964,7 +964,7 @@ static inline int configure_spi(const struct device *dev)
 
 	if (!spi_is_ready(&conf->spi)) {
 		LOG_ERR("SPI bus %s is not ready",
-			conf->spi.bus->name);
+			device_name_get(conf->spi.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/kscan/kscan_cst816s.c
+++ b/drivers/kscan/kscan_cst816s.c
@@ -241,7 +241,7 @@ static int cst816s_chip_init(const struct device *dev)
 	cst816s_chip_reset(dev);
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C bus %s not ready", cfg->i2c.bus->name);
+		LOG_ERR("I2C bus %s not ready", device_name_get(cfg->i2c.bus));
 		return -ENODEV;
 	}
 	ret = i2c_reg_read_byte_dt(&cfg->i2c, CST816S_REG_CHIP_ID, &chip_id);
@@ -278,7 +278,7 @@ static int cst816s_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->int_gpio.port)) {
-		LOG_ERR("GPIO port %s not ready", config->int_gpio.port->name);
+		LOG_ERR("GPIO port %s not ready", device_name_get(config->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/kscan/kscan_sdl.c
+++ b/drivers/kscan/kscan_sdl.c
@@ -62,7 +62,7 @@ static int sdl_configure(const struct device *dev, kscan_callback_t callback)
 		LOG_ERR("Callback is null");
 		return -EINVAL;
 	}
-	LOG_DBG("%s: set callback", dev->name);
+	LOG_DBG("%s: set callback", device_name_get(dev));
 
 	data->callback = callback;
 
@@ -73,7 +73,7 @@ static int sdl_enable_callback(const struct device *dev)
 {
 	struct sdl_data *data = dev->data;
 
-	LOG_DBG("%s: enable cb", dev->name);
+	LOG_DBG("%s: enable cb", device_name_get(dev));
 	data->enabled = true;
 	return 0;
 }
@@ -82,7 +82,7 @@ static int sdl_disable_callback(const struct device *dev)
 {
 	struct sdl_data *data = dev->data;
 
-	LOG_DBG("%s: disable cb", dev->name);
+	LOG_DBG("%s: disable cb", device_name_get(dev));
 	data->enabled = false;
 	return 0;
 }
@@ -93,7 +93,7 @@ static int sdl_init(const struct device *dev)
 
 	data->dev = dev;
 
-	LOG_INF("Init '%s' device", dev->name);
+	LOG_INF("Init '%s' device", device_name_get(dev));
 	SDL_AddEventWatch(sdl_filter, data);
 
 	return 0;

--- a/drivers/led/led_gpio.c
+++ b/drivers/led/led_gpio.c
@@ -55,7 +55,7 @@ static int led_gpio_init(const struct device *dev)
 	int err = 0;
 
 	if (!config->num_leds) {
-		LOG_ERR("%s: no LEDs found (DT child nodes missing)", dev->name);
+		LOG_ERR("%s: no LEDs found (DT child nodes missing)", device_name_get(dev));
 		err = -ENODEV;
 	}
 
@@ -69,7 +69,7 @@ static int led_gpio_init(const struct device *dev)
 				LOG_ERR("Cannot configure GPIO (err %d)", err);
 			}
 		} else {
-			LOG_ERR("%s: GPIO device not ready", dev->name);
+			LOG_ERR("%s: GPIO device not ready", device_name_get(dev));
 			err = -ENODEV;
 		}
 	}

--- a/drivers/led/led_pwm.c
+++ b/drivers/led/led_pwm.c
@@ -85,7 +85,7 @@ static int led_pwm_init(const struct device *dev)
 
 	if (!config->num_leds) {
 		LOG_ERR("%s: no LEDs found (DT child nodes missing)",
-			dev->name);
+			device_name_get(dev));
 		return -ENODEV;
 	}
 
@@ -93,7 +93,7 @@ static int led_pwm_init(const struct device *dev)
 		const struct pwm_dt_spec *led = &config->led[i];
 
 		if (!device_is_ready(led->dev)) {
-			LOG_ERR("%s: pwm device not ready", led->dev->name);
+			LOG_ERR("%s: pwm device not ready", device_name_get(led->dev));
 			return -ENODEV;
 		}
 	}

--- a/drivers/led/led_shell.c
+++ b/drivers/led/led_shell.c
@@ -53,7 +53,7 @@ static int cmd_off(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(shell, "%s: turning off LED %d", dev->name, led);
+	shell_print(shell, "%s: turning off LED %d", device_name_get(dev), led);
 
 	err = led_off(dev, led);
 	if (err) {
@@ -74,7 +74,7 @@ static int cmd_on(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(shell, "%s: turning on LED %d", dev->name, led);
+	shell_print(shell, "%s: turning on LED %d", device_name_get(dev), led);
 
 	err = led_on(dev, led);
 	if (err) {
@@ -97,7 +97,7 @@ static int cmd_get_info(const struct shell *shell, size_t argc, char **argv)
 		return err;
 	}
 
-	shell_print(shell, "%s: getting LED %d information", dev->name, led);
+	shell_print(shell, "%s: getting LED %d information", device_name_get(dev), led);
 
 	err = led_get_info(dev, led, &info);
 	if (err) {
@@ -148,7 +148,7 @@ static int cmd_set_brightness(const struct shell *shell,
 	}
 
 	shell_print(shell, "%s: setting LED %d brightness to %lu",
-		    dev->name, led, value);
+		    device_name_get(dev), led, value);
 
 	err = led_set_brightness(dev, led, (uint8_t) value);
 	if (err) {
@@ -200,7 +200,7 @@ static int cmd_set_color(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "%s: setting LED %d color to %d",
-		      dev->name, led, color[0]);
+		      device_name_get(dev), led, color[0]);
 	for (i = 1; i < num_colors; i++) {
 		shell_fprintf(shell, SHELL_NORMAL, ":%d", color[i]);
 	}
@@ -240,7 +240,7 @@ static int cmd_set_channel(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	shell_print(shell, "%s: setting channel %d to %lu",
-		    dev->name, channel, value);
+		    device_name_get(dev), channel, value);
 
 	err = led_set_channel(dev, channel, (uint8_t) value);
 	if (err) {
@@ -293,7 +293,7 @@ cmd_write_channels(const struct shell *shell, size_t argc, char **argv)
 	}
 
 	shell_fprintf(shell, SHELL_NORMAL, "%s: writing from channel %d: %d",
-		      dev->name, start_channel, value[0]);
+		      device_name_get(dev), start_channel, value[0]);
 	for (i = 1; i < num_channels; i++) {
 		shell_fprintf(shell, SHELL_NORMAL, " %d", value[i]);
 	}

--- a/drivers/led/lp503x.c
+++ b/drivers/led/lp503x.c
@@ -179,7 +179,7 @@ static int lp503x_init(const struct device *dev)
 	}
 	if (config->num_leds > LP503X_MAX_LEDS) {
 		LOG_ERR("%s: invalid number of LEDs %d (max %d)",
-			dev->name, config->num_leds, LP503X_MAX_LEDS);
+			device_name_get(dev), config->num_leds, LP503X_MAX_LEDS);
 		return -EINVAL;
 	}
 

--- a/drivers/led/tlc59108.c
+++ b/drivers/led/tlc59108.c
@@ -189,7 +189,7 @@ static int tlc59108_led_init(const struct device *dev)
 	struct led_data *dev_data = &data->dev_data;
 
 	if (!device_is_ready(config->i2c.bus)) {
-		LOG_ERR("I2C bus device %s is not ready", config->i2c.bus->name);
+		LOG_ERR("I2C bus device %s is not ready", device_name_get(config->i2c.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/led_strip/lpd880x.c
+++ b/drivers/led_strip/lpd880x.c
@@ -130,7 +130,7 @@ static int lpd880x_strip_init(const struct device *dev)
 	const struct lpd880x_config *config = dev->config;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_ERR("SPI device %s not ready", config->bus.bus->name);
+		LOG_ERR("SPI device %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/led_strip/tlc5971.c
+++ b/drivers/led_strip/tlc5971.c
@@ -293,17 +293,18 @@ static int tlc5971_init(const struct device *dev)
 	struct tlc5971_data *data = dev->data;
 
 	if (!spi_is_ready(&cfg->bus)) {
-		LOG_ERR("%s: SPI device %s not ready", dev->name, cfg->bus.bus->name);
+		LOG_ERR("%s: SPI device %s not ready", device_name_get(dev),
+			device_name_get(cfg->bus.bus));
 		return -ENODEV;
 	}
 
 	if ((cfg->num_pixels % TLC5971_PIXELS_PER_DEVICE) != 0) {
-		LOG_ERR("%s: chain length must be multiple of 4", dev->name);
+		LOG_ERR("%s: chain length must be multiple of 4", device_name_get(dev));
 		return -EINVAL;
 	}
 
 	if (cfg->num_colors != TLC5971_NUMBER_OF_COLORS) {
-		LOG_ERR("%s: the tlc5971 only supports %i colors", dev->name,
+		LOG_ERR("%s: the tlc5971 only supports %i colors", device_name_get(dev),
 			TLC5971_NUMBER_OF_COLORS);
 		return -EINVAL;
 	}
@@ -315,7 +316,7 @@ static int tlc5971_init(const struct device *dev)
 		case LED_COLOR_ID_BLUE:
 			break;
 		default:
-			LOG_ERR("%s: invalid color mapping", dev->name);
+			LOG_ERR("%s: invalid color mapping", device_name_get(dev));
 			return -EINVAL;
 		}
 	}

--- a/drivers/led_strip/ws2812_gpio.c
+++ b/drivers/led_strip/ws2812_gpio.c
@@ -231,7 +231,7 @@ static const uint8_t ws2812_gpio_##idx##_color_mapping[] =		\
 			default:					\
 				LOG_ERR("%s: invalid channel to color mapping." \
 					" Check the color-mapping DT property",	\
-					dev->name);			\
+					device_name_get(dev));			\
 				return -EINVAL;				\
 			}						\
 		}							\

--- a/drivers/led_strip/ws2812_spi.c
+++ b/drivers/led_strip/ws2812_spi.c
@@ -168,7 +168,7 @@ static int ws2812_spi_init(const struct device *dev)
 	uint8_t i;
 
 	if (!spi_is_ready(&cfg->bus)) {
-		LOG_ERR("SPI device %s not ready", cfg->bus.bus->name);
+		LOG_ERR("SPI device %s not ready", device_name_get(cfg->bus.bus));
 		return -ENODEV;
 	}
 
@@ -182,7 +182,7 @@ static int ws2812_spi_init(const struct device *dev)
 		default:
 			LOG_ERR("%s: invalid channel to color mapping."
 				"Check the color-mapping DT property",
-				dev->name);
+				device_name_get(dev));
 			return -EINVAL;
 		}
 	}

--- a/drivers/lora/sx127x.c
+++ b/drivers/lora/sx127x.c
@@ -364,7 +364,7 @@ void SX127xIoIrqInit(DioIrqHandler **irqHandlers)
 
 		if (!device_is_ready(sx127x_dios[i].port)) {
 			LOG_ERR("GPIO port %s not ready",
-				sx127x_dios[i].port->name);
+				device_name_get(sx127x_dios[i].port));
 			return;
 		}
 

--- a/drivers/lora/sx12xx_common.c
+++ b/drivers/lora/sx12xx_common.c
@@ -44,13 +44,13 @@ int __sx12xx_configure_pin(const struct gpio_dt_spec *gpio, gpio_flags_t flags)
 	int err;
 
 	if (!device_is_ready(gpio->port)) {
-		LOG_ERR("GPIO device not ready %s", gpio->port->name);
+		LOG_ERR("GPIO device not ready %s", device_name_get(gpio->port));
 		return -ENODEV;
 	}
 
 	err = gpio_pin_configure_dt(gpio, flags);
 	if (err) {
-		LOG_ERR("Cannot configure gpio %s %d: %d", gpio->port->name,
+		LOG_ERR("Cannot configure gpio %s %d: %d", device_name_get(gpio->port),
 			gpio->pin, err);
 		return err;
 	}

--- a/drivers/mdio/mdio_sam.c
+++ b/drivers/mdio/mdio_sam.c
@@ -65,7 +65,7 @@ static int mdio_transfer(const struct device *dev, uint8_t prtad, uint8_t devad,
 	/* Wait until done */
 	while (!(cfg->regs->GMAC_NSR & GMAC_NSR_IDLE)) {
 		if (timeout-- == 0U) {
-			LOG_ERR("transfer timedout %s", dev->name);
+			LOG_ERR("transfer timedout %s", device_name_get(dev));
 			k_sem_give(&data->sem);
 
 			return -ETIMEDOUT;

--- a/drivers/mdio/mdio_shell.c
+++ b/drivers/mdio/mdio_shell.c
@@ -30,7 +30,7 @@ static int cmd_mdio_scan(const struct shell *sh, size_t argc, char **argv)
 
 	dev = DEVICE_DT_GET(MDIO_NODE_ID);
 	if (!device_is_ready(dev)) {
-		shell_error(sh, "MDIO: Device driver %s is not ready.", dev->name);
+		shell_error(sh, "MDIO: Device driver %s is not ready.", device_name_get(dev));
 
 		return -ENODEV;
 	}
@@ -59,7 +59,7 @@ static int cmd_mdio_scan(const struct shell *sh, size_t argc, char **argv)
 
 	mdio_bus_disable(dev);
 
-	shell_print(sh, "%u devices found on %s", cnt, dev->name);
+	shell_print(sh, "%u devices found on %s", cnt, device_name_get(dev));
 
 	return 0;
 }
@@ -74,7 +74,7 @@ static int cmd_mdio_write(const struct shell *sh, size_t argc, char **argv)
 
 	dev = DEVICE_DT_GET(MDIO_NODE_ID);
 	if (!device_is_ready(dev)) {
-		shell_error(sh, "MDIO: Device driver %s is not ready.", dev->name);
+		shell_error(sh, "MDIO: Device driver %s is not ready.", device_name_get(dev));
 
 		return -ENODEV;
 	}
@@ -86,7 +86,7 @@ static int cmd_mdio_write(const struct shell *sh, size_t argc, char **argv)
 	mdio_bus_enable(dev);
 
 	if (mdio_write(dev, port_addr, dev_addr, data) < 0) {
-		shell_error(sh, "Failed to write to device: %s", dev->name);
+		shell_error(sh, "Failed to write to device: %s", device_name_get(dev));
 		mdio_bus_disable(dev);
 
 		return -EIO;
@@ -107,7 +107,7 @@ static int cmd_mdio_read(const struct shell *sh, size_t argc, char **argv)
 
 	dev = DEVICE_DT_GET(MDIO_NODE_ID);
 	if (!device_is_ready(dev)) {
-		shell_error(sh, "MDIO: Device driver %s is not ready.", dev->name);
+		shell_error(sh, "MDIO: Device driver %s is not ready.", device_name_get(dev));
 
 		return -ENODEV;
 	}
@@ -118,7 +118,7 @@ static int cmd_mdio_read(const struct shell *sh, size_t argc, char **argv)
 	mdio_bus_enable(dev);
 
 	if (mdio_read(dev, port_addr, dev_addr, &data) < 0) {
-		shell_error(sh, "Failed to read from device: %s", dev->name);
+		shell_error(sh, "Failed to read from device: %s", device_name_get(dev));
 		mdio_bus_disable(dev);
 
 		return -EIO;

--- a/drivers/memc/memc_mcux_flexspi.c
+++ b/drivers/memc/memc_mcux_flexspi.c
@@ -139,7 +139,7 @@ static int memc_flexspi_init(const struct device *dev)
 
 	/* we should not configure the device we are running on */
 	if (memc_flexspi_is_running_xip(dev)) {
-		LOG_DBG("XIP active on %s, skipping init", dev->name);
+		LOG_DBG("XIP active on %s, skipping init", device_name_get(dev));
 		return 0;
 	}
 

--- a/drivers/misc/ft8xx/ft8xx_drv.c
+++ b/drivers/misc/ft8xx/ft8xx_drv.c
@@ -56,7 +56,7 @@ int ft8xx_drv_init(void)
 	int ret;
 
 	if (!spi_is_ready(&spi)) {
-		LOG_ERR("SPI bus %s not ready", spi.bus->name);
+		LOG_ERR("SPI bus %s not ready", device_name_get(spi.bus));
 		return -ENODEV;
 	}
 
@@ -64,7 +64,7 @@ int ft8xx_drv_init(void)
 	 * If not, use polling mode.
 	 */
 	if (!device_is_ready(irq_gpio.port)) {
-		LOG_ERR("GPIO device %s is not ready", irq_gpio.port->name);
+		LOG_ERR("GPIO device %s is not ready", device_name_get(irq_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/modem/gsm_ppp.c
+++ b/drivers/modem/gsm_ppp.c
@@ -874,7 +874,7 @@ attaching:
 				gsm->state = GSM_PPP_STATE_ERROR;
 			} else {
 				LOG_INF("AT channel %d connected to %s",
-					DLCI_AT, gsm->at_dev->name);
+					DLCI_AT, device_name_get(gsm->at_dev));
 			}
 		}
 
@@ -955,7 +955,7 @@ static void mux_setup_next(struct gsm_modem *gsm)
 static void mux_attach_cb(const struct device *mux, int dlci_address,
 			  bool connected, void *user_data)
 {
-	LOG_DBG("DLCI %d to %s %s", dlci_address, mux->name,
+	LOG_DBG("DLCI %d to %s %s", dlci_address, device_name_get(mux),
 		connected ? "connected" : "disconnected");
 
 	if (connected) {
@@ -973,7 +973,7 @@ static int mux_attach(const struct device *mux, const struct device *uart,
 				  user_data);
 	if (ret < 0) {
 		LOG_ERR("Cannot attach DLCI %d (%s) to %s (%d)", dlci_address,
-			mux->name, uart->name, ret);
+			device_name_get(mux), device_name_get(uart), ret);
 		return ret;
 	}
 
@@ -1068,7 +1068,7 @@ static void mux_setup(struct k_work *work)
 		}
 
 		LOG_INF("PPP channel %d connected to %s",
-			DLCI_PPP, gsm->ppp_dev->name);
+			DLCI_PPP, device_name_get(gsm->ppp_dev));
 
 		k_work_init_delayable(&gsm->gsm_configure_work, gsm_finalize_connection);
 		(void)gsm_work_reschedule(&gsm->gsm_configure_work, K_NO_WAIT);

--- a/drivers/modem/hl7800.c
+++ b/drivers/modem/hl7800.c
@@ -633,7 +633,7 @@ static int read_pin(int default_state, const struct gpio_dt_spec *spec)
 
 	if (state < 0) {
 		LOG_ERR("Unable to read port: %s pin: %d status: %d",
-			spec->port->name, spec->pin, state);
+			device_name_get(spec->port), spec->pin, state);
 		state = default_state;
 	}
 
@@ -6107,7 +6107,7 @@ static int hl7800_init(const struct device *dev)
 	for (i = 0; i < MAX_MDM_CONTROL_PINS; i++) {
 		if (!device_is_ready(hl7800_cfg.gpio[i].port)) {
 			LOG_ERR("gpio port (%s) not ready!",
-				hl7800_cfg.gpio[i].port->name);
+				device_name_get(hl7800_cfg.gpio[i].port));
 			return -ENODEV;
 		}
 	}

--- a/drivers/modem/modem_iface_uart_async.c
+++ b/drivers/modem/modem_iface_uart_async.c
@@ -126,7 +126,7 @@ int modem_iface_uart_init_dev(struct modem_iface *iface,
 	 * race conditions with modem_iface_uart_isr.
 	 */
 	if (iface->dev) {
-		LOG_WRN("Device %s already inited", iface->dev->name);
+		LOG_WRN("Device %s already inited", device_name_get(iface->dev));
 		uart_rx_disable(iface->dev);
 	}
 

--- a/drivers/modem/modem_iface_uart_interrupt.c
+++ b/drivers/modem/modem_iface_uart_interrupt.c
@@ -130,7 +130,7 @@ static bool mux_is_active(struct modem_iface *iface)
 	bool active = false;
 
 #if defined(CONFIG_UART_MUX_DEVICE_NAME)
-	active = strncmp(CONFIG_UART_MUX_DEVICE_NAME, iface->dev->name,
+	active = strncmp(CONFIG_UART_MUX_DEVICE_NAME, device_name_get(iface->dev),
 			 sizeof(CONFIG_UART_MUX_DEVICE_NAME) - 1) == 0;
 #endif /* CONFIG_UART_MUX_DEVICE_NAME */
 

--- a/drivers/modem/modem_receiver.c
+++ b/drivers/modem/modem_receiver.c
@@ -227,7 +227,7 @@ int mdm_receiver_register(struct mdm_receiver_context *ctx,
 
 	if (!device_is_ready(uart_dev)) {
 		LOG_ERR("Device is not ready: %s",
-			uart_dev ? uart_dev->name : "<null>");
+			uart_dev ? device_name_get(uart_dev) : "<null>");
 		return -ENODEV;
 	}
 

--- a/drivers/modem/modem_shell.c
+++ b/drivers/modem/modem_shell.c
@@ -33,14 +33,14 @@ struct modem_shell_user_data {
 #define ms_send(ctx_, buf_, size_) \
 			(ctx_->iface.write(&ctx_->iface, buf_, size_))
 #define ms_context_from_id	modem_context_from_id
-#define UART_DEV_NAME(ctx)	(ctx->iface.dev->name)
+#define UART_DEV_NAME(ctx)	(device_name_get(ctx->iface.dev))
 #elif defined(CONFIG_MODEM_RECEIVER)
 #include "modem_receiver.h"
 #define ms_context		mdm_receiver_context
 #define ms_max_context		CONFIG_MODEM_RECEIVER_MAX_CONTEXTS
 #define ms_send			mdm_receiver_send
 #define ms_context_from_id	mdm_receiver_context_from_id
-#define UART_DEV_NAME(ctx_)	(ctx_->uart_dev->name)
+#define UART_DEV_NAME(ctx_)	(device_name_get(ctx_->uart_dev))
 #else
 #error "MODEM_CONTEXT or MODEM_RECEIVER need to be enabled"
 #endif
@@ -178,7 +178,8 @@ static void uart_mux_cb(const struct device *uart, const struct device *dev,
 
 	shell_fprintf(shell, SHELL_NORMAL,
 		      "%s\t\t%s\t\t%d (%s)\n",
-		      uart->name, dev->name, dlci_address, ch);
+		      device_name_get(uart), device_name_get(dev),
+		      dlci_address, ch);
 }
 #endif
 

--- a/drivers/modem/wncm14a2a.c
+++ b/drivers/modem/wncm14a2a.c
@@ -1403,7 +1403,7 @@ static int wncm14a2a_init(const struct device *dev)
 	for (i = 0; i < MAX_MDM_CONTROL_PINS; i++) {
 		if (!device_is_ready(wncm14a2a_cfg.gpio[i].port)) {
 			LOG_ERR("gpio port (%s) not ready!",
-				wncm14a2a_cfg.gpio[i].port->name);
+				device_name_get(wncm14a2a_cfg.gpio[i].port));
 			return -ENODEV;
 		}
 

--- a/drivers/net/ppp.c
+++ b/drivers/net/ppp.c
@@ -843,7 +843,7 @@ static int ppp_consume_ringbuf(struct ppp_driver_context *ppp)
 
 	/* This will print too much data, enable only if really needed */
 	if (0) {
-		LOG_HEXDUMP_DBG(data, len, ppp->dev->name);
+		LOG_HEXDUMP_DBG(data, len, device_name_get(ppp->dev));
 	}
 
 	tmp = len;
@@ -1040,10 +1040,10 @@ static int ppp_start(const struct device *dev)
 		/* dts chosen zephyr,ppp-uart case */
 		context->dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_ppp_uart));
 #endif
-		LOG_INF("Initializing PPP to use %s", context->dev->name);
+		LOG_INF("Initializing PPP to use %s", device_name_get(context->dev));
 
 		if (!device_is_ready(context->dev)) {
-			LOG_ERR("Device %s is not ready", context->dev->name);
+			LOG_ERR("Device %s is not ready", device_name_get(context->dev));
 			return -ENODEV;
 		}
 #if defined(CONFIG_NET_PPP_ASYNC_UART)

--- a/drivers/neural_net/intel_gna.c
+++ b/drivers/neural_net/intel_gna.c
@@ -186,25 +186,25 @@ static int intel_gna_initialize(const struct device *dev)
 			GNA_PG_DIR_ENTRY(&gna_page_table[page]) : (uint32_t)-1;
 		gna_config_desc.pagedir[page] = page_dir_entry;
 		LOG_DBG("%s: page %u pagetable %08x",
-			dev->name, page, gna_config_desc.pagedir[page]);
+			device_name_get(dev), page, gna_config_desc.pagedir[page]);
 	}
 	gna_config_desc.vamaxaddr = GNA_ADDRESSABLE_MEM_SIZE;
 	LOG_DBG("%s: max virtual address %08x",
-			dev->name, gna_config_desc.vamaxaddr);
+			device_name_get(dev), gna_config_desc.vamaxaddr);
 
 	/* flush cache */
 	SOC_DCACHE_FLUSH((void *)&gna_config_desc, sizeof(gna_config_desc));
 
 	LOG_INF("%s: initialized (max %u models & max %u pending requests)",
-			dev->name, GNA_MAX_NUM_MODELS,
+			device_name_get(dev), GNA_MAX_NUM_MODELS,
 			GNA_REQUEST_QUEUE_LEN);
 	LOG_INF("%s: max addressable memory %u MB",
-			dev->name, GNA_ADDRESSABLE_MEM_SIZE >> 20);
+			device_name_get(dev), GNA_ADDRESSABLE_MEM_SIZE >> 20);
 	LOG_INF("%s: %u page table(s) at %p and %u bytes",
-			dev->name, (uint32_t)GNA_NUM_PG_TABLES_NEEDED,
+			device_name_get(dev), (uint32_t)GNA_NUM_PG_TABLES_NEEDED,
 			gna_page_table, sizeof(gna_page_table));
 	LOG_INF("%s: configuration descriptor at %p",
-			dev->name, &gna_config_desc);
+			device_name_get(dev), &gna_config_desc);
 
 	/* register interrupt handler */
 	IRQ_CONNECT(DT_INST_IRQN(0), DT_INST_IRQ(0, priority),
@@ -264,7 +264,7 @@ static int intel_gna_configure(const struct device *dev,
 	INTEL_GNA_CONFIG_DESC_DUMP(dev);
 
 	LOG_INF("Device %s (version %u.%u) configured with power mode %u",
-			dev->name, regs->gnaversion >> 1,
+			device_name_get(dev), regs->gnaversion >> 1,
 			(uint32_t)(regs->gnaversion & BIT(0)),
 			CONFIG_INTEL_GNA_POWER_MODE);
 

--- a/drivers/peci/peci_npcx.c
+++ b/drivers/peci/peci_npcx.c
@@ -238,7 +238,7 @@ static int peci_npcx_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(clk_dev)) {
-		LOG_ERR("%s device not ready", clk_dev->name);
+		LOG_ERR("%s device not ready", device_name_get(clk_dev));
 		return -ENODEV;
 	}
 

--- a/drivers/power_domain/power_domain_gpio.c
+++ b/drivers/power_domain/power_domain_gpio.c
@@ -45,7 +45,7 @@ static int pd_gpio_pm_action(const struct device *dev,
 		k_sleep(data->next_boot);
 		/* Switch power on */
 		gpio_pin_set_dt(&cfg->enable, 1);
-		LOG_INF("%s is now ON", dev->name);
+		LOG_INF("%s is now ON", device_name_get(dev));
 		/* Wait for domain to come up */
 		k_sleep(K_USEC(cfg->startup_delay_us));
 		/* Notify supported devices they are now powered */
@@ -56,7 +56,7 @@ static int pd_gpio_pm_action(const struct device *dev,
 		pm_device_children_action_run(dev, PM_DEVICE_ACTION_TURN_OFF, NULL);
 		/* Switch power off */
 		gpio_pin_set_dt(&cfg->enable, 0);
-		LOG_INF("%s is now OFF", dev->name);
+		LOG_INF("%s is now OFF", device_name_get(dev));
 		/* Store next time we can boot */
 		next_boot_ticks = k_uptime_ticks() + k_us_to_ticks_ceil32(cfg->off_on_delay_us);
 		data->next_boot = K_TIMEOUT_ABS_TICKS(next_boot_ticks);
@@ -64,12 +64,12 @@ static int pd_gpio_pm_action(const struct device *dev,
 	case PM_DEVICE_ACTION_TURN_ON:
 		/* Actively control the enable pin now that the device is powered */
 		gpio_pin_configure_dt(&cfg->enable, GPIO_OUTPUT_INACTIVE);
-		LOG_DBG("%s is OFF and powered", dev->name);
+		LOG_DBG("%s is OFF and powered", device_name_get(dev));
 		break;
 	case PM_DEVICE_ACTION_TURN_OFF:
 		/* Let the enable pin float while device is not powered */
 		gpio_pin_configure_dt(&cfg->enable, GPIO_DISCONNECTED);
-		LOG_DBG("%s is OFF and not powered", dev->name);
+		LOG_DBG("%s is OFF and not powered", device_name_get(dev));
 		break;
 	default:
 		rc = -ENOTSUP;
@@ -85,7 +85,7 @@ static int pd_gpio_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(cfg->enable.port)) {
-		LOG_ERR("GPIO port %s is not ready", cfg->enable.port->name);
+		LOG_ERR("GPIO port %s is not ready", device_name_get(cfg->enable.port));
 		return -ENODEV;
 	}
 	/* We can't know how long the domain has been off for before boot */

--- a/drivers/ps2/ps2_npcx_channel.c
+++ b/drivers/ps2/ps2_npcx_channel.c
@@ -82,7 +82,7 @@ static int ps2_npcx_channel_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->ps2_ctrl)) {
-		LOG_ERR("%s device not ready", config->ps2_ctrl->name);
+		LOG_ERR("%s device not ready", device_name_get(config->ps2_ctrl));
 		return -ENODEV;
 	}
 

--- a/drivers/ps2/ps2_npcx_controller.c
+++ b/drivers/ps2/ps2_npcx_controller.c
@@ -331,7 +331,7 @@ static int ps2_npcx_ctrl_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(clk_dev)) {
-		LOG_ERR("%s device not ready", clk_dev->name);
+		LOG_ERR("%s device not ready", device_name_get(clk_dev));
 		return -ENODEV;
 	}
 

--- a/drivers/pwm/pwm_imx.c
+++ b/drivers/pwm/pwm_imx.c
@@ -120,7 +120,7 @@ static int imx_pwm_set_cycles(const struct device *dev, uint32_t channel,
 	if (data->period_cycles != period_cycles) {
 		LOG_WRN("Changing period cycles from %d to %d in %s",
 			    data->period_cycles, period_cycles,
-			    dev->name);
+			    device_name_get(dev));
 
 		data->period_cycles = period_cycles;
 		PWM_PWMPR_REG(config->base) = period_cycles;

--- a/drivers/pwm/pwm_mcux_ftm.c
+++ b/drivers/pwm/pwm_mcux_ftm.c
@@ -112,7 +112,7 @@ static int mcux_ftm_set_cycles(const struct device *dev, uint32_t channel,
 			LOG_WRN("Changing period cycles from %d to %d"
 				" affects all %d channels in %s",
 				data->period_cycles, period_cycles,
-				config->channel_count, dev->name);
+				config->channel_count, device_name_get(dev));
 		}
 
 		data->period_cycles = period_cycles;

--- a/drivers/pwm/pwm_mcux_tpm.c
+++ b/drivers/pwm/pwm_mcux_tpm.c
@@ -80,7 +80,7 @@ static int mcux_tpm_set_cycles(const struct device *dev, uint32_t channel,
 			LOG_WRN("Changing period cycles from %d to %d"
 				" affects all %d channels in %s",
 				data->period_cycles, period_cycles,
-				config->channel_count, dev->name);
+				config->channel_count, device_name_get(dev));
 		}
 
 		data->period_cycles = period_cycles;

--- a/drivers/pwm/pwm_nrfx.c
+++ b/drivers/pwm/pwm_nrfx.c
@@ -271,7 +271,7 @@ static int pwm_nrfx_init(const struct device *dev)
 					  NULL,
 					  NULL);
 	if (result != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize device: %s", dev->name);
+		LOG_ERR("Failed to initialize device: %s", device_name_get(dev));
 		return -EBUSY;
 	}
 

--- a/drivers/pwm/pwm_rv32m1_tpm.c
+++ b/drivers/pwm/pwm_rv32m1_tpm.c
@@ -83,7 +83,7 @@ static int rv32m1_tpm_set_cycles(const struct device *dev, uint32_t channel,
 			LOG_WRN("Changing period cycles from %d to %d"
 				" affects all %d channels in %s",
 				data->period_cycles, period_cycles,
-				config->channel_count, dev->name);
+				config->channel_count, device_name_get(dev));
 		}
 
 		data->period_cycles = period_cycles;

--- a/drivers/regulator/regulator_fixed.c
+++ b/drivers/regulator/regulator_fixed.c
@@ -56,7 +56,7 @@ static int common_init(const struct device *dev)
 	gpio_flags_t flags;
 
 	if (!device_is_ready(cfg->enable.port)) {
-		LOG_ERR("GPIO port: %s not ready", cfg->enable.port->name);
+		LOG_ERR("GPIO port: %s not ready", device_name_get(cfg->enable.port));
 		return -ENODEV;
 	}
 
@@ -271,7 +271,7 @@ static int regulator_fixed_init_onoff(const struct device *dev)
 		rc = 0;
 	}
 
-	LOG_INF("%s onoff: %d", dev->name, rc);
+	LOG_INF("%s onoff: %d", device_name_get(dev), rc);
 
 	return rc;
 }
@@ -334,7 +334,7 @@ static int regulator_fixed_init_sync(const struct device *dev)
 	__ASSERT(cfg->off_on_delay_us == 0,
 		 "sync not valid with shutdown delay");
 
-	LOG_INF("%s sync: %d", dev->name, rc);
+	LOG_INF("%s sync: %d", device_name_get(dev), rc);
 
 	return rc;
 }

--- a/drivers/regulator/regulator_pmic.c
+++ b/drivers/regulator/regulator_pmic.c
@@ -145,7 +145,7 @@ int regulator_set_voltage(const struct device *dev, int min_uV, int max_uV)
 				"but voltage is in range.");
 		return -EINVAL;
 	}
-	LOG_DBG("Setting regulator %s to %duV", dev->name,
+	LOG_DBG("Setting regulator %s to %duV", device_name_get(dev),
 			data->voltages[i].uV);
 	return regulator_modify_register(config, config->vsel_reg,
 			config->vsel_mask, data->voltages[i].reg_val);

--- a/drivers/sensor/adt7420/adt7420_trigger.c
+++ b/drivers/sensor/adt7420/adt7420_trigger.c
@@ -136,8 +136,8 @@ int adt7420_init_interrupt(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-			cfg->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+			device_name_get(cfg->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adxl362/adxl362.c
+++ b/drivers/sensor/adxl362/adxl362.c
@@ -709,7 +709,7 @@ static int adxl362_init(const struct device *dev)
 	int err;
 
 	if (!spi_is_ready(&config->bus)) {
-		LOG_DBG("spi device not ready: %s", config->bus.bus->name);
+		LOG_DBG("spi device not ready: %s", device_name_get(config->bus.bus));
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/adxl362/adxl362_trigger.c
+++ b/drivers/sensor/adxl362/adxl362_trigger.c
@@ -141,7 +141,7 @@ int adxl362_init_interrupt(const struct device *dev)
 	k_mutex_init(&drv_data->trigger_mutex);
 
 	if (!device_is_ready(cfg->interrupt.port)) {
-		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR("GPIO port %s not ready", device_name_get(cfg->interrupt.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/adxl372/adxl372.c
+++ b/drivers/sensor/adxl372/adxl372.c
@@ -890,13 +890,13 @@ static int adxl372_init(const struct device *dev)
 
 #ifdef CONFIG_ADXL372_I2C
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C bus %s not ready!", cfg->i2c.bus->name);
+		LOG_ERR("I2C bus %s not ready!", device_name_get(cfg->i2c.bus));
 		return -EINVAL;
 	}
 #endif
 #ifdef CONFIG_ADXL372_SPI
 	if (!spi_is_ready(&cfg->spi)) {
-		LOG_ERR("SPI bus %s not ready!", cfg->spi.bus->name);
+		LOG_ERR("SPI bus %s not ready!", device_name_get(cfg->spi.bus));
 		return -EINVAL;
 	}
 #endif /* CONFIG_ADXL372_SPI */

--- a/drivers/sensor/adxl372/adxl372_trigger.c
+++ b/drivers/sensor/adxl372/adxl372_trigger.c
@@ -151,7 +151,7 @@ int adxl372_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->interrupt.port)) {
-		LOG_ERR("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_ERR("GPIO port %s not ready", device_name_get(cfg->interrupt.port));
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/amg88xx/amg88xx_trigger.c
+++ b/drivers/sensor/amg88xx/amg88xx_trigger.c
@@ -173,8 +173,8 @@ int amg88xx_init_interrupt(const struct device *dev)
 	const struct amg88xx_config *config = dev->config;
 
 	if (!device_is_ready(config->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				config->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(config->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/apds9960/apds9960.c
+++ b/drivers/sensor/apds9960/apds9960.c
@@ -361,8 +361,8 @@ static int apds9960_init_interrupt(const struct device *dev)
 	struct apds9960_data *drv_data = dev->data;
 
 	if (!device_is_ready(config->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-			config->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+			device_name_get(config->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/bme280/bme280.c
+++ b/drivers/sensor/bme280/bme280.c
@@ -385,7 +385,7 @@ static int bme280_chip_init(const struct device *dev)
 	/* Wait for the sensor to be ready */
 	k_sleep(K_MSEC(1));
 
-	LOG_DBG("\"%s\" OK", dev->name);
+	LOG_DBG("\"%s\" OK", device_name_get(dev));
 	return 0;
 }
 

--- a/drivers/sensor/bme680/bme680.c
+++ b/drivers/sensor/bme680/bme680.c
@@ -366,7 +366,7 @@ static int bme680_init(const struct device *dev)
 
 	err = bme680_bus_check(dev);
 	if (err < 0) {
-		LOG_ERR("Bus not ready for '%s'", dev->name);
+		LOG_ERR("Bus not ready for '%s'", device_name_get(dev));
 		return err;
 	}
 

--- a/drivers/sensor/bmi160/bmi160_trigger.c
+++ b/drivers/sensor/bmi160/bmi160_trigger.c
@@ -270,7 +270,7 @@ int bmi160_trigger_mode_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->interrupt.port)) {
-		LOG_DBG("GPIO port %s not ready", cfg->interrupt.port->name);
+		LOG_DBG("GPIO port %s not ready", device_name_get(cfg->interrupt.port));
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -887,7 +887,7 @@ static int fdc2x1x_init_sd_pin(const struct device *dev)
 	const struct fdc2x1x_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->sd_gpio.port)) {
-		LOG_ERR("%s: sd_gpio device not ready", cfg->sd_gpio.port->name);
+		LOG_ERR("%s: sd_gpio device not ready", device_name_get(cfg->sd_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/fdc2x1x/fdc2x1x.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x.c
@@ -920,7 +920,7 @@ static int fdc2x1x_init(const struct device *dev)
 		return -EINVAL;
 	}
 
-	if (cfg->sd_gpio.port->name) {
+	if (cfg->sd_gpio.port != NULL) {
 		if (fdc2x1x_init_sd_pin(dev) < 0) {
 			return -ENODEV;
 		}

--- a/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
+++ b/drivers/sensor/fdc2x1x/fdc2x1x_trigger.c
@@ -131,7 +131,7 @@ int fdc2x1x_init_interrupt(const struct device *dev)
 	k_mutex_init(&drv_data->trigger_mutex);
 
 	if (!device_is_ready(cfg->intb_gpio.port)) {
-		LOG_ERR("%s: intb_gpio device not ready", cfg->intb_gpio.port->name);
+		LOG_ERR("%s: intb_gpio device not ready", device_name_get(cfg->intb_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/hts221/hts221_trigger.c
+++ b/drivers/sensor/hts221/hts221_trigger.c
@@ -127,7 +127,7 @@ int hts221_init_interrupt(const struct device *dev)
 	}
 
 	if (!device_is_ready(cfg->gpio_drdy.port)) {
-		LOG_ERR("device %s is not ready", cfg->gpio_drdy.port->name);
+		LOG_ERR("device %s is not ready", device_name_get(cfg->gpio_drdy.port));
 		return -ENODEV;
 	}
 
@@ -137,7 +137,7 @@ int hts221_init_interrupt(const struct device *dev)
 	status = gpio_pin_configure_dt(&cfg->gpio_drdy, GPIO_INPUT);
 	if (status < 0) {
 		LOG_ERR("Could not configure %s.%02u",
-			cfg->gpio_drdy.port->name, cfg->gpio_drdy.pin);
+			device_name_get(cfg->gpio_drdy.port), cfg->gpio_drdy.pin);
 		return status;
 	}
 

--- a/drivers/sensor/iis2dh/iis2dh_trigger.c
+++ b/drivers/sensor/iis2dh/iis2dh_trigger.c
@@ -140,7 +140,8 @@ int iis2dh_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, cfg->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+			device_name_get(cfg->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/iis2iclx/iis2iclx.c
+++ b/drivers/sensor/iis2iclx/iis2iclx.c
@@ -592,7 +592,7 @@ static int iis2iclx_init(const struct device *dev)
 #endif
 	struct iis2iclx_data *data = dev->data;
 
-	LOG_INF("Initialize device %s", dev->name);
+	LOG_INF("Initialize device %s", device_name_get(dev));
 	data->dev = dev;
 	if (iis2iclx_init_chip(dev) < 0) {
 		LOG_ERR("failed to initialize chip");

--- a/drivers/sensor/iis2iclx/iis2iclx_shub.c
+++ b/drivers/sensor/iis2iclx/iis2iclx_shub.c
@@ -755,7 +755,7 @@ int iis2iclx_shub_init(const struct device *dev)
 	struct iis2iclx_shub_slist *sp;
 	struct iis2iclx_data *data = dev->data;
 
-	LOG_INF("shub: start sensorhub for %s", dev->name);
+	LOG_INF("shub: start sensorhub for %s", device_name_get(dev));
 	for (n = 0; n < ARRAY_SIZE(iis2iclx_shub_slist); n++) {
 		if (data->num_ext_dev >= IIS2ICLX_SHUB_MAX_NUM_SLVS) {
 			break;
@@ -791,7 +791,7 @@ int iis2iclx_shub_init(const struct device *dev)
 		data->shub_ext[data->num_ext_dev++] = n;
 	}
 
-	LOG_DBG("shub: dev %s - num_ext_dev %d", dev->name, data->num_ext_dev);
+	LOG_DBG("shub: dev %s - num_ext_dev %d", device_name_get(dev), data->num_ext_dev);
 	if (data->num_ext_dev == 0) {
 		LOG_WRN("shub: no slave devices found");
 		return -ENOTSUP;

--- a/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
+++ b/drivers/sensor/iis3dhhc/iis3dhhc_trigger.c
@@ -127,7 +127,8 @@ int iis3dhhc_init_interrupt(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name, cfg->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+			device_name_get(cfg->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ina23x/ina230.c
+++ b/drivers/sensor/ina23x/ina230.c
@@ -262,7 +262,7 @@ static int ina230_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s is not ready", config->bus.bus->name);
+		LOG_ERR("I2C bus %s is not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ina23x/ina237.c
+++ b/drivers/sensor/ina23x/ina237.c
@@ -347,7 +347,7 @@ static int ina237_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s is not ready", config->bus.bus->name);
+		LOG_ERR("I2C bus %s is not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/lis2dh/lis2dh_trigger.c
+++ b/drivers/sensor/lis2dh/lis2dh_trigger.c
@@ -441,7 +441,7 @@ int lis2dh_init_interrupt(const struct device *dev)
 	if (!device_is_ready(cfg->gpio_drdy.port)) {
 		/* API may return false even when ptr is NULL */
 		if (cfg->gpio_drdy.port != NULL) {
-			LOG_ERR("device %s is not ready", cfg->gpio_drdy.port->name);
+			LOG_ERR("device %s is not ready", device_name_get(cfg->gpio_drdy.port));
 			return -ENODEV;
 		}
 
@@ -454,7 +454,7 @@ int lis2dh_init_interrupt(const struct device *dev)
 	status = gpio_pin_configure_dt(&cfg->gpio_drdy, GPIO_INPUT);
 	if (status < 0) {
 		LOG_ERR("Could not configure %s.%02u",
-			cfg->gpio_drdy.port->name, cfg->gpio_drdy.pin);
+			device_name_get(cfg->gpio_drdy.port), cfg->gpio_drdy.pin);
 		return status;
 	}
 
@@ -468,8 +468,8 @@ int lis2dh_init_interrupt(const struct device *dev)
 		return status;
 	}
 
-	LOG_INF("%s: int1 on %s.%02u", dev->name,
-				       cfg->gpio_drdy.port->name,
+	LOG_INF("%s: int1 on %s.%02u", device_name_get(dev),
+				       device_name_get(cfg->gpio_drdy.port),
 				       cfg->gpio_drdy.pin);
 
 check_gpio_int:
@@ -481,7 +481,7 @@ check_gpio_int:
 	if (!device_is_ready(cfg->gpio_int.port)) {
 		/* API may return false even when ptr is NULL */
 		if (cfg->gpio_int.port != NULL) {
-			LOG_ERR("device %s is not ready", cfg->gpio_int.port->name);
+			LOG_ERR("device %s is not ready", device_name_get(cfg->gpio_int.port));
 			return -ENODEV;
 		}
 
@@ -494,7 +494,7 @@ check_gpio_int:
 	status = gpio_pin_configure_dt(&cfg->gpio_int, GPIO_INPUT);
 	if (status < 0) {
 		LOG_ERR("Could not configure %s.%02u",
-			cfg->gpio_int.port->name, cfg->gpio_int.pin);
+			device_name_get(cfg->gpio_int.port), cfg->gpio_int.pin);
 		return status;
 	}
 
@@ -509,8 +509,8 @@ check_gpio_int:
 		return status;
 	}
 
-	LOG_INF("%s: int2 on %s.%02u", dev->name,
-				       cfg->gpio_int.port->name,
+	LOG_INF("%s: int2 on %s.%02u", device_name_get(dev),
+				       device_name_get(cfg->gpio_int.port),
 				       cfg->gpio_int.pin);
 
 	/* disable interrupt in case of warm (re)boot */

--- a/drivers/sensor/lis2ds12/lis2ds12.c
+++ b/drivers/sensor/lis2ds12/lis2ds12.c
@@ -31,7 +31,7 @@ static int lis2ds12_set_odr(const struct device *dev, uint8_t odr)
 
 	/* check if power off */
 	if (odr == 0U) {
-		LOG_DBG("%s: set power-down", dev->name);
+		LOG_DBG("%s: set power-down", device_name_get(dev));
 		return lis2ds12_xl_data_rate_set(ctx, LIS2DS12_XL_ODR_OFF);
 	}
 
@@ -42,7 +42,7 @@ static int lis2ds12_set_odr(const struct device *dev, uint8_t odr)
 	 */
 	if ((odr >= 9 && cfg->pm != 3) || (odr < 9 && cfg->pm == 3) ||
 	    (odr == 1 && cfg->pm != 1)) {
-		LOG_ERR("%s: bad odr and pm combination", dev->name);
+		LOG_ERR("%s: bad odr and pm combination", device_name_get(dev));
 		return -ENOTSUP;
 	}
 
@@ -88,7 +88,7 @@ static int lis2ds12_set_odr(const struct device *dev, uint8_t odr)
 		val = LIS2DS12_XL_ODR_6k4Hz_HF;
 		break;
 	default:
-		LOG_ERR("%s: bad odr %d", dev->name, odr);
+		LOG_ERR("%s: bad odr %d", device_name_get(dev), odr);
 		return -ENOTSUP;
 	}
 
@@ -134,7 +134,7 @@ static int lis2ds12_accel_config(const struct device *dev,
 	case SENSOR_ATTR_FULL_SCALE:
 		return lis2ds12_set_range(dev, sensor_ms2_to_g(val));
 	case SENSOR_ATTR_SAMPLING_FREQUENCY:
-		LOG_DBG("%s: set odr to %d Hz", dev->name, val->val1);
+		LOG_DBG("%s: set odr to %d Hz", device_name_get(dev), val->val1);
 		return lis2ds12_set_odr(dev, LIS2DS12_ODR_TO_REG(val->val1));
 	default:
 		LOG_DBG("Accel attribute not supported.");
@@ -276,12 +276,12 @@ static int lis2ds12_init(const struct device *dev)
 	/* check chip ID */
 	ret = lis2ds12_device_id_get(ctx, &chip_id);
 	if (ret < 0) {
-		LOG_ERR("%s: Not able to read dev id", dev->name);
+		LOG_ERR("%s: Not able to read dev id", device_name_get(dev));
 		return ret;
 	}
 
 	if (chip_id != LIS2DS12_ID) {
-		LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, chip_id);
+		LOG_ERR("%s: Invalid chip ID 0x%02x", device_name_get(dev), chip_id);
 		return -EINVAL;
 	}
 
@@ -293,29 +293,29 @@ static int lis2ds12_init(const struct device *dev)
 
 	k_busy_wait(100);
 
-	LOG_DBG("%s: chip id 0x%x", dev->name, chip_id);
+	LOG_DBG("%s: chip id 0x%x", device_name_get(dev), chip_id);
 
 #ifdef CONFIG_LIS2DS12_TRIGGER
 	ret = lis2ds12_trigger_init(dev);
 	if (ret < 0) {
-		LOG_ERR("%s: Failed to initialize triggers", dev->name);
+		LOG_ERR("%s: Failed to initialize triggers", device_name_get(dev));
 		return ret;
 	}
 #endif
 
 	/* set sensor default pm and odr */
-	LOG_DBG("%s: pm: %d, odr: %d", dev->name, cfg->pm, cfg->odr);
+	LOG_DBG("%s: pm: %d, odr: %d", device_name_get(dev), cfg->pm, cfg->odr);
 	ret = lis2ds12_set_odr(dev, (cfg->pm == 0) ? 0 : cfg->odr);
 	if (ret < 0) {
-		LOG_ERR("%s: odr init error (12.5 Hz)", dev->name);
+		LOG_ERR("%s: odr init error (12.5 Hz)", device_name_get(dev));
 		return ret;
 	}
 
 	/* set sensor default scale */
-	LOG_DBG("%s: range is %d", dev->name, cfg->range);
+	LOG_DBG("%s: range is %d", device_name_get(dev), cfg->range);
 	ret = lis2ds12_set_range(dev, cfg->range);
 	if (ret < 0) {
-		LOG_ERR("%s: range init error %d", dev->name, cfg->range);
+		LOG_ERR("%s: range init error %d", device_name_get(dev), cfg->range);
 		return ret;
 	}
 

--- a/drivers/sensor/lis2ds12/lis2ds12_trigger.c
+++ b/drivers/sensor/lis2ds12/lis2ds12_trigger.c
@@ -27,7 +27,7 @@ static void lis2ds12_gpio_callback(const struct device *dev,
 
 	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_DISABLE);
 	if (ret < 0) {
-		LOG_ERR("%s: Not able to configure pin_int", dev->name);
+		LOG_ERR("%s: Not able to configure pin_int", device_name_get(dev));
 	}
 
 #if defined(CONFIG_LIS2DS12_TRIGGER_OWN_THREAD)
@@ -62,7 +62,7 @@ static void lis2ds12_handle_int(const struct device *dev)
 	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_int,
 					      GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret < 0) {
-		LOG_ERR("%s: Not able to configure pin_int", dev->name);
+		LOG_ERR("%s: Not able to configure pin_int", device_name_get(dev));
 	}
 }
 
@@ -124,12 +124,12 @@ int lis2ds12_trigger_init(const struct device *dev)
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!device_is_ready(cfg->gpio_int.port)) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+						device_name_get(cfg->gpio_int.port));
 			return -ENODEV;
 		}
 
-		LOG_DBG("%s: gpio_int not defined in DT", dev->name);
+		LOG_DBG("%s: gpio_int not defined in DT", device_name_get(dev));
 		return 0;
 	}
 
@@ -141,8 +141,8 @@ int lis2ds12_trigger_init(const struct device *dev)
 		return ret;
 	}
 
-	LOG_INF("%s: int on %s.%02u", dev->name, cfg->gpio_int.port->name,
-				      cfg->gpio_int.pin);
+	LOG_INF("%s: int on %s.%02u", device_name_get(dev),
+		device_name_get(cfg->gpio_int.port), cfg->gpio_int.pin);
 
 	gpio_init_callback(&data->gpio_cb,
 			   lis2ds12_gpio_callback,
@@ -190,7 +190,7 @@ int lis2ds12_trigger_set(const struct device *dev,
 
 	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_DISABLE);
 	if (ret < 0) {
-		LOG_ERR("%s: Not able to configure pin_int", dev->name);
+		LOG_ERR("%s: Not able to configure pin_int", device_name_get(dev));
 		return ret;
 	}
 

--- a/drivers/sensor/lis2dw12/lis2dw12_trigger.c
+++ b/drivers/sensor/lis2dw12/lis2dw12_trigger.c
@@ -380,18 +380,18 @@ int lis2dw12_init_interrupt(const struct device *dev)
 	/* setup data ready gpio interrupt (INT1 or INT2) */
 	if (!device_is_ready(cfg->gpio_int.port)) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->gpio_int.port));
 			return -ENODEV;
 		}
 
-		LOG_DBG("%s: gpio_int not defined in DT", dev->name);
+		LOG_DBG("%s: gpio_int not defined in DT", device_name_get(dev));
 		return 0;
 	}
 
 	lis2dw12->dev = dev;
 
-	LOG_INF("%s: int-pin is on INT%d", dev->name, cfg->int_pin);
+	LOG_INF("%s: int-pin is on INT%d", device_name_get(dev), cfg->int_pin);
 #if defined(CONFIG_LIS2DW12_TRIGGER_OWN_THREAD)
 	k_sem_init(&lis2dw12->gpio_sem, 0, K_SEM_MAX_LIMIT);
 
@@ -410,8 +410,8 @@ int lis2dw12_init_interrupt(const struct device *dev)
 		return ret;
 	}
 
-	LOG_INF("%s: int on %s.%02u", dev->name, cfg->gpio_int.port->name,
-				      cfg->gpio_int.pin);
+	LOG_INF("%s: int on %s.%02u", device_name_get(dev),
+		device_name_get(cfg->gpio_int.port), cfg->gpio_int.pin);
 
 	gpio_init_callback(&lis2dw12->gpio_cb,
 			   lis2dw12_gpio_callback,

--- a/drivers/sensor/lps22hh/lps22hh.c
+++ b/drivers/sensor/lps22hh/lps22hh.c
@@ -175,16 +175,16 @@ static int lps22hh_init_chip(const struct device *dev)
 #endif
 
 	if (lps22hh_device_id_get(ctx, &chip_id) < 0) {
-		LOG_ERR("%s: Not able to read dev id", dev->name);
+		LOG_ERR("%s: Not able to read dev id", device_name_get(dev));
 		return -EIO;
 	}
 
 	if (chip_id != LPS22HH_ID) {
-		LOG_ERR("%s: Invalid chip ID 0x%02x", dev->name, chip_id);
+		LOG_ERR("%s: Invalid chip ID 0x%02x", device_name_get(dev), chip_id);
 		return -EIO;
 	}
 
-	LOG_DBG("%s: chip id 0x%x", dev->name, chip_id);
+	LOG_DBG("%s: chip id 0x%x", device_name_get(dev), chip_id);
 
 #if DT_ANY_INST_ON_BUS_STATUS_OKAY(i3c)
 	if (cfg->i3c.bus != NULL) {
@@ -211,15 +211,15 @@ static int lps22hh_init_chip(const struct device *dev)
 #endif
 
 	/* set sensor default odr */
-	LOG_DBG("%s: odr: %d", dev->name, cfg->odr);
+	LOG_DBG("%s: odr: %d", device_name_get(dev), cfg->odr);
 	ret = lps22hh_set_odr_raw(dev, cfg->odr);
 	if (ret < 0) {
-		LOG_ERR("%s: Failed to set odr %d", dev->name, cfg->odr);
+		LOG_ERR("%s: Failed to set odr %d", device_name_get(dev), cfg->odr);
 		return ret;
 	}
 
 	if (lps22hh_block_data_update_set(ctx, PROPERTY_ENABLE) < 0) {
-		LOG_ERR("%s: Failed to set BDU", dev->name);
+		LOG_ERR("%s: Failed to set BDU", device_name_get(dev));
 		return ret;
 	}
 

--- a/drivers/sensor/lps22hh/lps22hh_trigger.c
+++ b/drivers/sensor/lps22hh/lps22hh_trigger.c
@@ -93,7 +93,7 @@ static void lps22hh_handle_interrupt(const struct device *dev)
 	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_int,
 					      GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret < 0) {
-		LOG_ERR("%s: Not able to configure pin_int", dev->name);
+		LOG_ERR("%s: Not able to configure pin_int", device_name_get(dev));
 	}
 }
 
@@ -118,7 +118,7 @@ static void lps22hh_gpio_callback(const struct device *dev,
 
 	ret = gpio_pin_interrupt_configure_dt(&cfg->gpio_int, GPIO_INT_DISABLE);
 	if (ret < 0) {
-		LOG_ERR("%s: Not able to configure pin_int", dev->name);
+		LOG_ERR("%s: Not able to configure pin_int", device_name_get(dev));
 	}
 
 	lps22hh_intr_callback(lps22hh);
@@ -173,12 +173,12 @@ int lps22hh_init_interrupt(const struct device *dev)
 #endif
 	   ) {
 		if (cfg->gpio_int.port) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-						cfg->gpio_int.port->name);
+			LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->gpio_int.port));
 			return -ENODEV;
 		}
 
-		LOG_DBG("%s: gpio_int not defined in DT", dev->name);
+		LOG_DBG("%s: gpio_int not defined in DT", device_name_get(dev));
 		return 0;
 	}
 
@@ -206,8 +206,8 @@ int lps22hh_init_interrupt(const struct device *dev)
 			return ret;
 		}
 
-		LOG_INF("%s: int on %s.%02u", dev->name, cfg->gpio_int.port->name,
-					      cfg->gpio_int.pin);
+		LOG_INF("%s: int on %s.%02u", device_name_get(dev),
+			device_name_get(cfg->gpio_int.port), cfg->gpio_int.pin);
 
 		gpio_init_callback(&lps22hh->gpio_cb,
 				   lps22hh_gpio_callback,

--- a/drivers/sensor/lsm6dso/lsm6dso.c
+++ b/drivers/sensor/lsm6dso/lsm6dso.c
@@ -820,7 +820,7 @@ static int lsm6dso_init(const struct device *dev)
 #endif
 	struct lsm6dso_data *data = dev->data;
 
-	LOG_INF("Initialize device %s", dev->name);
+	LOG_INF("Initialize device %s", device_name_get(dev));
 	data->dev = dev;
 
 #ifdef CONFIG_LSM6DSO_TRIGGER

--- a/drivers/sensor/lsm6dso/lsm6dso_shub.c
+++ b/drivers/sensor/lsm6dso/lsm6dso_shub.c
@@ -687,7 +687,7 @@ int lsm6dso_shub_get_idx(const struct device *dev, enum sensor_channel type)
 		}
 	}
 
-	LOG_ERR("shub: dev %s type %d not supported", dev->name, type);
+	LOG_ERR("shub: dev %s type %d not supported", device_name_get(dev), type);
 	return -ENOTSUP;
 }
 
@@ -735,7 +735,7 @@ int lsm6dso_shub_config(const struct device *dev, enum sensor_channel chan,
 	}
 
 	if (n == data->num_ext_dev) {
-		LOG_DBG("shub: %s chan %d not supported", dev->name, chan);
+		LOG_DBG("shub: %s chan %d not supported", device_name_get(dev), chan);
 		return -ENOTSUP;
 	}
 
@@ -754,7 +754,7 @@ int lsm6dso_shub_init(const struct device *dev)
 	uint8_t chip_id;
 	struct lsm6dso_shub_slist *sp;
 
-	LOG_INF("shub: start sensorhub for %s", dev->name);
+	LOG_INF("shub: start sensorhub for %s", device_name_get(dev));
 	for (n = 0; n < ARRAY_SIZE(lsm6dso_shub_slist); n++) {
 		if (data->num_ext_dev >= LSM6DSO_SHUB_MAX_NUM_SLVS) {
 			break;
@@ -791,7 +791,7 @@ int lsm6dso_shub_init(const struct device *dev)
 		data->shub_ext[data->num_ext_dev++] = n;
 	}
 
-	LOG_DBG("shub: dev %s - num_ext_dev %d", dev->name, data->num_ext_dev);
+	LOG_DBG("shub: dev %s - num_ext_dev %d", device_name_get(dev), data->num_ext_dev);
 	if (data->num_ext_dev == 0) {
 		LOG_ERR("shub: no slave devices found");
 		return -EINVAL;

--- a/drivers/sensor/max31875/max31875.c
+++ b/drivers/sensor/max31875/max31875.c
@@ -249,7 +249,7 @@ static int max31875_init(const struct device *dev)
 	struct max31875_data *data = dev->data;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR("I2C dev %s not ready", device_name_get(cfg->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/mpu9250/mpu9250.c
+++ b/drivers/sensor/mpu9250/mpu9250.c
@@ -241,7 +241,7 @@ static int mpu9250_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(cfg->i2c.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->i2c.bus->name);
+		LOG_ERR("I2C dev %s not ready", device_name_get(cfg->i2c.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
+++ b/drivers/sensor/nuvoton_tach_npcx/tach_nuvoton_npcx.c
@@ -231,7 +231,7 @@ static int tach_npcx_configure(const struct device *dev)
 		inst->TCKC |= BIT(NPCX_TCKC_LOW_PWR);
 		if (config->sample_clk != data->input_clk) {
 			LOG_ERR("%s operate freq is %d not fixed to 32kHz",
-				dev->name, data->input_clk);
+				device_name_get(dev), data->input_clk);
 			return -EINVAL;
 		}
 	} else {
@@ -240,7 +240,7 @@ static int tach_npcx_configure(const struct device *dev)
 
 		if (data->input_clk > config->sample_clk) {
 			LOG_ERR("%s operate freq exceeds APB1 clock",
-				dev->name);
+				device_name_get(dev));
 			return -EINVAL;
 		}
 		inst->TPRSC = MIN(NPCX_TACHO_PRSC_MAX, MAX(prescaler, 1));

--- a/drivers/sensor/qdec_sam/qdec_sam.c
+++ b/drivers/sensor/qdec_sam/qdec_sam.c
@@ -110,7 +110,7 @@ static int qdec_sam_initialize(const struct device *dev)
 
 	qdec_sam_configure(dev);
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -199,7 +199,7 @@ static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 
-	entry->syntax = (dev != NULL) ? dev->name : NULL;
+	entry->syntax = (dev != NULL) ? device_name_get(dev) : NULL;
 	entry->handler = NULL;
 	entry->help  = NULL;
 	entry->subcmd = &dsub_channel_name;

--- a/drivers/sensor/sensor_shell.c
+++ b/drivers/sensor/sensor_shell.c
@@ -191,11 +191,11 @@ static void channel_name_get(size_t idx, struct shell_static_entry *entry)
 	}
 }
 
-static void device_name_get(size_t idx, struct shell_static_entry *entry);
+static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry);
 
-SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
+SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, cmd_device_name_get);
 
-static void device_name_get(size_t idx, struct shell_static_entry *entry)
+static void cmd_device_name_get(size_t idx, struct shell_static_entry *entry)
 {
 	const struct device *dev = shell_device_lookup(idx, NULL);
 

--- a/drivers/sensor/sht3xd/sht3xd.c
+++ b/drivers/sensor/sht3xd/sht3xd.c
@@ -170,7 +170,7 @@ static int sht3xd_init(const struct device *dev)
 	const struct sht3xd_config *cfg = dev->config;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C bus %s is not ready!", cfg->bus.bus->name);
+		LOG_ERR("I2C bus %s is not ready!", device_name_get(cfg->bus.bus));
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/si7210/si7210.c
+++ b/drivers/sensor/si7210/si7210.c
@@ -458,7 +458,7 @@ static int si7210_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s not ready!", config->bus.bus->name);
+		LOG_ERR("I2C bus %s not ready!", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sm351lt/sm351lt.c
+++ b/drivers/sensor/sm351lt/sm351lt.c
@@ -222,7 +222,7 @@ static int sm351lt_init(const struct device *dev)
 
 #if defined(CONFIG_THREAD_NAME) && defined(CONFIG_THREAD_MAX_NAME_LEN)
 	/* Sets up thread name as the device name */
-	k_thread_name_set(&data->thread, dev->name);
+	k_thread_name_set(&data->thread, device_name_get(dev));
 #endif
 
 #elif defined(CONFIG_SM351LT_TRIGGER_GLOBAL_THREAD)

--- a/drivers/sensor/stm32_temp/stm32_temp.c
+++ b/drivers/sensor/stm32_temp/stm32_temp.c
@@ -122,7 +122,7 @@ static int stm32_temp_init(const struct device *dev)
 	k_mutex_init(&data->mutex);
 
 	if (!device_is_ready(data->adc)) {
-		LOG_ERR("Device %s is not ready", data->adc->name);
+		LOG_ERR("Device %s is not ready", device_name_get(data->adc));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/stm32_vbat/stm32_vbat.c
+++ b/drivers/sensor/stm32_vbat/stm32_vbat.c
@@ -93,7 +93,7 @@ static int stm32_vbat_init(const struct device *dev)
 	k_mutex_init(&data->mutex);
 
 	if (!device_is_ready(data->adc)) {
-		LOG_ERR("Device %s is not ready", data->adc->name);
+		LOG_ERR("Device %s is not ready", device_name_get(data->adc));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/sx9500/sx9500_trigger.c
+++ b/drivers/sensor/sx9500/sx9500_trigger.c
@@ -145,8 +145,8 @@ int sx9500_setup_interrupt(const struct device *dev)
 	data->dev = dev;
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-			cfg->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+			device_name_get(cfg->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/ti_hdc/ti_hdc.c
+++ b/drivers/sensor/ti_hdc/ti_hdc.c
@@ -143,8 +143,8 @@ static int ti_hdc_init(const struct device *dev)
 
 		/* setup data ready gpio interrupt */
 		if (!device_is_ready(cfg->drdy.port)) {
-			LOG_ERR("%s: device %s is not ready", dev->name,
-					cfg->drdy.port->name);
+			LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+					device_name_get(cfg->drdy.port));
 			return -ENODEV;
 		}
 

--- a/drivers/sensor/ti_hdc20xx/ti_hdc20xx.c
+++ b/drivers/sensor/ti_hdc20xx/ti_hdc20xx.c
@@ -163,7 +163,7 @@ static int ti_hdc20xx_init(const struct device *dev)
 	int rc;
 
 	if (!device_is_ready(config->bus.bus)) {
-		LOG_ERR("I2C bus %s not ready", config->bus.bus->name);
+		LOG_ERR("I2C bus %s not ready", device_name_get(config->bus.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tmp007/tmp007_trigger.c
+++ b/drivers/sensor/tmp007/tmp007_trigger.c
@@ -164,8 +164,8 @@ int tmp007_init_interrupt(const struct device *dev)
 	drv_data->dev = dev;
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tmp108/tmp108.c
+++ b/drivers/sensor/tmp108/tmp108.c
@@ -327,7 +327,7 @@ static int setup_interrupts(const struct device *dev)
 
 	if (!device_is_ready(alert_gpio->port)) {
 		LOG_ERR("tmp108: gpio controller %s not ready",
-			alert_gpio->port->name);
+			device_name_get(alert_gpio->port));
 		return -ENODEV;
 	}
 
@@ -366,7 +366,7 @@ static int tmp108_init(const struct device *dev)
 	int result = 0;
 
 	if (!device_is_ready(cfg->i2c_spec.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->i2c_spec.bus->name);
+		LOG_ERR("I2C dev %s not ready", device_name_get(cfg->i2c_spec.bus));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/tmp112/tmp112.c
+++ b/drivers/sensor/tmp112/tmp112.c
@@ -190,7 +190,7 @@ int tmp112_init(const struct device *dev)
 	struct tmp112_data *data = dev->data;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR("I2C dev %s not ready", device_name_get(cfg->bus.bus));
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/tmp116/tmp116.c
+++ b/drivers/sensor/tmp116/tmp116.c
@@ -149,13 +149,13 @@ static inline int tmp116_device_id_check(const struct device *dev, uint16_t *id)
 {
 	if (tmp116_reg_read(dev, TMP116_REG_DEVICE_ID, id) != 0) {
 		LOG_ERR("%s: Failed to get Device ID register!",
-			dev->name);
+			device_name_get(dev));
 		return -EIO;
 	}
 
 	if ((*id != TMP116_DEVICE_ID) && (*id != TMP117_DEVICE_ID)) {
 		LOG_ERR("%s: Failed to match the device IDs!",
-			dev->name);
+			device_name_get(dev));
 		return -EINVAL;
 	}
 
@@ -180,12 +180,12 @@ static int tmp116_sample_fetch(const struct device *dev,
 	rc = tmp116_reg_read(dev, TMP116_REG_CFGR, &cfg_reg);
 	if (rc < 0) {
 		LOG_ERR("%s, Failed to read from CFGR register",
-			dev->name);
+			device_name_get(dev));
 		return rc;
 	}
 
 	if ((cfg_reg & TMP116_CFGR_DATA_READY) == 0) {
-		LOG_DBG("%s: no data ready", dev->name);
+		LOG_DBG("%s: no data ready", device_name_get(dev));
 		return -EBUSY;
 	}
 
@@ -193,7 +193,7 @@ static int tmp116_sample_fetch(const struct device *dev,
 	rc = tmp116_reg_read(dev, TMP116_REG_TEMP, &value);
 	if (rc < 0) {
 		LOG_ERR("%s: Failed to read from TEMP register!",
-			dev->name);
+			device_name_get(dev));
 		return rc;
 	}
 
@@ -241,7 +241,7 @@ static int tmp116_attr_set(const struct device *dev,
 	case SENSOR_ATTR_OFFSET:
 		if (drv_data->id != TMP117_DEVICE_ID) {
 			LOG_ERR("%s: Offset is only supported by TMP117",
-			dev->name);
+			device_name_get(dev));
 			return -EINVAL;
 		}
 		/*
@@ -271,7 +271,7 @@ static int tmp116_init(const struct device *dev)
 	uint16_t id;
 
 	if (!device_is_ready(cfg->bus.bus)) {
-		LOG_ERR("I2C dev %s not ready", cfg->bus.bus->name);
+		LOG_ERR("I2C dev %s not ready", device_name_get(cfg->bus.bus));
 		return -EINVAL;
 	}
 

--- a/drivers/sensor/vcnl4040/vcnl4040_trigger.c
+++ b/drivers/sensor/vcnl4040/vcnl4040_trigger.c
@@ -269,8 +269,8 @@ int vcnl4040_trigger_init(const struct device *dev)
 
 	/* Get the GPIO device */
 	if (!device_is_ready(config->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				config->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(config->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/sensor/vl53l0x/vl53l0x.c
+++ b/drivers/sensor/vl53l0x/vl53l0x.c
@@ -63,7 +63,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 	ret = VL53L0X_StaticInit(&drv_data->vl53l0x);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_StaticInit failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -72,7 +72,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					    &PhaseCal);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_PerformRefCalibration failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -81,7 +81,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					       &isApertureSpads);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_PerformRefSpadManagement failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -89,7 +89,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 				    VL53L0X_DEVICEMODE_SINGLE_RANGING);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetDeviceMode failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -98,7 +98,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					  1);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetLimitCheckEnable sigma failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -107,7 +107,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					  1);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetLimitCheckEnable signal rate failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -117,7 +117,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetLimitCheckValue signal rate failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -126,7 +126,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					 VL53L0X_SETUP_SIGMA_LIMIT);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetLimitCheckValue sigma failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -134,7 +134,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 							     VL53L0X_SETUP_MAX_TIME_FOR_RANGING);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetMeasurementTimingBudgetMicroSeconds failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -143,7 +143,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					  VL53L0X_SETUP_PRE_RANGE_VCSEL_PERIOD);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetVcselPulsePeriod pre range failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -152,7 +152,7 @@ static int vl53l0x_setup_single_shot(const struct device *dev)
 					  VL53L0X_SETUP_FINAL_RANGE_VCSEL_PERIOD);
 	if (ret) {
 		LOG_ERR("[%s] VL53L0X_SetVcselPulsePeriod final range failed",
-			dev->name);
+			device_name_get(dev));
 		goto exit;
 	}
 
@@ -169,14 +169,14 @@ static int vl53l0x_start(const struct device *dev)
 	uint16_t vl53l0x_id = 0U;
 	VL53L0X_DeviceInfo_t vl53l0x_dev_info;
 
-	LOG_DBG("[%s] Starting", dev->name);
+	LOG_DBG("[%s] Starting", device_name_get(dev));
 
 	/* Pull XSHUT high to start the sensor */
 	if (config->xshut.port) {
 		r = gpio_pin_set_dt(&config->xshut, 1);
 		if (r < 0) {
 			LOG_ERR("[%s] Unable to set XSHUT gpio (error %d)",
-				dev->name, r);
+				device_name_get(dev), r);
 			return -EIO;
 		}
 		k_sleep(K_MSEC(2));
@@ -187,12 +187,12 @@ static int vl53l0x_start(const struct device *dev)
 		ret = VL53L0X_SetDeviceAddress(&drv_data->vl53l0x, 2 * config->i2c.addr);
 		if (ret != 0) {
 			LOG_ERR("[%s] Unable to reconfigure I2C address",
-				dev->name);
+				device_name_get(dev));
 			return -EIO;
 		}
 
 		drv_data->vl53l0x.I2cDevAddr = config->i2c.addr;
-		LOG_DBG("[%s] I2C address reconfigured", dev->name);
+		LOG_DBG("[%s] I2C address reconfigured", device_name_get(dev));
 		k_sleep(K_MSEC(2));
 	}
 #endif
@@ -202,11 +202,11 @@ static int vl53l0x_start(const struct device *dev)
 
 	ret = VL53L0X_GetDeviceInfo(&drv_data->vl53l0x, &vl53l0x_dev_info);
 	if (ret < 0) {
-		LOG_ERR("[%s] Could not get info from device.", dev->name);
+		LOG_ERR("[%s] Could not get info from device.", device_name_get(dev));
 		return -ENODEV;
 	}
 
-	LOG_DBG("[%s] VL53L0X_GetDeviceInfo = %d", dev->name, ret);
+	LOG_DBG("[%s] VL53L0X_GetDeviceInfo = %d", device_name_get(dev), ret);
 	LOG_DBG("   Device Name : %s", vl53l0x_dev_info.Name);
 	LOG_DBG("   Device Type : %s", vl53l0x_dev_info.Type);
 	LOG_DBG("   Device ID : %s", vl53l0x_dev_info.ProductId);
@@ -219,7 +219,7 @@ static int vl53l0x_start(const struct device *dev)
 			     VL53L0X_REG_WHO_AM_I,
 			     (uint16_t *) &vl53l0x_id);
 	if ((ret < 0) || (vl53l0x_id != VL53L0X_CHIP_ID)) {
-		LOG_ERR("[%s] Issue on device identification", dev->name);
+		LOG_ERR("[%s] Issue on device identification", device_name_get(dev));
 		return -ENOTSUP;
 	}
 
@@ -227,7 +227,7 @@ static int vl53l0x_start(const struct device *dev)
 	ret = VL53L0X_DataInit(&drv_data->vl53l0x);
 	if (ret < 0) {
 		LOG_ERR("[%s] VL53L0X_DataInit return error (%d)",
-			dev->name, ret);
+			device_name_get(dev), ret);
 		return -ENOTSUP;
 	}
 
@@ -237,7 +237,7 @@ static int vl53l0x_start(const struct device *dev)
 	}
 
 	drv_data->started = true;
-	LOG_DBG("[%s] Started", dev->name);
+	LOG_DBG("[%s] Started", device_name_get(dev));
 	return 0;
 }
 
@@ -263,7 +263,7 @@ static int vl53l0x_sample_fetch(const struct device *dev,
 						      &drv_data->RangingMeasurementData);
 	if (ret < 0) {
 		LOG_ERR("[%s] Could not perform measurment (error=%d)",
-			dev->name, ret);
+			device_name_get(dev), ret);
 		return -EINVAL;
 	}
 
@@ -314,14 +314,14 @@ static int vl53l0x_init(const struct device *dev)
 
 #ifdef CONFIG_VL53L0X_RECONFIGURE_ADDRESS
 	if (!config->xshut.port) {
-		LOG_ERR("[%s] Missing XSHUT gpio spec", dev->name);
+		LOG_ERR("[%s] Missing XSHUT gpio spec", device_name_get(dev));
 		return -ENOTSUP;
 	}
 #else
 	if (config->i2c.addr != VL53L0X_INITIAL_ADDR) {
 		LOG_ERR("[%s] Invalid device address (should be 0x%X or "
 			"CONFIG_VL53L0X_RECONFIGURE_ADDRESS should be enabled)",
-			dev->name, VL53L0X_INITIAL_ADDR);
+			device_name_get(dev), VL53L0X_INITIAL_ADDR);
 		return -ENOTSUP;
 	}
 #endif
@@ -330,7 +330,7 @@ static int vl53l0x_init(const struct device *dev)
 		r = gpio_pin_configure_dt(&config->xshut, GPIO_OUTPUT);
 		if (r < 0) {
 			LOG_ERR("[%s] Unable to configure GPIO as output",
-				dev->name);
+				device_name_get(dev));
 		}
 	}
 
@@ -338,10 +338,10 @@ static int vl53l0x_init(const struct device *dev)
 	/* Pull XSHUT low to shut down the sensor for now */
 	r = gpio_pin_set_dt(&config->xshut, 0);
 	if (r < 0) {
-		LOG_ERR("[%s] Unable to shutdown sensor", dev->name);
+		LOG_ERR("[%s] Unable to shutdown sensor", device_name_get(dev));
 		return -EIO;
 	}
-	LOG_DBG("[%s] Shutdown", dev->name);
+	LOG_DBG("[%s] Shutdown", device_name_get(dev));
 #else
 	r = vl53l0x_start(dev);
 	if (r) {
@@ -349,7 +349,7 @@ static int vl53l0x_init(const struct device *dev)
 	}
 #endif
 
-	LOG_DBG("[%s] Initialized", dev->name);
+	LOG_DBG("[%s] Initialized", device_name_get(dev));
 	return 0;
 }
 

--- a/drivers/sensor/wsen_itds/itds_trigger.c
+++ b/drivers/sensor/wsen_itds/itds_trigger.c
@@ -110,8 +110,8 @@ int itds_trigger_mode_init(const struct device *dev)
 	}
 
 	if (!device_is_ready(cfg->int_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->int_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->int_gpio.port));
 		return -ENODEV;
 	}
 

--- a/drivers/serial/uart_native_posix.c
+++ b/drivers/serial/uart_native_posix.c
@@ -218,7 +218,7 @@ static int np_uart_0_init(const struct device *dev)
 	d = (struct native_uart_status *)dev->data;
 
 	if (IS_ENABLED(CONFIG_NATIVE_UART_0_ON_OWN_PTY)) {
-		int tty_fn = open_tty(d, dev->name, auto_attach);
+		int tty_fn = open_tty(d, device_name_get(dev), auto_attach);
 
 		d->in_fd = tty_fn;
 		d->out_fd = tty_fn;
@@ -254,7 +254,7 @@ static int np_uart_1_init(const struct device *dev)
 
 	d = (struct native_uart_status *)dev->data;
 
-	tty_fn = open_tty(d, dev->name, false);
+	tty_fn = open_tty(d, device_name_get(dev), false);
 
 	d->in_fd = tty_fn;
 	d->out_fd = tty_fn;

--- a/drivers/serial/uart_rtt.c
+++ b/drivers/serial/uart_rtt.c
@@ -36,10 +36,10 @@ static int uart_rtt_init(const struct device *dev)
 	if (dev->config) {
 		const struct uart_rtt_config *cfg = dev->config;
 
-		SEGGER_RTT_ConfigUpBuffer(cfg->channel, dev->name,
+		SEGGER_RTT_ConfigUpBuffer(cfg->channel, device_name_get(dev),
 					  cfg->up_buffer, cfg->up_size,
 					  SEGGER_RTT_MODE_NO_BLOCK_SKIP);
-		SEGGER_RTT_ConfigDownBuffer(cfg->channel, dev->name,
+		SEGGER_RTT_ConfigDownBuffer(cfg->channel, device_name_get(dev),
 					    cfg->down_buffer, cfg->down_size,
 					    SEGGER_RTT_MODE_NO_BLOCK_SKIP);
 	}

--- a/drivers/serial/uart_stm32.c
+++ b/drivers/serial/uart_stm32.c
@@ -142,7 +142,7 @@ static inline void uart_stm32_set_baudrate(const struct device *dev, uint32_t ba
 		}
 
 		if (presc_idx == ARRAY_SIZE(LPUART_PRESCALER_TAB)) {
-			LOG_ERR("Unable to set %s to %d", dev->name, baud_rate);
+			LOG_ERR("Unable to set %s to %d", device_name_get(dev), baud_rate);
 			return;
 		}
 
@@ -152,7 +152,7 @@ static inline void uart_stm32_set_baudrate(const struct device *dev, uint32_t ba
 #else
 		lpuartdiv = lpuartdiv_calc(clock_rate, baud_rate);
 		if (lpuartdiv < LPUART_BRR_MIN_VALUE || lpuartdiv > LPUART_BRR_MASK) {
-			LOG_ERR("Unable to set %s to %d", dev->name, baud_rate);
+			LOG_ERR("Unable to set %s to %d", device_name_get(dev), baud_rate);
 			return;
 		}
 #endif /* USART_PRESC_PRESCALER */

--- a/drivers/spi/spi_andes_atcspi200.c
+++ b/drivers/spi/spi_andes_atcspi200.c
@@ -138,7 +138,7 @@ static int configure(const struct device *dev,
 
 	if (SPI_OP_MODE_GET(config->operation) != SPI_OP_MODE_MASTER) {
 		LOG_ERR("Slave mode is not supported on %s",
-			    dev->name);
+			    device_name_get(dev));
 		return -EINVAL;
 	}
 

--- a/drivers/spi/spi_context.h
+++ b/drivers/spi/spi_context.h
@@ -214,7 +214,7 @@ static inline int spi_context_cs_configure_all(struct spi_context *ctx)
 	for (cs_gpio = ctx->cs_gpios; cs_gpio < &ctx->cs_gpios[ctx->num_cs_gpios]; cs_gpio++) {
 		if (!device_is_ready(cs_gpio->port)) {
 			LOG_ERR("CS GPIO port %s pin %d is not ready",
-				cs_gpio->port->name, cs_gpio->pin);
+				device_name_get(cs_gpio->port), cs_gpio->pin);
 			return -ENODEV;
 		}
 

--- a/drivers/spi/spi_emul.c
+++ b/drivers/spi/spi_emul.c
@@ -98,7 +98,7 @@ static int spi_emul_init(const struct device *dev)
 int spi_emul_register(const struct device *dev, struct spi_emul *emul)
 {
 	struct spi_emul_data *data = dev->data;
-	const char *name = emul->target->dev->name;
+	const char *name = device_name_get(emul->target->dev);
 
 	sys_slist_append(&data->emuls, &emul->node);
 

--- a/drivers/spi/spi_ll_stm32.c
+++ b/drivers/spi/spi_ll_stm32.c
@@ -906,13 +906,13 @@ static int spi_stm32_init(const struct device *dev)
 #ifdef CONFIG_SPI_STM32_DMA
 	if ((data->dma_rx.dma_dev != NULL) &&
 				!device_is_ready(data->dma_rx.dma_dev)) {
-		LOG_ERR("%s device not ready", data->dma_rx.dma_dev->name);
+		LOG_ERR("%s device not ready", device_name_get(data->dma_rx.dma_dev));
 		return -ENODEV;
 	}
 
 	if ((data->dma_tx.dma_dev != NULL) &&
 				!device_is_ready(data->dma_tx.dma_dev)) {
-		LOG_ERR("%s device not ready", data->dma_tx.dma_dev->name);
+		LOG_ERR("%s device not ready", device_name_get(data->dma_tx.dma_dev));
 		return -ENODEV;
 	}
 

--- a/drivers/spi/spi_mcux_flexcomm.c
+++ b/drivers/spi/spi_mcux_flexcomm.c
@@ -744,12 +744,12 @@ static int spi_mcux_init(const struct device *dev)
 
 #ifdef CONFIG_SPI_MCUX_FLEXCOMM_DMA
 	if (!device_is_ready(data->dma_tx.dma_dev)) {
-		LOG_ERR("%s device is not ready", data->dma_tx.dma_dev->name);
+		LOG_ERR("%s device is not ready", device_name_get(data->dma_tx.dma_dev));
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(data->dma_rx.dma_dev)) {
-		LOG_ERR("%s device is not ready", data->dma_rx.dma_dev->name);
+		LOG_ERR("%s device is not ready", device_name_get(data->dma_rx.dma_dev));
 		return -ENODEV;
 	}
 #endif /* CONFIG_SPI_MCUX_FLEXCOMM_DMA */

--- a/drivers/spi/spi_mcux_lpspi.c
+++ b/drivers/spi/spi_mcux_lpspi.c
@@ -548,12 +548,12 @@ static int spi_mcux_init(const struct device *dev)
 
 #ifdef CONFIG_SPI_MCUX_LPSPI_DMA
 	if (!device_is_ready(data->dma_tx.dma_dev)) {
-		LOG_ERR("%s device is not ready", data->dma_tx.dma_dev->name);
+		LOG_ERR("%s device is not ready", device_name_get(data->dma_tx.dma_dev));
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(data->dma_rx.dma_dev)) {
-		LOG_ERR("%s device is not ready", data->dma_rx.dma_dev->name);
+		LOG_ERR("%s device is not ready", device_name_get(data->dma_rx.dma_dev));
 		return -ENODEV;
 	}
 #endif /* CONFIG_SPI_MCUX_LPSPI_DMA */

--- a/drivers/spi/spi_npcx_fiu.c
+++ b/drivers/spi/spi_npcx_fiu.c
@@ -146,7 +146,7 @@ static int spi_npcx_fiu_init(const struct device *dev)
 	int ret;
 
 	if (!device_is_ready(clk_dev)) {
-		LOG_ERR("%s device not ready", clk_dev->name);
+		LOG_ERR("%s device not ready", device_name_get(clk_dev));
 		return -ENODEV;
 	}
 

--- a/drivers/spi/spi_nrfx_spi.c
+++ b/drivers/spi/spi_nrfx_spi.c
@@ -101,7 +101,7 @@ static int configure(const struct device *dev,
 	}
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) != SPI_OP_MODE_MASTER) {
-		LOG_ERR("Slave mode is not supported on %s", dev->name);
+		LOG_ERR("Slave mode is not supported on %s", device_name_get(dev));
 		return -EINVAL;
 	}
 

--- a/drivers/spi/spi_nrfx_spim.c
+++ b/drivers/spi/spi_nrfx_spim.c
@@ -140,7 +140,7 @@ static int configure(const struct device *dev,
 	}
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) != SPI_OP_MODE_MASTER) {
-		LOG_ERR("Slave mode is not supported on %s", dev->name);
+		LOG_ERR("Slave mode is not supported on %s", device_name_get(dev));
 		return -EINVAL;
 	}
 
@@ -277,7 +277,7 @@ static int anomaly_58_workaround_init(const struct device *dev)
 			return -ENODEV;
 		}
 		LOG_DBG("PAN 58 workaround enabled for %s: ppi %u, gpiote %u",
-			dev->name, dev_data->ppi_ch, dev_data->gpiote_ch);
+			device_name_get(dev), dev_data->ppi_ch, dev_data->gpiote_ch);
 	}
 
 	return 0;

--- a/drivers/spi/spi_nrfx_spis.c
+++ b/drivers/spi/spi_nrfx_spis.c
@@ -78,7 +78,7 @@ static int configure(const struct device *dev,
 	}
 
 	if (SPI_OP_MODE_GET(spi_cfg->operation) == SPI_OP_MODE_MASTER) {
-		LOG_ERR("Master mode is not supported on %s", dev->name);
+		LOG_ERR("Master mode is not supported on %s", device_name_get(dev));
 		return -EINVAL;
 	}
 
@@ -254,7 +254,7 @@ static int spi_nrfx_init(const struct device *dev)
 				event_handler, dev_data);
 
 	if (result != NRFX_SUCCESS) {
-		LOG_ERR("Failed to initialize device: %s", dev->name);
+		LOG_ERR("Failed to initialize device: %s", device_name_get(dev));
 		return -EBUSY;
 	}
 

--- a/drivers/video/ov2640.c
+++ b/drivers/video/ov2640.c
@@ -1044,8 +1044,8 @@ static int ov2640_init_0(const struct device *dev)
 
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	if (!device_is_ready(cfg->reset_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->reset_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->reset_gpio.port));
 		return -ENODEV;
 	}
 #endif

--- a/drivers/video/ov7725.c
+++ b/drivers/video/ov7725.c
@@ -634,8 +634,8 @@ static int ov7725_init_0(const struct device *dev)
 
 #if DT_INST_NODE_HAS_PROP(0, reset_gpios)
 	if (!device_is_ready(cfg->reset_gpio.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->reset_gpio.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->reset_gpio.port));
 		return -ENODEV;
 	}
 #endif

--- a/drivers/watchdog/wdt_gecko.c
+++ b/drivers/watchdog/wdt_gecko.c
@@ -262,7 +262,7 @@ static int wdt_gecko_init(const struct device *dev)
 	/* Enable IRQs */
 	config->irq_cfg_func();
 
-	LOG_INF("Device %s initialized", dev->name);
+	LOG_INF("Device %s initialized", device_name_get(dev));
 
 	return 0;
 }

--- a/drivers/wifi/eswifi/eswifi_bus_spi.c
+++ b/drivers/wifi/eswifi/eswifi_bus_spi.c
@@ -236,7 +236,7 @@ int eswifi_spi_init(struct eswifi_dev *eswifi)
 
 	/* SPI DATA READY PIN */
 	if (!device_is_ready(cfg->dr.port)) {
-		LOG_ERR("device %s is not ready", cfg->dr.port->name);
+		LOG_ERR("device %s is not ready", device_name_get(cfg->dr.port));
 		return -ENODEV;
 	}
 	gpio_pin_configure_dt(&cfg->dr, GPIO_INPUT);

--- a/drivers/wifi/eswifi/eswifi_core.c
+++ b/drivers/wifi/eswifi/eswifi_core.c
@@ -654,15 +654,15 @@ static int eswifi_init(const struct device *dev)
 	eswifi->bus->init(eswifi);
 
 	if (!device_is_ready(cfg->resetn.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->resetn.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->resetn.port));
 		return -ENODEV;
 	}
 	gpio_pin_configure_dt(&cfg->resetn, GPIO_OUTPUT_INACTIVE);
 
 	if (!device_is_ready(cfg->wakeup.port)) {
-		LOG_ERR("%s: device %s is not ready", dev->name,
-				cfg->wakeup.port->name);
+		LOG_ERR("%s: device %s is not ready", device_name_get(dev),
+				device_name_get(cfg->wakeup.port));
 		return -ENODEV;
 	}
 	gpio_pin_configure_dt(&cfg->wakeup, GPIO_OUTPUT_ACTIVE);

--- a/include/zephyr/drivers/can.h
+++ b/include/zephyr/drivers/can.h
@@ -573,7 +573,7 @@ struct can_device_state {
 			CONTAINER_OF(dev->state, struct can_device_state, devstate); \
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 6,	\
 			   STATS_NAME_INIT_PARMS(can));			\
-		stats_register(dev->name, &(state->stats.s_hdr));	\
+		stats_register(device_name_get(dev), &(state->stats.s_hdr));	\
 		return init_fn(dev);					\
 	}
 

--- a/include/zephyr/drivers/i2c.h
+++ b/include/zephyr/drivers/i2c.h
@@ -474,7 +474,7 @@ static inline void i2c_xfer_stats(const struct device *dev, struct i2c_msg *msgs
 			CONTAINER_OF(dev->state, struct i2c_device_state, devstate); \
 		stats_init(&state->stats.s_hdr, STATS_SIZE_32, 4,	\
 			   STATS_NAME_INIT_PARMS(i2c));			\
-		stats_register(dev->name, &(state->stats.s_hdr));	\
+		stats_register(device_name_get(dev), &(state->stats.s_hdr));	\
 		return init_fn(dev);					\
 	}
 

--- a/kernel/Kconfig
+++ b/kernel/Kconfig
@@ -951,6 +951,15 @@ config HAS_DYNAMIC_DEVICE_HANDLES
 	  Hidden option that makes possible to manipulate device handles at
 	  runtime.
 
+config DEVICE_STORE_NAME
+	bool "Store devices name"
+	default y
+	help
+	  When enabled, devices will have a unique human readable name. Device
+	  names can be useful when debugging or to obtain a device instance at
+	  runtime. Turning this option off can save ROM. When disabled,
+	  device_get_binding will not be available.
+
 endmenu
 
 rsource "Kconfig.vm"

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -88,6 +88,7 @@ void z_sys_init_run_level(int32_t level)
 	}
 }
 
+#ifdef CONFIG_DEVICE_STORE_NAME
 const struct device *z_impl_device_get_binding(const char *name)
 {
 	const struct device *dev;
@@ -118,8 +119,10 @@ const struct device *z_impl_device_get_binding(const char *name)
 
 	return NULL;
 }
+#endif /* CONFIG_DEVICE_STORE_NAME */
 
 #ifdef CONFIG_USERSPACE
+#ifdef CONFIG_DEVICE_STORE_NAME
 static inline const struct device *z_vrfy_device_get_binding(const char *name)
 {
 	char name_copy[Z_DEVICE_MAX_NAME_LEN];
@@ -132,6 +135,7 @@ static inline const struct device *z_vrfy_device_get_binding(const char *name)
 	return z_impl_device_get_binding(name_copy);
 }
 #include <syscalls/device_get_binding_mrsh.c>
+#endif /* CONFIG_DEVICE_STORE_NAME */
 
 static inline bool z_vrfy_device_is_ready(const struct device *dev)
 {

--- a/kernel/device.c
+++ b/kernel/device.c
@@ -106,13 +106,14 @@ const struct device *z_impl_device_get_binding(const char *name)
 	 * performed. Reserve string comparisons for a fallback.
 	 */
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if (z_device_is_ready(dev) && (dev->name == name)) {
+		if (z_device_is_ready(dev) && (device_name_get(dev) == name)) {
 			return dev;
 		}
 	}
 
 	for (dev = __device_start; dev != __device_end; dev++) {
-		if (z_device_is_ready(dev) && (strcmp(name, dev->name) == 0)) {
+		if (z_device_is_ready(dev) &&
+		    (strcmp(name, device_name_get(dev)) == 0)) {
 			return dev;
 		}
 	}

--- a/samples/application_development/out_of_tree_driver/src/main.c
+++ b/samples/application_development/out_of_tree_driver/src/main.c
@@ -23,7 +23,7 @@ void main(void)
 
 	__ASSERT(dev, "Failed to get device binding");
 
-	printk("device is %p, name is %s\n", dev, dev->name);
+	printk("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	k_object_access_grant(dev, k_current_get());
 	k_thread_user_mode_enter(user_entry, NULL, NULL, NULL);

--- a/samples/basic/blinky_pwm/src/main.c
+++ b/samples/basic/blinky_pwm/src/main.c
@@ -30,7 +30,7 @@ void main(void)
 
 	if (!device_is_ready(pwm_led0.dev)) {
 		printk("Error: PWM device %s is not ready\n",
-		       pwm_led0.dev->name);
+		       device_name_get(pwm_led0.dev));
 		return;
 	}
 

--- a/samples/basic/button/src/main.c
+++ b/samples/basic/button/src/main.c
@@ -44,14 +44,14 @@ void main(void)
 
 	if (!device_is_ready(button.port)) {
 		printk("Error: button device %s is not ready\n",
-		       button.port->name);
+		       device_name_get(button.port));
 		return;
 	}
 
 	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 	if (ret != 0) {
 		printk("Error %d: failed to configure %s pin %d\n",
-		       ret, button.port->name, button.pin);
+		       ret, device_name_get(button.port), button.pin);
 		return;
 	}
 
@@ -59,27 +59,27 @@ void main(void)
 					      GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n",
-			ret, button.port->name, button.pin);
+			ret, device_name_get(button.port), button.pin);
 		return;
 	}
 
 	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));
 	gpio_add_callback(button.port, &button_cb_data);
-	printk("Set up button at %s pin %d\n", button.port->name, button.pin);
+	printk("Set up button at %s pin %d\n", device_name_get(button.port), button.pin);
 
 	if (led.port && !device_is_ready(led.port)) {
 		printk("Error %d: LED device %s is not ready; ignoring it\n",
-		       ret, led.port->name);
+		       ret, device_name_get(led.port));
 		led.port = NULL;
 	}
 	if (led.port) {
 		ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT);
 		if (ret != 0) {
 			printk("Error %d: failed to configure LED device %s pin %d\n",
-			       ret, led.port->name, led.pin);
+			       ret, device_name_get(led.port), led.pin);
 			led.port = NULL;
 		} else {
-			printk("Set up LED at %s pin %d\n", led.port->name, led.pin);
+			printk("Set up LED at %s pin %d\n", device_name_get(led.port), led.pin);
 		}
 	}
 

--- a/samples/basic/fade_led/src/main.c
+++ b/samples/basic/fade_led/src/main.c
@@ -30,7 +30,7 @@ void main(void)
 
 	if (!device_is_ready(pwm_led0.dev)) {
 		printk("Error: PWM device %s is not ready\n",
-		       pwm_led0.dev->name);
+		       device_name_get(pwm_led0.dev));
 		return;
 	}
 

--- a/samples/basic/minimal/common.conf
+++ b/samples/basic/minimal/common.conf
@@ -1,3 +1,6 @@
+# Devices
+CONFIG_DEVICE_STORE_NAME=n
+
 # Drivers and peripherals
 CONFIG_I2C=n
 CONFIG_WATCHDOG=n

--- a/samples/basic/servo_motor/src/main.c
+++ b/samples/basic/servo_motor/src/main.c
@@ -33,7 +33,8 @@ void main(void)
 	printk("Servomotor control\n");
 
 	if (!device_is_ready(servo.dev)) {
-		printk("Error: PWM device %s is not ready\n", servo.dev->name);
+		printk("Error: PWM device %s is not ready\n",
+		       device_name_get(servo.dev));
 		return;
 	}
 

--- a/samples/basic/threads/src/main.c
+++ b/samples/basic/threads/src/main.c
@@ -58,7 +58,7 @@ void blink(const struct led *led, uint32_t sleep_ms, uint32_t id)
 	int ret;
 
 	if (!device_is_ready(spec->port)) {
-		printk("Error: %s device is not ready\n", spec->port->name);
+		printk("Error: %s device is not ready\n", device_name_get(spec->port));
 		return;
 	}
 

--- a/samples/bluetooth/central_otc/src/main.c
+++ b/samples/bluetooth/central_otc/src/main.c
@@ -170,13 +170,15 @@ static void configure_button_irq(const struct gpio_dt_spec btn)
 	int ret;
 
 	if (!device_is_ready(btn.port)) {
-		printk("Error: button device %s is not ready\n", btn.port->name);
+		printk("Error: button device %s is not ready\n",
+		       device_name_get(btn.port));
 		return;
 	}
 
 	ret = gpio_pin_configure_dt(&btn, GPIO_INPUT);
 	if (ret != 0) {
-		printk("Error %d: failed to configure %s pin %d\n", ret, btn.port->name, btn.pin);
+		printk("Error %d: failed to configure %s pin %d\n", ret,
+		       device_name_get(btn.port), btn.pin);
 		return;
 	}
 
@@ -184,14 +186,15 @@ static void configure_button_irq(const struct gpio_dt_spec btn)
 
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
-		       btn.port->name, btn.pin);
+		       device_name_get(btn.port), btn.pin);
 		return;
 	}
 
 	button_cb_data.pin_mask |= BIT(btn.pin);
 	gpio_add_callback(btn.port, &button_cb_data);
 
-	printk("Set up button at %s pin %d\n", btn.port->name, btn.pin);
+	printk("Set up button at %s pin %d\n", device_name_get(btn.port),
+	       btn.pin);
 }
 
 static void configure_buttons(void)

--- a/samples/bluetooth/hci_spi/src/main.c
+++ b/samples/bluetooth/hci_spi/src/main.c
@@ -266,12 +266,12 @@ static int hci_spi_init(const struct device *unused)
 	LOG_DBG("");
 
 	if (!device_is_ready(spi_hci_dev)) {
-		LOG_ERR("SPI bus %s is not ready", spi_hci_dev->name);
+		LOG_ERR("SPI bus %s is not ready", device_name_get(spi_hci_dev));
 		return -EINVAL;
 	}
 
 	if (!device_is_ready(irq.port)) {
-		LOG_ERR("IRQ GPIO port %s is not ready", irq.port->name);
+		LOG_ERR("IRQ GPIO port %s is not ready", device_name_get(irq.port));
 		return -EINVAL;
 	}
 	gpio_pin_configure_dt(&irq, GPIO_OUTPUT_INACTIVE);

--- a/samples/bluetooth/hci_uart/src/main.c
+++ b/samples/bluetooth/hci_uart/src/main.c
@@ -329,7 +329,7 @@ static int hci_uart_init(const struct device *unused)
 	LOG_DBG("");
 
 	if (!device_is_ready(hci_uart_dev)) {
-		LOG_ERR("HCI UART %s is not ready", hci_uart_dev->name);
+		LOG_ERR("HCI UART %s is not ready", device_name_get(hci_uart_dev));
 		return -EINVAL;
 	}
 

--- a/samples/bluetooth/mesh_provisioner/src/main.c
+++ b/samples/bluetooth/mesh_provisioner/src/main.c
@@ -308,19 +308,20 @@ static void button_init(void)
 	int ret;
 
 	if (!device_is_ready(button.port)) {
-		printk("Error: button device %s is not ready\n", button.port->name);
+		printk("Error: button device %s is not ready\n",
+		       device_name_get(button.port));
 		return;
 	}
 	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 	if (ret != 0) {
-		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
-		       button.pin);
+		printk("Error %d: failed to configure %s pin %d\n", ret,
+		       device_name_get(button.port), button.pin);
 		return;
 	}
 	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
-		       button.port->name, button.pin);
+		       device_name_get(button.port), button.pin);
 		return;
 	}
 	gpio_init_callback(&button_cb_data, button_pressed, BIT(button.pin));

--- a/samples/bluetooth/peripheral_ht/src/hts.c
+++ b/samples/bluetooth/peripheral_ht/src/hts.c
@@ -70,7 +70,7 @@ void hts_init(void)
 		temp_dev = NULL;
 	} else {
 		printk("temp device is %p, name is %s\n", temp_dev,
-		       temp_dev->name);
+		       device_name_get(temp_dev));
 	}
 }
 

--- a/samples/bluetooth/st_ble_sensor/src/button_svc.c
+++ b/samples/bluetooth/st_ble_sensor/src/button_svc.c
@@ -30,14 +30,14 @@ int button_init(gpio_callback_handler_t handler)
 
 	if (!device_is_ready(button.port)) {
 		LOG_ERR("Error: button GPIO device %s is not ready",
-			button.port->name);
+			device_name_get(button.port));
 		return -ENODEV;
 	}
 
 	ret = gpio_pin_configure_dt(&button, GPIO_INPUT);
 	if (ret != 0) {
 		LOG_ERR("Error %d: can't configure button on GPIO %s pin %d",
-			ret, button.port->name, button.pin);
+			ret, device_name_get(button.port), button.pin);
 		return ret;
 
 	}
@@ -47,7 +47,7 @@ int button_init(gpio_callback_handler_t handler)
 	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret != 0) {
 		LOG_ERR("Error %d: can't configure button interrupt on "
-			"GPIO %s pin %d", ret, button.port->name, button.pin);
+			"GPIO %s pin %d", device_name_get(ret, button.port), button.pin);
 		return ret;
 	}
 	return 0;

--- a/samples/bluetooth/st_ble_sensor/src/led_svc.c
+++ b/samples/bluetooth/st_ble_sensor/src/led_svc.c
@@ -38,14 +38,14 @@ int led_init(void)
 	led_ok = device_is_ready(led.port);
 	if (!led_ok) {
 		LOG_ERR("Error: LED on GPIO %s pin %d is not ready",
-			led.port->name, led.pin);
+			device_name_get(led.port), led.pin);
 		return -ENODEV;
 	}
 
 	ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_INACTIVE);
 	if (ret < 0) {
 		LOG_ERR("Error %d: failed to configure GPIO %s pin %d",
-			ret, led.port->name, led.pin);
+			ret, device_name_get(led.port), led.pin);
 	}
 
 	return ret;

--- a/samples/boards/96b_argonkey/microphone/src/main.c
+++ b/samples/boards/96b_argonkey/microphone/src/main.c
@@ -89,7 +89,7 @@ void main(void)
 	static const struct device *const ledc = DEVICE_DT_GET_ONE(ti_lp3943);
 
 	if (!device_is_ready(ledc)) {
-		printk("Device %s is not ready\n", ledc->name);
+		printk("Device %s is not ready\n", device_name_get(ledc));
 		return;
 	}
 
@@ -114,7 +114,7 @@ void main(void)
 	const struct device *const mic_dev = DEVICE_DT_GET_ONE(st_mpxxdtyy);
 
 	if (!device_is_ready(mic_dev)) {
-		printk("Device %s is not ready\n", mic_dev->name);
+		printk("Device %s is not ready\n", device_name_get(mic_dev));
 		return;
 	}
 

--- a/samples/boards/96b_argonkey/sensors/README.rst
+++ b/samples/boards/96b_argonkey/sensors/README.rst
@@ -32,7 +32,7 @@ build correctly. Example:
       struct device *hum_dev = DEVICE_DT_GET_ONE(st_hts221);
 
       if (!device_is_ready(hum_dev)) {
-        printk("%s: device not ready.\n", hum_dev->name);
+        printk("%s: device not ready.\n", device_name_get(hum_dev));
         return;
       }
     #endif

--- a/samples/boards/96b_argonkey/sensors/src/main.c
+++ b/samples/boards/96b_argonkey/sensors/src/main.c
@@ -117,7 +117,7 @@ void main(void)
 
 #ifdef CONFIG_LP3943
 	if (!device_is_ready(ledc)) {
-		printk("%s: device not ready.\n", ledc->name);
+		printk("%s: device not ready.\n", device_name_get(ledc));
 		return;
 	}
 
@@ -135,13 +135,13 @@ void main(void)
 #endif
 
 	if (!device_is_ready(led0_gpio.port)) {
-		printk("%s: device not ready.\n", led0_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(led0_gpio.port));
 		return;
 	}
 	gpio_pin_configure_dt(&led0_gpio, GPIO_OUTPUT_ACTIVE);
 
 	if (!device_is_ready(led1_gpio.port)) {
-		printk("%s: device not ready.\n", led1_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(led1_gpio.port));
 		return;
 	}
 	gpio_pin_configure_dt(&led1_gpio, GPIO_OUTPUT_INACTIVE);
@@ -158,7 +158,7 @@ void main(void)
 	const struct device *const baro_dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
 
 	if (!device_is_ready(baro_dev)) {
-		printk("%s: device not ready.\n", baro_dev->name);
+		printk("%s: device not ready.\n", device_name_get(baro_dev));
 		return;
 	}
 #endif
@@ -167,7 +167,7 @@ void main(void)
 	const struct device *const hum_dev = DEVICE_DT_GET_ONE(st_hts221);
 
 	if (!device_is_ready(hum_dev)) {
-		printk("%s: device not ready.\n", hum_dev->name);
+		printk("%s: device not ready.\n", device_name_get(hum_dev));
 		return;
 	}
 #endif
@@ -176,7 +176,7 @@ void main(void)
 	const struct device *const accel_dev = DEVICE_DT_GET_ONE(st_lsm6dsl);
 
 	if (!device_is_ready(accel_dev)) {
-		printk("%s: device not ready.\n", accel_dev->name);
+		printk("%s: device not ready.\n", device_name_get(accel_dev));
 		return;
 	}
 
@@ -240,7 +240,7 @@ void main(void)
 	const struct device *const tof_dev = DEVICE_DT_GET_ONE(st_vl53l0x);
 
 	if (!device_is_ready(tof_dev)) {
-		printk("%s: device not ready.\n", tof_dev->name);
+		printk("%s: device not ready.\n", device_name_get(tof_dev));
 		return;
 	}
 #endif

--- a/samples/boards/bbc_microbit/pong/src/main.c
+++ b/samples/boards/bbc_microbit/pong/src/main.c
@@ -497,7 +497,7 @@ static void configure_buttons(void)
 
 	/* since sw0_gpio.port == sw1_gpio.port, we only need to check ready once */
 	if (!device_is_ready(sw0_gpio.port)) {
-		printk("%s: device not ready.\n", sw0_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(sw0_gpio.port));
 		return;
 	}
 
@@ -522,7 +522,7 @@ void main(void)
 	k_work_init_delayable(&refresh, game_refresh);
 
 	if (!device_is_ready(pwm.dev)) {
-		printk("%s: device not ready.\n", pwm.dev->name);
+		printk("%s: device not ready.\n", device_name_get(pwm.dev));
 		return;
 	}
 

--- a/samples/boards/bbc_microbit/sound/src/main.c
+++ b/samples/boards/bbc_microbit/sound/src/main.c
@@ -86,13 +86,13 @@ void main(void)
 	static struct gpio_callback button_cb_data;
 
 	if (!device_is_ready(pwm.dev)) {
-		printk("%s: device not ready.\n", pwm.dev->name);
+		printk("%s: device not ready.\n", device_name_get(pwm.dev));
 		return;
 	}
 
 	/* since sw0_gpio.port == sw1_gpio.port, we only need to check ready once */
 	if (!device_is_ready(sw0_gpio.port)) {
-		printk("%s: device not ready.\n", sw0_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(sw0_gpio.port));
 		return;
 	}
 

--- a/samples/boards/esp32/flash_encryption/src/main.c
+++ b/samples/boards/esp32/flash_encryption/src/main.c
@@ -28,7 +28,7 @@ void main(void)
 
 	flash_device = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
 	if (!device_is_ready(flash_device)) {
-		printk("%s: device not ready.\n", flash_device->name);
+		printk("%s: device not ready.\n", device_name_get(flash_device));
 		return;
 	}
 

--- a/samples/boards/mimxrt1060_evk/system_off/src/main.c
+++ b/samples/boards/mimxrt1060_evk/system_off/src/main.c
@@ -36,7 +36,8 @@ void main(void)
 	printk("\n%s system off demo\n", CONFIG_BOARD);
 
 	if (!device_is_ready(button.port)) {
-		printk("Error: button device %s is not ready\n", button.port->name);
+		printk("Error: button device %s is not ready\n",
+		       device_name_get(button.port));
 		return;
 	}
 
@@ -45,15 +46,15 @@ void main(void)
 	int ret = gpio_pin_configure_dt(&button, GPIO_INPUT | GPIO_PULL_UP);
 
 	if (ret != 0) {
-		printk("Error %d: failed to configure %s pin %d\n", ret, button.port->name,
-		       button.pin);
+		printk("Error %d: failed to configure %s pin %d\n", ret,
+		       device_name_get(button.port), button.pin);
 		return;
 	}
 
 	ret = gpio_pin_interrupt_configure_dt(&button, GPIO_INT_LEVEL_LOW);
 	if (ret != 0) {
 		printk("Error %d: failed to configure interrupt on %s pin %d\n", ret,
-		       button.port->name, button.pin);
+		       device_name_get(button.port), button.pin);
 		return;
 	}
 
@@ -82,7 +83,8 @@ void main(void)
 	}
 	printk("RTC Alarm set for %llu seconds to wake from soft-off.\n",
 	       counter_ticks_to_us(snvs_rtc_dev, alarm_cfg.ticks) / (1000ULL * 1000ULL));
-	printk("Entering system off; press %s to restart sooner\n", button.port->name);
+	printk("Entering system off; press %s to restart sooner\n",
+	       device_name_get(button.port));
 
 	pm_state_force(0u, &(struct pm_state_info){ PM_STATE_SOFT_OFF, 0, 0 });
 

--- a/samples/boards/nrf/battery/src/battery.c
+++ b/samples/boards/nrf/battery/src/battery.c
@@ -90,19 +90,19 @@ static int divider_setup(void)
 	int rc;
 
 	if (!device_is_ready(ddp->adc)) {
-		LOG_ERR("ADC device is not ready %s", ddp->adc->name);
+		LOG_ERR("ADC device is not ready %s", device_name_get(ddp->adc));
 		return -ENOENT;
 	}
 
 	if (gcp->port) {
 		if (!device_is_ready(gcp->port)) {
-			LOG_ERR("%s: device not ready", gcp->port->name);
+			LOG_ERR("%s: device not ready", device_name_get(gcp->port));
 			return -ENOENT;
 		}
 		rc = gpio_pin_configure_dt(gcp, GPIO_OUTPUT_INACTIVE);
 		if (rc != 0) {
 			LOG_ERR("Failed to control feed %s.%u: %d",
-				gcp->port->name, gcp->pin, rc);
+				device_name_get(gcp->port), gcp->pin, rc);
 			return rc;
 		}
 	}

--- a/samples/boards/nrf/clock_skew/src/main.c
+++ b/samples/boards/nrf/clock_skew/src/main.c
@@ -201,7 +201,7 @@ void main(void)
 
 	/* Grab the clock driver */
 	if (!device_is_ready(clock0)) {
-		printk("%s: device not ready.\n", clock0->name);
+		printk("%s: device not ready.\n", device_name_get(clock0));
 		return;
 	}
 
@@ -214,7 +214,7 @@ void main(void)
 
 	/* Grab the timer. */
 	if (!device_is_ready(timer0)) {
-		printk("%s: device not ready.\n", timer0->name);
+		printk("%s: device not ready.\n", device_name_get(timer0));
 		return;
 	}
 
@@ -224,19 +224,19 @@ void main(void)
 	sync_config.ref_Hz = counter_get_frequency(timer0);
 	if (sync_config.ref_Hz == 0) {
 		printk("Timer %s has no fixed frequency\n",
-			timer0->name);
+			device_name_get(timer0));
 		return;
 	}
 
 	top = counter_get_top_value(timer0);
 	if (top != UINT32_MAX) {
 		printk("Timer %s wraps at %u (0x%08x) not at 32 bits\n",
-		       timer0->name, top, top);
+		       device_name_get(timer0), top, top);
 		return;
 	}
 
 	rc = counter_start(timer0);
-	printk("Start %s: %d\n", timer0->name, rc);
+	printk("Start %s: %d\n", device_name_get(timer0), rc);
 
 	show_clocks("Timer-running clocks");
 
@@ -245,7 +245,7 @@ void main(void)
 	sync_state.cfg = &sync_config;
 
 	printf("Checking %s at %u Hz against ticks at %u Hz\n",
-	       timer0->name, sync_config.ref_Hz, sync_config.local_Hz);
+	       device_name_get(timer0), sync_config.ref_Hz, sync_config.local_Hz);
 	printf("Timer wraps every %u s\n",
 	       (uint32_t)(BIT64(32) / sync_config.ref_Hz));
 

--- a/samples/boards/nrf/nrfx_prs/src/main.c
+++ b/samples/boards/nrf/nrfx_prs/src/main.c
@@ -81,14 +81,14 @@ static bool init_buttons(void)
 		int ret;
 
 		if (!device_is_ready(btn->gpio.port)) {
-			printk("%s is not ready\n", btn->gpio.port->name);
+			printk("%s is not ready\n", device_name_get(btn->gpio.port));
 			return false;
 		}
 
 		ret = gpio_pin_configure_dt(&btn->gpio, GPIO_INPUT);
 		if (ret < 0) {
 			printk("Failed to configure %s pin %d: %d\n",
-				btn->gpio.port->name, btn->gpio.pin, ret);
+				device_name_get(btn->gpio.port), btn->gpio.pin, ret);
 			return false;
 		}
 
@@ -96,7 +96,7 @@ static bool init_buttons(void)
 						      GPIO_INT_EDGE_TO_ACTIVE);
 		if (ret < 0) {
 			printk("Failed to configure interrupt on %s pin %d: %d\n",
-				btn->gpio.port->name, btn->gpio.pin, ret);
+				device_name_get(btn->gpio.port), btn->gpio.pin, ret);
 			return false;
 		}
 
@@ -314,7 +314,7 @@ static bool background_transfer(const struct device *spi_dev)
 	};
 	int ret;
 
-	printk("-- Background transfer on \"%s\" --\n", spi_dev->name);
+	printk("-- Background transfer on \"%s\" --\n", device_name_get(spi_dev));
 
 	ret = spi_transceive(spi_dev, &spi_dev_cfg, &tx, &rx);
 	if (ret < 0) {
@@ -339,7 +339,7 @@ void main(void)
 	const struct device *const spi_dev = DEVICE_DT_GET(SPI_DEV_NODE);
 
 	if (!device_is_ready(spi_dev)) {
-		printk("%s is not ready\n", spi_dev->name);
+		printk("%s is not ready\n", device_name_get(spi_dev));
 		return;
 	}
 

--- a/samples/boards/nrf/system_off/src/main.c
+++ b/samples/boards/nrf/system_off/src/main.c
@@ -41,7 +41,7 @@ void main(void)
 	const struct device *const cons = DEVICE_DT_GET(DT_CHOSEN(zephyr_console));
 
 	if (!device_is_ready(cons)) {
-		printk("%s: device not ready.\n", cons->name);
+		printk("%s: device not ready.\n", device_name_get(cons));
 		return;
 	}
 

--- a/samples/boards/reel_board/mesh_badge/src/periphs.c
+++ b/samples/boards/reel_board/mesh_badge/src/periphs.c
@@ -144,7 +144,7 @@ int periphs_init(void)
 	/* Bind sensors */
 	for (i = 0U; i < ARRAY_SIZE(dev_info); i++) {
 		if (!device_is_ready(dev_info[i])) {
-			printk("%s: device not ready.\n", dev_info[i]->name);
+			printk("%s: device not ready.\n", device_name_get(dev_info[i]));
 			return -ENODEV;
 		}
 	}

--- a/samples/boards/reel_board/mesh_badge/src/reel_board.c
+++ b/samples/boards/reel_board/mesh_badge/src/reel_board.c
@@ -505,7 +505,7 @@ static int configure_button(void)
 	static struct gpio_callback button_cb;
 
 	if (!device_is_ready(sw0_gpio.port)) {
-		printk("%s: device not ready.\n", sw0_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(sw0_gpio.port));
 		return -ENODEV;
 	}
 
@@ -554,7 +554,7 @@ static int configure_leds(void)
 
 	for (i = 0; i < ARRAY_SIZE(leds); i++) {
 		if (!device_is_ready(leds[i].port)) {
-			printk("%s: device not ready.\n", leds[i].port->name);
+			printk("%s: device not ready.\n", device_name_get(leds[i].port));
 			return -ENODEV;
 		}
 
@@ -585,7 +585,7 @@ void board_refresh_display(void)
 int board_init(void)
 {
 	if (!device_is_ready(epd_dev)) {
-		printk("%s: device not ready.\n", epd_dev->name);
+		printk("%s: device not ready.\n", device_name_get(epd_dev));
 		return -ENODEV;
 	}
 

--- a/samples/boards/sensortile_box/src/main.c
+++ b/samples/boards/sensortile_box/src/main.c
@@ -267,13 +267,13 @@ void main(void)
 	}
 
 	if (!device_is_ready(led0_gpio.port)) {
-		printk("%s: device not ready.\n", led0_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(led0_gpio.port));
 		return;
 	}
 	gpio_pin_configure_dt(&led0_gpio, GPIO_OUTPUT_ACTIVE);
 
 	if (!device_is_ready(led1_gpio.port)) {
-		printk("%s: device not ready.\n", led1_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(led1_gpio.port));
 		return;
 	}
 	gpio_pin_configure_dt(&led1_gpio, GPIO_OUTPUT_INACTIVE);
@@ -299,31 +299,31 @@ void main(void)
 	const struct device *const lis2mdl = DEVICE_DT_GET_ONE(st_lis2mdl);
 
 	if (!device_is_ready(hts221)) {
-		printk("%s: device not ready.\n", hts221->name);
+		printk("%s: device not ready.\n", device_name_get(hts221));
 		return;
 	}
 	if (!device_is_ready(lis2dw12)) {
-		printk("%s: device not ready.\n", lis2dw12->name);
+		printk("%s: device not ready.\n", device_name_get(lis2dw12));
 		return;
 	}
 	if (!device_is_ready(lps22hh)) {
-		printk("%s: device not ready.\n", lps22hh->name);
+		printk("%s: device not ready.\n", device_name_get(lps22hh));
 		return;
 	}
 	if (!device_is_ready(lsm6dso)) {
-		printk("%s: device not ready.\n", lsm6dso->name);
+		printk("%s: device not ready.\n", device_name_get(lsm6dso));
 		return;
 	}
 	if (!device_is_ready(stts751)) {
-		printk("%s: device not ready.\n", stts751->name);
+		printk("%s: device not ready.\n", device_name_get(stts751));
 		return;
 	}
 	if (!device_is_ready(iis3dhhc)) {
-		printk("%s: device not ready.\n", iis3dhhc->name);
+		printk("%s: device not ready.\n", device_name_get(iis3dhhc));
 		return;
 	}
 	if (!device_is_ready(lis2mdl)) {
-		printk("%s: device not ready.\n", lis2mdl->name);
+		printk("%s: device not ready.\n", device_name_get(lis2mdl));
 		return;
 	}
 

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/ext_flash.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/ext_flash.c
@@ -84,7 +84,7 @@ void CC1352R1_LAUNCHXL_shutDownExtFlash(void)
 	dev = DEVICE_DT_GET(GPIO_PORT);
 
 	if (!device_is_ready(dev)) {
-		printk("%s: device not ready.\n", dev->name);
+		printk("%s: device not ready.\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
+++ b/samples/boards/ti/cc13x2_cc26x2/system_off/src/main.c
@@ -33,7 +33,7 @@ void main(void)
 
 	/* Configure to generate PORT event (wakeup) on button 1 press. */
 	if (!device_is_ready(sw0_gpio.port)) {
-		printk("%s: device not ready.\n", sw0_gpio.port->name);
+		printk("%s: device not ready.\n", device_name_get(sw0_gpio.port));
 		return;
 	}
 

--- a/samples/boards/up_squared/gpio_counter/src/main.c
+++ b/samples/boards/up_squared/gpio_counter/src/main.c
@@ -91,7 +91,7 @@ void button_cb(const struct device *gpiodev, struct gpio_callback *cb,
 int get_gpio_dev(struct _pin *pin)
 {
 	if (!device_is_ready(pin->gpio_dev)) {
-		printk("ERROR: GPIO device is not ready for %s\n", pin->gpio_dev->name);
+		printk("ERROR: GPIO device is not ready for %s\n", device_name_get(pin->gpio_dev));
 		return -1;
 	}
 

--- a/samples/drivers/adc/src/main.c
+++ b/samples/drivers/adc/src/main.c
@@ -59,7 +59,7 @@ void main(void)
 			int32_t val_mv;
 
 			printk("- %s, channel %d: ",
-			       adc_channels[i].dev->name,
+			       device_name_get(adc_channels[i].dev),
 			       adc_channels[i].channel_id);
 
 			(void)adc_sequence_init_dt(&adc_channels[i], &sequence);

--- a/samples/drivers/audio/dmic/src/main.c
+++ b/samples/drivers/audio/dmic/src/main.c
@@ -82,7 +82,7 @@ void main(void)
 	LOG_INF("DMIC sample");
 
 	if (!device_is_ready(dmic_dev)) {
-		LOG_ERR("%s is not ready", dmic_dev->name);
+		LOG_ERR("%s is not ready", device_name_get(dmic_dev));
 		return;
 	}
 

--- a/samples/drivers/can/babbling/src/main.c
+++ b/samples/drivers/can/babbling/src/main.c
@@ -110,7 +110,7 @@ void main(void)
 #endif /* DT_NODE_EXISTS(BUTTON_NODE) */
 
 	printk("babbling on %s with %s (%d-bit) CAN ID 0x%0*x, RTR %d, CAN-FD %d\n",
-	       dev->name,
+	       device_name_get(dev),
 	       frame.id_type == CAN_STANDARD_IDENTIFIER ? "standard" : "extended",
 	       frame.id_type == CAN_STANDARD_IDENTIFIER ? 11 : 29,
 	       frame.id_type == CAN_STANDARD_IDENTIFIER ? 3 : 8, frame.id,

--- a/samples/drivers/can/counter/src/main.c
+++ b/samples/drivers/can/counter/src/main.c
@@ -216,7 +216,7 @@ void main(void)
 	int ret;
 
 	if (!device_is_ready(can_dev)) {
-		printk("CAN: Device %s not ready.\n", can_dev->name);
+		printk("CAN: Device %s not ready.\n", device_name_get(can_dev));
 		return;
 	}
 
@@ -236,7 +236,7 @@ void main(void)
 	if (led.port != NULL) {
 		if (!device_is_ready(led.port)) {
 			printk("LED: Device %s not ready.\n",
-			       led.port->name);
+			       device_name_get(led.port));
 			return;
 		}
 		ret = gpio_pin_configure_dt(&led, GPIO_OUTPUT_HIGH);

--- a/samples/drivers/clock_control_litex/src/main.c
+++ b/samples/drivers/clock_control_litex/src/main.c
@@ -315,14 +315,14 @@ void main(void)
 
 	printf("Clock Control Example! %s\n", CONFIG_ARCH);
 
-	printf("device name: %s\n", dev->name);
+	printf("device name: %s\n", device_name_get(dev));
 	if (!device_is_ready(dev)) {
-		printf("error: device %s is not ready\n", dev->name);
+		printf("error: device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 
 	printf("clock control device is %p, name is %s\n",
-	       dev, dev->name);
+	       dev, device_name_get(dev));
 
 	litex_clk_test(dev);
 }

--- a/samples/drivers/counter/maxim_ds3231/src/main.c
+++ b/samples/drivers/counter/maxim_ds3231/src/main.c
@@ -232,7 +232,7 @@ void main(void)
 	const struct device *const ds3231 = DEVICE_DT_GET_ONE(maxim_ds3231);
 
 	if (!device_is_ready(ds3231)) {
-		printk("%s: device not ready.\n", ds3231->name);
+		printk("%s: device not ready.\n", device_name_get(ds3231));
 		return;
 	}
 

--- a/samples/drivers/dac/src/main.c
+++ b/samples/drivers/dac/src/main.c
@@ -33,7 +33,7 @@ static const struct dac_channel_cfg dac_ch_cfg = {
 void main(void)
 {
 	if (!device_is_ready(dac_dev)) {
-		printk("DAC device %s is not ready\n", dac_dev->name);
+		printk("DAC device %s is not ready\n", device_name_get(dac_dev));
 		return;
 	}
 

--- a/samples/drivers/display/src/main.c
+++ b/samples/drivers/display/src/main.c
@@ -183,11 +183,11 @@ void main(void)
 	display_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(display_dev)) {
 		LOG_ERR("Device %s not found. Aborting sample.",
-			display_dev->name);
+			device_name_get(display_dev));
 		RETURN_FROM_MAIN(1);
 	}
 
-	LOG_INF("Display sample for %s", display_dev->name);
+	LOG_INF("Display sample for %s", device_name_get(display_dev));
 	display_get_capabilities(display_dev, &capabilities);
 
 	if (capabilities.screen_info & SCREEN_INFO_MONO_VTILED) {

--- a/samples/drivers/eeprom/src/main.c
+++ b/samples/drivers/eeprom/src/main.c
@@ -27,11 +27,11 @@ static const struct device *get_eeprom_device(void)
 	if (!device_is_ready(dev)) {
 		printk("\nError: Device \"%s\" is not ready; "
 		       "check the driver initialization logs for errors.\n",
-		       dev->name);
+		       device_name_get(dev));
 		return NULL;
 	}
 
-	printk("Found EEPROM device \"%s\"\n", dev->name);
+	printk("Found EEPROM device \"%s\"\n", device_name_get(dev));
 	return dev;
 }
 

--- a/samples/drivers/espi/src/main.c
+++ b/samples/drivers/espi/src/main.c
@@ -1203,27 +1203,27 @@ int espi_test(void)
 
 #if DT_NODE_HAS_STATUS(BRD_PWR_NODE, okay)
 	if (!device_is_ready(pwrgd_gpio.port)) {
-		LOG_ERR("%s: device not ready.", pwrgd_gpio.port->name);
+		LOG_ERR("%s: device not ready.", device_name_get(pwrgd_gpio.port));
 		return -ENODEV;
 	}
 	if (!device_is_ready(rsm_gpio.port)) {
-		LOG_ERR("%s: device not ready.", rsm_gpio.port->name);
+		LOG_ERR("%s: device not ready.", device_name_get(rsm_gpio.port));
 		return -ENODEV;
 	}
 #endif
 	if (!device_is_ready(espi_dev)) {
-		LOG_ERR("%s: device not ready.", espi_dev->name);
+		LOG_ERR("%s: device not ready.", device_name_get(espi_dev));
 		return -ENODEV;
 	}
 
 #ifdef CONFIG_ESPI_SAF
 	if (!device_is_ready(qspi_dev)) {
-		LOG_ERR("%s: device not ready.", qspi_dev->name);
+		LOG_ERR("%s: device not ready.", device_name_get(qspi_dev));
 		return -ENODEV;
 	}
 
 	if (!device_is_ready(espi_saf_dev)) {
-		LOG_ERR("%s: device not ready.", espi_saf_dev->name);
+		LOG_ERR("%s: device not ready.", device_name_get(espi_saf_dev));
 		return -ENODEV;
 	}
 #endif
@@ -1260,13 +1260,13 @@ int espi_test(void)
 	 */
 	ret = spi_saf_init();
 	if (ret) {
-		LOG_ERR("Unable to configure %d:%s", ret, qspi_dev->name);
+		LOG_ERR("Unable to configure %d:%s", device_name_get(ret, qspi_dev));
 		return ret;
 	}
 
 	ret = espi_saf_init();
 	if (ret) {
-		LOG_ERR("Unable to configure %d:%s", ret, espi_saf_dev->name);
+		LOG_ERR("Unable to configure %d:%s", device_name_get(ret, espi_saf_dev));
 		return ret;
 	}
 

--- a/samples/drivers/flash_shell/src/main.c
+++ b/samples/drivers/flash_shell/src/main.c
@@ -718,7 +718,7 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 	}
 	if (flash_device) {
 		PR_SHELL(shell, "Leaving behind device %s\n",
-			 flash_device->name);
+			 device_name_get(flash_device));
 	}
 	flash_device = dev;
 
@@ -728,7 +728,7 @@ static int cmd_set_dev(const struct shell *shell, size_t argc, char **argv)
 void main(void)
 {
 	if (device_is_ready(flash_device)) {
-		printk("Found flash controller %s.\n", flash_device->name);
+		printk("Found flash controller %s.\n", device_name_get(flash_device));
 		printk("Flash I/O commands can be run.\n");
 	} else {
 		flash_device = NULL;

--- a/samples/drivers/i2s/echo/src/codec.c
+++ b/samples/drivers/i2s/echo/src/codec.c
@@ -103,7 +103,7 @@ bool init_wm8731_i2c(void)
 	};
 
 	if (!device_is_ready(i2c_dev)) {
-		printk("%s is not ready\n", i2c_dev->name);
+		printk("%s is not ready\n", device_name_get(i2c_dev));
 		return false;
 	}
 

--- a/samples/drivers/i2s/echo/src/main.c
+++ b/samples/drivers/i2s/echo/src/main.c
@@ -74,14 +74,14 @@ static bool init_buttons(void)
 	static struct gpio_callback sw0_cb_data;
 
 	if (!device_is_ready(sw0_spec.port)) {
-		printk("%s is not ready\n", sw0_spec.port->name);
+		printk("%s is not ready\n", device_name_get(sw0_spec.port));
 		return false;
 	}
 
 	ret = gpio_pin_configure_dt(&sw0_spec, GPIO_INPUT);
 	if (ret < 0) {
 		printk("Failed to configure %s pin %d: %d\n",
-		       sw0_spec.port->name, sw0_spec.pin, ret);
+		       device_name_get(sw0_spec.port), sw0_spec.pin, ret);
 		return false;
 	}
 
@@ -89,27 +89,27 @@ static bool init_buttons(void)
 					      GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret < 0) {
 		printk("Failed to configure interrupt on %s pin %d: %d\n",
-		       sw0_spec.port->name, sw0_spec.pin, ret);
+		       device_name_get(sw0_spec.port), sw0_spec.pin, ret);
 		return false;
 	}
 
 	gpio_init_callback(&sw0_cb_data, sw0_handler, BIT(sw0_spec.pin));
 	gpio_add_callback(sw0_spec.port, &sw0_cb_data);
-	printk("Press \"%s\" to toggle the echo effect\n", sw0_spec.port->name);
+	printk("Press \"%s\" to toggle the echo effect\n", device_name_get(sw0_spec.port));
 #endif
 
 #if DT_NODE_HAS_STATUS(SW1_NODE, okay)
 	static struct gpio_callback sw1_cb_data;
 
 	if (!device_is_ready(sw1_spec.port)) {
-		printk("%s is not ready\n", sw1_spec.port->name);
+		printk("%s is not ready\n", device_name_get(sw1_spec.port));
 		return false;
 	}
 
 	ret = gpio_pin_configure_dt(&sw1_spec, GPIO_INPUT);
 	if (ret < 0) {
 		printk("Failed to configure %s pin %d: %d\n",
-		       sw1_spec.port->name, sw1_spec.pin, ret);
+		       device_name_get(sw1_spec.port), sw1_spec.pin, ret);
 		return false;
 	}
 
@@ -117,13 +117,13 @@ static bool init_buttons(void)
 					      GPIO_INT_EDGE_TO_ACTIVE);
 	if (ret < 0) {
 		printk("Failed to configure interrupt on %s pin %d: %d\n",
-		       sw1_spec.port->name, sw1_spec.pin, ret);
+		       device_name_get(sw1_spec.port), sw1_spec.pin, ret);
 		return false;
 	}
 
 	gpio_init_callback(&sw1_cb_data, sw1_handler, BIT(sw1_spec.pin));
 	gpio_add_callback(sw1_spec.port, &sw1_cb_data);
-	printk("Press \"%s\" to stop/restart I2S streams\n", sw1_spec.port->name);
+	printk("Press \"%s\" to stop/restart I2S streams\n", device_name_get(sw1_spec.port));
 #endif
 
 	(void)ret;
@@ -263,12 +263,12 @@ void main(void)
 	}
 
 	if (!device_is_ready(i2s_dev_rx)) {
-		printk("%s is not ready\n", i2s_dev_rx->name);
+		printk("%s is not ready\n", device_name_get(i2s_dev_rx));
 		return;
 	}
 
 	if (i2s_dev_rx != i2s_dev_tx && !device_is_ready(i2s_dev_tx)) {
-		printk("%s is not ready\n", i2s_dev_tx->name);
+		printk("%s is not ready\n", device_name_get(i2s_dev_tx));
 		return;
 	}
 

--- a/samples/drivers/jesd216/src/main.c
+++ b/samples/drivers/jesd216/src/main.c
@@ -277,7 +277,7 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET(FLASH_NODE);
 
 	if (!device_is_ready(dev)) {
-		printf("%s: device not ready\n", dev->name);
+		printf("%s: device not ready\n", device_name_get(dev));
 		return;
 	}
 
@@ -302,7 +302,7 @@ void main(void)
 		return;
 	}
 
-	printf("%s: SFDP v %u.%u AP %x with %u PH\n", dev->name,
+	printf("%s: SFDP v %u.%u AP %x with %u PH\n", device_name_get(dev),
 		hp->rev_major, hp->rev_minor, hp->access, 1 + hp->nph);
 
 	const struct jesd216_param_header *php = hp->phdr;

--- a/samples/drivers/kscan/src/main.c
+++ b/samples/drivers/kscan/src/main.c
@@ -154,7 +154,7 @@ void main(void)
 	printk("Kscan matrix sample application\n");
 
 	if (!device_is_ready(kscan_dev)) {
-		LOG_ERR("kscan device %s not ready", kscan_dev->name);
+		LOG_ERR("kscan device %s not ready", device_name_get(kscan_dev));
 		return;
 	}
 

--- a/samples/drivers/kscan_touch/src/main.c
+++ b/samples/drivers/kscan_touch/src/main.c
@@ -31,7 +31,7 @@ void main(void)
 	printk("Kscan touch panel sample application\n");
 
 	if (!device_is_ready(kscan_dev)) {
-		LOG_ERR("kscan device %s not ready", kscan_dev->name);
+		LOG_ERR("kscan device %s not ready", device_name_get(kscan_dev));
 		return;
 	}
 

--- a/samples/drivers/lcd_hd44780/src/main.c
+++ b/samples/drivers/lcd_hd44780/src/main.c
@@ -530,7 +530,7 @@ void main(void)
 	const struct device *const gpio_dev = DEVICE_DT_GET(GPIO_NODE);
 
 	if (!device_is_ready(gpio_dev)) {
-		printk("Device %s not ready!\n", gpio_dev->name);
+		printk("Device %s not ready!\n", device_name_get(gpio_dev));
 		return;
 	}
 

--- a/samples/drivers/led_apa102/src/main.c
+++ b/samples/drivers/led_apa102/src/main.c
@@ -61,10 +61,10 @@ void main(void)
 		LOG_ERR("LED strip device not found");
 		return;
 	} else if (!device_is_ready(strip)) {
-		LOG_ERR("LED strip device %s is not ready", strip->name);
+		LOG_ERR("LED strip device %s is not ready", device_name_get(strip));
 		return;
 	} else {
-		LOG_INF("Found LED strip device %s", strip->name);
+		LOG_INF("Found LED strip device %s", device_name_get(strip));
 	}
 
 	/*

--- a/samples/drivers/led_apa102c_bitbang/src/main.c
+++ b/samples/drivers/led_apa102c_bitbang/src/main.c
@@ -72,7 +72,7 @@ void main(void)
 
 	gpio_dev = DEVICE_DT_GET(DT_ALIAS(gpio_0));
 	if (!device_is_ready(gpio_dev)) {
-		printk("GPIO device %s is not ready!\n", gpio_dev->name);
+		printk("GPIO device %s is not ready!\n", device_name_get(gpio_dev));
 		return;
 	}
 

--- a/samples/drivers/led_lp3943/src/main.c
+++ b/samples/drivers/led_lp3943/src/main.c
@@ -27,10 +27,10 @@ void main(void)
 		LOG_ERR("No device with compatible ti,lp3943 found");
 		return;
 	} else if (!device_is_ready(led_dev)) {
-		LOG_ERR("LED device %s not ready", led_dev->name);
+		LOG_ERR("LED device %s not ready", device_name_get(led_dev));
 		return;
 	} else {
-		LOG_INF("Found LED device %s", led_dev->name);
+		LOG_INF("Found LED device %s", device_name_get(led_dev));
 	}
 
 	/*

--- a/samples/drivers/led_lp503x/src/main.c
+++ b/samples/drivers/led_lp503x/src/main.c
@@ -221,10 +221,10 @@ void main(void)
 		LOG_ERR("No device with compatible ti,lp503x found");
 		return;
 	} else if (!device_is_ready(lp503x_dev)) {
-		LOG_ERR("LED controller %s is not ready", lp503x_dev->name);
+		LOG_ERR("LED controller %s is not ready", device_name_get(lp503x_dev));
 		return;
 	}
-	LOG_INF("Found LED controller %s", lp503x_dev->name);
+	LOG_INF("Found LED controller %s", device_name_get(lp503x_dev));
 
 	for (led = 0; led < LP503X_MAX_LEDS; led++) {
 		int col;

--- a/samples/drivers/led_lp5562/src/main.c
+++ b/samples/drivers/led_lp5562/src/main.c
@@ -171,10 +171,10 @@ void main(void)
 		LOG_ERR("No \"ti,lp5562\" device found");
 		return;
 	} else if (!device_is_ready(dev)) {
-		LOG_ERR("LED device %s is not ready", dev->name);
+		LOG_ERR("LED device %s is not ready", device_name_get(dev));
 		return;
 	} else {
-		LOG_INF("Found LED device %s", dev->name);
+		LOG_INF("Found LED device %s", device_name_get(dev));
 	}
 
 	LOG_INF("Testing leds");

--- a/samples/drivers/led_lpd8806/src/main.c
+++ b/samples/drivers/led_lpd8806/src/main.c
@@ -59,10 +59,10 @@ void main(void)
 		LOG_ERR("LED strip device not found");
 		return;
 	} else if (!device_is_ready(strip)) {
-		LOG_INF("LED strip device %s is not ready", strip->name);
+		LOG_INF("LED strip device %s is not ready", device_name_get(strip));
 		return;
 	}
-	LOG_INF("Found LED strip device %s", strip->name);
+	LOG_INF("Found LED strip device %s", device_name_get(strip));
 
 	/*
 	 * Display a pattern that "walks" the three primary colors

--- a/samples/drivers/led_pca9633/src/main.c
+++ b/samples/drivers/led_pca9633/src/main.c
@@ -31,10 +31,10 @@ void main(void)
 		LOG_ERR("No devices with compatible nxp,pca9633 found");
 		return;
 	} else if (!device_is_ready(led_dev)) {
-		LOG_ERR("LED device %s is not ready", led_dev->name);
+		LOG_ERR("LED device %s is not ready", device_name_get(led_dev));
 		return;
 	} else {
-		LOG_INF("Found LED device %s", led_dev->name);
+		LOG_INF("Found LED device %s", device_name_get(led_dev));
 	}
 
 	LOG_INF("Testing leds");

--- a/samples/drivers/led_pwm/src/main.c
+++ b/samples/drivers/led_pwm/src/main.c
@@ -105,12 +105,12 @@ void main(void)
 
 	led_pwm = DEVICE_DT_GET(LED_PWM_NODE_ID);
 	if (!device_is_ready(led_pwm)) {
-		LOG_ERR("Device %s is not ready", led_pwm->name);
+		LOG_ERR("Device %s is not ready", device_name_get(led_pwm));
 		return;
 	}
 
 	if (!num_leds) {
-		LOG_ERR("No LEDs found for %s", led_pwm->name);
+		LOG_ERR("No LEDs found for %s", device_name_get(led_pwm));
 		return;
 	}
 

--- a/samples/drivers/led_ws2812/src/main.c
+++ b/samples/drivers/led_ws2812/src/main.c
@@ -41,9 +41,9 @@ void main(void)
 	int rc;
 
 	if (device_is_ready(strip)) {
-		LOG_INF("Found LED strip device %s", strip->name);
+		LOG_INF("Found LED strip device %s", device_name_get(strip));
 	} else {
-		LOG_ERR("LED strip device %s is not ready", strip->name);
+		LOG_ERR("LED strip device %s is not ready", device_name_get(strip));
 		return;
 	}
 

--- a/samples/drivers/lora/receive/src/main.c
+++ b/samples/drivers/lora/receive/src/main.c
@@ -48,7 +48,7 @@ void main(void)
 	int8_t snr;
 
 	if (!device_is_ready(lora_dev)) {
-		LOG_ERR("%s Device not ready", lora_dev->name);
+		LOG_ERR("%s Device not ready", device_name_get(lora_dev));
 		return;
 	}
 

--- a/samples/drivers/lora/send/src/main.c
+++ b/samples/drivers/lora/send/src/main.c
@@ -29,7 +29,7 @@ void main(void)
 	int ret;
 
 	if (!device_is_ready(lora_dev)) {
-		LOG_ERR("%s Device not ready", lora_dev->name);
+		LOG_ERR("%s Device not ready", device_name_get(lora_dev));
 		return;
 	}
 

--- a/samples/drivers/ps2/src/main.c
+++ b/samples/drivers/ps2/src/main.c
@@ -177,7 +177,7 @@ void main(void)
 	 * keyboard and mouse as desired
 	 */
 	if (!device_is_ready(ps2_0_dev)) {
-		printk("%s: device not ready.\n", ps2_0_dev->name);
+		printk("%s: device not ready.\n", device_name_get(ps2_0_dev));
 		return;
 	}
 	ps2_config(ps2_0_dev, mb_callback);

--- a/samples/drivers/spi_bitbang/src/main.c
+++ b/samples/drivers/spi_bitbang/src/main.c
@@ -123,7 +123,7 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET(SPIBB_NODE);
 
 	if (!device_is_ready(dev)) {
-		printk("%s: device not ready.\n", dev->name);
+		printk("%s: device not ready.\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/drivers/spi_flash/src/main.c
+++ b/samples/drivers/spi_flash/src/main.c
@@ -37,11 +37,11 @@ void main(void)
 	flash_dev = DEVICE_DT_GET(DT_ALIAS(spi_flash0));
 
 	if (!device_is_ready(flash_dev)) {
-		printk("%s: device not ready.\n", flash_dev->name);
+		printk("%s: device not ready.\n", device_name_get(flash_dev));
 		return;
 	}
 
-	printf("\n%s SPI flash testing\n", flash_dev->name);
+	printf("\n%s SPI flash testing\n", device_name_get(flash_dev));
 	printf("==========================\n");
 
 

--- a/samples/drivers/spi_flash_at45/src/main.c
+++ b/samples/drivers/spi_flash_at45/src/main.c
@@ -37,7 +37,7 @@ void main(void)
 #endif
 
 	if (!device_is_ready(flash_dev)) {
-		printk("%s: device not ready.\n", flash_dev->name);
+		printk("%s: device not ready.\n", device_name_get(flash_dev));
 		return;
 	}
 
@@ -46,7 +46,7 @@ void main(void)
 	(void)flash_get_page_info_by_idx(flash_dev, 0, &pages_info);
 	chip_size = page_count * pages_info.size;
 	printk("Using %s, chip size: %u bytes (page: %u)\n",
-	       flash_dev->name, chip_size, pages_info.size);
+	       device_name_get(flash_dev), chip_size, pages_info.size);
 #endif
 
 	printk("Reading the first byte of the test region ... ");

--- a/samples/drivers/spi_fujitsu_fram/src/main.c
+++ b/samples/drivers/spi_fujitsu_fram/src/main.c
@@ -147,7 +147,7 @@ void main(void)
 
 	spi = DEVICE_DT_GET(DT_ALIAS(spi_1));
 	if (!device_is_ready(spi)) {
-		printk("SPI device %s is not ready\n", spi->name);
+		printk("SPI device %s is not ready\n", device_name_get(spi));
 		return;
 	}
 

--- a/samples/drivers/watchdog/src/main.c
+++ b/samples/drivers/watchdog/src/main.c
@@ -63,7 +63,7 @@ void main(void)
 	printk("Watchdog sample application\n");
 
 	if (!device_is_ready(wdt)) {
-		printk("%s: device not ready.\n", wdt->name);
+		printk("%s: device not ready.\n", device_name_get(wdt));
 		return;
 	}
 

--- a/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
+++ b/samples/modules/tflite-micro/magic_wand/src/accelerometer_handler.cpp
@@ -36,17 +36,17 @@ bool initial = true;
 TfLiteStatus SetupAccelerometer(tflite::ErrorReporter *error_reporter)
 {
 	if (!device_is_ready(sensor)) {
-		printk("%s: device not ready.\n", sensor->name);
+		printk("%s: device not ready.\n", device_name_get(sensor));
 		return kTfLiteApplicationError;
 	}
 
 	if (sensor == NULL) {
 		TF_LITE_REPORT_ERROR(error_reporter,
 				     "Failed to get accelerometer, name: %s\n",
-				     sensor->name);
+				     device_name_get(sensor));
 	} else {
 		TF_LITE_REPORT_ERROR(error_reporter, "Got accelerometer, name: %s\n",
-				     sensor->name);
+				     device_name_get(sensor));
 	}
 	return kTfLiteOk;
 }

--- a/samples/net/gsm_modem/src/main.c
+++ b/samples/net/gsm_modem/src/main.c
@@ -119,7 +119,7 @@ int main(void)
 
 	LOG_INF("Board '%s' APN '%s' UART '%s' device %p (%s)",
 		CONFIG_BOARD, CONFIG_MODEM_GSM_APN,
-		uart_dev->name, uart_dev, gsm_dev->name);
+		device_name_get(uart_dev), uart_dev, device_name_get(gsm_dev));
 
 	net_mgmt_init_event_callback(&mgmt_cb, event_handler,
 				     NET_EVENT_L4_CONNECTED |

--- a/samples/net/lwm2m_client/src/lwm2m-client.c
+++ b/samples/net/lwm2m_client/src/lwm2m-client.c
@@ -191,7 +191,7 @@ static void *temperature_get_buf(uint16_t obj_inst_id, uint16_t res_id,
 	dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
 
 	if (!device_is_ready(dev)) {
-		LOG_ERR("%s: device not ready.", dev->name);
+		LOG_ERR("%s: device not ready.", device_name_get(dev));
 		return;
 	}
 #endif

--- a/samples/sensor/accel_polling/src/main.c
+++ b/samples/sensor/accel_polling/src/main.c
@@ -32,19 +32,20 @@ static int print_accels(const struct device *dev)
 
 	ret = sensor_sample_fetch(dev);
 	if (ret < 0) {
-		printk("%s: sensor_sample_fetch() failed: %d\n", dev->name, ret);
+		printk("%s: sensor_sample_fetch() failed: %d\n", device_name_get(dev), ret);
 		return ret;
 	}
 
 	for (size_t i = 0; i < ARRAY_SIZE(channels); i++) {
 		ret = sensor_channel_get(dev, channels[i], &accel[i]);
 		if (ret < 0) {
-			printk("%s: sensor_channel_get(%c) failed: %d\n", dev->name, 'X' + i, ret);
+			printk("%s: sensor_channel_get(%c) failed: %d\n",
+			       device_name_get(dev), 'X' + i, ret);
 			return ret;
 		}
 	}
 
-	printk("%16s [m/s^2]:    (%12.6f, %12.6f, %12.6f)\n", dev->name,
+	printk("%16s [m/s^2]:    (%12.6f, %12.6f, %12.6f)\n", device_name_get(dev),
 	       sensor_value_to_double(&accel[0]), sensor_value_to_double(&accel[1]),
 	       sensor_value_to_double(&accel[2]));
 
@@ -57,7 +58,7 @@ void main(void)
 
 	for (size_t i = 0; i < ARRAY_SIZE(sensors); i++) {
 		if (!device_is_ready(sensors[i])) {
-			printk("sensor: device %s not ready.\n", sensors[i]->name);
+			printk("sensor: device %s not ready.\n", device_name_get(sensors[i]));
 			return;
 		}
 	}

--- a/samples/sensor/adt7420/src/main.c
+++ b/samples/sensor/adt7420/src/main.c
@@ -178,7 +178,7 @@ void main(void)
 		return;
 	}
 
-	printf("device is %p, name is %s\n", dev, dev->name);
+	printf("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	process(dev);
 }

--- a/samples/sensor/amg88xx/src/main.c
+++ b/samples/sensor/amg88xx/src/main.c
@@ -58,7 +58,7 @@ void main(void)
 		return;
 	}
 
-	printk("device: %p, name: %s\n", dev, dev->name);
+	printk("device: %p, name: %s\n", dev, device_name_get(dev));
 
 #ifdef CONFIG_AMG88XX_TRIGGER
 	struct sensor_value attr = {

--- a/samples/sensor/ams_iAQcore/src/main.c
+++ b/samples/sensor/ams_iAQcore/src/main.c
@@ -20,7 +20,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->name);
+	printk("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	while (1) {
 		sensor_sample_fetch(dev);

--- a/samples/sensor/bme280/src/main.c
+++ b/samples/sensor/bme280/src/main.c
@@ -27,11 +27,11 @@ static const struct device *get_bme280_device(void)
 	if (!device_is_ready(dev)) {
 		printk("\nError: Device \"%s\" is not ready; "
 		       "check the driver initialization logs for errors.\n",
-		       dev->name);
+		       device_name_get(dev));
 		return NULL;
 	}
 
-	printk("Found device \"%s\", getting sensor data\n", dev->name);
+	printk("Found device \"%s\", getting sensor data\n", device_name_get(dev));
 	return dev;
 }
 

--- a/samples/sensor/bme680/src/main.c
+++ b/samples/sensor/bme680/src/main.c
@@ -19,7 +19,7 @@ void main(void)
 		return;
 	}
 
-	printf("Device %p name is %s\n", dev, dev->name);
+	printf("Device %p name is %s\n", dev, device_name_get(dev));
 
 	while (1) {
 		k_sleep(K_MSEC(3000));

--- a/samples/sensor/bmg160/src/main.c
+++ b/samples/sensor/bmg160/src/main.c
@@ -178,7 +178,7 @@ void main(void)
 #endif
 
 	if (!device_is_ready(bmg160)) {
-		printf("Device %s is not ready.\n", bmg160->name);
+		printf("Device %s is not ready.\n", device_name_get(bmg160));
 		return;
 	}
 

--- a/samples/sensor/bmi270/src/main.c
+++ b/samples/sensor/bmi270/src/main.c
@@ -16,11 +16,11 @@ void main(void)
 	struct sensor_value full_scale, sampling_freq, oversampling;
 
 	if (!device_is_ready(dev)) {
-		printf("Device %s is not ready\n", dev->name);
+		printf("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 
-	printf("Device %p name is %s\n", dev, dev->name);
+	printf("Device %p name is %s\n", dev, device_name_get(dev));
 
 	/* Setting scale in G, due to loss of precision if the SI unit m/s^2
 	 * is used

--- a/samples/sensor/bq274xx/src/main.c
+++ b/samples/sensor/bq274xx/src/main.c
@@ -211,11 +211,11 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET_ONE(ti_bq274xx);
 
 	if (!device_is_ready(dev)) {
-		printk("Device %s is not ready\n", dev->name);
+		printk("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->name);
+	printk("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	do_main(dev);
 }

--- a/samples/sensor/ccs811/src/main.c
+++ b/samples/sensor/ccs811/src/main.c
@@ -118,11 +118,11 @@ void main(void)
 	int rc;
 
 	if (!device_is_ready(dev)) {
-		printk("Device %s is not ready\n", dev->name);
+		printk("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->name);
+	printk("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	rc = ccs811_configver_fetch(dev, &cfgver);
 	if (rc == 0) {

--- a/samples/sensor/dht/src/main.c
+++ b/samples/sensor/dht/src/main.c
@@ -35,7 +35,7 @@ void main(void)
 	const struct device *const dht22 = DEVICE_DT_GET_ONE(aosong_dht);
 
 	if (!device_is_ready(dht22)) {
-		printf("Device %s is not ready\n", dht22->name);
+		printf("Device %s is not ready\n", device_name_get(dht22));
 		return;
 	}
 

--- a/samples/sensor/dps310/src/main.c
+++ b/samples/sensor/dps310/src/main.c
@@ -15,11 +15,11 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET_ONE(infineon_dps310);
 
 	if (!device_is_ready(dev)) {
-		printk("Device %s is not ready\n", dev->name);
+		printk("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 
-	printk("dev %p name %s\n", dev, dev->name);
+	printk("dev %p name %s\n", dev, device_name_get(dev));
 
 	while (1) {
 		struct sensor_value temp, press;

--- a/samples/sensor/ds18b20/src/main.c
+++ b/samples/sensor/ds18b20/src/main.c
@@ -26,11 +26,11 @@ static const struct device *get_ds18b20_device(void)
 	if (!device_is_ready(dev)) {
 		printk("\nError: Device \"%s\" is not ready; "
 		       "check the driver initialization logs for errors.\n",
-		       dev->name);
+		       device_name_get(dev));
 		return NULL;
 	}
 
-	printk("Found device \"%s\", getting sensor data\n", dev->name);
+	printk("Found device \"%s\", getting sensor data\n", device_name_get(dev));
 	return dev;
 }
 

--- a/samples/sensor/ens210/src/main.c
+++ b/samples/sensor/ens210/src/main.c
@@ -15,11 +15,11 @@ void main(void)
 	struct sensor_value temperature, humidity;
 
 	if (!device_is_ready(dev)) {
-		printk("Device %s is not ready\n", dev->name);
+		printk("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->name);
+	printk("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	while (1) {
 		sensor_sample_fetch(dev);

--- a/samples/sensor/fdc2x1x/src/main.c
+++ b/samples/sensor/fdc2x1x/src/main.c
@@ -73,7 +73,7 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET(DEVICE_NODE);
 
 	if (!device_is_ready(dev)) {
-		printk("Device %s is not ready\n", dev->name);
+		printk("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/fxos8700-hid/src/main.c
+++ b/samples/sensor/fxos8700-hid/src/main.c
@@ -95,7 +95,7 @@ int callbacks_configure(const struct gpio_dt_spec *gpio,
 	int ret;
 
 	if (!device_is_ready(gpio->port)) {
-		LOG_ERR("%s: device not ready.", gpio->port->name);
+		LOG_ERR("%s: device not ready.", device_name_get(gpio->port));
 		return -ENODEV;
 	}
 
@@ -173,7 +173,7 @@ void main(void)
 	const struct device *accel_dev, *hid_dev;
 
 	if (!device_is_ready(led_gpio.port)) {
-		LOG_ERR("%s: device not ready.", led_gpio.port->name);
+		LOG_ERR("%s: device not ready.", device_name_get(led_gpio.port));
 		return;
 	}
 
@@ -199,7 +199,7 @@ void main(void)
 
 	accel_dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
 	if (!device_is_ready(accel_dev)) {
-		LOG_ERR("%s: device not ready.", accel_dev->name);
+		LOG_ERR("%s: device not ready.", device_name_get(accel_dev));
 		return;
 	}
 

--- a/samples/sensor/fxos8700/src/main.c
+++ b/samples/sensor/fxos8700/src/main.c
@@ -35,7 +35,7 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET_ONE(nxp_fxos8700);
 
 	if (!device_is_ready(dev)) {
-		printf("Device %s is not ready\n", dev->name);
+		printf("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/i3g4250d/src/main.c
+++ b/samples/sensor/i3g4250d/src/main.c
@@ -55,7 +55,7 @@ void main(void)
 	const struct device *const sensor = DEVICE_DT_GET_ONE(st_i3g4250d);
 
 	if (!device_is_ready(sensor)) {
-		printf("Sensor %s is not ready\n", sensor->name);
+		printf("Sensor %s is not ready\n", device_name_get(sensor));
 		return;
 	}
 

--- a/samples/sensor/ina219/src/main.c
+++ b/samples/sensor/ina219/src/main.c
@@ -16,7 +16,7 @@ void main(void)
 	int rc;
 
 	if (!device_is_ready(ina)) {
-		printf("Device %s is not ready.\n", ina->name);
+		printf("Device %s is not ready.\n", device_name_get(ina));
 		return;
 	}
 

--- a/samples/sensor/lis2dh/src/main.c
+++ b/samples/sensor/lis2dh/src/main.c
@@ -72,7 +72,7 @@ void main(void)
 		return;
 	}
 	if (!device_is_ready(sensor)) {
-		printf("Device %s is not ready\n", sensor->name);
+		printf("Device %s is not ready\n", device_name_get(sensor));
 		return;
 	}
 

--- a/samples/sensor/lps22hb/src/main.c
+++ b/samples/sensor/lps22hb/src/main.c
@@ -46,7 +46,7 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET_ONE(st_lps22hb_press);
 
 	if (!device_is_ready(dev)) {
-		printf("Device %s is not ready\n", dev->name);
+		printf("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/lsm303dlhc/src/main.c
+++ b/samples/sensor/lsm303dlhc/src/main.c
@@ -42,12 +42,12 @@ void main(void)
 	const struct device *const magnetometer = DEVICE_DT_GET_ONE(st_lsm303dlhc_magn);
 
 	if (!device_is_ready(accelerometer)) {
-		printf("Device %s is not ready\n", accelerometer->name);
+		printf("Device %s is not ready\n", device_name_get(accelerometer));
 		return;
 	}
 
 	if (!device_is_ready(magnetometer)) {
-		printf("Device %s is not ready\n", magnetometer->name);
+		printf("Device %s is not ready\n", device_name_get(magnetometer));
 		return;
 	}
 

--- a/samples/sensor/lsm6dso/src/main.c
+++ b/samples/sensor/lsm6dso/src/main.c
@@ -110,7 +110,7 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET_ONE(st_lsm6dso);
 
 	if (!device_is_ready(dev)) {
-		printk("%s: device not ready.\n", dev->name);
+		printk("%s: device not ready.\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/magn_polling/src/main.c
+++ b/samples/sensor/magn_polling/src/main.c
@@ -21,7 +21,7 @@ void main(void)
 		return;
 	}
 
-	printk("Polling magnetometer data from %s.\n", dev->name);
+	printk("Polling magnetometer data from %s.\n", device_name_get(dev));
 
 	while (1) {
 		ret = sensor_sample_fetch(dev);

--- a/samples/sensor/max30101/src/main.c
+++ b/samples/sensor/max30101/src/main.c
@@ -18,7 +18,7 @@ void main(void)
 		return;
 	}
 	if (!device_is_ready(dev)) {
-		printf("max30101 device %s is not ready\n", dev->name);
+		printf("max30101 device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/max44009/src/main.c
+++ b/samples/sensor/max44009/src/main.c
@@ -24,7 +24,7 @@ void main(void)
 	printk("MAX44009 light sensor application\n");
 
 	if (!device_is_ready(dev)) {
-		printk("Device %s is not ready\n", dev->name);
+		printk("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/mcp9808/src/main.c
+++ b/samples/sensor/mcp9808/src/main.c
@@ -114,7 +114,7 @@ void main(void)
 		return;
 	}
 	if (!device_is_ready(dev)) {
-		printf("Device %s is not ready.\n", dev->name);
+		printf("Device %s is not ready.\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/mpr/src/main.c
+++ b/samples/sensor/mpr/src/main.c
@@ -15,7 +15,7 @@ void main(void)
 	int rc;
 
 	if (!device_is_ready(dev)) {
-		printf("Device %s is not ready\n", dev->name);
+		printf("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/mpu6050/src/main.c
+++ b/samples/sensor/mpu6050/src/main.c
@@ -89,7 +89,7 @@ void main(void)
 	const struct device *const mpu6050 = DEVICE_DT_GET_ONE(invensense_mpu6050);
 
 	if (!device_is_ready(mpu6050)) {
-		printf("Device %s is not ready\n", mpu6050->name);
+		printf("Device %s is not ready\n", device_name_get(mpu6050));
 		return;
 	}
 

--- a/samples/sensor/ms5837/src/main.c
+++ b/samples/sensor/ms5837/src/main.c
@@ -23,7 +23,7 @@ void main(void)
 	}
 	if (!device_is_ready(dev)) {
 		LOG_ERR("MS5837 device %s is not ready, aborting test.",
-			dev->name);
+			device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/sgp40_sht4x/src/main.c
+++ b/samples/sensor/sgp40_sht4x/src/main.c
@@ -32,12 +32,12 @@ void main(void)
 	struct sensor_value temp, hum, gas;
 
 	if (!device_is_ready(sht)) {
-		printf("Device %s is not ready.\n", sht->name);
+		printf("Device %s is not ready.\n", device_name_get(sht));
 		return;
 	}
 
 	if (!device_is_ready(sgp)) {
-		printf("Device %s is not ready.\n", sgp->name);
+		printf("Device %s is not ready.\n", device_name_get(sgp));
 		return;
 	}
 

--- a/samples/sensor/sht3xd/src/main.c
+++ b/samples/sensor/sht3xd/src/main.c
@@ -29,7 +29,7 @@ void main(void)
 	int rc;
 
 	if (!device_is_ready(dev)) {
-		printf("Device %s is not ready\n", dev->name);
+		printf("Device %s is not ready\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/sensor/sm351lt/src/main.c
+++ b/samples/sensor/sm351lt/src/main.c
@@ -44,7 +44,7 @@ void main(void)
 	const struct device *const sensor = DEVICE_DT_GET_ONE(honeywell_sm351lt);
 
 	if (!device_is_ready(sensor)) {
-		printk("Device %s is not ready\n", sensor->name);
+		printk("Device %s is not ready\n", device_name_get(sensor));
 		return;
 	}
 

--- a/samples/sensor/sx9500/src/main.c
+++ b/samples/sensor/sx9500/src/main.c
@@ -81,7 +81,7 @@ void main(void)
 		return;
 	}
 
-	printk("device is %p, name is %s\n", dev, dev->name);
+	printk("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	do_main(dev);
 }

--- a/samples/sensor/thermometer/src/main.c
+++ b/samples/sensor/thermometer/src/main.c
@@ -21,7 +21,7 @@ void main(void)
 	}
 
 	printf("temp device is %p, name is %s\n",
-	       temp_dev, temp_dev->name);
+	       temp_dev, device_name_get(temp_dev));
 
 	while (1) {
 		int r;

--- a/samples/sensor/ti_hdc/src/main.c
+++ b/samples/sensor/ti_hdc/src/main.c
@@ -22,7 +22,7 @@ void main(void)
 		return;
 	}
 
-	printk("Dev %p name %s is ready!\n", dev, dev->name);
+	printk("Dev %p name %s is ready!\n", dev, device_name_get(dev));
 
 	struct sensor_value temp, humidity;
 

--- a/samples/sensor/tmp112/src/main.c
+++ b/samples/sensor/tmp112/src/main.c
@@ -59,8 +59,8 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET_ANY(ti_tmp112);
 
 	__ASSERT(dev != NULL, "Failed to get device binding");
-	__ASSERT(device_is_ready(dev), "Device %s is not ready", dev->name);
-	printk("device is %p, name is %s\n", dev, dev->name);
+	__ASSERT(device_is_ready(dev), "Device %s is not ready", device_name_get(dev));
+	printk("device is %p, name is %s\n", dev, device_name_get(dev));
 
 	do_main(dev);
 }

--- a/samples/sensor/tmp116/src/main.c
+++ b/samples/sensor/tmp116/src/main.c
@@ -32,7 +32,7 @@ void main(void)
 	__ASSERT(device_is_ready(dev), "TMP116 device not ready");
 	__ASSERT(device_is_ready(eeprom), "TMP116 eeprom device not ready");
 
-	printk("Device %s - %p is ready\n", dev->name, dev);
+	printk("Device %s - %p is ready\n", device_name_get(dev), dev);
 
 	ret = eeprom_read(eeprom, 0, eeprom_content, sizeof(eeprom_content));
 	if (ret == 0) {

--- a/samples/shields/x_nucleo_53l0a1/src/main.c
+++ b/samples/shields/x_nucleo_53l0a1/src/main.c
@@ -43,14 +43,14 @@ static void mode_show_distance(void)
 
 	ret = sensor_sample_fetch(CENTER);
 	if (ret) {
-		printk("sensor_sample_fetch(%s) failed -> %d\n", CENTER->name, ret);
+		printk("sensor_sample_fetch(%s) failed -> %d\n", device_name_get(CENTER), ret);
 		display_chars(TEXT_Err);
 		return;
 	}
 
 	ret = sensor_channel_get(CENTER, SENSOR_CHAN_DISTANCE, &value);
 	if (ret) {
-		printk("sensor_channel_get(%s) failed -> %d\n", CENTER->name, ret);
+		printk("sensor_channel_get(%s) failed -> %d\n", device_name_get(CENTER), ret);
 		display_chars(TEXT_Err);
 		return;
 	}
@@ -72,7 +72,7 @@ static void mode_show_presence(void)
 		ret = sensor_sample_fetch(sensors[i]);
 		if (ret) {
 			printk("sensor_sample_fetch(%s) failed -> %d\n",
-			       sensors[i]->name, ret);
+			       device_name_get(sensors[i]), ret);
 			display_chars(TEXT_Err);
 			return;
 		}
@@ -81,7 +81,7 @@ static void mode_show_presence(void)
 					 &value);
 		if (ret) {
 			printk("sensor_channel_get(%s) failed -> %d\n",
-			       sensors[i]->name, ret);
+			       device_name_get(sensors[i]), ret);
 			display_chars(TEXT_Err);
 			return;
 		}
@@ -125,7 +125,7 @@ void main(void)
 
 	if (!device_is_ready(button.port)) {
 		printk("Error: button device %s is not ready\n",
-		       button.port->name);
+		       device_name_get(button.port));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks01a1/src/main.c
+++ b/samples/shields/x_nucleo_iks01a1/src/main.c
@@ -35,19 +35,19 @@ void main(void)
 #endif
 
 	if (!device_is_ready(hts221)) {
-		printk("%s: device not ready.\n", hts221->name);
+		printk("%s: device not ready.\n", device_name_get(hts221));
 		return;
 	}
 	if (!device_is_ready(lis3mdl)) {
-		printk("%s: device not ready.\n", lis3mdl->name);
+		printk("%s: device not ready.\n", device_name_get(lis3mdl));
 		return;
 	}
 	if (!device_is_ready(lsm6ds0)) {
-		printk("%s: device not ready.\n", lsm6ds0->name);
+		printk("%s: device not ready.\n", device_name_get(lsm6ds0));
 		return;
 	}
 	if (!device_is_ready(lps25hb)) {
-		printk("%s: device not ready.\n", lps25hb->name);
+		printk("%s: device not ready.\n", device_name_get(lps25hb));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/sensorhub/src/main.c
@@ -37,7 +37,7 @@ void main(void)
 	const struct device *const lsm6dsl = DEVICE_DT_GET_ONE(st_lsm6dsl);
 
 	if (!device_is_ready(lsm6dsl)) {
-		printk("%s: device not ready.\n", lsm6dsl->name);
+		printk("%s: device not ready.\n", device_name_get(lsm6dsl));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks01a2/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a2/standard/src/main.c
@@ -37,23 +37,23 @@ void main(void)
 #endif
 
 	if (!device_is_ready(hts221)) {
-		printk("%s: device not ready.\n", hts221->name);
+		printk("%s: device not ready.\n", device_name_get(hts221));
 		return;
 	}
 	if (!device_is_ready(lps22hb)) {
-		printk("%s: device not ready.\n", lps22hb->name);
+		printk("%s: device not ready.\n", device_name_get(lps22hb));
 		return;
 	}
 	if (!device_is_ready(lsm6dsl)) {
-		printk("%s: device not ready.\n", lsm6dsl->name);
+		printk("%s: device not ready.\n", device_name_get(lsm6dsl));
 		return;
 	}
 	if (!device_is_ready(lsm303agr_a)) {
-		printk("%s: device not ready.\n", lsm303agr_a->name);
+		printk("%s: device not ready.\n", device_name_get(lsm303agr_a));
 		return;
 	}
 	if (!device_is_ready(lsm303agr_m)) {
-		printk("%s: device not ready.\n", lsm303agr_m->name);
+		printk("%s: device not ready.\n", device_name_get(lsm303agr_m));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/sensorhub/src/main.c
@@ -184,11 +184,11 @@ void main(void)
 	int cnt = 1;
 
 	if (!device_is_ready(lis2dw12)) {
-		printk("%s: device not ready.\n", lis2dw12->name);
+		printk("%s: device not ready.\n", device_name_get(lis2dw12));
 		return;
 	}
 	if (!device_is_ready(lsm6dso)) {
-		printk("%s: device not ready.\n", lsm6dso->name);
+		printk("%s: device not ready.\n", device_name_get(lsm6dso));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks01a3/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks01a3/standard/src/main.c
@@ -256,27 +256,27 @@ void main(void)
 	int cnt = 1;
 
 	if (!device_is_ready(hts221)) {
-		printk("%s: device not ready.\n", hts221->name);
+		printk("%s: device not ready.\n", device_name_get(hts221));
 		return;
 	}
 	if (!device_is_ready(lps22hh)) {
-		printk("%s: device not ready.\n", lps22hh->name);
+		printk("%s: device not ready.\n", device_name_get(lps22hh));
 		return;
 	}
 	if (!device_is_ready(stts751)) {
-		printk("%s: device not ready.\n", stts751->name);
+		printk("%s: device not ready.\n", device_name_get(stts751));
 		return;
 	}
 	if (!device_is_ready(lis2mdl)) {
-		printk("%s: device not ready.\n", lis2mdl->name);
+		printk("%s: device not ready.\n", device_name_get(lis2mdl));
 		return;
 	}
 	if (!device_is_ready(lis2dw12)) {
-		printk("%s: device not ready.\n", lis2dw12->name);
+		printk("%s: device not ready.\n", device_name_get(lis2dw12));
 		return;
 	}
 	if (!device_is_ready(lsm6dso)) {
-		printk("%s: device not ready.\n", lsm6dso->name);
+		printk("%s: device not ready.\n", device_name_get(lsm6dso));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/microphone/src/main.c
@@ -52,7 +52,7 @@ void main(void)
 	const struct device *const mic_dev = DEVICE_DT_GET_ONE(st_mpxxdtyy);
 
 	if (!device_is_ready(mic_dev)) {
-		printk("%s: device not ready.\n", mic_dev->name);
+		printk("%s: device not ready.\n", device_name_get(mic_dev));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/sensorhub/src/main.c
@@ -161,11 +161,11 @@ void main(void)
 	int cnt = 1;
 
 	if (!device_is_ready(iis2dlpc)) {
-		printk("%s: device not ready.\n", iis2dlpc->name);
+		printk("%s: device not ready.\n", device_name_get(iis2dlpc));
 		return;
 	}
 	if (!device_is_ready(ism330dhcx)) {
-		printk("%s: device not ready.\n", ism330dhcx->name);
+		printk("%s: device not ready.\n", device_name_get(ism330dhcx));
 		return;
 	}
 

--- a/samples/shields/x_nucleo_iks02a1/standard/src/main.c
+++ b/samples/shields/x_nucleo_iks02a1/standard/src/main.c
@@ -173,15 +173,15 @@ void main(void)
 	int cnt = 1;
 
 	if (!device_is_ready(iis2dlpc)) {
-		printk("%s: device not ready.\n", iis2dlpc->name);
+		printk("%s: device not ready.\n", device_name_get(iis2dlpc));
 		return;
 	}
 	if (!device_is_ready(iis2mdc)) {
-		printk("%s: device not ready.\n", iis2mdc->name);
+		printk("%s: device not ready.\n", device_name_get(iis2mdc));
 		return;
 	}
 	if (!device_is_ready(ism330dhcx)) {
-		printk("%s: device not ready.\n", ism330dhcx->name);
+		printk("%s: device not ready.\n", device_name_get(ism330dhcx));
 		return;
 	}
 

--- a/samples/subsys/display/cfb/src/main.c
+++ b/samples/subsys/display/cfb/src/main.c
@@ -19,7 +19,7 @@ void main(void)
 
 	dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_display));
 	if (!device_is_ready(dev)) {
-		printf("Device %s not ready\n", dev->name);
+		printf("Device %s not ready\n", device_name_get(dev));
 		return;
 	}
 
@@ -28,7 +28,7 @@ void main(void)
 		return;
 	}
 
-	printf("Initialized %s\n", dev->name);
+	printf("Initialized %s\n", device_name_get(dev));
 
 	if (cfb_framebuffer_init(dev)) {
 		printf("Framebuffer initialization failed!\n");

--- a/samples/subsys/edac/src/main.c
+++ b/samples/subsys/edac/src/main.c
@@ -35,7 +35,7 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET(DT_NODELABEL(ibecc));
 
 	if (!device_is_ready(dev)) {
-		printk("%s: device not ready.\n", dev->name);
+		printk("%s: device not ready.\n", device_name_get(dev));
 		return;
 	}
 

--- a/samples/subsys/fs/littlefs/src/main.c
+++ b/samples/subsys/fs/littlefs/src/main.c
@@ -247,7 +247,7 @@ static int littlefs_flash_erase(unsigned int id)
 	}
 
 	LOG_PRINTK("Area %u at 0x%x on %s for %u bytes\n",
-		   id, (unsigned int)pfa->fa_off, pfa->fa_dev->name,
+		   id, (unsigned int)pfa->fa_off, device_name_get(pfa->fa_dev),
 		   (unsigned int)pfa->fa_size);
 
 	/* Optional wipe flash contents */

--- a/samples/subsys/lorawan/class_a/src/main.c
+++ b/samples/subsys/lorawan/class_a/src/main.c
@@ -61,7 +61,7 @@ void main(void)
 
 	lora_dev = DEVICE_DT_GET(DT_ALIAS(lora0));
 	if (!device_is_ready(lora_dev)) {
-		LOG_ERR("%s: device not ready.", lora_dev->name);
+		LOG_ERR("%s: device not ready.", device_name_get(lora_dev));
 		return;
 	}
 

--- a/samples/subsys/mgmt/osdp/control_panel/src/main.c
+++ b/samples/subsys/mgmt/osdp/control_panel/src/main.c
@@ -61,7 +61,7 @@ void main(void)
 	};
 
 	if (!device_is_ready(led0.port)) {
-		printk("Failed to get LED GPIO port %s\n", led0.port->name);
+		printk("Failed to get LED GPIO port %s\n", device_name_get(led0.port));
 		return;
 	}
 

--- a/samples/subsys/mgmt/osdp/peripheral_device/src/main.c
+++ b/samples/subsys/mgmt/osdp/peripheral_device/src/main.c
@@ -34,14 +34,14 @@ void main(void)
 	struct osdp_cmd cmd;
 
 	if (!device_is_ready(led0.port)) {
-		printk("LED0 GPIO port %s is not ready\n", led0.port->name);
+		printk("LED0 GPIO port %s is not ready\n", device_name_get(led0.port));
 		return;
 	}
 
 	ret = gpio_pin_configure_dt(&led0, GPIO_OUTPUT_ACTIVE);
 	if (ret < 0) {
 		printk("Failed to configure gpio port %s pin %d\n",
-		       led0.port->name, led0.pin);
+		       device_name_get(led0.port), led0.pin);
 		return;
 	}
 

--- a/samples/subsys/mgmt/updatehub/src/main.c
+++ b/samples/subsys/mgmt/updatehub/src/main.c
@@ -146,7 +146,7 @@ void main(void)
 	const struct device *const uart_dev = DEVICE_DT_GET(UART_NODE);
 
 	LOG_INF("APN '%s' UART '%s' device %p", CONFIG_MODEM_GSM_APN,
-		uart_dev->name, uart_dev);
+		device_name_get(uart_dev), uart_dev);
 #endif
 
 	net_mgmt_init_event_callback(&mgmt_cb, event_handler, EVENT_MASK);

--- a/samples/subsys/modbus/rtu_server/src/main.c
+++ b/samples/subsys/modbus/rtu_server/src/main.c
@@ -156,7 +156,7 @@ void main(void)
 		k_sleep(K_MSEC(100));
 	}
 
-	LOG_INF("Client connected to server on %s", dev->name);
+	LOG_INF("Client connected to server on %s", device_name_get(dev));
 #endif
 
 	if (init_modbus_server()) {

--- a/samples/subsys/nvs/src/main.c
+++ b/samples/subsys/nvs/src/main.c
@@ -80,7 +80,7 @@ void main(void)
 	 */
 	fs.flash_device = NVS_PARTITION_DEVICE;
 	if (!device_is_ready(fs.flash_device)) {
-		printk("Flash device %s is not ready\n", fs.flash_device->name);
+		printk("Flash device %s is not ready\n", device_name_get(fs.flash_device));
 		return;
 	}
 	fs.offset = NVS_PARTITION_OFFSET;

--- a/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
+++ b/samples/subsys/rtio/sensor_batch_processing/src/vnd_sensor.c
@@ -41,14 +41,14 @@ static int vnd_sensor_iodev_read(const struct device *dev, uint8_t *buf,
 	uint32_t sample_number;
 	uint32_t key;
 
-	LOG_DBG("%s: buf_len = %d, buf = %p", dev->name, buf_len, buf);
+	LOG_DBG("%s: buf_len = %d, buf = %p", device_name_get(dev), buf_len, buf);
 
 	key = irq_lock();
 	sample_number = data->sample_number++;
 	irq_unlock(key);
 
 	if (buf_len < config->sample_size) {
-		LOG_ERR("%s: Buffer is too small", dev->name);
+		LOG_ERR("%s: Buffer is too small", device_name_get(dev));
 		return -ENOMEM;
 	}
 
@@ -67,7 +67,7 @@ static void vnd_sensor_iodev_execute(const struct device *dev,
 	if (sqe->op == RTIO_OP_RX) {
 		result = vnd_sensor_iodev_read(dev, sqe->buf, sqe->buf_len);
 	} else {
-		LOG_ERR("%s: Invalid op", dev->name);
+		LOG_ERR("%s: Invalid op", device_name_get(dev));
 		result = -EINVAL;
 	}
 
@@ -89,7 +89,7 @@ static void vnd_sensor_iodev_submit(const struct rtio_sqe *sqe, struct rtio *r)
 	};
 
 	if (k_msgq_put(&data->msgq, &msg, K_NO_WAIT) != 0) {
-		LOG_ERR("%s: Could not put a msg", dev->name);
+		LOG_ERR("%s: Could not put a msg", device_name_get(dev));
 		rtio_sqe_err(r, sqe, -EWOULDBLOCK);
 	}
 }
@@ -100,7 +100,7 @@ static void vnd_sensor_handle_int(const struct device *dev)
 	struct vnd_sensor_msg msg;
 
 	if (k_msgq_get(&data->msgq, &msg, K_NO_WAIT) != 0) {
-		LOG_ERR("%s: Could not get a msg", dev->name);
+		LOG_ERR("%s: Could not get a msg", device_name_get(dev));
 	} else {
 		vnd_sensor_iodev_execute(dev, &msg.sqe, msg.r);
 	}

--- a/samples/subsys/usb/cdc_acm_composite/src/main.c
+++ b/samples/subsys/usb/cdc_acm_composite/src/main.c
@@ -123,7 +123,7 @@ void main(void)
 	for (int idx = 0; idx < ARRAY_SIZE(peers); idx++) {
 		if (!device_is_ready(peers[idx].dev)) {
 			LOG_ERR("CDC ACM device %s is not ready",
-				peers[idx].dev->name);
+				device_name_get(peers[idx].dev));
 			return;
 		}
 	}

--- a/samples/subsys/usb/hid-cdc/src/main.c
+++ b/samples/subsys/usb/hid-cdc/src/main.c
@@ -514,7 +514,7 @@ int callbacks_configure(const struct gpio_dt_spec *gpio,
 			struct gpio_callback *callback)
 {
 	if (!device_is_ready(gpio->port)) {
-		LOG_ERR("%s: device not ready.", gpio->port->name);
+		LOG_ERR("%s: device not ready.", device_name_get(gpio->port));
 		return -ENODEV;
 	}
 
@@ -562,7 +562,7 @@ void main(void)
 	for (int idx = 0; idx < ARRAY_SIZE(cdc_dev); idx++) {
 		if (!device_is_ready(cdc_dev[idx])) {
 			LOG_ERR("CDC ACM device %s is not ready",
-				cdc_dev[idx]->name);
+				device_name_get(cdc_dev[idx]));
 			return;
 		}
 	}
@@ -612,7 +612,7 @@ void main(void)
 
 	/* Initialize CDC ACM */
 	for (int idx = 0; idx < ARRAY_SIZE(cdc_dev); idx++) {
-		LOG_INF("Wait for DTR on %s", cdc_dev[idx]->name);
+		LOG_INF("Wait for DTR on %s", device_name_get(cdc_dev[idx]));
 		while (1) {
 			uart_line_ctrl_get(cdc_dev[idx],
 					   UART_LINE_CTRL_DTR,
@@ -625,7 +625,7 @@ void main(void)
 			}
 		}
 
-		LOG_INF("DTR on device %s", cdc_dev[idx]->name);
+		LOG_INF("DTR on device %s", device_name_get(cdc_dev[idx]));
 	}
 
 	/* Wait 1 sec for the host to do all settings */
@@ -635,10 +635,12 @@ void main(void)
 	uart_irq_callback_set(cdc_dev[1], cdc_kbd_int_handler);
 
 	write_data(cdc_dev[0], welcome, strlen(welcome));
-	write_data(cdc_dev[0], cdc_dev[0]->name, strlen(cdc_dev[0]->name));
+	write_data(cdc_dev[0], device_name_get(cdc_dev[0]),
+		   strlen(device_name_get(cdc_dev[0])));
 	write_data(cdc_dev[0], banner0, strlen(banner0));
 	write_data(cdc_dev[1], welcome, strlen(welcome));
-	write_data(cdc_dev[1], cdc_dev[1]->name, strlen(cdc_dev[1]->name));
+	write_data(cdc_dev[1], device_name_get(cdc_dev[1]),
+		   strlen(device_name_get(cdc_dev[1])));
 	write_data(cdc_dev[1], banner1, strlen(banner1));
 
 	uart_irq_rx_enable(cdc_dev[0]);

--- a/samples/subsys/usb/hid-mouse/src/main.c
+++ b/samples/subsys/usb/hid-mouse/src/main.c
@@ -87,7 +87,7 @@ static void left_button(const struct device *gpio, struct gpio_callback *cb,
 	ret = gpio_pin_get(gpio, sw0.pin);
 	if (ret < 0) {
 		LOG_ERR("Failed to get the state of port %s pin %u, error: %d",
-			gpio->name, sw0.pin, ret);
+			device_name_get(gpio), sw0.pin, ret);
 		return;
 	}
 
@@ -119,7 +119,7 @@ static void right_button(const struct device *gpio, struct gpio_callback *cb,
 	ret = gpio_pin_get(gpio, sw1.pin);
 	if (ret < 0) {
 		LOG_ERR("Failed to get the state of port %s pin %u, error: %d",
-			gpio->name, sw1.pin, ret);
+			device_name_get(gpio), sw1.pin, ret);
 		return;
 	}
 
@@ -144,7 +144,7 @@ static void x_move(const struct device *gpio, struct gpio_callback *cb,
 	ret = gpio_pin_get(gpio, sw2.pin);
 	if (ret < 0) {
 		LOG_ERR("Failed to get the state of port %s pin %u, error: %d",
-			gpio->name, sw2.pin, ret);
+			device_name_get(gpio), sw2.pin, ret);
 		return;
 	}
 
@@ -167,7 +167,7 @@ static void y_move(const struct device *gpio, struct gpio_callback *cb,
 	ret = gpio_pin_get(gpio, sw3.pin);
 	if (ret < 0) {
 		LOG_ERR("Failed to get the state of port %s pin %u, error: %d",
-			gpio->name, sw3.pin, ret);
+			device_name_get(gpio), sw3.pin, ret);
 		return;
 	}
 
@@ -195,21 +195,21 @@ int callbacks_configure(const struct gpio_dt_spec *spec,
 	}
 
 	if (!device_is_ready(gpio)) {
-		LOG_ERR("GPIO port %s is not ready", gpio->name);
+		LOG_ERR("GPIO port %s is not ready", device_name_get(gpio));
 		return -ENODEV;
 	}
 
 	ret = gpio_pin_configure_dt(spec, GPIO_INPUT);
 	if (ret < 0) {
 		LOG_ERR("Failed to configure port %s pin %u, error: %d",
-			gpio->name, pin, ret);
+			device_name_get(gpio), pin, ret);
 		return ret;
 	}
 
 	ret = gpio_pin_get(gpio, pin);
 	if (ret < 0) {
 		LOG_ERR("Failed to get the state of port %s pin %u, error: %d",
-			gpio->name, pin, ret);
+			device_name_get(gpio), pin, ret);
 		return ret;
 	}
 
@@ -220,7 +220,7 @@ int callbacks_configure(const struct gpio_dt_spec *spec,
 	if (ret < 0) {
 		LOG_ERR("Failed to add the callback for port %s pin %u, "
 			"error: %d",
-			gpio->name, pin, ret);
+			device_name_get(gpio), pin, ret);
 		return ret;
 	}
 
@@ -228,7 +228,7 @@ int callbacks_configure(const struct gpio_dt_spec *spec,
 	if (ret < 0) {
 		LOG_ERR("Failed to configure interrupt for port %s pin %u, "
 			"error: %d",
-			gpio->name, pin, ret);
+			device_name_get(gpio), pin, ret);
 		return ret;
 	}
 
@@ -242,7 +242,7 @@ void main(void)
 	const struct device *hid_dev;
 
 	if (!device_is_ready(led0.port)) {
-		LOG_ERR("LED device %s is not ready", led0.port->name);
+		LOG_ERR("LED device %s is not ready", device_name_get(led0.port));
 		return;
 	}
 

--- a/samples/subsys/usb/mass/src/main.c
+++ b/samples/subsys/usb/mass/src/main.c
@@ -43,7 +43,7 @@ static int setup_flash(struct fs_mount_t *mnt)
 
 	rc = flash_area_open(id, &pfa);
 	printk("Area %u at 0x%x on %s for %u bytes\n",
-	       id, (unsigned int)pfa->fa_off, pfa->fa_dev->name,
+	       id, (unsigned int)pfa->fa_off, device_name_get(pfa->fa_dev),
 	       (unsigned int)pfa->fa_size);
 
 	if (rc < 0 && IS_ENABLED(CONFIG_APP_WIPE_STORAGE)) {

--- a/samples/subsys/video/capture/src/main.c
+++ b/samples/subsys/video/capture/src/main.c
@@ -37,14 +37,14 @@ void main(void)
 	const struct device *const dev = DEVICE_DT_GET_ONE(nxp_imx_csi);
 
 	if (!device_is_ready(dev)) {
-		LOG_ERR("%s: device not ready.\n", dev->name);
+		LOG_ERR("%s: device not ready.\n", device_name_get(dev));
 		return;
 	}
 
 	video = dev;
 #endif
 
-	printk("- Device name: %s\n", video->name);
+	printk("- Device name: %s\n", device_name_get(video));
 
 	/* Get capabilities */
 	if (video_get_caps(video, VIDEO_EP_OUT, &caps)) {

--- a/samples/subsys/video/tcpserversink/src/main.c
+++ b/samples/subsys/video/tcpserversink/src/main.c
@@ -68,7 +68,7 @@ void main(void)
 	}
 
 	if (!device_is_ready(video)) {
-		LOG_ERR("%s: device not ready.\n", video->name);
+		LOG_ERR("%s: device not ready.\n", device_name_get(video));
 		return;
 	}
 

--- a/subsys/emul/emul.c
+++ b/subsys/emul/emul.c
@@ -18,7 +18,7 @@ const struct emul *emul_get_binding(const char *name)
 	const struct emul *emul_it;
 
 	for (emul_it = __emul_list_start; emul_it < __emul_list_end; emul_it++) {
-		if (strcmp(emul_it->dev->name, name) == 0) {
+		if (strcmp(device_name_get(emul_it->dev), name) == 0) {
 			return emul_it;
 		}
 	}
@@ -37,11 +37,11 @@ int emul_init_for_bus(const struct device *dev)
 	const struct emul_link_for_bus *elp;
 	const struct emul_link_for_bus *const end = cfg->children + cfg->num_children;
 
-	LOG_INF("Registering %d emulator(s) for %s", cfg->num_children, dev->name);
+	LOG_INF("Registering %d emulator(s) for %s", cfg->num_children, device_name_get(dev));
 	for (elp = cfg->children; elp < end; elp++) {
-		const struct emul *emul = emul_get_binding(elp->dev->name);
+		const struct emul *emul = emul_get_binding(device_name_get(elp->dev));
 
-		__ASSERT(emul, "Cannot find emulator for '%s'", elp->dev->name);
+		__ASSERT(emul, "Cannot find emulator for '%s'", device_name_get(elp->dev));
 
 		switch (emul->bus_type) {
 		case EMUL_BUS_TYPE_I2C:
@@ -58,7 +58,7 @@ int emul_init_for_bus(const struct device *dev)
 
 		if (rc != 0) {
 			LOG_WRN("Init %s emulator failed: %d",
-				 elp->dev->name, rc);
+				 device_name_get(elp->dev), rc);
 		}
 
 		switch (emul->bus_type) {
@@ -80,11 +80,12 @@ int emul_init_for_bus(const struct device *dev)
 		default:
 			rc = -EINVAL;
 			LOG_WRN("Found no emulated bus enabled to register emulator %s",
-				elp->dev->name);
+				device_name_get(elp->dev));
 		}
 
 		if (rc != 0) {
-			LOG_WRN("Failed to register emulator for %s: %d", elp->dev->name, rc);
+			LOG_WRN("Failed to register emulator for %s: %d",
+				device_name_get(elp->dev), rc);
 		}
 	}
 

--- a/subsys/fb/cfb_shell.c
+++ b/subsys/fb/cfb_shell.c
@@ -297,7 +297,7 @@ static int cmd_get_device(const struct shell *shell, size_t argc, char *argv[])
 		return -ENODEV;
 	}
 
-	shell_print(shell, "Framebuffer Device: %s", dev->name);
+	shell_print(shell, "Framebuffer Device: %s", device_name_get(dev));
 
 	return err;
 }
@@ -422,7 +422,7 @@ static int cmd_init(const struct shell *shell, size_t argc, char *argv[])
 		return err;
 	}
 
-	shell_print(shell, "Framebuffer initialized: %s", dev->name);
+	shell_print(shell, "Framebuffer initialized: %s", device_name_get(dev));
 	cmd_clear(shell, argc, argv);
 
 	return err;

--- a/subsys/fs/littlefs_fs.c
+++ b/subsys/fs/littlefs_fs.c
@@ -640,7 +640,7 @@ static int littlefs_flash_init(struct fs_mount_t *mountp)
 	dev = flash_area_get_device(*fap);
 	if (dev == NULL) {
 		LOG_ERR("can't get flash device: %s",
-			(*fap)->fa_dev->name);
+			device_name_get((*fap)->fa_dev));
 		return -ENODEV;
 	}
 
@@ -770,7 +770,7 @@ static int littlefs_mount(struct fs_mount_t *mountp)
 		const struct device *dev =
 			flash_area_get_device((struct flash_area *)fs->backend);
 		LOG_INF("FS at %s:0x%x is %u 0x%x-byte blocks with %u cycle",
-			dev->name,
+			device_name_get(dev),
 			(uint32_t)((struct flash_area *)fs->backend)->fa_off,
 			block_count, block_size, block_cycles);
 		LOG_INF("sizes: rd %u ; pr %u ; ca %u ; la %u",

--- a/subsys/modbus/modbus_serial.c
+++ b/subsys/modbus/modbus_serial.c
@@ -517,7 +517,7 @@ int modbus_serial_init(struct modbus_context *ctx,
 	}
 
 	if (!device_is_ready(cfg->dev)) {
-		LOG_ERR("Bus device %s is not ready", cfg->dev->name);
+		LOG_ERR("Bus device %s is not ready", device_name_get(cfg->dev));
 		return -ENODEV;
 	}
 

--- a/subsys/net/ip/net_shell.c
+++ b/subsys/net/ip/net_shell.c
@@ -1805,7 +1805,7 @@ static void capture_cb(struct net_capture_info *info, void *user_data)
 	get_address_str(info->local, addr_local, sizeof(addr_local));
 	get_address_str(info->peer, addr_peer, sizeof(addr_peer));
 
-	PR("%s\t%c        %d      %s\t%s\n", info->capture_dev->name,
+	PR("%s\t%c        %d      %s\t%s\n", device_name_get(info->capture_dev),
 	   info->is_enabled ?
 	   (net_if_get_by_iface(info->capture_iface) + '0') : '-',
 	   net_if_get_by_iface(info->tunnel_iface),

--- a/subsys/pm/pm.c
+++ b/subsys/pm/pm.c
@@ -84,7 +84,7 @@ static int pm_suspend_devices(void)
 			continue;
 		} else if (ret < 0) {
 			LOG_ERR("Device %s did not enter %s state (%d)",
-				dev->name,
+				device_name_get(dev),
 				pm_device_state_str(PM_DEVICE_STATE_SUSPENDED),
 				ret);
 			return ret;

--- a/subsys/random/rand32_ctr_drbg.c
+++ b/subsys/random/rand32_ctr_drbg.c
@@ -59,7 +59,7 @@ static int ctr_drbg_initialize(void)
 	entropy_dev = DEVICE_DT_GET(DT_CHOSEN(zephyr_entropy));
 
 	if (!device_is_ready(entropy_dev)) {
-		__ASSERT(0, "Entropy device %s not ready", entropy_dev->name);
+		__ASSERT(0, "Entropy device %s not ready", device_name_get(entropy_dev));
 		return -ENODEV;
 	}
 

--- a/subsys/random/rand32_entropy_device.c
+++ b/subsys/random/rand32_entropy_device.c
@@ -19,7 +19,7 @@ uint32_t z_impl_sys_rand32_get(void)
 	int ret;
 
 	__ASSERT(device_is_ready(entropy_dev), "Entropy device %s not ready",
-		 entropy_dev->name);
+		 device_name_get(entropy_dev));
 
 	ret = entropy_get_entropy(entropy_dev, (uint8_t *)&random_num,
 				  sizeof(random_num));
@@ -43,7 +43,7 @@ static int rand_get(uint8_t *dst, size_t outlen, bool csrand)
 	int ret;
 
 	__ASSERT(device_is_ready(entropy_dev), "Entropy device %s not ready",
-		 entropy_dev->name);
+		 device_name_get(entropy_dev));
 
 	ret = entropy_get_entropy(entropy_dev, dst, outlen);
 

--- a/subsys/shell/modules/device_service.c
+++ b/subsys/shell/modules/device_service.c
@@ -39,7 +39,7 @@ static const char *get_device_name(const struct device *dev,
 				   char *buf,
 				   size_t len)
 {
-	const char *name = dev->name;
+	const char *name = device_name_get(dev);
 
 	if ((name == NULL) || (name[0] == 0)) {
 		snprintf(buf, len, "[%p]", dev);

--- a/subsys/shell/shell_utils.c
+++ b/subsys/shell/shell_utils.c
@@ -504,10 +504,10 @@ const struct device *shell_device_lookup(size_t idx,
 
 	while (dev < dev_end) {
 		if (device_is_ready(dev)
-		    && (dev->name != NULL)
-		    && (strlen(dev->name) != 0)
+		    && (device_name_get(dev) != NULL)
+		    && (strlen(device_name_get(dev)) != 0)
 		    && ((prefix == NULL)
-			|| (strncmp(prefix, dev->name,
+			|| (strncmp(prefix, device_name_get(dev),
 				    strlen(prefix)) == 0))) {
 			if (match_idx == idx) {
 				return dev;

--- a/subsys/storage/flash_map/flash_map_shell.c
+++ b/subsys/storage/flash_map/flash_map_shell.c
@@ -25,7 +25,7 @@ static void fa_cb(const struct flash_area *fa, void *user_data)
 	struct shell *shell = user_data;
 
 	shell_print(shell, "%-4d %-8d %-20s  0x%-10x 0x%-12x",
-		    fa->fa_id, fa->fa_device_id, fa->fa_dev->name,
+		    fa->fa_id, fa->fa_device_id, device_name_get(fa->fa_dev),
 		    (uint32_t) fa->fa_off, fa->fa_size);
 }
 

--- a/subsys/usb/device/class/audio/audio.c
+++ b/subsys/usb/device/class/audio/audio.c
@@ -772,7 +772,7 @@ static int audio_class_handle_req(struct usb_setup_packet *pSetup,
 
 static int usb_audio_device_init(const struct device *dev)
 {
-	LOG_DBG("Init Audio Device: dev %p (%s)", dev, dev->name);
+	LOG_DBG("Init Audio Device: dev %p (%s)", dev, device_name_get(dev));
 
 	return 0;
 }

--- a/subsys/usb/device/class/hid/core.c
+++ b/subsys/usb/device/class/hid/core.c
@@ -716,7 +716,7 @@ static const struct usb_hid_device_api {
 
 static int usb_hid_device_init(const struct device *dev)
 {
-	LOG_DBG("Init HID Device: dev %p (%s)", dev, dev->name);
+	LOG_DBG("Init HID Device: dev %p (%s)", dev, device_name_get(dev));
 
 	return 0;
 }

--- a/subsys/usb/device/usb_device.c
+++ b/subsys/usb/device/usb_device.c
@@ -1236,7 +1236,8 @@ static int usb_vbus_set(bool on)
 	struct gpio_dt_spec gpio_dev = GPIO_DT_SPEC_GET(USB_DEV_NODE, vbus_gpios);
 
 	if (!device_is_ready(gpio_dev.port)) {
-		LOG_DBG("USB requires GPIO. Device %s is not ready!", gpio_dev.port->name);
+		LOG_DBG("USB requires GPIO. Device %s is not ready!",
+			device_name_get(gpio_dev.port));
 		return -ENODEV;
 	}
 

--- a/tests/drivers/adc/adc_dma/src/test_adc.c
+++ b/tests/drivers/adc/adc_dma/src/test_adc.c
@@ -102,7 +102,7 @@ static void init_pit(void)
 	top_cfg.ticks = counter_us_to_ticks(dev, HW_TRIGGER_INTERVAL);
 	err = counter_set_top_value(dev, &top_cfg);
 	zassert_equal(0, err, "%s: Counter failed to set top value (err: %d)",
-		      dev->name, err);
+		      device_name_get(dev), err);
 }
 
 static const struct device *init_adc(void)

--- a/tests/drivers/can/timing/src/main.c
+++ b/tests/drivers/can/timing/src/main.c
@@ -294,7 +294,7 @@ void *can_timing_setup(void)
 	err = can_get_core_clock(dev, &core_clock);
 	zassert_equal(err, 0, "failed to get core CAN clock");
 
-	printk("testing on device %s @ %u Hz\n", dev->name, core_clock);
+	printk("testing on device %s @ %u Hz\n", device_name_get(dev), core_clock);
 
 	k_object_access_grant(dev, k_current_get());
 

--- a/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
+++ b/tests/drivers/clock_control/clock_control_api/src/test_clock_control.c
@@ -138,7 +138,8 @@ static void test_all_instances(test_func_t func,
 	for (size_t i = 0; i < ARRAY_SIZE(devices); i++) {
 		for (size_t j = 0; j < devices[i].subsys_cnt; j++) {
 			zassert_true(device_is_ready(devices[i].dev),
-					"Device %s is not ready", devices[i].dev->name);
+					"Device %s is not ready",
+					device_name_get(devices[i].dev));
 			test_with_single_instance(devices[i].dev,
 					devices[i].subsys_data[j].subsys,
 					devices[i].subsys_data[j].startup_us,
@@ -159,21 +160,21 @@ static void test_on_off_status_instance(const struct device *dev,
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
-			"%s: Unexpected status (%d)", dev->name, status);
+			"%s: Unexpected status (%d)", device_name_get(dev), status);
 
 	err = clock_control_on(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected err (%d)", device_name_get(dev), err);
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(status, CLOCK_CONTROL_STATUS_ON,
-			"%s: Unexpected status (%d)", dev->name, status);
+			"%s: Unexpected status (%d)", device_name_get(dev), status);
 
 	err = clock_control_off(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected err (%d)", device_name_get(dev), err);
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
-			"%s: Unexpected status (%d)", dev->name, status);
+			"%s: Unexpected status (%d)", device_name_get(dev), status);
 }
 
 ZTEST(clock_control, test_on_off_status)
@@ -235,15 +236,15 @@ static void test_async_on_instance(const struct device *dev,
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
-			"%s: Unexpected status (%d)", dev->name, status);
+			"%s: Unexpected status (%d)", device_name_get(dev), status);
 
 	err = clock_control_async_on(dev, subsys, clock_on_callback, &executed);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected err (%d)", device_name_get(dev), err);
 
 	/* wait for clock started. */
 	k_busy_wait(startup_us);
 
-	zassert_true(executed, "%s: Expected flag to be true", dev->name);
+	zassert_true(executed, "%s: Expected flag to be true", device_name_get(dev));
 	zassert_equal(CLOCK_CONTROL_STATUS_ON,
 			clock_control_get_status(dev, subsys),
 			"Unexpected clock status");
@@ -270,22 +271,22 @@ static void test_async_on_stopped_on_instance(const struct device *dev,
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
-			"%s: Unexpected status (%d)", dev->name, status);
+			"%s: Unexpected status (%d)", device_name_get(dev), status);
 
 	/* lock to prevent clock interrupt for fast starting clocks.*/
 	key = irq_lock();
 	err = clock_control_async_on(dev, subsys, clock_on_callback, &executed);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected err (%d)", device_name_get(dev), err);
 
 	/* Attempt to stop clock while it is being started. */
 	err = clock_control_off(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected err (%d)", device_name_get(dev), err);
 
 	irq_unlock(key);
 
 	k_busy_wait(10000);
 
-	zassert_false(executed, "%s: Expected flag to be false", dev->name);
+	zassert_false(executed, "%s: Expected flag to be false", device_name_get(dev));
 }
 
 ZTEST(clock_control, test_async_on_stopped)
@@ -305,13 +306,13 @@ static void test_double_start_on_instance(const struct device *dev,
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
-			"%s: Unexpected status (%d)", dev->name, status);
+			"%s: Unexpected status (%d)", device_name_get(dev), status);
 
 	err = clock_control_on(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected err (%d)", device_name_get(dev), err);
 
 	err = clock_control_on(dev, subsys);
-	zassert_true(err < 0, "%s: Unexpected return value:%d", dev->name, err);
+	zassert_true(err < 0, "%s: Unexpected return value:%d", device_name_get(dev), err);
 }
 
 ZTEST(clock_control, test_double_start)
@@ -332,10 +333,10 @@ static void test_double_stop_on_instance(const struct device *dev,
 
 	status = clock_control_get_status(dev, subsys);
 	zassert_equal(CLOCK_CONTROL_STATUS_OFF, status,
-			"%s: Unexpected status (%d)", dev->name, status);
+			"%s: Unexpected status (%d)", device_name_get(dev), status);
 
 	err = clock_control_off(dev, subsys);
-	zassert_equal(0, err, "%s: Unexpected err (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected err (%d)", device_name_get(dev), err);
 }
 
 ZTEST(clock_control, test_double_stop)

--- a/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
+++ b/tests/drivers/counter/counter_nrf_rtc/fixed_top/src/test_counter_fixed_top.c
@@ -37,7 +37,7 @@ static void counter_tear_down_instance(const struct device *dev)
 	int err;
 
 	err = counter_stop(dev);
-	zassert_equal(0, err, "%s: Counter failed to stop", dev->name);
+	zassert_equal(0, err, "%s: Counter failed to stop", device_name_get(dev));
 
 }
 
@@ -63,7 +63,7 @@ static void test_set_custom_top_value_fails_on_instance(const struct device *dev
 	top_cfg.ticks = counter_get_max_top_value(dev) - 1;
 
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_true(err != 0, "%s: Expected error code", dev->name);
+	zassert_true(err != 0, "%s: Expected error code", device_name_get(dev));
 }
 
 ZTEST(counter, test_set_custom_top_value_fails)
@@ -88,7 +88,7 @@ static void test_top_handler_on_instance(const struct device *dev)
 	top_cfg.ticks = counter_get_max_top_value(dev);
 
 	err = counter_set_top_value(dev, &top_cfg);
-	zassert_equal(0, err, "%s: Unexpected error code (%d)", dev->name, err);
+	zassert_equal(0, err, "%s: Unexpected error code (%d)", device_name_get(dev), err);
 
 #ifdef CONFIG_COUNTER_RTC0
 	nrf_rtc_task_trigger(NRF_RTC0, NRF_RTC_TASK_TRIGGER_OVERFLOW);
@@ -101,7 +101,7 @@ static void test_top_handler_on_instance(const struct device *dev)
 	k_busy_wait(10000);
 
 	tmp_top_cnt = top_cnt;
-	zassert_equal(tmp_top_cnt, 1, "%s: Expected top handler", dev->name);
+	zassert_equal(tmp_top_cnt, 1, "%s: Expected top handler", device_name_get(dev));
 }
 
 ZTEST(counter, test_top_handler)

--- a/tests/drivers/eeprom/src/main.c
+++ b/tests/drivers/eeprom/src/main.c
@@ -176,7 +176,7 @@ static void run_tests_on_eeprom(const struct device *dev)
 {
 	eeprom = dev;
 
-	printk("Running tests on device \"%s\"\n", eeprom->name);
+	printk("Running tests on device \"%s\"\n", device_name_get(eeprom));
 	k_object_access_grant(eeprom, k_current_get());
 	ztest_run_all(NULL);
 }

--- a/tests/drivers/entropy/api/src/main.c
+++ b/tests/drivers/entropy/api/src/main.c
@@ -78,7 +78,7 @@ static int get_entropy(void)
 	}
 
 	TC_PRINT("random device is %p, name is %s\n",
-		 dev, dev->name);
+		 dev, device_name_get(dev));
 
 	ret = random_entropy(dev, buffer, 0);
 

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_config.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_config.c
@@ -53,7 +53,7 @@ ZTEST(gpio_api_1pin_conf, test_gpio_pin_configure_push_pull)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT);
 	zassert_equal(ret, 0, "Failed to configure the pin as an output");
@@ -170,7 +170,7 @@ ZTEST(gpio_api_1pin_conf, test_gpio_pin_configure_single_ended)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	/* If the LED is connected directly between the MCU pin and power or
 	 * ground we can test only one of the Open Drain / Open Source modes.

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_pin.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_pin.c
@@ -66,7 +66,7 @@ ZTEST(gpio_api_1pin_pin, test_gpio_pin_toggle)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -108,7 +108,7 @@ ZTEST(gpio_api_1pin_pin, test_gpio_pin_toggle_visual)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT |
 				 TEST_PIN_DTS_FLAGS);
@@ -147,7 +147,7 @@ ZTEST(gpio_api_1pin_pin, test_gpio_pin_set_get_raw)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -184,7 +184,7 @@ ZTEST(gpio_api_1pin_pin, test_gpio_pin_set_get)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -221,7 +221,7 @@ ZTEST(gpio_api_1pin_pin, test_gpio_pin_set_get_active_high)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT |
 				 GPIO_ACTIVE_HIGH);
@@ -271,7 +271,7 @@ ZTEST(gpio_api_1pin_pin, test_gpio_pin_set_get_active_low)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT |
 				 GPIO_ACTIVE_LOW);

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_pin_interrupt.c
@@ -58,7 +58,7 @@ void test_gpio_pin_interrupt_edge(unsigned int cfg_flags,
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_INPUT | GPIO_OUTPUT);
 	if (ret == -ENOTSUP) {
@@ -132,7 +132,7 @@ void test_gpio_pin_interrupt_level(unsigned int cfg_flags,
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_INPUT | GPIO_OUTPUT);
 	if (ret == -ENOTSUP) {

--- a/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
+++ b/tests/drivers/gpio/gpio_api_1pin/src/test_port.c
@@ -117,7 +117,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_toggle)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -166,7 +166,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_masked_get_raw)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -206,7 +206,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_masked_get)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -247,7 +247,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_masked_get_active_high)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT |
 				 GPIO_ACTIVE_HIGH);
@@ -298,7 +298,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_masked_get_active_low)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT |
 				 GPIO_ACTIVE_LOW);
@@ -342,7 +342,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_bits_clear_bits_raw)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -383,7 +383,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_bits_clear_bits)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -424,7 +424,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_clr_bits_raw)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {
@@ -461,7 +461,7 @@ ZTEST(gpio_api_1pin_port, test_gpio_port_set_clr_bits)
 	port = DEVICE_DT_GET(TEST_NODE);
 	zassert_true(device_is_ready(port), "GPIO dev is not ready");
 
-	TC_PRINT("Running test on port=%s, pin=%d\n", port->name, TEST_PIN);
+	TC_PRINT("Running test on port=%s, pin=%d\n", device_name_get(port), TEST_PIN);
 
 	ret = gpio_pin_configure(port, TEST_PIN, GPIO_OUTPUT | GPIO_INPUT);
 	if (ret == -ENOTSUP) {

--- a/tests/drivers/gpio/gpio_basic_api/src/main.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/main.c
@@ -26,7 +26,7 @@ static void board_setup(void)
 
 	if (in_dev != out_dev) {
 		printk("FATAL: output controller %s != input controller %s\n",
-		       out_dev->name, in_dev->name);
+		       device_name_get(out_dev), device_name_get(in_dev));
 		k_panic();
 	}
 #endif

--- a/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
+++ b/tests/drivers/gpio/gpio_basic_api/src/test_gpio_port.c
@@ -69,10 +69,10 @@ static int setup(void)
 	int rc;
 	gpio_port_value_t v1;
 
-	TC_PRINT("Validate device %s\n", dev->name);
+	TC_PRINT("Validate device %s\n", device_name_get(dev));
 	zassert_true(device_is_ready(dev), "GPIO dev is not ready");
 
-	TC_PRINT("Check %s output %d connected to input %d\n", dev->name,
+	TC_PRINT("Check %s output %d connected to input %d\n", device_name_get(dev),
 		 PIN_OUT, PIN_IN);
 
 	rc = gpio_pin_configure(dev, PIN_IN, GPIO_INPUT);

--- a/tests/drivers/i2c/i2c_target_api/src/main.c
+++ b/tests/drivers/i2c/i2c_target_api/src/main.c
@@ -48,7 +48,7 @@ static int run_full_read(const struct device *i2c, uint8_t addr,
 	int ret;
 
 	TC_PRINT("Testing full read: Master: %s, address: 0x%x\n",
-		 i2c->name, addr);
+		 device_name_get(i2c), addr);
 
 	/* Read EEPROM from I2C Master requests, then compare */
 	ret = i2c_burst_read(i2c, addr, 0, i2c_buffer, TEST_DATA_SIZE);
@@ -75,7 +75,7 @@ static int run_partial_read(const struct device *i2c, uint8_t addr,
 	int ret;
 
 	TC_PRINT("Testing partial read. Master: %s, address: 0x%x, off=%d\n",
-		 i2c->name, addr, offset);
+		 device_name_get(i2c), addr, offset);
 
 	ret = i2c_burst_read(i2c, addr,
 			     offset, i2c_buffer, TEST_DATA_SIZE-offset);
@@ -102,7 +102,7 @@ static int run_program_read(const struct device *i2c, uint8_t addr,
 	int ret, i;
 
 	TC_PRINT("Testing program. Master: %s, address: 0x%x, off=%d\n",
-		i2c->name, addr, offset);
+		device_name_get(i2c), addr, offset);
 
 	for (i = 0 ; i < TEST_DATA_SIZE-offset ; ++i) {
 		i2c_buffer[i] = i;
@@ -148,7 +148,7 @@ ZTEST(i2c_eeprom_target, test_eeprom_target)
 	zassert_true(device_is_ready(i2c_0), "EEPROM 0 - I2C bus not ready");
 
 	TC_PRINT("Found EEPROM 0 on I2C bus device %s at addr %02x\n",
-		 i2c_0->name, addr_0);
+		 device_name_get(i2c_0), addr_0);
 
 	zassert_not_null(i2c_1, "EEPROM 1 - I2C device not found");
 	zassert_not_null(eeprom_1, "EEPROM 1 device not found");
@@ -156,7 +156,7 @@ ZTEST(i2c_eeprom_target, test_eeprom_target)
 	zassert_true(device_is_ready(i2c_1), "EEPROM 1 - I2C bus not ready");
 
 	TC_PRINT("Found EEPROM 1 on I2C bus device %s at addr %02x\n",
-		 i2c_1->name, addr_1);
+		 device_name_get(i2c_1), addr_1);
 
 	if (IS_ENABLED(CONFIG_APP_DUAL_ROLE_I2C)) {
 		TC_PRINT("Testing dual-role\n");

--- a/tests/drivers/sensor/accel/src/main.c
+++ b/tests/drivers/sensor/accel/src/main.c
@@ -48,7 +48,7 @@ static void run_tests_on_accel(const struct device *accel)
 {
 	zassert_true(device_is_ready(accel), "Accelerometer device is not ready");
 
-	PRINT("Running tests on '%s'\n", accel->name);
+	PRINT("Running tests on '%s'\n", device_name_get(accel));
 	k_object_access_grant(accel, k_current_get());
 }
 

--- a/tests/subsys/emul/src/main.c
+++ b/tests/subsys/emul/src/main.c
@@ -22,8 +22,8 @@ ZTEST(emul, test_emul_dt_get)
 
 	/* Verify that EMUL_DT_GET returned the expected struct emul. */
 	zassert_not_null(emul_static, "EMUL_DT_GET returned NULL");
-	zassert_ok(strcmp(emul_static->dev->name, DT_NODE_FULL_NAME(TEST_ACCEL)),
-		   "Unexpected device name %s", emul_static->dev->name);
+	zassert_ok(strcmp(device_name_get(emul_static->dev), DT_NODE_FULL_NAME(TEST_ACCEL)),
+		   "Unexpected device name %s", device_name_get(emul_static->dev));
 }
 
 ZTEST_SUITE(emul, NULL, NULL, NULL, NULL, NULL);


### PR DESCRIPTION
With the adoption of DEVICE_DT_GET() device names are in many cases
optional and used only for stuff like debugging or in shells. This patch
makes struct device name field optional so that ROM can be saved in case
user can afford it. This means that the name field in struct device
should no longer be accessed directly but using a new function:
device_name_get().

Note that the option controlling such feature is
CONFIG_DEVICE_STORE_NAME, enabled by default.

Some quick numbers using `hello_world`:

`nrf52840dk_nrf52840`: $\Delta_{\textrm{FLASH}} = -100~\textrm{bytes}$
`nucleo_h743zi`: $\Delta_{\textrm{FLASH}} = -272~\textrm{bytes}$

Signed-off-by: Gerard Marull-Paretas <gerard.marull@nordicsemi.no>