### PR TITLE
mgmt: mcumgr: Make img_mgmt structures packed

### DIFF
--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/image.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/image.h
@@ -34,7 +34,7 @@ struct image_version {
 	uint8_t iv_minor;
 	uint16_t iv_revision;
 	uint32_t iv_build_num;
-};
+} __packed;
 
 /** Image header.  All fields are in little endian byte order. */
 struct image_header {
@@ -46,20 +46,20 @@ struct image_header {
 	uint32_t ih_flags;	/* IMAGE_F_[...]. */
 	struct image_version ih_ver;
 	uint32_t _pad3;
-};
+} __packed;
 
 /** Image TLV header.  All fields in little endian. */
 struct image_tlv_info {
 	uint16_t it_magic;
 	uint16_t it_tlv_tot;  /* size of TLV area (including tlv_info header) */
-};
+} __packed;
 
 /** Image trailer TLV format. All fields in little endian. */
 struct image_tlv {
 	uint8_t  it_type;   /* IMAGE_TLV_[...]. */
 	uint8_t  _pad;
 	uint16_t it_len;	/* Data length (not including TLV header). */
-};
+} __packed;
 
 _Static_assert(sizeof(struct image_header) == IMAGE_HEADER_SIZE,
 			   "struct image_header not required size");

--- a/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
+++ b/subsys/mgmt/mcumgr/lib/cmd/img_mgmt/include/img_mgmt/img_mgmt.h
@@ -71,7 +71,7 @@ struct img_mgmt_upload_req {
 	struct zcbor_string img_data;
 	struct zcbor_string data_sha;
 	bool upgrade;			/* Only allow greater version numbers. */
-};
+} __packed;
 
 /** Global state for upload in progress. */
 struct img_mgmt_state {
@@ -84,7 +84,7 @@ struct img_mgmt_state {
 	/** Hash of image data; used for resumption of a partial upload. */
 	uint8_t data_sha_len;
 	uint8_t data_sha[IMG_MGMT_DATA_SHA_LEN];
-};
+} __packed;
 
 /** Describes what to do during processing of an upload request. */
 struct img_mgmt_upload_action {
@@ -102,7 +102,7 @@ struct img_mgmt_upload_action {
 	/** "rsn" string to be sent as explanation for "rc" code */
 	const char *rc_rsn;
 #endif
-};
+} __packed;
 
 /**
  * @brief Registers the image management command handler group.


### PR DESCRIPTION
Resolves an issue with processors that do not support unaligned memory
access when using img_mgmt functions, e.g. ARM Cortex M0, by marking
structures as packed.

Fixes #49066