### PR TITLE
drivers/timer: stm32:  Changes around LPTIM configuration

### DIFF
--- a/boards/arm/b_u585i_iot02a/Kconfig.defconfig
+++ b/boards/arm/b_u585i_iot02a/Kconfig.defconfig
@@ -16,4 +16,8 @@ config SPI_STM32_INTERRUPT
 config USE_DT_CODE_PARTITION
 	default y if TRUSTED_EXECUTION_NONSECURE
 
+# LPTIM clocked by LSE, force tick freq to 4096 for tick accuracy
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4096 if STM32_LPTIM_TIMER
+
 endif # BOARD_B_U585I_IOT02A

--- a/boards/arm/disco_l475_iot1/Kconfig.defconfig
+++ b/boards/arm/disco_l475_iot1/Kconfig.defconfig
@@ -8,6 +8,10 @@ if BOARD_DISCO_L475_IOT1
 config BOARD
 	default "disco_l475_iot1"
 
+# LPTIM clocked by LSE, force tick freq to 4096 for tick accuracy
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4096 if STM32_LPTIM_TIMER
+
 config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI

--- a/boards/arm/nucleo_h723zg/Kconfig.defconfig
+++ b/boards/arm/nucleo_h723zg/Kconfig.defconfig
@@ -15,9 +15,4 @@ config NET_L2_ETHERNET
 
 endif # NETWORKING
 
-choice STM32_LPTIM_CLOCK
-	default STM32_LPTIM_CLOCK_LSE
-	depends on STM32_LPTIM_TIMER
-endchoice
-
 endif # BOARD_NUCLEO_H723ZG

--- a/boards/arm/nucleo_l073rz/Kconfig.defconfig
+++ b/boards/arm/nucleo_l073rz/Kconfig.defconfig
@@ -12,10 +12,4 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
-# FIXME: LSE not working as LPTIM clock source. Use LSI instead.
-choice STM32_LPTIM_CLOCK
-	default STM32_LPTIM_CLOCK_LSI
-	depends on STM32_LPTIM_TIMER
-endchoice
-
 endif # BOARD_NUCLEO_L073RZ

--- a/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
+++ b/boards/arm/nucleo_l073rz/nucleo_l073rz.dts
@@ -37,6 +37,14 @@
 		};
 	};
 
+	power-states {
+		stop: state {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			min-residency-us = <100>;
+		};
+	};
+
 	pwmleds: pwmleds {
 		compatible = "pwm-leds";
 		/* NOTE: disabled by default, PWM2 conflicts with SPI1 */
@@ -55,9 +63,17 @@
 	};
 };
 
+&cpu0 {
+	cpu-power-states = <&stop>;
+};
+
 &clk_hse {
 	hse-bypass;
 	clock-frequency = <DT_FREQ_M(8)>; /* STLink 8MHz clock */
+	status = "okay";
+};
+
+&clk_lsi {
 	status = "okay";
 };
 
@@ -74,6 +90,11 @@
 	ahb-prescaler = <1>;
 	apb1-prescaler = <1>;
 	apb2-prescaler = <1>;
+};
+
+&lptim1 {
+	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
+		<&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;
 };
 
 &usart1 {

--- a/boards/arm/nucleo_wb55rg/Kconfig.defconfig
+++ b/boards/arm/nucleo_wb55rg/Kconfig.defconfig
@@ -13,4 +13,8 @@ choice BT_HCI_BUS_TYPE
 	depends on BT
 endchoice
 
+# LPTIM clocked by LSE, force tick freq to 4096 for tick accuracy
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4096 if STM32_LPTIM_TIMER
+
 endif # BOARD_NUCLEO_WB55RG

--- a/boards/arm/nucleo_wl55jc/Kconfig.defconfig
+++ b/boards/arm/nucleo_wl55jc/Kconfig.defconfig
@@ -8,4 +8,7 @@ if BOARD_NUCLEO_WL55JC
 config BOARD
 	default "nucleo_wl55jc"
 
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4096 if STM32_LPTIM_TIMER
+
 endif # BOARD_NUCLEO_WL55JC

--- a/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
+++ b/boards/arm/nucleo_wl55jc/nucleo_wl55jc.dts
@@ -88,6 +88,10 @@
 	cpu-power-states = <&stop0 &stop1 &stop2>;
 };
 
