### PR TITLE
Bluetooth: LC3: Fix prefer and streaming context macros

### DIFF
--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -257,18 +257,19 @@ enum bt_codec_config_type {
  */
  #define BT_CODEC_LC3_DATA(_freq, _duration, _chan_count, _len_min, _len_max, _max_frames_per_sdu) \
 { \
-	 BT_CODEC_DATA(BT_CODEC_LC3_FREQ, \
-		       ((_freq) & 0xFFU), \
-		       (((_freq) >> 8) & 0xFFU)), \
-	 BT_CODEC_DATA(BT_CODEC_LC3_DURATION, _duration), \
-	 BT_CODEC_DATA(BT_CODEC_LC3_CHAN_COUNT, _chan_count), \
-	 BT_CODEC_DATA(BT_CODEC_LC3_FRAME_LEN, \
-		       ((_len_min) & 0xFFU), \
-		       (((_len_min) >> 8) & 0xFFU), \
-		       ((_len_max) & 0xFFU), \
-		       (((_len_max) >> 8) & 0xFFU)) \
-	 COND_CODE_1(_max_frames_per_sdu, (), \
-		     (, BT_CODEC_DATA(BT_CODEC_LC3_FRAME_COUNT, _max_frames_per_sdu))) \
+	BT_CODEC_DATA(BT_CODEC_LC3_FREQ, \
+		      ((_freq) & 0xFFU), \
+		      (((_freq) >> 8) & 0xFFU)), \
+	BT_CODEC_DATA(BT_CODEC_LC3_DURATION, _duration), \
+	BT_CODEC_DATA(BT_CODEC_LC3_CHAN_COUNT, _chan_count), \
+	BT_CODEC_DATA(BT_CODEC_LC3_FRAME_LEN, \
+		      ((_len_min) & 0xFFU), \
+		      (((_len_min) >> 8) & 0xFFU), \
+		      ((_len_max) & 0xFFU), \
+		      (((_len_max) >> 8) & 0xFFU)) \
+	COND_CODE_1(_max_frames_per_sdu, (), \
+		    (, BT_CODEC_DATA(BT_CODEC_LC3_FRAME_COUNT, \
+				     _max_frames_per_sdu))) \
 }
 
 /**
@@ -304,18 +305,19 @@ enum bt_codec_config_type {
  */
 #define BT_CODEC_LC3_CONFIG_DATA(_freq, _duration, _loc, _len, _frame_blocks_per_sdu) \
 { \
-	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FREQ, _freq), \
-	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_DURATION, _duration), \
-	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_CHAN_ALLOC, \
-		       ((_loc) & 0xFFU), \
-		       (((_loc) >> 8) & 0xFFU), \
-		       (((_loc) >> 16) & 0xFFU), \
-		       (((_loc) >> 24) & 0xFFU)), \
-	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_LEN, \
-		       ((_len) & 0xFFU), \
-		       (((_len) >> 8) & 0xFFU)) \
-	 COND_CODE_1(_frame_blocks_per_sdu, (), \
-		     (, BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU, _frames_per_sdu))) \
+	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FREQ, _freq), \
+	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_DURATION, _duration), \
+	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_CHAN_ALLOC, \
+		      ((_loc) & 0xFFU), \
+		      (((_loc) >> 8) & 0xFFU), \
+		      (((_loc) >> 16) & 0xFFU), \
+		      (((_loc) >> 24) & 0xFFU)), \
+	BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_LEN, \
+		      ((_len) & 0xFFU), \
+		      (((_len) >> 8) & 0xFFU)) \
+	COND_CODE_1(_frame_blocks_per_sdu, (), \
+		    (, BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU, \
+				     _frames_per_sdu))) \
 }
 
 /**

--- a/include/zephyr/bluetooth/audio/lc3.h
+++ b/include/zephyr/bluetooth/audio/lc3.h
@@ -257,11 +257,16 @@ enum bt_codec_config_type {
  */
  #define BT_CODEC_LC3_DATA(_freq, _duration, _chan_count, _len_min, _len_max, _max_frames_per_sdu) \
 { \
-	 BT_CODEC_DATA(BT_CODEC_LC3_FREQ, (_freq) & 0xffu, (_freq) >> 8), \
+	 BT_CODEC_DATA(BT_CODEC_LC3_FREQ, \
+		       ((_freq) & 0xFFU), \
+		       (((_freq) >> 8) & 0xFFU)), \
 	 BT_CODEC_DATA(BT_CODEC_LC3_DURATION, _duration), \
 	 BT_CODEC_DATA(BT_CODEC_LC3_CHAN_COUNT, _chan_count), \
-	 BT_CODEC_DATA(BT_CODEC_LC3_FRAME_LEN, (_len_min) & 0xffu, (_len_min) >> 8, \
-		       (_len_max) & 0xffu, (_len_max) >> 8) \
+	 BT_CODEC_DATA(BT_CODEC_LC3_FRAME_LEN, \
+		       ((_len_min) & 0xFFU), \
+		       (((_len_min) >> 8) & 0xFFU), \
+		       ((_len_max) & 0xFFU), \
+		       (((_len_max) >> 8) & 0xFFU)) \
 	 COND_CODE_1(_max_frames_per_sdu, (), \
 		     (, BT_CODEC_DATA(BT_CODEC_LC3_FRAME_COUNT, _max_frames_per_sdu))) \
 }
