### PR TITLE
dts: bindings: serial: Add common bindings for STM32 serial driver.

### DIFF
--- a/dts/bindings/serial/st,stm32-lpuart.yaml
+++ b/dts/bindings/serial/st,stm32-lpuart.yaml
@@ -2,34 +2,4 @@ description: STM32 LPUART
 
 compatible: "st,stm32-lpuart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
-
-properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    clocks:
-      required: true
-
-    tx-invert:
-      type: boolean
-      required: false
-      description: |
-        Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
-        we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-    rx-invert:
-      type: boolean
-      required: false
-      description: |
-        Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
-        we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-    pinctrl-0:
-      required: true
-
-    pinctrl-names:
-      required: true
+include: st,stm32-uart-base.yaml

--- a/dts/bindings/serial/st,stm32-uart-base.yaml
+++ b/dts/bindings/serial/st,stm32-uart-base.yaml
@@ -1,0 +1,48 @@
+# Copyright (c) 2020 STMICROELECTRONICS
+# SPDX-License-Identifier: Apache-2.0
+
+# Common fields for STM32 UART peripherals.
+description: STM32 UART-BASE
+
+compatible: "st,stm32-uart-base"
+
+include: [uart-controller.yaml, pinctrl-device.yaml]
+
+properties:
+    reg:
+      required: true
+
+    clocks:
+      required: true
+
+    interrupts:
+      required: true
+
+    single-wire:
+      type: boolean
+      required: false
+      description: |
+        Enable the single wire half-duplex communication.
+        Using this mode, TX and RX lines are internally connected and
+        only TX pin is used afterwards and should be configured.
+        RX/TX conflicts must be handled on user side.
+
+    tx-invert:
+      type: boolean
+      required: false
+      description: |
+        Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
+        we use 1=Low, 0=High instead of 1=High, 0=Low.
+
+    rx-invert:
+      type: boolean
+      required: false
+      description: |
+        Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
+        we use 1=Low, 0=High instead of 1=High, 0=Low.
+
+    pinctrl-0:
+      required: true
+
+    pinctrl-names:
+      required: true

--- a/dts/bindings/serial/st,stm32-uart.yaml
+++ b/dts/bindings/serial/st,stm32-uart.yaml
@@ -2,40 +2,4 @@ description: STM32 UART
 
 compatible: "st,stm32-uart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
-
-properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    single-wire:
-      type: boolean
-      required: false
-      description: |
-        Enable the single wire half-duplex communication.
-        Using this mode, TX and RX lines are internally connected and
-        only TX pin is used afterwards and should be configured.
-        RX/TX conflicts must be handled on user side.
-
-    tx-invert:
-      type: boolean
-      required: false
-      description: |
-        Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
-        we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-    rx-invert:
-      type: boolean
-      required: false
-      description: |
-        Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
-        we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-    pinctrl-0:
-      required: true
-
-    pinctrl-names:
-      required: true
+include: st,stm32-uart-base.yaml

--- a/dts/bindings/serial/st,stm32-usart.yaml
+++ b/dts/bindings/serial/st,stm32-usart.yaml
@@ -2,46 +2,4 @@ description: STM32 USART
 
 compatible: "st,stm32-usart"
 
-include: [uart-controller.yaml, pinctrl-device.yaml]
-
-properties:
-    reg:
-      required: true
-
-    interrupts:
-      required: true
-
-    single-wire:
-      type: boolean
-      required: false
-      description: |
-        Enable the single wire half-duplex communication.
-        Using this mode, TX and RX lines are internally connected and
-        only TX pin is used afterwards and should be configured.
-        RX/TX conflicts must be handled on user side.
-
-    tx-rx-swap:
-      type: boolean
-      required: false
-      description: |
-        Swap the TX and RX pins. Used in case of a cross-wired connection.
-
-    tx-invert:
-      type: boolean
-      required: false
-      description: |
-        Invert the binary logic of tx pin. When enabled, physical logic levels are inverted and
-        we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-    rx-invert:
-      type: boolean
-      required: false
-      description: |
-        Invert the binary logic of rx pin. When enabled, physical logic levels are inverted and
-        we use 1=Low, 0=High instead of 1=High, 0=Low.
-
-    pinctrl-0:
-      required: true
-
-    pinctrl-names:
-      required: true
+include: st,stm32-uart-base.yaml


### PR DESCRIPTION
There are 3 bindings for STM32 serial driver:
st,stm32-uart.yaml
st,stm32-usart.yaml
st,stm32-lpuart.yaml
Add a common st,stm32-uart-base.yaml that would be included by these
3 bindings an would group common properties.


Signed-off-by: TLIG Dhaou <dhaou.tlig-ext@st.com>