### PR TITLE
soc: xtensa: split the cavs server and the FW loader

### DIFF
--- a/boards/xtensa/intel_adsp_cavs15/doc/index.rst
+++ b/boards/xtensa/intel_adsp_cavs15/doc/index.rst
@@ -77,6 +77,7 @@ ip address), and the user account is ``user``. Then copy the python tool to the
 ``up_squared`` board from your build environment::
 
    $ scp boards/xtensa/intel_adsp/tools/cavstool.py user@cavs15:
+   $ scp boards/xtensa/intel_adsp/tools/remote-fw-service.py user@cavs15:
 
 
 Note that the ``/dev/hda`` device file created by the diagnostic driver must
@@ -85,7 +86,7 @@ loader script as root:
 
 .. code-block:: console
 
-   cavs15$ sudo ./cavstool.py
+   cavs15$ sudo ./remote-fw-service.py
 
 Cavstool_server.py is a daemon which accepts a firmware image from a remote host
 and loads it into the ADSP. After successful firmware download, the daemon also

--- a/boards/xtensa/intel_adsp_cavs18/doc/generic_intel_adsp.rst
+++ b/boards/xtensa/intel_adsp_cavs18/doc/generic_intel_adsp.rst
@@ -17,8 +17,20 @@ This documentation describes how to run the intel_adsp_cavs boards. Including:
 Set up the environment
 **********************
 
-1. Copy soc/xtensa/intel_adsp/tools/cavstool.py to the target
-   host machine (DUT).
+1. Copy following two tools to the $HOME directory of the target machine (DUT):
+
+- soc/xtensa/intel_adsp/tools/cavstool.py
+   (The firmware loader)
+
+- soc/xtensa/intel_adsp/tools/remote-fw-service.py
+   (The remote service provider)
+
+   You can use scp command to copy them to DUT, Ex.
+
+.. code-block:: console
+
+   $scp boards/xtensa/intel_adsp/tools/cavstool.py user@myboard:~
+   $scp boards/xtensa/intel_adsp/tools/remote-fw-service.py user@myboard:~
 
 2. In your build machine, install the rimage tool, the signed key and
    the toml config file. Please refer to please refer:
@@ -55,7 +67,7 @@ Build and run the tests
 
 .. code-block:: console
 
-   sudo ./cavstool.py
+   sudo ./remote-fw-service.py
 
 2. Build the application. Take hello world as an example:
 
@@ -104,22 +116,22 @@ using, you can do it with following parameters:
 .. code-block:: console
 
    # with specifying the port
-   sudo ./cavstool.py --log-port 54321 --req-port 12345
+   sudo ./remote-fw-service.py --log-port 54321 --req-port 12345
 
    # can be simplified with
-   sudo ./cavstool.py -p 54321 -r 12345
+   sudo ./remote-fw-service -p 54321 -r 12345
 
    # with specifying a IP address
-   sudo ./cavstool.py -s 192.168.0.2
+   sudo ./remote-fw-service -s 192.168.0.2
 
    # with specifying the IP address with a log port
-   sudo ./cavstool.py -s 192.168.0.2:54321
+   sudo ./remote-fw-service -s 192.168.0.2:54321
 
    # with specifying the IP, log and request port
-   sudo ./cavstool.py -s 192.168.0.2:54321 -r 12345
+   sudo ./remote-fw-service -s 192.168.0.2:54321 -r 12345
 
    # Also works in this way
-   sudo ./cavstool.py -s 192.168.0.2 -p 54321 -r 12345
+   sudo ./remote-fw-service -s 192.168.0.2 -p 54321 -r 12345
 
 
 Run by twister
@@ -189,10 +201,10 @@ like following example. Assume you have a log port of 54321 and a req port
      platform: intel_adsp_cavs25
      product: None
      runner: intel_adsp
-     serial_pty: "/home/user/zephyrproject/zephyr/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.4,--port-log,54321,-l"
+     serial_pty: "/home/user/zephyrproject/zephyr/soc/xtensa/intel_adsp/tools/cavstool_client.py,-s,192.168.1.4,--log-port,54321,-l"
      runner_params:
        - --remote-host=192.168.1.4
-       - --tool-opt=--port-req
+       - --tool-opt=--req-port
        - --tool-opt=12345
 
 

--- a/soc/xtensa/intel_adsp/tools/cavstool_client.py
+++ b/soc/xtensa/intel_adsp/tools/cavstool_client.py
@@ -98,9 +98,10 @@ class cavstool_client():
         log.info(f"Start to monitor log output...")
         while True:
             # Receive data from the server and print out
-            receive_log = str(self.sock.recv(BUF_SIZE).strip(), "utf-8")
+            receive_log = str(self.sock.recv(BUF_SIZE), "utf-8").replace('\x00','')
             if receive_log:
-                print(f"{receive_log}")
+                sys.stdout.write(f"{receive_log}")
+                sys.stdout.flush()
                 time.sleep(0.1)
 
     def __del__(self):

--- a/soc/xtensa/intel_adsp/tools/remote-fw-service.py
+++ b/soc/xtensa/intel_adsp/tools/remote-fw-service.py
@@ -171,7 +171,7 @@ class adsp_log_handler(socketserver.BaseRequestHandler):
 
     def is_connection_alive(self):
         try:
-            self.request.sendall(b' ')
+            self.request.sendall(b'\x00')
         except (BrokenPipeError, ConnectionResetError):
             log.info("Client is disconnect.")
             return False