@@ -272,8 +277,8 @@ enum bt_codec_config_type {
 #define BT_CODEC_LC3_META(_prefer_context) \
 { \
 	BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_PREF_CONTEXT, \
-		      (_prefer_context) & 0xffu, \
-		      (_prefer_context) >> 8) \
+		      ((_prefer_context) & 0xFFU), \
+		      (((_prefer_context) >> 8) & 0xFFU)) \
 }
 
 /**
@@ -301,9 +306,14 @@ enum bt_codec_config_type {
 { \
 	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FREQ, _freq), \
 	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_DURATION, _duration), \
-	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_CHAN_ALLOC, (_loc) & 0xffu, ((_loc) >> 8) & 0xffu, \
-		       ((_loc) >> 16) & 0xffu, (_loc) >> 24), \
-	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_LEN, (_len) & 0xffu, (_len) >> 8) \
+	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_CHAN_ALLOC, \
+		       ((_loc) & 0xFFU), \
+		       (((_loc) >> 8) & 0xFFU), \
+		       (((_loc) >> 16) & 0xFFU), \
+		       (((_loc) >> 24) & 0xFFU)), \
+	 BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_LEN, \
+		       ((_len) & 0xFFU), \
+		       (((_len) >> 8) & 0xFFU)) \
 	 COND_CODE_1(_frame_blocks_per_sdu, (), \
 		     (, BT_CODEC_DATA(BT_CODEC_CONFIG_LC3_FRAME_BLKS_PER_SDU, _frames_per_sdu))) \
 }
@@ -314,8 +324,8 @@ enum bt_codec_config_type {
 #define BT_CODEC_LC3_CONFIG_META(_stream_context) \
 { \
 	BT_CODEC_DATA(BT_AUDIO_METADATA_TYPE_STREAM_CONTEXT, \
-		      _stream_context, \
-		      _stream_context >> 8), \
+		      ((_stream_context) & 0xFFU), \
+		      (((_stream_context) >> 8) & 0xFFU)) \
 }
 
 /**


### PR DESCRIPTION
Fix the BT_CODEC_LC3_META (prefer context) and
BT_CODEC_LC3_CONFIG_META (streaming context) macros, as
they did not properly set the right values due to missing
parenthesis.

Also added casts to `uint8_t` to avoid compiler warnings on
e.g. GCC when assigning a non uint8_t value to a uint8_t array.

Signed-off-by: Emil Gydesen <emil.gydesen@nordicsemi.no>