### PR TITLE
dts: arm64: agilex: add additional cpu nodes

### DIFF
--- a/dts/arm64/intel/intel_socfpga_agilex.dtsi
+++ b/dts/arm64/intel/intel_socfpga_agilex.dtsi
@@ -14,10 +14,28 @@
 		#address-cells = <1>;
 		#size-cells= <0>;
 
-		cpu@0 {
+		cpu0: cpu@0 {
 			device_type = "cpu";
 			compatible = "arm,cortex-a53";
 			reg = <0>;
+		};
+
+		cpu1: cpu@1 {
+			compatible = "arm,cortex-a53";
+			device_type = "cpu";
+			reg = <0x1>;
+		};
+
+		cpu2: cpu@2 {
+			compatible = "arm,cortex-a53";
+			device_type = "cpu";
+			reg = <0x2>;
+		};
+
+		cpu3: cpu@3 {
+			compatible = "arm,cortex-a53";
+			device_type = "cpu";
+			reg = <0x3>;
 		};
 	};
 


### PR DESCRIPTION
Add CPU1 - CPU3 nodes and add the cpu0 label.

Signed-off-by: Dinh Nguyen <dinguyen@kernel.org>
---
v2: add cpu0 label