+&clk_lsi {
+	status = "okay";
+};
+
 &lptim1 {
 	clocks = <&rcc STM32_CLOCK_BUS_APB1 0x80000000>,
 		 <&rcc STM32_SRC_LSI LPTIM1_SEL(1)>;

--- a/boards/arm/stm32h735g_disco/Kconfig.defconfig
+++ b/boards/arm/stm32h735g_disco/Kconfig.defconfig
@@ -12,9 +12,4 @@ config SPI_STM32_INTERRUPT
 	default y
 	depends on SPI
 
-choice STM32_LPTIM_CLOCK
-	default STM32_LPTIM_CLOCK_LSE
-	depends on STM32_LPTIM_TIMER
-endchoice
-
 endif # BOARD_STM32H735G_DISCO

--- a/boards/arm/stm32l562e_dk/Kconfig.defconfig
+++ b/boards/arm/stm32l562e_dk/Kconfig.defconfig
@@ -8,6 +8,10 @@ if BOARD_STM32L562E_DK
 config BOARD
 	default "stm32l562e_dk"
 
+# LPTIM clocked by LSE, force tick freq to 4096 for tick accuracy
+config SYS_CLOCK_TICKS_PER_SEC
+	default 4096 if STM32_LPTIM_TIMER
+
 if BT
 
 config SPI

--- a/drivers/timer/Kconfig.stm32_lptim
+++ b/drivers/timer/Kconfig.stm32_lptim
@@ -5,7 +5,8 @@
 
 menuconfig STM32_LPTIM_TIMER
 	bool "STM32 Low Power Timer [EXPERIMENTAL]"
-	depends on "$(dt_nodelabel_enabled,lptim1)"
+	default y
+	depends on DT_HAS_ST_STM32_LPTIM_ENABLED
 	depends on CLOCK_CONTROL && PM
 	select TICKLESS_CAPABLE
 	select EXPERIMENTAL

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -28,6 +28,7 @@
 #define LPTIM (LPTIM_TypeDef *) DT_INST_REG_ADDR(0)
 
 #if DT_INST_NUM_CLOCKS(0) == 1
+#warning Kconfig for LPTIM source clock (LSI/LSE) is deprecated, use device tree.
 static const struct stm32_pclken lptim_clk[] = {
 	STM32_CLOCK_INFO(0, DT_DRV_INST(0)),
 	/* Use Kconfig to configure source clocks fields */

--- a/drivers/timer/stm32_lptim_timer.c
+++ b/drivers/timer/stm32_lptim_timer.c
@@ -298,6 +298,15 @@ static int sys_clock_driver_init(const struct device *dev)
 	LL_SRDAMR_GRP1_EnableAutonomousClock(LL_SRDAMR_GRP1_PERIPH_LPTIM1AMEN);
 #endif
 
+	/* For tick accuracy, a specific tick to freq ratio is expected */
+	/* This check assumes LSI@32KHz or LSE@32768Hz */
+	if (((lptim_clk[1].bus == STM32_SRC_LSI) &&
+	      (CONFIG_SYS_CLOCK_TICKS_PER_SEC == 4000)) ||
+	    ((lptim_clk[1].bus == STM32_SRC_LSE) &&
+	      (CONFIG_SYS_CLOCK_TICKS_PER_SEC == 4096))) {
+		return -ENOTSUP;
+	}
+
 	/* Enable LPTIM clock source */
 	clock_control_configure(clk_ctrl, (clock_control_subsys_t *) &lptim_clk[1],
 				NULL);

--- a/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32g0/Kconfig.defconfig.series
@@ -12,7 +12,4 @@ source "soc/arm/st_stm32/stm32g0/Kconfig.defconfig.stm32g0*"
 config SOC_SERIES
 	default "stm32g0"
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 endif # SOC_SERIES_STM32G0X

--- a/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32h7/Kconfig.defconfig.series
@@ -17,7 +17,4 @@ config ROM_START_OFFSET
 	default 0x400 if BOOTLOADER_MCUBOOT
 	default 0x0   if !BOOTLOADER_MCUBOOT
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 endif # SOC_SERIES_STM32H7X

--- a/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l0/Kconfig.defconfig.series
@@ -12,9 +12,6 @@ source "soc/arm/st_stm32/stm32l0/Kconfig.defconfig.stm32l0*"
 config SOC_SERIES
 	default "stm32l0"
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 # adjust the fallback because of the LSI oscaillator characteristics
 config TASK_WDT_HW_FALLBACK_DELAY
 	depends on TASK_WDT_HW_FALLBACK

--- a/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l4/Kconfig.defconfig.series
@@ -13,7 +13,4 @@ source "soc/arm/st_stm32/stm32l4/Kconfig.defconfig.stm32l4*"
 config SOC_SERIES
 	default "stm32l4"
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 endif # SOC_SERIES_STM32L4X

--- a/soc/arm/st_stm32/stm32l5/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32l5/Kconfig.defconfig.series
@@ -10,7 +10,4 @@ source "soc/arm/st_stm32/stm32l5/Kconfig.defconfig.stm32l5*"
 config SOC_SERIES
 	default "stm32l5"
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 endif # SOC_SERIES_STM32L5X

--- a/soc/arm/st_stm32/stm32u5/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32u5/Kconfig.defconfig.series
@@ -10,9 +10,6 @@ source "soc/arm/st_stm32/stm32u5/Kconfig.defconfig.stm32u5*"
 config SOC_SERIES
 	default "stm32u5"
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 config MCUBOOT_EXTRA_IMGTOOL_ARGS
 	default "--header-size 1024" if BOOTLOADER_MCUBOOT
 

--- a/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wb/Kconfig.defconfig.series
@@ -10,7 +10,4 @@ source "soc/arm/st_stm32/stm32wb/Kconfig.defconfig.stm32wb*"
 config SOC_SERIES
 	default "stm32wb"
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 endif # SOC_SERIES_STM32WBX

--- a/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.series
+++ b/soc/arm/st_stm32/stm32wl/Kconfig.defconfig.series
@@ -10,7 +10,4 @@ source "soc/arm/st_stm32/stm32wl/Kconfig.defconfig.stm32wl*"
 config SOC_SERIES
 	default "stm32wl"
 
-config STM32_LPTIM_TIMER
-	default y if PM
-
 endif # SOC_SERIES_STM32WLX


### PR DESCRIPTION
In https://github.com/zephyrproject-rtos/zephyr/pull/49035/files deprecation message that was set in https://github.com/zephyrproject-rtos/zephyr/pull/48771 was removed in order to get CI to pass.

Fix the root issues and set the message back.

Additionally fix related issues:
 - L0 LSI case
 - SYS_CLOCK_TICKS_PER_SEC setting