### PR TITLE
dts: Standardize string token names for arrays

### DIFF
--- a/scripts/dts/gen_defines.py
+++ b/scripts/dts/gen_defines.py
@@ -623,8 +623,6 @@ def write_vanilla_props(node):
                 if isinstance(subval, str):
                     macro2val[macro + f"_IDX_{i}"] = quote_str(subval)
                     subval_as_token = edtlib.str_as_token(subval)
-                    macro2val[macro + f"_IDX_{i}_TOKEN"] = subval_as_token
-                    macro2val[macro + f"_IDX_{i}_UPPER_TOKEN"] = subval_as_token.upper()
                     macro2val[macro + f"_IDX_{i}_STRING_TOKEN"] = subval_as_token
                     macro2val[macro + f"_IDX_{i}_STRING_UPPER_TOKEN"] = subval_as_token.upper()
                 else:

--- a/soc/arm/xilinx_zynq7000/common/pinctrl_soc.h
+++ b/soc/arm/xilinx_zynq7000/common/pinctrl_soc.h
@@ -380,7 +380,7 @@ typedef struct {
 #define Z_PINCTRL_STATE_PIN_CHILD_GROUP_INIT(node_id, prop, idx)	\
 	FOR_EACH_FIXED_ARG(Z_PINCTRL_STATE_PIN_CHILD_GROUP_PIN_INIT, (), node_id, \
 		UTIL_CAT(UTIL_CAT(MIO_GROUP_,				\
-				  DT_CAT6(node_id, _P_, prop, _IDX_, idx, _UPPER_TOKEN)), _PINS))
+				  DT_STRING_UPPER_TOKEN_BY_IDX(node_id, prop, idx)), _PINS))
 
 /* Reverse order of arguments to adapt between FOR_EACH_FIXED_ARG() and DT_FOREACH_PROP_ELEM() */
 #define Z_PINCTRL_STATE_PIN_CHILD_GROUP_PIN_INIT(pin, node_id)		\
@@ -388,7 +388,7 @@ typedef struct {
 
 /* Process pin using MIOx macros defines above */
 #define Z_PINCTRL_STATE_PIN_CHILD_PIN_INIT(node_id, prop, idx)		\
-	Z_PINCTRL_STATE_PIN_INIT(node_id, DT_CAT6(node_id, _P_, prop, _IDX_, idx, _UPPER_TOKEN))
+	Z_PINCTRL_STATE_PIN_INIT(node_id, DT_STRING_UPPER_TOKEN_BY_IDX(node_id, prop, idx))
 
 /* Process pin functions and special functions (CD, WP) */
 #define Z_PINCTRL_STATE_PIN_INIT(node_id, pin)				\


### PR DESCRIPTION
Use the same postfixes for string arrays as we use for strings:

	_TOKEN -> _STRING_TOKEN
	_UPPER_TOKEN -> _STRING_UPPER_TOKEN

Signed-off-by: Kumar Gala <galak@kernel.org>