### PR TITLE
cmake: Add support to add symbols to nocache section

### DIFF
--- a/arch/common/nocache.ld
+++ b/arch/common/nocache.ld
@@ -18,6 +18,9 @@ SECTION_DATA_PROLOGUE(_NOCACHE_SECTION_NAME,(NOLOAD),)
 	_nocache_ram_start = .;
 	*(.nocache)
 	*(".nocache.*")
+
+#include <snippets-nocache-section.ld>
+
 #if defined(CONFIG_MMU)
 	MMU_ALIGN;
 #else

--- a/cmake/modules/extensions.cmake
+++ b/cmake/modules/extensions.cmake
@@ -1146,6 +1146,7 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #    RAM_SECTIONS  Inside the RAMABLE_REGION GROUP, not initialized.
 #    DATA_SECTIONS Inside the RAMABLE_REGION GROUP, initialized.
 #    RAMFUNC_SECTION Inside the RAMFUNC RAMABLE_REGION GROUP, not initialized.
+#    NOCACHE_SECTION Inside the NOCACHE section
 #    SECTIONS      Near the end of the file. Don't use this when linking into
 #                  RAMABLE_REGION, use RAM_SECTIONS instead.
 #    PINNED_RODATA Similar to RODATA but pinned in memory.
@@ -1159,9 +1160,9 @@ endfunction(zephyr_check_compiler_flag_hardcoded)
 #
 # Use NOINIT, RWDATA, and RODATA unless they don't work for your use case.
 #
-# When placing into NOINIT, RWDATA, RODATA, ROM_START, RAMFUNC_SECTION the
-# contents of the files will be placed inside an output section, so assume
-# the section definition is already present, e.g.:
+# When placing into NOINIT, RWDATA, RODATA, ROM_START, RAMFUNC_SECTION,
+# NOCACHE_SECTION the contents of the files will be placed inside
+# an output section, so assume the section definition is already present, e.g.:
 #    _mysection_start = .;
 #    KEEP(*(.mysection));
 #    _mysection_end = .;
@@ -1195,6 +1196,7 @@ function(zephyr_linker_sources location)
   set(rwdata_path        "${snippet_base}/snippets-rwdata.ld")
   set(rodata_path        "${snippet_base}/snippets-rodata.ld")
   set(ramfunc_path       "${snippet_base}/snippets-ramfunc-section.ld")
+  set(nocache_path       "${snippet_base}/snippets-nocache-section.ld")
 
   set(pinned_ram_sections_path  "${snippet_base}/snippets-pinned-ram-sections.ld")
   set(pinned_data_sections_path "${snippet_base}/snippets-pinned-data-sections.ld")
@@ -1211,6 +1213,7 @@ function(zephyr_linker_sources location)
     file(WRITE ${rwdata_path} "")
     file(WRITE ${rodata_path} "")
     file(WRITE ${ramfunc_path} "")
+    file(WRITE ${nocache_path} "")
     file(WRITE ${pinned_ram_sections_path} "")
     file(WRITE ${pinned_data_sections_path} "")
     file(WRITE ${pinned_rodata_path} "")
@@ -1234,6 +1237,8 @@ function(zephyr_linker_sources location)
     set(snippet_path "${rodata_path}")
   elseif("${location}" STREQUAL "RAMFUNC_SECTION")
     set(snippet_path "${ramfunc_path}")
+  elseif("${location}" STREQUAL "NOCACHE_SECTION")
+    set(snippet_path "${nocache_path}")
   elseif("${location}" STREQUAL "PINNED_RAM_SECTIONS")
     set(snippet_path "${pinned_ram_sections_path}")
   elseif("${location}" STREQUAL "PINNED_DATA_SECTIONS")


### PR DESCRIPTION
This PR allows the user to add symbols to the nocache section. The use for this could be as follows

```
zephyr_linker_sources_ifdef(CONFIG_NOCACHE_MEMORY
  NOCACHE_SECTION
  nocache.ld
)
```
nocache.ld (as shown below) can define additional symbols to  go into the nocache section

```
. = ALIGN(4);
KEEP(*(NonCacheable))
```