--- a/soc/xtensa/intel_adsp/tools/remote-fw-service.py
+++ b/soc/xtensa/intel_adsp/tools/remote-fw-service.py
@@ -1,0 +1,925 @@
+#!/usr/bin/env python3
+# Copyright(c) 2022 Intel Corporation. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+import os
+import sys
+import struct
+import logging
+import asyncio
+import time
+import subprocess
+import ctypes
+import mmap
+import argparse
+import socketserver
+import threading
+import hashlib
+from urllib.parse import urlparse
+
+# Global variable use to sync between log and request services.
+# When it is true, the adsp is able to start running.
+start_output = False
+lock = threading.Lock()
+
+# INADDR_ANY as default
+HOST = ''
+PORT_LOG = 9999
+PORT_REQ = PORT_LOG + 1
+BUF_SIZE = 4096
+
+# Define the command and the max size
+CMD_LOG_START = "start_log"
+CMD_DOWNLOAD = "download"
+MAX_CMD_SZ = 16
+
+# Define the header format and size for
+# transmiting the firmware
+PACKET_HEADER_FORMAT_FW = 'I 42s 32s'
+HEADER_SZ = 78
+
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("cavs-fw")
+
+PAGESZ = 4096
+HUGEPAGESZ = 2 * 1024 * 1024
+HUGEPAGE_FILE = "/dev/hugepages/cavs-fw-dma.tmp."
+
+# SRAM windows.  Each appears in a 128k region starting at 512k.
+#
+# Window 0 is the FW_STATUS area, and 4k after that the IPC "outbox"
+# Window 1 is the IPC "inbox" (host-writable memory, just 384 bytes currently)
+# Window 2 is unused by this script
+# Window 3 is winstream-formatted log output
+OUTBOX_OFFSET    = (512 + (0 * 128)) * 1024 + 4096
+INBOX_OFFSET     = (512 + (1 * 128)) * 1024
+WINSTREAM_OFFSET = (512 + (3 * 128)) * 1024
+
+# ADSPCS bits
+CRST   = 0
+CSTALL = 8
+SPA    = 16
+CPA    = 24
+
+class HDAStream:
+    # creates an hda stream with at 2 buffers of buf_len
+    def __init__(self, stream_id: int):
+        self.stream_id = stream_id
+        self.base = hdamem + 0x0080 + (stream_id * 0x20)
+        log.info(f"Mapping registers for hda stream {self.stream_id} at base {self.base:x}")
+
+        self.hda = Regs(hdamem)
+        self.hda.GCAP    = 0x0000
+        self.hda.GCTL    = 0x0008
+        self.hda.DPLBASE = 0x0070
+        self.hda.DPUBASE = 0x0074
+        self.hda.SPBFCH  = 0x0700
+        self.hda.SPBFCTL = 0x0704
+        self.hda.PPCH    = 0x0800
+        self.hda.PPCTL   = 0x0804
+        self.hda.PPSTS   = 0x0808
+        self.hda.SPIB = 0x0708 + stream_id*0x08
+        self.hda.freeze()
+
+        self.regs = Regs(self.base)
+        self.regs.CTL  = 0x00
+        self.regs.STS  = 0x03
+        self.regs.LPIB = 0x04
+        self.regs.CBL  = 0x08
+        self.regs.LVI  = 0x0c
+        self.regs.FIFOW = 0x0e
+        self.regs.FIFOS = 0x10
+        self.regs.FMT = 0x12
+        self.regs.FIFOL= 0x14
+        self.regs.BDPL = 0x18
+        self.regs.BDPU = 0x1c
+        self.regs.freeze()
+
+        self.dbg0 = Regs(hdamem + 0x0084 + (0x20*stream_id))
+        self.dbg0.DPIB = 0x00
+        self.dbg0.EFIFOS = 0x10
+        self.dbg0.freeze()
+
+        self.reset()
+
+    def __del__(self):
+        self.reset()
+
+    def config(self, buf_len: int):
+        log.info(f"Configuring stream {self.stream_id}")
+        self.buf_len = buf_len
+        log.info("Allocating huge page and setting up buffers")
+        self.mem, self.hugef, self.buf_list_addr, self.pos_buf_addr, self.n_bufs = self.setup_buf(buf_len)
+
+        log.info("Setting buffer list, length, and stream id and traffic priority bit")
+        self.regs.CTL = ((self.stream_id & 0xFF) << 20) | (1 << 18) # must be set to something other than 0?
+        self.regs.BDPU = (self.buf_list_addr >> 32) & 0xffffffff
+        self.regs.BDPL = self.buf_list_addr & 0xffffffff
+        self.regs.CBL = buf_len
+        self.regs.LVI = self.n_bufs - 1
+        self.mem.seek(0)
+        self.debug()
+        log.info(f"Configured stream {self.stream_id}")
+
+    def write(self, data):
+
+        bufl = min(len(data), self.buf_len)
+        log.info(f"Writing data to stream {self.stream_id}, len {bufl}, SPBFCTL {self.hda.SPBFCTL:x}, SPIB {self.hda.SPIB}")
+        self.mem[0:bufl] = data[0:bufl]
+        self.mem[bufl:bufl+bufl] = data[0:bufl]
+        self.hda.SPBFCTL |= (1 << self.stream_id)
+        self.hda.SPIB += bufl
+        log.info(f"Wrote data to stream {self.stream_id}, SPBFCTL {self.hda.SPBFCTL:x}, SPIB {self.hda.SPIB}")
+
+    def start(self):
+        log.info(f"Starting stream {self.stream_id}, CTL {self.regs.CTL:x}")
+        self.regs.CTL |= 2
+        log.info(f"Started stream {self.stream_id}, CTL {self.regs.CTL:x}")
+
+    def stop(self):
+        log.info(f"Stopping stream {self.stream_id}, CTL {self.regs.CTL:x}")
+        self.regs.CTL &= 2
+        time.sleep(0.1)
+        self.regs.CTL |= 1
+        log.info(f"Stopped stream {self.stream_id}, CTL {self.regs.CTL:x}")
+
+    def setup_buf(self, buf_len: int):
+        (mem, phys_addr, hugef) = map_phys_mem(self.stream_id)
+
+        log.info(f"Mapped 2M huge page at 0x{phys_addr:x} for buf size ({buf_len})")
+
+        # create two buffers in the page of buf_len and mark them
+        # in a buffer descriptor list for the hardware to use
+        buf0_len = buf_len
+        buf1_len = buf_len
+        bdl_off = buf0_len + buf1_len
+        # bdl is 2 (64bits, 16 bytes) per entry, we have two
+        mem[bdl_off:bdl_off + 32] = struct.pack("<QQQQ",
+                                                phys_addr,
+                                                buf0_len,
+                                                phys_addr + buf0_len,
+                                                buf1_len)
+        dpib_off = bdl_off+32
+
+        # ensure buffer is initialized, sanity
+        for i in range(0, buf_len*2):
+            mem[i] = 0
+
+        log.info("Filled the buffer descriptor list (BDL) for DMA.")
+        return (mem, hugef, phys_addr + bdl_off, phys_addr+dpib_off, 2)
+
+    def debug(self):
+        log.debug("HDA %d: PPROC %d, CTL 0x%x, LPIB 0x%x, BDPU 0x%x, BDPL 0x%x, CBL 0x%x, LVI 0x%x",
+                 self.stream_id, (hda.PPCTL >> self.stream_id) & 1, self.regs.CTL, self.regs.LPIB, self.regs.BDPU,
+                 self.regs.BDPL, self.regs.CBL, self.regs.LVI)
+        log.debug("    FIFOW %d, FIFOS %d, FMT %x, FIFOL %d, DPIB %d, EFIFOS %d",
+                 self.regs.FIFOW & 0x7, self.regs.FIFOS, self.regs.FMT, self.regs.FIFOL, self.dbg0.DPIB, self.dbg0.EFIFOS)
+        log.debug("    status: FIFORDY %d, DESE %d, FIFOE %d, BCIS %d",
+                 (self.regs.STS >> 5) & 1, (self.regs.STS >> 4) & 1, (self.regs.STS >> 3) & 1, (self.regs.STS >> 2) & 1)
+
+    def reset(self):
+        # Turn DMA off and reset the stream.  Clearing START first is a
+        # noop per the spec, but absolutely required for stability.
+        # Apparently the reset doesn't stop the stream, and the next load
+        # starts before it's ready and kills the load (and often the DSP).
+        # The sleep too is required, on at least one board (a fast
+        # chromebook) putting the two writes next each other also hangs
+        # the DSP!
+        log.info(f"Resetting stream {self.stream_id}")
+        self.debug()
+        self.regs.CTL &= ~2 # clear START
+        time.sleep(0.1)
+        # set enter reset bit
+        self.regs.CTL = 1
+        while (self.regs.CTL & 1) == 0: pass
+        # clear enter reset bit to exit reset
+        self.regs.CTL = 0
+        while (self.regs.CTL & 1) == 1: pass
+
+        log.info(f"Disable SPIB and set position 0 of stream {self.stream_id}")
+        self.hda.SPBFCTL = 0
+        self.hda.SPIB = 0
+
+        #log.info("Setting dma position buffer and enable it")
+        #self.hda.DPUBASE = self.pos_buf_addr >> 32 & 0xffffffff
+        #self.hda.DPLBASE = self.pos_buf_addr & 0xfffffff0 | 1
+
+        log.info(f"Enabling dsp capture (PROCEN) of stream {self.stream_id}")
+        self.hda.PPCTL |= (1 << self.stream_id)
+
+        self.debug()
+        log.info(f"Reset stream {self.stream_id}")
+
+
+def map_regs():
+    p = runx(f"grep -iEl 'PCI_CLASS=40(10|38)0' /sys/bus/pci/devices/*/uevent")
+    pcidir = os.path.dirname(p)
+
+    # Platform/quirk detection.  ID lists cribbed from the SOF kernel driver
+    global cavs15, cavs18, cavs25
+    did = int(open(f"{pcidir}/device").read().rstrip(), 16)
+    cavs15 = did in [ 0x5a98, 0x1a98, 0x3198 ]
+    cavs18 = did in [ 0x9dc8, 0xa348, 0x02c8, 0x06c8, 0xa3f0 ]
+    cavs25 = did in [ 0xa0c8, 0x43c8, 0x4b55, 0x4b58, 0x7ad0, 0x51c8 ]
+
+    # Check sysfs for a loaded driver and remove it
+    if os.path.exists(f"{pcidir}/driver"):
+        mod = os.path.basename(os.readlink(f"{pcidir}/driver/module"))
+        found_msg = f"Existing driver \"{mod}\" found"
+        if args.log_only:
+            log.info(found_msg)
+        else:
+            log.warning(found_msg + ", unloading module")
+            runx(f"rmmod -f {mod}")
+            # Disengage runtime power management so the kernel doesn't put it to sleep
+            log.info(f"Forcing {pcidir}/power/control to always 'on'")
+            with open(f"{pcidir}/power/control", "w") as ctrl:
+                ctrl.write("on")
+
+    # Make sure PCI memory space access and busmastering are enabled.
+    # Also disable interrupts so as not to confuse the kernel.
+    with open(f"{pcidir}/config", "wb+") as cfg:
+        cfg.seek(4)
+        cfg.write(b'\x06\x04')
+
+    # Standard HD Audio Registers
+    global hdamem
+    (hdamem, _) = bar_map(pcidir, 0)
+    hda = Regs(hdamem)
+    hda.GCAP    = 0x0000
+    hda.GCTL    = 0x0008
+    hda.SPBFCTL = 0x0704
+    hda.PPCTL   = 0x0804
+
+    # Find the ID of the first output stream
+    hda_ostream_id = (hda.GCAP >> 8) & 0x0f # number of input streams
+    log.info(f"Selected output stream {hda_ostream_id} (GCAP = 0x{hda.GCAP:x})")
+    hda.SD_SPIB = 0x0708 + (8 * hda_ostream_id)
+    hda.freeze()
+
+
+    # Standard HD Audio Stream Descriptor
+    sd = Regs(hdamem + 0x0080 + (hda_ostream_id * 0x20))
+    sd.CTL  = 0x00
+    sd.CBL  = 0x08
+    sd.LVI  = 0x0c
+    sd.BDPL = 0x18
+    sd.BDPU = 0x1c
+    sd.freeze()
+
+    # Intel Audio DSP Registers
+    global bar4_mmap
+    (bar4_mem, bar4_mmap) = bar_map(pcidir, 4)
+    dsp = Regs(bar4_mem)
+    dsp.ADSPCS         = 0x00004
+    dsp.HIPCTDR        = 0x00040 if cavs15 else 0x000c0
+    dsp.HIPCTDA        =                        0x000c4 # 1.8+ only
+    dsp.HIPCTDD        = 0x00044 if cavs15 else 0x000c8
+    dsp.HIPCIDR        = 0x00048 if cavs15 else 0x000d0
+    dsp.HIPCIDA        =                        0x000d4 # 1.8+ only
+    dsp.HIPCIDD        = 0x0004c if cavs15 else 0x000d8
+    dsp.SRAM_FW_STATUS = 0x80000 # Start of first SRAM window
+    dsp.freeze()
+
+    return (hda, sd, dsp, hda_ostream_id)
+
+def setup_dma_mem(fw_bytes):
+    (mem, phys_addr, _) = map_phys_mem(hda_ostream_id)
+    mem[0:len(fw_bytes)] = fw_bytes
+
+    log.info("Mapped 2M huge page at 0x%x to contain %d bytes of firmware"
+          % (phys_addr, len(fw_bytes)))
+
+    # HDA requires at least two buffers be defined, but we don't care about
+    # boundaries because it's all a contiguous region. Place a vestigial
+    # 128-byte (minimum size and alignment) buffer after the main one, and put
+    # the 4-entry BDL list into the final 128 bytes of the page.
+    buf0_len = HUGEPAGESZ - 2 * 128
+    buf1_len = 128
+    bdl_off = buf0_len + buf1_len
+    mem[bdl_off:bdl_off + 32] = struct.pack("<QQQQ",
+                                            phys_addr, buf0_len,
+                                            phys_addr + buf0_len, buf1_len)
+    log.info("Filled the buffer descriptor list (BDL) for DMA.")
+    return (phys_addr + bdl_off, 2)
+
+global_mmaps = [] # protect mmap mappings from garbage collection!
+
+# Maps 2M of contiguous memory using a single page from hugetlbfs,
+# then locates its physical address for use as a DMA buffer.
+def map_phys_mem(stream_id):
+    # Make sure hugetlbfs is mounted (not there on chromeos)
+    os.system("mount | grep -q hugetlbfs ||"
+              + " (mkdir -p /dev/hugepages; "
+              + "  mount -t hugetlbfs hugetlbfs /dev/hugepages)")
+
+    # Ensure the kernel has enough budget for one new page
+    free = int(runx("awk '/HugePages_Free/ {print $2}' /proc/meminfo"))
+    if free == 0:
+        tot = 1 + int(runx("awk '/HugePages_Total/ {print $2}' /proc/meminfo"))
+        os.system(f"echo {tot} > /proc/sys/vm/nr_hugepages")
+
+    hugef_name = HUGEPAGE_FILE + str(stream_id)
+    hugef = open(hugef_name, "w+")
+    hugef.truncate(HUGEPAGESZ)
+    mem = mmap.mmap(hugef.fileno(), HUGEPAGESZ)
+    log.info("type of mem is %s", str(type(mem)))
+    global_mmaps.append(mem)
+    os.unlink(hugef_name)
+
+    # Find the local process address of the mapping, then use that to extract
+    # the physical address from the kernel's pagemap interface.  The physical
+    # page frame number occupies the bottom bits of the entry.
+    mem[0] = 0 # Fault the page in so it has an address!
+    vaddr = ctypes.addressof(ctypes.c_int.from_buffer(mem))
+    vpagenum = vaddr >> 12
+    pagemap = open("/proc/self/pagemap", "rb")
+    pagemap.seek(vpagenum * 8)
+    pent = pagemap.read(8)
+    paddr = (struct.unpack("Q", pent)[0] & ((1 << 55) - 1)) * PAGESZ
+    pagemap.close()
+    return (mem, paddr, hugef)
+
+# Maps a PCI BAR and returns the in-process address
+def bar_map(pcidir, barnum):
+    f = open(pcidir + "/resource" + str(barnum), "r+")
+    mm = mmap.mmap(f.fileno(), os.fstat(f.fileno()).st_size)
+    global_mmaps.append(mm)
+    log.info("Mapped PCI bar %d of length %d bytes."
+             % (barnum, os.fstat(f.fileno()).st_size))
+    return (ctypes.addressof(ctypes.c_int.from_buffer(mm)), mm)
+
+# Syntactic sugar to make register block definition & use look nice.
+# Instantiate from a base address, assign offsets to (uint32) named registers as
+# fields, call freeze(), then the field acts as a direct alias for the register!
+class Regs:
+    def __init__(self, base_addr):
+        vars(self)["base_addr"] = base_addr
+        vars(self)["ptrs"] = {}
+        vars(self)["frozen"] = False
+    def freeze(self):
+        vars(self)["frozen"] = True
+    def __setattr__(self, name, val):
+        if not self.frozen and name not in self.ptrs:
+            addr = self.base_addr + val
+            self.ptrs[name] = ctypes.c_uint32.from_address(addr)
+        else:
+            self.ptrs[name].value = val
+    def __getattr__(self, name):
+        return self.ptrs[name].value
+
+def runx(cmd):
+    return subprocess.check_output(cmd, shell=True).decode().rstrip()
+
+def mask(bit):
+    if cavs25:
+        return 0b1 << bit
+    if cavs18:
+        return 0b1111 << bit
+    if cavs15:
+        return 0b11 << bit
+
+def load_firmware(fw_file):
+    try:
+        fw_bytes = open(fw_file, "rb").read()
+    except Exception as e:
+        log.error(f"Could not read firmware file: `{fw_file}'")
+        log.error(e)
+        sys.exit(1)
+
+    (magic, sz) = struct.unpack("4sI", fw_bytes[0:8])
+    if magic == b'XMan':
+        log.info(f"Trimming {sz} bytes of extended manifest")
+        fw_bytes = fw_bytes[sz:len(fw_bytes)]
+
+    # This actually means "enable access to BAR4 registers"!
+    hda.PPCTL |= (1 << 30) # GPROCEN, "global processing enable"
+
+    log.info("Resetting HDA device")
+    hda.GCTL = 0
+    while hda.GCTL & 1: pass
+    hda.GCTL = 1
+    while not hda.GCTL & 1: pass
+
+    log.info(f"Stalling and Resetting DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
+    dsp.ADSPCS |= mask(CSTALL)
+    dsp.ADSPCS |= mask(CRST)
+    while (dsp.ADSPCS & mask(CRST)) == 0: pass
+
+    log.info(f"Powering down DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
+    dsp.ADSPCS &= ~mask(SPA)
+    while dsp.ADSPCS & mask(CPA): pass
+
+    log.info(f"Configuring HDA stream {hda_ostream_id} to transfer firmware image")
+    (buf_list_addr, num_bufs) = setup_dma_mem(fw_bytes)
+    sd.CTL = 1
+    while (sd.CTL & 1) == 0: pass
+    sd.CTL = 0
+    while (sd.CTL & 1) == 1: pass
+    sd.CTL = (1 << 20) # Set stream ID to anything non-zero
+    sd.BDPU = (buf_list_addr >> 32) & 0xffffffff
+    sd.BDPL = buf_list_addr & 0xffffffff
+    sd.CBL = len(fw_bytes)
+    sd.LVI = num_bufs - 1
+    hda.PPCTL |= (1 << hda_ostream_id)
+
+    # SPIB ("Software Position In Buffer") is an Intel HDA extension
+    # that puts a transfer boundary into the stream beyond which the
+    # other side will not read.  The ROM wants to poll on a "buffer
+    # full" bit on the other side that only works with this enabled.
+    hda.SPBFCTL |= (1 << hda_ostream_id)
+    hda.SD_SPIB = len(fw_bytes)
+
+    # Start DSP.  Host needs to provide power to all cores on 1.5
+    # (which also starts them) and 1.8 (merely gates power, DSP also
+    # has to set PWRCTL). On 2.5 where the DSP has full control,
+    # and only core 0 is set.
+    log.info(f"Starting DSP, ADSPCS = 0x{dsp.ADSPCS:x}")
+    dsp.ADSPCS = mask(SPA)
+    while (dsp.ADSPCS & mask(CPA)) == 0: pass
+
+    log.info(f"Unresetting DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
+    dsp.ADSPCS &= ~mask(CRST)
+    while (dsp.ADSPCS & 1) != 0: pass
+
+    log.info(f"Running DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
+    dsp.ADSPCS &= ~mask(CSTALL)
+
+    # Wait for the ROM to boot and signal it's ready.  This not so short
+    # sleep seems to be needed; if we're banging on the memory window
+    # during initial boot (before/while the window control registers
+    # are configured?) the DSP hardware will hang fairly reliably.
+    log.info(f"Wait for ROM startup, ADSPCS = 0x{dsp.ADSPCS:x}")
+    time.sleep(1)
+    while (dsp.SRAM_FW_STATUS >> 24) != 5: pass
+
+    # Send the DSP an IPC message to tell the device how to boot.
+    # Note: with cAVS 1.8+ the ROM receives the stream argument as an
+    # index within the array of output streams (and we always use the
+    # first one by construction).  But with 1.5 it's the HDA index,
+    # and depends on the number of input streams on the device.
+    stream_idx = hda_ostream_id if cavs15 else 0
+    ipcval = (  (1 << 31)            # BUSY bit
+                | (0x01 << 24)       # type = PURGE_FW
+                | (1 << 14)          # purge_fw = 1
+                | (stream_idx << 9)) # dma_id
+    log.info(f"Sending IPC command, HIPIDR = 0x{ipcval:x}")
+    dsp.HIPCIDR = ipcval
+
+    log.info(f"Starting DMA, FW_STATUS = 0x{dsp.SRAM_FW_STATUS:x}")
+    sd.CTL |= 2 # START flag
+
+    wait_fw_entered()
+
+    # Turn DMA off and reset the stream.  Clearing START first is a
+    # noop per the spec, but absolutely required for stability.
+    # Apparently the reset doesn't stop the stream, and the next load
+    # starts before it's ready and kills the load (and often the DSP).
+    # The sleep too is required, on at least one board (a fast
+    # chromebook) putting the two writes next each other also hangs
+    # the DSP!
+    sd.CTL &= ~2 # clear START
+    time.sleep(0.1)
+    sd.CTL |= 1
+    log.info(f"cAVS firmware load complete")
+
+def fw_is_alive():
+    return dsp.SRAM_FW_STATUS & ((1 << 28) - 1) == 5 # "FW_ENTERED"
+
+def wait_fw_entered(timeout_s=2):
+    log.info("Waiting %s for firmware handoff, FW_STATUS = 0x%x",
+             "forever" if timeout_s is None else f"{timeout_s} seconds",
+             dsp.SRAM_FW_STATUS)
+    hertz = 100
+    attempts = None if timeout_s is None else timeout_s * hertz
+    while True:
+        alive = fw_is_alive()
+        if alive:
+            break
+        if attempts is not None:
+            attempts -= 1
+            if attempts < 0:
+                break
+        time.sleep(1 / hertz)
+
+    if not alive:
+        log.warning("Load failed?  FW_STATUS = 0x%x", dsp.SRAM_FW_STATUS)
+    else:
+        log.info("FW alive, FW_STATUS = 0x%x", dsp.SRAM_FW_STATUS)
+
+
+# This SHOULD be just "mem[start:start+length]", but slicing an mmap
+# array seems to be unreliable on one of my machines (python 3.6.9 on
+# Ubuntu 18.04).  Read out bytes individually.
+def win_read(start, length):
+    try:
+        return b''.join(bar4_mmap[WINSTREAM_OFFSET + x].to_bytes(1, 'little')
+                        for x in range(start, start + length))
+    except IndexError as ie:
+        # A FW in a bad state may cause winstream garbage
+        log.error("IndexError in bar4_mmap[%d + %d]", WINSTREAM_OFFSET, start)
+        log.error("bar4_mmap.size()=%d", bar4_mmap.size())
+        raise ie
+
+def win_hdr():
+    return struct.unpack("<IIII", win_read(0, 16))
+
+# Python implementation of the same algorithm in sys_winstream_read(),
+# see there for details.
+def winstream_read(last_seq):
+    while True:
+        (wlen, start, end, seq) = win_hdr()
+        if last_seq == 0:
+            last_seq = seq if args.no_history else (seq - ((end - start) % wlen))
+        if seq == last_seq or start == end:
+            return (seq, "")
+        behind = seq - last_seq
+        if behind > ((end - start) % wlen):
+            return (seq, "")
+        copy = (end - behind) % wlen
+        suffix = min(behind, wlen - copy)
+        result = win_read(16 + copy, suffix)
+        if suffix < behind:
+            result += win_read(16, behind - suffix)
+        (wlen, start1, end, seq1) = win_hdr()
+        if start1 == start and seq1 == seq:
+            # Best effort attempt at decoding, replacing unusable characters
+            # Found to be useful when it really goes wrong
+            return (seq, result.decode("utf-8", "replace"))
+
+
+async def ipc_delay_done():
+    await asyncio.sleep(0.1)
+    dsp.HIPCTDA = 1<<31
+
+ipc_timestamp = 0
+
+# Super-simple command language, driven by the test code on the DSP
+def ipc_command(data, ext_data):
+    send_msg = False
+    done = True
+    log.debug ("ipc data %d, ext_data %x", data, ext_data)
+    if data == 0: # noop, with synchronous DONE
+        pass
+    elif data == 1: # async command: signal DONE after a delay (on 1.8+)
+        if not cavs15:
+            done = False
+            asyncio.ensure_future(ipc_delay_done())
+    elif data == 2: # echo back ext_data as a message command
+        send_msg = True
+    elif data == 3: # set ADSPCS
+        dsp.ADSPCS = ext_data
+    elif data == 4: # echo back microseconds since last timestamp command
+        global ipc_timestamp
+        t = round(time.time() * 1e6)
+        ext_data = t - ipc_timestamp
+        ipc_timestamp = t
+        send_msg = True
+    elif data == 5: # copy word at outbox[ext_data >> 16] to inbox[ext_data & 0xffff]
+        src = OUTBOX_OFFSET + 4 * (ext_data >> 16)
+        dst =  INBOX_OFFSET + 4 * (ext_data & 0xffff)
+        for i in range(4):
+            bar4_mmap[dst + i] = bar4_mmap[src + i]
+    elif data == 6: # HDA RESET (init if not exists)
+        stream_id = ext_data & 0xff
+        if stream_id in hda_streams:
+            hda_streams[stream_id].reset()
+        else:
+            hda_str = HDAStream(stream_id)
+            hda_streams[stream_id] = hda_str
+    elif data == 7: # HDA CONFIG
+        stream_id = ext_data & 0xFF
+        buf_len = ext_data >> 8 & 0xFFFF
+        hda_str = hda_streams[stream_id]
+        hda_str.config(buf_len)
+    elif data == 8: # HDA START
+        stream_id = ext_data & 0xFF
+        hda_streams[stream_id].start()
+        hda_streams[stream_id].mem.seek(0)
+
+    elif data == 9: # HDA STOP
+        stream_id = ext_data & 0xFF
+        hda_streams[stream_id].stop()
+    elif data == 10: # HDA VALIDATE
+        stream_id = ext_data & 0xFF
+        hda_str = hda_streams[stream_id]
+        hda_str.debug()
+        is_ramp_data = True
+        hda_str.mem.seek(0)
+        for (i, val) in enumerate(hda_str.mem.read(256)):
+            if i != val:
+                is_ramp_data = False
+            # log.info("stream[%d][%d]: %d", stream_id, i, val) # debug helper
+        log.info("Is ramp data? " + str(is_ramp_data))
+        ext_data = int(is_ramp_data)
+        log.info(f"Ext data to send back on ramp status {ext_data}")
+        send_msg = True
+    elif data == 11: # HDA HOST OUT SEND
+        stream_id = ext_data & 0xff
+        buf = bytearray(256)
+        for i in range(0, 256):
+            buf[i] = i
+        hda_streams[stream_id].write(buf)
+    elif data == 12: # HDA PRINT
+        stream_id = ext_data & 0xFF
+        buf_len = ext_data >> 8 & 0xFFFF
+        hda_str = hda_streams[stream_id]
+        # check for wrap here
+        pos = hda_str.mem.tell()
+        read_lens = [buf_len, 0]
+        if pos + buf_len >= hda_str.buf_len*2:
+            read_lens[0] = hda_str.buf_len*2 - pos
+            read_lens[1] = buf_len - read_lens[0]
+        # validate the read lens
+        assert (read_lens[0] + pos) <= (hda_str.buf_len*2)
+        assert read_lens[0] % 128 == 0
+        assert read_lens[1] % 128 == 0
+        buf_data0 = hda_str.mem.read(read_lens[0])
+        hda_msg0 = buf_data0.decode("utf-8", "replace")
+        sys.stdout.write(hda_msg0)
+        if read_lens[1] != 0:
+            hda_str.mem.seek(0)
+            buf_data1 = hda_str.mem.read(read_lens[1])
+            hda_msg1 = buf_data1.decode("utf-8", "replace")
+            sys.stdout.write(hda_msg1)
+        pos = hda_str.mem.tell()
+        sys.stdout.flush()
+    else:
+        log.warning(f"cavstool: Unrecognized IPC command 0x{data:x} ext 0x{ext_data:x}")
+        if not fw_is_alive():
+            if args.log_only:
+                log.info("DSP power seems off")
+                wait_fw_entered(timeout_s=None)
+            else:
+                log.warning("DSP power seems off?!")
+                time.sleep(2) # potential spam reduction
+
+            return
+
+    dsp.HIPCTDR = 1<<31 # Ack local interrupt, also signals DONE on v1.5
+    if cavs18:
+        time.sleep(0.01) # Needed on 1.8, or the command below won't send!
+
+    if done and not cavs15:
+        dsp.HIPCTDA = 1<<31 # Signal done
+    if send_msg:
+        dsp.HIPCIDD = ext_data
+        dsp.HIPCIDR = (1<<31) | ext_data
+
+async def _main(server):
+    #TODO this bit me, remove the globals, write a little FirmwareLoader class or something to contain.
+    global hda, sd, dsp, hda_ostream_id, hda_streams
+    global start_output
+    try:
+        (hda, sd, dsp, hda_ostream_id) = map_regs()
+    except Exception as e:
+        log.error("Could not map device in sysfs; run as root?")
+        log.error(e)
+        sys.exit(1)
+
+    log.info(f"Detected cAVS {'1.5' if cavs15 else '1.8+'} hardware")
+
+    if args.log_only:
+        wait_fw_entered(timeout_s=None)
+    else:
+        if not fw_file:
+            log.error("Firmware file argument missing")
+            sys.exit(1)
+
+        load_firmware(fw_file)
+        time.sleep(0.1)
+        if not args.quiet:
+            adsp_log("--\n", server)
+
+    hda_streams = dict()
+
+    last_seq = 0
+    while start_output is True:
+        await asyncio.sleep(0.03)
+        (last_seq, output) = winstream_read(last_seq)
+        if output:
+            adsp_log(output, server)
+        if dsp.HIPCIDA & 0x80000000:
+            dsp.HIPCIDA = 1<<31 # must ACK any DONE interrupts that arrive!
+        if dsp.HIPCTDR & 0x80000000:
+            ipc_command(dsp.HIPCTDR & ~0x80000000, dsp.HIPCTDD)
+
+        if server:
+            # Check if the client connection is alive.
+            if not is_connection_alive(server):
+                lock.acquire()
+                start_output = False
+                lock.release()
+
+class adsp_request_handler(socketserver.BaseRequestHandler):
+    """
+    The request handler class for control the actions of server.
+    """
+
+    def receive_fw(self):
+        log.info("Receiving...")
+        # Receive the header first
+        d = self.request.recv(HEADER_SZ)
+
+        # Unpacked the header data
+        # Include size(4), filename(42) and MD5(32)
+        header = d[:HEADER_SZ]
+        total = d[HEADER_SZ:]
+        s = struct.Struct(PACKET_HEADER_FORMAT_FW)
+        fsize, fname, md5_tx_b = s.unpack(header)
+        log.info(f'size:{fsize}, filename:{fname}, MD5:{md5_tx_b}')
+
+        # Receive the firmware. We only receive the specified amount of bytes.
+        while len(total) < fsize:
+            data = self.request.recv(min(BUF_SIZE, fsize - len(total)))
+            if not data:
+                raise EOFError("truncated firmware file")
+            total += data
+
+        log.info(f"Done Receiving {len(total)}.")
+
+        try:
+            with open(fname,'wb') as f:
+                f.write(total)
+        except Exception as e:
+            log.error(f"Get exception {e} during FW transfer.")
+            return None
+
+        # Check the MD5 of the firmware
+        md5_rx = hashlib.md5(total).hexdigest()
+        md5_tx = md5_tx_b.decode('utf-8')
+
+        if md5_tx != md5_rx:
+            log.error(f'MD5 mismatch: {md5_tx} vs. {md5_rx}')
+            return None
+
+        return fname
+
+    def handle(self):
+        global start_output, fw_file
+
+        cmd = self.request.recv(MAX_CMD_SZ)
+        log.info(f"{self.client_address[0]} wrote: {cmd}")
+        action = cmd.decode("utf-8")
+        log.debug(f'load {action}')
+
+        if action == CMD_DOWNLOAD:
+            self.request.sendall(cmd)
+            recv_file = self.receive_fw()
+
+            if recv_file:
+                self.request.sendall("success".encode('utf-8'))
+                log.info("Firmware well received. Ready to download.")
+            else:
+                self.request.sendall("failed".encode('utf-8'))
+                log.error("Receive firmware failed.")
+
+            lock.acquire()
+            fw_file = recv_file
+            start_output = True
+            lock.release()
+
+        else:
+            log.error("incorrect load communitcation!")
+
+class adsp_log_handler(socketserver.BaseRequestHandler):
+    """
+    The log handler class for grabbing output messages of server.
+    """
+    def run_adsp(self):
+        self.loop = asyncio.get_event_loop()
+        self.loop.run_until_complete(_main(self))
+
+    def handle(self):
+        cmd = self.request.recv(MAX_CMD_SZ)
+        log.info(f"{self.client_address[0]} wrote: {cmd}")
+        action = cmd.decode("utf-8")
+        log.debug(f'monitor {action}')
+
+        if action == CMD_LOG_START:
+            global start_output, fw_file
+
+            self.request.sendall(cmd)
+
+            log.info(f"Waiting for instruction...")
+            while start_output is False:
+                time.sleep(1)
+                if not is_connection_alive(self):
+                    break
+
+            if fw_file:
+                log.info(f"Loaded FW {fw_file} and running...")
+                if os.path.exists(fw_file):
+                    self.run_adsp()
+                    log.info("service complete.")
+                else:
+                    log.error("Cannot find the FW file.")
+
+            lock.acquire()
+            start_output = False
+            if fw_file:
+                os.remove(fw_file)
+            fw_file = None
+            lock.release()
+
+        else:
+            log.error("incorrect monitor communitcation!")
+
+        log.info("Wait for next service...")
+
+def is_connection_alive(server):
+    try:
+        server.request.sendall(b' ')
+    except (BrokenPipeError, ConnectionResetError):
+        log.info("Client is disconnect.")
+        return False
+
+    return True
+
+def adsp_log(output, server):
+    if server:
+        server.request.sendall(output.encode("utf-8"))
+    else:
+        sys.stdout.write(output)
+        sys.stdout.flush()
+
+
+ap = argparse.ArgumentParser(description="DSP loader/logger tool")
+ap.add_argument("-q", "--quiet", action="store_true",
+                help="No loader output, just DSP logging")
+ap.add_argument("-v", "--verbose", action="store_true",
+                help="More loader output, DEBUG logging level")
+ap.add_argument("-l", "--log-only", action="store_true",
+                help="Don't load firmware, just show log output")
+ap.add_argument("-n", "--no-history", action="store_true",
+                help="No current log buffer at start, just new output")
+ap.add_argument("-s", "--server-addr",
+                help="Specify the only IP address the log server will LISTEN on")
+ap.add_argument("-p", "--log-port",
+                help="Specify the PORT that the log server to active")
+ap.add_argument("-r", "--req-port",
+                help="Specify the PORT that the request server to active")
+ap.add_argument("fw_file", nargs="?", help="Firmware file")
+
+args = ap.parse_args()
+
+if args.quiet:
+    log.setLevel(logging.WARN)
+elif args.verbose:
+    log.setLevel(logging.DEBUG)
+
+if args.fw_file:
+    fw_file = args.fw_file
+else:
+    fw_file = None
+
+if args.server_addr:
+    url = urlparse("//" + args.server_addr)
+
+    if url.hostname:
+        HOST = url.hostname
+
+    if url.port:
+        PORT_LOG = int(url.port)
+
+if args.log_port:
+    PORT_LOG = int(args.log_port)
+
+if args.req_port:
+    PORT_REQ = int(args.req_port)
+
+log.info(f"Serve on LOG PORT: {PORT_LOG} REQ PORT: {PORT_REQ}")
+
+if __name__ == "__main__":
+    # When fw_file is assigned or in log_only mode, it will
+    # not serve as a daemon. That mean it just run load
+    # firmware or read the log directly.
+    if args.fw_file or args.log_only:
+        start_output = True
+        try:
+            asyncio.get_event_loop().run_until_complete(_main(None))
+        except KeyboardInterrupt:
+            start_output = False
+        except Exception as e:
+            log.error(e)
+        finally:
+            sys.exit(0)
+
+    # Launch the command request service
+    socketserver.TCPServer.allow_reuse_address = True
+    req_server = socketserver.TCPServer((HOST, PORT_REQ), adsp_request_handler)
+    req_t = threading.Thread(target=req_server.serve_forever, daemon=True)
+
+    # Activate the log service which output adsp execution
+    with socketserver.TCPServer((HOST, PORT_LOG), adsp_log_handler) as log_server:
+        try:
+            log.info("Req server start...")
+            req_t.start()
+            log.info("Log server start...")
+            log_server.serve_forever()
+        except KeyboardInterrupt:
+            lock.acquire()
+            start_output = False
+            lock.release()
+            log_server.shutdown()
+            req_server.shutdown()

--- a/soc/xtensa/intel_adsp/tools/remote-fw-service.py
+++ b/soc/xtensa/intel_adsp/tools/remote-fw-service.py
@@ -5,21 +5,17 @@ import os
 import sys
 import struct
 import logging
-import asyncio
 import time
 import subprocess
-import ctypes
-import mmap
 import argparse
 import socketserver
 import threading
 import hashlib
+import queue
 from urllib.parse import urlparse
 
 # Global variable use to sync between log and request services.
-# When it is true, the adsp is able to start running.
-start_output = False
-lock = threading.Lock()
+runner = None
 
 # INADDR_ANY as default
 HOST = ''
@@ -32,684 +28,17 @@ CMD_LOG_START = "start_log"
 CMD_DOWNLOAD = "download"
 MAX_CMD_SZ = 16
 
+# Define the return value in handle function
+ERR_FAIL = 1
+
 # Define the header format and size for
 # transmiting the firmware
 PACKET_HEADER_FORMAT_FW = 'I 42s 32s'
 HEADER_SZ = 78
 
-
 logging.basicConfig(level=logging.INFO)
-log = logging.getLogger("cavs-fw")
+log = logging.getLogger("remote-fw")
 
-PAGESZ = 4096
-HUGEPAGESZ = 2 * 1024 * 1024
-HUGEPAGE_FILE = "/dev/hugepages/cavs-fw-dma.tmp."
-
-# SRAM windows.  Each appears in a 128k region starting at 512k.
-#
-# Window 0 is the FW_STATUS area, and 4k after that the IPC "outbox"
-# Window 1 is the IPC "inbox" (host-writable memory, just 384 bytes currently)
-# Window 2 is unused by this script
-# Window 3 is winstream-formatted log output
-OUTBOX_OFFSET    = (512 + (0 * 128)) * 1024 + 4096
-INBOX_OFFSET     = (512 + (1 * 128)) * 1024
-WINSTREAM_OFFSET = (512 + (3 * 128)) * 1024
-
-# ADSPCS bits
-CRST   = 0
-CSTALL = 8
-SPA    = 16
-CPA    = 24
-
-class HDAStream:
-    # creates an hda stream with at 2 buffers of buf_len
-    def __init__(self, stream_id: int):
-        self.stream_id = stream_id
-        self.base = hdamem + 0x0080 + (stream_id * 0x20)
-        log.info(f"Mapping registers for hda stream {self.stream_id} at base {self.base:x}")
-
-        self.hda = Regs(hdamem)
-        self.hda.GCAP    = 0x0000
-        self.hda.GCTL    = 0x0008
-        self.hda.DPLBASE = 0x0070
-        self.hda.DPUBASE = 0x0074
-        self.hda.SPBFCH  = 0x0700
-        self.hda.SPBFCTL = 0x0704
-        self.hda.PPCH    = 0x0800
-        self.hda.PPCTL   = 0x0804
-        self.hda.PPSTS   = 0x0808
-        self.hda.SPIB = 0x0708 + stream_id*0x08
-        self.hda.freeze()
-
-        self.regs = Regs(self.base)
-        self.regs.CTL  = 0x00
-        self.regs.STS  = 0x03
-        self.regs.LPIB = 0x04
-        self.regs.CBL  = 0x08
-        self.regs.LVI  = 0x0c
-        self.regs.FIFOW = 0x0e
-        self.regs.FIFOS = 0x10
-        self.regs.FMT = 0x12
-        self.regs.FIFOL= 0x14
-        self.regs.BDPL = 0x18
-        self.regs.BDPU = 0x1c
-        self.regs.freeze()
-
-        self.dbg0 = Regs(hdamem + 0x0084 + (0x20*stream_id))
-        self.dbg0.DPIB = 0x00
-        self.dbg0.EFIFOS = 0x10
-        self.dbg0.freeze()
-
-        self.reset()
-
-    def __del__(self):
-        self.reset()
-
-    def config(self, buf_len: int):
-        log.info(f"Configuring stream {self.stream_id}")
-        self.buf_len = buf_len
-        log.info("Allocating huge page and setting up buffers")
-        self.mem, self.hugef, self.buf_list_addr, self.pos_buf_addr, self.n_bufs = self.setup_buf(buf_len)
-
-        log.info("Setting buffer list, length, and stream id and traffic priority bit")
-        self.regs.CTL = ((self.stream_id & 0xFF) << 20) | (1 << 18) # must be set to something other than 0?
-        self.regs.BDPU = (self.buf_list_addr >> 32) & 0xffffffff
-        self.regs.BDPL = self.buf_list_addr & 0xffffffff
-        self.regs.CBL = buf_len
-        self.regs.LVI = self.n_bufs - 1
-        self.mem.seek(0)
-        self.debug()
-        log.info(f"Configured stream {self.stream_id}")
-
-    def write(self, data):
-
-        bufl = min(len(data), self.buf_len)
-        log.info(f"Writing data to stream {self.stream_id}, len {bufl}, SPBFCTL {self.hda.SPBFCTL:x}, SPIB {self.hda.SPIB}")
-        self.mem[0:bufl] = data[0:bufl]
-        self.mem[bufl:bufl+bufl] = data[0:bufl]
-        self.hda.SPBFCTL |= (1 << self.stream_id)
-        self.hda.SPIB += bufl
-        log.info(f"Wrote data to stream {self.stream_id}, SPBFCTL {self.hda.SPBFCTL:x}, SPIB {self.hda.SPIB}")
-
-    def start(self):
-        log.info(f"Starting stream {self.stream_id}, CTL {self.regs.CTL:x}")
-        self.regs.CTL |= 2
-        log.info(f"Started stream {self.stream_id}, CTL {self.regs.CTL:x}")
-
-    def stop(self):
-        log.info(f"Stopping stream {self.stream_id}, CTL {self.regs.CTL:x}")
-        self.regs.CTL &= 2
-        time.sleep(0.1)
-        self.regs.CTL |= 1
-        log.info(f"Stopped stream {self.stream_id}, CTL {self.regs.CTL:x}")
-
-    def setup_buf(self, buf_len: int):
-        (mem, phys_addr, hugef) = map_phys_mem(self.stream_id)
-
-        log.info(f"Mapped 2M huge page at 0x{phys_addr:x} for buf size ({buf_len})")
-
-        # create two buffers in the page of buf_len and mark them
-        # in a buffer descriptor list for the hardware to use
-        buf0_len = buf_len
-        buf1_len = buf_len
-        bdl_off = buf0_len + buf1_len
-        # bdl is 2 (64bits, 16 bytes) per entry, we have two
-        mem[bdl_off:bdl_off + 32] = struct.pack("<QQQQ",
-                                                phys_addr,
-                                                buf0_len,
-                                                phys_addr + buf0_len,
-                                                buf1_len)
-        dpib_off = bdl_off+32
-
-        # ensure buffer is initialized, sanity
-        for i in range(0, buf_len*2):
-            mem[i] = 0
-
-        log.info("Filled the buffer descriptor list (BDL) for DMA.")
-        return (mem, hugef, phys_addr + bdl_off, phys_addr+dpib_off, 2)
-
-    def debug(self):
-        log.debug("HDA %d: PPROC %d, CTL 0x%x, LPIB 0x%x, BDPU 0x%x, BDPL 0x%x, CBL 0x%x, LVI 0x%x",
-                 self.stream_id, (hda.PPCTL >> self.stream_id) & 1, self.regs.CTL, self.regs.LPIB, self.regs.BDPU,
-                 self.regs.BDPL, self.regs.CBL, self.regs.LVI)
-        log.debug("    FIFOW %d, FIFOS %d, FMT %x, FIFOL %d, DPIB %d, EFIFOS %d",
-                 self.regs.FIFOW & 0x7, self.regs.FIFOS, self.regs.FMT, self.regs.FIFOL, self.dbg0.DPIB, self.dbg0.EFIFOS)
-        log.debug("    status: FIFORDY %d, DESE %d, FIFOE %d, BCIS %d",
-                 (self.regs.STS >> 5) & 1, (self.regs.STS >> 4) & 1, (self.regs.STS >> 3) & 1, (self.regs.STS >> 2) & 1)
-
-    def reset(self):
-        # Turn DMA off and reset the stream.  Clearing START first is a
-        # noop per the spec, but absolutely required for stability.
-        # Apparently the reset doesn't stop the stream, and the next load
-        # starts before it's ready and kills the load (and often the DSP).
-        # The sleep too is required, on at least one board (a fast
-        # chromebook) putting the two writes next each other also hangs
-        # the DSP!
-        log.info(f"Resetting stream {self.stream_id}")
-        self.debug()
-        self.regs.CTL &= ~2 # clear START
-        time.sleep(0.1)
-        # set enter reset bit
-        self.regs.CTL = 1
-        while (self.regs.CTL & 1) == 0: pass
-        # clear enter reset bit to exit reset
-        self.regs.CTL = 0
-        while (self.regs.CTL & 1) == 1: pass
-
-        log.info(f"Disable SPIB and set position 0 of stream {self.stream_id}")
-        self.hda.SPBFCTL = 0
-        self.hda.SPIB = 0
-
-        #log.info("Setting dma position buffer and enable it")
-        #self.hda.DPUBASE = self.pos_buf_addr >> 32 & 0xffffffff
-        #self.hda.DPLBASE = self.pos_buf_addr & 0xfffffff0 | 1
-
-        log.info(f"Enabling dsp capture (PROCEN) of stream {self.stream_id}")
-        self.hda.PPCTL |= (1 << self.stream_id)
-
-        self.debug()
-        log.info(f"Reset stream {self.stream_id}")
-
-
-def map_regs():
-    p = runx(f"grep -iEl 'PCI_CLASS=40(10|38)0' /sys/bus/pci/devices/*/uevent")
-    pcidir = os.path.dirname(p)
-
-    # Platform/quirk detection.  ID lists cribbed from the SOF kernel driver
-    global cavs15, cavs18, cavs25
-    did = int(open(f"{pcidir}/device").read().rstrip(), 16)
-    cavs15 = did in [ 0x5a98, 0x1a98, 0x3198 ]
-    cavs18 = did in [ 0x9dc8, 0xa348, 0x02c8, 0x06c8, 0xa3f0 ]
-    cavs25 = did in [ 0xa0c8, 0x43c8, 0x4b55, 0x4b58, 0x7ad0, 0x51c8 ]
-
-    # Check sysfs for a loaded driver and remove it
-    if os.path.exists(f"{pcidir}/driver"):
-        mod = os.path.basename(os.readlink(f"{pcidir}/driver/module"))
-        found_msg = f"Existing driver \"{mod}\" found"
-        if args.log_only:
-            log.info(found_msg)
-        else:
-            log.warning(found_msg + ", unloading module")
-            runx(f"rmmod -f {mod}")
-            # Disengage runtime power management so the kernel doesn't put it to sleep
-            log.info(f"Forcing {pcidir}/power/control to always 'on'")
-            with open(f"{pcidir}/power/control", "w") as ctrl:
-                ctrl.write("on")
-
-    # Make sure PCI memory space access and busmastering are enabled.
-    # Also disable interrupts so as not to confuse the kernel.
-    with open(f"{pcidir}/config", "wb+") as cfg:
-        cfg.seek(4)
-        cfg.write(b'\x06\x04')
-
-    # Standard HD Audio Registers
-    global hdamem
-    (hdamem, _) = bar_map(pcidir, 0)
-    hda = Regs(hdamem)
-    hda.GCAP    = 0x0000
-    hda.GCTL    = 0x0008
-    hda.SPBFCTL = 0x0704
-    hda.PPCTL   = 0x0804
-
-    # Find the ID of the first output stream
-    hda_ostream_id = (hda.GCAP >> 8) & 0x0f # number of input streams
-    log.info(f"Selected output stream {hda_ostream_id} (GCAP = 0x{hda.GCAP:x})")
-    hda.SD_SPIB = 0x0708 + (8 * hda_ostream_id)
-    hda.freeze()
-
-
-    # Standard HD Audio Stream Descriptor
-    sd = Regs(hdamem + 0x0080 + (hda_ostream_id * 0x20))
-    sd.CTL  = 0x00
-    sd.CBL  = 0x08
-    sd.LVI  = 0x0c
-    sd.BDPL = 0x18
-    sd.BDPU = 0x1c
-    sd.freeze()
-
-    # Intel Audio DSP Registers
-    global bar4_mmap
-    (bar4_mem, bar4_mmap) = bar_map(pcidir, 4)
-    dsp = Regs(bar4_mem)
-    dsp.ADSPCS         = 0x00004
-    dsp.HIPCTDR        = 0x00040 if cavs15 else 0x000c0
-    dsp.HIPCTDA        =                        0x000c4 # 1.8+ only
-    dsp.HIPCTDD        = 0x00044 if cavs15 else 0x000c8
-    dsp.HIPCIDR        = 0x00048 if cavs15 else 0x000d0
-    dsp.HIPCIDA        =                        0x000d4 # 1.8+ only
-    dsp.HIPCIDD        = 0x0004c if cavs15 else 0x000d8
-    dsp.SRAM_FW_STATUS = 0x80000 # Start of first SRAM window
-    dsp.freeze()
-
-    return (hda, sd, dsp, hda_ostream_id)
-
-def setup_dma_mem(fw_bytes):
-    (mem, phys_addr, _) = map_phys_mem(hda_ostream_id)
-    mem[0:len(fw_bytes)] = fw_bytes
-
-    log.info("Mapped 2M huge page at 0x%x to contain %d bytes of firmware"
-          % (phys_addr, len(fw_bytes)))
-
-    # HDA requires at least two buffers be defined, but we don't care about
-    # boundaries because it's all a contiguous region. Place a vestigial
-    # 128-byte (minimum size and alignment) buffer after the main one, and put
-    # the 4-entry BDL list into the final 128 bytes of the page.
-    buf0_len = HUGEPAGESZ - 2 * 128
-    buf1_len = 128
-    bdl_off = buf0_len + buf1_len
-    mem[bdl_off:bdl_off + 32] = struct.pack("<QQQQ",
-                                            phys_addr, buf0_len,
-                                            phys_addr + buf0_len, buf1_len)
-    log.info("Filled the buffer descriptor list (BDL) for DMA.")
-    return (phys_addr + bdl_off, 2)
-
-global_mmaps = [] # protect mmap mappings from garbage collection!
-
-# Maps 2M of contiguous memory using a single page from hugetlbfs,
-# then locates its physical address for use as a DMA buffer.
-def map_phys_mem(stream_id):
-    # Make sure hugetlbfs is mounted (not there on chromeos)
-    os.system("mount | grep -q hugetlbfs ||"
-              + " (mkdir -p /dev/hugepages; "
-              + "  mount -t hugetlbfs hugetlbfs /dev/hugepages)")
-
-    # Ensure the kernel has enough budget for one new page
-    free = int(runx("awk '/HugePages_Free/ {print $2}' /proc/meminfo"))
-    if free == 0:
-        tot = 1 + int(runx("awk '/HugePages_Total/ {print $2}' /proc/meminfo"))
-        os.system(f"echo {tot} > /proc/sys/vm/nr_hugepages")
-
-    hugef_name = HUGEPAGE_FILE + str(stream_id)
-    hugef = open(hugef_name, "w+")
-    hugef.truncate(HUGEPAGESZ)
-    mem = mmap.mmap(hugef.fileno(), HUGEPAGESZ)
-    log.info("type of mem is %s", str(type(mem)))
-    global_mmaps.append(mem)
-    os.unlink(hugef_name)
-
-    # Find the local process address of the mapping, then use that to extract
-    # the physical address from the kernel's pagemap interface.  The physical
-    # page frame number occupies the bottom bits of the entry.
-    mem[0] = 0 # Fault the page in so it has an address!
-    vaddr = ctypes.addressof(ctypes.c_int.from_buffer(mem))
-    vpagenum = vaddr >> 12
-    pagemap = open("/proc/self/pagemap", "rb")
-    pagemap.seek(vpagenum * 8)
-    pent = pagemap.read(8)
-    paddr = (struct.unpack("Q", pent)[0] & ((1 << 55) - 1)) * PAGESZ
-    pagemap.close()
-    return (mem, paddr, hugef)
-
-# Maps a PCI BAR and returns the in-process address
-def bar_map(pcidir, barnum):
-    f = open(pcidir + "/resource" + str(barnum), "r+")
-    mm = mmap.mmap(f.fileno(), os.fstat(f.fileno()).st_size)
-    global_mmaps.append(mm)
-    log.info("Mapped PCI bar %d of length %d bytes."
-             % (barnum, os.fstat(f.fileno()).st_size))
-    return (ctypes.addressof(ctypes.c_int.from_buffer(mm)), mm)
-
-# Syntactic sugar to make register block definition & use look nice.
-# Instantiate from a base address, assign offsets to (uint32) named registers as
-# fields, call freeze(), then the field acts as a direct alias for the register!
-class Regs:
-    def __init__(self, base_addr):
-        vars(self)["base_addr"] = base_addr
-        vars(self)["ptrs"] = {}
-        vars(self)["frozen"] = False
-    def freeze(self):
-        vars(self)["frozen"] = True
-    def __setattr__(self, name, val):
-        if not self.frozen and name not in self.ptrs:
-            addr = self.base_addr + val
-            self.ptrs[name] = ctypes.c_uint32.from_address(addr)
-        else:
-            self.ptrs[name].value = val
-    def __getattr__(self, name):
-        return self.ptrs[name].value
-
-def runx(cmd):
-    return subprocess.check_output(cmd, shell=True).decode().rstrip()
-
-def mask(bit):
-    if cavs25:
-        return 0b1 << bit
-    if cavs18:
-        return 0b1111 << bit
-    if cavs15:
-        return 0b11 << bit
-
-def load_firmware(fw_file):
-    try:
-        fw_bytes = open(fw_file, "rb").read()
-    except Exception as e:
-        log.error(f"Could not read firmware file: `{fw_file}'")
-        log.error(e)
-        sys.exit(1)
-
-    (magic, sz) = struct.unpack("4sI", fw_bytes[0:8])
-    if magic == b'XMan':
-        log.info(f"Trimming {sz} bytes of extended manifest")
-        fw_bytes = fw_bytes[sz:len(fw_bytes)]
-
-    # This actually means "enable access to BAR4 registers"!
-    hda.PPCTL |= (1 << 30) # GPROCEN, "global processing enable"
-
-    log.info("Resetting HDA device")
-    hda.GCTL = 0
-    while hda.GCTL & 1: pass
-    hda.GCTL = 1
-    while not hda.GCTL & 1: pass
-
-    log.info(f"Stalling and Resetting DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
-    dsp.ADSPCS |= mask(CSTALL)
-    dsp.ADSPCS |= mask(CRST)
-    while (dsp.ADSPCS & mask(CRST)) == 0: pass
-
-    log.info(f"Powering down DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
-    dsp.ADSPCS &= ~mask(SPA)
-    while dsp.ADSPCS & mask(CPA): pass
-
-    log.info(f"Configuring HDA stream {hda_ostream_id} to transfer firmware image")
-    (buf_list_addr, num_bufs) = setup_dma_mem(fw_bytes)
-    sd.CTL = 1
-    while (sd.CTL & 1) == 0: pass
-    sd.CTL = 0
-    while (sd.CTL & 1) == 1: pass
-    sd.CTL = (1 << 20) # Set stream ID to anything non-zero
-    sd.BDPU = (buf_list_addr >> 32) & 0xffffffff
-    sd.BDPL = buf_list_addr & 0xffffffff
-    sd.CBL = len(fw_bytes)
-    sd.LVI = num_bufs - 1
-    hda.PPCTL |= (1 << hda_ostream_id)
-
-    # SPIB ("Software Position In Buffer") is an Intel HDA extension
-    # that puts a transfer boundary into the stream beyond which the
-    # other side will not read.  The ROM wants to poll on a "buffer
-    # full" bit on the other side that only works with this enabled.
-    hda.SPBFCTL |= (1 << hda_ostream_id)
-    hda.SD_SPIB = len(fw_bytes)
-
-    # Start DSP.  Host needs to provide power to all cores on 1.5
-    # (which also starts them) and 1.8 (merely gates power, DSP also
-    # has to set PWRCTL). On 2.5 where the DSP has full control,
-    # and only core 0 is set.
-    log.info(f"Starting DSP, ADSPCS = 0x{dsp.ADSPCS:x}")
-    dsp.ADSPCS = mask(SPA)
-    while (dsp.ADSPCS & mask(CPA)) == 0: pass
-
-    log.info(f"Unresetting DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
-    dsp.ADSPCS &= ~mask(CRST)
-    while (dsp.ADSPCS & 1) != 0: pass
-
-    log.info(f"Running DSP cores, ADSPCS = 0x{dsp.ADSPCS:x}")
-    dsp.ADSPCS &= ~mask(CSTALL)
-
-    # Wait for the ROM to boot and signal it's ready.  This not so short
-    # sleep seems to be needed; if we're banging on the memory window
-    # during initial boot (before/while the window control registers
-    # are configured?) the DSP hardware will hang fairly reliably.
-    log.info(f"Wait for ROM startup, ADSPCS = 0x{dsp.ADSPCS:x}")
-    time.sleep(1)
-    while (dsp.SRAM_FW_STATUS >> 24) != 5: pass
-
-    # Send the DSP an IPC message to tell the device how to boot.
-    # Note: with cAVS 1.8+ the ROM receives the stream argument as an
-    # index within the array of output streams (and we always use the
-    # first one by construction).  But with 1.5 it's the HDA index,
-    # and depends on the number of input streams on the device.
-    stream_idx = hda_ostream_id if cavs15 else 0
-    ipcval = (  (1 << 31)            # BUSY bit
-                | (0x01 << 24)       # type = PURGE_FW
-                | (1 << 14)          # purge_fw = 1
-                | (stream_idx << 9)) # dma_id
-    log.info(f"Sending IPC command, HIPIDR = 0x{ipcval:x}")
-    dsp.HIPCIDR = ipcval
-
-    log.info(f"Starting DMA, FW_STATUS = 0x{dsp.SRAM_FW_STATUS:x}")
-    sd.CTL |= 2 # START flag
-
-    wait_fw_entered()
-
-    # Turn DMA off and reset the stream.  Clearing START first is a
-    # noop per the spec, but absolutely required for stability.
-    # Apparently the reset doesn't stop the stream, and the next load
-    # starts before it's ready and kills the load (and often the DSP).
-    # The sleep too is required, on at least one board (a fast
-    # chromebook) putting the two writes next each other also hangs
-    # the DSP!
-    sd.CTL &= ~2 # clear START
-    time.sleep(0.1)
-    sd.CTL |= 1
-    log.info(f"cAVS firmware load complete")
-
-def fw_is_alive():
-    return dsp.SRAM_FW_STATUS & ((1 << 28) - 1) == 5 # "FW_ENTERED"
-
-def wait_fw_entered(timeout_s=2):
-    log.info("Waiting %s for firmware handoff, FW_STATUS = 0x%x",
-             "forever" if timeout_s is None else f"{timeout_s} seconds",
-             dsp.SRAM_FW_STATUS)
-    hertz = 100
-    attempts = None if timeout_s is None else timeout_s * hertz
-    while True:
-        alive = fw_is_alive()
-        if alive:
-            break
-        if attempts is not None:
-            attempts -= 1
-            if attempts < 0:
-                break
-        time.sleep(1 / hertz)
-
-    if not alive:
-        log.warning("Load failed?  FW_STATUS = 0x%x", dsp.SRAM_FW_STATUS)
-    else:
-        log.info("FW alive, FW_STATUS = 0x%x", dsp.SRAM_FW_STATUS)
-
-
-# This SHOULD be just "mem[start:start+length]", but slicing an mmap
-# array seems to be unreliable on one of my machines (python 3.6.9 on
-# Ubuntu 18.04).  Read out bytes individually.
-def win_read(start, length):
-    try:
-        return b''.join(bar4_mmap[WINSTREAM_OFFSET + x].to_bytes(1, 'little')
-                        for x in range(start, start + length))
-    except IndexError as ie:
-        # A FW in a bad state may cause winstream garbage
-        log.error("IndexError in bar4_mmap[%d + %d]", WINSTREAM_OFFSET, start)
-        log.error("bar4_mmap.size()=%d", bar4_mmap.size())
-        raise ie
-
-def win_hdr():
-    return struct.unpack("<IIII", win_read(0, 16))
-
-# Python implementation of the same algorithm in sys_winstream_read(),
-# see there for details.
-def winstream_read(last_seq):
-    while True:
-        (wlen, start, end, seq) = win_hdr()
-        if last_seq == 0:
-            last_seq = seq if args.no_history else (seq - ((end - start) % wlen))
-        if seq == last_seq or start == end:
-            return (seq, "")
-        behind = seq - last_seq
-        if behind > ((end - start) % wlen):
-            return (seq, "")
-        copy = (end - behind) % wlen
-        suffix = min(behind, wlen - copy)
-        result = win_read(16 + copy, suffix)
-        if suffix < behind:
-            result += win_read(16, behind - suffix)
-        (wlen, start1, end, seq1) = win_hdr()
-        if start1 == start and seq1 == seq:
-            # Best effort attempt at decoding, replacing unusable characters
-            # Found to be useful when it really goes wrong
-            return (seq, result.decode("utf-8", "replace"))
-
-
-async def ipc_delay_done():
-    await asyncio.sleep(0.1)
-    dsp.HIPCTDA = 1<<31
-
-ipc_timestamp = 0
-
-# Super-simple command language, driven by the test code on the DSP
-def ipc_command(data, ext_data):
-    send_msg = False
-    done = True
-    log.debug ("ipc data %d, ext_data %x", data, ext_data)
-    if data == 0: # noop, with synchronous DONE
-        pass
-    elif data == 1: # async command: signal DONE after a delay (on 1.8+)
-        if not cavs15:
-            done = False
-            asyncio.ensure_future(ipc_delay_done())
-    elif data == 2: # echo back ext_data as a message command
-        send_msg = True
-    elif data == 3: # set ADSPCS
-        dsp.ADSPCS = ext_data
-    elif data == 4: # echo back microseconds since last timestamp command
-        global ipc_timestamp
-        t = round(time.time() * 1e6)
-        ext_data = t - ipc_timestamp
-        ipc_timestamp = t
-        send_msg = True
-    elif data == 5: # copy word at outbox[ext_data >> 16] to inbox[ext_data & 0xffff]
-        src = OUTBOX_OFFSET + 4 * (ext_data >> 16)
-        dst =  INBOX_OFFSET + 4 * (ext_data & 0xffff)
-        for i in range(4):
-            bar4_mmap[dst + i] = bar4_mmap[src + i]
-    elif data == 6: # HDA RESET (init if not exists)
-        stream_id = ext_data & 0xff
-        if stream_id in hda_streams:
-            hda_streams[stream_id].reset()
-        else:
-            hda_str = HDAStream(stream_id)
-            hda_streams[stream_id] = hda_str
-    elif data == 7: # HDA CONFIG
-        stream_id = ext_data & 0xFF
-        buf_len = ext_data >> 8 & 0xFFFF
-        hda_str = hda_streams[stream_id]
-        hda_str.config(buf_len)
-    elif data == 8: # HDA START
-        stream_id = ext_data & 0xFF
-        hda_streams[stream_id].start()
-        hda_streams[stream_id].mem.seek(0)
-
-    elif data == 9: # HDA STOP
-        stream_id = ext_data & 0xFF
-        hda_streams[stream_id].stop()
-    elif data == 10: # HDA VALIDATE
-        stream_id = ext_data & 0xFF
-        hda_str = hda_streams[stream_id]
-        hda_str.debug()
-        is_ramp_data = True
-        hda_str.mem.seek(0)
-        for (i, val) in enumerate(hda_str.mem.read(256)):
-            if i != val:
-                is_ramp_data = False
-            # log.info("stream[%d][%d]: %d", stream_id, i, val) # debug helper
-        log.info("Is ramp data? " + str(is_ramp_data))
-        ext_data = int(is_ramp_data)
-        log.info(f"Ext data to send back on ramp status {ext_data}")
-        send_msg = True
-    elif data == 11: # HDA HOST OUT SEND
-        stream_id = ext_data & 0xff
-        buf = bytearray(256)
-        for i in range(0, 256):
-            buf[i] = i
-        hda_streams[stream_id].write(buf)
-    elif data == 12: # HDA PRINT
-        stream_id = ext_data & 0xFF
-        buf_len = ext_data >> 8 & 0xFFFF
-        hda_str = hda_streams[stream_id]
-        # check for wrap here
-        pos = hda_str.mem.tell()
-        read_lens = [buf_len, 0]
-        if pos + buf_len >= hda_str.buf_len*2:
-            read_lens[0] = hda_str.buf_len*2 - pos
-            read_lens[1] = buf_len - read_lens[0]
-        # validate the read lens
-        assert (read_lens[0] + pos) <= (hda_str.buf_len*2)
-        assert read_lens[0] % 128 == 0
-        assert read_lens[1] % 128 == 0
-        buf_data0 = hda_str.mem.read(read_lens[0])
-        hda_msg0 = buf_data0.decode("utf-8", "replace")
-        sys.stdout.write(hda_msg0)
-        if read_lens[1] != 0:
-            hda_str.mem.seek(0)
-            buf_data1 = hda_str.mem.read(read_lens[1])
-            hda_msg1 = buf_data1.decode("utf-8", "replace")
-            sys.stdout.write(hda_msg1)
-        pos = hda_str.mem.tell()
-        sys.stdout.flush()
-    else:
-        log.warning(f"cavstool: Unrecognized IPC command 0x{data:x} ext 0x{ext_data:x}")
-        if not fw_is_alive():
-            if args.log_only:
-                log.info("DSP power seems off")
-                wait_fw_entered(timeout_s=None)
-            else:
-                log.warning("DSP power seems off?!")
-                time.sleep(2) # potential spam reduction
-
-            return
-
-    dsp.HIPCTDR = 1<<31 # Ack local interrupt, also signals DONE on v1.5
-    if cavs18:
-        time.sleep(0.01) # Needed on 1.8, or the command below won't send!
-
-    if done and not cavs15:
-        dsp.HIPCTDA = 1<<31 # Signal done
-    if send_msg:
-        dsp.HIPCIDD = ext_data
-        dsp.HIPCIDR = (1<<31) | ext_data
-
-async def _main(server):
-    #TODO this bit me, remove the globals, write a little FirmwareLoader class or something to contain.
-    global hda, sd, dsp, hda_ostream_id, hda_streams
-    global start_output
-    try:
-        (hda, sd, dsp, hda_ostream_id) = map_regs()
-    except Exception as e:
-        log.error("Could not map device in sysfs; run as root?")
-        log.error(e)
-        sys.exit(1)
-
-    log.info(f"Detected cAVS {'1.5' if cavs15 else '1.8+'} hardware")
-
-    if args.log_only:
-        wait_fw_entered(timeout_s=None)
-    else:
-        if not fw_file:
-            log.error("Firmware file argument missing")
-            sys.exit(1)
-
-        load_firmware(fw_file)
-        time.sleep(0.1)
-        if not args.quiet:
-            adsp_log("--\n", server)
-
-    hda_streams = dict()
-
-    last_seq = 0
-    while start_output is True:
-        await asyncio.sleep(0.03)
-        (last_seq, output) = winstream_read(last_seq)
-        if output:
-            adsp_log(output, server)
-        if dsp.HIPCIDA & 0x80000000:
-            dsp.HIPCIDA = 1<<31 # must ACK any DONE interrupts that arrive!
-        if dsp.HIPCTDR & 0x80000000:
-            ipc_command(dsp.HIPCTDR & ~0x80000000, dsp.HIPCTDD)
-
-        if server:
-            # Check if the client connection is alive.
-            if not is_connection_alive(server):
-                lock.acquire()
-                start_output = False
-                lock.release()
 
 class adsp_request_handler(socketserver.BaseRequestHandler):
     """
@@ -755,40 +84,44 @@ class adsp_request_handler(socketserver.BaseRequestHandler):
 
         return fname
 
-    def handle(self):
-        global start_output, fw_file
+    def do_download(self):
+        recv_file = self.receive_fw()
 
+        if recv_file:
+            recv_file = recv_file.decode('utf-8')
+
+            if os.path.exists(recv_file):
+                runner.set_fw_ready(recv_file)
+                return 0
+
+        log.error("Cannot find the FW file.")
+        return ERR_FAIL
+
+    def handle(self):
         cmd = self.request.recv(MAX_CMD_SZ)
         log.info(f"{self.client_address[0]} wrote: {cmd}")
         action = cmd.decode("utf-8")
         log.debug(f'load {action}')
+        ret = ERR_FAIL
 
         if action == CMD_DOWNLOAD:
             self.request.sendall(cmd)
-            recv_file = self.receive_fw()
-
-            if recv_file:
-                self.request.sendall("success".encode('utf-8'))
-                log.info("Firmware well received. Ready to download.")
-            else:
-                self.request.sendall("failed".encode('utf-8'))
-                log.error("Receive firmware failed.")
-
-            lock.acquire()
-            fw_file = recv_file
-            start_output = True
-            lock.release()
-
+            ret = self.do_download()
         else:
             log.error("incorrect load communitcation!")
+            return
+
+        if not ret:
+            self.request.sendall("success".encode('utf-8'))
+            log.info("Firmware well received. Ready to download.")
+        else:
+            self.request.sendall("failed".encode('utf-8'))
+            log.error("Receive firmware failed.")
 
 class adsp_log_handler(socketserver.BaseRequestHandler):
     """
     The log handler class for grabbing output messages of server.
     """
-    def run_adsp(self):
-        self.loop = asyncio.get_event_loop()
-        self.loop.run_until_complete(_main(self))
 
     def handle(self):
         cmd = self.request.recv(MAX_CMD_SZ)
@@ -797,69 +130,149 @@ class adsp_log_handler(socketserver.BaseRequestHandler):
         log.debug(f'monitor {action}')
 
         if action == CMD_LOG_START:
-            global start_output, fw_file
-
             self.request.sendall(cmd)
-
-            log.info(f"Waiting for instruction...")
-            while start_output is False:
-                time.sleep(1)
-                if not is_connection_alive(self):
-                    break
-
-            if fw_file:
-                log.info(f"Loaded FW {fw_file} and running...")
-                if os.path.exists(fw_file):
-                    self.run_adsp()
-                    log.info("service complete.")
-                else:
-                    log.error("Cannot find the FW file.")
-
-            lock.acquire()
-            start_output = False
-            if fw_file:
-                os.remove(fw_file)
-            fw_file = None
-            lock.release()
-
         else:
             log.error("incorrect monitor communitcation!")
 
+        log.info("wait for FW ready...")
+        while not runner.is_fw_ready():
+            if not self.is_connection_alive():
+                return
+
+            time.sleep(1)
+
+        log.info("FW is ready...")
+
+        with subprocess.Popen(runner.get_script(), stdout=subprocess.PIPE) as proc:
+            # Thread for monitoring the conntection
+            t = threading.Thread(target=self.check_connection, args=(proc,))
+            t.start()
+
+            while True:
+                try:
+                    out = proc.stdout.readline()
+                    self.request.sendall(out)
+                    ret = proc.poll()
+                    if ret:
+                        log.info(f"retrun code: {ret}")
+                        break
+
+                except (BrokenPipeError, ConnectionResetError):
+                    log.info("Client is disconnect.")
+                    break
+
+            t.join()
+
+        log.info("service complete.")
+
+    def finish(self):
+        runner.cleanup()
         log.info("Wait for next service...")
 
-def is_connection_alive(server):
-    try:
-        server.request.sendall(b' ')
-    except (BrokenPipeError, ConnectionResetError):
-        log.info("Client is disconnect.")
-        return False
+    def is_connection_alive(self):
+        try:
+            self.request.sendall(b' ')
+        except (BrokenPipeError, ConnectionResetError):
+            log.info("Client is disconnect.")
+            return False
 
-    return True
+        return True
 
-def adsp_log(output, server):
-    if server:
-        server.request.sendall(output.encode("utf-8"))
-    else:
-        sys.stdout.write(output)
-        sys.stdout.flush()
+    def check_connection(self, proc):
+        # Not to check connection alive for
+        # the first 10 secs.
+        time.sleep(10)
+
+        log.info("Checking result...")
+        while True:
+            if not self.is_connection_alive():
+                log.info(f"Do kill {proc.pid}")
+
+                try:
+                    proc.kill()
+                except PermissionError:
+                    log.info("cannot kill proc due to it start with sudo...")
+                    os.system(f"sudo kill -9 {proc.pid} ")
+                return
+
+            time.sleep(1)
+
+class device_runner():
+    def __init__(self, args):
+        self.fw_file = None
+        self.lock = threading.Lock()
+        self.fw_queue = queue.Queue()
+
+        # Board specific config
+        self.board = board_config(args)
+        self.load_cmd = self.board.get_cmd()
+
+    def set_fw_ready(self, fw_recv):
+        if fw_recv:
+            self.fw_queue.put(fw_recv)
+
+    def is_fw_ready(self):
+        self.fw_file = self.fw_queue.get()
+        log.info(f"Current FW is {self.fw_file}")
+
+        return bool(self.fw_file)
+
+    def cleanup(self):
+        self.lock.acquire()
+        self.script = None
+        if self.fw_file:
+            os.remove(self.fw_file)
+        self.fw_file = None
+        self.lock.release()
+
+    def get_script(self):
+        if os.geteuid() != 0:
+            self.script = ([f'sudo', f'{self.load_cmd}'])
+        else:
+            self.script = ([f'{self.load_cmd}'])
+
+        self.script.append(f'{self.fw_file}')
+
+        if self.board.params:
+            for param in self.board.params:
+                self.script.append(param)
+
+        log.info(f'run script: {self.script}')
+        return self.script
+
+class board_config():
+    def __init__(self, args):
+
+        self.load_cmd = args.load_cmd    # cmd for loading
+        self.params = []            # params of loading cmd
+
+        if not self.load_cmd:
+            self.load_cmd = "./cavstool.py"
+
+        if not self.load_cmd or not os.path.exists(self.load_cmd):
+            log.error(f'Cannot find load cmd {self.load_cmd}.')
+            sys.exit(1)
+
+    def get_cmd(self):
+        return self.load_cmd
+
+    def get_params(self):
+        return self.params
 
 
-ap = argparse.ArgumentParser(description="DSP loader/logger tool")
+ap = argparse.ArgumentParser(description="RemoteHW service tool")
 ap.add_argument("-q", "--quiet", action="store_true",
                 help="No loader output, just DSP logging")
 ap.add_argument("-v", "--verbose", action="store_true",
                 help="More loader output, DEBUG logging level")
-ap.add_argument("-l", "--log-only", action="store_true",
-                help="Don't load firmware, just show log output")
-ap.add_argument("-n", "--no-history", action="store_true",
-                help="No current log buffer at start, just new output")
 ap.add_argument("-s", "--server-addr",
                 help="Specify the only IP address the log server will LISTEN on")
 ap.add_argument("-p", "--log-port",
                 help="Specify the PORT that the log server to active")
 ap.add_argument("-r", "--req-port",
                 help="Specify the PORT that the request server to active")
-ap.add_argument("fw_file", nargs="?", help="Firmware file")
+ap.add_argument("-c", "--load-cmd",
+                help="Specify loading command of the board")
 
 args = ap.parse_args()
 
@@ -867,11 +280,6 @@ if args.quiet:
     log.setLevel(logging.WARN)
 elif args.verbose:
     log.setLevel(logging.DEBUG)
-
-if args.fw_file:
-    fw_file = args.fw_file
-else:
-    fw_file = None
 
 if args.server_addr:
     url = urlparse("//" + args.server_addr)
@@ -890,36 +298,28 @@ if args.req_port:
 
 log.info(f"Serve on LOG PORT: {PORT_LOG} REQ PORT: {PORT_REQ}")
 
+
 if __name__ == "__main__":
-    # When fw_file is assigned or in log_only mode, it will
-    # not serve as a daemon. That mean it just run load
-    # firmware or read the log directly.
-    if args.fw_file or args.log_only:
-        start_output = True
-        try:
-            asyncio.get_event_loop().run_until_complete(_main(None))
-        except KeyboardInterrupt:
-            start_output = False
-        except Exception as e:
-            log.error(e)
-        finally:
-            sys.exit(0)
+
+    # Do board configuration setup
+    runner = device_runner(args)
 
     # Launch the command request service
     socketserver.TCPServer.allow_reuse_address = True
     req_server = socketserver.TCPServer((HOST, PORT_REQ), adsp_request_handler)
     req_t = threading.Thread(target=req_server.serve_forever, daemon=True)
 
-    # Activate the log service which output adsp execution
-    with socketserver.TCPServer((HOST, PORT_LOG), adsp_log_handler) as log_server:
-        try:
-            log.info("Req server start...")
-            req_t.start()
-            log.info("Log server start...")
-            log_server.serve_forever()
-        except KeyboardInterrupt:
-            lock.acquire()
-            start_output = False
-            lock.release()
-            log_server.shutdown()
-            req_server.shutdown()
+    # Activate the log service which output board's execution result
+    log_server = socketserver.TCPServer((HOST, PORT_LOG), adsp_log_handler)
+    log_t = threading.Thread(target=log_server.serve_forever, daemon=True)
+
+    try:
+        log.info("Req server start...")
+        req_t.start()
+        log.info("Log server start...")
+        log_t.start()
+        req_t.join()
+        log_t.join()
+    except KeyboardInterrupt:
+        log_server.shutdown()
+        req_server.shutdown()


### PR DESCRIPTION
The PR is to spilt the cavs server and FW loader, to make the 
cavstool.py a pure FW loader and runner as it used to be. 
The reasons to do this is:

- Keep the FW loader won't be affected by the changes of
   the client-server-based HW service as possible. It also
   make the debugging more easier.
- Spawn another process for the FW loader. If the FW loader
   got stuck during executing, the service can stop it.

Fixes #47652. 
 
And change the server program's name to remote-fw-service.py
because we also try make the client-server-based FW service 
being able to use on other boards besides cavs boards in the future.
