### PR TITLE
twister: Add esp32 section name to overflow check

### DIFF
--- a/scripts/pylib/twister/twisterlib/runner.py
+++ b/scripts/pylib/twister/twisterlib/runner.py
@@ -218,7 +218,7 @@ class CMake:
                     log.write(log_msg)
 
             if log_msg:
-                overflow_found = re.findall("region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM)' overflowed by", log_msg)
+                overflow_found = re.findall("region `(FLASH|ROM|RAM|ICCM|DCCM|SRAM|dram0_1_seg)' overflowed by", log_msg)
                 if overflow_found and not self.options.overflow_as_errors:
                     logger.debug("Test skipped due to {} Overflow".format(overflow_found[0]))
                     self.instance.status = "skipped"


### PR DESCRIPTION
esp32 platforms can overflow their dram0_1_seg so add that section name
to the overflow check in twister.  We were seeing this with the
samples/arch/smp/pi/sample.smp.pi test and would get:

 zephyr_pre0.elf section `noinit' will not fit in region `dram0_1_seg'
 region `dram0_1_seg' overflowed by 17456 bytes

Fixes #49164

Signed-off-by: Kumar Gala <galak@kernel.org>