### PR TITLE
MIMXRT595 PMIC Enablement

### DIFF
--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33-pinctrl.dtsi
@@ -61,4 +61,16 @@
 		};
 	};
 
+	pinmux_pmic_i2c: pinmux_pmic_i2c {
+		group0 {
+			pinmux = <PMIC_I2C_SCL>,
+				<PMIC_I2C_SDA>;
+			bias-pull-up;
+			input-enable;
+			slew-rate = "normal";
+			drive-strength = "normal";
+			drive-open-drain;
+		};
+	};
+
 };

--- a/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
+++ b/boards/arm/mimxrt595_evk/mimxrt595_evk_cm33.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <nxp/nxp_rt5xx.dtsi>
+#include <zephyr/dt-bindings/regulator/pca9420_i2c.h>
 
 #include "mimxrt595_evk_cm33-pinctrl.dtsi"
 
@@ -143,6 +144,91 @@ arduino_serial: &flexcomm12 {
 	pinctrl-0 = <&pinmux_flexcomm12_usart>;
 	pinctrl-names = "default";
 };
+
+/* PCA9420 PMIC */
+&pmic_i2c {
+	status = "okay";
+	clock-frequency = <I2C_BITRATE_FAST>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	pinctrl-0 = <&pinmux_pmic_i2c>;
+	pinctrl-names = "default";
+
+	pca9420: pca9420@61 {
+		reg = <0x61>;
+
+		pca9420_sw1: sw1_buck {
+			compatible = "regulator-pmic";
+			voltage-range = <PCA9420_SW1_VOLTAGE_RANGE>;
+			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
+			num-voltages = <42>;
+			ilim-reg = <PCA9420_TOP_CNTL0>;
+			ilim-mask = <PCA9420_TOP_CNTL0_VIN_ILIM_SEL_MASK>;
+			num-current-levels = <7>;
+			vsel-reg = <PCA9420_MODECFG_0_0>;
+			vsel-mask = <PCA9420_MODECFG_0_SW1_OUT_MASK>;
+			enable-reg = <PCA9420_MODECFG_0_2>;
+			enable-mask = <PCA9420_MODECFG_2_SW1_EN_MASK>;
+			enable-val = <PCA9420_MODECFG_2_SW1_EN_VAL>;
+			min-uV = <500000>;
+			max-uV = <1800000>;
+		};
+
+		pca9420_sw2: sw2_buck {
+			compatible = "regulator-pmic";
+			voltage-range = <PCA9420_SW2_VOLTAGE_RANGE>;
+			num-voltages = <50>;
+			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
+			ilim-reg = <PCA9420_TOP_CNTL0>;
+			ilim-mask = <PCA9420_TOP_CNTL0_VIN_ILIM_SEL_MASK>;
+			num-current-levels = <7>;
+			vsel-reg = <PCA9420_MODECFG_0_1>;
+			vsel-mask = <PCA9420_MODECFG_1_SW2_OUT_MASK>;
+			enable-reg = <PCA9420_MODECFG_0_2>;
+			enable-mask = <PCA9420_MODECFG_2_SW2_EN_MASK>;
+			enable-val = <PCA9420_MODECFG_2_SW2_EN_VAL>;
+			min-uV = <1500000>;
+			max-uV = <3300000>;
+		};
+
+		pca9420_ldo1: ldo1_reg {
+			compatible = "regulator-pmic";
+			voltage-range = <PCA9420_LDO1_VOLTAGE_RANGE>;
+			num-voltages = <9>;
+			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
+			ilim-reg = <PCA9420_TOP_CNTL0>;
+			ilim-mask = <PCA9420_TOP_CNTL0_VIN_ILIM_SEL_MASK>;
+			num-current-levels = <7>;
+			vsel-reg = <PCA9420_MODECFG_0_2>;
+			vsel-mask = <PCA9420_MODECFG_2_LDO1_OUT_MASK>;
+			enable-reg = <PCA9420_MODECFG_0_2>;
+			enable-mask = <PCA9420_MODECFG_2_LDO1_EN_MASK>;
+			enable-val = <PCA9420_MODECFG_2_LDO1_EN_VAL>;
+			min-uV = <1700000>;
+			max-uV = <1900000>;
+		};
+
+		pca9420_ldo2: ldo2_reg {
+			compatible = "regulator-pmic";
+			voltage-range = <PCA9420_LDO2_VOLTAGE_RANGE>;
+			num-voltages = <50>;
+			current-levels = <PCA9420_CURRENT_LIMIT_LEVELS>;
+			ilim-reg = <PCA9420_TOP_CNTL0>;
+			ilim-mask = <PCA9420_TOP_CNTL0_VIN_ILIM_SEL_MASK>;
+			num-current-levels = <7>;
+			vsel-reg = <PCA9420_MODECFG_0_3>;
+			vsel-mask = <PCA9420_MODECFG_3_LDO2_OUT_MASK>;
+			enable-reg = <PCA9420_MODECFG_0_2>;
+			enable-mask = <PCA9420_MODECFG_2_LDO2_EN_MASK>;
+			enable-val = <PCA9420_MODECFG_2_LDO2_EN_VAL>;
+			min-uV = <1500000>;
+			max-uV = <3300000>;
+		};
+
+
+	};
+};
+
 
 &gpio0 {
 	status = "okay";

--- a/dts/arm/nxp/nxp_rt5xx_common.dtsi
+++ b/dts/arm/nxp/nxp_rt5xx_common.dtsi
@@ -215,6 +215,14 @@
 		status = "disabled";
 	};
 
+	pmic_i2c: i2c@127000 {
+		compatible = "nxp,lpc-i2c";
+		reg = <0x127000 0x1000>;
+		interrupts = <21 0>;
+		clocks = <&clkctl1 MCUX_PMIC_I2C_CLK>;
+		status = "disabled";
+	};
+
 	flexcomm8: flexcomm@209000 {
 		compatible = "nxp,lpc-flexcomm";
 		reg = <0x209000 0x1000>;

--- a/soc/arm/nxp_imx/rt5xx/soc.c
+++ b/soc/arm/nxp_imx/rt5xx/soc.c
@@ -277,6 +277,9 @@ void clock_init(void)
 	/* Switch FLEXCOMM12 to FRG */
 	CLOCK_AttachClk(kFRG_to_FLEXCOMM12);
 #endif
+#if DT_NODE_HAS_COMPAT_STATUS(DT_NODELABEL(pmic_i2c), nxp_lpc_i2c, okay)
+	CLOCK_AttachClk(kFRO_DIV4_to_FLEXCOMM15);
+#endif
 	/* Switch CLKOUT to FRO_DIV2 */
 	CLOCK_AttachClk(kFRO_DIV2_to_CLKOUT);
 


### PR DESCRIPTION
Enabled the PMIC peripheral for MIMXRT595 board. 
This Peripheral is controlled via PCA9420 chip found 
on the board.